### PR TITLE
mobile: Fix flaky ClientIntegrationTest

### DIFF
--- a/mobile/test/common/integration/client_integration_test.cc
+++ b/mobile/test/common/integration/client_integration_test.cc
@@ -206,15 +206,8 @@ void ClientIntegrationTest::basicTest() {
                                    std::to_string(request_data.length()));
 
   EnvoyStreamCallbacks stream_callbacks = createDefaultStreamCallbacks();
-  stream_callbacks.on_data_ = [this](const Buffer::Instance& buffer, uint64_t length,
-                                     bool end_stream, envoy_stream_intel) {
-    if (end_stream) {
-      std::string response_body(length, ' ');
-      buffer.copyOut(0, length, response_body.data());
-      EXPECT_EQ(response_body, "");
-    }
-    cc_.on_data_calls_++;
-  };
+  stream_callbacks.on_data_ = [this](const Buffer::Instance&, uint64_t,
+                                     bool, envoy_stream_intel) { cc_.on_data_calls_++; };
 
   stream_ = createNewStream(std::move(stream_callbacks));
   stream_->sendHeaders(std::make_unique<Http::TestRequestHeaderMapImpl>(default_request_headers_),

--- a/mobile/test/common/integration/client_integration_test.cc
+++ b/mobile/test/common/integration/client_integration_test.cc
@@ -206,8 +206,9 @@ void ClientIntegrationTest::basicTest() {
                                    std::to_string(request_data.length()));
 
   EnvoyStreamCallbacks stream_callbacks = createDefaultStreamCallbacks();
-  stream_callbacks.on_data_ = [this](const Buffer::Instance&, uint64_t,
-                                     bool, envoy_stream_intel) { cc_.on_data_calls_++; };
+  stream_callbacks.on_data_ = [this](const Buffer::Instance&, uint64_t, bool, envoy_stream_intel) {
+    cc_.on_data_calls_++;
+  };
 
   stream_ = createNewStream(std::move(stream_callbacks));
   stream_->sendHeaders(std::make_unique<Http::TestRequestHeaderMapImpl>(default_request_headers_),


### PR DESCRIPTION
This PR removes the test expectation that the `end_stream` always contains 0 bytes since this behavior is not guaranteed causing test flakiness. This is similar to https://github.com/envoyproxy/envoy/pull/34252. See also https://github.com/envoyproxy/envoy-mobile/issues/1393.

Fixes https://github.com/envoyproxy/envoy/issues/36074.

Risk Level: low (test only)
Testing: `bazel test //test/common/integration:client_integration_test --runs_per_test=200`
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
