### PR TITLE
orca: refactored the lbPolicyData and orca report callbacks

### DIFF
--- a/envoy/upstream/BUILD
+++ b/envoy/upstream/BUILD
@@ -73,6 +73,7 @@ envoy_cc_library(
         "//envoy/network:transport_socket_interface",
         "//envoy/stats:primitive_stats_macros",
         "//envoy/stats:stats_macros",
+        "@com_github_cncf_xds//xds/data/orca/v3:pkg_cc_proto",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
     ],
 )
@@ -84,7 +85,6 @@ envoy_cc_library(
         ":upstream_interface",
         "//envoy/router:router_interface",
         "//envoy/upstream:types_interface",
-        "@com_github_cncf_xds//xds/data/orca/v3:pkg_cc_proto",
     ],
 )
 

--- a/envoy/upstream/load_balancer.h
+++ b/envoy/upstream/load_balancer.h
@@ -110,29 +110,6 @@ public:
    * and return the corresponding host directly.
    */
   virtual absl::optional<OverrideHost> overrideHostToSelect() const PURE;
-
-  // Interface for callbacks when ORCA load reports are received from upstream.
-  class OrcaLoadReportCallbacks {
-  public:
-    virtual ~OrcaLoadReportCallbacks() = default;
-    /**
-     * Invoked when a new orca report is received for this LB context.
-     * @param orca_load_report supplies the ORCA load report.
-     * @param host supplies the upstream host, which provided the load report.
-     * @return absl::Status the result of ORCA load report processing by the load balancer.
-     */
-    virtual absl::Status
-    onOrcaLoadReport(const xds::data::orca::v3::OrcaLoadReport& orca_load_report,
-                     const HostDescription& host) PURE;
-  };
-
-  /**
-   * Install a callback to be invoked when ORCA Load report is received for this
-   * LB context.
-   * Note: LB Context keeps a weak pointer to `callbacks` and doesn't invoke the callback
-   * if it is `expired()`.
-   */
-  virtual void setOrcaLoadReportCallbacks(std::weak_ptr<OrcaLoadReportCallbacks> callbacks) PURE;
 };
 
 /**

--- a/envoy/upstream/upstream.h
+++ b/envoy/upstream/upstream.h
@@ -300,36 +300,6 @@ public:
    * Set true to disable active health check for the host.
    */
   virtual void setDisableActiveHealthCheck(bool disable_active_health_check) PURE;
-
-  /**
-   * Base interface for attaching LbPolicy-specific data to individual hosts.
-   */
-  class HostLbPolicyData {
-  public:
-    virtual ~HostLbPolicyData() = default;
-  };
-  using HostLbPolicyDataPtr = std::unique_ptr<HostLbPolicyData>;
-
-  /**
-   * Set load balancing policy related data to the host.
-   * NOTE: this method should only be called at main thread before the host is used
-   * across worker threads.
-   */
-  virtual void setLbPolicyData(HostLbPolicyDataPtr lb_policy_data) PURE;
-
-  /**
-   * Get the load balancing policy related data of the host.
-   * @return the optional reference to the load balancing policy related data of the host.
-   */
-  virtual OptRef<HostLbPolicyData> lbPolicyData() const PURE;
-
-  /**
-   * Get the typed load balancing policy related data of the host.
-   * @return the optional reference to the typed load balancing policy related data of the host.
-   */
-  template <class HostLbPolicyDataType> OptRef<HostLbPolicyDataType> typedLbPolicyData() const {
-    return makeOptRefFromPtr(dynamic_cast<HostLbPolicyDataType*>(lbPolicyData().ptr()));
-  }
 };
 
 using HostConstSharedPtr = std::shared_ptr<const Host>;

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -376,13 +376,13 @@ FilterUtility::StrictHeaderChecker::checkHeader(Http::RequestHeaderMap& headers,
   PANIC("unexpectedly reached");
 }
 
