### PR TITLE
Revert "github/ci: Workaround failing `gsutil` issue (#37480)"

### DIFF
--- a/.github/workflows/_publish_build.yml
+++ b/.github/workflows/_publish_build.yml
@@ -78,8 +78,7 @@ jobs:
           bazel-extra: >-
             --config=remote-cache-envoy-engflow
           rbe: false
-          # TODO(phlax): Switch this back to medium size
-          runs-on: envoy-arm64-large
+          runs-on: envoy-arm64-medium
 
   distribution:
     permissions:


### PR DESCRIPTION
This reverts commit 6a4608f4c66f1932c9aa64325bc592ac309c7ca4.

i added a better workaround that forces install of gsutil if it detects a buggy vm