### PR TITLE
Add cancelWrapper helper function in /common.

### DIFF
--- a/source/common/common/BUILD
+++ b/source/common/common/BUILD
@@ -31,6 +31,14 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
+    name = "cancel_wrapper_lib",
+    hdrs = ["cancel_wrapper.h"],
+    deps = [
+        "@com_google_absl//absl/functional:any_invocable",
+    ],
+)
+
+envoy_cc_library(
     name = "containers_lib",
     hdrs = ["containers.h"],
     deps = [

--- a/source/common/common/cancel_wrapper.h
+++ b/source/common/common/cancel_wrapper.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <memory>
+#include <utility>
+
+#include "absl/functional/any_invocable.h"
+
+namespace Envoy {
+namespace CancelWrapper {
+
+// Wraps a callback with a cancellation function. The cancellation function is saved
+// in an 'out' pointer argument to facilitate simple chaining in place, e.g. typical
+// usage would be of the form
+//
+// someFunctionThatTakesACallback(cancelWrapped([this](SomeResponse response) {
+//   doStuff(response);
+// }, &cancel_callback_));
+//
+// Then cancel_callback_ could be called (conditionally on having been populated) in the
+// class destructor to prevent use of "this" in a dispatched event that ends up occurring
+// after the calling object was destroyed.
+//
+// This cancellation is not safe to be called between threads - it is intended to be used in
+// conjunction with dispatchers for events that will be occurring on a single thread but
+// whose order may be unpredictable due to outside triggers.
+template <typename Callback>
+auto cancelWrapped(Callback&& callback, absl::AnyInvocable<void()>* cancel_out) {
+  auto cancelled_flag = std::make_shared<bool>(false);
+  *cancel_out = [cancelled_flag]() { *cancelled_flag = true; };
+  return [cb = std::move(callback),
+          cancelled_flag = std::move(cancelled_flag)](auto&&... args) mutable {
+    if (*cancelled_flag) {
+      return;
+    }
+    return std::move(cb)(std::forward<decltype(args)>(args)...);
+  };
+}
+
+} // namespace CancelWrapper
+} // namespace Envoy

--- a/source/common/common/cancel_wrapper.h
+++ b/source/common/common/cancel_wrapper.h
@@ -8,6 +8,8 @@
 namespace Envoy {
 namespace CancelWrapper {
 
+using CancelFunction = absl::AnyInvocable<void()>;
+
 // Wraps a callback with a cancellation function. The cancellation function is saved
 // in an 'out' pointer argument to facilitate simple chaining in place, e.g. typical
 // usage would be of the form
@@ -23,8 +25,7 @@ namespace CancelWrapper {
 // This cancellation is not safe to be called between threads - it is intended to be used in
 // conjunction with dispatchers for events that will be occurring on a single thread but
 // whose order may be unpredictable due to outside triggers.
-template <typename Callback>
-auto cancelWrapped(Callback&& callback, absl::AnyInvocable<void()>* cancel_out) {
+template <typename Callback> auto cancelWrapped(Callback&& callback, CancelFunction* cancel_out) {
   auto cancelled_flag = std::make_shared<bool>(false);
   *cancel_out = [cancelled_flag]() { *cancelled_flag = true; };
   return [cb = std::move(callback),

--- a/source/common/common/cancel_wrapper.h
+++ b/source/common/common/cancel_wrapper.h
@@ -33,7 +33,7 @@ template <typename Callback> auto cancelWrapped(Callback&& callback, CancelFunct
     if (*cancelled_flag) {
       return;
     }
-    return std::move(cb)(std::forward<decltype(args)>(args)...);
+    return cb(std::forward<decltype(args)>(args)...);
   };
 }
 

--- a/test/common/common/BUILD
+++ b/test/common/common/BUILD
@@ -34,6 +34,15 @@ envoy_cc_test(
 )
 
 envoy_cc_test(
+    name = "cancel_wrapper_test",
+    srcs = ["cancel_wrapper_test.cc"],
+    rbe_pool = "6gig",
+    deps = [
+        "//source/common/common:cancel_wrapper_lib",
+    ],
+)
+
+envoy_cc_test(
     name = "containers_test",
     srcs = ["containers_test.cc"],
     rbe_pool = "6gig",

--- a/test/common/common/cancel_wrapper_test.cc
+++ b/test/common/common/cancel_wrapper_test.cc
@@ -1,0 +1,73 @@
+#include "source/common/common/cancel_wrapper.h"
+
+#include "gtest/gtest.h"
+
+namespace Envoy {
+namespace CancelWrapper {
+
+TEST(CancelWrapper, WrappedCallbackIsExecutable) {
+  int x = 0;
+  absl::AnyInvocable<void()> cancel;
+  absl::AnyInvocable<void()> cb = [&x]() { x = 1; };
+  auto wrapped = cancelWrapped(std::move(cb), &cancel);
+  EXPECT_EQ(0, x);
+  wrapped();
+  EXPECT_EQ(1, x);
+}
+
+TEST(CancelWrapper, WrappedCallbackBareLambdaIsExecutable) {
+  int x = 0;
+  absl::AnyInvocable<void()> cancel;
+  auto wrapped = cancelWrapped([&x]() { x = 1; }, &cancel);
+  EXPECT_EQ(0, x);
+  wrapped();
+  EXPECT_EQ(1, x);
+}
+
+TEST(CancelWrapper, CancelledCallbackIsExecutableButDoesNothing) {
+  int x = 0;
+  absl::AnyInvocable<void()> cb = [&x]() { x = 1; };
+  absl::AnyInvocable<void()> cancel;
+  auto wrapped = cancelWrapped(std::move(cb), &cancel);
+  cancel();
+  EXPECT_EQ(0, x);
+  wrapped();
+  EXPECT_EQ(0, x);
+}
+
+TEST(CancelWrapper, WrappedCallbackWithArgsIsExecutable) {
+  int x = 0;
+  absl::AnyInvocable<void(int)> cb = [&x](int new_val) { x = new_val; };
+  absl::AnyInvocable<void()> cancel;
+  auto wrapped = cancelWrapped(std::move(cb), &cancel);
+  EXPECT_EQ(0, x);
+  wrapped(3);
+  EXPECT_EQ(3, x);
+}
+
+TEST(CancelWrapper, WrappedCallbackWithNonCopyableArgsAndCapturesIsExecutable) {
+  int x = 0;
+  absl::AnyInvocable<void(std::unique_ptr<int>)> cb = [y = std::make_unique<int>(5),
+                                                       &x](std::unique_ptr<int> added_val) mutable {
+    x = *y + *added_val;
+  };
+  absl::AnyInvocable<void()> cancel;
+  auto wrapped = cancelWrapped(std::move(cb), &cancel);
+  EXPECT_EQ(0, x);
+  wrapped(std::make_unique<int>(3));
+  EXPECT_EQ(8, x);
+}
+
+TEST(CancelWrapper, WrappedCallbackLambdaWithNonCopyableArgsAndCapturesIsExecutable) {
+  int x = 0;
+  absl::AnyInvocable<void()> cancel;
+  auto wrapped = cancelWrapped([y = std::make_unique<int>(5), &x](
+                                   std::unique_ptr<int> added_val) mutable { x = *y + *added_val; },
+                               &cancel);
+  EXPECT_EQ(0, x);
+  wrapped(std::make_unique<int>(3));
+  EXPECT_EQ(8, x);
+}
+
+} // namespace CancelWrapper
+} // namespace Envoy

--- a/test/common/common/cancel_wrapper_test.cc
+++ b/test/common/common/cancel_wrapper_test.cc
@@ -7,7 +7,7 @@ namespace CancelWrapper {
 
 TEST(CancelWrapper, WrappedCallbackIsExecutable) {
   int x = 0;
-  absl::AnyInvocable<void()> cancel;
+  CancelFunction cancel;
   absl::AnyInvocable<void()> cb = [&x]() { x = 1; };
   auto wrapped = cancelWrapped(std::move(cb), &cancel);
   EXPECT_EQ(0, x);
@@ -17,7 +17,7 @@ TEST(CancelWrapper, WrappedCallbackIsExecutable) {
 
 TEST(CancelWrapper, WrappedCallbackBareLambdaIsExecutable) {
   int x = 0;
-  absl::AnyInvocable<void()> cancel;
+  CancelFunction cancel;
   auto wrapped = cancelWrapped([&x]() { x = 1; }, &cancel);
   EXPECT_EQ(0, x);
   wrapped();
@@ -27,7 +27,7 @@ TEST(CancelWrapper, WrappedCallbackBareLambdaIsExecutable) {
 TEST(CancelWrapper, CancelledCallbackIsExecutableButDoesNothing) {
   int x = 0;
   absl::AnyInvocable<void()> cb = [&x]() { x = 1; };
-  absl::AnyInvocable<void()> cancel;
+  CancelFunction cancel;
   auto wrapped = cancelWrapped(std::move(cb), &cancel);
   cancel();
   EXPECT_EQ(0, x);
@@ -38,7 +38,7 @@ TEST(CancelWrapper, CancelledCallbackIsExecutableButDoesNothing) {
 TEST(CancelWrapper, WrappedCallbackWithArgsIsExecutable) {
   int x = 0;
   absl::AnyInvocable<void(int)> cb = [&x](int new_val) { x = new_val; };
-  absl::AnyInvocable<void()> cancel;
+  CancelFunction cancel;
   auto wrapped = cancelWrapped(std::move(cb), &cancel);
   EXPECT_EQ(0, x);
   wrapped(3);
@@ -51,7 +51,7 @@ TEST(CancelWrapper, WrappedCallbackWithNonCopyableArgsAndCapturesIsExecutable) {
                                                        &x](std::unique_ptr<int> added_val) mutable {
     x = *y + *added_val;
   };
-  absl::AnyInvocable<void()> cancel;
+  CancelFunction cancel;
   auto wrapped = cancelWrapped(std::move(cb), &cancel);
   EXPECT_EQ(0, x);
   wrapped(std::make_unique<int>(3));
@@ -60,7 +60,7 @@ TEST(CancelWrapper, WrappedCallbackWithNonCopyableArgsAndCapturesIsExecutable) {
 
 TEST(CancelWrapper, WrappedCallbackLambdaWithNonCopyableArgsAndCapturesIsExecutable) {
   int x = 0;
-  absl::AnyInvocable<void()> cancel;
+  CancelFunction cancel;
   auto wrapped = cancelWrapped([y = std::make_unique<int>(5), &x](
                                    std::unique_ptr<int> added_val) mutable { x = *y + *added_val; },
                                &cancel);


### PR DESCRIPTION
Commit Message: Add cancelWrapper helper function in /common.
Additional Description: In the cache filter implementation where there are multiple async streams and objects in flight any of which can be aborted from outside the filter's own flow, it's convenient and clear to have a cancel operation performed on being destroyed, rather than inferring "don't call the callback" from a `weak_ptr` (which can do the wrong thing in that onDestroy can happen before destructor, and is verbose and repetitive). Implementing these cancellation functions manually every time is also error-prone and repetitive. This introduces a reusable wrapper template to facilitate cancellable callbacks.
Risk Level: None, no change to production code yet.
Testing: Unit tested.
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
