### PR TITLE
Align target names for opentelemetry-proto with BCR

### DIFF
--- a/api/bazel/external_proto_deps.bzl
+++ b/api/bazel/external_proto_deps.bzl
@@ -12,7 +12,7 @@ EXTERNAL_PROTO_IMPORT_BAZEL_DEP_MAP = {
     "google/api/expr/v1alpha1/checked.proto": "@com_google_googleapis//google/api/expr/v1alpha1:checked_proto",
     "google/api/expr/v1alpha1/syntax.proto": "@com_google_googleapis//google/api/expr/v1alpha1:syntax_proto",
     "io/prometheus/client/metrics.proto": "@prometheus_metrics_model//:client_model",
-    "opentelemetry/proto/common/v1/common.proto": "@opentelemetry_proto//:common",
+    "opentelemetry/proto/common/v1/common.proto": "@opentelemetry_proto//:common_proto",
 }
 
 # This maps from the Bazel proto_library target to the Go language binding target for external dependencies.
@@ -28,18 +28,24 @@ EXTERNAL_PROTO_GO_BAZEL_DEP_MAP = {
     #    go_googleapis in https://github.com/bazelbuild/rules_go/blob/master/go/dependencies.rst#overriding-dependencies
     "@com_google_googleapis//google/api/expr/v1alpha1:checked_proto": "@org_golang_google_genproto_googleapis_api//expr/v1alpha1",
     "@com_google_googleapis//google/api/expr/v1alpha1:syntax_proto": "@org_golang_google_genproto_googleapis_api//expr/v1alpha1",
-    "@opentelemetry_proto//:trace": "@opentelemetry_proto//:trace_go_proto",
-    "@opentelemetry_proto//:logs": "@opentelemetry_proto//:logs_go_proto",
-    "@opentelemetry_proto//:metrics": "@opentelemetry_proto//:metrics_go_proto",
-    "@opentelemetry_proto//:common": "@opentelemetry_proto//:common_go_proto",
+    "@opentelemetry_proto//:trace_proto": "@opentelemetry_proto//:trace_proto_go",
+    "@opentelemetry_proto//:trace_service_proto": "@opentelemetry_proto//:trace_service_grpc_go",
+    "@opentelemetry_proto//:logs_proto": "@opentelemetry_proto//:logs_proto_go",
+    "@opentelemetry_proto//:logs_service_proto": "@opentelemetry_proto//:logs_service_grpc_go",
+    "@opentelemetry_proto//:metrics_proto": "@opentelemetry_proto//:metrics_proto_go",
+    "@opentelemetry_proto//:metrics_service_proto": "@opentelemetry_proto//:metrics_service_grpc_go",
+    "@opentelemetry_proto//:common_proto": "@opentelemetry_proto//:common_proto_go",
 }
 
 # This maps from the Bazel proto_library target to the C++ language binding target for external dependencies.
 EXTERNAL_PROTO_CC_BAZEL_DEP_MAP = {
     "@com_google_googleapis//google/api/expr/v1alpha1:checked_proto": "@com_google_googleapis//google/api/expr/v1alpha1:checked_cc_proto",
     "@com_google_googleapis//google/api/expr/v1alpha1:syntax_proto": "@com_google_googleapis//google/api/expr/v1alpha1:syntax_cc_proto",
-    "@opentelemetry_proto//:trace": "@opentelemetry_proto//:trace_cc_proto",
-    "@opentelemetry_proto//:logs": "@opentelemetry_proto//:logs_cc_proto",
-    "@opentelemetry_proto//:metrics": "@opentelemetry_proto//:metrics_cc_proto",
-    "@opentelemetry_proto//:common": "@opentelemetry_proto//:common_cc_proto",
+    "@opentelemetry_proto//:trace_proto": "@opentelemetry_proto//:trace_proto_cc",
+    "@opentelemetry_proto//:trace_service_proto": "@opentelemetry_proto//:trace_service_grpc_cc",
+    "@opentelemetry_proto//:logs_proto": "@opentelemetry_proto//:logs_proto_cc",
+    "@opentelemetry_proto//:logs_service_proto": "@opentelemetry_proto//:logs_service_grpc_cc",
+    "@opentelemetry_proto//:metrics_proto": "@opentelemetry_proto//:metrics_proto_cc",
+    "@opentelemetry_proto//:metrics_service_proto": "@opentelemetry_proto//:metrics_service_grpc_cc",
+    "@opentelemetry_proto//:common_proto": "@opentelemetry_proto//:common_proto_cc",
 }

