### PR TITLE
factory context: extend ServerFactoryContext with getTransportSocketFactoryContext

### DIFF
--- a/envoy/server/factory_context.h
+++ b/envoy/server/factory_context.h
@@ -184,6 +184,11 @@ public:
   virtual ProcessContextOptRef processContext() PURE;
 
   /**
+   * @return TransportSocketFactoryContext which lifetime is no shorter than the server.
+   */
+  virtual TransportSocketFactoryContext& getTransportSocketFactoryContext() const PURE;
+
+  /**
    * @return the init manager of the cluster. This can be used for extensions that need
    *         to initialize after cluster manager init but before the server starts listening.
    *         All extensions should register themselves during configuration load. initialize()

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -188,6 +188,9 @@ public:
   ProtobufMessage::ValidationContext& messageValidationContext() override {
     return server_.messageValidationContext();
   }
+  TransportSocketFactoryContext& getTransportSocketFactoryContext() const override {
+    return server_.transportSocketFactoryContext();
+  };
   Envoy::Runtime::Loader& runtime() override { return server_.runtime(); }
   Stats::Scope& scope() override { return *server_scope_; }
   Stats::Scope& serverScope() override { return *server_scope_; }

--- a/test/mocks/server/server_factory_context.cc
+++ b/test/mocks/server/server_factory_context.cc
@@ -30,6 +30,7 @@ MockServerFactoryContext::MockServerFactoryContext()
   ON_CALL(*this, messageValidationVisitor())
       .WillByDefault(ReturnRef(ProtobufMessage::getStrictValidationVisitor()));
   ON_CALL(*this, api()).WillByDefault(ReturnRef(api_));
+  ON_CALL(*this, getTransportSocketFactoryContext()).WillByDefault(ReturnRef(*transport_socket_factory_context_));
   ON_CALL(*this, drainManager()).WillByDefault(ReturnRef(drain_manager_));
   ON_CALL(*this, statsConfig()).WillByDefault(ReturnRef(stats_config_));
   ON_CALL(*this, accessLogManager()).WillByDefault(ReturnRef(access_log_manager_));

--- a/test/mocks/server/server_factory_context.cc
+++ b/test/mocks/server/server_factory_context.cc
@@ -30,7 +30,6 @@ MockServerFactoryContext::MockServerFactoryContext()
   ON_CALL(*this, messageValidationVisitor())
       .WillByDefault(ReturnRef(ProtobufMessage::getStrictValidationVisitor()));
   ON_CALL(*this, api()).WillByDefault(ReturnRef(api_));
-  ON_CALL(*this, getTransportSocketFactoryContext()).WillByDefault(ReturnRef(*transport_socket_factory_context_));
   ON_CALL(*this, drainManager()).WillByDefault(ReturnRef(drain_manager_));
   ON_CALL(*this, statsConfig()).WillByDefault(ReturnRef(stats_config_));
   ON_CALL(*this, accessLogManager()).WillByDefault(ReturnRef(access_log_manager_));

--- a/test/mocks/server/server_factory_context.h
+++ b/test/mocks/server/server_factory_context.h
@@ -75,7 +75,8 @@ public:
   MOCK_METHOD(ProtobufMessage::ValidationContext&, messageValidationContext, ());
   MOCK_METHOD(ProtobufMessage::ValidationVisitor&, messageValidationVisitor, ());
   MOCK_METHOD(Api::Api&, api, ());
-  MOCK_METHOD(TransportSocketFactoryContext&, getTransportSocketFactoryContext, (), (const, override));
+  MOCK_METHOD(TransportSocketFactoryContext&, getTransportSocketFactoryContext, (),
+              (const, override));
   Http::Context& httpContext() override { return http_context_; }
   Grpc::Context& grpcContext() override { return grpc_context_; }
   Router::Context& routerContext() override { return router_context_; }
@@ -162,7 +163,8 @@ public:
   MOCK_METHOD(ProtobufMessage::ValidationContext&, messageValidationContext, ());
   MOCK_METHOD(ProtobufMessage::ValidationVisitor&, messageValidationVisitor, ());
   MOCK_METHOD(Api::Api&, api, ());
-  MOCK_METHOD(TransportSocketFactoryContext&, getTransportSocketFactoryContext, (), (const, override));
+  MOCK_METHOD(TransportSocketFactoryContext&, getTransportSocketFactoryContext, (),
+              (const, override));
   MOCK_METHOD(Http::Context&, httpContext, ());
   MOCK_METHOD(Grpc::Context&, grpcContext, ());
   MOCK_METHOD(Router::Context&, routerContext, ());

--- a/test/mocks/server/server_factory_context.h
+++ b/test/mocks/server/server_factory_context.h
@@ -75,6 +75,7 @@ public:
   MOCK_METHOD(ProtobufMessage::ValidationContext&, messageValidationContext, ());
   MOCK_METHOD(ProtobufMessage::ValidationVisitor&, messageValidationVisitor, ());
   MOCK_METHOD(Api::Api&, api, ());
+  MOCK_METHOD(TransportSocketFactoryContext&, getTransportSocketFactoryContext, (), (const));
   Http::Context& httpContext() override { return http_context_; }
   Grpc::Context& grpcContext() override { return grpc_context_; }
   Router::Context& routerContext() override { return router_context_; }
@@ -95,6 +96,7 @@ public:
   testing::NiceMock<Upstream::MockClusterManager> cluster_manager_;
   testing::NiceMock<Event::MockDispatcher> dispatcher_;
   testing::NiceMock<MockDrainManager> drain_manager_;
+  TransportSocketFactoryContext* transport_socket_factory_context_;
   testing::NiceMock<LocalInfo::MockLocalInfo> local_info_;
   testing::NiceMock<Envoy::Runtime::MockLoader> runtime_loader_;
   testing::NiceMock<Stats::MockIsolatedStatsStore> store_;
@@ -165,6 +167,7 @@ public:
   MOCK_METHOD(Grpc::Context&, grpcContext, ());
   MOCK_METHOD(Router::Context&, routerContext, ());
   MOCK_METHOD(ProcessContextOptRef, processContext, ());
+  MOCK_METHOD(TransportSocketFactoryContext&, getTransportSocketFactoryContext, (), (const));
   MOCK_METHOD(envoy::config::bootstrap::v3::Bootstrap&, bootstrap, ());
   MOCK_METHOD(Server::DrainManager&, drainManager, ());
   MOCK_METHOD(Init::Manager&, initManager, ());

--- a/test/mocks/server/server_factory_context.h
+++ b/test/mocks/server/server_factory_context.h
@@ -75,7 +75,7 @@ public:
   MOCK_METHOD(ProtobufMessage::ValidationContext&, messageValidationContext, ());
   MOCK_METHOD(ProtobufMessage::ValidationVisitor&, messageValidationVisitor, ());
   MOCK_METHOD(Api::Api&, api, ());
-  MOCK_METHOD(TransportSocketFactoryContext&, getTransportSocketFactoryContext, (), (const));
+  MOCK_METHOD(TransportSocketFactoryContext&, getTransportSocketFactoryContext, (), (const, override));
   Http::Context& httpContext() override { return http_context_; }
   Grpc::Context& grpcContext() override { return grpc_context_; }
   Router::Context& routerContext() override { return router_context_; }
@@ -96,7 +96,6 @@ public:
   testing::NiceMock<Upstream::MockClusterManager> cluster_manager_;
   testing::NiceMock<Event::MockDispatcher> dispatcher_;
   testing::NiceMock<MockDrainManager> drain_manager_;
-  TransportSocketFactoryContext* transport_socket_factory_context_;
   testing::NiceMock<LocalInfo::MockLocalInfo> local_info_;
   testing::NiceMock<Envoy::Runtime::MockLoader> runtime_loader_;
   testing::NiceMock<Stats::MockIsolatedStatsStore> store_;
@@ -167,7 +166,6 @@ public:
   MOCK_METHOD(Grpc::Context&, grpcContext, ());
   MOCK_METHOD(Router::Context&, routerContext, ());
   MOCK_METHOD(ProcessContextOptRef, processContext, ());
-  MOCK_METHOD(TransportSocketFactoryContext&, getTransportSocketFactoryContext, (), (const));
   MOCK_METHOD(envoy::config::bootstrap::v3::Bootstrap&, bootstrap, ());
   MOCK_METHOD(Server::DrainManager&, drainManager, ());
   MOCK_METHOD(Init::Manager&, initManager, ());

--- a/test/mocks/server/server_factory_context.h
+++ b/test/mocks/server/server_factory_context.h
@@ -162,6 +162,7 @@ public:
   MOCK_METHOD(ProtobufMessage::ValidationContext&, messageValidationContext, ());
   MOCK_METHOD(ProtobufMessage::ValidationVisitor&, messageValidationVisitor, ());
   MOCK_METHOD(Api::Api&, api, ());
+  MOCK_METHOD(TransportSocketFactoryContext&, getTransportSocketFactoryContext, (), (const, override));
   MOCK_METHOD(Http::Context&, httpContext, ());
   MOCK_METHOD(Grpc::Context&, grpcContext, ());
   MOCK_METHOD(Router::Context&, routerContext, ());


### PR DESCRIPTION
Commit Message: factory context: extend ServerFactoryContext with getTransportSocketFactoryContext
Additional Description: This change is necessary to allow upstream filters reading secrets from SDS.
Risk Level: low
Testing: -
Docs Changes: Not needed as it is only an internal change.
Release Notes: Not needed as it is only an internal change.
Platform Specific Features: -

This change is necessary to unblock:
1. injecting credentials to upstream requests #38398
2. reading image pull secret by upstream wasm filters #37635