### PR TITLE
fix hcm fuzz test case

### DIFF
--- a/test/common/http/conn_manager_impl_corpus/maybe_end_decode
+++ b/test/common/http/conn_manager_impl_corpus/maybe_end_decode
@@ -1,0 +1,65 @@
+actions {
+  new_stream {
+    request_headers {
+      headers {
+        key: ":path"
+        value: "/"
+      }
+    }
+    status: HEADER_STOP_ALL_ITERATION_AND_BUFFER
+  }
+}
+actions {
+  stream_action {
+    request {
+      data {
+        status: DATA_STOP_ITERATION_NO_BUFFER
+      }
+    }
+  }
+}
+actions {
+  new_stream {
+    request_headers {
+      headers {
+        key: ":path"
+        value: "/"
+      }
+    }
+    status: HEADER_STOP_ALL_ITERATION_AND_BUFFER
+  }
+}
+actions {
+  stream_action {
+    request {
+      trailers {
+      }
+    }
+  }
+}
+actions {
+  stream_action {
+    stream_id: 5
+    request {
+      trailers {
+      }
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      continue_decoding {
+      }
+    }
+  }
+}
+actions {
+  stream_action {
+    stream_id: 5
+    request {
+      continue_decoding {
+      }
+    }
+  }
+}

--- a/test/common/http/conn_manager_impl_fuzz_test.cc
+++ b/test/common/http/conn_manager_impl_fuzz_test.cc
@@ -482,7 +482,7 @@ public:
       break;
     }
     case test::common::http::RequestAction::kContinueDecoding: {
-      if (!decoding_done_ &&
+      if (!decoding_done_ && state != StreamState::Closed &&
           (header_status_ == FilterHeadersStatus::StopAllIterationAndBuffer ||
            header_status_ == FilterHeadersStatus::StopAllIterationAndWatermark ||
            header_status_ == FilterHeadersStatus::StopIteration) &&


### PR DESCRIPTION
Commit Message: fix hcm fuzz test case
Additional Description:

This PR fixes a fuzzer issue caused by the fuzzer sending trailers to the HCM then calling continueDecoding (which then hits [this assertion](https://github.com/search?q=repo%3Aenvoyproxy%2Fenvoy%20ASSERT(!state_.decoder_filter_chain_complete_)%3B&type=code) in the HCM and fails). This PR adds a check to prevent this from happening.

Risk Level: none, test only
Testing: fuzz fix
Docs Changes: none
Release Notes: none
Platform Specific Features: none