### PR TITLE
Add stacktrace to ASSERTs

### DIFF
--- a/source/common/common/assert.h
+++ b/source/common/common/assert.h
@@ -135,6 +135,9 @@ void resetEnvoyBugCountersForTest();
       ENVOY_LOG_TO_LOGGER(Envoy::Logger::Registry::getLog(Envoy::Logger::Id::assert), critical,    \
                           "assert failure: {}.{}{}", CONDITION_STR,                                \
                           details.empty() ? "" : " Details: ", details);                           \
+      Envoy::Assert::EnvoyBugStackTrace st;                                                        \
+      st.capture();                                                                                \
+      st.logStackTrace();                                                                          \
       ACTION;                                                                                      \
     }                                                                                              \
   } while (false)

--- a/test/common/common/assert_test.cc
+++ b/test/common/common/assert_test.cc
@@ -21,6 +21,9 @@ TEST(ReleaseAssertDeathTest, AssertIncludesStackTrace) {
 #ifdef NDEBUG
   GTEST_SKIP() << "optimized build inlines functions so the stack trace won't be reliable";
 #endif
+#if __has_feature(memory_sanitizer)
+  GTEST_SKIP() << "memory sanitizer build inlines functions so the stack trace won't be reliable";
+#endif
   EXPECT_DEATH({ releaseAssertInAFunction(); }, "releaseAssertInAFunction");
 }
 

--- a/test/common/common/assert_test.cc
+++ b/test/common/common/assert_test.cc
@@ -21,8 +21,10 @@ TEST(ReleaseAssertDeathTest, AssertIncludesStackTrace) {
 #ifdef NDEBUG
   GTEST_SKIP() << "optimized build inlines functions so the stack trace won't be reliable";
 #endif
+#if defined(__has_feature)
 #if __has_feature(memory_sanitizer)
   GTEST_SKIP() << "memory sanitizer build inlines functions so the stack trace won't be reliable";
+#endif
 #endif
   EXPECT_DEATH({ releaseAssertInAFunction(); }, "releaseAssertInAFunction");
 }

--- a/test/common/common/assert_test.cc
+++ b/test/common/common/assert_test.cc
@@ -15,7 +15,7 @@ public:
 
 class ReleaseAsserterImpl : public ReleaseAsserter {
 public:
-  void releaseAssertInAFunction() override { RELEASE_ASSERT(0, "") }
+  void releaseAssertInAFunction() override { RELEASE_ASSERT(0, ""); }
 };
 } // namespace
 

--- a/test/common/common/assert_test.cc
+++ b/test/common/common/assert_test.cc
@@ -7,12 +7,16 @@
 
 namespace Envoy {
 
+static void releaseAssertInAFunction() { RELEASE_ASSERT(0, ""); }
+
 TEST(ReleaseAssertDeathTest, VariousLogs) {
   EXPECT_DEATH({ RELEASE_ASSERT(0, ""); }, ".*assert failure: 0.*");
   EXPECT_DEATH({ RELEASE_ASSERT(0, "With some logs"); },
                ".*assert failure: 0. Details: With some logs.*");
   EXPECT_DEATH({ RELEASE_ASSERT(0 == EAGAIN, fmt::format("using {}", "fmt")); },
                ".*assert failure: 0 == EAGAIN. Details: using fmt.*");
+  // ensure a stack trace is included.
+  EXPECT_DEATH({ releaseAssertInAFunction(); }, "releaseAssertInAFunction");
 }
 
 TEST(AssertDeathTest, VariousLogs) {

--- a/test/common/common/assert_test.cc
+++ b/test/common/common/assert_test.cc
@@ -7,7 +7,7 @@
 
 namespace Envoy {
 
-static void releaseAssertInAFunction() { RELEASE_ASSERT(0, ""); }
+static void __attribute__((noinline)) releaseAssertInAFunction() { RELEASE_ASSERT(0, ""); }
 
 TEST(ReleaseAssertDeathTest, VariousLogs) {
   EXPECT_DEATH({ RELEASE_ASSERT(0, ""); }, ".*assert failure: 0.*");


### PR DESCRIPTION
Commit Message: Add stacktrace to ASSERTs
Additional Description: Before this change, ASSERTs provoke a stacktrace, but it is always the useless two-line stacktrace
```
#0: sigHandler()
#1: restore_rt
```
as demonstrated by the test case added in this PR not passing before the change.
It's a bit odd that after this change there will be two stacktraces output on assert, but at least one of them will be useful.

Risk Level: Minimal, it's just output from asserts so if it does anything it's during a crash anyway.
Testing: Added a test case, and used to debug my production issue which I couldn't with the original version.
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
