### PR TITLE
Add integration test for upstream filters with AsyncClient

### DIFF
--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -611,6 +611,7 @@ envoy_cc_test(
         ":integration_lib",
         "//test/integration/filters:add_header_filter_config_lib",
         "//test/integration/filters:add_header_filter_proto_cc_proto",
+        "//test/integration/filters:async_upstream_filter_lib",
         "//test/integration/filters:on_local_reply_filter_config_lib",
         "//test/integration/filters:repick_cluster_filter_lib",
         "@envoy_api//envoy/config/bootstrap/v3:pkg_cc_proto",

--- a/test/integration/filters/BUILD
+++ b/test/integration/filters/BUILD
@@ -20,6 +20,11 @@ envoy_proto_library(
 )
 
 envoy_proto_library(
+    name = "async_upstream_filter_proto",
+    srcs = ["async_upstream_filter.proto"],
+)
+
+envoy_proto_library(
     name = "test_listener_filter_proto",
     srcs = ["test_listener_filter.proto"],
 )
@@ -73,6 +78,20 @@ envoy_cc_test_library(
         "//test/extensions/filters/http/common:empty_http_filter_config_lib",
     ],
     alwayslink = 1,
+)
+
+envoy_cc_test_library(
+    name = "async_upstream_filter_lib",
+    srcs = ["async_upstream_filter.cc"],
+    deps = [
+        ":async_upstream_filter_proto_cc_proto",
+        ":common_lib",
+        "//envoy/http:filter_interface",
+        "//envoy/registry",
+        "//envoy/server:filter_config_interface",
+        "//source/extensions/filters/http/common:factory_base_lib",
+        "//source/extensions/filters/http/common:pass_through_filter_lib",
+    ],
 )
 
 envoy_cc_test_library(

--- a/test/integration/filters/async_upstream_filter.cc
+++ b/test/integration/filters/async_upstream_filter.cc
@@ -1,0 +1,98 @@
+
+
+#include "envoy/http/filter.h"
+#include "envoy/registry/registry.h"
+#include "envoy/server/filter_config.h"
+
+#include "source/extensions/filters/http/common/factory_base.h"
+#include "source/extensions/filters/http/common/pass_through_filter.h"
+
+#include "test/integration/filters/async_upstream_filter.pb.h"
+#include "test/integration/filters/async_upstream_filter.pb.validate.h"
+#include "test/integration/filters/common.h"
+
+namespace Envoy {
+
+class AsyncUpstreamFilter : public Http::PassThroughFilter,
+                            public Http::AsyncClient::StreamCallbacks {
+public:
+  AsyncUpstreamFilter(Upstream::ClusterManager& cluster_manager)
+      : cluster_manager_(cluster_manager) {}
+
+  absl::string_view clusterName() {
+    Router::RouteConstSharedPtr route = decoder_callbacks_->route();
+    RELEASE_ASSERT(route != nullptr, "no error handling in AsyncUpstreamFilter yet");
+    const Router::RouteEntry* route_entry = route->routeEntry();
+    RELEASE_ASSERT(route_entry != nullptr, "no error handling in AsyncUpstreamFilter yet");
+    return route_entry->clusterName();
+  }
+
+  Http::AsyncClient& asyncClient(absl::string_view cluster_name) {
+    Upstream::ThreadLocalCluster* thread_local_cluster =
+        cluster_manager_.getThreadLocalCluster(cluster_name);
+    RELEASE_ASSERT(thread_local_cluster != nullptr, "no error handling in AsyncUpstreamFilter yet");
+    return thread_local_cluster->httpAsyncClient();
+  }
+
+  Http::FilterHeadersStatus decodeHeaders(Http::RequestHeaderMap& headers,
+                                          bool end_stream) override {
+    RELEASE_ASSERT(end_stream, "AsyncUpstreamFilter doesn't support request body or trailers yet");
+    absl::string_view cluster_name = clusterName();
+    Http::AsyncClient& async_client = asyncClient(cluster_name);
+    sendHeaders(async_client, headers, end_stream);
+    return Http::FilterHeadersStatus::StopIteration;
+  }
+
+  void sendHeaders(Http::AsyncClient& async_client, Http::RequestHeaderMap& headers,
+                   bool end_stream) {
+    stream_ = async_client.start(*this, Http::AsyncClient::StreamOptions());
+    stream_->sendHeaders(headers, end_stream);
+  }
+
+  // StreamCallbacks
+  void onHeaders(Http::ResponseHeaderMapPtr&& headers, bool end_stream) override {
+    decoder_callbacks_->encodeHeaders(std::move(headers), end_stream, "async_upstream_filtered");
+  }
+  void onData(Buffer::Instance& buffer, bool end_stream) override {
+    decoder_callbacks_->encodeData(buffer, end_stream);
+  }
+  void onTrailers(Http::ResponseTrailerMapPtr&& trailers) override {
+    decoder_callbacks_->encodeTrailers(std::move(trailers));
+  }
+  void onComplete() override { stream_ = nullptr; }
+  void onReset() override {}
+
+  ~AsyncUpstreamFilter() {
+    if (stream_) {
+      stream_->reset();
+    }
+  }
+
+private:
+  Upstream::ClusterManager& cluster_manager_;
+  Http::AsyncClient::Stream* stream_{nullptr};
+};
+
+class AsyncUpstreamFilterFactory : public Extensions::HttpFilters::Common::DualFactoryBase<
+                                       test::integration::filters::AsyncUpstreamFilterConfig> {
+public:
+  AsyncUpstreamFilterFactory() : DualFactoryBase("envoy.test.async_upstream") {}
+
+  absl::StatusOr<Http::FilterFactoryCb>
+  createFilterFactoryFromProtoTyped(const test::integration::filters::AsyncUpstreamFilterConfig&,
+                                    const std::string&, DualInfo,
+                                    Server::Configuration::ServerFactoryContext& context) override {
+    return [&cluster_manager =
+                context.clusterManager()](Http::FilterChainFactoryCallbacks& callbacks) -> void {
+      callbacks.addStreamFilter(std::make_shared<AsyncUpstreamFilter>(cluster_manager));
+    };
+  };
+};
+
+using UpstreamAsyncUpstreamFilterFactory = AsyncUpstreamFilterFactory;
+
+REGISTER_FACTORY(AsyncUpstreamFilterFactory, Server::Configuration::NamedHttpFilterConfigFactory);
+REGISTER_FACTORY(UpstreamAsyncUpstreamFilterFactory,
+                 Server::Configuration::UpstreamHttpFilterConfigFactory);
+
+} // namespace Envoy

--- a/test/integration/filters/async_upstream_filter.proto
+++ b/test/integration/filters/async_upstream_filter.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+
+package test.integration.filters;
+
+// This filter intercepts the request from downstream and reissues the same
+// request via an AsyncClient, which should bypass the rest of the main
+// filter chain, and still pass through all relevant upstream filters.
+//
+// Currently supports only header-only requests.
+message AsyncUpstreamFilterConfig {
+}


### PR DESCRIPTION
Commit Message: Add integration test for upstream filters with AsyncClient
Additional Description: Behaviors were non-obvious to me and as far as I can tell there were no tests ensuring that the behavior is what it is; this adds a test for "AsyncClient bypasses router upstream filters but uses cluster upstream filters" and a test for "if both router and cluster upstream filters are set, router upstreams are ignored".
Risk Level: None, test-only.
Testing: Yes it is.
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
