### PR TITLE
ratelimit: support per-descriptor hits_addend

### DIFF
--- a/api/envoy/api/v2/ratelimit/ratelimit.proto
+++ b/api/envoy/api/v2/ratelimit/ratelimit.proto
@@ -63,6 +63,15 @@ message RateLimitDescriptor {
 
     // Descriptor value.
     string value = 2 [(validate.rules).string = {min_bytes: 1}];
+
+    // A per-descriptor override for the number of hits added to the matched limit by a request.
+    // This value takes precedence over the globally configured value. If neither this field nor
+    // the global value is set, the matched limit is incremented by 1 for each request.
+    //
+    // Additionally, this value can be overridden by setting the filter state value
+    // `envoy.ratelimit.hits_addend` to the desired number. If an invalid number (e.g., < 0) is
+    // provided, it will be ignored.
+    uint32 hits_addend = 3;
   }
 
   // Descriptor entries.

--- a/api/envoy/extensions/common/ratelimit/v3/ratelimit.proto
+++ b/api/envoy/extensions/common/ratelimit/v3/ratelimit.proto
@@ -103,6 +103,15 @@ message RateLimitDescriptor {
 
     // Descriptor value.
     string value = 2 [(validate.rules).string = {min_len: 1}];
+
+    // A per-descriptor override for the number of hits added to the matched limit by a request.
+    // This value takes precedence over the globally configured value. If neither this field nor
+    // the global value is set, the matched limit is incremented by 1 for each request.
+    //
+    // Additionally, this value can be overridden by setting the filter state value
+    // `envoy.ratelimit.hits_addend` to the desired number. If an invalid number (e.g., < 0) is
+    // provided, it will be ignored.
+    uint32 hits_addend = 3;
   }
 
   // Override rate limit to apply to this descriptor instead of the limit

--- a/envoy/ratelimit/ratelimit.h
+++ b/envoy/ratelimit/ratelimit.h
@@ -30,14 +30,15 @@ struct RateLimitOverride {
 struct DescriptorEntry {
   std::string key_;
   std::string value_;
+  uint32_t hits_addend_;
 
   friend bool operator==(const DescriptorEntry& lhs, const DescriptorEntry& rhs) {
-    return lhs.key_ == rhs.key_ && lhs.value_ == rhs.value_;
+    return lhs.key_ == rhs.key_ && lhs.value_ == rhs.value_ && lhs.hits_addend_ == rhs.hits_addend_;
   }
   template <typename H>
   friend H AbslHashValue(H h, // NOLINT(readability-identifier-naming)
                          const DescriptorEntry& entry) {
-    return H::combine(std::move(h), entry.key_, entry.value_);
+    return H::combine(std::move(h), entry.key_, entry.value_, entry.hits_addend_);
   }
 };
 
@@ -73,7 +74,7 @@ struct LocalDescriptor {
 
   std::string toString() const {
     return absl::StrJoin(entries_, ", ", [](std::string* out, const auto& e) {
-      absl::StrAppend(out, e.key_, "=", e.value_);
+      absl::StrAppend(out, e.key_, "=", e.value_, "(", e.hits_addend_, ")");
     });
   }
 

--- a/source/extensions/filters/common/ratelimit/ratelimit_impl.cc
+++ b/source/extensions/filters/common/ratelimit/ratelimit_impl.cc
@@ -47,6 +47,7 @@ void GrpcClientImpl::createRequest(envoy::service::ratelimit::v3::RateLimitReque
           new_descriptor->add_entries();
       new_entry->set_key(entry.key_);
       new_entry->set_value(entry.value_);
+      new_entry->set_hits_addend(entry.hits_addend_);
     }
     if (descriptor.limit_) {
       envoy::extensions::common::ratelimit::v3::RateLimitDescriptor_RateLimitOverride* new_limit =


### PR DESCRIPTION
## Description

We can now provide multiple descriptor(s) in the same RateLimit request, but they all share same `hits_addend`. If we want to limit the QPS and bandwidth at same time, we need to configure two rate limit filters in the same filter chain. It's a little complex and add additional overhead/latency.

In this PR, we are exposing `hits_addend` at the per-descriptor level which could be overridden to achieve the behavior described above.

Fixes #37347

--- 

**Commit Message:** ratelimit: support per-descriptor hits_addend
**Additional Description:** This PR exposes `hits_addend` at the per-descriptor level which could be overridden to achieve the behavior described above.
**Risk Level:** Low
**Testing:** Added Unit Tests
**Docs Changes:** Added
**Release Notes:** Added