### PR TITLE
sub-formatter: change string data member to bool

### DIFF
--- a/source/common/protobuf/utility.cc
+++ b/source/common/protobuf/utility.cc
@@ -789,7 +789,7 @@ const ProtobufWkt::Value& ValueUtil::nullValue() {
   return *v;
 }
 
-ProtobufWkt::Value ValueUtil::stringValue(const std::string& str) {
+ProtobufWkt::Value ValueUtil::stringValue(absl::string_view str) {
   ProtobufWkt::Value val;
   val.set_string_value(str);
   return val;

--- a/source/common/protobuf/utility.h
+++ b/source/common/protobuf/utility.h
@@ -624,11 +624,11 @@ public:
   static const ProtobufWkt::Value& nullValue();
 
   /**
-   * Wrap std::string into ProtobufWkt::Value string value.
+   * Wrap absl::string_view into ProtobufWkt::Value string value.
    * @param str string to be wrapped.
    * @return wrapped string.
    */
-  static ProtobufWkt::Value stringValue(const std::string& str);
+  static ProtobufWkt::Value stringValue(absl::string_view str);
 
   /**
    * Wrap optional std::string into ProtobufWkt::Value string value.


### PR DESCRIPTION
Commit Message: sub-formatter: change string data member to bool
Additional Description:
A couple of objects have a data member of string type, that could be of type bool.
Converting them to a bool type should reserve some memory that is allocated for each instantiated object.

Risk Level: low - internal refactor
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A