### PR TITLE
fix typo in contrib/

### DIFF
--- a/contrib/golang/filters/http/source/config.h
+++ b/contrib/golang/filters/http/source/config.h
@@ -15,7 +15,7 @@ namespace Golang {
 constexpr char CanonicalName[] = "envoy.filters.http.golang";
 
 /**
- * Config registration for the golang extentions  filter. @see
+ * Config registration for the golang extensions  filter. @see
  * NamedHttpFilterConfigFactory.
  */
 class GolangFilterConfig : public Common::FactoryBase<

--- a/contrib/golang/filters/http/source/golang_filter.cc
+++ b/contrib/golang/filters/http/source/golang_filter.cc
@@ -146,7 +146,7 @@ void Filter::onDestroy() {
   // initRequest haven't be called yet, which mean haven't called into Go.
   if (req_->configId == 0) {
     // should release the req object, since stream reset may happen before calling into Go side,
-    // which means no GC finializer will be invoked to release this C++ object.
+    // which means no GC finalizer will be invoked to release this C++ object.
     delete req_;
     return;
   }
@@ -643,7 +643,7 @@ CAPIStatus Filter::copyHeaders(ProcessorState& state, GoString* go_strs, char* g
   return CAPIStatus::CAPIOK;
 }
 
-// It won't take affect immidiately while it's invoked from a Go thread, instead, it will post a
+// It won't take affect immediately while it's invoked from a Go thread, instead, it will post a
 // callback to run in the envoy worker thread.
 CAPIStatus Filter::setHeader(ProcessorState& state, absl::string_view key, absl::string_view value,
                              headerAction act) {
@@ -677,7 +677,7 @@ CAPIStatus Filter::setHeader(ProcessorState& state, absl::string_view key, absl:
       RELEASE_ASSERT(false, absl::StrCat("unknown header action: ", act));
     }
   } else {
-    // should deep copy the string_view before post to dipatcher callback.
+    // should deep copy the string_view before post to dispatcher callback.
     auto key_str = std::string(key);
     auto value_str = std::string(value);
 
@@ -708,7 +708,7 @@ CAPIStatus Filter::setHeader(ProcessorState& state, absl::string_view key, absl:
   return CAPIStatus::CAPIOK;
 }
 
-// It won't take affect immidiately while it's invoked from a Go thread, instead, it will post a
+// It won't take affect immediately while it's invoked from a Go thread, instead, it will post a
 // callback to run in the envoy worker thread.
 CAPIStatus Filter::removeHeader(ProcessorState& state, absl::string_view key) {
   Thread::LockGuard lock(mutex_);
@@ -729,7 +729,7 @@ CAPIStatus Filter::removeHeader(ProcessorState& state, absl::string_view key) {
     // it's safe to write header in the safe thread.
     headers->remove(Http::LowerCaseString(key));
   } else {
-    // should deep copy the string_view before post to dipatcher callback.
+    // should deep copy the string_view before post to dispatcher callback.
     auto key_str = std::string(key);
 
     auto weak_ptr = weak_from_this();
@@ -867,7 +867,7 @@ CAPIStatus Filter::setTrailer(ProcessorState& state, absl::string_view key, absl
       RELEASE_ASSERT(false, absl::StrCat("unknown header action: ", act));
     }
   } else {
-    // should deep copy the string_view before post to dipatcher callback.
+    // should deep copy the string_view before post to dispatcher callback.
     auto key_str = std::string(key);
     auto value_str = std::string(value);
 
@@ -915,7 +915,7 @@ CAPIStatus Filter::removeTrailer(ProcessorState& state, absl::string_view key) {
   if (state.isThreadSafe()) {
     trailers->remove(Http::LowerCaseString(key));
   } else {
-    // should deep copy the string_view before post to dipatcher callback.
+    // should deep copy the string_view before post to dispatcher callback.
     auto key_str = std::string(key);
 
     auto weak_ptr = weak_from_this();

--- a/contrib/golang/filters/http/source/golang_filter.h
+++ b/contrib/golang/filters/http/source/golang_filter.h
@@ -234,7 +234,7 @@ public:
   Http::FilterTrailersStatus decodeTrailers(Http::RequestTrailerMap&) override;
   void setDecoderFilterCallbacks(Http::StreamDecoderFilterCallbacks& callbacks) override {
     decoding_state_.setDecoderFilterCallbacks(callbacks);
-    // We initilizes dispatcher as soon as it is available.
+    // We initializes dispatcher as soon as it is available.
     dispatcher_ = &callbacks.dispatcher();
   }
 

--- a/contrib/golang/filters/http/source/processor_state.cc
+++ b/contrib/golang/filters/http/source/processor_state.cc
@@ -163,7 +163,7 @@ bool ProcessorState::handleDataGolangStatus(const GolangStatus status) {
 };
 
 // should set trailers_ to nullptr when return true.
-// means we should not read/write trailers then, since trailers will pass to next fitler.
+// means we should not read/write trailers then, since trailers will pass to next filter.
 bool ProcessorState::handleTrailerGolangStatus(const GolangStatus status) {
   ENVOY_LOG(debug, "golang filter handle trailer status, state: {}, status: {}", stateStr(),
             int(status));

--- a/contrib/golang/upstreams/http/tcp/source/processor_state.cc
+++ b/contrib/golang/upstreams/http/tcp/source/processor_state.cc
@@ -99,7 +99,7 @@ void EncodingProcessorState::handleDataGolangStatus(const HttpTcpBridgeStatus st
 
   switch (status) {
   case HttpTcpBridgeStatus::HttpTcpBridgeContinue:
-    // streaming send data to upstream, go side get each_data_piece, may be called multipled times.
+    // streaming send data to upstream, go side get each_data_piece, may be called multiple times.
 
     if (end_stream) {
       setFilterState(FilterState::Done);

--- a/contrib/golang/upstreams/http/tcp/source/processor_state.h
+++ b/contrib/golang/upstreams/http/tcp/source/processor_state.h
@@ -51,14 +51,14 @@ enum class HttpTcpBridgeStatus {
   /**
    *
    * Used when you want to leave the current func area and continue further func. (when streaming,
-   * go side get each_data_piece, may be called multipled times)
+   * go side get each_data_piece, may be called multiple times)
    *
    * Here is the specific explanation in different funcs:
    *
    * encodeHeaders: will go to encodeData, go side in encodeData will streaming get each_data_piece.
    *
    * encodeData: streaming send data to upstream, go side get each_data_piece, may be called
-   * multipled times.
+   * multiple times.
    *
    * onUpstreamData: go side in onUpstreamData will get each_data_piece, pass data
    * and headers to downstream streaming.
@@ -78,7 +78,7 @@ enum class HttpTcpBridgeStatus {
    * data one-off. (Be careful: cannot be used when end_stream=true)
    *
    * onUpstreamData: every data
-   * trigger will call go side, and go side get whloe buffered data ever since at every time.
+   * trigger will call go side, and go side get whole buffered data ever since at every time.
    */
   HttpTcpBridgeStopAndBuffer,
 

--- a/contrib/golang/upstreams/http/tcp/source/upstream_request.cc
+++ b/contrib/golang/upstreams/http/tcp/source/upstream_request.cc
@@ -264,7 +264,7 @@ void HttpTcpBridge::onUpstreamData(Buffer::Instance& data, bool end_stream) {
     break;
 
   case HttpTcpBridgeStatus::HttpTcpBridgeStopAndBuffer:
-    // every data trigger will call go side, and go side get whloe buffered data ever since at every
+    // every data trigger will call go side, and go side get whole buffered data ever since at every
     // time.
     //
     // if onUpstreamData is called streaming multiple times, data is gradually appended by default,

--- a/contrib/hyperscan/matching/input_matchers/source/matcher.cc
+++ b/contrib/hyperscan/matching/input_matchers/source/matcher.cc
@@ -158,7 +158,7 @@ void Matcher::compile(const std::vector<const char*>& expressions,
 
 hs_scratch_t* Matcher::getScratch(ScratchThreadLocalPtr& local_scratch) const {
   // Some matchers are constructed before dispatching threads and set() method of thread local slot
-  // will only initialize thread local object in existing threads, which may lead to unintialized
+  // will only initialize thread local object in existing threads, which may lead to uninitialized
   // thread local object in threads which are dispatched later. E.g, stats matchers are constructed
   // before workers while there is chance to use these matchers in working threads. As a result,
   // we have to ask main thread to allocate thread local object again.

--- a/contrib/hyperscan/matching/input_matchers/test/matcher_test.cc
+++ b/contrib/hyperscan/matching/input_matchers/test/matcher_test.cc
@@ -17,7 +17,7 @@ namespace InputMatchers {
 namespace Hyperscan {
 
 // Verify that we do not get TSAN or other errors when creating scratch in
-// multithreading.
+// multi-threading.
 TEST(ThreadLocalTest, RaceScratchCreation) {
   Thread::ThreadFactory& thread_factory = Thread::threadFactoryForTest();
 

--- a/contrib/kafka/filters/network/source/mesh/command_handlers/fetch_record_converter.cc
+++ b/contrib/kafka/filters/network/source/mesh/command_handlers/fetch_record_converter.cc
@@ -110,7 +110,7 @@ Bytes FetchRecordConverterImpl::renderRecordBatch(
 void FetchRecordConverterImpl::appendRecord(const InboundRecord& record, Bytes& out) const {
 
   Bytes tmp = {};
-  // This is not precise maths, as we could be over-reserving a little due to var-length fields.
+  // This is not precise math, as we could be over-reserving a little due to var-length fields.
   tmp.reserve(sizeof(int8_t) + sizeof(int64_t) + sizeof(int32_t) + record.dataLengthEstimate());
 
   // attributes: int8

--- a/contrib/kafka/filters/network/source/serialization.h
+++ b/contrib/kafka/filters/network/source/serialization.h
@@ -1477,7 +1477,7 @@ uint32_t EncodingContext::encode(const NullableArray<T>& arg, Buffer::Instance& 
 
 /**
  * Encode nullable object as marker byte (1 if present, -1 otherwise), then if object is present,
- * have it serialise itself.
+ * have it to serialize itself.
  */
 template <typename T>
 uint32_t EncodingContext::encode(const absl::optional<T>& arg, Buffer::Instance& dst) {

--- a/contrib/qat/compression/qatzip/compressor/test/qatzip_compressor_impl_test.cc
+++ b/contrib/qat/compression/qatzip/compressor/test/qatzip_compressor_impl_test.cc
@@ -71,7 +71,7 @@ class QatzipConfigTest
       public ::testing::WithParamInterface<std::tuple<int, std::string, int, int, int>> {};
 
 // These tests should pass even if required hardware or setup steps required for qatzip are missing.
-// Qatzip uses a sofware fallback in this case.
+// Qatzip uses a software fallback in this case.
 INSTANTIATE_TEST_SUITE_P(QatzipConfigTestInstantiation, QatzipConfigTest,
                          // First tuple has all default values.
                          ::testing::Values(std::make_tuple(1, "DEFAULT", 1024, 131072, 4096),

--- a/contrib/qat/compression/qatzstd/compressor/test/qatzstd_compressor_impl_test.cc
+++ b/contrib/qat/compression/qatzstd/compressor/test/qatzstd_compressor_impl_test.cc
@@ -70,7 +70,7 @@ class QatzstdConfigTest : public QatzstdCompressorImplTest,
                           public ::testing::WithParamInterface<std::tuple<int, int, bool, int>> {};
 
 // These tests should pass even if required hardware or setup steps required for qatzstd are
-// missing. Qatzstd uses a sofware fallback in this case.
+// missing. Qatzstd uses a software fallback in this case.
 INSTANTIATE_TEST_SUITE_P(
     QatzstdConfigTestInstantiation, QatzstdConfigTest,
     // First tuple has all default values.

--- a/contrib/qat/private_key_providers/source/qat.h
+++ b/contrib/qat/private_key_providers/source/qat.h
@@ -60,8 +60,8 @@ private:
 };
 
 /**
- * QatSection represents a section definition in QAT configuration. Its main purpose is to initialize
- * HW and load balance operations to the QAT handles.
+ * QatSection represents a section definition in QAT configuration. Its main purpose is to
+ * initialize HW and load balance operations to the QAT handles.
  */
 class QatSection : public Logger::Loggable<Logger::Id::connection> {
 public:

--- a/contrib/qat/private_key_providers/source/qat.h
+++ b/contrib/qat/private_key_providers/source/qat.h
@@ -60,7 +60,7 @@ private:
 };
 
 /**
- * QatSection represents a section definition in QAT configuration. Its main purpose is to initalize
+ * QatSection represents a section definition in QAT configuration. Its main purpose is to initialize
  * HW and load balance operations to the QAT handles.
  */
 class QatSection : public Logger::Loggable<Logger::Id::connection> {

--- a/contrib/sip_proxy/filters/network/source/metadata.h
+++ b/contrib/sip_proxy/filters/network/source/metadata.h
@@ -142,7 +142,7 @@ public:
   void resetAffinityIteration() { affinity_iteration_ = affinity_.begin(); }
   std::vector<AffinityEntry>::iterator& affinityIteration() { return affinity_iteration_; };
   std::vector<AffinityEntry>::iterator& nextAffinityIteration() {
-    // When try next affinity, destination set by pervious one become invalid, should be cleared.
+    // When try next affinity, destination set by previous one become invalid, should be cleared.
     resetDestination();
 
     if (affinity_iteration_ != affinity_.end()) {

--- a/contrib/sip_proxy/filters/network/source/router/router_impl.cc
+++ b/contrib/sip_proxy/filters/network/source/router/router_impl.cc
@@ -409,7 +409,7 @@ FilterStatus Router::messageBegin(MessageMetadataSharedPtr metadata) {
                      metadata->affinityIteration()->key());
 
     if (!metadata->destination().empty()) {
-      // TRA query get result, and set destintion.
+      // TRA query get result, and set destination.
       host = metadata->destination();
       ENVOY_STREAM_LOG(debug, "has already set destination {} from affinity", *callbacks_, host);
     } else {
@@ -438,8 +438,8 @@ FilterStatus Router::messageBegin(MessageMetadataSharedPtr metadata) {
       }
     }
 
-    // Already get destintion for current affinity, try to get or create new connection for this
-    // destination. If this destintion is invalid, try next affinity.
+    // Already get destination for current affinity, try to get or create new connection for this
+    // destination. If this destination is invalid, try next affinity.
     if (auto upstream_request = transaction_info->getUpstreamRequest(std::string(host));
         upstream_request != nullptr) {
       // There is action connection, reuse it.


### PR DESCRIPTION
Commit Message:
Run `check_spelling_pedantic.py` tool in contrib/ folder and fix the obvious typos

Additional Description:
Risk Level: low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
