### PR TITLE
mobile: Bump min Android SDK version to 26

### DIFF
--- a/mobile/bazel/android_artifacts.bzl
+++ b/mobile/bazel/android_artifacts.bzl
@@ -308,7 +308,7 @@ def _manifest(package_name):
     package="{}" >
 
     <uses-sdk
-            android:minSdkVersion="21"
+            android:minSdkVersion="26"
             android:targetSdkVersion="29"/>
 </manifest>
 """.format(package_name)

--- a/mobile/bazel/test_manifest.xml
+++ b/mobile/bazel/test_manifest.xml
@@ -7,6 +7,6 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
 
     <uses-sdk
-            android:minSdkVersion="21"
+            android:minSdkVersion="26"
             android:targetSdkVersion="27"/>
 </manifest>

--- a/mobile/examples/java/hello_world/AndroidManifest.xml
+++ b/mobile/examples/java/hello_world/AndroidManifest.xml
@@ -8,7 +8,7 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
 
     <uses-sdk
-            android:minSdkVersion="21"
+            android:minSdkVersion="26"
             android:targetSdkVersion="27"/>
 
     <application

--- a/mobile/examples/kotlin/hello_world/AndroidManifest.xml
+++ b/mobile/examples/kotlin/hello_world/AndroidManifest.xml
@@ -6,7 +6,7 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
 
     <uses-sdk
-            android:minSdkVersion="21"
+            android:minSdkVersion="26"
             android:targetSdkVersion="27"/>
 
     <application

--- a/mobile/examples/kotlin/shared/AndroidManifest.xml
+++ b/mobile/examples/kotlin/shared/AndroidManifest.xml
@@ -4,6 +4,6 @@
           android:versionName="0.1">
 
     <uses-sdk
-            android:minSdkVersion="21"
+            android:minSdkVersion="26"
             android:targetSdkVersion="27"/>
 </manifest>

--- a/mobile/library/java/io/envoyproxy/envoymobile/engine/AndroidEngineManifest.xml
+++ b/mobile/library/java/io/envoyproxy/envoymobile/engine/AndroidEngineManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="io.envoyproxy.envoymobile.engine">
     <uses-sdk
-            android:minSdkVersion="21"
+            android:minSdkVersion="26"
             android:targetSdkVersion="29"/>
 
 </manifest>

--- a/mobile/library/java/io/envoyproxy/envoymobile/utilities/UtilitiesManifest.xml
+++ b/mobile/library/java/io/envoyproxy/envoymobile/utilities/UtilitiesManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="io.envoyproxy.envoymobile.utilities">
     <uses-sdk
-            android:minSdkVersion="21"
+            android:minSdkVersion="26"
             android:targetSdkVersion="29"/>
 
 </manifest>

--- a/mobile/library/java/org/chromium/net/ChromiumNetManifest.xml
+++ b/mobile/library/java/org/chromium/net/ChromiumNetManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="org.chromium.net">
     <uses-sdk
-            android:minSdkVersion="21"
+            android:minSdkVersion="26"
             android:targetSdkVersion="27" />
 
 </manifest>

--- a/mobile/library/java/org/chromium/net/impl/CronvoyManifest.xml
+++ b/mobile/library/java/org/chromium/net/impl/CronvoyManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="org.cronvoy">
     <uses-sdk
-            android:minSdkVersion="21"
+            android:minSdkVersion="26"
             android:targetSdkVersion="27" />
 
 </manifest>

--- a/mobile/library/java/org/chromium/net/urlconnection/URLConnectionManifest.xml
+++ b/mobile/library/java/org/chromium/net/urlconnection/URLConnectionManifest.xml
@@ -2,6 +2,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="org.urlconnection">
   <uses-sdk
-      android:minSdkVersion="21"
+      android:minSdkVersion="26"
       android:targetSdkVersion="29" />
 </manifest>

--- a/mobile/library/kotlin/io/envoyproxy/envoymobile/EnvoyManifest.xml
+++ b/mobile/library/kotlin/io/envoyproxy/envoymobile/EnvoyManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="io.envoyproxy.envoymobile">
     <uses-sdk
-            android:minSdkVersion="21"
+            android:minSdkVersion="26"
             android:targetSdkVersion="29"/>
 
 </manifest>

--- a/mobile/test/kotlin/apps/baseline/AndroidManifest.xml
+++ b/mobile/test/kotlin/apps/baseline/AndroidManifest.xml
@@ -6,7 +6,7 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
 
     <uses-sdk
-            android:minSdkVersion="21"
+            android:minSdkVersion="26"
             android:targetSdkVersion="27"/>
 
     <application

--- a/mobile/test/kotlin/apps/experimental/AndroidManifest.xml
+++ b/mobile/test/kotlin/apps/experimental/AndroidManifest.xml
@@ -6,7 +6,7 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
 
     <uses-sdk
-            android:minSdkVersion="21"
+            android:minSdkVersion="26"
             android:targetSdkVersion="27"/>
 
     <application


### PR DESCRIPTION
This PR bumps the minimum Android SDK version to 26.

Risk Level: low
Testing: CI
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: mobile
