### PR TITLE
replace access log list to access log vector

### DIFF
--- a/envoy/access_log/access_log.h
+++ b/envoy/access_log/access_log.h
@@ -103,9 +103,7 @@ using FilterPtr = std::unique_ptr<Filter>;
  */
 using Instance = InstanceBase<Formatter::HttpFormatterContext>;
 using InstanceSharedPtr = std::shared_ptr<Instance>;
-
-using InstanceInlinedVector = absl::InlinedVector<InstanceSharedPtr, 4>;
-using InstanceVector = std::vector<InstanceSharedPtr>;
+using InstanceSharedPtrVector = std::vector<InstanceSharedPtr>;
 
 } // namespace AccessLog
 } // namespace Envoy

--- a/envoy/access_log/access_log.h
+++ b/envoy/access_log/access_log.h
@@ -104,5 +104,8 @@ using FilterPtr = std::unique_ptr<Filter>;
 using Instance = InstanceBase<Formatter::HttpFormatterContext>;
 using InstanceSharedPtr = std::shared_ptr<Instance>;
 
+using InstanceInlinedVector = absl::InlinedVector<InstanceSharedPtr, 4>;
+using InstanceVector = std::vector<InstanceSharedPtr>;
+
 } // namespace AccessLog
 } // namespace Envoy

--- a/envoy/http/codec.h
+++ b/envoy/http/codec.h
@@ -262,7 +262,7 @@ public:
   /**
    * @return List of shared pointers to access loggers for this stream.
    */
-  virtual AccessLog::InstanceInlinedVector accessLogHandlers() PURE;
+  virtual AccessLog::InstanceSharedPtrVector accessLogHandlers() PURE;
 };
 
 /**

--- a/envoy/http/codec.h
+++ b/envoy/http/codec.h
@@ -262,7 +262,7 @@ public:
   /**
    * @return List of shared pointers to access loggers for this stream.
    */
-  virtual std::list<AccessLog::InstanceSharedPtr> accessLogHandlers() PURE;
+  virtual AccessLog::InstanceInlinedVector accessLogHandlers() PURE;
 };
 
 /**

--- a/envoy/network/listener.h
+++ b/envoy/network/listener.h
@@ -273,9 +273,9 @@ public:
   virtual ResourceLimit& openConnections() PURE;
 
   /**
-   * @return std::vector<AccessLog::InstanceSharedPtr> access logs emitted by the listener.
+   * @return AccessLog::InstanceVector access logs emitted by the listener.
    */
-  virtual const std::vector<AccessLog::InstanceSharedPtr>& accessLogs() const PURE;
+  virtual const AccessLog::InstanceVector& accessLogs() const PURE;
 
   /**
    * @return pending connection backlog for TCP listeners.

--- a/envoy/network/listener.h
+++ b/envoy/network/listener.h
@@ -273,9 +273,9 @@ public:
   virtual ResourceLimit& openConnections() PURE;
 
   /**
-   * @return AccessLog::InstanceVector access logs emitted by the listener.
+   * @return AccessLog::InstanceSharedPtrVector access logs emitted by the listener.
    */
-  virtual const AccessLog::InstanceVector& accessLogs() const PURE;
+  virtual const AccessLog::InstanceSharedPtrVector& accessLogs() const PURE;
 
   /**
    * @return pending connection backlog for TCP listeners.

--- a/envoy/server/admin.h
+++ b/envoy/server/admin.h
@@ -236,7 +236,7 @@ public:
    * @param address network address to bind and listen on.
    * @param socket_options socket options to apply to the listening socket.
    */
