### PR TITLE
wasm: remove redundant xds attributes

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -2,6 +2,9 @@ date: Pending
 
 behavior_changes:
 # *Changes that are expected to cause an incompatibility if applicable; deployment changes are likely required*
+- area: wasm
+  change: |
+    Remove previously deprecated xDS attributes from ``get_property``, use ``xds`` attributes instead.
 
 minor_behavior_changes:
 # *Changes that may cause incompatibilities for some users, but should not for most*

--- a/docs/root/intro/arch_overview/advanced/attributes.rst
+++ b/docs/root/intro/arch_overview/advanced/attributes.rst
@@ -211,14 +211,6 @@ In addition to all above, the following extra attributes are available to Wasm e
    plugin_name, string, Plugin name
    plugin_root_id, string, Plugin root ID
    plugin_vm_id, string, Plugin VM ID
-   node, :ref:`Node<envoy_v3_api_msg_config.core.v3.node>`, Local node description. DEPRECATED: please use `xds` attributes.
-   cluster_name, string, Upstream cluster name. DEPRECATED: please use `xds` attributes.
-   cluster_metadata, :ref:`Metadata<envoy_v3_api_msg_config.core.v3.metadata>`, Upstream cluster metadata. DEPRECATED: please use `xds` attributes.
-   listener_direction, int, Enumeration value of the :ref:`listener traffic direction<envoy_v3_api_field_config.listener.v3.Listener.traffic_direction>`. DEPRECATED: please use `xds` attributes.
-   listener_metadata, :ref:`Metadata<envoy_v3_api_msg_config.core.v3.metadata>`, Listener metadata. DEPRECATED: please use `xds` attributes.
-   route_name, string, Route name. DEPRECATED: please use `xds` attributes.
-   route_metadata, :ref:`Metadata<envoy_v3_api_msg_config.core.v3.metadata>`, Route metadata. DEPRECATED: please use `xds` attributes.
-   upstream_host_metadata, :ref:`Metadata<envoy_v3_api_msg_config.core.v3.metadata>`, Upstream host metadata. DEPRECATED: please use `xds` attributes.
 
 Path expressions
 ----------------

--- a/source/extensions/common/wasm/context.cc
+++ b/source/extensions/common/wasm/context.cc
@@ -100,13 +100,6 @@ Http::RequestHeaderMapPtr buildRequestHeaderMapFromPairs(const Pairs& pairs) {
 
 template <typename P> static uint32_t headerSize(const P& p) { return p ? p->size() : 0; }
 
-Upstream::HostDescriptionConstSharedPtr getHost(const StreamInfo::StreamInfo* info) {
-  if (info && info->upstreamInfo() && info->upstreamInfo().value().get().upstreamHost()) {
-    return info->upstreamInfo().value().get().upstreamHost();
-  }
-  return nullptr;
-}
-
 } // namespace
 
 // Test support.
@@ -435,10 +428,7 @@ WasmResult serializeValue(Filters::Common::Expr::CelValue value, std::string* re
   return WasmResult::SerializationFailure;
 }
 
-#define PROPERTY_TOKENS(_f)                                                                        \
-  _f(NODE) _f(LISTENER_DIRECTION) _f(LISTENER_METADATA) _f(CLUSTER_NAME) _f(CLUSTER_METADATA)      \
-      _f(ROUTE_NAME) _f(ROUTE_METADATA) _f(PLUGIN_NAME) _f(UPSTREAM_HOST_METADATA)                 \
-          _f(PLUGIN_ROOT_ID) _f(PLUGIN_VM_ID) _f(CONNECTION_ID)
+#define PROPERTY_TOKENS(_f) _f(PLUGIN_NAME) _f(PLUGIN_ROOT_ID) _f(PLUGIN_VM_ID) _f(CONNECTION_ID)
 
 static inline std::string downCase(std::string s) {
   std::transform(s.begin(), s.end(), s.begin(), [](unsigned char c) { return std::tolower(c); });
@@ -513,57 +503,6 @@ Context::findValue(absl::string_view name, Protobuf::Arena* arena, bool last) co
     }
     break;
   }
