### PR TITLE
dynamic_modules: HTTP filter config implementation

### DIFF
--- a/source/extensions/dynamic_modules/abi.h
+++ b/source/extensions/dynamic_modules/abi.h
@@ -22,35 +22,36 @@ extern "C" {
 // -----------------------------------------------------------------------------
 //
 // Types used in the ABI. The name of a type must be prefixed with "envoy_dynamic_module_type_".
-// Types with "_in_module_ptr" suffix are pointers owned by the module.
-// Types with "_in_envoy_ptr" suffix are pointers owned by Envoy.
+// Types with "_module_ptr" suffix are pointers owned by the module, i.e. memory space allocated by
+// the module. Types with "_envoy_ptr" suffix are pointers owned by Envoy, i.e. memory space
+// allocated by Envoy.
 
 /**
- * envoy_dynamic_module_type_abi_version_in_envoy_ptr represents a null-terminated string that
+ * envoy_dynamic_module_type_abi_version_envoy_ptr represents a null-terminated string that
  * contains the ABI version of the dynamic module. This is used to ensure that the dynamic module is
  * built against the compatible version of the ABI.
  *
  * OWNERSHIP: Envoy owns the pointer.
  */
-typedef const char*
-    envoy_dynamic_module_type_abi_version_in_envoy_ptr; // NOLINT(modernize-use-using)
+typedef const char* // NOLINT(modernize-use-using)
+    envoy_dynamic_module_type_abi_version_envoy_ptr;
 
 /**
- * envoy_dynamic_module_type_http_filter_config_in_envoy_ptr is a raw pointer to
+ * envoy_dynamic_module_type_http_filter_config_envoy_ptr is a raw pointer to
  * the DynamicModuleHttpFilterConfig class in Envoy. This is passed to the module when
  * creating a new in-module HTTP filter configuration and used to access the HTTP filter-scoped
  * information such as metadata, metrics, etc.
  *
- * This has 1:1 correspondence with envoy_dynamic_module_type_http_filter_config_in_module_ptr in
+ * This has 1:1 correspondence with envoy_dynamic_module_type_http_filter_config_module_ptr in
  * the module.
  *
  * OWNERSHIP: Envoy owns the pointer.
  */
 typedef const void* // NOLINT(modernize-use-using)
-    envoy_dynamic_module_type_http_filter_config_in_envoy_ptr;
+    envoy_dynamic_module_type_http_filter_config_envoy_ptr;
 
 /**
- * envoy_dynamic_module_type_http_filter_config_in_module_ptr is a pointer to an in-module HTTP
+ * envoy_dynamic_module_type_http_filter_config_module_ptr is a pointer to an in-module HTTP
  * configuration corresponding to an Envoy HTTP filter configuration. The config is responsible for
  * creating a new HTTP filter that corresponds to each HTTP stream.
  *
@@ -60,7 +61,7 @@ typedef const void* // NOLINT(modernize-use-using)
  * released when envoy_dynamic_module_on_http_filter_config_destroy is called for the same pointer.
  */
 typedef const void* // NOLINT(modernize-use-using)
-    envoy_dynamic_module_type_http_filter_config_in_module_ptr;
+    envoy_dynamic_module_type_http_filter_config_module_ptr;
 
 // -----------------------------------------------------------------------------
 // ------------------------------- Event Hooks ---------------------------------
@@ -86,15 +87,15 @@ typedef const void* // NOLINT(modernize-use-using)
  * to check compatibility and gracefully fail the initialization because there is no way to
  * report an error to Envoy.
  *
- * @return envoy_dynamic_module_type_abi_version_in_envoy_ptr is the ABI version of the dynamic
+ * @return envoy_dynamic_module_type_abi_version_envoy_ptr is the ABI version of the dynamic
  * module. Null means the error and the module will be unloaded immediately.
  */
-envoy_dynamic_module_type_abi_version_in_envoy_ptr envoy_dynamic_module_on_program_init();
+envoy_dynamic_module_type_abi_version_envoy_ptr envoy_dynamic_module_on_program_init();
 
 /**
  * envoy_dynamic_module_on_http_filter_config_new is called by the main thread when the http
  * filter config is loaded. The function returns a
- * envoy_dynamic_module_type_http_filter_config_in_module_ptr for given name and config.
+ * envoy_dynamic_module_type_http_filter_config_module_ptr for given name and config.
  *
  * @param filter_config_envoy_ptr is the pointer to the DynamicModuleHttpFilterConfig object for the
  * corresponding config.
@@ -102,13 +103,13 @@ envoy_dynamic_module_type_abi_version_in_envoy_ptr envoy_dynamic_module_on_progr
  * @param name_size is the size of the name.
  * @param config_ptr is the configuration for the module.
  * @param config_size is the size of the configuration.
- * @return envoy_dynamic_module_type_http_filter_config_in_module_ptr is the pointer to the
+ * @return envoy_dynamic_module_type_http_filter_config_module_ptr is the pointer to the
  * in-module HTTP filter configuration. Returning nullptr indicates a failure to initialize the
  * module. When it fails, the filter configuration will be rejected.
  */
-envoy_dynamic_module_type_http_filter_config_in_module_ptr
+envoy_dynamic_module_type_http_filter_config_module_ptr
 envoy_dynamic_module_on_http_filter_config_new(
-    envoy_dynamic_module_type_http_filter_config_in_envoy_ptr filter_config_envoy_ptr,
+    envoy_dynamic_module_type_http_filter_config_envoy_ptr filter_config_envoy_ptr,
     const char* name_ptr, int name_size, const char* config_ptr, int config_size);
 
 /**
@@ -119,7 +120,7 @@ envoy_dynamic_module_on_http_filter_config_new(
  * corresponding Envoy HTTP filter configuration is being destroyed.
  */
 void envoy_dynamic_module_on_http_filter_config_destroy(
-    envoy_dynamic_module_type_http_filter_config_in_module_ptr filter_config_ptr);
+    envoy_dynamic_module_type_http_filter_config_module_ptr filter_config_ptr);
 
 #ifdef __cplusplus
 }

