### PR TITLE
opentelemetry tracer: implement TraceIDRatioBased and ParentBased samplers 

### DIFF
--- a/api/envoy/extensions/tracers/opentelemetry/samplers/v3/BUILD
+++ b/api/envoy/extensions/tracers/opentelemetry/samplers/v3/BUILD
@@ -7,6 +7,7 @@ licenses(["notice"])  # Apache 2
 api_proto_package(
     deps = [
         "//envoy/config/core/v3:pkg",
+        "//envoy/type/v3:pkg",
         "@com_github_cncf_xds//udpa/annotations:pkg",
         "@com_github_cncf_xds//xds/annotations/v3:pkg",
         "@com_github_cncf_xds//xds/type/v3:pkg",

--- a/api/envoy/extensions/tracers/opentelemetry/samplers/v3/parent_based_sampler.proto
+++ b/api/envoy/extensions/tracers/opentelemetry/samplers/v3/parent_based_sampler.proto
@@ -1,0 +1,31 @@
+syntax = "proto3";
+
+package envoy.extensions.tracers.opentelemetry.samplers.v3;
+
+import "envoy/config/core/v3/extension.proto";
+
+import "udpa/annotations/status.proto";
+
+option java_package = "io.envoyproxy.envoy.extensions.tracers.opentelemetry.samplers.v3";
+option java_outer_classname = "ParentBasedSamplerProto";
+option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/extensions/tracers/opentelemetry/samplers/v3;samplersv3";
+option (udpa.annotations.file_status).package_version_status = ACTIVE;
+
+// [#protodoc-title: Parent Based Sampler config]
+// Configuration for the "ParentBased" Sampler extension.
+// The sampler follows the "ParentBased" implementation from the OpenTelemetry
+// SDK specification.
+//
+// See:
+// `ParentBased sampler specification <https://opentelemetry.io/docs/specs/otel/trace/sdk/#parentbased>`_
+// [#extension: envoy.tracers.opentelemetry.samplers.parent_based]
+
+message ParentBasedSamplerConfig {
+  // Specifies the sampler to be used by this sampler.
+  // The configured sampler will be used if the parent trace ID is not passed to Envoy
+  //
+  // required
+  // [#extension-category: envoy.tracers.opentelemetry.samplers]
+  config.core.v3.TypedExtensionConfig wrapped_sampler = 1;
+}

--- a/api/envoy/extensions/tracers/opentelemetry/samplers/v3/trace_id_ratio_based_sampler.proto
+++ b/api/envoy/extensions/tracers/opentelemetry/samplers/v3/trace_id_ratio_based_sampler.proto
@@ -1,0 +1,29 @@
+syntax = "proto3";
+
+package envoy.extensions.tracers.opentelemetry.samplers.v3;
+
+import "udpa/annotations/status.proto";
+
+option java_package = "io.envoyproxy.envoy.extensions.tracers.opentelemetry.samplers.v3";
+option java_outer_classname = "TraceIdRatioBasedSamplerProto";
+option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/extensions/tracers/opentelemetry/samplers/v3;samplersv3";
+option (udpa.annotations.file_status).package_version_status = ACTIVE;
+
+// [#protodoc-title: Trace Id Ratio Based Sampler config]
+// Configuration for the "TraceIdRatioBased" Sampler extension.
+// The sampler follows the "TraceIdRatioBased" implementation from the OpenTelemetry
+// SDK specification.
+//
+// See:
+// `TraceIdRatioBased sampler specification <https://opentelemetry.io/docs/specs/otel/trace/sdk/#traceidratiobased>`_
+// [#extension: envoy.tracers.opentelemetry.samplers.trace_id_ratio_based]
+
+message TraceIdRatioBasedSamplerConfig {
+  // This is a required value in the [0, 1] interval, If the given trace_id
+  // falls into a given ratio of all possible trace_id values, ShouldSample will
+  // return RECORD_AND_SAMPLE.
+  // required
+  // [#extension-category: envoy.tracers.opentelemetry.samplers]
+  double ratio = 1;
+}

--- a/api/envoy/extensions/tracers/opentelemetry/samplers/v3/trace_id_ratio_based_sampler.proto
+++ b/api/envoy/extensions/tracers/opentelemetry/samplers/v3/trace_id_ratio_based_sampler.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package envoy.extensions.tracers.opentelemetry.samplers.v3;
 
+import "envoy/type/v3/percent.proto";
+
 import "udpa/annotations/status.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.tracers.opentelemetry.samplers.v3";
@@ -20,10 +22,9 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // [#extension: envoy.tracers.opentelemetry.samplers.trace_id_ratio_based]
 
 message TraceIdRatioBasedSamplerConfig {
-  // This is a required value in the [0, 1] interval, If the given trace_id
-  // falls into a given ratio of all possible trace_id values, ShouldSample will
-  // return RECORD_AND_SAMPLE.
+  // If the given trace_id falls into a given percentage of all possible
+  // trace_id values, ShouldSample will return RECORD_AND_SAMPLE.
   // required
   // [#extension-category: envoy.tracers.opentelemetry.samplers]
-  double ratio = 1;
+  type.v3.FractionalPercent sampling_percentage = 2;
 }

--- a/api/envoy/extensions/tracers/opentelemetry/samplers/v3/trace_id_ratio_based_sampler.proto
+++ b/api/envoy/extensions/tracers/opentelemetry/samplers/v3/trace_id_ratio_based_sampler.proto
@@ -26,5 +26,5 @@ message TraceIdRatioBasedSamplerConfig {
   // trace_id values, ShouldSample will return RECORD_AND_SAMPLE.
   // required
   // [#extension-category: envoy.tracers.opentelemetry.samplers]
-  type.v3.FractionalPercent sampling_percentage = 2;
+  type.v3.FractionalPercent sampling_percentage = 1;
 }

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -614,6 +614,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
             "envoy.tracers.opentelemetry.samplers.always_on",
             "envoy.tracers.opentelemetry.samplers.dynatrace",
             "envoy.tracers.opentelemetry.samplers.cel",
+            "envoy.tracers.opentelemetry.samplers.parent_based",
+            "envoy.tracers.opentelemetry.samplers.trace_id_ratio_based",
         ],
         release_date = "2025-01-22",
         cpe = "N/A",

--- a/source/extensions/extensions_build_config.bzl
+++ b/source/extensions/extensions_build_config.bzl
@@ -298,9 +298,11 @@ EXTENSIONS = {
     # OpenTelemetry tracer samplers
     #
 
-    "envoy.tracers.opentelemetry.samplers.always_on":         "//source/extensions/tracers/opentelemetry/samplers/always_on:config",
-    "envoy.tracers.opentelemetry.samplers.dynatrace":         "//source/extensions/tracers/opentelemetry/samplers/dynatrace:config",
-    "envoy.tracers.opentelemetry.samplers.cel":               "//source/extensions/tracers/opentelemetry/samplers/cel:config",
+    "envoy.tracers.opentelemetry.samplers.cel":                           "//source/extensions/tracers/opentelemetry/samplers/cel:config",
+    "envoy.tracers.opentelemetry.samplers.always_on":                     "//source/extensions/tracers/opentelemetry/samplers/always_on:config",
+    "envoy.tracers.opentelemetry.samplers.dynatrace":                     "//source/extensions/tracers/opentelemetry/samplers/dynatrace:config",
+    "envoy.tracers.opentelemetry.samplers.parent_based":                  "//source/extensions/tracers/opentelemetry/samplers/parent_based:config",
+    "envoy.tracers.opentelemetry.samplers.trace_id_ratio_based":          "//source/extensions/tracers/opentelemetry/samplers/trace_id_ratio_based:config",
 
     #
     # Transport sockets

--- a/source/extensions/extensions_metadata.yaml
+++ b/source/extensions/extensions_metadata.yaml
@@ -1282,6 +1282,20 @@ envoy.tracers.opentelemetry.samplers.always_on:
   status: wip
   type_urls:
   - envoy.extensions.tracers.opentelemetry.samplers.v3.AlwaysOnSamplerConfig
+envoy.tracers.opentelemetry.samplers.parent_based:
+  categories:
+  - envoy.tracers.opentelemetry.samplers
+  security_posture: unknown
+  status: wip
+  type_urls:
+  - envoy.extensions.tracers.opentelemetry.samplers.v3.ParentBasedSamplerConfig
+envoy.tracers.opentelemetry.samplers.trace_id_ratio_based:
+  categories:
+  - envoy.tracers.opentelemetry.samplers
+  security_posture: unknown
+  status: wip
+  type_urls:
+  - envoy.extensions.tracers.opentelemetry.samplers.v3.TraceIdRatioBasedSamplerConfig
 envoy.tracers.opentelemetry.samplers.dynatrace:
   categories:
   - envoy.tracers.opentelemetry.samplers

--- a/source/extensions/tracers/opentelemetry/samplers/parent_based/BUILD
+++ b/source/extensions/tracers/opentelemetry/samplers/parent_based/BUILD
@@ -1,0 +1,34 @@
+load(
+    "//bazel:envoy_build_system.bzl",
+    "envoy_cc_extension",
+    "envoy_cc_library",
+    "envoy_extension_package",
+)
+
+licenses(["notice"])  # Apache 2
+
+envoy_extension_package()
+
+envoy_cc_extension(
+    name = "config",
+    srcs = ["config.cc"],
+    hdrs = ["config.h"],
+    deps = [
+        ":parent_based_sampler_lib",
+        "//envoy/registry",
+        "//source/common/config:utility_lib",
+        "//source/extensions/tracers/opentelemetry/samplers/trace_id_ratio_based:config",
+        "@envoy_api//envoy/extensions/tracers/opentelemetry/samplers/v3:pkg_cc_proto",
+    ],
+)
+
+envoy_cc_library(
+    name = "parent_based_sampler_lib",
+    srcs = ["parent_based_sampler.cc"],
+    hdrs = ["parent_based_sampler.h"],
+    deps = [
+        "//source/extensions/tracers/opentelemetry:opentelemetry_tracer_lib",
+        "//source/extensions/tracers/opentelemetry/samplers:sampler_lib",
+        "@envoy_api//envoy/extensions/tracers/opentelemetry/samplers/v3:pkg_cc_proto",
+    ],
+)

--- a/source/extensions/tracers/opentelemetry/samplers/parent_based/config.cc
+++ b/source/extensions/tracers/opentelemetry/samplers/parent_based/config.cc
@@ -1,0 +1,38 @@
+#include "source/extensions/tracers/opentelemetry/samplers/parent_based/config.h"
+
+#include "envoy/extensions/tracers/opentelemetry/samplers/v3/parent_based_sampler.pb.validate.h"
+#include "envoy/server/tracer_config.h"
+
+#include "source/common/config/utility.h"
+#include "source/extensions/tracers/opentelemetry/samplers/parent_based/parent_based_sampler.h"
+#include "source/extensions/tracers/opentelemetry/samplers/trace_id_ratio_based/config.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace Tracers {
+namespace OpenTelemetry {
+
+SamplerSharedPtr
+ParentBasedSamplerFactory::createSampler(const Protobuf::Message& config,
+                                         Server::Configuration::TracerFactoryContext& context) {
+  auto mptr = Envoy::Config::Utility::translateAnyToFactoryConfig(
+      dynamic_cast<const ProtobufWkt::Any&>(config), context.messageValidationVisitor(), *this);
+  const auto& proto_config = MessageUtil::downcastAndValidate<
+      const envoy::extensions::tracers::opentelemetry::samplers::v3::ParentBasedSamplerConfig&>(
+      *mptr, context.messageValidationVisitor());
+  auto* factory =
+      Envoy::Config::Utility::getFactory<SamplerFactory>(proto_config.wrapped_sampler());
+  SamplerSharedPtr wrapped_sampler =
+      factory->createSampler(proto_config.wrapped_sampler().typed_config(), context);
+  return std::make_shared<ParentBasedSampler>(config, context, wrapped_sampler);
+}
+
+/**
+ * Static registration for the Env sampler factory. @see RegisterFactory.
+ */
+REGISTER_FACTORY(ParentBasedSamplerFactory, SamplerFactory);
+
+} // namespace OpenTelemetry
+} // namespace Tracers
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/tracers/opentelemetry/samplers/parent_based/config.cc
+++ b/source/extensions/tracers/opentelemetry/samplers/parent_based/config.cc
@@ -20,10 +20,10 @@ ParentBasedSamplerFactory::createSampler(const Protobuf::Message& config,
   const auto& proto_config = MessageUtil::downcastAndValidate<
       const envoy::extensions::tracers::opentelemetry::samplers::v3::ParentBasedSamplerConfig&>(
       *mptr, context.messageValidationVisitor());
-  auto* factory =
-      Envoy::Config::Utility::getFactory<SamplerFactory>(proto_config.wrapped_sampler());
+  auto& factory =
+      Envoy::Config::Utility::getAndCheckFactory<SamplerFactory>(proto_config.wrapped_sampler());
   SamplerSharedPtr wrapped_sampler =
-      factory->createSampler(proto_config.wrapped_sampler().typed_config(), context);
+      factory.createSampler(proto_config.wrapped_sampler().typed_config(), context);
   return std::make_shared<ParentBasedSampler>(config, context, wrapped_sampler);
 }
 

--- a/source/extensions/tracers/opentelemetry/samplers/parent_based/config.h
+++ b/source/extensions/tracers/opentelemetry/samplers/parent_based/config.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <string>
+
+#include "envoy/extensions/tracers/opentelemetry/samplers/v3/parent_based_sampler.pb.h"
+#include "envoy/registry/registry.h"
+
+#include "source/extensions/tracers/opentelemetry/samplers/sampler.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace Tracers {
+namespace OpenTelemetry {
+
+/**
+ * Config registration for the ParentBasedSampler. @see SamplerFactory.
+ */
+class ParentBasedSamplerFactory : public SamplerFactory {
+public:
+  /**
+   * @brief Create a Sampler. @see ParentBasedSampler
+   *
+   * @param config Protobuf config for the sampler.
+   * @param context A reference to the TracerFactoryContext.
+   * @return SamplerSharedPtr
+   */
+  SamplerSharedPtr createSampler(const Protobuf::Message& config,
+                                 Server::Configuration::TracerFactoryContext& context) override;
+
+  ProtobufTypes::MessagePtr createEmptyConfigProto() override {
+    return std::make_unique<
+        envoy::extensions::tracers::opentelemetry::samplers::v3::ParentBasedSamplerConfig>();
+  }
+  std::string name() const override { return "envoy.tracers.opentelemetry.samplers.parent_based"; }
+};
+
+DECLARE_FACTORY(ParentBasedSamplerFactory);
+
+} // namespace OpenTelemetry
+} // namespace Tracers
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/tracers/opentelemetry/samplers/parent_based/parent_based_sampler.cc
+++ b/source/extensions/tracers/opentelemetry/samplers/parent_based/parent_based_sampler.cc
@@ -11,14 +11,15 @@ namespace Extensions {
 namespace Tracers {
 namespace OpenTelemetry {
 
-SamplingResult ParentBasedSampler::shouldSample(const absl::optional<SpanContext> parent_context,
+SamplingResult ParentBasedSampler::shouldSample(const StreamInfo::StreamInfo& stream_info,
+                                                const absl::optional<SpanContext> parent_context,
                                                 const std::string& trace_id,
                                                 const std::string& name, OTelSpanKind kind,
                                                 OptRef<const Tracing::TraceContext> trace_context,
                                                 const std::vector<SpanContext>& links) {
   if (!parent_context.has_value() || parent_context->traceId().empty()) {
-    return wrapped_sampler_->shouldSample(parent_context, trace_id, name, kind, trace_context,
-                                          links);
+    return wrapped_sampler_->shouldSample(stream_info, parent_context, trace_id, name, kind,
+                                          trace_context, links);
   }
 
   SamplingResult result;

--- a/source/extensions/tracers/opentelemetry/samplers/parent_based/parent_based_sampler.cc
+++ b/source/extensions/tracers/opentelemetry/samplers/parent_based/parent_based_sampler.cc
@@ -1,0 +1,39 @@
+#include "source/extensions/tracers/opentelemetry/samplers/parent_based/parent_based_sampler.h"
+
+#include <memory>
+#include <sstream>
+#include <string>
+
+#include "source/extensions/tracers/opentelemetry/span_context.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace Tracers {
+namespace OpenTelemetry {
+
+SamplingResult ParentBasedSampler::shouldSample(const absl::optional<SpanContext> parent_context,
+                                                const std::string& trace_id,
+                                                const std::string& name, OTelSpanKind kind,
+                                                OptRef<const Tracing::TraceContext> trace_context,
+                                                const std::vector<SpanContext>& links) {
+  if (!parent_context.has_value() || parent_context->traceId().empty()) {
+    return wrapped_sampler_->shouldSample(parent_context, trace_id, name, kind, trace_context,
+                                          links);
+  }
+
+  SamplingResult result;
+  result.tracestate = parent_context.value().tracestate();
+  if (parent_context->sampled()) {
+    result.decision = Decision::RecordAndSample;
+  } else {
+    result.decision = Decision::Drop;
+  }
+  return result;
+}
+
+std::string ParentBasedSampler::getDescription() const { return "ParentBasedSampler"; }
+
+} // namespace OpenTelemetry
+} // namespace Tracers
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/tracers/opentelemetry/samplers/parent_based/parent_based_sampler.h
+++ b/source/extensions/tracers/opentelemetry/samplers/parent_based/parent_based_sampler.h
@@ -29,7 +29,8 @@ public:
                               Server::Configuration::TracerFactoryContext& /*context*/,
                               SamplerSharedPtr wrapped_sampler)
       : wrapped_sampler_(wrapped_sampler) {}
-  SamplingResult shouldSample(const absl::optional<SpanContext> parent_context,
+  SamplingResult shouldSample(const StreamInfo::StreamInfo& stream_info,
+                              const absl::optional<SpanContext> parent_context,
                               const std::string& trace_id, const std::string& name,
                               OTelSpanKind spankind,
                               OptRef<const Tracing::TraceContext> trace_context,

--- a/source/extensions/tracers/opentelemetry/samplers/parent_based/parent_based_sampler.h
+++ b/source/extensions/tracers/opentelemetry/samplers/parent_based/parent_based_sampler.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <memory>
+
+#include "envoy/extensions/tracers/opentelemetry/samplers/v3/parent_based_sampler.pb.h"
+#include "envoy/server/factory_context.h"
+
+#include "source/common/common/logger.h"
+#include "source/extensions/tracers/opentelemetry/samplers/sampler.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace Tracers {
+namespace OpenTelemetry {
+
+/**
+ * This is a sampler decorator. If the parent context is empty or doesn't have a valid traceId,
+ * the ParentBasedSampler will delegate the decision to the wrapped sampler.
+ * Otherwise, it will decide based on the sampled flag of the parent context:
+ * if parent_context->sampled -> return RecordAndSample
+ * else -> return Decision::Drop
+ * Check https://opentelemetry.io/docs/specs/otel/trace/sdk/#parentbased for the official docs and
+ * https://github.com/open-telemetry/opentelemetry-cpp/blob/eb2b9753ea2df64079e07d40489388ea1b323108/sdk/src/trace/samplers/parent.cc#L30
+ * for an official implementation
+ */
+class ParentBasedSampler : public Sampler, Logger::Loggable<Logger::Id::tracing> {
+public:
+  explicit ParentBasedSampler(const Protobuf::Message& /*config*/,
+                              Server::Configuration::TracerFactoryContext& /*context*/,
+                              SamplerSharedPtr wrapped_sampler)
+      : wrapped_sampler_(wrapped_sampler) {}
+  SamplingResult shouldSample(const absl::optional<SpanContext> parent_context,
+                              const std::string& trace_id, const std::string& name,
+                              OTelSpanKind spankind,
+                              OptRef<const Tracing::TraceContext> trace_context,
+                              const std::vector<SpanContext>& links) override;
+  std::string getDescription() const override;
+
+private:
+  SamplerSharedPtr wrapped_sampler_;
+};
+
+} // namespace OpenTelemetry
+} // namespace Tracers
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/tracers/opentelemetry/samplers/trace_id_ratio_based/BUILD
+++ b/source/extensions/tracers/opentelemetry/samplers/trace_id_ratio_based/BUILD
@@ -1,0 +1,34 @@
+load(
+    "//bazel:envoy_build_system.bzl",
+    "envoy_cc_extension",
+    "envoy_cc_library",
+    "envoy_extension_package",
+)
+
+licenses(["notice"])  # Apache 2
+
+envoy_extension_package()
+
+envoy_cc_extension(
+    name = "config",
+    srcs = ["config.cc"],
+    hdrs = ["config.h"],
+    deps = [
+        ":trace_id_ratio_based_sampler_lib",
+        "//envoy/registry",
+        "//source/common/config:utility_lib",
+        "@envoy_api//envoy/extensions/tracers/opentelemetry/samplers/v3:pkg_cc_proto",
+    ],
+)
+
+envoy_cc_library(
+    name = "trace_id_ratio_based_sampler_lib",
+    srcs = ["trace_id_ratio_based_sampler.cc"],
+    hdrs = ["trace_id_ratio_based_sampler.h"],
+    deps = [
+        "//source/common/common:safe_memcpy_lib",
+        "//source/extensions/tracers/opentelemetry:opentelemetry_tracer_lib",
+        "//source/extensions/tracers/opentelemetry/samplers:sampler_lib",
+        "@envoy_api//envoy/extensions/tracers/opentelemetry/samplers/v3:pkg_cc_proto",
+    ],
+)

--- a/source/extensions/tracers/opentelemetry/samplers/trace_id_ratio_based/BUILD
+++ b/source/extensions/tracers/opentelemetry/samplers/trace_id_ratio_based/BUILD
@@ -26,6 +26,8 @@ envoy_cc_library(
     srcs = ["trace_id_ratio_based_sampler.cc"],
     hdrs = ["trace_id_ratio_based_sampler.h"],
     deps = [
+        # "//source/common/common:minimal_logger_lib",
+        "//source/common/common:logger_lib",
         "//source/common/common:safe_memcpy_lib",
         "//source/extensions/tracers/opentelemetry:opentelemetry_tracer_lib",
         "//source/extensions/tracers/opentelemetry/samplers:sampler_lib",

--- a/source/extensions/tracers/opentelemetry/samplers/trace_id_ratio_based/BUILD
+++ b/source/extensions/tracers/opentelemetry/samplers/trace_id_ratio_based/BUILD
@@ -26,7 +26,6 @@ envoy_cc_library(
     srcs = ["trace_id_ratio_based_sampler.cc"],
     hdrs = ["trace_id_ratio_based_sampler.h"],
     deps = [
-        # "//source/common/common:minimal_logger_lib",
         "//source/common/common:logger_lib",
         "//source/common/common:safe_memcpy_lib",
         "//source/extensions/tracers/opentelemetry:opentelemetry_tracer_lib",

--- a/source/extensions/tracers/opentelemetry/samplers/trace_id_ratio_based/BUILD
+++ b/source/extensions/tracers/opentelemetry/samplers/trace_id_ratio_based/BUILD
@@ -30,5 +30,6 @@ envoy_cc_library(
         "//source/extensions/tracers/opentelemetry:opentelemetry_tracer_lib",
         "//source/extensions/tracers/opentelemetry/samplers:sampler_lib",
         "@envoy_api//envoy/extensions/tracers/opentelemetry/samplers/v3:pkg_cc_proto",
+        "@envoy_api//envoy/type/v3:pkg_cc_proto",
     ],
 )

--- a/source/extensions/tracers/opentelemetry/samplers/trace_id_ratio_based/config.cc
+++ b/source/extensions/tracers/opentelemetry/samplers/trace_id_ratio_based/config.cc
@@ -1,0 +1,36 @@
+#include "source/extensions/tracers/opentelemetry/samplers/trace_id_ratio_based/config.h"
+
+#include "envoy/extensions/tracers/opentelemetry/samplers/v3/trace_id_ratio_based_sampler.pb.h"
+#include "envoy/extensions/tracers/opentelemetry/samplers/v3/trace_id_ratio_based_sampler.pb.validate.h"
+#include "envoy/server/tracer_config.h"
+
+#include "source/common/config/utility.h"
+#include "source/extensions/tracers/opentelemetry/samplers/trace_id_ratio_based/trace_id_ratio_based_sampler.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace Tracers {
+namespace OpenTelemetry {
+
+SamplerSharedPtr TraceIdRatioBasedSamplerFactory::createSampler(
+    const Protobuf::Message& config, Server::Configuration::TracerFactoryContext& context) {
+  auto mptr = Envoy::Config::Utility::translateAnyToFactoryConfig(
+      dynamic_cast<const ProtobufWkt::Any&>(config), context.messageValidationVisitor(), *this);
+
+  const auto& proto_config =
+      MessageUtil::downcastAndValidate<const envoy::extensions::tracers::opentelemetry::samplers::
+                                           v3::TraceIdRatioBasedSamplerConfig&>(
+          *mptr, context.messageValidationVisitor());
+
+  return std::make_shared<TraceIdRatioBasedSampler>(proto_config, context);
+}
+
+/**
+ * Static registration for the Env sampler factory. @see RegisterFactory.
+ */
+REGISTER_FACTORY(TraceIdRatioBasedSamplerFactory, SamplerFactory);
+
+} // namespace OpenTelemetry
+} // namespace Tracers
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/tracers/opentelemetry/samplers/trace_id_ratio_based/config.h
+++ b/source/extensions/tracers/opentelemetry/samplers/trace_id_ratio_based/config.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <string>
+
+#include "envoy/extensions/tracers/opentelemetry/samplers/v3/trace_id_ratio_based_sampler.pb.h"
+#include "envoy/registry/registry.h"
+
+#include "source/extensions/tracers/opentelemetry/samplers/sampler.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace Tracers {
+namespace OpenTelemetry {
+
+/**
+ * Config registration for the TraceIdRatioBasedSampler. @see SamplerFactory.
+ */
+class TraceIdRatioBasedSamplerFactory : public SamplerFactory {
+public:
+  /**
+   * @brief Create a Sampler. @see TraceIdRatioBasedSampler
+   *
+   * @param config Protobuf config for the sampler.
+   * @param context A reference to the TracerFactoryContext.
+   * @return SamplerSharedPtr
+   */
+  SamplerSharedPtr createSampler(const Protobuf::Message& config,
+                                 Server::Configuration::TracerFactoryContext& context) override;
+
+  ProtobufTypes::MessagePtr createEmptyConfigProto() override {
+    return std::make_unique<
+        envoy::extensions::tracers::opentelemetry::samplers::v3::TraceIdRatioBasedSamplerConfig>();
+  }
+
+  std::string name() const override {
+    return "envoy.tracers.opentelemetry.samplers.trace_id_ratio_based";
+  }
+};
+
+DECLARE_FACTORY(TraceIdRatioBasedSamplerFactory);
+
+} // namespace OpenTelemetry
+} // namespace Tracers
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/tracers/opentelemetry/samplers/trace_id_ratio_based/trace_id_ratio_based_sampler.cc
+++ b/source/extensions/tracers/opentelemetry/samplers/trace_id_ratio_based/trace_id_ratio_based_sampler.cc
@@ -82,12 +82,11 @@ TraceIdRatioBasedSampler::TraceIdRatioBasedSampler(
   description_ = "TraceIdRatioBasedSampler{" + std::to_string(ratio) + "}";
 }
 
-SamplingResult
-TraceIdRatioBasedSampler::shouldSample(const absl::optional<SpanContext> parent_context,
-                                       const std::string& trace_id, const std::string& /*name*/,
-                                       OTelSpanKind /*kind*/,
-                                       OptRef<const Tracing::TraceContext> /*trace_context*/,
-                                       const std::vector<SpanContext>& /*links*/) {
+SamplingResult TraceIdRatioBasedSampler::shouldSample(
+    const StreamInfo::StreamInfo&, const absl::optional<SpanContext> parent_context,
+    const std::string& trace_id, const std::string& /*name*/, OTelSpanKind /*kind*/,
+    OptRef<const Tracing::TraceContext> /*trace_context*/,
+    const std::vector<SpanContext>& /*links*/) {
   SamplingResult result;
   result.decision = Decision::Drop;
   if (parent_context.has_value()) {

--- a/source/extensions/tracers/opentelemetry/samplers/trace_id_ratio_based/trace_id_ratio_based_sampler.cc
+++ b/source/extensions/tracers/opentelemetry/samplers/trace_id_ratio_based/trace_id_ratio_based_sampler.cc
@@ -1,0 +1,114 @@
+#include "source/extensions/tracers/opentelemetry/samplers/trace_id_ratio_based/trace_id_ratio_based_sampler.h"
+
+#include <cstdint>
+#include <cstring>
+#include <iostream>
+#include <memory>
+#include <sstream>
+#include <string>
+
+#include "source/common/common/safe_memcpy.h"
+#include "source/extensions/tracers/opentelemetry/span_context.h"
+
+namespace {
+/**
+ * Converts a ratio in [0, 1] to a threshold in [0, UINT64_MAX].
+ *
+ * Adapted from https://github.com/open-telemetry/opentelemetry-cpp
+ */
+uint64_t ratioToThreshold(double ratio) noexcept {
+  if (ratio <= 0.0) {
+    return 0;
+  }
+  if (ratio >= 1.0) {
+    return UINT64_MAX;
+  }
+
+  // We can't directly return ratio * UINT64_MAX because of precision issues with doubles.
+  //
+  // UINT64_MAX is (2^64 - 1), but a double has limited precision and rounds up when
+  // converting large numbers. For probabilities >= 1 - (2^-54), multiplying by UINT64_MAX
+  // can cause overflow and the result wraps around to zero!
+  // We know (UINT64_MAX)*ratio = (UINT32_MAX*2^32 + UINT32_MAX)*ratio. So, To avoid this,
+  // we calculate the high and low 32 bits separately by using the double's precision to
+  // get the most accurate result.
+  // Then we add the the high and low bits to get the result.
+  const double product = UINT32_MAX * ratio;
+  double hi_bits;
+  double lo_bits = modf(product, &hi_bits);
+  lo_bits = ldexp(lo_bits, 32) + product;
+  return (static_cast<uint64_t>(hi_bits) << 32) + static_cast<uint64_t>(lo_bits);
+}
+
+/**
+ * @param trace_id a required value to be converted to uint64_t. trace_id must
+ * at least 8 bytes long. trace_id is expected to be a valid hex string.
+ * @return Returns the uint64 value associated with first 8 bytes of the trace_id.
+ *
+ * Adapted from https://github.com/open-telemetry/opentelemetry-cpp
+ */
+uint64_t calculateThresholdFromBuffer(const std::string& trace_id) noexcept {
+  uint8_t buffer[8] = {0};
+  for (size_t i = 0; i < 8; ++i) {
+    std::string byte_string = trace_id.substr(i * 2, 2);
+    buffer[i] = static_cast<uint8_t>(std::stoul(byte_string, nullptr, 16));
+  }
+
+  uint64_t first_8_bytes = 0;
+  Envoy::safeMemcpyUnsafeSrc(&first_8_bytes, buffer);
+  double ratio = static_cast<double>(first_8_bytes) / static_cast<double>(UINT64_MAX);
+
+  return ratioToThreshold(ratio);
+}
+} // namespace
+
+namespace Envoy {
+namespace Extensions {
+namespace Tracers {
+namespace OpenTelemetry {
+
+TraceIdRatioBasedSampler::TraceIdRatioBasedSampler(
+    const envoy::extensions::tracers::opentelemetry::samplers::v3::TraceIdRatioBasedSamplerConfig&
+        config,
+    Server::Configuration::TracerFactoryContext& /*context*/)
+    : threshold_(ratioToThreshold(config.ratio())) {
+  double ratio = config.ratio();
+  if (ratio > 1.0) {
+    ratio = 1.0;
+  }
+  if (ratio < 0.0) {
+    ratio = 0.0;
+  }
+  description_ = "TraceIdRatioBasedSampler{" + std::to_string(ratio) + "}";
+}
+
+SamplingResult
+TraceIdRatioBasedSampler::shouldSample(const absl::optional<SpanContext> parent_context,
+                                       const std::string& trace_id, const std::string& /*name*/,
+                                       OTelSpanKind /*kind*/,
+                                       OptRef<const Tracing::TraceContext> /*trace_context*/,
+                                       const std::vector<SpanContext>& /*links*/) {
+  SamplingResult result;
+  result.decision = Decision::Drop;
+  if (parent_context.has_value()) {
+    result.tracestate = parent_context.value().tracestate();
+  }
+
+  if (threshold_ == 0) {
+    return result;
+  }
+
+  if (calculateThresholdFromBuffer(trace_id) <= threshold_) {
+    result.decision = Decision::RecordAndSample;
+    return result;
+  }
+
+  return result;
+}
+
+std::string TraceIdRatioBasedSampler::getDescription() const { return description_; }
+
+} // namespace OpenTelemetry
+} // namespace Tracers
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/tracers/opentelemetry/samplers/trace_id_ratio_based/trace_id_ratio_based_sampler.h
+++ b/source/extensions/tracers/opentelemetry/samplers/trace_id_ratio_based/trace_id_ratio_based_sampler.h
@@ -23,7 +23,8 @@ public:
                                         TraceIdRatioBasedSamplerConfig& /*config*/,
                                     Server::Configuration::TracerFactoryContext& /*context*/);
 
-  SamplingResult shouldSample(const absl::optional<SpanContext> parent_context,
+  SamplingResult shouldSample(const StreamInfo::StreamInfo& stream_info,
+                              const absl::optional<SpanContext> parent_context,
                               const std::string& trace_id, const std::string& name,
                               OTelSpanKind spankind,
                               OptRef<const Tracing::TraceContext> trace_context,

--- a/source/extensions/tracers/opentelemetry/samplers/trace_id_ratio_based/trace_id_ratio_based_sampler.h
+++ b/source/extensions/tracers/opentelemetry/samplers/trace_id_ratio_based/trace_id_ratio_based_sampler.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <memory>
+
+#include "envoy/extensions/tracers/opentelemetry/samplers/v3/trace_id_ratio_based_sampler.pb.h"
+#include "envoy/server/factory_context.h"
+
+#include "source/common/common/logger.h"
+#include "source/extensions/tracers/opentelemetry/samplers/sampler.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace Tracers {
+namespace OpenTelemetry {
+/**
+ * https://opentelemetry.io/docs/specs/otel/trace/sdk/#traceidratiobased
+ * The TraceIdRatioBased MUST ignore the parent SampledFlag. To respect the parent SampledFlag, the
+ * TraceIdRatioBased should be used as a delegate of the ParentBased sampler.
+ */
+class TraceIdRatioBasedSampler : public Sampler, Logger::Loggable<Logger::Id::tracing> {
+public:
+  explicit TraceIdRatioBasedSampler(const envoy::extensions::tracers::opentelemetry::samplers::v3::
+                                        TraceIdRatioBasedSamplerConfig& /*config*/,
+                                    Server::Configuration::TracerFactoryContext& /*context*/);
+
+  SamplingResult shouldSample(const absl::optional<SpanContext> parent_context,
+                              const std::string& trace_id, const std::string& name,
+                              OTelSpanKind spankind,
+                              OptRef<const Tracing::TraceContext> trace_context,
+                              const std::vector<SpanContext>& links) override;
+  std::string getDescription() const override;
+
+private:
+  std::string description_;
+  const uint64_t threshold_;
+};
+
+} // namespace OpenTelemetry
+} // namespace Tracers
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/tracers/opentelemetry/samplers/trace_id_ratio_based/trace_id_ratio_based_sampler.h
+++ b/source/extensions/tracers/opentelemetry/samplers/trace_id_ratio_based/trace_id_ratio_based_sampler.h
@@ -4,6 +4,7 @@
 
 #include "envoy/extensions/tracers/opentelemetry/samplers/v3/trace_id_ratio_based_sampler.pb.h"
 #include "envoy/server/factory_context.h"
+#include "envoy/type/v3/percent.pb.h"
 
 #include "source/common/common/logger.h"
 #include "source/extensions/tracers/opentelemetry/samplers/sampler.h"
@@ -33,7 +34,7 @@ public:
 
 private:
   std::string description_;
-  const uint64_t threshold_;
+  const envoy::type::v3::FractionalPercent sampling_percentage_;
 };
 
 } // namespace OpenTelemetry

--- a/source/extensions/tracers/opentelemetry/samplers/trace_id_ratio_based/trace_id_ratio_based_sampler.h
+++ b/source/extensions/tracers/opentelemetry/samplers/trace_id_ratio_based/trace_id_ratio_based_sampler.h
@@ -31,6 +31,7 @@ public:
                               OptRef<const Tracing::TraceContext> trace_context,
                               const std::vector<SpanContext>& links) override;
   std::string getDescription() const override;
+  uint64_t traceIdToUint64(const std::string& trace_id) noexcept;
 
 private:
   std::string description_;

--- a/test/extensions/tracers/opentelemetry/samplers/parent_based/BUILD
+++ b/test/extensions/tracers/opentelemetry/samplers/parent_based/BUILD
@@ -1,0 +1,60 @@
+load(
+    "//bazel:envoy_build_system.bzl",
+    "envoy_package",
+)
+load(
+    "//test/extensions:extensions_build_system.bzl",
+    "envoy_extension_cc_test",
+)
+
+licenses(["notice"])  # Apache 2
+
+envoy_package()
+
+envoy_extension_cc_test(
+    name = "config_test",
+    srcs = ["config_test.cc"],
+    extension_names = ["envoy.tracers.opentelemetry.samplers.parent_based"],
+    rbe_pool = "6gig",
+    deps = [
+        "//envoy/registry",
+        "//source/extensions/tracers/opentelemetry/samplers/parent_based:config",
+        "//source/extensions/tracers/opentelemetry/samplers/parent_based:parent_based_sampler_lib",
+        "//test/mocks/server:tracer_factory_context_mocks",
+        "//test/test_common:utility_lib",
+    ],
+)
+
+envoy_extension_cc_test(
+    name = "parent_based_sampler_test",
+    srcs = ["parent_based_sampler_test.cc"],
+    extension_names = ["envoy.tracers.opentelemetry.samplers.parent_based"],
+    rbe_pool = "6gig",
+    deps = [
+        "//source/common/common:random_generator_lib",
+        "//source/extensions/tracers/opentelemetry/samplers/parent_based:config",
+        "//source/extensions/tracers/opentelemetry/samplers/parent_based:parent_based_sampler_lib",
+        "//source/extensions/tracers/opentelemetry/samplers/trace_id_ratio_based:config",
+        "//source/extensions/tracers/opentelemetry/samplers/trace_id_ratio_based:trace_id_ratio_based_sampler_lib",
+        "//test/mocks/server:tracer_factory_context_mocks",
+        "//test/test_common:utility_lib",
+        "@envoy_api//envoy/extensions/tracers/opentelemetry/samplers/v3:pkg_cc_proto",
+    ],
+)
+
+envoy_extension_cc_test(
+    name = "parent_based_sampler_integration_test",
+    srcs = [
+        "parent_based_sampler_integration_test.cc",
+    ],
+    extension_names = ["envoy.tracers.opentelemetry.samplers.parent_based"],
+    rbe_pool = "6gig",
+    deps = [
+        "//source/exe:main_common_lib",
+        "//source/extensions/tracers/opentelemetry:config",
+        "//source/extensions/tracers/opentelemetry/samplers/parent_based:config",
+        "//test/integration:http_integration_lib",
+        "//test/test_common:utility_lib",
+        "@envoy_api//envoy/extensions/filters/network/http_connection_manager/v3:pkg_cc_proto",
+    ],
+)

--- a/test/extensions/tracers/opentelemetry/samplers/parent_based/config_test.cc
+++ b/test/extensions/tracers/opentelemetry/samplers/parent_based/config_test.cc
@@ -1,0 +1,43 @@
+#include "envoy/registry/registry.h"
+
+#include "source/extensions/tracers/opentelemetry/samplers/parent_based/config.h"
+
+#include "test/mocks/server/tracer_factory_context.h"
+#include "test/test_common/utility.h"
+
+#include "gtest/gtest.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace Tracers {
+namespace OpenTelemetry {
+
+// Test create sampler via factory
+TEST(ParentBasedSamplerFactoryTest, Test) {
+  auto* factory = Registry::FactoryRegistry<SamplerFactory>::getFactory(
+      "envoy.tracers.opentelemetry.samplers.parent_based");
+  ASSERT_NE(factory, nullptr);
+  EXPECT_STREQ(factory->name().c_str(), "envoy.tracers.opentelemetry.samplers.parent_based");
+  EXPECT_NE(factory->createEmptyConfigProto(), nullptr);
+
+  envoy::config::core::v3::TypedExtensionConfig typed_config;
+  const std::string yaml = R"EOF(
+    name: envoy.tracers.opentelemetry.samplers.parent_based
+    typed_config:
+        "@type": type.googleapis.com/envoy.extensions.tracers.opentelemetry.samplers.v3.ParentBasedSamplerConfig
+        wrapped_sampler:
+            name: envoy.tracers.opentelemetry.samplers.trace_id_ratio_based
+            typed_config:
+                "@type": type.googleapis.com/envoy.extensions.tracers.opentelemetry.samplers.v3.TraceIdRatioBasedSamplerConfig
+                ratio: "0.002"
+  )EOF";
+  TestUtility::loadFromYaml(yaml, typed_config);
+  NiceMock<Server::Configuration::MockTracerFactoryContext> context;
+  EXPECT_NE(factory->createSampler(typed_config.typed_config(), context), nullptr);
+  EXPECT_STREQ(factory->name().c_str(), "envoy.tracers.opentelemetry.samplers.parent_based");
+}
+
+} // namespace OpenTelemetry
+} // namespace Tracers
+} // namespace Extensions
+} // namespace Envoy

--- a/test/extensions/tracers/opentelemetry/samplers/parent_based/config_test.cc
+++ b/test/extensions/tracers/opentelemetry/samplers/parent_based/config_test.cc
@@ -29,7 +29,9 @@ TEST(ParentBasedSamplerFactoryTest, Test) {
             name: envoy.tracers.opentelemetry.samplers.trace_id_ratio_based
             typed_config:
                 "@type": type.googleapis.com/envoy.extensions.tracers.opentelemetry.samplers.v3.TraceIdRatioBasedSamplerConfig
-                ratio: "0.002"
+                sampling_percentage:
+                    numerator: 20
+                    denominator: TEN_THOUSAND
   )EOF";
   TestUtility::loadFromYaml(yaml, typed_config);
   NiceMock<Server::Configuration::MockTracerFactoryContext> context;

--- a/test/extensions/tracers/opentelemetry/samplers/parent_based/parent_based_sampler_integration_test.cc
+++ b/test/extensions/tracers/opentelemetry/samplers/parent_based/parent_based_sampler_integration_test.cc
@@ -19,10 +19,11 @@ namespace {
 const char* TRACEPARENT_VALUE = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01";
 const char* TRACEPARENT_VALUE_START = "00-0af7651916cd43dd8448eb211c80319c";
 
-class AlwaysOnSamplerIntegrationTest : public Envoy::HttpIntegrationTest,
-                                       public testing::TestWithParam<Network::Address::IpVersion> {
+class ParentBasedSamplerIntegrationTest
+    : public Envoy::HttpIntegrationTest,
+      public testing::TestWithParam<Network::Address::IpVersion> {
 public:
-  AlwaysOnSamplerIntegrationTest() : HttpIntegrationTest(Http::CodecType::HTTP1, GetParam()) {
+  ParentBasedSamplerIntegrationTest() : HttpIntegrationTest(Http::CodecType::HTTP1, GetParam()) {
 
     const std::string yaml_string = R"EOF(
   provider:
@@ -35,9 +36,14 @@ public:
         timeout: 0.250s
       service_name: "a_service_name"
       sampler:
-        name: envoy.tracers.opentelemetry.samplers.always_on
+        name: envoy.tracers.opentelemetry.samplers.parent_based
         typed_config:
-          "@type": type.googleapis.com/envoy.extensions.tracers.opentelemetry.samplers.v3.AlwaysOnSamplerConfig
+          "@type": type.googleapis.com/envoy.extensions.tracers.opentelemetry.samplers.v3.ParentBasedSamplerConfig
+          wrapped_sampler:
+            name: envoy.tracers.opentelemetry.samplers.trace_id_ratio_based
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.tracers.opentelemetry.samplers.v3.TraceIdRatioBasedSamplerConfig
+          ratio: 0.5
   )EOF";
 
     auto tracing_config =
@@ -53,12 +59,12 @@ public:
   }
 };
 
-INSTANTIATE_TEST_SUITE_P(IpVersions, AlwaysOnSamplerIntegrationTest,
+INSTANTIATE_TEST_SUITE_P(IpVersions, ParentBasedSamplerIntegrationTest,
                          testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                          TestUtility::ipTestParamsToString);
 
 // Sends a request with traceparent and tracestate header.
-TEST_P(AlwaysOnSamplerIntegrationTest, TestWithTraceparentAndTracestate) {
+TEST_P(ParentBasedSamplerIntegrationTest, TestWithTraceparentAndTracestate) {
   Http::TestRequestHeaderMapImpl request_headers{
       {":method", "GET"},     {":path", "/test/long/url"}, {":scheme", "http"},
       {":authority", "host"}, {"tracestate", "key=value"}, {"traceparent", TRACEPARENT_VALUE}};
@@ -85,7 +91,7 @@ TEST_P(AlwaysOnSamplerIntegrationTest, TestWithTraceparentAndTracestate) {
 }
 
 // Sends a request with traceparent but no tracestate header.
-TEST_P(AlwaysOnSamplerIntegrationTest, TestWithTraceparentOnly) {
+TEST_P(ParentBasedSamplerIntegrationTest, TestWithTraceparentOnly) {
   Http::TestRequestHeaderMapImpl request_headers{{":method", "GET"},
                                                  {":path", "/test/long/url"},
                                                  {":scheme", "http"},
@@ -113,7 +119,7 @@ TEST_P(AlwaysOnSamplerIntegrationTest, TestWithTraceparentOnly) {
 }
 
 // Sends a request without traceparent and tracestate header.
-TEST_P(AlwaysOnSamplerIntegrationTest, TestWithoutTraceparentAndTracestate) {
+TEST_P(ParentBasedSamplerIntegrationTest, TestWithoutTraceparentAndTracestate) {
   Http::TestRequestHeaderMapImpl request_headers{
       {":method", "GET"}, {":path", "/test/long/url"}, {":scheme", "http"}, {":authority", "host"}};
 

--- a/test/extensions/tracers/opentelemetry/samplers/parent_based/parent_based_sampler_integration_test.cc
+++ b/test/extensions/tracers/opentelemetry/samplers/parent_based/parent_based_sampler_integration_test.cc
@@ -43,7 +43,9 @@ public:
             name: envoy.tracers.opentelemetry.samplers.trace_id_ratio_based
         typed_config:
           "@type": type.googleapis.com/envoy.extensions.tracers.opentelemetry.samplers.v3.TraceIdRatioBasedSamplerConfig
-          ratio: 0.5
+          sampling_percentage:
+              numerator: 50
+              denominator: HUNDRED
   )EOF";
 
     auto tracing_config =

--- a/test/extensions/tracers/opentelemetry/samplers/parent_based/parent_based_sampler_test.cc
+++ b/test/extensions/tracers/opentelemetry/samplers/parent_based/parent_based_sampler_test.cc
@@ -1,0 +1,130 @@
+#include <string>
+
+#include "envoy/extensions/tracers/opentelemetry/samplers/v3/parent_based_sampler.pb.h"
+#include "envoy/extensions/tracers/opentelemetry/samplers/v3/trace_id_ratio_based_sampler.pb.h"
+
+#include "source/common/common/random_generator.h"
+#include "source/extensions/tracers/opentelemetry/samplers/parent_based/parent_based_sampler.h"
+#include "source/extensions/tracers/opentelemetry/samplers/trace_id_ratio_based/trace_id_ratio_based_sampler.h"
+#include "source/extensions/tracers/opentelemetry/span_context.h"
+
+#include "test/mocks/server/tracer_factory_context.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace Tracers {
+namespace OpenTelemetry {
+
+// // Verify the ShouldSample function
+TEST(ParentBasedSamplerTest, TestShouldSample) {
+  // Case 1: Parent doesn't exist -> Return result of delegateSampler()
+  NiceMock<Server::Configuration::MockTracerFactoryContext> context;
+  envoy::extensions::tracers::opentelemetry::samplers::v3::TraceIdRatioBasedSamplerConfig
+      trace_id_ratio_based_config;
+  envoy::extensions::tracers::opentelemetry::samplers::v3::ParentBasedSamplerConfig
+      parent_based_config;
+  std::srand(std::time(nullptr));
+
+  for (int i = 0; i < 100; ++i) {
+    trace_id_ratio_based_config.set_ratio(static_cast<double>(std::rand()) / RAND_MAX);
+    auto wrapped_sampler =
+        std::make_shared<TraceIdRatioBasedSampler>(trace_id_ratio_based_config, context);
+
+    auto sampler =
+        std::make_shared<ParentBasedSampler>(parent_based_config, context, wrapped_sampler);
+
+    Random::RandomGeneratorImpl random_generator;
+    uint64_t trace_id_high = random_generator.random();
+    uint64_t trace_id_low = random_generator.random();
+    auto trace_id = absl::StrCat(Hex::uint64ToHex(trace_id_high), Hex::uint64ToHex(trace_id_low));
+
+    auto root_sampling_result = wrapped_sampler->shouldSample(
+        absl::nullopt, trace_id, "a_random_name",
+        ::opentelemetry::proto::trace::v1::Span::SPAN_KIND_SERVER, {}, {});
+    auto sampling_result =
+        sampler->shouldSample(absl::nullopt, trace_id, "a_random_name",
+                              ::opentelemetry::proto::trace::v1::Span::SPAN_KIND_SERVER, {}, {});
+
+    EXPECT_EQ(sampling_result.decision, root_sampling_result.decision);
+    EXPECT_EQ(sampling_result.isRecording(), root_sampling_result.isRecording());
+    EXPECT_EQ(sampling_result.isSampled(), root_sampling_result.isSampled());
+  }
+
+  // Case 2: Parent exists and SampledFlag is true -> Return RecordAndSample.
+  for (int i = 0; i < 10; ++i) {
+    trace_id_ratio_based_config.set_ratio(static_cast<double>(std::rand()) / RAND_MAX);
+    auto wrapped_sampler =
+        std::make_shared<TraceIdRatioBasedSampler>(trace_id_ratio_based_config, context);
+
+    auto sampler =
+        std::make_shared<ParentBasedSampler>(parent_based_config, context, wrapped_sampler);
+
+    Random::RandomGeneratorImpl random_generator;
+    uint64_t trace_id_high = random_generator.random();
+    uint64_t trace_id_low = random_generator.random();
+    auto trace_id = absl::StrCat(Hex::uint64ToHex(trace_id_high), Hex::uint64ToHex(trace_id_low));
+    SpanContext parent_context("0", "12345", "45678", true, "random_key=random_value");
+    auto sampling_result =
+        sampler->shouldSample(parent_context, trace_id, "a_random_name",
+                              ::opentelemetry::proto::trace::v1::Span::SPAN_KIND_SERVER, {}, {});
+
+    EXPECT_EQ(sampling_result.decision, Decision::RecordAndSample);
+    EXPECT_TRUE(sampling_result.isRecording());
+    EXPECT_TRUE(sampling_result.isSampled());
+  }
+
+  // Case 3: Parent exists and SampledFlag is false -> Return Drop.
+  for (int i = 0; i < 10; ++i) {
+    trace_id_ratio_based_config.set_ratio(static_cast<double>(std::rand()) / RAND_MAX);
+    auto wrapped_sampler =
+        std::make_shared<TraceIdRatioBasedSampler>(trace_id_ratio_based_config, context);
+
+    auto sampler =
+        std::make_shared<ParentBasedSampler>(parent_based_config, context, wrapped_sampler);
+
+    Random::RandomGeneratorImpl random_generator;
+    uint64_t trace_id_high = random_generator.random();
+    uint64_t trace_id_low = random_generator.random();
+    auto trace_id = absl::StrCat(Hex::uint64ToHex(trace_id_high), Hex::uint64ToHex(trace_id_low));
+    SpanContext parent_context("0", "12345", "45678", false, "random_key=random_value");
+    auto sampling_result =
+        sampler->shouldSample(parent_context, trace_id, "a_random_name",
+                              ::opentelemetry::proto::trace::v1::Span::SPAN_KIND_SERVER, {}, {});
+
+    EXPECT_EQ(sampling_result.decision, Decision::Drop);
+    EXPECT_FALSE(sampling_result.isRecording());
+    EXPECT_FALSE(sampling_result.isSampled());
+  }
+}
+
+// Verify the GetDescription function and other tracing attributes
+TEST(ParentBasedSamplerTest, TestGetDescriptionAndContext) {
+  NiceMock<Server::Configuration::MockTracerFactoryContext> context;
+  envoy::extensions::tracers::opentelemetry::samplers::v3::TraceIdRatioBasedSamplerConfig
+      trace_id_ratio_based_config;
+  std::srand(std::time(nullptr));
+  trace_id_ratio_based_config.set_ratio(static_cast<double>(std::rand()) / RAND_MAX);
+  auto wrapped_sampler =
+      std::make_shared<TraceIdRatioBasedSampler>(trace_id_ratio_based_config, context);
+
+  envoy::extensions::tracers::opentelemetry::samplers::v3::ParentBasedSamplerConfig
+      parent_based_config;
+  auto sampler =
+      std::make_shared<ParentBasedSampler>(parent_based_config, context, wrapped_sampler);
+
+  SpanContext parent_context("0", "12345", "45678", false, "random_key=random_value");
+  auto sampling_result =
+      sampler->shouldSample(parent_context, "3f4a7c912a5a82779d2a7573f4c758ba", "a_random_name",
+                            ::opentelemetry::proto::trace::v1::Span::SPAN_KIND_SERVER, {}, {});
+  EXPECT_STREQ(sampler->getDescription().c_str(), "ParentBasedSampler");
+  EXPECT_EQ(sampling_result.attributes, nullptr);
+  EXPECT_STREQ(sampling_result.tracestate.c_str(), "random_key=random_value");
+}
+
+} // namespace OpenTelemetry
+} // namespace Tracers
+} // namespace Extensions
+} // namespace Envoy

--- a/test/extensions/tracers/opentelemetry/samplers/parent_based/parent_based_sampler_test.cc
+++ b/test/extensions/tracers/opentelemetry/samplers/parent_based/parent_based_sampler_test.cc
@@ -18,6 +18,8 @@ namespace Extensions {
 namespace Tracers {
 namespace OpenTelemetry {
 
+const auto percentage_denominator = envoy::type::v3::FractionalPercent::MILLION;
+
 // // Verify the ShouldSample function
 TEST(ParentBasedSamplerTest, TestShouldSample) {
   // Case 1: Parent doesn't exist -> Return result of delegateSampler()
@@ -30,7 +32,11 @@ TEST(ParentBasedSamplerTest, TestShouldSample) {
   std::srand(std::time(nullptr));
 
   for (int i = 0; i < 100; ++i) {
-    trace_id_ratio_based_config.set_ratio(static_cast<double>(std::rand()) / RAND_MAX);
+    uint64_t numerator = std::rand() % ProtobufPercentHelper::fractionalPercentDenominatorToInt(
+                                           percentage_denominator);
+    trace_id_ratio_based_config.mutable_sampling_percentage()->set_denominator(
+        percentage_denominator);
+    trace_id_ratio_based_config.mutable_sampling_percentage()->set_numerator(numerator);
     auto wrapped_sampler =
         std::make_shared<TraceIdRatioBasedSampler>(trace_id_ratio_based_config, context);
 
@@ -56,7 +62,11 @@ TEST(ParentBasedSamplerTest, TestShouldSample) {
 
   // Case 2: Parent exists and SampledFlag is true -> Return RecordAndSample.
   for (int i = 0; i < 10; ++i) {
-    trace_id_ratio_based_config.set_ratio(static_cast<double>(std::rand()) / RAND_MAX);
+    uint64_t numerator = std::rand() % ProtobufPercentHelper::fractionalPercentDenominatorToInt(
+                                           percentage_denominator);
+    trace_id_ratio_based_config.mutable_sampling_percentage()->set_denominator(
+        percentage_denominator);
+    trace_id_ratio_based_config.mutable_sampling_percentage()->set_numerator(numerator);
     auto wrapped_sampler =
         std::make_shared<TraceIdRatioBasedSampler>(trace_id_ratio_based_config, context);
 
@@ -79,7 +89,11 @@ TEST(ParentBasedSamplerTest, TestShouldSample) {
 
   // Case 3: Parent exists and SampledFlag is false -> Return Drop.
   for (int i = 0; i < 10; ++i) {
-    trace_id_ratio_based_config.set_ratio(static_cast<double>(std::rand()) / RAND_MAX);
+    uint64_t numerator = std::rand() % ProtobufPercentHelper::fractionalPercentDenominatorToInt(
+                                           percentage_denominator);
+    trace_id_ratio_based_config.mutable_sampling_percentage()->set_denominator(
+        percentage_denominator);
+    trace_id_ratio_based_config.mutable_sampling_percentage()->set_numerator(numerator);
     auto wrapped_sampler =
         std::make_shared<TraceIdRatioBasedSampler>(trace_id_ratio_based_config, context);
 
@@ -108,7 +122,11 @@ TEST(ParentBasedSamplerTest, TestGetDescriptionAndContext) {
   envoy::extensions::tracers::opentelemetry::samplers::v3::TraceIdRatioBasedSamplerConfig
       trace_id_ratio_based_config;
   std::srand(std::time(nullptr));
-  trace_id_ratio_based_config.set_ratio(static_cast<double>(std::rand()) / RAND_MAX);
+  uint64_t numerator = std::rand() % ProtobufPercentHelper::fractionalPercentDenominatorToInt(
+                                         percentage_denominator);
+  trace_id_ratio_based_config.mutable_sampling_percentage()->set_denominator(
+      percentage_denominator);
+  trace_id_ratio_based_config.mutable_sampling_percentage()->set_numerator(numerator);
   auto wrapped_sampler =
       std::make_shared<TraceIdRatioBasedSampler>(trace_id_ratio_based_config, context);
 

--- a/test/extensions/tracers/opentelemetry/samplers/trace_id_ratio_based/BUILD
+++ b/test/extensions/tracers/opentelemetry/samplers/trace_id_ratio_based/BUILD
@@ -1,0 +1,58 @@
+load(
+    "//bazel:envoy_build_system.bzl",
+    "envoy_package",
+)
+load(
+    "//test/extensions:extensions_build_system.bzl",
+    "envoy_extension_cc_test",
+)
+
+licenses(["notice"])  # Apache 2
+
+envoy_package()
+
+envoy_extension_cc_test(
+    name = "config_test",
+    srcs = ["config_test.cc"],
+    extension_names = ["envoy.tracers.opentelemetry.samplers.trace_id_ratio_based"],
+    rbe_pool = "6gig",
+    deps = [
+        "//envoy/registry",
+        "//source/extensions/tracers/opentelemetry/samplers/trace_id_ratio_based:config",
+        "//source/extensions/tracers/opentelemetry/samplers/trace_id_ratio_based:trace_id_ratio_based_sampler_lib",
+        "//test/mocks/server:tracer_factory_context_mocks",
+        "//test/test_common:utility_lib",
+    ],
+)
+
+envoy_extension_cc_test(
+    name = "trace_id_ratio_based_sampler_test",
+    srcs = ["trace_id_ratio_based_sampler_test.cc"],
+    extension_names = ["envoy.tracers.opentelemetry.samplers.trace_id_ratio_based"],
+    rbe_pool = "6gig",
+    deps = [
+        "//source/common/common:random_generator_lib",
+        "//source/extensions/tracers/opentelemetry/samplers/trace_id_ratio_based:config",
+        "//source/extensions/tracers/opentelemetry/samplers/trace_id_ratio_based:trace_id_ratio_based_sampler_lib",
+        "//test/mocks/server:tracer_factory_context_mocks",
+        "//test/test_common:utility_lib",
+        "@envoy_api//envoy/extensions/tracers/opentelemetry/samplers/v3:pkg_cc_proto",
+    ],
+)
+
+envoy_extension_cc_test(
+    name = "trace_id_ratio_based_sampler_integration_test",
+    srcs = [
+        "trace_id_ratio_based_sampler_integration_test.cc",
+    ],
+    extension_names = ["envoy.tracers.opentelemetry.samplers.trace_id_ratio_based"],
+    rbe_pool = "6gig",
+    deps = [
+        "//source/exe:main_common_lib",
+        "//source/extensions/tracers/opentelemetry:config",
+        "//source/extensions/tracers/opentelemetry/samplers/trace_id_ratio_based:config",
+        "//test/integration:http_integration_lib",
+        "//test/test_common:utility_lib",
+        "@envoy_api//envoy/extensions/filters/network/http_connection_manager/v3:pkg_cc_proto",
+    ],
+)

--- a/test/extensions/tracers/opentelemetry/samplers/trace_id_ratio_based/BUILD
+++ b/test/extensions/tracers/opentelemetry/samplers/trace_id_ratio_based/BUILD
@@ -37,6 +37,7 @@ envoy_extension_cc_test(
         "//test/mocks/server:tracer_factory_context_mocks",
         "//test/test_common:utility_lib",
         "@envoy_api//envoy/extensions/tracers/opentelemetry/samplers/v3:pkg_cc_proto",
+        "@envoy_api//envoy/type/v3:pkg_cc_proto",
     ],
 )
 

--- a/test/extensions/tracers/opentelemetry/samplers/trace_id_ratio_based/config_test.cc
+++ b/test/extensions/tracers/opentelemetry/samplers/trace_id_ratio_based/config_test.cc
@@ -1,0 +1,41 @@
+#include "envoy/registry/registry.h"
+
+#include "source/extensions/tracers/opentelemetry/samplers/trace_id_ratio_based/config.h"
+
+#include "test/mocks/server/tracer_factory_context.h"
+#include "test/test_common/utility.h"
+
+#include "gtest/gtest.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace Tracers {
+namespace OpenTelemetry {
+
+// Test create sampler via factory
+TEST(TraceIdRatioBasedSamplerFactoryTest, Test) {
+  auto* factory = Registry::FactoryRegistry<SamplerFactory>::getFactory(
+      "envoy.tracers.opentelemetry.samplers.trace_id_ratio_based");
+  ASSERT_NE(factory, nullptr);
+  EXPECT_STREQ(factory->name().c_str(),
+               "envoy.tracers.opentelemetry.samplers.trace_id_ratio_based");
+  EXPECT_NE(factory->createEmptyConfigProto(), nullptr);
+
+  envoy::config::core::v3::TypedExtensionConfig typed_config;
+  const std::string yaml = R"EOF(
+    name: envoy.tracers.opentelemetry.samplers.trace_id_ratio_based
+    typed_config:
+        "@type": type.googleapis.com/envoy.extensions.tracers.opentelemetry.samplers.v3.TraceIdRatioBasedSamplerConfig
+        ratio: 0.0002
+  )EOF";
+  TestUtility::loadFromYaml(yaml, typed_config);
+  NiceMock<Server::Configuration::MockTracerFactoryContext> context;
+  EXPECT_NE(factory->createSampler(typed_config.typed_config(), context), nullptr);
+  EXPECT_STREQ(factory->name().c_str(),
+               "envoy.tracers.opentelemetry.samplers.trace_id_ratio_based");
+}
+
+} // namespace OpenTelemetry
+} // namespace Tracers
+} // namespace Extensions
+} // namespace Envoy

--- a/test/extensions/tracers/opentelemetry/samplers/trace_id_ratio_based/config_test.cc
+++ b/test/extensions/tracers/opentelemetry/samplers/trace_id_ratio_based/config_test.cc
@@ -26,7 +26,9 @@ TEST(TraceIdRatioBasedSamplerFactoryTest, Test) {
     name: envoy.tracers.opentelemetry.samplers.trace_id_ratio_based
     typed_config:
         "@type": type.googleapis.com/envoy.extensions.tracers.opentelemetry.samplers.v3.TraceIdRatioBasedSamplerConfig
-        ratio: 0.0002
+        sampling_percentage:
+            numerator: 2
+            denominator: TEN_THOUSAND
   )EOF";
   TestUtility::loadFromYaml(yaml, typed_config);
   NiceMock<Server::Configuration::MockTracerFactoryContext> context;

--- a/test/extensions/tracers/opentelemetry/samplers/trace_id_ratio_based/trace_id_ratio_based_sampler_integration_test.cc
+++ b/test/extensions/tracers/opentelemetry/samplers/trace_id_ratio_based/trace_id_ratio_based_sampler_integration_test.cc
@@ -40,7 +40,9 @@ public:
         name: envoy.tracers.opentelemetry.samplers.trace_id_ratio_based
         typed_config:
           "@type": type.googleapis.com/envoy.extensions.tracers.opentelemetry.samplers.v3.TraceIdRatioBasedSamplerConfig
-          ratio: 0.002
+          sampling_percentage:
+              numerator: 20
+              denominator: TEN_THOUSAND
   )EOF";
 
     auto tracing_config =

--- a/test/extensions/tracers/opentelemetry/samplers/trace_id_ratio_based/trace_id_ratio_based_sampler_test.cc
+++ b/test/extensions/tracers/opentelemetry/samplers/trace_id_ratio_based/trace_id_ratio_based_sampler_test.cc
@@ -1,0 +1,154 @@
+#include <cstdint>
+#include <string>
+
+#include "envoy/extensions/tracers/opentelemetry/samplers/v3/trace_id_ratio_based_sampler.pb.h"
+
+#include "source/common/common/random_generator.h"
+#include "source/extensions/tracers/opentelemetry/samplers/trace_id_ratio_based/trace_id_ratio_based_sampler.h"
+#include "source/extensions/tracers/opentelemetry/span_context.h"
+
+#include "test/mocks/server/tracer_factory_context.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace Tracers {
+namespace OpenTelemetry {
+
+// As per the docs: https://opentelemetry.io/docs/specs/otel/trace/sdk/#traceidratiobased
+// > A TraceIDRatioBased sampler with a given sampling rate MUST also sample
+//	 all traces that any TraceIDRatioBased sampler with a lower sampling rate
+//	 would sample.
+TEST(TraceIdRatioBasedSamplerTest, TestTraceIdRatioSamplesInclusively) {
+  NiceMock<Server::Configuration::MockTracerFactoryContext> context;
+
+  std::srand(std::time(nullptr));
+  for (int i = 0; i < 100; ++i) {
+    double ratio_low = static_cast<double>(std::rand()) / RAND_MAX;
+    double ratio_high = static_cast<double>(std::rand()) / RAND_MAX;
+    if (ratio_low > ratio_high) {
+      double holder = ratio_low;
+      ratio_low = ratio_high;
+      ratio_high = holder;
+    }
+    envoy::extensions::tracers::opentelemetry::samplers::v3::TraceIdRatioBasedSamplerConfig
+        config_low;
+    envoy::extensions::tracers::opentelemetry::samplers::v3::TraceIdRatioBasedSamplerConfig
+        config_high;
+    config_low.set_ratio(ratio_low);
+    config_high.set_ratio(ratio_high);
+    auto sampler_low = std::make_shared<TraceIdRatioBasedSampler>(config_low, context);
+    auto sampler_high = std::make_shared<TraceIdRatioBasedSampler>(config_high, context);
+
+    Random::RandomGeneratorImpl random_generator;
+    auto trace_id = absl::StrCat(Hex::uint64ToHex(random_generator.random()),
+                                 Hex::uint64ToHex(random_generator.random()));
+
+    auto sampling_result_low = sampler_low->shouldSample(
+        absl::nullopt, trace_id, "operation_name",
+        ::opentelemetry::proto::trace::v1::Span::SPAN_KIND_SERVER, {}, {});
+
+    if (sampling_result_low.decision == Decision::RecordAndSample) {
+      EXPECT_TRUE(sampling_result_low.isSampled());
+      EXPECT_TRUE(sampling_result_low.isRecording());
+
+      auto sampling_result_high = sampler_high->shouldSample(
+          absl::nullopt, trace_id, "operation_name",
+          ::opentelemetry::proto::trace::v1::Span::SPAN_KIND_SERVER, {}, {});
+      EXPECT_TRUE(sampling_result_high.isRecording());
+      EXPECT_TRUE(sampling_result_high.isSampled());
+    }
+  }
+}
+
+// Test special ratios including 0, 1, and numbers out of [0, 1]
+TEST(TraceIdRatioBasedSamplerTest, TestSpecialRatios) {
+  NiceMock<Server::Configuration::MockTracerFactoryContext> context;
+  envoy::extensions::tracers::opentelemetry::samplers::v3::TraceIdRatioBasedSamplerConfig config;
+  std::srand(std::time(nullptr));
+
+  // ratio = 0, should never sample
+  config.set_ratio(0);
+  auto sampler = std::make_shared<TraceIdRatioBasedSampler>(config, context);
+
+  for (int i = 0; i < 10; ++i) {
+    Random::RandomGeneratorImpl random_generator;
+    auto trace_id = absl::StrCat(Hex::uint64ToHex(random_generator.random()),
+                                 Hex::uint64ToHex(random_generator.random()));
+    auto sampling_result =
+        sampler->shouldSample(absl::nullopt, trace_id, "operation_name",
+                              ::opentelemetry::proto::trace::v1::Span::SPAN_KIND_SERVER, {}, {});
+    EXPECT_EQ(sampling_result.decision, Decision::Drop);
+  }
+
+  // ratio < 0, should never sample
+  config.set_ratio(-5);
+  sampler = std::make_shared<TraceIdRatioBasedSampler>(config, context);
+
+  for (int i = 0; i < 10; ++i) {
+    Random::RandomGeneratorImpl random_generator;
+    auto trace_id = absl::StrCat(Hex::uint64ToHex(random_generator.random()),
+                                 Hex::uint64ToHex(random_generator.random()));
+    auto sampling_result =
+        sampler->shouldSample(absl::nullopt, trace_id, "operation_name",
+                              ::opentelemetry::proto::trace::v1::Span::SPAN_KIND_SERVER, {}, {});
+    EXPECT_EQ(sampling_result.decision, Decision::Drop);
+  }
+
+  // ratio = 1, should always sample
+  config.set_ratio(1);
+  sampler = std::make_shared<TraceIdRatioBasedSampler>(config, context);
+
+  for (int i = 0; i < 10; ++i) {
+    Random::RandomGeneratorImpl random_generator;
+    auto trace_id = absl::StrCat(Hex::uint64ToHex(random_generator.random()),
+                                 Hex::uint64ToHex(random_generator.random()));
+    auto sampling_result =
+        sampler->shouldSample(absl::nullopt, trace_id, "operation_name",
+                              ::opentelemetry::proto::trace::v1::Span::SPAN_KIND_SERVER, {}, {});
+    EXPECT_EQ(sampling_result.decision, Decision::RecordAndSample);
+  }
+
+  // ratio < 0, should never sample
+  config.set_ratio(7);
+  sampler = std::make_shared<TraceIdRatioBasedSampler>(config, context);
+
+  for (int i = 0; i < 10; ++i) {
+    Random::RandomGeneratorImpl random_generator;
+    auto trace_id = absl::StrCat(Hex::uint64ToHex(random_generator.random()),
+                                 Hex::uint64ToHex(random_generator.random()));
+    auto sampling_result =
+        sampler->shouldSample(absl::nullopt, trace_id, "operation_name",
+                              ::opentelemetry::proto::trace::v1::Span::SPAN_KIND_SERVER, {}, {});
+    EXPECT_EQ(sampling_result.decision, Decision::RecordAndSample);
+  }
+}
+
+TEST(TraceIdRatioBasedSamplerTest, TestTraceIdRatioDescription) {
+  envoy::extensions::tracers::opentelemetry::samplers::v3::TraceIdRatioBasedSamplerConfig config;
+  NiceMock<Server::Configuration::MockTracerFactoryContext> context;
+  config.set_ratio(0.0157);
+  auto sampler = std::make_shared<TraceIdRatioBasedSampler>(config, context);
+  EXPECT_STREQ(sampler->getDescription().c_str(), "TraceIdRatioBasedSampler{0.015700}");
+}
+
+TEST(TraceIdRatioBasedSamplerTest, TestTraceIdRatioAttrs) {
+  envoy::extensions::tracers::opentelemetry::samplers::v3::TraceIdRatioBasedSamplerConfig config;
+  NiceMock<Server::Configuration::MockTracerFactoryContext> context;
+  std::srand(std::time(nullptr));
+  config.set_ratio(static_cast<double>(std::rand()) / RAND_MAX);
+  auto sampler = std::make_shared<TraceIdRatioBasedSampler>(config, context);
+  SpanContext parent_context("0", "12345", "45678", true, "random_key=random_value");
+  auto sampling_result =
+      sampler->shouldSample(parent_context, "8a23f4f4e6efde581e64092eebc3a682", "operation_name",
+                            ::opentelemetry::proto::trace::v1::Span::SPAN_KIND_SERVER, {}, {});
+  EXPECT_EQ(sampling_result.attributes, nullptr);
+  EXPECT_STREQ(sampling_result.tracestate.c_str(), "random_key=random_value");
+}
+
+} // namespace OpenTelemetry
+} // namespace Tracers
+} // namespace Extensions
+} // namespace Envoy

--- a/test/extensions/tracers/opentelemetry/samplers/trace_id_ratio_based/trace_id_ratio_based_sampler_test.cc
+++ b/test/extensions/tracers/opentelemetry/samplers/trace_id_ratio_based/trace_id_ratio_based_sampler_test.cc
@@ -23,6 +23,7 @@ namespace OpenTelemetry {
 //	 would sample.
 TEST(TraceIdRatioBasedSamplerTest, TestTraceIdRatioSamplesInclusively) {
   NiceMock<Server::Configuration::MockTracerFactoryContext> context;
+  NiceMock<StreamInfo::MockStreamInfo> info;
 
   std::srand(std::time(nullptr));
   for (int i = 0; i < 100; ++i) {
@@ -47,7 +48,7 @@ TEST(TraceIdRatioBasedSamplerTest, TestTraceIdRatioSamplesInclusively) {
                                  Hex::uint64ToHex(random_generator.random()));
 
     auto sampling_result_low = sampler_low->shouldSample(
-        absl::nullopt, trace_id, "operation_name",
+        info, absl::nullopt, trace_id, "operation_name",
         ::opentelemetry::proto::trace::v1::Span::SPAN_KIND_SERVER, {}, {});
 
     if (sampling_result_low.decision == Decision::RecordAndSample) {
@@ -55,7 +56,7 @@ TEST(TraceIdRatioBasedSamplerTest, TestTraceIdRatioSamplesInclusively) {
       EXPECT_TRUE(sampling_result_low.isRecording());
 
       auto sampling_result_high = sampler_high->shouldSample(
-          absl::nullopt, trace_id, "operation_name",
+          info, absl::nullopt, trace_id, "operation_name",
           ::opentelemetry::proto::trace::v1::Span::SPAN_KIND_SERVER, {}, {});
       EXPECT_TRUE(sampling_result_high.isRecording());
       EXPECT_TRUE(sampling_result_high.isSampled());
@@ -66,6 +67,7 @@ TEST(TraceIdRatioBasedSamplerTest, TestTraceIdRatioSamplesInclusively) {
 // Test special ratios including 0, 1, and numbers out of [0, 1]
 TEST(TraceIdRatioBasedSamplerTest, TestSpecialRatios) {
   NiceMock<Server::Configuration::MockTracerFactoryContext> context;
+  NiceMock<StreamInfo::MockStreamInfo> info;
   envoy::extensions::tracers::opentelemetry::samplers::v3::TraceIdRatioBasedSamplerConfig config;
   std::srand(std::time(nullptr));
 
@@ -78,7 +80,7 @@ TEST(TraceIdRatioBasedSamplerTest, TestSpecialRatios) {
     auto trace_id = absl::StrCat(Hex::uint64ToHex(random_generator.random()),
                                  Hex::uint64ToHex(random_generator.random()));
     auto sampling_result =
-        sampler->shouldSample(absl::nullopt, trace_id, "operation_name",
+        sampler->shouldSample(info, absl::nullopt, trace_id, "operation_name",
                               ::opentelemetry::proto::trace::v1::Span::SPAN_KIND_SERVER, {}, {});
     EXPECT_EQ(sampling_result.decision, Decision::Drop);
   }
@@ -92,7 +94,7 @@ TEST(TraceIdRatioBasedSamplerTest, TestSpecialRatios) {
     auto trace_id = absl::StrCat(Hex::uint64ToHex(random_generator.random()),
                                  Hex::uint64ToHex(random_generator.random()));
     auto sampling_result =
-        sampler->shouldSample(absl::nullopt, trace_id, "operation_name",
+        sampler->shouldSample(info, absl::nullopt, trace_id, "operation_name",
                               ::opentelemetry::proto::trace::v1::Span::SPAN_KIND_SERVER, {}, {});
     EXPECT_EQ(sampling_result.decision, Decision::Drop);
   }
@@ -106,7 +108,7 @@ TEST(TraceIdRatioBasedSamplerTest, TestSpecialRatios) {
     auto trace_id = absl::StrCat(Hex::uint64ToHex(random_generator.random()),
                                  Hex::uint64ToHex(random_generator.random()));
     auto sampling_result =
-        sampler->shouldSample(absl::nullopt, trace_id, "operation_name",
+        sampler->shouldSample(info, absl::nullopt, trace_id, "operation_name",
                               ::opentelemetry::proto::trace::v1::Span::SPAN_KIND_SERVER, {}, {});
     EXPECT_EQ(sampling_result.decision, Decision::RecordAndSample);
   }
@@ -120,7 +122,7 @@ TEST(TraceIdRatioBasedSamplerTest, TestSpecialRatios) {
     auto trace_id = absl::StrCat(Hex::uint64ToHex(random_generator.random()),
                                  Hex::uint64ToHex(random_generator.random()));
     auto sampling_result =
-        sampler->shouldSample(absl::nullopt, trace_id, "operation_name",
+        sampler->shouldSample(info, absl::nullopt, trace_id, "operation_name",
                               ::opentelemetry::proto::trace::v1::Span::SPAN_KIND_SERVER, {}, {});
     EXPECT_EQ(sampling_result.decision, Decision::RecordAndSample);
   }
@@ -129,6 +131,7 @@ TEST(TraceIdRatioBasedSamplerTest, TestSpecialRatios) {
 TEST(TraceIdRatioBasedSamplerTest, TestTraceIdRatioDescription) {
   envoy::extensions::tracers::opentelemetry::samplers::v3::TraceIdRatioBasedSamplerConfig config;
   NiceMock<Server::Configuration::MockTracerFactoryContext> context;
+  NiceMock<StreamInfo::MockStreamInfo> info;
   config.set_ratio(0.0157);
   auto sampler = std::make_shared<TraceIdRatioBasedSampler>(config, context);
   EXPECT_STREQ(sampler->getDescription().c_str(), "TraceIdRatioBasedSampler{0.015700}");
@@ -137,13 +140,14 @@ TEST(TraceIdRatioBasedSamplerTest, TestTraceIdRatioDescription) {
 TEST(TraceIdRatioBasedSamplerTest, TestTraceIdRatioAttrs) {
   envoy::extensions::tracers::opentelemetry::samplers::v3::TraceIdRatioBasedSamplerConfig config;
   NiceMock<Server::Configuration::MockTracerFactoryContext> context;
+  NiceMock<StreamInfo::MockStreamInfo> info;
   std::srand(std::time(nullptr));
   config.set_ratio(static_cast<double>(std::rand()) / RAND_MAX);
   auto sampler = std::make_shared<TraceIdRatioBasedSampler>(config, context);
   SpanContext parent_context("0", "12345", "45678", true, "random_key=random_value");
-  auto sampling_result =
-      sampler->shouldSample(parent_context, "8a23f4f4e6efde581e64092eebc3a682", "operation_name",
-                            ::opentelemetry::proto::trace::v1::Span::SPAN_KIND_SERVER, {}, {});
+  auto sampling_result = sampler->shouldSample(
+      info, parent_context, "8a23f4f4e6efde581e64092eebc3a682", "operation_name",
+      ::opentelemetry::proto::trace::v1::Span::SPAN_KIND_SERVER, {}, {});
   EXPECT_EQ(sampling_result.attributes, nullptr);
   EXPECT_STREQ(sampling_result.tracestate.c_str(), "random_key=random_value");
 }


### PR DESCRIPTION
Commit Message: implement TraceIDRatioBased and ParentBased samplers

Additional Description:
[A previous issue](https://github.com/envoyproxy/envoy/issues/35016) existed for adding opentelemetry samplers to Envoy so I didn't create a new one. The PR at hand implements two of these samplers.
The implementation and testing strategies are inspired by the OTEL's [Go](https://github.com/open-telemetry/opentelemetry-go) and [CPP](https://github.com/open-telemetry/opentelemetry-cpp) SDKs.

Risk Level: Low

Testing: The PR has unit and integration tests which I've run locally.

Docs Changes:
Release Notes:
Platform Specific Features:
