### PR TITLE
quic: fix parsing of UDP_GRO and ECN socket options to also work in big endian platforms

### DIFF
--- a/source/common/network/io_socket_handle_impl.cc
+++ b/source/common/network/io_socket_handle_impl.cc
@@ -280,17 +280,24 @@ absl::optional<uint32_t> maybeGetPacketsDroppedFromHeader([[maybe_unused]] const
   return absl::nullopt;
 }
 
+template <typename T> T getUnsignedIntFromHeader(const cmsghdr& cmsg) {
+  static_assert(std::is_unsigned_v<T>, "return type must be unsigned integral");
+  T value;
+  memcpy(&value, CMSG_DATA(&cmsg), sizeof(value));
+  return value;
+}
+
 template <typename T> absl::optional<T> maybeGetUnsignedIntFromHeader(const cmsghdr& cmsg) {
   static_assert(std::is_unsigned_v<T>, "return type must be unsigned integral");
   switch (cmsg.cmsg_len) {
   case CMSG_LEN(sizeof(uint8_t)):
-    return static_cast<T>(*reinterpret_cast<const uint8_t*>(CMSG_DATA(&cmsg)));
+    return static_cast<T>(getUnsignedIntFromHeader<uint8_t>(cmsg));
   case CMSG_LEN(sizeof(uint16_t)):
-    return static_cast<T>(*reinterpret_cast<const uint16_t*>(CMSG_DATA(&cmsg)));
+    return static_cast<T>(getUnsignedIntFromHeader<uint16_t>(cmsg));
   case CMSG_LEN(sizeof(uint32_t)):
-    return static_cast<T>(*reinterpret_cast<const uint32_t*>(CMSG_DATA(&cmsg)));
+    return static_cast<T>(getUnsignedIntFromHeader<uint32_t>(cmsg));
   case CMSG_LEN(sizeof(uint64_t)):
-    return static_cast<T>(*reinterpret_cast<const uint64_t*>(CMSG_DATA(&cmsg)));
+    return static_cast<T>(getUnsignedIntFromHeader<uint64_t>(cmsg));
   default:;
   }
   IS_ENVOY_BUG(

--- a/source/common/network/io_socket_handle_impl.cc
+++ b/source/common/network/io_socket_handle_impl.cc
@@ -5,6 +5,7 @@
 #include "envoy/buffer/buffer.h"
 
 #include "source/common/api/os_sys_calls_impl.h"
+#include "source/common/common/safe_memcpy.h"
 #include "source/common/common/utility.h"
 #include "source/common/event/file_event_impl.h"
 #include "source/common/network/address_impl.h"
@@ -283,7 +284,7 @@ absl::optional<uint32_t> maybeGetPacketsDroppedFromHeader([[maybe_unused]] const
 template <typename T> T getUnsignedIntFromHeader(const cmsghdr& cmsg) {
   static_assert(std::is_unsigned_v<T>, "return type must be unsigned integral");
   T value;
-  memcpy(&value, CMSG_DATA(&cmsg), sizeof(value));
+  safeMemcpyUnsafeSrc(&value, CMSG_DATA(&cmsg));
   return value;
 }
 


### PR DESCRIPTION
Commit Message: quic: fix parsing of UDP_GRO and ECN socket options to also work in big endian platforms
Additional Description:
Check the actual cms_len so that the entire value will be parsed.

Fixes:

//test/common/quic:active_quic_listener_test
//test/integration:quic_http_integration_test

on big endian platforms.
Risk Level: low
Testing: unit tests
Docs Changes: no
Release Notes: no
Platform Specific Features: 
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
