### PR TITLE
Fix missing initializer warning in ext_authz tests on newer version of clang

### DIFF
--- a/source/extensions/filters/common/ext_authz/ext_authz.h
+++ b/source/extensions/filters/common/ext_authz/ext_authz.h
@@ -88,44 +88,44 @@ struct Response {
   CheckStatus status;
   // A set of HTTP headers returned by the authorization server, that will be optionally appended
   // to the request to the upstream server.
-  UnsafeHeaderVector headers_to_append;
+  UnsafeHeaderVector headers_to_append{};
   // A set of HTTP headers returned by the authorization server, will be optionally set
   // (using "setCopy") to the request to the upstream server.
-  UnsafeHeaderVector headers_to_set;
+  UnsafeHeaderVector headers_to_set{};
   // A set of HTTP headers returned by the authorization server, will be optionally added
   // (using "addCopy") to the request to the upstream server.
-  UnsafeHeaderVector headers_to_add;
+  UnsafeHeaderVector headers_to_add{};
   // A set of HTTP headers returned by the authorization server, will be optionally added
   // (using "addCopy") to the response sent back to the downstream client on OK auth
   // responses.
-  UnsafeHeaderVector response_headers_to_add;
+  UnsafeHeaderVector response_headers_to_add{};
   // A set of HTTP headers returned by the authorization server, will be optionally set (using
   // "setCopy") to the response sent back to the downstream client on OK auth responses.
-  UnsafeHeaderVector response_headers_to_set;
+  UnsafeHeaderVector response_headers_to_set{};
   // A set of HTTP headers returned by the authorization server, will be optionally added
   // (using "addCopy") to the response sent back to the downstream client on OK auth
   // responses only if the headers were not returned from the authz server.
-  UnsafeHeaderVector response_headers_to_add_if_absent;
+  UnsafeHeaderVector response_headers_to_add_if_absent{};
   // A set of HTTP headers returned by the authorization server, will be optionally set (using
   // "setCopy") to the response sent back to the downstream client on OK auth responses
   // only if the headers were returned from the authz server.
-  UnsafeHeaderVector response_headers_to_overwrite_if_exists;
+  UnsafeHeaderVector response_headers_to_overwrite_if_exists{};
   // A set of HTTP headers consumed by the authorization server, will be removed
   // from the request to the upstream server.
-  std::vector<std::string> headers_to_remove;
+  std::vector<std::string> headers_to_remove{};
   // A set of query string parameters to be set (possibly overwritten) on the
   // request to the upstream server.
-  Http::Utility::QueryParamsVector query_parameters_to_set;
+  Http::Utility::QueryParamsVector query_parameters_to_set{};
   // A set of query string parameters to remove from the request to the upstream server.
-  std::vector<std::string> query_parameters_to_remove;
+  std::vector<std::string> query_parameters_to_remove{};
   // Optional http body used only on denied response.
-  std::string body;
+  std::string body{};
   // Optional http status used only on denied response.
   Http::Code status_code{};
 
   // A set of metadata returned by the authorization server, that will be emitted as filter's
   // dynamic metadata that other filters can leverage.
-  ProtobufWkt::Struct dynamic_metadata;
+  ProtobufWkt::Struct dynamic_metadata{};
 };
 
 using ResponsePtr = std::unique_ptr<Response>;


### PR DESCRIPTION
Commit Message:

I'm trying to make Envoy build with newer version of LLVM toolchain, specifically 18. I'm hitting a warning about missing initializers of the Request structure in tests when dedicated initializers are used to set values of some, but not all fields.

We can easily address this warning by just providing the default initializers in the struct definition. That's what this change does.

Additional Description: Related to work in #37911
Risk Level: low
Testing: `bazel build //test/extensions/filters/common/ext_authz:ext_authz_grpc_impl_test --config=clang-libc++` with clang-18
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a

+cc @phlax 
