### PR TITLE
network: Log local and remote address families on network error

### DIFF
--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -45,14 +45,7 @@ std::ostream& operator<<(std::ostream& os, Connection::State connection_state) {
 }
 
 absl::string_view ipVersionAsString(Network::Address::IpVersion ip_version) {
-  switch (ip_version) {
-  case Address::IpVersion::v4:
-    return "v4";
-  case Address::IpVersion::v6:
-    return "v6";
-  default:
-    return "unknown";
-  }
+  return ip_version == Network::Address::IpVersion::v4 ? "v4" : "v6";
 }
 
 } // namespace
@@ -1048,19 +1041,27 @@ void ClientConnectionImpl::connect() {
   } else {
     immediate_error_event_ = ConnectionEvent::RemoteClose;
     connecting_ = false;
-    absl::string_view remote_address_family =
-        socket_->connectionInfoProvider().remoteAddress()->type() == Address::Type::Ip
-            ? ipVersionAsString(socket_->connectionInfoProvider().remoteAddress()->ip()->version())
-            : "";
-    absl::string_view local_address_family =
-        socket_->connectionInfoProvider().remoteAddress()->type() == Address::Type::Ip
-            ? ipVersionAsString(socket_->connectionInfoProvider().localAddress()->ip()->version())
-            : "";
-    setFailureReason(absl::StrCat(
-        "immediate connect error: ", errorDetails(result.errno_),
-        "|remote address:", socket_->connectionInfoProvider().remoteAddress()->asString(),
-        "|remote address family:", remote_address_family,
-        "|local address family:", local_address_family));
+    if (Runtime::runtimeFeatureEnabled(
+            "envoy.reloadable_features.log_ip_families_on_network_error")) {
+      absl::string_view remote_address_family =
+          socket_->connectionInfoProvider().remoteAddress()->type() == Address::Type::Ip
+              ? ipVersionAsString(
+                    socket_->connectionInfoProvider().remoteAddress()->ip()->version())
+              : "";
+      absl::string_view local_address_family =
+          socket_->connectionInfoProvider().remoteAddress()->type() == Address::Type::Ip
+              ? ipVersionAsString(socket_->connectionInfoProvider().localAddress()->ip()->version())
+              : "";
+      setFailureReason(absl::StrCat(
+          "immediate connect error: ", errorDetails(result.errno_),
+          "|remote address:", socket_->connectionInfoProvider().remoteAddress()->asString(),
+          "|remote address family:", remote_address_family,
+          "|local address family:", local_address_family));
+    } else {
+      setFailureReason(absl::StrCat(
+          "immediate connect error: ", errorDetails(result.errno_),
+          "|remote address:", socket_->connectionInfoProvider().remoteAddress()->asString()));
+    }
     ENVOY_CONN_LOG_EVENT(debug, "connection_immediate_error", "{}", *this, failureReason());
 
     // Trigger a write event. This is needed on macOS and seems harmless on Linux.

--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -44,6 +44,17 @@ std::ostream& operator<<(std::ostream& os, Connection::State connection_state) {
   return os;
 }
 
+absl::string_view ipVersionAsString(Network::Address::IpVersion ip_version) {
+  switch (ip_version) {
+  case Address::IpVersion::v4:
+    return "v4";
+  case Address::IpVersion::v6:
+    return "v6";
+  default:
+    return "unknown";
+  }
+}
+
 } // namespace
 
 void ConnectionImplUtility::updateBufferStats(uint64_t delta, uint64_t new_total,
@@ -1037,9 +1048,19 @@ void ClientConnectionImpl::connect() {
   } else {
     immediate_error_event_ = ConnectionEvent::RemoteClose;
     connecting_ = false;
+    absl::string_view remote_address_family =
+        socket_->connectionInfoProvider().remoteAddress()->type() == Address::Type::Ip
+            ? ipVersionAsString(socket_->connectionInfoProvider().remoteAddress()->ip()->version())
+            : "";
+    absl::string_view local_address_family =
+        socket_->connectionInfoProvider().remoteAddress()->type() == Address::Type::Ip
+            ? ipVersionAsString(socket_->connectionInfoProvider().localAddress()->ip()->version())
+            : "";
     setFailureReason(absl::StrCat(
         "immediate connect error: ", errorDetails(result.errno_),
-        "|remote address:", socket_->connectionInfoProvider().remoteAddress()->asString()));
+        "|remote address:", socket_->connectionInfoProvider().remoteAddress()->asString(),
+        "|remote address family:", remote_address_family,
+        "|local address family:", local_address_family));
     ENVOY_CONN_LOG_EVENT(debug, "connection_immediate_error", "{}", *this, failureReason());
 
     // Trigger a write event. This is needed on macOS and seems harmless on Linux.

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -153,6 +153,8 @@ FALSE_RUNTIME_GUARD(envoy_reloadable_features_quic_no_tcp_delay);
 FALSE_RUNTIME_GUARD(envoy_reloadable_features_http_inspector_use_balsa_parser);
 // TODO(renjietang): Evaluate and make this a config knob or remove.
 FALSE_RUNTIME_GUARD(envoy_reloadable_features_use_canonical_suffix_for_quic_brokenness);
