### PR TITLE
http2: fix reported protocol error from graceful upstream close

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -116,6 +116,10 @@ bug_fixes:
   change: |
     RBAC will now allow stat prefixes configured in per-route config to override the base config's
     stat prefix.
+- area: http2
+  change: |
+    Fixed bug where an upstream that sent a GOAWAY and gracefully closed a connection would result in an increment of
+    the cluster stat ``upstream_cx_protocol_error`` and setting the ``UpstreamProtocolError`` response flag.
 - area: http3
   change: |
     Fixed a bug where an empty trailers block could be sent. This would occur if a filter removed

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -119,7 +119,9 @@ bug_fixes:
 - area: http2
   change: |
     Fixed bug where an upstream that sent a GOAWAY and gracefully closed a connection would result in an increment of
-    the cluster stat ``upstream_cx_protocol_error`` and setting the ``UpstreamProtocolError`` response flag.
+    the cluster stat ``upstream_cx_protocol_error`` and setting the ``UpstreamProtocolError`` response flag. This behavior
+    can be reverted by setting the runtime guard ``envoy.reloadable_features.http2_no_protocol_error_upon_clean_close``
+    to false.
 - area: http3
   change: |
     Fixed a bug where an empty trailers block could be sent. This would occur if a filter removed

--- a/source/common/http/status.cc
+++ b/source/common/http/status.cc
@@ -27,6 +27,8 @@ absl::string_view statusCodeToString(StatusCode code) {
     return "InboundFramesWithEmptyPayloadError";
   case StatusCode::EnvoyOverloadError:
     return "EnvoyOverloadError";
+  case StatusCode::GoAwayGracefulClose:
+    return "GoAwayGracefulClose";
   }
   return "";
 }
@@ -124,6 +126,12 @@ Status envoyOverloadError(absl::string_view message) {
   return status;
 }
 
+Status goAwayGracefulCloseError() {
+  absl::Status status(absl::StatusCode::kInternal, {});
+  storePayload(status, EnvoyStatusPayload(StatusCode::GoAwayGracefulClose));
+  return status;
+}
+
 // Methods for checking and extracting error information
 StatusCode getStatusCode(const Status& status) {
   return status.ok() ? StatusCode::Ok : getPayload(status).status_code_;
@@ -158,6 +166,10 @@ bool isInboundFramesWithEmptyPayloadError(const Status& status) {
 
 bool isEnvoyOverloadError(const Status& status) {
   return getStatusCode(status) == StatusCode::EnvoyOverloadError;
+}
+
+bool isGoAwayGracefulCloseError(const Status& status) {
+  return getStatusCode(status) == StatusCode::GoAwayGracefulClose;
 }
 
 } // namespace Http

--- a/source/common/http/status.h
+++ b/source/common/http/status.h
@@ -79,6 +79,11 @@ enum class StatusCode : int {
    * Indicates that Envoy is overloaded and may shed load.
    */
   EnvoyOverloadError = 6,
+
+  /**
+   * Indicates the connection was gracefully closed due to GOAWAY.
+   */
+  GoAwayGracefulClose = 7,
 };
 
 using Status = absl::Status;
@@ -100,6 +105,7 @@ Status prematureResponseError(absl::string_view message, Http::Code http_code);
 Status codecClientError(absl::string_view message);
 Status inboundFramesWithEmptyPayloadError();
 Status envoyOverloadError(absl::string_view message);
+Status goAwayGracefulCloseError();
 
 /**
  * Returns Envoy::StatusCode of the given status object.
@@ -116,6 +122,7 @@ ABSL_MUST_USE_RESULT bool isPrematureResponseError(const Status& status);
 ABSL_MUST_USE_RESULT bool isCodecClientError(const Status& status);
 ABSL_MUST_USE_RESULT bool isInboundFramesWithEmptyPayloadError(const Status& status);
 ABSL_MUST_USE_RESULT bool isEnvoyOverloadError(const Status& status);
+ABSL_MUST_USE_RESULT bool isGoAwayGracefulCloseError(const Status& status);
 
 /**
  * Returns Http::Code value of the PrematureResponseError status.

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -55,6 +55,7 @@ RUNTIME_GUARD(envoy_reloadable_features_http1_balsa_disallow_lone_cr_in_chunk_ex
 // Ignore the automated "remove this flag" issue: we should keep this for 1 year.
 RUNTIME_GUARD(envoy_reloadable_features_http1_use_balsa_parser);
 RUNTIME_GUARD(envoy_reloadable_features_http2_discard_host_header);
+RUNTIME_GUARD(envoy_reloadable_features_http2_no_protocol_error_upon_clean_close);
 // Ignore the automated "remove this flag" issue: we should keep this for 1 year.
 RUNTIME_GUARD(envoy_reloadable_features_http2_use_oghttp2);
 RUNTIME_GUARD(envoy_reloadable_features_http2_use_visitor_for_data);


### PR DESCRIPTION
Risk Level: Medium
Testing: Added new tests
Release Notes: added
Runtime guard: envoy.reloadable_features.http2_no_protocol_error_upon_clean_close
Fixes #21522