### PR TITLE
bazel: Add output utils

### DIFF
--- a/tools/cat/BUILD
+++ b/tools/cat/BUILD
@@ -1,0 +1,5 @@
+load("@envoy_toolshed//:utils.bzl", "cat")
+
+licenses(["notice"])  # Apache 2
+
+cat()

--- a/tools/jq/BUILD
+++ b/tools/jq/BUILD
@@ -1,0 +1,5 @@
+load("@envoy_toolshed//:utils.bzl", "jqcat")
+
+licenses(["notice"])  # Apache 2
+
+jqcat(name = "jq")


### PR DESCRIPTION
these utils allow you to dump the contents of a build target, either directly (with `cat`) or as JSON (with `jq`)