### PR TITLE
Deprecate quic_receive_ecn

### DIFF
--- a/source/common/network/io_socket_handle_impl.cc
+++ b/source/common/network/io_socket_handle_impl.cc
@@ -412,11 +412,9 @@ Api::IoCallUint64Result IoSocketHandleImpl::recvmsg(Buffer::RawSlice* slices,
         }
       }
 #endif
-      if (receive_ecn_) {
-        absl::optional<uint8_t> maybe_tos = maybeGetTosFromHeader(*cmsg);
-        if (maybe_tos) {
-          output.msg_[0].tos_ = *maybe_tos;
-        }
+      absl::optional<uint8_t> maybe_tos = maybeGetTosFromHeader(*cmsg);
+      if (maybe_tos) {
+        output.msg_[0].tos_ = *maybe_tos;
       }
     }
   }
@@ -502,12 +500,10 @@ Api::IoCallUint64Result IoSocketHandleImpl::recvmmsg(RawSliceArrays& slices, uin
           output.msg_[0].saved_cmsg_ = cmsg_slice;
         }
         Address::InstanceConstSharedPtr addr = maybeGetDstAddressFromHeader(*cmsg, self_port);
-        if (receive_ecn_) {
-          absl::optional<uint8_t> maybe_tos = maybeGetTosFromHeader(*cmsg);
-          if (maybe_tos) {
-            output.msg_[0].tos_ = *maybe_tos;
-            continue;
-          }
+        absl::optional<uint8_t> maybe_tos = maybeGetTosFromHeader(*cmsg);
+        if (maybe_tos) {
+          output.msg_[0].tos_ = *maybe_tos;
+          continue;
         }
         if (addr != nullptr) {
           // This is a IP packet info message.

--- a/source/common/network/io_socket_handle_impl.h
+++ b/source/common/network/io_socket_handle_impl.h
@@ -30,7 +30,6 @@ public:
                               absl::optional<int> domain = absl::nullopt,
                               size_t address_cache_max_capacity = 0)
       : IoSocketHandleBaseImpl(fd, socket_v6only, domain),
-        receive_ecn_(Runtime::runtimeFeatureEnabled("envoy.reloadable_features.quic_receive_ecn")),
         address_cache_max_capacity_(address_cache_max_capacity) {
     if (address_cache_max_capacity > 0) {
       recent_received_addresses_ = std::vector<QuicEnvoyAddressPair>();
@@ -105,9 +104,6 @@ protected:
   // and IPV6 addresses.
   const size_t cmsg_space_{CMSG_SPACE(sizeof(int)) + CMSG_SPACE(sizeof(struct in_pktinfo)) +
                            CMSG_SPACE(sizeof(struct in6_pktinfo)) + CMSG_SPACE(sizeof(uint16_t))};
-
-  // Latches a copy of the runtime feature "envoy.reloadable_features.quic_receive_ecn".
-  const bool receive_ecn_;
 
   size_t addressCacheMaxSize() const { return address_cache_max_capacity_; }
 

--- a/source/common/quic/active_quic_listener.cc
+++ b/source/common/quic/active_quic_listener.cc
@@ -72,8 +72,7 @@ ActiveQuicListener::ActiveQuicListener(
   auto alarm_factory =
       std::make_unique<EnvoyQuicAlarmFactory>(dispatcher_, *connection_helper->GetClock());
   // Set the socket to report incoming ECN.
-  if (udp_listener_->localAddress() == nullptr ||
-      udp_listener_->localAddress()->ip() == nullptr) {
+  if (udp_listener_->localAddress() == nullptr || udp_listener_->localAddress()->ip() == nullptr) {
     IS_ENVOY_BUG("UDP Listener does not have local IP address");
   } else {
     int optval = 1;
@@ -433,8 +432,8 @@ ActiveQuicListenerFactory::createActiveQuicListener(
   return std::make_unique<ActiveQuicListener>(
       runtime, worker_index, concurrency, dispatcher, parent, std::move(listen_socket),
       listener_config, quic_config, kernel_worker_routing, enabled, quic_stat_names,
-      packets_to_read_to_connection_count_ratio, crypto_server_stream_factory,
-      proof_source_factory, std::move(cid_generator), worker_selector_,
+      packets_to_read_to_connection_count_ratio, crypto_server_stream_factory, proof_source_factory,
+      std::move(cid_generator), worker_selector_,
       makeOptRefFromPtr(connection_debug_visitor_factory_.get()), reject_new_connections_);
 }
 

--- a/source/common/quic/active_quic_listener.cc
+++ b/source/common/quic/active_quic_listener.cc
@@ -33,7 +33,7 @@ ActiveQuicListener::ActiveQuicListener(
     Network::SocketSharedPtr&& listen_socket, Network::ListenerConfig& listener_config,
     const quic::QuicConfig& quic_config, bool kernel_worker_routing,
     const envoy::config::core::v3::RuntimeFeatureFlag& enabled, QuicStatNames& quic_stat_names,
-    uint32_t packets_to_read_to_connection_count_ratio, bool receive_ecn,
+    uint32_t packets_to_read_to_connection_count_ratio,
     EnvoyQuicCryptoServerStreamFactoryInterface& crypto_server_stream_factory,
     EnvoyQuicProofSourceFactoryInterface& proof_source_factory,
     QuicConnectionIdGeneratorPtr&& cid_generator, QuicConnectionIdWorkerSelector worker_selector,
@@ -72,25 +72,23 @@ ActiveQuicListener::ActiveQuicListener(
   auto alarm_factory =
       std::make_unique<EnvoyQuicAlarmFactory>(dispatcher_, *connection_helper->GetClock());
   // Set the socket to report incoming ECN.
-  if (receive_ecn) {
-    if (udp_listener_->localAddress() == nullptr ||
-        udp_listener_->localAddress()->ip() == nullptr) {
-      IS_ENVOY_BUG("UDP Listener does not have local IP address");
-    } else {
-      int optval = 1;
-      socklen_t optlen = sizeof(optval);
-      if (udp_listener_->localAddress()->ip()->ipv6() != nullptr) {
-        listen_socket_.setSocketOption(IPPROTO_IPV6, IPV6_RECVTCLASS, &optval, optlen);
+  if (udp_listener_->localAddress() == nullptr ||
+      udp_listener_->localAddress()->ip() == nullptr) {
+    IS_ENVOY_BUG("UDP Listener does not have local IP address");
+  } else {
+    int optval = 1;
+    socklen_t optlen = sizeof(optval);
+    if (udp_listener_->localAddress()->ip()->ipv6() != nullptr) {
+      listen_socket_.setSocketOption(IPPROTO_IPV6, IPV6_RECVTCLASS, &optval, optlen);
 #ifndef __APPLE__
-        // Linux dual-stack sockets require setting IP_RECVTOS separately. Apple
-        // sockets will return an error.
-        if (!udp_listener_->localAddress()->ip()->ipv6()->v6only()) {
-          listen_socket_.setSocketOption(IPPROTO_IP, IP_RECVTOS, &optval, optlen);
-        }
-#endif // __APPLE__
-      } else {
+      // Linux dual-stack sockets require setting IP_RECVTOS separately. Apple
+      // sockets will return an error.
+      if (!udp_listener_->localAddress()->ip()->ipv6()->v6only()) {
         listen_socket_.setSocketOption(IPPROTO_IP, IP_RECVTOS, &optval, optlen);
       }
+#endif // __APPLE__
+    } else {
+      listen_socket_.setSocketOption(IPPROTO_IP, IP_RECVTOS, &optval, optlen);
     }
   }
   quic_dispatcher_ = std::make_unique<EnvoyQuicDispatcher>(
@@ -266,7 +264,6 @@ ActiveQuicListenerFactory::ActiveQuicListenerFactory(
       packets_to_read_to_connection_count_ratio_(
           PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, packets_to_read_to_connection_count_ratio,
                                           DEFAULT_PACKETS_TO_READ_PER_CONNECTION)),
-      receive_ecn_(Runtime::runtimeFeatureEnabled("envoy.reloadable_features.quic_receive_ecn")),
       context_(context), reject_new_connections_(config.reject_new_connections()) {
   const int64_t idle_network_timeout_ms =
       config.has_idle_timeout() ? DurationUtil::durationToMilliseconds(config.idle_timeout())
@@ -436,7 +433,7 @@ ActiveQuicListenerFactory::createActiveQuicListener(
   return std::make_unique<ActiveQuicListener>(
       runtime, worker_index, concurrency, dispatcher, parent, std::move(listen_socket),
       listener_config, quic_config, kernel_worker_routing, enabled, quic_stat_names,
-      packets_to_read_to_connection_count_ratio, receive_ecn_, crypto_server_stream_factory,
+      packets_to_read_to_connection_count_ratio, crypto_server_stream_factory,
       proof_source_factory, std::move(cid_generator), worker_selector_,
       makeOptRefFromPtr(connection_debug_visitor_factory_.get()), reject_new_connections_);
 }

--- a/source/common/quic/active_quic_listener.h
+++ b/source/common/quic/active_quic_listener.h
@@ -36,7 +36,7 @@ public:
                      bool kernel_worker_routing,
                      const envoy::config::core::v3::RuntimeFeatureFlag& enabled,
                      QuicStatNames& quic_stat_names,
-                     uint32_t packets_to_read_to_connection_count_ratio, bool receive_ecn,
+                     uint32_t packets_to_read_to_connection_count_ratio,
                      EnvoyQuicCryptoServerStreamFactoryInterface& crypto_server_stream_factory,
                      EnvoyQuicProofSourceFactoryInterface& proof_source_factory,
                      QuicConnectionIdGeneratorPtr&& cid_generator,
@@ -155,7 +155,6 @@ private:
   envoy::config::core::v3::RuntimeFeatureFlag enabled_;
   QuicStatNames& quic_stat_names_;
   const uint32_t packets_to_read_to_connection_count_ratio_;
-  bool receive_ecn_;
   const Network::Socket::OptionsSharedPtr options_{std::make_shared<Network::Socket::Options>()};
   QuicConnectionIdWorkerSelector worker_selector_;
   bool kernel_worker_routing_{};

--- a/source/common/quic/envoy_quic_utils.cc
+++ b/source/common/quic/envoy_quic_utils.cc
@@ -217,9 +217,7 @@ createConnectionSocket(const Network::Address::InstanceConstSharedPtr& peer_addr
   }
   connection_socket->addOptions(Network::SocketOptionFactory::buildIpPacketInfoOptions());
   connection_socket->addOptions(Network::SocketOptionFactory::buildRxQueueOverFlowOptions());
-  if (Runtime::runtimeFeatureEnabled("envoy.reloadable_features.quic_receive_ecn")) {
-    connection_socket->addOptions(Network::SocketOptionFactory::buildIpRecvTosOptions());
-  }
+  connection_socket->addOptions(Network::SocketOptionFactory::buildIpRecvTosOptions());
   if (prefer_gro && Api::OsSysCallsSingleton::get().supportsUdpGro()) {
     connection_socket->addOptions(Network::SocketOptionFactory::buildUdpGroOptions());
   }

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -78,7 +78,6 @@ RUNTIME_GUARD(envoy_reloadable_features_proxy_104);
 RUNTIME_GUARD(envoy_reloadable_features_proxy_ssl_port);
 RUNTIME_GUARD(envoy_reloadable_features_proxy_status_mapping_more_core_response_flags);
 RUNTIME_GUARD(envoy_reloadable_features_quic_connect_client_udp_sockets);
-RUNTIME_GUARD(envoy_reloadable_features_quic_receive_ecn);
 // Ignore the automated "remove this flag" issue: we should keep this for 1 year. Confirm with
 // @danzh2010 or @RyanTheOptimist before removing.
 RUNTIME_GUARD(envoy_reloadable_features_quic_send_server_preferred_address_to_all_clients);

--- a/test/common/quic/active_quic_listener_test.cc
+++ b/test/common/quic/active_quic_listener_test.cc
@@ -89,9 +89,8 @@ protected:
     return std::make_unique<TestActiveQuicListener>(
         runtime, worker_index, concurrency, dispatcher, parent, std::move(listen_socket),
         listener_config, quic_config, kernel_worker_routing, enabled, quic_stat_names,
-        packets_to_read_to_connection_count_ratio, /*receive_ecn=*/true,
-        crypto_server_stream_factory, proof_source_factory, std::move(cid_generator),
-        testWorkerSelector, std::nullopt);
+        packets_to_read_to_connection_count_ratio, crypto_server_stream_factory,
+        proof_source_factory, std::move(cid_generator), testWorkerSelector, std::nullopt);
   }
 };
 
@@ -141,7 +140,6 @@ protected:
   }
 
   void SetUp() override {
-    Runtime::maybeSetRuntimeGuard("envoy.reloadable_features.quic_receive_ecn", true);
     envoy::config::bootstrap::v3::LayeredRuntime config;
     config.add_layers()->mutable_admin_layer();
     listen_socket_ =
@@ -647,7 +645,6 @@ TEST_P(ActiveQuicListenerTest, EcnReportingIsEnabled) {
 }
 
 TEST_P(ActiveQuicListenerTest, EcnReporting) {
-  Runtime::maybeSetRuntimeGuard("envoy.reloadable_features.quic_receive_ecn", true);
   initialize();
   maybeConfigureMocks(/* connection_count = */ 1);
   quic::QuicConnectionId connection_id = quic::test::TestConnectionId(1);
@@ -665,7 +662,6 @@ TEST_P(ActiveQuicListenerTest, EcnReportingDualStack) {
   if (local_address_->ip()->version() == Network::Address::IpVersion::v4) {
     return;
   }
-  Runtime::maybeSetRuntimeGuard("envoy.reloadable_features.quic_receive_ecn", true);
   initialize();
   maybeConfigureMocks(/* connection_count = */ 1);
   quic::QuicConnectionId connection_id = quic::test::TestConnectionId(1);

--- a/test/common/quic/envoy_quic_client_session_test.cc
+++ b/test/common/quic/envoy_quic_client_session_test.cc
@@ -126,7 +126,6 @@ public:
   }
 
   void SetUp() override {
-    Runtime::maybeSetRuntimeGuard("envoy.reloadable_features.quic_receive_ecn", true);
     quic_connection_ = new TestEnvoyQuicClientConnection(
         quic::test::TestConnectionId(), connection_helper_, alarm_factory_, writer_, quic_version_,
         *dispatcher_, createConnectionSocket(peer_addr_, self_addr_, nullptr, /*prefer_gro=*/true),


### PR DESCRIPTION
Commit Message: Deprecate envoy_reloadable_features_quic_receive_ecn
Additional Description: N/A
Risk Level: Low
Testing: No new tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
[Optional Fixes #Issue] 38048
[Optional Deprecated:] envoy_reloadable_features_quic_receive_ecn

