### PR TITLE
tests: remove unused protobuf repeated field variables

### DIFF
--- a/test/common/config/config_provider_impl_test.cc
+++ b/test/common/config/config_provider_impl_test.cc
@@ -268,7 +268,6 @@ TEST_F(ConfigProviderImplTest, SharedOwnership) {
   // No config protos have been received via the subscription yet.
   EXPECT_FALSE(provider1->configProtoInfoVector<test::common::config::DummyConfig>().has_value());
 
-  Protobuf::RepeatedPtrField<ProtobufWkt::Any> untyped_dummy_configs;
   const auto dummy_config = parseDummyConfigFromYaml("a: a dummy config");
 
   DummyConfigSubscription& subscription =

--- a/test/common/router/scoped_rds_test.cc
+++ b/test/common/router/scoped_rds_test.cc
@@ -1352,7 +1352,6 @@ scoped_routes:
 $1
 )EOF";
 
-  Protobuf::RepeatedPtrField<ProtobufWkt::Any> resources;
   const auto resource = parseScopedRouteConfigurationFromYaml(R"EOF(
 name: dynamic-foo
 route_configuration_name: dynamic-foo-route-config


### PR DESCRIPTION
Commit Message: tests: remove unused protobuf repeated field variables
Additional Description:
Removing unused vars from tests.

Risk Level: low - tests only.
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A