### PR TITLE
xds: internal refactor using absl::span instead of vector

### DIFF
--- a/envoy/config/subscription.h
+++ b/envoy/config/subscription.h
@@ -191,10 +191,10 @@ public:
    * being updated. Accepted changes have their version_info reflected in subsequent
    * requests.
    */
-  virtual void onConfigUpdate(
-      const Protobuf::RepeatedPtrField<envoy::service::discovery::v3::Resource>& added_resources,
-      const Protobuf::RepeatedPtrField<std::string>& removed_resources,
-      const std::string& system_version_info) PURE;
+  virtual void
+  onConfigUpdate(absl::Span<const envoy::service::discovery::v3::Resource* const> added_resources,
+                 const Protobuf::RepeatedPtrField<std::string>& removed_resources,
+                 const std::string& system_version_info) PURE;
 
   /**
    * Called when either the Subscription is unable to fetch a config update or when onConfigUpdate

--- a/envoy/config/xds_config_tracker.h
+++ b/envoy/config/xds_config_tracker.h
@@ -60,10 +60,10 @@ public:
    * @param added_resources A list of decoded resources to add to the current state.
    * @param removed_resources A list of resources to remove from the current state.
    */
-  virtual void onConfigAccepted(
-      const absl::string_view type_url,
-      const Protobuf::RepeatedPtrField<envoy::service::discovery::v3::Resource>& added_resources,
-      const Protobuf::RepeatedPtrField<std::string>& removed_resources) PURE;
+  virtual void
+  onConfigAccepted(const absl::string_view type_url,
+                   absl::Span<const envoy::service::discovery::v3::Resource* const> added_resources,
+                   const Protobuf::RepeatedPtrField<std::string>& removed_resources) PURE;
 
   /**
    * Invoked when xds configs are rejected during xDS ingestion.

--- a/source/extensions/config_subscription/grpc/delta_subscription_state.cc
+++ b/source/extensions/config_subscription/grpc/delta_subscription_state.cc
@@ -218,12 +218,14 @@ void DeltaSubscriptionState::handleGoodResponse(
     }
   }
 
-  watch_map_.onConfigUpdate(non_heartbeat_resources, message.removed_resources(),
+  absl::Span<const envoy::service::discovery::v3::Resource* const> non_heartbeat_resources_span =
+      absl::MakeConstSpan(non_heartbeat_resources.data(), non_heartbeat_resources.size());
+  watch_map_.onConfigUpdate(non_heartbeat_resources_span, message.removed_resources(),
                             message.system_version_info());
 
   // Processing point when resources are successfully ingested.
   if (xds_config_tracker_.has_value()) {
-    xds_config_tracker_->onConfigAccepted(message.type_url(), non_heartbeat_resources,
+    xds_config_tracker_->onConfigAccepted(message.type_url(), non_heartbeat_resources_span,
                                           message.removed_resources());
   }
 

--- a/source/extensions/config_subscription/grpc/watch_map.h
+++ b/source/extensions/config_subscription/grpc/watch_map.h
@@ -105,10 +105,10 @@ public:
   void onConfigUpdate(const std::vector<DecodedResourcePtr>& resources,
                       const std::string& version_info) override;
 
-  void onConfigUpdate(
-      const Protobuf::RepeatedPtrField<envoy::service::discovery::v3::Resource>& added_resources,
-      const Protobuf::RepeatedPtrField<std::string>& removed_resources,
-      const std::string& system_version_info) override;
+  void
+  onConfigUpdate(absl::Span<const envoy::service::discovery::v3::Resource* const> added_resources,
+                 const Protobuf::RepeatedPtrField<std::string>& removed_resources,
+                 const std::string& system_version_info) override;
   void onConfigUpdateFailed(ConfigUpdateFailureReason reason, const EnvoyException* e) override;
 
   WatchMap(const WatchMap&) = delete;

--- a/source/extensions/config_subscription/grpc/xds_mux/delta_subscription_state.cc
+++ b/source/extensions/config_subscription/grpc/xds_mux/delta_subscription_state.cc
@@ -188,12 +188,14 @@ void DeltaSubscriptionState::handleGoodResponse(
     }
   }
 
-  callbacks().onConfigUpdate(non_heartbeat_resources, message.removed_resources(),
+  absl::Span<const envoy::service::discovery::v3::Resource* const> non_heartbeat_resources_span =
+      absl::MakeConstSpan(non_heartbeat_resources.data(), non_heartbeat_resources.size());
+  callbacks().onConfigUpdate(non_heartbeat_resources_span, message.removed_resources(),
                              message.system_version_info());
 
   // Processing point when resources are successfully ingested.
   if (xds_config_tracker_.has_value()) {
-    xds_config_tracker_->onConfigAccepted(message.type_url(), non_heartbeat_resources,
+    xds_config_tracker_->onConfigAccepted(message.type_url(), non_heartbeat_resources_span,
                                           message.removed_resources());
   }
 

--- a/test/integration/xds_config_tracker_integration_test.cc
+++ b/test/integration/xds_config_tracker_integration_test.cc
@@ -68,15 +68,14 @@ public:
     }
   }
 
-  void onConfigAccepted(
-      const absl::string_view,
-      const Protobuf::RepeatedPtrField<envoy::service::discovery::v3::Resource>& resources,
-      const Protobuf::RepeatedPtrField<std::string>&) override {
+  void onConfigAccepted(const absl::string_view,
+                        absl::Span<const envoy::service::discovery::v3::Resource* const> resources,
+                        const Protobuf::RepeatedPtrField<std::string>&) override {
     stats_.on_config_accepted_.inc();
     test::envoy::config::xds::TestTrackerMetadata test_metadata;
-    for (const auto& resource : resources) {
-      if (resource.has_metadata()) {
-        const auto& config_typed_metadata = resource.metadata().typed_filter_metadata();
+    for (const auto* resource : resources) {
+      if (resource->has_metadata()) {
+        const auto& config_typed_metadata = resource->metadata().typed_filter_metadata();
         if (const auto& metadata_it = config_typed_metadata.find(kTestKey);
             metadata_it != config_typed_metadata.end()) {
           const auto status = Envoy::MessageUtil::unpackTo(metadata_it->second, test_metadata);

--- a/test/mocks/config/mocks.h
+++ b/test/mocks/config/mocks.h
@@ -56,11 +56,10 @@ public:
   MOCK_METHOD(void, onConfigUpdate,
               (const std::vector<DecodedResourcePtr>& resources, const std::string& version_info));
 
-  MOCK_METHOD(
-      void, onConfigUpdate,
-      (const Protobuf::RepeatedPtrField<envoy::service::discovery::v3::Resource>& added_resources,
-       const Protobuf::RepeatedPtrField<std::string>& removed_resources,
-       const std::string& system_version_info));
+  MOCK_METHOD(void, onConfigUpdate,
+              (absl::Span<const envoy::service::discovery::v3::Resource* const> added_resources,
+               const Protobuf::RepeatedPtrField<std::string>& removed_resources,
+               const std::string& system_version_info));
   MOCK_METHOD(void, onConfigUpdateFailed,
               (Envoy::Config::ConfigUpdateFailureReason reason, const EnvoyException* e));
 };


### PR DESCRIPTION
Commit Message: xds: internal refactor using absl::span instead of vector
Additional Description:
Changing an internal function argument type from std::vector to absl::Span.
This is not expected to have any change to current behavior.
A followup PR will remove the copy of non_heartbeat_resources vector (which will be runtime guarded).

Risk Level: low - no actual change.
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
