### PR TITLE
dynamic_modules: adds dynamic metadata callbakcs

### DIFF
--- a/source/extensions/dynamic_modules/BUILD
+++ b/source/extensions/dynamic_modules/BUILD
@@ -36,6 +36,10 @@ envoy_cc_library(
         "-Wl,--export-dynamic-symbol=envoy_dynamic_module_callback_http_get_response_trailers",
         "-Wl,--export-dynamic-symbol=envoy_dynamic_module_callback_http_get_response_trailers_count",
         "-Wl,--export-dynamic-symbol=envoy_dynamic_module_callback_http_set_response_trailer",
+        "-Wl,--export-dynamic-symbol=envoy_dynamic_module_callback_http_set_dynamic_metadata_number",
+        "-Wl,--export-dynamic-symbol=envoy_dynamic_module_callback_http_get_dynamic_metadata_number",
+        "-Wl,--export-dynamic-symbol=envoy_dynamic_module_callback_http_set_dynamic_metadata_string",
+        "-Wl,--export-dynamic-symbol=envoy_dynamic_module_callback_http_get_dynamic_metadata_string",
     ],
     deps = [
         ":abi_version_lib",

--- a/source/extensions/dynamic_modules/abi.h
+++ b/source/extensions/dynamic_modules/abi.h
@@ -629,7 +629,7 @@ bool envoy_dynamic_module_callback_http_set_response_trailer(
 bool envoy_dynamic_module_callback_http_set_dynamic_metadata_number(
     envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr,
     envoy_dynamic_module_type_buffer_module_ptr namespace_ptr, size_t namespace_length,
-    envoy_dynamic_module_type_buffer_module_ptr key_ptr, size_t key_length, uint64_t value);
+    envoy_dynamic_module_type_buffer_module_ptr key_ptr, size_t key_length, double value);
 
 /**
  * envoy_dynamic_module_callback_http_get_dynamic_metadata_number is called by the module to get
@@ -649,7 +649,7 @@ bool envoy_dynamic_module_callback_http_set_dynamic_metadata_number(
 bool envoy_dynamic_module_callback_http_get_dynamic_metadata_number(
     envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr,
     envoy_dynamic_module_type_buffer_module_ptr namespace_ptr, size_t namespace_length,
-    envoy_dynamic_module_type_buffer_module_ptr key_ptr, size_t key_length, uint64_t* result);
+    envoy_dynamic_module_type_buffer_module_ptr key_ptr, size_t key_length, double* result);
 
 /**
  * envoy_dynamic_module_callback_http_set_dynamic_metadata_string is called by the module to set

--- a/source/extensions/dynamic_modules/abi.h
+++ b/source/extensions/dynamic_modules/abi.h
@@ -35,12 +35,14 @@
 #ifdef __cplusplus
 #include <cstdbool>
 #include <cstddef>
+#include <cstdint>
 
 extern "C" {
 #else
 
 #include <stdbool.h>
 #include <stddef.h>
+#include <stdint.h>
 #endif
 
 // -----------------------------------------------------------------------------
@@ -397,6 +399,8 @@ void envoy_dynamic_module_on_http_filter_destroy(
 // Callbacks are functions implemented by Envoy that can be called by the module to interact with
 // Envoy. The name of a callback must be prefixed with "envoy_dynamic_module_callback_".
 
+// ---------------------- HTTP Header/Trailer callbacks ------------------------
+
 /**
  * envoy_dynamic_module_callback_http_get_request_header is called by the module to get the
  * value of the request header with the given key. Since a header can have multiple values, the
@@ -605,6 +609,95 @@ bool envoy_dynamic_module_callback_http_set_response_trailer(
     envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr,
     envoy_dynamic_module_type_buffer_module_ptr key, size_t key_length,
     envoy_dynamic_module_type_buffer_module_ptr value, size_t value_length);
+
+// ------------------------ Dynamic Metadata Callbacks -------------------------
+
+/**
+ * envoy_dynamic_module_callback_http_set_dynamic_metadata_number is called by the module to set
+ * the number value of the dynamic metadata with the given namespace and key. If the metadata is not
+ * accessible, this returns false. If the namespace does not exist, it will be created.
+ *
+ * @param filter_envoy_ptr is the pointer to the DynamicModuleHttpFilter object of the
+ * corresponding HTTP filter.
+ * @param namespace_ptr is the namespace of the dynamic metadata.
+ * @param namespace_length is the length of the namespace.
+ * @param key_ptr is the key of the dynamic metadata.
+ * @param key_length is the length of the key.
+ * @param value is the number value of the dynamic metadata to be set.
+ * @return true if the operation is successful, false otherwise.
+ */
+bool envoy_dynamic_module_callback_http_set_dynamic_metadata_number(
+    envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr,
+    envoy_dynamic_module_type_buffer_module_ptr namespace_ptr, size_t namespace_length,
+    envoy_dynamic_module_type_buffer_module_ptr key_ptr, size_t key_length, uint64_t value);
+
+/**
+ * envoy_dynamic_module_callback_http_get_dynamic_metadata_number is called by the module to get
+ * the number value of the dynamic metadata with the given namespace and key. If the metadata is not
+ * accessible, the namespace does not exist, or the key does not exist, this returns false.
+ *
+ * @param filter_envoy_ptr is the pointer to the DynamicModuleHttpFilter object of the
+ * corresponding HTTP filter.
+ * @param namespace_ptr is the namespace of the dynamic metadata.
+ * @param namespace_length is the length of the namespace.
+ * @param key_ptr is the key of the dynamic metadata.
+ * @param key_length is the length of the key.
+ * @param result is the pointer to the variable where the number value of the dynamic metadata will
+ * be stored.
+ * @return true if the operation is successful, false otherwise.
+ */
+bool envoy_dynamic_module_callback_http_get_dynamic_metadata_number(
+    envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr,
+    envoy_dynamic_module_type_buffer_module_ptr namespace_ptr, size_t namespace_length,
+    envoy_dynamic_module_type_buffer_module_ptr key_ptr, size_t key_length, uint64_t* result);
+
+/**
+ * envoy_dynamic_module_callback_http_set_dynamic_metadata_string is called by the module to set
+ * the string value of the dynamic metadata with the given namespace and key. If the metadata is not
+ * accessible, this returns false. If the namespace does not exist, it will be created.
+ *
+ * @param filter_envoy_ptr is the pointer to the DynamicModuleHttpFilter object of the
+ * corresponding HTTP filter.
+ * @param namespace_ptr is the namespace of the dynamic metadata.
+ * @param namespace_length is the length of the namespace.
+ * @param key_ptr is the key of the dynamic metadata.
+ * @param key_length is the length of the key.
+ * @param value_ptr is the string value of the dynamic metadata to be set.
+ * @param value_length is the length of the value.
+ * @return true if the operation is successful, false otherwise.
+ */
+bool envoy_dynamic_module_callback_http_set_dynamic_metadata_string(
+    envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr,
+    envoy_dynamic_module_type_buffer_module_ptr namespace_ptr, size_t namespace_length,
+    envoy_dynamic_module_type_buffer_module_ptr key_ptr, size_t key_length,
+    envoy_dynamic_module_type_buffer_module_ptr value_ptr, size_t value_length);
+
+/**
+ * envoy_dynamic_module_callback_http_get_dynamic_metadata_string is called by the module to get
+ * the string value of the dynamic metadata with the given namespace and key. If the metadata is not
+ * accessible, the namespace does not exist, or the key does not exist, this returns false.
+ *
+ * @param filter_envoy_ptr is the pointer to the DynamicModuleHttpFilter object of the
+ * corresponding HTTP filter.
+ * @param namespace_ptr is the namespace of the dynamic metadata.
+ * @param namespace_length is the length of the namespace.
+ * @param key_ptr is the key of the dynamic metadata.
+ * @param key_length is the length of the key.
+ * @param result_buffer_ptr is the pointer to the pointer variable where the pointer to the buffer
+ * of the value will be stored.
+ * @param result_buffer_length_ptr is the pointer to the variable where the length of the buffer
+ * will be stored.
+ * @return true if the operation is successful, false otherwise.
+ *
+ * Note that the buffer pointed by the pointer stored in result is owned by Envoy, and
+ * they are guaranteed to be valid until the end of the current event hook unless the setter
+ * callback is called.
+ */
+bool envoy_dynamic_module_callback_http_get_dynamic_metadata_string(
+    envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr,
+    envoy_dynamic_module_type_buffer_module_ptr namespace_ptr, size_t namespace_length,
+    envoy_dynamic_module_type_buffer_module_ptr key_ptr, size_t key_length,
+    envoy_dynamic_module_type_buffer_envoy_ptr* result, size_t* result_length);
 
 #ifdef __cplusplus
 }

