### PR TITLE
doc: update inotify assertion to provide more accurate feedback

### DIFF
--- a/source/common/filesystem/inotify/watcher_impl.cc
+++ b/source/common/filesystem/inotify/watcher_impl.cc
@@ -19,8 +19,8 @@ namespace Filesystem {
 WatcherImpl::WatcherImpl(Event::Dispatcher& dispatcher, Filesystem::Instance& file_system)
     : file_system_(file_system) {
   inotify_fd_ = inotify_init1(IN_NONBLOCK);
-  RELEASE_ASSERT(inotify_fd_ >= 0,
-                 "Consider increasing value of user.max_inotify_watches via sysctl");
+  RELEASE_ASSERT(inotify_fd_ >= 0, "Consider increasing value of fs.inotify.max_user_watches "
+                                   "and/or fs.inotify.max_user_instances via sysctl");
   inotify_event_ = dispatcher.createFileEvent(
       inotify_fd_,
       [this](uint32_t events) {


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: update the inotify critical assertion message to provide more accurate feedback
Additional Description: If inotify fails to watch additional file descriptors the solution is usually a combination of setting max_user_instances as well as max_user_watches (from personal experience). In addition, it seems like the original message had `user` and `inotify` inverted by accident? 
Risk Level: low
Testing: -
Docs Changes: -
Release Notes: -
Platform Specific Features: -
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]

