### PR TITLE
[RLQS] Implement RLQS stream restarts if the stream goes down mid-use.

### DIFF
--- a/source/extensions/filters/http/rate_limit_quota/client.h
+++ b/source/extensions/filters/http/rate_limit_quota/client.h
@@ -37,7 +37,7 @@ class RateLimitClient {
 public:
   virtual ~RateLimitClient() = default;
 
-  virtual absl::Status startStream(const StreamInfo::StreamInfo& stream_info) PURE;
+  virtual absl::Status startStream(const StreamInfo::StreamInfo* stream_info) PURE;
   virtual void closeStream() PURE;
   virtual void sendUsageReport(absl::optional<size_t> bucket_id) PURE;
 

--- a/source/extensions/filters/http/rate_limit_quota/client_impl.cc
+++ b/source/extensions/filters/http/rate_limit_quota/client_impl.cc
@@ -72,13 +72,9 @@ void RateLimitClientImpl::sendUsageReport(absl::optional<size_t> bucket_id) {
     }
   }
 
-  if (stream_ != nullptr) {
-    // Build the report and then send the report to RLQS server.
-    // `end_stream` should always be set to false as we don't want to close the stream locally.
-    stream_->sendMessage(buildReport(bucket_id), /*end_stream=*/false);
-  } else {
-    ENVOY_LOG(error, "gRPC stream is still unavailable so usage reports will be dropped.");
-  }
+  // Build the report and then send the report to RLQS server.
+  // `end_stream` should always be set to false as we don't want to close the stream locally.
+  stream_->sendMessage(buildReport(bucket_id), /*end_stream=*/false);
 }
 
 void RateLimitClientImpl::onReceiveMessage(RateLimitQuotaResponsePtr&& response) {

--- a/source/extensions/filters/http/rate_limit_quota/client_impl.cc
+++ b/source/extensions/filters/http/rate_limit_quota/client_impl.cc
@@ -64,13 +64,20 @@ RateLimitQuotaUsageReports RateLimitClientImpl::buildReport(absl::optional<size_
 // This function covers both periodical report and immediate report case, with the difference that
 // bucked id in periodical report case is empty.
 void RateLimitClientImpl::sendUsageReport(absl::optional<size_t> bucket_id) {
+  if (stream_ == nullptr) {
+    ENVOY_LOG(debug, "The RLQS stream has been closed and must be restarted to send reports.");
+    if (absl::Status err = startStream(nullptr); !err.ok()) {
+      ENVOY_LOG(error, "Failed to start the stream to send reports.");
+      return;
+    }
+  }
+
   if (stream_ != nullptr) {
     // Build the report and then send the report to RLQS server.
     // `end_stream` should always be set to false as we don't want to close the stream locally.
     stream_->sendMessage(buildReport(bucket_id), /*end_stream=*/false);
   } else {
-    // Don't send any reports if stream has already been closed.
-    ENVOY_LOG(debug, "The stream has already been closed; no reports will be sent.");
+    ENVOY_LOG(error, "gRPC stream is still unavailable so usage reports will be dropped.");
   }
 }
 
@@ -165,20 +172,27 @@ void RateLimitClientImpl::onRemoteClose(Grpc::Status::GrpcStatus status,
   stream_ = nullptr;
 }
 
-absl::Status RateLimitClientImpl::startStream(const StreamInfo::StreamInfo& stream_info) {
+absl::Status RateLimitClientImpl::startStream(const StreamInfo::StreamInfo* stream_info) {
   // Starts stream if it has not been opened yet.
   if (stream_ == nullptr) {
     ENVOY_LOG(debug, "Trying to start the new gRPC stream");
+    auto stream_options = Http::AsyncClient::RequestOptions();
+    if (stream_info) {
+      stream_options.setParentContext(Http::AsyncClient::ParentContext{stream_info});
+    }
     stream_ = aync_client_.start(
         *Protobuf::DescriptorPool::generated_pool()->FindMethodByName(
             "envoy.service.rate_limit_quota.v3.RateLimitQuotaService.StreamRateLimitQuotas"),
-        *this,
-        Http::AsyncClient::RequestOptions().setParentContext(
-            Http::AsyncClient::ParentContext{&stream_info}));
+        *this, stream_options);
   }
 
-  // Returns error status if start failed (i.e., stream_ is nullptr).
-  return stream_ == nullptr ? absl::InternalError("Failed to start the stream") : absl::OkStatus();
+  // If still null after attempting a start.
+  if (stream_ == nullptr) {
+    return absl::InternalError("Failed to start the stream");
+  }
+
+  ENVOY_LOG(debug, "gRPC stream has been started");
+  return absl::OkStatus();
 }
 
 } // namespace RateLimitQuota

--- a/source/extensions/filters/http/rate_limit_quota/client_impl.h
+++ b/source/extensions/filters/http/rate_limit_quota/client_impl.h
@@ -45,7 +45,7 @@ public:
   void onRemoteClose(Grpc::Status::GrpcStatus status, const std::string& message) override;
 
   // RateLimitClient methods.
-  absl::Status startStream(const StreamInfo::StreamInfo& stream_info) override;
+  absl::Status startStream(const StreamInfo::StreamInfo* stream_info) override;
   void closeStream() override;
   // Send the usage report to RLQS server
   void sendUsageReport(absl::optional<size_t> bucket_id) override;

--- a/source/extensions/filters/http/rate_limit_quota/filter.cc
+++ b/source/extensions/filters/http/rate_limit_quota/filter.cc
@@ -185,7 +185,7 @@ RateLimitQuotaFilter::sendImmediateReport(const size_t bucket_id,
 
   // Start the streaming on the first request.
   // It will be a no-op if the stream is already active.
-  auto status = client_.rate_limit_client->startStream(callbacks_->streamInfo());
+  auto status = client_.rate_limit_client->startStream(&callbacks_->streamInfo());
   if (!status.ok()) {
     ENVOY_LOG(error, "Failed to start the gRPC stream: ", status.message());
     // TODO(tyxia) Check `NoAssignmentBehavior` behavior instead of fail-open here.

--- a/test/extensions/filters/http/rate_limit_quota/client_test.cc
+++ b/test/extensions/filters/http/rate_limit_quota/client_test.cc
@@ -18,7 +18,7 @@ public:
 };
 
 TEST_F(RateLimitClientTest, OpenAndCloseStream) {
-  EXPECT_OK(test_client.client_->startStream(test_client.stream_info_));
+  EXPECT_OK(test_client.client_->startStream(&test_client.stream_info_));
   EXPECT_CALL(test_client.stream_, closeStream());
   EXPECT_CALL(test_client.stream_, resetStream());
   test_client.client_->closeStream();
@@ -27,7 +27,7 @@ TEST_F(RateLimitClientTest, OpenAndCloseStream) {
 TEST_F(RateLimitClientTest, SendUsageReport) {
   ::envoy::service::rate_limit_quota::v3::BucketId bucket_id;
   TestUtility::loadFromYaml(SingleBukcetId, bucket_id);
-  EXPECT_OK(test_client.client_->startStream(test_client.stream_info_));
+  EXPECT_OK(test_client.client_->startStream(&test_client.stream_info_));
   bool end_stream = false;
   // Send quota usage report and ensure that we get it.
   EXPECT_CALL(test_client.stream_, sendMessageRaw_(_, end_stream));
@@ -39,7 +39,7 @@ TEST_F(RateLimitClientTest, SendUsageReport) {
 }
 
 TEST_F(RateLimitClientTest, SendRequestAndReceiveResponse) {
-  EXPECT_OK(test_client.client_->startStream(test_client.stream_info_));
+  EXPECT_OK(test_client.client_->startStream(&test_client.stream_info_));
   ASSERT_NE(test_client.stream_callbacks_, nullptr);
 
   auto empty_request_headers = Http::RequestHeaderMapImpl::create();

--- a/test/extensions/filters/http/rate_limit_quota/client_test_utils.h
+++ b/test/extensions/filters/http/rate_limit_quota/client_test_utils.h
@@ -70,12 +70,12 @@ public:
   }
 
   Grpc::RawAsyncClientSharedPtr mockCreateAsyncClient(Unused, Unused, Unused) {
-    auto async_client = std::make_shared<Grpc::MockAsyncClient>();
-    EXPECT_CALL(*async_client, startRaw("envoy.service.rate_limit_quota.v3.RateLimitQuotaService",
-                                        "StreamRateLimitQuotas", _, _))
-        .WillOnce(Invoke(this, &RateLimitTestClient::mockStartRaw));
+    async_client_ = std::make_shared<Grpc::MockAsyncClient>();
+    EXPECT_CALL(*async_client_, startRaw("envoy.service.rate_limit_quota.v3.RateLimitQuotaService",
+                                         "StreamRateLimitQuotas", _, _))
+        .WillRepeatedly(Invoke(this, &RateLimitTestClient::mockStartRaw));
 
-    return async_client;
+    return async_client_;
   }
 
   Grpc::RawAsyncStream* mockStartRaw(Unused, Unused, Grpc::RawAsyncStreamCallbacks& callbacks,
@@ -97,7 +97,7 @@ public:
   Grpc::RawAsyncStreamCallbacks* stream_callbacks_;
   Grpc::Status::GrpcStatus grpc_status_ = Grpc::Status::WellKnownGrpcStatus::Ok;
   RateLimitClientPtr client_;
-  // std::unique_ptr<RateLimitClient> client_;
+  std::shared_ptr<Grpc::MockAsyncClient> async_client_ = nullptr;
   MockRateLimitQuotaCallbacks callbacks_;
   bool external_inited_ = false;
   bool start_failed_ = false;

--- a/test/extensions/filters/http/rate_limit_quota/mocks.h
+++ b/test/extensions/filters/http/rate_limit_quota/mocks.h
@@ -28,7 +28,7 @@ public:
   MockRateLimitClient() = default;
   ~MockRateLimitClient() override = default;
 
-  MOCK_METHOD(absl::Status, startStream, (const StreamInfo::StreamInfo&));
+  MOCK_METHOD(absl::Status, startStream, (const StreamInfo::StreamInfo*));
   MOCK_METHOD(void, closeStream, ());
   MOCK_METHOD(void, sendUsageReport, (absl::optional<size_t>));
 


### PR DESCRIPTION
Commit Message: Implement RLQS stream restarts if the stream goes down mid-use.
Additional Description: Stream restarts are done during periodic usage reporting, which limits retry spam while backends are offline.
Risk Level:
Testing: Integration testing updated to exercise the filter before and after stream closure.
Docs Changes:
Release Notes:
Platform Specific Features: