### PR TITLE
runtime: load rtds bool correctly as true/false instead of 1/0

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -128,6 +128,11 @@ bug_fixes:
     the number of requests per I/O cycle is configured and an HTTP decoder filter that pauses filter chain is present. This behavior
     can be reverted by setting the runtime guard ``envoy.reloadable_features.use_filter_manager_state_for_downstream_end_stream``
     to false.
+- area: runtime
+  change: |
+    Fixed an inconsistency in how boolean values are loaded in RTDS, where they were previously converted to "1"/"0" instead of "true"/"false". 
+    The correct string representation ("true"/"false") will now be used. This change can be reverted by setting the runtime guard 
+    `envoy.reloadable_features.boolean_to_string_fix` to false.
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -130,9 +130,9 @@ bug_fixes:
     to false.
 - area: runtime
   change: |
-    Fixed an inconsistency in how boolean values are loaded in RTDS, where they were previously converted to "1"/"0" instead of "true"/"false". 
-    The correct string representation ("true"/"false") will now be used. This change can be reverted by setting the runtime guard 
-    `envoy.reloadable_features.boolean_to_string_fix` to false.
+    Fixed an inconsistency in how boolean values are loaded in RTDS, where they were previously converted to "1"/"0"
+    instead of "true"/"false". The correct string representation ("true"/"false") will now be used. This change can be
+    reverted by setting the runtime guard ``envoy.reloadable_features.boolean_to_string_fix`` to false.
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -1,6 +1,7 @@
 #include "source/common/runtime/runtime_features.h"
 
 #include "absl/flags/commandlineflag.h"
+#include "absl/flags/declare.h"
 #include "absl/flags/flag.h"
 #include "absl/strings/match.h"
 #include "absl/strings/str_replace.h"
@@ -30,6 +31,7 @@
 // ASAP by filing a bug on github. Overriding non-buggy code is strongly discouraged to avoid the
 // problem of the bugs being found after the old code path has been removed.
 RUNTIME_GUARD(envoy_reloadable_features_allow_alt_svc_for_ips);
+RUNTIME_GUARD(envoy_reloadable_features_boolean_to_string_fix);
 RUNTIME_GUARD(envoy_reloadable_features_check_switch_protocol_websocket_handshake);
 RUNTIME_GUARD(envoy_reloadable_features_conn_pool_delete_when_idle);
 RUNTIME_GUARD(envoy_reloadable_features_consistent_header_validation);
@@ -222,7 +224,7 @@ bool isRuntimeFeature(absl::string_view feature) {
   return RuntimeFeaturesDefaults::get().getFlag(feature) != nullptr;
 }
 
