### PR TITLE
gcc: remove -Wdangling-reference workaround

### DIFF
--- a/source/extensions/access_loggers/grpc/grpc_access_log_utils.cc
+++ b/source/extensions/access_loggers/grpc/grpc_access_log_utils.cc
@@ -275,14 +275,7 @@ void Utility::extractCommonAccessLogProperties(
   }
 
   if (stream_info.upstreamInfo().has_value()) {
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdangling-reference"
-#endif
     const auto& upstream_info = stream_info.upstreamInfo().value().get();
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic pop
-#endif
     if (upstream_info.upstreamHost() != nullptr) {
       Network::Utility::addressToProtobufAddress(
           *upstream_info.upstreamHost()->address(),

--- a/source/extensions/common/dubbo/hessian2_utils.h
+++ b/source/extensions/common/dubbo/hessian2_utils.h
@@ -5,15 +5,7 @@
 #include "envoy/buffer/buffer.h"
 
 #include "absl/strings/string_view.h"
-
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdangling-reference"
-#endif
 #include "hessian2/basic_codec/object_codec.hpp"
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic pop
-#endif
 #include "hessian2/codec.hpp"
 #include "hessian2/object.hpp"
 #include "hessian2/reader.hpp"

--- a/source/extensions/filters/network/dubbo_proxy/hessian_utils.h
+++ b/source/extensions/filters/network/dubbo_proxy/hessian_utils.h
@@ -5,16 +5,7 @@
 #include "envoy/buffer/buffer.h"
 
 #include "absl/strings/string_view.h"
-
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdangling-reference"
-#endif
 #include "hessian2/basic_codec/object_codec.hpp"
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic pop
-#endif
-
 #include "hessian2/codec.hpp"
 #include "hessian2/object.hpp"
 #include "hessian2/reader.hpp"

--- a/source/extensions/health_checkers/grpc/health_checker_impl.cc
+++ b/source/extensions/health_checkers/grpc/health_checker_impl.cc
@@ -196,15 +196,8 @@ void GrpcHealthCheckerImpl::GrpcActiveHealthCheckSession::onInterval() {
   request_encoder_ = &client_->newStream(*this);
   request_encoder_->getStream().addCallbacks(*this);
 
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdangling-reference"
-#endif
   const std::string& authority =
       getHostname(host_, parent_.authority_value_, parent_.cluster_.info());
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic pop
-#endif
   auto headers_message =
       Grpc::Common::prepareHeaders(authority, parent_.service_method_.service()->full_name(),
                                    parent_.service_method_.name(), absl::nullopt);

--- a/source/extensions/health_checkers/http/health_checker_impl.h
+++ b/source/extensions/health_checkers/http/health_checker_impl.h
@@ -141,14 +141,7 @@ private:
     Http::CodecClientPtr client_;
     Http::ResponseHeaderMapPtr response_headers_;
     Buffer::InstancePtr response_body_;
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdangling-reference"
-#endif
     const std::string& hostname_;
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic pop
-#endif
     Network::ConnectionInfoProviderSharedPtr local_connection_info_provider_;
     // Keep small members (bools and enums) at the end of class, to reduce alignment overhead.
     const Http::Protocol protocol_;

--- a/source/extensions/health_checkers/thrift/thrift.h
+++ b/source/extensions/health_checkers/thrift/thrift.h
@@ -57,14 +57,7 @@ private:
 
   private:
     ThriftHealthChecker& parent_;
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdangling-reference"
-#endif
     const std::string& hostname_;
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic pop
-#endif
     ClientPtr client_;
     bool expect_close_{};
   };


### PR DESCRIPTION
The false positive warnings have been resolved in current versions of gcc.

Risk Level: low
Testing: CI
