### PR TITLE
Fix documentation for TcpProxy.metadata_match

### DIFF
--- a/api/envoy/extensions/filters/network/tcp_proxy/v3/tcp_proxy.proto
+++ b/api/envoy/extensions/filters/network/tcp_proxy/v3/tcp_proxy.proto
@@ -175,9 +175,9 @@ message TcpProxy {
   // :ref:`TcpProxy.weighted_clusters <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.weighted_clusters>`.
   OnDemand on_demand = 14;
 
-  // Optional endpoint metadata match criteria. Only endpoints in the upstream
-  // cluster with metadata matching that set in metadata_match will be
-  // considered. The filter name should be specified as ``envoy.lb``.
+  // Optional endpoint metadata match criteria used by the subset load balancer. Only endpoints
+  // in the upstream cluster with metadata matching what is set in this field will be considered
+  // for load balancing. The filter name should be specified as ``envoy.lb``.
   config.core.v3.Metadata metadata_match = 9;
 
   // The idle timeout for connections managed by the TCP proxy filter. The idle timeout


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Fix documentation for TcpProxy.metadata_match
Additional Description: Currently, the documentation for TcpProxy.metadata_match implies that metadata matching will occur even when not using a subset lb, which I don't think is true.
Risk Level: Low
Testing:
Docs Changes: Yes
Release Notes: No
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
