### PR TITLE
Add DNS query Trace of NotStarted before queuing.

### DIFF
--- a/source/extensions/network/dns_resolver/getaddrinfo/getaddrinfo.cc
+++ b/source/extensions/network/dns_resolver/getaddrinfo/getaddrinfo.cc
@@ -36,6 +36,7 @@ ActiveDnsQuery* GetAddrInfoDnsResolver::resolve(const std::string& dns_name,
                                                 ResolveCb callback) {
   ENVOY_LOG(debug, "adding new query [{}] to pending queries", dns_name);
   auto new_query = std::make_unique<PendingQuery>(dns_name, dns_lookup_family, callback);
+  new_query->addTrace(static_cast<uint8_t>(GetAddrInfoTrace::NotStarted));
   ActiveDnsQuery* active_query;
   {
     absl::MutexLock guard(&mutex_);
@@ -48,7 +49,6 @@ ActiveDnsQuery* GetAddrInfoDnsResolver::resolve(const std::string& dns_name,
     }
     active_query = pending_queries_.back().pending_query_.get();
   }
-  active_query->addTrace(static_cast<uint8_t>(GetAddrInfoTrace::NotStarted));
   return active_query;
 }
 


### PR DESCRIPTION
Before this change, it was possible that the `addTrace(NotStarted)` occured after the resolver thread picked up the query and started work. This can be seen when running the getaddrinfo tests 1000 times in the form of failure around or just under 1% of the time.

```
bazel test --config=libc++ --runs_per_test 1000 //test/extensions/network/dns_resolver/getaddrinfo:getaddrinfo_test
```

Risk Level: low
Testing: CI