### PR TITLE
ci/macos: Increase timeout to 120m

### DIFF
--- a/.github/workflows/envoy-macos.yml
+++ b/.github/workflows/envoy-macos.yml
@@ -53,7 +53,7 @@ jobs:
       steps-pre: ${{ matrix.steps-pre }}
       target: ${{ matrix.target }}
       target-name: ${{ matrix.target-name }}
-      timeout-minutes: 90
+      timeout-minutes: 120
       trusted: ${{ fromJSON(needs.load.outputs.trusted) }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
when caches are blown this CI takes longer than the current 90s allowed