### PR TITLE
route: remove redundant loader reference in weighted cluster entries

### DIFF
--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -670,7 +670,7 @@ RouteEntryImplBase::RouteEntryImplBase(const CommonVirtualHostSharedPtr& vhost,
                                        factory_context, validator, cluster),
           std::unique_ptr<WeightedClusterEntry>);
       weighted_clusters.emplace_back(std::move(cluster_entry));
-      total_weight += weighted_clusters.back()->clusterWeight();
+      total_weight += weighted_clusters.back()->clusterWeight(loader_);
       if (total_weight > std::numeric_limits<uint32_t>::max()) {
         creation_status = absl::InvalidArgumentError(
             fmt::format("The sum of weights of all weighted clusters of route {} exceeds {}",
@@ -1422,7 +1422,7 @@ RouteConstSharedPtr RouteEntryImplBase::pickWeightedCluster(const Http::HeaderMa
     total_cluster_weight = 0;
     for (const WeightedClusterEntrySharedPtr& cluster :
          weighted_clusters_config_->weighted_clusters_) {
-      auto cluster_weight = cluster->clusterWeight();
+      auto cluster_weight = cluster->clusterWeight(loader_);
       cluster_weights.push_back(cluster_weight);
       if (cluster_weight > std::numeric_limits<uint32_t>::max() - total_cluster_weight) {
         IS_ENVOY_BUG("Sum of weight cannot overflow 2^32");
@@ -1452,7 +1452,7 @@ RouteConstSharedPtr RouteEntryImplBase::pickWeightedCluster(const Http::HeaderMa
     if (runtime_key_prefix_configured) {
       end = begin + *cluster_weight++;
     } else {
-      end = begin + cluster->clusterWeight();
+      end = begin + cluster->clusterWeight(loader_);
     }
 
     if (selected_value >= begin && selected_value < end) {
@@ -1557,7 +1557,6 @@ RouteEntryImplBase::WeightedClusterEntry::WeightedClusterEntry(
     ProtobufMessage::ValidationVisitor& validator,
     const envoy::config::route::v3::WeightedCluster::ClusterWeight& cluster)
     : DynamicRouteEntry(parent, nullptr, cluster.name()), runtime_key_(runtime_key),
-      loader_(factory_context.runtime()),
       cluster_weight_(PROTOBUF_GET_WRAPPED_REQUIRED(cluster, weight)),
       per_filter_configs_(THROW_OR_RETURN_VALUE(
           PerFilterConfigs::create(cluster.typed_per_filter_config(), factory_context, validator),

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -997,8 +997,8 @@ public:
            ProtobufMessage::ValidationVisitor& validator,
            const envoy::config::route::v3::WeightedCluster::ClusterWeight& cluster);
 
-    uint64_t clusterWeight() const {
-      return loader_.snapshot().getInteger(runtime_key_, cluster_weight_);
+    uint64_t clusterWeight(Runtime::Loader& loader) const {
+      return loader.snapshot().getInteger(runtime_key_, cluster_weight_);
     }
 
     const MetadataMatchCriteria* metadataMatchCriteria() const override {
@@ -1067,7 +1067,6 @@ public:
                          const envoy::config::route::v3::WeightedCluster::ClusterWeight& cluster);
 
     const std::string runtime_key_;
-    Runtime::Loader& loader_;
     const uint64_t cluster_weight_;
     MetadataMatchCriteriaConstPtr cluster_metadata_match_criteria_;
     HeaderParserPtr request_headers_parser_;


### PR DESCRIPTION
Commit Message: route: remove redundant loader reference in weighted cluster entries
Additional Description:
Currently each WeightedClusterEntry owns a reference to the Runtime Loader that is shared across the Route (and the Envoy).
This PR reduces the amount of memory a WeightedClusterEntry requires by removing the reference and using the one from the wrapping route.

Risk Level: low - no actual change
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
