### PR TITLE
kafka: update protocol code to handle future versions of Kafka protocol (3.8)

### DIFF
--- a/contrib/kafka/filters/network/source/protocol/generator.py
+++ b/contrib/kafka/filters/network/source/protocol/generator.py
@@ -93,6 +93,7 @@ class MessageContext:
     """
     State kept during processing only one (request/response) message.
     """
+
     def __init__(self, message, versions, common_structs_el):
         # Name of parent message type that's being processed right now.
         self.message = message
@@ -190,14 +191,12 @@ class StatefulProcessor:
         self.context = MessageContext(spec.get('name'), versions, spec.get('commonStructs'))
 
         # Parse the type itself.
-        complex_type = self.parse_complex_type(
-            self.context.message, spec, versions)
+        complex_type = self.parse_complex_type(self.context.message, spec, versions)
         complex_type.register_flexible_versions(flexible_versions)
 
         # Request / response types need to carry api key version.
         result = complex_type.with_extra('api_key', spec['apiKey'])
         return result
-
 
     def parse_complex_type(self, type_name, field_spec, versions):
         """
@@ -226,7 +225,7 @@ class StatefulProcessor:
 
         # Some structures share the same name, use request/response as prefix.
         if cpp_name in ['EntityData', 'EntryData', 'PartitionData', 'PartitionSnapshot',
-                            'SnapshotId', 'TopicData', 'TopicPartitions', 'TopicSnapshot']:
+                        'SnapshotId', 'TopicData', 'TopicPartitions', 'TopicSnapshot']:
             cpp_name = self.type.capitalize() + type_name
 
         # Some of the types repeat multiple times (e.g. AlterableConfig).
@@ -241,7 +240,6 @@ class StatefulProcessor:
             self.known_types.add(cpp_name)
 
         return Complex(type_name, cpp_name, fields, versions)
-
 
     def parse_field(self, field_spec, highest_possible_version):
         """
@@ -276,7 +274,6 @@ class StatefulProcessor:
                 versions = Statics.parse_version_string(
                     field_spec['versions'], highest_possible_version)
                 return self.parse_complex_type(type_name, field_spec, versions)
-
 
     def parse_and_register_common_struct(self, common_struct):
         """

--- a/contrib/kafka/filters/network/source/protocol/generator.py
+++ b/contrib/kafka/filters/network/source/protocol/generator.py
@@ -89,22 +89,46 @@ def generate_test_code(
         fd.write(contents)
 
 
+class MessageContext:
+    """
+    State kept during processing only one (request/response) message.
+    """
+    def __init__(self, message, versions, common_structs_el):
+        # Name of parent message type that's being processed right now.
+        self.message = message
+        # Versions supported by this message type.
+        self.top_level_versions = versions
+        # Common structs declared in this message type.
+        self.common_structs = {}
+        # The order of common structs and dependencies between them are unpredictable.
+        # So we keep a handle to the source if we encounter something not yet parsed.
+        self.common_structs_el = common_structs_el
+
+    def contains_common_struct(self, type_name):
+        return type_name in self.common_structs
+
+    def get_common_struct(self, type_name):
+        return self.common_structs[type_name]
+
+    def register_common_struct(self, common_struct):
+        self.common_structs[common_struct.original_name] = common_struct
+
+
 class StatefulProcessor:
     """
-  Helper entity that keeps state during the processing.
-  Some state needs to be shared across multiple message types, as we need to handle identical
-  sub-type names (e.g. both AlterConfigsRequest & IncrementalAlterConfigsRequest have child
-  AlterConfigsResource, what would cause a compile-time error if we were to handle it trivially).
-  """
+    Helper entity that keeps state during the processing.
+    Some state needs to be shared across multiple message types, as we need to handle identical
+    sub-type names (e.g. both AlterConfigsRequest & IncrementalAlterConfigsRequest have child
+    AlterConfigsResource, what would cause a compile-time error if we were to handle it trivially).
+    """
 
     def __init__(self, type):
