### PR TITLE
Adds logger id for dynamic_modules

### DIFF
--- a/source/common/common/logger.h
+++ b/source/common/common/logger.h
@@ -50,6 +50,7 @@ const static bool should_log = true;
   FUNCTION(decompression)                                                                          \
   FUNCTION(dns)                                                                                    \
   FUNCTION(dubbo)                                                                                  \
+  FUNCTION(dynamic_modules)                                                                        \
   FUNCTION(envoy_bug)                                                                              \
   FUNCTION(ext_authz)                                                                              \
   FUNCTION(ext_proc)                                                                               \

--- a/source/common/common/logger.h
+++ b/source/common/common/logger.h
@@ -50,7 +50,6 @@ const static bool should_log = true;
   FUNCTION(decompression)                                                                          \
   FUNCTION(dns)                                                                                    \
   FUNCTION(dubbo)                                                                                  \
-  FUNCTION(dynamic_modules)                                                                        \
   FUNCTION(envoy_bug)                                                                              \
   FUNCTION(ext_authz)                                                                              \
   FUNCTION(ext_proc)                                                                               \
@@ -98,7 +97,8 @@ const static bool should_log = true;
   FUNCTION(wasm)                                                                                   \
   FUNCTION(websocket)                                                                              \
   FUNCTION(golang)                                                                                 \
-  FUNCTION(stats_sinks)
+  FUNCTION(stats_sinks)                                                                            \
+  FUNCTION(dynamic_modules)
 
 // clang-format off
 enum class Id {


### PR DESCRIPTION
Commit Message: Adds logger id for dynamic_modules
Additional Description:

This commit adds a logger_id for the core dynamic_modules extension.

* https://github.com/envoyproxy/envoy/tree/main/source/extensions/dynamic_modules
* https://github.com/envoyproxy/envoy/tree/main/source/extensions/filters/http/dynamic_modules

This is to mainly avoid unnecessarily requesting review from logger owners into
dynamic_modules PRs just for adding one line.


Risk Level: low
Testing: none
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
