### PR TITLE
mobile: Make FilterThrowingExceptionTest hermetic

### DIFF
--- a/mobile/test/kotlin/integration/BUILD
+++ b/mobile/test/kotlin/integration/BUILD
@@ -353,9 +353,6 @@ envoy_mobile_android_test(
     srcs = [
         "FilterThrowingExceptionTest.kt",
     ],
-    exec_properties = {
-        "dockerNetwork": "standard",
-    },
     native_deps = [
         "//test/jni:libenvoy_jni_with_test_extensions.so",
     ] + select({
@@ -369,5 +366,6 @@ envoy_mobile_android_test(
     deps = [
         "//library/kotlin/io/envoyproxy/envoymobile:envoy_interfaces_lib",
         "//library/kotlin/io/envoyproxy/envoymobile:envoy_lib",
+        "//test/java/io/envoyproxy/envoymobile/engine/testing:http_test_server_factory_lib",
     ],
 )

--- a/mobile/test/kotlin/integration/FilterThrowingExceptionTest.kt
+++ b/mobile/test/kotlin/integration/FilterThrowingExceptionTest.kt
@@ -19,11 +19,15 @@ import io.envoyproxy.envoymobile.ResponseFilter
 import io.envoyproxy.envoymobile.ResponseHeaders
 import io.envoyproxy.envoymobile.ResponseTrailers
 import io.envoyproxy.envoymobile.StreamIntel
+import io.envoyproxy.envoymobile.engine.EnvoyConfiguration
 import io.envoyproxy.envoymobile.engine.JniLibrary
+import io.envoyproxy.envoymobile.engine.testing.HttpTestServerFactory
 import java.nio.ByteBuffer
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
+import org.junit.After
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -88,6 +92,18 @@ class FilterThrowingExceptionTest {
     JniLibrary.loadTestLibrary()
   }
 
+  private lateinit var httpTestServer: HttpTestServerFactory.HttpTestServer
+
+  @Before
+  fun setUp() {
+    httpTestServer = HttpTestServerFactory.start(HttpTestServerFactory.Type.HTTP2_WITH_TLS)
+  }
+
+  @After
+  fun tearDown() {
+    httpTestServer.shutdown()
+  }
+
   @Test
   fun `registers a filter that throws an exception and performs an HTTP request`() {
     val onEngineRunningLatch = CountDownLatch(1)
@@ -106,6 +122,7 @@ class FilterThrowingExceptionTest {
       builder
         .setLogLevel(LogLevel.DEBUG)
         .setLogger { _, msg -> print(msg) }
+        .setTrustChainVerification(EnvoyConfiguration.TrustChainVerification.ACCEPT_UNTRUSTED)
         .setEventTracker { event ->
           if (
             event["name"] == "event_log" && event["log_name"] == "jni_cleared_pending_exception"
@@ -122,8 +139,8 @@ class FilterThrowingExceptionTest {
       RequestHeadersBuilder(
           method = RequestMethod.GET,
           scheme = "https",
-          authority = "api.lyft.com",
-          path = "/ping"
+          authority = httpTestServer.address,
+          path = "/simple.txt"
         )
         .build()
 
@@ -131,6 +148,7 @@ class FilterThrowingExceptionTest {
       .streamClient()
       .newStreamPrototype()
       .setOnResponseHeaders { responseHeaders, _, _ ->
+        println("here!!")
         val status = responseHeaders.httpStatus ?: 0L
         assertThat(status).isEqualTo(200)
         onResponseHeadersLatch.countDown()


### PR DESCRIPTION
This PR updates the test by using a local test server instead of making an external network request, which can make the test flaky.

Risk Level: low (test only)
Testing: unit test
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
