### PR TITLE
tools: Remove `envoy_package`

### DIFF
--- a/bazel/envoy_library.bzl
+++ b/bazel/envoy_library.bzl
@@ -223,12 +223,12 @@ def envoy_cc_win32_library(name, srcs = [], hdrs = [], **kargs):
     )
 
 # Envoy proto targets should be specified with this function.
-def envoy_proto_library(name, **kwargs):
+def envoy_proto_library(name, visibility = ["//visibility:public"], **kwargs):
     api_cc_py_proto_library(
         name,
         # Avoid generating .so, we don't need it, can interfere with builds
         # such as OSS-Fuzz.
         linkstatic = 1,
-        visibility = ["//visibility:public"],
+        visibility = visibility,
         **kwargs
     )

--- a/distribution/binary/BUILD
+++ b/distribution/binary/BUILD
@@ -1,11 +1,8 @@
 load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
 load("@rules_pkg//pkg:pkg.bzl", "pkg_tar")
-load("//bazel:envoy_build_system.bzl", "envoy_package")
 load("//distribution/binary:compiler.bzl", "bundled")
 
 licenses(["notice"])  # Apache 2
-
-envoy_package()
 
 bundled(
     name = "envoy",

--- a/docs/BUILD
+++ b/docs/BUILD
@@ -1,9 +1,5 @@
 load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup", "pkg_files")
 load("@rules_pkg//pkg:pkg.bzl", "pkg_tar")
-load(
-    "//bazel:envoy_build_system.bzl",
-    "envoy_package",
-)
 
 licenses(["notice"])  # Apache 2
 
@@ -13,8 +9,6 @@ exports_files([
     "empty_extensions.json",
     "redirects.txt",
 ])
-
-envoy_package()
 
 filegroup(
     name = "configs",
@@ -46,6 +40,7 @@ filegroup(
             "root/intro/arch_overview/security/_include/ssl.yaml",
         ],
     }),
+    visibility = ["//visibility:public"],
 )
 
 filegroup(
@@ -57,11 +52,13 @@ filegroup(
         "//bazel:windows_x86_64": [],
         "//conditions:default": glob(["root/_configs/go/*.yaml"]),
     }),
+    visibility = ["//visibility:public"],
 )
 
 filegroup(
     name = "proto_examples",
     srcs = glob(["root/**/*.pb"]),
+    visibility = ["//visibility:public"],
 )
 
 genrule(
@@ -267,6 +264,7 @@ genrule(
         "//tools/docs:sphinx_runner",
         "@envoy_api//:v3_proto_set",
     ],
+    visibility = ["//visibility:public"],
 )
 
 # No git stamping, speeds up local dev switching branches

--- a/tools/api_versioning/BUILD
+++ b/tools/api_versioning/BUILD
@@ -1,16 +1,11 @@
 load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
-load(
-    "//bazel:envoy_build_system.bzl",
-    "envoy_package",
-)
 
 licenses(["notice"])  # Apache 2
