### PR TITLE
dynamic_modules: add mut to &FilterConfig on filter creation

### DIFF
--- a/source/extensions/dynamic_modules/sdk/rust/src/lib_test.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/lib_test.rs
@@ -82,7 +82,7 @@ fn test_envoy_dynamic_module_on_http_filter_new_destroy() {
   impl<EC: EnvoyHttpFilterConfig, EHF: EnvoyHttpFilter> HttpFilterConfig<EC, EHF>
     for TestHttpFilterConfig
   {
-    fn new_http_filter(&self, _envoy: &mut EC) -> Box<dyn HttpFilter<EHF>> {
+    fn new_http_filter(&mut self, _envoy: &mut EC) -> Box<dyn HttpFilter<EHF>> {
       Box::new(TestHttpFilter)
     }
   }
@@ -95,12 +95,12 @@ fn test_envoy_dynamic_module_on_http_filter_new_destroy() {
     }
   }
 
-  let filter_config = TestHttpFilterConfig;
+  let mut filter_config = TestHttpFilterConfig;
   let result = envoy_dynamic_module_on_http_filter_new_impl(
     &mut EnvoyHttpFilterConfigImpl {
       raw_ptr: std::ptr::null_mut(),
     },
-    &filter_config,
+    &mut filter_config,
   );
   assert!(!result.is_null());
 
@@ -118,7 +118,7 @@ fn test_envoy_dynamic_module_on_http_filter_callbacks() {
   impl<EC: EnvoyHttpFilterConfig, EHF: EnvoyHttpFilter> HttpFilterConfig<EC, EHF>
     for TestHttpFilterConfig
   {
-    fn new_http_filter(&self, _envoy: &mut EC) -> Box<dyn HttpFilter<EHF>> {
+    fn new_http_filter(&mut self, _envoy: &mut EC) -> Box<dyn HttpFilter<EHF>> {
       Box::new(TestHttpFilter)
     }
   }
@@ -185,12 +185,12 @@ fn test_envoy_dynamic_module_on_http_filter_callbacks() {
     }
   }
 
-  let filter_config = TestHttpFilterConfig;
+  let mut filter_config = TestHttpFilterConfig;
   let filter = envoy_dynamic_module_on_http_filter_new_impl(
     &mut EnvoyHttpFilterConfigImpl {
       raw_ptr: std::ptr::null_mut(),
     },
-    &filter_config,
+    &mut filter_config,
   );
 
   unsafe {

--- a/test/extensions/dynamic_modules/test_data/rust/http.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/http.rs
@@ -35,7 +35,7 @@ struct HeaderCallbacksFilterConfig {}
 impl<EC: EnvoyHttpFilterConfig, EHF: EnvoyHttpFilter> HttpFilterConfig<EC, EHF>
   for HeaderCallbacksFilterConfig
 {
-  fn new_http_filter(&self, _envoy: &mut EC) -> Box<dyn HttpFilter<EHF>> {
+  fn new_http_filter(&mut self, _envoy: &mut EC) -> Box<dyn HttpFilter<EHF>> {
     Box::new(HeaderCallbacksFilter {})
   }
 }
@@ -239,7 +239,7 @@ struct SendResponseFilterConfig {}
 impl<EC: EnvoyHttpFilterConfig, EHF: EnvoyHttpFilter> HttpFilterConfig<EC, EHF>
   for SendResponseFilterConfig
 {
-  fn new_http_filter(&self, _envoy: &mut EC) -> Box<dyn HttpFilter<EHF>> {
+  fn new_http_filter(&mut self, _envoy: &mut EC) -> Box<dyn HttpFilter<EHF>> {
     Box::new(SendResponseFilter {})
   }
 }
@@ -274,7 +274,7 @@ struct DynamicMetadataCallbacksFilterConfig {}
 impl<EC: EnvoyHttpFilterConfig, EHF: EnvoyHttpFilter> HttpFilterConfig<EC, EHF>
   for DynamicMetadataCallbacksFilterConfig
 {
-  fn new_http_filter(&self, _envoy: &mut EC) -> Box<dyn HttpFilter<EHF>> {
+  fn new_http_filter(&mut self, _envoy: &mut EC) -> Box<dyn HttpFilter<EHF>> {
     Box::new(DynamicMetadataCallbacksFilter {})
   }
 }
@@ -365,7 +365,7 @@ struct BodyCallbacksFilterConfig {}
 impl<EC: EnvoyHttpFilterConfig, EHF: EnvoyHttpFilter> HttpFilterConfig<EC, EHF>
   for BodyCallbacksFilterConfig
 {
-  fn new_http_filter(&self, _envoy: &mut EC) -> Box<dyn HttpFilter<EHF>> {
+  fn new_http_filter(&mut self, _envoy: &mut EC) -> Box<dyn HttpFilter<EHF>> {
     Box::new(BodyCallbacksFilter::default())
   }
 }

--- a/test/extensions/dynamic_modules/test_data/rust/http_integration_test.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/http_integration_test.rs
@@ -32,7 +32,7 @@ struct PassthroughHttpFilterConfig {}
 impl<EC: EnvoyHttpFilterConfig, EHF: EnvoyHttpFilter> HttpFilterConfig<EC, EHF>
   for PassthroughHttpFilterConfig
 {
-  fn new_http_filter(&self, _envoy: &mut EC) -> Box<dyn HttpFilter<EHF>> {
+  fn new_http_filter(&mut self, _envoy: &mut EC) -> Box<dyn HttpFilter<EHF>> {
     Box::new(PassthroughHttpFilter {})
   }
 }
@@ -48,7 +48,7 @@ struct HeadersHttpFilterConfig {
 impl<EC: EnvoyHttpFilterConfig, EHF: EnvoyHttpFilter> HttpFilterConfig<EC, EHF>
   for HeadersHttpFilterConfig
 {
-  fn new_http_filter(&self, _envoy: &mut EC) -> Box<dyn HttpFilter<EHF>> {
+  fn new_http_filter(&mut self, _envoy: &mut EC) -> Box<dyn HttpFilter<EHF>> {
     let headers_to_add: Vec<(String, String)> = self
       .headers_to_add
       .split(',')
@@ -165,7 +165,7 @@ struct BodyCallbacksFilterConfig {
 impl<EC: EnvoyHttpFilterConfig, EHF: EnvoyHttpFilter> HttpFilterConfig<EC, EHF>
   for BodyCallbacksFilterConfig
 {
-  fn new_http_filter(&self, _envoy: &mut EC) -> Box<dyn HttpFilter<EHF>> {
+  fn new_http_filter(&mut self, _envoy: &mut EC) -> Box<dyn HttpFilter<EHF>> {
     Box::new(BodyCallbacksFilter {
       immediate_end_of_stream: self.immediate_end_of_stream,
       seen_request_body: false,
@@ -258,7 +258,7 @@ struct SendResponseHttpFilterConfig {
 impl<EC: EnvoyHttpFilterConfig, EHF: EnvoyHttpFilter> HttpFilterConfig<EC, EHF>
   for SendResponseHttpFilterConfig
 {
-  fn new_http_filter(&self, _envoy: &mut EC) -> Box<dyn HttpFilter<EHF>> {
+  fn new_http_filter(&mut self, _envoy: &mut EC) -> Box<dyn HttpFilter<EHF>> {
     Box::new(SendResponseHttpFilter {
       on_request_headers: self.on_request_headers,
     })

--- a/test/extensions/dynamic_modules/test_data/rust/no_op.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/no_op.rs
@@ -38,7 +38,7 @@ struct NopHttpFilterConfig {
 impl<EC: EnvoyHttpFilterConfig, EHF: EnvoyHttpFilter> HttpFilterConfig<EC, EHF>
   for NopHttpFilterConfig
 {
-  fn new_http_filter(&self, _envoy: &mut EC) -> Box<dyn HttpFilter<EHF>> {
+  fn new_http_filter(&mut self, _envoy: &mut EC) -> Box<dyn HttpFilter<EHF>> {
     Box::new(NopHttpFilter {
       on_request_headers_called: false,
       on_request_body_called: false,


### PR DESCRIPTION
Commit Message: dynamic_modules: add mut to &FilterConfig on filter creation
Additional Description:

This adds `mut` keywrod to &HttpFilterConfig on new_http_filter method. Without this, for example, we cannot share a cache across multiple http filters on a central place.

Risk Level: low
Testing: existing ones
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a

