### PR TITLE
Implement ScopeTrackedObjectStack::trackedStream()

### DIFF
--- a/source/common/common/scope_tracked_object_stack.h
+++ b/source/common/common/scope_tracked_object_stack.h
@@ -23,6 +23,16 @@ public:
 
   void add(const ScopeTrackedObject& object) { tracked_objects_.push_back(object); }
 
+  OptRef<const StreamInfo::StreamInfo> trackedStream() const override {
+    for (auto iter = tracked_objects_.rbegin(); iter != tracked_objects_.rend(); ++iter) {
+      OptRef<const StreamInfo::StreamInfo> stream = iter->get().trackedStream();
+      if (stream.has_value()) {
+        return stream;
+      }
+    }
+    return {};
+  }
+
   void dumpState(std::ostream& os, int indent_level) const override {
     for (auto iter = tracked_objects_.rbegin(); iter != tracked_objects_.rend(); ++iter) {
       iter->get().dumpState(os, indent_level);

--- a/test/common/common/BUILD
+++ b/test/common/common/BUILD
@@ -558,6 +558,7 @@ envoy_cc_test(
     deps = [
         "//source/common/common:scope_tracked_object_stack",
         "//source/common/common:utility_lib",
+        "//test/mocks/stream_info:stream_info_mocks",
     ],
 )
 

--- a/test/common/common/scope_tracked_object_stack_test.cc
+++ b/test/common/common/scope_tracked_object_stack_test.cc
@@ -5,6 +5,7 @@
 #include "source/common/common/scope_tracked_object_stack.h"
 #include "source/common/common/utility.h"
 
+#include "test/mocks/stream_info/mocks.h"
 #include "test/test_common/utility.h"
 
 #include "gtest/gtest.h"
@@ -24,6 +25,19 @@ TEST(OpaqueScopeTrackedObjectTest, ShouldDumpTrackedObjectsInFILO) {
   encapsulated_object.dumpState(ostream, 0);
 
   EXPECT_EQ(ostream.contents(), "secondfirst");
+}
+
+TEST(OpaqueScopeTrackedObjectTest, ReturnTrackedStreamInFILO) {
+  StreamInfo::MockStreamInfo first_stream_info;
+  StreamInfo::MockStreamInfo second_stream_info;
+  MessageTrackedObject first{"first", first_stream_info};
+  MessageTrackedObject second{"second", second_stream_info};
+
+  ScopeTrackedObjectStack encapsulated_object;
+  encapsulated_object.add(first);
+  encapsulated_object.add(second);
+
+  EXPECT_EQ(encapsulated_object.trackedStream().ptr(), &second_stream_info);
 }
 
 } // namespace

--- a/test/test_common/utility.h
+++ b/test/test_common/utility.h
@@ -1218,10 +1218,16 @@ ApiPtr createApiForTest(Stats::Store& stat_store, Event::TimeSystem& time_system
 class MessageTrackedObject : public ScopeTrackedObject {
 public:
   MessageTrackedObject(absl::string_view sv) : sv_(sv) {}
+  MessageTrackedObject(absl::string_view sv, const StreamInfo::StreamInfo& tracked_stream)
+      : sv_(sv), tracked_stream_(tracked_stream) {}
+
+  OptRef<const StreamInfo::StreamInfo> trackedStream() const override { return tracked_stream_; }
+
   void dumpState(std::ostream& os, int /*indent_level*/) const override { os << sv_; }
 
 private:
   absl::string_view sv_;
+  OptRef<const StreamInfo::StreamInfo> tracked_stream_;
 };
 
 MATCHER_P(HeaderMapEqualIgnoreOrder, expected, "") {


### PR DESCRIPTION
Implement ScopeTrackedObjectStack::trackedStream() to return tracked streaminfo in reverse order.

Commit Message: Implement ScopeTrackedObjectStack::trackedStream() to return tracked streaminfo in reverse order.
Additional Description:
Risk Level: None
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
