### PR TITLE
quic: report stream reset direction in reset callback failure string

### DIFF
--- a/source/common/quic/envoy_quic_client_stream.cc
+++ b/source/common/quic/envoy_quic_client_stream.cc
@@ -258,7 +258,8 @@ bool EnvoyQuicClientStream::OnStopSending(quic::QuicResetStreamError error) {
     runResetCallbacks(
         quicRstErrorToEnvoyRemoteResetReason(error.internal_code()),
         Runtime::runtimeFeatureEnabled("envoy.reloadable_features.report_stream_reset_error_code")
-            ? absl::StrCat("rx|", quic::QuicRstStreamErrorCodeToString(error.internal_code()))
+            ? absl::StrCat(quic::QuicRstStreamErrorCodeToString(error.internal_code()),
+                           "|FROM_PEER")
             : absl::string_view());
   }
   return true;
@@ -360,7 +361,7 @@ void EnvoyQuicClientStream::OnStreamReset(const quic::QuicRstStreamFrame& frame)
     runResetCallbacks(
         quicRstErrorToEnvoyRemoteResetReason(frame.error_code),
         Runtime::runtimeFeatureEnabled("envoy.reloadable_features.report_stream_reset_error_code")
-            ? absl::StrCat("rx|", quic::QuicRstStreamErrorCodeToString(frame.error_code))
+            ? absl::StrCat(quic::QuicRstStreamErrorCodeToString(frame.error_code), "|FROM_PEER")
             : absl::string_view());
   }
 }
@@ -374,7 +375,7 @@ void EnvoyQuicClientStream::ResetWithError(quic::QuicResetStreamError error) {
   runResetCallbacks(
       quicRstErrorToEnvoyLocalResetReason(error.internal_code()),
       Runtime::runtimeFeatureEnabled("envoy.reloadable_features.report_stream_reset_error_code")
-          ? absl::StrCat("tx|", quic::QuicRstStreamErrorCodeToString(error.internal_code()))
+          ? absl::StrCat(quic::QuicRstStreamErrorCodeToString(error.internal_code()), "|FROM_SELF")
           : absl::string_view());
   if (session()->connection()->connected()) {
     quic::QuicSpdyClientStream::ResetWithError(error);

--- a/source/common/quic/envoy_quic_client_stream.cc
+++ b/source/common/quic/envoy_quic_client_stream.cc
@@ -258,8 +258,7 @@ bool EnvoyQuicClientStream::OnStopSending(quic::QuicResetStreamError error) {
     runResetCallbacks(
         quicRstErrorToEnvoyRemoteResetReason(error.internal_code()),
         Runtime::runtimeFeatureEnabled("envoy.reloadable_features.report_stream_reset_error_code")
-            ? absl::StrCat("remote reset|",
-                           quic::QuicRstStreamErrorCodeToString(error.internal_code()))
+            ? absl::StrCat("rx|", quic::QuicRstStreamErrorCodeToString(error.internal_code()))
             : absl::string_view());
   }
   return true;
@@ -361,7 +360,7 @@ void EnvoyQuicClientStream::OnStreamReset(const quic::QuicRstStreamFrame& frame)
     runResetCallbacks(
         quicRstErrorToEnvoyRemoteResetReason(frame.error_code),
         Runtime::runtimeFeatureEnabled("envoy.reloadable_features.report_stream_reset_error_code")
-            ? absl::StrCat("remote reset|", quic::QuicRstStreamErrorCodeToString(frame.error_code))
+            ? absl::StrCat("rx|", quic::QuicRstStreamErrorCodeToString(frame.error_code))
             : absl::string_view());
   }
 }
