### PR TITLE
aws: fix test flake when no IMDS can be found (#35633)

### DIFF
--- a/source/extensions/common/aws/metadata_fetcher.cc
+++ b/source/extensions/common/aws/metadata_fetcher.cc
@@ -52,6 +52,12 @@ public:
     ASSERT(!request_);
     complete_ = false;
     receiver_ = makeOptRef(receiver);
+
+    // Stop processing if we are shutting down
+    if (cm_.isShutdown()) {
+      return;
+    }
+
     const auto thread_local_cluster = cm_.getThreadLocalCluster(cluster_name_);
     if (thread_local_cluster == nullptr) {
       ENVOY_LOG(error, "{} AWS Metadata failed: [cluster = {}] not found", __func__, cluster_name_);


### PR DESCRIPTION
Commit Message: aws: fix test flake when no IMDS can be found 
Additional Description: Lack of IMDS (169.254.169.254 address) can cause a race condition and crash during testing due to the shutdown of cluster manager. This scenario should not occur normally, as cluster manager will still exist and the lack of IMDS is handled gracefully.
