### PR TITLE
Don't use generated linker script when build Kafka client library

### DIFF
--- a/bazel/foreign_cc/BUILD
+++ b/bazel/foreign_cc/BUILD
@@ -97,7 +97,7 @@ configure_make(
     ],
     tags = ["skip_on_windows"],
     targets = [
-        "ARFLAGS='' libs install-subdirs",
+        "ARFLAGS='' WITH_LDS='n' libs install-subdirs",
     ],
     deps = [":lz4"],
     alwayslink = True,


### PR DESCRIPTION
Commit Message:

The linker script generator that comes with the library is not quite correct and as a result sometimes generates symbols that are not exported by the library (see
https://github.com/confluentinc/librdkafka/issues/4593). Since LLVM version 17 it results in a link failure.

There is a fix sent upstream for this, but the PR fixing the issue has been out since October 2024 and didn't get any attention and I couldn't get maintainers of the library to look at the PR or the related bug either. So for now, I'm just disabling the use of linker script when building Kafka client library all together to work around the issue on our side.

I couldn't find the rationale for using custom linker script in the first place, but from what I can see in the upstream repo the linker script that they generate and use is a version script. And looking at the docs (see
https://www.gnu.org/software/gnulib/manual/html_node/LD-Version-Scripts.html) it looks like this script only really matters when building a shared library.

If I'm correct, then we don't really care about this, as we build and link Envoy statically with the Kafka client library anyways. At the very least I didn't notice any issues because of this change in my tests.

Additional Description: related to work in #37911 
Risk Level: low
Testing: builds + regular release gating tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a

+cc @phlax 
