### PR TITLE
Add propagate_unsampled field to trace config

### DIFF
--- a/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
+++ b/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
@@ -171,7 +171,9 @@ message HttpConnectionManager {
     // Default: 100%
     type.v3.Percent overall_sampling = 5;
 
-    // Whether tracing metadata should be propagated upstream when the request is not sampled.
+    // Whether tracing headers should be written should Envoy not sample the request for tracing.
+    // When set to false, the existing tracing headers are preserved when Envoy does not sample the
+    // request. This allows upstream services to make their own sampling decision.
     // Default: true.
     google.protobuf.BoolValue propagate_unsampled = 11;
 

--- a/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
+++ b/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
@@ -129,7 +129,7 @@ message HttpConnectionManager {
     UNESCAPE_AND_FORWARD = 4;
   }
 
-  // [#next-free-field: 11]
+  // [#next-free-field: 12]
   message Tracing {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager.Tracing";
@@ -170,6 +170,10 @@ message HttpConnectionManager {
     // :ref:`HTTP Connection Manager <config_http_conn_man_runtime>`.
     // Default: 100%
     type.v3.Percent overall_sampling = 5;
+
+    // Whether tracing metadata should be propagated upstream when the request is not sampled.
+    // Default: true.
+    google.protobuf.BoolValue propagate_unsampled = 11;
 
     // Whether to annotate spans with additional data. If true, spans will include logs for stream
     // events.

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -150,6 +150,11 @@ new_features:
   change: |
     Added support for :ref:`backoff_options <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.backoff_options>`
     to configure the backoff strategy for TCP proxy retries.
+- area: http
+  change: |
+    Added :ref:`propagate_unsampled
+    <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.Tracing.propagate_unsampled>`
+    to support not modifying the existing trace context when requests aren't sampled.
 - area: redis
   change: |
     Added support for multi-key commands on transactions.

--- a/envoy/tracing/trace_config.h
+++ b/envoy/tracing/trace_config.h
@@ -91,6 +91,11 @@ public:
   virtual bool spawnUpstreamSpan() const PURE;
 
   /**
+   * @return whether to propagate span information for unsampled requests.
+   */
+  virtual bool propagateUnsampled() const PURE;
+
+  /**
    * @return true if spans should be annotated with more detailed information.
    */
   virtual bool verbose() const PURE;

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -1452,6 +1452,10 @@ void ConnectionManagerImpl::ActiveStream::traceRequest() {
   ConnectionManagerImpl::chargeTracingStats(tracing_decision.reason,
                                             connection_manager_.config_->tracingStats());
 
+  if (!connection_manager_tracing_config_->propagateUnsampled()) {
+    return;
+  }
+
   Tracing::HttpTraceContext trace_context(*request_headers_);
   active_span_ = connection_manager_.tracer().startSpan(
       *this, trace_context, filter_manager_.streamInfo(), tracing_decision);

--- a/source/common/tracing/tracer_config_impl.h
+++ b/source/common/tracing/tracer_config_impl.h
@@ -71,6 +71,9 @@ public:
         tracing_config, overall_sampling, 10000, 10000)};
     overall_sampling_.set_numerator(overall_sampling_numerator);
     overall_sampling_.set_denominator(envoy::type::v3::FractionalPercent::TEN_THOUSAND);
+    propagate_unsampled_ = tracing_config.has_propagate_unsampled()
+                               ? tracing_config.propagate_unsampled().value()
+                               : true;
 
     verbose_ = tracing_config.verbose();
     max_path_tag_length_ = PROTOBUF_GET_WRAPPED_OR_DEFAULT(tracing_config, max_path_tag_length,
@@ -82,11 +85,12 @@ public:
                                      envoy::type::v3::FractionalPercent client_sampling,
                                      envoy::type::v3::FractionalPercent random_sampling,
                                      envoy::type::v3::FractionalPercent overall_sampling,
-                                     bool verbose, uint32_t max_path_tag_length)
+                                     bool propagate_unsampled, bool verbose,
+                                     uint32_t max_path_tag_length)
       : operation_name_(operation_name), custom_tags_(custom_tags),
         client_sampling_(client_sampling), random_sampling_(random_sampling),
-        overall_sampling_(overall_sampling), verbose_(verbose),
-        max_path_tag_length_(max_path_tag_length) {}
+        overall_sampling_(overall_sampling), propagate_unsampled_(propagate_unsampled),
+        verbose_(verbose), max_path_tag_length_(max_path_tag_length) {}
 
   ConnectionManagerTracingConfigImpl() = default;
 
@@ -99,6 +103,7 @@ public:
   const envoy::type::v3::FractionalPercent& getOverallSampling() const override {
     return overall_sampling_;
   }
+  bool propagateUnsampled() const override { return propagate_unsampled_; }
   const Tracing::CustomTagMap& getCustomTags() const override { return custom_tags_; }
 
   Tracing::OperationName operationName() const override { return operation_name_; }
@@ -113,6 +118,7 @@ public:
   envoy::type::v3::FractionalPercent client_sampling_;
   envoy::type::v3::FractionalPercent random_sampling_;
   envoy::type::v3::FractionalPercent overall_sampling_;
+  bool propagate_unsampled_{};
   bool verbose_{};
   uint32_t max_path_tag_length_{};
   bool spawn_upstream_span_{};

--- a/test/common/http/conn_manager_impl_test_base.cc
+++ b/test/common/http/conn_manager_impl_test_base.cc
@@ -227,6 +227,7 @@ void HttpConnectionManagerImplMixin::setup(const SetupOpts& opts) {
                                        percent1,
                                        percent2,
                                        percent1,
+                                       true,
                                        false,
                                        256});
   }

--- a/test/common/http/conn_manager_utility_test.cc
+++ b/test/common/http/conn_manager_utility_test.cc
@@ -108,7 +108,7 @@ public:
     percent2.set_numerator(10000);
     percent2.set_denominator(envoy::type::v3::FractionalPercent::TEN_THOUSAND);
     tracing_config_ = {
-        Tracing::OperationName::Ingress, {}, percent1, percent2, percent1, false, 256};
+        Tracing::OperationName::Ingress, {}, percent1, percent2, percent1, true, false, 256};
     ON_CALL(config_, tracingConfig()).WillByDefault(Return(&tracing_config_));
     ON_CALL(config_, localReply()).WillByDefault(ReturnRef(*local_reply_));
 


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: add propagate_unsampled field to trace config
Additional Description: 
This PR prevents Span implementations from modifying the existing trace context by not constructing them if propagate_unsampled=true. This allows Envoy sidecars to not interfere with services' sampling decisions.
Risk Level: Medium
Testing: Unit tests
Docs Changes:  inline in proto
Release Notes: Added
Platform Specific Features: N/A
Fixes #38222
