### PR TITLE
Refactor cache_filter to expect caches to post cb

### DIFF
--- a/source/extensions/filters/http/cache/cache_filter.h
+++ b/source/extensions/filters/http/cache/cache_filter.h
@@ -164,6 +164,8 @@ private:
   FilterState filter_state_ = FilterState::Initial;
 
   bool is_head_request_ = false;
+  // This toggle is used to detect callbacks being called directly and not posted.
+  bool callback_called_directly_ = false;
   // The status of the insert operation or header update, or decision not to insert or update.
   // If it's too early to determine the final status, this is empty.
   absl::optional<InsertStatus> insert_status_;

--- a/source/extensions/filters/http/cache/cache_insert_queue.h
+++ b/source/extensions/filters/http/cache/cache_insert_queue.h
@@ -12,7 +12,7 @@ namespace Cache {
 
 using OverHighWatermarkCallback = std::function<void()>;
 using UnderLowWatermarkCallback = std::function<void()>;
-using AbortInsertCallback = std::function<void()>;
+using AbortInsertCallback = absl::AnyInvocable<void()>;
 class CacheInsertFragment;
 
 // This queue acts as an intermediary between CacheFilter and the cache

--- a/source/extensions/filters/http/cache/http_cache.h
+++ b/source/extensions/filters/http/cache/http_cache.h
@@ -122,19 +122,20 @@ struct CacheInfo {
   bool supports_range_requests_ = false;
 };
 
-using LookupBodyCallback = std::function<void(Buffer::InstancePtr&&, bool end_stream)>;
-using LookupHeadersCallback = std::function<void(LookupResult&&, bool end_stream)>;
-using LookupTrailersCallback = std::function<void(Http::ResponseTrailerMapPtr&&)>;
-using InsertCallback = std::function<void(bool success_ready_for_more)>;
+using LookupBodyCallback = absl::AnyInvocable<void(Buffer::InstancePtr&&, bool end_stream)>;
+using LookupHeadersCallback = absl::AnyInvocable<void(LookupResult&&, bool end_stream)>;
+using LookupTrailersCallback = absl::AnyInvocable<void(Http::ResponseTrailerMapPtr&&)>;
+using InsertCallback = absl::AnyInvocable<void(bool success_ready_for_more)>;
+using UpdateHeadersCallback = absl::AnyInvocable<void(bool)>;
 
 // Manages the lifetime of an insertion.
 class InsertContext {
 public:
   // Accepts response_headers for caching. Only called once.
   //
-  // Implementations MUST call insert_complete(true) on success, or
-  // insert_complete(false) to attempt to abort the insertion. This
-  // call may be made asynchronously, but any async operation that can
+  // Implementations MUST post to the filter's dispatcher insert_complete(true)
+  // on success, or insert_complete(false) to attempt to abort the insertion.
+  // This call may be made asynchronously, but any async operation that can
   // potentially silently fail must include a timeout, to avoid memory leaks.
   virtual void insertHeaders(const Http::ResponseHeaderMap& response_headers,
                              const ResponseMetadata& metadata, InsertCallback insert_complete,
@@ -149,17 +150,17 @@ public:
   // InsertContextPtr. A cache can abort the insertion by passing 'false' into
   // ready_for_next_fragment.
   //
-  // The cache implementation MUST call ready_for_next_fragment. This call may be
-  // made asynchronously, but any async operation that can potentially silently
-  // fail must include a timeout, to avoid memory leaks.
+  // The cache implementation MUST post ready_for_next_fragment to the filter's
+  // dispatcher. This post may be made asynchronously, but any async operation
+  // that can potentially silently fail must include a timeout, to avoid memory leaks.
   virtual void insertBody(const Buffer::Instance& fragment, InsertCallback ready_for_next_fragment,
                           bool end_stream) PURE;
 
   // Inserts trailers into the cache.
   //
-  // The cache implementation MUST call insert_complete. This call may be
-  // made asynchronously, but any async operation that can potentially silently
-  // fail must include a timeout, to avoid memory leaks.
+  // The cache implementation MUST post insert_complete to the filter's dispatcher.
+  // This call may be made asynchronously, but any async operation that can
+  // potentially silently fail must include a timeout, to avoid memory leaks.
   virtual void insertTrailers(const Http::ResponseTrailerMap& trailers,
                               InsertCallback insert_complete) PURE;
 
@@ -199,6 +200,9 @@ public:
   // implementation should wait until that is known before calling the callback,
   // and must pass a LookupResult with range_details_->satisfiable_ = false
   // if the request is invalid.
+  //
+  // A cache that posts the callback must wrap it such that if the LookupContext is
+  // destroyed before the callback is executed, the callback is not executed.
   virtual void getHeaders(LookupHeadersCallback&& cb) PURE;
 
   // Reads the next fragment from the cache, calling cb when the fragment is ready.
@@ -228,11 +232,17 @@ public:
   // getBody requests bytes  0-23 .......... callback with bytes 0-9
   // getBody requests bytes 10-23 .......... callback with bytes 10-19
   // getBody requests bytes 20-23 .......... callback with bytes 20-23
+  //
+  // A cache that posts the callback must wrap it such that if the LookupContext is
+  // destroyed before the callback is executed, the callback is not executed.
   virtual void getBody(const AdjustedByteRange& range, LookupBodyCallback&& cb) PURE;
 
   // Get the trailers from the cache. Only called if the request reached the end of
   // the body and LookupBodyCallback did not pass true for end_stream. The
   // Http::ResponseTrailerMapPtr passed to cb must not be null.
+  //
+  // A cache that posts the callback must wrap it such that if the LookupContext is
+  // destroyed before the callback is executed, the callback is not executed.
   virtual void getTrailers(LookupTrailersCallback&& cb) PURE;
 
   // This routine is called prior to a LookupContext being destroyed. LookupContext is responsible
@@ -248,7 +258,7 @@ public:
   // 5. [Other thread] RPC completes and calls RPCLookupContext::onRPCDone.
   // --> RPCLookupContext's destructor and onRpcDone cause a data race in RPCLookupContext.
   // onDestroy() should cancel any outstanding async operations and, if necessary,
-  // it should block on that cancellation to avoid data races. InsertContext must not invoke any
+  // it should block on that cancellation to avoid data races. LookupContext must not invoke any
   // callbacks to the CacheFilter after having onDestroy() invoked.
   virtual void onDestroy() PURE;
 
@@ -289,7 +299,7 @@ public:
   virtual void updateHeaders(const LookupContext& lookup_context,
                              const Http::ResponseHeaderMap& response_headers,
                              const ResponseMetadata& metadata,
-                             std::function<void(bool)> on_complete) PURE;
+                             UpdateHeadersCallback on_complete) PURE;
 
   // Returns statically known information about a cache.
   virtual CacheInfo cacheInfo() const PURE;

--- a/source/extensions/http/cache/file_system_http_cache/file_system_http_cache.h
+++ b/source/extensions/http/cache/file_system_http_cache/file_system_http_cache.h
@@ -79,8 +79,7 @@ public:
    */
   void updateHeaders(const LookupContext& lookup_context,
                      const Http::ResponseHeaderMap& response_headers,
-                     const ResponseMetadata& metadata,
-                     std::function<void(bool)> on_complete) override;
+                     const ResponseMetadata& metadata, UpdateHeadersCallback on_complete) override;
 
   /**
    * The config of this cache. Used by the factory to ensure there aren't incompatible

--- a/source/extensions/http/cache/file_system_http_cache/insert_context.h
+++ b/source/extensions/http/cache/file_system_http_cache/insert_context.h
@@ -88,7 +88,6 @@ private:
   void commitCreateHardLink();
   CacheFileHeader cache_file_header_proto_;
   bool end_stream_after_headers_ = false;
-  InsertCallback on_insert_complete_;
   std::unique_ptr<FileLookupContext> lookup_context_;
   Key key_;
   std::shared_ptr<FileSystemHttpCache> cache_;

--- a/source/extensions/http/cache/file_system_http_cache/lookup_context.cc
+++ b/source/extensions/http/cache/file_system_http_cache/lookup_context.cc
@@ -140,7 +140,7 @@ void FileLookupContext::getBody(const AdjustedByteRange& range, LookupBodyCallba
   ASSERT(file_handle_);
   auto queued = file_handle_->read(
       dispatcher(), header_block_.offsetToBody() + range.begin(), range.length(),
-      [this, cb = std::move(cb), range](absl::StatusOr<Buffer::InstancePtr> read_result) {
+      [this, cb = std::move(cb), range](absl::StatusOr<Buffer::InstancePtr> read_result) mutable {
         ASSERT(dispatcher()->isThreadSafe());
         cancel_action_in_flight_ = nullptr;
         if (!read_result.ok() || read_result.value()->length() != range.length()) {
@@ -164,7 +164,7 @@ void FileLookupContext::getTrailers(LookupTrailersCallback&& cb) {
   ASSERT(file_handle_);
   auto queued = file_handle_->read(
       dispatcher(), header_block_.offsetToTrailers(), header_block_.trailerSize(),
-      [this, cb = std::move(cb)](absl::StatusOr<Buffer::InstancePtr> read_result) {
+      [this, cb = std::move(cb)](absl::StatusOr<Buffer::InstancePtr> read_result) mutable {
         ASSERT(dispatcher()->isThreadSafe());
         cancel_action_in_flight_ = nullptr;
         if (!read_result.ok() || read_result.value()->length() != header_block_.trailerSize()) {

--- a/source/extensions/http/cache/simple_http_cache/simple_http_cache.cc
+++ b/source/extensions/http/cache/simple_http_cache/simple_http_cache.cc
@@ -33,35 +33,57 @@ absl::optional<Key> variedRequestKey(const LookupRequest& request,
 
 class SimpleLookupContext : public LookupContext {
 public:
-  SimpleLookupContext(SimpleHttpCache& cache, LookupRequest&& request)
-      : cache_(cache), request_(std::move(request)) {}
+  SimpleLookupContext(Event::Dispatcher& dispatcher, SimpleHttpCache& cache,
+                      LookupRequest&& request)
+      : dispatcher_(dispatcher), cache_(cache), request_(std::move(request)) {}
 
   void getHeaders(LookupHeadersCallback&& cb) override {
     auto entry = cache_.lookup(request_);
     body_ = std::move(entry.body_);
     trailers_ = std::move(entry.trailers_);
-    cb(entry.response_headers_ ? request_.makeLookupResult(std::move(entry.response_headers_),
-                                                           std::move(entry.metadata_), body_.size())
-                               : LookupResult{},
-       body_.empty() && trailers_ == nullptr);
+    LookupResult result = entry.response_headers_
+                              ? request_.makeLookupResult(std::move(entry.response_headers_),
+                                                          std::move(entry.metadata_), body_.size())
+                              : LookupResult{};
+    bool end_stream = body_.empty() && trailers_ == nullptr;
+    dispatcher_.post([result = std::move(result), cb = std::move(cb), end_stream,
+                      cancelled = cancelled_]() mutable {
+      if (!*cancelled) {
+        std::move(cb)(std::move(result), end_stream);
+      }
+    });
   }
 
   void getBody(const AdjustedByteRange& range, LookupBodyCallback&& cb) override {
     ASSERT(range.end() <= body_.length(), "Attempt to read past end of body.");
-    cb(std::make_unique<Buffer::OwnedImpl>(&body_[range.begin()], range.length()),
-       trailers_ == nullptr && range.end() == body_.length());
+    auto result = std::make_unique<Buffer::OwnedImpl>(&body_[range.begin()], range.length());
+    bool end_stream = trailers_ == nullptr && range.end() == body_.length();
+    dispatcher_.post([result = std::move(result), cb = std::move(cb), end_stream,
+                      cancelled = cancelled_]() mutable {
+      if (!*cancelled) {
+        std::move(cb)(std::move(result), end_stream);
+      }
+    });
   }
 
   // The cache must call cb with the cached trailers.
   void getTrailers(LookupTrailersCallback&& cb) override {
     ASSERT(trailers_);
-    cb(std::move(trailers_));
+    dispatcher_.post(
+        [cb = std::move(cb), trailers = std::move(trailers_), cancelled = cancelled_]() mutable {
+          if (!*cancelled) {
+            std::move(cb)(std::move(trailers));
+          }
+        });
   }
 
   const LookupRequest& request() const { return request_; }
-  void onDestroy() override {}
+  void onDestroy() override { *cancelled_ = true; }
+  Event::Dispatcher& dispatcher() const { return dispatcher_; }
 
 private:
+  Event::Dispatcher& dispatcher_;
+  std::shared_ptr<bool> cancelled_ = std::make_shared<bool>(false);
   SimpleHttpCache& cache_;
   const LookupRequest request_;
   std::string body_;
@@ -70,13 +92,18 @@ private:
 
 class SimpleInsertContext : public InsertContext {
 public:
-  SimpleInsertContext(LookupContext& lookup_context, SimpleHttpCache& cache)
-      : key_(dynamic_cast<SimpleLookupContext&>(lookup_context).request().key()),
-        request_headers_(
-            dynamic_cast<SimpleLookupContext&>(lookup_context).request().requestHeaders()),
-        vary_allow_list_(
-            dynamic_cast<SimpleLookupContext&>(lookup_context).request().varyAllowList()),
-        cache_(cache) {}
+  SimpleInsertContext(SimpleLookupContext& lookup_context, SimpleHttpCache& cache)
+      : dispatcher_(lookup_context.dispatcher()), key_(lookup_context.request().key()),
+        request_headers_(lookup_context.request().requestHeaders()),
+        vary_allow_list_(lookup_context.request().varyAllowList()), cache_(cache) {}
+
+  void post(InsertCallback cb, bool result) {
+    dispatcher_.post([cb = std::move(cb), result = result, cancelled = cancelled_]() mutable {
+      if (!*cancelled) {
+        std::move(cb)(result);
+      }
+    });
+  }
 
   void insertHeaders(const Http::ResponseHeaderMap& response_headers,
                      const ResponseMetadata& metadata, InsertCallback insert_success,
@@ -85,9 +112,9 @@ public:
     response_headers_ = Http::createHeaderMap<Http::ResponseHeaderMapImpl>(response_headers);
     metadata_ = metadata;
     if (end_stream) {
-      insert_success(commit());
+      post(std::move(insert_success), commit());
     } else {
-      insert_success(true);
+      post(std::move(insert_success), true);
     }
   }
 
@@ -98,9 +125,9 @@ public:
 
     body_.add(chunk);
     if (end_stream) {
-      ready_for_next_chunk(commit());
+      post(std::move(ready_for_next_chunk), commit());
     } else {
-      ready_for_next_chunk(true);
+      post(std::move(ready_for_next_chunk), true);
     }
   }
 
@@ -108,10 +135,10 @@ public:
                       InsertCallback insert_complete) override {
     ASSERT(!committed_);
     trailers_ = Http::createHeaderMap<Http::ResponseTrailerMapImpl>(trailers);
-    insert_complete(commit());
+    post(std::move(insert_complete), commit());
   }
 
-  void onDestroy() override {}
+  void onDestroy() override { *cancelled_ = true; }
 
 private:
   bool commit() {
@@ -126,6 +153,8 @@ private:
     }
   }
 
+  Event::Dispatcher& dispatcher_;
+  std::shared_ptr<bool> cancelled_ = std::make_shared<bool>(false);
   Key key_;
   const Http::RequestHeaderMap& request_headers_;
   const VaryAllowList& vary_allow_list_;
@@ -139,32 +168,38 @@ private:
 } // namespace
 
 LookupContextPtr SimpleHttpCache::makeLookupContext(LookupRequest&& request,
-                                                    Http::StreamDecoderFilterCallbacks&) {
-  return std::make_unique<SimpleLookupContext>(*this, std::move(request));
+                                                    Http::StreamDecoderFilterCallbacks& callbacks) {
+  return std::make_unique<SimpleLookupContext>(callbacks.dispatcher(), *this, std::move(request));
 }
 
 void SimpleHttpCache::updateHeaders(const LookupContext& lookup_context,
                                     const Http::ResponseHeaderMap& response_headers,
                                     const ResponseMetadata& metadata,
-                                    std::function<void(bool)> on_complete) {
+                                    UpdateHeadersCallback on_complete) {
   const auto& simple_lookup_context = static_cast<const SimpleLookupContext&>(lookup_context);
   const Key& key = simple_lookup_context.request().key();
   absl::WriterMutexLock lock(&mutex_);
   auto iter = map_.find(key);
+  auto post_complete = [on_complete = std::move(on_complete),
+                        &dispatcher = simple_lookup_context.dispatcher()](bool result) mutable {
+    dispatcher.post([on_complete = std::move(on_complete), result]() mutable {
+      std::move(on_complete)(result);
+    });
+  };
   if (iter == map_.end() || !iter->second.response_headers_) {
-    on_complete(false);
+    std::move(post_complete)(false);
     return;
   }
   if (VaryHeaderUtils::hasVary(*iter->second.response_headers_)) {
     absl::optional<Key> varied_key =
         variedRequestKey(simple_lookup_context.request(), *iter->second.response_headers_);
     if (!varied_key.has_value()) {
-      on_complete(false);
+      std::move(post_complete)(false);
       return;
     }
     iter = map_.find(varied_key.value());
     if (iter == map_.end() || !iter->second.response_headers_) {
-      on_complete(false);
+      std::move(post_complete)(false);
       return;
     }
   }
@@ -172,7 +207,7 @@ void SimpleHttpCache::updateHeaders(const LookupContext& lookup_context,
 
   applyHeaderUpdate(response_headers, *entry.response_headers_);
   entry.metadata_ = metadata;
-  on_complete(true);
+  std::move(post_complete)(true);
 }
 
 SimpleHttpCache::Entry SimpleHttpCache::lookup(const LookupRequest& request) {
@@ -278,7 +313,8 @@ bool SimpleHttpCache::varyInsert(const Key& request_key,
 InsertContextPtr SimpleHttpCache::makeInsertContext(LookupContextPtr&& lookup_context,
                                                     Http::StreamEncoderFilterCallbacks&) {
   ASSERT(lookup_context != nullptr);
-  return std::make_unique<SimpleInsertContext>(*lookup_context, *this);
+  return std::make_unique<SimpleInsertContext>(dynamic_cast<SimpleLookupContext&>(*lookup_context),
+                                               *this);
 }
 
 constexpr absl::string_view Name = "envoy.extensions.http.cache.simple";

--- a/source/extensions/http/cache/simple_http_cache/simple_http_cache.h
+++ b/source/extensions/http/cache/simple_http_cache/simple_http_cache.h
@@ -40,8 +40,7 @@ public:
                                      Http::StreamEncoderFilterCallbacks& callbacks) override;
   void updateHeaders(const LookupContext& lookup_context,
                      const Http::ResponseHeaderMap& response_headers,
-                     const ResponseMetadata& metadata,
-                     std::function<void(bool)> on_complete) override;
+                     const ResponseMetadata& metadata, UpdateHeadersCallback on_complete) override;
   CacheInfo cacheInfo() const override;
 
   Entry lookup(const LookupRequest& request);

--- a/test/extensions/filters/http/cache/http_cache_implementation_test_common.h
+++ b/test/extensions/filters/http/cache/http_cache_implementation_test_common.h
@@ -63,6 +63,7 @@ protected:
 
   std::shared_ptr<HttpCache> cache() const { return delegate_->cache(); }
   bool validationEnabled() const { return delegate_->validationEnabled(); }
+  void pumpIntoDispatcher() { delegate_->beforePumpingDispatcher(); }
   void pumpDispatcher() { delegate_->pumpDispatcher(); }
   LookupContextPtr lookup(absl::string_view request_path);
 
@@ -90,6 +91,8 @@ protected:
                      const ResponseMetadata& metadata);
 
   LookupRequest makeLookupRequest(absl::string_view request_path);
+
+  LookupContextPtr lookupContextWithAllParts();
 
   testing::AssertionResult
   expectLookupSuccessWithHeaders(LookupContext* lookup_context,

--- a/test/extensions/filters/http/cache/mocks.h
+++ b/test/extensions/filters/http/cache/mocks.h
@@ -17,7 +17,7 @@ public:
               (LookupContextPtr && lookup_context, Http::StreamEncoderFilterCallbacks& callbacks));
   MOCK_METHOD(void, updateHeaders,
               (const LookupContext& lookup_context, const Http::ResponseHeaderMap& response_headers,
-               const ResponseMetadata& metadata, std::function<void(bool)> on_complete));
+               const ResponseMetadata& metadata, absl::AnyInvocable<void(bool)> on_complete));
   MOCK_METHOD(CacheInfo, cacheInfo, (), (const));
 };
 


### PR DESCRIPTION
Commit Message: Refactor cache_filter to expect caches to post cb
Additional Description: This is a bit of an unintuitive change in that it moves some work from the common class to the plugin, meaning that work will be duplicated. However, there's a good reason for this - if the cache class needs to use a dispatcher to get back onto its own thread, having cache_filter also post means that actions end up being queued in the dispatcher twice.

A different possible solution would be to have the cache_filter callbacks only post if the callback comes in on the wrong thread, but there's a wrinkle in that model too - if the callback executes immediately, on the same thread, as was the case with the simple_http_cache, it executes too soon, trying to resume a connection that hasn't yet stopped, which is an error. That, too, could be covered with *another* workaround, either intercepting when that happens and posting the resume, or intercepting when that happens and replacing the resume with returning `Continue` instead, but both of those options make the cache filter itself more complicated (and therefore error prone).

Having just one consistent path, where the cache implementation always posts the callback (and never calls it if cancelled), and the cache always performs the callback outside of the initial call's context and on its own thread, is the least complexity, and avoids the performance impact of posting twice, at a cost of a bit more verbosity in the simple cache implementation.

This PR also wraps the UpdateHeadersCallback into a declared type, and makes it an `AnyInvocable` instead of a `std::function`, which enforces that callbacks are called only once and that they're moved not copied, avoiding accidental performance drains.

Risk Level: Low; WIP filter, existing tests still pass.
Testing: Existing tests should be covering all cases. Added tests to enforce that all cache implementations' `LookupContext` correctly posts callback actions, and correctly cancels calling the callback if the context is deleted before the post resolves.
Docs Changes: Code-comments only.
Release Notes: Maybe?
Platform Specific Features: n/a
