### PR TITLE
mobile: Fix c-ares initialization on Android

### DIFF
--- a/mobile/library/java/io/envoyproxy/envoymobile/engine/AndroidEngineImpl.java
+++ b/mobile/library/java/io/envoyproxy/envoymobile/engine/AndroidEngineImpl.java
@@ -1,6 +1,8 @@
 package io.envoyproxy.envoymobile.engine;
 
 import android.content.Context;
+import android.net.ConnectivityManager;
+
 import io.envoyproxy.envoymobile.engine.types.EnvoyEventTracker;
 import io.envoyproxy.envoymobile.engine.types.EnvoyHTTPCallbacks;
 import io.envoyproxy.envoymobile.engine.types.EnvoyLogger;
@@ -15,6 +17,7 @@ import java.util.Map;
 /* Android-specific implementation of the `EnvoyEngine` interface. */
 public class AndroidEngineImpl implements EnvoyEngine {
   private final EnvoyEngine envoyEngine;
+  private final Context context;
 
   /**
    * @param runningCallback Called when the engine finishes its async startup and begins running.
@@ -22,6 +25,7 @@ public class AndroidEngineImpl implements EnvoyEngine {
   public AndroidEngineImpl(Context context, EnvoyOnEngineRunning runningCallback,
                            EnvoyLogger logger, EnvoyEventTracker eventTracker,
                            Boolean enableProxying) {
+    this.context = context;
     this.envoyEngine = new EnvoyEngineImpl(runningCallback, logger, eventTracker);
     if (ContextUtils.getApplicationContext() == null) {
       ContextUtils.initApplicationContext(context.getApplicationContext());
@@ -44,6 +48,10 @@ public class AndroidEngineImpl implements EnvoyEngine {
 
   @Override
   public EnvoyStatus runWithConfig(EnvoyConfiguration envoyConfiguration, String logLevel) {
+    if (envoyConfiguration.useCares) {
+      JniLibrary.initCares(
+          (ConnectivityManager)context.getSystemService(Context.CONNECTIVITY_SERVICE));
+    }
     return envoyEngine.runWithConfig(envoyConfiguration, logLevel);
   }
 

--- a/mobile/library/java/io/envoyproxy/envoymobile/engine/JniLibrary.java
+++ b/mobile/library/java/io/envoyproxy/envoymobile/engine/JniLibrary.java
@@ -1,5 +1,7 @@
 package io.envoyproxy.envoymobile.engine;
 
+import android.net.ConnectivityManager;
+
 import io.envoyproxy.envoymobile.engine.types.EnvoyEventTracker;
 import io.envoyproxy.envoymobile.engine.types.EnvoyHTTPCallbacks;
 import io.envoyproxy.envoymobile.engine.types.EnvoyLogger;
@@ -305,4 +307,11 @@ public class JniLibrary {
       long maxConnectionsPerHost, long streamIdleTimeoutSeconds, long perTryIdleTimeoutSeconds,
       String appVersion, String appId, boolean trustChainVerification, byte[][] filterChain,
       boolean enablePlatformCertificatesValidation, String upstreamTlsSni, byte[][] runtimeGuards);
+
+  /**
+   * Initializes c-ares.
+   * See <a
+   * href="https://c-ares.org/docs/ares_library_init_android.html">ares_library_init_android</a>.
+   */
+  public static native void initCares(ConnectivityManager connectivityManager);
 }

--- a/mobile/library/jni/jni_impl.cc
+++ b/mobile/library/jni/jni_impl.cc
@@ -3,6 +3,7 @@
 
 #include "source/common/protobuf/protobuf.h"
 
+#include "ares.h"
 #include "library/cc/engine_builder.h"
 #include "library/common/api/c_types.h"
 #include "library/common/bridge/utility.h"
@@ -199,6 +200,19 @@ extern "C" JNIEXPORT void JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibra
   Envoy::InternalEngine* internal_engine = reinterpret_cast<Envoy::InternalEngine*>(engine_handle);
   internal_engine->terminate();
   delete internal_engine;
+}
+
+extern "C" JNIEXPORT void JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibrary_initCares(
+    JNIEnv* env, jclass, jobject connectivity_manager) {
+#if defined(__ANDROID_API__)
+  Envoy::JNI::JniHelper jni_helper(env);
+  ares_library_init_jvm(jni_helper.getJavaVm());
+  ares_library_init_android(connectivity_manager);
+#else
+  // For suppressing unused parameters.
+  (void)env;
+  (void)connectivity_manager;
+#endif
 }
 
 extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibrary_recordCounterInc(

--- a/mobile/test/kotlin/apps/experimental/MainActivity.kt
+++ b/mobile/test/kotlin/apps/experimental/MainActivity.kt
@@ -84,6 +84,7 @@ class MainActivity : Activity() {
             Log.d(TAG, "Event emitted: ${entry.key}, ${entry.value}")
           }
         })
+        .useCares(true)
         .build()
 
     recyclerView = findViewById<RecyclerView>(R.id.recycler_view)!!


### PR DESCRIPTION
This PR fixes an issue with c-ares where the DNS servers are empty due to a missing initialization by calling [ares_library_init_android](https://c-ares.org/docs/ares_library_init_android.html).

Risk Level: low
Testing: test app
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: mobile (Android)