### PR TITLE
[mobile]expose onNetworkTypeChanged API to Engine

### DIFF
--- a/mobile/library/cc/engine.cc
+++ b/mobile/library/cc/engine.cc
@@ -1,5 +1,6 @@
 #include "engine.h"
 
+#include "library/common/engine_types.h"
 #include "library/common/internal_engine.h"
 #include "library/common/types/c_types.h"
 
@@ -25,6 +26,10 @@ StreamClientSharedPtr Engine::streamClient() {
 std::string Engine::dumpStats() { return engine_->dumpStats(); }
 
 envoy_status_t Engine::terminate() { return engine_->terminate(); }
+
+void Engine::onDefaultNetworkChanged(NetworkType network) {
+  engine_->onDefaultNetworkChanged(network);
+}
 
 } // namespace Platform
 } // namespace Envoy

--- a/mobile/library/cc/engine.h
+++ b/mobile/library/cc/engine.h
@@ -3,6 +3,7 @@
 #include <functional>
 
 #include "library/cc/stream_client.h"
+#include "library/common/engine_types.h"
 #include "library/common/types/c_types.h"
 
 namespace Envoy {
@@ -20,6 +21,7 @@ public:
 
   std::string dumpStats();
   StreamClientSharedPtr streamClient();
+  void onDefaultNetworkChanged(NetworkType network);
 
   envoy_status_t terminate();
   Envoy::InternalEngine* engine() { return engine_; }


### PR DESCRIPTION
Commit Message: expose onNetworkTypeChanged API to Engine
Additional Description: This prevents applications from directly depending on InternalEngine.
Risk Level: low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: mobile only
