### PR TITLE
Return StatusOr from createRouteSpecificFilterConfig for exception removal

### DIFF
--- a/contrib/golang/filters/http/source/config.cc
+++ b/contrib/golang/filters/http/source/config.cc
@@ -48,7 +48,7 @@ Http::FilterFactoryCb GolangFilterConfig::createFilterFactoryFromProtoTyped(
   };
 }
 
- absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
+absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
 GolangFilterConfig::createRouteSpecificFilterConfigTyped(
     const envoy::extensions::filters::http::golang::v3alpha::ConfigsPerRoute& proto_config,
     Server::Configuration::ServerFactoryContext& context, ProtobufMessage::ValidationVisitor&) {

--- a/contrib/golang/filters/http/source/config.cc
+++ b/contrib/golang/filters/http/source/config.cc
@@ -48,7 +48,7 @@ Http::FilterFactoryCb GolangFilterConfig::createFilterFactoryFromProtoTyped(
   };
 }
 
-Router::RouteSpecificFilterConfigConstSharedPtr
+ absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
 GolangFilterConfig::createRouteSpecificFilterConfigTyped(
     const envoy::extensions::filters::http::golang::v3alpha::ConfigsPerRoute& proto_config,
     Server::Configuration::ServerFactoryContext& context, ProtobufMessage::ValidationVisitor&) {

--- a/contrib/golang/filters/http/source/config.h
+++ b/contrib/golang/filters/http/source/config.h
@@ -32,7 +32,7 @@ private:
       const std::string& stats_prefix,
       Server::Configuration::FactoryContext& factory_context) override;
 
-  Router::RouteSpecificFilterConfigConstSharedPtr createRouteSpecificFilterConfigTyped(
+  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr> createRouteSpecificFilterConfigTyped(
       const envoy::extensions::filters::http::golang::v3alpha::ConfigsPerRoute& proto_config,
       Server::Configuration::ServerFactoryContext& context,
       ProtobufMessage::ValidationVisitor& validator) override;

--- a/contrib/golang/filters/http/source/config.h
+++ b/contrib/golang/filters/http/source/config.h
@@ -32,7 +32,8 @@ private:
       const std::string& stats_prefix,
       Server::Configuration::FactoryContext& factory_context) override;
 
-  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr> createRouteSpecificFilterConfigTyped(
+  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
+  createRouteSpecificFilterConfigTyped(
       const envoy::extensions::filters::http::golang::v3alpha::ConfigsPerRoute& proto_config,
       Server::Configuration::ServerFactoryContext& context,
       ProtobufMessage::ValidationVisitor& validator) override;

--- a/envoy/server/filter_config.h
+++ b/envoy/server/filter_config.h
@@ -242,7 +242,7 @@ public:
    * @return RouteSpecificFilterConfigConstSharedPtr allow the filter to pre-process per route
    * config. Returned object will be stored in the loaded route configuration.
    */
-  virtual Router::RouteSpecificFilterConfigConstSharedPtr
+  virtual absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
   createRouteSpecificFilterConfig(const Protobuf::Message&, ServerFactoryContext&,
                                   ProtobufMessage::ValidationVisitor&) {
     return nullptr;

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -2443,7 +2443,8 @@ PerFilterConfigs::createRouteSpecificFilterConfig(
   ProtobufTypes::MessagePtr proto_config = factory->createEmptyRouteConfigProto();
   RETURN_IF_NOT_OK(
       Envoy::Config::Utility::translateOpaqueConfig(typed_config, validator, *proto_config));
-  auto object_status = factory->createRouteSpecificFilterConfig(*proto_config, factory_context, validator);
+  auto object_status =
+      factory->createRouteSpecificFilterConfig(*proto_config, factory_context, validator);
   RETURN_IF_NOT_OK(object_status.status());
   auto object = object_status.value();
   if (object == nullptr) {

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -2443,7 +2443,9 @@ PerFilterConfigs::createRouteSpecificFilterConfig(
   ProtobufTypes::MessagePtr proto_config = factory->createEmptyRouteConfigProto();
   RETURN_IF_NOT_OK(
       Envoy::Config::Utility::translateOpaqueConfig(typed_config, validator, *proto_config));
-  auto object = factory->createRouteSpecificFilterConfig(*proto_config, factory_context, validator);
+  auto object_status = factory->createRouteSpecificFilterConfig(*proto_config, factory_context, validator);
+  RETURN_IF_NOT_OK(object_status.status());
+  auto object = object_status.value();
   if (object == nullptr) {
     if (is_optional) {
       ENVOY_LOG(

--- a/source/extensions/filters/http/aws_lambda/config.cc
+++ b/source/extensions/filters/http/aws_lambda/config.cc
@@ -93,7 +93,7 @@ absl::StatusOr<Http::FilterFactoryCb> AwsLambdaFilterFactory::createFilterFactor
   };
 }
 
- absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
+absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
 AwsLambdaFilterFactory::createRouteSpecificFilterConfigTyped(
     const envoy::extensions::filters::http::aws_lambda::v3::PerRouteConfig& per_route_config,
     Server::Configuration::ServerFactoryContext& server_context,

--- a/source/extensions/filters/http/aws_lambda/config.cc
+++ b/source/extensions/filters/http/aws_lambda/config.cc
@@ -93,7 +93,7 @@ absl::StatusOr<Http::FilterFactoryCb> AwsLambdaFilterFactory::createFilterFactor
   };
 }
 
-Router::RouteSpecificFilterConfigConstSharedPtr
+ absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
 AwsLambdaFilterFactory::createRouteSpecificFilterConfigTyped(
     const envoy::extensions::filters::http::aws_lambda::v3::PerRouteConfig& per_route_config,
     Server::Configuration::ServerFactoryContext& server_context,

--- a/source/extensions/filters/http/aws_lambda/config.h
+++ b/source/extensions/filters/http/aws_lambda/config.h
@@ -30,7 +30,7 @@ private:
       const std::string& stats_prefix, DualInfo dual_info,
       Server::Configuration::ServerFactoryContext& context) override;
 
-  Router::RouteSpecificFilterConfigConstSharedPtr createRouteSpecificFilterConfigTyped(
+   absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>createRouteSpecificFilterConfigTyped(
       const envoy::extensions::filters::http::aws_lambda::v3::PerRouteConfig&,
       Server::Configuration::ServerFactoryContext&, ProtobufMessage::ValidationVisitor&) override;
 };

--- a/source/extensions/filters/http/aws_lambda/config.h
+++ b/source/extensions/filters/http/aws_lambda/config.h
@@ -30,7 +30,8 @@ private:
       const std::string& stats_prefix, DualInfo dual_info,
       Server::Configuration::ServerFactoryContext& context) override;
 
-   absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>createRouteSpecificFilterConfigTyped(
+  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
+  createRouteSpecificFilterConfigTyped(
       const envoy::extensions::filters::http::aws_lambda::v3::PerRouteConfig&,
       Server::Configuration::ServerFactoryContext&, ProtobufMessage::ValidationVisitor&) override;
 };

--- a/source/extensions/filters/http/aws_request_signing/config.cc
+++ b/source/extensions/filters/http/aws_request_signing/config.cc
@@ -102,7 +102,7 @@ AwsRequestSigningFilterFactory::createFilterFactoryFromProtoTyped(
   };
 }
 
- absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
+absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
 AwsRequestSigningFilterFactory::createRouteSpecificFilterConfigTyped(
     const AwsRequestSigningProtoPerRouteConfig& per_route_config,
     Server::Configuration::ServerFactoryContext& context, ProtobufMessage::ValidationVisitor&) {

--- a/source/extensions/filters/http/aws_request_signing/config.cc
+++ b/source/extensions/filters/http/aws_request_signing/config.cc
@@ -102,7 +102,7 @@ AwsRequestSigningFilterFactory::createFilterFactoryFromProtoTyped(
   };
 }
 
-Router::RouteSpecificFilterConfigConstSharedPtr
+ absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
 AwsRequestSigningFilterFactory::createRouteSpecificFilterConfigTyped(
     const AwsRequestSigningProtoPerRouteConfig& per_route_config,
     Server::Configuration::ServerFactoryContext& context, ProtobufMessage::ValidationVisitor&) {

--- a/source/extensions/filters/http/aws_request_signing/config.h
+++ b/source/extensions/filters/http/aws_request_signing/config.h
@@ -31,7 +31,7 @@ private:
                                     const std::string& stats_prefix, DualInfo dual_info,
                                     Server::Configuration::ServerFactoryContext& context) override;
 
-  Router::RouteSpecificFilterConfigConstSharedPtr
+  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
   createRouteSpecificFilterConfigTyped(const AwsRequestSigningProtoPerRouteConfig& per_route_config,
                                        Server::Configuration::ServerFactoryContext& context,
                                        ProtobufMessage::ValidationVisitor&) override;

--- a/source/extensions/filters/http/bandwidth_limit/config.cc
+++ b/source/extensions/filters/http/bandwidth_limit/config.cc
@@ -24,7 +24,7 @@ Http::FilterFactoryCb BandwidthLimitFilterConfig::createFilterFactoryFromProtoTy
   };
 }
 
-Router::RouteSpecificFilterConfigConstSharedPtr
+absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
 BandwidthLimitFilterConfig::createRouteSpecificFilterConfigTyped(
     const envoy::extensions::filters::http::bandwidth_limit::v3::BandwidthLimit& proto_config,
     Server::Configuration::ServerFactoryContext& context, ProtobufMessage::ValidationVisitor&) {

--- a/source/extensions/filters/http/bandwidth_limit/config.h
+++ b/source/extensions/filters/http/bandwidth_limit/config.h
@@ -24,7 +24,8 @@ private:
       const envoy::extensions::filters::http::bandwidth_limit::v3::BandwidthLimit& proto_config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
 
-  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr> createRouteSpecificFilterConfigTyped(
+  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
+  createRouteSpecificFilterConfigTyped(
       const envoy::extensions::filters::http::bandwidth_limit::v3::BandwidthLimit& proto_config,
       Server::Configuration::ServerFactoryContext&, ProtobufMessage::ValidationVisitor&) override;
 };

--- a/source/extensions/filters/http/bandwidth_limit/config.h
+++ b/source/extensions/filters/http/bandwidth_limit/config.h
@@ -24,7 +24,7 @@ private:
       const envoy::extensions::filters::http::bandwidth_limit::v3::BandwidthLimit& proto_config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
 
-  Router::RouteSpecificFilterConfigConstSharedPtr createRouteSpecificFilterConfigTyped(
+  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr> createRouteSpecificFilterConfigTyped(
       const envoy::extensions::filters::http::bandwidth_limit::v3::BandwidthLimit& proto_config,
       Server::Configuration::ServerFactoryContext&, ProtobufMessage::ValidationVisitor&) override;
 };

--- a/source/extensions/filters/http/basic_auth/config.cc
+++ b/source/extensions/filters/http/basic_auth/config.cc
@@ -75,7 +75,7 @@ Http::FilterFactoryCb BasicAuthFilterFactory::createFilterFactoryFromProtoTyped(
   };
 }
 
-Router::RouteSpecificFilterConfigConstSharedPtr
+absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
 BasicAuthFilterFactory::createRouteSpecificFilterConfigTyped(
     const BasicAuthPerRoute& proto_config, Server::Configuration::ServerFactoryContext& context,
     ProtobufMessage::ValidationVisitor&) {

--- a/source/extensions/filters/http/basic_auth/config.h
+++ b/source/extensions/filters/http/basic_auth/config.h
@@ -21,7 +21,7 @@ private:
   Http::FilterFactoryCb createFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::basic_auth::v3::BasicAuth& config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
-  Router::RouteSpecificFilterConfigConstSharedPtr createRouteSpecificFilterConfigTyped(
+  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr> createRouteSpecificFilterConfigTyped(
       const envoy::extensions::filters::http::basic_auth::v3::BasicAuthPerRoute& proto_config,
       Server::Configuration::ServerFactoryContext& context,
       ProtobufMessage::ValidationVisitor&) override;

--- a/source/extensions/filters/http/basic_auth/config.h
+++ b/source/extensions/filters/http/basic_auth/config.h
@@ -21,7 +21,8 @@ private:
   Http::FilterFactoryCb createFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::basic_auth::v3::BasicAuth& config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
-  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr> createRouteSpecificFilterConfigTyped(
+  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
+  createRouteSpecificFilterConfigTyped(
       const envoy::extensions::filters::http::basic_auth::v3::BasicAuthPerRoute& proto_config,
       Server::Configuration::ServerFactoryContext& context,
       ProtobufMessage::ValidationVisitor&) override;

--- a/source/extensions/filters/http/buffer/config.cc
+++ b/source/extensions/filters/http/buffer/config.cc
@@ -26,7 +26,7 @@ absl::StatusOr<Http::FilterFactoryCb> BufferFilterFactory::createFilterFactoryFr
   };
 }
 
-Router::RouteSpecificFilterConfigConstSharedPtr
+absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
 BufferFilterFactory::createRouteSpecificFilterConfigTyped(
     const envoy::extensions::filters::http::buffer::v3::BufferPerRoute& proto_config,
     Server::Configuration::ServerFactoryContext&, ProtobufMessage::ValidationVisitor&) {

--- a/source/extensions/filters/http/buffer/config.h
+++ b/source/extensions/filters/http/buffer/config.h
@@ -25,7 +25,8 @@ private:
       const std::string& stats_prefix, DualInfo,
       Server::Configuration::ServerFactoryContext& context) override;
 
-  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr> createRouteSpecificFilterConfigTyped(
+  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
+  createRouteSpecificFilterConfigTyped(
       const envoy::extensions::filters::http::buffer::v3::BufferPerRoute&,
       Server::Configuration::ServerFactoryContext&, ProtobufMessage::ValidationVisitor&) override;
 };

--- a/source/extensions/filters/http/buffer/config.h
+++ b/source/extensions/filters/http/buffer/config.h
@@ -25,7 +25,7 @@ private:
       const std::string& stats_prefix, DualInfo,
       Server::Configuration::ServerFactoryContext& context) override;
 
-  Router::RouteSpecificFilterConfigConstSharedPtr createRouteSpecificFilterConfigTyped(
+  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr> createRouteSpecificFilterConfigTyped(
       const envoy::extensions::filters::http::buffer::v3::BufferPerRoute&,
       Server::Configuration::ServerFactoryContext&, ProtobufMessage::ValidationVisitor&) override;
 };

--- a/source/extensions/filters/http/common/factory_base.h
+++ b/source/extensions/filters/http/common/factory_base.h
@@ -23,7 +23,7 @@ public:
     return std::make_unique<RouteConfigProto>();
   }
 
