### PR TITLE
ci/publishing: Minor workflow fix

### DIFF
--- a/.github/workflows/envoy-publish.yml
+++ b/.github/workflows/envoy-publish.yml
@@ -39,8 +39,7 @@ jobs:
       packages: read
       pull-requests: read
     if: >-
-      ${{ github.event.workflow_run.conclusion == 'success'
-       && (github.repository == 'envoyproxy/envoy' || vars.ENVOY_CI) }}
+      ${{ github.event.workflow_run.conclusion == 'success' }}
     uses: ./.github/workflows/_load.yml
     with:
       check-name: publish


### PR DESCRIPTION
Currently if the request stage fails or is cancelled it causes the publish wf to fail rather than just being skipped as the others do - this should fix that