### PR TITLE
set_filter_state: enable per-route configuration override

### DIFF
--- a/source/extensions/filters/common/set_filter_state/filter_config.h
+++ b/source/extensions/filters/common/set_filter_state/filter_config.h
@@ -28,7 +28,8 @@ struct Value {
   Formatter::FormatterConstSharedPtr value_;
 };
 
-class Config : public Logger::Loggable<Logger::Id::config> {
+class Config : public ::Envoy::Router::RouteSpecificFilterConfig,
+               public Logger::Loggable<Logger::Id::config> {
 public:
   Config(const Protobuf::RepeatedPtrField<FilterStateValueProto>& proto_values, LifeSpan life_span,
          Server::Configuration::GenericFactoryContext& context)

--- a/source/extensions/filters/http/set_filter_state/config.h
+++ b/source/extensions/filters/http/set_filter_state/config.h
@@ -38,6 +38,10 @@ private:
       const envoy::extensions::filters::http::set_filter_state::v3::Config& proto_config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
 
+  Router::RouteSpecificFilterConfigConstSharedPtr createRouteSpecificFilterConfigTyped(
+      const envoy::extensions::filters::http::set_filter_state::v3::Config& proto_config,
+      Server::Configuration::ServerFactoryContext&, ProtobufMessage::ValidationVisitor&) override;
+
   Http::FilterFactoryCb createFilterFactoryFromProtoWithServerContextTyped(
       const envoy::extensions::filters::http::set_filter_state::v3::Config& proto_config,
       const std::string& stats_prefix,


### PR DESCRIPTION


Commit Message: set_filter_state: enable per-route configuration override
Additional Description:
This extends this filter to support usage in route configuration. When present, both the listener and route level settings are applied (listener first, then route).

Risk Level: Low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
