### PR TITLE
bazel: Increase the HTTP scale timeout to 2.0

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -29,7 +29,7 @@ build --experimental_repository_downloader_retries=2
 build --enable_platform_specific_config
 build --incompatible_merge_fixed_and_default_shell_env
 # A workaround for slow ICU download.
-build --experimental_scale_timeouts=2.0
+build --http_timeout_scaling=2.0
 
 # Pass CC, CXX and LLVM_CONFIG variables from the environment.
 # We assume they have stable values, so this won't cause action cache misses.

--- a/.bazelrc
+++ b/.bazelrc
@@ -28,6 +28,8 @@ build --define envoy_mobile_listener=enabled
 build --experimental_repository_downloader_retries=2
 build --enable_platform_specific_config
 build --incompatible_merge_fixed_and_default_shell_env
+# A workaround for slow ICU download.
+build --experimental_scale_timeouts=2.0
 
 # Pass CC, CXX and LLVM_CONFIG variables from the environment.
 # We assume they have stable values, so this won't cause action cache misses.


### PR DESCRIPTION
This is an attempt to fix the slow ICU download that's causing a lot of CI failures. See https://github.com/envoyproxy/envoy/issues/38135. For more information on `--http_timeout_scaling`, see https://bazel.build/reference/command-line-reference#flag--http_timeout_scaling.

Risk Level: low
Testing: CI
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
