### PR TITLE
Disable QUIC ACK_FREQUENCY fuzz test

### DIFF
--- a/test/common/quic/envoy_quic_h3_fuzz_helper.cc
+++ b/test/common/quic/envoy_quic_h3_fuzz_helper.cc
@@ -317,9 +317,9 @@ QuicPacketizer::QuicPacketPtr QuicPacketizer::serializePacket(const QuicFrame& f
   case QuicFrame::kNewToken:
     return serializeNewTokenFrame(frame.new_token());
 #if 0
-  // AckFrequency is undergoing major revision to update to the most recent
-  // draft. This test is blocking QUICHE development; restore when QUICHE is
-  // up to date.
+  // TODO(martinduke): AckFrequency is undergoing major revision to update to
+  // the most recent draft. This test is blocking QUICHE development; restore
+  // when QUICHE is up to date.
   case QuicFrame::kAckFrequency: {
     const auto& f = frame.ack_frequency();
     auto delta = quic::QuicTime::Delta::FromMilliseconds(clampU64(f.milliseconds()));

--- a/test/common/quic/envoy_quic_h3_fuzz_helper.cc
+++ b/test/common/quic/envoy_quic_h3_fuzz_helper.cc
@@ -316,6 +316,10 @@ QuicPacketizer::QuicPacketPtr QuicPacketizer::serializePacket(const QuicFrame& f
     return serializeMessageFrame(frame.message_frame());
   case QuicFrame::kNewToken:
     return serializeNewTokenFrame(frame.new_token());
+#if 0
+  // AckFrequency is undergoing major revision to update to the most recent
+  // draft. This test is blocking QUICHE development; restore when QUICHE is
+  // up to date.
   case QuicFrame::kAckFrequency: {
     const auto& f = frame.ack_frequency();
     auto delta = quic::QuicTime::Delta::FromMilliseconds(clampU64(f.milliseconds()));
@@ -323,6 +327,7 @@ QuicPacketizer::QuicPacketPtr QuicPacketizer::serializePacket(const QuicFrame& f
         f.control_frame_id(), clampU64(f.sequence_number()), clampU64(f.packet_tolerance()), delta);
     return serialize(quic::QuicFrame(&ack_frequency));
   }
+#endif
   default:
     break;
   }


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Disable Fuzz testing for legacy QUIC ACK_FREQUENCY frames
Additional Description: The QUICHE ACK_FREQUENCY implementation is badly out of date compared to the spec. Disable Fuzz Tests for the old format to avoid compiler failures while QUICHE development continues.
Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
