### PR TITLE
lb: apis for async host resolution

### DIFF
--- a/envoy/upstream/load_balancer.h
+++ b/envoy/upstream/load_balancer.h
@@ -33,6 +33,10 @@ using ClusterProto = envoy::config::cluster::v3::Cluster;
  * If chooseHost returns a HostSelectionResponse with an AsyncHostSelectionHandle
  * handle, and the endpoint does not wish to receive onAsyncHostSelction call,
  * it must call cancel() on the provided handle.
+ *
+ * Please note that the AsyncHostSelectionHandle may be deleted after the
+ * cancel() call. It is up to the implemention of the asynchronous load balancer
+ * to ensure the cancelation state persists until the load balancer checks it.
  */
 class AsyncHostSelectionHandle {
 public:
@@ -53,10 +57,10 @@ public:
  */
 struct HostSelectionResponse {
   HostSelectionResponse(HostConstSharedPtr host,
-                        std::shared_ptr<AsyncHostSelectionHandle> cancelable = nullptr)
+                        std::unique_ptr<AsyncHostSelectionHandle> cancelable = nullptr)
       : host(host), cancelable(std::move(cancelable)) {}
   HostConstSharedPtr host;
-  std::shared_ptr<AsyncHostSelectionHandle> cancelable;
+  std::unique_ptr<AsyncHostSelectionHandle> cancelable;
 };
 
 /**

--- a/envoy/upstream/load_balancer.h
+++ b/envoy/upstream/load_balancer.h
@@ -28,6 +28,35 @@ namespace Upstream {
 
 using ClusterProto = envoy::config::cluster::v3::Cluster;
 
+/*
+ * A handle to allow cancelation of asynchronous host selection.
+ * If chooseHost returns a HostSelectionResponse with an AsyncHostSelection
+ * handle, and the endpoint does not wish to receive onAsyncHostSelction call,
+ * it must call cancel() on the provided handle.
+ */
+struct AsyncHostSelection {
+  virtual ~AsyncHostSelection() = default;
+  virtual void cancel() PURE;
+};
+
+/*
+ * The response to a LoadBalancer::chooseHost call.
+ *
+ * chooseHost either returns a host directly or, in the case of asynchronous
+ * load balancing, returns an AsyncHostSelection handle.
+ *
+ * If it returns a AsyncHostSelection handle, the load balancer guarantees an
+ * eventual call to LoadBalancerContext::onAsyncHostSelction unless
+ * AsyncHostSelection::cancel is called.
+ */
+struct HostSelectionResponse {
+  HostSelectionResponse(HostConstSharedPtr host,
+                        std::shared_ptr<AsyncHostSelection> cancelable = nullptr)
+      : host(host), cancelable(std::move(cancelable)) {}
+  HostConstSharedPtr host;
+  std::shared_ptr<AsyncHostSelection> cancelable;
+};
+
 /**
  * Context information passed to a load balancer to use when choosing a host. Not all load
  * balancers make use of all context information.
@@ -113,6 +142,11 @@ public:
    * and return the corresponding host directly.
    */
   virtual absl::optional<OverrideHost> overrideHostToSelect() const PURE;
+
+  /* Called by the load balancer when asynchronous host selection completes
+   * @param host supplies the upstream host selected
+   */
+  virtual void onAsyncHostSelection(HostConstSharedPtr host) PURE;
 };
 
 /**
@@ -130,13 +164,33 @@ class LoadBalancer {
 public:
   virtual ~LoadBalancer() = default;
 
+  /*
+   * This is a convenience wrapper function for code which does not yet support
+   * asynchronous host selection. It cancels any asynchronous lookup and treats
+   * it as host selection failure.
+   */
+  static HostConstSharedPtr
+  onlyAllowSynchronousHostSelection(HostSelectionResponse host_selection) {
+    if (host_selection.cancelable) {
+      // Async host selection not handled yet. Treat this as host selection
+      // failure.
+      host_selection.cancelable->cancel();
+    }
+    return std::move(host_selection.host);
+  }
+
   /**
    * Ask the load balancer for the next host to use depending on the underlying LB algorithm.
    * @param context supplies the load balancer context. Not all load balancers make use of all
    *        context information. Load balancers should be written to assume that context information
    *        is missing and use sensible defaults.
+   * @return a HostSelectionResponse either containing a host, or AsyncHostSelection handle.
+   *
+   * Please note that asynchronous host selection is not yet fully supported in
+   * Envoy. All endpoints will treat asynchronous resolution as host resolution
+   * failure. TODO(alyssawilk) land #38007
    */
-  virtual HostConstSharedPtr chooseHost(LoadBalancerContext* context) PURE;
+  virtual HostSelectionResponse chooseHost(LoadBalancerContext* context) PURE;
 
   /**
    * Returns a best effort prediction of the next host to be picked, or nullptr if not predictable.

--- a/envoy/upstream/thread_local_cluster.h
+++ b/envoy/upstream/thread_local_cluster.h
@@ -104,7 +104,7 @@ public:
    * @return host the next host selected by the load balancer or null if no host
    * is available.
    */
-  virtual HostConstSharedPtr chooseHost(LoadBalancerContext* context) PURE;
+  virtual HostSelectionResponse chooseHost(LoadBalancerContext* context) PURE;
 
   /**
    * Allocate a load balanced HTTP connection pool for a cluster. This is *per-thread* so that

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -195,9 +195,7 @@ private:
   RequestTrailerMap& addDecodedTrailers() override { PANIC("not implemented"); }
   void addDecodedData(Buffer::Instance&, bool) override {
     // This should only be called if the user has set up buffering. The request is already fully
-    // buffered. Note that this is only called via the async client's internal use of the router
-    // filter which uses this function for buffering.
-    ASSERT(buffered_body_ != nullptr);
+    // buffered so addDecodedData is a no-op.
   }
   MetadataMapVector& addDecodedMetadata() override { PANIC("not implemented"); }
   void injectDecodedDataToFilterChain(Buffer::Instance&, bool) override {}

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -195,7 +195,9 @@ private:
   RequestTrailerMap& addDecodedTrailers() override { PANIC("not implemented"); }
   void addDecodedData(Buffer::Instance&, bool) override {
     // This should only be called if the user has set up buffering. The request is already fully
-    // buffered so addDecodedData is a no-op.
+    // buffered. Note that this is only called via the async client's internal use of the router
+    // filter which uses this function for buffering.
+    ASSERT(buffered_body_ != nullptr);
   }
   MetadataMapVector& addDecodedMetadata() override { PANIC("not implemented"); }
   void injectDecodedDataToFilterChain(Buffer::Instance&, bool) override {}

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -863,7 +863,8 @@ Filter::createConnPool(Upstream::ThreadLocalCluster& thread_local_cluster) {
     }
   }
 
-  Upstream::HostConstSharedPtr host = thread_local_cluster.chooseHost(this);
+  Upstream::HostConstSharedPtr host = Upstream::LoadBalancer::onlyAllowSynchronousHostSelection(
+      thread_local_cluster.chooseHost(this));
   if (!host) {
     return nullptr;
   }

--- a/source/common/tcp_proxy/tcp_proxy.cc
+++ b/source/common/tcp_proxy/tcp_proxy.cc
@@ -569,7 +569,8 @@ bool Filter::maybeTunnel(Upstream::ThreadLocalCluster& cluster) {
             config_->regexEngine()),
         std::unique_ptr<Http::NullRouteImpl>);
   }
-  Upstream::HostConstSharedPtr host = cluster.chooseHost(this);
+  Upstream::HostConstSharedPtr host =
+      Upstream::LoadBalancer::onlyAllowSynchronousHostSelection(cluster.chooseHost(this));
   if (host) {
     generic_conn_pool_ = factory->createGenericConnPool(
         host, cluster, config_->tunnelingConfigHelper(), this, *upstream_callbacks_,

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -1247,7 +1247,7 @@ ClusterManagerImpl::ThreadLocalClusterManagerImpl::ClusterEntry::tcpConnPool(
 absl::optional<TcpPoolData>
 ClusterManagerImpl::ThreadLocalClusterManagerImpl::ClusterEntry::tcpConnPool(
     ResourcePriority priority, LoadBalancerContext* context) {
-  HostConstSharedPtr host = chooseHost(context);
+  HostConstSharedPtr host = LoadBalancer::onlyAllowSynchronousHostSelection(chooseHost(context));
   if (!host) {
     return absl::nullopt;
   }
@@ -1624,7 +1624,9 @@ void ClusterManagerImpl::postThreadLocalHealthFailure(const HostSharedPtr& host)
 
 Host::CreateConnectionData ClusterManagerImpl::ThreadLocalClusterManagerImpl::ClusterEntry::tcpConn(
     LoadBalancerContext* context) {
-  HostConstSharedPtr logical_host = chooseHost(context);
+  HostConstSharedPtr logical_host =
+      LoadBalancer::onlyAllowSynchronousHostSelection(chooseHost(context));
+
   if (logical_host) {
     auto conn_info = logical_host->createConnection(
         parent_.thread_local_dispatcher_, nullptr,
@@ -2214,23 +2216,25 @@ void ClusterManagerImpl::ThreadLocalClusterManagerImpl::httpConnPoolIsIdle(
   }
 }
 
-HostConstSharedPtr ClusterManagerImpl::ThreadLocalClusterManagerImpl::ClusterEntry::chooseHost(
+HostSelectionResponse ClusterManagerImpl::ThreadLocalClusterManagerImpl::ClusterEntry::chooseHost(
     LoadBalancerContext* context) {
   auto cross_priority_host_map = priority_set_.crossPriorityHostMap();
   HostConstSharedPtr host = HostUtility::selectOverrideHost(cross_priority_host_map.get(),
                                                             override_host_statuses_, context);
   if (host != nullptr) {
-    return host;
+    return {std::move(host), nullptr};
   }
+
   if (HostUtility::allowLBChooseHost(context)) {
-    host = lb_->chooseHost(context);
+    Upstream::HostSelectionResponse host_selection = lb_->chooseHost(context);
+    if (host_selection.host || host_selection.cancelable) {
+      return host_selection;
+    }
   }
-  if (host) {
-    return host;
-  }
+
   cluster_info_->trafficStats()->upstream_cx_none_healthy_.inc();
   ENVOY_LOG(debug, "no healthy host");
-  return nullptr;
+  return {nullptr};
 }
 
 HostConstSharedPtr ClusterManagerImpl::ThreadLocalClusterManagerImpl::ClusterEntry::peekAnotherHost(

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -2222,7 +2222,7 @@ HostSelectionResponse ClusterManagerImpl::ThreadLocalClusterManagerImpl::Cluster
   HostConstSharedPtr host = HostUtility::selectOverrideHost(cross_priority_host_map.get(),
                                                             override_host_statuses_, context);
   if (host != nullptr) {
-    return {std::move(host), nullptr};
+    return {std::move(host)};
   }
 
   if (HostUtility::allowLBChooseHost(context)) {

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -582,7 +582,7 @@ private:
       const PrioritySet& prioritySet() override { return priority_set_; }
       ClusterInfoConstSharedPtr info() override { return cluster_info_; }
       LoadBalancer& loadBalancer() override { return *lb_; }
-      HostConstSharedPtr chooseHost(LoadBalancerContext* context) override;
+      HostSelectionResponse chooseHost(LoadBalancerContext* context) override;
       absl::optional<HttpPoolData> httpConnPool(HostConstSharedPtr host, ResourcePriority priority,
                                                 absl::optional<Http::Protocol> downstream_protocol,
                                                 LoadBalancerContext* context) override;

--- a/source/common/upstream/load_balancer_context_base.h
+++ b/source/common/upstream/load_balancer_context_base.h
@@ -34,6 +34,8 @@ public:
   }
 
   absl::optional<OverrideHost> overrideHostToSelect() const override { return {}; }
+
+  void onAsyncHostSelection(HostConstSharedPtr) override {}
 };
 
 } // namespace Upstream

--- a/source/common/upstream/load_balancer_context_base.h
+++ b/source/common/upstream/load_balancer_context_base.h
@@ -35,7 +35,7 @@ public:
 
   absl::optional<OverrideHost> overrideHostToSelect() const override { return {}; }
 
-  void onAsyncHostSelection(HostConstSharedPtr) override {}
+  void onAsyncHostSelection(HostConstSharedPtr&&) override {}
 };
 
 } // namespace Upstream

--- a/source/extensions/clusters/aggregate/cluster.cc
+++ b/source/extensions/clusters/aggregate/cluster.cc
@@ -150,7 +150,7 @@ absl::optional<uint32_t> AggregateClusterLoadBalancer::LoadBalancerImpl::hostToL
   }
 }
 
-Upstream::HostConstSharedPtr
+Upstream::HostSelectionResponse
 AggregateClusterLoadBalancer::LoadBalancerImpl::chooseHost(Upstream::LoadBalancerContext* context) {
   const Upstream::HealthyAndDegradedLoad* priority_loads = nullptr;
   if (context != nullptr) {
@@ -174,12 +174,12 @@ AggregateClusterLoadBalancer::LoadBalancerImpl::chooseHost(Upstream::LoadBalance
   return cluster->loadBalancer().chooseHost(&aggregate_context);
 }
 
-Upstream::HostConstSharedPtr
+Upstream::HostSelectionResponse
 AggregateClusterLoadBalancer::chooseHost(Upstream::LoadBalancerContext* context) {
   if (load_balancer_) {
     return load_balancer_->chooseHost(context);
   }
-  return nullptr;
+  return {nullptr};
 }
 
 Upstream::HostConstSharedPtr

--- a/source/extensions/clusters/aggregate/cluster.h
+++ b/source/extensions/clusters/aggregate/cluster.h
@@ -80,7 +80,7 @@ public:
   void onClusterRemoval(const std::string& cluster_name) override;
 
   // Upstream::LoadBalancer
-  Upstream::HostConstSharedPtr chooseHost(Upstream::LoadBalancerContext* context) override;
+  Upstream::HostSelectionResponse chooseHost(Upstream::LoadBalancerContext* context) override;
   Upstream::HostConstSharedPtr peekAnotherHost(Upstream::LoadBalancerContext*) override;
   absl::optional<Upstream::SelectedPoolAndConnection>
   selectExistingConnection(Upstream::LoadBalancerContext* /*context*/,
@@ -102,7 +102,7 @@ private:
           priority_context_(priority_context) {}
 
     // Upstream::LoadBalancer
-    Upstream::HostConstSharedPtr chooseHost(Upstream::LoadBalancerContext* context) override;
+    Upstream::HostSelectionResponse chooseHost(Upstream::LoadBalancerContext* context) override;
     // Preconnecting not yet implemented for extensions.
     Upstream::HostConstSharedPtr peekAnotherHost(Upstream::LoadBalancerContext*) override {
       return nullptr;

--- a/source/extensions/clusters/dynamic_forward_proxy/cluster.h
+++ b/source/extensions/clusters/dynamic_forward_proxy/cluster.h
@@ -44,8 +44,8 @@ public:
 
   bool allowCoalescedConnections() const { return allow_coalesced_connections_; }
   bool enableSubCluster() const override { return enable_sub_cluster_; }
-  Upstream::HostConstSharedPtr chooseHost(absl::string_view host,
-                                          Upstream::LoadBalancerContext* context) const;
+  Upstream::HostSelectionResponse chooseHost(absl::string_view host,
+                                             Upstream::LoadBalancerContext* context) const;
 
   // Extensions::Common::DynamicForwardProxy::DfpCluster
   std::pair<bool, absl::optional<envoy::config::cluster::v3::Cluster>>
@@ -98,7 +98,7 @@ private:
     // DfpLb
     Upstream::HostConstSharedPtr findHostByName(const std::string& host) const override;
     // Upstream::LoadBalancer
-    Upstream::HostConstSharedPtr chooseHost(Upstream::LoadBalancerContext* context) override;
+    Upstream::HostSelectionResponse chooseHost(Upstream::LoadBalancerContext* context) override;
     // Preconnecting not implemented.
     Upstream::HostConstSharedPtr peekAnotherHost(Upstream::LoadBalancerContext*) override {
       return nullptr;

--- a/source/extensions/clusters/original_dst/original_dst_cluster.cc
+++ b/source/extensions/clusters/original_dst/original_dst_cluster.cc
@@ -29,7 +29,7 @@ OriginalDstClusterHandle::~OriginalDstClusterHandle() {
   dispatcher.post([cluster = std::move(cluster)]() mutable { cluster.reset(); });
 }
 
-HostConstSharedPtr OriginalDstCluster::LoadBalancer::chooseHost(LoadBalancerContext* context) {
+HostSelectionResponse OriginalDstCluster::LoadBalancer::chooseHost(LoadBalancerContext* context) {
   if (context) {
     // Check if filter state override is present, if yes use it before anything else.
     Network::Address::InstanceConstSharedPtr dst_host = filterStateOverrideHost(context);
@@ -91,7 +91,7 @@ HostConstSharedPtr OriginalDstCluster::LoadBalancer::chooseHost(LoadBalancerCont
             parent->cluster_->addHost(host);
           }
         });
-        return host;
+        return {host};
       } else {
         ENVOY_LOG(debug, "Failed to create host for {}.", dst_addr.asString());
       }
@@ -99,7 +99,7 @@ HostConstSharedPtr OriginalDstCluster::LoadBalancer::chooseHost(LoadBalancerCont
   }
   // TODO(ramaraochavali): add a stat and move this log line to debug.
   ENVOY_LOG(warn, "original_dst_load_balancer: No downstream connection or no original_dst.");
-  return nullptr;
+  return {nullptr};
 }
 
 Network::Address::InstanceConstSharedPtr

--- a/source/extensions/clusters/original_dst/original_dst_cluster.h
+++ b/source/extensions/clusters/original_dst/original_dst_cluster.h
@@ -95,7 +95,7 @@ public:
           host_map_(parent->cluster_->getCurrentHostMap()) {}
 
     // Upstream::LoadBalancer
-    HostConstSharedPtr chooseHost(LoadBalancerContext* context) override;
+    HostSelectionResponse chooseHost(LoadBalancerContext* context) override;
     // Preconnecting is not implemented for OriginalDstCluster
     HostConstSharedPtr peekAnotherHost(LoadBalancerContext*) override { return nullptr; }
     // Pool selection not implemented for OriginalDstCluster

--- a/source/extensions/clusters/redis/redis_cluster_lb.cc
+++ b/source/extensions/clusters/redis/redis_cluster_lb.cc
@@ -126,10 +126,11 @@ Upstream::HostConstSharedPtr chooseRandomHost(const Upstream::HostSetImpl& host_
 }
 } // namespace
 
