### PR TITLE
http: remove envoy_reloadable_features_http2_validate_authority_with_quiche

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -185,6 +185,9 @@ removed_config_or_runtime:
     Removed ``envoy.reloadable_features.normalize_host_for_preresolve_dfp_dns`` runtime flag and legacy code paths.
 - area: http
   change: |
+    Removed the ``envoy.reloadable_features.http2_validate_authority_with_quiche`` runtime flag and its legacy code paths.
+- area: http
+  change: |
     Removed ``envoy.reloadable_features.use_http3_header_normalisation`` runtime flag and legacy code paths.
 
 new_features:

--- a/source/common/http/header_utility.cc
+++ b/source/common/http/header_utility.cc
@@ -324,14 +324,6 @@ bool HeaderUtility::authorityIsValid(const absl::string_view header_value) {
           "envoy.reloadable_features.internal_authority_header_validator")) {
     return check_authority_h1_h2(header_value);
   }
-
-#ifdef ENVOY_NGHTTP2
-  if (!Runtime::runtimeFeatureEnabled(
-          "envoy.reloadable_features.http2_validate_authority_with_quiche")) {
-    return nghttp2_check_authority(reinterpret_cast<const uint8_t*>(header_value.data()),
-                                   header_value.size()) != 0;
-  }
-#endif
   return http2::adapter::HeaderValidator::IsValidAuthority(header_value);
 }
 

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -57,7 +57,6 @@ RUNTIME_GUARD(envoy_reloadable_features_http2_discard_host_header);
 // Ignore the automated "remove this flag" issue: we should keep this for 1 year.
 RUNTIME_GUARD(envoy_reloadable_features_http2_use_oghttp2);
 RUNTIME_GUARD(envoy_reloadable_features_http2_use_visitor_for_data);
-RUNTIME_GUARD(envoy_reloadable_features_http2_validate_authority_with_quiche);
 RUNTIME_GUARD(envoy_reloadable_features_http3_happy_eyeballs);
 RUNTIME_GUARD(envoy_reloadable_features_http3_remove_empty_trailers);
 RUNTIME_GUARD(envoy_reloadable_features_http_filter_avoid_reentrant_local_reply);


### PR DESCRIPTION
Commit Message: http: remove envoy.reloadable_features.http2_validate_authority_with_quiche
Additional Description:
Deprecating and removing the runtime flag `envoy.reloadable_features.http2_validate_authority_with_quiche`.

Risk Level: low
Testing: N/A
Docs Changes: N/A
Release Notes: Added
Platform Specific Features: N/A
Fixes #30419