### PR TITLE
Add a custom header to allow forcing early data

### DIFF
--- a/envoy/http/header_map.h
+++ b/envoy/http/header_map.h
@@ -178,6 +178,7 @@ private:
  */
 #define INLINE_REQ_STRING_HEADERS(HEADER_FUNC)                                                     \
   HEADER_FUNC(ClientTraceId)                                                                       \
+  HEADER_FUNC(EnvoyAllowEarlyData)                                                                 \
   HEADER_FUNC(EnvoyDownstreamServiceCluster)                                                       \
   HEADER_FUNC(EnvoyDownstreamServiceNode)                                                          \
   HEADER_FUNC(EnvoyExternalAddress)                                                                \

--- a/mobile/library/common/http/client.cc
+++ b/mobile/library/common/http/client.cc
@@ -602,6 +602,7 @@ void Client::sendHeaders(envoy_stream_t stream, RequestHeaderMapPtr headers, boo
     // https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/router_filter#x-envoy-retry-on
     headers->addCopy(Headers::get().EnvoyRetryOn,
                      Headers::get().EnvoyRetryOnValues.Http3PostConnectFailure);
+    headers->addCopy(Headers::get.EnvoyAllowEarlyData, "true")
   }
   ENVOY_LOG(debug, "[S{}] request headers for stream (end_stream={}):\n{}", stream, end_stream,
             *headers);

--- a/source/common/http/headers.h
+++ b/source/common/http/headers.h
@@ -150,6 +150,9 @@ public:
   const LowerCaseString ContentType{"content-type"};
   const LowerCaseString Cookie{"cookie"};
   const LowerCaseString Date{"date"};
+  // This is different from `early-data` which is sent on the wire. This custom header
+  // is designed be force requests to allow early data in Envoy.
+  const LowerCaseString EnvoyAllowEarlyData{absl::StrCat(prefix(), "-allow-early-data")};
   const LowerCaseString EnvoyAttemptCount{absl::StrCat(prefix(), "-attempt-count")};
   const LowerCaseString EnvoyCluster{absl::StrCat(prefix(), "-cluster")};
   const LowerCaseString EnvoyDegraded{absl::StrCat(prefix(), "-degraded")};

--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -1458,6 +1458,10 @@ Utility::convertCoreToRouteRetryPolicy(const envoy::config::core::v3::RetryPolic
 
 bool Utility::isSafeRequest(const Http::RequestHeaderMap& request_headers) {
   absl::string_view method = request_headers.getMethodValue();
+  auto result = request_headers.get(Headers::get().EnvoyAllowEarlyData);
+  if (!result.empty() && result[0]->value() == "true") {
+    return true;
+  }
   return method == Http::Headers::get().MethodValues.Get ||
          method == Http::Headers::get().MethodValues.Head ||
          method == Http::Headers::get().MethodValues.Options ||

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -761,6 +761,9 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers,
   const bool can_send_early_data =
       route_entry_->earlyDataPolicy().allowsEarlyDataForRequest(*downstream_headers_);
 
+  // Consume the envoy-allow-early-data header so it doesn't get onto the wire.
+  downstream_headers_->removeEnvoyAllowEarlyData();
+
   include_timeout_retry_header_in_request_ = route_->virtualHost().includeIsTimeoutRetryHeader();
 
   // Set initial HTTP/3 use based on the presence of HTTP/1.1 proxy config.


### PR DESCRIPTION
Commit Message: Add a custom header to allow forcing early data
Additional Description: This is used by mobile when a request is marked idempotent.
Risk Level: Low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
