### PR TITLE
[bp/1.32] opentelemetrytracer: limit calculated sampling exponent in Dynatrace sampler

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -17,6 +17,9 @@ bug_fixes:
     Reverted :ref:`custom header
     <envoy_v3_api_msg_extensions.http.original_ip_detection.custom_header.v3.CustomHeaderConfig>` extension to its
     original behavior by disabling automatic XFF header appending that was inadvertently introduced in PR #31831.
+- area: tracers
+  change: |
+    Avoid possible overflow when setting span attributes in Dynatrace sampler.
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/source/extensions/tracers/opentelemetry/samplers/dynatrace/sampling_controller.cc
+++ b/source/extensions/tracers/opentelemetry/samplers/dynatrace/sampling_controller.cc
@@ -75,7 +75,7 @@ SamplingState SamplingController::getSamplingState(const std::string& sampling_k
   }
   absl::ReaderMutexLock ss_lock{&stream_summary_mutex_};
   const uint32_t exp = stream_summary_->getN() / divisor;
-  return SamplingState{exp};
+  return SamplingState{std::min(exp, MAX_SAMPLING_EXPONENT)};
 }
 
 std::string SamplingController::getSamplingKey(const absl::string_view path_query,

--- a/test/extensions/tracers/opentelemetry/samplers/dynatrace/sampling_controller_test.cc
+++ b/test/extensions/tracers/opentelemetry/samplers/dynatrace/sampling_controller_test.cc
@@ -206,6 +206,13 @@ TEST(SamplingControllerTest, TestWarmup) {
   EXPECT_EQ(sc.getSamplingState("GET_1").getExponent(), 8);
   EXPECT_EQ(sc.getSamplingState("GET_6").getExponent(), 8);
   EXPECT_EQ(sc.getSamplingState("GET_789").getExponent(), 8);
+
+  offerEntry(sc, "GET_7", 10000);
+  EXPECT_EQ(sc.getSamplingState("GET_1").getExponent(), SamplingController::MAX_SAMPLING_EXPONENT);
+  EXPECT_EQ(sc.getSamplingState("GET_6").getExponent(), SamplingController::MAX_SAMPLING_EXPONENT);
+  EXPECT_EQ(sc.getSamplingState("GET_789").getExponent(),
+            SamplingController::MAX_SAMPLING_EXPONENT);
+  EXPECT_EQ(sc.getSamplingState("GET_7").getExponent(), SamplingController::MAX_SAMPLING_EXPONENT);
 }
 
 // Test getting sampling state from an empty SamplingController


### PR DESCRIPTION
Commit Message: Backport #37240
Additional Description:
Risk Level: Low
Testing: Manual
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
[Optional Runtime guard:] N/A
[Optional Fixes #37199]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]