### PR TITLE
odcds: resolve subscription issue when managing multiple upstream endpoints

### DIFF
--- a/source/common/upstream/od_cds_api_impl.cc
+++ b/source/common/upstream/od_cds_api_impl.cc
@@ -89,7 +89,7 @@ void OdCdsApiImpl::sendAwaiting() {
   // used any more.
   ENVOY_LOG(debug, "odcds: sending request for awaiting cluster names {}",
             fmt::join(awaiting_names_, ", "));
-  subscription_->requestOnDemandUpdate(awaiting_names_);
+  subscription_->updateResourceInterest(awaiting_names_);
   awaiting_names_.clear();
 }
 
@@ -108,7 +108,7 @@ void OdCdsApiImpl::updateOnDemand(std::string cluster_name) {
 
   case StartStatus::InitialFetchDone:
     ENVOY_LOG(trace, "odcds: requesting for cluster name {}", cluster_name);
-    subscription_->requestOnDemandUpdate({std::move(cluster_name)});
+    subscription_->updateResourceInterest({std::move(cluster_name)});
     return;
   }
   PANIC("corrupt enum");

--- a/test/common/upstream/od_cds_api_impl_test.cc
+++ b/test/common/upstream/od_cds_api_impl_test.cc
@@ -51,7 +51,7 @@ TEST_F(OdCdsApiImplTest, FollowingClusterNamesHitAwaitingList) {
   InSequence s;
 
   EXPECT_CALL(*cm_.subscription_factory_.subscription_, start(ElementsAre("fake_cluster")));
-  EXPECT_CALL(*cm_.subscription_factory_.subscription_, requestOnDemandUpdate(_)).Times(0);
+  EXPECT_CALL(*cm_.subscription_factory_.subscription_, updateResourceInterest(_)).Times(0);
   odcds_->updateOnDemand("fake_cluster");
   odcds_->updateOnDemand("another_cluster");
 }
@@ -70,7 +70,7 @@ TEST_F(OdCdsApiImplTest, AwaitingListIsProcessedOnConfigUpdate) {
   const auto decoded_resources = TestUtility::decodeResources({cluster});
   EXPECT_CALL(
       *cm_.subscription_factory_.subscription_,
-      requestOnDemandUpdate(UnorderedElementsAre("another_cluster_1", "another_cluster_2")));
+      updateResourceInterest(UnorderedElementsAre("another_cluster_1", "another_cluster_2")));
   ASSERT_TRUE(odcds_callbacks_->onConfigUpdate(decoded_resources.refvec_, {}, "0").ok());
 }
 
@@ -85,7 +85,7 @@ TEST_F(OdCdsApiImplTest, AwaitingListIsProcessedOnConfigUpdateFailed) {
 
   EXPECT_CALL(
       *cm_.subscription_factory_.subscription_,
-      requestOnDemandUpdate(UnorderedElementsAre("another_cluster_1", "another_cluster_2")));
+      updateResourceInterest(UnorderedElementsAre("another_cluster_1", "another_cluster_2")));
   odcds_callbacks_->onConfigUpdateFailed(Envoy::Config::ConfigUpdateFailureReason::FetchTimedout,
                                          nullptr);
 }
@@ -101,7 +101,7 @@ TEST_F(OdCdsApiImplTest, AwaitingListIsProcessedOnceOnly) {
 
   EXPECT_CALL(
       *cm_.subscription_factory_.subscription_,
-      requestOnDemandUpdate(UnorderedElementsAre("another_cluster_1", "another_cluster_2")));
+      updateResourceInterest(UnorderedElementsAre("another_cluster_1", "another_cluster_2")));
   odcds_callbacks_->onConfigUpdateFailed(Envoy::Config::ConfigUpdateFailureReason::FetchTimedout,
                                          nullptr);
   odcds_callbacks_->onConfigUpdateFailed(Envoy::Config::ConfigUpdateFailureReason::FetchTimedout,
@@ -114,7 +114,7 @@ TEST_F(OdCdsApiImplTest, NothingIsRequestedOnEmptyAwaitingList) {
 
   odcds_->updateOnDemand("fake_cluster");
 
-  EXPECT_CALL(*cm_.subscription_factory_.subscription_, requestOnDemandUpdate(_)).Times(0);
+  EXPECT_CALL(*cm_.subscription_factory_.subscription_, updateResourceInterest(_)).Times(0);
   odcds_callbacks_->onConfigUpdateFailed(Envoy::Config::ConfigUpdateFailureReason::FetchTimedout,
                                          nullptr);
 }
@@ -130,7 +130,7 @@ TEST_F(OdCdsApiImplTest, OnDemandUpdateIsRequestedAfterInitialFetch) {
   const auto decoded_resources = TestUtility::decodeResources({cluster});
   ASSERT_TRUE(odcds_callbacks_->onConfigUpdate(decoded_resources.refvec_, {}, "0").ok());
   EXPECT_CALL(*cm_.subscription_factory_.subscription_,
-              requestOnDemandUpdate(UnorderedElementsAre("another_cluster")));
+              updateResourceInterest(UnorderedElementsAre("another_cluster")));
   odcds_->updateOnDemand("another_cluster");
 }
 


### PR DESCRIPTION
**Commit Message:**
When using on-demand VHDS and CDS with multiple upstream endpoints, only the first endpoint functions correctly. This PR resolves that issue.

**Additional Description:**
The first request from an upstream endpoint triggers the on-demand xDS flow (VHDS → CDS → EDS), subscribing to the required resources. However, when multiple upstream endpoints are present, only the first one works as expected. For subsequent endpoints, EDS is not triggered, preventing the retrieval of the clusterLoadAssignment resource for those clusters. 
Please refer to this for more detail: [ODCDS is unable to work with EDS when handling multiple upstream endpoints](https://github.com/envoyproxy/envoy/issues/36373)

**Risk Level:**
Low

**Testing:**
Unit tests

**Docs Changes:**
No need

**Release Notes:**
No need

**Platform Specific Features:**
No

