### PR TITLE
kafka: close connection when rejectable request appears

### DIFF
--- a/api/contrib/envoy/extensions/filters/network/kafka_broker/v3/kafka_broker.proto
+++ b/api/contrib/envoy/extensions/filters/network/kafka_broker/v3/kafka_broker.proto
@@ -39,6 +39,17 @@ message KafkaBroker {
     // Broker address rewrite rules that match by broker ID.
     IdBasedBrokerRewriteSpec id_based_broker_address_rewrite_spec = 3;
   }
+
+  // Optional list of allowed Kafka API keys. Only requests with provided API keys will be
+  // routed, otherwise the connection will be closed. No effect if empty.
+  repeated uint32 api_keys_allowed = 4 [(validate.rules).repeated = {
+    items {uint32 {gte: 0, lte: 32767}}
+  }];
+  // Optional list of denied Kafka API keys. Requests with API keys matching this list will have
+  // the connection closed. No effect if empty.
+  repeated uint32 api_keys_denied = 5 [(validate.rules).repeated = {
+    items {uint32 {gte: 0, lte: 32767}}
+  }];
 }
 
 // Collection of rules matching by broker ID.

--- a/api/contrib/envoy/extensions/filters/network/kafka_broker/v3/kafka_broker.proto
+++ b/api/contrib/envoy/extensions/filters/network/kafka_broker/v3/kafka_broker.proto
@@ -15,7 +15,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // [#protodoc-title: Kafka Broker]
 // Kafka Broker :ref:`configuration overview <config_network_filters_kafka_broker>`.
 // [#extension: envoy.filters.network.kafka_broker]
-
+// [#next-free-field: 6]
 message KafkaBroker {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.network.kafka_broker.v2alpha1.KafkaBroker";
@@ -42,14 +42,13 @@ message KafkaBroker {
 
   // Optional list of allowed Kafka API keys. Only requests with provided API keys will be
   // routed, otherwise the connection will be closed. No effect if empty.
-  repeated uint32 api_keys_allowed = 4 [(validate.rules).repeated = {
-    items {uint32 {gte: 0, lte: 32767}}
-  }];
+  repeated uint32 api_keys_allowed = 4
+      [(validate.rules).repeated = {items {uint32 {lte: 32767 gte: 0}}}];
+
   // Optional list of denied Kafka API keys. Requests with API keys matching this list will have
   // the connection closed. No effect if empty.
-  repeated uint32 api_keys_denied = 5 [(validate.rules).repeated = {
-    items {uint32 {gte: 0, lte: 32767}}
-  }];
+  repeated uint32 api_keys_denied = 5
+      [(validate.rules).repeated = {items {uint32 {lte: 32767 gte: 0}}}];
 }
 
 // Collection of rules matching by broker ID.

--- a/api/envoy/config/filter/network/kafka_broker/v2alpha1/kafka_broker.proto
+++ b/api/envoy/config/filter/network/kafka_broker/v2alpha1/kafka_broker.proto
@@ -38,6 +38,17 @@ message KafkaBroker {
     // Broker address rewrite rules that match by broker ID.
     IdBasedBrokerRewriteSpec id_based_broker_address_rewrite_spec = 3;
   }
+
+  // Optional list of allowed Kafka API keys. Only requests with provided API keys will be
+  // routed, otherwise the connection will be closed. No effect if empty.
+  repeated uint32 api_keys_allowed = 4 [(validate.rules).repeated = {
+    items {uint32 {gte: 0, lte: 32767}}
+  }];
+  // Optional list of denied Kafka API keys. Requests with API keys matching this list will have
+  // the connection closed. No effect if empty.
+  repeated uint32 api_keys_denied = 5 [(validate.rules).repeated = {
+    items {uint32 {gte: 0, lte: 32767}}
+  }];
 }
 
 // Collection of rules matching by broker ID.

--- a/api/envoy/config/filter/network/kafka_broker/v2alpha1/kafka_broker.proto
+++ b/api/envoy/config/filter/network/kafka_broker/v2alpha1/kafka_broker.proto
@@ -17,7 +17,7 @@ option (udpa.annotations.file_status).package_version_status = FROZEN;
 // [#protodoc-title: Kafka Broker]
 // Kafka Broker :ref:`configuration overview <config_network_filters_kafka_broker>`.
 // [#extension: envoy.filters.network.kafka_broker]
