### PR TITLE
fips build: fixed an issue when tar is running as root

### DIFF
--- a/bazel/external/boringssl_fips.genrule_cmd
+++ b/bazel/external/boringssl_fips.genrule_cmd
@@ -44,7 +44,7 @@ fi
 
 curl -sLO https://github.com/llvm/llvm-project/releases/download/llvmorg-"$VERSION"/clang+llvm-"$VERSION"-"$PLATFORM".tar.xz
 echo "$SHA256" clang+llvm-"$VERSION"-"$PLATFORM".tar.xz | sha256sum --check
-tar xf clang+llvm-"$VERSION"-"$PLATFORM".tar.xz
+tar xf clang+llvm-"$VERSION"-"$PLATFORM".tar.xz --no-same-owner
 
 printf "set(CMAKE_C_COMPILER \"clang\")\nset(CMAKE_CXX_COMPILER \"clang++\")\n" > ${HOME}/toolchain
 export PATH="$PWD/clang+llvm-$VERSION-$PLATFORM/bin:$PATH"
@@ -66,7 +66,7 @@ fi
 
 curl -sLO https://dl.google.com/go/go"$VERSION"."$PLATFORM".tar.gz \
   && echo "$SHA256" go"$VERSION"."$PLATFORM".tar.gz | sha256sum --check
-tar xf go"$VERSION"."$PLATFORM".tar.gz
+tar xf go"$VERSION"."$PLATFORM".tar.gz --no-same-owner
 
 export GOPATH="$PWD/gopath"
 export GOROOT="$PWD/go"
@@ -82,7 +82,7 @@ VERSION=1.10.2
 SHA256=ce35865411f0490368a8fc383f29071de6690cbadc27704734978221f25e2bed
 curl -sLO https://github.com/ninja-build/ninja/archive/refs/tags/v"$VERSION".tar.gz \
   && echo "$SHA256" v"$VERSION".tar.gz | sha256sum --check
-tar -xvf v"$VERSION".tar.gz
+tar -xvf v"$VERSION".tar.gz --no-same-owner
 cd ninja-"$VERSION"
 python3 ./configure.py --bootstrap
 
@@ -106,7 +106,7 @@ fi
 
 curl -sLO https://github.com/Kitware/CMake/releases/download/v"$VERSION"/cmake-"$VERSION"-"$PLATFORM".tar.gz \
   && echo "$SHA256" cmake-"$VERSION"-"$PLATFORM".tar.gz | sha256sum --check
-tar xf cmake-"$VERSION"-"$PLATFORM".tar.gz
+tar xf cmake-"$VERSION"-"$PLATFORM".tar.gz --no-same-owner
 
 export PATH="$PWD/cmake-$VERSION-$PLATFORM/bin:$PATH"
 


### PR DESCRIPTION
fips build: fixed an issue when tar is running as root causing 'Cannot change ownership to uid 1000, gid 1000: Invalid argument' error

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: fips build: fixed an issue when tar is running as root causing 'Cannot change ownership to uid 1000, gid 1000: Invalid argument' error

Additional Description: See this thread for issue and solution: https://superuser.com/questions/1435437/how-to-get-around-this-error-when-untarring-an-archive-tar-cannot-change-owner
Risk Level: Low
Testing: Was tested with our internal build pipeline (buildkite)
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: Build
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