-  Router::RouteSpecificFilterConfigConstSharedPtr
+  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
   createRouteSpecificFilterConfig(const Protobuf::Message& proto_config,
                                   Server::Configuration::ServerFactoryContext& context,
                                   ProtobufMessage::ValidationVisitor& validator) override {
@@ -49,7 +49,7 @@ public:
 protected:
   CommonFactoryBase(const std::string& name) : name_(name) {}
 
-  virtual Router::RouteSpecificFilterConfigConstSharedPtr
+  virtual absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
   createRouteSpecificFilterConfigTyped(const RouteConfigProto&,
                                        Server::Configuration::ServerFactoryContext&,
                                        ProtobufMessage::ValidationVisitor&) {

--- a/source/extensions/filters/http/compressor/config.cc
+++ b/source/extensions/filters/http/compressor/config.cc
@@ -35,7 +35,7 @@ absl::StatusOr<Http::FilterFactoryCb> CompressorFilterFactory::createFilterFacto
   };
 }
 
-Router::RouteSpecificFilterConfigConstSharedPtr
+absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
 CompressorFilterFactory::createRouteSpecificFilterConfigTyped(
     const envoy::extensions::filters::http::compressor::v3::CompressorPerRoute& proto_config,
     Server::Configuration::ServerFactoryContext&, ProtobufMessage::ValidationVisitor&) {

--- a/source/extensions/filters/http/compressor/config.h
+++ b/source/extensions/filters/http/compressor/config.h
@@ -25,7 +25,7 @@ private:
       const envoy::extensions::filters::http::compressor::v3::Compressor& proto_config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
 
-  Router::RouteSpecificFilterConfigConstSharedPtr createRouteSpecificFilterConfigTyped(
+  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr> createRouteSpecificFilterConfigTyped(
       const envoy::extensions::filters::http::compressor::v3::CompressorPerRoute& proto_config,
       Server::Configuration::ServerFactoryContext& context,
       ProtobufMessage::ValidationVisitor& validator) override;

--- a/source/extensions/filters/http/compressor/config.h
+++ b/source/extensions/filters/http/compressor/config.h
@@ -25,7 +25,8 @@ private:
       const envoy::extensions::filters::http::compressor::v3::Compressor& proto_config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
 
-  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr> createRouteSpecificFilterConfigTyped(
+  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
+  createRouteSpecificFilterConfigTyped(
       const envoy::extensions::filters::http::compressor::v3::CompressorPerRoute& proto_config,
       Server::Configuration::ServerFactoryContext& context,
       ProtobufMessage::ValidationVisitor& validator) override;

--- a/source/extensions/filters/http/cors/config.cc
+++ b/source/extensions/filters/http/cors/config.cc
@@ -27,7 +27,7 @@ Http::FilterFactoryCb CorsFilterFactory::createFilterFactoryFromProtoTyped(
   };
 }
 
-Router::RouteSpecificFilterConfigConstSharedPtr
+absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
 CorsFilterFactory::createRouteSpecificFilterConfigTyped(
     const envoy::extensions::filters::http::cors::v3::CorsPolicy& policy,
     Server::Configuration::ServerFactoryContext& context, ProtobufMessage::ValidationVisitor&) {

--- a/source/extensions/filters/http/cors/config.h
+++ b/source/extensions/filters/http/cors/config.h
@@ -23,7 +23,8 @@ public:
       const envoy::extensions::filters::http::cors::v3::Cors& proto_config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
 
-  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr> createRouteSpecificFilterConfigTyped(
+  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
+  createRouteSpecificFilterConfigTyped(
       const envoy::extensions::filters::http::cors::v3::CorsPolicy& policy,
       Server::Configuration::ServerFactoryContext& context,
       ProtobufMessage::ValidationVisitor& validator) override;

--- a/source/extensions/filters/http/cors/config.h
+++ b/source/extensions/filters/http/cors/config.h
@@ -23,7 +23,7 @@ public:
       const envoy::extensions::filters::http::cors::v3::Cors& proto_config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
 
-  Router::RouteSpecificFilterConfigConstSharedPtr createRouteSpecificFilterConfigTyped(
+  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr> createRouteSpecificFilterConfigTyped(
       const envoy::extensions::filters::http::cors::v3::CorsPolicy& policy,
       Server::Configuration::ServerFactoryContext& context,
       ProtobufMessage::ValidationVisitor& validator) override;

--- a/source/extensions/filters/http/csrf/config.cc
+++ b/source/extensions/filters/http/csrf/config.cc
@@ -21,7 +21,7 @@ Http::FilterFactoryCb CsrfFilterFactory::createFilterFactoryFromProtoTyped(
   };
 }
 
-Router::RouteSpecificFilterConfigConstSharedPtr
+absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
 CsrfFilterFactory::createRouteSpecificFilterConfigTyped(
     const envoy::extensions::filters::http::csrf::v3::CsrfPolicy& policy,
     Server::Configuration::ServerFactoryContext& context, ProtobufMessage::ValidationVisitor&) {

--- a/source/extensions/filters/http/csrf/config.h
+++ b/source/extensions/filters/http/csrf/config.h
@@ -22,7 +22,8 @@ private:
   Http::FilterFactoryCb createFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::csrf::v3::CsrfPolicy& policy,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
-  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr> createRouteSpecificFilterConfigTyped(
+  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
+  createRouteSpecificFilterConfigTyped(
       const envoy::extensions::filters::http::csrf::v3::CsrfPolicy& policy,
       Server::Configuration::ServerFactoryContext& context,
       ProtobufMessage::ValidationVisitor& validator) override;

--- a/source/extensions/filters/http/csrf/config.h
+++ b/source/extensions/filters/http/csrf/config.h
@@ -22,7 +22,7 @@ private:
   Http::FilterFactoryCb createFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::csrf::v3::CsrfPolicy& policy,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
-  Router::RouteSpecificFilterConfigConstSharedPtr createRouteSpecificFilterConfigTyped(
+  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr> createRouteSpecificFilterConfigTyped(
       const envoy::extensions::filters::http::csrf::v3::CsrfPolicy& policy,
       Server::Configuration::ServerFactoryContext& context,
       ProtobufMessage::ValidationVisitor& validator) override;

--- a/source/extensions/filters/http/custom_response/factory.cc
+++ b/source/extensions/filters/http/custom_response/factory.cc
@@ -18,7 +18,7 @@ namespace CustomResponse {
   };
 }
 
-Router::RouteSpecificFilterConfigConstSharedPtr
+absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
 CustomResponseFilterFactory::createRouteSpecificFilterConfigTyped(
     const envoy::extensions::filters::http::custom_response::v3::CustomResponse& config,
     Envoy::Server::Configuration::ServerFactoryContext& context,

--- a/source/extensions/filters/http/custom_response/factory.h
+++ b/source/extensions/filters/http/custom_response/factory.h
@@ -23,7 +23,7 @@ public:
       const envoy::extensions::filters::http::custom_response::v3::CustomResponse& config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
 
-  Router::RouteSpecificFilterConfigConstSharedPtr createRouteSpecificFilterConfigTyped(
+  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr> createRouteSpecificFilterConfigTyped(
       const envoy::extensions::filters::http::custom_response::v3::CustomResponse& proto_config,
       Server::Configuration::ServerFactoryContext& context,
       ProtobufMessage::ValidationVisitor& validator) override;

--- a/source/extensions/filters/http/custom_response/factory.h
+++ b/source/extensions/filters/http/custom_response/factory.h
@@ -23,7 +23,8 @@ public:
       const envoy::extensions::filters::http::custom_response::v3::CustomResponse& config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
 
-  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr> createRouteSpecificFilterConfigTyped(
+  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
+  createRouteSpecificFilterConfigTyped(
       const envoy::extensions::filters::http::custom_response::v3::CustomResponse& proto_config,
       Server::Configuration::ServerFactoryContext& context,
       ProtobufMessage::ValidationVisitor& validator) override;

--- a/source/extensions/filters/http/dynamic_forward_proxy/config.cc
+++ b/source/extensions/filters/http/dynamic_forward_proxy/config.cc
@@ -34,7 +34,7 @@ DynamicForwardProxyFilterFactory::createFilterFactoryFromProtoTyped(
   };
 }
 
-Router::RouteSpecificFilterConfigConstSharedPtr
+absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
 DynamicForwardProxyFilterFactory::createRouteSpecificFilterConfigTyped(
     const envoy::extensions::filters::http::dynamic_forward_proxy::v3::PerRouteConfig& config,
     Server::Configuration::ServerFactoryContext&, ProtobufMessage::ValidationVisitor&) {

--- a/source/extensions/filters/http/dynamic_forward_proxy/config.h
+++ b/source/extensions/filters/http/dynamic_forward_proxy/config.h
@@ -25,7 +25,7 @@ private:
   absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::dynamic_forward_proxy::v3::FilterConfig& proto_config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
-  Router::RouteSpecificFilterConfigConstSharedPtr createRouteSpecificFilterConfigTyped(
+  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr> createRouteSpecificFilterConfigTyped(
       const envoy::extensions::filters::http::dynamic_forward_proxy::v3::PerRouteConfig& config,
       Server::Configuration::ServerFactoryContext&, ProtobufMessage::ValidationVisitor&) override;
 };

--- a/source/extensions/filters/http/dynamic_forward_proxy/config.h
+++ b/source/extensions/filters/http/dynamic_forward_proxy/config.h
@@ -25,7 +25,8 @@ private:
   absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::dynamic_forward_proxy::v3::FilterConfig& proto_config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
-  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr> createRouteSpecificFilterConfigTyped(
+  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
+  createRouteSpecificFilterConfigTyped(
       const envoy::extensions::filters::http::dynamic_forward_proxy::v3::PerRouteConfig& config,
       Server::Configuration::ServerFactoryContext&, ProtobufMessage::ValidationVisitor&) override;
 };

--- a/source/extensions/filters/http/ext_authz/config.cc
+++ b/source/extensions/filters/http/ext_authz/config.cc
@@ -63,7 +63,7 @@ Http::FilterFactoryCb ExtAuthzFilterConfig::createFilterFactoryFromProtoWithServ
   return callback;
 }
 
-Router::RouteSpecificFilterConfigConstSharedPtr
+absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
 ExtAuthzFilterConfig::createRouteSpecificFilterConfigTyped(
     const envoy::extensions::filters::http::ext_authz::v3::ExtAuthzPerRoute& proto_config,
     Server::Configuration::ServerFactoryContext&, ProtobufMessage::ValidationVisitor&) {

--- a/source/extensions/filters/http/ext_authz/config.h
+++ b/source/extensions/filters/http/ext_authz/config.h
@@ -35,7 +35,8 @@ private:
       const std::string& stats_prefix,
       Server::Configuration::ServerFactoryContext& server_context) override;
 
-  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr> createRouteSpecificFilterConfigTyped(
+  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
+  createRouteSpecificFilterConfigTyped(
       const envoy::extensions::filters::http::ext_authz::v3::ExtAuthzPerRoute& proto_config,
       Server::Configuration::ServerFactoryContext& context,
       ProtobufMessage::ValidationVisitor& validator) override;

--- a/source/extensions/filters/http/ext_authz/config.h
+++ b/source/extensions/filters/http/ext_authz/config.h
@@ -35,7 +35,7 @@ private:
       const std::string& stats_prefix,
       Server::Configuration::ServerFactoryContext& server_context) override;
 
-  Router::RouteSpecificFilterConfigConstSharedPtr createRouteSpecificFilterConfigTyped(
+  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr> createRouteSpecificFilterConfigTyped(
       const envoy::extensions::filters::http::ext_authz::v3::ExtAuthzPerRoute& proto_config,
       Server::Configuration::ServerFactoryContext& context,
       ProtobufMessage::ValidationVisitor& validator) override;

--- a/source/extensions/filters/http/ext_proc/config.cc
+++ b/source/extensions/filters/http/ext_proc/config.cc
@@ -109,7 +109,7 @@ ExternalProcessingFilterConfig::createFilterFactoryFromProtoTyped(
   }
 }
 
-Router::RouteSpecificFilterConfigConstSharedPtr
+absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
 ExternalProcessingFilterConfig::createRouteSpecificFilterConfigTyped(
     const envoy::extensions::filters::http::ext_proc::v3::ExtProcPerRoute& proto_config,
     Server::Configuration::ServerFactoryContext&, ProtobufMessage::ValidationVisitor&) {

--- a/source/extensions/filters/http/ext_proc/config.h
+++ b/source/extensions/filters/http/ext_proc/config.h
@@ -29,7 +29,8 @@ private:
       const std::string& stats_prefix, DualInfo dual_info,
       Server::Configuration::ServerFactoryContext& context) override;
 
-  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr> createRouteSpecificFilterConfigTyped(
+  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
+  createRouteSpecificFilterConfigTyped(
       const envoy::extensions::filters::http::ext_proc::v3::ExtProcPerRoute& proto_config,
       Server::Configuration::ServerFactoryContext& context,
       ProtobufMessage::ValidationVisitor& validator) override;

--- a/source/extensions/filters/http/ext_proc/config.h
+++ b/source/extensions/filters/http/ext_proc/config.h
@@ -29,7 +29,7 @@ private:
       const std::string& stats_prefix, DualInfo dual_info,
       Server::Configuration::ServerFactoryContext& context) override;
 
-  Router::RouteSpecificFilterConfigConstSharedPtr createRouteSpecificFilterConfigTyped(
+  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr> createRouteSpecificFilterConfigTyped(
       const envoy::extensions::filters::http::ext_proc::v3::ExtProcPerRoute& proto_config,
       Server::Configuration::ServerFactoryContext& context,
       ProtobufMessage::ValidationVisitor& validator) override;

--- a/source/extensions/filters/http/fault/config.cc
+++ b/source/extensions/filters/http/fault/config.cc
@@ -33,7 +33,7 @@ Http::FilterFactoryCb FaultFilterFactory::createFilterFactoryFromProtoWithServer
   };
 }
 
-Router::RouteSpecificFilterConfigConstSharedPtr
+absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
 FaultFilterFactory::createRouteSpecificFilterConfigTyped(
     const envoy::extensions::filters::http::fault::v3::HTTPFault& config,
     Server::Configuration::ServerFactoryContext& context, ProtobufMessage::ValidationVisitor&) {

--- a/source/extensions/filters/http/fault/config.h
+++ b/source/extensions/filters/http/fault/config.h
@@ -28,7 +28,7 @@ private:
       const std::string& stats_prefix,
       Server::Configuration::ServerFactoryContext& server_context) override;
 
-  Router::RouteSpecificFilterConfigConstSharedPtr createRouteSpecificFilterConfigTyped(
+  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr> createRouteSpecificFilterConfigTyped(
       const envoy::extensions::filters::http::fault::v3::HTTPFault& proto_config,
       Server::Configuration::ServerFactoryContext& context,
       ProtobufMessage::ValidationVisitor& validator) override;

--- a/source/extensions/filters/http/fault/config.h
+++ b/source/extensions/filters/http/fault/config.h
@@ -28,7 +28,8 @@ private:
       const std::string& stats_prefix,
       Server::Configuration::ServerFactoryContext& server_context) override;
 
-  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr> createRouteSpecificFilterConfigTyped(
+  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
+  createRouteSpecificFilterConfigTyped(
       const envoy::extensions::filters::http::fault::v3::HTTPFault& proto_config,
       Server::Configuration::ServerFactoryContext& context,
       ProtobufMessage::ValidationVisitor& validator) override;

--- a/source/extensions/filters/http/file_system_buffer/config.cc
+++ b/source/extensions/filters/http/file_system_buffer/config.cc
@@ -34,7 +34,7 @@ Http::FilterFactoryCb FileSystemBufferFilterFactory::createFilterFactoryFromProt
   };
 }
 
-Router::RouteSpecificFilterConfigConstSharedPtr
+absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
 FileSystemBufferFilterFactory::createRouteSpecificFilterConfigTyped(
     const ProtoFileSystemBufferFilterConfig& config,
     Server::Configuration::ServerFactoryContext& context, ProtobufMessage::ValidationVisitor&) {

--- a/source/extensions/filters/http/file_system_buffer/config.h
+++ b/source/extensions/filters/http/file_system_buffer/config.h
@@ -28,7 +28,8 @@ public:
           config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
 
-  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr> createRouteSpecificFilterConfigTyped(
+  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
+  createRouteSpecificFilterConfigTyped(
       const envoy::extensions::filters::http::file_system_buffer::v3::FileSystemBufferFilterConfig&
           config,
       Server::Configuration::ServerFactoryContext& context,

--- a/source/extensions/filters/http/file_system_buffer/config.h
+++ b/source/extensions/filters/http/file_system_buffer/config.h
@@ -28,7 +28,7 @@ public:
           config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
 
-  Router::RouteSpecificFilterConfigConstSharedPtr createRouteSpecificFilterConfigTyped(
+  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr> createRouteSpecificFilterConfigTyped(
       const envoy::extensions::filters::http::file_system_buffer::v3::FileSystemBufferFilterConfig&
           config,
       Server::Configuration::ServerFactoryContext& context,

--- a/source/extensions/filters/http/grpc_http1_reverse_bridge/config.cc
+++ b/source/extensions/filters/http/grpc_http1_reverse_bridge/config.cc
@@ -20,7 +20,8 @@ Http::FilterFactoryCb Config::createFilterFactoryFromProtoTyped(
   };
 }
 
-absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr> Config::createRouteSpecificFilterConfigTyped(
+absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
+Config::createRouteSpecificFilterConfigTyped(
     const envoy::extensions::filters::http::grpc_http1_reverse_bridge::v3::FilterConfigPerRoute&
         proto_config,
     Server::Configuration::ServerFactoryContext&, ProtobufMessage::ValidationVisitor&) {

--- a/source/extensions/filters/http/grpc_http1_reverse_bridge/config.cc
+++ b/source/extensions/filters/http/grpc_http1_reverse_bridge/config.cc
@@ -20,7 +20,7 @@ Http::FilterFactoryCb Config::createFilterFactoryFromProtoTyped(
   };
 }
 
-Router::RouteSpecificFilterConfigConstSharedPtr Config::createRouteSpecificFilterConfigTyped(
+absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr> Config::createRouteSpecificFilterConfigTyped(
     const envoy::extensions::filters::http::grpc_http1_reverse_bridge::v3::FilterConfigPerRoute&
         proto_config,
     Server::Configuration::ServerFactoryContext&, ProtobufMessage::ValidationVisitor&) {

--- a/source/extensions/filters/http/grpc_http1_reverse_bridge/config.h
+++ b/source/extensions/filters/http/grpc_http1_reverse_bridge/config.h
@@ -24,7 +24,7 @@ public:
       Envoy::Server::Configuration::FactoryContext& context) override;
 
 private:
-  Router::RouteSpecificFilterConfigConstSharedPtr createRouteSpecificFilterConfigTyped(
+  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr> createRouteSpecificFilterConfigTyped(
       const envoy::extensions::filters::http::grpc_http1_reverse_bridge::v3::FilterConfigPerRoute&
           proto_config,
       Server::Configuration::ServerFactoryContext& context,

--- a/source/extensions/filters/http/grpc_http1_reverse_bridge/config.h
+++ b/source/extensions/filters/http/grpc_http1_reverse_bridge/config.h
@@ -24,7 +24,8 @@ public:
       Envoy::Server::Configuration::FactoryContext& context) override;
 
 private:
-  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr> createRouteSpecificFilterConfigTyped(
+  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
+  createRouteSpecificFilterConfigTyped(
       const envoy::extensions::filters::http::grpc_http1_reverse_bridge::v3::FilterConfigPerRoute&
           proto_config,
       Server::Configuration::ServerFactoryContext& context,

--- a/source/extensions/filters/http/grpc_json_transcoder/config.cc
+++ b/source/extensions/filters/http/grpc_json_transcoder/config.cc
@@ -24,7 +24,7 @@ Http::FilterFactoryCb GrpcJsonTranscoderFilterConfig::createFilterFactoryFromPro
   };
 }
 
-Router::RouteSpecificFilterConfigConstSharedPtr
+absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
 GrpcJsonTranscoderFilterConfig::createRouteSpecificFilterConfigTyped(
     const envoy::extensions::filters::http::grpc_json_transcoder::v3::GrpcJsonTranscoder&
         proto_config,

--- a/source/extensions/filters/http/grpc_json_transcoder/config.h
+++ b/source/extensions/filters/http/grpc_json_transcoder/config.h
@@ -25,7 +25,7 @@ private:
           proto_config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
 
-  Router::RouteSpecificFilterConfigConstSharedPtr createRouteSpecificFilterConfigTyped(
+  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr> createRouteSpecificFilterConfigTyped(
       const envoy::extensions::filters::http::grpc_json_transcoder::v3::GrpcJsonTranscoder&,
       Server::Configuration::ServerFactoryContext& context,
       ProtobufMessage::ValidationVisitor& validator) override;

--- a/source/extensions/filters/http/grpc_json_transcoder/config.h
+++ b/source/extensions/filters/http/grpc_json_transcoder/config.h
@@ -25,7 +25,8 @@ private:
           proto_config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
 
-  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr> createRouteSpecificFilterConfigTyped(
+  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
+  createRouteSpecificFilterConfigTyped(
       const envoy::extensions::filters::http::grpc_json_transcoder::v3::GrpcJsonTranscoder&,
       Server::Configuration::ServerFactoryContext& context,
       ProtobufMessage::ValidationVisitor& validator) override;

--- a/source/extensions/filters/http/header_mutation/config.cc
+++ b/source/extensions/filters/http/header_mutation/config.cc
@@ -19,7 +19,7 @@ HeaderMutationFactoryConfig::createFilterFactoryFromProtoTyped(
   };
 }
 
-Router::RouteSpecificFilterConfigConstSharedPtr
+absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
 HeaderMutationFactoryConfig::createRouteSpecificFilterConfigTyped(
     const PerRouteProtoConfig& proto_config, Server::Configuration::ServerFactoryContext&,
     ProtobufMessage::ValidationVisitor&) {

--- a/source/extensions/filters/http/header_mutation/config.h
+++ b/source/extensions/filters/http/header_mutation/config.h
@@ -24,7 +24,7 @@ private:
   createFilterFactoryFromProtoTyped(const ProtoConfig& proto_config,
                                     const std::string& stats_prefix, DualInfo info,
                                     Server::Configuration::ServerFactoryContext& context) override;
-  Router::RouteSpecificFilterConfigConstSharedPtr
+  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
   createRouteSpecificFilterConfigTyped(const PerRouteProtoConfig& proto_config,
                                        Server::Configuration::ServerFactoryContext&,
                                        ProtobufMessage::ValidationVisitor&) override;

--- a/source/extensions/filters/http/header_to_metadata/config.cc
+++ b/source/extensions/filters/http/header_to_metadata/config.cc
@@ -26,7 +26,7 @@ Http::FilterFactoryCb HeaderToMetadataConfig::createFilterFactoryFromProtoTyped(
   };
 }
 
-Router::RouteSpecificFilterConfigConstSharedPtr
+absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
 HeaderToMetadataConfig::createRouteSpecificFilterConfigTyped(
     const envoy::extensions::filters::http::header_to_metadata::v3::Config& config,
     Server::Configuration::ServerFactoryContext& context, ProtobufMessage::ValidationVisitor&) {

--- a/source/extensions/filters/http/header_to_metadata/config.h
+++ b/source/extensions/filters/http/header_to_metadata/config.h
@@ -22,7 +22,7 @@ private:
   Http::FilterFactoryCb createFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::header_to_metadata::v3::Config& proto_config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
-  Router::RouteSpecificFilterConfigConstSharedPtr createRouteSpecificFilterConfigTyped(
+  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr> createRouteSpecificFilterConfigTyped(
       const envoy::extensions::filters::http::header_to_metadata::v3::Config& config,
       Server::Configuration::ServerFactoryContext&, ProtobufMessage::ValidationVisitor&) override;
 };

--- a/source/extensions/filters/http/header_to_metadata/config.h
+++ b/source/extensions/filters/http/header_to_metadata/config.h
@@ -22,7 +22,8 @@ private:
   Http::FilterFactoryCb createFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::header_to_metadata::v3::Config& proto_config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
-  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr> createRouteSpecificFilterConfigTyped(
+  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
+  createRouteSpecificFilterConfigTyped(
       const envoy::extensions::filters::http::header_to_metadata::v3::Config& config,
       Server::Configuration::ServerFactoryContext&, ProtobufMessage::ValidationVisitor&) override;
 };

--- a/source/extensions/filters/http/jwt_authn/filter_factory.cc
+++ b/source/extensions/filters/http/jwt_authn/filter_factory.cc
@@ -50,7 +50,7 @@ FilterFactory::createFilterFactoryFromProtoTyped(const JwtAuthentication& proto_
   };
 }
 
-Envoy::Router::RouteSpecificFilterConfigConstSharedPtr
+absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
 FilterFactory::createRouteSpecificFilterConfigTyped(
     const envoy::extensions::filters::http::jwt_authn::v3::PerRouteConfig& per_route,
     Envoy::Server::Configuration::ServerFactoryContext&,

--- a/source/extensions/filters/http/jwt_authn/filter_factory.h
+++ b/source/extensions/filters/http/jwt_authn/filter_factory.h
@@ -25,7 +25,8 @@ private:
       const envoy::extensions::filters::http::jwt_authn::v3::JwtAuthentication& proto_config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
 
-  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr> createRouteSpecificFilterConfigTyped(
+  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
+  createRouteSpecificFilterConfigTyped(
       const envoy::extensions::filters::http::jwt_authn::v3::PerRouteConfig& per_route,
       Envoy::Server::Configuration::ServerFactoryContext&,
       Envoy::ProtobufMessage::ValidationVisitor&) override;

--- a/source/extensions/filters/http/jwt_authn/filter_factory.h
+++ b/source/extensions/filters/http/jwt_authn/filter_factory.h
@@ -25,7 +25,7 @@ private:
       const envoy::extensions::filters::http::jwt_authn::v3::JwtAuthentication& proto_config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
 
-  Envoy::Router::RouteSpecificFilterConfigConstSharedPtr createRouteSpecificFilterConfigTyped(
+  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr> createRouteSpecificFilterConfigTyped(
       const envoy::extensions::filters::http::jwt_authn::v3::PerRouteConfig& per_route,
       Envoy::Server::Configuration::ServerFactoryContext&,
       Envoy::ProtobufMessage::ValidationVisitor&) override;

--- a/source/extensions/filters/http/kill_request/kill_request_config.cc
+++ b/source/extensions/filters/http/kill_request/kill_request_config.cc
@@ -20,7 +20,7 @@ Http::FilterFactoryCb KillRequestFilterFactory::createFilterFactoryFromProtoType
   };
 }
 
-Router::RouteSpecificFilterConfigConstSharedPtr
+absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
 KillRequestFilterFactory::createRouteSpecificFilterConfigTyped(
     const envoy::extensions::filters::http::kill_request::v3::KillRequest& proto_config,
     Server::Configuration::ServerFactoryContext&, ProtobufMessage::ValidationVisitor&) {

--- a/source/extensions/filters/http/kill_request/kill_request_config.h
+++ b/source/extensions/filters/http/kill_request/kill_request_config.h
@@ -23,7 +23,7 @@ private:
       const envoy::extensions::filters::http::kill_request::v3::KillRequest& proto_config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
 
-  Router::RouteSpecificFilterConfigConstSharedPtr createRouteSpecificFilterConfigTyped(
+  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr> createRouteSpecificFilterConfigTyped(
       const envoy::extensions::filters::http::kill_request::v3::KillRequest& proto_config,
       Server::Configuration::ServerFactoryContext& context,
       ProtobufMessage::ValidationVisitor& validator) override;

--- a/source/extensions/filters/http/kill_request/kill_request_config.h
+++ b/source/extensions/filters/http/kill_request/kill_request_config.h
@@ -23,7 +23,8 @@ private:
       const envoy::extensions::filters::http::kill_request::v3::KillRequest& proto_config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
 
-  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr> createRouteSpecificFilterConfigTyped(
+  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
+  createRouteSpecificFilterConfigTyped(
       const envoy::extensions::filters::http::kill_request::v3::KillRequest& proto_config,
       Server::Configuration::ServerFactoryContext& context,
       ProtobufMessage::ValidationVisitor& validator) override;

--- a/source/extensions/filters/http/local_ratelimit/config.cc
+++ b/source/extensions/filters/http/local_ratelimit/config.cc
@@ -23,7 +23,7 @@ Http::FilterFactoryCb LocalRateLimitFilterConfig::createFilterFactoryFromProtoTy
   };
 }
 
-Router::RouteSpecificFilterConfigConstSharedPtr
+absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
 LocalRateLimitFilterConfig::createRouteSpecificFilterConfigTyped(
     const envoy::extensions::filters::http::local_ratelimit::v3::LocalRateLimit& proto_config,
     Server::Configuration::ServerFactoryContext& context, ProtobufMessage::ValidationVisitor&) {

--- a/source/extensions/filters/http/local_ratelimit/config.h
+++ b/source/extensions/filters/http/local_ratelimit/config.h
@@ -23,7 +23,8 @@ private:
   Http::FilterFactoryCb createFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::local_ratelimit::v3::LocalRateLimit& proto_config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
-  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr> createRouteSpecificFilterConfigTyped(
+  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
+  createRouteSpecificFilterConfigTyped(
       const envoy::extensions::filters::http::local_ratelimit::v3::LocalRateLimit& proto_config,
       Server::Configuration::ServerFactoryContext&, ProtobufMessage::ValidationVisitor&) override;
 };

--- a/source/extensions/filters/http/local_ratelimit/config.h
+++ b/source/extensions/filters/http/local_ratelimit/config.h
@@ -23,7 +23,7 @@ private:
   Http::FilterFactoryCb createFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::local_ratelimit::v3::LocalRateLimit& proto_config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
-  Router::RouteSpecificFilterConfigConstSharedPtr createRouteSpecificFilterConfigTyped(
+  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr> createRouteSpecificFilterConfigTyped(
       const envoy::extensions::filters::http::local_ratelimit::v3::LocalRateLimit& proto_config,
       Server::Configuration::ServerFactoryContext&, ProtobufMessage::ValidationVisitor&) override;
 };

--- a/source/extensions/filters/http/lua/config.cc
+++ b/source/extensions/filters/http/lua/config.cc
@@ -25,7 +25,7 @@ Http::FilterFactoryCb LuaFilterConfig::createFilterFactoryFromProtoTyped(
   };
 }
 
-Router::RouteSpecificFilterConfigConstSharedPtr
+absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
 LuaFilterConfig::createRouteSpecificFilterConfigTyped(
     const envoy::extensions::filters::http::lua::v3::LuaPerRoute& proto_config,
     Server::Configuration::ServerFactoryContext& context, ProtobufMessage::ValidationVisitor&) {

--- a/source/extensions/filters/http/lua/config.h
+++ b/source/extensions/filters/http/lua/config.h
@@ -24,7 +24,8 @@ private:
       const envoy::extensions::filters::http::lua::v3::Lua& proto_config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
 
-  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr> createRouteSpecificFilterConfigTyped(
+  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
+  createRouteSpecificFilterConfigTyped(
       const envoy::extensions::filters::http::lua::v3::LuaPerRoute& proto_config,
       Server::Configuration::ServerFactoryContext& context,
       ProtobufMessage::ValidationVisitor& validator) override;

--- a/source/extensions/filters/http/lua/config.h
+++ b/source/extensions/filters/http/lua/config.h
@@ -24,7 +24,7 @@ private:
       const envoy::extensions::filters::http::lua::v3::Lua& proto_config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
 
-  Router::RouteSpecificFilterConfigConstSharedPtr createRouteSpecificFilterConfigTyped(
+  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr> createRouteSpecificFilterConfigTyped(
       const envoy::extensions::filters::http::lua::v3::LuaPerRoute& proto_config,
       Server::Configuration::ServerFactoryContext& context,
       ProtobufMessage::ValidationVisitor& validator) override;

--- a/source/extensions/filters/http/match_delegate/config.cc
+++ b/source/extensions/filters/http/match_delegate/config.cc
@@ -346,7 +346,7 @@ absl::StatusOr<Envoy::Http::FilterFactoryCb> MatchDelegateConfig::createFilterFa
   };
 }
 
-Router::RouteSpecificFilterConfigConstSharedPtr
+absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
 MatchDelegateConfig::createRouteSpecificFilterConfigTyped(
     const envoy::extensions::common::matching::v3::ExtensionWithMatcherPerRoute& proto_config,
     Server::Configuration::ServerFactoryContext& server_context,

--- a/source/extensions/filters/http/match_delegate/config.h
+++ b/source/extensions/filters/http/match_delegate/config.h
@@ -152,7 +152,8 @@ private:
       Envoy::Http::Matching::HttpFilterActionContext& action_context, FactoryCtx& context,
       FilterCfgFactory& factory);
 
-  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr> createRouteSpecificFilterConfigTyped(
+  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
+  createRouteSpecificFilterConfigTyped(
       const envoy::extensions::common::matching::v3::ExtensionWithMatcherPerRoute& proto_config,
       Server::Configuration::ServerFactoryContext& context,
       ProtobufMessage::ValidationVisitor& validation) override;

--- a/source/extensions/filters/http/match_delegate/config.h
+++ b/source/extensions/filters/http/match_delegate/config.h
@@ -152,7 +152,7 @@ private:
       Envoy::Http::Matching::HttpFilterActionContext& action_context, FactoryCtx& context,
       FilterCfgFactory& factory);
 
-  Router::RouteSpecificFilterConfigConstSharedPtr createRouteSpecificFilterConfigTyped(
+  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr> createRouteSpecificFilterConfigTyped(
       const envoy::extensions::common::matching::v3::ExtensionWithMatcherPerRoute& proto_config,
       Server::Configuration::ServerFactoryContext& context,
       ProtobufMessage::ValidationVisitor& validation) override;

--- a/source/extensions/filters/http/on_demand/config.cc
+++ b/source/extensions/filters/http/on_demand/config.cc
@@ -20,7 +20,7 @@ Http::FilterFactoryCb OnDemandFilterFactory::createFilterFactoryFromProtoTyped(
   };
 }
 
-Router::RouteSpecificFilterConfigConstSharedPtr
+absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
 OnDemandFilterFactory::createRouteSpecificFilterConfigTyped(
     const envoy::extensions::filters::http::on_demand::v3::PerRouteConfig& proto_config,
     Server::Configuration::ServerFactoryContext& context,

--- a/source/extensions/filters/http/on_demand/config.h
+++ b/source/extensions/filters/http/on_demand/config.h
@@ -25,7 +25,7 @@ private:
       const envoy::extensions::filters::http::on_demand::v3::OnDemand& proto_config,
       const std::string&, Server::Configuration::FactoryContext& context) override;
 
-  Router::RouteSpecificFilterConfigConstSharedPtr createRouteSpecificFilterConfigTyped(
+  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr> createRouteSpecificFilterConfigTyped(
       const envoy::extensions::filters::http::on_demand::v3::PerRouteConfig& config,
       Server::Configuration::ServerFactoryContext& context,
       ProtobufMessage::ValidationVisitor& visitor) override;

--- a/source/extensions/filters/http/on_demand/config.h
+++ b/source/extensions/filters/http/on_demand/config.h
@@ -25,7 +25,8 @@ private:
       const envoy::extensions::filters::http::on_demand::v3::OnDemand& proto_config,
       const std::string&, Server::Configuration::FactoryContext& context) override;
 
-  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr> createRouteSpecificFilterConfigTyped(
+  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
+  createRouteSpecificFilterConfigTyped(
       const envoy::extensions::filters::http::on_demand::v3::PerRouteConfig& config,
       Server::Configuration::ServerFactoryContext& context,
       ProtobufMessage::ValidationVisitor& visitor) override;

--- a/source/extensions/filters/http/ratelimit/config.cc
+++ b/source/extensions/filters/http/ratelimit/config.cc
@@ -40,7 +40,7 @@ Http::FilterFactoryCb RateLimitFilterConfig::createFilterFactoryFromProtoTyped(
   };
 }
 
-Router::RouteSpecificFilterConfigConstSharedPtr
+absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
 RateLimitFilterConfig::createRouteSpecificFilterConfigTyped(
     const envoy::extensions::filters::http::ratelimit::v3::RateLimitPerRoute& proto_config,
     Server::Configuration::ServerFactoryContext&, ProtobufMessage::ValidationVisitor&) {

--- a/source/extensions/filters/http/ratelimit/config.h
+++ b/source/extensions/filters/http/ratelimit/config.h
@@ -26,7 +26,8 @@ private:
       const envoy::extensions::filters::http::ratelimit::v3::RateLimit& proto_config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
 
-  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr> createRouteSpecificFilterConfigTyped(
+  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
+  createRouteSpecificFilterConfigTyped(
       const envoy::extensions::filters::http::ratelimit::v3::RateLimitPerRoute& proto_config,
       Server::Configuration::ServerFactoryContext& context,
       ProtobufMessage::ValidationVisitor& validator) override;

--- a/source/extensions/filters/http/ratelimit/config.h
+++ b/source/extensions/filters/http/ratelimit/config.h
@@ -26,7 +26,7 @@ private:
       const envoy::extensions::filters::http::ratelimit::v3::RateLimit& proto_config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
 
-  Router::RouteSpecificFilterConfigConstSharedPtr createRouteSpecificFilterConfigTyped(
+  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr> createRouteSpecificFilterConfigTyped(
       const envoy::extensions::filters::http::ratelimit::v3::RateLimitPerRoute& proto_config,
       Server::Configuration::ServerFactoryContext& context,
       ProtobufMessage::ValidationVisitor& validator) override;

--- a/source/extensions/filters/http/rbac/config.cc
+++ b/source/extensions/filters/http/rbac/config.cc
@@ -24,7 +24,7 @@ Http::FilterFactoryCb RoleBasedAccessControlFilterConfigFactory::createFilterFac
   };
 }
 
-Router::RouteSpecificFilterConfigConstSharedPtr
+absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
 RoleBasedAccessControlFilterConfigFactory::createRouteSpecificFilterConfigTyped(
     const envoy::extensions::filters::http::rbac::v3::RBACPerRoute& proto_config,
     Server::Configuration::ServerFactoryContext& context,

--- a/source/extensions/filters/http/rbac/config.h
+++ b/source/extensions/filters/http/rbac/config.h
@@ -24,7 +24,7 @@ private:
       const envoy::extensions::filters::http::rbac::v3::RBAC& proto_config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
 
-  Router::RouteSpecificFilterConfigConstSharedPtr createRouteSpecificFilterConfigTyped(
+  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr> createRouteSpecificFilterConfigTyped(
       const envoy::extensions::filters::http::rbac::v3::RBACPerRoute& proto_config,
       Server::Configuration::ServerFactoryContext& context,
       ProtobufMessage::ValidationVisitor& validator) override;

--- a/source/extensions/filters/http/rbac/config.h
+++ b/source/extensions/filters/http/rbac/config.h
@@ -24,7 +24,8 @@ private:
       const envoy::extensions::filters::http::rbac::v3::RBAC& proto_config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
 
-  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr> createRouteSpecificFilterConfigTyped(
+  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
+  createRouteSpecificFilterConfigTyped(
       const envoy::extensions::filters::http::rbac::v3::RBACPerRoute& proto_config,
       Server::Configuration::ServerFactoryContext& context,
       ProtobufMessage::ValidationVisitor& validator) override;

--- a/source/extensions/filters/http/stateful_session/config.cc
+++ b/source/extensions/filters/http/stateful_session/config.cc
@@ -21,7 +21,7 @@ Http::FilterFactoryCb StatefulSessionFactoryConfig::createFilterFactoryFromProto
   };
 }
 
-Router::RouteSpecificFilterConfigConstSharedPtr
+absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
 StatefulSessionFactoryConfig::createRouteSpecificFilterConfigTyped(
     const PerRouteProtoConfig& proto_config, Server::Configuration::ServerFactoryContext& context,
     ProtobufMessage::ValidationVisitor& visitor) {

--- a/source/extensions/filters/http/stateful_session/config.h
+++ b/source/extensions/filters/http/stateful_session/config.h
@@ -23,7 +23,7 @@ private:
   createFilterFactoryFromProtoTyped(const ProtoConfig& proto_config,
                                     const std::string& stats_prefix,
                                     Server::Configuration::FactoryContext& context) override;
-  Router::RouteSpecificFilterConfigConstSharedPtr
+  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
   createRouteSpecificFilterConfigTyped(const PerRouteProtoConfig& proto_config,
                                        Server::Configuration::ServerFactoryContext&,
                                        ProtobufMessage::ValidationVisitor&) override;

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -10576,7 +10576,7 @@ public:
       return ProtobufTypes::MessagePtr{new ProtobufWkt::Timestamp()};
     }
     std::set<std::string> configTypes() override { return {"google.protobuf.Timestamp"}; }
-    Router::RouteSpecificFilterConfigConstSharedPtr
+    absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
     createRouteSpecificFilterConfig(const Protobuf::Message& message,
                                     Server::Configuration::ServerFactoryContext&,
                                     ProtobufMessage::ValidationVisitor&) override {

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -4817,7 +4817,7 @@ public:
   }
   ProtobufTypes::MessagePtr createEmptyConfigProto() override { PANIC("not implemented"); }
   ProtobufTypes::MessagePtr createEmptyRouteConfigProto() override { PANIC("not implemented"); }
-  Router::RouteSpecificFilterConfigConstSharedPtr
+  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
   createRouteSpecificFilterConfig(const Protobuf::Message&,
                                   Server::Configuration::ServerFactoryContext&,
                                   ProtobufMessage::ValidationVisitor&) override {

--- a/test/extensions/filters/http/aws_lambda/config_test.cc
+++ b/test/extensions/filters/http/aws_lambda/config_test.cc
@@ -96,8 +96,11 @@ TEST(AwsLambdaFilterConfigTest, ValidPerRouteConfigCreatesFilter) {
   testing::NiceMock<Server::Configuration::MockServerFactoryContext> context;
   AwsLambdaFilterFactory factory;
 
-  auto route_specific_config_ptr = factory.createRouteSpecificFilterConfig(
-      proto_config, context, ProtobufMessage::getStrictValidationVisitor()).value();
+  auto route_specific_config_ptr =
+      factory
+          .createRouteSpecificFilterConfig(proto_config, context,
+                                           ProtobufMessage::getStrictValidationVisitor())
+          .value();
   Http::MockFilterChainFactoryCallbacks filter_callbacks;
   ASSERT_NE(route_specific_config_ptr, nullptr);
   auto filter_settings_ptr =
@@ -135,8 +138,10 @@ TEST(AwsLambdaFilterConfigTest, PerRouteConfigWithInvalidARNThrows) {
   testing::NiceMock<Server::Configuration::MockServerFactoryContext> context;
   AwsLambdaFilterFactory factory;
 
-  EXPECT_THROW(factory.createRouteSpecificFilterConfig(
-                   proto_config, context, ProtobufMessage::getStrictValidationVisitor()).value(),
+  EXPECT_THROW(factory
+                   .createRouteSpecificFilterConfig(proto_config, context,
+                                                    ProtobufMessage::getStrictValidationVisitor())
+                   .value(),
                EnvoyException);
 }
 
@@ -154,8 +159,11 @@ TEST(AwsLambdaFilterConfigTest, AsynchrnousPerRouteConfig) {
   testing::NiceMock<Server::Configuration::MockServerFactoryContext> context;
   AwsLambdaFilterFactory factory;
 
-  auto route_specific_config_ptr = factory.createRouteSpecificFilterConfig(
-      proto_config, context, ProtobufMessage::getStrictValidationVisitor()).value();
+  auto route_specific_config_ptr =
+      factory
+          .createRouteSpecificFilterConfig(proto_config, context,
+                                           ProtobufMessage::getStrictValidationVisitor())
+          .value();
   Http::MockFilterChainFactoryCallbacks filter_callbacks;
   ASSERT_NE(route_specific_config_ptr, nullptr);
   auto filter_settings_ptr =

--- a/test/extensions/filters/http/aws_lambda/config_test.cc
+++ b/test/extensions/filters/http/aws_lambda/config_test.cc
@@ -97,7 +97,7 @@ TEST(AwsLambdaFilterConfigTest, ValidPerRouteConfigCreatesFilter) {
   AwsLambdaFilterFactory factory;
 
   auto route_specific_config_ptr = factory.createRouteSpecificFilterConfig(
-      proto_config, context, ProtobufMessage::getStrictValidationVisitor());
+      proto_config, context, ProtobufMessage::getStrictValidationVisitor()).value();
   Http::MockFilterChainFactoryCallbacks filter_callbacks;
   ASSERT_NE(route_specific_config_ptr, nullptr);
   auto filter_settings_ptr =
@@ -136,7 +136,7 @@ TEST(AwsLambdaFilterConfigTest, PerRouteConfigWithInvalidARNThrows) {
   AwsLambdaFilterFactory factory;
 
   EXPECT_THROW(factory.createRouteSpecificFilterConfig(
-                   proto_config, context, ProtobufMessage::getStrictValidationVisitor()),
+                   proto_config, context, ProtobufMessage::getStrictValidationVisitor()).value(),
                EnvoyException);
 }
 
@@ -155,7 +155,7 @@ TEST(AwsLambdaFilterConfigTest, AsynchrnousPerRouteConfig) {
   AwsLambdaFilterFactory factory;
 
   auto route_specific_config_ptr = factory.createRouteSpecificFilterConfig(
-      proto_config, context, ProtobufMessage::getStrictValidationVisitor());
+      proto_config, context, ProtobufMessage::getStrictValidationVisitor()).value();
   Http::MockFilterChainFactoryCallbacks filter_callbacks;
   ASSERT_NE(route_specific_config_ptr, nullptr);
   auto filter_settings_ptr =

--- a/test/extensions/filters/http/aws_request_signing/config_test.cc
+++ b/test/extensions/filters/http/aws_request_signing/config_test.cc
@@ -572,8 +572,11 @@ stat_prefix: foo_prefix
 
   EXPECT_THROW(
       {
-        const auto route_config = factory.createRouteSpecificFilterConfig(
-            proto_config, context, ProtobufMessage::getNullValidationVisitor()).value();
+        const auto route_config =
+            factory
+                .createRouteSpecificFilterConfig(proto_config, context,
+                                                 ProtobufMessage::getNullValidationVisitor())
+                .value();
       },
       EnvoyException);
 }

--- a/test/extensions/filters/http/aws_request_signing/config_test.cc
+++ b/test/extensions/filters/http/aws_request_signing/config_test.cc
@@ -366,7 +366,7 @@ stat_prefix: foo_prefix
 
   const auto route_config = factory.createRouteSpecificFilterConfig(
       proto_config, context, ProtobufMessage::getNullValidationVisitor());
-  ASSERT_NE(route_config, nullptr);
+  ASSERT_TRUE(route_config.ok());
 }
 
 TEST(AwsRequestSigningFilterConfigTest, RouteSpecificFilterConfigSigV4RegionInEnv) {
@@ -392,7 +392,7 @@ stat_prefix: foo_prefix
 
   const auto route_config = factory.createRouteSpecificFilterConfig(
       proto_config, context, ProtobufMessage::getNullValidationVisitor());
-  ASSERT_NE(route_config, nullptr);
+  ASSERT_TRUE(route_config.ok());
 }
 
 TEST(AwsRequestSigningFilterConfigTest, RouteSpecificFilterConfigSigV4A) {
@@ -417,7 +417,7 @@ stat_prefix: foo_prefix
 
   const auto route_config = factory.createRouteSpecificFilterConfig(
       proto_config, context, ProtobufMessage::getNullValidationVisitor());
-  ASSERT_NE(route_config, nullptr);
+  ASSERT_TRUE(route_config.ok());
 }
 
 TEST(AwsRequestSigningFilterConfigTest, InvalidRegionRouteSpecificFilterConfigSigV4) {
@@ -573,7 +573,7 @@ stat_prefix: foo_prefix
   EXPECT_THROW(
       {
         const auto route_config = factory.createRouteSpecificFilterConfig(
-            proto_config, context, ProtobufMessage::getNullValidationVisitor());
+            proto_config, context, ProtobufMessage::getNullValidationVisitor()).value();
       },
       EnvoyException);
 }

--- a/test/extensions/filters/http/bandwidth_limit/config_test.cc
+++ b/test/extensions/filters/http/bandwidth_limit/config_test.cc
@@ -48,8 +48,11 @@ TEST(Factory, RouteSpecificFilterConfig) {
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
 
   EXPECT_CALL(context.dispatcher_, createTimer_(_)).Times(0);
-  const auto route_config = factory.createRouteSpecificFilterConfig(
-      *proto_config, context, ProtobufMessage::getNullValidationVisitor()).value();
+  const auto route_config =
+      factory
+          .createRouteSpecificFilterConfig(*proto_config, context,
+                                           ProtobufMessage::getNullValidationVisitor())
+          .value();
   const auto* config = dynamic_cast<const FilterConfig*>(route_config.get());
   EXPECT_EQ(config->limit(), 10);
   EXPECT_EQ(config->fillInterval().count(), 100);
@@ -76,8 +79,11 @@ TEST(Factory, RouteSpecificFilterConfigDisabledByDefault) {
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
 
   EXPECT_CALL(context.dispatcher_, createTimer_(_)).Times(0);
-  const auto route_config = factory.createRouteSpecificFilterConfig(
-      *proto_config, context, ProtobufMessage::getNullValidationVisitor()).value();
+  const auto route_config =
+      factory
+          .createRouteSpecificFilterConfig(*proto_config, context,
+                                           ProtobufMessage::getNullValidationVisitor())
+          .value();
   const auto* config = dynamic_cast<const FilterConfig*>(route_config.get());
   EXPECT_EQ(config->enableMode(), EnableMode::BandwidthLimit_EnableMode_DISABLED);
   EXPECT_EQ(config->limit(), 10);
@@ -98,8 +104,11 @@ TEST(Factory, RouteSpecificFilterConfigDefault) {
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
 
   EXPECT_CALL(context.dispatcher_, createTimer_(_)).Times(0);
-  const auto route_config = factory.createRouteSpecificFilterConfig(
-      *proto_config, context, ProtobufMessage::getNullValidationVisitor()).value();
+  const auto route_config =
+      factory
+          .createRouteSpecificFilterConfig(*proto_config, context,
+                                           ProtobufMessage::getNullValidationVisitor())
+          .value();
   const auto* config = dynamic_cast<const FilterConfig*>(route_config.get());
   EXPECT_EQ(config->limit(), 10);
   EXPECT_EQ(config->fillInterval().count(), 50);
@@ -121,8 +130,10 @@ TEST(Factory, PerRouteConfigNoLimits) {
   TestUtility::loadFromYaml(config_yaml, *proto_config);
 
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
-  EXPECT_THROW(factory.createRouteSpecificFilterConfig(*proto_config, context,
-                                                       ProtobufMessage::getNullValidationVisitor()).value(),
+  EXPECT_THROW(factory
+                   .createRouteSpecificFilterConfig(*proto_config, context,
+                                                    ProtobufMessage::getNullValidationVisitor())
+                   .value(),
                EnvoyException);
 }
 } // namespace BandwidthLimitFilter

--- a/test/extensions/filters/http/bandwidth_limit/config_test.cc
+++ b/test/extensions/filters/http/bandwidth_limit/config_test.cc
@@ -49,7 +49,7 @@ TEST(Factory, RouteSpecificFilterConfig) {
 
   EXPECT_CALL(context.dispatcher_, createTimer_(_)).Times(0);
   const auto route_config = factory.createRouteSpecificFilterConfig(
-      *proto_config, context, ProtobufMessage::getNullValidationVisitor());
+      *proto_config, context, ProtobufMessage::getNullValidationVisitor()).value();
   const auto* config = dynamic_cast<const FilterConfig*>(route_config.get());
   EXPECT_EQ(config->limit(), 10);
   EXPECT_EQ(config->fillInterval().count(), 100);
@@ -77,7 +77,7 @@ TEST(Factory, RouteSpecificFilterConfigDisabledByDefault) {
 
   EXPECT_CALL(context.dispatcher_, createTimer_(_)).Times(0);
   const auto route_config = factory.createRouteSpecificFilterConfig(
-      *proto_config, context, ProtobufMessage::getNullValidationVisitor());
+      *proto_config, context, ProtobufMessage::getNullValidationVisitor()).value();
   const auto* config = dynamic_cast<const FilterConfig*>(route_config.get());
   EXPECT_EQ(config->enableMode(), EnableMode::BandwidthLimit_EnableMode_DISABLED);
   EXPECT_EQ(config->limit(), 10);
@@ -99,7 +99,7 @@ TEST(Factory, RouteSpecificFilterConfigDefault) {
 
   EXPECT_CALL(context.dispatcher_, createTimer_(_)).Times(0);
   const auto route_config = factory.createRouteSpecificFilterConfig(
-      *proto_config, context, ProtobufMessage::getNullValidationVisitor());
+      *proto_config, context, ProtobufMessage::getNullValidationVisitor()).value();
   const auto* config = dynamic_cast<const FilterConfig*>(route_config.get());
   EXPECT_EQ(config->limit(), 10);
   EXPECT_EQ(config->fillInterval().count(), 50);
@@ -122,7 +122,7 @@ TEST(Factory, PerRouteConfigNoLimits) {
 
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   EXPECT_THROW(factory.createRouteSpecificFilterConfig(*proto_config, context,
-                                                       ProtobufMessage::getNullValidationVisitor()),
+                                                       ProtobufMessage::getNullValidationVisitor()).value(),
                EnvoyException);
 }
 } // namespace BandwidthLimitFilter

--- a/test/extensions/filters/http/buffer/config_test.cc
+++ b/test/extensions/filters/http/buffer/config_test.cc
@@ -106,7 +106,7 @@ TEST(BufferFilterFactoryTest, BufferFilterRouteSpecificConfig) {
 
   Router::RouteSpecificFilterConfigConstSharedPtr route_config =
       factory.createRouteSpecificFilterConfig(*proto_config, factory_context,
-                                              ProtobufMessage::getNullValidationVisitor());
+                                              ProtobufMessage::getNullValidationVisitor()).value();
   EXPECT_TRUE(route_config.get());
 
   const auto* inflated = dynamic_cast<const BufferFilterSettings*>(route_config.get());

--- a/test/extensions/filters/http/buffer/config_test.cc
+++ b/test/extensions/filters/http/buffer/config_test.cc
@@ -105,8 +105,10 @@ TEST(BufferFilterFactoryTest, BufferFilterRouteSpecificConfig) {
   cfg.set_disabled(true);
 
   Router::RouteSpecificFilterConfigConstSharedPtr route_config =
-      factory.createRouteSpecificFilterConfig(*proto_config, factory_context,
-                                              ProtobufMessage::getNullValidationVisitor()).value();
+      factory
+          .createRouteSpecificFilterConfig(*proto_config, factory_context,
+                                           ProtobufMessage::getNullValidationVisitor())
+          .value();
   EXPECT_TRUE(route_config.get());
 
   const auto* inflated = dynamic_cast<const BufferFilterSettings*>(route_config.get());

--- a/test/extensions/filters/http/compressor/config_test.cc
+++ b/test/extensions/filters/http/compressor/config_test.cc
@@ -37,9 +37,11 @@ TEST(CompressorFilterFactoryTests, EmptyPerRouteConfig) {
   envoy::extensions::filters::http::compressor::v3::CompressorPerRoute per_route;
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   CompressorFilterFactory factory;
-  EXPECT_THROW(factory.createRouteSpecificFilterConfig(per_route, context,
-                                                       context.messageValidationVisitor()).value(),
-               ProtoValidationException);
+  EXPECT_THROW(
+      factory
+          .createRouteSpecificFilterConfig(per_route, context, context.messageValidationVisitor())
+          .value(),
+      ProtoValidationException);
 }
 
 } // namespace

--- a/test/extensions/filters/http/compressor/config_test.cc
+++ b/test/extensions/filters/http/compressor/config_test.cc
@@ -38,7 +38,7 @@ TEST(CompressorFilterFactoryTests, EmptyPerRouteConfig) {
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   CompressorFilterFactory factory;
   EXPECT_THROW(factory.createRouteSpecificFilterConfig(per_route, context,
-                                                       context.messageValidationVisitor()),
+                                                       context.messageValidationVisitor()).value(),
                ProtoValidationException);
 }
 

--- a/test/extensions/filters/http/dynamic_forward_proxy/config_test.cc
+++ b/test/extensions/filters/http/dynamic_forward_proxy/config_test.cc
@@ -26,8 +26,10 @@ TEST(DynamicForwardProxyFilterFactoryTest, RouteSpecificConfig) {
   EXPECT_TRUE(proto_config.get());
 
   Router::RouteSpecificFilterConfigConstSharedPtr route_config =
-      factory.createRouteSpecificFilterConfig(*proto_config, context,
-                                              ProtobufMessage::getNullValidationVisitor()).value();
+      factory
+          .createRouteSpecificFilterConfig(*proto_config, context,
+                                           ProtobufMessage::getNullValidationVisitor())
+          .value();
   EXPECT_TRUE(route_config.get());
 }
 

--- a/test/extensions/filters/http/dynamic_forward_proxy/config_test.cc
+++ b/test/extensions/filters/http/dynamic_forward_proxy/config_test.cc
@@ -27,7 +27,7 @@ TEST(DynamicForwardProxyFilterFactoryTest, RouteSpecificConfig) {
 
   Router::RouteSpecificFilterConfigConstSharedPtr route_config =
       factory.createRouteSpecificFilterConfig(*proto_config, context,
-                                              ProtobufMessage::getNullValidationVisitor());
+                                              ProtobufMessage::getNullValidationVisitor()).value();
   EXPECT_TRUE(route_config.get());
 }
 

--- a/test/extensions/filters/http/ext_proc/config_test.cc
+++ b/test/extensions/filters/http/ext_proc/config_test.cc
@@ -147,7 +147,7 @@ TEST(HttpExtProcConfigTest, CorrectRouteMetadataOnlyConfig) {
 
   testing::NiceMock<Server::Configuration::MockServerFactoryContext> context;
   Router::RouteSpecificFilterConfigConstSharedPtr cb = factory.createRouteSpecificFilterConfig(
-      *proto_config, context, context.messageValidationVisitor());
+      *proto_config, context, context.messageValidationVisitor()).value();
 }
 
 TEST(HttpExtProcConfigTest, InvalidServiceConfig) {
@@ -451,7 +451,7 @@ TEST(HttpExtProcConfigTest, CompleteRouteConfig) {
 
   testing::NiceMock<Server::Configuration::MockServerFactoryContext> context;
   Router::RouteSpecificFilterConfigConstSharedPtr cb = factory.createRouteSpecificFilterConfig(
-      *proto_config, context, context.messageValidationVisitor());
+      *proto_config, context, context.messageValidationVisitor()).value();
   ASSERT_NE(nullptr, cb);
 }
 

--- a/test/extensions/filters/http/ext_proc/config_test.cc
+++ b/test/extensions/filters/http/ext_proc/config_test.cc
@@ -146,8 +146,11 @@ TEST(HttpExtProcConfigTest, CorrectRouteMetadataOnlyConfig) {
   TestUtility::loadFromYaml(yaml, *proto_config);
 
   testing::NiceMock<Server::Configuration::MockServerFactoryContext> context;
-  Router::RouteSpecificFilterConfigConstSharedPtr cb = factory.createRouteSpecificFilterConfig(
-      *proto_config, context, context.messageValidationVisitor()).value();
+  Router::RouteSpecificFilterConfigConstSharedPtr cb =
+      factory
+          .createRouteSpecificFilterConfig(*proto_config, context,
+                                           context.messageValidationVisitor())
+          .value();
 }
 
 TEST(HttpExtProcConfigTest, InvalidServiceConfig) {
@@ -450,8 +453,11 @@ TEST(HttpExtProcConfigTest, CompleteRouteConfig) {
   TestUtility::loadFromYaml(yaml, *proto_config);
 
   testing::NiceMock<Server::Configuration::MockServerFactoryContext> context;
-  Router::RouteSpecificFilterConfigConstSharedPtr cb = factory.createRouteSpecificFilterConfig(
-      *proto_config, context, context.messageValidationVisitor()).value();
+  Router::RouteSpecificFilterConfigConstSharedPtr cb =
+      factory
+          .createRouteSpecificFilterConfig(*proto_config, context,
+                                           context.messageValidationVisitor())
+          .value();
   ASSERT_NE(nullptr, cb);
 }
 

--- a/test/extensions/filters/http/file_system_buffer/config_test.cc
+++ b/test/extensions/filters/http/file_system_buffer/config_test.cc
@@ -64,8 +64,10 @@ public:
   makeRouteConfig(const ProtoFileSystemBufferFilterConfig& route_proto_config) {
     NiceMock<Server::Configuration::MockServerFactoryContext> context;
     return std::dynamic_pointer_cast<const FileSystemBufferFilterConfig>(
-        factory()->createRouteSpecificFilterConfig(route_proto_config, context,
-                                                   ProtobufMessage::getNullValidationVisitor()).value());
+        factory()
+            ->createRouteSpecificFilterConfig(route_proto_config, context,
+                                              ProtobufMessage::getNullValidationVisitor())
+            .value());
   }
 };
 

--- a/test/extensions/filters/http/file_system_buffer/config_test.cc
+++ b/test/extensions/filters/http/file_system_buffer/config_test.cc
@@ -65,7 +65,7 @@ public:
     NiceMock<Server::Configuration::MockServerFactoryContext> context;
     return std::dynamic_pointer_cast<const FileSystemBufferFilterConfig>(
         factory()->createRouteSpecificFilterConfig(route_proto_config, context,
-                                                   ProtobufMessage::getNullValidationVisitor()));
+                                                   ProtobufMessage::getNullValidationVisitor()).value());
   }
 };
 

--- a/test/extensions/filters/http/grpc_http1_reverse_bridge/config_test.cc
+++ b/test/extensions/filters/http/grpc_http1_reverse_bridge/config_test.cc
@@ -48,8 +48,10 @@ TEST(ReverseBridgeFilterFactoryTest, ReverseBridgeFilterRouteSpecificConfig) {
   cfg.set_disabled(true);
 
   Router::RouteSpecificFilterConfigConstSharedPtr route_config =
-      config_factory.createRouteSpecificFilterConfig(*proto_config, factory_context,
-                                                     ProtobufMessage::getNullValidationVisitor()).value();
+      config_factory
+          .createRouteSpecificFilterConfig(*proto_config, factory_context,
+                                           ProtobufMessage::getNullValidationVisitor())
+          .value();
   EXPECT_TRUE(route_config.get());
 
   const auto* inflated = dynamic_cast<const FilterConfigPerRoute*>(route_config.get());

--- a/test/extensions/filters/http/grpc_http1_reverse_bridge/config_test.cc
+++ b/test/extensions/filters/http/grpc_http1_reverse_bridge/config_test.cc
@@ -49,7 +49,7 @@ TEST(ReverseBridgeFilterFactoryTest, ReverseBridgeFilterRouteSpecificConfig) {
 
   Router::RouteSpecificFilterConfigConstSharedPtr route_config =
       config_factory.createRouteSpecificFilterConfig(*proto_config, factory_context,
-                                                     ProtobufMessage::getNullValidationVisitor());
+                                                     ProtobufMessage::getNullValidationVisitor()).value();
   EXPECT_TRUE(route_config.get());
 
   const auto* inflated = dynamic_cast<const FilterConfigPerRoute*>(route_config.get());

--- a/test/extensions/filters/http/header_mutation/config_test.cc
+++ b/test/extensions/filters/http/header_mutation/config_test.cc
@@ -57,7 +57,7 @@ TEST(FactoryTest, FactoryTest) {
 
   EXPECT_NE(nullptr, factory->createRouteSpecificFilterConfig(
                          per_route_proto_config, mock_factory_context.server_factory_context_,
-                         mock_factory_context.messageValidationVisitor()));
+                         mock_factory_context.messageValidationVisitor()).value());
 }
 
 TEST(FactoryTest, UpstreamFactoryTest) {

--- a/test/extensions/filters/http/header_mutation/config_test.cc
+++ b/test/extensions/filters/http/header_mutation/config_test.cc
@@ -55,9 +55,11 @@ TEST(FactoryTest, FactoryTest) {
   EXPECT_CALL(filter_callbacks, addStreamFilter(_));
   cb(filter_callbacks);
 
-  EXPECT_NE(nullptr, factory->createRouteSpecificFilterConfig(
-                         per_route_proto_config, mock_factory_context.server_factory_context_,
-                         mock_factory_context.messageValidationVisitor()).value());
+  EXPECT_NE(nullptr, factory
+                         ->createRouteSpecificFilterConfig(
+                             per_route_proto_config, mock_factory_context.server_factory_context_,
+                             mock_factory_context.messageValidationVisitor())
+                         .value());
 }
 
 TEST(FactoryTest, UpstreamFactoryTest) {

--- a/test/extensions/filters/http/header_to_metadata/config_test.cc
+++ b/test/extensions/filters/http/header_to_metadata/config_test.cc
@@ -143,7 +143,7 @@ request_rules:
   HeaderToMetadataConfig factory;
 
   const auto route_config = factory.createRouteSpecificFilterConfig(
-      proto_config, context, ProtobufMessage::getNullValidationVisitor());
+      proto_config, context, ProtobufMessage::getNullValidationVisitor()).value();
   const auto* config = dynamic_cast<const Config*>(route_config.get());
   EXPECT_TRUE(config->doRequest());
   EXPECT_FALSE(config->doResponse());

--- a/test/extensions/filters/http/header_to_metadata/config_test.cc
+++ b/test/extensions/filters/http/header_to_metadata/config_test.cc
@@ -142,8 +142,11 @@ request_rules:
   testing::NiceMock<Server::Configuration::MockServerFactoryContext> context;
   HeaderToMetadataConfig factory;
 
-  const auto route_config = factory.createRouteSpecificFilterConfig(
-      proto_config, context, ProtobufMessage::getNullValidationVisitor()).value();
+  const auto route_config =
+      factory
+          .createRouteSpecificFilterConfig(proto_config, context,
+                                           ProtobufMessage::getNullValidationVisitor())
+          .value();
   const auto* config = dynamic_cast<const Config*>(route_config.get());
   EXPECT_TRUE(config->doRequest());
   EXPECT_FALSE(config->doResponse());

--- a/test/extensions/filters/http/jwt_authn/filter_factory_test.cc
+++ b/test/extensions/filters/http/jwt_authn/filter_factory_test.cc
@@ -81,7 +81,7 @@ TEST(HttpJwtAuthnFilterFactoryTest, EmptyPerRouteConfig) {
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   FilterFactory factory;
   EXPECT_THROW(factory.createRouteSpecificFilterConfig(per_route, context,
-                                                       context.messageValidationVisitor()),
+                                                       context.messageValidationVisitor()).value(),
                EnvoyException);
 }
 
@@ -90,7 +90,7 @@ TEST(HttpJwtAuthnFilterFactoryTest, WrongPerRouteConfigType) {
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   FilterFactory factory;
   EXPECT_THROW(factory.createRouteSpecificFilterConfig(per_route, context,
-                                                       context.messageValidationVisitor()),
+                                                       context.messageValidationVisitor()).value(),
                std::bad_cast);
 }
 
@@ -101,7 +101,7 @@ TEST(HttpJwtAuthnFilterFactoryTest, DisabledPerRouteConfig) {
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   FilterFactory factory;
   auto base_ptr = factory.createRouteSpecificFilterConfig(per_route, context,
-                                                          context.messageValidationVisitor());
+                                                          context.messageValidationVisitor()).value();
   EXPECT_NE(base_ptr, nullptr);
   const PerRouteFilterConfig* typed_ptr = dynamic_cast<const PerRouteFilterConfig*>(base_ptr.get());
   EXPECT_NE(typed_ptr, nullptr);
@@ -115,7 +115,7 @@ TEST(HttpJwtAuthnFilterFactoryTest, GoodPerRouteConfig) {
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   FilterFactory factory;
   auto base_ptr = factory.createRouteSpecificFilterConfig(per_route, context,
-                                                          context.messageValidationVisitor());
+                                                          context.messageValidationVisitor()).value();
   EXPECT_NE(base_ptr, nullptr);
   const PerRouteFilterConfig* typed_ptr = dynamic_cast<const PerRouteFilterConfig*>(base_ptr.get());
   EXPECT_NE(typed_ptr, nullptr);

--- a/test/extensions/filters/http/jwt_authn/filter_factory_test.cc
+++ b/test/extensions/filters/http/jwt_authn/filter_factory_test.cc
@@ -80,18 +80,22 @@ TEST(HttpJwtAuthnFilterFactoryTest, EmptyPerRouteConfig) {
   PerRouteConfig per_route;
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   FilterFactory factory;
-  EXPECT_THROW(factory.createRouteSpecificFilterConfig(per_route, context,
-                                                       context.messageValidationVisitor()).value(),
-               EnvoyException);
+  EXPECT_THROW(
+      factory
+          .createRouteSpecificFilterConfig(per_route, context, context.messageValidationVisitor())
+          .value(),
+      EnvoyException);
 }
 
 TEST(HttpJwtAuthnFilterFactoryTest, WrongPerRouteConfigType) {
   JwtAuthentication per_route;
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   FilterFactory factory;
-  EXPECT_THROW(factory.createRouteSpecificFilterConfig(per_route, context,
-                                                       context.messageValidationVisitor()).value(),
-               std::bad_cast);
+  EXPECT_THROW(
+      factory
+          .createRouteSpecificFilterConfig(per_route, context, context.messageValidationVisitor())
+          .value(),
+      std::bad_cast);
 }
 
 TEST(HttpJwtAuthnFilterFactoryTest, DisabledPerRouteConfig) {
@@ -100,8 +104,10 @@ TEST(HttpJwtAuthnFilterFactoryTest, DisabledPerRouteConfig) {
 
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   FilterFactory factory;
-  auto base_ptr = factory.createRouteSpecificFilterConfig(per_route, context,
-                                                          context.messageValidationVisitor()).value();
+  auto base_ptr =
+      factory
+          .createRouteSpecificFilterConfig(per_route, context, context.messageValidationVisitor())
+          .value();
   EXPECT_NE(base_ptr, nullptr);
   const PerRouteFilterConfig* typed_ptr = dynamic_cast<const PerRouteFilterConfig*>(base_ptr.get());
   EXPECT_NE(typed_ptr, nullptr);
@@ -114,8 +120,10 @@ TEST(HttpJwtAuthnFilterFactoryTest, GoodPerRouteConfig) {
 
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   FilterFactory factory;
-  auto base_ptr = factory.createRouteSpecificFilterConfig(per_route, context,
-                                                          context.messageValidationVisitor()).value();
+  auto base_ptr =
+      factory
+          .createRouteSpecificFilterConfig(per_route, context, context.messageValidationVisitor())
+          .value();
   EXPECT_NE(base_ptr, nullptr);
   const PerRouteFilterConfig* typed_ptr = dynamic_cast<const PerRouteFilterConfig*>(base_ptr.get());
   EXPECT_NE(typed_ptr, nullptr);

--- a/test/extensions/filters/http/kill_request/kill_request_config_test.cc
+++ b/test/extensions/filters/http/kill_request/kill_request_config_test.cc
@@ -49,8 +49,10 @@ TEST(KillRequestConfigTest, RouteSpecificConfig) {
   EXPECT_TRUE(proto_config.get());
 
   Router::RouteSpecificFilterConfigConstSharedPtr route_config =
-      factory.createRouteSpecificFilterConfig(*proto_config, context,
-                                              ProtobufMessage::getNullValidationVisitor()).value();
+      factory
+          .createRouteSpecificFilterConfig(*proto_config, context,
+                                           ProtobufMessage::getNullValidationVisitor())
+          .value();
   EXPECT_TRUE(route_config.get());
 }
 

--- a/test/extensions/filters/http/kill_request/kill_request_config_test.cc
+++ b/test/extensions/filters/http/kill_request/kill_request_config_test.cc
@@ -50,7 +50,7 @@ TEST(KillRequestConfigTest, RouteSpecificConfig) {
 
   Router::RouteSpecificFilterConfigConstSharedPtr route_config =
       factory.createRouteSpecificFilterConfig(*proto_config, context,
-                                              ProtobufMessage::getNullValidationVisitor());
+                                              ProtobufMessage::getNullValidationVisitor()).value();
   EXPECT_TRUE(route_config.get());
 }
 

--- a/test/extensions/filters/http/local_ratelimit/config_test.cc
+++ b/test/extensions/filters/http/local_ratelimit/config_test.cc
@@ -62,7 +62,7 @@ response_headers_to_add:
 
   EXPECT_CALL(context.dispatcher_, createTimer_(_));
   const auto route_config = factory.createRouteSpecificFilterConfig(
-      *proto_config, context, ProtobufMessage::getNullValidationVisitor());
+      *proto_config, context, ProtobufMessage::getNullValidationVisitor()).value();
   const auto* config = dynamic_cast<const FilterConfig*>(route_config.get());
   EXPECT_TRUE(config->requestAllowed({}).allowed);
 }
@@ -84,7 +84,7 @@ token_bucket:
 
   EXPECT_CALL(context.dispatcher_, createTimer_(_));
   const auto route_config = factory.createRouteSpecificFilterConfig(
-      *proto_config, context, ProtobufMessage::getNullValidationVisitor());
+      *proto_config, context, ProtobufMessage::getNullValidationVisitor()).value();
   const auto* config = dynamic_cast<const FilterConfig*>(route_config.get());
   EXPECT_FALSE(config->enabled());
   EXPECT_FALSE(config->enforced());
@@ -101,7 +101,7 @@ stat_prefix: test
 
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   EXPECT_THROW(factory.createRouteSpecificFilterConfig(*proto_config, context,
-                                                       ProtobufMessage::getNullValidationVisitor()),
+                                                       ProtobufMessage::getNullValidationVisitor()).value(),
                EnvoyException);
 }
 
@@ -122,7 +122,7 @@ token_bucket:
 
   EXPECT_CALL(context.dispatcher_, createTimer_(_));
   EXPECT_THROW(factory.createRouteSpecificFilterConfig(*proto_config, context,
-                                                       ProtobufMessage::getNullValidationVisitor()),
+                                                       ProtobufMessage::getNullValidationVisitor()).value(),
                EnvoyException);
 }
 
@@ -167,7 +167,7 @@ descriptors:
 
   EXPECT_CALL(context.dispatcher_, createTimer_(_)).Times(0);
   EXPECT_THROW(factory.createRouteSpecificFilterConfig(*proto_config, context,
-                                                       ProtobufMessage::getNullValidationVisitor()),
+                                                       ProtobufMessage::getNullValidationVisitor()).value(),
                EnvoyException);
 }
 
@@ -220,7 +220,7 @@ descriptors:
 
   EXPECT_CALL(context.dispatcher_, createTimer_(_));
   const auto route_config = factory.createRouteSpecificFilterConfig(
-      *proto_config, context, ProtobufMessage::getNullValidationVisitor());
+      *proto_config, context, ProtobufMessage::getNullValidationVisitor()).value();
   const auto* config = dynamic_cast<const FilterConfig*>(route_config.get());
   EXPECT_TRUE(config->requestAllowed({}).allowed);
 }
@@ -274,7 +274,7 @@ descriptors:
 
   EXPECT_CALL(context.dispatcher_, createTimer_(_));
   EXPECT_THROW(factory.createRouteSpecificFilterConfig(*proto_config, context,
-                                                       ProtobufMessage::getNullValidationVisitor()),
+                                                       ProtobufMessage::getNullValidationVisitor()).value(),
                EnvoyException);
 }
 