-Stats::StatName Filter::upstreamZone(Upstream::HostDescriptionConstSharedPtr upstream_host) {
+Stats::StatName Filter::upstreamZone(OptRef<const Upstream::HostDescription> upstream_host) {
   return upstream_host ? upstream_host->localityZoneStatName() : config_->empty_stat_name_;
 }
 
 void Filter::chargeUpstreamCode(uint64_t response_status_code,
                                 const Http::ResponseHeaderMap& response_headers,
-                                Upstream::HostDescriptionConstSharedPtr upstream_host,
+                                OptRef<const Upstream::HostDescription> upstream_host,
                                 bool dropped) {
   // Passing the response_status_code explicitly is an optimization to avoid
   // multiple calls to slow Http::Utility::getResponseStatus.
@@ -436,7 +436,7 @@ void Filter::chargeUpstreamCode(uint64_t response_status_code,
 }
 
 void Filter::chargeUpstreamCode(Http::Code code,
-                                Upstream::HostDescriptionConstSharedPtr upstream_host,
+                                OptRef<const Upstream::HostDescription> upstream_host,
                                 bool dropped) {
   const uint64_t response_status_code = enumToInt(code);
   const auto fake_response_headers = Http::createHeaderMap<Http::ResponseHeaderMapImpl>(
@@ -568,7 +568,7 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers,
   // See if we are supposed to immediately kill some percentage of this cluster's traffic.
   if (cluster_->maintenanceMode()) {
     callbacks_->streamInfo().setResponseFlag(StreamInfo::CoreResponseFlag::UpstreamOverflow);
-    chargeUpstreamCode(Http::Code::ServiceUnavailable, nullptr, true);
+    chargeUpstreamCode(Http::Code::ServiceUnavailable, {}, true);
     callbacks_->sendLocalReply(
         Http::Code::ServiceUnavailable, "maintenance mode",
         [modify_headers, this](Http::ResponseHeaderMap& headers) {
@@ -871,7 +871,7 @@ Filter::createConnPool(Upstream::ThreadLocalCluster& thread_local_cluster) {
 
 void Filter::sendNoHealthyUpstreamResponse() {
   callbacks_->streamInfo().setResponseFlag(StreamInfo::CoreResponseFlag::NoHealthyUpstream);
-  chargeUpstreamCode(Http::Code::ServiceUnavailable, nullptr, false);
+  chargeUpstreamCode(Http::Code::ServiceUnavailable, {}, false);
   callbacks_->sendLocalReply(Http::Code::ServiceUnavailable, "no healthy upstream", modify_headers_,
                              absl::nullopt,
                              StreamInfo::ResponseCodeDetails::get().NoHealthyUpstream);
@@ -1280,14 +1280,14 @@ void Filter::chargeUpstreamAbort(Http::Code code, bool dropped, UpstreamRequest&
       stats_.rq_reset_after_downstream_response_started_.inc();
     }
   } else {
-    Upstream::HostDescriptionConstSharedPtr upstream_host = upstream_request.upstreamHost();
+    OptRef<const Upstream::HostDescription> upstream_host = upstream_request.upstreamHost();
 
     chargeUpstreamCode(code, upstream_host, dropped);
     // If we had non-5xx but still have been reset by backend or timeout before
     // starting response, we treat this as an error. We only get non-5xx when
     // timeout_response_code_ is used for code above, where this member can
     // assume values such as 204 (NoContent).
-    if (upstream_host != nullptr && !Http::CodeUtility::is5xx(enumToInt(code))) {
+    if (upstream_host.has_value() && !Http::CodeUtility::is5xx(enumToInt(code))) {
       upstream_host->stats().rq_error_.inc();
     }
   }
@@ -2101,7 +2101,7 @@ bool Filter::checkDropOverload(Upstream::ThreadLocalCluster& cluster,
     if (config_->random_.bernoulli(cluster.dropOverload())) {
       ENVOY_STREAM_LOG(debug, "The request is dropped by DROP_OVERLOAD", *callbacks_);
       callbacks_->streamInfo().setResponseFlag(StreamInfo::CoreResponseFlag::DropOverLoad);
-      chargeUpstreamCode(Http::Code::ServiceUnavailable, nullptr, true);
+      chargeUpstreamCode(Http::Code::ServiceUnavailable, {}, true);
       callbacks_->sendLocalReply(
           Http::Code::ServiceUnavailable, "drop overload",
           [modify_headers, this](Http::ResponseHeaderMap& headers) {
@@ -2129,10 +2129,14 @@ void Filter::maybeProcessOrcaLoadReport(const Envoy::Http::HeaderMap& headers_or
   }
   // Check whether we need to send the load report to the LRS or invoke the ORCA
   // callbacks.
-  auto host = upstream_request.upstreamHost();
-  const bool need_to_send_load_report =
-      (host != nullptr) && cluster_->lrsReportMetricNames().has_value();
-  if (!need_to_send_load_report && orca_load_report_callbacks_.expired()) {
+  OptRef<const Upstream::HostDescription> upstream_host = upstream_request.upstreamHost();
+  if (!upstream_host.has_value()) {
+    return;
+  }
+
+  OptRef<Upstream::HostLbPolicyData> host_lb_policy_data = upstream_host->lbPolicyData();
+
+  if (!cluster_->lrsReportMetricNames().has_value() && !host_lb_policy_data.has_value()) {
     return;
   }
 
@@ -2146,15 +2150,16 @@ void Filter::maybeProcessOrcaLoadReport(const Envoy::Http::HeaderMap& headers_or
 
   orca_load_report_received_ = true;
 
-  if (need_to_send_load_report) {
+  if (cluster_->lrsReportMetricNames().has_value()) {
     ENVOY_STREAM_LOG(trace, "Adding ORCA load report {} to load metrics", *callbacks_,
                      orca_load_report->DebugString());
-    Envoy::Orca::addOrcaLoadReportToLoadMetricStats(cluster_->lrsReportMetricNames().value(),
-                                                    orca_load_report.value(),
-                                                    host->loadMetricStats());
+    Envoy::Orca::addOrcaLoadReportToLoadMetricStats(
+        *cluster_->lrsReportMetricNames(), *orca_load_report, upstream_host->loadMetricStats());
   }
-  if (auto callbacks = orca_load_report_callbacks_.lock(); callbacks != nullptr) {
-    const absl::Status status = callbacks->onOrcaLoadReport(*orca_load_report, *host);
+  if (host_lb_policy_data.has_value()) {
+    ENVOY_LOG(trace, "orca_load_report for {} report = {}", upstream_host->address()->asString(),
+              (*orca_load_report).DebugString());
+    const absl::Status status = host_lb_policy_data->onHostLoadReport(*orca_load_report);
     if (!status.ok()) {
       ENVOY_STREAM_LOG(error, "Failed to invoke OrcaLoadReportCallbacks: {}", *callbacks_,
                        status.message());

--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -430,10 +430,6 @@ public:
     return callbacks_->upstreamOverrideHost();
   }
 
-  void setOrcaLoadReportCallbacks(std::weak_ptr<OrcaLoadReportCallbacks> callbacks) override {
-    orca_load_report_callbacks_ = callbacks;
-  }
-
   /**
    * Set a computed cookie to be sent with the downstream headers.
    * @param key supplies the size of the cookie
@@ -508,11 +504,11 @@ private:
 
   void onPerTryTimeoutCommon(UpstreamRequest& upstream_request, Stats::Counter& error_counter,
                              const std::string& response_code_details);
-  Stats::StatName upstreamZone(Upstream::HostDescriptionConstSharedPtr upstream_host);
+  Stats::StatName upstreamZone(OptRef<const Upstream::HostDescription> upstream_host);
   void chargeUpstreamCode(uint64_t response_status_code,
                           const Http::ResponseHeaderMap& response_headers,
-                          Upstream::HostDescriptionConstSharedPtr upstream_host, bool dropped);
-  void chargeUpstreamCode(Http::Code code, Upstream::HostDescriptionConstSharedPtr upstream_host,
+                          OptRef<const Upstream::HostDescription> upstream_host, bool dropped);
+  void chargeUpstreamCode(Http::Code code, OptRef<const Upstream::HostDescription> upstream_host,
                           bool dropped);
   void chargeUpstreamAbort(Http::Code code, bool dropped, UpstreamRequest& upstream_request);
   void cleanup();
@@ -616,7 +612,6 @@ private:
   Http::Code timeout_response_code_ = Http::Code::GatewayTimeout;
   FilterUtility::HedgingParams hedging_params_;
   Http::StreamFilterSidestreamWatermarkCallbacks watermark_callbacks_;
-  std::weak_ptr<OrcaLoadReportCallbacks> orca_load_report_callbacks_;
   bool grpc_request_ : 1;
   bool exclude_http_code_stats_ : 1;
   bool downstream_response_started_ : 1;

--- a/source/common/router/upstream_request.h
+++ b/source/common/router/upstream_request.h
@@ -146,7 +146,9 @@ public:
   void encodeBodyAndTrailers();
 
   // Getters and setters
-  Upstream::HostDescriptionConstSharedPtr& upstreamHost() { return upstream_host_; }
+  OptRef<const Upstream::HostDescription> upstreamHost() {
+    return makeOptRefFromPtr(upstream_host_.get());
+  }
   void outlierDetectionTimeoutRecorded(bool recorded) {
     outlier_detection_timeout_recorded_ = recorded;
   }

--- a/source/common/upstream/load_balancer_context_base.h
+++ b/source/common/upstream/load_balancer_context_base.h
@@ -34,8 +34,6 @@ public:
   }
 
   absl::optional<OverrideHost> overrideHostToSelect() const override { return {}; }
-
-  void setOrcaLoadReportCallbacks(std::weak_ptr<OrcaLoadReportCallbacks>) override {}
 };
 
 } // namespace Upstream

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -238,6 +238,13 @@ public:
     last_hc_pass_time_.emplace(std::move(last_hc_pass_time));
   }
 
+  void setLbPolicyData(HostLbPolicyDataPtr lb_policy_data) override {
+    lb_policy_data_ = std::move(lb_policy_data);
+  }
+  OptRef<HostLbPolicyData> lbPolicyData() const override {
+    return makeOptRefFromPtr(lb_policy_data_.get());
+  }
+
 protected:
   HostDescriptionImplBase(
       ClusterInfoConstSharedPtr cluster, const std::string& hostname,
@@ -273,6 +280,7 @@ private:
       socket_factory_ ABSL_GUARDED_BY(metadata_mutex_);
   const MonotonicTime creation_time_;
   absl::optional<MonotonicTime> last_hc_pass_time_;
+  HostLbPolicyDataPtr lb_policy_data_;
 };
 
 /**
@@ -424,13 +432,6 @@ public:
     return std::make_unique<HostHandleImpl>(shared_from_this());
   }
 
-  void setLbPolicyData(HostLbPolicyDataPtr lb_policy_data) override {
-    lb_policy_data_ = std::move(lb_policy_data);
-  }
-  OptRef<HostLbPolicyData> lbPolicyData() const override {
-    return makeOptRefFromPtr(lb_policy_data_.get());
-  }
-
 protected:
   static CreateConnectionData
   createConnection(Event::Dispatcher& dispatcher, const ClusterInfo& cluster,
@@ -457,7 +458,6 @@ private:
   // flag access? May be we could refactor HealthFlag to contain all these statuses and flags in the
   // future.
   std::atomic<Host::HealthStatus> eds_health_status_{};
-  HostLbPolicyDataPtr lb_policy_data_;
 
   struct HostHandleImpl : HostHandle {
     HostHandleImpl(const std::shared_ptr<const HostImplBase>& parent) : parent_(parent) {

--- a/source/extensions/clusters/common/logical_host.h
+++ b/source/extensions/clusters/common/logical_host.h
@@ -130,6 +130,7 @@ public:
                                 const envoy::config::core::v3::Metadata* metadata) const override {
     return logical_host_->resolveTransportSocketFactory(dest_address, metadata);
   }
+  OptRef<HostLbPolicyData> lbPolicyData() const override { return logical_host_->lbPolicyData(); }
 
   // Upstream:HostDescription mutators are all no-ops, because logical_host_ is
   // const. These should never be called except during coverage tests.
@@ -145,6 +146,7 @@ public:
   void canary(bool) override {}
   void setLastHcPassTime(MonotonicTime) override {}
   void priority(uint32_t) override {}
+  void setLbPolicyData(HostLbPolicyDataPtr) override {}
 
 private:
   const Network::Address::InstanceConstSharedPtr address_;

--- a/source/extensions/load_balancing_policies/client_side_weighted_round_robin/client_side_weighted_round_robin_lb.cc
+++ b/source/extensions/load_balancing_policies/client_side_weighted_round_robin/client_side_weighted_round_robin_lb.cc
@@ -50,13 +50,10 @@ ClientSideWeightedRoundRobinLoadBalancer::WorkerLocalLb::WorkerLocalLb(
     const PrioritySet& priority_set, const PrioritySet* local_priority_set, ClusterLbStats& stats,
     Runtime::Loader& runtime, Random::RandomGenerator& random,
     const envoy::config::cluster::v3::Cluster::CommonLbConfig& common_config,
-    const ClientSideWeightedRoundRobinLbConfig& client_side_weighted_round_robin_config,
     TimeSource& time_source, OptRef<ThreadLocalShim> tls_shim)
     : RoundRobinLoadBalancer(priority_set, local_priority_set, stats, runtime, random,
                              common_config,
                              /*round_robin_config=*/std::nullopt, time_source) {
-  orca_load_report_handler_ =
-      std::make_shared<OrcaLoadReportHandler>(client_side_weighted_round_robin_config, time_source);
   if (tls_shim.has_value()) {
     apply_weights_cb_handle_ = tls_shim->apply_weights_cb_helper_.add([this](uint32_t priority) {
       refresh(priority);
@@ -67,12 +64,7 @@ ClientSideWeightedRoundRobinLoadBalancer::WorkerLocalLb::WorkerLocalLb(
 
 HostConstSharedPtr
 ClientSideWeightedRoundRobinLoadBalancer::WorkerLocalLb::chooseHost(LoadBalancerContext* context) {
-  HostConstSharedPtr host = RoundRobinLoadBalancer::chooseHost(context);
-  if (context != nullptr) {
-    // Configure callbacks to receive ORCA load report.
-    context->setOrcaLoadReportCallbacks(orca_load_report_handler_);
-  }
-  return host;
+  return RoundRobinLoadBalancer::chooseHost(context);
 }
 
 ClientSideWeightedRoundRobinLoadBalancer::OrcaLoadReportHandler::OrcaLoadReportHandler(
@@ -80,35 +72,11 @@ ClientSideWeightedRoundRobinLoadBalancer::OrcaLoadReportHandler::OrcaLoadReportH
     : metric_names_for_computing_utilization_(lb_config.metric_names_for_computing_utilization),
       error_utilization_penalty_(lb_config.error_utilization_penalty), time_source_(time_source) {}
 
-absl::Status ClientSideWeightedRoundRobinLoadBalancer::OrcaLoadReportHandler::onOrcaLoadReport(
-    const OrcaLoadReportProto& orca_load_report, const HostDescription& host_description) {
-  const Host* host = dynamic_cast<const Host*>(&host_description);
-  ENVOY_BUG(host != nullptr, "Unable to cast HostDescription to Host.");
-  ENVOY_LOG(trace,
-            "LoadBalancerContext::OrcaLoadReportCb "
-            "orca_load_report for {} report = {}",
-            getHostAddress(host), orca_load_report.DebugString());
-  auto client_side_data = host->typedLbPolicyData<ClientSideHostLbPolicyData>();
-  if (!client_side_data.has_value()) {
-    return absl::NotFoundError("Host does not have ClientSideLbPolicyData");
-  }
-  return updateClientSideDataFromOrcaLoadReport(orca_load_report, *client_side_data);
-}
-
 void ClientSideWeightedRoundRobinLoadBalancer::initFromConfig(
     const ClientSideWeightedRoundRobinLbConfig& lb_config) {
   blackout_period_ = lb_config.blackout_period;
   weight_expiration_period_ = lb_config.weight_expiration_period;
   weight_update_period_ = lb_config.weight_update_period;
-}
-
-void ClientSideWeightedRoundRobinLoadBalancer::startWeightUpdatesOnMainThread(
-    Event::Dispatcher& main_thread_dispatcher) {
-  weight_calculation_timer_ = main_thread_dispatcher.createTimer([this]() -> void {
-    updateWeightsOnMainThread();
-    weight_calculation_timer_->enableTimer(weight_update_period_);
-  });
-  weight_calculation_timer_->enableTimer(weight_update_period_);
 }
 
 void ClientSideWeightedRoundRobinLoadBalancer::updateWeightsOnMainThread() {
@@ -192,9 +160,15 @@ void ClientSideWeightedRoundRobinLoadBalancer::addClientSideLbPolicyDataToHosts(
   for (const auto& host_ptr : hosts) {
     if (!host_ptr->lbPolicyData().has_value()) {
       ENVOY_LOG(trace, "Adding LB policy data to Host {}", getHostAddress(host_ptr.get()));
-      host_ptr->setLbPolicyData(std::make_unique<ClientSideHostLbPolicyData>());
+      host_ptr->setLbPolicyData(std::make_unique<ClientSideHostLbPolicyData>(report_handler_));
     }
   }
+}
+
+absl::Status ClientSideWeightedRoundRobinLoadBalancer::ClientSideHostLbPolicyData::onHostLoadReport(
+    const Upstream::HostLoadReport& report) {
+  ASSERT(report_handler_ != nullptr);
+  return report_handler_->updateClientSideDataFromOrcaLoadReport(report, *this);
 }
 
 absl::optional<uint32_t>
@@ -272,12 +246,9 @@ absl::Status ClientSideWeightedRoundRobinLoadBalancer::OrcaLoadReportHandler::
 
 Upstream::LoadBalancerPtr ClientSideWeightedRoundRobinLoadBalancer::WorkerLocalLbFactory::create(
     Upstream::LoadBalancerParams params) {
-  const auto* typed_lb_config =
-      dynamic_cast<const ClientSideWeightedRoundRobinLbConfig*>(lb_config_.ptr());
-  ASSERT(typed_lb_config != nullptr);
   return std::make_unique<Upstream::ClientSideWeightedRoundRobinLoadBalancer::WorkerLocalLb>(
       params.priority_set, params.local_priority_set, cluster_info_.lbStats(), runtime_, random_,
-      cluster_info_.lbConfig(), *typed_lb_config, time_source_, tls_->get());
+      cluster_info_.lbConfig(), time_source_, tls_->get());
 }
 
 void ClientSideWeightedRoundRobinLoadBalancer::WorkerLocalLbFactory::applyWeightsToAllWorkers(
@@ -293,16 +264,32 @@ ClientSideWeightedRoundRobinLoadBalancer::ClientSideWeightedRoundRobinLoadBalanc
     OptRef<const Upstream::LoadBalancerConfig> lb_config, const Upstream::ClusterInfo& cluster_info,
     const Upstream::PrioritySet& priority_set, Runtime::Loader& runtime,
     Envoy::Random::RandomGenerator& random, TimeSource& time_source)
-    : factory_(std::make_shared<WorkerLocalLbFactory>(lb_config, cluster_info, priority_set,
-                                                      runtime, random, time_source)),
-      lb_config_(lb_config), cluster_info_(cluster_info), priority_set_(priority_set),
-      runtime_(runtime), random_(random), time_source_(time_source) {}
+    : cluster_info_(cluster_info), priority_set_(priority_set), runtime_(runtime), random_(random),
+      time_source_(time_source) {
+
+  const auto* typed_lb_config =
+      dynamic_cast<const ClientSideWeightedRoundRobinLbConfig*>(lb_config.ptr());
+  ASSERT(typed_lb_config != nullptr);
+  report_handler_ = std::make_shared<OrcaLoadReportHandler>(*typed_lb_config, time_source_);
+  factory_ =
+      std::make_shared<WorkerLocalLbFactory>(cluster_info, priority_set, runtime, random,
+                                             time_source, typed_lb_config->tls_slot_allocator_);
+
+  initFromConfig(*typed_lb_config);
+
+  weight_calculation_timer_ =
+      typed_lb_config->main_thread_dispatcher_.createTimer([this]() -> void {
+        updateWeightsOnMainThread();
+        weight_calculation_timer_->enableTimer(weight_update_period_);
+      });
+}
 
 absl::Status ClientSideWeightedRoundRobinLoadBalancer::initialize() {
   // Ensure that all hosts have client side lb policy data.
   for (const HostSetPtr& host_set : priority_set_.hostSetsPerPriority()) {
     addClientSideLbPolicyDataToHosts(host_set->hosts());
   }
+
   // Setup a callback to receive priority set updates.
   priority_update_cb_ = priority_set_.addPriorityUpdateCb(
       [this](uint32_t, const HostVector& hosts_added, const HostVector&) -> absl::Status {
@@ -311,11 +298,8 @@ absl::Status ClientSideWeightedRoundRobinLoadBalancer::initialize() {
         return absl::OkStatus();
       });
 
-  const auto* typed_lb_config =
-      dynamic_cast<const ClientSideWeightedRoundRobinLbConfig*>(lb_config_.ptr());
-  ASSERT(typed_lb_config != nullptr);
-  initFromConfig(*typed_lb_config);
-  startWeightUpdatesOnMainThread(typed_lb_config->main_thread_dispatcher_);
+  weight_calculation_timer_->enableTimer(weight_update_period_);
+
   return absl::OkStatus();
 }
 

--- a/source/extensions/load_balancing_policies/client_side_weighted_round_robin/client_side_weighted_round_robin_lb.h
+++ b/source/extensions/load_balancing_policies/client_side_weighted_round_robin/client_side_weighted_round_robin_lb.h
@@ -47,15 +47,22 @@ public:
 class ClientSideWeightedRoundRobinLoadBalancer : public Upstream::ThreadAwareLoadBalancer,
                                                  protected Logger::Loggable<Logger::Id::upstream> {
 public:
+  class OrcaLoadReportHandler;
+  using OrcaLoadReportHandlerSharedPtr = std::shared_ptr<OrcaLoadReportHandler>;
+
   // This struct is used to store the client side data for the host. Hosts are
   // not shared between different clusters, but are shared between load
   // balancer instances on different threads.
-  struct ClientSideHostLbPolicyData : public Envoy::Upstream::Host::HostLbPolicyData {
-    ClientSideHostLbPolicyData() = default;
-    ClientSideHostLbPolicyData(uint32_t weight, MonotonicTime non_empty_since,
-                               MonotonicTime last_update_time)
-        : weight_(weight), non_empty_since_(non_empty_since), last_update_time_(last_update_time) {}
-    virtual ~ClientSideHostLbPolicyData() = default;
+  struct ClientSideHostLbPolicyData : public Envoy::Upstream::HostLbPolicyData {
+    ClientSideHostLbPolicyData(OrcaLoadReportHandlerSharedPtr handler)
+        : report_handler_(std::move(handler)) {}
+    ClientSideHostLbPolicyData(OrcaLoadReportHandlerSharedPtr handler, uint32_t weight,
+                               MonotonicTime non_empty_since, MonotonicTime last_update_time)
+        : report_handler_(std::move(handler)), weight_(weight), non_empty_since_(non_empty_since),
+          last_update_time_(last_update_time) {}
+
+    absl::Status onHostLoadReport(const Upstream::HostLoadReport& report) override;
+
     // Update the weight and timestamps for first and last update time.
     void updateWeightNow(uint32_t weight, const MonotonicTime& now) {
       weight_.store(weight);
@@ -82,6 +89,8 @@ public:
       return weight_;
     }
 
+    OrcaLoadReportHandlerSharedPtr report_handler_;
+
     // Weight as calculated from the last load report.
     std::atomic<uint32_t> weight_ = 1;
     // Time when the weight is first updated. The weight is invalid if it is within of
@@ -99,18 +108,16 @@ public:
   // It stores the config necessary to calculate host weight based on the report.
   // The load balancer context stores a weak pointer to this handler,
   // so it is NOT invoked if the load balancer is deleted.
-  class OrcaLoadReportHandler : public LoadBalancerContext::OrcaLoadReportCallbacks {
+  class OrcaLoadReportHandler {
   public:
     OrcaLoadReportHandler(const ClientSideWeightedRoundRobinLbConfig& lb_config,
                           TimeSource& time_source);
-    ~OrcaLoadReportHandler() override = default;
 
-  private:
-    friend class ClientSideWeightedRoundRobinLoadBalancerFriend;
-
-    // {LoadBalancerContext::OrcaLoadReportCallbacks} implementation.
-    absl::Status onOrcaLoadReport(const OrcaLoadReportProto& orca_load_report,
-                                  const HostDescription& host_description) override;
+    // Update client side data from `orca_load_report`. Invoked from `onOrcaLoadReport` callback on
+    // the worker thread.
+    absl::Status
+    updateClientSideDataFromOrcaLoadReport(const OrcaLoadReportProto& orca_load_report,
+                                           ClientSideHostLbPolicyData& client_side_data);
 
     // Get utilization from `orca_load_report` using named metrics specified in
     // `metric_names_for_computing_utilization`.
@@ -124,12 +131,6 @@ public:
         const OrcaLoadReportProto& orca_load_report,
         const std::vector<std::string>& metric_names_for_computing_utilization,
         double error_utilization_penalty);
-
-    // Update client side data from `orca_load_report`. Invoked from `onOrcaLoadReport` callback on
-    // the worker thread.
-    absl::Status
-    updateClientSideDataFromOrcaLoadReport(const OrcaLoadReportProto& orca_load_report,
-                                           ClientSideHostLbPolicyData& client_side_data);
 
     const std::vector<std::string> metric_names_for_computing_utilization_;
     const double error_utilization_penalty_;
@@ -145,36 +146,29 @@ public:
   // This class is used to handle the load balancing on the worker thread.
   class WorkerLocalLb : public RoundRobinLoadBalancer {
   public:
-    WorkerLocalLb(
-        const PrioritySet& priority_set, const PrioritySet* local_priority_set,
-        ClusterLbStats& stats, Runtime::Loader& runtime, Random::RandomGenerator& random,
-        const envoy::config::cluster::v3::Cluster::CommonLbConfig& common_config,
-        const ClientSideWeightedRoundRobinLbConfig& client_side_weighted_round_robin_config,
-        TimeSource& time_source, OptRef<ThreadLocalShim> tls_shim);
+    WorkerLocalLb(const PrioritySet& priority_set, const PrioritySet* local_priority_set,
+                  ClusterLbStats& stats, Runtime::Loader& runtime, Random::RandomGenerator& random,
+                  const envoy::config::cluster::v3::Cluster::CommonLbConfig& common_config,
+                  TimeSource& time_source, OptRef<ThreadLocalShim> tls_shim);
 
   private:
     friend class ClientSideWeightedRoundRobinLoadBalancerFriend;
 
     HostConstSharedPtr chooseHost(LoadBalancerContext* context) override;
 
-    std::shared_ptr<OrcaLoadReportHandler> orca_load_report_handler_;
     Common::CallbackHandlePtr apply_weights_cb_handle_;
   };
 
   // Factory used to create worker-local load balancer on the worker thread.
   class WorkerLocalLbFactory : public Upstream::LoadBalancerFactory {
   public:
-    WorkerLocalLbFactory(OptRef<const Upstream::LoadBalancerConfig> lb_config,
-                         const Upstream::ClusterInfo& cluster_info,
+    WorkerLocalLbFactory(const Upstream::ClusterInfo& cluster_info,
                          const Upstream::PrioritySet& priority_set, Runtime::Loader& runtime,
-                         Envoy::Random::RandomGenerator& random, TimeSource& time_source)
-        : lb_config_(lb_config), cluster_info_(cluster_info), priority_set_(priority_set),
-          runtime_(runtime), random_(random), time_source_(time_source) {
-      const auto* typed_lb_config =
-          dynamic_cast<const ClientSideWeightedRoundRobinLbConfig*>(lb_config.ptr());
-      ASSERT(typed_lb_config != nullptr);
-      tls_ =
-          ThreadLocal::TypedSlot<ThreadLocalShim>::makeUnique(typed_lb_config->tls_slot_allocator_);
+                         Envoy::Random::RandomGenerator& random, TimeSource& time_source,
+                         ThreadLocal::SlotAllocator& tls)
+        : cluster_info_(cluster_info), priority_set_(priority_set), runtime_(runtime),
+          random_(random), time_source_(time_source) {
+      tls_ = ThreadLocal::TypedSlot<ThreadLocalShim>::makeUnique(tls);
       tls_->set([](Envoy::Event::Dispatcher&) { return std::make_shared<ThreadLocalShim>(); });
     }
 
@@ -184,8 +178,6 @@ public:
 
     void applyWeightsToAllWorkers(uint32_t priority);
 
-  protected:
-    OptRef<const Upstream::LoadBalancerConfig> lb_config_;
     std::unique_ptr<Envoy::ThreadLocal::TypedSlot<ThreadLocalShim>> tls_;
 
     const Upstream::ClusterInfo& cluster_info_;
@@ -213,9 +205,6 @@ private:
   // Initialize LB based on the config.
   void initFromConfig(const ClientSideWeightedRoundRobinLbConfig& lb_config);
 
-  // Start weight updates on the main thread.
-  void startWeightUpdatesOnMainThread(Event::Dispatcher& main_thread_dispatcher);
-
   // Update weights using client side host LB policy data for all priority sets.
   // Executed on the main thread.
   void updateWeightsOnMainThread();
@@ -225,7 +214,7 @@ private:
   bool updateWeightsOnHosts(const HostVector& hosts);
 
   // Add client side host LB policy data to all `hosts`.
-  static void addClientSideLbPolicyDataToHosts(const HostVector& hosts);
+  void addClientSideLbPolicyDataToHosts(const HostVector& hosts);
 
   // Get weight based on client side host LB policy data if it is valid (not
   // empty at least since `max_non_empty_since` and updated no later than
@@ -234,10 +223,10 @@ private:
   getClientSideWeightIfValidFromHost(const Host& host, MonotonicTime max_non_empty_since,
                                      MonotonicTime min_last_update_time);
 
+  OrcaLoadReportHandlerSharedPtr report_handler_;
   // Factory used to create worker-local load balancers on the worker thread.
   std::shared_ptr<WorkerLocalLbFactory> factory_;
-  // Data that is also passed to the worker-local load balancer via factory_.
-  OptRef<const Upstream::LoadBalancerConfig> lb_config_;
+
   const Upstream::ClusterInfo& cluster_info_;
   const Upstream::PrioritySet& priority_set_;
   Runtime::Loader& runtime_;

--- a/source/extensions/load_balancing_policies/subset/subset_lb.h
+++ b/source/extensions/load_balancing_policies/subset/subset_lb.h
@@ -200,10 +200,6 @@ public:
       return wrapped_->overrideHostToSelect();
     }
 
-    void setOrcaLoadReportCallbacks(std::weak_ptr<OrcaLoadReportCallbacks> callbacks) override {
-      wrapped_->setOrcaLoadReportCallbacks(callbacks);
-    }
-
   private:
     LoadBalancerContext* wrapped_;
     Router::MetadataMatchCriteriaConstPtr metadata_match_;

--- a/test/extensions/load_balancing_policies/client_side_weighted_round_robin/client_side_weighted_round_robin_lb_test.cc
+++ b/test/extensions/load_balancing_policies/client_side_weighted_round_robin/client_side_weighted_round_robin_lb_test.cc
@@ -13,15 +13,12 @@
 namespace Envoy {
 namespace Upstream {
 
-// Friend ClientSideWeightedRoundRobinLoadBalancer to provide access to private methods.
 class ClientSideWeightedRoundRobinLoadBalancerFriend {
 public:
   explicit ClientSideWeightedRoundRobinLoadBalancerFriend(
       std::shared_ptr<ClientSideWeightedRoundRobinLoadBalancer> lb,
       std::shared_ptr<ClientSideWeightedRoundRobinLoadBalancer::WorkerLocalLb> worker_lb)
       : lb_(std::move(lb)), worker_lb_(std::move(worker_lb)) {}
-
-  ~ClientSideWeightedRoundRobinLoadBalancerFriend() = default;
 
   HostConstSharedPtr chooseHost(LoadBalancerContext* context) {
     return worker_lb_->chooseHost(context);
@@ -36,10 +33,6 @@ public:
   void updateWeightsOnMainThread() { lb_->updateWeightsOnMainThread(); }
 
   void updateWeightsOnHosts(const HostVector& hosts) { lb_->updateWeightsOnHosts(hosts); }
-
-  static void addClientSideLbPolicyDataToHosts(const HostVector& hosts) {
-    ClientSideWeightedRoundRobinLoadBalancer::addClientSideLbPolicyDataToHosts(hosts);
-  }
 
   static absl::optional<uint32_t>
   getClientSideWeightIfValidFromHost(const Host& host, const MonotonicTime& min_non_empty_since,
@@ -67,14 +60,23 @@ public:
   absl::Status updateClientSideDataFromOrcaLoadReport(
       const xds::data::orca::v3::OrcaLoadReport& orca_load_report,
       ClientSideWeightedRoundRobinLoadBalancer::ClientSideHostLbPolicyData& client_side_data) {
-    return worker_lb_->orca_load_report_handler_->updateClientSideDataFromOrcaLoadReport(
-        orca_load_report, client_side_data);
+    return client_side_data.onHostLoadReport(orca_load_report);
   }
 
-  absl::Status onOrcaLoadReport(const OrcaLoadReportProto& orca_load_report,
-                                const HostDescription& host_description) {
-    return worker_lb_->orca_load_report_handler_->onOrcaLoadReport(orca_load_report,
-                                                                   host_description);
+  void setHostClientSideWeight(HostSharedPtr& host, uint32_t weight,
+                               long long non_empty_since_seconds,
+                               long long last_update_time_seconds) {
+    auto client_side_data =
+        std::make_unique<ClientSideWeightedRoundRobinLoadBalancer::ClientSideHostLbPolicyData>(
+            lb_->report_handler_, weight, /*non_empty_since=*/
+            MonotonicTime(std::chrono::seconds(non_empty_since_seconds)),
+            /*last_update_time=*/
+            MonotonicTime(std::chrono::seconds(last_update_time_seconds)));
+    host->setLbPolicyData(std::move(client_side_data));
+  }
+
+  ClientSideWeightedRoundRobinLoadBalancer::OrcaLoadReportHandlerSharedPtr orcaLoadReportHandler() {
+    return lb_->report_handler_;
   }
 
 private:
@@ -83,18 +85,6 @@ private:
 };
 
 namespace {
-
-void setHostClientSideWeight(HostSharedPtr& host, uint32_t weight,
-                             long long non_empty_since_seconds,
-                             long long last_update_time_seconds) {
-  auto client_side_data =
-      std::make_unique<ClientSideWeightedRoundRobinLoadBalancer::ClientSideHostLbPolicyData>(
-          weight, /*non_empty_since=*/
-          MonotonicTime(std::chrono::seconds(non_empty_since_seconds)),
-          /*last_update_time=*/
-          MonotonicTime(std::chrono::seconds(last_update_time_seconds)));
-  host->setLbPolicyData(std::move(client_side_data));
-}
 
 class ClientSideWeightedRoundRobinLoadBalancerTest : public LoadBalancerTestBase {
 public:
@@ -123,7 +113,7 @@ public:
             lb_config_, cluster_info_, priority_set_, runtime_, random_, simTime()),
         std::make_shared<ClientSideWeightedRoundRobinLoadBalancer::WorkerLocalLb>(
             priority_set_, local_priority_set_.get(), stats_, runtime_, random_, common_config_,
-            lb_config_, simTime(), /*tls_shim=*/absl::nullopt));
+            simTime(), /*tls_shim=*/absl::nullopt));
 
     // Initialize the thread aware load balancer from config.
     ASSERT_EQ(lb_->initialize(), absl::OkStatus());
@@ -177,9 +167,9 @@ TEST_P(ClientSideWeightedRoundRobinLoadBalancerTest,
       makeTestHost(info_, "tcp://127.0.0.1:82", simTime()),
   };
   simTime().setMonotonicTime(MonotonicTime(std::chrono::seconds(30)));
-  setHostClientSideWeight(hosts[0], 40, 5, 10);
-  setHostClientSideWeight(hosts[1], 41, 5, 10);
-  setHostClientSideWeight(hosts[2], 42, 5, 10);
+  lb_->setHostClientSideWeight(hosts[0], 40, 5, 10);
+  lb_->setHostClientSideWeight(hosts[1], 41, 5, 10);
+  lb_->setHostClientSideWeight(hosts[2], 42, 5, 10);
   // Setting client side weights should not change the host weights.
   EXPECT_EQ(hosts[0]->weight(), 1);
   EXPECT_EQ(hosts[1]->weight(), 1);
@@ -201,7 +191,7 @@ TEST_P(ClientSideWeightedRoundRobinLoadBalancerTest, UpdateWeightsOneHostHasClie
   };
   simTime().setMonotonicTime(MonotonicTime(std::chrono::seconds(30)));
   // Set client side weight for one host.
-  setHostClientSideWeight(hosts[0], 42, 5, 10);
+  lb_->setHostClientSideWeight(hosts[0], 42, 5, 10);
   // Setting client side weights should not change the host weights.
   EXPECT_EQ(hosts[0]->weight(), 1);
   EXPECT_EQ(hosts[1]->weight(), 1);
@@ -225,9 +215,9 @@ TEST_P(ClientSideWeightedRoundRobinLoadBalancerTest, UpdateWeightsDefaultIsOddMe
   };
   simTime().setMonotonicTime(MonotonicTime(std::chrono::seconds(30)));
   // Set client side weight for first three hosts.
-  setHostClientSideWeight(hosts[0], 5, 5, 10);
-  setHostClientSideWeight(hosts[1], 42, 5, 10);
-  setHostClientSideWeight(hosts[2], 5000, 5, 10);
+  lb_->setHostClientSideWeight(hosts[0], 5, 5, 10);
+  lb_->setHostClientSideWeight(hosts[1], 42, 5, 10);
+  lb_->setHostClientSideWeight(hosts[2], 5000, 5, 10);
   // Setting client side weights should not change the host weights.
   EXPECT_EQ(hosts[0]->weight(), 1);
   EXPECT_EQ(hosts[1]->weight(), 1);
@@ -256,8 +246,8 @@ TEST_P(ClientSideWeightedRoundRobinLoadBalancerTest, UpdateWeightsDefaultIsEvenM
   };
   simTime().setMonotonicTime(MonotonicTime(std::chrono::seconds(30)));
   // Set client side weight for first two hosts.
-  setHostClientSideWeight(hosts[0], 5, 5, 10);
-  setHostClientSideWeight(hosts[1], 42, 5, 10);
+  lb_->setHostClientSideWeight(hosts[0], 5, 5, 10);
+  lb_->setHostClientSideWeight(hosts[1], 42, 5, 10);
   // Setting client side weights should not change the host weights.
   EXPECT_EQ(hosts[0]->weight(), 1);
   EXPECT_EQ(hosts[1]->weight(), 1);
@@ -290,13 +280,6 @@ TEST_P(ClientSideWeightedRoundRobinLoadBalancerTest, ChooseHostWithClientSideWei
   hostSet().runCallbacks({}, {});
   simTime().setMonotonicTime(MonotonicTime(std::chrono::seconds(5)));
   for (const auto& host_ptr : hostSet().hosts_) {
-    // chooseHost calls setOrcaLoadReportCallbacks.
-    std::weak_ptr<LoadBalancerContext::OrcaLoadReportCallbacks> weak_orca_load_report_callbacks;
-    EXPECT_CALL(lb_context_, setOrcaLoadReportCallbacks(_))
-        .WillOnce(
-            Invoke([&](std::weak_ptr<LoadBalancerContext::OrcaLoadReportCallbacks> callbacks) {
-              weak_orca_load_report_callbacks = callbacks;
-            }));
     HostConstSharedPtr host = lb_->chooseHost(&lb_context_);
     // Hosts have equal weights, so chooseHost returns the current host.
     ASSERT_EQ(host, host_ptr);
@@ -304,11 +287,7 @@ TEST_P(ClientSideWeightedRoundRobinLoadBalancerTest, ChooseHostWithClientSideWei
     xds::data::orca::v3::OrcaLoadReport orca_load_report;
     orca_load_report.set_rps_fractional(1000);
     orca_load_report.set_application_utilization(0.5);
-    // Orca load report callback does NOT change the host weight.
-    auto orca_load_report_callbacks = weak_orca_load_report_callbacks.lock();
-    ASSERT_NE(orca_load_report_callbacks, nullptr);
-    EXPECT_EQ(orca_load_report_callbacks->onOrcaLoadReport(orca_load_report, *host.get()),
-              absl::OkStatus());
+    EXPECT_EQ(host->lbPolicyData()->onHostLoadReport(orca_load_report), absl::OkStatus());
     EXPECT_EQ(host->weight(), 1);
   }
   // Update weights on hosts.
@@ -329,7 +308,8 @@ TEST_P(ClientSideWeightedRoundRobinLoadBalancerTest, ProcessOrcaLoadReport_First
   orca_load_report.set_application_utilization(0.5);
 
   auto client_side_data =
-      std::make_shared<ClientSideWeightedRoundRobinLoadBalancer::ClientSideHostLbPolicyData>();
+      std::make_shared<ClientSideWeightedRoundRobinLoadBalancer::ClientSideHostLbPolicyData>(
+          lb_->orcaLoadReportHandler());
   EXPECT_EQ(lb_->updateClientSideDataFromOrcaLoadReport(orca_load_report, *client_side_data),
             absl::OkStatus());
   // First report, so non_empty_since_ is updated.
@@ -350,7 +330,8 @@ TEST_P(ClientSideWeightedRoundRobinLoadBalancerTest, ProcessOrcaLoadReport_Updat
 
   auto client_side_data =
       std::make_shared<ClientSideWeightedRoundRobinLoadBalancer::ClientSideHostLbPolicyData>(
-          42, /*non_empty_since=*/MonotonicTime(std::chrono::seconds(1)),
+          lb_->orcaLoadReportHandler(), 42,
+          /*non_empty_since=*/MonotonicTime(std::chrono::seconds(1)),
           /*last_update_time=*/MonotonicTime(std::chrono::seconds(10)));
   EXPECT_EQ(lb_->updateClientSideDataFromOrcaLoadReport(orca_load_report, *client_side_data),
             absl::OkStatus());
@@ -373,7 +354,8 @@ TEST_P(ClientSideWeightedRoundRobinLoadBalancerTest, ProcessOrcaLoadReport_Updat
 
   auto client_side_data =
       std::make_shared<ClientSideWeightedRoundRobinLoadBalancer::ClientSideHostLbPolicyData>(
-          42, /*non_empty_since=*/MonotonicTime(std::chrono::seconds(1)),
+          lb_->orcaLoadReportHandler(), 42,
+          /*non_empty_since=*/MonotonicTime(std::chrono::seconds(1)),
           /*last_update_time=*/MonotonicTime(std::chrono::seconds(10)));
   EXPECT_EQ(lb_->updateClientSideDataFromOrcaLoadReport(orca_load_report, *client_side_data),
             absl::InvalidArgumentError("QPS must be positive"));
@@ -381,21 +363,6 @@ TEST_P(ClientSideWeightedRoundRobinLoadBalancerTest, ProcessOrcaLoadReport_Updat
   EXPECT_EQ(client_side_data->non_empty_since_.load(), MonotonicTime(std::chrono::seconds(1)));
   EXPECT_EQ(client_side_data->last_update_time_.load(), MonotonicTime(std::chrono::seconds(10)));
   EXPECT_EQ(client_side_data->weight_.load(), 42);
-}
-
-TEST_P(ClientSideWeightedRoundRobinLoadBalancerTest, OnOrcaLoadReport_NoClientSideData) {
-  init(false);
-  simTime().setMonotonicTime(MonotonicTime(std::chrono::seconds(30)));
-
-  xds::data::orca::v3::OrcaLoadReport orca_load_report;
-  // QPS is 0, so the report is invalid.
-  orca_load_report.set_rps_fractional(0);
-  orca_load_report.set_application_utilization(0.5);
-
-  auto host = makeTestHost(info_, "tcp://127.0.0.1:80", simTime());
-
-  EXPECT_EQ(lb_->onOrcaLoadReport(orca_load_report, *host.get()),
-            absl::NotFoundError("Host does not have ClientSideLbPolicyData"));
 }
 
 INSTANTIATE_TEST_SUITE_P(PrimaryOrFailoverAndLegacyOrNew,
@@ -416,7 +383,7 @@ TEST(ClientSideWeightedRoundRobinLoadBalancerTest, GetClientSideWeightIfValidFro
   NiceMock<Envoy::Upstream::MockHost> host;
   host.lb_policy_data_ =
       std::make_unique<ClientSideWeightedRoundRobinLoadBalancer::ClientSideHostLbPolicyData>(
-          42, /*non_empty_since=*/MonotonicTime(std::chrono::seconds(5)),
+          nullptr, 42, /*non_empty_since=*/MonotonicTime(std::chrono::seconds(5)),
           /*last_update_time=*/MonotonicTime(std::chrono::seconds(10)));
   // Non empty since is too recent (5 > 2).
   EXPECT_FALSE(ClientSideWeightedRoundRobinLoadBalancerFriend::getClientSideWeightIfValidFromHost(
@@ -434,7 +401,7 @@ TEST(ClientSideWeightedRoundRobinLoadBalancerTest, GetClientSideWeightIfValidFro
   NiceMock<Envoy::Upstream::MockHost> host;
   host.lb_policy_data_ =
       std::make_unique<ClientSideWeightedRoundRobinLoadBalancer::ClientSideHostLbPolicyData>(
-          42, /*non_empty_since=*/MonotonicTime(std::chrono::seconds(1)),
+          nullptr, 42, /*non_empty_since=*/MonotonicTime(std::chrono::seconds(1)),
           /*last_update_time=*/MonotonicTime(std::chrono::seconds(7)));
   // Last update time is too stale (7 < 8).
   EXPECT_FALSE(ClientSideWeightedRoundRobinLoadBalancerFriend::getClientSideWeightIfValidFromHost(
@@ -452,7 +419,7 @@ TEST(ClientSideWeightedRoundRobinLoadBalancerTest, GetClientSideWeightIfValidFro
   NiceMock<Envoy::Upstream::MockHost> host;
   host.lb_policy_data_ =
       std::make_unique<ClientSideWeightedRoundRobinLoadBalancer::ClientSideHostLbPolicyData>(
-          42, /*non_empty_since=*/MonotonicTime(std::chrono::seconds(1)),
+          nullptr, 42, /*non_empty_since=*/MonotonicTime(std::chrono::seconds(1)),
           /*last_update_time=*/MonotonicTime(std::chrono::seconds(10)));
   // Not empty since is not too recent (1 < 2) and last update time is not too
   // old (10 > 8).

--- a/test/mocks/upstream/host.cc
+++ b/test/mocks/upstream/host.cc
@@ -46,6 +46,9 @@ MockHostDescription::MockHostDescription()
       .WillByDefault(Invoke([this](Upstream::ResourcePriority pri) -> bool {
         return cluster().resourceManager(pri).connections().canCreate();
       }));
+  ON_CALL(*this, lbPolicyData()).WillByDefault(Invoke([this]() -> OptRef<HostLbPolicyData> {
+    return makeOptRefFromPtr(lb_policy_data_.get());
+  }));
 }
 
 MockHostDescription::~MockHostDescription() = default;

--- a/test/mocks/upstream/host.h
+++ b/test/mocks/upstream/host.h
@@ -115,6 +115,8 @@ public:
               (const Network::Address::InstanceConstSharedPtr& dest_address,
                const envoy::config::core::v3::Metadata* metadata),
               (const));
+  MOCK_METHOD(void, setLbPolicyData, (HostLbPolicyDataPtr lb_policy_data));
+  MOCK_METHOD(OptRef<HostLbPolicyData>, lbPolicyData, (), (const));
 
   std::string hostname_;
   Network::Address::InstanceConstSharedPtr address_;
@@ -124,6 +126,7 @@ public:
   testing::NiceMock<MockClusterInfo> cluster_;
   HostStats stats_;
   LoadMetricStatsImpl load_metric_stats_;
+  HostLbPolicyDataPtr lb_policy_data_;
   envoy::config::core::v3::Locality locality_;
   mutable Stats::TestUtil::TestSymbolTable symbol_table_;
   mutable std::unique_ptr<Stats::StatNameManagedStorage> locality_zone_stat_name_;

--- a/test/mocks/upstream/load_balancer_context.h
+++ b/test/mocks/upstream/load_balancer_context.h
@@ -26,7 +26,6 @@ public:
   MOCK_METHOD(Network::TransportSocketOptionsConstSharedPtr, upstreamTransportSocketOptions, (),
               (const));
   MOCK_METHOD(absl::optional<OverrideHost>, overrideHostToSelect, (), (const));
-  MOCK_METHOD(void, setOrcaLoadReportCallbacks, (std::weak_ptr<OrcaLoadReportCallbacks>));
 
 private:
   HealthyAndDegradedLoad priority_load_;


### PR DESCRIPTION

Commit Message: orca: refactored the lbPolicyData and orca report callbacks
Additional Description:

1. Moved the `lbPolicyData` to `HostDescription`. Because we can never assume the `HostDescription` could be casted as `Host`. This actually fixed a bug of `ClientSideWeightedRoundRobin`. The `LogicalHost` and `RealHostDescription` is a special case in this whole abstraction. (I want to change it also, but it cannot be done in short time.)
3. Removed `OrcaLoadReportCallbacks` and let the `HostLbPolicyData` to processing orca report directly. When I also start developing an orca-based Lb and re-read the `ClientSideWeightedRoundRobin`'s code, I found actually the `HostLbPolicyData` and orca report processing is thread independent. It's uncessary to let the worker local load balancer to be involved. This change simplify the whole process.

Risk Level: low. The `ClientSideWeightedRoundRobin` is still not stable now.
Testing: n/a.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.