### PR TITLE
[mobile]Convert network type from enum to bitmap so that compound network type can be represented

### DIFF
--- a/mobile/library/cc/engine.cc
+++ b/mobile/library/cc/engine.cc
@@ -1,6 +1,5 @@
 #include "engine.h"
 
-#include "library/common/engine_types.h"
 #include "library/common/internal_engine.h"
 #include "library/common/types/c_types.h"
 
@@ -27,9 +26,7 @@ std::string Engine::dumpStats() { return engine_->dumpStats(); }
 
 envoy_status_t Engine::terminate() { return engine_->terminate(); }
 
-void Engine::onDefaultNetworkChanged(NetworkType network) {
-  engine_->onDefaultNetworkChanged(network);
-}
+void Engine::onDefaultNetworkChanged(int network) { engine_->onDefaultNetworkChanged(network); }
 
 void Engine::onDefaultNetworkUnavailable() { engine_->onDefaultNetworkUnavailable(); }
 

--- a/mobile/library/cc/engine.h
+++ b/mobile/library/cc/engine.h
@@ -3,7 +3,6 @@
 #include <functional>
 
 #include "library/cc/stream_client.h"
-#include "library/common/engine_types.h"
 #include "library/common/types/c_types.h"
 
 namespace Envoy {
@@ -21,7 +20,7 @@ public:
 
   std::string dumpStats();
   StreamClientSharedPtr streamClient();
-  void onDefaultNetworkChanged(NetworkType network);
+  void onDefaultNetworkChanged(int network);
   void onDefaultNetworkUnavailable();
   void onDefaultNetworkAvailable();
 

--- a/mobile/library/common/engine_types.h
+++ b/mobile/library/common/engine_types.h
@@ -138,12 +138,12 @@ struct EnvoyStreamCallbacks {
 
 /** Networks classified by the physical link. */
 enum class NetworkType : int {
-  // This is the default and includes cases where network characteristics are unknown.
-  Generic = 0,
+  // This includes VPN or cases where network characteristics are unknown.
+  Generic = 1, // 001
   // This includes WiFi and other local area wireless networks.
-  WLAN = 1,
+  WLAN = 2, // 010
   // This includes all mobile phone networks.
-  WWAN = 2,
+  WWAN = 4, // 100
 };
 
 } // namespace Envoy

--- a/mobile/library/common/internal_engine.cc
+++ b/mobile/library/common/internal_engine.cc
@@ -279,7 +279,7 @@ void InternalEngine::onDefaultNetworkAvailable() {
   ENVOY_LOG_MISC(trace, "Calling the default network available callback");
 }
 
-void InternalEngine::onDefaultNetworkChanged(NetworkType network) {
+void InternalEngine::onDefaultNetworkChanged(int network) {
   ENVOY_LOG_MISC(trace, "Calling the default network changed callback");
   dispatcher_->post([&, network]() -> void {
     envoy_netconf_t configuration = Network::ConnectivityManagerImpl::setPreferredNetwork(network);

--- a/mobile/library/common/internal_engine.h
+++ b/mobile/library/common/internal_engine.h
@@ -128,7 +128,7 @@ public:
    * - Force refresh the hosts in the DNS cache (will take `setIpVersionToRemove` into account).
    * - Optionally (if configured) clear HTTP/3 broken status.
    */
-  void onDefaultNetworkChanged(NetworkType network);
+  void onDefaultNetworkChanged(int network);
 
   /**
    * This functions does the following when the default network is unavailable.

--- a/mobile/library/common/network/connectivity_manager.h
+++ b/mobile/library/common/network/connectivity_manager.h
@@ -203,7 +203,7 @@ public:
    * @param network, the OS-preferred network.
    * @returns configuration key to associate with any related calls.
    */
-  static envoy_netconf_t setPreferredNetwork(NetworkType network);
+  static envoy_netconf_t setPreferredNetwork(int network);
 
   ConnectivityManagerImpl(Upstream::ClusterManager& cluster_manager,
                           DnsCacheManagerSharedPtr dns_cache_manager)

--- a/mobile/library/common/network/connectivity_manager.h
+++ b/mobile/library/common/network/connectivity_manager.h
@@ -106,7 +106,7 @@ public:
   /**
    * @returns the current OS default/preferred network class.
    */
-  virtual NetworkType getPreferredNetwork() PURE;
+  virtual int getPreferredNetwork() PURE;
 
   /**
    * @returns the current mode used to determine upstream socket options.
@@ -169,7 +169,7 @@ public:
   /**
    * @returns the current socket options that should be used for connections.
    */
-  virtual Socket::OptionsSharedPtr getUpstreamSocketOptions(NetworkType network,
+  virtual Socket::OptionsSharedPtr getUpstreamSocketOptions(int network,
                                                             SocketMode socket_mode) PURE;
 
   /**
@@ -225,7 +225,7 @@ public:
   std::vector<InterfacePair> enumerateV6Interfaces() override;
   std::vector<InterfacePair> enumerateInterfaces(unsigned short family, unsigned int select_flags,
                                                  unsigned int reject_flags) override;
-  NetworkType getPreferredNetwork() override;
+  int getPreferredNetwork() override;
   SocketMode getSocketMode() override;
   envoy_netconf_t getConfigurationKey() override;
   Envoy::Network::ProxySettingsConstSharedPtr getProxySettings() override;
@@ -235,8 +235,7 @@ public:
   void setInterfaceBindingEnabled(bool enabled) override;
   void refreshDns(envoy_netconf_t configuration_key, bool drain_connections) override;
   void resetConnectivityState() override;
-  Socket::OptionsSharedPtr getUpstreamSocketOptions(NetworkType network,
-                                                    SocketMode socket_mode) override;
+  Socket::OptionsSharedPtr getUpstreamSocketOptions(int network, SocketMode socket_mode) override;
   envoy_netconf_t addUpstreamSocketOptions(Socket::OptionsSharedPtr options) override;
   Extensions::Common::DynamicForwardProxy::DnsCacheSharedPtr dnsCache() override;
   Upstream::ClusterManager& clusterManager() override { return cluster_manager_; }
@@ -246,13 +245,13 @@ private:
     // The configuration key is passed through calls dispatched on the run loop to determine if
     // they're still valid/relevant at time of execution.
     envoy_netconf_t configuration_key_ ABSL_GUARDED_BY(mutex_);
-    NetworkType network_ ABSL_GUARDED_BY(mutex_);
+    int network_ ABSL_GUARDED_BY(mutex_);
     uint8_t remaining_faults_ ABSL_GUARDED_BY(mutex_);
     SocketMode socket_mode_ ABSL_GUARDED_BY(mutex_);
     Thread::MutexBasicLockable mutex_;
   };
-  Socket::OptionsSharedPtr getAlternateInterfaceSocketOptions(NetworkType network);
-  InterfacePair getActiveAlternateInterface(NetworkType network, unsigned short family);
+  Socket::OptionsSharedPtr getAlternateInterfaceSocketOptions(int network);
+  InterfacePair getActiveAlternateInterface(int network, unsigned short family);
 
   bool enable_drain_post_dns_refresh_{false};
   bool enable_interface_binding_{false};

--- a/mobile/library/java/io/envoyproxy/envoymobile/engine/AndroidEngineImpl.java
+++ b/mobile/library/java/io/envoyproxy/envoymobile/engine/AndroidEngineImpl.java
@@ -6,7 +6,6 @@ import android.net.ConnectivityManager;
 import io.envoyproxy.envoymobile.engine.types.EnvoyEventTracker;
 import io.envoyproxy.envoymobile.engine.types.EnvoyHTTPCallbacks;
 import io.envoyproxy.envoymobile.engine.types.EnvoyLogger;
-import io.envoyproxy.envoymobile.engine.types.EnvoyNetworkType;
 import io.envoyproxy.envoymobile.engine.types.EnvoyOnEngineRunning;
 import io.envoyproxy.envoymobile.engine.types.EnvoyStringAccessor;
 import io.envoyproxy.envoymobile.engine.types.EnvoyStatus;
@@ -86,7 +85,7 @@ public class AndroidEngineImpl implements EnvoyEngine {
   }
 
   @Override
-  public void onDefaultNetworkChanged(EnvoyNetworkType network) {
+  public void onDefaultNetworkChanged(int network) {
     envoyEngine.onDefaultNetworkChanged(network);
   }
 

--- a/mobile/library/java/io/envoyproxy/envoymobile/engine/AndroidNetworkMonitor.java
+++ b/mobile/library/java/io/envoyproxy/envoymobile/engine/AndroidNetworkMonitor.java
@@ -116,14 +116,20 @@ public class AndroidNetworkMonitor {
 
     private void onDefaultNetworkChanged(NetworkCapabilities networkCapabilities) {
       if (networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)) {
+        int networkType = 0;
         if (networkCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) ||
             networkCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI_AWARE)) {
-          envoyEngine.onDefaultNetworkChanged(EnvoyNetworkType.WLAN);
+          networkType |= EnvoyNetworkType.WLAN.getValue();
         } else if (networkCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR)) {
-          envoyEngine.onDefaultNetworkChanged(EnvoyNetworkType.WWAN);
+          networkType |= EnvoyNetworkType.WWAN.getValue();
         } else {
-          envoyEngine.onDefaultNetworkChanged(EnvoyNetworkType.GENERIC);
+          networkType |= EnvoyNetworkType.GENERIC.getValue();
         }
+        // A network can be both VPN and another type, so we need to check for VPN separately.
+        if (networkCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_VPN)) {
+          networkType |= EnvoyNetworkType.GENERIC.getValue();
+        }
+        envoyEngine.onDefaultNetworkChanged(networkType);
       }
       previousTransportTypes = getTransportTypes(networkCapabilities);
     }

--- a/mobile/library/java/io/envoyproxy/envoymobile/engine/EnvoyEngine.java
+++ b/mobile/library/java/io/envoyproxy/envoymobile/engine/EnvoyEngine.java
@@ -1,7 +1,6 @@
 package io.envoyproxy.envoymobile.engine;
 
 import io.envoyproxy.envoymobile.engine.types.EnvoyHTTPCallbacks;
-import io.envoyproxy.envoymobile.engine.types.EnvoyNetworkType;
 import io.envoyproxy.envoymobile.engine.types.EnvoyStringAccessor;
 import io.envoyproxy.envoymobile.engine.types.EnvoyStatus;
 
@@ -70,7 +69,7 @@ public interface EnvoyEngine {
   /**
    * A callback into the Envoy Engine when the default network type was changed.
    */
-  void onDefaultNetworkChanged(EnvoyNetworkType network);
+  void onDefaultNetworkChanged(int network);
 
   /**
    * A callback into the Envoy Engine when the default network is unavailable.

--- a/mobile/library/java/io/envoyproxy/envoymobile/engine/EnvoyEngineImpl.java
+++ b/mobile/library/java/io/envoyproxy/envoymobile/engine/EnvoyEngineImpl.java
@@ -5,7 +5,6 @@ import io.envoyproxy.envoymobile.engine.types.EnvoyHTTPCallbacks;
 import io.envoyproxy.envoymobile.engine.types.EnvoyHTTPFilterFactory;
 import io.envoyproxy.envoymobile.engine.types.EnvoyKeyValueStore;
 import io.envoyproxy.envoymobile.engine.types.EnvoyLogger;
-import io.envoyproxy.envoymobile.engine.types.EnvoyNetworkType;
 import io.envoyproxy.envoymobile.engine.types.EnvoyOnEngineRunning;
 import io.envoyproxy.envoymobile.engine.types.EnvoyStringAccessor;
 import io.envoyproxy.envoymobile.engine.types.EnvoyStatus;
@@ -141,9 +140,9 @@ public class EnvoyEngineImpl implements EnvoyEngine {
   }
 
   @Override
-  public void onDefaultNetworkChanged(EnvoyNetworkType network) {
+  public void onDefaultNetworkChanged(int network) {
     checkIsTerminated();
-    JniLibrary.onDefaultNetworkChanged(engineHandle, network.getValue());
+    JniLibrary.onDefaultNetworkChanged(engineHandle, network);
   }
 
   @Override

--- a/mobile/library/java/io/envoyproxy/envoymobile/engine/types/EnvoyNetworkType.java
+++ b/mobile/library/java/io/envoyproxy/envoymobile/engine/types/EnvoyNetworkType.java
@@ -2,9 +2,9 @@ package io.envoyproxy.envoymobile.engine.types;
 
 // Network interface type
 public enum EnvoyNetworkType {
-  GENERIC(0),
-  WLAN(1),
-  WWAN(2),
+  GENERIC(1),
+  WLAN(2),
+  WWAN(4),
   ;
 
   private final int value;

--- a/mobile/library/jni/jni_impl.cc
+++ b/mobile/library/jni/jni_impl.cc
@@ -1375,8 +1375,7 @@ extern "C" JNIEXPORT void JNICALL
 Java_io_envoyproxy_envoymobile_engine_JniLibrary_onDefaultNetworkChanged(JNIEnv*, jclass,
                                                                          jlong engine,
                                                                          jint network_type) {
-  reinterpret_cast<Envoy::InternalEngine*>(engine)->onDefaultNetworkChanged(
-      static_cast<Envoy::NetworkType>(network_type));
+  reinterpret_cast<Envoy::InternalEngine*>(engine)->onDefaultNetworkChanged(network_type);
 }
 
 extern "C" JNIEXPORT void JNICALL

--- a/mobile/library/objective-c/EnvoyNetworkMonitor.mm
+++ b/mobile/library/objective-c/EnvoyNetworkMonitor.mm
@@ -58,6 +58,7 @@
     }
 
     BOOL isCellular = nw_path_uses_interface_type(path, nw_interface_type_cellular);
+    int network = 0;
     if (!isCellular) {
       if (nw_path_uses_interface_type(path, nw_interface_type_wifi)) {
         network |= static_cast<int>(Envoy::NetworkType::WLAN);

--- a/mobile/library/objective-c/EnvoyNetworkMonitor.mm
+++ b/mobile/library/objective-c/EnvoyNetworkMonitor.mm
@@ -42,7 +42,7 @@
       dispatch_queue_create("io.envoyproxy.envoymobile.EnvoyNetworkMonitor", attrs);
   nw_path_monitor_set_queue(_path_monitor, queue);
 
-  __block Envoy::NetworkType previousNetworkType = (Envoy::NetworkType)-1;
+  __block int previousNetworkType = 0;
   Envoy::InternalEngine *engine = _engine;
   nw_path_monitor_set_update_handler(_path_monitor, ^(nw_path_t _Nonnull path) {
     BOOL isSatisfied = nw_path_get_status(path) == nw_path_status_satisfied;
@@ -58,10 +58,18 @@
     }
 
     BOOL isCellular = nw_path_uses_interface_type(path, nw_interface_type_cellular);
-    Envoy::NetworkType network = Envoy::NetworkType::WWAN;
     if (!isCellular) {
-      BOOL isWifi = nw_path_uses_interface_type(path, nw_interface_type_wifi);
-      network = isWifi ? Envoy::NetworkType::WLAN : Envoy::NetworkType::Generic;
+      if (nw_path_uses_interface_type(path, nw_interface_type_wifi)) {
+        network |= static_cast<int>(Envoy::NetworkType::WLAN);
+      } else {
+        network |= static_cast<int>(Envoy::NetworkType::Generic);
+      }
+    } else {
+      network |= static_cast<int>(Envoy::NetworkType::WWAN);
+    }
+    // Check for VPN
+    if (nw_path_uses_interface_type(path, nw_interface_type_other)) {
+      network |= static_cast<int>(Envoy::NetworkType::Generic);
     }
 
     if (network != previousNetworkType) {
@@ -98,6 +106,7 @@
   nw_path_monitor_start(_path_monitor);
 }
 
+// TODO(renjietang): API is deprecated, remove.
 - (void)startReachability {
   NSString *name = @"io.envoyproxy.envoymobile.EnvoyNetworkMonitor";
   SCNetworkReachabilityRef reachability =
@@ -135,8 +144,9 @@ static void _reachability_callback(SCNetworkReachabilityRef target,
 
   NSLog(@"[Envoy] setting preferred network to %@", isUsingWWAN ? @"WWAN" : @"WLAN");
   EnvoyNetworkMonitor *monitor = (__bridge EnvoyNetworkMonitor *)info;
-  monitor->_engine->onDefaultNetworkChanged(isUsingWWAN ? Envoy::NetworkType::WWAN
-                                                        : Envoy::NetworkType::WLAN);
+  monitor->_engine->onDefaultNetworkChanged(isUsingWWAN
+                                                ? static_cast<int>(Envoy::NetworkType::WWAN)
+                                                : static_cast<int>(Envoy::NetworkType::WLAN));
 }
 
 @end

--- a/mobile/test/common/extensions/filters/http/network_configuration/network_configuration_filter_test.cc
+++ b/mobile/test/common/extensions/filters/http/network_configuration/network_configuration_filter_test.cc
@@ -33,7 +33,7 @@ public:
   MOCK_METHOD(std::vector<Network::InterfacePair>, enumerateV6Interfaces, ());
   MOCK_METHOD(std::vector<Network::InterfacePair>, enumerateInterfaces,
               (unsigned short family, unsigned int select_flags, unsigned int reject_flags));
-  MOCK_METHOD(NetworkType, getPreferredNetwork, ());
+  MOCK_METHOD(int, getPreferredNetwork, ());
   MOCK_METHOD(Network::SocketMode, getSocketMode, ());
   MOCK_METHOD(envoy_netconf_t, getConfigurationKey, ());
   MOCK_METHOD(Envoy::Network::ProxySettingsConstSharedPtr, getProxySettings, ());
@@ -44,7 +44,7 @@ public:
   MOCK_METHOD(void, refreshDns, (envoy_netconf_t configuration_key, bool drain_connections));
   MOCK_METHOD(void, resetConnectivityState, ());
   MOCK_METHOD(Network::Socket::OptionsSharedPtr, getUpstreamSocketOptions,
-              (NetworkType network, Network::SocketMode socket_mode));
+              (int network, Network::SocketMode socket_mode));
   MOCK_METHOD(envoy_netconf_t, addUpstreamSocketOptions,
               (Network::Socket::OptionsSharedPtr options));
 

--- a/mobile/test/common/integration/client_integration_test.cc
+++ b/mobile/test/common/integration/client_integration_test.cc
@@ -1335,7 +1335,7 @@ TEST_P(ClientIntegrationTest, TestProxyResolutionApi) {
 TEST_P(ClientIntegrationTest, OnNetworkChanged) {
   builder_.addRuntimeGuard("dns_cache_set_ip_version_to_remove", true);
   initialize();
-  internalEngine()->onDefaultNetworkChanged(NetworkType::WLAN);
+  internalEngine()->onDefaultNetworkChanged(1);
   basicTest();
   if (upstreamProtocol() == Http::CodecType::HTTP1) {
     ASSERT_EQ(cc_.on_complete_received_byte_count_, 67);

--- a/mobile/test/common/network/connectivity_manager_test.cc
+++ b/mobile/test/common/network/connectivity_manager_test.cc
@@ -22,8 +22,8 @@ public:
         connectivity_manager_(std::make_shared<ConnectivityManagerImpl>(cm_, dns_cache_manager_)) {
     ON_CALL(*dns_cache_manager_, lookUpCacheByName(_)).WillByDefault(Return(dns_cache_));
     // Toggle network to reset network state.
-    ConnectivityManagerImpl::setPreferredNetwork(NetworkType::Generic);
-    ConnectivityManagerImpl::setPreferredNetwork(NetworkType::WLAN);
+    ConnectivityManagerImpl::setPreferredNetwork(1);
+    ConnectivityManagerImpl::setPreferredNetwork(2);
   }
 
   std::shared_ptr<NiceMock<Extensions::Common::DynamicForwardProxy::MockDnsCacheManager>>
@@ -35,7 +35,7 @@ public:
 
 TEST_F(ConnectivityManagerTest, SetPreferredNetworkWithNewNetworkChangesConfigurationKey) {
   envoy_netconf_t original_key = connectivity_manager_->getConfigurationKey();
-  envoy_netconf_t new_key = ConnectivityManagerImpl::setPreferredNetwork(NetworkType::WWAN);
+  envoy_netconf_t new_key = ConnectivityManagerImpl::setPreferredNetwork(4);
   EXPECT_NE(original_key, new_key);
   EXPECT_EQ(new_key, connectivity_manager_->getConfigurationKey());
 }
@@ -43,7 +43,7 @@ TEST_F(ConnectivityManagerTest, SetPreferredNetworkWithNewNetworkChangesConfigur
 TEST_F(ConnectivityManagerTest,
        DISABLED_SetPreferredNetworkWithUnchangedNetworkReturnsStaleConfigurationKey) {
   envoy_netconf_t original_key = connectivity_manager_->getConfigurationKey();
-  envoy_netconf_t stale_key = ConnectivityManagerImpl::setPreferredNetwork(NetworkType::WLAN);
+  envoy_netconf_t stale_key = ConnectivityManagerImpl::setPreferredNetwork(2);
   EXPECT_NE(original_key, stale_key);
   EXPECT_EQ(original_key, connectivity_manager_->getConfigurationKey());
 }
@@ -168,7 +168,7 @@ TEST_F(ConnectivityManagerTest, ReportNetworkUsageDisablesOverrideAfterThirdFaul
 
 TEST_F(ConnectivityManagerTest, ReportNetworkUsageDisregardsCallsWithStaleConfigurationKey) {
   envoy_netconf_t stale_key = connectivity_manager_->getConfigurationKey();
-  envoy_netconf_t current_key = ConnectivityManagerImpl::setPreferredNetwork(NetworkType::WWAN);
+  envoy_netconf_t current_key = ConnectivityManagerImpl::setPreferredNetwork(4);
   EXPECT_NE(stale_key, current_key);
 
   connectivity_manager_->setInterfaceBindingEnabled(true);

--- a/mobile/test/java/io/envoyproxy/envoymobile/engine/AndroidNetworkMonitorTest.java
+++ b/mobile/test/java/io/envoyproxy/envoymobile/engine/AndroidNetworkMonitorTest.java
@@ -1,7 +1,7 @@
 package io.envoyproxy.envoymobile.engine;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -100,7 +100,7 @@ public class AndroidNetworkMonitorTest {
       callback.onCapabilitiesChanged(ShadowNetwork.newInstance(0), capabilities);
     });
 
-    verify(mockEnvoyEngine).onDefaultNetworkChanged(EnvoyNetworkType.WLAN);
+    verify(mockEnvoyEngine).onDefaultNetworkChanged(2);
   }
 
   @Test
@@ -112,7 +112,7 @@ public class AndroidNetworkMonitorTest {
       callback.onCapabilitiesChanged(ShadowNetwork.newInstance(0), capabilities);
     });
 
-    verify(mockEnvoyEngine).onDefaultNetworkChanged(EnvoyNetworkType.WWAN);
+    verify(mockEnvoyEngine).onDefaultNetworkChanged(4);
   }
 
   @Test
@@ -124,7 +124,7 @@ public class AndroidNetworkMonitorTest {
       callback.onCapabilitiesChanged(ShadowNetwork.newInstance(0), capabilities);
     });
 
-    verify(mockEnvoyEngine).onDefaultNetworkChanged(EnvoyNetworkType.GENERIC);
+    verify(mockEnvoyEngine).onDefaultNetworkChanged(1);
   }
 
   @Test
@@ -136,7 +136,7 @@ public class AndroidNetworkMonitorTest {
     shadowOf(capabilities).addTransportType(NetworkCapabilities.TRANSPORT_WIFI);
     callback.onCapabilitiesChanged(ShadowNetwork.newInstance(0), capabilities);
 
-    verify(mockEnvoyEngine).onDefaultNetworkChanged(EnvoyNetworkType.WLAN);
+    verify(mockEnvoyEngine).onDefaultNetworkChanged(2;
   }
 
   @Test
@@ -148,7 +148,7 @@ public class AndroidNetworkMonitorTest {
     shadowOf(capabilities).addTransportType(NetworkCapabilities.TRANSPORT_CELLULAR);
     callback.onCapabilitiesChanged(ShadowNetwork.newInstance(0), capabilities);
 
-    verify(mockEnvoyEngine).onDefaultNetworkChanged(EnvoyNetworkType.WWAN);
+    verify(mockEnvoyEngine).onDefaultNetworkChanged(4);
   }
 
   @Test
@@ -160,7 +160,7 @@ public class AndroidNetworkMonitorTest {
     shadowOf(capabilities).addTransportType(NetworkCapabilities.TRANSPORT_ETHERNET);
     callback.onCapabilitiesChanged(ShadowNetwork.newInstance(0), capabilities);
 
-    verify(mockEnvoyEngine).onDefaultNetworkChanged(EnvoyNetworkType.GENERIC);
+    verify(mockEnvoyEngine).onDefaultNetworkChanged(1);
   }
 
   @Test
@@ -173,7 +173,7 @@ public class AndroidNetworkMonitorTest {
     shadowOf(capabilities).addTransportType(NetworkCapabilities.TRANSPORT_CELLULAR);
     callback.onCapabilitiesChanged(ShadowNetwork.newInstance(0), capabilities);
 
-    verify(mockEnvoyEngine).onDefaultNetworkChanged(EnvoyNetworkType.WWAN);
+    verify(mockEnvoyEngine).onDefaultNetworkChanged(4);
   }
 
   @Test
@@ -186,7 +186,7 @@ public class AndroidNetworkMonitorTest {
     shadowOf(capabilities).addTransportType(NetworkCapabilities.TRANSPORT_WIFI);
     callback.onCapabilitiesChanged(ShadowNetwork.newInstance(0), capabilities);
 
-    verify(mockEnvoyEngine).onDefaultNetworkChanged(EnvoyNetworkType.WLAN);
+    verify(mockEnvoyEngine).onDefaultNetworkChanged(2);
   }
 
   @Test
@@ -199,7 +199,7 @@ public class AndroidNetworkMonitorTest {
     shadowOf(capabilities).addTransportType(NetworkCapabilities.TRANSPORT_ETHERNET);
     callback.onCapabilitiesChanged(ShadowNetwork.newInstance(0), capabilities);
 
-    verify(mockEnvoyEngine).onDefaultNetworkChanged(EnvoyNetworkType.GENERIC);
+    verify(mockEnvoyEngine).onDefaultNetworkChanged(1);
   }
 
   @Test
@@ -213,7 +213,7 @@ public class AndroidNetworkMonitorTest {
     shadowOf(capabilities).addTransportType(NetworkCapabilities.TRANSPORT_VPN);
     callback.onCapabilitiesChanged(ShadowNetwork.newInstance(0), capabilities);
 
-    verify(mockEnvoyEngine).onDefaultNetworkChanged(EnvoyNetworkType.WLAN);
+    verify(mockEnvoyEngine).onDefaultNetworkChanged(3);
   }
 
   @Test
@@ -227,7 +227,7 @@ public class AndroidNetworkMonitorTest {
     shadowOf(capabilities).addTransportType(NetworkCapabilities.TRANSPORT_WIFI);
     callback.onCapabilitiesChanged(ShadowNetwork.newInstance(0), capabilities);
 
-    verify(mockEnvoyEngine).onDefaultNetworkChanged(EnvoyNetworkType.WLAN);
+    verify(mockEnvoyEngine).onDefaultNetworkChanged(2);
   }
 
   @Test
@@ -240,7 +240,7 @@ public class AndroidNetworkMonitorTest {
     shadowOf(capabilities).addTransportType(NetworkCapabilities.TRANSPORT_WIFI);
     callback.onCapabilitiesChanged(ShadowNetwork.newInstance(0), capabilities);
 
-    verify(mockEnvoyEngine, never()).onDefaultNetworkChanged(any());
+    verify(mockEnvoyEngine, never()).onDefaultNetworkChanged(anyInt());
   }
 
   @Test
@@ -251,6 +251,6 @@ public class AndroidNetworkMonitorTest {
     shadowOf(capabilities).addTransportType(NetworkCapabilities.TRANSPORT_WIFI);
     callback.onCapabilitiesChanged(ShadowNetwork.newInstance(0), capabilities);
 
-    verify(mockEnvoyEngine, never()).onDefaultNetworkChanged(any());
+    verify(mockEnvoyEngine, never()).onDefaultNetworkChanged(anyInt());
   }
 }

--- a/mobile/test/java/io/envoyproxy/envoymobile/engine/AndroidNetworkMonitorTest.java
+++ b/mobile/test/java/io/envoyproxy/envoymobile/engine/AndroidNetworkMonitorTest.java
@@ -136,7 +136,7 @@ public class AndroidNetworkMonitorTest {
     shadowOf(capabilities).addTransportType(NetworkCapabilities.TRANSPORT_WIFI);
     callback.onCapabilitiesChanged(ShadowNetwork.newInstance(0), capabilities);
 
-    verify(mockEnvoyEngine).onDefaultNetworkChanged(2;
+    verify(mockEnvoyEngine).onDefaultNetworkChanged(2);
   }
 
   @Test

--- a/mobile/test/java/org/chromium/net/CronetHttp3Test.java
+++ b/mobile/test/java/org/chromium/net/CronetHttp3Test.java
@@ -297,7 +297,7 @@ public class CronetHttp3Test {
 
     // Force a network change
     cronvoyEngine.getEnvoyEngine().onDefaultNetworkUnavailable();
-    cronvoyEngine.getEnvoyEngine().onDefaultNetworkChanged(EnvoyNetworkType.WLAN);
+    cronvoyEngine.getEnvoyEngine().onDefaultNetworkChanged(2);
     cronvoyEngine.getEnvoyEngine().onDefaultNetworkAvailable();
 
     // Do another HTTP/3 request
@@ -331,7 +331,7 @@ public class CronetHttp3Test {
 
     // Force a network change
     cronvoyEngine.getEnvoyEngine().onDefaultNetworkUnavailable();
-    cronvoyEngine.getEnvoyEngine().onDefaultNetworkChanged(EnvoyNetworkType.WLAN);
+    cronvoyEngine.getEnvoyEngine().onDefaultNetworkChanged(2);
     cronvoyEngine.getEnvoyEngine().onDefaultNetworkAvailable();
 
     // Do another HTTP/3 request
@@ -360,7 +360,7 @@ public class CronetHttp3Test {
 
     // This should change QUIC brokenness to "failed recently".
     cronvoyEngine.getEnvoyEngine().onDefaultNetworkUnavailable();
-    cronvoyEngine.getEnvoyEngine().onDefaultNetworkChanged(EnvoyNetworkType.WLAN);
+    cronvoyEngine.getEnvoyEngine().onDefaultNetworkChanged(2);
     cronvoyEngine.getEnvoyEngine().onDefaultNetworkAvailable();
 
     // The next request may go out over HTTP/2 or HTTP/3 (depends on who wins the race)

--- a/mobile/test/kotlin/io/envoyproxy/envoymobile/mocks/MockEnvoyEngine.kt
+++ b/mobile/test/kotlin/io/envoyproxy/envoymobile/mocks/MockEnvoyEngine.kt
@@ -4,7 +4,6 @@ import io.envoyproxy.envoymobile.engine.EnvoyConfiguration
 import io.envoyproxy.envoymobile.engine.EnvoyEngine
 import io.envoyproxy.envoymobile.engine.EnvoyHTTPStream
 import io.envoyproxy.envoymobile.engine.types.EnvoyHTTPCallbacks
-import io.envoyproxy.envoymobile.engine.types.EnvoyNetworkType
 import io.envoyproxy.envoymobile.engine.types.EnvoyStatus
 import io.envoyproxy.envoymobile.engine.types.EnvoyStringAccessor
 
@@ -42,7 +41,7 @@ class MockEnvoyEngine : EnvoyEngine {
 
   override fun onDefaultNetworkAvailable() = Unit
 
-  override fun onDefaultNetworkChanged(network: EnvoyNetworkType) = Unit
+  override fun onDefaultNetworkChanged(network: Int) = Unit
 
   override fun onDefaultNetworkUnavailable() = Unit
 


### PR DESCRIPTION
Commit Message: Convert network type from enum to bitmap so that compound network type can be represented
Additional Description: One example is a network can be both VPN and WLAN.
Risk Level: low
Testing: existing tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: mobile only
