### PR TITLE
lua cluster_specifier: fix crash in getCluster()

### DIFF
--- a/test/extensions/router/cluster_specifiers/lua/lua_cluster_specifier_test.cc
+++ b/test/extensions/router/cluster_specifiers/lua/lua_cluster_specifier_test.cc
@@ -265,6 +265,9 @@ TEST_F(LuaClusterSpecifierPluginTest, ClusterMethods) {
   Http::TestRequestHeaderMapImpl headers{{":path", "/"}};
   auto route = plugin_->route(mock_route, headers);
   EXPECT_EQ("pass", route->routeEntry()->clusterName());
+
+  // Force the runtime to gc and destroy all the userdata.
+  config_->perLuaCodeSetup()->runtimeGC();
 }
 
 } // namespace Lua


### PR DESCRIPTION
Envoy would crash when the Lua garbage collector ran if `getCluster()` had been called.

This was added in #36998