### PR TITLE
http: allow trigger GOAWAY from l7 filters

### DIFF
--- a/envoy/http/filter.h
+++ b/envoy/http/filter.h
@@ -645,6 +645,11 @@ public:
                               absl::string_view details) PURE;
 
   /**
+   * Attempt to send GOAWAY and close the connection.   
+   */
+  virtual void sendGoAwayandClose() PURE;
+
+  /**
    * Adds decoded metadata. This function can only be called in
    * StreamDecoderFilter::decodeHeaders/Data/Trailers(). Do not call in
    * StreamDecoderFilter::decodeMetadata().

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -227,6 +227,7 @@ private:
   }
   void addDownstreamWatermarkCallbacks(DownstreamWatermarkCallbacks&) override {}
   void removeDownstreamWatermarkCallbacks(DownstreamWatermarkCallbacks&) override {}
+  void sendGoAwayandClose() override {} 
   void setDecoderBufferLimit(uint32_t) override {
     IS_ENVOY_BUG("decoder buffer limits should not be overridden on async streams.");
   }

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -756,6 +756,12 @@ void ConnectionManagerImpl::onDrainTimeout() {
   checkForDeferredClose(false);
 }
 
+void ConnectionManagerImpl::sendGoAwayandClose() {
+  ENVOY_CONN_LOG(debug, "boteng sendGoAwayandClose", read_callbacks_->connection());
+  codec_->goAway();
+  doConnectionClose(Network::ConnectionCloseType::FlushWriteAndDelay, absl::nullopt, "forced_goaway");
+}
+
 void ConnectionManagerImpl::chargeTracingStats(const Tracing::Reason& tracing_reason,
                                                ConnectionManagerTracingStats& tracing_stats) {
   switch (tracing_reason) {

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -190,6 +190,11 @@ private:
                         absl::string_view details) override {
       return filter_manager_.sendLocalReply(code, body, modify_headers, grpc_status, details);
     }
+
+    void sendGoAwayandClose() override {
+      return connection_manager_.sendGoAwayandClose();
+    }
+
     std::list<AccessLog::InstanceSharedPtr> accessLogHandlers() override {
       std::list<AccessLog::InstanceSharedPtr> combined_log_handlers(
           filter_manager_.accessLogHandlers());
@@ -589,6 +594,8 @@ private:
   void doConnectionClose(absl::optional<Network::ConnectionCloseType> close_type,
                          absl::optional<StreamInfo::CoreResponseFlag> response_flag,
                          absl::string_view details);
+  void sendGoAwayandClose();
+                         
   // Returns true if a RST_STREAM for the given stream is premature. Premature
   // means the RST_STREAM arrived before response headers were sent and than
   // the stream was alive for short period of time. This period is specified

--- a/source/common/http/filter_manager.cc
+++ b/source/common/http/filter_manager.cc
@@ -453,6 +453,10 @@ void ActiveStreamDecoderFilter::sendLocalReply(
   ActiveStreamFilterBase::sendLocalReply(code, body, modify_headers, grpc_status, details);
 }
 
+void ActiveStreamDecoderFilter::sendGoAwayandClose() {
+  parent_.sendGoAwayandClose();
+}
+
 void ActiveStreamDecoderFilter::encode1xxHeaders(ResponseHeaderMapPtr&& headers) {
   // If Envoy is not configured to proxy 100-Continue responses, swallow the 100 Continue
   // here. This avoids the potential situation where Envoy strips Expect: 100-Continue and sends a

--- a/source/common/http/filter_manager.h
+++ b/source/common/http/filter_manager.h
@@ -262,6 +262,7 @@ struct ActiveStreamDecoderFilter : public ActiveStreamFilterBase,
   void setUpstreamOverrideHost(Upstream::LoadBalancerContext::OverrideHost) override;
   absl::optional<Upstream::LoadBalancerContext::OverrideHost> upstreamOverrideHost() const override;
   bool shouldLoadShed() const override;
+  void sendGoAwayandClose() override;
 
   // Each decoder filter instance checks if the request passed to the filter is gRPC
   // so that we can issue gRPC local responses to gRPC requests. Filter's decodeHeaders()
@@ -448,6 +449,11 @@ public:
    * Called after encoding has completed.
    */
   virtual void endStream() PURE;