-  case PropertyToken::NODE:
-    if (root_local_info_) {
-      return CelProtoWrapper::CreateMessage(&root_local_info_->node(), arena);
-    } else if (plugin_) {
-      return CelProtoWrapper::CreateMessage(&plugin()->localInfo().node(), arena);
-    }
-    break;
-  case PropertyToken::LISTENER_DIRECTION:
-    if (plugin_) {
-      return CelValue::CreateInt64(plugin()->direction());
-    }
-    break;
-  case PropertyToken::LISTENER_METADATA:
-    if (plugin_) {
-      return CelProtoWrapper::CreateMessage(plugin()->listenerMetadata(), arena);
-    }
-    break;
-  case PropertyToken::CLUSTER_NAME:
-    if (getHost(info)) {
-      return CelValue::CreateString(&getHost(info)->cluster().name());
-    } else if (info && info->route() && info->route()->routeEntry()) {
-      return CelValue::CreateString(&info->route()->routeEntry()->clusterName());
-    } else if (info && info->upstreamClusterInfo().has_value() &&
-               info->upstreamClusterInfo().value()) {
-      return CelValue::CreateString(&info->upstreamClusterInfo().value()->name());
-    }
-    break;
-  case PropertyToken::CLUSTER_METADATA:
-    if (getHost(info)) {
-      return CelProtoWrapper::CreateMessage(&getHost(info)->cluster().metadata(), arena);
-    } else if (info && info->upstreamClusterInfo().has_value() &&
-               info->upstreamClusterInfo().value()) {
-      return CelProtoWrapper::CreateMessage(&info->upstreamClusterInfo().value()->metadata(),
-                                            arena);
-    }
-    break;
-  case PropertyToken::UPSTREAM_HOST_METADATA:
-    if (getHost(info)) {
-      return CelProtoWrapper::CreateMessage(getHost(info)->metadata().get(), arena);
-    }
-    break;
-  case PropertyToken::ROUTE_NAME:
-    if (info) {
-      return CelValue::CreateString(&info->getRouteName());
-    }
-    break;
-  case PropertyToken::ROUTE_METADATA:
-    if (info && info->route()) {
-      return CelProtoWrapper::CreateMessage(&info->route()->metadata(), arena);
-    }
-    break;
   case PropertyToken::PLUGIN_NAME:
     if (plugin_) {
       return CelValue::CreateStringView(plugin()->name_);

--- a/source/extensions/common/wasm/remote_async_datasource.cc
+++ b/source/extensions/common/wasm/remote_async_datasource.cc
@@ -13,12 +13,6 @@ static constexpr uint32_t RetryInitialDelayMilliseconds = 1000;
 static constexpr uint32_t RetryMaxDelayMilliseconds = 10 * 1000;
 static constexpr uint32_t RetryCount = 1;
 
-absl::optional<std::string> getPath(const envoy::config::core::v3::DataSource& source) {
-  return source.specifier_case() == envoy::config::core::v3::DataSource::SpecifierCase::kFilename
-             ? absl::make_optional(source.filename())
-             : absl::nullopt;
-}
-
 RemoteAsyncDataProvider::RemoteAsyncDataProvider(
     Upstream::ClusterManager& cm, Init::Manager& manager,
     const envoy::config::core::v3::RemoteDataSource& source, Event::Dispatcher& dispatcher,

--- a/test/extensions/filters/http/wasm/test_data/metadata_rust.rs
+++ b/test/extensions/filters/http/wasm/test_data/metadata_rust.rs
@@ -59,7 +59,7 @@ impl HttpContext for TestStream {
     }
 
     fn on_http_request_body(&mut self, _: usize, _: bool) -> Action {
-        if let Some(value) = self.get_property(vec!["node", "metadata", "wasm_node_get_key"]) {
+        if let Some(value) = self.get_property(vec!["xds", "node", "metadata", "wasm_node_get_key"]) {
             error!("onBody {}", String::from_utf8(value).unwrap());
         } else {
             debug!("missing node metadata");

--- a/test/extensions/filters/http/wasm/wasm_filter_test.cc
+++ b/test/extensions/filters/http/wasm/wasm_filter_test.cc
@@ -1835,8 +1835,6 @@ TEST_P(WasmHttpFilterTest, ClusterMetadata) {
   }
   setupTest("", "cluster_metadata");
   setupFilter();
-  EXPECT_CALL(filter(),
-              log_(spdlog::level::warn, Eq(absl::string_view("cluster metadata: cluster"))));
   auto cluster = std::make_shared<NiceMock<Upstream::MockClusterInfo>>();
   auto cluster_metadata = std::make_shared<envoy::config::core::v3::Metadata>(
       TestUtility::parseYaml<envoy::config::core::v3::Metadata>(
@@ -1852,14 +1850,8 @@ TEST_P(WasmHttpFilterTest, ClusterMetadata) {
 
   EXPECT_CALL(encoder_callbacks_, streamInfo()).WillRepeatedly(ReturnRef(request_stream_info_));
   EXPECT_CALL(*cluster, metadata()).WillRepeatedly(ReturnRef(*cluster_metadata));
-  EXPECT_CALL(*host_description, cluster()).WillRepeatedly(ReturnRef(*cluster));
-  request_stream_info_.upstreamInfo()->setUpstreamHost(host_description);
   EXPECT_CALL(request_stream_info_, requestComplete)
       .WillRepeatedly(Return(std::chrono::milliseconds(30)));
-  filter().log({&request_headers}, request_stream_info_);
-
-  // If upstream host is empty, fallback to upstream cluster info for cluster metadata.
-  request_stream_info_.upstreamInfo()->setUpstreamHost(nullptr);
   EXPECT_CALL(request_stream_info_, upstreamClusterInfo()).WillRepeatedly(Return(cluster));
   EXPECT_CALL(filter(),
               log_(spdlog::level::warn, Eq(absl::string_view("cluster metadata: cluster"))));


### PR DESCRIPTION
Change-Id: I152e259f3f8e5f69463a64fedce4181ce606824b

Commit Message: Remove attributes that were marked as deprecated in https://github.com/envoyproxy/envoy/commit/ff991f3454b426bfec49c752d1e7ffbafa9fdd76. This improves the alignment of `get_property` ABI with the generic attribute support in Envoy in CEL, for example, and simplifies the implementation.

Additional Description:
Risk Level: low, experimental filter, advanced warning to stop using attributes was given
Testing: updated
Docs Changes: yes
Release Notes: yes