### PR TITLE
Reapply "rbac: add delay_deny implementation in RBAC network filter

### DIFF
--- a/api/envoy/extensions/filters/network/rbac/v3/rbac.proto
+++ b/api/envoy/extensions/filters/network/rbac/v3/rbac.proto
@@ -4,6 +4,8 @@ package envoy.extensions.filters.network.rbac.v3;
 
 import "envoy/config/rbac/v3/rbac.proto";
 
+import "google/protobuf/duration.proto";
+
 import "xds/annotations/v3/status.proto";
 import "xds/type/matcher/v3/matcher.proto";
 
@@ -26,7 +28,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 //
 // Header should not be used in rules/shadow_rules in RBAC network filter as
 // this information is only available in :ref:`RBAC http filter <config_http_filters_rbac>`.
-// [#next-free-field: 8]
+// [#next-free-field: 9]
 message RBAC {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.network.rbac.v2.RBAC";
@@ -87,4 +89,10 @@ message RBAC {
   // every payload (e.g., Mongo, MySQL, Kafka) set the enforcement type to
   // CONTINUOUS to enforce RBAC policies on every message boundary.
   EnforcementType enforcement_type = 4;
+
+  // Delay the specified duration before closing the connection when the policy evaluation
+  // result is ``DENY``. If this is not present, the connection will be closed immediately.
+  // This is useful to provide a better protection for Envoy against clients that retries
+  // aggressively when the connection is rejected by the RBAC filter.
+  google.protobuf.Duration delay_deny = 8;
 }

--- a/source/extensions/filters/network/rbac/rbac_filter.cc
+++ b/source/extensions/filters/network/rbac/rbac_filter.cc
@@ -63,9 +63,14 @@ RoleBasedAccessControlFilterConfig::RoleBasedAccessControlFilterConfig(
                                                   action_validation_visitor_)),
       shadow_engine_(Filters::Common::RBAC::createShadowEngine(
           proto_config, context, validation_visitor, action_validation_visitor_)),
-      enforcement_type_(proto_config.enforcement_type()) {}
+      enforcement_type_(proto_config.enforcement_type()),
+      delay_deny_ms_(PROTOBUF_GET_MS_OR_DEFAULT(proto_config, delay_deny, 0)) {}
 
 Network::FilterStatus RoleBasedAccessControlFilter::onData(Buffer::Instance&, bool) {
+  if (is_delay_denied_) {
+    return Network::FilterStatus::StopIteration;
+  }
+
   ENVOY_LOG(
       debug,
       "checking connection: requestedServerName: {}, sourceIP: {}, directRemoteIP: {},"
@@ -118,12 +123,42 @@ Network::FilterStatus RoleBasedAccessControlFilter::onData(Buffer::Instance&, bo
   } else if (engine_result_ == Deny) {
     callbacks_->connection().streamInfo().setConnectionTerminationDetails(
         Filters::Common::RBAC::responseDetail(log_policy_id));
-    callbacks_->connection().close(Network::ConnectionCloseType::NoFlush, "rbac_deny_close");
+
+    std::chrono::milliseconds duration = config_->delayDenyMs();
+    if (duration > std::chrono::milliseconds(0)) {
+      ENVOY_LOG(debug, "connection will be delay denied in {}ms", duration.count());
+      delay_timer_ = callbacks_->connection().dispatcher().createTimer(
+          [this]() -> void { closeConnection(); });
+      ASSERT(!is_delay_denied_);
+      is_delay_denied_ = true;
+      callbacks_->connection().readDisable(true);
+      delay_timer_->enableTimer(duration);
+    } else {
+      closeConnection();
+    }
     return Network::FilterStatus::StopIteration;
   }
 
   ENVOY_LOG(debug, "no engine, allowed by default");
   return Network::FilterStatus::Continue;
+}
+
+void RoleBasedAccessControlFilter::closeConnection() {
+  callbacks_->connection().close(Network::ConnectionCloseType::NoFlush, "rbac_deny_close");
+}
+
+void RoleBasedAccessControlFilter::resetTimerState() {
+  if (delay_timer_) {
+    delay_timer_->disableTimer();
+    delay_timer_.reset();
+  }
+}
+
+void RoleBasedAccessControlFilter::onEvent(Network::ConnectionEvent event) {
+  if (event == Network::ConnectionEvent::RemoteClose ||
+      event == Network::ConnectionEvent::LocalClose) {
+    resetTimerState();
+  }
 }
 
 void RoleBasedAccessControlFilter::setDynamicMetadata(std::string shadow_engine_result,

--- a/source/extensions/filters/network/rbac/rbac_filter.h
+++ b/source/extensions/filters/network/rbac/rbac_filter.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "envoy/event/timer.h"
 #include "envoy/extensions/filters/network/rbac/v3/rbac.pb.h"
 #include "envoy/network/connection.h"
 #include "envoy/network/filter.h"
@@ -58,6 +59,8 @@ public:
     return enforcement_type_;
   }
 
+  std::chrono::milliseconds delayDenyMs() const { return delay_deny_ms_; }
+
 private:
   Filters::Common::RBAC::RoleBasedAccessControlFilterStats stats_;
   const std::string shadow_rules_stat_prefix_;
@@ -66,6 +69,7 @@ private:
   std::unique_ptr<const Filters::Common::RBAC::RoleBasedAccessControlEngine> engine_;
   std::unique_ptr<const Filters::Common::RBAC::RoleBasedAccessControlEngine> shadow_engine_;
   const envoy::extensions::filters::network::rbac::v3::RBAC::EnforcementType enforcement_type_;
+  std::chrono::milliseconds delay_deny_ms_;
 };
 
 using RoleBasedAccessControlFilterConfigSharedPtr =