@@ -308,7 +308,7 @@ response_headers_to_add:
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
 
   EXPECT_THROW(factory.createRouteSpecificFilterConfig(*proto_config, context,
-                                                       ProtobufMessage::getNullValidationVisitor()),
+                                                       ProtobufMessage::getNullValidationVisitor()).value(),
                EnvoyException);
 }
 
@@ -341,7 +341,7 @@ local_rate_limit_per_downstream_connection: true
 
   EXPECT_THROW_WITH_MESSAGE(
       factory.createRouteSpecificFilterConfig(*proto_config, context,
-                                              ProtobufMessage::getNullValidationVisitor()),
+                                              ProtobufMessage::getNullValidationVisitor()).value(),
       EnvoyException,
       "local_cluster_rate_limit is set and local_rate_limit_per_downstream_connection is set to "
       "true");
@@ -375,7 +375,7 @@ local_cluster_rate_limit: {}
 
   EXPECT_THROW_WITH_MESSAGE(
       factory.createRouteSpecificFilterConfig(*proto_config, context,
-                                              ProtobufMessage::getNullValidationVisitor()),
+                                              ProtobufMessage::getNullValidationVisitor()).value(),
       EnvoyException, "local_cluster_rate_limit is set but no local cluster name is present");
 }
 
@@ -408,7 +408,7 @@ local_cluster_rate_limit: {}
 
   EXPECT_THROW_WITH_MESSAGE(
       factory.createRouteSpecificFilterConfig(*proto_config, context,
-                                              ProtobufMessage::getNullValidationVisitor()),
+                                              ProtobufMessage::getNullValidationVisitor()).value(),
       EnvoyException, "local_cluster_rate_limit is set but no local cluster is present");
 }
 
