### PR TITLE
clang-tidy: fixes error in common::Cleanup class 

### DIFF
--- a/envoy/common/execution_context.h
+++ b/envoy/common/execution_context.h
@@ -115,7 +115,7 @@ private:
       [execution_context = ExecutionContext::fromStreamInfo(trackedStream),                        \
        scoped_object = (scopedObject)] {                                                           \
         if (execution_context == nullptr) {                                                        \
-          return Envoy::Cleanup::Noop();                                                           \
+          return Envoy::Cleanup::noop();                                                           \
         }                                                                                          \
         return execution_context->onScopeEnter(scoped_object);                                     \
       }()

--- a/source/common/common/cleanup.h
+++ b/source/common/common/cleanup.h
@@ -24,8 +24,8 @@ public:
 
   bool cancelled() { return cancelled_; }
 
-  static Cleanup Noop() {
-    return Cleanup([] {});
+  static Cleanup noop() {
+    return {[]() {}};
   }
 
 private:

--- a/test/common/common/execution_context_test.cc
+++ b/test/common/common/execution_context_test.cc
@@ -22,11 +22,11 @@ thread_local const Http::FilterContext* current_filter_context = nullptr;
 
 class TestExecutionContext : public ExecutionContext {
 public:
-  Envoy::Cleanup onScopeEnter(Envoy::Tracing::Span*) override { return Envoy::Cleanup::Noop(); }
+  Envoy::Cleanup onScopeEnter(Envoy::Tracing::Span*) override { return Envoy::Cleanup::noop(); }
 
   Envoy::Cleanup onScopeEnter(const Http::FilterContext* filter_context) override {
     if (filter_context == nullptr) {
-      return Envoy::Cleanup::Noop();
+      return Envoy::Cleanup::noop();
     }
     const Http::FilterContext* old_filter_context = current_filter_context;
     current_filter_context = filter_context;


### PR DESCRIPTION
part of #28566 
