### PR TITLE
csrf: increase only one counter per request

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -81,6 +81,10 @@ minor_behavior_changes:
 - area: dns
   change: |
     Patched c-ares to address CVE-2024-25629.
+- area: csrf
+  change: |
+    Increase only the statistics counter ``missing_source_origin`` for requests with a missing source origin.
+    Previously, the ``request_invalid`` counter was also increased for such requests.
 
 bug_fixes:
 # *Changes expected to improve the state of the world and are unlikely to have negative effects*

--- a/source/extensions/filters/http/csrf/csrf_filter.cc
+++ b/source/extensions/filters/http/csrf/csrf_filter.cc
@@ -59,7 +59,7 @@ std::string sourceOriginValue(const Http::RequestHeaderMap& headers) {
 std::string targetOriginValue(const Http::RequestHeaderMap& headers) {
   const auto host_value = headers.getHostValue();
 
-  // Don't even bother if there's not Host header.
+  // Don't even bother if there's no Host header.
   if (host_value.empty()) {
     return EMPTY_STRING;
   }
@@ -100,19 +100,12 @@ Http::FilterHeadersStatus CsrfFilter::decodeHeaders(Http::RequestHeaderMap& head
     return Http::FilterHeadersStatus::Continue;
   }
 
-  bool is_valid = true;
   const auto source_origin = sourceOriginValue(headers);
   if (source_origin.empty()) {
-    is_valid = false;
     config_->stats().missing_source_origin_.inc();
-  }
-
-  if (!isValid(source_origin, headers)) {
-    is_valid = false;
+  } else if (!isValid(source_origin, headers)) {
     config_->stats().request_invalid_.inc();
-  }
-
-  if (is_valid == true) {
+  } else {
     config_->stats().request_valid_.inc();
     return Http::FilterHeadersStatus::Continue;
   }


### PR DESCRIPTION
Requests with a missing source origin should increase only the counter "missing_source_origin" but not the counter "request_invalid".

Before this bugfix, the counter "request_invalid" was also increased, depending on the value of the "Host" or ":authority" header.

Risk Level: Low (only metrics affected)
Testing: With improved tests