### PR TITLE
Revert "jwt_authn: Add logic to refetch JWT on KID mismatch (#36458)"

### DIFF
--- a/api/envoy/extensions/filters/http/jwt_authn/v3/config.proto
+++ b/api/envoy/extensions/filters/http/jwt_authn/v3/config.proto
@@ -383,7 +383,6 @@ message JwtCacheConfig {
 }
 
 // This message specifies how to fetch JWKS from remote and how to cache it.
-// [#next-free-field: 6]
 message RemoteJwks {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.http.jwt_authn.v2alpha.RemoteJwks";
@@ -453,24 +452,6 @@ message RemoteJwks {
   //
   //
   config.core.v3.RetryPolicy retry_policy = 4;
-
-  // Refetch JWKS if extracted JWT has no KID or a KID that does not match any cached JWKS's KID.
-  //
-  //
-  // In envoy, if :ref:`async JWKS fetching <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.RemoteJwks.async_fetch>`
-  // is enabled along with this field, then KID mismatch will trigger a new async fetch after appropriate backoff delay.
-  //
-  //
-  // If async fetching is disabled, new JWKS is fetched on demand and the cache is isolated to the fetched worker thread.
-  //
-  // There is exponential backoff built into this retrieval system for two cases to avoid DoS on JWKS Server:
-  //
-  // * If there is a request containing a JWT with no KID, a new fetch will be made for this request. Upon retrieval,
-  //   a backoff will be triggered.
-  // * If there is a fetch due to KID mismatch, which results in a failed fetch or verification, a backoff will be triggered.
-  //
-  // During a backoff, no further fetches will be made due to KID mismatch.
-  bool refetch_jwks_on_kid_mismatch = 5;
 }
 
 // Fetch Jwks asynchronously in the main thread when the filter config is parsed.

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -342,11 +342,6 @@ new_features:
   change: |
     Added :ref:`attribute <arch_overview_attributes>` ``upstream.cx_pool_ready_duration``
     to get the duration from when the upstream request was created to when the upstream connection pool is ready.
-- area: jwt_authn
-  change: |
-    Added  :ref:`refetch_jwks_on_kid_mismatch
-    <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.RemoteJwks.refetch_jwks_on_kid_mismatch>`
-    to allow filter to refetch JWKS when extracted JWT's KID does not match cached JWKS's KID.
 - area: health_check
   change: |
     Added new health check filter stats including total requests, successful/failed checks, cached responses, and

--- a/source/extensions/filters/http/jwt_authn/BUILD
+++ b/source/extensions/filters/http/jwt_authn/BUILD
@@ -55,7 +55,6 @@ envoy_cc_library(
         "jwks_async_fetcher_lib",
         ":jwt_cache_lib",
         "//source/common/config:datasource_lib",
-        "//source/common/config:utility_lib",
         "@com_github_google_jwt_verify//:jwt_verify_lib",
         "@envoy_api//envoy/extensions/filters/http/jwt_authn/v3:pkg_cc_proto",
     ],

--- a/source/extensions/filters/http/jwt_authn/authenticator.cc
+++ b/source/extensions/filters/http/jwt_authn/authenticator.cc
@@ -51,12 +51,11 @@ public:
                     const absl::optional<std::string>& provider, bool allow_failed,
                     bool allow_missing, JwksCache& jwks_cache,
                     Upstream::ClusterManager& cluster_manager,
-                    CreateJwksFetcherCb create_jwks_fetcher_cb, TimeSource& time_source,
-                    Event::Dispatcher& dispatcher)
+                    CreateJwksFetcherCb create_jwks_fetcher_cb, TimeSource& time_source)
       : jwks_cache_(jwks_cache), cm_(cluster_manager),
         create_jwks_fetcher_cb_(create_jwks_fetcher_cb), check_audience_(check_audience),
         provider_(provider), is_allow_failed_(allow_failed), is_allow_missing_(allow_missing),
-        time_source_(time_source), dispatcher_(dispatcher) {}
+        time_source_(time_source) {}
   // Following functions are for JwksFetcher::JwksReceiver interface
   void onJwksSuccess(google::jwt_verify::JwksPtr&& jwks) override;
   void onJwksError(Failure reason) override;
@@ -131,9 +130,6 @@ private:
   const bool is_allow_missing_;
   TimeSource& time_source_;
   ::google::jwt_verify::Jwt* jwt_{};
