### PR TITLE
Make DownstreamTiming a struct, instead of a class

### DIFF
--- a/envoy/stream_info/stream_info.h
+++ b/envoy/stream_info/stream_info.h
@@ -354,8 +354,7 @@ struct UpstreamTiming {
   absl::optional<MonotonicTime> upstream_handshake_complete_;
 };
 
-class DownstreamTiming {
-public:
+struct DownstreamTiming {
   void setValue(absl::string_view key, MonotonicTime value) { timings_[key] = value; }
 
   absl::optional<MonotonicTime> getValue(absl::string_view value) const {
@@ -410,7 +409,6 @@ public:
     last_downstream_header_rx_byte_received_ = time_source.monotonicTime();
   }
 
-private:
   absl::flat_hash_map<std::string, MonotonicTime> timings_;
   // The time when the last byte of the request was received.
   absl::optional<MonotonicTime> last_downstream_rx_byte_received_;


### PR DESCRIPTION
Commit Message: Make DownstreamTiming a struct, instead of a class
Additional Description:This makes it consistent with UpstreamTiming, and makes it easier to dependency inject timing info for testing.
Risk Level: WCPGW
Testing: None
Docs Changes: None
Release Notes: None
Platform Specific Features: None
