### PR TITLE
feat: oauth2 filter add an option to opt out the nonce parameter

### DIFF
--- a/api/envoy/extensions/filters/http/oauth2/v3/oauth.proto
+++ b/api/envoy/extensions/filters/http/oauth2/v3/oauth.proto
@@ -84,7 +84,7 @@ message OAuth2Credentials {
 
 // OAuth config
 //
-// [#next-free-field: 21]
+// [#next-free-field: 22]
 message OAuth2Config {
   enum AuthType {
     // The ``client_id`` and ``client_secret`` will be sent in the URL encoded request body.
@@ -186,6 +186,9 @@ message OAuth2Config {
   // will still process incoming Refresh Tokens as part of the HMAC if they are there. This is to ensure compatibility while switching this setting on. Future
   // sessions would not set the Refresh Token cookie header.
   bool disable_refresh_token_set_cookie = 20;
+
+  // If set to true, the oauth2 filter will not send a nonce to the authorization server.
+  bool disable_nonce = 21;
 }
 
 // Filter config.

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -66,6 +66,8 @@ minor_behavior_changes:
     :ref:`use_refresh_token <envoy_v3_api_field_extensions.filters.http.oauth2.v3.OAuth2Config.use_refresh_token>`
     is now enabled by default. This behavioral change can be temporarily reverted by setting runtime guard
     ``envoy.reloadable_features.oauth2_use_refresh_token`` to false.
+    Added :ref:`disable_nonce <envoy_v3_api_field_extensions.filters.http.oauth2.v3.OAuth2Config.disable_nonce>`
+    to disable nonce parameter in the authorization request.
 - area: quic
   change: |
     Enable UDP GRO in QUIC client connections by default. This behavior can be reverted by setting

--- a/source/extensions/filters/http/oauth2/filter.cc
+++ b/source/extensions/filters/http/oauth2/filter.cc
@@ -268,8 +268,7 @@ void OAuth2CookieValidator::setParams(const Http::RequestHeaderMap& headers,
   secret_.assign(secret.begin(), secret.end());
 }
 
-bool OAuth2CookieValidator::canUpdateTokenByRefreshToken() const {
-  return !refresh_token_.empty(); }
+bool OAuth2CookieValidator::canUpdateTokenByRefreshToken() const { return !refresh_token_.empty(); }
 
 bool OAuth2CookieValidator::hmacIsValid() const {
   absl::string_view cookie_domain = host_;
@@ -292,8 +291,7 @@ bool OAuth2CookieValidator::timestampIsValid() const {
   return std::chrono::seconds(expires) > current_epoch;
 }
 
-bool OAuth2CookieValidator::isValid() const {
-  return hmacIsValid() && timestampIsValid(); }
+bool OAuth2CookieValidator::isValid() const { return hmacIsValid() && timestampIsValid(); }
 
 OAuth2Filter::OAuth2Filter(FilterConfigSharedPtr config,
                            std::unique_ptr<OAuth2Client>&& oauth_client, TimeSource& time_source)

--- a/source/extensions/filters/http/oauth2/filter.cc
+++ b/source/extensions/filters/http/oauth2/filter.cc
@@ -530,8 +530,7 @@ void OAuth2Filter::redirectToOAuthServer(Http::RequestHeaderMap& headers) const 
     state = Http::Utility::PercentEncoding::urlEncodeQueryParameter(
         absl::StrCat(stateParamsUrl, "=", escaped_url, "&", stateParamsNonce, "=", nonce));
   } else {
-    state = Http::Utility::PercentEncoding::urlEncodeQueryParameter(
-        absl::StrCat(stateParamsUrl, "=", escaped_url));
+    state = escaped_url;
   }
 
   Formatter::FormatterPtr formatter = THROW_OR_RETURN_VALUE(

--- a/source/extensions/filters/http/oauth2/filter.h
+++ b/source/extensions/filters/http/oauth2/filter.h
@@ -193,13 +193,13 @@ private:
   const AuthType auth_type_;
   const std::chrono::seconds default_expires_in_;
   const std::chrono::seconds default_refresh_token_expires_in_;
-  const bool forward_bearer_token_ : 1;
-  const bool preserve_authorization_header_ : 1;
-  const bool use_refresh_token_ : 1;
-  const bool disable_id_token_set_cookie_ : 1;
-  const bool disable_access_token_set_cookie_ : 1;
-  const bool disable_refresh_token_set_cookie_ : 1;
-  const bool disable_nonce_ : 1;
+  const bool forward_bearer_token_{};
+  const bool preserve_authorization_header_{};
+  const bool use_refresh_token_{};
+  const bool disable_id_token_set_cookie_{};
+  const bool disable_access_token_set_cookie_{};
+  const bool disable_refresh_token_set_cookie_{};
+  const bool disable_nonce_{};
   absl::optional<RouteRetryPolicy> retry_policy_;
 };
 

--- a/source/extensions/filters/http/oauth2/filter.h
+++ b/source/extensions/filters/http/oauth2/filter.h
@@ -160,6 +160,7 @@ public:
   bool disableIdTokenSetCookie() const { return disable_id_token_set_cookie_; }
   bool disableAccessTokenSetCookie() const { return disable_access_token_set_cookie_; }
   bool disableRefreshTokenSetCookie() const { return disable_refresh_token_set_cookie_; }
+  bool disableNonce() const { return disable_nonce_; }
   const OptRef<const RouteRetryPolicy> retryPolicy() const {
     if (!retry_policy_.has_value()) {
       return absl::nullopt;
@@ -198,6 +199,7 @@ private:
   const bool disable_id_token_set_cookie_ : 1;
   const bool disable_access_token_set_cookie_ : 1;
   const bool disable_refresh_token_set_cookie_ : 1;
+  const bool disable_nonce_ : 1;
   absl::optional<RouteRetryPolicy> retry_policy_;
 };
 

--- a/test/extensions/filters/http/oauth2/filter_test.cc
+++ b/test/extensions/filters/http/oauth2/filter_test.cc
@@ -1655,7 +1655,7 @@ TEST_F(OAuth2Test, OAuthTestFullFlowPostWithCookieDomain) {
 }
 
 /**
- * Testing oauth state disabled nonce.
+ * Testing oauth state when nonce is disabled.
  *
  * Expected behavior: The nonce should not be set in the state.
  */

--- a/test/extensions/filters/http/oauth2/filter_test.cc
+++ b/test/extensions/filters/http/oauth2/filter_test.cc
@@ -117,7 +117,7 @@ public:
             int default_refresh_token_expires_in = 0, bool preserve_authorization_header = false,
             bool disable_id_token_set_cookie = false, bool set_cookie_domain = false,
             bool disable_access_token_set_cookie = false,
-            bool disable_refresh_token_set_cookie = false) {
+            bool disable_refresh_token_set_cookie = false, bool disable_nonce = false) {
     envoy::extensions::filters::http::oauth2::v3::OAuth2Config p;
     auto* endpoint = p.mutable_token_endpoint();
     endpoint->set_cluster("auth.example.com");
@@ -132,6 +132,7 @@ public:
     p.set_disable_id_token_set_cookie(disable_id_token_set_cookie);
     p.set_disable_access_token_set_cookie(disable_access_token_set_cookie);
     p.set_disable_refresh_token_set_cookie(disable_refresh_token_set_cookie);
+    p.set_disable_nonce(disable_nonce);
 
     auto* useRefreshToken = p.mutable_use_refresh_token();
     useRefreshToken->set_value(use_refresh_token);
@@ -1643,6 +1644,98 @@ TEST_F(OAuth2Test, OAuthTestFullFlowPostWithCookieDomain) {
        "domain=example.com;path=/;Max-Age=;secure;HttpOnly"},
       {Http::Headers::get().SetCookie.get(),
        "OauthExpires=;domain=example.com;path=/;Max-Age=;secure;HttpOnly"},
+      {Http::Headers::get().Location.get(),
+       "https://traffic.example.com/test?name=admin&level=trace"},
+  };
+
+  EXPECT_CALL(decoder_callbacks_,
+              encodeHeaders_(HeaderMapEqualRef(&second_response_headers), true));
+
+  filter_->finishGetAccessTokenFlow();
+}
+
+/**
+ * Testing oauth state disabled nonce.
+ *
+ * Expected behavior: The nonce should not be set in the state.
+ */
+TEST_F(OAuth2Test, OAuthTestFullFlowPostDisableNonce) {
+  TestScopedRuntime scoped_runtime;
+  scoped_runtime.mergeValues({
+      {"envoy.reloadable_features.hmac_base64_encoding_only", "true"},
+  });
+  init(getConfig(true, false,
+                 ::envoy::extensions::filters::http::oauth2::v3::OAuth2Config_AuthType::
+                     OAuth2Config_AuthType_URL_ENCODED_BODY,
+                 0, false, false, false, false, false, true /* disable_nonce */));
+  // First construct the initial request to the oauth filter with URI parameters.
+  Http::TestRequestHeaderMapImpl first_request_headers{
+      {Http::Headers::get().Path.get(), "/test?name=admin&level=trace"},
+      {Http::Headers::get().Host.get(), "traffic.example.com"},
+      {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Post},
+      {Http::Headers::get().Scheme.get(), "https"},
+  };
+
+  // This is the immediate response - a redirect to the auth cluster.
+  Http::TestResponseHeaderMapImpl first_response_headers{
+      {Http::Headers::get().Status.get(), "302"},
+      {Http::Headers::get().Location.get(),
+       "https://auth.example.com/oauth/"
+       "authorize/?client_id=" +
+           TEST_CLIENT_ID +
+           "&redirect_uri=https%3A%2F%2Ftraffic.example.com%2F_oauth"
+           "&response_type=code"
+           "&scope=" +
+           TEST_ENCODED_AUTH_SCOPES +
+           "&state=https%3A%2F%2Ftraffic.example.com%2Ftest%3Fname%3Dadmin%26level%3Dtrace"
+           "&resource=oauth2-resource&resource=http%3A%2F%2Fexample.com"
+           "&resource=https%3A%2F%2Fexample.com%2Fsome%2Fpath%252F..%252F%2Futf8%C3%83%3Bfoo%"
+           "3Dbar%"
+           "3Fvar1%3D1%26var2%3D2"},
+  };
+
+  // Fail the validation to trigger the OAuth flow.
+  EXPECT_CALL(*validator_, setParams(_, _));
+  EXPECT_CALL(*validator_, isValid()).WillOnce(Return(false));
+
+  // Check that the redirect includes URL encoded query parameter characters.
+  EXPECT_CALL(decoder_callbacks_, encodeHeaders_(HeaderMapEqualRef(&first_response_headers), true));
+
+  // This represents the beginning of the OAuth filter.
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
+            filter_->decodeHeaders(first_request_headers, false));
+
+  // This represents the callback request from the authorization server.
+  Http::TestRequestHeaderMapImpl second_request_headers{
+      {Http::Headers::get().Path.get(), "/_oauth?code=123&state=https%3A%2F%2Ftraffic.example.com%"
+                                        "2Ftest%3Fname%3Dadmin%26level%3Dtrace"},
+      {Http::Headers::get().Host.get(), "traffic.example.com"},
+      {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
+      {Http::Headers::get().Scheme.get(), "https"},
+  };
+  // Deliberately fail the HMAC validation check.
+  EXPECT_CALL(*validator_, setParams(_, _));
+  EXPECT_CALL(*validator_, isValid()).WillOnce(Return(false));
+
+  EXPECT_CALL(*oauth_client_, asyncGetAccessToken("123", TEST_CLIENT_ID, "asdf_client_secret_fdsa",
+                                                  "https://traffic.example.com" + TEST_CALLBACK,
+                                                  AuthType::UrlEncodedBody));
+
+  // Invoke the callback logic. As a side effect, state_ will be populated.
+  EXPECT_EQ(Http::FilterHeadersStatus::StopAllIterationAndBuffer,
+            filter_->decodeHeaders(second_request_headers, false));
+
+  EXPECT_EQ(1, config_->stats().oauth_unauthorized_rq_.value());
+  EXPECT_EQ(config_->clusterName(), "auth.example.com");
+
+  // Expected response after the callback & validation is complete - verifying we kept the
+  // state and method of the original request, including the query string parameters.
+  Http::TestRequestHeaderMapImpl second_response_headers{
+      {Http::Headers::get().Status.get(), "302"},
+      {Http::Headers::get().SetCookie.get(), "OauthHMAC="
+                                             "fV62OgLipChTQQC3UFgDp+l5sCiSb3zt7nCoJiVivWw=;"
+                                             "path=/;Max-Age=;secure;HttpOnly"},
+      {Http::Headers::get().SetCookie.get(), "OauthExpires=;path=/;Max-Age=;secure;HttpOnly"},
       {Http::Headers::get().Location.get(),
        "https://traffic.example.com/test?name=admin&level=trace"},
   };


### PR DESCRIPTION
Commit Message: add an option to opt out nonce in the OAuth2 filter.
Additional Description: nonce is url-encoded and embedded in the state parameter. It should be transparent to the providers. However, some providers such as[ AWS cognito doesn't support url encoded state value](https://docs.aws.amazon.com/cognito/latest/developerguide/authorization-endpoint.html#get-authorize-request-parameters), so add a knob to the OAuth2 filter to make it possible to opt it out.
Risk Level: low
Testing: 
Docs Changes:
Release Notes: yes
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #37049]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]

Related: 
* https://github.com/envoyproxy/envoy/issues/36871 
* https://github.com/envoyproxy/gateway/issues/4625
