### PR TITLE
ext_proc: clean up

### DIFF
--- a/source/extensions/filters/http/ext_proc/client_impl.cc
+++ b/source/extensions/filters/http/ext_proc/client_impl.cc
@@ -65,8 +65,6 @@ void ExternalProcessorStreamImpl::send(envoy::service::ext_proc::v3::ProcessingR
   stream_.sendMessage(std::move(request), end_stream);
 }
 
-// TODO(tyxia) Refactor the logic of close() function. Invoking it when stream is already closed
-// is redundant.
 bool ExternalProcessorStreamImpl::close() {
   if (!stream_closed_) {
     ENVOY_LOG(debug, "Closing gRPC stream");

--- a/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
+++ b/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
@@ -1020,7 +1020,7 @@ TEST_P(ExtProcIntegrationTest, GetAndSetHeaders) {
 }
 
 TEST_P(ExtProcIntegrationTest, ResponseFromExtProcServerTooLarge) {
-  if (std::get<1>(std::get<0>(GetParam())) != Envoy::Grpc::ClientType::EnvoyGrpc) {
+  if (!IsEnvoyGrpc()) {
     GTEST_SKIP() << "max_receive_message_length is only supported on Envoy gRPC";
   }
   config_helper_.setBufferLimits(1024, 1024);
@@ -4584,7 +4584,7 @@ TEST_P(ExtProcIntegrationTest, InvalidServerOnResponseInObservabilityMode) {
 }
 
 TEST_P(ExtProcIntegrationTest, SidestreamPushbackDownstream) {
-  if (std::get<1>(std::get<0>(GetParam())) != Envoy::Grpc::ClientType::EnvoyGrpc) {
+  if (!IsEnvoyGrpc()) {
     return;
   }
 
@@ -4592,7 +4592,7 @@ TEST_P(ExtProcIntegrationTest, SidestreamPushbackDownstream) {
 }
 
 TEST_P(ExtProcIntegrationTest, SidestreamPushbackDownstreamObservabilityMode) {
-  if (std::get<1>(std::get<0>(GetParam())) != Envoy::Grpc::ClientType::EnvoyGrpc) {
+  if (!IsEnvoyGrpc()) {
     return;
   }
 
@@ -4601,7 +4601,7 @@ TEST_P(ExtProcIntegrationTest, SidestreamPushbackDownstreamObservabilityMode) {
 }
 
 TEST_P(ExtProcIntegrationTest, SidestreamPushbackDownstreamRuntimeDisable) {
-  if (std::get<1>(std::get<0>(GetParam())) != Envoy::Grpc::ClientType::EnvoyGrpc) {
+  if (!IsEnvoyGrpc()) {
     return;
   }
 
@@ -4612,7 +4612,7 @@ TEST_P(ExtProcIntegrationTest, SidestreamPushbackDownstreamRuntimeDisable) {
 }
 
 TEST_P(ExtProcIntegrationTest, SidestreamPushbackUpstream) {
-  if (std::get<1>(std::get<0>(GetParam())) != Envoy::Grpc::ClientType::EnvoyGrpc) {
+  if (!IsEnvoyGrpc()) {
     return;
   }
 
@@ -4660,7 +4660,7 @@ TEST_P(ExtProcIntegrationTest, SidestreamPushbackUpstream) {
 }
 
 TEST_P(ExtProcIntegrationTest, SidestreamPushbackUpstreamObservabilityMode) {
-  if (std::get<1>(std::get<0>(GetParam())) != Envoy::Grpc::ClientType::EnvoyGrpc) {
+  if (!IsEnvoyGrpc()) {
     return;
   }
 


### PR DESCRIPTION
- Remove obsolete TODO.  Refactor is not needed as it will actually incur more overhead: add a new isClosed() helper function which is virtual function. i.e., It will be called multiple layers/classes.
- Use isEnvoyGrpc helper in the test