### PR TITLE
Add an integration test about using AsyncClient from router->upstream_filters

### DIFF
--- a/test/integration/filters/async_upstream_filter.cc
+++ b/test/integration/filters/async_upstream_filter.cc
@@ -60,7 +60,7 @@ public:
     decoder_callbacks_->encodeTrailers(std::move(trailers));
   }
   void onComplete() override { stream_ = nullptr; }
-  void onReset() override {}
+  void onReset() override { stream_ = nullptr; }
 
   ~AsyncUpstreamFilter() {
     if (stream_) {


### PR DESCRIPTION
What the heck is going on here, why does this test crash?

```
[2025-01-31 16:27:27.519][27426][info][main] [source/server/server.cc:1060] exiting
[2025-01-31 16:27:27.519][27426][debug][init] [source/common/init/watcher_impl.cc:31] RunHelper destroyed
[2025-01-31 16:27:27.519][27426][debug][main] [source/server/server.cc:124] destroying listener manager
[2025-01-31 16:27:27.519][27426][debug][init] [source/common/init/target_impl.cc:34] target LDS destroyed
[2025-01-31 16:27:27.523][27426][debug][main] [source/common/event/dispatcher_impl.cc:92] destroying dispatcher worker_0
[2025-01-31 16:27:27.523][27426][debug][init] [source/common/init/watcher_impl.cc:31] Listener-local-init-watcher http destroyed
[2025-01-31 16:27:27.524][27426][critical][backtrace] [./source/server/backtrace.h:129] Caught Segmentation fault, suspect faulting address 0x10
[2025-01-31 16:27:27.524][27426][critical][backtrace] [./source/server/backtrace.h:113] Backtrace (use tools/stack_decode.py to get line numbers):
[2025-01-31 16:27:27.524][27426][critical][backtrace] [./source/server/backtrace.h:114] Envoy version: 0/1.34.0-dev/test/DEBUG/BoringSSL
[2025-01-31 16:27:27.539][27426][critical][backtrace] [./source/server/backtrace.h:121] #0: Envoy::SignalAction::sigHandler() [0x702cd5c]
[2025-01-31 16:27:27.539][27426][critical][backtrace] [./source/server/backtrace.h:121] #1: __restore_rt [0x716b8b1c4420]
[2025-01-31 16:27:27.554][27426][critical][backtrace] [./source/server/backtrace.h:121] #2: Envoy::Stats::ThreadLocalHistogramImpl::~ThreadLocalHistogramImpl() [0x4b01f5d]
[2025-01-31 16:27:27.569][27426][critical][backtrace] [./source/server/backtrace.h:121] #3: Envoy::Stats::ThreadLocalHistogramImpl::~ThreadLocalHistogramImpl() [0x4b01fc9]
[2025-01-31 16:27:27.585][27426][critical][backtrace] [./source/server/backtrace.h:121] #4: Envoy::Stats::RefcountPtr<>::resetInternal() [0x4b88b3a]
[2025-01-31 16:27:27.599][27426][critical][backtrace] [./source/server/backtrace.h:121] #5: Envoy::Stats::RefcountPtr<>::~RefcountPtr() [0x4b2b2d5]
[2025-01-31 16:27:27.614][27426][critical][backtrace] [./source/server/backtrace.h:121] #6: std::__1::__destroy_at<>() [0x4b3be85]
[2025-01-31 16:27:27.629][27426][critical][backtrace] [./source/server/backtrace.h:121] #7: std::__1::destroy_at<>() [0x4b3be65]
[2025-01-31 16:27:27.645][27426][critical][backtrace] [./source/server/backtrace.h:121] #8: std::__1::allocator_traits<>::destroy<>() [0x4b3bd09]
[2025-01-31 16:27:27.660][27426][critical][backtrace] [./source/server/backtrace.h:121] #9: std::__1::__list_imp<>::clear() [0x4b3bb88]
[2025-01-31 16:27:27.675][27426][critical][backtrace] [./source/server/backtrace.h:121] #10: std::__1::__list_imp<>::~__list_imp() [0x4b3bac5]
[2025-01-31 16:27:27.690][27426][critical][backtrace] [./source/server/backtrace.h:121] #11: std::__1::list<>::~list() [0x4b2b5e5]
[2025-01-31 16:27:27.705][27426][critical][backtrace] [./source/server/backtrace.h:121] #12: Envoy::Stats::ParentHistogramImpl::~ParentHistogramImpl() [0x4b02a0c]
[2025-01-31 16:27:27.720][27426][critical][backtrace] [./source/server/backtrace.h:121] #13: Envoy::Stats::ParentHistogramImpl::~ParentHistogramImpl() [0x4b02b89]
[2025-01-31 16:27:27.736][27426][critical][backtrace] [./source/server/backtrace.h:121] #14: Envoy::Stats::RefcountPtr<>::resetInternal() [0x4b7acb7]
[2025-01-31 16:27:27.750][27426][critical][backtrace] [./source/server/backtrace.h:121] #15: Envoy::Stats::RefcountPtr<>::~RefcountPtr() [0x4b2a135]
[2025-01-31 16:27:27.765][27426][critical][backtrace] [./source/server/backtrace.h:121] #16: std::__1::pair<>::~pair() [0x4b2a459]
[2025-01-31 16:27:27.780][27426][critical][backtrace] [./source/server/backtrace.h:121] #17: std::__1::__destroy_at<>() [0x4b331d5]
[2025-01-31 16:27:27.795][27426][critical][backtrace] [./source/server/backtrace.h:121] #18: std::__1::destroy_at<>() [0x4b331b5]
[2025-01-31 16:27:27.811][27426][critical][backtrace] [./source/server/backtrace.h:121] #19: std::__1::allocator_traits<>::destroy<>() [0x4b33189]
[2025-01-31 16:27:27.826][27426][critical][backtrace] [./source/server/backtrace.h:121] #20: absl::lts_20240722::container_internal::map_slot_policy<>::destroy<>() [0x4b3315d]
[2025-01-31 16:27:27.841][27426][critical][backtrace] [./source/server/backtrace.h:121] #21: absl::lts_20240722::container_internal::FlatHashMapPolicy<>::destroy<>() [0x4b3312d]
[2025-01-31 16:27:27.856][27426][critical][backtrace] [./source/server/backtrace.h:121] #22: absl::lts_20240722::container_internal::common_policy_traits<>::destroy<>() [0x4b330dd]
[2025-01-31 16:27:27.871][27426][critical][backtrace] [./source/server/backtrace.h:121] #23: absl::lts_20240722::container_internal::raw_hash_set<>::destroy() [0x4b32a35]
[2025-01-31 16:27:27.886][27426][critical][backtrace] [./source/server/backtrace.h:121] #24: absl::lts_20240722::container_internal::raw_hash_set<>::destroy_slots() [0x4b32c95]
[2025-01-31 16:27:27.901][27426][critical][backtrace] [./source/server/backtrace.h:121] #25: absl::lts_20240722::container_internal::raw_hash_set<>::destructor_impl() [0x4b32932]
[2025-01-31 16:27:27.916][27426][critical][backtrace] [./source/server/backtrace.h:121] #26: absl::lts_20240722::container_internal::raw_hash_set<>::~raw_hash_set() [0x4b328a5]
[2025-01-31 16:27:27.931][27426][critical][backtrace] [./source/server/backtrace.h:121] #27: absl::lts_20240722::container_internal::raw_hash_map<>::~raw_hash_map() [0x4b32885]
[2025-01-31 16:27:27.946][27426][critical][backtrace] [./source/server/backtrace.h:121] #28: absl::lts_20240722::flat_hash_map<>::~flat_hash_map() [0x4b27595]
[2025-01-31 16:27:27.961][27426][critical][backtrace] [./source/server/backtrace.h:121] #29: Envoy::Stats::ThreadLocalStoreImpl::CentralCacheEntry::~CentralCacheEntry() [0x4afe56d]
[2025-01-31 16:27:27.976][27426][critical][backtrace] [./source/server/backtrace.h:121] #30: Envoy::Stats::RefcountPtr<>::resetInternal() [0x4b6a7d5]
[2025-01-31 16:27:27.991][27426][critical][backtrace] [./source/server/backtrace.h:121] #31: Envoy::Stats::RefcountPtr<>::~RefcountPtr() [0x4b280d5]
[2025-01-31 16:27:28.006][27426][critical][backtrace] [./source/server/backtrace.h:121] #32: Envoy::Stats::ThreadLocalStoreImpl::ScopeImpl::~ScopeImpl() [0x4aff6d9]
[2025-01-31 16:27:28.021][27426][critical][backtrace] [./source/server/backtrace.h:121] #33: std::__1::__destroy_at<>() [0x4b48675]
[2025-01-31 16:27:28.036][27426][critical][backtrace] [./source/server/backtrace.h:121] #34: std::__1::destroy_at<>() [0x4b48655]
[2025-01-31 16:27:28.051][27426][critical][backtrace] [./source/server/backtrace.h:121] #35: std::__1::allocator_traits<>::destroy<>() [0x4b48639]
[2025-01-31 16:27:28.066][27426][critical][backtrace] [./source/server/backtrace.h:121] #36: std::__1::__shared_ptr_emplace<>::__on_zero_shared() [0x4b484ce]
[2025-01-31 16:27:28.081][27426][critical][backtrace] [./source/server/backtrace.h:121] #37: std::__1::__shared_weak_count::__release_shared() [0x84c8eee]
[2025-01-31 16:27:28.096][27426][critical][backtrace] [./source/server/backtrace.h:121] #38: Envoy::Server::PerFilterChainFactoryContextImpl::~PerFilterChainFactoryContextImpl() [0x595fe8b]
[2025-01-31 16:27:28.111][27426][critical][backtrace] [./source/server/backtrace.h:121] #39: Envoy::Server::PerFilterChainFactoryContextImpl::~PerFilterChainFactoryContextImpl() [0x58f5410]
[2025-01-31 16:27:28.126][27426][critical][backtrace] [./source/server/backtrace.h:121] #40: Envoy::Server::PerFilterChainFactoryContextImpl::~PerFilterChainFactoryContextImpl() [0x58f5459]
[2025-01-31 16:27:28.141][27426][critical][backtrace] [./source/server/backtrace.h:121] #41: std::__1::default_delete<>::operator()() [0x5829b9c]
[2025-01-31 16:27:28.157][27426][critical][backtrace] [./source/server/backtrace.h:121] #42: std::__1::unique_ptr<>::reset() [0x5829aac]
[2025-01-31 16:27:28.172][27426][critical][backtrace] [./source/server/backtrace.h:121] #43: std::__1::unique_ptr<>::~unique_ptr() [0x581e3a9]
[2025-01-31 16:27:28.187][27426][critical][backtrace] [./source/server/backtrace.h:121] #44: Envoy::Server::FilterChainImpl::~FilterChainImpl() [0x5891d42]
[2025-01-31 16:27:28.202][27426][critical][backtrace] [./source/server/backtrace.h:121] #45: std::__1::__destroy_at<>() [0x5891fa5]
[2025-01-31 16:27:28.217][27426][critical][backtrace] [./source/server/backtrace.h:121] #46: std::__1::destroy_at<>() [0x5891f85]
[2025-01-31 16:27:28.232][27426][critical][backtrace] [./source/server/backtrace.h:121] #47: std::__1::allocator_traits<>::destroy<>() [0x5891f69]
[2025-01-31 16:27:28.247][27426][critical][backtrace] [./source/server/backtrace.h:121] #48: std::__1::__shared_ptr_emplace<>::__on_zero_shared() [0x5891a3e]
[2025-01-31 16:27:28.247][27426][critical][backtrace] [./source/server/backtrace.h:121] #49: std::__1::__shared_weak_count::__release_shared() [0x84c8eee]
[2025-01-31 16:27:28.262][27426][critical][backtrace] [./source/server/backtrace.h:121] #50: std::__1::pair<>::~pair() [0x57d29fd]
[2025-01-31 16:27:28.277][27426][critical][backtrace] [./source/server/backtrace.h:121] #51: std::__1::__destroy_at<>() [0x57d29d5]
[2025-01-31 16:27:28.292][27426][critical][backtrace] [./source/server/backtrace.h:121] #52: std::__1::destroy_at<>() [0x57d29b5]
[2025-01-31 16:27:28.307][27426][critical][backtrace] [./source/server/backtrace.h:121] #53: std::__1::allocator_traits<>::destroy<>() [0x57d2989]
[2025-01-31 16:27:28.324][27426][critical][backtrace] [./source/server/backtrace.h:121] #54: absl::lts_20240722::container_internal::map_slot_policy<>::destroy<>() [0x57d295d]
[2025-01-31 16:27:28.340][27426][critical][backtrace] [./source/server/backtrace.h:121] #55: absl::lts_20240722::container_internal::FlatHashMapPolicy<>::destroy<>() [0x57d292d]
[2025-01-31 16:27:28.355][27426][critical][backtrace] [./source/server/backtrace.h:121] #56: absl::lts_20240722::container_internal::common_policy_traits<>::destroy<>() [0x57d28dd]
[2025-01-31 16:27:28.370][27426][critical][backtrace] [./source/server/backtrace.h:121] #57: absl::lts_20240722::container_internal::raw_hash_set<>::destroy() [0x57d2265]
[2025-01-31 16:27:28.386][27426][critical][backtrace] [./source/server/backtrace.h:121] #58: absl::lts_20240722::container_internal::raw_hash_set<>::destroy_slots() [0x57d24c5]
[2025-01-31 16:27:28.401][27426][critical][backtrace] [./source/server/backtrace.h:121] #59: absl::lts_20240722::container_internal::raw_hash_set<>::destructor_impl() [0x57d2192]
[2025-01-31 16:27:28.416][27426][critical][backtrace] [./source/server/backtrace.h:121] #60: absl::lts_20240722::container_internal::raw_hash_set<>::~raw_hash_set() [0x57d2105]
[2025-01-31 16:27:28.431][27426][critical][backtrace] [./source/server/backtrace.h:121] #61: absl::lts_20240722::container_internal::raw_hash_map<>::~raw_hash_map() [0x57d20e5]
[2025-01-31 16:27:28.446][27426][critical][backtrace] [./source/server/backtrace.h:121] #62: absl::lts_20240722::flat_hash_map<>::~flat_hash_map() [0x57cd985]
[2025-01-31 16:27:28.461][27426][critical][backtrace] [./source/server/backtrace.h:121] #63: Envoy::Server::FilterChainManagerImpl::~FilterChainManagerImpl() [0x58f5337]
```
