### PR TITLE
route: get all per filter config directly

### DIFF
--- a/contrib/golang/filters/http/source/golang_filter.cc
+++ b/contrib/golang/filters/http/source/golang_filter.cc
@@ -1376,11 +1376,7 @@ uint64_t Filter::getMergedConfigId() {
   Http::StreamFilterCallbacks* callbacks = decoding_state_.getFilterCallbacks();
 
   // get all of the per route config
-  std::list<const FilterConfigPerRoute*> route_config_list;
-  callbacks->traversePerFilterConfig(
-      [&route_config_list](const Router::RouteSpecificFilterConfig& cfg) {
-        route_config_list.push_back(dynamic_cast<const FilterConfigPerRoute*>(&cfg));
-      });
+  Route::RouteSpecificFilterConfigs route_config_list = callbacks->perFilterConfigs();
 
   ENVOY_LOG(debug, "golang filter route config list length: {}.", route_config_list.size());
 

--- a/contrib/golang/filters/http/source/golang_filter.cc
+++ b/contrib/golang/filters/http/source/golang_filter.cc
@@ -19,6 +19,7 @@
 #include "source/common/grpc/status.h"
 #include "source/common/http/headers.h"
 #include "source/common/http/http1/codec_impl.h"
+#include "source/common/http/utility.h"
 #include "source/common/router/string_accessor_impl.h"
 #include "source/extensions/filters/common/expr/context.h"
 
@@ -1376,12 +1377,13 @@ uint64_t Filter::getMergedConfigId() {
   Http::StreamFilterCallbacks* callbacks = decoding_state_.getFilterCallbacks();
 
   // get all of the per route config
-  Router::RouteSpecificFilterConfigs route_config_list = callbacks->perFilterConfigs();
+  auto route_config_list = Http::Utility::getAllPerFilterConfig<FilterConfigPerRoute>(callbacks);
 
   ENVOY_LOG(debug, "golang filter route config list length: {}.", route_config_list.size());
 
   auto id = config_->getConfigId();
   for (auto it : route_config_list) {
+    ASSERT(it != nullptr, "route config should not be null");
     auto route_config = *it;
     id = route_config.getPluginConfigId(id, config_->pluginName());
   }

--- a/contrib/golang/filters/http/source/golang_filter.cc
+++ b/contrib/golang/filters/http/source/golang_filter.cc
@@ -1376,7 +1376,7 @@ uint64_t Filter::getMergedConfigId() {
   Http::StreamFilterCallbacks* callbacks = decoding_state_.getFilterCallbacks();
 
   // get all of the per route config
-  Route::RouteSpecificFilterConfigs route_config_list = callbacks->perFilterConfigs();
+  Router::RouteSpecificFilterConfigs route_config_list = callbacks->perFilterConfigs();
 
   ENVOY_LOG(debug, "golang filter route config list length: {}.", route_config_list.size());
 

--- a/envoy/http/filter.h
+++ b/envoy/http/filter.h
@@ -463,13 +463,11 @@ public:
   virtual const Router::RouteSpecificFilterConfig* mostSpecificPerFilterConfig() const PURE;
 
   /**
-   * Find all the available per route filter configs, invoking the callback with each config (if
-   * it is present). Iteration of the configs is in order of specificity. That means that the
-   * callback will be called first for a config on a Virtual host, then a route, and finally a route
-   * entry (weighted cluster). If a config is not present, the callback will not be invoked.
+   * Return all the available per route filter configs. The configs is in order of specificity.
+   * That means that the config from a route configuration will be first, then the config from a
+   * virtual host, then the config from a route.
    */
-  virtual void traversePerFilterConfig(
-      std::function<void(const Router::RouteSpecificFilterConfig&)> cb) const PURE;
+  virtual Router::RouteSpecificFilterConfigs perFilterConfigs() const PURE;
 
   /**
    * Return the HTTP/1 stream encoder options if applicable. If the stream is not HTTP/1 returns

--- a/envoy/router/router.h
+++ b/envoy/router/router.h
@@ -122,6 +122,7 @@ public:
   virtual ~RouteSpecificFilterConfig() = default;
 };
 using RouteSpecificFilterConfigConstSharedPtr = std::shared_ptr<const RouteSpecificFilterConfig>;
+using RouteSpecificFilterConfigs = absl::InlinedVector<const RouteSpecificFilterConfig*, 4>;
 
 /**
  * CorsPolicy for Route and VirtualHost.
@@ -686,18 +687,14 @@ public:
    * hierarchy (Route --> VirtualHost --> RouteConfiguration). Or nullptr if none of them exist.
    */
   virtual const RouteSpecificFilterConfig*
-  mostSpecificPerFilterConfig(const std::string& name) const PURE;
+  mostSpecificPerFilterConfig(absl::string_view name) const PURE;
 
   /**
-   * Find all the available per route filter configs, invoking the callback with
-   * each config (if it is present). Iteration of the configs is in order of
-   * specificity. That means that the callback will be called first for a config on
-   * a route configuration, virtual host, route, and finally a route entry (weighted cluster). If
-   * a config is not present, the callback will not be invoked.
+   * Return all the available per route filter configs. The configs is in order of specificity.
+   * That means that the config from a route configuration will be first, then the config from a
+   * virtual host, then the config from a route.
    */
-  virtual void traversePerFilterConfig(
-      const std::string& filter_name,
-      std::function<void(const Router::RouteSpecificFilterConfig&)> cb) const PURE;
+  virtual Router::RouteSpecificFilterConfigs perFilterConfigs(absl::string_view name) const PURE;
 
   /**
    * @return const envoy::config::core::v3::Metadata& return the metadata provided in the config for
@@ -1248,17 +1245,14 @@ public:
    * hierarchy(Route --> VirtualHost --> RouteConfiguration). Or nullptr if none of them exist.
    */
   virtual const RouteSpecificFilterConfig*
-  mostSpecificPerFilterConfig(const std::string& name) const PURE;
+  mostSpecificPerFilterConfig(absl::string_view name) const PURE;
 
   /**
-   * Find all the available per route filter configs, invoking the callback with each config (if
-   * it is present). Iteration of the configs is in order of specificity. That means that the
-   * callback will be called first for a config on a Virtual host, then a route, and finally a route
-   * entry (weighted cluster). If a config is not present, the callback will not be invoked.
+   * Return all the available per route filter configs. The configs is in order of specificity.
+   * That means that the config from a route configuration will be first, then the config from a
+   * virtual host, then the config from a route.
    */
-  virtual void traversePerFilterConfig(
-      const std::string& filter_name,
-      std::function<void(const Router::RouteSpecificFilterConfig&)> cb) const PURE;
+  virtual Router::RouteSpecificFilterConfigs perFilterConfigs(absl::string_view name) const PURE;
 
   /**
    * @return const envoy::config::core::v3::Metadata& return the metadata provided in the config for

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -257,8 +257,7 @@ private:
   const Router::RouteSpecificFilterConfig* mostSpecificPerFilterConfig() const override {
     return nullptr;
   }
-  void traversePerFilterConfig(
-      std::function<void(const Router::RouteSpecificFilterConfig&)>) const override {}
+  Router::RouteSpecificFilterConfigs perFilterConfigs() const override {}
   Http1StreamEncoderOptionsOptRef http1StreamEncoderOptions() override { return {}; }
   OptRef<DownstreamStreamFilterCallbacks> downstreamCallbacks() override { return {}; }
   OptRef<UpstreamStreamFilterCallbacks> upstreamCallbacks() override { return {}; }

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -257,7 +257,7 @@ private:
   const Router::RouteSpecificFilterConfig* mostSpecificPerFilterConfig() const override {
     return nullptr;
   }
-  Router::RouteSpecificFilterConfigs perFilterConfigs() const override {}
+  Router::RouteSpecificFilterConfigs perFilterConfigs() const override { return {}; }
   Http1StreamEncoderOptionsOptRef http1StreamEncoderOptions() override { return {}; }
   OptRef<DownstreamStreamFilterCallbacks> downstreamCallbacks() override { return {}; }
   OptRef<UpstreamStreamFilterCallbacks> upstreamCallbacks() override { return {}; }

--- a/source/common/http/filter_manager.cc
+++ b/source/common/http/filter_manager.cc
@@ -284,16 +284,13 @@ ActiveStreamFilterBase::mostSpecificPerFilterConfig() const {
   return current_route->mostSpecificPerFilterConfig(filter_context_.config_name);
 }
 
-void ActiveStreamFilterBase::traversePerFilterConfig(
-    std::function<void(const Router::RouteSpecificFilterConfig&)> cb) const {
+Router::RouteSpecificFilterConfigs ActiveStreamFilterBase::perFilterConfigs() const {
   Router::RouteConstSharedPtr current_route = getRoute();
   if (current_route == nullptr) {
-    return;
+    return {};
   }
 
-  current_route->traversePerFilterConfig(
-      filter_context_.config_name,
-      [&cb](const Router::RouteSpecificFilterConfig& config) { cb(config); });
+  return current_route->perFilterConfigs(filter_context_.config_name);
 }
 
 Http1StreamEncoderOptionsOptRef ActiveStreamFilterBase::http1StreamEncoderOptions() {

--- a/source/common/http/filter_manager.h
+++ b/source/common/http/filter_manager.h
@@ -119,8 +119,7 @@ struct ActiveStreamFilterBase : public virtual StreamFilterCallbacks,
   void restoreContextOnContinue(ScopeTrackedObjectStack& tracked_object_stack) override;
   void resetIdleTimer() override;
   const Router::RouteSpecificFilterConfig* mostSpecificPerFilterConfig() const override;
-  void traversePerFilterConfig(
-      std::function<void(const Router::RouteSpecificFilterConfig&)> cb) const override;
+  Router::RouteSpecificFilterConfigs perFilterConfigs() const override;
   Http1StreamEncoderOptionsOptRef http1StreamEncoderOptions() override;
   OptRef<DownstreamStreamFilterCallbacks> downstreamCallbacks() override;
   OptRef<UpstreamStreamFilterCallbacks> upstreamCallbacks() override;

--- a/source/common/http/null_route_impl.h
+++ b/source/common/http/null_route_impl.h
@@ -64,12 +64,12 @@ struct NullVirtualHost : public Router::VirtualHost {
   bool includeIsTimeoutRetryHeader() const override { return false; }
   uint32_t retryShadowBufferLimit() const override { return std::numeric_limits<uint32_t>::max(); }
   const Router::RouteSpecificFilterConfig*
-  mostSpecificPerFilterConfig(const std::string&) const override {
+  mostSpecificPerFilterConfig(absl::string_view) const override {
     return nullptr;
   }
-  void traversePerFilterConfig(
-      const std::string&,
-      std::function<void(const Router::RouteSpecificFilterConfig&)>) const override {}
+  Router::RouteSpecificFilterConfigs perFilterConfigs(absl::string_view) const override {
+    return {};
+  }
   const envoy::config::core::v3::Metadata& metadata() const override {
     return Router::DefaultRouteMetadataPack::get().proto_metadata_;
   }
@@ -225,12 +225,12 @@ struct NullRouteImpl : public Router::Route {
   const Router::Decorator* decorator() const override { return nullptr; }
   const Router::RouteTracing* tracingConfig() const override { return nullptr; }
   const Router::RouteSpecificFilterConfig*
-  mostSpecificPerFilterConfig(const std::string&) const override {
+  mostSpecificPerFilterConfig(absl::string_view) const override {
     return nullptr;
   }
-  void traversePerFilterConfig(
-      const std::string&,
-      std::function<void(const Router::RouteSpecificFilterConfig&)>) const override {}
+  Router::RouteSpecificFilterConfigs perFilterConfigs(absl::string_view) const override {
+    return {};
+  }
   const envoy::config::core::v3::Metadata& metadata() const override {
     return Router::DefaultRouteMetadataPack::get().proto_metadata_;
   }

--- a/source/common/http/utility.h
+++ b/source/common/http/utility.h
@@ -543,43 +543,6 @@ const ConfigType* resolveMostSpecificPerFilterConfig(const Http::StreamFilterCal
 }
 
 /**
- * Merge all the available per route filter configs into one. To perform the merge,
- * the reduce function will be called on each two configs until a single merged config is left.
- *
- * @param reduce The first argument for this function will be the config from the previous level
- * and the second argument is the config from the current level (the more specific one). The
- * function should merge the second argument into the first argument.
- *
- * @return The merged config.
- */
-template <class ConfigType>
-absl::optional<ConfigType>
-getMergedPerFilterConfig(const Http::StreamFilterCallbacks* callbacks,
-                         std::function<void(ConfigType&, const ConfigType&)> reduce) {
-  static_assert(std::is_copy_constructible<ConfigType>::value,
-                "ConfigType must be copy constructible");
-  ASSERT(callbacks != nullptr);
-
-  absl::optional<ConfigType> merged;
-
-  callbacks->traversePerFilterConfig([&reduce,
-                                      &merged](const Router::RouteSpecificFilterConfig& cfg) {
-    const ConfigType* typed_cfg = dynamic_cast<const ConfigType*>(&cfg);
-    if (typed_cfg == nullptr) {
-      ENVOY_LOG_MISC(debug, "Failed to retrieve the correct type of route specific filter config");
-      return;
-    }
-    if (!merged) {
-      merged.emplace(*typed_cfg);
-    } else {
-      reduce(merged.value(), *typed_cfg);
-    }
-  });
-
-  return merged;
-}
-
-/**
  * Return all the available per route filter configs.
  *
  * @param callbacks The stream filter callbacks to check for route configs.
@@ -593,15 +556,15 @@ getAllPerFilterConfig(const Http::StreamFilterCallbacks* callbacks) {
   ASSERT(callbacks != nullptr);
 
   absl::InlinedVector<const ConfigType*, 3> all_configs;
-  callbacks->traversePerFilterConfig([&all_configs](const Router::RouteSpecificFilterConfig& cfg) {
-    const ConfigType* typed_cfg = dynamic_cast<const ConfigType*>(&cfg);
+
+  for (const auto* config : callbacks->perFilterConfigs()) {
+    const ConfigType* typed_cfg = dynamic_cast<const ConfigType*>(config);
     if (typed_cfg == nullptr) {
       ENVOY_LOG_MISC(debug, "Failed to retrieve the correct type of route specific filter config");
       return;
     }
-
     all_configs.push_back(typed_cfg);
-  });
+  }
 
   return all_configs;
 }

--- a/source/common/http/utility.h
+++ b/source/common/http/utility.h
@@ -561,7 +561,7 @@ getAllPerFilterConfig(const Http::StreamFilterCallbacks* callbacks) {
     const ConfigType* typed_cfg = dynamic_cast<const ConfigType*>(config);
     if (typed_cfg == nullptr) {
       ENVOY_LOG_MISC(debug, "Failed to retrieve the correct type of route specific filter config");
-      return;
+      continue;
     }
     all_configs.push_back(typed_cfg);
   }

--- a/source/common/http/utility.h
+++ b/source/common/http/utility.h
@@ -551,19 +551,19 @@ const ConfigType* resolveMostSpecificPerFilterConfig(const Http::StreamFilterCal
  * and their lifetime is the same as the matched route.
  */
 template <class ConfigType>
-absl::InlinedVector<const ConfigType*, 3>
+absl::InlinedVector<const ConfigType*, 4>
 getAllPerFilterConfig(const Http::StreamFilterCallbacks* callbacks) {
   ASSERT(callbacks != nullptr);
 
-  absl::InlinedVector<const ConfigType*, 3> all_configs;
+  absl::InlinedVector<const ConfigType*, 4> all_configs;
 
   for (const auto* config : callbacks->perFilterConfigs()) {
-    const ConfigType* typed_cfg = dynamic_cast<const ConfigType*>(config);
-    if (typed_cfg == nullptr) {
+    const ConfigType* typed_config = dynamic_cast<const ConfigType*>(config);
+    if (typed_config == nullptr) {
       ENVOY_LOG_MISC(debug, "Failed to retrieve the correct type of route specific filter config");
       continue;
     }
-    all_configs.push_back(typed_cfg);
+    all_configs.push_back(typed_config);
   }
 
   return all_configs;

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -963,7 +963,7 @@ public:
       return parent_->mostSpecificPerFilterConfig(name);
     }
     RouteSpecificFilterConfigs perFilterConfigs(absl::string_view filter_name) const override {
-      parent_->perFilterConfigs(filter_name);
+      return parent_->perFilterConfigs(filter_name);
     };
     const std::string& routeName() const override { return parent_->routeName(); }
 

--- a/source/common/router/delegating_route_impl.h
+++ b/source/common/router/delegating_route_impl.h
@@ -28,13 +28,11 @@ public:
   const Router::RouteTracing* tracingConfig() const override;
 
   const RouteSpecificFilterConfig*
-  mostSpecificPerFilterConfig(const std::string& name) const override {
+  mostSpecificPerFilterConfig(absl::string_view name) const override {
     return base_route_->mostSpecificPerFilterConfig(name);
   }
-  void traversePerFilterConfig(
-      const std::string& filter_name,
-      std::function<void(const Router::RouteSpecificFilterConfig&)> cb) const override {
-    base_route_->traversePerFilterConfig(filter_name, cb);
+  RouteSpecificFilterConfigs perFilterConfigs(absl::string_view filter_name) const override {
+    return base_route_->perFilterConfigs(filter_name);
   }
 
   const envoy::config::core::v3::Metadata& metadata() const override {

--- a/source/common/tcp_proxy/tcp_proxy.h
+++ b/source/common/tcp_proxy/tcp_proxy.h
@@ -545,6 +545,7 @@ public:
     const Router::RouteSpecificFilterConfig* mostSpecificPerFilterConfig() const override {
       return nullptr;
     }
+    Router::RouteSpecificFilterConfigs perFilterConfigs() const override { return {}; }
     Buffer::BufferMemoryAccountSharedPtr account() const override { return nullptr; }
     void setUpstreamOverrideHost(Upstream::LoadBalancerContext::OverrideHost) override {}
     absl::optional<Upstream::LoadBalancerContext::OverrideHost>
@@ -555,8 +556,6 @@ public:
     void restoreContextOnContinue(ScopeTrackedObjectStack& tracked_object_stack) override {
       tracked_object_stack.add(*this);
     }
-    void traversePerFilterConfig(
-        std::function<void(const Router::RouteSpecificFilterConfig&)>) const override {}
     Http::Http1StreamEncoderOptionsOptRef http1StreamEncoderOptions() override { return {}; }
     OptRef<Http::DownstreamStreamFilterCallbacks> downstreamCallbacks() override { return {}; }
     OptRef<Http::UpstreamStreamFilterCallbacks> upstreamCallbacks() override { return {}; }

--- a/source/extensions/filters/http/cors/BUILD
+++ b/source/extensions/filters/http/cors/BUILD
@@ -27,6 +27,7 @@ envoy_cc_library(
         "//source/common/common:enum_to_int",
         "//source/common/http:header_map_lib",
         "//source/common/http:headers_lib",
+        "//source/common/http:utility_lib",
     ],
 )
 

--- a/source/extensions/filters/http/cors/cors_filter.cc
+++ b/source/extensions/filters/http/cors/cors_filter.cc
@@ -53,14 +53,14 @@ CorsFilterConfig::CorsFilterConfig(const std::string& stats_prefix, Stats::Scope
 CorsFilter::CorsFilter(CorsFilterConfigSharedPtr config) : config_(std::move(config)) {}
 
 void CorsFilter::initializeCorsPolicies() {
-  decoder_callbacks_->traversePerFilterConfig([this](const Router::RouteSpecificFilterConfig& cfg) {
-    const auto* typed_cfg = dynamic_cast<const Router::CorsPolicy*>(&cfg);
+  for (const auto* cfg : decoder_callbacks_->perFilterConfigs()) {
+    const auto* typed_cfg = dynamic_cast<const Router::CorsPolicy*>(cfg);
     if (typed_cfg != nullptr) {
       policies_.push_back(typed_cfg);
     }
-  });
+  }
 
-  // The 'traversePerFilterConfig' will handle cors policy of virtual host first. So, we need
+  // The 'perFilterConfigs' will handle cors policy of virtual host first. So, we need
   // reverse the 'policies_' to make sure the cors policy of route entry to be first item in the
   // 'policies_'.
   if (policies_.size() >= 2) {

--- a/source/extensions/filters/http/cors/cors_filter.cc
+++ b/source/extensions/filters/http/cors/cors_filter.cc
@@ -10,6 +10,7 @@
 #include "source/common/common/enum_to_int.h"
 #include "source/common/http/header_map_impl.h"
 #include "source/common/http/headers.h"
+#include "source/common/http/utility.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -53,12 +54,7 @@ CorsFilterConfig::CorsFilterConfig(const std::string& stats_prefix, Stats::Scope
 CorsFilter::CorsFilter(CorsFilterConfigSharedPtr config) : config_(std::move(config)) {}
 
 void CorsFilter::initializeCorsPolicies() {
-  for (const auto* cfg : decoder_callbacks_->perFilterConfigs()) {
-    const auto* typed_cfg = dynamic_cast<const Router::CorsPolicy*>(cfg);
-    if (typed_cfg != nullptr) {
-      policies_.push_back(typed_cfg);
-    }
-  }
+  policies_ = Http::Utility::getAllPerFilterConfig<Router::CorsPolicy>(decoder_callbacks_);
 
   // The 'perFilterConfigs' will handle cors policy of virtual host first. So, we need
   // reverse the 'policies_' to make sure the cors policy of route entry to be first item in the

--- a/source/extensions/filters/http/cors/cors_filter.h
+++ b/source/extensions/filters/http/cors/cors_filter.h
@@ -104,7 +104,7 @@ private:
 
   Http::StreamDecoderFilterCallbacks* decoder_callbacks_{};
   Http::StreamEncoderFilterCallbacks* encoder_callbacks_{};
-  absl::InlinedVector<const Envoy::Router::CorsPolicy*, 2> policies_;
+  absl::InlinedVector<const Envoy::Router::CorsPolicy*, 4> policies_;
   bool is_cors_request_{};
   std::string latched_origin_;
 

--- a/source/extensions/filters/http/cors/cors_filter.h
+++ b/source/extensions/filters/http/cors/cors_filter.h
@@ -83,9 +83,7 @@ public:
     encoder_callbacks_ = &callbacks;
   };
 
-  const absl::InlinedVector<const Envoy::Router::CorsPolicy*, 2>& policiesForTest() const {
-    return policies_;
-  }
+  const auto& policiesForTest() const { return policies_; }
 
 private:
   friend class CorsFilterTest;

--- a/source/extensions/filters/http/custom_response/custom_response_filter.cc
+++ b/source/extensions/filters/http/custom_response/custom_response_filter.cc
@@ -48,18 +48,18 @@ Http::FilterHeadersStatus CustomResponseFilter::encodeHeaders(Http::ResponseHead
   // policy. Note that since the traversal is least to most specific, we can't
   // return early when a match is found.
   PolicySharedPtr policy;
-  decoder_callbacks_->traversePerFilterConfig(
-      [&policy, &headers, this](const Router::RouteSpecificFilterConfig& config) {
-        const FilterConfig* typed_config = dynamic_cast<const FilterConfig*>(&config);
-        if (typed_config) {
-          // Check if a match is found first to avoid overwriting policy with an
-          // empty shared_ptr.
-          auto maybe_policy = typed_config->getPolicy(headers, encoder_callbacks_->streamInfo());
-          if (maybe_policy) {
-            policy = maybe_policy;
-          }
-        }
-      });
+  for (const auto* cfg : decoder_callbacks_->perFilterConfigs()) {
+    const FilterConfig* typed_config = dynamic_cast<const FilterConfig*>(cfg);
+    if (typed_config) {
+      // Check if a match is found first to avoid overwriting policy with an
+      // empty shared_ptr.
+      auto maybe_policy = typed_config->getPolicy(headers, encoder_callbacks_->streamInfo());
+      if (maybe_policy) {
+        policy = maybe_policy;
+      }
+    }
+  }
+
   if (!policy) {
     policy = config_->getPolicy(headers, encoder_callbacks_->streamInfo());
   }

--- a/source/extensions/filters/http/custom_response/custom_response_filter.cc
+++ b/source/extensions/filters/http/custom_response/custom_response_filter.cc
@@ -48,15 +48,15 @@ Http::FilterHeadersStatus CustomResponseFilter::encodeHeaders(Http::ResponseHead
   // policy. Note that since the traversal is least to most specific, we can't
   // return early when a match is found.
   PolicySharedPtr policy;
-  for (const auto* cfg : decoder_callbacks_->perFilterConfigs()) {
-    const FilterConfig* typed_config = dynamic_cast<const FilterConfig*>(cfg);
-    if (typed_config) {
-      // Check if a match is found first to avoid overwriting policy with an
-      // empty shared_ptr.
-      auto maybe_policy = typed_config->getPolicy(headers, encoder_callbacks_->streamInfo());
-      if (maybe_policy) {
-        policy = maybe_policy;
-      }
+  for (const auto* typed_config :
+       Http::Utility::getAllPerFilterConfig<FilterConfig>(encoder_callbacks_)) {
+    ASSERT(typed_config != nullptr);
+
+    // Check if a match is found first to avoid overwriting policy with an
+    // empty shared_ptr.
+    auto maybe_policy = typed_config->getPolicy(headers, encoder_callbacks_->streamInfo());
+    if (maybe_policy) {
+      policy = maybe_policy;
     }
   }
 

--- a/source/extensions/filters/http/ext_authz/ext_authz.cc
+++ b/source/extensions/filters/http/ext_authz/ext_authz.cc
@@ -1,3 +1,4 @@
+#include "ext_authz.h"
 #include "source/extensions/filters/http/ext_authz/ext_authz.h"
 
 #include <chrono>
@@ -175,11 +176,16 @@ void Filter::initiateCall(const Http::RequestHeaderMap& headers) {
     return;
   }
 
-  auto&& maybe_merged_per_route_config =
-      Http::Utility::getMergedPerFilterConfig<FilterConfigPerRoute>(
-          decoder_callbacks_, [](FilterConfigPerRoute& cfg_base, const FilterConfigPerRoute& cfg) {
-            cfg_base.merge(cfg);
-          });
+  absl::optional<FilterConfigPerRoute> maybe_merged_per_route_config;
+  for (const auto* cfg :
+       Http::Utility::getAllPerFilterConfig<FilterConfigPerRoute>(decoder_callbacks_)) {
+    ASSERT(cfg != nullptr);
+    if (maybe_merged_per_route_config.has_value()) {
+      maybe_merged_per_route_config.value().merge(*cfg);
+    } else {
+      maybe_merged_per_route_config = *cfg;
+    }
+  }
 
   Protobuf::Map<std::string, std::string> context_extensions;
   if (maybe_merged_per_route_config) {

--- a/source/extensions/filters/http/ext_proc/ext_proc.cc
+++ b/source/extensions/filters/http/ext_proc/ext_proc.cc
@@ -1279,12 +1279,9 @@ void Filter::mergePerRouteConfig() {
   route_config_merged_ = true;
 
   absl::optional<FilterConfigPerRoute> merged_config;
-  for (const auto* cfg : decoder_callbacks_->perFilterConfigs()) {
-    const FilterConfigPerRoute* typed_cfg = dynamic_cast<const FilterConfigPerRoute*>(cfg);
-    if (typed_cfg == nullptr) {
-      ENVOY_LOG_MISC(debug, "Failed to retrieve the correct type of route specific filter config");
-      return;
-    }
+  for (const auto* typed_cfg :
+       Http::Utility::getAllPerFilterConfig<FilterConfigPerRoute>(decoder_callbacks_)) {
+    ASSERT(typed_cfg != nullptr);
     if (!merged_config.has_value()) {
       merged_config.emplace(*typed_cfg);
     } else {

--- a/source/extensions/filters/http/ext_proc/ext_proc.cc
+++ b/source/extensions/filters/http/ext_proc/ext_proc.cc
@@ -1279,10 +1279,8 @@ void Filter::mergePerRouteConfig() {
   route_config_merged_ = true;
 
   absl::optional<FilterConfigPerRoute> merged_config;
-
-  decoder_callbacks_->traversePerFilterConfig([&merged_config](
-                                                  const Router::RouteSpecificFilterConfig& cfg) {
-    const FilterConfigPerRoute* typed_cfg = dynamic_cast<const FilterConfigPerRoute*>(&cfg);
+  for (const auto* cfg : decoder_callbacks_->perFilterConfigs()) {
+    const FilterConfigPerRoute* typed_cfg = dynamic_cast<const FilterConfigPerRoute*>(cfg);
     if (typed_cfg == nullptr) {
       ENVOY_LOG_MISC(debug, "Failed to retrieve the correct type of route specific filter config");
       return;
@@ -1292,7 +1290,7 @@ void Filter::mergePerRouteConfig() {
     } else {
       merged_config.emplace(FilterConfigPerRoute(merged_config.value(), *typed_cfg));
     }
-  });
+  }
 
   if (!merged_config.has_value()) {
     return;

--- a/source/extensions/filters/http/file_system_buffer/filter.cc
+++ b/source/extensions/filters/http/file_system_buffer/filter.cc
@@ -1,3 +1,4 @@
+#include "filter.h"
 #include "source/extensions/filters/http/file_system_buffer/filter.h"
 
 namespace Envoy {
@@ -20,12 +21,13 @@ bool FileSystemBufferFilter::initPerRouteConfig() {
   auto route = request_callbacks_->route();
   FilterConfigVector config_chain;
   if (route) {
-    route->traversePerFilterConfig(
-        FileSystemBufferFilter::filterName(),
-        [&config_chain](const Router::RouteSpecificFilterConfig& route_cfg) {
-          auto cfg = dynamic_cast<const FileSystemBufferFilterConfig*>(&route_cfg);
-          config_chain.emplace_back(*cfg);
-        });
+    // TODO(wbpcode): fix this to use the callbacks to get the route specific configs.
+    for (const auto* cfg : route->perFilterConfigs(FileSystemBufferFilter::filterName())) {
+      auto typed_cfg = dynamic_cast<const FileSystemBufferFilterConfig*>(cfg);
+      if (typed_cfg) {
+        config_chain.emplace_back(*typed_cfg);
+      }
+    }
   }
   config_chain.emplace_back(*base_config_);
   config_.emplace(config_chain);

--- a/source/extensions/filters/http/header_mutation/header_mutation.h
+++ b/source/extensions/filters/http/header_mutation/header_mutation.h
@@ -82,7 +82,7 @@ public:
 private:
   HeaderMutationConfigSharedPtr config_{};
   // The lifetime of route config pointers is same as the matched route.
-  absl::InlinedVector<const PerRouteHeaderMutation*, 3> route_configs_{};
+  absl::InlinedVector<const PerRouteHeaderMutation*, 4> route_configs_{};
 };
 
 } // namespace HeaderMutation

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -10644,11 +10644,11 @@ public:
     check(dynamic_cast<const DerivedFilterConfig*>(
               route->mostSpecificPerFilterConfig(route_config_name)),
           expected_most_specific_config, "most specific config");
-    route->traversePerFilterConfig(
-        route_config_name, [&](const Router::RouteSpecificFilterConfig& cfg) {
-          auto* typed_cfg = dynamic_cast<const DerivedFilterConfig*>(&cfg);
-          traveled_cfg.push_back(typed_cfg->config_.seconds());
-        });
+    for (const auto* cfg : route->perFilterConfigs(route_config_name)) {
+      auto* typed_cfg = dynamic_cast<const DerivedFilterConfig*>(cfg);
+      traveled_cfg.push_back(typed_cfg->config_.seconds());
+    }
+
     ASSERT_EQ(expected_traveled_config, traveled_cfg);
   }
 
@@ -10666,11 +10666,10 @@ public:
     absl::InlinedVector<uint32_t, 3> traveled_cfg;
 
     EXPECT_EQ(nullptr, route->mostSpecificPerFilterConfig(route_config_name));
-    route->traversePerFilterConfig(
-        route_config_name, [&](const Router::RouteSpecificFilterConfig& cfg) {
-          auto* typed_cfg = dynamic_cast<const DerivedFilterConfig*>(&cfg);
-          traveled_cfg.push_back(typed_cfg->config_.seconds());
-        });
+    for (const auto* cfg : route->perFilterConfigs(route_config_name)) {
+      auto* typed_cfg = dynamic_cast<const DerivedFilterConfig*>(cfg);
+      traveled_cfg.push_back(typed_cfg->config_.seconds());
+    }
     EXPECT_EQ(0, traveled_cfg.size());
   }
 

--- a/test/common/router/delegating_route_impl_test.cc
+++ b/test/common/router/delegating_route_impl_test.cc
@@ -34,8 +34,7 @@ TEST(DelegatingRoute, DelegatingRouteTest) {
   std::string name;
   TEST_METHOD(mostSpecificPerFilterConfig, name);
 
-  std::function<void(const Router::RouteSpecificFilterConfig&)> cb;
-  TEST_METHOD(traversePerFilterConfig, name, cb);
+  TEST_METHOD(perFilterConfigs, name);
 }
 
 // Verify that DelegatingRouteEntry class forwards all calls to internal base route.

--- a/test/extensions/filters/http/ext_authz/ext_authz_test.cc
+++ b/test/extensions/filters/http/ext_authz/ext_authz_test.cc
@@ -2605,11 +2605,9 @@ TEST_P(HttpFilterTestParam, ContextExtensions) {
 
   EXPECT_CALL(*decoder_filter_callbacks_.route_, mostSpecificPerFilterConfig(_))
       .WillOnce(Return(&auth_per_route));
-  EXPECT_CALL(*decoder_filter_callbacks_.route_, traversePerFilterConfig(_, _))
-      .WillOnce(Invoke([&](const std::string&,
-                           std::function<void(const Router::RouteSpecificFilterConfig&)> cb) {
-        cb(auth_per_vhost);
-        cb(auth_per_route);
+  EXPECT_CALL(*decoder_filter_callbacks_.route_, perFilterConfigs(_))
+      .WillOnce(Invoke([&](absl::string_view) -> Router::RouteSpecificFilterConfigs {
+        return {&auth_per_vhost, &auth_per_route};
       }));
 
   prepareCheck();

--- a/test/extensions/filters/http/ext_proc/filter_test.cc
+++ b/test/extensions/filters/http/ext_proc/filter_test.cc
@@ -3473,11 +3473,9 @@ TEST_F(HttpFilterTest, MetadataOptionsOverride) {
 
   FilterConfigPerRoute route_config(override_cfg);
 
-  EXPECT_CALL(decoder_callbacks_, traversePerFilterConfig(_))
+  EXPECT_CALL(decoder_callbacks_, perFilterConfigs())
       .WillOnce(
-          testing::Invoke([&](std::function<void(const Router::RouteSpecificFilterConfig&)> cb) {
-            cb(route_config);
-          }));
+          testing::Invoke([&]() -> Router::RouteSpecificFilterConfigs { return {&route_config}; }));
 
   response_headers_.addCopy(LowerCaseString(":status"), "200");
   response_headers_.addCopy(LowerCaseString("content-type"), "text/plain");
@@ -3537,11 +3535,9 @@ TEST_F(HttpFilterTest, MetadataOptionsNoOverride) {
 
   FilterConfigPerRoute route_config(override_cfg);
 
-  EXPECT_CALL(decoder_callbacks_, traversePerFilterConfig(_))
+  EXPECT_CALL(decoder_callbacks_, perFilterConfigs())
       .WillOnce(
-          testing::Invoke([&](std::function<void(const Router::RouteSpecificFilterConfig&)> cb) {
-            cb(route_config);
-          }));
+          testing::Invoke([&]() -> Router::RouteSpecificFilterConfigs { return {&route_config}; }));
 
   response_headers_.addCopy(LowerCaseString(":status"), "200");
   response_headers_.addCopy(LowerCaseString("content-type"), "text/plain");
@@ -4469,11 +4465,9 @@ TEST_F(HttpFilterTest, GrpcServiceMetadataOverride) {
   *route_proto.mutable_overrides()->mutable_grpc_initial_metadata()->Add() =
       makeHeaderValue("c", "c");
   FilterConfigPerRoute route_config(route_proto);
-  EXPECT_CALL(decoder_callbacks_, traversePerFilterConfig(_))
+  EXPECT_CALL(decoder_callbacks_, perFilterConfigs())
       .WillOnce(
-          testing::Invoke([&](std::function<void(const Router::RouteSpecificFilterConfig&)> cb) {
-            cb(route_config);
-          }));
+          testing::Invoke([&]() -> Router::RouteSpecificFilterConfigs { return {&route_config}; }));
 
   // Build expected merged grpc_service configuration.
   {

--- a/test/extensions/filters/http/ext_proc/filter_test.cc
+++ b/test/extensions/filters/http/ext_proc/filter_test.cc
@@ -2675,11 +2675,9 @@ TEST_F(HttpFilterTest, ProcessingModeResponseHeadersOnlyWithoutCallingDecodeHead
   route_proto.mutable_overrides()->mutable_grpc_service()->mutable_envoy_grpc()->set_cluster_name(
       "cluster_1");
   FilterConfigPerRoute route_config(route_proto);
-  EXPECT_CALL(decoder_callbacks_, traversePerFilterConfig(_))
+  EXPECT_CALL(decoder_callbacks_, perFilterConfigs())
       .WillOnce(
-          testing::Invoke([&](std::function<void(const Router::RouteSpecificFilterConfig&)> cb) {
-            cb(route_config);
-          }));
+          testing::Invoke([&]() -> Router::RouteSpecificFilterConfigs { return {&route_config}; }));
   final_expected_grpc_service_.emplace(route_proto.overrides().grpc_service());
   config_with_hash_key_.setConfig(route_proto.overrides().grpc_service());
 

--- a/test/extensions/filters/http/file_system_buffer/filter_test.cc
+++ b/test/extensions/filters/http/file_system_buffer/filter_test.cc
@@ -774,13 +774,11 @@ TEST_F(FileSystemBufferFilterTest, MergesRouteConfig) {
   )");
   auto mock_route = std::make_shared<Router::MockRoute>();
   EXPECT_CALL(decoder_callbacks_, route()).WillOnce(Return(mock_route));
-  EXPECT_CALL(*mock_route, traversePerFilterConfig(_, _))
-      .WillOnce([vhost_config, route_config](
-                    const std::string&,
-                    std::function<void(const Router::RouteSpecificFilterConfig&)> add_config) {
-        add_config(*vhost_config);
-        add_config(*route_config);
-      });
+  EXPECT_CALL(*mock_route, perFilterConfigs(_))
+      .WillOnce(
+          [vhost_config, route_config](absl::string_view) -> Router::RouteSpecificFilterConfigs {
+            return {vhost_config.get(), route_config.get()};
+          });
   // The default config would return Continue, so these returning StopIteration shows that
   // both route_configs were applied.
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,

--- a/test/extensions/filters/http/header_mutation/header_mutation_test.cc
+++ b/test/extensions/filters/http/header_mutation/header_mutation_test.cc
@@ -113,10 +113,9 @@ TEST(HeaderMutationFilterTest, HeaderMutationFilterTest) {
     filter.setDecoderFilterCallbacks(decoder_callbacks);
     filter.setEncoderFilterCallbacks(encoder_callbacks);
 
-    EXPECT_CALL(*decoder_callbacks.route_, traversePerFilterConfig(_, _))
-        .WillOnce(Invoke([&](const std::string&,
-                             std::function<void(const Router::RouteSpecificFilterConfig&)> cb) {
-          cb(*config);
+    EXPECT_CALL(*decoder_callbacks.route_, perFilterConfigs(_))
+        .WillOnce(Invoke([&](absl::string_view) -> Router::RouteSpecificFilterConfigs {
+          return {config.get()};
         }));
 
     {
@@ -238,10 +237,9 @@ TEST(HeaderMutationFilterTest, HeaderMutationFilterTest) {
     };
 
     // If the decoding phase is not performed then try to get the config from the encoding phase.
-    EXPECT_CALL(*encoder_callbacks.route_, traversePerFilterConfig(_, _))
-        .WillOnce(Invoke([&](const std::string&,
-                             std::function<void(const Router::RouteSpecificFilterConfig&)> cb) {
-          cb(*config);
+    EXPECT_CALL(*encoder_callbacks.route_, perFilterConfigs(_))
+        .WillOnce(Invoke([&](absl::string_view) -> Router::RouteSpecificFilterConfigs {
+          return {config.get()};
         }));
 
     EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter.encodeHeaders(headers, true));

--- a/test/mocks/http/mocks.cc
+++ b/test/mocks/http/mocks.cc
@@ -109,15 +109,14 @@ MockStreamDecoderFilterCallbacks::MockStreamDecoderFilterCallbacks() {
         }
         return route->mostSpecificPerFilterConfig("envoy.filter");
       }));
-  ON_CALL(*this, traversePerFilterConfig(_))
-      .WillByDefault(
-          Invoke([this](std::function<void(const Router::RouteSpecificFilterConfig&)> cb) {
-            auto route = this->route();
-            if (route == nullptr) {
-              return;
-            }
-            route->traversePerFilterConfig("envoy.filter", cb);
-          }));
+  ON_CALL(*this, perFilterConfigs())
+      .WillByDefault(Invoke([this]() -> Router::RouteSpecificFilterConfigs {
+        auto route = this->route();
+        if (route == nullptr) {
+          return {};
+        }
+        return route->perFilterConfigs("envoy.filter");
+      }));
 }
 
 MockStreamDecoderFilterCallbacks::~MockStreamDecoderFilterCallbacks() = default;
@@ -158,15 +157,14 @@ MockStreamEncoderFilterCallbacks::MockStreamEncoderFilterCallbacks() {
         }
         return route->mostSpecificPerFilterConfig("envoy.filter");
       }));
-  ON_CALL(*this, traversePerFilterConfig(_))
-      .WillByDefault(
-          Invoke([this](std::function<void(const Router::RouteSpecificFilterConfig&)> cb) {
-            auto route = this->route();
-            if (route == nullptr) {
-              return;
-            }
-            route->traversePerFilterConfig("envoy.filter", cb);
-          }));
+  ON_CALL(*this, perFilterConfigs())
+      .WillByDefault(Invoke([this]() -> Router::RouteSpecificFilterConfigs {
+        auto route = this->route();
+        if (route == nullptr) {
+          return {};
+        }
+        return route->perFilterConfigs("envoy.filter");
+      }));
 }
 
 MockStreamEncoderFilterCallbacks::~MockStreamEncoderFilterCallbacks() = default;

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -272,8 +272,7 @@ public:
   MOCK_METHOD(void, addUpstreamSocketOptions, (const Network::Socket::OptionsSharedPtr& options));
   MOCK_METHOD(Network::Socket::OptionsSharedPtr, getUpstreamSocketOptions, (), (const));
   MOCK_METHOD(const Router::RouteSpecificFilterConfig*, mostSpecificPerFilterConfig, (), (const));
-  MOCK_METHOD(void, traversePerFilterConfig,
-              (std::function<void(const Router::RouteSpecificFilterConfig&)> cb), (const));
+  MOCK_METHOD(Router::RouteSpecificFilterConfigs, perFilterConfigs, (), (const));
   MOCK_METHOD(Http1StreamEncoderOptionsOptRef, http1StreamEncoderOptions, ());
   MOCK_METHOD(OptRef<DownstreamStreamFilterCallbacks>, downstreamCallbacks, ());
   MOCK_METHOD(OptRef<UpstreamStreamFilterCallbacks>, upstreamCallbacks, ());
@@ -369,8 +368,7 @@ public:
   MOCK_METHOD(uint32_t, encoderBufferLimit, ());
   MOCK_METHOD(void, restoreContextOnContinue, (ScopeTrackedObjectStack&));
   MOCK_METHOD(const Router::RouteSpecificFilterConfig*, mostSpecificPerFilterConfig, (), (const));
-  MOCK_METHOD(void, traversePerFilterConfig,
-              (std::function<void(const Router::RouteSpecificFilterConfig&)> cb), (const));
+  MOCK_METHOD(Router::RouteSpecificFilterConfigs, perFilterConfigs, (), (const));
   MOCK_METHOD(Http1StreamEncoderOptionsOptRef, http1StreamEncoderOptions, ());
   MOCK_METHOD(OptRef<DownstreamStreamFilterCallbacks>, downstreamCallbacks, ());
   MOCK_METHOD(OptRef<UpstreamStreamFilterCallbacks>, upstreamCallbacks, ());

--- a/test/mocks/router/mocks.h
+++ b/test/mocks/router/mocks.h
@@ -319,7 +319,7 @@ public:
   MOCK_METHOD(const RateLimitPolicy&, rateLimitPolicy, (), (const));
   MOCK_METHOD(const CorsPolicy*, corsPolicy, (), (const));
   MOCK_METHOD(const CommonConfig&, routeConfig, (), (const));
-  MOCK_METHOD(const RouteSpecificFilterConfig*, mostSpecificPerFilterConfig, (const std::string&),
+  MOCK_METHOD(const RouteSpecificFilterConfig*, mostSpecificPerFilterConfig, (absl::string_view),
               (const));
   MOCK_METHOD(bool, includeAttemptCountInRequest, (), (const));
   MOCK_METHOD(bool, includeAttemptCountInResponse, (), (const));
@@ -327,9 +327,7 @@ public:
   MOCK_METHOD(Upstream::RetryPrioritySharedPtr, retryPriority, ());
   MOCK_METHOD(Upstream::RetryHostPredicateSharedPtr, retryHostPredicate, ());
   MOCK_METHOD(uint32_t, retryShadowBufferLimit, (), (const));
-  MOCK_METHOD(void, traversePerFilterConfig,
-              (const std::string&, std::function<void(const Router::RouteSpecificFilterConfig&)>),
-              (const));
+  MOCK_METHOD(RouteSpecificFilterConfigs, perFilterConfigs, (absl::string_view), (const));
   MOCK_METHOD(const envoy::config::core::v3::Metadata&, metadata, (), (const));
   MOCK_METHOD(const Envoy::Config::TypedMetadata&, typedMetadata, (), (const));
   MOCK_METHOD(const VirtualCluster*, virtualCluster, (const Http::HeaderMap& headers), (const));
@@ -516,12 +514,10 @@ public:
   MOCK_METHOD(const Decorator*, decorator, (), (const));
   MOCK_METHOD(const RouteTracing*, tracingConfig, (), (const));
   MOCK_METHOD(absl::optional<bool>, filterDisabled, (absl::string_view), (const));
-  MOCK_METHOD(const RouteSpecificFilterConfig*, perFilterConfig, (const std::string&), (const));
-  MOCK_METHOD(const RouteSpecificFilterConfig*, mostSpecificPerFilterConfig, (const std::string&),
+  MOCK_METHOD(const RouteSpecificFilterConfig*, perFilterConfig, (absl::string_view), (const));
+  MOCK_METHOD(const RouteSpecificFilterConfig*, mostSpecificPerFilterConfig, (absl::string_view),
               (const));
-  MOCK_METHOD(void, traversePerFilterConfig,
-              (const std::string&, std::function<void(const Router::RouteSpecificFilterConfig&)>),
-              (const));
+  MOCK_METHOD(RouteSpecificFilterConfigs, perFilterConfigs, (absl::string_view), (const));
   MOCK_METHOD(const envoy::config::core::v3::Metadata&, metadata, (), (const));
   MOCK_METHOD(const Envoy::Config::TypedMetadata&, typedMetadata, (), (const));
   MOCK_METHOD(const std::string&, routeName, (), (const));


### PR DESCRIPTION
Commit Message: route: get all per filter config directly
Additional Description:

1. used absl::string_view rather than `const std::string&` as input parameter type. This allow the `mostSpecificPerFilterConfig()` and `perFilterConfigs()` to take a string view as input parameter. 
2. replace the `traversePerFilterConfig()` with `perFilterConfigs()`. The `perFilterConfigs()` will return a vector (inlined) of configs directly and needn't the caller to provide a callback function to collect them. The new method is more straight forward and easier to use. The new method didn't effect any exist logic, but reduce ~150 lines code.

Risk Level: low.
Testing: n/a.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.