### PR TITLE
1.32 backport: Relax recent SNI restrictions (#36950)

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -8,6 +8,10 @@ minor_behavior_changes:
 
 bug_fixes:
 # *Changes expected to improve the state of the world and are unlikely to have negative effects*
+- area: access_log
+  change: |
+    Relaxed the restriction on SNI logging to allow the ``_`` character, even if
+    ``envoy.reloadable_features.sanitize_sni_in_access_log`` is enabled.
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/source/common/common/utility.cc
+++ b/source/common/common/utility.cc
@@ -590,7 +590,8 @@ std::string StringUtil::sanitizeInvalidHostname(const absl::string_view source) 
   std::string ret_str = std::string(source);
   bool sanitized = false;
   for (size_t i = 0; i < ret_str.size(); ++i) {
-    if (absl::ascii_isalnum(ret_str[i]) || ret_str[i] == '.' || ret_str[i] == '-') {
+    if (absl::ascii_isalnum(ret_str[i]) || ret_str[i] == '.' || ret_str[i] == '-' ||
+        ret_str[i] == '_') {
       continue;
     }
     sanitized = true;

--- a/source/common/common/utility.h
+++ b/source/common/common/utility.h
@@ -492,8 +492,8 @@ public:
 
   /**
    * Sanitize host name strings for logging purposes. Replace invalid hostname characters (anything
-   * that's not alphanumeric, hyphen, or period) with underscore. The sanitized string is not a
-   * valid host name.
+   * that's not alphanumeric, hyphen, or period) with underscore. The sanitized string
+   * is not a valid host name.
    * @param source supplies the string to sanitize.
    * @return sanitized string.
    */

--- a/test/common/formatter/substitution_formatter_test.cc
+++ b/test/common/formatter/substitution_formatter_test.cc
@@ -958,6 +958,15 @@ TEST(SubstitutionFormatterTest, streamInfoFormatter) {
 
   {
     StreamInfoFormatter upstream_format("REQUESTED_SERVER_NAME");
+    std::string requested_server_name = "outbound_.8080_._.example.com";
+    stream_info.downstream_connection_info_provider_->setRequestedServerName(requested_server_name);
+    EXPECT_EQ("outbound_.8080_._.example.com", upstream_format.formatWithContext({}, stream_info));
+    EXPECT_THAT(upstream_format.formatValueWithContext({}, stream_info),
+                ProtoEq(ValueUtil::stringValue("outbound_.8080_._.example.com")));
+  }
+
+  {
+    StreamInfoFormatter upstream_format("REQUESTED_SERVER_NAME");
     std::string requested_server_name = "stub-server";
     stream_info.downstream_connection_info_provider_->setRequestedServerName(requested_server_name);
     EXPECT_EQ("stub-server", upstream_format.formatWithContext({}, stream_info));


### PR DESCRIPTION
This change is being backported as it is a bug-fix for a regression for a fix that was also applied to this branch. Merging this fixes the regression.

See https://github.com/istio/istio/issues/53426. Istio has used underscores in their SNI since the beginning and it is critical to its functionality. Usage of underscores in SNI is a bit of a grey area in the RFCs, which are extremely under-specified wrt to what exactly is the allowed formats. However, the de-facto standard is to allow them, as virtually every TLS library does so (including, but not limited to, Golang, rustls, openssl, boringssl).

This PR loosens the restriction to additionally allow underscores.

Note the intent of the SNI restrictions was not RFC compliance, etc -- but rather to fix [log
injection](https://github.com/envoyproxy/envoy/security/advisories/GHSA-p222-xhp9-39rc) attacks (putting ANSI escapes, HTML, etc) into logs. This change does not loosen the security properties we hoped to gain with the initial patch.

Signed-off-by: John Howard <john.howard@solo.io>
(cherry picked from commit 79ee3427d9aae17cb008f1c71ea6e6e25a458069)

