### PR TITLE
tls_inspector: add JA4 fingerprinting

### DIFF
--- a/api/envoy/extensions/filters/listener/tls_inspector/v3/tls_inspector.proto
+++ b/api/envoy/extensions/filters/listener/tls_inspector/v3/tls_inspector.proto
@@ -32,4 +32,9 @@ message TlsInspector {
   // tls inspector will consume.
   google.protobuf.UInt32Value initial_read_buffer_size = 2
       [(validate.rules).uint32 = {lt: 65537 gt: 255}];
+
+  // Populate ``JA4`` fingerprint hash using data from the TLS Client Hello packet.
+  // ``JA4`` is an improved version of ``JA3`` that includes TLS version, ciphers, extensions,
+  // and ALPN information in a hex format. Default is false.
+  google.protobuf.BoolValue enable_ja4_fingerprinting = 3;
 }

--- a/envoy/network/listen_socket.h
+++ b/envoy/network/listen_socket.h
@@ -64,9 +64,19 @@ public:
   virtual void setJA3Hash(absl::string_view ja3_hash) PURE;
 
   /**
+   * @param ja4Hash Connection ja3 fingerprint hash of the downstream connection.
+   */
+  virtual void setJA4Hash(absl::string_view ja4_hash) PURE;
+
+  /**
    * @return Connection ja3 fingerprint hash of the downstream connection, if any.
    */
   virtual absl::string_view ja3Hash() const PURE;
+
+  /**
+   * @return Connection ja4 fingerprint hash of the downstream connection, if any.
+   */
+  virtual absl::string_view ja4Hash() const PURE;
 
   /**
    *  @return absl::optional<std::chrono::milliseconds> An optional of the most recent round-trip

--- a/envoy/network/socket.h
+++ b/envoy/network/socket.h
@@ -278,6 +278,11 @@ public:
   virtual absl::string_view ja3Hash() const PURE;
 
   /**
+   * @return ja4 fingerprint hash of the downstream connection, if any.
+   */
+  virtual absl::string_view ja4Hash() const PURE;
+
+  /**
    * @return roundTripTime of the connection
    */
   virtual const absl::optional<std::chrono::milliseconds>& roundTripTime() const PURE;
@@ -352,6 +357,11 @@ public:
    * @param JA3 fingerprint.
    */
   virtual void setJA3Hash(const absl::string_view ja3_hash) PURE;
