### PR TITLE
[bp/1.30] ci/codeql: Only run on main branch (#36806)

### DIFF
--- a/.github/workflows/codeql-push.yml
+++ b/.github/workflows/codeql-push.yml
@@ -8,9 +8,11 @@ on:
     paths:
     - include/**
     - source/common/**
-    branches-ignore:
-    - dependabot/**
+    branches:
+    - main
   pull_request:
+    branches:
+    - main
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}-${{ github.workflow }}


### PR DESCRIPTION
this is currently triggering on the release branches

codeql uses ci cache which is very limited and running this on multiple branches is expiring caches making this take a very long time

