### PR TITLE
router: add upstream_service_time histogram metric

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -408,6 +408,11 @@ new_features:
   change: |
     Add the option to reduce the rate limit budget based on request/response contexts on stream done.
     See :ref:`apply_on_stream_done <envoy_v3_api_field_config.route.v3.RateLimit.apply_on_stream_done>` for more details.
+- area: router
+  change: |
+    Added histogram metric ``upstream_service_time`` which tracks the total time in milliseconds spent by the upstream
+    host processing the request and the network latency between Envoy and upstream host. This value matches what would
+    be found in the ``x-envoy-upstream-service-time`` response header.
 
 deprecated:
 - area: rbac

--- a/docs/root/configuration/http/http_filters/router_filter.rst
+++ b/docs/root/configuration/http/http_filters/router_filter.rst
@@ -434,6 +434,7 @@ owning HTTP connection manager.
   rq_total, Counter, Total routed requests
   rq_reset_after_downstream_response_started, Counter, Total requests that were reset after downstream response had started
   rq_overload_local_reply, Counter, Total requests that were load shed if downstream filter load shed point is configured
+  upstream_service_time, Histogram, Total time in milliseconds spent by the upstream host processing the request and the network latency between Envoy and upstream host. This value matches what would be found in the ``x-envoy-upstream-service-time`` response header.
 
 .. _config_http_filters_router_vcluster_stats:
 

--- a/source/common/router/context_impl.h
+++ b/source/common/router/context_impl.h
@@ -25,6 +25,7 @@ namespace Router {
   COUNTER(rq_redirect)                                                                             \
   COUNTER(rq_reset_after_downstream_response_started)                                              \
   COUNTER(rq_total)                                                                                \
+  HISTOGRAM(upstream_service_time, Milliseconds)                                                   \
   STATNAME(retry)
 
 MAKE_STAT_NAMES_STRUCT(StatNames, ALL_ROUTER_STATS);


### PR DESCRIPTION
## Description

This PR adds a new histogram metric called ``upstream_service_time`` in the Router Filter which tracks the total time in milliseconds spent by the upstream host processing the request and the network latency between Envoy and upstream host.

This value matches what would be found in the ``x-envoy-upstream-service-time`` response header.

Fixes #37129

---

**Commit Message:** router: add upstream_service_time histogram metric
**Additional Description:** Adds a new histogram metric called ``upstream_service_time`` in the router to track the total time in milliseconds spent by the upstream host processing the request and the network latency between Envoy and upstream host.
**Risk Level:** Low
**Testing:** Added Unit Test
**Docs Changes:** Added
**Release Notes:** Added