### PR TITLE
bazel: Remove stray headers from srcs

### DIFF
--- a/bazel/external/http_parser/BUILD
+++ b/bazel/external/http_parser/BUILD
@@ -2,10 +2,7 @@ licenses(["notice"])  # Apache 2
 
 cc_library(
     name = "http_parser",
-    srcs = [
-        "http_parser.c",
-        "http_parser.h",
-    ],
+    srcs = ["http_parser.c"],
     hdrs = ["http_parser.h"],
     # This compiler flag is set to an arbtitrarily high number so
     # as to effectively disables the http_parser header limit, as

--- a/bazel/external/quiche.BUILD
+++ b/bazel/external/quiche.BUILD
@@ -3407,7 +3407,7 @@ envoy_quic_cc_library(
 
 envoy_quic_cc_library(
     name = "quic_core_one_block_arena_lib",
-    srcs = ["quiche/quic/core/quic_one_block_arena.h"],
+    hdrs = ["quiche/quic/core/quic_one_block_arena.h"],
     deps = [
         ":quic_core_arena_scoped_ptr_lib",
         ":quic_core_types_lib",


### PR DESCRIPTION
The header _should_ be provided in `hdrs` - not in `srcs`