### PR TITLE
upstream-filter: update default upstream filter type

### DIFF
--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -1388,7 +1388,8 @@ ClusterInfoImpl::ClusterInfoImpl(
     if (http_filters.empty()) {
       auto* codec_filter = http_filters.Add();
       codec_filter->set_name("envoy.filters.http.upstream_codec");
-      codec_filter->mutable_typed_config()->set_type_url(upstream_codec_type_url);
+      codec_filter->mutable_typed_config()->set_type_url(
+          absl::StrCat("type.googleapis.com/", upstream_codec_type_url));
     } else {
       const auto last_type_url =
           Config::Utility::getFactoryType(http_filters[http_filters.size() - 1].typed_config());


### PR DESCRIPTION
Commit Message: upstream-filter: update default upstream filter type
Additional Description:
Prior to this the debug logs contain the following:
```
[source/common/http/filter_chain_helper.h:160]     config: Failed to convert protobuf message to JSON string: INVALID_ARGUMENT: @type must contain at least one / and a nonempty host; got: envoy.extensions.filters.http.upstream_codec.v3.UpstreamCodec
```
After this PR they contain:
```
[source/common/http/filter_chain_helper.h:160]     config: {"@type":"type.googleapis.com/envoy.extensions.filters.http.upstream_codec.v3.UpstreamCodec"}
```

Risk Level: low - seems to be impacting debug logs only
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
