### PR TITLE
Add `ENVOY_EXECUTION_SCOPE`.

### DIFF
--- a/envoy/common/BUILD
+++ b/envoy/common/BUILD
@@ -124,7 +124,10 @@ envoy_cc_library(
 envoy_cc_library(
     name = "execution_context",
     hdrs = ["execution_context.h"],
-    deps = [":pure_lib"],
+    deps = [
+        ":pure_lib",
+        "//source/common/common:cleanup_lib",
+    ],
 )
 
 envoy_cc_library(

--- a/envoy/common/execution_context.h
+++ b/envoy/common/execution_context.h
@@ -4,9 +4,18 @@
 
 #include "envoy/common/pure.h"
 
+#include "source/common/common/cleanup.h"
 #include "source/common/common/non_copyable.h"
 
 namespace Envoy {
+
+namespace Http {
+struct FilterContext;
+}
+
+namespace Tracing {
+class Span;
+}
 
 class ScopedExecutionContext;
 
@@ -18,6 +27,13 @@ class ExecutionContext : NonCopyable {
 public:
   ExecutionContext() = default;
   virtual ~ExecutionContext() = default;
+
+  // Called when enters a scope in which |span| is active.
+  // Returns an object that can do some cleanup when exits the scope.
+  virtual Envoy::Cleanup onScopeEnter(Envoy::Tracing::Span& span) PURE;
+  // Called when enters a scope in which |filter_context| is active.
+  // Returns an object that can do some cleanup when exits the scope.
+  virtual Envoy::Cleanup onScopeEnter(const Http::FilterContext& filter_context) PURE;
 
 protected:
   // Called when the current thread starts to run code on behalf of the owner of this object.
@@ -64,5 +80,23 @@ public:
 private:
   ExecutionContext* context_;
 };
+
+#ifdef ENVOY_ENABLE_EXECUTION_SCOPE
+#define ENVOY_EXECUTION_SCOPE_CAT_(a, b) a##b
+#define ENVOY_EXECUTION_SCOPE_CAT(a, b) ENVOY_EXECUTION_SCOPE_CAT_(a, b)
+// Invoked when |scopedObject| is active from the current line to the end of the current c++ scope.
+// |executionContext| is a pointer to the current ExecutionContext.
+// |scopedObject| is a pointer to a Envoy::Tracing::Span or a Http::FilterContext.
+#define ENVOY_EXECUTION_SCOPE(executionContext, scopedObject)                                      \
+  Envoy::Cleanup ENVOY_EXECUTION_SCOPE_CAT(on_scope_exit_, __LINE__) =                             \
+      [execution_context = (executionContext), scoped_object = (scopedObject)] {                   \
+        if (execution_context == nullptr || scoped_object == nullptr) {                            \
+          return Envoy::Cleanup::Noop();                                                           \
+        }                                                                                          \
+        return execution_context->onScopeEnter(*scoped_object);                                    \
+      }()
+#else
+#define ENVOY_EXECUTION_SCOPE(executionContext, scopedObject)
+#endif
 
 } // namespace Envoy

--- a/source/common/common/cleanup.h
+++ b/source/common/common/cleanup.h
@@ -24,6 +24,10 @@ public:
 
   bool cancelled() { return cancelled_; }
 
+  static Cleanup Noop() {
+    return Cleanup([] {});
+  }
+
 private:
   std::function<void()> f_;
   bool cancelled_{false};

--- a/source/common/http/BUILD
+++ b/source/common/http/BUILD
@@ -316,6 +316,7 @@ envoy_cc_library(
         "//source/common/http/matching:inputs_lib",
         "//source/common/local_reply:local_reply_lib",
         "//source/common/matcher:matcher_lib",
+        "//source/common/network:common_connection_filter_states_lib",
         "@envoy_api//envoy/extensions/filters/network/http_connection_manager/v3:pkg_cc_proto",
     ],
 )

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -1393,6 +1393,7 @@ void ConnectionManagerImpl::ActiveStream::decodeHeaders(RequestHeaderMapSharedPt
     traceRequest();
   }
 
+  ENVOY_EXECUTION_SCOPE(executionContext(), active_span_.get());
   if (!connection_manager_.shouldDeferRequestProxyingToNextIoCycle()) {
     filter_manager_.decodeHeaders(*request_headers_, end_stream);
   } else {
@@ -1464,6 +1465,7 @@ void ConnectionManagerImpl::ActiveStream::traceRequest() {
 void ConnectionManagerImpl::ActiveStream::decodeData(Buffer::Instance& data, bool end_stream) {
   ScopeTrackerScopeState scope(this,
                                connection_manager_.read_callbacks_->connection().dispatcher());
+  ENVOY_EXECUTION_SCOPE(executionContext(), active_span_.get());
   maybeRecordLastByteReceived(end_stream);
   filter_manager_.streamInfo().addBytesReceived(data.length());
   if (!state_.deferred_to_next_io_iteration_) {
@@ -1481,6 +1483,7 @@ void ConnectionManagerImpl::ActiveStream::decodeTrailers(RequestTrailerMapPtr&& 
   ENVOY_STREAM_LOG(debug, "request trailers complete:\n{}", *this, *trailers);
   ScopeTrackerScopeState scope(this,
                                connection_manager_.read_callbacks_->connection().dispatcher());
+  ENVOY_EXECUTION_SCOPE(executionContext(), active_span_.get());
   resetIdleTimer();
 
   ASSERT(!request_trailers_);
@@ -1501,6 +1504,7 @@ void ConnectionManagerImpl::ActiveStream::decodeTrailers(RequestTrailerMapPtr&& 
 }
 
 void ConnectionManagerImpl::ActiveStream::decodeMetadata(MetadataMapPtr&& metadata_map) {
+  ENVOY_EXECUTION_SCOPE(executionContext(), active_span_.get());
   resetIdleTimer();
   if (!state_.deferred_to_next_io_iteration_) {
     // After going through filters, the ownership of metadata_map will be passed to terminal filter.
@@ -1705,6 +1709,7 @@ void ConnectionManagerImpl::ActiveStream::onLocalReply(Code code) {
 }
 
 void ConnectionManagerImpl::ActiveStream::encode1xxHeaders(ResponseHeaderMap& response_headers) {
+  ENVOY_EXECUTION_SCOPE(executionContext(), active_span_.get());
   // Strip the T-E headers etc. Defer other header additions as well as drain-close logic to the
   // continuation headers.
   ConnectionManagerUtility::mutateResponseHeaders(
@@ -1723,6 +1728,7 @@ void ConnectionManagerImpl::ActiveStream::encode1xxHeaders(ResponseHeaderMap& re
 
 void ConnectionManagerImpl::ActiveStream::encodeHeaders(ResponseHeaderMap& headers,
                                                         bool end_stream) {
+  ENVOY_EXECUTION_SCOPE(executionContext(), active_span_.get());
   // Base headers.
 
   // We want to preserve the original date header, but we add a date header if it is absent
@@ -1868,6 +1874,7 @@ void ConnectionManagerImpl::ActiveStream::encodeHeaders(ResponseHeaderMap& heade
 }
 
 void ConnectionManagerImpl::ActiveStream::encodeData(Buffer::Instance& data, bool end_stream) {
+  ENVOY_EXECUTION_SCOPE(executionContext(), active_span_.get());
   ENVOY_STREAM_LOG(trace, "encoding data via codec (size={} end_stream={})", *this, data.length(),
                    end_stream);
 
@@ -1876,12 +1883,14 @@ void ConnectionManagerImpl::ActiveStream::encodeData(Buffer::Instance& data, boo
 }
 
 void ConnectionManagerImpl::ActiveStream::encodeTrailers(ResponseTrailerMap& trailers) {
+  ENVOY_EXECUTION_SCOPE(executionContext(), active_span_.get());
   ENVOY_STREAM_LOG(debug, "encoding trailers via codec:\n{}", *this, trailers);
 
   response_encoder_->encodeTrailers(trailers);
 }
 
 void ConnectionManagerImpl::ActiveStream::encodeMetadata(MetadataMapPtr&& metadata) {
+  ENVOY_EXECUTION_SCOPE(executionContext(), active_span_.get());
   MetadataMapVector metadata_map_vector;
   metadata_map_vector.emplace_back(std::move(metadata));
   ENVOY_STREAM_LOG(debug, "encoding metadata via codec:\n{}", *this, metadata_map_vector);
@@ -2159,6 +2168,7 @@ void ConnectionManagerImpl::ActiveStream::onRequestDataTooLarge() {
 
 void ConnectionManagerImpl::ActiveStream::recreateStream(
     StreamInfo::FilterStateSharedPtr filter_state) {
+  ENVOY_EXECUTION_SCOPE(executionContext(), active_span_.get());
   ResponseEncoder* response_encoder = response_encoder_;
   response_encoder_ = nullptr;
 
@@ -2230,6 +2240,7 @@ bool ConnectionManagerImpl::ActiveStream::onDeferredRequestProcessing() {
   if (!state_.deferred_to_next_io_iteration_) {
     return false;
   }
+  ENVOY_EXECUTION_SCOPE(executionContext(), active_span_.get());
   state_.deferred_to_next_io_iteration_ = false;
   bool end_stream = state_.deferred_end_stream_ && deferred_data_ == nullptr &&
                     deferred_request_trailers_ == nullptr && deferred_metadata_.empty();

--- a/source/common/http/filter_manager.cc
+++ b/source/common/http/filter_manager.cc
@@ -542,6 +542,7 @@ void FilterManager::decodeHeaders(ActiveStreamDecoderFilter* filter, RequestHead
          (*entry)->end_stream_);
 
   for (; entry != decoder_filters_.end(); entry++) {
+    ENVOY_EXECUTION_SCOPE(executionContext(), &(*entry)->filter_context_);
     ASSERT(!(state_.filter_call_state_ & FilterCallState::DecodeHeaders));
     state_.filter_call_state_ |= FilterCallState::DecodeHeaders;
     (*entry)->end_stream_ = (end_stream && continue_data_entry == decoder_filters_.end());
@@ -653,6 +654,7 @@ void FilterManager::decodeData(ActiveStreamDecoderFilter* filter, Buffer::Instan
          (*entry)->end_stream_);
 
   for (; entry != decoder_filters_.end(); entry++) {
+    ENVOY_EXECUTION_SCOPE(executionContext(), &(*entry)->filter_context_);
     // If the filter pointed by entry has stopped for all frame types, return now.
     if (handleDataIfStopAll(**entry, data, state_.decoder_filters_streaming_)) {
       return;
@@ -803,6 +805,7 @@ void FilterManager::decodeTrailers(ActiveStreamDecoderFilter* filter, RequestTra
   ASSERT(!state_.decoder_filter_chain_complete_ || entry == decoder_filters_.end());
 
   for (; entry != decoder_filters_.end(); entry++) {
+    ENVOY_EXECUTION_SCOPE(executionContext(), &(*entry)->filter_context_);
     // If the filter pointed by entry has stopped for all frame type, return now.
     if ((*entry)->stoppedAll()) {
       return;
@@ -846,6 +849,7 @@ void FilterManager::decodeMetadata(ActiveStreamDecoderFilter* filter, MetadataMa
   ASSERT(!(state_.filter_call_state_ & FilterCallState::DecodeMetadata));
 
   for (; entry != decoder_filters_.end(); entry++) {
+    ENVOY_EXECUTION_SCOPE(executionContext(), &(*entry)->filter_context_);
     // If the filter pointed by entry has stopped for all frame type, stores metadata and returns.
     // If the filter pointed by entry hasn't returned from decodeHeaders, stores newly added
     // metadata in case decodeHeaders returns StopAllIteration. The latter can happen when headers
@@ -1173,6 +1177,7 @@ void FilterManager::encode1xxHeaders(ActiveStreamEncoderFilter* filter,
   std::list<ActiveStreamEncoderFilterPtr>::iterator entry =
       commonEncodePrefix(filter, false, FilterIterationStartState::AlwaysStartFromNext);
   for (; entry != encoder_filters_.end(); entry++) {
+    ENVOY_EXECUTION_SCOPE(executionContext(), &(*entry)->filter_context_);
     ASSERT(!(state_.filter_call_state_ & FilterCallState::Encode1xxHeaders));
     state_.filter_call_state_ |= FilterCallState::Encode1xxHeaders;
     const Filter1xxHeadersStatus status = (*entry)->handle_->encode1xxHeaders(headers);
@@ -1222,6 +1227,7 @@ void FilterManager::encodeHeaders(ActiveStreamEncoderFilter* filter, ResponseHea
   std::list<ActiveStreamEncoderFilterPtr>::iterator continue_data_entry = encoder_filters_.end();
 
   for (; entry != encoder_filters_.end(); entry++) {
+    ENVOY_EXECUTION_SCOPE(executionContext(), &(*entry)->filter_context_);
     ASSERT(!(state_.filter_call_state_ & FilterCallState::EncodeHeaders));
     state_.filter_call_state_ |= FilterCallState::EncodeHeaders;
     (*entry)->end_stream_ = (end_stream && continue_data_entry == encoder_filters_.end());
@@ -1306,6 +1312,7 @@ void FilterManager::encodeMetadata(ActiveStreamEncoderFilter* filter,
       commonEncodePrefix(filter, false, FilterIterationStartState::CanStartFromCurrent);
 
   for (; entry != encoder_filters_.end(); entry++) {
+    ENVOY_EXECUTION_SCOPE(executionContext(), &(*entry)->filter_context_);
     // If the filter pointed by entry has stopped for all frame type, stores metadata and returns.
     // If the filter pointed by entry hasn't returned from encodeHeaders, stores newly added
     // metadata in case encodeHeaders returns StopAllIteration. The latter can happen when headers
@@ -1394,6 +1401,7 @@ void FilterManager::encodeData(ActiveStreamEncoderFilter* filter, Buffer::Instan
 
   const bool trailers_exists_at_start = filter_manager_callbacks_.responseTrailers().has_value();
   for (; entry != encoder_filters_.end(); entry++) {
+    ENVOY_EXECUTION_SCOPE(executionContext(), &(*entry)->filter_context_);
     // If the filter pointed by entry has stopped for all frame type, return now.
     if (handleDataIfStopAll(**entry, data, state_.encoder_filters_streaming_)) {
       return;
@@ -1464,6 +1472,7 @@ void FilterManager::encodeTrailers(ActiveStreamEncoderFilter* filter,
   std::list<ActiveStreamEncoderFilterPtr>::iterator entry =
       commonEncodePrefix(filter, true, FilterIterationStartState::CanStartFromCurrent);
   for (; entry != encoder_filters_.end(); entry++) {
+    ENVOY_EXECUTION_SCOPE(executionContext(), &(*entry)->filter_context_);
     // If the filter pointed by entry has stopped for all frame type, return now.
     if ((*entry)->stoppedAll()) {
       return;

--- a/source/common/http/filter_manager.h
+++ b/source/common/http/filter_manager.h
@@ -24,6 +24,7 @@
 #include "source/common/http/utility.h"
 #include "source/common/local_reply/local_reply.h"
 #include "source/common/matcher/matcher.h"
+#include "source/common/network/common_connection_filter_states.h"
 #include "source/common/protobuf/utility.h"
 #include "source/common/runtime/runtime_features.h"
 #include "source/common/stream_info/stream_info_impl.h"
@@ -664,6 +665,13 @@ public:
     DUMP_DETAILS(filter_manager_callbacks_.responseHeaders());
     DUMP_DETAILS(filter_manager_callbacks_.responseTrailers());
     DUMP_DETAILS(&streamInfo());
+  }
+
+  ExecutionContext* executionContext() const override {
+    if (!connection_.has_value()) {
+      return nullptr;
+    }
+    return getConnectionExecutionContext(*connection_);
   }
 
   void addAccessLogHandler(AccessLog::InstanceSharedPtr handler) {

--- a/test/common/common/BUILD
+++ b/test/common/common/BUILD
@@ -545,6 +545,7 @@ envoy_benchmark_test(
 envoy_cc_test(
     name = "execution_context_test",
     srcs = ["execution_context_test.cc"],
+    copts = ["-DENVOY_ENABLE_EXECUTION_SCOPE"],
     deps = [
         "//envoy/common:execution_context",
     ],

--- a/test/common/common/execution_context_test.cc
+++ b/test/common/common/execution_context_test.cc
@@ -1,11 +1,24 @@
 #include "envoy/common/execution_context.h"
+#include "envoy/http/filter_factory.h"
+
+#include "source/common/tracing/null_span_impl.h"
 
 #include "gtest/gtest.h"
 
 namespace Envoy {
 
+thread_local const Http::FilterContext* current_filter_context = nullptr;
+
 class TestExecutionContext : public ExecutionContext {
 public:
+  Envoy::Cleanup onScopeEnter(Envoy::Tracing::Span&) override { return Envoy::Cleanup::Noop(); }
+
+  Envoy::Cleanup onScopeEnter(const Http::FilterContext& filter_context) override {
+    const Http::FilterContext* old_filter_context = current_filter_context;
+    current_filter_context = &filter_context;
+    return Envoy::Cleanup([old_filter_context]() { current_filter_context = old_filter_context; });
+  }
+
   int activationDepth() const { return activation_depth_; }
   int activationGenerations() const { return activation_generations_; }
 
@@ -66,6 +79,38 @@ TEST(ExecutionContextTest, DisjointScopes) {
   }
 
   EXPECT_EQ(context.activationDepth(), 0);
+}
+
+TEST(ExecutionContextTest, NoopScope) {
+  ExecutionContext* null_exec_context = nullptr;
+  Http::FilterContext* null_filter_context = nullptr;
+  Tracing::Span* null_tracing_span = nullptr;
+  ENVOY_EXECUTION_SCOPE(null_exec_context, null_filter_context);
+  ENVOY_EXECUTION_SCOPE(null_exec_context, null_tracing_span);
+
+  Http::FilterContext filter_context;
+  ENVOY_EXECUTION_SCOPE(null_exec_context, &filter_context);
+  ENVOY_EXECUTION_SCOPE(null_exec_context, &Tracing::NullSpan::instance());
+
+  TestExecutionContext context;
+  ENVOY_EXECUTION_SCOPE(&context, null_filter_context);
+  ENVOY_EXECUTION_SCOPE(&context, null_tracing_span);
+}
+
+TEST(ExecutionContextTest, FilterScope) {
+  TestExecutionContext context;
+
+  Http::FilterContext outer_filter_context{"outer_filter"};
+  ENVOY_EXECUTION_SCOPE(&context, &outer_filter_context);
+  EXPECT_EQ(current_filter_context, &outer_filter_context);
+
+  {
+    Http::FilterContext inner_filter_context{"inner_filter"};
+    ENVOY_EXECUTION_SCOPE(&context, &inner_filter_context);
+    EXPECT_EQ(current_filter_context, &inner_filter_context);
+  }
+
+  EXPECT_EQ(current_filter_context, &outer_filter_context);
 }
 
 } // namespace Envoy

--- a/test/common/network/connection_impl_test.cc
+++ b/test/common/network/connection_impl_test.cc
@@ -73,6 +73,11 @@ public:
   NoopConnectionExecutionContext() = default;
   ~NoopConnectionExecutionContext() override = default;
 
+  Envoy::Cleanup onScopeEnter(Envoy::Tracing::Span&) override { return Envoy::Cleanup::Noop(); }
+  Envoy::Cleanup onScopeEnter(const Envoy::Http::FilterContext&) override {
+    return Envoy::Cleanup::Noop();
+  }
+
 protected:
   void activate() override {}
   void deactivate() override {}


### PR DESCRIPTION
Add `ENVOY_EXECUTION_SCOPE` to mark the start and end of a Envoy::Tracing::Span or Http::FilterContext, which is active in the current thread.

This macro only takes effect when `ENVOY_ENABLE_EXECUTION_SCOPE` is defined.

Commit Message: Add `ENVOY_EXECUTION_SCOPE`.
Additional Description:
Risk Level: No. It is no-op unless `ENVOY_ENABLE_EXECUTION_SCOPE` is defined.
Testing: Unit test in test/common/common/execution_context_test.cc.
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]