### PR TITLE
ext_proc: add unit tests for client_impl to increase coverage

### DIFF
--- a/test/extensions/filters/http/ext_proc/client_test.cc
+++ b/test/extensions/filters/http/ext_proc/client_test.cc
@@ -187,6 +187,150 @@ TEST_F(ExtProcStreamTest, StreamError) {
   EXPECT_TRUE(stream->localClosed());
 }
 
+TEST_F(ExtProcStreamTest, CancelStream) {
+  Http::AsyncClient::ParentContext parent_context;
+  parent_context.stream_info = &stream_info_;
+  auto options = Http::AsyncClient::StreamOptions().setParentContext(parent_context);
+
+  // Create client and verify we can call cancel() without issues
+  client_->cancel();
+
+  auto stream = client_->start(*this, config_with_hash_key_, options, watermark_callbacks_);
+
+  // Call cancel - should be safe to call multiple times
+  client_->cancel();
+  client_->cancel();
+
+  // Clean up
+  EXPECT_CALL(stream_, closeStream());
+  stream->closeLocalStream();
+}
+
+TEST_F(ExtProcStreamTest, StreamInfoAndCleanup) {
+  Http::AsyncClient::ParentContext parent_context;
+  parent_context.stream_info = &stream_info_;
+  auto options = Http::AsyncClient::StreamOptions().setParentContext(parent_context);
+
+  // Set up default action for streamInfo()
+  ON_CALL(stream_, streamInfo()).WillByDefault(testing::ReturnRef(stream_info_));
+
+  auto stream = client_->start(*this, config_with_hash_key_, options, watermark_callbacks_);
+
+  // Verify we can access stream info
+  EXPECT_EQ(&stream->streamInfo(), &stream_info_);
+  const auto& const_stream = *stream;
+  EXPECT_EQ(&const_stream.streamInfo(), &stream_info_);
+
+  // Mock stream watermark callbacks if flow control is enabled
+  if (Runtime::runtimeFeatureEnabled("envoy.reloadable_features.grpc_side_stream_flow_control")) {
+    // Mock stream for removeWatermarkCallbacks
+    EXPECT_CALL(stream_, removeWatermarkCallbacks());
+  }
+
+  // Notify filter destroy - should trigger cleanup
+  stream->notifyFilterDestroy();
+
+  EXPECT_CALL(stream_, closeStream());
+  stream->closeLocalStream();
+}
+
+TEST_F(ExtProcStreamTest, WatermarkCallbacksCleanup) {
+  Http::AsyncClient::ParentContext parent_context;
+  parent_context.stream_info = &stream_info_;
+  auto options = Http::AsyncClient::StreamOptions().setParentContext(parent_context);
+
+  // Set up default action for streamInfo()
+  ON_CALL(stream_, streamInfo()).WillByDefault(testing::ReturnRef(stream_info_));
+
+  auto stream = client_->start(*this, config_with_hash_key_, options, watermark_callbacks_);
+
+  const bool flow_control_enabled =
+      Runtime::runtimeFeatureEnabled("envoy.reloadable_features.grpc_side_stream_flow_control");
+
+  if (flow_control_enabled) {
+    // Set up expectation before calling notifyFilterDestroy
+    EXPECT_CALL(stream_, removeWatermarkCallbacks());
+  }
+
+  // Verify cleanup happens on filter destroy
+  stream->notifyFilterDestroy();
+
+  // Clean up
+  EXPECT_CALL(stream_, closeStream());
+  stream->closeLocalStream();
+}
+
+TEST_F(ExtProcStreamTest, NotifyFilterDestroyAfterRemoteClosed) {
+  Http::AsyncClient::ParentContext parent_context;
+  parent_context.stream_info = &stream_info_;
+  auto options = Http::AsyncClient::StreamOptions().setParentContext(parent_context);
+  ON_CALL(stream_, streamInfo()).WillByDefault(testing::ReturnRef(stream_info_));
+
+  auto stream = client_->start(*this, config_with_hash_key_, options, watermark_callbacks_);
+
+  // Close stream remotely first
+  stream_callbacks_->onRemoteClose(0, "");
+  EXPECT_TRUE(stream->remoteClosed());
+  EXPECT_TRUE(stream->localClosed());
+
+  // No watermark callback removals should happen since stream is already closed
+  EXPECT_CALL(stream_, removeWatermarkCallbacks()).Times(0);
+
+  stream->notifyFilterDestroy();
+}
+
+TEST_F(ExtProcStreamTest, ResetStreamWhenNotRemoteClosed) {
+  Http::AsyncClient::ParentContext parent_context;
+  parent_context.stream_info = &stream_info_;
+  auto options = Http::AsyncClient::StreamOptions().setParentContext(parent_context);
+  ON_CALL(stream_, streamInfo()).WillByDefault(testing::ReturnRef(stream_info_));
+
+  auto stream = client_->start(*this, config_with_hash_key_, options, watermark_callbacks_);
+
+  EXPECT_FALSE(stream->remoteClosed());
+  EXPECT_CALL(stream_, resetStream());
+  stream->resetStream();
+  EXPECT_TRUE(stream->remoteClosed());
+}
+
+TEST_F(ExtProcStreamTest, ResetStreamWhenAlreadyRemoteClosed) {
+  Http::AsyncClient::ParentContext parent_context;
+  parent_context.stream_info = &stream_info_;
+  auto options = Http::AsyncClient::StreamOptions().setParentContext(parent_context);
+  ON_CALL(stream_, streamInfo()).WillByDefault(testing::ReturnRef(stream_info_));
+
+  auto stream = client_->start(*this, config_with_hash_key_, options, watermark_callbacks_);
+
+  // Close remotely first
+  stream_callbacks_->onRemoteClose(0, "");
+  EXPECT_TRUE(stream->remoteClosed());
+
+  // resetStream() should not call stream_.resetStream() since already remotely closed
+  EXPECT_CALL(stream_, resetStream()).Times(0);
+  stream->resetStream();
+}
+
+TEST_F(ExtProcStreamTest, OnReceiveMessageAfterFilterDestroy) {
+  Http::AsyncClient::ParentContext parent_context;
+  parent_context.stream_info = &stream_info_;
+  auto options = Http::AsyncClient::StreamOptions().setParentContext(parent_context);
+  ON_CALL(stream_, streamInfo()).WillByDefault(testing::ReturnRef(stream_info_));
+
+  auto stream = client_->start(*this, config_with_hash_key_, options, watermark_callbacks_);
+
+  // Destroy filter first
+  stream->notifyFilterDestroy();
+
+  // Send a message - should be ignored since filter is destroyed
+  ProcessingResponse resp;
+  auto response_buf = Grpc::Common::serializeMessage(resp);
+  EXPECT_TRUE(stream_callbacks_->onReceiveMessageRaw(std::move(response_buf)));
+  EXPECT_FALSE(last_response_); // Message should be ignored
+
+  EXPECT_CALL(stream_, closeStream());
+  stream->closeLocalStream();
+}
+
 } // namespace
 } // namespace ExternalProcessing
 } // namespace HttpFilters


### PR DESCRIPTION
## Description

This PR adds some more tests to increase the coverage of the ExtProc directory.

**Before:**

![image](https://github.com/user-attachments/assets/0e7bdaf5-4b6c-4ba9-acdc-ac41fcd61b5e)

**After:**

![image](https://github.com/user-attachments/assets/90e574fc-4eb2-4ca2-bae3-c4f793874cf0)

---

**Commit Message:** ext_proc: add unit tests for client_impl to increase coverage
**Additional Description:** Adds additional tests for client_impl in ExtProc.
**Risk Level:** N/A
**Testing:** Added Unit Tests
**Docs Changes:** N/A
**Release Notes:** N/A