### PR TITLE
api: add regex match and rewrite support for the header/query mutation

### DIFF
--- a/api/envoy/config/core/v3/base.proto
+++ b/api/envoy/config/core/v3/base.proto
@@ -376,7 +376,7 @@ message KeyValueAppend {
   // key or to only add this key if it's absent.
   KeyValueAppendAction action = 2 [(validate.rules).enum = {defined_only: true}];
 
-  // Match and rewrite the value. If value matchs the regex ``pattern``, then the value will
+  // Match and rewrite the value. If value matches the regex ``pattern``, then the value will
   // be rewritten according to the ``substitution``
   // If the value doesn't match the ``pattern``, then the whole update will be ignored.
   // [#not-implemented-hide:]
@@ -487,7 +487,7 @@ message HeaderValueOption {
   // otherwise they are added.
   bool keep_empty_value = 4;
 
-  // Match and rewrite the value. If value matchs the regex ``pattern``, then the value will
+  // Match and rewrite the value. If value matches the regex ``pattern``, then the value will
   // be rewritten according to the ``substitution``
   // If the value doesn't match the ``pattern``, then the whole update will be ignored.
   // [#not-implemented-hide:]

--- a/api/envoy/config/core/v3/base.proto
+++ b/api/envoy/config/core/v3/base.proto
@@ -5,6 +5,7 @@ package envoy.config.core.v3;
 import "envoy/config/core/v3/address.proto";
 import "envoy/config/core/v3/backoff.proto";
 import "envoy/config/core/v3/http_uri.proto";
+import "envoy/type/matcher/v3/regex.proto";
 import "envoy/type/v3/percent.proto";
 import "envoy/type/v3/semantic_version.proto";
 
@@ -374,6 +375,12 @@ message KeyValueAppend {
   // Describes the action taken to append/overwrite the given value for an existing
   // key or to only add this key if it's absent.
   KeyValueAppendAction action = 2 [(validate.rules).enum = {defined_only: true}];
+
+  // Match and rewrite the value. If value matchs the regex ``pattern``, then the value will
+  // be rewritten according to the ``substitution``
+  // If the value doesn't match the ``pattern``, then the whole update will be ignored.
+  // [#not-implemented-hide:]
+  type.matcher.v3.RegexMatchAndSubstitute rewrite = 4;
 }
 
 // Key/value pair to append or remove.
@@ -426,6 +433,7 @@ message HeaderValue {
 }
 
 // Header name/value pair plus option to control append behavior.
+// [#next-free-field: 6]
 message HeaderValueOption {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.api.v2.core.HeaderValueOption";
@@ -478,6 +486,12 @@ message HeaderValueOption {
   // Is the header value allowed to be empty? If false (default), custom headers with empty values are dropped,
   // otherwise they are added.
   bool keep_empty_value = 4;
+
+  // Match and rewrite the value. If value matchs the regex ``pattern``, then the value will
+  // be rewritten according to the ``substitution``
+  // If the value doesn't match the ``pattern``, then the whole update will be ignored.
+  // [#not-implemented-hide:]
+  type.matcher.v3.RegexMatchAndSubstitute rewrite = 5;
 }
 
 // Wrapper for a set of headers.


### PR DESCRIPTION
Commit Message: api: add regex match and rewrite support for the header/query mutation
Additional Description:

Now, the header mutation (both the header mutation filter and `headers_to_add`) could set/add headers by the substitution formatter. (like `%REQ(xxxxx)%`. But it's impossible to extract more fine-grained part of one header or path. It would be great to extract sub-value from a header or path by the regex and set the sub-value to a new header.

For example:

```
        header:
          name: "proxy-target"
          value: "%REQ(:PATH)%"
        rewrite:
           pattern:
             regex: "/prefix/proxy/(.+)"
           substitution: "\\1"
        append_action: APPEND_IF_EXISTS_OR_ADD

```

https://docs.google.com/document/d/1amCGuj-8KaffTSPzqOnCRkX_s_kwnmORGW83jFmq314/edit?usp=sharing

part of #37885

Risk Level: none. api only.
Testing: n/a.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.