### PR TITLE
ext_proc: Add allow list for mode override

### DIFF
--- a/api/envoy/extensions/filters/http/ext_proc/v3/ext_proc.proto
+++ b/api/envoy/extensions/filters/http/ext_proc/v3/ext_proc.proto
@@ -94,7 +94,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // <arch_overview_advanced_filter_state_sharing>` object in a namespace matching the filter
 // name.
 //
-// [#next-free-field: 22]
+// [#next-free-field: 23]
 message ExternalProcessor {
   // Describes the route cache action to be taken when an external processor response
   // is received in response to request headers.
@@ -284,6 +284,15 @@ message ExternalProcessor {
   //       in a single body response message, followed by the remaining body responses.
   // In all scenarios, the header-body ordering must always be maintained.
   bool send_body_without_waiting_for_header_response = 21;
+
+  // When :ref:`allow_mode_override
+  // <envoy_v3_api_field_extensions.filters.http.ext_proc.v3.ExternalProcessor.allow_mode_override>` is enabled and
+  // ``allowed_override_modes`` is configured, the filter config :ref:`processing_mode
+  // <envoy_v3_api_field_extensions.filters.http.ext_proc.v3.ExternalProcessor.processing_mode>`
+  // can only be overridden by the response message from the external processing server iff the
+  // :ref:`mode_override <envoy_v3_api_field_service.ext_proc.v3.ProcessingResponse.mode_override>` is allowed by
+  // the ``allowed_override_modes`` allow-list below.
+  repeated envoy.extensions.filters.http.ext_proc.v3.ProcessingMode allowed_override_modes = 22;
 }
 
 // ExtProcHttpService is used for HTTP communication between the filter and the external processing service.

--- a/api/envoy/extensions/filters/http/ext_proc/v3/ext_proc.proto
+++ b/api/envoy/extensions/filters/http/ext_proc/v3/ext_proc.proto
@@ -292,7 +292,7 @@ message ExternalProcessor {
   // can only be overridden by the response message from the external processing server iff the
   // :ref:`mode_override <envoy_v3_api_field_service.ext_proc.v3.ProcessingResponse.mode_override>` is allowed by
   // the ``allowed_override_modes`` allow-list below.
-  repeated envoy.extensions.filters.http.ext_proc.v3.ProcessingMode allowed_override_modes = 22;
+  repeated ProcessingMode allowed_override_modes = 22;
 }
 
 // ExtProcHttpService is used for HTTP communication between the filter and the external processing service.

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -395,5 +395,10 @@ new_features:
     Added support to provide an override
     :ref:`authentication_header <envoy_v3_api_field_extensions.filters.http.basic_auth.v3.BasicAuth.authentication_header>`
     to load Basic Auth credential.
+- area: ext_proc
+  change: |
+    Added allow list
+    :ref:`allowed_override_modes <envoy_v3_api_field_extensions.filters.http.ext_proc.v3.ExternalProcessor.allowed_override_modes>`
+    for :ref:`mode_override <envoy_v3_api_field_service.ext_proc.v3.ProcessingResponse.mode_override>`
 
 deprecated:

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -399,6 +399,6 @@ new_features:
   change: |
     Added allow list
     :ref:`allowed_override_modes <envoy_v3_api_field_extensions.filters.http.ext_proc.v3.ExternalProcessor.allowed_override_modes>`
-    for :ref:`mode_override <envoy_v3_api_field_service.ext_proc.v3.ProcessingResponse.mode_override>`
+    for :ref:`mode_override <envoy_v3_api_field_service.ext_proc.v3.ProcessingResponse.mode_override>`.
 
 deprecated:

--- a/source/extensions/filters/http/ext_proc/BUILD
+++ b/source/extensions/filters/http/ext_proc/BUILD
@@ -30,6 +30,7 @@ envoy_cc_library(
         "//envoy/stats:stats_macros",
         "//source/common/buffer:buffer_lib",
         "//source/common/protobuf",
+        "//source/common/protobuf:utility_lib",
         "//source/common/runtime:runtime_features_lib",
         "//source/extensions/filters/common/mutation_rules:mutation_rules_lib",
         "//source/extensions/filters/http/common:pass_through_filter_lib",

--- a/source/extensions/filters/http/ext_proc/ext_proc.cc
+++ b/source/extensions/filters/http/ext_proc/ext_proc.cc
@@ -7,6 +7,7 @@
 #include "envoy/extensions/filters/http/ext_proc/v3/processing_mode.pb.h"
 
 #include "source/common/http/utility.h"
+#include "source/common/protobuf/utility.h"
 #include "source/common/runtime/runtime_features.h"
 #include "source/extensions/filters/http/ext_proc/mutation_utils.h"
 
@@ -206,6 +207,8 @@ FilterConfig::FilterConfig(
       untyped_receiving_namespaces_(
           config.metadata_options().receiving_namespaces().untyped().begin(),
           config.metadata_options().receiving_namespaces().untyped().end()),
+      allowed_override_modes_(config.allowed_override_modes().begin(),
+                              config.allowed_override_modes().end()),
       expression_manager_(builder, context.localInfo(), config.request_attributes(),
                           config.response_attributes()),
       immediate_mutation_checker_(context.regexEngine()),
@@ -1068,9 +1071,23 @@ void Filter::onReceiveMessage(std::unique_ptr<ProcessingResponse>&& r) {
   // set to true and filter is waiting for header processing response.
   // Otherwise, the response mode_override proto field is ignored.
   if (config_->allowModeOverride() && inHeaderProcessState() && response->has_mode_override()) {
-    ENVOY_LOG(debug, "Processing mode overridden by server for this request");
-    decoding_state_.setProcessingMode(response->mode_override());
-    encoding_state_.setProcessingMode(response->mode_override());
+    bool mode_override_allowed = true;
+    const auto& mode_overide = response->mode_override();
+    if (!config_->allowedOverrideModes().empty()) {
+      mode_override_allowed = absl::c_any_of(
+          config_->allowedOverrideModes(),
+          [&mode_overide](
+              const envoy::extensions::filters::http::ext_proc::v3::ProcessingMode& other) {
+            return Protobuf::util::MessageDifferencer::Equals(mode_overide, other);
+          });
+    }
+    if (mode_override_allowed) {
+      ENVOY_LOG(debug, "Processing mode overridden by server for this request");
+      decoding_state_.setProcessingMode(mode_overide);
+      encoding_state_.setProcessingMode(mode_overide);
+    } else {
+      ENVOY_LOG(debug, "Processing mode overridden by server is disallowed");
+    }
   }
 
   ENVOY_LOG(debug, "Received {} response", responseCaseToString(response->response_case()));

--- a/source/extensions/filters/http/ext_proc/ext_proc.cc
+++ b/source/extensions/filters/http/ext_proc/ext_proc.cc
@@ -1073,7 +1073,9 @@ void Filter::onReceiveMessage(std::unique_ptr<ProcessingResponse>&& r) {
   if (config_->allowModeOverride() && inHeaderProcessState() && response->has_mode_override()) {
     bool mode_override_allowed = true;
     const auto& mode_overide = response->mode_override();
+    // First, check if mode override allow-list is configured
     if (!config_->allowedOverrideModes().empty()) {
+      // Second, check if mode override from response is allowed.
       mode_override_allowed = absl::c_any_of(
           config_->allowedOverrideModes(),
           [&mode_overide](
@@ -1081,6 +1083,7 @@ void Filter::onReceiveMessage(std::unique_ptr<ProcessingResponse>&& r) {
             return Protobuf::util::MessageDifferencer::Equals(mode_overide, other);
           });
     }
+
     if (mode_override_allowed) {
       ENVOY_LOG(debug, "Processing mode overridden by server for this request");
       decoding_state_.setProcessingMode(mode_overide);

--- a/source/extensions/filters/http/ext_proc/ext_proc.h
+++ b/source/extensions/filters/http/ext_proc/ext_proc.h
@@ -261,6 +261,11 @@ public:
     return immediate_mutation_checker_;
   }
 
+  const std::vector<envoy::extensions::filters::http::ext_proc::v3::ProcessingMode>&
+  allowedOverrideModes() const {
+    return allowed_override_modes_;
+  }
+
   ThreadLocalStreamManager& threadLocalStreamManager() {
     return thread_local_stream_manager_slot_->getTyped<ThreadLocalStreamManager>();
   }
@@ -297,6 +302,8 @@ private:
   const std::vector<std::string> untyped_forwarding_namespaces_;
   const std::vector<std::string> typed_forwarding_namespaces_;
   const std::vector<std::string> untyped_receiving_namespaces_;
+  const std::vector<envoy::extensions::filters::http::ext_proc::v3::ProcessingMode>
+      allowed_override_modes_;
   const ExpressionManager expression_manager_;
 
   const ImmediateMutationChecker immediate_mutation_checker_;

--- a/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
+++ b/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
@@ -4688,7 +4688,7 @@ TEST_P(ExtProcIntegrationTest, ModeOverrideAllowed) {
         return true;
       });
 
-  // ext_proc server will receive the body message since the processing body mode has been overriden
+  // ext_proc server will receive the body message since the processing body mode has been overridden
   // from `ProcessingMode::NONE` to `ProcessingMode::STREAMED`
   processRequestBodyMessage(*grpc_upstreams_[0], false, [](const HttpBody& body, BodyResponse&) {
     EXPECT_TRUE(body.end_of_stream());

--- a/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
+++ b/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
@@ -4688,8 +4688,8 @@ TEST_P(ExtProcIntegrationTest, ModeOverrideAllowed) {
         return true;
       });
 
-  // ext_proc server will receive the body message since the processing body mode has been overridden
-  // from `ProcessingMode::NONE` to `ProcessingMode::STREAMED`
+  // ext_proc server will receive the body message since the processing body mode has been
+  // overridden from `ProcessingMode::NONE` to `ProcessingMode::STREAMED`
   processRequestBodyMessage(*grpc_upstreams_[0], false, [](const HttpBody& body, BodyResponse&) {
     EXPECT_TRUE(body.end_of_stream());
     return true;

--- a/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
+++ b/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
@@ -4721,7 +4721,7 @@ TEST_P(ExtProcIntegrationTest, ModeOverrideDisallowed) {
       });
 
   // ext_proc server still receive the body message even though body mode override was set to
-  // ProcessingMode::NONE. It is because that ProcessingMode::NONE was in allow list.
+  // ProcessingMode::NONE. It is because that ProcessingMode::NONE was not in allow list.
   processRequestBodyMessage(*grpc_upstreams_[0], false, [](const HttpBody& body, BodyResponse&) {
     EXPECT_TRUE(body.end_of_stream());
     return true;


### PR DESCRIPTION
Added allow list `allowed_override_modes` for mode_override.
Risk Level: LOW
Testing: Integration test 
Docs Changes: N/A
Release Notes: Yes
Platform Specific Features: N/A
