### PR TITLE
[balsa] Add runtime flag for http_inspector parser

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -53,5 +53,8 @@ new_features:
   change: |
     Added %DOWNSTREAM_LOCAL_EMAIL_SAN%, %DOWNSTREAM_PEER_EMAIL_SAN%, %DOWNSTREAM_LOCAL_OTHERNAME_SAN% and
     %DOWNSTREAM_PEER_OTHERNAME_SAN% substitution formatters.
+- area: http_inspector
+  change: |
+    Added default-false ``envoy.reloadable_features.http_inspector_use_balsa_parser`` for HttpInspector to use BalsaParser.
 
 deprecated:

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -153,6 +153,8 @@ FALSE_RUNTIME_GUARD(envoy_reloadable_features_dns_cache_set_ip_version_to_remove
 FALSE_RUNTIME_GUARD(envoy_reloadable_features_reset_brokenness_on_nework_change);
 // TODO(botengyao): this will be default true in the next release after this warning release.
 FALSE_RUNTIME_GUARD(envoy_reloadable_features_explicit_internal_address_config);
+// Adding runtime flag to use balsa_parser for http_inspector.
+FALSE_RUNTIME_GUARD(envoy_reloadable_features_http_inspector_use_balsa_parser);
 
 // A flag to set the maximum TLS version for google_grpc client to TLS1.2, when needed for
 // compliance restrictions.

--- a/source/extensions/filters/listener/http_inspector/BUILD
+++ b/source/extensions/filters/listener/http_inspector/BUILD
@@ -24,6 +24,7 @@ envoy_cc_library(
         "//source/common/common:minimal_logger_lib",
         "//source/common/http:headers_lib",
         "//source/common/http:utility_lib",
+        "//source/common/http/http1:balsa_parser_lib",
         "//source/common/http/http1:legacy_parser_lib",
         "//source/common/http/http1:parser_interface",
     ],

--- a/source/extensions/filters/listener/http_inspector/http_inspector.cc
+++ b/source/extensions/filters/listener/http_inspector/http_inspector.cc
@@ -87,15 +87,11 @@ ParseState Filter::parseHttpHeader(absl::string_view data) {
     }
 
     absl::string_view new_data = data.substr(nread_);
-    const size_t pos = new_data.find_first_of("\r\n");
+    const size_t pos = new_data.find_first_of('\n');
     if (pos != absl::string_view::npos) {
-      // Include \r or \n
-      if (new_data[pos] == '\r' && (pos + 1 < new_data.size())) {
-        // Including '\n' as BalsaParser executes on seeing '\n'.
-        new_data = new_data.substr(0, pos + 2);
-      } else {
-        new_data = new_data.substr(0, pos + 1);
-      }
+      // Include \n
+      new_data = new_data.substr(0, pos + 1);
+
       ssize_t rc = parser_->execute(new_data.data(), new_data.length());
       nread_ += rc;
       ENVOY_LOG(trace, "http inspector: http_parser parsed {} chars, error code: {}", rc,

--- a/source/extensions/filters/listener/http_inspector/http_inspector.h
+++ b/source/extensions/filters/listener/http_inspector/http_inspector.h
@@ -2,11 +2,13 @@
 
 #include "envoy/event/file_event.h"
 #include "envoy/event/timer.h"
+#include "envoy/http/codec.h"
 #include "envoy/network/filter.h"
 #include "envoy/stats/scope.h"
 #include "envoy/stats/stats_macros.h"
 
 #include "source/common/common/logger.h"
+#include "source/common/http/http1/balsa_parser.h"
 #include "source/common/http/http1/legacy_parser_impl.h"
 #include "source/common/http/http1/parser.h"
 
@@ -124,6 +126,7 @@ private:
   std::unique_ptr<Http::Http1::Parser> parser_;
   NoOpParserCallbacks no_op_callbacks_;
   ssize_t nread_ = 0;
+  uint32_t max_request_headers_kb_{Http::DEFAULT_MAX_REQUEST_HEADERS_KB};
 };
 
 } // namespace HttpInspector

--- a/test/extensions/filters/listener/http_inspector/BUILD
+++ b/test/extensions/filters/listener/http_inspector/BUILD
@@ -30,6 +30,7 @@ envoy_extension_cc_test(
         "//test/mocks/api:api_mocks",
         "//test/mocks/network:network_mocks",
         "//test/mocks/stats:stats_mocks",
+        "//test/test_common:test_runtime_lib",
         "//test/test_common:threadsafe_singleton_injector_lib",
     ],
 )

--- a/test/extensions/filters/listener/http_inspector/http_inspector_test.cc
+++ b/test/extensions/filters/listener/http_inspector/http_inspector_test.cc
@@ -7,7 +7,9 @@
 #include "test/mocks/api/mocks.h"
 #include "test/mocks/network/mocks.h"
 #include "test/mocks/stats/mocks.h"
+#include "test/test_common/test_runtime.h"
 #include "test/test_common/threadsafe_singleton_injector.h"
+#include "test/test_common/utility.h"
 
 #include "gtest/gtest.h"
 
@@ -27,15 +29,28 @@ namespace ListenerFilters {
 namespace HttpInspector {
 namespace {
 
-class HttpInspectorTest : public testing::Test {
+std::string testParamToString(const ::testing::TestParamInfo<Http1ParserImpl>& info) {
+  return TestUtility::http1ParserImplToString(info.param);
+}
+
+class HttpInspectorTest : public testing::TestWithParam<Http1ParserImpl> {
 public:
   HttpInspectorTest()
       : cfg_(std::make_shared<Config>(*store_.rootScope())),
-        io_handle_(Network::SocketInterfaceImpl::makePlatformSpecificSocket(42, false,
-                                                                            absl::nullopt, {})) {}
+        io_handle_(
+            Network::SocketInterfaceImpl::makePlatformSpecificSocket(42, false, absl::nullopt, {})),
+        parser_impl_(GetParam()) {}
   ~HttpInspectorTest() override { io_handle_->close(); }
 
   void init() {
+    if (parser_impl_ == Http1ParserImpl::BalsaParser) {
+      scoped_runtime_.mergeValues(
+          {{"envoy.reloadable_features.http_inspector_use_balsa_parser", "true"}});
+    } else {
+      scoped_runtime_.mergeValues(
+          {{"envoy.reloadable_features.http_inspector_use_balsa_parser", "false"}});
+    }
+
     filter_ = std::make_unique<Filter>(cfg_);
 
     EXPECT_CALL(cb_, socket()).WillRepeatedly(ReturnRef(socket_));
@@ -334,9 +349,16 @@ public:
   Event::FileReadyCb file_event_callback_;
   Network::IoHandlePtr io_handle_;
   std::unique_ptr<Network::ListenerFilterBufferImpl> buffer_;
+  TestScopedRuntime scoped_runtime_;
+  const Http1ParserImpl parser_impl_;
 };
 
-TEST_F(HttpInspectorTest, SkipHttpInspectForTLS) {
+INSTANTIATE_TEST_SUITE_P(Parsers, HttpInspectorTest,
+                         ::testing::Values(Http1ParserImpl::HttpParser,
+                                           Http1ParserImpl::BalsaParser),
+                         testParamToString);
+
+TEST_P(HttpInspectorTest, SkipHttpInspectForTLS) {
   filter_ = std::make_unique<Filter>(cfg_);
 
   EXPECT_CALL(cb_, socket()).WillRepeatedly(ReturnRef(socket_));
@@ -345,7 +367,7 @@ TEST_F(HttpInspectorTest, SkipHttpInspectForTLS) {
   EXPECT_EQ(filter_->onAccept(cb_), Network::FilterStatus::Continue);
 }
 
-TEST_F(HttpInspectorTest, InlineReadInspectHttp10) {
+TEST_P(HttpInspectorTest, InlineReadInspectHttp10) {
   const absl::string_view header =
       "GET /anything HTTP/1.0\r\nhost: google.com\r\nuser-agent: curl/7.64.0\r\naccept: "
       "*/*\r\nx-forwarded-proto: http\r\nx-request-id: "
@@ -354,17 +376,21 @@ TEST_F(HttpInspectorTest, InlineReadInspectHttp10) {
   testHttpInspectFound(header, Http::Utility::AlpnNames::get().Http10);
 }
 
-TEST_F(HttpInspectorTest, InlineReadParseError) {
+TEST_P(HttpInspectorTest, InlineReadParseError) {
   const absl::string_view header =
       "NOT_A_LEGAL_PREFIX /anything HTTP/1.0\r\nhost: google.com\r\nuser-agent: "
       "curl/7.64.0\r\naccept: "
       "*/*\r\nx-forwarded-proto: http\r\nx-request-id: "
       "a52df4a0-ed00-4a19-86a7-80e5049c6c84\r\nx-envoy-expected-rq-timeout-ms: "
       "15000\r\ncontent-length: 0\r\n\r\n";
-  testHttpInspectNotFound(header);
+  if (parser_impl_ == Http1ParserImpl::BalsaParser) {
+    testHttpInspectFound(header, Http::Utility::AlpnNames::get().Http10);
+  } else {
+    testHttpInspectNotFound(header);
+  }
 }
 
-TEST_F(HttpInspectorTest, InspectHttp10) {
+TEST_P(HttpInspectorTest, InspectHttp10) {
   const absl::string_view header =
       "GET /anything HTTP/1.0\r\nhost: google.com\r\nuser-agent: curl/7.64.0\r\naccept: "
       "*/*\r\nx-forwarded-proto: http\r\nx-request-id: "
@@ -373,7 +399,7 @@ TEST_F(HttpInspectorTest, InspectHttp10) {
   testHttpInspectFound(header, Http::Utility::AlpnNames::get().Http10);
 }
 
-TEST_F(HttpInspectorTest, InspectHttp11) {
+TEST_P(HttpInspectorTest, InspectHttp11) {
   const absl::string_view header =
       "GET /anything HTTP/1.1\r\nhost: google.com\r\nuser-agent: curl/7.64.0\r\naccept: "
       "*/*\r\nx-forwarded-proto: http\r\nx-request-id: "
@@ -382,7 +408,7 @@ TEST_F(HttpInspectorTest, InspectHttp11) {
   testHttpInspectFound(header, Http::Utility::AlpnNames::get().Http11);
 }
 
-TEST_F(HttpInspectorTest, InspectHttp11WithNonEmptyRequestBody) {
+TEST_P(HttpInspectorTest, InspectHttp11WithNonEmptyRequestBody) {
   const absl::string_view header =
       "GET /anything HTTP/1.1\r\nhost: google.com\r\nuser-agent: curl/7.64.0\r\naccept: "
       "*/*\r\nx-forwarded-proto: http\r\nx-request-id: "
@@ -391,47 +417,54 @@ TEST_F(HttpInspectorTest, InspectHttp11WithNonEmptyRequestBody) {
   testHttpInspectFound(header, Http::Utility::AlpnNames::get().Http11);
 }
 
-TEST_F(HttpInspectorTest, ExtraSpaceInRequestLine) {
+TEST_P(HttpInspectorTest, ExtraSpaceInRequestLine) {
   const absl::string_view header = "GET  /anything  HTTP/1.1\r\n\r\n";
   testHttpInspectFound(header, Http::Utility::AlpnNames::get().Http11);
 }
 
-TEST_F(HttpInspectorTest, InvalidHttpMethod) {
+TEST_P(HttpInspectorTest, InvalidHttpMethod) {
+  if (parser_impl_ == Http1ParserImpl::BalsaParser) {
+    return;
+  }
   const absl::string_view header = "BAD /anything HTTP/1.1";
   testHttpInspectNotFound(header);
 }
 
-TEST_F(HttpInspectorTest, InvalidHttpRequestLine) {
+TEST_P(HttpInspectorTest, InvalidHttpRequestLine) {
   const absl::string_view header = "BAD /anything HTTP/1.1\r\n";
-  testHttpInspectNotFound(header);
+  if (parser_impl_ == Http1ParserImpl::BalsaParser) {
+    testHttpInspectFound(header, Http::Utility::AlpnNames::get().Http11);
+  } else {
+    testHttpInspectNotFound(header);
+  }
 }
 
-TEST_F(HttpInspectorTest, OldHttpProtocol) {
+TEST_P(HttpInspectorTest, OldHttpProtocol) {
   const absl::string_view header = "GET /anything HTTP/0.9\r\n";
   testHttpInspectFound(header, Http::Utility::AlpnNames::get().Http10);
 }
 
-TEST_F(HttpInspectorTest, InvalidRequestLine) {
+TEST_P(HttpInspectorTest, InvalidRequestLine) {
   const absl::string_view header = "GET /anything HTTP/1.1 BadRequestLine\r\n";
   testHttpInspectNotFound(header);
 }
 
-TEST_F(HttpInspectorTest, InvalidRequestLine2) {
+TEST_P(HttpInspectorTest, InvalidRequestLine2) {
   const absl::string_view header = "\r\n\r\n\r\n";
   testHttpInspectNotFound(header);
 }
 
-TEST_F(HttpInspectorTest, InvalidRequestLine3) {
+TEST_P(HttpInspectorTest, InvalidRequestLine3) {
   const absl::string_view header = "\r\n\r\n\r\n BAD";
   testHttpInspectNotFound(header);
 }
 
-TEST_F(HttpInspectorTest, InvalidRequestLine4) {
+TEST_P(HttpInspectorTest, InvalidRequestLine4) {
   const absl::string_view header = "\r\nGET /anything HTTP/1.1\r\n";
   testHttpInspectNotFound(header);
 }
 
-TEST_F(HttpInspectorTest, InspectHttp2) {
+TEST_P(HttpInspectorTest, InspectHttp2) {
   const std::string header =
       "505249202a20485454502f322e300d0a0d0a534d0d0a0d0a00000c04000000000000041000000000020000000000"
       "00040800000000000fff000100007d010500000001418aa0e41d139d09b8f0000f048860757a4ce6aa660582867a"
@@ -441,7 +474,7 @@ TEST_F(HttpInspectorTest, InspectHttp2) {
   testHttpInspectFound(header, Http::Utility::AlpnNames::get().Http2c);
 }
 
-TEST_F(HttpInspectorTest, InvalidConnectionPreface) {
+TEST_P(HttpInspectorTest, InvalidConnectionPreface) {
   init();
 
   const std::string header = "505249202a20485454502f322e300d0a";
@@ -473,7 +506,7 @@ TEST_F(HttpInspectorTest, InvalidConnectionPreface) {
   EXPECT_EQ(0, cfg_->stats().http_not_found_.value());
 }
 
-TEST_F(HttpInspectorTest, MultipleReadsHttp2) {
+TEST_P(HttpInspectorTest, MultipleReadsHttp2) {
   const std::string header =
       "505249202a20485454502f322e300d0a0d0a534d0d0a0d0a00000c04000000000000041000000000020000000000"
       "00040800000000000fff000100007d010500000001418aa0e41d139d09b8f0000f048860757a4ce6aa660582867a"
@@ -483,26 +516,37 @@ TEST_F(HttpInspectorTest, MultipleReadsHttp2) {
   testHttpInspectMultipleReadsFound(header, Http::Utility::AlpnNames::get().Http2c);
 }
 
-TEST_F(HttpInspectorTest, MultipleReadsHttp2BadPreface) {
+TEST_P(HttpInspectorTest, MultipleReadsHttp2BadPreface) {
+  // http_parser returns invalid method
+  if (parser_impl_ == Http1ParserImpl::BalsaParser) {
+    return;
+  }
   const std::string header = "505249202a20485454502f322e300d0a0d0c";
   testHttpInspectMultipleReadsNotFound(header, true);
 }
 
-TEST_F(HttpInspectorTest, MultipleReadsHttp1) {
+TEST_P(HttpInspectorTest, MultipleReadsHttp1) {
   const absl::string_view data = "GET /anything HTTP/1.0\r";
   testHttpInspectMultipleReadsFound(data, Http::Utility::AlpnNames::get().Http10);
 }
 
-TEST_F(HttpInspectorTest, MultipleReadsHttp1IncompleteBadHeader) {
+TEST_P(HttpInspectorTest, MultipleReadsHttp1IncompleteBadHeader) {
+  if (parser_impl_ == Http1ParserImpl::BalsaParser) {
+    return;
+  }
   const absl::string_view data = "X";
   testHttpInspectMultipleReadsNotFound(data);
 }
 
-TEST_F(HttpInspectorTest, MultipleReadsHttp1BadProtocol) {
+TEST_P(HttpInspectorTest, MultipleReadsHttp1BadProtocol) {
 #ifdef ENVOY_ENABLE_UHV
   // permissive parsing
   return;
 #endif
+
+  if (parser_impl_ == Http1ParserImpl::BalsaParser) {
+    return;
+  }
 
   const std::string valid_header = "GET /index HTTP/1.1\r";
   //  offset:                       0         10
@@ -510,7 +554,7 @@ TEST_F(HttpInspectorTest, MultipleReadsHttp1BadProtocol) {
   testHttpInspectMultipleReadsNotFound(truncate_header);
 }
 
-TEST_F(HttpInspectorTest, Http1WithLargeRequestLine) {
+TEST_P(HttpInspectorTest, Http1WithLargeRequestLine) {
   // Verify that the http inspector can detect http requests
   // with large request line even when they are split over
   // multiple recv calls.
@@ -581,7 +625,7 @@ TEST_F(HttpInspectorTest, Http1WithLargeRequestLine) {
   EXPECT_EQ(1, cfg_->stats().http10_found_.value());
 }
 
-TEST_F(HttpInspectorTest, Http1WithLargeHeader) {
+TEST_P(HttpInspectorTest, Http1WithLargeHeader) {
   init();
   absl::string_view request = "GET /index HTTP/1.0\rfield: ";
   //                           0                  20


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Add runtime flag for http_inspector parser
Additional Description: Add default false runtime flag to use balsa_parser in the http_inspector. As part of https://github.com/envoyproxy/envoy/issues/36433 to support parsing of custom methods with http_inspector. 
Risk Level: Low 
Testing:  parametrized all the existing tests of `HttpInspectorTest` to run for both http-parser and BalsaParser.
running the command `bazel test //test/extensions/filters/listener/http_inspector:http_inspector_test
` runs the tests for both the parsers. (Some BalsaParser tests are disabled for now.)
 
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
