### PR TITLE
[redis_proxy] Add support for SELECT and KEYS

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -214,6 +214,9 @@ removed_config_or_runtime:
     Removed runtime flag ``envoy.reloadable_features.exclude_host_in_eds_status_draining``.
 
 new_features:
+- area: redis
+  change: |
+    Added support for keys and select.
 - area: wasm
   change: |
     Added the wasm vm reload support to reload wasm vm when the wasm vm is failed with runtime errors. See

--- a/docs/root/intro/arch_overview/other_protocols/redis.rst
+++ b/docs/root/intro/arch_overview/other_protocols/redis.rst
@@ -157,11 +157,13 @@ For details on each command's usage see the official
   EXISTS, Generic
   EXPIRE, Generic
   EXPIREAT, Generic
+  KEYS, String
   PERSIST, Generic
   PEXPIRE, Generic
   PEXPIREAT, Generic
   PTTL, Generic
   RESTORE, Generic
+  SELECT, Generic
   TOUCH, Generic
   TTL, Generic
   TYPE, Generic

--- a/docs/root/intro/arch_overview/other_protocols/redis.rst
+++ b/docs/root/intro/arch_overview/other_protocols/redis.rst
@@ -302,7 +302,7 @@ Envoy can also generate its own errors in response to the client.
   the connection."
   invalid request, "Command was rejected by the first stage of the command splitter due to
   datatype or length."
-  unsupported command, "The command was not recognized by Envoy and therefore cannot be serviced
+  ERR unknown command, "The command was not recognized by Envoy and therefore cannot be serviced
   because it cannot be hashed to a backend server."
   finished with n errors, "Fragmented commands which sum the response (e.g. DEL) will return the
   total number of errors received if any were received."

--- a/source/extensions/clusters/redis/redis_cluster_lb.cc
+++ b/source/extensions/clusters/redis/redis_cluster_lb.cc
@@ -1,5 +1,7 @@
 #include "source/extensions/clusters/redis/redis_cluster_lb.h"
 
+#include <string>
+
 namespace Envoy {
 namespace Extensions {
 namespace Clusters {
@@ -138,8 +140,17 @@ Upstream::HostConstSharedPtr RedisClusterLoadBalancerFactory::RedisClusterLoadBa
     return nullptr;
   }
 
-  auto shard = shard_vector_->at(
-      slot_array_->at(hash.value() % Envoy::Extensions::Clusters::Redis::MaxSlot));
+  RedisShardSharedPtr shard;
+  if (dynamic_cast<const RedisSpecifyShardContextImpl*>(context)) {
+    if (hash.value() < shard_vector_->size()) {
+      shard = shard_vector_->at(hash.value());
+    } else {
+      return nullptr;
+    }
+  } else {
+    shard = shard_vector_->at(
+        slot_array_->at(hash.value() % Envoy::Extensions::Clusters::Redis::MaxSlot));
+  }
 
   auto redis_context = dynamic_cast<RedisLoadBalancerContext*>(context);
   if (redis_context && redis_context->isReadCommand()) {
@@ -213,6 +224,12 @@ absl::string_view RedisLoadBalancerContextImpl::hashtag(absl::string_view v, boo
 
   return v.substr(start + 1, end - start - 1);
 }
+RedisSpecifyShardContextImpl::RedisSpecifyShardContextImpl(
+    uint64_t shard_index, const NetworkFilters::Common::Redis::RespValue& request,
+    NetworkFilters::Common::Redis::Client::ReadPolicy read_policy)
+    : RedisLoadBalancerContextImpl(std::to_string(shard_index), true, true, request, read_policy),
+      shard_index_(shard_index) {}
+
 } // namespace Redis
 } // namespace Clusters
 } // namespace Extensions

--- a/source/extensions/clusters/redis/redis_cluster_lb.h
+++ b/source/extensions/clusters/redis/redis_cluster_lb.h
@@ -113,6 +113,26 @@ private:
   const NetworkFilters::Common::Redis::Client::ReadPolicy read_policy_;
 };
 
