### PR TITLE
clang-tidy: ignore value_or used in optref helper

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -67,6 +67,7 @@ CheckOptions:
     |^event_base_free$|
     |^(get|set)EVP_PKEY$|
     |^has_value$|
+    |^value_or$|
     |^Ip6(ntohl|htonl)$|
     |^get_$|
     |^HeaderHasValue(Ref)?$|


### PR DESCRIPTION
This adds `value_or` to the ignore-list of naming convention.
The similar `has_value` was already in the list and both are to
be aligned with their `absl::optional` counterparts.

part of https://github.com/envoyproxy/envoy/issues/28566

cc @phlax 

