### PR TITLE
(rbac) add principal matchers for dynamic downstream IPs

### DIFF
--- a/api/envoy/config/rbac/v3/rbac.proto
+++ b/api/envoy/config/rbac/v3/rbac.proto
@@ -312,7 +312,7 @@ message Permission {
 
 // Principal defines an identity or a group of identities for a downstream
 // subject.
-// [#next-free-field: 14]
+// [#next-free-field: 16]
 message Principal {
   option (udpa.annotations.versioning).previous_message_type = "envoy.config.rbac.v2.Principal";
 
@@ -336,6 +336,23 @@ message Principal {
     // is used from the certificate, otherwise the subject field is used. If
     // unset, it applies to any user that is authenticated.
     type.matcher.v3.StringMatcher principal_name = 2;
+  }
+
+  message FilterStateIPMatcherConfig {
+    // The key at which the filter state object is stored.
+    string key = 1;
+
+    core.v3.CidrRange ip_range = 2;
+  }
+
+  message DynamicMetadataIPMatcherConfig {
+    // The name of the filter that set the dynamic metadata.
+    string filter = 1;
+
+    // Field names in the dynamic metadata in order.
+    repeated string path = 2;
+
+    core.v3.CidrRange ip_range = 3;
   }
 
   oneof identifier {
@@ -405,6 +422,18 @@ message Principal {
     // Matches against metadata from either dynamic state or route configuration. Preferred over the
     // ``metadata`` field as it provides more flexibility in metadata source selection.
     SourcedMetadata sourced_metadata = 13;
+
+    // A CIDR block for matching an IP fetched from filter state. If an IP is not found at the key
+    // in filter state, the matcher will fail.
+    // Useful to essentially override
+    // :ref:`remote_ip <envoy_v3_api_field_config.rbac.v3.Principal.remote_ip>` or
+    // :ref:`direct_remote_ip <envoy_v3_api_field_config.rbac.v3.Principal.direct_remote_ip>`.
+    FilterStateIPMatcherConfig filter_state_ip = 14;
+
+    // The same as
+    // :ref:`filter_state_ip <envoy_v3_api_field_config.rbac.v3.Principal.filter_state_ip>`, except
+    // the IP is fetched from dynamic metadata_ip instead.
+    DynamicMetadataIPMatcherConfig dynamic_metadata_ip = 15;
   }
 }
 

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -275,6 +275,14 @@ new_features:
   change: |
     Added a new ``setUpstreamOverrideHost()`` which could be used to set the given host as the upstream host for the
     current request.
+- area: rbac
+  change: |
+    Added RBAC principal matchers
+    :ref:`filter_state_ip <envoy_v3_api_field_config.rbac.v3.Principal.filter_state_ip>` and
+    :ref:`dynamic_metadata_ip <envoy_v3_api_field_config.rbac.v3.Principal.dynamic_metadata_ip>`
+    which are functionally similar to
+    :ref:`remote_ip <envoy_v3_api_field_config.rbac.v3.Principal.remote_ip>` except the downstream
+    IP is fetched from filter state or dynamic metadata, respectively.
 
 deprecated:
 - area: rbac

--- a/envoy/network/BUILD
+++ b/envoy/network/BUILD
@@ -14,6 +14,7 @@ envoy_cc_library(
     deps = [
         "//envoy/common:base_includes",
         "//envoy/common:pure_lib",
+        "//envoy/stream_info:filter_state_interface",
     ],
 )
 

--- a/envoy/network/address.h
+++ b/envoy/network/address.h
@@ -9,6 +9,7 @@
 
 #include "envoy/common/platform.h"
 #include "envoy/common/pure.h"
+#include "envoy/stream_info/filter_state.h"
 
 #include "absl/numeric/int128.h"
 #include "absl/strings/string_view.h"
@@ -23,6 +24,20 @@ namespace Address {
 
 class Instance;
 using InstanceConstSharedPtr = std::shared_ptr<const Instance>;
+
+/*
+ * Used to store InstanceConstSharedPtr in filter state.
+ */
+class InstanceConstSharedPtrAccessor : public Envoy::StreamInfo::FilterState::Object {
+public:
+  InstanceConstSharedPtrAccessor(Network::Address::InstanceConstSharedPtr ip)
+      : ip_(std::move(ip)) {}
+
+  Network::Address::InstanceConstSharedPtr getIp() const { return ip_; }
+
+private:
+  Network::Address::InstanceConstSharedPtr ip_;
+};
 
 /**
  * Interface for an Ipv4 address.

--- a/source/extensions/filters/common/rbac/matchers.h
+++ b/source/extensions/filters/common/rbac/matchers.h
@@ -171,6 +171,39 @@ private:
   const Type type_;
 };
 
+class DynamicMetadataIPMatcher : public Matcher {
+public:
+  DynamicMetadataIPMatcher(
+      const envoy::config::rbac::v3::Principal::DynamicMetadataIPMatcherConfig& config)
+      : range_(THROW_OR_RETURN_VALUE(Network::Address::CidrRange::create(config.ip_range()),
+                                     Network::Address::CidrRange)),
+        filter_(config.filter()),
+        path_(std::vector<std::string>(config.path().begin(), config.path().end())) {}
+
+  bool matches(const Network::Connection&, const Envoy::Http::RequestHeaderMap&,
+               const StreamInfo::StreamInfo& info) const override;
+
+private:
+  const Network::Address::CidrRange range_;
+  const std::string filter_;
+  const std::vector<std::string> path_;
+};
+
+class FilterStateIPMatcher : public Matcher {
+public:
+  FilterStateIPMatcher(const envoy::config::rbac::v3::Principal::FilterStateIPMatcherConfig& config)
+      : range_(THROW_OR_RETURN_VALUE(Network::Address::CidrRange::create(config.ip_range()),
+                                     Network::Address::CidrRange)),
+        key_(config.key()) {}
+
+  bool matches(const Network::Connection& connection, const Envoy::Http::RequestHeaderMap&,
+               const StreamInfo::StreamInfo& info) const override;
+
+private:
+  const Network::Address::CidrRange range_;
+  const std::string key_;
+};
+
 /**
  * Matches the port number of the destination (local) address.
  */


### PR DESCRIPTION
Commit Message: (rbac) add principal matchers for dynamic downstream IPs
Additional Description:

This PR adds two matchers to RBAC (filter_state_ip, dynamic_metadata_ip) which compare an IP from filter state / dynamic metadata to a CIDR block. If the IP is not found where specified in configuration, the matcher fails. The IP is assumed to be a downstream IP, so the matchers are principal matchers.

Risk Level: low
Testing: unit tested
Docs Changes: none
Release Notes: changelog updated
Platform Specific Features: none