### PR TITLE
context: use server factory context as lb context

### DIFF
--- a/envoy/upstream/load_balancer.h
+++ b/envoy/upstream/load_balancer.h
@@ -13,6 +13,11 @@
 #include "xds/data/orca/v3/orca_load_report.pb.h"
 
 namespace Envoy {
+namespace Server {
+namespace Configuration {
+class ServerFactoryContext;
+} // namespace Configuration
+} // namespace Server
 namespace Http {
 namespace ConnectionPool {
 class ConnectionLifetimeCallbacks;
@@ -271,15 +276,7 @@ using LoadBalancerConfigPtr = std::unique_ptr<LoadBalancerConfig>;
 /**
  * Context information passed to a load balancer factory to use when creating a load balancer.
  */
-class LoadBalancerFactoryContext {
-public:
-  virtual ~LoadBalancerFactoryContext() = default;
-
-  /**
-   * @return Event::Dispatcher& the main thread dispatcher.
-   */
-  virtual Event::Dispatcher& mainThreadDispatcher() PURE;
-};
+using LoadBalancerFactoryContext = Server::Configuration::ServerFactoryContext;
 
 /**
  * Factory config for load balancers. To support a load balancing policy of
@@ -314,12 +311,9 @@ public:
    * @param lb_factory_context supplies the load balancer factory context.
    * @param config supplies the typed proto config of the load balancer. A dynamic_cast could
    *        be performed on the config to the expected proto type.
-   * @param visitor supplies the validation visitor that will be used to validate the embedded
-   *        Any proto message.
    */
   virtual LoadBalancerConfigPtr loadConfig(LoadBalancerFactoryContext& lb_factory_context,
-                                           const Protobuf::Message& config,
-                                           ProtobufMessage::ValidationVisitor& visitor) PURE;
+                                           const Protobuf::Message& config) PURE;
 
   std::string category() const override { return "envoy.load_balancing_policies"; }
 };

--- a/envoy/upstream/load_balancer.h
+++ b/envoy/upstream/load_balancer.h
@@ -274,11 +274,6 @@ public:
 using LoadBalancerConfigPtr = std::unique_ptr<LoadBalancerConfig>;
 
 /**
- * Context information passed to a load balancer factory to use when creating a load balancer.
- */
-using LoadBalancerFactoryContext = Server::Configuration::ServerFactoryContext;
-
-/**
  * Factory config for load balancers. To support a load balancing policy of
  * LOAD_BALANCING_POLICY_CONFIG, at least one load balancer factory corresponding to a policy in
  * load_balancing_policy must be registered with Envoy. Envoy will use the first policy for which
@@ -308,12 +303,13 @@ public:
    *
    * @return LoadBalancerConfigPtr a new load balancer config.
    *
-   * @param lb_factory_context supplies the load balancer factory context.
+   * @param factory_context supplies the load balancer factory context.
    * @param config supplies the typed proto config of the load balancer. A dynamic_cast could
    *        be performed on the config to the expected proto type.
    */
-  virtual LoadBalancerConfigPtr loadConfig(LoadBalancerFactoryContext& lb_factory_context,
-                                           const Protobuf::Message& config) PURE;
+  virtual LoadBalancerConfigPtr
+  loadConfig(Server::Configuration::ServerFactoryContext& factory_context,
+             const Protobuf::Message& config) PURE;
 
   std::string category() const override { return "envoy.load_balancing_policies"; }
 };

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -381,20 +381,6 @@ createUpstreamLocalAddressSelector(
   return selector_or_error.value();
 }
 
-class LoadBalancerFactoryContextImpl : public Upstream::LoadBalancerFactoryContext {
-public:
-  explicit LoadBalancerFactoryContextImpl(
-      Server::Configuration::ServerFactoryContext& server_context)
-      : server_context_(server_context) {}
-
-  Event::Dispatcher& mainThreadDispatcher() override {
-    return server_context_.mainThreadDispatcher();
-  }
-
-private:
-  Server::Configuration::ServerFactoryContext& server_context_;
-};
-
 } // namespace
 
 // Allow disabling ALPN checks for transport sockets. See
@@ -1095,8 +1081,7 @@ createOptions(const envoy::config::cluster::v3::Cluster& config,
 
 absl::StatusOr<LegacyLbPolicyConfigHelper::Result>
 LegacyLbPolicyConfigHelper::getTypedLbConfigFromLegacyProtoWithoutSubset(
-    LoadBalancerFactoryContext& lb_factory_context, const ClusterProto& cluster,
-    ProtobufMessage::ValidationVisitor& visitor) {
+    LoadBalancerFactoryContext& lb_factory_context, const ClusterProto& cluster) {
   LoadBalancerConfigPtr lb_config;
   TypedLoadBalancerFactory* lb_factory = nullptr;
 
@@ -1139,13 +1124,12 @@ LegacyLbPolicyConfigHelper::getTypedLbConfigFromLegacyProtoWithoutSubset(
                     ClusterProto::LbPolicy_Name(cluster.lb_policy())));
   }
 
-  return Result{lb_factory, lb_factory->loadConfig(lb_factory_context, cluster, visitor)};
+  return Result{lb_factory, lb_factory->loadConfig(lb_factory_context, cluster)};
 }
 
 absl::StatusOr<LegacyLbPolicyConfigHelper::Result>
 LegacyLbPolicyConfigHelper::getTypedLbConfigFromLegacyProto(
-    LoadBalancerFactoryContext& lb_factory_context, const ClusterProto& cluster,
-    ProtobufMessage::ValidationVisitor& visitor) {
+    LoadBalancerFactoryContext& lb_factory_context, const ClusterProto& cluster) {
   // Handle the lb subset config case first.
   // Note it is possible to have a lb_subset_config without actually having any subset selectors.
   // In this case the subset load balancer should not be used.
@@ -1153,12 +1137,12 @@ LegacyLbPolicyConfigHelper::getTypedLbConfigFromLegacyProto(
     auto* lb_factory = Config::Utility::getFactoryByName<TypedLoadBalancerFactory>(
         "envoy.load_balancing_policies.subset");
     if (lb_factory != nullptr) {
-      return Result{lb_factory, lb_factory->loadConfig(lb_factory_context, cluster, visitor)};
+      return Result{lb_factory, lb_factory->loadConfig(lb_factory_context, cluster)};
     }
     return absl::InvalidArgumentError("No subset load balancer factory found");
   }
 
-  return getTypedLbConfigFromLegacyProtoWithoutSubset(lb_factory_context, cluster, visitor);
+  return getTypedLbConfigFromLegacyProtoWithoutSubset(lb_factory_context, cluster);
 }
 
 using ProtocolOptionsHashMap =
