### PR TITLE
tcp conn pool: fix wrong connection pool deletion

### DIFF
--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -684,7 +684,8 @@ private:
 
     void httpConnPoolIsIdle(HostConstSharedPtr host, ResourcePriority priority,
                             const std::vector<uint8_t>& hash_key);
-    void tcpConnPoolIsIdle(HostConstSharedPtr host, const std::vector<uint8_t>& hash_key);
+    void tcpConnPoolIsIdle(HostConstSharedPtr host, const std::vector<uint8_t>& hash_key,
+                           const Envoy::Tcp::ConnectionPool::Instance* pool_to_erase);
     void removeTcpConn(const HostConstSharedPtr& host, Network::ClientConnection& connection);
     void removeHosts(const std::string& name, const HostVector& hosts_removed);
     void updateClusterMembership(const std::string& name, uint32_t priority,


### PR DESCRIPTION
Commit Message: Fixes an issue when active tcp conn pool is incorrectly deleted: After an empty tcp conn pool is added to the deferred deletion list the connection pool is removed from the pool map. Then, if new conn pool for the same host with the same hash_key is created before the deferred deletion is cleared it will be incorrectly deleted, because `tcpConnPoolIsIdle` erases the pool based on its hash_key. See detailed description in #37679.
Additional Description: N/A
Risk Level: Low
Testing: unit
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
Fixes #37679

