### PR TITLE
Adding new code owner for ext_proc filter

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -29,7 +29,7 @@ extensions/filters/common/original_src @klarose @mattklein123
 # cdn_loop extension
 /*/extensions/filters/http/cdn_loop @justin-mp @penguingao @alyssawilk
 # external processing filter
-/*/extensions/filters/http/ext_proc @gbrail @stevenzzzz @tyxia @mattklein123 @yanavlasov
+/*/extensions/filters/http/ext_proc @gbrail @stevenzzzz @tyxia @mattklein123 @yanavlasov @yanjunxiang-google
 /*/extensions/filters/common/mutation_rules @gbrail @tyxia @mattklein123 @yanavlasov
 # jwt_authn http filter extension
 /*/extensions/filters/http/jwt_authn @taoxuy @lizan @tyxia @yanavlasov


### PR DESCRIPTION
Description:
Adding new code owner for ext_proc filter

Risk Level: low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
