### PR TITLE
opentelemetrytracer: Log (debug) the number of exported spans 

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -406,6 +406,9 @@ new_features:
   change: |
     Add the option to reduce the rate limit budget based on request/response contexts on stream done.
     See :ref:`apply_on_stream_done <envoy_v3_api_field_config.route.v3.RateLimit.apply_on_stream_done>` for more details.
+- area: tracing
+  change: |
+    Added debug log containing the number of exported spans on the OpenTelemetry tracer.
 
 deprecated:
 - area: rbac

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -406,9 +406,6 @@ new_features:
   change: |
     Add the option to reduce the rate limit budget based on request/response contexts on stream done.
     See :ref:`apply_on_stream_done <envoy_v3_api_field_config.route.v3.RateLimit.apply_on_stream_done>` for more details.
-- area: tracing
-  change: |
-    Added debug log containing the number of exported spans on the OpenTelemetry tracer.
 
 deprecated:
 - area: rbac

--- a/source/extensions/tracers/opentelemetry/grpc_trace_exporter.cc
+++ b/source/extensions/tracers/opentelemetry/grpc_trace_exporter.cc
@@ -42,6 +42,7 @@ void OpenTelemetryGrpcTraceExporter::onFailure(Grpc::Status::GrpcStatus status,
 bool OpenTelemetryGrpcTraceExporter::log(const ExportTraceServiceRequest& request) {
   client_->send(service_method_, request, *this, Tracing::NullSpan::instance(),
                 Http::AsyncClient::RequestOptions());
+  OpenTelemetryTraceExporter::logExportedSpans(request);
   return true;
 }
 

--- a/source/extensions/tracers/opentelemetry/http_trace_exporter.cc
+++ b/source/extensions/tracers/opentelemetry/http_trace_exporter.cc
@@ -70,6 +70,8 @@ bool OpenTelemetryHttpTraceExporter::log(const ExportTraceServiceRequest& reques
   Http::AsyncClient::Request* in_flight_request =
       thread_local_cluster->httpAsyncClient().send(std::move(message), *this, options);
 
+  OpenTelemetryTraceExporter::logExportedSpans(request);
+
   if (in_flight_request == nullptr) {
     return false;
   }

--- a/source/extensions/tracers/opentelemetry/trace_exporter.h
+++ b/source/extensions/tracers/opentelemetry/trace_exporter.h
@@ -29,6 +29,24 @@ public:
    * @return false When sending the request failed.
    */
   virtual bool log(const ExportTraceServiceRequest& request) = 0;
+
+  /**
+   * @brief Logs as debug the number of exported spans.
+   *
+   * @param request The protobuf-encoded OTLP trace request.
+   */
+  void logExportedSpans(const ExportTraceServiceRequest& request) {
+    if (!ENVOY_LOG_COMP_LEVEL_FINE_GRAIN_IF(ENVOY_LOGGER(), debug)) {
+      return;
+    }
+
+    if (request.resource_spans(0).has_resource()) {
+      if (request.resource_spans(0).scope_spans(0).has_scope()) {
+        ENVOY_LOG(debug, "Number of exported spans: {}",
+                  request.resource_spans(0).scope_spans(0).spans_size());
+      }
+    }
+  }
 };
 
 using OpenTelemetryTraceExporterPtr = std::unique_ptr<OpenTelemetryTraceExporter>;

--- a/source/extensions/tracers/opentelemetry/trace_exporter.h
+++ b/source/extensions/tracers/opentelemetry/trace_exporter.h
@@ -36,10 +36,6 @@ public:
    * @param request The protobuf-encoded OTLP trace request.
    */
   void logExportedSpans(const ExportTraceServiceRequest& request) {
-    if (!ENVOY_LOG_COMP_LEVEL_FINE_GRAIN_IF(ENVOY_LOGGER(), debug)) {
-      return;
-    }
-
     if (request.resource_spans(0).has_resource()) {
       if (request.resource_spans(0).scope_spans(0).has_scope()) {
         ENVOY_LOG(debug, "Number of exported spans: {}",


### PR DESCRIPTION
Commit Message: Log (debug) the number of exported spans 

Additional Description: 

Adds a debug log message containing the number of (about to be) exported spans. This is helpful in troubleshooting for cases where the configuration looks "correct" but no spans are seen in the tracing back-end. The stats sink could be used, but that only exports via OTLP/gRPC which is not always possible. 
Risk Level: Low
Testing: Manual and Unit tests
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