-  Event::Dispatcher& dispatcher_;
-  // Set to true if the JWT in this request caused a KID mismatch.
-  bool kid_mismatch_request_{false};
 };
 
 std::string AuthenticatorImpl::name() const {
@@ -272,24 +268,16 @@ void AuthenticatorImpl::startVerify() {
 
   auto jwks_obj = jwks_data_->getJwksObj();
   if (jwks_obj != nullptr && !jwks_data_->isExpired()) {
-    // If KID mismatch fetching is set and fetch is disallowed, trigger the
-    // verification process.
-    if (jwks_data_->getJwtProvider().remote_jwks().refetch_jwks_on_kid_mismatch() &&
-        jwks_data_->isRemoteJwksFetchAllowed()) {
-      if (!jwt_->kid_.empty()) {
-        for (const auto& jwk : jwks_obj->keys()) {
-          if (jwk->kid_ == jwt_->kid_) {
-            verifyKey();
-            return;
-          }
-        }
-      }
-      ENVOY_LOG(info, "Triggering refetch of JWKS due to KID mismatch");
-      kid_mismatch_request_ = true;
-    } else {
-      verifyKey();
-      return;
-    }
+    // TODO(qiwzhang): It would seem there's a window of error whereby if the JWT issuer
+    // has started signing with a new key that's not in our cache, then the
+    // verification will fail even though the JWT is valid. A simple fix
+    // would be to check the JWS kid header field; if present check we have
+    // the key cached, if we do proceed to verify else try a new JWKS retrieval.
+    // JWTs without a kid header field in the JWS we might be best to get each
+    // time? This all only matters for remote JWKS.
+
+    verifyKey();
+    return;
   }
 
   // TODO(potatop): potential optimization.
@@ -302,10 +290,6 @@ void AuthenticatorImpl::startVerify() {
       fetcher_ = create_jwks_fetcher_cb_(cm_, jwks_data_->getJwtProvider().remote_jwks());
     }
     fetcher_->fetch(*parent_span_, *this);
-    // Disallow fetches across other worker threads due to in-flight fetch.
-    if (kid_mismatch_request_) {
-      dispatcher_.post([this]() { jwks_data_->allowRemoteJwksFetch(absl::nullopt, true); });
-    }
     return;
   }
   // No valid keys for this issuer. This may happen as a result of incorrect local
@@ -315,14 +299,7 @@ void AuthenticatorImpl::startVerify() {
 
 void AuthenticatorImpl::onJwksSuccess(google::jwt_verify::JwksPtr&& jwks) {
   jwks_cache_.stats().jwks_fetch_success_.inc();
-
-  const Status status =
-      jwks_data_
-          ->setRemoteJwks(std::move(jwks),
-                          jwks_data_->getJwtProvider().remote_jwks().has_async_fetch() &&
-                              kid_mismatch_request_)
-          ->getStatus();
-
+  const Status status = jwks_data_->setRemoteJwks(std::move(jwks))->getStatus();
   if (status != Status::Ok) {
     doneWithStatus(status);
   } else {
@@ -442,15 +419,6 @@ void AuthenticatorImpl::handleGoodJwt(bool cache_hit) {
     // move the ownership of "owned_jwt_" into the function.
     jwks_data_->getJwtCache().insert(curr_token_->token(), std::move(owned_jwt_));
   }
-
-  // On successful retrieval & verification of JWKS due to KID mismatch,
-  //  - If retrieved due to KID being empty, trigger backoff.
-  //  - Else, shut down backoff.
-  if (kid_mismatch_request_ && !jwks_data_->isRemoteJwksFetchAllowed()) {
-    dispatcher_.post([this]() { jwks_data_->allowRemoteJwksFetch(!jwt_->kid_.empty(), false); });
-    kid_mismatch_request_ = false;
-  }
-
   doneWithStatus(Status::Ok);
 }
 
@@ -482,13 +450,6 @@ void AuthenticatorImpl::doneWithStatus(const Status& status) {
   if (Status::Ok != status) {
     // Forward the failed status to dynamic metadata
     ENVOY_LOG(debug, "status is: {}", ::google::jwt_verify::getStatusString(status));
-
-    // Trigger backoff to disallow further fetches when retrieval & verification is due to KID
-    // mismatch and fails.
-    if (kid_mismatch_request_ && !jwks_data_->isRemoteJwksFetchAllowed()) {
-      dispatcher_.post([this]() { jwks_data_->allowRemoteJwksFetch(false, false); });
-      kid_mismatch_request_ = false;
-    }
 
     std::string failed_status_in_metadata;
 
@@ -546,10 +507,10 @@ AuthenticatorPtr Authenticator::create(const CheckAudience* check_audience,
                                        bool allow_failed, bool allow_missing, JwksCache& jwks_cache,
                                        Upstream::ClusterManager& cluster_manager,
                                        CreateJwksFetcherCb create_jwks_fetcher_cb,
-                                       TimeSource& time_source, Event::Dispatcher& dispatcher) {
+                                       TimeSource& time_source) {
   return std::make_unique<AuthenticatorImpl>(check_audience, provider, allow_failed, allow_missing,
                                              jwks_cache, cluster_manager, create_jwks_fetcher_cb,
-                                             time_source, dispatcher);
+                                             time_source);
 }
 
 } // namespace JwtAuthn

--- a/source/extensions/filters/http/jwt_authn/authenticator.h
+++ b/source/extensions/filters/http/jwt_authn/authenticator.h
@@ -47,7 +47,7 @@ public:
                                  bool allow_missing, JwksCache& jwks_cache,
                                  Upstream::ClusterManager& cluster_manager,
                                  CreateJwksFetcherCb create_jwks_fetcher_cb,
-                                 TimeSource& time_source, Event::Dispatcher& dispatcher);
+                                 TimeSource& time_source);
 };
 
 /**

--- a/source/extensions/filters/http/jwt_authn/filter_config.cc
+++ b/source/extensions/filters/http/jwt_authn/filter_config.cc
@@ -18,8 +18,7 @@ FilterConfigImpl::FilterConfigImpl(
     const std::string& stats_prefix, Server::Configuration::FactoryContext& context)
     : proto_config_(std::move(proto_config)), stats_(generateStats(stats_prefix, context.scope())),
       cm_(context.serverFactoryContext().clusterManager()),
-      time_source_(context.serverFactoryContext().mainThreadDispatcher().timeSource()),
-      dispatcher_(context.serverFactoryContext().mainThreadDispatcher()) {
+      time_source_(context.serverFactoryContext().mainThreadDispatcher().timeSource()) {
 
   ENVOY_LOG(debug, "Loaded JwtAuthConfig: {}", proto_config_.DebugString());
 

--- a/source/extensions/filters/http/jwt_authn/filter_config.h
+++ b/source/extensions/filters/http/jwt_authn/filter_config.h
@@ -76,8 +76,6 @@ public:
   Upstream::ClusterManager& cm() const { return cm_; }
   TimeSource& timeSource() const { return time_source_; }
 
-  Event::Dispatcher& dispatcher() const { return dispatcher_; }
-
   // FilterConfig
 
   JwtAuthnFilterStats& stats() override { return stats_; }
@@ -114,8 +112,7 @@ public:
                           const absl::optional<std::string>& provider, bool allow_failed,
                           bool allow_missing) const override {
     return Authenticator::create(check_audience, provider, allow_failed, allow_missing,
-                                 getJwksCache(), cm(), Common::JwksFetcher::create, timeSource(),
-                                 dispatcher());
+                                 getJwksCache(), cm(), Common::JwksFetcher::create, timeSource());
   }
 
 private:
@@ -150,7 +147,6 @@ private:
   // all requirement_names for debug
   std::string all_requirement_names_;
   TimeSource& time_source_;
-  Event::Dispatcher& dispatcher_;
 };
 
 } // namespace JwtAuthn

--- a/source/extensions/filters/http/jwt_authn/jwks_async_fetcher.h
+++ b/source/extensions/filters/http/jwt_authn/jwks_async_fetcher.h
@@ -25,10 +25,6 @@ using CreateJwksFetcherCb = std::function<Common::JwksFetcherPtr(
  */
 using JwksDoneFetched = std::function<void(google::jwt_verify::JwksPtr&& jwks)>;
 
