### PR TITLE
docs: add and fix license URLs

### DIFF
--- a/api/bazel/repository_locations.bzl
+++ b/api/bazel/repository_locations.bzl
@@ -163,6 +163,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         urls = ["https://github.com/norbjd/protoc-gen-jsonschema/archive/{version}.zip"],
         use_category = ["build"],
         release_date = "2023-05-30",
+        license = "Apache-2.0",
+        license_url = "https://github.com/norbjd/protoc-gen-jsonschema/blob/{version}/LICENSE",
     ),
     dev_cel = dict(
         project_name = "CEL",
@@ -174,6 +176,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         urls = ["https://github.com/google/cel-spec/archive/v{version}.tar.gz"],
         use_category = ["api"],
         release_date = "2024-10-23",
+        license = "Apache-2.0",
+        license_url = "https://github.com/google/cel-spec/blob/v{version}/LICENSE",
     ),
     envoy_toolshed = dict(
         project_name = "envoy_toolshed",
@@ -187,6 +191,6 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         release_date = "2024-11-04",
         cpe = "N/A",
         license = "Apache-2.0",
-        license_url = "https://github.com/envoyproxy/envoy/blob/bazel-v{version}/LICENSE",
+        license_url = "https://github.com/envoyproxy/toolshed/blob/bazel-v{version}/LICENSE",
     ),
 )

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -203,7 +203,7 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         use_category = ["build"],
         cpe = "N/A",
         license = "MIT",
-        license_url = "https://github.com/aignas/rules_shellcheck/blob/v{version}/LICENSE",
+        license_url = "https://github.com/aignas/rules_shellcheck/blob/{version}/LICENSE",
     ),
     com_github_awslabs_aws_c_auth = dict(
         project_name = "aws-c-auth",
@@ -336,7 +336,7 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         release_date = "2024-07-20",
         cpe = "cpe:2.3:a:fmt:fmt:*",
         license = "fmt",
-        license_url = "https://github.com/fmtlib/fmt/blob/{version}/LICENSE.rst",
+        license_url = "https://github.com/fmtlib/fmt/blob/{version}/LICENSE",
     ),
     com_github_gabime_spdlog = dict(
         project_name = "spdlog",
@@ -1278,6 +1278,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         ],
         release_date = "2024-10-25",
         cpe = "N/A",
+        license = "Apache-2.0",
+        license_url = "https://github.com/google/cel-cpp/blob/v{version}/LICENSE",
     ),
     com_github_google_flatbuffers = dict(
         project_name = "FlatBuffers",


### PR DESCRIPTION
For cel, envoy_toolshed, fmt, protoc-gen-jsonschema, shellcheck rules

Risk Level: Low
Docs Changes: add and fix license URLs of external components