### PR TITLE
mobile: Make Android proxy tests hermetic

### DIFF
--- a/mobile/test/kotlin/integration/proxying/BUILD
+++ b/mobile/test/kotlin/integration/proxying/BUILD
@@ -34,9 +34,6 @@ envoy_mobile_android_test(
     srcs = [
         "ProxyInfoIntentPerformHTTPSRequestUsingProxyTest.kt",
     ],
-    exec_properties = {
-        "dockerNetwork": "standard",
-    },
     native_deps = [
         "//test/jni:libenvoy_jni_with_test_and_listener_extensions.so",
     ] + select({
@@ -52,6 +49,7 @@ envoy_mobile_android_test(
         "//library/kotlin/io/envoyproxy/envoymobile:envoy_lib",
         "//test/java/io/envoyproxy/envoymobile/engine/testing",
         "//test/java/io/envoyproxy/envoymobile/engine/testing:http_proxy_test_server_factory_lib",
+        "//test/java/io/envoyproxy/envoymobile/engine/testing:http_test_server_factory_lib",
     ],
 )
 
@@ -60,9 +58,6 @@ envoy_mobile_android_test(
     srcs = [
         "ProxyInfoIntentPerformHTTPSRequestUsingAsyncProxyTest.kt",
     ],
-    exec_properties = {
-        "dockerNetwork": "standard",
-    },
     native_deps = [
         "//test/jni:libenvoy_jni_with_test_and_listener_extensions.so",
     ] + select({
@@ -78,6 +73,7 @@ envoy_mobile_android_test(
         "//library/kotlin/io/envoyproxy/envoymobile:envoy_lib",
         "//test/java/io/envoyproxy/envoymobile/engine/testing",
         "//test/java/io/envoyproxy/envoymobile/engine/testing:http_proxy_test_server_factory_lib",
+        "//test/java/io/envoyproxy/envoymobile/engine/testing:http_test_server_factory_lib",
     ],
 )
 
@@ -86,9 +82,6 @@ envoy_mobile_android_test(
     srcs = [
         "ProxyInfoIntentPerformHTTPSRequestBadHostnameTest.kt",
     ],
-    exec_properties = {
-        "dockerNetwork": "standard",
-    },
     native_deps = [
         "//test/jni:libenvoy_jni_with_test_and_listener_extensions.so",
     ] + select({
@@ -104,6 +97,7 @@ envoy_mobile_android_test(
         "//library/kotlin/io/envoyproxy/envoymobile:envoy_lib",
         "//test/java/io/envoyproxy/envoymobile/engine/testing",
         "//test/java/io/envoyproxy/envoymobile/engine/testing:http_proxy_test_server_factory_lib",
+        "//test/java/io/envoyproxy/envoymobile/engine/testing:http_test_server_factory_lib",
     ],
 )
 
@@ -112,9 +106,6 @@ envoy_mobile_android_test(
     srcs = [
         "ProxyPollPerformHTTPRequestUsingProxyTest.kt",
     ],
-    exec_properties = {
-        "dockerNetwork": "standard",
-    },
     native_deps = [
         "//test/jni:libenvoy_jni_with_test_and_listener_extensions.so",
     ] + select({
@@ -130,6 +121,7 @@ envoy_mobile_android_test(
         "//library/kotlin/io/envoyproxy/envoymobile:envoy_lib",
         "//test/java/io/envoyproxy/envoymobile/engine/testing",
         "//test/java/io/envoyproxy/envoymobile/engine/testing:http_proxy_test_server_factory_lib",
+        "//test/java/io/envoyproxy/envoymobile/engine/testing:http_test_server_factory_lib",
     ],
 )
 

--- a/mobile/test/kotlin/integration/proxying/ProxyInfoIntentPerformHTTPRequestUsingProxyTest.kt
+++ b/mobile/test/kotlin/integration/proxying/ProxyInfoIntentPerformHTTPRequestUsingProxyTest.kt
@@ -66,7 +66,7 @@ class ProxyInfoIntentPerformHTTPRequestUsingProxyTest {
     shadowOf(connectivityManager)
       .setProxyForNetwork(
         connectivityManager.activeNetwork,
-        ProxyInfo.buildDirectProxy("127.0.0.1", httpProxyTestServer.port)
+        ProxyInfo.buildDirectProxy(httpProxyTestServer.ipAddress, httpProxyTestServer.port)
       )
 
     val onEngineRunningLatch = CountDownLatch(1)

--- a/mobile/test/kotlin/integration/proxying/ProxyInfoIntentPerformHTTPSRequestUsingAsyncProxyTest.kt
+++ b/mobile/test/kotlin/integration/proxying/ProxyInfoIntentPerformHTTPSRequestUsingAsyncProxyTest.kt
@@ -11,8 +11,10 @@ import io.envoyproxy.envoymobile.AndroidEngineBuilder
 import io.envoyproxy.envoymobile.LogLevel
 import io.envoyproxy.envoymobile.RequestHeadersBuilder
 import io.envoyproxy.envoymobile.RequestMethod
+import io.envoyproxy.envoymobile.engine.EnvoyConfiguration
 import io.envoyproxy.envoymobile.engine.JniLibrary
 import io.envoyproxy.envoymobile.engine.testing.HttpProxyTestServerFactory
+import io.envoyproxy.envoymobile.engine.testing.HttpTestServerFactory
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
@@ -41,16 +43,19 @@ class ProxyInfoIntentPerformHTTPSRequestUsingAsyncProxyTest {
   }
 
   private lateinit var httpProxyTestServer: HttpProxyTestServerFactory.HttpProxyTestServer
+  private lateinit var httpTestServer: HttpTestServerFactory.HttpTestServer
 
   @Before
   fun setUp() {
     httpProxyTestServer =
       HttpProxyTestServerFactory.start(HttpProxyTestServerFactory.Type.HTTPS_PROXY)
+    httpTestServer = HttpTestServerFactory.start(HttpTestServerFactory.Type.HTTP1_WITH_TLS)
   }
 
   @After
   fun tearDown() {
     httpProxyTestServer.shutdown()
+    httpTestServer.shutdown()
   }
 
   @Test
@@ -62,7 +67,7 @@ class ProxyInfoIntentPerformHTTPSRequestUsingAsyncProxyTest {
     Shadows.shadowOf(connectivityManager)
       .setProxyForNetwork(
         connectivityManager.activeNetwork,
-        ProxyInfo.buildDirectProxy("localhost", httpProxyTestServer.port)
+        ProxyInfo.buildDirectProxy(httpProxyTestServer.ipAddress, httpProxyTestServer.port)
       )
 
     val onEngineRunningLatch = CountDownLatch(1)
@@ -77,6 +82,7 @@ class ProxyInfoIntentPerformHTTPSRequestUsingAsyncProxyTest {
         .setLogger { _, msg -> print(msg) }
         .enableProxying(true)
         .setOnEngineRunning { onEngineRunningLatch.countDown() }
+        .setTrustChainVerification(EnvoyConfiguration.TrustChainVerification.ACCEPT_UNTRUSTED)
         .build()
 
     onEngineRunningLatch.await(10, TimeUnit.SECONDS)
@@ -86,8 +92,8 @@ class ProxyInfoIntentPerformHTTPSRequestUsingAsyncProxyTest {
       RequestHeadersBuilder(
           method = RequestMethod.GET,
           scheme = "https",
-          authority = "api.lyft.com",
-          path = "/ping"
+          authority = httpTestServer.address,
+          path = "/"
         )
         .build()
 

--- a/mobile/test/kotlin/integration/proxying/ProxyInfoIntentPerformHTTPSRequestUsingProxyTest.kt
+++ b/mobile/test/kotlin/integration/proxying/ProxyInfoIntentPerformHTTPSRequestUsingProxyTest.kt
@@ -11,8 +11,10 @@ import io.envoyproxy.envoymobile.AndroidEngineBuilder
 import io.envoyproxy.envoymobile.LogLevel
 import io.envoyproxy.envoymobile.RequestHeadersBuilder
 import io.envoyproxy.envoymobile.RequestMethod
+import io.envoyproxy.envoymobile.engine.EnvoyConfiguration
 import io.envoyproxy.envoymobile.engine.JniLibrary
 import io.envoyproxy.envoymobile.engine.testing.HttpProxyTestServerFactory
+import io.envoyproxy.envoymobile.engine.testing.HttpTestServerFactory
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
@@ -41,21 +43,23 @@ class ProxyInfoIntentPerformHTTPSRequestUsingProxyTest {
   }
 
   private lateinit var httpProxyTestServer: HttpProxyTestServerFactory.HttpProxyTestServer
+  private lateinit var httpTestServer: HttpTestServerFactory.HttpTestServer
 
   @Before
   fun setUp() {
     httpProxyTestServer =
       HttpProxyTestServerFactory.start(HttpProxyTestServerFactory.Type.HTTPS_PROXY)
+    httpTestServer = HttpTestServerFactory.start(HttpTestServerFactory.Type.HTTP1_WITH_TLS)
   }
 
   @After
   fun tearDown() {
     httpProxyTestServer.shutdown()
+    httpTestServer.shutdown()
   }
 
   @Test
   fun `performs an HTTPs request through a proxy`() {
-    println("IP ADDRESS: ${httpProxyTestServer.ipAddress}")
     val context = ApplicationProvider.getApplicationContext<Context>()
     val connectivityManager =
       context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
@@ -78,6 +82,7 @@ class ProxyInfoIntentPerformHTTPSRequestUsingProxyTest {
         .setLogger { _, msg -> print(msg) }
         .enableProxying(true)
         .setOnEngineRunning { onEngineRunningLatch.countDown() }
+        .setTrustChainVerification(EnvoyConfiguration.TrustChainVerification.ACCEPT_UNTRUSTED)
         .build()
 
     onEngineRunningLatch.await(10, TimeUnit.SECONDS)
@@ -87,8 +92,8 @@ class ProxyInfoIntentPerformHTTPSRequestUsingProxyTest {
       RequestHeadersBuilder(
           method = RequestMethod.GET,
           scheme = "https",
-          authority = "api.lyft.com",
-          path = "/ping"
+          authority = httpTestServer.address,
+          path = "/"
         )
         .build()
 

--- a/mobile/test/kotlin/integration/proxying/ProxyPollPerformHTTPRequestUsingProxyTest.kt
+++ b/mobile/test/kotlin/integration/proxying/ProxyPollPerformHTTPRequestUsingProxyTest.kt
@@ -11,6 +11,7 @@ import io.envoyproxy.envoymobile.RequestHeadersBuilder
 import io.envoyproxy.envoymobile.RequestMethod
 import io.envoyproxy.envoymobile.engine.JniLibrary
 import io.envoyproxy.envoymobile.engine.testing.HttpProxyTestServerFactory
+import io.envoyproxy.envoymobile.engine.testing.HttpTestServerFactory
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
@@ -39,16 +40,19 @@ class ProxyPollPerformHTTPRequestUsingProxyTest {
   }
 
   private lateinit var httpProxyTestServer: HttpProxyTestServerFactory.HttpProxyTestServer
+  private lateinit var httpTestServer: HttpTestServerFactory.HttpTestServer
 
   @Before
   fun setUp() {
     httpProxyTestServer =
       HttpProxyTestServerFactory.start(HttpProxyTestServerFactory.Type.HTTP_PROXY)
+    httpTestServer = HttpTestServerFactory.start(HttpTestServerFactory.Type.HTTP1_WITHOUT_TLS)
   }
 
   @After
   fun tearDown() {
     httpProxyTestServer.shutdown()
+    httpTestServer.shutdown()
   }
 
   @Test
@@ -60,7 +64,7 @@ class ProxyPollPerformHTTPRequestUsingProxyTest {
     Shadows.shadowOf(connectivityManager)
       .setProxyForNetwork(
         connectivityManager.activeNetwork,
-        ProxyInfo.buildDirectProxy("127.0.0.1", httpProxyTestServer.port)
+        ProxyInfo.buildDirectProxy(httpProxyTestServer.ipAddress, httpProxyTestServer.port)
       )
 
     val onEngineRunningLatch = CountDownLatch(1)
@@ -82,8 +86,8 @@ class ProxyPollPerformHTTPRequestUsingProxyTest {
       RequestHeadersBuilder(
           method = RequestMethod.GET,
           scheme = "http",
-          authority = "api.lyft.com",
-          path = "/ping"
+          authority = httpTestServer.address,
+          path = "/"
         )
         .build()
 
@@ -92,7 +96,7 @@ class ProxyPollPerformHTTPRequestUsingProxyTest {
       .newStreamPrototype()
       .setOnResponseHeaders { responseHeaders, _, _ ->
         val status = responseHeaders.httpStatus ?: 0L
-        assertThat(status).isEqualTo(301)
+        assertThat(status).isEqualTo(200)
         assertThat(responseHeaders.value("x-proxy-response")).isEqualTo(listOf("true"))
         onResponseHeadersLatch.countDown()
       }


### PR DESCRIPTION
This should make the tests less flaky.

Risk Level: low (tests only)
Testing: ` bazel test //test/kotlin/integration/proxying/...`
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