--- a/source/extensions/dynamic_modules/abi.h
+++ b/source/extensions/dynamic_modules/abi.h
@@ -22,8 +22,8 @@ extern "C" {
 // -----------------------------------------------------------------------------
 //
 // Types used in the ABI. The name of a type must be prefixed with "envoy_dynamic_module_type_".
-// *  Types with _in_module_ptr suffix are pointers owned by the module.
-// *  Types with _in_envoy_ptr suffix are pointers owned by Envoy.
+// Types with "_in_module_ptr" suffix are pointers owned by the module.
+// Types with "_in_envoy_ptr" suffix are pointers owned by Envoy.
 
 /**
  * envoy_dynamic_module_type_abi_version_in_envoy_ptr represents a null-terminated string that

--- a/source/extensions/dynamic_modules/abi.h
+++ b/source/extensions/dynamic_modules/abi.h
@@ -22,13 +22,45 @@ extern "C" {
 // -----------------------------------------------------------------------------
 //
 // Types used in the ABI. The name of a type must be prefixed with "envoy_dynamic_module_type_".
+// *  Types with _in_module_ptr suffix are pointers owned by the module.
+// *  Types with _in_envoy_ptr suffix are pointers owned by Envoy.
 
 /**
- * envoy_dynamic_module_type_abi_version represents a null-terminated string that contains the ABI
- * version of the dynamic module. This is used to ensure that the dynamic module is built against
- * the compatible version of the ABI.
+ * envoy_dynamic_module_type_abi_version_in_envoy_ptr represents a null-terminated string that
+ * contains the ABI version of the dynamic module. This is used to ensure that the dynamic module is
+ * built against the compatible version of the ABI.
+ *
+ * OWNERSHIP: Envoy owns the pointer.
  */
-typedef const char* envoy_dynamic_module_type_abi_version; // NOLINT(modernize-use-using)
+typedef const char*
+    envoy_dynamic_module_type_abi_version_in_envoy_ptr; // NOLINT(modernize-use-using)
+
+/**
+ * envoy_dynamic_module_type_http_filter_config_in_envoy_ptr is a raw pointer to
+ * the DynamicModuleHttpFilterConfig class in Envoy. This is passed to the module when
+ * creating a new in-module HTTP filter configuration and used to access the HTTP filter-scoped
+ * information such as metadata, metrics, etc.
+ *
+ * This has 1:1 correspondence with envoy_dynamic_module_type_http_filter_config_in_module_ptr in
+ * the module.
+ *
+ * OWNERSHIP: Envoy owns the pointer.
+ */
+typedef const void* // NOLINT(modernize-use-using)
+    envoy_dynamic_module_type_http_filter_config_in_envoy_ptr;
+
+/**
+ * envoy_dynamic_module_type_http_filter_config_in_module_ptr is a pointer to an in-module HTTP
+ * configuration corresponding to an Envoy HTTP filter configuration. The config is responsible for
+ * creating a new HTTP filter that corresponds to each HTTP stream.
+ *
+ * This has 1:1 correspondence with the DynamicModuleHttpFilterConfig class in Envoy.
+ *
+ * OWNERSHIP: The module is responsible for managing the lifetime of the pointer. The pointer can be
+ * released when envoy_dynamic_module_on_http_filter_config_destroy is called for the same pointer.
+ */
+typedef const void* // NOLINT(modernize-use-using)
+    envoy_dynamic_module_type_http_filter_config_in_module_ptr;
 
 // -----------------------------------------------------------------------------
 // ------------------------------- Event Hooks ---------------------------------
@@ -54,10 +86,40 @@ typedef const char* envoy_dynamic_module_type_abi_version; // NOLINT(modernize-u
  * to check compatibility and gracefully fail the initialization because there is no way to
  * report an error to Envoy.
  *
- * @return envoy_dynamic_module_type_abi_version is the ABI version of the dynamic module. Null
- *         means the error and the module will be unloaded immediately.
+ * @return envoy_dynamic_module_type_abi_version_in_envoy_ptr is the ABI version of the dynamic
+ * module. Null means the error and the module will be unloaded immediately.
  */
-envoy_dynamic_module_type_abi_version envoy_dynamic_module_on_program_init();
+envoy_dynamic_module_type_abi_version_in_envoy_ptr envoy_dynamic_module_on_program_init();
+
+/**
+ * envoy_dynamic_module_on_http_filter_config_new is called by the main thread when the http
+ * filter config is loaded. The function returns a
+ * envoy_dynamic_module_type_http_filter_config_in_module_ptr for given name and config.
+ *
+ * @param filter_config_envoy_ptr is the pointer to the DynamicModuleHttpFilterConfig object for the
+ * corresponding config.
+ * @param name_ptr is the name of the filter.
+ * @param name_size is the size of the name.
+ * @param config_ptr is the configuration for the module.
+ * @param config_size is the size of the configuration.
+ * @return envoy_dynamic_module_type_http_filter_config_in_module_ptr is the pointer to the
+ * in-module HTTP filter configuration. Returning nullptr indicates a failure to initialize the
+ * module. When it fails, the filter configuration will be rejected.
+ */
+envoy_dynamic_module_type_http_filter_config_in_module_ptr
+envoy_dynamic_module_on_http_filter_config_new(
+    envoy_dynamic_module_type_http_filter_config_in_envoy_ptr filter_config_envoy_ptr,
+    const char* name_ptr, int name_size, const char* config_ptr, int config_size);
+
+/**
+ * envoy_dynamic_module_on_http_filter_config_destroy is called when the HTTP filter configuration
+ * is destroyed in Envoy. The module should release any resources associated with the corresponding
+ * in-module HTTP filter configuration.
+ * @param filter_config_ptr is a pointer to the in-module HTTP filter configuration whose
+ * corresponding Envoy HTTP filter configuration is being destroyed.
+ */
+void envoy_dynamic_module_on_http_filter_config_destroy(
+    envoy_dynamic_module_type_http_filter_config_in_module_ptr filter_config_ptr);
 
 #ifdef __cplusplus
 }

--- a/source/extensions/dynamic_modules/abi_version.h
+++ b/source/extensions/dynamic_modules/abi_version.h
@@ -6,7 +6,7 @@ namespace DynamicModules {
 #endif
 // This is the ABI version calculated as a sha256 hash of the ABI header files. When the ABI
 // changes, this value must change, and the correctness of this value is checked by the test.
-const char* kAbiVersion = "4e64dfcd030df11c9be1d821b264bed34b6661eb80c41459bb1563a69a2bb569";
+const char* kAbiVersion = "164a60ff214ca3cd62526ddb7c3fe21cf943e8721a115c87feca81a58510072c";
 
 #ifdef __cplusplus
 } // namespace DynamicModules

--- a/source/extensions/dynamic_modules/abi_version.h
+++ b/source/extensions/dynamic_modules/abi_version.h
@@ -6,7 +6,7 @@ namespace DynamicModules {
 #endif
 // This is the ABI version calculated as a sha256 hash of the ABI header files. When the ABI
 // changes, this value must change, and the correctness of this value is checked by the test.
-const char* kAbiVersion = "4293760426255b24c25b97a18d9fd31b4d1956f10ba0ff2f723580a46ee8fa21";
+const char* kAbiVersion = "7a18d6db35ae34b3bd4464fcdb0dcda7f3b62a419c4a1e637deab25ac15b3f57";
 
 #ifdef __cplusplus
 } // namespace DynamicModules

--- a/source/extensions/dynamic_modules/abi_version.h
+++ b/source/extensions/dynamic_modules/abi_version.h
@@ -6,7 +6,7 @@ namespace DynamicModules {
 #endif
 // This is the ABI version calculated as a sha256 hash of the ABI header files. When the ABI
 // changes, this value must change, and the correctness of this value is checked by the test.
-const char* kAbiVersion = "7a18d6db35ae34b3bd4464fcdb0dcda7f3b62a419c4a1e637deab25ac15b3f57";
+const char* kAbiVersion = "4e64dfcd030df11c9be1d821b264bed34b6661eb80c41459bb1563a69a2bb569";
 
 #ifdef __cplusplus
 } // namespace DynamicModules

