### PR TITLE
Take absolute values when doing DNS jitter.

### DIFF
--- a/api/envoy/config/cluster/v3/cluster.proto
+++ b/api/envoy/config/cluster/v3/cluster.proto
@@ -965,7 +965,7 @@ message Cluster {
   // :ref:`STRICT_DNS<envoy_v3_api_enum_value_config.cluster.v3.Cluster.DiscoveryType.STRICT_DNS>`
   // and :ref:`LOGICAL_DNS<envoy_v3_api_enum_value_config.cluster.v3.Cluster.DiscoveryType.LOGICAL_DNS>`
   // this setting is ignored.
-  google.protobuf.Duration dns_jitter = 58;
+  google.protobuf.Duration dns_jitter = 58 [(validate.rules).duration = {gt {}}];
 
   // If the DNS failure refresh rate is specified and the cluster type is either
   // :ref:`STRICT_DNS<envoy_v3_api_enum_value_config.cluster.v3.Cluster.DiscoveryType.STRICT_DNS>`,

--- a/api/envoy/config/cluster/v3/cluster.proto
+++ b/api/envoy/config/cluster/v3/cluster.proto
@@ -965,7 +965,7 @@ message Cluster {
   // :ref:`STRICT_DNS<envoy_v3_api_enum_value_config.cluster.v3.Cluster.DiscoveryType.STRICT_DNS>`
   // and :ref:`LOGICAL_DNS<envoy_v3_api_enum_value_config.cluster.v3.Cluster.DiscoveryType.LOGICAL_DNS>`
   // this setting is ignored.
-  google.protobuf.Duration dns_jitter = 58 [(validate.rules).duration = {gt {}}];
+  google.protobuf.Duration dns_jitter = 58 [(validate.rules).duration = {gte {}}];
 
   // If the DNS failure refresh rate is specified and the cluster type is either
   // :ref:`STRICT_DNS<envoy_v3_api_enum_value_config.cluster.v3.Cluster.DiscoveryType.STRICT_DNS>`,

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -87,6 +87,9 @@ bug_fixes:
   change: |
     Relaxed the restriction on SNI logging to allow the ``_`` character, even if
     ``envoy.reloadable_features.sanitize_sni_in_access_log`` is enabled.
+- area: DNS
+  change: |
+    Fixed bug where setting `dns_jitter <envoy_v3_api_field_config.cluster.v3.Cluster.dns_jitter>` to large values caused Envoy to crash.
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -89,7 +89,8 @@ bug_fixes:
     ``envoy.reloadable_features.sanitize_sni_in_access_log`` is enabled.
 - area: DNS
   change: |
-    Fixed bug where setting ``dns_jitter <envoy_v3_api_field_config.cluster.v3.Cluster.dns_jitter>`` to large values caused Envoy to crash.
+    Fixed bug where setting ``dns_jitter <envoy_v3_api_field_config.cluster.v3.Cluster.dns_jitter>`` to large values caused Envoy Bug
+    to fire.
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -89,7 +89,7 @@ bug_fixes:
     ``envoy.reloadable_features.sanitize_sni_in_access_log`` is enabled.
 - area: DNS
   change: |
-    Fixed bug where setting `dns_jitter <envoy_v3_api_field_config.cluster.v3.Cluster.dns_jitter>` to large values caused Envoy to crash.
+    Fixed bug where setting ``dns_jitter <envoy_v3_api_field_config.cluster.v3.Cluster.dns_jitter>`` to large values caused Envoy to crash.
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/source/extensions/clusters/logical_dns/logical_dns_cluster.cc
+++ b/source/extensions/clusters/logical_dns/logical_dns_cluster.cc
@@ -152,11 +152,12 @@ void LogicalDnsCluster::startResolve() {
             final_refresh_rate = addrinfo.ttl_;
           }
           if (dns_jitter_ms_.count() != 0) {
-            // We need to wrap with std::chrono::abs because
-            // random() returns an uint64 that is interpreted as a long by
-            // std::chrono::milliseconds. If the random() return value has a leading 1 in its binary
-            // representation, then it will be interpreted as a negative long, potentially causing
-            // final_refresh_rate to be negative. This causes Envoy to crash.
+            // Note that `parent_.random_.random()` returns a uint64 while
+            // `parent_.dns_jitter_ms_.count()` returns a signed long that gets cast into a uint64.
+            // Thus, the modulo of the two will be a positive as long as
+            // `parent_dns_jitter_ms_.count()` is positive.
+            // It is important that this be positive, otherwise `final_refresh_rate` could be
+            // negative causing Envoy to crash.
             final_refresh_rate +=
                 std::chrono::abs(std::chrono::milliseconds(random_.random()) % dns_jitter_ms_);
           }

--- a/source/extensions/clusters/logical_dns/logical_dns_cluster.cc
+++ b/source/extensions/clusters/logical_dns/logical_dns_cluster.cc
@@ -152,14 +152,14 @@ void LogicalDnsCluster::startResolve() {
             final_refresh_rate = addrinfo.ttl_;
           }
           if (dns_jitter_ms_.count() != 0) {
-            // Note that `parent_.random_.random()` returns a uint64 while
-            // `parent_.dns_jitter_ms_.count()` returns a signed long that gets cast into a uint64.
+            // Note that `random_.random()` returns a uint64 while
+            // `dns_jitter_ms_.count()` returns a signed long that gets cast into a uint64.
             // Thus, the modulo of the two will be a positive as long as
-            // `parent_dns_jitter_ms_.count()` is positive.
+            // `dns_jitter_ms_.count()` is positive.
             // It is important that this be positive, otherwise `final_refresh_rate` could be
             // negative causing Envoy to crash.
             final_refresh_rate +=
-                std::chrono::abs(std::chrono::milliseconds(random_.random()) % dns_jitter_ms_);
+                std::chrono::milliseconds(random_.random() % dns_jitter_ms_.count());
           }
           ENVOY_LOG(debug, "DNS refresh rate reset for {}, refresh rate {} ms", dns_address_,
                     final_refresh_rate.count());

--- a/source/extensions/clusters/logical_dns/logical_dns_cluster.cc
+++ b/source/extensions/clusters/logical_dns/logical_dns_cluster.cc
@@ -153,11 +153,10 @@ void LogicalDnsCluster::startResolve() {
           }
           if (dns_jitter_ms_.count() != 0) {
             // We need to wrap with std::chrono::abs because
-            // random() returns an unsigned long that is interpreted as a long by
-            // std::chrono::milliseconds. If the random() return value is large enough, then
-            // it will be interpreted as a negative long, potentially causing final_refresh_rate to
-            // be negative. This causes Envoy to crash.
-            // TODO add abs.
+            // random() returns an uint64 that is interpreted as a long by
+            // std::chrono::milliseconds. If the random() return value has a leading 1 in its binary
+            // representation, then it will be interpreted as a negative long, potentially causing
+            // final_refresh_rate to be negative. This causes Envoy to crash.
             final_refresh_rate +=
                 std::chrono::abs(std::chrono::milliseconds(random_.random()) % dns_jitter_ms_);
           }

--- a/source/extensions/clusters/strict_dns/strict_dns_cluster.cc
+++ b/source/extensions/clusters/strict_dns/strict_dns_cluster.cc
@@ -198,11 +198,10 @@ void StrictDnsClusterImpl::ResolveTarget::startResolve() {
           }
           if (parent_.dns_jitter_ms_.count() > 0) {
             // We need to wrap with std::chrono::abs because
-            // random() returns an unsigned long that is interpreted as a long by
-            // std::chrono::milliseconds. If the random() return value is large enough, then
-            // it will be interpreted as a negative long, potentially causing final_refresh_rate to
-            // be negative. This causes Envoy to crash.
-            // TODO add abs
+            // random() returns an uint64 that is interpreted as a long by
+            // std::chrono::milliseconds. If the random() return value has a leading 1 in its binary
+            // representation, then it will be interpreted as a negative long, potentially causing
+            // final_refresh_rate to be negative. This causes Envoy to crash.
             final_refresh_rate += std::chrono::abs(
                 std::chrono::milliseconds(parent_.random_.random()) % parent_.dns_jitter_ms_);
           }

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -1,5 +1,6 @@
 #include <chrono>
 #include <cstdint>
+#include <limits>
 #include <list>
 #include <memory>
 #include <string>
@@ -1531,6 +1532,40 @@ TEST_F(StrictDnsClusterImplTest, TtlAsDnsRefreshRateYesJitter) {
   resolver.dns_callback_(
       Network::DnsResolver::ResolutionStatus::Completed, "",
       TestUtility::makeDnsResponse({"192.168.1.1", "192.168.1.2"}, std::chrono::seconds(ttl_s)));
+}
+
+TEST_F(StrictDnsClusterImplTest, ExtremeJitter) {
+  ResolverData resolver(*dns_resolver_, server_context_.dispatcher_);
+
+  const std::string yaml = R"EOF(
+    name: name
+    connect_timeout: 0.25s
+    type: STRICT_DNS
+    lb_policy: ROUND_ROBIN
+    dns_refresh_rate: 4s
+    dns_jitter: 1s
+    respect_dns_ttl: true
+    load_assignment:
+        endpoints:
+          - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    address: localhost1
+                    port_value: 11001
+  )EOF";
+  envoy::config::cluster::v3::Cluster cluster_config = parseClusterFromV3Yaml(yaml);
+  Envoy::Upstream::ClusterFactoryContextImpl factory_context(
+      server_context_, server_context_.cluster_manager_, nullptr, ssl_context_manager_, nullptr,
+      false);
+  auto cluster = *StrictDnsClusterImpl::create(cluster_config, factory_context, dns_resolver_);
+  cluster->initialize([] {});
+
+  EXPECT_CALL(*resolver.timer_, enableTimer(testing::Ge(std::chrono::milliseconds(1000)), _));
+  ON_CALL(random_, random()).WillByDefault(Return(std::numeric_limits<int64_t>::min()));
+  resolver.dns_callback_(
+      Network::DnsResolver::ResolutionStatus::Completed, "",
+      TestUtility::makeDnsResponse({"192.168.1.1", "192.168.1.2"}, std::chrono::seconds(1)));
 }
 
 // Ensures that HTTP/2 user defined SETTINGS parameter validation is enforced on clusters.

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -1491,6 +1491,30 @@ TEST_F(StrictDnsClusterImplTest, TtlAsDnsRefreshRateNoJitter) {
                          TestUtility::makeDnsResponse({}, std::chrono::seconds(5)));
 }
 
