### PR TITLE
secrets: move SSL context manager to the server context since it is per process

### DIFF
--- a/contrib/cryptomb/private_key_providers/source/config.cc
+++ b/contrib/cryptomb/private_key_providers/source/config.cc
@@ -26,7 +26,7 @@ namespace CryptoMb {
 Ssl::PrivateKeyMethodProviderSharedPtr
 CryptoMbPrivateKeyMethodFactory::createPrivateKeyMethodProviderInstance(
     const envoy::extensions::transport_sockets::tls::v3::PrivateKeyProvider& proto_config,
-    Server::Configuration::TransportSocketFactoryContext& private_key_provider_context) {
+    Server::Configuration::ServerFactoryContext& private_key_provider_context) {
   ProtobufTypes::MessagePtr message =
       std::make_unique<envoy::extensions::private_key_providers::cryptomb::v3alpha::
                            CryptoMbPrivateKeyMethodConfig>();

--- a/contrib/cryptomb/private_key_providers/source/config.h
+++ b/contrib/cryptomb/private_key_providers/source/config.h
@@ -15,7 +15,7 @@ public:
   // Ssl::PrivateKeyMethodProviderInstanceFactory
   Ssl::PrivateKeyMethodProviderSharedPtr createPrivateKeyMethodProviderInstance(
       const envoy::extensions::transport_sockets::tls::v3::PrivateKeyProvider& message,
-      Server::Configuration::TransportSocketFactoryContext& private_key_provider_context) override;
+      Server::Configuration::ServerFactoryContext& private_key_provider_context) override;
   std::string name() const override { return "cryptomb"; };
 };
 

