### PR TITLE
logger: Change the thread safety of the logging context

### DIFF
--- a/mobile/examples/cc/fetch_client/fetch_client.cc
+++ b/mobile/examples/cc/fetch_client/fetch_client.cc
@@ -18,12 +18,12 @@
 namespace Envoy {
 
 Fetch::Fetch()
-    : logging_context_(spdlog::level::level_enum::info, Envoy::Logger::Logger::DEFAULT_LOG_FORMAT,
-                       lock_, false),
-      stats_allocator_(symbol_table_), store_root_(stats_allocator_),
+    : stats_allocator_(symbol_table_), store_root_(stats_allocator_),
       api_(std::make_unique<Envoy::Api::Impl>(platform_impl_.threadFactory(), store_root_,
                                               time_system_, platform_impl_.fileSystem(),
                                               random_generator_, bootstrap_)) {
+  Envoy::Logger::Context::init(spdlog::level::level_enum::info,
+                               Envoy::Logger::Logger::DEFAULT_LOG_FORMAT, lock_, false);
   Envoy::Event::Libevent::Global::initialize();
 }
 

--- a/mobile/examples/cc/fetch_client/fetch_client.h
+++ b/mobile/examples/cc/fetch_client/fetch_client.h
@@ -40,7 +40,6 @@ private:
   envoy_status_t sendRequest(absl::string_view url, std::vector<Http::Protocol>& protocols);
 
   Thread::MutexBasicLockable lock_;
-  Logger::Context logging_context_;
   PlatformImpl platform_impl_;
   Stats::SymbolTableImpl symbol_table_;
   Event::RealTimeSystem time_system_; // NO_CHECK_FORMAT(real_time)

--- a/mobile/test/common/integration/test_server.cc
+++ b/mobile/test/common/integration/test_server.cc
@@ -146,7 +146,7 @@ void TestServer::start(TestServerType type, int port) {
   port_ = port;
   ASSERT(!upstream_);
   // pre-setup: see https://github.com/envoyproxy/envoy/blob/main/test/test_runner.cc
-  Logger::Context logging_state(spdlog::level::level_enum::err,
+  Logger::Context::init(spdlog::level::level_enum::err,
                                 "[%Y-%m-%d %T.%e][%t][%l][%n] [%g:%#] %v", lock_, false, false);
   // end pre-setup
   Network::DownstreamTransportSocketFactoryPtr factory;

--- a/source/exe/stripped_main_base.cc
+++ b/source/exe/stripped_main_base.cc
@@ -72,9 +72,8 @@ StrippedMainBase::StrippedMainBase(const Server::Options& options, Event::TimeSy
     tls_ = std::make_unique<ThreadLocal::InstanceImpl>();
     Thread::BasicLockable& log_lock = restarter_->logLock();
     Thread::BasicLockable& access_log_lock = restarter_->accessLogLock();
-    logging_context_ = std::make_unique<Logger::Context>(options_.logLevel(), options_.logFormat(),
-                                                         log_lock, options_.logFormatEscaped(),
-                                                         options_.enableFineGrainLogging());
+    Logger::Context::init(options_.logLevel(), options_.logFormat(), log_lock,
+                          options_.logFormatEscaped(), options_.enableFineGrainLogging());
 
     configureComponentLogLevels();
 
@@ -94,9 +93,8 @@ StrippedMainBase::StrippedMainBase(const Server::Options& options, Event::TimeSy
   }
   case Server::Mode::Validate:
     restarter_ = std::make_unique<Server::HotRestartNopImpl>();
-    logging_context_ =
-        std::make_unique<Logger::Context>(options_.logLevel(), options_.logFormat(),
-                                          restarter_->logLock(), options_.logFormatEscaped());
+    Logger::Context::init(options_.logLevel(), options_.logFormat(), restarter_->logLock(),
+                          options_.logFormatEscaped());
     process_context_ = std::move(process_context);
     break;
   }

--- a/source/exe/stripped_main_base.h
+++ b/source/exe/stripped_main_base.h
@@ -78,7 +78,6 @@ protected:
   ThreadLocal::InstanceImplPtr tls_;
   std::unique_ptr<Server::HotRestart> restarter_;
   Stats::ThreadLocalStoreImplPtr stats_store_;
-  std::unique_ptr<Logger::Context> logging_context_;
   std::unique_ptr<Init::Manager> init_manager_{std::make_unique<Init::ManagerImpl>("Server")};
   std::unique_ptr<Server::Instance> server_;
 

--- a/test/benchmark/main.cc
+++ b/test/benchmark/main.cc
@@ -73,8 +73,7 @@ int main(int argc, char** argv) {
 
   // Reduce logs so benchmark output is readable.
   Envoy::Thread::MutexBasicLockable lock;
-  Logger::Context logging_context{spdlog::level::warn, Logger::Context::getFineGrainLogFormat(),
-                                  lock, false};
+  Logger::Context::init(spdlog::level::warn, Logger::Context::getFineGrainLogFormat(), lock, false);
 
   skip_expensive_benchmarks = skip_switch.getValue();
 

--- a/test/common/common/log_macros_test.cc
+++ b/test/common/common/log_macros_test.cc
@@ -61,8 +61,9 @@ private:
 
 TEST(Logger, StreamFineGrainLoggerRegistration) {
   Envoy::Thread::MutexBasicLockable lock;
-  Logger::Context logging_context{spdlog::level::warn, Logger::Context::getFineGrainLogFormat(),
-                                  lock, false};
+  // Reset in case context was set previously.
+  Logger::Context::reset();
+  Logger::Context::init(spdlog::level::warn, Logger::Context::getFineGrainLogFormat(), lock, false);
   Logger::Context::enableFineGrainLogger();
   TestFilterLog filter;
   getFineGrainLogContext().removeFineGrainLogEntryForTest(__FILE__);
@@ -74,12 +75,14 @@ TEST(Logger, StreamFineGrainLoggerRegistration) {
   SpdLoggerSharedPtr p = getFineGrainLogContext().getFineGrainLogEntry(__FILE__);
   ASSERT_NE(p, nullptr);
   EXPECT_EQ(p->level(), spdlog::level::warn);
+  Logger::Context::reset();
 }
 
 TEST(Logger, EventFineGrainLoggerRegistration) {
   Envoy::Thread::MutexBasicLockable lock;
-  Logger::Context logging_context{spdlog::level::warn, Logger::Context::getFineGrainLogFormat(),
-                                  lock, false};
+  // Reset in case context was set previously.
+  Logger::Context::reset();
+  Logger::Context::init(spdlog::level::warn, Logger::Context::getFineGrainLogFormat(), lock, false);
   Logger::Context::enableFineGrainLogger();
   TestFilterLog filter;
   getFineGrainLogContext().removeFineGrainLogEntryForTest(__FILE__);
@@ -91,12 +94,14 @@ TEST(Logger, EventFineGrainLoggerRegistration) {
   SpdLoggerSharedPtr p = getFineGrainLogContext().getFineGrainLogEntry(__FILE__);
   ASSERT_NE(p, nullptr);
   EXPECT_EQ(p->level(), spdlog::level::warn);
+  Logger::Context::reset();
 }
 
 TEST(Logger, ConnFineGrainLoggerRegistration) {
   Envoy::Thread::MutexBasicLockable lock;
-  Logger::Context logging_context{spdlog::level::warn, Logger::Context::getFineGrainLogFormat(),
-                                  lock, false};
+  // Reset in case context was set previously.
+  Logger::Context::reset();
+  Logger::Context::init(spdlog::level::warn, Logger::Context::getFineGrainLogFormat(), lock, false);
   Logger::Context::enableFineGrainLogger();
   TestFilterLog filter;
   getFineGrainLogContext().removeFineGrainLogEntryForTest(__FILE__);
@@ -108,6 +113,7 @@ TEST(Logger, ConnFineGrainLoggerRegistration) {
   SpdLoggerSharedPtr p = getFineGrainLogContext().getFineGrainLogEntry(__FILE__);
   ASSERT_NE(p, nullptr);
   EXPECT_EQ(p->level(), spdlog::level::warn);
+  Logger::Context::reset();
 }
 
 TEST(Logger, All) {

--- a/test/common/listener_manager/filter_chain_benchmark_test.cc
+++ b/test/common/listener_manager/filter_chain_benchmark_test.cc
@@ -209,13 +209,13 @@ public:
   }
 
   Envoy::Thread::MutexBasicLockable lock_;
-  Logger::Context logging_state_{spdlog::level::warn, Logger::Logger::DEFAULT_LOG_FORMAT, lock_,
-                                 false};
+  Logger::Context::init(spdlog::level::warn, Logger::Logger::DEFAULT_LOG_FORMAT, lock_, false);
   std::string listener_yaml_config_;
   envoy::config::listener::v3::Listener listener_config_;
   absl::Span<const envoy::config::listener::v3::FilterChain* const> filter_chains_;
   MockFilterChainFactoryBuilder dummy_builder_;
   Init::ManagerImpl init_manager_{"fcm_benchmark"};
+  Logger::Context::reset();
 };
 
 // NOLINTNEXTLINE(readability-redundant-member-init)

--- a/test/extensions/clusters/eds/eds_speed_test.cc
+++ b/test/extensions/clusters/eds/eds_speed_test.cc
@@ -200,8 +200,8 @@ public:
 
 static void priorityAndLocalityWeighted(State& state) {
   Envoy::Thread::MutexBasicLockable lock;
-  Envoy::Logger::Context logging_state(spdlog::level::warn,
-                                       Envoy::Logger::Logger::DEFAULT_LOG_FORMAT, lock, false);
+  Envoy::Logger::Context::init(spdlog::level::warn, Envoy::Logger::Logger::DEFAULT_LOG_FORMAT, lock,
+                               false);
   for (auto _ : state) { // NOLINT: Silences warning about dead store
     Envoy::Upstream::EdsSpeedTest speed_test(state, state.range(2));
     // if we've been instructed to skip tests, only run once no matter the argument:
@@ -209,6 +209,7 @@ static void priorityAndLocalityWeighted(State& state) {
 
     speed_test.priorityAndLocalityWeightedHelper(state.range(0), endpoints, true);
   }
+  Envoy::Logger::Context::reset();
 }
 
 BENCHMARK(priorityAndLocalityWeighted)
@@ -217,8 +218,8 @@ BENCHMARK(priorityAndLocalityWeighted)
 
 static void duplicateUpdate(State& state) {
   Envoy::Thread::MutexBasicLockable lock;
-  Envoy::Logger::Context logging_state(spdlog::level::warn,
-                                       Envoy::Logger::Logger::DEFAULT_LOG_FORMAT, lock, false);
+  Envoy::Logger::Context::init(spdlog::level::warn, Envoy::Logger::Logger::DEFAULT_LOG_FORMAT, lock,
+                               false);
 
   for (auto _ : state) { // NOLINT: Silences warning about dead store
     Envoy::Upstream::EdsSpeedTest speed_test(state, state.range(1));
@@ -227,14 +228,15 @@ static void duplicateUpdate(State& state) {
     speed_test.priorityAndLocalityWeightedHelper(true, endpoints, true);
     speed_test.priorityAndLocalityWeightedHelper(true, endpoints, true);
   }
+  Envoy::Logger::Context::reset();
 }
 
 BENCHMARK(duplicateUpdate)->Ranges({{1, 100000}, {false, true}})->Unit(benchmark::kMillisecond);
 
 static void healthOnlyUpdate(State& state) {
   Envoy::Thread::MutexBasicLockable lock;
-  Envoy::Logger::Context logging_state(spdlog::level::warn,
-                                       Envoy::Logger::Logger::DEFAULT_LOG_FORMAT, lock, false);
+  Envoy::Logger::Context::init(spdlog::level::warn, Envoy::Logger::Logger::DEFAULT_LOG_FORMAT, lock,
+                               false);
   for (auto _ : state) { // NOLINT: Silences warning about dead store
     Envoy::Upstream::EdsSpeedTest speed_test(state, state.range(1));
     uint32_t endpoints = skipExpensiveBenchmarks() ? 1 : state.range(0);
@@ -242,6 +244,7 @@ static void healthOnlyUpdate(State& state) {
     speed_test.priorityAndLocalityWeightedHelper(true, endpoints, true);
     speed_test.priorityAndLocalityWeightedHelper(true, endpoints, false);
   }
+  Envoy::Logger::Context::reset();
 }
 
 BENCHMARK(healthOnlyUpdate)->Ranges({{1, 100000}, {false, true}})->Unit(benchmark::kMillisecond);

--- a/test/extensions/common/wasm/wasm_speed_test.cc
+++ b/test/extensions/common/wasm/wasm_speed_test.cc
@@ -21,7 +21,7 @@ namespace Envoy {
 
 void bmWasmSpeedTest(benchmark::State& state) {
   Envoy::Thread::MutexBasicLockable lock;
-  Envoy::Logger::Context logging_state(spdlog::level::warn,
+  Envoy::Logger::Context::init(spdlog::level::warn,
                                        Envoy::Logger::Logger::DEFAULT_LOG_FORMAT, lock, false);
   Envoy::Logger::Registry::getLog(Envoy::Logger::Id::wasm).set_level(spdlog::level::off);
   Envoy::Stats::IsolatedStoreImpl stats_store;
@@ -59,6 +59,8 @@ void bmWasmSpeedTest(benchmark::State& state) {
       thread->join();
     }
   }
+
+  Envoy::Logger::Context::reset();
 }
 
 BENCHMARK(bmWasmSpeedTest);

--- a/test/extensions/load_balancing_policies/common/benchmark_base_tester.cc
+++ b/test/extensions/load_balancing_policies/common/benchmark_base_tester.cc
@@ -5,6 +5,11 @@ namespace Upstream {
 
 BaseTester::BaseTester(uint64_t num_hosts, uint32_t weighted_subset_percent, uint32_t weight,
                        bool attach_metadata) {
+  // Reduce default log level to warn while running this benchmark to avoid problems due to
+  // excessive debug logging in upstream_impl.cc
+  Envoy::Logger::Context::init(spdlog::level::warn, Envoy::Logger::Logger::DEFAULT_LOG_FORMAT,
+                               lock_, false);
+
   Upstream::HostVector hosts;
   ASSERT(num_hosts < 65536);
   for (uint64_t i = 0; i < num_hosts; i++) {
@@ -35,6 +40,8 @@ BaseTester::BaseTester(uint64_t num_hosts, uint32_t weighted_subset_percent, uin
       0, Upstream::HostSetImpl::partitionHosts(updated_hosts, hosts_per_locality), {}, hosts, {},
       random_.random(), absl::nullopt);
 }
+
+BaseTester::~BaseTester() { Envoy::Logger::Context::reset(); }
 
 } // namespace Upstream
 } // namespace Envoy

--- a/test/extensions/load_balancing_policies/common/benchmark_base_tester.h
+++ b/test/extensions/load_balancing_policies/common/benchmark_base_tester.h
@@ -24,12 +24,9 @@ public:
   // We weight the first weighted_subset_percent of hosts with weight.
   BaseTester(uint64_t num_hosts, uint32_t weighted_subset_percent = 0, uint32_t weight = 0,
              bool attach_metadata = false);
+  virtual ~BaseTester();
 
   Envoy::Thread::MutexBasicLockable lock_;
-  // Reduce default log level to warn while running this benchmark to avoid problems due to
-  // excessive debug logging in upstream_impl.cc
-  Envoy::Logger::Context logging_context_{spdlog::level::warn,
-                                          Envoy::Logger::Logger::DEFAULT_LOG_FORMAT, lock_, false};
 
   Upstream::PrioritySetImpl priority_set_;
   Upstream::PrioritySetImpl local_priority_set_;

--- a/test/fuzz/fuzz_runner.cc
+++ b/test/fuzz/fuzz_runner.cc
@@ -46,8 +46,7 @@ void Runner::setupEnvironment(int argc, char** argv, spdlog::level::level_enum d
   // shutdown hook (see
   // https://github.com/llvm-mirror/compiler-rt/blob/master/lib/fuzzer/FuzzerInterface.h).
   static auto* lock = new Thread::MutexBasicLockable();
-  static auto* logging_context =
-      new Logger::Context(log_level_, TestEnvironment::getOptions().logFormat(), *lock, false);
+  Logger::Context::init(log_level_, TestEnvironment::getOptions().logFormat(), *lock, false);
   UNREFERENCED_PARAMETER(logging_context);
 
   // Suppress all libprotobuf non-fatal logging as long as this object exists.
@@ -77,6 +76,7 @@ void runCleanupHooks() {
     delete cleanup_hooks;
     cleanup_hooks = nullptr;
   }
+  Envoy::Logger::Context::reset();
 }
 
 } // namespace Fuzz

--- a/test/test_runner.cc
+++ b/test/test_runner.cc
@@ -142,8 +142,8 @@ int TestRunner::runTests(int argc, char** argv) {
   Thread::MutexBasicLockable lock;
 
   Server::Options& options = TestEnvironment::getOptions();
-  Logger::Context logging_state(options.logLevel(), options.logFormat(), lock, false,
-                                options.enableFineGrainLogging());
+  Logger::Context::init(options.logLevel(), options.logFormat(), lock, false,
+                        options.enableFineGrainLogging());
 
   // Allocate fake log access manager.
   testing::NiceMock<AccessLog::MockAccessLogManager> access_log_manager;

--- a/test/tools/config_load_check/config_load_check.cc
+++ b/test/tools/config_load_check/config_load_check.cc
@@ -26,8 +26,8 @@ int main(int argc, char* argv[]) {
 
     Envoy::Event::Libevent::Global::initialize();
     Envoy::Thread::MutexBasicLockable lock;
-    Envoy::Logger::Context logging_context(static_cast<spdlog::level::level_enum>(2),
-                                           Envoy::Logger::Logger::DEFAULT_LOG_FORMAT, lock, false);
+    Envoy::Logger::Context::init(static_cast<spdlog::level::level_enum>(2),
+                                 Envoy::Logger::Logger::DEFAULT_LOG_FORMAT, lock, false);
 
     const uint32_t num_tested = Envoy::ConfigTest::run(std::string(argv[1]));
     std::cout << fmt::format("Configs tested: {}. ", num_tested);


### PR DESCRIPTION
In Envoy Mobile, it's possible that more than one Envoy engine exists in the same process.  This can lead to crash issues on `Context` destruction when restoring the previously saved `Context`.

There's no reason for a process to have more than one `Context`, so this PR changes the model so that there is only one `Context` at a given time without any nesting, with the ability to reset the `Context` and start a new one via `reset()` and `init()`.