@@ -445,8 +445,8 @@ local_cluster_rate_limit: {}
   EXPECT_CALL(*local_cluster, prioritySet()).WillOnce(ReturnRef(priority_set));
 
   EXPECT_CALL(context.dispatcher_, createTimer_(_));
-  EXPECT_NO_THROW(factory.createRouteSpecificFilterConfig(
-      *proto_config, context, ProtobufMessage::getNullValidationVisitor()));
+  EXPECT_TRUE(factory.createRouteSpecificFilterConfig(
+      *proto_config, context, ProtobufMessage::getNullValidationVisitor()).value());
 }
 
 } // namespace LocalRateLimitFilter

--- a/test/extensions/filters/http/local_ratelimit/config_test.cc
+++ b/test/extensions/filters/http/local_ratelimit/config_test.cc
@@ -61,8 +61,11 @@ response_headers_to_add:
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
 
   EXPECT_CALL(context.dispatcher_, createTimer_(_));
-  const auto route_config = factory.createRouteSpecificFilterConfig(
-      *proto_config, context, ProtobufMessage::getNullValidationVisitor()).value();
+  const auto route_config =
+      factory
+          .createRouteSpecificFilterConfig(*proto_config, context,
+                                           ProtobufMessage::getNullValidationVisitor())
+          .value();
   const auto* config = dynamic_cast<const FilterConfig*>(route_config.get());
   EXPECT_TRUE(config->requestAllowed({}).allowed);
 }
