### PR TITLE
swap out cidr_range_interface for ..._lib

### DIFF
--- a/source/common/common/BUILD
+++ b/source/common/common/BUILD
@@ -343,7 +343,7 @@ envoy_cc_library(
         "//envoy/common:exception_lib",
         "//envoy/common:matchers_interface",
         "//envoy/common:pure_lib",
-        "//source/common/network:cidr_range_interface",
+        "//source/common/network:cidr_range_lib",
         "@com_google_absl//absl/status:statusor",
     ],
 )


### PR DESCRIPTION
Commit Message: swap out cidr_range_interface for ..._lib
Additional Description:

Currently `//source/common/common:filter_state_object_matchers_lib` does not link `source/common/network/cidr_range.cc`. This PR fixes that.

Risk Level: low
Testing: none, quick build rule fix
Docs Changes: none
Release Notes: none
Platform Specific Features: none