### PR TITLE
ci: Add bazel client caching

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -513,26 +513,26 @@ build:rbe-engflow --bes_upload_mode=fully_async
 build:rbe-engflow --nolegacy_important_outputs
 
 # RBE (Engflow Envoy)
-build:common-envoy-engflow --google_default_credentials=false
-build:common-envoy-engflow --credential_helper=*.engflow.com=%workspace%/bazel/engflow-bazel-credential-helper.sh
-build:common-envoy-engflow --grpc_keepalive_time=60s
-build:common-envoy-engflow --grpc_keepalive_timeout=30s
+common:common-envoy-engflow --google_default_credentials=false
+common:common-envoy-engflow --credential_helper=*.engflow.com=%workspace%/bazel/engflow-bazel-credential-helper.sh
+common:common-envoy-engflow --grpc_keepalive_time=60s
+common:common-envoy-engflow --grpc_keepalive_timeout=30s
 
-build:cache-envoy-engflow --remote_cache=grpcs://mordenite.cluster.engflow.com
-build:cache-envoy-engflow --remote_timeout=3600s
-build:bes-envoy-engflow --bes_backend=grpcs://mordenite.cluster.engflow.com/
-build:bes-envoy-engflow --bes_results_url=https://mordenite.cluster.engflow.com/invocation/
-build:bes-envoy-engflow --bes_timeout=3600s
-build:bes-envoy-engflow --bes_upload_mode=fully_async
-build:bes-envoy-engflow --nolegacy_important_outputs
-build:rbe-envoy-engflow --remote_executor=grpcs://mordenite.cluster.engflow.com
-build:rbe-envoy-engflow --remote_default_exec_properties=container-image=docker://gcr.io/envoy-ci/envoy-build@sha256:7adc40c09508f957624c4d2e0f5aeecb73a59207ee6ded53b107eac828c091b2
-build:rbe-envoy-engflow --jobs=200
-build:rbe-envoy-engflow --define=engflow_rbe=true
+common:cache-envoy-engflow --remote_cache=grpcs://mordenite.cluster.engflow.com
+common:cache-envoy-engflow --remote_timeout=3600s
+common:bes-envoy-engflow --bes_backend=grpcs://mordenite.cluster.engflow.com/
+common:bes-envoy-engflow --bes_results_url=https://mordenite.cluster.engflow.com/invocation/
+common:bes-envoy-engflow --bes_timeout=3600s
+common:bes-envoy-engflow --bes_upload_mode=fully_async
+common:bes-envoy-engflow --nolegacy_important_outputs
+common:rbe-envoy-engflow --remote_executor=grpcs://mordenite.cluster.engflow.com
+common:rbe-envoy-engflow --remote_default_exec_properties=container-image=docker://gcr.io/envoy-ci/envoy-build@sha256:7adc40c09508f957624c4d2e0f5aeecb73a59207ee6ded53b107eac828c091b2
+common:rbe-envoy-engflow --jobs=200
+common:rbe-envoy-engflow --define=engflow_rbe=true
 
-build:remote-envoy-engflow --config=common-envoy-engflow
-build:remote-envoy-engflow --config=cache-envoy-engflow
-build:remote-envoy-engflow --config=rbe-envoy-engflow
+common:remote-envoy-engflow --config=common-envoy-engflow
+common:remote-envoy-engflow --config=cache-envoy-engflow
+common:remote-envoy-engflow --config=rbe-envoy-engflow
 
 #############################################################################
 # debug: Various Bazel debugging flags

--- a/.github/workflows/_check_build.yml
+++ b/.github/workflows/_check_build.yml
@@ -5,7 +5,14 @@ permissions:
 
 on:
   workflow_call:
+    secrets:
+      gcs-cache-key:
+        required: true
+
     inputs:
+      gcs-cache-bucket:
+        type: string
+        required: true
       request:
         type: string
         required: true
@@ -20,6 +27,8 @@ concurrency:
 
 jobs:
   build:
+    secrets:
+      gcs-cache-key: ${{ secrets.gcs-cache-key }}
     permissions:
       contents: read
       packages: read
@@ -33,6 +42,7 @@ jobs:
         ERROR
         error:
         Error:
+      gcs-cache-bucket: ${{ inputs.gcs-cache-bucket }}
       rbe: true
       request: ${{ inputs.request }}
       target: ${{ matrix.target }}

--- a/.github/workflows/_check_coverage.yml
+++ b/.github/workflows/_check_coverage.yml
@@ -6,9 +6,15 @@ permissions:
 on:
   workflow_call:
     secrets:
+      gcs-cache-key:
+        required: true
       gcp-key:
         required: true
+
     inputs:
+      gcs-cache-bucket:
+        type: string
+        required: true
       request:
         type: string
         required: true
@@ -24,6 +30,7 @@ concurrency:
 jobs:
   coverage:
     secrets:
+      gcs-cache-key: ${{ secrets.gcs-cache-key }}
       gcp-key: ${{ secrets.gcp-key }}
     permissions:
       contents: read
