### PR TITLE
http2: updates test coverage for Http2CodecImplTest.CheckHeaderValueValidation

### DIFF
--- a/test/common/http/http2/codec_impl_test.cc
+++ b/test/common/http/http2/codec_impl_test.cc
@@ -4455,7 +4455,7 @@ TEST_P(Http2CodecImplTest, CheckHeaderValueValidation) {
   for (int i = 0; i <= 0xff; ++i) {
     if (i == 0 && http2_implementation_ == Http2Impl::Oghttp2) {
       // oghttp2 fails this specific case for now.
-      return;
+      continue;
     }
 
     TestRequestHeaderMapImpl request_headers;

--- a/test/common/http/http2/codec_impl_test.cc
+++ b/test/common/http/http2/codec_impl_test.cc
@@ -4448,15 +4448,16 @@ TEST_P(Http2CodecImplTest, CheckHeaderValueValidation) {
   scoped_runtime_.mergeValues({{"envoy.reloadable_features.validate_upstream_headers", "false"}});
   stream_error_on_invalid_http_messaging_ = true;
   initialize();
-  if (http2_implementation_ == Http2Impl::Oghttp2) {
-    // oghttp2 fails this test for now.
-    return;
-  }
 
   // Change one character in the header value and verify that codec correctly
   // accepts or rejects based on the table above.
   std::string header_value{"aaaaaaaa"};
   for (int i = 0; i <= 0xff; ++i) {
+    if (i == 0 && http2_implementation_ == Http2Impl::Oghttp2) {
+      // oghttp2 fails this specific case for now.
+      return;
+    }
+
     TestRequestHeaderMapImpl request_headers;
     HttpTestUtility::addDefaultHeaders(request_headers);
     header_value[2] = static_cast<char>(i);

--- a/test/common/http/http2/codec_impl_test.cc
+++ b/test/common/http/http2/codec_impl_test.cc
@@ -4449,6 +4449,13 @@ TEST_P(Http2CodecImplTest, CheckHeaderValueValidation) {
   stream_error_on_invalid_http_messaging_ = true;
   initialize();
 
+#ifdef ENVOY_ENABLE_UHV
+  // UHV does not appear to reject some header value chars.
+  if (http2_implementation_ == Http2Impl::Oghttp2) {
+    GTEST_SKIP();
+  }
+#endif
+
   // Change one character in the header value and verify that codec correctly
   // accepts or rejects based on the table above.
   std::string header_value{"aaaaaaaa"};
@@ -4461,6 +4468,9 @@ TEST_P(Http2CodecImplTest, CheckHeaderValueValidation) {
     TestRequestHeaderMapImpl request_headers;
     HttpTestUtility::addDefaultHeaders(request_headers);
     header_value[2] = static_cast<char>(i);
+
+    SCOPED_TRACE(absl::StrCat("header value: [", absl::CEscape(header_value), "]"));
+
     HeaderString header_string("a");
     setHeaderStringUnvalidated(header_string, header_value);
     request_headers.addViaMove(HeaderString(absl::string_view("foo")), std::move(header_string));


### PR DESCRIPTION
The only case where codec behavior differs is `\0`, so that case is still skipped.

UHV + oghttp2 is also skipped, as otherwise the `compile-time-options` build fails.

Commit Message:
Additional Description:
Risk Level: none, test only
Testing: ran codec_impl_test locally
Docs Changes:
Release Notes:
Platform Specific Features:
