### PR TITLE
quic: removes more references to spdy::Http2HeaderBlock.

### DIFF
--- a/test/common/quic/envoy_quic_client_stream_test.cc
+++ b/test/common/quic/envoy_quic_client_stream_test.cc
@@ -153,7 +153,7 @@ public:
           EXPECT_EQ("200", headers->getStatusValue());
           EXPECT_EQ(capsule_protocol[0]->value().getStringView(), "?1");
         });
-    spdy::Http2HeaderBlock response_headers;
+    quiche::HttpHeaderBlock response_headers;
     response_headers[":status"] = "200";
     response_headers["capsule-protocol"] = "?1";
     std::string payload = spdyHeaderToHttp3StreamPayload(response_headers);
@@ -189,8 +189,8 @@ protected:
   std::string host_{"www.abc.com"};
   Http::TestRequestHeaderMapImpl request_headers_;
   Http::TestRequestTrailerMapImpl request_trailers_;
-  spdy::Http2HeaderBlock spdy_response_headers_;
-  spdy::Http2HeaderBlock spdy_trailers_;
+  quiche::HttpHeaderBlock spdy_response_headers_;
+  quiche::HttpHeaderBlock spdy_trailers_;
   Buffer::OwnedImpl request_body_{"Hello world"};
   std::string response_body_{"OK\n"};
 #ifdef ENVOY_ENABLE_HTTP_DATAGRAMS
