### PR TITLE
fix potential null dereference in ext_authz

### DIFF
--- a/source/extensions/filters/http/ext_authz/ext_authz.h
+++ b/source/extensions/filters/http/ext_authz/ext_authz.h
@@ -42,7 +42,8 @@ namespace ExtAuthz {
   COUNTER(disabled)                                                                                \
   COUNTER(failure_mode_allowed)                                                                    \
   COUNTER(invalid)                                                                                 \
-  COUNTER(ignored_dynamic_metadata)
+  COUNTER(ignored_dynamic_metadata)                                                                \
+  COUNTER(filter_state_name_collision)
 
 /**
  * Wrapper struct for ext_authz filter stats. @see stats_macros.h
@@ -402,7 +403,7 @@ private:
   Upstream::ClusterInfoConstSharedPtr cluster_;
   // The stats for the filter.
   ExtAuthzFilterStats stats_;
-  ExtAuthzLoggingInfo* logging_info_;
+  ExtAuthzLoggingInfo* logging_info_{nullptr};
 
   // This is used to hold the final configs after we merge them with per-route configs.
   bool allow_partial_message_{};

--- a/test/extensions/filters/http/ext_authz/ext_authz_test.cc
+++ b/test/extensions/filters/http/ext_authz/ext_authz_test.cc
@@ -3966,7 +3966,6 @@ TEST_P(HttpFilterTestParam, DisableRequestBodyBufferingOnRoute) {
 }
 
 TEST_P(EmitFilterStateTest, OkResponse) {
-  ENVOY_LOG_MISC(debug, "START OF TEST");
   Filters::Common::ExtAuthz::Response response{};
   response.status = Filters::Common::ExtAuthz::CheckStatus::OK;
 


### PR DESCRIPTION
Commit Message: fix potential null dereference in ext_authz
Additional Description:

Previously, if ext_authz had emit filter state stats set to true and another filter added filter state under the ext authz filter's name, it would result in a null dereference. The member logging_info_ would not be set in initiateCall after seeing there was already data there. Later, we would dereference logging_info_ to update the stats as if it were initialized already.

I've added a check for a null logging_info_ and added logging & a stat for when there's a filter state naming collision.

I also made some readability improvements to the ext_authz test.

Risk Level: low
Testing: unit tested
Docs Changes: none
Release Notes: none
Platform Specific Features: none