### PR TITLE
ratelimit: fix the RLS proto docs

### DIFF
--- a/api/envoy/config/route/v3/route_components.proto
+++ b/api/envoy/config/route/v3/route_components.proto
@@ -1932,9 +1932,18 @@ message RateLimit {
       // The key to use in the descriptor entry.
       string descriptor_key = 2 [(validate.rules).string = {min_len: 1}];
 
-      // If set to true, Envoy skips the descriptor while calling rate limiting service
-      // when header is not present in the request. By default it skips calling the
-      // rate limiting service if this header is not present in the request.
+      // Controls the behavior when the specified header is not present in the request.
+      //
+      // If set to ``false`` (default):
+      //
+      // * Envoy does **NOT** call the rate limiting service for this descriptor.
+      // * Useful if the header is optional and you prefer to skip rate limiting when it's absent.
+      //
+      // If set to ``true``:
+      //
+      // * Envoy calls the rate limiting service but omits this descriptor if the header is missing.
+      // * Useful if you want Envoy to enforce rate limiting even when the header is not present.
+      //
       bool skip_if_absent = 3;
     }
 
@@ -1955,13 +1964,15 @@ message RateLimit {
 
       // Controls the behavior when the specified query parameter is not present in the request.
       //
-      // If set to ``true`` (default is ``false``):
-      // - The rate limiting service will **NOT** be called for this descriptor.
-      // - Useful when the query parameter is optional and you want to skip rate limiting.
+      // If set to ``false`` (default):
       //
-      // If set to ``false``:
-      // - The rate limiting service will be called.
-      // - Useful when you want to enforce rate limiting even if the query parameter is missing.
+      // * Envoy does **NOT** call the rate limiting service for this descriptor.
+      // * Useful if the query parameter is optional and you prefer to skip rate limiting when it's absent.
+      //
+      // If set to ``true``:
+      //
+      // * Envoy calls the rate limiting service but omits this descriptor if the query parameter is missing.
+      // * Useful if you want Envoy to enforce rate limiting even when the query parameter is not present.
       //
       bool skip_if_absent = 3;
     }
@@ -2097,9 +2108,19 @@ message RateLimit {
       // Source of metadata
       Source source = 4 [(validate.rules).enum = {defined_only: true}];
 
-      // If set to true, Envoy skips the descriptor while calling rate limiting service
-      // when ``metadata_key`` is empty and ``default_value`` is not set. By default it skips calling the
-      // rate limiting service in that case.
+      // Controls the behavior when the specified ``metadata_key`` is empty and ``default_value`` is not set.
+      //
+      // If set to ``false`` (default):
+      //
+      // * Envoy does **NOT** call the rate limiting service for this descriptor.
+      // * Useful if the metadata is optional and you prefer to skip rate limiting when it's absent.
+      //
+      // If set to ``true``:
+      //
+      // * Envoy calls the rate limiting service but omits this descriptor if the ``metadata_key`` is empty and
+      //   ``default_value`` is missing.
+      // * Useful if you want Envoy to enforce rate limiting even when the metadata is not present.
+      //
       bool skip_if_absent = 5;
     }
 


### PR DESCRIPTION
## Description

This PR fixes some mistakes in the RateLimit proto. The query param `skip_if_absent` description is reversed and the styling is off.

We do what's mentioned to be part of flag = `true` when the flag is actually `false` and vice-versa.

<img width="913" alt="Screenshot 2025-01-14 at 08 30 42" src="https://github.com/user-attachments/assets/1d6348c1-31a5-4042-a9fe-c106777c7949" />

---

**Commit Message:** ratelimit: fix the RLS proto docs
**Additional Description:** Fix RateLimit proto docs.
**Risk Level:** N/A
**Testing:** N/A
**Docs Changes:** N/A
**Release Notes:** N/A