### PR TITLE
Fix contrib/cryptomb/private_key_providers/test:speed_test build in FIPS mode

### DIFF
--- a/contrib/cryptomb/private_key_providers/test/speed_test.cc
+++ b/contrib/cryptomb/private_key_providers/test/speed_test.cc
@@ -331,7 +331,7 @@ void verifyP256(uint8_t* ciphertext, uint8_t* secret) {
   bssl::UniquePtr<BIGNUM> key(BN_new());
   BN_bin2bn(p256Key().data(), p256Key().size(), key.get());
 
-  const EC_GROUP* group = EC_group_p256();
+  const EC_GROUP* group = EC_GROUP_new_by_curve_name(NID_X9_62_prime256v1);
   bssl::UniquePtr<EC_POINT> point(EC_POINT_new(group));
   EC_POINT_oct2point(group, point.get(), ciphertext, 65, nullptr);
   bssl::UniquePtr<EC_POINT> result(EC_POINT_new(group));
@@ -418,7 +418,7 @@ static void BM_P256_Computing(benchmark::State& state) {
   uint8_t ciphertext[65];
   uint8_t secret[32];
   for (auto _ : state) { // NOLINT
-    const EC_GROUP* group = EC_group_p256();
+    const EC_GROUP* group = EC_GROUP_new_by_curve_name(NID_X9_62_prime256v1);
     bssl::UniquePtr<BIGNUM> priv_key(BN_new());
     BN_rand_range_ex(priv_key.get(), 1, EC_GROUP_get0_order(group));
     bssl::UniquePtr<EC_POINT> public_key(EC_POINT_new(group));
@@ -446,7 +446,7 @@ BENCHMARK(BM_P256_Computing);
 #ifndef IPP_CRYPTO_DISABLED
 // NOLINTNEXTLINE(readability-identifier-naming)
 static void BM_P256_Computing_CryptoMB(benchmark::State& state) {
-  const EC_GROUP* group = EC_group_p256();
+  const EC_GROUP* group = EC_GROUP_new_by_curve_name(NID_X9_62_prime256v1);
   uint8_t ciphertext[8][65];
   uint8_t secret[8][32];
   for (auto _ : state) { // NOLINT


### PR DESCRIPTION
Commit Message:

Some of the tests in that file rely on EC_group_p256 function that was first introduced in
https://github.com/google/boringssl/commit/417069f8b2fd6dd4f8c2f5f69de7c038a2397050. Evnidently the version of BoringSSL that Envoy uses in FIPS mode does not contain this change. Because of that build of speed_test.cc fails.

To fix the issue I'm replacing calls to EC_group_p256 with EC_GROUP_new_by_curve_name(NID_X9_62_prime256v1). To the best of my knowledge functionally it should be exactly the same thing.

NOTE: Probably a more long term solution would be to update the version of BoringSSL we are using to newer one, as the current one is more than 2 years old at this point. However, it's a bit more work than I can do right now, thuse this temporary fix. I will return to the question of updating BoringSSL though affter I close the ongoing bugs.

Additional Description: n/a
Risk Level: low
Testing: tested that builds work now and that all tests in //contrib/cryptomb/private_key_providers/test are still passing.
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a