--- a/source/extensions/dynamic_modules/dynamic_modules.cc
+++ b/source/extensions/dynamic_modules/dynamic_modules.cc
@@ -16,8 +16,8 @@ namespace DynamicModules {
 
 constexpr char DYNAMIC_MODULES_SEARCH_PATH[] = "ENVOY_DYNAMIC_MODULES_SEARCH_PATH";
 
-absl::StatusOr<DynamicModuleSharedPtr> newDynamicModule(const absl::string_view object_file_path,
-                                                        const bool do_not_close) {
+absl::StatusOr<DynamicModulePtr> newDynamicModule(const absl::string_view object_file_path,
+                                                  const bool do_not_close) {
   // RTLD_LOCAL is always needed to avoid collisions between multiple modules.
   // RTLD_LAZY is required for not only performance but also simply to load the module, otherwise
   // dlopen results in Invalid argument.
@@ -33,7 +33,7 @@ absl::StatusOr<DynamicModuleSharedPtr> newDynamicModule(const absl::string_view 
         absl::StrCat("Failed to load dynamic module: ", object_file_path, " : ", dlerror()));
   }
 
-  DynamicModuleSharedPtr dynamic_module = std::make_shared<DynamicModule>(handle);
+  DynamicModulePtr dynamic_module = std::make_unique<DynamicModule>(handle);
 
   const auto init_function =
       dynamic_module->getFunctionPointer<decltype(&envoy_dynamic_module_on_program_init)>(
@@ -41,7 +41,7 @@ absl::StatusOr<DynamicModuleSharedPtr> newDynamicModule(const absl::string_view 
 
   if (init_function == nullptr) {
     return absl::InvalidArgumentError(
-        absl::StrCat("Failed to resolve envoy_dynamic_module_on_program_init: ", dlerror()));
+        "Failed to resolve symbol envoy_dynamic_module_on_program_init");
   }
 
   const char* abi_version = (*init_function)();
@@ -57,8 +57,8 @@ absl::StatusOr<DynamicModuleSharedPtr> newDynamicModule(const absl::string_view 
   return dynamic_module;
 }
 
-absl::StatusOr<DynamicModuleSharedPtr> newDynamicModuleByName(const absl::string_view module_name,
-                                                              const bool do_not_close) {
+absl::StatusOr<DynamicModulePtr> newDynamicModuleByName(const absl::string_view module_name,
+                                                        const bool do_not_close) {
   const char* module_search_path = getenv(DYNAMIC_MODULES_SEARCH_PATH);
   if (module_search_path == nullptr) {
     return absl::InvalidArgumentError(absl::StrCat("Failed to load dynamic module: ", module_name,

--- a/source/extensions/dynamic_modules/dynamic_modules.h
+++ b/source/extensions/dynamic_modules/dynamic_modules.h
@@ -47,7 +47,7 @@ private:
   void* handle_;
 };
 
-using DynamicModuleSharedPtr = std::shared_ptr<DynamicModule>;
+using DynamicModulePtr = std::unique_ptr<DynamicModule>;
 
 /**
  * Creates a new DynamicModule. This is mainly exposed for testing purposes. Use
@@ -58,8 +58,8 @@ using DynamicModuleSharedPtr = std::shared_ptr<DynamicModule>;
  * terminated. For example, c-shared objects compiled by Go doesn't support dlclose
  * https://github.com/golang/go/issues/11100.
  */
-absl::StatusOr<DynamicModuleSharedPtr> newDynamicModule(const absl::string_view object_file_path,
-                                                        const bool do_not_close);
+absl::StatusOr<DynamicModulePtr> newDynamicModule(const absl::string_view object_file_path,
+                                                  const bool do_not_close);
 
 /**
  * Creates a new DynamicModule by name under the search path specified by the environment variable
@@ -70,8 +70,8 @@ absl::StatusOr<DynamicModuleSharedPtr> newDynamicModule(const absl::string_view 
  * will not be destroyed. This is useful when an object has some global state that should not be
  * terminated.
  */
-absl::StatusOr<DynamicModuleSharedPtr> newDynamicModuleByName(const absl::string_view module_name,
-                                                              const bool do_not_close);
+absl::StatusOr<DynamicModulePtr> newDynamicModuleByName(const absl::string_view module_name,
+                                                        const bool do_not_close);
 
 } // namespace DynamicModules
 } // namespace Extensions

--- a/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
@@ -125,20 +125,20 @@ pub struct EnvoyHttpConfig {
 #[no_mangle]
 unsafe extern "C" fn envoy_dynamic_module_on_http_filter_config_new(
     envoy_filter_config_ptr: abi::envoy_dynamic_module_type_http_filter_config_in_envoy_ptr,
-    name_ptr: *const ::std::os::raw::c_char,
+    name_ptr: *const u8,
     name_size: usize,
-    config_ptr: *const ::std::os::raw::c_char,
+    config_ptr: *const u8,
     config_size: usize,
 ) -> abi::envoy_dynamic_module_type_http_filter_config_in_module_ptr {
-    // This assume that the name and config are valid UTF-8 strings. Should we relax? At the moment, both are String at protobuf level.
+    // This assumes that the name and config are valid UTF-8 strings. Should we relax? At the moment, both are String at protobuf level.
     let name = if name_size > 0 {
-        let slice = std::slice::from_raw_parts(name_ptr as *const u8, name_size);
+        let slice = std::slice::from_raw_parts(name_ptr, name_size);
         std::str::from_utf8(slice).unwrap()
     } else {
         ""
     };
     let config = if config_size > 0 {
-        let slice = std::slice::from_raw_parts(config_ptr as *const u8, config_size);
+        let slice = std::slice::from_raw_parts(config_ptr, config_size);
         std::str::from_utf8(slice).unwrap()
     } else {
         ""

--- a/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
@@ -10,28 +10,45 @@ pub mod abi {
     include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 }
 
-/// Declare the init function for the dynamic module. This function is called when the dynamic module is loaded.
-/// The function must return true on success, and false on failure. When it returns false,
-/// the dynamic module will not be loaded.
+/// Declare the init functions for the dynamic module.
 ///
-/// This is useful to perform any process-wide initialization that the dynamic module needs.
+/// The first argument has [`ProgramInitFunction`] type, and it is called when the dynamic module is loaded.
+///
+/// The second argument has [`NewHttpFilterConfigFunction`] type, and it is called when the new HTTP filter configuration is created.
 ///
 /// # Example
 ///
 /// ```
-/// use envoy_proxy_dynamic_modules_rust_sdk::declare_program_init;
+/// use envoy_proxy_dynamic_modules_rust_sdk::*;
 ///
-/// declare_program_init!(my_program_init);
+/// declare_init_functions!(my_program_init, my_new_http_filter_config_fn);
 ///
 /// fn my_program_init() -> bool {
 ///    true
 /// }
+///
+/// fn my_new_http_filter_config_fn(
+///   _envoy_filter_factory: EnvoyHttpConfig,
+///   _name: &str,
+///   _config: &str,
+/// ) -> Option<Box<dyn HttpConfig>> {
+///   Some(Box::new(MyHttpConfig {}))
+/// }
+///
+/// struct MyHttpConfig {}
+///
+/// impl HttpConfig for MyHttpConfig {}
 /// ```
 #[macro_export]
-macro_rules! declare_program_init {
-    ($f:ident) => {
+macro_rules! declare_init_functions {
+    ($f:ident,$new_http_filter_config_fn:expr) => {
         #[no_mangle]
         pub extern "C" fn envoy_dynamic_module_on_program_init() -> *const ::std::os::raw::c_char {
+            unsafe {
+                // We can assume that this is only called once at the beginning of the program, so it is safe to set a mutable global variable.
+                envoy_proxy_dynamic_modules_rust_sdk::NEW_HTTP_FILTER_CONFIG_FUNCTION =
+                    $new_http_filter_config_fn
+            };
             if ($f()) {
                 envoy_proxy_dynamic_modules_rust_sdk::abi::kAbiVersion.as_ptr()
                     as *const ::std::os::raw::c_char
@@ -40,4 +57,119 @@ macro_rules! declare_program_init {
             }
         }
     };
+}
+
+/// The function signature for the program init function.
+///
+/// This is called when the dynamic module is loaded, and it must return true on success, and false on failure. When it returns false,
+/// the dynamic module will not be loaded.
+///
+/// This is useful to perform any process-wide initialization that the dynamic module needs.
+pub type ProgramInitFunction = fn() -> bool;
+
+/// The function signature for the new HTTP filter configuration function.
+///
+/// This is called when a new HTTP filter configuration is created, and it must return a new instance of the [`HttpConfig`] object.
+/// Returning `None` will cause the HTTP filter configuration to be rejected.
+//
+// TODO(@mathetake): I guess there would be a way to avoid the use of dyn in the first place. E.g. one idea is to accept a type parameter declare_init_functions! macro.
+pub type NewHttpFilterConfigFunction = fn(
+    envoy_filter_factory: EnvoyHttpConfig,
+    name: &str,
+    config: &str,
+) -> Option<Box<dyn HttpConfig>>;
+
+/// The global init function for HTTP filter configurations. This is set via the `declare_init_functions` macro,
+/// and is not intended to be set directly.
+pub static mut NEW_HTTP_FILTER_CONFIG_FUNCTION: NewHttpFilterConfigFunction = |_, _, _| {
+    panic!("NEW_HTTP_FILTER_CONFIG_FUNCTION is not set");
+};
+
+/// The trait that represents the configuration for an Envoy Http filter configuration.
+/// This has one to one mapping with the [`EnvoyHttpConfig`] object.
+///
+/// The object is created when the corresponding Envoy Http filter config is created, and it is
+/// destroyed when the corresponding Envoy Http filter config is destroyed.
+pub trait HttpConfig {
+    /// This is called when a HTTP filter chain is created for a new stream.
+    fn new_http_filter(&self) -> Box<dyn HttpFilter> {
+        unimplemented!() // TODO.
+    }
+
+    /// This is called when the corresponding Envoy Http filter config is destroyed/unloaded.
+    ///
+    /// After this returns, this object is destructed.
+    //
+    // NOTE: alternatively, we can replace this with `Drop` trait, but this allows us to clarify the lifetime of the
+    // object and explain exactly when the object is destroyed.
+    fn destroy(&mut self) {}
+}
+
+/// The trait that represents an Envoy Http filter for each stream.
+pub trait HttpFilter {} // TODO.
+
+/// An opaque object that represents the underlying Envoy Http filter config. This has one to one
+/// mapping with the Envoy Http filter config object as well as [`HttpConfig`] object.
+///
+/// This is a shallow wrapper around the raw pointer to the Envoy HTTP filter object, and it
+/// can be copied and stored somewhere else up until the corresponding [`HttpConfig::destroy`]
+/// for the corresponding [`HttpConfig`] is called.
+//
+// TODO(@mathetake): make this only avaialble for non-test code, and provide a mock for testing. So that users
+// can write a unit tests for their HttpConfig implementations.
+#[derive(Debug, Clone, Copy)]
+pub struct EnvoyHttpConfig {
+    raw_addr: abi::envoy_dynamic_module_type_http_filter_config_in_envoy_ptr,
+}
+
+#[no_mangle]
+unsafe extern "C" fn envoy_dynamic_module_on_http_filter_config_new(
+    envoy_filter_config_ptr: abi::envoy_dynamic_module_type_http_filter_config_in_envoy_ptr,
+    name_ptr: *const ::std::os::raw::c_char,
+    name_size: usize,
+    config_ptr: *const ::std::os::raw::c_char,
+    config_size: usize,
+) -> abi::envoy_dynamic_module_type_http_filter_config_in_module_ptr {
+    // This assume that the name and config are valid UTF-8 strings. Should we relax? At the moment, both are String at protobuf level.
+    let name = if name_size > 0 {
+        let slice = std::slice::from_raw_parts(name_ptr as *const u8, name_size);
+        std::str::from_utf8(slice).unwrap()
+    } else {
+        ""
+    };
+    let config = if config_size > 0 {
+        let slice = std::slice::from_raw_parts(config_ptr as *const u8, config_size);
+        std::str::from_utf8(slice).unwrap()
+    } else {
+        ""
+    };
+
+    let envoy_filter_config = EnvoyHttpConfig {
+        raw_addr: envoy_filter_config_ptr,
+    };
+
+    let filter_config =
+        if let Some(config) = NEW_HTTP_FILTER_CONFIG_FUNCTION(envoy_filter_config, name, config) {
+            config
+        } else {
+            return std::ptr::null();
+        };
+
+    // We wrap the Box<dyn HttpConfig> in another Box to ensuure that the object is not dropped after being into a raw pointer.
+    // To be honest, this seems like a hack, and we should find a better way to handle this.
+    // See https://users.rust-lang.org/t/sending-a-boxed-trait-over-ffi/21708 for the exact problem.
+    let boxed_filter_config_ptr = Box::into_raw(Box::new(filter_config));
+    boxed_filter_config_ptr as abi::envoy_dynamic_module_type_http_filter_config_in_module_ptr
+}
+
+#[no_mangle]
+unsafe extern "C" fn envoy_dynamic_module_on_http_filter_config_destroy(
+    http_filter: abi::envoy_dynamic_module_type_http_filter_config_in_module_ptr,
+) {
+    let factory = http_filter as *mut *mut dyn HttpConfig;
+    (**factory).destroy();
+
+    // Drop the Box<dyn HttpConfig> and the Box<*mut dyn HttpConfig>
+    let _outer = Box::from_raw(factory);
+    let _inner = Box::from_raw(*factory);
 }

--- a/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
@@ -109,8 +109,8 @@ pub trait HttpFilter {} // TODO.
 /// This is a shallow wrapper around the raw pointer to the Envoy HTTP filter config object, and it
 /// can be copied and used up until the corresponding [`HttpFilterConfig`] is dropped.
 //
-// TODO(@mathetake): make this only avaialble for non-test code, and provide a mock for testing. So that users
-// can write a unit tests for their HttpFilterConfig implementations.
+// TODO(@mathetake): make this only avaialble for non-test code, and provide a mock for testing so that users
+// can write unit tests for their HttpFilterConfig implementations.
 #[derive(Debug, Clone, Copy)]
 pub struct EnvoyHttpFilterConfig {
     raw_ptr: abi::envoy_dynamic_module_type_http_filter_config_envoy_ptr,
@@ -188,6 +188,11 @@ mod tests {
             &new_fn,
         );
         assert!(!result.is_null());
+
+        // Drop.
+        unsafe {
+            envoy_dynamic_module_on_http_filter_config_destroy(result);
+        }
 
         // None should result in null pointer.
         new_fn = |_, _, _| None;

--- a/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
@@ -114,7 +114,7 @@ pub trait HttpFilter {} // TODO.
 // can write a unit tests for their HttpFilterConfig implementations.
 #[derive(Debug, Clone, Copy)]
 pub struct EnvoyHttpFilterConfig {
-    raw_addr: abi::envoy_dynamic_module_type_http_filter_config_envoy_ptr,
+    raw_ptr: abi::envoy_dynamic_module_type_http_filter_config_envoy_ptr,
 }
 
 #[no_mangle]
@@ -140,7 +140,7 @@ unsafe extern "C" fn envoy_dynamic_module_on_http_filter_config_new(
     };
 
     let envoy_filter_config = EnvoyHttpFilterConfig {
-        raw_addr: envoy_filter_config_ptr,
+        raw_ptr: envoy_filter_config_ptr,
     };
 
     let filter_config =

--- a/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
@@ -106,9 +106,8 @@ pub trait HttpFilter {} // TODO.
 /// An opaque object that represents the underlying Envoy Http filter config. This has one to one
 /// mapping with the Envoy Http filter config object as well as [`HttpFilterConfig`] object.
 ///
-/// This is a shallow wrapper around the raw pointer to the Envoy HTTP filter object, and it
-/// can be copied and stored somewhere else up until the corresponding [`HttpFilterConfig::destroy`]
-/// for the corresponding [`HttpFilterConfig`] is called.
+/// This is a shallow wrapper around the raw pointer to the Envoy HTTP filter config object, and it
+/// can be copied and used up until the corresponding [`HttpFilterConfig`] is dropped.
 //
 // TODO(@mathetake): make this only avaialble for non-test code, and provide a mock for testing. So that users
 // can write a unit tests for their HttpFilterConfig implementations.

--- a/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
@@ -135,7 +135,7 @@ unsafe extern "C" fn envoy_dynamic_module_on_http_filter_config_new(
         envoy_filter_config,
         name,
         config,
-        &NEW_HTTP_FILTER_CONFIG_FUNCTION
+        NEW_HTTP_FILTER_CONFIG_FUNCTION
             .get()
             .expect("NEW_HTTP_FILTER_CONFIG_FUNCTION must be set"),
     )

--- a/source/extensions/filters/http/dynamic_modules/factory.cc
+++ b/source/extensions/filters/http/dynamic_modules/factory.cc
@@ -14,20 +14,28 @@ absl::StatusOr<Http::FilterFactoryCb> DynamicModuleConfigFactory::createFilterFa
       raw_config, context.messageValidationVisitor());
 
   const auto& module_config = proto_config.dynamic_module_config();
-  const auto dynamic_module = Extensions::DynamicModules::newDynamicModuleByName(
+  auto dynamic_module = Extensions::DynamicModules::newDynamicModuleByName(
       module_config.name(), module_config.do_not_close());
   if (!dynamic_module.ok()) {
     return absl::InvalidArgumentError("Failed to load dynamic module: " +
                                       std::string(dynamic_module.status().message()));
   }
-  auto filter_config = std::make_shared<
-      Envoy::Extensions::DynamicModules::HttpFilters::DynamicModuleHttpFilterConfig>(
-      proto_config.filter_name(), proto_config.filter_config(), dynamic_module.value());
 
-  return [filter_config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
+  absl::StatusOr<
+      Envoy::Extensions::DynamicModules::HttpFilters::DynamicModuleHttpFilterConfigSharedPtr>
+      filter_config =
+          Envoy::Extensions::DynamicModules::HttpFilters::newDynamicModuleHttpFilterConfig(
+              proto_config.filter_name(), proto_config.filter_config(),
+              std::move(dynamic_module.value()));
+
+  if (!filter_config.ok()) {
+    return absl::InvalidArgumentError("Failed to create filter config: " +
+                                      std::string(filter_config.status().message()));
+  }
+  return [config = filter_config.value()](Http::FilterChainFactoryCallbacks& callbacks) -> void {
     auto filter =
         std::make_shared<Envoy::Extensions::DynamicModules::HttpFilters::DynamicModuleHttpFilter>(
-            filter_config);
+            config);
     callbacks.addStreamDecoderFilter(filter);
     callbacks.addStreamEncoderFilter(filter);
   };

--- a/source/extensions/filters/http/dynamic_modules/filter_config.cc
+++ b/source/extensions/filters/http/dynamic_modules/filter_config.cc
@@ -7,10 +7,50 @@ namespace HttpFilters {
 
 DynamicModuleHttpFilterConfig::DynamicModuleHttpFilterConfig(
     const absl::string_view filter_name, const absl::string_view filter_config,
-    Extensions::DynamicModules::DynamicModuleSharedPtr dynamic_module)
-    : filter_name_(filter_name), filter_config_(filter_config), dynamic_module_(dynamic_module){};
+    Extensions::DynamicModules::DynamicModulePtr dynamic_module)
+    : filter_name_(filter_name), filter_config_(filter_config),
+      dynamic_module_(std::move(dynamic_module)){};
 
-DynamicModuleHttpFilterConfig::~DynamicModuleHttpFilterConfig() = default;
+DynamicModuleHttpFilterConfig::~DynamicModuleHttpFilterConfig() {
+  (*in_module_config_destroy_)(in_module_config_);
+};
+
+absl::StatusOr<DynamicModuleHttpFilterConfigSharedPtr>
+newDynamicModuleHttpFilterConfig(const absl::string_view filter_name,
+                                 const absl::string_view filter_config,
+                                 Extensions::DynamicModules::DynamicModulePtr dynamic_module) {
+  auto constructor =
+      dynamic_module->getFunctionPointer<decltype(&envoy_dynamic_module_on_http_filter_config_new)>(
+          "envoy_dynamic_module_on_http_filter_config_new");
+  if (constructor == nullptr) {
+    return absl::InvalidArgumentError(
+        "Failed to resolve symbol envoy_dynamic_module_on_http_filter_config_new");
+  }
+
+  auto destroy =
+      dynamic_module
+          ->getFunctionPointer<decltype(&envoy_dynamic_module_on_http_filter_config_destroy)>(
+              "envoy_dynamic_module_on_http_filter_config_destroy");
+  if (destroy == nullptr) {
+    return absl::InvalidArgumentError(
+        "Failed to resolve symbol envoy_dynamic_module_on_http_filter_config_destroy");
+  }
+
+  auto config = std::make_shared<DynamicModuleHttpFilterConfig>(filter_name, filter_config,
+                                                                std::move(dynamic_module));
+
+  const void* filter_config_envoy_ptr =
+      (*constructor)(static_cast<void*>(config.get()), filter_name.data(), filter_name.size(),
+                     filter_config.data(), filter_config.size());
+
+  if (filter_config_envoy_ptr == nullptr) {
+    return absl::InvalidArgumentError("Failed to initialize dynamic module");
+  }
+
+  config->in_module_config_ = filter_config_envoy_ptr;
+  config->in_module_config_destroy_ = destroy;
+  return config;
+}
 
 } // namespace HttpFilters
 } // namespace DynamicModules

--- a/source/extensions/filters/http/dynamic_modules/filter_config.h
+++ b/source/extensions/filters/http/dynamic_modules/filter_config.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "source/extensions/dynamic_modules/abi.h"
 #include "source/extensions/dynamic_modules/dynamic_modules.h"
 
 namespace Envoy {
@@ -21,9 +22,15 @@ public:
    */
   DynamicModuleHttpFilterConfig(const absl::string_view filter_name,
                                 const absl::string_view filter_config,
-                                Extensions::DynamicModules::DynamicModuleSharedPtr dynamic_module);
+                                Extensions::DynamicModules::DynamicModulePtr dynamic_module);
 
   ~DynamicModuleHttpFilterConfig();
+
+  // The corresponding in-module configuration.
+  envoy_dynamic_module_type_http_filter_config_in_module_ptr in_module_config_ = nullptr;
+
+  // The function pointer to the module's destroy function, resolved in the constructor.
+  decltype(&envoy_dynamic_module_on_http_filter_config_destroy) in_module_config_destroy_ = nullptr;
 
 private:
   // The name of the filter passed in the constructor.
@@ -33,10 +40,22 @@ private:
   const std::string filter_config_;
 
   // The handle for the module.
-  Extensions::DynamicModules::DynamicModuleSharedPtr dynamic_module_;
+  Extensions::DynamicModules::DynamicModulePtr dynamic_module_;
 };
 
 using DynamicModuleHttpFilterConfigSharedPtr = std::shared_ptr<DynamicModuleHttpFilterConfig>;
+
+/**
+ * Creates a new DynamicModuleHttpFilterConfig for given configuration.
+ * @param filter_name the name of the filter.
+ * @param filter_config the configuration for the module.
+ * @param dynamic_module the dynamic module to use.
+ * @return a shared pointer to the new config object or an error if the module could not be loaded.
+ */
+absl::StatusOr<DynamicModuleHttpFilterConfigSharedPtr>
+newDynamicModuleHttpFilterConfig(const absl::string_view filter_name,
+                                 const absl::string_view filter_config,
+                                 Extensions::DynamicModules::DynamicModulePtr dynamic_module);
 
 } // namespace HttpFilters
 } // namespace DynamicModules

--- a/source/extensions/filters/http/dynamic_modules/filter_config.h
+++ b/source/extensions/filters/http/dynamic_modules/filter_config.h
@@ -27,7 +27,7 @@ public:
   ~DynamicModuleHttpFilterConfig();
 
   // The corresponding in-module configuration.
-  envoy_dynamic_module_type_http_filter_config_in_module_ptr in_module_config_ = nullptr;
+  envoy_dynamic_module_type_http_filter_config_module_ptr in_module_config_ = nullptr;
 
   // The function pointer to the module's destroy function, resolved in the constructor.
   decltype(&envoy_dynamic_module_on_http_filter_config_destroy) in_module_config_destroy_ = nullptr;

--- a/test/extensions/dynamic_modules/BUILD
+++ b/test/extensions/dynamic_modules/BUILD
@@ -66,7 +66,7 @@ envoy_cc_test_library(
 rust_test(
     name = "rust_sdk_test",
     crate = "//source/extensions/dynamic_modules/sdk/rust:envoy_proxy_dynamic_modules_rust_sdk",
-    # tags = ["nocoverage"],
+    tags = ["nocoverage"],
 )
 
 rust_doc_test(

--- a/test/extensions/dynamic_modules/BUILD
+++ b/test/extensions/dynamic_modules/BUILD
@@ -66,21 +66,25 @@ envoy_cc_test_library(
 rust_test(
     name = "rust_sdk_test",
     crate = "//source/extensions/dynamic_modules/sdk/rust:envoy_proxy_dynamic_modules_rust_sdk",
+    # tags = ["nocoverage"],
 )
 
 rust_doc_test(
     name = "rust_sdk_doc_test",
     crate = "//source/extensions/dynamic_modules/sdk/rust:envoy_proxy_dynamic_modules_rust_sdk",
+    tags = ["nocoverage"],
 )
 
 # As per the discussion in https://github.com/envoyproxy/envoy/pull/35627,
 # we set the rust_fmt and clippy target here instead of the part of //tools/code_format target for now.
 rustfmt_test(
     name = "rust_sdk_fmt",
+    tags = ["nocoverage"],
     targets = ["//source/extensions/dynamic_modules/sdk/rust:envoy_proxy_dynamic_modules_rust_sdk"],
 )
 
 rust_clippy(
     name = "rust_sdk_clippy",
+    tags = ["nocoverage"],
     deps = ["//source/extensions/dynamic_modules/sdk/rust:envoy_proxy_dynamic_modules_rust_sdk"],
 )

--- a/test/extensions/dynamic_modules/BUILD
+++ b/test/extensions/dynamic_modules/BUILD
@@ -70,7 +70,7 @@ rust_test(
         # It is a known issue that TSAN detectes a false positive in the test runner of Rust toolchain:
         # https://github.com/rust-lang/rust/issues/39608
         #
-        # To avoid this issue, we need to usee nightly and pass RUSTFLAGS="-Z sanitizer=thread" to this target only
+        # To avoid this issue, we need to use nightly and pass RUSTFLAGS="-Z sanitizer=thread" to this target only
         # when we run the test with TSAN: https://github.com/rust-lang/rust/commit/4b91729df22015bd412f6fc0fa397785d1e2159c
         "no_tsan",
         "nocoverage",

--- a/test/extensions/dynamic_modules/BUILD
+++ b/test/extensions/dynamic_modules/BUILD
@@ -66,7 +66,15 @@ envoy_cc_test_library(
 rust_test(
     name = "rust_sdk_test",
     crate = "//source/extensions/dynamic_modules/sdk/rust:envoy_proxy_dynamic_modules_rust_sdk",
-    tags = ["nocoverage"],
+    tags = [
+        # It is a known issue that TSAN detectes a false positive in the test runner of Rust toolchain:
+        # https://github.com/rust-lang/rust/issues/39608
+        #
+        # To avoid this issue, we need to usee nightly and pass RUSTFLAGS="-Z sanitizer=thread" to this target only
+        # when we run the test with TSAN: https://github.com/rust-lang/rust/commit/4b91729df22015bd412f6fc0fa397785d1e2159c
+        "no_tsan",
+        "nocoverage",
+    ],
 )
 
 rust_doc_test(

--- a/test/extensions/dynamic_modules/BUILD
+++ b/test/extensions/dynamic_modules/BUILD
@@ -69,9 +69,12 @@ rust_test(
     tags = [
         # It is a known issue that TSAN detectes a false positive in the test runner of Rust toolchain:
         # https://github.com/rust-lang/rust/issues/39608
-        #
-        # To avoid this issue, we need to use nightly and pass RUSTFLAGS="-Z sanitizer=thread" to this target only
+        # To avoid this issue, we need to use nightly and pass RUSTFLAGS="-Zsanitizer=thread" to this target only
         # when we run the test with TSAN: https://github.com/rust-lang/rust/commit/4b91729df22015bd412f6fc0fa397785d1e2159c
+        # However, that causes symbol conflicts between the sanitizer built by Rust and the one built by Bazel.
+        # Moreover, we also need to rebuild the Rust std-lib with the cargo option "-Zbuild-std", but that is
+        # not supported by the rules_rust yet: https://github.com/bazelbuild/rules_rust/issues/2068
+        # So, we disable TSAN for now. In contrast, ASAN works without any issue.
         "no_tsan",
         "nocoverage",
     ],

--- a/test/extensions/dynamic_modules/BUILD
+++ b/test/extensions/dynamic_modules/BUILD
@@ -1,4 +1,11 @@
 load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_clippy",
+    "rust_doc_test",
+    "rust_test",
+    "rustfmt_test",
+)
+load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_test",
     "envoy_cc_test_library",
@@ -53,4 +60,27 @@ envoy_cc_test_library(
         "//test/test_common:environment_lib",
         "//test/test_common:utility_lib",
     ],
+)
+
+# We have targets for the tests of SDK itself here so that //test/... will be able to run them.
+rust_test(
+    name = "rust_sdk_test",
+    crate = "//source/extensions/dynamic_modules/sdk/rust:envoy_proxy_dynamic_modules_rust_sdk",
+)
+
+rust_doc_test(
+    name = "rust_sdk_doc_test",
+    crate = "//source/extensions/dynamic_modules/sdk/rust:envoy_proxy_dynamic_modules_rust_sdk",
+)
+
+# As per the discussion in https://github.com/envoyproxy/envoy/pull/35627,
+# we set the rust_fmt and clippy target here instead of the part of //tools/code_format target for now.
+rustfmt_test(
+    name = "rust_sdk_fmt",
+    targets = ["//source/extensions/dynamic_modules/sdk/rust:envoy_proxy_dynamic_modules_rust_sdk"],
+)
+
+rust_clippy(
+    name = "rust_sdk_clippy",
+    deps = ["//source/extensions/dynamic_modules/sdk/rust:envoy_proxy_dynamic_modules_rust_sdk"],
 )

--- a/test/extensions/dynamic_modules/dynamic_modules_test.cc
+++ b/test/extensions/dynamic_modules/dynamic_modules_test.cc
@@ -10,7 +10,7 @@ namespace Extensions {
 namespace DynamicModules {
 
 TEST(DynamicModuleTestGeneral, InvalidPath) {
-  absl::StatusOr<DynamicModuleSharedPtr> result = newDynamicModule("invalid_name", false);
+  absl::StatusOr<DynamicModulePtr> result = newDynamicModule("invalid_name", false);
   EXPECT_FALSE(result.ok());
   EXPECT_EQ(result.status().code(), absl::StatusCode::kInvalidArgument);
 }
@@ -21,7 +21,7 @@ INSTANTIATE_TEST_SUITE_P(LanguageTests, DynamicModuleTestLanguages, testing::Val
 TEST_P(DynamicModuleTestLanguages, DoNotClose) {
   std::string language = GetParam();
   using GetSomeVariableFuncType = int (*)();
-  absl::StatusOr<DynamicModuleSharedPtr> module =
+  absl::StatusOr<DynamicModulePtr> module =
       newDynamicModule(testSharedObjectPath("no_op", language), false);
   EXPECT_TRUE(module.ok());
   const auto getSomeVariable =
@@ -59,24 +59,24 @@ TEST_P(DynamicModuleTestLanguages, DoNotClose) {
 
 TEST_P(DynamicModuleTestLanguages, LoadNoOp) {
   std::string language = GetParam();
-  absl::StatusOr<DynamicModuleSharedPtr> module =
+  absl::StatusOr<DynamicModulePtr> module =
       newDynamicModule(testSharedObjectPath("no_op", language), false);
   EXPECT_TRUE(module.ok());
 }
 
 TEST_P(DynamicModuleTestLanguages, NoProgramInit) {
   std::string language = GetParam();
-  absl::StatusOr<DynamicModuleSharedPtr> result =
+  absl::StatusOr<DynamicModulePtr> result =
       newDynamicModule(testSharedObjectPath("no_program_init", language), false);
   EXPECT_FALSE(result.ok());
   EXPECT_EQ(result.status().code(), absl::StatusCode::kInvalidArgument);
   EXPECT_THAT(result.status().message(),
-              testing::HasSubstr("undefined symbol: envoy_dynamic_module_on_program_init"));
+              testing::HasSubstr("Failed to resolve symbol envoy_dynamic_module_on_program_init"));
 }
 
 TEST_P(DynamicModuleTestLanguages, ProgramInitFail) {
   std::string language = GetParam();
-  absl::StatusOr<DynamicModuleSharedPtr> result =
+  absl::StatusOr<DynamicModulePtr> result =
       newDynamicModule(testSharedObjectPath("program_init_fail", language), false);
   EXPECT_FALSE(result.ok());
   EXPECT_EQ(result.status().code(), absl::StatusCode::kInvalidArgument);
@@ -86,7 +86,7 @@ TEST_P(DynamicModuleTestLanguages, ProgramInitFail) {
 
 TEST_P(DynamicModuleTestLanguages, ABIVersionMismatch) {
   std::string language = GetParam();
-  absl::StatusOr<DynamicModuleSharedPtr> result =
+  absl::StatusOr<DynamicModulePtr> result =
       newDynamicModule(testSharedObjectPath("abi_version_mismatch", language), false);
   EXPECT_FALSE(result.ok());
   EXPECT_EQ(result.status().code(), absl::StatusCode::kInvalidArgument);
@@ -101,14 +101,14 @@ TEST(CreateDynamicModulesByName, OK) {
           "{{ test_rundir }}/test/extensions/dynamic_modules/test_data/rust"),
       1);
 
-  absl::StatusOr<DynamicModuleSharedPtr> module = newDynamicModuleByName("no_op", false);
+  absl::StatusOr<DynamicModulePtr> module = newDynamicModuleByName("no_op", false);
   EXPECT_TRUE(module.ok());
   TestEnvironment::unsetEnvVar("ENVOY_DYNAMIC_MODULES_SEARCH_PATH");
 }
 
 TEST(CreateDynamicModulesByName, EnvVarNotSet) {
   // Without setting the search path, this should fail.
-  absl::StatusOr<DynamicModuleSharedPtr> module = newDynamicModuleByName("no_op", false);
+  absl::StatusOr<DynamicModulePtr> module = newDynamicModuleByName("no_op", false);
   EXPECT_FALSE(module.ok());
   EXPECT_EQ(module.status().code(), absl::StatusCode::kInvalidArgument);
   EXPECT_THAT(module.status().message(),

--- a/test/extensions/dynamic_modules/http/BUILD
+++ b/test/extensions/dynamic_modules/http/BUILD
@@ -12,7 +12,9 @@ envoy_cc_test(
     name = "factory_test",
     srcs = ["factory_test.cc"],
     data = [
-        "//test/extensions/dynamic_modules/test_data/rust:no_op",
+        "//test/extensions/dynamic_modules/test_data/c:no_http_config_destory",
+        "//test/extensions/dynamic_modules/test_data/c:no_http_config_new",
+        "//test/extensions/dynamic_modules/test_data/c:no_op",
     ],
     # factory_context_mocks needs this.
     rbe_pool = "6gig",

--- a/test/extensions/dynamic_modules/http/factory_test.cc
+++ b/test/extensions/dynamic_modules/http/factory_test.cc
@@ -19,8 +19,7 @@ TEST(DynamicModuleConfigFactory, Overrides) {
 TEST(DynamicModuleConfigFactory, LoadOK) {
   TestEnvironment::setEnvVar(
       "ENVOY_DYNAMIC_MODULES_SEARCH_PATH",
-      TestEnvironment::substitute(
-          "{{ test_rundir }}/test/extensions/dynamic_modules/test_data/rust"),
+      TestEnvironment::substitute("{{ test_rundir }}/test/extensions/dynamic_modules/test_data/c"),
       1);
 
   envoy::extensions::filters::http::dynamic_modules::v3::DynamicModuleFilter config;
@@ -49,6 +48,12 @@ filter_config: bar
 }
 
 TEST(DynamicModuleConfigFactory, LoadError) {
+  TestEnvironment::setEnvVar(
+      "ENVOY_DYNAMIC_MODULES_SEARCH_PATH",
+      TestEnvironment::substitute("{{ test_rundir }}/test/extensions/dynamic_modules/test_data/c"),
+      1);
+
+  // Non existent module.
   envoy::extensions::filters::http::dynamic_modules::v3::DynamicModuleFilter config;
   const std::string yaml = R"EOF(
 dynamic_module_config:
@@ -67,6 +72,42 @@ filter_config: bar
   EXPECT_FALSE(result.ok());
   EXPECT_EQ(result.status().code(), absl::StatusCode::kInvalidArgument);
   EXPECT_THAT(result.status().message(), testing::HasSubstr("Failed to load dynamic module:"));
+
+  // The init function envoy_dynamic_module_on_http_filter_config_new is not defined.
+  const std::string yaml2 = R"EOF(
+dynamic_module_config:
+    name: no_http_config_new
+filter_name: foo
+filter_config: bar
+)EOF";
+
+  envoy::extensions::filters::http::dynamic_modules::v3::DynamicModuleFilter proto_config2;
+  TestUtility::loadFromYamlAndValidate(yaml2, proto_config2);
+
+  auto result2 = factory.createFilterFactoryFromProto(proto_config2, "", context);
+  EXPECT_FALSE(result2.ok());
+  EXPECT_EQ(result2.status().code(), absl::StatusCode::kInvalidArgument);
+  EXPECT_THAT(result2.status().message(),
+              testing::HasSubstr(
+                  "Failed to resolve symbol envoy_dynamic_module_on_http_filter_config_new"));
+
+  // The destroy function envoy_dynamic_module_on_http_filter_config_destroy is not defined.
+  const std::string yaml3 = R"EOF(
+dynamic_module_config:
+    name: no_http_config_destory
+filter_name: foo
+filter_config: bar
+)EOF";
+
+  envoy::extensions::filters::http::dynamic_modules::v3::DynamicModuleFilter proto_config3;
+  TestUtility::loadFromYamlAndValidate(yaml3, proto_config3);
+
+  auto result3 = factory.createFilterFactoryFromProto(proto_config3, "", context);
+  EXPECT_FALSE(result3.ok());
+  EXPECT_EQ(result3.status().code(), absl::StatusCode::kInvalidArgument);
+  EXPECT_THAT(result3.status().message(),
+              testing::HasSubstr(
+                  "Failed to resolve symbol envoy_dynamic_module_on_http_filter_config_destroy"));
 }
 
 } // namespace HttpFilters

--- a/test/extensions/dynamic_modules/http/filter_test.cc
+++ b/test/extensions/dynamic_modules/http/filter_test.cc
@@ -20,13 +20,12 @@ TEST_P(DynamicModuleTestLanguages, Nop) {
   auto dynamic_module = newDynamicModule(testSharedObjectPath("no_op", language), false);
   EXPECT_TRUE(dynamic_module.ok());
 
-  auto filter_config_ptr = std::make_shared<
-      Envoy::Extensions::DynamicModules::HttpFilters::DynamicModuleHttpFilterConfig>(
-      filter_name, filter_config, dynamic_module.value());
+  auto filter_config_or_status =
+      Envoy::Extensions::DynamicModules::HttpFilters::newDynamicModuleHttpFilterConfig(
+          filter_name, filter_config, std::move(dynamic_module.value()));
+  EXPECT_TRUE(filter_config_or_status.ok());
 
-  auto filter =
-      std::make_shared<Envoy::Extensions::DynamicModules::HttpFilters::DynamicModuleHttpFilter>(
-          filter_config_ptr);
+  auto filter = std::make_shared<DynamicModuleHttpFilter>(filter_config_or_status.value());
 
   // The followings are mostly for coverage at the moment.
   NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks;

--- a/test/extensions/dynamic_modules/test_data/c/BUILD
+++ b/test/extensions/dynamic_modules/test_data/c/BUILD
@@ -14,3 +14,7 @@ test_program(name = "no_program_init")
 test_program(name = "program_init_fail")
 
 test_program(name = "abi_version_mismatch")
+
+test_program(name = "no_http_config_new")
+
+test_program(name = "no_http_config_destory")

--- a/test/extensions/dynamic_modules/test_data/c/abi_version_mismatch.c
+++ b/test/extensions/dynamic_modules/test_data/c/abi_version_mismatch.c
@@ -1,5 +1,5 @@
 #include "source/extensions/dynamic_modules/abi.h"
 
-envoy_dynamic_module_type_abi_version_in_envoy_ptr envoy_dynamic_module_on_program_init() {
+envoy_dynamic_module_type_abi_version_envoy_ptr envoy_dynamic_module_on_program_init() {
   return "invalid-version-hash";
 }

--- a/test/extensions/dynamic_modules/test_data/c/abi_version_mismatch.c
+++ b/test/extensions/dynamic_modules/test_data/c/abi_version_mismatch.c
@@ -1,5 +1,5 @@
 #include "source/extensions/dynamic_modules/abi.h"
 
-envoy_dynamic_module_type_abi_version envoy_dynamic_module_on_program_init() {
+envoy_dynamic_module_type_abi_version_in_envoy_ptr envoy_dynamic_module_on_program_init() {
   return "invalid-version-hash";
 }

--- a/test/extensions/dynamic_modules/test_data/c/no_http_config_destory.c
+++ b/test/extensions/dynamic_modules/test_data/c/no_http_config_destory.c
@@ -1,14 +1,5 @@
-#include <assert.h>
-
 #include "source/extensions/dynamic_modules/abi.h"
 #include "source/extensions/dynamic_modules/abi_version.h"
-
-static int some_variable = 0;
-
-int getSomeVariable() {
-  some_variable++;
-  return some_variable;
-}
 
 envoy_dynamic_module_type_abi_version_in_envoy_ptr envoy_dynamic_module_on_program_init() {
   return kAbiVersion;
@@ -18,10 +9,6 @@ envoy_dynamic_module_type_http_filter_config_in_module_ptr
 envoy_dynamic_module_on_http_filter_config_new(
     envoy_dynamic_module_type_http_filter_config_in_envoy_ptr filter_config_envoy_ptr,
     const char* name_ptr, int name_size, const char* config_ptr, int config_size) {
+  static int some_variable = 0;
   return &some_variable;
-}
-
-void envoy_dynamic_module_on_http_filter_config_destroy(
-    envoy_dynamic_module_type_http_filter_config_in_module_ptr filter_config_ptr) {
-  assert(filter_config_ptr == &some_variable);
 }

--- a/test/extensions/dynamic_modules/test_data/c/no_http_config_destory.c
+++ b/test/extensions/dynamic_modules/test_data/c/no_http_config_destory.c
@@ -1,13 +1,13 @@
 #include "source/extensions/dynamic_modules/abi.h"
 #include "source/extensions/dynamic_modules/abi_version.h"
 
-envoy_dynamic_module_type_abi_version_in_envoy_ptr envoy_dynamic_module_on_program_init() {
+envoy_dynamic_module_type_abi_version_envoy_ptr envoy_dynamic_module_on_program_init() {
   return kAbiVersion;
 }
 
-envoy_dynamic_module_type_http_filter_config_in_module_ptr
+envoy_dynamic_module_type_http_filter_config_module_ptr
 envoy_dynamic_module_on_http_filter_config_new(
-    envoy_dynamic_module_type_http_filter_config_in_envoy_ptr filter_config_envoy_ptr,
+    envoy_dynamic_module_type_http_filter_config_envoy_ptr filter_config_envoy_ptr,
     const char* name_ptr, int name_size, const char* config_ptr, int config_size) {
   static int some_variable = 0;
   return &some_variable;

--- a/test/extensions/dynamic_modules/test_data/c/no_http_config_new.c
+++ b/test/extensions/dynamic_modules/test_data/c/no_http_config_new.c
@@ -1,6 +1,6 @@
 #include "source/extensions/dynamic_modules/abi.h"
 #include "source/extensions/dynamic_modules/abi_version.h"
 
-envoy_dynamic_module_type_abi_version_in_envoy_ptr envoy_dynamic_module_on_program_init() {
+envoy_dynamic_module_type_abi_version_envoy_ptr envoy_dynamic_module_on_program_init() {
   return kAbiVersion;
 }

--- a/test/extensions/dynamic_modules/test_data/c/no_http_config_new.c
+++ b/test/extensions/dynamic_modules/test_data/c/no_http_config_new.c
@@ -1,7 +1,6 @@
-#include <stddef.h>
-
 #include "source/extensions/dynamic_modules/abi.h"
+#include "source/extensions/dynamic_modules/abi_version.h"
 
 envoy_dynamic_module_type_abi_version_in_envoy_ptr envoy_dynamic_module_on_program_init() {
-  return NULL;
+  return kAbiVersion;
 }

--- a/test/extensions/dynamic_modules/test_data/c/no_op.c
+++ b/test/extensions/dynamic_modules/test_data/c/no_op.c
@@ -10,18 +10,18 @@ int getSomeVariable() {
   return some_variable;
 }
 
-envoy_dynamic_module_type_abi_version_in_envoy_ptr envoy_dynamic_module_on_program_init() {
+envoy_dynamic_module_type_abi_version_envoy_ptr envoy_dynamic_module_on_program_init() {
   return kAbiVersion;
 }
 
-envoy_dynamic_module_type_http_filter_config_in_module_ptr
+envoy_dynamic_module_type_http_filter_config_module_ptr
 envoy_dynamic_module_on_http_filter_config_new(
-    envoy_dynamic_module_type_http_filter_config_in_envoy_ptr filter_config_envoy_ptr,
+    envoy_dynamic_module_type_http_filter_config_envoy_ptr filter_config_envoy_ptr,
     const char* name_ptr, int name_size, const char* config_ptr, int config_size) {
   return &some_variable;
 }
 
 void envoy_dynamic_module_on_http_filter_config_destroy(
-    envoy_dynamic_module_type_http_filter_config_in_module_ptr filter_config_ptr) {
+    envoy_dynamic_module_type_http_filter_config_module_ptr filter_config_ptr) {
   assert(filter_config_ptr == &some_variable);
 }

--- a/test/extensions/dynamic_modules/test_data/c/program_init_fail.c
+++ b/test/extensions/dynamic_modules/test_data/c/program_init_fail.c
@@ -2,6 +2,6 @@
 
 #include "source/extensions/dynamic_modules/abi.h"
 
-envoy_dynamic_module_type_abi_version_in_envoy_ptr envoy_dynamic_module_on_program_init() {
+envoy_dynamic_module_type_abi_version_envoy_ptr envoy_dynamic_module_on_program_init() {
   return NULL;
 }

--- a/test/extensions/dynamic_modules/test_data/rust/no_op.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/no_op.rs
@@ -1,8 +1,9 @@
-use envoy_proxy_dynamic_modules_rust_sdk::declare_program_init;
+use envoy_proxy_dynamic_modules_rust_sdk::declare_init_functions;
 use std::sync::atomic::{AtomicI32, Ordering};
 
-declare_program_init!(init);
+declare_init_functions!(init, new_nop_http_filter_config_fn);
 
+/// This implements the [`envoy_proxy_dynamic_modules_rust_sdk::ProgramInitFunction`] signature.
 fn init() -> bool {
     true
 }
@@ -12,4 +13,28 @@ static SOME_VARIABLE: AtomicI32 = AtomicI32::new(1);
 #[no_mangle]
 pub extern "C" fn getSomeVariable() -> i32 {
     SOME_VARIABLE.fetch_add(1, Ordering::SeqCst)
+}
+
+/// This implements the [`envoy_proxy_dynamic_modules_rust_sdk::NewHttpFilterConfigFunction`] signature.
+fn new_nop_http_filter_config_fn(
+    _envoy_filter_factory: envoy_proxy_dynamic_modules_rust_sdk::EnvoyHttpConfig,
+    name: &str,
+    config: &str,
+) -> Option<Box<dyn envoy_proxy_dynamic_modules_rust_sdk::HttpConfig>> {
+    let name = name.to_string();
+    let config = config.to_string();
+    Some(Box::new(NopHttpFilterConfig { name, config }))
+}
+
+/// A no-op HTTP filter configuration that implements [`envoy_proxy_dynamic_modules_rust_sdk::HttpConfig`] trait.
+struct NopHttpFilterConfig {
+    name: String,
+    config: String,
+}
+
+impl envoy_proxy_dynamic_modules_rust_sdk::HttpConfig for NopHttpFilterConfig {
+    fn destroy(&mut self) {
+        assert_eq!(self.name, "foo");
+        assert_eq!(self.config, "bar");
+    }
 }

--- a/test/extensions/dynamic_modules/test_data/rust/no_op.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/no_op.rs
@@ -26,14 +26,17 @@ fn new_nop_http_filter_config_fn(
     Some(Box::new(NopHttpFilterConfig { name, config }))
 }
 
-/// A no-op HTTP filter configuration that implements [`envoy_proxy_dynamic_modules_rust_sdk::HttpConfig`] trait.
+/// A no-op HTTP filter configuration that implements [`envoy_proxy_dynamic_modules_rust_sdk::HttpConfig`]
+/// as well as the [`Drop`] to test the cleanup of the configuration.
 struct NopHttpFilterConfig {
     name: String,
     config: String,
 }
 
-impl envoy_proxy_dynamic_modules_rust_sdk::HttpConfig for NopHttpFilterConfig {
-    fn destroy(&mut self) {
+impl envoy_proxy_dynamic_modules_rust_sdk::HttpConfig for NopHttpFilterConfig {}
+
+impl Drop for NopHttpFilterConfig {
+    fn drop(&mut self) {
         assert_eq!(self.name, "foo");
         assert_eq!(self.config, "bar");
     }

--- a/test/extensions/dynamic_modules/test_data/rust/no_op.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/no_op.rs
@@ -17,23 +17,23 @@ pub extern "C" fn getSomeVariable() -> i32 {
 
 /// This implements the [`envoy_proxy_dynamic_modules_rust_sdk::NewHttpFilterConfigFunction`] signature.
 fn new_nop_http_filter_config_fn(
-    _envoy_filter_factory: envoy_proxy_dynamic_modules_rust_sdk::EnvoyHttpConfig,
+    _envoy_filter_factory: envoy_proxy_dynamic_modules_rust_sdk::EnvoyHttpFilterConfig,
     name: &str,
     config: &str,
-) -> Option<Box<dyn envoy_proxy_dynamic_modules_rust_sdk::HttpConfig>> {
+) -> Option<Box<dyn envoy_proxy_dynamic_modules_rust_sdk::HttpFilterConfig>> {
     let name = name.to_string();
     let config = config.to_string();
     Some(Box::new(NopHttpFilterConfig { name, config }))
 }
 
-/// A no-op HTTP filter configuration that implements [`envoy_proxy_dynamic_modules_rust_sdk::HttpConfig`]
+/// A no-op HTTP filter configuration that implements [`envoy_proxy_dynamic_modules_rust_sdk::HttpFilterConfig`]
 /// as well as the [`Drop`] to test the cleanup of the configuration.
 struct NopHttpFilterConfig {
     name: String,
     config: String,
 }
 
-impl envoy_proxy_dynamic_modules_rust_sdk::HttpConfig for NopHttpFilterConfig {}
+impl envoy_proxy_dynamic_modules_rust_sdk::HttpFilterConfig for NopHttpFilterConfig {}
 
 impl Drop for NopHttpFilterConfig {
     fn drop(&mut self) {


### PR DESCRIPTION
Commit Message: dynamic_modules: HTTP filter config implementation
Additional Description:

This expands the ABI for HTTP filter configurations. Especially this adds two
even hooks coupled with the life cycle of HTTP filter config handled in the main
thread.

The key idea is to do the direct pointer (context) passing between the boundary;
This allows us to avoid maintaining IDs and global mapping state, which makes it 
easier to test as well as it has benefit in terms of performance. E.g. there's no 
need to look up "contexts" on each event hook entry.

The next follow-up PR will add per-stream event hooks (filter implementation).
After the event hooks are done, module->Envoy functions will be added (e.g.
accessing headers, etc.)

Risk Level: low
Testing: done
Docs Changes: n/a
Release Notes: n/a 
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
