### PR TITLE
Fix MSAN warnings on clang-18 due to destruction order issues

### DIFF
--- a/test/common/http/BUILD
+++ b/test/common/http/BUILD
@@ -294,6 +294,7 @@ envoy_cc_test(
         "conn_manager_impl_test_2.cc",
     ],
     rbe_pool = "2core",
+    shard_count = 5,
     deps = [
         ":conn_manager_impl_test_base_lib",
         ":custom_header_extension_lib",

--- a/test/common/http/http3/conn_pool_test.cc
+++ b/test/common/http/http3/conn_pool_test.cc
@@ -78,6 +78,7 @@ public:
 
   Upstream::MockHost& mockHost() { return static_cast<Upstream::MockHost&>(*host_); }
 
+  testing::NiceMock<ThreadLocal::MockInstance> thread_local_;
   NiceMock<Event::MockDispatcher> dispatcher_;
   Quic::PersistentQuicInfoImpl quic_info_{dispatcher_, 45};
   Upstream::HostSharedPtr host_{new NiceMock<Upstream::MockHost>};
@@ -99,7 +100,6 @@ public:
   std::unique_ptr<Http3ConnPoolImpl> pool_;
   MockPoolConnectResultCallback connect_result_callback_;
   std::shared_ptr<Network::MockSocketOption> socket_option_{new Network::MockSocketOption()};
-  testing::NiceMock<ThreadLocal::MockInstance> thread_local_;
   absl::Status creation_status_;
   bool happy_eyeballs_ = false;
 };

--- a/test/common/listener_manager/BUILD
+++ b/test/common/listener_manager/BUILD
@@ -73,6 +73,7 @@ envoy_cc_test(
     name = "listener_manager_impl_test",
     srcs = ["listener_manager_impl_test.cc"],
     rbe_pool = "6gig",
+    shard_count = 5,
     deps = [
         ":listener_manager_impl_test_lib",
         "//source/common/api:os_sys_calls_lib",

--- a/test/common/quic/client_connection_factory_impl_test.cc
+++ b/test/common/quic/client_connection_factory_impl_test.cc
@@ -78,6 +78,7 @@ protected:
     return session->write_buffer_watermark_simulation_.highWatermark();
   }
 
+  testing::NiceMock<ThreadLocal::MockInstance> thread_local_;
   NiceMock<Event::MockDispatcher> dispatcher_;
   std::unique_ptr<PersistentQuicInfoImpl> quic_info_;
   std::shared_ptr<Upstream::MockClusterInfo> cluster_{new NiceMock<Upstream::MockClusterInfo>()};
@@ -92,7 +93,6 @@ protected:
   QuicStatNames quic_stat_names_{store_.symbolTable()};
   quic::DeterministicConnectionIdGenerator connection_id_generator_{
       quic::kQuicDefaultConnectionIdLength};
-  testing::NiceMock<ThreadLocal::MockInstance> thread_local_;
 };
 
 TEST_P(QuicNetworkConnectionTest, BufferLimits) {

--- a/test/common/quic/quic_transport_socket_factory_test.cc
+++ b/test/common/quic/quic_transport_socket_factory_test.cc
@@ -33,11 +33,11 @@ public:
                   .earlyDataEnabled());
   }
 
+  testing::NiceMock<ThreadLocal::MockInstance> thread_local_;
   QuicServerTransportSocketConfigFactory config_factory_;
   Stats::TestUtil::TestStore server_stats_store_;
   Api::ApiPtr server_api_;
   NiceMock<Server::Configuration::MockTransportSocketFactoryContext> context_;
-  testing::NiceMock<ThreadLocal::MockInstance> thread_local_;
 };
 
 TEST_F(QuicServerTransportSocketFactoryConfigTest, EarlyDataEnabledByDefault) {
@@ -124,13 +124,13 @@ public:
         std::unique_ptr<Envoy::Ssl::ClientContextConfig>(context_config_), context_);
   }
 
