### PR TITLE
Remove exceptions from stat_sinks

### DIFF
--- a/source/extensions/stat_sinks/common/statsd/statsd.cc
+++ b/source/extensions/stat_sinks/common/statsd/statsd.cc
@@ -210,8 +210,8 @@ TcpStatsdSink::create(const LocalInfo::LocalInfo& local_info, const std::string&
                       ThreadLocal::SlotAllocator& tls, Upstream::ClusterManager& cluster_manager,
                       Stats::Scope& scope, const std::string& prefix) {
   absl::Status creation_status;
-  auto sink = std::make_unique<TcpStatsdSink>(local_info, cluster_name, tls, cluster_manager, scope,
-                                              creation_status, prefix);
+  auto sink = std::unique_ptr<TcpStatsdSink>(new TcpStatsdSink(
+      local_info, cluster_name, tls, cluster_manager, scope, creation_status, prefix));
   RETURN_IF_ERROR(creation_status);
   return sink;
 }

--- a/source/extensions/stat_sinks/common/statsd/statsd.cc
+++ b/source/extensions/stat_sinks/common/statsd/statsd.cc
@@ -212,7 +212,7 @@ TcpStatsdSink::create(const LocalInfo::LocalInfo& local_info, const std::string&
   absl::Status creation_status;
   auto sink = std::unique_ptr<TcpStatsdSink>(new TcpStatsdSink(
       local_info, cluster_name, tls, cluster_manager, scope, creation_status, prefix));
-  RETURN_IF_ERROR(creation_status);
+  RETURN_IF_NOT_OK_REF(creation_status);
   return sink;
 }
 

--- a/source/extensions/stat_sinks/common/statsd/statsd.cc
+++ b/source/extensions/stat_sinks/common/statsd/statsd.cc
@@ -5,7 +5,6 @@
 #include <string>
 
 #include "envoy/buffer/buffer.h"
-#include "envoy/common/exception.h"
 #include "envoy/common/platform.h"
 #include "envoy/event/dispatcher.h"
 #include "envoy/stats/scope.h"
