### PR TITLE
[contrib][postgres] Remove <> after constructor in the PG proxy code

### DIFF
--- a/contrib/postgres_proxy/filters/network/source/postgres_message.h
+++ b/contrib/postgres_proxy/filters/network/source/postgres_message.h
@@ -394,7 +394,7 @@ public:
 // Terminal template definition for variadic Sequence template.
 template <> class Sequence<> {
 public:
-  Sequence<>() = default;
+  Sequence() = default;
   std::string toString() const { return ""; }
   bool read(const Buffer::Instance&, uint64_t&, uint64_t&) { return true; }
   Message::ValidationResult validate(const Buffer::Instance&, const uint64_t, uint64_t&,


### PR DESCRIPTION
Commit Message:

Angle brackets are not required after constructor and, maybe, aren't even correct, though I'm not 100% sure on what the standard says on the matter.

It seems like clang is fine with this syntax, but when you try to build Envoy with gcc it complains:

```
./contrib/postgres_proxy/filters/network/source/postgres_message.h: At global scope:
./contrib/postgres_proxy/filters/network/source/postgres_message.h:397:14: error: expected unqualified-id before ')' token
  397 |   Sequence<>() = default;
      |              ^
Target //contrib/exe:envoy-static failed to build
```

Given that it's at least unusual to have angle brackets after constructor in a class template specialization let's remove them and satisfy both gcc and clang.

Additional Description:

It's one of the issue that prevent contrib build with gcc. It's not the original issue reported in https://github.com/envoyproxy/envoy/issues/31807, but that issue is what started the investigation.

Risk Level: Low
Testing: bazel build with --config=gcc and --config=docker-gcc options and in various compliation modes.
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
