### PR TITLE
mobile: allowing for immediate pool drain on network change

### DIFF
--- a/mobile/library/common/internal_engine.cc
+++ b/mobile/library/common/internal_engine.cc
@@ -294,6 +294,11 @@ void InternalEngine::onDefaultNetworkChanged(NetworkType network) {
         connectivity_manager_->dnsCache()->setIpVersionToRemove(absl::nullopt);
       }
     }
+    if (Runtime::runtimeFeatureEnabled("envoy.reloadable_features.drain_pools_on_network_change")) {
+      ENVOY_LOG_EVENT(debug, "netconf_immediate_drain", "DrainAllHosts");
+      connectivity_manager_->clusterManager().drainConnections(
+          [](const Upstream::Host&) { return true; });
+    }
     if (Runtime::runtimeFeatureEnabled(
             "envoy.reloadable_features.reset_brokenness_on_nework_change")) {
       Http::HttpServerPropertiesCacheManager& cache_manager =

--- a/mobile/library/common/network/connectivity_manager.h
+++ b/mobile/library/common/network/connectivity_manager.h
@@ -186,6 +186,11 @@ public:
    * @returns the default DNS cache set up in base configuration or nullptr.
    */
   virtual Extensions::Common::DynamicForwardProxy::DnsCacheSharedPtr dnsCache() PURE;
+
+  /**
+   * Returns the cluster manager for this Envoy Mobile instance
+   */
+  virtual Upstream::ClusterManager& clusterManager() PURE;
 };
 
 class ConnectivityManagerImpl : public ConnectivityManager,
@@ -234,6 +239,7 @@ public:
                                                     SocketMode socket_mode) override;
   envoy_netconf_t addUpstreamSocketOptions(Socket::OptionsSharedPtr options) override;
   Extensions::Common::DynamicForwardProxy::DnsCacheSharedPtr dnsCache() override;
+  Upstream::ClusterManager& clusterManager() override { return cluster_manager_; }
 
 private:
   struct NetworkState {

--- a/mobile/test/common/extensions/filters/http/network_configuration/network_configuration_filter_test.cc
+++ b/mobile/test/common/extensions/filters/http/network_configuration/network_configuration_filter_test.cc
@@ -57,6 +57,7 @@ public:
                const Extensions::Common::DynamicForwardProxy::DnsHostInfoSharedPtr&,
                Network::DnsResolver::ResolutionStatus));
   MOCK_METHOD(Extensions::Common::DynamicForwardProxy::DnsCacheSharedPtr, dnsCache, ());
