### PR TITLE
clang-tidy: removes ExcludeHeaderFilterRegex not available in LLVM 14

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -111,9 +111,6 @@ UseColor: true
 
 WarningsAsErrors: '*'
 
-# The ABI header file is a pure C header file, and clang-tidy is only for C++.
-ExcludeHeaderFilterRegex: 'source/extensions/dynamic_modules/abi.h'
-
 ## The version here is arbitrary since any change to this file will
 ## trigger a full run of clang-tidy against all files.
 ## It can be useful as it seems some header changes may not trigger the


### PR DESCRIPTION
This directive was introduced in #37317 but turns out this is not available in LLVM 14.
So for now we remove this. By the time we enable clang-tidy on CI we should find
a way to ignore it, but for now simply remove it so that we can run clang-tidy locally.

part of https://github.com/envoyproxy/envoy/issues/28566


cc @phlax 