### PR TITLE
Fix ext_proc duplicate data issue

### DIFF
--- a/source/extensions/filters/http/ext_proc/processor_state.cc
+++ b/source/extensions/filters/http/ext_proc/processor_state.cc
@@ -513,10 +513,8 @@ bool ProcessorState::handleStreamedBodyResponse(const CommonResponse& common_res
     MutationUtils::applyBodyMutations(common_response.body_mutation(), chunk_data);
   }
   bool should_continue = chunk->end_stream;
-  if (chunk_data.length() > 0) {
-    ENVOY_LOG(trace, "Injecting {} bytes of data to filter stream", chunk_data.length());
-    injectDataToFilterChain(chunk_data, chunk->end_stream);
-  }
+  ENVOY_LOG(trace, "Injecting {} bytes of data to filter stream", chunk_data.length());
+  injectDataToFilterChain(chunk_data, chunk->end_stream);
 
   if (queueBelowLowLimit()) {
     clearWatermark();
@@ -536,15 +534,13 @@ bool ProcessorState::handleDuplexStreamedBodyResponse(const CommonResponse& comm
   const std::string& body = streamed_response.body();
   const bool end_of_stream = streamed_response.end_of_stream();
 
-  if (!body.empty()) {
-    Buffer::OwnedImpl buffer;
-    buffer.add(body);
-    ENVOY_LOG(trace,
-              "Injecting {} bytes of data to filter stream in FULL_DUPLEX_STREAMED mode. "
-              "end_of_stream is {}",
-              buffer.length(), end_of_stream);
-    injectDataToFilterChain(buffer, end_of_stream);
-  }
+  Buffer::OwnedImpl buffer;
+  buffer.add(body);
+  ENVOY_LOG(trace,
+            "Injecting {} bytes of data to filter stream in FULL_DUPLEX_STREAMED mode. "
+            "end_of_stream is {}",
+            buffer.length(), end_of_stream);
+  injectDataToFilterChain(buffer, end_of_stream);
 
   if (end_of_stream) {
     onFinishProcessorCall(Grpc::Status::Ok);

--- a/test/extensions/filters/http/ext_proc/BUILD
+++ b/test/extensions/filters/http/ext_proc/BUILD
@@ -201,6 +201,33 @@ envoy_extension_cc_test(
 )
 
 envoy_extension_cc_test(
+    name = "ext_proc_misc_test",
+    srcs = ["ext_proc_misc_test.cc"],
+    copts = select({
+        "//bazel:windows_x86_64": [],
+        "//conditions:default": [
+            "-DUSE_CEL_PARSER",
+        ],
+    }),
+    extension_names = [
+        "envoy.filters.http.ext_proc",
+    ],
+    rbe_pool = "2core",
+    tags = ["skip_on_windows"],
+    deps = [
+        ":utils_lib",
+        "//source/extensions/filters/http/ext_proc:config",
+        "//test/common/http:common_lib",
+        "//test/integration:http_integration_lib",
+        "//test/test_common:test_runtime_lib",
+        "//test/test_common:utility_lib",
+        "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/filters/http/ext_proc/v3:pkg_cc_proto",
+        "@envoy_api//envoy/service/ext_proc/v3:pkg_cc_proto",
+    ],
+)
+
+envoy_extension_cc_test(
     name = "streaming_integration_test",
     size = "large",
     srcs = ["streaming_integration_test.cc"],

--- a/test/extensions/filters/http/ext_proc/ext_proc_misc_test.cc
+++ b/test/extensions/filters/http/ext_proc/ext_proc_misc_test.cc
@@ -1,0 +1,249 @@
+#include <algorithm>
+#include <iostream>
+
+#include "envoy/config/core/v3/base.pb.h"
+#include "envoy/extensions/filters/http/ext_proc/v3/ext_proc.pb.h"
+#include "envoy/network/address.h"
+#include "envoy/service/ext_proc/v3/external_processor.pb.h"
+
+#include "source/extensions/filters/http/ext_proc/config.h"
+#include "source/extensions/filters/http/ext_proc/ext_proc.h"
+
+#include "test/common/http/common.h"
+#include "test/extensions/filters/http/ext_proc/utils.h"
+#include "test/integration/http_integration.h"
+#include "test/test_common/test_runtime.h"
+#include "test/test_common/utility.h"
+
+#include "gtest/gtest.h"
+
+namespace Envoy {
+
+using envoy::extensions::filters::http::ext_proc::v3::ProcessingMode;
+using envoy::service::ext_proc::v3::BodyResponse;
+using envoy::service::ext_proc::v3::HeadersResponse;
+using envoy::service::ext_proc::v3::HttpBody;
+using envoy::service::ext_proc::v3::HttpHeaders;
+using envoy::service::ext_proc::v3::ProcessingRequest;
+using envoy::service::ext_proc::v3::ProcessingResponse;
+using Http::LowerCaseString;
+
+class ExtProcMiscIntegrationTest : public HttpIntegrationTest,
+                                   public Grpc::GrpcClientIntegrationParamTest {
+protected:
+  ExtProcMiscIntegrationTest() : HttpIntegrationTest(Http::CodecType::HTTP1, ipVersion()) {}
+
+  void createUpstreams() override {
+    HttpIntegrationTest::createUpstreams();
+
+    // Create separate "upstreams" for ExtProc gRPC servers
+    for (int i = 0; i < grpc_upstream_count_; ++i) {
+      grpc_upstreams_.push_back(&addFakeUpstream(Http::CodecType::HTTP2));
+    }
+  }
+
+  void TearDown() override {
+    if (processor_connection_) {
+      ASSERT_TRUE(processor_connection_->close());
+      ASSERT_TRUE(processor_connection_->waitForDisconnect());
+    }
+    cleanupUpstreamAndDownstream();
+  }
+
+  void initializeConfig(const std::vector<std::pair<int, int>>& cluster_endpoints = {{0, 1},
+                                                                                     {1, 1}}) {
+    int total_cluster_endpoints = 0;
+    std::for_each(
+        cluster_endpoints.begin(), cluster_endpoints.end(),
+        [&total_cluster_endpoints](const auto& item) { total_cluster_endpoints += item.second; });
+    ASSERT_EQ(total_cluster_endpoints, grpc_upstream_count_);
+
+    config_helper_.addConfigModifier([this, cluster_endpoints](
+                                         envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
+      for (const auto& [cluster_id, endpoint_count] : cluster_endpoints) {
+        auto* server_cluster = bootstrap.mutable_static_resources()->add_clusters();
+        server_cluster->MergeFrom(bootstrap.static_resources().clusters()[0]);
+        std::string cluster_name = absl::StrCat("ext_proc_server_", cluster_id);
+        server_cluster->set_name(cluster_name);
+        server_cluster->mutable_load_assignment()->set_cluster_name(cluster_name);
+        ASSERT_EQ(server_cluster->load_assignment().endpoints_size(), 1);
+        auto* endpoints = server_cluster->mutable_load_assignment()->mutable_endpoints(0);
+        ASSERT_EQ(endpoints->lb_endpoints_size(), 1);
+        for (int i = 1; i < endpoint_count; ++i) {
+          auto* new_lb_endpoint = endpoints->add_lb_endpoints();
+          new_lb_endpoint->MergeFrom(endpoints->lb_endpoints(0));
+        }
+      }
+
+      const std::string valid_grpc_cluster_name = "ext_proc_server_0";
+      setGrpcService(*proto_config_.mutable_grpc_service(), valid_grpc_cluster_name,
+                     grpc_upstreams_[0]->localAddress());
+
+      std::string ext_proc_filter_name = "envoy.filters.http.ext_proc";
+      envoy::extensions::filters::network::http_connection_manager::v3::HttpFilter ext_proc_filter;
+      ext_proc_filter.set_name(ext_proc_filter_name);
+      ext_proc_filter.mutable_typed_config()->PackFrom(proto_config_);
+      config_helper_.prependFilter(MessageUtil::getJsonStringFromMessageOrError(ext_proc_filter));
+    });
+
+    setUpstreamProtocol(Http::CodecType::HTTP1);
+    setDownstreamProtocol(Http::CodecType::HTTP1);
+  }
+
+  IntegrationStreamDecoderPtr sendDownstreamRequest(
+      absl::optional<std::function<void(Http::RequestHeaderMap& headers)>> modify_headers) {
+    auto conn = makeClientConnection(lookupPort("http"));
+    codec_client_ = makeHttpConnection(std::move(conn));
+    Http::TestRequestHeaderMapImpl headers;
+    HttpTestUtility::addDefaultHeaders(headers);
+    if (modify_headers) {
+      (*modify_headers)(headers);
+    }
+    return codec_client_->makeHeaderOnlyRequest(headers);
+  }
+
+  void processRequestHeadersMessage(
+      FakeUpstream& grpc_upstream, bool first_message,
+      absl::optional<std::function<bool(const HttpHeaders&, HeadersResponse&)>> cb) {
+    ProcessingRequest request;
+    if (first_message) {
+      ASSERT_TRUE(grpc_upstream.waitForHttpConnection(*dispatcher_, processor_connection_));
+      ASSERT_TRUE(processor_connection_->waitForNewStream(*dispatcher_, processor_stream_));
+    }
+    ASSERT_TRUE(processor_stream_->waitForGrpcMessage(*dispatcher_, request));
+    ASSERT_TRUE(request.has_request_headers());
+    if (first_message) {
+      processor_stream_->startGrpcStream();
+    }
+    ProcessingResponse response;
+    auto* headers = response.mutable_request_headers();
+    const bool sendReply = !cb || (*cb)(request.request_headers(), *headers);
+    if (sendReply) {
+      processor_stream_->sendGrpcMessage(response);
+    }
+  }
+
+  void processResponseHeadersMessage(
+      FakeUpstream& grpc_upstream, bool first_message,
+      absl::optional<std::function<bool(const HttpHeaders&, HeadersResponse&)>> cb) {
+    ProcessingRequest request;
+    if (first_message) {
+      ASSERT_TRUE(grpc_upstream.waitForHttpConnection(*dispatcher_, processor_connection_));
+      ASSERT_TRUE(processor_connection_->waitForNewStream(*dispatcher_, processor_stream_));
+    }
+    ASSERT_TRUE(processor_stream_->waitForGrpcMessage(*dispatcher_, request));
+    ASSERT_TRUE(request.has_response_headers());
+    if (first_message) {
+      processor_stream_->startGrpcStream();
+    }
+    ProcessingResponse response;
+    auto* headers = response.mutable_response_headers();
+    const bool sendReply = !cb || (*cb)(request.response_headers(), *headers);
+    if (sendReply) {
+      processor_stream_->sendGrpcMessage(response);
+    }
+  }
+
+  void processRequestBodyMessage(
+      FakeUpstream& grpc_upstream, bool first_message,
+      absl::optional<std::function<bool(const HttpBody&, BodyResponse&)>> cb) {
+    ProcessingRequest request;
+    if (first_message) {
+      ASSERT_TRUE(grpc_upstream.waitForHttpConnection(*dispatcher_, processor_connection_));
+      ASSERT_TRUE(processor_connection_->waitForNewStream(*dispatcher_, processor_stream_));
+    }
+    ASSERT_TRUE(processor_stream_->waitForGrpcMessage(*dispatcher_, request));
+    ASSERT_TRUE(request.has_request_body());
+    if (first_message) {
+      processor_stream_->startGrpcStream();
+    }
+
+    // Send back the response from ext_proc server.
+    ProcessingResponse response;
+    auto* body = response.mutable_request_body();
+    const bool sendReply = !cb || (*cb)(request.request_body(), *body);
+    if (sendReply) {
+      processor_stream_->sendGrpcMessage(response);
+    }
+  }
+
+  void verifyDownstreamResponse(IntegrationStreamDecoder& response, int status_code) {
+    ASSERT_TRUE(response.waitForEndStream());
+    EXPECT_TRUE(response.complete());
+    EXPECT_EQ(std::to_string(status_code), response.headers().getStatusValue());
+  }
+
+  bool IsEnvoyGrpc() { return std::get<1>(GetParam()) == Envoy::Grpc::ClientType::EnvoyGrpc; }
+
+  envoy::extensions::filters::http::ext_proc::v3::ExternalProcessor proto_config_{};
+  std::vector<FakeUpstream*> grpc_upstreams_;
+  FakeHttpConnectionPtr processor_connection_;
+  FakeStreamPtr processor_stream_;
+  TestScopedRuntime scoped_runtime_;
+  int grpc_upstream_count_ = 2;
+};
+
+INSTANTIATE_TEST_SUITE_P(IpVersionsClientTypeDeferredProcessing, ExtProcMiscIntegrationTest,
+                         GRPC_CLIENT_INTEGRATION_PARAMS);
+
+// Test sending empty last body chunk with end_of_stream = true.
+TEST_P(ExtProcMiscIntegrationTest, SendEmptyLastBodyChunk) {
+  if (IsEnvoyGrpc()) {
+    return;
+  }
+
+  proto_config_.mutable_message_timeout()->set_seconds(2);
+  config_helper_.setBufferLimits(1024 * 1024, 1024 * 1024);
+  proto_config_.mutable_processing_mode()->set_request_body_mode(ProcessingMode::STREAMED);
+  proto_config_.mutable_processing_mode()->set_response_header_mode(ProcessingMode::SKIP);
+
+  // Config retry policy.
+  config_helper_.addConfigModifier([](ConfigHelper::HttpConnectionManager& hcm) {
+    auto* vhost = hcm.mutable_route_config()->mutable_virtual_hosts()->Mutable(0);
+    auto* retry_policy = vhost->mutable_retry_policy();
+    retry_policy->set_retry_on("connect-failure");
+    retry_policy->mutable_num_retries()->set_value(2);
+  });
+  initializeConfig();
+  HttpIntegrationTest::initialize();
+
+  auto conn = makeClientConnection(lookupPort("http"));
+  codec_client_ = makeHttpConnection(std::move(conn));
+  Http::TestRequestHeaderMapImpl headers;
+  HttpTestUtility::addDefaultHeaders(headers);
+  headers.setMethod("POST");
+
+  auto encoder_decoder = codec_client_->startRequest(headers);
+  request_encoder_ = &encoder_decoder.first;
+  auto response = std::move(encoder_decoder.second);
+  const uint32_t init_body_size = 1000;
+  std::string init_body(init_body_size, 'a');
+  codec_client_->sendData(*request_encoder_, init_body, false);
+  processRequestHeadersMessage(*grpc_upstreams_[0], true, absl::nullopt);
+
+  timeSystem().advanceTimeWaitImpl(std::chrono::milliseconds(20));
+  const uint32_t body_size = 2000;
+  std::string req_body(body_size, 'b');
+  codec_client_->sendData(*request_encoder_, req_body, false);
+  codec_client_->sendData(*request_encoder_, "", true);
+
+  bool end_stream = false;
+  while (!end_stream) {
+    processRequestBodyMessage(*grpc_upstreams_[0], false,
+                              [&end_stream](const HttpBody& body, BodyResponse&) {
+                                end_stream = body.end_of_stream();
+                                return true;
+                              });
+  }
+
+  ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, fake_upstream_connection_));
+  ASSERT_TRUE(fake_upstream_connection_->waitForNewStream(*dispatcher_, upstream_request_));
+  ASSERT_TRUE(upstream_request_->waitForEndStream(*dispatcher_));
+  // Upstream should receive 3000 bytes data.
+  EXPECT_EQ(upstream_request_->body().length(), body_size + init_body_size);
+
+  upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, true);
+  verifyDownstreamResponse(*response, 200);
+}
+
+} // namespace Envoy

--- a/test/extensions/filters/http/ext_proc/filter_test.cc
+++ b/test/extensions/filters/http/ext_proc/filter_test.cc
@@ -2017,6 +2017,9 @@ TEST_F(HttpFilterTest, PostStreamingBodiesDifferentOrder) {
     got_response_body.move(resp_chunk);
   }
 
+  EXPECT_CALL(encoder_callbacks_, injectEncodedDataToFilterChain(_, true))
+      .WillRepeatedly(Invoke(
+          [&got_response_body](Buffer::Instance& data, Unused) { got_response_body.move(data); }));
   Buffer::OwnedImpl last_resp_chunk;
   EXPECT_EQ(FilterDataStatus::StopIterationNoBuffer, filter_->encodeData(last_resp_chunk, true));
 


### PR DESCRIPTION
Fixes: https://github.com/envoyproxy/envoy/issues/36119

The issue is due to ext_proc failed to send the last empty chunk with end_stream = true to the backend server. This ends up causing a copy of the data stored in the decoding buffer for the retry purpose are sent again, which caused duplicate data is sent to backend server. The fix is simply having the ext_proc filter inject the last empty chunk to the filter chain and send to the backend server.