### PR TITLE
golang: allow injecting extra data

### DIFF
--- a/contrib/golang/common/go/api/api.h
+++ b/contrib/golang/common/go/api/api.h
@@ -69,6 +69,7 @@ typedef enum { // NOLINT(modernize-use-using)
   CAPIYield = -6,
   CAPIInternalFailure = -7,
   CAPISerializationFailure = -8,
+  CAPIInvalidScene = -9,
 } CAPIStatus;
 
 /* These APIs are related to the decode/encode phase, use the pointer of processState. */
@@ -79,6 +80,7 @@ CAPIStatus envoyGoFilterHttpSendLocalReply(void* s, int response_code, void* bod
                                            int details_len);
 CAPIStatus envoyGoFilterHttpSendPanicReply(void* s, void* details_data, int details_len);
 CAPIStatus envoyGoFilterHttpAddData(void* s, void* data, int data_len, bool is_streaming);
+CAPIStatus envoyGoFilterHttpInjectData(void* s, void* data, int data_len);
 
 CAPIStatus envoyGoFilterHttpGetHeader(void* s, void* key_data, int key_len, uint64_t* value_data,
                                       int* value_len);

--- a/contrib/golang/common/go/api/capi.go
+++ b/contrib/golang/common/go/api/capi.go
@@ -24,6 +24,7 @@ type HttpCAPI interface {
 	HttpContinue(s unsafe.Pointer, status uint64)
 	HttpSendLocalReply(s unsafe.Pointer, responseCode int, bodyText string, headers map[string][]string, grpcStatus int64, details string)
 	HttpAddData(s unsafe.Pointer, data []byte, isStreaming bool)
+	HttpInjectData(s unsafe.Pointer, data []byte)
 
 	// Send a specialized reply that indicates that the filter has failed on the go side. Internally this is used for
 	// when unhandled panics are detected.

--- a/contrib/golang/common/go/api/filter.go
+++ b/contrib/golang/common/go/api/filter.go
@@ -191,6 +191,8 @@ type FilterProcessCallbacks interface {
 	// For example, turn a headers only request into a request with a body, add more body when processing trailers, and so on.
 	// The second argument isStreaming supplies if this caller streams data or buffers the full body.
 	AddData(data []byte, isStreaming bool)
+	// InjectData inject the content of slice data via Envoy StreamXXFilterCallbacks's injectXXDataToFilterChaininjectData.
+	InjectData(data []byte)
 }
 
 type DecoderFilterCallbacks interface {

--- a/contrib/golang/filters/http/source/cgo.cc
+++ b/contrib/golang/filters/http/source/cgo.cc
@@ -151,6 +151,14 @@ CAPIStatus envoyGoFilterHttpAddData(void* s, void* data, int data_len, bool is_s
       });
 }
 
+CAPIStatus envoyGoFilterHttpInjectData(void* s, void* data, int data_length) {
+  return envoyGoFilterProcessStateHandlerWrapper(
+      s, [data, data_length](std::shared_ptr<Filter>& filter, ProcessorState& state) -> CAPIStatus {
+        auto value = stringViewFromGoPointer(data, data_length);
+        return filter->injectData(state, value);
+      });
+}
+
 // unsafe API, without copy memory from c to go.
 CAPIStatus envoyGoFilterHttpGetHeader(void* s, void* key_data, int key_len, uint64_t* value_data,
                                       int* value_len) {

--- a/contrib/golang/filters/http/source/go/pkg/http/capi_impl.go
+++ b/contrib/golang/filters/http/source/go/pkg/http/capi_impl.go
@@ -77,7 +77,8 @@ func handleCApiStatus(status C.CAPIStatus) {
 	case C.CAPIFilterIsGone,
 		C.CAPIFilterIsDestroy,
 		C.CAPINotInGo,
-		C.CAPIInvalidPhase:
+		C.CAPIInvalidPhase,
+		C.CAPIInvalidScene:
 		panic(capiStatusToStr(status))
 	}
 }