@@ -75,6 +79,7 @@ using RoleBasedAccessControlFilterConfigSharedPtr =
  * Implementation of a basic RBAC network filter.
  */
 class RoleBasedAccessControlFilter : public Network::ReadFilter,
+                                     public Network::ConnectionCallbacks,
                                      public Logger::Loggable<Logger::Id::rbac> {
 
 public:
@@ -87,7 +92,13 @@ public:
   Network::FilterStatus onNewConnection() override { return Network::FilterStatus::Continue; };
   void initializeReadFilterCallbacks(Network::ReadFilterCallbacks& callbacks) override {
     callbacks_ = &callbacks;
+    callbacks_->connection().addConnectionCallbacks(*this);
   }
+
+  // Network::ConnectionCallbacks
+  void onEvent(Network::ConnectionEvent event) override;
+  void onAboveWriteBufferHighWatermark() override {}
+  void onBelowWriteBufferLowWatermark() override {}
 
   void setDynamicMetadata(std::string shadow_engine_result, std::string shadow_policy_id);
 
@@ -98,6 +109,10 @@ private:
   EngineResult shadow_engine_result_{Unknown};
 
   Result checkEngine(Filters::Common::RBAC::EnforcementMode mode);
+  void closeConnection();
+  void resetTimerState();
+  Event::TimerPtr delay_timer_{nullptr};
+  bool is_delay_denied_{false};
 };
 
 } // namespace RBACFilter

--- a/test/extensions/filters/network/rbac/integration_test.cc
+++ b/test/extensions/filters/network/rbac/integration_test.cc
@@ -7,6 +7,7 @@
 
 #include "test/integration/integration.h"
 #include "test/test_common/environment.h"
+#include "test/test_common/simulated_time_system.h"
 
 #include "fmt/printf.h"
 
@@ -22,6 +23,7 @@ std::string rbac_config;
 
 class RoleBasedAccessControlNetworkFilterIntegrationTest
     : public testing::TestWithParam<Network::Address::IpVersion>,
