### PR TITLE
Add tests for ext_proc stream resets

### DIFF
--- a/source/common/http/codec_client.cc
+++ b/source/common/http/codec_client.cc
@@ -156,7 +156,7 @@ void CodecClient::completeRequest(ActiveRequest& request) {
 }
 
 void CodecClient::onReset(ActiveRequest& request, StreamResetReason reason) {
-  ENVOY_CONN_LOG(debug, "request reset", *connection_);
+  ENVOY_CONN_LOG(debug, "Request reset. Reason {}", *connection_, static_cast<int>(reason));
   if (codec_client_callbacks_) {
     codec_client_callbacks_->onStreamReset(reason);
   }

--- a/test/common/grpc/grpc_client_integration_test_harness.h
+++ b/test/common/grpc/grpc_client_integration_test_harness.h
@@ -234,7 +234,16 @@ public:
 
   void closeStream() {
     grpc_stream_->closeStream();
+    waitForEndStream();
+  }
+
+  void waitForEndStream() {
     AssertionResult result = fake_stream_->waitForEndStream(dispatcher_helper_.dispatcher_);
+    RELEASE_ASSERT(result, result.message());
+  }
+
+  void waitForReset() {
+    AssertionResult result = fake_stream_->waitForReset(dispatcher_helper_.dispatcher_);
     RELEASE_ASSERT(result, result.message());
   }
 

--- a/test/integration/fake_upstream.cc
+++ b/test/integration/fake_upstream.cc
@@ -324,6 +324,17 @@ AssertionResult FakeStream::waitForReset(milliseconds timeout) {
   return AssertionSuccess();
 }
 
+AssertionResult FakeStream::waitForReset(Event::Dispatcher& client_dispatcher,
+                                         std::chrono::milliseconds timeout) {
+  absl::MutexLock lock(&lock_);
+  if (!waitForWithDispatcherRun(
+          time_system_, lock_, [this]() ABSL_EXCLUSIVE_LOCKS_REQUIRED(lock_) { return saw_reset_; },
+          client_dispatcher, timeout)) {
+    return AssertionFailure() << "Timed out waiting for reset of stream.";
+  }
+  return AssertionSuccess();
+}
+
 void FakeStream::startGrpcStream(bool send_headers) {
   ASSERT(!grpc_stream_started_, "gRPC stream should not be started more than once");
   grpc_stream_started_ = true;

--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -165,6 +165,11 @@ public:
   testing::AssertionResult
   waitForReset(std::chrono::milliseconds timeout = TestUtility::DefaultTimeout);
 
+  ABSL_MUST_USE_RESULT
+  testing::AssertionResult
+  waitForReset(Event::Dispatcher& client_dispatcher,
+               std::chrono::milliseconds timeout = TestUtility::DefaultTimeout);
+
   // gRPC convenience methods.
   void startGrpcStream(bool send_headers = true);
   void finishGrpcStream(Grpc::Status::GrpcStatus status);


### PR DESCRIPTION
Commit Message:
These tests document current broken behavior of ext_proc always resetting gRPC side streams. 

Risk Level: Low
Testing: Unit Tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
