### PR TITLE
not-for-submission: header-matcher benchmark speed test

### DIFF
--- a/test/common/http/BUILD
+++ b/test/common/http/BUILD
@@ -411,6 +411,26 @@ envoy_cc_test(
     ],
 )
 
+envoy_cc_benchmark_binary(
+    name = "header_matcher_speed_test",
+    srcs = ["header_matcher_speed_test.cc"],
+    rbe_pool = "6gig",
+    deps = [
+        "//source/common/http:header_utility_lib",
+        "//test/mocks/server:server_factory_context_mocks",
+        "//test/mocks/stream_info:stream_info_mocks",
+        "//test/test_common:test_runtime_lib",
+        "//test/test_common:utility_lib",
+        "@com_github_google_benchmark//:benchmark",
+        "@envoy_api//envoy/config/route/v3:pkg_cc_proto",
+    ],
+)
+
+envoy_benchmark_test(
+    name = "header_matcher_benchmark_test",
+    benchmark_binary = "header_matcher_speed_test",
+)
+
 envoy_cc_test(
     name = "user_agent_test",
     srcs = ["user_agent_test.cc"],

--- a/test/common/http/header_matcher_speed_test.cc
+++ b/test/common/http/header_matcher_speed_test.cc
@@ -1,0 +1,178 @@
+#include "envoy/config/route/v3/route.pb.h"
+#include "envoy/config/route/v3/route.pb.validate.h"
+
+#include "source/common/common/assert.h"
+#include "source/common/http/header_utility.h"
+
+#include "test/mocks/server/server_factory_context.h"
+#include "test/mocks/stream_info/mocks.h"
+#include "test/test_common/utility.h"
+
+#include "benchmark/benchmark.h"
+#include "gmock/gmock.h"
+
+#define NEW_HEADER_DATA_MATCHER 0
+
+namespace Envoy {
+namespace Http {
+namespace {
+
+using envoy::config::route::v3::HeaderMatcher;
+using testing::NiceMock;
+using testing::ReturnRef;
+
+/**
+ * Generates a request with the path:
+ * - /shelves/shelf_match/route_match
+ */
+static Http::TestRequestHeaderMapImpl genMatchingRequestHeaders() {
+  return Http::TestRequestHeaderMapImpl{{":authority", "www.google.com"},
+                                        {":method", "GET"},
+                                        {":path", "/"},
+                                        {":match-header", "/shelves/shelf_match/route_match"},
+                                        {"x-forwarded-proto", "http"}};
+}
+
+/**
+ * Generates a request with the path:
+ * - /shelves/shelf_x/route_x
+ */
+static Http::TestRequestHeaderMapImpl genNonMatchingRequestHeaders(int x) {
+  return Http::TestRequestHeaderMapImpl{
+      {":authority", "www.google.com"},
+      {":method", "GET"},
+      {":path", "/"},
+      {":match-header", absl::StrCat("/shelves/shelf_", x, "/route_", x)},
+      {"x-forwarded-proto", "http"}};
+}
+
+/**
+ * Generates the route config for the type of matcher being tested.
+ */
+#if NEW_HEADER_DATA_MATCHER
+static HeaderUtility::HeaderDataPtr genMatchConfig(
+#else
+static HeaderUtility::HeaderData genMatchConfig(
+#endif // NEW_HEADER_DATA_MATCHER
+    HeaderMatcher::HeaderMatchSpecifierCase match_type,
+    Server::Configuration::ServerFactoryContext& context) {
+  // Create the matcher config.
+  envoy::config::route::v3::HeaderMatcher header_matcher_config;
+  header_matcher_config.set_name("match-header");
+
+  switch (match_type) {
+  case HeaderMatcher::HeaderMatchSpecifierCase::kPrefixMatch: {
+    header_matcher_config.set_exact_match(absl::StrCat("/shelves/shelf_match"));
+    break;
+  }
+  case HeaderMatcher::HeaderMatchSpecifierCase::kExactMatch: {
+    header_matcher_config.set_exact_match(absl::StrCat("/shelves/shelf_match/route_match"));
+    break;
+  }
+  case HeaderMatcher::HeaderMatchSpecifierCase::kSafeRegexMatch: {
+    envoy::type::matcher::v3::RegexMatcher* regex =
+        header_matcher_config.mutable_safe_regex_match();
+    regex->mutable_google_re2();
+    regex->set_regex(absl::StrCat("^/shelves/[^\\\\/]+/route_match$"));
+    break;
+  }
+  default:
+    PANIC("reached unexpected code");
+  }
+
+  // Create the matcher.
+#if NEW_HEADER_DATA_MATCHER
+  return HeaderUtility::createHeaderData(header_matcher_config, context);
+#else
+  return HeaderUtility::HeaderData(header_matcher_config, context);
+#endif // NEW_HEADER_DATA_MATCHER
+}
+
+/**
+ * Measure the speed of doing a header match against a route table of varying sizes.
+ * Why? Currently, route matching (which invokes header matching) is linear in
+ * first-to-win ordering.
+ *
+ * We construct the first `n - 1` items in the route table so they are not
+ * matched by the incoming request. Only the last route will be matched.
+ * We then time how long it takes for the request to be matched against the
+ * last route.
+ */
+static void bmRouteTableSize(benchmark::State& state,
+                             HeaderMatcher::HeaderMatchSpecifierCase match_type) {
+  // Setup router for benchmarking.
+  Api::ApiPtr api = Api::createApiForTest();
+  NiceMock<Server::Configuration::MockServerFactoryContext> factory_context;
+  NiceMock<Envoy::StreamInfo::MockStreamInfo> stream_info;
+  ON_CALL(factory_context, api()).WillByDefault(ReturnRef(*api));
+
+  // Create matcher config.
+#if NEW_HEADER_DATA_MATCHER
+  HeaderUtility::HeaderDataPtr header_matcher =
+#else
+  HeaderUtility::HeaderData header_matcher =
+#endif // NEW_HEADER_DATA_MATCHER
+      genMatchConfig(match_type, factory_context);
+
+  int num_of_matches = state.range(0);
+  // Create a vector of `n - 1` non-matching header maps, and the last one will
+  // be a matching header map.
+  std::vector<Http::TestRequestHeaderMapImpl> input_header_maps;
+  input_header_maps.reserve(num_of_matches);
+  for (int i = 0; i < num_of_matches - 1; ++i) {
+    input_header_maps.emplace_back(genNonMatchingRequestHeaders(i));
+  }
+  input_header_maps.emplace_back(genMatchingRequestHeaders());
+
+  for (auto _ : state) { // NOLINT
+    // Do the actual timing here.
+    // The last request will match the matcher's config.
+    for (auto it = input_header_maps.begin(); it != input_header_maps.end(); ++it) {
+#if NEW_HEADER_DATA_MATCHER
+      header_matcher->matchesHeaders(*it);
+#else
+      HeaderUtility::matchHeaders(*it, header_matcher);
+#endif // NEW_HEADER_DATA_MATCHER
+    }
+  }
+}
+
+/**
+ * Benchmark a route table with path prefix matchers in the form of:
+ * - /shelves/shelf_1/...
+ * - /shelves/shelf_2/...
+ * - etc.
+ */
+static void bmRouteTableSizeWithPathPrefixMatch(benchmark::State& state) {
+  bmRouteTableSize(state, HeaderMatcher::HeaderMatchSpecifierCase::kPrefixMatch);
+}
+
+/**
+ * Benchmark a route table with exact path matchers in the form of:
+ * - /shelves/shelf_1/route_1
+ * - /shelves/shelf_2/route_2
+ * - etc.
+ */
+static void bmRouteTableSizeWithExactPathMatch(benchmark::State& state) {
+  bmRouteTableSize(state, HeaderMatcher::HeaderMatchSpecifierCase::kExactMatch);
+}
+
+/**
+ * Benchmark a route table with regex path matchers in the form of:
+ * - /shelves/{shelf_id}/route_1
+ * - /shelves/{shelf_id}/route_2
+ * - etc.
+ *
+ * This represents common OpenAPI path templating.
+ */
+static void bmRouteTableSizeWithRegexMatch(benchmark::State& state) {
+  bmRouteTableSize(state, HeaderMatcher::HeaderMatchSpecifierCase::kSafeRegexMatch);
+}
+
+BENCHMARK(bmRouteTableSizeWithPathPrefixMatch)->RangeMultiplier(2)->Ranges({{1, 2 << 13}});
+BENCHMARK(bmRouteTableSizeWithExactPathMatch)->RangeMultiplier(2)->Ranges({{1, 2 << 13}});
+BENCHMARK(bmRouteTableSizeWithRegexMatch)->RangeMultiplier(2)->Ranges({{1, 2 << 13}});
+
+} // namespace
+} // namespace Http
+} // namespace Envoy


### PR DESCRIPTION
Commit Message: not-for-submission: header-matcher benchmark speed test
Additional Description:
Not for submission!
This is a speed-test that is based on [config_impl_speed_test](https://github.com/envoyproxy/envoy/blob/main/test/common/router/config_impl_speed_test.cc) to test the impact of the header-matcher changes from PR #36878 on the speed of the header-matcher.
See [PR #36878 comment](https://github.com/envoyproxy/envoy/pull/36878#pullrequestreview-2405450146) that triggered this benchmark.

Benchmark description:
Each of the benchmark activations creates a single HeaderData matcher entry, and N header-maps where the first N-1 header maps aren't matching the HeaderData matcher entry and the last one does. The benchmark then measures how long it takes to invoke the HeaderData matcher function on the N header-maps.
As the API is modified in PR #36878, we use an ifdef-else macro to control which header-data matcher to use.
Both Envoy-head and with PR #36878 changes were compiled using:
`bazel build -c opt //test/common/http:header_matcher_speed_test --config=libc++`
and executed by running:
`bazel-bin/test/common/http/header_matcher_speed_test --benchmark_repetitions=3 --benchmark_out=output.csv --benchmark_out_format=csv`

The results are:

 | name | HEAD_real_time | HEAD_cpu_time | PR36878_real_time | PR36878_cpu_time | time_unit |
 | ---- | --------- | --------- | --------- | ---------| --------- |
 | bmRouteTableSizeWithPathPrefixMatch/1 | 43.3158 | 43.2863 | 41.5253 | 41.506 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/1 | 44.3709 | 44.3189 | 41.5529 | 41.5167 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/1 | 43.5272 | 43.4897 | 41.5374 | 41.4917 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/1_mean | 43.738 | 43.6983 | 41.5385 | 41.5048 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/1_median | 43.5272 | 43.4897 | 41.5374 | 41.506 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/1_stddev | 0.558249 | 0.54699 | 0.0138318 | 0.0125373 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/1_cv | 0.0127635 | 0.0125174 | 0.000332988 | 0.000302068 | 
 | bmRouteTableSizeWithPathPrefixMatch/2 | 86.528 | 86.4706 | 82.403 | 82.333 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/2 | 86.283 | 86.2297 | 82.5009 | 82.4626 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/2 | 86.1178 | 86.0571 | 82.2236 | 82.1319 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/2_mean | 86.3096 | 86.2525 | 82.3758 | 82.3092 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/2_median | 86.283 | 86.2297 | 82.403 | 82.333 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/2_stddev | 0.206386 | 0.207721 | 0.140673 | 0.16663 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/2_cv | 0.00239122 | 0.00240829 | 0.0017077 | 0.00202445 | 
 | bmRouteTableSizeWithPathPrefixMatch/4 | 189.836 | 189.682 | 183.197 | 183.005 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/4 | 189.425 | 189.289 | 183.535 | 183.332 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/4 | 189.114 | 188.984 | 184.13 | 183.95 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/4_mean | 189.458 | 189.319 | 183.621 | 183.429 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/4_median | 189.425 | 189.289 | 183.535 | 183.332 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/4_stddev | 0.362241 | 0.350034 | 0.47224 | 0.480119 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/4_cv | 0.00191198 | 0.00184891 | 0.00257182 | 0.00261746 | 
 | bmRouteTableSizeWithPathPrefixMatch/8 | 355.647 | 355.426 | 340.903 | 340.613 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/8 | 355.833 | 355.478 | 340.435 | 340.045 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/8 | 355.42 | 355.146 | 340.515 | 340.22 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/8_mean | 355.633 | 355.35 | 340.618 | 340.293 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/8_median | 355.647 | 355.426 | 340.515 | 340.22 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/8_stddev | 0.207186 | 0.178483 | 0.250596 | 0.290812 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/8_cv | 0.000582583 | 0.000502274 | 0.00073571 | 0.000854593 | 
 | bmRouteTableSizeWithPathPrefixMatch/16 | 695.839 | 695.25 | 667.961 | 667.296 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/16 | 699.843 | 699.208 | 671.482 | 670.953 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/16 | 697.497 | 696.813 | 666.319 | 665.798 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/16_mean | 697.726 | 697.09 | 668.587 | 668.016 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/16_median | 697.497 | 696.813 | 667.961 | 667.296 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/16_stddev | 2.01169 | 1.99311 | 2.6379 | 2.65205 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/16_cv | 0.00288321 | 0.00285919 | 0.00394548 | 0.00397004 | 
 | bmRouteTableSizeWithPathPrefixMatch/32 | 1384.43 | 1383.19 | 1326.09 | 1324.36 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/32 | 1393.08 | 1391.58 | 1329.92 | 1328.69 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/32 | 1393.92 | 1392.53 | 1322.76 | 1321.48 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/32_mean | 1390.48 | 1389.1 | 1326.26 | 1324.84 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/32_median | 1393.08 | 1391.58 | 1326.09 | 1324.36 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/32_stddev | 5.25187 | 5.14111 | 3.58 | 3.62863 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/32_cv | 0.00377703 | 0.00370104 | 0.00269932 | 0.00273891 | 
 | bmRouteTableSizeWithPathPrefixMatch/64 | 2781.33 | 2778.59 | 2656.63 | 2654.17 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/64 | 2798.41 | 2796.1 | 2674.48 | 2672.21 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/64 | 2791.42 | 2787.99 | 2685.15 | 2681.94 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/64_mean | 2790.39 | 2787.56 | 2672.09 | 2669.44 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/64_median | 2791.42 | 2787.99 | 2674.48 | 2672.21 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/64_stddev | 8.58967 | 8.76292 | 14.4091 | 14.0898 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/64_cv | 0.00307831 | 0.00314358 | 0.00539246 | 0.00527818 | 
 | bmRouteTableSizeWithPathPrefixMatch/128 | 5571.91 | 5564.13 | 5337.93 | 5331.78 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/128 | 5598.07 | 5594.86 | 5502.81 | 5499.8 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/128 | 5588.84 | 5583 | 5359.68 | 5353.97 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/128_mean | 5586.27 | 5580.66 | 5400.14 | 5395.18 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/128_median | 5588.84 | 5583 | 5359.68 | 5353.97 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/128_stddev | 13.2681 | 15.4984 | 89.5807 | 91.2776 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/128_cv | 0.00237513 | 0.00277717 | 0.0165886 | 0.0169184 | 
 | bmRouteTableSizeWithPathPrefixMatch/256 | 11335.2 | 11325.6 | 10878.9 | 10869 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/256 | 11323.7 | 11315.7 | 10899.9 | 10890.1 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/256 | 11349.4 | 11341.2 | 10879 | 10872.8 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/256_mean | 11336.1 | 11327.5 | 10885.9 | 10877.3 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/256_median | 11335.2 | 11325.6 | 10879 | 10872.8 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/256_stddev | 12.8646 | 12.8577 | 12.0593 | 11.2661 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/256_cv | 0.00113484 | 0.00113508 | 0.00110778 | 0.00103574 | 
 | bmRouteTableSizeWithPathPrefixMatch/512 | 22678.9 | 22657.3 | 21784 | 21768.7 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/512 | 22657.1 | 22625.4 | 21840.7 | 21821.3 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/512 | 22619.6 | 22597.9 | 21789.2 | 21769.6 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/512_mean | 22651.9 | 22626.9 | 21804.6 | 21786.5 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/512_median | 22657.1 | 22625.4 | 21789.2 | 21769.6 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/512_stddev | 29.963 | 29.7486 | 31.3628 | 30.1 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/512_cv | 0.00132276 | 0.00131475 | 0.00143835 | 0.00138159 | 
 | bmRouteTableSizeWithPathPrefixMatch/1024 | 45246.3 | 45189.1 | 43812.2 | 43779.7 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/1024 | 45477.9 | 45421.9 | 43709 | 43657 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/1024 | 45602.9 | 45567.1 | 43801.1 | 43770.2 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/1024_mean | 45442.3 | 45392.7 | 43774.1 | 43735.6 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/1024_median | 45477.9 | 45421.9 | 43801.1 | 43770.2 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/1024_stddev | 180.93 | 190.677 | 56.6672 | 68.2451 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/1024_cv | 0.00398153 | 0.00420061 | 0.00129454 | 0.0015604 | 
 | bmRouteTableSizeWithPathPrefixMatch/2048 | 98122.7 | 97992.8 | 102519 | 102410 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/2048 | 98076.1 | 97987.6 | 95643.6 | 95564.3 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/2048 | 97761.4 | 97686.4 | 96301 | 96203.3 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/2048_mean | 97986.7 | 97888.9 | 98154.5 | 98059.2 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/2048_median | 98076.1 | 97987.6 | 96301 | 96203.3 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/2048_stddev | 196.549 | 175.41 | 3793.93 | 3781.37 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/2048_cv | 0.00200587 | 0.00179193 | 0.0386527 | 0.0385621 | 
 | bmRouteTableSizeWithPathPrefixMatch/4096 | 209166 | 208992 | 209364 | 209091 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/4096 | 210103 | 209956 | 200895 | 200765 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/4096 | 212931 | 212763 | 206304 | 206061 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/4096_mean | 210733 | 210570 | 205521 | 205306 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/4096_median | 210103 | 209956 | 206304 | 206061 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/4096_stddev | 1959.67 | 1959.06 | 4288.54 | 4214.2 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/4096_cv | 0.00929931 | 0.00930362 | 0.0208667 | 0.0205265 | 
 | bmRouteTableSizeWithPathPrefixMatch/8192 | 425312 | 424990 | 412622 | 412394 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/8192 | 420732 | 420183 | 407340 | 406876 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/8192 | 420016 | 419617 | 410092 | 409607 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/8192_mean | 422020 | 421596 | 410018 | 409626 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/8192_median | 420732 | 420183 | 410092 | 409607 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/8192_stddev | 2873.17 | 2952.17 | 2641.91 | 2759.48 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/8192_cv | 0.00680813 | 0.00700236 | 0.00644341 | 0.0067366 | 
 | bmRouteTableSizeWithPathPrefixMatch/16384 | 862581 | 861336 | 840159 | 839445 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/16384 | 863688 | 863033 | 841093 | 840341 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/16384 | 841598 | 840414 | 839780 | 839031 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/16384_mean | 855955 | 854928 | 840344 | 839606 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/16384_median | 862581 | 861336 | 840159 | 839445 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/16384_stddev | 12446.6 | 12597.6 | 675.591 | 669.317 | ns |
 | bmRouteTableSizeWithPathPrefixMatch/16384_cv | 0.0145412 | 0.0147353 | 0.000803945 | 0.000797181 | 
 | bmRouteTableSizeWithExactPathMatch/1 | 43.3596 | 43.3199 | 42.998 | 42.9684 | ns |
 | bmRouteTableSizeWithExactPathMatch/1 | 43.3534 | 43.3225 | 41.3237 | 41.2869 | ns |
 | bmRouteTableSizeWithExactPathMatch/1 | 43.3362 | 43.2964 | 41.4403 | 41.398 | ns |
 | bmRouteTableSizeWithExactPathMatch/1_mean | 43.3497 | 43.3129 | 41.9207 | 41.8844 | ns |
 | bmRouteTableSizeWithExactPathMatch/1_median | 43.3534 | 43.3199 | 41.4403 | 41.398 | ns |
 | bmRouteTableSizeWithExactPathMatch/1_stddev | 0.0120926 | 0.0143874 | 0.934827 | 0.940381 | ns |
 | bmRouteTableSizeWithExactPathMatch/1_cv | 0.000278954 | 0.000332173 | 0.0222999 | 0.0224518 | 
 | bmRouteTableSizeWithExactPathMatch/2 | 86.0127 | 85.9255 | 82.3044 | 82.2343 | ns |
 | bmRouteTableSizeWithExactPathMatch/2 | 86.1111 | 86.0273 | 82.3611 | 82.3083 | ns |
 | bmRouteTableSizeWithExactPathMatch/2 | 86.1866 | 86.1023 | 82.3246 | 82.2361 | ns |
 | bmRouteTableSizeWithExactPathMatch/2_mean | 86.1035 | 86.0184 | 82.33 | 82.2596 | ns |
 | bmRouteTableSizeWithExactPathMatch/2_median | 86.1111 | 86.0273 | 82.3246 | 82.2361 | ns |
 | bmRouteTableSizeWithExactPathMatch/2_stddev | 0.0872197 | 0.0887159 | 0.0287457 | 0.0422147 | ns |
 | bmRouteTableSizeWithExactPathMatch/2_cv | 0.00101296 | 0.00103136 | 0.000349152 | 0.000513189 | 
 | bmRouteTableSizeWithExactPathMatch/4 | 189.411 | 189.206 | 184.134 | 183.905 | ns |
 | bmRouteTableSizeWithExactPathMatch/4 | 189.363 | 189.205 | 183.952 | 183.713 | ns |
 | bmRouteTableSizeWithExactPathMatch/4 | 189.36 | 189.175 | 183.59 | 183.404 | ns |
 | bmRouteTableSizeWithExactPathMatch/4_mean | 189.378 | 189.195 | 183.892 | 183.674 | ns |
 | bmRouteTableSizeWithExactPathMatch/4_median | 189.363 | 189.205 | 183.952 | 183.713 | ns |
 | bmRouteTableSizeWithExactPathMatch/4_stddev | 0.0285218 | 0.0173923 | 0.2769 | 0.252899 | ns |
 | bmRouteTableSizeWithExactPathMatch/4_cv | 0.000150608 | 9.19E-05 | 0.00150577 | 0.00137689 | 
 | bmRouteTableSizeWithExactPathMatch/8 | 356.494 | 356.2 | 340.132 | 339.942 | ns |
 | bmRouteTableSizeWithExactPathMatch/8 | 356.299 | 355.878 | 341.406 | 340.958 | ns |
 | bmRouteTableSizeWithExactPathMatch/8 | 355.859 | 355.466 | 340.198 | 339.87 | ns |
 | bmRouteTableSizeWithExactPathMatch/8_mean | 356.217 | 355.848 | 340.579 | 340.257 | ns |
 | bmRouteTableSizeWithExactPathMatch/8_median | 356.299 | 355.878 | 340.198 | 339.942 | ns |
 | bmRouteTableSizeWithExactPathMatch/8_stddev | 0.325282 | 0.368218 | 0.716992 | 0.608716 | ns |
 | bmRouteTableSizeWithExactPathMatch/8_cv | 0.000913157 | 0.00103476 | 0.00210522 | 0.00178899 | 
 | bmRouteTableSizeWithExactPathMatch/16 | 697.26 | 696.734 | 665.355 | 664.611 | ns |
 | bmRouteTableSizeWithExactPathMatch/16 | 697.303 | 696.632 | 715.001 | 714.375 | ns |
 | bmRouteTableSizeWithExactPathMatch/16 | 699.124 | 698.378 | 668.367 | 667.772 | ns |
 | bmRouteTableSizeWithExactPathMatch/16_mean | 697.896 | 697.248 | 682.908 | 682.253 | ns |
 | bmRouteTableSizeWithExactPathMatch/16_median | 697.303 | 696.734 | 668.367 | 667.772 | ns |
 | bmRouteTableSizeWithExactPathMatch/16_stddev | 1.06402 | 0.980172 | 27.8343 | 27.8639 | ns |
 | bmRouteTableSizeWithExactPathMatch/16_cv | 0.00152461 | 0.00140577 | 0.0407584 | 0.040841 | 
 | bmRouteTableSizeWithExactPathMatch/32 | 1390.38 | 1388.8 | 1425.58 | 1424.42 | ns |
 | bmRouteTableSizeWithExactPathMatch/32 | 1382.68 | 1381.5 | 1323.03 | 1321.24 | ns |
 | bmRouteTableSizeWithExactPathMatch/32 | 1387.89 | 1386.83 | 1329.41 | 1328.55 | ns |
 | bmRouteTableSizeWithExactPathMatch/32_mean | 1386.98 | 1385.71 | 1359.34 | 1358.07 | ns |
 | bmRouteTableSizeWithExactPathMatch/32_median | 1387.89 | 1386.83 | 1329.41 | 1328.55 | ns |
 | bmRouteTableSizeWithExactPathMatch/32_stddev | 3.93279 | 3.77551 | 57.4573 | 57.5753 | ns |
 | bmRouteTableSizeWithExactPathMatch/32_cv | 0.0028355 | 0.0027246 | 0.0422685 | 0.042395 | 
 | bmRouteTableSizeWithExactPathMatch/64 | 2788.53 | 2786.12 | 2661.35 | 2658.95 | ns |
 | bmRouteTableSizeWithExactPathMatch/64 | 2780.72 | 2778.76 | 2685.7 | 2682.86 | ns |
 | bmRouteTableSizeWithExactPathMatch/64 | 2789.69 | 2787.06 | 2675 | 2672.41 | ns |
 | bmRouteTableSizeWithExactPathMatch/64_mean | 2786.31 | 2783.98 | 2674.02 | 2671.41 | ns |
 | bmRouteTableSizeWithExactPathMatch/64_median | 2788.53 | 2786.12 | 2675 | 2672.41 | ns |
 | bmRouteTableSizeWithExactPathMatch/64_stddev | 4.88267 | 4.54569 | 12.208 | 11.9875 | ns |
 | bmRouteTableSizeWithExactPathMatch/64_cv | 0.00175237 | 0.0016328 | 0.00456542 | 0.00448734 | 
 | bmRouteTableSizeWithExactPathMatch/128 | 5599.03 | 5594.38 | 5358.59 | 5353.48 | ns |
 | bmRouteTableSizeWithExactPathMatch/128 | 5601.6 | 5595.6 | 5352.81 | 5347.29 | ns |
 | bmRouteTableSizeWithExactPathMatch/128 | 5593.12 | 5587.29 | 5345.85 | 5340.38 | ns |
 | bmRouteTableSizeWithExactPathMatch/128_mean | 5597.91 | 5592.42 | 5352.42 | 5347.05 | ns |
 | bmRouteTableSizeWithExactPathMatch/128_median | 5599.03 | 5594.38 | 5352.81 | 5347.29 | ns |
 | bmRouteTableSizeWithExactPathMatch/128_stddev | 4.34784 | 4.48414 | 6.37915 | 6.55283 | ns |
 | bmRouteTableSizeWithExactPathMatch/128_cv | 0.000776689 | 0.000801825 | 0.00119183 | 0.0012255 | 
 | bmRouteTableSizeWithExactPathMatch/256 | 11321.6 | 11310.9 | 10859.8 | 10847.1 | ns |
 | bmRouteTableSizeWithExactPathMatch/256 | 11359.1 | 11351.4 | 10871.6 | 10862.7 | ns |
 | bmRouteTableSizeWithExactPathMatch/256 | 11361.8 | 11348.9 | 10869.3 | 10855.6 | ns |
 | bmRouteTableSizeWithExactPathMatch/256_mean | 11347.5 | 11337.1 | 10866.9 | 10855.1 | ns |
 | bmRouteTableSizeWithExactPathMatch/256_median | 11359.1 | 11348.9 | 10869.3 | 10855.6 | ns |
 | bmRouteTableSizeWithExactPathMatch/256_stddev | 22.4918 | 22.7178 | 6.25111 | 7.81188 | ns |
 | bmRouteTableSizeWithExactPathMatch/256_cv | 0.00198209 | 0.00200385 | 0.000575244 | 0.000719649 | 
 | bmRouteTableSizeWithExactPathMatch/512 | 22706.3 | 22685.7 | 21743.3 | 21727.7 | ns |
 | bmRouteTableSizeWithExactPathMatch/512 | 22656.9 | 22627.8 | 21743.3 | 21720.5 | ns |
 | bmRouteTableSizeWithExactPathMatch/512 | 22645.5 | 22626.3 | 21768 | 21746 | ns |
 | bmRouteTableSizeWithExactPathMatch/512_mean | 22669.6 | 22646.6 | 21751.5 | 21731.4 | ns |
 | bmRouteTableSizeWithExactPathMatch/512_median | 22656.9 | 22627.8 | 21743.3 | 21727.7 | ns |
 | bmRouteTableSizeWithExactPathMatch/512_stddev | 32.2882 | 33.854 | 14.2859 | 13.1325 | ns |
 | bmRouteTableSizeWithExactPathMatch/512_cv | 0.0014243 | 0.00149488 | 0.000656778 | 0.000604309 | 
 | bmRouteTableSizeWithExactPathMatch/1024 | 45711 | 45660.9 | 43644.6 | 43594 | ns |
 | bmRouteTableSizeWithExactPathMatch/1024 | 45406 | 45362.3 | 43702.5 | 43662.4 | ns |
 | bmRouteTableSizeWithExactPathMatch/1024 | 45986.3 | 45946.1 | 43827.6 | 43781 | ns |
 | bmRouteTableSizeWithExactPathMatch/1024_mean | 45701.1 | 45656.4 | 43724.9 | 43679.2 | ns |
 | bmRouteTableSizeWithExactPathMatch/1024_median | 45711 | 45660.9 | 43702.5 | 43662.4 | ns |
 | bmRouteTableSizeWithExactPathMatch/1024_stddev | 290.24 | 291.958 | 93.5008 | 94.6055 | ns |
 | bmRouteTableSizeWithExactPathMatch/1024_cv | 0.00635084 | 0.00639469 | 0.00213839 | 0.00216592 | 
 | bmRouteTableSizeWithExactPathMatch/2048 | 98586.6 | 98481.6 | 94628.7 | 94539.1 | ns |
 | bmRouteTableSizeWithExactPathMatch/2048 | 98898.5 | 98776.5 | 94516.9 | 94400.2 | ns |
 | bmRouteTableSizeWithExactPathMatch/2048 | 98881.3 | 98787.3 | 93944.8 | 93886.8 | ns |
 | bmRouteTableSizeWithExactPathMatch/2048_mean | 98788.8 | 98681.8 | 94363.5 | 94275.4 | ns |
 | bmRouteTableSizeWithExactPathMatch/2048_median | 98881.3 | 98776.5 | 94516.9 | 94400.2 | ns |
 | bmRouteTableSizeWithExactPathMatch/2048_stddev | 175.325 | 173.493 | 366.862 | 343.646 | ns |
 | bmRouteTableSizeWithExactPathMatch/2048_cv | 0.00177475 | 0.0017581 | 0.00388776 | 0.00364513 | 
 | bmRouteTableSizeWithExactPathMatch/4096 | 209273 | 209123 | 205084 | 204861 | ns |
 | bmRouteTableSizeWithExactPathMatch/4096 | 210959 | 210743 | 205458 | 205287 | ns |
 | bmRouteTableSizeWithExactPathMatch/4096 | 208733 | 208515 | 208357 | 208079 | ns |
 | bmRouteTableSizeWithExactPathMatch/4096_mean | 209655 | 209460 | 206300 | 206076 | ns |
 | bmRouteTableSizeWithExactPathMatch/4096_median | 209273 | 209123 | 205458 | 205287 | ns |
 | bmRouteTableSizeWithExactPathMatch/4096_stddev | 1161.48 | 1151.73 | 1791.68 | 1748.16 | ns |
 | bmRouteTableSizeWithExactPathMatch/4096_cv | 0.00553997 | 0.00549854 | 0.00868484 | 0.00848311 | 
 | bmRouteTableSizeWithExactPathMatch/8192 | 421685 | 421303 | 417427 | 416982 | ns |
 | bmRouteTableSizeWithExactPathMatch/8192 | 420370 | 419933 | 413802 | 413297 | ns |
 | bmRouteTableSizeWithExactPathMatch/8192 | 423473 | 422998 | 411874 | 411372 | ns |
 | bmRouteTableSizeWithExactPathMatch/8192_mean | 421843 | 421411 | 414368 | 413884 | ns |
 | bmRouteTableSizeWithExactPathMatch/8192_median | 421685 | 421303 | 413802 | 413297 | ns |
 | bmRouteTableSizeWithExactPathMatch/8192_stddev | 1557.41 | 1535.29 | 2819.15 | 2850.79 | ns |
 | bmRouteTableSizeWithExactPathMatch/8192_cv | 0.00369193 | 0.0036432 | 0.0068035 | 0.00688791 | 
 | bmRouteTableSizeWithExactPathMatch/16384 | 862108 | 861139 | 816185 | 815682 | ns |
 | bmRouteTableSizeWithExactPathMatch/16384 | 855607 | 854749 | 824213 | 823784 | ns |
 | bmRouteTableSizeWithExactPathMatch/16384 | 865326 | 864664 | 848582 | 847846 | ns |
 | bmRouteTableSizeWithExactPathMatch/16384_mean | 861014 | 860184 | 829660 | 829104 | ns |
 | bmRouteTableSizeWithExactPathMatch/16384_median | 862108 | 861139 | 824213 | 823784 | ns |
 | bmRouteTableSizeWithExactPathMatch/16384_stddev | 4951.07 | 5025.99 | 16871.6 | 16728.8 | ns |
 | bmRouteTableSizeWithExactPathMatch/16384_cv | 0.00575028 | 0.00584292 | 0.0203356 | 0.020177 | 
 | bmRouteTableSizeWithRegexMatch/1 | 43.3269 | 43.292 | 41.205 | 41.162 | ns |
 | bmRouteTableSizeWithRegexMatch/1 | 43.278 | 43.2419 | 41.2369 | 41.1941 | ns |
 | bmRouteTableSizeWithRegexMatch/1 | 43.261 | 43.214 | 41.3355 | 41.3 | ns |
 | bmRouteTableSizeWithRegexMatch/1_mean | 43.2886 | 43.2493 | 41.2591 | 41.2187 | ns |
 | bmRouteTableSizeWithRegexMatch/1_median | 43.278 | 43.2419 | 41.2369 | 41.1941 | ns |
 | bmRouteTableSizeWithRegexMatch/1_stddev | 0.0341961 | 0.0395256 | 0.0680286 | 0.0722506 | ns |
 | bmRouteTableSizeWithRegexMatch/1_cv | 0.000789956 | 0.000913903 | 0.00164881 | 0.00175286 | 
 | bmRouteTableSizeWithRegexMatch/2 | 86.344 | 86.2684 | 82.0647 | 81.991 | ns |
 | bmRouteTableSizeWithRegexMatch/2 | 86.1079 | 86.0201 | 82.248 | 82.1438 | ns |
 | bmRouteTableSizeWithRegexMatch/2 | 86.0875 | 85.9769 | 82.2234 | 82.1354 | ns |
 | bmRouteTableSizeWithRegexMatch/2_mean | 86.1798 | 86.0885 | 82.1787 | 82.0901 | ns |
 | bmRouteTableSizeWithRegexMatch/2_median | 86.1079 | 86.0201 | 82.2234 | 82.1354 | ns |
 | bmRouteTableSizeWithRegexMatch/2_stddev | 0.142551 | 0.157297 | 0.0995087 | 0.0858838 | ns |
 | bmRouteTableSizeWithRegexMatch/2_cv | 0.00165412 | 0.00182715 | 0.00121088 | 0.00104621 | 
 | bmRouteTableSizeWithRegexMatch/4 | 190.93 | 190.728 | 183.962 | 183.774 | ns |
 | bmRouteTableSizeWithRegexMatch/4 | 189.782 | 189.645 | 184.065 | 183.933 | ns |
 | bmRouteTableSizeWithRegexMatch/4 | 189.471 | 189.293 | 183.315 | 183.105 | ns |
 | bmRouteTableSizeWithRegexMatch/4_mean | 190.061 | 189.888 | 183.78 | 183.604 | ns |
 | bmRouteTableSizeWithRegexMatch/4_median | 189.782 | 189.645 | 183.962 | 183.774 | ns |
 | bmRouteTableSizeWithRegexMatch/4_stddev | 0.768358 | 0.747724 | 0.406585 | 0.439152 | ns |
 | bmRouteTableSizeWithRegexMatch/4_cv | 0.00404269 | 0.0039377 | 0.00221234 | 0.00239184 | 
 | bmRouteTableSizeWithRegexMatch/8 | 356.707 | 356.45 | 340.116 | 339.887 | ns |
 | bmRouteTableSizeWithRegexMatch/8 | 357.054 | 356.727 | 341.86 | 341.594 | ns |
 | bmRouteTableSizeWithRegexMatch/8 | 356.268 | 355.941 | 340.869 | 340.574 | ns |
 | bmRouteTableSizeWithRegexMatch/8_mean | 356.676 | 356.373 | 340.948 | 340.685 | ns |
 | bmRouteTableSizeWithRegexMatch/8_median | 356.707 | 356.45 | 340.869 | 340.574 | ns |
 | bmRouteTableSizeWithRegexMatch/8_stddev | 0.39411 | 0.398581 | 0.875184 | 0.858996 | ns |
 | bmRouteTableSizeWithRegexMatch/8_cv | 0.00110495 | 0.00111844 | 0.00256691 | 0.00252138 | 
 | bmRouteTableSizeWithRegexMatch/16 | 698.949 | 698.315 | 670.009 | 669.411 | ns |
 | bmRouteTableSizeWithRegexMatch/16 | 698.044 | 697.502 | 666.867 | 666.237 | ns |
 | bmRouteTableSizeWithRegexMatch/16 | 698.861 | 698.13 | 668.587 | 667.987 | ns |
 | bmRouteTableSizeWithRegexMatch/16_mean | 698.618 | 697.982 | 668.488 | 667.878 | ns |
 | bmRouteTableSizeWithRegexMatch/16_median | 698.861 | 698.13 | 668.587 | 667.987 | ns |
 | bmRouteTableSizeWithRegexMatch/16_stddev | 0.499326 | 0.425806 | 1.57301 | 1.58996 | ns |
 | bmRouteTableSizeWithRegexMatch/16_cv | 0.000714733 | 0.000610053 | 0.00235308 | 0.00238061 | 
 | bmRouteTableSizeWithRegexMatch/32 | 1393.89 | 1391.81 | 1342.52 | 1341.51 | ns |
 | bmRouteTableSizeWithRegexMatch/32 | 1392.4 | 1390.83 | 1325.32 | 1324.49 | ns |
 | bmRouteTableSizeWithRegexMatch/32 | 1397.33 | 1395.94 | 1347.41 | 1346.34 | ns |
 | bmRouteTableSizeWithRegexMatch/32_mean | 1394.54 | 1392.86 | 1338.42 | 1337.45 | ns |
 | bmRouteTableSizeWithRegexMatch/32_median | 1393.89 | 1391.81 | 1342.52 | 1341.51 | ns |
 | bmRouteTableSizeWithRegexMatch/32_stddev | 2.52961 | 2.71563 | 11.601 | 11.4785 | ns |
 | bmRouteTableSizeWithRegexMatch/32_cv | 0.00181394 | 0.00194968 | 0.00866767 | 0.00858241 | 
 | bmRouteTableSizeWithRegexMatch/64 | 2786.98 | 2784.03 | 2653.59 | 2650.52 | ns |
 | bmRouteTableSizeWithRegexMatch/64 | 2783.81 | 2781.42 | 2665.86 | 2663.56 | ns |
 | bmRouteTableSizeWithRegexMatch/64 | 2782.34 | 2780.4 | 2675.18 | 2673.22 | ns |
 | bmRouteTableSizeWithRegexMatch/64_mean | 2784.38 | 2781.95 | 2664.88 | 2662.44 | ns |
 | bmRouteTableSizeWithRegexMatch/64_median | 2783.81 | 2781.42 | 2665.86 | 2663.56 | ns |
 | bmRouteTableSizeWithRegexMatch/64_stddev | 2.372 | 1.87094 | 10.8242 | 11.3906 | ns |
 | bmRouteTableSizeWithRegexMatch/64_cv | 0.000851894 | 0.00067253 | 0.00406181 | 0.00427826 | 
 | bmRouteTableSizeWithRegexMatch/128 | 5607.07 | 5601.73 | 5351.15 | 5344.94 | ns |
 | bmRouteTableSizeWithRegexMatch/128 | 5597.43 | 5592.4 | 5354.57 | 5350.08 | ns |
 | bmRouteTableSizeWithRegexMatch/128 | 5595.81 | 5590.69 | 5356.44 | 5350.5 | ns |
 | bmRouteTableSizeWithRegexMatch/128_mean | 5600.1 | 5594.94 | 5354.05 | 5348.51 | ns |
 | bmRouteTableSizeWithRegexMatch/128_median | 5597.43 | 5592.4 | 5354.57 | 5350.08 | ns |
 | bmRouteTableSizeWithRegexMatch/128_stddev | 6.08744 | 5.94279 | 2.68028 | 3.09661 | ns |
 | bmRouteTableSizeWithRegexMatch/128_cv | 0.00108702 | 0.00106217 | 0.000500607 | 0.000578967 | 
 | bmRouteTableSizeWithRegexMatch/256 | 11286.3 | 11276.7 | 10874.1 | 10862.8 | ns |
 | bmRouteTableSizeWithRegexMatch/256 | 11349.3 | 11343.6 | 10899.6 | 10890.3 | ns |
 | bmRouteTableSizeWithRegexMatch/256 | 11348.8 | 11336.8 | 10876 | 10867.7 | ns |
 | bmRouteTableSizeWithRegexMatch/256_mean | 11328.2 | 11319 | 10883.2 | 10873.6 | ns |
 | bmRouteTableSizeWithRegexMatch/256_median | 11348.8 | 11336.8 | 10876 | 10867.7 | ns |
 | bmRouteTableSizeWithRegexMatch/256_stddev | 36.2277 | 36.8029 | 14.1959 | 14.6914 | ns |
 | bmRouteTableSizeWithRegexMatch/256_cv | 0.00319802 | 0.00325141 | 0.00130438 | 0.0013511 | 
 | bmRouteTableSizeWithRegexMatch/512 | 22739.2 | 22718 | 21771.9 | 21749.7 | ns |
 | bmRouteTableSizeWithRegexMatch/512 | 22632.8 | 22611.3 | 21760 | 21735.4 | ns |
 | bmRouteTableSizeWithRegexMatch/512 | 22629.9 | 22613.6 | 21773.4 | 21751.7 | ns |
 | bmRouteTableSizeWithRegexMatch/512_mean | 22667.3 | 22647.6 | 21768.4 | 21745.6 | ns |
 | bmRouteTableSizeWithRegexMatch/512_median | 22632.8 | 22613.6 | 21771.9 | 21749.7 | ns |
 | bmRouteTableSizeWithRegexMatch/512_stddev | 62.3252 | 60.9401 | 7.38888 | 8.8794 | ns |
 | bmRouteTableSizeWithRegexMatch/512_cv | 0.00274956 | 0.00269079 | 0.000339431 | 0.000408331 | 
 | bmRouteTableSizeWithRegexMatch/1024 | 45617.3 | 45595.2 | 43899.6 | 43862.4 | ns |
 | bmRouteTableSizeWithRegexMatch/1024 | 45519.4 | 45491.8 | 43682.9 | 43648.8 | ns |
 | bmRouteTableSizeWithRegexMatch/1024 | 45589 | 45552.4 | 43730.9 | 43697.3 | ns |
 | bmRouteTableSizeWithRegexMatch/1024_mean | 45575.2 | 45546.5 | 43771.2 | 43736.2 | ns |
 | bmRouteTableSizeWithRegexMatch/1024_median | 45589 | 45552.4 | 43730.9 | 43697.3 | ns |
 | bmRouteTableSizeWithRegexMatch/1024_stddev | 50.3952 | 51.9786 | 113.799 | 111.994 | ns |
 | bmRouteTableSizeWithRegexMatch/1024_cv | 0.00110576 | 0.00114122 | 0.00259986 | 0.00256067 | 
 | bmRouteTableSizeWithRegexMatch/2048 | 97844.5 | 97765.6 | 95753.2 | 95668.3 | ns |
 | bmRouteTableSizeWithRegexMatch/2048 | 98476.8 | 98348.6 | 95406.3 | 95306 | ns |
 | bmRouteTableSizeWithRegexMatch/2048 | 99032.4 | 98936.6 | 96136.3 | 96072.7 | ns |
 | bmRouteTableSizeWithRegexMatch/2048_mean | 98451.2 | 98350.3 | 95765.3 | 95682.3 | ns |
 | bmRouteTableSizeWithRegexMatch/2048_median | 98476.8 | 98348.6 | 95753.2 | 95668.3 | ns |
 | bmRouteTableSizeWithRegexMatch/2048_stddev | 594.332 | 585.476 | 365.189 | 383.541 | ns |
 | bmRouteTableSizeWithRegexMatch/2048_cv | 0.00603682 | 0.00595296 | 0.00381337 | 0.00400848 | 
 | bmRouteTableSizeWithRegexMatch/4096 | 208866 | 208575 | 204402 | 204214 | ns |
 | bmRouteTableSizeWithRegexMatch/4096 | 209281 | 209081 | 205823 | 205622 | ns |
 | bmRouteTableSizeWithRegexMatch/4096 | 209980 | 209743 | 204257 | 204088 | ns |
 | bmRouteTableSizeWithRegexMatch/4096_mean | 209376 | 209133 | 204827 | 204641 | ns |
 | bmRouteTableSizeWithRegexMatch/4096_median | 209281 | 209081 | 204402 | 204214 | ns |
 | bmRouteTableSizeWithRegexMatch/4096_stddev | 563.459 | 585.904 | 865.292 | 851.534 | ns |
 | bmRouteTableSizeWithRegexMatch/4096_cv | 0.00269114 | 0.00280158 | 0.0042245 | 0.00416111 | 
 | bmRouteTableSizeWithRegexMatch/8192 | 422766 | 422319 | 412095 | 411684 | ns |
 | bmRouteTableSizeWithRegexMatch/8192 | 422249 | 421859 | 414240 | 413937 | ns |
 | bmRouteTableSizeWithRegexMatch/8192 | 417110 | 416686 | 412713 | 412264 | ns |
 | bmRouteTableSizeWithRegexMatch/8192_mean | 420708 | 420288 | 413016 | 412628 | ns |
 | bmRouteTableSizeWithRegexMatch/8192_median | 422249 | 421859 | 412713 | 412264 | ns |
 | bmRouteTableSizeWithRegexMatch/8192_stddev | 3127.16 | 3128.14 | 1103.98 | 1169.56 | ns |
 | bmRouteTableSizeWithRegexMatch/8192_cv | 0.00743307 | 0.00744285 | 0.00267297 | 0.00283443 | 
 | bmRouteTableSizeWithRegexMatch/16384 | 867216 | 866680 | 844493 | 843905 | ns |
 | bmRouteTableSizeWithRegexMatch/16384 | 871347 | 870522 | 831976 | 830997 | ns |
 | bmRouteTableSizeWithRegexMatch/16384 | 867828 | 866911 | 828070 | 826884 | ns |
 | bmRouteTableSizeWithRegexMatch/16384_mean | 868797 | 868038 | 834846 | 833929 | ns |
 | bmRouteTableSizeWithRegexMatch/16384_median | 867828 | 866911 | 831976 | 830997 | ns |
 | bmRouteTableSizeWithRegexMatch/16384_stddev | 2229.49 | 2154.54 | 8579.43 | 8881.42 | ns |
 | bmRouteTableSizeWithRegexMatch/16384_cv | 0.00256618 | 0.00248208 | 0.0102767 | 0.0106501 | 