+      public Event::TestUsingSimulatedTime,
       public BaseIntegrationTest {
 public:
   RoleBasedAccessControlNetworkFilterIntegrationTest()
@@ -131,6 +133,36 @@ typed_config:
   EXPECT_EQ(1U, test_server_->counter("tcp.rbac.denied")->value());
   EXPECT_EQ(1U, test_server_->counter("tcp.rbac.shadow_allowed")->value());
   EXPECT_EQ(0U, test_server_->counter("tcp.rbac.shadow_denied")->value());
+}
+
+TEST_P(RoleBasedAccessControlNetworkFilterIntegrationTest, DelayDenied) {
+  initializeFilter(R"EOF(
+name: rbac
+typed_config:
+  "@type": type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC
+  stat_prefix: tcp.
+  rules:
+    policies:
+      "deny_all":
+        permissions:
+          - any: true
+        principals:
+          - not_id:
+              any: true
+  delay_deny: 5s
+)EOF");
+  IntegrationTcpClientPtr tcp_client = makeTcpConnection(lookupPort("listener_0"));
+  ASSERT_TRUE(tcp_client->write("hello", false, false));
+  ASSERT_TRUE(tcp_client->connected());
+
+  timeSystem().advanceTimeWait(std::chrono::seconds(3));
+  ASSERT_TRUE(tcp_client->connected());
+
+  timeSystem().advanceTimeWait(std::chrono::seconds(6));
+  tcp_client->waitForDisconnect();
+
+  EXPECT_EQ(0U, test_server_->counter("tcp.rbac.allowed")->value());
+  EXPECT_EQ(1U, test_server_->counter("tcp.rbac.denied")->value());
 }
 
 TEST_P(RoleBasedAccessControlNetworkFilterIntegrationTest, DeniedWithDenyAction) {

--- a/test/extensions/filters/network/rbac/integration_test.cc
+++ b/test/extensions/filters/network/rbac/integration_test.cc
@@ -7,7 +7,6 @@
 
 #include "test/integration/integration.h"
 #include "test/test_common/environment.h"
-#include "test/test_common/simulated_time_system.h"
 
 #include "fmt/printf.h"
 
@@ -23,7 +22,6 @@ std::string rbac_config;
 
 class RoleBasedAccessControlNetworkFilterIntegrationTest
     : public testing::TestWithParam<Network::Address::IpVersion>,
-      public Event::TestUsingSimulatedTime,
       public BaseIntegrationTest {
 public:
   RoleBasedAccessControlNetworkFilterIntegrationTest()

--- a/test/integration/integration_tcp_client.h
+++ b/test/integration/integration_tcp_client.h
@@ -45,6 +45,7 @@ public:
   ABSL_MUST_USE_RESULT AssertionResult
   write(const std::string& data, bool end_stream = false, bool verify = true,
         std::chrono::milliseconds timeout = TestUtility::DefaultTimeout);
+
   const std::string& data() { return payload_reader_->data(); }
   bool connected() const { return !disconnected_; }
   // clear up to the `count` number of bytes of received data


### PR DESCRIPTION
Reapply the RBAC change by reverting https://github.com/envoyproxy/envoy/pull/35899.

The original commit is reverted for flaky RBAC integration test.

The fix is pretty simple by just removing the simulated time in the test, I'm not sure of the root cause but the test does not really need the simulated test.

Before the fix, the flaky test can be reproduced easily with `--runs_per_test=1000`, After the test, I can no longer reproduce 
the failure. To be on the safer side, I ran the test with `--runs_per_test=10000` and still couldn't reproduce the test failure.

Test output:
```
 % bazel test //test/extensions/filters/network/rbac:integration_test --runs_per_test=10000  --test_timeout=60 --test_env=ENVOY_IP_TEST_VERSIONS=v4only
INFO: Invocation ID: c1ebbc18-4887-4626-9d19-e257d42fe4cd
INFO: Analyzed target //test/extensions/filters/network/rbac:integration_test (0 packages loaded, 19 targets configured).
INFO: Found 1 test target...
Target //test/extensions/filters/network/rbac:integration_test up-to-date:
  bazel-bin/test/extensions/filters/network/rbac/integration_test
INFO: Elapsed time: 2486.472s, Critical Path: 24.73s
INFO: 10001 processes: 1 internal, 10000 processwrapper-sandbox.
INFO: Build completed successfully, 10001 total actions

Executed 1 out of 1 test: 1 test passes.
```