### PR TITLE
Migrate from Add*() to Record*() set of methods

### DIFF
--- a/api/bazel/cc_proto_descriptor_library/testdata/text_format_transcoder_test.cc
+++ b/api/bazel/cc_proto_descriptor_library/testdata/text_format_transcoder_test.cc
@@ -33,8 +33,8 @@ public:
                                 bool ignore_warnings = false);
 
   // google::protobuf::io::ErrorCollector:
-  void AddError(int line, ColumnNumber column, const std::string& message) override;
-  void AddWarning(int line, ColumnNumber column, const std::string& message) override;
+  void RecordError(int line, int column, absl::string_view message) override;
+  void RecordWarning(int line, int column, absl::string_view message) override;
 
 private:
   std::string& error_text_;
@@ -47,16 +47,16 @@ StringErrorCollector::StringErrorCollector(std::string& error_text, bool one_ind
     : error_text_(error_text), index_offset_(one_indexing ? 1 : 0),
       ignore_warnings_(ignore_warnings) {}
 
-void StringErrorCollector::AddError(int line, ColumnNumber column, const std::string& message) {
+void StringErrorCollector::RecordError(int line, ColumnNumber column, absl::string_view message) {
   absl::SubstituteAndAppend(&error_text_, "$0($1): $2\n", line + index_offset_,
                             column + index_offset_, message);
 }
 
-void StringErrorCollector::AddWarning(int line, ColumnNumber column, const std::string& message) {
+void StringErrorCollector::RecordWarning(int line, ColumnNumber column, absl::string_view message) {
   if (ignore_warnings_) {
     return;
   }
-  AddError(line, column, message);
+  RecordError(line, column, message);
 }
 
 using ::testing::Eq;


### PR DESCRIPTION
- In Protobuf v22 `RecordWarning()` and `RecordError()` have been introduced and `AddWarning()` and `AddError()` deprecated
- In Protobuf v26 `AddWarning()` and `AddError()` have been removed