### PR TITLE
Drop unused constants to make newer versions of clang happy

### DIFF
--- a/test/extensions/filters/http/oauth2/filter_test.cc
+++ b/test/extensions/filters/http/oauth2/filter_test.cc
@@ -35,8 +35,6 @@ using testing::ReturnRef;
 
 static const std::string TEST_CALLBACK = "/_oauth";
 static const std::string TEST_CLIENT_ID = "1";
-static const std::string TEST_CLIENT_SECRET_ID = "MyClientSecretKnoxID";
-static const std::string TEST_TOKEN_SECRET_ID = "MyTokenSecretKnoxID";
 static const std::string TEST_DEFAULT_SCOPE = "user";
 static const std::string TEST_ENCODED_AUTH_SCOPES = "user%20openid%20email";
 static const std::string TEST_STATE_CSRF_TOKEN =


### PR DESCRIPTION
Commit Message:

On newer version of Clang those generate a warning and with the settings we use ultimately result in a compilation failure.

We probably should either disable the warning or just adjust the test. Looking at the history of the test, it seems that these constants have never been used, so I prefer to just drop them.

Additional Description:

It's related to #37911, it appears that the compiler warning that causes this test fail to compile on clang 18 didn't exist in clang 14 that we are currently using.

Risk Level: Low
Testing: by running changed test
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
