### PR TITLE
code_format: fix newline trim

### DIFF
--- a/tools/code_format/check_format.py
+++ b/tools/code_format/check_format.py
@@ -299,7 +299,7 @@ class FormatChecker:
     def read_lines(self, path):
         with open(path) as f:
             for l in f:
-                yield l[:-1]
+                yield l.rstrip('\r\n')
         yield ""
 
     # Read a UTF-8 encoded file as a str.


### PR DESCRIPTION
Additional Description: In case a file does not end with a new line, the code format script will trim last character from last line, which will cause the file to be corrupted. To reproduce, for example, run the format tool on a bazel BUILD file that does not end with a new line
Risk Level: medium
Testing: none
Docs Changes: none
Release Notes: none
Platform Specific Features: none