### PR TITLE
ratelimit: per-descriptor hits_addend for route config

### DIFF
--- a/source/common/formatter/substitution_formatter.h
+++ b/source/common/formatter/substitution_formatter.h
@@ -13,7 +13,11 @@
 #include "envoy/stream_info/stream_info.h"
 
 #include "source/common/common/utility.h"
+
+#ifdef ENVOY_STATIC_EXTENSION_REGISTRATION // See the comments in the header file around
+                                           // resolveHitsAddendSource.
 #include "source/common/formatter/http_formatter_context.h"
+#endif
 #include "source/common/json/json_loader.h"
 #include "source/common/json/json_streamer.h"
 #include "source/common/json/json_utility.h"

--- a/source/common/formatter/substitution_formatter.h
+++ b/source/common/formatter/substitution_formatter.h
@@ -13,11 +13,7 @@
 #include "envoy/stream_info/stream_info.h"
 
 #include "source/common/common/utility.h"
-
-#ifdef ENVOY_STATIC_EXTENSION_REGISTRATION // See the comments in the header file around
-                                           // resolveHitsAddendSource.
 #include "source/common/formatter/http_formatter_context.h"
-#endif
 #include "source/common/json/json_loader.h"
 #include "source/common/json/json_streamer.h"
 #include "source/common/json/json_utility.h"

--- a/source/common/router/BUILD
+++ b/source/common/router/BUILD
@@ -7,7 +7,6 @@ load(
     "envoy_cc_library",
     "envoy_package",
 )
-load(":envoy_select.bzl", "envoy_select_static_extension_registration")
 
 licenses(["notice"])  # Apache 2
 
