### PR TITLE
redis cluster: remove unnecessary validation to the lb type

### DIFF
--- a/source/extensions/filters/network/redis_proxy/conn_pool_impl.cc
+++ b/source/extensions/filters/network/redis_proxy/conn_pool_impl.cc
@@ -36,10 +36,6 @@ const Common::Redis::RespValue& getRequest(const RespVariant& request) {
 
 static uint16_t default_port = 6379;
 
-bool isClusterProvidedLb(const Upstream::ClusterInfo& info) {
-  return info.loadBalancerFactory().name() == "envoy.load_balancing_policies.cluster_provided";
-}
-
 } // namespace
 
 InstanceImpl::InstanceImpl(
@@ -168,8 +164,7 @@ void InstanceImpl::ThreadLocalPool::onClusterAddOrUpdateNonVirtual(
   Upstream::ClusterInfoConstSharedPtr info = cluster_->info();
   OptRef<const envoy::config::cluster::v3::Cluster::CustomClusterType> cluster_type =
       info->clusterType();
-  is_redis_cluster_ = isClusterProvidedLb(*info) && cluster_type.has_value() &&
-                      cluster_type->name() == "envoy.clusters.redis";
+  is_redis_cluster_ = cluster_type.has_value() && cluster_type->name() == "envoy.clusters.redis";
 }
 
 void InstanceImpl::ThreadLocalPool::onClusterRemoval(const std::string& cluster_name) {

--- a/test/extensions/filters/network/redis_proxy/conn_pool_impl_test.cc
+++ b/test/extensions/filters/network/redis_proxy/conn_pool_impl_test.cc
@@ -1157,10 +1157,6 @@ TEST_F(RedisConnPoolImplTest, MakeRequestToRedisCluster) {
   EXPECT_CALL(*cm_.thread_local_cluster_.cluster_.info_, clusterType())
       .WillOnce(Return(
           makeOptRef<const envoy::config::cluster::v3::Cluster::CustomClusterType>(cluster_type)));
-  EXPECT_CALL(*cm_.thread_local_cluster_.cluster_.info_, loadBalancerFactory())
-      .WillOnce(
-          ReturnRef(Config::Utility::getAndCheckFactoryByName<Upstream::TypedLoadBalancerFactory>(
-              "envoy.load_balancing_policies.cluster_provided")));
 
   setup();
 
@@ -1180,10 +1176,6 @@ TEST_F(RedisConnPoolImplTest, MakeRequestToRedisClusterHashtag) {
   EXPECT_CALL(*cm_.thread_local_cluster_.cluster_.info_, clusterType())
       .WillOnce(Return(
           makeOptRef<const envoy::config::cluster::v3::Cluster::CustomClusterType>(cluster_type)));
-  EXPECT_CALL(*cm_.thread_local_cluster_.cluster_.info_, loadBalancerFactory())
-      .WillOnce(
-          ReturnRef(Config::Utility::getAndCheckFactoryByName<Upstream::TypedLoadBalancerFactory>(
-              "envoy.load_balancing_policies.cluster_provided")));
 
   setup();
 


### PR DESCRIPTION
Commit Message: redis cluster: remove unnecessary validation to the lb type
Additional Description:

This validation is unnecessary becase if cluster provided lb is not used, the following check when loading cluster will failed directly.

```
  if (!cluster_provided_lb && lb != nullptr) {
    return absl::InvalidArgumentError(
        fmt::format("cluster manager: cluster provided LB not specified but cluster "
                    "'{}' provided one. Check cluster documentation.",
                    cluster_info->name()));
  }
```

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
