### PR TITLE
tooling: narrowing exception checks

### DIFF
--- a/tools/code_format/config.yaml
+++ b/tools/code_format/config.yaml
@@ -160,36 +160,86 @@ paths:
     # Extensions can exempt entire directories but new extensions
     # points should ideally use StatusOr
     - source/extensions/access_loggers
-    - source/extensions/bootstrap
-    - source/extensions/clusters
+    - source/extensions/bootstrap/wasm/config.cc
+    - source/extensions/clusters/eds/
+    - source/extensions/clusters/logical_dns
+    - source/extensions/clusters/original_dst
+    - source/extensions/clusters/redis
+    - source/extensions/clusters/static
+    - source/extensions/clusters/strict_dns
     - source/extensions/common
-    - source/extensions/config
+    - source/extensions/config/validators/minimum_clusters/minimum_clusters_validator.cc
     - source/extensions/config_subscription
-    - source/extensions/compression/zstd/common
-    - source/extensions/early_data
-    - source/extensions/filters
+    - source/extensions/compression/zstd/common/dictionary_manager.h
+    - source/extensions/filters/http/adaptive_concurrency/controller
+    - source/extensions/filters/http/admission_control
+    - source/extensions/filters/http/aws_lambda
+    - source/extensions/filters/http/aws_request_signing
+    - source/extensions/filters/http/bandwidth_limit
+    - source/extensions/filters/http/basic_auth
+    - source/extensions/filters/http/cache
+    - source/extensions/filters/http/cdn_loop
+    - source/extensions/filters/http/common
+    - source/extensions/filters/http/composite
+    - source/extensions/filters/http/ext_authz
+    - source/extensions/filters/http/ext_proc
+    - source/extensions/filters/http/file_system_buffer
+    - source/extensions/filters/http/gcp_authn
+    - source/extensions/filters/http/grpc_field_extraction
+    - source/extensions/filters/http/grpc_json_transcoder
+    - source/extensions/filters/http/grpc_stats
+    - source/extensions/filters/http/header_mutation
+    - source/extensions/filters/http/header_to_metadata
+    - source/extensions/filters/http/health_check
+    - source/extensions/filters/http/ip_tagging
+    - source/extensions/filters/http/json_to_metadata
+    - source/extensions/filters/http/jwt_authn
+    - source/extensions/filters/http/local_ratelimit
+    - source/extensions/filters/http/oauth2
+    - source/extensions/filters/http/file_system_buffer
+    - source/extensions/filters/http/header_to_metadata
+    - source/extensions/filters/http/on_demand
+    - source/extensions/filters/http/json_to_metadata
+    - source/extensions/filters/http/json_to_metadata
+    - source/extensions/filters/http/thrift_to_metadata
+    - source/extensions/filters/http/lua
+    - source/extensions/filters/http/proto_message_extraction
+    - source/extensions/filters/http/rate_limit_quota
+    - source/extensions/filters/http/ratelimit
+    - source/extensions/filters/http/oauth2
+    - source/extensions/filters/http/wasm
+    - source/extensions/filters/network
+    - source/extensions/filters/common
+    - source/extensions/filters/udp
+    - source/extensions/filters/listener
     - source/extensions/formatter
-    - source/extensions/geoip_providers
+    - source/extensions/geoip_providers/maxmind/geoip_provider.cc
     - source/extensions/grpc_credentials
-    - source/extensions/health_check
+    - source/extensions/health_check/event_sinks/file/file_sink_impl.h
     - source/extensions/health_checkers
-    - source/extensions/http
-    - source/extensions/io_socket
+    - source/extensions/http/cache/file_system_http_cache/config.cc
+    - source/extensions/http/custom_response
+    - source/extensions/http/early_header_mutation
+    - source/extensions/http/injected_credentials
+    - source/extensions/http/original_ip_detection
+    - source/extensions/http/stateful_session
+    - source/extensions/io_socket/user_space
     - source/extensions/key_value
-    - source/extensions/listener_managers
-    - source/extensions/load_balancing_policies
+    - source/extensions/load_balancing_policies/maglev
+    - source/extensions/load_balancing_policies/ring_hash
+    - source/extensions/load_balancing_policies/subset
     - source/extensions/matching
-    - source/extensions/network
-    - source/extensions/path
+    - source/extensions/network/dns_resolver/cares/
     - source/extensions/quic/server_preferred_address
     - source/extensions/rate_limit_descriptors
     - source/extensions/resource_monitors
-    - source/extensions/retry
-    - source/extensions/router
+    - source/extensions/router/cluster_specifiers/lua/lua_cluster_specifier.cc
     - source/extensions/stat_sinks
-    - source/extensions/string_matcher
+    - source/extensions/string_matcher/lua/match.cc
     - source/extensions/tracers
-    - source/extensions/transport_sockets
+    - source/extensions/transport_sockets/internal_upstream
+    - source/extensions/transport_sockets/tls/cert_validator
+    - source/extensions/transport_sockets/tcp_stats/config.cc
 
   # Only one C++ file should instantiate grpc_init
   grpc_init:


### PR DESCRIPTION
I reviewed a PR adding exceptions to a previously exception free path without realizing it.  Narrowing the checks so we're more likely to catch this in CI.

Risk Level: n/a (tooling only)
Testing: ci
Docs Changes: n/a
Release Notes: n/a
part of https://github.com/envoyproxy/envoy/issues/27412