### PR TITLE
SAN-matcher: refactoring DNS exact SAN matcher out of regular matchers

### DIFF
--- a/source/common/tls/cert_validator/default_validator.cc
+++ b/source/common/tls/cert_validator/default_validator.cc
@@ -163,7 +163,7 @@ absl::StatusOr<int> DefaultCertValidator::initializeSslContexts(std::vector<SSL_
           return absl::InvalidArgumentError(
               absl::StrCat("Failed to create string SAN matcher of type ", matcher.san_type()));
         }
-        subject_alt_name_matchers_.push_back(std::move(san_matcher));
+        subject_alt_name_matchers_.emplace_back(std::move(san_matcher));
       }
       verify_mode = verify_mode_validation_context;
     }
@@ -214,7 +214,7 @@ bool DefaultCertValidator::verifyCertAndUpdateStatus(
     // validated as a DNS SAN, but this change will require a runtime flag for the behavior change.
     verify_san_override = transport_socket_options->verifySubjectAltNameListOverride();
   } else if (auto_sni_san_match_ && !sni.empty()) {
-    match_sni_san.push_back(std::make_unique<StringSanMatcher>(sni));
+    match_sni_san.emplace_back(std::make_unique<DnsStringSanMatcher>(sni));
     match_san_override = match_sni_san;
   }
   Envoy::Ssl::ClientValidationStatus validated = verifyCertificate(

--- a/source/common/tls/cert_validator/default_validator.cc
+++ b/source/common/tls/cert_validator/default_validator.cc
@@ -214,7 +214,7 @@ bool DefaultCertValidator::verifyCertAndUpdateStatus(
     // validated as a DNS SAN, but this change will require a runtime flag for the behavior change.
     verify_san_override = transport_socket_options->verifySubjectAltNameListOverride();
   } else if (auto_sni_san_match_ && !sni.empty()) {
-    match_sni_san.emplace_back(std::make_unique<DnsStringSanMatcher>(sni));
+    match_sni_san.emplace_back(std::make_unique<DnsExactStringSanMatcher>(sni));
     match_san_override = match_sni_san;
   }
   Envoy::Ssl::ClientValidationStatus validated = verifyCertificate(

--- a/source/common/tls/cert_validator/san_matcher.cc
+++ b/source/common/tls/cert_validator/san_matcher.cc
@@ -26,7 +26,7 @@ bool StringSanMatcher::match(const GENERAL_NAME* general_name) const {
   return matcher_.match(Utility::generalNameAsString(general_name));
 }
 
-bool DnsStringSanMatcher::match(const GENERAL_NAME* general_name) const {
+bool DnsExactStringSanMatcher::match(const GENERAL_NAME* general_name) const {
   if (general_name->type != GEN_DNS) {
     return false;
   }
@@ -46,7 +46,7 @@ SanMatcherPtr createStringSanMatcher(
     // For DNS SAN, if the StringMatcher type is exact, we have to follow DNS matching semantics.
     if (matcher.matcher().match_pattern_case() ==
         envoy::type::matcher::v3::StringMatcher::MatchPatternCase::kExact) {
-      return SanMatcherPtr{std::make_unique<DnsStringSanMatcher>(matcher.matcher().exact())};
+      return SanMatcherPtr{std::make_unique<DnsExactStringSanMatcher>(matcher.matcher().exact())};
     } else {
       return SanMatcherPtr{std::make_unique<StringSanMatcher>(GEN_DNS, matcher.matcher(), context)};
     }

--- a/source/common/tls/cert_validator/san_matcher.h
+++ b/source/common/tls/cert_validator/san_matcher.h
@@ -57,12 +57,12 @@ private:
 // A DNS string SAN matcher that uses the dnsNameMatch() function.
 // This should be used for DNS SAN where the StringMatcher type is exact,
 // and the DNS matching semantics must be followed.
-class DnsStringSanMatcher : public SanMatcher {
+class DnsExactStringSanMatcher : public SanMatcher {
 public:
   bool match(const GENERAL_NAME* general_name) const override;
-  ~DnsStringSanMatcher() override = default;
+  ~DnsExactStringSanMatcher() override = default;
 
-  DnsStringSanMatcher(absl::string_view dns_exact_match) : dns_exact_match_(dns_exact_match) {}
+  DnsExactStringSanMatcher(absl::string_view dns_exact_match) : dns_exact_match_(dns_exact_match) {}
 
 private:
   const std::string dns_exact_match_;

--- a/test/common/tls/cert_validator/default_validator_test.cc
+++ b/test/common/tls/cert_validator/default_validator_test.cc
@@ -430,6 +430,9 @@ TEST(DefaultCertValidatorTest, TestMatchSubjectAltNameIncorrectTypeMatched) {
 }
 
 TEST(DefaultCertValidatorTest, TestMatchSubjectAltNameExactDNSFailure) {
+  // This will only be tested under debug (assertion is triggered) to ensure
+  // that the class will not be initialized in the DNS-exact mode.
+#ifndef NDEBUG
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
 
   envoy::type::matcher::v3::StringMatcher matcher;
@@ -437,6 +440,7 @@ TEST(DefaultCertValidatorTest, TestMatchSubjectAltNameExactDNSFailure) {
   EXPECT_DEATH(std::make_unique<StringSanMatcher>(GEN_DNS, matcher, context),
                "general_name_type != 2 || matcher.match_pattern_case() != "
                "envoy::type::matcher::v3::StringMatcher::MatchPatternCase::kExact");
+#endif
 }
 
 TEST(DefaultCertValidatorTest, TestMatchSubjectAltNameWildcardDNSMatched) {

--- a/test/common/tls/cert_validator/default_validator_test.cc
+++ b/test/common/tls/cert_validator/default_validator_test.cc
@@ -449,7 +449,7 @@ TEST(DefaultCertValidatorTest, TestMatchSubjectAltNameWildcardDNSMatched) {
                                   "}}/test/common/tls/test_data/san_multiple_dns_cert.pem"));
   std::vector<SanMatcherPtr> subject_alt_name_matchers;
   subject_alt_name_matchers.push_back(
-      SanMatcherPtr{std::make_unique<DnsStringSanMatcher>("api.example.com")});
+      SanMatcherPtr{std::make_unique<DnsExactStringSanMatcher>("api.example.com")});
   EXPECT_TRUE(DefaultCertValidator::matchSubjectAltName(cert.get(), subject_alt_name_matchers));
 }
 
@@ -460,7 +460,7 @@ TEST(DefaultCertValidatorTest, TestMultiLevelMatch) {
                                   "}}/test/common/tls/test_data/san_multiple_dns_cert.pem"));
   std::vector<SanMatcherPtr> subject_alt_name_matchers;
   subject_alt_name_matchers.push_back(
-      SanMatcherPtr{std::make_unique<DnsStringSanMatcher>("foo.api.example.com")});
+      SanMatcherPtr{std::make_unique<DnsExactStringSanMatcher>("foo.api.example.com")});
   EXPECT_FALSE(DefaultCertValidator::matchSubjectAltName(cert.get(), subject_alt_name_matchers));
 }
 
@@ -546,7 +546,7 @@ TEST(DefaultCertValidatorTest, TestCertificateVerificationWithSANMatcher) {
   matcher.MergeFrom(TestUtility::createExactMatcher("hello.example.com"));
   std::vector<SanMatcherPtr> invalid_san_matchers;
   invalid_san_matchers.push_back(
-      SanMatcherPtr{std::make_unique<DnsStringSanMatcher>(matcher.exact())});
+      SanMatcherPtr{std::make_unique<DnsExactStringSanMatcher>(matcher.exact())});
   std::string error;
   // Verify the certificate with incorrect SAN exact matcher.
   EXPECT_EQ(default_validator->verifyCertificate(cert.get(), /*verify_san_list=*/{},


### PR DESCRIPTION
Commit Message: SAN-matcher: refactoring DNS exact SAN matcher out of regular matchers
Additional Description:
The current SAN-matcher has a specific matching behavior when the matching general-type is DNS and the matcher-type is Exact.
This PR refactors that behavior into a different class `DnsStringSanMatcher` and ensures that when the code creates a SAN-Matcher the correct class is used.

Risk Level: low - internal refactor only
Testing: Updated tests.
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A