-
-envoy_package()
 
 py_library(
     name = "utils",
     srcs = ["utils.py"],
+    visibility = ["//visibility:public"],
 )
 
 py_test(

--- a/tools/base/envoy_python.bzl
+++ b/tools/base/envoy_python.bzl
@@ -172,7 +172,7 @@ def envoy_jinja_env(
         deps = [name_entry_point],
     )
 
-def envoy_genjson(name, srcs = [], yaml_srcs = [], filter = None, args = None):
+def envoy_genjson(name, srcs = [], yaml_srcs = [], filter = None, args = None, visibility = None):
     '''Generate JSON from JSON and YAML sources
 
     By default the sources will be merged in jq `slurp` mode.
@@ -223,6 +223,7 @@ def envoy_genjson(name, srcs = [], yaml_srcs = [], filter = None, args = None):
         out = "%s.json" % name,
         args = args,
         filter = filter,
+        visibility = visibility,
     )
 
 def envoy_py_data(

--- a/tools/bootstrap2pb/BUILD
+++ b/tools/bootstrap2pb/BUILD
@@ -1,12 +1,9 @@
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_binary",
-    "envoy_package",
 )
 
 licenses(["notice"])  # Apache 2
-
-envoy_package()
 
 envoy_cc_binary(
     name = "bootstrap2pb",

--- a/tools/ci/BUILD
+++ b/tools/ci/BUILD
@@ -1,10 +1,7 @@
 load("@rules_python//python/entry_points:py_console_script_binary.bzl", "py_console_script_binary")
-load("//bazel:envoy_build_system.bzl", "envoy_package")
 load("//tools/python:namespace.bzl", "envoy_py_namespace")
 
 licenses(["notice"])  # Apache 2
-
-envoy_package()
 
 envoy_py_namespace()
 

--- a/tools/clang-format/BUILD
+++ b/tools/clang-format/BUILD
@@ -1,12 +1,10 @@
 load("@base_pip3//:requirements.bzl", "requirement")
-load("//bazel:envoy_build_system.bzl", "envoy_package")
 load(":clang_format.bzl", "clang_format")
 
 licenses(["notice"])  # Apache 2
 
-envoy_package()
-
 clang_format(
     name = "clang-format",
     target = requirement("clang-format"),
+    visibility = ["//visibility:public"],
 )

--- a/tools/clang-tidy/BUILD
+++ b/tools/clang-tidy/BUILD
@@ -1,10 +1,7 @@
 load("@base_pip3//:requirements.bzl", "requirement")
-load("//bazel:envoy_build_system.bzl", "envoy_package")
 load(":clang_tidy.bzl", "clang_tidy")
 
 licenses(["notice"])  # Apache 2
-
-envoy_package()
 
 clang_tidy(
     name = "clang-tidy",

--- a/tools/code/BUILD
+++ b/tools/code/BUILD
@@ -1,7 +1,6 @@
 load("@aspect_bazel_lib//lib:jq.bzl", "jq")
 load("@envoy_repo//:path.bzl", "PATH")
 load("@rules_python//python/entry_points:py_console_script_binary.bzl", "py_console_script_binary")
-load("//bazel:envoy_build_system.bzl", "envoy_package")
 load(
     "//test/extensions/filters/network/common/fuzz:config.bzl",
     "READFILTER_FUZZ_FILTERS",
@@ -10,8 +9,6 @@ load(
 load("//tools/python:namespace.bzl", "envoy_py_namespace")
 
 licenses(["notice"])  # Apache 2
-
-envoy_package()
 
 envoy_py_namespace()
 

--- a/tools/code_format/BUILD
+++ b/tools/code_format/BUILD
@@ -1,11 +1,8 @@
 load("@base_pip3//:requirements.bzl", "requirement")
 load("@envoy_repo//:path.bzl", "PATH")
 load("@rules_python//python:defs.bzl", "py_binary")
-load("//bazel:envoy_build_system.bzl", "envoy_package")
 
 licenses(["notice"])  # Apache 2
-
-envoy_package()
 
 py_library(
     name = "envoy_build_fixer",

--- a/tools/code_format/config.yaml
+++ b/tools/code_format/config.yaml
@@ -62,7 +62,6 @@ paths:
   build_fixer:
     exclude:
     - BUILD
-    - tools/BUILD
     - bazel/BUILD
     - bazel/external/
     - bazel/toolchains/

--- a/tools/code_format/envoy_build_fixer.py
+++ b/tools/code_format/envoy_build_fixer.py
@@ -92,7 +92,7 @@ def fix_package_and_license(path, contents):
 
     # Ensure we have an envoy_package / envoy_mobile_package import load if this is a real Envoy package.
     # We also allow the prefix to be overridden if envoy is included in a larger workspace.
-    if re.search(ENVOY_RULE_REGEX, contents):
+    if "tools/" not in path and re.search(ENVOY_RULE_REGEX, contents):
         new_load = 'new_load {}//bazel:envoy_build_system.bzl %s' % package_string
         contents = run_buildozer([
             (new_load.format(os.getenv("ENVOY_BAZEL_PREFIX", "")), '__pkg__'),

--- a/tools/dependency/BUILD
+++ b/tools/dependency/BUILD
@@ -2,13 +2,10 @@ load("@base_pip3//:requirements.bzl", "requirement")
 load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 load("@envoy_repo//:path.bzl", "PATH")
 load("@rules_python//python/entry_points:py_console_script_binary.bzl", "py_console_script_binary")
-load("//bazel:envoy_build_system.bzl", "envoy_package")
 load("//tools/base:envoy_python.bzl", "envoy_genjson", "envoy_pytool_binary")
 load("//tools/python:namespace.bzl", "envoy_py_namespace")
 
 licenses(["notice"])  # Apache 2
-
-envoy_package()
 
 envoy_py_namespace()
 
@@ -35,6 +32,7 @@ envoy_genjson(
     .[0]
     | del(.confluentinc_librdkafka)
     """,
+    visibility = ["//visibility:public"],
 )
 
 py_console_script_binary(
@@ -55,6 +53,7 @@ py_console_script_binary(
     }),
     pkg = "@base_pip3//envoy_dependency_check",
     script = "envoy.dependency.check",
+    visibility = ["//visibility:public"],
     deps = [requirement("orjson")],
 )
 

--- a/tools/distribution/BUILD
+++ b/tools/distribution/BUILD
@@ -1,12 +1,9 @@
 load("@base_pip3//:requirements.bzl", "requirement")
 load("@rules_python//python/entry_points:py_console_script_binary.bzl", "py_console_script_binary")
-load("//bazel:envoy_build_system.bzl", "envoy_package")
 load("//tools/base:envoy_python.bzl", "envoy_pytool_binary")
 load("//tools/python:namespace.bzl", "envoy_py_namespace")
 
 licenses(["notice"])  # Apache 2
-
-envoy_package()
 
 envoy_py_namespace()
 
@@ -14,18 +11,21 @@ py_console_script_binary(
     name = "release",
     pkg = "@base_pip3//envoy_distribution_release",
     script = "envoy.distribution.release",
+    visibility = ["//visibility:public"],
 )
 
 py_console_script_binary(
     name = "sign",
     pkg = "@base_pip3//envoy_gpg_sign",
     script = "envoy.gpg.sign",
+    visibility = ["//visibility:public"],
 )
 
 py_console_script_binary(
     name = "verify",
     pkg = "@base_pip3//envoy_distribution_verify",
     script = "envoy.distribution.verify",
+    visibility = ["//visibility:public"],
 )
 
 envoy_pytool_binary(

--- a/tools/docs/BUILD
+++ b/tools/docs/BUILD
@@ -1,18 +1,16 @@
 load("@base_pip3//:requirements.bzl", "requirement")
 load("@rules_python//python/entry_points:py_console_script_binary.bzl", "py_console_script_binary")
-load("//bazel:envoy_build_system.bzl", "envoy_package")
 load("//tools/base:envoy_python.bzl", "ENVOY_PYTOOL_NAMESPACE", "envoy_pytool_binary")
 load("//tools/python:namespace.bzl", "envoy_py_namespace")
 
 licenses(["notice"])  # Apache 2
-
-envoy_package()
 
 envoy_py_namespace()
 
 envoy_pytool_binary(
     name = "generate_extensions_security_rst",
     srcs = ["generate_extensions_security_rst.py"],
+    visibility = ["//visibility:public"],
     deps = [
         requirement("envoy.base.utils"),
     ],
@@ -23,11 +21,13 @@ envoy_pytool_binary(
     srcs = ["generate_external_deps_rst.py"],
     args = ["$(location //bazel:all_repository_locations)"],
     data = ["//bazel:all_repository_locations"],
+    visibility = ["//visibility:public"],
 )
 
 envoy_pytool_binary(
     name = "generate_api_rst",
     srcs = ["generate_api_rst.py"],
+    visibility = ["//visibility:public"],
 )
 
 # The upstream lib is maintained here:
@@ -49,6 +49,7 @@ py_console_script_binary(
 envoy_pytool_binary(
     name = "generate_version_histories",
     srcs = ["generate_version_histories.py"],
+    visibility = ["//visibility:public"],
     deps = [
         requirement("aio.run.runner"),
         requirement("envoy.base.utils"),

--- a/tools/gcs/BUILD
+++ b/tools/gcs/BUILD
@@ -1,9 +1,6 @@
 load("@envoy_repo//:path.bzl", "PATH")
-load("//bazel:envoy_build_system.bzl", "envoy_package")
 
 licenses(["notice"])  # Apache 2
-
-envoy_package()
 
 sh_binary(
     name = "upload",

--- a/tools/gsutil/BUILD
+++ b/tools/gsutil/BUILD
@@ -1,11 +1,8 @@
 load("@base_pip3//:requirements.bzl", "requirement")
 load("@rules_python//python:defs.bzl", "py_binary", "py_library")
-load("//bazel:envoy_build_system.bzl", "envoy_package")
 load("//bazel:repositories_extra.bzl", "PYTHON_MINOR_VERSION")
 
 licenses(["notice"])  # Apache 2
-
-envoy_package()
 
 # Please see ./tools/gsutil/vendor_util.sh for a Docker-based
 # method of updating this vendored lib.
@@ -18,6 +15,7 @@ py_library(
 py_binary(
     name = "gsutil",
     srcs = ["gsutil.py"],
+    visibility = ["//visibility:public"],
     deps = [
         ":crcmod",
         requirement("gsutil"),

--- a/tools/h3_request/BUILD
+++ b/tools/h3_request/BUILD
@@ -1,14 +1,8 @@
 load("@base_pip3//:requirements.bzl", "requirement")
-load(
-    "//bazel:envoy_build_system.bzl",
-    "envoy_package",
-)
 load("//tools/base:envoy_python.bzl", "envoy_pytool_binary")
 load("//tools/python:namespace.bzl", "envoy_py_namespace")
 
 licenses(["notice"])  # Apache 2
-
-envoy_package()
 
 envoy_py_namespace()
 
@@ -17,6 +11,7 @@ envoy_py_namespace()
 envoy_pytool_binary(
     name = "h3_request",
     srcs = ["h3_request.py"],
+    visibility = ["//visibility:public"],
     deps = [
         requirement("aioquic"),
     ],

--- a/tools/proto_format/BUILD
+++ b/tools/proto_format/BUILD
@@ -2,13 +2,10 @@ load("@aspect_bazel_lib//lib:jq.bzl", "jq")
 load("@envoy_repo//:path.bzl", "PATH")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_files", "strip_prefix")
 load("@rules_pkg//pkg:pkg.bzl", "pkg_tar")
-load("//bazel:envoy_build_system.bzl", "envoy_package")
 load("//tools/base:envoy_python.bzl", "envoy_genjson", "envoy_py_data", "envoy_pytool_binary")
 load("//tools/python:namespace.bzl", "envoy_py_namespace")
 
 licenses(["notice"])  # Apache 2
-
-envoy_package()
 
 envoy_py_namespace()
 

--- a/tools/protodoc/BUILD
+++ b/tools/protodoc/BUILD
@@ -1,14 +1,11 @@
 load("@base_pip3//:requirements.bzl", "requirement")
 load("@com_github_grpc_grpc//bazel:python_rules.bzl", "py_proto_library")
 load("@rules_proto//proto:defs.bzl", "proto_library")
-load("//bazel:envoy_build_system.bzl", "envoy_package")
 load("//tools/base:envoy_python.bzl", "envoy_genjson", "envoy_jinja_env", "envoy_py_data", "envoy_pytool_binary", "envoy_pytool_library")
 load("//tools/protodoc:protodoc.bzl", "protodoc_rule")
 load("//tools/python:namespace.bzl", "envoy_py_namespace")
 
 licenses(["notice"])  # Apache 2
-
-envoy_package()
 
 envoy_py_namespace()
 
@@ -133,6 +130,7 @@ envoy_pytool_binary(
 
 protodoc_rule(
     name = "api_v3_protodoc",
+    visibility = ["//visibility:public"],
     deps = [
         "@envoy_api//:v3_protos",
         "@envoy_api//:xds_protos",

--- a/tools/protoprint/BUILD
+++ b/tools/protoprint/BUILD
@@ -2,14 +2,11 @@ load("@base_pip3//:requirements.bzl", "requirement")
 load("@com_github_grpc_grpc//bazel:python_rules.bzl", "py_proto_library")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_files", "strip_prefix")
 load("@rules_pkg//pkg:pkg.bzl", "pkg_tar")
-load("//bazel:envoy_build_system.bzl", "envoy_package")
 load("//tools/base:envoy_python.bzl", "envoy_py_data", "envoy_pytool_binary")
 load("//tools/protoprint:protoprint.bzl", "protoprint_rule")
 load("//tools/python:namespace.bzl", "envoy_py_namespace")
 
 licenses(["notice"])  # Apache 2
-
-envoy_package()
 
 envoy_py_namespace()
 
@@ -68,6 +65,7 @@ pkg_tar(
     name = "protoprinted",
     srcs = [":protoprinted_files_stripped"],
     extension = "tar.gz",
+    visibility = ["//visibility:public"],
 )
 
 protoprint_rule(

--- a/tools/repo/BUILD
+++ b/tools/repo/BUILD
@@ -1,11 +1,8 @@
 load("@base_pip3//:requirements.bzl", "requirement")
-load("//bazel:envoy_build_system.bzl", "envoy_package")
 load("//tools/base:envoy_python.bzl", "envoy_pytool_binary")
 load("//tools/python:namespace.bzl", "envoy_py_namespace")
 
 licenses(["notice"])  # Apache 2
-
-envoy_package()
 
 envoy_py_namespace()
 
@@ -14,6 +11,7 @@ envoy_pytool_binary(
     srcs = ["notify.py"],
     args = ["$(location //:reviewers.yaml)"],
     data = ["//:reviewers.yaml"],
+    visibility = ["//visibility:public"],
     deps = [
         requirement("aio.api.github"),
         requirement("aio.run.runner"),

--- a/tools/sha/BUILD
+++ b/tools/sha/BUILD
@@ -1,9 +1,6 @@
 load("@envoy_repo//:path.bzl", "PATH")
-load("//bazel:envoy_build_system.bzl", "envoy_package")
 
 licenses(["notice"])  # Apache 2
-
-envoy_package()
 
 sh_binary(
     name = "replace",

--- a/tools/socket_passing/BUILD
+++ b/tools/socket_passing/BUILD
@@ -1,16 +1,14 @@
 load(
     "//bazel:envoy_build_system.bzl",
-    "envoy_package",
     "envoy_py_test_binary",
 )
 
 licenses(["notice"])  # Apache 2
-
-envoy_package()
 
 envoy_py_test_binary(
     name = "socket_passing",
     srcs = [
         "socket_passing.py",
     ],
+    visibility = ["//visibility:public"],
 )

--- a/tools/type_whisperer/BUILD
+++ b/tools/type_whisperer/BUILD
@@ -1,13 +1,11 @@
 load("@rules_python//python:defs.bzl", "py_binary")
-load("//bazel:envoy_build_system.bzl", "envoy_cc_library", "envoy_package", "envoy_proto_library")
+load("//bazel:envoy_build_system.bzl", "envoy_cc_library", "envoy_proto_library")
 load("//tools/type_whisperer:api_build_file.bzl", "api_build_file")
 load("//tools/type_whisperer:file_descriptor_set_text.bzl", "file_descriptor_set_text")
 load("//tools/type_whisperer:proto_cc_source.bzl", "proto_cc_source")
 load("//tools/type_whisperer:type_database.bzl", "type_database")
 
 licenses(["notice"])  # Apache 2
-
-envoy_package()
 
 envoy_proto_library(
     name = "types",
@@ -99,6 +97,7 @@ envoy_cc_library(
         ":embedded_api_type_db",
     ],
     hdrs = ["api_type_db.h"],
+    visibility = ["//visibility:public"],
     deps = [
         "//source/common/protobuf",
         "//tools/type_whisperer:api_type_db_proto_cc_proto",
@@ -124,4 +123,5 @@ py_binary(
 api_build_file(
     name = "api_build_file",
     typedb = "//tools/type_whisperer:api_type_db",
+    visibility = ["//visibility:public"],
 )

--- a/tools/zstd/BUILD
+++ b/tools/zstd/BUILD
@@ -1,11 +1,9 @@
-load("//bazel:envoy_build_system.bzl", "envoy_package")
 load(":zstd.bzl", "zstd")
 
 licenses(["notice"])  # Apache 2
 
-envoy_package()
-
 zstd(
     name = "zstd",
     target = "//bazel/foreign_cc:zstd",
+    visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
the `envoy_package` rule works against bazel's visibility system by just making everything visible - which is a bit of an anti-pattern - but it also pulls in a lot of unused/unnecessary deps when accessing tools 