-
+// [#next-free-field: 6]
 message KafkaBroker {
   // The prefix to use when emitting :ref:`statistics <config_network_filters_kafka_broker_stats>`.
   string stat_prefix = 1 [(validate.rules).string = {min_bytes: 1}];
@@ -41,14 +41,13 @@ message KafkaBroker {
 
   // Optional list of allowed Kafka API keys. Only requests with provided API keys will be
   // routed, otherwise the connection will be closed. No effect if empty.
-  repeated uint32 api_keys_allowed = 4 [(validate.rules).repeated = {
-    items {uint32 {gte: 0, lte: 32767}}
-  }];
+  repeated uint32 api_keys_allowed = 4
+      [(validate.rules).repeated = {items {uint32 {lte: 32767 gte: 0}}}];
+
   // Optional list of denied Kafka API keys. Requests with API keys matching this list will have
   // the connection closed. No effect if empty.
-  repeated uint32 api_keys_denied = 5 [(validate.rules).repeated = {
-    items {uint32 {gte: 0, lte: 32767}}
-  }];
+  repeated uint32 api_keys_denied = 5
+      [(validate.rules).repeated = {items {uint32 {lte: 32767 gte: 0}}}];
 }
 
 // Collection of rules matching by broker ID.

--- a/contrib/kafka/filters/network/source/broker/BUILD
+++ b/contrib/kafka/filters/network/source/broker/BUILD
@@ -35,6 +35,7 @@ envoy_cc_library(
     ],
     deps = [
         "//source/common/common:assert_lib",
+        "@com_google_absl//absl/container:flat_hash_set",
         "@envoy_api//contrib/envoy/extensions/filters/network/kafka_broker/v3:pkg_cc_proto",
     ],
 )
