### PR TITLE
Fix asan failure

### DIFF
--- a/test/extensions/geoip_providers/maxmind/geoip_provider_test.cc
+++ b/test/extensions/geoip_providers/maxmind/geoip_provider_test.cc
@@ -157,13 +157,13 @@ public:
   Api::ApiPtr api_;
   NiceMock<Server::Configuration::MockServerFactoryContext> server_factory_context_;
   NiceMock<Server::Configuration::MockFactoryContext> context_;
-  DriverSharedPtr provider_;
   MaxmindProviderFactory* provider_factory_;
   Event::SimulatedTimeSystem time_system_;
   absl::flat_hash_map<std::string, std::string> captured_lookup_response_;
   absl::Mutex mutex_;
   std::vector<Filesystem::Watcher::OnChangedCb> on_changed_cbs_ ABSL_GUARDED_BY(mutex_);
   absl::optional<ConditionalInitializer> cb_added_nullopt = absl::nullopt;
+  DriverSharedPtr provider_;
 };
 
 class GeoipProviderTest : public testing::Test, public GeoipProviderTestBase {};


### PR DESCRIPTION
Fix for:
```
==12==ERROR: AddressSanitizer: heap-use-after-free on address 0x60300019d860 at pc 0xb7d3f059f8cc bp 0xe6dc6a8fde80 sp 0xe6dc6a8fd670
WRITE of size 24 at 0x60300019d860 thread T1
    #0 0xb7d3f059f8c8 in __asan_memset (/home/nezdolik.linux/.cache/bazel/_bazel_nezdolik/9a5f062d7ba021dba530b9f40b2998a7/execroot/envoy/bazel-out/aarch64-fastbuild/bin/test/extensions/geoip_providers/maxmind/geoip_provider_test+0x48ef8c8)
    #1 0xb7d3f065bb9c in std::function<absl::lts_20230802::Status (unsigned int)>& std::vector<std::function<absl::lts_20230802::Status (unsigned int)>, std::allocator<std::function<absl::lts_20230802::Status (unsigned int)>>>::emplace_back<std::function<absl::lts_20230802::Status (unsigned int)>>(std::function<absl::lts_20230802::Status (unsigned int)>&&) (/home/nezdolik.linux/.cache/bazel/_bazel_nezdolik/9a5f062d7ba021dba530b9f40b2998a7/execroot/envoy/bazel-out/aarch64-fastbuild/bin/test/extensions/geoip_providers/maxmind/geoip_provider_test+0x49abb9c)
    #2 0xb7d3f065b6a0 in Envoy::Extensions::GeoipProviders::Maxmind::GeoipProviderTestBase::initializeProvider(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, std::optional<Envoy::ConditionalInitializer>&)::'lambda'()::operator()() const::'lambda'(std::basic_string_view<char, std::char_traits<char>>, unsigned int, std::function<absl::lts_20230802::Status (unsigned int)>)::operator()(std::basic_string_view<char, std::char_traits<char>>, unsigned int, std::function<absl::lts_20230802::Status (unsigned int)>) const (/home/nezdolik.linux/.cache/bazel/_bazel_nezdolik/9a5f062d7ba021dba530b9f40b2998a7/execroot/envoy/bazel-out/aarch64-fastbuild/bin/test/extensions/geoip_providers/maxmind/geoip_provider_test+0x49ab6a0)
    #3 0xb7d3f065b2c0 in std::_Function_handler<absl::lts_20230802::Status (std::basic_string_view<char, std::char_traits<char>>, unsigned int, std::function<absl::lts_20230802::Status (unsigned int)>), Envoy::Extensions::GeoipProviders::Maxmind::GeoipProviderTestBase::initializeProvider(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, std::optional<Envoy::ConditionalInitializer>&)::'lambda'()::operator()() const::'lambda'(std::basic_string_view<char, std::char_traits<char>>, unsigned int, std::function<absl::lts_20230802::Status (unsigned int)>)>::_M_invoke(std::_Any_data const&, std::basic_string_view<char, std::char_traits<char>>&&, unsigned int&&, std::function<absl::lts_20230802::Status (unsigned int)>&&) (/home/nezdolik.linux/.cache/bazel/_bazel_nezdolik/9a5f062d7ba021dba530b9f40b2998a7/execroot/envoy/bazel-out/aarch64-fastbuild/bin/test/extensions/geoip_providers/maxmind/geoip_provider_test+0x49ab2c0)
    #4 0xb7d3f3080050 in decltype(std::forward<std::function<absl::lts_20230802::Status (std::basic_string_view<char, std::char_traits<char>>, unsigned int, std::function<absl::lts_20230802::Status (unsigned int)>)> const&>(fp)(std::get<0ul>(std::forward<std::tuple<std::basic_string_view<char, std::char_traits<char>>, unsigned int, std::function<absl::lts_20230802::Status (unsigned int)>>>(fp0)), std::get<1ul>(std::forward<std::tuple<std::basic_string_view<char, std::char_traits<char>>, unsigned int, std::function<absl::lts_20230802::Status (unsigned int)>>>(fp0)), std::get<2ul>(std::forward<std::tuple<std::basic_string_view<char, std::char_traits<char>>, unsigned int, std::function<absl::lts_20230802::Status (unsigned int)>>>(fp0)))) testing::internal::ApplyImpl<std::function<absl::lts_20230802::Status (std::basic_string_view<char, std::char_traits<char>>, unsigned int, std::function<absl::lts_20230802::Status (unsigned int)>)> const&, std::tuple<std::basic_string_view<char, std::char_traits<char>>, unsigned int, std::function<absl::lts_20230802::Status (unsigned int)>>, 0ul, 1ul, 2ul>(std::function<absl::lts_20230802::Status (std::basic_string_view<char, std::char_traits<char>>, unsigned int, std::function<absl::lts_20230802::Status (unsigned int)>)> const&, std::tuple<std::basic_string_view<char, std::char_traits<char>>, unsigned int, std::function<absl::lts_20230802::Status (unsigned int)>>&&, testing::internal::IndexSequence<0ul, 1ul, 2ul>) (/home/nezdolik.linux/.cache/bazel/_bazel_nezdolik/9a5f062d7ba021dba530b9f40b2998a7/execroot/envoy/bazel-out/aarch64-fastbuild/bin/test/extensions/geoip_providers/maxmind/geoip_provider_test+0x73d0050)
    #5 0xb7d3f3080438 in testing::internal::ActionResultHolder<absl::lts_20230802::Status>* testing::internal::ActionResultHolder<absl::lts_20230802::Status>::PerformAction<absl::lts_20230802::Status (std::basic_string_view<char, std::char_traits<char>>, unsigned int, std::function<absl::lts_20230802::Status (unsigned int)>)>(testing::Action<absl::lts_20230802::Status (std::basic_string_view<char, std::char_traits<char>>, unsigned int, std::function<absl::lts_20230802::Status (unsigned int)>)> const&, testing::internal::Function<absl::lts_20230802::Status (std::basic_string_view<char, std::char_traits<char>>, unsigned int, std::function<absl::lts_20230802::Status (unsigned int)>)>::ArgumentTuple&&) (/home/nezdolik.linux/.cache/bazel/_bazel_nezdolik/9a5f062d7ba021dba530b9f40b2998a7/execroot/envoy/bazel-out/aarch64-fastbuild/bin/test/extensions/geoip_providers/maxmind/geoip_provider_test+0x73d0438)
    #6 0xb7d3f307e148 in testing::internal::FunctionMocker<absl::lts_20230802::Status (std::basic_string_view<char, std::char_traits<char>>, unsigned int, std::function<absl::lts_20230802::Status (unsigned int)>)>::UntypedPerformAction(void const*, void*) const (/home/nezdolik.linux/.cache/bazel/_bazel_nezdolik/9a5f062d7ba021dba530b9f40b2998a7/execroot/envoy/bazel-out/aarch64-fastbuild/bin/test/extensions/geoip_providers/maxmind/geoip_provider_test+0x73ce148)
    #7 0xb7d3f531993c in testing::internal::UntypedFunctionMockerBase::UntypedInvokeWith(void*) (/home/nezdolik.linux/.cache/bazel/_bazel_nezdolik/9a5f062d7ba021dba530b9f40b2998a7/execroot/envoy/bazel-out/aarch64-fastbuild/bin/test/extensions/geoip_providers/maxmind/geoip_provider_test+0x966993c)
    #8 0xb7d3f0657fa0 in testing::internal::FunctionMocker<absl::lts_20230802::Status (std::basic_string_view<char, std::char_traits<char>>, unsigned int, std::function<absl::lts_20230802::Status (unsigned int)>)>::Invoke(std::basic_string_view<char, std::char_traits<char>>, unsigned int, std::function<absl::lts_20230802::Status (unsigned int)>) (/home/nezdolik.linux/.cache/bazel/_bazel_nezdolik/9a5f062d7ba021dba530b9f40b2998a7/execroot/envoy/bazel-out/aarch64-fastbuild/bin/test/extensions/geoip_providers/maxmind/geoip_provider_test+0x49a7fa0)
    #9 0xb7d3f0657c2c in Envoy::Filesystem::MockWatcher::addWatch(std::basic_string_view<char, std::char_traits<char>>, unsigned int, std::function<absl::lts_20230802::Status (unsigned int)>) (/home/nezdolik.linux/.cache/bazel/_bazel_nezdolik/9a5f062d7ba021dba530b9f40b2998a7/execroot/envoy/bazel-out/aarch64-fastbuild/bin/test/extensions/geoip_providers/maxmind/geoip_provider_test+0x49a7c2c)
    #10 0xb7d3f06b63b4 in std::_Function_handler<void (), Envoy::Extensions::GeoipProviders::Maxmind::GeoipProvider::GeoipProvider(Envoy::Event::Dispatcher&, Envoy::Api::Api&, std::shared_ptr<Envoy::Singleton::Instance>, std::shared_ptr<Envoy::Extensions::GeoipProviders::Maxmind::GeoipProviderConfig>)::$_0>::_M_invoke(std::_Any_data const&) geoip_provider.cc
    #11 0xb7d3f45c9fc8 in Envoy::Thread::PosixThreadFactory::createPthread(Envoy::Thread::ThreadHandle*)::$_0::__invoke(void*) thread_impl.cc
    #12 0xe6dc6ea637cc  (/lib/aarch64-linux-gnu/libc.so.6+0x837cc) (BuildId: 5b12268cafe96b30a4b950adece623b540b747be)
    #13 0xe6dc6eacf5c8  (/lib/aarch64-linux-gnu/libc.so.6+0xef5c8) (BuildId: 5b12268cafe96b30a4b950adece623b540b747be)

0x60300019d860 is located 0 bytes inside of 32-byte region [0x60300019d860,0x60300019d880)
freed by thread T0 here:
    #0 0xb7d3f05a0138 in free (/home/nezdolik.linux/.cache/bazel/_bazel_nezdolik/9a5f062d7ba021dba530b9f40b2998a7/execroot/envoy/bazel-out/aarch64-fastbuild/bin/test/extensions/geoip_providers/maxmind/geoip_provider_test+0x48f0138)
    #1 0xb7d3f05edd2c in std::vector<std::function<absl::lts_20230802::Status (unsigned int)>, std::allocator<std::function<absl::lts_20230802::Status (unsigned int)>>>::~vector() (/home/nezdolik.linux/.cache/bazel/_bazel_nezdolik/9a5f062d7ba021dba530b9f40b2998a7/execroot/envoy/bazel-out/aarch64-fastbuild/bin/test/extensions/geoip_providers/maxmind/geoip_provider_test+0x493dd2c)
    #2 0xb7d3f0648504 in Envoy::Extensions::GeoipProviders::Maxmind::GeoipProviderTestBase::~GeoipProviderTestBase() (/home/nezdolik.linux/.cache/bazel/_bazel_nezdolik/9a5f062d7ba021dba530b9f40b2998a7/execroot/envoy/bazel-out/aarch64-fastbuild/bin/test/extensions/geoip_providers/maxmind/geoip_provider_test+0x4998504)
    #3 0xb7d3f05eba10 in Envoy::Extensions::GeoipProviders::Maxmind::GeoipProviderTest_ValidConfigCityAndIspDbsSuccessfulLookup_Test::~GeoipProviderTest_ValidConfigCityAndIspDbsSuccessfulLookup_Test() (/home/nezdolik.linux/.cache/bazel/_bazel_nezdolik/9a5f062d7ba021dba530b9f40b2998a7/execroot/envoy/bazel-out/aarch64-fastbuild/bin/test/extensions/geoip_providers/maxmind/geoip_provider_test+0x493ba10)
    #4 0xb7d3f53a68b0 in testing::Test::DeleteSelf_() (/home/nezdolik.linux/.cache/bazel/_bazel_nezdolik/9a5f062d7ba021dba530b9f40b2998a7/execroot/envoy/bazel-out/aarch64-fastbuild/bin/test/extensions/geoip_providers/maxmind/geoip_provider_test+0x96f68b0)
    #5 0xb7d3f53a5ccc in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (/home/nezdolik.linux/.cache/bazel/_bazel_nezdolik/9a5f062d7ba021dba530b9f40b2998a7/execroot/envoy/bazel-out/aarch64-fastbuild/bin/test/extensions/geoip_providers/maxmind/geoip_provider_test+0x96f5ccc)
    #6 0xb7d3f53702fc in testing::TestInfo::Run() (/home/nezdolik.linux/.cache/bazel/_bazel_nezdolik/9a5f062d7ba021dba530b9f40b2998a7/execroot/envoy/bazel-out/aarch64-fastbuild/bin/test/extensions/geoip_providers/maxmind/geoip_provider_test+0x96c02fc)
    #7 0xb7d3f5371dc8 in testing::TestSuite::Run() (/home/nezdolik.linux/.cache/bazel/_bazel_nezdolik/9a5f062d7ba021dba530b9f40b2998a7/execroot/envoy/bazel-out/aarch64-fastbuild/bin/test/extensions/geoip_providers/maxmind/geoip_provider_test+0x96c1dc8)
    #8 0xb7d3f5394e84 in testing::internal::UnitTestImpl::RunAllTests() (/home/nezdolik.linux/.cache/bazel/_bazel_nezdolik/9a5f062d7ba021dba530b9f40b2998a7/execroot/envoy/bazel-out/aarch64-fastbuild/bin/test/extensions/geoip_providers/maxmind/geoip_provider_test+0x96e4e84)
    #9 0xb7d3f53a82a4 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (/home/nezdolik.linux/.cache/bazel/_bazel_nezdolik/9a5f062d7ba021dba530b9f40b2998a7/execroot/envoy/bazel-out/aarch64-fastbuild/bin/test/extensions/geoip_providers/maxmind/geoip_provider_test+0x96f82a4)
    #10 0xb7d3f53945d0 in testing::UnitTest::Run() (/home/nezdolik.linux/.cache/bazel/_bazel_nezdolik/9a5f062d7ba021dba530b9f40b2998a7/execroot/envoy/bazel-out/aarch64-fastbuild/bin/test/extensions/geoip_providers/maxmind/geoip_provider_test+0x96e45d0)
    #11 0xb7d3f2f2ea10 in Envoy::TestRunner::runTests(int, char**) (/home/nezdolik.linux/.cache/bazel/_bazel_nezdolik/9a5f062d7ba021dba530b9f40b2998a7/execroot/envoy/bazel-out/aarch64-fastbuild/bin/test/extensions/geoip_providers/maxmind/geoip_provider_test+0x727ea10)
    #12 0xb7d3f2f2b2c0 in main (/home/nezdolik.linux/.cache/bazel/_bazel_nezdolik/9a5f062d7ba021dba530b9f40b2998a7/execroot/envoy/bazel-out/aarch64-fastbuild/bin/test/extensions/geoip_providers/maxmind/geoip_provider_test+0x727b2c0)
    #13 0xe6dc6ea07580  (/lib/aarch64-linux-gnu/libc.so.6+0x27580) (BuildId: 5b12268cafe96b30a4b950adece623b540b747be)
    #14 0xe6dc6ea07654 in __libc_start_main (/lib/aarch64-linux-gnu/libc.so.6+0x27654) (BuildId: 5b12268cafe96b30a4b950adece623b540b747be)
    #15 0xb7d3f0502eec in _start (/home/nezdolik.linux/.cache/bazel/_bazel_nezdolik/9a5f062d7ba021dba530b9f40b2998a7/execroot/envoy/bazel-out/aarch64-fastbuild/bin/test/extensions/geoip_providers/maxmind/geoip_provider_test+0x4852eec)

previously allocated by thread T1 here:
    #0 0xb7d3f05a03cc in malloc (/home/nezdolik.linux/.cache/bazel/_bazel_nezdolik/9a5f062d7ba021dba530b9f40b2998a7/execroot/envoy/bazel-out/aarch64-fastbuild/bin/test/extensions/geoip_providers/maxmind/geoip_provider_test+0x48f03cc)
    #1 0xb7d3f5428378 in operator new(unsigned long) (/home/nezdolik.linux/.cache/bazel/_bazel_nezdolik/9a5f062d7ba021dba530b9f40b2998a7/execroot/envoy/bazel-out/aarch64-fastbuild/bin/test/extensions/geoip_providers/maxmind/geoip_provider_test+0x9778378)
    #2 0xb7d3f065b994 in std::vector<std::function<absl::lts_20230802::Status (unsigned int)>, std::allocator<std::function<absl::lts_20230802::Status (unsigned int)>>>::reserve(unsigned long) (/home/nezdolik.linux/.cache/bazel/_bazel_nezdolik/9a5f062d7ba021dba530b9f40b2998a7/execroot/envoy/bazel-out/aarch64-fastbuild/bin/test/extensions/geoip_providers/maxmind/geoip_provider_test+0x49ab994)
    #3 0xb7d3f065b684 in Envoy::Extensions::GeoipProviders::Maxmind::GeoipProviderTestBase::initializeProvider(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, std::optional<Envoy::ConditionalInitializer>&)::'lambda'()::operator()() const::'lambda'(std::basic_string_view<char, std::char_traits<char>>, unsigned int, std::function<absl::lts_20230802::Status (unsigned int)>)::operator()(std::basic_string_view<char, std::char_traits<char>>, unsigned int, std::function<absl::lts_20230802::Status (unsigned int)>) const (/home/nezdolik.linux/.cache/bazel/_bazel_nezdolik/9a5f062d7ba021dba530b9f40b2998a7/execroot/envoy/bazel-out/aarch64-fastbuild/bin/test/extensions/geoip_providers/maxmind/geoip_provider_test+0x49ab684)
    #4 0xb7d3f065b2c0 in std::_Function_handler<absl::lts_20230802::Status (std::basic_string_view<char, std::char_traits<char>>, unsigned int, std::function<absl::lts_20230802::Status (unsigned int)>), Envoy::Extensions::GeoipProviders::Maxmind::GeoipProviderTestBase::initializeProvider(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, std::optional<Envoy::ConditionalInitializer>&)::'lambda'()::operator()() const::'lambda'(std::basic_string_view<char, std::char_traits<char>>, unsigned int, std::function<absl::lts_20230802::Status (unsigned int)>)>::_M_invoke(std::_Any_data const&, std::basic_string_view<char, std::char_traits<char>>&&, unsigned int&&, std::function<absl::lts_20230802::Status (unsigned int)>&&) (/home/nezdolik.linux/.cache/bazel/_bazel_nezdolik/9a5f062d7ba021dba530b9f40b2998a7/execroot/envoy/bazel-out/aarch64-fastbuild/bin/test/extensions/geoip_providers/maxmind/geoip_provider_test+0x49ab2c0)
    #5 0xb7d3f3080050 in decltype(std::forward<std::function<absl::lts_20230802::Status (std::basic_string_view<char, std::char_traits<char>>, unsigned int, std::function<absl::lts_20230802::Status (unsigned int)>)> const&>(fp)(std::get<0ul>(std::forward<std::tuple<std::basic_string_view<char, std::char_traits<char>>, unsigned int, std::function<absl::lts_20230802::Status (unsigned int)>>>(fp0)), std::get<1ul>(std::forward<std::tuple<std::basic_string_view<char, std::char_traits<char>>, unsigned int, std::function<absl::lts_20230802::Status (unsigned int)>>>(fp0)), std::get<2ul>(std::forward<std::tuple<std::basic_string_view<char, std::char_traits<char>>, unsigned int, std::function<absl::lts_20230802::Status (unsigned int)>>>(fp0)))) testing::internal::ApplyImpl<std::function<absl::lts_20230802::Status (std::basic_string_view<char, std::char_traits<char>>, unsigned int, std::function<absl::lts_20230802::Status (unsigned int)>)> const&, std::tuple<std::basic_string_view<char, std::char_traits<char>>, unsigned int, std::function<absl::lts_20230802::Status (unsigned int)>>, 0ul, 1ul, 2ul>(std::function<absl::lts_20230802::Status (std::basic_string_view<char, std::char_traits<char>>, unsigned int, std::function<absl::lts_20230802::Status (unsigned int)>)> const&, std::tuple<std::basic_string_view<char, std::char_traits<char>>, unsigned int, std::function<absl::lts_20230802::Status (unsigned int)>>&&, testing::internal::IndexSequence<0ul, 1ul, 2ul>) (/home/nezdolik.linux/.cache/bazel/_bazel_nezdolik/9a5f062d7ba021dba530b9f40b2998a7/execroot/envoy/bazel-out/aarch64-fastbuild/bin/test/extensions/geoip_providers/maxmind/geoip_provider_test+0x73d0050)
    #6 0xb7d3f3080438 in testing::internal::ActionResultHolder<absl::lts_20230802::Status>* testing::internal::ActionResultHolder<absl::lts_20230802::Status>::PerformAction<absl::lts_20230802::Status (std::basic_string_view<char, std::char_traits<char>>, unsigned int, std::function<absl::lts_20230802::Status (unsigned int)>)>(testing::Action<absl::lts_20230802::Status (std::basic_string_view<char, std::char_traits<char>>, unsigned int, std::function<absl::lts_20230802::Status (unsigned int)>)> const&, testing::internal::Function<absl::lts_20230802::Status (std::basic_string_view<char, std::char_traits<char>>, unsigned int, std::function<absl::lts_20230802::Status (unsigned int)>)>::ArgumentTuple&&) (/home/nezdolik.linux/.cache/bazel/_bazel_nezdolik/9a5f062d7ba021dba530b9f40b2998a7/execroot/envoy/bazel-out/aarch64-fastbuild/bin/test/extensions/geoip_providers/maxmind/geoip_provider_test+0x73d0438)
    #7 0xb7d3f307e148 in testing::internal::FunctionMocker<absl::lts_20230802::Status (std::basic_string_view<char, std::char_traits<char>>, unsigned int, std::function<absl::lts_20230802::Status (unsigned int)>)>::UntypedPerformAction(void const*, void*) const (/home/nezdolik.linux/.cache/bazel/_bazel_nezdolik/9a5f062d7ba021dba530b9f40b2998a7/execroot/envoy/bazel-out/aarch64-fastbuild/bin/test/extensions/geoip_providers/maxmind/geoip_provider_test+0x73ce148)
    #8 0xb7d3f531993c in testing::internal::UntypedFunctionMockerBase::UntypedInvokeWith(void*) (/home/nezdolik.linux/.cache/bazel/_bazel_nezdolik/9a5f062d7ba021dba530b9f40b2998a7/execroot/envoy/bazel-out/aarch64-fastbuild/bin/test/extensions/geoip_providers/maxmind/geoip_provider_test+0x966993c)
    #9 0xb7d3f0657fa0 in testing::internal::FunctionMocker<absl::lts_20230802::Status (std::basic_string_view<char, std::char_traits<char>>, unsigned int, std::function<absl::lts_20230802::Status (unsigned int)>)>::Invoke(std::basic_string_view<char, std::char_traits<char>>, unsigned int, std::function<absl::lts_20230802::Status (unsigned int)>) (/home/nezdolik.linux/.cache/bazel/_bazel_nezdolik/9a5f062d7ba021dba530b9f40b2998a7/execroot/envoy/bazel-out/aarch64-fastbuild/bin/test/extensions/geoip_providers/maxmind/geoip_provider_test+0x49a7fa0)
    #10 0xb7d3f0657c2c in Envoy::Filesystem::MockWatcher::addWatch(std::basic_string_view<char, std::char_traits<char>>, unsigned int, std::function<absl::lts_20230802::Status (unsigned int)>) (/home/nezdolik.linux/.cache/bazel/_bazel_nezdolik/9a5f062d7ba021dba530b9f40b2998a7/execroot/envoy/bazel-out/aarch64-fastbuild/bin/test/extensions/geoip_providers/maxmind/geoip_provider_test+0x49a7c2c)
    #11 0xb7d3f06b61d4 in std::_Function_handler<void (), Envoy::Extensions::GeoipProviders::Maxmind::GeoipProvider::GeoipProvider(Envoy::Event::Dispatcher&, Envoy::Api::Api&, std::shared_ptr<Envoy::Singleton::Instance>, std::shared_ptr<Envoy::Extensions::GeoipProviders::Maxmind::GeoipProviderConfig>)::$_0>::_M_invoke(std::_Any_data const&) geoip_provider.cc
    #12 0xb7d3f45c9fc8 in Envoy::Thread::PosixThreadFactory::createPthread(Envoy::Thread::ThreadHandle*)::$_0::__invoke(void*) thread_impl.cc
    #13 0xe6dc6ea637cc  (/lib/aarch64-linux-gnu/libc.so.6+0x837cc) (BuildId: 5b12268cafe96b30a4b950adece623b540b747be)
    #14 0xe6dc6eacf5c8  (/lib/aarch64-linux-gnu/libc.so.6+0xef5c8) (BuildId: 5b12268cafe96b30a4b950adece623b540b747be)
```

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
