### PR TITLE
docs: fix some typos and use proper note annotations in access logs docs

### DIFF
--- a/docs/root/intro/arch_overview/observability/access_logging.rst
+++ b/docs/root/intro/arch_overview/observability/access_logging.rst
@@ -8,20 +8,18 @@ The :ref:`HTTP connection manager <arch_overview_http_conn_man>`, the
 :ref:`thrift proxy <config_network_filters_thrift_proxy>`
 support extensible access logging with the following features:
 
-* Any number of access logs per a connection stream.
-* Customizable access log filters that allow different types of requests and responses to be written
-  to different access logs.
+* Multiple access logs per connection stream.
+* Customizable access log filters for routing different requests/responses to separate logs.
+* Independent downstream connection logging via listener access logs.
 
 Downstream connection access logging can be enabled using :ref:`listener access
 logs<envoy_v3_api_field_config.listener.v3.Listener.access_log>`. The listener access logs complement
-HTTP request access logging and can be enabled separately and independently from
-filter access logs.
+HTTP request access logging and can be enabled separately and independently from filter access logs.
 
-If access log is enabled, then by default it will be reported to the configured sinks at the end of a UDP
-session, TCP connection, or HTTP stream. It is possible to extend this behavior and report access logs
-periodically or at the start of a UDP session, TCP connection, or HTTP stream. Reporting access logs right
-upstream connection establishment or new incoming HTTP request does not depend on periodic reporting, and
-the other way around.
+By default, if access logging is enabled, logs are sent to the configured sinks at the end of each UDP session,
+TCP connection, or HTTP stream. However, it is possible to extend this behavior and report access logs periodically or
+at the start of a UDP session, TCP connection, or HTTP stream. Generating access logs at the start of an upstream
+connection or request does not depend on periodic logging, and vice versa.
 
 .. _arch_overview_access_log_start:
 
@@ -31,29 +29,35 @@ Start of session access logs
 UDP Proxy
 *********
 
-For UDP Proxy, when UDP tunneling over HTTP is configured, it is possible to enable an access log record once after a successful upstream tunnel connected by using
+For UDP Proxy, when UDP tunneling over HTTP is configured, it is possible to enable an access log record once after a
+successful upstream tunnel connection is established by setting
 :ref:`access log flush interval <envoy_v3_api_field_extensions.filters.udp.udp_proxy.v3.UdpProxyConfig.UdpAccessLogOptions.flush_access_log_on_tunnel_connected>`
 
 TCP Proxy
 *********
 
-For TCP Proxy, it is possible to enable an access log record once after a successful upstream connection by using
+For TCP Proxy, it is possible to enable a one-time access log entry right after a successful upstream connection by using
 :ref:`flush access log on connected <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.TcpAccessLogOptions.flush_access_log_on_connected>`
 
 HTTP Connection Manager
 ***********************
 
-For HTTP Connection Manager, it is possible to enable an access log once when a new HTTP request is received, and before iterating the filter chain by using
+For HTTP Connection Manager, it is possible to enable a one-time access log entry each time a new HTTP request arrives,
+and before the filter chain is processed by using
 :ref:`flush access log on new request <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.HcmAccessLogOptions.flush_access_log_on_new_request>`
-Note: Some information such as upstream host will not be available yet.
+
+.. note::
+   Some information such as upstream host will not be available yet.
 
 HTTP Router Filter
 ******************
 
-For Router Filter, is is possible to enable an upstream access log when a new upstream stream is associated with the downstream stream,
-and after successfully establishing a connection with the upstream by using
+For Router Filter, is is possible to enable one-time upstream access log entry each time a new upstream stream is
+associated with a downstream stream, after the connection with the upstream is established, by using
 :ref:`flush upstream log on upstream stream <envoy_v3_api_field_extensions.filters.http.router.v3.Router.UpstreamAccessLogOptions.flush_upstream_log_on_upstream_stream>`
-Note: In case that the HTTP request involves retries, a start of request upstream access log will be recorded for each retry.
+
+.. note::
+   If the HTTP request involves retries, a start-of-request upstream access log is generated for each retry attempt.
 
 .. _arch_overview_access_log_periodic:
 
@@ -63,30 +67,38 @@ Periodic access logs
 UDP Proxy
 *********
 
-For UDP Proxy, it is possible to enable a prediodic access log by using
+For UDP Proxy, it is possible to enable periodic logging by configuring an
 :ref:`access log flush interval <envoy_v3_api_field_extensions.filters.udp.udp_proxy.v3.UdpProxyConfig.UdpAccessLogOptions.access_log_flush_interval>`
 
 TCP Proxy
 *********
 
-For TCP Proxy, it is possible to enable a prediodic access log by using
+For TCP Proxy, it is possible to enable periodic logging by configuring an
 :ref:`access log flush interval <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.TcpAccessLogOptions.access_log_flush_interval>`
-Note: The first access log entry is generated one interval after a new connection is received by the TCP Proxy whether or not an upstream connection has been made.
+
+.. note::
+   The first log entry is generated one interval after a new connection is received, regardless of whether an upstream
+   connection is made.
 
 HTTP Connection Manager
 ***********************
 
-For HTTP Connection Manager, it is possible to enable a prediodic access log by using
+For HTTP Connection Manager, it is possible to enable periodic logging by configuring an
 :ref:`access log flush interval <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.HcmAccessLogOptions.access_log_flush_interval>`
-Note: The first access log entry is generated one interval after a new HTTP request is received by the HTTP Connection Manager and before iterating
-the HTTP filter chain, whether or not an upstream connection has been made.
+
+.. note::
+   The first log entry is generated one interval after a new HTTP request is received by the HTTP Connection Manager
+   (and before processing the filter chain), regardless of whether an upstream connection is made.
 
 HTTP Router Filter
 ******************
 
-For Router Filter, it is possible to enable a prediodic access log by using
+For Router Filter, it is possible to enable periodic logging by configuring an
 :ref:`upstream log flush interval <envoy_v3_api_field_extensions.filters.http.router.v3.Router.UpstreamAccessLogOptions.upstream_log_flush_interval>`
-Note: The first access log entry is generated one interval after a new HTTP request is received by the router filter, whether or not an upstream connection has been made.
+
+.. note::
+   The first log entry is generated one interval after a new HTTP request is received by the router filter, regardless
+   of whether an upstream connection is made.
 
 .. _arch_overview_access_log_filters:
 
@@ -108,40 +120,32 @@ Envoy supports pluggable access logging sinks. The currently supported sinks are
 File
 ****
 
-* Asynchronous IO flushing architecture. Access logging will never block the main network processing
-  threads.
-* Customizable access log formats using predefined fields as well as arbitrary HTTP request and
-  response headers.
+* Uses an asynchronous I/O flushing mechanism so it never blocks the main network threads.
+* Offers customizable log formats through predefined fields and arbitrary HTTP request/response headers.
 
 gRPC
 ****
 
-* Envoy can send access log messages to a gRPC access logging service.
-
+* Used to send access log messages to a gRPC access logging service.
 
 Stdout
 *********
 
-* Asynchronous IO flushing architecture. Access logging will never block the main network processing
-  threads.
-* Customizable access log formats using predefined fields as well as arbitrary HTTP request and
-  response headers.
-* Writes to the standard output of the process. It works in all platforms.
-
+* Uses an asynchronous I/O flushing mechanism so it never blocks the main network threads.
+* Offers customizable log formats through predefined fields and arbitrary HTTP request/response headers.
+* Writes to the standard output of the process. It is supported on all platforms.
 
 Stderr
 ********
 
-* Asynchronous IO flushing architecture. Access logging will never block the main network processing
-  threads.
-* Customizable access log formats using predefined fields as well as arbitrary HTTP request and
-  response headers.
-* Writes to the standard error of the process. It works in all platforms.
+* Uses an asynchronous I/O flushing mechanism so it never blocks the main network threads.
+* Offers customizable log formats through predefined fields and arbitrary HTTP request/response headers.
+* Writes to the standard error of the process. It is supported on all platforms.
 
 Fluentd
 ********
 
-* Flush access logs over a TCP connection to an upstream that is accepting the Fluentd Forward Protocol as described in:
+* Sends access logs over a TCP connection to an upstream destination that supports the Fluentd Forward Protocol as described in:
   `Fluentd Forward Protocol Specification <https://github.com/fluent/fluentd/wiki/Forward-Protocol-Specification-v1>`_.
 * The data sent over the wire is a stream of
   `Fluentd Forward Mode events <https://github.com/fluent/fluentd/wiki/Forward-Protocol-Specification-v1#forward-mode>`_

--- a/docs/root/intro/arch_overview/observability/access_logging.rst
+++ b/docs/root/intro/arch_overview/observability/access_logging.rst
@@ -53,7 +53,7 @@ HTTP Router Filter
 ******************
 
 For Router Filter, it is possible to enable one-time upstream access log entry each time a new upstream stream is