@@ -47,11 +48,28 @@ envoy_cc_library(
     ],
     deps = [
         ":filter_config_lib",
+        ":request_handler_lib",
         ":rewriter_lib",
         "//contrib/kafka/filters/network/source:kafka_metrics_lib",
         "//contrib/kafka/filters/network/source:kafka_request_codec_lib",
         "//contrib/kafka/filters/network/source:kafka_response_codec_lib",
         "//envoy/buffer:buffer_interface",
+        "//envoy/network:connection_interface",
+        "//envoy/network:filter_interface",
+        "//source/common/common:minimal_logger_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "request_handler_lib",
+    srcs = ["request_handler.cc"],
+    hdrs = [
+        "request_handler.h",
+    ],
+    deps = [
+        ":filter_config_lib",
+        "//contrib/kafka/filters/network/source:kafka_request_codec_lib",
+        "//contrib/kafka/filters/network/source:kafka_response_codec_lib",
         "//envoy/network:connection_interface",
         "//envoy/network:filter_interface",
         "//source/common/common:minimal_logger_lib",

--- a/contrib/kafka/filters/network/source/broker/filter.h
+++ b/contrib/kafka/filters/network/source/broker/filter.h
@@ -7,6 +7,7 @@
 
 #include "absl/container/flat_hash_map.h"
 #include "contrib/kafka/filters/network/source/broker/filter_config.h"
+#include "contrib/kafka/filters/network/source/broker/request_handler.h"
 #include "contrib/kafka/filters/network/source/broker/rewriter.h"
 #include "contrib/kafka/filters/network/source/external/request_metrics.h"
 #include "contrib/kafka/filters/network/source/external/response_metrics.h"
@@ -114,30 +115,9 @@ private:
  * Implementation of Kafka broker-level filter.
  * Uses two decoders - request and response ones, that are connected using Forwarder instance.
  * KafkaMetricsFacade is listening for both request/response events to keep metrics.
- * ResponseRewriter is listening for response events to capture and rewrite them if needed.
- *
- *        +---------------------------------------------------+
- *        |                                                   |
- *        |               +--------------+                    |
- *        |   +---------->+RequestDecoder+----------------+   |
- *        |   |           +-------+------+                |   |
- *        |   |                   |                       |   |
- *        |   |                   |                       |   |
- *        |   |                   v                       v   v
- * +------+---+------+       +----+----+        +---------+---+----+
- * |KafkaBrokerFilter|       |Forwarder|        |KafkaMetricsFacade|
- * +------+---+------+       +----+----+        +---------+--------+
- *        |   |                   |                       ^
- *        |   |                   |                       |
- *        |   |                   v                       |
- *        |   |           +-------+-------+               |
- *        |   +---------->+ResponseDecoder+---------------+
- *        |               +-------+-------+
- *        |                       |
- *        |                       v
- *        |               +-------+--------+
- *        +-------------->+ResponseRewriter+
- *                        +----------------+
+ * RequestHandler is listening for request events to close a connection if an unacceptable request
+ * is received. ResponseRewriter is listening for response events to capture and rewrite them if
+ * needed.
  */
 class KafkaBrokerFilter : public Network::Filter, private Logger::Loggable<Logger::Id::kafka> {
 public:
@@ -152,7 +132,7 @@ public:
   /**
    * Visible for testing.
    */
-  KafkaBrokerFilter(KafkaMetricsFacadeSharedPtr metrics,
+  KafkaBrokerFilter(KafkaMetricsFacadeSharedPtr metrics, RequestHandlerSharedPtr request_handler,
                     ResponseRewriterSharedPtr response_rewriter,
                     ResponseDecoderSharedPtr response_decoder,
                     RequestDecoderSharedPtr request_decoder);
@@ -177,6 +157,7 @@ private:
                     const KafkaMetricsFacadeSharedPtr& metrics);
 
   const KafkaMetricsFacadeSharedPtr metrics_;
+  const RequestHandlerSharedPtr request_handler_;
   const ResponseRewriterSharedPtr response_rewriter_;
   const ResponseDecoderSharedPtr response_decoder_;
   const RequestDecoderSharedPtr request_decoder_;

--- a/contrib/kafka/filters/network/source/broker/filter_config.cc
+++ b/contrib/kafka/filters/network/source/broker/filter_config.cc
@@ -21,17 +21,29 @@ static std::vector<RewriteRule> extractRewriteRules(const KafkaBrokerProtoConfig
   }
 }
 
+template <typename Iter> static absl::flat_hash_set<int16_t> extractApiKeySet(const Iter& arg) {
+  return {arg.begin(), arg.end()};
+}
+
 BrokerFilterConfig::BrokerFilterConfig(const KafkaBrokerProtoConfig& proto_config)
     : BrokerFilterConfig{proto_config.stat_prefix(), proto_config.force_response_rewrite(),
-                         extractRewriteRules(proto_config)} {}
+                         extractRewriteRules(proto_config),
+                         extractApiKeySet(proto_config.api_keys_allowed()),
+                         extractApiKeySet(proto_config.api_keys_denied())} {}
 
 BrokerFilterConfig::BrokerFilterConfig(const std::string& stat_prefix,
                                        const bool force_response_rewrite,
-                                       const std::vector<RewriteRule>& broker_address_rewrite_rules)
+                                       const std::vector<RewriteRule>& broker_address_rewrite_rules,
+                                       const absl::flat_hash_set<int16_t>& api_keys_allowed,
+                                       const absl::flat_hash_set<int16_t>& api_keys_denied)
     : stat_prefix_{stat_prefix}, force_response_rewrite_{force_response_rewrite},
-      broker_address_rewrite_rules_{broker_address_rewrite_rules} {
+      broker_address_rewrite_rules_{broker_address_rewrite_rules},
+      api_keys_allowed_{api_keys_allowed}, api_keys_denied_{api_keys_denied} {
+
   ASSERT(!stat_prefix_.empty());
 };
+
+const std::string& BrokerFilterConfig::statPrefix() const { return stat_prefix_; }
 
 bool BrokerFilterConfig::needsResponseRewrite() const {
   return force_response_rewrite_ || !broker_address_rewrite_rules_.empty();
@@ -48,7 +60,11 @@ BrokerFilterConfig::findBrokerAddressOverride(const uint32_t broker_id) const {
   return absl::nullopt;
 }
 
-const std::string& BrokerFilterConfig::statPrefix() const { return stat_prefix_; }
+absl::flat_hash_set<int16_t> BrokerFilterConfig::apiKeysAllowed() const {
+  return api_keys_allowed_;
+}
+
+absl::flat_hash_set<int16_t> BrokerFilterConfig::apiKeysDenied() const { return api_keys_denied_; }
 
 } // namespace Broker
 } // namespace Kafka