@@ -92,6 +93,8 @@ func capiStatusToStr(status C.CAPIStatus) string {
 		return errNotInGo
 	case C.CAPIInvalidPhase:
 		return errInvalidPhase
+	case C.CAPIInvalidScene:
+		return errInvalidScene
 	}
 
 	return "unknown status"
@@ -151,6 +154,13 @@ func (c *httpCApiImpl) HttpSendPanicReply(s unsafe.Pointer, details string) {
 func (c *httpCApiImpl) HttpAddData(s unsafe.Pointer, data []byte, isStreaming bool) {
 	state := (*processState)(s)
 	res := C.envoyGoFilterHttpAddData(unsafe.Pointer(state.processState), unsafe.Pointer(unsafe.SliceData(data)), C.int(len(data)), C.bool(isStreaming))
+	handleCApiStatus(res)
+}
+
+func (c *httpCApiImpl) HttpInjectData(s unsafe.Pointer, data []byte) {
+	state := (*processState)(s)
+	res := C.envoyGoFilterHttpInjectData(unsafe.Pointer(state.processState),
+		unsafe.Pointer(unsafe.SliceData(data)), C.int(len(data)))
 	handleCApiStatus(res)
 }
 

--- a/contrib/golang/filters/http/source/go/pkg/http/filter.go
+++ b/contrib/golang/filters/http/source/go/pkg/http/filter.go
@@ -171,6 +171,10 @@ func (s *processState) AddData(data []byte, isStreaming bool) {
 	cAPI.HttpAddData(unsafe.Pointer(s), data, isStreaming)
 }
 
+func (s *processState) InjectData(data []byte) {
+	cAPI.HttpInjectData(unsafe.Pointer(s), data)
+}
+
 func (r *httpRequest) StreamInfo() api.StreamInfo {
 	return &r.streamInfo
 }

--- a/contrib/golang/filters/http/source/go/pkg/http/type.go
+++ b/contrib/golang/filters/http/source/go/pkg/http/type.go
@@ -32,6 +32,7 @@ const (
 	errFilterDestroyed = "golang filter has been destroyed"
 	errNotInGo         = "not proccessing Go"
 	errInvalidPhase    = "invalid phase, maybe headers/buffer already continued"
+	errInvalidScene    = "invalid scene for this API"
 )
 
 // api.HeaderMap

--- a/contrib/golang/filters/http/source/golang_filter.h
+++ b/contrib/golang/filters/http/source/golang_filter.h
@@ -269,6 +269,7 @@ public:
   CAPIStatus sendPanicReply(ProcessorState& state, absl::string_view details);
 
   CAPIStatus addData(ProcessorState& state, absl::string_view data, bool is_streaming);
+  CAPIStatus injectData(ProcessorState& state, absl::string_view data);
 
   CAPIStatus getHeader(ProcessorState& state, absl::string_view key, uint64_t* value_data,
                        int* value_len);

--- a/contrib/golang/filters/http/test/test_data/BUILD
+++ b/contrib/golang/filters/http/test/test_data/BUILD
@@ -20,6 +20,7 @@ go_binary(
         "//contrib/golang/filters/http/test/test_data/add_data",
         "//contrib/golang/filters/http/test/test_data/basic",
         "//contrib/golang/filters/http/test/test_data/buffer",
+        "//contrib/golang/filters/http/test/test_data/bufferinjectdata",
         "//contrib/golang/filters/http/test/test_data/echo",
         "//contrib/golang/filters/http/test/test_data/metric",
         "//contrib/golang/filters/http/test/test_data/passthrough",

--- a/contrib/golang/filters/http/test/test_data/bufferinjectdata/BUILD
+++ b/contrib/golang/filters/http/test/test_data/bufferinjectdata/BUILD
@@ -1,0 +1,21 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+licenses(["notice"])  # Apache 2
+
+go_library(
+    name = "bufferinjectdata",
+    srcs = [
+        "config.go",
+        "filter.go",
+    ],
+    cgo = True,
+    importpath = "example.com/test-data/bufferinjectdata",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//contrib/golang/common/go/api",
+        "//contrib/golang/filters/http/source/go/pkg/http",
+        "@com_github_cncf_xds_go//xds/type/v3:type",
+        "@org_golang_google_protobuf//types/known/anypb",
+        "@org_golang_google_protobuf//types/known/structpb",
+    ],
+)

--- a/contrib/golang/filters/http/test/test_data/bufferinjectdata/config.go
+++ b/contrib/golang/filters/http/test/test_data/bufferinjectdata/config.go
@@ -1,0 +1,39 @@
+package bufferinjectdata
+
+import (
+	"google.golang.org/protobuf/types/known/anypb"
+
+	"github.com/envoyproxy/envoy/contrib/golang/common/go/api"
+	"github.com/envoyproxy/envoy/contrib/golang/filters/http/source/go/pkg/http"
+)
+
+const Name = "bufferinjectdata"
+
+func init() {
+	http.RegisterHttpFilterFactoryAndConfigParser(Name, filterFactory, &parser{})
+}
+
+type config struct {
+}
+
+type parser struct {
+}
+
+func (p *parser) Parse(any *anypb.Any, callbacks api.ConfigCallbackHandler) (interface{}, error) {
+	return &config{}, nil
+}
+
+func (p *parser) Merge(parent interface{}, child interface{}) interface{} {
+	return child
+}
+
+func filterFactory(c interface{}, callbacks api.FilterCallbackHandler) api.StreamFilter {
+	conf, ok := c.(*config)
+	if !ok {
+		panic("unexpected config type")
+	}
+	return &filter{
+		callbacks: callbacks,
+		config:    conf,
+	}
+}

--- a/contrib/golang/filters/http/test/test_data/bufferinjectdata/filter.go
+++ b/contrib/golang/filters/http/test/test_data/bufferinjectdata/filter.go
@@ -1,0 +1,152 @@
+package bufferinjectdata
+
+import (
+	"net/url"
+	"runtime/debug"
+	"sync"
+	"time"
+
+	"github.com/envoyproxy/envoy/contrib/golang/common/go/api"
+)
+
+type filter struct {
+	api.PassThroughStreamFilter
+
+	callbacks api.FilterCallbackHandler
+	params    url.Values
+	config    *config
+
+	count int
+}
+
+func (f *filter) disallowInjectData() {
+	defer func() {
+		if p := recover(); p != nil {
+			api.LogErrorf("panic: %v\n%s", p, debug.Stack())
+			f.callbacks.DecoderFilterCallbacks().SendLocalReply(400, "Not allowed", nil, 0, "")
+		}
+	}()
+	f.callbacks.DecoderFilterCallbacks().InjectData([]byte("just try"))
+}
+
+func (f *filter) DecodeHeaders(headers api.RequestHeaderMap, endStream bool) api.StatusType {
+	path := headers.Path()
+	u, _ := url.Parse(path)
+	f.params = u.Query()
+
+	if f.params.Has("inject_data_when_processing_header") {
+		f.disallowInjectData()
+		return api.LocalReply
+	}
+
+	if f.params.Has("bufferingly_decode") {
+		return api.StopAndBuffer
+	}
+	return api.Continue
+}
+
+func (f *filter) DecodeData(buffer api.BufferInstance, endStream bool) api.StatusType {
+	if f.params.Has("inject_data_when_processing_data_synchronously") {
+		f.disallowInjectData()
+		return api.LocalReply
+	}
+
+	// buffer.InjectData must be called in async mode
+	go func() {
+		defer f.callbacks.DecoderFilterCallbacks().RecoverPanic()
+
+		status := f.decodeData(buffer, endStream)
+		if status != api.LocalReply {
+			f.callbacks.DecoderFilterCallbacks().Continue(status)
+		}
+	}()
+	return api.Running
+}
+
+func (f *filter) decodeData(buffer api.BufferInstance, endStream bool) api.StatusType {
+	cb := f.callbacks.DecoderFilterCallbacks()
+	if f.params.Has("nonbufferingly_decode") {
+		return f.processDataNonbufferingly(cb, buffer, endStream)
+	} else if f.params.Has("bufferingly_decode") {
+		return f.processDataBufferingly(cb, buffer, endStream)
+	}
+	return api.Continue
+}
+
+func (f *filter) EncodeHeaders(headers api.ResponseHeaderMap, endStream bool) api.StatusType {
+	if f.params.Has("bufferingly_encode") {
+		return api.StopAndBuffer
+	}
+	return api.Continue
+}
+
+func (f *filter) EncodeData(buffer api.BufferInstance, endStream bool) api.StatusType {
+	// buffer.InjectData must be called in async mode
+	go func() {
+		defer f.callbacks.EncoderFilterCallbacks().RecoverPanic()
+
+		status := f.encodeData(buffer, endStream)
+		if status != api.LocalReply {
+			f.callbacks.EncoderFilterCallbacks().Continue(status)
+		}
+	}()
+	return api.Running
+}
+
+func (f *filter) encodeData(buffer api.BufferInstance, endStream bool) api.StatusType {
+	cb := f.callbacks.EncoderFilterCallbacks()
+	if f.params.Has("nonbufferingly_encode") {
+		return f.processDataNonbufferingly(cb, buffer, endStream)
+	}
+	if f.params.Has("bufferingly_encode") {
+		return f.processDataBufferingly(cb, buffer, endStream)
+	}
+	return api.Continue
+}
+
+func (f *filter) processDataNonbufferingly(cb api.FilterProcessCallbacks, buffer api.BufferInstance, endStream bool) api.StatusType {
+	f.flushInNonbufferedResponse(cb, buffer)
+	f.count++
+	return api.Continue
+}
+
+func injectData(cb api.FilterProcessCallbacks, data string, wait bool) {
+	cb.InjectData([]byte(data))
+}
+
+func (f *filter) flushInNonbufferedResponse(cb api.FilterProcessCallbacks, buffer api.BufferInstance) {
+	// The remote sends: "To be, " and then "that is "
+	api.LogInfof("The remote sends %s", buffer.String())
+	cb.InjectData(buffer.Bytes())
+	buffer.Reset()
+	if f.count == 0 {
+		injectData(cb, "or not to be, ", false)
+	} else if f.count == 1 {
+		injectData(cb, "the question", false)
+	}
+}
+
+func (f *filter) processDataBufferingly(cb api.FilterProcessCallbacks, buffer api.BufferInstance, endStream bool) api.StatusType {
+	if !endStream {
+		return api.StopAndBuffer
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func(buffer api.BufferInstance) {
+		defer wg.Done()
+		flushInBufferedResponse(cb, buffer)
+	}(buffer)
+	wg.Wait()
+	return api.Continue
+}
+
+func flushInBufferedResponse(cb api.FilterProcessCallbacks, buffer api.BufferInstance) {
+	// The remote sends: "To be, "
+	api.LogInfof("The remote sends %s", buffer.String())
+	cb.InjectData(buffer.Bytes())
+	buffer.Reset()
+	injectData(cb, "or not to be, ", false)
+	time.Sleep(10 * time.Millisecond)
+	injectData(cb, "that is the question", false)
+}

--- a/contrib/golang/filters/http/test/test_data/plugins.go
+++ b/contrib/golang/filters/http/test/test_data/plugins.go
@@ -6,6 +6,7 @@ import (
 	_ "example.com/test-data/add_data"
 	_ "example.com/test-data/basic"
 	_ "example.com/test-data/buffer"
+	_ "example.com/test-data/bufferinjectdata"
 	_ "example.com/test-data/echo"
 	_ "example.com/test-data/metric"
 	_ "example.com/test-data/passthrough"


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: golang: allow injecting extra data
Additional Description: This PR adds a feature that allows users to flush the data immediately when processing the data asynchronously.
Risk Level: Low
Testing: Integration test
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
