### PR TITLE
Revert "ext_proc: Ext proc half close on destroy and defer reset till trailers received.  (#37083)"

### DIFF
--- a/source/extensions/filters/http/ext_proc/client.h
+++ b/source/extensions/filters/http/ext_proc/client.h
@@ -23,13 +23,7 @@ public:
   virtual void send(envoy::service::ext_proc::v3::ProcessingRequest&& request,
                     bool end_stream) PURE;
   // Idempotent close. Return true if it actually closed.
-  // Sends a half-close from the client side.
-  // No further messages can be sent after this, but gRPC server may still send
-  // messages back.
-  virtual bool closeLocalStream() PURE;
-  virtual bool remoteClosed() const PURE;
-  virtual bool localClosed() const PURE;
-  virtual void resetStream() PURE;
+  virtual bool close() PURE;
   virtual const StreamInfo::StreamInfo& streamInfo() const PURE;
   virtual StreamInfo::StreamInfo& streamInfo() PURE;
   virtual void notifyFilterDestroy() PURE;

--- a/source/extensions/filters/http/ext_proc/client_impl.h
+++ b/source/extensions/filters/http/ext_proc/client_impl.h
@@ -56,7 +56,7 @@ public:
   void send(ProcessingRequest&& request, bool end_stream) override;
   // Close the stream. This is idempotent and will return true if we
   // actually closed it.
