### PR TITLE
bazel/ci: Remove old fetch setup

### DIFF
--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -18,65 +18,6 @@ echo "building for ${ENVOY_BUILD_ARCH}"
 
 cd "${SRCDIR}"
 
-# Its better to fetch too little rather than too much, as whatever is
-# actually used is what will be cached.
-# Fetching is mostly for robustness rather than optimization.
-FETCH_TARGETS=(
-    @bazel_tools//tools/jdk:remote_jdk11
-    //bazel/rbe/toolchains/...
-    //tools/gsutil
-    //tools/zstd)
-FETCH_BUILD_TARGETS=(
-    //contrib/exe/...
-    //distribution/...
-    //source/exe/...)
-FETCH_GCC_TARGETS=(
-    //source/exe/...)
-# TODO(phlax): add this as a general cache
-#  this fetches a bit too much for some of the targets
-#  but its not really possible to filter their needs so move
-#  to a shared precache
-FETCH_TEST_TARGETS=(
-    @nodejs//...
-    //test/...)
-FETCH_ALL_TEST_TARGETS=(
-    @com_github_google_quiche//:ci_tests
-    "${FETCH_TEST_TARGETS[@]}")
-FETCH_API_TARGETS=(
-    @envoy_api//...
-    //tools/api_proto_plugin/...
-    //tools/protoprint/...
-    //tools/protoxform/...
-    //tools/type_whisperer/...
-    //tools/testdata/protoxform/...)
-FETCH_DOCS_TARGETS+=(
-    //docs/...)
-FETCH_FORMAT_TARGETS+=(
-    //tools/code_format/...)
-FETCH_PROTO_TARGETS=(
-    @com_github_bufbuild_buf//:bin/buf
-    //tools/proto_format/...)
-
-
-retry () {
-    local n wait iterations
-    wait="${1}"
-    iterations="${2}"
-    shift 2
-    n=0
-    until [ "$n" -ge "$iterations" ]; do
-        "${@}" \
-            && break
-        n=$((n+1))
-        if [[ "$n" -lt "$iterations" ]]; then
-            sleep "$wait"
-            echo "Retrying ..."
-        else
-            echo "Fetch failed"
-            exit 1
-        fi
-    done
-}
 
 if [[ "${ENVOY_BUILD_ARCH}" == "x86_64" ]]; then
   BUILD_ARCH_DIR="/linux/amd64"
@@ -719,57 +660,6 @@ case $CI_TARGET in
               /source/generated/docs \
               docs \
               "${GCS_REDIRECT_PATH}"
-        ;;
-
-    fetch|fetch-*)
-        case $CI_TARGET in
-            fetch)
-                targets=("${FETCH_TARGETS[@]}")
-                ;;
-            fetch-check_and_fix_proto_format)
-                targets=("${FETCH_PROTO_TARGETS[@]}")
-                ;;
-            fetch-docs)
-                targets=("${FETCH_DOCS_TARGETS[@]}")
-                ;;
-            fetch-format)
-                targets=("${FETCH_FORMAT_TARGETS[@]}")
-                ;;
-            fetch-gcc)
-                targets=("${FETCH_GCC_TARGETS[@]}")
-                ;;
-            fetch-release|fetch-release.test_only)
-                targets=(
-                    "${FETCH_BUILD_TARGETS[@]}"
-                    "${FETCH_ALL_TEST_TARGETS[@]}")
-                ;;
-            fetch-release.server_only)
-                targets=(
-                    "${FETCH_BUILD_TARGETS[@]}")
-                ;;
-            fetch-*coverage)
-                targets=("${FETCH_TEST_TARGETS[@]}")
-                ;;
-            fetch-*san|fetch-compile_time_options)
-                targets=("${FETCH_ALL_TEST_TARGETS[@]}")
-                ;;
-            fetch-api)
-                targets=("${FETCH_API_TARGETS[@]}")
-                ;;
-            *)
-                exit 0
-                ;;
-        esac
-        setup_clang_toolchain
-        FETCH_ARGS=(
-            --noshow_progress
-            --noshow_loading_progress)
-        echo "Fetching ${targets[*]} ..."
-        retry 15 10 bazel \
-              fetch \
-              "${BAZEL_GLOBAL_OPTIONS[@]}" \
-              "${FETCH_ARGS[@]}" \
-              "${targets[@]}"
         ;;
 
     fix_proto_format)


### PR DESCRIPTION
fetch doesnt work very well or in ways you would expect (may improve with bzlmod)

currently this isnt used but when we add it back we will use `aquery` instead to populate the cache