+
+  /**
+   * Attempt to send GOAWAY and close the connection.   
+   */
+  virtual void sendGoAwayandClose() PURE;
 
   /**
    * Called when the stream write buffer is no longer above the low watermark.
@@ -852,6 +858,10 @@ public:
   bool sawDownstreamReset() { return state_.saw_downstream_reset_; }
 
   virtual bool shouldLoadShed() { return false; };
+
+  void sendGoAwayandClose() {
+    filter_manager_callbacks_.sendGoAwayandClose(); 
+  }
 
 protected:
   struct State {

--- a/source/common/router/upstream_request.h
+++ b/source/common/router/upstream_request.h
@@ -339,6 +339,7 @@ public:
   void disarmRequestTimeout() override {}
   void resetIdleTimer() override {}
   void onLocalReply(Http::Code) override {}
+  void sendGoAwayandClose() override {}
   // Upgrade filter chains not supported.
   const Router::RouteEntry::UpgradeMap* upgradeMap() override { return nullptr; }
 

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -536,6 +536,7 @@ envoy_cc_test(
         "//test/integration/filters:response_metadata_filter_config_lib",
         "//test/integration/filters:set_response_code_filter_config_proto_cc_proto",
         "//test/integration/filters:set_response_code_filter_lib",
+        "//test/integration/filters:send_goaway_filter_lib",
         "//test/integration/filters:stop_in_headers_continue_in_data_filter_lib",
         "//test/integration/filters:stop_iteration_and_continue",
         "//test/mocks/http:http_mocks",

--- a/test/integration/filters/BUILD
+++ b/test/integration/filters/BUILD
@@ -122,6 +122,21 @@ envoy_cc_test_library(
 )
 
 envoy_cc_test_library(
+    name = "send_goaway_filter_lib",
+    srcs = [
+        "send_goaway_filter.cc",
+    ],
+    deps = [
+        ":common_lib",
+        "//envoy/http:filter_interface",
+        "//envoy/registry",
+        "//envoy/server:filter_config_interface",
+        "//source/extensions/filters/http/common:pass_through_filter_lib",
+        "//test/extensions/filters/http/common:empty_http_filter_config_lib",
+    ],
+)
+
+envoy_cc_test_library(
     name = "tee_filter_lib",
     srcs = [
         "tee_filter.cc",

--- a/test/integration/filters/send_goaway_filter.cc
+++ b/test/integration/filters/send_goaway_filter.cc
@@ -1,0 +1,52 @@
+#include <string>
+
+#include "envoy/http/filter.h"
+#include "envoy/registry/registry.h"
+#include "envoy/server/filter_config.h"
+
+#include "source/extensions/filters/http/common/pass_through_filter.h"
+
+#include "test/extensions/filters/http/common/empty_http_filter_config.h"
+#include "test/integration/filters/common.h"
+
+namespace Envoy {
+
+class GoAwayDuringDecoding : public Http::PassThroughFilter {
+public:
+  constexpr static char name[] = "send-goaway-during-decode-filter";
+
+  Http::FilterHeadersStatus decodeHeaders(Http::RequestHeaderMap& request_headers, bool) override {
+    auto result = request_headers.get(Http::LowerCaseString("skip-goaway"));
+    if (!result.empty() && result[0]->value() == "true") {
+      go_away_skiped_ = true;
+      return Http::FilterHeadersStatus::Continue;
+    }
+    decoder_callbacks_->sendGoAwayandClose();
+    return Http::FilterHeadersStatus::StopIteration;
+  }
+
+  // Due to the above local reply, this method should never be invoked in tests.
+  Http::FilterDataStatus decodeData(Buffer::Instance&, bool) override {
+    ASSERT(go_away_skiped_);
+    return Http::FilterDataStatus::Continue;
+  }
+
+  // Due to the above local reply, this method should never be invoked in tests.
+  Http::FilterMetadataStatus decodeMetadata(Http::MetadataMap&) override {
+    ASSERT(go_away_skiped_);
+    return Http::FilterMetadataStatus::Continue;
+  }
+
+private:
+  bool go_away_skiped_ = false;
+};
+
+constexpr char GoAwayDuringDecoding::name[];
+static Registry::RegisterFactory<SimpleFilterConfig<GoAwayDuringDecoding>,
+                                 Server::Configuration::NamedHttpFilterConfigFactory>
+    register_;
+// static Registry::RegisterFactory<SimpleFilterConfig<GoAwayDuringDecoding>,
+//                                  Server::Configuration::UpstreamHttpFilterConfigFactory>
+//     register_upstream_;
+
+} // namespace Envoy


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
