### PR TITLE
[contrib][http language filter] Change position of libstdc++ library when linking ICU tools

### DIFF
--- a/bazel/foreign_cc/BUILD
+++ b/bazel/foreign_cc/BUILD
@@ -199,6 +199,7 @@ configure_make(
     env = {
         "CXXFLAGS": "-fPIC -DU_CHARSET_IS_UTF8=1 -DU_USING_ICU_NAMESPACE=0 -DUCONFIG_ONLY_HTML_CONVERSION=1 -DUCONFIG_NO_LEGACY_CONVERSION=1 -DUCONFIG_NO_BREAK_ITERATION=1 -DUCONFIG_NO_COLLATION=1 -DUCONFIG_NO_FORMATTING=1 -DUCONFIG_NO_TRANSLITERATION=1 -DUCONFIG_NO_REGULAR_EXPRESSIONS=1",
         "CFLAGS": "-fPIC",
+        "LIBS": "-l:libstdc++.a",
         "ICU_DATA_FILTER_FILE": "$(execpath //bazel/foreign_cc:icu_data_filter.json)",
     },
     lib_source = "@com_github_unicode_org_icu//:all",


### PR DESCRIPTION
Commit Message:

Clang and gcc are subtly different and it seems to be the cause of contrib build failures reported in
https://github.com/envoyproxy/envoy/issues/31807 (e.g., when using gcc to link the final binary it results in a bunch of essential for gcc C++ symbols like __gxx_personality_v0).

The issue appear to be the order of the libraries when linking. gcc, when building statically linked binaries basically needs libstdc++ to be the last library or alsmot the last library in the command line. And clang does not appear to care about it much.

This change provides libstdc++ library in LIBS environment variabe which will put it in the right position when building the ICU library. This works well for both clang and gcc.

Additional Description:

It address the issue reported in https://github.com/envoyproxy/envoy/issues/31807, though by itseld this change is not enough to make gcc builds work - a few more changes are needed.

Risk Level: Low
Testing: built with `--config=gcc` and `--config=docker-gcc` and checked that //contrib/language/filters/http/test:language_config_test pass after the change.
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A