### PR TITLE
[bp/1.31] build(deps): bump distroless/base-nossl-debian12 from `aa91f01` to `1…

### DIFF
--- a/ci/Dockerfile-envoy
+++ b/ci/Dockerfile-envoy
@@ -58,7 +58,7 @@ COPY --chown=0:0 --chmod=755 \
 
 
 # STAGE: envoy-distroless
-FROM gcr.io/distroless/base-nossl-debian12:nonroot@sha256:aa91f01b56d02af049a3984dd5dd7c0ea39c97f398ac415cfc92b085bd63f6fd AS envoy-distroless
+FROM gcr.io/distroless/base-nossl-debian12:nonroot@sha256:174f326c2730c718b3f857735c2a55f654dc057285ecacc7c29736ee777acb08 AS envoy-distroless
 EXPOSE 10000
 ENTRYPOINT ["/usr/local/bin/envoy"]
 CMD ["-c", "/etc/envoy/envoy.yaml"]


### PR DESCRIPTION
…74f326` in /ci (#37119)

