### PR TITLE
Fix null metadata dereference in Thrift proxy router for shadow traffic

### DIFF
--- a/source/extensions/filters/network/thrift_proxy/router/router.h
+++ b/source/extensions/filters/network/thrift_proxy/router/router.h
@@ -153,6 +153,7 @@ public:
             stat_name_set_->add("thrift.upstream_resp_exception_remote")),
         upstream_resp_invalid_type_(stat_name_set_->add("thrift.upstream_resp_invalid_type")),
         upstream_resp_decoding_error_(stat_name_set_->add("thrift.upstream_resp_decoding_error")),
+        upstream_resp_metadata_null_(stat_name_set_->add("thrift.upstream_resp_metadata_null")),
         upstream_rq_time_(stat_name_set_->add("thrift.upstream_rq_time")),
         upstream_rq_size_(stat_name_set_->add("thrift.upstream_rq_size")),
         upstream_resp_size_(stat_name_set_->add("thrift.upstream_resp_size")),
@@ -309,6 +310,19 @@ public:
   }
 
   /**
+   * Increment counter for encountering null response metadata.
+   * @param cluster Upstream::ClusterInfo& describing the upstream cluster
+   * @param upstream_host Upstream::HostDescriptionConstSharedPtr describing the upstream host
+   */
+  void incResponseMetadataNull(const Upstream::ClusterInfo& cluster,
+                               Upstream::HostDescriptionConstSharedPtr upstream_host) const {
+    incClusterScopeCounter(cluster, upstream_host, upstream_resp_metadata_null_);
+    ASSERT(upstream_host != nullptr);
+    upstream_host->stats().rq_error_.inc();
+  }
+
+
+  /**
    * Record a value for the request size histogram.
    * @param cluster Upstream::ClusterInfo& describing the upstream cluster
    * @param value uint64_t size in bytes of the full request
@@ -405,6 +419,7 @@ private:
   const Stats::StatName upstream_resp_exception_remote_;
   const Stats::StatName upstream_resp_invalid_type_;
   const Stats::StatName upstream_resp_decoding_error_;
+  const Stats::StatName upstream_resp_metadata_null_;
   const Stats::StatName upstream_rq_time_;
   const Stats::StatName upstream_rq_size_;
   const Stats::StatName upstream_resp_size_;

--- a/source/extensions/filters/network/thrift_proxy/router/router.h
+++ b/source/extensions/filters/network/thrift_proxy/router/router.h
@@ -321,7 +321,6 @@ public:
     upstream_host->stats().rq_error_.inc();
   }
 
-
   /**
    * Record a value for the request size histogram.
    * @param cluster Upstream::ClusterInfo& describing the upstream cluster

--- a/source/extensions/filters/network/thrift_proxy/router/shadow_writer_impl.h
+++ b/source/extensions/filters/network/thrift_proxy/router/shadow_writer_impl.h
@@ -46,9 +46,7 @@ struct NullResponseDecoder : public DecoderCallbacks, public ProtocolConverter {
     decoder_->onData(upstream_buffer_, underflow);
     return underflow;
   }
-  MessageMetadataSharedPtr& responseMetadata() {
-    return metadata_;
-  }
+  MessageMetadataSharedPtr& responseMetadata() { return metadata_; }
   bool responseSuccess() { return success_.value_or(false); }
 
   // ProtocolConverter

--- a/source/extensions/filters/network/thrift_proxy/router/shadow_writer_impl.h
+++ b/source/extensions/filters/network/thrift_proxy/router/shadow_writer_impl.h
@@ -47,7 +47,6 @@ struct NullResponseDecoder : public DecoderCallbacks, public ProtocolConverter {
     return underflow;
   }
   MessageMetadataSharedPtr& responseMetadata() {
-    ASSERT(metadata_ != nullptr);
     return metadata_;
   }
   bool responseSuccess() { return success_.value_or(false); }

--- a/source/extensions/filters/network/thrift_proxy/router/upstream_request.cc
+++ b/source/extensions/filters/network/thrift_proxy/router/upstream_request.cc
@@ -139,7 +139,7 @@ UpstreamRequest::handleRegularResponse(Buffer::Instance& data,
       ENVOY_LOG(debug, "No response metadata produced; resetting stream");
       upstream_host_->outlierDetector().putResult(
           Upstream::Outlier::Result::ExtOriginRequestFailed);
-      stats_.incResponseDecodingError(cluster, upstream_host_);
+      stats_.incResponseMetadataNull(cluster, upstream_host_);
       resetStream();
       return ThriftFilters::ResponseStatus::Reset;
     }

--- a/source/extensions/filters/network/thrift_proxy/router/upstream_request.cc
+++ b/source/extensions/filters/network/thrift_proxy/router/upstream_request.cc
@@ -138,7 +138,7 @@ UpstreamRequest::handleRegularResponse(Buffer::Instance& data,
     if (!callbacks.responseMetadata()) {
       ENVOY_LOG(debug, "No response metadata produced; resetting stream");
       upstream_host_->outlierDetector().putResult(
-        Upstream::Outlier::Result::ExtOriginRequestFailed);
+          Upstream::Outlier::Result::ExtOriginRequestFailed);
       stats_.incResponseDecodingError(cluster, upstream_host_);
       resetStream();
       return ThriftFilters::ResponseStatus::Reset;

--- a/source/extensions/filters/network/thrift_proxy/router/upstream_request.cc
+++ b/source/extensions/filters/network/thrift_proxy/router/upstream_request.cc
@@ -135,6 +135,14 @@ UpstreamRequest::handleRegularResponse(Buffer::Instance& data,
 
   const auto status = callbacks.upstreamData(data);
   if (status == ThriftFilters::ResponseStatus::Complete) {
+    if (!callbacks.responseMetadata()) {
+      ENVOY_LOG(debug, "No response metadata produced; resetting stream");
+      upstream_host_->outlierDetector().putResult(
+        Upstream::Outlier::Result::ExtOriginRequestFailed);
+      stats_.incResponseDecodingError(cluster, upstream_host_);
+      resetStream();
+      return ThriftFilters::ResponseStatus::Reset;
+    }
 
     stats_.recordUpstreamResponseSize(cluster, response_size_);
 

--- a/test/extensions/filters/network/thrift_proxy/shadow_writer_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/shadow_writer_test.cc
@@ -193,7 +193,7 @@ public:
 
     if (null_metadata) {
       EXPECT_EQ(1UL, cluster_.cluster_.info_->statsScope()
-                         .counterFromString("thrift.upstream_resp_decoding_error")
+                         .counterFromString("thrift.upstream_resp_metadata_null")
                          .value());
       return;
     }

--- a/test/extensions/filters/network/thrift_proxy/shadow_writer_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/shadow_writer_test.cc
@@ -108,8 +108,7 @@ public:
   void testOnUpstreamData(MessageType message_type = MessageType::Reply, bool success = true,
                           bool on_data_throw_app_exception = false,
                           bool on_data_throw_regular_exception = false,
-                          bool close_before_response = false,
-                          bool null_metadata = false) {
+                          bool close_before_response = false, bool null_metadata = false) {
     NiceMock<Network::MockClientConnection> connection;
 
     EXPECT_CALL(cm_, getThreadLocalCluster(_)).WillOnce(Return(&cluster_));
@@ -173,7 +172,6 @@ public:
       decoder_ptr->success_ = success;
     }
 
-
     if (on_data_throw_regular_exception || on_data_throw_app_exception) {
       EXPECT_CALL(connection, close(_));
       EXPECT_CALL(*decoder_ptr, upstreamData(_))
@@ -195,7 +193,8 @@ public:
 
     if (null_metadata) {
       EXPECT_EQ(1UL, cluster_.cluster_.info_->statsScope()
-        .counterFromString("thrift.upstream_resp_decoding_error").value());
+                         .counterFromString("thrift.upstream_resp_decoding_error")
+                         .value());
       return;
     }
 


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Addresses a segmentation fault in Envoy’s Thrift proxy when handling shadow traffic. The crash occurs due to a null pointer dereference of MessageMetadata within the shadow router path during response parsing from upstream. In scenarios where the Thrift decoder unexpectedly returns a complete parsing status without metadata, the previous logic led to crashing. Now, UpstreamRequest has been updated to include null-checks around metadata access during handleRegularResponse(), treating it as an error condition.
Added a new Counter to track null metadata from responses for Thrift router
`thrift.upstream_resp_metadata_null`

Additional Description:
Backtrace from production machine
```
Program terminated with signal SIGSEGV, Segmentation fault.  
#0  0x00007f4ea0ea32ab in raise () from /lib/x86_64-linux-gnu/libpthread.so.0  
   [Current thread is 1 (Thread 0x7f4e9ac44700 (LWP 64))]  
  
Stack trace:  
  
#0  0x00007f4ea0ea32ab in raise () from /lib/x86_64-linux-gnu/libpthread.so.0  
#1  0x000056039f8dad43 in Envoy::SignalAction::sigHandler(int, siginfo_t*, void*)   
    at external/envoy/source/common/signal/signal_action.cc:53  
  
#2  <signal handler called>  
  
#3  std::_1::optional_storage_base<Envoy::Extensions::NetworkFilters::ThriftProxy::MessageType, false>::has_value() const   
    at __bazel_toolchain_llvm_repo/bin/../include/c++/v1/optional:359  
  
#4  std::1::optional<Envoy::Extensions::NetworkFilters::ThriftProxy::MessageType>::value() const &   
    at __bazel_toolchain_llvm_repo/bin/../include/c++/v1/optional:826  
  
#5  Envoy::Extensions::NetworkFilters::ThriftProxy::MessageMetadata::messageType() at external/envoy/source/extensions/filters/network/thrift_proxy/metadata.h:110  
  
#6  Envoy::Extensions::NetworkFilters::ThriftProxy::Router::UpstreamRequest::handleRegularResponse(..)   
    at external/envoy/source/extensions/filters/network/thrift_proxy/router/upstream_request.cc:141  
  
#7  0x000056039ed896fa in Envoy::Extensions::NetworkFilters::ThriftProxy::Router::UpstreamRequest::handleUpstreamData   
    at external/envoy/source/extensions/filters/network/thrift_proxy/router/upstream_request.cc:198  
  
#8  0x000056039ed82ff9 in non-virtual thunk to Envoy::Extensions::NetworkFilters::ThriftProxy::Router::ShadowRouterImpl::onUpstreamData(..)   
    at external/envoy/source/extensions/filters/network/thrift_proxy/router/shadow_writer_impl.cc:288  
  
#9  0x000056039f3403ed in Envoy::Tcp::ActiveTcpClient::onUpstreamData at external/envoy/source/common/tcp/conn_pool.h:124  
  
#10 Envoy::Tcp::ActiveTcpClient::ConnReadFilter::onData at external/envoy/source/common/tcp/conn_pool.h:47  
  
#11 0x000056039f7fb3f5 in Envoy::Network::FilterManagerImpl::onContinueReading(..)   
    at external/envoy/source/common/network/filter_manager_impl.cc:92  
  
#12 0x000056039f7985a5 in Envoy::Network::ConnectionImpl::onRead at external/envoy/source/common/network/connection_impl.cc:384  
  
#13 Envoy::Network::ConnectionImpl::onReadReady at external/envoy/source/common/network/connection_impl.cc:709  
  
#14 0x000056039f7948d7 in Envoy::Network::ConnectionImpl::onFileEvent events=3   
    at external/envoy/source/common/network/connection_impl.cc:648  
  
#15 0x000056039f79e536 in Envoy::Network::ConnectionImpl::ConnectionImpl(..)::$_7::operator()(unsigned int) const   
    at external/envoy/source/common/network/connection_impl.cc:103  
  
#16 std::1::invoke<R, Func, ArgTypes...>(Func&&, ArgTypes&&...) (f=..., __args=<error reading variable>)   
    at __bazel_toolchain_llvm_repo/bin/../include/c++/v1/type_traits/invoke.h:344  
  
#17 std::1::invoke_void_return_wrapper<absl::lts_20240722::Status, false>::call(..)   
    at __bazel_toolchain_llvm_repo/bin/../include/c++/v1/type_traits/invoke.h:411  
  
#18 std::1::function::alloc_func<..>::operator()(unsigned int&&)   
    at __bazel_toolchain_llvm_repo/bin/../include/c++/v1/functional/function.h:169  
  
#19 std::1::function::func<..>::operator()(unsigned int&&)   
    at __bazel_toolchain_llvm_repo/bin/../include/c++/v1/functional/function.h:311  
  
#20 0x000056039f785086 in std::1::function::value_func<..>::operator()(unsigned int&&) const   
    at __bazel_toolchain_llvm_repo/bin/../include/c++/v1/functional/function.h:428  
  
#21 std::1::function<..>::operator()(unsigned int) const   
    at __bazel_toolchain_llvm_repo/bin/../include/c++/v1/functional/function.h:981  
  
#22 Envoy::Event::DispatcherImpl::createFileEvent(..)::$_0::operator()(unsigned int) const   
    at external/envoy/source/common/event/dispatcher_impl.cc:186  
  
#23 std::1::invoke<R, Func, ArgTypes...>(Func&&, ArgTypes&&...)   
    at __bazel_toolchain_llvm_repo/bin/../include/c++/v1/type_traits/invoke.h:344  
  
#24 std::1::invoke_void_return_wrapper<absl::lts_20240722::Status, false>::call(..)   
    at __bazel_toolchain_llvm_repo/bin/../include/c++/v1/type_traits/invoke.h:411  
  
#25 std::1::function::alloc_func<..>::operator()(unsigned int&&)   
    at __bazel_toolchain_llvm_repo/bin/../include/c++/v1/functional/function.h:169  
  
#26 std::1::function::func<..>::operator()(unsigned int&&)   
    at __bazel_toolchain_llvm_repo/bin/../include/c++/v1/functional/function.h:311  
  
#27 0x000056039f786155 in std::1::function::value_func<..>::operator()(unsigned int&&) const   
    at __bazel_toolchain_llvm_repo/bin/../include/c++/v1/functional/function.h:428  
  
#28 std::1::function<..>::operator()(unsigned int) const   
    at __bazel_toolchain_llvm_repo/bin/../include/c++/v1/functional/function.h:981  
  
#29 Envoy::Event::FileEventImpl::mergeInjectedEventsAndRunCb(int)   
    at external/envoy/source/common/event/file_event_impl.cc:161  
  
#30 0x000056039fa02503 in event_process_active_single_queue ()  
#31 0x000056039fa010f1 in event_base_loop ()  
#32 0x000056039ef71d71 in Envoy::Server::WorkerImpl::threadRoutine(..)   
    at external/envoy/source/server/worker_impl.cc:156  
  
#33 0x000056039fa83e7f in std::1::function<void()>::operator()() const   
    at __bazel_toolchain_llvm_repo/bin/../include/c++/v1/functional/function.h:981  
  
#34 Envoy::Thread::PosixThreadFactory::createPthread(Envoy::Thread::ThreadHandle*)::$_0::operator()(void*) const   
    at external/envoy/source/common/common/posix/thread_impl.cc:178  
  
#35 Envoy::Thread::PosixThreadFactory::createPthread(Envoy::Thread::ThreadHandle*)::$_0::_invoke(void*)   
    at external/envoy/source/common/common/posix/thread_impl.cc:173  
  
#36 0x00007f4ea0e97609 in start_thread () from /lib/x86_64-linux-gnu/libpthread.so.0  
#37 0x00007f4ea0dac133 in clone () from /lib/x86_64-linux-gnu/libc.so.6 
```
Risk Level: Medium
Testing: new unit test
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