@@ -83,8 +86,11 @@ token_bucket:
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
 
   EXPECT_CALL(context.dispatcher_, createTimer_(_));
-  const auto route_config = factory.createRouteSpecificFilterConfig(
-      *proto_config, context, ProtobufMessage::getNullValidationVisitor()).value();
+  const auto route_config =
+      factory
+          .createRouteSpecificFilterConfig(*proto_config, context,
+                                           ProtobufMessage::getNullValidationVisitor())
+          .value();
   const auto* config = dynamic_cast<const FilterConfig*>(route_config.get());
   EXPECT_FALSE(config->enabled());
   EXPECT_FALSE(config->enforced());
@@ -100,8 +106,10 @@ stat_prefix: test
   TestUtility::loadFromYaml(config_yaml, *proto_config);
 
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
-  EXPECT_THROW(factory.createRouteSpecificFilterConfig(*proto_config, context,
-                                                       ProtobufMessage::getNullValidationVisitor()).value(),
+  EXPECT_THROW(factory
+                   .createRouteSpecificFilterConfig(*proto_config, context,
+                                                    ProtobufMessage::getNullValidationVisitor())
+                   .value(),
                EnvoyException);
 }
 
@@ -121,8 +129,10 @@ token_bucket:
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
 
   EXPECT_CALL(context.dispatcher_, createTimer_(_));
