### PR TITLE
Remove deprecated use of hash_set::find

### DIFF
--- a/source/common/common/utility.cc
+++ b/source/common/common/utility.cc
@@ -84,7 +84,7 @@ std::string DateFormatter::fromTime(SystemTime time) const {
   const auto epoch_time_ss =
       std::chrono::duration_cast<std::chrono::seconds>(time.time_since_epoch());
 
-  const auto iter = cached_times.find(raw_format_string_, raw_format_hash_);
+  const auto iter = cached_times.find(raw_format_string_);
 
   if (iter == cached_times.end() || iter->second.epoch_time_seconds != epoch_time_ss) {
     // No cached entry found for the given format string and time.

--- a/source/common/common/utility.h
+++ b/source/common/common/utility.h
@@ -47,8 +47,7 @@ const std::string errorDetails(int error_code);
 class DateFormatter {
 public:
   DateFormatter(absl::string_view format_string, bool local_time = false)
-      : raw_format_string_(format_string),
-        raw_format_hash_(CachedTimes::hasher{}(raw_format_string_)), local_time_(local_time) {
+      : raw_format_string_(format_string), local_time_(local_time) {
     parse(format_string);
   }
 
@@ -158,7 +157,6 @@ private:
 
   // This is the format string as supplied in configuration, e.g. "foo %3f bar".
   const std::string raw_format_string_;
-  const size_t raw_format_hash_{};
 
   // Use local time zone instead of UTC if this is set to true.
   const bool local_time_{};


### PR DESCRIPTION
Commit Message:
The use of this symbol has been deprecated and marked for inlining. The function being deprecated is absl::container_internal::raw_hash_set::find.

Risk Level: Low
Testing: Unit Tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
