### PR TITLE
http2: removes the false path for an old runtime feature

### DIFF
--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -649,10 +649,7 @@ void ConnectionImpl::StreamImpl::submitTrailers(const HeaderMap& trailers) {
 
 void ConnectionImpl::ClientStreamImpl::submitHeaders(const HeaderMap& headers, bool end_stream) {
   ASSERT(stream_id_ == -1);
-  stream_id_ = parent_.adapter_->SubmitRequest(
-      buildHeaders(headers),
-      nullptr, end_stream,
-      base());
+  stream_id_ = parent_.adapter_->SubmitRequest(buildHeaders(headers), nullptr, end_stream, base());
   ASSERT(stream_id_ > 0);
 }
 
@@ -672,9 +669,7 @@ void ConnectionImpl::ClientStreamImpl::advanceHeadersState() {
 
 void ConnectionImpl::ServerStreamImpl::submitHeaders(const HeaderMap& headers, bool end_stream) {
   ASSERT(stream_id_ != -1);
-  parent_.adapter_->SubmitResponse(
-      stream_id_, buildHeaders(headers),
-      nullptr, end_stream);
+  parent_.adapter_->SubmitResponse(stream_id_, buildHeaders(headers), nullptr, end_stream);
 }
 
 Status ConnectionImpl::ServerStreamImpl::onBeginHeaders() {

--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -647,55 +647,11 @@ void ConnectionImpl::StreamImpl::submitTrailers(const HeaderMap& trailers) {
   parent_.adapter_->SubmitTrailer(stream_id_, final_headers);
 }
 
-std::pair<int64_t, bool>
-ConnectionImpl::StreamDataFrameSource::SelectPayloadLength(size_t max_length) {
-  if (stream_.pending_send_data_->length() == 0 && !stream_.local_end_stream_) {
-    ASSERT(!stream_.data_deferred_);
-    stream_.data_deferred_ = true;
-    return {kBlocked, false};
-  } else {
-    const size_t length = std::min<size_t>(max_length, stream_.pending_send_data_->length());
-    bool end_data = false;
-    if (stream_.local_end_stream_ && length == stream_.pending_send_data_->length()) {
-      end_data = true;
-      if (stream_.pending_trailers_to_encode_) {
-        stream_.submitTrailers(*stream_.pending_trailers_to_encode_);
-        stream_.pending_trailers_to_encode_.reset();
-      } else {
-        send_fin_ = true;
-      }
-    }
-    return {static_cast<int64_t>(length), end_data};
-  }
-}
-
-bool ConnectionImpl::StreamDataFrameSource::Send(absl::string_view frame_header,
-                                                 size_t payload_length) {
-  stream_.parent_.protocol_constraints_.incrementOutboundDataFrameCount();
-
-  Buffer::OwnedImpl output;
-  stream_.parent_.addOutboundFrameFragment(
-      output, reinterpret_cast<const uint8_t*>(frame_header.data()), frame_header.size());
-  if (!stream_.parent_.protocol_constraints_.checkOutboundFrameLimits().ok()) {
-    ENVOY_CONN_LOG(debug, "error sending data frame: Too many frames in the outbound queue",
-                   stream_.parent_.connection_);
-    stream_.setDetails(Http2ResponseCodeDetails::get().outbound_frame_flood);
-  }
-
-  stream_.parent_.stats_.pending_send_bytes_.sub(payload_length);
-  output.move(*stream_.pending_send_data_, payload_length);
-  stream_.parent_.connection_.write(output, false);
-  return true;
-}
-
 void ConnectionImpl::ClientStreamImpl::submitHeaders(const HeaderMap& headers, bool end_stream) {
   ASSERT(stream_id_ == -1);
-  const bool skip_frame_source =
-      end_stream ||
-      Runtime::runtimeFeatureEnabled("envoy.reloadable_features.http2_use_visitor_for_data");
   stream_id_ = parent_.adapter_->SubmitRequest(
       buildHeaders(headers),
-      skip_frame_source ? nullptr : std::make_unique<StreamDataFrameSource>(*this), end_stream,
+      nullptr, end_stream,
       base());
   ASSERT(stream_id_ > 0);
 }
@@ -716,12 +672,9 @@ void ConnectionImpl::ClientStreamImpl::advanceHeadersState() {
 
 void ConnectionImpl::ServerStreamImpl::submitHeaders(const HeaderMap& headers, bool end_stream) {
   ASSERT(stream_id_ != -1);
-  const bool skip_frame_source =
-      end_stream ||
-      Runtime::runtimeFeatureEnabled("envoy.reloadable_features.http2_use_visitor_for_data");
   parent_.adapter_->SubmitResponse(
       stream_id_, buildHeaders(headers),
-      skip_frame_source ? nullptr : std::make_unique<StreamDataFrameSource>(*this), end_stream);
+      nullptr, end_stream);
 }
 
 Status ConnectionImpl::ServerStreamImpl::onBeginHeaders() {

--- a/source/common/http/http2/codec_impl.h
+++ b/source/common/http/http2/codec_impl.h
@@ -491,26 +491,6 @@ protected:
     void grantPeerAdditionalStreamWindow();
   };
 
-  // Encapsulates the logic for sending DATA frames on a given stream.
-  // Deprecated. Remove when removing
-  // `envoy_reloadable_features_http2_use_visitor_for_data`.
-  class StreamDataFrameSource : public http2::adapter::DataFrameSource {
-  public:
-    explicit StreamDataFrameSource(StreamImpl& stream) : stream_(stream) {}
-
-    // Returns a pair of the next payload length, and whether that payload is the end of the data
-    // for this stream.
-    std::pair<int64_t, bool> SelectPayloadLength(size_t max_length) override;
-    // Queues the frame header and a DATA frame payload of the specified length for writing.
-    bool Send(absl::string_view frame_header, size_t payload_length) override;
-    // Whether the codec should send the END_STREAM flag on the final DATA frame.
-    bool send_fin() const override { return send_fin_; }
-
-  private:
-    StreamImpl& stream_;
-    bool send_fin_ = false;
-  };
-
   using StreamImplPtr = std::unique_ptr<StreamImpl>;
 
   /**

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -54,8 +54,6 @@ RUNTIME_GUARD(envoy_reloadable_features_http1_balsa_disallow_lone_cr_in_chunk_ex
 RUNTIME_GUARD(envoy_reloadable_features_http1_use_balsa_parser);
 RUNTIME_GUARD(envoy_reloadable_features_http2_discard_host_header);
 RUNTIME_GUARD(envoy_reloadable_features_http2_no_protocol_error_upon_clean_close);
-// Ignore the automated "remove this flag" issue: we should keep this for 1 year.
-RUNTIME_GUARD(envoy_reloadable_features_http2_use_visitor_for_data);
 RUNTIME_GUARD(envoy_reloadable_features_http3_happy_eyeballs);
 RUNTIME_GUARD(envoy_reloadable_features_http3_remove_empty_trailers);
 RUNTIME_GUARD(envoy_reloadable_features_http_filter_avoid_reentrant_local_reply);


### PR DESCRIPTION
Commit Message: removes `envoy.reloadable_features.http2_use_visitor_for_data`
Additional Description:
Risk Level: low
Testing: ran unit and integration tests locally
Docs Changes:
Release Notes:
Platform Specific Features:
