### PR TITLE
docs: remove all usages of "JWT token" in text

### DIFF
--- a/api/envoy/config/filter/http/jwt_authn/v2alpha/README.md
+++ b/api/envoy/config/filter/http/jwt_authn/v2alpha/README.md
@@ -60,7 +60,7 @@ bespoke: beta:true,jwt_value:"eyJFbnZveSI6ICJyb2NrcyJ9.e30.c2lnbmVk",trace=1234
 The header `name` may be `Authorization`.
 
 The `value_prefix` must match exactly, i.e., case-sensitively.
-If the `value_prefix` is not found, the header is skipped: not considered as a source for a JWT token.
+If the `value_prefix` is not found, the header is skipped: not considered as a source for a JWT.
 
 If there are no JWT-legal characters after the `value_prefix`, the entire string after it
-is taken to be the JWT token. This is unlikely to succeed; the error will reported by the JWT parser.
+is taken to be the JWT. This is unlikely to succeed; the error will reported by the JWT parser.

--- a/api/envoy/config/filter/http/jwt_authn/v2alpha/config.proto
+++ b/api/envoy/config/filter/http/jwt_authn/v2alpha/config.proto
@@ -36,7 +36,7 @@ option (udpa.annotations.file_status).package_version_status = FROZEN;
 // * issuer: the principal that issues the JWT. It has to match the one from the token.
 // * allowed audiences: the ones in the token have to be listed here.
 // * how to fetch public key JWKS to verify the token signature.
-// * how to extract JWT token in the request.
+// * how to extract the JWT in the request.
 // * how to pass successfully verified token payload.
 //
 // Example:
@@ -137,7 +137,7 @@ message JwtProvider {
   // Multiple JWTs can be verified for a request. Each JWT has to be extracted from the locations
   // its provider specified or from the default locations.
   //
-  // Specify the HTTP headers to extract JWT token. For examples, following config:
+  // Specify the HTTP headers to extract the JWT. For examples, following config:
   //
   // .. code-block:: yaml
   //
@@ -209,7 +209,7 @@ message RemoteJwks {
   google.protobuf.Duration cache_duration = 2;
 }
 
-// This message specifies a header location to extract JWT token.
+// This message specifies a header location to extract JWT.
 message JwtHeader {
   // The HTTP header name.
   string name = 1 [(validate.rules).string = {min_bytes: 1}];
@@ -305,7 +305,7 @@ message JwtRequirement {
     // The requirement is always satisfied even if JWT is missing or the JWT
     // verification fails. A typical usage is: this filter is used to only verify
     // JWTs and pass the verified JWT payloads to another filter, the other filter
-    // will make decision. In this mode, all JWT tokens will be verified.
+    // will make decision. In this mode, all JWTs will be verified.
     google.protobuf.Empty allow_missing_or_failed = 5;
 
     // The requirement is satisfied if JWT is missing, but failed if JWT is

--- a/api/envoy/extensions/filters/http/jwt_authn/v3/config.proto
+++ b/api/envoy/extensions/filters/http/jwt_authn/v3/config.proto
@@ -35,7 +35,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // * issuer: the principal that issues the JWT. If specified, it has to match the ``iss`` field in JWT.
 // * allowed audiences: the ones in the token have to be listed here.
 // * how to fetch public key JWKS to verify the token signature.
-// * how to extract JWT token in the request.
+// * how to extract the JWT in the request.
 // * how to pass successfully verified token payload.
 //
 // Example:
@@ -208,7 +208,7 @@ message JwtProvider {
   // Multiple JWTs can be verified for a request. Each JWT has to be extracted from the locations
   // its provider specified or from the default locations.
   //
-  // Specify the HTTP headers to extract JWT token. For examples, following config:
+  // Specify the HTTP headers to extract the JWT. For examples, following config:
   //
   // .. code-block:: yaml
   //
@@ -348,7 +348,7 @@ message JwtProvider {
   uint32 clock_skew_seconds = 10;
 
   // Enables JWT cache, its size is specified by ``jwt_cache_size``.
-  // Only valid JWT tokens are cached.
+  // Only valid JWTs are cached.
   JwtCacheConfig jwt_cache_config = 12;
 
   // Add JWT claim to HTTP Header
@@ -365,7 +365,7 @@ message JwtProvider {
   // This header is only reserved for jwt claim; any other value will be overwritten.
   repeated JwtClaimToHeader claim_to_headers = 15;
 
-  // Clears route cache in order to allow JWT token to correctly affect
+  // Clears route cache in order to allow the JWT to correctly affect
   // routing decisions. Filter clears all cached routes when:
   //
   // 1. The field is set to ``true``.
@@ -378,7 +378,7 @@ message JwtProvider {
 
 // This message specifies JWT Cache configuration.
 message JwtCacheConfig {
-  // The unit is number of JWT tokens, default to 100.
+  // The unit is number of JWTs, default to 100.
   uint32 jwt_cache_size = 1;
 }
 
@@ -469,7 +469,7 @@ message JwksAsyncFetch {
   google.protobuf.Duration failed_refetch_duration = 2;
 }
 
-// This message specifies a header location to extract JWT token.
+// This message specifies a header location to extract the JWT.
 message JwtHeader {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.http.jwt_authn.v2alpha.JwtHeader";
@@ -576,7 +576,7 @@ message JwtRequirement {
     // The requirement is always satisfied even if JWT is missing or the JWT
     // verification fails. A typical usage is: this filter is used to only verify
     // JWTs and pass the verified JWT payloads to another filter, the other filter
-    // will make decision. In this mode, all JWT tokens will be verified.
+    // will make decision. In this mode, all JWTs will be verified.
     google.protobuf.Empty allow_missing_or_failed = 5;
 
     // The requirement is satisfied if JWT is missing, but failed if JWT is

--- a/api/envoy/service/auth/v2/attribute_context.proto
+++ b/api/envoy/service/auth/v2/attribute_context.proto
@@ -27,7 +27,7 @@ option (udpa.annotations.file_status).package_version_status = FROZEN;
 // of the `AttributeContext`. The `AttributeContext` is a collection of individual attributes
 // supported by Envoy authorization system.
 // [#comment: The following items are left out of this proto
-// Request.Auth field for jwt tokens
+// Request.Auth field for JWTs
 // Request.Api for api management
 // Origin peer that originated the request
 // Caching Protocol

--- a/api/envoy/service/auth/v3/attribute_context.proto
+++ b/api/envoy/service/auth/v3/attribute_context.proto
@@ -29,7 +29,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // of the ``AttributeContext``. The ``AttributeContext`` is a collection of individual attributes
 // supported by Envoy authorization system.
 // [#comment: The following items are left out of this proto
-// Request.Auth field for jwt tokens
+// Request.Auth field for JWTs
 // Request.Api for api management
 // Origin peer that originated the request
 // Caching Protocol

--- a/changelogs/1.24.0.yaml
+++ b/changelogs/1.24.0.yaml
@@ -122,7 +122,7 @@ bug_fixes:
     fixed a bug with internal redirects not being performed for drained connections.
 - area: jwt_authn
   change: |
-    fixed a bug where a negative "exp", "iat", or "nbf" integer in JWT token readed as a large positive value.
+    fixed a bug where a negative "exp", "iat", or "nbf" integer in JWTs readed as a large positive value.
 - area: grpc_transcoder
   change: |
     fixed a bug where a request with a wrong binding type is not rejected if the request body is empty.

--- a/configs/jwt_authn.yaml
+++ b/configs/jwt_authn.yaml
@@ -1,4 +1,4 @@
-# An example config to validate JWT tokens issued by Firebase.
+# An example config to validate JWTs issued by Firebase.
 admin:
   address:
     socket_address:

--- a/docs/root/configuration/http/http_filters/_include/jwt-authn-filter.yaml
+++ b/docs/root/configuration/http/http_filters/_include/jwt-authn-filter.yaml
@@ -1,4 +1,4 @@
-# An example config to validate JWT tokens issued by Firebase.
+# An example config to validate JWTs issued by Firebase.
 admin:
   address:
     socket_address:

--- a/docs/root/configuration/http/http_filters/_include/jwt-authn-headers-filter.yaml
+++ b/docs/root/configuration/http/http_filters/_include/jwt-authn-headers-filter.yaml
@@ -1,4 +1,4 @@
-# An example config to validate JWT tokens issued by Firebase.
+# An example config to validate JWTs issued by Firebase.
 admin:
   address:
     socket_address:

--- a/docs/root/configuration/http/http_filters/jwt_authn_filter.rst
+++ b/docs/root/configuration/http/http_filters/jwt_authn_filter.rst
@@ -44,7 +44,7 @@ JwtProvider
 * ``from_cookies``: extract JWT from HTTP request cookies.
 * ``forward_payload_header``: forward the JWT payload in the specified HTTP header.
 * ``claim_to_headers``: copy JWT claim to HTTP header.
-* ``jwt_cache_config``: Enables JWT cache, its size can be specified by ``jwt_cache_size``. Only valid JWT tokens are cached.
+* ``jwt_cache_config``: Enables JWT cache, its size can be specified by ``jwt_cache_size``. Only valid JWTs are cached.
 
 Default Extract Location
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -100,10 +100,10 @@ This means all of the following will return a JWT of ``eyJFbnZveSI6ICJyb2NrcyJ9.
 The header :ref:`name <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtHeader.name>` may be ``Authorization``.
 
 The :ref:`value_prefix <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtHeader.value_prefix>` must match exactly, i.e., case-sensitively.
-If the :ref:`value_prefix <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtHeader.value_prefix>` is not found, the header is skipped, not considered as a source for a JWT token.
+If the :ref:`value_prefix <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtHeader.value_prefix>` is not found, the header is skipped, not considered as a source for a JWT.
 
 If there are no JWT-legal characters after the :ref:`value_prefix <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtHeader.value_prefix>`, the entire string after it
-is taken to be the JWT token. This is unlikely to succeed; the error will reported by the JWT parser.
+is taken to be the JWT. This is unlikely to succeed; the error will reported by the JWT parser.
 
 
 Remote JWKS config example
@@ -139,7 +139,7 @@ Another config example using inline JWKS:
     :linenos:
     :caption: :download:`jwt-authn-inline-filter.yaml <_include/jwt-authn-inline-filter.yaml>`
 
-Above example uses config inline string to specify JWKS. The JWT token will be extracted from HTTP headers as:
+Above example uses config inline string to specify JWKS. The JWT will be extracted from HTTP headers as:
 
 .. code-block::
 
@@ -200,7 +200,7 @@ If a JWT is valid, you can add some of its claims of type (string, integer, bool
 The field :ref:`claim_to_headers <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtProvider.claim_to_headers>` is a repeat of message :ref:`JWTClaimToHeader <envoy_v3_api_msg_extensions.filters.http.jwt_authn.v3.JWTClaimToHeader>` which has two fields:
 
 * Field ``header_name`` specifies the name of new http header reserved for jwt claim. If this header is already present with some other value then it will be replaced with the claim value. If the claim value doesn't exist then this header wouldn't be available for any other value.
-* Field ``claim_name`` specifies the claim from verified jwt token.
+* Field ``claim_name`` specifies the claim from the verified JWT.
 
 .. literalinclude:: _include/jwt-authn-claim-filter.yaml
     :language: yaml

--- a/source/extensions/filters/http/jwt_authn/authenticator.cc
+++ b/source/extensions/filters/http/jwt_authn/authenticator.cc
@@ -200,7 +200,7 @@ void AuthenticatorImpl::startVerify() {
     }
   }
 
-  ENVOY_LOG(debug, "{}: Verifying JWT token of issuer {}", name(), jwt_->iss_);
+  ENVOY_LOG(debug, "{}: Verifying JWT of issuer {}", name(), jwt_->iss_);
   // Check if `iss` is allowed.
   if (!curr_token_->isIssuerAllowed(jwt_->iss_)) {
     doneWithStatus(Status::JwtUnknownIssuer);
@@ -444,7 +444,7 @@ void AuthenticatorImpl::setPayloadMetadata(const ProtobufWkt::Struct& jwt_payloa
 }
 
 void AuthenticatorImpl::doneWithStatus(const Status& status) {
-  ENVOY_LOG(debug, "{}: JWT token verification completed with: {}", name(),
+  ENVOY_LOG(debug, "{}: JWT verification completed with: {}", name(),
             ::google::jwt_verify::getStatusString(status));
 
   if (Status::Ok != status) {

--- a/source/extensions/filters/http/jwt_authn/extractor.cc
+++ b/source/extensions/filters/http/jwt_authn/extractor.cc
@@ -60,7 +60,7 @@ struct JwtConstValueStruct {
   // The header value prefix for Authorization.
   const std::string BearerPrefix{"Bearer "};
 
-  // The default query parameter name to extract JWT token
+  // The default query parameter name to extract JWT
   const std::string AccessTokenParam{"access_token"};
 };
 using JwtConstValues = ConstSingleton<JwtConstValueStruct>;

--- a/source/extensions/filters/http/jwt_authn/extractor.h
+++ b/source/extensions/filters/http/jwt_authn/extractor.h
@@ -67,7 +67,7 @@ public:
   virtual ~Extractor() = default;
 
   /**
-   * Extract all JWT tokens from the headers. If set of header_keys or param_keys
+   * Extract all JWTs from the headers. If set of header_keys or param_keys
    * is not empty only those in the matching locations will be returned.
    *
    * @param headers is the HTTP request headers.

--- a/source/extensions/filters/http/jwt_authn/filter.cc
+++ b/source/extensions/filters/http/jwt_authn/filter.cc
@@ -89,7 +89,7 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers,
     onComplete(Status::Ok);
   } else {
     original_uri_ = Http::Utility::buildOriginalUri(headers, MaximumUriLength);
-    // Verify the JWT token, onComplete() will be called when completed.
+    // Verify the JWT, onComplete() will be called when completed.
     context_ = Verifier::createContext(headers, decoder_callbacks_->activeSpan(), this);
     verifier->verify(context_);
   }

--- a/source/extensions/filters/http/jwt_authn/jwt_cache.h
+++ b/source/extensions/filters/http/jwt_authn/jwt_cache.h
@@ -26,11 +26,11 @@ class JwtCache {
 public:
   virtual ~JwtCache() = default;
 
-  // Lookup a JWT token in the cache, if found return the pointer to its parsed jwt struct.
+  // Lookup a JWT in the cache, if found return the pointer to its parsed jwt struct.
   // If no found, return nullptr.
   virtual ::google::jwt_verify::Jwt* lookup(const std::string& token) PURE;
 
-  // Insert a JWT token and its parsed JWT struct to the cache.
+  // Insert a JWT and its parsed JWT struct to the cache.
   // The function will take over the ownership of jwt object.
   virtual void insert(const std::string& token,
                       std::unique_ptr<::google::jwt_verify::Jwt>&& jwt) PURE;

--- a/source/extensions/filters/http/jwt_authn/verifier.cc
+++ b/source/extensions/filters/http/jwt_authn/verifier.cc
@@ -295,7 +295,7 @@ public:
     if (++completion_state.number_completed_children_ == verifiers_.size()) {
       // Aggregate all children status into a final status.
       // JwtMissed and JwtUnknownIssuer should be treated differently than other errors.
-      // JwtMissed means not Jwt token for the required provider.
+      // JwtMissed means not JWT for the required provider.
       // JwtUnknownIssuer means wrong issuer for the required provider.
       Status final_status = Status::JwtMissed;
       for (const auto& it : verifiers_) {

--- a/test/extensions/filters/http/jwt_authn/filter_integration_test.cc
+++ b/test/extensions/filters/http/jwt_authn/filter_integration_test.cc
@@ -76,7 +76,7 @@ INSTANTIATE_TEST_SUITE_P(
     testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParamsWithoutHTTP3()),
     HttpProtocolIntegrationTest::protocolTestParamsToString);
 
-// With local Jwks, this test verifies a request is passed with a good Jwt token.
+// With local Jwks, this test verifies a request is passed with a good JWT.
 TEST_P(LocalJwksIntegrationTest, WithGoodToken) {
   config_helper_.prependFilter(getFilterConfig(true, false));
   initialize();
@@ -104,7 +104,7 @@ TEST_P(LocalJwksIntegrationTest, WithGoodToken) {
   EXPECT_EQ("200", response->headers().getStatusValue());
 }
 
-// With local Jwks, this test verifies a request is rejected with an expired Jwt token.
+// With local Jwks, this test verifies a request is rejected with an expired JWT.
 TEST_P(LocalJwksIntegrationTest, ExpiredToken) {
   config_helper_.prependFilter(getFilterConfig(true, false));
   initialize();
@@ -174,7 +174,7 @@ TEST_P(LocalJwksIntegrationTest, ExpiredTokenHeadReply) {
   EXPECT_THAT(response->body(), ::testing::IsEmpty());
 }
 
-// With local Jwks, this test verifies a request is rejected with an expired Jwt token
+// With local Jwks, this test verifies a request is rejected with an expired JWT
 // with only a 401 status without WWWAuthenticate/Body set with error details
 TEST_P(LocalJwksIntegrationTest, ExpiredTokenWithStripFailureResponse) {
   config_helper_.prependFilter(getFilterConfig(true, true));
@@ -232,7 +232,7 @@ TEST_P(LocalJwksIntegrationTest, NoRequiresPath) {
   EXPECT_EQ("200", response->headers().getStatusValue());
 }
 
-// This test verifies a CORS preflight request without JWT token is allowed.
+// This test verifies a CORS preflight request without JWT is allowed.
 TEST_P(LocalJwksIntegrationTest, CorsPreflight) {
   config_helper_.prependFilter(getFilterConfig(true, false));
   initialize();
@@ -464,7 +464,7 @@ INSTANTIATE_TEST_SUITE_P(
     testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParamsWithoutHTTP3()),
     HttpProtocolIntegrationTest::protocolTestParamsToString);
 
-// With remote Jwks, this test verifies a request is passed with a good Jwt token
+// With remote Jwks, this test verifies a request is passed with a good JWT
 // and a good public key fetched from a remote server.
 TEST_P(RemoteJwksIntegrationTest, WithGoodToken) {
   initializeFilter(/*add_cluster=*/true);
@@ -522,7 +522,7 @@ TEST_P(RemoteJwksIntegrationTest, WithGoodTokenClearRouteCache) {
   cleanup();
 }
 
-// With remote Jwks, this test verifies a request is rejected even with a good Jwt token
+// With remote Jwks, this test verifies a request is rejected even with a good JWT
 // when the remote jwks server replied with 500.
 TEST_P(RemoteJwksIntegrationTest, FetchFailedJwks) {
   initializeFilter(/*add_cluster=*/true);
@@ -722,7 +722,7 @@ TEST_P(PerRouteIntegrationTest, PerRouteConfigDisabled) {
 
   codec_client_ = makeHttpConnection(lookupPort("http"));
 
-  // So the request without a JWT token is OK.
+  // So the request without a JWT is OK.
   auto response = codec_client_->makeHeaderOnlyRequest(Http::TestRequestHeaderMapImpl{
       {":method", "GET"},
       {":path", "/"},
@@ -759,7 +759,7 @@ TEST_P(PerRouteIntegrationTest, PerRouteConfigWrongRequireName) {
 
   codec_client_ = makeHttpConnection(lookupPort("http"));
 
-  // So the request with a good Jwt token is rejected.
+  // So the request with a good JWT is rejected.
   auto response = codec_client_->makeHeaderOnlyRequest(Http::TestRequestHeaderMapImpl{
       {":method", "GET"},
       {":path", "/"},
@@ -794,7 +794,7 @@ TEST_P(PerRouteIntegrationTest, PerRouteConfigOK) {
 
   codec_client_ = makeHttpConnection(lookupPort("http"));
 
-  // So the request with a JWT token is OK.
+  // So the request with a JWT is OK.
   auto response = codec_client_->makeHeaderOnlyRequest(Http::TestRequestHeaderMapImpl{
       {":method", "GET"},
       {":path", "/"},

--- a/test/extensions/filters/http/jwt_authn/jwt_authn_fuzz_test.cc
+++ b/test/extensions/filters/http/jwt_authn/jwt_authn_fuzz_test.cc
@@ -82,7 +82,7 @@ DEFINE_PROTO_FUZZER(const JwtAuthnFuzzInput& input) {
   NiceMock<Http::MockStreamDecoderFilterCallbacks> filter_callbacks;
 
   // Test the expired token.
-  // The jwt token in the corpus files expired at 2001001001 (at year 2033).
+  // The JWT in the corpus files expired at 2001001001 (at year 2033).
   if (input.force_jwt_expired()) {
     // 20 years == 615168000 seconds.
     mock_factory_ctx.server_factory_context_.time_system_.advanceTimeWait(

--- a/test/extensions/filters/http/jwt_authn/provider_verifier_test.cc
+++ b/test/extensions/filters/http/jwt_authn/provider_verifier_test.cc
@@ -271,7 +271,7 @@ INSTANTIATE_TEST_SUITE_P(ProviderVerifiersJwtCache, ProviderVerifiersJwtCacheTes
 // This test verifies that two JWT requirements with different audiences behave the same with
 // jwt_cache and without. The first requirement is checking audiences specified in the provider
 // which is "example_service". The second requirement is type "provider_and_audiences" and its
-// specified audiences is "other_service". The audience in the JWT token is "example_service". The
+// specified audiences is "other_service". The audience in the JWT is "example_service". The
 // first requirement should work and the second one should fail.
 TEST_P(ProviderVerifiersJwtCacheTest, TestRequirementsWithAudiences) {
   TestUtility::loadFromYaml(ExampleConfig, proto_config_);


### PR DESCRIPTION
JWT stands for *JSON Web Token*. Code comments and documentation both contain many "JWT token" which is double.

This pull request replaces those pieces of text with JWT (or sometimes plural).

This pull request should have no code changes.


---

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
