### PR TITLE
router_check_tool: Load runtime flags before running the tests

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -29,6 +29,9 @@ removed_config_or_runtime:
     Removed runtime flag ``envoy.restart_features.allow_client_socket_creation_failure`` and legacy code paths.
 
 new_features:
+- area: router_check_tool
+  change: |
+    Added support for loading runtime flags to all tests.
 - area: tls
   change: |
     Added support for P-384 and P-521 curves for TLS server certificates.

--- a/docs/root/configuration/operations/tools/router_check.rst
+++ b/docs/root/configuration/operations/tools/router_check.rst
@@ -16,7 +16,7 @@ virtual host name, manual path rewrite, manual host rewrite, path redirect, and
 header field matches. Extensions for other test cases can be added. Details about installing the tool
 and sample tool input/output can be found at :ref:`installation <install_tools_route_table_check_tool>`.
 
-The route table check tool config is composed of an array of json test objects. Each test object is composed of
+The tests in the route table check tool config is composed of an array of json test objects. Each test object is composed of
 three parts.
 
 Test name
@@ -31,10 +31,14 @@ Validate
   The validate fields specify the expected values and test cases to check. At least one test
   case is required.
 
+The configuration also allows runtime flags to be set prior to running the tests.
+
 A simple tool configuration json has one test case and is written as follows. The test
 expects a cluster name match of "instant-server".::
 
-   tests
+   runtime:
+     re2.max_program_size.error_level: 32768
+   tests:
    - test_name: Cluster_name_test
      input:
        authority: api.lyft.com
@@ -44,7 +48,8 @@ expects a cluster name match of "instant-server".::
 
 .. code-block:: yaml
 
-  tests
+  runtime: ...
+  tests:
   - test_name: ...
     input:
       authority: ...