+        # Whether we are processing request or response.
         self.type = type
         # Complex types that have been encountered during processing.
         self.known_types = set()
-        # Name of parent message type that's being processed right now.
-        self.currently_processed_message_type = None
-        # Common structs declared in this message type.
-        self.common_structs = {}
+        # Context for current message (set in 'parse_top_level_element').
+        self.context = None
 
     def parse_messages(self, input_files):
         """
@@ -128,8 +152,9 @@ class StatefulProcessor:
                     amended = re.sub(r'-2147483648', 'INT32_MIN', without_empty_newlines)
                     message_spec = json.loads(amended)
                     api_key = message_spec['apiKey']
-                    # (adam.kotwasinski) ConsumerGroupHeartbeat needs some more changes to parse.
-                    if api_key not in [68]:
+                    # (adam.kotwasinski) Higher API keys in the future versions of Kafka need
+                    # some more changes to parse.
+                    if api_key < 68 or api_key == 69:
                         message = self.parse_top_level_element(message_spec)
                         messages.append(message)
             except Exception as e:
@@ -142,11 +167,10 @@ class StatefulProcessor:
 
     def parse_top_level_element(self, spec):
         """
-    Parse a given structure into a request/response.
-    Request/response is just a complex type, that has name & version information kept in differently
-    named fields, compared to sub-structures in a message.
-    """
-        self.currently_processed_message_type = spec['name']
+        Parse a given structure into a request/response.
+        Request/response is just a complex type, that has name & version information kept
+        in differently named fields, compared to the sub-structures in a message.
+        """
 
         # Figure out all versions of this message type.
         versions = Statics.parse_version_string(spec['validVersions'], 2 << 16 - 1)
@@ -162,71 +186,69 @@ class StatefulProcessor:
         if [x for x in flexible_versions if x not in versions]:
             raise ValueError('invalid flexible versions')
 
-        try:
-            # In 2.4 some types are declared at top level, and only referenced inside.
-            # So let's parse them and store them in state.
-            common_structs = spec.get('commonStructs')
-            if common_structs is not None:
-                for common_struct in reversed(common_structs):
-                    common_struct_name = common_struct['name']
-                    common_struct_versions = Statics.parse_version_string(
-                        common_struct['versions'], versions[-1])
-                    parsed_complex = self.parse_complex_type(
-                        common_struct_name, common_struct, common_struct_versions)
-                    self.common_structs[parsed_complex.name] = parsed_complex
+        # Initialize the context that will be shared for this file's processing.
+        self.context = MessageContext(spec.get('name'), versions, spec.get('commonStructs'))
 
-            # Parse the type itself.
-            complex_type = self.parse_complex_type(
-                self.currently_processed_message_type, spec, versions)
-            complex_type.register_flexible_versions(flexible_versions)
+        # Parse the type itself.
+        complex_type = self.parse_complex_type(
+            self.context.message, spec, versions)
+        complex_type.register_flexible_versions(flexible_versions)
 
-            # Request / response types need to carry api key version.
-            result = complex_type.with_extra('api_key', spec['apiKey'])
-            return result
+        # Request / response types need to carry api key version.
+        result = complex_type.with_extra('api_key', spec['apiKey'])
+        return result
 