--- a/contrib/kafka/filters/network/source/broker/filter_config.h
+++ b/contrib/kafka/filters/network/source/broker/filter_config.h
@@ -2,6 +2,7 @@
 
 #include <utility>
 
+#include "absl/container/flat_hash_set.h"
 #include "absl/types/optional.h"
 #include "contrib/envoy/extensions/filters/network/kafka_broker/v3/kafka_broker.pb.h"
 #include "contrib/envoy/extensions/filters/network/kafka_broker/v3/kafka_broker.pb.validate.h"
@@ -39,7 +40,9 @@ public:
 
   // Visible for testing.
   BrokerFilterConfig(const std::string& stat_prefix, const bool force_response_rewrite,
-                     const std::vector<RewriteRule>& broker_address_rewrite_rules);
+                     const std::vector<RewriteRule>& broker_address_rewrite_rules,
+                     const absl::flat_hash_set<int16_t>& api_keys_allowed,
+                     const absl::flat_hash_set<int16_t>& api_keys_denied);
 
   /**
    * Returns the prefix for stats.
@@ -56,10 +59,22 @@ public:
    */
   virtual absl::optional<HostAndPort> findBrokerAddressOverride(const uint32_t broker_id) const;
 
+  /**
+   * Returns what API keys are allowed.
+   */
+  virtual absl::flat_hash_set<int16_t> apiKeysAllowed() const;
+
+  /**
+   * Returns what API keys are denied.
+   */
+  virtual absl::flat_hash_set<int16_t> apiKeysDenied() const;
+
 private:
   std::string stat_prefix_;
   bool force_response_rewrite_;
   std::vector<RewriteRule> broker_address_rewrite_rules_;
+  absl::flat_hash_set<int16_t> api_keys_allowed_;
+  absl::flat_hash_set<int16_t> api_keys_denied_;
 };
 
 using BrokerFilterConfigSharedPtr = std::shared_ptr<BrokerFilterConfig>;

--- a/contrib/kafka/filters/network/source/broker/request_handler.cc
+++ b/contrib/kafka/filters/network/source/broker/request_handler.cc
@@ -1,0 +1,49 @@
+#include "contrib/kafka/filters/network/source/broker/request_handler.h"
+
+#include "envoy/network/connection.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace Kafka {
+namespace Broker {
+
+// RequestHandlerImpl.
+
+RequestHandlerImpl::RequestHandlerImpl(const BrokerFilterConfigSharedPtr& config)
+    : api_keys_allowed_{config->apiKeysAllowed()}, api_keys_denied_{config->apiKeysDenied()} {}
+
+void RequestHandlerImpl::onMessage(AbstractRequestSharedPtr request) {
+  const auto api_key = request->apiKey();
+  const auto allowed = apiKeyAllowed(api_key, api_keys_allowed_, api_keys_denied_);
+  if (!allowed) {
+    auto& connection = callbacks_->connection();
+    ENVOY_CONN_LOG(debug, "Closing connection for request {}", connection, api_key);
+    connection.close(Network::ConnectionCloseType::FlushWrite, "denied (API key)");
+  }
+}
+
+void RequestHandlerImpl::onFailedParse(RequestParseFailureSharedPtr) {}
+
+void RequestHandlerImpl::setReadFilterCallbacks(Network::ReadFilterCallbacks& callbacks) {
+  this->callbacks_ = &callbacks;
+}
+
+bool RequestHandlerImpl::apiKeyAllowed(const int16_t api_key,
+                                       const absl::flat_hash_set<int16_t>& allowed,
+                                       const absl::flat_hash_set<int16_t>& denied) {
+  // If allowlist is configured, first check whether the request is allowed at all.
+  if (!allowed.empty()) {
+    if (!allowed.contains(api_key)) {
+      return false;
+    }
+  }
+  // Check whether request is denied.
+  return !denied.contains(api_key);
+}
+
+} // namespace Broker
+} // namespace Kafka
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/contrib/kafka/filters/network/source/broker/request_handler.h
+++ b/contrib/kafka/filters/network/source/broker/request_handler.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include "envoy/network/filter.h"
+
+#include "source/common/common/logger.h"
+
+#include "absl/container/flat_hash_set.h"
+#include "contrib/kafka/filters/network/source/broker/filter_config.h"
+#include "contrib/kafka/filters/network/source/external/requests.h"
+#include "contrib/kafka/filters/network/source/request_codec.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace Kafka {
+namespace Broker {
+
+class RequestHandler : public RequestCallback {
+public:
+  ~RequestHandler() override = default;
+
+  virtual void setReadFilterCallbacks(Network::ReadFilterCallbacks& callbacks) PURE;
+};
+
+using RequestHandlerSharedPtr = std::shared_ptr<RequestHandler>;
+
+class RequestHandlerImpl : public RequestHandler, private Logger::Loggable<Logger::Id::kafka> {
+public:
+  RequestHandlerImpl(const BrokerFilterConfigSharedPtr& config);
+
+  // RequestCallback
+  void onMessage(AbstractRequestSharedPtr request) override;
+  void onFailedParse(RequestParseFailureSharedPtr parse_failure) override;
+
+  // RequestHandler
+  void setReadFilterCallbacks(Network::ReadFilterCallbacks& callbacks) override;
+
+  static bool apiKeyAllowed(const int16_t api_key,
+                            const absl::flat_hash_set<int16_t>& api_keys_allowed,
+                            const absl::flat_hash_set<int16_t>& api_keys_denied);
+
+private:
+  Network::ReadFilterCallbacks* callbacks_;
+
+  absl::flat_hash_set<int16_t> api_keys_allowed_;
+  absl::flat_hash_set<int16_t> api_keys_denied_;
+};
+
+} // namespace Broker
+} // namespace Kafka
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/contrib/kafka/filters/network/source/kafka_request.h
+++ b/contrib/kafka/filters/network/source/kafka_request.h
@@ -102,6 +102,12 @@ public:
   AbstractRequest(const RequestHeader& request_header) : request_header_{request_header} {};
 
   /**
+   * Returns request API key.
+   * @return request API key
+   */
+  int16_t apiKey() const { return request_header_.api_key_; }
+
+  /**
    * Computes the size of this request, if it were to be serialized.
    * @return serialized size of request
    */

