### PR TITLE
dynamic_modules: exclude abi.h from clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -39,11 +39,6 @@ Checks: >
   readability-redundant-smartptr-get,
   readability-redundant-string-cstr
 
-Checks: '-modernize-use-using'
-Exclude:
-  # The ABI of dynamic modules is a pure C header, not C++.
-  - './source/extensions/dynamic_modules/abi.h'
-
 CheckOptions:
 - key: cppcoreguidelines-unused-variable.IgnorePattern
   value: "^_$"
@@ -115,6 +110,9 @@ HeaderFilterRegex: '^./source/.*|^./contrib/.*|^./test/.*|^./envoy/.*'
 UseColor: true
 
 WarningsAsErrors: '*'
+
+# The ABI header file is a pure C header file, and clang-tidy is only for C++.
+ExcludeHeaderFilterRegex: 'source/extensions/dynamic_modules/abi.h'
 
 ## The version here is arbitrary since any change to this file will
 ## trigger a full run of clang-tidy against all files.

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -39,6 +39,11 @@ Checks: >
   readability-redundant-smartptr-get,
   readability-redundant-string-cstr
 
+Checks: '-modernize-use-using'
+Exclude:
+  # The ABI of dynamic modules is a pure C header, not C++.
+  - './source/extensions/dynamic_modules/abi.h'
+
 CheckOptions:
 - key: cppcoreguidelines-unused-variable.IgnorePattern
   value: "^_$"

--- a/source/extensions/dynamic_modules/abi.h
+++ b/source/extensions/dynamic_modules/abi.h
@@ -1,7 +1,5 @@
 #pragma once
 
-// NOLINT(namespace-envoy)
-
 // This is a pure C header file that defines the ABI of the core of dynamic modules used by Envoy.
 //
 // This must not contain any dependencies besides standard library since it is not only used by

--- a/source/extensions/dynamic_modules/abi.h
+++ b/source/extensions/dynamic_modules/abi.h
@@ -33,8 +33,7 @@ extern "C" {
  *
  * OWNERSHIP: Envoy owns the pointer.
  */
-typedef const char* // NOLINT(modernize-use-using)
-    envoy_dynamic_module_type_abi_version_envoy_ptr;
+typedef const char* envoy_dynamic_module_type_abi_version_envoy_ptr;
 
 /**
  * envoy_dynamic_module_type_http_filter_config_envoy_ptr is a raw pointer to
@@ -47,8 +46,7 @@ typedef const char* // NOLINT(modernize-use-using)
  *
  * OWNERSHIP: Envoy owns the pointer.
  */
-typedef const void* // NOLINT(modernize-use-using)
-    envoy_dynamic_module_type_http_filter_config_envoy_ptr;
+typedef const void* envoy_dynamic_module_type_http_filter_config_envoy_ptr;
 
 /**
  * envoy_dynamic_module_type_http_filter_config_module_ptr is a pointer to an in-module HTTP
@@ -60,8 +58,7 @@ typedef const void* // NOLINT(modernize-use-using)
  * OWNERSHIP: The module is responsible for managing the lifetime of the pointer. The pointer can be
  * released when envoy_dynamic_module_on_http_filter_config_destroy is called for the same pointer.
  */
-typedef const void* // NOLINT(modernize-use-using)
-    envoy_dynamic_module_type_http_filter_config_module_ptr;
+typedef const void* envoy_dynamic_module_type_http_filter_config_module_ptr;
 
 // -----------------------------------------------------------------------------
 // ------------------------------- Event Hooks ---------------------------------

--- a/source/extensions/dynamic_modules/abi.h
+++ b/source/extensions/dynamic_modules/abi.h
@@ -1,5 +1,7 @@
 #pragma once
 
+// NOLINT(namespace-envoy)
+
 // This is a pure C header file that defines the ABI of the core of dynamic modules used by Envoy.
 //
 // This must not contain any dependencies besides standard library since it is not only used by

--- a/source/extensions/dynamic_modules/abi_version.h
+++ b/source/extensions/dynamic_modules/abi_version.h
@@ -6,7 +6,7 @@ namespace DynamicModules {
 #endif
 // This is the ABI version calculated as a sha256 hash of the ABI header files. When the ABI
 // changes, this value must change, and the correctness of this value is checked by the test.
-const char* kAbiVersion = "c54ac08013985b919604693f4909c658c29d951abdd691fd79d306ed7fdf4820";
+const char* kAbiVersion = "152372902a15b54edce8a868b15931579b79d979dbc004689761b47b8622d4a3";
 
 #ifdef __cplusplus
 } // namespace DynamicModules

--- a/source/extensions/dynamic_modules/abi_version.h
+++ b/source/extensions/dynamic_modules/abi_version.h
@@ -6,7 +6,7 @@ namespace DynamicModules {
 #endif
 // This is the ABI version calculated as a sha256 hash of the ABI header files. When the ABI
 // changes, this value must change, and the correctness of this value is checked by the test.
-const char* kAbiVersion = "164a60ff214ca3cd62526ddb7c3fe21cf943e8721a115c87feca81a58510072c";
+const char* kAbiVersion = "152372902a15b54edce8a868b15931579b79d979dbc004689761b47b8622d4a3";
 
 #ifdef __cplusplus
 } // namespace DynamicModules

--- a/source/extensions/dynamic_modules/abi_version.h
+++ b/source/extensions/dynamic_modules/abi_version.h
@@ -6,7 +6,7 @@ namespace DynamicModules {
 #endif
 // This is the ABI version calculated as a sha256 hash of the ABI header files. When the ABI
 // changes, this value must change, and the correctness of this value is checked by the test.
-const char* kAbiVersion = "152372902a15b54edce8a868b15931579b79d979dbc004689761b47b8622d4a3";
+const char* kAbiVersion = "c54ac08013985b919604693f4909c658c29d951abdd691fd79d306ed7fdf4820";
 
 #ifdef __cplusplus
 } // namespace DynamicModules


### PR DESCRIPTION
Commit Message: dynamic_modules: dynamic_modules: exclude abi.h from clang-tidy
Additional Description:

This commit disables clang-tidy for the whole ABI header which is a pure C file. 
Previously, I added `// NOLINT` comment line on each place, 
clang-tidy is only for C++ source code, so this disables it considering the 
readability. This shouldn't be a problem as the header only has types and 
function declarations.


Risk Level: none
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
