### PR TITLE
ci/codeql: Fix build setup

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -272,8 +272,7 @@ build:rbe-toolchain-clang-libc++ --action_env=CXXFLAGS=-stdlib=libc++
 build:rbe-toolchain-clang-libc++ --action_env=LDFLAGS=-stdlib=libc++
 build:rbe-toolchain-clang-libc++ --define force_libcpp=enabled
 
-# Do not inherit from "clang-asan" to avoid picking up flags from local clang.bazelrc.
-build:rbe-toolchain-asan --config=asan
+build:rbe-toolchain-asan --config=clang-asan
 build:rbe-toolchain-asan --linkopt -fuse-ld=lld
 build:rbe-toolchain-asan --action_env=ENVOY_UBSAN_VPTR=1
 build:rbe-toolchain-asan --copt=-fsanitize=vptr,function

--- a/.github/workflows/codeql-daily.yml
+++ b/.github/workflows/codeql-daily.yml
@@ -54,13 +54,18 @@ jobs:
        cd bin/clang14
        wget https://github.com/llvm/llvm-project/releases/download/llvmorg-14.0.0/clang+llvm-14.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz
        tar -xf clang+llvm-14.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz --strip-components 1
-       export PATH=bin/clang14/bin:$PATH
 
     - name: Build
       run: |
        bazel/setup_clang.sh bin/clang14
        bazelisk shutdown
-       bazelisk build -c fastbuild --spawn_strategy=local --discard_analysis_cache --nouse_action_cache --config clang --config libc++ \
+       bazel build \
+           -c fastbuild \
+           --spawn_strategy=local \
+           --discard_analysis_cache \
+           --nouse_action_cache \
+           --config=clang-libc++ \
+           --config=ci \
            //source/common/http/...
 
     - name: Clean Artifacts

--- a/.github/workflows/codeql-push.yml
+++ b/.github/workflows/codeql-push.yml
@@ -85,7 +85,6 @@ jobs:
        cd bin/clang14
        wget https://github.com/llvm/llvm-project/releases/download/llvmorg-14.0.0/clang+llvm-14.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz
        tar -xf clang+llvm-14.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz --strip-components 1
-       export PATH=bin/clang14/bin:$PATH
 
     - name: Build
       if: ${{ env.BUILD_TARGETS != '' }}
@@ -97,8 +96,8 @@ jobs:
            --spawn_strategy=local \
            --discard_analysis_cache \
            --nouse_action_cache \
-           --config clang \
-           --config libc++ \
+           --config=clang-libc++ \
+           --config=ci \
            $BUILD_TARGETS
        echo -e "Built targets...\n$BUILD_TARGETS"
 

--- a/bazel/setup_clang.sh
+++ b/bazel/setup_clang.sh
@@ -15,11 +15,14 @@ fi
 LLVM_VERSION="$("${LLVM_CONFIG}" --version)"
 LLVM_LIBDIR="$("${LLVM_CONFIG}" --libdir)"
 LLVM_TARGET="$("${LLVM_CONFIG}" --host-target)"
+PATH="$("${LLVM_CONFIG}" --bindir):${PATH}"
 
 RT_LIBRARY_PATH="${LLVM_LIBDIR}/clang/${LLVM_VERSION}/lib/${LLVM_TARGET}"
 
 cat <<EOF > "${BAZELRC_FILE}"
 # Generated file, do not edit. If you want to disable clang, just delete this file.
+build:clang --host_action_env=PATH=${PATH} --action_env=PATH=${PATH}
+
 build:clang --action_env=LLVM_CONFIG=${LLVM_CONFIG} --host_action_env=LLVM_CONFIG=${LLVM_CONFIG}
 build:clang --repo_env=LLVM_CONFIG=${LLVM_CONFIG}
 build:clang --linkopt=-L${LLVM_LIBDIR}

--- a/ci/build_setup.sh
+++ b/ci/build_setup.sh
@@ -119,10 +119,12 @@ export BAZEL_STARTUP_OPTION_LIST
 export BAZEL_BUILD_OPTION_LIST
 export BAZEL_GLOBAL_OPTION_LIST
 
-if [[ -e "${LLVM_ROOT}" ]]; then
-    "${CURRENT_SCRIPT_DIR}/../bazel/setup_clang.sh" "${LLVM_ROOT}"
-else
-    echo "LLVM_ROOT not found, not setting up llvm."
+if [[ -z "${ENVOY_RBE}" ]]; then
+    if [[ -e "${LLVM_ROOT}" ]]; then
+        "${CURRENT_SCRIPT_DIR}/../bazel/setup_clang.sh" "${LLVM_ROOT}"
+    else
+        echo "LLVM_ROOT not found, not setting up llvm."
+    fi
 fi
 
 [[ "${BAZEL_EXPUNGE}" == "1" ]] && bazel clean "${BAZEL_BUILD_OPTIONS[@]}" --expunge

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -351,9 +351,14 @@ case $CI_TARGET in
 
     asan)
         setup_clang_toolchain
+        if [[ -n "$ENVOY_RBE" ]]; then
+            ASAN_CONFIG="--config=rbe-toolchain-asan"
+        else
+            ASAN_CONFIG="--config=clang-asan"
+        fi
         BAZEL_BUILD_OPTIONS+=(
             -c dbg
-            "--config=clang-asan"
+            "${ASAN_CONFIG}"
             "--build_tests_only"
             "--remote_download_minimal")
         echo "bazel ASAN/UBSAN debug build with tests"

--- a/ci/filter_example_setup.sh
+++ b/ci/filter_example_setup.sh
@@ -29,6 +29,6 @@ cp -a "${ENVOY_SRCDIR}"/bazel/protoc "${ENVOY_FILTER_EXAMPLE_SRCDIR}"/bazel/
 cp -f "${ENVOY_SRCDIR}"/.bazelrc "${ENVOY_FILTER_EXAMPLE_SRCDIR}"/
 rm -f "${ENVOY_FILTER_EXAMPLE_SRCDIR}"/.bazelversion
 cp -f "${ENVOY_SRCDIR}"/.bazelversion "${ENVOY_FILTER_EXAMPLE_SRCDIR}"/
-cp -f "${ENVOY_SRCDIR}"/*.bazelrc "${ENVOY_FILTER_EXAMPLE_SRCDIR}"/
+cp -f "${ENVOY_SRCDIR}"/*.bazelrc "${ENVOY_FILTER_EXAMPLE_SRCDIR}"/ || :
 
 export FILTER_WORKSPACE_SET=1


### PR DESCRIPTION
This fixes the recent issues with codeql caused by removing some of the setup in setup_clang.sh

this is a partial revert of that, essentially for containerless local builds

it also prevents this codepath from being used in RBE, which was a main goal of the previous changes 