### PR TITLE
changelog: fix a small typo in rbac deprecation line

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -201,5 +201,5 @@ new_features:
 deprecated:
 - area: rbac
   change: |
-    metadata :ref:`sourced_metadata <envoy_v3_api_field_config.rbac.v3.Permission.metadata>` is now deprecated in the
+    metadata :ref:`metadata <envoy_v3_api_field_config.rbac.v3.Permission.metadata>` is now deprecated in the
     favor of :ref:`sourced_metadata <envoy_v3_api_field_config.rbac.v3.Permission.sourced_metadata>`.


### PR DESCRIPTION
## Description

This PR fixes a very small typo in the change logs for RBAC `metadata` deprecation line which is mistakenly spelled as `sourced_metadata`.

---

**Commit Message:** ****
**Additional Description:** Fixes a very small typo in the change logs for RBAC `metadata` deprecation line which is mistakenly spelled as `sourced_metadata`.
**Risk Level:** N/A
**Testing:** N/A
**Docs Changes:** N/A
**Release Notes:** N/A