--- a/contrib/kafka/filters/network/test/broker/BUILD
+++ b/contrib/kafka/filters/network/test/broker/BUILD
@@ -24,6 +24,7 @@ envoy_cc_test(
     srcs = ["filter_unit_test.cc"],
     rbe_pool = "6gig",
     deps = [
+        ":mock_request_lib",
         "//contrib/kafka/filters/network/source/broker:filter_lib",
         "//envoy/event:timer_interface",
         "//test/mocks/network:network_mocks",
@@ -35,12 +36,22 @@ envoy_cc_test(
     name = "filter_protocol_test",
     srcs = ["filter_protocol_test.cc"],
     deps = [
-        ":mock_filter_config_test_lib",
         "//contrib/kafka/filters/network/source/broker:filter_lib",
         "//contrib/kafka/filters/network/test:buffer_based_test_lib",
         "//contrib/kafka/filters/network/test:message_utilities",
         "//test/common/stats:stat_test_utility_lib",
         "//test/test_common:test_time_lib",
+    ],
+)
+
+envoy_cc_test(
+    name = "request_handler_unit_test",
+    srcs = ["request_handler_unit_test.cc"],
+    deps = [
+        ":mock_filter_config_test_lib",
+        ":mock_request_lib",
+        "//contrib/kafka/filters/network/source/broker:request_handler_lib",
+        "//test/mocks/network:network_mocks",
     ],
 )
 
@@ -60,5 +71,14 @@ envoy_cc_test_library(
     hdrs = ["mock_filter_config.h"],
     deps = [
         "//contrib/kafka/filters/network/source/broker:filter_config_lib",
+    ],
+)
+
+envoy_cc_test_library(
+    name = "mock_request_lib",
+    srcs = [],
+    hdrs = ["mock_request.h"],
+    deps = [
+        "//contrib/kafka/filters/network/source:kafka_request_lib",
     ],
 )

--- a/contrib/kafka/filters/network/test/broker/filter_protocol_test.cc
+++ b/contrib/kafka/filters/network/test/broker/filter_protocol_test.cc
@@ -12,7 +12,6 @@
 #include "contrib/kafka/filters/network/source/broker/filter.h"
 #include "contrib/kafka/filters/network/source/external/requests.h"
 #include "contrib/kafka/filters/network/source/external/responses.h"
-#include "contrib/kafka/filters/network/test/broker/mock_filter_config.h"
 #include "contrib/kafka/filters/network/test/buffer_based_test.h"
 #include "contrib/kafka/filters/network/test/message_utilities.h"
 #include "gtest/gtest.h"
@@ -37,8 +36,9 @@ protected:
   Stats::Scope& scope_{*store_.rootScope()};
   Event::TestRealTimeSystem time_source_;
   KafkaBrokerFilter testee_{scope_, time_source_,
-                            std::make_shared<BrokerFilterConfig>(std::string("prefix"), false,
-                                                                 std::vector<RewriteRule>{})};
+                            std::make_shared<BrokerFilterConfig>(
+                                std::string("prefix"), false, std::vector<RewriteRule>{},
+                                absl::flat_hash_set<int16_t>{}, absl::flat_hash_set<int16_t>{})};
 
   Network::FilterStatus consumeRequestFromBuffer() {
     return testee_.onData(RequestB::buffer_, false);

--- a/contrib/kafka/filters/network/test/broker/mock_filter_config.h
+++ b/contrib/kafka/filters/network/test/broker/mock_filter_config.h
@@ -14,8 +14,12 @@ public:
   MOCK_METHOD((const std::string&), stat_prefix, (), (const));
   MOCK_METHOD(bool, needsResponseRewrite, (), (const));
   MOCK_METHOD((absl::optional<HostAndPort>), findBrokerAddressOverride, (const uint32_t), (const));
-  MockBrokerFilterConfig() : BrokerFilterConfig{"prefix", false, {}} {};
+  MOCK_METHOD((absl::flat_hash_set<int16_t>), apiKeysAllowed, (), (const));
+  MOCK_METHOD((absl::flat_hash_set<int16_t>), apiKeysDenied, (), (const));
+  MockBrokerFilterConfig() : BrokerFilterConfig{"prefix", false, {}, {}, {}} {};
 };
+
+using MockBrokerFilterConfigSharedPtr = std::shared_ptr<MockBrokerFilterConfig>;
 
 } // namespace Broker
 } // namespace Kafka

