### PR TITLE
set is_ssl on upstream http filters with the upstreamInfo instead from downstreamInfo

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -21,7 +21,10 @@ minor_behavior_changes:
 
 bug_fixes:
 # *Changes expected to improve the state of the world and are unlikely to have negative effects*
-
+- area: upstream tcp tunneling http filters
+  change: |
+    A fix to a scenario where upstream is ssl and downstream is not or the other way around while using upstream http 
+    filters with tcp tunneling. ssl info is taken from the downstreamAddressProvider instead of the upstream_info.
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`
 - area: http


### PR DESCRIPTION

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
The downstream headers are being passed to the upstream headers and if is_ssl is true - it adds the relevant header to the scheme. This is_ssl flag is set according to the downstream info - meaning if the downstream is using ssl - so will the upstream. The problem arises when we want to use http connection from the downstream and https on upstream or the other way around. This fix will make it so we will take the is_ssl according to the upstream info.

adding all usecases in upstream.cc to take the sslConnection info from: upstreamInfo()->upstreamSslConnection()
instead of the downstreamAddressProvider()
Additional Description: None
Risk Level: Low
Testing: TBD - tried creating a scenario under `tcp_tunneling_integration_test.cc` that downstream has no-ssl connection and upstream has ssl connection but I failed - would love some help.
Docs Changes: None
Release Notes: Added
Platform Specific Features: None
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
