### PR TITLE
Disable bazel's layering_check feature during CodeQL build.

### DIFF
--- a/.github/workflows/codeql-daily.yml
+++ b/.github/workflows/codeql-daily.yml
@@ -64,6 +64,7 @@ jobs:
            --spawn_strategy=local \
            --discard_analysis_cache \
            --nouse_action_cache \
+           --features="-layering_check" \
            --config=clang-libc++ \
            --config=ci \
            //source/common/http/...

--- a/.github/workflows/codeql-push.yml
+++ b/.github/workflows/codeql-push.yml
@@ -96,6 +96,7 @@ jobs:
            --spawn_strategy=local \
            --discard_analysis_cache \
            --nouse_action_cache \
+           --features="-layering_check" \
            --config=clang-libc++ \
            --config=ci \
            $BUILD_TARGETS


### PR DESCRIPTION
It doesn't work without sandboxing, and this build uses `--spawn_strategy=local`.

https://github.com/bazelbuild/bazel/issues/21592

Once we upgrade to a bazel 7.3.0+, this should no longer be needed.

Risk Level: Low; only affects CI CodeQL build
