### PR TITLE
Update rate_limit_quota CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -202,7 +202,7 @@ extensions/filters/http/oauth2 @derekargueta @mattklein123
 /*/extensions/filters/http/ratelimit @esmet @mattklein123
 /*/extensions/filters/network/ratelimit @esmet @mattklein123
 # HTTP Quota Based Rate Limit
-/*/extensions/filters/http/rate_limit_quota @tyxia @yanavlasov
+/*/extensions/filters/http/rate_limit_quota @tyxia @yanavlasov @bsurber
 # HTTP Bandwidth Limit
 /*/extensions/filters/http/bandwidth_limit @nitgoy @mattklein123 @yanavlasov @tonya11en
 # HTTP Basic Auth


### PR DESCRIPTION
Commit Message: Add bsurber as a codeowner for the rate_limit_quota http extension
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features: