### PR TITLE
dynamic_modules: adds ClearRouteCache callback

### DIFF
--- a/source/extensions/dynamic_modules/BUILD
+++ b/source/extensions/dynamic_modules/BUILD
@@ -51,6 +51,7 @@ envoy_cc_library(
             "-Wl,--export-dynamic-symbol=envoy_dynamic_module_callback_http_get_response_body_vector_size",
             "-Wl,--export-dynamic-symbol=envoy_dynamic_module_callback_http_append_response_body",
             "-Wl,--export-dynamic-symbol=envoy_dynamic_module_callback_http_drain_response_body",
+            "-Wl,--export-dynamic-symbol=envoy_dynamic_module_callback_http_clear_route_cache",
         ],
     }),
     deps = [

--- a/source/extensions/dynamic_modules/abi.h
+++ b/source/extensions/dynamic_modules/abi.h
@@ -836,6 +836,16 @@ bool envoy_dynamic_module_callback_http_get_dynamic_metadata_string(
     envoy_dynamic_module_type_buffer_module_ptr key_ptr, size_t key_length,
     envoy_dynamic_module_type_buffer_envoy_ptr* result, size_t* result_length);
 
+// ------------------- Misc Callbacks for HTTP Filters -------------------------
+
+/**
+ * envoy_dynamic_module_callback_http_clear_route_cache is called by the module to clear the route
+ * cache for the HTTP filter. This is useful when the module wants to make their own routing
+ * decision. This will be a no-op when it's called in the wrong phase.
+ */
+void envoy_dynamic_module_callback_http_clear_route_cache(
+    envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr);
+
 #ifdef __cplusplus
 }
 #endif

--- a/source/extensions/dynamic_modules/abi_version.h
+++ b/source/extensions/dynamic_modules/abi_version.h
@@ -6,7 +6,7 @@ namespace DynamicModules {
 #endif
 // This is the ABI version calculated as a sha256 hash of the ABI header files. When the ABI
 // changes, this value must change, and the correctness of this value is checked by the test.
-const char* kAbiVersion = "05d8d5fac54ffcfc596312d93fff5d5082cbe37d4aca21fd4270ffa253980f34";
+const char* kAbiVersion = "c49e84f9df73b57feac0ab03d8390609e9019ce50d9fb418e45b17b477ce26da";
 
 #ifdef __cplusplus
 } // namespace DynamicModules

--- a/source/extensions/dynamic_modules/abi_version.h
+++ b/source/extensions/dynamic_modules/abi_version.h
@@ -6,7 +6,7 @@ namespace DynamicModules {
 #endif
 // This is the ABI version calculated as a sha256 hash of the ABI header files. When the ABI
 // changes, this value must change, and the correctness of this value is checked by the test.
-const char* kAbiVersion = "c49e84f9df73b57feac0ab03d8390609e9019ce50d9fb418e45b17b477ce26da";
+const char* kAbiVersion = "9e0126c182a3b4b5cae6f6e4a24246bdafa024e2831e0754df49ec3ccc909b38";
 
 #ifdef __cplusplus
 } // namespace DynamicModules

--- a/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
@@ -475,6 +475,12 @@ pub trait EnvoyHttpFilter {
   /// Note that after changing the response body, it is caller's responsibility to modify the
   /// content-length header if necessary.
   fn append_response_body(&mut self, data: &[u8]) -> bool;
+
+  /// Clear the route cache calculated during a previous phase of the filter chain.
+  ///
+  /// This is useful when the filter wants to force a re-evaluation of the route selection after
+  /// modifying the request headers, etc that affect the routing decision.
+  fn clear_route_cache(&mut self);
 }
 
 /// This implements the [`EnvoyHttpFilter`] trait with the given raw pointer to the Envoy HTTP
@@ -820,6 +826,10 @@ impl EnvoyHttpFilter for EnvoyHttpFilterImpl {
         data.len(),
       )
     }
+  }
+
+  fn clear_route_cache(&mut self) {
+    unsafe { abi::envoy_dynamic_module_callback_http_clear_route_cache(self.raw_ptr) }
   }
 }
 

--- a/source/extensions/filters/http/dynamic_modules/abi_impl.cc
+++ b/source/extensions/filters/http/dynamic_modules/abi_impl.cc
@@ -519,6 +519,12 @@ bool envoy_dynamic_module_callback_http_drain_response_body(
   });
   return true;
 }
