### PR TITLE
gcc: add a `--host_linkopt` to use `gold` too

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -91,7 +91,7 @@ build:clang-pch --spawn_strategy=local
 build:clang-pch --define=ENVOY_CLANG_PCH=1
 
 # Use gold linker for gcc compiler.
-build:gcc --linkopt=-fuse-ld=gold
+build:gcc --linkopt=-fuse-ld=gold --host_linkopt=-fuse-ld=gold
 build:gcc --test_env=HEAPCHECK=
 build:gcc --action_env=BAZEL_COMPILER=gcc
 build:gcc --action_env=CC=gcc --action_env=CXX=g++


### PR DESCRIPTION
Without this, when building in the envoy docker without RBE, I see gcc trying to use `lld` instead, and it's (a) not in `$PATH` and (b) counter to what we had set in `--linkopt` for the gcc config.

Risk Level: low
Testing: local build in envoy docker