-using isRemoteJwksFetchAllowedCb = std::function<bool(void)>;
-
-using allowRemoteJwksFetchCb = std::function<void(absl::optional<bool>, bool)>;
-
 // This class handles fetching Jwks asynchronously.
 // It will be no-op if async_fetch is not enabled.
 // At its constructor, it will start to fetch Jwks, register with init_manager if not fast_listener.
@@ -39,16 +35,11 @@ class JwksAsyncFetcher : public Logger::Loggable<Logger::Id::jwt>,
 public:
   JwksAsyncFetcher(const envoy::extensions::filters::http::jwt_authn::v3::RemoteJwks& remote_jwks,
                    Server::Configuration::FactoryContext& context, CreateJwksFetcherCb fetcher_fn,
-                   JwtAuthnFilterStats& stats, JwksDoneFetched done_fn,
-                   isRemoteJwksFetchAllowedCb is_fetch_allowed_fn,
-                   allowRemoteJwksFetchCb allow_fetch_fn);
+                   JwtAuthnFilterStats& stats, JwksDoneFetched done_fn);
 
   // Get the remote Jwks cache duration.
   static std::chrono::seconds
   getCacheDuration(const envoy::extensions::filters::http::jwt_authn::v3::RemoteJwks& remote_jwks);
-
-  // Reset async fetch timer to default value.
-  void resetFetchTimer();
 
 private:
   // Fetch the Jwks
@@ -83,10 +74,6 @@ private:
 
   // The init target.
   std::unique_ptr<Init::TargetImpl> init_target_;
-
-  const isRemoteJwksFetchAllowedCb is_fetch_allowed_fn_;
-
-  const allowRemoteJwksFetchCb allow_fetch_fn_;
 
   // Used in logs.
   const std::string debug_name_;

