### PR TITLE
use library target instead of the default all while build liburing

### DIFF
--- a/bazel/foreign_cc/BUILD
+++ b/bazel/foreign_cc/BUILD
@@ -16,6 +16,7 @@ configure_make(
         "nocompdb",
         "skip_on_windows",
     ],
+    targets = ["library", "install"],
 )
 
 envoy_cc_library(

--- a/bazel/foreign_cc/BUILD
+++ b/bazel/foreign_cc/BUILD
@@ -16,7 +16,10 @@ configure_make(
         "nocompdb",
         "skip_on_windows",
     ],
-    targets = ["library", "install"],
+    targets = [
+        "library",
+        "install",
+    ],
 )
 
 envoy_cc_library(


### PR DESCRIPTION
Commit Message: use library target instead of the default all while build liburing
Additional Description:
Otherwise, error `use of undeclared identifier "so_incoming_napi_id"` will happen in some old systems.
Also, it makes build faster, since the examples and test targets are unnecessary in the default all target.

Risk Level: low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
