### PR TITLE
filter: add capability to selectively dump request/response state on crash

### DIFF
--- a/api/envoy/config/bootstrap/v3/bootstrap.proto
+++ b/api/envoy/config/bootstrap/v3/bootstrap.proto
@@ -41,7 +41,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // <config_overview_bootstrap>` for more detail.
 
 // Bootstrap :ref:`configuration overview <config_overview_bootstrap>`.
-// [#next-free-field: 42]
+// [#next-free-field: 43]
 message Bootstrap {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.bootstrap.v2.Bootstrap";
@@ -415,6 +415,66 @@ message Bootstrap {
   // Optional configuration for memory allocation manager.
   // Memory releasing is only supported for `tcmalloc allocator <https://github.com/google/tcmalloc>`_.
   MemoryAllocatorManager memory_allocator_manager = 41;
+
+  // Optional configuration for controlling what state gets included in the state dumps after unexpected termination.
+  // This allows operators to selectively enable/disable certain types of information from being included in state
+  // dumps for security or performance reasons.
+  //
+  // If not specified, all state will be dumped (default behavior).
+  //
+  // This can be used to:
+  // * Completely disable dumping of certain types of request or response data.
+  // * Specify an allow list of specific headers that should be included.
+  // * Control dumping of stream info state.
+  //
+  DumpStateConfig dump_state_config = 42;
+}
+
+message DumpStateConfig {
+  // Configuration for controlling what state gets dumped when the ``dumpState()`` function is called. This allows
+  // selectively enabling/disabling certain types of information from being included in state dumps, which can be useful
+  // for security or performance reasons.
+  message DumpConfig {
+    // Configures how this type of state should be dumped.
+    oneof config {
+      option (validate.required) = true;
+
+      // When set to ``true``, completely disables dumping of this type of state information. This provides a simple way
+      // to completely exclude certain data from dumps.
+      bool disabled = 1;
+
+      // Provides an allow-list of specific headers that should be included in dumps. Only headers in this list will be
+      // dumped and the remaining will be excluded. This provides granular control over exactly which headers appear in
+      // the dumps.
+      HeaderList allowed_headers = 2;
+    }
+
+    // List of specific headers that should be included in dumps when using an allow-list.
+    message HeaderList {
+      // The list of header names that should be included in the dumps. Any headers not in this list will be excluded
+      // from dumps. Header names should match the exact header key.
+      repeated string headers = 1;
+    }
+  }
+
+  // Controls dumping of HTTP request headers. When not specified, all request headers will be dumped.
+  // Can be disabled entirely or limited to specific headers via allow-list.
+  DumpConfig request_headers = 1;
+
+  // Controls dumping of HTTP request trailers. When not specified, all request trailers will be dumped.
+  // Can be disabled entirely or limited to specific trailers via allow-list.
+  DumpConfig request_trailers = 2;
+
+  // Controls dumping of HTTP response headers. When not specified, all response headers will be dumped.
+  // Can be disabled entirely or limited to specific headers via allow-list.
+  DumpConfig response_headers = 3;
+
+  // Controls dumping of HTTP response trailers. When not specified, all response trailers will be dumped.
+  // Can be disabled entirely or limited to specific trailers via allow-list.
+  DumpConfig response_trailers = 4;
+
+  // Controls dumping of stream info state. When not specified, all stream info will be dumped.
+  DumpConfig stream_info = 5;
 }
 
 // Administration interface :ref:`operations documentation

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -406,6 +406,12 @@ new_features:
   change: |
     Add the option to reduce the rate limit budget based on request/response contexts on stream done.
     See :ref:`apply_on_stream_done <envoy_v3_api_field_config.route.v3.RateLimit.apply_on_stream_done>` for more details.
+- area: filter_manager
+  change: |
+    Added new configuration options in :ref:`bootstrap dump_state_config<envoy_v3_api_field_config.bootstrap.v3.Bootstrap.dump_state_config>`
+    to redact sensitive headers in the state dump. This provide users more control over sensitive data exposure during
+    fatal error dumps. Users can choose to disable dumping the entire request or response headers or selectively pass a
+    list of allowed headers.
 
 deprecated:
 - area: rbac

--- a/envoy/router/router_filter_interface.h
+++ b/envoy/router/router_filter_interface.h
@@ -152,6 +152,11 @@ public:
    * @returns the number of attempts (e.g. retries) performed for this stream.
    */
   virtual uint32_t attemptCount() const PURE;
+
+  /*
+   * @returns the dump state config from bootstrap.
+   */
+  virtual const envoy::config::bootstrap::v3::DumpStateConfig* dumpStateConfig() const PURE;
 };
 
 } // namespace Router

