### PR TITLE
mobile: Fix order-dependent //test/common/logger:logger_delegate_test 

### DIFF
--- a/mobile/test/common/logger/logger_delegate_test.cc
+++ b/mobile/test/common/logger/logger_delegate_test.cc
@@ -19,9 +19,7 @@ public:
     Api::External::registerApi(std::string(ENVOY_EVENT_TRACKER_API_NAME), &event_tracker);
   }
 
-  void SetUp() override {
-    Context::changeAllLogLevels(spdlog::level::info);
-  }
+  void SetUp() override { Context::changeAllLogLevels(spdlog::level::info); }
 };
 
 std::unique_ptr<EnvoyEventTracker> LambdaDelegateTest::event_tracker =

--- a/mobile/test/common/logger/logger_delegate_test.cc
+++ b/mobile/test/common/logger/logger_delegate_test.cc
@@ -18,6 +18,10 @@ public:
   static void SetUpTestSuite() {
     Api::External::registerApi(std::string(ENVOY_EVENT_TRACKER_API_NAME), &event_tracker);
   }
+
+  void SetUp() override {
+    Context::changeAllLogLevels(spdlog::level::info);
+  }
 };
 
 std::unique_ptr<EnvoyEventTracker> LambdaDelegateTest::event_tracker =


### PR DESCRIPTION
Internally we discovered an order-dependent test that will cause the test to fail because changing the log level is in `LogCbWithLevels` is global. The fix is to restore the log level in the `SetUp`.

Risk Level: low (test only)
Testing: unit test
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a