+
+  /**
+   * @param JA4 fingerprint.
+   */
+  virtual void setJA4Hash(const absl::string_view ja4_hash) PURE;
 
   /**
    * @param  milliseconds of round trip time of previous connection

--- a/source/common/formatter/stream_info_formatter.cc
+++ b/source/common/formatter/stream_info_formatter.cc
@@ -1662,6 +1662,18 @@ const StreamInfoFormatterProviderLookupTable& getKnownStreamInfoFormatterProvide
                     return result;
                   });
             }}},
+          {"TLS_JA4_FINGERPRINT",
+           {CommandSyntaxChecker::COMMAND_ONLY,
+            [](absl::string_view, absl::optional<size_t>) {
+              return std::make_unique<StreamInfoStringFormatterProvider>(
+                  [](const StreamInfo::StreamInfo& stream_info) {
+                    absl::optional<std::string> result;
+                    if (!stream_info.downstreamAddressProvider().ja4Hash().empty()) {
+                      result = std::string(stream_info.downstreamAddressProvider().ja4Hash());
+                    }
+                    return result;
+                  });
+            }}},
           {"UNIQUE_ID",
            {CommandSyntaxChecker::COMMAND_ONLY,
             [](absl::string_view, const absl::optional<size_t>&) {

--- a/source/common/http/filter_manager.h
+++ b/source/common/http/filter_manager.h
@@ -614,6 +614,9 @@ public:
   absl::string_view ja3Hash() const override {
     return StreamInfoImpl::downstreamAddressProvider().ja3Hash();
   }
+  absl::string_view ja4Hash() const override {
+    return StreamInfoImpl::downstreamAddressProvider().ja4Hash();
+  }
   const absl::optional<std::chrono::milliseconds>& roundTripTime() const override {
     return StreamInfoImpl::downstreamAddressProvider().roundTripTime();
   }

--- a/source/common/network/connection_socket_impl.h
+++ b/source/common/network/connection_socket_impl.h
@@ -74,6 +74,11 @@ public:
   }
   absl::string_view ja3Hash() const override { return connectionInfoProvider().ja3Hash(); }
 
+  void setJA4Hash(absl::string_view ja4_hash) override {
+    connectionInfoProvider().setJA4Hash(ja4_hash);
+  }
+  absl::string_view ja4Hash() const override { return connectionInfoProvider().ja4Hash(); }
+
   absl::optional<std::chrono::milliseconds> lastRoundTripTime() override {
     return ioHandle().lastRoundTripTime();
   }

--- a/source/common/network/socket_impl.h
+++ b/source/common/network/socket_impl.h
@@ -68,6 +68,8 @@ public:
   }
   absl::string_view ja3Hash() const override { return ja3_hash_; }
   void setJA3Hash(const absl::string_view ja3_hash) override { ja3_hash_ = std::string(ja3_hash); }
+  absl::string_view ja4Hash() const override { return ja4_hash_; }
+  void setJA4Hash(const absl::string_view ja4_hash) override { ja4_hash_ = std::string(ja4_hash); }
   const absl::optional<std::chrono::milliseconds>& roundTripTime() const override {
     return round_trip_time_;
   }
@@ -98,6 +100,7 @@ private:
   absl::optional<std::string> interface_name_;
   Ssl::ConnectionInfoConstSharedPtr ssl_info_;
   std::string ja3_hash_;
+  std::string ja4_hash_;
   absl::optional<std::chrono::milliseconds> round_trip_time_;
   FilterChainInfoConstSharedPtr filter_chain_info_;
   ListenerInfoConstSharedPtr listener_info_;

--- a/source/extensions/filters/listener/tls_inspector/tls_inspector.h
+++ b/source/extensions/filters/listener/tls_inspector/tls_inspector.h
@@ -57,6 +57,7 @@ public:
   const TlsInspectorStats& stats() const { return stats_; }
   bssl::UniquePtr<SSL> newSsl();
   bool enableJA3Fingerprinting() const { return enable_ja3_fingerprinting_; }
+  bool enableJA4Fingerprinting() const { return enable_ja4_fingerprinting_; }
   uint32_t maxClientHelloSize() const { return max_client_hello_size_; }
   uint32_t initialReadBufferSize() const { return initial_read_buffer_size_; }
 
@@ -68,6 +69,7 @@ private:
   TlsInspectorStats stats_;
   bssl::UniquePtr<SSL_CTX> ssl_ctx_;
   const bool enable_ja3_fingerprinting_;
+  const bool enable_ja4_fingerprinting_;
   const uint32_t max_client_hello_size_;
   const uint32_t initial_read_buffer_size_;
 };
@@ -92,6 +94,7 @@ private:
   void onALPN(const unsigned char* data, unsigned int len);
   void onServername(absl::string_view name);
   void createJA3Hash(const SSL_CLIENT_HELLO* ssl_client_hello);
+  void createJA4Hash(const SSL_CLIENT_HELLO* ssl_client_hello);
   uint32_t maxConfigReadBytes() const { return config_->maxClientHelloSize(); }
 
   ConfigSharedPtr config_;

--- a/test/common/listener_manager/filter_chain_benchmark_test.cc
+++ b/test/common/listener_manager/filter_chain_benchmark_test.cc
@@ -77,6 +77,7 @@ public:
   absl::string_view detectedTransportProtocol() const override { return transport_protocol_; }
   absl::string_view requestedServerName() const override { return server_name_; }
   absl::string_view ja3Hash() const override { return ja3_hash_; }
+  absl::string_view ja4Hash() const override { return ja4_hash_; }
   const std::vector<std::string>& requestedApplicationProtocols() const override {
     return application_protocols_;
   }
@@ -112,6 +113,7 @@ public:
   const OptionsSharedPtr& options() const override { return options_; }
   void setRequestedServerName(absl::string_view) override {}
   void setJA3Hash(absl::string_view) override {}
+  void setJA4Hash(absl::string_view) override {}
   Api::SysCallIntResult bind(Network::Address::InstanceConstSharedPtr) override { return {0, 0}; }
   Api::SysCallIntResult listen(int) override { return {0, 0}; }
   Api::SysCallIntResult connect(const Network::Address::InstanceConstSharedPtr) override {
@@ -138,6 +140,7 @@ private:
   std::shared_ptr<Network::ConnectionInfoSetterImpl> connection_info_provider_;
   std::string server_name_;
   std::string ja3_hash_;
+  std::string ja4_hash_;
   std::string transport_protocol_;
   std::vector<std::string> application_protocols_;
 };

--- a/test/config/utility.cc
+++ b/test/config/utility.cc
@@ -211,8 +211,9 @@ typed_config:
 )EOF";
 }
 
-std::string ConfigHelper::tlsInspectorFilter(bool enable_ja3_fingerprinting) {
-  if (!enable_ja3_fingerprinting) {
+std::string ConfigHelper::tlsInspectorFilter(bool enable_ja3_fingerprinting,
+                                             bool enable_ja4_fingerprinting) {
+  if (!enable_ja3_fingerprinting && !enable_ja4_fingerprinting) {
     return R"EOF(
 name: "envoy.filters.listener.tls_inspector"
 typed_config:
@@ -225,6 +226,7 @@ name: "envoy.filters.listener.tls_inspector"
 typed_config:
   "@type": type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
   enable_ja3_fingerprinting: true
+  enable_ja4_fingerprinting: true
 )EOF";
 }
 

--- a/test/config/utility.h
+++ b/test/config/utility.h
@@ -207,7 +207,8 @@ public:
                                            bool multiple_addresses = false);
 
   // A string for a tls inspector listener filter which can be used with addListenerFilter()
-  static std::string tlsInspectorFilter(bool enable_ja3_fingerprinting = false);
+  static std::string tlsInspectorFilter(bool enable_ja3_fingerprinting = false,
+                                        bool enable_ja4_fingerprinting = false);
 
   // A string for the test inspector filter.
   static std::string testInspectorFilter();

--- a/test/extensions/filters/listener/common/fuzz/listener_filter_fakes.cc
+++ b/test/extensions/filters/listener/common/fuzz/listener_filter_fakes.cc
@@ -53,6 +53,12 @@ void FakeConnectionSocket::setJA3Hash(absl::string_view ja3_hash) {
 
 absl::string_view FakeConnectionSocket::ja3Hash() const { return ja3_hash_; }
 
+void FakeConnectionSocket::setJA4Hash(absl::string_view ja4_hash) {
+  ja4_hash_ = std::string(ja4_hash);
+}
+
+absl::string_view FakeConnectionSocket::ja4Hash() const { return ja4_hash_; }
+
 Api::SysCallIntResult FakeConnectionSocket::getSocketOption([[maybe_unused]] int level, int,
                                                             [[maybe_unused]] void* optval,
                                                             socklen_t*) const {

--- a/test/extensions/filters/listener/common/fuzz/listener_filter_fakes.h
+++ b/test/extensions/filters/listener/common/fuzz/listener_filter_fakes.h
@@ -44,6 +44,10 @@ public:
 
   absl::string_view ja3Hash() const override;
 
+  void setJA4Hash(absl::string_view ja4_hash) override;
+
+  absl::string_view ja4Hash() const override;
+
   Api::SysCallIntResult getSocketOption(int level, int, void* optval, socklen_t*) const override;
 
   absl::optional<std::chrono::milliseconds> lastRoundTripTime() override;
@@ -54,6 +58,7 @@ private:
   std::string transport_protocol_;
   std::string server_name_;
   std::string ja3_hash_;
+  std::string ja4_hash_;
 };
 
 // TODO: Move over to Fake (name is confusing)

--- a/test/extensions/filters/listener/tls_inspector/tls_inspector_test.cc
+++ b/test/extensions/filters/listener/tls_inspector/tls_inspector_test.cc
@@ -95,6 +95,8 @@ public:
 
   void testJA3(const std::string& fingerprint, bool expect_server_name = true,
                const std::string& hash = {}, bool expect_alpn = true);
+  void testJA4(const std::string& expected_ja4, const std::string& sni = "",
+               const std::string& alpn = "");
 
   NiceMock<Api::MockOsSysCalls> os_sys_calls_;
   TestThreadsafeSingletonInjector<Api::OsSysCallsImpl> os_calls_{&os_sys_calls_};
@@ -483,6 +485,407 @@ TEST_P(TlsInspectorTest, RequestedMaxReadSizeDoesNotGoBeyondMaxSize) {
   EXPECT_EQ(Network::FilterStatus::StopIteration, state);
   EXPECT_EQ(max_size, filter_->maxReadBytes());
   EXPECT_FALSE(io_handle_->isOpen());
+}
+
+void TlsInspectorTest::testJA4(const std::string& expected_ja4, const std::string& sni,
+                               const std::string& alpn) {
+  envoy::extensions::filters::listener::tls_inspector::v3::TlsInspector proto_config;
+  proto_config.mutable_enable_ja4_fingerprinting()->set_value(true);
+  cfg_ = std::make_shared<Config>(*store_.rootScope(), proto_config);
+
+  std::vector<uint8_t> client_hello =
+      Tls::Test::generateClientHello(std::get<0>(GetParam()), std::get<1>(GetParam()), sni, alpn);
+
+  init();
+  mockSysCallForPeek(client_hello);
+
+  EXPECT_CALL(socket_, setJA4Hash(absl::string_view(expected_ja4)));
+
+  if (!sni.empty()) {
+    EXPECT_CALL(socket_, setRequestedServerName(absl::string_view(sni)));
+  }
+
+  if (alpn.empty() || alpn[0] == 0) {
+    // No ALPN extension at all or empty ALPN list
+    EXPECT_CALL(socket_, setRequestedApplicationProtocols(_)).Times(0);
+  } else {
+    // Normal ALPN list
+    std::vector<absl::string_view> alpn_protos;
+    size_t start = 0;
+    while (start < alpn.size()) {
+      size_t len = static_cast<size_t>(alpn[start]);
+      alpn_protos.push_back(absl::string_view(alpn.data() + start + 1, len));
+      start += len + 1;
+    }
+    EXPECT_CALL(socket_, setRequestedApplicationProtocols(testing::ContainerEq(alpn_protos)));
+  }
+
+  EXPECT_CALL(socket_, setDetectedTransportProtocol(absl::string_view("tls")));
+  EXPECT_CALL(socket_, detectedTransportProtocol()).Times(::testing::AnyNumber());
+
+  EXPECT_TRUE(file_event_callback_(Event::FileReadyType::Read).ok());
+  auto state = filter_->onData(*buffer_);
+  EXPECT_EQ(Network::FilterStatus::Continue, state);
+}
+
+const absl::flat_hash_map<uint16_t, std::string> basic_test_version_to_ja4_ = {
+    {TLS1_VERSION, "t10i040500_cefcabfea53d_950472255fe9"},
+    {TLS1_1_VERSION, "t11i040500_cefcabfea53d_950472255fe9"},
+    {TLS1_2_VERSION, "t12i100600_a8cf61a50a39_0f3b2bcde21d"},
+    {TLS1_3_VERSION, "t13i030500_55b375c5d22e_678be4e4848e"}};
+
+TEST_P(TlsInspectorTest, JA4Basic) {
+  const uint16_t min_version = std::get<0>(GetParam());
+  const uint16_t max_version = std::get<1>(GetParam());
+
+  std::string expected_value = (min_version == Config::TLS_MIN_SUPPORTED_VERSION &&
+                                max_version == Config::TLS_MAX_SUPPORTED_VERSION)
+                                   ? "t13i130900_f57a46bbacb6_78e6aca7449b"
+                                   : basic_test_version_to_ja4_.at(min_version);
+
+  testJA4(expected_value);
+}
+
+const absl::flat_hash_map<uint16_t, std::string> sni_test_version_to_ja4_ = {
+    {TLS1_VERSION, "t10d040600_cefcabfea53d_950472255fe9"},
+    {TLS1_1_VERSION, "t11d040600_cefcabfea53d_950472255fe9"},
+    {TLS1_2_VERSION, "t12d100700_a8cf61a50a39_0f3b2bcde21d"},
+    {TLS1_3_VERSION, "t13d030600_55b375c5d22e_678be4e4848e"}};
+
+TEST_P(TlsInspectorTest, JA4WithSNI) {
+  const uint16_t min_version = std::get<0>(GetParam());
+  const uint16_t max_version = std::get<1>(GetParam());
+
+  std::string expected_value = (min_version == Config::TLS_MIN_SUPPORTED_VERSION &&
+                                max_version == Config::TLS_MAX_SUPPORTED_VERSION)
+                                   ? "t13d131000_f57a46bbacb6_78e6aca7449b"
+                                   : sni_test_version_to_ja4_.at(min_version);
+
+  testJA4(expected_value, "example.com");
+}
+
+const absl::flat_hash_map<uint16_t, std::string> alpn_test_version_to_ja4_ = {
+    {TLS1_VERSION, "t10i0406h2_cefcabfea53d_950472255fe9"},
+    {TLS1_1_VERSION, "t11i0406h2_cefcabfea53d_950472255fe9"},
+    {TLS1_2_VERSION, "t12i1007h2_a8cf61a50a39_0f3b2bcde21d"},
+    {TLS1_3_VERSION, "t13i0306h2_55b375c5d22e_678be4e4848e"}};
+
+TEST_P(TlsInspectorTest, JA4WithALPN) {
+  const uint16_t min_version = std::get<0>(GetParam());
+  const uint16_t max_version = std::get<1>(GetParam());
+
+  std::string expected_value = (min_version == Config::TLS_MIN_SUPPORTED_VERSION &&
+                                max_version == Config::TLS_MAX_SUPPORTED_VERSION)
+                                   ? "t13i1310h2_f57a46bbacb6_78e6aca7449b"
+                                   : alpn_test_version_to_ja4_.at(min_version);
+
+  testJA4(expected_value, "", "\x02h2\x08http/1.1");
+}
+
+const absl::flat_hash_map<uint16_t, std::string> alpn_sni_test_version_to_ja4_ = {
+    {TLS1_VERSION, "t10d0407h2_cefcabfea53d_950472255fe9"},
+    {TLS1_1_VERSION, "t11d0407h2_cefcabfea53d_950472255fe9"},
+    {TLS1_2_VERSION, "t12d1008h2_a8cf61a50a39_0f3b2bcde21d"},
+    {TLS1_3_VERSION, "t13d0307h2_55b375c5d22e_678be4e4848e"}};
+
+TEST_P(TlsInspectorTest, JA4WithSNIAndALPN) {
+  const uint16_t min_version = std::get<0>(GetParam());
+  const uint16_t max_version = std::get<1>(GetParam());
+
+  std::string expected_value = (min_version == Config::TLS_MIN_SUPPORTED_VERSION &&
+                                max_version == Config::TLS_MAX_SUPPORTED_VERSION)
+                                   ? "t13d1312h2_f57a46bbacb6_ef7df7f74e48"
+                                   : alpn_sni_test_version_to_ja4_.at(min_version);
+
+  testJA4(expected_value, "example.com", "\x02h2\x08http/1.1");
+}
+
+const absl::flat_hash_map<uint16_t, std::string> alpn_single_char_test_version_to_ja4_ = {
+    {TLS1_VERSION, "t10i0406hh_cefcabfea53d_950472255fe9"},
+    {TLS1_1_VERSION, "t11i0406hh_cefcabfea53d_950472255fe9"},
+    {TLS1_2_VERSION, "t12i1007hh_a8cf61a50a39_0f3b2bcde21d"},
+    {TLS1_3_VERSION, "t13i0306hh_55b375c5d22e_678be4e4848e"}};
+
+TEST_P(TlsInspectorTest, JA4WithSingleCharacterALPN) {
+  const uint16_t min_version = std::get<0>(GetParam());
+  const uint16_t max_version = std::get<1>(GetParam());
+
+  // Create single character ALPN
+  std::string alpn;
+  alpn.push_back(0x01); // length
+  alpn.push_back('h');  // single character
+
+  std::string expected_ja4 = (min_version == Config::TLS_MIN_SUPPORTED_VERSION &&
+                              max_version == Config::TLS_MAX_SUPPORTED_VERSION)
+                                 ? "t13i1310hh_f57a46bbacb6_78e6aca7449b" // same char repeated
+                                 : alpn_single_char_test_version_to_ja4_.at(min_version);
+
+  testJA4(expected_ja4, "", alpn);
+}
+
+const absl::flat_hash_map<uint16_t, std::string> no_alpn_test_version_to_ja4_ = {
+    {TLS1_VERSION, "t10i040500_cefcabfea53d_950472255fe9"},
+    {TLS1_1_VERSION, "t11i040500_cefcabfea53d_950472255fe9"},
+    {TLS1_2_VERSION, "t12i100600_a8cf61a50a39_0f3b2bcde21d"},
+    {TLS1_3_VERSION, "t13i030500_55b375c5d22e_678be4e4848e"}};
+
+TEST_P(TlsInspectorTest, JA4WithEmptyALPN) {
+  const uint16_t min_version = std::get<0>(GetParam());
+  const uint16_t max_version = std::get<1>(GetParam());
+
+  // Create empty ALPN list
+  std::string alpn;
+  alpn.push_back(0x00); // zero length
+
+  std::string expected_ja4 = (min_version == Config::TLS_MIN_SUPPORTED_VERSION &&
+                              max_version == Config::TLS_MAX_SUPPORTED_VERSION)
+                                 ? "t13i130900_f57a46bbacb6_78e6aca7449b" // "00" for empty ALPN
+                                 : no_alpn_test_version_to_ja4_.at(min_version);
+
+  testJA4(expected_ja4, "", alpn);
+}
+
+TEST_P(TlsInspectorTest, JA4MalformedClientHello) {
+  init();
+  std::vector<uint8_t> malformed_hello(50, 0); // Invalid ClientHello
+  mockSysCallForPeek(malformed_hello);
+
+  EXPECT_CALL(socket_, setJA4Hash(_)).Times(0);
+  EXPECT_CALL(socket_, setDetectedTransportProtocol(_)).Times(0);
+
+  EXPECT_TRUE(file_event_callback_(Event::FileReadyType::Read).ok());
+  auto state = filter_->onData(*buffer_);
+  EXPECT_EQ(Network::FilterStatus::Continue, state);
+  EXPECT_EQ(1, cfg_->stats().tls_not_found_.value());
+}
+
+const absl::flat_hash_map<uint16_t, std::string> no_ext_test_version_to_ja4_ = {
+    {TLS1_VERSION, "t10i020000_04659ec43a24_000000000000"},
+    {TLS1_1_VERSION, "t11i020000_04659ec43a24_000000000000"},
+    {TLS1_2_VERSION, "t12i020000_04659ec43a24_000000000000"},
+    {TLS1_3_VERSION, "t13i020000_62ed6f6ca7ad_000000000000"}};
+
+TEST_P(TlsInspectorTest, JA4WithNoExtensions) {
+  const uint16_t min_version = std::get<0>(GetParam());
+  const uint16_t max_version = std::get<1>(GetParam());
+
+  envoy::extensions::filters::listener::tls_inspector::v3::TlsInspector proto_config;
+  proto_config.mutable_enable_ja4_fingerprinting()->set_value(true);
+  cfg_ = std::make_shared<Config>(*store_.rootScope(), proto_config);
+
+  // Generate ClientHello with no extensions
+  std::vector<uint8_t> client_hello =
+      Tls::Test::generateClientHelloWithoutExtensions(std::get<1>(GetParam()));
+
+  init();
+  mockSysCallForPeek(client_hello);
+
+  std::string expected_ja4 = (min_version == Config::TLS_MIN_SUPPORTED_VERSION &&
+                              max_version == Config::TLS_MAX_SUPPORTED_VERSION)
+                                 ? "t13i020000_62ed6f6ca7ad_000000000000" // "00" for empty ALPN
+                                 : no_ext_test_version_to_ja4_.at(min_version);
+
+  EXPECT_CALL(socket_, setJA4Hash(absl::string_view(expected_ja4)));
+  EXPECT_CALL(socket_, setDetectedTransportProtocol(absl::string_view("tls")));
+
+  EXPECT_TRUE(file_event_callback_(Event::FileReadyType::Read).ok());
+  auto state = filter_->onData(*buffer_);
+  EXPECT_EQ(Network::FilterStatus::Continue, state);
+}
+
+TEST_P(TlsInspectorTest, JA4VersionFallback) {
+  envoy::extensions::filters::listener::tls_inspector::v3::TlsInspector proto_config;
+  proto_config.mutable_enable_ja4_fingerprinting()->set_value(true);
+  cfg_ = std::make_shared<Config>(*store_.rootScope(), proto_config);
+
+  // Create ClientHello without supported_versions extension
+  std::vector<uint8_t> client_hello =
+      Tls::Test::generateClientHello(TLS1_2_VERSION, TLS1_2_VERSION, "", "");
+
+  init();
+  mockSysCallForPeek(client_hello);
+
+  // Should fall back to ClientHello version field
+  std::string expected_ja4 = "t12i100600_a8cf61a50a39_0f3b2bcde21d";
+  EXPECT_CALL(socket_, setJA4Hash(absl::string_view(expected_ja4)));
+  EXPECT_CALL(socket_, setDetectedTransportProtocol(absl::string_view("tls")));
+  EXPECT_CALL(socket_, detectedTransportProtocol()).Times(::testing::AnyNumber());
+  EXPECT_CALL(socket_, setRequestedServerName(_)).Times(0);           // No SNI in this test
+  EXPECT_CALL(socket_, setRequestedApplicationProtocols(_)).Times(0); // No ALPN in this test
+
+  EXPECT_TRUE(file_event_callback_(Event::FileReadyType::Read).ok());
+  auto state = filter_->onData(*buffer_);
+  EXPECT_EQ(Network::FilterStatus::Continue, state);
+}
+
+const absl::flat_hash_map<uint16_t, std::string> empty_ext_test_version_to_ja4_ = {
+    {TLS1_VERSION, "t10i010000_0f2cb44170f4_000000000000"},
+    {TLS1_1_VERSION, "t11i010000_0f2cb44170f4_000000000000"},
+    {TLS1_2_VERSION, "t12i010000_0f2cb44170f4_000000000000"},
+    {TLS1_3_VERSION, "t13i010000_0f2cb44170f4_000000000000"}};
+
+TEST_P(TlsInspectorTest, JA4EmptyExtensionsList) {
+  const uint16_t min_version = std::get<0>(GetParam());
+  const uint16_t max_version = std::get<1>(GetParam());
+
+  envoy::extensions::filters::listener::tls_inspector::v3::TlsInspector proto_config;
+  proto_config.mutable_enable_ja4_fingerprinting()->set_value(true);
+  cfg_ = std::make_shared<Config>(*store_.rootScope(), proto_config);
+
+  std::vector<uint8_t> client_hello = Tls::Test::generateClientHelloEmptyExtensions(max_version);
+
+  init();
+  mockSysCallForPeek(client_hello);
+
+  // Set up proper expectations for socket calls
+  std::string expected_ja4 = (min_version == Config::TLS_MIN_SUPPORTED_VERSION &&
+                              max_version == Config::TLS_MAX_SUPPORTED_VERSION)
+                                 ? "t13i010000_0f2cb44170f4_000000000000"
+                                 : empty_ext_test_version_to_ja4_.at(min_version);
+  EXPECT_CALL(socket_, setJA4Hash(absl::string_view(expected_ja4)));
+  EXPECT_CALL(socket_, setDetectedTransportProtocol(absl::string_view("tls")));
+  EXPECT_CALL(socket_, detectedTransportProtocol()).Times(::testing::AnyNumber());
+  EXPECT_CALL(socket_, setRequestedServerName(_)).Times(0);
+  EXPECT_CALL(socket_, setRequestedApplicationProtocols(_)).Times(0);
+
+  EXPECT_TRUE(file_event_callback_(Event::FileReadyType::Read).ok());
+  auto state = filter_->onData(*buffer_);
+  EXPECT_EQ(Network::FilterStatus::Continue, state);
+}
+
+const absl::flat_hash_map<uint16_t, std::string> max_ciphers_test_version_to_ja4_ = {
+    {TLS1_VERSION, "t10i990500_f254cf4fa23b_950472255fe9"},
+    {TLS1_1_VERSION, "t11i990500_f254cf4fa23b_950472255fe9"},
+    {TLS1_2_VERSION, "t12i990600_f254cf4fa23b_0f3b2bcde21d"},
+    {TLS1_3_VERSION, "t13i990500_b33cacf22aea_678be4e4848e"}};
+
+TEST_P(TlsInspectorTest, JA4MaxValuesCiphers) {
+  const uint16_t min_version = std::get<0>(GetParam());
+  const uint16_t max_version = std::get<1>(GetParam());
+
+  envoy::extensions::filters::listener::tls_inspector::v3::TlsInspector proto_config;
+  proto_config.mutable_enable_ja4_fingerprinting()->set_value(true);
+  cfg_ = std::make_shared<Config>(*store_.rootScope(), proto_config);
+
+  // Start with basic ClientHello
+  std::vector<uint8_t> client_hello =
+      Tls::Test::generateClientHello(std::get<0>(GetParam()), std::get<1>(GetParam()), "", "");
+
+  // First, find the cipher suites section
+  size_t session_id_len_pos = 43; // 5(record) + 4(handshake) + 2(version) + 32(random)
+  uint8_t session_id_len = client_hello[session_id_len_pos];
+  size_t cipher_suites_len_pos = session_id_len_pos + 1 + session_id_len;
+
+  // Get the original cipher suites length
+  uint16_t original_cipher_length =
+      (client_hello[cipher_suites_len_pos] << 8) | client_hello[cipher_suites_len_pos + 1];
+
+  // Create new cipher suites
+  std::vector<uint8_t> new_ciphers;
+  const uint16_t num_ciphers = 100;
+  uint16_t cipher_length = num_ciphers * 2;
+
+  // Add length prefix
+  new_ciphers.push_back((cipher_length >> 8) & 0xFF);
+  new_ciphers.push_back(cipher_length & 0xFF);
+
+  // Add cipher suites
+  for (uint16_t i = 0; i < num_ciphers; i++) {
+    if (std::get<1>(GetParam()) >= TLS1_3_VERSION) {
+      // Use a variety of TLS 1.3 ciphers
+      switch (i % 5) {
+      case 0:
+        new_ciphers.push_back(0x13);
+        new_ciphers.push_back(0x01); // TLS_AES_128_GCM_SHA256
+        break;
+      case 1:
+        new_ciphers.push_back(0x13);
+        new_ciphers.push_back(0x02); // TLS_AES_256_GCM_SHA384
+        break;
+      case 2:
+        new_ciphers.push_back(0x13);
+        new_ciphers.push_back(0x03); // TLS_CHACHA20_POLY1305_SHA256
+        break;
+      case 3:
+        new_ciphers.push_back(0x13);
+        new_ciphers.push_back(0x04); // TLS_AES_128_CCM_SHA256
+        break;
+      case 4:
+        new_ciphers.push_back(0x13);
+        new_ciphers.push_back(0x05); // TLS_AES_128_CCM_8_SHA256
+        break;
+      }
+    } else {
+      // Use a variety of TLS 1.2 ciphers
+      switch (i % 5) {
+      case 0:
+        new_ciphers.push_back(0xc0);
+        new_ciphers.push_back(0x2f); // TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+        break;
+      case 1:
+        new_ciphers.push_back(0xc0);
+        new_ciphers.push_back(0x30); // TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+        break;
+      case 2:
+        new_ciphers.push_back(0xc0);
+        new_ciphers.push_back(0x2b); // TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+        break;
+      case 3:
+        new_ciphers.push_back(0xc0);
+        new_ciphers.push_back(0x2c); // TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+        break;
+      case 4:
+        new_ciphers.push_back(0xcc);
+        new_ciphers.push_back(0xa9); // TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
+        break;
+      }
+    }
+  }
+
+  // Create modified ClientHello
+  std::vector<uint8_t> modified_hello;
+
+  // Copy up to cipher suites
+  modified_hello.insert(modified_hello.end(), client_hello.begin(),
+                        client_hello.begin() + cipher_suites_len_pos);
+
+  // Add new cipher suites
+  modified_hello.insert(modified_hello.end(), new_ciphers.begin(), new_ciphers.end());
+
+  // Copy remaining data after original cipher suites
+  modified_hello.insert(modified_hello.end(),
+                        client_hello.begin() + cipher_suites_len_pos + 2 + original_cipher_length,
+                        client_hello.end());
+
+  // Update record layer length
+  size_t record_length = modified_hello.size() - 5;
+  modified_hello[3] = (record_length >> 8) & 0xFF;
+  modified_hello[4] = record_length & 0xFF;
+
+  // Update handshake message length
+  size_t handshake_length = record_length - 4;
+  modified_hello[6] = (handshake_length >> 16) & 0xFF;
+  modified_hello[7] = (handshake_length >> 8) & 0xFF;
+  modified_hello[8] = handshake_length & 0xFF;
+
+  init();
+  mockSysCallForPeek(modified_hello);
+
+  // Set up proper expectations for socket calls
+  std::string expected_ja4 = (min_version == Config::TLS_MIN_SUPPORTED_VERSION &&
+                              max_version == Config::TLS_MAX_SUPPORTED_VERSION)
+                                 ? "t13i990900_b33cacf22aea_78e6aca7449b"
+                                 : max_ciphers_test_version_to_ja4_.at(min_version);
+
+  EXPECT_CALL(socket_, setDetectedTransportProtocol(absl::string_view("tls")));
+  EXPECT_CALL(socket_, detectedTransportProtocol()).Times(::testing::AnyNumber());
+  EXPECT_CALL(socket_, setJA4Hash(expected_ja4));
+  EXPECT_CALL(socket_, setRequestedServerName(_)).Times(0);
+  EXPECT_CALL(socket_, setRequestedApplicationProtocols(_)).Times(0);
+
+  EXPECT_TRUE(file_event_callback_(Event::FileReadyType::Read).ok());
+  auto state = filter_->onData(*buffer_);
+  EXPECT_EQ(Network::FilterStatus::Continue, state);
 }
 
 } // namespace

--- a/test/extensions/filters/listener/tls_inspector/tls_utility.h
+++ b/test/extensions/filters/listener/tls_inspector/tls_utility.h
@@ -26,6 +26,24 @@ std::vector<uint8_t> generateClientHello(uint16_t tls_min_version, uint16_t tls_
  */
 std::vector<uint8_t> generateClientHelloFromJA3Fingerprint(const std::string& ja3_fingerprint);
 
