### PR TITLE
access_log: add UPSTREAM_HOST_NAME_WITHOUT_PORT variable

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -203,6 +203,10 @@ new_features:
   change: |
     added :ref:`sourced_metadata <envoy_v3_api_field_config.rbac.v3.Permission.sourced_metadata>` which allows
     specifying an optional source for the metadata to be matched in addition to the metadata matcher.
+- area: access_log
+  change: |
+    Added support for :ref:`%UPSTREAM_HOST_NAME_WITHOUT_PORT% <config_access_log_format_upstream_host_name_without_port>`
+    for the upstream host identifier without the port value.
 
 deprecated:
 - area: rbac

--- a/docs/root/configuration/observability/access_log/usage.rst
+++ b/docs/root/configuration/observability/access_log/usage.rst
@@ -598,6 +598,12 @@ UDP
   Upstream host name (e.g., DNS name). If no DNS name is available, the main address of the upstream host
   (e.g., ip:port for TCP connections) will be used.
 
+.. _config_access_log_format_upstream_host_name_without_port:
+
+%UPSTREAM_HOST_NAME_WITHOUT_PORT%
+  Upstream host name (e.g., DNS name) without port component. If no DNS name is available,
+  the main address of the upstream host (e.g., ip for TCP connections) will be used.
+
 %UPSTREAM_CLUSTER%
   Upstream cluster to which the upstream host belongs to. :ref:`alt_stat_name
   <envoy_v3_api_field_config.cluster.v3.Cluster.alt_stat_name>` will be used if provided.

--- a/source/common/formatter/stream_info_formatter.cc
+++ b/source/common/formatter/stream_info_formatter.cc
@@ -1102,7 +1102,7 @@ const StreamInfoFormatterProviderLookupTable& getKnownStreamInfoFormatterProvide
                     std::string host_name = host->hostname();
                     if (host_name.empty()) {
                       // If no hostname is available, the main address is used.
-                      return host->address()->ip()->addressAsString();
+                      host_name = host->address()->asString();
                     }
                     Envoy::Http::HeaderUtility::stripPortFromHost(host_name);
                     return absl::make_optional<std::string>(std::move(host_name));

--- a/source/common/http/header_utility.cc
+++ b/source/common/http/header_utility.cc
@@ -415,6 +415,14 @@ absl::optional<uint32_t> HeaderUtility::stripPortFromHost(RequestHeaderMap& head
   return port;
 }
 
+void HeaderUtility::stripPortFromHost(std::string& host) {
+  const absl::string_view::size_type port_start = getPortStart(host);
+  if (port_start == absl::string_view::npos) {
+    return;
+  }
+  host = host.substr(0, port_start);
+}
+
 absl::string_view::size_type HeaderUtility::getPortStart(absl::string_view host) {
   const absl::string_view::size_type port_start = host.rfind(':');
   if (port_start == absl::string_view::npos) {

--- a/source/common/http/header_utility.h
+++ b/source/common/http/header_utility.h
@@ -406,6 +406,11 @@ public:
                                                     absl::optional<uint32_t> listener_port);
 
   /**
+   * @brief Remove the port part from host if it exists.
+   */
+  static void stripPortFromHost(std::string& host);
+
+  /**
    * @brief Return the index of the port, or npos if the host has no port
    *
    * Note this does not do validity checks on the port, it just finds the

--- a/test/common/formatter/substitution_formatter_test.cc
+++ b/test/common/formatter/substitution_formatter_test.cc
@@ -669,6 +669,28 @@ TEST(SubstitutionFormatterTest, streamInfoFormatter) {
                 ProtoEq(ValueUtil::stringValue("10.0.0.1:443")));
   }
 
+  {
+    StreamInfoFormatter upstream_format("UPSTREAM_HOST_NAME_WITHOUT_PORT");
+
+    // Hostname includes port.
+    mock_host->hostname_ = "upstream_host_xxx:443";
+    EXPECT_EQ("upstream_host_xxx", upstream_format.formatWithContext({}, stream_info));
+    EXPECT_THAT(upstream_format.formatValueWithContext({}, stream_info),
+                ProtoEq(ValueUtil::stringValue("upstream_host_xxx")));
+
+    // Hostname doesn't include port.
+    mock_host->hostname_ = "upstream_host_xxx";
+    EXPECT_EQ("upstream_host_xxx", upstream_format.formatWithContext({}, stream_info));
+    EXPECT_THAT(upstream_format.formatValueWithContext({}, stream_info),
+                ProtoEq(ValueUtil::stringValue("upstream_host_xxx")));
+
+    // Hostname is not used then the main address (only the ip) is used.
+    mock_host->hostname_.clear();
+    EXPECT_EQ("10.0.0.1", upstream_format.formatWithContext({}, stream_info));
+    EXPECT_THAT(upstream_format.formatValueWithContext({}, stream_info),
+                ProtoEq(ValueUtil::stringValue("10.0.0.1")));
+  }
+
   auto test_upstream_remote_address =
       Network::Address::InstanceConstSharedPtr{new Network::Address::Ipv4Instance("10.0.0.2", 80)};
   auto default_upstream_remote_address = stream_info.upstreamInfo()->upstreamRemoteAddress();


### PR DESCRIPTION
Resolve #37095 

Commit Message: add UPSTREAM_HOST_NAME_WITHOUT_PORT variable for access log
Additional Description: when using Dynamic Forward Proxy cluster in addition to Strict DNS clusters, the UPSTREAM_HOST_NAME variable returns inconsistent value in access log:
For Strict DNS cluster: We're getting the DNS name only as expected.
For Dynamic Forward Proxy cluster: We're getting the DNS name with the port value.
Risk Level: low
Testing: unit
Docs Changes: Added
Release Notes: Added
Platform Specific Features: N/A