@@ -1336,10 +1320,8 @@ ClusterInfoImpl::ClusterInfoImpl(
   } else {
     // If load_balancing_policy is not set, we will try to convert legacy lb_policy
     // to load_balancing_policy and use it.
-    LoadBalancerFactoryContextImpl lb_factory_context(server_context);
-
-    auto lb_pair = LegacyLbPolicyConfigHelper::getTypedLbConfigFromLegacyProto(
-        lb_factory_context, config, server_context.messageValidationVisitor());
+    auto lb_pair =
+        LegacyLbPolicyConfigHelper::getTypedLbConfigFromLegacyProto(server_context, config);
     SET_AND_RETURN_IF_NOT_OK(lb_pair.status(), creation_status);
     load_balancer_factory_ = lb_pair->factory;
     ASSERT(load_balancer_factory_ != nullptr, "null load balancer factory");
@@ -1511,14 +1493,12 @@ ClusterInfoImpl::configureLbPolicies(const envoy::config::cluster::v3::Cluster& 
             policy.typed_extension_config(), /*is_optional=*/true);
     if (factory != nullptr) {
       // Load and validate the configuration.
-      LoadBalancerFactoryContextImpl lb_factory_context(context);
       auto proto_message = factory->createEmptyConfigProto();
       Config::Utility::translateOpaqueConfig(policy.typed_extension_config().typed_config(),
                                              context.messageValidationVisitor(), *proto_message);
 
       load_balancer_factory_ = factory;
-      load_balancer_config_ = factory->loadConfig(lb_factory_context, *proto_message,
-                                                  context.messageValidationVisitor());
+      load_balancer_config_ = factory->loadConfig(context, *proto_message);
 
       break;
     }

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -1081,7 +1081,7 @@ createOptions(const envoy::config::cluster::v3::Cluster& config,
 
 absl::StatusOr<LegacyLbPolicyConfigHelper::Result>
 LegacyLbPolicyConfigHelper::getTypedLbConfigFromLegacyProtoWithoutSubset(
-    LoadBalancerFactoryContext& lb_factory_context, const ClusterProto& cluster) {
+    Server::Configuration::ServerFactoryContext& factory_context, const ClusterProto& cluster) {
   LoadBalancerConfigPtr lb_config;
   TypedLoadBalancerFactory* lb_factory = nullptr;
 
@@ -1124,12 +1124,12 @@ LegacyLbPolicyConfigHelper::getTypedLbConfigFromLegacyProtoWithoutSubset(
                     ClusterProto::LbPolicy_Name(cluster.lb_policy())));
   }
 
-  return Result{lb_factory, lb_factory->loadConfig(lb_factory_context, cluster)};
+  return Result{lb_factory, lb_factory->loadConfig(factory_context, cluster)};
 }
 
 absl::StatusOr<LegacyLbPolicyConfigHelper::Result>
 LegacyLbPolicyConfigHelper::getTypedLbConfigFromLegacyProto(
-    LoadBalancerFactoryContext& lb_factory_context, const ClusterProto& cluster) {
+    Server::Configuration::ServerFactoryContext& factory_context, const ClusterProto& cluster) {
   // Handle the lb subset config case first.
   // Note it is possible to have a lb_subset_config without actually having any subset selectors.
   // In this case the subset load balancer should not be used.
@@ -1137,12 +1137,12 @@ LegacyLbPolicyConfigHelper::getTypedLbConfigFromLegacyProto(
     auto* lb_factory = Config::Utility::getFactoryByName<TypedLoadBalancerFactory>(
         "envoy.load_balancing_policies.subset");
     if (lb_factory != nullptr) {
-      return Result{lb_factory, lb_factory->loadConfig(lb_factory_context, cluster)};
+      return Result{lb_factory, lb_factory->loadConfig(factory_context, cluster)};
     }
     return absl::InvalidArgumentError("No subset load balancer factory found");
   }
 
-  return getTypedLbConfigFromLegacyProtoWithoutSubset(lb_factory_context, cluster);
+  return getTypedLbConfigFromLegacyProtoWithoutSubset(factory_context, cluster);
 }
 
 using ProtocolOptionsHashMap =

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -91,13 +91,11 @@ public:
 
   static absl::StatusOr<Result>
   getTypedLbConfigFromLegacyProtoWithoutSubset(LoadBalancerFactoryContext& lb_factory_context,
-                                               const ClusterProto& cluster,
-                                               ProtobufMessage::ValidationVisitor& visitor);
+                                               const ClusterProto& cluster);
 
   static absl::StatusOr<Result>
   getTypedLbConfigFromLegacyProto(LoadBalancerFactoryContext& lb_factory_context,
-                                  const ClusterProto& cluster,
-                                  ProtobufMessage::ValidationVisitor& visitor);
+                                  const ClusterProto& cluster);
 };
 
 /**

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -89,12 +89,11 @@ public:
     LoadBalancerConfigPtr config;
   };
 
-  static absl::StatusOr<Result>
-  getTypedLbConfigFromLegacyProtoWithoutSubset(LoadBalancerFactoryContext& lb_factory_context,
-                                               const ClusterProto& cluster);
+  static absl::StatusOr<Result> getTypedLbConfigFromLegacyProtoWithoutSubset(
+      Server::Configuration::ServerFactoryContext& factory_context, const ClusterProto& cluster);
 
   static absl::StatusOr<Result>
-  getTypedLbConfigFromLegacyProto(LoadBalancerFactoryContext& lb_factory_context,
+  getTypedLbConfigFromLegacyProto(Server::Configuration::ServerFactoryContext& factory_context,
                                   const ClusterProto& cluster);
 };
 

--- a/source/extensions/load_balancing_policies/client_side_weighted_round_robin/config.h
+++ b/source/extensions/load_balancing_policies/client_side_weighted_round_robin/config.h
@@ -34,7 +34,7 @@ public:
         lb_config, cluster_info, priority_set, runtime, random, time_source);
   }
 
-  Upstream::LoadBalancerConfigPtr loadConfig(Upstream::LoadBalancerFactoryContext& context,
+  Upstream::LoadBalancerConfigPtr loadConfig(Server::Configuration::ServerFactoryContext& context,
                                              const Protobuf::Message& config) override {
     const auto& lb_config = dynamic_cast<const ClientSideWeightedRoundRobinLbProto&>(config);
     return Upstream::LoadBalancerConfigPtr{new Upstream::ClientSideWeightedRoundRobinLbConfig(

--- a/source/extensions/load_balancing_policies/client_side_weighted_round_robin/config.h
+++ b/source/extensions/load_balancing_policies/client_side_weighted_round_robin/config.h
@@ -2,6 +2,7 @@
 
 #include "envoy/event/dispatcher.h"
 #include "envoy/extensions/load_balancing_policies/client_side_weighted_round_robin/v3/client_side_weighted_round_robin.pb.h"
+#include "envoy/server/factory_context.h"
 #include "envoy/upstream/load_balancer.h"
 
 #include "source/common/common/logger.h"
@@ -34,8 +35,7 @@ public:
   }
 
   Upstream::LoadBalancerConfigPtr loadConfig(Upstream::LoadBalancerFactoryContext& context,
-                                             const Protobuf::Message& config,
-                                             ProtobufMessage::ValidationVisitor&) override {
+                                             const Protobuf::Message& config) override {
     const auto& lb_config = dynamic_cast<const ClientSideWeightedRoundRobinLbProto&>(config);
     return Upstream::LoadBalancerConfigPtr{new Upstream::ClientSideWeightedRoundRobinLbConfig(
         lb_config, context.mainThreadDispatcher())};

--- a/source/extensions/load_balancing_policies/cluster_provided/config.h
+++ b/source/extensions/load_balancing_policies/cluster_provided/config.h
@@ -31,8 +31,7 @@ public:
                                               TimeSource& time_source) override;
 
   Upstream::LoadBalancerConfigPtr loadConfig(Upstream::LoadBalancerFactoryContext&,
-                                             const Protobuf::Message&,
-                                             ProtobufMessage::ValidationVisitor&) override {
+                                             const Protobuf::Message&) override {
     return std::make_unique<ClusterProvidedLbConfig>();
   }
 };

--- a/source/extensions/load_balancing_policies/cluster_provided/config.h
+++ b/source/extensions/load_balancing_policies/cluster_provided/config.h
@@ -30,7 +30,7 @@ public:
                                               Random::RandomGenerator& random,
                                               TimeSource& time_source) override;
 
-  Upstream::LoadBalancerConfigPtr loadConfig(Upstream::LoadBalancerFactoryContext&,
+  Upstream::LoadBalancerConfigPtr loadConfig(Server::Configuration::ServerFactoryContext&,
                                              const Protobuf::Message&) override {
     return std::make_unique<ClusterProvidedLbConfig>();
   }

--- a/source/extensions/load_balancing_policies/common/BUILD
+++ b/source/extensions/load_balancing_policies/common/BUILD
@@ -12,6 +12,7 @@ envoy_cc_library(
     name = "factory_base",
     hdrs = ["factory_base.h"],
     deps = [
+        "//envoy/server:factory_context_interface",
         "//envoy/upstream:load_balancer_interface",
         "//source/common/upstream:load_balancer_factory_base_lib",
     ],

--- a/source/extensions/load_balancing_policies/common/factory_base.h
+++ b/source/extensions/load_balancing_policies/common/factory_base.h
@@ -2,6 +2,7 @@
 
 #include <memory>
 
+#include "envoy/server/factory_context.h"
 #include "envoy/upstream/load_balancer.h"
 
 #include "source/common/upstream/load_balancer_factory_base.h"

--- a/source/extensions/load_balancing_policies/least_request/config.h
+++ b/source/extensions/load_balancing_policies/least_request/config.h
@@ -58,7 +58,7 @@ class Factory : public Common::FactoryBase<LeastRequestLbProto, LeastRequestCrea
 public:
   Factory() : FactoryBase("envoy.load_balancing_policies.least_request") {}
 
-  Upstream::LoadBalancerConfigPtr loadConfig(Upstream::LoadBalancerFactoryContext&,
+  Upstream::LoadBalancerConfigPtr loadConfig(Server::Configuration::ServerFactoryContext&,
                                              const Protobuf::Message& config) override {
     auto active_or_legacy = Common::ActiveOrLegacy<LeastRequestLbProto, ClusterProto>::get(&config);
     ASSERT(active_or_legacy.hasLegacy() || active_or_legacy.hasActive());

--- a/source/extensions/load_balancing_policies/least_request/config.h
+++ b/source/extensions/load_balancing_policies/least_request/config.h
@@ -59,8 +59,7 @@ public:
   Factory() : FactoryBase("envoy.load_balancing_policies.least_request") {}
 
   Upstream::LoadBalancerConfigPtr loadConfig(Upstream::LoadBalancerFactoryContext&,
-                                             const Protobuf::Message& config,
-                                             ProtobufMessage::ValidationVisitor&) override {
+                                             const Protobuf::Message& config) override {
     auto active_or_legacy = Common::ActiveOrLegacy<LeastRequestLbProto, ClusterProto>::get(&config);
     ASSERT(active_or_legacy.hasLegacy() || active_or_legacy.hasActive());
 

--- a/source/extensions/load_balancing_policies/maglev/config.h
+++ b/source/extensions/load_balancing_policies/maglev/config.h
@@ -29,8 +29,7 @@ public:
                                               TimeSource& time_source) override;
 
   Upstream::LoadBalancerConfigPtr loadConfig(Upstream::LoadBalancerFactoryContext&,
-                                             const Protobuf::Message& config,
-                                             ProtobufMessage::ValidationVisitor&) override {
+                                             const Protobuf::Message& config) override {
     auto active_or_legacy =
         Common::ActiveOrLegacy<Upstream::MaglevLbProto, Upstream::ClusterProto>::get(&config);
 

--- a/source/extensions/load_balancing_policies/maglev/config.h
+++ b/source/extensions/load_balancing_policies/maglev/config.h
@@ -28,7 +28,7 @@ public:
                                               Random::RandomGenerator& random,
                                               TimeSource& time_source) override;
 
-  Upstream::LoadBalancerConfigPtr loadConfig(Upstream::LoadBalancerFactoryContext&,
+  Upstream::LoadBalancerConfigPtr loadConfig(Server::Configuration::ServerFactoryContext&,
                                              const Protobuf::Message& config) override {
     auto active_or_legacy =
         Common::ActiveOrLegacy<Upstream::MaglevLbProto, Upstream::ClusterProto>::get(&config);

--- a/source/extensions/load_balancing_policies/random/config.h
+++ b/source/extensions/load_balancing_policies/random/config.h
@@ -44,8 +44,7 @@ public:
   Factory() : FactoryBase("envoy.load_balancing_policies.random") {}
 
   Upstream::LoadBalancerConfigPtr loadConfig(Upstream::LoadBalancerFactoryContext&,
-                                             const Protobuf::Message& config,
-                                             ProtobufMessage::ValidationVisitor&) override {
+                                             const Protobuf::Message& config) override {
     auto typed_config = dynamic_cast<const RandomLbProto*>(&config);
     if (typed_config == nullptr) {
       return std::make_unique<EmptyRandomLbConfig>();

--- a/source/extensions/load_balancing_policies/random/config.h
+++ b/source/extensions/load_balancing_policies/random/config.h
@@ -43,7 +43,7 @@ class Factory : public Common::FactoryBase<RandomLbProto, RandomCreator> {
 public:
   Factory() : FactoryBase("envoy.load_balancing_policies.random") {}
 
-  Upstream::LoadBalancerConfigPtr loadConfig(Upstream::LoadBalancerFactoryContext&,
+  Upstream::LoadBalancerConfigPtr loadConfig(Server::Configuration::ServerFactoryContext&,
                                              const Protobuf::Message& config) override {
     auto typed_config = dynamic_cast<const RandomLbProto*>(&config);
     if (typed_config == nullptr) {

--- a/source/extensions/load_balancing_policies/ring_hash/config.h
+++ b/source/extensions/load_balancing_policies/ring_hash/config.h
@@ -28,7 +28,7 @@ public:
                                               Random::RandomGenerator& random,
                                               TimeSource& time_source) override;
 
-  Upstream::LoadBalancerConfigPtr loadConfig(Upstream::LoadBalancerFactoryContext&,
+  Upstream::LoadBalancerConfigPtr loadConfig(Server::Configuration::ServerFactoryContext&,
                                              const Protobuf::Message& config) override {
     auto active_or_legacy =
         Common::ActiveOrLegacy<Upstream::RingHashLbProto, Upstream::ClusterProto>::get(&config);

--- a/source/extensions/load_balancing_policies/ring_hash/config.h
+++ b/source/extensions/load_balancing_policies/ring_hash/config.h
@@ -29,8 +29,7 @@ public:
                                               TimeSource& time_source) override;
 
   Upstream::LoadBalancerConfigPtr loadConfig(Upstream::LoadBalancerFactoryContext&,
-                                             const Protobuf::Message& config,
-                                             ProtobufMessage::ValidationVisitor&) override {
+                                             const Protobuf::Message& config) override {
     auto active_or_legacy =
         Common::ActiveOrLegacy<Upstream::RingHashLbProto, Upstream::ClusterProto>::get(&config);
 

--- a/source/extensions/load_balancing_policies/round_robin/config.h
+++ b/source/extensions/load_balancing_policies/round_robin/config.h
@@ -58,8 +58,7 @@ public:
   Factory() : FactoryBase("envoy.load_balancing_policies.round_robin") {}
 
   Upstream::LoadBalancerConfigPtr loadConfig(Upstream::LoadBalancerFactoryContext&,
-                                             const Protobuf::Message& config,
-                                             ProtobufMessage::ValidationVisitor&) override {
+                                             const Protobuf::Message& config) override {
     auto active_or_legacy = Common::ActiveOrLegacy<RoundRobinLbProto, ClusterProto>::get(&config);
     ASSERT(active_or_legacy.hasLegacy() || active_or_legacy.hasActive());
 

--- a/source/extensions/load_balancing_policies/round_robin/config.h
+++ b/source/extensions/load_balancing_policies/round_robin/config.h
@@ -57,7 +57,7 @@ class Factory : public Common::FactoryBase<RoundRobinLbProto, RoundRobinCreator>
 public:
   Factory() : FactoryBase("envoy.load_balancing_policies.round_robin") {}
 
-  Upstream::LoadBalancerConfigPtr loadConfig(Upstream::LoadBalancerFactoryContext&,
+  Upstream::LoadBalancerConfigPtr loadConfig(Server::Configuration::ServerFactoryContext&,
                                              const Protobuf::Message& config) override {
     auto active_or_legacy = Common::ActiveOrLegacy<RoundRobinLbProto, ClusterProto>::get(&config);
     ASSERT(active_or_legacy.hasLegacy() || active_or_legacy.hasActive());

--- a/source/extensions/load_balancing_policies/subset/config.cc
+++ b/source/extensions/load_balancing_policies/subset/config.cc
@@ -72,8 +72,7 @@ SubsetLbFactory::create(OptRef<const Upstream::LoadBalancerConfig> lb_config,
 
 Upstream::LoadBalancerConfigPtr
 SubsetLbFactory::loadConfig(Upstream::LoadBalancerFactoryContext& lb_factory_context,
-                            const Protobuf::Message& config,
-                            ProtobufMessage::ValidationVisitor& visitor) {
+                            const Protobuf::Message& config) {
   auto active_or_legacy = Common::ActiveOrLegacy<SubsetLbProto, ClusterProto>::get(&config);
   ASSERT(active_or_legacy.hasLegacy() || active_or_legacy.hasActive());
 
@@ -85,14 +84,14 @@ SubsetLbFactory::loadConfig(Upstream::LoadBalancerFactoryContext& lb_factory_con
                       envoy::config::cluster::v3::Cluster::LbPolicy_Name(
                           active_or_legacy.legacy()->lb_policy())));
     }
-    return std::make_unique<Upstream::SubsetLoadBalancerConfig>(
-        lb_factory_context, *active_or_legacy.legacy(), visitor);
+    return std::make_unique<Upstream::SubsetLoadBalancerConfig>(lb_factory_context,
+                                                                *active_or_legacy.legacy());
   }
 
   // Load the subset load balancer configuration. This will contains child load balancer
   // config and child load balancer factory.
   return std::make_unique<Upstream::SubsetLoadBalancerConfig>(lb_factory_context,
-                                                              *active_or_legacy.active(), visitor);
+                                                              *active_or_legacy.active());
 }
 
 /**

--- a/source/extensions/load_balancing_policies/subset/config.cc
+++ b/source/extensions/load_balancing_policies/subset/config.cc
@@ -71,7 +71,7 @@ SubsetLbFactory::create(OptRef<const Upstream::LoadBalancerConfig> lb_config,
 }
 
 Upstream::LoadBalancerConfigPtr
-SubsetLbFactory::loadConfig(Upstream::LoadBalancerFactoryContext& lb_factory_context,
+SubsetLbFactory::loadConfig(Server::Configuration::ServerFactoryContext& factory_context,
                             const Protobuf::Message& config) {
   auto active_or_legacy = Common::ActiveOrLegacy<SubsetLbProto, ClusterProto>::get(&config);
   ASSERT(active_or_legacy.hasLegacy() || active_or_legacy.hasActive());
@@ -84,13 +84,13 @@ SubsetLbFactory::loadConfig(Upstream::LoadBalancerFactoryContext& lb_factory_con
                       envoy::config::cluster::v3::Cluster::LbPolicy_Name(
                           active_or_legacy.legacy()->lb_policy())));
     }
-    return std::make_unique<Upstream::SubsetLoadBalancerConfig>(lb_factory_context,
+    return std::make_unique<Upstream::SubsetLoadBalancerConfig>(factory_context,
                                                                 *active_or_legacy.legacy());
   }
 
   // Load the subset load balancer configuration. This will contains child load balancer
   // config and child load balancer factory.
-  return std::make_unique<Upstream::SubsetLoadBalancerConfig>(lb_factory_context,
+  return std::make_unique<Upstream::SubsetLoadBalancerConfig>(factory_context,
                                                               *active_or_legacy.active());
 }
 

--- a/source/extensions/load_balancing_policies/subset/config.h
+++ b/source/extensions/load_balancing_policies/subset/config.h
@@ -26,7 +26,7 @@ public:
 
   Upstream::LoadBalancerConfigPtr
   loadConfig(Upstream::LoadBalancerFactoryContext& lb_factory_context,
-             const Protobuf::Message& config, ProtobufMessage::ValidationVisitor& visitor) override;
+             const Protobuf::Message& config) override;
 };
 
 } // namespace Subset

--- a/source/extensions/load_balancing_policies/subset/config.h
+++ b/source/extensions/load_balancing_policies/subset/config.h
@@ -25,7 +25,7 @@ public:
                                               TimeSource& time_source) override;
 
   Upstream::LoadBalancerConfigPtr
-  loadConfig(Upstream::LoadBalancerFactoryContext& lb_factory_context,
+  loadConfig(Server::Configuration::ServerFactoryContext& factory_context,
              const Protobuf::Message& config) override;
 };
 

--- a/source/extensions/load_balancing_policies/subset/subset_lb_config.cc
+++ b/source/extensions/load_balancing_policies/subset/subset_lb_config.cc
@@ -49,7 +49,7 @@ SubsetSelector::SubsetSelector(const Protobuf::RepeatedPtrField<std::string>& se
 }
 
 SubsetLoadBalancerConfig::SubsetLoadBalancerConfig(
-    Upstream::LoadBalancerFactoryContext& lb_factory_context,
+    Server::Configuration::ServerFactoryContext& factory_context,
     const SubsetLbConfigProto& subset_config)
     : subset_info_(std::make_unique<LoadBalancerSubsetInfoImpl>(subset_config)) {
   absl::InlinedVector<absl::string_view, 4> missing_policies;
@@ -62,10 +62,10 @@ SubsetLoadBalancerConfig::SubsetLoadBalancerConfig(
       // Load and validate the configuration.
       auto sub_lb_proto_message = factory->createEmptyConfigProto();
       Config::Utility::translateOpaqueConfig(policy.typed_extension_config().typed_config(),
-                                             lb_factory_context.messageValidationVisitor(),
+                                             factory_context.messageValidationVisitor(),
                                              *sub_lb_proto_message);
 
-      child_lb_config_ = factory->loadConfig(lb_factory_context, *sub_lb_proto_message);
+      child_lb_config_ = factory->loadConfig(factory_context, *sub_lb_proto_message);
       child_lb_factory_ = factory;
       break;
     }
@@ -81,12 +81,12 @@ SubsetLoadBalancerConfig::SubsetLoadBalancerConfig(
 }
 
 SubsetLoadBalancerConfig::SubsetLoadBalancerConfig(
-    Upstream::LoadBalancerFactoryContext& lb_factory_context, const ClusterProto& cluster)
+    Server::Configuration::ServerFactoryContext& factory_context, const ClusterProto& cluster)
     : subset_info_(std::make_unique<LoadBalancerSubsetInfoImpl>(cluster.lb_subset_config())) {
   ASSERT(subset_info_->isEnabled());
 
   auto sub_lb_pair = LegacyLbPolicyConfigHelper::getTypedLbConfigFromLegacyProtoWithoutSubset(
-      lb_factory_context, cluster);
+      factory_context, cluster);
   if (!sub_lb_pair.ok()) {
     throw EnvoyException(std::string(sub_lb_pair.status().message()));
   }

--- a/source/extensions/load_balancing_policies/subset/subset_lb_config.cc
+++ b/source/extensions/load_balancing_policies/subset/subset_lb_config.cc
@@ -50,7 +50,7 @@ SubsetSelector::SubsetSelector(const Protobuf::RepeatedPtrField<std::string>& se
 
 SubsetLoadBalancerConfig::SubsetLoadBalancerConfig(
     Upstream::LoadBalancerFactoryContext& lb_factory_context,
-    const SubsetLbConfigProto& subset_config, ProtobufMessage::ValidationVisitor& visitor)
+    const SubsetLbConfigProto& subset_config)
     : subset_info_(std::make_unique<LoadBalancerSubsetInfoImpl>(subset_config)) {
   absl::InlinedVector<absl::string_view, 4> missing_policies;
 
@@ -62,9 +62,10 @@ SubsetLoadBalancerConfig::SubsetLoadBalancerConfig(
       // Load and validate the configuration.
       auto sub_lb_proto_message = factory->createEmptyConfigProto();
       Config::Utility::translateOpaqueConfig(policy.typed_extension_config().typed_config(),
-                                             visitor, *sub_lb_proto_message);
+                                             lb_factory_context.messageValidationVisitor(),
+                                             *sub_lb_proto_message);
 
-      child_lb_config_ = factory->loadConfig(lb_factory_context, *sub_lb_proto_message, visitor);
+      child_lb_config_ = factory->loadConfig(lb_factory_context, *sub_lb_proto_message);
       child_lb_factory_ = factory;
       break;
     }
@@ -80,13 +81,12 @@ SubsetLoadBalancerConfig::SubsetLoadBalancerConfig(
 }
 
 SubsetLoadBalancerConfig::SubsetLoadBalancerConfig(
-    Upstream::LoadBalancerFactoryContext& lb_factory_context, const ClusterProto& cluster,
-    ProtobufMessage::ValidationVisitor& visitor)
+    Upstream::LoadBalancerFactoryContext& lb_factory_context, const ClusterProto& cluster)
     : subset_info_(std::make_unique<LoadBalancerSubsetInfoImpl>(cluster.lb_subset_config())) {
   ASSERT(subset_info_->isEnabled());
 
   auto sub_lb_pair = LegacyLbPolicyConfigHelper::getTypedLbConfigFromLegacyProtoWithoutSubset(
-      lb_factory_context, cluster, visitor);
+      lb_factory_context, cluster);
   if (!sub_lb_pair.ok()) {
     throw EnvoyException(std::string(sub_lb_pair.status().message()));
   }

--- a/source/extensions/load_balancing_policies/subset/subset_lb_config.h
+++ b/source/extensions/load_balancing_policies/subset/subset_lb_config.h
@@ -209,9 +209,9 @@ using DefaultLoadBalancerSubsetInfo = ConstSingleton<LoadBalancerSubsetInfoImpl>
 
 class SubsetLoadBalancerConfig : public Upstream::LoadBalancerConfig {
 public:
-  SubsetLoadBalancerConfig(Upstream::LoadBalancerFactoryContext& lb_factory_context,
+  SubsetLoadBalancerConfig(Server::Configuration::ServerFactoryContext& factory_context,
                            const SubsetLbConfigProto& subset_config);
-  SubsetLoadBalancerConfig(Upstream::LoadBalancerFactoryContext& lb_factory_context,
+  SubsetLoadBalancerConfig(Server::Configuration::ServerFactoryContext& factory_context,
                            const ClusterProto& cluster);
   SubsetLoadBalancerConfig(LoadBalancerSubsetInfoPtr subset_info,
                            TypedLoadBalancerFactory* child_factory,

--- a/source/extensions/load_balancing_policies/subset/subset_lb_config.h
+++ b/source/extensions/load_balancing_policies/subset/subset_lb_config.h
@@ -210,11 +210,9 @@ using DefaultLoadBalancerSubsetInfo = ConstSingleton<LoadBalancerSubsetInfoImpl>
 class SubsetLoadBalancerConfig : public Upstream::LoadBalancerConfig {
 public:
   SubsetLoadBalancerConfig(Upstream::LoadBalancerFactoryContext& lb_factory_context,
-                           const SubsetLbConfigProto& subset_config,
-                           ProtobufMessage::ValidationVisitor& visitor);
+                           const SubsetLbConfigProto& subset_config);
   SubsetLoadBalancerConfig(Upstream::LoadBalancerFactoryContext& lb_factory_context,
-                           const ClusterProto& cluster,
-                           ProtobufMessage::ValidationVisitor& visitor);
+                           const ClusterProto& cluster);
   SubsetLoadBalancerConfig(LoadBalancerSubsetInfoPtr subset_info,
                            TypedLoadBalancerFactory* child_factory,
                            LoadBalancerConfigPtr child_config);

--- a/test/extensions/load_balancing_policies/client_side_weighted_round_robin/config_test.cc
+++ b/test/extensions/load_balancing_policies/client_side_weighted_round_robin/config_test.cc
@@ -18,8 +18,7 @@ TEST(ClientSideWeightedRoundRobinConfigTest, ValidateFail) {
   NiceMock<Upstream::MockPrioritySet> main_thread_priority_set;
   NiceMock<Upstream::MockPrioritySet> thread_local_priority_set;
   NiceMock<Event::MockDispatcher> mock_thread_dispatcher;
-  ON_CALL(lb_factory_context, mainThreadDispatcher())
-      .WillByDefault(ReturnRef(mock_thread_dispatcher));
+  ON_CALL(context, mainThreadDispatcher()).WillByDefault(ReturnRef(mock_thread_dispatcher));
 
   envoy::config::core::v3::TypedExtensionConfig config;
   config.set_name("envoy.load_balancing_policies.client_side_weighted_round_robin");

--- a/test/extensions/load_balancing_policies/client_side_weighted_round_robin/config_test.cc
+++ b/test/extensions/load_balancing_policies/client_side_weighted_round_robin/config_test.cc
@@ -18,7 +18,6 @@ TEST(ClientSideWeightedRoundRobinConfigTest, ValidateFail) {
   NiceMock<Upstream::MockPrioritySet> main_thread_priority_set;
   NiceMock<Upstream::MockPrioritySet> thread_local_priority_set;
   NiceMock<Event::MockDispatcher> mock_thread_dispatcher;
-  NiceMock<Upstream::MockLoadBalancerFactoryContext> lb_factory_context;
   ON_CALL(lb_factory_context, mainThreadDispatcher())
       .WillByDefault(ReturnRef(mock_thread_dispatcher));
 
@@ -31,8 +30,7 @@ TEST(ClientSideWeightedRoundRobinConfigTest, ValidateFail) {
   auto& factory = Config::Utility::getAndCheckFactory<Upstream::TypedLoadBalancerFactory>(config);
   EXPECT_EQ("envoy.load_balancing_policies.client_side_weighted_round_robin", factory.name());
 
-  auto lb_config = factory.loadConfig(lb_factory_context, *factory.createEmptyConfigProto(),
-                                      context.messageValidationVisitor());
+  auto lb_config = factory.loadConfig(context, *factory.createEmptyConfigProto());
 
   auto thread_aware_lb =
       factory.create(*lb_config, cluster_info, main_thread_priority_set, context.runtime_loader_,

--- a/test/extensions/load_balancing_policies/least_request/config_test.cc
+++ b/test/extensions/load_balancing_policies/least_request/config_test.cc
@@ -19,7 +19,6 @@ TEST(LeastRequestConfigTest, ValidateFail) {
   NiceMock<Upstream::MockClusterInfo> cluster_info;
   NiceMock<Upstream::MockPrioritySet> main_thread_priority_set;
   NiceMock<Upstream::MockPrioritySet> thread_local_priority_set;
-  NiceMock<Upstream::MockLoadBalancerFactoryContext> lb_factory_context;
 
   envoy::config::core::v3::TypedExtensionConfig config;
   config.set_name("envoy.load_balancing_policies.least_request");
@@ -29,8 +28,7 @@ TEST(LeastRequestConfigTest, ValidateFail) {
   auto& factory = Config::Utility::getAndCheckFactory<Upstream::TypedLoadBalancerFactory>(config);
   EXPECT_EQ("envoy.load_balancing_policies.least_request", factory.name());
 
-  auto lb_config = factory.loadConfig(lb_factory_context, *factory.createEmptyConfigProto(),
-                                      context.messageValidationVisitor());
+  auto lb_config = factory.loadConfig(context, *factory.createEmptyConfigProto());
   auto thread_aware_lb =
       factory.create(*lb_config, cluster_info, main_thread_priority_set, context.runtime_loader_,
                      context.api_.random_, context.time_system_);

--- a/test/extensions/load_balancing_policies/maglev/config_test.cc
+++ b/test/extensions/load_balancing_policies/maglev/config_test.cc
@@ -20,7 +20,6 @@ TEST(MaglevConfigTest, Validate) {
   NiceMock<Upstream::MockClusterInfo> cluster_info;
   NiceMock<Upstream::MockPrioritySet> main_thread_priority_set;
   NiceMock<Upstream::MockPrioritySet> thread_local_priority_set;
-  NiceMock<Upstream::MockLoadBalancerFactoryContext> lb_factory_context;
 
   {
     envoy::config::core::v3::TypedExtensionConfig config;
@@ -31,8 +30,7 @@ TEST(MaglevConfigTest, Validate) {
     auto& factory = Config::Utility::getAndCheckFactory<Upstream::TypedLoadBalancerFactory>(config);
     EXPECT_EQ("envoy.load_balancing_policies.maglev", factory.name());
 
-    auto lb_config = factory.loadConfig(lb_factory_context, *factory.createEmptyConfigProto(),
-                                        context.messageValidationVisitor());
+    auto lb_config = factory.loadConfig(context, *factory.createEmptyConfigProto());
     auto thread_aware_lb =
         factory.create(*lb_config, cluster_info, main_thread_priority_set, context.runtime_loader_,
                        context.api_.random_, context.time_system_);
@@ -60,8 +58,7 @@ TEST(MaglevConfigTest, Validate) {
 
     auto message_ptr = factory.createEmptyConfigProto();
     message_ptr->MergeFrom(config_msg);
-    auto lb_config =
-        factory.loadConfig(lb_factory_context, *message_ptr, context.messageValidationVisitor());
+    auto lb_config = factory.loadConfig(context, *message_ptr);
 
     EXPECT_THROW_WITH_MESSAGE(factory.create(*lb_config, cluster_info, main_thread_priority_set,
                                              context.runtime_loader_, context.api_.random_,

--- a/test/extensions/load_balancing_policies/random/config_test.cc
+++ b/test/extensions/load_balancing_policies/random/config_test.cc
@@ -19,7 +19,6 @@ TEST(RandomConfigTest, ValidateFail) {
   NiceMock<Upstream::MockClusterInfo> cluster_info;
   NiceMock<Upstream::MockPrioritySet> main_thread_priority_set;
   NiceMock<Upstream::MockPrioritySet> thread_local_priority_set;
-  NiceMock<Upstream::MockLoadBalancerFactoryContext> lb_factory_context;
 
   envoy::config::core::v3::TypedExtensionConfig config;
   config.set_name("envoy.load_balancing_policies.random");
@@ -29,8 +28,7 @@ TEST(RandomConfigTest, ValidateFail) {
   auto& factory = Config::Utility::getAndCheckFactory<Upstream::TypedLoadBalancerFactory>(config);
   EXPECT_EQ("envoy.load_balancing_policies.random", factory.name());
 
-  auto lb_config = factory.loadConfig(lb_factory_context, *factory.createEmptyConfigProto(),
-                                      context.messageValidationVisitor());
+  auto lb_config = factory.loadConfig(context, *factory.createEmptyConfigProto());
   auto thread_aware_lb =
       factory.create(*lb_config, cluster_info, main_thread_priority_set, context.runtime_loader_,
                      context.api_.random_, context.time_system_);

--- a/test/extensions/load_balancing_policies/ring_hash/config_test.cc
+++ b/test/extensions/load_balancing_policies/ring_hash/config_test.cc
@@ -21,7 +21,6 @@ TEST(RingHashConfigTest, Validate) {
   NiceMock<Upstream::MockClusterInfo> cluster_info;
   NiceMock<Upstream::MockPrioritySet> main_thread_priority_set;
   NiceMock<Upstream::MockPrioritySet> thread_local_priority_set;
-  NiceMock<Upstream::MockLoadBalancerFactoryContext> lb_factory_context;
 
   {
     envoy::config::core::v3::TypedExtensionConfig config;
@@ -32,8 +31,7 @@ TEST(RingHashConfigTest, Validate) {
     auto& factory = Config::Utility::getAndCheckFactory<Upstream::TypedLoadBalancerFactory>(config);
     EXPECT_EQ("envoy.load_balancing_policies.ring_hash", factory.name());
 
-    auto lb_config = factory.loadConfig(lb_factory_context, *factory.createEmptyConfigProto(),
-                                        context.messageValidationVisitor());
+    auto lb_config = factory.loadConfig(context, *factory.createEmptyConfigProto());
     auto thread_aware_lb =
         factory.create(*lb_config, cluster_info, main_thread_priority_set, context.runtime_loader_,
                        context.api_.random_, context.time_system_);
@@ -65,8 +63,7 @@ TEST(RingHashConfigTest, Validate) {
 
     auto message_ptr = factory.createEmptyConfigProto();
     message_ptr->MergeFrom(config_msg);
-    auto lb_config =
-        factory.loadConfig(lb_factory_context, *message_ptr, context.messageValidationVisitor());
+    auto lb_config = factory.loadConfig(context, *message_ptr);
 
     EXPECT_THROW_WITH_MESSAGE(
         factory.create(*lb_config, cluster_info, main_thread_priority_set, context.runtime_loader_,

--- a/test/extensions/load_balancing_policies/round_robin/config_test.cc
+++ b/test/extensions/load_balancing_policies/round_robin/config_test.cc
@@ -19,7 +19,6 @@ TEST(RoundRobinConfigTest, ValidateFail) {
   NiceMock<Upstream::MockClusterInfo> cluster_info;
   NiceMock<Upstream::MockPrioritySet> main_thread_priority_set;
   NiceMock<Upstream::MockPrioritySet> thread_local_priority_set;
-  NiceMock<Upstream::MockLoadBalancerFactoryContext> lb_factory_context;
 
   envoy::config::core::v3::TypedExtensionConfig config;
   config.set_name("envoy.load_balancing_policies.round_robin");
@@ -29,8 +28,7 @@ TEST(RoundRobinConfigTest, ValidateFail) {
   auto& factory = Config::Utility::getAndCheckFactory<Upstream::TypedLoadBalancerFactory>(config);
   EXPECT_EQ("envoy.load_balancing_policies.round_robin", factory.name());
 
-  auto lb_config = factory.loadConfig(lb_factory_context, *factory.createEmptyConfigProto(),
-                                      context.messageValidationVisitor());
+  auto lb_config = factory.loadConfig(context, *factory.createEmptyConfigProto());
 
   auto thread_aware_lb =
       factory.create(*lb_config, cluster_info, main_thread_priority_set, context.runtime_loader_,

--- a/test/extensions/load_balancing_policies/subset/BUILD
+++ b/test/extensions/load_balancing_policies/subset/BUILD
@@ -67,6 +67,7 @@ envoy_extension_cc_test(
         "//test/mocks/access_log:access_log_mocks",
         "//test/mocks/filesystem:filesystem_mocks",
         "//test/mocks/runtime:runtime_mocks",
+        "//test/mocks/server:factory_context_mocks",
         "//test/mocks/upstream:cluster_info_mocks",
         "//test/mocks/upstream:host_mocks",
         "//test/mocks/upstream:host_set_mocks",

--- a/test/extensions/load_balancing_policies/subset/BUILD
+++ b/test/extensions/load_balancing_policies/subset/BUILD
@@ -90,6 +90,7 @@ envoy_extension_cc_benchmark_binary(
         "//source/extensions/load_balancing_policies/random:config",
         "//source/extensions/load_balancing_policies/subset:config",
         "//test/extensions/load_balancing_policies/common:benchmark_base_tester_lib",
+        "//test/mocks/server:factory_context_mocks",
         "//test/mocks/upstream:load_balancer_mocks",
         "@com_github_google_benchmark//:benchmark",
         "@envoy_api//envoy/config/cluster/v3:pkg_cc_proto",

--- a/test/extensions/load_balancing_policies/subset/config_test.cc
+++ b/test/extensions/load_balancing_policies/subset/config_test.cc
@@ -20,7 +20,6 @@ TEST(SubsetConfigTest, SubsetConfigTest) {
   NiceMock<Upstream::MockClusterInfo> cluster_info;
   NiceMock<Upstream::MockPrioritySet> main_thread_priority_set;
   NiceMock<Upstream::MockPrioritySet> thread_local_priority_set;
-  NiceMock<Upstream::MockLoadBalancerFactoryContext> lb_factory_context;
 
   envoy::config::core::v3::TypedExtensionConfig config;
   config.set_name("envoy.load_balancing_policies.subset");
@@ -51,8 +50,7 @@ TEST(SubsetConfigTest, SubsetConfigTest) {
   auto& factory = Config::Utility::getAndCheckFactory<Upstream::TypedLoadBalancerFactory>(config);
   EXPECT_EQ("envoy.load_balancing_policies.subset", factory.name());
 
-  auto lb_config =
-      factory.loadConfig(lb_factory_context, *config_msg, context.messageValidationVisitor());
+  auto lb_config = factory.loadConfig(context, *config_msg);
 
   auto thread_aware_lb =
       factory.create(*lb_config, cluster_info, main_thread_priority_set, context.runtime_loader_,
@@ -73,7 +71,6 @@ TEST(SubsetConfigTest, SubsetConfigTestWithUnknownSubsetLoadBalancingPolicy) {
   NiceMock<Upstream::MockClusterInfo> cluster_info;
   NiceMock<Upstream::MockPrioritySet> main_thread_priority_set;
   NiceMock<Upstream::MockPrioritySet> thread_local_priority_set;
-  NiceMock<Upstream::MockLoadBalancerFactoryContext> lb_factory_context;
 
   envoy::config::core::v3::TypedExtensionConfig config;
   config.set_name("envoy.load_balancing_policies.subset");
@@ -103,8 +100,7 @@ TEST(SubsetConfigTest, SubsetConfigTestWithUnknownSubsetLoadBalancingPolicy) {
   EXPECT_EQ("envoy.load_balancing_policies.subset", factory.name());
 
   EXPECT_THROW_WITH_MESSAGE(
-      factory.loadConfig(lb_factory_context, *config_msg, context.messageValidationVisitor()),
-      EnvoyException,
+      factory.loadConfig(context.server_factory_context_, *config_msg), EnvoyException,
       "cluster: didn't find a registered load balancer factory implementation for subset lb with "
       "names from [envoy.load_balancing_policies.unknown]");
 }

--- a/test/extensions/load_balancing_policies/subset/subset_benchmark.cc
+++ b/test/extensions/load_balancing_policies/subset/subset_benchmark.cc
@@ -15,7 +15,7 @@
 #include "test/benchmark/main.h"
 #include "test/common/upstream/utility.h"
 #include "test/extensions/load_balancing_policies/common/benchmark_base_tester.h"
-#include "test/mocks/server/server_factory_context.h"
+#include "test/mocks/server/factory_context.h"
 #include "test/mocks/upstream/cluster_info.h"
 #include "test/mocks/upstream/load_balancer.h"
 #include "test/test_common/simulated_time_system.h"

--- a/test/extensions/load_balancing_policies/subset/subset_benchmark.cc
+++ b/test/extensions/load_balancing_policies/subset/subset_benchmark.cc
@@ -15,6 +15,7 @@
 #include "test/benchmark/main.h"
 #include "test/common/upstream/utility.h"
 #include "test/extensions/load_balancing_policies/common/benchmark_base_tester.h"
+#include "test/mocks/server/server_factory_context.h"
 #include "test/mocks/upstream/cluster_info.h"
 #include "test/mocks/upstream/load_balancer.h"
 #include "test/test_common/simulated_time_system.h"
@@ -43,10 +44,10 @@ public:
     child_lb->mutable_typed_extension_config()->set_name("envoy.load_balancing_policies.random");
     envoy::extensions::load_balancing_policies::random::v3::Random random_lb_config;
     child_lb->mutable_typed_extension_config()->mutable_typed_config()->PackFrom(random_lb_config);
-    NiceMock<Upstream::MockLoadBalancerFactoryContext> lb_factory_context;
+    NiceMock<Server::Configuration::MockServerFactoryContext> factory_context;
 
-    subset_config_ = std::make_unique<Upstream::SubsetLoadBalancerConfig>(
-        lb_factory_context, subset_config_proto, ProtobufMessage::getStrictValidationVisitor());
+    subset_config_ =
+        std::make_unique<Upstream::SubsetLoadBalancerConfig>(factory_context, subset_config_proto);
 
     lb_ = std::make_unique<Upstream::SubsetLoadBalancer>(*subset_config_, *info_, priority_set_,
                                                          &local_priority_set_, stats_, stats_scope_,

--- a/test/extensions/load_balancing_policies/subset/subset_test.cc
+++ b/test/extensions/load_balancing_policies/subset/subset_test.cc
@@ -21,6 +21,7 @@
 #include "test/mocks/common.h"
 #include "test/mocks/filesystem/mocks.h"
 #include "test/mocks/runtime/mocks.h"
+#include "test/mocks/server/factory_context.h"
 #include "test/mocks/upstream/cluster_info.h"
 #include "test/mocks/upstream/host.h"
 #include "test/mocks/upstream/host_set.h"
@@ -705,7 +706,7 @@ public:
   }
 
   std::string child_lb_name_{"envoy.load_balancing_policies.round_robin"};
-  NiceMock<MockLoadBalancerFactoryContext> lb_factory_context_;
+  NiceMock<Server::Configuration::MockServerFactoryContext> server_context_;
   LoadBalancerConfigPtr child_lb_config_;
   NiceMock<MockPrioritySet> priority_set_;
   MockHostSet& host_set_ = *priority_set_.getMockHostSet(0);
@@ -2333,8 +2334,7 @@ TEST_F(SubsetLoadBalancerTest, EnabledLocalityWeightAwareness) {
       Config::Utility::getFactoryByName<Upstream::TypedLoadBalancerFactory>(child_lb_name_);
   envoy::extensions::load_balancing_policies::round_robin::v3::RoundRobin rr_config;
   rr_config.mutable_locality_lb_config()->mutable_locality_weighted_lb_config();
-  child_lb_config_ = child_factory->loadConfig(lb_factory_context_, rr_config,
-                                               ProtobufMessage::getStrictValidationVisitor());
+  child_lb_config_ = child_factory->loadConfig(server_context_, rr_config);
   initLbConfigAndLB();
 
   TestLoadBalancerContext context({{"version", "1.1"}});
@@ -2372,8 +2372,7 @@ TEST_F(SubsetLoadBalancerTest, EnabledScaleLocalityWeights) {
       Config::Utility::getFactoryByName<Upstream::TypedLoadBalancerFactory>(child_lb_name_);
   envoy::extensions::load_balancing_policies::round_robin::v3::RoundRobin rr_config;
   rr_config.mutable_locality_lb_config()->mutable_locality_weighted_lb_config();
-  child_lb_config_ = child_factory->loadConfig(lb_factory_context_, rr_config,
-                                               ProtobufMessage::getStrictValidationVisitor());
+  child_lb_config_ = child_factory->loadConfig(server_context_, rr_config);
   initLbConfigAndLB();
 
   TestLoadBalancerContext context({{"version", "1.1"}});
@@ -2422,8 +2421,7 @@ TEST_F(SubsetLoadBalancerTest, EnabledScaleLocalityWeightsRounding) {
       Config::Utility::getFactoryByName<Upstream::TypedLoadBalancerFactory>(child_lb_name_);
   envoy::extensions::load_balancing_policies::round_robin::v3::RoundRobin rr_config;
   rr_config.mutable_locality_lb_config()->mutable_locality_weighted_lb_config();
-  child_lb_config_ = child_factory->loadConfig(lb_factory_context_, rr_config,
-                                               ProtobufMessage::getStrictValidationVisitor());
+  child_lb_config_ = child_factory->loadConfig(server_context_, rr_config);
   initLbConfigAndLB();
 
   TestLoadBalancerContext context({{"version", "1.0"}});

--- a/test/integration/load_balancers/custom_lb_policy.h
+++ b/test/integration/load_balancers/custom_lb_policy.h
@@ -74,8 +74,7 @@ public:
   }
 
   Upstream::LoadBalancerConfigPtr loadConfig(Upstream::LoadBalancerFactoryContext&,
-                                             const Protobuf::Message&,
-                                             ProtobufMessage::ValidationVisitor&) override {
+                                             const Protobuf::Message&) override {
     return std::make_unique<EmptyLoadBalancerConfig>();
   }
 };

--- a/test/integration/load_balancers/custom_lb_policy.h
+++ b/test/integration/load_balancers/custom_lb_policy.h
@@ -73,7 +73,7 @@ public:
     return std::make_unique<ThreadAwareLbImpl>();
   }
 
-  Upstream::LoadBalancerConfigPtr loadConfig(Upstream::LoadBalancerFactoryContext&,
+  Upstream::LoadBalancerConfigPtr loadConfig(Server::Configuration::ServerFactoryContext&,
                                              const Protobuf::Message&) override {
     return std::make_unique<EmptyLoadBalancerConfig>();
   }

--- a/test/mocks/upstream/load_balancer.h
+++ b/test/mocks/upstream/load_balancer.h
@@ -26,12 +26,5 @@ public:
   std::shared_ptr<MockHost> host_{new MockHost()};
 };
 
-class MockLoadBalancerFactoryContext : public LoadBalancerFactoryContext {
-public:
-  MockLoadBalancerFactoryContext() = default;
-  ~MockLoadBalancerFactoryContext() = default;
-  MOCK_METHOD(Event::Dispatcher&, mainThreadDispatcher, ());
-};
-
 } // namespace Upstream
 } // namespace Envoy

--- a/test/mocks/upstream/typed_load_balancer_factory.h
+++ b/test/mocks/upstream/typed_load_balancer_factory.h
@@ -26,8 +26,8 @@ public:
                const PrioritySet& priority_set, Runtime::Loader& runtime,
                Random::RandomGenerator& random, TimeSource& time_source));
 
-  LoadBalancerConfigPtr loadConfig(Upstream::LoadBalancerFactoryContext&, const Protobuf::Message&,
-                                   ProtobufMessage::ValidationVisitor&) override {
+  LoadBalancerConfigPtr loadConfig(Upstream::LoadBalancerFactoryContext&,
+                                   const Protobuf::Message&) override {
     return std::make_unique<EmptyLoadBalancerConfig>();
   }
 

--- a/test/mocks/upstream/typed_load_balancer_factory.h
+++ b/test/mocks/upstream/typed_load_balancer_factory.h
@@ -26,7 +26,7 @@ public:
                const PrioritySet& priority_set, Runtime::Loader& runtime,
                Random::RandomGenerator& random, TimeSource& time_source));
 
-  LoadBalancerConfigPtr loadConfig(Upstream::LoadBalancerFactoryContext&,
+  LoadBalancerConfigPtr loadConfig(Server::Configuration::ServerFactoryContext&,
                                    const Protobuf::Message&) override {
     return std::make_unique<EmptyLoadBalancerConfig>();
   }


### PR DESCRIPTION

Commit Message: context: use server factory context as lb context
Additional Description:

1. Simplify the context. We needn't more and more factory context.
2. allow the lb to access other API like runtime when loading configuration.

NOTE: This PR also changed the signature of the loadConfig() method. The message validator is removed and you can use the messageValidationVisitor() of the input factory context to validate the proto message.

Risk Level: low.
Testing: n/a.
Docs Changes: n/a.
Release Notes: n/a.