### PR TITLE
Remove incorrect/outdated doc for explicit_http_config

### DIFF
--- a/api/envoy/extensions/upstreams/http/v3/http_protocol_options.proto
+++ b/api/envoy/extensions/upstreams/http/v3/http_protocol_options.proto
@@ -140,7 +140,6 @@ message HttpProtocolOptions {
     option (validate.required) = true;
 
     // To explicitly configure either HTTP/1 or HTTP/2 (but not both!) use ``explicit_http_config``.
-    // If the ``explicit_http_config`` is empty, HTTP/1.1 is used.
     ExplicitHttpConfig explicit_http_config = 3;
 
     // This allows switching on protocol based on what protocol the downstream


### PR DESCRIPTION
Commit Message: Remove incorrect/outdated doc for explicit_http_config
Additional Description: Per #38064, this docstring became incorrect with #14362 so should be removed.
Risk Level: None, doc-only.
Testing: n/a
Docs Changes: Yes it is.
Release Notes: n/a
Platform Specific Features: n/a
