### PR TITLE
golang: avoid setting invalid pointer in Golang side when header value is empty

### DIFF
--- a/contrib/golang/filters/http/source/golang_filter.cc
+++ b/contrib/golang/filters/http/source/golang_filter.cc
@@ -571,9 +571,12 @@ void copyHeaderMapToGo(Http::HeaderMap& m, GoString* go_strs, char* go_buf) {
 
     len = value.length();
     go_strs[i].n = len;
-    go_strs[i].p = go_buf;
-    memcpy(go_buf, value.data(), len); // NOLINT(safe-memcpy)
-    go_buf += len;
+    // go_buf may be an invalid pointer in Golang side when len is 0.
+    if (len > 0) {
+      go_strs[i].p = go_buf;
+      memcpy(go_buf, value.data(), len); // NOLINT(safe-memcpy)
+      go_buf += len;
+    }
     i++;
     return Http::HeaderMap::Iterate::Continue;
   });


### PR DESCRIPTION
Otherwise, Golang may panic when it found this invalid pointer.
It's not easy to add a test case for it, since Golang only panic during GC.

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