+  MOCK_METHOD(Upstream::ClusterManager&, clusterManager, ());
 };
 
 class NetworkConfigurationFilterTest : public testing::Test {

--- a/mobile/test/java/org/chromium/net/CronetHttp3Test.java
+++ b/mobile/test/java/org/chromium/net/CronetHttp3Test.java
@@ -51,6 +51,9 @@ public class CronetHttp3Test {
   private CronvoyUrlRequestContext cronvoyEngine;
   // A URL which will point to the IP and port of the test servers.
   private String testServerUrl;
+  // Optional reloadable flags to set.
+  private boolean drainOnNetworkChange = false;
+  private boolean resetBrokennessOnNetworkChange = false;
 
   @BeforeClass
   public static void loadJniLibrary() {
@@ -88,7 +91,11 @@ public class CronetHttp3Test {
     // Set up the Envoy engine.
     NativeCronvoyEngineBuilderImpl nativeCronetEngineBuilder =
         new NativeCronvoyEngineBuilderImpl(ApplicationProvider.getApplicationContext());
-    nativeCronetEngineBuilder.addRuntimeGuard("reset_brokenness_on_nework_change", true);
+    nativeCronetEngineBuilder.addRuntimeGuard("drain_pools_on_network_change",
+                                              drainOnNetworkChange);
+    nativeCronetEngineBuilder.addRuntimeGuard("reset_brokenness_on_nework_change",
+                                              resetBrokennessOnNetworkChange);
+
     if (setUpLogging) {
       nativeCronetEngineBuilder.setLogger(logger);
       nativeCronetEngineBuilder.setLogLevel(EnvoyEngine.LogLevel.TRACE);
@@ -273,7 +280,75 @@ public class CronetHttp3Test {
   @Test
   @SmallTest
   @Feature({"Cronet"})
+  public void networkChangeNoDrains() throws Exception {
+    setUp(printEnvoyLogs);
+
+    // Do the initial handshake dance
+    doInitialHttp2Request();
+
+    // Do an HTTP/3 request
+    TestUrlRequestCallback get1Callback = doBasicGetRequest();
+    assertEquals(200, get1Callback.mResponseInfo.getHttpStatusCode());
+    assertEquals("h3", get1Callback.mResponseInfo.getNegotiatedProtocol());
+
+    // There should be one HTTP/3 connection
+    String postStats = cronvoyEngine.getEnvoyEngine().dumpStats();
+    assertTrue(postStats.contains("cluster.base.upstream_cx_http3_total: 1"));
+
+    // Force a network change
+    cronvoyEngine.getEnvoyEngine().onDefaultNetworkUnavailable();
+    cronvoyEngine.getEnvoyEngine().onDefaultNetworkChanged(EnvoyNetworkType.WLAN);
+    cronvoyEngine.getEnvoyEngine().onDefaultNetworkAvailable();
+
+    // Do another HTTP/3 request
+    TestUrlRequestCallback get2Callback = doBasicGetRequest();
+    assertEquals(200, get2Callback.mResponseInfo.getHttpStatusCode());
+    assertEquals("h3", get2Callback.mResponseInfo.getNegotiatedProtocol());
+
+    // There should still only be one HTTP/3 connection.
+    postStats = cronvoyEngine.getEnvoyEngine().dumpStats();
+    assertTrue(postStats.contains("cluster.base.upstream_cx_http3_total: 1"));
+  }
+
+  @Test
+  @SmallTest
+  @Feature({"Cronet"})
+  public void networkChangeWithDrains() throws Exception {
+    drainOnNetworkChange = true;
+    setUp(printEnvoyLogs);
+
+    // Do the initial handshake dance
+    doInitialHttp2Request();
+
+    // Do an HTTP/3 request
+    TestUrlRequestCallback get1Callback = doBasicGetRequest();
+    assertEquals(200, get1Callback.mResponseInfo.getHttpStatusCode());
+    assertEquals("h3", get1Callback.mResponseInfo.getNegotiatedProtocol());
+
+    // There should be one HTTP/3 connection
+    String postStats = cronvoyEngine.getEnvoyEngine().dumpStats();
+    assertTrue(postStats.contains("cluster.base.upstream_cx_http3_total: 1"));
+
+    // Force a network change
+    cronvoyEngine.getEnvoyEngine().onDefaultNetworkUnavailable();
+    cronvoyEngine.getEnvoyEngine().onDefaultNetworkChanged(EnvoyNetworkType.WLAN);
+    cronvoyEngine.getEnvoyEngine().onDefaultNetworkAvailable();
+
+    // Do another HTTP/3 request
+    TestUrlRequestCallback get2Callback = doBasicGetRequest();
+    assertEquals(200, get2Callback.mResponseInfo.getHttpStatusCode());
+    assertEquals("h3", get2Callback.mResponseInfo.getNegotiatedProtocol());
+
+    // There should still only be one HTTP/3 connection.
+    postStats = cronvoyEngine.getEnvoyEngine().dumpStats();
+    assertTrue(postStats.contains("cluster.base.upstream_cx_http3_total: 2"));
+  }
+
+  @Test
+  @SmallTest
+  @Feature({"Cronet"})
   public void networkChangeAffectsBrokenness() throws Exception {
+    resetBrokennessOnNetworkChange = true;
     setUp(printEnvoyLogs);
 
     // Set HTTP/3 to be marked as broken.

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -149,6 +149,8 @@ FALSE_RUNTIME_GUARD(envoy_restart_features_xds_failover_support);
 FALSE_RUNTIME_GUARD(envoy_reloadable_features_dns_cache_set_ip_version_to_remove);
 // TODO(alyssawilk): evaluate and make this a config knob or remove.
 FALSE_RUNTIME_GUARD(envoy_reloadable_features_reset_brokenness_on_nework_change);
+// TODO(alyssawilk): evaluate and make this a config knob or remove.
+FALSE_RUNTIME_GUARD(envoy_reloadable_features_drain_pools_on_network_change);
 // TODO(fredyw): evaluate and either make this a config knob or remove.
 FALSE_RUNTIME_GUARD(envoy_reloadable_features_quic_no_tcp_delay);
 // Adding runtime flag to use balsa_parser for http_inspector.


### PR DESCRIPTION
Risk Level: n/a (mobile only)
Testing: new e2e test
Docs Changes: n/a
Release Notes: n/a