### PR TITLE
Docs: Fix broken refs and attention blocks

### DIFF
--- a/api/envoy/config/core/v3/health_check.proto
+++ b/api/envoy/config/core/v3/health_check.proto
@@ -375,6 +375,7 @@ message HealthCheck {
   // The default value for "healthy edge interval" is the same as the default interval.
   google.protobuf.Duration healthy_edge_interval = 16 [(validate.rules).duration = {gt {}}];
 
+  //
   // .. attention::
   //   This field is deprecated in favor of the extension
   //   :ref:`event_logger <envoy_v3_api_field_config.core.v3.HealthCheck.event_logger>` and

--- a/api/envoy/config/core/v3/health_check.proto
+++ b/api/envoy/config/core/v3/health_check.proto
@@ -375,14 +375,13 @@ message HealthCheck {
   // The default value for "healthy edge interval" is the same as the default interval.
   google.protobuf.Duration healthy_edge_interval = 16 [(validate.rules).duration = {gt {}}];
 
+  // Specifies the path to the :ref:`health check event log <arch_overview_health_check_logging>`.
   //
   // .. attention::
   //   This field is deprecated in favor of the extension
   //   :ref:`event_logger <envoy_v3_api_field_config.core.v3.HealthCheck.event_logger>` and
   //   :ref:`event_log_path <envoy_v3_api_field_extensions.health_check.event_sinks.file.v3.HealthCheckEventFileSink.event_log_path>`
   //   in the file sink extension.
-  //
-  // Specifies the path to the :ref:`health check event log <arch_overview_health_check_logging>`.
   string event_log_path = 17
       [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
 

--- a/api/envoy/config/core/v3/health_check.proto
+++ b/api/envoy/config/core/v3/health_check.proto
@@ -376,10 +376,10 @@ message HealthCheck {
   google.protobuf.Duration healthy_edge_interval = 16 [(validate.rules).duration = {gt {}}];
 
   // .. attention::
-  // This field is deprecated in favor of the extension
-  // :ref:`event_logger <envoy_v3_api_field_config.core.v3.HealthCheck.event_logger>` and
-  // :ref:`event_log_path <envoy_v3_api_field_extensions.health_check.event_sinks.file.v3.HealthCheckEventFileSink.event_log_path>`
-  // in the file sink extension.
+  //   This field is deprecated in favor of the extension
+  //   :ref:`event_logger <envoy_v3_api_field_config.core.v3.HealthCheck.event_logger>` and
+  //   :ref:`event_log_path <envoy_v3_api_field_extensions.health_check.event_sinks.file.v3.HealthCheckEventFileSink.event_log_path>`
+  //   in the file sink extension.
   //
   // Specifies the path to the :ref:`health check event log <arch_overview_health_check_logging>`.
   string event_log_path = 17

--- a/api/envoy/extensions/filters/http/cors/v3/cors.proto
+++ b/api/envoy/extensions/filters/http/cors/v3/cors.proto
@@ -21,7 +21,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // [#extension: envoy.filters.http.cors]
 
 // Cors filter config. Set this in
-// ref:`http_filters <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.http_filters>`
+// :ref:`http_filters <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.http_filters>`
 // to enable the CORS filter.
 //
 // Please note that the :ref:`CorsPolicy <envoy_v3_api_msg_extensions.filters.http.cors.v3.CorsPolicy>`

--- a/api/envoy/extensions/filters/network/tcp_proxy/v3/tcp_proxy.proto
+++ b/api/envoy/extensions/filters/network/tcp_proxy/v3/tcp_proxy.proto
@@ -228,6 +228,7 @@ message TcpProxy {
   google.protobuf.Duration max_downstream_connection_duration = 13
       [(validate.rules).duration = {gte {nanos: 1000000}}];
 
+  //
   // .. attention::
   //   This field is deprecated in favor of
   //   :ref:`access_log_flush_interval
@@ -241,6 +242,7 @@ message TcpProxy {
     (envoy.annotations.deprecated_at_minor_version) = "3.0"
   ];
 
+  //
   // .. attention::
   //   This field is deprecated in favor of
   //   :ref:`flush_access_log_on_connected

--- a/api/envoy/extensions/filters/network/tcp_proxy/v3/tcp_proxy.proto
+++ b/api/envoy/extensions/filters/network/tcp_proxy/v3/tcp_proxy.proto
@@ -229,12 +229,12 @@ message TcpProxy {
       [(validate.rules).duration = {gte {nanos: 1000000}}];
 
   // .. attention::
-  // This field is deprecated in favor of
-  // :ref:`access_log_flush_interval
-  // <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.TcpAccessLogOptions.access_log_flush_interval>`.
-  // Note that if both this field and :ref:`access_log_flush_interval
-  // <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.TcpAccessLogOptions.access_log_flush_interval>`
-  // are specified, the former (deprecated field) is ignored.
+  //   This field is deprecated in favor of
+  //   :ref:`access_log_flush_interval
+  //   <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.TcpAccessLogOptions.access_log_flush_interval>`.
+  //   Note that if both this field and :ref:`access_log_flush_interval
+  //   <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.TcpAccessLogOptions.access_log_flush_interval>`
+  //   are specified, the former (deprecated field) is ignored.
   google.protobuf.Duration access_log_flush_interval = 15 [
     deprecated = true,
     (validate.rules).duration = {gte {nanos: 1000000}},
@@ -242,12 +242,12 @@ message TcpProxy {
   ];
 
   // .. attention::
-  // This field is deprecated in favor of
-  // :ref:`flush_access_log_on_connected
-  // <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.TcpAccessLogOptions.flush_access_log_on_connected>`.
-  // Note that if both this field and :ref:`flush_access_log_on_connected
-  // <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.TcpAccessLogOptions.flush_access_log_on_connected>`
-  // are specified, the former (deprecated field) is ignored.
+  //   This field is deprecated in favor of
+  //   :ref:`flush_access_log_on_connected
+  //   <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.TcpAccessLogOptions.flush_access_log_on_connected>`.
+  //   Note that if both this field and :ref:`flush_access_log_on_connected
+  //   <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.TcpAccessLogOptions.flush_access_log_on_connected>`
+  //   are specified, the former (deprecated field) is ignored.
   bool flush_access_log_on_connected = 16
       [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
 

--- a/api/envoy/extensions/filters/network/tcp_proxy/v3/tcp_proxy.proto
+++ b/api/envoy/extensions/filters/network/tcp_proxy/v3/tcp_proxy.proto
@@ -228,28 +228,28 @@ message TcpProxy {
   google.protobuf.Duration max_downstream_connection_duration = 13
       [(validate.rules).duration = {gte {nanos: 1000000}}];
 
+  // Note that if both this field and :ref:`access_log_flush_interval
+  // <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.TcpAccessLogOptions.access_log_flush_interval>`
+  // are specified, the former (deprecated field) is ignored.
   //
   // .. attention::
   //   This field is deprecated in favor of
   //   :ref:`access_log_flush_interval
   //   <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.TcpAccessLogOptions.access_log_flush_interval>`.
-  //   Note that if both this field and :ref:`access_log_flush_interval
-  //   <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.TcpAccessLogOptions.access_log_flush_interval>`
-  //   are specified, the former (deprecated field) is ignored.
   google.protobuf.Duration access_log_flush_interval = 15 [
     deprecated = true,
     (validate.rules).duration = {gte {nanos: 1000000}},
     (envoy.annotations.deprecated_at_minor_version) = "3.0"
   ];
 
+  // Note that if both this field and :ref:`flush_access_log_on_connected
+  // <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.TcpAccessLogOptions.flush_access_log_on_connected>`
+  // are specified, the former (deprecated field) is ignored.
   //
   // .. attention::
   //   This field is deprecated in favor of
   //   :ref:`flush_access_log_on_connected
   //   <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.TcpAccessLogOptions.flush_access_log_on_connected>`.
-  //   Note that if both this field and :ref:`flush_access_log_on_connected
-  //   <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.TcpAccessLogOptions.flush_access_log_on_connected>`
-  //   are specified, the former (deprecated field) is ignored.
   bool flush_access_log_on_connected = 16
       [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
 

--- a/docs/root/configuration/http/http_filters/compressor_filter.rst
+++ b/docs/root/configuration/http/http_filters/compressor_filter.rst
@@ -165,7 +165,7 @@ specific to responses only:
   header_not_valid, Counter, Number of requests sent with a not valid ``accept-encoding`` header (aka ``q=0`` or an unsupported encoding type).
   not_compressed_etag, Counter, Number of requests that were not compressed due to the etag header. ``disable_on_etag_header`` must be turned on for this to happen.
 
-.. attention:
+.. attention::
 
    In case the compressor is not configured to compress responses with the field
    ``response_direction_config`` of the :ref:`Compressor <envoy_v3_api_msg_extensions.filters.http.compressor.v3.Compressor>`

--- a/docs/root/intro/arch_overview/upstream/connection_pooling.rst
+++ b/docs/root/intro/arch_overview/upstream/connection_pooling.rst
@@ -97,7 +97,7 @@ both IPv4 and IPv6 addresses. For clusters which use
 by specifying additional IP addresses for a host using the
 :ref:`additional_addresses <envoy_v3_api_field_config.endpoint.v3.Endpoint.additional_addresses>` field.
 The addresses specified in this field will be appended in a list to the one specified in
-:ref:`address <envoy_v3_api_field_config.endpoint.v3.Endpoint.address>`
+:ref:`address <envoy_v3_api_field_config.endpoint.v3.Endpoint.address>`.
 
 The list of all addresses will be sorted according the the Happy Eyeballs
 specification and a connection will be attempted to the first in the list. If this connection succeeds,
@@ -108,7 +108,7 @@ Eventually an attempt will succeed to one of the addresses in which case that co
 all attempts will fail in which case a connection error will be reported.
 
 HTTP/3 has limited Happy-Eyeballs-like support.
-When using ref:`auto_config <envoy_v3_api_field_extensions.upstreams.http.v3.HttpProtocolOptions.auto_config>`
+When using :ref:`auto_config <envoy_v3_api_field_extensions.upstreams.http.v3.HttpProtocolOptions.auto_config>`
 for HTTP/3 with TCP-failover, Envoy will make a best-effort attempt to try two address families. As with TCP
 Happy Eyeballs support, Envoy allows 300ms for the first HTTP/3 attempt to connect. If the connection explicitly
 fails or the 300ms timeout expires, if DNS resolution results in the first two resolved addresses being of


### PR DESCRIPTION
Commit Message: Docs: Fix broken refs and attention blocks
Additional Description:
ReStructuredText has a way to cross-reference sources using the :ref: syntax. It turns out that going over `/api/` (excluding `api/envoy/**/v2/*`) and `/docs` with regex `[^:]ref:` showed some hits, meaning the syntax was not parsed and the link was broken.

The same for the text blocks like `.. attention::`, the text to be highlighted needs to be indented with at least 2 spaces, otherwise the block is not interpreted, this was done using `\/\/\s+\.\.\s\w+::\n\s+\/\/(\s{0,1}\w)`
Risk Level: None
Docs Changes: 
- https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/tcp_proxy/v3/tcp_proxy.proto.html#extensions-filters-network-tcp-proxy-v3-tcpproxy
- https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/http/cors/v3/cors.proto.html#extensions-filters-http-cors-v3-cors
- https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/health_check.proto.html#config-core-v3-healthcheck
- https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/connection_pooling.html#happy-eyeballs-support
- https://www.envoyproxy.io/docs/envoy/v1.33.0/configuration/http/http_filters/compressor_filter#statistics
