### PR TITLE
ci/example: Dont build/test the filter example in Envoy CI

### DIFF
--- a/.azure-pipelines/ci.yml
+++ b/.azure-pipelines/ci.yml
@@ -64,9 +64,6 @@ parameters:
   displayName: "Upload bazel run data to BES"
   type: boolean
   default: true
-- name: envoyBuildFilterExample
-  type: string
-  default: ""
 - name: cacheTestResults
   displayName: "Cache test results"
   type: boolean
@@ -224,7 +221,6 @@ steps:
     echo "##vso[task.setvariable variable=BAZEL_FAKE_SCM_REVISION]${BAZEL_FAKE_SCM_REVISION}"
     echo "##vso[task.setvariable variable=BAZEL_STARTUP_EXTRA_OPTIONS]${{ parameters.bazelStartupExtraOptions }}"
     echo "##vso[task.setvariable variable=CI_TARGET_BRANCH]${CI_TARGET_BRANCH}"
-    echo "##vso[task.setvariable variable=ENVOY_BUILD_FILTER_EXAMPLE]${{ parameters.envoyBuildFilterExample }}"
     echo "##vso[task.setvariable variable=ENVOY_DOCKER_BUILD_DIR]$(Build.StagingDirectory)"
     echo "##vso[task.setvariable variable=ENVOY_RBE]${ENVOY_RBE}"
     echo "##vso[task.setvariable variable=ENVOY_SHARED_TMP_DIR]${ENVOY_SHARED_TMP_DIR}"
@@ -275,7 +271,6 @@ steps:
 - script: ci/run_envoy_docker.sh 'ci/do_ci.sh ${{ parameters.ciTarget }}'
   workingDirectory: $(Build.SourcesDirectory)
   env:
-    ENVOY_BUILD_FILTER_EXAMPLE: ${{ parameters.envoyBuildFilterExample }}
     ${{ each var in parameters.env }}:
       ${{ var.key }}: ${{ var.value }}
   displayName: "Run CI script ${{ parameters.ciTarget }}"

--- a/.azure-pipelines/stage/checks.yml
+++ b/.azure-pipelines/stage/checks.yml
@@ -47,12 +47,10 @@ jobs:
         CI_TARGET: "fuzz_coverage"
       compile_time_options:
         CI_TARGET: "compile_time_options"
-        ENVOY_FILTER_EXAMPLE: true
       tsan:
         CI_TARGET: "tsan"
       asan:
         CI_TARGET: "asan"
-        ENVOY_FILTER_EXAMPLE: true
       # Disabled due to https://github.com/envoyproxy/envoy/pull/18218
       # api_compat:
       #  CI_TARGET: "api_compat"
@@ -60,7 +58,6 @@ jobs:
         CI_TARGET: "gcc"
       msan:
         CI_TARGET: "msan"
-        ENVOY_FILTER_EXAMPLE: true
       #
       # Temporarily disabled to facilitate release CI, should be resolved
       #    as part of https://github.com/envoyproxy/envoy/issues/28566
@@ -81,7 +78,6 @@ jobs:
     parameters:
       ciTarget: $(CI_TARGET)
       cacheName: $(CI_TARGET)
-      envoyBuildFilterExample: $(ENVOY_FILTER_EXAMPLE)
       cacheTestResults: ${{ parameters.cacheTestResults }}
       diskspaceHack: true
       managedAgent: false

--- a/ci/build_setup.sh
+++ b/ci/build_setup.sh
@@ -33,8 +33,6 @@ fi
     export ENVOY_BUILD_ARCH
 }
 
-export ENVOY_BUILD_FILTER_EXAMPLE="${ENVOY_BUILD_FILTER_EXAMPLE:-0}"
-
 read -ra BAZEL_BUILD_EXTRA_OPTIONS <<< "${BAZEL_BUILD_EXTRA_OPTIONS:-}"
 read -ra BAZEL_EXTRA_TEST_OPTIONS <<< "${BAZEL_EXTRA_TEST_OPTIONS:-}"
 read -ra BAZEL_STARTUP_EXTRA_OPTIONS <<< "${BAZEL_STARTUP_EXTRA_OPTIONS:-}"
@@ -154,12 +152,5 @@ mkdir -p "${ENVOY_FAILED_TEST_LOGS}"
 # This is where we copy the build profile to.
 export ENVOY_BUILD_PROFILE="${ENVOY_BUILD_DIR}"/generated/build-profile
 mkdir -p "${ENVOY_BUILD_PROFILE}"
-
-if [[ "${ENVOY_BUILD_FILTER_EXAMPLE}" == "true" ]]; then
-  # shellcheck source=ci/filter_example_setup.sh
-  . "${CURRENT_SCRIPT_DIR}"/filter_example_setup.sh
-else
-  echo "Skip setting up Envoy Filter Example."
-fi
 
 export NO_BUILD_SETUP=1

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -359,14 +359,6 @@ case $CI_TARGET in
         echo "bazel ASAN/UBSAN debug build with tests"
         echo "Building and testing envoy tests ${TEST_TARGETS[*]}"
         bazel_with_collection test "${BAZEL_BUILD_OPTIONS[@]}" "${TEST_TARGETS[@]}"
-        if [ "${ENVOY_BUILD_FILTER_EXAMPLE}" == "1" ]; then
-            echo "Building and testing envoy-filter-example tests..."
-            pushd "${ENVOY_FILTER_EXAMPLE_SRCDIR}"
-            bazel_with_collection \
-                test "${BAZEL_BUILD_OPTIONS[@]}" \
-                "${ENVOY_FILTER_EXAMPLE_TESTS[@]}"
-            popd
-        fi
         # TODO(mattklein123): This part of the test is now flaky in CI and it's unclear why, possibly
         # due to sandboxing issue. Debug and enable it again.
         # if [ "${CI_SKIP_INTEGRATION_TEST_TRAFFIC_TAPPING}" != "1" ] ; then
@@ -424,7 +416,6 @@ case $CI_TARGET in
         setup_clang_toolchain
         # This doesn't go into CI but is available for developer convenience.
         echo "bazel with different compiletime options build with tests..."
-        cd "${ENVOY_FILTER_EXAMPLE_SRCDIR}"
         TEST_TARGETS=("${TEST_TARGETS[@]/#\/\//@envoy\/\/}")
         # Building all the dependencies from scratch to link them against libc++.
         echo "Building and testing with wasm=wamr: ${TEST_TARGETS[*]}"
@@ -972,16 +963,6 @@ case $CI_TARGET in
              --build_tests_only \
              --remote_download_minimal \
              "${TEST_TARGETS[@]}"
-        if [ "${ENVOY_BUILD_FILTER_EXAMPLE}" == "1" ]; then
-            echo "Building and testing envoy-filter-example tests..."
-            pushd "${ENVOY_FILTER_EXAMPLE_SRCDIR}"
-            bazel_with_collection \
-                test "${BAZEL_BUILD_OPTIONS[@]}" \
-                -c dbg \
-                --config=clang-tsan \
-                "${ENVOY_FILTER_EXAMPLE_TESTS[@]}"
-            popd
-        fi
         ;;
 
     verify_distro)


### PR DESCRIPTION
Currently the compile-time-options/msan/asan tests are run in the context of the filter-example

This adds a lot of complexity to the build and messes up our test artefacts.

The example is not well maintained - it has circle CI configured which hasnt passed in years. Ideally we close that repo and add it instead to the examples repo