### PR TITLE
xDS: add enum specified in xRFC TP3 in the right place

### DIFF
--- a/api/envoy/admin/v3/config_dump_shared.proto
+++ b/api/envoy/admin/v3/config_dump_shared.proto
@@ -39,6 +39,11 @@ enum ClientResourceStatus {
 
   // Client received this resource and replied with NACK.
   NACKED = 4;
+
+  // Client received an error from the control plane. The attached config
+  // dump is the most recent accepted one. If no config is accepted yet,
+  // the attached config dump will be empty.
+  CLIENT_RECEIVED_ERROR = 5;
 }
 
 message UpdateFailureState {


### PR DESCRIPTION
Commit Message: xDS: add enum specified in xRFC TP3 in the right place
Additional Description: In #37818, I incorrectly added this new value to the deprecated location for this enum, not the real location. :(
Risk Level: Low
Testing: N/A
Docs Changes: Included in PR
Release Notes: N/A
Platform Specific Features: N/A

CC @adisuissa 