### PR TITLE
clang-tidy: default member error in cpu_utilization

### DIFF
--- a/source/extensions/resource_monitors/cpu_utilization/cpu_utilization_monitor.cc
+++ b/source/extensions/resource_monitors/cpu_utilization/cpu_utilization_monitor.cc
@@ -29,7 +29,7 @@ CpuUtilizationMonitor::CpuUtilizationMonitor(
     const envoy::extensions::resource_monitors::cpu_utilization::v3::
         CpuUtilizationConfig& /*config*/,
     std::unique_ptr<CpuStatsReader> cpu_stats_reader)
-    : utilization_(0.0), cpu_stats_reader_(std::move(cpu_stats_reader)) {
+    : cpu_stats_reader_(std::move(cpu_stats_reader)) {
   previous_cpu_times_ = cpu_stats_reader_->getCpuTimes();
 }
 

--- a/source/extensions/resource_monitors/cpu_utilization/cpu_utilization_monitor.h
+++ b/source/extensions/resource_monitors/cpu_utilization/cpu_utilization_monitor.h
@@ -22,7 +22,7 @@ public:
   void updateResourceUsage(Server::ResourceUpdateCallbacks& callbacks) override;
 
 private:
-  double utilization_;
+  double utilization_ = 0.0;
   CpuTimes previous_cpu_times_;
   std::unique_ptr<CpuStatsReader> cpu_stats_reader_;
 };


### PR DESCRIPTION
part of  #28566

___

```
cpu_utilization_monitor.h:25:10: error: use default member initializer for 'utilization_' [modernize-use-default-member-init,-warnings-as-errors]
```