### PR TITLE
Patch tcmalloc to fix the thread safety analysis warning

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -866,6 +866,8 @@ def _com_github_luajit_luajit():
 def _com_github_google_tcmalloc():
     external_http_archive(
         name = "com_github_google_tcmalloc",
+        patches = ["@envoy//bazel:tcmalloc.patch"],
+        patch_args = ["-p1"],
     )
 
 def _com_github_gperftools_gperftools():

--- a/bazel/tcmalloc.patch
+++ b/bazel/tcmalloc.patch
@@ -1,0 +1,16 @@
+diff --git a/tcmalloc/page_allocator_interface.h b/tcmalloc/page_allocator_interface.h
+index f9bf0bd..593f130 100644
+--- a/tcmalloc/page_allocator_interface.h
++++ b/tcmalloc/page_allocator_interface.h
+@@ -80,7 +80,10 @@ class PageAllocatorInterface {
+   virtual void PrintInPbtxt(PbtxtRegion* region)
+       ABSL_LOCKS_EXCLUDED(pageheap_lock) = 0;
+ 
+-  const PageAllocInfo& info() const { return info_; }
++  const PageAllocInfo& info() const
++      ABSL_EXCLUSIVE_LOCKS_REQUIRED(pageheap_lock) {
++    return info_;
++  }
+ 
+  protected:
+   PageAllocInfo info_ ABSL_GUARDED_BY(pageheap_lock);


### PR DESCRIPTION
Commit Message:

I'm trying to build Envoy with Clang-18 and the version of tcmalloc we currently uses trips thread safety analysis, which generates a warning and ultimately results in a build failure.

The issue was fixed in the upstream tcmalloc, however the current version of binutils in the Envoy CI image not new enough to be able to build fresh versions of tcmalloc.

Given that we are already in a process of updating LLVM toolchain version in the Envoy CI, for now I'm going with patching tcmalloc instead of addressing all the issues required to bump the version of tcmalloc.

Additional Description: Related to the work in https://github.com/envoyproxy/envoy/issues/37911

Risk Level: Low
Testing: built with clang-18, plus the usual CI tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