@@ -432,11 +431,14 @@ envoy_cc_library(
         "//source/common/protobuf:utility_lib",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
         "@envoy_api//envoy/config/route/v3:pkg_cc_proto",
-    ] + envoy_select_static_extension_registration([
-        # See the comments in the header file.
-        "//source/common/formatter:formatter_extension_lib",
-        "//source/common/formatter:substitution_formatter_lib",
-    ]),
+    ] + select({
+        "//bazel:disable_static_extension_registration": [],
+        "//conditions:default": [
+            # See the comments in the header file.
+            "//source/common/formatter:formatter_extension_lib",
+            "//source/common/formatter:substitution_formatter_lib",
+        ],
+    }),
 )
 
 envoy_cc_library(

--- a/source/common/router/BUILD
+++ b/source/common/router/BUILD
@@ -424,6 +424,8 @@ envoy_cc_library(
         "//source/common/common:empty_string",
         "//source/common/config:metadata_lib",
         "//source/common/config:utility_lib",
+        "//source/common/formatter:formatter_extension_lib",
+        "//source/common/formatter:substitution_formatter_lib",
         "//source/common/http:header_utility_lib",
         "//source/common/http/matching:data_impl_lib",
         "//source/common/matcher:matcher_lib",

--- a/source/common/router/BUILD
+++ b/source/common/router/BUILD
@@ -7,6 +7,7 @@ load(
     "envoy_cc_library",
     "envoy_package",
 )
+load(":envoy_select.bzl", "envoy_select_static_extension_registration")
 
 licenses(["notice"])  # Apache 2
 
@@ -424,8 +425,6 @@ envoy_cc_library(
         "//source/common/common:empty_string",
         "//source/common/config:metadata_lib",
         "//source/common/config:utility_lib",
-        "//source/common/formatter:formatter_extension_lib",
-        "//source/common/formatter:substitution_formatter_lib",
         "//source/common/http:header_utility_lib",
         "//source/common/http/matching:data_impl_lib",
         "//source/common/matcher:matcher_lib",
@@ -433,7 +432,11 @@ envoy_cc_library(
         "//source/common/protobuf:utility_lib",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
         "@envoy_api//envoy/config/route/v3:pkg_cc_proto",
-    ],
+    ] + envoy_select_static_extension_registration([
+        # See the comments in the header file.
+        "//source/common/formatter:formatter_extension_lib",
+        "//source/common/formatter:substitution_formatter_lib",
+    ]),
 )
 
 envoy_cc_library(

--- a/source/common/router/router_ratelimit.cc
+++ b/source/common/router/router_ratelimit.cc
@@ -12,7 +12,11 @@
 #include "source/common/common/empty_string.h"
 #include "source/common/config/metadata.h"
 #include "source/common/config/utility.h"
+
+#ifdef ENVOY_STATIC_EXTENSION_REGISTRATION // See the comments in the header file around
+                                           // resolveHitsAddendSource.
 #include "source/common/formatter/substitution_formatter.h"
+#endif
 #include "source/common/protobuf/utility.h"
 
 namespace Envoy {

--- a/source/common/router/router_ratelimit.h
+++ b/source/common/router/router_ratelimit.h
@@ -238,6 +238,13 @@ private:
   Matcher::DataInputPtr<Http::HttpMatchingData> data_input_;
 };
 
+// This requires the formatter to be resolved at runtime which currently uses excetions.
+// Therefore, it cannot be supported in the Envoy mobile for now.
+// Moreover, to make the hits_addend meaningful, the formatter should be able to access
+// the static registry of formatters which is also not supported in the Envoy mobile.
+//
+// TODO(mathetake): revisit after removing exceptions from formatters.
+#ifdef ENVOY_STATIC_EXTENSION_REGISTRATION
 /**
  * Resolve hits addend source from configuration. It sets either hits_addend_provider or hits_addend
  * based on the configuration.
@@ -254,6 +261,7 @@ absl::StatusOr<uint64_t>
 getHitsAddendViaProvider(const Formatter::FormatterProvider& hits_addend_provider,
                          const Http::RequestHeaderMap& headers,
                          const StreamInfo::StreamInfo& stream_info);
+#endif
 
 /*
  * Implementation of RateLimitPolicyEntry that holds the action for the configuration.

--- a/source/common/router/router_ratelimit.h
+++ b/source/common/router/router_ratelimit.h
@@ -7,7 +7,10 @@
 
 #include "envoy/config/core/v3/base.pb.h"
 #include "envoy/config/route/v3/route_components.pb.h"
+
+#ifdef ENVOY_STATIC_EXTENSION_REGISTRATION
 #include "envoy/formatter/substitution_formatter.h"
+#endif
 #include "envoy/ratelimit/ratelimit.h"
 #include "envoy/router/router.h"
 #include "envoy/router/router_ratelimit.h"

--- a/source/common/router/router_ratelimit.h
+++ b/source/common/router/router_ratelimit.h
@@ -238,12 +238,13 @@ private:
   Matcher::DataInputPtr<Http::HttpMatchingData> data_input_;
 };
 
-// This requires the formatter to be resolved at runtime which currently uses excetions.
-// Therefore, it cannot be supported in the Envoy mobile for now.
-// Moreover, to make the hits_addend meaningful, the formatter should be able to access
-// the static registry of formatters which is also not supported in the Envoy mobile.
+// This requires the formatter to be resolved which currently uses exceptions, so it cannot be
+// supported in mobile for now. Moreover, to make the hits_addend meaningful, the formatter should
+// be able to access the static registry of formatters which is also not supported in the Envoy
+// mobile.
 //
-// TODO(mathetake): revisit after removing exceptions from formatters.
+// TODO(mathetake): revisit after removing exceptions from formatters. Maybe deprecate the ratelimit
+// from the router would be a better solution.
 #ifdef ENVOY_STATIC_EXTENSION_REGISTRATION
 /**
  * Resolve hits addend source from configuration. It sets either hits_addend_provider or hits_addend

--- a/source/common/router/router_ratelimit.h
+++ b/source/common/router/router_ratelimit.h
@@ -296,10 +296,10 @@ private:
   absl::optional<RateLimitOverrideActionPtr> limit_override_ = absl::nullopt;
   const bool apply_on_stream_done_ = false;
 
-  #ifdef ENVOY_STATIC_EXTENSION_REGISTRATION
+#ifdef ENVOY_STATIC_EXTENSION_REGISTRATION
   Formatter::FormatterProviderPtr hits_addend_provider_ = nullptr;
   absl::optional<uint64_t> hits_addend_ = absl::nullopt;
-  #endif
+#endif
 };
 
 /**

--- a/source/common/router/router_ratelimit.h
+++ b/source/common/router/router_ratelimit.h
@@ -295,8 +295,11 @@ private:
   std::vector<RateLimit::DescriptorProducerPtr> actions_;
   absl::optional<RateLimitOverrideActionPtr> limit_override_ = absl::nullopt;
   const bool apply_on_stream_done_ = false;
+
+  #ifdef ENVOY_STATIC_EXTENSION_REGISTRATION
   Formatter::FormatterProviderPtr hits_addend_provider_ = nullptr;
   absl::optional<uint64_t> hits_addend_ = absl::nullopt;
+  #endif
 };
 
 /**

--- a/test/common/router/router_ratelimit_test.cc
+++ b/test/common/router/router_ratelimit_test.cc
@@ -362,20 +362,26 @@ TEST_F(RateLimitPolicyEntryTest, MaskedRemoteAddressIpv4) {
 actions:
 - masked_remote_address:
     v4_prefix_mask_len: 16
+hits_addend:
+  format: "%REQ(x-test-hits-addend)%"
   )EOF";
 
   setupTest(yaml);
 
+  header_.addCopy("x-test-hits-addend", "1234");
   rate_limit_entry_->populateDescriptors(descriptors_, "", header_, stream_info_);
   EXPECT_THAT(
       std::vector<Envoy::RateLimit::Descriptor>({{{{"masked_remote_address", "10.0.0.0/16"}}}}),
       testing::ContainerEq(descriptors_));
+  EXPECT_EQ(1234, descriptors_[0].hits_addend_);
 }
 
 TEST_F(RateLimitPolicyEntryIpv6Test, MaskedRemoteAddressIpv6Default) {
   const std::string yaml = R"EOF(
 actions:
 - masked_remote_address: {}
+hits_addend:
+  number: 1234
   )EOF";
 
   setupTest(yaml);
@@ -384,6 +390,7 @@ actions:
   EXPECT_THAT(std::vector<Envoy::RateLimit::Descriptor>(
                   {{{{"masked_remote_address", "2001:abcd:ef01:2345:6789:abcd:ef01:234/128"}}}}),
               testing::ContainerEq(descriptors_));
+  EXPECT_EQ(1234, descriptors_[0].hits_addend_);
 }
 
 TEST_F(RateLimitPolicyEntryIpv6Test, MaskedRemoteAddressIpv6) {


### PR DESCRIPTION
Commit Message: ratelimit: per-descriptor hits_addend for route config
Additional Description:

This is a follow up on #37684. Previously, the newly introduced
per-descriptor hits_addend API was only supported by typed_per_filter_config
and its support in the "legacy" core router ratelimit configuration was left TODO.

Since the RateLimitPolicy is coupled with route(r), this impl must be inside
the core, which makes it inappropriate to use formatter in Envoy mobile due to 
its use of exceptions. However, even if it didn't have exception uses, it would be
still useless as the mobile cannot use rate limit filter at the end of the day.
So, this patch uses the macro to exclude the entire logic and dependency for
Envoy mobile, which can be relaxed after removing exceptions from formatters.

Risk Level: low
Testing: unit test
Docs Changes: n/a (already done in #37684)
Release Notes: n/a (already done in #37684)
Platform Specific Features: n/a

