### PR TITLE
Remove extraneous target source/common/common:xds_manager_lib

### DIFF
--- a/source/common/common/BUILD
+++ b/source/common/common/BUILD
@@ -624,14 +624,3 @@ envoy_cc_library(
         "@com_google_absl//absl/container:node_hash_set",
     ],
 )
-
-envoy_cc_library(
-    name = "xds_manager_lib",
-    srcs = ["xds_manager_impl.cc"],
-    hdrs = ["xds_manager_impl.h"],
-    deps = [
-        "//envoy/config:xds_manager_interface",
-        "//envoy/upstream:cluster_manager_interface",
-        "//source/common/common:thread_lib",
-    ],
-)


### PR DESCRIPTION
Commit Message: Remove extraneous target source/common/common:xds_manager_lib
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]

Fairly sure that this was introduced in #36768 by mistake. I can't find any references to the target, `source/common/common/xds_manager_impl.{h,c}` don't exist.