### PR TITLE
[contrib] Stop building ICU tools to fix gcc Envoy build

### DIFF
--- a/bazel/foreign_cc/BUILD
+++ b/bazel/foreign_cc/BUILD
@@ -184,7 +184,6 @@ configure_make(
     configure_options = [
         "--enable-option-checking",
         "--enable-static",
-        "--enable-tools",
         "--disable-draft",
         "--disable-dyload",
         "--disable-extras",
@@ -193,6 +192,7 @@ configure_make(
         "--disable-samples",
         "--disable-shared",
         "--disable-tests",
+        "--disable-tools",
         "--with-data-packaging=static",
     ],
     data = ["@com_github_unicode_org_icu//:all"],


### PR DESCRIPTION
Commit Message:

Clang and gcc are subtly different and it seems to be the cause of contrib build failures reported in
https://github.com/envoyproxy/envoy/issues/31807 (e.g., when using gcc to link the final binary it results in a bunch of essential for gcc C++ symbols like __gxx_personality_v0).

This issue could be addressed (i.e., Envoy can be built using gcc). However, given that it only happens when we build ICU binary tools and those tools aren't used by Envoy directly or the build system, we can just not build them and address the issue this way.

Additional Description:

It addresses the immediate problem reported in https://github.com/envoyproxy/envoy/issues/31807, but by itself it's not enough to fix gcc builds, so I'm not marking this PR as fixing that issue because of that, since ultimately we want to achieve successful gcc builds.

Risk Level: Low
Testing: building contrib and non-contrib Envoy using --config=gcc and --config=docker-gcc
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A