### PR TITLE
tcp_proxy_protocol: reduce stats contention by moving the stats to factory

### DIFF
--- a/source/extensions/transport_sockets/proxy_protocol/proxy_protocol.h
+++ b/source/extensions/transport_sockets/proxy_protocol/proxy_protocol.h
@@ -49,7 +49,7 @@ private:
   Network::TransportSocketCallbacks* callbacks_{};
   Buffer::OwnedImpl header_buffer_{};
   ProxyProtocolConfig_Version version_{ProxyProtocolConfig_Version::ProxyProtocolConfig_Version_V1};
-  UpstreamProxyProtocolStats stats_;
+  UpstreamProxyProtocolStats& stats_;
   const bool pass_all_tlvs_;
   absl::flat_hash_set<uint8_t> pass_through_tlvs_{};
 };
@@ -69,7 +69,8 @@ public:
 
 private:
   ProxyProtocolConfig config_;
-  Stats::Scope& scope_;
+  const std::string stats_prefix_;
+  UpstreamProxyProtocolStats stats_;
 };
 
 } // namespace ProxyProtocol


### PR DESCRIPTION

Commit Message: reduce data plane stats contention by moving the stats to the factory
Additional Description:
Risk Level: low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
