### PR TITLE
docs: fix small typo in RBAC docs

### DIFF
--- a/api/envoy/config/rbac/v3/rbac.proto
+++ b/api/envoy/config/rbac/v3/rbac.proto
@@ -206,8 +206,10 @@ message Policy {
 // metadata should be sourced from, rather than only matching against dynamic metadata.
 //
 // The matcher can be configured to look up metadata from:
+//
 // * Dynamic metadata: Runtime metadata added by filters during request processing
 // * Route metadata: Static metadata configured on the route entry
+//
 message SourcedMetadata {
   // Metadata matcher configuration that defines what metadata to match against. This includes the filter name,
   // metadata key path, and expected value.


### PR DESCRIPTION
## Description

This PR fixes a small typo in the RBAC docs where the list is not being rendered properly due to missing newlines.

---

**Commit Message:** docs: fix small typo in RBAC docs
**Additional Description:** Fixes a small typo in the RABC docs to render the list on sourced metadata correctly.
**Risk Level:** N/A
**Testing:** N/A
**Docs Changes:** N/A
**Release Notes:** N/A