### PR TITLE
Backport #34322 to release/v1.29.

### DIFF
--- a/api/envoy/config/listener/v3/listener.proto
+++ b/api/envoy/config/listener/v3/listener.proto
@@ -53,7 +53,7 @@ message ListenerCollection {
   repeated xds.core.v3.CollectionEntry entries = 1;
 }
 
-// [#next-free-field: 35]
+// [#next-free-field: 36]
 message Listener {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.Listener";
 
@@ -387,6 +387,9 @@ message Listener {
   // Whether the listener should limit connections based upon the value of
   // :ref:`global_downstream_max_connections <config_overload_manager_limiting_connections>`.
   bool ignore_global_conn_limit = 31;
+
+  // Whether the listener bypasses configured overload manager actions.
+  bool bypass_overload_manager = 35;
 }
 
 // A placeholder proto so that users can explicitly configure the standard

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -16,5 +16,9 @@ removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`
 
 new_features:
+- area: listener
+  change: |
+    Added :ref:`bypass_overload_manager <envoy_v3_api_field_config.listener.v3.Listener.bypass_overload_manager>`
+    to bypass the overload manager for a listener. When set to true, the listener will not be subject to overload protection.
 
 deprecated:

--- a/envoy/network/listener.h
+++ b/envoy/network/listener.h
@@ -162,6 +162,11 @@ public:
    * @return whether the listener is a Quic listener.
    */
   virtual bool isQuic() const PURE;
+
+  /**
+   * @return bool whether the listener should bypass overload manager actions
+   */
+  virtual bool shouldBypassOverloadManager() const PURE;
 };
 
 using ListenerInfoConstSharedPtr = std::shared_ptr<const ListenerInfo>;
@@ -291,6 +296,11 @@ public:
    * limit.
    */
   virtual bool ignoreGlobalConnLimit() const PURE;
+
+  /**
+   * @return bool whether the listener should bypass overload manager actions
+   */
+  virtual bool shouldBypassOverloadManager() const PURE;
 };
 
 /**
@@ -467,6 +477,11 @@ public:
    */
   virtual void
   configureLoadShedPoints(Server::LoadShedPointProvider& load_shed_point_provider) PURE;
+
+  /**
+   * Check whether the listener should bypass overload manager actions
+   */
+  virtual bool shouldBypassOverloadManager() const PURE;
 };
 
 using ListenerPtr = std::unique_ptr<Listener>;

--- a/envoy/server/factory_context.h
+++ b/envoy/server/factory_context.h
@@ -192,6 +192,12 @@ public:
   virtual OverloadManager& overloadManager() PURE;
 
   /**
+   * @return NullOverloadManager& the dummy overload manager for the server for
+   * listeners that are bypassing a configured OverloadManager
+   */
+  virtual OverloadManager& nullOverloadManager() PURE;
+
+  /**
    * @return whether external healthchecks are currently failed or not.
    */
   virtual bool healthCheckFailed() const PURE;

--- a/envoy/server/instance.h
+++ b/envoy/server/instance.h
@@ -145,6 +145,11 @@ public:
   virtual OverloadManager& overloadManager() PURE;
 
   /**
+   * @return the server's null overload manager in case we want to skip overloading the server.
+   */
+  virtual OverloadManager& nullOverloadManager() PURE;
+
+  /**
    * @return the server's secret manager
    */
   virtual Secret::SecretManager& secretManager() PURE;

--- a/envoy/server/worker.h
+++ b/envoy/server/worker.h
@@ -107,10 +107,13 @@ public:
   /**
    * @param index supplies the index of the worker, in the range of [0, concurrency).
    * @param overload_manager supplies the server's overload manager.
+   * @param null_overload_manager supplies the server's null overload manager for conditions where
+   * overload manager is disabled.
    * @param worker_name supplies the name of the worker, used for per-worker stats.
    * @return WorkerPtr a new worker.
    */
   virtual WorkerPtr createWorker(uint32_t index, OverloadManager& overload_manager,
+                                 OverloadManager& null_overload_manager,
                                  const std::string& worker_name) PURE;
 };
 

--- a/mobile/library/common/engine_common.cc
+++ b/mobile/library/common/engine_common.cc
@@ -62,6 +62,9 @@ public:
   std::unique_ptr<Envoy::Server::OverloadManager> createOverloadManager() override {
     return std::make_unique<Envoy::Server::NullOverloadManager>(threadLocal(), true);
   }
+  std::unique_ptr<Envoy::Server::OverloadManager> createNullOverloadManager() override {
+    return std::make_unique<Envoy::Server::NullOverloadManager>(threadLocal(), true);
+  }
   std::unique_ptr<Server::GuardDog> maybeCreateGuardDog(absl::string_view) override {
     return nullptr;
   }

--- a/source/common/listener_manager/connection_handler_impl.cc
+++ b/source/common/listener_manager/connection_handler_impl.cc
@@ -24,8 +24,10 @@ ConnectionHandlerImpl::ConnectionHandlerImpl(Event::Dispatcher& dispatcher,
 
 ConnectionHandlerImpl::ConnectionHandlerImpl(Event::Dispatcher& dispatcher,
                                              absl::optional<uint32_t> worker_index,
-                                             OverloadManager& overload_manager)
+                                             OverloadManager& overload_manager,
+                                             OverloadManager& null_overload_manager)
     : worker_index_(worker_index), dispatcher_(dispatcher), overload_manager_(overload_manager),
+      null_overload_manager_(null_overload_manager),
       per_handler_stat_prefix_(dispatcher.name() + "."), disable_listeners_(false) {}
 
 void ConnectionHandlerImpl::incNumConnections() { ++num_handler_connections_; }
@@ -74,10 +76,18 @@ void ConnectionHandlerImpl::addListener(absl::optional<uint64_t> overridden_list
         local_registry->createActiveInternalListener(*this, config, dispatcher());
     // TODO(soulxu): support multiple internal addresses in listener in the future.
     ASSERT(config.listenSocketFactories().size() == 1);
-    details->addActiveListener(config, config.listenSocketFactories()[0]->localAddress(),
-                               listener_reject_fraction_, disable_listeners_,
-                               std::move(internal_listener), overload_manager_);
+    details->addActiveListener(
+        config, config.listenSocketFactories()[0]->localAddress(), listener_reject_fraction_,
+        disable_listeners_, std::move(internal_listener),
+        config.shouldBypassOverloadManager() ? null_overload_manager_ : overload_manager_);
   } else if (config.listenSocketFactories()[0]->socketType() == Network::Socket::Type::Stream) {
+    auto overload_state =
+        config.shouldBypassOverloadManager()
+            ? (null_overload_manager_
+                   ? makeOptRef(null_overload_manager_->getThreadLocalOverloadState())
+                   : absl::nullopt)
+            : (overload_manager_ ? makeOptRef(overload_manager_->getThreadLocalOverloadState())
+                                 : absl::nullopt);
     for (auto& socket_factory : config.listenSocketFactories()) {
       auto address = socket_factory->localAddress();
       // worker_index_ doesn't have a value on the main thread for the admin server.
@@ -86,10 +96,8 @@ void ConnectionHandlerImpl::addListener(absl::optional<uint64_t> overridden_list
           std::make_unique<ActiveTcpListener>(
               *this, config, runtime, random,
               socket_factory->getListenSocket(worker_index_.has_value() ? *worker_index_ : 0),
-              address, config.connectionBalancer(*address),
-              overload_manager_ ? makeOptRef(overload_manager_->getThreadLocalOverloadState())
-                                : absl::nullopt),
-          overload_manager_);
+              address, config.connectionBalancer(*address), overload_state),
+          config.shouldBypassOverloadManager() ? null_overload_manager_ : overload_manager_);
     }
   } else {
     ASSERT(config.udpListenerConfig().has_value(), "UDP listener factory is not initialized.");
@@ -101,7 +109,7 @@ void ConnectionHandlerImpl::addListener(absl::optional<uint64_t> overridden_list
           config.udpListenerConfig()->listenerFactory().createActiveUdpListener(
               runtime, *worker_index_, *this, socket_factory->getListenSocket(*worker_index_),
               dispatcher_, config),
-          overload_manager_);
+          config.shouldBypassOverloadManager() ? null_overload_manager_ : overload_manager_);
     }
   }
 
@@ -271,7 +279,7 @@ void ConnectionHandlerImpl::disableListeners() {
   disable_listeners_ = true;
   for (auto& iter : listener_map_by_tag_) {
     iter.second->invokeListenerMethod([](Network::ConnectionHandler::ActiveListener& listener) {
-      if (listener.listener() != nullptr) {
+      if (listener.listener() != nullptr && !listener.listener()->shouldBypassOverloadManager()) {
         listener.pauseListening();
       }
     });
@@ -282,7 +290,7 @@ void ConnectionHandlerImpl::enableListeners() {
   disable_listeners_ = false;
   for (auto& iter : listener_map_by_tag_) {
     iter.second->invokeListenerMethod([](Network::ConnectionHandler::ActiveListener& listener) {
-      if (listener.listener() != nullptr) {
+      if (listener.listener() != nullptr && !listener.listener()->shouldBypassOverloadManager()) {
         listener.resumeListening();
       }
     });
@@ -292,12 +300,12 @@ void ConnectionHandlerImpl::enableListeners() {
 void ConnectionHandlerImpl::setListenerRejectFraction(UnitFloat reject_fraction) {
   listener_reject_fraction_ = reject_fraction;
   for (auto& iter : listener_map_by_tag_) {
-    iter.second->invokeListenerMethod(
-        [&reject_fraction](Network::ConnectionHandler::ActiveListener& listener) {
-          if (listener.listener() != nullptr) {
-            listener.listener()->setRejectFraction(reject_fraction);
-          }
-        });
+    iter.second->invokeListenerMethod([&reject_fraction](
+                                          Network::ConnectionHandler::ActiveListener& listener) {
+      if (listener.listener() != nullptr && !listener.listener()->shouldBypassOverloadManager()) {
+        listener.listener()->setRejectFraction(reject_fraction);
+      }
+    });
   }
 }
 
@@ -357,8 +365,8 @@ Network::ListenerPtr ConnectionHandlerImpl::createListener(
     Server::ThreadLocalOverloadStateOptRef overload_state) {
   return std::make_unique<Network::TcpListenerImpl>(
       dispatcher(), random, runtime, std::move(socket), cb, config.bindToPort(),
-      config.ignoreGlobalConnLimit(), config.maxConnectionsToAcceptPerSocketEvent(),
-      overload_state);
+      config.ignoreGlobalConnLimit(), config.shouldBypassOverloadManager(),
+      config.maxConnectionsToAcceptPerSocketEvent(), overload_state);
 }
 
 Network::BalancedConnectionHandlerOptRef

--- a/source/common/listener_manager/connection_handler_impl.h
+++ b/source/common/listener_manager/connection_handler_impl.h
@@ -38,7 +38,7 @@ public:
 
   ConnectionHandlerImpl(Event::Dispatcher& dispatcher, absl::optional<uint32_t> worker_index);
   ConnectionHandlerImpl(Event::Dispatcher& dispatcher, absl::optional<uint32_t> worker_index,
-                        OverloadManager& overload_manager);
+                        OverloadManager& overload_manager, OverloadManager& null_overload_manager);
 
   // Network::ConnectionHandler
   uint64_t numConnections() const override { return num_handler_connections_; }
@@ -154,6 +154,7 @@ private:
   const absl::optional<uint32_t> worker_index_;
   Event::Dispatcher& dispatcher_;
   OptRef<OverloadManager> overload_manager_;
+  OptRef<OverloadManager> null_overload_manager_;
   const std::string per_handler_stat_prefix_;
   // Declare before its users ActiveListenerDetails.
   std::atomic<uint64_t> num_handler_connections_{};
@@ -171,8 +172,10 @@ class ConnectionHandlerFactoryImpl : public ConnectionHandlerFactory {
 public:
   std::unique_ptr<ConnectionHandler>
   createConnectionHandler(Event::Dispatcher& dispatcher, absl::optional<uint32_t> worker_index,
-                          OverloadManager& overload_manager) override {
-    return std::make_unique<ConnectionHandlerImpl>(dispatcher, worker_index, overload_manager);
+                          OverloadManager& overload_manager,
+                          OverloadManager& null_overload_manager) override {
+    return std::make_unique<ConnectionHandlerImpl>(dispatcher, worker_index, overload_manager,
+                                                   null_overload_manager);
   }
   std::unique_ptr<ConnectionHandler>
   createConnectionHandler(Event::Dispatcher& dispatcher,

--- a/source/common/listener_manager/listener_impl.cc
+++ b/source/common/listener_manager/listener_impl.cc
@@ -266,6 +266,7 @@ ListenerImpl::ListenerImpl(const envoy::config::listener::v3::Listener& config,
           added_via_api_ ? parent_.server_.messageValidationContext().dynamicValidationVisitor()
                          : parent_.server_.messageValidationContext().staticValidationVisitor()),
       ignore_global_conn_limit_(config.ignore_global_conn_limit()),
+      bypass_overload_manager_(config.bypass_overload_manager()),
       listener_init_target_(fmt::format("Listener-init-target {}", name),
                             [this]() { dynamic_init_manager_->initialize(local_init_watcher_); }),
       dynamic_init_manager_(std::make_unique<Init::ManagerImpl>(
@@ -400,6 +401,7 @@ ListenerImpl::ListenerImpl(ListenerImpl& origin,
           added_via_api_ ? parent_.server_.messageValidationContext().dynamicValidationVisitor()
                          : parent_.server_.messageValidationContext().staticValidationVisitor()),
       ignore_global_conn_limit_(config.ignore_global_conn_limit()),
+      bypass_overload_manager_(config.bypass_overload_manager()),
       // listener_init_target_ is not used during in place update because we expect server started.
       listener_init_target_("", nullptr),
       dynamic_init_manager_(std::make_unique<Init::ManagerImpl>(

--- a/source/common/listener_manager/listener_impl.h
+++ b/source/common/listener_manager/listener_impl.h
@@ -316,6 +316,7 @@ public:
   }
   Init::Manager& initManager() override;
   bool ignoreGlobalConnLimit() const override { return ignore_global_conn_limit_; }
+  bool shouldBypassOverloadManager() const override { return bypass_overload_manager_; }
   const Network::ListenerInfoConstSharedPtr& listenerInfo() const override {
     ASSERT(listener_factory_context_ != nullptr);
     return listener_factory_context_->listener_factory_context_base_->listener_info_;
@@ -430,6 +431,7 @@ private:
   const uint32_t max_connections_to_accept_per_socket_event_;
   ProtobufMessage::ValidationVisitor& validation_visitor_;
   const bool ignore_global_conn_limit_;
+  const bool bypass_overload_manager_;
 
   // A target is added to Server's InitManager if workers_started_ is false.
   Init::TargetImpl listener_init_target_;

--- a/source/common/listener_manager/listener_info_impl.h
+++ b/source/common/listener_manager/listener_info_impl.h
@@ -15,19 +15,22 @@ class ListenerInfoImpl : public Network::ListenerInfo {
 public:
   explicit ListenerInfoImpl(const envoy::config::listener::v3::Listener& config)
       : metadata_(config.metadata()), direction_(config.traffic_direction()),
-        is_quic_(config.udp_listener_config().has_quic_options()) {}
+        is_quic_(config.udp_listener_config().has_quic_options()),
+        bypass_overload_manager_(config.bypass_overload_manager()) {}
   ListenerInfoImpl() = default;
 
   // Network::ListenerInfo
   const envoy::config::core::v3::Metadata& metadata() const override;
   const Envoy::Config::TypedMetadata& typedMetadata() const override;
   envoy::config::core::v3::TrafficDirection direction() const override { return direction_; }
+  bool shouldBypassOverloadManager() const override { return bypass_overload_manager_; };
   bool isQuic() const override { return is_quic_; }
 
 private:
   const ListenerMetadataPack metadata_;
   const envoy::config::core::v3::TrafficDirection direction_{};
   const bool is_quic_{};
+  const bool bypass_overload_manager_{};
 };
 
 } // namespace Server

--- a/source/common/listener_manager/listener_manager_impl.cc
+++ b/source/common/listener_manager/listener_manager_impl.cc
@@ -364,8 +364,8 @@ ListenerManagerImpl::ListenerManagerImpl(Instance& server,
   }
 
   for (uint32_t i = 0; i < server.options().concurrency(); i++) {
-    workers_.emplace_back(
-        worker_factory.createWorker(i, server.overloadManager(), absl::StrCat("worker_", i)));
+    workers_.emplace_back(worker_factory.createWorker(
+        i, server.overloadManager(), server.nullOverloadManager(), absl::StrCat("worker_", i)));
   }
 }
 

--- a/source/common/network/tcp_listener_impl.cc
+++ b/source/common/network/tcp_listener_impl.cc
@@ -118,12 +118,13 @@ void TcpListenerImpl::onSocketEvent(short flags) {
 TcpListenerImpl::TcpListenerImpl(Event::Dispatcher& dispatcher, Random::RandomGenerator& random,
                                  Runtime::Loader& runtime, SocketSharedPtr socket,
                                  TcpListenerCallbacks& cb, bool bind_to_port,
-                                 bool ignore_global_conn_limit,
+                                 bool ignore_global_conn_limit, bool bypass_overload_manager,
                                  uint32_t max_connections_to_accept_per_socket_event,
                                  Server::ThreadLocalOverloadStateOptRef overload_state)
     : BaseListenerImpl(dispatcher, std::move(socket)), cb_(cb), random_(random), runtime_(runtime),
       bind_to_port_(bind_to_port), reject_fraction_(0.0),
       ignore_global_conn_limit_(ignore_global_conn_limit),
+      bypass_overload_manager_(bypass_overload_manager),
       max_connections_to_accept_per_socket_event_(max_connections_to_accept_per_socket_event),
       overload_state_(overload_state),
       track_global_cx_limit_in_overload_manager_(
@@ -169,6 +170,8 @@ void TcpListenerImpl::configureLoadShedPoints(
       trace, listener_accept_ == nullptr,
       "LoadShedPoint envoy.load_shed_points.tcp_listener_accept is not found. Is it configured?");
 }
+
+bool TcpListenerImpl::shouldBypassOverloadManager() const { return bypass_overload_manager_; }
 
 } // namespace Network
 } // namespace Envoy

--- a/source/common/network/tcp_listener_impl.h
+++ b/source/common/network/tcp_listener_impl.h
@@ -18,7 +18,7 @@ class TcpListenerImpl : public BaseListenerImpl {
 public:
   TcpListenerImpl(Event::Dispatcher& dispatcher, Random::RandomGenerator& random,
                   Runtime::Loader& runtime, SocketSharedPtr socket, TcpListenerCallbacks& cb,
-                  bool bind_to_port, bool ignore_global_conn_limit,
+                  bool bind_to_port, bool ignore_global_conn_limit, bool bypass_overload_manager,
                   uint32_t max_connections_to_accept_per_socket_event,
                   Server::ThreadLocalOverloadStateOptRef overload_state);
   ~TcpListenerImpl() override {
@@ -30,6 +30,7 @@ public:
   void enable() override;
   void setRejectFraction(UnitFloat reject_fraction) override;
   void configureLoadShedPoints(Server::LoadShedPointProvider& load_shed_point_provider) override;
+  bool shouldBypassOverloadManager() const override;
 
 protected:
   TcpListenerCallbacks& cb_;
@@ -46,6 +47,7 @@ private:
   bool bind_to_port_;
   UnitFloat reject_fraction_;
   const bool ignore_global_conn_limit_;
+  const bool bypass_overload_manager_;
   const uint32_t max_connections_to_accept_per_socket_event_;
   Server::LoadShedPoint* listener_accept_{nullptr};
   Server::ThreadLocalOverloadStateOptRef overload_state_;

--- a/source/common/network/udp_listener_impl.h
+++ b/source/common/network/udp_listener_impl.h
@@ -32,6 +32,7 @@ public:
   void enable() override;
   void setRejectFraction(UnitFloat) override {}
   void configureLoadShedPoints(Server::LoadShedPointProvider&) override {}
+  bool shouldBypassOverloadManager() const override { return false; }
 
   // Network::UdpListener
   Event::Dispatcher& dispatcher() override;

--- a/source/extensions/bootstrap/internal_listener/active_internal_listener.h
+++ b/source/extensions/bootstrap/internal_listener/active_internal_listener.h
@@ -52,6 +52,7 @@ public:
 
     void setRejectFraction(UnitFloat) override {}
     void configureLoadShedPoints(Server::LoadShedPointProvider&) override {}
+    bool shouldBypassOverloadManager() const override { return false; }
   };
 
   // Network::TcpConnectionHandler

--- a/source/extensions/filters/network/http_connection_manager/config.cc
+++ b/source/extensions/filters/network/http_connection_manager/config.cc
@@ -279,11 +279,14 @@ HttpConnectionManagerFilterConfigFactory::createFilterFactoryFromProtoAndHopByHo
   return [singletons, filter_config, &context,
           clear_hop_by_hop_headers](Network::FilterManager& filter_manager) -> void {
     auto& server_context = context.serverFactoryContext();
+    Server::OverloadManager& overload_manager = context.listenerInfo().shouldBypassOverloadManager()
+                                                    ? server_context.nullOverloadManager()
+                                                    : server_context.overloadManager();
 
     auto hcm = std::make_shared<Http::ConnectionManagerImpl>(
         *filter_config, context.drainDecision(), server_context.api().randomGenerator(),
         server_context.httpContext(), server_context.runtime(), server_context.localInfo(),
-        server_context.clusterManager(), server_context.overloadManager(),
+        server_context.clusterManager(), overload_manager,
         server_context.mainThreadDispatcher().timeSource());
     if (!clear_hop_by_hop_headers) {
       hcm->setClearHopByHopResponseHeaders(false);
@@ -811,11 +814,14 @@ HttpConnectionManagerFactory::createHttpConnectionManagerFactoryFromProto(
   return [singletons, filter_config, &context, clear_hop_by_hop_headers](
              Network::ReadFilterCallbacks& read_callbacks) -> Http::ApiListenerPtr {
     auto& server_context = context.serverFactoryContext();
+    Server::OverloadManager& overload_manager = context.listenerInfo().shouldBypassOverloadManager()
+                                                    ? server_context.nullOverloadManager()
+                                                    : server_context.overloadManager();
 
     auto conn_manager = std::make_unique<Http::ConnectionManagerImpl>(
         *filter_config, context.drainDecision(), server_context.api().randomGenerator(),
         server_context.httpContext(), server_context.runtime(), server_context.localInfo(),
-        server_context.clusterManager(), server_context.overloadManager(),
+        server_context.clusterManager(), overload_manager,
         server_context.mainThreadDispatcher().timeSource());
     if (!clear_hop_by_hop_headers) {
       conn_manager->setClearHopByHopResponseHeaders(false);

--- a/source/server/BUILD
+++ b/source/server/BUILD
@@ -476,6 +476,7 @@ envoy_cc_library(
         ":guarddog_lib",
         ":server_base_lib",
         "//source/common/memory:heap_shrinker_lib",
+        "//source/server:null_overload_manager_lib",
         "//source/server:overload_manager_lib",
     ],
 )

--- a/source/server/admin/admin.cc
+++ b/source/server/admin/admin.cc
@@ -282,8 +282,8 @@ bool AdminImpl::createNetworkFilterChain(Network::Connection& connection,
   // Pass in the null overload manager so that the admin interface is accessible even when Envoy
   // is overloaded.
   connection.addReadFilter(Network::ReadFilterSharedPtr{new Http::ConnectionManagerImpl(
-      shared_from_this(), server_.drainManager(), server_.api().randomGenerator(),
-      server_.httpContext(), server_.runtime(), server_.localInfo(), server_.clusterManager(),
+      *this, server_.drainManager(), server_.api().randomGenerator(), server_.httpContext(),
+      server_.runtime(), server_.localInfo(), server_.clusterManager(),
       server_.nullOverloadManager(), server_.timeSource())});
   return true;
 }

--- a/source/server/admin/admin.cc
+++ b/source/server/admin/admin.cc
@@ -55,7 +55,6 @@ void AdminImpl::startHttpListener(std::list<AccessLog::InstanceSharedPtr> access
                                   Network::Socket::OptionsSharedPtr socket_options) {
   access_logs_ = std::move(access_logs);
 
-  null_overload_manager_.start();
   socket_ = std::make_shared<Network::TcpListenSocket>(address, socket_options, true);
   RELEASE_ASSERT(0 == socket_->ioHandle().listen(ENVOY_TCP_BACKLOG_SIZE).return_value_,
                  "listen() failed on admin listener");
@@ -114,7 +113,7 @@ AdminImpl::AdminImpl(const std::string& profile_path, Server::Instance& server,
           server_.api().randomGenerator())),
       profile_path_(profile_path), stats_(Http::ConnectionManagerImpl::generateStats(
                                        "http.admin.", *server_.stats().rootScope())),
-      null_overload_manager_(server_.threadLocal(), false),
+      null_overload_manager_(server.threadLocal(), false),
       tracing_stats_(Http::ConnectionManagerImpl::generateTracingStats("http.admin.",
                                                                        *no_op_store_.rootScope())),
       route_config_provider_(server.timeSource()),
@@ -283,9 +282,9 @@ bool AdminImpl::createNetworkFilterChain(Network::Connection& connection,
   // Pass in the null overload manager so that the admin interface is accessible even when Envoy
   // is overloaded.
   connection.addReadFilter(Network::ReadFilterSharedPtr{new Http::ConnectionManagerImpl(
-      *this, server_.drainManager(), server_.api().randomGenerator(), server_.httpContext(),
-      server_.runtime(), server_.localInfo(), server_.clusterManager(), null_overload_manager_,
-      server_.timeSource())});
+      shared_from_this(), server_.drainManager(), server_.api().randomGenerator(),
+      server_.httpContext(), server_.runtime(), server_.localInfo(), server_.clusterManager(),
+      server_.nullOverloadManager(), server_.timeSource())});
   return true;
 }
 

--- a/source/server/admin/admin.h
+++ b/source/server/admin/admin.h
@@ -407,6 +407,7 @@ private:
     }
     Init::Manager& initManager() override { return *init_manager_; }
     bool ignoreGlobalConnLimit() const override { return ignore_global_conn_limit_; }
+    bool shouldBypassOverloadManager() const override { return true; }
 
     AdminImpl& parent_;
     const std::string name_;

--- a/source/server/config_validation/BUILD
+++ b/source/server/config_validation/BUILD
@@ -102,6 +102,7 @@ envoy_cc_library(
         "//source/common/version:version_lib",
         "//source/server:configuration_lib",
         "//source/server:hot_restart_nop_lib",
+        "//source/server:null_overload_manager_lib",
         "//source/server:overload_manager_lib",
         "//source/server:server_lib",
         "//source/server:utils_lib",

--- a/source/server/config_validation/server.cc
+++ b/source/server/config_validation/server.cc
@@ -15,6 +15,7 @@
 #include "source/common/version/version.h"
 #include "source/server/admin/admin_factory_context.h"
 #include "source/server/listener_manager_factory.h"
+#include "source/server/null_overload_manager.h"
 #include "source/server/overload_manager_impl.h"
 #include "source/server/regex_engine.h"
 #include "source/server/ssl_context_manager.h"
@@ -112,6 +113,7 @@ void ValidationInstance::initialize(const Options& options,
   overload_manager_ = std::make_unique<OverloadManagerImpl>(
       dispatcher(), *stats().rootScope(), threadLocal(), bootstrap_.overload_manager(),
       messageValidationContext().staticValidationVisitor(), *api_, options_);
+  null_overload_manager_ = std::make_unique<NullOverloadManager>(threadLocal(), false);
   Configuration::InitialImpl initial_config(bootstrap_);
   AdminFactoryContext factory_context(*this, std::make_shared<ListenerInfoImpl>());
   initial_config.initAdminAccessLog(bootstrap_, factory_context);

--- a/source/server/config_validation/server.h
+++ b/source/server/config_validation/server.h
@@ -103,6 +103,7 @@ public:
   void shutdownAdmin() override {}
   Singleton::Manager& singletonManager() override { return *singleton_manager_; }
   OverloadManager& overloadManager() override { return *overload_manager_; }
+  OverloadManager& nullOverloadManager() override { return *null_overload_manager_; }
   bool healthCheckFailed() override { return false; }
   const Options& options() override { return options_; }
   time_t startTimeCurrentEpoch() override { PANIC("not implemented"); }
@@ -134,7 +135,8 @@ public:
   void setSinkPredicates(std::unique_ptr<Stats::SinkPredicates>&&) override {}
 
   // Server::WorkerFactory
-  WorkerPtr createWorker(uint32_t, OverloadManager&, const std::string&) override {
+  WorkerPtr createWorker(uint32_t, OverloadManager&, OverloadManager&,
+                         const std::string&) override {
     // Returned workers are not currently used so we can return nothing here safely vs. a
     // validation mock.
     return nullptr;
@@ -184,6 +186,7 @@ private:
   std::unique_ptr<Upstream::ValidationClusterManagerFactory> cluster_manager_factory_;
   std::unique_ptr<ListenerManager> listener_manager_;
   std::unique_ptr<OverloadManager> overload_manager_;
+  std::unique_ptr<OverloadManager> null_overload_manager_;
   MutexTracer* mutex_tracer_{nullptr};
   Grpc::ContextImpl grpc_context_;
   Http::ContextImpl http_context_;

--- a/source/server/instance_impl.cc
+++ b/source/server/instance_impl.cc
@@ -1,6 +1,7 @@
 #include "source/server/instance_impl.h"
 
 #include "source/server/guarddog_impl.h"
+#include "source/server/null_overload_manager.h"
 #include "source/server/overload_manager_impl.h"
 
 namespace Envoy {
@@ -14,6 +15,10 @@ std::unique_ptr<OverloadManager> InstanceImpl::createOverloadManager() {
   return std::make_unique<OverloadManagerImpl>(
       dispatcher(), *stats().rootScope(), threadLocal(), bootstrap().overload_manager(),
       messageValidationContext().staticValidationVisitor(), api(), options());
+}
+
+std::unique_ptr<OverloadManager> InstanceImpl::createNullOverloadManager() {
+  return std::make_unique<NullOverloadManager>(threadLocal(), false);
 }
 
 std::unique_ptr<Server::GuardDog> InstanceImpl::maybeCreateGuardDog(absl::string_view name) {

--- a/source/server/instance_impl.h
+++ b/source/server/instance_impl.h
@@ -14,6 +14,7 @@ public:
 protected:
   void maybeCreateHeapShrinker() override;
   std::unique_ptr<OverloadManager> createOverloadManager() override;
+  std::unique_ptr<OverloadManager> createNullOverloadManager() override;
   std::unique_ptr<Server::GuardDog> maybeCreateGuardDog(absl::string_view name) override;
 
 private:

--- a/source/server/listener_manager_factory.h
+++ b/source/server/listener_manager_factory.h
@@ -31,7 +31,8 @@ public:
                           absl::optional<uint32_t> worker_index) PURE;
   virtual std::unique_ptr<ConnectionHandler>
   createConnectionHandler(Event::Dispatcher& dispatcher, absl::optional<uint32_t> worker_index,
-                          OverloadManager& overload_manager) PURE;
+                          OverloadManager& overload_manager,
+                          OverloadManager& null_overload_manager) PURE;
 
   std::string category() const override { return "envoy.connection_handler"; }
 };

--- a/source/server/null_overload_manager.h
+++ b/source/server/null_overload_manager.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "envoy/server/overload/overload_manager.h"
+#include "envoy/thread_local/thread_local.h"
 
 #include "source/common/event/scaled_range_timer_manager_impl.h"
 

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -607,6 +607,7 @@ void InstanceBase::initializeOrThrow(Network::Address::InstanceConstSharedPtr lo
 
   // Initialize the overload manager early so other modules can register for actions.
   overload_manager_ = createOverloadManager();
+  null_overload_manager_ = createNullOverloadManager();
 
   maybeCreateHeapShrinker();
 
@@ -865,7 +866,7 @@ void InstanceBase::loadServerFlags(const absl::optional<std::string>& flags_path
 RunHelper::RunHelper(Instance& instance, const Options& options, Event::Dispatcher& dispatcher,
                      Upstream::ClusterManager& cm, AccessLog::AccessLogManager& access_log_manager,
                      Init::Manager& init_manager, OverloadManager& overload_manager,
-                     std::function<void()> post_init_cb)
+                     OverloadManager& null_overload_manager, std::function<void()> post_init_cb)
     : init_watcher_("RunHelper", [&instance, post_init_cb]() {
         if (!instance.isShutdown()) {
           post_init_cb();
@@ -900,6 +901,7 @@ RunHelper::RunHelper(Instance& instance, const Options& options, Event::Dispatch
 
   // Start overload manager before workers.
   overload_manager.start();
+  null_overload_manager.start();
 
   // If there is no global limit to the number of active connections, warn on startup.
   if (!overload_manager.getThreadLocalOverloadState().isResourceMonitorEnabled(
@@ -941,11 +943,12 @@ RunHelper::RunHelper(Instance& instance, const Options& options, Event::Dispatch
 void InstanceBase::run() {
   // RunHelper exists primarily to facilitate testing of how we respond to early shutdown during
   // startup (see RunHelperTest in server_test.cc).
-  const auto run_helper = RunHelper(*this, options_, *dispatcher_, clusterManager(),
-                                    access_log_manager_, init_manager_, overloadManager(), [this] {
-                                      notifyCallbacksForStage(Stage::PostInit);
-                                      startWorkers();
-                                    });
+  const auto run_helper =
+      RunHelper(*this, options_, *dispatcher_, clusterManager(), access_log_manager_, init_manager_,
+                overloadManager(), nullOverloadManager(), [this] {
+                  notifyCallbacksForStage(Stage::PostInit);
+                  startWorkers();
+                });
 
   // Run the main dispatch loop waiting to exit.
   ENVOY_LOG(info, "starting main dispatch loop");

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -155,7 +155,7 @@ public:
   RunHelper(Instance& instance, const Options& options, Event::Dispatcher& dispatcher,
             Upstream::ClusterManager& cm, AccessLog::AccessLogManager& access_log_manager,
             Init::Manager& init_manager, OverloadManager& overload_manager,
-            std::function<void()> workers_start_cb);
+            OverloadManager& null_overload_manager, std::function<void()> workers_start_cb);
 
 private:
   Init::WatcherImpl init_watcher_;
@@ -200,6 +200,7 @@ public:
   Configuration::StatsConfig& statsConfig() override { return server_.statsConfig(); }
   envoy::config::bootstrap::v3::Bootstrap& bootstrap() override { return server_.bootstrap(); }
   OverloadManager& overloadManager() override { return server_.overloadManager(); }
+  OverloadManager& nullOverloadManager() override { return server_.nullOverloadManager(); }
   bool healthCheckFailed() const override { return server_.healthCheckFailed(); }
 
   // Configuration::TransportSocketFactoryContext
@@ -250,6 +251,7 @@ public:
 
   virtual void maybeCreateHeapShrinker() PURE;
   virtual std::unique_ptr<OverloadManager> createOverloadManager() PURE;
+  virtual std::unique_ptr<OverloadManager> createNullOverloadManager() PURE;
   virtual std::unique_ptr<Server::GuardDog> maybeCreateGuardDog(absl::string_view name) PURE;
 
   void run() override;
@@ -273,6 +275,7 @@ public:
   Secret::SecretManager& secretManager() override { return *secret_manager_; }
   Envoy::MutexTracer* mutexTracer() override { return mutex_tracer_; }
   OverloadManager& overloadManager() override { return *overload_manager_; }
+  OverloadManager& nullOverloadManager() override { return *null_overload_manager_; }
   Runtime::Loader& runtime() override;
   void shutdown() override;
   bool isShutdown() final { return shutdown_; }
@@ -400,6 +403,7 @@ private:
   Upstream::ProdClusterInfoFactory info_factory_;
   Upstream::HdsDelegatePtr hds_delegate_;
   std::unique_ptr<OverloadManager> overload_manager_;
+  std::unique_ptr<OverloadManager> null_overload_manager_;
   std::vector<BootstrapExtensionPtr> bootstrap_extensions_;
   Envoy::MutexTracer* mutex_tracer_;
   Grpc::ContextImpl grpc_context_;

--- a/source/server/worker_impl.h
+++ b/source/server/worker_impl.h
@@ -33,6 +33,7 @@ public:
 
   // Server::WorkerFactory
   WorkerPtr createWorker(uint32_t index, OverloadManager& overload_manager,
+                         OverloadManager& null_overload_manager,
                          const std::string& worker_name) override;
 
 private:

--- a/test/common/http/codec_client_test.cc
+++ b/test/common/http/codec_client_test.cc
@@ -501,6 +501,7 @@ public:
     upstream_listener_ = std::make_unique<Network::TcpListenerImpl>(
         *dispatcher_, api_->randomGenerator(), runtime_, std::move(socket), listener_callbacks_,
         listener_config.bindToPort(), listener_config.ignoreGlobalConnLimit(),
+        listener_config.shouldBypassOverloadManager(),
         listener_config.maxConnectionsToAcceptPerSocketEvent(), overload_state);
     client_connection_ = client_connection.get();
     client_connection_->addConnectionCallbacks(client_callbacks_);

--- a/test/common/network/connection_impl_test.cc
+++ b/test/common/network/connection_impl_test.cc
@@ -164,6 +164,7 @@ protected:
     listener_ = std::make_unique<Network::TcpListenerImpl>(
         *dispatcher_, api_->randomGenerator(), runtime_, socket_, listener_callbacks_,
         listener_config.bindToPort(), listener_config.ignoreGlobalConnLimit(),
+        listener_config.shouldBypassOverloadManager(),
         listener_config.maxConnectionsToAcceptPerSocketEvent(), overload_state);
     client_connection_ = std::make_unique<Network::TestClientConnectionImpl>(
         *dispatcher_, socket_->connectionInfoProvider().localAddress(), source_address_,
@@ -1874,6 +1875,7 @@ TEST_P(ConnectionImplTest, BindFailureTest) {
   listener_ = std::make_unique<Network::TcpListenerImpl>(
       *dispatcher_, api_->randomGenerator(), runtime_, socket_, listener_callbacks_,
       listener_config.bindToPort(), listener_config.ignoreGlobalConnLimit(),
+      listener_config.shouldBypassOverloadManager(),
       listener_config.maxConnectionsToAcceptPerSocketEvent(), overload_state);
 
   client_connection_ = dispatcher_->createClientConnection(
@@ -3428,6 +3430,7 @@ public:
     listener_ = std::make_unique<Network::TcpListenerImpl>(
         *dispatcher_, api_->randomGenerator(), runtime_, socket_, listener_callbacks_,
         listener_config.bindToPort(), listener_config.ignoreGlobalConnLimit(),
+        listener_config.shouldBypassOverloadManager(),
         listener_config.maxConnectionsToAcceptPerSocketEvent(), overload_state);
 
     client_connection_ = dispatcher_->createClientConnection(

--- a/test/common/network/listener_impl_test.cc
+++ b/test/common/network/listener_impl_test.cc
@@ -43,6 +43,7 @@ static void errorCallbackTest(Address::IpVersion version) {
   Network::ListenerPtr listener = std::make_unique<Network::TcpListenerImpl>(
       *dispatcher, api->randomGenerator(), runtime, socket, listener_callbacks,
       listener_config.bindToPort(), listener_config.ignoreGlobalConnLimit(),
+      listener_config.shouldBypassOverloadManager(),
       listener_config.maxConnectionsToAcceptPerSocketEvent(), overload_state);
 
   Network::ClientConnectionPtr client_connection = dispatcher->createClientConnection(
@@ -76,19 +77,21 @@ public:
   TestTcpListenerImpl(Event::DispatcherImpl& dispatcher, Random::RandomGenerator& random_generator,
                       Runtime::Loader& runtime, SocketSharedPtr socket, TcpListenerCallbacks& cb,
                       bool bind_to_port, bool ignore_global_conn_limit,
+                      bool bypass_overload_manager,
                       Server::ThreadLocalOverloadStateOptRef overload_state)
       : TestTcpListenerImpl(dispatcher, random_generator, runtime, socket, cb, bind_to_port,
-                            ignore_global_conn_limit,
+                            ignore_global_conn_limit, bypass_overload_manager,
                             Network::DefaultMaxConnectionsToAcceptPerSocketEvent, overload_state) {}
 
   TestTcpListenerImpl(Event::DispatcherImpl& dispatcher, Random::RandomGenerator& random_generator,
                       Runtime::Loader& runtime, SocketSharedPtr socket, TcpListenerCallbacks& cb,
                       bool bind_to_port, bool ignore_global_conn_limit,
+                      bool bypass_overload_manager,
                       uint32_t max_connections_to_accept_per_socket_event,
                       Server::ThreadLocalOverloadStateOptRef overload_state)
       : TcpListenerImpl(dispatcher, random_generator, runtime, socket, cb, bind_to_port,
-                        ignore_global_conn_limit, max_connections_to_accept_per_socket_event,
-                        overload_state) {}
+                        ignore_global_conn_limit, bypass_overload_manager,
+                        max_connections_to_accept_per_socket_event, overload_state) {}
 
   MOCK_METHOD(Address::InstanceConstSharedPtr, getLocalAddress, (os_fd_t fd));
 };
@@ -108,10 +111,11 @@ TEST_P(TcpListenerImplTest, UseActualDst) {
   Server::ThreadLocalOverloadStateOptRef overload_state;
   // Do not redirect since use_original_dst is false.
   Network::TestTcpListenerImpl listener(dispatcherImpl(), random_generator, runtime, socket,
-                                        listener_callbacks1, true, false, overload_state);
+                                        listener_callbacks1, true, false, false, overload_state);
   Network::MockTcpListenerCallbacks listener_callbacks2;
   Network::TestTcpListenerImpl listenerDst(dispatcherImpl(), random_generator, runtime, socketDst,
-                                           listener_callbacks2, false, false, overload_state);
+                                           listener_callbacks2, false, false, false,
+                                           overload_state);
 
   Network::ClientConnectionPtr client_connection = dispatcher_->createClientConnection(
       socket->connectionInfoProvider().localAddress(), Network::Address::InstanceConstSharedPtr(),
@@ -150,6 +154,7 @@ TEST_P(TcpListenerImplTest, GlobalConnectionLimitEnforcement) {
   Network::ListenerPtr listener = std::make_unique<Network::TcpListenerImpl>(
       *dispatcher_, api_->randomGenerator(), scoped_runtime.loader(), socket, listener_callbacks,
       listener_config.bindToPort(), listener_config.ignoreGlobalConnLimit(),
+      listener_config.shouldBypassOverloadManager(),
       listener_config.maxConnectionsToAcceptPerSocketEvent(), overload_state);
 
   std::vector<Network::ClientConnectionPtr> client_connections;
@@ -223,6 +228,7 @@ TEST_P(TcpListenerImplTest, GlobalConnectionLimitListenerOptOut) {
   Network::ListenerPtr listener = std::make_unique<Network::TcpListenerImpl>(
       *dispatcher_, api_->randomGenerator(), scoped_runtime.loader(), socket, listener_callbacks,
       listener_config.bindToPort(), listener_config.ignoreGlobalConnLimit(),
+      listener_config.shouldBypassOverloadManager(),
       listener_config.maxConnectionsToAcceptPerSocketEvent(), overload_state);
 
   std::vector<Network::ClientConnectionPtr> client_connections;
@@ -271,7 +277,7 @@ TEST_P(TcpListenerImplTest, WildcardListenerUseActualDst) {
   Server::ThreadLocalOverloadStateOptRef overload_state;
   // Do not redirect since use_original_dst is false.
   Network::TestTcpListenerImpl listener(dispatcherImpl(), random_generator, runtime, socket,
-                                        listener_callbacks, true, false, overload_state);
+                                        listener_callbacks, true, false, false, overload_state);
 
   auto local_dst_address = Network::Utility::getAddressWithPort(
       *Network::Test::getCanonicalLoopbackAddress(version_),
@@ -317,7 +323,7 @@ TEST_P(TcpListenerImplTest, WildcardListenerIpv4Compat) {
   Server::ThreadLocalOverloadStateOptRef overload_state;
   // Do not redirect since use_original_dst is false.
   Network::TestTcpListenerImpl listener(dispatcherImpl(), random_generator, runtime, socket,
-                                        listener_callbacks, true, false, overload_state);
+                                        listener_callbacks, true, false, false, overload_state);
 
   auto listener_address = Network::Utility::getAddressWithPort(
       *Network::Test::getCanonicalLoopbackAddress(version_),
@@ -360,7 +366,7 @@ TEST_P(TcpListenerImplTest, DisableAndEnableListener) {
   NiceMock<Runtime::MockLoader> runtime;
   Server::ThreadLocalOverloadStateOptRef overload_state;
   TestTcpListenerImpl listener(dispatcherImpl(), random_generator, runtime, socket,
-                               listener_callbacks, true, false, overload_state);
+                               listener_callbacks, true, false, false, overload_state);
 
   // When listener is disabled, the timer should fire before any connection is accepted.
   listener.disable();
@@ -404,7 +410,7 @@ TEST_P(TcpListenerImplTest, SetListenerRejectFractionZero) {
   NiceMock<Runtime::MockLoader> runtime;
   Server::ThreadLocalOverloadStateOptRef overload_state;
   TestTcpListenerImpl listener(dispatcherImpl(), random_generator, runtime, socket,
-                               listener_callbacks, true, false, overload_state);
+                               listener_callbacks, true, false, false, overload_state);
 
   listener.setRejectFraction(UnitFloat(0));
 
@@ -438,7 +444,7 @@ TEST_P(TcpListenerImplTest, SetListenerRejectFractionIntermediate) {
   NiceMock<Runtime::MockLoader> runtime;
   Server::ThreadLocalOverloadStateOptRef overload_state;
   TestTcpListenerImpl listener(dispatcherImpl(), random_generator, runtime, socket,
-                               listener_callbacks, true, false, overload_state);
+                               listener_callbacks, true, false, false, overload_state);
 
   listener.setRejectFraction(UnitFloat(0.5f));
 
@@ -506,7 +512,7 @@ TEST_P(TcpListenerImplTest, SetListenerRejectFractionAll) {
   NiceMock<Runtime::MockLoader> runtime;
   Server::ThreadLocalOverloadStateOptRef overload_state;
   TestTcpListenerImpl listener(dispatcherImpl(), random_generator, runtime, socket,
-                               listener_callbacks, true, false, overload_state);
+                               listener_callbacks, true, false, false, overload_state);
 
   listener.setRejectFraction(UnitFloat(1));
 
@@ -541,7 +547,7 @@ TEST_P(TcpListenerImplTest, LoadShedPointCanRejectConnection) {
   NiceMock<Runtime::MockLoader> runtime;
   Server::ThreadLocalOverloadStateOptRef overload_state;
   TestTcpListenerImpl listener(dispatcherImpl(), random_generator, runtime, socket,
-                               listener_callbacks, true, false, overload_state);
+                               listener_callbacks, true, false, false, overload_state);
 
   Server::MockOverloadManager overload_manager;
   Server::MockLoadShedPoint accept_connection_point;
@@ -583,7 +589,7 @@ TEST_P(TcpListenerImplTest, EachQueuedConnectionShouldQueryTheLoadShedPoint) {
   NiceMock<Runtime::MockLoader> runtime;
   Server::ThreadLocalOverloadStateOptRef overload_state;
   TestTcpListenerImpl listener(dispatcherImpl(), random_generator, runtime, socket,
-                               listener_callbacks, true, false, overload_state);
+                               listener_callbacks, true, false, false, overload_state);
 
   Server::MockOverloadManager overload_manager;
   Server::MockLoadShedPoint accept_connection_point;
@@ -649,7 +655,7 @@ TEST_P(TcpListenerImplTest, ShouldOnlyAcceptTheMaxNumberOfConnectionsConfiguredP
   Server::ThreadLocalOverloadStateOptRef overload_state;
   const uint32_t max_connections_to_accept_per_socket_event = 1;
   TestTcpListenerImpl listener(dispatcherImpl(), random_generator, runtime, socket,
-                               listener_callbacks, true, false,
+                               listener_callbacks, true, false, false,
                                max_connections_to_accept_per_socket_event, overload_state);
 
   // Create two client connections, they should get accepted.

--- a/test/extensions/bootstrap/internal_listener/active_internal_listener_test.cc
+++ b/test/extensions/bootstrap/internal_listener/active_internal_listener_test.cc
@@ -344,6 +344,7 @@ public:
       open_connections_.setMax(num_connections);
     }
     void clearMaxConnections() { open_connections_.resetMax(); }
+    bool shouldBypassOverloadManager() const override { return false; }
 
     ConnectionHandlerTest& parent_;
     std::shared_ptr<NiceMock<Network::MockListenSocket>> socket_;

--- a/test/extensions/common/proxy_protocol/proxy_protocol_regression_test.cc
+++ b/test/extensions/common/proxy_protocol/proxy_protocol_regression_test.cc
@@ -98,6 +98,7 @@ public:
   uint32_t tcpBacklogSize() const override { return ENVOY_TCP_BACKLOG_SIZE; }
   Init::Manager& initManager() override { return *init_manager_; }
   bool ignoreGlobalConnLimit() const override { return false; }
+  bool shouldBypassOverloadManager() const override { return false; }
 
   // Network::FilterChainManager
   const Network::FilterChain* findFilterChain(const Network::ConnectionSocket&,

--- a/test/extensions/filters/listener/common/fuzz/listener_filter_fuzzer.h
+++ b/test/extensions/filters/listener/common/fuzz/listener_filter_fuzzer.h
@@ -78,6 +78,7 @@ public:
   }
   Init::Manager& initManager() override { return *init_manager_; }
   bool ignoreGlobalConnLimit() const override { return false; }
+  bool shouldBypassOverloadManager() const override { return false; }
 
   // Network::FilterChainManager
   const Network::FilterChain* findFilterChain(const Network::ConnectionSocket&,

--- a/test/extensions/filters/listener/proxy_protocol/proxy_protocol_test.cc
+++ b/test/extensions/filters/listener/proxy_protocol/proxy_protocol_test.cc
@@ -118,6 +118,7 @@ public:
   }
   Init::Manager& initManager() override { return *init_manager_; }
   bool ignoreGlobalConnLimit() const override { return false; }
+  bool shouldBypassOverloadManager() const override { return false; }
 
   // Network::FilterChainManager
   const Network::FilterChain* findFilterChain(const Network::ConnectionSocket&,
@@ -2168,6 +2169,7 @@ public:
   }
   Init::Manager& initManager() override { return *init_manager_; }
   bool ignoreGlobalConnLimit() const override { return false; }
+  bool shouldBypassOverloadManager() const override { return false; }
 
   // Network::FilterChainManager
   const Network::FilterChain* findFilterChain(const Network::ConnectionSocket&,

--- a/test/extensions/filters/network/common/fuzz/utils/fakes.h
+++ b/test/extensions/filters/network/common/fuzz/utils/fakes.h
@@ -20,6 +20,7 @@ public:
     return envoy::config::core::v3::UNSPECIFIED;
   }
   bool isQuic() const override { return false; }
+  bool shouldBypassOverloadManager() const override { return false; }
 
 private:
   Envoy::Config::MetadataPack<Envoy::Network::ListenerTypedMetadataFactory> metadata_;

--- a/test/extensions/network/dns_resolver/cares/dns_impl_test.cc
+++ b/test/extensions/network/dns_resolver/cares/dns_impl_test.cc
@@ -733,6 +733,7 @@ public:
     listener_ = std::make_unique<Network::TcpListenerImpl>(
         *dispatcher_, api_->randomGenerator(), runtime_, socket_, *server_,
         listener_config.bindToPort(), listener_config.ignoreGlobalConnLimit(),
+        listener_config.shouldBypassOverloadManager(),
         listener_config.maxConnectionsToAcceptPerSocketEvent(), overload_state);
     updateDnsResolverOptions();
 

--- a/test/extensions/transport_sockets/tls/ssl_socket_test.cc
+++ b/test/extensions/transport_sockets/tls/ssl_socket_test.cc
@@ -335,7 +335,7 @@ Network::ListenerPtr createListener(Network::SocketSharedPtr&& socket,
                                     Random::RandomGenerator& rng, Event::Dispatcher& dispatcher) {
   return std::make_unique<Network::TcpListenerImpl>(
       dispatcher, rng, runtime, socket, cb, listener_config.bindToPort(),
-      listener_config.ignoreGlobalConnLimit(),
+      listener_config.ignoreGlobalConnLimit(), listener_config.shouldBypassOverloadManager(),
       listener_config.maxConnectionsToAcceptPerSocketEvent(), overload_state);
 }
 
@@ -986,6 +986,7 @@ protected:
     return std::make_unique<Network::TcpListenerImpl>(
         dispatcher, api_->randomGenerator(), runtime, std::move(socket), cb,
         listener_config.bindToPort(), listener_config.ignoreGlobalConnLimit(),
+        listener_config.shouldBypassOverloadManager(),
         listener_config.maxConnectionsToAcceptPerSocketEvent(), overload_state);
   }
 

--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -899,6 +899,7 @@ private:
     Network::ConnectionBalancer& connectionBalancer(const Network::Address::Instance&) override {
       return connection_balancer_;
     }
+    bool shouldBypassOverloadManager() const override { return false; }
     const std::vector<AccessLog::InstanceSharedPtr>& accessLogs() const override {
       return empty_access_logs_;
     }

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -472,6 +472,7 @@ public:
   MOCK_METHOD(const Envoy::Config::TypedMetadata&, typedMetadata, (), (const));
   MOCK_METHOD(envoy::config::core::v3::TrafficDirection, direction, (), (const));
   MOCK_METHOD(bool, isQuic, (), (const));
+  MOCK_METHOD(bool, shouldBypassOverloadManager, (), (const));
 };
 
 class MockListenerConfig : public ListenerConfig {
@@ -498,6 +499,7 @@ public:
   MOCK_METHOD(uint32_t, maxConnectionsToAcceptPerSocketEvent, (), (const));
   MOCK_METHOD(Init::Manager&, initManager, ());
   MOCK_METHOD(bool, ignoreGlobalConnLimit, (), (const));
+  MOCK_METHOD(bool, shouldBypassOverloadManager, (), (const));
 
   const std::vector<AccessLog::InstanceSharedPtr>& accessLogs() const override {
     return empty_access_logs_;
@@ -524,6 +526,7 @@ public:
   MOCK_METHOD(void, disable, ());
   MOCK_METHOD(void, setRejectFraction, (UnitFloat));
   MOCK_METHOD(void, configureLoadShedPoints, (Server::LoadShedPointProvider&));
+  MOCK_METHOD(bool, shouldBypassOverloadManager, (), (const));
 };
 
 class MockConnectionHandler : public virtual ConnectionHandler {
@@ -655,6 +658,7 @@ public:
   MOCK_METHOD(Api::IoCallUint64Result, send, (const UdpSendData&));
   MOCK_METHOD(Api::IoCallUint64Result, flush, ());
   MOCK_METHOD(void, activateRead, ());
+  MOCK_METHOD(bool, shouldBypassOverloadManager, (), (const));
 
   Event::MockDispatcher dispatcher_;
 };

--- a/test/mocks/server/instance.cc
+++ b/test/mocks/server/instance.cc
@@ -45,6 +45,7 @@ MockInstance::MockInstance()
   ON_CALL(*this, mutexTracer()).WillByDefault(Return(nullptr));
   ON_CALL(*this, singletonManager()).WillByDefault(ReturnRef(*singleton_manager_));
   ON_CALL(*this, overloadManager()).WillByDefault(ReturnRef(overload_manager_));
+  ON_CALL(*this, nullOverloadManager()).WillByDefault(ReturnRef(null_overload_manager_));
   ON_CALL(*this, messageValidationContext()).WillByDefault(ReturnRef(validation_context_));
   ON_CALL(*this, statsConfig()).WillByDefault(ReturnRef(*stats_config_));
   ON_CALL(*this, serverFactoryContext()).WillByDefault(ReturnRef(*server_factory_context_));

--- a/test/mocks/server/instance.h
+++ b/test/mocks/server/instance.h
@@ -37,6 +37,8 @@ public:
   MOCK_METHOD(Envoy::MutexTracer*, mutexTracer, ());
   MOCK_METHOD(const Options&, options, ());
   MOCK_METHOD(OverloadManager&, overloadManager, ());
+  MOCK_METHOD(OverloadManager&, nullOverloadManager, ());
+  MOCK_METHOD(bool, shouldBypassOverloadManager, (), (const));
   MOCK_METHOD(Runtime::Loader&, runtime, ());
   MOCK_METHOD(void, shutdown, ());
   MOCK_METHOD(bool, isShutdown, ());
@@ -89,6 +91,7 @@ public:
   testing::NiceMock<Init::MockManager> init_manager_;
   testing::NiceMock<MockListenerManager> listener_manager_;
   testing::NiceMock<MockOverloadManager> overload_manager_;
+  testing::NiceMock<MockOverloadManager> null_overload_manager_;
   Singleton::ManagerPtr singleton_manager_;
   Grpc::ContextImpl grpc_context_;
   Http::ContextImpl http_context_;

--- a/test/mocks/server/server_factory_context.cc
+++ b/test/mocks/server/server_factory_context.cc
@@ -34,6 +34,7 @@ MockServerFactoryContext::MockServerFactoryContext()
   ON_CALL(*this, lifecycleNotifier()).WillByDefault(ReturnRef(lifecycle_notifier_));
   ON_CALL(*this, options()).WillByDefault(ReturnRef(options_));
   ON_CALL(*this, overloadManager()).WillByDefault(ReturnRef(overload_manager_));
+  ON_CALL(*this, nullOverloadManager()).WillByDefault(ReturnRef(null_overload_manager_));
 }
 MockServerFactoryContext::~MockServerFactoryContext() = default;
 

--- a/test/mocks/server/server_factory_context.h
+++ b/test/mocks/server/server_factory_context.h
@@ -82,6 +82,8 @@ public:
   MOCK_METHOD(StatsConfig&, statsConfig, (), ());
   MOCK_METHOD(AccessLog::AccessLogManager&, accessLogManager, (), ());
   MOCK_METHOD(OverloadManager&, overloadManager, ());
+  MOCK_METHOD(OverloadManager&, nullOverloadManager, ());
+  MOCK_METHOD(bool, shouldBypassOverloadManager, (), (const));
   MOCK_METHOD(bool, healthCheckFailed, (), (const));
 
   testing::NiceMock<Upstream::MockClusterManager> cluster_manager_;
@@ -102,6 +104,7 @@ public:
   Event::GlobalTimeSystem time_system_;
   testing::NiceMock<Api::MockApi> api_;
   testing::NiceMock<MockOverloadManager> overload_manager_;
+  testing::NiceMock<MockOverloadManager> null_overload_manager_;
   Http::ContextImpl http_context_;
   Grpc::ContextImpl grpc_context_;
   Router::ContextImpl router_context_;
@@ -158,6 +161,8 @@ public:
   MOCK_METHOD(StatsConfig&, statsConfig, (), ());
   MOCK_METHOD(AccessLog::AccessLogManager&, accessLogManager, (), ());
   MOCK_METHOD(OverloadManager&, overloadManager, ());
+  MOCK_METHOD(OverloadManager&, nullOverloadManager, ());
+  MOCK_METHOD(bool, shouldBypassOverloadManager, (), (const));
   MOCK_METHOD(bool, healthCheckFailed, (), (const));
 };
 

--- a/test/mocks/server/worker_factory.h
+++ b/test/mocks/server/worker_factory.h
@@ -13,7 +13,8 @@ public:
   ~MockWorkerFactory() override;
 
   // Server::WorkerFactory
-  WorkerPtr createWorker(uint32_t, OverloadManager&, const std::string&) override {
+  WorkerPtr createWorker(uint32_t, OverloadManager&, OverloadManager&,
+                         const std::string&) override {
     return WorkerPtr{createWorker_()};
   }
 

--- a/test/server/BUILD
+++ b/test/server/BUILD
@@ -273,6 +273,7 @@ envoy_cc_test(
         "//envoy/registry",
         "//source/common/stats:isolated_store_lib",
         "//source/extensions/resource_monitors/common:factory_base_lib",
+        "//source/server:null_overload_manager_lib",
         "//source/server:overload_manager_lib",
         "//test/mocks/event:event_mocks",
         "//test/mocks/protobuf:protobuf_mocks",
@@ -283,6 +284,17 @@ envoy_cc_test(
         "//test/test_common:test_runtime_lib",
         "//test/test_common:utility_lib",
         "@envoy_api//envoy/config/overload/v3:pkg_cc_proto",
+    ],
+)
+
+envoy_cc_test(
+    name = "null_overload_manager_test",
+    srcs = ["null_overload_manager_test.cc"],
+    deps = [
+        "//source/server:null_overload_manager_lib",
+        "//source/server:overload_manager_lib",
+        "//test/mocks/event:event_mocks",
+        "//test/mocks/thread_local:thread_local_mocks",
     ],
 )
 

--- a/test/server/admin/BUILD
+++ b/test/server/admin/BUILD
@@ -58,6 +58,7 @@ envoy_cc_test(
         "//source/common/protobuf",
         "//source/common/protobuf:utility_lib",
         "//source/common/stats:thread_local_store_lib",
+        "//source/server:null_overload_manager_lib",
         "//source/server/admin:admin_lib",
         "//test/mocks/runtime:runtime_mocks",
         "//test/mocks/server:server_mocks",

--- a/test/server/admin/admin_test.cc
+++ b/test/server/admin/admin_test.cc
@@ -17,6 +17,7 @@
 #include "source/extensions/access_loggers/common/file_access_log_impl.h"
 #include "source/server/admin/stats_request.h"
 #include "source/server/configuration_impl.h"
+#include "source/server/null_overload_manager.h"
 
 #include "test/server/admin/admin_instance.h"
 #include "test/test_common/logging.h"
@@ -303,7 +304,7 @@ public:
   AdminImpl::NullScopedRouteConfigProvider& scopedRouteConfigProvider() {
     return scoped_route_config_provider_;
   }
-  NullOverloadManager& overloadManager() { return admin_.null_overload_manager_; }
+  OverloadManager& overloadManager() { return admin_.null_overload_manager_; }
   NullOverloadManager::OverloadState& overloadState() { return overload_state_; }
   AdminImpl::AdminListenSocketFactory& socketFactory() { return socket_factory_; }
   AdminImpl::AdminListener& listener() { return listener_; }

--- a/test/server/connection_handler_test.cc
+++ b/test/server/connection_handler_test.cc
@@ -180,6 +180,7 @@ public:
     }
     Init::Manager& initManager() override { return *init_manager_; }
     bool ignoreGlobalConnLimit() const override { return ignore_global_conn_limit_; }
+    bool shouldBypassOverloadManager() const override { return false; }
     void setMaxConnections(const uint32_t num_connections) {
       open_connections_.setMax(num_connections);
     }
@@ -294,6 +295,7 @@ public:
     MOCK_METHOD(Api::IoCallUint64Result, send, (const Network::UdpSendData&), (override));
     MOCK_METHOD(Api::IoCallUint64Result, flush, (), (override));
     MOCK_METHOD(void, activateRead, (), (override));
+    MOCK_METHOD(bool, shouldBypassOverloadManager, (), (const, override));
 
   private:
     ConnectionHandlerTest& parent_;

--- a/test/server/null_overload_manager_test.cc
+++ b/test/server/null_overload_manager_test.cc
@@ -1,0 +1,76 @@
+#include "envoy/event/scaled_range_timer_manager.h"
+#include "envoy/server/overload/overload_manager.h"
+#include "envoy/server/overload/thread_local_overload_state.h"
+
+#include "source/server/null_overload_manager.h"
+#include "source/server/overload_manager_impl.h"
+
+#include "test/mocks/event/mocks.h"
+#include "test/mocks/thread_local/mocks.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+using testing::_;
+using testing::AnyNumber;
+using testing::FloatNear;
+using testing::NiceMock;
+using testing::Property;
+
+namespace Envoy {
+namespace Server {
+namespace {
+
+class NullOverloadManagerTest : public testing::Test {
+protected:
+  NullOverloadManagerTest() {}
+
+  NiceMock<Event::MockDispatcher> dispatcher_;
+  NiceMock<ThreadLocal::MockInstance> thread_local_;
+};
+
+TEST_F(NullOverloadManagerTest, NullOverloadManagerOverloadState) {
+  NullOverloadManager::OverloadState overload_state_non_permissive(dispatcher_, false);
+
+  // Verify that the manager always returns an inactive state for any action
+  auto action_state = overload_state_non_permissive.getState("envoy.overload_actions.shrink_heap");
+  EXPECT_THAT(action_state, AllOf(Property(&OverloadActionState::isSaturated, false),
+                                  Property(&OverloadActionState::value, UnitFloat::min())));
+  action_state =
+      overload_state_non_permissive.getState("envoy.overload_actions.stop_accepting_requests");
+  EXPECT_THAT(action_state, AllOf(Property(&OverloadActionState::isSaturated, false),
+                                  Property(&OverloadActionState::value, UnitFloat::min())));
+  action_state = overload_state_non_permissive.getState("envoy.overload_actions.some_other_action");
+  EXPECT_THAT(action_state, AllOf(Property(&OverloadActionState::isSaturated, false),
+                                  Property(&OverloadActionState::value, UnitFloat::min())));
+
+  // Verify that the manager does not allocate or deallocate any resources
+  EXPECT_FALSE(overload_state_non_permissive.tryAllocateResource(
+      Server::OverloadProactiveResourceName::GlobalDownstreamMaxConnections, 100));
+  EXPECT_FALSE(overload_state_non_permissive.tryDeallocateResource(
+      Server::OverloadProactiveResourceName::GlobalDownstreamMaxConnections, 50));
+
+  // Verify that the manager does not enable any resource monitors
+  EXPECT_FALSE(overload_state_non_permissive.isResourceMonitorEnabled(
+      Server::OverloadProactiveResourceName::GlobalDownstreamMaxConnections));
+
+  // Verify that the manager returns a null ProactiveResourceMonitor for any resource
+  EXPECT_FALSE(overload_state_non_permissive
+                   .getProactiveResourceMonitorForTest(
+                       Server::OverloadProactiveResourceName::GlobalDownstreamMaxConnections)
+                   .has_value());
+}
+
+TEST_F(NullOverloadManagerTest, NullOverloadManagerNoOpOperations) {
+  NullOverloadManager overload_manager(thread_local_, false);
+  EXPECT_TRUE(overload_manager.registerForAction("envoy.overload_actions.shrink_heap", dispatcher_,
+                                                 [](OverloadActionState) {}));
+  auto* point = overload_manager.getLoadShedPoint("envoy.load_shed_point.dummy_point");
+  EXPECT_EQ(point, nullptr);
+  auto scaled_timer_factory = overload_manager.scaledTimerFactory();
+  EXPECT_EQ(scaled_timer_factory, nullptr);
+}
+
+} // namespace
+} // namespace Server
+} // namespace Envoy

--- a/test/server/overload_manager_impl_test.cc
+++ b/test/server/overload_manager_impl_test.cc
@@ -10,6 +10,7 @@
 
 #include "source/common/stats/isolated_store_impl.h"
 #include "source/extensions/resource_monitors/common/factory_base.h"
+#include "source/server/null_overload_manager.h"
 #include "source/server/overload_manager_impl.h"
 
 #include "test/common/stats/stat_test_utility.h"

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -176,7 +176,7 @@ public:
     ON_CALL(server_, shutdown()).WillByDefault(Assign(&shutdown_, true));
 
     helper_ = std::make_unique<RunHelper>(server_, options_, dispatcher_, cm_, access_log_manager_,
-                                          init_manager_, overload_manager_,
+                                          init_manager_, overload_manager_, null_overload_manager_,
                                           [this] { start_workers_.ready(); });
   }
 
@@ -186,6 +186,7 @@ public:
   NiceMock<Upstream::MockClusterManager> cm_;
   NiceMock<AccessLog::MockAccessLogManager> access_log_manager_;
   NiceMock<MockOverloadManager> overload_manager_;
+  NiceMock<MockOverloadManager> null_overload_manager_;
   Init::ManagerImpl init_manager_{""};
   ReadyWatcher start_workers_;
   std::unique_ptr<RunHelper> helper_;


### PR DESCRIPTION
This is to address https://github.com/envoyproxy/envoy/issues/35985.

Original Commit Message:

Add the ability to bypass overload manager for listeners (#34322)

Commit Message: Add the ability to bypass overload manager for listeners
Additional Description: This flag can be used to disable overload manager on specific listeners where, for instance, we don't want to stop accepting requests. In my company, we implemented a CPU Utilization resource monitor that helps us drop requests when we hit a certain utilization percentage, but there are certain listeners that receive administrative traffic that we don't want overload manager to touch. Another use case is, we want to only throttle ingress traffic but not egress traffic going via Envoy. Another contributor authored #29781, but it has been marked as stale.

Risk Level: Low
Testing: Unit tests & Integration tests added
Docs Changes: No
Release Notes: Add bypass_overload_manager flag to Listener in order to prevent overload manager from taking actions on the traffic going through the said listener. Platform Specific Features:
