### PR TITLE
Make FakeStream::{headers, trailers} thread safe to make clang-18 happy

### DIFF
--- a/envoy/http/header_map.h
+++ b/envoy/http/header_map.h
@@ -744,6 +744,8 @@ class RequestTrailerMap
     : public HeaderMap,
       public CustomInlineHeaderBase<CustomInlineHeaderRegistry::Type::RequestTrailers> {};
 using RequestTrailerMapPtr = std::unique_ptr<RequestTrailerMap>;
+using RequestTrailerMapSharedPtr = std::shared_ptr<RequestTrailerMap>;
+using RequestTrailerMapConstSharedPtr = std::shared_ptr<const RequestTrailerMap>;
 using RequestTrailerMapOptRef = OptRef<RequestTrailerMap>;
 using RequestTrailerMapOptConstRef = OptRef<const RequestTrailerMap>;
 


### PR DESCRIPTION
Commit Message:

Those methods return references to internal protected members, so ideally all the callers should acquire a lock before calling those.

I suspect that we got away with returning reference so far because in most cases we don't actully need to synchronize when calling any of these methods because synchronization happens erlier when we call one of waitForX methods.

Anyways, the new Clang complains about it, so we can as well fix it in a way that makes it clear that the methods are thread safe.

This PR changes the the signature of the methods to return a shared pointer to const data instead of references where it's not the case already. 

Additional Description:

Related to #37911 and fixes one of the issues in #38093

body() method has a similar problem, but it's addressed in a separate PR: #38265

Risk Level: Low
Testing: `bazel test //test/server/config_validation:config_fuzz_test --config=clang-libc++` (that's how I found the issue in the first place) + all the regular release gating tests.
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a

+cc @phlax 
