### PR TITLE
flake: fix credential_injector_oauth_integration_test/RetryOnClusterNotFound

### DIFF
--- a/test/extensions/http/credential_injector/oauth2/credential_injector_oauth_integration_test.cc
+++ b/test/extensions/http/credential_injector/oauth2/credential_injector_oauth_integration_test.cc
@@ -630,11 +630,12 @@ typed_config:
 )EOF";
   initializeFilter(filter_config);
   test_server_->waitForCounterEq(
+      "http.config_test.credential_injector.oauth2.token_fetch_failed_on_cluster_not_found", 0,
+      std::chrono::milliseconds(10));
+  // ensures that the token request is retried
+  test_server_->waitForCounterGe(
       "http.config_test.credential_injector.oauth2.token_fetch_failed_on_cluster_not_found", 1,
-      std::chrono::milliseconds(1300));
-  test_server_->waitForCounterEq(
-      "http.config_test.credential_injector.oauth2.token_fetch_failed_on_cluster_not_found", 2,
-      std::chrono::milliseconds(1300));
+      std::chrono::milliseconds(2000));
 }
 
 TEST_P(CredentialInjectorIntegrationTest, RetryOnStreamReset) {


### PR DESCRIPTION
Commit Message: test flake: fix credential_injector_oauth_integration_test/RetryOnClusterNotFound
Additional Description: 
Test was verifying stat increment on every retry. Test was relying on retry timeout to approximate the stat increment verification timeout. This can fail based on resources/load on the underlying machine.
Now test has been changed from verifying stat increment on every failed retry to if any retry happened which will be more stable.

fixes: https://github.com/envoyproxy/envoy/issues/38263