### PR TITLE
Make ScopedExecutionContext no-op if !ExecutionContext::isEnabled().

### DIFF
--- a/envoy/common/execution_context.h
+++ b/envoy/common/execution_context.h
@@ -81,8 +81,9 @@ class ScopedExecutionContext : NonCopyable {
 public:
   ScopedExecutionContext() : ScopedExecutionContext(nullptr) {}
   ScopedExecutionContext(const ScopeTrackedObject* object)
-      : context_(object != nullptr ? ExecutionContext::fromStreamInfo(object->trackedStream())
-                                   : nullptr) {
+      : context_((object != nullptr && ExecutionContext::isEnabled())
+                     ? ExecutionContext::fromStreamInfo(object->trackedStream())
+                     : nullptr) {
     if (context_ != nullptr) {
       context_->activate();
     }


### PR DESCRIPTION
Make `ScopedExecutionContext` no-op if `!ExecutionContext::isEnabled()`.

This saves a call to `ScopeTrackedObject::trackedStream()` when execution context is disabled.

Commit Message: Make ScopedExecutionContext no-op if !ExecutionContext::isEnabled().
Additional Description:
Risk Level: None.
Testing: Existing execution_context_test.cc.
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
