### PR TITLE
contrib: upgrade go version to 1.23

### DIFF
--- a/bazel/dependency_imports.bzl
+++ b/bazel/dependency_imports.bzl
@@ -18,7 +18,7 @@ load("@rules_rust//rust:defs.bzl", "rust_common")
 load("@rules_rust//rust:repositories.bzl", "rules_rust_dependencies", "rust_register_toolchains", "rust_repository_set")
 
 # go version for rules_go
-GO_VERSION = "1.22.5"
+GO_VERSION = "1.23.1"
 
 JQ_VERSION = "1.7"
 YQ_VERSION = "4.24.4"

--- a/contrib/golang/filters/http/test/test_data/access_log/go.mod
+++ b/contrib/golang/filters/http/test/test_data/access_log/go.mod
@@ -1,6 +1,6 @@
 module example.com/access_log
 
-go 1.20
+go 1.23
 
 require github.com/envoyproxy/envoy v1.24.0
 

--- a/contrib/golang/filters/http/test/test_data/action/go.mod
+++ b/contrib/golang/filters/http/test/test_data/action/go.mod
@@ -1,6 +1,6 @@
 module example.com/action
 
-go 1.20
+go 1.23
 
 require github.com/envoyproxy/envoy v1.24.0
 

--- a/contrib/golang/filters/http/test/test_data/basic/go.mod
+++ b/contrib/golang/filters/http/test/test_data/basic/go.mod
@@ -1,6 +1,6 @@
 module example.com/basic
 
-go 1.20
+go 1.23
 
 require github.com/envoyproxy/envoy v1.24.0
 

--- a/contrib/golang/filters/http/test/test_data/buffer/go.mod
+++ b/contrib/golang/filters/http/test/test_data/buffer/go.mod
@@ -1,6 +1,6 @@
 module example.com/buffer
 
-go 1.20
+go 1.23
 
 require (
 	github.com/envoyproxy/envoy v1.24.0

--- a/contrib/golang/filters/http/test/test_data/dummy/go.mod
+++ b/contrib/golang/filters/http/test/test_data/dummy/go.mod
@@ -1,6 +1,6 @@
 module example.com/dummy
 
-go 1.20
+go 1.23
 
 require github.com/envoyproxy/envoy v1.24.0
 

--- a/contrib/golang/filters/http/test/test_data/echo/go.mod
+++ b/contrib/golang/filters/http/test/test_data/echo/go.mod
@@ -1,6 +1,6 @@
 module example.com/echo
 
-go 1.20
+go 1.23
 
 require (
 	github.com/cncf/xds/go v0.0.0-20231128003011-0fa0005c9caa

--- a/contrib/golang/filters/http/test/test_data/metric/go.mod
+++ b/contrib/golang/filters/http/test/test_data/metric/go.mod
@@ -1,6 +1,6 @@
 module example.com/basic
 
-go 1.20
+go 1.23
 
 require github.com/envoyproxy/envoy v1.24.0
 

--- a/contrib/golang/filters/http/test/test_data/passthrough/go.mod
+++ b/contrib/golang/filters/http/test/test_data/passthrough/go.mod
@@ -1,6 +1,6 @@
 module example.com/passthrough
 
-go 1.20
+go 1.23
 
 require github.com/envoyproxy/envoy v1.24.0
 

--- a/contrib/golang/filters/http/test/test_data/property/go.mod
+++ b/contrib/golang/filters/http/test/test_data/property/go.mod
@@ -1,6 +1,6 @@
 module example.com/property
 
-go 1.20
+go 1.23
 
 require (
 	github.com/envoyproxy/envoy v1.24.0

--- a/contrib/golang/filters/http/test/test_data/routeconfig/go.mod
+++ b/contrib/golang/filters/http/test/test_data/routeconfig/go.mod
@@ -1,6 +1,6 @@
 module example.com/routeconfig
 
-go 1.20
+go 1.23
 
 require (
 	github.com/cncf/xds/go v0.0.0-20231128003011-0fa0005c9caa

--- a/contrib/golang/filters/http/test/test_data/websocket/go.mod
+++ b/contrib/golang/filters/http/test/test_data/websocket/go.mod
@@ -1,6 +1,6 @@
 module example.com/websocket
 
-go 1.20
+go 1.23
 
 require github.com/envoyproxy/envoy v1.24.0
 

--- a/contrib/golang/filters/network/test/test_data/go.mod
+++ b/contrib/golang/filters/network/test/test_data/go.mod
@@ -1,6 +1,6 @@
 module github.com/envoyproxy/envoy/contrib/golang/filters/network/test/test_data
 
-go 1.18
+go 1.23
 
 require github.com/envoyproxy/envoy v1.24.0
 

--- a/contrib/golang/router/cluster_specifier/test/test_data/simple/go.mod
+++ b/contrib/golang/router/cluster_specifier/test/test_data/simple/go.mod
@@ -1,6 +1,6 @@
 module example.com/routeconfig
 
-go 1.18
+go 1.23
 
 require (
 	github.com/cncf/xds/go v0.0.0-20231128003011-0fa0005c9caa

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/envoyproxy/envoy
 
-go 1.20
+go 1.23
 
-require google.golang.org/protobuf v1.34.1
+require google.golang.org/protobuf v1.34.2
 
 require github.com/google/go-cmp v0.5.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,3 +2,5 @@ github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 google.golang.org/protobuf v1.34.1 h1:9ddQBjfCyZPOHPUiPxpYESBLc+T8P3E+Vo4IbKZgFWg=
 google.golang.org/protobuf v1.34.1/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
+google.golang.org/protobuf v1.34.2 h1:6xV6lTsCfpGD21XK49h7MhtcApnLqkfYgPcdHftf6hg=
+google.golang.org/protobuf v1.34.2/go.mod h1:qYOHts0dSfpeUzUFpOMr/WGzszTmLH+DiWniOlNbLDw=


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: upgrade go version to 1.23
Additional Description:

Given the [Go release policy](https://go.dev/doc/devel/release#policy):
> Each major Go release is supported until there are two newer major releases.

This PR upgrades Go toolchain to its latest release after seeking advices from @doujiang24.

Risk Level: low.
Testing: n/a.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.
