### PR TITLE
Grant LB policies write access to connection stream info

### DIFF
--- a/contrib/golang/filters/network/source/upstream.h
+++ b/contrib/golang/filters/network/source/upstream.h
@@ -61,7 +61,7 @@ public:
   void onEvent(Network::ConnectionEvent event) override;
 
   // Upstream::LoadBalancerContextBase
-  const StreamInfo::StreamInfo* requestStreamInfo() const override { return stream_info_.get(); }
+  StreamInfo::StreamInfo* requestStreamInfo() const override { return stream_info_.get(); }
 
   void connect();
   void enableHalfClose(bool enabled);

--- a/contrib/golang/filters/network/test/upstream_test.cc
+++ b/contrib/golang/filters/network/test/upstream_test.cc
@@ -56,7 +56,7 @@ TEST_F(UpstreamConnTest, ConnectUpstream) {
   initialize();
 
   const auto* dst_addr =
-      upConn_->requestStreamInfo()->filterState().getDataReadOnly<Network::AddressObject>(
+      upConn_->requestStreamInfo()->filterState()->getDataReadOnly<Network::AddressObject>(
           "envoy.network.transport_socket.original_dst_address");
   EXPECT_EQ(dst_addr->address()->asString(), addr_);
 

--- a/envoy/upstream/load_balancer.h
+++ b/envoy/upstream/load_balancer.h
@@ -57,7 +57,7 @@ public:
    * @return const StreamInfo* the incoming request stream info or nullptr to use during load
    * balancing.
    */
-  virtual const StreamInfo::StreamInfo* requestStreamInfo() const PURE;
+  virtual StreamInfo::StreamInfo* requestStreamInfo() const PURE;
 
   /**
    * @return const Http::HeaderMap* the incoming headers or nullptr to use during load

--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -373,9 +373,7 @@ public:
   const Network::Connection* downstreamConnection() const override {
     return callbacks_->connection().ptr();
   }
-  const StreamInfo::StreamInfo* requestStreamInfo() const override {
-    return &callbacks_->streamInfo();
-  }
+  StreamInfo::StreamInfo* requestStreamInfo() const override { return &callbacks_->streamInfo(); }
   const Http::RequestHeaderMap* downstreamHeaders() const override { return downstream_headers_; }
 
   bool shouldSelectAnotherHost(const Upstream::Host& host) override {

--- a/source/common/tcp_proxy/tcp_proxy.h
+++ b/source/common/tcp_proxy/tcp_proxy.h
@@ -430,7 +430,7 @@ public:
     return &read_callbacks_->connection();
   }
 
-  const StreamInfo::StreamInfo* requestStreamInfo() const override {
+  StreamInfo::StreamInfo* requestStreamInfo() const override {
     return &read_callbacks_->connection().streamInfo();
   }
 

--- a/source/common/upstream/load_balancer_context_base.h
+++ b/source/common/upstream/load_balancer_context_base.h
@@ -13,7 +13,7 @@ public:
 
   const Router::MetadataMatchCriteria* metadataMatchCriteria() override { return nullptr; }
 
-  const StreamInfo::StreamInfo* requestStreamInfo() const override { return nullptr; }
+  StreamInfo::StreamInfo* requestStreamInfo() const override { return nullptr; }
 
   const Http::RequestHeaderMap* downstreamHeaders() const override { return nullptr; }
 

--- a/source/extensions/clusters/dynamic_forward_proxy/cluster.cc
+++ b/source/extensions/clusters/dynamic_forward_proxy/cluster.cc
@@ -359,7 +359,7 @@ Cluster::LoadBalancer::chooseHost(Upstream::LoadBalancerContext* context) {
   const Router::StringAccessor* dynamic_host_filter_state = nullptr;
   if (context->requestStreamInfo()) {
     dynamic_host_filter_state =
-        context->requestStreamInfo()->filterState().getDataReadOnly<Router::StringAccessor>(
+        context->requestStreamInfo()->filterState()->getDataReadOnly<Router::StringAccessor>(
             DynamicHostFilterStateKey);
   }
 
@@ -384,7 +384,7 @@ Cluster::LoadBalancer::chooseHost(Upstream::LoadBalancerContext* context) {
   uint32_t port = is_secure ? 443 : 80;
   if (context->requestStreamInfo()) {
     const StreamInfo::UInt32Accessor* dynamic_port_filter_state =
-        context->requestStreamInfo()->filterState().getDataReadOnly<StreamInfo::UInt32Accessor>(
+        context->requestStreamInfo()->filterState()->getDataReadOnly<StreamInfo::UInt32Accessor>(
             DynamicPortFilterStateKey);
     if (dynamic_port_filter_state != nullptr && dynamic_port_filter_state->value() > 0 &&
         dynamic_port_filter_state->value() <= 65535) {

--- a/source/extensions/clusters/original_dst/original_dst_cluster.cc
+++ b/source/extensions/clusters/original_dst/original_dst_cluster.cc
@@ -105,7 +105,7 @@ HostConstSharedPtr OriginalDstCluster::LoadBalancer::chooseHost(LoadBalancerCont
 Network::Address::InstanceConstSharedPtr
 OriginalDstCluster::LoadBalancer::filterStateOverrideHost(LoadBalancerContext* context) {
   const auto streamInfos = {
-      static_cast<const StreamInfo::StreamInfo*>(context->requestStreamInfo()),
+      const_cast<const StreamInfo::StreamInfo*>(context->requestStreamInfo()),
       context->downstreamConnection() ? &context->downstreamConnection()->streamInfo() : nullptr};
   for (const auto streamInfo : streamInfos) {
     if (streamInfo == nullptr) {
@@ -154,7 +154,7 @@ OriginalDstCluster::LoadBalancer::metadataOverrideHost(LoadBalancerContext* cont
     return nullptr;
   }
   const auto streamInfos = {
-      static_cast<const StreamInfo::StreamInfo*>(context->requestStreamInfo()),
+      const_cast<const StreamInfo::StreamInfo*>(context->requestStreamInfo()),
       context->downstreamConnection() ? &context->downstreamConnection()->streamInfo() : nullptr};
   const ProtobufWkt::Value* value = nullptr;
   for (const auto streamInfo : streamInfos) {

--- a/source/extensions/clusters/original_dst/original_dst_cluster.cc
+++ b/source/extensions/clusters/original_dst/original_dst_cluster.cc
@@ -105,7 +105,7 @@ HostConstSharedPtr OriginalDstCluster::LoadBalancer::chooseHost(LoadBalancerCont
 Network::Address::InstanceConstSharedPtr
 OriginalDstCluster::LoadBalancer::filterStateOverrideHost(LoadBalancerContext* context) {
   const auto streamInfos = {
-      context->requestStreamInfo(),
+      static_cast<const StreamInfo::StreamInfo*>(context->requestStreamInfo()),
       context->downstreamConnection() ? &context->downstreamConnection()->streamInfo() : nullptr};
   for (const auto streamInfo : streamInfos) {
     if (streamInfo == nullptr) {
@@ -154,7 +154,7 @@ OriginalDstCluster::LoadBalancer::metadataOverrideHost(LoadBalancerContext* cont
     return nullptr;
   }
   const auto streamInfos = {
-      context->requestStreamInfo(),
+      static_cast<const StreamInfo::StreamInfo*>(context->requestStreamInfo()),
       context->downstreamConnection() ? &context->downstreamConnection()->streamInfo() : nullptr};
   const ProtobufWkt::Value* value = nullptr;
   for (const auto streamInfo : streamInfos) {

--- a/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.cc
+++ b/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.cc
@@ -305,7 +305,7 @@ UdpProxyFilter::createSessionWithOptionalHost(Network::UdpRecvData::LocalPeerAdd
 
 Upstream::HostConstSharedPtr UdpProxyFilter::ClusterInfo::chooseHost(
     const Network::Address::InstanceConstSharedPtr& peer_address,
-    const StreamInfo::StreamInfo* stream_info) const {
+    StreamInfo::StreamInfo* stream_info) const {
   UdpLoadBalancerContext context(filter_.config_->hashPolicy(), peer_address, stream_info);
   Upstream::HostConstSharedPtr host = cluster_.loadBalancer().chooseHost(&context);
   return host;

--- a/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.h
+++ b/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.h
@@ -149,7 +149,7 @@ class UdpLoadBalancerContext : public Upstream::LoadBalancerContextBase {
 public:
   UdpLoadBalancerContext(const Udp::HashPolicy* hash_policy,
                          const Network::Address::InstanceConstSharedPtr& peer_address,
-                         const StreamInfo::StreamInfo* stream_info)
+                         StreamInfo::StreamInfo* stream_info)
       : stream_info_(stream_info) {
     if (hash_policy) {
       hash_ = hash_policy->generateHash(*peer_address);
@@ -157,11 +157,11 @@ public:
   }
 
   absl::optional<uint64_t> computeHashKey() override { return hash_; }
-  const StreamInfo::StreamInfo* requestStreamInfo() const override { return stream_info_; }
+  StreamInfo::StreamInfo* requestStreamInfo() const override { return stream_info_; }
 
 private:
   absl::optional<uint64_t> hash_;
-  const StreamInfo::StreamInfo* stream_info_;
+  StreamInfo::StreamInfo* const stream_info_;
 };
 
 /**
@@ -858,7 +858,7 @@ protected:
 
     Upstream::HostConstSharedPtr
     chooseHost(const Network::Address::InstanceConstSharedPtr& peer_address,
-               const StreamInfo::StreamInfo* stream_info) const;
+               StreamInfo::StreamInfo* stream_info) const;
 
     UdpProxyFilter& filter_;
     Upstream::ThreadLocalCluster& cluster_;

--- a/source/extensions/load_balancing_policies/subset/subset_lb.h
+++ b/source/extensions/load_balancing_policies/subset/subset_lb.h
@@ -171,7 +171,7 @@ public:
     const Network::Connection* downstreamConnection() const override {
       return wrapped_->downstreamConnection();
     }
-    const StreamInfo::StreamInfo* requestStreamInfo() const override {
+    StreamInfo::StreamInfo* requestStreamInfo() const override {
       return wrapped_->requestStreamInfo();
     }
     const Http::RequestHeaderMap* downstreamHeaders() const override {

--- a/test/common/http/async_client_impl_test.cc
+++ b/test/common/http/async_client_impl_test.cc
@@ -935,8 +935,9 @@ TEST_F(AsyncClientImplTest, WithFilterState) {
   EXPECT_CALL(cm_.thread_local_cluster_, httpConnPool(_, _, _))
       .WillOnce(Invoke([&](Upstream::ResourcePriority, absl::optional<Http::Protocol>,
                            Upstream::LoadBalancerContext* context) {
-        const StreamInfo::FilterState& filter_state = context->requestStreamInfo()->filterState();
-        const TestStateObject* state = filter_state.getDataReadOnly<TestStateObject>("test-filter");
+        StreamInfo::FilterStateSharedPtr filter_state = context->requestStreamInfo()->filterState();
+        const TestStateObject* state =
+            filter_state->getDataReadOnly<TestStateObject>("test-filter");
         EXPECT_NE(state, nullptr);
         EXPECT_EQ(state->value(), "stored-test-state");
         return Upstream::HttpPoolData([]() {}, &cm_.thread_local_cluster_.conn_pool_);

--- a/test/common/upstream/BUILD
+++ b/test/common/upstream/BUILD
@@ -89,6 +89,7 @@ envoy_cc_test(
     srcs = ["cluster_manager_impl_test.cc"],
     rbe_pool = "4core",
     deps = [
+        ":metadata_writer_lb_proto_cc_proto",
         ":test_cluster_manager",
         "//envoy/config:config_validator_interface",
         "//source/common/router:context_lib",
@@ -681,4 +682,9 @@ envoy_cc_test_library(
         "//envoy/upstream:upstream_interface",
         "@com_google_absl//absl/types:optional",
     ],
+)
+
+envoy_proto_library(
+    name = "metadata_writer_lb_proto",
+    srcs = ["metadata_writer_lb.proto"],
 )

--- a/test/common/upstream/metadata_writer_lb.proto
+++ b/test/common/upstream/metadata_writer_lb.proto
@@ -1,0 +1,6 @@
+syntax = "proto3";
+
+package test.load_balancing_policies.metadata_writer;
+
+message MetadataWriterLbConfig {
+}

--- a/test/extensions/clusters/dynamic_forward_proxy/cluster_test.cc
+++ b/test/extensions/clusters/dynamic_forward_proxy/cluster_test.cc
@@ -124,10 +124,9 @@ public:
   }
 
   Upstream::MockLoadBalancerContext* setFilterStateHostAndReturnContext(const std::string& host) {
-    StreamInfo::FilterState& filter_state =
-        const_cast<StreamInfo::FilterState&>(lb_context_.requestStreamInfo()->filterState());
+    StreamInfo::FilterStateSharedPtr filter_state = lb_context_.requestStreamInfo()->filterState();
 
-    filter_state.setData(
+    filter_state->setData(
         "envoy.upstream.dynamic_host", std::make_shared<Router::StringAccessorImpl>(host),
         StreamInfo::FilterState::StateType::Mutable, StreamInfo::FilterState::LifeSpan::Connection,
         StreamInfo::StreamSharingMayImpactPooling::SharedWithUpstreamConnection);

--- a/test/extensions/clusters/original_dst/original_dst_cluster_test.cc
+++ b/test/extensions/clusters/original_dst/original_dst_cluster_test.cc
@@ -43,7 +43,7 @@ public:
   TestLoadBalancerContext(const Network::Connection* connection)
       : TestLoadBalancerContext(connection, nullptr) {}
   TestLoadBalancerContext(const Network::Connection* connection,
-                          const StreamInfo::StreamInfo* request_stream_info)
+                          StreamInfo::StreamInfo* request_stream_info)
       : connection_(connection), request_stream_info_(request_stream_info) {}
   TestLoadBalancerContext(const Network::Connection* connection, const std::string& key,
                           const std::string& value)
@@ -55,14 +55,14 @@ public:
   // Upstream::LoadBalancerContext
   absl::optional<uint64_t> computeHashKey() override { return 0; }
   const Network::Connection* downstreamConnection() const override { return connection_; }
-  const StreamInfo::StreamInfo* requestStreamInfo() const override { return request_stream_info_; }
+  StreamInfo::StreamInfo* requestStreamInfo() const override { return request_stream_info_; }
   const Http::RequestHeaderMap* downstreamHeaders() const override {
     return downstream_headers_.get();
   }
 
   absl::optional<uint64_t> hash_key_;
   const Network::Connection* connection_;
-  const StreamInfo::StreamInfo* request_stream_info_;
+  StreamInfo::StreamInfo* request_stream_info_;
   Http::RequestHeaderMapPtr downstream_headers_;
 };
 

--- a/test/integration/load_balancers/custom_lb_policy.h
+++ b/test/integration/load_balancers/custom_lb_policy.h
@@ -24,7 +24,12 @@ private:
   public:
     LbImpl(const Upstream::HostSharedPtr& host) : host_(host) {}
 
-    Upstream::HostConstSharedPtr chooseHost(Upstream::LoadBalancerContext*) override {
+    Upstream::HostConstSharedPtr chooseHost(Upstream::LoadBalancerContext* context) override {
+      if (context && context->requestStreamInfo()) {
+        ProtobufWkt::Struct value;
+        (*value.mutable_fields())["foo"] = ValueUtil::stringValue("bar");
+        context->requestStreamInfo()->setDynamicMetadata("envoy.load_balancers.custom_lb", value);
+      }
       return host_;
     }
     Upstream::HostConstSharedPtr peekAnotherHost(Upstream::LoadBalancerContext*) override {

--- a/test/integration/load_balancers/custom_lb_policy.h
+++ b/test/integration/load_balancers/custom_lb_policy.h
@@ -24,12 +24,7 @@ private:
   public:
     LbImpl(const Upstream::HostSharedPtr& host) : host_(host) {}
 
-    Upstream::HostConstSharedPtr chooseHost(Upstream::LoadBalancerContext* context) override {
-      if (context && context->requestStreamInfo()) {
-        ProtobufWkt::Struct value;
-        (*value.mutable_fields())["foo"] = ValueUtil::stringValue("bar");
-        context->requestStreamInfo()->setDynamicMetadata("envoy.load_balancers.custom_lb", value);
-      }
+    Upstream::HostConstSharedPtr chooseHost(Upstream::LoadBalancerContext*) override {
       return host_;
     }
     Upstream::HostConstSharedPtr peekAnotherHost(Upstream::LoadBalancerContext*) override {

--- a/test/mocks/upstream/load_balancer_context.h
+++ b/test/mocks/upstream/load_balancer_context.h
@@ -15,7 +15,7 @@ public:
   MOCK_METHOD(absl::optional<uint64_t>, computeHashKey, ());
   MOCK_METHOD(Router::MetadataMatchCriteria*, metadataMatchCriteria, ());
   MOCK_METHOD(const Network::Connection*, downstreamConnection, (), (const));
-  MOCK_METHOD(const StreamInfo::StreamInfo*, requestStreamInfo, (), (const));
+  MOCK_METHOD(StreamInfo::StreamInfo*, requestStreamInfo, (), (const));
   MOCK_METHOD(const Http::RequestHeaderMap*, downstreamHeaders, (), (const));
   MOCK_METHOD(const HealthyAndDegradedLoad&, determinePriorityLoad,
               (const PrioritySet&, const HealthyAndDegradedLoad&,


### PR DESCRIPTION
Additional Description:
We have uses cases where LB policies need to be able to write to request metadata when choosing or picking hosts. The metadata can be used in logging or by HTTP filters.

This PR makes access to the request stream info non `const`.

Risk Level: Low
Testing: Unit tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
