### PR TITLE
Relax recent SNI restrictions

### DIFF
--- a/source/common/common/utility.cc
+++ b/source/common/common/utility.cc
@@ -590,7 +590,8 @@ std::string StringUtil::sanitizeInvalidHostname(const absl::string_view source) 
   std::string ret_str = std::string(source);
   bool sanitized = false;
   for (size_t i = 0; i < ret_str.size(); ++i) {
-    if (absl::ascii_isalnum(ret_str[i]) || ret_str[i] == '.' || ret_str[i] == '-') {
+    if (absl::ascii_isalnum(ret_str[i]) || ret_str[i] == '.' || ret_str[i] == '-' ||
+        ret_str[i] == '_') {
       continue;
     }
     sanitized = true;

--- a/source/common/common/utility.h
+++ b/source/common/common/utility.h
@@ -492,8 +492,8 @@ public:
 
   /**
    * Sanitize host name strings for logging purposes. Replace invalid hostname characters (anything
-   * that's not alphanumeric, hyphen, or period) with underscore. The sanitized string is not a
-   * valid host name.
+   * that's not alphanumeric, hyphen, or period) with underscore. The sanitized string
+   * is not a valid host name.
    * @param source supplies the string to sanitize.
    * @return sanitized string.
    */

--- a/test/common/formatter/substitution_formatter_test.cc
+++ b/test/common/formatter/substitution_formatter_test.cc
@@ -958,6 +958,15 @@ TEST(SubstitutionFormatterTest, streamInfoFormatter) {
 
   {
     StreamInfoFormatter upstream_format("REQUESTED_SERVER_NAME");
+    std::string requested_server_name = "outbound_.8080_._.example.com";
+    stream_info.downstream_connection_info_provider_->setRequestedServerName(requested_server_name);
+    EXPECT_EQ("outbound_.8080_._.example.com", upstream_format.formatWithContext({}, stream_info));
+    EXPECT_THAT(upstream_format.formatValueWithContext({}, stream_info),
+                ProtoEq(ValueUtil::stringValue("outbound_.8080_._.example.com")));
+  }
+
+  {
+    StreamInfoFormatter upstream_format("REQUESTED_SERVER_NAME");
     std::string requested_server_name = "stub-server";
     stream_info.downstream_connection_info_provider_->setRequestedServerName(requested_server_name);
     EXPECT_EQ("stub-server", upstream_format.formatWithContext({}, stream_info));


### PR DESCRIPTION

Commit Message: Relax recent SNI restrictions
Additional Description:
See https://github.com/istio/istio/issues/53426. Istio has used underscores in their SNI since the beginning and it is critical to its functionality. Usage of underscores in SNI is a bit of a grey area in the RFCs, which are extremely under-specified wrt to what exactly is the allowed formats. However, the de-facto standard is to allow them, as virtually every TLS library does so (including, but not limited to, Golang, rustls, openssl, boringssl).

This PR loosens the restriction to additionally allow underscores.

Note the intent of the SNI restrictions was not RFC compliance, etc -- but rather to fix [log injection](https://github.com/envoyproxy/envoy/security/advisories/GHSA-p222-xhp9-39rc) attacks (putting ANSI escapes, HTML, etc) into logs. This change does not loosen the security properties we hoped to gain with the initial patch.

Risk Level: Low
Testing: Unit tests added for the new case allowed
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
