### PR TITLE
local-rate-limit: add descriptor fill_interval lower bound

### DIFF
--- a/source/extensions/filters/common/local_ratelimit/local_ratelimit_impl.cc
+++ b/source/extensions/filters/common/local_ratelimit/local_ratelimit_impl.cc
@@ -210,6 +210,12 @@ LocalRateLimiterImpl::LocalRateLimiterImpl(
     const auto per_descriptor_fill_interval = std::chrono::milliseconds(
         PROTOBUF_GET_MS_OR_DEFAULT(descriptor.token_bucket(), fill_interval, 0));
 
+    // Validate that the descriptor's fill interval is logically correct (same
+    // constraint of >=50msec as for fill_interval).
+    if (per_descriptor_fill_interval < std::chrono::milliseconds(50)) {
+      throw EnvoyException("local rate limit descriptor token bucket fill timer must be >= 50ms");
+    }
+
     if (per_descriptor_fill_interval.count() % fill_interval.count() != 0) {
       throw EnvoyException(
           "local rate descriptor limit is not a multiple of token bucket fill timer");

--- a/test/extensions/filters/common/local_ratelimit/local_ratelimit_test.cc
+++ b/test/extensions/filters/common/local_ratelimit/local_ratelimit_test.cc
@@ -418,6 +418,17 @@ TEST_F(LocalRateLimiterDescriptorImplTest, DescriptorRateLimitDivisibleByTokenFi
       EnvoyException, "local rate descriptor limit is not a multiple of token bucket fill timer");
 }
 
+// Verify descriptor rate limit time with small fill interval is rejected.
+TEST_F(LocalRateLimiterDescriptorImplTest, DescriptorRateLimitSmallFillInterval) {
+  // Set fill interval to 10 milliseconds.
+  TestUtility::loadFromYaml(fmt::format(single_descriptor_config_yaml, 10, 10, "0.010s"),
+                            *descriptors_.Add());
+
+  EXPECT_THROW_WITH_MESSAGE(
+      LocalRateLimiterImpl(std::chrono::milliseconds(59000), 2, 1, dispatcher_, descriptors_),
+      EnvoyException, "local rate limit descriptor token bucket fill timer must be >= 50ms");
+}
+
 TEST_F(LocalRateLimiterDescriptorImplTest, DuplicateDescriptor) {
   TestUtility::loadFromYaml(fmt::format(single_descriptor_config_yaml, 1, 1, "0.1s"),
                             *descriptors_.Add());

--- a/test/extensions/filters/http/common/fuzz/filter_corpus/local_rate_limit_descriptor_small_fill_interval
+++ b/test/extensions/filters/http/common/fuzz/filter_corpus/local_rate_limit_descriptor_small_fill_interval
@@ -1,0 +1,7 @@
+config {
+  name: "envoy.local_rate_limit"
+  typed_config {
+    type_url: "type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit"
+    value: "\n\002\337\214B&\n\026\n\020envoy.ip_tagging\022\002\337\214\022\014\010\200\200\200\004\032\005\020\200\200\200\010h\001x\001"
+  }
+}


### PR DESCRIPTION
Commit Message: local-rate-limit: add descriptor fill_interval lower bound
Additional Description:
The local-rate-limit filter has a lower-bound fill_interval validation for the non-descriptor field.
This PR adds the same lower-bound to the fill_interval of a descriptor.
Note that this will reject previously valid configs that were under 50msec. In this case the config must change to be at least 50msec.

This was found by a [fuzz test](https://oss-fuzz.com/testcase-detail/5797822746656768).

Risk Level: low
Testing: Added fuzz test corpus
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A