--- a/contrib/kafka/filters/network/test/broker/mock_request.h
+++ b/contrib/kafka/filters/network/test/broker/mock_request.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "contrib/kafka/filters/network/source/kafka_request.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace Kafka {
+namespace Broker {
+
+class MockRequest : public AbstractRequest {
+public:
+  MockRequest(const int16_t api_key, const int16_t api_version, const int32_t correlation_id)
+      : AbstractRequest{{api_key, api_version, correlation_id, ""}} {};
+  uint32_t computeSize() const override { return 0; };
+  uint32_t encode(Buffer::Instance&) const override { return 0; };
+};
+
+using MockRequestSharedPtr = std::shared_ptr<MockRequest>;
+
+} // namespace Broker
+} // namespace Kafka
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/contrib/kafka/filters/network/test/broker/request_handler_unit_test.cc
+++ b/contrib/kafka/filters/network/test/broker/request_handler_unit_test.cc
@@ -1,0 +1,83 @@
+#include "source/common/buffer/buffer_impl.h"
+
+#include "test/mocks/network/mocks.h"
+
+#include "contrib/kafka/filters/network/source/broker/request_handler.h"
+#include "contrib/kafka/filters/network/test/broker/mock_filter_config.h"
+#include "contrib/kafka/filters/network/test/broker/mock_request.h"
+#include "gtest/gtest.h"
+
+using testing::_;
+using testing::Return;
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace Kafka {
+namespace Broker {
+
+class RequestHandlerImplUnitTest : public testing::Test {
+protected:
+  MockBrokerFilterConfigSharedPtr config_ = std::make_shared<MockBrokerFilterConfig>();
+
+  NiceMock<Network::MockReadFilterCallbacks> filter_callbacks_;
+
+  RequestHandlerImpl createTestee() {
+    RequestHandlerImpl result{config_};
+    result.setReadFilterCallbacks(filter_callbacks_);
+    return result;
+  }
+};
+
+TEST_F(RequestHandlerImplUnitTest, ShouldDoNothing) {
+  // given
+  const absl::flat_hash_set<int16_t> ret = {};
+  EXPECT_CALL(*config_, apiKeysAllowed).WillRepeatedly(Return(ret));
+  EXPECT_CALL(*config_, apiKeysDenied).WillRepeatedly(Return(ret));
+  EXPECT_CALL(filter_callbacks_.connection_, close(_, _)).Times(0);
+
+  RequestHandlerImpl testee = createTestee();
+  MockRequestSharedPtr request = std::make_shared<MockRequest>(0, 0, 0);
+
+  // when
+  testee.onMessage(request);
+
+  // then - expectations fulfilled (connection untouched).
+}
+
+TEST_F(RequestHandlerImplUnitTest, ShouldCloseConnection) {
+  // given
+  const absl::flat_hash_set<int16_t> allowed = {};
+  const absl::flat_hash_set<int16_t> rejected = {13};
+  EXPECT_CALL(*config_, apiKeysAllowed).WillRepeatedly(Return(allowed));
+  EXPECT_CALL(*config_, apiKeysDenied).WillRepeatedly(Return(rejected));
+  EXPECT_CALL(filter_callbacks_.connection_, close(Network::ConnectionCloseType::FlushWrite, _));
+
+  RequestHandlerImpl testee = createTestee();
+  MockRequestSharedPtr request = std::make_shared<MockRequest>(13, 0, 0);
+
+  // when
+  testee.onMessage(request);
+
+  // then - expectations fulfilled (connection closed).
+}
+
+TEST(RequestHandlerImplApiKeyAllowed, ShouldGiveCorrectResults) {
+  ASSERT_TRUE(RequestHandlerImpl::apiKeyAllowed(13, {}, {})); // No config.
+
+  ASSERT_TRUE(RequestHandlerImpl::apiKeyAllowed(13, {13, 42}, {}));     // Allowed.
+  ASSERT_TRUE(RequestHandlerImpl::apiKeyAllowed(13, {}, {0, 1, 2, 3})); // Not denied.
+  ASSERT_TRUE(
+      RequestHandlerImpl::apiKeyAllowed(13, {13, 42}, {0, 1, 2, 3})); // Allowed + not denied.
+
+  ASSERT_FALSE(RequestHandlerImpl::apiKeyAllowed(13, {}, {13, 42}));     // Denied.
+  ASSERT_FALSE(RequestHandlerImpl::apiKeyAllowed(13, {0, 1, 2, 3}, {})); // Not allowed.
+  ASSERT_FALSE(
+      RequestHandlerImpl::apiKeyAllowed(13, {0, 1, 2, 3}, {13, 42})); // Not allowed + denied.
+}
+
+} // namespace Broker
+} // namespace Kafka
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/docs/root/configuration/listeners/network_filters/kafka_broker_filter.rst
+++ b/docs/root/configuration/listeners/network_filters/kafka_broker_filter.rst
@@ -179,6 +179,36 @@ The responses that can be mutated are:
 
 .. _config_network_filters_kafka_broker_debugging:
 
