### PR TITLE
MockDispatcher to not accidentally run on other threads

### DIFF
--- a/test/common/thread_local/thread_local_impl_test.cc
+++ b/test/common/thread_local/thread_local_impl_test.cc
@@ -378,7 +378,9 @@ TEST(ThreadLocalInstanceImplDispatcherTest, DestroySlotOnWorker) {
 
         EXPECT_CALL(main_dispatcher, isThreadSafe()).WillOnce(Return(false));
         // Destroy the slot on worker thread and expect the post() of main dispatcher to be called.
-        EXPECT_CALL(main_dispatcher, post(_));
+        // Override the behavior to do nothing, because the default mock behavior asserts that the
+        // callback must run on the same thread as the dispatcher.
+        EXPECT_CALL(main_dispatcher, post(_)).WillOnce([]() {});
 
         slot.reset();
 

--- a/test/mocks/event/mocks.cc
+++ b/test/mocks/event/mocks.cc
@@ -30,8 +30,8 @@ MockDispatcher::MockDispatcher(const std::string& name) : name_(name) {
   ON_CALL(*this, createScaledTimer_(_, _)).WillByDefault(ReturnNew<NiceMock<Event::MockTimer>>());
   ON_CALL(*this, createScaledTypedTimer_(_, _))
       .WillByDefault(ReturnNew<NiceMock<Event::MockTimer>>());
-  ON_CALL(*this, post(_)).WillByDefault([this](PostCb cb) -> void {
-    ASSERT(isThreadSafe(),
+  ON_CALL(*this, post(_)).WillByDefault([thread_factory, thread_id](PostCb cb) -> void {
+    ASSERT(thread_factory->currentThreadId() == thread_id,
            "MockDispatcher tried to execute a callback on a different thread - a test with threads "
            "should probably use a dispatcher from Api::createApiForTest() instead.");
     cb();

--- a/test/mocks/event/mocks.cc
+++ b/test/mocks/event/mocks.cc
@@ -20,6 +20,8 @@ MockDispatcher::MockDispatcher() : MockDispatcher("test_thread") {}
 
 MockDispatcher::MockDispatcher(const std::string& name) : name_(name) {
   time_system_ = std::make_unique<GlobalTimeSystem>();
+  auto thread_factory = &Api::createApiForTest()->threadFactory();
+  Envoy::Thread::ThreadId thread_id = thread_factory->currentThreadId();
   ON_CALL(*this, initializeStats(_, _)).WillByDefault(Return());
   ON_CALL(*this, clearDeferredDeleteList()).WillByDefault(Invoke([this]() -> void {
     to_delete_.clear();
@@ -28,14 +30,21 @@ MockDispatcher::MockDispatcher(const std::string& name) : name_(name) {
   ON_CALL(*this, createScaledTimer_(_, _)).WillByDefault(ReturnNew<NiceMock<Event::MockTimer>>());
   ON_CALL(*this, createScaledTypedTimer_(_, _))
       .WillByDefault(ReturnNew<NiceMock<Event::MockTimer>>());
-  ON_CALL(*this, post(_)).WillByDefault(Invoke([](PostCb cb) -> void { cb(); }));
+  ON_CALL(*this, post(_)).WillByDefault([this](PostCb cb) -> void {
+    ASSERT(isThreadSafe(),
+           "MockDispatcher tried to execute a callback on a different thread - a test with threads "
+           "should probably use a dispatcher from Api::createApiForTest() instead.");
+    cb();
+  });
 
   ON_CALL(buffer_factory_, createBuffer_(_, _, _))
       .WillByDefault(Invoke([](std::function<void()> below_low, std::function<void()> above_high,
                                std::function<void()> above_overflow) -> Buffer::Instance* {
         return new Buffer::WatermarkBuffer(below_low, above_high, above_overflow);
       }));
-  ON_CALL(*this, isThreadSafe()).WillByDefault(Return(true));
+  ON_CALL(*this, isThreadSafe()).WillByDefault([thread_factory, thread_id]() {
+    return thread_factory->currentThreadId() == thread_id;
+  });
 }
 
 MockDispatcher::~MockDispatcher() = default;


### PR DESCRIPTION
Commit Message: MockDispatcher to not accidentally run on other threads
Additional Description: Several issues have been found recently where the MockDispatcher's default behavior of just running the callback immediately causes tests to pass, but asan/tsan/release tests fail, because it ends up running the callback on a different thread, exactly the opposite of almost the whole point of posting things on a dispatcher which is to put them on a specific thread. This change makes MockDispatcher insist on being on whichever thread created the dispatcher, most likely the main thread in tests. This is still not great because the behavior of running the callback immediately is still quite different from the behavior of a dispatcher in production, e.g.
```
auto x = std::make_shared<int>(0);
this_thread_dispatcher.post([x]() { *x += 5; });
*x += 1;
std::cerr << *x << std::endl;
```
would always output 6 with a default MockDispatcher, and would always output 1 with a production dispatcher, but at least cases like that can be debugged linearly and will be the same in all test environments, versus the running on a different (and incorrect) thread problem is very difficult to debug and sometimes only shows up (and sometimes flakily) in the harder to run test contexts.
(But still pretty bad in that test coverage would say a thing works, then in production it could do a different thing than it did in tests.)

Since it's a mock the behavior can also be manually overridden to be the old way. Arguably it should have just always required explicit manual interception because it's supposed to be a mock not a fake.

Risk Level: Should be safe since it's test-only.
Testing: This is test-only.
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
