### PR TITLE
api: add TIMEOUT value to CSDS status enum

### DIFF
--- a/api/envoy/admin/v3/config_dump_shared.proto
+++ b/api/envoy/admin/v3/config_dump_shared.proto
@@ -43,7 +43,10 @@ enum ClientResourceStatus {
   // Client received an error from the control plane. The attached config
   // dump is the most recent accepted one. If no config is accepted yet,
   // the attached config dump will be empty.
-  CLIENT_RECEIVED_ERROR = 5;
+  RECEIVED_ERROR = 5;
+
+  // Client timed out waiting for the resource from the control plane.
+  TIMEOUT = 6;
 }
 
 message UpdateFailureState {


### PR DESCRIPTION
Commit Message: api: add TIMEOUT value to CSDS status enum
Additional Description: Also remove unnecessary `CLIENT_` prefix to the enum value added in #37858.  For context, see https://github.com/grpc/proposal/pull/466.
Risk Level: Low
Testing: N/A
Docs Changes: Included in PR
Release Notes: N/A
Platform Specific Features: N/A

CC @adisuissa 