-bool runtimeFeatureEnabled(absl::string_view feature) {
+bool      runtimeFeatureEnabled(absl::string_view feature) {
   absl::CommandLineFlag* flag = RuntimeFeaturesDefaults::get().getFlag(feature);
   if (flag == nullptr) {
     IS_ENVOY_BUG(absl::StrCat("Unable to find runtime feature ", feature));

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -1,7 +1,6 @@
 #include "source/common/runtime/runtime_features.h"
 
 #include "absl/flags/commandlineflag.h"
-#include "absl/flags/declare.h"
 #include "absl/flags/flag.h"
 #include "absl/strings/match.h"
 #include "absl/strings/str_replace.h"
@@ -224,7 +223,7 @@ bool isRuntimeFeature(absl::string_view feature) {
   return RuntimeFeaturesDefaults::get().getFlag(feature) != nullptr;
 }
 
-bool      runtimeFeatureEnabled(absl::string_view feature) {
+bool runtimeFeatureEnabled(absl::string_view feature) {
   absl::CommandLineFlag* flag = RuntimeFeaturesDefaults::get().getFlag(feature);
   if (flag == nullptr) {
     IS_ENVOY_BUG(absl::StrCat("Unable to find runtime feature ", feature));

--- a/source/common/runtime/runtime_impl.cc
+++ b/source/common/runtime/runtime_impl.cc
@@ -375,9 +375,13 @@ SnapshotImpl::Entry SnapshotImpl::createEntry(const ProtobufWkt::Value& value,
   case ProtobufWkt::Value::kBoolValue:
     entry.bool_value_ = value.bool_value();
     if (entry.raw_string_value_.empty()) {
-      // Convert boolean to "true"/"false"
-      // absl::StrCat would convert to "1"/"0" so it is not used
-      entry.raw_string_value_ = value.bool_value() ? "true" : "false";
+      if (Runtime::runtimeFeatureEnabled("envoy.reloadable_features.boolean_to_string_fix")) {
+        // Convert boolean to "true"/"false"
+        entry.raw_string_value_ = value.bool_value() ? "true" : "false";
+      } else {
+        // Use absl::StrCat for backward compatibility, which converts to "1"/"0"
+        entry.raw_string_value_ = absl::StrCat(value.bool_value());
+      }
     }
     break;
   case ProtobufWkt::Value::kStructValue:

--- a/source/common/runtime/runtime_impl.cc
+++ b/source/common/runtime/runtime_impl.cc
@@ -375,7 +375,8 @@ SnapshotImpl::Entry SnapshotImpl::createEntry(const ProtobufWkt::Value& value,
   case ProtobufWkt::Value::kBoolValue:
     entry.bool_value_ = value.bool_value();
     if (entry.raw_string_value_.empty()) {
-      // Convert boolean to "true"/"false" (absl::StrCat would convert to "1"/"0" so it is not used).
+      // Convert boolean to "true"/"false"
+      // absl::StrCat would convert to "1"/"0" so it is not used
       entry.raw_string_value_ = value.bool_value() ? "true" : "false";
     }
     break;

--- a/source/common/runtime/runtime_impl.cc
+++ b/source/common/runtime/runtime_impl.cc
@@ -375,7 +375,8 @@ SnapshotImpl::Entry SnapshotImpl::createEntry(const ProtobufWkt::Value& value,
   case ProtobufWkt::Value::kBoolValue:
     entry.bool_value_ = value.bool_value();
     if (entry.raw_string_value_.empty()) {
-      entry.raw_string_value_ = absl::StrCat(value.bool_value());
+      // Convert boolean value to string representation ("true" or "false")
+      entry.raw_string_value_ = value.bool_value() ? "true" : "false";
     }
     break;
   case ProtobufWkt::Value::kStructValue:

--- a/source/common/runtime/runtime_impl.cc
+++ b/source/common/runtime/runtime_impl.cc
@@ -375,7 +375,7 @@ SnapshotImpl::Entry SnapshotImpl::createEntry(const ProtobufWkt::Value& value,
   case ProtobufWkt::Value::kBoolValue:
     entry.bool_value_ = value.bool_value();
     if (entry.raw_string_value_.empty()) {
-      // Convert boolean value to string representation ("true" or "false")
+      // Convert boolean to "true"/"false" (absl::StrCat would convert to "1"/"0" so it is not used).
       entry.raw_string_value_ = value.bool_value() ? "true" : "false";
     }
     break;

--- a/test/common/runtime/runtime_impl_test.cc
+++ b/test/common/runtime/runtime_impl_test.cc
@@ -1110,7 +1110,7 @@ TEST_F(RtdsLoaderImplTest, OnConfigUpdateSuccess) {
   EXPECT_EQ("bar", loader_->snapshot().get("foo").value().get());
   EXPECT_EQ("yar", loader_->snapshot().get("bar").value().get());
   EXPECT_EQ("meh", loader_->snapshot().get("baz").value().get());
-  EXPECT_EQ("true", loader_->snapshot().get("toggle").value().get()); // Expecting "true" as string representation
+  EXPECT_EQ("true", loader_->snapshot().get("toggle").value().get());
 
   EXPECT_EQ(0, store_.counter("runtime.load_error").value());
   EXPECT_EQ(2, store_.counter("runtime.load_success").value());

--- a/test/common/runtime/runtime_impl_test.cc
+++ b/test/common/runtime/runtime_impl_test.cc
@@ -1318,7 +1318,6 @@ TEST_F(RtdsLoaderImplTest, BadConfigSource) {
 TEST_F(RtdsLoaderImplTest, BooleanToStringConversionWhenFlagEnabled) {
   setup();
 
-  // Enable the runtime guard flag
   absl::SetFlag(&FLAGS_envoy_reloadable_features_boolean_to_string_fix, true);
 
   auto runtime = TestUtility::parseYaml<envoy::service::runtime::v3::Runtime>(R"EOF(
@@ -1332,7 +1331,6 @@ TEST_F(RtdsLoaderImplTest, BooleanToStringConversionWhenFlagEnabled) {
 
   EXPECT_EQ("true", loader_->snapshot().get("toggle").value().get());
 
-  // Metrics checks (adjust as per your actual metric names)
   EXPECT_EQ(0, store_.counter("runtime.load_error").value());
   EXPECT_EQ(2, store_.counter("runtime.load_success").value());
   EXPECT_EQ(3, store_.gauge("runtime.num_keys", Stats::Gauge::ImportMode::NeverImport).value());
@@ -1342,7 +1340,6 @@ TEST_F(RtdsLoaderImplTest, BooleanToStringConversionWhenFlagEnabled) {
 TEST_F(RtdsLoaderImplTest, BooleanToStringConversionWhenFlagDisabled) {
   setup();
 
-  // Disable the runtime guard flag
   absl::SetFlag(&FLAGS_envoy_reloadable_features_boolean_to_string_fix, false);
 
   auto runtime = TestUtility::parseYaml<envoy::service::runtime::v3::Runtime>(R"EOF(
@@ -1356,7 +1353,6 @@ TEST_F(RtdsLoaderImplTest, BooleanToStringConversionWhenFlagDisabled) {
 
   EXPECT_EQ("1", loader_->snapshot().get("toggle").value().get()); // Assuming previous behavior
 
-  // Metrics checks (adjust as per your actual metric names)
   EXPECT_EQ(0, store_.counter("runtime.load_error").value());
   EXPECT_EQ(2, store_.counter("runtime.load_success").value());
   EXPECT_EQ(3, store_.gauge("runtime.num_keys", Stats::Gauge::ImportMode::NeverImport).value());

--- a/test/common/runtime/runtime_impl_test.cc
+++ b/test/common/runtime/runtime_impl_test.cc
@@ -1330,11 +1330,6 @@ TEST_F(RtdsLoaderImplTest, BooleanToStringConversionWhenFlagEnabled) {
   doOnConfigUpdateVerifyNoThrow(runtime);
 
   EXPECT_EQ("true", loader_->snapshot().get("toggle").value().get());
-
-  EXPECT_EQ(0, store_.counter("runtime.load_error").value());
-  EXPECT_EQ(2, store_.counter("runtime.load_success").value());
-  EXPECT_EQ(3, store_.gauge("runtime.num_keys", Stats::Gauge::ImportMode::NeverImport).value());
-  EXPECT_EQ(2, store_.gauge("runtime.num_layers", Stats::Gauge::ImportMode::NeverImport).value());
 }
 
 TEST_F(RtdsLoaderImplTest, BooleanToStringConversionWhenFlagDisabled) {
@@ -1352,11 +1347,6 @@ TEST_F(RtdsLoaderImplTest, BooleanToStringConversionWhenFlagDisabled) {
   doOnConfigUpdateVerifyNoThrow(runtime);
 
   EXPECT_EQ("1", loader_->snapshot().get("toggle").value().get()); // Assuming previous behavior
-
-  EXPECT_EQ(0, store_.counter("runtime.load_error").value());
-  EXPECT_EQ(2, store_.counter("runtime.load_success").value());
-  EXPECT_EQ(3, store_.gauge("runtime.num_keys", Stats::Gauge::ImportMode::NeverImport).value());
-  EXPECT_EQ(2, store_.gauge("runtime.num_layers", Stats::Gauge::ImportMode::NeverImport).value());
 }
 
 } // namespace

--- a/test/common/runtime/runtime_impl_test.cc
+++ b/test/common/runtime/runtime_impl_test.cc
@@ -1110,7 +1110,6 @@ TEST_F(RtdsLoaderImplTest, OnConfigUpdateSuccess) {
   EXPECT_EQ("bar", loader_->snapshot().get("foo").value().get());
   EXPECT_EQ("yar", loader_->snapshot().get("bar").value().get());
   EXPECT_EQ("meh", loader_->snapshot().get("baz").value().get());
-  EXPECT_EQ("true", loader_->snapshot().get("toggle").value().get());
 
   EXPECT_EQ(0, store_.counter("runtime.load_error").value());
   EXPECT_EQ(2, store_.counter("runtime.load_success").value());

--- a/test/common/runtime/runtime_impl_test.cc
+++ b/test/common/runtime/runtime_impl_test.cc
@@ -1102,6 +1102,7 @@ TEST_F(RtdsLoaderImplTest, OnConfigUpdateSuccess) {
     layer:
       foo: bar
       baz: meh
+      toggle: true
   )EOF");
   EXPECT_CALL(rtds_init_callback_, Call());
   doOnConfigUpdateVerifyNoThrow(runtime);
@@ -1109,10 +1110,11 @@ TEST_F(RtdsLoaderImplTest, OnConfigUpdateSuccess) {
   EXPECT_EQ("bar", loader_->snapshot().get("foo").value().get());
   EXPECT_EQ("yar", loader_->snapshot().get("bar").value().get());
   EXPECT_EQ("meh", loader_->snapshot().get("baz").value().get());
+  EXPECT_EQ("true", loader_->snapshot().get("toggle").value().get()); // Expecting "true" as string representation
 
   EXPECT_EQ(0, store_.counter("runtime.load_error").value());
   EXPECT_EQ(2, store_.counter("runtime.load_success").value());
-  EXPECT_EQ(3, store_.gauge("runtime.num_keys", Stats::Gauge::ImportMode::NeverImport).value());
+  EXPECT_EQ(4, store_.gauge("runtime.num_keys", Stats::Gauge::ImportMode::NeverImport).value());
   EXPECT_EQ(2, store_.gauge("runtime.num_layers", Stats::Gauge::ImportMode::NeverImport).value());
 
   runtime = TestUtility::parseYaml<envoy::service::runtime::v3::Runtime>(R"EOF(


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Load RTDS boolean config correctly as true/false instead of 1/0
Additional Description: Currently, RTDS boolean values are being loaded as `1` or `0`, which is inconsistent with the expected `true` or `false` values. This discrepancy needs to be corrected so that boolean values are consistently loaded and represented as `true` or `false`. For further details, please refer to the [issue comment](https://github.com/envoyproxy/envoy/issues/35762#issuecomment-2338685970) where this inconsistency is discussed.
Risk Level: Low (to be consistent with initially loaded true/false value)
Testing: new Unit Test
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
[Optional Fixes #Issue] https://github.com/envoyproxy/envoy/issues/35762