### PR TITLE
lua cluster_specifier: fix lua reference for multiple clusters

### DIFF
--- a/source/extensions/filters/common/lua/lua.h
+++ b/source/extensions/filters/common/lua/lua.h
@@ -263,6 +263,15 @@ public:
     reset(object, leave_on_stack);
   }
 
+  LuaRef(const LuaRef&) = delete;
+
+  LuaRef(LuaRef&& that) {
+    object_ = that.object_;
+    ref_ = that.ref_;
+    that.object_ = std::pair<T*, lua_State*>{};
+    that.ref_ = LUA_NOREF;
+  }
+
   ~LuaRef() { unref(); }
   T* get() { return object_.first; }
 
@@ -317,6 +326,9 @@ protected:
 template <typename T> class LuaDeathRef : public LuaRef<T> {
 public:
   using LuaRef<T>::LuaRef;
+
+  LuaDeathRef(const LuaDeathRef&) = delete;
+  LuaDeathRef(LuaDeathRef&&) = default;
 
   ~LuaDeathRef() { markDead(); }
 


### PR DESCRIPTION
When Lua scripts called `getCluster` multiple times, earlier Lua references could become invalidated.

This was because the references were stored in a vector, and when the vector is resized, the references were copied (not moved), and the destructor of the old reference would mark the lua object as dead.

Risk Level: Low
Testing: Added tests
Release Notes: none-this feature is only three days old
