### PR TITLE
json: replacing IS_ENVOY_BUG when a large number value is used with an error

### DIFF
--- a/source/common/json/json_internal.cc
+++ b/source/common/json/json_internal.cc
@@ -193,8 +193,13 @@ public:
   }
   bool number_unsigned(uint64_t value) override {
     if (value > static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) {
-      IS_ENVOY_BUG("JSON value from line {} is larger than int64_t (not supported)");
-      value = std::numeric_limits<int64_t>::max();
+      // Envoy's code is discouraging the use of exceptions. The following sets
+      // the error details as if an exception occurs, and returns false to stop
+      // parsing.
+      error_ = fmt::format("JSON value from line {} is larger than int64_t (not supported)",
+                           line_number_);
+      error_position_ = absl::StrCat("line: ", line_number_);
+      return false;
     }
     return handleValueEvent(Field::createValue(static_cast<int64_t>(value)));
   }

--- a/test/common/json/json_loader_test.cc
+++ b/test/common/json/json_loader_test.cc
@@ -318,8 +318,11 @@ TEST_F(JsonLoaderTest, Integer) {
     EXPECT_EQ(std::numeric_limits<int64_t>::min(), *json->getInteger("min"));
   }
   {
-    EXPECT_ENVOY_BUG(
-        EXPECT_TRUE(Factory::loadFromString("{\"val\":9223372036854775808}").status().ok()), "");
+    const absl::StatusOr<ObjectSharedPtr> res =
+        Factory::loadFromString("{\"val\":9223372036854775808}");
+    expectError(res, absl::StatusCode::kInternal,
+                "JSON supplied is not valid. Error(line: 1): JSON value from line 1 is larger than "
+                "int64_t (not supported)\n");
     ObjectSharedPtr json = *Factory::loadFromString("{\"val\":-9223372036854775809}");
     EXPECT_FALSE(json->getInteger("val").status().ok());
   }

--- a/test/common/router/header_parser_corpus/large_number_value
+++ b/test/common/router/header_parser_corpus/large_number_value
@@ -1,0 +1,1 @@
+headers_to_add {   header {     key: " "     value: "%DYNAMIC_METADATA([12697409830940311499])%"   } } 


### PR DESCRIPTION
Commit Message: json: replacing IS_ENVOY_BUG when a large number value is used with an error
Additional Description:
Followup to #36919. In #36919, there was a behavior change when the JSON library parsed a large number.
Prior to #36919 Envoy would have thrown an exception which ended up rejecting the value or erroring out. After that an ENVOY_BUG was introduced, but probably shouldn't have had, as Envoy may receive a value that is large and should handle it correctly (e.g., when ingesting a config).

This was detected due to fuzz bug [379811166](https://g-issues.oss-fuzz.com/issues/379811166).

Risk Level: low
Testing: Added fuzz test case, and updated the unit-tests.
Docs Changes: N/A (no docs were updated in the original PR).
Release Notes: N/A (no release notes were introduced in the original PR). 
Platform Specific Features: N/A
