### PR TITLE
mobile: use 10s default value of connect timeout

### DIFF
--- a/mobile/library/cc/engine_builder.h
+++ b/mobile/library/cc/engine_builder.h
@@ -144,7 +144,7 @@ private:
   std::unique_ptr<EngineCallbacks> callbacks_;
   std::unique_ptr<EnvoyEventTracker> event_tracker_{nullptr};
 
-  int connect_timeout_seconds_ = 30;
+  int connect_timeout_seconds_ = 10;
   int dns_refresh_seconds_ = 60;
   int dns_failure_refresh_seconds_base_ = 2;
   int dns_failure_refresh_seconds_max_ = 10;

--- a/mobile/library/java/org/chromium/net/impl/NativeCronvoyEngineBuilderImpl.java
+++ b/mobile/library/java/org/chromium/net/impl/NativeCronvoyEngineBuilderImpl.java
@@ -234,8 +234,8 @@ public class NativeCronvoyEngineBuilderImpl extends CronvoyEngineBuilderImpl {
     return this;
   }
 
-  public NativeCronvoyEngineBuilderImpl setConnectTimeoutSeconds(int connect_timeout) {
-    mConnectTimeoutSeconds = connect_timeout;
+  public NativeCronvoyEngineBuilderImpl setConnectTimeoutSeconds(int connectTimeout) {
+    mConnectTimeoutSeconds = connectTimeout;
     return this;
   }
 

--- a/mobile/library/java/org/chromium/net/impl/NativeCronvoyEngineBuilderImpl.java
+++ b/mobile/library/java/org/chromium/net/impl/NativeCronvoyEngineBuilderImpl.java
@@ -38,7 +38,7 @@ public class NativeCronvoyEngineBuilderImpl extends CronvoyEngineBuilderImpl {
   // TODO(refactor) move unshared variables into their specific methods.
   private final List<EnvoyNativeFilterConfig> nativeFilterChain = new ArrayList<>();
   private final EnvoyEventTracker mEnvoyEventTracker = null;
-  private final int mConnectTimeoutSeconds = 30;
+  private int mConnectTimeoutSeconds = 10;
   private final int mDnsRefreshSeconds = 60;
   private final int mDnsFailureRefreshSecondsBase = 2;
   private final int mDnsFailureRefreshSecondsMax = 10;
@@ -231,6 +231,11 @@ public class NativeCronvoyEngineBuilderImpl extends CronvoyEngineBuilderImpl {
    */
   public NativeCronvoyEngineBuilderImpl setUpstreamTlsSni(String sni) {
     mUpstreamTlsSni = sni;
+    return this;
+  }
+
+  public NativeCronvoyEngineBuilderImpl setConnectTimeoutSeconds(int connect_timeout) {
+    mConnectTimeoutSeconds = connect_timeout;
     return this;
   }
 

--- a/mobile/library/kotlin/io/envoyproxy/envoymobile/EngineBuilder.kt
+++ b/mobile/library/kotlin/io/envoyproxy/envoymobile/EngineBuilder.kt
@@ -26,7 +26,7 @@ open class EngineBuilder() {
     )
   }
   private var logLevel = LogLevel.INFO
-  private var connectTimeoutSeconds = 30
+  private var connectTimeoutSeconds = 10
   private var dnsRefreshSeconds = 60
   private var dnsFailureRefreshSecondsBase = 2
   private var dnsFailureRefreshSecondsMax = 10


### PR DESCRIPTION
Commit Message: change the  default connect timeout from 30s to 10s to align with Chromium default https://source.chromium.org/chromium/chromium/src/+/main:net/quic/quic_context.h;l=157;drc=04989307509c78d67b34f2282ca549397719d046;bpv=1;bpt=1

Additional Description: Also add Cronvoy  API to change to a different value.
Risk Level: low, mobile only
Testing: existing tests pass
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
