### PR TITLE
uhv: fully validate IPv6 Host address

### DIFF
--- a/source/extensions/http/header_validators/envoy_default/header_validator.cc
+++ b/source/extensions/http/header_validators/envoy_default/header_validator.cc
@@ -360,7 +360,7 @@ HeaderValidator::validateHostHeaderIPv6(absl::string_view host) {
     return HostHeaderValidationResult::reject(UhvResponseCodeDetail::get().InvalidHost);
   }
   uint32_t empty_string_count = 0;
-  for (auto & cur_component : address_components) {
+  for (auto& cur_component : address_components) {
     // each part must be 16 bits
     if (cur_component.size() > 4) {
       return HostHeaderValidationResult::reject(UhvResponseCodeDetail::get().InvalidHost);
@@ -385,7 +385,8 @@ HeaderValidator::validateHostHeaderIPv6(absl::string_view host) {
   }
   // Double colon is allowed at the beginning or end
   // Otherwise the address shouldn't have two empty parts
-  if (empty_string_count == 2 && !(absl::StartsWith(address, "::") || absl::EndsWith(address, "::"))) {
+  if (empty_string_count == 2 &&
+      !(absl::StartsWith(address, "::") || absl::EndsWith(address, "::"))) {
     return HostHeaderValidationResult::reject(UhvResponseCodeDetail::get().InvalidHost);
   }
 

--- a/test/extensions/http/header_validators/envoy_default/base_header_validator_test.cc
+++ b/test/extensions/http/header_validators/envoy_default/base_header_validator_test.cc
@@ -189,16 +189,33 @@ TEST_F(BaseHeaderValidatorTest, ValidateHostHeaderInvalidRegName) {
 TEST_F(BaseHeaderValidatorTest, ValidateHostHeaderValidIPv6) {
   HeaderString valid{"[2001:0db8:85a3:0000:0000:8a2e:0370:7334]:443"};
   HeaderString valid_no_port{"[2001:0db8:85a3:0000:0000:8a2e:0370:7334]"};
+  HeaderString valid_double_colon_all_0{"[::]"};
+  HeaderString valid_double_colon{"[2001::7334]"};
+  HeaderString valid_double_colon_at_beginning{"[::2001:7334]"};
+  HeaderString valid_double_colon_at_end{"[2001:7334::]"};
   auto uhv = createBase(empty_config);
 
   EXPECT_ACCEPT(uhv->validateHostHeader(valid));
   EXPECT_ACCEPT(uhv->validateHostHeader(valid_no_port));
+  EXPECT_ACCEPT(uhv->validateHostHeader(valid_double_colon_all_0));
+  EXPECT_ACCEPT(uhv->validateHostHeader(valid_double_colon));
+  EXPECT_ACCEPT(uhv->validateHostHeader(valid_double_colon_at_beginning));
+  EXPECT_ACCEPT(uhv->validateHostHeader(valid_double_colon_at_end));
 }
 
 TEST_F(BaseHeaderValidatorTest, ValidateHostHeaderInvalidIPv6) {
   HeaderString invalid_missing_closing_bracket{"[2001:0db8:85a3:0000:0000:8a2e:0370:7334"};
   HeaderString invalid_chars{"[200z:0db8:85a3:0000:0000:8a2e:0370:7334]"};
   HeaderString invalid_no_brackets{"200z:0db8:85a3:0000:0000:8a2e:0370:7334"};
+  HeaderString invalid_more_than_8_parts{"[2001:0db8:85a3:0000:0000:8a2e:0370:7334:1]:443"};
+  HeaderString invalid_not_16_bits{"[1:1:20012:1:1:1:1:1]:443"};
+  HeaderString invalid_2_double_colons{"[2::1::1]:443"};
+  HeaderString invalid_2_double_colons_at_beginning{"[::1::1]:443"};
+  HeaderString invalid_2_double_colons_at_end{"[1::1::]:443"};
+  HeaderString invalid_2_double_colons_at_beginning_and_end{"[::1:1::]:443"};
+  HeaderString invalid_3_colons{"[:::]:443"};
+  HeaderString invalid_single_colon_at_end{"[1::1:]:443"};
+  HeaderString invalid_single_colon_at_beginning{"[:1::1:2]:443"};
   auto uhv = createBase(empty_config);
 
   EXPECT_REJECT_WITH_DETAILS(uhv->validateHostHeader(invalid_missing_closing_bracket),
@@ -206,6 +223,24 @@ TEST_F(BaseHeaderValidatorTest, ValidateHostHeaderInvalidIPv6) {
   EXPECT_REJECT_WITH_DETAILS(uhv->validateHostHeader(invalid_chars),
                              UhvResponseCodeDetail::get().InvalidHost);
   EXPECT_REJECT_WITH_DETAILS(uhv->validateHostHeader(invalid_no_brackets),
+                             UhvResponseCodeDetail::get().InvalidHost);
+  EXPECT_REJECT_WITH_DETAILS(uhv->validateHostHeader(invalid_more_than_8_parts),
+                             UhvResponseCodeDetail::get().InvalidHost);
+  EXPECT_REJECT_WITH_DETAILS(uhv->validateHostHeader(invalid_not_16_bits),
+                             UhvResponseCodeDetail::get().InvalidHost);
+  EXPECT_REJECT_WITH_DETAILS(uhv->validateHostHeader(invalid_2_double_colons),
+                             UhvResponseCodeDetail::get().InvalidHost);
+  EXPECT_REJECT_WITH_DETAILS(uhv->validateHostHeader(invalid_2_double_colons_at_beginning),
+                             UhvResponseCodeDetail::get().InvalidHost);
+  EXPECT_REJECT_WITH_DETAILS(uhv->validateHostHeader(invalid_2_double_colons_at_end),
+                             UhvResponseCodeDetail::get().InvalidHost);
+  EXPECT_REJECT_WITH_DETAILS(uhv->validateHostHeader(invalid_2_double_colons_at_beginning_and_end),
+                             UhvResponseCodeDetail::get().InvalidHost);
+  EXPECT_REJECT_WITH_DETAILS(uhv->validateHostHeader(invalid_3_colons),
+                             UhvResponseCodeDetail::get().InvalidHost);
+  EXPECT_REJECT_WITH_DETAILS(uhv->validateHostHeader(invalid_single_colon_at_end),
+                             UhvResponseCodeDetail::get().InvalidHost);
+  EXPECT_REJECT_WITH_DETAILS(uhv->validateHostHeader(invalid_single_colon_at_beginning),
                              UhvResponseCodeDetail::get().InvalidHost);
 }
 


### PR DESCRIPTION
Commit Message: uhv: fully validate IPv6 Host address
Additional Description: Validate each part of ipv6 address splitted by `:` is 16 bit. No more than 8 parts. Only one double colon is allowed.
Risk Level: Low
Testing: Unit testing
Docs Changes:
Release Notes:
Platform Specific Features:
Fixes #23314 #22859
