### PR TITLE
build: explicitly include absl/status/status.h in drain decision interface

### DIFF
--- a/envoy/network/BUILD
+++ b/envoy/network/BUILD
@@ -106,6 +106,7 @@ envoy_cc_library(
     deps = [
         "//envoy/common:callback",
         "@com_google_absl//absl/base",
+        "@com_google_absl//absl/status",
     ],
 )
 

--- a/envoy/network/drain_decision.h
+++ b/envoy/network/drain_decision.h
@@ -7,6 +7,7 @@
 #include "envoy/common/pure.h"
 
 #include "absl/base/attributes.h"
+#include "absl/status/status.h"
 
 namespace Envoy {
 namespace Network {


### PR DESCRIPTION
Signed-off-by: James Heppenstall [james.heppenstall@mongodb.com](mailto:james.heppenstall@mongodb.com)

Commit Message: build: explicitly include absl/status/status.h in drain decision interface
Additional Description: MongoDB develops a number of custom filters in a repository that consumes Envoy as a submodule. While upgrading to `v1.32`, we started noticing some test build failures related to `absl::Status` being undeclared in `envoy/network/drain_decision.h`. It looks like `absl/status/status.h` is being included transitively in this file and should instead be declared explicitly.
Risk Level: Low
Testing: Manual
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
