### PR TITLE
[quic]Check canonical suffix when checking checking QUIC brokenness

### DIFF
--- a/envoy/http/http_server_properties_cache.h
+++ b/envoy/http/http_server_properties_cache.h
@@ -182,6 +182,11 @@ public:
   virtual bool isHttp3Broken(const Origin& origin) PURE;
 
   /**
+   * @ origin The origin to mark h3 broken.
+   */
+  virtual void markHttp3Broken(const Origin& origin) PURE;
+
+  /**
    * Changes any origins with status "Broken" for HTTP/3 to "Failed Recently"
    */
   virtual void resetBrokenness() PURE;

--- a/envoy/http/http_server_properties_cache.h
+++ b/envoy/http/http_server_properties_cache.h
@@ -176,6 +176,12 @@ public:
   getOrCreateHttp3StatusTracker(const Origin& origin) PURE;
 
   /**
+   * @param origin The origin to check h3 brokenness for.
+   * @return if it's broken.
+   */
+  virtual bool isHttp3Broken(const Origin& origin) PURE;
+
+  /**
    * Changes any origins with status "Broken" for HTTP/3 to "Failed Recently"
    */
   virtual void resetBrokenness() PURE;

--- a/envoy/http/http_server_properties_cache.h
+++ b/envoy/http/http_server_properties_cache.h
@@ -177,7 +177,7 @@ public:
 
   /**
    * @param origin The origin to check h3 brokenness for.
-   * @return if it's broken.
+   * @return true if it's broken.
    */
   virtual bool isHttp3Broken(const Origin& origin) PURE;
 

--- a/source/common/http/conn_pool_grid.cc
+++ b/source/common/http/conn_pool_grid.cc
@@ -488,7 +488,10 @@ HttpServerPropertiesCache::Http3StatusTracker& ConnectivityGrid::getHttp3StatusT
   return alternate_protocols_->getOrCreateHttp3StatusTracker(origin_);
 }
 
