### PR TITLE
Replace string addition with absl::StrCat

### DIFF
--- a/source/common/protobuf/create_reflectable_message.cc
+++ b/source/common/protobuf/create_reflectable_message.cc
@@ -447,7 +447,8 @@ void loadFileDescriptors(const FileDescriptorInfo& file_descriptor_info) {
 
 Protobuf::ReflectableMessage createReflectableMessage(const Protobuf::Message& message) {
   Protobuf::ReflectableMessage reflectable_message = createDynamicMessage(getTranscoder(), message);
-  ASSERT(reflectable_message, "Unable to create dyanmic message for: " + message.GetTypeName());
+  ASSERT(reflectable_message,
+         absl::StrCat("Unable to create dyanmic message for: ", message.GetTypeName()));
   return reflectable_message;
 }
 

--- a/source/common/protobuf/utility.cc
+++ b/source/common/protobuf/utility.cc
@@ -943,8 +943,8 @@ absl::Status MessageUtil::loadFromFile(const std::string& path, Protobuf::Messag
     loadFromJson(contents, message, validation_visitor);
   }
 #else
-  return absl::InvalidArgumentError("Unable to parse file \"" + path + "\" (type " +
-                                    message.GetTypeName() + ")");
+  return absl::InvalidArgumentError(
+      absl::StrCat("Unable to parse file \"", path, "\" (type ", message.GetTypeName(), ")"));
 #endif
   return absl::OkStatus();
 }


### PR DESCRIPTION
This makes the code compatible with a future Protobuf release where various methods return absl::string_view instead of std::string or const std::string&.

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
