### PR TITLE
mobile: Make Android HTTP proxy test hermetic

### DIFF
--- a/mobile/test/kotlin/integration/proxying/BUILD
+++ b/mobile/test/kotlin/integration/proxying/BUILD
@@ -10,9 +10,6 @@ envoy_mobile_android_test(
     srcs = [
         "ProxyInfoIntentPerformHTTPRequestUsingProxyTest.kt",
     ],
-    exec_properties = {
-        "dockerNetwork": "standard",
-    },
     native_deps = [
         "//test/jni:libenvoy_jni_with_test_and_listener_extensions.so",
     ] + select({
@@ -28,6 +25,7 @@ envoy_mobile_android_test(
         "//library/kotlin/io/envoyproxy/envoymobile:envoy_lib",
         "//test/java/io/envoyproxy/envoymobile/engine/testing",
         "//test/java/io/envoyproxy/envoymobile/engine/testing:http_proxy_test_server_factory_lib",
+        "//test/java/io/envoyproxy/envoymobile/engine/testing:http_test_server_factory_lib",
     ],
 )
 


### PR DESCRIPTION
This updates the Android HTTP proxy test hermetic by sending a request to a test proxy server instead of sending a request to `api.lyft.com`.

Risk Level: low (test only)
Testing: unit test
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