+/**
+ * Generate a TLS ClientHello in wire-format without any extensions.
+ * This creates a minimal, valid ClientHello message with only the required fields.
+ *
+ * @param tls_max_version Maximum supported TLS version to advertise.
+ * @return A vector containing the wire-format ClientHello message bytes.
+ */
+std::vector<uint8_t> generateClientHelloWithoutExtensions(uint16_t tls_max_version);
+
+/**
+ * Generate a TLS ClientHello in wire-format with empty extensions.
+ * This creates a minimal, valid ClientHello message with only the required fields.
+ *
+ * @param tls_max_version Maximum supported TLS version to advertise.
+ * @return A vector containing the wire-format ClientHello message bytes.
+ */
+std::vector<uint8_t> generateClientHelloEmptyExtensions(uint16_t tls_max_version);
+
 } // namespace Test
 } // namespace Tls
 } // namespace Envoy

--- a/test/mocks/network/connection.h
+++ b/test/mocks/network/connection.h
@@ -78,6 +78,7 @@ public:
   MOCK_METHOD(Ssl::ConnectionInfoConstSharedPtr, ssl, (), (const));                                \
   MOCK_METHOD(absl::string_view, requestedServerName, (), (const));                                \
   MOCK_METHOD(absl::string_view, ja3Hash, (), (const));                                            \
