### PR TITLE
Typo in documentation of http original_src filter

### DIFF
--- a/docs/root/configuration/http/http_filters/original_src_filter.rst
+++ b/docs/root/configuration/http/http_filters/original_src_filter.rst
@@ -70,7 +70,7 @@ The following example configures Envoy to use the original source for all connec
   http_filters:
     - name: envoy.filters.http.original_src
       typed_config:
-        "@type": type.googleapis.com/envoy.extensions.filters.listener.original_src.v3.OriginalSrc
+        "@type": type.googleapis.com/envoy.extensions.filters.http.original_src.v3.OriginalSrc
         mark: 123
     - name: envoy.filters.http.router
       typed_config:


### PR DESCRIPTION
The doc is about http original_src filter while in the example, the listed type is that of listener filter.
![image](https://github.com/user-attachments/assets/a6e6e473-9d02-4e92-a9e7-3f3bca7291ab)

Existing example will result in following error:
Didn't find a registered implementation for 'envoy.filters.http.original_src' with type URL: 'envoy.extensions.filters.listener.original_src.v3.OriginalSrc'

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Typo in documentation of http original_src filter
Additional Description:
Risk Level: Low
Testing: Locally
Docs Changes: Yes
Release Notes: Typo in documentation of http original_src filter
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
