### PR TITLE
async-client: fix stream creation validation

### DIFF
--- a/source/common/http/async_client_impl.cc
+++ b/source/common/http/async_client_impl.cc
@@ -126,6 +126,11 @@ AsyncStreamImpl::AsyncStreamImpl(AsyncClientImpl& parent, AsyncClient::StreamCal
       retry_policy_(createRetryPolicy(parent, options, parent_.factory_context_, creation_status)),
       account_(options.account_), buffer_limit_(options.buffer_limit_), send_xff_(options.send_xff),
       send_internal_(options.send_internal) {
+  // A field initialization may set the creation-status as unsuccessful.
+  // In that case return immediately.
+  if (!creation_status.ok()) {
+    return;
+  }
   auto route_or_error = NullRouteImpl::create(
       parent_.cluster_->name(),
       retry_policy_ != nullptr ? *retry_policy_ : *options.parsed_retry_policy,

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -106,8 +106,10 @@ public:
   create(AsyncClientImpl& parent, AsyncClient::StreamCallbacks& callbacks,
          const AsyncClient::StreamOptions& options) {
     absl::Status creation_status = absl::OkStatus();
-    return std::unique_ptr<AsyncStreamImpl>(
+    std::unique_ptr<AsyncStreamImpl> stream = std::unique_ptr<AsyncStreamImpl>(
         new AsyncStreamImpl(parent, callbacks, options, creation_status));
+    RETURN_IF_NOT_OK(creation_status);
+    return stream;
   }
 
   ~AsyncStreamImpl() override {

--- a/test/common/http/async_client_impl_test.cc
+++ b/test/common/http/async_client_impl_test.cc
@@ -2355,6 +2355,24 @@ retry_back_off:
   EXPECT_EQ(route_entry.retryPolicy().maxInterval(), std::chrono::seconds(30));
 }
 
+TEST_F(AsyncClientImplUnitTest, AsyncStreamImplInitTestWithInvalidRetryPolicy) {
+  // Set an invalid retry back off.
+  const std::string yaml = R"EOF(
+per_try_timeout: 30s
+num_retries: 10
+retry_on: 5xx,gateway-error,connect-failure,reset
+retry_back_off:
+  base_interval: 10s
+  max_interval: 3s
+)EOF";
+  envoy::config::route::v3::RetryPolicy retry_policy;
+  TestUtility::loadFromYaml(yaml, retry_policy);
+
+  absl::StatusOr<std::unique_ptr<AsyncStreamImpl>> stream_or_error = Http::AsyncStreamImpl::create(
+      client_, stream_callbacks_, AsyncClient::StreamOptions().setRetryPolicy(retry_policy));
+  EXPECT_FALSE(stream_or_error.ok());
+}
+
 TEST_F(AsyncClientImplUnitTest, AsyncStreamImplInitTestWithRetryPolicy) {
   const std::string yaml = R"EOF(
 per_try_timeout: 30s


### PR DESCRIPTION
Commit Message: async-client: fix stream creation validation
Additional Description:
PR #34323 added the use of status-or for the creation of the async-client stream.
This PR ensures that when the creation of the object is unsuccessful, an error will be returned.

Risk Level: low
Testing: Added a unit test
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