+  MOCK_METHOD(absl::string_view, ja4Hash, (), (const));                                            \
   MOCK_METHOD(State, state, (), (const));                                                          \
   MOCK_METHOD(bool, connecting, (), (const));                                                      \
   MOCK_METHOD(void, write, (Buffer::Instance & data, bool end_stream));                            \

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -387,7 +387,9 @@ public:
   MOCK_METHOD(void, setRequestedServerName, (absl::string_view));
   MOCK_METHOD(absl::string_view, requestedServerName, (), (const));
   MOCK_METHOD(void, setJA3Hash, (absl::string_view));
+  MOCK_METHOD(void, setJA4Hash, (absl::string_view));
   MOCK_METHOD(absl::string_view, ja3Hash, (), (const));
+  MOCK_METHOD(absl::string_view, ja4Hash, (), (const));
   MOCK_METHOD(void, addOption_, (const Socket::OptionConstSharedPtr&));
   MOCK_METHOD(void, addOptions_, (const Socket::OptionsSharedPtr&));
   MOCK_METHOD(const Network::ConnectionSocket::OptionsSharedPtr&, options, (), (const));


### PR DESCRIPTION
## Description

This PR implements the [JA4 fingerprinting](https://github.com/FoxIO-LLC/ja4/tree/main/technical_details) in TLS Inspector filter.

**Source:** https://blog.cloudflare.com/de-de/ja4-signals/

---

**Commit Message:** add JA4 fingerprinting
**Additional Description:** Adds JA4 fingerprinting support in TLS inspector filter.
**Risk Level:** Low
**Testing:** Added Unit/Integration Tests
**Docs Changes:** Added
**Release Notes:** Added
**Platform Specific Features:** N/A