### PR TITLE
fix xff trusted hops

### DIFF
--- a/source/extensions/http/original_ip_detection/xff/xff.cc
+++ b/source/extensions/http/original_ip_detection/xff/xff.cc
@@ -55,8 +55,8 @@ XffIPDetection::detect(Envoy::Http::OriginalIPDetectionParams& params) {
     return {ret.address_, ret.allow_trusted_address_checks_, absl::nullopt, skip_xff_append_};
   }
 
-  auto ret =
-      Envoy::Http::Utility::getLastAddressFromXFF(params.request_headers, xff_num_trusted_hops_);
+  auto ret = Envoy::Http::Utility::getLastAddressFromXFF(params.request_headers,
+                                                         xff_num_trusted_hops_ - 1);
   return {ret.address_, ret.allow_trusted_address_checks_, absl::nullopt, skip_xff_append_};
 }
 


### PR DESCRIPTION
Commit Message: this PR resolves the issue of incorrect handling of XFF trusted hops, which was inconsistent between the two approaches—OriginalIpDetectionExtension and HCM xffNumTrustedHops—used for retrieving the remote IP from the XFF header. Additionally, the old behavior in the OriginalIpDetectionExtension was also not aligned with the Envoy documentation, which specifies that the original IP should correspond to the rightmost trusted hop in the XFF header.

For example, for a request going thourgh two trusted proxies, like this:

client(203.0.113.128) ----->proxy 1( 203.0.113.10) --------->proxy 2(203.0.113.1)--------> Enovy

proxy1 will add the client ip 92.168.1.1 to the XFF header, and proxy 2 will append it's direct upstream ip 92.168.1.2 to the XFF header. When Envoy finally receives the request, the xff header is `X-Forwarded-For: 203.0.113.128, 203.0.113.10`.

In this setup, the trusted hops is 2, and the correct client IP is the second rightmost ip in the XFF header 192.168.1.1

More details in the issue: https://github.com/envoyproxy/envoy/issues/34241#issuecomment-2211598450

Disclaimer: I may have misunderstood the functionality of HCM [xff_num_trusted_hops](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-xff-num-trusted-hops) and the XFF extension. If the current behavior is correct, we would appreciate any assistance in addressing the related issue in Envoy Gateway https://github.com/envoyproxy/gateway/pull/4702

Additional Description:
Risk Level:
Testing:
Docs Changes: No
Release Notes: Yes
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #34241]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]

Related Envoy Gateay issue: https://github.com/envoyproxy/gateway/pull/4702
