### PR TITLE
mobile: Make the Apple proxy settings monitor refresh interval configurable

### DIFF
--- a/mobile/library/cc/engine_builder.cc
+++ b/mobile/library/cc/engine_builder.cc
@@ -334,8 +334,11 @@ EngineBuilder& EngineBuilder::addRestartRuntimeGuard(std::string guard, bool val
 }
 
 #if defined(__APPLE__)
-EngineBuilder& EngineBuilder::respectSystemProxySettings(bool value) {
+EngineBuilder& EngineBuilder::respectSystemProxySettings(bool value, int refresh_interval_secs) {
   respect_system_proxy_settings_ = value;
+  if (refresh_interval_secs > 0) {
+    proxy_settings_refresh_interval_secs_ = refresh_interval_secs;
+  }
   return *this;
 }
 
@@ -905,7 +908,7 @@ EngineSharedPtr EngineBuilder::build() {
 
 #if defined(__APPLE__)
   if (respect_system_proxy_settings_) {
-    registerAppleProxyResolver();
+    registerAppleProxyResolver(proxy_settings_refresh_interval_secs_);
   }
 #endif
 

--- a/mobile/library/cc/engine_builder.h
+++ b/mobile/library/cc/engine_builder.h
@@ -113,7 +113,10 @@ public:
   // use in reading and using the system proxy settings.
   // If/when we move Android system proxy registration to the C++ Engine Builder, we will make this
   // API available on all platforms.
-  EngineBuilder& respectSystemProxySettings(bool value);
+  // The optional `refresh_interval_secs` parameter determines how often the system proxy settings
+  // are polled by the operating system; defaults to 10 seconds. If the value is <= 0, the default
+  // value will be used.
+  EngineBuilder& respectSystemProxySettings(bool value, int refresh_interval_secs = 10);
   EngineBuilder& setIosNetworkServiceType(int ios_network_service_type);
 #else
   // Only android supports c_ares
@@ -184,6 +187,7 @@ private:
 #if defined(__APPLE__)
   // TODO(abeyad): once stable, consider setting the default to true.
   bool respect_system_proxy_settings_ = false;
+  int proxy_settings_refresh_interval_secs_ = 10;
   int ios_network_service_type_ = 0;
 #endif
   int dns_min_refresh_seconds_ = 60;

--- a/mobile/library/common/network/apple_proxy_resolution.cc
+++ b/mobile/library/common/network/apple_proxy_resolution.cc
@@ -12,8 +12,8 @@
 extern "C" {
 #endif
 
-void registerAppleProxyResolver() {
-  auto resolver = std::make_unique<Envoy::Network::AppleProxyResolver>();
+void registerAppleProxyResolver(int refresh_interval_secs) {
+  auto resolver = std::make_unique<Envoy::Network::AppleProxyResolver>(refresh_interval_secs);
   resolver->start();
 
   auto api = std::make_unique<Envoy::Network::ProxyResolverApi>();

--- a/mobile/library/common/network/apple_proxy_resolution.h
+++ b/mobile/library/common/network/apple_proxy_resolution.h
@@ -9,7 +9,7 @@ extern "C" {
 /**
  * Registers the Apple proxy resolver.
  */
-void registerAppleProxyResolver();
+void registerAppleProxyResolver(int refresh_interval_secs);
 
 #ifdef __cplusplus
 }

--- a/mobile/library/common/network/apple_proxy_resolver.cc
+++ b/mobile/library/common/network/apple_proxy_resolver.cc
@@ -6,9 +6,9 @@
 namespace Envoy {
 namespace Network {
 
-AppleProxyResolver::AppleProxyResolver()
-    : proxy_settings_monitor_(
-          std::make_unique<AppleSystemProxySettingsMonitor>(proxySettingsUpdater())),
+AppleProxyResolver::AppleProxyResolver(int proxy_settings_refresh_interval_secs)
+    : proxy_settings_monitor_(std::make_unique<AppleSystemProxySettingsMonitor>(
+          proxySettingsUpdater(), proxy_settings_refresh_interval_secs)),
       pac_proxy_resolver_(std::make_unique<ApplePacProxyResolver>()),
       thread_factory_(Thread::PosixThreadFactory::create()) {}
 

--- a/mobile/library/common/network/apple_proxy_resolver.h
+++ b/mobile/library/common/network/apple_proxy_resolver.h
@@ -25,7 +25,7 @@ namespace Network {
  */
 class AppleProxyResolver : public ProxyResolver {
 public:
-  AppleProxyResolver();
+  explicit AppleProxyResolver(int proxy_settings_refresh_interval_secs = 10);
   virtual ~AppleProxyResolver();
 
   /**

--- a/mobile/library/common/network/apple_system_proxy_settings_monitor.cc
+++ b/mobile/library/common/network/apple_system_proxy_settings_monitor.cc
@@ -9,12 +9,11 @@
 namespace Envoy {
 namespace Network {
 
-// The interval at which system proxy settings should be polled at.
-CFTimeInterval kProxySettingsRefreshRateSeconds = 10;
-
 AppleSystemProxySettingsMonitor::AppleSystemProxySettingsMonitor(
-    SystemProxySettingsReadCallback proxy_settings_read_callback)
-    : proxy_settings_read_callback_(proxy_settings_read_callback) {}
+    SystemProxySettingsReadCallback proxy_settings_read_callback,
+    CFTimeInterval proxy_settings_refresh_interval)
+    : proxy_settings_read_callback_(proxy_settings_read_callback),
+      proxy_settings_refresh_interval_(proxy_settings_refresh_interval) {}
 
 void AppleSystemProxySettingsMonitor::start() {
   if (started_) {
@@ -36,7 +35,7 @@ void AppleSystemProxySettingsMonitor::start() {
 
   source_ = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, queue_);
   dispatch_source_set_timer(source_, dispatch_time(DISPATCH_TIME_NOW, 0),
-                            kProxySettingsRefreshRateSeconds * NSEC_PER_SEC, 0);
+                            proxy_settings_refresh_interval_ * NSEC_PER_SEC, 0);
   dispatch_source_set_event_handler(source_, ^{
     const auto new_proxy_settings = readSystemProxySettings();
     if (new_proxy_settings != proxy_settings) {

--- a/mobile/library/common/network/apple_system_proxy_settings_monitor.h
+++ b/mobile/library/common/network/apple_system_proxy_settings_monitor.h
@@ -23,8 +23,11 @@ public:
    *
    * @param proxy_settings_read_callback The closure to call every time system proxy settings
    *                                     change. The closure is called on a non-main queue.
+   * @param proxy_settings_refresh_interval The refresh interval, in seconds, for fetching proxy
+   *                                        settings from the Apple APIs. Defaults to 10 seconds.
    */
-  AppleSystemProxySettingsMonitor(SystemProxySettingsReadCallback proxy_settings_read_callback);
+  AppleSystemProxySettingsMonitor(SystemProxySettingsReadCallback proxy_settings_read_callback,
+                                  CFTimeInterval proxy_settings_refresh_interval);
   virtual ~AppleSystemProxySettingsMonitor();
 
   /**
@@ -44,6 +47,7 @@ private:
   dispatch_queue_t queue_;
   bool started_ = false;
   SystemProxySettingsReadCallback proxy_settings_read_callback_;
+  CFTimeInterval proxy_settings_refresh_interval_;
 };
 
 } // namespace Network

--- a/mobile/library/objective-c/EnvoyEngineImpl.mm
+++ b/mobile/library/objective-c/EnvoyEngineImpl.mm
@@ -502,7 +502,7 @@ static envoy_data ios_get_string(const void *context) {
   }
 
   if (config.respectSystemProxySettings) {
-    registerAppleProxyResolver();
+    registerAppleProxyResolver(/*proxy_settings_refresh_interval_secs=*/10);
   }
 }
 

--- a/mobile/test/common/proxy/test_apple_proxy_settings_monitor.cc
+++ b/mobile/test/common/proxy/test_apple_proxy_settings_monitor.cc
@@ -11,8 +11,9 @@ namespace Network {
 TestAppleSystemProxySettingsMonitor::TestAppleSystemProxySettingsMonitor(
     const std::string& host, const int port, const bool use_pac_resolver,
     Network::SystemProxySettingsReadCallback proxy_settings_read_callback)
-    : AppleSystemProxySettingsMonitor(std::move(proxy_settings_read_callback)), host_(host),
-      port_(port), use_pac_resolver_(use_pac_resolver) {}
+    : AppleSystemProxySettingsMonitor(std::move(proxy_settings_read_callback),
+                                      /*proxy_settings_refresh_interval=*/10),
+      host_(host), port_(port), use_pac_resolver_(use_pac_resolver) {}
 
 CFDictionaryRef TestAppleSystemProxySettingsMonitor::getSystemProxySettings() const {
   if (use_pac_resolver_) {


### PR DESCRIPTION
The default is set to 10 seconds, the same value Cronet uses.