### PR TITLE
dynamic_forward_proxy: bugfix for udp dynamic forward proxy filter when displaying buffer

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -123,6 +123,10 @@ bug_fixes:
 - area: validation/tools
   change: |
     Add back missing extension for ``schema_validator_tool``.
+- area: udp/dynamic_forward_proxy
+  change: |
+    Fixed bug where dynamic_forward_proxy udp session filter disabled buffer in filter config
+    instead of disabling buffer for the filter instance.
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/source/extensions/filters/udp/udp_proxy/session_filters/dynamic_forward_proxy/proxy_filter.cc
+++ b/source/extensions/filters/udp/udp_proxy/session_filters/dynamic_forward_proxy/proxy_filter.cc
@@ -137,12 +137,12 @@ void ProxyFilter::onLoadDnsCacheComplete(
     read_callbacks_->injectDatagramToFilterChain(*buffered_datagram);
   }
 
-  disableBuffer();
+  diableSessionBuffer();
   buffered_bytes_ = 0;
 }
 
 void ProxyFilter::maybeBufferDatagram(Network::UdpRecvData& data) {
-  if (!bufferEnabled()) {
+  if (!sessionBufferEnabled()) {
     return;
   }
 

--- a/source/extensions/filters/udp/udp_proxy/session_filters/dynamic_forward_proxy/proxy_filter.cc
+++ b/source/extensions/filters/udp/udp_proxy/session_filters/dynamic_forward_proxy/proxy_filter.cc
@@ -137,12 +137,12 @@ void ProxyFilter::onLoadDnsCacheComplete(
     read_callbacks_->injectDatagramToFilterChain(*buffered_datagram);
   }
 
-  config_->disableBuffer();
+  disableBuffer();
   buffered_bytes_ = 0;
 }
 
 void ProxyFilter::maybeBufferDatagram(Network::UdpRecvData& data) {
-  if (!config_->bufferEnabled()) {
+  if (!bufferEnabled()) {
     return;
   }
 

--- a/source/extensions/filters/udp/udp_proxy/session_filters/dynamic_forward_proxy/proxy_filter.h
+++ b/source/extensions/filters/udp/udp_proxy/session_filters/dynamic_forward_proxy/proxy_filter.h
@@ -71,7 +71,7 @@ class ProxyFilter
       Logger::Loggable<Logger::Id::forward_proxy> {
 public:
   ProxyFilter(ProxyFilterConfigSharedPtr config)
-      : config_(std::move(config)), buffer_enabled_(config_->bufferEnabled()){};
+      : config_(std::move(config)), session_buffer_enabled_(config_->bufferEnabled()){};
 
   // Network::ReadFilter
   ReadFilterStatus onNewSession() override;
@@ -85,14 +85,14 @@ public:
   void onLoadDnsCacheComplete(
       const Extensions::Common::DynamicForwardProxy::DnsHostInfoSharedPtr&) override;
 
-  bool bufferEnabled() const { return buffer_enabled_; };
+  bool sessionBufferEnabled() const { return session_buffer_enabled_; };
 
 private:
   void maybeBufferDatagram(Network::UdpRecvData& data);
-  void disableBuffer() { buffer_enabled_ = false; }
+  void diableSessionBuffer() { session_buffer_enabled_ = false; }
 
   const ProxyFilterConfigSharedPtr config_;
-  bool buffer_enabled_;
+  bool session_buffer_enabled_;
   Upstream::ResourceAutoIncDecPtr circuit_breaker_;
   Extensions::Common::DynamicForwardProxy::DnsCache::LoadDnsCacheEntryHandlePtr cache_load_handle_;
   ReadFilterCallbacks* read_callbacks_{};

--- a/source/extensions/filters/udp/udp_proxy/session_filters/dynamic_forward_proxy/proxy_filter.h
+++ b/source/extensions/filters/udp/udp_proxy/session_filters/dynamic_forward_proxy/proxy_filter.h
@@ -70,7 +70,8 @@ class ProxyFilter
       public Extensions::Common::DynamicForwardProxy::DnsCache::LoadDnsCacheEntryCallbacks,
       Logger::Loggable<Logger::Id::forward_proxy> {
 public:
-  ProxyFilter(ProxyFilterConfigSharedPtr config) : config_(std::move(config)), buffer_enabled_(config_->bufferEnabled()){};
+  ProxyFilter(ProxyFilterConfigSharedPtr config)
+      : config_(std::move(config)), buffer_enabled_(config_->bufferEnabled()){};
 
   // Network::ReadFilter
   ReadFilterStatus onNewSession() override;

--- a/source/extensions/filters/udp/udp_proxy/session_filters/dynamic_forward_proxy/proxy_filter.h
+++ b/source/extensions/filters/udp/udp_proxy/session_filters/dynamic_forward_proxy/proxy_filter.h
@@ -40,7 +40,6 @@ public:
   Extensions::Common::DynamicForwardProxy::DnsCache& cache() { return *dns_cache_; }
   DynamicForwardProxyStats& filterStats() { return filter_stats_; }
   bool bufferEnabled() const { return buffer_enabled_; };
-  void disableBuffer() { buffer_enabled_ = false; }
   uint32_t maxBufferedDatagrams() const { return max_buffered_datagrams_; };
   uint64_t maxBufferedBytes() const { return max_buffered_bytes_; };
 
@@ -53,7 +52,7 @@ private:
   Extensions::Common::DynamicForwardProxy::DnsCacheSharedPtr dns_cache_;
   const Stats::ScopeSharedPtr stats_scope_;
   DynamicForwardProxyStats filter_stats_;
-  bool buffer_enabled_;
+  const bool buffer_enabled_;
   uint32_t max_buffered_datagrams_;
   uint64_t max_buffered_bytes_;
 };
@@ -71,7 +70,7 @@ class ProxyFilter
       public Extensions::Common::DynamicForwardProxy::DnsCache::LoadDnsCacheEntryCallbacks,
       Logger::Loggable<Logger::Id::forward_proxy> {
 public:
-  ProxyFilter(ProxyFilterConfigSharedPtr config) : config_(std::move(config)){};
+  ProxyFilter(ProxyFilterConfigSharedPtr config) : config_(std::move(config)), buffer_enabled_(config_->bufferEnabled()){};
 
   // Network::ReadFilter
   ReadFilterStatus onNewSession() override;
@@ -85,10 +84,14 @@ public:
   void onLoadDnsCacheComplete(
       const Extensions::Common::DynamicForwardProxy::DnsHostInfoSharedPtr&) override;
 
+  bool bufferEnabled() const { return buffer_enabled_; };
+
 private:
   void maybeBufferDatagram(Network::UdpRecvData& data);
+  void disableBuffer() { buffer_enabled_ = false; }
 
   const ProxyFilterConfigSharedPtr config_;
+  bool buffer_enabled_;
   Upstream::ResourceAutoIncDecPtr circuit_breaker_;
   Extensions::Common::DynamicForwardProxy::DnsCache::LoadDnsCacheEntryHandlePtr cache_load_handle_;
   ReadFilterCallbacks* read_callbacks_{};

--- a/test/extensions/filters/udp/udp_proxy/session_filters/dynamic_forward_proxy/proxy_filter_test.cc
+++ b/test/extensions/filters/udp/udp_proxy/session_filters/dynamic_forward_proxy/proxy_filter_test.cc
@@ -93,8 +93,6 @@ TEST_F(DynamicProxyFilterTest, DefaultBufferConfig) {
   EXPECT_TRUE(filter_config_->bufferEnabled());
   EXPECT_EQ(1024, filter_config_->maxBufferedDatagrams());
   EXPECT_EQ(16384, filter_config_->maxBufferedBytes());
-  filter_config_->disableBuffer();
-  EXPECT_FALSE(filter_config_->bufferEnabled());
 }
 
 TEST_F(DynamicProxyFilterTest, CustomBufferConfig) {
@@ -248,7 +246,10 @@ TEST_F(DynamicProxyFilterTest, LoadingCacheEntryWithDefaultBufferConfig) {
   filter_->onLoadDnsCacheComplete(host_info);
 
   EXPECT_CALL(*handle, onDestroy());
-  EXPECT_FALSE(filter_config_->bufferEnabled());
+
+  // Filter buffer is disabled but the filter config still has the buffer enabled.
+  EXPECT_FALSE(filter_->bufferEnabled());
+  EXPECT_TRUE(filter_config_->bufferEnabled());
 }
 
 TEST_F(DynamicProxyFilterTest, LoadingCacheEntryWithBufferSizeOverflow) {
@@ -282,7 +283,10 @@ TEST_F(DynamicProxyFilterTest, LoadingCacheEntryWithBufferSizeOverflow) {
   filter_->onLoadDnsCacheComplete(host_info);
 
   EXPECT_CALL(*handle, onDestroy());
-  EXPECT_FALSE(filter_config_->bufferEnabled());
+
+  // Filter buffer is disabled but the filter config still has the buffer enabled.
+  EXPECT_FALSE(filter_->bufferEnabled());
+  EXPECT_TRUE(filter_config_->bufferEnabled());
 }
 
 TEST_F(DynamicProxyFilterTest, LoadingCacheEntryWithBufferBytesOverflow) {
@@ -316,7 +320,10 @@ TEST_F(DynamicProxyFilterTest, LoadingCacheEntryWithBufferBytesOverflow) {
   filter_->onLoadDnsCacheComplete(host_info);
 
   EXPECT_CALL(*handle, onDestroy());
-  EXPECT_FALSE(filter_config_->bufferEnabled());
+
+  // Filter buffer is disabled but the filter config still has the buffer enabled.
+  EXPECT_FALSE(filter_->bufferEnabled());
+  EXPECT_TRUE(filter_config_->bufferEnabled());
 }
 
 TEST_F(DynamicProxyFilterTest, LoadingCacheEntryWithContinueFilterChainFailure) {

--- a/test/extensions/filters/udp/udp_proxy/session_filters/dynamic_forward_proxy/proxy_filter_test.cc
+++ b/test/extensions/filters/udp/udp_proxy/session_filters/dynamic_forward_proxy/proxy_filter_test.cc
@@ -248,7 +248,7 @@ TEST_F(DynamicProxyFilterTest, LoadingCacheEntryWithDefaultBufferConfig) {
   EXPECT_CALL(*handle, onDestroy());
 
   // Filter buffer is disabled but the filter config still has the buffer enabled.
-  EXPECT_FALSE(filter_->bufferEnabled());
+  EXPECT_FALSE(filter_->sessionBufferEnabled());
   EXPECT_TRUE(filter_config_->bufferEnabled());
 }
 
@@ -285,7 +285,7 @@ TEST_F(DynamicProxyFilterTest, LoadingCacheEntryWithBufferSizeOverflow) {
   EXPECT_CALL(*handle, onDestroy());
 
   // Filter buffer is disabled but the filter config still has the buffer enabled.
-  EXPECT_FALSE(filter_->bufferEnabled());
+  EXPECT_FALSE(filter_->sessionBufferEnabled());
   EXPECT_TRUE(filter_config_->bufferEnabled());
 }
 
@@ -322,7 +322,7 @@ TEST_F(DynamicProxyFilterTest, LoadingCacheEntryWithBufferBytesOverflow) {
   EXPECT_CALL(*handle, onDestroy());
 
   // Filter buffer is disabled but the filter config still has the buffer enabled.
-  EXPECT_FALSE(filter_->bufferEnabled());
+  EXPECT_FALSE(filter_->sessionBufferEnabled());
   EXPECT_TRUE(filter_config_->bufferEnabled());
 }
 


### PR DESCRIPTION
Commit Message: Fixed bug where dynamic_forward_proxy udp session filter disabled buffer in filter config instead of disabling buffer for the filter instance.
Additional Description:
Risk Level: low
Testing: unit
Docs Changes: N/A
Release Notes: added
Platform Specific Features: N/A
