### PR TITLE
Add `arch` to APT repository configuration

### DIFF
--- a/docs/root/start/install.rst
+++ b/docs/root/start/install.rst
@@ -28,7 +28,7 @@ Install Envoy on Debian-based Linux
    .. code-tab:: console Debian bullseye
 
       $ wget -O- https://apt.envoyproxy.io/signing.key | sudo gpg --dearmor -o /etc/apt/keyrings/envoy-keyring.gpg
-      $ echo "deb [arch=$(dpkg --print-architecture), signed-by=/etc/apt/keyrings/envoy-keyring.gpg] https://apt.envoyproxy.io bullseye main" | sudo tee /etc/apt/sources.list.d/envoy.list
+      $ echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/envoy-keyring.gpg] https://apt.envoyproxy.io bullseye main" | sudo tee /etc/apt/sources.list.d/envoy.list
       $ sudo apt-get update
       $ sudo apt-get install envoy
       $ envoy --version
@@ -36,7 +36,7 @@ Install Envoy on Debian-based Linux
    .. code-tab:: console Ubuntu focal
 
       $ wget -O- https://apt.envoyproxy.io/signing.key | sudo gpg --dearmor -o /etc/apt/keyrings/envoy-keyring.gpg
-      $ echo "deb [arch=$(dpkg --print-architecture), signed-by=/etc/apt/keyrings/envoy-keyring.gpg] https://apt.envoyproxy.io focal main" | sudo tee /etc/apt/sources.list.d/envoy.list
+      $ echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/envoy-keyring.gpg] https://apt.envoyproxy.io focal main" | sudo tee /etc/apt/sources.list.d/envoy.list
       $ sudo apt-get update
       $ sudo apt-get install envoy
       $ envoy --version
@@ -44,7 +44,7 @@ Install Envoy on Debian-based Linux
    .. code-tab:: console Ubuntu jammy
 
       $ wget -O- https://apt.envoyproxy.io/signing.key | sudo gpg --dearmor -o /etc/apt/keyrings/envoy-keyring.gpg
-      $ echo "deb [arch=$(dpkg --print-architecture), signed-by=/etc/apt/keyrings/envoy-keyring.gpg] https://apt.envoyproxy.io jammy main" | sudo tee /etc/apt/sources.list.d/envoy.list
+      $ echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/envoy-keyring.gpg] https://apt.envoyproxy.io jammy main" | sudo tee /etc/apt/sources.list.d/envoy.list
       $ sudo apt-get update
       $ sudo apt-get install envoy
       $ envoy --version

--- a/docs/root/start/install.rst
+++ b/docs/root/start/install.rst
@@ -20,7 +20,7 @@ Install Envoy on Debian-based Linux
    .. code-tab:: console Debian bookworm
 
       $ wget -O- https://apt.envoyproxy.io/signing.key | sudo gpg --dearmor -o /etc/apt/keyrings/envoy-keyring.gpg
-      $ echo "deb [arch=$(dpkg --print-architecture), signed-by=/etc/apt/keyrings/envoy-keyring.gpg] https://apt.envoyproxy.io bookworm main" | sudo tee /etc/apt/sources.list.d/envoy.list
+      $ echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/envoy-keyring.gpg] https://apt.envoyproxy.io bookworm main" | sudo tee /etc/apt/sources.list.d/envoy.list
       $ sudo apt-get update
       $ sudo apt-get install envoy
       $ envoy --version

--- a/docs/root/start/install.rst
+++ b/docs/root/start/install.rst
@@ -20,7 +20,7 @@ Install Envoy on Debian-based Linux
    .. code-tab:: console Debian bookworm
 
       $ wget -O- https://apt.envoyproxy.io/signing.key | sudo gpg --dearmor -o /etc/apt/keyrings/envoy-keyring.gpg
-      $ echo "deb [signed-by=/etc/apt/keyrings/envoy-keyring.gpg] https://apt.envoyproxy.io bookworm main" | sudo tee /etc/apt/sources.list.d/envoy.list
+      $ echo "deb [arch=$(dpkg --print-architecture), signed-by=/etc/apt/keyrings/envoy-keyring.gpg] https://apt.envoyproxy.io bookworm main" | sudo tee /etc/apt/sources.list.d/envoy.list
       $ sudo apt-get update
       $ sudo apt-get install envoy
       $ envoy --version
@@ -28,7 +28,7 @@ Install Envoy on Debian-based Linux
    .. code-tab:: console Debian bullseye
 
       $ wget -O- https://apt.envoyproxy.io/signing.key | sudo gpg --dearmor -o /etc/apt/keyrings/envoy-keyring.gpg
-      $ echo "deb [signed-by=/etc/apt/keyrings/envoy-keyring.gpg] https://apt.envoyproxy.io bullseye main" | sudo tee /etc/apt/sources.list.d/envoy.list
+      $ echo "deb [arch=$(dpkg --print-architecture), signed-by=/etc/apt/keyrings/envoy-keyring.gpg] https://apt.envoyproxy.io bullseye main" | sudo tee /etc/apt/sources.list.d/envoy.list
       $ sudo apt-get update
       $ sudo apt-get install envoy
       $ envoy --version
@@ -36,7 +36,7 @@ Install Envoy on Debian-based Linux
    .. code-tab:: console Ubuntu focal
 
       $ wget -O- https://apt.envoyproxy.io/signing.key | sudo gpg --dearmor -o /etc/apt/keyrings/envoy-keyring.gpg
-      $ echo "deb [signed-by=/etc/apt/keyrings/envoy-keyring.gpg] https://apt.envoyproxy.io focal main" | sudo tee /etc/apt/sources.list.d/envoy.list
+      $ echo "deb [arch=$(dpkg --print-architecture), signed-by=/etc/apt/keyrings/envoy-keyring.gpg] https://apt.envoyproxy.io focal main" | sudo tee /etc/apt/sources.list.d/envoy.list
       $ sudo apt-get update
       $ sudo apt-get install envoy
       $ envoy --version
@@ -44,7 +44,7 @@ Install Envoy on Debian-based Linux
    .. code-tab:: console Ubuntu jammy
 
       $ wget -O- https://apt.envoyproxy.io/signing.key | sudo gpg --dearmor -o /etc/apt/keyrings/envoy-keyring.gpg
-      $ echo "deb [signed-by=/etc/apt/keyrings/envoy-keyring.gpg] https://apt.envoyproxy.io jammy main" | sudo tee /etc/apt/sources.list.d/envoy.list
+      $ echo "deb [arch=$(dpkg --print-architecture), signed-by=/etc/apt/keyrings/envoy-keyring.gpg] https://apt.envoyproxy.io jammy main" | sudo tee /etc/apt/sources.list.d/envoy.list
       $ sudo apt-get update
       $ sudo apt-get install envoy
       $ envoy --version


### PR DESCRIPTION
On more recent Debian/Ubuntu versions, not specifying the `arch` gives a warning like this:

```
N: Skipping acquire of configured file 'main/binary-i386/Packages' as repository 'https://apt.envoyproxy.io jammy InRelease' doesn't support architecture 'i386'
```

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
