### PR TITLE
build: fix compile commands generation

### DIFF
--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -1026,6 +1026,7 @@ case $CI_TARGET in
         ;;
 
     refresh_compdb)
+        setup_clang_toolchain
         # Override the BAZEL_STARTUP_OPTIONS to setting different output directory.
         # So the compdb headers won't be overwritten by another bazel run.
         for i in "${!BAZEL_STARTUP_OPTIONS[@]}"; do


### PR DESCRIPTION
Adds `setup_clang_toolchain` to  properly generate compile_commands.json. Fixes [#36686](https://github.com/envoyproxy/envoy/issues/36686).

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Adds setup_clang_toolchain command to fix compile_commands.json generation.
Additional Description: Fixes #36686
Risk Level: low
Testing: Passing
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A