-Upstream::HostConstSharedPtr RedisClusterLoadBalancerFactory::RedisClusterLoadBalancer::chooseHost(
+Upstream::HostSelectionResponse
+RedisClusterLoadBalancerFactory::RedisClusterLoadBalancer::chooseHost(
     Envoy::Upstream::LoadBalancerContext* context) {
   if (!slot_array_) {
-    return nullptr;
+    return {nullptr};
   }
   absl::optional<uint64_t> hash;
   if (context) {
@@ -137,7 +138,7 @@ Upstream::HostConstSharedPtr RedisClusterLoadBalancerFactory::RedisClusterLoadBa
   }
 
   if (!hash) {
-    return nullptr;
+    return {nullptr};
   }
 
   RedisShardSharedPtr shard;
@@ -145,7 +146,7 @@ Upstream::HostConstSharedPtr RedisClusterLoadBalancerFactory::RedisClusterLoadBa
     if (hash.value() < shard_vector_->size()) {
       shard = shard_vector_->at(hash.value());
     } else {
-      return nullptr;
+      return {nullptr};
     }
   } else {
     shard = shard_vector_->at(

--- a/source/extensions/clusters/redis/redis_cluster_lb.h
+++ b/source/extensions/clusters/redis/redis_cluster_lb.h
@@ -219,7 +219,7 @@ private:
           random_(random) {}
 
     // Upstream::LoadBalancerBase
-    Upstream::HostConstSharedPtr chooseHost(Upstream::LoadBalancerContext*) override;
+    Upstream::HostSelectionResponse chooseHost(Upstream::LoadBalancerContext*) override;
     Upstream::HostConstSharedPtr peekAnotherHost(Upstream::LoadBalancerContext*) override {
       return nullptr;
     }

--- a/source/extensions/filters/network/redis_proxy/conn_pool_impl.cc
+++ b/source/extensions/filters/network/redis_proxy/conn_pool_impl.cc
@@ -291,7 +291,8 @@ uint16_t InstanceImpl::ThreadLocalPool::shardSize() {
   for (uint16_t size = 0;; size++) {
     Clusters::Redis::RedisSpecifyShardContextImpl lb_context(
         size, request, Common::Redis::Client::ReadPolicy::Primary);
-    Upstream::HostConstSharedPtr host = cluster_->loadBalancer().chooseHost(&lb_context);
+    Upstream::HostConstSharedPtr host = Upstream::LoadBalancer::onlyAllowSynchronousHostSelection(
+        cluster_->loadBalancer().chooseHost(&lb_context));
     if (!host) {
       return size;
     }
@@ -313,7 +314,8 @@ InstanceImpl::ThreadLocalPool::makeRequest(const std::string& key, RespVariant&&
       key, config_->enableHashtagging(), is_redis_cluster_, getRequest(request),
       transaction.active_ ? Common::Redis::Client::ReadPolicy::Primary : config_->readPolicy());
 
-  Upstream::HostConstSharedPtr host = cluster_->loadBalancer().chooseHost(&lb_context);
+  Upstream::HostConstSharedPtr host = Upstream::LoadBalancer::onlyAllowSynchronousHostSelection(
+      cluster_->loadBalancer().chooseHost(&lb_context));
   if (!host) {
     ENVOY_LOG(debug, "host not found: '{}'", key);
     return nullptr;
@@ -336,7 +338,8 @@ InstanceImpl::ThreadLocalPool::makeRequestToShard(uint16_t shard_index, RespVari
       shard_index, getRequest(request),
       transaction.active_ ? Common::Redis::Client::ReadPolicy::Primary : config_->readPolicy());
 
-  Upstream::HostConstSharedPtr host = cluster_->loadBalancer().chooseHost(&lb_context);
+  Upstream::HostConstSharedPtr host = Upstream::LoadBalancer::onlyAllowSynchronousHostSelection(
+      cluster_->loadBalancer().chooseHost(&lb_context));
   if (!host) {
     ENVOY_LOG(debug, "host not found: '{}'", shard_index);
     return nullptr;

--- a/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.cc
+++ b/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.cc
@@ -105,7 +105,8 @@ Network::FilterStatus StickySessionUdpProxyFilter::onDataInternal(Network::UdpRe
       ClusterInfo* cluster = active_session->cluster();
       ASSERT(cluster);
 
-      auto host = cluster->chooseHost(data.addresses_.peer_, nullptr);
+      auto host = Upstream::LoadBalancer::onlyAllowSynchronousHostSelection(
+          cluster->chooseHost(data.addresses_.peer_, nullptr));
       if (host != nullptr && host->coarseHealth() != Upstream::Host::Health::Unhealthy &&
           host.get() != &active_session->host().value().get()) {
         ENVOY_LOG(debug, "upstream session unhealthy, recreating the session");
@@ -130,7 +131,8 @@ PerPacketLoadBalancingUdpProxyFilter::onDataInternal(Network::UdpRecvData& data)
     return Network::FilterStatus::StopIteration;
   }
 
-  auto host = cluster->chooseHost(data.addresses_.peer_, nullptr);
+  auto host = Upstream::LoadBalancer::onlyAllowSynchronousHostSelection(
+      cluster->chooseHost(data.addresses_.peer_, nullptr));
   if (host == nullptr) {
     ENVOY_LOG(debug, "cannot find any valid host.");
     cluster->cluster_info_->trafficStats()->upstream_cx_none_healthy_.inc();
@@ -266,7 +268,8 @@ UdpProxyFilter::createSession(Network::UdpRecvData::LocalPeerAddresses&& address
     return nullptr;
   }
 
-  auto host = cluster->chooseHost(addresses.peer_, nullptr);
+  auto host = Upstream::LoadBalancer::onlyAllowSynchronousHostSelection(
+      cluster->chooseHost(addresses.peer_, nullptr));
   if (host == nullptr) {
     ENVOY_LOG(debug, "cannot find any valid host.");
     cluster->cluster_info_->trafficStats()->upstream_cx_none_healthy_.inc();
@@ -303,11 +306,12 @@ UdpProxyFilter::createSessionWithOptionalHost(Network::UdpRecvData::LocalPeerAdd
   return nullptr;
 }
 
-Upstream::HostConstSharedPtr UdpProxyFilter::ClusterInfo::chooseHost(
+Upstream::HostSelectionResponse UdpProxyFilter::ClusterInfo::chooseHost(
     const Network::Address::InstanceConstSharedPtr& peer_address,
     StreamInfo::StreamInfo* stream_info) const {
   UdpLoadBalancerContext context(filter_.config_->hashPolicy(), peer_address, stream_info);
-  Upstream::HostConstSharedPtr host = cluster_.loadBalancer().chooseHost(&context);
+  Upstream::HostConstSharedPtr host = Upstream::LoadBalancer::onlyAllowSynchronousHostSelection(
+      cluster_.loadBalancer().chooseHost(&context));
   return host;
 }
 
@@ -588,7 +592,8 @@ bool UdpProxyFilter::UdpActiveSession::createUpstream() {
   }
 
   if (!host_) {
-    host_ = cluster_->chooseHost(addresses_.peer_, &udp_session_info_);
+    host_ = Upstream::LoadBalancer::onlyAllowSynchronousHostSelection(
+        cluster_->chooseHost(addresses_.peer_, &udp_session_info_));
     if (host_ == nullptr) {
       ENVOY_LOG(debug, "cannot find any valid host.");
       cluster_->cluster_info_->trafficStats()->upstream_cx_none_healthy_.inc();
@@ -902,7 +907,8 @@ TunnelingConnectionPoolImpl::TunnelingConnectionPoolImpl(
       downstream_info_(downstream_info) {
   // TODO(ohadvano): support upstream HTTP/3.
   absl::optional<Http::Protocol> protocol = Http::Protocol::Http2;
-  auto host = thread_local_cluster.loadBalancer().chooseHost(context);
+  auto host = Upstream::LoadBalancer::onlyAllowSynchronousHostSelection(
+      thread_local_cluster.loadBalancer().chooseHost(context));
   conn_pool_data_ = thread_local_cluster.httpConnPool(host, Upstream::ResourcePriority::Default,
                                                       protocol, context);
 }

--- a/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.h
+++ b/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.h
@@ -865,7 +865,7 @@ protected:
       host_to_sessions_[host].emplace(session);
     }
 
-    Upstream::HostConstSharedPtr
+    Upstream::HostSelectionResponse
     chooseHost(const Network::Address::InstanceConstSharedPtr& peer_address,
                StreamInfo::StreamInfo* stream_info) const;
 

--- a/source/extensions/load_balancing_policies/common/load_balancer_impl.cc
+++ b/source/extensions/load_balancing_policies/common/load_balancer_impl.cc
@@ -585,7 +585,7 @@ bool ZoneAwareLoadBalancerBase::earlyExitNonLocalityRouting() {
   return false;
 }
 
-HostConstSharedPtr ZoneAwareLoadBalancerBase::chooseHost(LoadBalancerContext* context) {
+HostSelectionResponse ZoneAwareLoadBalancerBase::chooseHost(LoadBalancerContext* context) {
   HostConstSharedPtr host;
 
   const size_t max_attempts = context ? context->hostSelectionRetryCount() + 1 : 1;

--- a/source/extensions/load_balancing_policies/common/load_balancer_impl.h
+++ b/source/extensions/load_balancing_policies/common/load_balancer_impl.h
@@ -237,7 +237,7 @@ class ZoneAwareLoadBalancerBase : public LoadBalancerBase {
 public:
   using LocalityLbConfig = envoy::extensions::load_balancing_policies::common::v3::LocalityLbConfig;
 
-  HostConstSharedPtr chooseHost(LoadBalancerContext* context) override;
+  HostSelectionResponse chooseHost(LoadBalancerContext* context) override;
 
 protected:
   // Both priority_set and local_priority_set if non-null must have at least one host set.

--- a/source/extensions/load_balancing_policies/common/thread_aware_lb_impl.h
+++ b/source/extensions/load_balancing_policies/common/thread_aware_lb_impl.h
@@ -32,7 +32,7 @@ public:
   class HashingLoadBalancer {
   public:
     virtual ~HashingLoadBalancer() = default;
-    virtual HostConstSharedPtr chooseHost(uint64_t hash, uint32_t attempt) const PURE;
+    virtual HostSelectionResponse chooseHost(uint64_t hash, uint32_t attempt) const PURE;
     const absl::string_view hashKey(HostConstSharedPtr host, bool use_hostname) const {
       const ProtobufWkt::Value& val = Config::Metadata::metadataValue(
           host->metadata().get(), Config::MetadataFilters::get().ENVOY_LB,
@@ -67,7 +67,7 @@ public:
       ASSERT(hashing_lb_ptr_ != nullptr);
       ASSERT(hash_balance_factor > 0);
     }
-    HostConstSharedPtr chooseHost(uint64_t hash, uint32_t attempt) const override;
+    HostSelectionResponse chooseHost(uint64_t hash, uint32_t attempt) const override;
 
   protected:
     virtual double hostOverloadFactor(const Host& host, double weight) const;
@@ -91,7 +91,7 @@ public:
   absl::Status initialize() override;
 
   // Upstream::LoadBalancer
-  HostConstSharedPtr chooseHost(LoadBalancerContext*) override { return nullptr; }
+  HostSelectionResponse chooseHost(LoadBalancerContext*) override { return {nullptr}; }
   // Preconnect not implemented for hash based load balancing
   HostConstSharedPtr peekAnotherHost(LoadBalancerContext*) override { return nullptr; }
   // Pool selection not implemented.
@@ -126,7 +126,7 @@ private:
         : stats_(stats), random_(random) {}
 
     // Upstream::LoadBalancer
-    HostConstSharedPtr chooseHost(LoadBalancerContext* context) override;
+    HostSelectionResponse chooseHost(LoadBalancerContext* context) override;
     // Preconnect not implemented for hash based load balancing
     HostConstSharedPtr peekAnotherHost(LoadBalancerContext*) override { return nullptr; }
     absl::optional<Upstream::SelectedPoolAndConnection>

--- a/source/extensions/load_balancing_policies/maglev/maglev_lb.cc
+++ b/source/extensions/load_balancing_policies/maglev/maglev_lb.cc
@@ -262,8 +262,7 @@ HostSelectionResponse OriginalMaglevTable::chooseHost(uint64_t hash, uint32_t at
     hash ^= ~0ULL - attempt + 1;
   }
 
-  HostConstSharedPtr host = table_[hash % table_size_];
-  return {std::move(host)};
+  return {table_[hash % table_size_]};
 }
 
 HostSelectionResponse CompactMaglevTable::chooseHost(uint64_t hash, uint32_t attempt) const {
@@ -280,8 +279,7 @@ HostSelectionResponse CompactMaglevTable::chooseHost(uint64_t hash, uint32_t att
 
   const uint32_t index = table_.get(hash % table_size_);
   ASSERT(index < host_table_.size(), "Compact MaglevTable index into host table out of range");
-  HostConstSharedPtr host = host_table_[index];
-  return {std::move(host)};
+  return {host_table_[index]};
 }
 
 uint64_t MaglevTable::permutation(const TableBuildEntry& entry) {

--- a/source/extensions/load_balancing_policies/maglev/maglev_lb.cc
+++ b/source/extensions/load_balancing_policies/maglev/maglev_lb.cc
@@ -250,9 +250,9 @@ void CompactMaglevTable::logMaglevTable(bool use_hostname_for_hashing) const {
 MaglevTable::MaglevTable(uint64_t table_size, MaglevLoadBalancerStats& stats)
     : table_size_(table_size), stats_(stats) {}
 
-HostConstSharedPtr OriginalMaglevTable::chooseHost(uint64_t hash, uint32_t attempt) const {
+HostSelectionResponse OriginalMaglevTable::chooseHost(uint64_t hash, uint32_t attempt) const {
   if (table_.empty()) {
-    return nullptr;
+    return {nullptr};
   }
 
   if (attempt > 0) {
@@ -262,12 +262,13 @@ HostConstSharedPtr OriginalMaglevTable::chooseHost(uint64_t hash, uint32_t attem
     hash ^= ~0ULL - attempt + 1;
   }
 
-  return table_[hash % table_size_];
+  HostConstSharedPtr host = table_[hash % table_size_];
+  return {std::move(host)};
 }
 
-HostConstSharedPtr CompactMaglevTable::chooseHost(uint64_t hash, uint32_t attempt) const {
+HostSelectionResponse CompactMaglevTable::chooseHost(uint64_t hash, uint32_t attempt) const {
   if (host_table_.empty()) {
-    return nullptr;
+    return {nullptr};
   }
 
   if (attempt > 0) {
@@ -279,7 +280,8 @@ HostConstSharedPtr CompactMaglevTable::chooseHost(uint64_t hash, uint32_t attemp
 
   const uint32_t index = table_.get(hash % table_size_);
   ASSERT(index < host_table_.size(), "Compact MaglevTable index into host table out of range");
-  return host_table_[index];
+  HostConstSharedPtr host = host_table_[index];
+  return {std::move(host)};
 }
 
 uint64_t MaglevTable::permutation(const TableBuildEntry& entry) {

--- a/source/extensions/load_balancing_policies/maglev/maglev_lb.h
+++ b/source/extensions/load_balancing_policies/maglev/maglev_lb.h
@@ -135,7 +135,7 @@ public:
   ~OriginalMaglevTable() override = default;
 
   // ThreadAwareLoadBalancerBase::HashingLoadBalancer
-  HostConstSharedPtr chooseHost(uint64_t hash, uint32_t attempt) const override;
+  HostSelectionResponse chooseHost(uint64_t hash, uint32_t attempt) const override;
 
 private:
   void constructImplementationInternals(std::vector<TableBuildEntry>& table_build_entries,
@@ -159,7 +159,7 @@ public:
   ~CompactMaglevTable() override = default;
 
   // ThreadAwareLoadBalancerBase::HashingLoadBalancer
-  HostConstSharedPtr chooseHost(uint64_t hash, uint32_t attempt) const override;
+  HostSelectionResponse chooseHost(uint64_t hash, uint32_t attempt) const override;
 
 private:
   void constructImplementationInternals(std::vector<TableBuildEntry>& table_build_entries,

--- a/source/extensions/load_balancing_policies/ring_hash/ring_hash_lb.cc
+++ b/source/extensions/load_balancing_policies/ring_hash/ring_hash_lb.cc
@@ -89,9 +89,9 @@ RingHashLoadBalancerStats RingHashLoadBalancer::generateStats(Stats::Scope& scop
   return {ALL_RING_HASH_LOAD_BALANCER_STATS(POOL_GAUGE(scope))};
 }
 
-HostConstSharedPtr RingHashLoadBalancer::Ring::chooseHost(uint64_t h, uint32_t attempt) const {
+HostSelectionResponse RingHashLoadBalancer::Ring::chooseHost(uint64_t h, uint32_t attempt) const {
   if (ring_.empty()) {
-    return nullptr;
+    return {nullptr};
   }
 
   // Ported from https://github.com/RJ/ketama/blob/master/libketama/ketama.c (ketama_get_server)

--- a/source/extensions/load_balancing_policies/ring_hash/ring_hash_lb.h
+++ b/source/extensions/load_balancing_policies/ring_hash/ring_hash_lb.h
@@ -100,7 +100,7 @@ private:
          bool use_hostname_for_hashing, RingHashLoadBalancerStats& stats);
 
     // ThreadAwareLoadBalancerBase::HashingLoadBalancer
-    HostConstSharedPtr chooseHost(uint64_t hash, uint32_t attempt) const override;
+    HostSelectionResponse chooseHost(uint64_t hash, uint32_t attempt) const override;
 
     std::vector<RingEntry> ring_;
 

--- a/source/extensions/load_balancing_policies/subset/subset_lb.h
+++ b/source/extensions/load_balancing_policies/subset/subset_lb.h
@@ -42,7 +42,7 @@ public:
   ~SubsetLoadBalancer() override;
 
   // Upstream::LoadBalancer
-  HostConstSharedPtr chooseHost(LoadBalancerContext* context) override;
+  HostSelectionResponse chooseHost(LoadBalancerContext* context) override;
   // TODO(alyssawilk) implement for non-metadata match.
   HostConstSharedPtr peekAnotherHost(LoadBalancerContext*) override { return nullptr; }
   // Pool selection not implemented.
@@ -199,6 +199,7 @@ public:
     absl::optional<OverrideHost> overrideHostToSelect() const override {
       return wrapped_->overrideHostToSelect();
     }
+    void onAsyncHostSelection(Upstream::HostConstSharedPtr) override {}
 
   private:
     LoadBalancerContext* wrapped_;
@@ -220,7 +221,7 @@ private:
   class LbSubset {
   public:
     virtual ~LbSubset() = default;
-    virtual HostConstSharedPtr chooseHost(LoadBalancerContext* context) const PURE;
+    virtual HostSelectionResponse chooseHost(LoadBalancerContext* context) const PURE;
     virtual void pushHost(uint32_t priority, HostSharedPtr host) PURE;
     virtual void finalize(uint32_t priority, uint64_t seed) PURE;
     virtual bool active() const PURE;
@@ -234,7 +235,7 @@ private:
         : subset_(subset_lb, locality_weight_aware, scale_locality_weight) {}
 
     // Subset
-    HostConstSharedPtr chooseHost(LoadBalancerContext* context) const override {
+    HostSelectionResponse chooseHost(LoadBalancerContext* context) const override {
       return subset_.lb_->chooseHost(context);
     }
     void pushHost(uint32_t priority, HostSharedPtr host) override {
@@ -280,7 +281,7 @@ private:
 
   class SingleHostLbSubset : public LbSubset {
     // Subset
-    HostConstSharedPtr chooseHost(LoadBalancerContext*) const override { return subset_; }
+    HostSelectionResponse chooseHost(LoadBalancerContext*) const override { return subset_; }
     // This is called at most once for every update for single host subset.
     void pushHost(uint32_t priority, HostSharedPtr host) override {
       new_hosts_[priority] = std::move(host);

--- a/source/extensions/load_balancing_policies/subset/subset_lb.h
+++ b/source/extensions/load_balancing_policies/subset/subset_lb.h
@@ -199,7 +199,7 @@ public:
     absl::optional<OverrideHost> overrideHostToSelect() const override {
       return wrapped_->overrideHostToSelect();
     }
-    void onAsyncHostSelection(Upstream::HostConstSharedPtr) override {}
+    void onAsyncHostSelection(Upstream::HostConstSharedPtr&&) override {}
 
   private:
     LoadBalancerContext* wrapped_;

--- a/test/common/grpc/grpc_client_integration_test_harness.h
+++ b/test/common/grpc/grpc_client_integration_test_harness.h
@@ -348,7 +348,8 @@ public:
                                                     host_ptr_, Upstream::ResourcePriority::Default,
                                                     nullptr, nullptr, state_);
     EXPECT_CALL(cm_.thread_local_cluster_, chooseHost(_))
-        .WillRepeatedly(Return(cm_.thread_local_cluster_.lb_.host_));
+        .WillRepeatedly(
+            Return(Upstream::HostSelectionResponse{cm_.thread_local_cluster_.lb_.host_}));
     EXPECT_CALL(cm_.thread_local_cluster_, httpConnPool(_, _, _, _))
         .WillRepeatedly(Return(Upstream::HttpPoolData([]() {}, http_conn_pool_.get())));
     http_async_client_ = std::make_unique<Http::AsyncClientImpl>(

--- a/test/common/grpc/grpc_client_integration_test_harness.h
+++ b/test/common/grpc/grpc_client_integration_test_harness.h
@@ -347,9 +347,9 @@ public:
     http_conn_pool_ = Http::Http2::allocateConnPool(*dispatcher_, api_->randomGenerator(),
                                                     host_ptr_, Upstream::ResourcePriority::Default,
                                                     nullptr, nullptr, state_);
-    EXPECT_CALL(cm_.thread_local_cluster_, chooseHost(_))
-        .WillRepeatedly(
-            Return(Upstream::HostSelectionResponse{cm_.thread_local_cluster_.lb_.host_}));
+    EXPECT_CALL(cm_.thread_local_cluster_, chooseHost(_)).WillRepeatedly(Invoke([this] {
+      return Upstream::HostSelectionResponse{cm_.thread_local_cluster_.lb_.host_};
+    }));
     EXPECT_CALL(cm_.thread_local_cluster_, httpConnPool(_, _, _, _))
         .WillRepeatedly(Return(Upstream::HttpPoolData([]() {}, http_conn_pool_.get())));
     http_async_client_ = std::make_unique<Http::AsyncClientImpl>(

--- a/test/common/http/async_client_impl_test.cc
+++ b/test/common/http/async_client_impl_test.cc
@@ -57,9 +57,9 @@ public:
         .WillByDefault(ReturnRef(envoy::config::core::v3::Locality().default_instance()));
     cm_.initializeThreadLocalClusters({"fake_cluster"});
     HttpTestUtility::addDefaultHeaders(headers_);
-    ON_CALL(cm_.thread_local_cluster_, chooseHost(_))
-        .WillByDefault(
-            Return(Upstream::HostSelectionResponse{cm_.thread_local_cluster_.lb_.host_}));
+    ON_CALL(cm_.thread_local_cluster_, chooseHost(_)).WillByDefault(Invoke([this] {
+      return Upstream::HostSelectionResponse{cm_.thread_local_cluster_.lb_.host_};
+    }));
   }
 
   virtual void expectSuccess(AsyncClient::Request* sent_request, uint64_t code) {

--- a/test/common/http/async_client_impl_test.cc
+++ b/test/common/http/async_client_impl_test.cc
@@ -58,7 +58,8 @@ public:
     cm_.initializeThreadLocalClusters({"fake_cluster"});
     HttpTestUtility::addDefaultHeaders(headers_);
     ON_CALL(cm_.thread_local_cluster_, chooseHost(_))
-        .WillByDefault(Return(cm_.thread_local_cluster_.lb_.host_));
+        .WillByDefault(
+            Return(Upstream::HostSelectionResponse{cm_.thread_local_cluster_.lb_.host_}));
   }
 
   virtual void expectSuccess(AsyncClient::Request* sent_request, uint64_t code) {

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -86,7 +86,8 @@ public:
       : RouterTestBase(false, false, false, false, Protobuf::RepeatedPtrField<std::string>{}) {
     EXPECT_CALL(callbacks_, activeSpan()).WillRepeatedly(ReturnRef(span_));
     ON_CALL(cm_.thread_local_cluster_, chooseHost(_))
-        .WillByDefault(Return(cm_.thread_local_cluster_.lb_.host_));
+        .WillByDefault(
+            Return(Upstream::HostSelectionResponse{cm_.thread_local_cluster_.lb_.host_}));
   };
 
   void testRequestResponse(bool with_trailers, bool can_use_http3 = true) {

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -85,9 +85,9 @@ public:
   RouterTest()
       : RouterTestBase(false, false, false, false, Protobuf::RepeatedPtrField<std::string>{}) {
     EXPECT_CALL(callbacks_, activeSpan()).WillRepeatedly(ReturnRef(span_));
-    ON_CALL(cm_.thread_local_cluster_, chooseHost(_))
-        .WillByDefault(
-            Return(Upstream::HostSelectionResponse{cm_.thread_local_cluster_.lb_.host_}));
+    ON_CALL(cm_.thread_local_cluster_, chooseHost(_)).WillByDefault(Invoke([this] {
+      return Upstream::HostSelectionResponse{cm_.thread_local_cluster_.lb_.host_};
+    }));
   };
 
   void testRequestResponse(bool with_trailers, bool can_use_http3 = true) {

--- a/test/common/router/router_test_base.cc
+++ b/test/common/router/router_test_base.cc
@@ -46,7 +46,7 @@ RouterTestBase::RouterTestBase(bool start_child_span, bool suppress_envoy_header
   EXPECT_CALL(callbacks_.route_->route_entry_.early_data_policy_, allowsEarlyDataForRequest(_))
       .WillRepeatedly(Invoke(Http::Utility::isSafeRequest));
   ON_CALL(cm_.thread_local_cluster_, chooseHost(_))
-      .WillByDefault(Return(cm_.thread_local_cluster_.lb_.host_));
+      .WillByDefault(Return(Upstream::HostSelectionResponse{cm_.thread_local_cluster_.lb_.host_}));
 }
 
 void RouterTestBase::expectResponseTimerCreate() {

--- a/test/common/router/router_test_base.cc
+++ b/test/common/router/router_test_base.cc
@@ -45,8 +45,9 @@ RouterTestBase::RouterTestBase(bool start_child_span, bool suppress_envoy_header
 
   EXPECT_CALL(callbacks_.route_->route_entry_.early_data_policy_, allowsEarlyDataForRequest(_))
       .WillRepeatedly(Invoke(Http::Utility::isSafeRequest));
-  ON_CALL(cm_.thread_local_cluster_, chooseHost(_))
-      .WillByDefault(Return(Upstream::HostSelectionResponse{cm_.thread_local_cluster_.lb_.host_}));
+  ON_CALL(cm_.thread_local_cluster_, chooseHost(_)).WillByDefault(Invoke([this] {
+    return Upstream::HostSelectionResponse{cm_.thread_local_cluster_.lb_.host_};
+  }));
 }
 
 void RouterTestBase::expectResponseTimerCreate() {

--- a/test/common/router/router_upstream_filter_test.cc
+++ b/test/common/router/router_upstream_filter_test.cc
@@ -88,8 +88,10 @@ public:
         locality())
         .WillByDefault(ReturnRef(upstream_locality_));
     ON_CALL(context_.server_factory_context_.cluster_manager_.thread_local_cluster_, chooseHost(_))
-        .WillByDefault(Return(Upstream::HostSelectionResponse{
-            context_.server_factory_context_.cluster_manager_.thread_local_cluster_.lb_.host_}));
+        .WillByDefault(Invoke([this] {
+          return Upstream::HostSelectionResponse{
+              context_.server_factory_context_.cluster_manager_.thread_local_cluster_.lb_.host_};
+        }));
     router_->downstream_connection_.stream_info_.downstream_connection_info_provider_
         ->setLocalAddress(host_address_);
     router_->downstream_connection_.stream_info_.downstream_connection_info_provider_

--- a/test/common/router/router_upstream_filter_test.cc
+++ b/test/common/router/router_upstream_filter_test.cc
@@ -88,8 +88,8 @@ public:
         locality())
         .WillByDefault(ReturnRef(upstream_locality_));
     ON_CALL(context_.server_factory_context_.cluster_manager_.thread_local_cluster_, chooseHost(_))
-        .WillByDefault(Return(
-            context_.server_factory_context_.cluster_manager_.thread_local_cluster_.lb_.host_));
+        .WillByDefault(Return(Upstream::HostSelectionResponse{
+            context_.server_factory_context_.cluster_manager_.thread_local_cluster_.lb_.host_}));
     router_->downstream_connection_.stream_info_.downstream_connection_info_provider_
         ->setLocalAddress(host_address_);
     router_->downstream_connection_.stream_info_.downstream_connection_info_provider_

--- a/test/common/router/router_upstream_log_test.cc
+++ b/test/common/router/router_upstream_log_test.cc
@@ -132,8 +132,8 @@ public:
         address())
         .WillByDefault(Return(host_address_));
     ON_CALL(context_.server_factory_context_.cluster_manager_.thread_local_cluster_, chooseHost(_))
-        .WillByDefault(Return(
-            context_.server_factory_context_.cluster_manager_.thread_local_cluster_.lb_.host_));
+        .WillByDefault(Return(Upstream::HostSelectionResponse{
+            context_.server_factory_context_.cluster_manager_.thread_local_cluster_.lb_.host_}));
     ON_CALL(
         *context_.server_factory_context_.cluster_manager_.thread_local_cluster_.conn_pool_.host_,
         locality())

--- a/test/common/router/router_upstream_log_test.cc
+++ b/test/common/router/router_upstream_log_test.cc
@@ -132,8 +132,10 @@ public:
         address())
         .WillByDefault(Return(host_address_));
     ON_CALL(context_.server_factory_context_.cluster_manager_.thread_local_cluster_, chooseHost(_))
-        .WillByDefault(Return(Upstream::HostSelectionResponse{
-            context_.server_factory_context_.cluster_manager_.thread_local_cluster_.lb_.host_}));
+        .WillByDefault(Invoke([this] {
+          return Upstream::HostSelectionResponse{
+              context_.server_factory_context_.cluster_manager_.thread_local_cluster_.lb_.host_};
+        }));
     ON_CALL(
         *context_.server_factory_context_.cluster_manager_.thread_local_cluster_.conn_pool_.host_,
         locality())

--- a/test/common/tcp_proxy/config_test.cc
+++ b/test/common/tcp_proxy/config_test.cc
@@ -683,8 +683,9 @@ public:
   TcpProxyNonDeprecatedConfigRoutingTest() {
     ON_CALL(factory_context_.server_factory_context_.cluster_manager_.thread_local_cluster_,
             chooseHost(_))
-        .WillByDefault(Return(factory_context_.server_factory_context_.cluster_manager_
-                                  .thread_local_cluster_.lb_.host_));
+        .WillByDefault(Return(Upstream::HostSelectionResponse{
+            factory_context_.server_factory_context_.cluster_manager_.thread_local_cluster_.lb_
+                .host_}));
   }
 
   void setup() {
@@ -745,8 +746,9 @@ public:
   void setup(const std::string& yaml) {
     ON_CALL(factory_context_.server_factory_context_.cluster_manager_.thread_local_cluster_,
             chooseHost(_))
-        .WillByDefault(Return(factory_context_.server_factory_context_.cluster_manager_
-                                  .thread_local_cluster_.lb_.host_));
+        .WillByDefault(Return(Upstream::HostSelectionResponse{
+            factory_context_.server_factory_context_.cluster_manager_.thread_local_cluster_.lb_
+                .host_}));
     factory_context_.server_factory_context_.cluster_manager_.initializeThreadLocalClusters(
         {"fake_cluster"});
     config_ = std::make_shared<Config>(constructConfigFromYaml(yaml, factory_context_));
@@ -798,8 +800,9 @@ TEST_F(TcpProxyHashingTest, HashWithSourceIp) {
     mock_connection.stream_info_.downstream_connection_info_provider_->setRemoteAddress(nullptr);
     ON_CALL(factory_context_.server_factory_context_.cluster_manager_.thread_local_cluster_,
             chooseHost(_))
-        .WillByDefault(Return(factory_context_.server_factory_context_.cluster_manager_
-                                  .thread_local_cluster_.lb_.host_));
+        .WillByDefault(Return(Upstream::HostSelectionResponse{
+            factory_context_.server_factory_context_.cluster_manager_.thread_local_cluster_.lb_
+                .host_}));
     EXPECT_CALL(factory_context_.server_factory_context_.cluster_manager_.thread_local_cluster_,
                 tcpConnPool(_, _, _))
         .WillOnce(Invoke([](Upstream::HostConstSharedPtr, Upstream::ResourcePriority,

--- a/test/common/tcp_proxy/config_test.cc
+++ b/test/common/tcp_proxy/config_test.cc
@@ -683,9 +683,11 @@ public:
   TcpProxyNonDeprecatedConfigRoutingTest() {
     ON_CALL(factory_context_.server_factory_context_.cluster_manager_.thread_local_cluster_,
             chooseHost(_))
-        .WillByDefault(Return(Upstream::HostSelectionResponse{
-            factory_context_.server_factory_context_.cluster_manager_.thread_local_cluster_.lb_
-                .host_}));
+        .WillByDefault(Invoke([this] {
+          return Upstream::HostSelectionResponse{
+              factory_context_.server_factory_context_.cluster_manager_.thread_local_cluster_.lb_
+                  .host_};
+        }));
   }
 
   void setup() {
@@ -746,9 +748,11 @@ public:
   void setup(const std::string& yaml) {
     ON_CALL(factory_context_.server_factory_context_.cluster_manager_.thread_local_cluster_,
             chooseHost(_))
-        .WillByDefault(Return(Upstream::HostSelectionResponse{
-            factory_context_.server_factory_context_.cluster_manager_.thread_local_cluster_.lb_
-                .host_}));
+        .WillByDefault(Invoke([this] {
+          return Upstream::HostSelectionResponse{
+              factory_context_.server_factory_context_.cluster_manager_.thread_local_cluster_.lb_
+                  .host_};
+        }));
     factory_context_.server_factory_context_.cluster_manager_.initializeThreadLocalClusters(
         {"fake_cluster"});
     config_ = std::make_shared<Config>(constructConfigFromYaml(yaml, factory_context_));
@@ -800,9 +804,11 @@ TEST_F(TcpProxyHashingTest, HashWithSourceIp) {
     mock_connection.stream_info_.downstream_connection_info_provider_->setRemoteAddress(nullptr);
     ON_CALL(factory_context_.server_factory_context_.cluster_manager_.thread_local_cluster_,
             chooseHost(_))
-        .WillByDefault(Return(Upstream::HostSelectionResponse{
-            factory_context_.server_factory_context_.cluster_manager_.thread_local_cluster_.lb_
-                .host_}));
+        .WillByDefault(Invoke([this] {
+          return Upstream::HostSelectionResponse{
+              factory_context_.server_factory_context_.cluster_manager_.thread_local_cluster_.lb_
+                  .host_};
+        }));
     EXPECT_CALL(factory_context_.server_factory_context_.cluster_manager_.thread_local_cluster_,
                 tcpConnPool(_, _, _))
         .WillOnce(Invoke([](Upstream::HostConstSharedPtr, Upstream::ResourcePriority,

--- a/test/common/tcp_proxy/tcp_proxy_test.cc
+++ b/test/common/tcp_proxy/tcp_proxy_test.cc
@@ -64,8 +64,9 @@ public:
   TcpProxyTest() {
     EXPECT_CALL(factory_context_.server_factory_context_.cluster_manager_.thread_local_cluster_,
                 chooseHost(_))
-        .WillRepeatedly(Return(factory_context_.server_factory_context_.cluster_manager_
-                                   .thread_local_cluster_.lb_.host_));
+        .WillRepeatedly(Return(Upstream::HostSelectionResponse{
+            factory_context_.server_factory_context_.cluster_manager_.thread_local_cluster_.lb_
+                .host_}));
   }
   using TcpProxyTestBase::setup;
   void setup(uint32_t connections, bool set_redirect_records,

--- a/test/common/tcp_proxy/tcp_proxy_test.cc
+++ b/test/common/tcp_proxy/tcp_proxy_test.cc
@@ -64,9 +64,11 @@ public:
   TcpProxyTest() {
     EXPECT_CALL(factory_context_.server_factory_context_.cluster_manager_.thread_local_cluster_,
                 chooseHost(_))
-        .WillRepeatedly(Return(Upstream::HostSelectionResponse{
-            factory_context_.server_factory_context_.cluster_manager_.thread_local_cluster_.lb_
-                .host_}));
+        .WillRepeatedly(Invoke([this] {
+          return Upstream::HostSelectionResponse{
+              factory_context_.server_factory_context_.cluster_manager_.thread_local_cluster_.lb_
+                  .host_};
+        }));
   }
   using TcpProxyTestBase::setup;
   void setup(uint32_t connections, bool set_redirect_records,

--- a/test/common/upstream/load_balancer_simulation_test.cc
+++ b/test/common/upstream/load_balancer_simulation_test.cc
@@ -116,7 +116,7 @@ void leastRequestLBWeightTest(LRLBTestParams params) {
       *time_source};
 
   for (uint64_t i = 0; i < num_requests; i++) {
-    host_hits[lb_.chooseHost(nullptr)]++;
+    host_hits[lb_.chooseHost(nullptr).host]++;
   }
 
   std::vector<double> observed_pcts;
@@ -268,7 +268,7 @@ public:
                             per_zone_local_shared),
           {}, empty_vector_, empty_vector_, random_.random(), absl::nullopt);
 
-      HostConstSharedPtr selected = lb.chooseHost(nullptr);
+      HostConstSharedPtr selected = lb.chooseHost(nullptr).host;
       hits[selected->address()->asString()]++;
     }
 

--- a/test/extensions/clusters/aggregate/cluster_test.cc
+++ b/test/extensions/clusters/aggregate/cluster_test.cc
@@ -180,13 +180,15 @@ TEST_F(AggregateClusterTest, LoadBalancerTest) {
   //     Priority 1: 33.3%
   Upstream::HostSharedPtr host =
       Upstream::makeTestHost(primary_info_, "tcp://127.0.0.1:80", simTime());
-  EXPECT_CALL(primary_load_balancer_, chooseHost(_)).WillRepeatedly(Return(host));
-  EXPECT_CALL(secondary_load_balancer_, chooseHost(_)).WillRepeatedly(Return(nullptr));
+  EXPECT_CALL(primary_load_balancer_, chooseHost(_))
+      .WillRepeatedly(Return(Upstream::HostSelectionResponse{host}));
+  EXPECT_CALL(secondary_load_balancer_, chooseHost(_))
+      .WillRepeatedly(Return(Upstream::HostSelectionResponse{nullptr}));
 
   for (int i = 0; i <= 65; ++i) {
     EXPECT_CALL(random_, random()).WillRepeatedly(Return(i));
     EXPECT_TRUE(lb_->peekAnotherHost(nullptr) == nullptr);
-    Upstream::HostConstSharedPtr target = lb_->chooseHost(nullptr);
+    Upstream::HostConstSharedPtr target = lb_->chooseHost(nullptr).host;
     OptRef<Envoy::Http::ConnectionPool::ConnectionLifetimeCallbacks> lifetime_callbacks =
         lb_->lifetimeCallbacks();
     EXPECT_FALSE(lifetime_callbacks.has_value());
@@ -197,11 +199,13 @@ TEST_F(AggregateClusterTest, LoadBalancerTest) {
     EXPECT_EQ(host.get(), target.get());
   }
 
-  EXPECT_CALL(primary_load_balancer_, chooseHost(_)).WillRepeatedly(Return(nullptr));
-  EXPECT_CALL(secondary_load_balancer_, chooseHost(_)).WillRepeatedly(Return(host));
+  EXPECT_CALL(primary_load_balancer_, chooseHost(_))
+      .WillRepeatedly(Return(Upstream::HostSelectionResponse{nullptr}));
+  EXPECT_CALL(secondary_load_balancer_, chooseHost(_))
+      .WillRepeatedly(Return(Upstream::HostSelectionResponse{host}));
   for (int i = 66; i < 100; ++i) {
     EXPECT_CALL(random_, random()).WillRepeatedly(Return(i));
-    Upstream::HostConstSharedPtr target = lb_->chooseHost(nullptr);
+    Upstream::HostConstSharedPtr target = lb_->chooseHost(nullptr).host;
     EXPECT_EQ(host.get(), target.get());
   }
 
@@ -215,20 +219,24 @@ TEST_F(AggregateClusterTest, LoadBalancerTest) {
   // Cluster 2:
   //     Priority 0: 33.3%
   //     Priority 1: 33.3%
-  EXPECT_CALL(primary_load_balancer_, chooseHost(_)).WillRepeatedly(Return(host));
-  EXPECT_CALL(secondary_load_balancer_, chooseHost(_)).WillRepeatedly(Return(nullptr));
+  EXPECT_CALL(primary_load_balancer_, chooseHost(_))
+      .WillRepeatedly(Return(Upstream::HostSelectionResponse{host}));
+  EXPECT_CALL(secondary_load_balancer_, chooseHost(_))
+      .WillRepeatedly(Return(Upstream::HostSelectionResponse{nullptr}));
 
   for (int i = 0; i <= 57; ++i) {
     EXPECT_CALL(random_, random()).WillRepeatedly(Return(i));
-    Upstream::HostConstSharedPtr target = lb_->chooseHost(nullptr);
+    Upstream::HostConstSharedPtr target = lb_->chooseHost(nullptr).host;
     EXPECT_EQ(host.get(), target.get());
   }
 
-  EXPECT_CALL(primary_load_balancer_, chooseHost(_)).WillRepeatedly(Return(nullptr));
-  EXPECT_CALL(secondary_load_balancer_, chooseHost(_)).WillRepeatedly(Return(host));
+  EXPECT_CALL(primary_load_balancer_, chooseHost(_))
+      .WillRepeatedly(Return(Upstream::HostSelectionResponse{nullptr}));
+  EXPECT_CALL(secondary_load_balancer_, chooseHost(_))
+      .WillRepeatedly(Return(Upstream::HostSelectionResponse{host}));
   for (int i = 58; i < 100; ++i) {
     EXPECT_CALL(random_, random()).WillRepeatedly(Return(i));
-    Upstream::HostConstSharedPtr target = lb_->chooseHost(nullptr);
+    Upstream::HostConstSharedPtr target = lb_->chooseHost(nullptr).host;
     EXPECT_EQ(host.get(), target.get());
   }
 }
@@ -251,23 +259,27 @@ TEST_F(AggregateClusterTest, AllHostAreUnhealthyTest) {
   // Cluster 2:
   //     Priority 0: 0%
   //     Priority 1: 0%
-  EXPECT_CALL(primary_load_balancer_, chooseHost(_)).WillRepeatedly(Return(host));
-  EXPECT_CALL(secondary_load_balancer_, chooseHost(_)).WillRepeatedly(Return(nullptr));
+  EXPECT_CALL(primary_load_balancer_, chooseHost(_))
+      .WillRepeatedly(Return(Upstream::HostSelectionResponse{host}));
+  EXPECT_CALL(secondary_load_balancer_, chooseHost(_))
+      .WillRepeatedly(Return(Upstream::HostSelectionResponse{nullptr}));
 
   // Choose the first cluster as the second one is unavailable.
   for (int i = 0; i < 50; ++i) {
     EXPECT_CALL(random_, random()).WillRepeatedly(Return(i));
-    Upstream::HostConstSharedPtr target = lb_->chooseHost(nullptr);
+    Upstream::HostConstSharedPtr target = lb_->chooseHost(nullptr).host;
     EXPECT_EQ(host.get(), target.get());
   }
 
-  EXPECT_CALL(primary_load_balancer_, chooseHost(_)).WillRepeatedly(Return(nullptr));
-  EXPECT_CALL(secondary_load_balancer_, chooseHost(_)).WillRepeatedly(Return(host));
+  EXPECT_CALL(primary_load_balancer_, chooseHost(_))
+      .WillRepeatedly(Return(Upstream::HostSelectionResponse{nullptr}));
+  EXPECT_CALL(secondary_load_balancer_, chooseHost(_))
+      .WillRepeatedly(Return(Upstream::HostSelectionResponse{host}));
 
   // Choose the second cluster as the first one is unavailable.
   for (int i = 50; i < 100; ++i) {
     EXPECT_CALL(random_, random()).WillRepeatedly(Return(i));
-    Upstream::HostConstSharedPtr target = lb_->chooseHost(nullptr);
+    Upstream::HostConstSharedPtr target = lb_->chooseHost(nullptr).host;
     EXPECT_EQ(host.get(), target.get());
   }
 }
@@ -288,21 +300,25 @@ TEST_F(AggregateClusterTest, ClusterInPanicTest) {
   //     Priority 0: 20%
   //     Priority 1: 20%
   // All priorities are in panic mode. Traffic will be distributed evenly among four priorities.
-  EXPECT_CALL(primary_load_balancer_, chooseHost(_)).WillRepeatedly(Return(host));
-  EXPECT_CALL(secondary_load_balancer_, chooseHost(_)).WillRepeatedly(Return(nullptr));
+  EXPECT_CALL(primary_load_balancer_, chooseHost(_))
+      .WillRepeatedly(Return(Upstream::HostSelectionResponse{host}));
+  EXPECT_CALL(secondary_load_balancer_, chooseHost(_))
+      .WillRepeatedly(Return(Upstream::HostSelectionResponse{nullptr}));
 
   for (int i = 0; i < 50; ++i) {
     EXPECT_CALL(random_, random()).WillRepeatedly(Return(i));
-    Upstream::HostConstSharedPtr target = lb_->chooseHost(nullptr);
+    Upstream::HostConstSharedPtr target = lb_->chooseHost(nullptr).host;
     EXPECT_EQ(host.get(), target.get());
   }
 
-  EXPECT_CALL(primary_load_balancer_, chooseHost(_)).WillRepeatedly(Return(nullptr));
-  EXPECT_CALL(secondary_load_balancer_, chooseHost(_)).WillRepeatedly(Return(host));
+  EXPECT_CALL(primary_load_balancer_, chooseHost(_))
+      .WillRepeatedly(Return(Upstream::HostSelectionResponse{nullptr}));
+  EXPECT_CALL(secondary_load_balancer_, chooseHost(_))
+      .WillRepeatedly(Return(Upstream::HostSelectionResponse{host}));
 
   for (int i = 50; i < 100; ++i) {
     EXPECT_CALL(random_, random()).WillRepeatedly(Return(i));
-    Upstream::HostConstSharedPtr target = lb_->chooseHost(nullptr);
+    Upstream::HostConstSharedPtr target = lb_->chooseHost(nullptr).host;
     EXPECT_EQ(host.get(), target.get());
   }
 
@@ -317,21 +333,25 @@ TEST_F(AggregateClusterTest, ClusterInPanicTest) {
   // Cluster 2:
   //     Priority 0: 10%
   //     Priority 0: 50%
-  EXPECT_CALL(primary_load_balancer_, chooseHost(_)).WillRepeatedly(Return(host));
-  EXPECT_CALL(secondary_load_balancer_, chooseHost(_)).WillRepeatedly(Return(nullptr));
+  EXPECT_CALL(primary_load_balancer_, chooseHost(_))
+      .WillRepeatedly(Return(Upstream::HostSelectionResponse{host}));
+  EXPECT_CALL(secondary_load_balancer_, chooseHost(_))
+      .WillRepeatedly(Return(Upstream::HostSelectionResponse{nullptr}));
 
   for (int i = 0; i <= 25; ++i) {
     EXPECT_CALL(random_, random()).WillRepeatedly(Return(i));
-    Upstream::HostConstSharedPtr target = lb_->chooseHost(nullptr);
+    Upstream::HostConstSharedPtr target = lb_->chooseHost(nullptr).host;
     EXPECT_EQ(host.get(), target.get());
   }
 
-  EXPECT_CALL(primary_load_balancer_, chooseHost(_)).WillRepeatedly(Return(nullptr));
-  EXPECT_CALL(secondary_load_balancer_, chooseHost(_)).WillRepeatedly(Return(host));
+  EXPECT_CALL(primary_load_balancer_, chooseHost(_))
+      .WillRepeatedly(Return(Upstream::HostSelectionResponse{nullptr}));
+  EXPECT_CALL(secondary_load_balancer_, chooseHost(_))
+      .WillRepeatedly(Return(Upstream::HostSelectionResponse{host}));
 
   for (int i = 26; i < 100; ++i) {
     EXPECT_CALL(random_, random()).WillRepeatedly(Return(i));
-    Upstream::HostConstSharedPtr target = lb_->chooseHost(nullptr);
+    Upstream::HostConstSharedPtr target = lb_->chooseHost(nullptr).host;
     EXPECT_EQ(host.get(), target.get());
   }
 }

--- a/test/extensions/clusters/aggregate/cluster_test.cc
+++ b/test/extensions/clusters/aggregate/cluster_test.cc
@@ -180,10 +180,12 @@ TEST_F(AggregateClusterTest, LoadBalancerTest) {
   //     Priority 1: 33.3%
   Upstream::HostSharedPtr host =
       Upstream::makeTestHost(primary_info_, "tcp://127.0.0.1:80", simTime());
-  EXPECT_CALL(primary_load_balancer_, chooseHost(_))
-      .WillRepeatedly(Return(Upstream::HostSelectionResponse{host}));
-  EXPECT_CALL(secondary_load_balancer_, chooseHost(_))
-      .WillRepeatedly(Return(Upstream::HostSelectionResponse{nullptr}));
+  EXPECT_CALL(primary_load_balancer_, chooseHost(_)).WillRepeatedly(Invoke([host] {
+    return Upstream::HostSelectionResponse{host};
+  }));
+  EXPECT_CALL(secondary_load_balancer_, chooseHost(_)).WillRepeatedly(Invoke([] {
+    return Upstream::HostSelectionResponse{nullptr};
+  }));
 
   for (int i = 0; i <= 65; ++i) {
     EXPECT_CALL(random_, random()).WillRepeatedly(Return(i));
@@ -199,10 +201,12 @@ TEST_F(AggregateClusterTest, LoadBalancerTest) {
     EXPECT_EQ(host.get(), target.get());
   }
 
-  EXPECT_CALL(primary_load_balancer_, chooseHost(_))
-      .WillRepeatedly(Return(Upstream::HostSelectionResponse{nullptr}));
-  EXPECT_CALL(secondary_load_balancer_, chooseHost(_))
-      .WillRepeatedly(Return(Upstream::HostSelectionResponse{host}));
+  EXPECT_CALL(primary_load_balancer_, chooseHost(_)).WillRepeatedly(Invoke([] {
+    return Upstream::HostSelectionResponse{nullptr};
+  }));
+  EXPECT_CALL(secondary_load_balancer_, chooseHost(_)).WillRepeatedly(Invoke([host] {
+    return Upstream::HostSelectionResponse{host};
+  }));
   for (int i = 66; i < 100; ++i) {
     EXPECT_CALL(random_, random()).WillRepeatedly(Return(i));
     Upstream::HostConstSharedPtr target = lb_->chooseHost(nullptr).host;
@@ -219,10 +223,12 @@ TEST_F(AggregateClusterTest, LoadBalancerTest) {
   // Cluster 2:
   //     Priority 0: 33.3%
   //     Priority 1: 33.3%
-  EXPECT_CALL(primary_load_balancer_, chooseHost(_))
-      .WillRepeatedly(Return(Upstream::HostSelectionResponse{host}));
-  EXPECT_CALL(secondary_load_balancer_, chooseHost(_))
-      .WillRepeatedly(Return(Upstream::HostSelectionResponse{nullptr}));
+  EXPECT_CALL(primary_load_balancer_, chooseHost(_)).WillRepeatedly(Invoke([host] {
+    return Upstream::HostSelectionResponse{host};
+  }));
+  EXPECT_CALL(secondary_load_balancer_, chooseHost(_)).WillRepeatedly(Invoke([] {
+    return Upstream::HostSelectionResponse{nullptr};
+  }));
 
   for (int i = 0; i <= 57; ++i) {
     EXPECT_CALL(random_, random()).WillRepeatedly(Return(i));
@@ -230,10 +236,12 @@ TEST_F(AggregateClusterTest, LoadBalancerTest) {
     EXPECT_EQ(host.get(), target.get());
   }
 
-  EXPECT_CALL(primary_load_balancer_, chooseHost(_))
-      .WillRepeatedly(Return(Upstream::HostSelectionResponse{nullptr}));
-  EXPECT_CALL(secondary_load_balancer_, chooseHost(_))
-      .WillRepeatedly(Return(Upstream::HostSelectionResponse{host}));
+  EXPECT_CALL(primary_load_balancer_, chooseHost(_)).WillRepeatedly(Invoke([] {
+    return Upstream::HostSelectionResponse{nullptr};
+  }));
+  EXPECT_CALL(secondary_load_balancer_, chooseHost(_)).WillRepeatedly(Invoke([host] {
+    return Upstream::HostSelectionResponse{host};
+  }));
   for (int i = 58; i < 100; ++i) {
     EXPECT_CALL(random_, random()).WillRepeatedly(Return(i));
     Upstream::HostConstSharedPtr target = lb_->chooseHost(nullptr).host;
@@ -259,10 +267,12 @@ TEST_F(AggregateClusterTest, AllHostAreUnhealthyTest) {
   // Cluster 2:
   //     Priority 0: 0%
   //     Priority 1: 0%
-  EXPECT_CALL(primary_load_balancer_, chooseHost(_))
-      .WillRepeatedly(Return(Upstream::HostSelectionResponse{host}));
-  EXPECT_CALL(secondary_load_balancer_, chooseHost(_))
-      .WillRepeatedly(Return(Upstream::HostSelectionResponse{nullptr}));
+  EXPECT_CALL(primary_load_balancer_, chooseHost(_)).WillRepeatedly(Invoke([host] {
+    return Upstream::HostSelectionResponse{host};
+  }));
+  EXPECT_CALL(secondary_load_balancer_, chooseHost(_)).WillRepeatedly(Invoke([] {
+    return Upstream::HostSelectionResponse{nullptr};
+  }));
 
   // Choose the first cluster as the second one is unavailable.
   for (int i = 0; i < 50; ++i) {
@@ -271,10 +281,12 @@ TEST_F(AggregateClusterTest, AllHostAreUnhealthyTest) {
     EXPECT_EQ(host.get(), target.get());
   }
 
-  EXPECT_CALL(primary_load_balancer_, chooseHost(_))
-      .WillRepeatedly(Return(Upstream::HostSelectionResponse{nullptr}));
-  EXPECT_CALL(secondary_load_balancer_, chooseHost(_))
-      .WillRepeatedly(Return(Upstream::HostSelectionResponse{host}));
+  EXPECT_CALL(primary_load_balancer_, chooseHost(_)).WillRepeatedly(Invoke([] {
+    return Upstream::HostSelectionResponse{nullptr};
+  }));
+  EXPECT_CALL(secondary_load_balancer_, chooseHost(_)).WillRepeatedly(Invoke([host] {
+    return Upstream::HostSelectionResponse{host};
+  }));
 
   // Choose the second cluster as the first one is unavailable.
   for (int i = 50; i < 100; ++i) {
@@ -300,10 +312,12 @@ TEST_F(AggregateClusterTest, ClusterInPanicTest) {
   //     Priority 0: 20%
   //     Priority 1: 20%
   // All priorities are in panic mode. Traffic will be distributed evenly among four priorities.
-  EXPECT_CALL(primary_load_balancer_, chooseHost(_))
-      .WillRepeatedly(Return(Upstream::HostSelectionResponse{host}));
-  EXPECT_CALL(secondary_load_balancer_, chooseHost(_))
-      .WillRepeatedly(Return(Upstream::HostSelectionResponse{nullptr}));
+  EXPECT_CALL(primary_load_balancer_, chooseHost(_)).WillRepeatedly(Invoke([host] {
+    return Upstream::HostSelectionResponse{host};
+  }));
+  EXPECT_CALL(secondary_load_balancer_, chooseHost(_)).WillRepeatedly(Invoke([] {
+    return Upstream::HostSelectionResponse{nullptr};
+  }));
 
   for (int i = 0; i < 50; ++i) {
     EXPECT_CALL(random_, random()).WillRepeatedly(Return(i));
@@ -311,10 +325,12 @@ TEST_F(AggregateClusterTest, ClusterInPanicTest) {
     EXPECT_EQ(host.get(), target.get());
   }
 
-  EXPECT_CALL(primary_load_balancer_, chooseHost(_))
-      .WillRepeatedly(Return(Upstream::HostSelectionResponse{nullptr}));
-  EXPECT_CALL(secondary_load_balancer_, chooseHost(_))
-      .WillRepeatedly(Return(Upstream::HostSelectionResponse{host}));
+  EXPECT_CALL(primary_load_balancer_, chooseHost(_)).WillRepeatedly(Invoke([] {
+    return Upstream::HostSelectionResponse{nullptr};
+  }));
+  EXPECT_CALL(secondary_load_balancer_, chooseHost(_)).WillRepeatedly(Invoke([host] {
+    return Upstream::HostSelectionResponse{host};
+  }));
 
   for (int i = 50; i < 100; ++i) {
     EXPECT_CALL(random_, random()).WillRepeatedly(Return(i));
@@ -333,10 +349,12 @@ TEST_F(AggregateClusterTest, ClusterInPanicTest) {
   // Cluster 2:
   //     Priority 0: 10%
   //     Priority 0: 50%
-  EXPECT_CALL(primary_load_balancer_, chooseHost(_))
-      .WillRepeatedly(Return(Upstream::HostSelectionResponse{host}));
-  EXPECT_CALL(secondary_load_balancer_, chooseHost(_))
-      .WillRepeatedly(Return(Upstream::HostSelectionResponse{nullptr}));
+  EXPECT_CALL(primary_load_balancer_, chooseHost(_)).WillRepeatedly(Invoke([host] {
+    return Upstream::HostSelectionResponse{host};
+  }));
+  EXPECT_CALL(secondary_load_balancer_, chooseHost(_)).WillRepeatedly(Invoke([] {
+    return Upstream::HostSelectionResponse{nullptr};
+  }));
 
   for (int i = 0; i <= 25; ++i) {
     EXPECT_CALL(random_, random()).WillRepeatedly(Return(i));
@@ -344,10 +362,12 @@ TEST_F(AggregateClusterTest, ClusterInPanicTest) {
     EXPECT_EQ(host.get(), target.get());
   }
 
-  EXPECT_CALL(primary_load_balancer_, chooseHost(_))
-      .WillRepeatedly(Return(Upstream::HostSelectionResponse{nullptr}));
-  EXPECT_CALL(secondary_load_balancer_, chooseHost(_))
-      .WillRepeatedly(Return(Upstream::HostSelectionResponse{host}));
+  EXPECT_CALL(primary_load_balancer_, chooseHost(_)).WillRepeatedly(Invoke([] {
+    return Upstream::HostSelectionResponse{nullptr};
+  }));
+  EXPECT_CALL(secondary_load_balancer_, chooseHost(_)).WillRepeatedly(Invoke([host] {
+    return Upstream::HostSelectionResponse{host};
+  }));
 
   for (int i = 26; i < 100; ++i) {
     EXPECT_CALL(random_, random()).WillRepeatedly(Return(i));

--- a/test/extensions/clusters/aggregate/cluster_update_test.cc
+++ b/test/extensions/clusters/aggregate/cluster_update_test.cc
@@ -85,7 +85,7 @@ INSTANTIATE_TEST_SUITE_P(DeferredClusters, AggregateClusterUpdateTest, testing::
 
 TEST_P(AggregateClusterUpdateTest, NoHealthyUpstream) {
   initialize(default_yaml_config_);
-  EXPECT_EQ(nullptr, cluster_->loadBalancer().chooseHost(nullptr));
+  EXPECT_EQ(nullptr, cluster_->loadBalancer().chooseHost(nullptr).host);
 }
 
 TEST_P(AggregateClusterUpdateTest, BasicFlow) {
@@ -99,7 +99,7 @@ TEST_P(AggregateClusterUpdateTest, BasicFlow) {
   EXPECT_TRUE(*cluster_manager_->addOrUpdateCluster(Upstream::defaultStaticCluster("primary"), ""));
   auto primary = cluster_manager_->getThreadLocalCluster("primary");
   EXPECT_NE(nullptr, primary);
-  auto host = cluster_->loadBalancer().chooseHost(nullptr);
+  auto host = cluster_->loadBalancer().chooseHost(nullptr).host;
   EXPECT_NE(nullptr, host);
   EXPECT_EQ("primary", host->cluster().name());
   EXPECT_EQ("127.0.0.1:11001", host->address()->asString());
@@ -108,7 +108,7 @@ TEST_P(AggregateClusterUpdateTest, BasicFlow) {
       *cluster_manager_->addOrUpdateCluster(Upstream::defaultStaticCluster("secondary"), ""));
   auto secondary = cluster_manager_->getThreadLocalCluster("secondary");
   EXPECT_NE(nullptr, secondary);
-  host = cluster_->loadBalancer().chooseHost(nullptr);
+  host = cluster_->loadBalancer().chooseHost(nullptr).host;
   EXPECT_NE(nullptr, host);
   EXPECT_EQ("primary", host->cluster().name());
   EXPECT_EQ("127.0.0.1:11001", host->address()->asString());
@@ -117,14 +117,14 @@ TEST_P(AggregateClusterUpdateTest, BasicFlow) {
       *cluster_manager_->addOrUpdateCluster(Upstream::defaultStaticCluster("tertiary"), ""));
   auto tertiary = cluster_manager_->getThreadLocalCluster("tertiary");
   EXPECT_NE(nullptr, tertiary);
-  host = cluster_->loadBalancer().chooseHost(nullptr);
+  host = cluster_->loadBalancer().chooseHost(nullptr).host;
   EXPECT_NE(nullptr, host);
   EXPECT_EQ("primary", host->cluster().name());
   EXPECT_EQ("127.0.0.1:11001", host->address()->asString());
 
   EXPECT_TRUE(cluster_manager_->removeCluster("primary"));
   EXPECT_EQ(nullptr, cluster_manager_->getThreadLocalCluster("primary"));
-  host = cluster_->loadBalancer().chooseHost(nullptr);
+  host = cluster_->loadBalancer().chooseHost(nullptr).host;
   EXPECT_NE(nullptr, host);
   EXPECT_EQ("secondary", host->cluster().name());
   EXPECT_EQ("127.0.0.1:11001", host->address()->asString());
@@ -133,7 +133,7 @@ TEST_P(AggregateClusterUpdateTest, BasicFlow) {
   EXPECT_TRUE(*cluster_manager_->addOrUpdateCluster(Upstream::defaultStaticCluster("primary"), ""));
   primary = cluster_manager_->getThreadLocalCluster("primary");
   EXPECT_NE(nullptr, primary);
-  host = cluster_->loadBalancer().chooseHost(nullptr);
+  host = cluster_->loadBalancer().chooseHost(nullptr).host;
   EXPECT_NE(nullptr, host);
   EXPECT_EQ("primary", host->cluster().name());
   EXPECT_EQ("127.0.0.1:11001", host->address()->asString());
@@ -186,22 +186,22 @@ TEST_P(AggregateClusterUpdateTest, LoadBalancingTest) {
   Upstream::HostConstSharedPtr host;
   for (int i = 0; i < 33; ++i) {
     EXPECT_CALL(factory_.random_, random()).WillRepeatedly(Return(i));
-    EXPECT_EQ(host3, cluster_->loadBalancer().chooseHost(nullptr));
+    EXPECT_EQ(host3, cluster_->loadBalancer().chooseHost(nullptr).host);
   }
 
   for (int i = 33; i < 66; ++i) {
     EXPECT_CALL(factory_.random_, random()).WillRepeatedly(Return(i));
-    EXPECT_EQ(host6, cluster_->loadBalancer().chooseHost(nullptr));
+    EXPECT_EQ(host6, cluster_->loadBalancer().chooseHost(nullptr).host);
   }
 
   for (int i = 66; i < 99; ++i) {
     EXPECT_CALL(factory_.random_, random()).WillRepeatedly(Return(i));
-    EXPECT_EQ(host1, cluster_->loadBalancer().chooseHost(nullptr));
+    EXPECT_EQ(host1, cluster_->loadBalancer().chooseHost(nullptr).host);
   }
 
   for (int i = 99; i < 100; ++i) {
     EXPECT_CALL(factory_.random_, random()).WillRepeatedly(Return(i));
-    EXPECT_EQ(host4, cluster_->loadBalancer().chooseHost(nullptr));
+    EXPECT_EQ(host4, cluster_->loadBalancer().chooseHost(nullptr).host);
   }
 
   EXPECT_TRUE(cluster_manager_->removeCluster("primary"));
@@ -228,24 +228,24 @@ TEST_P(AggregateClusterUpdateTest, LoadBalancingTest) {
   //   Priority 1: 1/3 healthy, 1/3 degraded
   for (int i = 0; i < 33; ++i) {
     EXPECT_CALL(factory_.random_, random()).WillRepeatedly(Return(i));
-    host = cluster_->loadBalancer().chooseHost(nullptr);
-    EXPECT_EQ(host6, cluster_->loadBalancer().chooseHost(nullptr));
+    host = cluster_->loadBalancer().chooseHost(nullptr).host;
+    EXPECT_EQ(host6, cluster_->loadBalancer().chooseHost(nullptr).host);
   }
 
   for (int i = 33; i < 66; ++i) {
     EXPECT_CALL(factory_.random_, random()).WillRepeatedly(Return(i));
-    host = cluster_->loadBalancer().chooseHost(nullptr);
-    EXPECT_EQ(host9, cluster_->loadBalancer().chooseHost(nullptr));
+    host = cluster_->loadBalancer().chooseHost(nullptr).host;
+    EXPECT_EQ(host9, cluster_->loadBalancer().chooseHost(nullptr).host);
   }
 
   for (int i = 66; i < 99; ++i) {
     EXPECT_CALL(factory_.random_, random()).WillRepeatedly(Return(i));
-    EXPECT_EQ(host4, cluster_->loadBalancer().chooseHost(nullptr));
+    EXPECT_EQ(host4, cluster_->loadBalancer().chooseHost(nullptr).host);
   }
 
   for (int i = 99; i < 100; ++i) {
     EXPECT_CALL(factory_.random_, random()).WillRepeatedly(Return(i));
-    EXPECT_EQ(host7, cluster_->loadBalancer().chooseHost(nullptr));
+    EXPECT_EQ(host7, cluster_->loadBalancer().chooseHost(nullptr).host);
   }
 }
 
@@ -288,7 +288,7 @@ TEST_P(AggregateClusterUpdateTest, InitializeAggregateClusterAfterOtherClusters)
   cluster_ = cluster_manager_->getThreadLocalCluster("aggregate_cluster");
   auto primary = cluster_manager_->getThreadLocalCluster("primary");
   EXPECT_NE(nullptr, primary);
-  auto host = cluster_->loadBalancer().chooseHost(nullptr);
+  auto host = cluster_->loadBalancer().chooseHost(nullptr).host;
   EXPECT_NE(nullptr, host);
   EXPECT_EQ("primary", host->cluster().name());
   EXPECT_EQ("127.0.0.1:80", host->address()->asString());
@@ -312,12 +312,12 @@ TEST_P(AggregateClusterUpdateTest, InitializeAggregateClusterAfterOtherClusters)
 
   for (int i = 0; i < 50; ++i) {
     EXPECT_CALL(factory_.random_, random()).WillRepeatedly(Return(i));
-    EXPECT_EQ(host3, cluster_->loadBalancer().chooseHost(nullptr));
+    EXPECT_EQ(host3, cluster_->loadBalancer().chooseHost(nullptr).host);
   }
 
   for (int i = 50; i < 100; ++i) {
     EXPECT_CALL(factory_.random_, random()).WillRepeatedly(Return(i));
-    EXPECT_EQ(host1, cluster_->loadBalancer().chooseHost(nullptr));
+    EXPECT_EQ(host1, cluster_->loadBalancer().chooseHost(nullptr).host);
   }
 }
 

--- a/test/extensions/clusters/dynamic_forward_proxy/cluster_test.cc
+++ b/test/extensions/clusters/dynamic_forward_proxy/cluster_test.cc
@@ -241,10 +241,10 @@ TEST_F(ClusterTest, BasicFlow) {
   makeTestHost("host1:0", "1.2.3.4");
   InSequence s;
 
-  EXPECT_EQ(nullptr, lb_->chooseHost(setHostAndReturnContext("")));
+  EXPECT_EQ(nullptr, lb_->chooseHost(setHostAndReturnContext("")).host);
 
   // Verify no host LB cases.
-  EXPECT_EQ(nullptr, lb_->chooseHost(setHostAndReturnContext("foo")));
+  EXPECT_EQ(nullptr, lb_->chooseHost(setHostAndReturnContext("foo")).host);
   EXPECT_EQ(nullptr, lb_->peekAnotherHost(setHostAndReturnContext("foo")));
 
   // LB will immediately resolve host1.
@@ -255,7 +255,7 @@ TEST_F(ClusterTest, BasicFlow) {
             cluster_->prioritySet().hostSetsPerPriority()[0]->hosts()[0]->address()->asString());
   EXPECT_CALL(*host_map_["host1:0"], touch());
   EXPECT_EQ("1.2.3.4:0",
-            lb_->chooseHost(setHostAndReturnContext("host1:0"))->address()->asString());
+            lb_->chooseHost(setHostAndReturnContext("host1:0")).host->address()->asString());
 
   // After changing the address, LB will immediately resolve the new address with a refresh.
   updateTestHostAddress("host1:0", "2.3.4.5");
@@ -265,13 +265,13 @@ TEST_F(ClusterTest, BasicFlow) {
             cluster_->prioritySet().hostSetsPerPriority()[0]->hosts()[0]->address()->asString());
   EXPECT_CALL(*host_map_["host1:0"], touch());
   EXPECT_EQ("2.3.4.5:0",
-            lb_->chooseHost(setHostAndReturnContext("host1:0"))->address()->asString());
+            lb_->chooseHost(setHostAndReturnContext("host1:0")).host->address()->asString());
 
   // Remove the host, LB will immediately fail to find the host in the map.
   EXPECT_CALL(*this, onMemberUpdateCb(SizeIs(0), SizeIs(1)));
   update_callbacks_->onDnsHostRemove("host1:0");
   EXPECT_EQ(0UL, cluster_->prioritySet().hostSetsPerPriority()[0]->hosts().size());
-  EXPECT_EQ(nullptr, lb_->chooseHost(setHostAndReturnContext("host1:0")));
+  EXPECT_EQ(nullptr, lb_->chooseHost(setHostAndReturnContext("host1:0")).host);
 }
 
 // Outlier detection
@@ -285,35 +285,35 @@ TEST_F(ClusterTest, OutlierDetection) {
   EXPECT_TRUE(update_callbacks_->onDnsHostAddOrUpdate("host1:0", host_map_["host1:0"]).ok());
   EXPECT_CALL(*host_map_["host1:0"], touch());
   EXPECT_EQ("1.2.3.4:0",
-            lb_->chooseHost(setHostAndReturnContext("host1:0"))->address()->asString());
+            lb_->chooseHost(setHostAndReturnContext("host1:0")).host->address()->asString());
 
   EXPECT_CALL(*this, onMemberUpdateCb(SizeIs(1), SizeIs(0)));
   EXPECT_TRUE(update_callbacks_->onDnsHostAddOrUpdate("host2:0", host_map_["host2:0"]).ok());
   EXPECT_CALL(*host_map_["host2:0"], touch());
   EXPECT_EQ("5.6.7.8:0",
-            lb_->chooseHost(setHostAndReturnContext("host2:0"))->address()->asString());
+            lb_->chooseHost(setHostAndReturnContext("host2:0")).host->address()->asString());
 
   // Fail outlier check for host1
   setOutlierFailed("host1:0");
-  EXPECT_EQ(nullptr, lb_->chooseHost(setHostAndReturnContext("host1:0")));
+  EXPECT_EQ(nullptr, lb_->chooseHost(setHostAndReturnContext("host1:0")).host);
   // "host2:0" should not be affected
   EXPECT_CALL(*host_map_["host2:0"], touch());
   EXPECT_EQ("5.6.7.8:0",
-            lb_->chooseHost(setHostAndReturnContext("host2:0"))->address()->asString());
+            lb_->chooseHost(setHostAndReturnContext("host2:0")).host->address()->asString());
 
   // Clear outlier check failure for host1, it should be available again
   clearOutlierFailed("host1:0");
   EXPECT_CALL(*host_map_["host1:0"], touch());
   EXPECT_EQ("1.2.3.4:0",
-            lb_->chooseHost(setHostAndReturnContext("host1:0"))->address()->asString());
+            lb_->chooseHost(setHostAndReturnContext("host1:0")).host->address()->asString());
 }
 
 // Various invalid LB context permutations in case the cluster is used outside of HTTP.
 TEST_F(ClusterTest, InvalidLbContext) {
   initialize(default_yaml_config_, false);
   ON_CALL(lb_context_, downstreamHeaders()).WillByDefault(Return(nullptr));
-  EXPECT_EQ(nullptr, lb_->chooseHost(&lb_context_));
-  EXPECT_EQ(nullptr, lb_->chooseHost(nullptr));
+  EXPECT_EQ(nullptr, lb_->chooseHost(&lb_context_).host);
+  EXPECT_EQ(nullptr, lb_->chooseHost(nullptr).host);
 }
 
 TEST_F(ClusterTest, FilterStateHostOverride) {
@@ -323,8 +323,9 @@ TEST_F(ClusterTest, FilterStateHostOverride) {
   EXPECT_CALL(*this, onMemberUpdateCb(SizeIs(1), SizeIs(0)));
   EXPECT_TRUE(update_callbacks_->onDnsHostAddOrUpdate("host1:0", host_map_["host1:0"]).ok());
   EXPECT_CALL(*host_map_["host1:0"], touch());
-  EXPECT_EQ("1.2.3.4:0",
-            lb_->chooseHost(setFilterStateHostAndReturnContext("host1:0"))->address()->asString());
+  EXPECT_EQ(
+      "1.2.3.4:0",
+      lb_->chooseHost(setFilterStateHostAndReturnContext("host1:0")).host->address()->asString());
 }
 
 // Verify cluster attaches to a populated cache.

--- a/test/extensions/clusters/redis/redis_cluster_lb_test.cc
+++ b/test/extensions/clusters/redis/redis_cluster_lb_test.cc
@@ -58,7 +58,7 @@ public:
     Upstream::LoadBalancerPtr lb = lb_->factory()->create(lb_params_);
     for (auto& assignment : expected_assignments) {
       TestLoadBalancerContext context(assignment.first, read_command, read_policy);
-      auto host = lb->chooseHost(&context);
+      auto host = lb->chooseHost(&context).host;
       EXPECT_FALSE(host == nullptr);
       EXPECT_EQ(hosts[assignment.second]->address()->asString(), host->address()->asString());
     }
@@ -102,7 +102,7 @@ public:
 // Works correctly without any hosts.
 TEST_F(RedisClusterLoadBalancerTest, NoHost) {
   init();
-  EXPECT_EQ(nullptr, lb_->factory()->create(lb_params_)->chooseHost(nullptr));
+  EXPECT_EQ(nullptr, lb_->factory()->create(lb_params_)->chooseHost(nullptr).host);
 };
 
 // Works correctly with empty context
@@ -124,7 +124,7 @@ TEST_F(RedisClusterLoadBalancerTest, NoHash) {
   init();
   factory_->onClusterSlotUpdate(std::move(slots), all_hosts);
   TestLoadBalancerContext context(absl::nullopt);
-  EXPECT_EQ(nullptr, lb_->factory()->create(lb_params_)->chooseHost(&context));
+  EXPECT_EQ(nullptr, lb_->factory()->create(lb_params_)->chooseHost(&context).host);
 };
 
 TEST_F(RedisClusterLoadBalancerTest, Basic) {
@@ -185,7 +185,7 @@ TEST_F(RedisClusterLoadBalancerTest, Shard) {
   Upstream::LoadBalancerPtr lb = lb_->factory()->create(lb_params_);
   for (uint16_t i = 0; i < 5; i++) {
     RedisSpecifyShardContextImpl context(i, get_request);
-    auto host = lb->chooseHost(&context);
+    auto host = lb->chooseHost(&context).host;
     if (i < 3) {
       EXPECT_FALSE(host == nullptr);
       EXPECT_EQ(hosts[i]->address()->asString(), host->address()->asString());
@@ -359,7 +359,7 @@ TEST_F(RedisClusterLoadBalancerTest, ReadStrategiesNoReplica) {
   Upstream::LoadBalancerPtr lb = lb_->factory()->create(lb_params_);
   TestLoadBalancerContext context(1100, true,
                                   NetworkFilters::Common::Redis::Client::ReadPolicy::Replica);
-  auto host = lb->chooseHost(&context);
+  auto host = lb->chooseHost(&context).host;
   EXPECT_TRUE(host == nullptr);
 }
 

--- a/test/extensions/filters/network/ratelimit/ratelimit_test.cc
+++ b/test/extensions/filters/network/ratelimit/ratelimit_test.cc
@@ -560,8 +560,9 @@ stat_prefix: name
 
   EXPECT_CALL(factory_context.server_factory_context_.cluster_manager_.thread_local_cluster_,
               chooseHost(_))
-      .WillRepeatedly(Return(factory_context.server_factory_context_.cluster_manager_
-                                 .thread_local_cluster_.lb_.host_));
+      .WillRepeatedly(Return(
+          Upstream::HostSelectionResponse{factory_context.server_factory_context_.cluster_manager_
+                                              .thread_local_cluster_.lb_.host_}));
   EXPECT_CALL(factory_context.server_factory_context_.cluster_manager_.thread_local_cluster_,
               tcpConnPool(_, _, _))
       .WillOnce(Return(Upstream::TcpPoolData([]() {}, &conn_pool)));

--- a/test/extensions/filters/network/ratelimit/ratelimit_test.cc
+++ b/test/extensions/filters/network/ratelimit/ratelimit_test.cc
@@ -560,9 +560,11 @@ stat_prefix: name
 
   EXPECT_CALL(factory_context.server_factory_context_.cluster_manager_.thread_local_cluster_,
               chooseHost(_))
-      .WillRepeatedly(Return(
-          Upstream::HostSelectionResponse{factory_context.server_factory_context_.cluster_manager_
-                                              .thread_local_cluster_.lb_.host_}));
+      .WillRepeatedly(Invoke([&] {
+        return Upstream::HostSelectionResponse{
+            factory_context.server_factory_context_.cluster_manager_.thread_local_cluster_.lb_
+                .host_};
+      }));
   EXPECT_CALL(factory_context.server_factory_context_.cluster_manager_.thread_local_cluster_,
               tcpConnPool(_, _, _))
       .WillOnce(Return(Upstream::TcpPoolData([]() {}, &conn_pool)));

--- a/test/extensions/filters/network/redis_proxy/conn_pool_impl_test.cc
+++ b/test/extensions/filters/network/redis_proxy/conn_pool_impl_test.cc
@@ -31,6 +31,7 @@
 #include "gtest/gtest.h"
 
 using testing::_;
+using testing::ByMove;
 using testing::DoAll;
 using testing::Eq;
 using testing::InSequence;
@@ -823,7 +824,7 @@ TEST_F(RedisConnPoolImplTest, HostRemove) {
   Common::Redis::Client::MockClient* client2 = new NiceMock<Common::Redis::Client::MockClient>();
 
   EXPECT_CALL(cm_.thread_local_cluster_.lb_, chooseHost(_))
-      .WillOnce(Return(Upstream::HostSelectionResponse{host1}));
+      .WillOnce(Return(ByMove(Upstream::HostSelectionResponse{host1})));
   EXPECT_CALL(*this, create_(Eq(host1))).WillOnce(Return(client1));
 
   Common::Redis::Client::MockPoolRequest active_request1;
@@ -834,7 +835,7 @@ TEST_F(RedisConnPoolImplTest, HostRemove) {
   EXPECT_NE(nullptr, request1);
 
   EXPECT_CALL(cm_.thread_local_cluster_.lb_, chooseHost(_))
-      .WillOnce(Return(Upstream::HostSelectionResponse{host2}));
+      .WillOnce(Return(ByMove(Upstream::HostSelectionResponse{host2})));
   EXPECT_CALL(*this, create_(Eq(host2))).WillOnce(Return(client2));
 
   Common::Redis::Client::MockPoolRequest active_request2;
@@ -893,7 +894,7 @@ TEST_F(RedisConnPoolImplTest, NoHost) {
   Common::Redis::RespValueSharedPtr value = std::make_shared<Common::Redis::RespValue>();
   MockPoolCallbacks callbacks;
   EXPECT_CALL(cm_.thread_local_cluster_.lb_, chooseHost(_))
-      .WillOnce(Return(Upstream::HostSelectionResponse{nullptr}));
+      .WillOnce(Return(ByMove(Upstream::HostSelectionResponse{nullptr})));
   Common::Redis::Client::PoolRequest* request =
       conn_pool_->makeRequest("hash_key", value, callbacks, transaction_);
   EXPECT_EQ(nullptr, request);

--- a/test/extensions/filters/network/redis_proxy/conn_pool_impl_test.cc
+++ b/test/extensions/filters/network/redis_proxy/conn_pool_impl_test.cc
@@ -266,7 +266,7 @@ public:
               auto redis_context =
                   dynamic_cast<Clusters::Redis::RedisLoadBalancerContext*>(context);
               EXPECT_EQ(redis_context->readPolicy(), expected_read_policy);
-              return cm_.thread_local_cluster_.lb_.host_;
+              return {cm_.thread_local_cluster_.lb_.host_};
             }));
     EXPECT_CALL(*this, create_(_)).WillOnce(Return(client));
     EXPECT_CALL(*cm_.thread_local_cluster_.lb_.host_, address())
@@ -349,7 +349,7 @@ TEST_F(RedisConnPoolImplTest, Basic) {
         EXPECT_EQ(context->computeHashKey().value(), MurmurHash::murmurHash2("hash_key"));
         EXPECT_EQ(context->metadataMatchCriteria(), nullptr);
         EXPECT_EQ(context->downstreamConnection(), nullptr);
-        return cm_.thread_local_cluster_.lb_.host_;
+        return {cm_.thread_local_cluster_.lb_.host_};
       }));
   EXPECT_CALL(*this, create_(_)).WillOnce(Return(client));
   EXPECT_CALL(*cm_.thread_local_cluster_.lb_.host_, address())
@@ -470,7 +470,7 @@ TEST_F(RedisConnPoolImplTest, BasicRespVariant) {
         EXPECT_EQ(context->computeHashKey().value(), MurmurHash::murmurHash2("hash_key"));
         EXPECT_EQ(context->metadataMatchCriteria(), nullptr);
         EXPECT_EQ(context->downstreamConnection(), nullptr);
-        return cm_.thread_local_cluster_.lb_.host_;
+        return {cm_.thread_local_cluster_.lb_.host_};
       }));
   EXPECT_CALL(*this, create_(_)).WillOnce(Return(client));
   EXPECT_CALL(*cm_.thread_local_cluster_.lb_.host_, address())
@@ -529,7 +529,7 @@ TEST_F(RedisConnPoolImplTest, ClientRequestFailed) {
         EXPECT_EQ(context->computeHashKey().value(), MurmurHash::murmurHash2("hash_key"));
         EXPECT_EQ(context->metadataMatchCriteria(), nullptr);
         EXPECT_EQ(context->downstreamConnection(), nullptr);
-        return cm_.thread_local_cluster_.lb_.host_;
+        return {cm_.thread_local_cluster_.lb_.host_};
       }));
   EXPECT_CALL(*this, create_(_)).WillOnce(Return(client));
   EXPECT_CALL(*cm_.thread_local_cluster_.lb_.host_, address())
@@ -558,7 +558,7 @@ TEST_F(RedisConnPoolImplTest, RedisConnectionRateLimited) {
         EXPECT_EQ(context->computeHashKey().value(), MurmurHash::murmurHash2("hash_key"));
         EXPECT_EQ(context->metadataMatchCriteria(), nullptr);
         EXPECT_EQ(context->downstreamConnection(), nullptr);
-        return cm_.thread_local_cluster_.lb_.host_;
+        return {cm_.thread_local_cluster_.lb_.host_};
       }));
   EXPECT_CALL(*this, create_(_)).WillOnce(Return(client));
   EXPECT_CALL(*cm_.thread_local_cluster_.lb_.host_, address())
@@ -577,7 +577,7 @@ TEST_F(RedisConnPoolImplTest, RedisConnectionRateLimited) {
         EXPECT_EQ(context->computeHashKey().value(), MurmurHash::murmurHash2("hash_key"));
         EXPECT_EQ(context->metadataMatchCriteria(), nullptr);
         EXPECT_EQ(context->downstreamConnection(), nullptr);
-        return cm_.thread_local_cluster_.lb_.host_;
+        return {cm_.thread_local_cluster_.lb_.host_};
       }));
   EXPECT_CALL(*this, create_(_)).Times(0);
   EXPECT_CALL(*cm_.thread_local_cluster_.lb_.host_, address())
@@ -597,7 +597,7 @@ TEST_F(RedisConnPoolImplTest, RedisConnectionRateLimited) {
         EXPECT_EQ(context->computeHashKey().value(), MurmurHash::murmurHash2("hash_key"));
         EXPECT_EQ(context->metadataMatchCriteria(), nullptr);
         EXPECT_EQ(context->downstreamConnection(), nullptr);
-        return cm_.thread_local_cluster_.lb_.host_;
+        return {cm_.thread_local_cluster_.lb_.host_};
       }));
   EXPECT_CALL(*this, create_(_)).WillOnce(Return(new_client));
   EXPECT_CALL(*cm_.thread_local_cluster_.lb_.host_, address())
@@ -822,7 +822,8 @@ TEST_F(RedisConnPoolImplTest, HostRemove) {
   Common::Redis::Client::MockClient* client1 = new NiceMock<Common::Redis::Client::MockClient>();
   Common::Redis::Client::MockClient* client2 = new NiceMock<Common::Redis::Client::MockClient>();
 
-  EXPECT_CALL(cm_.thread_local_cluster_.lb_, chooseHost(_)).WillOnce(Return(host1));
+  EXPECT_CALL(cm_.thread_local_cluster_.lb_, chooseHost(_))
+      .WillOnce(Return(Upstream::HostSelectionResponse{host1}));
   EXPECT_CALL(*this, create_(Eq(host1))).WillOnce(Return(client1));
 
   Common::Redis::Client::MockPoolRequest active_request1;
@@ -832,7 +833,8 @@ TEST_F(RedisConnPoolImplTest, HostRemove) {
       conn_pool_->makeRequest("hash_key", value, callbacks, transaction_);
   EXPECT_NE(nullptr, request1);
 
-  EXPECT_CALL(cm_.thread_local_cluster_.lb_, chooseHost(_)).WillOnce(Return(host2));
+  EXPECT_CALL(cm_.thread_local_cluster_.lb_, chooseHost(_))
+      .WillOnce(Return(Upstream::HostSelectionResponse{host2}));
   EXPECT_CALL(*this, create_(Eq(host2))).WillOnce(Return(client2));
 
   Common::Redis::Client::MockPoolRequest active_request2;
@@ -890,7 +892,8 @@ TEST_F(RedisConnPoolImplTest, NoHost) {
 
   Common::Redis::RespValueSharedPtr value = std::make_shared<Common::Redis::RespValue>();
   MockPoolCallbacks callbacks;
-  EXPECT_CALL(cm_.thread_local_cluster_.lb_, chooseHost(_)).WillOnce(Return(nullptr));
+  EXPECT_CALL(cm_.thread_local_cluster_.lb_, chooseHost(_))
+      .WillOnce(Return(Upstream::HostSelectionResponse{nullptr}));
   Common::Redis::Client::PoolRequest* request =
       conn_pool_->makeRequest("hash_key", value, callbacks, transaction_);
   EXPECT_EQ(nullptr, request);

--- a/test/extensions/filters/udp/udp_proxy/udp_proxy_filter_test.cc
+++ b/test/extensions/filters/udp/udp_proxy/udp_proxy_filter_test.cc
@@ -801,7 +801,7 @@ matcher:
 
   EXPECT_CALL(factory_context_.server_factory_context_.cluster_manager_.thread_local_cluster_.lb_,
               chooseHost(_))
-      .WillOnce(Return(nullptr));
+      .WillOnce(Return(Upstream::HostSelectionResponse{nullptr}));
   recvDataFromDownstream("10.0.0.1:1000", "10.0.0.2:80", "hello");
   EXPECT_EQ(1, factory_context_.server_factory_context_.cluster_manager_.thread_local_cluster_
                    .cluster_.info_->traffic_stats_->upstream_cx_none_healthy_.value());
@@ -1095,7 +1095,7 @@ matcher:
   auto new_host = createHost(new_host_address);
   EXPECT_CALL(factory_context_.server_factory_context_.cluster_manager_.thread_local_cluster_.lb_,
               chooseHost(_))
-      .WillOnce(Return(new_host));
+      .WillOnce(Return(Upstream::HostSelectionResponse{new_host}));
   expectSessionCreate(new_host_address);
   test_sessions_[1].expectWriteToUpstream("hello", 0, nullptr, true);
   recvDataFromDownstream("10.0.0.1:1000", "10.0.0.2:80", "hello");
@@ -1193,7 +1193,7 @@ use_per_packet_load_balancing: true
   auto new_host = createHost(new_host_address);
   EXPECT_CALL(factory_context_.server_factory_context_.cluster_manager_.thread_local_cluster_.lb_,
               chooseHost(_))
-      .WillOnce(Return(new_host));
+      .WillOnce(Return(Upstream::HostSelectionResponse{new_host}));
   expectSessionCreate(new_host_address);
   test_sessions_[1].expectWriteToUpstream("hello2", 0, nullptr, true);
   recvDataFromDownstream("10.0.0.1:1000", "10.0.0.2:80", "hello2");
@@ -1230,7 +1230,7 @@ use_per_packet_load_balancing: true
 
   EXPECT_CALL(factory_context_.server_factory_context_.cluster_manager_.thread_local_cluster_.lb_,
               chooseHost(_))
-      .WillOnce(Return(nullptr));
+      .WillOnce(Return(Upstream::HostSelectionResponse{nullptr}));
   recvDataFromDownstream("10.0.0.1:1000", "10.0.0.2:80", "hello");
   EXPECT_EQ(0, config_->stats().downstream_sess_total_.value());
   EXPECT_EQ(0, config_->stats().downstream_sess_active_.value());
@@ -1264,7 +1264,7 @@ use_per_packet_load_balancing: true
 
   EXPECT_CALL(factory_context_.server_factory_context_.cluster_manager_.thread_local_cluster_.lb_,
               chooseHost(_))
-      .WillOnce(Return(nullptr));
+      .WillOnce(Return(Upstream::HostSelectionResponse{nullptr}));
   recvDataFromDownstream("10.0.0.1:1000", "10.0.0.2:80", "hello2");
   EXPECT_EQ(1, config_->stats().downstream_sess_total_.value());
   EXPECT_EQ(1, config_->stats().downstream_sess_active_.value());
@@ -1338,7 +1338,7 @@ use_per_packet_load_balancing: true
   auto new_host = createHost(new_host_address);
   EXPECT_CALL(factory_context_.server_factory_context_.cluster_manager_.thread_local_cluster_.lb_,
               chooseHost(_))
-      .WillOnce(Return(new_host));
+      .WillOnce(Return(Upstream::HostSelectionResponse{new_host}));
   expectSessionCreate(new_host_address);
   test_sessions_[1].expectWriteToUpstream("hello2", 0, nullptr, true);
   recvDataFromDownstream("10.0.0.1:1000", "10.0.0.2:80", "hello2");

--- a/test/extensions/filters/udp/udp_proxy/udp_proxy_filter_test.cc
+++ b/test/extensions/filters/udp/udp_proxy/udp_proxy_filter_test.cc
@@ -801,7 +801,7 @@ matcher:
 
   EXPECT_CALL(factory_context_.server_factory_context_.cluster_manager_.thread_local_cluster_.lb_,
               chooseHost(_))
-      .WillOnce(Return(Upstream::HostSelectionResponse{nullptr}));
+      .WillOnce(Return(ByMove(Upstream::HostSelectionResponse{nullptr})));
   recvDataFromDownstream("10.0.0.1:1000", "10.0.0.2:80", "hello");
   EXPECT_EQ(1, factory_context_.server_factory_context_.cluster_manager_.thread_local_cluster_
                    .cluster_.info_->traffic_stats_->upstream_cx_none_healthy_.value());
@@ -1095,7 +1095,7 @@ matcher:
   auto new_host = createHost(new_host_address);
   EXPECT_CALL(factory_context_.server_factory_context_.cluster_manager_.thread_local_cluster_.lb_,
               chooseHost(_))
-      .WillOnce(Return(Upstream::HostSelectionResponse{new_host}));
+      .WillOnce(Return(ByMove(Upstream::HostSelectionResponse{new_host})));
   expectSessionCreate(new_host_address);
   test_sessions_[1].expectWriteToUpstream("hello", 0, nullptr, true);
   recvDataFromDownstream("10.0.0.1:1000", "10.0.0.2:80", "hello");
@@ -1193,7 +1193,7 @@ use_per_packet_load_balancing: true
   auto new_host = createHost(new_host_address);
   EXPECT_CALL(factory_context_.server_factory_context_.cluster_manager_.thread_local_cluster_.lb_,
               chooseHost(_))
-      .WillOnce(Return(Upstream::HostSelectionResponse{new_host}));
+      .WillOnce(Return(ByMove(Upstream::HostSelectionResponse{new_host})));
   expectSessionCreate(new_host_address);
   test_sessions_[1].expectWriteToUpstream("hello2", 0, nullptr, true);
   recvDataFromDownstream("10.0.0.1:1000", "10.0.0.2:80", "hello2");
@@ -1230,7 +1230,7 @@ use_per_packet_load_balancing: true
 
   EXPECT_CALL(factory_context_.server_factory_context_.cluster_manager_.thread_local_cluster_.lb_,
               chooseHost(_))
-      .WillOnce(Return(Upstream::HostSelectionResponse{nullptr}));
+      .WillOnce(Return(ByMove(Upstream::HostSelectionResponse{nullptr})));
   recvDataFromDownstream("10.0.0.1:1000", "10.0.0.2:80", "hello");
   EXPECT_EQ(0, config_->stats().downstream_sess_total_.value());
   EXPECT_EQ(0, config_->stats().downstream_sess_active_.value());
@@ -1264,7 +1264,7 @@ use_per_packet_load_balancing: true
 
   EXPECT_CALL(factory_context_.server_factory_context_.cluster_manager_.thread_local_cluster_.lb_,
               chooseHost(_))
-      .WillOnce(Return(Upstream::HostSelectionResponse{nullptr}));
+      .WillOnce(Return(ByMove(Upstream::HostSelectionResponse{nullptr})));
   recvDataFromDownstream("10.0.0.1:1000", "10.0.0.2:80", "hello2");
   EXPECT_EQ(1, config_->stats().downstream_sess_total_.value());
   EXPECT_EQ(1, config_->stats().downstream_sess_active_.value());
@@ -1338,7 +1338,7 @@ use_per_packet_load_balancing: true
   auto new_host = createHost(new_host_address);
   EXPECT_CALL(factory_context_.server_factory_context_.cluster_manager_.thread_local_cluster_.lb_,
               chooseHost(_))
-      .WillOnce(Return(Upstream::HostSelectionResponse{new_host}));
+      .WillOnce(Return(ByMove(Upstream::HostSelectionResponse{new_host})));
   expectSessionCreate(new_host_address);
   test_sessions_[1].expectWriteToUpstream("hello2", 0, nullptr, true);
   recvDataFromDownstream("10.0.0.1:1000", "10.0.0.2:80", "hello2");

--- a/test/extensions/load_balancing_policies/client_side_weighted_round_robin/client_side_weighted_round_robin_lb_test.cc
+++ b/test/extensions/load_balancing_policies/client_side_weighted_round_robin/client_side_weighted_round_robin_lb_test.cc
@@ -20,7 +20,7 @@ public:
       std::shared_ptr<ClientSideWeightedRoundRobinLoadBalancer::WorkerLocalLb> worker_lb)
       : lb_(std::move(lb)), worker_lb_(std::move(worker_lb)) {}
 
-  HostConstSharedPtr chooseHost(LoadBalancerContext* context) {
+  HostSelectionResponse chooseHost(LoadBalancerContext* context) {
     return worker_lb_->chooseHost(context);
   }
 
@@ -134,7 +134,7 @@ public:
       EXPECT_EQ(hostSet().healthy_hosts_[i], lb_->peekAnotherHost(nullptr));
     }
     for (auto i : picks) {
-      EXPECT_EQ(hostSet().healthy_hosts_[i], lb_->chooseHost(nullptr));
+      EXPECT_EQ(hostSet().healthy_hosts_[i], lb_->chooseHost(nullptr).host);
     }
   }
 
@@ -280,7 +280,7 @@ TEST_P(ClientSideWeightedRoundRobinLoadBalancerTest, ChooseHostWithClientSideWei
   hostSet().runCallbacks({}, {});
   simTime().setMonotonicTime(MonotonicTime(std::chrono::seconds(5)));
   for (const auto& host_ptr : hostSet().hosts_) {
-    HostConstSharedPtr host = lb_->chooseHost(&lb_context_);
+    HostConstSharedPtr host = lb_->chooseHost(&lb_context_).host;
     // Hosts have equal weights, so chooseHost returns the current host.
     ASSERT_EQ(host, host_ptr);
     // Invoke the callback with an Orca load report.

--- a/test/extensions/load_balancing_policies/common/load_balancer_impl_base_test.cc
+++ b/test/extensions/load_balancing_policies/common/load_balancer_impl_base_test.cc
@@ -24,7 +24,7 @@ public:
   using LoadBalancerBase::percentageDegradedLoad;
   using LoadBalancerBase::percentageLoad;
 
-  HostConstSharedPtr chooseHost(LoadBalancerContext*) override { PANIC("not implemented"); }
+  HostSelectionResponse chooseHost(LoadBalancerContext*) override { PANIC("not implemented"); }
 
   HostConstSharedPtr peekAnotherHost(LoadBalancerContext*) override { PANIC("not implemented"); }
 };

--- a/test/extensions/load_balancing_policies/least_request/least_request_lb_benchmark.cc
+++ b/test/extensions/load_balancing_policies/least_request/least_request_lb_benchmark.cc
@@ -38,7 +38,7 @@ void benchmarkLeastRequestLoadBalancerChooseHost(::benchmark::State& state) {
     state.ResumeTiming();
 
     for (uint64_t i = 0; i < keys_to_simulate; ++i) {
-      hit_counter[tester.lb_->chooseHost(&context)->address()->asString()] += 1;
+      hit_counter[tester.lb_->chooseHost(&context).host->address()->asString()] += 1;
     }
 
     // Do not time computation of mean, standard deviation, and relative standard deviation.

--- a/test/extensions/load_balancing_policies/least_request/least_request_lb_simulation_test.cc
+++ b/test/extensions/load_balancing_policies/least_request/least_request_lb_simulation_test.cc
@@ -89,7 +89,7 @@ void leastRequestLBWeightTest(LRLBTestParams params) {
       *time_source};
 
   for (uint64_t i = 0; i < num_requests; i++) {
-    host_hits[lb_.chooseHost(nullptr)]++;
+    host_hits[lb_.chooseHost(nullptr).host]++;
   }
 
   std::vector<double> observed_pcts;

--- a/test/extensions/load_balancing_policies/maglev/maglev_lb_benchmark.cc
+++ b/test/extensions/load_balancing_policies/maglev/maglev_lb_benchmark.cc
@@ -41,7 +41,7 @@ void benchmarkMaglevLoadBalancerChooseHost(::benchmark::State& state) {
     // comparing different hashing algorithms.
     for (uint64_t i = 0; i < keys_to_simulate; i++) {
       context.hash_key_ = hashInt(i);
-      hit_counter[lb->chooseHost(&context)->address()->asString()] += 1;
+      hit_counter[lb->chooseHost(&context).host->address()->asString()] += 1;
     }
 
     // Do not time computation of mean, standard deviation, and relative standard deviation.
@@ -93,7 +93,7 @@ void benchmarkMaglevLoadBalancerHostLoss(::benchmark::State& state) {
     TestLoadBalancerContext context;
     for (uint64_t i = 0; i < keys_to_simulate; i++) {
       context.hash_key_ = hashInt(i);
-      hosts.push_back(lb->chooseHost(&context));
+      hosts.push_back(lb->chooseHost(&context).host);
     }
 
     MaglevTester tester2(num_hosts - hosts_to_lose);
@@ -102,7 +102,7 @@ void benchmarkMaglevLoadBalancerHostLoss(::benchmark::State& state) {
     std::vector<HostConstSharedPtr> hosts2;
     for (uint64_t i = 0; i < keys_to_simulate; i++) {
       context.hash_key_ = hashInt(i);
-      hosts2.push_back(lb->chooseHost(&context));
+      hosts2.push_back(lb->chooseHost(&context).host);
     }
 
     ASSERT(hosts.size() == hosts2.size());
@@ -140,7 +140,7 @@ void benchmarkMaglevLoadBalancerWeighted(::benchmark::State& state) {
     TestLoadBalancerContext context;
     for (uint64_t i = 0; i < keys_to_simulate; i++) {
       context.hash_key_ = hashInt(i);
-      hosts.push_back(lb->chooseHost(&context));
+      hosts.push_back(lb->chooseHost(&context).host);
     }
 
     MaglevTester tester2(num_hosts, weighted_subset_percent, after_weight);
@@ -149,7 +149,7 @@ void benchmarkMaglevLoadBalancerWeighted(::benchmark::State& state) {
     std::vector<HostConstSharedPtr> hosts2;
     for (uint64_t i = 0; i < keys_to_simulate; i++) {
       context.hash_key_ = hashInt(i);
-      hosts2.push_back(lb->chooseHost(&context));
+      hosts2.push_back(lb->chooseHost(&context).host);
     }
 
     ASSERT(hosts.size() == hosts2.size());

--- a/test/extensions/load_balancing_policies/random/random_lb_simulation_test.cc
+++ b/test/extensions/load_balancing_policies/random/random_lb_simulation_test.cc
@@ -106,7 +106,7 @@ public:
                             per_zone_local_shared),
           {}, empty_vector_, empty_vector_, random_.random(), absl::nullopt);
 
-      HostConstSharedPtr selected = lb.chooseHost(nullptr);
+      HostConstSharedPtr selected = lb.chooseHost(nullptr).host;
       hits[selected->address()->asString()]++;
     }
 

--- a/test/extensions/load_balancing_policies/random/random_lb_test.cc
+++ b/test/extensions/load_balancing_policies/random/random_lb_test.cc
@@ -24,7 +24,7 @@ TEST_P(RandomLoadBalancerTest, NoHosts) {
   init();
 
   EXPECT_EQ(nullptr, lb_->peekAnotherHost(nullptr));
-  EXPECT_EQ(nullptr, lb_->chooseHost(nullptr));
+  EXPECT_EQ(nullptr, lb_->chooseHost(nullptr).host);
 }
 
 TEST_P(RandomLoadBalancerTest, Normal) {
@@ -41,8 +41,8 @@ TEST_P(RandomLoadBalancerTest, Normal) {
   EXPECT_EQ(hostSet().healthy_hosts_[1], lb_->peekAnotherHost(nullptr));
 
   EXPECT_CALL(random_, random()).Times(0);
-  EXPECT_EQ(hostSet().healthy_hosts_[0], lb_->chooseHost(nullptr));
-  EXPECT_EQ(hostSet().healthy_hosts_[1], lb_->chooseHost(nullptr));
+  EXPECT_EQ(hostSet().healthy_hosts_[0], lb_->chooseHost(nullptr).host);
+  EXPECT_EQ(hostSet().healthy_hosts_[1], lb_->chooseHost(nullptr).host);
 }
 
 TEST_P(RandomLoadBalancerTest, FailClusterOnPanic) {
@@ -53,7 +53,7 @@ TEST_P(RandomLoadBalancerTest, FailClusterOnPanic) {
   hostSet().hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:80", simTime()),
                       makeTestHost(info_, "tcp://127.0.0.1:81", simTime())};
   hostSet().runCallbacks({}, {}); // Trigger callbacks. The added/removed lists are not relevant.
-  EXPECT_EQ(nullptr, lb_->chooseHost(nullptr));
+  EXPECT_EQ(nullptr, lb_->chooseHost(nullptr).host);
 }
 
 INSTANTIATE_TEST_SUITE_P(PrimaryOrFailoverAndLegacyOrNew, RandomLoadBalancerTest,

--- a/test/extensions/load_balancing_policies/ring_hash/ring_hash_lb_benchmark.cc
+++ b/test/extensions/load_balancing_policies/ring_hash/ring_hash_lb_benchmark.cc
@@ -74,7 +74,7 @@ void benchmarkRingHashLoadBalancerChooseHost(::benchmark::State& state) {
     //                     other test.
     for (uint64_t i = 0; i < keys_to_simulate; i++) {
       context.hash_key_ = hashInt(i);
-      hit_counter[lb->chooseHost(&context)->address()->asString()] += 1;
+      hit_counter[lb->chooseHost(&context).host->address()->asString()] += 1;
     }
 
     // Do not time computation of mean, standard deviation, and relative standard deviation.
@@ -111,7 +111,7 @@ void benchmarkRingHashLoadBalancerHostLoss(::benchmark::State& state) {
     TestLoadBalancerContext context;
     for (uint64_t i = 0; i < keys_to_simulate; i++) {
       context.hash_key_ = hashInt(i);
-      hosts.push_back(lb->chooseHost(&context));
+      hosts.push_back(lb->chooseHost(&context).host);
     }
 
     RingHashTester tester2(num_hosts - hosts_to_lose, min_ring_size);
@@ -120,7 +120,7 @@ void benchmarkRingHashLoadBalancerHostLoss(::benchmark::State& state) {
     std::vector<HostConstSharedPtr> hosts2;
     for (uint64_t i = 0; i < keys_to_simulate; i++) {
       context.hash_key_ = hashInt(i);
-      hosts2.push_back(lb->chooseHost(&context));
+      hosts2.push_back(lb->chooseHost(&context).host);
     }
 
     ASSERT(hosts.size() == hosts2.size());

--- a/test/extensions/transport_sockets/starttls/upstream_starttls_integration_test.cc
+++ b/test/extensions/transport_sockets/starttls/upstream_starttls_integration_test.cc
@@ -128,7 +128,7 @@ private:
 
 Network::FilterStatus StartTlsSwitchFilter::onNewConnection() {
   auto c = cluster_manager_.getThreadLocalCluster("cluster_0");
-  auto h = c->loadBalancer().chooseHost(nullptr);
+  auto h = c->loadBalancer().chooseHost(nullptr).host;
   upstream_connection_ =
       h->createConnection(read_callbacks_->connection().dispatcher(), nullptr, nullptr).connection_;
   upstream_connection_->addConnectionCallbacks(*upstream_connection_cb_);

--- a/test/integration/load_balancers/custom_lb_policy.h
+++ b/test/integration/load_balancers/custom_lb_policy.h
@@ -24,8 +24,8 @@ private:
   public:
     LbImpl(const Upstream::HostSharedPtr& host) : host_(host) {}
 
-    Upstream::HostConstSharedPtr chooseHost(Upstream::LoadBalancerContext*) override {
-      return host_;
+    Upstream::HostSelectionResponse chooseHost(Upstream::LoadBalancerContext*) override {
+      return {host_};
     }
     Upstream::HostConstSharedPtr peekAnotherHost(Upstream::LoadBalancerContext*) override {
       return nullptr;

--- a/test/mocks/upstream/load_balancer.cc
+++ b/test/mocks/upstream/load_balancer.cc
@@ -7,7 +7,9 @@ namespace Envoy {
 namespace Upstream {
 using ::testing::_;
 using ::testing::Return;
-MockLoadBalancer::MockLoadBalancer() { ON_CALL(*this, chooseHost(_)).WillByDefault(Return(host_)); }
+MockLoadBalancer::MockLoadBalancer() {
+  ON_CALL(*this, chooseHost(_)).WillByDefault(Return(HostSelectionResponse{host_}));
+}
 
 MockLoadBalancer::~MockLoadBalancer() = default;
 

--- a/test/mocks/upstream/load_balancer.cc
+++ b/test/mocks/upstream/load_balancer.cc
@@ -6,9 +6,9 @@
 namespace Envoy {
 namespace Upstream {
 using ::testing::_;
-using ::testing::Return;
+using ::testing::Invoke;
 MockLoadBalancer::MockLoadBalancer() {
-  ON_CALL(*this, chooseHost(_)).WillByDefault(Return(HostSelectionResponse{host_}));
+  ON_CALL(*this, chooseHost(_)).WillByDefault(Invoke([this] { return HostSelectionResponse{host_}; }));
 }
 
 MockLoadBalancer::~MockLoadBalancer() = default;

--- a/test/mocks/upstream/load_balancer.cc
+++ b/test/mocks/upstream/load_balancer.cc
@@ -8,7 +8,9 @@ namespace Upstream {
 using ::testing::_;
 using ::testing::Invoke;
 MockLoadBalancer::MockLoadBalancer() {
-  ON_CALL(*this, chooseHost(_)).WillByDefault(Invoke([this] { return HostSelectionResponse{host_}; }));
+  ON_CALL(*this, chooseHost(_)).WillByDefault(Invoke([this] {
+    return HostSelectionResponse{host_};
+  }));
 }
 
 MockLoadBalancer::~MockLoadBalancer() = default;

--- a/test/mocks/upstream/load_balancer.h
+++ b/test/mocks/upstream/load_balancer.h
@@ -15,7 +15,7 @@ public:
   ~MockLoadBalancer() override;
 
   // Upstream::LoadBalancer
-  MOCK_METHOD(HostConstSharedPtr, chooseHost, (LoadBalancerContext * context));
+  MOCK_METHOD(HostSelectionResponse, chooseHost, (LoadBalancerContext * context));
   MOCK_METHOD(HostConstSharedPtr, peekAnotherHost, (LoadBalancerContext * context));
   MOCK_METHOD(absl::optional<Upstream::SelectedPoolAndConnection>, selectExistingConnection,
               (Upstream::LoadBalancerContext * context, const Upstream::Host& host,
@@ -23,7 +23,7 @@ public:
   MOCK_METHOD(OptRef<Envoy::Http::ConnectionPool::ConnectionLifetimeCallbacks>, lifetimeCallbacks,
               ());
 
-  std::shared_ptr<MockHost> host_{new MockHost()};
+  std::shared_ptr<MockHost> host_{new NiceMock<MockHost>()};
 };
 
 } // namespace Upstream

--- a/test/mocks/upstream/load_balancer_context.h
+++ b/test/mocks/upstream/load_balancer_context.h
@@ -26,6 +26,7 @@ public:
   MOCK_METHOD(Network::TransportSocketOptionsConstSharedPtr, upstreamTransportSocketOptions, (),
               (const));
   MOCK_METHOD(absl::optional<OverrideHost>, overrideHostToSelect, (), (const));
+  MOCK_METHOD(void, onAsyncHostSelection, (HostConstSharedPtr host));
 
 private:
   HealthyAndDegradedLoad priority_load_;

--- a/test/mocks/upstream/load_balancer_context.h
+++ b/test/mocks/upstream/load_balancer_context.h
@@ -26,7 +26,7 @@ public:
   MOCK_METHOD(Network::TransportSocketOptionsConstSharedPtr, upstreamTransportSocketOptions, (),
               (const));
   MOCK_METHOD(absl::optional<OverrideHost>, overrideHostToSelect, (), (const));
-  MOCK_METHOD(void, onAsyncHostSelection, (HostConstSharedPtr host));
+  MOCK_METHOD(void, onAsyncHostSelection, (HostConstSharedPtr && host));
 
 private:
   HealthyAndDegradedLoad priority_load_;

--- a/test/mocks/upstream/thread_local_cluster.h
+++ b/test/mocks/upstream/thread_local_cluster.h
@@ -33,7 +33,7 @@ public:
   MOCK_METHOD(absl::optional<HttpPoolData>, httpConnPool,
               (HostConstSharedPtr host, ResourcePriority priority,
                absl::optional<Http::Protocol> downstream_protocol, LoadBalancerContext* context));
-  MOCK_METHOD(HostConstSharedPtr, chooseHost, (LoadBalancerContext * context));
+  MOCK_METHOD(HostSelectionResponse, chooseHost, (LoadBalancerContext * context));
   MOCK_METHOD(absl::optional<TcpPoolData>, tcpConnPool,
               (HostConstSharedPtr host, ResourcePriority priority, LoadBalancerContext* context));
   MOCK_METHOD(absl::optional<TcpPoolData>, tcpConnPool,


### PR DESCRIPTION
refactor for https://github.com/envoyproxy/envoy/pull/38007

This adds async APIs for chooseHost.  All endpoints treat async resolution as resolution failure, canceling the lookup and proceeding with null host.

Risk Level: medium
Testing: in followup
Docs Changes: n/a
Release Notes: n/a