@@ -375,7 +374,7 @@ void EnvoyQuicClientStream::ResetWithError(quic::QuicResetStreamError error) {
   runResetCallbacks(
       quicRstErrorToEnvoyLocalResetReason(error.internal_code()),
       Runtime::runtimeFeatureEnabled("envoy.reloadable_features.report_stream_reset_error_code")
-          ? absl::StrCat("local reset", quic::QuicRstStreamErrorCodeToString(error.internal_code()))
+          ? absl::StrCat("tx|", quic::QuicRstStreamErrorCodeToString(error.internal_code()))
           : absl::string_view());
   if (session()->connection()->connected()) {
     quic::QuicSpdyClientStream::ResetWithError(error);

--- a/source/common/quic/envoy_quic_client_stream.cc
+++ b/source/common/quic/envoy_quic_client_stream.cc
@@ -258,7 +258,8 @@ bool EnvoyQuicClientStream::OnStopSending(quic::QuicResetStreamError error) {
     runResetCallbacks(
         quicRstErrorToEnvoyRemoteResetReason(error.internal_code()),
         Runtime::runtimeFeatureEnabled("envoy.reloadable_features.report_stream_reset_error_code")
-            ? quic::QuicRstStreamErrorCodeToString(error.internal_code())
+            ? absl::StrCat("remote reset|",
+                           quic::QuicRstStreamErrorCodeToString(error.internal_code()))
             : absl::string_view());
   }
   return true;
@@ -360,7 +361,7 @@ void EnvoyQuicClientStream::OnStreamReset(const quic::QuicRstStreamFrame& frame)
     runResetCallbacks(
         quicRstErrorToEnvoyRemoteResetReason(frame.error_code),
         Runtime::runtimeFeatureEnabled("envoy.reloadable_features.report_stream_reset_error_code")
-            ? quic::QuicRstStreamErrorCodeToString(frame.error_code)
+            ? absl::StrCat("remote reset|", quic::QuicRstStreamErrorCodeToString(frame.error_code))
             : absl::string_view());
   }
 }
@@ -374,7 +375,7 @@ void EnvoyQuicClientStream::ResetWithError(quic::QuicResetStreamError error) {
   runResetCallbacks(
       quicRstErrorToEnvoyLocalResetReason(error.internal_code()),
       Runtime::runtimeFeatureEnabled("envoy.reloadable_features.report_stream_reset_error_code")
-          ? quic::QuicRstStreamErrorCodeToString(error.internal_code())
+          ? absl::StrCat("local reset", quic::QuicRstStreamErrorCodeToString(error.internal_code()))
           : absl::string_view());
   if (session()->connection()->connected()) {
     quic::QuicSpdyClientStream::ResetWithError(error);

--- a/source/common/quic/envoy_quic_server_stream.cc
+++ b/source/common/quic/envoy_quic_server_stream.cc
@@ -340,8 +340,7 @@ bool EnvoyQuicServerStream::OnStopSending(quic::QuicResetStreamError error) {
     runResetCallbacks(
         quicRstErrorToEnvoyRemoteResetReason(error.internal_code()),
         Runtime::runtimeFeatureEnabled("envoy.reloadable_features.report_stream_reset_error_code")
-            ? absl::StrCat("remote reset|",
-                           quic::QuicRstStreamErrorCodeToString(error.internal_code()))
+            ? absl::StrCat("rx|", quic::QuicRstStreamErrorCodeToString(error.internal_code()))
             : absl::string_view());
   }
   return true;
@@ -361,7 +360,7 @@ void EnvoyQuicServerStream::OnStreamReset(const quic::QuicRstStreamFrame& frame)
     runResetCallbacks(
         quicRstErrorToEnvoyRemoteResetReason(frame.error_code),
         Runtime::runtimeFeatureEnabled("envoy.reloadable_features.report_stream_reset_error_code")
-            ? absl::StrCat("remote reset|", quic::QuicRstStreamErrorCodeToString(frame.error_code))
+            ? absl::StrCat("rx|", quic::QuicRstStreamErrorCodeToString(frame.error_code))
             : absl::string_view());
   }
 }
