### PR TITLE
mobile: change HTTP/2 and HTTP/3 stream and connection flow control windows

### DIFF
--- a/mobile/library/cc/engine_builder.cc
+++ b/mobile/library/cc/engine_builder.cc
@@ -646,6 +646,8 @@ std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> EngineBuilder::generate
   h2_options->mutable_connection_keepalive()->mutable_timeout()->set_seconds(
       h2_connection_keepalive_timeout_seconds_);
   h2_options->mutable_max_concurrent_streams()->set_value(100);
+  h2_options->mutable_initial_stream_window_size()->set_value(initial_stream_window_size_);
+  h2_options->mutable_initial_connection_window_size()->set_value(initial_connection_window_size_);
 
   envoy::extensions::http::header_formatters::preserve_case::v3::PreserveCaseFormatterConfig
       preserve_case_config;
@@ -718,6 +720,16 @@ std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> EngineBuilder::generate
         ->mutable_http3_protocol_options()
         ->mutable_quic_protocol_options()
         ->set_client_connection_options(http3_client_connection_options_);
+    alpn_options.mutable_auto_config()
+        ->mutable_http3_protocol_options()
+        ->mutable_quic_protocol_options()
+        ->mutable_initial_stream_window_size()
+        ->set_value(initial_stream_window_size_);
+    alpn_options.mutable_auto_config()
+        ->mutable_http3_protocol_options()
+        ->mutable_quic_protocol_options()
+        ->mutable_initial_connection_window_size()
+        ->set_value(initial_connection_window_size_);
     alpn_options.mutable_auto_config()->mutable_alternate_protocols_cache_options()->set_name(
         "default_alternate_protocols_cache");
     for (const auto& [host, port] : quic_hints_) {

--- a/mobile/library/cc/engine_builder.h
+++ b/mobile/library/cc/engine_builder.h
@@ -205,7 +205,10 @@ private:
   // https://source.chromium.org/chromium/chromium/src/+/main:net/quic/quic_session_pool.cc;l=790-793;drc=7f04a8e033c23dede6beae129cd212e6d4473d72
   // https://source.chromium.org/chromium/chromium/src/+/main:net/third_party/quiche/src/quiche/quic/core/quic_constants.h;l=43-47;drc=34ad7f3844f882baf3d31a6bc6e300acaa0e3fc8
   int32_t udp_socket_send_buffer_size_ = 1452 * 20;
-
+  // These are the same values Cronet uses for QUIC:
+  // https://source.chromium.org/chromium/chromium/src/+/main:net/quic/quic_context.cc;l=21-22;drc=6849bf6b37e96bd1c38a5f77f7deaa28b53779c4;bpv=1;bpt=1
+  const uint32_t initial_stream_window_size_ = 6 * 1024 * 1024;      // 6MB
+  const uint32_t initial_connection_window_size_ = 15 * 1024 * 1024; // 15MB
   int quic_connection_idle_timeout_seconds_ = 30;
 };
 

--- a/mobile/test/cc/unit/envoy_config_test.cc
+++ b/mobile/test/cc/unit/envoy_config_test.cc
@@ -116,7 +116,8 @@ TEST(TestConfig, ConfigIsApplied) {
       "key: \"app_version\" value { string_value: \"1.2.3\" } }",
       "key: \"app_id\" value { string_value: \"1234-1234-1234\" } }",
       "validation_context { trusted_ca {",
-  };
+      "initial_stream_window_size { value: 6291456 }",
+      "initial_connection_window_size { value: 15728640 }"};
 
   for (const auto& string : must_contain) {
     EXPECT_THAT(config_str, HasSubstr(string)) << "'" << string << "' not found in " << config_str;


### PR DESCRIPTION
Commit Message: Change those flow control windows to align with chromium values: https://source.chromium.org/chromium/chromium/src/+/main:net/quic/quic_context.cc;l=21-22;drc=6849bf6b37e96bd1c38a5f77f7deaa28b53779c4.

Additional Description: the current Envoy default windows are way too large.

Risk Level: low
Testing: add unit tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
