### PR TITLE
ext_proc: add more tests to increase coverage

### DIFF
--- a/test/extensions/filters/http/ext_proc/config_test.cc
+++ b/test/extensions/filters/http/ext_proc/config_test.cc
@@ -328,6 +328,191 @@ TEST(HttpExtProcConfigTest, InvalidServiceConfigServerContext) {
       EnvoyException, "One and only one of grpc_service or http_service must be configured");
 }
 
+TEST(HttpExtProcConfigTest, EmptyConfig) {
+  std::string yaml = R"EOF(
+  grpc_service:
+    google_grpc:
+      target_uri: ext_proc_server
+      stat_prefix: google
+  )EOF";
+
+  ExternalProcessingFilterConfig factory;
+  ProtobufTypes::MessagePtr proto_config = factory.createEmptyConfigProto();
+  TestUtility::loadFromYaml(yaml, *proto_config);
+
+  testing::NiceMock<Server::Configuration::MockFactoryContext> context;
+  EXPECT_CALL(context, messageValidationVisitor());
+  Http::FilterFactoryCb cb =
+      factory.createFilterFactoryFromProto(*proto_config, "stats", context).value();
+  Http::MockFilterChainFactoryCallbacks filter_callback;
+  EXPECT_CALL(filter_callback, addStreamFilter(_));
+  cb(filter_callback);
+}
+
+TEST(HttpExtProcConfigTest, CorrectHttpServiceConfig) {
+  std::string yaml = R"EOF(
+  http_service:
+    http_service:
+      http_uri:
+        uri: "ext_proc_server_0:9000"
+        cluster: "ext_proc_server_0"
+        timeout:
+          seconds: 500
+  processing_mode:
+    request_header_mode: send
+    response_header_mode: skip
+  )EOF";
+
+  ExternalProcessingFilterConfig factory;
+  ProtobufTypes::MessagePtr proto_config = factory.createEmptyConfigProto();
+  TestUtility::loadFromYaml(yaml, *proto_config);
+
+  testing::NiceMock<Server::Configuration::MockFactoryContext> context;
+  EXPECT_CALL(context, messageValidationVisitor());
+  Http::FilterFactoryCb cb =
+      factory.createFilterFactoryFromProto(*proto_config, "stats", context).value();
+  Http::MockFilterChainFactoryCallbacks filter_callback;
+  EXPECT_CALL(filter_callback, addStreamFilter(_));
+  cb(filter_callback);
+}
+
+TEST(HttpExtProcConfigTest, UpstreamConfig) {
+  std::string yaml = R"EOF(
+  grpc_service:
+    google_grpc:
+      target_uri: ext_proc_server
+      stat_prefix: google
+  processing_mode:
+    request_header_mode: send
+    response_header_mode: skip
+  )EOF";
+
+  UpstreamExternalProcessingFilterConfig factory;
+  ProtobufTypes::MessagePtr proto_config = factory.createEmptyConfigProto();
+  TestUtility::loadFromYaml(yaml, *proto_config);
+
+  testing::NiceMock<Server::Configuration::MockServerFactoryContext> context;
+  EXPECT_CALL(context, messageValidationVisitor());
+  Http::FilterFactoryCb cb =
+      factory.createFilterFactoryFromProtoWithServerContext(*proto_config, "stats", context);
+  Http::MockFilterChainFactoryCallbacks filter_callback;
+  EXPECT_CALL(filter_callback, addStreamFilter(_));
+  cb(filter_callback);
+}
+
+TEST(HttpExtProcConfigTest, CustomTimeoutConfig) {
+  std::string yaml = R"EOF(
+  grpc_service:
+    google_grpc:
+      target_uri: ext_proc_server
+      stat_prefix: google
+  message_timeout:
+    seconds: 2
+    nanos: 500000000
+  max_message_timeout:
+    seconds: 5
+  )EOF";
+
+  ExternalProcessingFilterConfig factory;
+  ProtobufTypes::MessagePtr proto_config = factory.createEmptyConfigProto();
+  TestUtility::loadFromYaml(yaml, *proto_config);
+
+  testing::NiceMock<Server::Configuration::MockFactoryContext> context;
+  Http::FilterFactoryCb cb =
+      factory.createFilterFactoryFromProto(*proto_config, "stats", context).value();
+  Http::MockFilterChainFactoryCallbacks filter_callback;
+  EXPECT_CALL(filter_callback, addStreamFilter(_));
+  cb(filter_callback);
+}
+
+TEST(HttpExtProcConfigTest, CompleteRouteConfig) {
+  std::string yaml = R"EOF(
+  overrides:
+    request_attributes:
+    - "route-attr1"
+    - "route-attr2"
+    response_attributes:
+    - "route-resp1"
+    processing_mode:
+      request_header_mode: skip
+      response_header_mode: send
+      request_body_mode: none
+      response_body_mode: none
+    grpc_initial_metadata:
+      - key: "route-meta1"
+        value: "value1"
+      - key: "route-meta2"
+        value: "value2"
+  )EOF";
+
+  ExternalProcessingFilterConfig factory;
+  ProtobufTypes::MessagePtr proto_config = factory.createEmptyRouteConfigProto();
+  TestUtility::loadFromYaml(yaml, *proto_config);
+
+  testing::NiceMock<Server::Configuration::MockServerFactoryContext> context;
+  Router::RouteSpecificFilterConfigConstSharedPtr cb = factory.createRouteSpecificFilterConfig(
+      *proto_config, context, context.messageValidationVisitor());
+  ASSERT_NE(nullptr, cb);
+}
+
+TEST(HttpExtProcConfigTest, FullDuplexStreamedValidation) {
+  // Valid configuration: FULL_DUPLEX_STREAMED with SEND trailers
+  std::string valid_yaml = R"EOF(
+  grpc_service:
+    google_grpc:
+      target_uri: ext_proc_server
+      stat_prefix: google
+  processing_mode:
+    response_body_mode: FULL_DUPLEX_STREAMED
+    response_trailer_mode: SEND
+  )EOF";
+
+  ExternalProcessingFilterConfig factory;
+  ProtobufTypes::MessagePtr proto_config = factory.createEmptyConfigProto();
+  TestUtility::loadFromYaml(valid_yaml, *proto_config);
+
+  testing::NiceMock<Server::Configuration::MockFactoryContext> context;
+  auto result = factory.createFilterFactoryFromProto(*proto_config, "stats", context);
+  EXPECT_TRUE(result.ok());
+
+  // Invalid configuration: FULL_DUPLEX_STREAMED with SKIP trailers
+  std::string invalid_yaml = R"EOF(
+  grpc_service:
+    google_grpc:
+      target_uri: ext_proc_server
+      stat_prefix: google
+  processing_mode:
+    response_body_mode: FULL_DUPLEX_STREAMED
+    response_trailer_mode: SKIP
+  )EOF";
+
+  proto_config = factory.createEmptyConfigProto();
+  TestUtility::loadFromYaml(invalid_yaml, *proto_config);
+
+  auto invalid_result = factory.createFilterFactoryFromProto(*proto_config, "stats", context);
+  EXPECT_FALSE(invalid_result.ok());
+  EXPECT_EQ(invalid_result.status().message(),
+            "If the ext_proc filter has the response_body_mode set to FULL_DUPLEX_STREAMED, "
+            "then the response_trailer_mode has to be set to SEND");
+
+  // Verify other response_body_mode values work with SKIP trailers
+  std::string other_modes_yaml = R"EOF(
+  grpc_service:
+    google_grpc:
+      target_uri: ext_proc_server
+      stat_prefix: google
+  processing_mode:
+    response_body_mode: BUFFERED
+    response_trailer_mode: SKIP
+  )EOF";
+
+  proto_config = factory.createEmptyConfigProto();
+  TestUtility::loadFromYaml(other_modes_yaml, *proto_config);
+
+  auto other_result = factory.createFilterFactoryFromProto(*proto_config, "stats", context);
+  EXPECT_TRUE(other_result.ok());
+}
+
 } // namespace
 } // namespace ExternalProcessing
 } // namespace HttpFilters


### PR DESCRIPTION
## Description

This PR adds some more tests to increase the coverage of the ExtProc directory. Another refactoring PR currently fails as the overall coverage of the ExtProc directory fell short of 0.1

**Before:**

![image](https://github.com/user-attachments/assets/fa03e446-0107-4093-9266-0e2a5ad803bb)

**After:**

![image](https://github.com/user-attachments/assets/686c17cf-344a-44e5-8860-a1141febb88f)

---

**Commit Message:** ext_proc: add more tests to increase coverage
**Additional Description:** Adds additional tests for ExtProc Config.
**Risk Level:** N/A
**Testing:** Added Unit Tests
**Docs Changes:** N/A
**Release Notes:** N/A