-  EXPECT_THROW(factory.createRouteSpecificFilterConfig(*proto_config, context,
-                                                       ProtobufMessage::getNullValidationVisitor()).value(),
+  EXPECT_THROW(factory
+                   .createRouteSpecificFilterConfig(*proto_config, context,
+                                                    ProtobufMessage::getNullValidationVisitor())
+                   .value(),
                EnvoyException);
 }
 
@@ -166,8 +176,10 @@ descriptors:
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
 
   EXPECT_CALL(context.dispatcher_, createTimer_(_)).Times(0);
-  EXPECT_THROW(factory.createRouteSpecificFilterConfig(*proto_config, context,
-                                                       ProtobufMessage::getNullValidationVisitor()).value(),
+  EXPECT_THROW(factory
+                   .createRouteSpecificFilterConfig(*proto_config, context,
+                                                    ProtobufMessage::getNullValidationVisitor())
+                   .value(),
                EnvoyException);
 }
 
@@ -219,8 +231,11 @@ descriptors:
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
 
   EXPECT_CALL(context.dispatcher_, createTimer_(_));
-  const auto route_config = factory.createRouteSpecificFilterConfig(
-      *proto_config, context, ProtobufMessage::getNullValidationVisitor()).value();
+  const auto route_config =
+      factory
+          .createRouteSpecificFilterConfig(*proto_config, context,
+                                           ProtobufMessage::getNullValidationVisitor())
+          .value();
   const auto* config = dynamic_cast<const FilterConfig*>(route_config.get());
   EXPECT_TRUE(config->requestAllowed({}).allowed);
 }
