### PR TITLE
fuzz: fixing utility_fuzzer initialize_and_validate error handling

### DIFF
--- a/test/common/http/utility_corpus/empty_initialize_and_validate
+++ b/test/common/http/utility_corpus/empty_initialize_and_validate
@@ -1,0 +1,1 @@
+initialize_and_validate { } 

--- a/test/common/http/utility_fuzz_test.cc
+++ b/test/common/http/utility_fuzz_test.cc
@@ -87,7 +87,7 @@ DEFINE_PROTO_FUZZER(const test::common::http::UtilityTestCase& input) {
   case test::common::http::UtilityTestCase::kInitializeAndValidate: {
     const auto& options = input.initialize_and_validate();
     auto options_or_error = Http2::Utility::initializeAndValidateOptions(options);
-    if (options_or_error.status().ok()) {
+    if (!options_or_error.status().ok()) {
       absl::string_view msg = options_or_error.status().message();
       // initializeAndValidateOptions throws exceptions for 4 different reasons due to malformed
       // settings, so check for them and allow any other exceptions through


### PR DESCRIPTION
Commit Message: fuzz: fixing utility_fuzzer initialize_and_validate error handling
Additional Description:
Fixing a logical error in the initialize_and_validate part of the HTTP utility fuzzer.

Fixes fuzz issue [379773073](https://g-issues.oss-fuzz.com/issues/379773073?pli=1&authuser=0).

Risk Level: low - tests only
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