-  virtual void startHttpListener(AccessLog::InstanceVector access_logs,
+  virtual void startHttpListener(AccessLog::InstanceSharedPtrVector access_logs,
                                  Network::Address::InstanceConstSharedPtr address,
                                  Network::Socket::OptionsSharedPtr socket_options) PURE;
 

--- a/envoy/server/admin.h
+++ b/envoy/server/admin.h
@@ -236,7 +236,7 @@ public:
    * @param address network address to bind and listen on.
    * @param socket_options socket options to apply to the listening socket.
    */
-  virtual void startHttpListener(std::list<AccessLog::InstanceSharedPtr> access_logs,
+  virtual void startHttpListener(AccessLog::InstanceVector access_logs,
                                  Network::Address::InstanceConstSharedPtr address,
                                  Network::Socket::OptionsSharedPtr socket_options) PURE;
 

--- a/envoy/server/configuration.h
+++ b/envoy/server/configuration.h
@@ -136,7 +136,7 @@ public:
   /**
    * @return std::list<AccessLog::InstanceSharedPtr> the list of access loggers.
    */
-  virtual AccessLog::InstanceVector accessLogs() const PURE;
+  virtual AccessLog::InstanceSharedPtrVector accessLogs() const PURE;
 
   /**
    * @return const std::string& profiler output path.

--- a/envoy/server/configuration.h
+++ b/envoy/server/configuration.h
@@ -136,7 +136,7 @@ public:
   /**
    * @return std::list<AccessLog::InstanceSharedPtr> the list of access loggers.
    */
-  virtual std::list<AccessLog::InstanceSharedPtr> accessLogs() const PURE;
+  virtual AccessLog::InstanceVector accessLogs() const PURE;
 
   /**
    * @return const std::string& profiler output path.

--- a/source/common/http/conn_manager_config.h
+++ b/source/common/http/conn_manager_config.h
@@ -217,7 +217,7 @@ public:
   /**
    *  @return const std::list<AccessLog::InstanceSharedPtr>& the access logs to write to.
    */
-  virtual const AccessLog::InstanceVector& accessLogs() PURE;
+  virtual const AccessLog::InstanceSharedPtrVector& accessLogs() PURE;
 
   /**
    * @return const absl::optional<std::chrono::milliseconds>& the interval to flush the access logs.

--- a/source/common/http/conn_manager_config.h
+++ b/source/common/http/conn_manager_config.h
@@ -217,7 +217,7 @@ public:
   /**
    *  @return const std::list<AccessLog::InstanceSharedPtr>& the access logs to write to.
    */
-  virtual const std::list<AccessLog::InstanceSharedPtr>& accessLogs() PURE;
+  virtual const AccessLog::InstanceVector& accessLogs() PURE;
 
   /**
    * @return const absl::optional<std::chrono::milliseconds>& the interval to flush the access logs.

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -189,12 +189,14 @@ private:
                         absl::string_view details) override {
       return filter_manager_.sendLocalReply(code, body, modify_headers, grpc_status, details);
     }
-    AccessLog::InstanceInlinedVector accessLogHandlers() override {
-      AccessLog::InstanceInlinedVector combined_log_handlers;
-
-      const AccessLog::InstanceVector& config_log_handlers =
+    AccessLog::InstanceSharedPtrVector accessLogHandlers() override {
+      const AccessLog::InstanceSharedPtrVector& config_log_handlers =
           connection_manager_.config_->accessLogs();
-      const AccessLog::InstanceVector& filter_log_handlers = filter_manager_.accessLogHandlers();
+      const AccessLog::InstanceSharedPtrVector& filter_log_handlers =
+          filter_manager_.accessLogHandlers();
+
+      AccessLog::InstanceSharedPtrVector combined_log_handlers;
+      combined_log_handlers.reserve(config_log_handlers.size() + filter_log_handlers.size());
 
       if (!Runtime::runtimeFeatureEnabled(
               "envoy.reloadable_features.filter_access_loggers_first")) {

--- a/source/common/http/filter_manager.h
+++ b/source/common/http/filter_manager.h
@@ -703,7 +703,7 @@ public:
     }
   }
 
-  const AccessLog::InstanceVector& accessLogHandlers() { return access_log_handlers_; }
+  const AccessLog::InstanceSharedPtrVector& accessLogHandlers() { return access_log_handlers_; }
 
   void onStreamComplete() {
     for (auto filter : filters_) {
@@ -1038,7 +1038,7 @@ private:
   std::list<ActiveStreamDecoderFilterPtr> decoder_filters_;
   std::list<ActiveStreamEncoderFilterPtr> encoder_filters_;
   std::list<StreamFilterBase*> filters_;
-  AccessLog::InstanceVector access_log_handlers_;
+  AccessLog::InstanceSharedPtrVector access_log_handlers_;
 
   // Stores metadata added in the decoding filter that is being processed. Will be cleared before
   // processing the next filter. The storage is created on demand. We need to store metadata

--- a/source/common/http/filter_manager.h
+++ b/source/common/http/filter_manager.h
@@ -703,7 +703,7 @@ public:
     }
   }
 
-  std::list<AccessLog::InstanceSharedPtr> accessLogHandlers() { return access_log_handlers_; }
+  const AccessLog::InstanceVector& accessLogHandlers() { return access_log_handlers_; }
 
   void onStreamComplete() {
     for (auto filter : filters_) {
@@ -1038,7 +1038,7 @@ private:
   std::list<ActiveStreamDecoderFilterPtr> decoder_filters_;
   std::list<ActiveStreamEncoderFilterPtr> encoder_filters_;
   std::list<StreamFilterBase*> filters_;
-  std::list<AccessLog::InstanceSharedPtr> access_log_handlers_;
+  AccessLog::InstanceVector access_log_handlers_;
 
   // Stores metadata added in the decoding filter that is being processed. Will be cleared before
   // processing the next filter. The storage is created on demand. We need to store metadata

--- a/source/common/listener_manager/listener_impl.h
+++ b/source/common/listener_manager/listener_impl.h
@@ -315,7 +315,7 @@ public:
     return *balancer->second;
   }
   ResourceLimit& openConnections() override { return *open_connections_; }
-  const AccessLog::InstanceVector& accessLogs() const override { return access_logs_; }
+  const AccessLog::InstanceSharedPtrVector& accessLogs() const override { return access_logs_; }
   uint32_t tcpBacklogSize() const override { return tcp_backlog_size_; }
   uint32_t maxConnectionsToAcceptPerSocketEvent() const override {
     return max_connections_to_accept_per_socket_event_;
@@ -452,7 +452,7 @@ private:
   Filter::ListenerFilterFactoriesList listener_filter_factories_;
   std::vector<Network::UdpListenerFilterFactoryCb> udp_listener_filter_factories_;
   Filter::QuicListenerFilterFactoriesList quic_listener_filter_factories_;
-  AccessLog::InstanceVector access_logs_;
+  AccessLog::InstanceSharedPtrVector access_logs_;
   const envoy::config::listener::v3::Listener config_;
   const std::string version_info_;
   // Using std::vector instead of hash map for supporting multiple zero port addresses.

--- a/source/common/listener_manager/listener_impl.h
+++ b/source/common/listener_manager/listener_impl.h
@@ -315,9 +315,7 @@ public:
     return *balancer->second;
   }
   ResourceLimit& openConnections() override { return *open_connections_; }
-  const std::vector<AccessLog::InstanceSharedPtr>& accessLogs() const override {
-    return access_logs_;
-  }
+  const AccessLog::InstanceVector& accessLogs() const override { return access_logs_; }
   uint32_t tcpBacklogSize() const override { return tcp_backlog_size_; }
   uint32_t maxConnectionsToAcceptPerSocketEvent() const override {
     return max_connections_to_accept_per_socket_event_;
@@ -454,7 +452,7 @@ private:
   Filter::ListenerFilterFactoriesList listener_filter_factories_;
   std::vector<Network::UdpListenerFilterFactoryCb> udp_listener_filter_factories_;
   Filter::QuicListenerFilterFactoriesList quic_listener_filter_factories_;
-  std::vector<AccessLog::InstanceSharedPtr> access_logs_;
+  AccessLog::InstanceVector access_logs_;
   const envoy::config::listener::v3::Listener config_;
   const std::string version_info_;
   // Using std::vector instead of hash map for supporting multiple zero port addresses.

--- a/source/common/quic/quic_stats_gatherer.h
+++ b/source/common/quic/quic_stats_gatherer.h
@@ -35,7 +35,7 @@ public:
   // Log this stream using available stream info and access loggers.
   void maybeDoDeferredLog(bool record_ack_timing = true);
   // Set list of pointers to access loggers.
-  void setAccessLogHandlers(AccessLog::InstanceInlinedVector handlers) {
+  void setAccessLogHandlers(AccessLog::InstanceSharedPtrVector handlers) {
     access_log_handlers_ = std::move(handlers);
   }
   // Set headers, trailers, and stream info used for deferred logging.
@@ -55,7 +55,7 @@ public:
 private:
   uint64_t bytes_outstanding_ = 0;
   bool fin_sent_ = false;
-  AccessLog::InstanceInlinedVector access_log_handlers_{};
+  AccessLog::InstanceSharedPtrVector access_log_handlers_{};
   Http::RequestHeaderMapConstSharedPtr request_header_map_;
   Http::ResponseHeaderMapConstSharedPtr response_header_map_;
   Http::ResponseTrailerMapConstSharedPtr response_trailer_map_;

--- a/source/common/quic/quic_stats_gatherer.h
+++ b/source/common/quic/quic_stats_gatherer.h
@@ -35,8 +35,8 @@ public:
   // Log this stream using available stream info and access loggers.
   void maybeDoDeferredLog(bool record_ack_timing = true);
   // Set list of pointers to access loggers.
-  void setAccessLogHandlers(std::list<AccessLog::InstanceSharedPtr> handlers) {
-    access_log_handlers_ = handlers;
+  void setAccessLogHandlers(AccessLog::InstanceInlinedVector handlers) {
+    access_log_handlers_ = std::move(handlers);
   }
   // Set headers, trailers, and stream info used for deferred logging.
   void
@@ -55,7 +55,7 @@ public:
 private:
   uint64_t bytes_outstanding_ = 0;
   bool fin_sent_ = false;
-  std::list<AccessLog::InstanceSharedPtr> access_log_handlers_{};
+  AccessLog::InstanceInlinedVector access_log_handlers_{};
   Http::RequestHeaderMapConstSharedPtr request_header_map_;
   Http::ResponseHeaderMapConstSharedPtr response_header_map_;
   Http::ResponseTrailerMapConstSharedPtr response_trailer_map_;

--- a/source/common/tcp_proxy/tcp_proxy.h
+++ b/source/common/tcp_proxy/tcp_proxy.h
@@ -282,7 +282,7 @@ public:
   RouteConstSharedPtr getRegularRouteFromEntries(Network::Connection& connection);
 
   const TcpProxyStats& stats() { return shared_config_->stats(); }
-  const std::vector<AccessLog::InstanceSharedPtr>& accessLogs() { return access_logs_; }
+  const AccessLog::InstanceVector& accessLogs() { return access_logs_; }
   uint32_t maxConnectAttempts() const { return max_connect_attempts_; }
   const absl::optional<std::chrono::milliseconds>& idleTimeout() {
     return shared_config_->idleTimeout();
@@ -362,7 +362,7 @@ private:
   RouteConstSharedPtr default_route_;
   std::vector<WeightedClusterEntryConstSharedPtr> weighted_clusters_;
   uint64_t total_cluster_weight_;
-  std::vector<AccessLog::InstanceSharedPtr> access_logs_;
+  AccessLog::InstanceVector access_logs_;
   const uint32_t max_connect_attempts_;
   ThreadLocal::SlotPtr upstream_drain_manager_slot_;
   SharedConfigSharedPtr shared_config_;

--- a/source/common/tcp_proxy/tcp_proxy.h
+++ b/source/common/tcp_proxy/tcp_proxy.h
@@ -282,7 +282,7 @@ public:
   RouteConstSharedPtr getRegularRouteFromEntries(Network::Connection& connection);
 
   const TcpProxyStats& stats() { return shared_config_->stats(); }
-  const AccessLog::InstanceVector& accessLogs() { return access_logs_; }
+  const AccessLog::InstanceSharedPtrVector& accessLogs() { return access_logs_; }
   uint32_t maxConnectAttempts() const { return max_connect_attempts_; }
   const absl::optional<std::chrono::milliseconds>& idleTimeout() {
     return shared_config_->idleTimeout();
@@ -362,7 +362,7 @@ private:
   RouteConstSharedPtr default_route_;
   std::vector<WeightedClusterEntryConstSharedPtr> weighted_clusters_;
   uint64_t total_cluster_weight_;
-  AccessLog::InstanceVector access_logs_;
+  AccessLog::InstanceSharedPtrVector access_logs_;
   const uint32_t max_connect_attempts_;
   ThreadLocal::SlotPtr upstream_drain_manager_slot_;
   SharedConfigSharedPtr shared_config_;

--- a/source/extensions/filters/http/composite/factory_wrapper.h
+++ b/source/extensions/filters/http/composite/factory_wrapper.h
@@ -30,7 +30,7 @@ struct FactoryCallbacksWrapper : public Http::FilterChainFactoryCallbacks {
       absl::variant<Http::StreamDecoderFilterSharedPtr, Http::StreamEncoderFilterSharedPtr,
                     Http::StreamFilterSharedPtr>;
   absl::optional<FilterAlternative> filter_to_inject_;
-  AccessLog::InstanceVector access_loggers_;
+  AccessLog::InstanceSharedPtrVector access_loggers_;
   std::vector<absl::Status> errors_;
 };
 } // namespace Composite

--- a/source/extensions/filters/http/composite/factory_wrapper.h
+++ b/source/extensions/filters/http/composite/factory_wrapper.h
@@ -30,7 +30,7 @@ struct FactoryCallbacksWrapper : public Http::FilterChainFactoryCallbacks {
       absl::variant<Http::StreamDecoderFilterSharedPtr, Http::StreamEncoderFilterSharedPtr,
                     Http::StreamFilterSharedPtr>;
   absl::optional<FilterAlternative> filter_to_inject_;
-  std::vector<AccessLog::InstanceSharedPtr> access_loggers_;
+  AccessLog::InstanceVector access_loggers_;
   std::vector<absl::Status> errors_;
 };
 } // namespace Composite

--- a/source/extensions/filters/http/composite/filter.h
+++ b/source/extensions/filters/http/composite/filter.h
@@ -162,7 +162,7 @@ private:
     Http::StreamEncoderFilterSharedPtr encoder_filter_;
     Http::StreamDecoderFilterSharedPtr decoder_filter_;
   };
-  AccessLog::InstanceVector access_loggers_;
+  AccessLog::InstanceSharedPtrVector access_loggers_;
 
   Http::StreamFilterSharedPtr delegated_filter_;
   Http::StreamEncoderFilterCallbacks* encoder_callbacks_{};

--- a/source/extensions/filters/http/composite/filter.h
+++ b/source/extensions/filters/http/composite/filter.h
@@ -162,7 +162,7 @@ private:
     Http::StreamEncoderFilterSharedPtr encoder_filter_;
     Http::StreamDecoderFilterSharedPtr decoder_filter_;
   };
-  std::vector<AccessLog::InstanceSharedPtr> access_loggers_;
+  AccessLog::InstanceVector access_loggers_;
 
   Http::StreamFilterSharedPtr delegated_filter_;
   Http::StreamEncoderFilterCallbacks* encoder_callbacks_{};

--- a/source/extensions/filters/network/http_connection_manager/config.h
+++ b/source/extensions/filters/network/http_connection_manager/config.h
@@ -155,7 +155,7 @@ public:
   const Http::RequestIDExtensionSharedPtr& requestIDExtension() override {
     return request_id_extension_;
   }
-  const std::list<AccessLog::InstanceSharedPtr>& accessLogs() override { return access_logs_; }
+  const AccessLog::InstanceVector& accessLogs() override { return access_logs_; }
   bool flushAccessLogOnNewRequest() override { return flush_access_log_on_new_request_; }
   bool flushAccessLogOnTunnelSuccessfullyEstablished() const override {
     return flush_log_on_tunnel_successfully_established_;
@@ -292,7 +292,7 @@ private:
   Server::Configuration::FactoryContext& context_;
   FilterFactoriesList filter_factories_;
   std::map<std::string, FilterConfig> upgrade_filter_factories_;
-  std::list<AccessLog::InstanceSharedPtr> access_logs_;
+  AccessLog::InstanceVector access_logs_;
   bool flush_access_log_on_new_request_;
   absl::optional<std::chrono::milliseconds> access_log_flush_interval_;
   bool flush_log_on_tunnel_successfully_established_{false};

--- a/source/extensions/filters/network/http_connection_manager/config.h
+++ b/source/extensions/filters/network/http_connection_manager/config.h
@@ -155,7 +155,7 @@ public:
   const Http::RequestIDExtensionSharedPtr& requestIDExtension() override {
     return request_id_extension_;
   }
-  const AccessLog::InstanceVector& accessLogs() override { return access_logs_; }
+  const AccessLog::InstanceSharedPtrVector& accessLogs() override { return access_logs_; }
   bool flushAccessLogOnNewRequest() override { return flush_access_log_on_new_request_; }
   bool flushAccessLogOnTunnelSuccessfullyEstablished() const override {
     return flush_log_on_tunnel_successfully_established_;
@@ -292,7 +292,7 @@ private:
   Server::Configuration::FactoryContext& context_;
   FilterFactoriesList filter_factories_;
   std::map<std::string, FilterConfig> upgrade_filter_factories_;
-  AccessLog::InstanceVector access_logs_;
+  AccessLog::InstanceSharedPtrVector access_logs_;
   bool flush_access_log_on_new_request_;
   absl::optional<std::chrono::milliseconds> access_log_flush_interval_;
   bool flush_log_on_tunnel_successfully_established_{false};

--- a/source/extensions/filters/network/thrift_proxy/config.h
+++ b/source/extensions/filters/network/thrift_proxy/config.h
@@ -88,9 +88,7 @@ public:
   Router::Config& routerConfig() override { return *this; }
   bool payloadPassthrough() const override { return payload_passthrough_; }
   uint64_t maxRequestsPerConnection() const override { return max_requests_per_connection_; }
-  const std::vector<AccessLog::InstanceSharedPtr>& accessLogs() const override {
-    return access_logs_;
-  }
+  const AccessLog::InstanceVector& accessLogs() const override { return access_logs_; }
   bool headerKeysPreserveCase() const override { return header_keys_preserve_case_; }
 
 private:
@@ -108,7 +106,7 @@ private:
   const bool payload_passthrough_;
 
   const uint64_t max_requests_per_connection_{};
-  std::vector<AccessLog::InstanceSharedPtr> access_logs_;
+  AccessLog::InstanceVector access_logs_;
   const bool header_keys_preserve_case_;
 };
 

--- a/source/extensions/filters/network/thrift_proxy/config.h
+++ b/source/extensions/filters/network/thrift_proxy/config.h
@@ -88,7 +88,7 @@ public:
   Router::Config& routerConfig() override { return *this; }
   bool payloadPassthrough() const override { return payload_passthrough_; }
   uint64_t maxRequestsPerConnection() const override { return max_requests_per_connection_; }
-  const AccessLog::InstanceVector& accessLogs() const override { return access_logs_; }
+  const AccessLog::InstanceSharedPtrVector& accessLogs() const override { return access_logs_; }
   bool headerKeysPreserveCase() const override { return header_keys_preserve_case_; }
 
 private:
@@ -106,7 +106,7 @@ private:
   const bool payload_passthrough_;
 
   const uint64_t max_requests_per_connection_{};
-  AccessLog::InstanceVector access_logs_;
+  AccessLog::InstanceSharedPtrVector access_logs_;
   const bool header_keys_preserve_case_;
 };
 

--- a/source/extensions/filters/network/thrift_proxy/conn_manager.h
+++ b/source/extensions/filters/network/thrift_proxy/conn_manager.h
@@ -42,7 +42,7 @@ public:
   virtual Router::Config& routerConfig() PURE;
   virtual bool payloadPassthrough() const PURE;
   virtual uint64_t maxRequestsPerConnection() const PURE;
-  virtual const AccessLog::InstanceVector& accessLogs() const PURE;
+  virtual const AccessLog::InstanceSharedPtrVector& accessLogs() const PURE;
   virtual bool headerKeysPreserveCase() const PURE;
 };
 

--- a/source/extensions/filters/network/thrift_proxy/conn_manager.h
+++ b/source/extensions/filters/network/thrift_proxy/conn_manager.h
@@ -42,7 +42,7 @@ public:
   virtual Router::Config& routerConfig() PURE;
   virtual bool payloadPassthrough() const PURE;
   virtual uint64_t maxRequestsPerConnection() const PURE;
-  virtual const std::vector<AccessLog::InstanceSharedPtr>& accessLogs() const PURE;
+  virtual const AccessLog::InstanceVector& accessLogs() const PURE;
   virtual bool headerKeysPreserveCase() const PURE;
 };
 

--- a/source/extensions/filters/udp/udp_proxy/config.h
+++ b/source/extensions/filters/udp/udp_proxy/config.h
@@ -139,12 +139,10 @@ public:
   const Network::ResolvedUdpSocketConfig& upstreamSocketConfig() const override {
     return upstream_socket_config_;
   }
-  const std::vector<AccessLog::InstanceSharedPtr>& sessionAccessLogs() const override {
+  const AccessLog::InstanceVector& sessionAccessLogs() const override {
     return session_access_logs_;
   }
-  const std::vector<AccessLog::InstanceSharedPtr>& proxyAccessLogs() const override {
-    return proxy_access_logs_;
-  }
+  const AccessLog::InstanceVector& proxyAccessLogs() const override { return proxy_access_logs_; }
   const UdpSessionFilterChainFactory& sessionFilterFactory() const override { return *this; };
   bool hasSessionFilters() const override { return !filter_factories_.empty(); }
   const UdpTunnelingConfigPtr& tunnelingConfig() const override { return tunneling_config_; };
@@ -194,8 +192,8 @@ private:
   std::unique_ptr<const HashPolicyImpl> hash_policy_;
   mutable UdpProxyDownstreamStats stats_;
   const Network::ResolvedUdpSocketConfig upstream_socket_config_;
-  std::vector<AccessLog::InstanceSharedPtr> session_access_logs_;
-  std::vector<AccessLog::InstanceSharedPtr> proxy_access_logs_;
+  AccessLog::InstanceVector session_access_logs_;
+  AccessLog::InstanceVector proxy_access_logs_;
   UdpTunnelingConfigPtr tunneling_config_;
   std::shared_ptr<UdpSessionFilterConfigProviderManager>
       udp_session_filter_config_provider_manager_;

--- a/source/extensions/filters/udp/udp_proxy/config.h
+++ b/source/extensions/filters/udp/udp_proxy/config.h
@@ -139,10 +139,12 @@ public:
   const Network::ResolvedUdpSocketConfig& upstreamSocketConfig() const override {
     return upstream_socket_config_;
   }
-  const AccessLog::InstanceVector& sessionAccessLogs() const override {
+  const AccessLog::InstanceSharedPtrVector& sessionAccessLogs() const override {
     return session_access_logs_;
   }
-  const AccessLog::InstanceVector& proxyAccessLogs() const override { return proxy_access_logs_; }
+  const AccessLog::InstanceSharedPtrVector& proxyAccessLogs() const override {
+    return proxy_access_logs_;
+  }
   const UdpSessionFilterChainFactory& sessionFilterFactory() const override { return *this; };
   bool hasSessionFilters() const override { return !filter_factories_.empty(); }
   const UdpTunnelingConfigPtr& tunnelingConfig() const override { return tunneling_config_; };
@@ -192,8 +194,8 @@ private:
   std::unique_ptr<const HashPolicyImpl> hash_policy_;
   mutable UdpProxyDownstreamStats stats_;
   const Network::ResolvedUdpSocketConfig upstream_socket_config_;
-  AccessLog::InstanceVector session_access_logs_;
-  AccessLog::InstanceVector proxy_access_logs_;
+  AccessLog::InstanceSharedPtrVector session_access_logs_;
+  AccessLog::InstanceSharedPtrVector proxy_access_logs_;
   UdpTunnelingConfigPtr tunneling_config_;
   std::shared_ptr<UdpSessionFilterConfigProviderManager>
       udp_session_filter_config_provider_manager_;

--- a/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.h
+++ b/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.h
@@ -130,8 +130,8 @@ public:
   virtual UdpProxyDownstreamStats& stats() const PURE;
   virtual TimeSource& timeSource() const PURE;
   virtual const Network::ResolvedUdpSocketConfig& upstreamSocketConfig() const PURE;
-  virtual const std::vector<AccessLog::InstanceSharedPtr>& sessionAccessLogs() const PURE;
-  virtual const std::vector<AccessLog::InstanceSharedPtr>& proxyAccessLogs() const PURE;
+  virtual const AccessLog::InstanceVector& sessionAccessLogs() const PURE;
+  virtual const AccessLog::InstanceVector& proxyAccessLogs() const PURE;
   virtual const UdpSessionFilterChainFactory& sessionFilterFactory() const PURE;
   virtual bool hasSessionFilters() const PURE;
   virtual const UdpTunnelingConfigPtr& tunnelingConfig() const PURE;

--- a/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.h
+++ b/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.h
@@ -130,8 +130,8 @@ public:
   virtual UdpProxyDownstreamStats& stats() const PURE;
   virtual TimeSource& timeSource() const PURE;
   virtual const Network::ResolvedUdpSocketConfig& upstreamSocketConfig() const PURE;
-  virtual const AccessLog::InstanceVector& sessionAccessLogs() const PURE;
-  virtual const AccessLog::InstanceVector& proxyAccessLogs() const PURE;
+  virtual const AccessLog::InstanceSharedPtrVector& sessionAccessLogs() const PURE;
+  virtual const AccessLog::InstanceSharedPtrVector& proxyAccessLogs() const PURE;
   virtual const UdpSessionFilterChainFactory& sessionFilterFactory() const PURE;
   virtual bool hasSessionFilters() const PURE;
   virtual const UdpTunnelingConfigPtr& tunnelingConfig() const PURE;

--- a/source/server/admin/admin.cc
+++ b/source/server/admin/admin.cc
@@ -50,7 +50,7 @@ ConfigTracker& AdminImpl::getConfigTracker() { return config_tracker_; }
 AdminImpl::NullRouteConfigProvider::NullRouteConfigProvider(TimeSource& time_source)
     : config_(new Router::NullConfigImpl()), time_source_(time_source) {}
 
-void AdminImpl::startHttpListener(std::list<AccessLog::InstanceSharedPtr> access_logs,
+void AdminImpl::startHttpListener(AccessLog::InstanceVector access_logs,
                                   Network::Address::InstanceConstSharedPtr address,
                                   Network::Socket::OptionsSharedPtr socket_options) {
   access_logs_ = std::move(access_logs);

--- a/source/server/admin/admin.cc
+++ b/source/server/admin/admin.cc
@@ -50,7 +50,7 @@ ConfigTracker& AdminImpl::getConfigTracker() { return config_tracker_; }
 AdminImpl::NullRouteConfigProvider::NullRouteConfigProvider(TimeSource& time_source)
     : config_(new Router::NullConfigImpl()), time_source_(time_source) {}
 
-void AdminImpl::startHttpListener(AccessLog::InstanceVector access_logs,
+void AdminImpl::startHttpListener(AccessLog::InstanceSharedPtrVector access_logs,
                                   Network::Address::InstanceConstSharedPtr address,
                                   Network::Socket::OptionsSharedPtr socket_options) {
   access_logs_ = std::move(access_logs);

--- a/source/server/admin/admin.h
+++ b/source/server/admin/admin.h
@@ -94,7 +94,7 @@ public:
   bool removeHandler(const std::string& prefix) override;
   ConfigTracker& getConfigTracker() override;
 
-  void startHttpListener(AccessLog::InstanceVector access_logs,
+  void startHttpListener(AccessLog::InstanceSharedPtrVector access_logs,
                          Network::Address::InstanceConstSharedPtr address,
                          Network::Socket::OptionsSharedPtr socket_options) override;
   uint32_t concurrency() const override { return server_.options().concurrency(); }
@@ -127,7 +127,7 @@ public:
   const Http::RequestIDExtensionSharedPtr& requestIDExtension() override {
     return request_id_extension_;
   }
-  const AccessLog::InstanceVector& accessLogs() override { return access_logs_; }
+  const AccessLog::InstanceSharedPtrVector& accessLogs() override { return access_logs_; }
   bool flushAccessLogOnNewRequest() override { return flush_access_log_on_new_request_; }
   bool flushAccessLogOnTunnelSuccessfullyEstablished() const override { return false; }
   const absl::optional<std::chrono::milliseconds>& accessLogFlushInterval() override {
@@ -395,7 +395,9 @@ private:
       return connection_balancer_;
     }
     ResourceLimit& openConnections() override { return open_connections_; }
-    const AccessLog::InstanceVector& accessLogs() const override { return empty_access_logs_; }
+    const AccessLog::InstanceSharedPtrVector& accessLogs() const override {
+      return empty_access_logs_;
+    }
     uint32_t tcpBacklogSize() const override { return ENVOY_TCP_BACKLOG_SIZE; }
     uint32_t maxConnectionsToAcceptPerSocketEvent() const override {
       return Network::DefaultMaxConnectionsToAcceptPerSocketEvent;
@@ -412,7 +414,7 @@ private:
     BasicResourceLimitImpl open_connections_;
 
   private:
-    const AccessLog::InstanceVector empty_access_logs_;
+    const AccessLog::InstanceSharedPtrVector empty_access_logs_;
     std::unique_ptr<Init::Manager> init_manager_;
     const bool ignore_global_conn_limit_;
   };
@@ -448,7 +450,7 @@ private:
   const Network::ListenerInfoConstSharedPtr listener_info_;
   AdminFactoryContext factory_context_;
   Http::RequestIDExtensionSharedPtr request_id_extension_;
-  AccessLog::InstanceVector access_logs_;
+  AccessLog::InstanceSharedPtrVector access_logs_;
   const bool flush_access_log_on_new_request_ = false;
   const absl::optional<std::chrono::milliseconds> null_access_log_flush_interval_;
   const std::string profile_path_;

--- a/source/server/admin/admin.h
+++ b/source/server/admin/admin.h
@@ -94,7 +94,7 @@ public:
   bool removeHandler(const std::string& prefix) override;
   ConfigTracker& getConfigTracker() override;
 
-  void startHttpListener(std::list<AccessLog::InstanceSharedPtr> access_logs,
+  void startHttpListener(AccessLog::InstanceVector access_logs,
                          Network::Address::InstanceConstSharedPtr address,
                          Network::Socket::OptionsSharedPtr socket_options) override;
   uint32_t concurrency() const override { return server_.options().concurrency(); }
@@ -127,7 +127,7 @@ public:
   const Http::RequestIDExtensionSharedPtr& requestIDExtension() override {
     return request_id_extension_;
   }
-  const std::list<AccessLog::InstanceSharedPtr>& accessLogs() override { return access_logs_; }
+  const AccessLog::InstanceVector& accessLogs() override { return access_logs_; }
   bool flushAccessLogOnNewRequest() override { return flush_access_log_on_new_request_; }
   bool flushAccessLogOnTunnelSuccessfullyEstablished() const override { return false; }
   const absl::optional<std::chrono::milliseconds>& accessLogFlushInterval() override {
@@ -395,9 +395,7 @@ private:
       return connection_balancer_;
     }
     ResourceLimit& openConnections() override { return open_connections_; }
-    const std::vector<AccessLog::InstanceSharedPtr>& accessLogs() const override {
-      return empty_access_logs_;
-    }
+    const AccessLog::InstanceVector& accessLogs() const override { return empty_access_logs_; }
     uint32_t tcpBacklogSize() const override { return ENVOY_TCP_BACKLOG_SIZE; }
     uint32_t maxConnectionsToAcceptPerSocketEvent() const override {
       return Network::DefaultMaxConnectionsToAcceptPerSocketEvent;
@@ -414,7 +412,7 @@ private:
     BasicResourceLimitImpl open_connections_;
 
   private:
-    const std::vector<AccessLog::InstanceSharedPtr> empty_access_logs_;
+    const AccessLog::InstanceVector empty_access_logs_;
     std::unique_ptr<Init::Manager> init_manager_;
     const bool ignore_global_conn_limit_;
   };
@@ -450,7 +448,7 @@ private:
   const Network::ListenerInfoConstSharedPtr listener_info_;
   AdminFactoryContext factory_context_;
   Http::RequestIDExtensionSharedPtr request_id_extension_;
-  std::list<AccessLog::InstanceSharedPtr> access_logs_;
+  AccessLog::InstanceVector access_logs_;
   const bool flush_access_log_on_new_request_ = false;
   const absl::optional<std::chrono::milliseconds> null_access_log_flush_interval_;
   const std::string profile_path_;

--- a/source/server/config_validation/admin.cc
+++ b/source/server/config_validation/admin.cc
@@ -20,7 +20,7 @@ const Network::Socket& ValidationAdmin::socket() { return *socket_; }
 
 ConfigTracker& ValidationAdmin::getConfigTracker() { return config_tracker_; }
 
-void ValidationAdmin::startHttpListener(AccessLog::InstanceVector,
+void ValidationAdmin::startHttpListener(AccessLog::InstanceSharedPtrVector,
                                         Network::Address::InstanceConstSharedPtr,
                                         Network::Socket::OptionsSharedPtr) {}
 

--- a/source/server/config_validation/admin.cc
+++ b/source/server/config_validation/admin.cc
@@ -20,7 +20,7 @@ const Network::Socket& ValidationAdmin::socket() { return *socket_; }
 
 ConfigTracker& ValidationAdmin::getConfigTracker() { return config_tracker_; }
 
-void ValidationAdmin::startHttpListener(std::list<AccessLog::InstanceSharedPtr>,
+void ValidationAdmin::startHttpListener(AccessLog::InstanceVector,
                                         Network::Address::InstanceConstSharedPtr,
                                         Network::Socket::OptionsSharedPtr) {}
 

--- a/source/server/config_validation/admin.h
+++ b/source/server/config_validation/admin.h
@@ -31,7 +31,7 @@ public:
   bool removeHandler(const std::string&) override;
   const Network::Socket& socket() override;
   ConfigTracker& getConfigTracker() override;
-  void startHttpListener(std::list<AccessLog::InstanceSharedPtr> access_logs,
+  void startHttpListener(AccessLog::InstanceVector access_logs,
                          Network::Address::InstanceConstSharedPtr address,
                          Network::Socket::OptionsSharedPtr) override;
   Http::Code request(absl::string_view path_and_query, absl::string_view method,

--- a/source/server/config_validation/admin.h
+++ b/source/server/config_validation/admin.h
@@ -31,7 +31,7 @@ public:
   bool removeHandler(const std::string&) override;
   const Network::Socket& socket() override;
   ConfigTracker& getConfigTracker() override;
-  void startHttpListener(AccessLog::InstanceVector access_logs,
+  void startHttpListener(AccessLog::InstanceSharedPtrVector access_logs,
                          Network::Address::InstanceConstSharedPtr address,
                          Network::Socket::OptionsSharedPtr) override;
   Http::Code request(absl::string_view path_and_query, absl::string_view method,

--- a/source/server/configuration_impl.h
+++ b/source/server/configuration_impl.h
@@ -210,11 +210,11 @@ private:
     const std::string& profilePath() const override { return profile_path_; }
     Network::Address::InstanceConstSharedPtr address() override { return address_; }
     Network::Socket::OptionsSharedPtr socketOptions() override { return socket_options_; }
-    AccessLog::InstanceVector accessLogs() const override { return access_logs_; }
+    AccessLog::InstanceSharedPtrVector accessLogs() const override { return access_logs_; }
     bool ignoreGlobalConnLimit() const override { return ignore_global_conn_limit_; }
 
     std::string profile_path_;
-    AccessLog::InstanceVector access_logs_;
+    AccessLog::InstanceSharedPtrVector access_logs_;
     Network::Address::InstanceConstSharedPtr address_;
     Network::Socket::OptionsSharedPtr socket_options_;
     bool ignore_global_conn_limit_;

--- a/source/server/configuration_impl.h
+++ b/source/server/configuration_impl.h
@@ -210,11 +210,11 @@ private:
     const std::string& profilePath() const override { return profile_path_; }
     Network::Address::InstanceConstSharedPtr address() override { return address_; }
     Network::Socket::OptionsSharedPtr socketOptions() override { return socket_options_; }
-    std::list<AccessLog::InstanceSharedPtr> accessLogs() const override { return access_logs_; }
+    AccessLog::InstanceVector accessLogs() const override { return access_logs_; }
     bool ignoreGlobalConnLimit() const override { return ignore_global_conn_limit_; }
 
     std::string profile_path_;
-    std::list<AccessLog::InstanceSharedPtr> access_logs_;
+    AccessLog::InstanceVector access_logs_;
     Network::Address::InstanceConstSharedPtr address_;
     Network::Socket::OptionsSharedPtr socket_options_;
     bool ignore_global_conn_limit_;

--- a/test/common/http/async_client_impl_test.cc
+++ b/test/common/http/async_client_impl_test.cc
@@ -163,6 +163,31 @@ TEST_F(AsyncClientImplTest, BasicStream) {
   stream->sendHeaders(headers, false);
   stream->sendData(*body, true);
 
+  {
+    // Senseless but improves coverage.
+    Http::StreamDecoderFilterCallbacks* filter_callbacks =
+        dynamic_cast<Http::AsyncStreamImpl*>(stream);
+    filter_callbacks->continueDecoding(); // No-op.
+    Buffer::OwnedImpl buffer;
+    filter_callbacks->injectDecodedDataToFilterChain(buffer, true);   // No-op.
+    filter_callbacks->modifyDecodingBuffer([](Buffer::Instance&) {}); // No-op.
+    filter_callbacks->encodeMetadata(nullptr);                        // No-op.
+    EXPECT_EQ(false, filter_callbacks->recreateStream(nullptr));      // No-op.
+    filter_callbacks->getUpstreamSocketOptions();                     // No-op.
+    filter_callbacks->addUpstreamSocketOptions(nullptr);              // No-op.
+    filter_callbacks->mostSpecificPerFilterConfig();                  // No-op.
+    filter_callbacks->perFilterConfigs();                             // No-op.
+    filter_callbacks->http1StreamEncoderOptions();                    // No-op.
+    filter_callbacks->downstreamCallbacks();                          // No-op.
+    filter_callbacks->upstreamCallbacks();                            // No-op.
+    filter_callbacks->resetIdleTimer();                               // No-op.
+    filter_callbacks->setUpstreamOverrideHost({});                    // No-op.
+    filter_callbacks->filterConfigName();                             // No-op.
+    filter_callbacks->informationalHeaders();                         // No-op.
+    filter_callbacks->responseHeaders();                              // No-op.
+    filter_callbacks->responseTrailers();                             // No-op.
+  }
+
   response_decoder_->decode1xxHeaders(
       ResponseHeaderMapPtr(new TestResponseHeaderMapImpl{{":status", "100"}}));
   response_decoder_->decodeHeaders(

--- a/test/common/http/conn_manager_impl_fuzz_test.cc
+++ b/test/common/http/conn_manager_impl_fuzz_test.cc
@@ -128,7 +128,7 @@ public:
 
   // Http::ConnectionManagerConfig
   const RequestIDExtensionSharedPtr& requestIDExtension() override { return request_id_extension_; }
-  const AccessLog::InstanceVector& accessLogs() override { return access_logs_; }
+  const AccessLog::InstanceSharedPtrVector& accessLogs() override { return access_logs_; }
   bool flushAccessLogOnNewRequest() override { return flush_access_log_on_new_request_; }
   bool flushAccessLogOnTunnelSuccessfullyEstablished() const override {
     return flush_access_log_on_tunnel_successfully_established_;
@@ -252,7 +252,7 @@ public:
       config_;
   NiceMock<Random::MockRandomGenerator> random_;
   RequestIDExtensionSharedPtr request_id_extension_;
-  AccessLog::InstanceVector access_logs_;
+  AccessLog::InstanceSharedPtrVector access_logs_;
   bool flush_access_log_on_new_request_ = false;
   bool flush_access_log_on_tunnel_successfully_established_ = false;
   absl::optional<std::chrono::milliseconds> access_log_flush_interval_;

--- a/test/common/http/conn_manager_impl_fuzz_test.cc
+++ b/test/common/http/conn_manager_impl_fuzz_test.cc
@@ -128,7 +128,7 @@ public:
 
   // Http::ConnectionManagerConfig
   const RequestIDExtensionSharedPtr& requestIDExtension() override { return request_id_extension_; }
-  const std::list<AccessLog::InstanceSharedPtr>& accessLogs() override { return access_logs_; }
+  const AccessLog::InstanceVector& accessLogs() override { return access_logs_; }
   bool flushAccessLogOnNewRequest() override { return flush_access_log_on_new_request_; }
   bool flushAccessLogOnTunnelSuccessfullyEstablished() const override {
     return flush_access_log_on_tunnel_successfully_established_;
@@ -252,7 +252,7 @@ public:
       config_;
   NiceMock<Random::MockRandomGenerator> random_;
   RequestIDExtensionSharedPtr request_id_extension_;
-  std::list<AccessLog::InstanceSharedPtr> access_logs_;
+  AccessLog::InstanceVector access_logs_;
   bool flush_access_log_on_new_request_ = false;
   bool flush_access_log_on_tunnel_successfully_established_ = false;
   absl::optional<std::chrono::milliseconds> access_log_flush_interval_;

--- a/test/common/http/conn_manager_impl_test_base.cc
+++ b/test/common/http/conn_manager_impl_test_base.cc
@@ -23,9 +23,7 @@ public:
   const RequestIDExtensionSharedPtr& requestIDExtension() override {
     return parent_.requestIDExtension();
   }
-  const std::list<AccessLog::InstanceSharedPtr>& accessLogs() override {
-    return parent_.accessLogs();
-  }
+  const AccessLog::InstanceVector& accessLogs() override { return parent_.accessLogs(); }
   const absl::optional<std::chrono::milliseconds>& accessLogFlushInterval() override {
     return parent_.accessLogFlushInterval();
   }

--- a/test/common/http/conn_manager_impl_test_base.cc
+++ b/test/common/http/conn_manager_impl_test_base.cc
@@ -23,7 +23,7 @@ public:
   const RequestIDExtensionSharedPtr& requestIDExtension() override {
     return parent_.requestIDExtension();
   }
-  const AccessLog::InstanceVector& accessLogs() override { return parent_.accessLogs(); }
+  const AccessLog::InstanceSharedPtrVector& accessLogs() override { return parent_.accessLogs(); }
   const absl::optional<std::chrono::milliseconds>& accessLogFlushInterval() override {
     return parent_.accessLogFlushInterval();
   }

--- a/test/common/http/conn_manager_impl_test_base.h
+++ b/test/common/http/conn_manager_impl_test_base.h
@@ -93,7 +93,7 @@ public:
                              const ResponseHeaderMap& expected_response);
 
   // Http::ConnectionManagerConfig
-  const AccessLog::InstanceVector& accessLogs() override { return access_logs_; }
+  const AccessLog::InstanceSharedPtrVector& accessLogs() override { return access_logs_; }
   bool flushAccessLogOnNewRequest() override { return flush_access_log_on_new_request_; }
   bool flushAccessLogOnTunnelSuccessfullyEstablished() const override {
     return flush_log_on_tunnel_successfully_established_;
@@ -256,7 +256,7 @@ public:
   NiceMock<Runtime::MockLoader> runtime_;
   NiceMock<Envoy::AccessLog::MockAccessLogManager> log_manager_;
   std::string access_log_path_;
-  AccessLog::InstanceVector access_logs_;
+  AccessLog::InstanceSharedPtrVector access_logs_;
   bool flush_access_log_on_new_request_ = false;
   bool flush_log_on_tunnel_successfully_established_ = false;
   absl::optional<std::chrono::milliseconds> access_log_flush_interval_;

--- a/test/common/http/conn_manager_impl_test_base.h
+++ b/test/common/http/conn_manager_impl_test_base.h
@@ -93,7 +93,7 @@ public:
                              const ResponseHeaderMap& expected_response);
 
   // Http::ConnectionManagerConfig
-  const std::list<AccessLog::InstanceSharedPtr>& accessLogs() override { return access_logs_; }
+  const AccessLog::InstanceVector& accessLogs() override { return access_logs_; }
   bool flushAccessLogOnNewRequest() override { return flush_access_log_on_new_request_; }
   bool flushAccessLogOnTunnelSuccessfullyEstablished() const override {
     return flush_log_on_tunnel_successfully_established_;
@@ -256,7 +256,7 @@ public:
   NiceMock<Runtime::MockLoader> runtime_;
   NiceMock<Envoy::AccessLog::MockAccessLogManager> log_manager_;
   std::string access_log_path_;
-  std::list<AccessLog::InstanceSharedPtr> access_logs_;
+  AccessLog::InstanceVector access_logs_;
   bool flush_access_log_on_new_request_ = false;
   bool flush_log_on_tunnel_successfully_established_ = false;
   absl::optional<std::chrono::milliseconds> access_log_flush_interval_;

--- a/test/common/quic/envoy_quic_server_stream_test.cc
+++ b/test/common/quic/envoy_quic_server_stream_test.cc
@@ -844,7 +844,7 @@ TEST_F(EnvoyQuicServerStreamTest, StatsGathererLogsOnStreamDestruction) {
 
   // Set up QuicStatsGatherer with required access logger, stream info, headers and trailers.
   std::shared_ptr<AccessLog::MockInstance> mock_logger(new NiceMock<AccessLog::MockInstance>());
-  std::list<AccessLog::InstanceSharedPtr> loggers = {mock_logger};
+  AccessLog::InstanceInlinedVector loggers = {mock_logger};
   Event::GlobalTimeSystem test_time_;
   Envoy::StreamInfo::StreamInfoImpl stream_info{Http::Protocol::Http2, test_time_.timeSystem(),
                                                 nullptr,

--- a/test/common/quic/envoy_quic_server_stream_test.cc
+++ b/test/common/quic/envoy_quic_server_stream_test.cc
@@ -844,7 +844,7 @@ TEST_F(EnvoyQuicServerStreamTest, StatsGathererLogsOnStreamDestruction) {
 
   // Set up QuicStatsGatherer with required access logger, stream info, headers and trailers.
   std::shared_ptr<AccessLog::MockInstance> mock_logger(new NiceMock<AccessLog::MockInstance>());
-  AccessLog::InstanceInlinedVector loggers = {mock_logger};
+  AccessLog::InstanceSharedPtrVector loggers = {mock_logger};
   Event::GlobalTimeSystem test_time_;
   Envoy::StreamInfo::StreamInfoImpl stream_info{Http::Protocol::Http2, test_time_.timeSystem(),
                                                 nullptr,

--- a/test/common/tcp_proxy/tcp_proxy_test.cc
+++ b/test/common/tcp_proxy/tcp_proxy_test.cc
@@ -73,8 +73,7 @@ public:
 
     configure(config);
     mock_access_logger_ = std::make_shared<NiceMock<AccessLog::MockInstance>>();
-    const_cast<std::vector<AccessLog::InstanceSharedPtr>&>(config_->accessLogs())
-        .push_back(mock_access_logger_);
+    const_cast<AccessLog::InstanceVector&>(config_->accessLogs()).push_back(mock_access_logger_);
     upstream_local_address_ = *Network::Utility::resolveUrl("tcp://2.2.2.2:50000");
     upstream_remote_address_ = *Network::Utility::resolveUrl("tcp://127.0.0.1:80");
     for (uint32_t i = 0; i < connections; i++) {

--- a/test/common/tcp_proxy/tcp_proxy_test.cc
+++ b/test/common/tcp_proxy/tcp_proxy_test.cc
@@ -73,7 +73,8 @@ public:
 
     configure(config);
     mock_access_logger_ = std::make_shared<NiceMock<AccessLog::MockInstance>>();
-    const_cast<AccessLog::InstanceVector&>(config_->accessLogs()).push_back(mock_access_logger_);
+    const_cast<AccessLog::InstanceSharedPtrVector&>(config_->accessLogs())
+        .push_back(mock_access_logger_);
     upstream_local_address_ = *Network::Utility::resolveUrl("tcp://2.2.2.2:50000");
     upstream_remote_address_ = *Network::Utility::resolveUrl("tcp://127.0.0.1:80");
     for (uint32_t i = 0; i < connections; i++) {

--- a/test/extensions/bootstrap/internal_listener/active_internal_listener_test.cc
+++ b/test/extensions/bootstrap/internal_listener/active_internal_listener_test.cc
@@ -330,7 +330,7 @@ public:
     Network::ConnectionBalancer& connectionBalancer(const Network::Address::Instance&) override {
       return *connection_balancer_;
     }
-    const AccessLog::InstanceVector& accessLogs() const override { return access_logs_; }
+    const AccessLog::InstanceSharedPtrVector& accessLogs() const override { return access_logs_; }
     ResourceLimit& openConnections() override { return open_connections_; }
     uint32_t tcpBacklogSize() const override { return tcp_backlog_size_; }
     uint32_t maxConnectionsToAcceptPerSocketEvent() const override {
@@ -357,7 +357,7 @@ public:
     std::unique_ptr<InternalListenerConfigImpl> internal_listener_config_;
     Network::ConnectionBalancerSharedPtr connection_balancer_;
     BasicResourceLimitImpl open_connections_;
-    const AccessLog::InstanceVector access_logs_;
+    const AccessLog::InstanceSharedPtrVector access_logs_;
     std::shared_ptr<NiceMock<Network::MockFilterChainManager>> inline_filter_chain_manager_;
     std::unique_ptr<Init::Manager> init_manager_;
     const bool ignore_global_conn_limit_;

--- a/test/extensions/bootstrap/internal_listener/active_internal_listener_test.cc
+++ b/test/extensions/bootstrap/internal_listener/active_internal_listener_test.cc
@@ -330,9 +330,7 @@ public:
     Network::ConnectionBalancer& connectionBalancer(const Network::Address::Instance&) override {
       return *connection_balancer_;
     }
-    const std::vector<AccessLog::InstanceSharedPtr>& accessLogs() const override {
-      return access_logs_;
-    }
+    const AccessLog::InstanceVector& accessLogs() const override { return access_logs_; }
     ResourceLimit& openConnections() override { return open_connections_; }
     uint32_t tcpBacklogSize() const override { return tcp_backlog_size_; }
     uint32_t maxConnectionsToAcceptPerSocketEvent() const override {
@@ -359,7 +357,7 @@ public:
     std::unique_ptr<InternalListenerConfigImpl> internal_listener_config_;
     Network::ConnectionBalancerSharedPtr connection_balancer_;
     BasicResourceLimitImpl open_connections_;
-    const std::vector<AccessLog::InstanceSharedPtr> access_logs_;
+    const AccessLog::InstanceVector access_logs_;
     std::shared_ptr<NiceMock<Network::MockFilterChainManager>> inline_filter_chain_manager_;
     std::unique_ptr<Init::Manager> init_manager_;
     const bool ignore_global_conn_limit_;

--- a/test/extensions/common/proxy_protocol/proxy_protocol_regression_test.cc
+++ b/test/extensions/common/proxy_protocol/proxy_protocol_regression_test.cc
@@ -92,7 +92,9 @@ public:
   Network::ConnectionBalancer& connectionBalancer(const Network::Address::Instance&) override {
     return connection_balancer_;
   }
-  const AccessLog::InstanceVector& accessLogs() const override { return empty_access_logs_; }
+  const AccessLog::InstanceSharedPtrVector& accessLogs() const override {
+    return empty_access_logs_;
+  }
   uint32_t tcpBacklogSize() const override { return ENVOY_TCP_BACKLOG_SIZE; }
   Init::Manager& initManager() override { return *init_manager_; }
   bool ignoreGlobalConnLimit() const override { return false; }
@@ -190,7 +192,7 @@ public:
   std::shared_ptr<Network::MockReadFilter> read_filter_;
   std::string name_;
   const Network::FilterChainSharedPtr filter_chain_;
-  const AccessLog::InstanceVector empty_access_logs_;
+  const AccessLog::InstanceSharedPtrVector empty_access_logs_;
   std::unique_ptr<Init::Manager> init_manager_;
   NiceMock<Runtime::MockLoader> runtime_;
   testing::NiceMock<Random::MockRandomGenerator> random_;

--- a/test/extensions/common/proxy_protocol/proxy_protocol_regression_test.cc
+++ b/test/extensions/common/proxy_protocol/proxy_protocol_regression_test.cc
@@ -92,9 +92,7 @@ public:
   Network::ConnectionBalancer& connectionBalancer(const Network::Address::Instance&) override {
     return connection_balancer_;
   }
-  const std::vector<AccessLog::InstanceSharedPtr>& accessLogs() const override {
-    return empty_access_logs_;
-  }
+  const AccessLog::InstanceVector& accessLogs() const override { return empty_access_logs_; }
   uint32_t tcpBacklogSize() const override { return ENVOY_TCP_BACKLOG_SIZE; }
   Init::Manager& initManager() override { return *init_manager_; }
   bool ignoreGlobalConnLimit() const override { return false; }
@@ -192,7 +190,7 @@ public:
   std::shared_ptr<Network::MockReadFilter> read_filter_;
   std::string name_;
   const Network::FilterChainSharedPtr filter_chain_;
-  const std::vector<AccessLog::InstanceSharedPtr> empty_access_logs_;
+  const AccessLog::InstanceVector empty_access_logs_;
   std::unique_ptr<Init::Manager> init_manager_;
   NiceMock<Runtime::MockLoader> runtime_;
   testing::NiceMock<Random::MockRandomGenerator> random_;

--- a/test/extensions/filters/listener/common/fuzz/listener_filter_fuzzer.h
+++ b/test/extensions/filters/listener/common/fuzz/listener_filter_fuzzer.h
@@ -69,9 +69,7 @@ public:
   Network::ConnectionBalancer& connectionBalancer(const Network::Address::Instance&) override {
     return connection_balancer_;
   }
-  const std::vector<AccessLog::InstanceSharedPtr>& accessLogs() const override {
-    return empty_access_logs_;
-  }
+  const AccessLog::InstanceVector& accessLogs() const override { return empty_access_logs_; }
   uint32_t tcpBacklogSize() const override { return ENVOY_TCP_BACKLOG_SIZE; }
   uint32_t maxConnectionsToAcceptPerSocketEvent() const override {
     return Network::DefaultMaxConnectionsToAcceptPerSocketEvent;
@@ -114,7 +112,7 @@ private:
   NiceMock<Network::MockConnectionCallbacks> connection_callbacks_;
   std::string name_;
   const Network::FilterChainSharedPtr filter_chain_;
-  const std::vector<AccessLog::InstanceSharedPtr> empty_access_logs_;
+  const AccessLog::InstanceVector empty_access_logs_;
   std::unique_ptr<Init::Manager> init_manager_;
   bool connection_established_{};
   const Network::ListenerInfoConstSharedPtr listener_info_;

--- a/test/extensions/filters/listener/common/fuzz/listener_filter_fuzzer.h
+++ b/test/extensions/filters/listener/common/fuzz/listener_filter_fuzzer.h
@@ -69,7 +69,9 @@ public:
   Network::ConnectionBalancer& connectionBalancer(const Network::Address::Instance&) override {
     return connection_balancer_;
   }
-  const AccessLog::InstanceVector& accessLogs() const override { return empty_access_logs_; }
+  const AccessLog::InstanceSharedPtrVector& accessLogs() const override {
+    return empty_access_logs_;
+  }
   uint32_t tcpBacklogSize() const override { return ENVOY_TCP_BACKLOG_SIZE; }
   uint32_t maxConnectionsToAcceptPerSocketEvent() const override {
     return Network::DefaultMaxConnectionsToAcceptPerSocketEvent;
@@ -112,7 +114,7 @@ private:
   NiceMock<Network::MockConnectionCallbacks> connection_callbacks_;
   std::string name_;
   const Network::FilterChainSharedPtr filter_chain_;
-  const AccessLog::InstanceVector empty_access_logs_;
+  const AccessLog::InstanceSharedPtrVector empty_access_logs_;
   std::unique_ptr<Init::Manager> init_manager_;
   bool connection_established_{};
   const Network::ListenerInfoConstSharedPtr listener_info_;

--- a/test/extensions/filters/listener/proxy_protocol/proxy_protocol_test.cc
+++ b/test/extensions/filters/listener/proxy_protocol/proxy_protocol_test.cc
@@ -122,9 +122,7 @@ public:
   Network::ConnectionBalancer& connectionBalancer(const Network::Address::Instance&) override {
     return connection_balancer_;
   }
-  const std::vector<AccessLog::InstanceSharedPtr>& accessLogs() const override {
-    return empty_access_logs_;
-  }
+  const AccessLog::InstanceVector& accessLogs() const override { return empty_access_logs_; }
   uint32_t tcpBacklogSize() const override { return ENVOY_TCP_BACKLOG_SIZE; }
   uint32_t maxConnectionsToAcceptPerSocketEvent() const override {
     return Network::DefaultMaxConnectionsToAcceptPerSocketEvent;
@@ -241,7 +239,7 @@ public:
   std::string name_;
   Api::OsSysCallsImpl os_sys_calls_actual_;
   const Network::FilterChainSharedPtr filter_chain_;
-  const std::vector<AccessLog::InstanceSharedPtr> empty_access_logs_;
+  const AccessLog::InstanceVector empty_access_logs_;
   std::unique_ptr<Init::Manager> init_manager_;
   const Network::ListenerInfoConstSharedPtr listener_info_;
 };
@@ -2704,9 +2702,7 @@ public:
   Network::ConnectionBalancer& connectionBalancer(const Network::Address::Instance&) override {
     return connection_balancer_;
   }
-  const std::vector<AccessLog::InstanceSharedPtr>& accessLogs() const override {
-    return empty_access_logs_;
-  }
+  const AccessLog::InstanceVector& accessLogs() const override { return empty_access_logs_; }
   uint32_t tcpBacklogSize() const override { return ENVOY_TCP_BACKLOG_SIZE; }
   uint32_t maxConnectionsToAcceptPerSocketEvent() const override {
     return Network::DefaultMaxConnectionsToAcceptPerSocketEvent;
@@ -2783,7 +2779,7 @@ public:
   std::shared_ptr<Network::MockReadFilter> read_filter_;
   std::string name_;
   const Network::FilterChainSharedPtr filter_chain_;
-  const std::vector<AccessLog::InstanceSharedPtr> empty_access_logs_;
+  const AccessLog::InstanceVector empty_access_logs_;
   std::unique_ptr<Init::Manager> init_manager_;
   const Network::ListenerInfoConstSharedPtr listener_info_;
 };

--- a/test/extensions/filters/listener/proxy_protocol/proxy_protocol_test.cc
+++ b/test/extensions/filters/listener/proxy_protocol/proxy_protocol_test.cc
@@ -122,7 +122,9 @@ public:
   Network::ConnectionBalancer& connectionBalancer(const Network::Address::Instance&) override {
     return connection_balancer_;
   }
-  const AccessLog::InstanceVector& accessLogs() const override { return empty_access_logs_; }
+  const AccessLog::InstanceSharedPtrVector& accessLogs() const override {
+    return empty_access_logs_;
+  }
   uint32_t tcpBacklogSize() const override { return ENVOY_TCP_BACKLOG_SIZE; }
   uint32_t maxConnectionsToAcceptPerSocketEvent() const override {
     return Network::DefaultMaxConnectionsToAcceptPerSocketEvent;
@@ -239,7 +241,7 @@ public:
   std::string name_;
   Api::OsSysCallsImpl os_sys_calls_actual_;
   const Network::FilterChainSharedPtr filter_chain_;
-  const AccessLog::InstanceVector empty_access_logs_;
+  const AccessLog::InstanceSharedPtrVector empty_access_logs_;
   std::unique_ptr<Init::Manager> init_manager_;
   const Network::ListenerInfoConstSharedPtr listener_info_;
 };
@@ -2702,7 +2704,9 @@ public:
   Network::ConnectionBalancer& connectionBalancer(const Network::Address::Instance&) override {
     return connection_balancer_;
   }
-  const AccessLog::InstanceVector& accessLogs() const override { return empty_access_logs_; }
+  const AccessLog::InstanceSharedPtrVector& accessLogs() const override {
+    return empty_access_logs_;
+  }
   uint32_t tcpBacklogSize() const override { return ENVOY_TCP_BACKLOG_SIZE; }
   uint32_t maxConnectionsToAcceptPerSocketEvent() const override {
     return Network::DefaultMaxConnectionsToAcceptPerSocketEvent;
@@ -2779,7 +2783,7 @@ public:
   std::shared_ptr<Network::MockReadFilter> read_filter_;
   std::string name_;
   const Network::FilterChainSharedPtr filter_chain_;
-  const AccessLog::InstanceVector empty_access_logs_;
+  const AccessLog::InstanceSharedPtrVector empty_access_logs_;
   std::unique_ptr<Init::Manager> init_manager_;
   const Network::ListenerInfoConstSharedPtr listener_info_;
 };

--- a/test/integration/fake_access_log.h
+++ b/test/integration/fake_access_log.h
@@ -51,7 +51,7 @@ public:
 private:
   std::mutex log_callback_lock_;
   LogSignature log_cb_{nullptr};
-  std::vector<AccessLog::InstanceSharedPtr> access_log_instances_;
+  AccessLog::InstanceVector access_log_instances_;
 };
 
 } // namespace Envoy

--- a/test/integration/fake_access_log.h
+++ b/test/integration/fake_access_log.h
@@ -51,7 +51,7 @@ public:
 private:
   std::mutex log_callback_lock_;
   LogSignature log_cb_{nullptr};
-  AccessLog::InstanceVector access_log_instances_;
+  AccessLog::InstanceSharedPtrVector access_log_instances_;
 };
 
 } // namespace Envoy

--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -232,9 +232,7 @@ public:
     RELEASE_ASSERT(false, "initialize if this is needed");
     return *stream_info_;
   }
-  std::list<AccessLog::InstanceSharedPtr> accessLogHandlers() override {
-    return access_log_handlers_;
-  }
+  AccessLog::InstanceInlinedVector accessLogHandlers() override { return access_log_handlers_; }
 
   // Http::StreamCallbacks
   void onResetStream(Http::StreamResetReason reason,
@@ -269,7 +267,7 @@ private:
   Http::MetadataMap metadata_map_;
   absl::node_hash_map<std::string, uint64_t> duplicated_metadata_key_count_;
   std::shared_ptr<StreamInfo::StreamInfo> stream_info_;
-  std::list<AccessLog::InstanceSharedPtr> access_log_handlers_;
+  AccessLog::InstanceInlinedVector access_log_handlers_;
   bool received_data_{false};
   bool grpc_stream_started_{false};
   Http::ServerHeaderValidatorPtr header_validator_;
@@ -906,9 +904,7 @@ private:
       return connection_balancer_;
     }
     bool shouldBypassOverloadManager() const override { return false; }
-    const std::vector<AccessLog::InstanceSharedPtr>& accessLogs() const override {
-      return empty_access_logs_;
-    }
+    const AccessLog::InstanceVector& accessLogs() const override { return empty_access_logs_; }
     const Network::ListenerInfoConstSharedPtr& listenerInfo() const override {
       return listener_info_;
     }
@@ -929,7 +925,7 @@ private:
     const std::string name_;
     Network::NopConnectionBalancerImpl connection_balancer_;
     BasicResourceLimitImpl connection_resource_;
-    const std::vector<AccessLog::InstanceSharedPtr> empty_access_logs_;
+    const AccessLog::InstanceVector empty_access_logs_;
     std::unique_ptr<Init::Manager> init_manager_;
     const Network::ListenerInfoConstSharedPtr listener_info_;
     std::unique_ptr<Server::Configuration::MockListenerFactoryContext> context_;

--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -232,7 +232,7 @@ public:
     RELEASE_ASSERT(false, "initialize if this is needed");
     return *stream_info_;
   }
-  AccessLog::InstanceInlinedVector accessLogHandlers() override { return access_log_handlers_; }
+  AccessLog::InstanceSharedPtrVector accessLogHandlers() override { return access_log_handlers_; }
 
   // Http::StreamCallbacks
   void onResetStream(Http::StreamResetReason reason,
@@ -267,7 +267,7 @@ private:
   Http::MetadataMap metadata_map_;
   absl::node_hash_map<std::string, uint64_t> duplicated_metadata_key_count_;
   std::shared_ptr<StreamInfo::StreamInfo> stream_info_;
-  AccessLog::InstanceInlinedVector access_log_handlers_;
+  AccessLog::InstanceSharedPtrVector access_log_handlers_;
   bool received_data_{false};
   bool grpc_stream_started_{false};
   Http::ServerHeaderValidatorPtr header_validator_;
@@ -904,7 +904,9 @@ private:
       return connection_balancer_;
     }
     bool shouldBypassOverloadManager() const override { return false; }
-    const AccessLog::InstanceVector& accessLogs() const override { return empty_access_logs_; }
+    const AccessLog::InstanceSharedPtrVector& accessLogs() const override {
+      return empty_access_logs_;
+    }
     const Network::ListenerInfoConstSharedPtr& listenerInfo() const override {
       return listener_info_;
     }
@@ -925,7 +927,7 @@ private:
     const std::string name_;
     Network::NopConnectionBalancerImpl connection_balancer_;
     BasicResourceLimitImpl connection_resource_;
-    const AccessLog::InstanceVector empty_access_logs_;
+    const AccessLog::InstanceSharedPtrVector empty_access_logs_;
     std::unique_ptr<Init::Manager> init_manager_;
     const Network::ListenerInfoConstSharedPtr listener_info_;
     std::unique_ptr<Server::Configuration::MockListenerFactoryContext> context_;

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -621,7 +621,7 @@ public:
   }
 
   MOCK_METHOD(const RequestIDExtensionSharedPtr&, requestIDExtension, ());
-  MOCK_METHOD(const AccessLog::InstanceVector&, accessLogs, ());
+  MOCK_METHOD(const AccessLog::InstanceSharedPtrVector&, accessLogs, ());
   MOCK_METHOD(bool, flushAccessLogOnNewRequest, ());
   MOCK_METHOD(bool, flushAccessLogOnTunnelSuccessfullyEstablished, (), (const));
   MOCK_METHOD(const absl::optional<std::chrono::milliseconds>&, accessLogFlushInterval, ());

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -621,7 +621,7 @@ public:
   }
 
   MOCK_METHOD(const RequestIDExtensionSharedPtr&, requestIDExtension, ());
-  MOCK_METHOD(const std::list<AccessLog::InstanceSharedPtr>&, accessLogs, ());
+  MOCK_METHOD(const AccessLog::InstanceVector&, accessLogs, ());
   MOCK_METHOD(bool, flushAccessLogOnNewRequest, ());
   MOCK_METHOD(bool, flushAccessLogOnTunnelSuccessfullyEstablished, (), (const));
   MOCK_METHOD(const absl::optional<std::chrono::milliseconds>&, accessLogFlushInterval, ());

--- a/test/mocks/http/stream_decoder.h
+++ b/test/mocks/http/stream_decoder.h
@@ -31,7 +31,7 @@ public:
   // Http::RequestDecoder
   MOCK_METHOD(void, decodeHeaders_, (RequestHeaderMapSharedPtr & headers, bool end_stream));
   MOCK_METHOD(void, decodeTrailers_, (RequestTrailerMapPtr & trailers));
-  MOCK_METHOD(std::list<AccessLog::InstanceSharedPtr>, accessLogHandlers, ());
+  MOCK_METHOD(AccessLog::InstanceInlinedVector, accessLogHandlers, ());
 };
 
 class MockResponseDecoder : public ResponseDecoder {

--- a/test/mocks/http/stream_decoder.h
+++ b/test/mocks/http/stream_decoder.h
@@ -31,7 +31,7 @@ public:
   // Http::RequestDecoder
   MOCK_METHOD(void, decodeHeaders_, (RequestHeaderMapSharedPtr & headers, bool end_stream));
   MOCK_METHOD(void, decodeTrailers_, (RequestTrailerMapPtr & trailers));
-  MOCK_METHOD(AccessLog::InstanceInlinedVector, accessLogHandlers, ());
+  MOCK_METHOD(AccessLog::InstanceSharedPtrVector, accessLogHandlers, ());
 };
 
 class MockResponseDecoder : public ResponseDecoder {

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -507,7 +507,9 @@ public:
   MOCK_METHOD(bool, ignoreGlobalConnLimit, (), (const));
   MOCK_METHOD(bool, shouldBypassOverloadManager, (), (const));
 
-  const AccessLog::InstanceVector& accessLogs() const override { return empty_access_logs_; }
+  const AccessLog::InstanceSharedPtrVector& accessLogs() const override {
+    return empty_access_logs_;
+  }
 
   const ListenerInfoConstSharedPtr& listenerInfo() const override { return listener_info_; }
 
@@ -517,7 +519,7 @@ public:
   ListenerInfoConstSharedPtr listener_info_;
   Stats::IsolatedStoreImpl store_;
   std::string name_;
-  const AccessLog::InstanceVector empty_access_logs_;
+  const AccessLog::InstanceSharedPtrVector empty_access_logs_;
 };
 
 class MockListener : public Listener {

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -507,9 +507,7 @@ public:
   MOCK_METHOD(bool, ignoreGlobalConnLimit, (), (const));
   MOCK_METHOD(bool, shouldBypassOverloadManager, (), (const));
 
-  const std::vector<AccessLog::InstanceSharedPtr>& accessLogs() const override {
-    return empty_access_logs_;
-  }
+  const AccessLog::InstanceVector& accessLogs() const override { return empty_access_logs_; }
 
   const ListenerInfoConstSharedPtr& listenerInfo() const override { return listener_info_; }
 
@@ -519,7 +517,7 @@ public:
   ListenerInfoConstSharedPtr listener_info_;
   Stats::IsolatedStoreImpl store_;
   std::string name_;
-  const std::vector<AccessLog::InstanceSharedPtr> empty_access_logs_;
+  const AccessLog::InstanceVector empty_access_logs_;
 };
 
 class MockListener : public Listener {

--- a/test/mocks/server/admin.h
+++ b/test/mocks/server/admin.h
@@ -31,7 +31,7 @@ public:
   MOCK_METHOD(Network::Socket&, socket, ());
   MOCK_METHOD(ConfigTracker&, getConfigTracker, ());
   MOCK_METHOD(void, startHttpListener,
-              (AccessLog::InstanceVector access_logs,
+              (AccessLog::InstanceSharedPtrVector access_logs,
                Network::Address::InstanceConstSharedPtr address,
                Network::Socket::OptionsSharedPtr socket_options));
   MOCK_METHOD(Http::Code, request,

--- a/test/mocks/server/admin.h
+++ b/test/mocks/server/admin.h
@@ -31,7 +31,7 @@ public:
   MOCK_METHOD(Network::Socket&, socket, ());
   MOCK_METHOD(ConfigTracker&, getConfigTracker, ());
   MOCK_METHOD(void, startHttpListener,
-              (std::list<AccessLog::InstanceSharedPtr> access_logs,
+              (AccessLog::InstanceVector access_logs,
                Network::Address::InstanceConstSharedPtr address,
                Network::Socket::OptionsSharedPtr socket_options));
   MOCK_METHOD(Http::Code, request,

--- a/test/server/admin/admin_instance.cc
+++ b/test/server/admin/admin_instance.cc
@@ -11,7 +11,7 @@ AdminInstanceTest::AdminInstanceTest()
     : cpu_profile_path_(TestEnvironment::temporaryPath("envoy.prof")),
       admin_(cpu_profile_path_, server_, false), request_headers_{{":path", "/"}},
       admin_filter_(admin_) {
-  std::list<AccessLog::InstanceSharedPtr> access_logs;
+  AccessLog::InstanceVector access_logs;
   Filesystem::FilePathAndType file_info{Filesystem::DestinationType::File, "/dev/null"};
   access_logs.emplace_back(new Extensions::AccessLoggers::File::FileAccessLog(
       file_info, {}, *Formatter::HttpSubstitutionFormatUtils::defaultSubstitutionFormatter(),

--- a/test/server/admin/admin_instance.cc
+++ b/test/server/admin/admin_instance.cc
@@ -11,7 +11,7 @@ AdminInstanceTest::AdminInstanceTest()
     : cpu_profile_path_(TestEnvironment::temporaryPath("envoy.prof")),
       admin_(cpu_profile_path_, server_, false), request_headers_{{":path", "/"}},
       admin_filter_(admin_) {
-  AccessLog::InstanceVector access_logs;
+  AccessLog::InstanceSharedPtrVector access_logs;
   Filesystem::FilePathAndType file_info{Filesystem::DestinationType::File, "/dev/null"};
   access_logs.emplace_back(new Extensions::AccessLoggers::File::FileAccessLog(
       file_info, {}, *Formatter::HttpSubstitutionFormatUtils::defaultSubstitutionFormatter(),

--- a/test/server/admin/admin_test.cc
+++ b/test/server/admin/admin_test.cc
@@ -79,7 +79,7 @@ TEST_P(AdminInstanceTest, WriteAddressToFile) {
 TEST_P(AdminInstanceTest, AdminAddress) {
   server_.options_.admin_address_path_ = TestEnvironment::temporaryPath("admin.address");
   AdminImpl admin_address_out_path(cpu_profile_path_, server_, false);
-  std::list<AccessLog::InstanceSharedPtr> access_logs;
+  AccessLog::InstanceVector access_logs;
   Filesystem::FilePathAndType file_info{Filesystem::DestinationType::File, "/dev/null"};
   access_logs.emplace_back(new Extensions::AccessLoggers::File::FileAccessLog(
       file_info, {}, *Formatter::HttpSubstitutionFormatUtils::defaultSubstitutionFormatter(),
@@ -94,7 +94,7 @@ TEST_P(AdminInstanceTest, AdminBadAddressOutPath) {
   server_.options_.admin_address_path_ =
       TestEnvironment::temporaryPath("some/unlikely/bad/path/admin.address");
   AdminImpl admin_bad_address_out_path(cpu_profile_path_, server_, false);
-  std::list<AccessLog::InstanceSharedPtr> access_logs;
+  AccessLog::InstanceVector access_logs;
   Filesystem::FilePathAndType file_info{Filesystem::DestinationType::File, "/dev/null"};
   access_logs.emplace_back(new Extensions::AccessLoggers::File::FileAccessLog(
       file_info, {}, *Formatter::HttpSubstitutionFormatUtils::defaultSubstitutionFormatter(),

--- a/test/server/admin/admin_test.cc
+++ b/test/server/admin/admin_test.cc
@@ -79,7 +79,7 @@ TEST_P(AdminInstanceTest, WriteAddressToFile) {
 TEST_P(AdminInstanceTest, AdminAddress) {
   server_.options_.admin_address_path_ = TestEnvironment::temporaryPath("admin.address");
   AdminImpl admin_address_out_path(cpu_profile_path_, server_, false);
-  AccessLog::InstanceVector access_logs;
+  AccessLog::InstanceSharedPtrVector access_logs;
   Filesystem::FilePathAndType file_info{Filesystem::DestinationType::File, "/dev/null"};
   access_logs.emplace_back(new Extensions::AccessLoggers::File::FileAccessLog(
       file_info, {}, *Formatter::HttpSubstitutionFormatUtils::defaultSubstitutionFormatter(),
@@ -94,7 +94,7 @@ TEST_P(AdminInstanceTest, AdminBadAddressOutPath) {
   server_.options_.admin_address_path_ =
       TestEnvironment::temporaryPath("some/unlikely/bad/path/admin.address");
   AdminImpl admin_bad_address_out_path(cpu_profile_path_, server_, false);
-  AccessLog::InstanceVector access_logs;
+  AccessLog::InstanceSharedPtrVector access_logs;
   Filesystem::FilePathAndType file_info{Filesystem::DestinationType::File, "/dev/null"};
   access_logs.emplace_back(new Extensions::AccessLoggers::File::FileAccessLog(
       file_info, {}, *Formatter::HttpSubstitutionFormatUtils::defaultSubstitutionFormatter(),

--- a/test/server/connection_handler_test.cc
+++ b/test/server/connection_handler_test.cc
@@ -170,7 +170,7 @@ public:
     void setDirection(envoy::config::core::v3::TrafficDirection direction) {
       direction_ = direction;
     }
-    const AccessLog::InstanceVector& accessLogs() const override { return access_logs_; }
+    const AccessLog::InstanceSharedPtrVector& accessLogs() const override { return access_logs_; }
     ResourceLimit& openConnections() override { return open_connections_; }
     uint32_t tcpBacklogSize() const override { return tcp_backlog_size_; }
     uint32_t maxConnectionsToAcceptPerSocketEvent() const override {
@@ -196,7 +196,7 @@ public:
     const bool continue_on_listener_filters_timeout_;
     std::unique_ptr<UdpListenerConfigImpl> udp_listener_config_;
     BasicResourceLimitImpl open_connections_;
-    const AccessLog::InstanceVector access_logs_;
+    const AccessLog::InstanceSharedPtrVector access_logs_;
     std::shared_ptr<NiceMock<Network::MockFilterChainManager>> inline_filter_chain_manager_;
     std::unique_ptr<Init::Manager> init_manager_;
     const bool ignore_global_conn_limit_;

--- a/test/server/connection_handler_test.cc
+++ b/test/server/connection_handler_test.cc
@@ -170,9 +170,7 @@ public:
     void setDirection(envoy::config::core::v3::TrafficDirection direction) {
       direction_ = direction;
     }
-    const std::vector<AccessLog::InstanceSharedPtr>& accessLogs() const override {
-      return access_logs_;
-    }
+    const AccessLog::InstanceVector& accessLogs() const override { return access_logs_; }
     ResourceLimit& openConnections() override { return open_connections_; }
     uint32_t tcpBacklogSize() const override { return tcp_backlog_size_; }
     uint32_t maxConnectionsToAcceptPerSocketEvent() const override {
@@ -198,7 +196,7 @@ public:
     const bool continue_on_listener_filters_timeout_;
     std::unique_ptr<UdpListenerConfigImpl> udp_listener_config_;
     BasicResourceLimitImpl open_connections_;
-    const std::vector<AccessLog::InstanceSharedPtr> access_logs_;
+    const AccessLog::InstanceVector access_logs_;
     std::shared_ptr<NiceMock<Network::MockFilterChainManager>> inline_filter_chain_manager_;
     std::unique_ptr<Init::Manager> init_manager_;
     const bool ignore_global_conn_limit_;


### PR DESCRIPTION
Commit Message: replace access log list to access log vector
Additional Description:

std::list is not good choice for the scenario where needn't 0(1) insert/remove.

Risk Level: low.
Testing: n/a.
Docs Changes: n/a.
Release Notes: n/a.