### PR TITLE
jwks: Add UA string to headers

### DIFF
--- a/source/common/http/headers.h
+++ b/source/common/http/headers.h
@@ -350,6 +350,7 @@ public:
 
   struct {
     const std::string EnvoyHealthChecker{"Envoy/HC"};
+    const std::string GoBrowser{"Go-browser"};
   } UserAgentValues;
 
   struct {

--- a/source/extensions/filters/http/common/jwks_fetcher.cc
+++ b/source/extensions/filters/http/common/jwks_fetcher.cc
@@ -57,6 +57,7 @@ public:
 
     Http::RequestMessagePtr message = Http::Utility::prepareHeaders(remote_jwks_.http_uri());
     message->headers().setReferenceMethod(Http::Headers::get().MethodValues.Get);
+    message->headers().setReferenceUserAgent(Http::Headers::get().UserAgentValues.GoBrowser);
     ENVOY_LOG(debug, "fetch pubkey from [uri = {}]: start", remote_jwks_.http_uri().uri());
     auto options = Http::AsyncClient::RequestOptions()
                        .setTimeout(std::chrono::milliseconds(


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Add the "Go-browser" UA string to the headers to make request for JWKS Fetcher
Additional Description: Since none of the requests are having a UA string it makes sense to add it as part of utility lib itself
Risk Level: N/A
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
Fixes #35785 