### PR TITLE
[mobile]Skip applying IP_TTL options

### DIFF
--- a/envoy/network/socket.h
+++ b/envoy/network/socket.h
@@ -558,6 +558,11 @@ public:
       return true;
     }
     for (const auto& option : *options) {
+      auto details = option->getOptionDetails(socket, state);
+      if (details.has_value() && (details->name_.name() == "IPPROTO_IPV6/IPV6_UNICAST_HOPS" ||
+                                  details->name_.name() == "IPPROTO_IP/IP_TTL")) {
+        continue;
+      }
       if (!option->setOption(socket, state)) {
         return false;
       }


### PR DESCRIPTION
Commit Message: Skip applying IP_TTL options.
Additional Description: This option is used by Envoy Mobile only to direct requests from different networks to different connections. However, setting this option has real world impacts. The option should just be used to calculate connection pool hash keys but should not be applied when setting up a real connection. 
Risk Level: low
Testing: existing tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: mobile only
