### PR TITLE
docs: fix typos in the current changelogs

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -417,7 +417,7 @@ deprecated:
 - area: cluster
   change: |
     DNS-related fields in :ref:`Cluster <envoy_v3_api_msg_config.cluster.v3.Cluster>` are deprecated when using
-    strict and logical dns clusters. Instead, use the
+    strict and logical DNS clusters. Instead, use the
     :ref:`cluster_type <envoy_v3_api_field_config.cluster.v3.Cluster.cluster_type>` extension point with
     :ref:`typed_config <envoy_v3_api_field_config.cluster.v3.Cluster.CustomClusterType.typed_config>` of type
     :ref:`DnsCluster <envoy_v3_api_msg_extensions.clusters.dns.v3.DnsCluster>`.

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -252,7 +252,7 @@ new_features:
     behaviour can also be overridden with this field.
 - area: tls
   change: |
-    Added support for P-384 and P-521 curves for TLS server certificates.
+    Added support for ``P-384`` and ``P-521`` curves for TLS server certificates.
 - area: tls
   change: |
     Added an :ref:`option
@@ -271,8 +271,8 @@ new_features:
     added ``clear_route_cache`` foreign function to clear the route cache.
 - area: access_log
   change: |
-    Added %DOWNSTREAM_LOCAL_EMAIL_SAN%, %DOWNSTREAM_PEER_EMAIL_SAN%, %DOWNSTREAM_LOCAL_OTHERNAME_SAN% and
-    %DOWNSTREAM_PEER_OTHERNAME_SAN% substitution formatters.
+    Added ``%DOWNSTREAM_LOCAL_EMAIL_SAN%``, ``%DOWNSTREAM_PEER_EMAIL_SAN%``, ``%DOWNSTREAM_LOCAL_OTHERNAME_SAN%`` and
+    ``%DOWNSTREAM_PEER_OTHERNAME_SAN%`` substitution formatters.
 - area: access_log
   change: |
     Added support for logging upstream connection establishment duration in the
@@ -284,7 +284,8 @@ new_features:
     Add logging functions to all lua objects. Previously these were only available on the Lua http filter request handle.
 - area: access log
   change: |
-    Added fields for :ref:`DOWNSTREAM_DIRECT_LOCAL_ADDRESS and DOWNSTREAM_DIRECT_LOCAL_ADDRESS_WITHOUT_PORT <config_access_log_format>`.
+    Added fields for :ref:`DOWNSTREAM_DIRECT_LOCAL_ADDRESS <config_access_log_format>` and
+    :ref:`DOWNSTREAM_DIRECT_LOCAL_ADDRESS_WITHOUT_PORT <config_access_log_format>`.
 - area: quic
   change: |
     Added :ref:`QUIC stats debug visitor <envoy_v3_api_msg_extensions.quic.connection_debug_visitor.quic_stats.v3.Config>` to
@@ -340,8 +341,8 @@ new_features:
     specifying an optional source for the metadata to be matched in addition to the metadata matcher.
 - area: c-ares
   change: |
-    added nameserver rotation option to c-ares resolver. When enabled via :ref:rotate_nameservers
-    <envoy_v3_api_field_extensions.network.dns_resolver.cares.v3.CaresDnsResolverConfig.rotate_nameservers>, this
+    added nameserver rotation option to c-ares resolver. When enabled via :ref:`rotate_nameservers
+    <envoy_v3_api_field_extensions.network.dns_resolver.cares.v3.CaresDnsResolverConfig.rotate_nameservers>`, this
     performs round-robin selection of the configured nameservers for each resolution to help distribute query load.
 - area: access_log
   change: |
@@ -355,7 +356,7 @@ new_features:
     the key ``envoy.udp_proxy.cluster`` without setting ``envoy.upstream.dynamic_host``.
 - area: ext_authz
   change: |
-    added filter state field latency_us, bytesSent and bytesReceived access for CEL and logging.
+    added filter state field ``latency_us``, ``bytesSent`` and ``bytesReceived`` access for CEL and logging.
 - area: sni_dynamic_forward_proxy
   change: |
     Added support in SNI dynamic forward proxy for saving the resolved upstream address in the filter state.
@@ -384,7 +385,7 @@ new_features:
     <envoy_v3_api_field_config.route.v3.RateLimit.hits_addend>` for more details.
 - area: filters
   change: |
-    Updatd the ``set_filter_state`` :ref:`filter <config_http_filters_set_filter_state>` to support per-route overrides.
+    Updated the ``set_filter_state`` :ref:`filter <config_http_filters_set_filter_state>` to support per-route overrides.
 - area: grpc-json
   change: |
     Added a new http filter for :ref:`gRPC to JSON transcoding <config_http_filters_grpc_json_reverse_transcoder>`.
@@ -394,7 +395,7 @@ new_features:
     :ref:`attributes <arch_overview_attributes>` for looking up xDS configuration information.
 - area: redis
   change: |
-    Added support for UNWATCH command.
+    Added support for ``UNWATCH`` command.
 - area: ratelimit
   change: |
     Add the :ref:`rate_limits
@@ -411,13 +412,14 @@ new_features:
 deprecated:
 - area: rbac
   change: |
-    metadata :ref:`metadata <envoy_v3_api_field_config.rbac.v3.Permission.metadata>` is now deprecated in the
+    :ref:`metadata <envoy_v3_api_field_config.rbac.v3.Permission.metadata>` is now deprecated in the
     favor of :ref:`sourced_metadata <envoy_v3_api_field_config.rbac.v3.Permission.sourced_metadata>`.
 - area: cluster
   change: |
-    `DNS-related fields in :ref:`Cluster <envoy_v3_api_msg_config.cluster.v3.Cluster> are deprecated when using
-    strict and logical dns clusters. Instead, use the :ref:`cluster_type <envoy_v3_api_field_config.cluster.v3.Cluster.cluster_type`
-    extension point with :ref:`typed_config<envoy_v3_api_field_config.cluster.v3.Cluster.CustomClusterType.typed_config>` of type
+    DNS-related fields in :ref:`Cluster <envoy_v3_api_msg_config.cluster.v3.Cluster>` are deprecated when using
+    strict and logical dns clusters. Instead, use the
+    :ref:`cluster_type <envoy_v3_api_field_config.cluster.v3.Cluster.cluster_type>` extension point with
+    :ref:`typed_config <envoy_v3_api_field_config.cluster.v3.Cluster.CustomClusterType.typed_config>` of type
     :ref:`DnsCluster <envoy_v3_api_msg_extensions.clusters.dns.v3.DnsCluster>`.
 - area: aws_iam
   change: |

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -252,7 +252,7 @@ new_features:
     behaviour can also be overridden with this field.
 - area: tls
   change: |
-    Added support for ``P-384`` and ``P-521`` curves for TLS server certificates.
+    Added support for **P-384** and **P-521** curves for TLS server certificates.
 - area: tls
   change: |
     Added an :ref:`option


### PR DESCRIPTION
## Description

This PR fixes some small typo in the change-logs. Some of the entries are not getting rendered properly due to missing backticks, etc.

For example,
<img width="890" alt="Screenshot 2025-01-06 at 00 22 15" src="https://github.com/user-attachments/assets/6f115586-5821-4d3c-a9f0-90b9317b8f62" /> 

---

**Commit Message:** docs: fix typos in the current changelogs
**Additional Description:** Fixes some small typo in the change-logs to render the entries properly.
**Risk Level:** N/A
**Testing:** N/A
**Docs Changes:** N/A
**Release Notes:** N/A