--- a/source/extensions/filters/http/jwt_authn/jwks_cache.cc
+++ b/source/extensions/filters/http/jwt_authn/jwks_cache.cc
@@ -29,27 +29,12 @@ namespace HttpFilters {
 namespace JwtAuthn {
 namespace {
 
-static constexpr uint32_t RetryInitialDelayMilliseconds = 1000;
-static constexpr uint32_t RetryMaxDelayMilliseconds = 30000;
-
 class JwksDataImpl : public JwksCache::JwksData, public Logger::Loggable<Logger::Id::jwt> {
 public:
   JwksDataImpl(const JwtProvider& jwt_provider, Server::Configuration::FactoryContext& context,
                CreateJwksFetcherCb fetcher_cb, JwtAuthnFilterStats& stats)
       : jwt_provider_(jwt_provider), time_source_(context.serverFactoryContext().timeSource()),
-        tls_(context.serverFactoryContext().threadLocal()),
-        random_(context.serverFactoryContext().api().randomGenerator()),
-        dispatcher_(context.serverFactoryContext().mainThreadDispatcher()) {
-
-    remote_fetch_backoff_strategy_ = std::make_unique<JitteredExponentialBackOffStrategy>(
-        RetryInitialDelayMilliseconds, RetryMaxDelayMilliseconds, random_);
-
-    remote_fetch_disallow_timer_ =
-        context.serverFactoryContext().mainThreadDispatcher().createTimer([this]() -> void {
-          tls_.runOnAllThreads(
-              [](OptRef<ThreadLocalCache> obj) { obj->is_backoff_enabled_ = false; });
-          ENVOY_LOG(debug, "JWKS fetch backoff completed. Fetching can resume.");
-        });
+        tls_(context.serverFactoryContext().threadLocal()) {
 
     if (jwt_provider_.has_remote_jwks()) {
       // remote_jwks.retry_policy has an invalid case that could not be validated by the
@@ -94,8 +79,7 @@ public:
     bool enable_jwt_cache = jwt_provider_.has_jwt_cache_config();
     const auto& config = jwt_provider_.jwt_cache_config();
     tls_.set([enable_jwt_cache, config](Envoy::Event::Dispatcher& dispatcher) {
-      return std::make_shared<ThreadLocalCache>(enable_jwt_cache, config, dispatcher.timeSource(),
-                                                false, false);
+      return std::make_shared<ThreadLocalCache>(enable_jwt_cache, config, dispatcher.timeSource());
     });
 
     const auto inline_jwks =
@@ -116,11 +100,7 @@ public:
       if (jwt_provider_.has_remote_jwks()) {
         async_fetcher_ = std::make_unique<JwksAsyncFetcher>(
             jwt_provider_.remote_jwks(), context, fetcher_cb, stats,
-            [this](google::jwt_verify::JwksPtr&& jwks) { setJwksToAllThreads(std::move(jwks)); },
-            [this]() -> bool { return isRemoteJwksFetchAllowed(); },
-            [this](absl::optional<bool> stop_backoff, bool fetch_in_flight) {
-              allowRemoteJwksFetch(stop_backoff, fetch_in_flight);
-            });
+            [this](google::jwt_verify::JwksPtr&& jwks) { setJwksToAllThreads(std::move(jwks)); });
       }
     }
   }
@@ -164,60 +144,23 @@ public:
 
   bool isExpired() const override { return time_source_.monotonicTime() >= tls_->expire_; }
 
-  const ::google::jwt_verify::Jwks* setRemoteJwks(JwksConstPtr&& jwks,
-                                                  bool update_all_threads) override {
+  const ::google::jwt_verify::Jwks* setRemoteJwks(JwksConstPtr&& jwks) override {
+    // convert unique_ptr to shared_ptr
     JwksConstSharedPtr shared_jwks = std::move(jwks);
     tls_->jwks_ = shared_jwks;
     tls_->expire_ = time_source_.monotonicTime() +
                     JwksAsyncFetcher::getCacheDuration(jwt_provider_.remote_jwks());
-
-    if (update_all_threads) {
-      dispatcher_.post([this, jwks = shared_jwks]() mutable { setJwksToAllThreads(jwks); });
-    }
-
     return shared_jwks.get();
   }
 
   JwtCache& getJwtCache() override { return *tls_->jwt_cache_; }
 
-  bool isRemoteJwksFetchAllowed() override {
-    if (!jwt_provider_.has_remote_jwks() &&
-        !jwt_provider_.remote_jwks().refetch_jwks_on_kid_mismatch()) {
-      return true;
-    }
-    return !(tls_->fetch_in_flight_ || tls_->is_backoff_enabled_);
-  }
-
-  void allowRemoteJwksFetch(absl::optional<bool> stop_backoff, bool fetch_in_flight) override {
-    ASSERT(dispatcher_.isThreadSafe());
-
-    if (stop_backoff.has_value()) {
-      tls_.runOnAllThreads([stop_backoff, fetch_in_flight](OptRef<ThreadLocalCache> obj) {
-        obj->is_backoff_enabled_ = stop_backoff.value();
-        obj->fetch_in_flight_ = fetch_in_flight;
-      });
-      if (stop_backoff.value()) {
-        remote_fetch_disallow_timer_->disableTimer();
-        remote_fetch_backoff_strategy_->reset();
-      } else {
-        remote_fetch_disallow_timer_->enableTimer(
-            std::chrono::milliseconds(remote_fetch_backoff_strategy_->nextBackOffMs()));
-        ENVOY_LOG(debug, "JWKS fetch backoff triggered due to fetch/verification failure.");
-      }
-    } else {
-      tls_.runOnAllThreads([fetch_in_flight](OptRef<ThreadLocalCache> obj) {
-        obj->fetch_in_flight_ = fetch_in_flight;
-      });
-    }
-  }
-
 private:
   struct ThreadLocalCache : public ThreadLocal::ThreadLocalObject {
     ThreadLocalCache(bool enable_jwt_cache,
                      const envoy::extensions::filters::http::jwt_authn::v3::JwtCacheConfig& config,
-                     TimeSource& time_source, bool fetch_in_flight, bool backoff_enabled)
-        : jwt_cache_(JwtCache::create(enable_jwt_cache, config, time_source)),
-          fetch_in_flight_(fetch_in_flight), is_backoff_enabled_(backoff_enabled) {}
+                     TimeSource& time_source)
+        : jwt_cache_(JwtCache::create(enable_jwt_cache, config, time_source)) {}
 
     // The jwks object.
     JwksConstSharedPtr jwks_;
@@ -225,13 +168,11 @@ private:
     const JwtCachePtr jwt_cache_;
     // The pubkey expiration time.
     MonotonicTime expire_;
-
-    bool fetch_in_flight_;
-    bool is_backoff_enabled_;
   };
 
   // Set jwks shared_ptr to all threads.
-  void setJwksToAllThreads(JwksConstSharedPtr shared_jwks) {
+  void setJwksToAllThreads(JwksConstPtr&& jwks) {
+    JwksConstSharedPtr shared_jwks = std::move(jwks);
     tls_.runOnAllThreads([shared_jwks](OptRef<ThreadLocalCache> obj) {
       obj->jwks_ = shared_jwks;
       obj->expire_ = std::chrono::steady_clock::time_point::max();
@@ -250,13 +191,6 @@ private:
   JwksAsyncFetcherPtr async_fetcher_;
   absl::optional<Matchers::StringMatcherImpl<envoy::type::matcher::v3::StringMatcher>> sub_matcher_;
   absl::optional<absl::Duration> max_exp_;
-
-  // For exponential backoff, when fetch/verify fails on KID mismatch.
-  Random::RandomGenerator& random_;
-  JitteredExponentialBackOffStrategyPtr remote_fetch_backoff_strategy_;
-  Event::TimerPtr remote_fetch_disallow_timer_;
-
-  Event::Dispatcher& dispatcher_;
 };
 
 using JwksDataImplPtr = std::unique_ptr<JwksDataImpl>;

--- a/source/extensions/filters/http/jwt_authn/jwks_cache.h
+++ b/source/extensions/filters/http/jwt_authn/jwks_cache.h
@@ -4,11 +4,9 @@
 
 #include "envoy/api/api.h"
 #include "envoy/common/pure.h"
-#include "envoy/common/random_generator.h"
 #include "envoy/common/time.h"
 #include "envoy/extensions/filters/http/jwt_authn/v3/config.pb.h"
 
-#include "source/common/config/utility.h"
 #include "source/extensions/filters/http/common/jwks_fetcher.h"
 #include "source/extensions/filters/http/jwt_authn/jwks_async_fetcher.h"
 #include "source/extensions/filters/http/jwt_authn/jwt_cache.h"
@@ -75,18 +73,10 @@ public:
     virtual bool isExpired() const PURE;
 
     // Set a remote Jwks.
-    virtual const ::google::jwt_verify::Jwks* setRemoteJwks(JwksConstPtr&& jwks,
-                                                            bool update_all_threads) PURE;
+    virtual const ::google::jwt_verify::Jwks* setRemoteJwks(JwksConstPtr&& jwks) PURE;
 
     // Get Token Cache.
     virtual JwtCache& getJwtCache() PURE;
-
-    // Return true if fetch is allowed.
-    virtual bool isRemoteJwksFetchAllowed() PURE;
-
-    // Update to allow fetches.
-    virtual void allowRemoteJwksFetch(absl::optional<bool> fetch_succeeded,
-                                      bool fetch_in_flight) PURE;
   };
 
   // If there is only one provider in the config, return the data for that provider.

--- a/test/extensions/filters/http/jwt_authn/authenticator_test.cc
+++ b/test/extensions/filters/http/jwt_authn/authenticator_test.cc
@@ -53,7 +53,7 @@ public:
         check_audience, provider, allow_failed, allow_missing, filter_config_->getJwksCache(),
         filter_config_->cm(),
         [this](Upstream::ClusterManager&, const RemoteJwks&) { return std::move(fetcher_); },
-        filter_config_->timeSource(), filter_config_->dispatcher());
+        filter_config_->timeSource());
     jwks_ = Jwks::createFrom(PublicKey, Jwks::JWKS);
     EXPECT_TRUE(jwks_->getStatus() == Status::Ok);
   }
@@ -176,124 +176,6 @@ TEST_F(AuthenticatorTest, TestOkJWTandCache) {
 
   EXPECT_EQ(1U, filter_config_->stats().jwks_fetch_success_.value());
   EXPECT_EQ(0U, filter_config_->stats().jwks_fetch_failed_.value());
-}
-
-// Test to validate refetching JWKS when KID of JWT to be verified
-// does not match cached JWKS's KID. `PublicKey` contains KID 1 and 2,
-// which will validate both `GoodTokenWithKid1` and `GoodTokenWithKid2`,
-// but will fail `GoodTokenWithKid3` which will trigger a JWKS refetch.
-TEST_F(AuthenticatorTest, TestRefetchingJwksWithMultipleKidJwks) {
-  (*proto_config_.mutable_providers())[std::string(ProviderName)]
-      .mutable_remote_jwks()
-      ->set_refetch_jwks_on_kid_mismatch(true);
-  createAuthenticator();
-
-  // JWT signed by KID1. Authenticator fetches the first JWKS, PublicKey that contains both KID1
-  // and KID2.
-  EXPECT_CALL(*raw_fetcher_, fetch(_, _))
-      .WillOnce(Invoke([this](Tracing::Span&, JwksFetcher::JwksReceiver& receiver) {
-        receiver.onJwksSuccess(std::move(jwks_));
-      }));
-  Http::TestRequestHeaderMapImpl headers{
-      {"Authorization", "Bearer " + std::string(GoodTokenWithKid1)}};
-  expectVerifyStatus(Status::Ok, headers);
-  jwks_ = Jwks::createFrom(PublicKey, Jwks::JWKS);
-
-  // JWT signed by KID2. Since cached JWKS already contains KID2, no refetching would be done.
-  EXPECT_CALL(*raw_fetcher_, fetch(_, _)).Times(0);
-  headers =
-      Http::TestRequestHeaderMapImpl{{"Authorization", "Bearer " + std::string(GoodTokenWithKid2)}};
-  expectVerifyStatus(Status::Ok, headers);
-
-  // JWT signed by KID3. Since cached JWKS doesn't contain KID3, refetching would be done.
-  EXPECT_CALL(*raw_fetcher_, fetch(_, _))
-      .WillOnce(Invoke([this](Tracing::Span&, JwksFetcher::JwksReceiver& receiver) {
-        receiver.onJwksSuccess(std::move(jwks_));
-      }));
-  headers =
-      Http::TestRequestHeaderMapImpl{{"Authorization", "Bearer " + std::string(GoodTokenWithKid3)}};
-  expectVerifyStatus(Status::JwtVerificationFail, headers);
-}
-
-// Test to validate refetching JWKS and backoff when `PublicKey` is split based on KIDs
-TEST_F(AuthenticatorTest, TestRefetchingJwksAndBackoffWithSingleKidJwks) {
-  (*proto_config_.mutable_providers())[std::string(ProviderName)]
-      .mutable_remote_jwks()
-      ->set_refetch_jwks_on_kid_mismatch(true);
-  createAuthenticator();
-
-  // JWT signed by KID1. Authenticator fetches the first JWKS, PublicKey1 that contains KID1.
-  jwks_ = Jwks::createFrom(PublicKey1, Jwks::JWKS);
-  EXPECT_CALL(*raw_fetcher_, fetch(_, _))
-      .WillOnce(Invoke([this](Tracing::Span&, JwksFetcher::JwksReceiver& receiver) {
-        receiver.onJwksSuccess(std::move(jwks_));
-      }));
-  Http::TestRequestHeaderMapImpl headers{
-      {"Authorization", "Bearer " + std::string(GoodTokenWithKid1)}};
-  expectVerifyStatus(Status::Ok, headers);
-
-  // JWT signed by KID2. Authenticator refetches the current JWKS, PublicKey1 that fails target JWT.
-  jwks_ = Jwks::createFrom(PublicKey1, Jwks::JWKS);
-  EXPECT_CALL(*raw_fetcher_, fetch(_, _))
-      .WillOnce(Invoke([this](Tracing::Span&, JwksFetcher::JwksReceiver& receiver) {
-        receiver.onJwksSuccess(std::move(jwks_));
-      }));
-  headers =
-      Http::TestRequestHeaderMapImpl{{"Authorization", "Bearer " + std::string(GoodTokenWithKid2)}};
-  expectVerifyStatus(Status::JwksKidAlgMismatch, headers);
-
-  // Backoff triggered due to previous failed JWKS validation causing no fetch.
-  jwks_ = Jwks::createFrom(PublicKey2, Jwks::JWKS);
-  EXPECT_CALL(*raw_fetcher_, fetch(_, _)).Times(0);
-  headers =
-      Http::TestRequestHeaderMapImpl{{"Authorization", "Bearer " + std::string(GoodTokenWithKid2)}};
-  expectVerifyStatus(Status::JwksKidAlgMismatch, headers);
-
-  // Successful JWKS validation to end backoff.
-  headers =
-      Http::TestRequestHeaderMapImpl{{"Authorization", "Bearer " + std::string(GoodTokenWithKid1)}};
-  expectVerifyStatus(Status::Ok, headers);
-
-  // Attempt refetching KID2 due to backoff completion.
-  EXPECT_CALL(*raw_fetcher_, fetch(_, _))
-      .WillOnce(Invoke([this](Tracing::Span&, JwksFetcher::JwksReceiver& receiver) {
-        receiver.onJwksSuccess(std::move(jwks_));
-      }));
-  headers =
-      Http::TestRequestHeaderMapImpl{{"Authorization", "Bearer " + std::string(GoodTokenWithKid2)}};
-  expectVerifyStatus(Status::Ok, headers);
-}
-
-// Test to validate refetching JWKS and backoff when JWT contains no KID.
-TEST_F(AuthenticatorTest, TestRefetchingJwksAndBackoffWithNoKidJwt) {
-  (*proto_config_.mutable_providers())[std::string(ProviderName)]
-      .mutable_remote_jwks()
-      ->set_refetch_jwks_on_kid_mismatch(true);
-  createAuthenticator();
-
-  jwks_ = Jwks::createFrom(PublicKey1, Jwks::JWKS);
-  EXPECT_CALL(*raw_fetcher_, fetch(_, _))
-      .WillOnce(Invoke([this](Tracing::Span&, JwksFetcher::JwksReceiver& receiver) {
-        receiver.onJwksSuccess(std::move(jwks_));
-      }));
-  Http::TestRequestHeaderMapImpl headers{
-      {"Authorization", "Bearer " + std::string(GoodToken)}}; // Has No KID
-  expectVerifyStatus(Status::Ok, headers);
-  jwks_ = Jwks::createFrom(PublicKey2, Jwks::JWKS);
-
-  // Test with JWT that has no KID, which would trigger a refetch.
-  EXPECT_CALL(*raw_fetcher_, fetch(_, _))
-      .WillOnce(Invoke([this](Tracing::Span&, JwksFetcher::JwksReceiver& receiver) {
-        receiver.onJwksSuccess(std::move(jwks_));
-      }));
-  headers = Http::TestRequestHeaderMapImpl{{"Authorization", "Bearer " + std::string(GoodToken)}};
-  expectVerifyStatus(Status::Ok, headers);
-
-  // Backoff triggered, hence no fetch.
-  EXPECT_CALL(*raw_fetcher_, fetch(_, _)).Times(0);
-  headers = Http::TestRequestHeaderMapImpl{{"Authorization", "Bearer " + std::string(GoodToken)}};
-  // Verification done against existing JWKS cache due to active backoff.
-  expectVerifyStatus(Status::Ok, headers);
 }
 
 TEST_F(AuthenticatorTest, TestCompletePaddingInJwtPayload) {
@@ -1212,7 +1094,7 @@ public:
 
   void createAuthenticator(const absl::optional<std::string>& provider) {
     auth_ = Authenticator::create(nullptr, provider, false, false, jwks_cache_, cm_,
-                                  mock_fetcher_.AsStdFunction(), time_system_, dispatcher_);
+                                  mock_fetcher_.AsStdFunction(), time_system_);
   }
 
   void expectVerifyStatus(Status expected_status, Http::RequestHeaderMap& headers) {
@@ -1239,7 +1121,6 @@ public:
   NiceMock<Tracing::MockSpan> parent_span_;
   std::string out_name_;
   ProtobufWkt::Struct out_extracted_data_;
-  Event::MockDispatcher dispatcher_;
 };
 
 TEST_F(AuthenticatorJwtCacheTest, TestNonProvider) {

--- a/test/extensions/filters/http/jwt_authn/jwks_async_fetcher_test.cc
+++ b/test/extensions/filters/http/jwt_authn/jwks_async_fetcher_test.cc
@@ -64,16 +64,11 @@ public:
         [this](Upstream::ClusterManager&, const RemoteJwks&) {
           return std::make_unique<MockJwksFetcher>(
               [this](Common::JwksFetcher::JwksReceiver& receiver) {
-                if (fetch_allowed) {
-                  fetch_receiver_array_.push_back(&receiver);
-                }
+                fetch_receiver_array_.push_back(&receiver);
               });
         },
         stats_,
-        [this](google::jwt_verify::JwksPtr&& jwks) { out_jwks_array_.push_back(std::move(jwks)); },
-        // Simulating the isRemoteJwksFetchAllowed and allowRemoteJwksFetch callbacks.
-        [this]() -> bool { return fetch_allowed; },
-        [this](absl::optional<bool>, bool fetch_allowed_) { fetch_allowed = fetch_allowed_; });
+        [this](google::jwt_verify::JwksPtr&& jwks) { out_jwks_array_.push_back(std::move(jwks)); });
 
     if (initManagerUsed()) {
       init_target_handle_->initialize(init_watcher_);
@@ -90,7 +85,6 @@ public:
   Init::TargetHandlePtr init_target_handle_;
   NiceMock<Init::ExpectableWatcherImpl> init_watcher_;
   Event::MockTimer* timer_{};
-  bool fetch_allowed{true};
 };
 
 INSTANTIATE_TEST_SUITE_P(JwksAsyncFetcherTest, JwksAsyncFetcherTest,
@@ -211,44 +205,6 @@ TEST_P(JwksAsyncFetcherTest, TestGoodFetchAndRefresh) {
   EXPECT_EQ(out_jwks_array_.size(), 2);
   EXPECT_EQ(2U, stats_.jwks_fetch_success_.value());
   EXPECT_EQ(0U, stats_.jwks_fetch_failed_.value());
-}
-
-TEST_P(JwksAsyncFetcherTest, TestBackoffDuringAsyncFetch) {
-  const char config[] = R"(
-      http_uri:
-        uri: https://pubkey_server/pubkey_path
-        cluster: pubkey_cluster
-      async_fetch: {}
-      refetch_jwks_on_kid_mismatch: true
-)";
-
-  setupAsyncFetcher(config);
-
-  // Initial fetch is successful.
-  EXPECT_EQ(fetch_receiver_array_.size(), 1);
-  auto jwks = google::jwt_verify::Jwks::createFrom(PublicKey, google::jwt_verify::Jwks::JWKS);
-  fetch_receiver_array_[0]->onJwksSuccess(std::move(jwks));
-
-  // Output 1 jwks.
-  EXPECT_EQ(out_jwks_array_.size(), 1);
-
-  // Disallow fetch.
-  fetch_allowed = false;
-  timer_->invokeCallback();
-
-  // No fetch is done since fetch is disallowed.
-  EXPECT_EQ(fetch_receiver_array_.size(), 1);
-  EXPECT_EQ(out_jwks_array_.size(), 1);
-
-  // Re-allow fetch.
-  fetch_allowed = true;
-  timer_->invokeCallback();
-
-  // New fetch is successful since fetch is now allowed.
-  EXPECT_EQ(fetch_receiver_array_.size(), 2);
-  jwks = google::jwt_verify::Jwks::createFrom(PublicKey, google::jwt_verify::Jwks::JWKS);
-  fetch_receiver_array_[1]->onJwksSuccess(std::move(jwks));
-  EXPECT_EQ(out_jwks_array_.size(), 2);
 }
 
 TEST_P(JwksAsyncFetcherTest, TestNetworkFailureFetchWithDefaultRefetch) {

--- a/test/extensions/filters/http/jwt_authn/jwks_cache_test.cc
+++ b/test/extensions/filters/http/jwt_authn/jwks_cache_test.cc
@@ -98,48 +98,13 @@ TEST_F(JwksCacheTest, TestSetRemoteJwks) {
   auto jwks = cache_->findByIssuer("https://example.com");
   EXPECT_TRUE(jwks->getJwksObj() == nullptr);
 
-  EXPECT_EQ(jwks->setRemoteJwks(std::move(jwks_), false)->getStatus(), Status::Ok);
+  EXPECT_EQ(jwks->setRemoteJwks(std::move(jwks_))->getStatus(), Status::Ok);
   EXPECT_FALSE(jwks->getJwksObj() == nullptr);
   EXPECT_FALSE(jwks->isExpired());
 
   // cache duration is 1 second, sleep two seconds to expire it
   context_.server_factory_context_.time_system_.advanceTimeWait(std::chrono::seconds(2));
   EXPECT_TRUE(jwks->isExpired());
-}
-
-// Test setRemoteJwks to all threads
-TEST_F(JwksCacheTest, TestSetRemoteJwksToAllThreads) {
-  cache_ = JwksCache::create(config_, context_, mock_fetcher_.AsStdFunction(), stats_);
-
-  auto jwks = cache_->findByIssuer("https://example.com");
-  EXPECT_TRUE(jwks->getJwksObj() == nullptr);
-
-  EXPECT_EQ(jwks->setRemoteJwks(std::move(jwks_), true)->getStatus(), Status::Ok);
-  EXPECT_FALSE(jwks->getJwksObj() == nullptr);
-}
-
-// Test allowing/disallowing remote fetch.
-TEST_F(JwksCacheTest, TestRemoteFetchAllowed) {
-  cache_ = JwksCache::create(config_, context_, mock_fetcher_.AsStdFunction(), stats_);
-  auto jwks = cache_->findByIssuer("https://example.com");
-
-  // Fetch should be allowed by default.
-  EXPECT_TRUE(jwks->isRemoteJwksFetchAllowed());
-
-  // Start backoff which should disallow fetch.
-  jwks->allowRemoteJwksFetch(true, false);
-  EXPECT_FALSE(jwks->isRemoteJwksFetchAllowed());
-  // Stop backoff which should allow fetch.
-  jwks->allowRemoteJwksFetch(false, false);
-  EXPECT_TRUE(jwks->isRemoteJwksFetchAllowed());
-
-  // Fetch in flight.
-  jwks->allowRemoteJwksFetch(false, true);
-  EXPECT_FALSE(jwks->isRemoteJwksFetchAllowed());
-
-  // Fetch in flight completed, which should allow further fetches.
-  jwks->allowRemoteJwksFetch(false, false);
-  EXPECT_TRUE(jwks->isRemoteJwksFetchAllowed());
 }
 
 // Test setRemoteJwks and use default cache duration.
@@ -152,7 +117,7 @@ TEST_F(JwksCacheTest, TestSetRemoteJwksWithDefaultCacheDuration) {
   auto jwks = cache_->findByIssuer("https://example.com");
   EXPECT_TRUE(jwks->getJwksObj() == nullptr);
 
-  EXPECT_EQ(jwks->setRemoteJwks(std::move(jwks_), false)->getStatus(), Status::Ok);
+  EXPECT_EQ(jwks->setRemoteJwks(std::move(jwks_))->getStatus(), Status::Ok);
   EXPECT_FALSE(jwks->getJwksObj() == nullptr);
   EXPECT_FALSE(jwks->isExpired());
 }

--- a/test/extensions/filters/http/jwt_authn/mock.h
+++ b/test/extensions/filters/http/jwt_authn/mock.h
@@ -88,9 +88,7 @@ public:
               (), (const));
   MOCK_METHOD(const ::google::jwt_verify::Jwks*, getJwksObj, (), (const));
   MOCK_METHOD(bool, isExpired, (), (const));
-  MOCK_METHOD(const ::google::jwt_verify::Jwks*, setRemoteJwks, (JwksConstPtr&&, bool), ());
-  MOCK_METHOD(bool, isRemoteJwksFetchAllowed, (), ());
-  MOCK_METHOD(void, allowRemoteJwksFetch, (absl::optional<bool>, bool), ());
+  MOCK_METHOD(const ::google::jwt_verify::Jwks*, setRemoteJwks, (JwksConstPtr &&), ());
   MOCK_METHOD(JwtCache&, getJwtCache, (), ());
 
   envoy::extensions::filters::http::jwt_authn::v3::JwtProvider jwt_provider_;

--- a/test/extensions/filters/http/jwt_authn/test_common.h
+++ b/test/extensions/filters/http/jwt_authn/test_common.h
@@ -66,37 +66,6 @@ const char PublicKey[] = R"(
 }
 )";
 
