### PR TITLE
clang-tidy: fixes errors in extproc

### DIFF
--- a/source/extensions/filters/http/ext_proc/client.h
+++ b/source/extensions/filters/http/ext_proc/client.h
@@ -19,7 +19,7 @@ namespace ExternalProcessing {
 
 class ExternalProcessorStream : public StreamBase {
 public:
-  virtual ~ExternalProcessorStream() = default;
+  ~ExternalProcessorStream() override = default;
   virtual void send(envoy::service::ext_proc::v3::ProcessingRequest&& request,
                     bool end_stream) PURE;
   // Idempotent close. Return true if it actually closed.
@@ -39,7 +39,7 @@ using ExternalProcessorStreamPtr = std::unique_ptr<ExternalProcessorStream>;
 
 class ExternalProcessorCallbacks : public RequestCallbacks {
 public:
-  virtual ~ExternalProcessorCallbacks() = default;
+  ~ExternalProcessorCallbacks() override = default;
   virtual void onReceiveMessage(
       std::unique_ptr<envoy::service::ext_proc::v3::ProcessingResponse>&& response) PURE;
   virtual void onGrpcError(Grpc::Status::GrpcStatus error) PURE;
@@ -49,7 +49,7 @@ public:
 
 class ExternalProcessorClient : public ClientBase {
 public:
-  virtual ~ExternalProcessorClient() = default;
+  ~ExternalProcessorClient() override = default;
   virtual ExternalProcessorStreamPtr
   start(ExternalProcessorCallbacks& callbacks,
         const Grpc::GrpcServiceConfigWithHashKey& config_with_hash_key,

--- a/source/extensions/filters/http/ext_proc/ext_proc.h
+++ b/source/extensions/filters/http/ext_proc/ext_proc.h
@@ -403,7 +403,7 @@ public:
                         config->untypedReceivingMetadataNamespaces()) {}
 
   const FilterConfig& config() const { return *config_; }
-  const envoy::config::core::v3::GrpcService& grpc_service_config() const {
+  const envoy::config::core::v3::GrpcService& grpcServiceConfig() const {
     return config_with_hash_key_.config();
   }
 

--- a/source/extensions/filters/http/ext_proc/http_client/http_client_impl.cc
+++ b/source/extensions/filters/http/ext_proc/http_client/http_client_impl.cc
@@ -54,7 +54,7 @@ void ExtProcHttpClient::sendRequest(envoy::service::ext_proc::v3::ProcessingRequ
                            DurationUtil::durationToMilliseconds(http_uri.timeout())))
                        .setSendInternal(false)
                        .setSendXff(false);
-    const std::string cluster = http_uri.cluster();
+    const std::string& cluster = http_uri.cluster();
     const auto thread_local_cluster = context().clusterManager().getThreadLocalCluster(cluster);
     if (thread_local_cluster) {
       active_request_ =

--- a/source/extensions/filters/http/ext_proc/http_client/http_client_impl.h
+++ b/source/extensions/filters/http/ext_proc/http_client/http_client_impl.h
@@ -22,7 +22,7 @@ public:
                     Server::Configuration::ServerFactoryContext& context)
       : config_(config), context_(context) {}
 
-  ~ExtProcHttpClient() { cancel(); }
+  ~ExtProcHttpClient() override { cancel(); }
 
   void sendRequest(envoy::service::ext_proc::v3::ProcessingRequest&& req, bool end_stream,
                    const uint64_t stream_id, RequestCallbacks* callbacks,

--- a/source/extensions/filters/http/ext_proc/processor_state.cc
+++ b/source/extensions/filters/http/ext_proc/processor_state.cc
@@ -466,7 +466,7 @@ bool ProcessorState::handleDuplexStreamedBodyResponse(const CommonResponse& comm
   const std::string& body = streamed_response.body();
   const bool end_of_stream = streamed_response.end_of_stream();
 
-  if (body.size() > 0) {
+  if (!body.empty()) {
     Buffer::OwnedImpl buffer;
     buffer.add(body);
     ENVOY_LOG(trace,

--- a/source/extensions/filters/http/ext_proc/processor_state.h
+++ b/source/extensions/filters/http/ext_proc/processor_state.h
@@ -80,10 +80,7 @@ public:
                           const std::vector<std::string>& untyped_forwarding_namespaces,
                           const std::vector<std::string>& typed_forwarding_namespaces,
                           const std::vector<std::string>& untyped_receiving_namespaces)
-      : filter_(filter), watermark_requested_(false), paused_(false), no_body_(false),
-        complete_body_available_(false), trailers_available_(false),
-        trailers_sent_to_server_(false), body_replaced_(false), body_received_(false),
-        partial_body_processed_(false), traffic_direction_(traffic_direction),
+      : filter_(filter), traffic_direction_(traffic_direction),
         untyped_forwarding_namespaces_(&untyped_forwarding_namespaces),
         typed_forwarding_namespaces_(&typed_forwarding_namespaces),
         untyped_receiving_namespaces_(&untyped_receiving_namespaces) {}
@@ -233,26 +230,26 @@ protected:
   CallbackState callback_state_ = CallbackState::Idle;
 
   // Keep track of whether we requested a watermark.
-  bool watermark_requested_ : 1;
+  bool watermark_requested_ : 1 = false;
   // Keep track of whether we paused processing and may require
   // a "continue."
-  bool paused_ : 1;
+  bool paused_ : 1 = false;
 
   // If true, then there is not going to be a body
-  bool no_body_ : 1;
+  bool no_body_ : 1 = false;
   // If true, then the filter received the complete body
-  bool complete_body_available_ : 1;
+  bool complete_body_available_ : 1 = false;
   // If true, then the filter received the trailers
-  bool trailers_available_ : 1;
+  bool trailers_available_ : 1 = false;
   // If true, the trailers is already sent to the server.
-  bool trailers_sent_to_server_ : 1;
+  bool trailers_sent_to_server_ : 1 = false;
   // If true, then a CONTINUE_AND_REPLACE status was used on a response
-  bool body_replaced_ : 1;
+  bool body_replaced_ : 1 = false;
   // If true, some body data is received.
-  bool body_received_ : 1;
+  bool body_received_ : 1 = false;
   // If true, we are in "buffered partial" mode and we already reached the buffer
   // limit, sent the body in a message, and got back a reply.
-  bool partial_body_processed_ : 1;
+  bool partial_body_processed_ : 1 = false;
 
   // If true, the server wants to see the headers
   bool send_headers_ : 1;

--- a/test/extensions/filters/http/ext_proc/filter_test.cc
+++ b/test/extensions/filters/http/ext_proc/filter_test.cc
@@ -5194,7 +5194,7 @@ TEST_F(HttpFilterTest, GrpcServiceMetadataOverride) {
   EXPECT_EQ(FilterHeadersStatus::StopIteration, filter_->decodeHeaders(request_headers_, true));
   processRequestHeaders(false, absl::nullopt);
 
-  const auto& meta = filter_->grpc_service_config().initial_metadata();
+  const auto& meta = filter_->grpcServiceConfig().initial_metadata();
   EXPECT_EQ(meta[0].value(), "a"); // a = a inherited
   EXPECT_EQ(meta[1].value(), "c"); // b = c overridden
   EXPECT_EQ(meta[2].value(), "c"); // c = c added


### PR DESCRIPTION
part of #28566 