### PR TITLE
Play safe with spdlog from within a signal handler

### DIFF
--- a/source/common/common/logger.cc
+++ b/source/common/common/logger.cc
@@ -82,6 +82,14 @@ void DelegatingLogSink::set_formatter(std::unique_ptr<spdlog::formatter> formatt
   formatter_ = std::move(formatter);
 }
 
+spdlog::formatter* DelegatingLogSink::get_formatter() {
+  absl::MutexLock lock(&format_mutex_);
+  if (formatter_) {
+    return formatter_.get();
+  }
+  return nullptr;
+}
+
 void DelegatingLogSink::log(const spdlog::details::log_msg& msg) {
   absl::ReleasableMutexLock lock(&format_mutex_);
   absl::string_view msg_view = absl::string_view(msg.payload.data(), msg.payload.size());

--- a/source/common/common/logger.h
+++ b/source/common/common/logger.h
@@ -245,6 +245,8 @@ public:
    */
   static std::string escapeLogLine(absl::string_view source);
 
+  spdlog::formatter* get_formatter();
+
 private:
   friend class SinkDelegate;
 


### PR DESCRIPTION
The flag `need_localtime` is `true` by default and makes the spdlog library to call
[`localtime_r()`](https://github.com/gabime/spdlog/blob/v1.15.0/include/spdlog/pattern_formatter-inl.h#L1003),
which is not safe to call from within a signal handler.
    
In Fedora and RHEL we are getting a `SIGSEGV` in the `signals_test`
testsuite because of that. In Ubuntu the tests pass but it is undefined
behavior.
    
We cannot set this flag to `false` globally, e.g. at construction time, because
loggers need it to log the date and time. Thus, we only do that when
necessary, i.e., from within the signal handler.
    
Date and time logged from this point on will use the last `time_t` returned by
the last call to `localtime_r()`, but milliseconds are the real ones, since they
do not rely on the cached `time_t`.
    
Thus this is a safe change as we can see in the log snippet below when a crash occurs:
```
[2024-11-19 22:57:52.743][8714][trace][http] [source/common/http/http1/codec_impl.cc:695] [Tags: "ConnectionId":"0"] parsed 153 bytes
[2024-11-19 22:57:52.744][8714][trace][main] [source/common/event/dispatcher_impl.cc:127] clearing deferred deletion list (size=1)
[2024-11-19 22:57:57.690][8722][debug][main] [source/server/server.cc:238] flushing stats
[2024-11-19 22:58:02.691][8722][debug][main] [source/server/server.cc:238] flushing stats
[2024-11-19 22:58:02.739][8714][critical][assert] [test/integration/http_integration.cc:585] assert failure: 0. Details: Timed out waiting for new connection.
[2024-11-19 22:58:02.739][8714][critical][backtrace] [./source/server/backtrace.h:127] Caught Aborted, suspect faulting address 0x3e80000220a
[2024-11-19 22:58:02.739][8714][critical][backtrace] [./source/server/backtrace.h:111] Backtrace (use tools/stack_decode.py to get line numbers):
[2024-11-19 22:58:02.739][8714][critical][backtrace] [./source/server/backtrace.h:112] Envoy version: 0/1.33.0-dev/test/DEBUG/BoringSSL
[2024-11-19 22:58:02.750][8714][critical][backtrace] [./source/server/backtrace.h:119] #0: Envoy::SignalAction::sigHandler() [0x5f61314]
```
    
References:
- https://sourceware.org/bugzilla/show_bug.cgi?id=1390#c4
- https://man7.org/linux/man-pages/man7/signal-safety.7.html
