### PR TITLE
Update BoringSSL URLs from 'master' to 'main'

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -147,14 +147,14 @@ REPOSITORY_LOCATIONS_SPEC = dict(
     boringssl_fips = dict(
         project_name = "BoringSSL (FIPS)",
         project_desc = "FIPS compliant BoringSSL",
-        project_url = "https://boringssl.googlesource.com/boringssl/+/master/crypto/fipsmodule/FIPS.md",
+        project_url = "https://boringssl.googlesource.com/boringssl/+/main/crypto/fipsmodule/FIPS.md",
         # When this is updated to a revision newer than 2022-08-12,
         # CertValidatorUtil::setIgnoreCertificateExpiration can be simplified.
         #
         # !!! NOTE !!!
         # Anytime the FIPS BoringSSL version is upgraded, `bazel/external/boringssl_fips.genrule_cmd` must be updated to use the toolchain
         # specified in the associated accreditation certificate, which can be found linked from
-        # https://boringssl.googlesource.com/boringssl/+/refs/heads/master/crypto/fipsmodule/FIPS.md, for example
+        # https://boringssl.googlesource.com/boringssl/+/refs/heads/main/crypto/fipsmodule/FIPS.md, for example
         # https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4735.
         version = "fips-20220613",
         sha256 = "62f733289f2d677c2723f556aa58034c438f3a7bbca6c12b156538a88e38da8a",

--- a/docs/root/intro/arch_overview/security/ssl.rst
+++ b/docs/root/intro/arch_overview/security/ssl.rst
@@ -41,7 +41,7 @@ FIPS 140-2
 ----------
 
 BoringSSL can be built in a
-`FIPS-compliant mode <https://boringssl.googlesource.com/boringssl/+/master/crypto/fipsmodule/FIPS.md>`_,
+`FIPS-compliant mode <https://boringssl.googlesource.com/boringssl/+/main/crypto/fipsmodule/FIPS.md>`_,
 following the build instructions from the `Security Policy for BoringCrypto module
 <https://csrc.nist.gov/CSRC/media/projects/cryptographic-module-validation-program/documents/security-policies/140sp3678.pdf>`_,
 using ``--define boringssl=fips`` Bazel option. Currently, this option is only available on Linux-x86_64.
@@ -264,4 +264,4 @@ Common errors are:
 * ``TLSV1_ALERT_UNKNOWN_CA``: Peer certificate CA is not in trusted CA.
 
 More detailed list of error that can be raised by BoringSSL can be found
-`here <https://github.com/google/boringssl/blob/master/crypto/err/ssl.errordata>`_
+`here <https://github.com/google/boringssl/blob/main/crypto/err/ssl.errordata>`_

--- a/source/common/crypto/utility_impl.cc
+++ b/source/common/crypto/utility_impl.cc
@@ -81,7 +81,7 @@ const EVP_MD* UtilityImpl::getHashFunction(absl::string_view name) {
   const std::string hash = absl::AsciiStrToLower(name);
 
   // Hash algorithms set refers
-  // https://github.com/google/boringssl/blob/master/include/openssl/digest.h
+  // https://github.com/google/boringssl/blob/main/include/openssl/digest.h
   if (hash == "sha1") {
     return EVP_sha1();
   } else if (hash == "sha224") {

--- a/test/common/tls/ocsp/asn1_utility_test.cc
+++ b/test/common/tls/ocsp/asn1_utility_test.cc
@@ -308,7 +308,7 @@ TEST_F(Asn1UtilityTest, TestParseGeneralizedTimeInvalidTime) {
 }
 
 // Taken from
-// https://boringssl.googlesource.com/boringssl/+/master/crypto/bytestring/cbb.c#531
+// https://boringssl.googlesource.com/boringssl/+/main/crypto/bytestring/cbb.c#531
 // because boringssl_fips does not yet implement `CBB_add_asn1_int64`
 void cbbAddAsn1Int64(CBB* cbb, int64_t value) {
   if (value >= 0) {


### PR DESCRIPTION
Commit Message: Update BoringSSL URLs from 'master' to 'main'
Additional Description:
Risk Level: low
Testing: n/a
Docs Changes: updated URLs
Release Notes: n/a
Platform Specific Features: n/a