### PR TITLE
mobile: Fix missing logging output in Swift integration tests

### DIFF
--- a/mobile/library/swift/EngineBuilder.swift
+++ b/mobile/library/swift/EngineBuilder.swift
@@ -529,7 +529,7 @@ open class EngineBuilder: NSObject {
                                         if let log = self.logger {
                                           if let lvl = LogLevel(rawValue: level) {
                                             log(lvl, message)
-                                            print(msg, terminator: "")
+                                            print(message, terminator: "")
                                           }
                                         }
                                       },

--- a/mobile/library/swift/EngineBuilder.swift
+++ b/mobile/library/swift/EngineBuilder.swift
@@ -529,7 +529,6 @@ open class EngineBuilder: NSObject {
                                         if let log = self.logger {
                                           if let lvl = LogLevel(rawValue: level) {
                                             log(lvl, message)
-                                            print(message, terminator: "")
                                           }
                                         }
                                       },

--- a/mobile/library/swift/EngineBuilder.swift
+++ b/mobile/library/swift/EngineBuilder.swift
@@ -529,6 +529,7 @@ open class EngineBuilder: NSObject {
                                         if let log = self.logger {
                                           if let lvl = LogLevel(rawValue: level) {
                                             log(lvl, message)
+                                            print(message, delimiter="")
                                           }
                                         }
                                       },

--- a/mobile/library/swift/EngineBuilder.swift
+++ b/mobile/library/swift/EngineBuilder.swift
@@ -529,7 +529,7 @@ open class EngineBuilder: NSObject {
                                         if let log = self.logger {
                                           if let lvl = LogLevel(rawValue: level) {
                                             log(lvl, message)
-                                            print(message, delimiter="")
+                                            print(msg, terminator: "")
                                           }
                                         }
                                       },

--- a/mobile/test/swift/integration/CancelGRPCStreamTest.swift
+++ b/mobile/test/swift/integration/CancelGRPCStreamTest.swift
@@ -11,6 +11,13 @@ final class CancelGRPCStreamTests: XCTestCase {
     register_test_extensions()
   }
 