+// TODO(fredyw): Remove after done with debugging.
+FALSE_RUNTIME_GUARD(envoy_reloadable_features_log_ip_families_on_network_error);
 
 // A flag to set the maximum TLS version for google_grpc client to TLS1.2, when needed for
 // compliance restrictions.

--- a/test/common/network/connection_impl_test.cc
+++ b/test/common/network/connection_impl_test.cc
@@ -472,6 +472,13 @@ TEST_P(ConnectionImplTest, ImmediateConnectError) {
   dispatcher_->run(Event::Dispatcher::RunType::Block);
 
   EXPECT_THAT(client_connection_->transportFailureReason(), StartsWith("immediate connect error"));
+  if (socket_->connectionInfoProvider().localAddress()->ip()->version() == Address::IpVersion::v4) {
+    EXPECT_THAT(client_connection_->transportFailureReason(),
+                HasSubstr("remote address family:v4|local address family:v4"));
+  } else {
+    EXPECT_THAT(client_connection_->transportFailureReason(),
+                HasSubstr("remote address family:v6|local address family:v6"));
+  }
 }
 
 TEST_P(ConnectionImplTest, SetServerTransportSocketTimeout) {

--- a/test/common/network/connection_impl_test.cc
+++ b/test/common/network/connection_impl_test.cc
@@ -472,6 +472,39 @@ TEST_P(ConnectionImplTest, ImmediateConnectError) {
   dispatcher_->run(Event::Dispatcher::RunType::Block);
 
   EXPECT_THAT(client_connection_->transportFailureReason(), StartsWith("immediate connect error"));
+  EXPECT_THAT(client_connection_->transportFailureReason(),
+              Not(HasSubstr("remote address family")));
+  EXPECT_THAT(client_connection_->transportFailureReason(), Not(HasSubstr("local address family")));
+}
+
+TEST_P(ConnectionImplTest, ImmediateConnectErrorLogIpFamilies) {
+  TestScopedRuntime scoped_runtime;
+  scoped_runtime.mergeValues(
+      {{"envoy.reloadable_features.log_ip_families_on_network_error", "true"}});
+  dispatcher_ = api_->allocateDispatcher("test_thread");
+
+  // Using a broadcast/multicast address as the connection destinations address causes an
+  // immediate error return from connect().
+  Address::InstanceConstSharedPtr broadcast_address;
+  socket_ = std::make_shared<Network::Test::TcpListenSocketImmediateListen>(
+      Network::Test::getCanonicalLoopbackAddress(GetParam()));
+  if (socket_->connectionInfoProvider().localAddress()->ip()->version() == Address::IpVersion::v4) {
+    broadcast_address = std::make_shared<Address::Ipv4Instance>("224.0.0.1", 0);
+  } else {
+    broadcast_address = std::make_shared<Address::Ipv6Instance>("ff02::1", 0);
+  }
+
+  client_connection_ = dispatcher_->createClientConnection(
+      broadcast_address, source_address_, Network::Test::createRawBufferSocket(), nullptr, nullptr);
+  client_connection_->addConnectionCallbacks(client_callbacks_);
+  client_connection_->connect();
+
+  // Verify that also the immediate connect errors generate a remote close event.
+  EXPECT_CALL(client_callbacks_, onEvent(ConnectionEvent::RemoteClose))
+      .WillOnce(InvokeWithoutArgs([&]() -> void { dispatcher_->exit(); }));
+  dispatcher_->run(Event::Dispatcher::RunType::Block);
+
+  EXPECT_THAT(client_connection_->transportFailureReason(), StartsWith("immediate connect error"));
   if (socket_->connectionInfoProvider().localAddress()->ip()->version() == Address::IpVersion::v4) {
     EXPECT_THAT(client_connection_->transportFailureReason(),
                 HasSubstr("remote address family:v4|local address family:v4"));


### PR DESCRIPTION
This PR adds debugging info by logging the local and remote address families on network, such as an issue with trying to connect to an IPv6-only server on an IPv4-only network or IPv4-only server on an IPv6-only network. This feature can only be enabled by setting `envoy.reloadable_features.log_ip_families_on_network_error` runtime guard to true. It defaults to false.

Risk Level: low
Testing: unit test
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
Runtime guard: `envoy.reloadable_features.log_ip_families_on_network_error`