+  testing::NiceMock<ThreadLocal::MockInstance> thread_local_;
   NiceMock<Server::Configuration::MockTransportSocketFactoryContext> context_;
   std::unique_ptr<Quic::QuicClientTransportSocketFactory> factory_;
   // Will be owned by factory_.
   NiceMock<Ssl::MockClientContextConfig>* context_config_{
       new NiceMock<Ssl::MockClientContextConfig>};
   std::function<void()> update_callback_;
-  testing::NiceMock<ThreadLocal::MockInstance> thread_local_;
 };
 
 TEST_F(QuicClientTransportSocketFactoryTest, SupportedAlpns) {

--- a/test/common/router/BUILD
+++ b/test/common/router/BUILD
@@ -328,6 +328,7 @@ envoy_cc_test(
         "router_2_test.cc",
     ],
     rbe_pool = "6gig",
+    shard_count = 5,
     deps = [
         ":router_test_base_lib",
         "//source/common/buffer:buffer_lib",

--- a/test/common/stats/thread_local_store_test.cc
+++ b/test/common/stats/thread_local_store_test.cc
@@ -1532,13 +1532,13 @@ protected:
 
   static constexpr size_t million_ = 1000 * 1000;
 
+  NiceMock<ThreadLocal::MockInstance> tls_;
   MockSink sink_;
   SymbolTableImpl symbol_table_;
   AllocatorImpl alloc_;
   ThreadLocalStoreImpl store_;
   Scope& scope_;
   NiceMock<Event::MockDispatcher> main_thread_dispatcher_;
-  NiceMock<ThreadLocal::MockInstance> tls_;
   bool threading_enabled_{false};
 };
 

--- a/test/common/tcp_proxy/tcp_proxy_test.cc
+++ b/test/common/tcp_proxy/tcp_proxy_test.cc
@@ -600,6 +600,10 @@ TEST_P(TcpProxyTest, StreamDecoderFilterCallbacks) {
   std::array<char, 256> buffer;
   OutputBufferStream ostream{buffer.data(), buffer.size()};
   EXPECT_NO_THROW(stream_decoder_callbacks.dumpState(ostream, 0));
+
+  // Release filter explicitly. Filter destructor tries to use access logger, so we want filter
+  // to be destroyed before the access logger to avoid accessing released memory.
+  filter_.reset();
 }
 
 TEST_P(TcpProxyTest, RouteWithMetadataMatch) {

--- a/test/common/tls/BUILD
+++ b/test/common/tls/BUILD
@@ -91,6 +91,7 @@ envoy_cc_test(
     ],
     external_deps = ["ssl"],
     rbe_pool = "6gig",
+    shard_count = 5,
     deps = [
         ":ssl_certs_test_lib",
         ":test_private_key_method_provider_test_lib",


### PR DESCRIPTION
Commit Message:

This change contains multiple MSAN fixes detected by clang-18. They all in different places, but all of them are caused by a similar issue.

In C++ members of the class are always created in the same order in which they are declared in the class. And they are always destroyed in reverse order. So the first memeber of the class is created first and destroyed last.

When there are interdependencies between the members of a class the order of destruction becomes important. We typically don't want to access data of the already destroyed members in destructors of the members that are being destroyed.

MSAN on clang-18 detected a bunch of cases where we access some fields after they were destroyed. In all but one case, issues happens in tests only and not in the Envoy binary. There is one case where a similar problem occurs in regular Envoy code, but this issue is benign, because we are accessing an atomic variable that does not trully get destroyed.

So, all-in-all, these are not serious issues, but we want to fix it to make clang MSAN tests happy on new LLVM toolchain.

I also sharded a few tests, because it was the only way I could actually run them through the end within given timeouts on my workstation. Hopefully that's not a problem.

Additional Description: Related to the work done in #37911
Risk Level: Low
Testing: msan checks with clang-18
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a

+cc @phlax 
