### PR TITLE
fix fuzz test failure

### DIFF
--- a/test/extensions/filters/http/ext_authz/ext_authz_fuzz_lib.cc
+++ b/test/extensions/filters/http/ext_authz/ext_authz_fuzz_lib.cc
@@ -37,6 +37,9 @@ ReusableFilterFactory::newFilter(FilterConfigSharedPtr config,
                                  const envoy::config::core::v3::Metadata& metadata) {
   decoding_buffer_ = std::make_unique<Buffer::OwnedImpl>();
   metadata_ = metadata;
+  decoder_callbacks_.stream_info_.filter_state_ =
+      std::make_shared<StreamInfo::FilterStateImpl>(StreamInfo::FilterState::LifeSpan::FilterChain);
+
   std::unique_ptr<Filter> filter = std::make_unique<Filter>(std::move(config), std::move(client));
   filter->setDecoderFilterCallbacks(decoder_callbacks_);
   filter->setEncoderFilterCallbacks(encoder_callbacks_);

--- a/test/extensions/filters/http/ext_authz/ext_authz_grpc_corpus/emit_filter_state_stats
+++ b/test/extensions/filters/http/ext_authz/ext_authz_grpc_corpus/emit_filter_state_stats
@@ -1,0 +1,9 @@
+base {
+  config {
+    stat_prefix: "#"
+    failure_mode_allow_header_add: true
+    emit_filter_state_stats: true
+  }
+  request_data {
+  }
+}


### PR DESCRIPTION

Commit Message: fix fuzz test failure
Additional Description:

the fuzzer reuses the filter state between test cases currently which causes a fuzz bug. This PR makes it so that it resets the filter state every time a new filter is created.

Risk Level: low
Testing: test-only change
Docs Changes: none
Release Notes: none
Platform Specific Features: none