### PR TITLE
xds-failover: fixing runtime feature flag in tests

### DIFF
--- a/test/extensions/config_subscription/grpc/grpc_mux_failover_test.cc
+++ b/test/extensions/config_subscription/grpc/grpc_mux_failover_test.cc
@@ -409,6 +409,9 @@ TEST_F(GrpcMuxFailoverTest, PrimaryOnlyAttemptsAfterPrimaryAvailable) {
 // will try to reconnect to the primary (and then failover), and keep
 // alternating between the two.
 TEST_F(GrpcMuxFailoverTest, AlternatingPrimaryAndFailoverAttemptsAfterFailoverAvailable) {
+  TestScopedRuntime scoped_runtime;
+  scoped_runtime.mergeValues(
+      {{"envoy.reloadable_features.xds_failover_to_primary_enabled", "true"}});
   connectToFailover();
 
   // Emulate a 5 times disconnects.

--- a/test/extensions/config_subscription/grpc/xds_failover_integration_test.cc
+++ b/test/extensions/config_subscription/grpc/xds_failover_integration_test.cc
@@ -575,6 +575,8 @@ TEST_P(XdsFailoverAdsIntegrationTest, NoFailoverUseAfterPrimaryResponse) {
 
 // Validate that once failover responds, and then disconnects, primary will be attempted.
 TEST_P(XdsFailoverAdsIntegrationTest, PrimaryUseAfterFailoverResponseAndDisconnect) {
+  config_helper_.addRuntimeOverride("envoy.reloadable_features.xds_failover_to_primary_enabled",
+                                    "true");
   // These tests are not executed with GoogleGrpc because they are flaky due to
   // the large timeout values for retries.
   SKIP_IF_GRPC_CLIENT(Grpc::ClientType::GoogleGrpc);
@@ -692,6 +694,8 @@ TEST_P(XdsFailoverAdsIntegrationTest, PrimaryUseAfterFailoverResponseAndDisconne
 // still doesn't respond, failover will be attempted with the correct
 // initial_resource_versions.
 TEST_P(XdsFailoverAdsIntegrationTest, FailoverUseAfterFailoverResponseAndDisconnect) {
+  config_helper_.addRuntimeOverride("envoy.reloadable_features.xds_failover_to_primary_enabled",
+                                    "true");
   // These tests are not executed with GoogleGrpc because they are flaky due to
   // the large timeout values for retries.
   SKIP_IF_GRPC_CLIENT(Grpc::ClientType::GoogleGrpc);
@@ -814,6 +818,8 @@ TEST_P(XdsFailoverAdsIntegrationTest, FailoverUseAfterFailoverResponseAndDisconn
 // both are not responding.
 TEST_P(XdsFailoverAdsIntegrationTest,
        PrimaryAndFailoverAttemptsAfterFailoverResponseAndDisconnect) {
+  config_helper_.addRuntimeOverride("envoy.reloadable_features.xds_failover_to_primary_enabled",
+                                    "true");
   // These tests are not executed with GoogleGrpc because they are flaky due to
   // the large timeout values for retries.
   SKIP_IF_GRPC_CLIENT(Grpc::ClientType::GoogleGrpc);


### PR DESCRIPTION
Commit Message: xds-failover: fixing runtime feature flag in tests
Additional Description:
PR #36386 added a runtime flag to disable the move to primary feature.
This PR explicitly sets the knob to true on some tests that depend on that behavior.

Risk Level: low - tests only
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