+
+void envoy_dynamic_module_callback_http_clear_route_cache(
+    envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr) {
+  auto filter = static_cast<DynamicModuleHttpFilter*>(filter_envoy_ptr);
+  filter->decoder_callbacks_->downstreamCallbacks()->clearRouteCache();
+}
 }
 } // namespace HttpFilters
 } // namespace DynamicModules

--- a/test/extensions/dynamic_modules/http/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/http/abi_impl_test.cc
@@ -614,6 +614,19 @@ TEST(ABIImpl, ResponseBody) {
   EXPECT_EQ(bufferVectorToString(result_buffer_vector3), "rbaz");
 }
 
+TEST(ABIImpl, ClearRouteCache) {
+  DynamicModuleHttpFilter filter{nullptr};
+  Http::MockStreamDecoderFilterCallbacks callbacks;
+  StreamInfo::MockStreamInfo stream_info;
+  EXPECT_CALL(callbacks, streamInfo()).WillRepeatedly(testing::ReturnRef(stream_info));
+  filter.setDecoderFilterCallbacks(callbacks);
+  Http::MockDownstreamStreamFilterCallbacks downstream_callbacks;
+  EXPECT_CALL(downstream_callbacks, clearRouteCache());
+  EXPECT_CALL(callbacks, downstreamCallbacks())
+      .WillOnce(testing::Return(OptRef(downstream_callbacks)));
+  envoy_dynamic_module_callback_http_clear_route_cache(&filter);
+}
+
 } // namespace HttpFilters
 } // namespace DynamicModules
 } // namespace Extensions

--- a/test/extensions/dynamic_modules/http/filter_test.cc
+++ b/test/extensions/dynamic_modules/http/filter_test.cc
@@ -72,6 +72,15 @@ TEST(DynamiModulesTest, HeaderCallbacks) {
   auto filter = std::make_shared<DynamicModuleHttpFilter>(filter_config_or_status.value());
   filter->initializeInModuleFilter();
 
+  Http::MockStreamDecoderFilterCallbacks callbacks;
+  StreamInfo::MockStreamInfo stream_info;
+  EXPECT_CALL(callbacks, streamInfo()).WillRepeatedly(testing::ReturnRef(stream_info));
+  Http::MockDownstreamStreamFilterCallbacks downstream_callbacks;
+  EXPECT_CALL(downstream_callbacks, clearRouteCache());
+  EXPECT_CALL(callbacks, downstreamCallbacks())
+      .WillOnce(testing::Return(OptRef(downstream_callbacks)));
+  filter->setDecoderFilterCallbacks(callbacks);
+
   std::initializer_list<std::pair<std::string, std::string>> headers = {
       {"single", "value"}, {"multi", "value1"}, {"multi", "value2"}};
   Http::TestRequestHeaderMapImpl request_headers{headers};

--- a/test/extensions/dynamic_modules/test_data/rust/http.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/http.rs
@@ -49,6 +49,8 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for HeaderCallbacksFilter {
     envoy_filter: &mut EHF,
     _end_of_stream: bool,
   ) -> abi::envoy_dynamic_module_type_on_http_filter_request_headers_status {
+    envoy_filter.clear_route_cache();
+
     // Test single getter API.
     let single_value = envoy_filter
       .get_request_header_value("single")

--- a/test/extensions/dynamic_modules/test_data/rust/http_test.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/http_test.rs
@@ -7,6 +7,11 @@ fn test_header_callbacks_filter_on_request_headers() {
   let mut envoy_filter = MockEnvoyHttpFilter::default();
 
   envoy_filter
+    .expect_clear_route_cache()
+    .return_const(())
+    .once();
+
+  envoy_filter
     .expect_get_request_header_value()
     .withf(|name| name == "single")
     .returning(|_| Some(EnvoyBuffer::new("value")))


### PR DESCRIPTION
Commit Message: dynamic_modules: adds ClearRouteCache callback
Additional Description:

This adds envoy_dynamic_module_callback_http_clear_route_cache that allows users to make a custom routing decision. This was one of many gaps between dynamic_modules and other extension mechanisms.

Risk Level: low 
Testing: done
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
