### PR TITLE
mobile: Don't activate previous logging context on engine destruction

### DIFF
--- a/mobile/library/common/engine_common.cc
+++ b/mobile/library/common/engine_common.cc
@@ -100,10 +100,14 @@ EngineCommon::EngineCommon(std::shared_ptr<Envoy::OptionsImplBase> options) : op
       };
   // `set_new_handler` is false because the application using Envoy Mobile should decide how to
   // handle `new` memory allocation failures.
+  // `activate_saved_logging_context_on_destruction` controls whether the logging Context activates
+  // a previously stored static context on destruction. This sometimes causes memory crashes in
+  // Envoy Mobile on StrippedMainBase destruction, so avoid cleaning up the logging context to
+  // prevent crashes on engine destruction.
   base_ = std::make_unique<StrippedMainBase>(
       *options_, real_time_system_, default_listener_hooks_, prod_component_factory_,
       std::make_unique<PlatformImpl>(), std::make_unique<Random::RandomGeneratorImpl>(), nullptr,
-      create_instance, /*set_new_handler=*/false);
+      create_instance, /*set_new_handler=*/false, /*activate_saved_logging_context_on_destruction=*/false);
   // Disabling signal handling in the options makes it so that the server's event dispatcher _does
   // not_ listen for termination signals such as SIGTERM, SIGINT, etc
   // (https://github.com/envoyproxy/envoy/blob/048f4231310fbbead0cbe03d43ffb4307fff0517/source/server/server.cc#L519).

--- a/mobile/library/common/engine_common.cc
+++ b/mobile/library/common/engine_common.cc
@@ -107,7 +107,8 @@ EngineCommon::EngineCommon(std::shared_ptr<Envoy::OptionsImplBase> options) : op
   base_ = std::make_unique<StrippedMainBase>(
       *options_, real_time_system_, default_listener_hooks_, prod_component_factory_,
       std::make_unique<PlatformImpl>(), std::make_unique<Random::RandomGeneratorImpl>(), nullptr,
-      create_instance, /*set_new_handler=*/false, /*activate_saved_logging_context_on_destruction=*/false);
+      create_instance, /*set_new_handler=*/false,
+      /*activate_saved_logging_context_on_destruction=*/false);
   // Disabling signal handling in the options makes it so that the server's event dispatcher _does
   // not_ listen for termination signals such as SIGTERM, SIGINT, etc
   // (https://github.com/envoyproxy/envoy/blob/048f4231310fbbead0cbe03d43ffb4307fff0517/source/server/server.cc#L519).

--- a/source/common/common/logger.h
+++ b/source/common/common/logger.h
@@ -291,7 +291,8 @@ enum class LoggerMode { Envoy, FineGrainLog };
 class Context {
 public:
   Context(spdlog::level::level_enum log_level, const std::string& log_format,
-          Thread::BasicLockable& lock, bool should_escape, bool enable_fine_grain_logging = false);
+          Thread::BasicLockable& lock, bool should_escape, bool enable_fine_grain_logging = false,
+          bool activate_saved_on_destruction = true);
   ~Context();
 
   /**
@@ -316,6 +317,7 @@ private:
   Thread::BasicLockable& lock_;
   bool should_escape_;
   bool enable_fine_grain_logging_;
+  bool activate_saved_on_destruction_;
   Context* const save_context_;
 
   std::string fine_grain_log_format_;

--- a/source/exe/stripped_main_base.cc
+++ b/source/exe/stripped_main_base.cc
@@ -47,7 +47,8 @@ StrippedMainBase::StrippedMainBase(const Server::Options& options, Event::TimeSy
                                    std::unique_ptr<Server::Platform> platform_impl,
                                    std::unique_ptr<Random::RandomGenerator>&& random_generator,
                                    std::unique_ptr<ProcessContext> process_context,
-                                   CreateInstanceFunction create_instance, bool set_new_handler)
+                                   CreateInstanceFunction create_instance, bool set_new_handler,
+                                   bool activate_saved_logging_context_on_destruction)
     : platform_impl_(std::move(platform_impl)), options_(options),
       component_factory_(component_factory), stats_allocator_(symbol_table_) {
   // Process the option to disable extensions as early as possible,
@@ -72,9 +73,9 @@ StrippedMainBase::StrippedMainBase(const Server::Options& options, Event::TimeSy
     tls_ = std::make_unique<ThreadLocal::InstanceImpl>();
     Thread::BasicLockable& log_lock = restarter_->logLock();
     Thread::BasicLockable& access_log_lock = restarter_->accessLogLock();
-    logging_context_ = std::make_unique<Logger::Context>(options_.logLevel(), options_.logFormat(),
-                                                         log_lock, options_.logFormatEscaped(),
-                                                         options_.enableFineGrainLogging());
+    logging_context_ = std::make_unique<Logger::Context>(
+        options_.logLevel(), options_.logFormat(), log_lock, options_.logFormatEscaped(),
+        options_.enableFineGrainLogging(), activate_saved_logging_context_on_destruction);
 
     configureComponentLogLevels();
 

--- a/source/exe/stripped_main_base.h
+++ b/source/exe/stripped_main_base.h
@@ -53,7 +53,8 @@ public:
                    std::unique_ptr<Server::Platform> platform_impl,
                    std::unique_ptr<Random::RandomGenerator>&& random_generator,
                    std::unique_ptr<ProcessContext> process_context,
-                   CreateInstanceFunction create_instance, bool set_new_handler = true);
+                   CreateInstanceFunction create_instance, bool set_new_handler = true,
+                   bool activate_saved_logging_context_on_destruction = true);
 
   void runServer() {
     ASSERT(options_.mode() == Server::Mode::Serve);


### PR DESCRIPTION
When the StrippedMainBase destructor is invoked in Envoy Mobile engine destruction, occassionally the program crashes first due to trying to activate the previous saved logging Context. There's a race condition with accessing the static Context and its own destructor being invoked.

This change allows Envoy Mobile's use of StrippedMainBase to avoid those crash issues by not trying to reactivate the previous saved logging Context on engine destruction, since it wouldn't be useful to the library anyway.