### PR TITLE
Attempt to partially fix docgen for Cluster proto

### DIFF
--- a/api/envoy/config/cluster/v3/cluster.proto
+++ b/api/envoy/config/cluster/v3/cluster.proto
@@ -942,7 +942,7 @@ message Cluster {
   // "envoy.filters.network.thrift_proxy". See the extension's documentation for details on
   // specific options.
   // [#next-major-version: make this a list of typed extensions.]
-  // [#extension-category: envoy.cluster.protocol_options]
+  // [#extension-category: envoy.upstream_options]
   map<string, google.protobuf.Any> typed_extension_protocol_options = 36;
 
   // If the DNS refresh rate is specified and the cluster type is either

--- a/api/envoy/config/cluster/v3/cluster.proto
+++ b/api/envoy/config/cluster/v3/cluster.proto
@@ -942,6 +942,7 @@ message Cluster {
   // "envoy.filters.network.thrift_proxy". See the extension's documentation for details on
   // specific options.
   // [#next-major-version: make this a list of typed extensions.]
+  // [#extension-category: envoy.cluster.protocol_options]
   map<string, google.protobuf.Any> typed_extension_protocol_options = 36;
 
   // If the DNS refresh rate is specified and the cluster type is either

--- a/source/extensions/extensions_metadata.yaml
+++ b/source/extensions/extensions_metadata.yaml
@@ -1368,7 +1368,7 @@ envoy.upstreams.http.http:
   status: stable
 envoy.upstreams.http.http_protocol_options:
   categories:
-  - envoy.upstreams
+  - envoy.cluster.protocol_options
   security_posture: robust_to_untrusted_downstream
   status: stable
 envoy.upstreams.http.tcp:
@@ -1388,7 +1388,7 @@ envoy.upstreams.tcp.generic:
   status: stable
 envoy.upstreams.tcp.tcp_protocol_options:
   categories:
-  - envoy.upstreams
+  - envoy.cluster.protocol_options
   security_posture: unknown
   status: alpha
 envoy.upstream.local_address_selector.default_local_address_selector:

--- a/source/extensions/extensions_metadata.yaml
+++ b/source/extensions/extensions_metadata.yaml
@@ -1368,7 +1368,7 @@ envoy.upstreams.http.http:
   status: stable
 envoy.upstreams.http.http_protocol_options:
   categories:
-  - envoy.cluster.protocol_options
+  - envoy.upstream_options
   security_posture: robust_to_untrusted_downstream
   status: stable
 envoy.upstreams.http.tcp:
@@ -1388,7 +1388,7 @@ envoy.upstreams.tcp.generic:
   status: stable
 envoy.upstreams.tcp.tcp_protocol_options:
   categories:
-  - envoy.cluster.protocol_options
+  - envoy.upstream_options
   security_posture: unknown
   status: alpha
 envoy.upstream.local_address_selector.default_local_address_selector:

--- a/tools/extensions/extensions_schema.yaml
+++ b/tools/extensions/extensions_schema.yaml
@@ -64,6 +64,7 @@ security_postures:
 categories:
 - envoy.access_loggers
 - envoy.bootstrap
+- envoy.cluster.protocol_options
 - envoy.clusters
 - envoy.compression.compressor
 - envoy.compression.decompressor

--- a/tools/extensions/extensions_schema.yaml
+++ b/tools/extensions/extensions_schema.yaml
@@ -64,7 +64,6 @@ security_postures:
 categories:
 - envoy.access_loggers
 - envoy.bootstrap
-- envoy.cluster.protocol_options
 - envoy.clusters
 - envoy.compression.compressor
 - envoy.compression.decompressor
@@ -93,6 +92,7 @@ categories:
 - envoy.matching.common_inputs
 - envoy.matching.input_matchers
 - envoy.tls.key_providers
+- envoy.upstream_options
 - envoy.quic.connection_debug_visitor
 - envoy.quic.connection_id_generator
 - envoy.quic.proof_source


### PR DESCRIPTION
Commit Message: Attempt to partially fix docgen for Cluster proto
Additional Description: `http_protocol_options` does not in fact work in `upstream_config`, it works in `typed_extension_protocol_options`. This PR changes the docgen behavior to reflect what actually works rather than being misleading. I don't know what else needs to be moved, I do know `upstream_config` only accepts four types, but the types I logged while debugging why `http_protocol_options` didn't work don't *clearly* map to the types in the tip at all so I'm not sure how to fix. It's clear `tcp.generic` doesn't belong, but I don't know where it should be moved to. This is, at least, a step in the right direction.

The set that does belong in `upstream_config` according to logging is:
```
envoy.filters.connection_pools.http.generic
envoy.filters.connection_pools.http.http
envoy.filters.connection_pools.http.tcp
envoy.filters.connection_pools.http.udp
```

![Screenshot by Dropbox Capture](https://github.com/user-attachments/assets/3d350e3b-22b0-442e-8ec6-75aac38a7e81)
and
![Screenshot by Dropbox Capture](https://github.com/user-attachments/assets/b85b1ced-9485-4d00-9733-816c22223a2e)

This partially addresses #38065 and might have been helpful in #37840 