### PR TITLE
Basic_auth: Add bcrypt support

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -163,6 +163,17 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         release_date = "2022-06-13",
         cpe = "cpe:2.3:a:google:boringssl:*",
     ),
+    com_github_bcrypt = dict(
+        project_name = "bcrypt",
+        project_desc = " C++ wrapper around bcrypt password hashing",
+        project_url = "https://github.com/hilch/Bcrypt.cpp",
+        version = "V2.0_NODEBCRYPT",
+        sha256 = "150abb95058a459e58f2bf995fd85af1d616374cc920d1ebb84666a8b2b3c50c",
+        urls = ["https://github.com/hilch/Bcrypt.cpp/archive/refs/tags/{version}.tar.gz"],
+        use_category = ["controlplane", "dataplane_core"],
+        release_date = "2021-12-24",
+        cpe = "N/A",
+    ),
     aspect_bazel_lib = dict(
         project_name = "Aspect Bazel helpers",
         project_desc = "Base Starlark libraries and basic Bazel rules which are useful for constructing rulesets and BUILD files",

--- a/source/extensions/filters/http/basic_auth/BUILD
+++ b/source/extensions/filters/http/basic_auth/BUILD
@@ -13,7 +13,7 @@ envoy_cc_library(
     name = "basic_auth_lib",
     srcs = ["basic_auth_filter.cc"],
     hdrs = ["basic_auth_filter.h"],
-    external_deps = ["ssl"],
+    external_deps = ["ssl", "bcrypt"],
     deps = [
         "//envoy/server:filter_config_interface",
         "//source/common/common:base64_lib",


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Added bcrypt support for basic auth extension
Additional Description: This PR adds support to include bcrypt hashes in basic auth during configuration
Risk Level: N/A
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
[Optional Runtime guard:]
[Optional Fixes #36278]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
