### PR TITLE
quic: Use MaybeSendRstStreamFrame instead of ResetWriteSide in a quic test

### DIFF
--- a/test/integration/quic_http_integration_test.cc
+++ b/test/integration/quic_http_integration_test.cc
@@ -2512,7 +2512,9 @@ TEST_P(QuicHttpIntegrationTest, StreamTimeoutWithHalfClose) {
       static_cast<EnvoyQuicClientSession*>(codec_client_->connection());
   quic::QuicStream* stream = quic_session->GetActiveStream(0);
   // Only send RESET_STREAM to close write side of this stream.
-  stream->ResetWriteSide(quic::QuicResetStreamError::FromInternal(quic::QUIC_STREAM_NO_ERROR));
+  quic_session->MaybeSendRstStreamFrame(
+      stream->id(), quic::QuicResetStreamError::FromInternal(quic::QUIC_STREAM_NO_ERROR),
+      stream->stream_bytes_written());
 
   // Wait for the server to timeout this request and the local reply.
   EXPECT_TRUE(response->waitForEndStream());


### PR DESCRIPTION
quic: Use MaybeSendRstStreamFrame instead of ResetWriteSide in a quic test

ResetWriteSide is deprecated and will be removed once this usage of it is removed.
Risk Level: None - test only
Testing: existing unit test
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A