### PR TITLE
stats: removes unused stdregex tag extractor

### DIFF
--- a/source/common/common/regex.h
+++ b/source/common/common/regex.h
@@ -78,8 +78,6 @@ public:
 
 DECLARE_FACTORY(GoogleReEngineFactory);
 
-enum class Type { Re2, StdRegex };
-
 /**
  * Utilities for constructing regular expressions.
  */

--- a/source/common/config/well_known_names.cc
+++ b/source/common/config/well_known_names.cc
@@ -243,7 +243,7 @@ TagNameValues::TagNameValues() {
 void TagNameValues::addRe2(const std::string& name, const std::string& regex,
                            const std::string& substr, const std::string& negative_matching_value) {
   descriptor_vec_.emplace_back(
-      Descriptor{name, expandRegex(regex), substr, negative_matching_value, Regex::Type::Re2});
+      Descriptor{name, expandRegex(regex), substr, negative_matching_value});
 }
 
 void TagNameValues::addTokenized(const std::string& name, const std::string& tokens) {

--- a/source/common/config/well_known_names.h
+++ b/source/common/config/well_known_names.h
@@ -76,7 +76,6 @@ public:
     const std::string regex_;
     const std::string substr_;
     const std::string negative_match_; // A value that will not match as the extracted tag value.
-    const Regex::Type re_type_;
   };
 
   struct TokenizedDescriptor {

--- a/source/common/stats/tag_producer_impl.cc
+++ b/source/common/stats/tag_producer_impl.cc
@@ -66,7 +66,7 @@ absl::Status TagProducerImpl::addExtractorsMatching(absl::string_view name) {
   for (const auto& desc : Config::TagNames::get().descriptorVec()) {
     if (desc.name_ == name) {
       auto extractor_or_error = TagExtractorImplBase::createTagExtractor(
-          desc.name_, desc.regex_, desc.substr_, desc.negative_match_, desc.re_type_);
+          desc.name_, desc.regex_, desc.substr_, desc.negative_match_);
       if (!extractor_or_error.ok()) {
         return extractor_or_error.status();
       }
@@ -157,7 +157,7 @@ TagProducerImpl::addDefaultExtractors(const envoy::config::metrics::v3::StatsCon
   if (!config.has_use_all_default_tags() || config.use_all_default_tags().value()) {
     for (const auto& desc : Config::TagNames::get().descriptorVec()) {
       auto extractor_or_error = TagExtractorImplBase::createTagExtractor(
-          desc.name_, desc.regex_, desc.substr_, desc.negative_match_, desc.re_type_);
+          desc.name_, desc.regex_, desc.substr_, desc.negative_match_);
       RETURN_IF_NOT_OK_REF(extractor_or_error.status());
       addExtractor(std::move(extractor_or_error.value()));
     }

--- a/test/common/stats/thread_local_store_test.cc
+++ b/test/common/stats/thread_local_store_test.cc
@@ -830,7 +830,7 @@ TEST_F(StatsThreadLocalStoreTest, ExtractAndAppendTagsRegexValueWithMatch) {
   envoy::config::metrics::v3::StatsConfig stats_config;
   auto* tag_specifier = stats_config.add_stats_tags();
   tag_specifier->set_tag_name("foo_tag");
-  tag_specifier->set_regex("^foo.(.+)");
+  tag_specifier->set_regex("^foo.((.+))");
 
   const Stats::TagVector tags_vector;
   store_->setTagProducer(TagProducerImpl::createTagProducer(stats_config, tags_vector).value());

--- a/test/extensions/filters/http/cors/cors_filter_test.cc
+++ b/test/extensions/filters/http/cors/cors_filter_test.cc
@@ -31,7 +31,7 @@ Matchers::StringMatcherPtr makeExactStringMatcher(const std::string& exact_match
       config, context);
 }
 
-Matchers::StringMatcherPtr makeStdRegexStringMatcher(const std::string& regex) {
+Matchers::StringMatcherPtr makeRegexStringMatcher(const std::string& regex) {
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   envoy::type::matcher::v3::StringMatcher config;
   config.MergeFrom(TestUtility::createRegexMatcher(regex));
@@ -803,7 +803,7 @@ TEST_F(CorsFilterTest, OptionsRequestMatchingOriginByRegex) {
   };
 
   cors_policy_->allow_origins_.clear();
-  cors_policy_->allow_origins_.emplace_back(makeStdRegexStringMatcher(".*"));
+  cors_policy_->allow_origins_.emplace_back(makeRegexStringMatcher(".*"));
 
   EXPECT_CALL(decoder_callbacks_, encodeHeaders_(HeaderMapEqualRef(&response_headers), true));
 
@@ -826,7 +826,7 @@ TEST_F(CorsFilterTest, OptionsRequestNotMatchingOriginByRegex) {
                                                  {"access-control-request-method", "GET"}};
 
   cors_policy_->allow_origins_.clear();
-  cors_policy_->allow_origins_.emplace_back(makeStdRegexStringMatcher(".*.envoyproxy.io"));
+  cors_policy_->allow_origins_.emplace_back(makeRegexStringMatcher(".*.envoyproxy.io"));
 
   EXPECT_CALL(decoder_callbacks_, encodeHeaders_(_, false)).Times(0);
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, false));

--- a/tools/code_format/config.yaml
+++ b/tools/code_format/config.yaml
@@ -110,7 +110,6 @@ paths:
     - source/common/formatter/stream_info_formatter.h
     - source/common/formatter/stream_info_formatter.cc
     - source/common/formatter/substitution_formatter.h
-    - source/common/stats/tag_extractor_impl.cc
     - source/common/protobuf/yaml_utility.cc
     - source/common/protobuf/utility.cc
     - source/common/grpc/google_grpc_utils.cc


### PR DESCRIPTION
Commit Message: stats: removes unused stdregex tag extractor
Additional Description:

Previously, the stdregex option was only used in tests, and in the main
source code it's set to re2 and no use of stdregex anymore.

This removes the std::regex impl, which helps us remove the exclusion 
of `source/common/stats/tag_extractor_impl.cc` from no-exception 
source code in light of #27412.

Risk Level: low
Testing: done (existing tests)
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a