+class RedisSpecifyShardContextImpl : public RedisLoadBalancerContextImpl {
+public:
+  /**
+   * The redis specify Shard load balancer context for Redis requests.
+   * @param shard_index specify the shard index for the Redis request.
+   * @param request specify the Redis request.
+   * @param read_policy specify the read policy.
+   */
+  RedisSpecifyShardContextImpl(uint64_t shard_index,
+                               const NetworkFilters::Common::Redis::RespValue& request,
+                               NetworkFilters::Common::Redis::Client::ReadPolicy read_policy =
+                                   NetworkFilters::Common::Redis::Client::ReadPolicy::Primary);
+
+  // Upstream::LoadBalancerContextBase
+  absl::optional<uint64_t> computeHashKey() override { return shard_index_; }
+
+private:
+  const absl::optional<uint64_t> shard_index_;
+};
+
 class ClusterSlotUpdateCallBack {
 public:
   virtual ~ClusterSlotUpdateCallBack() = default;

--- a/source/extensions/filters/network/common/redis/supported_commands.h
+++ b/source/extensions/filters/network/common/redis/supported_commands.h
@@ -122,6 +122,14 @@ struct SupportedCommands {
   static bool isReadCommand(const std::string& command) {
     return !writeCommands().contains(command);
   }
+
+  static bool isSupportedCommand(const std::string& command) {
+    return (simpleCommands().contains(command) || evalCommands().contains(command) ||
+            hashMultipleSumResultCommands().contains(command) ||
+            transactionCommands().contains(command) || auth() == command || echo() == command ||
+            mget() == command || mset() == command || keys() == command || ping() == command ||
+            time() == command || quit() == command || select() == command);
+  }
 };
 
 } // namespace Redis

