### PR TITLE
Patch rules_foreign_cc to not link bazel default libraries into GNUMake

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -985,9 +985,9 @@ def _rules_ruby():
 
 def _foreign_cc_dependencies():
     external_http_archive(
-    name = "rules_foreign_cc",
-    patches = ["@envoy//bazel:rules_foreign_cc.patch"],
-    patch_args = ["-p1"],
+        name = "rules_foreign_cc",
+        patches = ["@envoy//bazel:rules_foreign_cc.patch"],
+        patch_args = ["-p1"],
     )
 
 def _com_github_maxmind_libmaxminddb():

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -984,7 +984,11 @@ def _rules_ruby():
     external_http_archive("rules_ruby")
 
 def _foreign_cc_dependencies():
-    external_http_archive(name = "rules_foreign_cc")
+    external_http_archive(
+    name = "rules_foreign_cc",
+    patches = ["@envoy//bazel:rules_foreign_cc.patch"],
+    patch_args = ["-p1"],
+    )
 
 def _com_github_maxmind_libmaxminddb():
     external_http_archive(

--- a/bazel/rules_foreign_cc.patch
+++ b/bazel/rules_foreign_cc.patch
@@ -1,0 +1,12 @@
+diff --git a/foreign_cc/private/cc_toolchain_util.bzl b/foreign_cc/private/cc_toolchain_util.bzl
+index 9b33974..2287607 100644
+--- a/foreign_cc/private/cc_toolchain_util.bzl
++++ b/foreign_cc/private/cc_toolchain_util.bzl
+@@ -42,6 +42,7 @@ CxxFlagsInfo = provider(
+ # them here when configuring the toolchain flags to pass to the external
+ # build system.
+ FOREIGN_CC_DISABLED_FEATURES = [
++    "default_link_libs",
+     "fdo_instrument",
+     "fdo_optimize",
+     "layering_check",

--- a/bazel/rules_foreign_cc.patch
+++ b/bazel/rules_foreign_cc.patch
@@ -1,12 +1,14 @@
-diff --git a/foreign_cc/private/cc_toolchain_util.bzl b/foreign_cc/private/cc_toolchain_util.bzl
-index 9b33974..2287607 100644
---- a/foreign_cc/private/cc_toolchain_util.bzl
-+++ b/foreign_cc/private/cc_toolchain_util.bzl
-@@ -42,6 +42,7 @@ CxxFlagsInfo = provider(
- # them here when configuring the toolchain flags to pass to the external
- # build system.
- FOREIGN_CC_DISABLED_FEATURES = [
-+    "default_link_libs",
-     "fdo_instrument",
-     "fdo_optimize",
-     "layering_check",
+diff --git a/toolchains/private/BUILD.bazel b/toolchains/private/BUILD.bazel
+index 4ccdeef..25658e9 100644
+--- a/toolchains/private/BUILD.bazel
++++ b/toolchains/private/BUILD.bazel
+@@ -23,6 +23,9 @@ native_tool_toolchain(
+ make_tool(
+     name = "make_tool",
+     srcs = "@gnumake_src//:all_srcs",
++    features = [
++        "-default_link_libs",
++    ],
+     tags = ["manual"],
+ )
+ 


### PR DESCRIPTION
When upstream `rules_foreign_cc` builds its own GNUMake, it injects bazel's default libraries into `LDFLAGS`, which causes trouble on Darwin in newer versions of Bazel that added `-lm` to the list of default libraries.

As explained nicely in https://github.com/bazel-contrib/rules_foreign_cc/issues/1227, Apple's libm re-exports a bunch of symbols and, due to linker argument order, clobbers some symbols from make itself. We don't need any of the default libraries in GNUMake, so disable the feature to link them.

Risk Level: low
Testing: CI
