### PR TITLE
router: fix shadowed spans fully ignoring parent sample status

### DIFF
--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -797,7 +797,7 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers,
         continue;
       }
       auto shadow_headers = Http::createHeaderMap<Http::RequestHeaderMapImpl>(*shadow_headers_);
-      auto sampled = shadow_policy.traceSampled() ? absl::nullopt : false;
+      auto sampled = shadow_policy.traceSampled() ? absl::nullopt : absl::optional<bool>(false);
       auto options =
           Http::AsyncClient::RequestOptions()
               .setTimeout(timeout_.global_timeout_)

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -1068,11 +1068,12 @@ void Filter::maybeDoShadowing() {
       request->trailers(Http::createHeaderMap<Http::RequestTrailerMapImpl>(*shadow_trailers_));
     }
 
+    auto sampled = shadow_policy.traceSampled() ? absl::nullopt : absl::optional<bool>(false);
     auto options = Http::AsyncClient::RequestOptions()
                        .setTimeout(timeout_.global_timeout_)
                        .setParentSpan(callbacks_->activeSpan())
                        .setChildSpanName("mirror")
-                       .setSampled(shadow_policy.traceSampled())
+                       .setSampled(sampled)
                        .setIsShadow(true)
                        .setIsShadowSuffixDisabled(shadow_policy.disableShadowHostSuffixAppend());
     options.setFilterConfig(config_);

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -797,12 +797,13 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers,
         continue;
       }
       auto shadow_headers = Http::createHeaderMap<Http::RequestHeaderMapImpl>(*shadow_headers_);
+      auto sampled = shadow_policy.traceSampled() ? absl::nullopt : false;
       auto options =
           Http::AsyncClient::RequestOptions()
               .setTimeout(timeout_.global_timeout_)
               .setParentSpan(callbacks_->activeSpan())
               .setChildSpanName("mirror")
-              .setSampled(shadow_policy.traceSampled())
+              .setSampled(sampled)
               .setIsShadow(true)
               .setIsShadowSuffixDisabled(shadow_policy.disableShadowHostSuffixAppend())
               .setBufferAccount(callbacks_->account())

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -4657,7 +4657,7 @@ TEST_P(RouterShadowingTest, BufferingShadowWithClusterHeader) {
         EXPECT_NE(request->body().length(), 0);
         EXPECT_NE(nullptr, request->trailers());
         EXPECT_EQ(absl::optional<std::chrono::milliseconds>(10), options.timeout);
-        EXPECT_TRUE(options.sampled_.value());
+        EXPECT_EQ(absl::nullopt, options.sampled_);
       }));
 
   router_->decodeTrailers(trailers);
@@ -4785,7 +4785,7 @@ TEST_P(RouterShadowingTest, StreamingShadow) {
       .WillOnce(Invoke([&](const std::string&, Http::RequestHeaderMapPtr&,
                            const Http::AsyncClient::RequestOptions& options) {
         EXPECT_EQ(absl::optional<std::chrono::milliseconds>(10), options.timeout);
-        EXPECT_TRUE(options.sampled_.value());
+        EXPECT_EQ(absl::nullopt, options.sampled_);
         return &foo_request;
       }));
   NiceMock<Http::MockAsyncClient> fizz_client;
@@ -4865,7 +4865,7 @@ TEST_P(RouterShadowingTest, BufferingShadow) {
         EXPECT_NE(request->body().length(), 0);
         EXPECT_NE(nullptr, request->trailers());
         EXPECT_EQ(absl::optional<std::chrono::milliseconds>(10), options.timeout);
-        EXPECT_TRUE(options.sampled_.value());
+        EXPECT_EQ(absl::nullopt, options.sampled_);
       }));
   EXPECT_CALL(*shadow_writer_, shadow_("fizz", _, _))
       .WillOnce(Invoke([](const std::string&, Http::RequestMessagePtr& request,
@@ -4929,7 +4929,7 @@ TEST_P(RouterShadowingTest, ShadowCallbacksNotCalledInDestructor) {
       .WillOnce(Invoke([&](const std::string&, Http::RequestHeaderMapPtr&,
                            const Http::AsyncClient::RequestOptions& options) {
         EXPECT_EQ(absl::optional<std::chrono::milliseconds>(10), options.timeout);
-        EXPECT_TRUE(options.sampled_.value());
+        EXPECT_EQ(absl::nullopt, options.sampled_);
         return &foo_request;
       }));
   router_->decodeHeaders(headers, false);


### PR DESCRIPTION
Commit Message: router: fix shadowed spans fully ignoring parent sample status
Additional Description: 
If shadow_policy.traceSampled is true, defer to the parent sample status instead of forcing it to be sampled.
If it is false, continue to force it to not be sampled

Similar to #17085, shadowed request spans were overriding the parent sample status, leading to oversampling when `shadow_policy.traceSampled` is `true`. This uses the API change introduced in #19343 to instead defer to the parent sample status in that case


Risk Level: low
Testing: done
Docs Changes: todo
Release Notes: todo
Platform Specific Features: n/a
Runtime guard: n/a?

Fixes #37766 