### PR TITLE
bugfix/listener: apply socket options on additional address

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -50,6 +50,12 @@ bug_fixes:
     Set IP_BIND_ADDRESS_NO_PORT socket option in the original_src filter to prevent port exhaustion caused by the
     kernel prematurely reserving ephemeral ports. This behavior change can be reverted by setting runtime guard
     ``envoy.reloadable_features.original_src_fix_port_exhaustion`` to ``false``.
+- area: listener
+  change: |
+    Fixed a bug where socket options specified only on an additional address were not applied unless
+    :ref:`socket_options <envoy_v3_api_field_config.listener.v3.Listener.socket_options>` on the listener is set.
+    Now additional address :ref:`socket_options <envoy_v3_api_field_config.listener.v3.AdditionalAddress.socket_options>` are correctly
+    applied even if the listener has no socket options configured.
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/source/common/listener_manager/listener_impl.cc
+++ b/source/common/listener_manager/listener_impl.cc
@@ -690,7 +690,7 @@ void ListenerImpl::buildListenSocketOptions(
       addListenSocketOptions(listen_socket_options_list_[i],
                              Network::SocketOptionFactory::buildReusePortOptions());
     }
-    if (!config.socket_options().empty()) {
+    if (!address_opts_list[i].get().empty()) {
       addListenSocketOptions(
           listen_socket_options_list_[i],
           Network::SocketOptionFactory::buildLiteralOptions(address_opts_list[i]));

--- a/test/common/listener_manager/listener_manager_impl_test.h
+++ b/test/common/listener_manager/listener_manager_impl_test.h
@@ -279,10 +279,14 @@ protected:
                        const Network::Socket::OptionsSharedPtr& options,
                        ListenerComponentFactory::BindType, const Network::SocketCreationOptions&,
                        uint32_t) -> Network::SocketSharedPtr {
-              EXPECT_NE(options.get(), nullptr);
-              EXPECT_EQ(options->size(), expected_num_options);
-              EXPECT_TRUE(Network::Socket::applyOptions(options, *listener_factory_.socket_,
-                                                        expected_state));
+              if (expected_num_options == 0) {
+                EXPECT_EQ(options.get(), nullptr);
+              } else {
+                EXPECT_NE(options.get(), nullptr);
+                EXPECT_EQ(options->size(), expected_num_options);
+                EXPECT_TRUE(Network::Socket::applyOptions(options, *listener_factory_.socket_,
+                                                          expected_state));
+              }
               return listener_factory_.socket_;
             }))
         .RetiresOnSaturation();

--- a/test/integration/listener_lds_integration_test.cc
+++ b/test/integration/listener_lds_integration_test.cc
@@ -567,6 +567,84 @@ TEST_P(ListenerMultiAddressesIntegrationTest, BasicSuccessWithMultiAddressesAndS
 }
 #endif
 