--- a/source/extensions/dynamic_modules/abi.h
+++ b/source/extensions/dynamic_modules/abi.h
@@ -634,7 +634,8 @@ bool envoy_dynamic_module_callback_http_set_dynamic_metadata_number(
 /**
  * envoy_dynamic_module_callback_http_get_dynamic_metadata_number is called by the module to get
  * the number value of the dynamic metadata with the given namespace and key. If the metadata is not
- * accessible, the namespace does not exist, or the key does not exist, this returns false.
+ * accessible, the namespace does not exist, the key does not exist or the value is not a number,
+ * this returns false.
  *
  * @param filter_envoy_ptr is the pointer to the DynamicModuleHttpFilter object of the
  * corresponding HTTP filter.
@@ -675,7 +676,8 @@ bool envoy_dynamic_module_callback_http_set_dynamic_metadata_string(
 /**
  * envoy_dynamic_module_callback_http_get_dynamic_metadata_string is called by the module to get
  * the string value of the dynamic metadata with the given namespace and key. If the metadata is not
- * accessible, the namespace does not exist, or the key does not exist, this returns false.
+ * accessible, the namespace does not exist, the key does not exist or the value is not a string,
+ * this returns false.
  *
  * @param filter_envoy_ptr is the pointer to the DynamicModuleHttpFilter object of the
  * corresponding HTTP filter.

--- a/source/extensions/dynamic_modules/abi_version.h
+++ b/source/extensions/dynamic_modules/abi_version.h
@@ -6,7 +6,7 @@ namespace DynamicModules {
 #endif
 // This is the ABI version calculated as a sha256 hash of the ABI header files. When the ABI
 // changes, this value must change, and the correctness of this value is checked by the test.
-const char* kAbiVersion = "27dbe7918b67b12bfcf43e050ce142a300feb73fb3bd5779c754d1d1d3c8645f";
+const char* kAbiVersion = "fd363586ca79ce0a40c4a2ad365746aed80a331cb042c08f276f4cf9a6dfb2a9";
 
 #ifdef __cplusplus
 } // namespace DynamicModules

--- a/source/extensions/dynamic_modules/abi_version.h
+++ b/source/extensions/dynamic_modules/abi_version.h
@@ -6,7 +6,7 @@ namespace DynamicModules {
 #endif
 // This is the ABI version calculated as a sha256 hash of the ABI header files. When the ABI
 // changes, this value must change, and the correctness of this value is checked by the test.
-const char* kAbiVersion = "70bd571b5c3893a751925653bc9f069a6d8eaa6ac92239dc0fbd2a67245e3cfc";
+const char* kAbiVersion = "96ecb1011dfbd8375cab07853e6491d8ac30d4fe60e685c10ec39a0674c57a25";
 
 #ifdef __cplusplus
 } // namespace DynamicModules

--- a/source/extensions/dynamic_modules/abi_version.h
+++ b/source/extensions/dynamic_modules/abi_version.h
@@ -6,7 +6,7 @@ namespace DynamicModules {
 #endif
 // This is the ABI version calculated as a sha256 hash of the ABI header files. When the ABI
 // changes, this value must change, and the correctness of this value is checked by the test.
-const char* kAbiVersion = "fd363586ca79ce0a40c4a2ad365746aed80a331cb042c08f276f4cf9a6dfb2a9";
+const char* kAbiVersion = "70bd571b5c3893a751925653bc9f069a6d8eaa6ac92239dc0fbd2a67245e3cfc";
 
 #ifdef __cplusplus
 } // namespace DynamicModules

--- a/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
@@ -336,6 +336,8 @@ pub trait EnvoyHttpFilter {
   fn get_dynamic_metadata_number(&self, namespace: &str, key: &str) -> Option<f64>;
 
   /// Set the number-typed dynamic metadata value with the given key.
+  /// If the namespace is not found, this will create a new namespace.
+  ///
   /// Returns true if the operation is successful.
   fn set_dynamic_metadata_number(&mut self, namespace: &str, key: &str, value: f64) -> bool;
 
@@ -344,6 +346,8 @@ pub trait EnvoyHttpFilter {
   fn get_dynamic_metadata_string(&self, namespace: &str, key: &str) -> Option<EnvoyBuffer>;
 
   /// Set the string-typed dynamic metadata value with the given key.
+  /// If the namespace is not found, this will create a new namespace.
+  ///
   /// Returns true if the operation is successful.
   fn set_dynamic_metadata_string(&mut self, namespace: &str, key: &str, value: &str) -> bool;
 }

--- a/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
@@ -333,11 +333,11 @@ pub trait EnvoyHttpFilter {
 
   /// Get the number-typed dynamic metadata value with the given key.
   /// If the metadata is not found, this returns `None`.
-  fn get_dynamic_metadata_number(&self, namespace: &str, key: &str) -> Option<i64>;
+  fn get_dynamic_metadata_number(&self, namespace: &str, key: &str) -> Option<f64>;
 
   /// Set the number-typed dynamic metadata value with the given key.
   /// Returns true if the operation is successful.
-  fn set_dynamic_metadata_number(&mut self, namespace: &str, key: &str, value: u64) -> bool;
+  fn set_dynamic_metadata_number(&mut self, namespace: &str, key: &str, value: f64) -> bool;
 
   /// Get the string-typed dynamic metadata value with the given key.
   /// If the metadata is not found, this returns `None`.
@@ -506,12 +506,12 @@ impl EnvoyHttpFilter for EnvoyHttpFilterImpl {
     }
   }
 
-  fn get_dynamic_metadata_number(&self, namespace: &str, key: &str) -> Option<i64> {
+  fn get_dynamic_metadata_number(&self, namespace: &str, key: &str) -> Option<f64> {
     let namespace_ptr = namespace.as_ptr();
     let namespace_size = namespace.len();
     let key_ptr = key.as_ptr();
     let key_size = key.len();
-    let mut value: i64 = 0;
+    let mut value: f64 = 0f64;
     let success = unsafe {
       abi::envoy_dynamic_module_callback_http_get_dynamic_metadata_number(
         self.raw_ptr,
@@ -529,7 +529,7 @@ impl EnvoyHttpFilter for EnvoyHttpFilterImpl {
     }
   }
 
-  fn set_dynamic_metadata_number(&mut self, namespace: &str, key: &str, value: u64) -> bool {
+  fn set_dynamic_metadata_number(&mut self, namespace: &str, key: &str, value: f64) -> bool {
     let namespace_ptr = namespace.as_ptr();
     let namespace_size = namespace.len();
     let key_ptr = key.as_ptr();

--- a/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
@@ -330,6 +330,22 @@ pub trait EnvoyHttpFilter {
   ///
   /// Returns true if the operation is successful.
   fn set_response_trailer(&mut self, key: &str, value: &[u8]) -> bool;
+
+  /// Get the number-typed dynamic metadata value with the given key.
+  /// If the metadata is not found, this returns `None`.
+  fn get_dynamic_metadata_number(&self, namespace: &str, key: &str) -> Option<i64>;
+
+  /// Set the number-typed dynamic metadata value with the given key.
+  /// Returns true if the operation is successful.
+  fn set_dynamic_metadata_number(&mut self, namespace: &str, key: &str, value: u64) -> bool;
+
+  /// Get the string-typed dynamic metadata value with the given key.
+  /// If the metadata is not found, this returns `None`.
+  fn get_dynamic_metadata_string(&self, namespace: &str, key: &str) -> Option<EnvoyBuffer>;
+
+  /// Set the string-typed dynamic metadata value with the given key.
+  /// Returns true if the operation is successful.
+  fn set_dynamic_metadata_string(&mut self, namespace: &str, key: &str, value: &str) -> bool;
 }
 
 /// This implements the [`EnvoyHttpFilter`] trait with the given raw pointer to the Envoy HTTP
@@ -482,6 +498,91 @@ impl EnvoyHttpFilter for EnvoyHttpFilterImpl {
     unsafe {
       abi::envoy_dynamic_module_callback_http_set_response_trailer(
         self.raw_ptr,
+        key_ptr as *const _ as *mut _,
+        key_size,
+        value_ptr as *const _ as *mut _,
+        value_size,
+      )
+    }
+  }
+
+  fn get_dynamic_metadata_number(&self, namespace: &str, key: &str) -> Option<i64> {
+    let namespace_ptr = namespace.as_ptr();
+    let namespace_size = namespace.len();
+    let key_ptr = key.as_ptr();
+    let key_size = key.len();
+    let mut value: i64 = 0;
+    let success = unsafe {
+      abi::envoy_dynamic_module_callback_http_get_dynamic_metadata_number(
+        self.raw_ptr,
+        namespace_ptr as *const _ as *mut _,
+        namespace_size,
+        key_ptr as *const _ as *mut _,
+        key_size,
+        &mut value as *mut _ as *mut _,
+      )
+    };
+    if success {
+      Some(value)
+    } else {
+      None
+    }
+  }
+
+  fn set_dynamic_metadata_number(&mut self, namespace: &str, key: &str, value: u64) -> bool {
+    let namespace_ptr = namespace.as_ptr();
+    let namespace_size = namespace.len();
+    let key_ptr = key.as_ptr();
+    let key_size = key.len();
+    unsafe {
+      abi::envoy_dynamic_module_callback_http_set_dynamic_metadata_number(
+        self.raw_ptr,
+        namespace_ptr as *const _ as *mut _,
+        namespace_size,
+        key_ptr as *const _ as *mut _,
+        key_size,
+        value,
+      )
+    }
+  }
+
+  fn get_dynamic_metadata_string(&self, namespace: &str, key: &str) -> Option<EnvoyBuffer> {
+    let namespace_ptr = namespace.as_ptr();
+    let namespace_size = namespace.len();
+    let key_ptr = key.as_ptr();
+    let key_size = key.len();
+    let mut result_ptr: *const u8 = std::ptr::null();
+    let mut result_size: usize = 0;
+    let success = unsafe {
+      abi::envoy_dynamic_module_callback_http_get_dynamic_metadata_string(
+        self.raw_ptr,
+        namespace_ptr as *const _ as *mut _,
+        namespace_size,
+        key_ptr as *const _ as *mut _,
+        key_size,
+        &mut result_ptr as *mut _ as *mut _,
+        &mut result_size as *mut _ as *mut _,
+      )
+    };
+    if success {
+      Some(unsafe { EnvoyBuffer::new_from_raw(result_ptr, result_size) })
+    } else {
+      None
+    }
+  }
+
+  fn set_dynamic_metadata_string(&mut self, namespace: &str, key: &str, value: &str) -> bool {
+    let namespace_ptr = namespace.as_ptr();
+    let namespace_size = namespace.len();
+    let key_ptr = key.as_ptr();
+    let key_size = key.len();
+    let value_ptr = value.as_ptr();
+    let value_size = value.len();
+    unsafe {
+      abi::envoy_dynamic_module_callback_http_set_dynamic_metadata_string(
+        self.raw_ptr,
+        namespace_ptr as *const _ as *mut _,
+        namespace_size,
         key_ptr as *const _ as *mut _,
         key_size,
         value_ptr as *const _ as *mut _,

--- a/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
@@ -332,7 +332,7 @@ pub trait EnvoyHttpFilter {
   fn set_response_trailer(&mut self, key: &str, value: &[u8]) -> bool;
 
   /// Get the number-typed dynamic metadata value with the given key.
-  /// If the metadata is not found, this returns `None`.
+  /// If the metadata is not found or is the wrong type, this returns `None`.
   fn get_dynamic_metadata_number(&self, namespace: &str, key: &str) -> Option<f64>;
 
   /// Set the number-typed dynamic metadata value with the given key.
@@ -340,7 +340,7 @@ pub trait EnvoyHttpFilter {
   fn set_dynamic_metadata_number(&mut self, namespace: &str, key: &str, value: f64) -> bool;
 
   /// Get the string-typed dynamic metadata value with the given key.
-  /// If the metadata is not found, this returns `None`.
+  /// If the metadata is not found or is the wrong type, this returns `None`.
   fn get_dynamic_metadata_string(&self, namespace: &str, key: &str) -> Option<EnvoyBuffer>;
 
   /// Set the string-typed dynamic metadata value with the given key.

--- a/source/extensions/filters/http/dynamic_modules/abi_impl.cc
+++ b/source/extensions/filters/http/dynamic_modules/abi_impl.cc
@@ -289,6 +289,13 @@ bool envoy_dynamic_module_callback_http_get_dynamic_metadata_number(
   if (!key_metadata) {
     return false;
   }
+  if (!key_metadata->has_number_value()) {
+    ENVOY_LOG_TO_LOGGER(
+        Envoy::Logger::Registry::getLog(Envoy::Logger::Id::dynamic_modules), error,
+        fmt::format("key {} is not a number",
+                    absl::string_view(static_cast<const char*>(key_ptr), key_length)));
+    return false;
+  }
   *result = key_metadata->number_value();
   return true;
 }
@@ -319,6 +326,13 @@ bool envoy_dynamic_module_callback_http_get_dynamic_metadata_string(
   const auto key_metadata = getDynamicMetadataValue(filter_envoy_ptr, namespace_ptr,
                                                     namespace_length, key_ptr, key_length);
   if (!key_metadata) {
+    return false;
+  }
+  if (!key_metadata->has_string_value()) {
+    ENVOY_LOG_TO_LOGGER(
+        Envoy::Logger::Registry::getLog(Envoy::Logger::Id::dynamic_modules), error,
+        fmt::format("key {} is not a string",
+                    absl::string_view(static_cast<const char*>(key_ptr), key_length)));
     return false;
   }
   const auto& value = key_metadata->string_value();

--- a/source/extensions/filters/http/dynamic_modules/abi_impl.cc
+++ b/source/extensions/filters/http/dynamic_modules/abi_impl.cc
@@ -204,7 +204,8 @@ bool envoy_dynamic_module_callback_http_get_response_trailers(
  * corresponding HTTP filter.
  * @param namespace_ptr is the namespace of the dynamic metadata.
  * @param namespace_length is the length of the namespace.
- * @param create_if_not_exist is true if the namespace should be created if it does not exist.
+ * @param create_if_not_exist is true if the namespace should be created if it does not exist,
+ * assuming stream info is available.
  * @return the metadata namespace if it exists, nullptr otherwise.
  */
 ProtobufWkt::Struct*
@@ -271,6 +272,7 @@ bool envoy_dynamic_module_callback_http_set_dynamic_metadata_number(
   auto metadata_namespace =
       getDynamicMetadataNamespace(filter_envoy_ptr, namespace_ptr, namespace_length, true);
   if (!metadata_namespace) {
+    // If stream info is not available, we cannot guarantee that the namespace is created.
     return false;
   }
   absl::string_view key_view(static_cast<const char*>(key_ptr), key_length);
@@ -308,6 +310,7 @@ bool envoy_dynamic_module_callback_http_set_dynamic_metadata_string(
   auto metadata_namespace =
       getDynamicMetadataNamespace(filter_envoy_ptr, namespace_ptr, namespace_length, true);
   if (!metadata_namespace) {
+    // If stream info is not available, we cannot guarantee that the namespace is created.
     return false;
   }
   absl::string_view key_view(static_cast<const char*>(key_ptr), key_length);

--- a/source/extensions/filters/http/dynamic_modules/abi_impl.cc
+++ b/source/extensions/filters/http/dynamic_modules/abi_impl.cc
@@ -197,6 +197,135 @@ bool envoy_dynamic_module_callback_http_get_response_trailers(
   DynamicModuleHttpFilter* filter = static_cast<DynamicModuleHttpFilter*>(filter_envoy_ptr);
   return getHeadersImpl(filter->response_trailers_, result_headers);
 }
+
+/**
+ * Helper to get the metadata namespace from the stream info.
+ * @param filter_envoy_ptr is the pointer to the DynamicModuleHttpFilter object of the
+ * corresponding HTTP filter.
+ * @param namespace_ptr is the namespace of the dynamic metadata.
+ * @param namespace_length is the length of the namespace.
+ * @param create_if_not_exist is true if the namespace should be created if it does not exist.
+ * @return the metadata namespace if it exists, nullptr otherwise.
+ */
+ProtobufWkt::Struct*
+getDynamicMetadataNamespace(envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr,
+                            envoy_dynamic_module_type_buffer_module_ptr namespace_ptr,
+                            size_t namespace_length, bool create_if_not_exist) {
+  auto filter = static_cast<DynamicModuleHttpFilter*>(filter_envoy_ptr);
+  auto stream_info = filter->streamInfo();
+  if (!stream_info) {
+    ENVOY_LOG_TO_LOGGER(Envoy::Logger::Registry::getLog(Envoy::Logger::Id::dynamic_modules), debug,
+                        "stream info is not available");
+    return nullptr;
+  }
+  auto metadata = stream_info->dynamicMetadata().mutable_filter_metadata();
+  absl::string_view namespace_view(static_cast<const char*>(namespace_ptr), namespace_length);
+  auto metadata_namespace = metadata->find(namespace_view);
+  if (metadata_namespace == metadata->end()) {
+    if (!create_if_not_exist) {
+      ENVOY_LOG_TO_LOGGER(
+          Envoy::Logger::Registry::getLog(Envoy::Logger::Id::dynamic_modules), debug,
+          fmt::format("namespace {} not found in dynamic metadata", namespace_view));
+      return nullptr;
+    }
+    metadata_namespace = metadata->emplace(namespace_view, ProtobufWkt::Struct{}).first;
+  }
+  return &metadata_namespace->second;
+}
+
+/**
+ * Helper to get the metadata value from the metadata namespace.
+ *
+ * @param filter_envoy_ptr is the pointer to the DynamicModuleHttpFilter object of the
+ * corresponding HTTP filter.
+ * @param namespace_ptr is the namespace of the dynamic metadata.
+ * @param namespace_length is the length of the namespace.
+ * @param key_ptr is the key of the dynamic metadata.
+ * @param key_length is the length of the key.
+ * @return the metadata value if it exists, nullptr otherwise.
+ */
+const ProtobufWkt::Value*
+getDynamicMetadataValue(envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr,
+                        envoy_dynamic_module_type_buffer_module_ptr namespace_ptr,
+                        size_t namespace_length,
+                        envoy_dynamic_module_type_buffer_module_ptr key_ptr, size_t key_length) {
+  auto metadata_namespace =
+      getDynamicMetadataNamespace(filter_envoy_ptr, namespace_ptr, namespace_length, false);
+  if (!metadata_namespace) {
+    return nullptr;
+  }
+  absl::string_view key_view(static_cast<const char*>(key_ptr), key_length);
+  auto key_metadata = metadata_namespace->fields().find(key_view);
+  if (key_metadata == metadata_namespace->fields().end()) {
+    ENVOY_LOG_TO_LOGGER(Envoy::Logger::Registry::getLog(Envoy::Logger::Id::dynamic_modules), debug,
+                        fmt::format("key {} not found in metadata namespace", key_view));
+    return nullptr;
+  }
+  return &key_metadata->second;
+}
+
+bool envoy_dynamic_module_callback_http_set_dynamic_metadata_number(
+    envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr,
+    envoy_dynamic_module_type_buffer_module_ptr namespace_ptr, size_t namespace_length,
+    envoy_dynamic_module_type_buffer_module_ptr key_ptr, size_t key_length, uint64_t value) {
+  auto metadata_namespace =
+      getDynamicMetadataNamespace(filter_envoy_ptr, namespace_ptr, namespace_length, true);
+  if (!metadata_namespace) {
+    return false;
+  }
+  absl::string_view key_view(static_cast<const char*>(key_ptr), key_length);
+  ProtobufWkt::Struct metadata_value;
+  (*metadata_value.mutable_fields())[key_view].set_number_value(value);
+  metadata_namespace->MergeFrom(metadata_value);
+  return true;
+}
+
+bool envoy_dynamic_module_callback_http_get_dynamic_metadata_number(
+    envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr,
+    envoy_dynamic_module_type_buffer_module_ptr namespace_ptr, size_t namespace_length,
+    envoy_dynamic_module_type_buffer_module_ptr key_ptr, size_t key_length, uint64_t* result) {
+  const auto key_metadata = getDynamicMetadataValue(filter_envoy_ptr, namespace_ptr,
+                                                    namespace_length, key_ptr, key_length);
+  if (!key_metadata) {
+    return false;
+  }
+  *result = key_metadata->number_value();
+  return true;
+}
+
+bool envoy_dynamic_module_callback_http_set_dynamic_metadata_string(
+    envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr,
+    envoy_dynamic_module_type_buffer_module_ptr namespace_ptr, size_t namespace_length,
+    envoy_dynamic_module_type_buffer_module_ptr key_ptr, size_t key_length,
+    envoy_dynamic_module_type_buffer_module_ptr value_ptr, size_t value_length) {
+  auto metadata_namespace =
+      getDynamicMetadataNamespace(filter_envoy_ptr, namespace_ptr, namespace_length, true);
+  if (!metadata_namespace) {
+    return false;
+  }
+  absl::string_view key_view(static_cast<const char*>(key_ptr), key_length);
+  absl::string_view value_view(static_cast<const char*>(value_ptr), value_length);
+  ProtobufWkt::Struct metadata_value;
+  (*metadata_value.mutable_fields())[key_view].set_string_value(value_view);
+  metadata_namespace->MergeFrom(metadata_value);
+  return true;
+}
+
+bool envoy_dynamic_module_callback_http_get_dynamic_metadata_string(
+    envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr,
+    envoy_dynamic_module_type_buffer_module_ptr namespace_ptr, size_t namespace_length,
+    envoy_dynamic_module_type_buffer_module_ptr key_ptr, size_t key_length,
+    envoy_dynamic_module_type_buffer_envoy_ptr* result, size_t* result_length) {
+  const auto key_metadata = getDynamicMetadataValue(filter_envoy_ptr, namespace_ptr,
+                                                    namespace_length, key_ptr, key_length);
+  if (!key_metadata) {
+    return false;
+  }
+  const auto& value = key_metadata->string_value();
+  *result = const_cast<char*>(value.data());
+  *result_length = value.size();
+  return true;
+}
 }
 } // namespace HttpFilters
 } // namespace DynamicModules

