### PR TITLE
Initialize rate_limit_quota token buckets with a partial fill

### DIFF
--- a/source/common/common/token_bucket_impl.cc
+++ b/source/common/common/token_bucket_impl.cc
@@ -60,11 +60,16 @@ void TokenBucketImpl::maybeReset(uint64_t num_tokens) {
 
 AtomicTokenBucketImpl::AtomicTokenBucketImpl(uint64_t max_tokens, TimeSource& time_source,
                                              double fill_rate, bool init_fill)
+    : AtomicTokenBucketImpl::AtomicTokenBucketImpl(max_tokens, time_source, fill_rate,
+                                                   (init_fill) ? max_tokens : 0) {}
+
+AtomicTokenBucketImpl::AtomicTokenBucketImpl(uint64_t max_tokens, TimeSource& time_source,
+                                             double fill_rate, uint64_t initial_tokens)
     : max_tokens_(max_tokens), fill_rate_(std::max(std::abs(fill_rate), kMinFillRate)),
       time_source_(time_source) {
   auto time_in_seconds = timeNowInSeconds();
-  if (init_fill) {
-    time_in_seconds -= max_tokens_ / fill_rate_;
+  if (initial_tokens) {
+    time_in_seconds -= initial_tokens / fill_rate_;
   }
   time_in_seconds_.store(time_in_seconds, std::memory_order_relaxed);
 }

--- a/source/common/common/token_bucket_impl.h
+++ b/source/common/common/token_bucket_impl.h
@@ -49,6 +49,8 @@ public:
    */
   explicit AtomicTokenBucketImpl(uint64_t max_tokens, TimeSource& time_source,
                                  double fill_rate = 1.0, bool init_fill = true);
+  explicit AtomicTokenBucketImpl(uint64_t max_tokens, TimeSource& time_source, double fill_rate,
+                                 uint64_t initial_tokens);
 
   // This reference https://github.com/facebook/folly/blob/main/folly/TokenBucket.h.
   template <class GetConsumedTokens> double consume(const GetConsumedTokens& cb) {

--- a/source/extensions/filters/http/rate_limit_quota/global_client_impl.cc
+++ b/source/extensions/filters/http/rate_limit_quota/global_client_impl.cc
@@ -234,7 +234,8 @@ bool protoTokenBucketsEq(const ::envoy::type::v3::TokenBucket& new_tb,
 }
 
 std::shared_ptr<AtomicTokenBucketImpl>
-createTokenBucketFromAction(const RateLimitStrategy& strategy, TimeSource& time_source) {
+createTokenBucketFromAction(const RateLimitStrategy& strategy, TimeSource& time_source,
+                            const AtomicTokenBucketImpl* existing_token_bucket) {
   const auto& token_bucket = strategy.token_bucket();
   const auto& interval_proto = token_bucket.fill_interval();
   // Convert absl::duration to int64_t seconds
@@ -243,8 +244,16 @@ createTokenBucketFromAction(const RateLimitStrategy& strategy, TimeSource& time_
   double fill_rate_per_sec =
       static_cast<double>(token_bucket.tokens_per_fill().value()) / fill_interval_sec;
 
-  return std::make_shared<AtomicTokenBucketImpl>(token_bucket.max_tokens(), time_source,
-                                                 fill_rate_per_sec);
+  uint64_t max_tokens = token_bucket.max_tokens();
+  // Start the new token bucket with the same ratio of remaining tokens to max
+  // tokens as the existing token bucket (best effort).
+  uint64_t initial_tokens = (existing_token_bucket)
+                                ? max_tokens * (existing_token_bucket->remainingTokens() /
+                                                existing_token_bucket->maxTokens())
+                                : max_tokens;
+
+  return std::make_shared<AtomicTokenBucketImpl>(max_tokens, time_source, fill_rate_per_sec,
+                                                 initial_tokens);
 }
 
 void GlobalRateLimitClientImpl::onReceiveMessage(RateLimitQuotaResponsePtr&& response) {
@@ -314,8 +323,8 @@ void GlobalRateLimitClientImpl::onQuotaResponseImpl(const RateLimitQuotaResponse
         // Only create a new TokenBucket if the configuration is new or
         // different from the cache.)
         if (shouldReplaceTokenBucket(cached_bucket.get(), rate_limit_strategy)) {
-          bucket->token_bucket_limiter =
-              createTokenBucketFromAction(rate_limit_strategy, time_source_);
+          bucket->token_bucket_limiter = createTokenBucketFromAction(
+              rate_limit_strategy, time_source_, cached_bucket->token_bucket_limiter.get());
           ENVOY_LOG(info,
                     "A new TokenBucket has been configured by the RLQS "
                     "filter for id: {}",
@@ -468,7 +477,8 @@ void GlobalRateLimitClientImpl::onActionExpirationTimer(CachedBucket* bucket, si
               "The cached token bucket at bucket id {} has been replaced by "
               "the configured fallback token bucket.",
               id);
-    new_token_bucket = createTokenBucketFromAction(fallback_action, time_source_);
+    new_token_bucket = createTokenBucketFromAction(fallback_action, time_source_,
+                                                   cached_bucket->token_bucket_limiter.get());
   } else if (fallback_action.has_token_bucket()) {
     ENVOY_LOG(debug,
               "The cached token bucket at bucket id {} is carrying over during "

--- a/test/extensions/filters/http/rate_limit_quota/integration_test.cc
+++ b/test/extensions/filters/http/rate_limit_quota/integration_test.cc
@@ -970,12 +970,13 @@ TEST_P(RateLimitQuotaIntegrationTest, MultiRequestWithTokenBucketThrottling) {
 }
 
 TEST_P(RateLimitQuotaIntegrationTest, MultiRequestWithTokenBucketExpiration) {
-  int max_token = 1;
-  int tokens_per_fill = 30;
-  int fill_interval_sec = 15;
-  int expiration_sec = 30; // > fill_interval_sec so TokenBuckets can refill
-                           // between test phases.
-  int expiration_max_token = 2;
+  int max_token = 3;
+  int tokens_per_fill = 1;
+  int fill_interval_sec = 30;
+  // Set expiration so existing TokenBucket will refill to 33%% between test
+  // phases.
+  int expiration_sec = 30;
+  int expiration_max_token = 6;
   int fallback_expiration_sec = 20;
 
   RateLimitStrategy fallback_strategy;
@@ -1028,11 +1029,15 @@ TEST_P(RateLimitQuotaIntegrationTest, MultiRequestWithTokenBucketExpiration) {
   rlqs_stream_->sendGrpcMessage(rlqs_response);
   absl::SleepFor(absl::Seconds(0.5));
 
-  // The second request should be allowed by the token bucket assignment.
+  // The 2nd, 3rd and 4th requests are allowed by the token bucket assignment.
+  sendClientRequest(&custom_headers);
+  ASSERT_TRUE(expectAllowedRequest());
+  sendClientRequest(&custom_headers);
+  ASSERT_TRUE(expectAllowedRequest());
   sendClientRequest(&custom_headers);
   ASSERT_TRUE(expectAllowedRequest());
 
-  // The third request should be denied by the token bucket assignment.
+  // The 5th request should be denied by the token bucket assignment.
   sendClientRequest(&custom_headers);
   ASSERT_TRUE(expectDeniedRequest(429));
 
@@ -1040,14 +1045,14 @@ TEST_P(RateLimitQuotaIntegrationTest, MultiRequestWithTokenBucketExpiration) {
   // expiration.
   simTime().advanceTimeWait(std::chrono::seconds(expiration_sec));
 
-  // The fourth and fifth requests should be allowed by the fallback
-  // TokenBucket.
+  // The 6th & 7th requests should be allowed by the fallback TokenBucket as it
+  // should initialize at 33% capacity.
   sendClientRequest(&custom_headers);
   ASSERT_TRUE(expectAllowedRequest());
   sendClientRequest(&custom_headers);
   ASSERT_TRUE(expectAllowedRequest());
 
-  // The sixth request should be denied by the fallback TokenBucket.
+  // The 8th request should be denied by the emptied, fallback TokenBucket.
   sendClientRequest(&custom_headers);
   ASSERT_TRUE(expectDeniedRequest(429));
 
@@ -1061,58 +1066,104 @@ TEST_P(RateLimitQuotaIntegrationTest, MultiRequestWithTokenBucketExpiration) {
   }
 }
 
-TEST_P(RateLimitQuotaIntegrationTest, MultiRequestWithTokenBucket) {
+TEST_P(RateLimitQuotaIntegrationTest, MultiRequestWithTokenBucketReplacement) {
   initializeConfig();
   HttpIntegrationTest::initialize();
   absl::flat_hash_map<std::string, std::string> custom_headers = {{"environment", "staging"},
                                                                   {"group", "envoy"}};
-  int max_token = 1;
-  int tokens_per_fill = 30;
-  int fill_interval_sec = 60;
-  int fill_one_token_in_ms = fill_interval_sec / tokens_per_fill * 1000;
-  for (int i = 0; i < 10; ++i) {
-    // We advance time by 2s so that token bucket can be refilled.
-    if (i == 4 || i == 6) {
-      simTime().advanceTimeAndRun(std::chrono::milliseconds(fill_one_token_in_ms), *dispatcher_,
-                                  Envoy::Event::Dispatcher::RunType::NonBlock);
-    }
-    // Send downstream client request to upstream.
-    sendClientRequest(&custom_headers);
+  int max_token = 2;
+  int tokens_per_fill = 1;
+  int fill_interval_sec = 1;
+  int replacement_max_token = 6;
+  int replacement_tokens_per_fill = 2;
+  int replacement_fill_interval_sec = 1;
 
-    // Only first downstream client request will trigger the reports to RLQS
-    // server as the subsequent requests will find the entry in the cache.
-    if (i == 0) {
-      // Start the gRPC stream to RLQS server.
-      ASSERT_TRUE(grpc_upstreams_[0]->waitForHttpConnection(*dispatcher_, rlqs_connection_));
-      ASSERT_TRUE(rlqs_connection_->waitForNewStream(*dispatcher_, rlqs_stream_));
+  // First request is allowed by the default-open & triggers bucket creation +
+  // initial usage reporting.
+  sendClientRequest(&custom_headers);
 
-      // Expect an initial report when the RLQS bucket is first hit.
-      RateLimitQuotaUsageReports reports;
-      ASSERT_TRUE(rlqs_stream_->waitForGrpcMessage(*dispatcher_, reports));
-      rlqs_stream_->startGrpcStream();
+  // Start the gRPC stream to RLQS server.
+  ASSERT_TRUE(grpc_upstreams_[0]->waitForHttpConnection(*dispatcher_, rlqs_connection_));
+  ASSERT_TRUE(rlqs_connection_->waitForNewStream(*dispatcher_, rlqs_stream_));
 
-      // Build the response.
-      RateLimitQuotaResponse rlqs_response;
-      absl::flat_hash_map<std::string, std::string> custom_headers_cpy = custom_headers;
-      custom_headers_cpy.insert({"name", "prod"});
-      auto* bucket_action = rlqs_response.add_bucket_action();
-      for (const auto& [key, value] : custom_headers_cpy) {
-        (*bucket_action->mutable_bucket_id()->mutable_bucket()).insert({key, value});
-        auto* quota_assignment = bucket_action->mutable_quota_assignment_action();
-        quota_assignment->mutable_assignment_time_to_live()->set_seconds(120);
-        auto* strategy = quota_assignment->mutable_rate_limit_strategy();
-        auto* token_bucket = strategy->mutable_token_bucket();
-        token_bucket->set_max_tokens(max_token);
-        token_bucket->mutable_tokens_per_fill()->set_value(30);
-        token_bucket->mutable_fill_interval()->set_seconds(60);
-      }
+  // Expect an initial report when the RLQS bucket is first hit.
+  RateLimitQuotaUsageReports reports;
+  ASSERT_TRUE(rlqs_stream_->waitForGrpcMessage(*dispatcher_, reports));
+  rlqs_stream_->startGrpcStream();
 
-      // Send the response from RLQS server.
-      rlqs_stream_->sendGrpcMessage(rlqs_response);
-    }
+  // Expect default allow-all for the first request.
+  ASSERT_TRUE(expectAllowedRequest());
 
-    cleanUp();
-  }
+  // Build the TokenBucket response.
+  RateLimitQuotaResponse rlqs_response;
+  auto* bucket_action = rlqs_response.add_bucket_action();
+  bucket_action->mutable_bucket_id()->mutable_bucket()->insert(
+      {{"name", "prod"}, {"environment", "staging"}, {"group", "envoy"}});
+  auto* quota_assignment = bucket_action->mutable_quota_assignment_action();
+  quota_assignment->mutable_assignment_time_to_live()->set_seconds(120);
+  auto* strategy = quota_assignment->mutable_rate_limit_strategy();
+  auto* token_bucket = strategy->mutable_token_bucket();
+  token_bucket->set_max_tokens(max_token);
+  token_bucket->mutable_tokens_per_fill()->set_value(tokens_per_fill);
+  token_bucket->mutable_fill_interval()->set_seconds(fill_interval_sec);
+
+  // Send the response from RLQS server.
+  rlqs_stream_->sendGrpcMessage(rlqs_response);
+  absl::SleepFor(absl::Seconds(0.5));
+
+  // Initial requests are allowed by the token bucket assignment.
+  sendClientRequest(&custom_headers);
+  ASSERT_TRUE(expectAllowedRequest());
+  sendClientRequest(&custom_headers);
+  ASSERT_TRUE(expectAllowedRequest());
+  // Until the bucket is empty, then requests are denied.
+  sendClientRequest(&custom_headers);
+  ASSERT_TRUE(expectDeniedRequest(429));
+
+  // Check that a single token fills after the fill interval.
+  simTime().advanceTimeWait(std::chrono::seconds(fill_interval_sec));
+  sendClientRequest(&custom_headers);
+  ASSERT_TRUE(expectAllowedRequest());
+  sendClientRequest(&custom_headers);
+  ASSERT_TRUE(expectDeniedRequest(429));
+
+  // Allow for a 50% refill of the TokenBucket again before replacing it.
+  simTime().advanceTimeWait(std::chrono::seconds(fill_interval_sec));
+
+  // Prep a response to replace the existing TokenBucket with a larger one.
+  RateLimitQuotaResponse replacement_rlqs_response(rlqs_response);
+  auto* replacement_token_bucket = replacement_rlqs_response.mutable_bucket_action(0)
+                                       ->mutable_quota_assignment_action()
+                                       ->mutable_rate_limit_strategy()
+                                       ->mutable_token_bucket();
+  replacement_token_bucket->set_max_tokens(replacement_max_token);
+  replacement_token_bucket->mutable_tokens_per_fill()->set_value(replacement_tokens_per_fill);
+  replacement_token_bucket->mutable_fill_interval()->set_seconds(replacement_fill_interval_sec);
+
+  // Send the response to update the TokenBucket.
+  rlqs_stream_->sendGrpcMessage(replacement_rlqs_response);
+  absl::SleepFor(absl::Seconds(0.5));
+
+  // Expect the new TokenBucket to initialize at 50% capacity, based on the
+  // existing TokenBucket.
+  sendClientRequest(&custom_headers);
+  ASSERT_TRUE(expectAllowedRequest());
+  sendClientRequest(&custom_headers);
+  ASSERT_TRUE(expectAllowedRequest());
+  sendClientRequest(&custom_headers);
+  ASSERT_TRUE(expectAllowedRequest());
+  // Empty after 50%, not max_tokens.
+  sendClientRequest(&custom_headers);
+  ASSERT_TRUE(expectDeniedRequest(429));
+
+  // Test new TokenBucket's refill rate.
+  simTime().advanceTimeWait(std::chrono::seconds(fill_interval_sec));
+  sendClientRequest(&custom_headers);
+  ASSERT_TRUE(expectAllowedRequest());
+  sendClientRequest(&custom_headers);
+  ASSERT_TRUE(expectAllowedRequest());
+  sendClientRequest(&custom_headers);
+  ASSERT_TRUE(expectDeniedRequest(429));
 }
 
 TEST_P(RateLimitQuotaIntegrationTest, MultiRequestWithUnsupportedStrategy) {


### PR DESCRIPTION
Commit Message: When replacing a token bucket with another in a rate_limit_quota filter's bucket cache, initialize the replacement in a partially filled state, based on the ratio of available and max tokens of the existing token bucket. 

Additional Description: This enables more frequent updates in RateLimitQuotaResponses when giving assignments for token buckets. Previously, updates to an assignment had a side effect of resetting the available tokens in the token bucket. This implementation doesn't perfectly account for asynchronous flows but is better than the current implementation.

Risk Level: Low - the AtomicTokenBucketImpl class isn't widely used yet & changes are minimal. The rate_limit_quota filter is still in development.
Testing: Integration testing
Docs Changes:
Release Notes:
Platform Specific Features:

