### PR TITLE
bp/1.32: original_ip_detection: revert unintended XFF header appending behavior in CustomHeaderIPDetection

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -12,6 +12,11 @@ bug_fixes:
   change: |
     Relaxed the restriction on SNI logging to allow the ``_`` character, even if
     ``envoy.reloadable_features.sanitize_sni_in_access_log`` is enabled.
+- area: original_ip_detection custom header extension
+  change: |
+    Reverted :ref:`custom header
+    <envoy_v3_api_msg_extensions.http.original_ip_detection.custom_header.v3.CustomHeaderConfig>` extension to its
+    original behavior by disabling automatic XFF header appending that was inadvertently introduced in PR #31831.
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/source/extensions/http/original_ip_detection/custom_header/custom_header.cc
+++ b/source/extensions/http/original_ip_detection/custom_header/custom_header.cc
@@ -26,18 +26,22 @@ CustomHeaderIPDetection::CustomHeaderIPDetection(
 
 Envoy::Http::OriginalIPDetectionResult
 CustomHeaderIPDetection::detect(Envoy::Http::OriginalIPDetectionParams& params) {
+  // NOTE: The ``XFF`` header from this extension is intentionally not appended.
+  // To preserve the behavior prior to #31831, ``skip_xff_append`` is explicitly set to true.
+  constexpr bool skip_xff_append = true;
+
   auto hdr = params.request_headers.get(header_name_);
   if (hdr.empty()) {
-    return {nullptr, false, reject_options_, false};
+    return {nullptr, false, reject_options_, skip_xff_append};
   }
 
   auto header_value = hdr[0]->value().getStringView();
   auto addr = Network::Utility::parseInternetAddressNoThrow(std::string(header_value));
   if (addr) {
-    return {addr, allow_trusted_address_checks_, absl::nullopt, false};
+    return {addr, allow_trusted_address_checks_, absl::nullopt, skip_xff_append};
   }
 
-  return {nullptr, false, reject_options_, false};
+  return {nullptr, false, reject_options_, skip_xff_append};
 }
 
 } // namespace CustomHeader


### PR DESCRIPTION
## Description

This PR restores the original behavior prior to #31831, by explicitly setting `skip_xff_append` to `true`, as appending the `XFF` header from the custom header extension is not required.

See #37171 for more details.

---

**Commit Message:** original_ip_detection: revert unintended XFF header appending behavior in CustomHeaderIPDetection
**Additional Description:** This PR restores the pre #31831 behavior by explicitly setting `skip_xff_append` to `true`, as appending the `XFF` header from the custom header extension is not required.
**Risk Level:** Low
**Testing:** Added Unit Tests
**Docs Changes:** N/A
**Release Notes:** Added