### PR TITLE
add option to enable extensions using command line

### DIFF
--- a/source/extensions/BUILD
+++ b/source/extensions/BUILD
@@ -1,11 +1,23 @@
+load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
 load("@envoy_toolshed//:macros.bzl", "json_data")
 load("//bazel:envoy_build_system.bzl", "envoy_extension_package")
 load(":all_extensions.bzl", "envoy_all_extensions")
+load(":extensions_build_config.bzl", "update_extensions")
 load(":extensions_build_config.bzl", "EXTENSIONS")
 
 licenses(["notice"])  # Apache 2
 
 envoy_extension_package()
+
+string_flag(
+    name = "additional_extensions",
+    build_setting_default = "",
+)
+
+update_extensions(
+    name = "updated_extensions",
+    additional_extensions = ":additional_extensions",
+)
 
 exports_files([
     "extensions_metadata.yaml",

--- a/source/extensions/extensions_build_config.bzl
+++ b/source/extensions/extensions_build_config.bzl
@@ -1,5 +1,5 @@
 # See bazel/README.md for details on how this system works.
-DEFAULT_EXTENSIONS = {
+EXTENSIONS = {
     #
     # Access loggers
     #
@@ -538,14 +538,8 @@ DEFAULT_EXTENSIONS = {
     "envoy.generic_proxy.codecs.http1":                         "//source/extensions/filters/network/generic_proxy/codecs/http1:config",
 }
 
-EXTENSIONS = {}
-
 def _update_extensions_impl(ctx):
-    EXTENSIONS = dict(
-        [(key, value) for key, value in DEFAULT_EXTENSIONS.items()]
-    )
     additional_extensions = ctx.attr.additional_extensions
-
     if additional_extensions:
         EXTENSIONS.update(
             dict(

--- a/source/extensions/extensions_build_config.bzl
+++ b/source/extensions/extensions_build_config.bzl
@@ -1,5 +1,5 @@
 # See bazel/README.md for details on how this system works.
-EXTENSIONS = {
+DEFAULT_EXTENSIONS = {
     #
     # Access loggers
     #
@@ -537,6 +537,31 @@ EXTENSIONS = {
     "envoy.generic_proxy.codecs.dubbo":                         "//source/extensions/filters/network/generic_proxy/codecs/dubbo:config",
     "envoy.generic_proxy.codecs.http1":                         "//source/extensions/filters/network/generic_proxy/codecs/http1:config",
 }
+
+EXTENSIONS = {}
+
+def _update_extensions_impl(ctx):
+    EXTENSIONS = dict(
+        [(key, value) for key, value in DEFAULT_EXTENSIONS.items()]
+    )
+    additional_extensions = ctx.attr.additional_extensions
+
+    if additional_extensions:
+        EXTENSIONS.update(
+            dict(
+                [(key, value) for pair in additional_extensions.split(",")
+                 for key, value in [pair.split("=")]]
+            )
+        )
+
+    return [EXTENSIONS]
+
+update_extensions = rule(
+    implementation = _update_extensions_impl,
+    attrs = {
+        "additional_extensions": attr.string(),
+    },
+)
 
 # These can be changed to ["//visibility:public"], for  downstream builds which
 # need to directly reference Envoy extensions.


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: add option to enable extensions using command line
Additional Description: add option to enable extensions using command line
Risk Level: Low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
