### PR TITLE
tests: use makeOptRef to create an OptRef object

### DIFF
--- a/test/extensions/config_subscription/grpc/xds_failover_integration_test.cc
+++ b/test/extensions/config_subscription/grpc/xds_failover_integration_test.cc
@@ -669,14 +669,14 @@ TEST_P(XdsFailoverAdsIntegrationTest, PrimaryUseAfterFailoverResponseAndDisconne
   const absl::flat_hash_map<std::string, std::string> empty_initial_resource_versions_map;
   EXPECT_TRUE(compareDiscoveryRequest(CdsTypeUrl, "", {}, {}, {}, true,
                                       Grpc::Status::WellKnownGrpcStatus::Ok, "", xds_stream_.get(),
-                                      OptRef(empty_initial_resource_versions_map)));
+                                      makeOptRef(empty_initial_resource_versions_map)));
   EXPECT_TRUE(compareDiscoveryRequest(EdsTypeUrl, "", {"failover_cluster_0"},
                                       {"failover_cluster_0"}, {}, false,
                                       Grpc::Status::WellKnownGrpcStatus::Ok, "", xds_stream_.get(),
-                                      OptRef(empty_initial_resource_versions_map)));
+                                      makeOptRef(empty_initial_resource_versions_map)));
   EXPECT_TRUE(compareDiscoveryRequest(LdsTypeUrl, "", {}, {}, {}, false,
                                       Grpc::Status::WellKnownGrpcStatus::Ok, "", xds_stream_.get(),
-                                      OptRef(empty_initial_resource_versions_map)));
+                                      makeOptRef(empty_initial_resource_versions_map)));
   sendDiscoveryResponse<envoy::config::cluster::v3::Cluster>(
       CdsTypeUrl, {ConfigHelper::buildCluster("primary_cluster_0")},
       {ConfigHelper::buildCluster("primary_cluster_0")}, {}, "primary1", {}, xds_stream_.get());
@@ -791,14 +791,14 @@ TEST_P(XdsFailoverAdsIntegrationTest, FailoverUseAfterFailoverResponseAndDisconn
   const absl::flat_hash_map<std::string, std::string> empty_initial_resource_versions_map;
   EXPECT_TRUE(compareDiscoveryRequest(
       CdsTypeUrl, "", {}, {}, {}, true, Grpc::Status::WellKnownGrpcStatus::Ok, "",
-      failover_xds_stream_.get(), OptRef(cds_eds_initial_resource_versions_map)));
+      failover_xds_stream_.get(), makeOptRef(cds_eds_initial_resource_versions_map)));
   EXPECT_TRUE(compareDiscoveryRequest(
       EdsTypeUrl, "", {"failover_cluster_0"}, {"failover_cluster_0"}, {}, false,
       Grpc::Status::WellKnownGrpcStatus::Ok, "", failover_xds_stream_.get(),
-      OptRef(cds_eds_initial_resource_versions_map)));
+      makeOptRef(cds_eds_initial_resource_versions_map)));
   EXPECT_TRUE(compareDiscoveryRequest(
       LdsTypeUrl, "", {}, {}, {}, false, Grpc::Status::WellKnownGrpcStatus::Ok, "",
-      failover_xds_stream_.get(), OptRef(empty_initial_resource_versions_map)));
+      failover_xds_stream_.get(), makeOptRef(empty_initial_resource_versions_map)));
   sendDiscoveryResponse<envoy::config::cluster::v3::Cluster>(
       CdsTypeUrl, {ConfigHelper::buildCluster("failover_cluster_1")},
       {ConfigHelper::buildCluster("failover_cluster_1")}, {}, "failover2", {},
@@ -1048,13 +1048,13 @@ TEST_P(XdsFailoverAdsIntegrationTest, NoPrimaryUseAfterFailoverResponse) {
   const absl::flat_hash_map<std::string, std::string> empty_initial_resource_versions_map;
   EXPECT_TRUE(compareDiscoveryRequest(
       CdsTypeUrl, "1", {}, {}, {}, true, Grpc::Status::WellKnownGrpcStatus::Ok, "",
-      failover_xds_stream_.get(), OptRef(cds_eds_initial_resource_versions_map)));
+      failover_xds_stream_.get(), makeOptRef(cds_eds_initial_resource_versions_map)));
   EXPECT_TRUE(compareDiscoveryRequest(
       EdsTypeUrl, "1", {"failover_cluster_0"}, {"failover_cluster_0"}, {}, false,
       Grpc::Status::WellKnownGrpcStatus::Ok, "", failover_xds_stream_.get(),
-      OptRef(cds_eds_initial_resource_versions_map)));
+      makeOptRef(cds_eds_initial_resource_versions_map)));
   EXPECT_TRUE(compareDiscoveryRequest(
       LdsTypeUrl, "", {}, {}, {}, false, Grpc::Status::WellKnownGrpcStatus::Ok, "",
-      failover_xds_stream_.get(), OptRef(empty_initial_resource_versions_map)));
+      failover_xds_stream_.get(), makeOptRef(empty_initial_resource_versions_map)));
 }
 } // namespace Envoy

--- a/test/integration/ads_integration_test.cc
+++ b/test/integration/ads_integration_test.cc
@@ -2904,14 +2904,14 @@ TEST_P(AdsReplacementIntegrationTest, ReplaceAdsConfig) {
   const absl::flat_hash_map<std::string, std::string> empty_initial_resource_versions_map;
   EXPECT_TRUE(compareDiscoveryRequest(
       Config::TypeUrl::get().Cluster, "", {}, {}, {}, true, Grpc::Status::WellKnownGrpcStatus::Ok,
-      "", second_xds_stream_.get(), OptRef(cds_eds_initial_resource_versions_map)));
+      "", second_xds_stream_.get(), makeOptRef(cds_eds_initial_resource_versions_map)));
   EXPECT_TRUE(compareDiscoveryRequest(
       Config::TypeUrl::get().ClusterLoadAssignment, "", {"cluster_0"}, {"cluster_0"}, {}, false,
       Grpc::Status::WellKnownGrpcStatus::Ok, "", second_xds_stream_.get(),
-      OptRef(cds_eds_initial_resource_versions_map)));
+      makeOptRef(cds_eds_initial_resource_versions_map)));
   EXPECT_TRUE(compareDiscoveryRequest(
       Config::TypeUrl::get().Listener, "", {}, {}, {}, false, Grpc::Status::WellKnownGrpcStatus::Ok,
-      "", second_xds_stream_.get(), OptRef(empty_initial_resource_versions_map)));
+      "", second_xds_stream_.get(), makeOptRef(empty_initial_resource_versions_map)));
   // Send a CDS response with new resources.
   sendDiscoveryResponse<envoy::config::cluster::v3::Cluster>(
       Config::TypeUrl::get().Cluster, {buildCluster("replaced_cluster")},


### PR DESCRIPTION
Commit Message: tests: use makeOptRef to create an OptRef object
Additional Description:
C++17 attempts to enforce explicit deduction rules, so prior code fails in newer builds with the following error:
```
error: 'OptRef' may not intend to support class template argument deduction [-Werror,-Wctad-maybe-unsupported]
```
This PR changes the tests code to use `makeOptRef()` insted of letting `OptRef()` deduce the types.

Risk Level: low - tests only
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A