-        finally:
-            self.common_structs = {}
-            self.currently_processed_message_type = None
 
     def parse_complex_type(self, type_name, field_spec, versions):
         """
-    Parse given complex type, returning a structure that holds its name, field specification and
-    allowed versions.
-    """
+        Parse given complex type, returning a structure that holds its name, field specification and
+        allowed versions.
+        """
+        cpp_name = type_name
+
         fields_el = field_spec.get('fields')
 
-        if fields_el is not None:
-            fields = []
-            for child_field in field_spec['fields']:
-                child = self.parse_field(child_field, versions[-1])
-                if child is not None:
-                    fields.append(child)
-            # Some structures share the same name, use request/response as prefix.
-            if type_name in ['EntityData', 'EntryData', 'PartitionData', 'PartitionSnapshot',
-                             'SnapshotId', 'TopicData', 'TopicSnapshot']:
-                type_name = self.type.capitalize() + type_name
-            # Some of the types repeat multiple times (e.g. AlterableConfig).
-            # In such a case, every second or later occurrence of the same name is going to be prefixed
-            # with parent type, e.g. we have AlterableConfig (for AlterConfigsRequest) and then
-            # IncrementalAlterConfigsRequestAlterableConfig (for IncrementalAlterConfigsRequest).
-            # This keeps names unique, while keeping non-duplicate ones short.
-            if type_name not in self.known_types:
-                self.known_types.add(type_name)
+        # There are no fields, so it's a reference to a common struct.
+        if fields_el is None:
+            if self.context.contains_common_struct(type_name):
+                return self.context.get_common_struct(type_name)
             else:
-                type_name = self.currently_processed_message_type + type_name
-                self.known_types.add(type_name)
+                for candidate in self.context.common_structs_el:
+                    if candidate['name'] == type_name:
+                        return self.parse_and_register_common_struct(candidate)
 
-            return Complex(type_name, fields, versions)
+        # We have fields, that's an ordinary type.
+        fields = []
+        for child_field in field_spec['fields']:
+            child = self.parse_field(child_field, versions[-1])
+            if child is not None:
+                fields.append(child)
 
+        # Some structures share the same name, use request/response as prefix.
+        if cpp_name in ['EntityData', 'EntryData', 'PartitionData', 'PartitionSnapshot',
+                            'SnapshotId', 'TopicData', 'TopicPartitions', 'TopicSnapshot']:
+            cpp_name = self.type.capitalize() + type_name
+
+        # Some of the types repeat multiple times (e.g. AlterableConfig).
+        # In such a case, every second or later occurrence of the same name is going to be prefixed
+        # with parent type, e.g. we have AlterableConfig (for AlterConfigsRequest) and then
+        # IncrementalAlterConfigsRequestAlterableConfig (for IncrementalAlterConfigsRequest).
+        # This keeps names unique, while keeping non-duplicate ones short.
+        if cpp_name not in self.known_types:
+            self.known_types.add(cpp_name)
         else:
-            return self.common_structs[type_name]
+            cpp_name = self.context.message + cpp_name
+            self.known_types.add(cpp_name)
+
+        return Complex(type_name, cpp_name, fields, versions)
+
 
     def parse_field(self, field_spec, highest_possible_version):
         """
-    Parse given field, returning a structure holding the name, type, and versions when this field is
-    actually used (nullable or not). Obviously, field cannot be used in version higher than its
-    type's usage.
-    """
+        Parse given field, returning a structure holding the name, type, and versions when this
+        field is actually used (nullable or not). Obviously, field cannot be used in version higher
+        than its type's usage.
+        """
         if field_spec.get('tag') is not None:
             return None
 
@@ -254,6 +276,19 @@ class StatefulProcessor:
                 versions = Statics.parse_version_string(
                     field_spec['versions'], highest_possible_version)
                 return self.parse_complex_type(type_name, field_spec, versions)
+
+
+    def parse_and_register_common_struct(self, common_struct):
+        """
+        Parse a common struct (complex type) and store it.
+        """
+        common_struct_name = common_struct['name']
+        common_struct_versions = Statics.parse_version_string(
+            common_struct['versions'], self.context.top_level_versions[-1])
+        parsed_complex = self.parse_complex_type(
+            common_struct_name, common_struct, common_struct_versions)
+        self.context.register_common_struct(parsed_complex)
+        return parsed_complex
 
 
 class Statics:
