### PR TITLE
Fix OTel GRPC trace exporter dropping spans

### DIFF
--- a/source/extensions/tracers/opentelemetry/grpc_trace_exporter.cc
+++ b/source/extensions/tracers/opentelemetry/grpc_trace_exporter.cc
@@ -20,7 +20,7 @@ void OpenTelemetryGrpcTraceExporter::onCreateInitialMetadata(Http::RequestHeader
 }
 
 void OpenTelemetryGrpcTraceExporter::onSuccess(
-    Grpc::ResponsePtr<ExportTraceServiceResponse>&& response, Tracing::Span& _) {
+    Grpc::ResponsePtr<ExportTraceServiceResponse>&& response, Tracing::Span&) {
   if (response->has_partial_success()) {
     auto msg = response->partial_success().error_message();
     auto rejected_spans = response->partial_success().rejected_spans();
@@ -34,7 +34,7 @@ void OpenTelemetryGrpcTraceExporter::onSuccess(
 }
 
 void OpenTelemetryGrpcTraceExporter::onFailure(Grpc::Status::GrpcStatus status,
-                                               const std::string& message, Tracing::Span& _) {
+                                               const std::string& message, Tracing::Span&) {
   ENVOY_LOG(error, "OTLP trace export failed with status: {}, message: {}",
             Grpc::Utility::grpcStatusToString(status), message);
 }

--- a/source/extensions/tracers/opentelemetry/grpc_trace_exporter.cc
+++ b/source/extensions/tracers/opentelemetry/grpc_trace_exporter.cc
@@ -1,6 +1,8 @@
 #include "source/extensions/tracers/opentelemetry/grpc_trace_exporter.h"
 
+#include "otlp_utils.h"
 #include "source/common/common/logger.h"
+#include "source/common/grpc/status.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -9,11 +11,38 @@ namespace OpenTelemetry {
 
 OpenTelemetryGrpcTraceExporter::OpenTelemetryGrpcTraceExporter(
     const Grpc::RawAsyncClientSharedPtr& client)
-    : client_(client, *Protobuf::DescriptorPool::generated_pool()->FindMethodByName(
-                          "opentelemetry.proto.collector.trace.v1.TraceService.Export")) {}
+    : client_(client),
+      service_method_(*Protobuf::DescriptorPool::generated_pool()->FindMethodByName(
+          "opentelemetry.proto.collector.trace.v1.TraceService.Export")) {}
+
+void OpenTelemetryGrpcTraceExporter::onCreateInitialMetadata(Http::RequestHeaderMap& metadata) {
+  metadata.setReferenceUserAgent(OtlpUtils::getOtlpUserAgentHeader());
+}
+
+void OpenTelemetryGrpcTraceExporter::onSuccess(
+    Grpc::ResponsePtr<ExportTraceServiceResponse>&& response, Tracing::Span& _) {
+  if (response->has_partial_success()) {
+    auto msg = response->partial_success().error_message();
+    auto rejected_spans = response->partial_success().rejected_spans();
+    if (rejected_spans > 0 || !msg.empty()) {
+      if (msg.empty()) {
+        msg = "empty message";
+      }
+      ENVOY_LOG(warn, "OTLP partial success: {} ({} spans rejected)", msg, rejected_spans);
+    }
+  }
+}
+
+void OpenTelemetryGrpcTraceExporter::onFailure(Grpc::Status::GrpcStatus status,
+                                               const std::string& message, Tracing::Span& _) {
+  ENVOY_LOG(error, "OTLP trace export failed with status: {}, message: {}",
+            Grpc::Utility::grpcStatusToString(status), message);
+}
 
 bool OpenTelemetryGrpcTraceExporter::log(const ExportTraceServiceRequest& request) {
-  return client_.log(request);
+  client_->send(service_method_, request, *this, Tracing::NullSpan::instance(),
+                Http::AsyncClient::RequestOptions());
+  return true;
 }
 
 } // namespace OpenTelemetry

--- a/source/extensions/tracers/opentelemetry/grpc_trace_exporter.cc
+++ b/source/extensions/tracers/opentelemetry/grpc_trace_exporter.cc
@@ -29,14 +29,14 @@ void OpenTelemetryGrpcTraceExporter::onSuccess(
       if (msg.empty()) {
         msg = "empty message";
       }
-      ENVOY_LOG(warn, "OTLP partial success: {} ({} spans rejected)", msg, rejected_spans);
+      ENVOY_LOG(debug, "OTLP partial success: {} ({} spans rejected)", msg, rejected_spans);
     }
   }
 }
 
 void OpenTelemetryGrpcTraceExporter::onFailure(Grpc::Status::GrpcStatus status,
                                                const std::string& message, Tracing::Span&) {
-  ENVOY_LOG(error, "OTLP trace export failed with status: {}, message: {}",
+  ENVOY_LOG(debug, "OTLP trace export failed with status: {}, message: {}",
             Grpc::Utility::grpcStatusToString(status), message);
 }
 

--- a/source/extensions/tracers/opentelemetry/grpc_trace_exporter.cc
+++ b/source/extensions/tracers/opentelemetry/grpc_trace_exporter.cc
@@ -2,8 +2,7 @@
 
 #include "source/common/common/logger.h"
 #include "source/common/grpc/status.h"
-
-#include "otlp_utils.h"
+#include "source/extensions/tracers/opentelemetry/otlp_utils.h"
 
 namespace Envoy {
 namespace Extensions {

--- a/source/extensions/tracers/opentelemetry/grpc_trace_exporter.cc
+++ b/source/extensions/tracers/opentelemetry/grpc_trace_exporter.cc
@@ -1,8 +1,9 @@
 #include "source/extensions/tracers/opentelemetry/grpc_trace_exporter.h"
 
-#include "otlp_utils.h"
 #include "source/common/common/logger.h"
 #include "source/common/grpc/status.h"
+
+#include "otlp_utils.h"
 
 namespace Envoy {
 namespace Extensions {

--- a/source/extensions/tracers/opentelemetry/grpc_trace_exporter.h
+++ b/source/extensions/tracers/opentelemetry/grpc_trace_exporter.h
@@ -20,11 +20,10 @@ public:
 
   void onCreateInitialMetadata(Http::RequestHeaderMap& metadata) override;
 
-  void onSuccess(Grpc::ResponsePtr<ExportTraceServiceResponse>&& response,
-                 Tracing::Span& _) override;
+  void onSuccess(Grpc::ResponsePtr<ExportTraceServiceResponse>&& response, Tracing::Span&) override;
 
   void onFailure(Grpc::Status::GrpcStatus status, const std::string& message,
-                 Tracing::Span& _) override;
+                 Tracing::Span&) override;
 
   bool log(const ExportTraceServiceRequest& request) override;
 

--- a/source/extensions/tracers/opentelemetry/grpc_trace_exporter.h
+++ b/source/extensions/tracers/opentelemetry/grpc_trace_exporter.h
@@ -1,97 +1,35 @@
 #pragma once
 
-#include "envoy/grpc/async_client_manager.h"
-
-#include "source/common/common/logger.h"
 #include "source/common/grpc/typed_async_client.h"
-#include "source/extensions/tracers/opentelemetry/otlp_utils.h"
 #include "source/extensions/tracers/opentelemetry/trace_exporter.h"
-
-#include "opentelemetry/proto/collector/trace/v1/trace_service.pb.h"
 
 namespace Envoy {
 namespace Extensions {
 namespace Tracers {
 namespace OpenTelemetry {
 
-using opentelemetry::proto::collector::trace::v1::ExportTraceServiceRequest;
-using opentelemetry::proto::collector::trace::v1::ExportTraceServiceResponse;
-
 /**
  * Exporter client for OTLP Traces. Provides abstraction on top of gRPC stream.
  */
-class OpenTelemetryGrpcTraceExporterClient : Logger::Loggable<Logger::Id::tracing> {
-public:
-  OpenTelemetryGrpcTraceExporterClient(const Grpc::RawAsyncClientSharedPtr& client,
-                                       const Protobuf::MethodDescriptor& service_method)
-      : client_(client), service_method_(service_method) {}
-
-  struct LocalStream : public Grpc::AsyncStreamCallbacks<
-                           opentelemetry::proto::collector::trace::v1::ExportTraceServiceResponse> {
-    LocalStream(OpenTelemetryGrpcTraceExporterClient& parent) : parent_(parent) {}
-
-    // Grpc::AsyncStreamCallbacks
-    void onCreateInitialMetadata(Http::RequestHeaderMap& metadata) override {
-      metadata.setReferenceUserAgent(OtlpUtils::getOtlpUserAgentHeader());
-    }
-    void onReceiveInitialMetadata(Http::ResponseHeaderMapPtr&&) override {}
-    void onReceiveMessage(
-        std::unique_ptr<opentelemetry::proto::collector::trace::v1::ExportTraceServiceResponse>&&)
-        override {}
-    void onReceiveTrailingMetadata(Http::ResponseTrailerMapPtr&&) override {}
-    void onRemoteClose(Grpc::Status::GrpcStatus, const std::string&) override {
-      ASSERT(parent_.stream_ != nullptr);
-      if (parent_.stream_->stream_ != nullptr) {
-        // Only reset if we have a stream. Otherwise we had an inline failure and we will clear the
-        // stream data in send().
-        parent_.stream_.reset();
-      }
-    }
-
-    OpenTelemetryGrpcTraceExporterClient& parent_;
-    Grpc::AsyncStream<opentelemetry::proto::collector::trace::v1::ExportTraceServiceRequest>
-        stream_{};
-  };
-
-  bool log(const ExportTraceServiceRequest& request) {
-    // If we don't have a stream already, we need to initialize it.
-    if (!stream_) {
-      stream_ = std::make_unique<LocalStream>(*this);
-    }
-
-    // If we don't have a Grpc AsyncStream, we need to initialize it.
-    if (stream_->stream_ == nullptr) {
-      stream_->stream_ =
-          client_->start(service_method_, *stream_, Http::AsyncClient::StreamOptions());
-    }
-
-    // If we do have a Grpc AsyncStream, we can first check if we are above the write buffer, and
-    // send message if it's ok; if we don't have a stream, we need to clear out the stream data
-    // after stream creation failed.
-    if (stream_->stream_ != nullptr) {
-      if (stream_->stream_->isAboveWriteBufferHighWatermark()) {
-        return false;
-      }
-      stream_->stream_->sendMessage(request, true);
-    } else {
-      stream_.reset();
-    }
-    return true;
-  }
-
-  Grpc::AsyncClient<ExportTraceServiceRequest, ExportTraceServiceResponse> client_;
-  std::unique_ptr<LocalStream> stream_;
-  const Protobuf::MethodDescriptor& service_method_;
-};
-
-class OpenTelemetryGrpcTraceExporter : public OpenTelemetryTraceExporter {
+class OpenTelemetryGrpcTraceExporter
+    : public OpenTelemetryTraceExporter,
+      public Grpc::AsyncRequestCallbacks<ExportTraceServiceResponse> {
 public:
   OpenTelemetryGrpcTraceExporter(const Grpc::RawAsyncClientSharedPtr& client);
+  ~OpenTelemetryGrpcTraceExporter() override = default;
+
+  void onCreateInitialMetadata(Http::RequestHeaderMap& metadata) override;
+
+  void onSuccess(Grpc::ResponsePtr<ExportTraceServiceResponse>&& response,
+                 Tracing::Span& _) override;
+
+  void onFailure(Grpc::Status::GrpcStatus status, const std::string& message,
+                 Tracing::Span& _) override;
 
   bool log(const ExportTraceServiceRequest& request) override;
 
-private:
-  OpenTelemetryGrpcTraceExporterClient client_;
+  Grpc::AsyncClient<ExportTraceServiceRequest, ExportTraceServiceResponse> client_;
+  const Protobuf::MethodDescriptor& service_method_;
 };
 
 } // namespace OpenTelemetry

--- a/source/extensions/tracers/opentelemetry/trace_exporter.h
+++ b/source/extensions/tracers/opentelemetry/trace_exporter.h
@@ -5,6 +5,7 @@
 #include "opentelemetry/proto/collector/trace/v1/trace_service.pb.h"
 
 using opentelemetry::proto::collector::trace::v1::ExportTraceServiceRequest;
+using opentelemetry::proto::collector::trace::v1::ExportTraceServiceResponse;
 
 namespace Envoy {
 namespace Extensions {

--- a/test/extensions/tracers/opentelemetry/BUILD
+++ b/test/extensions/tracers/opentelemetry/BUILD
@@ -135,5 +135,7 @@ envoy_extension_cc_test(
         "//test/integration:http_integration_lib",
         "//test/test_common:test_runtime_lib",
         "//test/test_common:utility_lib",
+        "@envoy_api//envoy/config/trace/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/filters/network/http_connection_manager/v3:pkg_cc_proto",
     ],
 )

--- a/test/extensions/tracers/opentelemetry/BUILD
+++ b/test/extensions/tracers/opentelemetry/BUILD
@@ -121,3 +121,19 @@ envoy_extension_cc_test(
         "//test/test_common:utility_lib",
     ],
 )
+
+envoy_extension_cc_test(
+    name = "grpc_trace_exporter_integration_test",
+    srcs = ["grpc_trace_exporter_integration_test.cc"],
+    extension_names = ["envoy.tracers.opentelemetry"],
+    rbe_pool = "6gig",
+    deps = [
+        "//source/extensions/tracers/opentelemetry:config",
+        "//source/extensions/tracers/opentelemetry:opentelemetry_tracer_lib",
+        "//source/extensions/tracers/opentelemetry:trace_exporter",
+        "//test/common/config:dummy_config_proto_cc_proto",
+        "//test/integration:http_integration_lib",
+        "//test/test_common:test_runtime_lib",
+        "//test/test_common:utility_lib",
+    ],
+)

--- a/test/extensions/tracers/opentelemetry/grpc_trace_exporter_integration_test.cc
+++ b/test/extensions/tracers/opentelemetry/grpc_trace_exporter_integration_test.cc
@@ -123,6 +123,7 @@ TEST_P(OpenTelemetryTraceExporterIntegrationTest, GrpcExporter) {
   ASSERT_TRUE(grpc_receiver_upstream_->waitForHttpConnection(*dispatcher_, connection, timeout));
 
   std::map<std::string, int> name_counts;
+  std::vector<FakeStreamPtr> streams;
   for (auto i = 0; i < num_expected_exports; i++) {
     FakeStreamPtr stream;
     ASSERT_TRUE(connection->waitForNewStream(*dispatcher_, stream, timeout))
@@ -141,6 +142,7 @@ TEST_P(OpenTelemetryTraceExporterIntegrationTest, GrpcExporter) {
       ++name_counts[req.resource_spans(0).scope_spans(0).spans().at(j).name()];
     }
     ASSERT_TRUE(stream->waitForEndStream(*dispatcher_, timeout));
+    streams.push_back(std::move(stream));
   }
 
   ASSERT_TRUE(connection->close(timeout));

--- a/test/extensions/tracers/opentelemetry/grpc_trace_exporter_integration_test.cc
+++ b/test/extensions/tracers/opentelemetry/grpc_trace_exporter_integration_test.cc
@@ -1,0 +1,156 @@
+#include "envoy/config/trace/v3/opentelemetry.pb.h"
+#include "envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.pb.h"
+#include "google/protobuf/duration.pb.h"
+#include "opentelemetry/proto/collector/trace/v1/trace_service.pb.h"
+#include "test/integration/http_integration.h"
+
+#include "gtest/gtest.h"
+#include <cstddef>
+
+namespace Envoy {
+
+using envoy::config::trace::v3::OpenTelemetryConfig;
+using envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager;
+using opentelemetry::proto::collector::trace::v1::ExportTraceServiceRequest;
+using opentelemetry::proto::collector::trace::v1::ExportTraceServiceResponse;
+
+class OpenTelemetryTraceExporterIntegrationTest
+    : public testing::TestWithParam<std::tuple<int, int>>,
+      public HttpIntegrationTest {
+public:
+  OpenTelemetryTraceExporterIntegrationTest();
+
+  void createUpstreams() override {
+    HttpIntegrationTest::createUpstreams();
+    addFakeUpstream(Http::CodecType::HTTP2);
+    grpc_receiver_upstream_ = fake_upstreams_.back().get();
+  }
+
+  void setFlushIntervalMs(int64_t ms) {
+    (*otel_runtime_config_.mutable_fields())["tracing.opentelemetry.flush_interval_ms"]
+        .set_number_value(ms);
+  }
+
+  void setMinFlushSpans(int64_t ms) {
+    (*otel_runtime_config_.mutable_fields())["tracing.opentelemetry.min_flush_spans"]
+        .set_number_value(ms);
+  }
+
+  void initialize() override {
+    setFlushIntervalMs(99999'000); // disable flush interval
+    setUpstreamCount(1);
+    config_helper_.addConfigModifier([this](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
+      auto* grpc_receiver_cluster = bootstrap.mutable_static_resources()->add_clusters();
+      grpc_receiver_cluster->MergeFrom(bootstrap.static_resources().clusters()[0]);
+      grpc_receiver_cluster->set_name("grpc-receiver");
+
+      auto* layer = bootstrap.mutable_layered_runtime()->add_layers();
+      layer->set_name("test_otel_layer");
+      auto* static_layer = layer->mutable_static_layer();
+      layer->set_name("test_otel_static_layer");
+      *static_layer = otel_runtime_config_;
+      ConfigHelper::setHttp2(*grpc_receiver_cluster);
+    });
+
+    config_helper_.addConfigModifier([&](HttpConnectionManager& hcm) -> void {
+      HttpConnectionManager::Tracing tracing;
+      tracing.mutable_random_sampling()->set_value(100);
+      tracing.mutable_spawn_upstream_span()->set_value(true);
+
+      OpenTelemetryConfig otel_config;
+      otel_config.set_service_name("my-service");
+      otel_config.mutable_grpc_service()->mutable_envoy_grpc()->set_cluster_name("grpc-receiver");
+      *otel_config.mutable_grpc_service()->mutable_timeout() =
+          Protobuf::util::TimeUtil::MillisecondsToDuration(250);
+
+      tracing.mutable_provider()->set_name("envoy.tracers.opentelemetry");
+      tracing.mutable_provider()->mutable_typed_config()->PackFrom(otel_config);
+
+      *hcm.mutable_tracing() = tracing;
+    });
+    HttpIntegrationTest::initialize();
+  }
+
+  void cleanup() {
+    grpc_receiver_upstream_->cleanUp();
+    cleanupUpstreamAndDownstream();
+  }
+
+  void doHttpRequest() {
+    codec_client_ = makeHttpConnection(makeClientConnection(lookupPort("http")));
+
+    auto response =
+        sendRequestAndWaitForResponse(default_request_headers_, 0, default_response_headers_, 0);
+
+    codec_client_->close();
+    auto _ = codec_client_->waitForDisconnect();
+  }
+
+  FakeUpstream* grpc_receiver_upstream_{};
+  ProtobufWkt::Struct otel_runtime_config_;
+};
+
+struct TestCase {};
+
+OpenTelemetryTraceExporterIntegrationTest::OpenTelemetryTraceExporterIntegrationTest()
+    : HttpIntegrationTest(Http::CodecType::HTTP1, Network::Address::IpVersion::v4){};
+
+INSTANTIATE_TEST_SUITE_P(All, OpenTelemetryTraceExporterIntegrationTest,
+                         // values are (min_flush_spans, num_requests)
+                         testing::Values(std::make_tuple(1, 1), std::make_tuple(1, 2),
+                                         std::make_tuple(2, 1), std::make_tuple(2, 2),
+                                         std::make_tuple(5, 5), std::make_tuple(6, 3)));
+
+TEST_P(OpenTelemetryTraceExporterIntegrationTest, GrpcExporter) {
+  auto [min_flush_spans, num_requests] = GetParam();
+  setMinFlushSpans(min_flush_spans);
+
+  initialize();
+
+  dispatcher_->post([this, num_requests]() {
+    // each request will create two spans, one upstream and one downstream
+    for (auto i = 0; i < num_requests; i++) {
+      doHttpRequest();
+    }
+  });
+
+  // verify that we receive the correct number of export requests, each with the correct number
+  // of spans (there should be no unexported spans remaining)
+  auto num_expected_exports = (num_requests * 2) / min_flush_spans;
+  FakeHttpConnectionPtr connection;
+  ASSERT_TRUE(grpc_receiver_upstream_->waitForHttpConnection(*dispatcher_, connection));
+
+  std::map<std::string, int> name_counts;
+  for (auto i = 0; i < num_expected_exports; i++) {
+    FakeStreamPtr stream;
+    ASSERT_TRUE(connection->waitForNewStream(*dispatcher_, stream))
+        << "Expected to receive " << num_expected_exports << " export requests, but got " << i;
+    ExportTraceServiceRequest req;
+    ASSERT_TRUE(stream->waitForGrpcMessage(*dispatcher_, req));
+    stream->startGrpcStream(true);
+    ExportTraceServiceResponse resp;
+    stream->sendGrpcMessage(resp);
+    stream->finishGrpcStream(Grpc::Status::WellKnownGrpcStatus::Ok);
+
+    ASSERT_EQ(1, req.resource_spans().size());
+    ASSERT_EQ(1, req.resource_spans(0).scope_spans().size());
+    ASSERT_EQ(min_flush_spans, req.resource_spans(0).scope_spans(0).spans().size());
+    for (auto j = 0; j < min_flush_spans; j++) {
+      ++name_counts[req.resource_spans(0).scope_spans(0).spans().at(j).name()];
+    }
+    ASSERT_TRUE(stream->waitForEndStream(*dispatcher_));
+  }
+
+  ASSERT_TRUE(connection->close());
+  ASSERT_TRUE(connection->waitForDisconnect());
+  // the number of upstream and downstream spans received should be equal
+  ASSERT_EQ(2, name_counts.size());
+  ASSERT_THAT(name_counts,
+              testing::AllOf(testing::Contains(testing::Pair("ingress", testing::Eq(num_requests))),
+                             testing::Contains(testing::Pair("router cluster_0 egress",
+                                                             testing::Eq(num_requests)))));
+
+  cleanup();
+}
+
+} // namespace Envoy

--- a/test/extensions/tracers/opentelemetry/grpc_trace_exporter_test.cc
+++ b/test/extensions/tracers/opentelemetry/grpc_trace_exporter_test.cc
@@ -117,26 +117,26 @@ TEST_F(OpenTelemetryGrpcTraceExporterTest, ExportPartialSuccess) {
   auto response = std::make_unique<ExportTraceServiceResponse>();
   response->mutable_partial_success()->set_error_message("test error");
 
-  EXPECT_LOG_CONTAINS("warn", "OTLP partial success: test error (0 spans rejected)",
+  EXPECT_LOG_CONTAINS("debug", "OTLP partial success: test error (0 spans rejected)",
                       exporter.onSuccess(std::move(response), null_span));
 
   response = std::make_unique<ExportTraceServiceResponse>();
   response->mutable_partial_success()->set_error_message("test error 2");
   response->mutable_partial_success()->set_rejected_spans(10);
 
-  EXPECT_LOG_CONTAINS("warn", "OTLP partial success: test error 2 (10 spans rejected)",
+  EXPECT_LOG_CONTAINS("debug", "OTLP partial success: test error 2 (10 spans rejected)",
                       exporter.onSuccess(std::move(response), null_span));
 
   response = std::make_unique<ExportTraceServiceResponse>();
   response->mutable_partial_success()->set_rejected_spans(5);
 
-  EXPECT_LOG_CONTAINS("warn", "OTLP partial success: empty message (5 spans rejected)",
+  EXPECT_LOG_CONTAINS("debug", "OTLP partial success: empty message (5 spans rejected)",
                       exporter.onSuccess(std::move(response), null_span));
 
   response = std::make_unique<ExportTraceServiceResponse>();
   response->mutable_partial_success();
 
-  EXPECT_LOG_NOT_CONTAINS("warn", "OTLP partial success",
+  EXPECT_LOG_NOT_CONTAINS("debug", "OTLP partial success",
                           exporter.onSuccess(std::move(response), null_span));
 }
 

--- a/test/extensions/tracers/opentelemetry/grpc_trace_exporter_test.cc
+++ b/test/extensions/tracers/opentelemetry/grpc_trace_exporter_test.cc
@@ -4,10 +4,8 @@
 #include "source/common/version/version.h"
 #include "source/extensions/tracers/opentelemetry/grpc_trace_exporter.h"
 
-#include "test/mocks/common.h"
 #include "test/mocks/grpc/mocks.h"
 
-#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace Envoy {
@@ -17,44 +15,31 @@ namespace OpenTelemetry {
 
 using testing::_;
 using testing::Invoke;
-using testing::Return;
 
 class OpenTelemetryGrpcTraceExporterTest : public testing::Test {
 public:
-  using TraceCallbacks = Grpc::AsyncStreamCallbacks<
-      opentelemetry::proto::collector::trace::v1::ExportTraceServiceResponse>;
-
-  OpenTelemetryGrpcTraceExporterTest() : async_client_(new Grpc::MockAsyncClient) {
-    expectTraceExportStart();
-  }
-
-  void expectTraceExportStart() {
-    EXPECT_CALL(*async_client_, startRaw(_, _, _, _))
-        .WillOnce(
-            Invoke([this](absl::string_view, absl::string_view, Grpc::RawAsyncStreamCallbacks& cbs,
-                          const Http::AsyncClient::StreamOptions&) {
-              this->callbacks_ = dynamic_cast<TraceCallbacks*>(&cbs);
-              return &this->conn_;
-            }));
-  }
+  OpenTelemetryGrpcTraceExporterTest() : async_client_(new Grpc::MockAsyncClient) {}
 
   void expectTraceExportMessage(const std::string& expected_message_yaml) {
     opentelemetry::proto::collector::trace::v1::ExportTraceServiceRequest expected_message;
     TestUtility::loadFromYaml(expected_message_yaml, expected_message);
-    EXPECT_CALL(conn_, isAboveWriteBufferHighWatermark()).WillOnce(Return(false));
-    EXPECT_CALL(conn_, sendMessageRaw_(_, true))
-        .WillOnce(Invoke([expected_message](Buffer::InstancePtr& request, bool) {
+
+    EXPECT_CALL(*async_client_, sendRaw(_, _, _, _, _, _))
+        .WillOnce(Invoke([expected_message,
+                          this](absl::string_view, absl::string_view, Buffer::InstancePtr&& request,
+                                Grpc::RawAsyncRequestCallbacks&, Tracing::Span&,
+                                const Http::AsyncClient::RequestOptions&) -> Grpc::AsyncRequest* {
           opentelemetry::proto::collector::trace::v1::ExportTraceServiceRequest message;
           Buffer::ZeroCopyInputStreamImpl request_stream(std::move(request));
           EXPECT_TRUE(message.ParseFromZeroCopyStream(&request_stream));
           EXPECT_EQ(message.DebugString(), expected_message.DebugString());
+          return &async_request_;
         }));
   }
 
 protected:
   Grpc::MockAsyncClient* async_client_;
-  Grpc::MockAsyncStream conn_;
-  TraceCallbacks* callbacks_;
+  Grpc::MockAsyncRequest async_request_;
 };
 
 TEST_F(OpenTelemetryGrpcTraceExporterTest, CreateExporterAndExportSpan) {
@@ -73,21 +58,9 @@ TEST_F(OpenTelemetryGrpcTraceExporterTest, CreateExporterAndExportSpan) {
   EXPECT_TRUE(exporter.log(request));
 
   Http::TestRequestHeaderMapImpl metadata;
-  callbacks_->onCreateInitialMetadata(metadata);
+  exporter.onCreateInitialMetadata(metadata);
   EXPECT_EQ(metadata.getUserAgentValue(),
             "OTel-OTLP-Exporter-Envoy/" + Envoy::VersionInfo::version());
-}
-
-TEST_F(OpenTelemetryGrpcTraceExporterTest, NoExportWithHighWatermark) {
-  OpenTelemetryGrpcTraceExporter exporter(Grpc::RawAsyncClientPtr{async_client_});
-
-  EXPECT_CALL(conn_, isAboveWriteBufferHighWatermark()).WillOnce(Return(true));
-  EXPECT_CALL(conn_, sendMessageRaw_(_, false)).Times(0);
-  opentelemetry::proto::collector::trace::v1::ExportTraceServiceRequest request;
-  opentelemetry::proto::trace::v1::Span span;
-  span.set_name("tests");
-  *request.add_resource_spans()->add_scope_spans()->add_spans() = span;
-  EXPECT_FALSE(exporter.log(request));
 }
 
 TEST_F(OpenTelemetryGrpcTraceExporterTest, ExportWithRemoteClose) {
@@ -107,10 +80,10 @@ TEST_F(OpenTelemetryGrpcTraceExporterTest, ExportWithRemoteClose) {
   EXPECT_TRUE(exporter.log(request));
 
   // Terminate the request, now that we've created it.
-  callbacks_->onRemoteClose(Grpc::Status::Internal, "bad");
+  auto null_span = Tracing::NullSpan();
+  exporter.onFailure(Grpc::Status::Internal, "bad", null_span);
 
   // Second call should make a new request.
-  expectTraceExportStart();
   expectTraceExportMessage(request_yaml);
   EXPECT_TRUE(exporter.log(request));
 }
@@ -129,12 +102,12 @@ TEST_F(OpenTelemetryGrpcTraceExporterTest, ExportWithNoopCallbacks) {
   *request.add_resource_spans()->add_scope_spans()->add_spans() = span;
   EXPECT_TRUE(exporter.log(request));
 
+  auto null_span = Tracing::NullSpan();
   Http::TestRequestHeaderMapImpl metadata;
-  callbacks_->onCreateInitialMetadata(metadata);
-  callbacks_->onReceiveInitialMetadata(std::make_unique<Http::TestResponseHeaderMapImpl>());
-  callbacks_->onReceiveTrailingMetadata(std::make_unique<Http::TestResponseTrailerMapImpl>());
-  callbacks_->onReceiveMessage(
-      std::make_unique<opentelemetry::proto::collector::trace::v1::ExportTraceServiceResponse>());
+  exporter.onCreateInitialMetadata(metadata);
+  exporter.onSuccess(
+      std::make_unique<opentelemetry::proto::collector::trace::v1::ExportTraceServiceResponse>(),
+      null_span);
 }
 
 } // namespace OpenTelemetry

--- a/test/extensions/tracers/opentelemetry/opentelemetry_tracer_impl_test.cc
+++ b/test/extensions/tracers/opentelemetry/opentelemetry_tracer_impl_test.cc
@@ -44,8 +44,7 @@ public:
   void setup(envoy::config::trace::v3::OpenTelemetryConfig& opentelemetry_config) {
     auto mock_client_factory = std::make_unique<NiceMock<Grpc::MockAsyncClientFactory>>();
     auto mock_client = std::make_unique<NiceMock<Grpc::MockAsyncClient>>();
-    mock_stream_ptr_ = std::make_unique<NiceMock<Grpc::MockAsyncStream>>();
-    ON_CALL(*mock_client, startRaw(_, _, _, _)).WillByDefault(Return(mock_stream_ptr_.get()));
+    mock_client_ = mock_client.get();
     ON_CALL(*mock_client_factory, createUncachedRawAsyncClient())
         .WillByDefault(Return(ByMove(std::move(mock_client))));
     auto& factory_context = context_.server_factory_context_;
@@ -100,7 +99,7 @@ protected:
   NiceMock<Envoy::Tracing::MockConfig> mock_tracing_config_;
   NiceMock<StreamInfo::MockStreamInfo> stream_info_;
   Event::SimulatedTimeSystem time_system_;
-  std::unique_ptr<NiceMock<Grpc::MockAsyncStream>> mock_stream_ptr_{nullptr};
+  NiceMock<Grpc::MockAsyncClient>* mock_client_{nullptr};
   envoy::config::trace::v3::OpenTelemetryConfig config_;
   Tracing::DriverPtr driver_;
   NiceMock<Runtime::MockLoader> runtime_;
@@ -235,8 +234,9 @@ resource_spans:
   EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.opentelemetry.min_flush_spans", 5U))
       .Times(1)
       .WillRepeatedly(Return(1));
-  EXPECT_CALL(*mock_stream_ptr_,
-              sendMessageRaw_(Grpc::ProtoBufferEqIgnoreRepeatedFieldOrdering(request_proto), _));
+  EXPECT_CALL(
+      *mock_client_,
+      sendRaw(_, _, Grpc::ProtoBufferEqIgnoreRepeatedFieldOrdering(request_proto), _, _, _));
   span->finishSpan();
   EXPECT_EQ(1U, stats_.counter("tracing.opentelemetry.spans_sent").value());
 }
@@ -319,7 +319,7 @@ TEST_F(OpenTelemetryDriverTest, ExportOTLPSpan) {
       .Times(1)
       .WillRepeatedly(Return(1));
   // We should see a call to sendMessage to export that single span.
-  EXPECT_CALL(*mock_stream_ptr_, sendMessageRaw_(_, _));
+  EXPECT_CALL(*mock_client_, sendRaw(_, _, _, _, _, _));
   span->finishSpan();
   EXPECT_EQ(1U, stats_.counter("tracing.opentelemetry.spans_sent").value());
 }
@@ -347,7 +347,7 @@ TEST_F(OpenTelemetryDriverTest, ExportOTLPSpanWithBuffer) {
                          {Tracing::Reason::Sampling, true});
   EXPECT_NE(second_span.get(), nullptr);
   // Only now should we see the span exported.
-  EXPECT_CALL(*mock_stream_ptr_, sendMessageRaw_(_, _));
+  EXPECT_CALL(*mock_client_, sendRaw(_, _, _, _, _, _));
   second_span->finishSpan();
   EXPECT_EQ(2U, stats_.counter("tracing.opentelemetry.spans_sent").value());
 }
@@ -375,7 +375,7 @@ TEST_F(OpenTelemetryDriverTest, ExportOTLPSpanWithFlushTimeout) {
   // We should not yet see a call to sendMessage to export that single span.
   span->finishSpan();
   // Only now should we see the span exported.
-  EXPECT_CALL(*mock_stream_ptr_, sendMessageRaw_(_, _));
+  EXPECT_CALL(*mock_client_, sendRaw(_, _, _, _, _, _));
   // Timer should be enabled again.
   EXPECT_CALL(*timer_, enableTimer(std::chrono::milliseconds(5000), _));
   EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.opentelemetry.flush_interval_ms", 5000U))
@@ -421,7 +421,7 @@ TEST_F(OpenTelemetryDriverTest, SpawnChildSpan) {
       .Times(1)
       .WillRepeatedly(Return(1));
   // We should see a call to sendMessage to export that single span.
-  EXPECT_CALL(*mock_stream_ptr_, sendMessageRaw_(_, _));
+  EXPECT_CALL(*mock_client_, sendRaw(_, _, _, _, _, _));
   child_span->finishSpan();
   EXPECT_EQ(1U, stats_.counter("tracing.opentelemetry.spans_sent").value());
 }
@@ -618,8 +618,9 @@ resource_spans:
   EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.opentelemetry.min_flush_spans", 5U))
       .Times(1)
       .WillRepeatedly(Return(1));
-  EXPECT_CALL(*mock_stream_ptr_,
-              sendMessageRaw_(Grpc::ProtoBufferEqIgnoreRepeatedFieldOrdering(request_proto), _));
+  EXPECT_CALL(
+      *mock_client_,
+      sendRaw(_, _, Grpc::ProtoBufferEqIgnoreRepeatedFieldOrdering(request_proto), _, _, _));
   span->finishSpan();
   EXPECT_EQ(1U, stats_.counter("tracing.opentelemetry.spans_sent").value());
 }
@@ -699,8 +700,9 @@ resource_spans:
   EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.opentelemetry.min_flush_spans", 5U))
       .Times(1)
       .WillRepeatedly(Return(1));
-  EXPECT_CALL(*mock_stream_ptr_,
-              sendMessageRaw_(Grpc::ProtoBufferEqIgnoreRepeatedFieldOrdering(request_proto), _));
+  EXPECT_CALL(
+      *mock_client_,
+      sendRaw(_, _, Grpc::ProtoBufferEqIgnoreRepeatedFieldOrdering(request_proto), _, _, _));
   span->finishSpan();
   EXPECT_EQ(1U, stats_.counter("tracing.opentelemetry.spans_sent").value());
 }
@@ -788,8 +790,9 @@ resource_spans:
   EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.opentelemetry.min_flush_spans", 5U))
       .Times(1)
       .WillRepeatedly(Return(1));
-  EXPECT_CALL(*mock_stream_ptr_,
-              sendMessageRaw_(Grpc::ProtoBufferEqIgnoreRepeatedFieldOrdering(request_proto), _));
+  EXPECT_CALL(
+      *mock_client_,
+      sendRaw(_, _, Grpc::ProtoBufferEqIgnoreRepeatedFieldOrdering(request_proto), _, _, _));
   span->finishSpan();
   EXPECT_EQ(1U, stats_.counter("tracing.opentelemetry.spans_sent").value());
 }
@@ -806,7 +809,7 @@ TEST_F(OpenTelemetryDriverTest, IgnoreNotSampledSpan) {
   span->setSampled(false);
 
   EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.opentelemetry.min_flush_spans", 5U)).Times(0);
-  EXPECT_CALL(*mock_stream_ptr_, sendMessageRaw_(_, _)).Times(0);
+  EXPECT_CALL(*mock_client_, sendRaw(_, _, _, _, _, _)).Times(0);
   span->finishSpan();
   EXPECT_EQ(0U, stats_.counter("tracing.opentelemetry.spans_sent").value());
 }
@@ -830,7 +833,7 @@ TEST_F(OpenTelemetryDriverTest, NoExportWithoutGrpcService) {
       .Times(1)
       .WillRepeatedly(Return(1));
   // We should see a call to sendMessage to export that single span.
-  EXPECT_CALL(*mock_stream_ptr_, sendMessageRaw_(_, _)).Times(0);
+  EXPECT_CALL(*mock_client_, sendRaw(_, _, _, _, _, _)).Times(0);
   span->finishSpan();
   EXPECT_EQ(0U, stats_.counter("tracing.opentelemetry.spans_sent").value());
 }
@@ -899,8 +902,9 @@ resource_spans:
   EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.opentelemetry.min_flush_spans", 5U))
       .Times(1)
       .WillRepeatedly(Return(1));
-  EXPECT_CALL(*mock_stream_ptr_,
-              sendMessageRaw_(Grpc::ProtoBufferEqIgnoreRepeatedFieldOrdering(request_proto), _));
+  EXPECT_CALL(
+      *mock_client_,
+      sendRaw(_, _, Grpc::ProtoBufferEqIgnoreRepeatedFieldOrdering(request_proto), _, _, _));
   span->finishSpan();
   EXPECT_EQ(1U, stats_.counter("tracing.opentelemetry.spans_sent").value());
 }


### PR DESCRIPTION
Commit Message: extensions: fix OTel GRPC trace exporter dropping spans

Additional Description:
Fixes otel exporter dropping spans in some cases, for example:
- If, while waiting for a response to an export request, the span buffer is flushed again.
- If the span buffer is flushed after an upstream span ends, and there exists a corresponding downstream span, and the buffer is flushed again when the downstream span ends. This can be triggered by setting the `tracing.opentelemetry.min_flush_spans` runtime variable to `1`, or if the flush timer expires just after the upstream span ends. This is similar to the first case, but the specific order of http callbacks prevented the exporter client from ever being reset before the downstream request completed, if it was used to export spans after the upstream request completed.

Risk Level: 
Testing: Yes; added an integration test that I think will cover this. Updated mock usage in other otel tests to account for refactors to the exporter. 
Docs Changes:
Release Notes: 
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
