### PR TITLE
release note: add item for apply_on_stream_done ratelimit API

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -395,6 +395,10 @@ new_features:
     :ref:`VirtualHost.rate_limits <envoy_v3_api_field_config.route.v3.VirtualHost.rate_limits>` or
     :ref:`RouteAction.rate_limits <envoy_v3_api_field_config.route.v3.RouteAction.rate_limits>` fields
     will be ignored.
+- area: ratelimit
+  change: |
+    Add the option to reduce the rate limit budget based on request/response contexts on stream done.
+    See :ref:`apply_on_stream_done <envoy_v3_api_field_config.route.v3.RateLimit.apply_on_stream_done>` for more details.
 
 deprecated:
 - area: rbac


### PR DESCRIPTION
This is a follow up on #37548, and forgot to add
the release note in the PR.