### PR TITLE
Remove race between closing upstream connection and downstream request

### DIFF
--- a/test/integration/http_integration.h
+++ b/test/integration/http_integration.h
@@ -196,7 +196,12 @@ protected:
       const Http::TestResponseHeaderMapImpl& response_headers, uint32_t response_body_size,
       uint64_t upstream_index = 0, std::chrono::milliseconds timeout = TestUtility::DefaultTimeout);
 
-  IntegrationStreamDecoderPtr sendRequestAndWaitForResponse(
+  struct Result {
+    IntegrationStreamDecoderPtr response;
+    absl::optional<uint64_t> upstream_index;
+  };
+
+  Result sendRequestAndWaitForResponse(
       const Http::TestRequestHeaderMapImpl& request_headers, uint32_t request_body_size,
       const Http::TestResponseHeaderMapImpl& response_headers, uint32_t response_body_size,
       const std::vector<uint64_t>& upstream_indices,

--- a/test/integration/weighted_cluster_integration_test.cc
+++ b/test/integration/weighted_cluster_integration_test.cc
@@ -80,19 +80,23 @@ public:
     // Send the request headers from the client, wait until they are received
     // upstream. When they are received, send the default response headers from
     // upstream and wait until they are received at by client.
-    IntegrationStreamDecoderPtr response = sendRequestAndWaitForResponse(
-        request_headers, 0, default_response_headers_, 0, upstream_indices);
+    Result result = sendRequestAndWaitForResponse(request_headers, 0, default_response_headers_, 0,
+                                                  upstream_indices);
 
     // Verify the proxied request was received upstream, as expected.
     EXPECT_TRUE(upstream_request_->complete());
     EXPECT_EQ(0U, upstream_request_->bodyLength());
     // Verify the proxied response was received downstream, as expected.
-    EXPECT_TRUE(response->complete());
-    EXPECT_EQ("200", response->headers().getStatusValue());
-    EXPECT_EQ(0U, response->body().size());
+    EXPECT_TRUE(result.response->complete());
+    EXPECT_EQ("200", result.response->headers().getStatusValue());
+    EXPECT_EQ(0U, result.response->body().size());
 
     // Perform the clean-up.
     cleanupUpstreamAndDownstream();
+
+    std::string target_name =
+        absl::StrFormat("cluster.cluster_%d.upstream_cx_active", result.upstream_index.value());
+    test_server_->waitForGaugeEq(target_name, 0);
   }
 
 private:


### PR DESCRIPTION
Additional Description:
I'm unable to recreate this test flakiness locally. However I think the issue is a race between closing upstream connection and sending new downstream request. If Envoy takes longer to observe closed upstream connection it can send request into upstream connection that is already closing.

Risk Level: Low
Testing: Unit test
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
