### PR TITLE
ext_proc: refactoring handleHeadersResponse() to make it more modularized

### DIFF
--- a/source/extensions/filters/http/ext_proc/processor_state.h
+++ b/source/extensions/filters/http/ext_proc/processor_state.h
@@ -161,6 +161,12 @@ public:
   virtual void requestWatermark() PURE;
   virtual void clearWatermark() PURE;
 
+  /**
+   * Handles header response processing from an external processor.
+   *
+   * @param response The headers response received from external processor
+   * @return Status indicating success or failure of processing
+   */
   absl::Status handleHeadersResponse(const envoy::service::ext_proc::v3::HeadersResponse& response);
   absl::Status handleBodyResponse(const envoy::service::ext_proc::v3::BodyResponse& response);
   absl::Status
@@ -297,6 +303,20 @@ private:
   void clearStreamingChunk() { chunk_queue_.clear(); }
   CallbackState getCallbackStateAfterHeaderResp(
       const envoy::service::ext_proc::v3::CommonResponse& common_response) const;
+  absl::Status handleHeadersResponseWithContinueAndReplace(
+      const envoy::service::ext_proc::v3::CommonResponse& common_response);
+  void
+  applyReplacementBodyMutation(const envoy::service::ext_proc::v3::CommonResponse& common_response);
+  absl::Status handleHeadersResponseWithContinue();
+  absl::Status handleCompleteBodyAvailable();
+  absl::Status handleBufferedMode();
+  absl::Status handleStreamedMode();
+  absl::Status handleFullDuplexStreamedMode();
+  absl::Status handleBufferedPartialMode();
+  void enqueueBufferedDataToChunkQueue();
+  absl::Status sendBufferedPartialData();
+  absl::Status finalizeContinueResponse();
+  absl::Status finalizeResponse();
 };
 
 class DecodingProcessorState : public ProcessorState {


### PR DESCRIPTION
## Description

This PR refactors the `handleHeadersResponse()` method in the **ext_proc** filter to improve code maintainability and readability. The current implementation contains complex nested logic handling different callback states, making it difficult to understand and maintain. This change breaks down the functionality into smaller, focused methods while preserving the existing behavior.

Fixes #37047

---

**Commit Message:** ext_proc: refactoring handleHeadersResponse() to make it more modularized

**Additional Description:** The refactoring introduces several helper methods to handle different aspects of headers response processing inside ext_proc's `handleHeadersResponse()`. This modularization makes the code easier to understand, test, and modify while maintaining all existing functionality and error handling.

**Risk Level:** Very Low

**Testing:** 
- Existing test suite passes
- No new tests needed as this is a refactor
- Current test coverage validates all code paths
- Each state transition and mode handling remains unchanged

**Docs Changes:** N/A

**Release Notes:** N/A