@@ -623,12 +658,13 @@ class FieldSerializationSpec():
 
 class Complex(TypeSpecification):
     """
-  Represents a complex type (multiple types aggregated into one).
-  This type gets mapped to a C++ struct.
-  """
+    Represents a complex type (multiple types aggregated into one).
+    This type gets mapped to a C++ struct.
+    """
 
-    def __init__(self, name, fields, versions):
-        self.name = name
+    def __init__(self, original_name, type_name, fields, versions):
+        self.original_name = original_name
+        self.name = type_name
         self.fields = fields
         self.versions = versions
         self.flexible_versions = None  # Will be set in 'register_flexible_versions'.

--- a/contrib/kafka/filters/network/source/serialization.h
+++ b/contrib/kafka/filters/network/source/serialization.h
@@ -1410,8 +1410,7 @@ inline uint32_t EncodingContext::encodeCompact(const T& arg, Buffer::Instance& d
 /**
  * Uuid is not encoded in compact fashion, so we just delegate to normal implementation.
  */
-template <>
-inline uint32_t EncodingContext::encodeCompact(const Uuid& arg, Buffer::Instance& dst) {
+template <> inline uint32_t EncodingContext::encodeCompact(const Uuid& arg, Buffer::Instance& dst) {
   return encode(arg, dst);
 }
 

--- a/contrib/kafka/filters/network/source/serialization.h
+++ b/contrib/kafka/filters/network/source/serialization.h
@@ -1151,6 +1151,14 @@ template <typename T> inline uint32_t EncodingContext::computeCompactSize(const 
 }
 
 /**
+ * Template overload for Uuid.
+ * This data type is not compacted, so we just point to non-compact implementation.
+ */
+template <> inline uint32_t EncodingContext::computeCompactSize(const Uuid& arg) const {
+  return computeSize(arg);
+}
+
+/**
  * Template overload for int32_t.
  * This data type is not compacted, so we just point to non-compact implementation.
  */
@@ -1397,6 +1405,14 @@ template <> inline uint32_t EncodingContext::encode(const Uuid& arg, Buffer::Ins
 template <typename T>
 inline uint32_t EncodingContext::encodeCompact(const T& arg, Buffer::Instance& dst) {
   return arg.encodeCompact(dst, *this);
+}
+
+/**
+ * Uuid is not encoded in compact fashion, so we just delegate to normal implementation.
+ */
+template <>
+inline uint32_t EncodingContext::encodeCompact(const Uuid& arg, Buffer::Instance& dst) {
+  return encode(arg, dst);
 }
 
 /**

--- a/docs/root/configuration/listeners/network_filters/kafka_broker_filter.rst
+++ b/docs/root/configuration/listeners/network_filters/kafka_broker_filter.rst
@@ -6,7 +6,8 @@ Kafka Broker filter
 The Apache Kafka broker filter decodes the client protocol for
 `Apache Kafka <https://kafka.apache.org/>`_, both the requests and responses in the payload.
 The message versions in `Kafka 3.5.1 <http://kafka.apache.org/35/protocol.html#protocol_api_keys>`_
-are supported (apart from ConsumerGroupHeartbeat).
+are supported (apart from ConsumerGroupHeartbeat - what means consumers configured with
+``group.protocol=consumer``).
 
 By default the filter attempts not to influence the communication between client and brokers, so
 the messages that could not be decoded (due to Kafka client or broker running a newer version than


### PR DESCRIPTION
Commit Message: kafka: update protocol code to handle future versions of Kafka protocol (3.8)
Additional Description:  Refactor and enhance Kafka protocol generation code so that future versions of Kafka (3.8) can be trivially uptaken. The changes applied result in only one rename in generated code (`TopicPartitions -> RequestTopicPartitions`).
Risk Level: low
Testing: automated suite + manual with [envoy-kafka-tests](https://github.com/adamkotwasinski/envoy-kafka-tests/pull/12/files)
Docs Changes: clarification for Kafka broker
Release Notes: N/A
Platform Specific Features: N/A