@@ -273,8 +288,10 @@ descriptors:
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
 
   EXPECT_CALL(context.dispatcher_, createTimer_(_));
-  EXPECT_THROW(factory.createRouteSpecificFilterConfig(*proto_config, context,
-                                                       ProtobufMessage::getNullValidationVisitor()).value(),
+  EXPECT_THROW(factory
+                   .createRouteSpecificFilterConfig(*proto_config, context,
+                                                    ProtobufMessage::getNullValidationVisitor())
+                   .value(),
                EnvoyException);
 }
 
@@ -307,8 +324,10 @@ response_headers_to_add:
 
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
 
-  EXPECT_THROW(factory.createRouteSpecificFilterConfig(*proto_config, context,
-                                                       ProtobufMessage::getNullValidationVisitor()).value(),
+  EXPECT_THROW(factory
+                   .createRouteSpecificFilterConfig(*proto_config, context,
+                                                    ProtobufMessage::getNullValidationVisitor())
+                   .value(),
                EnvoyException);
 }
 
@@ -340,8 +359,10 @@ local_rate_limit_per_downstream_connection: true
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
 
   EXPECT_THROW_WITH_MESSAGE(
-      factory.createRouteSpecificFilterConfig(*proto_config, context,
-                                              ProtobufMessage::getNullValidationVisitor()).value(),
+      factory
+          .createRouteSpecificFilterConfig(*proto_config, context,
+                                           ProtobufMessage::getNullValidationVisitor())
+          .value(),
       EnvoyException,
       "local_cluster_rate_limit is set and local_rate_limit_per_downstream_connection is set to "
       "true");