-// Split the above public key into two keys
-const char PublicKey1[] = R"(
-{
-  "keys": [
-    {
-      "kty": "RSA",
-      "alg": "RS256",
-      "use": "sig",
-      "kid": "62a93512c9ee4c7f8067b5a216dade2763d32a47",
-      "n": "up97uqrF9MWOPaPkwSaBeuAPLOr9FKcaWGdVEGzQ4f3Zq5WKVZowx9TCBxmImNJ1qmUi13pB8otwM_l5lfY1AFBMxVbQCUXntLovhDaiSvYp4wGDjFzQiYA-pUq8h6MUZBnhleYrkU7XlCBwNVyN8qNMkpLA7KFZYz-486GnV2NIJJx_4BGa3HdKwQGxi2tjuQsQvao5W4xmSVaaEWopBwMy2QmlhSFQuPUpTaywTqUcUq_6SfAHhZ4IDa_FxEd2c2z8gFGtfst9cY3lRYf-c_ZdboY3mqN9Su3-j3z5r2SHWlhB_LNAjyWlBGsvbGPlTqDziYQwZN4aGsqVKQb9Vw",
-      "e": "AQAB"
-    },
-  ]
-}
-)";
-
-const char PublicKey2[] = R"(
-{
-  "keys": [
-    {
-      "kty": "RSA",
-      "alg": "RS256",
-      "use": "sig",
-      "kid": "b3319a147514df7ee5e4bcdee51350cc890cc89e",
-      "n": "up97uqrF9MWOPaPkwSaBeuAPLOr9FKcaWGdVEGzQ4f3Zq5WKVZowx9TCBxmImNJ1qmUi13pB8otwM_l5lfY1AFBMxVbQCUXntLovhDaiSvYp4wGDjFzQiYA-pUq8h6MUZBnhleYrkU7XlCBwNVyN8qNMkpLA7KFZYz-486GnV2NIJJx_4BGa3HdKwQGxi2tjuQsQvao5W4xmSVaaEWopBwMy2QmlhSFQuPUpTaywTqUcUq_6SfAHhZ4IDa_FxEd2c2z8gFGtfst9cY3lRYf-c_ZdboY3mqN9Su3-j3z5r2SHWlhB_LNAjyWlBGsvbGPlTqDziYQwZN4aGsqVKQb9Vw",
-      "e": "AQAB"
-    },
-  ]
-}
-)";
-
 // Provider config with various subject constraints
 const char SubjectConfig[] = R"(
 providers:
