### PR TITLE
Remove QUIC forward declarations from filter.h

### DIFF
--- a/envoy/network/BUILD
+++ b/envoy/network/BUILD
@@ -119,6 +119,7 @@ envoy_cc_library(
     name = "filter_interface",
     hdrs = ["filter.h"],
     deps = [
+        "",
         ":listen_socket_interface",
         ":listener_filter_buffer_interface",
         ":transport_socket_interface",
@@ -127,6 +128,8 @@ envoy_cc_library(
         "//envoy/stream_info:stream_info_interface",
         "//envoy/upstream:host_description_interface",
         "//source/common/protobuf",
+        "@com_github_google_quiche//:quic_core_packets_lib",
+        "@com_github_google_quiche//:quic_platform_socket_address",
     ],
 )
 

--- a/envoy/network/filter.h
+++ b/envoy/network/filter.h
@@ -12,10 +12,8 @@
 
 #include "source/common/protobuf/protobuf.h"
 
-namespace quic {
-class QuicSocketAddress;
-class QuicReceivedPacket;
-} // namespace quic
+#include "quiche/quic/core/quic_packets.h"
+#include "quiche/quic/platform/api/quic_socket_address.h"
 
 namespace Envoy {
 


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Remove QUIC class forward declarations from filter.h
Additional Description: Replace forward declarations with imports
Risk Level: Low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