--- a/source/common/http/async_client_impl.cc
+++ b/source/common/http/async_client_impl.cc
@@ -32,7 +32,7 @@ AsyncClientImpl::AsyncClientImpl(Upstream::ClusterInfoConstSharedPtr cluster,
           *stats_store.rootScope(), cm, factory_context.runtime(),
           factory_context.api().randomGenerator(), std::move(shadow_writer), true, false, false,
           false, false, false, Protobuf::RepeatedPtrField<std::string>{}, dispatcher.timeSource(),
-          http_context, router_context)),
+          http_context, router_context, nullptr)),
       dispatcher_(dispatcher), runtime_(factory_context.runtime()),
       local_reply_(LocalReply::Factory::createDefault()) {}
 

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -156,6 +156,10 @@ private:
       still_alive_.reset();
     }
 
+    const envoy::config::bootstrap::v3::DumpStateConfig* dumpStateConfig() const override {
+      return filter_manager_.dumpStateConfig();
+    }
+
     void log(AccessLog::AccessLogType type);
     void completeRequest();
 

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -95,7 +95,14 @@ FilterConfig::FilterConfig(Stats::StatName stat_prefix,
               : false,
           config.strict_check_headers(), context.serverFactoryContext().api().timeSource(),
           context.serverFactoryContext().httpContext(),
-          context.serverFactoryContext().routerContext()) {
+          context.serverFactoryContext().routerContext(),
+          [&context]() -> const envoy::config::bootstrap::v3::DumpStateConfig* {
+            const auto& bootstrap = context.serverFactoryContext().bootstrap();
+            if (bootstrap.has_dump_state_config()) {
+              return &bootstrap.dump_state_config();
+            }
+            return nullptr;
+          }()) {
   for (const auto& upstream_log : config.upstream_log()) {
     upstream_logs_.push_back(AccessLog::AccessLogFactory::fromProto(upstream_log, context));
   }

--- a/source/common/router/upstream_request.h
+++ b/source/common/router/upstream_request.h
@@ -12,6 +12,7 @@
 #include "envoy/http/codes.h"
 #include "envoy/http/conn_pool.h"
 #include "envoy/http/filter.h"
+#include "envoy/router/router_filter_interface.h"
 #include "envoy/stats/scope.h"
 #include "envoy/tcp/conn_pool.h"
 
@@ -304,6 +305,9 @@ public:
       return {*response_headers_};
     }
     return {};
+  }
+  const envoy::config::bootstrap::v3::DumpStateConfig* dumpStateConfig() const override {
+    return upstream_request_.parent_.dumpStateConfig();
   }
   Http::ResponseTrailerMapOptRef responseTrailers() override {
     if (response_trailers_) {

--- a/source/common/tcp_proxy/tcp_proxy.cc
+++ b/source/common/tcp_proxy/tcp_proxy.cc
@@ -702,7 +702,14 @@ TunnelingConfigHelperImpl::TunnelingConfigHelperImpl(
                      true, false, false, false, false, false, {},
                      context.serverFactoryContext().api().timeSource(),
                      context.serverFactoryContext().httpContext(),
-                     context.serverFactoryContext().routerContext()),
+                     context.serverFactoryContext().routerContext(),
+                     [&context]() -> const envoy::config::bootstrap::v3::DumpStateConfig* {
+                       const auto& bootstrap = context.serverFactoryContext().bootstrap();
+                       if (bootstrap.has_dump_state_config()) {
+                         return &bootstrap.dump_state_config();
+                       }
+                       return nullptr;
+                     }()),
       server_factory_context_(context.serverFactoryContext()) {
   if (!post_path_.empty() && !use_post_) {
     throw EnvoyException("Can't set a post path when POST method isn't used");

--- a/source/common/tcp_proxy/upstream.h
+++ b/source/common/tcp_proxy/upstream.h
@@ -341,6 +341,9 @@ public:
   bool downstreamResponseStarted() const override { return false; }
   bool downstreamEndStream() const override { return false; }
   uint32_t attemptCount() const override { return 0; }
+  const envoy::config::bootstrap::v3::DumpStateConfig* dumpStateConfig() const override {
+    return nullptr;
+  }
 
 protected:
   void onResetEncoder(Network::ConnectionEvent event, bool inform_downstream = true);

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -64,6 +64,7 @@ public:
   MOCK_METHOD(void, chargeStats, (const ResponseHeaderMap&));
   MOCK_METHOD(void, setRequestTrailers, (RequestTrailerMapPtr &&));
   MOCK_METHOD(void, setInformationalHeaders_, (ResponseHeaderMap&));
+  MOCK_METHOD(const envoy::config::bootstrap::v3::DumpStateConfig*, dumpStateConfig, (), (const));
   void setInformationalHeaders(ResponseHeaderMapPtr&& informational_headers) override {
     informational_headers_ = std::move(informational_headers);
     setInformationalHeaders_(*informational_headers_);


### PR DESCRIPTION
## Description

Added a new configuration option in the Bootstrap to control whether headers and trailers should be included in the state dump during crashes. This feature allows more secure debugging by redacting sensitive information from logs.

Fixes #37793

---

**Commit Message:** filter: add capability to selectively dump request/response state on crash
**Additional Description:** Add new config in Bootstrap to control whether the headers/trailers should be dumped during the crash. 
**Risk Level:** Low
**Testing:** Added Unit tests
**Docs Changes:** Added
**Release Notes:** Added