### PR TITLE
Bugfix: Post UDP buffer flushing on the dispatcher

### DIFF
--- a/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.cc
+++ b/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.cc
@@ -1038,9 +1038,7 @@ void UdpProxyFilter::TunnelingActiveSession::onAboveWriteBufferHighWatermark() {
 
 void UdpProxyFilter::TunnelingActiveSession::onBelowWriteBufferLowWatermark() {
   can_send_upstream_ = true;
-  cluster_.filter_.read_callbacks_->udpListener().dispatcher().post([this]() {
-    flushBuffer();
-  });
+  cluster_.filter_.read_callbacks_->udpListener().dispatcher().post([this]() { flushBuffer(); });
 }
 
 void UdpProxyFilter::TunnelingActiveSession::flushBuffer() {

--- a/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.cc
+++ b/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.cc
@@ -1038,7 +1038,9 @@ void UdpProxyFilter::TunnelingActiveSession::onAboveWriteBufferHighWatermark() {
 
 void UdpProxyFilter::TunnelingActiveSession::onBelowWriteBufferLowWatermark() {
   can_send_upstream_ = true;
-  flushBuffer();
+  cluster_.filter_.read_callbacks_->udpListener().dispatcher().post([this]() {
+    flushBuffer();
+  });
 }
 
 void UdpProxyFilter::TunnelingActiveSession::flushBuffer() {


### PR DESCRIPTION
Commit Message: Bugfix: Post UDP buffer flushing on the dispatcher
Additional Description: We're running Envoy version 1.30, and we've observed crashes while tunneling UDP over HTTP with the following stack trace:
```
Caught Segmentation fault, suspect faulting address 0xc
Backtrace (use tools/stack_decode.py to get line numbers):
Envoy version: 38c0958e771a7c2accf643ae0c92818cf83b4f10/1.27.0/Clean/RELEASE/BoringSSL
#0: [0x72c0e57cce30]
#1: nghttp2_session_mem_send_internal [0x5d2f3406db7c]
#2: nghttp2_session_send [0x5d2f3406ee80]
#3: http2::adapter::NgHttp2Adapter::Send() [0x5d2f340571dd]
#4: Envoy::Http::Http2::ConnectionImpl::sendPendingFrames() [0x5d2f33d6908b]
#5: Envoy::Http::Http2::ConnectionImpl::dispatch() [0x5d2f33d68bd2]
#6: Envoy::Http::Http2::ConnectionImpl::dispatch() [0x5d2f33d696c5]
#7: Envoy::Http::CodecClient::onData() [0x5d2f33bae0af]
#8: Envoy::Http::CodecClient::CodecReadFilter::onData() [0x5d2f33bb0b45]
#9: Envoy::Network::FilterManagerImpl::onContinueReading() [0x5d2f34020c21]
#10: Envoy::Network::ConnectionImpl::onReadReady() [0x5d2f33fc0aa6]
#11: Envoy::Network::ConnectionImpl::onFileEvent() [0x5d2f33fbdc01]
#12: std::_Function_handler<>::_M_invoke() [0x5d2f33faddef]
#13: Envoy::Event::FileEventImpl::assignEvents()::$_1::__invoke() [0x5d2f33faf292]
#14: event_process_active_single_queue [0x5d2f345fbba0]
#15: event_base_loop [0x5d2f345fa5b1]
#16: Envoy::Server::WorkerImpl::threadRoutine() [0x5d2f3374b009]
#17: Envoy::Thread::ThreadImplPosix::ThreadImplPosix()::{lambda()#1}::__invoke() [0x5d2f34602ec5]
#18: [0x72c0e58161d2]
```
After investing the issue, we've found that it occurs in the following scenario:
- Envoy calls `NgHttp2Adapter::Send()` to send data.
- NgHttp2 calls Envoy's callback to write data on the connection.
- Envoy moves data from the `pending_send_data_` buffer to output buffer (Envoy still hasn't written to the connection).
- The buffer is under limit.
- Envoy calls `pendingSendBufferHighWatermark()` which calls, in our case, `UdpProxyFilter::TunnelingActiveSession::onBelowWriteBufferLowWatermark()`.
- `UdpProxyFilter::TunnelingActiveSession::onBelowWriteBufferLowWatermark` flushes datagrams buffer and calls `upstream_->encodeData`.
- Envoy calls `NgHttp2Adapter::Send()` again (while the first call hasn't been finished yet).
- After flushing the buffer and returning from `pendingSendBufferHighWatermark()`, Envoy writes data on the connection and the Envoy's callback finishes.
- NgHttp2 continues to run after the end of Envoy's callback and try to access "session->aob.item" which is already assigned to NULL during nested sends.
- Envoy crashes (Note: We've tried to use OgHttp2 instead and Envoy wasn't crashing because in OgHttp2 they have a check which validates that the session isn't in "sending" state and skip sending otherwise).

The solution for the issue is to post UDP buffer flushing on the UDP listener dispatcher instead of the flushing immediately in the callback.

Risk Level: low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
