### PR TITLE
Make CancelWrapper enforce thread constraint

### DIFF
--- a/source/common/common/BUILD
+++ b/source/common/common/BUILD
@@ -34,6 +34,7 @@ envoy_cc_library(
     name = "cancel_wrapper_lib",
     hdrs = ["cancel_wrapper.h"],
     deps = [
+        "//source/common/common:assert_lib",
         "@com_google_absl//absl/functional:any_invocable",
     ],
 )


### PR DESCRIPTION
Commit Message: Make CancelWrapper enforce thread constraint
Additional Description: Followup to #36938, in debug builds, enforcing the directive that callbacks and cancellations must be on the same thread.
Risk Level: None, still not touching production code.
Testing: Added unit test.
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
