### PR TITLE
chore: fix the incorrect `scope` claim name in the API doc

### DIFF
--- a/api/envoy/extensions/filters/http/jwt_authn/v3/config.proto
+++ b/api/envoy/extensions/filters/http/jwt_authn/v3/config.proto
@@ -63,9 +63,9 @@ message JwtProvider {
   message NormalizePayload {
     // Each claim in this list will be interpreted as a space-delimited string
     // and converted to a list of strings based on the delimited values.
-    // Example: a token with a claim ``scopes: "email profile"`` is translated
-    // to dynamic metadata  ``scopes: ["email", "profile"]`` if this field is
-    // set value ``["scopes"]``. This special handling of ``scopes`` is
+    // Example: a token with a claim ``scope: "email profile"`` is translated
+    // to dynamic metadata  ``scope: ["email", "profile"]`` if this field is
+    // set value ``["scope"]``. This special handling of ``scope`` is
     // recommended by `RFC8693
     // <https://datatracker.ietf.org/doc/html/rfc8693#name-scope-scopes-claim>`_.
     repeated string space_delimited_claims = 1;


### PR DESCRIPTION
According to the JWT standard, the scope claim name is `scope`, not `scopes`.

Reference: https://www.iana.org/assignments/jwt/jwt.xhtml