### PR TITLE
[mobile] Report network subtype when on cellular

### DIFF
--- a/mobile/library/common/engine_types.h
+++ b/mobile/library/common/engine_types.h
@@ -138,12 +138,20 @@ struct EnvoyStreamCallbacks {
 
 /** Networks classified by the physical link. */
 enum class NetworkType : int {
-  // This includes VPN or cases where network characteristics are unknown.
+  // Includes VPN or cases where network characteristics are unknown.
   Generic = 1, // 001
-  // This includes WiFi and other local area wireless networks.
+  // Includes WiFi and other local area wireless networks.
   WLAN = 2, // 010
-  // This includes all mobile phone networks.
+  // Includes all mobile phone networks.
   WWAN = 4, // 100
+  // Includes 2G networks.
+  WWAN_2G = 8, // 1000
+  // Includes 3G networks.
+  WWAN_3G = 16, // 10000
+  // Includes 4G networks.
+  WWAN_4G = 32, // 100000
+  // Includes 5G networks.
+  WWAN_5G = 64, // 1000000
 };
 
 } // namespace Envoy

--- a/mobile/library/java/io/envoyproxy/envoymobile/engine/types/EnvoyNetworkType.java
+++ b/mobile/library/java/io/envoyproxy/envoymobile/engine/types/EnvoyNetworkType.java
@@ -5,6 +5,10 @@ public enum EnvoyNetworkType {
   GENERIC(1),
   WLAN(2),
   WWAN(4),
+  WWAN_2G(8),
+  WWAN_3G(16),
+  WWAN_4G(32),
+  WWAN_5G(64),
   ;
 
   private final int value;

--- a/mobile/test/java/io/envoyproxy/envoymobile/engine/AndroidNetworkMonitorTest.java
+++ b/mobile/test/java/io/envoyproxy/envoymobile/engine/AndroidNetworkMonitorTest.java
@@ -112,7 +112,7 @@ public class AndroidNetworkMonitorTest {
       callback.onCapabilitiesChanged(ShadowNetwork.newInstance(0), capabilities);
     });
 
-    verify(mockEnvoyEngine).onDefaultNetworkChanged(4);
+    verify(mockEnvoyEngine).onDefaultNetworkChanged(12);
   }
 
   @Test
