### PR TITLE
check OptRef has_value before dereferencing

### DIFF
--- a/source/extensions/filters/http/basic_auth/basic_auth_filter.cc
+++ b/source/extensions/filters/http/basic_auth/basic_auth_filter.cc
@@ -110,8 +110,9 @@ Http::FilterHeadersStatus BasicAuthFilter::onDenied(absl::string_view body,
   decoder_callbacks_->sendLocalReply(
       Http::Code::Unauthorized, body,
       [this](Http::ResponseHeaderMap& headers) {
+        // requestHeaders should always be non-null at this point since onDenied is only called by
+        // decodeHeaders.
         const auto request_headers = this->decoder_callbacks_->requestHeaders();
-        RELEASE_ASSERT(request_headers.has_value(), "request_headers has no value.");
         const std::string uri = Http::Utility::buildOriginalUri(*request_headers, MaximumUriLength);
         const std::string value = absl::StrCat("Basic realm=\"", uri, "\"");
         headers.setReferenceKey(Http::Headers::get().WWWAuthenticate, value);

--- a/source/extensions/filters/http/basic_auth/basic_auth_filter.cc
+++ b/source/extensions/filters/http/basic_auth/basic_auth_filter.cc
@@ -111,10 +111,8 @@ Http::FilterHeadersStatus BasicAuthFilter::onDenied(absl::string_view body,
       Http::Code::Unauthorized, body,
       [this](Http::ResponseHeaderMap& headers) {
         const auto request_headers = this->decoder_callbacks_->requestHeaders();
-        const std::string uri =
-            request_headers.has_value()
-                ? Http::Utility::buildOriginalUri(*request_headers, MaximumUriLength)
-                : "";
+        RELEASE_ASSERT(request_headers.has_value(), "request_headers has no value.");
+        const std::string uri = Http::Utility::buildOriginalUri(*request_headers, MaximumUriLength);
         const std::string value = absl::StrCat("Basic realm=\"", uri, "\"");
         headers.setReferenceKey(Http::Headers::get().WWWAuthenticate, value);
       },

--- a/source/extensions/filters/http/basic_auth/basic_auth_filter.cc
+++ b/source/extensions/filters/http/basic_auth/basic_auth_filter.cc
@@ -111,7 +111,10 @@ Http::FilterHeadersStatus BasicAuthFilter::onDenied(absl::string_view body,
       Http::Code::Unauthorized, body,
       [this](Http::ResponseHeaderMap& headers) {
         const auto request_headers = this->decoder_callbacks_->requestHeaders();
-        const std::string uri = Http::Utility::buildOriginalUri(*request_headers, MaximumUriLength);
+        const std::string uri =
+            request_headers.has_value()
+                ? Http::Utility::buildOriginalUri(*request_headers, MaximumUriLength)
+                : "";
         const std::string value = absl::StrCat("Basic realm=\"", uri, "\"");
         headers.setReferenceKey(Http::Headers::get().WWWAuthenticate, value);
       },

--- a/test/extensions/filters/http/common/fuzz/filter_corpus/build_original_uri
+++ b/test/extensions/filters/http/common/fuzz/filter_corpus/build_original_uri
@@ -1,0 +1,7 @@
+config {
+  name: "envoy.filters.http.basic_auth"
+  typed_config {
+    type_url: "type.googleapis.com/envoy.extensions.filters.http.basic_auth.v3.BasicAuth"
+    value: "\n\003\022\001#"
+  }
+}


### PR DESCRIPTION
Commit Message: check OptRef has_value before dereferencing
Additional Description:

In the BasicAuthFilter there's a spot where an OptRef (`request_headers`) is dereferenced without checking `has_value` first. This is unlikely to cause production issues as that would require `decoder_callbacks_->requestHeaders()` to be unset. This does, however, crash the `filter_fuzz_test` since the mock callbacks object does not override that function call.

Risk Level: none
Testing: fuzz test fix
Docs Changes: none
Release Notes: none
Platform Specific Features: none