### PR TITLE
Explicitly use void in the C function list of arguments for functions that take no arguments

### DIFF
--- a/source/extensions/dynamic_modules/abi.h
+++ b/source/extensions/dynamic_modules/abi.h
@@ -257,7 +257,7 @@ typedef enum {
  * @return envoy_dynamic_module_type_abi_version_envoy_ptr is the ABI version of the dynamic
  * module. Null means the error and the module will be unloaded immediately.
  */
-envoy_dynamic_module_type_abi_version_envoy_ptr envoy_dynamic_module_on_program_init();
+envoy_dynamic_module_type_abi_version_envoy_ptr envoy_dynamic_module_on_program_init(void);
 
 /**
  * envoy_dynamic_module_on_http_filter_config_new is called by the main thread when the http

--- a/test/extensions/dynamic_modules/dynamic_modules_test.cc
+++ b/test/extensions/dynamic_modules/dynamic_modules_test.cc
@@ -20,7 +20,7 @@ INSTANTIATE_TEST_SUITE_P(LanguageTests, DynamicModuleTestLanguages, testing::Val
 
 TEST_P(DynamicModuleTestLanguages, DoNotClose) {
   std::string language = GetParam();
-  using GetSomeVariableFuncType = int (*)();
+  using GetSomeVariableFuncType = int (*)(void);
   absl::StatusOr<DynamicModulePtr> module =
       newDynamicModule(testSharedObjectPath("no_op", language), false);
   EXPECT_TRUE(module.ok());

--- a/test/extensions/dynamic_modules/test_data/c/no_op.c
+++ b/test/extensions/dynamic_modules/test_data/c/no_op.c
@@ -5,12 +5,12 @@
 
 static int some_variable = 0;
 
-int getSomeVariable() {
+int getSomeVariable(void) {
   some_variable++;
   return some_variable;
 }
 
-envoy_dynamic_module_type_abi_version_envoy_ptr envoy_dynamic_module_on_program_init() {
+envoy_dynamic_module_type_abi_version_envoy_ptr envoy_dynamic_module_on_program_init(void) {
   return kAbiVersion;
 }
 


### PR DESCRIPTION
Commit Message:

Using void in the list of function arguments in C++ is allowed for functions that take no arguments, but it's rather uncommon.

However, when it comes to plain C, there is an actual difference between a function declaration `int foo()` and `int foo(void)`. The first one says that there is a function foo that returns an integer and nothing is known about the arguments the function takes. While the second one explicitly declares that the function takes no argument.

In practice this difference does not often matter, however, from the language point of view, they are not the same and it triggers UBSAN when running Envoy tests on clang-18.

Specifically, UBSAN complains that tests attempt to call a function thought a pointer of incompatible function type.

I don't believe it causes any issues in practice for Envoy, but addressing these warnings will help us to move to a newer version of LLVM toolchains for Envoy.

NOTE: There are some alternative ways we could address this issue as well, for example, we can change all the examples to use C++ instead of C, and, I belive, it would also address the issue, but it's a bit more invasive and I opted not to convert all the tests because of is practically a false positive UBSAN complain.

Additional Description:

Related to #37911 and fixes one of the issues in #38093

Risk Level: low
Testing: `bazel test -c dbg //test/extensions/dynamic_modules:dynamic_modules_test --config=docker-asan`
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a

+cc @phlax 
