### PR TITLE
dynamic_modules: use `size_t` for length of buffers

### DIFF
--- a/source/extensions/dynamic_modules/abi.h
+++ b/source/extensions/dynamic_modules/abi.h
@@ -14,10 +14,13 @@
 // same version of the ABI.
 
 #ifdef __cplusplus
+#include <cstddef>
+
 extern "C" {
-#endif
+#else
 
 #include <stddef.h>
+#endif
 
 // -----------------------------------------------------------------------------
 // ---------------------------------- Types ------------------------------------

--- a/source/extensions/dynamic_modules/abi.h
+++ b/source/extensions/dynamic_modules/abi.h
@@ -17,6 +17,8 @@
 extern "C" {
 #endif
 
+#include <stddef.h>
+
 // -----------------------------------------------------------------------------
 // ---------------------------------- Types ------------------------------------
 // -----------------------------------------------------------------------------
@@ -107,7 +109,7 @@ envoy_dynamic_module_type_abi_version_envoy_ptr envoy_dynamic_module_on_program_
 envoy_dynamic_module_type_http_filter_config_module_ptr
 envoy_dynamic_module_on_http_filter_config_new(
     envoy_dynamic_module_type_http_filter_config_envoy_ptr filter_config_envoy_ptr,
-    const char* name_ptr, int name_size, const char* config_ptr, int config_size);
+    const char* name_ptr, size_t name_size, const char* config_ptr, size_t config_size);
 
 /**
  * envoy_dynamic_module_on_http_filter_config_destroy is called when the HTTP filter configuration

--- a/source/extensions/dynamic_modules/abi_version.h
+++ b/source/extensions/dynamic_modules/abi_version.h
@@ -6,7 +6,7 @@ namespace DynamicModules {
 #endif
 // This is the ABI version calculated as a sha256 hash of the ABI header files. When the ABI
 // changes, this value must change, and the correctness of this value is checked by the test.
-const char* kAbiVersion = "152372902a15b54edce8a868b15931579b79d979dbc004689761b47b8622d4a3";
+const char* kAbiVersion = "6aaebe8708444b712aa3c371faf754f861554818f54078e2901a3575a31b961d";
 
 #ifdef __cplusplus
 } // namespace DynamicModules

--- a/source/extensions/dynamic_modules/abi_version.h
+++ b/source/extensions/dynamic_modules/abi_version.h
@@ -6,7 +6,7 @@ namespace DynamicModules {
 #endif
 // This is the ABI version calculated as a sha256 hash of the ABI header files. When the ABI
 // changes, this value must change, and the correctness of this value is checked by the test.
-const char* kAbiVersion = "6aaebe8708444b712aa3c371faf754f861554818f54078e2901a3575a31b961d";
+const char* kAbiVersion = "cf6fef3e32daba5206ecff01c3569fd4b8d7a07cef6b36822c8e03aeff97fec9";
 
 #ifdef __cplusplus
 } // namespace DynamicModules

--- a/source/extensions/dynamic_modules/sdk/rust/build.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/build.rs
@@ -2,14 +2,15 @@ use std::env;
 use std::path::PathBuf;
 
 fn main() {
-  // Print all environment variables for debugging!
-  for (key, value) in env::vars() {
-    eprintln!("{}: {}", key, value);
-  }
-
-  // Check if '/opt/llvm/bin/clang' exists, and if it does, set the CLANG_PATH environment variable.
-  // This matches how our CI containers are set up. If the clang doesn't exist there, bindgen will
-  // try to use the system clang. In any case, clang must be found to build the bindings.
+  // This is Envoy CI specific: Check if "/opt/llvm/bin/clang" exists, and if it does, set the
+  // CLANG_PATH environment variable. CLANG_PATH is for clang-sys used by bindgen:
+  // https://github.com/KyleMayes/clang-sys?tab=readme-ov-file#environment-variables
+  //
+  // "/opt/llvm/bin/clang" exists in Envoy CI containers. If the clang doesn't exist there, bindgen
+  // will try to use the system clang from PATH. So, this doesn't affect the local builds.
+  // In any case, clang must be found to build the bindings.
+  //
+  // TODO: add /opt/llvm/bin to PATH in the CI containers. That would be a better solution.
   if std::fs::metadata("/opt/llvm/bin/clang").is_ok() {
     env::set_var("CLANG_PATH", "/opt/llvm/bin/clang");
   }

--- a/source/extensions/dynamic_modules/sdk/rust/build.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/build.rs
@@ -7,14 +7,11 @@ fn main() {
     eprintln!("{}: {}", key, value);
   }
 
-  // Check if it has CC environment variable, and if that matches clang,
-  // then set the CLANG_PATH to the value of CC to instruct bindgen to use
-  // clang as the compiler.
-  // https://github.com/KyleMayes/clang-sys?tab=readme-ov-file#environment-variables
-  if let Some(cc) = env::var("CC").ok() {
-    if cc.contains("clang") {
-      env::set_var("CLANG_PATH", cc);
-    }
+  // Check if '/opt/llvm/bin/clang' exists, and if it does, set the CLANG_PATH environment variable.
+  // This matches how our CI containers are set up. If the clang doesn't exist there, bindgen will
+  // try to use the system clang. In any case, clang must be found to build the bindings.
+  if std::fs::metadata("/opt/llvm/bin/clang").is_ok() {
+    env::set_var("CLANG_PATH", "/opt/llvm/bin/clang");
   }
 
   println!("cargo:rerun-if-changed=abi.h");

--- a/source/extensions/dynamic_modules/sdk/rust/build.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/build.rs
@@ -2,16 +2,32 @@ use std::env;
 use std::path::PathBuf;
 
 fn main() {
-    println!("cargo:rerun-if-changed=abi.h");
-    let bindings = bindgen::Builder::default()
-        .header("../../abi.h")
-        .header("../../abi_version.h")
-        .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
-        .generate()
-        .expect("Unable to generate bindings");
+  // Print all environment variables for debugging!
+  for (key, value) in env::vars() {
+    eprintln!("{}: {}", key, value);
+  }
 
-    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
-    bindings
-        .write_to_file(out_path.join("bindings.rs"))
-        .expect("Couldn't write bindings");
+  // Check if it has CC environment variable, and if that matches clang,
+  // then set the CLANG_PATH to the value of CC to instruct bindgen to use
+  // clang as the compiler.
+  // https://github.com/KyleMayes/clang-sys?tab=readme-ov-file#environment-variables
+  if let Some(cc) = env::var("CC").ok() {
+    if cc.contains("clang") {
+      env::set_var("CLANG_PATH", cc);
+    }
+  }
+
+  println!("cargo:rerun-if-changed=abi.h");
+  let bindings = bindgen::Builder::default()
+    .header("../../abi.h")
+    .header("../../abi_version.h")
+    .clang_arg("-v")
+    .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
+    .generate()
+    .expect("Unable to generate bindings");
+
+  let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+  bindings
+    .write_to_file(out_path.join("bindings.rs"))
+    .expect("Couldn't write bindings");
 }

--- a/test/extensions/dynamic_modules/test_data/c/no_http_config_destory.c
+++ b/test/extensions/dynamic_modules/test_data/c/no_http_config_destory.c
@@ -8,7 +8,7 @@ envoy_dynamic_module_type_abi_version_envoy_ptr envoy_dynamic_module_on_program_
 envoy_dynamic_module_type_http_filter_config_module_ptr
 envoy_dynamic_module_on_http_filter_config_new(
     envoy_dynamic_module_type_http_filter_config_envoy_ptr filter_config_envoy_ptr,
-    const char* name_ptr, int name_size, const char* config_ptr, int config_size) {
+    const char* name_ptr, size_t name_size, const char* config_ptr, size_t config_size) {
   static int some_variable = 0;
   return &some_variable;
 }

--- a/test/extensions/dynamic_modules/test_data/c/no_op.c
+++ b/test/extensions/dynamic_modules/test_data/c/no_op.c
@@ -17,7 +17,7 @@ envoy_dynamic_module_type_abi_version_envoy_ptr envoy_dynamic_module_on_program_
 envoy_dynamic_module_type_http_filter_config_module_ptr
 envoy_dynamic_module_on_http_filter_config_new(
     envoy_dynamic_module_type_http_filter_config_envoy_ptr filter_config_envoy_ptr,
-    const char* name_ptr, int name_size, const char* config_ptr, int config_size) {
+    const char* name_ptr, size_t name_size, const char* config_ptr, size_t config_size) {
   return &some_variable;
 }
 


### PR DESCRIPTION
Commit Message: dynamic_modules: use size_t for length of buffers 

Additional Description:
Previously, `int` was used for the length of buffer/string, which was
obviously a bug as its size is 16-bit and signed. `size_t` is usually 
used for expressing the memory buffer by a pair of pointer and the length,
so this commit switches to use it.

Risk Level: n/a
Testing: done
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
