### PR TITLE
test: Remove unused `no_fuzz` tags

### DIFF
--- a/test/common/common/BUILD
+++ b/test/common/common/BUILD
@@ -76,8 +76,6 @@ envoy_cc_fuzz_test(
     name = "base64_fuzz_test",
     srcs = ["base64_fuzz_test.cc"],
     corpus = "base64_corpus",
-    # Fuzzer is stable, no bugs, simple test target; avoid emitting CO2.
-    tags = ["no_fuzz"],
     deps = ["//source/common/common:base64_lib"],
 )
 
@@ -85,8 +83,6 @@ envoy_cc_fuzz_test(
     name = "utility_fuzz_test",
     srcs = ["utility_fuzz_test.cc"],
     corpus = "utility_corpus",
-    # Fuzzer is stable, no bugs, simple test target; avoid emitting CO2.
-    tags = ["no_fuzz"],
     deps = ["//source/common/common:utility_lib"],
 )
 
@@ -220,8 +216,6 @@ envoy_cc_fuzz_test(
     name = "logger_fuzz_test",
     srcs = ["logger_fuzz_test.cc"],
     corpus = "logger_corpus",
-    # TODO(github.com/envoyproxy/envoy#8893): Re-enable once more fuzz tests are added
-    tags = ["no_fuzz"],
     deps = ["//source/common/common:minimal_logger_lib"],
 )
 

--- a/test/common/protobuf/BUILD
+++ b/test/common/protobuf/BUILD
@@ -94,8 +94,6 @@ envoy_cc_fuzz_test(
     name = "value_util_fuzz_test",
     srcs = ["value_util_fuzz_test.cc"],
     corpus = "value_util_corpus",
-    # Fuzzer is stable, no bugs, simple test target; avoid emitting CO2.
-    tags = ["no_fuzz"],
     deps = ["//source/common/protobuf:utility_lib"],
 )
 


### PR DESCRIPTION
afaict these have been unused since 549e249db5448d738daed5b3e8a49d1fae6b1b0b

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