@@ -376,8 +375,7 @@ void EnvoyQuicServerStream::ResetWithError(quic::QuicResetStreamError error) {
     runResetCallbacks(
         quicRstErrorToEnvoyLocalResetReason(error.internal_code()),
         Runtime::runtimeFeatureEnabled("envoy.reloadable_features.report_stream_reset_error_code")
-            ? absl::StrCat("local reset|",
-                           quic::QuicRstStreamErrorCodeToString(error.internal_code()))
+            ? absl::StrCat("tx|", quic::QuicRstStreamErrorCodeToString(error.internal_code()))
             : absl::string_view());
   }
   quic::QuicSpdyServerStreamBase::ResetWithError(error);

--- a/source/common/quic/envoy_quic_server_stream.cc
+++ b/source/common/quic/envoy_quic_server_stream.cc
@@ -340,7 +340,8 @@ bool EnvoyQuicServerStream::OnStopSending(quic::QuicResetStreamError error) {
     runResetCallbacks(
         quicRstErrorToEnvoyRemoteResetReason(error.internal_code()),
         Runtime::runtimeFeatureEnabled("envoy.reloadable_features.report_stream_reset_error_code")
-            ? quic::QuicRstStreamErrorCodeToString(error.internal_code())
+            ? absl::StrCat("remote reset|",
+                           quic::QuicRstStreamErrorCodeToString(error.internal_code()))
             : absl::string_view());
   }
   return true;
@@ -360,7 +361,7 @@ void EnvoyQuicServerStream::OnStreamReset(const quic::QuicRstStreamFrame& frame)
     runResetCallbacks(
         quicRstErrorToEnvoyRemoteResetReason(frame.error_code),
         Runtime::runtimeFeatureEnabled("envoy.reloadable_features.report_stream_reset_error_code")
-            ? quic::QuicRstStreamErrorCodeToString(frame.error_code)
+            ? absl::StrCat("remote reset|", quic::QuicRstStreamErrorCodeToString(frame.error_code))
             : absl::string_view());
   }
 }
@@ -375,7 +376,8 @@ void EnvoyQuicServerStream::ResetWithError(quic::QuicResetStreamError error) {
     runResetCallbacks(
         quicRstErrorToEnvoyLocalResetReason(error.internal_code()),
         Runtime::runtimeFeatureEnabled("envoy.reloadable_features.report_stream_reset_error_code")
-            ? quic::QuicRstStreamErrorCodeToString(error.internal_code())
+            ? absl::StrCat("local reset|",
+                           quic::QuicRstStreamErrorCodeToString(error.internal_code()))
             : absl::string_view());
   }
   quic::QuicSpdyServerStreamBase::ResetWithError(error);

--- a/source/common/quic/envoy_quic_server_stream.cc
+++ b/source/common/quic/envoy_quic_server_stream.cc
@@ -340,7 +340,8 @@ bool EnvoyQuicServerStream::OnStopSending(quic::QuicResetStreamError error) {
     runResetCallbacks(
         quicRstErrorToEnvoyRemoteResetReason(error.internal_code()),
         Runtime::runtimeFeatureEnabled("envoy.reloadable_features.report_stream_reset_error_code")
-            ? absl::StrCat("rx|", quic::QuicRstStreamErrorCodeToString(error.internal_code()))
+            ? absl::StrCat(quic::QuicRstStreamErrorCodeToString(error.internal_code()),
+                           "|FROM_PEER")
             : absl::string_view());
   }
   return true;
@@ -360,7 +361,7 @@ void EnvoyQuicServerStream::OnStreamReset(const quic::QuicRstStreamFrame& frame)
     runResetCallbacks(
         quicRstErrorToEnvoyRemoteResetReason(frame.error_code),
         Runtime::runtimeFeatureEnabled("envoy.reloadable_features.report_stream_reset_error_code")
-            ? absl::StrCat("rx|", quic::QuicRstStreamErrorCodeToString(frame.error_code))
+            ? absl::StrCat(quic::QuicRstStreamErrorCodeToString(frame.error_code), "|FROM_PEER")
             : absl::string_view());
   }
 }
