### PR TITLE
mobile/ci: Update to use the macos-14 runners

### DIFF
--- a/.github/workflows/mobile-ios_build.yml
+++ b/.github/workflows/mobile-ios_build.yml
@@ -42,7 +42,7 @@ jobs:
       command: ./bazelw
       container-command:
       request: ${{ needs.load.outputs.request }}
-      runs-on: macos-12-large
+      runs-on: macos-14-large
       source: |
         source ./ci/mac_ci_setup.sh
         ./bazelw shutdown
@@ -81,7 +81,7 @@ jobs:
       command: ./bazelw
       container-command:
       request: ${{ needs.load.outputs.request }}
-      runs-on: macos-12-large
+      runs-on: macos-14-large
       source: |
         source ./ci/mac_ci_setup.sh
         ./bazelw shutdown
@@ -126,7 +126,7 @@ jobs:
       command: ./bazelw
       container-command:
       request: ${{ needs.load.outputs.request }}
-      runs-on: macos-12-large
+      runs-on: macos-14-large
       source: |
         source ./ci/mac_ci_setup.sh
       steps-post: |

--- a/.github/workflows/mobile-ios_tests.yml
+++ b/.github/workflows/mobile-ios_tests.yml
@@ -42,7 +42,7 @@ jobs:
       command: ./bazelw
       container-command:
       request: ${{ needs.load.outputs.request }}
-      runs-on: macos-12
+      runs-on: macos-14
       source: |
         source ./ci/mac_ci_setup.sh
       steps-post: ${{ matrix.steps-post }}

--- a/.github/workflows/mobile-release_validation.yml
+++ b/.github/workflows/mobile-release_validation.yml
@@ -49,7 +49,7 @@ jobs:
       command: ./bazelw
       container-command:
       request: ${{ needs.load.outputs.request }}
-      runs-on: macos-12
+      runs-on: macos-14
       source: |
         source ./ci/mac_ci_setup.sh
       # Ignore errors: Bad CRC when unzipping large files: https://bbs.archlinux.org/viewtopic.php?id=153011

--- a/mobile/ci/mac_ci_setup.sh
+++ b/mobile/ci/mac_ci_setup.sh
@@ -6,7 +6,7 @@ set -e
 # Installs the dependencies required for a macOS build via homebrew.
 # Tools are not upgraded to new versions.
 # See:
-# https://github.com/actions/virtual-environments/blob/main/images/macos/macos-12-Readme.md for
+# https://github.com/actions/virtual-environments/blob/main/images/macos/macos-14-Readme.md for
 # a list of pre-installed tools in the macOS image.
 
 export HOMEBREW_NO_AUTO_UPDATE=1
@@ -54,7 +54,7 @@ do
     install "${DEP}"
 done
 
-# https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md#xcode
+# https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md#xcode
 sudo xcode-select --switch /Applications/Xcode_14.1.app
 
 retry ./bazelw version


### PR DESCRIPTION
The `macos-14` runners are needed to be able to use XCode 15.3.