### PR TITLE
ci/tools: use gen comp db python script directly to provide more flexibility

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -85,6 +85,15 @@ To force the Envoy build image to be refreshed by Docker you can set `ENVOY_DOCK
 ENVOY_DOCKER_PULL=true ./ci/run_envoy_docker.sh <build_script_args>
 ```
 
+
+# Generating compile commands
+
+The `./ci/do_ci.sh` script provides a CI target that generates compile commands for clangd or other tools.
+
+```bash
+ENVOY_GEN_COMPDB_OPTIONS="--vscode --exclude_contrib" ./ci/do_ci.sh refresh_compdb
+```
+
 ## On Linux
 
 An example basic invocation to build a developer version of the Envoy static binary (using the Bazel `fastbuild` type) is:

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -303,6 +303,7 @@ function bazel_envoy_api_go_build() {
 
 CI_TARGET=$1
 shift
+CI_PARAMS=("$@")
 
 if [[ "$CI_TARGET" =~ bazel.* ]]; then
     ORIG_CI_TARGET="$CI_TARGET"
@@ -1041,7 +1042,13 @@ case $CI_TARGET in
         ;;
 
     refresh_compdb)
-        "${CURRENT_SCRIPT_DIR}/../tools/vscode/refresh_compdb.sh"
+        if [[ -z "${SKIP_PROTO_FORMAT}" ]]; then
+            "${CURRENT_SCRIPT_DIR}/../tools/proto_format/proto_format.sh" fix
+        fi
+
+        "${CURRENT_SCRIPT_DIR}/../tools/gen_compilation_database.py" "${CI_PARAMS[@]}"
+        # Kill clangd to reload the compilation database
+        pkill clangd || :
         ;;
 
     *)

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -1047,7 +1047,9 @@ case $CI_TARGET in
 
         read -ra ENVOY_GEN_COMPDB_OPTIONS <<< "${ENVOY_GEN_COMPDB_OPTIONS:-}"
 
-        "${CURRENT_SCRIPT_DIR}/../tools/gen_compilation_database.py" "${ENVOY_GEN_COMPDB_OPTIONS[@]}"
+        TEST_TMPDIR="${BUILD_DIR}/envoy-compdb" \
+            "${CURRENT_SCRIPT_DIR}/../tools/gen_compilation_database.py" \
+            "${ENVOY_GEN_COMPDB_OPTIONS[@]}"
         # Kill clangd to reload the compilation database
         pkill clangd || :
         ;;

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -1047,6 +1047,7 @@ case $CI_TARGET in
 
         read -ra ENVOY_GEN_COMPDB_OPTIONS <<< "${ENVOY_GEN_COMPDB_OPTIONS:-}"
 
+        # Setting TEST_TMPDIR here so the compdb headers won't be overwritten by another bazel run.
         TEST_TMPDIR="${BUILD_DIR}/envoy-compdb" \
             "${CURRENT_SCRIPT_DIR}/../tools/gen_compilation_database.py" \
             "${ENVOY_GEN_COMPDB_OPTIONS[@]}"

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -303,7 +303,6 @@ function bazel_envoy_api_go_build() {
 
 CI_TARGET=$1
 shift
-CI_PARAMS=("$@")
 
 if [[ "$CI_TARGET" =~ bazel.* ]]; then
     ORIG_CI_TARGET="$CI_TARGET"
@@ -1046,7 +1045,9 @@ case $CI_TARGET in
             "${CURRENT_SCRIPT_DIR}/../tools/proto_format/proto_format.sh" fix
         fi
 
-        "${CURRENT_SCRIPT_DIR}/../tools/gen_compilation_database.py" "${CI_PARAMS[@]}"
+        read -ra ENVOY_GEN_COMPDB_OPTIONS <<< "${ENVOY_GEN_COMPDB_OPTIONS:-}"
+
+        "${CURRENT_SCRIPT_DIR}/../tools/gen_compilation_database.py" "${ENVOY_GEN_COMPDB_OPTIONS[@]}"
         # Kill clangd to reload the compilation database
         pkill clangd || :
         ;;

--- a/ci/run_envoy_docker.sh
+++ b/ci/run_envoy_docker.sh
@@ -158,6 +158,7 @@ docker run --rm \
        -e ENVOY_PUBLISH_DRY_RUN \
        -e ENVOY_REPO \
        -e ENVOY_TARBALL_DIR \
+       -e ENVOY_GEN_COMPDB_OPTIONS \
        -e SYSTEM_PULLREQUEST_PULLREQUESTNUMBER \
        -e GCS_ARTIFACT_BUCKET \
        -e GITHUB_REF_NAME \


### PR DESCRIPTION
Commit Message: ci/tools: use gen comp db python script directly to provide more flexibility

Additional Description:

```
$ ci/do_ci.sh refresh_compdb --vscode --include_all --exclude_contrib
```

This is much convenient now to specify parameters of .py script. 

Risk Level: low.
Testing: n/a.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.