### PR TITLE
Patch c-ares CVE-2024-25629

### DIFF
--- a/bazel/c-ares.patch
+++ b/bazel/c-ares.patch
@@ -1,0 +1,20 @@
+# Patch for c-ares CVE-2024-25629
+diff --git a/src/lib/ares__read_line.c b/src/lib/ares__read_line.c
+index d65ac1fcf8..018f55e8b2 100644
+--- a/src/lib/ares__read_line.c
++++ b/src/lib/ares__read_line.c
+@@ -59,6 +59,14 @@ ares_status_t ares__read_line(FILE *fp, char **buf, size_t *bufsize)
+       return (offset != 0) ? 0 : (ferror(fp)) ? ARES_EFILE : ARES_EOF;
+     }
+     len = offset + ares_strlen(*buf + offset);
++
++    /* Probably means there was an embedded NULL as the first character in
++     * the line, throw away line */
++    if (len == 0) {
++      offset = 0;
++      continue;
++    }
++
+     if ((*buf)[len - 1] == '\n') {
+       (*buf)[len - 1] = 0;
+       break;

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -303,6 +303,8 @@ def _com_github_c_ares_c_ares():
     external_http_archive(
         name = "com_github_c_ares_c_ares",
         build_file_content = BUILD_ALL_CONTENT,
+        patch_args = ["-p1"],
+        patches = ["@envoy//bazel:c-ares.patch"],
     )
 
 def _com_github_cyan4973_xxhash():


### PR DESCRIPTION
Additional Description:
c-ares is currently behind on upgrades due to incompatibility with gRPC. Patching c-ares CVE-2024-25629 to avoid scanner complaints.

Risk Level: Low
Testing: Unit Test
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
