### PR TITLE
docs: adds a release note about dynamic_modules

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -135,5 +135,9 @@ new_features:
 - area: attributes
   change: |
     Added :ref:`attribute <arch_overview_attributes>` ``upstream.locality`` to obtain upstream locality information.
+- area: dynamic_modules
+  change: |
+    Added the initial support for shared libraries to be loaded by Envoy at runtime. Please refer to the overview documentation for the
+    feature :ref:`here <arch_overview_dynamic_modules>`.
 
 deprecated:


### PR DESCRIPTION
Commit Message: docs: adds a release note about dynamic_modules
Additional Description:

This is a follow up on #38295 

Risk Level: n/a
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
