### PR TITLE
golang: optimize copyHeaderMapToGo: reduce memory copy.

### DIFF
--- a/contrib/golang/filters/http/source/golang_filter.cc
+++ b/contrib/golang/filters/http/source/golang_filter.cc
@@ -555,8 +555,9 @@ CAPIStatus Filter::getHeader(ProcessorState& state, absl::string_view key, uint6
 void copyHeaderMapToGo(Http::HeaderMap& m, GoString* go_strs, char* go_buf) {
   auto i = 0;
   m.iterate([&i, &go_strs, &go_buf](const Http::HeaderEntry& header) -> Http::HeaderMap::Iterate {
-    auto key = std::string(header.key().getStringView());
-    auto value = std::string(header.value().getStringView());
+    // It's safe to use StringView here, since we will copy them into Golang.
+    auto key = header.key().getStringView();
+    auto value = header.value().getStringView();
 
     auto len = key.length();
     // go_strs is the heap memory of go, and the length is twice the number of headers. So range it


### PR DESCRIPTION
Commit Message:
Additional Description:
In my local benchmark(requires some hack for benchmark), it makes header map init faster 10%+.
from 2656ns to 2269ns for per header map init.

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
