### PR TITLE
quic: migrates one more reference to quiche::HttpHeaderBlock

### DIFF
--- a/source/common/quic/envoy_quic_stream.cc
+++ b/source/common/quic/envoy_quic_stream.cc
@@ -79,7 +79,7 @@ void EnvoyQuicStream::encodeData(Buffer::Instance& data, bool end_stream) {
   }
 }
 
-void EnvoyQuicStream::encodeTrailersImpl(spdy::Http2HeaderBlock&& trailers) {
+void EnvoyQuicStream::encodeTrailersImpl(quiche::HttpHeaderBlock&& trailers) {
   if (quic_stream_.write_side_closed()) {
     IS_ENVOY_BUG("encodeTrailers is called on write-closed stream.");
     return;
@@ -126,7 +126,7 @@ void serializeMetadata(const Http::MetadataMapPtr& metadata, quic::QuicStreamId 
   quic::QpackEncoder qpack_encoder(&decoder_stream_error_delegate, quic::HuffmanEncoding::kDisabled,
                                    quic::CookieCrumbling::kDisabled);
 
-  spdy::Http2HeaderBlock header_block;
+  quiche::HttpHeaderBlock header_block;
   for (const auto& [key, value] : *metadata) {
     header_block.AppendValueOrAddHeader(key, value);
   }

--- a/source/common/quic/envoy_quic_stream.h
+++ b/source/common/quic/envoy_quic_stream.h
@@ -178,7 +178,7 @@ protected:
 
   StreamInfo::BytesMeterSharedPtr& mutableBytesMeter() { return bytes_meter_; }
 
-  void encodeTrailersImpl(spdy::Http2HeaderBlock&& trailers);
+  void encodeTrailersImpl(quiche::HttpHeaderBlock&& trailers);
 
   // Converts `header_list` into a new `Http::MetadataMap`.
   std::unique_ptr<Http::MetadataMap>


### PR DESCRIPTION


Commit Message: quic: migrates one more reference to quiche::HttpHeaderBlock
Additional Description:
Risk Level: none
Testing: ran unit and integration tests locally
Docs Changes:
Release Notes:
Platform Specific Features:
