### PR TITLE
Removes setting `BAZEL_BUILD_EXTRA_OPTIONS` in .devcontainer/setup.sh

### DIFF
--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -2,10 +2,6 @@
 
 BAZELRC_FILE=~/.bazelrc bazel/setup_clang.sh /opt/llvm
 
-if [[ -n "${BAZEL_BUILD_EXTRA_OPTIONS}" ]]; then
-    echo "build ${BAZEL_BUILD_EXTRA_OPTIONS}" | tee -a ~/.bazelrc
-fi
-
 # Ideally we want this line so bazel doesn't pollute things outside of the devcontainer, but some of
 # API tooling (proto_sync) depends on symlink like bazel-bin.
 # TODO(lizan): Fix API tooling and enable this again

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -2,11 +2,9 @@
 
 BAZELRC_FILE=~/.bazelrc bazel/setup_clang.sh /opt/llvm
 
-# TODO(phlax): use user.bazelrc
-# Use generated toolchain config because we know the base container is the one we're using in RBE.
-# Not using libc++ here because clangd will raise some tidy issue in libc++ header as of version 9.
-echo "build --config=rbe-toolchain-clang-libc++" >> ~/.bazelrc
-echo "build ${BAZEL_BUILD_EXTRA_OPTIONS}" | tee -a ~/.bazelrc
+if [[ -n "${BAZEL_BUILD_EXTRA_OPTIONS}" ]]; then
+    echo "build ${BAZEL_BUILD_EXTRA_OPTIONS}" | tee -a ~/.bazelrc
+fi
 
 # Ideally we want this line so bazel doesn't pollute things outside of the devcontainer, but some of
 # API tooling (proto_sync) depends on symlink like bazel-bin.


### PR DESCRIPTION
Commit Message: Removes unnecessary RBE default config in .devcontainer/setup.sh

Additional Description:
This removes the unnecessary default bazelrc configuration used in .devcontainer.
This was a cause of #23239 people asked about multiple times before.

cc @phlax 


Closes #23239