### PR TITLE
test: extend waitForInexactRawData

### DIFF
--- a/test/extensions/transport_sockets/http_11_proxy/connect_integration_test.cc
+++ b/test/extensions/transport_sockets/http_11_proxy/connect_integration_test.cc
@@ -125,7 +125,7 @@ typed_config:
     std::string prefix_data;
     const std::string hostname(default_request_headers_.getHostValue());
     const std::string port = Http::HeaderUtility::hostHasPort(hostname) ? "" : ":443";
-    ASSERT_TRUE(fake_upstream_connection_->waitForInexactRawData("\r\n\r\n", &prefix_data));
+    ASSERT_TRUE(fake_upstream_connection_->waitForInexactRawData("\r\n\r\n", prefix_data));
     EXPECT_EQ(absl::StrCat("CONNECT ", hostname, port, " HTTP/1.1\r\n\r\n"), prefix_data);
 
     absl::string_view content_length = include_content_length ? "Content-Length: 0\r\n" : "";

--- a/test/integration/fake_upstream.cc
+++ b/test/integration/fake_upstream.cc
@@ -1082,7 +1082,7 @@ Network::FilterStatus FakeRawConnection::ReadFilter::onData(Buffer::Instance& da
 }
 
 ABSL_MUST_USE_RESULT
-AssertionResult FakeHttpConnection::waitForInexactRawData(const char* data, std::string* out,
+AssertionResult FakeHttpConnection::waitForInexactRawData(absl::string_view data, std::string& out,
                                                           std::chrono::milliseconds timeout) {
   absl::MutexLock lock(&lock_);
   const auto reached = [this, data, &out]() ABSL_EXCLUSIVE_LOCKS_REQUIRED(lock_) {
@@ -1096,12 +1096,13 @@ AssertionResult FakeHttpConnection::waitForInexactRawData(const char* data, std:
     }
     absl::string_view peek_data(peek_buf, result.return_value_);
     size_t index = peek_data.find(data);
+    const auto data_len = data.length();
     if (index != absl::string_view::npos) {
       Buffer::OwnedImpl buffer;
-      *out = std::string(peek_data.data(), index + 4);
+      out = std::string(peek_data.data(), index + data_len);
       auto result = dynamic_cast<Network::ConnectionImpl*>(&connection())
                         ->ioHandle()
-                        .recv(peek_buf, index + 4, 0);
+                        .recv(peek_buf, index + data_len, 0);
       return true;
     }
     return false;

--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -509,9 +509,11 @@ public:
   // Update the maximum number of concurrent streams.
   void updateConcurrentStreams(uint64_t max_streams);
 
+  // Wait for the first occurrence of data, and strip the leading data up to the first occurrence.
+  // The out parameter will contain the stripped pieces.
   ABSL_MUST_USE_RESULT
   testing::AssertionResult
-  waitForInexactRawData(const char* data, std::string* out = nullptr,
+  waitForInexactRawData(absl::string_view data, std::string& out,
                         std::chrono::milliseconds timeout = TestUtility::DefaultTimeout);
 
   void writeRawData(absl::string_view data);


### PR DESCRIPTION
Commit Message:
Currently waitForInexactRawData is harded coded to support only 4 byte data as input. It's because the only callsite passes "\r\n\r\n".

Extend to support data of any length.
Also slightly adjust the signature.

Additional Description: 
Risk Level: LOW, test only
Testing: bazel test test/extensions/transport_sockets/http_11_proxy/...
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
