### PR TITLE
contrib: switch the minimal go version to a more stable version

### DIFF
--- a/contrib/golang/filters/http/test/test_data/access_log/go.mod
+++ b/contrib/golang/filters/http/test/test_data/access_log/go.mod
@@ -1,6 +1,6 @@
 module example.com/access_log
 
-go 1.23
+go 1.22
 
 require github.com/envoyproxy/envoy v1.24.0
 

--- a/contrib/golang/filters/http/test/test_data/action/go.mod
+++ b/contrib/golang/filters/http/test/test_data/action/go.mod
@@ -1,6 +1,6 @@
 module example.com/action
 
-go 1.23
+go 1.22
 
 require github.com/envoyproxy/envoy v1.24.0
 

--- a/contrib/golang/filters/http/test/test_data/basic/go.mod
+++ b/contrib/golang/filters/http/test/test_data/basic/go.mod
@@ -1,6 +1,6 @@
 module example.com/basic
 
-go 1.23
+go 1.22
 
 require github.com/envoyproxy/envoy v1.24.0
 

--- a/contrib/golang/filters/http/test/test_data/buffer/go.mod
+++ b/contrib/golang/filters/http/test/test_data/buffer/go.mod
@@ -1,6 +1,6 @@
 module example.com/buffer
 
-go 1.23
+go 1.22
 
 require (
 	github.com/envoyproxy/envoy v1.24.0

--- a/contrib/golang/filters/http/test/test_data/dummy/go.mod
+++ b/contrib/golang/filters/http/test/test_data/dummy/go.mod
@@ -1,6 +1,6 @@
 module example.com/dummy
 
-go 1.23
+go 1.22
 
 require github.com/envoyproxy/envoy v1.24.0
 

--- a/contrib/golang/filters/http/test/test_data/echo/go.mod
+++ b/contrib/golang/filters/http/test/test_data/echo/go.mod
@@ -1,6 +1,6 @@
 module example.com/echo
 
-go 1.23
+go 1.22
 
 require (
 	github.com/cncf/xds/go v0.0.0-20231128003011-0fa0005c9caa

--- a/contrib/golang/filters/http/test/test_data/metric/go.mod
+++ b/contrib/golang/filters/http/test/test_data/metric/go.mod
@@ -1,6 +1,6 @@
 module example.com/basic
 
-go 1.23
+go 1.22
 
 require github.com/envoyproxy/envoy v1.24.0
 

--- a/contrib/golang/filters/http/test/test_data/passthrough/go.mod
+++ b/contrib/golang/filters/http/test/test_data/passthrough/go.mod
@@ -1,6 +1,6 @@
 module example.com/passthrough
 
-go 1.23
+go 1.22
 
 require github.com/envoyproxy/envoy v1.24.0
 

--- a/contrib/golang/filters/http/test/test_data/property/go.mod
+++ b/contrib/golang/filters/http/test/test_data/property/go.mod
@@ -1,6 +1,6 @@
 module example.com/property
 
-go 1.23
+go 1.22
 
 require (
 	github.com/envoyproxy/envoy v1.24.0

--- a/contrib/golang/filters/http/test/test_data/routeconfig/go.mod
+++ b/contrib/golang/filters/http/test/test_data/routeconfig/go.mod
@@ -1,6 +1,6 @@
 module example.com/routeconfig
 
-go 1.23
+go 1.22
 
 require (
 	github.com/cncf/xds/go v0.0.0-20231128003011-0fa0005c9caa

--- a/contrib/golang/filters/http/test/test_data/websocket/go.mod
+++ b/contrib/golang/filters/http/test/test_data/websocket/go.mod
@@ -1,6 +1,6 @@
 module example.com/websocket
 
-go 1.23
+go 1.22
 
 require github.com/envoyproxy/envoy v1.24.0
 

--- a/contrib/golang/filters/network/test/test_data/go.mod
+++ b/contrib/golang/filters/network/test/test_data/go.mod
@@ -1,6 +1,6 @@
 module github.com/envoyproxy/envoy/contrib/golang/filters/network/test/test_data
 
-go 1.23
+go 1.22
 
 require github.com/envoyproxy/envoy v1.24.0
 

--- a/contrib/golang/router/cluster_specifier/test/test_data/simple/go.mod
+++ b/contrib/golang/router/cluster_specifier/test/test_data/simple/go.mod
@@ -1,6 +1,6 @@
 module example.com/routeconfig
 
-go 1.23
+go 1.22
 
 require (
 	github.com/cncf/xds/go v0.0.0-20231128003011-0fa0005c9caa

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/envoyproxy/envoy
 
-go 1.23
+go 1.22
 
 require google.golang.org/protobuf v1.34.2
 


### PR DESCRIPTION
Signed-off-by: spacewander <spacewanderlzx@gmail.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: contrib: switch the minimal go version to a more stable version
Additional Description:
It's too risky to use a version which is just released for a month as the minimal Go version requirement. That previous change hurts the adoption of Envoy Golang filter as it forced users to use the latest version as the minimal required version.
Risk Level: Low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
Fixes #36246
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