@@ -374,8 +395,10 @@ local_cluster_rate_limit: {}
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
 
   EXPECT_THROW_WITH_MESSAGE(
-      factory.createRouteSpecificFilterConfig(*proto_config, context,
-                                              ProtobufMessage::getNullValidationVisitor()).value(),
+      factory
+          .createRouteSpecificFilterConfig(*proto_config, context,
+                                           ProtobufMessage::getNullValidationVisitor())
+          .value(),
       EnvoyException, "local_cluster_rate_limit is set but no local cluster name is present");
 }
 
@@ -407,8 +430,10 @@ local_cluster_rate_limit: {}
   context.cluster_manager_.local_cluster_name_ = "local_cluster";
 
   EXPECT_THROW_WITH_MESSAGE(
-      factory.createRouteSpecificFilterConfig(*proto_config, context,
-                                              ProtobufMessage::getNullValidationVisitor()).value(),
+      factory
+          .createRouteSpecificFilterConfig(*proto_config, context,
+                                           ProtobufMessage::getNullValidationVisitor())
+          .value(),
       EnvoyException, "local_cluster_rate_limit is set but no local cluster is present");
 }
 
@@ -445,8 +470,10 @@ local_cluster_rate_limit: {}
   EXPECT_CALL(*local_cluster, prioritySet()).WillOnce(ReturnRef(priority_set));
 
   EXPECT_CALL(context.dispatcher_, createTimer_(_));
-  EXPECT_TRUE(factory.createRouteSpecificFilterConfig(
-      *proto_config, context, ProtobufMessage::getNullValidationVisitor()).value());
+  EXPECT_TRUE(factory
+                  .createRouteSpecificFilterConfig(*proto_config, context,
+                                                   ProtobufMessage::getNullValidationVisitor())
+                  .value());
 }
 
 } // namespace LocalRateLimitFilter

--- a/test/extensions/filters/http/match_delegate/config_test.cc
+++ b/test/extensions/filters/http/match_delegate/config_test.cc
@@ -128,8 +128,10 @@ xds_matcher:
   envoy::extensions::common::matching::v3::ExtensionWithMatcherPerRoute config;
   TestUtility::loadFromYamlAndValidate(yaml, config);
   Router::RouteSpecificFilterConfigConstSharedPtr route_config =
-      factory.createRouteSpecificFilterConfig(config, server_factory_context,
-                                              ProtobufMessage::getNullValidationVisitor()).value();
+      factory
+          .createRouteSpecificFilterConfig(config, server_factory_context,
+                                           ProtobufMessage::getNullValidationVisitor())
+          .value();
   EXPECT_TRUE(route_config.get());
 }
 

--- a/test/extensions/filters/http/match_delegate/config_test.cc
+++ b/test/extensions/filters/http/match_delegate/config_test.cc
@@ -129,7 +129,7 @@ xds_matcher:
   TestUtility::loadFromYamlAndValidate(yaml, config);
   Router::RouteSpecificFilterConfigConstSharedPtr route_config =
       factory.createRouteSpecificFilterConfig(config, server_factory_context,
-                                              ProtobufMessage::getNullValidationVisitor());
+                                              ProtobufMessage::getNullValidationVisitor()).value();
   EXPECT_TRUE(route_config.get());
 }
 

--- a/test/extensions/filters/http/rbac/config_test.cc
+++ b/test/extensions/filters/http/rbac/config_test.cc
@@ -114,8 +114,10 @@ TEST(RoleBasedAccessControlFilterConfigFactoryTest, RouteSpecificConfig) {
   EXPECT_TRUE(proto_config.get());
 
   Router::RouteSpecificFilterConfigConstSharedPtr route_config =
-      factory.createRouteSpecificFilterConfig(*proto_config, context,
-                                              ProtobufMessage::getNullValidationVisitor()).value();
+      factory
+          .createRouteSpecificFilterConfig(*proto_config, context,
+                                           ProtobufMessage::getNullValidationVisitor())
+          .value();
   EXPECT_TRUE(route_config.get());
 }
 

--- a/test/extensions/filters/http/rbac/config_test.cc
+++ b/test/extensions/filters/http/rbac/config_test.cc
@@ -115,7 +115,7 @@ TEST(RoleBasedAccessControlFilterConfigFactoryTest, RouteSpecificConfig) {
 
   Router::RouteSpecificFilterConfigConstSharedPtr route_config =
       factory.createRouteSpecificFilterConfig(*proto_config, context,
-                                              ProtobufMessage::getNullValidationVisitor());
+                                              ProtobufMessage::getNullValidationVisitor()).value();
   EXPECT_TRUE(route_config.get());
 }
 

--- a/test/extensions/filters/http/stateful_session/config_test.cc
+++ b/test/extensions/filters/http/stateful_session/config_test.cc
@@ -72,21 +72,29 @@ TEST(StatefulSessionFactoryConfigTest, SimpleConfigTest) {
   EXPECT_CALL(filter_callbacks, addStreamFilter(_));
   cb(filter_callbacks);
 
-  EXPECT_TRUE(factory.createRouteSpecificFilterConfig(proto_route_config, server_context,
-                                                          context.messageValidationVisitor()).ok());
-  EXPECT_TRUE(factory.createRouteSpecificFilterConfig(disabled_config, server_context,
-                                                          context.messageValidationVisitor()).ok());
+  EXPECT_TRUE(factory
+                  .createRouteSpecificFilterConfig(proto_route_config, server_context,
+                                                   context.messageValidationVisitor())
+                  .ok());
+  EXPECT_TRUE(factory
+                  .createRouteSpecificFilterConfig(disabled_config, server_context,
+                                                   context.messageValidationVisitor())
+                  .ok());
   EXPECT_THROW_WITH_MESSAGE(
-      factory.createRouteSpecificFilterConfig(not_exist_config, server_context,
-                                              context.messageValidationVisitor()).value(),
+      factory
+          .createRouteSpecificFilterConfig(not_exist_config, server_context,
+                                           context.messageValidationVisitor())
+          .value(),
       EnvoyException,
       "Didn't find a registered implementation for name: 'envoy.http.stateful_session.not_exist'");
 
   EXPECT_NO_THROW(factory.createFilterFactoryFromProto(empty_proto_config, "stats", context)
                       .status()
                       .IgnoreError());
-  EXPECT_TRUE(factory.createRouteSpecificFilterConfig(empty_proto_route_config, server_context,
-                                                          context.messageValidationVisitor()).ok());
+  EXPECT_TRUE(factory
+                  .createRouteSpecificFilterConfig(empty_proto_route_config, server_context,
+                                                   context.messageValidationVisitor())
+                  .ok());
 }
 
 } // namespace

--- a/test/extensions/filters/http/stateful_session/config_test.cc
+++ b/test/extensions/filters/http/stateful_session/config_test.cc
@@ -72,21 +72,21 @@ TEST(StatefulSessionFactoryConfigTest, SimpleConfigTest) {
   EXPECT_CALL(filter_callbacks, addStreamFilter(_));
   cb(filter_callbacks);
 
-  EXPECT_NO_THROW(factory.createRouteSpecificFilterConfig(proto_route_config, server_context,
-                                                          context.messageValidationVisitor()));
-  EXPECT_NO_THROW(factory.createRouteSpecificFilterConfig(disabled_config, server_context,
-                                                          context.messageValidationVisitor()));
+  EXPECT_TRUE(factory.createRouteSpecificFilterConfig(proto_route_config, server_context,
+                                                          context.messageValidationVisitor()).ok());
+  EXPECT_TRUE(factory.createRouteSpecificFilterConfig(disabled_config, server_context,
+                                                          context.messageValidationVisitor()).ok());
   EXPECT_THROW_WITH_MESSAGE(
       factory.createRouteSpecificFilterConfig(not_exist_config, server_context,
-                                              context.messageValidationVisitor()),
+                                              context.messageValidationVisitor()).value(),
       EnvoyException,
       "Didn't find a registered implementation for name: 'envoy.http.stateful_session.not_exist'");
 
   EXPECT_NO_THROW(factory.createFilterFactoryFromProto(empty_proto_config, "stats", context)
                       .status()
                       .IgnoreError());
-  EXPECT_NO_THROW(factory.createRouteSpecificFilterConfig(empty_proto_route_config, server_context,
-                                                          context.messageValidationVisitor()));
+  EXPECT_TRUE(factory.createRouteSpecificFilterConfig(empty_proto_route_config, server_context,
+                                                          context.messageValidationVisitor()).ok());
 }
 
 } // namespace

--- a/test/extensions/filters/network/generic_proxy/router/config_test.cc
+++ b/test/extensions/filters/network/generic_proxy/router/config_test.cc
@@ -22,7 +22,7 @@ TEST(RouterFactoryTest, RouterFactoryTest) {
 
   EXPECT_NE(nullptr, factory.createEmptyConfigProto());
   EXPECT_EQ(nullptr, factory.createEmptyRouteConfigProto());
-  EXPECT_FALSE(nullptr, factory.createRouteSpecificFilterConfig(
+  EXPECT_EQ(nullptr, factory.createRouteSpecificFilterConfig(
                          proto_config, factory_context.serverFactoryContext(),
                          factory_context.messageValidationVisitor()));
   EXPECT_EQ("envoy.filters.generic.router", factory.name());

--- a/test/extensions/filters/network/generic_proxy/router/config_test.cc
+++ b/test/extensions/filters/network/generic_proxy/router/config_test.cc
@@ -22,7 +22,7 @@ TEST(RouterFactoryTest, RouterFactoryTest) {
 
   EXPECT_NE(nullptr, factory.createEmptyConfigProto());
   EXPECT_EQ(nullptr, factory.createEmptyRouteConfigProto());
-  EXPECT_EQ(nullptr, factory.createRouteSpecificFilterConfig(
+  EXPECT_FALSE(nullptr, factory.createRouteSpecificFilterConfig(
                          proto_config, factory_context.serverFactoryContext(),
                          factory_context.messageValidationVisitor()));
   EXPECT_EQ("envoy.filters.generic.router", factory.name());

--- a/test/integration/filters/set_response_code_filter.cc
+++ b/test/integration/filters/set_response_code_filter.cc
@@ -105,7 +105,7 @@ private:
     };
   }
 
-  Router::RouteSpecificFilterConfigConstSharedPtr createRouteSpecificFilterConfigTyped(
+  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr> createRouteSpecificFilterConfigTyped(
       const test::integration::filters::SetResponseCodePerRouteFilterConfig& proto_config,
       Server::Configuration::ServerFactoryContext& context,
       ProtobufMessage::ValidationVisitor&) override {
@@ -145,7 +145,7 @@ private:
     };
   }
 
-  Router::RouteSpecificFilterConfigConstSharedPtr createRouteSpecificFilterConfigTyped(
+  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr> createRouteSpecificFilterConfigTyped(
       const test::integration::filters::SetResponseCodePerRouteFilterConfigDual& proto_config,
       Server::Configuration::ServerFactoryContext& context,
       ProtobufMessage::ValidationVisitor&) override {

--- a/test/integration/filters/set_response_code_filter.cc
+++ b/test/integration/filters/set_response_code_filter.cc
@@ -105,7 +105,8 @@ private:
     };
   }
 
-  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr> createRouteSpecificFilterConfigTyped(
+  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
+  createRouteSpecificFilterConfigTyped(
       const test::integration::filters::SetResponseCodePerRouteFilterConfig& proto_config,
       Server::Configuration::ServerFactoryContext& context,
       ProtobufMessage::ValidationVisitor&) override {
@@ -145,7 +146,8 @@ private:
     };
   }
 
-  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr> createRouteSpecificFilterConfigTyped(
+  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
+  createRouteSpecificFilterConfigTyped(
       const test::integration::filters::SetResponseCodePerRouteFilterConfigDual& proto_config,
       Server::Configuration::ServerFactoryContext& context,
       ProtobufMessage::ValidationVisitor&) override {


### PR DESCRIPTION
Commit Message: Return StatusOr from createRouteSpecificFilterConfig for exception removal

Additional Description:
This makes createRouteSpecificFilterConfig method return the 
StatusOr wrapped pointer to prepare for removing exceptions
from extension factory code path. The number of changed files
is large but almost all change is just wrapping the return
type with absl::StatusOr.  

Risk Level: low
Testing: existing tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
