### PR TITLE
xds: make certificate provider instance name required

### DIFF
--- a/api/envoy/extensions/transport_sockets/tls/v3/common.proto
+++ b/api/envoy/extensions/transport_sockets/tls/v3/common.proto
@@ -290,12 +290,12 @@ message TlsSessionTicketKeys {
 // respect to the TLS handshake.
 // [#not-implemented-hide:]
 message CertificateProviderPluginInstance {
-  // Provider instance name. If not present, defaults to "default".
+  // Provider instance name.
   //
   // Instance names should generally be defined not in terms of the underlying provider
   // implementation (e.g., "file_watcher") but rather in terms of the function of the
   // certificates (e.g., "foo_deployment_identity").
-  string instance_name = 1;
+  string instance_name = 1 [(validate.rules).message = {required: true}];
 
   // Opaque name used to specify certificate instances or types. For example, "ROOTCA" to specify
   // a root-certificate (validation context) or "example.com" to specify a certificate for a

--- a/api/envoy/extensions/transport_sockets/tls/v3/common.proto
+++ b/api/envoy/extensions/transport_sockets/tls/v3/common.proto
@@ -295,7 +295,7 @@ message CertificateProviderPluginInstance {
   // Instance names should generally be defined not in terms of the underlying provider
   // implementation (e.g., "file_watcher") but rather in terms of the function of the
   // certificates (e.g., "foo_deployment_identity").
-  string instance_name = 1 [(validate.rules).message = {required: true}];
+  string instance_name = 1 [(validate.rules).string = {min_len: 1}];
 
   // Opaque name used to specify certificate instances or types. For example, "ROOTCA" to specify
   // a root-certificate (validation context) or "example.com" to specify a certificate for a


### PR DESCRIPTION
Commit Message: xds: make certificate provider instance name required
Additional Description: The comment saying that there is a default value for this field is misleading.  All existing gRPC implementations have this as a required field.  Note that this change does not affect Envoy, since Envoy does not yet support this field.  However, I've added a PGV annotation (used by Envoy but not by gRPC) to avoid confusion when Envoy eventually adds support for this field.
Risk Level: Low
Testing: N/A
Docs Changes: Included in PR
Release Notes: N/A
Platform Specific Features: N/A
