### PR TITLE
cluster-manager: remove unnecessary cluster type check for secondary clusters

### DIFF
--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -540,11 +540,11 @@ ClusterManagerImpl::initialize(const envoy::config::bootstrap::v3::Bootstrap& bo
     if (cluster.type() == envoy::config::cluster::v3::Cluster::EDS &&
         !Config::SubscriptionFactory::isPathBasedConfigSource(
             cluster.eds_cluster_config().eds_config().config_source_specifier_case())) {
-      const bool required_for_ads = isBlockingAdsCluster(bootstrap, cluster.name());
-      has_ads_cluster |= required_for_ads;
+      // Passing "false" for required_for_ads because an ADS cluster cannot be
+      // defined using EDS (or non-primary cluster).
       auto status_or_cluster =
           loadCluster(cluster, MessageUtil::hash(cluster), "", /*added_via_api=*/false,
-                      required_for_ads, active_clusters_);
+                      /*required_for_ads=*/false, active_clusters_);
       if (!status_or_cluster.status().ok()) {
         return status_or_cluster.status();
       }

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -540,6 +540,7 @@ ClusterManagerImpl::initialize(const envoy::config::bootstrap::v3::Bootstrap& bo
     if (cluster.type() == envoy::config::cluster::v3::Cluster::EDS &&
         !Config::SubscriptionFactory::isPathBasedConfigSource(
             cluster.eds_cluster_config().eds_config().config_source_specifier_case())) {
+      ASSERT(!isBlockingAdsCluster(bootstrap, cluster.name()));
       // Passing "false" for required_for_ads because an ADS cluster cannot be
       // defined using EDS (or non-primary cluster).
       auto status_or_cluster =


### PR DESCRIPTION
Commit Message: cluster-manager: remove unnecessary cluster type check for secondary clusters
Additional Description:
Prior to this PR the cluster-manager initialization step checked whether a non-primary cluster will be used as ADS.
However, Envoy forbids this from happening (bootstrap config is rejected with an "Unknown gRPC client cluster" error).
In this PR we remove the code that checks whether the non-primary cluster is required for ADS or not. This makes the code more readable, maintainable, and eases the understanding of the initialization steps.

This is being validated by [runtime_bootstrap_ads_eds.yaml](https://github.com/envoyproxy/envoy/blob/98d153be301c16d8329074e31d04b5ac55d268dc/test/server/test_data/server/runtime_bootstrap_ads_eds.yaml#L14) test (executed [here](https://github.com/envoyproxy/envoy/blob/98d153be301c16d8329074e31d04b5ac55d268dc/test/server/server_test.cc#L1163)).

Risk Level: low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
