### PR TITLE
ext_proc: support HeaderAppendAction in mutation utils

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -24,6 +24,14 @@ behavior_changes:
     rather than waiting for the original request to complete. This allows shadowing requests larger than the buffer limit,
     but also means shadowing may take place for requests which are canceled mid-stream. This behavior change can be
     temporarily reverted by flipping  ``envoy.reloadable_features.streaming_shadow`` to false.
+- area: ext_proc
+  change: |
+    The default behavior for header mutations in ext_proc changed. Previously, header values would be replaced by default,
+    and setting append to true was required for appending. Now, header values will be appended by default if append is
+    not specified. The old behavior can be temporarily restored by setting runtime guard
+    ``envoy.reloadable_features.ext_proc_legacy_append`` to ``true``. For more control over header mutation behavior,
+    use the :ref:`append_action <envoy_v3_api_field_config.core.v3.HeaderValueOption.append_action>` field which will
+    be the only supported option in the future.
 
 minor_behavior_changes:
 # *Changes that may cause incompatibilities for some users, but should not for most*
@@ -265,6 +273,11 @@ new_features:
   change: |
     Added support in SNI dynamic forward proxy for saving the resolved upstream address in the filter state.
     The state is saved with the key ``envoy.stream.upstream_address``.
+- area: ext_proc
+  change: |
+    Added support for ``HeaderAppendAction`` in ext_proc mutation utils, allowing more granular control over header
+    modifications using ``APPEND_IF_EXISTS_OR_ADD``, ``ADD_IF_ABSENT``, ``OVERWRITE_IF_EXISTS``, and
+    ``OVERWRITE_IF_EXISTS_OR_ADD`` actions. The existing append behavior continues to work as before.
 
 deprecated:
 - area: rbac

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -113,6 +113,9 @@ RUNTIME_GUARD(envoy_restart_features_use_eds_cache_for_ads);
 
 // Begin false flags. Most of them should come with a TODO to flip true.
 
+// Used to temporarily allow the legacy append behavior on ext_proc header mutations
+FALSE_RUNTIME_GUARD(envoy_reloadable_features_ext_proc_legacy_append);
+
 // Sentinel and test flag.
 FALSE_RUNTIME_GUARD(envoy_reloadable_features_test_feature_false);
 // TODO(adisuissa) reset to true to enable unified mux by default

--- a/test/extensions/filters/http/ext_proc/BUILD
+++ b/test/extensions/filters/http/ext_proc/BUILD
@@ -151,6 +151,7 @@ envoy_extension_cc_test(
         "//source/extensions/filters/http/ext_proc:mutation_utils_lib",
         "//test/mocks/server:server_factory_context_mocks",
         "//test/mocks/stats:stats_mocks",
+        "//test/test_common:test_runtime_lib",
         "//test/test_common:utility_lib",
         "@envoy_api//envoy/config/common/mutation_rules/v3:pkg_cc_proto",
     ],

--- a/test/extensions/filters/http/ext_proc/filter_test.cc
+++ b/test/extensions/filters/http/ext_proc/filter_test.cc
@@ -796,6 +796,8 @@ TEST_F(HttpFilterTest, PostAndChangeHeaders) {
 
     auto* resp_headers_mut = header_resp.mutable_response()->mutable_header_mutation();
     auto* resp_add1 = resp_headers_mut->add_set_headers();
+    resp_add1->set_append_action(
+        envoy::config::core::v3::HeaderValueOption::OVERWRITE_IF_EXISTS_OR_ADD);
     resp_add1->mutable_header()->set_key("x-new-header");
     resp_add1->mutable_header()->set_raw_value("new");
   });