@@ -185,9 +154,6 @@ providers:
     - example_service
     - http://example_service1
     - https://example_service2/
-    - example_service_with_kid1
-    - example_service_with_kid2
-    - example_service_with_kid3
     remote_jwks:
       http_uri:
         uri: https://www.pubkey-server.com/pubkey-path
@@ -413,43 +379,6 @@ const char OtherGoodToken[] =
     "buwXk5M6d-"
     "drRvLcvlT5gB4adOIOlmhm8xtXgYpvqrXfmMJCHbP9no7JATFaTEAkmA3OOxDsaOju4BFgMtRZtDM8p12QQG0rFl_FE-"
     "2FqYX9qA4q41HJ4vxTSxgObeLGA";
-
-// { "iss": "https://example.com", "sub": "kid1@example.com",
-// "kid": "62a93512c9ee4c7f8067b5a216dade2763d32a47", "exp": 2001001001,
-// "aud": "example_service_with_kid1" }
-const char GoodTokenWithKid1[] =
-    "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IjYyYTkzNTEyYzllZTRjN2Y4MDY3YjVhMjE2ZGFkZTI3NjNkMz"
-    "JhNDcifQ.eyJpc3MiOiJodHRwczovL2V4YW1wbGUuY29tIiwic3ViIjoia2lkMUBleGFtcGxlLmNvbSIsImV4cCI6MjAwM"
-    "TAwMTAwMSwiYXVkIjoiZXhhbXBsZV9zZXJ2aWNlX3dpdGhfa2lkMSJ9.m_ZdaiIep0LoWkWKDluwCsJK_MwqGWR24tkaSG"
-    "PbCVWLzO_tfDXDSPQrtpMbNKmopgqKXQcqEHfwy44dKzIaMfRnK4ICmxPmXXcqWFHfxJM1YO8UmPwwzKXssijGnQvrJ43y"
-    "Z0050NTWhmhGhkx7RYLfgk1qMsSWNVls5CYllke8MWF55Ns-4vFr2WdTmz06iMBMuPZI3E0v932tYqSMrBjbhmbT0WS-"
-    "a0dgqfpMDgQThBHK0MXFvDWjMqQ1YBiLT8Utdkswc0Mu2FPtjVUAXU5DfyselEe3isgPTnbNTPvGkGYJ-JvJTJRfUF5-"
-    "IMGxEBJX9yQ0EuA16HCH13eQKA";
-
-// { "iss": "https://example.com", "sub": "kid2@example.com",
-// "kid": "b3319a147514df7ee5e4bcdee51350cc890cc89e", "exp": 2001001001,
-// "aud": "example_service_with_kid2" }
-const char GoodTokenWithKid2[] =
-    "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImIzMzE5YTE0NzUxNGRmN2VlNWU0YmNkZWU1MTM1MGNjODkwY2"
-    "M4OWUifQ.eyJpc3MiOiJodHRwczovL2V4YW1wbGUuY29tIiwic3ViIjoia2lkMkBleGFtcGxlLmNvbSIsImV4cCI6MjAwM"
-    "TAwMTAwMSwiYXVkIjoiZXhhbXBsZV9zZXJ2aWNlX3dpdGhfa2lkMiJ9.PpYWGuuxdTWdLAznYvA4DHBxa7BkgGMKvwp_"
-    "neb7mW9cKIRPz6hSVkSyI7hdgafeOIayGCEGWYYcs_UAS068Bd8oDI8p5iITGv0XyAer-zh-"
-    "jqNcNmNrdgUr3WkBSxWyeEPC9RYxaHamm115U0HA6DbvMJu3nm1ir3oKHVgq"
-    "-uSfhZQjtpXXKJU0v6ZEjJSaqyVt84ZDIwtpkDIHS7fjAT1U6pteVNdKyJy8MH7IMHzohY0b563kxI3PHubgPn8nJPRjzX"
-    "YnUBp3rc6N"
-    "iNhvYYQjXep_JFarh0aivlXrjtkhzoNb10raaIkboICp88KyH-seXc59we1naCMgRp_fag";
-
-// { "iss": "https://example.com", "sub": "kid3@example.com",
-// "kid": "6465fc44cf92ae01027d89ebb0e18e02aeb6dfff", "exp": 2001001001, "aud":
-// "example_service_with_kid3" }
-const char GoodTokenWithKid3[] =
-    "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IjY0NjVmYzQ0Y2Y5MmFlMDEwMjdkODllYmIwZTE4ZTAyYWViNm"
-    "RmZmYifQ.eyJpc3MiOiJodHRwczovL2V4YW1wbGUuY29tIiwic3ViIjoia2lkM0BleGFtcGxlLmNvbSIsImV4cCI6MjAwM"
-    "TAwMTAwMSwiYXVkIjoiZXhhbXBsZV9zZXJ2aWNlX3dpdGhfa2lkMyJ9.p3Pwx6kMYn46jXExHZyt5vnD-"
-    "NlIeA9XW3W8rJykUuPg5yQLMamm24PItH64PZUZgun7rhKxzsgZgAmUpmxB2b4pb5lhPJLHRQoJouzdU9Usr5H9GOt4a1p"
-    "77-6D7ocSX4iGMT4dqis4sncbMGgb5kVR_48iwD17kGDwCimH5mAdcoMyeuvR7c2xRaremyvqzS24CqyxrcxdRppyS-I5W"
-    "vNG4WtFaalNWUFVZNFtOjVuNlouo9IudLMtv7WFoJNOPRN-R-34Kj50Yk2"
-    "hXOQResUZwxsV6W83VleiWiOE2uNTWHTfJLVK1BtqVrSrxj7zv1NxVCW5M_X97Uq3ht6_JQ";
 
 //{
 //  "iss": "https://example.com",

--- a/tools/spelling/spelling_dictionary.txt
+++ b/tools/spelling/spelling_dictionary.txt
@@ -90,8 +90,6 @@ gperf
 HEXDIG
 HEXDIGIT
 HPE
-KID
-KIDs
 Kwasi
 LRU
 Mensah
@@ -258,7 +256,6 @@ JSON
 JSONs
 JWKS
 JWKs
-JWKS's
 JWS
 JWT
 JWTs
@@ -1199,7 +1196,6 @@ refcount
 referencee
 referer
 refetch
-refetches
 reframed
 refvec
 regex


### PR DESCRIPTION
Commit Message: Revert "jwt_authn: Add logic to refetch JWT on KID mismatch (#36458)"
Additional Description:

To resolve the frequent jwt flake. See https://github.com/envoyproxy/envoy/issues/37720.

It's merged recently **and the implementation of that feature has obvious thread-safty problem and lifetime problem.**

Risk Level: low.
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
