### PR TITLE
ext_proc: skip timeout timer on trailer in async mode.

### DIFF
--- a/source/extensions/filters/http/ext_proc/ext_proc.cc
+++ b/source/extensions/filters/http/ext_proc/ext_proc.cc
@@ -978,9 +978,16 @@ void Filter::sendTrailers(ProcessorState& state, const Http::HeaderMap& trailers
   auto* trailers_req = state.mutableTrailers(req);
   MutationUtils::headersToProto(trailers, config_->allowedHeaders(), config_->disallowedHeaders(),
                                 *trailers_req->mutable_trailers());
-  state.onStartProcessorCall(std::bind(&Filter::onMessageTimeout, this), config_->messageTimeout(),
-                             ProcessorState::CallbackState::TrailersCallback);
-  ENVOY_LOG(debug, "Sending trailers message");
+
+  if (observability_mode) {
+    ENVOY_LOG(debug, "Sending trailers message in observability mode");
+  } else {
+    state.onStartProcessorCall(std::bind(&Filter::onMessageTimeout, this),
+                               config_->messageTimeout(),
+                               ProcessorState::CallbackState::TrailersCallback);
+    ENVOY_LOG(debug, "Sending trailers message");
+  }
+
   sendRequest(std::move(req), false);
   stats_.stream_msgs_sent_.inc();
 }

--- a/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
+++ b/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
@@ -4334,6 +4334,25 @@ TEST_P(ExtProcIntegrationTest, ObservabilityModeWithFullResponse) {
   timeSystem().advanceTimeWaitImpl(std::chrono::milliseconds(deferred_close_timeout_ms));
 }
 
+TEST_P(ExtProcIntegrationTest, ObservabilityModeWithFullRequestNoSidestreamResponse) {
+  proto_config_.set_observability_mode(true);
+  uint32_t deferred_close_timeout_ms = 1000;
+  proto_config_.mutable_deferred_close_timeout()->set_seconds(deferred_close_timeout_ms / 1000);
+
+  proto_config_.mutable_processing_mode()->set_request_body_mode(ProcessingMode::STREAMED);
+  proto_config_.mutable_processing_mode()->set_request_trailer_mode(ProcessingMode::SEND);
+  proto_config_.mutable_processing_mode()->set_response_header_mode(ProcessingMode::SKIP);
+
+  initializeConfig();
+  HttpIntegrationTest::initialize();
+  auto response = sendDownstreamRequestWithBodyAndTrailer("Hello");
+
+  handleUpstreamRequest();
+  verifyDownstreamResponse(*response, 200);
+
+  timeSystem().advanceTimeWaitImpl(std::chrono::milliseconds(deferred_close_timeout_ms));
+}
+
 TEST_P(ExtProcIntegrationTest, ObservabilityModeWithLogging) {
   proto_config_.set_observability_mode(true);
 

--- a/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
+++ b/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
@@ -4353,14 +4353,13 @@ TEST_P(ExtProcIntegrationTest, ObservabilityModeWithFullRequestAndTimeout) {
                                  timeSystem().advanceTimeWaitImpl(400ms);
                                  return false;
                                });
-  processRequestBodyMessage(*grpc_upstreams_[0], false,
-                            [this](const HttpBody& body, BodyResponse&) {
-                              // Advance 400 ms. Default timeout is 200ms
-                              timeSystem().advanceTimeWaitImpl(400ms);
-                              return false;
-                            });
+  processRequestBodyMessage(*grpc_upstreams_[0], false, [this](const HttpBody&, BodyResponse&) {
+    // Advance 400 ms. Default timeout is 200ms
+    timeSystem().advanceTimeWaitImpl(400ms);
+    return false;
+  });
   processRequestTrailersMessage(*grpc_upstreams_[0], false,
-                                [this](const HttpTrailers& trailers, TrailersResponse&) {
+                                [this](const HttpTrailers&, TrailersResponse&) {
                                   // Advance 400 ms. Default timeout is 200ms
                                   timeSystem().advanceTimeWaitImpl(400ms);
                                   return false;


### PR DESCRIPTION
Commit Message: Like header and body, timer/timeout should be skipped on trailer as well in async. It is because there is no response/ or response is ignored.
Risk Level: Low
Testing: Integration test (test the timeout on header, body and trailer)
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
