### PR TITLE
build: add config_load_check_tool to tools-* image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,9 +7,11 @@
 !/linux/amd64/release.tar.zst
 !/linux/amd64/schema_validator_tool
 !/linux/amd64/router_check_tool
+!/linux/amd64/config_load_check_tool
 !/linux/arm64/release.tar.zst
 !/linux/arm64/schema_validator_tool
 !/linux/arm64/router_check_tool
+!/linux/arm64/config_load_check_tool
 !/local
 !/test/config/integration/certs
 !/windows

--- a/ci/Dockerfile-envoy
+++ b/ci/Dockerfile-envoy
@@ -55,7 +55,7 @@ FROM envoy AS envoy-tools
 ARG TARGETPLATFORM
 ENV TARGETPLATFORM="${TARGETPLATFORM:-linux/amd64}"
 COPY --chown=0:0 --chmod=755 \
-    "${TARGETPLATFORM}/schema_validator_tool" "${TARGETPLATFORM}/router_check_tool" /usr/local/bin/
+    "${TARGETPLATFORM}/schema_validator_tool" "${TARGETPLATFORM}/router_check_tool" "${TARGETPLATFORM}/config_load_check_tool" /usr/local/bin/
 
 
 # STAGE: envoy-distroless

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -96,6 +96,8 @@ function cp_binary_for_image_build() {
     -o "${BASE_TARGET_DIR}"/"${TARGET_DIR}"/schema_validator_tool
   strip bazel-bin/test/tools/router_check/router_check_tool \
     -o "${BASE_TARGET_DIR}"/"${TARGET_DIR}"/router_check_tool
+  strip bazel-bin/test/tools/config_load_check/config_load_check_tool \
+    -o "${BASE_TARGET_DIR}"/"${TARGET_DIR}"/config_load_check_tool
 
   # Copy the su-exec utility binary into the image
   cp -f bazel-bin/external/com_github_ncopa_suexec/su-exec "${BASE_TARGET_DIR}"/"${TARGET_DIR}"
@@ -163,6 +165,8 @@ function bazel_binary_build() {
     //test/tools/schema_validator:schema_validator_tool "${CONFIG_ARGS[@]}"
   bazel build "${BAZEL_BUILD_OPTIONS[@]}" --remote_download_toplevel -c "${COMPILE_TYPE}" \
     //test/tools/router_check:router_check_tool "${CONFIG_ARGS[@]}"
+  bazel build "${BAZEL_BUILD_OPTIONS[@]}" --remote_download_toplevel -c "${COMPILE_TYPE}" \
+    //test/tools/config_load_check:config_load_check_tool "${CONFIG_ARGS[@]}"
 
   # Build su-exec utility
   bazel build "${BAZEL_BUILD_OPTIONS[@]}" --remote_download_toplevel -c "${COMPILE_TYPE}" @com_github_ncopa_suexec//:su-exec
@@ -779,6 +783,12 @@ case $CI_TARGET in
         cp -a \
            bazel-bin/test/tools/router_check/router_check_tool.stripped \
            "${ENVOY_BINARY_DIR}/router_check_tool"
+        bazel build "${BAZEL_BUILD_OPTIONS[@]}" "${BAZEL_RELEASE_OPTIONS[@]}" \
+              --remote_download_toplevel \
+              //test/tools/config_load_check:config_load_check_tool.stripped
+        cp -a \
+           bazel-bin/test/tools/config_load_check/config_load_check_tool.stripped \
+           "${ENVOY_BINARY_DIR}/config_load_check_tool"
         echo "Release files created in ${ENVOY_BINARY_DIR}"
         ;;
 

--- a/docs/root/operations/tools/config_load_check_tool.rst
+++ b/docs/root/operations/tools/config_load_check_tool.rst
@@ -20,6 +20,8 @@ Output
   exit with status EXIT_SUCCESS.
 
 Building
+  The tool is included in the :ref:`tools image <install_tools>`.
+
   The tool can be built locally using Bazel. ::
 
     bazel build //test/tools/config_load_check:config_load_check_tool


### PR DESCRIPTION
This change adds `config_load_check_tool` binary to `tools-*` image

Fixes https://github.com/envoyproxy/envoy/issues/37987
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes: Changes: update [doc](https://www.envoyproxy.io/docs/envoy/latest/operations/tools/config_load_check_tool) about availability in tools image.
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
