### PR TITLE
matchers: remove unneeded ListMatcher data member

### DIFF
--- a/source/common/common/matchers.cc
+++ b/source/common/common/matchers.cc
@@ -72,12 +72,11 @@ bool DoubleMatcher::match(const ProtobufWkt::Value& value) const {
 }
 
 ListMatcher::ListMatcher(const envoy::type::matcher::v3::ListMatcher& matcher,
-                         Server::Configuration::CommonFactoryContext& context)
-    : matcher_(matcher) {
-  ASSERT(matcher_.match_pattern_case() ==
+                         Server::Configuration::CommonFactoryContext& context) {
+  ASSERT(matcher.match_pattern_case() ==
          envoy::type::matcher::v3::ListMatcher::MatchPatternCase::kOneOf);
 
-  oneof_value_matcher_ = ValueMatcher::create(matcher_.one_of(), context);
+  oneof_value_matcher_ = ValueMatcher::create(matcher.one_of(), context);
 }
 
 bool ListMatcher::match(const ProtobufWkt::Value& value) const {

--- a/source/common/common/matchers.h
+++ b/source/common/common/matchers.h
@@ -188,8 +188,6 @@ public:
   bool match(const ProtobufWkt::Value& value) const override;
 
 private:
-  const envoy::type::matcher::v3::ListMatcher matcher_;
-
   ValueMatcherConstSharedPtr oneof_value_matcher_;
 };
 


### PR DESCRIPTION
Commit Message: matchers: remove unneeded ListMatcher data member
Additional Description:
Removed a protobuf that was kept as a data member but only used in the c'tor.

Risk Level: low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