@@ -847,6 +849,7 @@ TEST_F(HttpFilterTest, PostAndRespondImmediately) {
   immediate_response->set_details("Got a bad request");
   auto* immediate_headers = immediate_response->mutable_headers();
   auto* hdr1 = immediate_headers->add_set_headers();
+  hdr1->set_append_action(envoy::config::core::v3::HeaderValueOption::OVERWRITE_IF_EXISTS_OR_ADD);
   hdr1->mutable_header()->set_key("content-type");
   hdr1->mutable_header()->set_raw_value("text/plain");
   auto* hdr2 = immediate_headers->add_set_headers();
@@ -902,6 +905,7 @@ TEST_F(HttpFilterTest, PostAndRespondImmediatelyWithDisabledConfig) {
   immediate_response->set_details("Got a bad request");
   auto* immediate_headers = immediate_response->mutable_headers();
   auto* hdr1 = immediate_headers->add_set_headers();
+  hdr1->set_append_action(envoy::config::core::v3::HeaderValueOption::OVERWRITE_IF_EXISTS_OR_ADD);
   hdr1->mutable_header()->set_key("content-type");
   hdr1->mutable_header()->set_raw_value("text/plain");
   stream_callbacks_->onReceiveMessage(std::move(resp1));
@@ -2859,6 +2863,8 @@ TEST_F(HttpFilterTest, ClearRouteCacheHeaderMutation) {
   processRequestHeaders(false, [](const HttpHeaders&, ProcessingResponse&, HeadersResponse& resp) {
     auto* resp_headers_mut = resp.mutable_response()->mutable_header_mutation();
     auto* resp_add = resp_headers_mut->add_set_headers();
+    resp_add->set_append_action(
+        envoy::config::core::v3::HeaderValueOption::OVERWRITE_IF_EXISTS_OR_ADD);
     resp_add->mutable_header()->set_key("x-new-header");
     resp_add->mutable_header()->set_raw_value("new");
     resp.mutable_response()->set_clear_route_cache(true);
@@ -2876,6 +2882,8 @@ TEST_F(HttpFilterTest, ClearRouteCacheHeaderMutation) {
   processResponseBody([](const HttpBody&, ProcessingResponse&, BodyResponse& resp) {
     auto* resp_headers_mut = resp.mutable_response()->mutable_header_mutation();
     auto* resp_add = resp_headers_mut->add_set_headers();
+    resp_add->set_append_action(
+        envoy::config::core::v3::HeaderValueOption::OVERWRITE_IF_EXISTS_OR_ADD);
     resp_add->mutable_header()->set_key("x-new-header");
     resp_add->mutable_header()->set_raw_value("new");
     resp.mutable_response()->set_clear_route_cache(true);
@@ -2909,6 +2917,8 @@ TEST_F(HttpFilterTest, ClearRouteCacheDisabledHeaderMutation) {
   processRequestHeaders(false, [](const HttpHeaders&, ProcessingResponse&, HeadersResponse& resp) {
     auto* resp_headers_mut = resp.mutable_response()->mutable_header_mutation();
     auto* resp_add = resp_headers_mut->add_set_headers();
+    resp_add->set_append_action(
+        envoy::config::core::v3::HeaderValueOption::OVERWRITE_IF_EXISTS_OR_ADD);
     resp_add->mutable_header()->set_key("x-new-header");
     resp_add->mutable_header()->set_raw_value("new");
     resp.mutable_response()->set_clear_route_cache(true);
@@ -2926,6 +2936,8 @@ TEST_F(HttpFilterTest, ClearRouteCacheDisabledHeaderMutation) {
   processResponseBody([](const HttpBody&, ProcessingResponse&, BodyResponse& resp) {
     auto* resp_headers_mut = resp.mutable_response()->mutable_header_mutation();
     auto* resp_add = resp_headers_mut->add_set_headers();
+    resp_add->set_append_action(
+        envoy::config::core::v3::HeaderValueOption::OVERWRITE_IF_EXISTS_OR_ADD);
     resp_add->mutable_header()->set_key("x-new-header");
     resp_add->mutable_header()->set_raw_value("new");
     resp.mutable_response()->set_clear_route_cache(true);
@@ -3031,6 +3043,8 @@ TEST_F(HttpFilterTest, FilterRouteCacheActionSetToClearHeaderMutation) {
   processRequestHeaders(false, [](const HttpHeaders&, ProcessingResponse&, HeadersResponse& resp) {
     auto* resp_headers_mut = resp.mutable_response()->mutable_header_mutation();
     auto* resp_add = resp_headers_mut->add_set_headers();
+    resp_add->set_append_action(
+        envoy::config::core::v3::HeaderValueOption::OVERWRITE_IF_EXISTS_OR_ADD);
     resp_add->mutable_header()->set_key("x-new-header");
     resp_add->mutable_header()->set_raw_value("new");
   });
@@ -3110,6 +3124,8 @@ TEST_F(HttpFilterTest, FilterRouteCacheActionSetToRetainWithHeaderMutation) {
   processRequestHeaders(false, [](const HttpHeaders&, ProcessingResponse&, HeadersResponse& resp) {
     auto* resp_headers_mut = resp.mutable_response()->mutable_header_mutation();
     auto* resp_add = resp_headers_mut->add_set_headers();
+    resp_add->set_append_action(
+        envoy::config::core::v3::HeaderValueOption::OVERWRITE_IF_EXISTS_OR_ADD);
     resp_add->mutable_header()->set_key("x-new-header");
     resp_add->mutable_header()->set_raw_value("new");
     resp.mutable_response()->set_clear_route_cache(true);
@@ -3138,6 +3154,8 @@ TEST_F(HttpFilterTest, FilterRouteCacheActionSetToRetainResponseNotWithHeaderMut
   processRequestHeaders(false, [](const HttpHeaders&, ProcessingResponse&, HeadersResponse& resp) {
     auto* resp_headers_mut = resp.mutable_response()->mutable_header_mutation();
     auto* resp_add = resp_headers_mut->add_set_headers();
+    resp_add->set_append_action(
+        envoy::config::core::v3::HeaderValueOption::OVERWRITE_IF_EXISTS_OR_ADD);
     resp_add->mutable_header()->set_key("x-new-header");
     resp_add->mutable_header()->set_raw_value("new");
   });
@@ -3165,14 +3183,15 @@ TEST_F(HttpFilterTest, ReplaceRequest) {
 
   Buffer::OwnedImpl req_buffer;
   setUpDecodingBuffering(req_buffer, true);
-  processRequestHeaders(
-      false, [](const HttpHeaders&, ProcessingResponse&, HeadersResponse& hdrs_resp) {
-        hdrs_resp.mutable_response()->set_status(CommonResponse::CONTINUE_AND_REPLACE);
-        auto* hdr = hdrs_resp.mutable_response()->mutable_header_mutation()->add_set_headers();
-        hdr->mutable_header()->set_key(":method");
-        hdr->mutable_header()->set_raw_value("POST");
-        hdrs_resp.mutable_response()->mutable_body_mutation()->set_body("Hello, World!");
-      });
+  processRequestHeaders(false, [](const HttpHeaders&, ProcessingResponse&,
+                                  HeadersResponse& hdrs_resp) {
+    hdrs_resp.mutable_response()->set_status(CommonResponse::CONTINUE_AND_REPLACE);
+    auto* hdr = hdrs_resp.mutable_response()->mutable_header_mutation()->add_set_headers();
+    hdr->set_append_action(envoy::config::core::v3::HeaderValueOption::OVERWRITE_IF_EXISTS_OR_ADD);
+    hdr->mutable_header()->set_key(":method");
+    hdr->mutable_header()->set_raw_value("POST");
+    hdrs_resp.mutable_response()->mutable_body_mutation()->set_body("Hello, World!");
+  });
 
   TestRequestHeaderMapImpl expected_request{
       {":scheme", "http"}, {":authority", "host"}, {":path", "/"}, {":method", "POST"}};
@@ -3226,14 +3245,15 @@ TEST_F(HttpFilterTest, ReplaceCompleteResponseBuffered) {
   Buffer::OwnedImpl buffered_resp_data;
   setUpEncodingBuffering(buffered_resp_data, true);
 
-  processResponseHeaders(
-      false, [](const HttpHeaders&, ProcessingResponse&, HeadersResponse& hdrs_resp) {
-        hdrs_resp.mutable_response()->set_status(CommonResponse::CONTINUE_AND_REPLACE);
-        auto* hdr = hdrs_resp.mutable_response()->mutable_header_mutation()->add_set_headers();
-        hdr->mutable_header()->set_key("x-test-header");
-        hdr->mutable_header()->set_raw_value("true");
-        hdrs_resp.mutable_response()->mutable_body_mutation()->set_body("Hello, World!");
-      });
+  processResponseHeaders(false, [](const HttpHeaders&, ProcessingResponse&,
+                                   HeadersResponse& hdrs_resp) {
+    hdrs_resp.mutable_response()->set_status(CommonResponse::CONTINUE_AND_REPLACE);
+    auto* hdr = hdrs_resp.mutable_response()->mutable_header_mutation()->add_set_headers();
+    hdr->set_append_action(envoy::config::core::v3::HeaderValueOption::OVERWRITE_IF_EXISTS_OR_ADD);
+    hdr->mutable_header()->set_key("x-test-header");
+    hdr->mutable_header()->set_raw_value("true");
+    hdrs_resp.mutable_response()->mutable_body_mutation()->set_body("Hello, World!");
+  });
 
   // Ensure buffered data was updated
   EXPECT_EQ(buffered_resp_data.toString(), "Hello, World!");
@@ -3428,16 +3448,17 @@ TEST_F(HttpFilterTest, IgnoreInvalidHeaderMutations) {
 
   EXPECT_EQ(FilterHeadersStatus::StopIteration, filter_->decodeHeaders(request_headers_, false));
 
-  processRequestHeaders(
-      false, [](const HttpHeaders&, ProcessingResponse&, HeadersResponse& header_resp) {
-        auto headers_mut = header_resp.mutable_response()->mutable_header_mutation();
-        auto add1 = headers_mut->add_set_headers();
-        // Not allowed to change the "host" header by default
-        add1->mutable_header()->set_key("Host");
-        add1->mutable_header()->set_raw_value("wrong:1234");
-        // Not allowed to remove x-envoy headers by default.
-        headers_mut->add_remove_headers("x-envoy-special-thing");
-      });
+  processRequestHeaders(false, [](const HttpHeaders&, ProcessingResponse&,
+                                  HeadersResponse& header_resp) {
+    auto headers_mut = header_resp.mutable_response()->mutable_header_mutation();
+    auto add1 = headers_mut->add_set_headers();
+    // Not allowed to change the "host" header by default
+    add1->set_append_action(envoy::config::core::v3::HeaderValueOption::OVERWRITE_IF_EXISTS_OR_ADD);
+    add1->mutable_header()->set_key("Host");
+    add1->mutable_header()->set_raw_value("wrong:1234");
+    // Not allowed to remove x-envoy headers by default.
+    headers_mut->add_remove_headers("x-envoy-special-thing");
+  });
 
   // The original headers should not have been modified now.
   TestRequestHeaderMapImpl expected{
@@ -3482,6 +3503,7 @@ TEST_F(HttpFilterTest, FailOnInvalidHeaderMutations) {
       resp1->mutable_request_headers()->mutable_response()->mutable_header_mutation();
   auto add1 = headers_mut->add_set_headers();
   // Not allowed to change the "host" header by default
+  add1->set_append_action(envoy::config::core::v3::HeaderValueOption::OVERWRITE_IF_EXISTS_OR_ADD);
   add1->mutable_header()->set_key("Host");
   add1->mutable_header()->set_raw_value("wrong:1234");
   // Not allowed to remove x-envoy headers by default.
@@ -3525,9 +3547,13 @@ TEST_F(HttpFilterTest, ResponseTrailerMutationExceedSizeLimit) {
         // The trailer mutation in the response does not exceed the count limit 100 or the
         // size limit 2kb. But the result header map size exceeds the count limit 2kb.
         auto add1 = headers_mut->add_set_headers();
+        add1->set_append_action(
+            envoy::config::core::v3::HeaderValueOption::OVERWRITE_IF_EXISTS_OR_ADD);
         add1->mutable_header()->set_key("x-new-header-0123456789");
         add1->mutable_header()->set_raw_value("new-header-0123456789");
         auto add2 = headers_mut->add_set_headers();
+        add2->set_append_action(
+            envoy::config::core::v3::HeaderValueOption::OVERWRITE_IF_EXISTS_OR_ADD);
         add2->mutable_header()->set_key("x-some-other-header-0123456789");
         add2->mutable_header()->set_raw_value("some-new-header-0123456789");
       },
@@ -4680,6 +4706,8 @@ TEST_F(HttpFilterTest, ClearRouteCacheHeaderMutationUpstreamIgnored) {
   processRequestHeaders(false, [](const HttpHeaders&, ProcessingResponse&, HeadersResponse& resp) {
     auto* resp_headers_mut = resp.mutable_response()->mutable_header_mutation();
     auto* resp_add = resp_headers_mut->add_set_headers();
+    resp_add->set_append_action(
+        envoy::config::core::v3::HeaderValueOption::OVERWRITE_IF_EXISTS_OR_ADD);
     resp_add->mutable_header()->set_key("x-new-header");
     resp_add->mutable_header()->set_raw_value("new");
     resp.mutable_response()->set_clear_route_cache(true);
@@ -4723,6 +4751,7 @@ TEST_F(HttpFilterTest, PostAndRespondImmediatelyUpstream) {
   immediate_response->set_details("Got a bad request");
   auto* immediate_headers = immediate_response->mutable_headers();
   auto* hdr1 = immediate_headers->add_set_headers();
+  hdr1->set_append_action(envoy::config::core::v3::HeaderValueOption::OVERWRITE_IF_EXISTS_OR_ADD);
   hdr1->mutable_header()->set_key("content-type");
   hdr1->mutable_header()->set_raw_value("text/plain");
   stream_callbacks_->onReceiveMessage(std::move(resp1));
@@ -5018,9 +5047,13 @@ TEST_F(HttpFilter2Test, LastDecodeDataCallExceedsStreamBufferLimitWouldJustRaise
         auto* headers_response = response->mutable_request_headers();
         auto* hdr =
             headers_response->mutable_response()->mutable_header_mutation()->add_set_headers();
+        hdr->set_append_action(
+            envoy::config::core::v3::HeaderValueOption::OVERWRITE_IF_EXISTS_OR_ADD);
         hdr->mutable_header()->set_key("foo");
         hdr->mutable_header()->set_raw_value("gift-from-external-server");
         hdr = headers_response->mutable_response()->mutable_header_mutation()->add_set_headers();
+        hdr->set_append_action(
+            envoy::config::core::v3::HeaderValueOption::OVERWRITE_IF_EXISTS_OR_ADD);
         hdr->mutable_header()->set_key(":path");
         hdr->mutable_header()->set_raw_value("/mutated_path/bluh");
         HttpFilterTest::stream_callbacks_->onReceiveMessage(std::move(response));
@@ -5123,9 +5156,13 @@ TEST_F(HttpFilter2Test, LastEncodeDataCallExceedsStreamBufferLimitWouldJustRaise
         auto* headers_response = response->mutable_response_headers();
         auto* hdr =
             headers_response->mutable_response()->mutable_header_mutation()->add_set_headers();
+        hdr->set_append_action(
+            envoy::config::core::v3::HeaderValueOption::OVERWRITE_IF_EXISTS_OR_ADD);
         hdr->mutable_header()->set_key("foo");
         hdr->mutable_header()->set_raw_value("gift-from-external-server");
         hdr = headers_response->mutable_response()->mutable_header_mutation()->add_set_headers();
+        hdr->set_append_action(
+            envoy::config::core::v3::HeaderValueOption::OVERWRITE_IF_EXISTS_OR_ADD);
         hdr->mutable_header()->set_key("new_response_header");
         hdr->mutable_header()->set_raw_value("bluh");
         HttpFilterTest::stream_callbacks_->onReceiveMessage(std::move(response));


### PR DESCRIPTION
## Description

Previously, **ext_proc** only supported the deprecated `append` field in `HeaderValueOption` for header mutations, ignoring the newer `append_action` field. This meant users could only choose between replacing a header value or appending to it, without access to more granular controls like **ADD_IF_ABSENT** or **OVERWRITE_IF_EXISTS**.

In this PR, we are adding support for all `HeaderAppendAction` values in **ext_proc** header mutations. Default behavior would be changed to append when no action is specified. This behavior could be temporarily reverted with runtime guard `envoy.reloadable_features.ext_proc_legacy_append`. We maintain the backward compatibility with the legacy `append` field.

The following actions are now supported:
- APPEND_IF_EXISTS_OR_ADD: Appends to existing headers or adds new ones
- ADD_IF_ABSENT: Only adds if header doesn't exist
- OVERWRITE_IF_EXISTS: Only overwrites if header exists
- OVERWRITE_IF_EXISTS_OR_ADD: Always overwrites or adds

Fixes #36982

---

**Commit Message:** ext_proc: support HeaderAppendAction in mutation utils
**Additional Description:** Add support for `HeaderAppendAction` in the ext_proc header mutations.
**Risk Level:** Low
**Testing:** Added unit tests covering all append_action behaviors and interaction with legacy append
**Docs Changes:** Added behavior change notice for the default append behavior
**Release Note:** Added release note about header mutation behavior change