--- a/test/tools/router_check/router.h
+++ b/test/tools/router_check/router.h
@@ -66,6 +66,7 @@ public:
    * config file.
    * */
   static RouterCheckTool create(const std::string& router_config_file,
+                                const std::string& validation_config_file,
                                 const bool disable_deprecation_check);
 
   /**

--- a/test/tools/router_check/router_check.cc
+++ b/test/tools/router_check/router_check.cc
@@ -31,8 +31,8 @@ int main(int argc, char* argv[]) {
   Envoy::TestDeprecatedV2Api _deprecated_v2_api;
 
   try {
-    Envoy::RouterCheckTool checktool =
-        Envoy::RouterCheckTool::create(options.configPath(), options.disableDeprecationCheck());
+    Envoy::RouterCheckTool checktool = Envoy::RouterCheckTool::create(
+        options.configPath(), options.testPath(), options.disableDeprecationCheck());
 
     if (options.isDetailed()) {
       checktool.setShowDetails();

--- a/test/tools/router_check/test/config/DefaultRuntime.golden.proto.json
+++ b/test/tools/router_check/test/config/DefaultRuntime.golden.proto.json
@@ -1,0 +1,46 @@
+{
+  "runtime": {
+    "re2.max_program_size.error_level": 32768
+  },
+  "tests": [
+    {
+      "test_name": "Test1",
+      "input": {
+        "authority": "some_cluster",
+        "path": "/foo",
+        "method": "GET"
+      },
+      "validate": {
+        "cluster_name": "some_cluster"
+      }
+    },
+    {
+      "test_name": "Test2",
+      "input": {
+        "authority": "www.lyft.com",
+        "path": "/bar",
+        "method": "GET"
+      },
+      "validate": {
+        "cluster_name": ""
+      }
+    },
+    {
+      "test_name": "Test3",
+      "input": {
+        "authority": "www.lyft.com",
+        "path": "/bar",
+        "method": "GET",
+        "additional_request_headers": [
+          {
+            "key": "some_header",
+            "value": "some_cluster"
+          }
+        ]
+      },
+      "validate": {
+        "cluster_name": "some_cluster"
+      }
+    }
+  ]
+}

--- a/test/tools/router_check/test/config/DefaultRuntime.yaml
+++ b/test/tools/router_check/test/config/DefaultRuntime.yaml
@@ -1,0 +1,25 @@
+virtual_hosts:
+- name: local_service
+  domains:
+  - '*'
+  routes:
+  - match:
+      prefix: "/foo"
+      headers:
+      - name: ":authority"
+    route:
+      cluster_header: ":authority"
+  - match:
+      prefix: "/bar"
+    route:
+      cluster_header: "some_header"
+      timeout:
+        nanos: 0
+  - match:
+      safe_regex:
+        # 100+ chars regex to test re2.max_program_size.error_level runtime override.
+        regex: (?:[a-zA-Z]{3,6}[0-9]{2,4}[A-Z]{1,3}\d{0,2}\W{0,2}){10,20}|(?:[a-zA-Z0-9!@#\$%\^\&\*\)\(+=._-]{25,50})|(?:[A-Z])
+    route:
+      cluster_header: "some_header"
+      timeout:
+        nanos: 0

--- a/test/tools/router_check/test/route_tests.sh
+++ b/test/tools/router_check/test/route_tests.sh
@@ -8,7 +8,7 @@ PATH_BIN="${TEST_SRCDIR}/envoy"/test/tools/router_check/router_check_tool
 # Config json path
 PATH_CONFIG="${TEST_SRCDIR}/envoy"/test/tools/router_check/test/config
 
-TESTS=("ContentType" "ClusterHeader" "DirectResponse" "HeaderMatchedRouting" "Redirect" "Redirect2" "Redirect3" "Redirect4" "Runtime" "TestRoutes" "Weighted")
+TESTS=("DefaultRuntime" "ContentType" "ClusterHeader" "DirectResponse" "HeaderMatchedRouting" "Redirect" "Redirect2" "Redirect3" "Redirect4" "Runtime" "TestRoutes" "Weighted")
 
 # Testing expected matches
 for t in "${TESTS[@]}"

--- a/test/tools/router_check/test/router_test.cc
+++ b/test/tools/router_check/test/router_test.cc
@@ -18,7 +18,7 @@ TEST(RouterCheckTest, RouterCheckTestRoutesSuccessTest) {
       TestEnvironment::runfilesPath(absl::StrCat(kDir, "TestRoutes.yaml"));
   const std::string tests_filename_ =
       TestEnvironment::runfilesPath(absl::StrCat(kDir, "TestRoutes.golden.proto.json"));
-  RouterCheckTool checktool = RouterCheckTool::create(config_filename_, false);
+  RouterCheckTool checktool = RouterCheckTool::create(config_filename_, tests_filename_, false);
   const std::vector<envoy::RouterCheckToolSchema::ValidationItemResult> test_results =
       checktool.compareEntries(tests_filename_);
   EXPECT_EQ(test_results.size(), 33);
@@ -33,7 +33,7 @@ TEST(RouterCheckTest, RouterCheckTestRoutesSuccessShowOnlyFailuresTest) {
       TestEnvironment::runfilesPath(absl::StrCat(kDir, "TestRoutes.yaml"));
   const std::string tests_filename_ =
       TestEnvironment::runfilesPath(absl::StrCat(kDir, "TestRoutes.golden.proto.json"));
-  RouterCheckTool checktool = RouterCheckTool::create(config_filename_, false);
+  RouterCheckTool checktool = RouterCheckTool::create(config_filename_, tests_filename_, false);
   checktool.setOnlyShowFailures();
   const std::vector<envoy::RouterCheckToolSchema::ValidationItemResult> test_results =
       checktool.compareEntries(tests_filename_);
@@ -45,7 +45,7 @@ TEST(RouterCheckTest, RouterCheckTestRoutesFailuresTest) {
       TestEnvironment::runfilesPath(absl::StrCat(kDir, "TestRoutes.yaml"));
   const std::string tests_filename_ =
       TestEnvironment::runfilesPath(absl::StrCat(kDir, "TestRoutesFailures.golden.proto.json"));
-  RouterCheckTool checktool = RouterCheckTool::create(config_filename_, false);
+  RouterCheckTool checktool = RouterCheckTool::create(config_filename_, tests_filename_, false);
   checktool.setOnlyShowFailures();
   const std::vector<envoy::RouterCheckToolSchema::ValidationItemResult> test_results =
       checktool.compareEntries(tests_filename_);

--- a/test/tools/router_check/validation.proto
+++ b/test/tools/router_check/validation.proto
@@ -4,6 +4,7 @@ package envoy.RouterCheckToolSchema;
 
 import "envoy/config/core/v3/base.proto";
 import "envoy/config/route/v3/route_components.proto";
+import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 import "validate/validate.proto";
 
@@ -15,6 +16,9 @@ import "validate/validate.proto";
 message Validation {
   // A collection of test cases.
   repeated ValidationItem tests = 1 [(validate.rules).repeated .min_items = 1];
+
+  // The runtime flags to be loaded before running the tests.
+  google.protobuf.Struct runtime = 2;
 }
 
 // Schema for each test case.


### PR DESCRIPTION
Commit Message: router_check_tool: Load runtime flags before running the tests.
Additional Description:  This adds a new field to the [Validation](https://github.com/envoyproxy/envoy/blob/55b0fc45cfdc2c0df002690606853540cf794fab/test/tools/router_check/validation.proto#L15) configuration to load runtime flags. More context in https://github.com/envoyproxy/envoy/pull/35662#discussion_r1794234910
Risk Level: Low
Testing: Extended existing tests. Without `re2.max_program_size.error_level` flag set the test fails. 

```shell
bazel-bin/test/tools/router_check/router_check_tool -c test/tools/router_check/test/config/DefaultRuntime.yaml -t test/tools/router_check/test/config/DefaultRuntime.golden.proto.json
```

Fixes: https://github.com/envoyproxy/envoy/issues/35174