### PR TITLE
coverage: Adjust the coverage threshold for common/posix

### DIFF
--- a/test/per_file_coverage.sh
+++ b/test/per_file_coverage.sh
@@ -6,6 +6,7 @@ declare -a KNOWN_LOW_COVERAGE=(
 "source/common:96.2"
 "source/common/api:84.5" # flaky due to posix: be careful adjusting
 "source/common/api/posix:83.8" # flaky (accept failover non-deterministic): be careful adjusting
+"source/common/common/posix:96.2" # flaky due to posix: be careful adjusting
 "source/common/config:96.1"
 "source/common/crypto:95.5"
 "source/common/event:95.2" # Emulated edge events guards don't report LCOV
@@ -20,6 +21,9 @@ declare -a KNOWN_LOW_COVERAGE=(
 "source/common/secret:95.4"
 "source/common/signal:87.2" # Death tests don't report LCOV
 "source/common/thread:0.0" # Death tests don't report LCOV
+"source/common/tls:94.8"
+"source/common/tls/cert_validator:94.4"
+"source/common/tls/private_key:88.9"
 "source/common/watchdog:58.6" # Death tests don't report LCOV
 "source/exe:94.2" # increased by #32346, need coverage for terminate_handler and hot restart failures
 "source/extensions/common:93.0" #flaky: be careful adjusting
@@ -46,9 +50,6 @@ declare -a KNOWN_LOW_COVERAGE=(
 "source/extensions/tracers/opencensus:94.0"
 "source/extensions/tracers/zipkin:95.8"
 "source/extensions/transport_sockets:97.4"
-"source/common/tls:94.8"
-"source/common/tls/cert_validator:94.4"
-"source/common/tls/private_key:88.9"
 "source/extensions/wasm_runtime/wamr:0.0" # Not enabled in coverage build
 "source/extensions/wasm_runtime/wasmtime:0.0" # Not enabled in coverage build
 "source/extensions/watchdog:83.3" # Death tests within extensions


### PR DESCRIPTION
NOTE: local runs of `bazel coverage` and `lcov` show 99% coverage.

Also, reorders some low coverage entries to be alphabetically friendly.