-  bool closeLocalStream() override;
+  bool close() override;
 
   void notifyFilterDestroy() override {
     // When the filter object is being destroyed,  `callbacks_` (which is a OptRef to filter object)
@@ -65,7 +65,7 @@ public:
 
     // Unregister the watermark callbacks(if any) to prevent access of filter callbacks after
     // the filter object is destroyed.
-    if (!local_closed_) {
+    if (!stream_closed_) {
       // Remove the parent stream info to avoid a dangling reference.
       stream_.streamInfo().clearParentStreamInfo();
       if (grpc_side_stream_flow_control_) {
@@ -74,22 +74,8 @@ public:
     }
   }
 
-  // Returns true if the stream is closed from the Server/remote side.
-  bool remoteClosed() const override { return remote_closed_; }
-
-  // Returns true if the stream is closed from the Envoy/client side.
-  bool localClosed() const override { return local_closed_; }
-
   // AsyncStreamCallbacks
   void onReceiveMessage(ProcessingResponsePtr&& message) override;
-
-  void resetStream() override {
-    if (!remoteClosed()) {
-      stream_.resetStream();
-      // Mark the stream as closed from the Server/remote side.
-      remote_closed_ = true;
-    }
-  }
 
   // RawAsyncStreamCallbacks
   void onCreateInitialMetadata(Http::RequestHeaderMap& metadata) override;
@@ -116,10 +102,7 @@ private:
   Grpc::AsyncClient<ProcessingRequest, ProcessingResponse> client_;
   Grpc::AsyncStream<ProcessingRequest> stream_;
   Http::AsyncClient::ParentContext grpc_context_;
-  // Whether stream is closed from Envoy/client side.
-  bool local_closed_ = false;
-  // Whether the stream is closed from the Server/remote side.
-  bool remote_closed_ = false;
+  bool stream_closed_ = false;
   // Boolean flag initiated by runtime flag.
   const bool grpc_side_stream_flow_control_;
 };

--- a/source/extensions/filters/http/ext_proc/ext_proc.cc
+++ b/source/extensions/filters/http/ext_proc/ext_proc.cc
@@ -424,37 +424,22 @@ void Filter::closeStream() {
   if (!config_->grpcService().has_value()) {
     return;
   }
-  // Stream not opened or already cleaned up.
-  if (stream_ == nullptr) {
-    ENVOY_LOG(debug, "Stream already closed or not opened yet.");
-    return;
-  }
 
-  if (!stream_->localClosed()) {
+  if (stream_) {
     ENVOY_LOG(debug, "Calling close on stream");
-    if (stream_->closeLocalStream()) {
+    if (stream_->close()) {
       stats_.streams_closed_.inc();
     }
-  }
-}
-
-void Filter::deferredResetStream() {
-  ENVOY_LOG(debug, "Calling deferred cleanup on stream");
-  if (stream_ == nullptr) {
-    ENVOY_LOG(debug, "Stream already reset or not opened yet.");
-    return;
-  }
-  config_->threadLocalStreamManager().deferredErase(stream_, filter_callbacks_->dispatcher());
-  stream_ = nullptr;
-}
-
-void Filter::cleanupStream() {
-  ENVOY_LOG(debug, "Calling cleanup stream");
-  if (stream_ != nullptr) {
-    stream_->resetStream();
     config_->threadLocalStreamManager().erase(stream_);
     stream_ = nullptr;
+  } else {
+    ENVOY_LOG(debug, "Stream already closed");
   }
+}
+
+void Filter::deferredCloseStream() {
+  ENVOY_LOG(debug, "Calling deferred close on stream");
+  config_->threadLocalStreamManager().deferredErase(stream_, filter_callbacks_->dispatcher());
 }
 
 void Filter::onDestroy() {
@@ -469,30 +454,23 @@ void Filter::onDestroy() {
     client_->cancel();
     return;
   }
-  if (stream_ != nullptr) {
-    if (!stream_->localClosed()) {
-      // Perform immediate close on the stream otherwise.
-      closeStream();
-    }
-    // Defer the resource cleanup if the remote is not closed (no trailers
-    // received).
-    // This means essentially not sending a reset to the server, which
-    // translates into a client CANCELED error on the server side.
-    if (config_->observabilityMode() || !stream_->remoteClosed()) {
-      // In observability mode where the main stream processing and side stream
-      // processing are asynchronous, it is possible that filter instance is
-      // destroyed before the side stream request arrives at ext_proc server. In
-      // order to prevent the data loss in this case, side stream resetting is
-      // deferred upon filter destruction with a timer.
 
-      // First, release the referenced filter resource.
+  if (config_->observabilityMode()) {
+    // In observability mode where the main stream processing and side stream processing are
+    // asynchronous, it is possible that filter instance is destroyed before the side stream request
+    // arrives at ext_proc server. In order to prevent the data loss in this case, side stream
+    // closure is deferred upon filter destruction with a timer.
+
+    // First, release the referenced filter resource.
+    if (stream_ != nullptr) {
       stream_->notifyFilterDestroy();
-      // Second, perform stream deferred closure.
-      deferredResetStream();
-    } else {
-      // Server closed the stream, so we can cleanup the stream immediately.
-      cleanupStream();
     }
+
+    // Second, perform stream deferred closure.
+    deferredCloseStream();
+  } else {
+    // Perform immediate close on the stream otherwise.
+    closeStream();
   }
 }
 
@@ -1354,7 +1332,6 @@ void Filter::onGrpcError(Grpc::Status::GrpcStatus status) {
     // make sure that they do not fire now.
     onFinishProcessorCalls(status);
     closeStream();
-    cleanupStream();
     ImmediateResponse errorResponse;
     errorResponse.mutable_status()->set_code(StatusCode::InternalServerError);
     errorResponse.set_details(absl::StrFormat("%s_gRPC_error_%i", ErrorPrefix, status));
@@ -1366,14 +1343,10 @@ void Filter::onGrpcClose() {
   ENVOY_LOG(debug, "Received gRPC stream close");
 
   processing_complete_ = true;
+  stats_.streams_closed_.inc();
   // Successful close. We can ignore the stream for the rest of our request
   // and response processing.
   closeStream();
-  // ExternalProcessorStreamImpl::onRemoteClose will call onGrpcClose in either
-  // happy path or error path.
-  // This will mark remote_closed_ as closed.
-  cleanupStream();
-
   clearAsyncState();
 }
 
@@ -1388,7 +1361,6 @@ void Filter::onMessageTimeout() {
     // the external processor for the rest of the request.
     processing_complete_ = true;
     closeStream();
-    cleanupStream();
     stats_.failure_mode_allowed_.inc();
     clearAsyncState();
 
@@ -1396,7 +1368,6 @@ void Filter::onMessageTimeout() {
     // Return an error and stop processing the current stream.
     processing_complete_ = true;
     closeStream();
-    cleanupStream();
     decoding_state_.onFinishProcessorCall(Grpc::Status::DeadlineExceeded);
     encoding_state_.onFinishProcessorCall(Grpc::Status::DeadlineExceeded);
     ImmediateResponse errorResponse;
@@ -1538,12 +1509,13 @@ void Filter::mergePerRouteConfig() {
   }
 }
 
-void DeferredDeletableStream::cleanupStreamOnTimer() {
+void DeferredDeletableStream::closeStreamOnTimer() {
   // Close the stream.
-  if (stream_ != nullptr) {
-    ENVOY_LOG(debug, "Resetting the stream.");
-    // After timeout if still no trailers received, reset the stream.
-    stream_->resetStream();
+  if (stream_) {
+    ENVOY_LOG(debug, "Closing the stream");
+    if (stream_->close()) {
+      stats.streams_closed_.inc();
+    }
     // Erase this entry from the map; this will also reset the stream_ pointer.
     parent.erase(stream_.get());
   } else {
@@ -1554,7 +1526,7 @@ void DeferredDeletableStream::cleanupStreamOnTimer() {
 // In the deferred closure mode, stream closure is deferred upon filter destruction, with a timer
 // to prevent unbounded resource usage growth.
 void DeferredDeletableStream::deferredClose(Envoy::Event::Dispatcher& dispatcher) {
-  derferred_close_timer = dispatcher.createTimer([this] { cleanupStreamOnTimer(); });
+  derferred_close_timer = dispatcher.createTimer([this] { closeStreamOnTimer(); });
   derferred_close_timer->enableTimer(std::chrono::milliseconds(deferred_close_timeout));
 }
 

--- a/test/extensions/filters/http/ext_proc/BUILD
+++ b/test/extensions/filters/http/ext_proc/BUILD
@@ -29,7 +29,7 @@ envoy_extension_cc_test(
 
 envoy_extension_cc_test(
     name = "filter_test",
-    size = "medium",
+    size = "small",
     srcs = ["filter_test.cc"],
     copts = select({
         "//bazel:windows_x86_64": [],

--- a/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
+++ b/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
@@ -638,16 +638,6 @@ protected:
 
     handleUpstreamRequest();
     verifyDownstreamResponse(*response, 200);
-    // Also verify that grpc-status sent via trailers are correctly propagated
-    // and recorded.
-    if (clientType() == Grpc::ClientType::EnvoyGrpc) {
-      const auto& ext_cluster =
-          test_server_->server().clusterManager().clusters().getCluster("ext_proc_server_0");
-      const auto& ext_server_host =
-          ext_cluster.value().get().prioritySet().hostSetsPerPriority()[0]->hosts()[0];
-      EXPECT_EQ(ext_server_host->stats().rq_success_.value(), 1);
-      EXPECT_EQ(ext_server_host->stats().rq_total_.value(), 1);
-    }
   }
 
   void testSendDyanmicMetadata() {

--- a/test/extensions/filters/http/ext_proc/filter_test.cc
+++ b/test/extensions/filters/http/ext_proc/filter_test.cc
@@ -163,30 +163,16 @@ protected:
     // This will fail if, at the end of the test, we left any timers enabled.
     // (This particular test suite does not actually let timers expire,
     // although other test suites do.)
-    EXPECT_TRUE(allNonDeferredCloseTimersAreDisabled());
+    EXPECT_TRUE(allTimersDisabled());
   }
 
-  // Since no trailers are sent, the last timer created by deferred close, is
-  // the only one that should be enabled.
-  bool allNonDeferredCloseTimersAreDisabled() {
-    if (timers_.empty()) {
-      return true;
-    }
-    // if trailers are seen, there is no deferred close timer.
-    bool has_deferred_close_timer = no_trailers_ ? true : false;
-    for (unsigned long i = 0; i + 1 < timers_.size() - 1; ++i) {
-      auto* t = timers_[i];
+  bool allTimersDisabled() {
+    for (auto* t : timers_) {
       if (t->enabled_) {
         return false;
       }
     }
-    // The last timer is the deferred close timer.
-    if (has_deferred_close_timer) {
-      // Last timer is not disabled.
-      return timers_[timers_.size() - 1]->enabled_;
-    } else {
-      return !(timers_[timers_.size() - 1]->enabled_);
-    }
+    return true;
   }
 
   ExternalProcessorStreamPtr doStart(ExternalProcessorCallbacks& callbacks,
@@ -205,6 +191,10 @@ protected:
     EXPECT_CALL(*stream, send(_, false)).WillRepeatedly(Invoke(this, &HttpFilterTest::doSend));
 
     EXPECT_CALL(*stream, streamInfo()).WillRepeatedly(ReturnRef(async_client_stream_info_));
+
+    // close is idempotent and only called once per filter
+    EXPECT_CALL(*stream, close()).WillOnce(Invoke(this, &HttpFilterTest::doSendClose));
+
     return stream;
   }
 
@@ -213,6 +203,8 @@ protected:
   };
 
   void doSend(ProcessingRequest&& request, Unused) { last_request_ = std::move(request); }
+
+  bool doSendClose() { return !server_closed_stream_; }
 
   void setUpDecodingBuffering(Buffer::Instance& buf, bool expect_modification = false) {
     EXPECT_CALL(decoder_callbacks_, decodingBuffer()).WillRepeatedly(Return(&buf));
@@ -642,6 +634,7 @@ protected:
   std::unique_ptr<MockClient> client_;
   ExternalProcessorCallbacks* stream_callbacks_ = nullptr;
   ProcessingRequest last_request_;
+  bool server_closed_stream_ = false;
   bool observability_mode_ = false;
   testing::NiceMock<Stats::MockIsolatedStatsStore> stats_store_;
   FilterConfigSharedPtr config_;
@@ -656,11 +649,6 @@ protected:
   TestResponseHeaderMapImpl response_headers_;
   TestRequestTrailerMapImpl request_trailers_;
   TestResponseTrailerMapImpl response_trailers_;
-  // If no trailers received, this means a non-clean close.
-  // Filter::onDestroy() will schedule a timer to
-  // cleanup the stream. This means the last timer will be active in most
-  // cases(timer out default is 5s).
-  bool no_trailers_ = true;
   std::vector<Event::MockTimer*> timers_;
   Event::MockTimer* deferred_close_timer_;
   Envoy::Event::SimulatedTimeSystem* test_time_;
@@ -1664,8 +1652,8 @@ TEST_F(HttpFilterTest, StreamingSendRequestDataGrpcFail) {
                            Unused, Unused,
                            std::function<void(ResponseHeaderMap & headers)> modify_headers, Unused,
                            Unused) { modify_headers(immediate_response_headers); }));
+  server_closed_stream_ = true;
   stream_callbacks_->onGrpcError(Grpc::Status::Internal);
-  no_trailers_ = false;
 
   // Sending another chunk of data. No more gRPC call.
   EXPECT_EQ(FilterDataStatus::Continue, filter_->decodeData(req_data, false));
@@ -1720,9 +1708,8 @@ TEST_F(HttpFilterTest, StreamingSendResponseDataGrpcFail) {
                            Unused, Unused,
                            std::function<void(ResponseHeaderMap & headers)> modify_headers, Unused,
                            Unused) { modify_headers(immediate_response_headers); }));
+  server_closed_stream_ = true;
   stream_callbacks_->onGrpcError(Grpc::Status::Internal);
-  no_trailers_ = false;
-
   // Sending 40 more chunks of data. No more gRPC calls.
   sendChunkRequestData(chunk_number * 2, false);
 
@@ -1770,8 +1757,8 @@ TEST_F(HttpFilterTest, GrpcFailOnRequestTrailer) {
                            Unused, Unused,
                            std::function<void(ResponseHeaderMap & headers)> modify_headers, Unused,
                            Unused) { modify_headers(immediate_response_headers); }));
+  server_closed_stream_ = true;
   stream_callbacks_->onGrpcError(Grpc::Status::Internal);
-  no_trailers_ = false;
 
   response_headers_.addCopy(LowerCaseString(":status"), "200");
   EXPECT_EQ(FilterHeadersStatus::Continue, filter_->encodeHeaders(response_headers_, true));
@@ -1780,7 +1767,7 @@ TEST_F(HttpFilterTest, GrpcFailOnRequestTrailer) {
   EXPECT_EQ(1, config_->stats().streams_started_.value());
   EXPECT_EQ(1, config_->stats().stream_msgs_sent_.value());
   EXPECT_EQ(0, config_->stats().stream_msgs_received_.value());
-  EXPECT_EQ(1, config_->stats().streams_closed_.value());
+  EXPECT_EQ(0, config_->stats().streams_closed_.value());
   EXPECT_EQ(1, config_->stats().streams_failed_.value());
 
   auto& grpc_calls_in = getGrpcCalls(envoy::config::core::v3::TrafficDirection::INBOUND);
@@ -2329,8 +2316,8 @@ TEST_F(HttpFilterTest, PostAndFail) {
                            Unused, Unused,
                            std::function<void(ResponseHeaderMap & headers)> modify_headers, Unused,
                            Unused) { modify_headers(immediate_response_headers); }));
+  server_closed_stream_ = true;
   stream_callbacks_->onGrpcError(Grpc::Status::Internal);
-  no_trailers_ = false;
 
   Buffer::OwnedImpl req_data("foo");
   EXPECT_EQ(FilterDataStatus::Continue, filter_->decodeData(req_data, true));
@@ -2381,8 +2368,8 @@ TEST_F(HttpFilterTest, PostAndFailOnResponse) {
                            Unused, Unused,
                            std::function<void(ResponseHeaderMap & headers)> modify_headers, Unused,
                            Unused) { modify_headers(immediate_response_headers); }));
+  server_closed_stream_ = true;
   stream_callbacks_->onGrpcError(Grpc::Status::Internal);
-  no_trailers_ = false;
 
   Buffer::OwnedImpl resp_data("bar");
   EXPECT_EQ(FilterDataStatus::Continue, filter_->encodeData(resp_data, false));
@@ -2421,8 +2408,8 @@ TEST_F(HttpFilterTest, PostAndIgnoreFailure) {
 
   // Oh no! The remote server had a failure which we will ignore
   EXPECT_CALL(decoder_callbacks_, continueDecoding());
+  server_closed_stream_ = true;
   stream_callbacks_->onGrpcError(Grpc::Status::Internal);
-  no_trailers_ = false;
 
   Buffer::OwnedImpl req_data("foo");
   EXPECT_EQ(FilterDataStatus::Continue, filter_->decodeData(req_data, true));
@@ -2461,8 +2448,8 @@ TEST_F(HttpFilterTest, PostAndClose) {
 
   // Close the stream, which should tell the filter to keep on going
   EXPECT_CALL(decoder_callbacks_, continueDecoding());
+  server_closed_stream_ = true;
   stream_callbacks_->onGrpcClose();
-  no_trailers_ = false;
 
   Buffer::OwnedImpl req_data("foo");
   EXPECT_EQ(FilterDataStatus::Continue, filter_->decodeData(req_data, true));
@@ -2497,13 +2484,12 @@ TEST_F(HttpFilterTest, PostAndDownstreamReset) {
 
   EXPECT_FALSE(last_request_.observability_mode());
   ASSERT_TRUE(last_request_.has_request_headers());
-  // Request header timer is enabled.
-  EXPECT_TRUE(std::any_of(timers_.begin(), timers_.end(),
-                          [](const auto& timer) { return timer->enabled_; }));
+  EXPECT_FALSE(allTimersDisabled());
+
   // Call onDestroy to mimic a downstream client reset.
   filter_->onDestroy();
 
-  EXPECT_TRUE(allNonDeferredCloseTimersAreDisabled());
+  EXPECT_TRUE(allTimersDisabled());
   EXPECT_EQ(1, config_->stats().streams_started_.value());
   EXPECT_EQ(1, config_->stats().stream_msgs_sent_.value());
   EXPECT_EQ(1, config_->stats().streams_closed_.value());
@@ -3449,7 +3435,6 @@ TEST_F(HttpFilterTest, IgnoreInvalidHeaderMutations) {
   EXPECT_THAT(&request_headers_, HeaderMapEqualIgnoreOrder(&expected));
 
   stream_callbacks_->onGrpcClose();
-  no_trailers_ = false;
   filter_->onDestroy();
 
   EXPECT_EQ(2, config_->stats().rejected_header_mutations_.value());
@@ -3489,7 +3474,6 @@ TEST_F(HttpFilterTest, FailOnInvalidHeaderMutations) {
   stream_callbacks_->onReceiveMessage(std::move(resp1));
   EXPECT_TRUE(immediate_response_headers.empty());
   stream_callbacks_->onGrpcClose();
-  no_trailers_ = false;
 
   filter_->onDestroy();
 }
@@ -4735,7 +4719,6 @@ TEST_F(HttpFilterTest, PostAndRespondImmediatelyUpstream) {
   EXPECT_EQ(config_->stats().stream_msgs_sent_.value(), 1);
   EXPECT_EQ(config_->stats().stream_msgs_received_.value(), 1);
   EXPECT_EQ(config_->stats().streams_closed_.value(), 1);
-  filter_->onDestroy();
 }
 
 TEST_F(HttpFilterTest, HeaderProcessingInObservabilityMode) {

--- a/test/extensions/filters/http/ext_proc/mock_server.cc
+++ b/test/extensions/filters/http/ext_proc/mock_server.cc
@@ -19,15 +19,7 @@ MockClient::MockClient() {
 }
 MockClient::~MockClient() = default;
 
-MockStream::MockStream() {
-  ON_CALL(*this, closeLocalStream()).WillByDefault(Invoke([this]() {
-    EXPECT_FALSE(local_closed_);
-    local_closed_ = true;
-    return local_closed_;
-  }));
-  ON_CALL(*this, remoteClosed()).WillByDefault(Invoke([this]() { return remote_closed_; }));
-  ON_CALL(*this, localClosed()).WillByDefault(Invoke([this]() { return local_closed_; }));
-}
+MockStream::MockStream() = default;
 MockStream::~MockStream() = default;
 
 } // namespace ExternalProcessing

--- a/test/extensions/filters/http/ext_proc/mock_server.h
+++ b/test/extensions/filters/http/ext_proc/mock_server.h
@@ -31,16 +31,10 @@ public:
   MockStream();
   ~MockStream() override;
   MOCK_METHOD(void, send, (envoy::service::ext_proc::v3::ProcessingRequest&&, bool));
-  MOCK_METHOD(bool, closeLocalStream, ());
+  MOCK_METHOD(bool, close, ());
   MOCK_METHOD(const StreamInfo::StreamInfo&, streamInfo, (), (const override));
   MOCK_METHOD(StreamInfo::StreamInfo&, streamInfo, ());
   MOCK_METHOD(void, notifyFilterDestroy, ());
-  MOCK_METHOD(bool, remoteClosed, (), (const override));
-  MOCK_METHOD(bool, localClosed, (), (const override));
-  MOCK_METHOD(void, resetStream, ());
-  // Whether close() has been called.
-  bool local_closed_ = false;
-  bool remote_closed_ = false;
 };
 
 } // namespace ExternalProcessing

--- a/test/extensions/filters/http/ext_proc/unit_test_fuzz/ext_proc_unit_test_fuzz.cc
+++ b/test/extensions/filters/http/ext_proc/unit_test_fuzz/ext_proc_unit_test_fuzz.cc
@@ -118,7 +118,7 @@ DEFINE_PROTO_FUZZER(
             }));
         EXPECT_CALL(*stream, streamInfo())
             .WillRepeatedly(ReturnRef(mocks.async_client_stream_info_));
-        EXPECT_CALL(*stream, closeLocalStream()).WillRepeatedly(Return(false));
+        EXPECT_CALL(*stream, close()).WillRepeatedly(Return(false));
         return stream;
       }));
 


### PR DESCRIPTION
Additional Description:
This PR is **suspected** of causing instability in prod. The cause is not yet fully diagnosed, but it is reverted as a safety measure.

Risk Level: Low
Testing: Unit tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
