### PR TITLE
aysnc_client: use proper scheme header

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -195,6 +195,12 @@ bug_fixes:
   change: |
     Fixed a bug where the DNS refresh rate was the DNS TTL instead of the configured dns_refresh_rate/dns_failure_refresh_rate
     when we failed to resolve the DNS query after a successful resolution.
+- area: http
+  change: |
+    Fixed the async client implementation to set the :scheme pseudo header according to the upstream protocol ('http' or 'https').
+    Before the :scheme header was always 'http'.
+    This behavioral change can be temporarily reverted by setting runtime guard
+    ``envoy.reloadable_features.async_client_scheme_header_fix`` to false.
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/source/common/http/async_client_impl.cc
+++ b/source/common/http/async_client_impl.cc
@@ -139,6 +139,7 @@ AsyncStreamImpl::AsyncStreamImpl(AsyncClientImpl& parent, AsyncClient::StreamCal
   route_ = std::move(*route_or_error);
   stream_info_.dynamicMetadata().MergeFrom(options.metadata);
   stream_info_.setIsShadow(options.is_shadow);
+  stream_info_.setShouldSchemeMatchUpstream(true);
   stream_info_.setUpstreamClusterInfo(parent_.cluster_);
   stream_info_.route_ = route_;
 

--- a/source/common/http/async_client_impl.cc
+++ b/source/common/http/async_client_impl.cc
@@ -139,7 +139,9 @@ AsyncStreamImpl::AsyncStreamImpl(AsyncClientImpl& parent, AsyncClient::StreamCal
   route_ = std::move(*route_or_error);
   stream_info_.dynamicMetadata().MergeFrom(options.metadata);
   stream_info_.setIsShadow(options.is_shadow);
-  stream_info_.setShouldSchemeMatchUpstream(true);
+  if (Runtime::runtimeFeatureEnabled("envoy.reloadable_features.async_client_scheme_header_fix")) {
+    stream_info_.setShouldSchemeMatchUpstream(true);
+  }
   stream_info_.setUpstreamClusterInfo(parent_.cluster_);
   stream_info_.route_ = route_;
 

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -30,6 +30,7 @@
 // ASAP by filing a bug on github. Overriding non-buggy code is strongly discouraged to avoid the
 // problem of the bugs being found after the old code path has been removed.
 RUNTIME_GUARD(envoy_reloadable_features_allow_alt_svc_for_ips);
+RUNTIME_GUARD(envoy_reloadable_features_async_client_scheme_header_fix);
 RUNTIME_GUARD(envoy_reloadable_features_avoid_dfp_cluster_removal_on_cds_update);
 RUNTIME_GUARD(envoy_reloadable_features_boolean_to_string_fix);
 RUNTIME_GUARD(envoy_reloadable_features_check_switch_protocol_websocket_handshake);

--- a/test/common/http/async_client_impl_test.cc
+++ b/test/common/http/async_client_impl_test.cc
@@ -2410,6 +2410,8 @@ TEST_F(AsyncClientImplUnitTest, NullVirtualHost) {
 }
 
 TEST_F(AsyncClientImplTest, UpstreamTlsScheme) {
+  // Validate the upstream peudo header ':scheme' is set to 'https' if upstream is using TLS
+
   message_->body().add("test body");
   Buffer::Instance& data = message_->body();
 


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
derive scheme header of async client request from upstream config instead of non-existing downstream.

Additional Description:
I saw that the "router decoding headers:" log message in `router.cc` stated that the :scheme header is always 'http' regardless of the upstream protocol used.
The reason for this is, the stream_info of a async client request does not have a downstream and the :scheme header is by default derived from the downstream (`FilterUtility::setUpstreamScheme()` call in in `router.cc` `Filter::decodeHeaders()` is called with `use_upstream=false` since `callbacks_->streamInfo().shouldSchemeMatchUpstream()` is false).

The Fix for this is to set `setShouldSchemeMatchUpstream(true)` on the async clients stream_info. Then `setUpstreamScheme()` call will derive the :scheme header from the upstream config.

I`m not sure if this is a real problem, since the async client by default uses http11 and the :scheme header is not sent to the server. Perhaps if the server triggers an http2 upgrade this might be an issue. 


Risk Level: low

Testing: 
* Manual testing (with JWT Authentication with JwtProvider `remote_jwks` endpoint configured)
* AsyncClientImplTest::UpstreamTlsScheme test added

Docs Changes: -

Release Notes: Set async client :scheme header depending on upstream protocol

Platform Specific Features: -
