### PR TITLE
minor-perf: move tls oscp string

### DIFF
--- a/source/common/tls/ocsp/ocsp.cc
+++ b/source/common/tls/ocsp/ocsp.cc
@@ -184,7 +184,7 @@ absl::StatusOr<std::unique_ptr<OcspResponse>> Asn1OcspUtility::parseOcspResponse
   RETURN_IF_NOT_OK_REF(status_or_error.status());
   auto opt = Asn1Utility::getOptional(elem, CBS_ASN1_CONSTRUCTED | CBS_ASN1_CONTEXT_SPECIFIC | 0);
   RETURN_IF_NOT_OK_REF(opt.status());
-  auto maybe_bytes = opt.value();
+  auto maybe_bytes = std::move(opt.value());
   ResponsePtr resp = nullptr;
   if (maybe_bytes) {
     auto resp_or_error = Asn1OcspUtility::parseResponseBytes(maybe_bytes.value());
@@ -244,7 +244,7 @@ absl::StatusOr<ResponsePtr> Asn1OcspUtility::parseResponseBytes(CBS& cbs) {
 
   auto parse_or_error = Asn1Utility::parseOid(elem);
   RETURN_IF_NOT_OK_REF(parse_or_error.status());
-  auto oid_str = parse_or_error.value();
+  auto oid_str = std::move(parse_or_error.value());
   if (!CBS_get_asn1(&elem, &response, CBS_ASN1_OCTETSTRING)) {
     return absl::InvalidArgumentError("Expected ASN.1 OCTETSTRING for response");
   }
@@ -296,11 +296,11 @@ absl::StatusOr<ResponseData> Asn1OcspUtility::parseResponseData(CBS& cbs) {
   auto version_or_error =
       Asn1Utility::getOptional(elem, CBS_ASN1_CONTEXT_SPECIFIC | CBS_ASN1_CONSTRUCTED | 0);
   RETURN_IF_NOT_OK_REF(version_or_error.status());
-  auto version_cbs = version_or_error.value();
+  auto version_cbs = std::move(version_or_error.value());
   if (version_cbs.has_value()) {
     auto version_or_error = Asn1Utility::parseInteger(*version_cbs);
     RETURN_IF_NOT_OK_REF(version_or_error.status());
-    auto version = version_or_error.value();
+    auto version = std::move(version_or_error.value());
     if (version != "00") {
       return absl::InvalidArgumentError(
           fmt::format("OCSP ResponseData version 0x{} is not supported", version));


### PR DESCRIPTION
Commit Message: minor-perf: move tls oscp string
Additional Description:
Minor perf moving the tls oscp string instead of copying.

Risk Level: low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A