### PR TITLE
Modify GetResult() method in extractor in PME filter

### DIFF
--- a/source/extensions/filters/http/proto_message_extraction/extractor.h
+++ b/source/extensions/filters/http/proto_message_extraction/extractor.h
@@ -57,7 +57,7 @@ public:
   // is the last message. It only keeps the result from the first one the last.
   virtual void processResponse(Protobuf::field_extraction::MessageData& message) = 0;
 
-  virtual const ExtractedMessageResult& GetResult() const = 0;
+  virtual ExtractedMessageResult GetResult() = 0;
 };
 
 using ExtractorPtr = std::unique_ptr<Extractor>;

--- a/source/extensions/filters/http/proto_message_extraction/extractor_impl.h
+++ b/source/extensions/filters/http/proto_message_extraction/extractor_impl.h
@@ -40,7 +40,7 @@ public:
 
   void processResponse(Protobuf::field_extraction::MessageData& message) override;
 
-  ExtractedMessageResult GetResult() const override {
+  ExtractedMessageResult GetResult() override {
     ExtractedMessageResult result = result_;
     result_.request_data.clear();
     result_.response_data.clear();

--- a/source/extensions/filters/http/proto_message_extraction/extractor_impl.h
+++ b/source/extensions/filters/http/proto_message_extraction/extractor_impl.h
@@ -40,7 +40,12 @@ public:
 
   void processResponse(Protobuf::field_extraction::MessageData& message) override;
 
-  const ExtractedMessageResult& GetResult() const override { return result_; }
+  ExtractedMessageResult GetResult() const override {
+    ExtractedMessageResult result = result_;
+    result_.request_data.clear();
+    result_.response_data.clear();
+    return result;
+  }
 
 private:
   const envoy::extensions::filters::http::proto_message_extraction::v3::MethodExtraction&


### PR DESCRIPTION
Commit Message: Modify `GetResult()` method in extractor in PME filter

Additional Description:
Clear request metadata and response metadata once the result is fetched. This ensures no messages are carried over in a streaming request. Please note that we call `GetResult()` once to fetch the metadata.

Risk Level: Low

Testing: Covered by unit tests

Docs Changes: Nil

Release Notes: Nil

Platform Specific Features: Nil