### PR TITLE
mobile: fixing a flow control bug for multiple large uploads

### DIFF
--- a/mobile/library/common/http/client.h
+++ b/mobile/library/common/http/client.h
@@ -331,6 +331,7 @@ private:
     // Set true in explicit flow control mode if the library has sent body data and may want to
     // send more when buffer is available.
     bool wants_write_notification_{};
+    Event::SchedulableCallbackPtr scheduled_callback_;
     // True if the bridge should operate in explicit flow control mode.
     //
     // In this mode only one callback can be sent to the bridge until more is
@@ -383,7 +384,6 @@ private:
 
   ApiListenerPtr api_listener_;
   Event::ProvisionalDispatcher& dispatcher_;
-  Event::SchedulableCallbackPtr scheduled_callback_;
   HttpClientStats stats_;
   // The set of open streams, which can safely have request data sent on them
   // or response data received.

--- a/mobile/test/common/http/client_test.cc
+++ b/mobile/test/common/http/client_test.cc
@@ -498,6 +498,85 @@ TEST_P(ClientTest, MultipleStreams) {
   ASSERT_EQ(callbacks_called1.on_complete_calls_, 1);
 }
 
+TEST_P(ClientTest, MultipleUploads) {
+  envoy_stream_t stream1 = 1;
+  envoy_stream_t stream2 = 2;
+  auto request_data1 = std::make_unique<Buffer::OwnedImpl>("request body1");
+  auto request_data2 = std::make_unique<Buffer::OwnedImpl>("request body2");
+
+  // Create a stream, and set up request_decoder_ and response_encoder_
+  StreamCallbacksCalled callbacks_called1;
+  auto stream_callbacks1 = createDefaultStreamCallbacks(callbacks_called1);
+  createStream(std::move(stream_callbacks1));
+
+  // Send request headers.
+  EXPECT_CALL(*request_decoder_, decodeHeaders_(_, false));
+  http_client_.sendHeaders(stream1, createDefaultRequestHeaders(), false);
+  http_client_.sendData(stream1, std::move(request_data1), true);
+
+  // Start stream2.
+  // Setup EnvoyStreamCallbacks to handle the response headers.
+  NiceMock<MockRequestDecoder> request_decoder2;
+  ON_CALL(request_decoder2, streamInfo()).WillByDefault(ReturnRef(stream_info_));
+  ResponseEncoder* response_encoder2{};
+  StreamCallbacksCalled callbacks_called2;
+  auto stream_callbacks2 = createDefaultStreamCallbacks(callbacks_called1);
+  stream_callbacks2.on_headers_ = [&](const ResponseHeaderMap& headers, bool end_stream,
+                                      envoy_stream_intel) -> void {
+    EXPECT_TRUE(end_stream);
+    EXPECT_EQ(headers.Status()->value().getStringView(), "200");
+    callbacks_called2.on_headers_calls_ = true;
+  };
+  stream_callbacks2.on_complete_ = [&](envoy_stream_intel, envoy_final_stream_intel) -> void {
+    callbacks_called2.on_complete_calls_++;
+  };
+
+  std::vector<Event::SchedulableCallback*> window_callbacks;
+  ON_CALL(dispatcher_, createSchedulableCallback).WillByDefault([&](std::function<void()> cb) {
+    Event::SchedulableCallbackPtr scheduler =
+        dispatcher_.Event::ProvisionalDispatcher::createSchedulableCallback(cb);
+    window_callbacks.push_back(scheduler.get());
+    return scheduler;
+  });
+
+  // Create a stream.
+  ON_CALL(dispatcher_, isThreadSafe()).WillByDefault(Return(true));
+
+  // Grab the response encoder in order to dispatch responses on the stream.
+  // Return the request decoder to make sure calls are dispatched to the decoder via the dispatcher
+  // API.
+  EXPECT_CALL(*api_listener_, newStreamHandle(_, _))
+      .WillOnce(Invoke([&](ResponseEncoder& encoder, bool) -> RequestDecoderHandlePtr {
+        response_encoder2 = &encoder;
+        return std::make_unique<TestHandle>(request_decoder2);
+      }));
+  http_client_.startStream(stream2, std::move(stream_callbacks2), explicit_flow_control_);
+
+  // Send request headers.
+  EXPECT_CALL(request_decoder2, decodeHeaders_(_, false));
+  http_client_.sendHeaders(stream2, createDefaultRequestHeaders(), false);
+  http_client_.sendData(stream2, std::move(request_data2), true);
+
+  for (auto* callback : window_callbacks) {
+    EXPECT_TRUE(callback->enabled());
+  }
+
+  // Finish stream 2.
+  EXPECT_CALL(dispatcher_, deferredDelete_(_));
+  TestResponseHeaderMapImpl response_headers2{{":status", "200"}};
+  response_encoder2->encodeHeaders(response_headers2, true);
+  ASSERT_EQ(callbacks_called2.on_headers_calls_, 1);
+  // Ensure that the on_headers on the EnvoyStreamCallbacks was called.
+  ASSERT_EQ(callbacks_called2.on_complete_calls_, 1);
+
+  // Finish stream 1.
+  EXPECT_CALL(dispatcher_, deferredDelete_(_));
+  TestResponseHeaderMapImpl response_headers{{":status", "200"}};
+  response_encoder_->encodeHeaders(response_headers, true);
+  ASSERT_EQ(callbacks_called1.on_headers_calls_, 1);
+  ASSERT_EQ(callbacks_called1.on_complete_calls_, 1);
+}
+
 TEST_P(ClientTest, EnvoyLocalError) {
   // Override the on_error default with some custom checks.
   StreamCallbacksCalled callbacks_called;

--- a/mobile/test/java/integration/BUILD
+++ b/mobile/test/java/integration/BUILD
@@ -51,7 +51,6 @@ envoy_mobile_android_test(
     srcs = [
         "AndroidEngineExplicitFlowTest.java",
     ],
-    flaky = True,
     native_deps = [
         "//test/jni:libenvoy_jni_with_test_extensions.so",
     ] + select({


### PR DESCRIPTION
Fixing two bugs in the send window code.
One where the callback could be called late, after stream completion.  
One where the callback was per-client not per-stream so streams could overwrite each others upcalls.

Risk Level: low
Testing: first is tested by existing tests no longer flaking.  second TBTested
Docs Changes: n/a
Release Notes: n/a
Fixes https://github.com/envoyproxy/envoy/issues/36493