### PR TITLE
[bp/1.33] deps: stop building libcurl docs (#38172)

### DIFF
--- a/bazel/foreign_cc/BUILD
+++ b/bazel/foreign_cc/BUILD
@@ -267,6 +267,7 @@ envoy_cmake(
     cache_entries = {
         "BUILD_CURL_EXE": "off",
         "BUILD_TESTING": "off",
+        "BUILD_LIBCURL_DOCS": "off",
         "BUILD_SHARED_LIBS": "off",
         "CURL_HIDDEN_SYMBOLS": "off",
         "CURL_USE_LIBSSH2": "off",


### PR DESCRIPTION
This should be turned off as it's not needed.
Ref https://github.com/Homebrew/homebrew-core/pull/205269

Fix #37470
