### PR TITLE
ext_proc http bytes tracking support

### DIFF
--- a/source/extensions/filters/http/ext_proc/client.h
+++ b/source/extensions/filters/http/ext_proc/client.h
@@ -44,7 +44,7 @@ public:
       std::unique_ptr<envoy::service::ext_proc::v3::ProcessingResponse>&& response) PURE;
   virtual void onGrpcError(Grpc::Status::GrpcStatus error) PURE;
   virtual void onGrpcClose() PURE;
-  virtual void logGrpcStreamInfo() PURE;
+  virtual void logStreamInfo() PURE;
 };
 
 class ExternalProcessorClient : public ClientBase {

--- a/source/extensions/filters/http/ext_proc/client_base.h
+++ b/source/extensions/filters/http/ext_proc/client_base.h
@@ -3,6 +3,7 @@
 #include <memory>
 
 #include "envoy/service/ext_proc/v3/external_processor.pb.h"
+#include "envoy/stream_info/stream_info.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -17,6 +18,7 @@ public:
   virtual ~RequestCallbacks() = default;
   virtual void onComplete(envoy::service::ext_proc::v3::ProcessingResponse& response) PURE;
   virtual void onError() PURE;
+  virtual void setStreamInfo(Envoy::StreamInfo::StreamInfo* stream_info) PURE;
 };
 
 /**

--- a/source/extensions/filters/http/ext_proc/client_base.h
+++ b/source/extensions/filters/http/ext_proc/client_base.h
@@ -38,7 +38,7 @@ public:
                            bool end_stream, const uint64_t stream_id, RequestCallbacks* callbacks,
                            StreamBase* stream) PURE;
   virtual void cancel() PURE;
-  virtual Envoy::StreamInfo::StreamInfo* getStreamInfo() PURE;
+  virtual const Envoy::StreamInfo::StreamInfo* getStreamInfo() PURE;
 };
 
 using ClientBasePtr = std::unique_ptr<ClientBase>;

--- a/source/extensions/filters/http/ext_proc/client_base.h
+++ b/source/extensions/filters/http/ext_proc/client_base.h
@@ -18,7 +18,6 @@ public:
   virtual ~RequestCallbacks() = default;
   virtual void onComplete(envoy::service::ext_proc::v3::ProcessingResponse& response) PURE;
   virtual void onError() PURE;
-  virtual void setStreamInfo(Envoy::StreamInfo::StreamInfo* stream_info) PURE;
 };
 
 /**
@@ -39,6 +38,7 @@ public:
                            bool end_stream, const uint64_t stream_id, RequestCallbacks* callbacks,
                            StreamBase* stream) PURE;
   virtual void cancel() PURE;
+  virtual Envoy::StreamInfo::StreamInfo* getStreamInfo() PURE;
 };
 
 using ClientBasePtr = std::unique_ptr<ClientBase>;

--- a/source/extensions/filters/http/ext_proc/client_base.h
+++ b/source/extensions/filters/http/ext_proc/client_base.h
@@ -38,7 +38,7 @@ public:
                            bool end_stream, const uint64_t stream_id, RequestCallbacks* callbacks,
                            StreamBase* stream) PURE;
   virtual void cancel() PURE;
-  virtual const Envoy::StreamInfo::StreamInfo* getStreamInfo() PURE;
+  virtual const Envoy::StreamInfo::StreamInfo* getStreamInfo() const PURE;
 };
 
 using ClientBasePtr = std::unique_ptr<ClientBase>;

--- a/source/extensions/filters/http/ext_proc/client_impl.cc
+++ b/source/extensions/filters/http/ext_proc/client_impl.cc
@@ -104,7 +104,7 @@ void ExternalProcessorStreamImpl::onRemoteClose(Grpc::Status::GrpcStatus status,
     return;
   }
 
-  callbacks_->logGrpcStreamInfo();
+  callbacks_->logStreamInfo();
   if (status == Grpc::Status::Ok) {
     callbacks_->onGrpcClose();
   } else {

--- a/source/extensions/filters/http/ext_proc/client_impl.h
+++ b/source/extensions/filters/http/ext_proc/client_impl.h
@@ -36,7 +36,7 @@ public:
                    const uint64_t stream_id, RequestCallbacks* callbacks,
                    StreamBase* stream) override;
   void cancel() override {}
-  Envoy::StreamInfo::StreamInfo* getStreamInfo() override { return nullptr; }
+  const Envoy::StreamInfo::StreamInfo* getStreamInfo() override { return nullptr; }
 
 private:
   Grpc::AsyncClientManager& client_manager_;

--- a/source/extensions/filters/http/ext_proc/client_impl.h
+++ b/source/extensions/filters/http/ext_proc/client_impl.h
@@ -36,6 +36,7 @@ public:
                    const uint64_t stream_id, RequestCallbacks* callbacks,
                    StreamBase* stream) override;
   void cancel() override {}
+  Envoy::StreamInfo::StreamInfo* getStreamInfo() override { return nullptr; }
 
 private:
   Grpc::AsyncClientManager& client_manager_;

--- a/source/extensions/filters/http/ext_proc/client_impl.h
+++ b/source/extensions/filters/http/ext_proc/client_impl.h
@@ -36,7 +36,7 @@ public:
                    const uint64_t stream_id, RequestCallbacks* callbacks,
                    StreamBase* stream) override;
   void cancel() override {}
-  const Envoy::StreamInfo::StreamInfo* getStreamInfo() override { return nullptr; }
+  const Envoy::StreamInfo::StreamInfo* getStreamInfo() const override { return nullptr; }
 
 private:
   Grpc::AsyncClientManager& client_manager_;

--- a/source/extensions/filters/http/ext_proc/ext_proc.cc
+++ b/source/extensions/filters/http/ext_proc/ext_proc.cc
@@ -1082,6 +1082,7 @@ void Filter::logStreamInfoBase(Envoy::StreamInfo::StreamInfo* stream_info) {
   if (stream_info == nullptr) {
     return;
   }
+
   const auto& upstream_meter = stream_info->getUpstreamBytesMeter();
   if (upstream_meter != nullptr) {
     logging_info_->setBytesSent(upstream_meter->wireBytesSent());
@@ -1099,12 +1100,6 @@ void Filter::logStreamInfo() {
     return;
   }
 
-  if (stream_ != nullptr && logging_info_ != nullptr && grpc_service_.has_envoy_grpc()) {
-    logStreamInfoBase(&stream_->streamInfo());
-  }
-}
-
-void Filter::logGrpcStreamInfo() {
   if (stream_ != nullptr && logging_info_ != nullptr && grpc_service_.has_envoy_grpc()) {
     logStreamInfoBase(&stream_->streamInfo());
   }

--- a/source/extensions/filters/http/ext_proc/ext_proc.cc
+++ b/source/extensions/filters/http/ext_proc/ext_proc.cc
@@ -1073,7 +1073,7 @@ void Filter::sendTrailers(ProcessorState& state, const Http::HeaderMap& trailers
   stats_.stream_msgs_sent_.inc();
 }
 
-void Filter::logStreamInfoBase(Envoy::StreamInfo::StreamInfo* stream_info) {
+void Filter::logStreamInfoBase(const Envoy::StreamInfo::StreamInfo* stream_info) {
   if (stream_info == nullptr || logging_info_ == nullptr) {
     return;
   }

--- a/source/extensions/filters/http/ext_proc/ext_proc.cc
+++ b/source/extensions/filters/http/ext_proc/ext_proc.cc
@@ -1101,7 +1101,7 @@ void Filter::logStreamInfo() {
     return;
   }
 
-  if (stream_ != nullptr &&  grpc_service_.has_envoy_grpc()) {
+  if (stream_ != nullptr && grpc_service_.has_envoy_grpc()) {
     // Envoy gRPC service
     logStreamInfoBase(&stream_->streamInfo());
   }

--- a/source/extensions/filters/http/ext_proc/ext_proc.cc
+++ b/source/extensions/filters/http/ext_proc/ext_proc.cc
@@ -1079,7 +1079,7 @@ void Filter::sendTrailers(ProcessorState& state, const Http::HeaderMap& trailers
 }
 
 void Filter::logStreamInfoBase(Envoy::StreamInfo::StreamInfo* stream_info) {
-  if (stream_info == nullptr) {
+  if (stream_info == nullptr || logging_info_ == nullptr) {
     return;
   }
 
@@ -1096,11 +1096,13 @@ void Filter::logStreamInfoBase(Envoy::StreamInfo::StreamInfo* stream_info) {
 
 void Filter::logStreamInfo() {
   if (!config().grpcService().has_value()) {
+    // HTTP service
     logStreamInfoBase(stream_info_http_);
     return;
   }
 
-  if (stream_ != nullptr && logging_info_ != nullptr && grpc_service_.has_envoy_grpc()) {
+  if (stream_ != nullptr &&  grpc_service_.has_envoy_grpc()) {
+    // Envoy gRPC service
     logStreamInfoBase(&stream_->streamInfo());
   }
 }

--- a/source/extensions/filters/http/ext_proc/ext_proc.h
+++ b/source/extensions/filters/http/ext_proc/ext_proc.h
@@ -426,7 +426,7 @@ public:
 
   void encodeComplete() override {
     if (config_->observabilityMode()) {
-      logGrpcStreamInfo();
+      logStreamInfo();
     }
   }
 
@@ -435,7 +435,9 @@ public:
       std::unique_ptr<envoy::service::ext_proc::v3::ProcessingResponse>&& response) override;
   void onGrpcError(Grpc::Status::GrpcStatus error) override;
   void onGrpcClose() override;
+  void logStreamInfoBase(Envoy::StreamInfo::StreamInfo* stream_info);
   void logGrpcStreamInfo() override;
+  void logStreamInfo();
 
   void onMessageTimeout();
   void onNewTimeout(const ProtobufWkt::Duration& override_message_timeout);
@@ -456,6 +458,7 @@ public:
   const ProcessorState& decodingState() { return decoding_state_; }
   void onComplete(envoy::service::ext_proc::v3::ProcessingResponse& response) override;
   void onError() override;
+  void setStreamInfo(Envoy::StreamInfo::StreamInfo* stream_info) override { stream_info_http_ = stream_info; }
 
 private:
   void mergePerRouteConfig();
@@ -537,6 +540,10 @@ private:
 
   // Set to true when the mergePerRouteConfig() method has been called.
   bool route_config_merged_ = false;
+
+  // The HTTP stream info when Envoy sends the requests to the external processor
+  // using HTTP client.
+  Envoy::StreamInfo::StreamInfo* stream_info_http_ = nullptr;
 
   std::vector<std::string> untyped_forwarding_namespaces_{};
   std::vector<std::string> typed_forwarding_namespaces_{};

--- a/source/extensions/filters/http/ext_proc/ext_proc.h
+++ b/source/extensions/filters/http/ext_proc/ext_proc.h
@@ -436,8 +436,7 @@ public:
   void onGrpcError(Grpc::Status::GrpcStatus error) override;
   void onGrpcClose() override;
   void logStreamInfoBase(Envoy::StreamInfo::StreamInfo* stream_info);
-  void logGrpcStreamInfo() override;
-  void logStreamInfo();
+  void logStreamInfo() override;
 
   void onMessageTimeout();
   void onNewTimeout(const ProtobufWkt::Duration& override_message_timeout);

--- a/source/extensions/filters/http/ext_proc/ext_proc.h
+++ b/source/extensions/filters/http/ext_proc/ext_proc.h
@@ -435,7 +435,7 @@ public:
       std::unique_ptr<envoy::service::ext_proc::v3::ProcessingResponse>&& response) override;
   void onGrpcError(Grpc::Status::GrpcStatus error) override;
   void onGrpcClose() override;
-  void logStreamInfoBase(Envoy::StreamInfo::StreamInfo* stream_info);
+  void logStreamInfoBase(const Envoy::StreamInfo::StreamInfo* stream_info);
   void logStreamInfo() override;
 
   void onMessageTimeout();

--- a/source/extensions/filters/http/ext_proc/ext_proc.h
+++ b/source/extensions/filters/http/ext_proc/ext_proc.h
@@ -457,7 +457,9 @@ public:
   const ProcessorState& decodingState() { return decoding_state_; }
   void onComplete(envoy::service::ext_proc::v3::ProcessingResponse& response) override;
   void onError() override;
-  void setStreamInfo(Envoy::StreamInfo::StreamInfo* stream_info) override { stream_info_http_ = stream_info; }
+  void setStreamInfo(Envoy::StreamInfo::StreamInfo* stream_info) override {
+    stream_info_http_ = stream_info;
+  }
 
 private:
   void mergePerRouteConfig();

--- a/source/extensions/filters/http/ext_proc/ext_proc.h
+++ b/source/extensions/filters/http/ext_proc/ext_proc.h
@@ -457,9 +457,6 @@ public:
   const ProcessorState& decodingState() { return decoding_state_; }
   void onComplete(envoy::service::ext_proc::v3::ProcessingResponse& response) override;
   void onError() override;
-  void setStreamInfo(Envoy::StreamInfo::StreamInfo* stream_info) override {
-    stream_info_http_ = stream_info;
-  }
 
 private:
   void mergePerRouteConfig();
@@ -541,10 +538,6 @@ private:
 
   // Set to true when the mergePerRouteConfig() method has been called.
   bool route_config_merged_ = false;
-
-  // The HTTP stream info when Envoy sends the requests to the external processor
-  // using HTTP client.
-  Envoy::StreamInfo::StreamInfo* stream_info_http_ = nullptr;
 
   std::vector<std::string> untyped_forwarding_namespaces_{};
   std::vector<std::string> typed_forwarding_namespaces_{};

--- a/source/extensions/filters/http/ext_proc/http_client/http_client_impl.cc
+++ b/source/extensions/filters/http/ext_proc/http_client/http_client_impl.cc
@@ -112,7 +112,7 @@ void ExtProcHttpClient::onFailure(const Http::AsyncClient::Request&,
   onError();
 }
 
-const Envoy::StreamInfo::StreamInfo* ExtProcHttpClient::getStreamInfo() {
+const Envoy::StreamInfo::StreamInfo* ExtProcHttpClient::getStreamInfo() const {
   if (active_request_ != nullptr) {
     return &active_request_->streamInfo();
   } else {

--- a/source/extensions/filters/http/ext_proc/http_client/http_client_impl.cc
+++ b/source/extensions/filters/http/ext_proc/http_client/http_client_impl.cc
@@ -112,7 +112,7 @@ void ExtProcHttpClient::onFailure(const Http::AsyncClient::Request&,
   onError();
 }
 
-Envoy::StreamInfo::StreamInfo* ExtProcHttpClient::getStreamInfo() {
+const Envoy::StreamInfo::StreamInfo* ExtProcHttpClient::getStreamInfo() {
   if (active_request_ != nullptr) {
     return &active_request_->streamInfo();
   } else {

--- a/source/extensions/filters/http/ext_proc/http_client/http_client_impl.cc
+++ b/source/extensions/filters/http/ext_proc/http_client/http_client_impl.cc
@@ -43,8 +43,7 @@ void ExtProcHttpClient::sendRequest(envoy::service::ext_proc::v3::ProcessingRequ
   auto req_in_json = MessageUtil::getJsonStringFromMessage(req);
   if (req_in_json.ok()) {
     const auto http_uri = config_.http_service().http_service().http_uri();
-    Http::RequestHeaderMapPtr headers =
-        buildHttpRequestHeaders(http_uri.uri(), stream_id);
+    Http::RequestHeaderMapPtr headers = buildHttpRequestHeaders(http_uri.uri(), stream_id);
     auto options = Http::AsyncClient::RequestOptions()
                        .setTimeout(std::chrono::milliseconds(
                            DurationUtil::durationToMilliseconds(http_uri.timeout())))

--- a/source/extensions/filters/http/ext_proc/http_client/http_client_impl.cc
+++ b/source/extensions/filters/http/ext_proc/http_client/http_client_impl.cc
@@ -113,7 +113,7 @@ void ExtProcHttpClient::onFailure(const Http::AsyncClient::Request&,
 }
 
 Envoy::StreamInfo::StreamInfo* ExtProcHttpClient::getStreamInfo() {
-  if (active_request_ != nullptr ) {
+  if (active_request_ != nullptr) {
     return &active_request_->streamInfo();
   } else {
     return nullptr;

--- a/source/extensions/filters/http/ext_proc/http_client/http_client_impl.cc
+++ b/source/extensions/filters/http/ext_proc/http_client/http_client_impl.cc
@@ -54,9 +54,11 @@ void ExtProcHttpClient::sendRequest(envoy::service::ext_proc::v3::ProcessingRequ
     if (thread_local_cluster) {
       active_request_ =
           thread_local_cluster->httpAsyncClient().startRequest(std::move(headers), *this, options);
-      Buffer::OwnedImpl body(req_in_json.value());
-      active_request_->sendData(body, true);
-      callbacks_->setStreamInfo(&active_request_->streamInfo());
+      if (active_request_ != nullptr) {
+        Buffer::OwnedImpl body(req_in_json.value());
+        active_request_->sendData(body, true);
+        callbacks_->setStreamInfo(&active_request_->streamInfo());
+      }
     } else {
       ENVOY_LOG(error, "ext_proc cluster {} does not exist in the config", cluster);
     }

--- a/source/extensions/filters/http/ext_proc/http_client/http_client_impl.h
+++ b/source/extensions/filters/http/ext_proc/http_client/http_client_impl.h
@@ -36,7 +36,7 @@ public:
   void onFailure(const Http::AsyncClient::Request& request,
                  Http::AsyncClient::FailureReason reason) override;
 
-  Envoy::StreamInfo::StreamInfo* getStreamInfo() override;
+  const Envoy::StreamInfo::StreamInfo* getStreamInfo() override;
 
   Server::Configuration::ServerFactoryContext& context() const { return context_; }
 

--- a/source/extensions/filters/http/ext_proc/http_client/http_client_impl.h
+++ b/source/extensions/filters/http/ext_proc/http_client/http_client_impl.h
@@ -42,7 +42,7 @@ private:
   void onError();
   envoy::extensions::filters::http::ext_proc::v3::ExternalProcessor config_;
   Server::Configuration::ServerFactoryContext& context_;
-  Http::AsyncClient::Request* active_request_{};
+  Http::AsyncClient::OngoingRequest* active_request_{};
   RequestCallbacks* callbacks_{};
 };
 

--- a/source/extensions/filters/http/ext_proc/http_client/http_client_impl.h
+++ b/source/extensions/filters/http/ext_proc/http_client/http_client_impl.h
@@ -36,6 +36,8 @@ public:
   void onFailure(const Http::AsyncClient::Request& request,
                  Http::AsyncClient::FailureReason reason) override;
 
+  Envoy::StreamInfo::StreamInfo* getStreamInfo() override;
+
   Server::Configuration::ServerFactoryContext& context() const { return context_; }
 
 private:

--- a/source/extensions/filters/http/ext_proc/http_client/http_client_impl.h
+++ b/source/extensions/filters/http/ext_proc/http_client/http_client_impl.h
@@ -36,7 +36,7 @@ public:
   void onFailure(const Http::AsyncClient::Request& request,
                  Http::AsyncClient::FailureReason reason) override;
 
-  const Envoy::StreamInfo::StreamInfo* getStreamInfo() override;
+  const Envoy::StreamInfo::StreamInfo* getStreamInfo() const override;
 
   Server::Configuration::ServerFactoryContext& context() const { return context_; }
 

--- a/source/extensions/filters/http/ext_proc/processor_state.cc
+++ b/source/extensions/filters/http/ext_proc/processor_state.cc
@@ -40,7 +40,7 @@ void ProcessorState::onStartProcessorCall(Event::TimerCb cb, std::chrono::millis
 void ProcessorState::onFinishProcessorCall(Grpc::Status::GrpcStatus call_status,
                                            CallbackState next_state) {
   ENVOY_LOG(debug, "Finish external processing call");
-  filter_.logGrpcStreamInfo();
+  filter_.logStreamInfo();
 
   stopMessageTimer();
 

--- a/test/extensions/filters/http/ext_proc/client_test.cc
+++ b/test/extensions/filters/http/ext_proc/client_test.cc
@@ -65,7 +65,7 @@ protected:
   void onGrpcError(Grpc::Status::GrpcStatus status) override { grpc_status_ = status; }
 
   void onGrpcClose() override { grpc_closed_ = true; }
-  void logGrpcStreamInfo() override {}
+  void logStreamInfo() override {}
   void onComplete(envoy::service::ext_proc::v3::ProcessingResponse&) override {}
   void onError() override {}
   void setStreamInfo(Envoy::StreamInfo::StreamInfo*) override {}

--- a/test/extensions/filters/http/ext_proc/client_test.cc
+++ b/test/extensions/filters/http/ext_proc/client_test.cc
@@ -68,6 +68,7 @@ protected:
   void logGrpcStreamInfo() override {}
   void onComplete(envoy::service::ext_proc::v3::ProcessingResponse&) override {}
   void onError() override {}
+  void setStreamInfo(Envoy::StreamInfo::StreamInfo*) override {}
 
   std::unique_ptr<ProcessingResponse> last_response_;
   Grpc::Status::GrpcStatus grpc_status_ = Grpc::Status::WellKnownGrpcStatus::Ok;

--- a/test/extensions/filters/http/ext_proc/client_test.cc
+++ b/test/extensions/filters/http/ext_proc/client_test.cc
@@ -68,7 +68,6 @@ protected:
   void logStreamInfo() override {}
   void onComplete(envoy::service::ext_proc::v3::ProcessingResponse&) override {}
   void onError() override {}
-  void setStreamInfo(Envoy::StreamInfo::StreamInfo*) override {}
 
   std::unique_ptr<ProcessingResponse> last_response_;
   Grpc::Status::GrpcStatus grpc_status_ = Grpc::Status::WellKnownGrpcStatus::Ok;

--- a/test/extensions/filters/http/ext_proc/http_client/BUILD
+++ b/test/extensions/filters/http/ext_proc/http_client/BUILD
@@ -39,6 +39,7 @@ envoy_extension_cc_test(
     deps = [
         "//source/extensions/filters/http/ext_proc:config",
         "//test/common/http:common_lib",
+        "//test/extensions/filters/http/ext_proc:logging_test_filter_lib",
         "//test/extensions/filters/http/ext_proc:utils_lib",
         "//test/integration:http_protocol_integration_lib",
         "//test/test_common:utility_lib",

--- a/test/extensions/filters/http/ext_proc/http_client/ext_proc_http_integration_test.cc
+++ b/test/extensions/filters/http/ext_proc/http_client/ext_proc_http_integration_test.cc
@@ -8,8 +8,8 @@
 #include "source/extensions/filters/http/ext_proc/ext_proc.h"
 
 #include "test/common/http/common.h"
-#include "test/extensions/filters/http/ext_proc/utils.h"
 #include "test/extensions/filters/http/ext_proc/logging_test_filter.pb.h"
+#include "test/extensions/filters/http/ext_proc/utils.h"
 #include "test/integration/http_protocol_integration.h"
 #include "test/test_common/utility.h"
 

--- a/test/extensions/filters/http/ext_proc/logging_test_filter.cc
+++ b/test/extensions/filters/http/ext_proc/logging_test_filter.cc
@@ -39,6 +39,7 @@ public:
       }
       ASSERT_TRUE(ext_proc_logging_info->upstreamHost() != nullptr);
       EXPECT_EQ(ext_proc_logging_info->upstreamHost()->cluster().name(), expected_cluster_name_);
+      EXPECT_EQ(ext_proc_logging_info->clusterInfo()->name(), expected_cluster_name_);
     }
   }
 

--- a/test/extensions/filters/http/ext_proc/mock_server.h
+++ b/test/extensions/filters/http/ext_proc/mock_server.h
@@ -23,7 +23,7 @@ public:
                RequestCallbacks*, StreamBase*));
   MOCK_METHOD(void, cancel, ());
 
-  MOCK_METHOD(Envoy::StreamInfo::StreamInfo*, getStreamInfo, ());
+  MOCK_METHOD(const Envoy::StreamInfo::StreamInfo*, getStreamInfo, ());
 };
 
 class MockStream : public ExternalProcessorStream {

--- a/test/extensions/filters/http/ext_proc/mock_server.h
+++ b/test/extensions/filters/http/ext_proc/mock_server.h
@@ -23,7 +23,7 @@ public:
                RequestCallbacks*, StreamBase*));
   MOCK_METHOD(void, cancel, ());
 
-  MOCK_METHOD(const Envoy::StreamInfo::StreamInfo*, getStreamInfo, ());
+  MOCK_METHOD(const Envoy::StreamInfo::StreamInfo*, getStreamInfo, (), (const));
 };
 
 class MockStream : public ExternalProcessorStream {

--- a/test/extensions/filters/http/ext_proc/mock_server.h
+++ b/test/extensions/filters/http/ext_proc/mock_server.h
@@ -22,6 +22,8 @@ public:
               (envoy::service::ext_proc::v3::ProcessingRequest&&, bool, const uint64_t,
                RequestCallbacks*, StreamBase*));
   MOCK_METHOD(void, cancel, ());
+
+  MOCK_METHOD(Envoy::StreamInfo::StreamInfo*, getStreamInfo, ());
 };
 
 class MockStream : public ExternalProcessorStream {


### PR DESCRIPTION
This is a follow up PR of: https://github.com/envoyproxy/envoy/pull/35740.

This PR added the bytes tracking support for ext_proc http service, which basically is counting how many bytes are sent to and received from ext_proc HTTP service.

It takes the stream_info from the active HTTP request, and saved in the ext_proc filter. When the external processing completes, the bytes counters from the stream_info are retrieved and stored into the filter state.

The existing logging test filter is leveraged to test the byte counters in the filter state are correctly updated. 