### PR TITLE
bazel: Increase the HTTP scale timeout to 6.0

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -29,7 +29,7 @@ build --experimental_repository_downloader_retries=2
 build --enable_platform_specific_config
 build --incompatible_merge_fixed_and_default_shell_env
 # A workaround for slow ICU download.
-build --http_timeout_scaling=2.0
+build --http_timeout_scaling=6.0
 
 # Pass CC, CXX and LLVM_CONFIG variables from the environment.
 # We assume they have stable values, so this won't cause action cache misses.


### PR DESCRIPTION
The default read timeout is [20 seconds](https://github.com/bazelbuild/bazel/blob/983f4022d0879edc37db8635b59c86e08044bfe8/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnector.java#L60). This PR attempts to increase the read timeout to 120 seconds by increasing the scale timeout factor by 6.0.

Risk Level: low
Testing: CI
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
