### PR TITLE
http2: migrates away from deprecated methods

### DIFF
--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -650,7 +650,7 @@ void ConnectionImpl::StreamImpl::submitTrailers(const HeaderMap& trailers) {
 
 void ConnectionImpl::ClientStreamImpl::submitHeaders(const HeaderMap& headers, bool end_stream) {
   ASSERT(stream_id_ == -1);
-  stream_id_ = parent_.adapter_->SubmitRequest(buildHeaders(headers), nullptr, end_stream, base());
+  stream_id_ = parent_.adapter_->SubmitRequest(buildHeaders(headers), end_stream, base());
   ASSERT(stream_id_ > 0);
 }
 
@@ -670,7 +670,7 @@ void ConnectionImpl::ClientStreamImpl::advanceHeadersState() {
 
 void ConnectionImpl::ServerStreamImpl::submitHeaders(const HeaderMap& headers, bool end_stream) {
   ASSERT(stream_id_ != -1);
-  parent_.adapter_->SubmitResponse(stream_id_, buildHeaders(headers), nullptr, end_stream);
+  parent_.adapter_->SubmitResponse(stream_id_, buildHeaders(headers), end_stream);
 }
 
 Status ConnectionImpl::ServerStreamImpl::onBeginHeaders() {


### PR DESCRIPTION
The library methods with a `DataFrameSource*` parameter were deprecated in https://github.com/google/quiche/commit/6e685764b0fe194610c04863f741b917ba47483d.

Commit Message: migrates away from deprecated methods
Additional Description:
Risk Level: none
Testing: ran unit and integration tests locally
Docs Changes:
Release Notes:
Platform Specific Features:
