### PR TITLE
ext_proc: fix an issue with trailer

### DIFF
--- a/source/extensions/filters/http/ext_proc/processor_state.cc
+++ b/source/extensions/filters/http/ext_proc/processor_state.cc
@@ -339,7 +339,7 @@ absl::Status ProcessorState::handleBodyResponse(const BodyResponse& response) {
       return absl::OkStatus();
     }
 
-    if (should_continue) {
+    if (should_continue || (trailers_available_ && chunk_queue_.empty())) {
       continueIfNecessary();
     }
     return absl::OkStatus();

--- a/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
+++ b/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
@@ -4652,4 +4652,17 @@ TEST_P(ExtProcIntegrationTest, SidestreamPushbackUpstreamObservabilityMode) {
   verifyDownstreamResponse(*response, 200);
 }
 
+TEST_P(ExtProcIntegrationTest, SendHeaderBodyNotSendTrailerTest) {
+  proto_config_.mutable_processing_mode()->set_request_header_mode(ProcessingMode::SEND);
+  proto_config_.mutable_processing_mode()->set_request_body_mode(ProcessingMode::STREAMED);
+  proto_config_.mutable_processing_mode()->set_response_header_mode(ProcessingMode::SKIP);
+  initializeConfig();
+  HttpIntegrationTest::initialize();
+  auto response = sendDownstreamRequestWithBodyAndTrailer("hello world");
+  processRequestHeadersMessage(*grpc_upstreams_[0], true, absl::nullopt);
+  processRequestBodyMessage(*grpc_upstreams_[0], false, absl::nullopt);
+  handleUpstreamRequest(100);
+  verifyDownstreamResponse(*response, 200);
+}
+
 } // namespace Envoy


### PR DESCRIPTION
If ext_proc filter is configured to send header, body but not send trailer, if the downstream request has trailer after body, then there is a problem when handling body response.

It supposes to return continueDecoding() to let the filter manager to send the trailer and finish the request sending. However, the current logic is missing that. This ends up timeout in this situation, and local reply is sent to downstream client.

Risk Level: low
Testing: inline
Docs Changes: N/A
