### PR TITLE
Add support for multiple formats of ORCA headers.

### DIFF
--- a/source/common/orca/BUILD
+++ b/source/common/orca/BUILD
@@ -13,8 +13,11 @@ envoy_cc_library(
     srcs = ["orca_parser.cc"],
     hdrs = ["orca_parser.h"],
     deps = [
+        "//envoy/common:exception_lib",
         "//envoy/http:header_map_interface",
         "//source/common/common:base64_lib",
+        "//source/common/http:header_utility_lib",
+        "//source/common/protobuf:utility_lib_header",
         "@com_github_cncf_xds//xds/data/orca/v3:pkg_cc_proto",
         "@com_github_fmtlib_fmt//:fmtlib",
         "@com_google_absl//absl/status:statusor",

--- a/source/common/orca/orca_parser.cc
+++ b/source/common/orca/orca_parser.cc
@@ -1,13 +1,27 @@
 #include "source/common/orca/orca_parser.h"
 
+#include <cmath>
+#include <cstddef>
 #include <string>
+#include <utility>
+#include <vector>
 
+#include "envoy/common/exception.h"
 #include "envoy/http/header_map.h"
 
 #include "source/common/common/base64.h"
 #include "source/common/common/fmt.h"
+#include "source/common/http/header_utility.h"
+#include "source/common/protobuf/utility.h"
 
+#include "absl/container/flat_hash_set.h"
+#include "absl/status/status.h"
+#include "absl/strings/match.h"
+#include "absl/strings/numbers.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/str_split.h"
 #include "absl/strings/string_view.h"
+#include "absl/strings/strip.h"
 
 using ::Envoy::Http::HeaderMap;
 using xds::data::orca::v3::OrcaLoadReport;
@@ -17,8 +31,106 @@ namespace Orca {
 
 namespace {
 
+const Http::LowerCaseString& endpointLoadMetricsHeader() {
+  CONSTRUCT_ON_FIRST_USE(Http::LowerCaseString, kEndpointLoadMetricsHeader);
+}
+
 const Http::LowerCaseString& endpointLoadMetricsHeaderBin() {
   CONSTRUCT_ON_FIRST_USE(Http::LowerCaseString, kEndpointLoadMetricsHeaderBin);
+}
+
+const Http::LowerCaseString& endpointLoadMetricsHeaderJson() {
+  CONSTRUCT_ON_FIRST_USE(Http::LowerCaseString, kEndpointLoadMetricsHeaderJson);
+}
+
+absl::Status tryCopyNamedMetricToOrcaLoadReport(absl::string_view metric_name, double metric_value,
+                                                OrcaLoadReport& orca_load_report) {
+  if (metric_name.empty()) {
+    return absl::InvalidArgumentError("named metric key is empty.");
+  }
+
+  orca_load_report.mutable_named_metrics()->insert({std::string(metric_name), metric_value});
+  return absl::OkStatus();
+}
+
+std::vector<absl::string_view> parseCommaDelimitedHeader(const HeaderMap::GetResult& entry) {
+  std::vector<absl::string_view> values;
+  values.reserve(entry.size());
+  for (size_t i = 0; i < entry.size(); ++i) {
+    std::vector<absl::string_view> tokens =
+        Envoy::Http::HeaderUtility::parseCommaDelimitedHeader(entry[i]->value().getStringView());
+    values.insert(values.end(), tokens.begin(), tokens.end());
+  }
+  return values;
+}
+
+absl::Status tryCopyMetricToOrcaLoadReport(absl::string_view metric_name,
+                                           absl::string_view metric_value,
+                                           OrcaLoadReport& orca_load_report) {
+  if (metric_name.empty()) {
+    return absl::InvalidArgumentError("metric names cannot be empty strings");
+  }
+
+  if (metric_value.empty()) {
+    return absl::InvalidArgumentError("metric values cannot be empty strings");
+  }
+
+  double value;
+  if (!absl::SimpleAtod(metric_value, &value)) {
+    return absl::InvalidArgumentError(fmt::format(
+        "unable to parse custom backend load metric value({}): {}", metric_name, metric_value));
+  }
+
+  if (std::isnan(value)) {
+    return absl::InvalidArgumentError(
+        fmt::format("custom backend load metric value({}) cannot be NaN.", metric_name));
+  }
+
+  if (std::isinf(value)) {
+    return absl::InvalidArgumentError(
+        fmt::format("custom backend load metric value({}) cannot be infinity.", metric_name));
+  }
+
+  if (absl::StartsWith(metric_name, kNamedMetricsFieldPrefix)) {
+    auto metric_name_without_prefix = absl::StripPrefix(metric_name, kNamedMetricsFieldPrefix);
+    return tryCopyNamedMetricToOrcaLoadReport(metric_name_without_prefix, value, orca_load_report);
+  }
+
+  if (metric_name == kCpuUtilizationField) {
+    orca_load_report.set_cpu_utilization(value);
+  } else if (metric_name == kMemUtilizationField) {
+    orca_load_report.set_mem_utilization(value);
+  } else if (metric_name == kApplicationUtilizationField) {
+    orca_load_report.set_application_utilization(value);
+  } else if (metric_name == kEpsField) {
+    orca_load_report.set_eps(value);
+  } else if (metric_name == kRpsFractionalField) {
+    orca_load_report.set_rps_fractional(value);
+  } else {
+    return absl::InvalidArgumentError(absl::StrCat("unsupported metric name: ", metric_name));
+  }
+  return absl::OkStatus();
+}
+
+absl::Status tryParseNativeHttpEncoded(const HeaderMap::GetResult& header,
+                                       OrcaLoadReport& orca_load_report) {
+  const std::vector<absl::string_view> values = parseCommaDelimitedHeader(header);
+
+  // Check for duplicate metric names here because OrcaLoadReport fields are not
+  // marked as optional and therefore don't differentiate between unset and
+  // default values.
+  absl::flat_hash_set<absl::string_view> metric_names;
+  for (const auto value : values) {
+    std::pair<absl::string_view, absl::string_view> entry =
+        absl::StrSplit(value, absl::MaxSplits(':', 1), absl::SkipWhitespace());
+    if (metric_names.contains(entry.first)) {
+      return absl::AlreadyExistsError(
+          absl::StrCat(kEndpointLoadMetricsHeader, " contains duplicate metric: ", entry.first));
+    }
+    RETURN_IF_NOT_OK(tryCopyMetricToOrcaLoadReport(entry.first, entry.second, orca_load_report));
+    metric_names.insert(entry.first);
+  }
+  return absl::OkStatus();
 }
 
 } // namespace
@@ -41,6 +153,21 @@ absl::StatusOr<OrcaLoadReport> parseOrcaLoadReportHeaders(const HeaderMap& heade
       return absl::InvalidArgumentError(
           fmt::format("unable to parse binaryheader to OrcaLoadReport: {}", header_value));
     }
+  } else if (const auto header_native_http = headers.get(endpointLoadMetricsHeader());
+             !header_native_http.empty()) {
+    // Native HTTP format.
+    RETURN_IF_NOT_OK(tryParseNativeHttpEncoded(header_native_http, load_report));
+  } else if (const auto header_json = headers.get(endpointLoadMetricsHeaderJson());
+             !header_json.empty()) {
+    // JSON format.
+#if defined(ENVOY_ENABLE_FULL_PROTOS) && defined(ENVOY_ENABLE_YAML)
+    bool has_unknown_field = false;
+    const std::string json_string = std::string(header_json[0]->value().getStringView());
+    RETURN_IF_ERROR(
+        Envoy::MessageUtil::loadFromJsonNoThrow(json_string, load_report, has_unknown_field));
+#else
+    IS_ENVOY_BUG("JSON formatted ORCA header support not implemented for this build");
+#endif // !ENVOY_ENABLE_FULL_PROTOS || !ENVOY_ENABLE_YAML
   } else {
     return absl::NotFoundError("no ORCA data sent from the backend");
   }

--- a/source/common/orca/orca_parser.cc
+++ b/source/common/orca/orca_parser.cc
@@ -148,7 +148,7 @@ absl::Status tryParseSerializedBinary(const absl::string_view header,
 absl::StatusOr<OrcaLoadReport> parseOrcaLoadReportHeaders(const HeaderMap& headers) {
   OrcaLoadReport load_report;
 
-  // Binary protobuf format. Lagacy header from gRPC implementation.
+  // Binary protobuf format. Legacy header from gRPC implementation.
   if (const auto header_bin = headers.get(endpointLoadMetricsHeaderBin()); !header_bin.empty()) {
     const auto header_value = header_bin[0]->value().getStringView();
     RETURN_IF_NOT_OK(tryParseSerializedBinary(header_value, load_report));

--- a/source/common/orca/orca_parser.h
+++ b/source/common/orca/orca_parser.h
@@ -11,7 +11,10 @@ namespace Orca {
 // Headers used to send ORCA load metrics from the backend.
 static constexpr absl::string_view kEndpointLoadMetricsHeader = "endpoint-load-metrics";
 static constexpr absl::string_view kEndpointLoadMetricsHeaderBin = "endpoint-load-metrics-bin";
-static constexpr absl::string_view kEndpointLoadMetricsHeaderJson = "endpoint-load-metrics-json";
+// Prefix used to determine format expected in kEndpointLoadMetricsHeader.
+static constexpr absl::string_view kHeaderFormatPrefixBin = "BIN";
+static constexpr absl::string_view kHeaderFormatPrefixJson = "JSON";
+static constexpr absl::string_view kHeaderFormatPrefixText = "TEXT";
 // The following fields are the names of the metrics tracked in the ORCA load
 // report proto.
 static constexpr absl::string_view kApplicationUtilizationField = "application_utilization";

--- a/source/common/orca/orca_parser.h
+++ b/source/common/orca/orca_parser.h
@@ -8,11 +8,21 @@
 namespace Envoy {
 namespace Orca {
 
-// Header used to send ORCA load metrics from the backend.
+// Headers used to send ORCA load metrics from the backend.
+static constexpr absl::string_view kEndpointLoadMetricsHeader = "endpoint-load-metrics";
 static constexpr absl::string_view kEndpointLoadMetricsHeaderBin = "endpoint-load-metrics-bin";
+static constexpr absl::string_view kEndpointLoadMetricsHeaderJson = "endpoint-load-metrics-json";
+// The following fields are the names of the metrics tracked in the ORCA load
+// report proto.
+static constexpr absl::string_view kApplicationUtilizationField = "application_utilization";
+static constexpr absl::string_view kCpuUtilizationField = "cpu_utilization";
+static constexpr absl::string_view kMemUtilizationField = "mem_utilization";
+static constexpr absl::string_view kEpsField = "eps";
+static constexpr absl::string_view kRpsFractionalField = "rps_fractional";
+static constexpr absl::string_view kNamedMetricsFieldPrefix = "named_metrics.";
 
 // Parses ORCA load metrics from a header map into an OrcaLoadReport proto.
-// Supports serialized binary formats.
+// Supports native HTTP, JSON and serialized binary formats.
 absl::StatusOr<xds::data::orca::v3::OrcaLoadReport>
 parseOrcaLoadReportHeaders(const Envoy::Http::HeaderMap& headers);
 } // namespace Orca

--- a/test/common/orca/orca_parser_test.cc
+++ b/test/common/orca/orca_parser_test.cc
@@ -1,4 +1,4 @@
-#include <string>
+#include <limits>
 
 #include "source/common/common/base64.h"
 #include "source/common/orca/orca_parser.h"
@@ -7,6 +7,7 @@
 #include "test/test_common/utility.h"
 
 #include "absl/status/status.h"
+#include "absl/strings/str_cat.h"
 #include "xds/data/orca/v3/orca_load_report.pb.h"
 
 namespace Envoy {
@@ -40,6 +41,123 @@ TEST(OrcaParserUtilTest, MissingOrcaHeaders) {
   // the backend.
   EXPECT_THAT(parseOrcaLoadReportHeaders(headers),
               StatusHelpers::HasStatus(absl::NotFoundError("no ORCA data sent from the backend")));
+}
+
+TEST(OrcaParserUtilTest, NativeHttpEncodedHeader) {
+  Http::TestRequestHeaderMapImpl headers{
+      {std::string(kEndpointLoadMetricsHeader),
+       "cpu_utilization:0.7,application_utilization:0.8,mem_utilization:0.9,"
+       "rps_fractional:1000,eps:2,"
+       "named_metrics.foo:123,named_metrics.bar:0.2"}};
+  EXPECT_THAT(parseOrcaLoadReportHeaders(headers),
+              StatusHelpers::IsOkAndHolds(ProtoEq(ExampleOrcaLoadReport())));
+}
+
+TEST(OrcaParserUtilTest, NativeHttpEncodedHeaderIncorrectFieldType) {
+  Http::TestRequestHeaderMapImpl headers{
+      {std::string(kEndpointLoadMetricsHeader), "cpu_utilization:\"0.7\""}};
+  EXPECT_THAT(parseOrcaLoadReportHeaders(headers),
+              StatusHelpers::HasStatus(
+                  absl::InvalidArgumentError("unable to parse custom backend load metric "
+                                             "value(cpu_utilization): \"0.7\"")));
+}
+
+TEST(OrcaParserUtilTest, NativeHttpEncodedHeaderNanMetricValue) {
+  Http::TestRequestHeaderMapImpl headers{
+      {std::string(kEndpointLoadMetricsHeader),
+       absl::StrCat("cpu_utilization:", std::numeric_limits<double>::quiet_NaN())}};
+  EXPECT_THAT(parseOrcaLoadReportHeaders(headers),
+              StatusHelpers::HasStatus(absl::InvalidArgumentError(
+                  "custom backend load metric value(cpu_utilization) cannot be NaN.")));
+}
+
+TEST(OrcaParserUtilTest, NativeHttpEncodedHeaderInfinityMetricValue) {
+  Http::TestRequestHeaderMapImpl headers{
+      {std::string(kEndpointLoadMetricsHeader),
+       absl::StrCat("cpu_utilization:", std::numeric_limits<double>::infinity())}};
+  EXPECT_THAT(parseOrcaLoadReportHeaders(headers),
+              StatusHelpers::HasStatus(absl::InvalidArgumentError(
+                  "custom backend load metric value(cpu_utilization) cannot be "
+                  "infinity.")));
+}
+
+TEST(OrcaParserUtilTest, NativeHttpEncodedHeaderContainsDuplicateMetric) {
+  Http::TestRequestHeaderMapImpl headers{
+      {std::string(kEndpointLoadMetricsHeader), "cpu_utilization:0.7,cpu_utilization:0.8"}};
+  EXPECT_THAT(parseOrcaLoadReportHeaders(headers),
+              StatusHelpers::HasStatus(absl::AlreadyExistsError(absl::StrCat(
+                  kEndpointLoadMetricsHeader, " contains duplicate metric: cpu_utilization"))));
+}
+
+TEST(OrcaParserUtilTest, NativeHttpEncodedHeaderUnsupportedMetric) {
+  Http::TestRequestHeaderMapImpl headers{
+      {std::string(kEndpointLoadMetricsHeader), "cpu_utilization:0.7,unsupported_metric:0.8"}};
+  EXPECT_THAT(parseOrcaLoadReportHeaders(headers),
+              StatusHelpers::HasStatus(
+                  absl::InvalidArgumentError("unsupported metric name: unsupported_metric")));
+}
+
+TEST(OrcaParserUtilTest, NativeHttpEncodedHeaderContainsDuplicateNamedMetric) {
+  Http::TestRequestHeaderMapImpl headers{{std::string(kEndpointLoadMetricsHeader),
+                                          "named_metrics.foo:123,named_metrics.duplicate:123,"
+                                          "named_metrics.duplicate:0.2"}};
+  EXPECT_THAT(
+      parseOrcaLoadReportHeaders(headers),
+      StatusHelpers::HasStatus(absl::AlreadyExistsError(absl::StrCat(
+          kEndpointLoadMetricsHeader, " contains duplicate metric: named_metrics.duplicate"))));
+}
+
+TEST(OrcaParserUtilTest, NativeHttpEncodedHeaderContainsEmptyNamedMetricKey) {
+  Http::TestRequestHeaderMapImpl headers{
+      {std::string(kEndpointLoadMetricsHeader), "named_metrics.:123"}};
+  EXPECT_THAT(parseOrcaLoadReportHeaders(headers),
+              StatusHelpers::HasStatus(absl::InvalidArgumentError("named metric key is empty.")));
+}
+
+TEST(OrcaParserUtilTest, InvalidNativeHttpEncodedHeader) {
+  Http::TestRequestHeaderMapImpl headers{
+      {std::string(kEndpointLoadMetricsHeader), "not-a-list-of-key-value-pairs"}};
+  EXPECT_THAT(parseOrcaLoadReportHeaders(headers),
+              StatusHelpers::HasStatus(
+                  absl::InvalidArgumentError("metric values cannot be empty strings")));
+}
+
+TEST(OrcaParserUtilTest, JsonHeader) {
+  Http::TestRequestHeaderMapImpl headers{
+      {std::string(kEndpointLoadMetricsHeaderJson),
+       "{\"cpu_utilization\": 0.7, \"application_utilization\": 0.8, "
+       "\"mem_utilization\": 0.9, \"rps_fractional\": 1000, \"eps\": 2, "
+       "\"named_metrics\": {\"foo\": 123,\"bar\": 0.2}}"}};
+  EXPECT_THAT(parseOrcaLoadReportHeaders(headers),
+              StatusHelpers::IsOkAndHolds(ProtoEq(ExampleOrcaLoadReport())));
+}
+
+TEST(OrcaParserUtilTest, InvalidJsonHeader) {
+  Http::TestRequestHeaderMapImpl headers{
+      {std::string(kEndpointLoadMetricsHeaderJson), "not-a-valid-json-string"}};
+  EXPECT_THAT(parseOrcaLoadReportHeaders(headers),
+              StatusHelpers::HasStatus(absl::StatusCode::kInvalidArgument,
+                                       testing::HasSubstr("invalid JSON")));
+}
+
+TEST(OrcaParserUtilTest, JsonHeaderUnknownField) {
+  Http::TestRequestHeaderMapImpl headers{
+      {std::string(kEndpointLoadMetricsHeaderJson),
+       "{\"cpu_utilization\": 0.7, \"application_utilization\": 0.8, "
+       "\"mem_utilization\": 0.9, \"rps_fractional\": 1000, \"eps\": 2,  "
+       "\"unknown_field\": 2,"
+       "\"named_metrics\": {\"foo\": 123,\"bar\": 0.2}}"}};
+  EXPECT_THAT(parseOrcaLoadReportHeaders(headers),
+              StatusHelpers::HasStatus(absl::StatusCode::kInvalidArgument,
+                                       testing::HasSubstr("invalid JSON")));
+}
+
+TEST(OrcaParserUtilTest, JsonHeaderIncorrectFieldType) {
+  Http::TestRequestHeaderMapImpl headers{
+      {std::string(kEndpointLoadMetricsHeaderJson), "{\"cpu_utilization\": \"0.7\""}};
+  EXPECT_THAT(parseOrcaLoadReportHeaders(headers),
+              StatusHelpers::HasStatus(absl::StatusCode::kInvalidArgument,
+                                       testing::HasSubstr("invalid JSON")));
 }
 
 TEST(OrcaParserUtilTest, BinaryHeader) {
@@ -82,6 +200,20 @@ TEST(OrcaParserUtilTest, EmptyBinaryHeader) {
   EXPECT_THAT(parseOrcaLoadReportHeaders(headers),
               StatusHelpers::HasStatus(absl::StatusCode::kInvalidArgument,
                                        testing::HasSubstr("ORCA binary header value is empty")));
+}
+
+TEST(OrcaParserUtilTest, BinHeaderPrecedence) {
+  // Verifies that the order of precedence (binary proto over native http
+  // format) is observed when multiple ORCA headers are sent from the backend.
+  const std::string proto_string =
+      TestUtility::getProtobufBinaryStringFromMessage(exampleOrcaLoadReport());
+  const auto orca_load_report_header_bin =
+      Envoy::Base64::encode(proto_string.c_str(), proto_string.length());
+  Http::TestRequestHeaderMapImpl headers{
+      {std::string(kEndpointLoadMetricsHeader), "cpu_utilization:0.7"},
+      {std::string(kEndpointLoadMetricsHeaderBin), orca_load_report_header_bin}};
+  EXPECT_THAT(parseOrcaLoadReportHeaders(headers),
+              StatusHelpers::IsOkAndHolds(ProtoEq(exampleOrcaLoadReport())));
 }
 
 } // namespace

--- a/test/common/orca/orca_parser_test.cc
+++ b/test/common/orca/orca_parser_test.cc
@@ -50,7 +50,7 @@ TEST(OrcaParserUtilTest, NativeHttpEncodedHeader) {
        "rps_fractional:1000,eps:2,"
        "named_metrics.foo:123,named_metrics.bar:0.2"}};
   EXPECT_THAT(parseOrcaLoadReportHeaders(headers),
-              StatusHelpers::IsOkAndHolds(ProtoEq(ExampleOrcaLoadReport())));
+              StatusHelpers::IsOkAndHolds(ProtoEq(exampleOrcaLoadReport())));
 }
 
 TEST(OrcaParserUtilTest, NativeHttpEncodedHeaderIncorrectFieldType) {
@@ -129,7 +129,7 @@ TEST(OrcaParserUtilTest, JsonHeader) {
        "\"mem_utilization\": 0.9, \"rps_fractional\": 1000, \"eps\": 2, "
        "\"named_metrics\": {\"foo\": 123,\"bar\": 0.2}}"}};
   EXPECT_THAT(parseOrcaLoadReportHeaders(headers),
-              StatusHelpers::IsOkAndHolds(ProtoEq(ExampleOrcaLoadReport())));
+              StatusHelpers::IsOkAndHolds(ProtoEq(exampleOrcaLoadReport())));
 }
 
 TEST(OrcaParserUtilTest, InvalidJsonHeader) {

--- a/test/common/orca/orca_parser_test.cc
+++ b/test/common/orca/orca_parser_test.cc
@@ -205,7 +205,7 @@ TEST(OrcaParserUtilTest, JsonHeaderIncorrectFieldType) {
 
 TEST(OrcaParserUtilTest, LegacyBinaryHeader) {
   // Verify processing of headers sent in legacy ORCA header inherited from gRPC
-  // implmentation works as intended.
+  // implementation works as intended.
   const std::string proto_string =
       TestUtility::getProtobufBinaryStringFromMessage(exampleOrcaLoadReport());
   const auto orca_load_report_header_bin =


### PR DESCRIPTION
Commit Message: Add support for multiple formats of ORCA headers.
Additional Description: Add support for multiple formats of ORCA headers. ORCA parsing introduced in https://github.com/envoyproxy/envoy/pull/35422
[Original Design Proposal](https://github.com/envoyproxy/envoy/issues/6614)
[Using ORCA load reports in Envoy](https://docs.google.com/document/d/1gb_2pcNnEzTgo1EJ6w1Ol7O-EH-O_Ysu5o215N9MTAg/edit#heading=h.bi4e79pb39fe)
Risk Level: Low
Testing: See included unit tests.
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: JSON format unsupported on Mobile.

CC @efimki @adisuissa @wbpcode