### PR TITLE
stream info: add bool string serlalizer

### DIFF
--- a/source/common/stream_info/bool_accessor_impl.h
+++ b/source/common/stream_info/bool_accessor_impl.h
@@ -19,6 +19,10 @@ public:
     return message;
   }
 
+  absl::optional<std::string> serializeAsString() const override {
+    return value_ ? "true" : "false";
+  }
+
   // From BoolAccessor.
   bool value() const override { return value_; }
 

--- a/test/common/stream_info/bool_accessor_impl_test.cc
+++ b/test/common/stream_info/bool_accessor_impl_test.cc
@@ -22,6 +22,12 @@ TEST(BoolAccessorImplTest, TestProto) {
   EXPECT_NE(nullptr, message);
 }
 
+TEST(BoolAccessorImplTest, TestString) {
+  BoolAccessorImpl accessor(true);
+  auto str = accessor.serializeAsString();
+  EXPECT_EQ("true", str);
+}
+
 } // namespace
 } // namespace StreamInfo
 } // namespace Envoy


### PR DESCRIPTION
Change-Id: I2065f5ed863ca4b6b439f00dc39de0dcdbe2eb4c

Commit Message: add missing serializer for bool object. I discovered this gap while using Wasm `get_property`.
Risk Level: low
Testing: yes