### PR TITLE
clang-tidy: respect '-Wno-builtin-macro-redefined' with c++20

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,7 @@
 Checks: >
   -clang-analyzer-core.NonNullParamChecker,
   -clang-analyzer-optin.cplusplus.UninitializedObject,
+  -clang-diagnostic-builtin-macro-redefined,
   abseil-duration-*,
   abseil-faster-strsplit-delimiter,
   abseil-no-namespace,


### PR DESCRIPTION
Previously, `redefining builtin macro [clang-diagnostic-builtin-macro-redefined,-warnings-as-errors]` was reported
despite the existence of the `-Wno-builtin-macro-redefined` in the compiler argument.
This is a known issue for older version of clang as in
* https://github.com/llvm/llvm-project/issues/56709
* https://github.com/erenon/bazel_clang_tidy/issues/29

The workaround discussed was to explicitly add `-clang-diagnostic-builtin-macro-redefined`
in the checks of clang-tidy, which can be removed after we upgrade to LLVM 17. 

part of #28566 


cc @phlax 