### PR TITLE
aws: remove singleton calls and add virtual cluster manager

### DIFF
--- a/source/extensions/common/aws/aws_cluster_manager.cc
+++ b/source/extensions/common/aws/aws_cluster_manager.cc
@@ -7,7 +7,7 @@ namespace Extensions {
 namespace Common {
 namespace Aws {
 
-AwsClusterManager::AwsClusterManager(Server::Configuration::ServerFactoryContext& context)
+AwsClusterManagerImpl::AwsClusterManagerImpl(Server::Configuration::ServerFactoryContext& context)
     : context_(context) {
 
   // If we are still initializing, defer cluster creation using an init target
@@ -28,8 +28,8 @@ AwsClusterManager::AwsClusterManager(Server::Configuration::ServerFactoryContext
 };
 
 absl::StatusOr<AwsManagedClusterUpdateCallbacksHandlePtr>
-AwsClusterManager::addManagedClusterUpdateCallbacks(absl::string_view cluster_name,
-                                                    AwsManagedClusterUpdateCallbacks& cb) {
+AwsClusterManagerImpl::addManagedClusterUpdateCallbacks(absl::string_view cluster_name,
+                                                        AwsManagedClusterUpdateCallbacks& cb) {
   auto it = managed_clusters_.find(cluster_name);
   ENVOY_LOG_MISC(debug, "Adding callback for cluster {}", cluster_name);
   if (it == managed_clusters_.end()) {
@@ -48,8 +48,8 @@ AwsClusterManager::addManagedClusterUpdateCallbacks(absl::string_view cluster_na
       context_, cb, managed_cluster->update_callbacks_);
 }
 
-void AwsClusterManager::onClusterAddOrUpdate(absl::string_view cluster_name,
-                                             Upstream::ThreadLocalClusterCommand&) {
+void AwsClusterManagerImpl::onClusterAddOrUpdate(absl::string_view cluster_name,
+                                                 Upstream::ThreadLocalClusterCommand&) {
   // Mark our cluster as ready for use
   auto it = managed_clusters_.find(cluster_name);
   if (it != managed_clusters_.end()) {
@@ -63,9 +63,9 @@ void AwsClusterManager::onClusterAddOrUpdate(absl::string_view cluster_name,
 }
 
 // No removal handler required, as we are using avoid_cds_removal flag
-void AwsClusterManager::onClusterRemoval(const std::string&){};
+void AwsClusterManagerImpl::onClusterRemoval(const std::string&){};
 
-void AwsClusterManager::createQueuedClusters() {
+void AwsClusterManagerImpl::createQueuedClusters() {
   std::vector<std::string> failed_clusters;
   for (const auto& it : managed_clusters_) {
     auto cluster_name = it.first;
@@ -84,7 +84,7 @@ void AwsClusterManager::createQueuedClusters() {
   }
 }
 
-absl::Status AwsClusterManager::addManagedCluster(
+absl::Status AwsClusterManagerImpl::addManagedCluster(
     absl::string_view cluster_name,
     const envoy::config::cluster::v3::Cluster::DiscoveryType cluster_type, absl::string_view uri) {
 
@@ -117,7 +117,7 @@ absl::Status AwsClusterManager::addManagedCluster(
 }
 
 absl::StatusOr<std::string>
-AwsClusterManager::getUriFromClusterName(absl::string_view cluster_name) {
+AwsClusterManagerImpl::getUriFromClusterName(absl::string_view cluster_name) {
   auto it = managed_clusters_.find(cluster_name);
   if (it == managed_clusters_.end()) {
     return absl::InvalidArgumentError("Cluster not found");

--- a/source/extensions/common/aws/aws_cluster_manager.h
+++ b/source/extensions/common/aws/aws_cluster_manager.h
@@ -37,6 +37,25 @@ public:
 using AwsManagedClusterUpdateCallbacksHandlePtr =
     std::unique_ptr<AwsManagedClusterUpdateCallbacksHandle>;
 
+class AwsClusterManager {
+
+public:
+  virtual ~AwsClusterManager() = default;
+
+  virtual absl::Status
+  addManagedCluster(absl::string_view cluster_name,
+                    const envoy::config::cluster::v3::Cluster::DiscoveryType cluster_type,
+                    absl::string_view uri) PURE;
+
+  virtual absl::StatusOr<AwsManagedClusterUpdateCallbacksHandlePtr>
+  addManagedClusterUpdateCallbacks(absl::string_view cluster_name,
+                                   AwsManagedClusterUpdateCallbacks& cb) PURE;
+  virtual absl::StatusOr<std::string> getUriFromClusterName(absl::string_view cluster_name) PURE;
+
+private:
+  virtual void createQueuedClusters() PURE;
+};
+
 /**
  * Manages clusters for any number of credentials provider instances
  *
@@ -63,14 +82,15 @@ using AwsManagedClusterUpdateCallbacksHandlePtr =
  * be many instantiations of the credential provider for different roles, regions and profiles. The
  * aws cluster manager will dedupe these clusters as required.
  */
-class AwsClusterManager : public Envoy::Singleton::Instance,
-                          public Upstream::ClusterUpdateCallbacks {
+class AwsClusterManagerImpl : public AwsClusterManager,
+                              public Envoy::Singleton::Instance,
+                              public Upstream::ClusterUpdateCallbacks {
   // Friend class for testing callbacks
   friend class AwsClusterManagerFriend;
 
 public:
-  AwsClusterManager(Server::Configuration::ServerFactoryContext& context);
-  ~AwsClusterManager() override {
+  AwsClusterManagerImpl(Server::Configuration::ServerFactoryContext& context);
+  ~AwsClusterManagerImpl() override {
     if (cm_handle_) {
       // We exit last due to being pinned, so we must call cancel on the callbacks handle as it will
       // already be invalid by this time
@@ -87,7 +107,7 @@ public:
   absl::Status
   addManagedCluster(absl::string_view cluster_name,
                     const envoy::config::cluster::v3::Cluster::DiscoveryType cluster_type,
-                    absl::string_view uri);
+                    absl::string_view uri) override;
 
   /**
    * Add a callback to be signaled when a managed cluster comes online. This is used to kick off
@@ -97,8 +117,8 @@ public:
 
   absl::StatusOr<AwsManagedClusterUpdateCallbacksHandlePtr>
   addManagedClusterUpdateCallbacks(absl::string_view cluster_name,
-                                   AwsManagedClusterUpdateCallbacks& cb);
-  absl::StatusOr<std::string> getUriFromClusterName(absl::string_view cluster_name);
+                                   AwsManagedClusterUpdateCallbacks& cb) override;
+  absl::StatusOr<std::string> getUriFromClusterName(absl::string_view cluster_name) override;
 
 private:
   // Callbacks for cluster manager
@@ -110,7 +130,7 @@ private:
    * manager initialization
    */
 
-  void createQueuedClusters();
+  void createQueuedClusters() override;
   struct CredentialsProviderCluster {
     CredentialsProviderCluster(envoy::config::cluster::v3::Cluster::DiscoveryType cluster_type,
                                std::string uri)
@@ -130,6 +150,7 @@ private:
   std::unique_ptr<Init::TargetImpl> init_target_;
 };
 
+using AwsClusterManagerImplPtr = std::shared_ptr<AwsClusterManagerImpl>;
 using AwsClusterManagerPtr = std::shared_ptr<AwsClusterManager>;
 using AwsClusterManagerOptRef = OptRef<AwsClusterManagerPtr>;
 

--- a/source/extensions/common/aws/credentials_provider_impl.cc
+++ b/source/extensions/common/aws/credentials_provider_impl.cc
@@ -894,10 +894,10 @@ CustomCredentialsProviderChain::CustomCredentialsProviderChain(
     const CustomCredentialsProviderChainFactories& factories) {
 
   aws_cluster_manager_ =
-      context.singletonManager().getTyped<Envoy::Extensions::Common::Aws::AwsClusterManager>(
+      context.singletonManager().getTyped<Envoy::Extensions::Common::Aws::AwsClusterManagerImpl>(
           SINGLETON_MANAGER_REGISTERED_NAME(aws_cluster_manager),
           [&context] {
-            return std::make_shared<Envoy::Extensions::Common::Aws::AwsClusterManager>(context);
+            return std::make_shared<Envoy::Extensions::Common::Aws::AwsClusterManagerImpl>(context);
           },
           true);
 
@@ -919,18 +919,17 @@ CustomCredentialsProviderChain::CustomCredentialsProviderChain(
 }
 
 DefaultCredentialsProviderChain::DefaultCredentialsProviderChain(
-    Api::Api& api, ServerFactoryContextOptRef context,
-    ABSL_ATTRIBUTE_UNUSED Singleton::Manager& singleton_manager, absl::string_view region,
+    Api::Api& api, ServerFactoryContextOptRef context, absl::string_view region,
     const MetadataCredentialsProviderBase::CurlMetadataFetcher& fetch_metadata_using_curl,
     const envoy::extensions::common::aws::v3::AwsCredentialProvider& credential_provider_config,
     const CredentialsProviderChainFactories& factories) {
 
   if (context) {
     aws_cluster_manager_ =
-        context->singletonManager().getTyped<Envoy::Extensions::Common::Aws::AwsClusterManager>(
+        context->singletonManager().getTyped<Envoy::Extensions::Common::Aws::AwsClusterManagerImpl>(
             SINGLETON_MANAGER_REGISTERED_NAME(aws_cluster_manager),
             [&context] {
-              return std::make_shared<Envoy::Extensions::Common::Aws::AwsClusterManager>(
+              return std::make_shared<Envoy::Extensions::Common::Aws::AwsClusterManagerImpl>(
                   context.value());
             },
             true);

--- a/source/extensions/common/aws/credentials_provider_impl.h
+++ b/source/extensions/common/aws/credentials_provider_impl.h
@@ -445,18 +445,15 @@ class DefaultCredentialsProviderChain : public CredentialsProviderChain,
                                         public CredentialsProviderChainFactories {
 public:
   DefaultCredentialsProviderChain(
-      Api::Api& api, ServerFactoryContextOptRef context, Singleton::Manager& singleton_manager,
-      absl::string_view region,
+      Api::Api& api, ServerFactoryContextOptRef context, absl::string_view region,
       const MetadataCredentialsProviderBase::CurlMetadataFetcher& fetch_metadata_using_curl,
       const envoy::extensions::common::aws::v3::AwsCredentialProvider& credential_provider_config =
           {})
-      : DefaultCredentialsProviderChain(api, context, singleton_manager, region,
-                                        fetch_metadata_using_curl, credential_provider_config,
-                                        *this) {}
+      : DefaultCredentialsProviderChain(api, context, region, fetch_metadata_using_curl,
+                                        credential_provider_config, *this) {}
 
   DefaultCredentialsProviderChain(
-      Api::Api& api, ServerFactoryContextOptRef context, Singleton::Manager& singleton_manager,
-      absl::string_view region,
+      Api::Api& api, ServerFactoryContextOptRef context, absl::string_view region,
       const MetadataCredentialsProviderBase::CurlMetadataFetcher& fetch_metadata_using_curl,
       const envoy::extensions::common::aws::v3::AwsCredentialProvider& credential_provider_config,
       const CredentialsProviderChainFactories& factories);

--- a/source/extensions/filters/http/aws_lambda/config.cc
+++ b/source/extensions/filters/http/aws_lambda/config.cc
@@ -61,8 +61,7 @@ AwsLambdaFilterFactory::getCredentialsProvider(
         server_context, credential_file_config);
   }
   return std::make_shared<Extensions::Common::Aws::DefaultCredentialsProviderChain>(
-      server_context.api(), makeOptRef(server_context), server_context.singletonManager(), region,
-      nullptr);
+      server_context.api(), makeOptRef(server_context), region, nullptr);
 }
 
 absl::StatusOr<Http::FilterFactoryCb> AwsLambdaFilterFactory::createFilterFactoryFromProtoTyped(

--- a/source/extensions/filters/http/aws_request_signing/config.cc
+++ b/source/extensions/filters/http/aws_request_signing/config.cc
@@ -132,15 +132,15 @@ AwsRequestSigningFilterFactory::createSigner(
       }
       credentials_provider =
           std::make_shared<Extensions::Common::Aws::DefaultCredentialsProviderChain>(
-              server_context.api(), makeOptRef(server_context), server_context.singletonManager(),
-              region, nullptr, credential_provider_config);
+              server_context.api(), makeOptRef(server_context), region, nullptr,
+              credential_provider_config);
     }
   } else {
     // No credential provider settings provided, so make the default credentials provider chain
     credentials_provider =
         std::make_shared<Extensions::Common::Aws::DefaultCredentialsProviderChain>(
-            server_context.api(), makeOptRef(server_context), server_context.singletonManager(),
-            region, nullptr, credential_provider_config);
+            server_context.api(), makeOptRef(server_context), region, nullptr,
+            credential_provider_config);
   }
 
   if (!credentials_provider.ok()) {

--- a/source/extensions/grpc_credentials/aws_iam/config.cc
+++ b/source/extensions/grpc_credentials/aws_iam/config.cc
@@ -68,8 +68,8 @@ std::shared_ptr<grpc::ChannelCredentials> AwsIamGrpcCredentialsFactory::getChann
         // factory context.
 
         auto credentials_provider = std::make_shared<Common::Aws::DefaultCredentialsProviderChain>(
-            context.api(), absl::nullopt /*Empty factory context*/, context.singletonManager(),
-            region, Common::Aws::Utility::fetchMetadataWithCurl);
+            context.api(), absl::nullopt /*Empty factory context*/, region,
+            Common::Aws::Utility::fetchMetadataWithCurl);
         auto signer = std::make_unique<Common::Aws::SigV4SignerImpl>(
             config.service_name(), region, credentials_provider, context,
             // TODO: extend API to allow specifying header exclusion. ref:

--- a/test/extensions/common/aws/BUILD
+++ b/test/extensions/common/aws/BUILD
@@ -18,6 +18,7 @@ envoy_cc_mock(
     deps = [
         "//source/common/http:message_lib",
         "//source/extensions/common/aws:credentials_provider_interface",
+        "//source/extensions/common/aws:aws_cluster_manager_lib",
         "//source/extensions/common/aws:metadata_fetcher_lib",
         "//source/extensions/common/aws:signer_interface",
         "//test/mocks/upstream:cluster_manager_mocks",
@@ -149,6 +150,7 @@ envoy_cc_test(
     deps = [
         "//source/extensions/common/aws:credentials_provider_impl_lib",
         "//source/extensions/common/aws:metadata_fetcher_lib",
+        "//source/extensions/common/aws:aws_cluster_manager_lib",
         "//test/extensions/common/aws:aws_mocks",
         "//test/mocks/api:api_mocks",
         "//test/mocks/event:event_mocks",

--- a/test/extensions/common/aws/BUILD
+++ b/test/extensions/common/aws/BUILD
@@ -17,8 +17,8 @@ envoy_cc_mock(
     rbe_pool = "6gig",
     deps = [
         "//source/common/http:message_lib",
-        "//source/extensions/common/aws:credentials_provider_interface",
         "//source/extensions/common/aws:aws_cluster_manager_lib",
+        "//source/extensions/common/aws:credentials_provider_interface",
         "//source/extensions/common/aws:metadata_fetcher_lib",
         "//source/extensions/common/aws:signer_interface",
         "//test/mocks/upstream:cluster_manager_mocks",
@@ -148,9 +148,9 @@ envoy_cc_test(
     srcs = ["credentials_provider_impl_test.cc"],
     rbe_pool = "6gig",
     deps = [
+        "//source/extensions/common/aws:aws_cluster_manager_lib",
         "//source/extensions/common/aws:credentials_provider_impl_lib",
         "//source/extensions/common/aws:metadata_fetcher_lib",
-        "//source/extensions/common/aws:aws_cluster_manager_lib",
         "//test/extensions/common/aws:aws_mocks",
         "//test/mocks/api:api_mocks",
         "//test/mocks/event:event_mocks",

--- a/test/extensions/common/aws/credentials_provider_impl_test.cc
+++ b/test/extensions/common/aws/credentials_provider_impl_test.cc
@@ -2640,9 +2640,8 @@ TEST_F(DefaultCredentialsProviderChainTest, NoEnvironmentVars) {
               createInstanceProfileCredentialsProvider(Ref(*api_), _, _, _, _, _, _, _));
   envoy::extensions::common::aws::v3::AwsCredentialProvider credential_provider_config = {};
 
-  DefaultCredentialsProviderChain chain(*api_, context_, context_.singletonManager(), "region",
-                                        DummyMetadataFetcher(), credential_provider_config,
-                                        factories_);
+  DefaultCredentialsProviderChain chain(*api_, context_, "region", DummyMetadataFetcher(),
+                                        credential_provider_config, factories_);
 }
 
 TEST_F(DefaultCredentialsProviderChainTest, MetadataDisabled) {
@@ -2652,9 +2651,8 @@ TEST_F(DefaultCredentialsProviderChainTest, MetadataDisabled) {
       .Times(0);
   envoy::extensions::common::aws::v3::AwsCredentialProvider credential_provider_config = {};
 
-  DefaultCredentialsProviderChain chain(*api_, context_, context_.singletonManager(), "region",
-                                        DummyMetadataFetcher(), credential_provider_config,
-                                        factories_);
+  DefaultCredentialsProviderChain chain(*api_, context_, "region", DummyMetadataFetcher(),
+                                        credential_provider_config, factories_);
 }
 
 TEST_F(DefaultCredentialsProviderChainTest, MetadataNotDisabled) {
@@ -2664,9 +2662,8 @@ TEST_F(DefaultCredentialsProviderChainTest, MetadataNotDisabled) {
               createInstanceProfileCredentialsProvider(Ref(*api_), _, _, _, _, _, _, _));
   envoy::extensions::common::aws::v3::AwsCredentialProvider credential_provider_config = {};
 
-  DefaultCredentialsProviderChain chain(*api_, context_, context_.singletonManager(), "region",
-                                        DummyMetadataFetcher(), credential_provider_config,
-                                        factories_);
+  DefaultCredentialsProviderChain chain(*api_, context_, "region", DummyMetadataFetcher(),
+                                        credential_provider_config, factories_);
 }
 
 TEST_F(DefaultCredentialsProviderChainTest, RelativeUri) {
@@ -2677,9 +2674,8 @@ TEST_F(DefaultCredentialsProviderChainTest, RelativeUri) {
                                                  "169.254.170.2:80/path/to/creds", _, _, ""));
   envoy::extensions::common::aws::v3::AwsCredentialProvider credential_provider_config = {};
 
-  DefaultCredentialsProviderChain chain(*api_, context_, context_.singletonManager(), "region",
-                                        DummyMetadataFetcher(), credential_provider_config,
-                                        factories_);
+  DefaultCredentialsProviderChain chain(*api_, context_, "region", DummyMetadataFetcher(),
+                                        credential_provider_config, factories_);
 }
 
 TEST_F(DefaultCredentialsProviderChainTest, FullUriNoAuthorizationToken) {
@@ -2689,9 +2685,8 @@ TEST_F(DefaultCredentialsProviderChainTest, FullUriNoAuthorizationToken) {
                               Ref(*api_), _, _, _, _, _, "http://host/path/to/creds", _, _, ""));
   envoy::extensions::common::aws::v3::AwsCredentialProvider credential_provider_config = {};
 
-  DefaultCredentialsProviderChain chain(*api_, context_, context_.singletonManager(), "region",
-                                        DummyMetadataFetcher(), credential_provider_config,
-                                        factories_);
+  DefaultCredentialsProviderChain chain(*api_, context_, "region", DummyMetadataFetcher(),
+                                        credential_provider_config, factories_);
 }
 
 TEST_F(DefaultCredentialsProviderChainTest, FullUriWithAuthorizationToken) {
@@ -2703,9 +2698,8 @@ TEST_F(DefaultCredentialsProviderChainTest, FullUriWithAuthorizationToken) {
                                                  "http://host/path/to/creds", _, _, "auth_token"));
   envoy::extensions::common::aws::v3::AwsCredentialProvider credential_provider_config = {};
 
-  DefaultCredentialsProviderChain chain(*api_, context_, context_.singletonManager(), "region",
-                                        DummyMetadataFetcher(), credential_provider_config,
-                                        factories_);
+  DefaultCredentialsProviderChain chain(*api_, context_, "region", DummyMetadataFetcher(),
+                                        credential_provider_config, factories_);
 }
 
 TEST_F(DefaultCredentialsProviderChainTest, NoWebIdentityRoleArn) {
@@ -2715,9 +2709,8 @@ TEST_F(DefaultCredentialsProviderChainTest, NoWebIdentityRoleArn) {
               createInstanceProfileCredentialsProvider(Ref(*api_), _, _, _, _, _, _, _));
   envoy::extensions::common::aws::v3::AwsCredentialProvider credential_provider_config = {};
 
-  DefaultCredentialsProviderChain chain(*api_, context_, context_.singletonManager(), "region",
-                                        DummyMetadataFetcher(), credential_provider_config,
-                                        factories_);
+  DefaultCredentialsProviderChain chain(*api_, context_, "region", DummyMetadataFetcher(),
+                                        credential_provider_config, factories_);
 }
 
 TEST_F(DefaultCredentialsProviderChainTest, NoWebIdentitySessionName) {
@@ -2730,9 +2723,8 @@ TEST_F(DefaultCredentialsProviderChainTest, NoWebIdentitySessionName) {
               createInstanceProfileCredentialsProvider(Ref(*api_), _, _, _, _, _, _, _));
   envoy::extensions::common::aws::v3::AwsCredentialProvider credential_provider_config = {};
 
-  DefaultCredentialsProviderChain chain(*api_, context_, context_.singletonManager(), "region",
-                                        DummyMetadataFetcher(), credential_provider_config,
-                                        factories_);
+  DefaultCredentialsProviderChain chain(*api_, context_, "region", DummyMetadataFetcher(),
+                                        credential_provider_config, factories_);
 }
 
 TEST_F(DefaultCredentialsProviderChainTest, WebIdentityWithSessionName) {
@@ -2746,9 +2738,8 @@ TEST_F(DefaultCredentialsProviderChainTest, WebIdentityWithSessionName) {
 
   envoy::extensions::common::aws::v3::AwsCredentialProvider credential_provider_config = {};
 
-  DefaultCredentialsProviderChain chain(*api_, context_, context_.singletonManager(), "region",
-                                        DummyMetadataFetcher(), credential_provider_config,
-                                        factories_);
+  DefaultCredentialsProviderChain chain(*api_, context_, "region", DummyMetadataFetcher(),
+                                        credential_provider_config, factories_);
 }
 
 TEST_F(DefaultCredentialsProviderChainTest, NoWebIdentityWithBlankConfig) {
@@ -2761,9 +2752,8 @@ TEST_F(DefaultCredentialsProviderChainTest, NoWebIdentityWithBlankConfig) {
 
   envoy::extensions::common::aws::v3::AwsCredentialProvider credential_provider_config = {};
 
-  DefaultCredentialsProviderChain chain(*api_, context_, context_.singletonManager(), "region",
-                                        DummyMetadataFetcher(), credential_provider_config,
-                                        factories_);
+  DefaultCredentialsProviderChain chain(*api_, context_, "region", DummyMetadataFetcher(),
+                                        credential_provider_config, factories_);
 }
 // These tests validate override of default credential provider with custom credential provider
 // settings
@@ -2791,9 +2781,8 @@ TEST_F(DefaultCredentialsProviderChainTest, WebIdentityWithCustomSessionName) {
   credential_provider_config.mutable_assume_role_with_web_identity_provider()
       ->set_role_session_name("custom-role-session-name");
 
-  DefaultCredentialsProviderChain chain(*api_, context_, context_.singletonManager(), "region",
-                                        DummyMetadataFetcher(), credential_provider_config,
-                                        factories_);
+  DefaultCredentialsProviderChain chain(*api_, context_, "region", DummyMetadataFetcher(),
+                                        credential_provider_config, factories_);
   EXPECT_EQ(role_session_name, "custom-role-session-name");
 }
 
@@ -2820,9 +2809,8 @@ TEST_F(DefaultCredentialsProviderChainTest, WebIdentityWithCustomRoleArn) {
   credential_provider_config.mutable_assume_role_with_web_identity_provider()->set_role_arn(
       "custom-role-arn");
 
-  DefaultCredentialsProviderChain chain(*api_, context_, context_.singletonManager(), "region",
-                                        DummyMetadataFetcher(), credential_provider_config,
-                                        factories_);
+  DefaultCredentialsProviderChain chain(*api_, context_, "region", DummyMetadataFetcher(),
+                                        credential_provider_config, factories_);
   EXPECT_EQ(role_arn, "custom-role-arn");
 }
 
@@ -2850,9 +2838,8 @@ TEST_F(DefaultCredentialsProviderChainTest, WebIdentityWithCustomDataSource) {
       ->mutable_web_identity_token_data_source()
       ->set_inline_string("custom_token_string");
 
-  DefaultCredentialsProviderChain chain(*api_, context_, context_.singletonManager(), "region",
-                                        DummyMetadataFetcher(), credential_provider_config,
-                                        factories_);
+  DefaultCredentialsProviderChain chain(*api_, context_, "region", DummyMetadataFetcher(),
+                                        credential_provider_config, factories_);
   EXPECT_EQ(inline_string, "custom_token_string");
 }
 
@@ -2882,9 +2869,8 @@ TEST_F(DefaultCredentialsProviderChainTest, CredentialsFileWithCustomDataSource)
       ->mutable_credentials_data_source()
       ->set_inline_string("custom_inline_string");
 
-  DefaultCredentialsProviderChain chain(*api_, context_, context_.singletonManager(), "region",
-                                        DummyMetadataFetcher(), credential_provider_config,
-                                        factories_);
+  DefaultCredentialsProviderChain chain(*api_, context_, "region", DummyMetadataFetcher(),
+                                        credential_provider_config, factories_);
   EXPECT_EQ(inline_string, "custom_inline_string");
 }
 

--- a/test/extensions/common/aws/credentials_provider_impl_test.cc
+++ b/test/extensions/common/aws/credentials_provider_impl_test.cc
@@ -428,7 +428,7 @@ public:
                          MetadataFetcher::MetadataReceiver::RefreshState::Ready,
                      std::chrono::seconds initialization_timer = std::chrono::seconds(2)) {
     ON_CALL(context_, clusterManager()).WillByDefault(ReturnRef(cluster_manager_));
-mock_manager_ = std::make_shared<MockAwsClusterManager>();
+    mock_manager_ = std::make_shared<MockAwsClusterManager>();
     base_manager_ = std::dynamic_pointer_cast<AwsClusterManager>(mock_manager_);
 
     manager_optref_.emplace(base_manager_);
@@ -607,7 +607,8 @@ mock_manager_ = std::make_shared<MockAwsClusterManager>();
   std::chrono::milliseconds expected_duration_;
   OptRef<std::shared_ptr<AwsClusterManager>> manager_optref_;
   std::shared_ptr<MockAwsClusterManager> mock_manager_;
-  std::shared_ptr<AwsClusterManager> base_manager_;};
+  std::shared_ptr<AwsClusterManager> base_manager_;
+};
 
 TEST_F(InstanceProfileCredentialsProviderTest, FailedCredentialListingIMDSv1) {
   // Setup timer.
@@ -1546,7 +1547,8 @@ public:
   MetadataFetcher::MetadataReceiver::RefreshState refresh_state_;
   OptRef<std::shared_ptr<AwsClusterManager>> manager_optref_;
   std::shared_ptr<MockAwsClusterManager> mock_manager_;
-  std::shared_ptr<AwsClusterManager> base_manager_;};
+  std::shared_ptr<AwsClusterManager> base_manager_;
+};
 
 TEST_F(ContainerCredentialsProviderTest, FailedFetchingDocument) {
 
@@ -1984,7 +1986,8 @@ public:
   std::chrono::milliseconds expected_duration_;
   OptRef<std::shared_ptr<AwsClusterManager>> manager_optref_;
   std::shared_ptr<MockAwsClusterManager> mock_manager_;
-  std::shared_ptr<AwsClusterManager> base_manager_;};
+  std::shared_ptr<AwsClusterManager> base_manager_;
+};
 
 TEST_F(ContainerEKSPodIdentityCredentialsProviderTest, AuthTokenFromFile) {
   // Setup timer.
@@ -2052,7 +2055,7 @@ public:
     cred_provider.set_role_arn("aws:iam::123456789012:role/arn");
     cred_provider.set_role_session_name("role-session-name");
 
- mock_manager_ = std::make_shared<MockAwsClusterManager>();
+    mock_manager_ = std::make_shared<MockAwsClusterManager>();
     base_manager_ = std::dynamic_pointer_cast<AwsClusterManager>(mock_manager_);
 
     manager_optref_.emplace(base_manager_);


### PR DESCRIPTION
Commit Message: aws: remove singleton calls and add virtual cluster manager
Additional Description: Minor cleanups and support for mocking new cluster manager component
Risk Level: Negligible
Testing: Unit
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
