### PR TITLE
[stream info] [test] Fix broken StreamInfoImpl test

### DIFF
--- a/test/common/stream_info/stream_info_impl_test.cc
+++ b/test/common/stream_info/stream_info_impl_test.cc
@@ -41,11 +41,12 @@ class StreamInfoImplTest : public testing::Test {
 protected:
   void assertStreamInfoSize(StreamInfoImpl stream_info) {
     ASSERT_TRUE(
-        sizeof(stream_info) == 840 || sizeof(stream_info) == 856 || sizeof(stream_info) == 888 ||
-        sizeof(stream_info) == 776 || sizeof(stream_info) == 728 || sizeof(stream_info) == 744 ||
-        sizeof(stream_info) == 680 || sizeof(stream_info) == 696 || sizeof(stream_info) == 688 ||
-        sizeof(stream_info) == 736 || sizeof(stream_info) == 728 || sizeof(stream_info) == 712 ||
-        sizeof(stream_info) == 704)
+        // with --config=docker-msan
+        sizeof(stream_info) == 712 ||
+        // with --config=docker-clang
+        sizeof(stream_info) == 720 ||
+        // with --config=docker-clang-libc++
+        sizeof(stream_info) == 688)
         << "If adding fields to StreamInfoImpl, please check to see if you "
            "need to add them to setFromForRecreateStream or setFrom! Current size "
         << sizeof(stream_info);

--- a/tools/spelling/spelling_dictionary.txt
+++ b/tools/spelling/spelling_dictionary.txt
@@ -333,6 +333,7 @@ ODCDS
 middlewildcard
 monostate
 mpd
+msan
 mutators
 mybucket
 myobject


### PR DESCRIPTION
Commit Message:

I'm not fully familiar with the background of the assertStreamInfoSize, but it appears that the purpose of this check is to make sure that changes to StreamInfoImpl aren't going to break setFromForRecreateStream or setFrom.

Ideally we would not rely on such a test and instead test setFromForRecreateStream functionality directly, but I understand that it might be difficult to come up with a good test that covers all the cases.

However, this test was apprently broken by
https://github.com/envoyproxy/envoy/pull/35650. This PR addedd a new field to the StreamInfoImpl changing the layout of the structure and with that the test.

Interestingly enough, the same PR actually updated StreamInfoImpl::setFrom function (which the test reminds us to do every time we change StreamInfoImpl), but at the same time it didn't change the test.

Anyways, keeping the status quo until we have a good alternative solution I'm fixing this test and add some comments in the check to give folks a clue as to why sizeof(StreamInfoImpl) may return different values and, consequently, how to change this test after changes to StreamInfoImpl.

I also noticed that the list of possible values for the size of StreamInfoImpl is way too long - we don't have that many different ABIs - and contains a duplicate, so I cleaned the list and reduced it to 3 values. One thing in mind, is that I didn't test it on ARM platforms - from all I know it should not make a difference, but it's something to keep in mind.

I will see in spare time if I can replace this test with something else that does not rely on a specific layout of the StreamInfoImpl structure.

Additional Description:
Risk Level: Low
Testing:

```
bazel test //test/common/stream_info:stream_info_impl_test --config=docker-clang
bazel test //test/common/stream_info:stream_info_impl_test --config=docker-msan
bazel test //test/common/stream_info:stream_info_impl_test --config=docker-clang-libc++
```

With  `-c opt` and `-c dbg` to make sure that optimization don't affect the ABI (which is expected, but just in case).

Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
Fixes commit #35650 

