### PR TITLE
Fix bug in UDP CMSG plumbing

### DIFF
--- a/envoy/network/BUILD
+++ b/envoy/network/BUILD
@@ -148,6 +148,7 @@ envoy_cc_library(
         "//envoy/api:os_sys_calls_interface",
         "//envoy/buffer:buffer_interface",
         "//envoy/event:file_event_interface",
+        "//source/common/buffer:buffer_lib",
         "//source/common/common:assert_lib",
         "@com_google_absl//absl/types:optional",
     ],

--- a/envoy/network/io_handle.h
+++ b/envoy/network/io_handle.h
@@ -11,6 +11,8 @@
 #include "envoy/event/file_event.h"
 #include "envoy/network/address.h"
 
+#include "source/common/buffer/buffer_impl.h"
+
 #include "absl/container/fixed_array.h"
 #include "absl/types/optional.h"
 
@@ -142,7 +144,7 @@ public:
     // The contents of the TOS byte in the IP header.
     uint8_t tos_{0};
     // UDP control message specified by save_cmsg_config in QUIC config.
-    Buffer::RawSlice saved_cmsg_;
+    Buffer::OwnedImpl saved_cmsg_;
   };
 
   /**

--- a/envoy/network/listener.h
+++ b/envoy/network/listener.h
@@ -359,7 +359,7 @@ struct UdpRecvData {
   Buffer::InstancePtr buffer_;
   MonotonicTime receive_time_;
   uint8_t tos_ = 0;
-  Buffer::RawSlice saved_cmsg_;
+  Buffer::OwnedImpl saved_cmsg_;
 };
 
 /**

--- a/source/common/network/io_socket_handle_impl.cc
+++ b/source/common/network/io_socket_handle_impl.cc
@@ -5,6 +5,7 @@
 #include "envoy/buffer/buffer.h"
 
 #include "source/common/api/os_sys_calls_impl.h"
+#include "source/common/buffer/buffer_impl.h"
 #include "source/common/common/safe_memcpy.h"
 #include "source/common/common/utility.h"
 #include "source/common/event/file_event_impl.h"
@@ -386,8 +387,8 @@ Api::IoCallUint64Result IoSocketHandleImpl::recvmsg(Buffer::RawSlice* slices,
       if (save_cmsg_config.hasConfig() &&
           cmsg->cmsg_type == static_cast<int>(save_cmsg_config.type.value()) &&
           cmsg->cmsg_level == static_cast<int>(save_cmsg_config.level.value())) {
-        Buffer::RawSlice cmsg_slice{CMSG_DATA(cmsg), cmsg->cmsg_len};
-        output.msg_[0].saved_cmsg_ = cmsg_slice;
+        Buffer::OwnedImpl cmsg_slice{CMSG_DATA(cmsg), cmsg->cmsg_len};
+        output.msg_[0].saved_cmsg_ = std::move(cmsg_slice);
       }
       if (output.msg_[0].local_address_ == nullptr) {
         Address::InstanceConstSharedPtr addr = maybeGetDstAddressFromHeader(*cmsg, self_port);
@@ -496,8 +497,8 @@ Api::IoCallUint64Result IoSocketHandleImpl::recvmmsg(RawSliceArrays& slices, uin
         if (save_cmsg_config.hasConfig() &&
             cmsg->cmsg_type == static_cast<int>(save_cmsg_config.type.value()) &&
             cmsg->cmsg_level == static_cast<int>(save_cmsg_config.level.value())) {
-          Buffer::RawSlice cmsg_slice{CMSG_DATA(cmsg), cmsg->cmsg_len};
-          output.msg_[0].saved_cmsg_ = cmsg_slice;
+          Buffer::OwnedImpl cmsg_slice{CMSG_DATA(cmsg), cmsg->cmsg_len};
+          output.msg_[0].saved_cmsg_ = std::move(cmsg_slice);
         }
         Address::InstanceConstSharedPtr addr = maybeGetDstAddressFromHeader(*cmsg, self_port);
         absl::optional<uint8_t> maybe_tos = maybeGetTosFromHeader(*cmsg);

--- a/source/common/network/udp_listener_impl.cc
+++ b/source/common/network/udp_listener_impl.cc
@@ -12,6 +12,7 @@
 #include "envoy/network/parent_drained_callback_registrar.h"
 
 #include "source/common/api/os_sys_calls_impl.h"
+#include "source/common/buffer/buffer_impl.h"
 #include "source/common/common/assert.h"
 #include "source/common/common/empty_string.h"
 #include "source/common/common/fmt.h"
@@ -124,7 +125,7 @@ void UdpListenerImpl::handleReadCallback() {
 void UdpListenerImpl::processPacket(Address::InstanceConstSharedPtr local_address,
                                     Address::InstanceConstSharedPtr peer_address,
                                     Buffer::InstancePtr buffer, MonotonicTime receive_time,
-                                    uint8_t tos, Buffer::RawSlice saved_cmsg) {
+                                    uint8_t tos, Buffer::OwnedImpl saved_cmsg) {
   // UDP listeners are always configured with the socket option that allows pulling the local
   // address. This should never be null.
   ASSERT(local_address != nullptr);
@@ -132,7 +133,7 @@ void UdpListenerImpl::processPacket(Address::InstanceConstSharedPtr local_addres
                        std::move(buffer),
                        receive_time,
                        tos,
-                       saved_cmsg};
+                       std::move(saved_cmsg)};
   cb_.onData(std::move(recvData));
 }
 

--- a/source/common/network/udp_listener_impl.h
+++ b/source/common/network/udp_listener_impl.h
@@ -46,7 +46,8 @@ public:
   // Network::UdpPacketProcessor
   void processPacket(Address::InstanceConstSharedPtr local_address,
                      Address::InstanceConstSharedPtr peer_address, Buffer::InstancePtr buffer,
-                     MonotonicTime receive_time, uint8_t tos, Buffer::RawSlice saved_cmsg) override;
+                     MonotonicTime receive_time, uint8_t tos,
+                     Buffer::OwnedImpl saved_cmsg) override;
   uint64_t maxDatagramSize() const override { return config_.max_rx_datagram_size_; }
   void onDatagramsDropped(uint32_t dropped) override { cb_.onDatagramsDropped(dropped); }
   size_t numPacketsExpectedPerEventLoop() const override {

--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -688,7 +688,7 @@ readFromSocketRecvMmsg(IoHandle& handle, const Address::Instance& local_address,
     }
     passPayloadToProcessor(msg_len, std::move(buffers[i].buffer_), output.msg_[i].peer_address_,
                            output.msg_[i].local_address_, udp_packet_processor, receive_time,
-                           output.msg_[i].tos_, output.msg_[i].saved_cmsg_);
+                           output.msg_[i].tos_, std::move(output.msg_[i].saved_cmsg_));
   }
   return result;
 }

--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -551,7 +551,7 @@ void passPayloadToProcessor(uint64_t bytes_read, Buffer::InstancePtr buffer,
                             Address::InstanceConstSharedPtr peer_addess,
                             Address::InstanceConstSharedPtr local_address,
                             UdpPacketProcessor& udp_packet_processor, MonotonicTime receive_time,
-                            uint8_t tos, Buffer::RawSlice saved_cmsg) {
+                            uint8_t tos, Buffer::OwnedImpl saved_cmsg) {
   ENVOY_BUG(peer_addess != nullptr,
             fmt::format("Unable to get remote address on the socket bound to local address: {}.",
                         (local_address == nullptr ? "unknown" : local_address->asString())));
@@ -564,7 +564,7 @@ void passPayloadToProcessor(uint64_t bytes_read, Buffer::InstancePtr buffer,
                         (local_address == nullptr ? "unknown" : local_address->asString()),
                         bytes_read));
   udp_packet_processor.processPacket(std::move(local_address), std::move(peer_addess),
-                                     std::move(buffer), receive_time, tos, saved_cmsg);
+                                     std::move(buffer), receive_time, tos, std::move(saved_cmsg));
 }
 
 Api::IoCallUint64Result readFromSocketRecvGro(IoHandle& handle,
@@ -603,10 +603,10 @@ Api::IoCallUint64Result readFromSocketRecvGro(IoHandle& handle,
     if (num_packets_read != nullptr) {
       *num_packets_read += 1;
     }
-    passPayloadToProcessor(result.return_value_, std::move(buffer),
-                           std::move(output.msg_[0].peer_address_),
-                           std::move(output.msg_[0].local_address_), udp_packet_processor,
-                           receive_time, output.msg_[0].tos_, output.msg_[0].saved_cmsg_);
+    passPayloadToProcessor(
+        result.return_value_, std::move(buffer), std::move(output.msg_[0].peer_address_),
+        std::move(output.msg_[0].local_address_), udp_packet_processor, receive_time,
+        output.msg_[0].tos_, std::move(output.msg_[0].saved_cmsg_));
     return result;
   }
 
@@ -622,7 +622,7 @@ Api::IoCallUint64Result readFromSocketRecvGro(IoHandle& handle,
     }
     passPayloadToProcessor(bytes_to_copy, std::move(sub_buffer), output.msg_[0].peer_address_,
                            output.msg_[0].local_address_, udp_packet_processor, receive_time,
-                           output.msg_[0].tos_, output.msg_[0].saved_cmsg_);
+                           output.msg_[0].tos_, std::move(output.msg_[0].saved_cmsg_));
   }
 
   return result;
@@ -721,7 +721,7 @@ Api::IoCallUint64Result readFromSocketRecvMsg(IoHandle& handle,
   passPayloadToProcessor(result.return_value_, std::move(buffer),
                          std::move(output.msg_[0].peer_address_),
                          std::move(output.msg_[0].local_address_), udp_packet_processor,
-                         receive_time, output.msg_[0].tos_, output.msg_[0].saved_cmsg_);
+                         receive_time, output.msg_[0].tos_, std::move(output.msg_[0].saved_cmsg_));
   return result;
 }
 

--- a/source/common/network/utility.h
+++ b/source/common/network/utility.h
@@ -35,7 +35,7 @@ public:
   virtual void processPacket(Address::InstanceConstSharedPtr local_address,
                              Address::InstanceConstSharedPtr peer_address,
                              Buffer::InstancePtr buffer, MonotonicTime receive_time, uint8_t tos,
-                             Buffer::RawSlice saved_cmsg) PURE;
+                             Buffer::OwnedImpl saved_cmsg) PURE;
 
   /**
    * Called whenever datagrams are dropped due to overflow or truncation.

--- a/source/common/quic/active_quic_listener.cc
+++ b/source/common/quic/active_quic_listener.cc
@@ -155,11 +155,12 @@ void ActiveQuicListener::onDataWorker(Network::UdpRecvData&& data) {
   Buffer::RawSlice slice = data.buffer_->frontSlice();
   ASSERT(data.buffer_->length() == slice.len_);
   // TODO(danzh): pass in TTL and UDP header.
-  quic::QuicReceivedPacket packet(
-      reinterpret_cast<char*>(slice.mem_), slice.len_, timestamp,
-      /*owns_buffer=*/false, /*ttl=*/0, /*ttl_valid=*/false,
-      reinterpret_cast<char*>(data.saved_cmsg_.mem_), data.saved_cmsg_.len_,
-      /*owns_header_buffer*/ false, getQuicEcnCodepointFromTosByte(data.tos_));
+  quic::QuicReceivedPacket packet(reinterpret_cast<char*>(slice.mem_), slice.len_, timestamp,
+                                  /*owns_buffer=*/false, /*ttl=*/0, /*ttl_valid=*/false,
+                                  reinterpret_cast<char*>(data.saved_cmsg_.frontSlice().mem_),
+                                  data.saved_cmsg_.frontSlice().len_,
+                                  /*owns_header_buffer*/ false,
+                                  getQuicEcnCodepointFromTosByte(data.tos_));
   if (!quic_dispatcher_->processPacket(self_address, peer_address, packet)) {
     if (non_dispatched_udp_packet_handler_.has_value()) {
       non_dispatched_udp_packet_handler_->handle(worker_index_, std::move(data));

--- a/source/common/quic/envoy_quic_client_connection.cc
+++ b/source/common/quic/envoy_quic_client_connection.cc
@@ -67,7 +67,7 @@ EnvoyQuicClientConnection::EnvoyQuicClientConnection(
 void EnvoyQuicClientConnection::processPacket(
     Network::Address::InstanceConstSharedPtr local_address,
     Network::Address::InstanceConstSharedPtr peer_address, Buffer::InstancePtr buffer,
-    MonotonicTime receive_time, uint8_t tos, Buffer::RawSlice /*saved_cmsg*/) {
+    MonotonicTime receive_time, uint8_t tos, Buffer::OwnedImpl /*saved_cmsg*/) {
   quic::QuicTime timestamp =
       quic::QuicTime::Zero() +
       quic::QuicTime::Delta::FromMicroseconds(

--- a/source/common/quic/envoy_quic_client_connection.h
+++ b/source/common/quic/envoy_quic_client_connection.h
@@ -75,7 +75,7 @@ public:
   void processPacket(Network::Address::InstanceConstSharedPtr local_address,
                      Network::Address::InstanceConstSharedPtr peer_address,
                      Buffer::InstancePtr buffer, MonotonicTime receive_time, uint8_t tos,
-                     Buffer::RawSlice saved_cmsg) override;
+                     Buffer::OwnedImpl saved_cmsg) override;
   uint64_t maxDatagramSize() const override;
   void onDatagramsDropped(uint32_t) override {
     // TODO(mattklein123): Emit a stat for this.

--- a/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.cc
+++ b/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.cc
@@ -683,7 +683,7 @@ void UdpProxyFilter::ActiveSession::onInjectWriteDatagramToFilterChain(ActiveWri
 void UdpProxyFilter::UdpActiveSession::processPacket(
     Network::Address::InstanceConstSharedPtr local_address,
     Network::Address::InstanceConstSharedPtr peer_address, Buffer::InstancePtr buffer,
-    MonotonicTime receive_time, uint8_t tos, Buffer::RawSlice saved_cmsg) {
+    MonotonicTime receive_time, uint8_t tos, Buffer::OwnedImpl saved_cmsg) {
   ASSERT(cluster_);
   const uint64_t rx_buffer_length = buffer->length();
   ENVOY_LOG(trace, "received {} byte datagram from upstream: downstream={} local={} upstream={}",
@@ -697,7 +697,7 @@ void UdpProxyFilter::UdpActiveSession::processPacket(
                                  std::move(buffer),
                                  receive_time,
                                  tos,
-                                 saved_cmsg};
+                                 std::move(saved_cmsg)};
   processUpstreamDatagram(recv_data);
 }
 

--- a/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.h
+++ b/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.h
@@ -691,7 +691,7 @@ protected:
     void processPacket(Network::Address::InstanceConstSharedPtr local_address,
                        Network::Address::InstanceConstSharedPtr peer_address,
                        Buffer::InstancePtr buffer, MonotonicTime receive_time, uint8_t tos,
-                       Buffer::RawSlice saved_csmg) override;
+                       Buffer::OwnedImpl saved_csmg) override;
 
     uint64_t maxDatagramSize() const override {
       return filter_.config_->upstreamSocketConfig().max_rx_datagram_size_;

--- a/source/extensions/upstreams/http/udp/upstream_request.cc
+++ b/source/extensions/upstreams/http/udp/upstream_request.cc
@@ -130,7 +130,7 @@ void UdpUpstream::onSocketReadReady() {
 void UdpUpstream::processPacket(Network::Address::InstanceConstSharedPtr /*local_address*/,
                                 Network::Address::InstanceConstSharedPtr /*peer_address*/,
                                 Buffer::InstancePtr buffer, MonotonicTime /*receive_time*/,
-                                uint8_t /*tos*/, Buffer::RawSlice /*saved_cmsg*/) {
+                                uint8_t /*tos*/, Buffer::OwnedImpl /*saved_cmsg*/) {
   std::string data = buffer->toString();
   quiche::ConnectUdpDatagramUdpPacketPayload payload(data);
   quiche::QuicheBuffer serialized_capsule =

--- a/source/extensions/upstreams/http/udp/upstream_request.h
+++ b/source/extensions/upstreams/http/udp/upstream_request.h
@@ -81,7 +81,7 @@ public:
   void processPacket(Network::Address::InstanceConstSharedPtr local_address,
                      Network::Address::InstanceConstSharedPtr peer_address,
                      Buffer::InstancePtr buffer, MonotonicTime receive_time, uint8_t tos,
-                     Buffer::RawSlice saved_cmsg) override;
+                     Buffer::OwnedImpl saved_cmsg) override;
   uint64_t maxDatagramSize() const override { return Network::DEFAULT_UDP_MAX_DATAGRAM_SIZE; }
   void onDatagramsDropped(uint32_t dropped) override {
     // TODO(https://github.com/envoyproxy/envoy/issues/23564): Add statistics for CONNECT-UDP

--- a/test/common/quic/envoy_quic_client_session_test.cc
+++ b/test/common/quic/envoy_quic_client_session_test.cc
@@ -70,11 +70,11 @@ public:
   void processPacket(Network::Address::InstanceConstSharedPtr local_address,
                      Network::Address::InstanceConstSharedPtr peer_address,
                      Buffer::InstancePtr buffer, MonotonicTime receive_time, uint8_t tos,
-                     Buffer::RawSlice saved_cmsg) override {
+                     Buffer::OwnedImpl saved_cmsg) override {
     last_local_address_ = local_address;
     last_peer_address_ = peer_address;
     EnvoyQuicClientConnection::processPacket(local_address, peer_address, std::move(buffer),
-                                             receive_time, tos, saved_cmsg);
+                                             receive_time, tos, std::move(saved_cmsg));
     ++num_packets_received_;
   }
 

--- a/test/integration/filters/test_listener_filter.h
+++ b/test/integration/filters/test_listener_filter.h
@@ -154,6 +154,8 @@ public:
     test_first_packet_received_filter_state_->incrementPacketCount();
     test_first_packet_received_filter_state_->setPacketLength(packet.length());
     test_first_packet_received_filter_state_->setPacketHeadersLength(packet.headers_length());
+    char* headers_buffer = new char[packet.headers_length()];
+    memcpy(headers_buffer, packet.packet_headers(), packet.headers_length());
     return Network::FilterStatus::Continue;
   }
 

--- a/test/integration/filters/test_listener_filter.h
+++ b/test/integration/filters/test_listener_filter.h
@@ -154,8 +154,10 @@ public:
     test_first_packet_received_filter_state_->incrementPacketCount();
     test_first_packet_received_filter_state_->setPacketLength(packet.length());
     test_first_packet_received_filter_state_->setPacketHeadersLength(packet.headers_length());
-    char* headers_buffer = new char[packet.headers_length()];
-    memcpy(headers_buffer, packet.packet_headers(), packet.headers_length());
+    if (packet.headers_length() > 0 && packet.packet_headers() != nullptr) {
+      char* headers_buffer = new char[packet.headers_length()];
+      memcpy(headers_buffer, packet.packet_headers(), packet.headers_length());
+    }
     return Network::FilterStatus::Continue;
   }
 

--- a/test/integration/quic_http_integration_test.cc
+++ b/test/integration/quic_http_integration_test.cc
@@ -169,11 +169,11 @@ public:
   void processPacket(Network::Address::InstanceConstSharedPtr local_address,
                      Network::Address::InstanceConstSharedPtr peer_address,
                      Buffer::InstancePtr buffer, MonotonicTime receive_time, uint8_t tos,
-                     Buffer::RawSlice saved_cmsg) override {
+                     Buffer::OwnedImpl saved_cmsg) override {
     last_local_address_ = local_address;
     last_peer_address_ = peer_address;
     EnvoyQuicClientConnection::processPacket(local_address, peer_address, std::move(buffer),
-                                             receive_time, tos, saved_cmsg);
+                                             receive_time, tos, std::move(saved_cmsg));
   }
 
   Network::Address::InstanceConstSharedPtr getLastLocalAddress() const {

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -720,7 +720,7 @@ public:
   MOCK_METHOD(void, processPacket,
               (Address::InstanceConstSharedPtr local_address,
                Address::InstanceConstSharedPtr peer_address, Buffer::InstancePtr buffer,
-               MonotonicTime receive_time, uint8_t tos, Buffer::RawSlice saved_cmsg));
+               MonotonicTime receive_time, uint8_t tos, Buffer::OwnedImpl saved_cmsg));
   MOCK_METHOD(void, onDatagramsDropped, (uint32_t dropped));
   MOCK_METHOD(uint64_t, maxDatagramSize, (), (const));
   MOCK_METHOD(size_t, numPacketsExpectedPerEventLoop, (), (const));

--- a/test/test_common/network_utility.cc
+++ b/test/test_common/network_utility.cc
@@ -207,12 +207,12 @@ struct SyncPacketProcessor : public Network::UdpPacketProcessor {
   void processPacket(Network::Address::InstanceConstSharedPtr local_address,
                      Network::Address::InstanceConstSharedPtr peer_address,
                      Buffer::InstancePtr buffer, MonotonicTime receive_time, uint8_t tos,
-                     Buffer::RawSlice saved_cmsg) override {
+                     Buffer::OwnedImpl saved_cmsg) override {
     Network::UdpRecvData datagram{{std::move(local_address), std::move(peer_address)},
                                   std::move(buffer),
                                   receive_time,
                                   tos,
-                                  saved_cmsg};
+                                  std::move(saved_cmsg)};
     data_.push_back(std::move(datagram));
   }
   uint64_t maxDatagramSize() const override { return max_rx_datagram_size_; }


### PR DESCRIPTION
Commit Message: Fix bug in UDP CMSG plumbing
Additional Description: Follow-up to #35382.

The original RawSlice that we wrote the csmg to points to stack memory that is immediately freed, so we use a different structure that properly moves the memory buffer up to the QuicReceivedPacket. The bug is reproduced in quic_http_integration_test with the change to TestQuicListenerFilter (i.e., if you remove the other changes in this PR) under ASAN builds.

Risk Level: Low
Testing: Reproduced in integration test (quic_http_integration_test)
Docs Changes: N/A
Release Notes: None.
