### PR TITLE
Adds missing host_action_env to rbe-clang-* for consistency

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -273,14 +273,14 @@ build:rbe-toolchain-clang --platforms=@envoy//bazel/rbe/toolchains:rbe_linux_cla
 build:rbe-toolchain-clang --host_platform=@envoy//bazel/rbe/toolchains:rbe_linux_clang_platform
 build:rbe-toolchain-clang --crosstool_top=@envoy//bazel/rbe/toolchains/configs/linux/clang/cc:toolchain
 build:rbe-toolchain-clang --extra_toolchains=@envoy//bazel/rbe/toolchains/configs/linux/clang/config:cc-toolchain
-build:rbe-toolchain-clang --action_env=CC=clang --action_env=CXX=clang++
+build:rbe-toolchain-clang --action_env=CC=clang --action_env=CXX=clang++ --host_action_env=CC=clang --host_action_env=CXX=clang++
 
 build:rbe-toolchain-clang-libc++ --config=rbe-toolchain
 build:rbe-toolchain-clang-libc++ --platforms=@envoy//bazel/rbe/toolchains:rbe_linux_clang_libcxx_platform
 build:rbe-toolchain-clang-libc++ --host_platform=@envoy//bazel/rbe/toolchains:rbe_linux_clang_libcxx_platform
 build:rbe-toolchain-clang-libc++ --crosstool_top=@envoy//bazel/rbe/toolchains/configs/linux/clang_libcxx/cc:toolchain
 build:rbe-toolchain-clang-libc++ --extra_toolchains=@envoy//bazel/rbe/toolchains/configs/linux/clang_libcxx/config:cc-toolchain
-build:rbe-toolchain-clang-libc++ --action_env=CC=clang --action_env=CXX=clang++
+build:rbe-toolchain-clang-libc++ --action_env=CC=clang --action_env=CXX=clang++ --host_action_env=CC=clang --host_action_env=CXX=clang++
 build:rbe-toolchain-clang-libc++ --action_env=CXXFLAGS=-stdlib=libc++
 build:rbe-toolchain-clang-libc++ --action_env=LDFLAGS=-stdlib=libc++
 build:rbe-toolchain-clang-libc++ --define force_libcpp=enabled


### PR DESCRIPTION
Commit Message: Adds host_action_env for RBE clang config for consistency
Additional Description:

Previously, `CC=clang` and `CXX=clang++` host envs were available in non RBE clang
family configurations vs not available in RBE families such as `rbe-toolchain-clang`.
This was causing the diff in the build result between the local plain `clang` vs
the one used in CI `rbe-toolchain-clang-libc++`. This closes the gap.

Risk Level: none 
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a

cc @phlax 
