### PR TITLE
dns: add round-robin nameserver rotation option to c-ares resolver

### DIFF
--- a/api/envoy/extensions/network/dns_resolver/cares/v3/cares_dns_resolver.proto
+++ b/api/envoy/extensions/network/dns_resolver/cares/v3/cares_dns_resolver.proto
@@ -20,7 +20,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // [#extension: envoy.network.dns_resolver.cares]
 
 // Configuration for c-ares DNS resolver.
-// [#next-free-field: 8]
+// [#next-free-field: 9]
 message CaresDnsResolverConfig {
   // A list of dns resolver addresses.
   // :ref:`use_resolvers_as_fallback<envoy_v3_api_field_extensions.network.dns_resolver.cares.v3.CaresDnsResolverConfig.use_resolvers_as_fallback>`
@@ -61,4 +61,11 @@ message CaresDnsResolverConfig {
   // Note: While the c-ares library defaults to 3 attempts, Envoy's default (if this field is unset) is 4 attempts.
   // This adjustment was made to maintain the previous behavior after users reported an increase in DNS resolution times.
   google.protobuf.UInt32Value query_tries = 7 [(validate.rules).uint32 = {gte: 1}];
+
+  // Enable round-robin selection of name servers for DNS resolution. When enabled, the resolver will cycle through the
+  // list of name servers for each resolution request. This can help distribute the query load across multiple name
+  // servers. If disabled (default), the resolver will try name servers in the order they are configured.
+  //
+  // Note: This setting overrides any system configuration for name server rotation.
+  bool rotate_nameservers = 8;
 }

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -203,7 +203,11 @@ new_features:
   change: |
     added :ref:`sourced_metadata <envoy_v3_api_field_config.rbac.v3.Permission.sourced_metadata>` which allows
     specifying an optional source for the metadata to be matched in addition to the metadata matcher.
-
+- area: c-ares
+  change: |
+    added nameserver rotation option to c-ares resolver. When enabled via :ref:rotate_nameservers
+    <envoy_v3_api_field_extensions.network.dns_resolver.cares.v3.CaresDnsResolverConfig.rotate_nameservers>, this
+    performs round-robin selection of the configured nameservers for each resolution to help distribute query load.
 deprecated:
 - area: rbac
   change: |

--- a/source/extensions/network/dns_resolver/cares/dns_impl.cc
+++ b/source/extensions/network/dns_resolver/cares/dns_impl.cc
@@ -50,7 +50,7 @@ DnsResolverImpl::DnsResolverImpl(
           config, query_timeout_seconds, DEFAULT_QUERY_TIMEOUT_SECONDS))),
       query_tries_(static_cast<uint32_t>(
           PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, query_tries, DEFAULT_QUERY_TRIES))),
-      resolvers_csv_(resolvers_csv),
+      rotate_nameservers_(config.rotate_nameservers()), resolvers_csv_(resolvers_csv),
       filter_unroutable_families_(config.filter_unroutable_families()),
       scope_(root_scope.createScope("dns.cares.")), stats_(generateCaresDnsResolverStats(*scope_)) {
   AresOptions options = defaultAresOptions();
@@ -118,6 +118,12 @@ DnsResolverImpl::AresOptions DnsResolverImpl::defaultAresOptions() {
   options.options_.timeout = query_timeout_seconds_;
   options.optmask_ |= ARES_OPT_TRIES;
   options.options_.tries = query_tries_;
+
+  if (rotate_nameservers_) {
+    options.optmask_ |= ARES_OPT_ROTATE;
+  } else {
+    options.optmask_ |= ARES_OPT_NOROTATE;
+  }
 
   return options;
 }

--- a/source/extensions/network/dns_resolver/cares/dns_impl.h
+++ b/source/extensions/network/dns_resolver/cares/dns_impl.h
@@ -201,6 +201,7 @@ private:
   const uint32_t udp_max_queries_;
   const uint64_t query_timeout_seconds_;
   const uint32_t query_tries_;
+  const bool rotate_nameservers_;
   const absl::optional<std::string> resolvers_csv_;
   const bool filter_unroutable_families_;
   Stats::ScopeSharedPtr scope_;


### PR DESCRIPTION
## Description

This PR adds support for [configuring round-robin nameserver selection](https://arc.net/l/quote/zjajnycz) in the c-ares DNS resolver. When enabled, this will rotate through the configured nameservers for each resolution request, helping to distribute query load across multiple nameservers.

---

**Commit Message:** dns: add round-robin nameserver rotation option to c-ares resolver

**Additional Description:**
This change adds a new `rotate_nameservers` option to the c-ares DNS resolver config proto. When enabled, Envoy will use round-robin selection of nameservers for DNS resolution, rather than always using them in configured order. This matches c-ares' native `ARES_OPT_ROTATE` and `ARES_OPT_NOROTATE` options.

The feature allows better load distribution across multiple nameservers without requiring any changes to DNS server configuration.

**Risk Level:** Low
- Changes are confined to DNS resolution configuration
- Builds on existing c-ares functionality
- Default behavior (no rotation) remains unchanged

**Testing:**
- Added unit tests verifying both enabled and disabled rotation behavior
- Tests verify proper setting of c-ares `ARES_OPT_ROTATE` and `ARES_OPT_NOROTATE` flags
- No changes to existing resolver test behavior

**Docs Changes:**
- Added API documentation for new `rotate_nameservers` field
- Added to DNS resolver configuration docs
- Added changelog entry under new features

**Release Notes:** Added nameserver rotation option to c-ares resolver to enable round-robin selection of nameservers for better load distribution.