### PR TITLE
mobile: Fix Android linter issues

### DIFF
--- a/mobile/library/java/io/envoyproxy/envoymobile/engine/AndroidNetworkMonitor.java
+++ b/mobile/library/java/io/envoyproxy/envoymobile/engine/AndroidNetworkMonitor.java
@@ -3,6 +3,7 @@ package io.envoyproxy.envoymobile.engine;
 import io.envoyproxy.envoymobile.engine.types.EnvoyNetworkType;
 
 import android.Manifest;
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.pm.PackageManager;
 import android.net.ConnectivityManager;
@@ -63,7 +64,6 @@ public class AndroidNetworkMonitor {
         NetworkCapabilities.TRANSPORT_CELLULAR,  NetworkCapabilities.TRANSPORT_WIFI,
         NetworkCapabilities.TRANSPORT_BLUETOOTH, NetworkCapabilities.TRANSPORT_ETHERNET,
         NetworkCapabilities.TRANSPORT_VPN,       NetworkCapabilities.TRANSPORT_WIFI_AWARE,
-        NetworkCapabilities.TRANSPORT_LOWPAN,
     };
     private static final int EMPTY_TRANSPORT_TYPE = -1;
 
@@ -77,6 +77,7 @@ public class AndroidNetworkMonitor {
       envoyEngine.onDefaultNetworkAvailable();
     }
 
+    @SuppressLint("WrongConstant")
     @Override
     public void onCapabilitiesChanged(@NonNull Network network,
                                       @NonNull NetworkCapabilities networkCapabilities) {


### PR DESCRIPTION
This PR suppresses the linter for the constant check as well as removing `NetworkCapabilities.TRANSPORT_LOWPAN` since it's only supported in version SDK 27.

Risk Level: low
Testing: CI
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: mobile