@@ -130,7 +130,7 @@ public class AndroidNetworkMonitorTest {
   @Test
   public void testOnCapabilitiesChangedPreviousNetworkIsEmptyCallbackIsCalledWlan() {
     AndroidNetworkMonitor.DefaultNetworkCallback callback =
-        new AndroidNetworkMonitor.DefaultNetworkCallback(mockEnvoyEngine);
+        new AndroidNetworkMonitor.DefaultNetworkCallback(mockEnvoyEngine, connectivityManager);
     NetworkCapabilities capabilities = ShadowNetworkCapabilities.newInstance();
     shadowOf(capabilities).addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET);
     shadowOf(capabilities).addTransportType(NetworkCapabilities.TRANSPORT_WIFI);
@@ -142,19 +142,19 @@ public class AndroidNetworkMonitorTest {
   @Test
   public void testOnCapabilitiesChangedPreviousNetworkIsEmptyCallbackIsCalledWwan() {
     AndroidNetworkMonitor.DefaultNetworkCallback callback =
-        new AndroidNetworkMonitor.DefaultNetworkCallback(mockEnvoyEngine);
+        new AndroidNetworkMonitor.DefaultNetworkCallback(mockEnvoyEngine, connectivityManager);
     NetworkCapabilities capabilities = ShadowNetworkCapabilities.newInstance();
     shadowOf(capabilities).addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET);
     shadowOf(capabilities).addTransportType(NetworkCapabilities.TRANSPORT_CELLULAR);
     callback.onCapabilitiesChanged(ShadowNetwork.newInstance(0), capabilities);
 
-    verify(mockEnvoyEngine).onDefaultNetworkChanged(4);
+    verify(mockEnvoyEngine).onDefaultNetworkChanged(12);
   }
 
   @Test
   public void testOnCapabilitiesChangedPreviousNetworkIsEmptyCallbackIsCalledGeneric() {
     AndroidNetworkMonitor.DefaultNetworkCallback callback =
-        new AndroidNetworkMonitor.DefaultNetworkCallback(mockEnvoyEngine);
+        new AndroidNetworkMonitor.DefaultNetworkCallback(mockEnvoyEngine, connectivityManager);
     NetworkCapabilities capabilities = ShadowNetworkCapabilities.newInstance();
     shadowOf(capabilities).addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET);
     shadowOf(capabilities).addTransportType(NetworkCapabilities.TRANSPORT_ETHERNET);
@@ -166,20 +166,20 @@ public class AndroidNetworkMonitorTest {
   @Test
   public void testOnCapabilitiesChangedPreviousNetworkNotEmptyCallbackIsCalledWwan() {
     AndroidNetworkMonitor.DefaultNetworkCallback callback =
-        new AndroidNetworkMonitor.DefaultNetworkCallback(mockEnvoyEngine);
+        new AndroidNetworkMonitor.DefaultNetworkCallback(mockEnvoyEngine, connectivityManager);
     callback.previousTransportTypes.add(NetworkCapabilities.TRANSPORT_WIFI);
     NetworkCapabilities capabilities = ShadowNetworkCapabilities.newInstance();
     shadowOf(capabilities).addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET);
     shadowOf(capabilities).addTransportType(NetworkCapabilities.TRANSPORT_CELLULAR);
     callback.onCapabilitiesChanged(ShadowNetwork.newInstance(0), capabilities);
 
-    verify(mockEnvoyEngine).onDefaultNetworkChanged(4);
+    verify(mockEnvoyEngine).onDefaultNetworkChanged(12);
   }
 
   @Test
   public void testOnCapabilitiesChangedPreviousNetworkNotEmptyCallCallbackIsCalledWlan() {
     AndroidNetworkMonitor.DefaultNetworkCallback callback =
-        new AndroidNetworkMonitor.DefaultNetworkCallback(mockEnvoyEngine);
+        new AndroidNetworkMonitor.DefaultNetworkCallback(mockEnvoyEngine, connectivityManager);
     callback.previousTransportTypes.add(NetworkCapabilities.TRANSPORT_CELLULAR);
     NetworkCapabilities capabilities = ShadowNetworkCapabilities.newInstance();
     shadowOf(capabilities).addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET);
@@ -192,7 +192,7 @@ public class AndroidNetworkMonitorTest {
   @Test
   public void testOnCapabilitiesChangedPreviousNetworkNotEmptyCallbackIsCalledGeneric() {
     AndroidNetworkMonitor.DefaultNetworkCallback callback =
-        new AndroidNetworkMonitor.DefaultNetworkCallback(mockEnvoyEngine);
+        new AndroidNetworkMonitor.DefaultNetworkCallback(mockEnvoyEngine, connectivityManager);
     callback.previousTransportTypes.add(NetworkCapabilities.TRANSPORT_BLUETOOTH);
     NetworkCapabilities capabilities = ShadowNetworkCapabilities.newInstance();
     shadowOf(capabilities).addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET);
@@ -205,7 +205,7 @@ public class AndroidNetworkMonitorTest {
   @Test
   public void testOnCapabilitiesChangedPreviousNetworkLessThanCurrentNetworkCallbackIsCalled() {
     AndroidNetworkMonitor.DefaultNetworkCallback callback =
-        new AndroidNetworkMonitor.DefaultNetworkCallback(mockEnvoyEngine);
+        new AndroidNetworkMonitor.DefaultNetworkCallback(mockEnvoyEngine, connectivityManager);
     callback.previousTransportTypes.add(NetworkCapabilities.TRANSPORT_WIFI);
     NetworkCapabilities capabilities = ShadowNetworkCapabilities.newInstance();
     shadowOf(capabilities).addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET);
@@ -219,7 +219,7 @@ public class AndroidNetworkMonitorTest {
   @Test
   public void testOnCapabilitiesChangedPreviousNetworkMoreThanCurrentNetworkCallbackIsCalled() {
     AndroidNetworkMonitor.DefaultNetworkCallback callback =
-        new AndroidNetworkMonitor.DefaultNetworkCallback(mockEnvoyEngine);
+        new AndroidNetworkMonitor.DefaultNetworkCallback(mockEnvoyEngine, connectivityManager);
     callback.previousTransportTypes.add(NetworkCapabilities.TRANSPORT_WIFI);
     callback.previousTransportTypes.add(NetworkCapabilities.TRANSPORT_VPN);
     NetworkCapabilities capabilities = ShadowNetworkCapabilities.newInstance();
@@ -233,7 +233,7 @@ public class AndroidNetworkMonitorTest {
   @Test
   public void testOnCapabilitiesChangedPreviousNetworkNotEmptyCallbackIsNotCalled() {
     AndroidNetworkMonitor.DefaultNetworkCallback callback =
-        new AndroidNetworkMonitor.DefaultNetworkCallback(mockEnvoyEngine);
+        new AndroidNetworkMonitor.DefaultNetworkCallback(mockEnvoyEngine, connectivityManager);
     callback.previousTransportTypes.add(NetworkCapabilities.TRANSPORT_WIFI);
     NetworkCapabilities capabilities = ShadowNetworkCapabilities.newInstance();
     shadowOf(capabilities).addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET);
@@ -246,7 +246,7 @@ public class AndroidNetworkMonitorTest {
   @Test
   public void testOnCapabilitiesChangedNoInternetCallbackIsNotCalled() {
     AndroidNetworkMonitor.DefaultNetworkCallback callback =
-        new AndroidNetworkMonitor.DefaultNetworkCallback(mockEnvoyEngine);
+        new AndroidNetworkMonitor.DefaultNetworkCallback(mockEnvoyEngine, connectivityManager);
     NetworkCapabilities capabilities = ShadowNetworkCapabilities.newInstance();
     shadowOf(capabilities).addTransportType(NetworkCapabilities.TRANSPORT_WIFI);
     callback.onCapabilitiesChanged(ShadowNetwork.newInstance(0), capabilities);


### PR DESCRIPTION
Commit Message: [mobile] Report network subtype when on cellular
Additional Description: Cellular networks will be further categorized as 2G/3G/4G/5G
Risk Level: low
Testing: unit tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: android only