+TEST_F(StrictDnsClusterImplTest, NegativeDnsJitter) {
+  const std::string yaml = R"EOF(
+    name: name
+    type: STRICT_DNS
+    lb_policy: ROUND_ROBIN
+    dns_refresh_rate: 4s
+    dns_jitter: -1s
+    load_assignment:
+        endpoints:
+          - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    address: localhost1
+                    port_value: 11001
+  )EOF";
+  envoy::config::cluster::v3::Cluster cluster_config = parseClusterFromV3Yaml(yaml);
+  Envoy::Upstream::ClusterFactoryContextImpl factory_context(
+      server_context_, server_context_.cluster_manager_, nullptr, ssl_context_manager_, nullptr,
+      false);
+  EXPECT_THROW_WITH_MESSAGE(
+      auto x = *StrictDnsClusterImpl::create(cluster_config, factory_context, dns_resolver_),
+      EnvoyException, "Invalid duration: Expected positive duration: seconds: -1\n");
+}
 TEST_F(StrictDnsClusterImplTest, TtlAsDnsRefreshRateYesJitter) {
   ResolverData resolver(*dns_resolver_, server_context_.dispatcher_);
 

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -1566,8 +1566,8 @@ TEST_F(StrictDnsClusterImplTest, ExtremeJitter) {
     connect_timeout: 0.25s
     type: STRICT_DNS
     lb_policy: ROUND_ROBIN
-    dns_refresh_rate: 4s
-    dns_jitter: 1s
+    dns_refresh_rate: 1s
+    dns_jitter: 1000s
     respect_dns_ttl: true
     load_assignment:
         endpoints:

--- a/test/extensions/clusters/logical_dns/logical_dns_cluster_test.cc
+++ b/test/extensions/clusters/logical_dns/logical_dns_cluster_test.cc
@@ -1,4 +1,5 @@
 #include <chrono>
+#include <limits>
 #include <memory>
 #include <string>
 #include <tuple>
@@ -642,6 +643,43 @@ TEST_F(LogicalDnsClusterTest, DNSRefreshHasJitter) {
   EXPECT_CALL(*resolve_timer_, enableTimer(std::chrono::milliseconds(4000 + jitter_ms), _));
   ON_CALL(random_, random()).WillByDefault(Return(random_return));
 
+  dns_callback_(
+      Network::DnsResolver::ResolutionStatus::Completed, "",
+      TestUtility::makeDnsResponse({"127.0.0.1", "127.0.0.2"}, std::chrono::seconds(3000)));
+}
+
+TEST_F(LogicalDnsClusterTest, ExtremeJitter) {
+  // When random returns large values, they were being reinterpreted as very negative values causing
+  // negative refresh rates.
+  const std::string jitter_yaml = R"EOF(
+  name: name
+  type: LOGICAL_DNS
+  dns_refresh_rate: 4s
+  dns_failure_refresh_rate:
+    base_interval: 7s
+    max_interval: 10s
+  connect_timeout: 0.25s
+  dns_jitter: 1s
+  lb_policy: ROUND_ROBIN
+  # Since the following expectResolve() requires Network::DnsLookupFamily::V4Only we need to set
+  # dns_lookup_family to V4_ONLY explicitly for v2 .yaml config.
+  dns_lookup_family: V4_ONLY
+  load_assignment:
+        endpoints:
+          - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    address: foo.bar.com
+                    port_value: 443
+  )EOF";
+
+  EXPECT_CALL(initialized_, ready());
+  expectResolve(Network::DnsLookupFamily::V4Only, "foo.bar.com");
+  setupFromV3Yaml(jitter_yaml);
+  EXPECT_CALL(membership_updated_, ready());
+  EXPECT_CALL(*resolve_timer_, enableTimer(testing::Ge(std::chrono::milliseconds(4000)), _));
+  ON_CALL(random_, random()).WillByDefault(Return(std::numeric_limits<int64_t>::min()));
   dns_callback_(
       Network::DnsResolver::ResolutionStatus::Completed, "",
       TestUtility::makeDnsResponse({"127.0.0.1", "127.0.0.2"}, std::chrono::seconds(3000)));

--- a/test/extensions/clusters/logical_dns/logical_dns_cluster_test.cc
+++ b/test/extensions/clusters/logical_dns/logical_dns_cluster_test.cc
@@ -676,12 +676,12 @@ TEST_F(LogicalDnsClusterTest, ExtremeJitter) {
   const std::string jitter_yaml = R"EOF(
   name: name
   type: LOGICAL_DNS
-  dns_refresh_rate: 4s
+  dns_refresh_rate: 1s
   dns_failure_refresh_rate:
     base_interval: 7s
     max_interval: 10s
   connect_timeout: 0.25s
-  dns_jitter: 1s
+  dns_jitter: 1000s
   lb_policy: ROUND_ROBIN
   # Since the following expectResolve() requires Network::DnsLookupFamily::V4Only we need to set
   # dns_lookup_family to V4_ONLY explicitly for v2 .yaml config.


### PR DESCRIPTION
Commit Message: Take absolute values when doing DNS jitter.
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue] #36943
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]

In response to #36943. Jitter is generated by taking a random value from the random generator and creating a std::chrono::millisecond.
Since the random value is a uint64, I figured that the resulting std::chrono::millisecond would have to be positive.
However, std::chrono::millisecond uses a int64 under the hood, so large random values were being converted to negative numbers.
For example, if the random generator returned 0x8000000000000000, there would be a jitter of -9223372036854775808ms.
This jitter would in turn case the refresh timer to be negative.