--- a/contrib/cryptomb/private_key_providers/source/cryptomb_private_key_provider.cc
+++ b/contrib/cryptomb/private_key_providers/source/cryptomb_private_key_provider.cc
@@ -681,11 +681,10 @@ void CryptoMbPrivateKeyMethodProvider::unregisterPrivateKeyMethod(SSL* ssl) {
 CryptoMbPrivateKeyMethodProvider::CryptoMbPrivateKeyMethodProvider(
     const envoy::extensions::private_key_providers::cryptomb::v3alpha::
         CryptoMbPrivateKeyMethodConfig& conf,
-    Server::Configuration::TransportSocketFactoryContext& factory_context, IppCryptoSharedPtr ipp)
-    : api_(factory_context.serverFactoryContext().api()),
-      tls_(ThreadLocal::TypedSlot<ThreadLocalData>::makeUnique(
-          factory_context.serverFactoryContext().threadLocal())),
-      stats_(generateCryptoMbStats("cryptomb", factory_context.statsScope())) {
+    Server::Configuration::ServerFactoryContext& factory_context, IppCryptoSharedPtr ipp)
+    : api_(factory_context.api()),
+      tls_(ThreadLocal::TypedSlot<ThreadLocalData>::makeUnique(factory_context.threadLocal())),
+      stats_(generateCryptoMbStats("cryptomb", factory_context.scope())) {
 
   if (!ipp->mbxIsCryptoMbApplicable(0)) {
     ENVOY_LOG(warn, "Multi-buffer CPU instructions not available.");

--- a/contrib/cryptomb/private_key_providers/source/cryptomb_private_key_provider.h
+++ b/contrib/cryptomb/private_key_providers/source/cryptomb_private_key_provider.h
@@ -185,7 +185,7 @@ public:
   CryptoMbPrivateKeyMethodProvider(
       const envoy::extensions::private_key_providers::cryptomb::v3alpha::
           CryptoMbPrivateKeyMethodConfig& config,
-      Server::Configuration::TransportSocketFactoryContext& private_key_provider_context,
+      Server::Configuration::ServerFactoryContext& private_key_provider_context,
       IppCryptoSharedPtr ipp);
 
   // Ssl::PrivateKeyMethodProvider

--- a/contrib/cryptomb/private_key_providers/test/fake_factory.cc
+++ b/contrib/cryptomb/private_key_providers/test/fake_factory.cc
@@ -151,7 +151,7 @@ FakeCryptoMbPrivateKeyMethodFactory::FakeCryptoMbPrivateKeyMethodFactory(
 Ssl::PrivateKeyMethodProviderSharedPtr
 FakeCryptoMbPrivateKeyMethodFactory::createPrivateKeyMethodProviderInstance(
     const envoy::extensions::transport_sockets::tls::v3::PrivateKeyProvider& proto_config,
-    Server::Configuration::TransportSocketFactoryContext& private_key_provider_context) {
+    Server::Configuration::ServerFactoryContext& private_key_provider_context) {
   ProtobufTypes::MessagePtr message =
       std::make_unique<envoy::extensions::private_key_providers::cryptomb::v3alpha::
                            CryptoMbPrivateKeyMethodConfig>();
@@ -169,8 +169,7 @@ FakeCryptoMbPrivateKeyMethodFactory::createPrivateKeyMethodProviderInstance(
 
   // We need to get more RSA key params in order to be able to use BoringSSL signing functions.
   std::string private_key = THROW_OR_RETURN_VALUE(
-      Config::DataSource::read(conf.private_key(), false,
-                               private_key_provider_context.serverFactoryContext().api()),
+      Config::DataSource::read(conf.private_key(), false, private_key_provider_context.api()),
       std::string);
 
   bssl::UniquePtr<BIO> bio(

--- a/contrib/cryptomb/private_key_providers/test/fake_factory.h
+++ b/contrib/cryptomb/private_key_providers/test/fake_factory.h
@@ -51,7 +51,7 @@ public:
   // Ssl::PrivateKeyMethodProviderInstanceFactory
   Ssl::PrivateKeyMethodProviderSharedPtr createPrivateKeyMethodProviderInstance(
       const envoy::extensions::transport_sockets::tls::v3::PrivateKeyProvider& message,
-      Server::Configuration::TransportSocketFactoryContext& private_key_provider_context) override;
+      Server::Configuration::ServerFactoryContext& private_key_provider_context) override;
   std::string name() const override { return "cryptomb"; };
 
 private:

--- a/contrib/qat/private_key_providers/source/config.cc
+++ b/contrib/qat/private_key_providers/source/config.cc
@@ -25,7 +25,7 @@ namespace Qat {
 Ssl::PrivateKeyMethodProviderSharedPtr
 QatPrivateKeyMethodFactory::createPrivateKeyMethodProviderInstance(
     const envoy::extensions::transport_sockets::tls::v3::PrivateKeyProvider& proto_config,
-    Server::Configuration::TransportSocketFactoryContext& private_key_provider_context) {
+    Server::Configuration::ServerFactoryContext& private_key_provider_context) {
   ProtobufTypes::MessagePtr message = std::make_unique<
       envoy::extensions::private_key_providers::qat::v3alpha::QatPrivateKeyMethodConfig>();
 

--- a/contrib/qat/private_key_providers/source/config.h
+++ b/contrib/qat/private_key_providers/source/config.h
@@ -17,7 +17,7 @@ class QatPrivateKeyMethodFactory : public Ssl::PrivateKeyMethodProviderInstanceF
   // Ssl::PrivateKeyMethodProviderInstanceFactory
   Ssl::PrivateKeyMethodProviderSharedPtr createPrivateKeyMethodProviderInstance(
       const envoy::extensions::transport_sockets::tls::v3::PrivateKeyProvider& message,
-      Server::Configuration::TransportSocketFactoryContext& private_key_provider_context) override;
+      Server::Configuration::ServerFactoryContext& private_key_provider_context) override;
 
 public:
   std::string name() const override { return "qat"; };

--- a/contrib/qat/private_key_providers/source/qat_private_key_provider.cc
+++ b/contrib/qat/private_key_providers/source/qat_private_key_provider.cc
@@ -347,11 +347,10 @@ void QatPrivateKeyMethodProvider::unregisterPrivateKeyMethod(SSL* ssl) {
 
 QatPrivateKeyMethodProvider::QatPrivateKeyMethodProvider(
     const envoy::extensions::private_key_providers::qat::v3alpha::QatPrivateKeyMethodConfig& conf,
-    Server::Configuration::TransportSocketFactoryContext& factory_context,
-    LibQatCryptoSharedPtr libqat)
-    : api_(factory_context.serverFactoryContext().api()), libqat_(libqat) {
+    Server::Configuration::ServerFactoryContext& factory_context, LibQatCryptoSharedPtr libqat)
+    : api_(factory_context.api()), libqat_(libqat) {
 
-  manager_ = factory_context.serverFactoryContext().singletonManager().getTyped<QatManager>(
+  manager_ = factory_context.singletonManager().getTyped<QatManager>(
       SINGLETON_MANAGER_REGISTERED_NAME(qat_manager),
       [libqat] { return std::make_shared<QatManager>(libqat); });
 

--- a/contrib/qat/private_key_providers/source/qat_private_key_provider.h
+++ b/contrib/qat/private_key_providers/source/qat_private_key_provider.h
@@ -40,7 +40,7 @@ public:
   QatPrivateKeyMethodProvider(
       const envoy::extensions::private_key_providers::qat::v3alpha::QatPrivateKeyMethodConfig&
           config,
-      Server::Configuration::TransportSocketFactoryContext& private_key_provider_context,
+      Server::Configuration::ServerFactoryContext& private_key_provider_context,
       LibQatCryptoSharedPtr libqat);
   // Ssl::PrivateKeyMethodProvider
   void registerPrivateKeyMethod(SSL* ssl, Ssl::PrivateKeyConnectionCallbacks& cb,

--- a/contrib/qat/private_key_providers/test/fake_factory.cc
+++ b/contrib/qat/private_key_providers/test/fake_factory.cc
@@ -154,7 +154,7 @@ CpaStatus FakeLibQatCryptoImpl::cpaCyStopInstance(CpaInstanceHandle instance_han
 Ssl::PrivateKeyMethodProviderSharedPtr
 FakeQatPrivateKeyMethodFactory::createPrivateKeyMethodProviderInstance(
     const envoy::extensions::transport_sockets::tls::v3::PrivateKeyProvider& proto_config,
-    Server::Configuration::TransportSocketFactoryContext& private_key_provider_context) {
+    Server::Configuration::ServerFactoryContext& private_key_provider_context) {
   ProtobufTypes::MessagePtr message = std::make_unique<
       envoy::extensions::private_key_providers::qat::v3alpha::QatPrivateKeyMethodConfig>();
 

--- a/contrib/qat/private_key_providers/test/fake_factory.h
+++ b/contrib/qat/private_key_providers/test/fake_factory.h
@@ -78,7 +78,7 @@ public:
   // Ssl::PrivateKeyMethodProviderInstanceFactory
   Ssl::PrivateKeyMethodProviderSharedPtr createPrivateKeyMethodProviderInstance(
       const envoy::extensions::transport_sockets::tls::v3::PrivateKeyProvider& message,
-      Server::Configuration::TransportSocketFactoryContext& private_key_provider_context) override;
+      Server::Configuration::ServerFactoryContext& private_key_provider_context) override;
   std::string name() const override { return "qat"; };
 };
 

--- a/contrib/qat/private_key_providers/test/ops_test.cc
+++ b/contrib/qat/private_key_providers/test/ops_test.cc
@@ -251,8 +251,8 @@ TEST_F(QatProviderRsaTest, TestQatDeviceInit) {
 
   // no device found
   libqat_->icpSalUserStart_return_value_ = CPA_STATUS_FAIL;
-  Ssl::PrivateKeyMethodProviderSharedPtr provider =
-      std::make_shared<QatPrivateKeyMethodProvider>(conf, factory_context_, libqat_);
+  Ssl::PrivateKeyMethodProviderSharedPtr provider = std::make_shared<QatPrivateKeyMethodProvider>(
+      conf, factory_context_.server_context_, libqat_);
   EXPECT_EQ(provider->isAvailable(), false);
   delete private_key;
 }

--- a/envoy/server/factory_context.h
+++ b/envoy/server/factory_context.h
@@ -145,6 +145,11 @@ public:
    * @return the server regex engine.
    */
   virtual Regex::Engine& regexEngine() PURE;
+
+  /**
+   * @return Ssl::ContextManager& the SSL context manager.
+   */
+  virtual Ssl::ContextManager& sslContextManager() PURE;
 };
 
 /**

--- a/envoy/server/transport_socket_config.h
+++ b/envoy/server/transport_socket_config.h
@@ -49,11 +49,6 @@ public:
   virtual ProtobufMessage::ValidationVisitor& messageValidationVisitor() PURE;
 
   /**
-   * @return Ssl::ContextManager& the SSL context manager.
-   */
-  virtual Ssl::ContextManager& sslContextManager() PURE;
-
-  /**
    * @return Stats::Scope& the transport socket's stats scope.
    */
   virtual Stats::Scope& statsScope() PURE;

--- a/envoy/ssl/private_key/BUILD
+++ b/envoy/ssl/private_key/BUILD
@@ -26,6 +26,7 @@ envoy_cc_library(
         ":private_key_interface",
         "//envoy/config:typed_config_interface",
         "//envoy/registry",
+        "//envoy/server:factory_context_interface",
         "@envoy_api//envoy/extensions/transport_sockets/tls/v3:pkg_cc_proto",
     ],
 )

--- a/envoy/ssl/private_key/private_key.h
+++ b/envoy/ssl/private_key/private_key.h
@@ -14,7 +14,7 @@ namespace Envoy {
 namespace Server {
 namespace Configuration {
 // Prevent a dependency loop with the forward declaration.
-class TransportSocketFactoryContext;
+class ServerFactoryContext;
 } // namespace Configuration
 } // namespace Server
 
@@ -88,7 +88,7 @@ public:
    */
   virtual PrivateKeyMethodProviderSharedPtr createPrivateKeyMethodProvider(
       const envoy::extensions::transport_sockets::tls::v3::PrivateKeyProvider& config,
-      Envoy::Server::Configuration::TransportSocketFactoryContext& factory_context) PURE;
+      Envoy::Server::Configuration::ServerFactoryContext& factory_context) PURE;
 };
 
 } // namespace Ssl

--- a/envoy/ssl/private_key/private_key_config.h
+++ b/envoy/ssl/private_key/private_key_config.h
@@ -3,6 +3,7 @@
 #include "envoy/config/typed_config.h"
 #include "envoy/extensions/transport_sockets/tls/v3/cert.pb.h"
 #include "envoy/registry/registry.h"
+#include "envoy/server/factory_context.h"
 #include "envoy/ssl/private_key/private_key.h"
 
 namespace Envoy {
@@ -19,11 +20,11 @@ public:
    * unable to produce a PrivateKeyMethodProvider with the provided parameters, it should throw
    * an EnvoyException. The returned pointer should always be valid.
    * @param config supplies the custom proto configuration for the PrivateKeyMethodProvider
-   * @param context supplies the factory context
+   * @param context supplies the server factory context
    */
   virtual PrivateKeyMethodProviderSharedPtr createPrivateKeyMethodProviderInstance(
       const envoy::extensions::transport_sockets::tls::v3::PrivateKeyProvider& config,
-      Server::Configuration::TransportSocketFactoryContext& factory_context) PURE;
+      Server::Configuration::ServerFactoryContext& factory_context) PURE;
 
   std::string category() const override { return "envoy.tls.key_providers"; };
 };

--- a/mobile/test/common/integration/test_server.cc
+++ b/mobile/test/common/integration/test_server.cc
@@ -135,7 +135,7 @@ TestServer::TestServer()
   ON_CALL(factory_context_.server_context_, api()).WillByDefault(testing::ReturnRef(*api_));
   ON_CALL(factory_context_, statsScope())
       .WillByDefault(testing::ReturnRef(*stats_store_.rootScope()));
-  ON_CALL(factory_context_, sslContextManager())
+  ON_CALL(factory_context_.server_context_, sslContextManager())
       .WillByDefault(testing::ReturnRef(context_manager_));
 
   Envoy::ExtensionRegistry::registerFactories();

--- a/source/common/listener_manager/listener_impl.cc
+++ b/source/common/listener_manager/listener_impl.cc
@@ -335,8 +335,8 @@ ListenerImpl::ListenerImpl(const envoy::config::listener::v3::Listener& config,
                           }),
       transport_factory_context_(
           std::make_shared<Server::Configuration::TransportSocketFactoryContextImpl>(
-              parent_.server_.serverFactoryContext(), parent_.server_.sslContextManager(),
-              listenerScope(), parent_.server_.clusterManager(), validation_visitor_)),
+              parent_.server_.serverFactoryContext(), listenerScope(),
+              parent_.server_.clusterManager(), validation_visitor_)),
       quic_stat_names_(parent_.quicStatNames()),
       missing_listener_config_stats_({ALL_MISSING_LISTENER_CONFIG_STATS(
           POOL_COUNTER(listener_factory_context_->listenerScope()))}) {

--- a/source/common/quic/quic_client_transport_socket_factory.cc
+++ b/source/common/quic/quic_client_transport_socket_factory.cc
@@ -47,7 +47,8 @@ QuicClientTransportSocketFactory::QuicClientTransportSocketFactory(
     : QuicTransportSocketFactoryBase(factory_context.statsScope(), "client"),
       tls_slot_(factory_context.serverFactoryContext().threadLocal()) {
   auto factory_or_error = Extensions::TransportSockets::Tls::ClientSslSocketFactory::create(
-      std::move(config), factory_context.sslContextManager(), factory_context.statsScope());
+      std::move(config), factory_context.serverFactoryContext().sslContextManager(),
+      factory_context.statsScope());
   SET_AND_RETURN_IF_NOT_OK(factory_or_error.status(), creation_status);
   fallback_factory_ = std::move(*factory_or_error);
   tls_slot_.set([](Event::Dispatcher&) { return std::make_shared<ThreadLocalQuicConfig>(); });

--- a/source/common/quic/quic_server_transport_socket_factory.cc
+++ b/source/common/quic/quic_server_transport_socket_factory.cc
@@ -31,7 +31,8 @@ QuicServerTransportSocketConfigFactory::createTransportSocketFactory(
 
   auto factory_or_error = QuicServerTransportSocketFactory::create(
       PROTOBUF_GET_WRAPPED_OR_DEFAULT(quic_transport, enable_early_data, true),
-      context.statsScope(), std::move(server_config), context.sslContextManager(), server_names);
+      context.statsScope(), std::move(server_config),
+      context.serverFactoryContext().sslContextManager(), server_names);
   RETURN_IF_NOT_OK(factory_or_error.status());
   (*factory_or_error)->initialize();
   return std::move(*factory_or_error);

--- a/source/common/ssl/tls_certificate_config_impl.h
+++ b/source/common/ssl/tls_certificate_config_impl.h
@@ -14,7 +14,7 @@ class TlsCertificateConfigImpl : public TlsCertificateConfig {
 public:
   static absl::StatusOr<std::unique_ptr<TlsCertificateConfigImpl>>
   create(const envoy::extensions::transport_sockets::tls::v3::TlsCertificate& config,
-         Server::Configuration::TransportSocketFactoryContext& factory_context, Api::Api& api);
+         Server::Configuration::ServerFactoryContext& factory_context);
 
   const std::string& certificateChain() const override { return certificate_chain_; }
   const std::string& certificateChainPath() const override { return certificate_chain_path_; }
@@ -33,8 +33,7 @@ public:
 private:
   TlsCertificateConfigImpl(
       const envoy::extensions::transport_sockets::tls::v3::TlsCertificate& config,
-      Server::Configuration::TransportSocketFactoryContext& factory_context, Api::Api& api,
-      absl::Status& creation_status);
+      Server::Configuration::ServerFactoryContext& factory_context, absl::Status& creation_status);
 
   const std::string certificate_chain_;
   const std::string certificate_chain_path_;

--- a/source/common/tls/context_config_impl.cc
+++ b/source/common/tls/context_config_impl.cc
@@ -188,8 +188,8 @@ ContextConfigImpl::ContextConfigImpl(
   if (!tls_certificate_providers_.empty()) {
     for (auto& provider : tls_certificate_providers_) {
       if (provider->secret() != nullptr) {
-        auto config_or_error =
-            Ssl::TlsCertificateConfigImpl::create(*provider->secret(), factory_context, api_);
+        auto config_or_error = Ssl::TlsCertificateConfigImpl::create(
+            *provider->secret(), factory_context.serverFactoryContext());
         SET_AND_RETURN_IF_NOT_OK(config_or_error.status(), creation_status);
         tls_certificate_configs_.emplace_back(std::move(*config_or_error));
       }
@@ -241,8 +241,8 @@ void ContextConfigImpl::setSecretUpdateCallback(std::function<absl::Status()> ca
           for (const auto& tls_certificate_provider : tls_certificate_providers_) {
             auto* secret = tls_certificate_provider->secret();
             if (secret != nullptr) {
-              auto config_or_error =
-                  Ssl::TlsCertificateConfigImpl::create(*secret, factory_context_, api_);
+              auto config_or_error = Ssl::TlsCertificateConfigImpl::create(
+                  *secret, factory_context_.serverFactoryContext());
               RETURN_IF_NOT_OK(config_or_error.status());
               tls_certificate_configs_.emplace_back(std::move(*config_or_error));
             }

--- a/source/common/tls/private_key/private_key_manager_impl.cc
+++ b/source/common/tls/private_key/private_key_manager_impl.cc
@@ -11,7 +11,7 @@ namespace Tls {
 Envoy::Ssl::PrivateKeyMethodProviderSharedPtr
 PrivateKeyMethodManagerImpl::createPrivateKeyMethodProvider(
     const envoy::extensions::transport_sockets::tls::v3::PrivateKeyProvider& config,
-    Server::Configuration::TransportSocketFactoryContext& factory_context) {
+    Server::Configuration::ServerFactoryContext& factory_context) {
 
   Ssl::PrivateKeyMethodProviderInstanceFactory* factory =
       Registry::FactoryRegistry<Ssl::PrivateKeyMethodProviderInstanceFactory>::getFactory(

--- a/source/common/tls/private_key/private_key_manager_impl.h
+++ b/source/common/tls/private_key/private_key_manager_impl.h
@@ -14,7 +14,7 @@ public:
   // Ssl::PrivateKeyMethodManager
   Ssl::PrivateKeyMethodProviderSharedPtr createPrivateKeyMethodProvider(
       const envoy::extensions::transport_sockets::tls::v3::PrivateKeyProvider& config,
-      Server::Configuration::TransportSocketFactoryContext& factory_context) override;
+      Server::Configuration::ServerFactoryContext& factory_context) override;
 };
 
 } // namespace Tls

--- a/source/common/upstream/health_discovery_service.cc
+++ b/source/common/upstream/health_discovery_service.cc
@@ -538,8 +538,8 @@ ProdClusterInfoFactory::createClusterInfo(const CreateClusterInfoParams& params)
       params.stats_.createScope(fmt::format("cluster.{}.", params.cluster_.name()));
 
   Envoy::Server::Configuration::TransportSocketFactoryContextImpl factory_context(
-      params.server_context_, params.ssl_context_manager_, *scope,
-      params.server_context_.clusterManager(), params.server_context_.messageValidationVisitor());
+      params.server_context_, *scope, params.server_context_.clusterManager(),
+      params.server_context_.messageValidationVisitor());
 
   // TODO(JimmyCYJ): Support SDS for HDS cluster.
   Network::UpstreamTransportSocketFactoryPtr socket_factory = THROW_OR_RETURN_VALUE(

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -1606,8 +1606,8 @@ ClusterImplBase::ClusterImplBase(const envoy::config::cluster::v3::Cluster& clus
   auto stats_scope = generateStatsScope(cluster, server_context.serverScope().store());
   transport_factory_context_ =
       std::make_unique<Server::Configuration::TransportSocketFactoryContextImpl>(
-          server_context, cluster_context.sslContextManager(), *stats_scope,
-          cluster_context.clusterManager(), cluster_context.messageValidationVisitor());
+          server_context, *stats_scope, cluster_context.clusterManager(),
+          cluster_context.messageValidationVisitor());
   transport_factory_context_->setInitManager(init_manager_);
 
   auto socket_factory_or_error = createTransportSocketFactory(cluster, *transport_factory_context_);

--- a/source/extensions/transport_sockets/tls/downstream_config.cc
+++ b/source/extensions/transport_sockets/tls/downstream_config.cc
@@ -24,8 +24,8 @@ DownstreamSslSocketFactory::createTransportSocketFactory(
           context, false);
   RETURN_IF_NOT_OK(server_config_or_error.status());
   return ServerSslSocketFactory::create(std::move(server_config_or_error.value()),
-                                        context.sslContextManager(), context.statsScope(),
-                                        server_names);
+                                        context.serverFactoryContext().sslContextManager(),
+                                        context.statsScope(), server_names);
 }
 
 ProtobufTypes::MessagePtr DownstreamSslSocketFactory::createEmptyConfigProto() {

--- a/source/extensions/transport_sockets/tls/upstream_config.cc
+++ b/source/extensions/transport_sockets/tls/upstream_config.cc
@@ -24,7 +24,8 @@ UpstreamSslSocketFactory::createTransportSocketFactory(
           context);
   RETURN_IF_NOT_OK(client_config_or_error.status());
   return ClientSslSocketFactory::create(std::move(client_config_or_error.value()),
-                                        context.sslContextManager(), context.statsScope());
+                                        context.serverFactoryContext().sslContextManager(),
+                                        context.statsScope());
 }
 
 ProtobufTypes::MessagePtr UpstreamSslSocketFactory::createEmptyConfigProto() {

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -207,11 +207,11 @@ public:
   envoy::config::bootstrap::v3::Bootstrap& bootstrap() override { return server_.bootstrap(); }
   OverloadManager& overloadManager() override { return server_.overloadManager(); }
   OverloadManager& nullOverloadManager() override { return server_.nullOverloadManager(); }
+  Ssl::ContextManager& sslContextManager() override { return server_.sslContextManager(); }
   bool healthCheckFailed() const override { return server_.healthCheckFailed(); }
 
   // Configuration::TransportSocketFactoryContext
   ServerFactoryContext& serverFactoryContext() override { return *this; }
-  Ssl::ContextManager& sslContextManager() override { return server_.sslContextManager(); }
   Secret::SecretManager& secretManager() override { return server_.secretManager(); }
   Stats::Scope& statsScope() override { return *server_scope_; }
   Init::Manager& initManager() override { return server_.initManager(); }

--- a/source/server/transport_socket_config_impl.h
+++ b/source/server/transport_socket_config_impl.h
@@ -13,11 +13,10 @@ namespace Configuration {
 class TransportSocketFactoryContextImpl : public TransportSocketFactoryContext {
 public:
   TransportSocketFactoryContextImpl(Server::Configuration::ServerFactoryContext& server_context,
-                                    Ssl::ContextManager& context_manager, Stats::Scope& stats_scope,
-                                    Upstream::ClusterManager& cm,
+                                    Stats::Scope& stats_scope, Upstream::ClusterManager& cm,
                                     ProtobufMessage::ValidationVisitor& validation_visitor)
-      : server_context_(server_context), context_manager_(context_manager),
-        stats_scope_(stats_scope), cluster_manager_(cm), validation_visitor_(validation_visitor) {}
+      : server_context_(server_context), stats_scope_(stats_scope), cluster_manager_(cm),
+        validation_visitor_(validation_visitor) {}
 
   /**
    * Pass an init manager to register dynamic secret provider.
@@ -31,7 +30,6 @@ public:
   ProtobufMessage::ValidationVisitor& messageValidationVisitor() override {
     return validation_visitor_;
   }
-  Ssl::ContextManager& sslContextManager() override { return context_manager_; }
   Stats::Scope& statsScope() override { return stats_scope_; }
   Secret::SecretManager& secretManager() override {
     return clusterManager().clusterManagerFactory().secretManager();
@@ -43,7 +41,6 @@ public:
 
 private:
   Server::Configuration::ServerFactoryContext& server_context_;
-  Ssl::ContextManager& context_manager_;
   Stats::Scope& stats_scope_;
   Upstream::ClusterManager& cluster_manager_;
   ProtobufMessage::ValidationVisitor& validation_visitor_;

--- a/test/common/http/conn_pool_grid_test.cc
+++ b/test/common/http/conn_pool_grid_test.cc
@@ -167,8 +167,6 @@ public:
         quic_stat_names_(store_.symbolTable()) {
     ON_CALL(factory_context_.server_context_, threadLocal())
         .WillByDefault(ReturnRef(thread_local_));
-    ON_CALL(factory_context_.server_context_, threadLocal())
-        .WillByDefault(ReturnRef(thread_local_));
     // Make sure we test happy eyeballs code.
     address_list_ = {*Network::Utility::resolveUrl("tcp://127.0.0.1:9000"),
                      *Network::Utility::resolveUrl("tcp://[::]:9000")};

--- a/test/common/http/http3/conn_pool_test.cc
+++ b/test/common/http/http3/conn_pool_test.cc
@@ -41,7 +41,9 @@ class Http3ConnPoolImplTest : public Event::TestUsingSimulatedTime, public testi
 public:
   Http3ConnPoolImplTest() {
     ON_CALL(context_.server_context_, threadLocal()).WillByDefault(ReturnRef(thread_local_));
-    EXPECT_CALL(context_.context_manager_, createSslClientContext(_, _))
+    ON_CALL(context_.server_context_, sslContextManager())
+        .WillByDefault(ReturnRef(ssl_context_manager_));
+    EXPECT_CALL(ssl_context_manager_, createSslClientContext(_, _))
         .WillRepeatedly(Return(ssl_context_));
     factory_ = *Quic::QuicClientTransportSocketFactory::create(
         std::unique_ptr<Envoy::Ssl::ClientContextConfig>(
@@ -89,6 +91,7 @@ public:
       new Upstream::HostDescription::AddressVector{
           *Network::Utility::resolveUrl("tcp://127.0.0.1:3000"),
           *Network::Utility::resolveUrl("tcp://[::]:3000")}};
+  NiceMock<Ssl::MockContextManager> ssl_context_manager_;
   NiceMock<Server::Configuration::MockTransportSocketFactoryContext> context_;
   std::unique_ptr<Quic::QuicClientTransportSocketFactory> factory_;
   Ssl::ClientContextSharedPtr ssl_context_{new Ssl::MockClientContext()};

--- a/test/common/listener_manager/listener_manager_impl_test.h
+++ b/test/common/listener_manager/listener_manager_impl_test.h
@@ -76,6 +76,8 @@ protected:
   void SetUp() override {
     ON_CALL(server_, api()).WillByDefault(ReturnRef(*api_));
     ON_CALL(*server_.server_factory_context_, api()).WillByDefault(ReturnRef(*api_));
+    ON_CALL(*server_.server_factory_context_, sslContextManager())
+        .WillByDefault(ReturnRef(server_.ssl_context_manager_));
     EXPECT_CALL(worker_factory_, createWorker_()).WillOnce(Return(worker_));
     ON_CALL(server_.validation_context_, staticValidationVisitor())
         .WillByDefault(ReturnRef(validation_visitor));

--- a/test/common/quic/client_connection_factory_impl_test.cc
+++ b/test/common/quic/client_connection_factory_impl_test.cc
@@ -31,6 +31,8 @@ class QuicNetworkConnectionTest : public Event::TestUsingSimulatedTime,
 protected:
   void initialize() {
     ON_CALL(context_.server_context_, threadLocal()).WillByDefault(ReturnRef(thread_local_));
+    ON_CALL(context_.server_context_, sslContextManager())
+        .WillByDefault(ReturnRef(ssl_context_manager_));
     EXPECT_CALL(*cluster_, perConnectionBufferLimitBytes()).WillOnce(Return(45));
     EXPECT_CALL(*cluster_, connectTimeout).WillOnce(Return(std::chrono::seconds(10)));
     auto* protocol_options = cluster_->http3_options_.mutable_quic_protocol_options();
@@ -66,7 +68,7 @@ protected:
     test_address_ = *Network::Utility::resolveUrl(absl::StrCat(
         "tcp://", Network::Test::getLoopbackAddressUrlString(GetParam()), ":", PEER_PORT));
     Ssl::ClientContextSharedPtr context{new Ssl::MockClientContext()};
-    EXPECT_CALL(context_.context_manager_, createSslClientContext(_, _)).WillOnce(Return(context));
+    EXPECT_CALL(ssl_context_manager_, createSslClientContext(_, _)).WillOnce(Return(context));
     factory_ = *Quic::QuicClientTransportSocketFactory::create(
         std::unique_ptr<Envoy::Ssl::ClientContextConfig>(
             new NiceMock<Ssl::MockClientContextConfig>),
@@ -79,6 +81,7 @@ protected:
   }
 
   NiceMock<Event::MockDispatcher> dispatcher_;
+  testing::NiceMock<Ssl::MockContextManager> ssl_context_manager_;
   std::unique_ptr<PersistentQuicInfoImpl> quic_info_;
   std::shared_ptr<Upstream::MockClusterInfo> cluster_{new NiceMock<Upstream::MockClusterInfo>()};
   Upstream::HostSharedPtr host_{new NiceMock<Upstream::MockHost>};

--- a/test/common/secret/sds_api_test.cc
+++ b/test/common/secret/sds_api_test.cc
@@ -179,7 +179,8 @@ TEST_F(SdsApiTest, DynamicTlsCertificateUpdateSuccess) {
   EXPECT_TRUE(subscription_factory_.callbacks_->onConfigUpdate(decoded_resources.refvec_, "").ok());
 
   testing::NiceMock<Server::Configuration::MockTransportSocketFactoryContext> ctx;
-  auto tls_config = Ssl::TlsCertificateConfigImpl::create(*sds_api.secret(), ctx, *api_).value();
+  auto tls_config =
+      Ssl::TlsCertificateConfigImpl::create(*sds_api.secret(), ctx.server_context_).value();
   const std::string cert_pem = "{{ test_rundir }}/test/common/tls/test_data/selfsigned_cert.pem";
   EXPECT_EQ(TestEnvironment::readFileToStringForTest(TestEnvironment::substitute(cert_pem)),
             tls_config->certificateChain());
@@ -600,7 +601,8 @@ TEST_F(SdsApiTest, DeltaUpdateSuccess) {
       subscription_factory_.callbacks_->onConfigUpdate(decoded_resources.refvec_, {}, "").ok());
 
   testing::NiceMock<Server::Configuration::MockTransportSocketFactoryContext> ctx;
-  auto tls_config = Ssl::TlsCertificateConfigImpl::create(*sds_api.secret(), ctx, *api_).value();
+  auto tls_config =
+      Ssl::TlsCertificateConfigImpl::create(*sds_api.secret(), ctx.server_context_).value();
   const std::string cert_pem = "{{ test_rundir }}/test/common/tls/test_data/selfsigned_cert.pem";
   EXPECT_EQ(TestEnvironment::readFileToStringForTest(TestEnvironment::substitute(cert_pem)),
             tls_config->certificateChain());

--- a/test/common/tls/context_impl_test.cc
+++ b/test/common/tls/context_impl_test.cc
@@ -2073,7 +2073,8 @@ TEST_F(ServerContextConfigImplTest, PrivateKeyMethodLoadFailureNoProvider) {
   envoy::extensions::transport_sockets::tls::v3::DownstreamTlsContext tls_context;
   NiceMock<Ssl::MockContextManager> context_manager;
   NiceMock<Ssl::MockPrivateKeyMethodManager> private_key_method_manager;
-  EXPECT_CALL(factory_context_, sslContextManager()).WillOnce(ReturnRef(context_manager));
+  EXPECT_CALL(factory_context_.server_context_, sslContextManager())
+      .WillOnce(ReturnRef(context_manager));
   EXPECT_CALL(context_manager, privateKeyMethodManager())
       .WillOnce(ReturnRef(private_key_method_manager));
   const std::string tls_context_yaml = R"EOF(
@@ -2098,7 +2099,8 @@ TEST_F(ServerContextConfigImplTest, PrivateKeyMethodLoadFailureNoProviderFallbac
   envoy::extensions::transport_sockets::tls::v3::DownstreamTlsContext tls_context;
   NiceMock<Ssl::MockContextManager> context_manager;
   NiceMock<Ssl::MockPrivateKeyMethodManager> private_key_method_manager;
-  EXPECT_CALL(factory_context_, sslContextManager()).WillOnce(ReturnRef(context_manager));
+  EXPECT_CALL(factory_context_.server_context_, sslContextManager())
+      .WillOnce(ReturnRef(context_manager));
   EXPECT_CALL(context_manager, privateKeyMethodManager())
       .WillOnce(ReturnRef(private_key_method_manager));
   const std::string tls_context_yaml = R"EOF(
@@ -2129,7 +2131,8 @@ TEST_F(ServerContextConfigImplTest, PrivateKeyMethodLoadFailureNoMethod) {
   auto private_key_method_provider_ptr =
       std::make_shared<NiceMock<Ssl::MockPrivateKeyMethodProvider>>();
   ContextManagerImpl manager(server_factory_context_);
-  EXPECT_CALL(factory_context_, sslContextManager()).WillOnce(ReturnRef(context_manager));
+  EXPECT_CALL(factory_context_.server_context_, sslContextManager())
+      .WillOnce(ReturnRef(context_manager));
   EXPECT_CALL(context_manager, privateKeyMethodManager())
       .WillOnce(ReturnRef(private_key_method_manager));
   EXPECT_CALL(private_key_method_manager, createPrivateKeyMethodProvider(_, _))
@@ -2164,7 +2167,8 @@ TEST_F(ServerContextConfigImplTest, PrivateKeyMethodLoadSuccess) {
   NiceMock<Ssl::MockPrivateKeyMethodManager> private_key_method_manager;
   auto private_key_method_provider_ptr =
       std::make_shared<NiceMock<Ssl::MockPrivateKeyMethodProvider>>();
-  EXPECT_CALL(factory_context_, sslContextManager()).WillOnce(ReturnRef(context_manager));
+  EXPECT_CALL(factory_context_.server_context_, sslContextManager())
+      .WillOnce(ReturnRef(context_manager));
   EXPECT_CALL(context_manager, privateKeyMethodManager())
       .WillOnce(ReturnRef(private_key_method_manager));
   EXPECT_CALL(private_key_method_manager, createPrivateKeyMethodProvider(_, _))
@@ -2193,7 +2197,8 @@ TEST_F(ServerContextConfigImplTest, PrivateKeyMethodFallback) {
   NiceMock<Ssl::MockPrivateKeyMethodManager> private_key_method_manager;
   auto private_key_method_provider_ptr =
       std::make_shared<NiceMock<Ssl::MockPrivateKeyMethodProvider>>();
-  EXPECT_CALL(factory_context_, sslContextManager()).WillOnce(ReturnRef(context_manager));
+  EXPECT_CALL(factory_context_.server_context_, sslContextManager())
+      .WillOnce(ReturnRef(context_manager));
   EXPECT_CALL(context_manager, privateKeyMethodManager())
       .WillOnce(ReturnRef(private_key_method_manager));
   EXPECT_CALL(private_key_method_manager, createPrivateKeyMethodProvider(_, _))

--- a/test/common/tls/ssl_socket_test.cc
+++ b/test/common/tls/ssl_socket_test.cc
@@ -416,7 +416,7 @@ void testUtil(const TestUtilOptions& options) {
       test_private_key_method_factory(test_factory);
   PrivateKeyMethodManagerImpl private_key_method_manager;
   if (options.expectedPrivateKeyMethod()) {
-    EXPECT_CALL(transport_socket_factory_context, sslContextManager())
+    EXPECT_CALL(transport_socket_factory_context.server_context_, sslContextManager())
         .WillOnce(ReturnRef(context_manager))
         .WillRepeatedly(ReturnRef(context_manager));
     EXPECT_CALL(context_manager, privateKeyMethodManager())

--- a/test/common/tls/test_private_key_method_provider.cc
+++ b/test/common/tls/test_private_key_method_provider.cc
@@ -315,7 +315,7 @@ int TestPrivateKeyMethodProvider::ecdsaConnectionIndex() {
 
 TestPrivateKeyMethodProvider::TestPrivateKeyMethodProvider(
     const ProtobufWkt::Any& typed_config,
-    Server::Configuration::TransportSocketFactoryContext& factory_context) {
+    Server::Configuration::ServerFactoryContext& factory_context) {
   std::string private_key_path;
 
   auto config = MessageUtil::anyConvert<ProtobufWkt::Struct>(typed_config);
@@ -359,11 +359,8 @@ TestPrivateKeyMethodProvider::TestPrivateKeyMethodProvider(
     return;
   }
 
-  std::string private_key = factory_context.serverFactoryContext()
-                                .api()
-                                .fileSystem()
-                                .fileReadToEnd(private_key_path)
-                                .value();
+  std::string private_key =
+      factory_context.api().fileSystem().fileReadToEnd(private_key_path).value();
   bssl::UniquePtr<BIO> bio(
       BIO_new_mem_buf(const_cast<char*>(private_key.data()), private_key.size()));
   bssl::UniquePtr<EVP_PKEY> pkey(PEM_read_bio_PrivateKey(bio.get(), nullptr, nullptr, nullptr));

--- a/test/common/tls/test_private_key_method_provider.h
+++ b/test/common/tls/test_private_key_method_provider.h
@@ -63,9 +63,8 @@ private:
 
 class TestPrivateKeyMethodProvider : public virtual Ssl::PrivateKeyMethodProvider {
 public:
-  TestPrivateKeyMethodProvider(
-      const ProtobufWkt::Any& typed_config,
-      Server::Configuration::TransportSocketFactoryContext& factory_context);
+  TestPrivateKeyMethodProvider(const ProtobufWkt::Any& typed_config,
+                               Server::Configuration::ServerFactoryContext& factory_context);
   // Ssl::PrivateKeyMethodProvider
   void registerPrivateKeyMethod(SSL* ssl, Ssl::PrivateKeyConnectionCallbacks& cb,
                                 Event::Dispatcher& dispatcher) override;
@@ -89,7 +88,7 @@ public:
   // Ssl::PrivateKeyMethodProviderInstanceFactory
   Ssl::PrivateKeyMethodProviderSharedPtr createPrivateKeyMethodProviderInstance(
       const envoy::extensions::transport_sockets::tls::v3::PrivateKeyProvider& config,
-      Server::Configuration::TransportSocketFactoryContext& factory_context) override {
+      Server::Configuration::ServerFactoryContext& factory_context) override {
     return std::make_shared<TestPrivateKeyMethodProvider>(config.typed_config(), factory_context);
   }
 

--- a/test/common/upstream/hds_test.cc
+++ b/test/common/upstream/hds_test.cc
@@ -63,6 +63,7 @@ protected:
         async_client_(new Grpc::MockAsyncClient()),
         api_(Api::createApiForTest(stats_store_, random_)), ssl_context_manager_(server_context_) {
     ON_CALL(server_context_, api()).WillByDefault(ReturnRef(*api_));
+    ON_CALL(server_context_, sslContextManager()).WillByDefault(ReturnRef(ssl_context_manager_));
     node_.set_id("hds-node");
   }
 
@@ -616,8 +617,7 @@ TEST_F(HdsTest, TestSocketContext) {
         Envoy::Stats::ScopeSharedPtr scope =
             params.stats_.createScope(fmt::format("cluster.{}.", params.cluster_.name()));
         Envoy::Server::Configuration::TransportSocketFactoryContextImpl factory_context(
-            params.server_context_, params.ssl_context_manager_, *scope,
-            params.server_context_.clusterManager(),
+            params.server_context_, *scope, params.server_context_.clusterManager(),
             params.server_context_.messageValidationVisitor());
 
         // Create a mock socket_factory for the scope of this unit test.
@@ -1107,8 +1107,7 @@ TEST_F(HdsTest, TestUpdateSocketContext) {
         Envoy::Stats::ScopeSharedPtr scope =
             params.stats_.createScope(fmt::format("cluster.{}.", params.cluster_.name()));
         Envoy::Server::Configuration::TransportSocketFactoryContextImpl factory_context(
-            params.server_context_, params.ssl_context_manager_, *scope,
-            params.server_context_.clusterManager(),
+            params.server_context_, *scope, params.server_context_.clusterManager(),
             params.server_context_.messageValidationVisitor());
 
         // Create a mock socket_factory for the scope of this unit test.

--- a/test/extensions/clusters/eds/leds_test.cc
+++ b/test/extensions/clusters/eds/leds_test.cc
@@ -89,8 +89,7 @@ public:
 
     cluster_scope_ = stats_.createScope("cluster.xds_cluster.");
     Envoy::Server::Configuration::TransportSocketFactoryContextImpl factory_context(
-        server_context_, ssl_context_manager_, *cluster_scope_, server_context_.cluster_manager_,
-        validation_visitor_);
+        server_context_, *cluster_scope_, server_context_.cluster_manager_, validation_visitor_);
 
     // Setup LEDS subscription.
     EXPECT_CALL(server_context_.cluster_manager_.subscription_factory_,
@@ -151,7 +150,6 @@ public:
   NiceMock<Server::Configuration::MockServerFactoryContext> server_context_;
   uint32_t callbacks_called_counter_{0};
   Stats::TestUtil::TestStore stats_;
-  Ssl::MockContextManager ssl_context_manager_;
   Envoy::Stats::ScopeSharedPtr cluster_scope_;
   LedsSubscriptionPtr leds_subscription_;
   NiceMock<Random::MockRandomGenerator> random_;

--- a/test/integration/base_integration_test.cc
+++ b/test/integration/base_integration_test.cc
@@ -74,7 +74,8 @@ BaseIntegrationTest::BaseIntegrationTest(const InstanceConstSharedPtrFn& upstrea
       }));
   ON_CALL(factory_context_.server_context_, api()).WillByDefault(ReturnRef(*api_));
   ON_CALL(factory_context_, statsScope()).WillByDefault(ReturnRef(*stats_store_.rootScope()));
-  ON_CALL(factory_context_, sslContextManager()).WillByDefault(ReturnRef(context_manager_));
+  ON_CALL(factory_context_.server_context_, sslContextManager())
+      .WillByDefault(ReturnRef(context_manager_));
   ON_CALL(factory_context_.server_context_, threadLocal()).WillByDefault(ReturnRef(thread_local_));
 
 #ifndef ENVOY_ADMIN_FUNCTIONALITY

--- a/test/integration/quic_http_integration_test.cc
+++ b/test/integration/quic_http_integration_test.cc
@@ -323,7 +323,8 @@ public:
     NiceMock<Server::Configuration::MockTransportSocketFactoryContext> context;
     ON_CALL(context.server_context_, api()).WillByDefault(testing::ReturnRef(*api_));
     ON_CALL(context, statsScope()).WillByDefault(testing::ReturnRef(stats_scope_));
-    ON_CALL(context, sslContextManager()).WillByDefault(testing::ReturnRef(context_manager_));
+    ON_CALL(context.server_context_, sslContextManager())
+        .WillByDefault(testing::ReturnRef(context_manager_));
     ON_CALL(context.server_context_, threadLocal())
         .WillByDefault(testing::ReturnRef(thread_local_));
     envoy::extensions::transport_sockets::quic::v3::QuicUpstreamTransport

--- a/test/integration/ssl_utility.cc
+++ b/test/integration/ssl_utility.cc
@@ -131,6 +131,8 @@ createUpstreamSslContext(ContextManager& context_manager, Api::Api& api, bool us
 
   NiceMock<Server::Configuration::MockTransportSocketFactoryContext> mock_factory_ctx;
   ON_CALL(mock_factory_ctx.server_context_, api()).WillByDefault(ReturnRef(api));
+  ON_CALL(mock_factory_ctx.server_context_, sslContextManager())
+      .WillByDefault(ReturnRef(context_manager));
   auto cfg = *Extensions::TransportSockets::Tls::ServerContextConfigImpl::create(
       tls_context, mock_factory_ctx, false);
 
@@ -144,7 +146,6 @@ createUpstreamSslContext(ContextManager& context_manager, Api::Api& api, bool us
   quic_config.mutable_downstream_tls_context()->MergeFrom(tls_context);
   ON_CALL(mock_factory_ctx, statsScope())
       .WillByDefault(ReturnRef(*upstream_stats_store->rootScope()));
-  ON_CALL(mock_factory_ctx, sslContextManager()).WillByDefault(ReturnRef(context_manager));
 
   std::vector<std::string> server_names;
   auto& config_factory = Config::Utility::getAndCheckFactoryByName<

--- a/test/integration/utility.cc
+++ b/test/integration/utility.cc
@@ -148,7 +148,8 @@ IntegrationUtil::createQuicUpstreamTransportSocketFactory(Api::Api& api, Stats::
   NiceMock<Server::Configuration::MockTransportSocketFactoryContext> context;
   ON_CALL(context.server_context_, api()).WillByDefault(testing::ReturnRef(api));
   ON_CALL(context, statsScope()).WillByDefault(testing::ReturnRef(*store.rootScope()));
-  ON_CALL(context, sslContextManager()).WillByDefault(testing::ReturnRef(context_manager));
+  ON_CALL(context.server_context_, sslContextManager())
+      .WillByDefault(testing::ReturnRef(context_manager));
   ON_CALL(context.server_context_, threadLocal()).WillByDefault(testing::ReturnRef(threadlocal));
   envoy::extensions::transport_sockets::quic::v3::QuicUpstreamTransport
       quic_transport_socket_config;

--- a/test/mocks/server/server_factory_context.cc
+++ b/test/mocks/server/server_factory_context.cc
@@ -37,6 +37,7 @@ MockServerFactoryContext::MockServerFactoryContext()
   ON_CALL(*this, options()).WillByDefault(ReturnRef(options_));
   ON_CALL(*this, overloadManager()).WillByDefault(ReturnRef(overload_manager_));
   ON_CALL(*this, nullOverloadManager()).WillByDefault(ReturnRef(null_overload_manager_));
+  ON_CALL(*this, sslContextManager()).WillByDefault(ReturnRef(ssl_context_manager_));
 }
 MockServerFactoryContext::~MockServerFactoryContext() = default;
 

--- a/test/mocks/server/server_factory_context.h
+++ b/test/mocks/server/server_factory_context.h
@@ -27,6 +27,7 @@
 #include "test/mocks/server/options.h"
 #include "test/mocks/server/overload_manager.h"
 #include "test/mocks/server/server_lifecycle_notifier.h"
+#include "test/mocks/ssl/mocks.h"
 #include "test/mocks/stats/mocks.h"
 #include "test/mocks/thread_local/mocks.h"
 #include "test/mocks/tracing/mocks.h"
@@ -86,6 +87,7 @@ public:
   MOCK_METHOD(AccessLog::AccessLogManager&, accessLogManager, (), ());
   MOCK_METHOD(OverloadManager&, overloadManager, ());
   MOCK_METHOD(OverloadManager&, nullOverloadManager, ());
+  MOCK_METHOD(Ssl::ContextManager&, sslContextManager, ());
   MOCK_METHOD(bool, shouldBypassOverloadManager, (), (const));
   MOCK_METHOD(bool, healthCheckFailed, (), (const));
 
@@ -116,6 +118,7 @@ public:
   envoy::config::bootstrap::v3::Bootstrap bootstrap_;
   testing::NiceMock<MockOptions> options_;
   Regex::GoogleReEngine regex_engine_;
+  testing::NiceMock<Ssl::MockContextManager> ssl_context_manager_;
 };
 
 class MockGenericFactoryContext : public GenericFactoryContext {
@@ -170,6 +173,7 @@ public:
   MOCK_METHOD(AccessLog::AccessLogManager&, accessLogManager, (), ());
   MOCK_METHOD(OverloadManager&, overloadManager, ());
   MOCK_METHOD(OverloadManager&, nullOverloadManager, ());
+  MOCK_METHOD(Ssl::ContextManager&, sslContextManager, ());
   MOCK_METHOD(bool, shouldBypassOverloadManager, (), (const));
   MOCK_METHOD(bool, healthCheckFailed, (), (const));
 };

--- a/test/mocks/server/transport_socket_factory_context.cc
+++ b/test/mocks/server/transport_socket_factory_context.cc
@@ -17,7 +17,6 @@ MockTransportSocketFactoryContext::MockTransportSocketFactoryContext()
   ON_CALL(*this, clusterManager()).WillByDefault(ReturnRef(cluster_manager_));
   ON_CALL(*this, messageValidationVisitor())
       .WillByDefault(ReturnRef(ProtobufMessage::getStrictValidationVisitor()));
-  ON_CALL(*this, sslContextManager()).WillByDefault(ReturnRef(context_manager_));
   ON_CALL(*this, statsScope()).WillByDefault(ReturnRef(*store_.rootScope()));
 
   ON_CALL(server_context_, serverScope()).WillByDefault(ReturnRef(*store_.rootScope()));

--- a/test/mocks/server/transport_socket_factory_context.h
+++ b/test/mocks/server/transport_socket_factory_context.h
@@ -8,7 +8,6 @@
 #include "test/mocks/api/mocks.h"
 #include "test/mocks/server/options.h"
 #include "test/mocks/server/server_factory_context.h"
-#include "test/mocks/ssl/mocks.h"
 #include "test/mocks/stats/mocks.h"
 #include "test/mocks/upstream/cluster_manager.h"
 
@@ -28,7 +27,6 @@ public:
   MOCK_METHOD(ServerFactoryContext&, serverFactoryContext, ());
   MOCK_METHOD(Upstream::ClusterManager&, clusterManager, ());
   MOCK_METHOD(ProtobufMessage::ValidationVisitor&, messageValidationVisitor, ());
-  MOCK_METHOD(Ssl::ContextManager&, sslContextManager, ());
   MOCK_METHOD(Stats::Scope&, statsScope, ());
   MOCK_METHOD(Init::Manager&, initManager, ());
 
@@ -36,7 +34,6 @@ public:
   testing::NiceMock<Upstream::MockClusterManager> cluster_manager_;
   testing::NiceMock<Api::MockApi> api_;
   testing::NiceMock<MockConfigTracker> config_tracker_;
-  testing::NiceMock<Ssl::MockContextManager> context_manager_;
   testing::NiceMock<Stats::MockIsolatedStatsStore> store_;
   testing::NiceMock<Server::MockOptions> options_;
   std::unique_ptr<Secret::SecretManager> secret_manager_;

--- a/test/mocks/ssl/mocks.h
+++ b/test/mocks/ssl/mocks.h
@@ -214,7 +214,7 @@ public:
 
   MOCK_METHOD(PrivateKeyMethodProviderSharedPtr, createPrivateKeyMethodProvider,
               (const envoy::extensions::transport_sockets::tls::v3::PrivateKeyProvider& config,
-               Envoy::Server::Configuration::TransportSocketFactoryContext& factory_context));
+               Envoy::Server::Configuration::ServerFactoryContext& factory_context));
 };
 
 class MockPrivateKeyMethodProvider : public PrivateKeyMethodProvider {


### PR DESCRIPTION
Change-Id: I4dc033f55c300324389c57ed39c6ce30af3b657a

Commit Message: Refactor `PrivateKeyManager` factory to take the server context instead of the transport sockets context.  This enables independent ownership of TLS certificate configs by the certificate producer, instead of instantiating them per individual transport socket, which paves the way to the certificate provider framework.
Additional Description:
Risk Level: low, contrib feature stats scope is changed.
Testing: regression
Docs Changes: none
Release Notes: none