@@ -375,7 +376,8 @@ void EnvoyQuicServerStream::ResetWithError(quic::QuicResetStreamError error) {
     runResetCallbacks(
         quicRstErrorToEnvoyLocalResetReason(error.internal_code()),
         Runtime::runtimeFeatureEnabled("envoy.reloadable_features.report_stream_reset_error_code")
-            ? absl::StrCat("tx|", quic::QuicRstStreamErrorCodeToString(error.internal_code()))
+            ? absl::StrCat(quic::QuicRstStreamErrorCodeToString(error.internal_code()),
+                           "|FROM_SELF")
             : absl::string_view());
   }
   quic::QuicSpdyServerStreamBase::ResetWithError(error);

--- a/test/common/quic/envoy_quic_client_session_test.cc
+++ b/test/common/quic/envoy_quic_client_session_test.cc
@@ -676,8 +676,8 @@ TEST_P(EnvoyQuicClientSessionTest, WriteBlockedAndUnblock) {
   EnvoyQuicClientConnectionPeer::onFileEvent(*quic_connection_, Event::FileReadyType::Write,
                                              *quic_connection_->connectionSocket());
   EXPECT_FALSE(quic_connection_->writer()->IsWriteBlocked());
-  EXPECT_CALL(stream_callbacks,
-              onResetStream(Http::StreamResetReason::LocalReset, "QUIC_STREAM_REQUEST_REJECTED"));
+  EXPECT_CALL(stream_callbacks, onResetStream(Http::StreamResetReason::LocalReset,
+                                              "tx|QUIC_STREAM_REQUEST_REJECTED"));
   EXPECT_CALL(*quic_connection_, SendControlFrame(_));
   stream.resetStream(Http::StreamResetReason::LocalReset);
 }

--- a/test/common/quic/envoy_quic_client_session_test.cc
+++ b/test/common/quic/envoy_quic_client_session_test.cc
@@ -677,7 +677,7 @@ TEST_P(EnvoyQuicClientSessionTest, WriteBlockedAndUnblock) {
                                              *quic_connection_->connectionSocket());
   EXPECT_FALSE(quic_connection_->writer()->IsWriteBlocked());
   EXPECT_CALL(stream_callbacks, onResetStream(Http::StreamResetReason::LocalReset,
-                                              "tx|QUIC_STREAM_REQUEST_REJECTED"));
+                                              "QUIC_STREAM_REQUEST_REJECTED|FROM_SELF"));
   EXPECT_CALL(*quic_connection_, SendControlFrame(_));
   stream.resetStream(Http::StreamResetReason::LocalReset);
 }

--- a/test/integration/protocol_integration_test.cc
+++ b/test/integration/protocol_integration_test.cc
@@ -4934,10 +4934,10 @@ TEST_P(ProtocolIntegrationTest, InvalidResponseHeaderNameStreamError) {
   EXPECT_EQ("502", response->headers().getStatusValue());
   test_server_->waitForCounterGe("http.config_test.downstream_rq_5xx", 1);
 
-  std::string error_message =
-      upstreamProtocol() == Http::CodecType::HTTP3
-          ? "upstream_reset_before_response_started{protocol_error|QUIC_BAD_APPLICATION_PAYLOAD}"
-          : "upstream_reset_before_response_started{protocol_error}";
+  std::string error_message = upstreamProtocol() == Http::CodecType::HTTP3
+                                  ? "upstream_reset_before_response_started{protocol_error|QUIC_"
+                                    "BAD_APPLICATION_PAYLOAD|FROM_SELF}"
+                                  : "upstream_reset_before_response_started{protocol_error}";
 
   EXPECT_EQ(waitForAccessLog(access_log_name_), error_message);
   // Upstream connection should stay up


### PR DESCRIPTION
Commit Message: add `FROM_PEER`/`FROM_SELF` to the transport_failure_reason string when a QUIC stream gets reset.

Risk Level: low, error reporting format change
Testing: existing tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A

