### PR TITLE
Build Envoy with aws_lc on Power (ppc64le)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ positively or negatively.
 
 For further details please see our complete [security release process](SECURITY.md).
 
+### ppc64le builds
+
+Builds for the ppc64le architecture or using aws-lc are not covered by the envoy security policy. The ppc64le architecture is currently best-effort and not maintained by the Envoy maintainers.
+
 ## Releases
 
 For further details please see our [release process](https://github.com/envoyproxy/envoy/blob/main/RELEASES.md).

--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -311,6 +311,22 @@ selects.config_setting_group(
 )
 
 selects.config_setting_group(
+    name = "disable_http3_on_linux_ppc64le",
+    match_all = [
+        ":disable_http3",
+        ":linux_ppc64le",
+    ],
+)
+
+selects.config_setting_group(
+    name = "disable_http3_on_not_x86_ppc",
+    match_all = [
+        ":disable_http3",
+        ":not_x86_ppc",
+    ],
+)
+
+selects.config_setting_group(
     name = "disable_http3_on_windows_x86_64",
     match_all = [
         ":disable_http3",
@@ -349,6 +365,14 @@ selects.config_setting_group(
     match_all = [
         ":enable_http3",
         ":linux_ppc",
+    ],
+)
+
+selects.config_setting_group(
+    name = "enable_http3_on_linux_ppc64le",
+    match_all = [
+        ":enable_http3",
+        ":linux_ppc64le",
     ],
 )
 
@@ -503,6 +527,14 @@ selects.config_setting_group(
     ],
 )
 
+selects.config_setting_group(
+    name = "boringssl_fips_ppc",
+    match_all = [
+        ":boringssl_fips",
+        ":linux_ppc64le",
+    ],
+)
+
 config_setting(
     name = "zlib_ng",
     constraint_values = [
@@ -544,10 +576,12 @@ config_setting(
 # Alias pointing to the selected version of BoringSSL:
 # - BoringSSL FIPS from @boringssl_fips//:ssl,
 # - non-FIPS BoringSSL from @boringssl//:ssl.
+# - aws-lc from @aws_lc//:ssl
 alias(
     name = "boringssl",
     actual = select({
-        "//bazel:boringssl_fips": "@boringssl_fips//:ssl",
+        "//bazel:boringssl_fips_ppc": "@aws_lc//:ssl",
+        "//bazel:boringssl_fips_x86": "@boringssl_fips//:ssl",
         "//conditions:default": "@boringssl//:ssl",
     }),
 )
@@ -555,7 +589,8 @@ alias(
 alias(
     name = "boringcrypto",
     actual = select({
-        "//bazel:boringssl_fips": "@boringssl_fips//:crypto",
+        "//bazel:boringssl_fips_ppc": "@aws_lc//:crypto",
+        "//bazel:boringssl_fips_x86": "@boringssl_fips//:crypto",
         "//conditions:default": "@boringssl//:crypto",
     }),
 )
@@ -580,6 +615,14 @@ config_setting(
     name = "linux_ppc",
     constraint_values = [
         "@platforms//cpu:ppc",
+        "@platforms//os:linux",
+    ],
+)
+
+config_setting(
+    name = "linux_ppc64le",
+    constraint_values = [
+        "@platforms//cpu:ppc64le",
         "@platforms//os:linux",
     ],
 )
@@ -794,6 +837,22 @@ selects.config_setting_group(
 )
 
 selects.config_setting_group(
+    name = "not_x86_ppc",
+    match_any = [
+        ":darwin_arm64",
+        ":ios_arm64",
+        ":ios_arm64e",
+        ":ios_armv7",
+        ":ios_armv7s",
+        ":ios_i386",
+        ":ios_sim_arm64",
+        ":linux_aarch64",
+        ":linux_mips64",
+        ":linux_s390x",
+    ],
+)
+
+selects.config_setting_group(
     name = "not_x86",
     match_any = [
         ":darwin_arm64",
@@ -806,6 +865,7 @@ selects.config_setting_group(
         ":linux_aarch64",
         ":linux_mips64",
         ":linux_ppc",
+        ":linux_ppc64le",
         ":linux_s390x",
     ],
 )

--- a/bazel/external/BUILD
+++ b/bazel/external/BUILD
@@ -1,6 +1,6 @@
 licenses(["notice"])  # Apache 2
 
-exports_files(["boringssl_fips.genrule_cmd"])
+exports_files(["boringssl_fips.genrule_cmd", "aws_lc.genrule_cmd"])
 
 # Use a wrapper cc_library with an empty source source file to force
 # compilation of other cc_library targets that only list *.a sources.

--- a/bazel/external/BUILD
+++ b/bazel/external/BUILD
@@ -1,6 +1,9 @@
 licenses(["notice"])  # Apache 2
 
-exports_files(["boringssl_fips.genrule_cmd", "aws_lc.genrule_cmd"])
+exports_files([
+    "aws_lc.genrule_cmd",
+    "boringssl_fips.genrule_cmd",
+])
 
 # Use a wrapper cc_library with an empty source source file to force
 # compilation of other cc_library targets that only list *.a sources.

--- a/bazel/external/aws_lc.BUILD
+++ b/bazel/external/aws_lc.BUILD
@@ -1,0 +1,34 @@
+licenses(["notice"])  # Apache 2
+
+cc_library(
+    name = "crypto",
+    srcs = [
+        "crypto/libcrypto.a",
+    ],
+    hdrs = glob(["include/openssl/*.h"]),
+    defines = ["BORINGSSL_FIPS"],
+    includes = ["include"],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "ssl",
+    srcs = [
+        "ssl/libssl.a",
+    ],
+    hdrs = glob(["include/openssl/*.h"]),
+    includes = ["include"],
+    visibility = ["//visibility:public"],
+    deps = [":crypto"],
+)
+
+genrule(
+    name = "build",
+    srcs = glob(["**"]),
+    outs = [
+        "crypto/libcrypto.a",
+        "ssl/libssl.a",
+    ],
+    cmd = "$(location {}) $(location crypto/libcrypto.a) $(location ssl/libssl.a)".format("@envoy//bazel/external:aws_lc.genrule_cmd"),
+    tools = ["@envoy//bazel/external:aws_lc.genrule_cmd"],
+)

--- a/bazel/external/aws_lc.genrule_cmd
+++ b/bazel/external/aws_lc.genrule_cmd
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+
+set -e
+
+export CXXFLAGS=''
+export LDFLAGS=''
+
+# BoringSSL build as described in the Security Policy for BoringCrypto module (2022-05-06):
+# https://csrc.nist.gov/CSRC/media/projects/cryptographic-module-validation-program/documents/security-policies/140sp4407.pdf
+
+OS=`uname`
+ARCH=`uname -m`
+# This works only on Linux-x86_64, Linux-ppc64le, and Linux-aarch64.
+
+if [[ "$OS" != "Linux" || ("$ARCH" != "x86_64" && "$ARCH" != "aarch64" && "$ARCH" != "ppc64le") ]]; then
+  echo "ERROR: AWS-LC FIPS is currently supported only on Linux-x86_64, Linux-ppc64le, and Linux-aarch64."
+  exit 1
+fi
+
+
+# Bazel magic.
+# ROOT=$(dirname $(rootpath boringssl/BUILDING.md))/..
+ROOT=./external
+pushd "$ROOT"
+
+# Build tools requirements (from section 12.1 of https://csrc.nist.gov/CSRC/media/projects/cryptographic-module-validation-program/documents/security-policies/140sp4407.pdf):
+# - Clang compiler version 12.0.0 (https://releases.llvm.org/download.html)
+# - Go programming language version 1.16.5 (https://golang.org/dl/)
+# - Ninja build system version 1.10.2 (https://github.com/ninja-build/ninja/releases)
+# - Cmake version 3.20.1 (https://cmake.org/download/)
+
+# Override $PATH for build tools, to avoid picking up anything else.
+export PATH="$(dirname `which cmake`):/usr/bin:/bin"
+
+# Clang
+VERSION=14.0.0
+if [[ "$ARCH" == "x86_64" ]]; then
+  PLATFORM="x86_64-linux-gnu-ubuntu-20.04"
+  SHA256=61582215dafafb7b576ea30cc136be92c877ba1f1c31ddbbd372d6d65622fef5
+elif [[ "$ARCH" == "ppc64le" ]]; then
+  PLATFORM="powerpc64le-linux-ubuntu-18.04"
+  SHA256=2d504c4920885c86b306358846178bc2232dfac83b47c3b1d05861a8162980e6
+else
+  PLATFORM="aarch64-linux-gnu"
+  SHA256=1792badcd44066c79148ffeb1746058422cc9d838462be07e3cb19a4b724a1ee
+fi
+
+curl -sLO https://github.com/llvm/llvm-project/releases/download/llvmorg-"$VERSION"/clang+llvm-"$VERSION"-"$PLATFORM".tar.xz
+tar xf clang+llvm-"$VERSION"-"$PLATFORM".tar.xz
+
+export HOME="$PWD"
+printf "set(CMAKE_C_COMPILER \"clang\")\nset(CMAKE_CXX_COMPILER \"clang++\")\n" > ${HOME}/toolchain
+export PATH="$PWD/clang+llvm-$VERSION-$PLATFORM/bin:$PATH"
+
+if [[ `clang --version | head -1 | awk '{print $3}'` != "$VERSION" ]]; then
+  echo "ERROR: Clang version doesn't match. Expected: ${VERSION}, Got: $(clang --version)"
+  exit 1
+fi
+
+# Go
+VERSION=1.18.1
+if [[ "$ARCH" == "x86_64" ]]; then
+  PLATFORM="linux-amd64"
+  SHA256=b3b815f47ababac13810fc6021eb73d65478e0b2db4b09d348eefad9581a2334
+elif [[ "$ARCH" == "ppc64le" ]]; then
+	PLATFORM="linux-ppc64le"
+	SHA256=33db623d1eecf362fe365107c12efc90eff0b9609e0b3345e258388019cb552a
+else
+  PLATFORM="linux-arm64"
+  SHA256=56a91851c97fb4697077abbca38860f735c32b38993ff79b088dac46e4735633
+fi
+
+curl -sLO https://dl.google.com/go/go"$VERSION"."$PLATFORM".tar.gz \
+  && echo "$SHA256" go"$VERSION"."$PLATFORM".tar.gz | sha256sum --check
+tar xf go"$VERSION"."$PLATFORM".tar.gz
+
+export GOPATH="$PWD/gopath"
+export GOROOT="$PWD/go"
+export PATH="$GOPATH/bin:$GOROOT/bin:$PATH"
+
+if [[ `go version | awk '{print $3}'` != "go$VERSION" ]]; then
+  echo "ERROR: Go version doesn't match."
+  exit 1
+fi
+
+# Ninja
+VERSION=1.10.2
+SHA256=ce35865411f0490368a8fc383f29071de6690cbadc27704734978221f25e2bed
+curl -sLO https://github.com/ninja-build/ninja/archive/refs/tags/v"$VERSION".tar.gz \
+  && echo "$SHA256" v"$VERSION".tar.gz | sha256sum --check
+tar -xvf v"$VERSION".tar.gz
+cd ninja-"$VERSION"
+python3 ./configure.py --bootstrap
+
+export PATH="$PWD:$PATH"
+
+if [[ `ninja --version` != "$VERSION" ]]; then
+  echo "ERROR: Ninja version doesn't match."
+  exit 1
+fi
+cd ..
+
+# CMake
+VERSION=3.22.1
+if [[ "$ARCH" != "ppc64le" ]]; then
+	if [[ "$ARCH" == "x86_64" ]]; then
+		PLATFORM="linux-x86_64"
+		SHA256=73565c72355c6652e9db149249af36bcab44d9d478c5546fd926e69ad6b43640
+	else
+		PLATFORM="linux-aarch64"
+		SHA256=601443375aa1a48a1a076bda7e3cca73af88400463e166fffc3e1da3ce03540b
+	fi
+
+	curl -sLO https://github.com/Kitware/CMake/releases/download/v"$VERSION"/cmake-"$VERSION"-"$PLATFORM".tar.gz \
+		&& echo "$SHA256" cmake-"$VERSION"-"$PLATFORM".tar.gz | sha256sum --check
+	tar xf cmake-"$VERSION"-"$PLATFORM".tar.gz
+	export PATH="$PWD/cmake-$VERSION-$PLATFORM/bin:$PATH"
+else
+	PLATFORM="linux-ppc64le"
+	echo "Building cmake for ppc64le"
+
+	curl -sL -o cmake-$VERSION-$PLATFORM.tar.gz https://github.com/Kitware/CMake/releases/download/v"$VERSION"/cmake-"$VERSION".tar.gz
+	tar xf cmake-"$VERSION"-"$PLATFORM".tar.gz
+
+  cd cmake-"$VERSION"
+  ./bootstrap && make
+  export PATH="$PWD/bin:$PATH"
+  cd ..
+fi
+
+if [[ `cmake --version | head -n1` != "cmake version $VERSION" ]]; then
+  echo "PATH: $PATH"
+  echo "PLATFORM: $PLATFORM"
+  echo "ERROR: CMake version doesn't match. Expected: ${VERSION}, Got: $(cmake --version | head -n1)"
+  exit 1
+fi
+
+echo "Cmake installed successfully"
+echo "PWD: $PWD"
+
+# Clean after previous build.
+rm -rf aws_lc/build
+
+# Build BoringSSL.
+cd aws_lc
+
+# Setting -fPIC only affects the compilation of the non-module code in libcrypto.a,
+# because the FIPS module itself is already built with -fPIC.
+mkdir build && cd build && cmake -GNinja -DCMAKE_TOOLCHAIN_FILE=${HOME}/toolchain -DFIPS=1 -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS="-fPIC" -DCMAKE_CXX_FLAGS="-fPIC" ..
+ninja
+export GTEST_FILTER="-SSLTest.HostMatching"
+#ninja run_tests
+./crypto/crypto_test
+
+echo "created build directory and built aws_lc with ninja"
+
+# Verify correctness of the FIPS build.
+if [[ `tool/bssl isfips` != "1" ]]; then
+  echo "ERROR: BoringSSL tool didn't report FIPS build."
+  exit 1
+fi
+
+# Move compiled libraries to the expected destinations.
+popd
+mv $ROOT/aws_lc/build/crypto/libcrypto.a $1
+mv $ROOT/aws_lc/build/ssl/libssl.a $2

--- a/bazel/protobuf.patch
+++ b/bazel/protobuf.patch
@@ -1,8 +1,8 @@
 diff --git a/BUILD.bazel b/BUILD.bazel
-index 32b26cbdc..e28b8e387 100644
+index 32b26cbdc..a5e7a554c 100644
 --- a/BUILD.bazel
 +++ b/BUILD.bazel
-@@ -229,14 +229,79 @@ alias(
+@@ -229,14 +229,88 @@ alias(
      visibility = ["//visibility:public"],
  )
  
@@ -31,6 +31,14 @@ index 32b26cbdc..e28b8e387 100644
 +    constraint_values = [
 +        "@platforms//os:linux",
 +        "@platforms//cpu:x86_64",
++    ],
++)
++
++config_setting(
++    name = "linux-ppcle_64",
++    constraint_values = [
++	"@platforms//os:linux",
++	"@platforms//cpu:ppc64le",
 +    ],
 +)
 +
@@ -64,6 +72,7 @@ index 32b26cbdc..e28b8e387 100644
 +    actual = select({
 +        ":linux-aarch_64": "@com_google_protobuf_protoc_linux_aarch_64//:protoc",
 +        ":linux-x86_64": "@com_google_protobuf_protoc_linux_x86_64//:protoc",
++        ":linux-ppcle_64": "@com_google_protobuf_protoc_linux_ppcle_64//:protoc",
 +        ":osx-aarch_64": "@com_google_protobuf_protoc_osx_aarch_64//:protoc",
 +        ":osx-x86_64": "@com_google_protobuf_protoc_osx_x86_64//:protoc",
 +        ":win64": "@com_google_protobuf_protoc_win64//:protoc",

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -111,7 +111,7 @@ def _go_deps(skip_targets):
 def _rust_deps():
     external_http_archive(
         "rules_rust",
-        patches = ["@envoy//bazel:rules_rust.patch"],
+        patches = ["@envoy//bazel:rules_rust.patch", "@envoy//bazel:rules_rust_ppc64le.patch"],
     )
 
 def envoy_dependencies(skip_targets = []):
@@ -134,6 +134,7 @@ def envoy_dependencies(skip_targets = []):
     # - non-FIPS BoringSSL from @boringssl//:ssl.
     _boringssl()
     _boringssl_fips()
+    _aws_lc()
     native.bind(
         name = "ssl",
         actual = "@envoy//bazel:boringssl",
@@ -266,6 +267,12 @@ def _boringssl_fips():
     external_http_archive(
         name = "boringssl_fips",
         build_file = "@envoy//bazel/external:boringssl_fips.BUILD",
+    )
+
+def _aws_lc():
+    external_http_archive(
+        name = "aws_lc",
+        build_file = "@envoy//bazel/external:aws_lc.BUILD",
     )
 
 def _com_github_openhistogram_libcircllhist():
@@ -620,7 +627,9 @@ def _com_google_protobuf():
     external_http_archive(
         name = "rules_java",
         patch_args = ["-p1"],
-        patches = ["@envoy//bazel:rules_java.patch"],
+        patches = [
+            "@envoy//bazel:rules_java.patch",
+        ],
     )
 
     for platform in PROTOC_VERSIONS:
@@ -715,6 +724,7 @@ def _v8():
         patches = [
             "@envoy//bazel:v8.patch",
             "@envoy//bazel:v8_include.patch",
+            "@envoy//bazel:v8_ppc64le.patch",
         ],
         patch_args = ["-p1"],
     )

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -10,6 +10,7 @@ PROTOBUF_VERSION = "29.3"
 PROTOC_VERSIONS = dict(
     linux_aarch_64 = "6427349140e01f06e049e707a58709a4f221ae73ab9a0425bc4a00c8d0e1ab32",
     linux_x86_64 = "3e866620c5be27664f3d2fa2d656b5f3e09b5152b42f1bedbf427b333e90021a",
+    linux_ppcle_64 = "0e9894ec2e3992b14d183e7ceac16465d6a6ee73e1d234695d80e6d1e947014c",
     osx_aarch_64 = "2b8a3403cd097f95f3ba656e14b76c732b6b26d7f183330b11e36ef2bc028765",
     osx_x86_64 = "9a788036d8f9854f7b03c305df4777cf0e54e5b081e25bf15252da87e0e90875",
     win64 = "57ea59e9f551ad8d71ffaa9b5cfbe0ca1f4e720972a1db7ec2d12ab44bff9383",
@@ -161,6 +162,18 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         urls = ["https://commondatastorage.googleapis.com/chromium-boringssl-fips/boringssl-0c6f40132b828e92ba365c6b7680e32820c63fa7.tar.xz"],
         use_category = ["controlplane", "dataplane_core"],
         release_date = "2022-06-13",
+        cpe = "cpe:2.3:a:google:boringssl:*",
+    ),
+    aws_lc = dict(
+        project_name = "AWS libcrypto (AWS-LC)",
+        project_desc = "OpenSSL compatible general-purpose crypto library",
+        project_url = "https://github.com/aws/aws-lc",
+        version = "e7bd0732f4287f1ff974b6c78ee0e8873a0b586d",
+        sha256 = "e32769bf19e17d8bf6d65238ef2925732daeb92cfe362aa347352bbbd97bf622",
+        strip_prefix = "aws-lc-{version}",
+        urls = ["https://github.com/aws/aws-lc/archive/{version}.tar.gz"],
+        use_category = ["controlplane", "dataplane_core"],
+        release_date = "2025-02-05",
         cpe = "cpe:2.3:a:google:boringssl:*",
     ),
     aspect_bazel_lib = dict(

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -173,7 +173,7 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         strip_prefix = "aws-lc-{version}",
         urls = ["https://github.com/aws/aws-lc/archive/{version}.tar.gz"],
         use_category = ["controlplane", "dataplane_core"],
-        release_date = "2025-02-05",
+        release_date = "2025-02-06",
         cpe = "cpe:2.3:a:google:boringssl:*",
     ),
     aspect_bazel_lib = dict(

--- a/bazel/rules_java_ppc64le.patch
+++ b/bazel/rules_java_ppc64le.patch
@@ -1,0 +1,75 @@
+diff --git a/MODULE.bazel b/MODULE.bazel
+index 801721a..b0c10dd 100644
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -5,7 +5,7 @@ module(
+     compatibility_level = 1,
+ )
+ 
+-bazel_dep(name = "platforms", version = "0.0.4")
++bazel_dep(name = "platforms", version = "0.0.11")
+ bazel_dep(name = "rules_cc", version = "0.0.10")
+ bazel_dep(name = "bazel_features", version = "1.11.0")
+ bazel_dep(name = "bazel_skylib", version = "1.6.1")
+diff --git a/java/bazel/repositories_util.bzl b/java/bazel/repositories_util.bzl
+index 7e9efbd..aaf0f1b 100644
+--- a/java/bazel/repositories_util.bzl
++++ b/java/bazel/repositories_util.bzl
+@@ -44,7 +44,7 @@ _RELEASE_CONFIGS = {
+         "adoptium": {
+             "release": "11.0.15+10",
+             "platforms": {
+-                "linux": ["ppc", "s390x"],
++                "linux": ["ppc", "ppc64le", "s390x"],
+             },
+         },
+         "microsoft": {
+@@ -66,7 +66,7 @@ _RELEASE_CONFIGS = {
+         "adoptium": {
+             "release": "17.0.8.1+1",
+             "platforms": {
+-                "linux": ["ppc", "s390x"],
++                "linux": ["ppc", "ppc64le", "s390x"],
+             },
+         },
+     },
+@@ -82,7 +82,7 @@ _RELEASE_CONFIGS = {
+         "adoptium": {
+             "release": "21.0.4+7",
+             "platforms": {
+-                "linux": ["ppc", "s390x"],
++                "linux": ["ppc", "ppc64le", "s390x"],
+             },
+         },
+     },
+diff --git a/java/repositories.bzl b/java/repositories.bzl
+index 27f4f85..f3ca8ac 100644
+--- a/java/repositories.bzl
++++ b/java/repositories.bzl
+@@ -166,7 +166,7 @@ _REMOTE_JDK_CONFIGS_LIST = [
+     ),
+     struct(
+         name = "remotejdk11_linux_ppc64le",
+-        target_compatible_with = ["@platforms//os:linux", "@platforms//cpu:ppc"],
++        target_compatible_with = ["@platforms//os:linux", "@platforms//cpu:ppc64le"],
+         sha256 = "a8fba686f6eb8ae1d1a9566821dbd5a85a1108b96ad857fdbac5c1e4649fc56f",
+         strip_prefix = "jdk-11.0.15+10",
+         urls = ["https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.15+10/OpenJDK11U-jdk_ppc64le_linux_hotspot_11.0.15_10.tar.gz", "https://mirror.bazel.build/github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.15+10/OpenJDK11U-jdk_ppc64le_linux_hotspot_11.0.15_10.tar.gz"],
+@@ -238,7 +238,7 @@ _REMOTE_JDK_CONFIGS_LIST = [
+     ),
+     struct(
+         name = "remotejdk17_linux_ppc64le",
+-        target_compatible_with = ["@platforms//os:linux", "@platforms//cpu:ppc"],
++        target_compatible_with = ["@platforms//os:linux", "@platforms//cpu:ppc64le"],
+         sha256 = "00a4c07603d0218cd678461b5b3b7e25b3253102da4022d31fc35907f21a2efd",
+         strip_prefix = "jdk-17.0.8.1+1",
+         urls = ["https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.8.1+1/OpenJDK17U-jdk_ppc64le_linux_hotspot_17.0.8.1_1.tar.gz", "https://mirror.bazel.build/github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.8.1+1/OpenJDK17U-jdk_ppc64le_linux_hotspot_17.0.8.1_1.tar.gz"],
+@@ -302,7 +302,7 @@ _REMOTE_JDK_CONFIGS_LIST = [
+     ),
+     struct(
+         name = "remotejdk21_linux_ppc64le",
+-        target_compatible_with = ["@platforms//os:linux", "@platforms//cpu:ppc"],
++        target_compatible_with = ["@platforms//os:linux", "@platforms//cpu:ppc64le"],
+         sha256 = "c208cd0fb90560644a90f928667d2f53bfe408c957a5e36206585ad874427761",
+         strip_prefix = "jdk-21.0.4+7",
+         urls = ["https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.4+7/OpenJDK21U-jdk_ppc64le_linux_hotspot_21.0.4_7.tar.gz", "https://mirror.bazel.build/github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.4+7/OpenJDK21U-jdk_ppc64le_linux_hotspot_21.0.4_7.tar.gz"],

--- a/bazel/rules_rust_ppc64le.patch
+++ b/bazel/rules_rust_ppc64le.patch
@@ -1,0 +1,61 @@
+diff --git MODULE.bazel MODULE.bazel
+index 225ff331..e4d5ba86 100644
+--- MODULE.bazel
++++ MODULE.bazel
+@@ -19,7 +19,7 @@ bazel_dep(
+ )
+ bazel_dep(
+     name = "platforms",
+-    version = "0.0.10",
++    version = "0.0.11",
+ )
+ bazel_dep(
+     name = "rules_cc",
+diff --git rust/platform/triple.bzl rust/platform/triple.bzl
+index 096ec5ef..9717b23a 100644
+--- rust/platform/triple.bzl
++++ rust/platform/triple.bzl
+@@ -117,7 +117,7 @@ def get_host_triple(repository_ctx, abi = None):
+     # Detect the host's cpu architecture
+ 
+     supported_architectures = {
+-        "linux": ["aarch64", "x86_64", "s390x"],
++        "linux": ["aarch64", "x86_64", "s390x", "powerpc64le"],
+         "macos": ["aarch64", "x86_64"],
+         "windows": ["aarch64", "x86_64"],
+     }
+@@ -126,6 +126,9 @@ def get_host_triple(repository_ctx, abi = None):
+     if arch == "amd64":
+         arch = "x86_64"
+ 
++    if arch == "ppc64le":
++        arch = "powerpc64le"
++
+     if "linux" in repository_ctx.os.name:
+         _validate_cpu_architecture(arch, supported_architectures["linux"])
+         return triple("{}-unknown-linux-{}".format(
+diff --git rust/platform/triple_mappings.bzl rust/platform/triple_mappings.bzl
+index b436af3a..20f02e37 100644
+--- rust/platform/triple_mappings.bzl
++++ rust/platform/triple_mappings.bzl
+@@ -112,7 +112,7 @@ _CPU_ARCH_TO_BUILTIN_PLAT_SUFFIX = {
+     "mipsel": None,
+     "powerpc": "ppc",
+     "powerpc64": None,
+-    "powerpc64le": None,
++    "powerpc64le": "ppc64le",
+     "riscv32": "riscv32",
+     "riscv32imc": "riscv32",
+     "riscv64": "riscv64",
+diff --git rust/repositories.bzl rust/repositories.bzl
+index 06de237d..3d24925b 100644
+--- rust/repositories.bzl
++++ rust/repositories.bzl
+@@ -41,6 +41,7 @@ DEFAULT_TOOLCHAIN_TRIPLES = {
+     "aarch64-pc-windows-msvc": "rust_windows_aarch64",
+     "aarch64-unknown-linux-gnu": "rust_linux_aarch64",
+     "s390x-unknown-linux-gnu": "rust_linux_s390x",
++    "powerpc64le-unknown-linux-gnu": "rust_linux_powerpc64le",
+     "x86_64-apple-darwin": "rust_darwin_x86_64",
+     "x86_64-pc-windows-msvc": "rust_windows_x86_64",
+     "x86_64-unknown-freebsd": "rust_freebsd_x86_64",

--- a/bazel/v8_ppc64le.patch
+++ b/bazel/v8_ppc64le.patch
@@ -1,0 +1,13 @@
+diff --git a/bazel/config/BUILD.bazel b/bazel/config/BUILD.bazel
+index 448260d..fe50366 100644
+--- a/bazel/config/BUILD.bazel
++++ b/bazel/config/BUILD.bazel
+@@ -61,7 +61,7 @@ config_setting(
+ 
+ config_setting(
+     name = "platform_cpu_ppc64le",
+-    constraint_values = ["@platforms//cpu:ppc"],
++    constraint_values = ["@platforms//cpu:ppc64le"],
+ )
+ 
+ v8_target_cpu(

--- a/envoy/ssl/private_key/private_key.h
+++ b/envoy/ssl/private_key/private_key.h
@@ -20,7 +20,7 @@ class TransportSocketFactoryContext;
 
 namespace Ssl {
 
-#ifdef OPENSSL_IS_BORINGSSL
+#if defined OPENSSL_IS_BORINGSSL || defined OPENSSL_IS_AWSLC
 using BoringSslPrivateKeyMethodSharedPtr = std::shared_ptr<SSL_PRIVATE_KEY_METHOD>;
 #endif
 
@@ -57,7 +57,7 @@ public:
    */
   virtual bool isAvailable() PURE;
 
-#ifdef OPENSSL_IS_BORINGSSL
+#if defined OPENSSL_IS_BORINGSSL || defined OPENSSL_IS_AWSLC
   /**
    * Get the private key methods from the provider.
    * @return the private key methods associated with this provider and

--- a/source/common/tls/BUILD
+++ b/source/common/tls/BUILD
@@ -245,7 +245,10 @@ envoy_cc_library(
 envoy_cc_library(
     name = "utility_lib",
     srcs = ["utility.cc"],
-    hdrs = ["utility.h"],
+    hdrs = [
+        "utility.h",
+        "aws_lc_compat.h",
+    ],
     external_deps = ["ssl"],
     deps = [
         "//source/common/common:assert_lib",

--- a/source/common/tls/BUILD
+++ b/source/common/tls/BUILD
@@ -246,8 +246,8 @@ envoy_cc_library(
     name = "utility_lib",
     srcs = ["utility.cc"],
     hdrs = [
-        "utility.h",
         "aws_lc_compat.h",
+        "utility.h",
     ],
     external_deps = ["ssl"],
     deps = [

--- a/source/common/tls/aws_lc_compat.h
+++ b/source/common/tls/aws_lc_compat.h
@@ -1,0 +1,3 @@
+#ifdef OPENSSL_IS_AWSLC
+#define sk_X509_NAME_find sk_X509_NAME_find_awslc
+#endif

--- a/source/common/tls/aws_lc_compat.h
+++ b/source/common/tls/aws_lc_compat.h
@@ -1,9 +1,15 @@
+#pragma once
+
 // Aws-lc can be utilized as an alternative to boringssl
 // This file provides API translation from boringssl to aws-lc when Envoy is compiled with aws-lc
-// As of now, aws-lc is only compiled with Envoy for the ppc64le platform
+// As of now, aws-lc is only compiled with Envoy for the ``ppc64le`` platform
 // More information about aws-lc can be found here: https://github.com/aws/aws-lc
 // This file should be included wherever the following identifiers are invoked by Envoy
+
+namespace Envoy {
 
 #ifdef OPENSSL_IS_AWSLC
 #define sk_X509_NAME_find sk_X509_NAME_find_awslc
 #endif
+
+} // namespace Envoy

--- a/source/common/tls/aws_lc_compat.h
+++ b/source/common/tls/aws_lc_compat.h
@@ -1,3 +1,9 @@
+// Aws-lc can be utilized as an alternative to boringssl
+// This file provides API translation from boringssl to aws-lc when Envoy is compiled with aws-lc
+// As of now, aws-lc is only compiled with Envoy for the ppc64le platform
+// More information about aws-lc can be found here: https://github.com/aws/aws-lc
+// This file should be included wherever the following identifiers are invoked by Envoy
+
 #ifdef OPENSSL_IS_AWSLC
 #define sk_X509_NAME_find sk_X509_NAME_find_awslc
 #endif

--- a/source/common/tls/cert_validator/default_validator.cc
+++ b/source/common/tls/cert_validator/default_validator.cc
@@ -534,9 +534,15 @@ absl::Status DefaultCertValidator::addClientValidationContext(SSL_CTX* ctx,
           "Failed to load trusted client CA certificates from ", config_->caCertPath()));
     }
     // Check for duplicates.
+    #ifdef OPENSSL_IS_AWSLC
+    if (sk_X509_NAME_find_awslc(list.get(), nullptr, name)) {
+      continue;
+    }
+    #else
     if (sk_X509_NAME_find(list.get(), nullptr, name)) {
       continue;
     }
+    #endif
     bssl::UniquePtr<X509_NAME> name_dup(X509_NAME_dup(name));
     if (name_dup == nullptr || !sk_X509_NAME_push(list.get(), name_dup.release())) {
       return absl::InvalidArgumentError(absl::StrCat(

--- a/source/common/tls/cert_validator/default_validator.cc
+++ b/source/common/tls/cert_validator/default_validator.cc
@@ -30,6 +30,7 @@
 #include "source/common/tls/cert_validator/cert_validator.h"
 #include "source/common/tls/cert_validator/factory.h"
 #include "source/common/tls/cert_validator/utility.h"
+#include "source/common/tls/aws_lc_compat.h"
 #include "source/common/tls/stats.h"
 #include "source/common/tls/utility.h"
 
@@ -534,15 +535,10 @@ absl::Status DefaultCertValidator::addClientValidationContext(SSL_CTX* ctx,
           "Failed to load trusted client CA certificates from ", config_->caCertPath()));
     }
     // Check for duplicates.
-    #ifdef OPENSSL_IS_AWSLC
-    if (sk_X509_NAME_find_awslc(list.get(), nullptr, name)) {
-      continue;
-    }
-    #else
     if (sk_X509_NAME_find(list.get(), nullptr, name)) {
       continue;
     }
-    #endif
+
     bssl::UniquePtr<X509_NAME> name_dup(X509_NAME_dup(name));
     if (name_dup == nullptr || !sk_X509_NAME_push(list.get(), name_dup.release())) {
       return absl::InvalidArgumentError(absl::StrCat(

--- a/source/common/tls/cert_validator/default_validator.cc
+++ b/source/common/tls/cert_validator/default_validator.cc
@@ -27,10 +27,10 @@
 #include "source/common/runtime/runtime_features.h"
 #include "source/common/stats/symbol_table.h"
 #include "source/common/stats/utility.h"
+#include "source/common/tls/aws_lc_compat.h"
 #include "source/common/tls/cert_validator/cert_validator.h"
 #include "source/common/tls/cert_validator/factory.h"
 #include "source/common/tls/cert_validator/utility.h"
-#include "source/common/tls/aws_lc_compat.h"
 #include "source/common/tls/stats.h"
 #include "source/common/tls/utility.h"
 

--- a/source/common/tls/context_impl.h
+++ b/source/common/tls/context_impl.h
@@ -32,7 +32,7 @@
 #endif
 
 namespace Envoy {
-#ifndef OPENSSL_IS_BORINGSSL
+#if !defined OPENSSL_IS_BORINGSSL && !defined OPENSSL_IS_AWSLC
 #error Envoy requires BoringSSL
 #endif
 

--- a/source/exe/BUILD
+++ b/source/exe/BUILD
@@ -48,9 +48,11 @@ envoy_cc_library(
     ] + select({
         "//bazel:enable_http3_on_windows_x86_64": envoy_all_extensions(WINDOWS_SKIP_TARGETS),
         "//bazel:enable_http3_on_linux_ppc": envoy_all_extensions(PPC_SKIP_TARGETS),
+        "//bazel:enable_http3_on_linux_ppc64le": envoy_all_extensions(PPC_SKIP_TARGETS),
         "//bazel:disable_http3_on_windows_x86_64": envoy_all_extensions(NO_HTTP3_SKIP_TARGETS + WINDOWS_SKIP_TARGETS),
         "//bazel:disable_http3_on_linux_ppc": envoy_all_extensions(NO_HTTP3_SKIP_TARGETS + PPC_SKIP_TARGETS),
-        "//bazel:disable_http3": envoy_all_extensions(NO_HTTP3_SKIP_TARGETS),
+        "//bazel:disable_http3_on_linux_ppc64le": envoy_all_extensions(PPC_SKIP_TARGETS + NO_HTTP3_SKIP_TARGETS),
+        "//bazel:disable_http3_on_not_x86_ppc": envoy_all_extensions(NO_HTTP3_SKIP_TARGETS),
         "//conditions:default": envoy_all_extensions(),
     }),
 )

--- a/source/extensions/transport_sockets/tls/cert_validator/spiffe/spiffe_validator.cc
+++ b/source/extensions/transport_sockets/tls/cert_validator/spiffe/spiffe_validator.cc
@@ -265,9 +265,15 @@ absl::Status SPIFFEValidator::addClientValidationContext(SSL_CTX* ctx, bool) {
     X509_NAME* name = X509_get_subject_name(ca.get());
 
     // Check for duplicates.
+    #ifdef OPENSSL_IS_AWSLC
+    if (sk_X509_NAME_find_awslc(list.get(), nullptr, name)) {
+      continue;
+    }
+    #else
     if (sk_X509_NAME_find(list.get(), nullptr, name)) {
       continue;
     }
+    #endif
 
     bssl::UniquePtr<X509_NAME> name_dup(X509_NAME_dup(name));
     if (name_dup == nullptr || !sk_X509_NAME_push(list.get(), name_dup.release())) {

--- a/source/extensions/transport_sockets/tls/cert_validator/spiffe/spiffe_validator.cc
+++ b/source/extensions/transport_sockets/tls/cert_validator/spiffe/spiffe_validator.cc
@@ -20,6 +20,7 @@
 #include "source/common/stats/symbol_table.h"
 #include "source/common/tls/cert_validator/factory.h"
 #include "source/common/tls/cert_validator/utility.h"
+#include "source/common/tls/aws_lc_compat.h"
 #include "source/common/tls/stats.h"
 #include "source/common/tls/utility.h"
 
@@ -265,15 +266,9 @@ absl::Status SPIFFEValidator::addClientValidationContext(SSL_CTX* ctx, bool) {
     X509_NAME* name = X509_get_subject_name(ca.get());
 
     // Check for duplicates.
-    #ifdef OPENSSL_IS_AWSLC
-    if (sk_X509_NAME_find_awslc(list.get(), nullptr, name)) {
-      continue;
-    }
-    #else
     if (sk_X509_NAME_find(list.get(), nullptr, name)) {
       continue;
     }
-    #endif
 
     bssl::UniquePtr<X509_NAME> name_dup(X509_NAME_dup(name));
     if (name_dup == nullptr || !sk_X509_NAME_push(list.get(), name_dup.release())) {

--- a/source/extensions/transport_sockets/tls/cert_validator/spiffe/spiffe_validator.cc
+++ b/source/extensions/transport_sockets/tls/cert_validator/spiffe/spiffe_validator.cc
@@ -18,9 +18,9 @@
 #include "source/common/json/json_loader.h"
 #include "source/common/protobuf/message_validator_impl.h"
 #include "source/common/stats/symbol_table.h"
+#include "source/common/tls/aws_lc_compat.h"
 #include "source/common/tls/cert_validator/factory.h"
 #include "source/common/tls/cert_validator/utility.h"
-#include "source/common/tls/aws_lc_compat.h"
 #include "source/common/tls/stats.h"
 #include "source/common/tls/utility.h"
 


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Build Envoy with aws_lc instead of boringssl when building for the ppc64le architecture.
Additional Description: Envoy uses boringssl as the default ssl implementation. As boringssl does not support the ppc64le architecture, a different ssl implementation is necessary to build Envoy for ppc64le.
Risk Level: High
Testing:
Docs Changes:
Release Notes:
Platform Specific Features: Boringssl no longer supports the ppc64le architecture. Here, aws_lc is used as a "drop-in" replacement for boringssl when building Envoy for ppc64le. Aws_lc is conditionally built **only** when Envoy is built for ppc64le with FIPS support.
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
