### PR TITLE
mobile: Enable setting the Platform Cert Validator thread priority

### DIFF
--- a/mobile/library/cc/engine_builder.cc
+++ b/mobile/library/cc/engine_builder.cc
@@ -554,6 +554,9 @@ std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> EngineBuilder::generate
   if (platform_certificates_validation_on_) {
     envoy_mobile::extensions::cert_validator::platform_bridge::PlatformBridgeCertValidator
         validator;
+    if (network_thread_priority_.has_value()) {
+      validator.mutable_thread_priority()->set_value(*network_thread_priority_);
+    }
     validation->mutable_custom_validator_config()->set_name(
         "envoy_mobile.cert_validator.platform_bridge_cert_validator");
     validation->mutable_custom_validator_config()->mutable_typed_config()->PackFrom(validator);

--- a/mobile/library/common/extensions/cert_validator/platform_bridge/BUILD
+++ b/mobile/library/common/extensions/cert_validator/platform_bridge/BUILD
@@ -38,6 +38,7 @@ envoy_cc_library(
         "@envoy//envoy/thread:thread_interface",
         "@envoy//source/common/common:macros",
         "@envoy//source/common/common:thread_impl_lib_posix",
+        "@envoy//source/common/config:utility_lib",
         "@envoy//source/common/tls/cert_validator:cert_validator_lib",
     ],
 )

--- a/mobile/library/common/extensions/cert_validator/platform_bridge/platform_bridge.proto
+++ b/mobile/library/common/extensions/cert_validator/platform_bridge/platform_bridge.proto
@@ -2,5 +2,15 @@ syntax = "proto3";
 
 package envoy_mobile.extensions.cert_validator.platform_bridge;
 
+import "google/protobuf/wrappers.proto";
+
+// Configuration for the platform bridge cert validator.
 message PlatformBridgeCertValidator {
+  // The thread priority that will be set on the thread that is created to execute platform cert
+  // validation. The exact values and meaning of the thread priority is OS dependent. For example,
+  // on Android, the values range from -20 to 19. On iOS, supply a value between 1 to 100, which
+  // will be divided by 100 to provide a value to the OS in the range of 0 to 1.
+  //
+  // If this field is not set, the platform-specific default thread priorities will be used.
+  google.protobuf.Int32Value thread_priority = 1;
 }

