### PR TITLE
[redis_proxy] Assert proper transaction initialization

### DIFF
--- a/source/extensions/filters/network/redis_proxy/command_splitter_impl.cc
+++ b/source/extensions/filters/network/redis_proxy/command_splitter_impl.cc
@@ -625,7 +625,8 @@ SplitRequestPtr TransactionRequest::create(Router& router,
   }
 
   // If we do a WATCH command without having started a transaction, we send it upstream and save the
-  // key, so we can support UNWATCH. We have to also set the connection details.
+  // key, so we can support UNWATCH. Connection details are set only when transaction actually
+  // starts.
   if (command_name == "watch" && !transaction.active_) {
     transaction.key_ = incoming_request->asArray()[1].asString();
   }

--- a/source/extensions/filters/network/redis_proxy/proxy_filter.cc
+++ b/source/extensions/filters/network/redis_proxy/proxy_filter.cc
@@ -78,6 +78,7 @@ ProxyFilter::ProxyFilter(Common::Redis::DecoderFactory& factory,
                          ExternalAuth::ExternalAuthClientPtr&& auth_client)
     : decoder_(factory.create(*this)), encoder_(std::move(encoder)), splitter_(splitter),
       config_(config), transaction_(this) {
+  assert(!transaction_.active_);
   config_->stats_.downstream_cx_total_.inc();
   config_->stats_.downstream_cx_active_.inc();
   connection_allowed_ = config_->downstream_auth_username_.empty() &&


### PR DESCRIPTION
Fixes #37825 

Making sure we know early that transaction initialization was not done correctly.

Tested manually, was unable to reproduce issue again. I'm guessing the assertion caused compiler to not do bad optimization there 🤷 