### PR TITLE
Hoist `java_rules` into envoy

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -617,6 +617,11 @@ def _com_google_protobuf():
     external_http_archive(
         name = "rules_python",
     )
+    external_http_archive(
+        name = "rules_java",
+        patch_args = ["-p1"],
+        patches = ["@envoy//bazel:rules_java.patch"],
+    )
 
     for platform in PROTOC_VERSIONS:
         # Ideally we dont use a private build artefact as done here.

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -1068,6 +1068,18 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         license = "Apache-2.0",
         license_url = "https://github.com/bazelbuild/rules_foreign_cc/blob/{version}/LICENSE",
     ),
+    rules_java = dict(
+        project_name = "Java rules for Bazel",
+        project_desc = "Bazel rules for the Java language",
+        project_url = "https://github.com/bazelbuild/rules_java/",
+        version = "7.12.3",
+        sha256 = "c0ee60f8757f140c157fc2c7af703d819514de6e025ebf70386d38bdd85fce83",
+        release_date = "2024-12-03",
+        urls = ["https://github.com/bazelbuild/rules_java/releases/download/{version}/rules_java-{version}.tar.gz"],
+        use_category = ["build"],
+        license = "Apache-2.0",
+        license_url = "https://github.com/bazelbuild/rules_java/blob/{version}/LICENSE",
+    ),
     rules_python = dict(
         project_name = "Python rules for Bazel",
         project_desc = "Bazel rules for the Python language",

--- a/mobile/bazel/envoy_mobile_repositories.bzl
+++ b/mobile/bazel/envoy_mobile_repositories.bzl
@@ -47,9 +47,8 @@ def swift_repos():
 def kotlin_repos():
     http_archive(
         name = "rules_java",
-        sha256 = "ac0757f2feca4a9c6ba9dd3d4858bbfccb019d7c48e725f76a14ddef673f728c",
-        strip_prefix = "rules_java-7.12.3",
-        url = "https://github.com/bazelbuild/rules_java/archive/7.12.3.tar.gz",
+        sha256 = "c0ee60f8757f140c157fc2c7af703d819514de6e025ebf70386d38bdd85fce83",
+        url = "https://github.com/bazelbuild/rules_java/releases/download/7.12.3/rules_java-7.12.3.tar.gz"
         patch_args = ["-p1"],
         patches = ["@envoy//bazel:rules_java.patch"],
     )

--- a/mobile/bazel/envoy_mobile_repositories.bzl
+++ b/mobile/bazel/envoy_mobile_repositories.bzl
@@ -48,7 +48,7 @@ def kotlin_repos():
     http_archive(
         name = "rules_java",
         sha256 = "c0ee60f8757f140c157fc2c7af703d819514de6e025ebf70386d38bdd85fce83",
-        url = "https://github.com/bazelbuild/rules_java/releases/download/7.12.3/rules_java-7.12.3.tar.gz"
+        url = "https://github.com/bazelbuild/rules_java/releases/download/7.12.3/rules_java-7.12.3.tar.gz",
         patch_args = ["-p1"],
         patches = ["@envoy//bazel:rules_java.patch"],
     )


### PR DESCRIPTION
Protobuf 29.0+ depends on `rules_java`, so let's bring it into Envoy core, syncing what we import in core and mobile.



- switch to release download url
- drop `strip_prefix` since the new url doesn't have a prefix to strip.
- add `rules_java` to `bazel/repository_locations.bzl`
- add `rules_java` to `_com_google_protobuf()` in `bazel/repositories.bzl`

Risk Level: low
Testing: CI