-bool ConnectivityGrid::isHttp3Broken() const { return getHttp3StatusTracker().isHttp3Broken(); }
+bool ConnectivityGrid::isHttp3Broken() const {
+  ENVOY_BUG(host_->address()->type() == Network::Address::Type::Ip, "Address is not an IP address");
+  return alternate_protocols_->isHttp3Broken(origin_);
+}
 
 void ConnectivityGrid::markHttp3Broken() {
   host_->cluster().trafficStats()->upstream_http3_broken_.inc();

--- a/source/common/http/conn_pool_grid.cc
+++ b/source/common/http/conn_pool_grid.cc
@@ -495,7 +495,8 @@ bool ConnectivityGrid::isHttp3Broken() const {
 
 void ConnectivityGrid::markHttp3Broken() {
   host_->cluster().trafficStats()->upstream_http3_broken_.inc();
-  getHttp3StatusTracker().markHttp3Broken();
+  ENVOY_BUG(host_->address()->type() == Network::Address::Type::Ip, "Address is not an IP address");
+  alternate_protocols_->markHttp3Broken(origin_);
 }
 
 void ConnectivityGrid::markHttp3Confirmed() { getHttp3StatusTracker().markHttp3Confirmed(); }

--- a/source/common/http/http_server_properties_cache_impl.cc
+++ b/source/common/http/http_server_properties_cache_impl.cc
@@ -336,7 +336,7 @@ HttpServerPropertiesCacheImpl::getHttp3BrokenCanonicalOrigin(absl::string_view h
     return {};
   }
 
-  auto it = canonical_h3_broken_map_.find(std::string(suffix));
+  auto it = canonical_h3_broken_map_.find(suffix);
   if (it == canonical_h3_broken_map_.end()) {
     return {};
   }
@@ -348,7 +348,7 @@ void HttpServerPropertiesCacheImpl::maybeSetHttp3BrokenCanonicalOrigin(const Ori
   if (suffix.empty()) {
     return;
   }
-  canonical_h3_broken_map_[std::string(suffix)] = origin;
+  canonical_h3_broken_map_[suffix] = origin;
 }
 
 void HttpServerPropertiesCacheImpl::resetBrokenness() {
@@ -375,7 +375,7 @@ HttpServerPropertiesCacheImpl::getCanonicalOrigin(absl::string_view hostname) {
     return {};
   }
 
-  auto it = canonical_alt_svc_map_.find(std::string(suffix));
+  auto it = canonical_alt_svc_map_.find(suffix);
   if (it == canonical_alt_svc_map_.end()) {
     return {};
   }
@@ -388,7 +388,7 @@ void HttpServerPropertiesCacheImpl::maybeSetCanonicalOrigin(const Origin& origin
     return;
   }
 
-  canonical_alt_svc_map_[std::string(suffix)] = origin;
+  canonical_alt_svc_map_[suffix] = origin;
 }
 
 } // namespace Http

--- a/source/common/http/http_server_properties_cache_impl.cc
+++ b/source/common/http/http_server_properties_cache_impl.cc
@@ -301,20 +301,20 @@ bool HttpServerPropertiesCacheImpl::isHttp3Broken(const Origin& origin) {
   absl::optional<Origin> canonical = getCanonicalOrigin(origin.hostname_);
 
   if (!Runtime::runtimeFeatureEnabled(
-          "envoy.reloadable_features.use_canonical_suffix_for_quic_broken") ||
+          "envoy.reloadable_features.use_canonical_suffix_for_quic_brokenness") ||
       !canonical.has_value()) {
     return getOrCreateHttp3StatusTracker(origin).isHttp3Broken();
   }
 
   // Note that we don't create a new tracker for the origin if there's already a corresponding one
   // for the canonical origin.
-  auto entry_it = protocols_.find(origin);
-  if (entry_it != protocols_.end() && entry_it->second.h3_status_tracker != nullptr) {
+  if (auto entry_it = protocols_.find(origin);
+      entry_it != protocols_.end() && entry_it->second.h3_status_tracker != nullptr) {
     return entry_it->second.h3_status_tracker->isHttp3Broken();
   }
 
-  entry_it = protocols_.find(*canonical);
-  if (entry_it != protocols_.end() && entry_it->second.h3_status_tracker != nullptr) {
+  if (auto entry_it = protocols_.find(*canonical);
+      entry_it != protocols_.end() && entry_it->second.h3_status_tracker != nullptr) {
     return entry_it->second.h3_status_tracker->isHttp3Broken();
   }
 

--- a/source/common/http/http_server_properties_cache_impl.cc
+++ b/source/common/http/http_server_properties_cache_impl.cc
@@ -297,7 +297,7 @@ HttpServerPropertiesCacheImpl::getOrCreateHttp3StatusTracker(const Origin& origi
   return *it->second.h3_status_tracker;
 }
 
-bool HttpServerPropertiesCache::isHttp3Broken(const Origin& origin) {
+bool HttpServerPropertiesCacheImpl::isHttp3Broken(const Origin& origin) {
   absl::optional<Origin> canonical = getCanonicalOrigin(origin.hostname_);
 
   if (!Runtime::runtimeFeatureEnabled(
@@ -307,7 +307,7 @@ bool HttpServerPropertiesCache::isHttp3Broken(const Origin& origin) {
   }
 
   // Note that we don't create a new tracker for the origin if there's already a corresponding one
-  // for the canonical suffix.
+  // for the canonical origin.
   auto entry_it = protocols_.find(origin);
   if (entry_it != protocols_.end() && entry_it->second.h3_status_tracker != nullptr) {
     return entry_it->second.h3_status_tracker->isHttp3Broken();

--- a/source/common/http/http_server_properties_cache_impl.cc
+++ b/source/common/http/http_server_properties_cache_impl.cc
@@ -337,8 +337,8 @@ HttpServerPropertiesCacheImpl::getCanonicalOriginForHttp3Brokenness(absl::string
     return {};
   }
 
-  auto it = canonical_h3_broken_map_.find(suffix);
-  if (it == canonical_h3_broken_map_.end()) {
+  auto it = canonical_h3_brokenness_map_.find(suffix);
+  if (it == canonical_h3_brokenness_map_.end()) {
     return {};
   }
   return it->second;
@@ -350,7 +350,7 @@ void HttpServerPropertiesCacheImpl::maybeSetCanonicalOriginForHttp3Brokenness(
   if (suffix.empty()) {
     return;
   }
-  canonical_h3_broken_map_[suffix] = origin;
+  canonical_h3_brokenness_map_[suffix] = origin;
 }
 
 void HttpServerPropertiesCacheImpl::resetBrokenness() {

--- a/source/common/http/http_server_properties_cache_impl.cc
+++ b/source/common/http/http_server_properties_cache_impl.cc
@@ -311,8 +311,7 @@ bool HttpServerPropertiesCacheImpl::isHttp3Broken(const Origin& origin) {
     return getOrCreateHttp3StatusTracker(origin).isHttp3Broken();
   }
 
-  // Note that we don't create a new tracker for the origin if there's already a corresponding one
-  // for the canonical origin.
+  // Note that we don't create a new tracker for the origin.
   if (auto entry_it = protocols_.find(origin);
       entry_it != protocols_.end() && entry_it->second.h3_status_tracker != nullptr) {
     return entry_it->second.h3_status_tracker->isHttp3Broken();

--- a/source/common/http/http_server_properties_cache_impl.cc
+++ b/source/common/http/http_server_properties_cache_impl.cc
@@ -321,8 +321,11 @@ bool HttpServerPropertiesCacheImpl::isHttp3Broken(const Origin& origin) {
   if (!canonical.has_value()) {
     return false;
   }
-  if (auto entry_it = protocols_.find(*canonical);
-      entry_it != protocols_.end() && entry_it->second.h3_status_tracker != nullptr) {
+  if (auto entry_it = protocols_.find(*canonical); entry_it != protocols_.end()) {
+    if (entry_it->second.h3_status_tracker == nullptr) {
+      ENVOY_BUG(false, "the canonical origin doesn't have HTTP3 tracker");
+      return false;
+    }
     return entry_it->second.h3_status_tracker->isHttp3Broken();
   }
 

--- a/source/common/http/http_server_properties_cache_impl.h
+++ b/source/common/http/http_server_properties_cache_impl.h
@@ -91,6 +91,7 @@ public:
   size_t size() const override;
   HttpServerPropertiesCache::Http3StatusTracker&
   getOrCreateHttp3StatusTracker(const Origin& origin) override;
+  bool isHttp3Broken(const Origin& origin) override;
   void resetBrokenness() override;
 
 private:

--- a/source/common/http/http_server_properties_cache_impl.h
+++ b/source/common/http/http_server_properties_cache_impl.h
@@ -160,8 +160,8 @@ private:
   // protocol mapping.
   absl::flat_hash_map<std::string, Origin> canonical_alt_svc_map_;
 
-  // Contains a map of origins which are known to have http3 broken.
-  // Map from a canonical suffix to an actual origin, which is known to have broken QUIC.
+  // Contains a map of origins whose http3 status are known.
+  // Map from a canonical suffix to an actual origin that can provide http3 brokenness info.
   absl::flat_hash_map<std::string, Origin> canonical_h3_brokenness_map_;
 
   // Contains list of suffixes (for example ".c.youtube.com",

--- a/source/common/http/http_server_properties_cache_impl.h
+++ b/source/common/http/http_server_properties_cache_impl.h
@@ -91,6 +91,7 @@ public:
   size_t size() const override;
   HttpServerPropertiesCache::Http3StatusTracker&
   getOrCreateHttp3StatusTracker(const Origin& origin) override;
+  void markHttp3Broken(const Origin& origin) override;
   bool isHttp3Broken(const Origin& origin) override;
   void resetBrokenness() override;
 
@@ -138,6 +139,13 @@ private:
   // Returns the canonical suffix, if any, associated with `hostname`.
   absl::string_view getCanonicalSuffix(absl::string_view hostname);
 
+  // Returns the canonical origin from the canonical_h3_broken_map, if any, associated with
+  // `hostname`.
+  absl::optional<Origin> getHttp3BrokenCanonicalOrigin(absl::string_view hostname);
+
+  // Updates the canonial origin for http3 brokenness book keeping.
+  void maybeSetHttp3BrokenCanonicalOrigin(const Origin& origin);
+
   // Returns the canonical origin, if any, associated with `hostname`.
   absl::optional<Origin> getCanonicalOrigin(absl::string_view hostname);
 
@@ -150,7 +158,11 @@ private:
   // Contains a map of servers which could share the same alternate protocol.
   // Map from a Canonical suffix to an actual origin, which has a plausible alternate
   // protocol mapping.
-  std::map<std::string, Origin> canonical_alt_svc_map_;
+  absl::flat_hash_map<std::string, Origin> canonical_alt_svc_map_;
+
+  // Contains a map of servers which are known to have http3 broken.
+  // Map from a canonical suffix to an actual origin, which is known to have broken QUIC.
+  absl::flat_hash_map<std::string, Origin> canonical_h3_broken_map_;
 
   // Contains list of suffixes (for example ".c.youtube.com",
   // ".googlevideo.com", ".googleusercontent.com") of canonical hostnames.

--- a/source/common/http/http_server_properties_cache_impl.h
+++ b/source/common/http/http_server_properties_cache_impl.h
@@ -162,7 +162,7 @@ private:
 
   // Contains a map of origins which are known to have http3 broken.
   // Map from a canonical suffix to an actual origin, which is known to have broken QUIC.
-  absl::flat_hash_map<std::string, Origin> canonical_h3_broken_map_;
+  absl::flat_hash_map<std::string, Origin> canonical_h3_brokenness_map_;
 
   // Contains list of suffixes (for example ".c.youtube.com",
   // ".googlevideo.com", ".googleusercontent.com") of canonical hostnames.

--- a/source/common/http/http_server_properties_cache_impl.h
+++ b/source/common/http/http_server_properties_cache_impl.h
@@ -143,7 +143,7 @@ private:
   // `hostname`.
   absl::optional<Origin> getCanonicalOriginForHttp3Brokenness(absl::string_view hostname);
 
-  // Updates the canonial origin for http3 brokenness book keeping.
+  // Updates the canonical origin for http3 brokenness book keeping.
   void maybeSetCanonicalOriginForHttp3Brokenness(const Origin& origin);
 
   // Returns the canonical origin, if any, associated with `hostname`.

--- a/source/common/http/http_server_properties_cache_impl.h
+++ b/source/common/http/http_server_properties_cache_impl.h
@@ -141,10 +141,10 @@ private:
 
   // Returns the canonical origin from the canonical_h3_broken_map, if any, associated with
   // `hostname`.
-  absl::optional<Origin> getHttp3BrokenCanonicalOrigin(absl::string_view hostname);
+  absl::optional<Origin> getCanonicalOriginForHttp3Brokenness(absl::string_view hostname);
 
   // Updates the canonial origin for http3 brokenness book keeping.
-  void maybeSetHttp3BrokenCanonicalOrigin(const Origin& origin);
+  void maybeSetCanonicalOriginForHttp3Brokenness(const Origin& origin);
 
   // Returns the canonical origin, if any, associated with `hostname`.
   absl::optional<Origin> getCanonicalOrigin(absl::string_view hostname);
@@ -160,7 +160,7 @@ private:
   // protocol mapping.
   absl::flat_hash_map<std::string, Origin> canonical_alt_svc_map_;
 
-  // Contains a map of servers which are known to have http3 broken.
+  // Contains a map of origins which are known to have http3 broken.
   // Map from a canonical suffix to an actual origin, which is known to have broken QUIC.
   absl::flat_hash_map<std::string, Origin> canonical_h3_broken_map_;
 

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -153,7 +153,7 @@ FALSE_RUNTIME_GUARD(envoy_reloadable_features_reset_brokenness_on_nework_change)
 // Adding runtime flag to use balsa_parser for http_inspector.
 FALSE_RUNTIME_GUARD(envoy_reloadable_features_http_inspector_use_balsa_parser);
 // TODO(renjietang): Evaluate and make this a config knob or remove.
-FALSE_RUNTIME_GUARD(envoy_reloadable_features_use_canonical_suffix_for_quic_broken);
+FALSE_RUNTIME_GUARD(envoy_reloadable_features_use_canonical_suffix_for_quic_brokenness);
 
 // A flag to set the maximum TLS version for google_grpc client to TLS1.2, when needed for
 // compliance restrictions.

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -152,6 +152,8 @@ FALSE_RUNTIME_GUARD(envoy_reloadable_features_dns_cache_set_ip_version_to_remove
 FALSE_RUNTIME_GUARD(envoy_reloadable_features_reset_brokenness_on_nework_change);
 // Adding runtime flag to use balsa_parser for http_inspector.
 FALSE_RUNTIME_GUARD(envoy_reloadable_features_http_inspector_use_balsa_parser);
+// TODO(renjietang): Evaluate and make this a config knob or remove.
+FALSE_RUNTIME_GUARD(envoy_reloadable_features_use_canonical_suffix_for_quic_broken);
 
 // A flag to set the maximum TLS version for google_grpc client to TLS1.2, when needed for
 // compliance restrictions.

--- a/test/common/http/http_server_properties_cache_impl_test.cc
+++ b/test/common/http/http_server_properties_cache_impl_test.cc
@@ -412,8 +412,8 @@ TEST_P(HttpServerPropertiesCacheImplTest, ClearBrokenness) {
 }
 
 TEST_P(HttpServerPropertiesCacheImplTest, CanonicalSuffix) {
-  Runtime::maybeSetRuntimeGuard("envoy.reloadable_features.use_canonical_suffix_for_quic_broken",
-                                true);
+  Runtime::maybeSetRuntimeGuard(
+      "envoy.reloadable_features.use_canonical_suffix_for_quic_brokenness", true);
   std::string suffix = ".example.com";
   std::string host1 = "first.example.com";
   std::string host2 = "www.second.example.com";
@@ -425,7 +425,7 @@ TEST_P(HttpServerPropertiesCacheImplTest, CanonicalSuffix) {
   protocols_->setAlternatives(origin1, protocols1_);
 
   protocols_->getOrCreateHttp3StatusTracker(origin1).markHttp3Broken();
-  EXPECT_TRUE(protocols_->isH3Broken(origin2));
+  EXPECT_TRUE(protocols_->isHttp3Broken(origin2));
 
   OptRef<const std::vector<HttpServerPropertiesCacheImpl::AlternateProtocol>> protocols =
       protocols_->findAlternatives(origin2);
@@ -434,6 +434,8 @@ TEST_P(HttpServerPropertiesCacheImplTest, CanonicalSuffix) {
 }
 
 TEST_P(HttpServerPropertiesCacheImplTest, CanonicalSuffixNoMatch) {
+  Runtime::maybeSetRuntimeGuard(
+      "envoy.reloadable_features.use_canonical_suffix_for_quic_brokenness", true);
   std::string suffix = ".example.com";
   std::string host1 = "www.example.com";
   std::string host2 = "www.other.com";
@@ -443,6 +445,9 @@ TEST_P(HttpServerPropertiesCacheImplTest, CanonicalSuffixNoMatch) {
   suffixes_.push_back(suffix);
   initialize();
   protocols_->setAlternatives(origin1, protocols1_);
+
+  protocols_->getOrCreateHttp3StatusTracker(origin1).markHttp3Broken();
+  EXPECT_FALSE(protocols_->isHttp3Broken(origin2));
 
   OptRef<const std::vector<HttpServerPropertiesCacheImpl::AlternateProtocol>> protocols =
       protocols_->findAlternatives(origin2);

--- a/test/common/http/http_server_properties_cache_impl_test.cc
+++ b/test/common/http/http_server_properties_cache_impl_test.cc
@@ -412,6 +412,8 @@ TEST_P(HttpServerPropertiesCacheImplTest, ClearBrokenness) {
 }
 
 TEST_P(HttpServerPropertiesCacheImplTest, CanonicalSuffix) {
+  Runtime::maybeSetRuntimeGuard("envoy.reloadable_features.use_canonical_suffix_for_quic_broken",
+                                true);
   std::string suffix = ".example.com";
   std::string host1 = "first.example.com";
   std::string host2 = "www.second.example.com";
@@ -421,6 +423,9 @@ TEST_P(HttpServerPropertiesCacheImplTest, CanonicalSuffix) {
   suffixes_.push_back(suffix);
   initialize();
   protocols_->setAlternatives(origin1, protocols1_);
+
+  protocols_->getOrCreateHttp3StatusTracker(origin1).markHttp3Broken();
+  EXPECT_TRUE(protocols_->isH3Broken(origin2));
 
   OptRef<const std::vector<HttpServerPropertiesCacheImpl::AlternateProtocol>> protocols =
       protocols_->findAlternatives(origin2);

--- a/test/common/http/http_server_properties_cache_impl_test.cc
+++ b/test/common/http/http_server_properties_cache_impl_test.cc
@@ -51,6 +51,7 @@ public:
   const std::string hostname3_ = "hostname3";
   const uint32_t port1_ = 1;
   const uint32_t port2_ = 2;
+  const uint32_t port3_ = 3;
   const std::string https_ = "https";
   const std::string http_ = "http";
 
@@ -379,7 +380,7 @@ TEST_P(HttpServerPropertiesCacheImplTest, GetOrCreateHttp3StatusTracker) {
   initialize();
   EXPECT_EQ(0u, protocols_->size());
 
-  protocols_->getOrCreateHttp3StatusTracker(origin1_).markHttp3Broken();
+  protocols_->markHttp3Broken(origin1_);
   EXPECT_EQ(1u, protocols_->size());
   EXPECT_TRUE(protocols_->getOrCreateHttp3StatusTracker(origin1_).isHttp3Broken());
   EXPECT_TRUE(protocols_->getOrCreateHttp3StatusTracker(origin1_).isHttp3Broken());
@@ -395,9 +396,9 @@ TEST_P(HttpServerPropertiesCacheImplTest, ClearBrokenness) {
   initialize();
   EXPECT_EQ(0u, protocols_->size());
 
-  protocols_->getOrCreateHttp3StatusTracker(origin1_).markHttp3Broken();
+  protocols_->markHttp3Broken(origin1_);
   protocols_->getOrCreateHttp3StatusTracker(origin2_).markHttp3Confirmed();
-  protocols_->getOrCreateHttp3StatusTracker(origin3_).markHttp3Broken();
+  protocols_->markHttp3Broken(origin3_);
 
   EXPECT_EQ(3u, protocols_->size());
   EXPECT_TRUE(protocols_->getOrCreateHttp3StatusTracker(origin1_).isHttp3Broken());
@@ -424,7 +425,7 @@ TEST_P(HttpServerPropertiesCacheImplTest, CanonicalSuffix) {
   initialize();
   protocols_->setAlternatives(origin1, protocols1_);
 
-  protocols_->getOrCreateHttp3StatusTracker(origin1).markHttp3Broken();
+  protocols_->markHttp3Broken(origin1);
   EXPECT_TRUE(protocols_->isHttp3Broken(origin2));
 
   OptRef<const std::vector<HttpServerPropertiesCacheImpl::AlternateProtocol>> protocols =
@@ -446,12 +447,42 @@ TEST_P(HttpServerPropertiesCacheImplTest, CanonicalSuffixNoMatch) {
   initialize();
   protocols_->setAlternatives(origin1, protocols1_);
 
-  protocols_->getOrCreateHttp3StatusTracker(origin1).markHttp3Broken();
+  protocols_->markHttp3Broken(origin1);
   EXPECT_FALSE(protocols_->isHttp3Broken(origin2));
 
   OptRef<const std::vector<HttpServerPropertiesCacheImpl::AlternateProtocol>> protocols =
       protocols_->findAlternatives(origin2);
   ASSERT_FALSE(protocols.has_value());
+}
+
+TEST_P(HttpServerPropertiesCacheImplTest, CanonicalSuffixQuicBrokennessNoBackPropagation) {
+  Runtime::maybeSetRuntimeGuard(
+      "envoy.reloadable_features.use_canonical_suffix_for_quic_brokenness", true);
+  std::string suffix = ".example.com";
+  std::string host1 = "first.example.com";
+  std::string host2 = "www.second.example.com";
+  std::string host3 = "www.third.example.com";
+  const HttpServerPropertiesCacheImpl::Origin origin1 = {https_, host1, port1_};
+  const HttpServerPropertiesCacheImpl::Origin origin2 = {https_, host2, port2_};
+  const HttpServerPropertiesCacheImpl::Origin origin3 = {https_, host3, port3_};
+
+  suffixes_.push_back(suffix);
+  initialize();
+  protocols_->setAlternatives(origin1, protocols1_);
+
+  OptRef<const std::vector<HttpServerPropertiesCacheImpl::AlternateProtocol>> protocols =
+      protocols_->findAlternatives(origin2);
+  ASSERT_TRUE(protocols.has_value());
+  EXPECT_EQ(protocols1_, protocols.ref());
+  EXPECT_FALSE(protocols_->isHttp3Broken(origin1));
+  EXPECT_FALSE(protocols_->isHttp3Broken(origin2));
+
+  // Marking origin2 broken will promote it to being canonical. origin3 will use this canonical
+  // origin to determine QUIC brokenness, while origin1 has its own tracker already and is exempt.
+  protocols_->markHttp3Broken(origin2);
+  EXPECT_TRUE(protocols_->isHttp3Broken(origin2));
+  EXPECT_TRUE(protocols_->isHttp3Broken(origin3));
+  EXPECT_FALSE(protocols_->isHttp3Broken(origin1));
 }
 
 TEST_P(HttpServerPropertiesCacheImplTest, ExplicitAlternativeTakesPriorityOverCanonicalSuffix) {

--- a/test/mocks/http/http_server_properties_cache.h
+++ b/test/mocks/http/http_server_properties_cache.h
@@ -22,6 +22,7 @@ public:
   MOCK_METHOD(HttpServerPropertiesCache::Http3StatusTracker&, getOrCreateHttp3StatusTracker,
               (const Origin& origin));
   MOCK_METHOD(bool, isHttp3Broken, (const Origin& origin));
+  MOCK_METHOD(void, markHttp3Broken, (const Origin& origin));
   MOCK_METHOD(void, resetBrokenness, ());
 };
 

--- a/test/mocks/http/http_server_properties_cache.h
+++ b/test/mocks/http/http_server_properties_cache.h
@@ -21,6 +21,7 @@ public:
   MOCK_METHOD(size_t, size, (), (const));
   MOCK_METHOD(HttpServerPropertiesCache::Http3StatusTracker&, getOrCreateHttp3StatusTracker,
               (const Origin& origin));
+  MOCK_METHOD(bool, isHttp3Broken, (const Origin& origin));
   MOCK_METHOD(void, resetBrokenness, ());
 };
 


### PR DESCRIPTION
Commit Message: Check canonical suffix when checking checking QUIC brokenness
Additional Description: 
Risk Level: low. protected by default false runtime guard
Testing: unit test
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
Runtime guard: envoy_reloadable_features_use_canonical_suffix_for_quic_broken
