### PR TITLE
Geoip fix asan failure

### DIFF
--- a/test/extensions/geoip_providers/maxmind/geoip_provider_test.cc
+++ b/test/extensions/geoip_providers/maxmind/geoip_provider_test.cc
@@ -94,6 +94,7 @@ public:
         Registry::FactoryRegistry<Geolocation::GeoipProviderFactory>::getFactory(
             "envoy.geoip_providers.maxmind"));
     ASSERT(provider_factory_);
+    on_changed_cbs_.reserve(1);
   }
 
   ~GeoipProviderTestBase() {


### PR DESCRIPTION
Fixing asan failures:
```
==16==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 48 byte(s) in 1 object(s) allocated from:
    #0 0x323ecbe in malloc /local/mnt/workspace/bcain_clang_hu-bcain-lv_22036/final/llvm-project/compiler-rt/lib/asan/asan_malloc_linux.cpp:69:3
    #1 0xa58a194 in operator new(unsigned long) (/b/f/w/bazel-out/k8-dbg/bin/test/extensions/geoip_providers/maxmind/geoip_provider_test.runfiles/envoy/test/extensions/geoip_providers/maxmind/geoip_provider_test+0xa58a194)
    #2 0x3348d04 in void std::__1::vector<std::__1::function<absl::lts_20230802::Status (unsigned int)>, std::__1::allocator<std::__1::function<absl::lts_20230802::Status (unsigned int)> > >::__emplace_back_slow_path<std::__1::function<absl::lts_20230802::Status (unsigned int)> >(std::__1::function<absl::lts_20230802::Status (unsigned int)>&&) /opt/llvm/bin/../include/c++/v1/vector:1558:49
    #3 0x3348883 in std::__1::function<absl::lts_20230802::Status (unsigned int)>& std::__1::vector<std::__1::function<absl::lts_20230802::Status (unsigned int)>, std::__1::allocator<std::__1::function<absl::lts_20230802::Status (unsigned int)> > >::emplace_back<std::__1::function<absl::lts_20230802::Status (unsigned int)> >(std::__1::function<absl::lts_20230802::Status (unsigned int)>&&) /opt/llvm/bin/../include/c++/v1/vector:1580:9
    #4 0x3348554 in Envoy::Extensions::GeoipProviders::Maxmind::GeoipProviderTestBase::initializeProvider(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::optional<Envoy::ConditionalInitializer>&)::'lambda'()::operator()() const::'lambda'(std::__1::basic_string_view<char, std::__1::char_traits<char> >, unsigned int, std::__1::function<absl::lts_20230802::Status (unsigned int)>)::operator()(std::__1::basic_string_view<char, std::__1::char_traits<char> >, unsigned int, std::__1::function<absl::lts_20230802::Status (unsigned int)>) const /proc/self/cwd/test/extensions/geoip_providers/maxmind/geoip_provider_test.cc:118:35
    #5 0x334830e in decltype(static_cast<Envoy::Extensions::GeoipProviders::Maxmind::GeoipProviderTestBase::initializeProvider(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::optional<Envoy::ConditionalInitializer>&)::'lambda'()::operator()() const::'lambda'(std::__1::basic_string_view<char, std::__1::char_traits<char> >, unsigned int, std::__1::function<absl::lts_20230802::Status (unsigned int)>)&>(fp)(static_cast<std::__1::basic_string_view<char, std::__1::char_traits<char> >>(fp0), static_cast<unsigned int>(fp0), static_cast<std::__1::function<absl::lts_20230802::Status (unsigned int)>>(fp0))) std::__1::__invoke<Envoy::Extensions::GeoipProviders::Maxmind::GeoipProviderTestBase::initializeProvider(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::optional<Envoy::ConditionalInitializer>&)::'lambda'()::operator()() const::'lambda'(std::__1::basic_string_view<char, std::__1::char_traits<char> >, unsigned int, std::__1::function<absl::lts_20230802::Status (unsigned int)>)&, std::__1::basic_string_view<char, std::__1::char_traits<char> >, unsigned int, std::__1::function<absl::lts_20230802::Status (unsigned int)> >(Envoy::Extensions::GeoipProviders::Maxmind::GeoipProviderTestBase::initializeProvider(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::optional<Envoy::ConditionalInitializer>&)::'lambda'()::operator()() const::'lambda'(std::__1::basic_string_view<char, std::__1::char_traits<char> >, unsigned int, std::__1::function<absl::lts_20230802::Status (unsigned int)>)&, std::__1::basic_string_view<char, std::__1::char_traits<char> >&&, unsigned int&&, std::__1::function<absl::lts_20230802::Status (unsigned int)>&&) /opt/llvm/bin/../include/c++/v1/type_traits:3640:23
    #6 0x33481c5 in absl::lts_20230802::Status std::__1::__invoke_void_return_wrapper<absl::lts_20230802::Status, false>::__call<Envoy::Extensions::GeoipProviders::Maxmind::GeoipProviderTestBase::initializeProvider(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::optional<Envoy::ConditionalInitializer>&)::'lambda'()::operator()() const::'lambda'(std::__1::basic_string_view<char, std::__1::char_traits<char> >, unsigned int, std::__1::function<absl::lts_20230802::Status (unsigned int)>)&, std::__1::basic_string_view<char, std::__1::char_traits<char> >, unsigned int, std::__1::function<absl::lts_20230802::Status (unsigned int)> >(Envoy::Extensions::GeoipProviders::Maxmind::GeoipProviderTestBase::initializeProvider(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::optional<Envoy::ConditionalInitializer>&)::'lambda'()::operator()() const::'lambda'(std::__1::basic_string_view<char, std::__1::char_traits<char> >, unsigned int, std::__1::function<absl::lts_20230802::Status (unsigned int)>)&, std::__1::basic_string_view<char, std::__1::char_traits<char> >&&, unsigned int&&, std::__1::function<absl::lts_20230802::Status (unsigned int)>&&) /opt/llvm/bin/../include/c++/v1/__functional/invoke.h:30:16
    #7 0x334819d in std::__1::__function::__alloc_func<Envoy::Extensions::GeoipProviders::Maxmind::GeoipProviderTestBase::initializeProvider(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::optional<Envoy::ConditionalInitializer>&)::'lambda'()::operator()() const::'lambda'(std::__1::basic_string_view<char, std::__1::char_traits<char> >, unsigned int, std::__1::function<absl::lts_20230802::Status (unsigned int)>), std::__1::allocator<Envoy::Extensions::GeoipProviders::Maxmind::GeoipProviderTestBase::initializeProvider(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::optional<Envoy::ConditionalInitializer>&)::'lambda'()::operator()() const::'lambda'(std::__1::basic_string_view<char, std::__1::char_traits<char> >, unsigned int, std::__1::function<absl::lts_20230802::Status (unsigned int)>)>, absl::lts_20230802::Status (std::__1::basic_string_view<char, std::__1::char_traits<char> >, unsigned int, std::__1::function<absl::lts_20230802::Status (unsigned int)>)>::operator()(std::__1::basic_string_view<char, std::__1::char_traits<char> >&&, unsigned int&&, std::__1::function<absl::lts_20230802::Status (unsigned int)>&&) /opt/llvm/bin/../include/c++/v1/__functional/function.h:180:16
    #8 0x3347993 in std::__1::__function::__func<Envoy::Extensions::GeoipProviders::Maxmind::GeoipProviderTestBase::initializeProvider(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::optional<Envoy::ConditionalInitializer>&)::'lambda'()::operator()() const::'lambda'(std::__1::basic_string_view<char, std::__1::char_traits<char> >, unsigned int, std::__1::function<absl::lts_20230802::Status (unsigned int)>), std::__1::allocator<Envoy::Extensions::GeoipProviders::Maxmind::GeoipProviderTestBase::initializeProvider(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::optional<Envoy::ConditionalInitializer>&)::'lambda'()::operator()() const::'lambda'(std::__1::basic_string_view<char, std::__1::char_traits<char> >, unsigned int, std::__1::function<absl::lts_20230802::Status (unsigned int)>)>, absl::lts_20230802::Status (std::__1::basic_string_view<char, std::__1::char_traits<char> >, unsigned int, std::__1::function<absl::lts_20230802::Status (unsigned int)>)>::operator()(std::__1::basic_string_view<char, std::__1::char_traits<char> >&&, unsigned int&&, std::__1::function<absl::lts_20230802::Status (unsigned int)>&&) /opt/llvm/bin/../include/c++/v1/__functional/function.h:354:12
    #9 0x71758dd in std::__1::__function::__value_func<absl::lts_20230802::Status (std::__1::basic_string_view<char, std::__1::char_traits<char> >, unsigned int, std::__1::function<absl::lts_20230802::Status (unsigned int)>)>::operator()(std::__1::basic_string_view<char, std::__1::char_traits<char> >&&, unsigned int&&, std::__1::function<absl::lts_20230802::Status (unsigned int)>&&) const /opt/llvm/bin/../include/c++/v1/__functional/function.h:507:16
    #10 0x7175738 in std::__1::function<absl::lts_20230802::Status (std::__1::basic_string_view<char, std::__1::char_traits<char> >, unsigned int, std::__1::function<absl::lts_20230802::Status (unsigned int)>)>::operator()(std::__1::basic_string_view<char, std::__1::char_traits<char> >, unsigned int, std::__1::function<absl::lts_20230802::Status (unsigned int)>) const /opt/llvm/bin/../include/c++/v1/__functional/function.h:1184:12
    #11 0x71754e8 in decltype(std::forward<std::__1::function<absl::lts_20230802::Status (std::__1::basic_string_view<char, std::__1::char_traits<char> >, unsigned int, std::__1::function<absl::lts_20230802::Status (unsigned int)>)> const&>(fp)(std::get<0ul>(std::forward<std::__1::tuple<std::__1::basic_string_view<char, std::__1::char_traits<char> >, unsigned int, std::__1::function<absl::lts_20230802::Status (unsigned int)> > >(fp0)), std::get<1ul>(std::forward<std::__1::tuple<std::__1::basic_string_view<char, std::__1::char_traits<char> >, unsigned int, std::__1::function<absl::lts_20230802::Status (unsigned int)> > >(fp0)), std::get<2ul>(std::forward<std::__1::tuple<std::__1::basic_string_view<char, std::__1::char_traits<char> >, unsigned int, std::__1::function<absl::lts_20230802::Status (unsigned int)> > >(fp0)))) testing::internal::ApplyImpl<std::__1::function<absl::lts_20230802::Status (std::__1::basic_string_view<char, std::__1::char_traits<char> >, unsigned int, std::__1::function<absl::lts_20230802::Status (unsigned int)>)> const&, std::__1::tuple<std::__1::basic_string_view<char, std::__1::char_traits<char> >, unsigned int, std::__1::function<absl::lts_20230802::Status (unsigned int)> >, 0ul, 1ul, 2ul>(std::__1::function<absl::lts_20230802::Status (std::__1::basic_string_view<char, std::__1::char_traits<char> >, unsigned int, std::__1::function<absl::lts_20230802::Status (unsigned int)>)> const&, std::__1::tuple<std::__1::basic_string_view<char, std::__1::char_traits<char> >, unsigned int, std::__1::function<absl::lts_20230802::Status (unsigned int)> >&&, testing::internal::IndexSequence<0ul, 1ul, 2ul>) /proc/self/cwd/external/com_google_googletest/googlemock/include/gmock/internal/gmock-internal-utils.h:420:10
    #12 0x7175395 in decltype(ApplyImpl(std::forward<std::__1::function<absl::lts_20230802::Status (std::__1::basic_string_view<char, std::__1::char_traits<char> >, unsigned int, std::__1::function<absl::lts_20230802::Status (unsigned int)>)> const&>(fp), std::forward<std::__1::tuple<std::__1::basic_string_view<char, std::__1::char_traits<char> >, unsigned int, std::__1::function<absl::lts_20230802::Status (unsigned int)> > >(fp0), (testing::internal::MakeIndexSequence<std::tuple_size<std::__1::remove_reference<std::__1::tuple<std::__1::basic_string_view<char, std::__1::char_traits<char> >, unsigned int, std::__1::function<absl::lts_20230802::Status (unsigned int)> > >::type>::value>)())) testing::internal::Apply<std::__1::function<absl::lts_20230802::Status (std::__1::basic_string_view<char, std::__1::char_traits<char> >, unsigned int, std::__1::function<absl::lts_20230802::Status (unsigned int)>)> const&, std::__1::tuple<std::__1::basic_string_view<char, std::__1::char_traits<char> >, unsigned int, std::__1::function<absl::lts_20230802::Status (unsigned int)> > >(std::__1::function<absl::lts_20230802::Status (std::__1::basic_string_view<char, std::__1::char_traits<char> >, unsigned int, std::__1::function<absl::lts_20230802::Status (unsigned int)>)> const&, std::__1::tuple<std::__1::basic_string_view<char, std::__1::char_traits<char> >, unsigned int, std::__1::function<absl::lts_20230802::Status (unsigned int)> >&&) /proc/self/cwd/external/com_google_googletest/googlemock/include/gmock/internal/gmock-internal-utils.h:429:10
    #13 0x7174d47 in testing::Action<absl::lts_20230802::Status (std::__1::basic_string_view<char, std::__1::char_traits<char> >, unsigned int, std::__1::function<absl::lts_20230802::Status (unsigned int)>)>::Perform(std::__1::tuple<std::__1::basic_string_view<char, std::__1::char_traits<char> >, unsigned int, std::__1::function<absl::lts_20230802::Status (unsigned int)> >) const /proc/self/cwd/external/com_google_googletest/googlemock/include/gmock/gmock-actions.h:497:12
    #14 0x7175afd in testing::internal::ActionResultHolder<absl::lts_20230802::Status>* testing::internal::ActionResultHolder<absl::lts_20230802::Status>::PerformAction<absl::lts_20230802::Status (std::__1::basic_string_view<char, std::__1::char_traits<char> >, unsigned int, std::__1::function<absl::lts_20230802::Status (unsigned int)>)>(testing::Action<absl::lts_20230802::Status (std::__1::basic_string_view<char, std::__1::char_traits<char> >, unsigned int, std::__1::function<absl::lts_20230802::Status (unsigned int)>)> const&, testing::internal::Function<absl::lts_20230802::Status (std::__1::basic_string_view<char, std::__1::char_traits<char> >, unsigned int, std::__1::function<absl::lts_20230802::Status (unsigned int)>)>::ArgumentTuple&&) /proc/self/cwd/external/com_google_googletest/googlemock/include/gmock/gmock-spec-builders.h:1402:24
    #15 0x7173651 in testing::internal::FunctionMocker<absl::lts_20230802::Status (std::__1::basic_string_view<char, std::__1::char_traits<char> >, unsigned int, std::__1::function<absl::lts_20230802::Status (unsigned int)>)>::UntypedPerformAction(void const*, void*) const /proc/self/cwd/external/com_google_googletest/googlemock/include/gmock/gmock-spec-builders.h:1556:12
    #16 0xa3e9535 in testing::internal::UntypedFunctionMockerBase::UntypedInvokeWith(void*) /proc/self/cwd/external/com_google_googletest/googlemock/src/gmock-spec-builders.cc:452:24
    #17 0x333e5b2 in testing::internal::FunctionMocker<absl::lts_20230802::Status (std::__1::basic_string_view<char, std::__1::char_traits<char> >, unsigned int, std::__1::function<absl::lts_20230802::Status (unsigned int)>)>::Invoke(std::__1::basic_string_view<char, std::__1::char_traits<char> >, unsigned int, std::__1::function<absl::lts_20230802::Status (unsigned int)>) /proc/self/cwd/external/com_google_googletest/googlemock/include/gmock/gmock-spec-builders.h:1593:15
    #18 0x333e24c in Envoy::Filesystem::MockWatcher::addWatch(std::__1::basic_string_view<char, std::__1::char_traits<char> >, unsigned int, std::__1::function<absl::lts_20230802::Status (unsigned int)>) /proc/self/cwd/./test/mocks/filesystem/mocks.h:78:3
    #19 0x3405db9 in decltype(static_cast<Envoy::Extensions::GeoipProviders::Maxmind::GeoipProvider::GeoipProvider(Envoy::Event::Dispatcher&, Envoy::Api::Api&, std::__1::shared_ptr<Envoy::Singleton::Instance>, std::__1::shared_ptr<Envoy::Extensions::GeoipProviders::Maxmind::GeoipProviderConfig>)::$_0&>(fp)()) std::__1::__invoke<Envoy::Extensions::GeoipProviders::Maxmind::GeoipProvider::GeoipProvider(Envoy::Event::Dispatcher&, Envoy::Api::Api&, std::__1::shared_ptr<Envoy::Singleton::Instance>, std::__1::shared_ptr<Envoy::Extensions::GeoipProviders::Maxmind::GeoipProviderConfig>)::$_0&>(Envoy::Extensions::GeoipProviders::Maxmind::GeoipProvider::GeoipProvider(Envoy::Event::Dispatcher&, Envoy::Api::Api&, std::__1::shared_ptr<Envoy::Singleton::Instance>, std::__1::shared_ptr<Envoy::Extensions::GeoipProviders::Maxmind::GeoipProviderConfig>)::$_0&) /proc/self/cwd/source/extensions/geoip_providers/maxmind/geoip_provider.cc:126:11
    #20 0x3404a63 in std::__1::__function::__func<Envoy::Extensions::GeoipProviders::Maxmind::GeoipProvider::GeoipProvider(Envoy::Event::Dispatcher&, Envoy::Api::Api&, std::__1::shared_ptr<Envoy::Singleton::Instance>, std::__1::shared_ptr<Envoy::Extensions::GeoipProviders::Maxmind::GeoipProviderConfig>)::$_0, std::__1::allocator<Envoy::Extensions::GeoipProviders::Maxmind::GeoipProvider::GeoipProvider(Envoy::Event::Dispatcher&, Envoy::Api::Api&, std::__1::shared_ptr<Envoy::Singleton::Instance>, std::__1::shared_ptr<Envoy::Extensions::GeoipProviders::Maxmind::GeoipProviderConfig>)::$_0>, void ()>::operator()() /opt/llvm/bin/../include/c++/v1/__functional/invoke.h:61:9
    #21 0x34f0239 in std::__1::__function::__value_func<void ()>::operator()() const /opt/llvm/bin/../include/c++/v1/__functional/function.h:507:16
    #22 0x91dbf37 in Envoy::Thread::PosixThreadFactory::createPthread(Envoy::Thread::ThreadHandle*)::$_6::__invoke(void*) /opt/llvm/bin/../include/c++/v1/__functional/function.h:1184:12
    #23 0x7fb0ecf9f608 in start_thread (/lib/x86_64-linux-gnu/libpthread.so.0+0x8608) (BuildId: 0c044ba611aeeeaebb8374e660061f341ebc0bac)
```

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
Fixes #35829
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
