### PR TITLE
fix(credential_injector/oauth2): send scopes when specified

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -22,6 +22,10 @@ bug_fixes:
     matcher would incorrectly handle ``present_match`` configurations by treating them as default present checks. This
     behavior can be temporarily reverted by setting runtime feature
     ``envoy_reloadable_features_enable_new_query_param_present_match_behavior`` to ``false``.
+- area: oauth2
+  change: |
+    Fixed oauth2 credential injector to send scope (if specified) to authorization server
+    when requesting new access token using client_credentials flow.
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/source/extensions/http/injected_credentials/oauth2/oauth_client.cc
+++ b/source/extensions/http/injected_credentials/oauth2/oauth_client.cc
@@ -39,12 +39,13 @@ OAuth2Client::GetTokenResult OAuth2ClientImpl::asyncGetAccessToken(const std::st
   const auto encoded_secret = Envoy::Http::Utility::PercentEncoding::encode(secret, ":/=&?");
 
   Envoy::Http::RequestMessagePtr request = createPostRequest();
-  const std::string body =
-      fmt::format(GetAccessTokenBodyFormatString, encoded_client_id, encoded_secret);
-  if (!(scopes.empty())) {
+  std::string body;
+  if (scopes.empty()) {
+    body = fmt::format(GetAccessTokenBodyFormatString, encoded_client_id, encoded_secret);
+  } else {
     const auto encoded_scopes = Envoy::Http::Utility::PercentEncoding::encode(scopes, ":/=&?");
-    const std::string body = fmt::format(GetAccessTokenBodyFormatStringWithScopes,
-                                         encoded_client_id, encoded_secret, encoded_scopes);
+    body = fmt::format(GetAccessTokenBodyFormatStringWithScopes, encoded_client_id, encoded_secret,
+                       encoded_scopes);
   }
   request->body().add(body);
   request->headers().setContentLength(body.length());


### PR DESCRIPTION
Commit Message:

Current code inadvertently shadows the existing body declaration such that when scopes are specified, they are not actually sent to the authorization server.

Additional Description:

Risk Level:

Testing:

Added test, verified it errors on current code and is resolved after this fix.

Docs Changes:

None, this now matches the existing documentation.

Release Notes:

Added CHANGELOG entry.

Platform Specific Features:
