### PR TITLE
perf: router config_impl move a shared pointer

### DIFF
--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -2443,10 +2443,10 @@ PerFilterConfigs::createRouteSpecificFilterConfig(
   ProtobufTypes::MessagePtr proto_config = factory->createEmptyRouteConfigProto();
   RETURN_IF_NOT_OK(
       Envoy::Config::Utility::translateOpaqueConfig(typed_config, validator, *proto_config));
-  auto object_status =
+  auto object_status_or_error =
       factory->createRouteSpecificFilterConfig(*proto_config, factory_context, validator);
-  RETURN_IF_NOT_OK(object_status.status());
-  auto object = object_status.value();
+  RETURN_IF_NOT_OK(object_status_or_error.status());
+  auto object = std::move(*object_status_or_error);
   if (object == nullptr) {
     if (is_optional) {
       ENVOY_LOG(

--- a/test/extensions/filters/http/local_ratelimit/config_test.cc
+++ b/test/extensions/filters/http/local_ratelimit/config_test.cc
@@ -473,7 +473,7 @@ local_cluster_rate_limit: {}
   EXPECT_TRUE(factory
                   .createRouteSpecificFilterConfig(*proto_config, context,
                                                    ProtobufMessage::getNullValidationVisitor())
-                  .value());
+                  .ok());
 }
 
 } // namespace LocalRateLimitFilter


### PR DESCRIPTION
Commit Message: perf: router config_impl move a shared pointer
Additional Description:
Minor perf, and variable renaming.
Followup to #37498 - moving a shared pointer instead of copying it.

Risk Level: low - internal only
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A