### PR TITLE
[PME filter] Clear any previously cached result in extractor

### DIFF
--- a/source/extensions/filters/http/proto_message_extraction/extractor.h
+++ b/source/extensions/filters/http/proto_message_extraction/extractor.h
@@ -58,6 +58,8 @@ public:
   virtual void processResponse(Protobuf::field_extraction::MessageData& message) = 0;
 
   virtual const ExtractedMessageResult& GetResult() const = 0;
+
+  virtual void ClearResult() = 0;
 };
 
 using ExtractorPtr = std::unique_ptr<Extractor>;

--- a/source/extensions/filters/http/proto_message_extraction/extractor_impl.h
+++ b/source/extensions/filters/http/proto_message_extraction/extractor_impl.h
@@ -42,6 +42,11 @@ public:
 
   const ExtractedMessageResult& GetResult() const override { return result_; }
 
+  void ClearResult() override {
+    result_.request_data.clear();
+    result_.response_data.clear();
+  }
+
 private:
   const envoy::extensions::filters::http::proto_message_extraction::v3::MethodExtraction&
       method_extraction_;

--- a/source/extensions/filters/http/proto_message_extraction/filter.cc
+++ b/source/extensions/filters/http/proto_message_extraction/filter.cc
@@ -146,6 +146,11 @@ Envoy::Http::FilterHeadersStatus Filter::decodeHeaders(Envoy::Http::RequestHeade
 
   // Cast away const for necessary modifications in a controlled context.
   extractor_ = const_cast<Extractor*>(extractor);
+
+  // The extractor is created per proto path. In case the of previously received proto path, clear
+  // any cached result from the extractor.
+  extractor_->ClearResult();
+
   auto cord_message_data_factory = std::make_unique<CreateMessageDataFunc>(
       []() { return std::make_unique<Protobuf::field_extraction::CordMessageData>(); });
 


### PR DESCRIPTION
Commit Message: Clear any previously cached result in extractor

Additional Description:  The extractor is created per proto path. In case the of previously received proto path, clear any cached result from the extractor.

Risk Level: Low

Testing: Covered by unit tests and integration tests

Docs Changes: Nil

Release Notes: Nil

Platform Specific Features: Nil