### PR TITLE
Remove matcher input type allowlist from Composite filter

### DIFF
--- a/source/extensions/filters/http/composite/config.h
+++ b/source/extensions/filters/http/composite/config.h
@@ -30,11 +30,6 @@ public:
       const envoy::extensions::filters::http::composite::v3::Composite& proto_config,
       const std::string& stats_prefix, DualInfo dual_info,
       Server::Configuration::ServerFactoryContext& context) override;
-
-  Server::Configuration::MatchingRequirementsPtr matchingRequirements() override {
-    return std::make_unique<
-        envoy::extensions::filters::common::dependency::v3::MatchingRequirements>();
-  }
 };
 
 using UpstreamCompositeFilterFactory = CompositeFilterFactory;

--- a/source/extensions/filters/http/composite/config.h
+++ b/source/extensions/filters/http/composite/config.h
@@ -32,20 +32,8 @@ public:
       Server::Configuration::ServerFactoryContext& context) override;
 
   Server::Configuration::MatchingRequirementsPtr matchingRequirements() override {
-    auto requirements = std::make_unique<
+    return std::make_unique<
         envoy::extensions::filters::common::dependency::v3::MatchingRequirements>();
-
-    // This ensure that trees are only allowed to match on request headers, avoiding configurations
-    // where the matcher requires data that will be available too late for the delegation to work
-    // correctly.
-    auto* allow_list = requirements->mutable_data_input_allow_list();
-    allow_list->add_type_url(TypeUtil::descriptorFullNameToTypeUrl(
-        envoy::type::matcher::v3::HttpRequestHeaderMatchInput::descriptor()->full_name()));
-    // CEL matcher and its input is also allowed.
-    allow_list->add_type_url(TypeUtil::descriptorFullNameToTypeUrl(
-        xds::type::matcher::v3::HttpAttributesCelMatchInput::descriptor()->full_name()));
-
-    return requirements;
   }
 };
 


### PR DESCRIPTION
This PR removes the type requirements that restrict the allowed input matchers on the Composite filter. Having these requirements checked in OSS code prevents users of Envoy from extending and customizing this extension point.

Risk Level: low
Testing: Via running existing tests
Fixes #37710