### PR TITLE
ecds: fixing an ECDS with upstream filter singleton issue

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -123,6 +123,9 @@ bug_fixes:
 - area: tracers
   change: |
     Avoid possible overflow when setting span attributes in Dynatrace sampler.
+- area: ecds
+  change: |
+    Fixing a singleton early destroy when using ECDS in an upstream filter.
 - area: load_balancing
   change: |
     Fixed default host weight calculation of :ref:`client_side_weighted_round_robin

--- a/source/common/http/filter_chain_helper.cc
+++ b/source/common/http/filter_chain_helper.cc
@@ -53,7 +53,8 @@ FilterChainUtility::createSingletonUpstreamFilterConfigProviderManager(
   std::shared_ptr<UpstreamFilterConfigProviderManager> upstream_filter_config_provider_manager =
       context.singletonManager().getTyped<Http::UpstreamFilterConfigProviderManager>(
           SINGLETON_MANAGER_REGISTERED_NAME(upstream_filter_config_provider_manager),
-          [] { return std::make_shared<Filter::UpstreamHttpFilterConfigProviderManagerImpl>(); });
+          [] { return std::make_shared<Filter::UpstreamHttpFilterConfigProviderManagerImpl>(); },
+          true);
   return upstream_filter_config_provider_manager;
 }
 

--- a/test/extensions/filters/http/common/fuzz/filter_corpus/upstream_filter_ecds
+++ b/test/extensions/filters/http/common/fuzz/filter_corpus/upstream_filter_ecds
@@ -1,0 +1,7 @@
+config {
+  name: "envoy.router"
+  typed_config {
+    type_url: "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
+    value: " \001Bj\n\tenvoy.lua\"]\nWtype.googleapis.com/envoy.extensions.filters.http.admission_control.v3.AdmissionControl\022\002\022\000B\322\001\n\tenvoy.lua*\304\001\n\005B\003\n\001p\"\272\001type.googlkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkeapis.com/envoy.extensions.filters.http.admission_control.v3.AdmissionControlB\031\n\tenvoy.lua\"\014\022\n\022\000\032\004\020\200\200\0102\000"
+  }
+}


### PR DESCRIPTION
Commit Message: ecds: fixing an ECDS with upstream filter singleton issue
Additional Description:
The upstream_filter_config_provider_manager singleton goes out of scope while processing a config with an upstream filter that is configured to use ECDS.
Note that to repro this a config with an upstream filter that uses ECDS is needed.

Risk Level: low - bug fix
Testing: added fuzz bug corpus
Docs Changes: N/A
Release Notes: Added
Platform Specific Features: N/A

Fixes fuzz issue [42520120](https://issues.oss-fuzz.com/issues/42520120).