### PR TITLE
mobile: Set the default DNS number of retries on Android to 3

### DIFF
--- a/mobile/library/cc/engine_builder.h
+++ b/mobile/library/cc/engine_builder.h
@@ -152,7 +152,7 @@ private:
   int dns_failure_refresh_seconds_base_ = 2;
   int dns_failure_refresh_seconds_max_ = 10;
   int dns_query_timeout_seconds_ = 5;
-  absl::optional<uint32_t> dns_num_retries_ = absl::nullopt;
+  absl::optional<uint32_t> dns_num_retries_ = 3;
   int h2_connection_keepalive_idle_interval_milliseconds_ = 100000000;
   int h2_connection_keepalive_timeout_seconds_ = 10;
   std::string app_version_ = "unspecified";


### PR DESCRIPTION
Prior to this PR, when `getaddrinfo` returns `EAI_AGAIN`, the code would retry the DNS indefinitely as can be seen in this CI failure: https://github.com/envoyproxy/envoy/actions/runs/12818760153/job/35744940259. This PR updates the default number of retries to 3.

Risk Level: low
Testing: CI
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: android
