### PR TITLE
Disable sidestream flow control 3

### DIFF
--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -225,16 +225,8 @@ private:
       watermark_callbacks_->get().onSidestreamBelowLowWatermark();
     }
   }
-  void addDownstreamWatermarkCallbacks(DownstreamWatermarkCallbacks& callbacks) override {
-    if (watermark_callbacks_.has_value()) {
-      watermark_callbacks_->get().addDownstreamWatermarkCallbacks(callbacks);
-    }
-  }
-  void removeDownstreamWatermarkCallbacks(DownstreamWatermarkCallbacks& callbacks) override {
-    if (watermark_callbacks_.has_value()) {
-      watermark_callbacks_->get().removeDownstreamWatermarkCallbacks(callbacks);
-    }
-  }
+  void addDownstreamWatermarkCallbacks(DownstreamWatermarkCallbacks& callbacks) override {}
+  void removeDownstreamWatermarkCallbacks(DownstreamWatermarkCallbacks& callbacks) override {}
   void sendGoAwayAndClose() override {}
 
   void setDecoderBufferLimit(uint32_t) override {

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -225,8 +225,8 @@ private:
       watermark_callbacks_->get().onSidestreamBelowLowWatermark();
     }
   }
-  void addDownstreamWatermarkCallbacks(DownstreamWatermarkCallbacks& callbacks) override {}
-  void removeDownstreamWatermarkCallbacks(DownstreamWatermarkCallbacks& callbacks) override {}
+  void addDownstreamWatermarkCallbacks(DownstreamWatermarkCallbacks&) override {}
+  void removeDownstreamWatermarkCallbacks(DownstreamWatermarkCallbacks&) override {}
   void sendGoAwayAndClose() override {}
 
   void setDecoderBufferLimit(uint32_t) override {

--- a/source/common/http/sidestream_watermark.h
+++ b/source/common/http/sidestream_watermark.h
@@ -33,9 +33,9 @@ public:
     }
   }
 
-  void addDownstreamWatermarkCallbacks(Http::DownstreamWatermarkCallbacks& callbacks) final {}
+  void addDownstreamWatermarkCallbacks(Http::DownstreamWatermarkCallbacks&) final {}
 
