### PR TITLE
ext_proc: generalize ext proc mock client for http service configs

### DIFF
--- a/test/extensions/filters/http/ext_proc/mock_server.cc
+++ b/test/extensions/filters/http/ext_proc/mock_server.cc
@@ -13,8 +13,10 @@ MockClient::MockClient() {
       .WillRepeatedly(
           Invoke([](envoy::service::ext_proc::v3::ProcessingRequest&& request, bool end_stream,
                     const uint64_t, RequestCallbacks*, StreamBase* stream) {
-            ExternalProcessorStream* grpc_stream = dynamic_cast<ExternalProcessorStream*>(stream);
-            grpc_stream->send(std::move(request), end_stream);
+            if (stream != nullptr) {
+              ExternalProcessorStream* grpc_stream = dynamic_cast<ExternalProcessorStream*>(stream);
+              grpc_stream->send(std::move(request), end_stream);
+            }
           }));
 }
 MockClient::~MockClient() = default;

--- a/test/extensions/filters/http/ext_proc/unit_test_fuzz/ext_proc_corpus/http_client
+++ b/test/extensions/filters/http/ext_proc/unit_test_fuzz/ext_proc_corpus/http_client
@@ -1,0 +1,12 @@
+config {
+  allow_mode_override: true
+  http_service {
+  }
+  send_body_without_waiting_for_header_response: true
+}
+request {
+}
+response {
+  request_body {
+  }
+}


### PR DESCRIPTION
Commit Message: generalize ext proc mock client for http service configs
Additional Description:

There's a fuzz bug caused by an http service being configured in the ext_proc filter.  This is because the mock client currently dereferences the stream parameter since it was written assuming the ext_proc was a grpc service. With the introduction of http services, the mock client can no longer blindly dereference the stream.

Risk Level: none
Testing: fixing fuzz test
Docs Changes: none
Release Notes: none
Platform Specific Features: none