### PR TITLE
csrf: Handle opaque origins correctly ("Origin: null")

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -141,6 +141,9 @@ bug_fixes:
   change: |
     Fixed bug where dynamic_forward_proxy udp session filter disabled buffer in filter config
     instead of disabling buffer for the filter instance.
+- area: csrf
+  change: |
+    Handle requests that have a "privacy sensitive" / opaque origin (``Origin: null``) as if the request had no origin information.
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/source/extensions/filters/http/csrf/csrf_filter.cc
+++ b/source/extensions/filters/http/csrf/csrf_filter.cc
@@ -24,6 +24,8 @@ struct RcDetailsValues {
 using RcDetails = ConstSingleton<RcDetailsValues>;
 
 namespace {
+constexpr absl::string_view NullOrigin{"null"};
+
 bool isModifyMethod(const Http::RequestHeaderMap& headers) {
   const absl::string_view method_type = headers.getMethodValue();
   if (method_type.empty()) {
@@ -49,7 +51,11 @@ std::string hostAndPort(const absl::string_view absolute_url) {
 //       the Origin header must include the scheme (and hostAndPort expects
 //       an absolute URL).
 std::string sourceOriginValue(const Http::RequestHeaderMap& headers) {
-  const auto origin = hostAndPort(headers.getInlineValue(origin_handle.handle()));
+  const auto origin_value = headers.getInlineValue(origin_handle.handle());
+  if (origin_value == NullOrigin) {
+    return Envoy::EMPTY_STRING;
+  }
+  const auto origin = hostAndPort(origin_value);
   if (!origin.empty()) {
     return origin;
   }

--- a/test/extensions/filters/http/csrf/csrf_filter_test.cc
+++ b/test/extensions/filters/http/csrf/csrf_filter_test.cc
@@ -123,6 +123,7 @@ TEST_F(CsrfFilterTest, RequestWithoutOriginAndWithoutDestination) {
   EXPECT_EQ(1U, config_->stats().missing_source_origin_.value());
   EXPECT_EQ(0U, config_->stats().request_invalid_.value());
   EXPECT_EQ(0U, config_->stats().request_valid_.value());
+  EXPECT_EQ("csrf_origin_mismatch", decoder_callbacks_.details());
 }
 
 TEST_F(CsrfFilterTest, RequestWithoutOriginAndWithDestination) {
@@ -137,6 +138,7 @@ TEST_F(CsrfFilterTest, RequestWithoutOriginAndWithDestination) {
   EXPECT_EQ(1U, config_->stats().missing_source_origin_.value());
   EXPECT_EQ(0U, config_->stats().request_invalid_.value());
   EXPECT_EQ(0U, config_->stats().request_valid_.value());
+  EXPECT_EQ("csrf_origin_mismatch", decoder_callbacks_.details());
 }
 
 TEST_F(CsrfFilterTest, RequestWithoutDestination) {
@@ -151,6 +153,7 @@ TEST_F(CsrfFilterTest, RequestWithoutDestination) {
   EXPECT_EQ(0U, config_->stats().missing_source_origin_.value());
   EXPECT_EQ(1U, config_->stats().request_invalid_.value());
   EXPECT_EQ(0U, config_->stats().request_valid_.value());
+  EXPECT_EQ("csrf_origin_mismatch", decoder_callbacks_.details());
 }
 
 TEST_F(CsrfFilterTest, RequestWithInvalidOrigin) {
@@ -323,6 +326,7 @@ TEST_F(CsrfFilterTest, RequestWithInvalidOriginCsrfEnabledShadowEnabled) {
   EXPECT_EQ(0U, config_->stats().missing_source_origin_.value());
   EXPECT_EQ(1U, config_->stats().request_invalid_.value());
   EXPECT_EQ(0U, config_->stats().request_valid_.value());
+  EXPECT_EQ("csrf_origin_mismatch", decoder_callbacks_.details());
 }
 
 TEST_F(CsrfFilterTest, RequestWithValidOriginCsrfEnabledShadowEnabled) {
@@ -332,6 +336,34 @@ TEST_F(CsrfFilterTest, RequestWithValidOriginCsrfEnabledShadowEnabled) {
                                                  {":scheme", "http"}};
 
   setShadowEnabled(true);
+
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.decodeHeaders(request_headers, false));
+  EXPECT_EQ(Http::FilterDataStatus::Continue, filter_.decodeData(data_, false));
+  EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_.decodeTrailers(request_trailers_));
+
+  EXPECT_EQ(0U, config_->stats().missing_source_origin_.value());
+  EXPECT_EQ(0U, config_->stats().request_invalid_.value());
+  EXPECT_EQ(1U, config_->stats().request_valid_.value());
+}
+
+TEST_F(CsrfFilterTest, RequestWithNullOriginForNullHost) {
+  Http::TestRequestHeaderMapImpl request_headers{
+      {":method", "PUT"}, {"origin", "null"}, {":authority", "null"}, {":scheme", "http"}};
+
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
+            filter_.decodeHeaders(request_headers, false));
+  EXPECT_EQ(Http::FilterDataStatus::Continue, filter_.decodeData(data_, false));
+  EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_.decodeTrailers(request_trailers_));
+
+  EXPECT_EQ(1U, config_->stats().missing_source_origin_.value());
+  EXPECT_EQ(0U, config_->stats().request_invalid_.value());
+  EXPECT_EQ(0U, config_->stats().request_valid_.value());
+  EXPECT_EQ("csrf_origin_mismatch", decoder_callbacks_.details());
+}
+
+TEST_F(CsrfFilterTest, RequestWithValidOriginForNullHost) {
+  Http::TestRequestHeaderMapImpl request_headers{
+      {":method", "PUT"}, {"origin", "http://null"}, {":authority", "null"}, {":scheme", "http"}};
 
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.decodeHeaders(request_headers, false));
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_.decodeData(data_, false));
@@ -395,6 +427,7 @@ TEST_F(CsrfFilterTest, NoCsrfEntry) {
   EXPECT_EQ(0U, config_->stats().missing_source_origin_.value());
   EXPECT_EQ(1U, config_->stats().request_invalid_.value());
   EXPECT_EQ(0U, config_->stats().request_valid_.value());
+  EXPECT_EQ("csrf_origin_mismatch", decoder_callbacks_.details());
 }
 
 TEST_F(CsrfFilterTest, NoRouteCsrfEntry) {
@@ -411,6 +444,7 @@ TEST_F(CsrfFilterTest, NoRouteCsrfEntry) {
   EXPECT_EQ(0U, config_->stats().missing_source_origin_.value());
   EXPECT_EQ(1U, config_->stats().request_invalid_.value());
   EXPECT_EQ(0U, config_->stats().request_valid_.value());
+  EXPECT_EQ("csrf_origin_mismatch", decoder_callbacks_.details());
 }
 
 TEST_F(CsrfFilterTest, NoVHostCsrfEntry) {
@@ -427,6 +461,7 @@ TEST_F(CsrfFilterTest, NoVHostCsrfEntry) {
   EXPECT_EQ(0U, config_->stats().missing_source_origin_.value());
   EXPECT_EQ(1U, config_->stats().request_invalid_.value());
   EXPECT_EQ(0U, config_->stats().request_valid_.value());
+  EXPECT_EQ("csrf_origin_mismatch", decoder_callbacks_.details());
 }
 
 TEST_F(CsrfFilterTest, RequestFromAdditionalExactOrigin) {
@@ -467,6 +502,7 @@ TEST_F(CsrfFilterTest, RequestFromInvalidAdditionalRegexOrigin) {
   EXPECT_EQ(0U, config_->stats().missing_source_origin_.value());
   EXPECT_EQ(1U, config_->stats().request_invalid_.value());
   EXPECT_EQ(0U, config_->stats().request_valid_.value());
+  EXPECT_EQ("csrf_origin_mismatch", decoder_callbacks_.details());
 }
 
 } // namespace Csrf


### PR DESCRIPTION
Treat requests that have an opaque origin like requests that have no origin information.

Additional Description: For more information about "Origin: null", see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Origin
Risk Level: Low
Testing: Unit tests
Release Notes: in `changelogs/current.yaml`