### PR TITLE
Revert "Revert "dynamic_modules: adds dynamic metadata callbakcs"

### DIFF
--- a/source/extensions/dynamic_modules/BUILD
+++ b/source/extensions/dynamic_modules/BUILD
@@ -36,6 +36,10 @@ envoy_cc_library(
         "-Wl,--export-dynamic-symbol=envoy_dynamic_module_callback_http_get_response_trailers",
         "-Wl,--export-dynamic-symbol=envoy_dynamic_module_callback_http_get_response_trailers_count",
         "-Wl,--export-dynamic-symbol=envoy_dynamic_module_callback_http_set_response_trailer",
+        "-Wl,--export-dynamic-symbol=envoy_dynamic_module_callback_http_set_dynamic_metadata_number",
+        "-Wl,--export-dynamic-symbol=envoy_dynamic_module_callback_http_get_dynamic_metadata_number",
+        "-Wl,--export-dynamic-symbol=envoy_dynamic_module_callback_http_set_dynamic_metadata_string",
+        "-Wl,--export-dynamic-symbol=envoy_dynamic_module_callback_http_get_dynamic_metadata_string",
     ],
     deps = [
         ":abi_version_lib",

--- a/source/extensions/dynamic_modules/abi.h
+++ b/source/extensions/dynamic_modules/abi.h
@@ -35,12 +35,14 @@
 #ifdef __cplusplus
 #include <cstdbool>
 #include <cstddef>
+#include <cstdint>
 
 extern "C" {
 #else
 
 #include <stdbool.h>
 #include <stddef.h>
+#include <stdint.h>
 #endif
 
 // -----------------------------------------------------------------------------
@@ -397,6 +399,8 @@ void envoy_dynamic_module_on_http_filter_destroy(
 // Callbacks are functions implemented by Envoy that can be called by the module to interact with
 // Envoy. The name of a callback must be prefixed with "envoy_dynamic_module_callback_".
 
+// ---------------------- HTTP Header/Trailer callbacks ------------------------
+
 /**
  * envoy_dynamic_module_callback_http_get_request_header is called by the module to get the
  * value of the request header with the given key. Since a header can have multiple values, the
@@ -605,6 +609,97 @@ bool envoy_dynamic_module_callback_http_set_response_trailer(
     envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr,
     envoy_dynamic_module_type_buffer_module_ptr key, size_t key_length,
     envoy_dynamic_module_type_buffer_module_ptr value, size_t value_length);
+
+// ------------------------ Dynamic Metadata Callbacks -------------------------
+
+/**
+ * envoy_dynamic_module_callback_http_set_dynamic_metadata_number is called by the module to set
+ * the number value of the dynamic metadata with the given namespace and key. If the metadata is not
+ * accessible, this returns false. If the namespace does not exist, it will be created.
+ *
+ * @param filter_envoy_ptr is the pointer to the DynamicModuleHttpFilter object of the
+ * corresponding HTTP filter.
+ * @param namespace_ptr is the namespace of the dynamic metadata.
+ * @param namespace_length is the length of the namespace.
+ * @param key_ptr is the key of the dynamic metadata.
+ * @param key_length is the length of the key.
+ * @param value is the number value of the dynamic metadata to be set.
+ * @return true if the operation is successful, false otherwise.
+ */
+bool envoy_dynamic_module_callback_http_set_dynamic_metadata_number(
+    envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr,
+    envoy_dynamic_module_type_buffer_module_ptr namespace_ptr, size_t namespace_length,
+    envoy_dynamic_module_type_buffer_module_ptr key_ptr, size_t key_length, double value);
+
+/**
+ * envoy_dynamic_module_callback_http_get_dynamic_metadata_number is called by the module to get
+ * the number value of the dynamic metadata with the given namespace and key. If the metadata is not
+ * accessible, the namespace does not exist, the key does not exist or the value is not a number,
+ * this returns false.
+ *
+ * @param filter_envoy_ptr is the pointer to the DynamicModuleHttpFilter object of the
+ * corresponding HTTP filter.
+ * @param namespace_ptr is the namespace of the dynamic metadata.
+ * @param namespace_length is the length of the namespace.
+ * @param key_ptr is the key of the dynamic metadata.
+ * @param key_length is the length of the key.
+ * @param result is the pointer to the variable where the number value of the dynamic metadata will
+ * be stored.
+ * @return true if the operation is successful, false otherwise.
+ */
+bool envoy_dynamic_module_callback_http_get_dynamic_metadata_number(
+    envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr,
+    envoy_dynamic_module_type_buffer_module_ptr namespace_ptr, size_t namespace_length,
+    envoy_dynamic_module_type_buffer_module_ptr key_ptr, size_t key_length, double* result);
+
+/**
+ * envoy_dynamic_module_callback_http_set_dynamic_metadata_string is called by the module to set
+ * the string value of the dynamic metadata with the given namespace and key. If the metadata is not
+ * accessible, this returns false. If the namespace does not exist, it will be created.
+ *
+ * @param filter_envoy_ptr is the pointer to the DynamicModuleHttpFilter object of the
+ * corresponding HTTP filter.
+ * @param namespace_ptr is the namespace of the dynamic metadata.
+ * @param namespace_length is the length of the namespace.
+ * @param key_ptr is the key of the dynamic metadata.
+ * @param key_length is the length of the key.
+ * @param value_ptr is the string value of the dynamic metadata to be set.
+ * @param value_length is the length of the value.
+ * @return true if the operation is successful, false otherwise.
+ */
+bool envoy_dynamic_module_callback_http_set_dynamic_metadata_string(
+    envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr,
+    envoy_dynamic_module_type_buffer_module_ptr namespace_ptr, size_t namespace_length,
+    envoy_dynamic_module_type_buffer_module_ptr key_ptr, size_t key_length,
+    envoy_dynamic_module_type_buffer_module_ptr value_ptr, size_t value_length);
+
+/**
+ * envoy_dynamic_module_callback_http_get_dynamic_metadata_string is called by the module to get
+ * the string value of the dynamic metadata with the given namespace and key. If the metadata is not
+ * accessible, the namespace does not exist, the key does not exist or the value is not a string,
+ * this returns false.
+ *
+ * @param filter_envoy_ptr is the pointer to the DynamicModuleHttpFilter object of the
+ * corresponding HTTP filter.
+ * @param namespace_ptr is the namespace of the dynamic metadata.
+ * @param namespace_length is the length of the namespace.
+ * @param key_ptr is the key of the dynamic metadata.
+ * @param key_length is the length of the key.
+ * @param result_buffer_ptr is the pointer to the pointer variable where the pointer to the buffer
+ * of the value will be stored.
+ * @param result_buffer_length_ptr is the pointer to the variable where the length of the buffer
+ * will be stored.
+ * @return true if the operation is successful, false otherwise.
+ *
+ * Note that the buffer pointed by the pointer stored in result is owned by Envoy, and
+ * they are guaranteed to be valid until the end of the current event hook unless the setter
+ * callback is called.
+ */
+bool envoy_dynamic_module_callback_http_get_dynamic_metadata_string(
+    envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr,
+    envoy_dynamic_module_type_buffer_module_ptr namespace_ptr, size_t namespace_length,
+    envoy_dynamic_module_type_buffer_module_ptr key_ptr, size_t key_length,
+    envoy_dynamic_module_type_buffer_envoy_ptr* result, size_t* result_length);
 
 #ifdef __cplusplus
 }

--- a/source/extensions/dynamic_modules/abi_version.h
+++ b/source/extensions/dynamic_modules/abi_version.h
@@ -6,7 +6,7 @@ namespace DynamicModules {
 #endif
 // This is the ABI version calculated as a sha256 hash of the ABI header files. When the ABI
 // changes, this value must change, and the correctness of this value is checked by the test.
-const char* kAbiVersion = "27dbe7918b67b12bfcf43e050ce142a300feb73fb3bd5779c754d1d1d3c8645f";
+const char* kAbiVersion = "96ecb1011dfbd8375cab07853e6491d8ac30d4fe60e685c10ec39a0674c57a25";
 
 #ifdef __cplusplus
 } // namespace DynamicModules

--- a/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
@@ -344,7 +344,11 @@ pub trait EnvoyHttpFilter {
 
   /// Get the string-typed dynamic metadata value with the given key.
   /// If the metadata is not found or is the wrong type, this returns `None`.
-  fn get_dynamic_metadata_string(&self, namespace: &str, key: &str) -> Option<EnvoyBuffer>;
+  fn get_dynamic_metadata_string<'a>(
+    &'a self,
+    namespace: &str,
+    key: &str,
+  ) -> Option<EnvoyBuffer<'a>>;
 
   /// Set the string-typed dynamic metadata value with the given key.
   /// If the namespace is not found, this will create a new namespace.

--- a/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
@@ -331,6 +331,26 @@ pub trait EnvoyHttpFilter {
   ///
   /// Returns true if the operation is successful.
   fn set_response_trailer(&mut self, key: &str, value: &[u8]) -> bool;
+
+  /// Get the number-typed dynamic metadata value with the given key.
+  /// If the metadata is not found or is the wrong type, this returns `None`.
+  fn get_dynamic_metadata_number(&self, namespace: &str, key: &str) -> Option<f64>;
+
+  /// Set the number-typed dynamic metadata value with the given key.
+  /// If the namespace is not found, this will create a new namespace.
+  ///
+  /// Returns true if the operation is successful.
+  fn set_dynamic_metadata_number(&mut self, namespace: &str, key: &str, value: f64) -> bool;
+
+  /// Get the string-typed dynamic metadata value with the given key.
+  /// If the metadata is not found or is the wrong type, this returns `None`.
+  fn get_dynamic_metadata_string(&self, namespace: &str, key: &str) -> Option<EnvoyBuffer>;
+
+  /// Set the string-typed dynamic metadata value with the given key.
+  /// If the namespace is not found, this will create a new namespace.
+  ///
+  /// Returns true if the operation is successful.
+  fn set_dynamic_metadata_string(&mut self, namespace: &str, key: &str, value: &str) -> bool;
 }
 
 /// This implements the [`EnvoyHttpFilter`] trait with the given raw pointer to the Envoy HTTP
@@ -483,6 +503,91 @@ impl EnvoyHttpFilter for EnvoyHttpFilterImpl {
     unsafe {
       abi::envoy_dynamic_module_callback_http_set_response_trailer(
         self.raw_ptr,
+        key_ptr as *const _ as *mut _,
+        key_size,
+        value_ptr as *const _ as *mut _,
+        value_size,
+      )
+    }
+  }
+
+  fn get_dynamic_metadata_number(&self, namespace: &str, key: &str) -> Option<f64> {
+    let namespace_ptr = namespace.as_ptr();
+    let namespace_size = namespace.len();
+    let key_ptr = key.as_ptr();
+    let key_size = key.len();
+    let mut value: f64 = 0f64;
+    let success = unsafe {
+      abi::envoy_dynamic_module_callback_http_get_dynamic_metadata_number(
+        self.raw_ptr,
+        namespace_ptr as *const _ as *mut _,
+        namespace_size,
+        key_ptr as *const _ as *mut _,
+        key_size,
+        &mut value as *mut _ as *mut _,
+      )
+    };
+    if success {
+      Some(value)
+    } else {
+      None
+    }
+  }
+
+  fn set_dynamic_metadata_number(&mut self, namespace: &str, key: &str, value: f64) -> bool {
+    let namespace_ptr = namespace.as_ptr();
+    let namespace_size = namespace.len();
+    let key_ptr = key.as_ptr();
+    let key_size = key.len();
+    unsafe {
+      abi::envoy_dynamic_module_callback_http_set_dynamic_metadata_number(
+        self.raw_ptr,
+        namespace_ptr as *const _ as *mut _,
+        namespace_size,
+        key_ptr as *const _ as *mut _,
+        key_size,
+        value,
+      )
+    }
+  }
+
+  fn get_dynamic_metadata_string(&self, namespace: &str, key: &str) -> Option<EnvoyBuffer> {
+    let namespace_ptr = namespace.as_ptr();
+    let namespace_size = namespace.len();
+    let key_ptr = key.as_ptr();
+    let key_size = key.len();
+    let mut result_ptr: *const u8 = std::ptr::null();
+    let mut result_size: usize = 0;
+    let success = unsafe {
+      abi::envoy_dynamic_module_callback_http_get_dynamic_metadata_string(
+        self.raw_ptr,
+        namespace_ptr as *const _ as *mut _,
+        namespace_size,
+        key_ptr as *const _ as *mut _,
+        key_size,
+        &mut result_ptr as *mut _ as *mut _,
+        &mut result_size as *mut _ as *mut _,
+      )
+    };
+    if success {
+      Some(unsafe { EnvoyBuffer::new_from_raw(result_ptr, result_size) })
+    } else {
+      None
+    }
+  }
+
+  fn set_dynamic_metadata_string(&mut self, namespace: &str, key: &str, value: &str) -> bool {
+    let namespace_ptr = namespace.as_ptr();
+    let namespace_size = namespace.len();
+    let key_ptr = key.as_ptr();
+    let key_size = key.len();
+    let value_ptr = value.as_ptr();
+    let value_size = value.len();
+    unsafe {
+      abi::envoy_dynamic_module_callback_http_set_dynamic_metadata_string(
+        self.raw_ptr,
+        namespace_ptr as *const _ as *mut _,
+        namespace_size,
         key_ptr as *const _ as *mut _,
         key_size,
         value_ptr as *const _ as *mut _,

--- a/source/extensions/filters/http/dynamic_modules/abi_impl.cc
+++ b/source/extensions/filters/http/dynamic_modules/abi_impl.cc
@@ -197,6 +197,152 @@ bool envoy_dynamic_module_callback_http_get_response_trailers(
   DynamicModuleHttpFilter* filter = static_cast<DynamicModuleHttpFilter*>(filter_envoy_ptr);
   return getHeadersImpl(filter->response_trailers_, result_headers);
 }
+
+/**
+ * Helper to get the metadata namespace from the stream info.
+ * @param filter_envoy_ptr is the pointer to the DynamicModuleHttpFilter object of the
+ * corresponding HTTP filter.
+ * @param namespace_ptr is the namespace of the dynamic metadata.
+ * @param namespace_length is the length of the namespace.
+ * @param create_if_not_exist is true if the namespace should be created if it does not exist,
+ * assuming stream info is available.
+ * @return the metadata namespace if it exists, nullptr otherwise.
+ */
+ProtobufWkt::Struct*
+getDynamicMetadataNamespace(envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr,
+                            envoy_dynamic_module_type_buffer_module_ptr namespace_ptr,
+                            size_t namespace_length, bool create_if_not_exist) {
+  auto filter = static_cast<DynamicModuleHttpFilter*>(filter_envoy_ptr);
+  auto stream_info = filter->streamInfo();
+  if (!stream_info) {
+    ENVOY_LOG_TO_LOGGER(Envoy::Logger::Registry::getLog(Envoy::Logger::Id::dynamic_modules), debug,
+                        "stream info is not available");
+    return nullptr;
+  }
+  auto metadata = stream_info->dynamicMetadata().mutable_filter_metadata();
+  absl::string_view namespace_view(static_cast<const char*>(namespace_ptr), namespace_length);
+  auto metadata_namespace = metadata->find(namespace_view);
+  if (metadata_namespace == metadata->end()) {
+    if (!create_if_not_exist) {
+      ENVOY_LOG_TO_LOGGER(
+          Envoy::Logger::Registry::getLog(Envoy::Logger::Id::dynamic_modules), debug,
+          fmt::format("namespace {} not found in dynamic metadata", namespace_view));
+      return nullptr;
+    }
+    metadata_namespace = metadata->emplace(namespace_view, ProtobufWkt::Struct{}).first;
+  }
+  return &metadata_namespace->second;
+}
+
+/**
+ * Helper to get the metadata value from the metadata namespace.
+ *
+ * @param filter_envoy_ptr is the pointer to the DynamicModuleHttpFilter object of the
+ * corresponding HTTP filter.
+ * @param namespace_ptr is the namespace of the dynamic metadata.
+ * @param namespace_length is the length of the namespace.
+ * @param key_ptr is the key of the dynamic metadata.
+ * @param key_length is the length of the key.
+ * @return the metadata value if it exists, nullptr otherwise.
+ */
+const ProtobufWkt::Value*
+getDynamicMetadataValue(envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr,
+                        envoy_dynamic_module_type_buffer_module_ptr namespace_ptr,
+                        size_t namespace_length,
+                        envoy_dynamic_module_type_buffer_module_ptr key_ptr, size_t key_length) {
+  auto metadata_namespace =
+      getDynamicMetadataNamespace(filter_envoy_ptr, namespace_ptr, namespace_length, false);
+  if (!metadata_namespace) {
+    return nullptr;
+  }
+  absl::string_view key_view(static_cast<const char*>(key_ptr), key_length);
+  auto key_metadata = metadata_namespace->fields().find(key_view);
+  if (key_metadata == metadata_namespace->fields().end()) {
+    ENVOY_LOG_TO_LOGGER(Envoy::Logger::Registry::getLog(Envoy::Logger::Id::dynamic_modules), debug,
+                        fmt::format("key {} not found in metadata namespace", key_view));
+    return nullptr;
+  }
+  return &key_metadata->second;
+}
+
+bool envoy_dynamic_module_callback_http_set_dynamic_metadata_number(
+    envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr,
+    envoy_dynamic_module_type_buffer_module_ptr namespace_ptr, size_t namespace_length,
+    envoy_dynamic_module_type_buffer_module_ptr key_ptr, size_t key_length, double value) {
+  auto metadata_namespace =
+      getDynamicMetadataNamespace(filter_envoy_ptr, namespace_ptr, namespace_length, true);
+  if (!metadata_namespace) {
+    // If stream info is not available, we cannot guarantee that the namespace is created.
+    return false;
+  }
+  absl::string_view key_view(static_cast<const char*>(key_ptr), key_length);
+  ProtobufWkt::Struct metadata_value;
+  (*metadata_value.mutable_fields())[key_view].set_number_value(value);
+  metadata_namespace->MergeFrom(metadata_value);
+  return true;
+}
+
+bool envoy_dynamic_module_callback_http_get_dynamic_metadata_number(
+    envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr,
+    envoy_dynamic_module_type_buffer_module_ptr namespace_ptr, size_t namespace_length,
+    envoy_dynamic_module_type_buffer_module_ptr key_ptr, size_t key_length, double* result) {
+  const auto key_metadata = getDynamicMetadataValue(filter_envoy_ptr, namespace_ptr,
+                                                    namespace_length, key_ptr, key_length);
+  if (!key_metadata) {
+    return false;
+  }
+  if (!key_metadata->has_number_value()) {
+    ENVOY_LOG_TO_LOGGER(
+        Envoy::Logger::Registry::getLog(Envoy::Logger::Id::dynamic_modules), error,
+        fmt::format("key {} is not a number",
+                    absl::string_view(static_cast<const char*>(key_ptr), key_length)));
+    return false;
+  }
+  *result = key_metadata->number_value();
+  return true;
+}
+
+bool envoy_dynamic_module_callback_http_set_dynamic_metadata_string(
+    envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr,
+    envoy_dynamic_module_type_buffer_module_ptr namespace_ptr, size_t namespace_length,
+    envoy_dynamic_module_type_buffer_module_ptr key_ptr, size_t key_length,
+    envoy_dynamic_module_type_buffer_module_ptr value_ptr, size_t value_length) {
+  auto metadata_namespace =
+      getDynamicMetadataNamespace(filter_envoy_ptr, namespace_ptr, namespace_length, true);
+  if (!metadata_namespace) {
+    // If stream info is not available, we cannot guarantee that the namespace is created.
+    return false;
+  }
+  absl::string_view key_view(static_cast<const char*>(key_ptr), key_length);
+  absl::string_view value_view(static_cast<const char*>(value_ptr), value_length);
+  ProtobufWkt::Struct metadata_value;
+  (*metadata_value.mutable_fields())[key_view].set_string_value(value_view);
+  metadata_namespace->MergeFrom(metadata_value);
+  return true;
+}
+
+bool envoy_dynamic_module_callback_http_get_dynamic_metadata_string(
+    envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr,
+    envoy_dynamic_module_type_buffer_module_ptr namespace_ptr, size_t namespace_length,
+    envoy_dynamic_module_type_buffer_module_ptr key_ptr, size_t key_length,
+    envoy_dynamic_module_type_buffer_envoy_ptr* result, size_t* result_length) {
+  const auto key_metadata = getDynamicMetadataValue(filter_envoy_ptr, namespace_ptr,
+                                                    namespace_length, key_ptr, key_length);
+  if (!key_metadata) {
+    return false;
+  }
+  if (!key_metadata->has_string_value()) {
+    ENVOY_LOG_TO_LOGGER(
+        Envoy::Logger::Registry::getLog(Envoy::Logger::Id::dynamic_modules), error,
+        fmt::format("key {} is not a string",
+                    absl::string_view(static_cast<const char*>(key_ptr), key_length)));
+    return false;
+  }
+  const auto& value = key_metadata->string_value();
+  *result = const_cast<char*>(value.data());
+  *result_length = value.size();
+  return true;
+}
 }
 } // namespace HttpFilters
 } // namespace DynamicModules

--- a/source/extensions/filters/http/dynamic_modules/filter.h
+++ b/source/extensions/filters/http/dynamic_modules/filter.h
@@ -59,6 +59,19 @@ public:
   ResponseHeaderMap* response_headers_ = nullptr;
   ResponseTrailerMap* response_trailers_ = nullptr;
 
+  /**
+   * Helper to get the downstream information of the stream.
+   */
+  StreamInfo::StreamInfo* streamInfo() {
+    if (decoder_callbacks_) {
+      return &decoder_callbacks_->streamInfo();
+    } else if (encoder_callbacks_) {
+      return &encoder_callbacks_->streamInfo();
+    } else {
+      return nullptr;
+    }
+  }
+
 private:
   /**
    * This is a helper function to get the `this` pointer as a void pointer which is passed to the

--- a/test/extensions/dynamic_modules/test_data/rust/http.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/http.rs
@@ -20,6 +20,7 @@ fn new_http_filter_config_fn<EHF: EnvoyHttpFilter>(
 ) -> Option<Box<dyn HttpFilterConfig<EHF>>> {
   match name {
     "header_callbacks" => Some(Box::new(HeaderCallbacksFilterConfig {})),
+    "dynamic_metadata_callbacks" => Some(Box::new(DynamicMetadataCallbacksFilterConfig {})),
     // TODO: add various configs for body, etc.
     _ => panic!("Unknown filter name: {}", name),
   }
@@ -36,8 +37,7 @@ impl<EHF: EnvoyHttpFilter> HttpFilterConfig<EHF> for HeaderCallbacksFilterConfig
   }
 }
 
-/// A no-op HTTP filter that implements [`envoy_proxy_dynamic_modules_rust_sdk::HttpFilter`]
-/// as well as the [`Drop`] to test the cleanup of the filter.
+/// A HTTP filter that implements [`envoy_proxy_dynamic_modules_rust_sdk::HttpFilter`].
 struct HeaderCallbacksFilter {}
 
 impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for HeaderCallbacksFilter {
@@ -225,5 +225,95 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for HeaderCallbacksFilter {
     assert_eq!(all_trailers[3].1.as_slice(), b"value");
 
     abi::envoy_dynamic_module_type_on_http_filter_response_trailers_status::Continue
+  }
+}
+
+
+/// A HTTP filter configuration that implements
+/// [`envoy_proxy_dynamic_modules_rust_sdk::HttpFilterConfig`] to test the dynamic metadata related
+/// callbacks.
+struct DynamicMetadataCallbacksFilterConfig {}
+
+impl<EHF: EnvoyHttpFilter> HttpFilterConfig<EHF> for DynamicMetadataCallbacksFilterConfig {
+  fn new_http_filter(&self, _envoy: EnvoyHttpFilterConfig) -> Box<dyn HttpFilter<EHF>> {
+    Box::new(DynamicMetadataCallbacksFilter {})
+  }
+}
+
+/// A HTTP filter that implements [`envoy_proxy_dynamic_modules_rust_sdk::HttpFilter`].
+struct DynamicMetadataCallbacksFilter {}
+
+impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for DynamicMetadataCallbacksFilter {
+  fn on_request_headers(
+    &mut self,
+    mut envoy_filter: EHF,
+    _end_of_stream: bool,
+  ) -> abi::envoy_dynamic_module_type_on_http_filter_request_headers_status {
+    // No namespace.
+    let no_namespace = envoy_filter.get_dynamic_metadata_number("no_namespace", "key");
+    assert!(no_namespace.is_none());
+    // Set a number.
+    envoy_filter.set_dynamic_metadata_number("ns_req_header", "key", 123f64);
+    let ns_req_header = envoy_filter.get_dynamic_metadata_number("ns_req_header", "key");
+    assert_eq!(ns_req_header, Some(123f64));
+    // Try getting a number as string.
+    let ns_req_header = envoy_filter.get_dynamic_metadata_string("ns_req_header", "key");
+    assert!(ns_req_header.is_none());
+    abi::envoy_dynamic_module_type_on_http_filter_request_headers_status::Continue
+  }
+
+  fn on_request_body(
+    &mut self,
+    mut envoy_filter: EHF,
+    _end_of_stream: bool,
+  ) -> abi::envoy_dynamic_module_type_on_http_filter_request_body_status {
+    // No namespace.
+    let no_namespace = envoy_filter.get_dynamic_metadata_string("no_namespace", "key");
+    assert!(no_namespace.is_none());
+    // Set a string.
+    envoy_filter.set_dynamic_metadata_string("ns_req_body", "key", "value");
+    let ns_req_body = envoy_filter.get_dynamic_metadata_string("ns_req_body", "key");
+    assert!(ns_req_body.is_some());
+    assert_eq!(ns_req_body.unwrap().as_slice(), b"value");
+    // Try getting a string as number.
+    let ns_req_body = envoy_filter.get_dynamic_metadata_number("ns_req_body", "key");
+    assert!(ns_req_body.is_none());
+    abi::envoy_dynamic_module_type_on_http_filter_request_body_status::Continue
+  }
+
+  fn on_response_headers(
+    &mut self,
+    mut envoy_filter: EHF,
+    _end_of_stream: bool,
+  ) -> abi::envoy_dynamic_module_type_on_http_filter_response_headers_status {
+    // No namespace.
+    let no_namespace = envoy_filter.get_dynamic_metadata_string("no_namespace", "key");
+    assert!(no_namespace.is_none());
+    // Set a number.
+    envoy_filter.set_dynamic_metadata_number("ns_res_header", "key", 123f64);
+    let ns_res_header = envoy_filter.get_dynamic_metadata_number("ns_res_header", "key");
+    assert_eq!(ns_res_header, Some(123f64));
+    // Try getting a number as string.
+    let ns_res_header = envoy_filter.get_dynamic_metadata_string("ns_res_header", "key");
+    assert!(ns_res_header.is_none());
+    abi::envoy_dynamic_module_type_on_http_filter_response_headers_status::Continue
+  }
+
+  fn on_response_body(
+    &mut self,
+    mut envoy_filter: EHF,
+    _end_of_stream: bool,
+  ) -> abi::envoy_dynamic_module_type_on_http_filter_response_body_status {
+    // No namespace.
+    let no_namespace = envoy_filter.get_dynamic_metadata_string("no_namespace", "key");
+    assert!(no_namespace.is_none());
+    // Set a string.
+    envoy_filter.set_dynamic_metadata_string("ns_res_body", "key", "value");
+    let ns_res_body = envoy_filter.get_dynamic_metadata_string("ns_res_body", "key");
+    assert!(ns_res_body.is_some());
+    // Try getting a string as number.
+    let ns_res_body = envoy_filter.get_dynamic_metadata_number("ns_res_body", "key");
+    assert!(ns_res_body.is_none());
+    abi::envoy_dynamic_module_type_on_http_filter_response_body_status::Continue
   }
 }


### PR DESCRIPTION
#37860 was reverted in #37896 because of the slight build fix
after #37880. This fixes the original commit.