### PR TITLE
Include iosfwd instead of iostream in headers

### DIFF
--- a/envoy/http/header_map.h
+++ b/envoy/http/header_map.h
@@ -3,7 +3,7 @@
 #include <algorithm>
 #include <cstdint>
 #include <cstring>
-#include <iostream>
+#include <iosfwd>
 #include <memory>
 #include <string>
 #include <type_traits>

--- a/envoy/http/metadata_interface.h
+++ b/envoy/http/metadata_interface.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <functional>
-#include <iostream>
+#include <iosfwd>
 #include <memory>
 #include <sstream>
 #include <vector>

--- a/source/common/quic/platform/quiche_logging_impl.h
+++ b/source/common/quic/platform/quiche_logging_impl.h
@@ -8,7 +8,7 @@
 
 #include <cerrno>
 #include <cstring>
-#include <iostream>
+#include <iosfwd>
 #include <sstream>
 #include <string>
 

--- a/source/common/quic/platform/quiche_mem_slice_impl.h
+++ b/source/common/quic/platform/quiche_mem_slice_impl.h
@@ -7,7 +7,7 @@
 // porting layer for QUICHE.
 
 #include <cstddef>
-#include <iostream>
+#include <iosfwd>
 #include <memory>
 
 #include "source/common/buffer/buffer_impl.h"

--- a/source/common/quic/quic_io_handle_wrapper.h
+++ b/source/common/quic/quic_io_handle_wrapper.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <chrono>
-#include <iostream>
+#include <iosfwd>
 
 #include "envoy/network/io_handle.h"
 

--- a/source/common/upstream/edf_scheduler.h
+++ b/source/common/upstream/edf_scheduler.h
@@ -1,6 +1,6 @@
 #pragma once
 #include <cstdint>
-#include <iostream>
+#include <iosfwd>
 #include <queue>
 
 #include "envoy/upstream/scheduler.h"

--- a/source/common/upstream/wrsq_scheduler.h
+++ b/source/common/upstream/wrsq_scheduler.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <algorithm>
-#include <iostream>
+#include <iosfwd>
 #include <memory>
 #include <queue>
 #include <utility>


### PR DESCRIPTION
This is for optimizing build speed. 