### PR TITLE
lua: add new function to set upstream host override

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -265,6 +265,10 @@ new_features:
   change: |
     Added support in SNI dynamic forward proxy for saving the resolved upstream address in the filter state.
     The state is saved with the key ``envoy.stream.upstream_address``.
+- area: lua
+  change: |
+    Added a new ``setUpstreamOverrideHost()`` which could be used to set the given host as the upstream host for the
+    current request.
 
 deprecated:
 - area: rbac

--- a/docs/root/configuration/http/http_filters/lua_filter.rst
+++ b/docs/root/configuration/http/http_filters/lua_filter.rst
@@ -558,6 +558,36 @@ Returns connection-level :repo:`information <envoy/stream_info/stream_info.h>` r
 
 Returns a connection-level :ref:`stream info object <config_http_filters_lua_cx_stream_info_wrapper>`.
 
+``setUpstreamOverrideHost()``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: lua
+
+  handle:setUpstreamOverrideHost(host, strict)
+
+Sets an upstream address override for the request. When the overridden host is available and can be selected directly,
+the load balancer bypasses its algorithm and routes traffic directly to the specified host. The strict flag determines
+whether the HTTP request must strictly use the overridden destination. If the destination is unavailable and strict is
+set to true, Envoy responds with a 503 Service Unavailable error.
+
+The function takes two arguments:
+
+* ``host`` (string): The host address to be used for upstream requests.
+* ``strict`` (boolean, optional): If set to true, the request is strictly routed to the overridden host. If the host is
+  unavailable, Envoy returns a 503 error. Defaults to false.
+
+Example:
+
+.. code-block:: lua
+
+  function envoy_on_request(request_handle)
+    -- Override upstream host without strict mode
+    request_handle:setUpstreamOverrideHost("192.168.21.13", false)
+
+    -- Override upstream host with strict mode
+    request_handle:setUpstreamOverrideHost("192.168.21.13", true)
+  end
+
 ``importPublicKey()``
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/source/extensions/filters/http/lua/lua_filter.cc
+++ b/source/extensions/filters/http/lua/lua_filter.cc
@@ -984,8 +984,7 @@ int StreamHandleWrapper::luaSetUpstreamOverrideHost(lua_State* state) {
   }
 
   // Set the upstream override host
-  override_host_ = std::string(host, len);
-  callbacks_.setUpstreamOverrideHost(std::make_pair(override_host_, strict));
+  callbacks_.setUpstreamOverrideHost(std::make_pair(std::string(host, len), strict));
 
   return 0;
 }

--- a/source/extensions/filters/http/lua/lua_filter.cc
+++ b/source/extensions/filters/http/lua/lua_filter.cc
@@ -963,6 +963,33 @@ void Filter::scriptLog(spdlog::level::level_enum level, absl::string_view messag
   }
 }
 
+int StreamHandleWrapper::luaSetUpstreamOverrideHost(lua_State* state) {
+  // Get the host address argument
+  size_t len;
+  const char* host = luaL_checklstring(state, 2, &len);
+
+  // Validate that host is not null and is an IP address
+  if (host == nullptr) {
+    luaL_error(state, "host argument is required");
+  }
+  if (!Http::Utility::parseAuthority(host).is_ip_address_) {
+    luaL_error(state, "host is not a valid IP address");
+  }
+
+  // Get the optional strict flag (defaults to false)
+  bool strict = false;
+  if (lua_gettop(state) >= 3) {
+    luaL_checktype(state, 3, LUA_TBOOLEAN);
+    strict = lua_toboolean(state, 3);
+  }
+
+  // Set the upstream override host
+  override_host_ = std::string(host, len);
+  callbacks_.setUpstreamOverrideHost(std::make_pair(override_host_, strict));
+
+  return 0;
+}
+
 void Filter::DecoderCallbacks::respond(Http::ResponseHeaderMapPtr&& headers, Buffer::Instance* body,
                                        lua_State*) {
   uint64_t status = Http::Utility::getResponseStatus(*headers);

--- a/source/extensions/filters/http/lua/lua_filter.h
+++ b/source/extensions/filters/http/lua/lua_filter.h
@@ -365,7 +365,6 @@ private:
   // Coroutine resumption MUST use resumeCoroutine.
   Filters::Common::Lua::Coroutine& coroutine_;
   Http::RequestOrResponseHeaderMap& headers_;
-  std::string override_host_;
   bool end_stream_;
   bool headers_continued_{};
   bool buffered_body_{};
@@ -587,7 +586,7 @@ private:
     }
     Tracing::Span& activeSpan() override { return callbacks_->activeSpan(); }
     void setUpstreamOverrideHost(std::pair<std::string, bool> host_and_strict) override {
-      callbacks_->setUpstreamOverrideHost(host_and_strict);
+      callbacks_->setUpstreamOverrideHost(std::move(host_and_strict));
     }
 
     Filter& parent_;

--- a/test/extensions/filters/http/lua/lua_integration_test.cc
+++ b/test/extensions/filters/http/lua/lua_integration_test.cc
@@ -1331,38 +1331,5 @@ typed_config:
   EXPECT_TRUE(response->complete());
 }
 
-// Test upstream host override functionality in Lua filter
-TEST_P(LuaIntegrationTest, UpstreamHostOverride) {
-  const std::string FILTER_AND_CODE = R"EOF(
-name: lua
-typed_config:
-  "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
-  default_source_code:
-    inline_string: |
-      function envoy_on_request(request_handle)
-        request_handle:setUpstreamOverrideHost("192.168.21.13", false)
-      end
-)EOF";
-
-  initializeFilter(FILTER_AND_CODE);
-
-  codec_client_ = makeHttpConnection(makeClientConnection(lookupPort("http")));
-  Http::TestRequestHeaderMapImpl request_headers{{":method", "GET"},
-                                                 {":path", "/test/long/url"},
-                                                 {":scheme", "http"},
-                                                 {":authority", "host"},
-                                                 {"x-forwarded-for", "10.0.0.1"}};
-
-  auto response = codec_client_->makeHeaderOnlyRequest(request_headers);
-  waitForNextUpstreamRequest();
-
-  upstream_request_->encodeHeaders(default_response_headers_, true);
-  ASSERT_TRUE(response->waitForEndStream());
-  EXPECT_TRUE(response->complete());
-  EXPECT_EQ("200", response->headers().getStatusValue());
-
-  cleanup();
-}
-
 } // namespace
 } // namespace Envoy


### PR DESCRIPTION
## Description

Adds new functionality to Lua filter flor allowing overriding the upstream host address.

**Example:**
```lua
function envoy_on_request(request_handle)
  request_handle:setUpstreamOverrideHost("192.168.21.11", true)
end
```

---

**Commit Message:** adds new function to the LUA script for setting upstream host override
**Additional Description:** The new `setUpstreamOverrideHost()` allows the dynamic upstream host override from Lua scripts.
**Risk Level:** Low
**Testing:** Added Unit + Integration tests
**Docs Changes:** Added
**Release Notes:** Added