### PR TITLE
lua: mention that body should be consumed before fetching trailers

### DIFF
--- a/docs/root/configuration/http/http_filters/lua_filter.rst
+++ b/docs/root/configuration/http/http_filters/lua_filter.rst
@@ -365,8 +365,10 @@ trailers()
 
   local trailers = handle:trailers()
 
-Returns the stream's trailers. May return nil if there are no trailers. The trailers may be
-modified before they are sent to the next filter.
+Returns the stream's trailers. Before calling this method, the caller should call ``body()`` or
+``bodyChunks()`` to consume the body, otherwise the trailers will not be available.
+May return nil if there are no trailers. The trailers may be modified before they are sent
+to the next filter.
 
 Returns a :ref:`header object <config_http_filters_lua_header_wrapper>`.
 


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: lua: mention that body should be consumed before fetching trailers
Additional Description:
Risk Level: Zero
Testing: N/A
Docs Changes: lua_filter.rst
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
Fixes https://github.com/envoyproxy/envoy/issues/36507
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
