### PR TITLE
redis_proxy: Fix #35983 - External Authentication should respect pipelining

### DIFF
--- a/source/extensions/filters/network/redis_proxy/proxy_filter.cc
+++ b/source/extensions/filters/network/redis_proxy/proxy_filter.cc
@@ -113,7 +113,7 @@ void ProxyFilter::onRespValue(Common::Redis::RespValuePtr&& value) {
   // we keep the request in the queue and let it be processed when the
   // authentication response is received.
   if (external_auth_call_status_ == ExternalAuthCallStatus::Pending) {
-    request.pending_value_ = std::move(value);
+    request.pending_request_value_ = std::move(value);
     return;
   }
 
@@ -201,8 +201,8 @@ void ProxyFilter::onAuthenticateExternal(CommandSplitter::SplitCallbacks& reques
   request.onResponse(std::move(redis_response));
 
   // Resume processing of pending requests.
-  while (!pending_requests_.empty() && pending_requests_.front().pending_value_) {
-    processRespValue(std::move(pending_requests_.front().pending_value_),
+  while (!pending_requests_.empty() && pending_requests_.front().pending_request_value_) {
+    processRespValue(std::move(pending_requests_.front().pending_request_value_),
                      pending_requests_.front());
   }
 }

--- a/source/extensions/filters/network/redis_proxy/proxy_filter.cc
+++ b/source/extensions/filters/network/redis_proxy/proxy_filter.cc
@@ -108,6 +108,19 @@ void ProxyFilter::initializeReadFilterCallbacks(Network::ReadFilterCallbacks& ca
 void ProxyFilter::onRespValue(Common::Redis::RespValuePtr&& value) {
   pending_requests_.emplace_back(*this);
   PendingRequest& request = pending_requests_.back();
+
+  // If external authentication is enabled and an AUTH command is ongoing,
+  // we keep the request in the queue and let it be processed when the
+  // authentication response is received.
+  if (external_auth_call_status_ == ExternalAuthCallStatus::Pending) {
+    request.pending_value_ = std::move(value);
+    return;
+  }
+
+  processRespValue(std::move(value), request);
+}
+
+void ProxyFilter::processRespValue(Common::Redis::RespValuePtr&& value, PendingRequest& request) {
   CommandSplitter::SplitRequestPtr split =
       splitter_.makeRequest(std::move(value), request, callbacks_->connection().dispatcher(),
                             callbacks_->connection().streamInfo());
@@ -186,20 +199,20 @@ void ProxyFilter::onAuthenticateExternal(CommandSplitter::SplitCallbacks& reques
   external_auth_call_status_ = ExternalAuthCallStatus::Ready;
 
   request.onResponse(std::move(redis_response));
+
+  // Resume processing of pending requests.
+  for (auto& pending_request : pending_requests_) {
+    if (pending_request.pending_value_ != nullptr) {
+      processRespValue(std::move(pending_request.pending_value_), pending_request);
+    }
+  }
 }
 
 void ProxyFilter::onAuth(PendingRequest& request, const std::string& password) {
   if (config_->external_auth_enabled_) {
-    if (external_auth_call_status_ == ExternalAuthCallStatus::Ready) {
-      auth_client_->authenticateExternal(*this, request, callbacks_->connection().streamInfo(),
-                                         EMPTY_STRING, password);
-      external_auth_call_status_ = ExternalAuthCallStatus::Pending;
-    } else {
-      Common::Redis::RespValuePtr response{new Common::Redis::RespValue()};
-      response->type(Common::Redis::RespType::Error);
-      response->asString() = "ERR an existing authentication request is pending";
-      request.onResponse(std::move(response));
-    }
+    auth_client_->authenticateExternal(*this, request, callbacks_->connection().streamInfo(),
+                                       EMPTY_STRING, password);
+    external_auth_call_status_ = ExternalAuthCallStatus::Pending;
     return;
   }
 
@@ -222,16 +235,9 @@ void ProxyFilter::onAuth(PendingRequest& request, const std::string& password) {
 void ProxyFilter::onAuth(PendingRequest& request, const std::string& username,
                          const std::string& password) {
   if (config_->external_auth_enabled_) {
-    if (external_auth_call_status_ == ExternalAuthCallStatus::Ready) {
-      auth_client_->authenticateExternal(*this, request, callbacks_->connection().streamInfo(),
-                                         username, password);
-      external_auth_call_status_ = ExternalAuthCallStatus::Pending;
-    } else {
-      Common::Redis::RespValuePtr response{new Common::Redis::RespValue()};
-      response->type(Common::Redis::RespType::Error);
-      response->asString() = "ERR an existing authentication request is pending";
-      request.onResponse(std::move(response));
-    }
+    auth_client_->authenticateExternal(*this, request, callbacks_->connection().streamInfo(),
+                                       username, password);
+    external_auth_call_status_ = ExternalAuthCallStatus::Pending;
     return;
   }
 

--- a/source/extensions/filters/network/redis_proxy/proxy_filter.h
+++ b/source/extensions/filters/network/redis_proxy/proxy_filter.h
@@ -139,6 +139,8 @@ private:
     Common::Redis::Client::Transaction& transaction() override { return parent_.transaction(); }
 
     ProxyFilter& parent_;
+    // This value is set when the request is on hold, waiting for an external auth response.
+    Common::Redis::RespValuePtr pending_value_;
     Common::Redis::RespValuePtr pending_response_;
     CommandSplitter::SplitRequestPtr request_handle_;
   };
@@ -148,6 +150,7 @@ private:
   void onAuth(PendingRequest& request, const std::string& username, const std::string& password);
   void onResponse(PendingRequest& request, Common::Redis::RespValuePtr&& value);
   bool checkPassword(const std::string& password);
+  void processRespValue(Common::Redis::RespValuePtr&& value, PendingRequest& request);
 
   Common::Redis::DecoderPtr decoder_;
   Common::Redis::EncoderPtr encoder_;

--- a/source/extensions/filters/network/redis_proxy/proxy_filter.h
+++ b/source/extensions/filters/network/redis_proxy/proxy_filter.h
@@ -140,7 +140,7 @@ private:
 
     ProxyFilter& parent_;
     // This value is set when the request is on hold, waiting for an external auth response.
-    Common::Redis::RespValuePtr pending_value_;
+    Common::Redis::RespValuePtr pending_request_value_;
     Common::Redis::RespValuePtr pending_response_;
     CommandSplitter::SplitRequestPtr request_handle_;
   };

--- a/test/extensions/filters/network/redis_proxy/proxy_filter_test.cc
+++ b/test/extensions/filters/network/redis_proxy/proxy_filter_test.cc
@@ -1172,6 +1172,74 @@ TEST_F(RedisProxyFilterWithExternalAuthAndExpiration, ExternalAuthPasswordCorrec
   EXPECT_EQ(Network::FilterStatus::Continue, filter_->onData(fake_data, false));
 }
 
+TEST_F(RedisProxyFilterWithExternalAuthAndExpiration, ExternalAuthWithPipelining) {
+  InSequence s;
+
+  Buffer::OwnedImpl fake_data;
+  Common::Redis::RespValuePtr auth_request(new Common::Redis::RespValue());
+  EXPECT_CALL(*decoder_, decode(Ref(fake_data))).WillOnce(Invoke([&](Buffer::Instance&) -> void {
+    decoder_callbacks_->onRespValue(std::move(auth_request));
+  }));
+
+  // AUTH expectation
+  EXPECT_CALL(splitter_, makeRequest_(Ref(*auth_request), _, _, _))
+      .WillOnce(Invoke([&](const Common::Redis::RespValue&,
+                           CommandSplitter::SplitCallbacks& callbacks, Event::Dispatcher&,
+                           const StreamInfo::StreamInfo&) -> CommandSplitter::SplitRequest* {
+        // External auth expectation.
+        EXPECT_CALL(*external_auth_client_, authenticateExternal(_, _, _, EMPTY_STRING, "password"))
+            .WillOnce(WithArgs<0, 1>(
+                Invoke([&](ExternalAuth::AuthenticateCallback& callback,
+                           CommandSplitter::SplitCallbacks& pending_request) -> void {
+                  ExternalAuth::AuthenticateResponsePtr auth_response =
+                      std::make_unique<ExternalAuth::AuthenticateResponse>(
+                          ExternalAuth::AuthenticateResponse{});
+                  auth_response->status = ExternalAuth::AuthenticationRequestStatus::Authorized;
+                  auto time = time_source_.systemTime() + std::chrono::hours(12);
+                  auth_response->expiration.set_seconds(
+                      duration_cast<std::chrono::seconds>(time.time_since_epoch()).count());
+
+                  // Expect that we receive OK from AUTH first
+                  Common::Redis::RespValuePtr reply(new Common::Redis::RespValue());
+                  reply->type(Common::Redis::RespType::SimpleString);
+                  reply->asString() = "OK";
+                  EXPECT_CALL(*encoder_, encode(Eq(ByRef(*reply)), _)).Times(1);
+                  EXPECT_CALL(filter_callbacks_.connection_, write(_, _));
+
+                  // PING expectation, will be processed after AUTH.
+                  Common::Redis::RespValuePtr ping_request(new Common::Redis::RespValue());
+                  EXPECT_CALL(splitter_, makeRequest_(Ref(*ping_request), _, _, _))
+                      .WillOnce(Invoke(
+                          [&](const Common::Redis::RespValue&,
+                              CommandSplitter::SplitCallbacks& callbacks, Event::Dispatcher&,
+                              const StreamInfo::StreamInfo&) -> CommandSplitter::SplitRequest* {
+                            // Having connection allowed proves pipelining was respected.
+                            EXPECT_TRUE(filter_->connectionAllowed());
+
+                            Common::Redis::RespValuePtr reply_ping(new Common::Redis::RespValue());
+                            reply_ping->type(Common::Redis::RespType::SimpleString);
+                            reply_ping->asString() = "PONG";
+                            EXPECT_CALL(*encoder_, encode(Eq(ByRef(*reply_ping)), _)).Times(1);
+                            EXPECT_CALL(filter_callbacks_.connection_, write(_, _));
+
+                            callbacks.onResponse(std::move(reply_ping));
+                            return nullptr;
+                          }));
+
+                  // Simulate that before the auth response is received, another command is
+                  // pipelined.
+                  decoder_callbacks_->onRespValue(std::move(ping_request));
+
+                  callback.onAuthenticateExternal(pending_request, std::move(auth_response));
+                })));
+
+        callbacks.onAuth("password");
+        return nullptr;
+      }));
+
+  EXPECT_EQ(Network::FilterStatus::Continue, filter_->onData(fake_data, false));
+}
+
 TEST_F(RedisProxyFilterWithExternalAuthAndExpiration, ExternalAuthPasswordCorrectButThenExpires) {
   InSequence s;
 

--- a/test/extensions/filters/network/redis_proxy/proxy_filter_test.cc
+++ b/test/extensions/filters/network/redis_proxy/proxy_filter_test.cc
@@ -1203,7 +1203,7 @@ TEST_F(RedisProxyFilterWithExternalAuthAndExpiration, ExternalAuthWithPipelining
                   Common::Redis::RespValuePtr reply(new Common::Redis::RespValue());
                   reply->type(Common::Redis::RespType::SimpleString);
                   reply->asString() = "OK";
-                  EXPECT_CALL(*encoder_, encode(Eq(ByRef(*reply)), _)).Times(1);
+                  EXPECT_CALL(*encoder_, encode(Eq(ByRef(*reply)), _));
                   EXPECT_CALL(filter_callbacks_.connection_, write(_, _));
 
                   // PING expectation, will be processed after AUTH.
@@ -1219,7 +1219,7 @@ TEST_F(RedisProxyFilterWithExternalAuthAndExpiration, ExternalAuthWithPipelining
                             Common::Redis::RespValuePtr reply_ping(new Common::Redis::RespValue());
                             reply_ping->type(Common::Redis::RespType::SimpleString);
                             reply_ping->asString() = "PONG";
-                            EXPECT_CALL(*encoder_, encode(Eq(ByRef(*reply_ping)), _)).Times(1);
+                            EXPECT_CALL(*encoder_, encode(Eq(ByRef(*reply_ping)), _));
                             EXPECT_CALL(filter_callbacks_.connection_, write(_, _));
 
                             callbacks.onResponse(std::move(reply_ping));


### PR DESCRIPTION
**Description**
We started using External Authentication and it works exactly as expected on a normal use-case. But on some setups, we notice that if an AUTH command is pipelined with another command, since the gRPC call is async, it may process another command before AUTH is fully processed, which by Redis standards should not be possible, ordering should be respected.

_Risk Level_: Low (small change to unreleased feature)

_Testing_:

**Unit Tests:** ✅ 

**Integration Tests:** ✅

**Manual Testing (repro):** ✅ 
Before fix:
![image](https://github.com/user-attachments/assets/ca0c0fa0-fe9a-4949-8d73-77d5950abce2)

After fix:
![image](https://github.com/user-attachments/assets/c32e044c-f85d-49b4-9d55-cd4ac10ceea4)


Fixes #35983 