### PR TITLE
docs: add more context around x-request-id propagation

### DIFF
--- a/docs/root/configuration/http/http_conn_man/headers.rst
+++ b/docs/root/configuration/http/http_conn_man/headers.rst
@@ -512,6 +512,34 @@ following features are available:
 See the architecture overview on
 :ref:`context propagation <arch_overview_tracing_context_propagation>` for more information.
 
+.. note::
+
+ The behavior of ``x-request-id`` is determined by two key configuration settings:
+
+ 1. ``use_remote_address`` field determines if the proxy treats the request as an "edge request".
+
+   - When ``true``, Envoy generates a new ``x-request-id`` for all requests unless :ref:`preserve_external_request_id<envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.preserve_external_request_id>` is set.
+   - When ``false``, Envoy preserves any existing ``x-request-id``.
+
+ 2. ``preserve_external_request_id`` field controls whether to keep existing ``x-request-id`` on the edge requests.
+
+   - Applies only when :ref:`use_remote_address <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.use_remote_address>` is set to ``true``.
+   - When ``true``, preserves the existing ``x-request-id`` from external requests.
+   - When ``false``, generates a new ``x-request-id`` for external requests.
+
+ **Common Scenarios:**
+
+ * **Edge Proxy** (``use_remote_address=true``):
+
+   - Always generates a new ``x-request-id`` unless :ref:`preserve_external_request_id <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.preserve_external_request_id>` is enabled.
+   - Typically used for internet-facing load balancers.
+
+ * **Internal Proxy** (``use_remote_address=false``):
+
+   - Always preserves any existing ``x-request-id``.
+   - Generates a new ``x-request-id`` only if one does not already exist.
+   - Typically used for service-to-service communication.
+
 .. _config_http_conn_man_headers_x-ot-span-context:
 
 x-ot-span-context


### PR DESCRIPTION
## Description

Public docs on [x-request-id](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/headers#x-request-id) is missing some context around how `use_remote_address` and `preserve_external_request_id` are key to determine whether or not the request id would be allowed from the downstream requests.

**Blurb Added:**
<img width="931" alt="Screenshot 2024-12-11 at 11 49 06" src="https://github.com/user-attachments/assets/36bdab59-69ac-479a-a17b-1df9ced72cbd">

---

**Commit Message:** docs: add more context around `x-request-id` propagation
**Additional Description:** Add some more context on how the Request ID header is honored when the request is coming from downstream.
**Risk Level:** N/A
**Testing:** N/A
**Docs Changes:** N/A
**Release Notes:** N/A