### PR TITLE
dynamic_modules: traitify EnvoyHttpFilterConfig to match EnvoyHttpFilter

### DIFF
--- a/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
@@ -129,7 +129,7 @@ pub trait HttpFilter<EHF: EnvoyHttpFilter> {
   /// indicate the status of the request headers processing.
   fn on_request_headers(
     &mut self,
-    _envoy_filter: EHF,
+    _envoy_filter: &mut EHF,
     _end_of_stream: bool,
   ) -> abi::envoy_dynamic_module_type_on_http_filter_request_headers_status {
     abi::envoy_dynamic_module_type_on_http_filter_request_headers_status::Continue
@@ -143,7 +143,7 @@ pub trait HttpFilter<EHF: EnvoyHttpFilter> {
   /// indicate the status of the request body processing.
   fn on_request_body(
     &mut self,
-    _envoy_filter: EHF,
+    _envoy_filter: &mut EHF,
     _end_of_stream: bool,
   ) -> abi::envoy_dynamic_module_type_on_http_filter_request_body_status {
     abi::envoy_dynamic_module_type_on_http_filter_request_body_status::Continue
@@ -156,7 +156,7 @@ pub trait HttpFilter<EHF: EnvoyHttpFilter> {
   /// indicate the status of the request trailers processing.
   fn on_request_trailers(
     &mut self,
-    _envoy_filter: EHF,
+    _envoy_filter: &mut EHF,
   ) -> abi::envoy_dynamic_module_type_on_http_filter_request_trailers_status {
     abi::envoy_dynamic_module_type_on_http_filter_request_trailers_status::Continue
   }
@@ -169,7 +169,7 @@ pub trait HttpFilter<EHF: EnvoyHttpFilter> {
   /// indicate the status of the response headers processing.
   fn on_response_headers(
     &mut self,
-    _envoy_filter: EHF,
+    _envoy_filter: &mut EHF,
     _end_of_stream: bool,
   ) -> abi::envoy_dynamic_module_type_on_http_filter_response_headers_status {
     abi::envoy_dynamic_module_type_on_http_filter_response_headers_status::Continue
@@ -183,7 +183,7 @@ pub trait HttpFilter<EHF: EnvoyHttpFilter> {
   /// indicate the status of the response body processing.
   fn on_response_body(
     &mut self,
-    _envoy_filter: EHF,
+    _envoy_filter: &mut EHF,
     _end_of_stream: bool,
   ) -> abi::envoy_dynamic_module_type_on_http_filter_response_body_status {
     abi::envoy_dynamic_module_type_on_http_filter_response_body_status::Continue
@@ -197,7 +197,7 @@ pub trait HttpFilter<EHF: EnvoyHttpFilter> {
   /// indicate the status of the response trailers processing.
   fn on_response_trailers(
     &mut self,
-    _envoy_filter: EHF,
+    _envoy_filter: &mut EHF,
   ) -> abi::envoy_dynamic_module_type_on_http_filter_response_trailers_status {
     abi::envoy_dynamic_module_type_on_http_filter_response_trailers_status::Continue
   }
@@ -885,7 +885,7 @@ unsafe extern "C" fn envoy_dynamic_module_on_http_filter_request_headers(
 ) -> abi::envoy_dynamic_module_type_on_http_filter_request_headers_status {
   let filter = filter_ptr as *mut *mut dyn HttpFilter<EnvoyHttpFilterImpl>;
   let filter = &mut **filter;
-  filter.on_request_headers(EnvoyHttpFilterImpl::new(envoy_ptr), end_of_stream)
+  filter.on_request_headers(&mut EnvoyHttpFilterImpl::new(envoy_ptr), end_of_stream)
 }
 
 #[no_mangle]
@@ -896,7 +896,7 @@ unsafe extern "C" fn envoy_dynamic_module_on_http_filter_request_body(
 ) -> abi::envoy_dynamic_module_type_on_http_filter_request_body_status {
   let filter = filter_ptr as *mut *mut dyn HttpFilter<EnvoyHttpFilterImpl>;
   let filter = &mut **filter;
-  filter.on_request_body(EnvoyHttpFilterImpl::new(envoy_ptr), end_of_stream)
+  filter.on_request_body(&mut EnvoyHttpFilterImpl::new(envoy_ptr), end_of_stream)
 }
 
 #[no_mangle]
@@ -906,7 +906,7 @@ unsafe extern "C" fn envoy_dynamic_module_on_http_filter_request_trailers(
 ) -> abi::envoy_dynamic_module_type_on_http_filter_request_trailers_status {
   let filter = filter_ptr as *mut *mut dyn HttpFilter<EnvoyHttpFilterImpl>;
   let filter = &mut **filter;
-  filter.on_request_trailers(EnvoyHttpFilterImpl::new(envoy_ptr))
+  filter.on_request_trailers(&mut EnvoyHttpFilterImpl::new(envoy_ptr))
 }
 
 #[no_mangle]
@@ -917,7 +917,7 @@ unsafe extern "C" fn envoy_dynamic_module_on_http_filter_response_headers(
 ) -> abi::envoy_dynamic_module_type_on_http_filter_response_headers_status {
   let filter = filter_ptr as *mut *mut dyn HttpFilter<EnvoyHttpFilterImpl>;
   let filter = &mut **filter;
-  filter.on_response_headers(EnvoyHttpFilterImpl::new(envoy_ptr), end_of_stream)
+  filter.on_response_headers(&mut EnvoyHttpFilterImpl::new(envoy_ptr), end_of_stream)
 }
 
 #[no_mangle]
@@ -928,7 +928,7 @@ unsafe extern "C" fn envoy_dynamic_module_on_http_filter_response_body(
 ) -> abi::envoy_dynamic_module_type_on_http_filter_response_body_status {
   let filter = filter_ptr as *mut *mut dyn HttpFilter<EnvoyHttpFilterImpl>;
   let filter = &mut **filter;
-  filter.on_response_body(EnvoyHttpFilterImpl::new(envoy_ptr), end_of_stream)
+  filter.on_response_body(&mut EnvoyHttpFilterImpl::new(envoy_ptr), end_of_stream)
 }
 
 #[no_mangle]
@@ -938,5 +938,5 @@ unsafe extern "C" fn envoy_dynamic_module_on_http_filter_response_trailers(
 ) -> abi::envoy_dynamic_module_type_on_http_filter_response_trailers_status {
   let filter = filter_ptr as *mut *mut dyn HttpFilter<EnvoyHttpFilterImpl>;
   let filter = &mut **filter;
-  filter.on_response_trailers(EnvoyHttpFilterImpl::new(envoy_ptr))
+  filter.on_response_trailers(&mut EnvoyHttpFilterImpl::new(envoy_ptr))
 }

--- a/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
@@ -842,7 +842,7 @@ fn envoy_dynamic_module_on_http_filter_config_new_impl(
 unsafe extern "C" fn envoy_dynamic_module_on_http_filter_config_destroy(
   config_ptr: abi::envoy_dynamic_module_type_http_filter_config_module_ptr,
 ) {
-  drop_wrapped_c_void_ptr!(config_ptr, 
+  drop_wrapped_c_void_ptr!(config_ptr,
     HttpFilterConfig<EnvoyHttpFilterConfigImpl,EnvoyHttpFilterImpl>);
 }
 

--- a/source/extensions/dynamic_modules/sdk/rust/src/lib_test.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/lib_test.rs
@@ -134,7 +134,7 @@ fn test_envoy_dynamic_module_on_http_filter_callbacks() {
   impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for TestHttpFilter {
     fn on_request_headers(
       &mut self,
-      _envoy_filter: EHF,
+      _envoy_filter: &mut EHF,
       _end_of_stream: bool,
     ) -> abi::envoy_dynamic_module_type_on_http_filter_request_headers_status {
       ON_REQUEST_HEADERS_CALLED.store(true, std::sync::atomic::Ordering::SeqCst);
@@ -143,7 +143,7 @@ fn test_envoy_dynamic_module_on_http_filter_callbacks() {
 
     fn on_request_body(
       &mut self,
-      _envoy_filter: EHF,
+      _envoy_filter: &mut EHF,
       _end_of_stream: bool,
     ) -> abi::envoy_dynamic_module_type_on_http_filter_request_body_status {
       ON_REQUEST_BODY_CALLED.store(true, std::sync::atomic::Ordering::SeqCst);
@@ -152,7 +152,7 @@ fn test_envoy_dynamic_module_on_http_filter_callbacks() {
 
     fn on_request_trailers(
       &mut self,
-      _envoy_filter: EHF,
+      _envoy_filter: &mut EHF,
     ) -> abi::envoy_dynamic_module_type_on_http_filter_request_trailers_status {
       ON_REQUEST_TRAILERS_CALLED.store(true, std::sync::atomic::Ordering::SeqCst);
       abi::envoy_dynamic_module_type_on_http_filter_request_trailers_status::Continue
@@ -160,7 +160,7 @@ fn test_envoy_dynamic_module_on_http_filter_callbacks() {
 
     fn on_response_headers(
       &mut self,
-      _envoy_filter: EHF,
+      _envoy_filter: &mut EHF,
       _end_of_stream: bool,
     ) -> abi::envoy_dynamic_module_type_on_http_filter_response_headers_status {
       ON_RESPONSE_HEADERS_CALLED.store(true, std::sync::atomic::Ordering::SeqCst);
@@ -169,7 +169,7 @@ fn test_envoy_dynamic_module_on_http_filter_callbacks() {
 
     fn on_response_body(
       &mut self,
-      _envoy_filter: EHF,
+      _envoy_filter: &mut EHF,
       _end_of_stream: bool,
     ) -> abi::envoy_dynamic_module_type_on_http_filter_response_body_status {
       ON_RESPONSE_BODY_CALLED.store(true, std::sync::atomic::Ordering::SeqCst);
@@ -178,7 +178,7 @@ fn test_envoy_dynamic_module_on_http_filter_callbacks() {
 
     fn on_response_trailers(
       &mut self,
-      _envoy_filter: EHF,
+      _envoy_filter: &mut EHF,
     ) -> abi::envoy_dynamic_module_type_on_http_filter_response_trailers_status {
       ON_RESPONSE_TRAILERS_CALLED.store(true, std::sync::atomic::Ordering::SeqCst);
       abi::envoy_dynamic_module_type_on_http_filter_response_trailers_status::Continue

--- a/test/extensions/dynamic_modules/test_data/rust/http.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/http.rs
@@ -13,11 +13,11 @@ fn init() -> bool {
 
 /// This implements the [`envoy_proxy_dynamic_modules_rust_sdk::NewHttpFilterConfigFunction`]
 /// signature.
-fn new_http_filter_config_fn<EHF: EnvoyHttpFilter>(
-  _envoy_filter_factory: EnvoyHttpFilterConfig,
+fn new_http_filter_config_fn<EC: EnvoyHttpFilterConfig, EHF: EnvoyHttpFilter>(
+  _envoy_filter_config: &mut EC,
   name: &str,
   _config: &str,
-) -> Option<Box<dyn HttpFilterConfig<EHF>>> {
+) -> Option<Box<dyn HttpFilterConfig<EC, EHF>>> {
   match name {
     "header_callbacks" => Some(Box::new(HeaderCallbacksFilterConfig {})),
     "send_response" => Some(Box::new(SendResponseFilterConfig {})),
@@ -33,8 +33,10 @@ fn new_http_filter_config_fn<EHF: EnvoyHttpFilter>(
 /// related callbacks.
 struct HeaderCallbacksFilterConfig {}
 
-impl<EHF: EnvoyHttpFilter> HttpFilterConfig<EHF> for HeaderCallbacksFilterConfig {
-  fn new_http_filter(&self, _envoy: EnvoyHttpFilterConfig) -> Box<dyn HttpFilter<EHF>> {
+impl<EC: EnvoyHttpFilterConfig, EHF: EnvoyHttpFilter> HttpFilterConfig<EC, EHF>
+  for HeaderCallbacksFilterConfig
+{
+  fn new_http_filter(&self, _envoy: &mut EC) -> Box<dyn HttpFilter<EHF>> {
     Box::new(HeaderCallbacksFilter {})
   }
 }
@@ -235,8 +237,10 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for HeaderCallbacksFilter {
 /// callback
 struct SendResponseFilterConfig {}
 
-impl<EHF: EnvoyHttpFilter> HttpFilterConfig<EHF> for SendResponseFilterConfig {
-  fn new_http_filter(&self, _envoy: EnvoyHttpFilterConfig) -> Box<dyn HttpFilter<EHF>> {
+impl<EC: EnvoyHttpFilterConfig, EHF: EnvoyHttpFilter> HttpFilterConfig<EC, EHF>
+  for SendResponseFilterConfig
+{
+  fn new_http_filter(&self, _envoy: &mut EC) -> Box<dyn HttpFilter<EHF>> {
     Box::new(SendResponseFilter {})
   }
 }
@@ -267,8 +271,10 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for SendResponseFilter {
 /// the default implementation.
 struct PassthroughHttpFilterConfig {}
 
-impl<EHF: EnvoyHttpFilter> HttpFilterConfig<EHF> for PassthroughHttpFilterConfig {
-  fn new_http_filter(&self, _envoy: EnvoyHttpFilterConfig) -> Box<dyn HttpFilter<EHF>> {
+impl<EC: EnvoyHttpFilterConfig, EHF: EnvoyHttpFilter> HttpFilterConfig<EC, EHF>
+  for PassthroughHttpFilterConfig
+{
+  fn new_http_filter(&self, _envoy: &mut EC) -> Box<dyn HttpFilter<EHF>> {
     Box::new(PassthroughHttpFilter {})
   }
 }
@@ -282,8 +288,10 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for PassthroughHttpFilter {}
 /// callbacks.
 struct DynamicMetadataCallbacksFilterConfig {}
 
-impl<EHF: EnvoyHttpFilter> HttpFilterConfig<EHF> for DynamicMetadataCallbacksFilterConfig {
-  fn new_http_filter(&self, _envoy: EnvoyHttpFilterConfig) -> Box<dyn HttpFilter<EHF>> {
+impl<EC: EnvoyHttpFilterConfig, EHF: EnvoyHttpFilter> HttpFilterConfig<EC, EHF>
+  for DynamicMetadataCallbacksFilterConfig
+{
+  fn new_http_filter(&self, _envoy: &mut EC) -> Box<dyn HttpFilter<EHF>> {
     Box::new(DynamicMetadataCallbacksFilter {})
   }
 }

--- a/test/extensions/dynamic_modules/test_data/rust/http.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/http.rs
@@ -47,7 +47,7 @@ struct HeaderCallbacksFilter {}
 impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for HeaderCallbacksFilter {
   fn on_request_headers(
     &mut self,
-    mut envoy_filter: EHF,
+    envoy_filter: &mut EHF,
     _end_of_stream: bool,
   ) -> abi::envoy_dynamic_module_type_on_http_filter_request_headers_status {
     // Test single getter API.
@@ -90,7 +90,7 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for HeaderCallbacksFilter {
 
   fn on_request_body(
     &mut self,
-    _envoy_filter: EHF,
+    _envoy_filter: &mut EHF,
     _end_of_stream: bool,
   ) -> abi::envoy_dynamic_module_type_on_http_filter_request_body_status {
     abi::envoy_dynamic_module_type_on_http_filter_request_body_status::Continue
@@ -98,7 +98,7 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for HeaderCallbacksFilter {
 
   fn on_request_trailers(
     &mut self,
-    mut envoy_filter: EHF,
+    envoy_filter: &mut EHF,
   ) -> abi::envoy_dynamic_module_type_on_http_filter_request_trailers_status {
     // Test single getter API.
     let single_value = envoy_filter
@@ -140,7 +140,7 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for HeaderCallbacksFilter {
 
   fn on_response_headers(
     &mut self,
-    mut envoy_filter: EHF,
+    envoy_filter: &mut EHF,
     _end_of_stream: bool,
   ) -> abi::envoy_dynamic_module_type_on_http_filter_response_headers_status {
     // Test single getter API.
@@ -183,7 +183,7 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for HeaderCallbacksFilter {
 
   fn on_response_body(
     &mut self,
-    _envoy_filter: EHF,
+    _envoy_filter: &mut EHF,
     _end_of_stream: bool,
   ) -> abi::envoy_dynamic_module_type_on_http_filter_response_body_status {
     abi::envoy_dynamic_module_type_on_http_filter_response_body_status::Continue
@@ -191,7 +191,7 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for HeaderCallbacksFilter {
 
   fn on_response_trailers(
     &mut self,
-    mut envoy_filter: EHF,
+    envoy_filter: &mut EHF,
   ) -> abi::envoy_dynamic_module_type_on_http_filter_response_trailers_status {
     // Test single getter API.
     let single_value = envoy_filter
@@ -252,7 +252,7 @@ struct SendResponseFilter {}
 impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for SendResponseFilter {
   fn on_request_headers(
     &mut self,
-    mut envoy_filter: EHF,
+    envoy_filter: &mut EHF,
     _end_of_stream: bool,
   ) -> abi::envoy_dynamic_module_type_on_http_filter_request_headers_status {
     envoy_filter.send_response(
@@ -302,7 +302,7 @@ struct DynamicMetadataCallbacksFilter {}
 impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for DynamicMetadataCallbacksFilter {
   fn on_request_headers(
     &mut self,
-    mut envoy_filter: EHF,
+    envoy_filter: &mut EHF,
     _end_of_stream: bool,
   ) -> abi::envoy_dynamic_module_type_on_http_filter_request_headers_status {
     // No namespace.
@@ -320,7 +320,7 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for DynamicMetadataCallbacksFilter {
 
   fn on_request_body(
     &mut self,
-    mut envoy_filter: EHF,
+    envoy_filter: &mut EHF,
     _end_of_stream: bool,
   ) -> abi::envoy_dynamic_module_type_on_http_filter_request_body_status {
     // No namespace.
@@ -339,7 +339,7 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for DynamicMetadataCallbacksFilter {
 
   fn on_response_headers(
     &mut self,
-    mut envoy_filter: EHF,
+    envoy_filter: &mut EHF,
     _end_of_stream: bool,
   ) -> abi::envoy_dynamic_module_type_on_http_filter_response_headers_status {
     // No namespace.
@@ -357,7 +357,7 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for DynamicMetadataCallbacksFilter {
 
   fn on_response_body(
     &mut self,
-    mut envoy_filter: EHF,
+    envoy_filter: &mut EHF,
     _end_of_stream: bool,
   ) -> abi::envoy_dynamic_module_type_on_http_filter_response_body_status {
     // No namespace.

--- a/test/extensions/dynamic_modules/test_data/rust/http_test.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/http_test.rs
@@ -58,7 +58,7 @@ fn test_header_callbacks_filter_on_request_headers() {
     .once();
 
   assert_eq!(
-    f.on_request_headers(envoy_filter, false),
+    f.on_request_headers(&mut envoy_filter, false),
     abi::envoy_dynamic_module_type_on_http_filter_request_headers_status::Continue
   );
 }
@@ -83,7 +83,7 @@ fn test_header_callbacks_on_request_headers_local_resp() {
     .return_const(());
 
   assert_eq!(
-    f.on_request_headers(envoy_filter, false),
+    f.on_request_headers(&mut envoy_filter, false),
     abi::envoy_dynamic_module_type_on_http_filter_request_headers_status::StopIteration
   );
 }

--- a/test/extensions/dynamic_modules/test_data/rust/no_op.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/no_op.rs
@@ -17,11 +17,11 @@ pub extern "C" fn getSomeVariable() -> i32 {
 
 /// This implements the [`envoy_proxy_dynamic_modules_rust_sdk::NewHttpFilterConfigFunction`]
 /// signature.
-fn new_nop_http_filter_config_fn<EHF: EnvoyHttpFilter>(
-  _envoy_filter_factory: EnvoyHttpFilterConfig,
+fn new_nop_http_filter_config_fn<EC: EnvoyHttpFilterConfig, EHF: EnvoyHttpFilter>(
+  _envoy_filter_config: &mut EC,
   name: &str,
   config: &str,
-) -> Option<Box<dyn HttpFilterConfig<EHF>>> {
+) -> Option<Box<dyn HttpFilterConfig<EC, EHF>>> {
   let name = name.to_string();
   let config = config.to_string();
   Some(Box::new(NopHttpFilterConfig { name, config }))
@@ -35,8 +35,10 @@ struct NopHttpFilterConfig {
   config: String,
 }
 
-impl<EHF: EnvoyHttpFilter> HttpFilterConfig<EHF> for NopHttpFilterConfig {
-  fn new_http_filter(&self, _envoy: EnvoyHttpFilterConfig) -> Box<dyn HttpFilter<EHF>> {
+impl<EC: EnvoyHttpFilterConfig, EHF: EnvoyHttpFilter> HttpFilterConfig<EC, EHF>
+  for NopHttpFilterConfig
+{
+  fn new_http_filter(&self, _envoy: &mut EC) -> Box<dyn HttpFilter<EHF>> {
     Box::new(NopHttpFilter {
       on_request_headers_called: false,
       on_request_body_called: false,

--- a/test/extensions/dynamic_modules/test_data/rust/no_op.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/no_op.rs
@@ -82,7 +82,7 @@ impl Drop for NopHttpFilter {
 impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for NopHttpFilter {
   fn on_request_headers(
     &mut self,
-    _envoy_filter: EHF,
+    _envoy_filter: &mut EHF,
     _end_of_stream: bool,
   ) -> abi::envoy_dynamic_module_type_on_http_filter_request_headers_status {
     self.on_request_headers_called = true;
@@ -91,7 +91,7 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for NopHttpFilter {
 
   fn on_request_body(
     &mut self,
-    _envoy_filter: EHF,
+    _envoy_filter: &mut EHF,
     _end_of_stream: bool,
   ) -> abi::envoy_dynamic_module_type_on_http_filter_request_body_status {
     self.on_request_body_called = true;
@@ -100,7 +100,7 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for NopHttpFilter {
 
   fn on_request_trailers(
     &mut self,
-    _envoy_filter: EHF,
+    _envoy_filter: &mut EHF,
   ) -> abi::envoy_dynamic_module_type_on_http_filter_request_trailers_status {
     self.on_request_trailers_called = true;
     abi::envoy_dynamic_module_type_on_http_filter_request_trailers_status::Continue
@@ -108,7 +108,7 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for NopHttpFilter {
 
   fn on_response_headers(
     &mut self,
-    _envoy_filter: EHF,
+    _envoy_filter: &mut EHF,
     _end_of_stream: bool,
   ) -> abi::envoy_dynamic_module_type_on_http_filter_response_headers_status {
     self.on_response_headers_called = true;
@@ -117,7 +117,7 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for NopHttpFilter {
 
   fn on_response_body(
     &mut self,
-    _envoy_filter: EHF,
+    _envoy_filter: &mut EHF,
     _end_of_stream: bool,
   ) -> abi::envoy_dynamic_module_type_on_http_filter_response_body_status {
     self.on_response_body_called = true;
@@ -126,7 +126,7 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for NopHttpFilter {
 
   fn on_response_trailers(
     &mut self,
-    _envoy_filter: EHF,
+    _envoy_filter: &mut EHF,
   ) -> abi::envoy_dynamic_module_type_on_http_filter_response_trailers_status {
     self.on_response_trailers_called = true;
     abi::envoy_dynamic_module_type_on_http_filter_response_trailers_status::Continue


### PR DESCRIPTION
Commit Message: dynamic_modules: traitify EnvoyHttpFilterConfig to match EnvoyHttpFilter
Additional Description:

In #37753, we made EnvoyHttpFilter as a trait for testability via mocks.
Even though there's no ABI methods for  EnvoyHttpFilterConfig, it will soon have 
a functionality like accessing metrics, per-filter-metadata etc. Then we will
need to make it as a trait just like we did EnvoyHttpFilter. 
Making it a trait changes multiple places, so this commit preemptively
does it to minimize the required change.

As a result, all callback accessing struct now will be hidden behind traits.
There's no functionality change in this commit.


Risk Level: low
Testing: existing ones
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a

