### PR TITLE
Add connection.downstream_bytes_sent and connection.downstream_bytes_received in CEL attributes

### DIFF
--- a/docs/root/intro/arch_overview/advanced/attributes.rst
+++ b/docs/root/intro/arch_overview/advanced/attributes.rst
@@ -122,6 +122,8 @@ RBAC):
    connection.uri_san_peer_certificate, string, The first URI entry in the SAN field of the peer certificate in the downstream TLS connection
    connection.sha256_peer_certificate_digest, string, SHA256 digest of the peer certificate in the downstream TLS connection if present
    connection.transport_failure_reason, string, The transport failure reason e.g. certificate validation failed
+   connection.downstream_bytes_sent, int, Number of bytes sent to the downstream.
+   connection.downstream_bytes_received, int, Number of bytes received from the downstream.
 
 The following additional attributes are available upon the downstream connection termination:
 

--- a/source/extensions/filters/common/expr/context.cc
+++ b/source/extensions/filters/common/expr/context.cc
@@ -224,6 +224,10 @@ absl::optional<CelValue> ConnectionWrapper::operator[](CelValue key) const {
       return CelValue::CreateStringView(info_.downstreamTransportFailureReason());
     }
     return {};
+  } else if (value == DownstreamBytesSent) {
+    return CelValue::CreateInt64(info_.getDownstreamBytesMeter()->wireBytesSent());
+  } else if (value == DownstreamBytesReceived) {
+    return CelValue::CreateInt64(info_.getDownstreamBytesMeter()->wireBytesReceived());
   }
 
   auto ssl_info = info_.downstreamAddressProvider().sslConnection();

--- a/source/extensions/filters/common/expr/context.h
+++ b/source/extensions/filters/common/expr/context.h
@@ -71,6 +71,8 @@ constexpr absl::string_view DNSSanLocalCertificate = "dns_san_local_certificate"
 constexpr absl::string_view DNSSanPeerCertificate = "dns_san_peer_certificate";
 constexpr absl::string_view SHA256PeerCertificateDigest = "sha256_peer_certificate_digest";
 constexpr absl::string_view DownstreamTransportFailureReason = "transport_failure_reason";
+constexpr absl::string_view DownstreamBytesSent = "downstream_bytes_sent";
+constexpr absl::string_view DownstreamBytesReceived = "downstream_bytes_received";
 
 // Source properties
 constexpr absl::string_view Source = "source";

--- a/test/extensions/filters/common/expr/context_test.cc
+++ b/test/extensions/filters/common/expr/context_test.cc
@@ -715,8 +715,7 @@ TEST(Context, ConnectionAttributes) {
   }
 
   {
-    auto value =
-        connection[CelValue::CreateStringView(DownstreamBytesReceived)];
+    auto value = connection[CelValue::CreateStringView(DownstreamBytesReceived)];
     EXPECT_TRUE(value.has_value());
     EXPECT_TRUE(value.value().IsInt64());
     EXPECT_EQ(downstream_bytes_received, value.value().Int64OrDie());


### PR DESCRIPTION
We will depend on CEL to get those information inside HTTP wasm

- unit tests added
- doc added