--- a/source/extensions/filters/http/dynamic_modules/abi_impl.cc
+++ b/source/extensions/filters/http/dynamic_modules/abi_impl.cc
@@ -267,7 +267,7 @@ getDynamicMetadataValue(envoy_dynamic_module_type_http_filter_envoy_ptr filter_e
 bool envoy_dynamic_module_callback_http_set_dynamic_metadata_number(
     envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr,
     envoy_dynamic_module_type_buffer_module_ptr namespace_ptr, size_t namespace_length,
-    envoy_dynamic_module_type_buffer_module_ptr key_ptr, size_t key_length, uint64_t value) {
+    envoy_dynamic_module_type_buffer_module_ptr key_ptr, size_t key_length, double value) {
   auto metadata_namespace =
       getDynamicMetadataNamespace(filter_envoy_ptr, namespace_ptr, namespace_length, true);
   if (!metadata_namespace) {
@@ -283,7 +283,7 @@ bool envoy_dynamic_module_callback_http_set_dynamic_metadata_number(
 bool envoy_dynamic_module_callback_http_get_dynamic_metadata_number(
     envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr,
     envoy_dynamic_module_type_buffer_module_ptr namespace_ptr, size_t namespace_length,
-    envoy_dynamic_module_type_buffer_module_ptr key_ptr, size_t key_length, uint64_t* result) {
+    envoy_dynamic_module_type_buffer_module_ptr key_ptr, size_t key_length, double* result) {
   const auto key_metadata = getDynamicMetadataValue(filter_envoy_ptr, namespace_ptr,
                                                     namespace_length, key_ptr, key_length);
   if (!key_metadata) {

--- a/source/extensions/filters/http/dynamic_modules/filter.h
+++ b/source/extensions/filters/http/dynamic_modules/filter.h
@@ -59,6 +59,19 @@ public:
   ResponseHeaderMap* response_headers_ = nullptr;
   ResponseTrailerMap* response_trailers_ = nullptr;
 
+  /**
+   * Helper to get the downstream information of the stream.
+   */
+  StreamInfo::StreamInfo* streamInfo() {
+    if (decoder_callbacks_) {
+      return &decoder_callbacks_->streamInfo();
+    } else if (encoder_callbacks_) {
+      return &encoder_callbacks_->streamInfo();
+    } else {
+      return nullptr;
+    }
+  }
+
 private:
   /**
    * This is a helper function to get the `this` pointer as a void pointer which is passed to the

--- a/test/extensions/dynamic_modules/http/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/http/abi_impl_test.cc
@@ -272,6 +272,64 @@ TEST(ABIImpl, get_headers) {
   }
 }
 
+TEST(ABIImpl, dynamic_metadata) {
+  DynamicModuleHttpFilter filter{nullptr};
+  const std::string namespace_str = "foo";
+  const std::string key_str = "key";
+  envoy_dynamic_module_type_buffer_module_ptr namespace_ptr =
+      const_cast<char*>(namespace_str.data());
+  size_t namespace_length = namespace_str.size();
+  envoy_dynamic_module_type_buffer_module_ptr key_ptr = const_cast<char*>(key_str.data());
+  size_t key_length = key_str.size();
+  uint64_t value = 42;
+  const std::string value_str = "value";
+  envoy_dynamic_module_type_buffer_module_ptr value_ptr = const_cast<char*>(value_str.data());
+  size_t value_length = value_str.size();
+  uint64_t result_number = 0;
+  char* result_str_ptr = nullptr;
+  size_t result_str_length = 0;
+
+  // No stream info.
+  EXPECT_FALSE(envoy_dynamic_module_callback_http_set_dynamic_metadata_number(
+      &filter, namespace_ptr, namespace_length, key_ptr, key_length, value));
+  EXPECT_FALSE(envoy_dynamic_module_callback_http_set_dynamic_metadata_string(
+      &filter, namespace_ptr, namespace_length, key_ptr, key_length, value_ptr, value_length));
+  EXPECT_FALSE(envoy_dynamic_module_callback_http_get_dynamic_metadata_number(
+      &filter, namespace_ptr, namespace_length, key_ptr, key_length, &result_number));
+  EXPECT_FALSE(envoy_dynamic_module_callback_http_get_dynamic_metadata_string(
+      &filter, namespace_ptr, namespace_length, key_ptr, key_length, &result_str_ptr,
+      &result_str_length));
+
+  // No namespace.
+  Http::MockStreamDecoderFilterCallbacks callbacks;
+  StreamInfo::MockStreamInfo stream_info;
+  EXPECT_CALL(callbacks, streamInfo()).WillRepeatedly(testing::ReturnRef(stream_info));
+  envoy::config::core::v3::Metadata metadata;
+  EXPECT_CALL(stream_info, dynamicMetadata()).WillRepeatedly(testing::ReturnRef(metadata));
+  filter.setDecoderFilterCallbacks(callbacks);
+  // Only tests get methods as setters create the namespace.
+  EXPECT_FALSE(envoy_dynamic_module_callback_http_get_dynamic_metadata_number(
+      &filter, namespace_ptr, namespace_length, key_ptr, key_length, &result_number));
+  EXPECT_FALSE(envoy_dynamic_module_callback_http_get_dynamic_metadata_string(
+      &filter, namespace_ptr, namespace_length, key_ptr, key_length, &result_str_ptr,
+      &result_str_length));
+
+  // With namespace and key.
+  EXPECT_TRUE(envoy_dynamic_module_callback_http_set_dynamic_metadata_number(
+      &filter, namespace_ptr, namespace_length, key_ptr, key_length, value));
+  EXPECT_TRUE(envoy_dynamic_module_callback_http_get_dynamic_metadata_number(
+      &filter, namespace_ptr, namespace_length, key_ptr, key_length, &result_number));
+  EXPECT_EQ(result_number, value); // Round trip.
+
+  EXPECT_TRUE(envoy_dynamic_module_callback_http_set_dynamic_metadata_string(
+      &filter, namespace_ptr, namespace_length, key_ptr, key_length, value_ptr, value_length));
+  EXPECT_TRUE(envoy_dynamic_module_callback_http_get_dynamic_metadata_string(
+      &filter, namespace_ptr, namespace_length, key_ptr, key_length, &result_str_ptr,
+      &result_str_length));
+  EXPECT_EQ(result_str_length, value_length);
+  EXPECT_EQ(std::string(result_str_ptr, result_str_length), value_str); // Round trip.
+}
+
 } // namespace HttpFilters
 } // namespace DynamicModules
 } // namespace Extensions

--- a/test/extensions/dynamic_modules/http/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/http/abi_impl_test.cc
@@ -319,7 +319,11 @@ TEST(ABIImpl, dynamic_metadata) {
       &filter, namespace_ptr, namespace_length, key_ptr, key_length, value));
   EXPECT_TRUE(envoy_dynamic_module_callback_http_get_dynamic_metadata_number(
       &filter, namespace_ptr, namespace_length, key_ptr, key_length, &result_number));
-  EXPECT_EQ(result_number, value); // Round trip.
+  EXPECT_EQ(result_number, value);
+  // Wrong type.
+  EXPECT_FALSE(envoy_dynamic_module_callback_http_get_dynamic_metadata_string(
+      &filter, namespace_ptr, namespace_length, key_ptr, key_length, &result_str_ptr,
+      &result_str_length));
 
   EXPECT_TRUE(envoy_dynamic_module_callback_http_set_dynamic_metadata_string(
       &filter, namespace_ptr, namespace_length, key_ptr, key_length, value_ptr, value_length));
@@ -327,7 +331,10 @@ TEST(ABIImpl, dynamic_metadata) {
       &filter, namespace_ptr, namespace_length, key_ptr, key_length, &result_str_ptr,
       &result_str_length));
   EXPECT_EQ(result_str_length, value_length);
-  EXPECT_EQ(std::string(result_str_ptr, result_str_length), value_str); // Round trip.
+  EXPECT_EQ(std::string(result_str_ptr, result_str_length), value_str);
+  // Wrong type.
+  EXPECT_FALSE(envoy_dynamic_module_callback_http_get_dynamic_metadata_number(
+      &filter, namespace_ptr, namespace_length, key_ptr, key_length, &result_number));
 }
 
 } // namespace HttpFilters

--- a/test/extensions/dynamic_modules/http/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/http/abi_impl_test.cc
@@ -281,11 +281,11 @@ TEST(ABIImpl, dynamic_metadata) {
   size_t namespace_length = namespace_str.size();
   envoy_dynamic_module_type_buffer_module_ptr key_ptr = const_cast<char*>(key_str.data());
   size_t key_length = key_str.size();
-  uint64_t value = 42;
+  double value = 42;
   const std::string value_str = "value";
   envoy_dynamic_module_type_buffer_module_ptr value_ptr = const_cast<char*>(value_str.data());
   size_t value_length = value_str.size();
-  uint64_t result_number = 0;
+  double result_number = 0;
   char* result_str_ptr = nullptr;
   size_t result_str_length = 0;
 

--- a/test/extensions/dynamic_modules/http/filter_test.cc
+++ b/test/extensions/dynamic_modules/http/filter_test.cc
@@ -120,25 +120,21 @@ TEST(DynamiModulesTest, DynamicMetadataCallbacks) {
   EXPECT_EQ(FilterDataStatus::Continue, filter->encodeData(data, false));
 
   // Check dynamic metadata set by the filter during even hooks.
-  // namespace: ns_req_header, key: key, value: 123
   auto ns_req_header = metadata.filter_metadata().find("ns_req_header");
   ASSERT_NE(ns_req_header, metadata.filter_metadata().end());
   auto key = ns_req_header->second.fields().find("key");
   ASSERT_NE(key, ns_req_header->second.fields().end());
   EXPECT_EQ(key->second.number_value(), 123);
-  // namespace: ns_res_header, key: key, value: 123
   auto ns_res_header = metadata.filter_metadata().find("ns_res_header");
   ASSERT_NE(ns_res_header, metadata.filter_metadata().end());
   key = ns_res_header->second.fields().find("key");
   ASSERT_NE(key, ns_res_header->second.fields().end());
   EXPECT_EQ(key->second.number_value(), 123);
-  // namespace: ns_req_body, key: key, value: "value"
   auto ns_req_body = metadata.filter_metadata().find("ns_req_body");
   ASSERT_NE(ns_req_body, metadata.filter_metadata().end());
   key = ns_req_body->second.fields().find("key");
   ASSERT_NE(key, ns_req_body->second.fields().end());
   EXPECT_EQ(key->second.string_value(), "value");
-  // namespace: ns_res_body, key: key, value: "value"
   auto ns_res_body = metadata.filter_metadata().find("ns_res_body");
   ASSERT_NE(ns_res_body, metadata.filter_metadata().end());
   key = ns_res_body->second.fields().find("key");

--- a/test/extensions/dynamic_modules/http/filter_test.cc
+++ b/test/extensions/dynamic_modules/http/filter_test.cc
@@ -86,6 +86,68 @@ TEST(DynamiModulesTest, HeaderCallbacks) {
   filter->onDestroy();
 }
 
+TEST(DynamiModulesTest, DynamicMetadataCallbacks) {
+  const std::string filter_name = "dynamic_metadata_callbacks";
+  const std::string filter_config = "";
+  // TODO: Add non-Rust test program once we have non-Rust SDK.
+  auto dynamic_module = newDynamicModule(testSharedObjectPath("http", "rust"), false);
+  if (!dynamic_module.ok()) {
+    ENVOY_LOG_MISC(debug, "Failed to load dynamic module: {}", dynamic_module.status().message());
+  }
+  EXPECT_TRUE(dynamic_module.ok());
+
+  auto filter_config_or_status =
+      Envoy::Extensions::DynamicModules::HttpFilters::newDynamicModuleHttpFilterConfig(
+          filter_name, filter_config, std::move(dynamic_module.value()));
+  EXPECT_TRUE(filter_config_or_status.ok());
+
+  auto filter = std::make_shared<DynamicModuleHttpFilter>(filter_config_or_status.value());
+  filter->initializeInModuleFilter();
+
+  Http::MockStreamDecoderFilterCallbacks callbacks;
+  StreamInfo::MockStreamInfo stream_info;
+  EXPECT_CALL(callbacks, streamInfo()).WillRepeatedly(testing::ReturnRef(stream_info));
+  envoy::config::core::v3::Metadata metadata;
+  EXPECT_CALL(stream_info, dynamicMetadata()).WillRepeatedly(testing::ReturnRef(metadata));
+  filter->setDecoderFilterCallbacks(callbacks);
+
+  Http::TestRequestHeaderMapImpl request_headers{};
+  Http::TestResponseHeaderMapImpl response_headers{};
+  Buffer::OwnedImpl data;
+  EXPECT_EQ(FilterHeadersStatus::Continue, filter->decodeHeaders(request_headers, false));
+  EXPECT_EQ(FilterDataStatus::Continue, filter->decodeData(data, false));
+  EXPECT_EQ(FilterHeadersStatus::Continue, filter->encodeHeaders(response_headers, false));
+  EXPECT_EQ(FilterDataStatus::Continue, filter->encodeData(data, false));
+
+  // Check dynamic metadata set by the filter during even hooks.
+  // namespace: ns_req_header, key: key, value: 123
+  auto ns_req_header = metadata.filter_metadata().find("ns_req_header");
+  ASSERT_NE(ns_req_header, metadata.filter_metadata().end());
+  auto key = ns_req_header->second.fields().find("key");
+  ASSERT_NE(key, ns_req_header->second.fields().end());
+  EXPECT_EQ(key->second.number_value(), 123);
+  // namespace: ns_res_header, key: key, value: 123
+  auto ns_res_header = metadata.filter_metadata().find("ns_res_header");
+  ASSERT_NE(ns_res_header, metadata.filter_metadata().end());
+  key = ns_res_header->second.fields().find("key");
+  ASSERT_NE(key, ns_res_header->second.fields().end());
+  EXPECT_EQ(key->second.number_value(), 123);
+  // namespace: ns_req_body, key: key, value: "value"
+  auto ns_req_body = metadata.filter_metadata().find("ns_req_body");
+  ASSERT_NE(ns_req_body, metadata.filter_metadata().end());
+  key = ns_req_body->second.fields().find("key");
+  ASSERT_NE(key, ns_req_body->second.fields().end());
+  EXPECT_EQ(key->second.string_value(), "value");
+  // namespace: ns_res_body, key: key, value: "value"
+  auto ns_res_body = metadata.filter_metadata().find("ns_res_body");
+  ASSERT_NE(ns_res_body, metadata.filter_metadata().end());
+  key = ns_res_body->second.fields().find("key");
+  ASSERT_NE(key, ns_res_body->second.fields().end());
+  EXPECT_EQ(key->second.string_value(), "value");
+
+  filter->onDestroy();
+}
+
 } // namespace HttpFilters
 } // namespace DynamicModules
 } // namespace Extensions

--- a/test/extensions/dynamic_modules/test_data/rust/http.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/http.rs
@@ -20,6 +20,7 @@ fn new_http_filter_config_fn<EHF: EnvoyHttpFilter>(
 ) -> Option<Box<dyn HttpFilterConfig<EHF>>> {
   match name {
     "header_callbacks" => Some(Box::new(HeaderCallbacksFilterConfig {})),
+    "dynamic_metadata_callbacks" => Some(Box::new(DynamicMetadataCallbacksFilterConfig {})),
     // TODO: add various configs for body, etc.
     _ => panic!("Unknown filter name: {}", name),
   }
@@ -36,8 +37,7 @@ impl<EHF: EnvoyHttpFilter> HttpFilterConfig<EHF> for HeaderCallbacksFilterConfig
   }
 }
 
-/// A no-op HTTP filter that implements [`envoy_proxy_dynamic_modules_rust_sdk::HttpFilter`]
-/// as well as the [`Drop`] to test the cleanup of the filter.
+/// A HTTP filter that implements [`envoy_proxy_dynamic_modules_rust_sdk::HttpFilter`].
 struct HeaderCallbacksFilter {}
 
 impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for HeaderCallbacksFilter {
@@ -225,5 +225,83 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for HeaderCallbacksFilter {
     assert_eq!(all_trailers[3].1.as_slice(), b"value");
 
     abi::envoy_dynamic_module_type_on_http_filter_response_trailers_status::Continue
+  }
+}
+
+
+/// A HTTP filter configuration that implements
+/// [`envoy_proxy_dynamic_modules_rust_sdk::HttpFilterConfig`] to test the dynamic metadata related
+/// callbacks.
+struct DynamicMetadataCallbacksFilterConfig {}
+
+impl<EHF: EnvoyHttpFilter> HttpFilterConfig<EHF> for DynamicMetadataCallbacksFilterConfig {
+  fn new_http_filter(&self, _envoy: EnvoyHttpFilterConfig) -> Box<dyn HttpFilter<EHF>> {
+    Box::new(DynamicMetadataCallbacksFilter {})
+  }
+}
+
+/// A HTTP filter that implements [`envoy_proxy_dynamic_modules_rust_sdk::HttpFilter`].
+struct DynamicMetadataCallbacksFilter {}
+
+impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for DynamicMetadataCallbacksFilter {
+  fn on_request_headers(
+    &mut self,
+    mut envoy_filter: EHF,
+    _end_of_stream: bool,
+  ) -> abi::envoy_dynamic_module_type_on_http_filter_request_headers_status {
+    // No namespace.
+    let no_namespace = envoy_filter.get_dynamic_metadata_number("no_namespace", "key");
+    assert!(no_namespace.is_none());
+    // Set a number.
+    envoy_filter.set_dynamic_metadata_number("ns_req_header", "key", 123);
+    let ns_req_header = envoy_filter.get_dynamic_metadata_number("ns_req_header", "key");
+    assert_eq!(ns_req_header, Some(123));
+    abi::envoy_dynamic_module_type_on_http_filter_request_headers_status::Continue
+  }
+
+  fn on_request_body(
+    &mut self,
+    mut envoy_filter: EHF,
+    _end_of_stream: bool,
+  ) -> abi::envoy_dynamic_module_type_on_http_filter_request_body_status {
+    // No namespace.
+    let no_namespace = envoy_filter.get_dynamic_metadata_string("no_namespace", "key");
+    assert!(no_namespace.is_none());
+    // Set a string.
+    envoy_filter.set_dynamic_metadata_string("ns_req_body", "key", "value");
+    let ns_req_body = envoy_filter.get_dynamic_metadata_string("ns_req_body", "key");
+    assert!(ns_req_body.is_some());
+    assert_eq!(ns_req_body.unwrap().as_slice(), b"value");
+    abi::envoy_dynamic_module_type_on_http_filter_request_body_status::Continue
+  }
+
+  fn on_response_headers(
+    &mut self,
+    mut envoy_filter: EHF,
+    _end_of_stream: bool,
+  ) -> abi::envoy_dynamic_module_type_on_http_filter_response_headers_status {
+    // No namespace.
+    let no_namespace = envoy_filter.get_dynamic_metadata_string("no_namespace", "key");
+    assert!(no_namespace.is_none());
+    // Set a number.
+    envoy_filter.set_dynamic_metadata_number("ns_res_header", "key", 123);
+    let ns_res_header = envoy_filter.get_dynamic_metadata_number("ns_res_header", "key");
+    assert_eq!(ns_res_header, Some(123));
+    abi::envoy_dynamic_module_type_on_http_filter_response_headers_status::Continue
+  }
+
+  fn on_response_body(
+    &mut self,
+    mut envoy_filter: EHF,
+    _end_of_stream: bool,
+  ) -> abi::envoy_dynamic_module_type_on_http_filter_response_body_status {
+    // No namespace.
+    let no_namespace = envoy_filter.get_dynamic_metadata_string("no_namespace", "key");
+    assert!(no_namespace.is_none());
+    // Set a string.
+    envoy_filter.set_dynamic_metadata_string("ns_res_body", "key", "value");
+    let ns_res_body = envoy_filter.get_dynamic_metadata_string("ns_res_body", "key");
+    assert!(ns_res_body.is_some());
+    abi::envoy_dynamic_module_type_on_http_filter_response_body_status::Continue
   }
 }

--- a/test/extensions/dynamic_modules/test_data/rust/http.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/http.rs
@@ -256,6 +256,9 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for DynamicMetadataCallbacksFilter {
     envoy_filter.set_dynamic_metadata_number("ns_req_header", "key", 123f64);
     let ns_req_header = envoy_filter.get_dynamic_metadata_number("ns_req_header", "key");
     assert_eq!(ns_req_header, Some(123f64));
+    // Try getting a number as string.
+    let ns_req_header = envoy_filter.get_dynamic_metadata_string("ns_req_header", "key");
+    assert!(ns_req_header.is_none());
     abi::envoy_dynamic_module_type_on_http_filter_request_headers_status::Continue
   }
 
@@ -272,6 +275,9 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for DynamicMetadataCallbacksFilter {
     let ns_req_body = envoy_filter.get_dynamic_metadata_string("ns_req_body", "key");
     assert!(ns_req_body.is_some());
     assert_eq!(ns_req_body.unwrap().as_slice(), b"value");
+    // Try getting a string as number.
+    let ns_req_body = envoy_filter.get_dynamic_metadata_number("ns_req_body", "key");
+    assert!(ns_req_body.is_none());
     abi::envoy_dynamic_module_type_on_http_filter_request_body_status::Continue
   }
 
@@ -287,6 +293,9 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for DynamicMetadataCallbacksFilter {
     envoy_filter.set_dynamic_metadata_number("ns_res_header", "key", 123f64);
     let ns_res_header = envoy_filter.get_dynamic_metadata_number("ns_res_header", "key");
     assert_eq!(ns_res_header, Some(123f64));
+    // Try getting a number as string.
+    let ns_res_header = envoy_filter.get_dynamic_metadata_string("ns_res_header", "key");
+    assert!(ns_res_header.is_none());
     abi::envoy_dynamic_module_type_on_http_filter_response_headers_status::Continue
   }
 
@@ -302,6 +311,9 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for DynamicMetadataCallbacksFilter {
     envoy_filter.set_dynamic_metadata_string("ns_res_body", "key", "value");
     let ns_res_body = envoy_filter.get_dynamic_metadata_string("ns_res_body", "key");
     assert!(ns_res_body.is_some());
+    // Try getting a string as number.
+    let ns_res_body = envoy_filter.get_dynamic_metadata_number("ns_res_body", "key");
+    assert!(ns_res_body.is_none());
     abi::envoy_dynamic_module_type_on_http_filter_response_body_status::Continue
   }
 }

--- a/test/extensions/dynamic_modules/test_data/rust/http.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/http.rs
@@ -253,9 +253,9 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for DynamicMetadataCallbacksFilter {
     let no_namespace = envoy_filter.get_dynamic_metadata_number("no_namespace", "key");
     assert!(no_namespace.is_none());
     // Set a number.
-    envoy_filter.set_dynamic_metadata_number("ns_req_header", "key", 123);
+    envoy_filter.set_dynamic_metadata_number("ns_req_header", "key", 123f64);
     let ns_req_header = envoy_filter.get_dynamic_metadata_number("ns_req_header", "key");
-    assert_eq!(ns_req_header, Some(123));
+    assert_eq!(ns_req_header, Some(123f64));
     abi::envoy_dynamic_module_type_on_http_filter_request_headers_status::Continue
   }
 
@@ -284,9 +284,9 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for DynamicMetadataCallbacksFilter {
     let no_namespace = envoy_filter.get_dynamic_metadata_string("no_namespace", "key");
     assert!(no_namespace.is_none());
     // Set a number.
-    envoy_filter.set_dynamic_metadata_number("ns_res_header", "key", 123);
+    envoy_filter.set_dynamic_metadata_number("ns_res_header", "key", 123f64);
     let ns_res_header = envoy_filter.get_dynamic_metadata_number("ns_res_header", "key");
-    assert_eq!(ns_res_header, Some(123));
+    assert_eq!(ns_res_header, Some(123f64));
     abi::envoy_dynamic_module_type_on_http_filter_response_headers_status::Continue
   }
 


### PR DESCRIPTION
Commit Message: dynamic_modules: adds dynamic metadata callbakcs
Additional Description:
This adds the following callbacks

* envoy_dynamic_module_callback_http_set_dynamic_metadata_number
* envoy_dynamic_module_callback_http_get_dynamic_metadata_number
* envoy_dynamic_module_callback_http_set_dynamic_metadata_string
* envoy_dynamic_module_callback_http_get_dynamic_metadata_string

for getting and setting basic dynamic metadata types from dynamic modules.
These callbacks are "typed" rather than accepting opaque "protobuf value".
The reason is that we discussed earlier that we shouldn't expose the protobuf
implementation detail at the ABI layer in order to avoid forcing all modules
to understand and bring in protobuf dependencies into their shared library.

More complex types can be added later, but I doubt that the majority of
users would need types beyond string and number types. We can revisit 
this later if necessary.

Risk Level: low
Testing: done
Docs Changes: n/a
Release Notes: n/a 
Platform Specific Features: n/a