-  void removeDownstreamWatermarkCallbacks(Http::DownstreamWatermarkCallbacks& callbacks) final {}
+  void removeDownstreamWatermarkCallbacks(Http::DownstreamWatermarkCallbacks&) final {}
 
   /**
    * The set function needs to be called by stream decoder filter before side stream connection is

--- a/source/common/http/sidestream_watermark.h
+++ b/source/common/http/sidestream_watermark.h
@@ -33,19 +33,9 @@ public:
     }
   }
 
-  void addDownstreamWatermarkCallbacks(Http::DownstreamWatermarkCallbacks& callbacks) final {
-    if (decode_callback_ != nullptr) {
-      // Sidestream subscribes to downstream watermark events.
-      decode_callback_->addDownstreamWatermarkCallbacks(callbacks);
-    }
-  }
+  void addDownstreamWatermarkCallbacks(Http::DownstreamWatermarkCallbacks& callbacks) final {}
 
-  void removeDownstreamWatermarkCallbacks(Http::DownstreamWatermarkCallbacks& callbacks) final {
-    if (decode_callback_ != nullptr) {
-      // Sidestream stops subscribing to downstream watermark events.
-      decode_callback_->removeDownstreamWatermarkCallbacks(callbacks);
-    }
-  }
+  void removeDownstreamWatermarkCallbacks(Http::DownstreamWatermarkCallbacks& callbacks) final {}
 
   /**
    * The set function needs to be called by stream decoder filter before side stream connection is

--- a/test/common/http/async_client_impl_test.cc
+++ b/test/common/http/async_client_impl_test.cc
@@ -497,7 +497,6 @@ TEST_F(AsyncClientImplTest, OngoingRequestWithWatermarking) {
   EXPECT_NE(request, nullptr);
 
   StrictMock<MockSidestreamWatermarkCallbacks> watermark_callbacks;
-  EXPECT_CALL(watermark_callbacks, removeDownstreamWatermarkCallbacks(_));
 
   // Registering a new watermark callback should note that the high watermark has already been hit.
   EXPECT_CALL(watermark_callbacks, onSidestreamAboveHighWatermark());
@@ -558,7 +557,6 @@ TEST_F(AsyncClientImplTest, OngoingRequestWithWatermarkingAndReset) {
 
   StrictMock<MockSidestreamWatermarkCallbacks> watermark_callbacks;
   request->setWatermarkCallbacks(watermark_callbacks);
-  EXPECT_CALL(watermark_callbacks, removeDownstreamWatermarkCallbacks(_));
 
   EXPECT_CALL(stream_encoder_, encodeData(BufferEqual(&data_copy), false));
   request->sendData(data, false);

--- a/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
+++ b/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
@@ -4758,63 +4758,6 @@ TEST_P(ExtProcIntegrationTest, SidestreamPushbackUpstreamObservabilityMode) {
   verifyDownstreamResponse(*response, 200);
 }
 
-// Downstream push back sidestream and upstream
-TEST_P(ExtProcIntegrationTest, DownstreamPushbackSidestreamAndUpstream) {
-  if (!IsEnvoyGrpc()) {
-    return;
-  }
-
-  config_helper_.setBufferLimits(1024, 1024);
-  proto_config_.mutable_processing_mode()->set_request_header_mode(ProcessingMode::SKIP);
-  proto_config_.mutable_processing_mode()->set_response_header_mode(ProcessingMode::SKIP);
-  proto_config_.mutable_processing_mode()->set_response_body_mode(ProcessingMode::STREAMED);
-
-  initializeConfig();
-  HttpIntegrationTest::initialize();
-
-  auto response = sendDownstreamRequestWithBody("hello world", absl::nullopt);
-
-  // Response from upstream server.
-  ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, fake_upstream_connection_));
-  ASSERT_TRUE(fake_upstream_connection_->waitForNewStream(*dispatcher_, upstream_request_));
-  ASSERT_TRUE(upstream_request_->waitForEndStream(*dispatcher_));
-  Http::TestResponseHeaderMapImpl response_headers =
-      Http::TestResponseHeaderMapImpl{{":status", "200"}};
-  upstream_request_->encodeHeaders(response_headers, false);
-  upstream_request_->encodeData(64 * 1024, true);
-  std::string body_str = std::string(64 * 1024, 'a');
-
-  bool end_stream = false;
-  int count = 0;
-  while (!end_stream) {
-    processResponseBodyMessage(
-        *grpc_upstreams_[0], count == 0 ? true : false,
-        [&end_stream, &body_str](const HttpBody& body, BodyResponse& body_resp) {
-          end_stream = body.end_of_stream();
-          auto* body_mut = body_resp.mutable_response()->mutable_body_mutation();
-          body_mut->set_body(body_str);
-          return true;
-        });
-    count++;
-  }
-
-  // Read disable on upstream, triggered by downstream.
-  EXPECT_GE(test_server_
-                ->counter("cluster.cluster_0.upstream_flow_control_"
-                          "paused_reading_total")
-                ->value(),
-            1);
-
-  // Read disable on sidestream(cluster ext_proc_server_0), triggered by
-  // downstream.
-  EXPECT_GE(test_server_
-                ->counter("cluster.ext_proc_server_0.upstream_flow_control_"
-                          "paused_reading_total")
-                ->value(),
-            1);
-  cleanupUpstreamAndDownstream();
-}
-
 TEST_P(ExtProcIntegrationTest, SendBodyBeforeHeaderRespStreamedBasicTest) {
   proto_config_.mutable_processing_mode()->set_request_header_mode(ProcessingMode::SEND);
   proto_config_.mutable_processing_mode()->set_request_body_mode(ProcessingMode::STREAMED);


### PR DESCRIPTION
Noticed some crashes internally, due to http asyncClient layer changes in https://github.com/envoyproxy/envoy/pull/35827
It is probably because http asyncClient is not ready (i.e., miss some changes) for sidestream flow control part 3 or has pre-existing bugs.

Disable it while it is under investigation. 