### PR TITLE
bazel/ci: Dont break caches with `PATH`

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -260,14 +260,14 @@ build:rbe-toolchain-clang --platforms=@envoy_build_tools//toolchains:rbe_linux_c
 build:rbe-toolchain-clang --host_platform=@envoy_build_tools//toolchains:rbe_linux_clang_platform
 build:rbe-toolchain-clang --crosstool_top=@envoy_build_tools//toolchains/configs/linux/clang/cc:toolchain
 build:rbe-toolchain-clang --extra_toolchains=@envoy_build_tools//toolchains/configs/linux/clang/config:cc-toolchain
-build:rbe-toolchain-clang --action_env=CC=clang --action_env=CXX=clang++ --action_env=PATH=/usr/sbin:/usr/bin:/sbin:/bin:/opt/llvm/bin
+build:rbe-toolchain-clang --action_env=CC=clang --action_env=CXX=clang++
 
 build:rbe-toolchain-clang-libc++ --config=rbe-toolchain
 build:rbe-toolchain-clang-libc++ --platforms=@envoy_build_tools//toolchains:rbe_linux_clang_libcxx_platform
 build:rbe-toolchain-clang-libc++ --host_platform=@envoy_build_tools//toolchains:rbe_linux_clang_libcxx_platform
 build:rbe-toolchain-clang-libc++ --crosstool_top=@envoy_build_tools//toolchains/configs/linux/clang_libcxx/cc:toolchain
 build:rbe-toolchain-clang-libc++ --extra_toolchains=@envoy_build_tools//toolchains/configs/linux/clang_libcxx/config:cc-toolchain
-build:rbe-toolchain-clang-libc++ --action_env=CC=clang --action_env=CXX=clang++ --action_env=PATH=/usr/sbin:/usr/bin:/sbin:/bin:/opt/llvm/bin
+build:rbe-toolchain-clang-libc++ --action_env=CC=clang --action_env=CXX=clang++
 build:rbe-toolchain-clang-libc++ --action_env=CXXFLAGS=-stdlib=libc++
 build:rbe-toolchain-clang-libc++ --action_env=LDFLAGS=-stdlib=libc++
 build:rbe-toolchain-clang-libc++ --define force_libcpp=enabled

--- a/bazel/setup_clang.sh
+++ b/bazel/setup_clang.sh
@@ -11,9 +11,6 @@ if [[ ! -e "${LLVM_PREFIX}/bin/llvm-config" ]]; then
   exit 1
 fi
 
-PATH="$("${LLVM_PREFIX}"/bin/llvm-config --bindir):${PATH}"
-export PATH
-
 LLVM_VERSION="$(llvm-config --version)"
 LLVM_LIBDIR="$(llvm-config --libdir)"
 LLVM_TARGET="$(llvm-config --host-target)"
@@ -21,7 +18,6 @@ LLVM_TARGET="$(llvm-config --host-target)"
 RT_LIBRARY_PATH="${LLVM_LIBDIR}/clang/${LLVM_VERSION}/lib/${LLVM_TARGET}"
 
 echo "# Generated file, do not edit. If you want to disable clang, just delete this file.
-build:clang --action_env='PATH=${PATH}' --host_action_env='PATH=${PATH}'
 build:clang --action_env='LLVM_CONFIG=${LLVM_PREFIX}/bin/llvm-config' --host_action_env='LLVM_CONFIG=${LLVM_PREFIX}/bin/llvm-config'
 build:clang --repo_env='LLVM_CONFIG=${LLVM_PREFIX}/bin/llvm-config'
 build:clang --linkopt='-L$(llvm-config --libdir)'


### PR DESCRIPTION
setting `PATH` breaks caches by making otherwise hermetically equivalent builds build differently in different environments

to make things worse `PATH` can be set in multiple places, so we break our own caches dep on how things are built
