### PR TITLE
Add `metric_names_for_computing_utilization` field to `ClientSideWeightedRoundRobin` LB Policy proto.

### DIFF
--- a/api/envoy/extensions/load_balancing_policies/client_side_weighted_round_robin/v3/client_side_weighted_round_robin.proto
+++ b/api/envoy/extensions/load_balancing_policies/client_side_weighted_round_robin/v3/client_side_weighted_round_robin.proto
@@ -30,11 +30,12 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // regardless of result. Only failed queries count toward eps. A config
 // parameter error_utilization_penalty controls the penalty to adjust endpoint
 // weights using eps and qps. The weight of a given endpoint is computed as:
-//   qps / (utilization + eps/qps * error_utilization_penalty)
+// ``qps / (utilization + eps/qps * error_utilization_penalty)``.
 //
-// See the :ref:`load balancing architecture overview<arch_overview_load_balancing_types>` for more information.
+// See the :ref:`load balancing architecture
+// overview<arch_overview_load_balancing_types>` for more information.
 //
-// [#next-free-field: 7]
+// [#next-free-field: 8]
 message ClientSideWeightedRoundRobin {
   // Whether to enable out-of-band utilization reporting collection from
   // the endpoints. By default, per-request utilization reporting is used.
@@ -68,4 +69,10 @@ message ClientSideWeightedRoundRobin {
   // calculated as eps/qps. Configuration is rejected if this value is negative.
   // Default is 1.0.
   google.protobuf.FloatValue error_utilization_penalty = 6 [(validate.rules).float = {gte: 0.0}];
+
+  // By default, endpoint weight is computed based on the :ref:`application_utilization <envoy_v3_api_field_.xds.data.orca.v3.OrcaLoadReport.application_utilization>` field reported by the endpoint.
+  // If that field is not set, then utilization will instead be computed by taking the max of the values of the metrics specified here.
+  // For map fields in the ORCA proto, the string will be of the form ``<map_field_name>.<map_key>``. For example, the string ``named_metrics.foo`` will mean to look for the key ``foo`` in the ORCA :ref:`named_metrics <envoy_v3_api_field_.xds.data.orca.v3.OrcaLoadReport.named_metrics>` field.
+  // If none of the specified metrics are present in the load report, then :ref:`cpu_utilization <envoy_v3_api_field_.xds.data.orca.v3.OrcaLoadReport.cpu_utilization>` is used instead.
+  repeated string metric_names_for_computing_utilization = 7;
 }


### PR DESCRIPTION
Commit Message:
Add `metric_names_for_computing_utilization` field to `ClientSideWeightedRoundRobin` LB Policy config proto.

- This is a minor change to unblock config plane work while #35905 is going through review.
- See #35905 for initial LB policy implementation.

Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a

#34777
