### PR TITLE
ratelimit: masked_remote_address action don't return descriptor_entry with statsd key words

### DIFF
--- a/source/common/router/router_ratelimit.cc
+++ b/source/common/router/router_ratelimit.cc
@@ -181,7 +181,7 @@ bool MaskedRemoteAddressAction::populateDescriptor(RateLimit::DescriptorEntry& d
     // For Ipv4, masked_address is returned in a format similar to '192.168.1.0/32', '.' It's a key
     // word in statsd, This makes it difficult to export measurements in Promethean format in the
     // RateLimit server.
-    absl::StrReplaceAll({}, &masked_address);
+    masked_address = absl::StrReplaceAll(masked_address, {{".", "_"}});
   }
   descriptor_entry = {"masked_remote_address", masked_address};
 

--- a/test/common/router/router_ratelimit_test.cc
+++ b/test/common/router/router_ratelimit_test.cc
@@ -376,10 +376,10 @@ actions:
   rate_limit_entry_->populateDescriptors(descriptors_, "", header_, stream_info_);
   rate_limit_entry_->populateLocalDescriptors(local_descriptors_, "", header_, stream_info_);
   EXPECT_THAT(
-      std::vector<Envoy::RateLimit::Descriptor>({{{{"masked_remote_address", "10.0.0.1/32"}}}}),
+      std::vector<Envoy::RateLimit::Descriptor>({{{{"masked_remote_address", "10_0_0_1/32"}}}}),
       testing::ContainerEq(descriptors_));
   EXPECT_THAT(std::vector<Envoy::RateLimit::LocalDescriptor>(
-                  {{{{"masked_remote_address", "10.0.0.1/32"}}}}),
+                  {{{{"masked_remote_address", "10_0_0_1/32"}}}}),
               testing::ContainerEq(local_descriptors_));
 }
 
@@ -395,10 +395,10 @@ actions:
   rate_limit_entry_->populateDescriptors(descriptors_, "", header_, stream_info_);
   rate_limit_entry_->populateLocalDescriptors(local_descriptors_, "", header_, stream_info_);
   EXPECT_THAT(
-      std::vector<Envoy::RateLimit::Descriptor>({{{{"masked_remote_address", "10.0.0.0/16"}}}}),
+      std::vector<Envoy::RateLimit::Descriptor>({{{{"masked_remote_address", "10_0_0_0/16"}}}}),
       testing::ContainerEq(descriptors_));
   EXPECT_THAT(std::vector<Envoy::RateLimit::LocalDescriptor>(
-                  {{{{"masked_remote_address", "10.0.0.0/16"}}}}),
+                  {{{{"masked_remote_address", "10_0_0_0/16"}}}}),
               testing::ContainerEq(local_descriptors_));
 }
 


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: For https://github.com/envoyproxy/gateway/issues/4281, descriptor_entry with `.` make it's hard to export metric in prometheus in RateLimit server.
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
