### PR TITLE
clang-tidy: fixes errors in common/tcp

### DIFF
--- a/source/common/tcp/async_tcp_client_impl.cc
+++ b/source/common/tcp/async_tcp_client_impl.cc
@@ -29,7 +29,7 @@ AsyncTcpClientImpl::~AsyncTcpClientImpl() {
     connection_->removeConnectionCallbacks(*this);
   }
 
-  close(Network::ConnectionCloseType::NoFlush);
+  closeImpl(Network::ConnectionCloseType::NoFlush);
 }
 
 bool AsyncTcpClientImpl::connect() {
@@ -76,7 +76,7 @@ void AsyncTcpClientImpl::onConnectTimeout() {
   close(Network::ConnectionCloseType::NoFlush);
 }
 
-void AsyncTcpClientImpl::close(Network::ConnectionCloseType type) {
+void AsyncTcpClientImpl::closeImpl(Network::ConnectionCloseType type) {
   if (connection_ && !closing_) {
     closing_ = true;
     connection_->close(type);

--- a/source/common/tcp/async_tcp_client_impl.h
+++ b/source/common/tcp/async_tcp_client_impl.h
@@ -68,7 +68,7 @@ public:
   }
 
 private:
-  // This implments the AsyncTcpClient::close but exists as non-virtual to avoid calling it in the
+  // This implements the AsyncTcpClient::close but exists as non-virtual to avoid calling it in the
   // destructor.
   void closeImpl(Network::ConnectionCloseType type);
 

--- a/source/common/tcp/async_tcp_client_impl.h
+++ b/source/common/tcp/async_tcp_client_impl.h
@@ -28,9 +28,9 @@ public:
   AsyncTcpClientImpl(Event::Dispatcher& dispatcher,
                      Upstream::ThreadLocalCluster& thread_local_cluster,
                      Upstream::LoadBalancerContext* context, bool enable_half_close);
-  ~AsyncTcpClientImpl();
+  ~AsyncTcpClientImpl() override;
 
-  void close(Network::ConnectionCloseType type) override;
+  void close(Network::ConnectionCloseType type) override { closeImpl(type); }
 
   Network::DetectedCloseType detectedCloseType() const override { return detected_close_; }
 
@@ -68,6 +68,10 @@ public:
   }
 
 private:
+  // This implments the AsyncTcpClient::close but exists as non-virtual to avoid calling it in the
+  // destructor.
+  void closeImpl(Network::ConnectionCloseType type);
+
   struct NetworkReadFilter : public Network::ReadFilterBaseImpl {
     NetworkReadFilter(AsyncTcpClientImpl& parent) : parent_(parent) {}
 


### PR DESCRIPTION
part of #28566 