### PR TITLE
mobile: Disable ClientIntegrationTest.DisableDnsRefreshOnFailure on macOS

### DIFF
--- a/mobile/test/common/integration/client_integration_test.cc
+++ b/mobile/test/common/integration/client_integration_test.cc
@@ -260,7 +260,6 @@ TEST_P(ClientIntegrationTest, BasicWithCares) {
     ASSERT_EQ(cc_.on_complete_received_byte_count_, 67);
   }
 }
-#endif
 
 TEST_P(ClientIntegrationTest, DisableDnsRefreshOnFailure) {
   builder_.setLogLevel(Logger::Logger::debug);
@@ -290,6 +289,7 @@ TEST_P(ClientIntegrationTest, DisableDnsRefreshOnFailure) {
 
   EXPECT_TRUE(found_cache_miss);
 }
+#endif
 
 TEST_P(ClientIntegrationTest, LargeResponse) {
   initialize();

--- a/mobile/test/common/integration/client_integration_test.cc
+++ b/mobile/test/common/integration/client_integration_test.cc
@@ -260,7 +260,11 @@ TEST_P(ClientIntegrationTest, BasicWithCares) {
     ASSERT_EQ(cc_.on_complete_received_byte_count_, 67);
   }
 }
+#endif
 
+// TODO(fredyw): Disable this until we support treating no DNS record as a failure in the Apple
+// resolver.
+#if not defined(__APPLE__)
 TEST_P(ClientIntegrationTest, DisableDnsRefreshOnFailure) {
   builder_.setLogLevel(Logger::Logger::debug);
   std::atomic<bool> found_cache_miss{false};


### PR DESCRIPTION
The DNS refresh on failure currently only works for `getaddrinfo` on Linux because the Apple DNS resolver treats `kDNSServiceErr_NoSuchRecord` as non-failure. 

Risk Level: low (test only)
Testing: integration test
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
