### PR TITLE
mobile: Add support for HTTP1 with TLS in the TestServer

### DIFF
--- a/mobile/test/common/integration/test_server.h
+++ b/mobile/test/common/integration/test_server.h
@@ -18,10 +18,11 @@ namespace Envoy {
 
 enum class TestServerType : int {
   HTTP1_WITHOUT_TLS = 0,
-  HTTP2_WITH_TLS = 1,
-  HTTP3 = 2,
-  HTTP_PROXY = 3,
-  HTTPS_PROXY = 4,
+  HTTP1_WITH_TLS = 1,
+  HTTP2_WITH_TLS = 2,
+  HTTP3 = 3,
+  HTTP_PROXY = 4,
+  HTTPS_PROXY = 5,
 };
 
 class TestServer : public ListenerHooks {
@@ -92,7 +93,7 @@ private:
       testing::NiceMock<Server::Configuration::MockTransportSocketFactoryContext>&);
 
   Network::DownstreamTransportSocketFactoryPtr createUpstreamTlsContext(
-      testing::NiceMock<Server::Configuration::MockTransportSocketFactoryContext>&);
+      testing::NiceMock<Server::Configuration::MockTransportSocketFactoryContext>&, bool);
 };
 
 } // namespace Envoy

--- a/mobile/test/java/io/envoyproxy/envoymobile/engine/testing/HttpProxyTestServerFactory.java
+++ b/mobile/test/java/io/envoyproxy/envoymobile/engine/testing/HttpProxyTestServerFactory.java
@@ -4,8 +4,8 @@ package io.envoyproxy.envoymobile.engine.testing;
 public final class HttpProxyTestServerFactory {
   /** The supported {@link HttpProxyTestServer} types. */
   public static class Type {
-    public static final int HTTP_PROXY = 3;
-    public static final int HTTPS_PROXY = 4;
+    public static final int HTTP_PROXY = 4;
+    public static final int HTTPS_PROXY = 5;
 
     private Type() {}
   }

--- a/mobile/test/java/io/envoyproxy/envoymobile/engine/testing/HttpTestServerFactory.java
+++ b/mobile/test/java/io/envoyproxy/envoymobile/engine/testing/HttpTestServerFactory.java
@@ -8,8 +8,9 @@ public final class HttpTestServerFactory {
   /** The supported {@link HttpTestServer} types. */
   public static class Type {
     public static final int HTTP1_WITHOUT_TLS = 0;
-    public static final int HTTP2_WITH_TLS = 1;
-    public static final int HTTP3 = 2;
+    public static final int HTTP1_WITH_TLS = 1;
+    public static final int HTTP2_WITH_TLS = 2;
+    public static final int HTTP3 = 3;
 
     private Type() {}
   }


### PR DESCRIPTION
This is needed for tests that use HTTP1 with TLS.

Risk Level: low (test only)
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