+#ifdef __linux__
+TEST_P(ListenerMultiAddressesIntegrationTest,
+       BasicSuccessWithSocketOptionsOnlySetOnAdditionalAddress) {
+  on_server_init_function_ = [&]() {
+    createLdsStream();
+    auto* additional_socket_option = listener_config_.mutable_additional_addresses(0)
+                                         ->mutable_socket_options()
+                                         ->add_socket_options();
+    additional_socket_option->set_level(IPPROTO_IP);
+    additional_socket_option->set_name(IP_TOS);
+    additional_socket_option->set_int_value(4); // IPTOS_RELIABILITY
+    additional_socket_option->set_state(envoy::config::core::v3::SocketOption::STATE_LISTENING);
+    sendLdsResponse({MessageUtil::getYamlStringFromMessage(listener_config_)}, "1");
+    createRdsStream(route_table_name_);
+  };
+  initialize();
+  test_server_->waitForCounterGe("listener_manager.lds.update_success", 1);
+  // testing-listener-0 is not initialized as we haven't pushed any RDS yet.
+  EXPECT_EQ(test_server_->server().initManager().state(), Init::Manager::State::Initializing);
+  // Workers not started, the LDS added listener 0 is in active_listeners_ list.
+  EXPECT_EQ(test_server_->server().listenerManager().listeners().size(), 1);
+  registerTestServerPorts({"address1", "address2"});
+
+  constexpr absl::string_view route_config_tmpl = R"EOF(
+      name: {}
+      virtual_hosts:
+      - name: integration
+        domains: ["*"]
+        routes:
+        - match: {{ prefix: "/" }}
+          route: {{ cluster: {} }}
+)EOF";
+  sendRdsResponse(fmt::format(route_config_tmpl, route_table_name_, "cluster_0"), "1");
+  test_server_->waitForCounterGe(
+      fmt::format("http.config_test.rds.{}.update_success", route_table_name_), 1);
+  // Now testing-listener-0 finishes initialization, Server initManager will be ready.
+  EXPECT_EQ(test_server_->server().initManager().state(), Init::Manager::State::Initialized);
+
+  test_server_->waitUntilListenersReady();
+  // NOTE: The line above doesn't tell you if listener is up and listening.
+  test_server_->waitForCounterGe("listener_manager.listener_create_success", 1);
+  // Request is sent to cluster_0.
+
+  int response_size = 800;
+  int request_size = 10;
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "200"},
+                                                   {"server_id", "cluster_0, backend_0"}};
+
+  codec_client_ = makeHttpConnection(lookupPort("address1"));
+  auto response = sendRequestAndWaitForResponse(
+      Http::TestResponseHeaderMapImpl{
+          {":method", "GET"}, {":path", "/"}, {":authority", "host"}, {":scheme", "http"}},
+      request_size, response_headers, response_size, /*cluster_0*/ 0);
+  verifyResponse(std::move(response), "200", response_headers, std::string(response_size, 'a'));
+  EXPECT_TRUE(upstream_request_->complete());
+  EXPECT_EQ(request_size, upstream_request_->bodyLength());
+  codec_client_->close();
+  // Wait for the client to be disconnected.
+  ASSERT_TRUE(codec_client_->waitForDisconnect());
+
+  codec_client_ = makeHttpConnection(lookupPort("address2"));
+  auto response2 = sendRequestAndWaitForResponse(
+      Http::TestResponseHeaderMapImpl{
+          {":method", "GET"}, {":path", "/"}, {":authority", "host"}, {":scheme", "http"}},
+      request_size, response_headers, response_size, /*cluster_0*/ 0);
+  verifyResponse(std::move(response2), "200", response_headers, std::string(response_size, 'a'));
+  EXPECT_TRUE(upstream_request_->complete());
+  EXPECT_EQ(request_size, upstream_request_->bodyLength());
+
+  int opt_value = 0;
+  socklen_t opt_len = sizeof(opt_value);
+  // Verify second address.
+  EXPECT_TRUE(getSocketOption("testing-listener-0", IPPROTO_IP, IP_TOS, &opt_value, &opt_len, 1));
+  EXPECT_EQ(opt_len, sizeof(opt_value));
+  EXPECT_EQ(4, opt_value);
+}
+#endif
+
 // Tests that a LDS adding listener works as expected.
 TEST_P(ListenerIntegrationTest, BasicSuccess) {
   on_server_init_function_ = [&]() {


### PR DESCRIPTION
Commit Message: This pull request fixes an issue where socket options configured on an additional address were not applied if no socket options were specified on the primary listener address. With this change, any socket options on the additional address are now correctly applied.

Additional Description: 
Reference config:
```
static_resources:
  listeners:
  - name: "ingress"
    address:
      socket_address:
        address: 127.0.0.1
        port_value: 1234
    additional_addresses:
    - address:
        socket_address:
          address: 127.0.0.2
          port_value: 5678
      socket_options:
        socket_options:
        - level: 1
          name: 2
          int_value: 3
          state: STATE_PREBIND
        - level: 4
          name: 5
          int_value: 6
          state: STATE_PREBIND
```
With this PR, the above socket options on 127.0.0.2 will be applied even though there are no socket options on 127.0.0.1. 

Please let me know if this needs to go behind a runtime guard. Thanks!

Risk Level: low
Testing: unit & integration test