### PR TITLE
golang: avoid accessing deleted decoder_callbacks

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -83,6 +83,9 @@ bug_fixes:
     Fixed metric for ADS disconnection counters using Google GRPC client. This extracts the GRPC client prefix specified
     in the :ref:`google_grpc <envoy_v3_api_field_config.core.v3.GrpcService.google_grpc>` resource used for ADS, and adds
     that as a tag ``envoy_google_grpc_client_prefix`` to the Prometheus stats.
+- area: golang
+  change:
+    Fixes a crash during Golang GC caused by accessing deleted decoder_callbacks. The bug was introduced in 1.31.0.
 - area: access_log
   change: |
     Relaxed the restriction on SNI logging to allow the ``_`` character, even if


### PR DESCRIPTION
This patch is provided by @doujiang24.

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: golang: avoid accessing deleted state
Additional Description: During Golang GC there will be envoyGoFilterHttpFinalize -> deferredDeleteRequest -> getDispatcher. Before this fix, the getDispatcher will use the occasional deleted decoder callback, which will cause a crash. After this fix, we won't touch the deleted callback anymore.
Risk Level: Low
Testing: after 3 hours load testing, the Envoy with this fix is still running well. 
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
Fixes #37225
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
