### PR TITLE
qat: stop qat device before qatzip process exit

### DIFF
--- a/contrib/qat/compression/qatzip/compressor/source/config.cc
+++ b/contrib/qat/compression/qatzip/compressor/source/config.cc
@@ -87,6 +87,7 @@ QatzipCompressorFactory::QatzipThreadLocal::QatzipThreadLocal(QzSessionParams_T 
 QatzipCompressorFactory::QatzipThreadLocal::~QatzipThreadLocal() {
   if (initialized_) {
     qzTeardownSession(&session_);
+    qzClose(&session_);
   }
 }
 


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: qat: stop qat device before qatzip process exit
Additional Description:
The QAT device remains occupied after the qatzip process exits. qzClose() must be called to fix it.
Risk Level: low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
