### PR TITLE
opentelemetrytracer: avoid exporting when there are no spans

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -189,6 +189,9 @@ bug_fixes:
   change: |
     Set token cookies in response regardless of :ref:`forward_bearer_token
     <envoy_v3_api_field_extensions.filters.http.oauth2.v3.OAuth2Config.forward_bearer_token>` config option.
+- area: tracing
+  change: |
+    Fixed a bug where the OpenTelemetry tracer exports the OTLP request even when no spans are present.
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/source/extensions/tracers/opentelemetry/tracer.cc
+++ b/source/extensions/tracers/opentelemetry/tracer.cc
@@ -163,6 +163,10 @@ void Tracer::enableTimer() {
 }
 
 void Tracer::flushSpans() {
+  if (span_buffer_.empty()) {
+    return;
+  }
+
   ExportTraceServiceRequest request;
   // A request consists of ResourceSpans.
   ::opentelemetry::proto::trace::v1::ResourceSpans* resource_span = request.add_resource_spans();


### PR DESCRIPTION
Commit Message: opentelemetrytracer: avoid exporting when there are no spans
Additional Description: Today, the OpenTelemetry tracer exports a OTLP request on each interval, even when there are no spans to be sent. The OTLP is empty, only containing the resource (and its attributes). 
Risk Level: Low
Testing: Manual
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #35997] 
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