--- a/mobile/library/common/extensions/cert_validator/platform_bridge/platform_bridge_cert_validator.cc
+++ b/mobile/library/common/extensions/cert_validator/platform_bridge/platform_bridge_cert_validator.cc
@@ -26,7 +26,7 @@ PlatformBridgeCertValidator::PlatformBridgeCertValidator(
   ENVOY_BUG(config != nullptr && config->caCert().empty() &&
                 config->certificateRevocationList().empty(),
             "Invalid certificate validation context config.");
-  if (config->customValidatorConfig().has_value()) {
+  if (config != nullptr && config->customValidatorConfig().has_value()) {
     envoy_mobile::extensions::cert_validator::platform_bridge::PlatformBridgeCertValidator cfg;
     Envoy::Config::Utility::translateOpaqueConfig(
         config->customValidatorConfig().value().typed_config(),

--- a/mobile/test/common/extensions/cert_validator/platform_bridge/BUILD
+++ b/mobile/test/common/extensions/cert_validator/platform_bridge/BUILD
@@ -18,6 +18,7 @@ envoy_extension_cc_test(
     repository = "@envoy",
     deps = [
         "//library/common/extensions/cert_validator/platform_bridge:config",
+        "//library/common/extensions/cert_validator/platform_bridge:platform_bridge_cc_proto",
         "//test/common/mocks/common:common_mocks",
         "@envoy//source/common/tls/cert_validator:cert_validator_lib",
         "@envoy//test/common/tls:ssl_test_utils",

--- a/mobile/test/common/extensions/cert_validator/platform_bridge/platform_bridge_cert_validator_test.cc
+++ b/mobile/test/common/extensions/cert_validator/platform_bridge/platform_bridge_cert_validator_test.cc
@@ -24,6 +24,7 @@
 #include "gtest/gtest.h"
 #include "library/common/bridge/utility.h"
 #include "library/common/extensions/cert_validator/platform_bridge/config.h"
+#include "library/common/extensions/cert_validator/platform_bridge/platform_bridge.pb.h"
 #include "openssl/ssl.h"
 #include "openssl/x509v3.h"
 
@@ -60,6 +61,30 @@ public:
               (const std::vector<std::string>& certs, absl::string_view hostname));
 };
 
+class PlatformBridgeCertValidatorCustomValidate : public PlatformBridgeCertValidator {
+public:
+  PlatformBridgeCertValidatorCustomValidate(
+      const Envoy::Ssl::CertificateValidationContextConfig* config, SslStats& stats,
+      Thread::PosixThreadFactory& thread_factory)
+      : PlatformBridgeCertValidator(config, stats), thread_factory_(thread_factory) {}
+
+  int recordedThreadPriority() const { return recorded_thread_priority_; }
+
+protected:
+  void verifyCertChainByPlatform(Event::Dispatcher* dispatcher,
+                                 std::vector<std::string> /* cert_chain */, std::string hostname,
+                                 std::vector<std::string> /* subject_alt_names */) override {
+    recorded_thread_priority_ = thread_factory_.currentThreadPriority();
+    postVerifyResultAndCleanUp(/* success = */ true, std::move(hostname), "",
+                               SSL_AD_CERTIFICATE_UNKNOWN, ValidationFailureType::Success,
+                               dispatcher, this);
+  }
+
+private:
+  Thread::PosixThreadFactory& thread_factory_;
+  int recorded_thread_priority_;
+};
+
 class PlatformBridgeCertValidatorTest
     : public testing::TestWithParam<CertificateValidationContext::TrustChainVerification> {
 protected:
@@ -84,6 +109,8 @@ protected:
     EXPECT_CALL(config_, caCert()).WillOnce(ReturnRef(empty_string_));
     EXPECT_CALL(config_, certificateRevocationList()).WillOnce(ReturnRef(empty_string_));
     EXPECT_CALL(config_, trustChainVerification()).WillOnce(Return(GetParam()));
+    EXPECT_CALL(config_, customValidatorConfig())
+        .WillRepeatedly(ReturnRef(platform_bridge_config_));
   }
 
   ~PlatformBridgeCertValidatorTest() {
@@ -136,6 +163,7 @@ protected:
   std::unique_ptr<MockValidator> mock_validator_;
   Thread::ThreadId main_thread_id_;
   std::unique_ptr<test::SystemHelperPeer::Handle> helper_handle_;
+  absl::optional<envoy::config::core::v3::TypedExtensionConfig> platform_bridge_config_;
 };
 
 INSTANTIATE_TEST_SUITE_P(TrustMode, PlatformBridgeCertValidatorTest,
@@ -410,6 +438,42 @@ TEST_P(PlatformBridgeCertValidatorTest, ThreadCreationFailed) {
   EXPECT_EQ(ValidationResults::ValidationStatus::Failed, results.status);
   EXPECT_EQ(Ssl::ClientValidationStatus::NotValidated, results.detailed_status);
   EXPECT_EQ("Failed creating a thread for cert chain validation.", *results.error_details);
+}
+
+TEST_P(PlatformBridgeCertValidatorTest, ThreadPriority) {
+  const int expected_thread_priority = 15;
+  envoy_mobile::extensions::cert_validator::platform_bridge::PlatformBridgeCertValidator
+      platform_bridge_config;
+  platform_bridge_config.mutable_thread_priority()->set_value(expected_thread_priority);
+  envoy::config::core::v3::TypedExtensionConfig typed_config;
+  typed_config.set_name("PlatformBridgeCertValidator");
+  typed_config.mutable_typed_config()->PackFrom(platform_bridge_config);
+  platform_bridge_config_ = std::move(typed_config);
+
+  EXPECT_CALL(helper_handle_->mock_helper(), cleanupAfterCertificateValidation());
+
+  initializeConfig();
+  PlatformBridgeCertValidatorCustomValidate validator(&config_, stats_, *thread_factory_);
+
+  std::string hostname = "server1.example.com";
+  bssl::UniquePtr<STACK_OF(X509)> cert_chain = readCertChainFromFile(
+      TestEnvironment::substitute("{{ test_rundir }}/test/common/tls/test_data/san_dns2_cert.pem"));
+  EXPECT_CALL(*mock_validator_, cleanup());
+  auto& callback_ref = *callback_;
+  EXPECT_CALL(callback_ref, dispatcher()).WillRepeatedly(ReturnRef(*dispatcher_));
+
+  ValidationResults results =
+      validator.doVerifyCertChain(*cert_chain, std::move(callback_), transport_socket_options_,
+                                  *ssl_ctx_, validation_context_, is_server_, hostname);
+  EXPECT_EQ(ValidationResults::ValidationStatus::Pending, results.status);
+
+  EXPECT_CALL(callback_ref,
+              onCertValidationResult(true, Envoy::Ssl::ClientValidationStatus::Validated, "", 46))
+      .WillOnce(Invoke([this, &validator, expected_thread_priority]() {
+        EXPECT_EQ(validator.recordedThreadPriority(), expected_thread_priority);
+        dispatcher_->exit();
+      }));
+  EXPECT_FALSE(waitForDispatcherToExit());
 }
 
 } // namespace Tls

--- a/mobile/test/common/extensions/cert_validator/platform_bridge/platform_bridge_cert_validator_test.cc
+++ b/mobile/test/common/extensions/cert_validator/platform_bridge/platform_bridge_cert_validator_test.cc
@@ -180,6 +180,7 @@ TEST_P(PlatformBridgeCertValidatorTest, NonEmptyCaCert) {
   EXPECT_CALL(config_, caCert()).WillRepeatedly(ReturnRef(ca_cert));
   EXPECT_CALL(config_, certificateRevocationList()).WillRepeatedly(ReturnRef(empty_string_));
   EXPECT_CALL(config_, trustChainVerification()).WillRepeatedly(Return(GetParam()));
+  EXPECT_CALL(config_, customValidatorConfig()).WillRepeatedly(ReturnRef(platform_bridge_config_));
 
   EXPECT_ENVOY_BUG({ PlatformBridgeCertValidator validator(&config_, stats_); },
                    "Invalid certificate validation context config.");
@@ -190,6 +191,7 @@ TEST_P(PlatformBridgeCertValidatorTest, NonEmptyRevocationList) {
   EXPECT_CALL(config_, caCert()).WillRepeatedly(ReturnRef(empty_string_));
   EXPECT_CALL(config_, certificateRevocationList()).WillRepeatedly(ReturnRef(revocation_list));
   EXPECT_CALL(config_, trustChainVerification()).WillRepeatedly(Return(GetParam()));
+  EXPECT_CALL(config_, customValidatorConfig()).WillRepeatedly(ReturnRef(platform_bridge_config_));
 
   EXPECT_ENVOY_BUG({ PlatformBridgeCertValidator validator(&config_, stats_); },
                    "Invalid certificate validation context config.");


### PR DESCRIPTION
If the Envoy Mobile thread has a thread priority set, the Platform Cert Validator's validation thread also has the thread priority set to the same value.