### PR TITLE
docs: added more info for stateful_session filter params

### DIFF
--- a/api/envoy/extensions/filters/http/stateful_session/v3/stateful_session.proto
+++ b/api/envoy/extensions/filters/http/stateful_session/v3/stateful_session.proto
@@ -18,14 +18,16 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // [#extension: envoy.filters.http.stateful_session]
 
 message StatefulSession {
-  // Specific implementation of session state. This session state will be used to store and
-  // get address of the upstream host to which the session is assigned.
+  // Specifies the implementation of session state. This session state is used to store and retrieve the address of the
+  // upstream host assigned to the session.
   //
   // [#extension-category: envoy.http.stateful_session]
   config.core.v3.TypedExtensionConfig session_state = 1;
 
-  // If set to True, the HTTP request must be routed to the requested destination.
-  // If the requested destination is not available, Envoy returns 503. Defaults to False.
+  // Determines whether the HTTP request must be strictly routed to the requested destination. When set to ``true``,
+  // if the requested destination is unavailable, Envoy will return a 503 status code. The default value is ``false``,
+  // which allows Envoy to fall back to its load balancing mechanism. In this case, if the requested destination is not
+  // found, the request will be routed according to the load balancing algorithm.
   bool strict = 2;
 }
 


### PR DESCRIPTION
## Description

This PR adds some clarification around the behavior when `strict` is not set for `stateful_session` filter.

---

**Commit Message:** docs: added more info for stateful_session filter params
**Additional Description:** Added some clarification around the behavior when `strict` is not set for `stateful_session` filter.
**Risk Level:** N/A
**Testing:** N/A
**Docs Changes:** Added
**Release Notes:** N/A