--- a/source/extensions/filters/network/common/redis/supported_commands.h
+++ b/source/extensions/filters/network/common/redis/supported_commands.h
@@ -80,6 +80,11 @@ struct SupportedCommands {
   static const std::string& mset() { CONSTRUCT_ON_FIRST_USE(std::string, "mset"); }
 
   /**
+   * @return keys command
+   */
+  static const std::string& keys() { CONSTRUCT_ON_FIRST_USE(std::string, "keys"); }
+
+  /**
    * @return ping command
    */
   static const std::string& ping() { CONSTRUCT_ON_FIRST_USE(std::string, "ping"); }
@@ -93,6 +98,11 @@ struct SupportedCommands {
    * @return quit command
    */
   static const std::string& quit() { CONSTRUCT_ON_FIRST_USE(std::string, "quit"); }
+
+  /**
+   * @return select command
+   */
+  static const std::string& select() { CONSTRUCT_ON_FIRST_USE(std::string, "select"); }
 
   /**
    * @return commands which alters the state of redis

--- a/source/extensions/filters/network/redis_proxy/command_splitter_impl.cc
+++ b/source/extensions/filters/network/redis_proxy/command_splitter_impl.cc
@@ -1,5 +1,7 @@
 #include "source/extensions/filters/network/redis_proxy/command_splitter_impl.h"
 
+#include <cstdint>
+
 #include "source/common/common/logger.h"
 #include "source/extensions/filters/network/common/redis/supported_commands.h"
 
@@ -69,6 +71,35 @@ makeFragmentedRequest(const RouteSharedPtr& route, const std::string& command,
       if (mirror_policy->shouldMirror(command)) {
         mirror_policy->upstream()->makeRequest(key, ConnPool::RespVariant(incoming_request),
                                                null_pool_callbacks, transaction);
+      }
+    }
+  }
+  return handler;
+}
+
+/**
+ * Make request and maybe mirror the request based on the mirror policies of the route.
+ * @param route supplies the route matched with the request.
+ * @param command supplies the command of the request.
+ * @param key supplies the key of the request.
+ * @param incoming_request supplies the request.
+ * @param callbacks supplies the request completion callbacks.
+ * @param transaction supplies the transaction info of the current connection.
+ * @return PoolRequest* a handle to the active request or nullptr if the request could not be made
+ *         for some reason.
+ */
+Common::Redis::Client::PoolRequest*
+makeFragmentedRequestToShard(const RouteSharedPtr& route, const std::string& command,
+                             uint16_t shard_index, const Common::Redis::RespValue& incoming_request,
+                             ConnPool::PoolCallbacks& callbacks,
+                             Common::Redis::Client::Transaction& transaction) {
+  auto handler = route->upstream(command)->makeRequestToShard(
+      shard_index, ConnPool::RespVariant(incoming_request), callbacks, transaction);
+  if (handler) {
+    for (auto& mirror_policy : route->mirrorPolicies()) {
+      if (mirror_policy->shouldMirror(command)) {
+        mirror_policy->upstream()->makeRequestToShard(
+            shard_index, ConnPool::RespVariant(incoming_request), null_pool_callbacks, transaction);
       }
     }
   }
@@ -385,6 +416,80 @@ void MSETRequest::onChildResponse(Common::Redis::RespValuePtr&& value, uint32_t 
   }
 }
 
+SplitRequestPtr KeysRequest::create(Router& router, Common::Redis::RespValuePtr&& incoming_request,
+                                    SplitCallbacks& callbacks, CommandStats& command_stats,
+                                    TimeSource& time_source, bool delay_command_latency,
+                                    const StreamInfo::StreamInfo& stream_info) {
+  if (incoming_request->asArray().size() != 2) {
+    onWrongNumberOfArguments(callbacks, *incoming_request);
+    command_stats.error_.inc();
+    return nullptr;
+  }
+  const auto route = router.upstreamPool(incoming_request->asArray()[1].asString(), stream_info);
+  uint32_t shard_size =
+      route ? route->upstream(incoming_request->asArray()[0].asString())->shardSize() : 0;
+  if (shard_size == 0) {
+    command_stats.error_.inc();
+    callbacks.onResponse(Common::Redis::Utility::makeError(Response::get().NoUpstreamHost));
+    return nullptr;
+  }
+
+  std::unique_ptr<KeysRequest> request_ptr{
+      new KeysRequest(callbacks, command_stats, time_source, delay_command_latency)};
+  request_ptr->num_pending_responses_ = shard_size;
+  request_ptr->pending_requests_.reserve(request_ptr->num_pending_responses_);
+
+  request_ptr->pending_response_ = std::make_unique<Common::Redis::RespValue>();
+  request_ptr->pending_response_->type(Common::Redis::RespType::Array);
+
+  Common::Redis::RespValueSharedPtr base_request = std::move(incoming_request);
+  for (uint32_t shard_index = 0; shard_index < shard_size; shard_index++) {
+    request_ptr->pending_requests_.emplace_back(*request_ptr, shard_index);
+    PendingRequest& pending_request = request_ptr->pending_requests_.back();
+
+    ENVOY_LOG(debug, "keys request shard index {}: {}", shard_index, base_request->toString());
+    pending_request.handle_ =
+        makeFragmentedRequestToShard(route, base_request->asArray()[0].asString(), shard_index,
+                                     *base_request, pending_request, callbacks.transaction());
+
+    if (!pending_request.handle_) {
+      pending_request.onResponse(Common::Redis::Utility::makeError(Response::get().NoUpstreamHost));
+    }
+  }
+
+  if (request_ptr->num_pending_responses_ > 0) {
+    return request_ptr;
+  }
+
+  return nullptr;
+}
+
+void KeysRequest::onChildResponse(Common::Redis::RespValuePtr&& value, uint32_t index) {
+  pending_requests_[index].handle_ = nullptr;
+  switch (value->type()) {
+  case Common::Redis::RespType::Array: {
+    pending_response_->asArray().insert(pending_response_->asArray().end(),
+                                        value->asArray().begin(), value->asArray().end());
+    break;
+  }
+  default: {
+    error_count_++;
+    break;
+  }
+  }
+
+  ASSERT(num_pending_responses_ > 0);
+  if (--num_pending_responses_ == 0) {
+    updateStats(error_count_ == 0);
+    if (error_count_ == 0) {
+      callbacks_.onResponse(std::move(pending_response_));
+    } else {
+      callbacks_.onResponse(Common::Redis::Utility::makeError(
+          fmt::format("finished with {} error(s)", error_count_)));
+    }
+  }
+}
+
 SplitRequestPtr
 SplitKeysSumResultRequest::create(Router& router, Common::Redis::RespValuePtr&& incoming_request,
                                   SplitCallbacks& callbacks, CommandStats& command_stats,
@@ -593,7 +698,7 @@ InstanceImpl::InstanceImpl(RouterPtr&& router, Stats::Scope& scope, const std::s
                            Common::Redis::FaultManagerPtr&& fault_manager)
     : router_(std::move(router)), simple_command_handler_(*router_),
       eval_command_handler_(*router_), mget_handler_(*router_), mset_handler_(*router_),
-      split_keys_sum_result_handler_(*router_),
+      keys_handler_(*router_), split_keys_sum_result_handler_(*router_),
       transaction_handler_(*router_), stats_{ALL_COMMAND_SPLITTER_STATS(
                                           POOL_COUNTER_PREFIX(scope, stat_prefix + "splitter."))},
       time_source_(time_source), fault_manager_(std::move(fault_manager)) {
@@ -615,6 +720,9 @@ InstanceImpl::InstanceImpl(RouterPtr&& router, Stats::Scope& scope, const std::s
 
   addHandler(scope, stat_prefix, Common::Redis::SupportedCommands::mset(), latency_in_micros,
              mset_handler_);
+
+  addHandler(scope, stat_prefix, Common::Redis::SupportedCommands::keys(), latency_in_micros,
+             keys_handler_);
 
   for (const std::string& command : Common::Redis::SupportedCommands::transactionCommands()) {
     addHandler(scope, stat_prefix, command, latency_in_micros, transaction_handler_);
@@ -701,6 +809,16 @@ SplitRequestPtr InstanceImpl::makeRequest(Common::Redis::RespValuePtr&& request,
 
     time_resp->asArray().swap(resp_array);
     callbacks.onResponse(std::move(time_resp));
+    return nullptr;
+  }
+
+  if (command_name == Common::Redis::SupportedCommands::select()) {
+    // Respond to OK locally.
+    if (request->asArray().size() != 2) {
+      onInvalidRequest(callbacks);
+      return nullptr;
+    }
+    localResponse(callbacks, "OK");
     return nullptr;
   }
 

--- a/source/extensions/filters/network/redis_proxy/command_splitter_impl.h
+++ b/source/extensions/filters/network/redis_proxy/command_splitter_impl.h
@@ -285,6 +285,26 @@ private:
 };
 
 /**
+ * KeysRequest sends the command to all Redis server. The response from each Redis (which
+ * must be an array) is merged and returned to the user. If there is any error or failure in
+ * processing the fragmented commands, an error will be returned.
+ */
+class KeysRequest : public FragmentedRequest {
+public:
+  static SplitRequestPtr create(Router& router, Common::Redis::RespValuePtr&& incoming_request,
+                                SplitCallbacks& callbacks, CommandStats& command_stats,
+                                TimeSource& time_source, bool delay_command_latency,
+                                const StreamInfo::StreamInfo& stream_info);
+
+private:
+  KeysRequest(SplitCallbacks& callbacks, CommandStats& command_stats, TimeSource& time_source,
+              bool delay_command_latency)
+      : FragmentedRequest(callbacks, command_stats, time_source, delay_command_latency) {}
+  // RedisProxy::CommandSplitter::FragmentedRequest
+  void onChildResponse(Common::Redis::RespValuePtr&& value, uint32_t index) override;
+};
+
+/**
  * SplitKeysSumResultRequest takes each key from the command and sends the same incoming command
  * with each key to the appropriate Redis server. The response from each Redis (which must be an
  * integer) is summed and returned to the user. If there is any error or failure in processing the
@@ -390,6 +410,7 @@ private:
   CommandHandlerFactory<EvalRequest> eval_command_handler_;
   CommandHandlerFactory<MGETRequest> mget_handler_;
   CommandHandlerFactory<MSETRequest> mset_handler_;
+  CommandHandlerFactory<KeysRequest> keys_handler_;
   CommandHandlerFactory<SplitKeysSumResultRequest> split_keys_sum_result_handler_;
   CommandHandlerFactory<TransactionRequest> transaction_handler_;
   TrieLookupTable<HandlerDataPtr> handler_lookup_table_;

--- a/source/extensions/filters/network/redis_proxy/conn_pool.h
+++ b/source/extensions/filters/network/redis_proxy/conn_pool.h
@@ -52,6 +52,7 @@ class Instance {
 public:
   virtual ~Instance() = default;
 
+  virtual uint16_t shardSize() PURE;
   /**
    * Makes a redis request.
    * @param hash_key supplies the key to use for consistent hashing.
@@ -64,6 +65,18 @@ public:
   virtual Common::Redis::Client::PoolRequest*
   makeRequest(const std::string& hash_key, RespVariant&& request, PoolCallbacks& callbacks,
               Common::Redis::Client::Transaction& transaction) PURE;
+  /**
+   * Makes a redis request.
+   * @param shard_index supplies the key to use for consistent hashing.
+   * @param request supplies the request to make.
+   * @param callbacks supplies the request completion callbacks.
+   * @param transaction supplies the transaction info of the current connection.
+   * @return PoolRequest* a handle to the active request or nullptr if the request could not be made
+   *         for some reason.
+   */
+  virtual Common::Redis::Client::PoolRequest*
+  makeRequestToShard(uint16_t shard_index, RespVariant&& request, PoolCallbacks& callbacks,
+                     Common::Redis::Client::Transaction& transaction) PURE;
 };
 
 using InstanceSharedPtr = std::shared_ptr<Instance>;

--- a/source/extensions/filters/network/redis_proxy/conn_pool_impl.cc
+++ b/source/extensions/filters/network/redis_proxy/conn_pool_impl.cc
@@ -69,6 +69,10 @@ void InstanceImpl::init() {
   });
 }
 
+//
+//
+uint16_t InstanceImpl::shardSize() { return tls_->getTyped<ThreadLocalPool>().shardSize(); }
+
 // This method is always called from a InstanceSharedPtr we don't have to worry about tls_->getTyped
 // failing due to InstanceImpl going away.
 Common::Redis::Client::PoolRequest*
@@ -85,6 +89,16 @@ InstanceImpl::makeRequestToHost(const std::string& host_address,
                                 const Common::Redis::RespValue& request,
                                 Common::Redis::Client::ClientCallbacks& callbacks) {
   return tls_->getTyped<ThreadLocalPool>().makeRequestToHost(host_address, request, callbacks);
+}
+
+// This method is always called from a InstanceSharedPtr we don't have to worry about tls_->getTyped
+// failing due to InstanceImpl going away.
+Common::Redis::Client::PoolRequest*
+InstanceImpl::makeRequestToShard(uint16_t shard_index, RespVariant&& request,
+                                 PoolCallbacks& callbacks,
+                                 Common::Redis::Client::Transaction& transaction) {
+  return tls_->getTyped<ThreadLocalPool>().makeRequestToShard(shard_index, std::move(request),
+                                                              callbacks, transaction);
 }
 
 InstanceImpl::ThreadLocalPool::ThreadLocalPool(
@@ -268,6 +282,25 @@ InstanceImpl::ThreadLocalPool::threadLocalActiveClient(Upstream::HostConstShared
   return client;
 }
 
+uint16_t InstanceImpl::ThreadLocalPool::shardSize() {
+  if (cluster_ == nullptr) {
+    ASSERT(client_map_.empty());
+    ASSERT(host_set_member_update_cb_handle_ == nullptr);
+    return 0;
+  }
+
+  Common::Redis::RespValue request;
+  for (uint16_t size = 0;; size++) {
+    Clusters::Redis::RedisSpecifyShardContextImpl lb_context(
+        size, request, Common::Redis::Client::ReadPolicy::Primary);
+    Upstream::HostConstSharedPtr host = cluster_->loadBalancer().chooseHost(&lb_context);
+    if (!host) {
+      return size;
+    }
+  }
+  return 0;
+}
+
 Common::Redis::Client::PoolRequest*
 InstanceImpl::ThreadLocalPool::makeRequest(const std::string& key, RespVariant&& request,
                                            PoolCallbacks& callbacks,
@@ -288,42 +321,29 @@ InstanceImpl::ThreadLocalPool::makeRequest(const std::string& key, RespVariant&&
     return nullptr;
   }
 
-  uint32_t client_idx = transaction.current_client_idx_;
-  // If there is an active transaction, establish a new connection if necessary.
-  if (transaction.active_ && !transaction.connection_established_) {
-    transaction.clients_[client_idx] =
-        client_factory_.create(host, dispatcher_, config_, redis_command_stats_, *(stats_scope_),
-                               auth_username_, auth_password_, true);
-    if (transaction.connection_cb_) {
-      transaction.clients_[client_idx]->addConnectionCallbacks(*transaction.connection_cb_);
-    }
-  }
+  return makeRequestToHost(host, std::move(request), callbacks, transaction);
+}
 
-  pending_requests_.emplace_back(*this, std::move(request), callbacks, host);
-  PendingRequest& pending_request = pending_requests_.back();
-
-  if (!transaction.active_) {
-    ThreadLocalActiveClientPtr& client = this->threadLocalActiveClient(host);
-    if (!client) {
-      ENVOY_LOG(debug, "redis connection is rate limited, erasing empty client");
-      pending_request.request_handler_ = nullptr;
-      onRequestCompleted();
-      client_map_.erase(host);
-      return nullptr;
-    }
-    pending_request.request_handler_ = client->redis_client_->makeRequest(
-        getRequest(pending_request.incoming_request_), pending_request);
-  } else {
-    pending_request.request_handler_ = transaction.clients_[client_idx]->makeRequest(
-        getRequest(pending_request.incoming_request_), pending_request);
-  }
-
-  if (pending_request.request_handler_) {
-    return &pending_request;
-  } else {
-    onRequestCompleted();
+Common::Redis::Client::PoolRequest*
+InstanceImpl::ThreadLocalPool::makeRequestToShard(uint16_t shard_index, RespVariant&& request,
+                                                  PoolCallbacks& callbacks,
+                                                  Common::Redis::Client::Transaction& transaction) {
+  if (cluster_ == nullptr) {
+    ASSERT(client_map_.empty());
+    ASSERT(host_set_member_update_cb_handle_ == nullptr);
     return nullptr;
   }
+
+  Clusters::Redis::RedisSpecifyShardContextImpl lb_context(
+      shard_index, getRequest(request),
+      transaction.active_ ? Common::Redis::Client::ReadPolicy::Primary : config_->readPolicy());
+
+  Upstream::HostConstSharedPtr host = cluster_->loadBalancer().chooseHost(&lb_context);
+  if (!host) {
+    ENVOY_LOG(debug, "host not found: '{}'", shard_index);
+    return nullptr;
+  }
+  return makeRequestToHost(host, std::move(request), callbacks, transaction);
 }
 
 Common::Redis::Client::PoolRequest* InstanceImpl::ThreadLocalPool::makeRequestToHost(
@@ -400,6 +420,48 @@ Common::Redis::Client::PoolRequest* InstanceImpl::ThreadLocalPool::makeRequestTo
   }
 
   return client->redis_client_->makeRequest(request, callbacks);
+}
+
+Common::Redis::Client::PoolRequest*
+InstanceImpl::ThreadLocalPool::makeRequestToHost(Upstream::HostConstSharedPtr& host,
+                                                 RespVariant&& request, PoolCallbacks& callbacks,
+                                                 Common::Redis::Client::Transaction& transaction) {
+  uint32_t client_idx = transaction.current_client_idx_;
+  // If there is an active transaction, establish a new connection if necessary.
+  if (transaction.active_ && !transaction.connection_established_) {
+    transaction.clients_[client_idx] =
+        client_factory_.create(host, dispatcher_, config_, redis_command_stats_, *(stats_scope_),
+                               auth_username_, auth_password_, true);
+    if (transaction.connection_cb_) {
+      transaction.clients_[client_idx]->addConnectionCallbacks(*transaction.connection_cb_);
+    }
+  }
+
+  pending_requests_.emplace_back(*this, std::move(request), callbacks, host);
+  PendingRequest& pending_request = pending_requests_.back();
+
+  if (!transaction.active_) {
+    ThreadLocalActiveClientPtr& client = this->threadLocalActiveClient(host);
+    if (!client) {
+      ENVOY_LOG(debug, "redis connection is rate limited, erasing empty client");
+      pending_request.request_handler_ = nullptr;
+      onRequestCompleted();
+      client_map_.erase(host);
+      return nullptr;
+    }
+    pending_request.request_handler_ = client->redis_client_->makeRequest(
+        getRequest(pending_request.incoming_request_), pending_request);
+  } else {
+    pending_request.request_handler_ = transaction.clients_[client_idx]->makeRequest(
+        getRequest(pending_request.incoming_request_), pending_request);
+  }
+
+  if (pending_request.request_handler_) {
+    return &pending_request;
+  } else {
+    onRequestCompleted();
+    return nullptr;
+  }
 }
 
 void InstanceImpl::ThreadLocalPool::onRequestCompleted() {

--- a/source/extensions/filters/network/redis_proxy/conn_pool_impl.cc
+++ b/source/extensions/filters/network/redis_proxy/conn_pool_impl.cc
@@ -69,8 +69,6 @@ void InstanceImpl::init() {
   });
 }
 
-//
-//
 uint16_t InstanceImpl::shardSize() { return tls_->getTyped<ThreadLocalPool>().shardSize(); }
 
 // This method is always called from a InstanceSharedPtr we don't have to worry about tls_->getTyped

--- a/test/extensions/filters/network/redis_proxy/command_splitter_impl_test.cc
+++ b/test/extensions/filters/network/redis_proxy/command_splitter_impl_test.cc
@@ -173,8 +173,7 @@ TEST_F(RedisCommandSplitterImplTest, InvalidRequestArrayNotStrings) {
 TEST_F(RedisCommandSplitterImplTest, UnsupportedCommand) {
   Common::Redis::RespValue response;
   response.type(Common::Redis::RespType::Error);
-  response.asString() = "unsupported command 'newcommand'";
-  EXPECT_CALL(callbacks_, connectionAllowed()).WillOnce(Return(true));
+  response.asString() = "ERR unknown command 'newcommand', with args beginning with: hello";
   EXPECT_CALL(callbacks_, onResponse_(PointeesEq(&response)));
   Common::Redis::RespValuePtr request{new Common::Redis::RespValue()};
   makeBulkStringArray(*request, {"newcommand", "hello"});

--- a/test/extensions/filters/network/redis_proxy/mocks.h
+++ b/test/extensions/filters/network/redis_proxy/mocks.h
@@ -86,14 +86,25 @@ public:
   MockInstance();
   ~MockInstance() override;
 
+  uint16_t shardSize() override { return shardSize_(); }
+
   Common::Redis::Client::PoolRequest* makeRequest(const std::string& hash_key,
                                                   RespVariant&& request, PoolCallbacks& callbacks,
                                                   Common::Redis::Client::Transaction&) override {
     return makeRequest_(hash_key, request, callbacks);
   }
 
+  Common::Redis::Client::PoolRequest*
+  makeRequestToShard(uint16_t shard_index, RespVariant&& request, PoolCallbacks& callbacks,
+                     Common::Redis::Client::Transaction&) override {
+    return makeRequestToShard_(shard_index, request, callbacks);
+  }
+
+  MOCK_METHOD(uint16_t, shardSize_, ());
   MOCK_METHOD(Common::Redis::Client::PoolRequest*, makeRequest_,
               (const std::string& hash_key, RespVariant& request, PoolCallbacks& callbacks));
+  MOCK_METHOD(Common::Redis::Client::PoolRequest*, makeRequestToShard_,
+              (uint16_t shard_index, RespVariant& request, PoolCallbacks& callbacks));
   MOCK_METHOD(bool, onRedirection, ());
 };
 } // namespace ConnPool

--- a/test/extensions/filters/network/redis_proxy/redis_proxy_integration_test.cc
+++ b/test/extensions/filters/network/redis_proxy/redis_proxy_integration_test.cc
@@ -880,13 +880,26 @@ TEST_P(RedisProxyIntegrationTest, QUITRequestAndResponse) {
 
 // This test sends an invalid Redis command from a fake
 // downstream client to the envoy proxy. Envoy will respond
+// with an ERR unknown command error.
+
+TEST_P(RedisProxyIntegrationTest, UnknownCommand) {
+  std::stringstream error_response;
+  error_response << "-"
+                 << "ERR unknown command 'foo', with args beginning with: "
+                 << "\r\n";
+  initialize();
+  simpleProxyResponse(makeBulkStringArray({"foo"}), error_response.str());
+}
+
+// This test sends an invalid Redis command from a fake
+// downstream client to the envoy proxy. Envoy will respond
 // with an invalid request error.
 
 TEST_P(RedisProxyIntegrationTest, InvalidRequest) {
   std::stringstream error_response;
   error_response << "-" << RedisCmdSplitter::Response::get().InvalidRequest << "\r\n";
   initialize();
-  simpleProxyResponse(makeBulkStringArray({"foo"}), error_response.str());
+  simpleProxyResponse(makeBulkStringArray({"keys"}), error_response.str());
 }
 
 // This test sends a simple Redis command to a fake upstream

--- a/test/extensions/filters/network/redis_proxy/redis_proxy_integration_test.cc
+++ b/test/extensions/filters/network/redis_proxy/redis_proxy_integration_test.cc
@@ -893,6 +893,32 @@ TEST_P(RedisProxyIntegrationTest, UnknownCommand) {
 
 // This test sends an invalid Redis command from a fake
 // downstream client to the envoy proxy. Envoy will respond
+// with an ERR unknown command error.
+
+TEST_P(RedisProxyIntegrationTest, UnknownCommandWithArgs) {
+  std::stringstream error_response;
+  error_response << "-"
+                 << "ERR unknown command 'hello', with args beginning with: world"
+                 << "\r\n";
+  initialize();
+  simpleProxyResponse(makeBulkStringArray({"hello", "world"}), error_response.str());
+}
+
+// This test sends an invalid Redis command from a fake
+// downstream client to the envoy proxy. Envoy will respond
+// with an ERR unknown command error.
+
+TEST_P(RedisProxyIntegrationTest, HelloCommand) {
+  std::stringstream error_response;
+  error_response << "-"
+                 << "ERR unknown command 'hello', with args beginning with: world"
+                 << "\r\n";
+  initialize();
+  simpleProxyResponse(makeBulkStringArray({"hello", "world"}), error_response.str());
+}
+
+// This test sends an invalid Redis command from a fake
+// downstream client to the envoy proxy. Envoy will respond
 // with an invalid request error.
 
 TEST_P(RedisProxyIntegrationTest, InvalidRequest) {
@@ -900,6 +926,19 @@ TEST_P(RedisProxyIntegrationTest, InvalidRequest) {
   error_response << "-" << RedisCmdSplitter::Response::get().InvalidRequest << "\r\n";
   initialize();
   simpleProxyResponse(makeBulkStringArray({"keys"}), error_response.str());
+}
+
+// This test sends an invalid Redis command from a fake
+// downstream client to the envoy proxy. Envoy will respond
+// with an invalid request error.
+
+TEST_P(RedisProxyIntegrationTest, InvalidArgsRequest) {
+  std::stringstream error_response;
+  error_response << "-"
+                 << "wrong number of arguments for 'keys' command"
+                 << "\r\n";
+  initialize();
+  simpleProxyResponse(makeBulkStringArray({"keys", "a*", "b*"}), error_response.str());
 }
 
 // This test sends a simple Redis command to a fake upstream


### PR DESCRIPTION
This RP mainly improves the compatibility of redis proxy, improvement as follows:

* Add support for the select command, referring to the implementation of Apache KVRocks and Microsoft Garnet, simply returns OK.
* Add keys command support, send keys commands to each shard on the backend, and then merge the results.
* For unsupport commands, the return value is the same as Redis, because some clients judge this return value, for example, [Java lettuce client](https://github.com/redis/lettuce/blob/14de5b88f922581f996c3b3311cb253eb36b32db/src/main/java/io/lettuce/core/RedisHandshake.java#L328)