### PR TITLE
dynamic_modules: adds a lifetime param on EnvoyBuffer

### DIFF
--- a/source/extensions/dynamic_modules/sdk/rust/src/buffer.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/buffer.rs
@@ -4,7 +4,7 @@
 /// thought of as an alias to &\[u8\] but the underlying memory is owned by Envoy.
 //
 // Implementation note: The lifetime parameter `'a` is used to ensure that the memory region pointed
-// to by `raw_ptr` is valid for the lifetime of the buffer, which can happen when the mutable
+// to by `raw_ptr` is valid. The invalidation can happen when the mutable
 // methods of [`crate::EnvoyHttpFilter`] are called.
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]

--- a/source/extensions/dynamic_modules/sdk/rust/src/buffer.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/buffer.rs
@@ -1,18 +1,20 @@
 /// A buffer struct that represents a contiguous memory region owned by Envoy.
 ///
-/// The life time (not in Rust sense) of the buffer is managed by Envoy, and it depends on how
-/// this [`EnvoyBuffer`] is created, for example, via [`crate::EnvoyHttpFilter`]'s methods.
-///
 /// This is cloneable and copyable, but the underlying memory is not copied. It can be
 /// thought of as an alias to &\[u8\] but the underlying memory is owned by Envoy.
+//
+// Implementation note: The lifetime parameter `'a` is used to ensure that the memory region pointed
+// to by `raw_ptr` is valid for the lifetime of the buffer, which can happen when the mutable
+// methods of [`crate::EnvoyHttpFilter`] are called.
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
-pub struct EnvoyBuffer {
+pub struct EnvoyBuffer<'a> {
   raw_ptr: *const u8,
   length: usize,
+  _marker: std::marker::PhantomData<&'a ()>,
 }
 
-impl EnvoyBuffer {
+impl EnvoyBuffer<'_> {
   /// This is a helper function to create an [`EnvoyBuffer`] from a static string.
   ///
   /// This is meant for use by the end users in unit tests.
@@ -21,6 +23,7 @@ impl EnvoyBuffer {
     Self {
       raw_ptr: static_str.as_ptr(),
       length: static_str.len(),
+      _marker: std::marker::PhantomData,
     }
   }
 
@@ -31,7 +34,11 @@ impl EnvoyBuffer {
   /// This is not meant to be used by the end users, but rather by the SDK itself in the
   /// actual integration with Envoy.
   pub unsafe fn new_from_raw(raw_ptr: *const u8, length: usize) -> Self {
-    Self { raw_ptr, length }
+    Self {
+      raw_ptr,
+      length,
+      _marker: std::marker::PhantomData,
+    }
   }
 
   pub fn as_slice(&self) -> &[u8] {

--- a/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
@@ -223,24 +223,25 @@ impl EnvoyHttpFilterConfig {
 /// The Envoy filter object is inherently not thread-safe, and it is always recommended to
 /// access it from the same thread as the one that [`HttpFilter`] even hooks are called.
 #[automock]
+#[allow(clippy::needless_lifetimes)] // Explicit lifetime specifiers are needed for mockall.
 pub trait EnvoyHttpFilter {
   /// Get the value of the request header with the given key.
   /// If the header is not found, this returns `None`.
   ///
   /// To handle multiple values for the same key, use
   /// [`EnvoyHttpFilter::get_request_header_values`] variant.
-  fn get_request_header_value(&self, key: &str) -> Option<EnvoyBuffer>;
+  fn get_request_header_value<'a>(&'a self, key: &str) -> Option<EnvoyBuffer<'a>>;
 
   /// Get the values of the request header with the given key.
   ///
   /// If the header is not found, this returns an empty vector.
-  fn get_request_header_values(&self, key: &str) -> Vec<EnvoyBuffer>;
+  fn get_request_header_values<'a>(&'a self, key: &str) -> Vec<EnvoyBuffer<'a>>;
 
   /// Get all request headers.
   ///
   /// Returns a list of key-value pairs of the request headers.
   /// If there are no headers or headers are not available, this returns an empty list.
-  fn get_request_headers(&self) -> Vec<(EnvoyBuffer, EnvoyBuffer)>;
+  fn get_request_headers<'a>(&'a self) -> Vec<(EnvoyBuffer<'a>, EnvoyBuffer<'a>)>;
 
   /// Set the request header with the given key and value.
   ///
@@ -256,18 +257,18 @@ pub trait EnvoyHttpFilter {
   ///
   /// To handle multiple values for the same key, use
   /// [`EnvoyHttpFilter::get_request_trailer_values`] variant.
-  fn get_request_trailer_value(&self, key: &str) -> Option<EnvoyBuffer>;
+  fn get_request_trailer_value<'a>(&'a self, key: &str) -> Option<EnvoyBuffer<'a>>;
 
   /// Get the values of the request trailer with the given key.
   ///
   /// If the trailer is not found, this returns an empty vector.
-  fn get_request_trailer_values(&self, key: &str) -> Vec<EnvoyBuffer>;
+  fn get_request_trailer_values<'a>(&'a self, key: &str) -> Vec<EnvoyBuffer<'a>>;
 
   /// Get all request trailers.
   ///
   /// Returns a list of key-value pairs of the request trailers.
   /// If there are no trailers or trailers are not available, this returns an empty list.
-  fn get_request_trailers(&self) -> Vec<(EnvoyBuffer, EnvoyBuffer)>;
+  fn get_request_trailers<'a>(&'a self) -> Vec<(EnvoyBuffer<'a>, EnvoyBuffer<'a>)>;
 
   /// Set the request trailer with the given key and value.
   ///
