### PR TITLE
[bp/1.31] opentelemetrytracer: limit calculated sampling exponent in Dynatrace sampler

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -12,6 +12,9 @@ bug_fixes:
   change: |
     Relaxed the restriction on SNI logging to allow the ``_`` character, even if
     ``envoy.reloadable_features.sanitize_sni_in_access_log`` is enabled.
+- area: tracers
+  change: |
+    Avoid possible overflow when setting span attributes in Dynatrace sampler.
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/source/extensions/tracers/opentelemetry/samplers/dynatrace/sampling_controller.cc
+++ b/source/extensions/tracers/opentelemetry/samplers/dynatrace/sampling_controller.cc
@@ -75,7 +75,7 @@ SamplingState SamplingController::getSamplingState(const std::string& sampling_k
   }
   absl::ReaderMutexLock ss_lock{&stream_summary_mutex_};
   const uint32_t exp = stream_summary_->getN() / divisor;
-  return SamplingState{exp};
+  return SamplingState{std::min(exp, MAX_SAMPLING_EXPONENT)};
 }
 
 std::string SamplingController::getSamplingKey(const absl::string_view path_query,

--- a/test/extensions/tracers/opentelemetry/samplers/dynatrace/sampling_controller_test.cc
+++ b/test/extensions/tracers/opentelemetry/samplers/dynatrace/sampling_controller_test.cc
@@ -206,6 +206,13 @@ TEST(SamplingControllerTest, TestWarmup) {
   EXPECT_EQ(sc.getSamplingState("GET_1").getExponent(), 8);
   EXPECT_EQ(sc.getSamplingState("GET_6").getExponent(), 8);
   EXPECT_EQ(sc.getSamplingState("GET_789").getExponent(), 8);
+
+  offerEntry(sc, "GET_7", 10000);
+  EXPECT_EQ(sc.getSamplingState("GET_1").getExponent(), SamplingController::MAX_SAMPLING_EXPONENT);
+  EXPECT_EQ(sc.getSamplingState("GET_6").getExponent(), SamplingController::MAX_SAMPLING_EXPONENT);
+  EXPECT_EQ(sc.getSamplingState("GET_789").getExponent(),
+            SamplingController::MAX_SAMPLING_EXPONENT);
+  EXPECT_EQ(sc.getSamplingState("GET_7").getExponent(), SamplingController::MAX_SAMPLING_EXPONENT);
 }
 
 // Test getting sampling state from an empty SamplingController


### PR DESCRIPTION
Commit Message: Backport #37240
Additional Description:
Risk Level: Low
Testing: Manual
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
[Optional Runtime guard:] N/A
[Optional Fixes #37199]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]