### PR TITLE
dynamic_modules: add EnvoyMutBuffer in Rust SDK

### DIFF
--- a/source/extensions/dynamic_modules/sdk/rust/src/buffer.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/buffer.rs
@@ -1,4 +1,5 @@
 /// A buffer struct that represents a contiguous memory region owned by Envoy.
+/// This is immutable and is meant to be used for reading underlying bytes.
 ///
 /// This is cloneable and copyable, but the underlying memory is not copied. It can be
 /// thought of as an alias to &\[u8\] but the underlying memory is owned by Envoy.
@@ -54,8 +55,69 @@ impl EnvoyBuffer<'_> {
   pub fn as_slice(&self) -> &[u8] {
     unsafe { std::slice::from_raw_parts(self.raw_ptr, self.length) }
   }
+}
 
+/// This is exactly the same as [`EnvoyBuffer`] except that it is mutable and data can be written
+/// in-place. See [`EnvoyBuffer`] for more details.
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct EnvoyMutBuffer<'a> {
+  raw_ptr: *mut u8,
+  length: usize,
+  _marker: std::marker::PhantomData<&'a ()>,
+}
+
+impl EnvoyMutBuffer<'_> {
+  /// This is a helper function to create an [`EnvoyMutBuffer`] from a static mutable storage.
+  /// This is only meant to be used in unit tests.
+  ///
+  /// Mutability is required because the data can be written in-place. Therefore, this needs to be
+  /// used with "unsafe" block for most of the cases like the following:
+  ///
+  /// ```
+  /// static mut BUF: [u8; 1024] = [0; 1024];
+  /// let mut buffer = envoy_proxy_dynamic_modules_rust_sdk::EnvoyMutBuffer::new(unsafe { &mut BUF });
+  /// ```
+  pub fn new(static_str: &'static mut [u8]) -> Self {
+    Self {
+      raw_ptr: static_str.as_mut_ptr(),
+      length: static_str.len(),
+      _marker: std::marker::PhantomData,
+    }
+  }
+
+  /// This is a helper function to create an [`EnvoyMutBuffer`] from a raw pointer and length.
+  ///
+  /// # Safety
+  ///
+  /// This is not meant to be used by the end users, but rather by the SDK itself in the
+  /// actual integration with Envoy.
+  pub unsafe fn new_from_raw(raw_ptr: *mut u8, length: usize) -> Self {
+    Self {
+      raw_ptr,
+      length,
+      _marker: std::marker::PhantomData,
+    }
+  }
+
+  /// This returns a immutable slice to the underlying memory region managed by Envoy.
+  pub fn as_slice(&self) -> &[u8] {
+    unsafe { std::slice::from_raw_parts(self.raw_ptr, self.length) }
+  }
+
+  /// This returns a mutable slice to the underlying memory region managed by Envoy.
   pub fn as_mut_slice(&mut self) -> &mut [u8] {
-    unsafe { std::slice::from_raw_parts_mut(self.raw_ptr as *mut u8, self.length) }
+    unsafe { std::slice::from_raw_parts_mut(self.raw_ptr, self.length) }
+  }
+}
+
+
+impl Default for EnvoyMutBuffer<'_> {
+  fn default() -> Self {
+    Self {
+      raw_ptr: std::ptr::null_mut(),
+      length: 0,
+      _marker: std::marker::PhantomData,
+    }
   }
 }

