### PR TITLE
github/ci: Bump remaining `ubuntu-20.04` jobs

### DIFF
--- a/.github/workflows/codeql-daily.yml
+++ b/.github/workflows/codeql-daily.yml
@@ -21,8 +21,8 @@ jobs:
     strategy:
       fail-fast: false
 
-    # CodeQL runs on ubuntu-20.04
-    runs-on: ubuntu-20.04
+    # CodeQL runs on ubuntu-24.04
+    runs-on: ubuntu-24.04
     if: github.repository == 'envoyproxy/envoy'
 
     steps:

--- a/.github/workflows/codeql-push.yml
+++ b/.github/workflows/codeql-push.yml
@@ -30,7 +30,7 @@ jobs:
       # for github/codeql-action/analyze to upload SARIF results
       security-events: write
       pull-requests: read
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     if: github.repository == 'envoyproxy/envoy'
     steps:
     - name: Checkout repository


### PR DESCRIPTION
this image is ~EOL and will start brownouting imminently