+Filtering requests
+------------------
+
+Broker filter can be used to filter out unwanted types of requests, e.g. fetch ones or produce ones.
+Both allowlist and denylist are possible.
+
+For example to allow only basic producer acces we can limit the access to the related requests:
+
+.. code-block:: yaml
+
+  - name: envoy.filters.network.kafka_broker
+    typed_config:
+      "@type": type.googleapis.com/envoy.extensions.filters.network.kafka_broker.v3.KafkaBroker
+      stat_prefix: prefix
+      api_keys_allowed:
+      - 0 # Produce
+      - 3 # Metadata
+      - 18 # API versions
+
+To disable consumers' read capability, we can just disable Fetch requests:
+
+.. code-block:: yaml
+
+  - name: envoy.filters.network.kafka_broker
+    typed_config:
+      "@type": type.googleapis.com/envoy.extensions.filters.network.kafka_broker.v3.KafkaBroker
+      stat_prefix: prefix
+      api_keys_denied:
+      - 1 # Fetch
+
 Debugging
 ---------
 


### PR DESCRIPTION
Commit Message: kafka: close connection when rejectable request appears
Additional Description: provides https://github.com/envoyproxy/envoy/issues/36978 by making the broker filter check the requests' API key against allow/denylists in the config - if we find a request to reject, we just close the connection. There is also a bonus: this sets up a framework for "_close connection if we don't like the request_" that we can expand upon later.
Risk Level: Low
Testing: automated (no filtering) + manual (filtering)
Docs Changes: Kafka broker .rst
Release Notes: n/a
Platform Specific Features: n/a