### PR TITLE
docs: add a blurb on the JA3 to access_logs

### DIFF
--- a/docs/root/configuration/observability/access_log/usage.rst
+++ b/docs/root/configuration/observability/access_log/usage.rst
@@ -1215,6 +1215,14 @@ UDP
   UDP
     Not implemented ("-").
 
+%TLS_JA3_FINGERPRINT%
+  HTTP/TCP/THRIFT
+    The JA3 fingerprint (MD5 hash) of the TLS Client Hello message from the downstream connection.
+    Provides a way to fingerprint TLS clients based on various Client Hello parameters like cipher suites,
+    extensions, elliptic curves, etc. Will be "-" if TLS is not used or the handshake is incomplete.
+  UDP
+    Not implemented ("-").
+
 .. _config_access_log_format_downstream_peer_cert_v_start:
 
 %DOWNSTREAM_PEER_CERT_V_START%

--- a/docs/root/configuration/observability/access_log/usage.rst
+++ b/docs/root/configuration/observability/access_log/usage.rst
@@ -1221,7 +1221,7 @@ UDP
     Provides a way to fingerprint TLS clients based on various Client Hello parameters like cipher suites,
     extensions, elliptic curves, etc. Will be ``-`` if TLS is not used or the handshake is incomplete.
   UDP
-    Not implemented ("-").
+    Not implemented (``-``).
 
 .. _config_access_log_format_downstream_peer_cert_v_start:
 

--- a/docs/root/configuration/observability/access_log/usage.rst
+++ b/docs/root/configuration/observability/access_log/usage.rst
@@ -1219,7 +1219,7 @@ UDP
   HTTP/TCP/Thrift
     The JA3 fingerprint (MD5 hash) of the TLS Client Hello message from the downstream connection.
     Provides a way to fingerprint TLS clients based on various Client Hello parameters like cipher suites,
-    extensions, elliptic curves, etc. Will be "-" if TLS is not used or the handshake is incomplete.
+    extensions, elliptic curves, etc. Will be ``-`` if TLS is not used or the handshake is incomplete.
   UDP
     Not implemented ("-").
 

--- a/docs/root/configuration/observability/access_log/usage.rst
+++ b/docs/root/configuration/observability/access_log/usage.rst
@@ -1216,7 +1216,7 @@ UDP
     Not implemented ("-").
 
 %TLS_JA3_FINGERPRINT%
-  HTTP/TCP/THRIFT
+  HTTP/TCP/Thrift
     The JA3 fingerprint (MD5 hash) of the TLS Client Hello message from the downstream connection.
     Provides a way to fingerprint TLS clients based on various Client Hello parameters like cipher suites,
     extensions, elliptic curves, etc. Will be "-" if TLS is not used or the handshake is incomplete.


### PR DESCRIPTION
## Description

This PR adds a blurb on the usage of `%TLS_JA3_FINGERPRINT%` in access logs to log the recorded JA3 fingerprint from the TLS Inspector.

---

**Commit Message:** docs: add a blurb on the JA3 to access_logs
**Additional Description:** Adds a blurb on the usage of `%TLS_JA3_FINGERPRINT%` in access logs.
**Risk Level:** N/A
**Testing:** N/A
**Docs Changes:** Added
**Release Notes:** N/A