### PR TITLE
[ext_proc] Fix fuzz bug and simplify processor state API

### DIFF
--- a/source/extensions/filters/http/ext_proc/ext_proc.cc
+++ b/source/extensions/filters/http/ext_proc/ext_proc.cc
@@ -871,7 +871,6 @@ FilterTrailersStatus Filter::onTrailers(ProcessorState& state, Http::HeaderMap& 
 
   bool body_delivered = state.completeBodyAvailable();
   state.setCompleteBodyAvailable(true);
-  state.setTrailersAvailable(true);
   state.setTrailers(&trailers);
 
   if ((state.callbackState() != ProcessorState::CallbackState::Idle) &&

--- a/source/extensions/filters/http/ext_proc/processor_state.h
+++ b/source/extensions/filters/http/ext_proc/processor_state.h
@@ -101,7 +101,6 @@ public:
   bool completeBodyAvailable() const { return complete_body_available_; }
   void setCompleteBodyAvailable(bool d) { complete_body_available_ = d; }
   void setHasNoBody(bool b) { no_body_ = b; }
-  void setTrailersAvailable(bool d) { trailers_available_ = d; }
   bool bodyReplaced() const { return body_replaced_; }
   bool bodyReceived() const { return body_received_; }
   void setBodyReceived(bool b) { body_received_ = b; }
@@ -248,8 +247,6 @@ protected:
   bool no_body_ : 1 = false;
   // If true, then the filter received the complete body
   bool complete_body_available_ : 1 = false;
-  // If true, then the filter received the trailers
-  bool trailers_available_ : 1 = false;
   // If true, the trailers is already sent to the server.
   bool trailers_sent_to_server_ : 1 = false;
   // If true, then a CONTINUE_AND_REPLACE status was used on a response

--- a/test/extensions/filters/http/ext_proc/unit_test_fuzz/ext_proc_corpus/null_trailers
+++ b/test/extensions/filters/http/ext_proc/unit_test_fuzz/ext_proc_corpus/null_trailers
@@ -1,0 +1,25 @@
+config {
+  grpc_service {
+    envoy_grpc {
+      cluster_name: "##"
+      skip_envoy_headers: true
+    }
+  }
+  failure_mode_allow: true
+  stat_prefix: "Y"
+  disable_clear_route_cache: true
+  allow_mode_override: true
+  disable_immediate_response: true
+}
+request {
+}
+response {
+  response_trailers {
+    header_mutation {
+    }
+  }
+  mode_override {
+    request_body_mode: BUFFERED_PARTIAL
+    response_body_mode: FULL_DUPLEX_STREAMED
+  }
+}


### PR DESCRIPTION
Commit Message: Fix fuzz bug and simplify processor state API
Additional Description: 

In this PR I fix a fuzz bug caused by a nullptr dereference (caused by not checking if the pointer is null beforehand).

I also noticed that currently the state_processor has both setTrailersAvailable(...) and setTrailers(...). Internally, `trailers_available_` is checked to see if it's safe to dereferences `trailers_`. This is error prone because `trailers_available_` is redundant when you can always just check `trailers_ != nullptr`.

Risk Level: low
Testing: fix fuzz test, otherwise no functional change; all tests still pass
Docs Changes: none
Release Notes: none
Platform Specific Features: none