+  override static func tearDown() {
+    super.tearDown()
+    // Flush the stdout and stderror to show the print output.
+    fflush(stdout)
+    fflush(stderr)
+  }
+
   func testCancelGRPCStream() {
     let filterName = "cancel_validation_filter"
 

--- a/mobile/test/swift/integration/CancelStreamTest.swift
+++ b/mobile/test/swift/integration/CancelStreamTest.swift
@@ -11,6 +11,13 @@ final class CancelStreamTests: XCTestCase {
     register_test_extensions()
   }
 
+  override static func tearDown() {
+    super.tearDown()
+    // Flush the stdout and stderror to show the print output.
+    fflush(stdout)
+    fflush(stderr)
+  }
+
   func testCancelStream() {
     let filterName = "cancel_validation_filter"
 

--- a/mobile/test/swift/integration/EndToEndNetworkingTest.swift
+++ b/mobile/test/swift/integration/EndToEndNetworkingTest.swift
@@ -10,6 +10,13 @@ final class EndToEndNetworkingTest: XCTestCase {
     register_test_extensions()
   }
 
+  override static func tearDown() {
+    super.tearDown()
+    // Flush the stdout and stderror to show the print output.
+    fflush(stdout)
+    fflush(stderr)
+  }
+
   func testNetworkRequestReturnsHeadersAndData() {
     EnvoyTestServer.startHttp1PlaintextServer()
     EnvoyTestServer.setHeadersAndData(

--- a/mobile/test/swift/integration/EngineApiTest.swift
+++ b/mobile/test/swift/integration/EngineApiTest.swift
@@ -9,6 +9,13 @@ final class EngineApiTest: XCTestCase {
     register_test_extensions()
   }
 
+  override static func tearDown() {
+    super.tearDown()
+    // Flush the stdout and stderror to show the print output.
+    fflush(stdout)
+    fflush(stderr)
+  }
+
   func testEngineApis() throws {
     let engineExpectation = self.expectation(description: "Engine Running")
 

--- a/mobile/test/swift/integration/FilterResetIdleTest.swift
+++ b/mobile/test/swift/integration/FilterResetIdleTest.swift
@@ -11,6 +11,13 @@ final class FilterResetIdleTests: XCTestCase {
     register_test_extensions()
   }
 
+  override static func tearDown() {
+    super.tearDown()
+    // Flush the stdout and stderror to show the print output.
+    fflush(stdout)
+    fflush(stderr)
+  }
+
   func testFilterResetIdle() {
     let filterName = "reset_idle_test_filter"
 

--- a/mobile/test/swift/integration/GRPCReceiveErrorTest.swift
+++ b/mobile/test/swift/integration/GRPCReceiveErrorTest.swift
@@ -11,6 +11,13 @@ final class GRPCReceiveErrorTests: XCTestCase {
     register_test_extensions()
   }
 
+  override static func tearDown() {
+    super.tearDown()
+    // Flush the stdout and stderror to show the print output.
+    fflush(stdout)
+    fflush(stderr)
+  }
+
   func testReceiveError() {
     let filterName = "error_validation_filter"
 

--- a/mobile/test/swift/integration/IdleTimeoutTest.swift
+++ b/mobile/test/swift/integration/IdleTimeoutTest.swift
@@ -11,6 +11,13 @@ final class IdleTimeoutTests: XCTestCase {
     register_test_extensions()
   }
 
+  override static func tearDown() {
+    super.tearDown()
+    // Flush the stdout and stderror to show the print output.
+    fflush(stdout)
+    fflush(stderr)
+  }
+
   func testIdleTimeout() {
     let filterName = "reset_idle_test_filter"
 

--- a/mobile/test/swift/integration/KeyValueStoreTest.swift
+++ b/mobile/test/swift/integration/KeyValueStoreTest.swift
@@ -11,6 +11,13 @@ final class KeyValueStoreTests: XCTestCase {
     register_test_extensions()
   }
 
+  override static func tearDown() {
+    super.tearDown()
+    // Flush the stdout and stderror to show the print output.
+    fflush(stdout)
+    fflush(stderr)
+  }
+
   func testKeyValueStore() {
     // swiftlint:disable:next line_length
     let kvStoreType = "type.googleapis.com/envoymobile.extensions.filters.http.test_kv_store.TestKeyValueStore"

--- a/mobile/test/swift/integration/ReceiveDataTest.swift
+++ b/mobile/test/swift/integration/ReceiveDataTest.swift
@@ -11,6 +11,13 @@ final class ReceiveDataTests: XCTestCase {
     register_test_extensions()
   }
 
+  override static func tearDown() {
+    super.tearDown()
+    // Flush the stdout and stderror to show the print output.
+    fflush(stdout)
+    fflush(stderr)
+  }
+
   func testReceiveData() {
     let directResponseBody = "response_body"
     EnvoyTestServer.startHttp1PlaintextServer()

--- a/mobile/test/swift/integration/ReceiveErrorTest.swift
+++ b/mobile/test/swift/integration/ReceiveErrorTest.swift
@@ -10,6 +10,13 @@ final class ReceiveErrorTests: XCTestCase {
     register_test_extensions()
   }
 
+  override static func tearDown() {
+    super.tearDown()
+    // Flush the stdout and stderror to show the print output.
+    fflush(stdout)
+    fflush(stderr)
+  }
+
   func testReceiveError() {
     let filterName = "error_validation_filter"
 
@@ -58,9 +65,6 @@ final class ReceiveErrorTests: XCTestCase {
       .setLogLevel(.debug)
       .setLogger { _, msg in
         print(msg, terminator: "")
-      }
-      .setLogger { _, msg in
-          print(msg, terminator: "")
       }
       .addPlatformFilter(
         name: filterName,

--- a/mobile/test/swift/integration/ResetConnectivityStateTest.swift
+++ b/mobile/test/swift/integration/ResetConnectivityStateTest.swift
@@ -11,6 +11,13 @@ final class ResetConnectivityStateTest: XCTestCase {
     register_test_extensions()
   }
 
+  override static func tearDown() {
+    super.tearDown()
+    // Flush the stdout and stderror to show the print output.
+    fflush(stdout)
+    fflush(stderr)
+  }
+
   func testResetConnectivityState() {
     EnvoyTestServer.startHttp1PlaintextServer()
 

--- a/mobile/test/swift/integration/SendDataTest.swift
+++ b/mobile/test/swift/integration/SendDataTest.swift
@@ -11,6 +11,13 @@ final class SendDataTests: XCTestCase {
     register_test_extensions()
   }
 
+  override static func tearDown() {
+    super.tearDown()
+    // Flush the stdout and stderror to show the print output.
+    fflush(stdout)
+    fflush(stderr)
+  }
+
   func testSendData() throws {
     EnvoyTestServer.startHttp1PlaintextServer()
     EnvoyTestServer.setHeadersAndData("x-response-foo", header_value: "aaa", response_body: "data")

--- a/mobile/test/swift/integration/SendHeadersTest.swift
+++ b/mobile/test/swift/integration/SendHeadersTest.swift
@@ -11,6 +11,13 @@ final class SendHeadersTests: XCTestCase {
     register_test_extensions()
   }
 
+  override static func tearDown() {
+    super.tearDown()
+    // Flush the stdout and stderror to show the print output.
+    fflush(stdout)
+    fflush(stderr)
+  }
+
   func testSendHeaders() {
     EnvoyTestServer.startHttp1PlaintextServer()
 

--- a/mobile/test/swift/integration/SendTrailersTest.swift
+++ b/mobile/test/swift/integration/SendTrailersTest.swift
@@ -11,6 +11,13 @@ final class SendTrailersTests: XCTestCase {
     register_test_extensions()
   }
 
+  override static func tearDown() {
+    super.tearDown()
+    // Flush the stdout and stderror to show the print output.
+    fflush(stdout)
+    fflush(stderr)
+  }
+
   func testSendTrailers() throws {
     // swiftlint:disable:next line_length
     let assertionFilterType = "type.googleapis.com/envoymobile.extensions.filters.http.assertion.Assertion"

--- a/mobile/test/swift/integration/SetEventTrackerTest.swift
+++ b/mobile/test/swift/integration/SetEventTrackerTest.swift
@@ -20,7 +20,7 @@ final class SetEventTrackerTest: XCTestCase {
     let engine = EngineBuilder()
       .setLogLevel(.debug)
       .setLogger { _, msg in
-          print(msg, terminator: "")
+          NSLog(msg)
       }
       .setEventTracker { event in
         if event["foo"] == "bar" {

--- a/mobile/test/swift/integration/SetEventTrackerTest.swift
+++ b/mobile/test/swift/integration/SetEventTrackerTest.swift
@@ -14,6 +14,7 @@ final class SetEventTrackerTest: XCTestCase {
   override static func tearDown() {
     super.tearDown()
     fflush(stdout)
+    fflush(stderr)
   }
 
   func testSetEventTracker() throws {

--- a/mobile/test/swift/integration/SetEventTrackerTest.swift
+++ b/mobile/test/swift/integration/SetEventTrackerTest.swift
@@ -11,6 +11,10 @@ final class SetEventTrackerTest: XCTestCase {
     register_test_extensions()
   }
 
+  override static func tearDown() {
+    fflush(stdout)
+  }
+
   func testSetEventTracker() throws {
     EnvoyTestServer.startHttp1PlaintextServer()
 

--- a/mobile/test/swift/integration/SetEventTrackerTest.swift
+++ b/mobile/test/swift/integration/SetEventTrackerTest.swift
@@ -12,6 +12,7 @@ final class SetEventTrackerTest: XCTestCase {
   }
 
   override static func tearDown() {
+    super.tearDown()
     fflush(stdout)
   }
 

--- a/mobile/test/swift/integration/SetEventTrackerTest.swift
+++ b/mobile/test/swift/integration/SetEventTrackerTest.swift
@@ -13,6 +13,7 @@ final class SetEventTrackerTest: XCTestCase {
 
   override static func tearDown() {
     super.tearDown()
+    // Flush the stdout and stderror to show the print output.
     fflush(stdout)
     fflush(stderr)
   }
@@ -30,7 +31,6 @@ final class SetEventTrackerTest: XCTestCase {
       }
       .setEventTracker { event in
         if event["foo"] == "bar" {
-          XCTFail("Test")
           eventExpectation.fulfill()
         }
       }

--- a/mobile/test/swift/integration/SetEventTrackerTest.swift
+++ b/mobile/test/swift/integration/SetEventTrackerTest.swift
@@ -20,7 +20,7 @@ final class SetEventTrackerTest: XCTestCase {
     let engine = EngineBuilder()
       .setLogLevel(.debug)
       .setLogger { _, msg in
-          NSLog(msg)
+          print(msg, delimiter="")
       }
       .setEventTracker { event in
         if event["foo"] == "bar" {

--- a/mobile/test/swift/integration/SetEventTrackerTest.swift
+++ b/mobile/test/swift/integration/SetEventTrackerTest.swift
@@ -20,7 +20,7 @@ final class SetEventTrackerTest: XCTestCase {
     let engine = EngineBuilder()
       .setLogLevel(.debug)
       .setLogger { _, msg in
-          print(msg, delimiter="")
+          print(msg, terminator: "")
       }
       .setEventTracker { event in
         if event["foo"] == "bar" {

--- a/mobile/test/swift/integration/SetEventTrackerTest.swift
+++ b/mobile/test/swift/integration/SetEventTrackerTest.swift
@@ -24,6 +24,7 @@ final class SetEventTrackerTest: XCTestCase {
       }
       .setEventTracker { event in
         if event["foo"] == "bar" {
+          XCTFail("Test")
           eventExpectation.fulfill()
         }
       }

--- a/mobile/test/swift/integration/SetEventTrackerTestNoTracker.swift
+++ b/mobile/test/swift/integration/SetEventTrackerTestNoTracker.swift
@@ -11,6 +11,13 @@ final class SetEventTrackerTestNoTracker: XCTestCase {
     register_test_extensions()
   }
 
+  override static func tearDown() {
+    super.tearDown()
+    // Flush the stdout and stderror to show the print output.
+    fflush(stdout)
+    fflush(stderr)
+  }
+
   func testEmitEventWithoutSettingEventTracker() throws {
     EnvoyTestServer.startHttp1PlaintextServer()
 

--- a/mobile/test/swift/integration/SetLoggerTest.swift
+++ b/mobile/test/swift/integration/SetLoggerTest.swift
@@ -11,6 +11,13 @@ final class LoggerTests: XCTestCase {
     register_test_extensions()
   }
 
+  override static func tearDown() {
+    super.tearDown()
+    // Flush the stdout and stderror to show the print output.
+    fflush(stdout)
+    fflush(stderr)
+  }
+
   func testSetLogger() throws {
     let engineExpectation = self.expectation(description: "Run started engine")
     let loggingExpectation = self.expectation(description: "Run used platform logger")
@@ -24,16 +31,14 @@ final class LoggerTests: XCTestCase {
       .setLogLevel(.debug)
       .setLogger { _, msg in
         print(msg, terminator: "")
+        if msg.contains("starting main dispatch loop") {
+          loggingExpectation.fulfill()
+        }
       }
       .addNativeFilter(
         name: "test_logger",
         // swiftlint:disable:next line_length
         typedConfig: "[type.googleapis.com/envoymobile.extensions.filters.http.test_logger.TestLogger]{}")
-      .setLogger { _, msg in
-        if msg.contains("starting main dispatch loop") {
-          loggingExpectation.fulfill()
-        }
-      }
       .setOnEngineRunning {
         engineExpectation.fulfill()
       }

--- a/mobile/test/swift/integration/proxying/HTTPRequestUsingProxyTest.swift
+++ b/mobile/test/swift/integration/proxying/HTTPRequestUsingProxyTest.swift
@@ -12,6 +12,13 @@ final class HTTPRequestUsingProxyTest: XCTestCase {
     register_test_extensions()
   }
 
+  override static func tearDown() {
+    super.tearDown()
+    // Flush the stdout and stderror to show the print output.
+    fflush(stdout)
+    fflush(stderr)
+  }
+
   private func executeRequest(engine: Engine, scheme: String, authority: String) -> String? {
     let responseHeadersExpectation =
         self.expectation(description: "Successful response headers received")


### PR DESCRIPTION
In Swift, `print` goes to stdout buffering. The fix is to flush the `stdout` and `stderr` before the end of the test.

See https://github.com/swiftlang/swift-corelibs-xctest/issues/422#issuecomment-1310952437

Risk Level: low (tests only)
Testing: CI
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a