--- a/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
@@ -380,14 +380,10 @@ pub trait EnvoyHttpFilter {
   /// // This is the test setup.
   /// let mut envoy_filter = MockEnvoyHttpFilter::default();
   /// // Mutable static storage is used for the test to simulate the response body operation.
-  /// static mut HELLO: [u8; 5] = *b"hello";
-  /// static mut WORLD: [u8; 5] = *b"world";
-  /// envoy_filter.expect_get_request_body().returning(|| {
-  ///   Some(vec![
-  ///     EnvoyMutBuffer::new(unsafe { &mut HELLO }),
-  ///     EnvoyMutBuffer::new(unsafe { &mut WORLD }),
-  ///   ])
-  /// });
+  /// static mut BUFFER: [u8; 10] = *b"helloworld";
+  /// envoy_filter
+  ///   .expect_get_request_body()
+  ///   .returning(|| Some(vec![EnvoyMutBuffer::new(unsafe { &mut BUFFER })]));
   /// envoy_filter.expect_drain_request_body().return_const(true);
   ///
   ///
@@ -440,14 +436,10 @@ pub trait EnvoyHttpFilter {
   /// // This is the test setup.
   /// let mut envoy_filter = MockEnvoyHttpFilter::default();
   /// // Mutable static storage is used for the test to simulate the response body operation.
-  /// static mut HELLO: [u8; 5] = *b"hello";
-  /// static mut WORLD: [u8; 5] = *b"world";
-  /// envoy_filter.expect_get_response_body().returning(|| {
-  ///   Some(vec![
-  ///     EnvoyMutBuffer::new(unsafe { &mut HELLO }),
-  ///     EnvoyMutBuffer::new(unsafe { &mut WORLD }),
-  ///   ])
-  /// });
+  /// static mut BUFFER: [u8; 10] = *b"helloworld";
+  /// envoy_filter
+  ///   .expect_get_response_body()
+  ///   .returning(|| Some(vec![EnvoyMutBuffer::new(unsafe { &mut BUFFER })]));
   /// envoy_filter.expect_drain_response_body().return_const(true);
   ///
   ///

--- a/test/extensions/dynamic_modules/test_data/rust/http.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/http.rs
@@ -470,8 +470,7 @@ struct BodyWriter<'a, EHF: EnvoyHttpFilter> {
 impl<'a, EHF: EnvoyHttpFilter> BodyWriter<'a, EHF> {
   fn new(envoy_filter: &'a mut EHF, request: bool) -> Self {
     // Before starting to write, drain the existing buffer content.
-    // To do this, we need to calculate the total buffer size.
-    let buffer_bytes = if request {
+    let current_vec = if request {
       envoy_filter
         .get_request_body()
         .expect("request body is None")
@@ -479,10 +478,13 @@ impl<'a, EHF: EnvoyHttpFilter> BodyWriter<'a, EHF> {
       envoy_filter
         .get_response_body()
         .expect("response body is None")
-    }
-    .iter()
-    .map(|buf| buf.as_slice().len())
-    .sum::<usize>();
+    };
+
+
+    let buffer_bytes = current_vec
+      .iter()
+      .map(|buf| buf.as_slice().len())
+      .sum::<usize>();
 
     if request {
       assert!(envoy_filter.drain_request_body(buffer_bytes));

--- a/test/extensions/dynamic_modules/test_data/rust/http_test.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/http_test.rs
@@ -96,10 +96,11 @@ fn test_body_callbacks_filter_on_bodies() {
   envoy_filter
     .expect_get_request_body()
     .returning(|| {
+      static mut BUF: [[u8; 4]; 3] = [*b"nice", *b"nice", *b"nice"];
       Some(vec![
-        EnvoyBuffer::new("nice"),
-        EnvoyBuffer::new("nice"),
-        EnvoyBuffer::new("nice"),
+        EnvoyMutBuffer::new(unsafe { &mut BUF[0] }),
+        EnvoyMutBuffer::new(unsafe { &mut BUF[1] }),
+        EnvoyMutBuffer::new(unsafe { &mut BUF[2] }),
       ])
     })
     .times(2);
@@ -117,10 +118,11 @@ fn test_body_callbacks_filter_on_bodies() {
   envoy_filter
     .expect_get_response_body()
     .returning(|| {
+      static mut BUF2: [[u8; 4]; 3] = [*b"cool", *b"cool", *b"cool"];
       Some(vec![
-        EnvoyBuffer::new("cool"),
-        EnvoyBuffer::new("cool"),
-        EnvoyBuffer::new("cool"),
+        EnvoyMutBuffer::new(unsafe { &mut BUF2[0] }),
+        EnvoyMutBuffer::new(unsafe { &mut BUF2[1] }),
+        EnvoyMutBuffer::new(unsafe { &mut BUF2[2] }),
       ])
     })
     .times(2);


### PR DESCRIPTION
Commit Message: dynamic_modules: add EnvoyMutBuffer in Rust SDK
Additional Description:

This is a follow up on https://github.com/envoyproxy/envoy/pull/38102#discussion_r1932907500
Risk Level: n/a
Testing: existing ones
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a