### PR TITLE
ignore request_header_mode in mode override comparison

### DIFF
--- a/api/envoy/extensions/filters/http/ext_proc/v3/ext_proc.proto
+++ b/api/envoy/extensions/filters/http/ext_proc/v3/ext_proc.proto
@@ -326,6 +326,7 @@ message ExternalProcessor {
   // can only be overridden by the response message from the external processing server iff the
   // :ref:`mode_override <envoy_v3_api_field_service.ext_proc.v3.ProcessingResponse.mode_override>` is allowed by
   // the ``allowed_override_modes`` allow-list below.
+  // Since request_header_mode is not applicable in any way, it's ignored in comparison.
   repeated ProcessingMode allowed_override_modes = 22;
 }
 

--- a/api/envoy/extensions/filters/http/ext_proc/v3/processing_mode.proto
+++ b/api/envoy/extensions/filters/http/ext_proc/v3/processing_mode.proto
@@ -111,8 +111,8 @@ message ProcessingMode {
     FULL_DUPLEX_STREAMED = 4;
   }
 
-  // How to handle the request header. Default is "SEND". A value of "DEFAULT" (unset) should be used
-  // with :ref:`mode_override
+  // How to handle the request header. Default is "SEND". 
+  // Not this field is ignored in :ref:`mode_override
   // <envoy_v3_api_field_service.ext_proc.v3.ProcessingResponse.mode_override>`, since mode
   // overrides can only affect messages exchanged after the request header is processed.
   HeaderSendMode request_header_mode = 1 [(validate.rules).enum = {defined_only: true}];

--- a/api/envoy/extensions/filters/http/ext_proc/v3/processing_mode.proto
+++ b/api/envoy/extensions/filters/http/ext_proc/v3/processing_mode.proto
@@ -112,7 +112,7 @@ message ProcessingMode {
   }
 
   // How to handle the request header. Default is "SEND". 
-  // Not this field is ignored in :ref:`mode_override
+  // Note this field is ignored in :ref:`mode_override
   // <envoy_v3_api_field_service.ext_proc.v3.ProcessingResponse.mode_override>`, since mode
   // overrides can only affect messages exchanged after the request header is processed.
   HeaderSendMode request_header_mode = 1 [(validate.rules).enum = {defined_only: true}];

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -18,6 +18,10 @@ minor_behavior_changes:
     When :ref:`mode_override <envoy_v3_api_field_service.ext_proc.v3.ProcessingResponse.mode_override>`
     headers/trailers modes have the value ``DEFAULT`` (unset), no change will be made to the processing
     mode set in the filter configuration.
+- area: ext_proc
+  change: |
+    Ignore `request_header_mode` field of :ref:`mode_override <envoy_v3_api_field_service.ext_proc.v3.ProcessingResponse.mode_override>`
+    when comparing the mode_override against allowed_override_modes as request_header mode override is not applicable.
 
 bug_fixes:
 # *Changes expected to improve the state of the world and are unlikely to have negative effects*

--- a/source/extensions/filters/http/ext_proc/ext_proc.cc
+++ b/source/extensions/filters/http/ext_proc/ext_proc.cc
@@ -1270,7 +1270,12 @@ void Filter::onReceiveMessage(std::unique_ptr<ProcessingResponse>&& r) {
           config_->allowedOverrideModes(),
           [&mode_override](
               const envoy::extensions::filters::http::ext_proc::v3::ProcessingMode& other) {
-            return Protobuf::util::MessageDifferencer::Equals(mode_override, other);
+            // Ignore matching on request_header_mode as it's not applicable.
+            return mode_override.request_body_mode() == other.request_body_mode() &&
+                   mode_override.request_trailer_mode() == other.request_trailer_mode() &&
+                   mode_override.response_header_mode() == other.response_header_mode() &&
+                   mode_override.response_body_mode() == other.response_body_mode() &&
+                   mode_override.response_trailer_mode() == other.response_trailer_mode();
           });
     }
 

--- a/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
+++ b/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
@@ -5340,4 +5340,38 @@ TEST_P(ExtProcIntegrationTest, ModeOverrideDisallowed) {
   verifyDownstreamResponse(*response, 200);
 }
 
+TEST_P(ExtProcIntegrationTest, RequestHeaderModeIgnoredInModeOverrideComparison) {
+  proto_config_.mutable_processing_mode()->set_request_body_mode(ProcessingMode::STREAMED);
+  proto_config_.mutable_processing_mode()->set_response_header_mode(ProcessingMode::SKIP);
+  proto_config_.set_allow_mode_override(true);
+  // Configure mode override allow list.
+  auto* added_mode = proto_config_.add_allowed_override_modes();
+  added_mode->set_request_header_mode(ProcessingMode::SEND);
+  added_mode->set_request_body_mode(ProcessingMode::BUFFERED);
+  initializeConfig();
+  HttpIntegrationTest::initialize();
+
+  std::string body_str = std::string(10, 'a');
+  auto response = sendDownstreamRequestWithBody(body_str, absl::nullopt);
+
+  // Process request header message.
+  processGenericMessage(
+      *grpc_upstreams_[0], true, [](const ProcessingRequest&, ProcessingResponse& resp) {
+        resp.mutable_request_headers();
+        // request_header_mode doesn't match the only allowed_overide_modes element, but it's fine.
+        resp.mutable_mode_override()->set_request_header_mode(ProcessingMode::SKIP);
+        resp.mutable_mode_override()->set_request_body_mode(ProcessingMode::BUFFERED);
+        return true;
+      });
+
+  // ext_proc server still receive the body message even though request header mode override doesn't
+  // match the only allowed mode's request_header_mode.
+  processRequestBodyMessage(*grpc_upstreams_[0], false, [](const HttpBody& body, BodyResponse&) {
+    EXPECT_TRUE(body.end_of_stream());
+    return true;
+  });
+  handleUpstreamRequest();
+  verifyDownstreamResponse(*response, 200);
+}
+
 } // namespace Envoy


### PR DESCRIPTION
Commit Message: ignore request_header_mode in mode override comparison, it's not applicable in anyway, but it does interfere mode matching if allowed_override_modes is configured.

Additional Description: This is a sister PR of #38254, let's simply ignore the request_header_mode in mode comparison as it's not applicable. OTOH, it does introduce confusion in allowed_override_modes comparison. 

Risk Level: LOW.
Testing: unit test
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
