### PR TITLE
Adding ext_proc MxN test with ext_proc server send out-of-order response

### DIFF
--- a/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
+++ b/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
@@ -5152,7 +5152,7 @@ TEST_P(ExtProcIntegrationTest, ServerSendOutOfOrderResponseDuplexStreamed) {
     auto* body_mut = body_resp->mutable_response()->mutable_body_mutation();
     auto* streamed_response = body_mut->mutable_streamed_response();
     streamed_response->set_body("r");
-    const bool end_of_stream = (i == 2)  ? true : false;
+    const bool end_of_stream = (i == 2) ? true : false;
     streamed_response->set_end_of_stream(end_of_stream);
     processor_stream_->sendGrpcMessage(response_body);
   }

--- a/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
+++ b/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
@@ -5188,7 +5188,7 @@ TEST_P(ExtProcIntegrationTest, ServerSendOutOfOrderResponseDuplexStreamed) {
   // Enable FULL_DUPLEX_STREAMED body processing in both directions.
   IntegrationStreamDecoderPtr response = initAndSendDataDuplexStreamedMode(body_sent, true, true);
 
-  // The ext_proc server receives the requst headers and body.
+  // The ext_proc server receives the request headers and body.
   ProcessingRequest header_request;
   serverReceiveHeaderDuplexStreamed(header_request);
   uint32_t total_req_body_msg = serverReceiveBodyDuplexStreamed(body_sent);

--- a/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
+++ b/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
@@ -273,13 +273,12 @@ protected:
     EXPECT_EQ(std::to_string(status_code), response.headers().getStatusValue());
   }
 
-  void handleUpstreamRequest(bool add_content_length = false,
-                             const std::string status_code = "200") {
+  void handleUpstreamRequest(bool add_content_length = false, int status_code = 200) {
     ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, fake_upstream_connection_));
     ASSERT_TRUE(fake_upstream_connection_->waitForNewStream(*dispatcher_, upstream_request_));
     ASSERT_TRUE(upstream_request_->waitForEndStream(*dispatcher_));
     Http::TestResponseHeaderMapImpl response_headers =
-        Http::TestResponseHeaderMapImpl{{":status", status_code}};
+        Http::TestResponseHeaderMapImpl{{":status", std::to_string(status_code)}};
     uint64_t content_length = 100;
     if (add_content_length) {
       response_headers.setContentLength(content_length);
@@ -5200,7 +5199,7 @@ TEST_P(ExtProcIntegrationTest, ServerSendOutOfOrderResponseDuplexStreamed) {
   serverSendBodyRespDuplexStreamed(total_req_body_msg);
 
   // The backend server processes the request and sends back a 400 response.
-  handleUpstreamRequest(false, "400");
+  handleUpstreamRequest(false, 400);
   // The body received by upstream server is expected to be empty.
   EXPECT_EQ(upstream_request_->body().toString(), "");
   // As the external processing is shut down, the response messages are not sent


### PR DESCRIPTION
Adding ext_proc MxN test with ext_proc server send out-of-order response.
This is to address a left-over comments of the initial MxN PR: https://github.com/envoyproxy/envoy/pull/34942.


Fix: https://github.com/envoyproxy/envoy/issues/37064