@@ -41,6 +48,7 @@ jobs:
         error:
         Error:
         lower than limit
+      gcs-cache-bucket: ${{ inputs.gcs-cache-bucket }}
       rbe: true
       request: ${{ inputs.request }}
       steps-post: |

--- a/.github/workflows/_check_san.yml
+++ b/.github/workflows/_check_san.yml
@@ -5,7 +5,14 @@ permissions:
 
 on:
   workflow_call:
+    secrets:
+      gcs-cache-key:
+        required: true
+
     inputs:
+      gcs-cache-bucket:
+        type: string
+        required: true
       request:
         type: string
         required: true
@@ -20,6 +27,8 @@ concurrency:
 
 jobs:
   san:
+    secrets:
+      gcs-cache-key: ${{ secrets.gcs-cache-key }}
     permissions:
       contents: read
       packages: read
@@ -34,6 +43,7 @@ jobs:
         ERROR
         error:
         Error:
+      gcs-cache-bucket: ${{ inputs.gcs-cache-bucket }}
       rbe: ${{ matrix.rbe }}
       target: ${{ matrix.target }}
       timeout-minutes: 180

--- a/.github/workflows/_precheck_deps.yml
+++ b/.github/workflows/_precheck_deps.yml
@@ -5,10 +5,16 @@ permissions:
 
 on:
   workflow_call:
+    secrets:
+      gcs-cache-key:
+        required: true
     inputs:
       dependency-review:
         type: boolean
         default: false
+      gcs-cache-bucket:
+        type: string
+        required: true
       request:
         type: string
         required: true
@@ -23,6 +29,8 @@ concurrency:
 
 jobs:
   deps:
+    secrets:
+      gcs-cache-key: ${{ secrets.gcs-cache-key }}
     permissions:
       contents: read
       packages: read
@@ -32,6 +40,7 @@ jobs:
       bazel-extra: '--config=remote-envoy-engflow'
       cache-build-image: ${{ fromJSON(inputs.request).request.build-image.default }}
       concurrency-suffix: -${{ matrix.target }}
+      gcs-cache-bucket: ${{ inputs.gcs-cache-bucket }}
       request: ${{ inputs.request }}
       error-match: |
         ERROR

--- a/.github/workflows/_precheck_format.yml
+++ b/.github/workflows/_precheck_format.yml
@@ -5,13 +5,20 @@ permissions:
 
 on:
   workflow_call:
+    secrets:
+      gcs-cache-key:
+        required: true
     inputs:
+      gcs-cache-bucket:
+        type: string
+        required: true
       request:
         type: string
         required: true
       trusted:
         type: boolean
         required: true
+
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}-${{ github.workflow }}-format
@@ -20,6 +27,8 @@ concurrency:
 
 jobs:
   format:
+    secrets:
+      gcs-cache-key: ${{ secrets.gcs-cache-key }}
     permissions:
       contents: read
       packages: read
@@ -29,6 +38,7 @@ jobs:
       bazel-extra: '--config=remote-envoy-engflow'
       cache-build-image: ${{ fromJSON(inputs.request).request.build-image.default }}
       concurrency-suffix: -${{ matrix.target }}
+      gcs-cache-bucket: ${{ inputs.gcs-cache-bucket }}
       request: ${{ inputs.request }}
       error-match: |
         ERROR

--- a/.github/workflows/_precheck_publish.yml
+++ b/.github/workflows/_precheck_publish.yml
@@ -8,7 +8,12 @@ on:
     secrets:
       gcp-key:
         required: true
+      gcs-cache-key:
+        required: true
     inputs:
+      gcs-cache-bucket:
+        type: string
+        required: true
       request:
         type: string
         required: true
@@ -25,16 +30,19 @@ jobs:
   publish:
     secrets:
       gcp-key: ${{ secrets.gcp-key }}
+      gcs-cache-key: ${{ secrets.gcs-cache-key }}
     permissions:
       contents: read
       packages: read
     uses: ./.github/workflows/_run.yml
     name: ${{ matrix.name || matrix.target }}
     with:
+      arch: ${{ matrix.arch }}
       bazel-extra: ${{ matrix.bazel-extra || '--config=remote-envoy-engflow' }}
       cache-build-image: ${{ fromJSON(inputs.request).request.build-image.default }}
       cache-build-image-key-suffix: ${{ matrix.arch == 'arm64' && '-arm64' || '' }}
       concurrency-suffix: -${{ matrix.target }}${{ matrix.arch && format('-{0}', matrix.arch) || '' }}
+      gcs-cache-bucket: ${{ inputs.gcs-cache-bucket }}
       gcs-only: "true"
       rbe: ${{ matrix.rbe }}
       request: ${{ inputs.request }}

--- a/.github/workflows/_publish_build.yml
+++ b/.github/workflows/_publish_build.yml
@@ -10,11 +10,16 @@ on:
         required: false
       dockerhub-password:
         required: false
+      gcs-cache-key:
+        required: true
       gpg-key:
         required: true
       gpg-key-password:
         required: true
     inputs:
