### PR TITLE
Remove unused listener FilterChain on_demand_configuration field

### DIFF
--- a/api/envoy/config/listener/v3/listener_components.proto
+++ b/api/envoy/config/listener/v3/listener_components.proto
@@ -201,24 +201,9 @@ message FilterChainMatch {
 message FilterChain {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.listener.FilterChain";
 
-  // The configuration for on-demand filter chain. If this field is not empty in FilterChain message,
-  // a filter chain will be built on-demand.
-  // On-demand filter chains help speedup the warming up of listeners since the building and initialization of
-  // an on-demand filter chain will be postponed to the arrival of new connection requests that require this filter chain.
-  // Filter chains that are not often used can be set as on-demand.
-  message OnDemandConfiguration {
-    // The timeout to wait for filter chain placeholders to complete rebuilding.
-    // 1. If this field is set to 0, timeout is disabled.
-    // 2. If not specified, a default timeout of 15s is used.
-    // Rebuilding will wait until dependencies are ready, have failed, or this timeout is reached.
-    // Upon failure or timeout, all connections related to this filter chain will be closed.
-    // Rebuilding will start again on the next new connection.
-    google.protobuf.Duration rebuild_timeout = 1;
-  }
+  reserved 2, 8;
 
-  reserved 2;
-
-  reserved "tls_context";
+  reserved "tls_context", "on_demand_configuration";
 
   // The criteria to use when matching a connection to this filter chain.
   FilterChainMatch filter_chain_match = 1;
@@ -269,11 +254,6 @@ message FilterChain {
   // <envoy_v3_api_field_config.listener.v3.Listener.filter_chain_matcher>`
   // requires that filter chains are uniquely named within a listener.
   string name = 7;
-
-  // [#not-implemented-hide:] The configuration to specify whether the filter chain will be built on-demand.
-  // If this field is not empty, the filter chain will be built on-demand.
-  // Otherwise, the filter chain will be built normally and block listener warming.
-  OnDemandConfiguration on_demand_configuration = 8;
 }
 
 // Listener filter chain match configuration. This is a recursive structure which allows complex


### PR DESCRIPTION
Commit Message: Remove unused listener FilterChain on_demand_configuration field

Additional Description:

API added in https://github.com/envoyproxy/envoy/pull/12599 but the implementation was abandoned in https://github.com/envoyproxy/envoy/pull/12310. The `FilterChain.OnDemandConfiguration` message still shows up in docs, which is confusing: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/listener/v3/listener_components.proto.html#config-listener-v3-filterchain-ondemandconfiguration

Risk Level: low
Testing: none
Docs Changes: none
Release Notes: Removed unused `config.listener.v3.FilterChain.OnDemandConfiguration` message
Platform Specific Features: none