### PR TITLE
fix flake in TcpTunnelingIntegrationTest.UpstreamHttpFiltersPauseAndResume

### DIFF
--- a/test/integration/tcp_tunneling_integration_test.cc
+++ b/test/integration/tcp_tunneling_integration_test.cc
@@ -948,10 +948,19 @@ TEST_P(TcpTunnelingIntegrationTest, UpstreamHttpFiltersPauseAndResume) {
   // Send upgrade headers downstream, fully establishing the connection.
   upstream_request_->encodeHeaders(default_response_headers_, false);
 
+  bool verify_no_remote_close = true;
+  if (upstreamProtocol() == Http::CodecType::HTTP1) {
+    // in HTTP1 case, the connection is closed on stream reset and therefore, it
+    // is possible to detect a remote close if remote FIN event gets processed before local close
+    // socket event. By sending verify_no_remote_close as false to the write function, we are
+    // allowing the test to pass even if remote close is detected.
+    verify_no_remote_close = false;
+  }
   // send some data to pause the filter
-  ASSERT_TRUE(tcp_client_->write("hello", false));
+  ASSERT_TRUE(tcp_client_->write("hello", false, verify_no_remote_close));
   // send end stream to resume the filter
-  ASSERT_TRUE(tcp_client_->write("hello", true));
+  ASSERT_TRUE(tcp_client_->write("hello", true, verify_no_remote_close));
+
   ASSERT_TRUE(upstream_request_->waitForData(*dispatcher_, 10));
 
   // Finally close and clean up.


### PR DESCRIPTION


<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: fix flake in TcpTunnelingIntegrationTest.UpstreamHttpFiltersPauseAndResume

fixes: https://github.com/envoyproxy/envoy/issues/35523