### PR TITLE
mobile/ci: Remove more unneeded iOS test apps

### DIFF
--- a/.github/workflows/mobile-ios_build.yml
+++ b/.github/workflows/mobile-ios_build.yml
@@ -158,20 +158,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - name: Build swift baseline app
-          app: //test/swift/apps/baseline:app
-          expected-status: 301
-          target: swift-baseline-app
         - name: Build swift experimental app
           args: >-
             --config=mobile-remote-ci-macos-ios
           app: //test/swift/apps/experimental:app
           expected-status: 200
           target: swift-experimental-app
-        - name: Build objc hello world
-          app: //examples/objective-c/hello_world:app
-          expected-status: 301
-          target: objc-hello-world
 
   request:
     secrets:


### PR DESCRIPTION
One test app is sufficient to run on CI and validate that an iOS app can be built and run on iOS platforms. The one app that will be used is //test/swift/apps/experimental:app. It includes various types of test filters for more comprehensive usage. The rest of the apps are deleted to reduce the burden on CI's macos runners.
