### PR TITLE
filters: revert to original behavior for invalid content-length handling in CEL Size extractor

### DIFF
--- a/source/extensions/filters/common/expr/context.cc
+++ b/source/extensions/filters/common/expr/context.cc
@@ -123,6 +123,8 @@ const RequestLookupValues& RequestLookupValues::get() {
                if (absl::SimpleAtoi(wrapper.headers_.value_->getContentLengthValue(), &length)) {
                  return CelValue::CreateInt64(length);
                }
+               // Invalid content length, return empty.
+               return {};
              }
              return CelValue::CreateInt64(wrapper.info_.bytesReceived());
            }},

--- a/test/extensions/filters/common/expr/context_test.cc
+++ b/test/extensions/filters/common/expr/context_test.cc
@@ -234,6 +234,19 @@ TEST(Context, RequestAttributes) {
     auto value = empty_request[CelValue::CreateStringView(Protocol)];
     EXPECT_FALSE(value.has_value());
   }
+
+  {
+    Http::TestRequestHeaderMapImpl invalid_length_headers{
+        {":method", "POST"},
+        {":scheme", "http"},
+        {":path", "/meow?yes=1"},
+        {":authority", "kittens.com"},
+        {"content-length", "invalid"} // Invalid content length value
+    };
+    RequestWrapper invalid_request(arena, &invalid_length_headers, info);
+    auto value = invalid_request[CelValue::CreateStringView(Size)];
+    EXPECT_FALSE(value.has_value());
+  }
 }
 
 TEST(Context, RequestAttributesNoHeaders) {


### PR DESCRIPTION


## Description

We recently refactored the CEL context expression logic in [this](https://github.com/envoyproxy/envoy/pull/37057) PR and as part of this refactoring the `Size` extractor's behavior got slightly changed to return the `bytes` when the `content-length` header exists but is invalid. 

This PR is to revert back to the original behavior of not returning anything in that case.

---

**Commit Message:** filters: revert to original behavior for invalid content-length handling in CEL Size extractor
**Additional Description:** This PR reverts back to the original behavior of the **Size** extractor when we have `content-length` header present but it's invalid.
**Risk Level:** Low
**Testing:** Added Unit Tests
**Docs Changes:** N/A
**Release Notes:** N/A