+      gcs-cache-bucket:
+        type: string
+        required: true
       request:
         type: string
         required: true
@@ -33,18 +38,22 @@ concurrency:
 
 jobs:
   binary:
+    secrets:
+      gcs-cache-key: ${{ secrets.gcs-cache-key }}
     permissions:
       contents: read
       packages: read
     name: ${{ matrix.name || matrix.target }}
     uses: ./.github/workflows/_run.yml
     with:
+      arch: ${{ matrix.arch }}
       bazel-extra: ${{ matrix.bazel-extra }}
       target: ${{ matrix.target }}
       target-suffix: ${{ matrix.arch }}
       cache-build-image: ${{ fromJSON(inputs.request).request.build-image.default }}
       cache-build-image-key-suffix: ${{ matrix.arch == 'arm64' && format('-{0}', matrix.arch) || '' }}
       concurrency-suffix: -${{ matrix.arch }}
+      gcs-cache-bucket: ${{ inputs.gcs-cache-bucket }}
       rbe: ${{ matrix.rbe }}
       request: ${{ inputs.request }}
       runs-on: ${{ matrix.runs-on }}
@@ -78,6 +87,7 @@ jobs:
       contents: read
       packages: read
     secrets:
+      gcs-cache-key: ${{ secrets.gcs-cache-key }}
       gpg-key: ${{ secrets.gpg-key }}
       gpg-key-password: ${{ secrets.gpg-key-password }}
     name: ${{ matrix.name || matrix.target }}
@@ -85,6 +95,7 @@ jobs:
     - binary
     uses: ./.github/workflows/_run.yml
     with:
+      arch: ${{ matrix.arch }}
       bazel-extra: >-
         --config=cache-envoy-engflow
         --config=common-envoy-engflow
@@ -96,6 +107,7 @@ jobs:
       cache-build-image: ${{ fromJSON(inputs.request).request.build-image.default }}
       cache-build-image-key-suffix: ${{ matrix.cache-build-image-key-suffix }}
       concurrency-suffix: -${{ matrix.arch }}
+      gcs-cache-bucket: ${{ inputs.gcs-cache-bucket }}
       import-gpg: true
       rbe: false
       request: ${{ inputs.request }}
@@ -155,6 +167,7 @@ jobs:
       contents: read
       packages: read
     secrets:
+      gcs-cache-key: ${{ secrets.gcs-cache-key }}
       gpg-key: ${{ secrets.gpg-key }}
       gpg-key-password: ${{ secrets.gpg-key-password }}
     name: ${{ matrix.name || matrix.target }}
@@ -174,6 +187,7 @@ jobs:
         packages.x64: envoy/x64/
         release.arm64: envoy/arm64/bin/
         release.x64: envoy/x64/bin/
+      gcs-cache-bucket: ${{ inputs.gcs-cache-bucket }}
       import-gpg: true
       request: ${{ inputs.request }}
       runs-on: ubuntu-24.04

--- a/.github/workflows/_publish_publish.yml
+++ b/.github/workflows/_publish_publish.yml
@@ -10,7 +10,12 @@ on:
       ENVOY_CI_SYNC_APP_KEY:
       ENVOY_CI_PUBLISH_APP_ID:
       ENVOY_CI_PUBLISH_APP_KEY:
+      gcs-cache-key:
+        required: true
     inputs:
+      gcs-cache-bucket:
+        type: string
+        required: true
       request:
         type: string
         required: true
@@ -32,6 +37,7 @@ jobs:
     secrets:
       app-id: ${{ inputs.trusted && secrets.ENVOY_CI_PUBLISH_APP_ID || '' }}
       app-key: ${{ inputs.trusted && secrets.ENVOY_CI_PUBLISH_APP_KEY || '' }}
+      gcs-cache-key: ${{ secrets.gcs-cache-key }}
     permissions:
       contents: read
       packages: read
@@ -43,6 +49,7 @@ jobs:
       cache-build-image: ${{ fromJSON(inputs.request).request.build-image.default }}
       downloads: |
         release.signed: release.signed
+      gcs-cache-bucket: ${{ inputs.gcs-cache-bucket }}
       source: ${{ matrix.source }}
       request: ${{ inputs.request }}
       steps-pre: ${{ matrix.steps-pre }}

--- a/.github/workflows/_publish_verify.yml
+++ b/.github/workflows/_publish_verify.yml
@@ -5,7 +5,13 @@ permissions:
 
 on:
   workflow_call:
+    secrets:
+      gcs-cache-key:
+        required: true
     inputs:
+      gcs-cache-bucket:
+        type: string
+        required: true
       request:
         type: string
         required: true
@@ -79,12 +85,15 @@ jobs:
               shell: bash
 
   distro:
+    secrets:
+      gcs-cache-key: ${{ secrets.gcs-cache-key }}
     permissions:
       contents: read
       packages: read
     name: ${{ matrix.name || matrix.target }}
     uses: ./.github/workflows/_run.yml
     with:
