### PR TITLE
docs: correct some spelling mistakes and de-dupe words in ExtAuthZ

### DIFF
--- a/api/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
+++ b/api/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
@@ -507,7 +507,7 @@ message CheckSettings {
   // :ref:`with_request_body <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.ExtAuthz.with_request_body>`
   // option for a specific route.
   //
-  // Please note that only one of *with_request_body* or
+  // Please note that only one of ``with_request_body`` or
   // :ref:`disable_request_body_buffering <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.CheckSettings.disable_request_body_buffering>`
   // may be specified.
   BufferSettings with_request_body = 3;

--- a/api/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
+++ b/api/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
@@ -215,7 +215,7 @@ message ExtAuthz {
   //
   // .. note::
   //
-  //  2. For requests to an HTTP authorization server: value of *Content-Length* will be set to 0 and the request to the
+  //  2. For requests to an HTTP authorization server: value of ``Content-Length`` will be set to 0 and the request to the
   //  authorization server will not have a message body. However, the check request can include the buffered
   //  client request body (controlled by :ref:`with_request_body
   //  <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.ExtAuthz.with_request_body>` setting),

--- a/api/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
+++ b/api/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
@@ -53,7 +53,7 @@ message ExtAuthz {
   config.core.v3.ApiVersion transport_api_version = 12
       [(validate.rules).enum = {defined_only: true}];
 
-  //  Changes filter's behaviour on errors:
+  //  Changes filter's behavior on errors:
   //
   //  1. When set to true, the filter will ``accept`` client request even if the communication with
   //  the authorization service has failed, or if the authorization service has returned a HTTP 5xx
@@ -210,12 +210,12 @@ message ExtAuthz {
   //
   // .. note::
   //
-  //  1. For requests to an HTTP authorization server: in addition to the the user's supplied matchers, ``Host``, ``Method``, ``Path``,
+  //  1. For requests to an HTTP authorization server: in addition to the user's supplied matchers, ``Host``, ``Method``, ``Path``,
   //     ``Content-Length``, and ``Authorization`` are **additionally included** in the list.
   //
   // .. note::
   //
-  //  2. For requests to an HTTP authorization server: *Content-Length* will be set to 0 and the request to the
+  //  2. For requests to an HTTP authorization server: value of *Content-Length* will be set to 0 and the request to the
   //  authorization server will not have a message body. However, the check request can include the buffered
   //  client request body (controlled by :ref:`with_request_body
   //  <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.ExtAuthz.with_request_body>` setting),
@@ -243,11 +243,11 @@ message ExtAuthz {
   google.protobuf.BoolValue charge_cluster_response_stats = 20;
 
   // Whether to encode the raw headers (i.e. unsanitized values & unconcatenated multi-line headers)
-  // in authentication request. Works with both HTTP and GRPC clients.
+  // in authentication request. Works with both HTTP and gRPC clients.
   //
   // When this is set to true, header values are not sanitized. Headers with the same key will also
   // not be combined into a single, comma-separated header.
-  // Requests to GRPC services will populate the field
+  // Requests to gRPC services will populate the field
   // :ref:`header_map<envoy_v3_api_field_service.auth.v3.AttributeContext.HttpRequest.header_map>`.
   // Requests to HTTP services will be constructed with the unsanitized header values and preserved
   // multi-line headers with the same key.
@@ -255,7 +255,7 @@ message ExtAuthz {
   // If this field is set to false, header values will be sanitized, with any non-UTF-8-compliant
   // bytes replaced with '!'. Headers with the same key will have their values concatenated into a
   // single comma-separated header value.
-  // Requests to GRPC services will populate the field
+  // Requests to gRPC services will populate the field
   // :ref:`headers<envoy_v3_api_field_service.auth.v3.AttributeContext.HttpRequest.headers>`.
   // Requests to HTTP services will have their header values sanitized and will not preserve
   // multi-line headers with the same key.
@@ -300,8 +300,8 @@ message ExtAuthz {
   // When set to true, the filter will emit per-stream stats for access logging. The filter state
   // key will be the same as the filter name.
   //
-  // If using Envoy GRPC, emits latency, bytes sent / received, upstream info, and upstream cluster
-  // info. If not using Envoy GRPC, emits only latency. Note that stats are ONLY added to filter
+  // If using Envoy gRPC, emits latency, bytes sent / received, upstream info, and upstream cluster
+  // info. If not using Envoy gRPC, emits only latency. Note that stats are ONLY added to filter
   // state if a check request is actually made to an ext_authz service.
   //
   // If this is false the filter will not emit stats, but filter_metadata will still be respected if
@@ -399,8 +399,8 @@ message AuthorizationRequest {
   //
   // .. note::
   //
-  //   In addition to the the user's supplied matchers, ``Host``, ``Method``, ``Path``,
-  //   ``Content-Length``, and ``Authorization`` are **automatically included** to the list.
+  //   In addition to the user's supplied matchers, ``Host``, ``Method``, ``Path``,
+  //   ``Content-Length``, and ``Authorization`` are **automatically included** in the list.
   //
   // .. note::
   //
@@ -507,7 +507,7 @@ message CheckSettings {
   // :ref:`with_request_body <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.ExtAuthz.with_request_body>`
   // option for a specific route.
   //
-  // Please note that only only one of *with_request_body* or
+  // Please note that only one of *with_request_body* or
   // :ref:`disable_request_body_buffering <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.CheckSettings.disable_request_body_buffering>`
   // may be specified.
   BufferSettings with_request_body = 3;


### PR DESCRIPTION
## Description

I noticed some minor mistakes in ExtAuthZ's documentation where certain words are duplicated and inconsistent style is used for some words like `gRPC` (Also spelled GRPC and grpc). This PR is fixing these nits.

---

**Commit Message**: docs: correct some spelling mistakes and de-dupe words in ExtAuthZ
**Additional Description**: Fixing documentation nits for ExtAuthZ filter.
**Risk Level**: N/A
**Testing**: N/A
**Docs Changes**: N/A
**Release Notes**: N/A