-associated with a downstream stream, after the connection with the upstream is established, by using
+associated with a downstream stream, after the connection with the upstream is established, by enabling
 :ref:`flush upstream log on upstream stream <envoy_v3_api_field_extensions.filters.http.router.v3.Router.UpstreamAccessLogOptions.flush_upstream_log_on_upstream_stream>`
 
 .. note::

--- a/docs/root/intro/arch_overview/observability/access_logging.rst
+++ b/docs/root/intro/arch_overview/observability/access_logging.rst
@@ -52,7 +52,7 @@ and before the filter chain is processed by using
 HTTP Router Filter
 ******************
 
-For Router Filter, is is possible to enable one-time upstream access log entry each time a new upstream stream is
+For Router Filter, it is possible to enable one-time upstream access log entry each time a new upstream stream is
 associated with a downstream stream, after the connection with the upstream is established, by using
 :ref:`flush upstream log on upstream stream <envoy_v3_api_field_extensions.filters.http.router.v3.Router.UpstreamAccessLogOptions.flush_upstream_log_on_upstream_stream>`
 

--- a/docs/root/intro/arch_overview/observability/access_logging.rst
+++ b/docs/root/intro/arch_overview/observability/access_logging.rst
@@ -43,7 +43,7 @@ HTTP Connection Manager
 ***********************
 
 For HTTP Connection Manager, it is possible to enable a one-time access log entry each time a new HTTP request arrives,
-and before the filter chain is processed by using
+and before the filter chain is processed by enabling
 :ref:`flush access log on new request <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.HcmAccessLogOptions.flush_access_log_on_new_request>`
 
 .. note::

--- a/docs/root/intro/arch_overview/observability/access_logging.rst
+++ b/docs/root/intro/arch_overview/observability/access_logging.rst
@@ -36,7 +36,7 @@ successful upstream tunnel connection is established by setting
 TCP Proxy
 *********
 
-For TCP Proxy, it is possible to enable a one-time access log entry right after a successful upstream connection by using
+For TCP Proxy, it is possible to enable a one-time access log entry right after a successful upstream connection by enabling
 :ref:`flush access log on connected <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.TcpAccessLogOptions.flush_access_log_on_connected>`
 
 HTTP Connection Manager

--- a/docs/root/intro/arch_overview/observability/access_logging.rst
+++ b/docs/root/intro/arch_overview/observability/access_logging.rst
@@ -31,7 +31,7 @@ UDP Proxy
 
 For UDP Proxy, when UDP tunneling over HTTP is configured, it is possible to enable an access log record once after a
 successful upstream tunnel connection is established by setting
-:ref:`access log flush interval <envoy_v3_api_field_extensions.filters.udp.udp_proxy.v3.UdpProxyConfig.UdpAccessLogOptions.flush_access_log_on_tunnel_connected>`
+:ref:`flush access log on tunnel connected <envoy_v3_api_field_extensions.filters.udp.udp_proxy.v3.UdpProxyConfig.UdpAccessLogOptions.flush_access_log_on_tunnel_connected>`.
 
 TCP Proxy
 *********

--- a/docs/root/intro/arch_overview/observability/access_logging.rst
+++ b/docs/root/intro/arch_overview/observability/access_logging.rst
@@ -30,7 +30,7 @@ UDP Proxy
 *********
 
 For UDP Proxy, when UDP tunneling over HTTP is configured, it is possible to enable an access log record once after a
-successful upstream tunnel connection is established by setting
+successful upstream tunnel connection is established by enabling
 :ref:`flush access log on tunnel connected <envoy_v3_api_field_extensions.filters.udp.udp_proxy.v3.UdpProxyConfig.UdpAccessLogOptions.flush_access_log_on_tunnel_connected>`.
 
 TCP Proxy


### PR DESCRIPTION
## Description

This PR fixes some minor typos like `prediodic` => `periodic` and uses proper annotations for all the notes in the [access logging docs](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/observability/access_logging).

[Preview Link](https://storage.googleapis.com/envoy-pr/28e8cf9/docs/intro/arch_overview/observability/access_logging.html)

---

**Commit Message:** docs: fix some typos and use proper note annotations in access logs docs
**Additional Description:** Fixes some minor typos and make notes use the proper annotations in Access Logging docs.
**Risk Level:** N/A
**Testing:** N/A
**Docs Changes:** N/A
**Release Notes:** N/A