### PR TITLE
fluentd_access_logger: fix cluster check in fluentd access log creation

### DIFF
--- a/envoy/upstream/cluster_manager.h
+++ b/envoy/upstream/cluster_manager.h
@@ -486,6 +486,12 @@ public:
   virtual void drainConnections(DrainConnectionsHostPredicate predicate) PURE;
 
   /**
+   * Check if the cluster is active, and if not, return an error
+   * @param cluster, the cluster to check.
+   */
+  virtual absl::Status checkActiveCluster(const std::string& cluster) PURE;
+
+  /**
    * Check if the cluster is active and statically configured, and if not, return an error
    * @param cluster, the cluster to check.
    */

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -1278,6 +1278,14 @@ void ClusterManagerImpl::drainConnections(DrainConnectionsHostPredicate predicat
   });
 }
 
+absl::Status ClusterManagerImpl::checkActiveCluster(const std::string& cluster) {
+  const auto& it = active_clusters_.find(cluster);
+  if (it == active_clusters_.end()) {
+    return absl::InvalidArgumentError(fmt::format("Unknown gRPC client cluster '{}'", cluster));
+  }
+  return absl::OkStatus();
+}
+
 absl::Status ClusterManagerImpl::checkActiveStaticCluster(const std::string& cluster) {
   const auto& it = active_clusters_.find(cluster);
   if (it == active_clusters_.end()) {

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -357,6 +357,8 @@ public:
 
   void drainConnections(DrainConnectionsHostPredicate predicate) override;
 
+  absl::Status checkActiveCluster(const std::string& cluster) override;
+
   absl::Status checkActiveStaticCluster(const std::string& cluster) override;
 
   // Upstream::MissingClusterNotifier

--- a/source/extensions/access_loggers/fluentd/config.cc
+++ b/source/extensions/access_loggers/fluentd/config.cc
@@ -39,8 +39,8 @@ FluentdAccessLogFactory::createAccessLogInstance(const Protobuf::Message& config
       const envoy::extensions::access_loggers::fluentd::v3::FluentdAccessLogConfig&>(
       config, context.messageValidationVisitor());
 
-  absl::Status status = context.serverFactoryContext().clusterManager().checkActiveStaticCluster(
-      proto_config.cluster());
+  absl::Status status =
+      context.serverFactoryContext().clusterManager().checkActiveCluster(proto_config.cluster());
   if (!status.ok()) {
     throw EnvoyException(fmt::format("cluster '{}' was not found", proto_config.cluster()));
   }

--- a/test/extensions/access_loggers/fluentd/fluentd_access_log_impl_test.cc
+++ b/test/extensions/access_loggers/fluentd/fluentd_access_log_impl_test.cc
@@ -518,8 +518,7 @@ TEST_F(FluentdAccessLogTest, UnknownCluster) {
   auto* record = config_.mutable_record();
   (*record->mutable_fields())["Message"].set_string_value("SomeValue");
 
-  EXPECT_CALL(context_.server_factory_context_.cluster_manager_,
-              checkActiveCluster("unknown"))
+  EXPECT_CALL(context_.server_factory_context_.cluster_manager_, checkActiveCluster("unknown"))
       .WillOnce(Return(absl::InvalidArgumentError("no cluster")));
 
   EXPECT_THROW_WITH_MESSAGE(

--- a/test/extensions/access_loggers/fluentd/fluentd_access_log_impl_test.cc
+++ b/test/extensions/access_loggers/fluentd/fluentd_access_log_impl_test.cc
@@ -519,7 +519,7 @@ TEST_F(FluentdAccessLogTest, UnknownCluster) {
   (*record->mutable_fields())["Message"].set_string_value("SomeValue");
 
   EXPECT_CALL(context_.server_factory_context_.cluster_manager_,
-              checkActiveStaticCluster("unknown"))
+              checkActiveCluster("unknown"))
       .WillOnce(Return(absl::InvalidArgumentError("no cluster")));
 
   EXPECT_THROW_WITH_MESSAGE(


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description: When adding fluentd access log to listener, cluster check in [createAccessLogInstance](https://github.com/ohadvano/envoy/blob/e22980c406bc6cad8e3545343fe8a503f47bf329/source/extensions/access_loggers/fluentd/config.cc#L35) seems to too narrow and only check for static cluster, this PR checks expands the check to include dynamic cluster as well. Fixes https://github.com/envoyproxy/envoy/issues/36511
Risk Level: Low
Testing: Added Unit Tests
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
