### PR TITLE
udp_proxy: improve retries by checking connect attempts immediately after failure

### DIFF
--- a/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.h
+++ b/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.h
@@ -590,6 +590,7 @@ protected:
     void writeDownstream(Network::UdpRecvData& data);
     void resetIdleTimer();
 
+    virtual bool shouldCreateUpstream() PURE;
     virtual bool createUpstream() PURE;
     virtual void writeUpstream(Network::UdpRecvData& data) PURE;
     virtual void onIdleTimer() PURE;
@@ -683,6 +684,7 @@ protected:
     ~UdpActiveSession() override = default;
 
     // ActiveSession
+    bool shouldCreateUpstream() override;
     bool createUpstream() override;
     void writeUpstream(Network::UdpRecvData& data) override;
     void onIdleTimer() override;
@@ -741,6 +743,7 @@ protected:
     ~TunnelingActiveSession() override = default;
 
     // ActiveSession
+    bool shouldCreateUpstream() override;
     bool createUpstream() override;
     void writeUpstream(Network::UdpRecvData& data) override;
     void onIdleTimer() override;


### PR DESCRIPTION
Commit Message:
Additional Description: 
- Improve retries by checking connect attempts immediately after the upstream connect failure.
- Prevent adding the same session more than once to cluster's sessions (it's not really a bug because absl::flat_hash_set is a hash set that only allows unique elements and the second attempt has no effect).

Risk Level: low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features: