### PR TITLE
test: fix os_sys_calls_test in some less common environments

### DIFF
--- a/test/common/api/os_sys_calls_test.cc
+++ b/test/common/api/os_sys_calls_test.cc
@@ -69,14 +69,15 @@ TEST(OsSyscallsTest, OpenPwritePreadFstatCloseStatUnlink) {
 }
 
 TEST(OsSyscallsTest, SupportsIpTransparent) {
-  bool supported = Api::OsSysCallsSingleton::get().supportsIpTransparent(
-      TestEnvironment::getIpVersionsForTest()[0]);
-  EXPECT_FALSE(supported);
+  // Some environments support this and some don't; just call the function to make sure nothing
+  // dire (like a crash) happens, without validating the return value.
+  Api::OsSysCallsSingleton::get().supportsIpTransparent(TestEnvironment::getIpVersionsForTest()[0]);
 }
 
 TEST(OsSyscallsTest, SupportsMptcp) {
-  bool supported = Api::OsSysCallsSingleton::get().supportsMptcp();
-  EXPECT_TRUE(supported);
+  // Some environments support this and some don't; just call the function to make sure nothing
+  // dire (like a crash) happens, without validating the return value.
+  Api::OsSysCallsSingleton::get().supportsMptcp();
 }
 
 TEST(OsSyscallsTest, IoCtlInvalidFd) {


### PR DESCRIPTION
supportsIpTransparent() and supportsMptcp() results depend on the OS being run on and the configuration of that OS, so remove the expectation of a specific value from the tests so that they'll pass in all environments.