@@ -283,18 +284,18 @@ pub trait EnvoyHttpFilter {
   ///
   /// To handle multiple values for the same key, use
   /// [`EnvoyHttpFilter::get_response_header_values`] variant.
-  fn get_response_header_value(&self, key: &str) -> Option<EnvoyBuffer>;
+  fn get_response_header_value<'a>(&'a self, key: &str) -> Option<EnvoyBuffer<'a>>;
 
   /// Get the values of the response header with the given key.
   ///
   /// If the header is not found, this returns an empty vector.
-  fn get_response_header_values(&self, key: &str) -> Vec<EnvoyBuffer>;
+  fn get_response_header_values<'a>(&'a self, key: &str) -> Vec<EnvoyBuffer<'a>>;
 
   /// Get all response headers.
   ///
   /// Returns a list of key-value pairs of the response headers.
   /// If there are no headers or headers are not available, this returns an empty list.
-  fn get_response_headers(&self) -> Vec<(EnvoyBuffer, EnvoyBuffer)>;
+  fn get_response_headers<'a>(&'a self) -> Vec<(EnvoyBuffer<'a>, EnvoyBuffer<'a>)>;
 
   /// Set the response header with the given key and value.
   ///
@@ -310,17 +311,17 @@ pub trait EnvoyHttpFilter {
   ///
   /// To handle multiple values for the same key, use
   /// [`EnvoyHttpFilter::get_response_trailer_values`] variant.
-  fn get_response_trailer_value(&self, key: &str) -> Option<EnvoyBuffer>;
+  fn get_response_trailer_value<'a>(&'a self, key: &str) -> Option<EnvoyBuffer<'a>>;
 
   /// Get the values of the response trailer with the given key.
   ///
   /// If the trailer is not found, this returns an empty vector.
-  fn get_response_trailer_values(&self, key: &str) -> Vec<EnvoyBuffer>;
+  fn get_response_trailer_values<'a>(&'a self, key: &str) -> Vec<EnvoyBuffer<'a>>;
   /// Get all response trailers.
   ///
   /// Returns a list of key-value pairs of the response trailers.
   /// If there are no trailers or trailers are not available, this returns an empty list.
-  fn get_response_trailers(&self) -> Vec<(EnvoyBuffer, EnvoyBuffer)>;
+  fn get_response_trailers<'a>(&'a self) -> Vec<(EnvoyBuffer<'a>, EnvoyBuffer<'a>)>;
 
   /// Set the response trailer with the given key and value.
   ///


### PR DESCRIPTION
Commit Message: dynamic_modules: adds a lifetime param on EnvoyBuffer
Additional Description:

This adds a lifetime parameter to `EnvoyBuffer` as well as 
to getter methods that return it. Since the data structure only holds 
a raw pointer and length, if a mutable setter method of EnvoyHttpFilter 
is used, it can be invalid. Previously it was relatively easy to write unsound logic
as there was no compile-time enforcement of invalidation.

This fixes the problem via life parameter and avoids making the EnvoyBuffer
variables outliving the next setter methods. For example, using the results returned 
by `get_request_trailers` _after_  `set_request_trailer` results in compilation
error:

```
Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
error[E0502]: cannot borrow `envoy_filter` as mutable because it is also borrowed as immutable
   --> test/extensions/dynamic_modules/test_data/rust/http.rs:118:5
    |
115 |     let all_trailers = envoy_filter.get_request_trailers();
    |                        ------------ immutable borrow occurs here
...
118 |     envoy_filter.set_request_trailer("new", b"value");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ mutable borrow occurs here
...
125 |     assert_eq!(all_trailers.len(), 4);
    |                ------------ immutable borrow later used here

```


Risk Level: low
Testing: existing tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a