@@ -189,20 +188,32 @@ const std::string UdpStatsdSink::buildTagStr(const std::vector<Stats::Tag>& tags
 TcpStatsdSink::TcpStatsdSink(const LocalInfo::LocalInfo& local_info,
                              const std::string& cluster_name, ThreadLocal::SlotAllocator& tls,
                              Upstream::ClusterManager& cluster_manager, Stats::Scope& scope,
-                             const std::string& prefix)
+                             absl::Status& creation_status, const std::string& prefix)
     : prefix_(prefix.empty() ? Statsd::getDefaultPrefix() : prefix), tls_(tls.allocateSlot()),
       cluster_manager_(cluster_manager),
       cx_overflow_stat_(scope.counterFromStatName(
           Stats::StatNameManagedStorage("statsd.cx_overflow", scope.symbolTable()).statName())) {
-  THROW_IF_NOT_OK(Config::Utility::checkLocalInfo("tcp statsd", local_info));
-  const auto cluster_or_error =
+  SET_AND_RETURN_IF_NOT_OK(Config::Utility::checkLocalInfo("tcp statsd", local_info),
+                           creation_status);
+  auto cluster_or_error =
       Config::Utility::checkCluster("tcp statsd", cluster_name, cluster_manager);
-  THROW_IF_NOT_OK_REF(cluster_or_error.status());
+  SET_AND_RETURN_IF_NOT_OK(cluster_or_error.status(), creation_status);
   const auto cluster = cluster_or_error.value();
   cluster_info_ = cluster->get().info();
   tls_->set([this](Event::Dispatcher& dispatcher) -> ThreadLocal::ThreadLocalObjectSharedPtr {
     return std::make_shared<TlsSink>(*this, dispatcher);
   });
+}
+
+absl::StatusOr<std::unique_ptr<TcpStatsdSink>>
+TcpStatsdSink::create(const LocalInfo::LocalInfo& local_info, const std::string& cluster_name,
+                      ThreadLocal::SlotAllocator& tls, Upstream::ClusterManager& cluster_manager,
+                      Stats::Scope& scope, const std::string& prefix) {
+  absl::Status creation_status;
+  auto sink = std::make_unique<TcpStatsdSink>(local_info, cluster_name, tls, cluster_manager, scope,
+                                              creation_status, prefix);
+  RETURN_IF_ERROR(creation_status);
+  return sink;
 }
 
 void TcpStatsdSink::flush(Stats::MetricSnapshot& snapshot) {

--- a/source/extensions/stat_sinks/common/statsd/statsd.h
+++ b/source/extensions/stat_sinks/common/statsd/statsd.h
@@ -107,7 +107,16 @@ class TcpStatsdSink : public Stats::Sink {
 public:
   TcpStatsdSink(const LocalInfo::LocalInfo& local_info, const std::string& cluster_name,
                 ThreadLocal::SlotAllocator& tls, Upstream::ClusterManager& cluster_manager,
-                Stats::Scope& scope, const std::string& prefix = getDefaultPrefix());
+                Stats::Scope& scope, absl::Status& creation_status,
+                const std::string& prefix = getDefaultPrefix());
+
+  /**
+   * This is a wrapper around the constructor to allows it to return a StatusOr.
+   */
+  static absl::StatusOr<std::unique_ptr<TcpStatsdSink>>
+  create(const LocalInfo::LocalInfo& local_info, const std::string& cluster_name,
+         ThreadLocal::SlotAllocator& tls, Upstream::ClusterManager& cluster_manager,
+         Stats::Scope& scope, const std::string& prefix = getDefaultPrefix());
 
   // Stats::Sink
   void flush(Stats::MetricSnapshot& snapshot) override;

--- a/source/extensions/stat_sinks/common/statsd/statsd.h
+++ b/source/extensions/stat_sinks/common/statsd/statsd.h
@@ -105,11 +105,6 @@ private:
  */
 class TcpStatsdSink : public Stats::Sink {
 public:
-  TcpStatsdSink(const LocalInfo::LocalInfo& local_info, const std::string& cluster_name,
-                ThreadLocal::SlotAllocator& tls, Upstream::ClusterManager& cluster_manager,
-                Stats::Scope& scope, absl::Status& creation_status,
-                const std::string& prefix = getDefaultPrefix());
-
   /**
    * This is a wrapper around the constructor to return StatusOr.
    */
@@ -125,6 +120,11 @@ public:
   const std::string& getPrefix() { return prefix_; }
 
 private:
+  TcpStatsdSink(const LocalInfo::LocalInfo& local_info, const std::string& cluster_name,
+                ThreadLocal::SlotAllocator& tls, Upstream::ClusterManager& cluster_manager,
+                Stats::Scope& scope, absl::Status& creation_status,
+                const std::string& prefix = getDefaultPrefix());
+
   struct TlsSink : public ThreadLocal::ThreadLocalObject, public Network::ConnectionCallbacks {
     TlsSink(TcpStatsdSink& parent, Event::Dispatcher& dispatcher);
     ~TlsSink() override;

--- a/source/extensions/stat_sinks/common/statsd/statsd.h
+++ b/source/extensions/stat_sinks/common/statsd/statsd.h
@@ -119,12 +119,13 @@ public:
 
   const std::string& getPrefix() { return prefix_; }
 
-private:
+protected:
   TcpStatsdSink(const LocalInfo::LocalInfo& local_info, const std::string& cluster_name,
                 ThreadLocal::SlotAllocator& tls, Upstream::ClusterManager& cluster_manager,
                 Stats::Scope& scope, absl::Status& creation_status,
                 const std::string& prefix = getDefaultPrefix());
 
+private:
   struct TlsSink : public ThreadLocal::ThreadLocalObject, public Network::ConnectionCallbacks {
     TlsSink(TcpStatsdSink& parent, Event::Dispatcher& dispatcher);
     ~TlsSink() override;

--- a/source/extensions/stat_sinks/common/statsd/statsd.h
+++ b/source/extensions/stat_sinks/common/statsd/statsd.h
@@ -111,7 +111,7 @@ public:
                 const std::string& prefix = getDefaultPrefix());
 
   /**
-   * This is a wrapper around the constructor to allows it to return a StatusOr.
+   * This is a wrapper around the constructor to return StatusOr.
    */
   static absl::StatusOr<std::unique_ptr<TcpStatsdSink>>
   create(const LocalInfo::LocalInfo& local_info, const std::string& cluster_name,

--- a/source/extensions/stat_sinks/dog_statsd/config.cc
+++ b/source/extensions/stat_sinks/dog_statsd/config.cc
@@ -16,14 +16,14 @@ namespace Extensions {
 namespace StatSinks {
 namespace DogStatsd {
 
-Stats::SinkPtr
+absl::StatusOr<Stats::SinkPtr>
 DogStatsdSinkFactory::createStatsSink(const Protobuf::Message& config,
                                       Server::Configuration::ServerFactoryContext& server) {
   const auto& sink_config =
       MessageUtil::downcastAndValidate<const envoy::config::metrics::v3::DogStatsdSink&>(
           config, server.messageValidationContext().staticValidationVisitor());
   auto address_or_error = Network::Address::resolveProtoAddress(sink_config.address());
-  THROW_IF_NOT_OK_REF(address_or_error.status());
+  RETURN_IF_NOT_OK_REF(address_or_error.status());
   Network::Address::InstanceConstSharedPtr address = address_or_error.value();
   ENVOY_LOG(debug, "dog_statsd UDP ip address: {}", address->asString());
   absl::optional<uint64_t> max_bytes;

--- a/source/extensions/stat_sinks/dog_statsd/config.h
+++ b/source/extensions/stat_sinks/dog_statsd/config.h
@@ -18,8 +18,9 @@ constexpr char DogStatsdName[] = "envoy.stat_sinks.dog_statsd";
 class DogStatsdSinkFactory : Logger::Loggable<Logger::Id::config>,
                              public Server::Configuration::StatsSinkFactory {
 public:
-  Stats::SinkPtr createStatsSink(const Protobuf::Message& config,
-                                 Server::Configuration::ServerFactoryContext& server) override;
+  absl::StatusOr<Stats::SinkPtr>
+  createStatsSink(const Protobuf::Message& config,
+                  Server::Configuration::ServerFactoryContext& server) override;
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override;
 

--- a/source/extensions/stat_sinks/graphite_statsd/config.cc
+++ b/source/extensions/stat_sinks/graphite_statsd/config.cc
@@ -15,7 +15,7 @@ namespace Extensions {
 namespace StatSinks {
 namespace GraphiteStatsd {
 
-Stats::SinkPtr
+absl::StatusOr<Stats::SinkPtr>
 GraphiteStatsdSinkFactory::createStatsSink(const Protobuf::Message& config,
                                            Server::Configuration::ServerFactoryContext& server) {
 
@@ -26,7 +26,7 @@ GraphiteStatsdSinkFactory::createStatsSink(const Protobuf::Message& config,
   case envoy::extensions::stat_sinks::graphite_statsd::v3::GraphiteStatsdSink::StatsdSpecifierCase::
       kAddress: {
     auto address_or_error = Network::Address::resolveProtoAddress(statsd_sink.address());
-    THROW_IF_NOT_OK_REF(address_or_error.status());
+    RETURN_IF_NOT_OK_REF(address_or_error.status());
     Network::Address::InstanceConstSharedPtr address = address_or_error.value();
     ENVOY_LOG(debug, "statsd UDP ip address: {}", address->asString());
     absl::optional<uint64_t> max_bytes;

--- a/source/extensions/stat_sinks/graphite_statsd/config.h
+++ b/source/extensions/stat_sinks/graphite_statsd/config.h
@@ -16,8 +16,9 @@ class GraphiteStatsdSinkFactory : Logger::Loggable<Logger::Id::config>,
                                   public Server::Configuration::StatsSinkFactory {
 public:
   // GraphiteStatsSinkFactory
-  Stats::SinkPtr createStatsSink(const Protobuf::Message& config,
-                                 Server::Configuration::ServerFactoryContext& server) override;
+  absl::StatusOr<Stats::SinkPtr>
+  createStatsSink(const Protobuf::Message& config,
+                  Server::Configuration::ServerFactoryContext& server) override;
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override;
 

--- a/source/extensions/stat_sinks/hystrix/config.cc
+++ b/source/extensions/stat_sinks/hystrix/config.cc
@@ -14,7 +14,7 @@ namespace Extensions {
 namespace StatSinks {
 namespace Hystrix {
 
-Stats::SinkPtr
+absl::StatusOr<Stats::SinkPtr>
 HystrixSinkFactory::createStatsSink(const Protobuf::Message& config,
                                     Server::Configuration::ServerFactoryContext& server) {
   const auto& hystrix_sink =

--- a/source/extensions/stat_sinks/hystrix/config.h
+++ b/source/extensions/stat_sinks/hystrix/config.h
@@ -18,8 +18,9 @@ class HystrixSinkFactory : Logger::Loggable<Logger::Id::config>,
                            public Server::Configuration::StatsSinkFactory {
 public:
   // StatsSinkFactory
-  Stats::SinkPtr createStatsSink(const Protobuf::Message& config,
-                                 Server::Configuration::ServerFactoryContext& server) override;
+  absl::StatusOr<Stats::SinkPtr>
+  createStatsSink(const Protobuf::Message& config,
+                  Server::Configuration::ServerFactoryContext& server) override;
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override;
 

--- a/source/extensions/stat_sinks/metrics_service/config.cc
+++ b/source/extensions/stat_sinks/metrics_service/config.cc
@@ -25,7 +25,7 @@ MetricsServiceSinkFactory::createStatsSink(const Protobuf::Message& config,
       MessageUtil::downcastAndValidate<const envoy::config::metrics::v3::MetricsServiceConfig&>(
           config, server.messageValidationContext().staticValidationVisitor());
   const auto& grpc_service = sink_config.grpc_service();
-  RETURN_IF_NOT_OK_REF(Config::Utility::checkTransportVersion(sink_config));
+  RETURN_IF_NOT_OK(Config::Utility::checkTransportVersion(sink_config));
   ENVOY_LOG(debug, "Metrics Service gRPC service configuration: {}", grpc_service.DebugString());
 
   auto client_or_error = server.clusterManager().grpcAsyncClientManager().getOrCreateRawAsyncClient(

--- a/source/extensions/stat_sinks/metrics_service/config.cc
+++ b/source/extensions/stat_sinks/metrics_service/config.cc
@@ -16,7 +16,7 @@ namespace Extensions {
 namespace StatSinks {
 namespace MetricsService {
 
-Stats::SinkPtr
+absl::StatusOr<Stats::SinkPtr>
 MetricsServiceSinkFactory::createStatsSink(const Protobuf::Message& config,
                                            Server::Configuration::ServerFactoryContext& server) {
   validateProtoDescriptors();
@@ -25,12 +25,12 @@ MetricsServiceSinkFactory::createStatsSink(const Protobuf::Message& config,
       MessageUtil::downcastAndValidate<const envoy::config::metrics::v3::MetricsServiceConfig&>(
           config, server.messageValidationContext().staticValidationVisitor());
   const auto& grpc_service = sink_config.grpc_service();
-  THROW_IF_NOT_OK(Config::Utility::checkTransportVersion(sink_config));
+  RETURN_IF_NOT_OK_REF(Config::Utility::checkTransportVersion(sink_config));
   ENVOY_LOG(debug, "Metrics Service gRPC service configuration: {}", grpc_service.DebugString());
 
   auto client_or_error = server.clusterManager().grpcAsyncClientManager().getOrCreateRawAsyncClient(
       grpc_service, server.scope(), false);
-  THROW_IF_NOT_OK_REF(client_or_error.status());
+  RETURN_IF_NOT_OK_REF(client_or_error.status());
   std::shared_ptr<GrpcMetricsStreamer<envoy::service::metrics::v3::StreamMetricsMessage,
                                       envoy::service::metrics::v3::StreamMetricsResponse>>
       grpc_metrics_streamer =

--- a/source/extensions/stat_sinks/metrics_service/config.h
+++ b/source/extensions/stat_sinks/metrics_service/config.h
@@ -19,8 +19,9 @@ constexpr char MetricsServiceName[] = "envoy.stat_sinks.metrics_service";
 class MetricsServiceSinkFactory : Logger::Loggable<Logger::Id::config>,
                                   public Server::Configuration::StatsSinkFactory {
 public:
-  Stats::SinkPtr createStatsSink(const Protobuf::Message& config,
-                                 Server::Configuration::ServerFactoryContext& server) override;
+  absl::StatusOr<Stats::SinkPtr>
+  createStatsSink(const Protobuf::Message& config,
+                  Server::Configuration::ServerFactoryContext& server) override;
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override;
 

--- a/source/extensions/stat_sinks/metrics_service/grpc_metrics_service_impl.cc
+++ b/source/extensions/stat_sinks/metrics_service/grpc_metrics_service_impl.cc
@@ -2,7 +2,6 @@
 
 #include <chrono>
 
-#include "envoy/common/exception.h"
 #include "envoy/config/metrics/v3/metrics_service.pb.h"
 #include "envoy/event/dispatcher.h"
 #include "envoy/service/metrics/v3/metrics_service.pb.h"

--- a/source/extensions/stat_sinks/open_telemetry/config.cc
+++ b/source/extensions/stat_sinks/open_telemetry/config.cc
@@ -10,7 +10,7 @@ namespace Extensions {
 namespace StatSinks {
 namespace OpenTelemetry {
 
-Stats::SinkPtr
+absl::StatusOr<Stats::SinkPtr>
 OpenTelemetrySinkFactory::createStatsSink(const Protobuf::Message& config,
                                           Server::Configuration::ServerFactoryContext& server) {
   validateProtoDescriptors();
@@ -29,7 +29,7 @@ OpenTelemetrySinkFactory::createStatsSink(const Protobuf::Message& config,
     auto client_or_error =
         server.clusterManager().grpcAsyncClientManager().getOrCreateRawAsyncClient(
             grpc_service, server.scope(), false);
-    THROW_IF_NOT_OK_REF(client_or_error.status());
+    RETURN_IF_NOT_OK_REF(client_or_error.status());
     std::shared_ptr<OpenTelemetryGrpcMetricsExporter> grpc_metrics_exporter =
         std::make_shared<OpenTelemetryGrpcMetricsExporterImpl>(otlp_options,
                                                                client_or_error.value());
@@ -41,7 +41,7 @@ OpenTelemetrySinkFactory::createStatsSink(const Protobuf::Message& config,
     break;
   }
 
-  throw EnvoyException("unexpected Open Telemetry protocol case num");
+  return absl::InvalidArgumentError("unexpected Open Telemetry protocol case num");
 }
 
 ProtobufTypes::MessagePtr OpenTelemetrySinkFactory::createEmptyConfigProto() {

--- a/source/extensions/stat_sinks/open_telemetry/config.h
+++ b/source/extensions/stat_sinks/open_telemetry/config.h
@@ -18,8 +18,9 @@ constexpr char OpenTelemetryName[] = "envoy.stat_sinks.open_telemetry";
 class OpenTelemetrySinkFactory : Logger::Loggable<Logger::Id::config>,
                                  public Server::Configuration::StatsSinkFactory {
 public:
-  Stats::SinkPtr createStatsSink(const Protobuf::Message& config,
-                                 Server::Configuration::ServerFactoryContext& server) override;
+  absl::StatusOr<Stats::SinkPtr>
+  createStatsSink(const Protobuf::Message& config,
+                  Server::Configuration::ServerFactoryContext& server) override;
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override;
 

--- a/source/extensions/stat_sinks/statsd/config.cc
+++ b/source/extensions/stat_sinks/statsd/config.cc
@@ -14,7 +14,7 @@ namespace Extensions {
 namespace StatSinks {
 namespace Statsd {
 
-Stats::SinkPtr
+absl::StatusOr<Stats::SinkPtr>
 StatsdSinkFactory::createStatsSink(const Protobuf::Message& config,
                                    Server::Configuration::ServerFactoryContext& server) {
 
@@ -24,7 +24,7 @@ StatsdSinkFactory::createStatsSink(const Protobuf::Message& config,
   switch (statsd_sink.statsd_specifier_case()) {
   case envoy::config::metrics::v3::StatsdSink::StatsdSpecifierCase::kAddress: {
     auto address_or_error = Network::Address::resolveProtoAddress(statsd_sink.address());
-    THROW_IF_NOT_OK_REF(address_or_error.status());
+    RETURN_IF_NOT_OK_REF(address_or_error.status());
     Network::Address::InstanceConstSharedPtr address = address_or_error.value();
     ENVOY_LOG(debug, "statsd UDP ip address: {}", address->asString());
     return std::make_unique<Common::Statsd::UdpStatsdSink>(server.threadLocal(), std::move(address),
@@ -32,9 +32,9 @@ StatsdSinkFactory::createStatsSink(const Protobuf::Message& config,
   }
   case envoy::config::metrics::v3::StatsdSink::StatsdSpecifierCase::kTcpClusterName:
     ENVOY_LOG(debug, "statsd TCP cluster: {}", statsd_sink.tcp_cluster_name());
-    return std::make_unique<Common::Statsd::TcpStatsdSink>(
-        server.localInfo(), statsd_sink.tcp_cluster_name(), server.threadLocal(),
-        server.clusterManager(), server.scope(), statsd_sink.prefix());
+    return Common::Statsd::TcpStatsdSink::create(server.localInfo(), statsd_sink.tcp_cluster_name(),
+                                                 server.threadLocal(), server.clusterManager(),
+                                                 server.scope(), statsd_sink.prefix());
   case envoy::config::metrics::v3::StatsdSink::StatsdSpecifierCase::STATSD_SPECIFIER_NOT_SET:
     break; // Fall through to PANIC
   }

--- a/source/extensions/stat_sinks/statsd/config.h
+++ b/source/extensions/stat_sinks/statsd/config.h
@@ -19,8 +19,9 @@ class StatsdSinkFactory : Logger::Loggable<Logger::Id::config>,
                           public Server::Configuration::StatsSinkFactory {
 public:
   // StatsSinkFactory
-  Stats::SinkPtr createStatsSink(const Protobuf::Message& config,
-                                 Server::Configuration::ServerFactoryContext& server) override;
+  absl::StatusOr<Stats::SinkPtr>
+  createStatsSink(const Protobuf::Message& config,
+                  Server::Configuration::ServerFactoryContext& server) override;
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override;
 

--- a/source/extensions/stat_sinks/wasm/config.cc
+++ b/source/extensions/stat_sinks/wasm/config.cc
@@ -14,7 +14,7 @@ namespace Extensions {
 namespace StatSinks {
 namespace Wasm {
 
-Stats::SinkPtr
+absl::StatusOr<Stats::SinkPtr>
 WasmSinkFactory::createStatsSink(const Protobuf::Message& proto_config,
                                  Server::Configuration::ServerFactoryContext& context) {
   const auto& config =

--- a/source/extensions/stat_sinks/wasm/config.h
+++ b/source/extensions/stat_sinks/wasm/config.h
@@ -24,8 +24,9 @@ class WasmSinkFactory : Logger::Loggable<Logger::Id::config>,
                         public Server::Configuration::StatsSinkFactory {
 public:
   // StatsSinkFactory
-  Stats::SinkPtr createStatsSink(const Protobuf::Message& config,
-                                 Server::Configuration::ServerFactoryContext& context) override;
+  absl::StatusOr<Stats::SinkPtr>
+  createStatsSink(const Protobuf::Message& config,
+                  Server::Configuration::ServerFactoryContext& context) override;
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override;
 

--- a/source/server/configuration_impl.cc
+++ b/source/server/configuration_impl.cc
@@ -145,12 +145,12 @@ absl::Status MainImpl::initialize(const envoy::config::bootstrap::v3::Bootstrap&
   RETURN_IF_NOT_OK(initializeWatchdogs(bootstrap, server));
   // This has to happen after ClusterManager initialization, as it depends on config from
   // ClusterManager.
-  initializeStatsConfig(bootstrap, server);
-  return absl::OkStatus();
+  return initializeStatsConfig(bootstrap, server);
 }
 
-void MainImpl::initializeStatsConfig(const envoy::config::bootstrap::v3::Bootstrap& bootstrap,
-                                     Instance& server) {
+absl::Status
+MainImpl::initializeStatsConfig(const envoy::config::bootstrap::v3::Bootstrap& bootstrap,
+                                Instance& server) {
   ENVOY_LOG(info, "loading stats configuration");
 
   for (const envoy::config::metrics::v3::StatsSink& sink_object : bootstrap.stats_sinks()) {
@@ -159,8 +159,11 @@ void MainImpl::initializeStatsConfig(const envoy::config::bootstrap::v3::Bootstr
     ProtobufTypes::MessagePtr message = Config::Utility::translateToFactoryConfig(
         sink_object, server.messageValidationContext().staticValidationVisitor(), factory);
 
-    stats_config_->addSink(factory.createStatsSink(*message, server.serverFactoryContext()));
+    auto sink = factory.createStatsSink(*message, server.serverFactoryContext());
+    RETURN_IF_NOT_OK_REF(sink.status());
+    stats_config_->addSink(std::move(sink.value()));
   }
+  return absl::OkStatus();
 }
 
 void MainImpl::initializeTracers(const envoy::config::trace::v3::Tracing& configuration,

--- a/source/server/configuration_impl.h
+++ b/source/server/configuration_impl.h
@@ -37,12 +37,13 @@ public:
   /**
    * Create a particular Stats::Sink implementation. If the implementation is unable to produce a
    * Stats::Sink with the provided parameters, it should throw an EnvoyException. The returned
-   * pointer should always be valid.
+   * pointer should always be valid when status is OK.
    * @param config supplies the custom proto configuration for the Stats::Sink
    * @param server supplies the server instance
    */
-  virtual Stats::SinkPtr createStatsSink(const Protobuf::Message& config,
-                                         Server::Configuration::ServerFactoryContext& server) PURE;
+  virtual absl::StatusOr<Stats::SinkPtr>
+  createStatsSink(const Protobuf::Message& config,
+                  Server::Configuration::ServerFactoryContext& server) PURE;
 
   std::string category() const override { return "envoy.stats_sinks"; }
 };
@@ -145,8 +146,8 @@ private:
   /**
    * Initialize stats configuration.
    */
-  void initializeStatsConfig(const envoy::config::bootstrap::v3::Bootstrap& bootstrap,
-                             Instance& server);
+  absl::Status initializeStatsConfig(const envoy::config::bootstrap::v3::Bootstrap& bootstrap,
+                                     Instance& server);
 
   /**
    * Initialize watchdog(s). Call before accessing any watchdog configuration.

--- a/test/extensions/stats_sinks/common/statsd/statsd_test.cc
+++ b/test/extensions/stats_sinks/common/statsd/statsd_test.cc
@@ -193,11 +193,10 @@ TEST_F(TcpStatsdSinkTest, NoHost) {
 }
 
 TEST_F(TcpStatsdSinkTest, WithCustomPrefix) {
-  sink_ = TcpStatsdSink::create(
-              local_info_, "fake_cluster", tls_, cluster_manager_,
-              *(cluster_manager_.active_clusters_["fake_cluster"]->info_->stats_store_.rootScope()),
-              "test_prefix")
-              .value();
+  sink_ = *TcpStatsdSink::create(
+      local_info_, "fake_cluster", tls_, cluster_manager_,
+      *(cluster_manager_.active_clusters_["fake_cluster"]->info_->stats_store_.rootScope()),
+      "test_prefix");
 
   NiceMock<Stats::MockCounter> counter;
   counter.name_ = "test_counter";

--- a/test/extensions/stats_sinks/common/statsd/statsd_test.cc
+++ b/test/extensions/stats_sinks/common/statsd/statsd_test.cc
@@ -37,9 +37,11 @@ public:
   TcpStatsdSinkTest() {
     cluster_manager_.initializeClusters({"fake_cluster"}, {});
     cluster_manager_.initializeThreadLocalClusters({"fake_cluster"});
-    sink_ = std::make_unique<TcpStatsdSink>(
-        local_info_, "fake_cluster", tls_, cluster_manager_,
-        *(cluster_manager_.active_clusters_["fake_cluster"]->info_->stats_store_.rootScope()));
+    sink_ =
+        TcpStatsdSink::create(
+            local_info_, "fake_cluster", tls_, cluster_manager_,
+            *(cluster_manager_.active_clusters_["fake_cluster"]->info_->stats_store_.rootScope()))
+            .value();
   }
 
   void expectCreateConnection() {
@@ -191,10 +193,11 @@ TEST_F(TcpStatsdSinkTest, NoHost) {
 }
 
 TEST_F(TcpStatsdSinkTest, WithCustomPrefix) {
-  sink_ = std::make_unique<TcpStatsdSink>(
-      local_info_, "fake_cluster", tls_, cluster_manager_,
-      *(cluster_manager_.active_clusters_["fake_cluster"]->info_->stats_store_.rootScope()),
-      "test_prefix");
+  sink_ = TcpStatsdSink::create(
+              local_info_, "fake_cluster", tls_, cluster_manager_,
+              *(cluster_manager_.active_clusters_["fake_cluster"]->info_->stats_store_.rootScope()),
+              "test_prefix")
+              .value();
 
   NiceMock<Stats::MockCounter> counter;
   counter.name_ = "test_counter";

--- a/test/extensions/stats_sinks/dog_statsd/config_test.cc
+++ b/test/extensions/stats_sinks/dog_statsd/config_test.cc
@@ -46,7 +46,7 @@ TEST_P(DogStatsdConfigLoopbackTest, ValidUdpIp) {
   TestUtility::jsonConvert(sink_config, *message);
 
   NiceMock<Server::Configuration::MockServerFactoryContext> server;
-  Stats::SinkPtr sink = factory->createStatsSink(*message, server);
+  Stats::SinkPtr sink = factory->createStatsSink(*message, server).value();
   EXPECT_NE(sink, nullptr);
   auto udp_sink = dynamic_cast<Common::Statsd::UdpStatsdSink*>(sink.get());
   EXPECT_NE(udp_sink, nullptr);
@@ -57,9 +57,10 @@ TEST_P(DogStatsdConfigLoopbackTest, ValidUdpIp) {
 // Negative test for protoc-gen-validate constraints for dog_statsd.
 TEST(DogStatsdConfigTest, ValidateFail) {
   NiceMock<Server::Configuration::MockServerFactoryContext> server;
-  EXPECT_THROW(
-      DogStatsdSinkFactory().createStatsSink(envoy::config::metrics::v3::DogStatsdSink(), server),
-      ProtoValidationException);
+  EXPECT_THROW(DogStatsdSinkFactory()
+                   .createStatsSink(envoy::config::metrics::v3::DogStatsdSink(), server)
+                   .value(),
+               ProtoValidationException);
 }
 
 TEST_P(DogStatsdConfigLoopbackTest, CustomBufferSize) {
@@ -81,7 +82,7 @@ TEST_P(DogStatsdConfigLoopbackTest, CustomBufferSize) {
   TestUtility::jsonConvert(sink_config, *message);
 
   NiceMock<Server::Configuration::MockServerFactoryContext> server;
-  Stats::SinkPtr sink = factory->createStatsSink(*message, server);
+  Stats::SinkPtr sink = factory->createStatsSink(*message, server).value();
   ASSERT_NE(sink, nullptr);
   auto udp_sink = dynamic_cast<Common::Statsd::UdpStatsdSink*>(sink.get());
   ASSERT_NE(udp_sink, nullptr);
@@ -106,7 +107,7 @@ TEST_P(DogStatsdConfigLoopbackTest, DefaultBufferSize) {
   TestUtility::jsonConvert(sink_config, *message);
 
   NiceMock<Server::Configuration::MockServerFactoryContext> server;
-  Stats::SinkPtr sink = factory->createStatsSink(*message, server);
+  Stats::SinkPtr sink = factory->createStatsSink(*message, server).value();
   ASSERT_NE(sink, nullptr);
   auto udp_sink = dynamic_cast<Common::Statsd::UdpStatsdSink*>(sink.get());
   ASSERT_NE(udp_sink, nullptr);
@@ -135,7 +136,7 @@ TEST_P(DogStatsdConfigLoopbackTest, WithCustomPrefix) {
   TestUtility::jsonConvert(sink_config, *message);
 
   NiceMock<Server::Configuration::MockServerFactoryContext> server;
-  Stats::SinkPtr sink = factory->createStatsSink(*message, server);
+  Stats::SinkPtr sink = factory->createStatsSink(*message, server).value();
   ASSERT_NE(sink, nullptr);
   auto udp_sink = dynamic_cast<Common::Statsd::UdpStatsdSink*>(sink.get());
   ASSERT_NE(udp_sink, nullptr);

--- a/test/extensions/stats_sinks/graphite_statsd/config_test.cc
+++ b/test/extensions/stats_sinks/graphite_statsd/config_test.cc
@@ -54,7 +54,7 @@ TEST_P(GraphiteStatsdConfigLoopbackTest, ValidUdpIp) {
   TestUtility::jsonConvert(sink_config, *message);
 
   NiceMock<Server::Configuration::MockServerFactoryContext> server;
-  Stats::SinkPtr sink = factory->createStatsSink(*message, server);
+  Stats::SinkPtr sink = factory->createStatsSink(*message, server).value();
   EXPECT_NE(sink, nullptr);
   auto udp_sink = dynamic_cast<Common::Statsd::UdpStatsdSink*>(sink.get());
   EXPECT_NE(udp_sink, nullptr);
@@ -66,8 +66,10 @@ TEST_P(GraphiteStatsdConfigLoopbackTest, ValidUdpIp) {
 TEST(GraphiteStatsdConfigTest, ValidateFail) {
   NiceMock<Server::Configuration::MockServerFactoryContext> server;
   EXPECT_THROW(
-      GraphiteStatsdSinkFactory().createStatsSink(
-          envoy::extensions::stat_sinks::graphite_statsd::v3::GraphiteStatsdSink(), server),
+      GraphiteStatsdSinkFactory()
+          .createStatsSink(envoy::extensions::stat_sinks::graphite_statsd::v3::GraphiteStatsdSink(),
+                           server)
+          .value(),
       ProtoValidationException);
 }
 
@@ -92,7 +94,8 @@ TEST_P(GraphiteStatsdConfigLoopbackTest, CustomBufferSize) {
   TestUtility::jsonConvert(sink_config, *message);
 
   NiceMock<Server::Configuration::MockServerFactoryContext> server;
-  Stats::SinkPtr sink = factory->createStatsSink(*message, server);
+  Stats::SinkPtr sink = factory->createStatsSink(*message, server).value();
+  ;
   ASSERT_NE(sink, nullptr);
   auto udp_sink = dynamic_cast<Common::Statsd::UdpStatsdSink*>(sink.get());
   ASSERT_NE(udp_sink, nullptr);
@@ -119,7 +122,8 @@ TEST_P(GraphiteStatsdConfigLoopbackTest, DefaultBufferSize) {
   TestUtility::jsonConvert(sink_config, *message);
 
   NiceMock<Server::Configuration::MockServerFactoryContext> server;
-  Stats::SinkPtr sink = factory->createStatsSink(*message, server);
+  Stats::SinkPtr sink = factory->createStatsSink(*message, server).value();
+  ;
   ASSERT_NE(sink, nullptr);
   auto udp_sink = dynamic_cast<Common::Statsd::UdpStatsdSink*>(sink.get());
   ASSERT_NE(udp_sink, nullptr);
@@ -150,7 +154,8 @@ TEST_P(GraphiteStatsdConfigLoopbackTest, WithCustomPrefix) {
   TestUtility::jsonConvert(sink_config, *message);
 
   NiceMock<Server::Configuration::MockServerFactoryContext> server;
-  Stats::SinkPtr sink = factory->createStatsSink(*message, server);
+  Stats::SinkPtr sink = factory->createStatsSink(*message, server).value();
+  ;
   ASSERT_NE(sink, nullptr);
   auto udp_sink = dynamic_cast<Common::Statsd::UdpStatsdSink*>(sink.get());
   ASSERT_NE(udp_sink, nullptr);

--- a/test/extensions/stats_sinks/hystrix/config_test.cc
+++ b/test/extensions/stats_sinks/hystrix/config_test.cc
@@ -32,7 +32,8 @@ TEST(StatsConfigTest, ValidHystrixSink) {
   TestUtility::jsonConvert(sink_config, *message);
 
   NiceMock<Server::Configuration::MockServerFactoryContext> server;
-  Stats::SinkPtr sink = factory->createStatsSink(*message, server);
+  Stats::SinkPtr sink = factory->createStatsSink(*message, server).value();
+  ;
   EXPECT_NE(sink, nullptr);
   EXPECT_NE(dynamic_cast<Hystrix::HystrixSink*>(sink.get()), nullptr);
 }

--- a/test/extensions/stats_sinks/open_telemetry/config_test.cc
+++ b/test/extensions/stats_sinks/open_telemetry/config_test.cc
@@ -29,7 +29,7 @@ TEST(OpenTelemetryConfigTest, OpenTelemetrySinkType) {
     ProtobufTypes::MessagePtr message = factory->createEmptyConfigProto();
     TestUtility::jsonConvert(sink_config, *message);
 
-    EXPECT_THROW(factory->createStatsSink(*message, server), EnvoyException);
+    EXPECT_THROW(factory->createStatsSink(*message, server).value(), ProtoValidationException);
   }
 
   {
@@ -38,7 +38,7 @@ TEST(OpenTelemetryConfigTest, OpenTelemetrySinkType) {
     ProtobufTypes::MessagePtr message = factory->createEmptyConfigProto();
     TestUtility::jsonConvert(sink_config, *message);
 
-    Stats::SinkPtr sink = factory->createStatsSink(*message, server);
+    Stats::SinkPtr sink = factory->createStatsSink(*message, server).value();
     EXPECT_NE(sink, nullptr);
     EXPECT_NE(dynamic_cast<OpenTelemetry::OpenTelemetryGrpcSink*>(sink.get()), nullptr);
   }

--- a/test/extensions/stats_sinks/statsd/config_test.cc
+++ b/test/extensions/stats_sinks/statsd/config_test.cc
@@ -37,7 +37,7 @@ TEST(StatsConfigTest, ValidTcpStatsd) {
 
   NiceMock<Server::Configuration::MockServerFactoryContext> server;
   server.cluster_manager_.initializeClusters({"fake_cluster"}, {});
-  Stats::SinkPtr sink = factory->createStatsSink(*message, server);
+  Stats::SinkPtr sink = factory->createStatsSink(*message, server).value();
   EXPECT_NE(sink, nullptr);
   EXPECT_NE(dynamic_cast<Common::Statsd::TcpStatsdSink*>(sink.get()), nullptr);
 }
@@ -70,7 +70,7 @@ TEST_P(StatsConfigParameterizedTest, UdpSinkDefaultPrefix) {
   TestUtility::jsonConvert(sink_config, *message);
 
   NiceMock<Server::Configuration::MockServerFactoryContext> server;
-  Stats::SinkPtr sink = factory->createStatsSink(*message, server);
+  Stats::SinkPtr sink = factory->createStatsSink(*message, server).value();
   ASSERT_NE(sink, nullptr);
 
   auto udp_sink = dynamic_cast<Common::Statsd::UdpStatsdSink*>(sink.get());
@@ -101,7 +101,7 @@ TEST_P(StatsConfigParameterizedTest, UdpSinkCustomPrefix) {
   TestUtility::jsonConvert(sink_config, *message);
 
   NiceMock<Server::Configuration::MockServerFactoryContext> server;
-  Stats::SinkPtr sink = factory->createStatsSink(*message, server);
+  Stats::SinkPtr sink = factory->createStatsSink(*message, server).value();
   ASSERT_NE(sink, nullptr);
 
   auto udp_sink = dynamic_cast<Common::Statsd::UdpStatsdSink*>(sink.get());
@@ -123,7 +123,7 @@ TEST(StatsConfigTest, TcpSinkDefaultPrefix) {
 
   NiceMock<Server::Configuration::MockServerFactoryContext> server;
   server.cluster_manager_.initializeClusters({"fake_cluster"}, {});
-  Stats::SinkPtr sink = factory->createStatsSink(*message, server);
+  Stats::SinkPtr sink = factory->createStatsSink(*message, server).value();
   ASSERT_NE(sink, nullptr);
 
   auto tcp_sink = dynamic_cast<Common::Statsd::TcpStatsdSink*>(sink.get());
@@ -147,7 +147,7 @@ TEST(StatsConfigTest, TcpSinkCustomPrefix) {
 
   NiceMock<Server::Configuration::MockServerFactoryContext> server;
   server.cluster_manager_.initializeClusters({"fake_cluster"}, {});
-  Stats::SinkPtr sink = factory->createStatsSink(*message, server);
+  Stats::SinkPtr sink = factory->createStatsSink(*message, server).value();
   ASSERT_NE(sink, nullptr);
 
   auto tcp_sink = dynamic_cast<Common::Statsd::TcpStatsdSink*>(sink.get());
@@ -177,7 +177,7 @@ TEST_P(StatsConfigLoopbackTest, ValidUdpIpStatsd) {
   TestUtility::jsonConvert(sink_config, *message);
 
   NiceMock<Server::Configuration::MockServerFactoryContext> server;
-  Stats::SinkPtr sink = factory->createStatsSink(*message, server);
+  Stats::SinkPtr sink = factory->createStatsSink(*message, server).value();
   EXPECT_NE(sink, nullptr);
   EXPECT_NE(dynamic_cast<Common::Statsd::UdpStatsdSink*>(sink.get()), nullptr);
   EXPECT_EQ(dynamic_cast<Common::Statsd::UdpStatsdSink*>(sink.get())->getUseTagForTest(), false);
@@ -186,9 +186,9 @@ TEST_P(StatsConfigLoopbackTest, ValidUdpIpStatsd) {
 // Negative test for protoc-gen-validate constraints for statsd.
 TEST(StatsdConfigTest, ValidateFail) {
   NiceMock<Server::Configuration::MockServerFactoryContext> server;
-  EXPECT_THROW(
-      StatsdSinkFactory().createStatsSink(envoy::config::metrics::v3::StatsdSink(), server),
-      ProtoValidationException);
+  EXPECT_THROW(auto sink = StatsdSinkFactory().createStatsSink(
+                   envoy::config::metrics::v3::StatsdSink(), server),
+               ProtoValidationException);
 }
 
 } // namespace

--- a/test/extensions/stats_sinks/statsd/config_test.cc
+++ b/test/extensions/stats_sinks/statsd/config_test.cc
@@ -186,9 +186,9 @@ TEST_P(StatsConfigLoopbackTest, ValidUdpIpStatsd) {
 // Negative test for protoc-gen-validate constraints for statsd.
 TEST(StatsdConfigTest, ValidateFail) {
   NiceMock<Server::Configuration::MockServerFactoryContext> server;
-  EXPECT_THROW(auto sink = StatsdSinkFactory().createStatsSink(
-                   envoy::config::metrics::v3::StatsdSink(), server),
-               ProtoValidationException);
+  EXPECT_THROW(
+      StatsdSinkFactory().createStatsSink(envoy::config::metrics::v3::StatsdSink(), server).value(),
+      ProtoValidationException);
 }
 
 } // namespace

--- a/test/extensions/stats_sinks/wasm/config_test.cc
+++ b/test/extensions/stats_sinks/wasm/config_test.cc
@@ -49,7 +49,7 @@ protected:
     EXPECT_CALL(context_, initManager()).WillRepeatedly(testing::ReturnRef(init_manager_));
     EXPECT_CALL(context_, lifecycleNotifier())
         .WillRepeatedly(testing::ReturnRef(lifecycle_notifier_));
-    sink_ = factory->createStatsSink(config, context_);
+    sink_ = factory->createStatsSink(config, context_).value();
     EXPECT_CALL(init_watcher_, ready());
     init_manager_.initialize(init_watcher_);
   }

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -365,8 +365,9 @@ private:
 class CustomStatsSinkFactory : public Server::Configuration::StatsSinkFactory {
 public:
   // StatsSinkFactory
-  Stats::SinkPtr createStatsSink(const Protobuf::Message&,
-                                 Server::Configuration::ServerFactoryContext& server) override {
+  absl::StatusOr<Stats::SinkPtr>
+  createStatsSink(const Protobuf::Message&,
+                  Server::Configuration::ServerFactoryContext& server) override {
     return std::make_unique<CustomStatsSink>(server.scope());
   }
 
@@ -1642,8 +1643,9 @@ private:
 class CallbacksStatsSinkFactory : public Server::Configuration::StatsSinkFactory {
 public:
   // StatsSinkFactory
-  Stats::SinkPtr createStatsSink(const Protobuf::Message&,
-                                 Server::Configuration::ServerFactoryContext& server) override {
+  absl::StatusOr<Stats::SinkPtr>
+  createStatsSink(const Protobuf::Message&,
+                  Server::Configuration::ServerFactoryContext& server) override {
     return std::make_unique<CallbacksStatsSink>(server);
   }
 

--- a/tools/code_format/config.yaml
+++ b/tools/code_format/config.yaml
@@ -228,7 +228,6 @@ paths:
     - source/extensions/rate_limit_descriptors
     - source/extensions/resource_monitors
     - source/extensions/router/cluster_specifiers/lua/lua_cluster_specifier.cc
-    - source/extensions/stat_sinks
     - source/extensions/string_matcher/lua/match.cc
     - source/extensions/tracers
     - source/extensions/transport_sockets/internal_upstream


### PR DESCRIPTION
Commit Message: Remove exceptions from stat_sinks
Additional Description:

This removes the exclusion of stat_sinks extensions from the
allow-list of exceptions.

Risk Level: low
Testing: existing ones
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a

