### PR TITLE
Allow empty resolver list for cares dns

### DIFF
--- a/api/envoy/extensions/network/dns_resolver/cares/v3/cares_dns_resolver.proto
+++ b/api/envoy/extensions/network/dns_resolver/cares/v3/cares_dns_resolver.proto
@@ -8,7 +8,6 @@ import "envoy/config/core/v3/resolver.proto";
 import "google/protobuf/wrappers.proto";
 
 import "udpa/annotations/status.proto";
-import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.network.dns_resolver.cares.v3";
 option java_outer_classname = "CaresDnsResolverProto";
@@ -26,7 +25,7 @@ message CaresDnsResolverConfig {
   // :ref:`use_resolvers_as_fallback<envoy_v3_api_field_extensions.network.dns_resolver.cares.v3.CaresDnsResolverConfig.use_resolvers_as_fallback>`
   // below dictates if the DNS client should override system defaults or only use the provided
   // resolvers if the system defaults are not available, i.e., as a fallback.
-  repeated config.core.v3.Address resolvers = 1 [(validate.rules).repeated = {min_items: 1}];
+  repeated config.core.v3.Address resolvers = 1;
 
   // If true use the resolvers listed in the
   // :ref:`resolvers<envoy_v3_api_field_extensions.network.dns_resolver.cares.v3.CaresDnsResolverConfig.resolvers>`


### PR DESCRIPTION
For https://github.com/istio/istio/issues/53577

I'm trying to configure DNS resolvers (specifically `CaresDnsResolverConfig.udp_max_queries`) while using the default system resolvers. Right now, I need to add one resolver, otherwise I get a proto validation error.

Commit Message: Allow empty resolver list for cares dns
Additional Description:
Risk Level: low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
