### PR TITLE
change git repo link for where examples are 

### DIFF
--- a/docs/root/start/sandboxes/setup.rst
+++ b/docs/root/start/sandboxes/setup.rst
@@ -70,21 +70,21 @@ You can `find instructions for installing Git on various operating systems here 
 
 .. _start_sandboxes_setup_envoy:
 
-Clone the Envoy repository
+Clone the Envoy examples repository
 --------------------------
 
-If you have not cloned the `Envoy repository <https://github.com/envoyproxy/envoy>`_ already,
+If you have not cloned the `Envoy examples repository <https://github.com/envoyproxy/examples>`_ already,
 clone it with:
 
 .. tabs::
 
    .. code-tab:: console SSH
 
-      git clone git@github.com:envoyproxy/envoy
+      git clone git@github.com:envoyproxy/examples
 
    .. code-tab:: console HTTPS
 
-      git clone https://github.com/envoyproxy/envoy.git
+      git clone https://github.com/envoyproxy/examples.git
 
 .. _start_sandboxes_setup_additional:
 

--- a/docs/root/start/sandboxes/setup.rst
+++ b/docs/root/start/sandboxes/setup.rst
@@ -71,7 +71,7 @@ You can `find instructions for installing Git on various operating systems here 
 .. _start_sandboxes_setup_envoy:
 
 Clone the Envoy examples repository
---------------------------
+-----------------------------------
 
 If you have not cloned the `Envoy examples repository <https://github.com/envoyproxy/examples>`_ already,
 clone it with:


### PR DESCRIPTION
see also #32737 and https://github.com/envoyproxy/envoy/issues/32737#issuecomment-2326210957, 

Commit Message: update git repo url in docs to refer to the new examples repo
Additional Description: might fix docs
Risk Level: none
Testing: none
Docs Changes: changes docs/root/start/sandboxes/setup.rst to refer to the right github repo (examples)