+      arch: ${{ matrix.arch }}
       bazel-extra: ${{ matrix.bazel-extra || '--config=remote-envoy-engflow' }}
       cache-build-image: ${{ fromJSON(inputs.request).request.build-image.default }}
       cache-build-image-key-suffix: ${{ matrix.arch == 'arm64' && format('-{0}', matrix.arch) || '' }}
@@ -92,6 +101,7 @@ jobs:
       concurrency-suffix: -${{ matrix.arch || 'x64' }}
       downloads: |
         release.signed: release.signed
+      gcs-cache-bucket: ${{ inputs.gcs-cache-bucket }}
       rbe: ${{ matrix.rbe && matrix.rbe || false }}
       request: ${{ inputs.request }}
       runs-on: ${{ matrix.runs-on || 'ubuntu-24.04' }}

--- a/.github/workflows/_request.yml
+++ b/.github/workflows/_request.yml
@@ -14,9 +14,20 @@ on:
         required: true
       lock-app-key:
         required: true
+      gcs-cache-key:
+        required: true
 
     # Defaults are set .github/config.yml on the `main` branch.
     inputs:
+      gcs-cache-bucket:
+        type: string
+        required: true
+
+      cache-bazel-hash-paths:
+        type: string
+        default: |
+          WORKSPACE
+          **/*.bzl
       config-file:
         type: string
         default: ./.github/config.yml
@@ -54,12 +65,13 @@ jobs:
           now
     - uses: envoyproxy/toolshed/gh-actions/github/checkout@actions-v0.3.5
       id: checkout
-      name: Checkout Envoy repository
+      name: Checkout Envoy repository (requested)
       with:
         pr: ${{ github.event.number }}
         branch: ${{ github.ref_name }}
         config: |
           fetch-depth: ${{ startsWith(github.event_name, 'pull_request') && 1 || 2 }}
+          path: requested
     # This step *LOOKS AT* the repo at the point requested
     # Its essential that this _job_ *MUST NOT EXECUTE ANY CODE FROM THE CHECKED OUT REPO*
     # *ALL* variables collected should be treated as untrusted and should be sanitized before
@@ -74,6 +86,22 @@ jobs:
         started: ${{ steps.started.outputs.value }}
         token: ${{ secrets.GITHUB_TOKEN }}
         vars: ${{ toJSON(vars) }}
+        working-directory: requested
+
+    - uses: envoyproxy/toolshed/gh-actions/github/checkout@actions-v0.3.5
+      id: checkout-target
+      name: Checkout Envoy repository (target branch)
+      with:
+        branch: ${{ fromJSON(steps.env.outputs.data).request.target-branch }}
+        config: |
+          fetch-depth: 1
+          path: target
+    - uses: envoyproxy/toolshed/gh-actions/hashfiles@actions-v0.3.5
+      id: bazel-cache-hash
+      name: Bazel cache hash
+      with:
+        files: ${{ inputs.cache-bazel-hash-paths }}
+        working-directory: target
 
     - name: Request summary
       id: summary
@@ -97,6 +125,8 @@ jobs:
       id: data
       with:
         input: |
+          cache:
+            bazel: ${{ steps.bazel-cache-hash.outputs.value }}
           env: ${{ steps.env.outputs.data }}
           title: ${{ steps.summary.outputs.title }}
           link: ${{ format('https://github.com/{0}/actions/runs/{1}', github.repository, github.run_id) }}
@@ -104,11 +134,13 @@ jobs:
         input-format: yaml
         filter: |
           .title as $title
+          | .cache as $cache
           | .env.config.envoy.icon as $icon
           | .link as $link
           | "\($icon) Request ([\($title)](\($link)))" as $linkedTitle
           | .summary as $summary
           | .env
+          | .config.ci.cache = $cache
           | .summary = {
               $summary,
               $title,
@@ -116,6 +148,7 @@ jobs:
               "linked-title": $linkedTitle}
           | del(.config.tables)
 
+    # TODO(phlax): shift this to ci/request action above
     - name: Check Docker cache (x64)
       id: cache-exists-docker-x64
       uses: actions/cache/restore@6849a6489940f00c2f30c0fb92c6274307ccb58a  # v4.1.2
@@ -131,26 +164,52 @@ jobs:
         path: /tmp/cache
         key: ${{ fromJSON(steps.data.outputs.value).request.build-image.default }}-arm64
 
+    - uses: envoyproxy/toolshed/gh-actions/gcp/setup@actions-v0.3.5
+      name: Setup GCP
+      with:
+        key: ${{ secrets.gcs-cache-key }}
+
+    - uses: envoyproxy/toolshed/gh-actions/gcs/cache/exists@actions-v0.3.5
+      name: Check GCS bucket cache (x64)
+      id: cache-exists-bazel-x64
+      with:
+        bucket: ${{ inputs.gcs-cache-bucket }}
+        key: ${{ fromJSON(steps.data.outputs.value).config.ci.cache.bazel }}-x64
+    - uses: envoyproxy/toolshed/gh-actions/gcs/cache/exists@actions-v0.3.5
+      name: Check GCS bucket cache (arm64)
+      id: cache-exists-bazel-arm64
+      with:
+        bucket: ${{ inputs.gcs-cache-bucket }}
+        key: ${{ fromJSON(steps.data.outputs.value).config.ci.cache.bazel }}-arm64
+
     - name: Caches
       uses: envoyproxy/toolshed/gh-actions/jq@actions-v0.3.5
       id: caches
       with:
         input-format: yaml
         input: |
+          bazel:
+            x64: ${{ steps.cache-exists-bazel-x64.outputs.exists || 'false' }}
+            arm64: ${{ steps.cache-exists-bazel-arm64.outputs.exists || 'false' }}
           docker:
             x64: ${{ steps.cache-exists-docker-x64.outputs.cache-hit || 'false' }}
             arm64: ${{ steps.cache-exists-docker-arm64.outputs.cache-hit || 'false' }}
 
   cache:
+    permissions:
+      contents: read
+      packages: read
     if: ${{ github.repository == 'envoyproxy/envoy' || vars.ENVOY_CI }}
     needs: incoming
     uses: ./.github/workflows/_request_cache.yml
     secrets:
       app-id: ${{ secrets.lock-app-id }}
       app-key: ${{ secrets.lock-app-key }}
+      gcs-cache-key: ${{ secrets.gcs-cache-key }}
     with:
       caches: ${{ needs.incoming.outputs.caches }}
       env: ${{ needs.incoming.outputs.env }}
+      gcs-cache-bucket: ${{ inputs.gcs-cache-bucket }}
 
   checks:
     if: ${{ github.repository == 'envoyproxy/envoy' || vars.ENVOY_CI }}

--- a/.github/workflows/_request_cache.yml
+++ b/.github/workflows/_request_cache.yml
@@ -10,12 +10,17 @@ on:
         required: true
       app-key:
         required: true
+      gcs-cache-key:
+        required: true
 
     inputs:
       env:
         type: string
         required: true
       caches:
+        type: string
+        required: true
+      gcs-cache-bucket:
         type: string
         required: true
 
@@ -43,3 +48,39 @@ jobs:
           arch: arm64
           cache-suffix: -arm64
           runs-on: envoy-arm64-small
+
+  bazel:
+    permissions:
+      contents: read
+      packages: read
+    secrets:
+      app-id: ${{ secrets.app-id }}
+      app-key: ${{ secrets.app-key }}
+      gcs-cache-key: ${{ secrets.gcs-cache-key }}
+    name: ${{ matrix.name || matrix.target }}
+    uses: ./.github/workflows/_request_cache_bazel.yml
+    with:
+      arch: ${{ matrix.arch || 'x64' }}
+      bazel-extra: ${{ matrix.bazel-extra }}
+      caches: ${{ inputs.caches }}
+      gcs-cache-bucket: ${{ inputs.gcs-cache-bucket }}
+      request: ${{ inputs.env }}
+      runs-on: ${{ matrix.runs-on }}
+      targets: ${{ matrix.targets || '...' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - name: Bazel (x64/cache)
+          bazel-extra: >-
+            --config=remote-clang-libc++
+            --config=remote-envoy-engflow
+        - name: Bazel (arm64/cache)
+          arch: arm64
+          runs-on: envoy-arm64-small
+          bazel-extra: >-
+             --config=clang-libc++
+             --config=common-envoy-engflow
+             --config=cache-envoy-engflow
+          targets: >-
+            //test/...

--- a/.github/workflows/_request_cache_bazel.yml
+++ b/.github/workflows/_request_cache_bazel.yml
@@ -1,0 +1,106 @@
+name: Request/Cache prime (bazel)
+
+permissions:
+  contents: read
+
+on:
+  workflow_call:
+    secrets:
+      app-id:
+        required: true
+      app-key:
+        required: true
+      gcs-cache-key:
+        required: true
+
+    inputs:
+      gcs-cache-bucket:
+        type: string
+        required: true
+
+      arch:
+        type: string
+        default: x64
+      bazel-extra:
+        type: string
+        default: >-
+          --config=remote-envoy-engflow
+      caches:
+        type: string
+        required: true
+      request:
+        type: string
+        required: true
+      runs-on:
+        type: string
+        default: ubuntu-24.04
+      lock-repository:
+        type: string
+        default: envoyproxy/ci-mutex
+      targets:
+        type: string
+        default: ...
+
+
+jobs:
+  bazel:
+    permissions:
+      contents: read
+      packages: read
+    runs-on: ${{ inputs.runs-on || 'ubuntu-24.04' }}
+    name: "[${{ inputs.arch }}] Prime Bazel cache"
+    if: ${{ ! fromJSON(inputs.caches).bazel[inputs.arch] }}
+    steps:
+    - uses: envoyproxy/toolshed/gh-actions/github/checkout@actions-v0.3.5
+      id: checkout-target
+      name: Checkout Envoy repository (target branch)
+      with:
+        branch: ${{ fromJSON(inputs.request).request.target-branch }}
+        config: |
+          fetch-depth: 1
+
+    - uses: envoyproxy/toolshed/gh-actions/appauth@actions-v0.3.5
+      id: appauth
+      name: Appauth (mutex lock)
+      with:
+        app_id: ${{ secrets.app-id }}
+        key: ${{ secrets.app-key }}
+
+    - uses: envoyproxy/toolshed/gh-actions/gcp/setup@actions-v0.3.5
+      name: Setup GCP
+      with:
+        key: ${{ secrets.gcs-cache-key }}
+    - run: |
+        # Simulate container build directory
+        sudo mkdir /build
+        sudo chown runner:docker /build
+        echo "GITHUB_TOKEN=${{ github.token }}" >> $GITHUB_ENV
+    - uses: envoyproxy/toolshed/gh-actions/cache/prime@actions-v0.3.5
+      id: bazel-cache
+      name: Prime Bazel cache
+      with:
+        change-directory: false
+        # TODO(phlax): add loop for multiple targets
+        command: |
+          # Simulate container source directory
+          sudo mkdir /source
+          sudo chown runner:docker /source
+          cd /source
+          git clone "$GITHUB_WORKSPACE" .
+
+          echo "Fetching: ${{ inputs.targets }}"
+          # ironically the repository_cache is just about the only thing you dont want to cache
+          bazel --output_user_root=/build/bazel_root \
+                --output_base=/build/bazel_root/base \
+                aquery "deps(${{ inputs.targets }})" \
+                --config=ci \
+                --repository_cache=/tmp/cache \
+                ${{ inputs.bazel-extra }} \
+                > /dev/null
+        gcs-bucket: ${{ inputs.gcs-cache-bucket }}
+        key: ${{ fromJSON(inputs.request).config.ci.cache.bazel }}-${{ inputs.arch }}
+        lock-token: ${{ steps.appauth.outputs.token }}
+        lock-repository: ${{ inputs.lock-repository }}
+        mount-tmpfs: false
+        path: /build/bazel_root
+        run-as-sudo: false

--- a/.github/workflows/_run.yml
+++ b/.github/workflows/_run.yml
@@ -11,6 +11,7 @@ on:
       dockerhub-username:
       dockerhub-password:
       gcp-key:
+      gcs-cache-key:
       gpg-key:
       gpg-key-password:
       rbe-key:
@@ -68,6 +69,8 @@ on:
           error:
           Error:
       fail-match:
+        type: string
+      gcs-cache-bucket:
         type: string
       gcs-only:
         type: string
@@ -239,12 +242,27 @@ jobs:
              "job-started": ${{ steps.started.outputs.value }}}
           | . * {$config, $check}
 
+    # Caches
+    - uses: envoyproxy/toolshed/gh-actions/gcp/setup@actions-v0.3.5
+      name: Setup GCP (cache)
+      if: ${{ inputs.gcs-cache-bucket }}
+      with:
+        key: ${{ secrets.gcs-cache-key }}
     - if: ${{ inputs.cache-build-image }}
       name: Restore Docker cache ${{ inputs.cache-build-image && format('({0})', inputs.cache-build-image) || '' }}
       uses: envoyproxy/toolshed/gh-actions/docker/cache/restore@actions-v0.3.5
       with:
         image-tag: ${{ inputs.cache-build-image }}
         key-suffix: ${{ inputs.cache-build-image-key-suffix }}
+    - uses: envoyproxy/toolshed/gh-actions/cache/restore@actions-v0.3.5
+      if: ${{ inputs.gcs-cache-bucket }}
+      name: >-
+        Restore Bazel cache
+        (${{ fromJSON(inputs.request).config.ci.cache.bazel }})
+      with:
+        gcs-bucket: ${{ inputs.gcs-cache-bucket }}
+        key: ${{ fromJSON(inputs.request).config.ci.cache.bazel }}-${{ inputs.arch || 'x64' }}
+        path: ${{ runner.temp }}/bazel_root
 
     - uses: envoyproxy/toolshed/gh-actions/appauth@actions-v0.3.5
       id: appauth
@@ -298,27 +316,30 @@ jobs:
           "fixed-cidr-v6": "2001:db8:1::/64"
           }' | sudo tee /etc/docker/daemon.json
         sudo service docker restart
+      name: Configure Docker ipv6
       if: ${{ inputs.docker-ipv6 }}
 
     - run: |
         echo "e3b4a6e9570da15ac1caffdded17a8bebdc7dfc9" > .BAZEL_FAKE_SCM_REVISION
       if: >-
-        ${{ fromJSON(inputs.request).request.pr == '' }}
-
+        ${{ fromJSON(inputs.request).request.pr != '' }}
+    - uses: envoyproxy/toolshed/gh-actions/gcp/setup@actions-v0.3.5
+      name: Setup GCP (artefacts/rbe)
+      id: gcp
+      with:
+        key: ${{ secrets.gcp-key }}
+        boto: false
+        boto-rm: true
     - run: |
-        if [[ "${{ secrets.gcp-key }}" == "" ]]; then
-            exit 0
-        fi
-        GCP_SERVICE_ACCOUNT_KEY_PATH=$(mktemp -p "${{ runner.temp }}" -t gcp_service_account.XXXXXX.json)
-        echo "${{ secrets.gcp-key }}" | base64 --decode > "${GCP_SERVICE_ACCOUNT_KEY_PATH}"
-        GCP_SERVICE_ACCOUNT_KEY_FILE="$(basename "${GCP_SERVICE_ACCOUNT_KEY_PATH}")"
+        mv "${{ steps.gcp.outputs.key-path }}" "${{ runner.temp }}"
+        GCP_SERVICE_ACCOUNT_KEY_FILE="$(basename "${{ steps.gcp.outputs.key-path }}")"
         echo "GCP_SERVICE_ACCOUNT_KEY_PATH=/build/${GCP_SERVICE_ACCOUNT_KEY_FILE}" >> "$GITHUB_ENV"
         if [[ "${{ inputs.gcs-only }}" != "" ]]; then
             exit 0
         fi
         BAZEL_BUILD_EXTRA_OPTIONS="--google_credentials=/build/${GCP_SERVICE_ACCOUNT_KEY_FILE} --config=rbe-google"
         echo "BAZEL_BUILD_EXTRA_OPTIONS=${BAZEL_BUILD_EXTRA_OPTIONS}" >> "$GITHUB_ENV"
-
+      if: ${{ steps.gcp.outputs.key-path }}
     - run: |
         echo "${{ vars.ENVOY_CI_BAZELRC }}" > repo.bazelrc
       if: ${{ vars.ENVOY_CI_BAZELRC }}

--- a/.github/workflows/envoy-checks.yml
+++ b/.github/workflows/envoy-checks.yml
@@ -44,6 +44,8 @@ jobs:
       # head-sha: ${{ github.sha }}
 
   build:
+    secrets:
+      gcs-cache-key: ${{ secrets.GCS_CACHE_KEY }}
     permissions:
       actions: read
       contents: read
@@ -55,11 +57,13 @@ jobs:
     needs:
     - load
     with:
+      gcs-cache-bucket: ${{ vars.ENVOY_CACHE_BUCKET }}
       request: ${{ needs.load.outputs.request }}
       trusted: ${{ fromJSON(needs.load.outputs.trusted) }}
 
   coverage:
     secrets:
+      gcs-cache-key: ${{ secrets.GCS_CACHE_KEY }}
       gcp-key: ${{ fromJSON(needs.load.outputs.trusted) && secrets.GCP_SERVICE_ACCOUNT_KEY_TRUSTED || secrets.GCP_SERVICE_ACCOUNT_KEY }}
     permissions:
       actions: read
@@ -72,10 +76,13 @@ jobs:
     needs:
     - load
     with:
+      gcs-cache-bucket: ${{ vars.ENVOY_CACHE_BUCKET }}
       request: ${{ needs.load.outputs.request }}
       trusted: ${{ fromJSON(needs.load.outputs.trusted) }}
 
   san:
+    secrets:
+      gcs-cache-key: ${{ secrets.GCS_CACHE_KEY }}
     permissions:
       actions: read
       contents: read
@@ -87,6 +94,7 @@ jobs:
     needs:
     - load
     with:
+      gcs-cache-bucket: ${{ vars.ENVOY_CACHE_BUCKET }}
       request: ${{ needs.load.outputs.request }}
       trusted: ${{ fromJSON(needs.load.outputs.trusted) }}
 

--- a/.github/workflows/envoy-prechecks.yml
+++ b/.github/workflows/envoy-prechecks.yml
@@ -39,6 +39,8 @@ jobs:
       check-name: prechecks
 
   format:
+    secrets:
+      gcs-cache-key: ${{ secrets.GCS_CACHE_KEY }}
     permissions:
       actions: read
       contents: read
@@ -50,10 +52,13 @@ jobs:
     needs:
     - load
     with:
+      gcs-cache-bucket: ${{ vars.ENVOY_CACHE_BUCKET }}
       request: ${{ needs.load.outputs.request }}
       trusted: ${{ fromJSON(needs.load.outputs.trusted) }}
 
   deps:
+    secrets:
+      gcs-cache-key: ${{ secrets.GCS_CACHE_KEY }}
     permissions:
       actions: read
       contents: read
@@ -65,6 +70,7 @@ jobs:
     needs:
     - load
     with:
+      gcs-cache-bucket: ${{ vars.ENVOY_CACHE_BUCKET }}
       dependency-review: ${{ github.event_name == 'pull_request_target' && github.repository == 'envoyproxy/envoy' }}
       request: ${{ needs.load.outputs.request }}
       trusted: ${{ fromJSON(needs.load.outputs.trusted) }}
@@ -72,6 +78,7 @@ jobs:
   publish:
     secrets:
       gcp-key: ${{ fromJSON(needs.load.outputs.trusted) && secrets.GCP_SERVICE_ACCOUNT_KEY_TRUSTED || secrets.GCP_SERVICE_ACCOUNT_KEY }}
+      gcs-cache-key: ${{ secrets.GCS_CACHE_KEY }}
     permissions:
       actions: read
       contents: read
@@ -83,6 +90,7 @@ jobs:
     needs:
     - load
     with:
+      gcs-cache-bucket: ${{ vars.ENVOY_CACHE_BUCKET }}
       request: ${{ needs.load.outputs.request }}
       trusted: ${{ fromJSON(needs.load.outputs.trusted) }}
 

--- a/.github/workflows/envoy-publish.yml
+++ b/.github/workflows/envoy-publish.yml
@@ -59,6 +59,7 @@ jobs:
         ${{ fromJSON(needs.load.outputs.trusted)
             && secrets.DOCKERHUB_PASSWORD
             || '' }}
+      gcs-cache-key: ${{ secrets.GCS_CACHE_KEY }}
       gpg-key: ${{ fromJSON(needs.load.outputs.trusted) && secrets.ENVOY_GPG_MAINTAINER_KEY || secrets.ENVOY_GPG_SNAKEOIL_KEY }}
       gpg-key-password: >-
         ${{ fromJSON(needs.load.outputs.trusted)
@@ -70,6 +71,7 @@ jobs:
     uses: ./.github/workflows/_publish_build.yml
     name: Build
     with:
+      gcs-cache-bucket: ${{ vars.ENVOY_CACHE_BUCKET }}
       request: ${{ needs.load.outputs.request }}
       trusted: ${{ fromJSON(needs.load.outputs.trusted) }}
 
@@ -79,6 +81,7 @@ jobs:
       ENVOY_CI_SYNC_APP_KEY: ${{ fromJSON(needs.load.outputs.trusted) && secrets.ENVOY_CI_SYNC_APP_KEY || '' }}
       ENVOY_CI_PUBLISH_APP_ID: ${{ fromJSON(needs.load.outputs.trusted) && secrets.ENVOY_CI_PUBLISH_APP_ID || '' }}
       ENVOY_CI_PUBLISH_APP_KEY: ${{ fromJSON(needs.load.outputs.trusted) && secrets.ENVOY_CI_PUBLISH_APP_KEY || '' }}
+      gcs-cache-key: ${{ secrets.GCS_CACHE_KEY }}
     permissions:
       contents: read
       packages: read
@@ -89,10 +92,13 @@ jobs:
     uses: ./.github/workflows/_publish_publish.yml
     name: Publish
     with:
+      gcs-cache-bucket: ${{ vars.ENVOY_CACHE_BUCKET }}
       request: ${{ needs.load.outputs.request }}
       trusted: ${{ fromJSON(needs.load.outputs.trusted) }}
 
   verify:
+    secrets:
+      gcs-cache-key: ${{ secrets.GCS_CACHE_KEY }}
     permissions:
       contents: read
       packages: read
@@ -103,6 +109,7 @@ jobs:
     uses: ./.github/workflows/_publish_verify.yml
     name: Verify
     with:
+      gcs-cache-bucket: ${{ vars.ENVOY_CACHE_BUCKET }}
       request: ${{ needs.load.outputs.request }}
       trusted: ${{ fromJSON(needs.load.outputs.trusted) }}
 

--- a/.github/workflows/request.yml
+++ b/.github/workflows/request.yml
@@ -36,6 +36,9 @@ jobs:
       app-id: ${{ secrets.ENVOY_CI_APP_ID }}
       lock-app-key: ${{ secrets.ENVOY_CI_MUTEX_APP_KEY }}
       lock-app-id: ${{ secrets.ENVOY_CI_MUTEX_APP_ID }}
+      gcs-cache-key: ${{ secrets.GCS_CACHE_WRITE_KEY }}
+    with:
+      gcs-cache-bucket: ${{ vars.ENVOY_CACHE_BUCKET }}
     # For branches this can be pinned to a specific version if required
     # NB: `uses` cannot be dynamic so it _must_ be hardcoded anywhere it is read
     uses: envoyproxy/envoy/.github/workflows/_request.yml@main


### PR DESCRIPTION
This readds bazel client caching which was lost in migration

It should resolve the issue of failing downloads (kafka/node) in build tests - if for some reason it doesnt initially, we can tweak to ensure it does

I gave up on trying to use the github actions cache as its too size-constrained so it was never going to work - so instead it uses a GCS bucket. 

The connection to GCP seems a bit slower than the github cache, but the implementation is faster so overall caching seems to be faster with GCS.

The time required to restore caches is easily offset by speedups in actual jobs - so adding this should be an optimization

Unlike the previous system it always caches against the target branch (`main`/`release/*`)  and ignores any changes in a PR

It also creates one cache per arch and not tailored caches for each job which saves a lot disk space and complexity, but it also means that individual jobs use more disk space

Probably what its caching can be tweaked/optimized and there are some other things we probably want to add - eg bazelisk

Fix #36340