### PR TITLE
[bp/1.28] vpp/build: Minor fix for cmake build (#35583)

### DIFF
--- a/contrib/vcl/source/BUILD
+++ b/contrib/vcl/source/BUILD
@@ -57,7 +57,7 @@ envoy_cmake(
     postfix_script = """
         mkdir -p $INSTALLDIR/lib/external $INSTALLDIR/include/external \
         && find . -name "*.a" | xargs -I{} cp -a {} $INSTALLDIR/lib/ \
-        && find . -name "*.h" | xargs -I{} cp -a {} $INSTALLDIR/include
+        && find . -name "*.h" ! -name config.h | xargs -I{} cp -a {} $INSTALLDIR/include
     """,
     tags = [
         "cpu:16",


### PR DESCRIPTION
There are multiple files named config.h and in some build environments it causes the build postscript to fail

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API
Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