--- a/api/bazel/repositories.bzl
+++ b/api/bazel/repositories.bzl
@@ -103,89 +103,288 @@ go_proto_library(
 )
 """
 
+# Aligned target names with https://github.com/bazelbuild/bazel-central-registry/tree/main/modules/opentelemetry-proto
 OPENTELEMETRY_BUILD_CONTENT = """
-load("@envoy_api//bazel:api_build_system.bzl", "api_cc_py_proto_library")
-load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+load("@com_github_grpc_grpc//bazel:cc_grpc_library.bzl", "cc_grpc_library")
+load("@com_github_grpc_grpc//bazel:python_rules.bzl", "py_proto_library", "py_grpc_library")
+load("@com_google_protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library", "go_grpc_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
-api_cc_py_proto_library(
-    name = "common",
+package(default_visibility = ["//visibility:public"])
+
+proto_library(
+    name = "common_proto",
     srcs = [
         "opentelemetry/proto/common/v1/common.proto",
     ],
-    visibility = ["//visibility:public"],
 )
 
-api_cc_py_proto_library(
-    name = "resource",
+cc_proto_library(
+    name = "common_proto_cc",
+    deps = [":common_proto"],
+)
+
+py_proto_library(
+    name = "common_proto_py",
+    deps = [":common_proto"],
+)
+
+go_proto_library(
+    name = "common_proto_go",
+    importpath = "go.opentelemetry.io/proto/otlp/common/v1",
+    protos = [":common_proto"],
+)
+
+proto_library(
+    name = "logs_proto",
+    srcs = [
+        "opentelemetry/proto/logs/v1/logs.proto",
+    ],
+    deps = [
+        ":common_proto",
+        ":resource_proto",
+    ],
+)
+
+cc_proto_library(
+    name = "logs_proto_cc",
+    deps = [":logs_proto"],
+)
+
+py_proto_library(
+    name = "logs_proto_py",
+    deps = [":logs_proto"],
+)
+
+go_proto_library(
+    name = "logs_proto_go",
+    importpath = "go.opentelemetry.io/proto/otlp/logs/v1",
+    protos = [":logs_proto"],
+    deps = [
+        ":common_proto_go",
+        ":resource_proto_go",
+    ],
+)
+
+proto_library(
+    name = "logs_service_proto",
+    srcs = [
+        "opentelemetry/proto/collector/logs/v1/logs_service.proto",
+    ],
+    deps = [
+        ":logs_proto",
+    ],
+)
+
+cc_proto_library(
+    name = "logs_service_proto_cc",
+    deps = [":logs_service_proto"],
+)
+
+cc_grpc_library(
+    name = "logs_service_grpc_cc",
+    srcs = [":logs_service_proto"],
+    generate_mocks = True,
+    grpc_only = True,
+    deps = [":logs_service_proto_cc"],
+)
+
+py_proto_library(
+    name = "logs_service_proto_py",
+    deps = [":logs_service_proto"],
+)
+
+py_grpc_library(
+    name = "logs_service_grpc_py",
+    srcs = [":logs_service_proto"],
+    deps = [":logs_service_proto_py"],
+)
+
+go_grpc_library(
+    name = "logs_service_grpc_go",
+    protos = [":logs_service_proto"],
+    importpath = "go.opentelemetry.io/proto/otlp/logs/v1",
+    embed = [
+        ":logs_proto_go",
+    ],
+)
+
+proto_library(
+    name = "metrics_proto",
+    srcs = [
+        "opentelemetry/proto/metrics/v1/metrics.proto",
+    ],
+    deps = [
+        ":common_proto",
+        ":resource_proto",
+    ],
+)
+
+cc_proto_library(
+    name = "metrics_proto_cc",
+    deps = [":metrics_proto"],
+)
+
+py_proto_library(
+    name = "metrics_proto_py",
+    deps = [":metrics_proto"],
+)
+
+go_proto_library(
+    name = "metrics_proto_go",
+    importpath = "go.opentelemetry.io/proto/otlp/metrics/v1",
+    protos = [":metrics_proto"],
+    deps = [
+        ":common_proto_go",
+        ":resource_proto_go",
+    ],
+)
+
+proto_library(
+    name = "metrics_service_proto",
+    srcs = [
+        "opentelemetry/proto/collector/metrics/v1/metrics_service.proto",
+    ],
+    deps = [
+        ":metrics_proto",
+    ],
+)
+
+cc_proto_library(
+    name = "metrics_service_proto_cc",
+    deps = [":metrics_service_proto"],
+)
+
+cc_grpc_library(
+    name = "metrics_service_grpc_cc",
+    srcs = [":metrics_service_proto"],
+    generate_mocks = True,
+    grpc_only = True,
+    deps = [":metrics_service_proto_cc"],
+)
+
+py_proto_library(
+    name = "metrics_service_proto_py",
+    deps = [":metrics_service_proto"],
+)
+
+py_grpc_library(
+    name = "metrics_service_grpc_py",
+    srcs = [":metrics_service_proto"],
+    deps = [":metrics_service_proto_py"],
+)
+
+go_grpc_library(
+    name = "metrics_service_grpc_go",
+    protos = [":metrics_service_proto"],
+    importpath = "go.opentelemetry.io/proto/otlp/metrics/v1",
+    embed = [
+        ":metrics_proto_go",
+    ],
+)
+
+proto_library(
+    name = "resource_proto",
     srcs = [
         "opentelemetry/proto/resource/v1/resource.proto",
     ],
     deps = [
-        "//:common",
+        ":common_proto",
     ],
-    visibility = ["//visibility:public"],
+)
+
+cc_proto_library(
+    name = "resource_proto_cc",
+    deps = [":resource_proto"],
+)
+
+py_proto_library(
+    name = "resource_proto_py",
+    deps = [":resource_proto"],
 )
 
 go_proto_library(
-    name = "common_go_proto",
-    importpath = "go.opentelemetry.io/proto/otlp/common/v1",
-    proto = ":common",
-    visibility = ["//visibility:public"],
-)
-
-# TODO(snowp): Generating one Go package from all of these protos could cause problems in the future,
-# but nothing references symbols from collector or resource so we're fine for now.
-api_cc_py_proto_library(
-    name = "logs",
-    srcs = [
-        "opentelemetry/proto/collector/logs/v1/logs_service.proto",
-        "opentelemetry/proto/logs/v1/logs.proto",
-    ],
+    name = "resource_proto_go",
+    importpath = "go.opentelemetry.io/proto/otlp/resource/v1",
+    protos = [":resource_proto"],
     deps = [
-        "//:common",
-        "//:resource",
+        ":common_proto_go",
     ],
-    visibility = ["//visibility:public"],
 )
 
-go_proto_library(
-    name = "logs_go_proto",
-    importpath = "go.opentelemetry.io/proto/otlp/logs/v1",
-    proto = ":logs",
-    visibility = ["//visibility:public"],
-)
-
-api_cc_py_proto_library(
-    name = "metrics",
+proto_library(
+    name = "trace_proto",
     srcs = [
-        "opentelemetry/proto/collector/metrics/v1/metrics_service.proto",
-        "opentelemetry/proto/metrics/v1/metrics.proto",
-    ],
-    deps = [
-        "//:common",
-        "//:resource",
-    ],
-    visibility = ["//visibility:public"],
-)
-
-go_proto_library(
-    name = "metrics_go_proto",
-    importpath = "go.opentelemetry.io/proto/otlp/metrics/v1",
-    proto = ":metrics",
-    visibility = ["//visibility:public"],
-)
-
-api_cc_py_proto_library(
-    name = "trace",
-    srcs = [
-        "opentelemetry/proto/collector/trace/v1/trace_service.proto",
         "opentelemetry/proto/trace/v1/trace.proto",
     ],
     deps = [
-        "//:common",
-        "//:resource",
+        ":common_proto",
+        ":resource_proto",
     ],
-    visibility = ["//visibility:public"],
+)
+
+cc_proto_library(
+    name = "trace_proto_cc",
+    deps = [":trace_proto"],
+)
+
+py_proto_library(
+    name = "trace_proto_py",
+    deps = [":trace_proto"],
+)
+
+go_proto_library(
+    name = "trace_proto_go",
+    importpath = "go.opentelemetry.io/proto/otlp/trace/v1",
+    protos = [":trace_proto"],
+    deps = [
+        ":common_proto_go",
+        ":resource_proto_go",
+    ],
+)
+
+proto_library(
+    name = "trace_service_proto",
+    srcs = [
+        "opentelemetry/proto/collector/trace/v1/trace_service.proto",
+    ],
+    deps = [
+        ":trace_proto",
+    ],
+)
+
+cc_proto_library(
+    name = "trace_service_proto_cc",
+    deps = [":trace_service_proto"],
+)
+
+cc_grpc_library(
+    name = "trace_service_grpc_cc",
+    srcs = [":trace_service_proto"],
+    generate_mocks = True,
+    grpc_only = True,
+    deps = [":trace_service_proto_cc"],
+)
+
+py_proto_library(
+    name = "trace_service_proto_py",
+    deps = [":trace_service_proto"],
+)
+
+py_grpc_library(
+    name = "trace_service_grpc_py",
+    srcs = [":trace_service_proto"],
+    deps = [":trace_service_proto_py"],
+)
+
+go_grpc_library(
+    name = "trace_service_grpc_go",
+    protos = [":trace_service_proto"],
+    importpath = "go.opentelemetry.io/proto/otlp/trace/v1",
+    embed = [
+        ":trace_proto_go",
+    ],
 )
 """
 

--- a/api/envoy/extensions/access_loggers/open_telemetry/v3/BUILD
+++ b/api/envoy/extensions/access_loggers/open_telemetry/v3/BUILD
@@ -9,6 +9,6 @@ api_proto_package(
         "//envoy/config/core/v3:pkg",
         "//envoy/extensions/access_loggers/grpc/v3:pkg",
         "@com_github_cncf_xds//udpa/annotations:pkg",
-        "@opentelemetry_proto//:common",
+        "@opentelemetry_proto//:common_proto",
     ],
 )

--- a/source/extensions/access_loggers/open_telemetry/BUILD
+++ b/source/extensions/access_loggers/open_telemetry/BUILD
@@ -25,7 +25,8 @@ envoy_cc_library(
         "//source/extensions/access_loggers/common:grpc_access_logger_clients_lib",
         "@envoy_api//envoy/extensions/access_loggers/grpc/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/access_loggers/open_telemetry/v3:pkg_cc_proto",
-        "@opentelemetry_proto//:logs_cc_proto",
+        "@opentelemetry_proto//:logs_proto_cc",
+        "@opentelemetry_proto//:logs_service_proto_cc",
     ],
 )
 
@@ -44,7 +45,8 @@ envoy_cc_library(
         "@envoy_api//envoy/data/accesslog/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/access_loggers/grpc/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/access_loggers/open_telemetry/v3:pkg_cc_proto",
-        "@opentelemetry_proto//:logs_cc_proto",
+        "@opentelemetry_proto//:logs_proto_cc",
+        "@opentelemetry_proto//:logs_service_proto_cc",
     ],
 )
 
@@ -83,6 +85,6 @@ envoy_cc_library(
         "//source/common/common:assert_lib",
         "//source/common/formatter:substitution_formatter_lib",
         "@com_google_absl//absl/strings:str_format",
-        "@opentelemetry_proto//:common_cc_proto",
+        "@opentelemetry_proto//:common_proto_cc",
     ],
 )

--- a/source/extensions/stat_sinks/open_telemetry/BUILD
+++ b/source/extensions/stat_sinks/open_telemetry/BUILD
@@ -18,7 +18,8 @@ envoy_cc_library(
         "//envoy/singleton:instance_interface",
         "//source/common/grpc:async_client_lib",
         "@envoy_api//envoy/extensions/stat_sinks/open_telemetry/v3:pkg_cc_proto",
-        "@opentelemetry_proto//:metrics_cc_proto",
+        "@opentelemetry_proto//:metrics_proto_cc",
+        "@opentelemetry_proto//:metrics_service_proto_cc",
     ],
 )
 

--- a/source/extensions/tracers/opentelemetry/BUILD
+++ b/source/extensions/tracers/opentelemetry/BUILD
@@ -50,7 +50,8 @@ envoy_cc_library(
         "//source/extensions/tracers/opentelemetry/samplers:sampler_lib",
         "@envoy_api//envoy/config/trace/v3:pkg_cc_proto",
         "@io_opentelemetry_cpp//api",
-        "@opentelemetry_proto//:trace_cc_proto",
+        "@opentelemetry_proto//:trace_proto_cc",
+        "@opentelemetry_proto//:trace_service_proto_cc",
     ],
 )
 
@@ -80,6 +81,7 @@ envoy_cc_library(
         "//source/common/version:version_lib",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
         "@io_opentelemetry_cpp//api",
-        "@opentelemetry_proto//:trace_cc_proto",
+        "@opentelemetry_proto//:trace_proto_cc",
+        "@opentelemetry_proto//:trace_service_proto_cc",
     ],
 )

--- a/source/extensions/tracers/opentelemetry/samplers/BUILD
+++ b/source/extensions/tracers/opentelemetry/samplers/BUILD
@@ -20,6 +20,6 @@ envoy_cc_library(
         "//envoy/server:tracer_config_interface",
         "//source/common/common:logger_lib",
         "//source/common/config:utility_lib",
-        "@opentelemetry_proto//:trace_cc_proto",
+        "@opentelemetry_proto//:trace_proto_cc",
     ],
 )

--- a/test/extensions/access_loggers/open_telemetry/BUILD
+++ b/test/extensions/access_loggers/open_telemetry/BUILD
@@ -28,7 +28,8 @@ envoy_extension_cc_test(
         "//test/mocks/thread_local:thread_local_mocks",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/access_loggers/grpc/v3:pkg_cc_proto",
-        "@opentelemetry_proto//:logs_cc_proto",
+        "@opentelemetry_proto//:logs_proto_cc",
+        "@opentelemetry_proto//:logs_service_proto_cc",
     ],
 )
 
@@ -53,7 +54,8 @@ envoy_extension_cc_test(
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
         "@envoy_api//envoy/data/accesslog/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/access_loggers/grpc/v3:pkg_cc_proto",
-        "@opentelemetry_proto//:logs_cc_proto",
+        "@opentelemetry_proto//:logs_proto_cc",
+        "@opentelemetry_proto//:logs_service_proto_cc",
     ],
 )
 
@@ -91,7 +93,8 @@ envoy_extension_cc_test(
         "@envoy_api//envoy/extensions/access_loggers/grpc/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/access_loggers/open_telemetry/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/filters/network/http_connection_manager/v3:pkg_cc_proto",
-        "@opentelemetry_proto//:logs_cc_proto",
+        "@opentelemetry_proto//:logs_proto_cc",
+        "@opentelemetry_proto//:logs_service_proto_cc",
     ],
 )
 
@@ -121,7 +124,7 @@ envoy_extension_cc_test(
         "//test/mocks/stream_info:stream_info_mocks",
         "//test/mocks/upstream:cluster_info_mocks",
         "//test/test_common:utility_lib",
-        "@opentelemetry_proto//:logs_cc_proto",
+        "@opentelemetry_proto//:logs_proto_cc",
     ] + select(
         {
             "//bazel:windows_x86_64": [],
@@ -144,7 +147,7 @@ envoy_cc_benchmark_binary(
         "//test/common/stream_info:test_util",
         "//test/mocks/stream_info:stream_info_mocks",
         "@com_github_google_benchmark//:benchmark",
-        "@opentelemetry_proto//:common_cc_proto",
+        "@opentelemetry_proto//:common_proto_cc",
     ],
 )
 


### PR DESCRIPTION
Align target names for opentelemetry-proto with [Bazel Central Registry](https://github.com/bazelbuild/bazel-central-registry/tree/main/modules/opentelemetry-proto).

This is a requirement for compatibility with Bzlmod.