### PR TITLE
tests: update call to makeOptRef

### DIFF
--- a/test/extensions/filters/http/common/fuzz/uber_filter.cc
+++ b/test/extensions/filters/http/common/fuzz/uber_filter.cc
@@ -97,7 +97,8 @@ void UberFilterFuzzer::fuzz(
     for (const auto& header : downstream_data.headers().headers()) {
       headers.addCopy(header.key(), header.value());
     }
-    ON_CALL(decoder_callbacks_, requestHeaders()).WillByDefault(Return(makeOptRef(headers)));
+    ON_CALL(decoder_callbacks_, requestHeaders())
+        .WillByDefault(Return(makeOptRef<Http::RequestHeaderMap>(headers)));
     HttpFilterFuzzer::runData(decoder_filter_.get(), downstream_data);
   } else {
     decoding_finished_ = true;


### PR DESCRIPTION
Commit Message: tests: update call to makeOptRef
Additional Description:
This PR makes the cast more specific. It seems to be needed for future versions of googletest.

Risk Level: low - tests only
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
