### PR TITLE
access_log: add an option to emit additional metadata from runtime_filter to store sampling decision

### DIFF
--- a/api/envoy/config/accesslog/v3/accesslog.proto
+++ b/api/envoy/config/accesslog/v3/accesslog.proto
@@ -153,6 +153,7 @@ message TraceableFilter {
 }
 
 // Filters for random sampling of requests.
+// [#next-free-field: 6]
 message RuntimeFilter {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.accesslog.v2.RuntimeFilter";
@@ -182,6 +183,23 @@ message RuntimeFilter {
   // cause the filter to behave like an independent random variable when
   // composed within logical operator filters).
   bool use_independent_randomness = 3;
+
+  // Controls whether the sampling decision is stored in the dynamic metadata to be reference later for auditing
+  // purposes. If not specified, defaults to false.
+  //
+  // When enabled, the following metadata will be emitted under the key "envoy.access_log.runtime_filter":
+  //   - "sampling_decision": bool - whether the request was sampled (true) or not (false)
+  //   - "numerator": number - the numerator of the sampling rate
+  //   - "denominator": number - the denominator of the sampling rate (100, 10000, or 1000000)
+  //   - "runtime_key": string - the runtime key used for sampling
+  //
+  // This metadata can be accessed later by other filters or loggers using dynamic metadata accessors.
+  bool emit_metadata = 4;
+
+  // Optional suffix to append to the metadata key. When specified, metadata will be emitted under
+  // "envoy.access_log.runtime_filter.<metadata_key_suffix>" instead of "envoy.access_log.runtime_filter".
+  // This allows multiple runtime filters to store their metadata under different keys.
+  string metadata_key_suffix = 5;
 }
 
 // Performs a logical “and” operation on the result of each filter in filters.

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -399,6 +399,13 @@ new_features:
   change: |
     Add the option to reduce the rate limit budget based on request/response contexts on stream done.
     See :ref:`apply_on_stream_done <envoy_v3_api_field_config.route.v3.RateLimit.apply_on_stream_done>` for more details.
+- area: access_log
+  change: |
+    Added ability to emit sampling metadata from runtime filters. When enabled via ``emit_metadata``, the runtime filter
+    will store its sampling decision and parameters in dynamic metadata under "envoy.access_log.runtime_filter" or
+    under "envoy.access_log.runtime_filter.<metadata_key_suffix>" if ``metadata_key_suffix`` is specified. This emitted
+    metadata includes the sampling decision, numerator, denominator, and runtime key used. This can be used for auditing
+    and debugging the sampling behavior later.
 
 deprecated:
 - area: rbac

--- a/source/common/access_log/access_log_impl.h
+++ b/source/common/access_log/access_log_impl.h
@@ -152,12 +152,27 @@ public:
   bool evaluate(const Formatter::HttpFormatterContext& context,
                 const StreamInfo::StreamInfo& info) const override;
 
+  std::string getMetadataKey() const {
+    if (metadata_key_suffix_.empty()) {
+      return RuntimeFilterMetadataKeyPrefix;
+    }
+    return absl::StrCat(RuntimeFilterMetadataKeyPrefix, ".", metadata_key_suffix_);
+  }
+
+  static constexpr const char* RuntimeFilterMetadataKeyPrefix = "envoy.access_log.runtime_filter";
+  static constexpr const char* SamplingDecisionKey = "sampling_decision";
+  static constexpr const char* NumeratorKey = "numerator";
+  static constexpr const char* DenominatorKey = "denominator";
+  static constexpr const char* RuntimeKeyFieldName = "runtime_key";
+
 private:
   Runtime::Loader& runtime_;
   Random::RandomGenerator& random_;
   const std::string runtime_key_;
   const envoy::type::v3::FractionalPercent percent_;
   const bool use_independent_randomness_;
+  const bool emit_metadata_;
+  const std::string metadata_key_suffix_;
 };
 
 /**


### PR DESCRIPTION
## Description

This PR adds the ability to emit sampling metadata from runtime filters. When enabled via `emit_metadata`, the runtime filter will now store its sampling decision and parameters in dynamic metadata under `envoy.access_log.runtime_filter` or under `envoy.access_log.runtime_filter.<metadata_key_suffix>` if `metadata_key_suffix` is specified. 

When enabled, the runtime filter starts emitting the following metadata:
- **sampling_decision**: Whether the request was sampled (true/false) 
- **numerator**: The numerator of the sampling rate
- **denominator**: The denominator of the sampling rate (100, 10000, or 1000000)
- **runtime_key**: The runtime key used for sampling

When we have multiple filters configured, this is super useful to understand what request was sampled and at what rate.

---

**Commit Message:** access_log: add metadata emission to runtime filter sampling decisions
**Additional Description:** The current runtime filter makes sampling decisions but doesn't persist those decisions anywhere. This makes it hard to understand why a particular request was sampled or not sampled after the fact.
**Risk Level:** Low
**Testing:** Added Unit Tests
**Docs Changes:** Added
**Release Notes:** Added