### PR TITLE
mobile/ci: Remove the Swift async app CI job

### DIFF
--- a/.github/workflows/mobile-ios_build.yml
+++ b/.github/workflows/mobile-ios_build.yml
@@ -168,12 +168,6 @@ jobs:
           app: //test/swift/apps/experimental:app
           expected-status: 200
           target: swift-experimental-app
-        - name: Build swift async await
-          app: //examples/swift/async_await:app
-          expected: >-
-            Uploaded 7 MB of data
-          target: swift-async-await
-          timeout: 10m
         - name: Build objc hello world
           app: //examples/objective-c/hello_world:app
           expected-status: 301


### PR DESCRIPTION
This app runs on CI and sends a 5MB POST request to httpbin.org. The app is flaky on CI due to sending requests to httpbin.org, and the app itself doesn't add much value to CI, as there are already hello world apps that test iOS app functionality on CI.

Fixes #37485 