### PR TITLE
rate limit config: use warn and pow2 for invalid hits addend

### DIFF
--- a/source/extensions/filters/common/ratelimit_config/ratelimit_config.cc
+++ b/source/extensions/filters/common/ratelimit_config/ratelimit_config.cc
@@ -167,7 +167,7 @@ void RateLimitPolicy::populateDescriptors(const Http::RequestHeaderMap& headers,
     if (success) {
       descriptor.hits_addend_ = static_cast<uint64_t>(hits_addend);
     } else {
-      ENVOY_LOG(debug, "Invalid hits_addend: {}", hits_addend_value.DebugString());
+      ENVOY_LOG_EVERY_POW_2(warn, "Invalid hits_addend: {}", hits_addend_value.DebugString());
       return;
     }
 


### PR DESCRIPTION
Commit Message: rate limit config: use warn and pow2 for invalid hits addend
Additional Description:

To simplify debugging.

Risk Level: low.
Testing: n/a.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.