### PR TITLE
mobile: Create a JNI binding for Runtime::runtimeFeatureEnabled

### DIFF
--- a/mobile/library/java/io/envoyproxy/envoymobile/engine/JniLibrary.java
+++ b/mobile/library/java/io/envoyproxy/envoymobile/engine/JniLibrary.java
@@ -319,4 +319,9 @@ public class JniLibrary {
    * href="https://c-ares.org/docs/ares_library_init_android.html">ares_library_init_android</a>.
    */
   public static native void initCares(ConnectivityManager connectivityManager);
+
+  /**
+   * Returns true if the runtime feature is enabled.
+   */
+  public static native boolean isRuntimeFeatureEnabled(String featureName);
 }

--- a/mobile/library/jni/jni_impl.cc
+++ b/mobile/library/jni/jni_impl.cc
@@ -215,6 +215,14 @@ extern "C" JNIEXPORT void JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibra
 #endif
 }
 
+extern "C" JNIEXPORT jboolean JNICALL
+Java_io_envoyproxy_envoymobile_engine_JniLibrary_runtimeFeatureEnabled(JNIEnv* env, jclass,
+                                                                       jstring feature_name) {
+  Envoy::JNI::JniHelper jni_helper(env);
+  return Envoy::Runtime::runtimeFeatureEnabled(
+      Envoy::JNI::javaStringToCppString(jni_helper, feature_name));
+}
+
 extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibrary_recordCounterInc(
     JNIEnv* env,
     jclass, // class


### PR DESCRIPTION
This PR allows us to have a runtime guard check in the Android code.

Risk Level: low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: mobile
