### PR TITLE
mobile: Deflake BidirectionalStreamTest

### DIFF
--- a/mobile/test/java/org/chromium/net/BUILD
+++ b/mobile/test/java/org/chromium/net/BUILD
@@ -305,7 +305,7 @@ envoy_mobile_android_test(
     srcs = [
         "BidirectionalStreamTest.java",
     ],
-    flaky = True,  # TODO(fredyw): Debug the reason for it being flaky.
+    flaky = True,
     native_deps = [
         "//test/jni:libenvoy_jni_with_test_extensions.so",
     ] + select({

--- a/mobile/test/java/org/chromium/net/BidirectionalStreamTest.java
+++ b/mobile/test/java/org/chromium/net/BidirectionalStreamTest.java
@@ -78,9 +78,6 @@ public class BidirectionalStreamTest {
   @After
   public void tearDown() throws Exception {
     assertTrue(Http2TestServer.shutdownHttp2TestServer());
-    if (mCronetEngine != null) {
-      mCronetEngine.shutdown();
-    }
   }
 
   private static void checkResponseInfo(UrlResponseInfo responseInfo, String expectedUrl,


### PR DESCRIPTION
I still don't fully understand how removing the `shutdown` fixes the issue. Although it doesn't completely fix the flakiness but it reduces the flakiness by a lot.

Risk Level: low (tests only)
Testing: `bazel test --runs_per_test=100 //test/java/org/chromium/net:bidirectional_stream_test`
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a