@@ -346,7 +346,7 @@ TEST_F(EnvoyQuicClientStreamTest, PostRequestAnd1xx) {
   // Receive several 10x headers, only the first 100 Continue header should be
   // delivered.
   for (const std::string status : {"100", "199", "100"}) {
-    spdy::Http2HeaderBlock continue_header;
+    quiche::HttpHeaderBlock continue_header;
     continue_header[":status"] = status;
     continue_header["i"] = absl::StrCat("", i++);
     std::string data = spdyHeaderToHttp3StreamPayload(continue_header);
@@ -365,7 +365,7 @@ TEST_F(EnvoyQuicClientStreamTest, ResetUpon101SwitchProtocol) {
   EXPECT_CALL(stream_callbacks_, onResetStream(Http::StreamResetReason::ProtocolError, _));
   // Receive several 10x headers, only the first 100 Continue header should be
   // delivered.
-  spdy::Http2HeaderBlock continue_header;
+  quiche::HttpHeaderBlock continue_header;
   continue_header[":status"] = "101";
   std::string data = spdyHeaderToHttp3StreamPayload(continue_header);
   quic::QuicStreamFrame frame(stream_id_, false, 0u, data);

--- a/test/common/quic/envoy_quic_h3_fuzz_helper.cc
+++ b/test/common/quic/envoy_quic_h3_fuzz_helper.cc
@@ -25,7 +25,7 @@ public:
   void OnDecoderStreamError(quic::QuicErrorCode, absl::string_view) override{};
 };
 
-static std::string encodeHeaders(const spdy::Http2HeaderBlock& headers) {
+static std::string encodeHeaders(const quiche::HttpHeaderBlock& headers) {
   static Delegate delegate;
   quic::QpackEncoder encoder(&delegate, quic::HuffmanEncoding::kEnabled,
                              quic::CookieCrumbling::kEnabled);
@@ -96,7 +96,7 @@ std::string H3Serializer::serialize(bool unidirectional, uint32_t type, uint32_t
   }
   case H3Frame::kHeaders: {
     const auto& f = h3frame.headers();
-    spdy::Http2HeaderBlock headers;
+    quiche::HttpHeaderBlock headers;
     for (const auto& hdr : f.headers().headers()) {
       headers.AppendValueOrAddHeader(hdr.key(), hdr.value());
     }
@@ -120,7 +120,7 @@ std::string H3Serializer::serialize(bool unidirectional, uint32_t type, uint32_t
   case H3Frame::kPushPromise: {
     const auto& f = h3frame.push_promise();
     uint64_t push_id = f.push_id();
-    spdy::Http2HeaderBlock headers;
+    quiche::HttpHeaderBlock headers;
     for (auto& hdr : f.headers().headers()) {
       headers.AppendValueOrAddHeader(hdr.key(), hdr.value());
     }

--- a/test/common/quic/envoy_quic_server_stream_test.cc
+++ b/test/common/quic/envoy_quic_server_stream_test.cc
@@ -128,7 +128,7 @@ public:
           EXPECT_FALSE(capsule_protocol.empty());
           EXPECT_EQ(capsule_protocol[0]->value().getStringView(), "?1");
         }));
-    spdy::Http2HeaderBlock request_headers;
+    quiche::HttpHeaderBlock request_headers;
     request_headers[":authority"] = host_;
     request_headers[":method"] = "CONNECT";
     request_headers[":protocol"] = "connect-udp";
@@ -232,10 +232,10 @@ protected:
   EnvoyQuicServerStream* quic_stream_;
   Http::MockRequestDecoder stream_decoder_;
   Http::MockStreamCallbacks stream_callbacks_;
-  spdy::Http2HeaderBlock spdy_request_headers_;
+  quiche::HttpHeaderBlock spdy_request_headers_;
   Http::TestResponseHeaderMapImpl response_headers_;
   Http::TestResponseTrailerMapImpl response_trailers_;
-  spdy::Http2HeaderBlock spdy_trailers_;
+  quiche::HttpHeaderBlock spdy_trailers_;
   std::string host_{"www.abc.com"};
   std::string request_body_{"Hello world"};
 #ifdef ENVOY_ENABLE_HTTP_DATAGRAMS
@@ -263,7 +263,7 @@ TEST_F(EnvoyQuicServerStreamTest, GetRequestAndResponse) {
                   headers->get(Http::Headers::get().Cookie)[0]->value().getStringView());
       }));
   EXPECT_CALL(stream_decoder_, decodeData(BufferStringEqual(""), /*end_stream=*/true));
-  spdy::Http2HeaderBlock spdy_headers;
+  quiche::HttpHeaderBlock spdy_headers;
   spdy_headers[":authority"] = host_;
   spdy_headers[":method"] = "GET";
   spdy_headers[":path"] = "/";
@@ -710,7 +710,7 @@ TEST_F(EnvoyQuicServerStreamTest, RequestHeaderTooLarge) {
   EXPECT_CALL(quic_session_, MaybeSendStopSendingFrame(_, _));
   EXPECT_CALL(quic_session_, MaybeSendRstStreamFrame(_, _, _));
   EXPECT_CALL(stream_callbacks_, onResetStream(Http::StreamResetReason::LocalReset, _));
-  spdy::Http2HeaderBlock spdy_headers;
+  quiche::HttpHeaderBlock spdy_headers;
   spdy_headers[":authority"] = host_;
   spdy_headers[":method"] = "POST";
   spdy_headers[":path"] = "/";
@@ -734,7 +734,7 @@ TEST_F(EnvoyQuicServerStreamTest, RequestTrailerTooLarge) {
   EXPECT_CALL(quic_session_, MaybeSendStopSendingFrame(_, _));
   EXPECT_CALL(quic_session_, MaybeSendRstStreamFrame(_, _, _));
   EXPECT_CALL(stream_callbacks_, onResetStream(Http::StreamResetReason::LocalReset, _));
-  spdy::Http2HeaderBlock spdy_trailers;
+  quiche::HttpHeaderBlock spdy_trailers;
   // This header exceeds max header size limit and should cause stream reset.
   spdy_trailers["long_header"] = std::string(16 * 1024 + 1, 'a');
   std::string payload = spdyHeaderToHttp3StreamPayload(spdy_trailers);
@@ -896,7 +896,7 @@ TEST_F(EnvoyQuicServerStreamTest, DecodeHttp3Datagram) {
 #endif
 
 TEST_F(EnvoyQuicServerStreamTest, RegularHeaderBeforePseudoHeader) {
-  spdy::Http2HeaderBlock spdy_headers;
+  quiche::HttpHeaderBlock spdy_headers;
   spdy_headers["foo"] = "bar";
   spdy_headers[":authority"] = host_;
   spdy_headers[":method"] = "GET";

--- a/test/common/quic/envoy_quic_utils_test.cc
+++ b/test/common/quic/envoy_quic_utils_test.cc
@@ -45,7 +45,7 @@ public:
 };
 
 TEST(EnvoyQuicUtilsTest, HeadersConversion) {
-  spdy::Http2HeaderBlock headers_block;
+  quiche::HttpHeaderBlock headers_block;
   headers_block[":authority"] = "www.google.com";
   headers_block[":path"] = "/index.hml";
   headers_block[":scheme"] = "https";
@@ -118,7 +118,7 @@ TEST(EnvoyQuicUtilsTest, HeadersConversion) {
 }
 
 TEST(EnvoyQuicUtilsTest, HeadersSizeBounds) {
-  spdy::Http2HeaderBlock headers_block;
+  quiche::HttpHeaderBlock headers_block;
   headers_block[":authority"] = "www.google.com";
   headers_block[":path"] = "/index.hml";
   headers_block[":scheme"] = "https";
@@ -139,7 +139,7 @@ TEST(EnvoyQuicUtilsTest, HeadersSizeBounds) {
 }
 
 TEST(EnvoyQuicUtilsTest, TrailersSizeBounds) {
-  spdy::Http2HeaderBlock headers_block;
+  quiche::HttpHeaderBlock headers_block;
   headers_block[":authority"] = "www.google.com";
   headers_block[":path"] = "/index.hml";
   headers_block[":scheme"] = "https";
@@ -158,7 +158,7 @@ TEST(EnvoyQuicUtilsTest, TrailersSizeBounds) {
 }
 
 TEST(EnvoyQuicUtilsTest, TrailerCharacters) {
-  spdy::Http2HeaderBlock headers_block;
+  quiche::HttpHeaderBlock headers_block;
   headers_block[":authority"] = "www.google.com";
   headers_block[":path"] = "/index.hml";
   headers_block[":scheme"] = "https";
@@ -244,7 +244,7 @@ TEST(EnvoyQuicUtilsTest, HeaderMapMaxSizeLimit) {
   EXPECT_EQ(response_header->maxHeadersCount(), 100);
   EXPECT_EQ(response_header->maxHeadersKb(), 60);
 
-  spdy::Http2HeaderBlock headers_block;
+  quiche::HttpHeaderBlock headers_block;
   headers_block[":authority"] = "www.google.com";
   headers_block[":path"] = "/index.hml";
   headers_block[":scheme"] = "https";

--- a/test/common/quic/test_utils.h
+++ b/test/common/quic/test_utils.h
@@ -274,7 +274,7 @@ void setQuicConfigWithDefaultValues(quic::QuicConfig* config) {
       config, quic::kMinimumFlowControlSendWindow);
 }
 
-std::string spdyHeaderToHttp3StreamPayload(const spdy::Http2HeaderBlock& header) {
+std::string spdyHeaderToHttp3StreamPayload(const quiche::HttpHeaderBlock& header) {
   quic::test::NoopQpackStreamSenderDelegate encoder_stream_sender_delegate;
   quic::NoopDecoderStreamErrorDelegate decoder_stream_error_delegate;
   auto qpack_encoder = std::make_unique<quic::QpackEncoder>(&decoder_stream_error_delegate,


### PR DESCRIPTION
spdy::Http2HeaderBlock is just an alias for quiche::HttpHeaderBlock.

Commit Message: removes more references to spdy::Http2HeaderBlock
Additional Description:
Risk Level: none
Testing: ran unit and integration tests locally
Docs Changes:
Release Notes:
Platform Specific Features:
