### PR TITLE
fips: Add Compliance policy and set it in SSL context

### DIFF
--- a/envoy/server/options.h
+++ b/envoy/server/options.h
@@ -61,6 +61,24 @@ enum class DrainStrategy {
   Immediate,
 };
 
+/**
+ * Specify the FIPS compliance policy
+ */
+enum class CompliancePolicy {
+  /**
+   * No policy (Default ?)
+   */
+  None,
+
+  /**
+   * fips_202205 TLS 1.2 or 1.3
+   * See
+   * https://boringssl.googlesource.com/boringssl/+/451ea3ca3e0b61273333162564f16d190f6b6d14%5E%21/
+   */
+  FIPS_202205,
+
+};
+
 using CommandLineOptionsPtr = std::unique_ptr<envoy::admin::v3::CommandLineOptions>;
 
 /**
@@ -115,6 +133,11 @@ public:
    * @return the strategy that defines behaviour of DrainManager::drainClose();
    */
   virtual DrainStrategy drainStrategy() const PURE;
+
+  /**
+   * @return the fips compliance policy
+   */
+  virtual CompliancePolicy compliancePolicy() const PURE;
 
   /**
    * @return the delay before shutting down the parent envoy in a hot restart,

--- a/source/server/options_impl_base.h
+++ b/source/server/options_impl_base.h
@@ -55,6 +55,9 @@ public:
     parent_shutdown_time_ = parent_shutdown_time;
   }
   void setDrainStrategy(Server::DrainStrategy drain_strategy) { drain_strategy_ = drain_strategy; }
+  void setCompliancePolicy(Server::CompliancePolicy compliance_policy) {
+    compliance_policy_ = compliance_policy;
+  }
   void setLogLevel(spdlog::level::level_enum log_level) { log_level_ = log_level; }
   absl::Status setLogLevel(absl::string_view log_level);
   void setLogFormat(const std::string& log_format) {
@@ -117,6 +120,7 @@ public:
   std::chrono::seconds drainTime() const override { return drain_time_; }
   std::chrono::seconds parentShutdownTime() const override { return parent_shutdown_time_; }
   Server::DrainStrategy drainStrategy() const override { return drain_strategy_; }
+  Server::CompliancePolicy compliancePolicy() const override { return compliance_policy_; }
 
   spdlog::level::level_enum logLevel() const override { return log_level_; }
   const std::vector<std::pair<std::string, spdlog::level::level_enum>>&
@@ -199,6 +203,7 @@ private:
   std::chrono::seconds drain_time_{600};
   std::chrono::seconds parent_shutdown_time_{900};
   Server::DrainStrategy drain_strategy_{Server::DrainStrategy::Gradual};
+  Server::CompliancePolicy compliance_policy_{Server::CompliancePolicy::None};
   Server::Mode mode_{Server::Mode::Serve};
   bool hot_restart_disabled_{false};
   bool signal_handling_enabled_{true};

--- a/test/mocks/server/options.h
+++ b/test/mocks/server/options.h
@@ -32,6 +32,7 @@ public:
   MOCK_METHOD(std::chrono::seconds, drainTime, (), (const));
   MOCK_METHOD(std::chrono::seconds, parentShutdownTime, (), (const));
   MOCK_METHOD(Server::DrainStrategy, drainStrategy, (), (const));
+  MOCK_METHOD(Server::CompliancePolicy, compliancePolicy, (), (const));
   MOCK_METHOD(spdlog::level::level_enum, logLevel, (), (const));
   MOCK_METHOD((const std::vector<std::pair<std::string, spdlog::level::level_enum>>&),
               componentLogLevels, (), (const));


### PR DESCRIPTION
Commit Message: Add Compliance policy and set it in SSL_CTX 
Additional Description:
This is an attempt to introduce compliance policy in envoy, in congruence with policy in boringssl (see
https://boringssl.googlesource.com/boringssl/+/451ea3ca3e0b61273333162564f16d190f6b6d14) We set fips ssl_compliance_policy_fips_202205 which sets fips 140-3 that allows use of TLS 1.3 (with allowed ciphers).

Risk Level: low.
Testing: n/a.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.


This PR is a draft/WIP that attempts to fix #31746 , and is intended to create a mechanism to specify compliance policy and set fips 140-3 in Envoy.

cc: @howardjohn @ggreenway 
