### PR TITLE
feat: inbound only graceful draining

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -8,6 +8,7 @@
 # leave room for compiler/linker.
 # The number 3G is chosen heuristically to both support large VM and small VM with RBE.
 # Startup options cannot be selected via config.
+# TODO: Adding just to test android
 startup --host_jvm_args=-Xmx3g
 
 common --noenable_bzlmod

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -113,6 +113,10 @@ new_features:
   change: |
     Added support for outlier detection in UDP proxy. This change can be temporarily reverted by setting runtime guard
     ``envoy.reloadable_features.enable_udp_proxy_outlier_detection`` to ``false``.
+- area: admin
+  change: |
+    Add support for the inbound_only and graceful query params of /drain_listeners to be used together by
+    implementing directional draining in DrainManager.
 - area: http
   change: |
     Added alpha support for asynchronous load balancing. See

--- a/docs/root/operations/admin.rst
+++ b/docs/root/operations/admin.rst
@@ -363,7 +363,8 @@ modify different aspects of the server:
 
    :ref:`Drains <arch_overview_draining>` all inbound listeners. ``traffic_direction`` field in
    :ref:`Listener <envoy_v3_api_msg_config.listener.v3.Listener>` is used to determine whether a listener
-   is inbound or outbound.
+   is inbound or outbound. May not be effective for network filters like :ref:`Redis <config_network_filters_redis_proxy>`,
+   :ref:`Mongo <config_network_filters_mongo_proxy>`, or :ref:`Thrift <config_network_filters_thrift_proxy>`.
 
    .. http:post:: /drain_listeners?graceful
 

--- a/envoy/network/drain_decision.h
+++ b/envoy/network/drain_decision.h
@@ -52,7 +52,8 @@ public:
    * @return handle to remove callback
    */
   ABSL_MUST_USE_RESULT
-  virtual Common::CallbackHandlePtr addOnDrainCloseCb(DrainDirection scope, DrainCloseCb cb) const PURE;
+  virtual Common::CallbackHandlePtr addOnDrainCloseCb(DrainDirection scope,
+                                                      DrainCloseCb cb) const PURE;
 };
 
 } // namespace Network

--- a/envoy/network/drain_decision.h
+++ b/envoy/network/drain_decision.h
@@ -12,6 +12,23 @@
 namespace Envoy {
 namespace Network {
 
+enum class DrainDirection {
+  /**
+   * Not draining yet. Default value, should not be externally set.
+   */
+  None = 0,
+
+  /**
+   * Drain inbound connections only.
+   */
+  InboundOnly,
+
+  /**
+   * Drain both inbound and outbound connections.
+   */
+  All,
+};
+
 class DrainDecision {
 public:
   using DrainCloseCb = std::function<absl::Status(std::chrono::milliseconds)>;
@@ -21,8 +38,9 @@ public:
   /**
    * @return TRUE if a connection should be drained and closed. It is up to individual network
    *         filters to determine when this should be called for the least impact possible.
+   * @param direction supplies the direction for which the caller is checking drain close.
    */
-  virtual bool drainClose() const PURE;
+  virtual bool drainClose(DrainDirection scope) const PURE;
 
   /**
    * @brief Register a callback to be called proactively when a drain decision enters into a
@@ -34,7 +52,7 @@ public:
    * @return handle to remove callback
    */
   ABSL_MUST_USE_RESULT
-  virtual Common::CallbackHandlePtr addOnDrainCloseCb(DrainCloseCb cb) const PURE;
+  virtual Common::CallbackHandlePtr addOnDrainCloseCb(DrainDirection scope, DrainCloseCb cb) const PURE;
 };
 
 } // namespace Network

--- a/envoy/server/drain_manager.h
+++ b/envoy/server/drain_manager.h
@@ -42,15 +42,17 @@ public:
 
   /**
    * Invoked to begin the drain procedure. (Making drain close operations more likely).
+   * @param direction is the direction of the drain.
    * @param drain_complete_cb will be invoked once the drain sequence is finished. The parameter is
    * optional and can be an unassigned function.
    */
-  virtual void startDrainSequence(std::function<void()> drain_complete_cb) PURE;
+  virtual void startDrainSequence(Network::DrainDirection direction,
+                                  std::function<void()> drain_complete_cb) PURE;
 
   /**
-   * @return whether the drain sequence has started.
+   * @return whether the drain sequence has started for this direction.
    */
-  virtual bool draining() const PURE;
+  virtual bool draining(Network::DrainDirection) const PURE;
 
   /**
    * Invoked in the newly launched primary process to begin the parent shutdown sequence. At the end

--- a/mobile/library/jni/BUILD
+++ b/mobile/library/jni/BUILD
@@ -171,7 +171,6 @@ cc_import(
     static_library = ":pthread",
 )
 
-
 envoy_cc_library(
     name = "pthread",
     srcs = ["//bazel:objc_dummy"],

--- a/mobile/library/jni/BUILD
+++ b/mobile/library/jni/BUILD
@@ -124,6 +124,7 @@ cc_binary(
         "-lm",
         # See libpthread below.
         "-L$(GENDIR)/{}".format(package_name()),
+        "-latomic",
     ] + select({
         "@envoy//bazel:dbg_build": ["-Wl,--build-id=sha1"],
         "//conditions:default": [],
@@ -169,6 +170,7 @@ cc_import(
     name = "libpthread",
     static_library = ":pthread",
 )
+
 
 envoy_cc_library(
     name = "pthread",

--- a/mobile/test/jni/BUILD
+++ b/mobile/test/jni/BUILD
@@ -63,10 +63,10 @@ cc_library(
 
 cc_binary(
     name = "libenvoy_jni_http_test_server_factory.so",
+    testonly = True,
     linkopts = [
         "-latomic",
     ],
-    testonly = True,
     linkshared = True,
     deps = [
         ":jni_http_test_server_factory_lib",
@@ -101,10 +101,10 @@ cc_library(
 cc_binary(
     name = "libenvoy_jni_http_proxy_test_server_factory.so",
     testonly = True,
-    linkshared = True,
     linkopts = [
         "-latomic",
     ],
+    linkshared = True,
     deps = [
         ":jni_http_proxy_test_server_factory_lib",
         "@envoy_mobile_extra_jni_deps//:extra_jni_dep",
@@ -148,10 +148,10 @@ cc_library(
 
 cc_binary(
     name = "libenvoy_jni_with_test_and_listener_extensions.so",
+    testonly = True,
     linkopts = [
         "-latomic",
     ],
-    testonly = True,
     linkshared = True,
     deps = [
         ":envoy_jni_with_test_and_listener_extensions_lib",

--- a/mobile/test/jni/BUILD
+++ b/mobile/test/jni/BUILD
@@ -63,6 +63,9 @@ cc_library(
 
 cc_binary(
     name = "libenvoy_jni_http_test_server_factory.so",
+    linkopts = [
+        "-latomic",
+    ],
     testonly = True,
     linkshared = True,
     deps = [
@@ -99,6 +102,9 @@ cc_binary(
     name = "libenvoy_jni_http_proxy_test_server_factory.so",
     testonly = True,
     linkshared = True,
+    linkopts = [
+        "-latomic",
+    ],
     deps = [
         ":jni_http_proxy_test_server_factory_lib",
         "@envoy_mobile_extra_jni_deps//:extra_jni_dep",
@@ -109,6 +115,9 @@ cc_binary(
 cc_binary(
     name = "libenvoy_jni_with_test_extensions.so",
     testonly = True,
+    linkopts = [
+        "-latomic",
+    ],
     linkshared = True,
     deps = [
         ":envoy_jni_with_test_extensions_lib",
@@ -139,6 +148,9 @@ cc_library(
 
 cc_binary(
     name = "libenvoy_jni_with_test_and_listener_extensions.so",
+    linkopts = [
+        "-latomic",
+    ],
     testonly = True,
     linkshared = True,
     deps = [

--- a/mobile/test/performance/BUILD
+++ b/mobile/test/performance/BUILD
@@ -6,10 +6,10 @@ envoy_mobile_package()
 
 envoy_cc_binary(
     name = "test_binary_size",
+    srcs = ["test_binary_size.cc"],
     linkopts = [
         "-latomic",
     ],
-    srcs = ["test_binary_size.cc"],
     repository = "@envoy",
     stamped = True,
     deps = ["//library/common:internal_engine_lib"],

--- a/mobile/test/performance/BUILD
+++ b/mobile/test/performance/BUILD
@@ -6,6 +6,9 @@ envoy_mobile_package()
 
 envoy_cc_binary(
     name = "test_binary_size",
+    linkopts = [
+        "-latomic",
+    ],
     srcs = ["test_binary_size.cc"],
     repository = "@envoy",
     stamped = True,

--- a/source/common/http/BUILD
+++ b/source/common/http/BUILD
@@ -400,6 +400,7 @@ envoy_cc_library(
         "//source/common/stats:timespan_lib",
         "//source/common/stream_info:stream_info_lib",
         "//source/common/tracing:http_tracer_lib",
+        "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/filters/network/http_connection_manager/v3:pkg_cc_proto",
         "@envoy_api//envoy/type/v3:pkg_cc_proto",
     ],

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -68,7 +68,8 @@ public:
                         Random::RandomGenerator& random_generator, Http::Context& http_context,
                         Runtime::Loader& runtime, const LocalInfo::LocalInfo& local_info,
                         Upstream::ClusterManager& cluster_manager,
-                        Server::OverloadManager& overload_manager, TimeSource& time_system);
+                        Server::OverloadManager& overload_manager, TimeSource& time_system,
+                        envoy::config::core::v3::TrafficDirection direction);
   ~ConnectionManagerImpl() override;
 
   static ConnectionManagerStats generateStats(const std::string& prefix, Stats::Scope& scope);
@@ -663,6 +664,7 @@ private:
   uint32_t requests_during_dispatch_count_{0};
   const uint32_t max_requests_during_dispatch_{UINT32_MAX};
   Event::SchedulableCallbackPtr deferred_request_processing_callback_;
+  const envoy::config::core::v3::TrafficDirection direction_;
 
   // If independent half-close is enabled and the upstream protocol is either HTTP/2 or HTTP/3
   // protocols the stream is destroyed after both request and response are complete i.e. reach their

--- a/source/common/listener_manager/filter_chain_manager_impl.cc
+++ b/source/common/listener_manager/filter_chain_manager_impl.cc
@@ -80,8 +80,8 @@ PerFilterChainFactoryContextImpl::PerFilterChainFactoryContextImpl(
       filter_chain_scope_(parent_context_.listenerScope().createScope("")),
       init_manager_(init_manager) {}
 
-bool PerFilterChainFactoryContextImpl::drainClose() const {
-  return is_draining_.load() || parent_context_.drainDecision().drainClose();
+bool PerFilterChainFactoryContextImpl::drainClose(Network::DrainDirection scope) const {
+  return is_draining_.load() || parent_context_.drainDecision().drainClose(scope);
 }
 
 Network::DrainDecision& PerFilterChainFactoryContextImpl::drainDecision() { return *this; }

--- a/source/common/listener_manager/filter_chain_manager_impl.h
+++ b/source/common/listener_manager/filter_chain_manager_impl.h
@@ -52,7 +52,8 @@ public:
 
   // DrainDecision
   bool drainClose(Network::DrainDirection) const override;
-  Common::CallbackHandlePtr addOnDrainCloseCb(Network::DrainDirection, DrainCloseCb) const override {
+  Common::CallbackHandlePtr addOnDrainCloseCb(Network::DrainDirection,
+                                              DrainCloseCb) const override {
     IS_ENVOY_BUG("Unexpected function call");
     return nullptr;
   }

--- a/source/common/listener_manager/filter_chain_manager_impl.h
+++ b/source/common/listener_manager/filter_chain_manager_impl.h
@@ -51,8 +51,8 @@ public:
                                             Init::Manager& init_manager);
 
   // DrainDecision
-  bool drainClose() const override;
-  Common::CallbackHandlePtr addOnDrainCloseCb(DrainCloseCb) const override {
+  bool drainClose(Network::DrainDirection) const override;
+  Common::CallbackHandlePtr addOnDrainCloseCb(Network::DrainDirection, DrainCloseCb) const override {
     IS_ENVOY_BUG("Unexpected function call");
     return nullptr;
   }

--- a/source/common/listener_manager/listener_impl.h
+++ b/source/common/listener_manager/listener_impl.h
@@ -147,7 +147,8 @@ public:
   bool drainClose(Network::DrainDirection scope) const override {
     return drain_manager_->drainClose(scope) || server_.drainManager().drainClose(scope);
   }
-  Common::CallbackHandlePtr addOnDrainCloseCb(Network::DrainDirection, DrainCloseCb) const override {
+  Common::CallbackHandlePtr addOnDrainCloseCb(Network::DrainDirection,
+                                              DrainCloseCb) const override {
     IS_ENVOY_BUG("Unexpected function call");
     return nullptr;
   }

--- a/source/common/listener_manager/listener_impl.h
+++ b/source/common/listener_manager/listener_impl.h
@@ -144,10 +144,10 @@ public:
   Network::DrainDecision& drainDecision() override;
 
   // DrainDecision
-  bool drainClose() const override {
-    return drain_manager_->drainClose() || server_.drainManager().drainClose();
+  bool drainClose(Network::DrainDirection scope) const override {
+    return drain_manager_->drainClose(scope) || server_.drainManager().drainClose(scope);
   }
-  Common::CallbackHandlePtr addOnDrainCloseCb(DrainCloseCb) const override {
+  Common::CallbackHandlePtr addOnDrainCloseCb(Network::DrainDirection, DrainCloseCb) const override {
     IS_ENVOY_BUG("Unexpected function call");
     return nullptr;
   }

--- a/source/common/listener_manager/listener_manager_impl.cc
+++ b/source/common/listener_manager/listener_manager_impl.cc
@@ -671,25 +671,26 @@ void ListenerManagerImpl::drainListener(ListenerImplPtr&& listener) {
 
   // Start the drain sequence which completes when the listener's drain manager has completed
   // draining at whatever the server configured drain times are.
-  draining_it->listener_->localDrainManager().startDrainSequence([this, draining_it]() -> void {
-    draining_it->listener_->debugLog("removing draining listener");
-    for (const auto& worker : workers_) {
-      // Once the drain time has completed via the drain manager's timer, we tell the workers
-      // to remove the listener.
-      worker->removeListener(*draining_it->listener_, [this, draining_it]() -> void {
-        // The remove listener completion is called on the worker thread. We post back to the
-        // main thread to avoid locking. This makes sure that we don't destroy the listener
-        // while filters might still be using its context (stats, etc.).
-        server_.dispatcher().post([this, draining_it]() -> void {
-          if (--draining_it->workers_pending_removal_ == 0) {
-            draining_it->listener_->debugLog("draining listener removal complete");
-            draining_listeners_.erase(draining_it);
-            stats_.total_listeners_draining_.set(draining_listeners_.size());
-          }
-        });
+  draining_it->listener_->localDrainManager().startDrainSequence(
+      Network::DrainDirection::All, [this, draining_it]() -> void {
+        draining_it->listener_->debugLog("removing draining listener");
+        for (const auto& worker : workers_) {
+          // Once the drain time has completed via the drain manager's timer, we tell the workers
+          // to remove the listener.
+          worker->removeListener(*draining_it->listener_, [this, draining_it]() -> void {
+            // The remove listener completion is called on the worker thread. We post back to the
+            // main thread to avoid locking. This makes sure that we don't destroy the listener
+            // while filters might still be using its context (stats, etc.).
+            server_.dispatcher().post([this, draining_it]() -> void {
+              if (--draining_it->workers_pending_removal_ == 0) {
+                draining_it->listener_->debugLog("draining listener removal complete");
+                draining_listeners_.erase(draining_it);
+                stats_.total_listeners_draining_.set(draining_listeners_.size());
+              }
+            });
+          });
+        }
       });
-    }
-  });
 
   updateWarmingActiveGauges();
 }
@@ -1028,14 +1029,21 @@ void ListenerManagerImpl::stopListeners(StopListenersType stop_listeners_type,
       // Close the socket once all workers stopped accepting its connections.
       // This allows clients to fast fail instead of waiting in the accept queue.
       const uint64_t listener_tag = listener.listenerTag();
-      stopListener(listener, options, [this, listener_tag]() {
-        stats_.listener_stopped_.inc();
-        for (auto& listener : active_listeners_) {
-          if (listener->listenerTag() == listener_tag) {
-            maybeCloseSocketsForListener(*listener);
+      // Only stop the listener if we don't have a record of its tag.
+      // This prevents us from double incrementing if listeners are stopped twice.
+      // This can happen if the admin endpoint is triggered for inbound_only and then
+      // all.
+      if (stopped_listener_tags_.find(listener_tag) == stopped_listener_tags_.end()) {
+        stopListener(listener, options, [this, listener_tag]() {
+          stats_.listener_stopped_.inc();
+          stopped_listener_tags_.insert(listener_tag);
+          for (auto& listener : active_listeners_) {
+            if (listener->listenerTag() == listener_tag) {
+              maybeCloseSocketsForListener(*listener);
+            }
           }
-        }
-      });
+        });
+      }
     }
   }
 }

--- a/source/common/listener_manager/listener_manager_impl.cc
+++ b/source/common/listener_manager/listener_manager_impl.cc
@@ -1033,8 +1033,9 @@ void ListenerManagerImpl::stopListeners(StopListenersType stop_listeners_type,
       // This prevents us from double incrementing if listeners are stopped twice.
       // This can happen if the admin endpoint is triggered for inbound_only and then
       // all.
-      if (stopped_listener_tags_.find(listener_tag) == stopped_listener_tags_.end()) {
-        stopListener(listener, options, [this, listener_tag]() {
+      stopListener(listener, options, [this, listener_tag]() {
+        // Perform the check in the callback to ensure it's done on the main thread
+        if (stopped_listener_tags_.find(listener_tag) == stopped_listener_tags_.end()) {
           stats_.listener_stopped_.inc();
           stopped_listener_tags_.insert(listener_tag);
           for (auto& listener : active_listeners_) {
@@ -1042,8 +1043,8 @@ void ListenerManagerImpl::stopListeners(StopListenersType stop_listeners_type,
               maybeCloseSocketsForListener(*listener);
             }
           }
-        });
-      }
+        }
+      });
     }
   }
 }

--- a/source/common/listener_manager/listener_manager_impl.cc
+++ b/source/common/listener_manager/listener_manager_impl.cc
@@ -1029,12 +1029,11 @@ void ListenerManagerImpl::stopListeners(StopListenersType stop_listeners_type,
       // Close the socket once all workers stopped accepting its connections.
       // This allows clients to fast fail instead of waiting in the accept queue.
       const uint64_t listener_tag = listener.listenerTag();
-      // Only stop the listener if we don't have a record of its tag.
-      // This prevents us from double incrementing if listeners are stopped twice.
-      // This can happen if the admin endpoint is triggered for inbound_only and then
-      // all.
       stopListener(listener, options, [this, listener_tag]() {
-        // Perform the check in the callback to ensure it's done on the main thread
+        // Only stop the listener if we don't have a record of its tag.
+        // This prevents us from double incrementing if listeners are stopped twice.
+        // This can happen if the admin endpoint is triggered for inbound_only and then
+        // all. We perform the check in the callback to ensure it's done on the main thread
         if (stopped_listener_tags_.find(listener_tag) == stopped_listener_tags_.end()) {
           stats_.listener_stopped_.inc();
           stopped_listener_tags_.insert(listener_tag);

--- a/source/common/listener_manager/listener_manager_impl.h
+++ b/source/common/listener_manager/listener_manager_impl.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <set>
 
 #include "envoy/admin/v3/config_dump.pb.h"
 #include "envoy/config/core/v3/address.pb.h"
@@ -360,6 +361,7 @@ private:
   absl::flat_hash_map<std::string, std::unique_ptr<UpdateFailureState>> error_state_tracker_;
   FailureStates overall_error_state_;
   Quic::QuicStatNames& quic_stat_names_;
+  absl::flat_hash_set<uint64_t> stopped_listener_tags_;
 };
 
 class ListenerFilterChainFactoryBuilder : public FilterChainFactoryBuilder {

--- a/source/extensions/filters/network/generic_proxy/proxy.cc
+++ b/source/extensions/filters/network/generic_proxy/proxy.cc
@@ -759,7 +759,8 @@ void Filter::closeDownstreamConnection() {
 }
 
 void Filter::mayBeDrainClose() {
-  if ((drain_decision_.drainClose() || stream_drain_decision_) && active_streams_.empty()) {
+  if ((drain_decision_.drainClose(Network::DrainDirection::All) || stream_drain_decision_) &&
+      active_streams_.empty()) {
     onDrainCloseAndNoActiveStreams();
   }
 }

--- a/source/extensions/filters/network/http_connection_manager/config.cc
+++ b/source/extensions/filters/network/http_connection_manager/config.cc
@@ -307,12 +307,11 @@ HttpConnectionManagerFilterConfigFactory::createFilterFactoryFromProtoAndHopByHo
     Server::OverloadManager& overload_manager = context.listenerInfo().shouldBypassOverloadManager()
                                                     ? server_context.nullOverloadManager()
                                                     : server_context.overloadManager();
-
     auto hcm = std::make_shared<Http::ConnectionManagerImpl>(
         filter_config, context.drainDecision(), server_context.api().randomGenerator(),
         server_context.httpContext(), server_context.runtime(), server_context.localInfo(),
         server_context.clusterManager(), overload_manager,
-        server_context.mainThreadDispatcher().timeSource());
+        server_context.mainThreadDispatcher().timeSource(), context.listenerInfo().direction());
     if (!clear_hop_by_hop_headers) {
       hcm->setClearHopByHopResponseHeaders(false);
     }
@@ -897,7 +896,7 @@ HttpConnectionManagerFactory::createHttpConnectionManagerFactoryFromProto(
         filter_config, context.drainDecision(), server_context.api().randomGenerator(),
         server_context.httpContext(), server_context.runtime(), server_context.localInfo(),
         server_context.clusterManager(), overload_manager,
-        server_context.mainThreadDispatcher().timeSource());
+        server_context.mainThreadDispatcher().timeSource(), context.listenerInfo().direction());
     if (!clear_hop_by_hop_headers) {
       conn_manager->setClearHopByHopResponseHeaders(false);
     }

--- a/source/extensions/filters/network/mongo_proxy/proxy.cc
+++ b/source/extensions/filters/network/mongo_proxy/proxy.cc
@@ -251,7 +251,7 @@ void ProxyFilter::decodeReply(ReplyMessagePtr&& message) {
     break;
   }
 
-  if (active_query_list_.empty() && drain_decision_.drainClose() &&
+  if (active_query_list_.empty() && drain_decision_.drainClose(Network::DrainDirection::All) &&
       runtime_.snapshot().featureEnabled(MongoRuntimeConfig::get().DrainCloseEnabled, 100)) {
     ENVOY_LOG(debug, "drain closing mongo connection");
     stats_.cx_drain_close_.inc();

--- a/source/extensions/filters/network/redis_proxy/proxy_filter.cc
+++ b/source/extensions/filters/network/redis_proxy/proxy_filter.cc
@@ -294,7 +294,8 @@ void ProxyFilter::onResponse(PendingRequest& request, Common::Redis::RespValuePt
   }
 
   // Check for drain close only if there are no pending responses.
-  if (pending_requests_.empty() && config_->drain_decision_.drainClose() &&
+  if (pending_requests_.empty() &&
+      config_->drain_decision_.drainClose(Network::DrainDirection::All) &&
       config_->runtime_.snapshot().featureEnabled(config_->redis_drain_close_runtime_key_, 100)) {
     config_->stats_.downstream_cx_drain_close_.inc();
     callbacks_->connection().close(Network::ConnectionCloseType::FlushWrite);

--- a/source/extensions/filters/network/thrift_proxy/conn_manager.cc
+++ b/source/extensions/filters/network/thrift_proxy/conn_manager.cc
@@ -353,7 +353,7 @@ FilterStatus ConnectionManager::ResponseDecoder::messageBegin(MessageMetadataSha
   // should be set before the encodeFrame() call. It should be set at or after the messageBegin
   // call so that the header is added after all upstream headers passed, due to messageBegin
   // possibly not getting headers in transportBegin.
-  if (cm.drain_decision_.drainClose()) {
+  if (cm.drain_decision_.drainClose(Network::DrainDirection::All)) {
     ENVOY_STREAM_LOG(debug, "propogate Drain header for drain close decision", parent_);
     // TODO(rgs1): should the key value contain something useful (e.g.: minutes til drain is
     // over)?

--- a/source/server/admin/admin.cc
+++ b/source/server/admin/admin.cc
@@ -300,7 +300,8 @@ bool AdminImpl::createNetworkFilterChain(Network::Connection& connection,
   connection.addReadFilter(Network::ReadFilterSharedPtr{new Http::ConnectionManagerImpl(
       shared_from_this(), server_.drainManager(), server_.api().randomGenerator(),
       server_.httpContext(), server_.runtime(), server_.localInfo(), server_.clusterManager(),
-      server_.nullOverloadManager(), server_.timeSource())});
+      server_.nullOverloadManager(), server_.timeSource(),
+      envoy::config::core::v3::TrafficDirection::UNSPECIFIED)});
   return true;
 }
 

--- a/source/server/api_listener_impl.h
+++ b/source/server/api_listener_impl.h
@@ -42,8 +42,8 @@ public:
 
   // Network::DrainDecision
   // TODO(junr03): hook up draining to listener state management.
-  bool drainClose() const override { return false; }
-  Common::CallbackHandlePtr addOnDrainCloseCb(DrainCloseCb) const override {
+  bool drainClose(Network::DrainDirection) const override { return false; }
+  Common::CallbackHandlePtr addOnDrainCloseCb(Network::DrainDirection, DrainCloseCb) const override {
     IS_ENVOY_BUG("Unexpected call to addOnDrainCloseCb");
     return nullptr;
   }

--- a/source/server/api_listener_impl.h
+++ b/source/server/api_listener_impl.h
@@ -43,7 +43,8 @@ public:
   // Network::DrainDecision
   // TODO(junr03): hook up draining to listener state management.
   bool drainClose(Network::DrainDirection) const override { return false; }
-  Common::CallbackHandlePtr addOnDrainCloseCb(Network::DrainDirection, DrainCloseCb) const override {
+  Common::CallbackHandlePtr addOnDrainCloseCb(Network::DrainDirection,
+                                              DrainCloseCb) const override {
     IS_ENVOY_BUG("Unexpected call to addOnDrainCloseCb");
     return nullptr;
   }

--- a/source/server/drain_manager_impl.cc
+++ b/source/server/drain_manager_impl.cc
@@ -27,9 +27,9 @@ DrainManagerImpl::createChildManager(Event::Dispatcher& dispatcher,
 
   // Wire up the child so that when the parent starts draining, the child also sees the
   // state-change
-  auto child_cb = children_->add(dispatcher, [child = child.get()] {
-    if (!child->draining_) {
-      child->startDrainSequence([] {});
+  auto child_cb = children_->add(dispatcher, [this, child = child.get()] {
+    if (!child->draining_.load().first) {
+      child->startDrainSequence(this->draining_.load().second, [] {});
     }
   });
   child->parent_callback_handle_ = std::move(child_cb);
@@ -40,7 +40,7 @@ DrainManagerPtr DrainManagerImpl::createChildManager(Event::Dispatcher& dispatch
   return createChildManager(dispatcher, drain_type_);
 }
 
-bool DrainManagerImpl::drainClose() const {
+bool DrainManagerImpl::drainClose(Network::DrainDirection direction) const {
   // If we are actively health check failed and the drain type is default, always drain close.
   //
   // TODO(mattklein123): In relation to x-envoy-immediate-health-check-fail, it would be better
@@ -52,7 +52,15 @@ bool DrainManagerImpl::drainClose() const {
     return true;
   }
 
-  if (!draining_) {
+  if (!draining_.load().first) {
+    return false;
+  }
+
+  // If the direction passed in is greater than the current draining direction
+  // (e.g. direction = ALL, but draining_.second == INBOUND_ONLY), then don't
+  // drain. We also don't want to drain if the direction is None (which doesn't really
+  // make sense, but it's the correct behavior).
+  if (direction == Network::DrainDirection::None || direction > draining_.load().second) {
     return false;
   }
 
@@ -64,12 +72,14 @@ bool DrainManagerImpl::drainClose() const {
   // P(return true) = elapsed time / drain timeout
   // If the drain deadline is exceeded, skip the probability calculation.
   const MonotonicTime current_time = dispatcher_.timeSource().monotonicTime();
-  if (current_time >= drain_deadline_) {
+  auto deadline = drain_deadlines_.find(direction);
+  ASSERT(deadline != drain_deadlines_.end());
+  if (current_time >= deadline->second) {
     return true;
   }
 
   const auto remaining_time =
-      std::chrono::duration_cast<std::chrono::seconds>(drain_deadline_ - current_time);
+      std::chrono::duration_cast<std::chrono::seconds>(deadline->second - current_time);
   const auto drain_time = server_.options().drainTime();
   ASSERT(server_.options().drainTime() >= remaining_time);
   const auto drain_time_count = drain_time.count();
@@ -85,18 +95,19 @@ bool DrainManagerImpl::drainClose() const {
          (server_.api().randomGenerator().random() % drain_time_count);
 }
 
-Common::CallbackHandlePtr DrainManagerImpl::addOnDrainCloseCb(DrainCloseCb cb) const {
+Common::CallbackHandlePtr DrainManagerImpl::addOnDrainCloseCb(Network::DrainDirection direction,
+                                                              DrainCloseCb cb) const {
   ASSERT(dispatcher_.isThreadSafe());
 
-  if (draining_) {
+  if (draining_.load().first && direction <= draining_.load().second) {
     const MonotonicTime current_time = dispatcher_.timeSource().monotonicTime();
 
     // Calculate the delay. If using an immediate drain-strategy or past our deadline, use
     // a zero millisecond delay. Otherwise, pick a random value within the remaining time-span.
     std::chrono::milliseconds drain_delay{0};
     if (server_.options().drainStrategy() != Server::DrainStrategy::Immediate) {
-      if (current_time < drain_deadline_) {
-        const auto delta = drain_deadline_ - current_time;
+      if (current_time < drain_deadlines_.find(direction)->second) {
+        const auto delta = drain_deadlines_.find(direction)->second - current_time;
         const auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(delta).count();
 
         // Note; current_time may be less than drain_deadline_ by only a
@@ -115,63 +126,66 @@ Common::CallbackHandlePtr DrainManagerImpl::addOnDrainCloseCb(DrainCloseCb cb) c
   return cbs_.add(cb);
 }
 
-void DrainManagerImpl::addDrainCompleteCallback(std::function<void()> cb) {
+void DrainManagerImpl::addDrainCompleteCallback(Network::DrainDirection direction,
+                                                std::function<void()> cb) {
   ASSERT(dispatcher_.isThreadSafe());
-  ASSERT(draining_);
+  ASSERT(draining_.load().first && direction <= draining_.load().second);
 
   // If the drain-tick-timer is active, add the callback to the queue. If not defined
   // then it must have already expired, invoke the callback immediately.
-  if (drain_tick_timer_) {
+  if (drain_tick_timers_[direction]) {
     drain_complete_cbs_.push_back(cb);
   } else {
     cb();
   }
 }
 
-void DrainManagerImpl::startDrainSequence(std::function<void()> drain_complete_cb) {
+void DrainManagerImpl::startDrainSequence(Network::DrainDirection direction,
+                                          std::function<void()> drain_complete_cb) {
   ASSERT(dispatcher_.isThreadSafe());
   ASSERT(drain_complete_cb);
+  ASSERT(direction != Network::DrainDirection::None, "a valid direction must be specified.");
+  auto current_drain = draining_.load();
 
   // If we've already started draining (either through direct invocation or through
   // parent-initiated draining), enqueue the drain_complete_cb and return
-  if (draining_) {
-    addDrainCompleteCallback(drain_complete_cb);
+  if (current_drain.first && direction <= current_drain.second) {
+    addDrainCompleteCallback(direction, drain_complete_cb);
     return;
   }
+  ASSERT(drain_tick_timers_.count(direction) == 0,
+         "cannot run two drain sequences for the same direction.");
 
-  ASSERT(!drain_tick_timer_);
   const std::chrono::seconds drain_delay(server_.options().drainTime());
-
   // Note https://github.com/envoyproxy/envoy/issues/31457, previous to which,
   // drain_deadline_ was set *after* draining_ resulting in a read/write race between
   // the main thread running this function from admin, and the worker thread calling
   // drainClose. Note that drain_deadline_ is default-constructed which guarantees
   // to set the time-since epoch to a count of 0
   // (https://en.cppreference.com/w/cpp/chrono/time_point/time_point).
-  ASSERT(drain_deadline_.time_since_epoch().count() == 0, "drain_deadline_ cannot be set twice.");
-
+  ASSERT(drain_deadlines_[direction].time_since_epoch().count() == 0,
+         "drain_deadline_ cannot be set twice for the same direction");
   // Since draining_ is atomic, it is safe to set drain_deadline_ without a mutex
   // as drain_close() only reads from drain_deadline_ if draining_ is true, and
   // C++ will not re-order an assign to an atomic. See
   // https://stackoverflow.com/questions/40320254/reordering-atomic-operations-in-c .
-  drain_deadline_ = dispatcher_.timeSource().monotonicTime() + drain_delay;
 
+  drain_deadlines_[direction] = dispatcher_.timeSource().monotonicTime() + drain_delay;
   // Atomic assign must come after the assign to drain_deadline_.
-  draining_.store(true, std::memory_order_seq_cst);
+  draining_.store(DrainPair{true, direction}, std::memory_order_seq_cst);
 
   // Signal to child drain-managers to start their drain sequence
   children_->runCallbacks();
-
   // Schedule callback to run at end of drain time
-  drain_tick_timer_ = dispatcher_.createTimer([this]() {
+  drain_tick_timers_[direction] = dispatcher_.createTimer([this, direction]() {
     for (auto& cb : drain_complete_cbs_) {
       cb();
     }
     drain_complete_cbs_.clear();
-    drain_tick_timer_.reset();
+    drain_tick_timers_[direction].reset();
   });
-  addDrainCompleteCallback(drain_complete_cb);
-  drain_tick_timer_->enableTimer(drain_delay);
+  addDrainCompleteCallback(direction, drain_complete_cb);
+  drain_tick_timers_[direction]->enableTimer(drain_delay);
 
   // Call registered on-drain callbacks - with gradual delays
   // Note: This will distribute drain events in the first 1/4th of the drain window
@@ -179,9 +193,9 @@ void DrainManagerImpl::startDrainSequence(std::function<void()> drain_complete_c
   const MonotonicTime current_time = dispatcher_.timeSource().monotonicTime();
   std::chrono::seconds remaining_time{0};
   if (server_.options().drainStrategy() != Server::DrainStrategy::Immediate &&
-      current_time < drain_deadline_) {
-    remaining_time =
-        std::chrono::duration_cast<std::chrono::seconds>(drain_deadline_ - current_time);
+      current_time < drain_deadlines_[direction]) {
+    remaining_time = std::chrono::duration_cast<std::chrono::seconds>(drain_deadlines_[direction] -
+                                                                      current_time);
     ASSERT(server_.options().drainTime() >= remaining_time);
   }
 

--- a/source/server/drain_manager_impl.h
+++ b/source/server/drain_manager_impl.h
@@ -29,9 +29,9 @@ public:
                    Event::Dispatcher& dispatcher);
 
   // Network::DrainDecision
-bool drainClose(Network::DrainDirection scope) const override;
-Common::CallbackHandlePtr addOnDrainCloseCb(Network::DrainDirection direction, DrainCloseCb cb) const override;
-
+  bool drainClose(Network::DrainDirection scope) const override;
+  Common::CallbackHandlePtr addOnDrainCloseCb(Network::DrainDirection direction,
+                                              DrainCloseCb cb) const override;
 
   // Server::DrainManager
   void startDrainSequence(Network::DrainDirection direction,

--- a/source/server/drain_manager_impl.h
+++ b/source/server/drain_manager_impl.h
@@ -37,7 +37,8 @@ public:
   void startDrainSequence(Network::DrainDirection direction,
                           std::function<void()> drain_complete_cb) override;
   bool draining(Network::DrainDirection direction) const override {
-    return draining_.load().first && direction <= draining_.load().second;
+    auto drain_pair = draining_.load();
+    return drain_pair.first && direction <= drain_pair.second;
   }
   void startParentShutdownSequence() override;
   DrainManagerPtr

--- a/source/server/drain_manager_impl.h
+++ b/source/server/drain_manager_impl.h
@@ -29,12 +29,16 @@ public:
                    Event::Dispatcher& dispatcher);
 
   // Network::DrainDecision
-  bool drainClose() const override;
-  Common::CallbackHandlePtr addOnDrainCloseCb(DrainCloseCb cb) const override;
+bool drainClose(Network::DrainDirection scope) const override;
+Common::CallbackHandlePtr addOnDrainCloseCb(DrainCloseCb cb) const override;
+
 
   // Server::DrainManager
-  void startDrainSequence(std::function<void()> drain_complete_cb) override;
-  bool draining() const override { return draining_; }
+  void startDrainSequence(Network::DrainDirection direction,
+                          std::function<void()> drain_complete_cb) override;
+  bool draining(Network::DrainDirection direction) const override {
+    return draining_.load().first && direction <= draining_.load().second;
+  }
   void startParentShutdownSequence() override;
   DrainManagerPtr
   createChildManager(Event::Dispatcher& dispatcher,
@@ -47,10 +51,16 @@ private:
   Instance& server_;
   Event::Dispatcher& dispatcher_;
   const envoy::config::listener::v3::Listener::DrainType drain_type_;
-
-  std::atomic<bool> draining_{false};
-  Event::TimerPtr drain_tick_timer_;
-  MonotonicTime drain_deadline_;
+  using DrainPair = struct {
+    bool first;
+    Network::DrainDirection second;
+  };
+  std::atomic<DrainPair> draining_{DrainPair{false, Network::DrainDirection::None}};
+  // A map of timers keyed by the direction that triggered the drain
+  std::map<Network::DrainDirection, Event::TimerPtr> drain_tick_timers_;
+  std::map<Network::DrainDirection, MonotonicTime> drain_deadlines_ = {
+      {Network::DrainDirection::InboundOnly, MonotonicTime()},
+      {Network::DrainDirection::All, MonotonicTime()}};
   mutable Common::CallbackManager<std::chrono::milliseconds> cbs_{};
   std::vector<std::function<void()>> drain_complete_cbs_{};
 

--- a/source/server/drain_manager_impl.h
+++ b/source/server/drain_manager_impl.h
@@ -30,7 +30,7 @@ public:
 
   // Network::DrainDecision
 bool drainClose(Network::DrainDirection scope) const override;
-Common::CallbackHandlePtr addOnDrainCloseCb(DrainCloseCb cb) const override;
+Common::CallbackHandlePtr addOnDrainCloseCb(Network::DrainDirection direction, DrainCloseCb cb) const override;
 
 
   // Server::DrainManager
@@ -46,7 +46,7 @@ Common::CallbackHandlePtr addOnDrainCloseCb(DrainCloseCb cb) const override;
   DrainManagerPtr createChildManager(Event::Dispatcher& dispatcher) override;
 
 private:
-  void addDrainCompleteCallback(std::function<void()> cb);
+  void addDrainCompleteCallback(Network::DrainDirection direction, std::function<void()> cb);
 
   Instance& server_;
   Event::Dispatcher& dispatcher_;
@@ -62,7 +62,7 @@ private:
       {Network::DrainDirection::InboundOnly, MonotonicTime()},
       {Network::DrainDirection::All, MonotonicTime()}};
   mutable Common::CallbackManager<std::chrono::milliseconds> cbs_{};
-  std::vector<std::function<void()>> drain_complete_cbs_{};
+  std::vector<std::function<void()>> drain_complete_cbs_;
 
   // Callbacks called by startDrainSequence to cascade/proxy to children
   std::shared_ptr<Common::ThreadSafeCallbackManager> children_;

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -153,7 +153,7 @@ void InstanceBase::drainListeners(OptRef<const Network::ExtraShutdownListenerOpt
   listener_manager_->stopListeners(ListenerManager::StopListenersType::All,
                                    options.has_value() ? *options
                                                        : Network::ExtraShutdownListenerOptions{});
-  drain_manager_->startDrainSequence([] {});
+  drain_manager_->startDrainSequence(Network::DrainDirection::All, [] {});
 }
 
 void InstanceBase::failHealthcheck(bool fail) {

--- a/test/common/http/BUILD
+++ b/test/common/http/BUILD
@@ -268,6 +268,7 @@ envoy_cc_test_library(
         "//source/extensions/access_loggers/common:file_access_log_lib",
         "//source/extensions/http/header_validators/envoy_default:http1_header_validator",
         "//source/extensions/request_id/uuid:config",
+        "//test/extensions/filters/network/common/fuzz/utils:network_filter_fuzzer_fakes_lib",
         "//test/mocks/access_log:access_log_mocks",
         "//test/mocks/event:event_mocks",
         "//test/mocks/http:early_header_mutation_mock",
@@ -299,6 +300,8 @@ envoy_cc_test(
         ":conn_manager_impl_test_base_lib",
         ":custom_header_extension_lib",
         "//envoy/network:proxy_protocol_options_lib",
+        "//test/extensions/filters/network/common/fuzz/utils:network_filter_fuzzer_fakes_lib",
+        "//test/server:utility_lib",
     ],
 )
 

--- a/test/common/http/conn_manager_impl_fuzz_test.cc
+++ b/test/common/http/conn_manager_impl_fuzz_test.cc
@@ -637,7 +637,8 @@ DEFINE_PROTO_FUZZER(const test::common::http::ConnManagerImplTestCase& input) {
       std::make_shared<Network::Address::Ipv4Instance>("0.0.0.0"));
 
   ConnectionManagerImpl conn_manager(config, drain_close, random, http_context, runtime, local_info,
-                                     cluster_manager, overload_manager, config->time_system_);
+                                     cluster_manager, overload_manager, config->time_system_,
+                                     envoy::config::core::v3::TrafficDirection::UNSPECIFIED);
   conn_manager.initializeReadFilterCallbacks(filter_callbacks);
 
   std::vector<FuzzStreamPtr> streams;

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -4069,7 +4069,7 @@ TEST_F(HttpConnectionManagerImplTest, FooUpgradeDrainClose) {
 
   // Store the basic request encoder during filter chain setup.
   auto* filter = new MockStreamFilter();
-  EXPECT_CALL(drain_close_, drainClose()).WillOnce(Return(true));
+  EXPECT_CALL(drain_close_, drainClose(Network::DrainDirection::All)).WillOnce(Return(true));
 
   EXPECT_CALL(*filter, decodeHeaders(_, false))
       .WillRepeatedly(Invoke([&](RequestHeaderMap&, bool) -> FilterHeadersStatus {
@@ -4201,7 +4201,7 @@ TEST_F(HttpConnectionManagerImplTest, DrainCloseRaceWithClose) {
   conn_manager_->onData(fake_input, false);
 
   ResponseHeaderMapPtr response_headers{new TestResponseHeaderMapImpl{{":status", "200"}}};
-  EXPECT_CALL(drain_close_, drainClose()).WillOnce(Return(true));
+  EXPECT_CALL(drain_close_, drainClose(Network::DrainDirection::All)).WillOnce(Return(true));
   EXPECT_CALL(*codec_, shutdownNotice());
   Event::MockTimer* drain_timer = setUpTimer();
   EXPECT_CALL(*drain_timer, enableTimer(_, _));
@@ -4305,7 +4305,7 @@ TEST_F(HttpConnectionManagerImplTest, DrainClose) {
   ResponseHeaderMapPtr response_headers{new TestResponseHeaderMapImpl{{":status", "300"}}};
   Event::MockTimer* drain_timer = setUpTimer();
   EXPECT_CALL(*drain_timer, enableTimer(_, _));
-  EXPECT_CALL(drain_close_, drainClose()).WillOnce(Return(true));
+  EXPECT_CALL(drain_close_, drainClose(Network::DrainDirection::All)).WillOnce(Return(true));
   EXPECT_CALL(*codec_, shutdownNotice());
   filter->callbacks_->streamInfo().setResponseCodeDetails("");
   filter->callbacks_->encodeHeaders(std::move(response_headers), true, "details");

--- a/test/common/http/conn_manager_impl_test_2.cc
+++ b/test/common/http/conn_manager_impl_test_2.cc
@@ -2,6 +2,8 @@
 
 #include "test/common/http/conn_manager_impl_test_base.h"
 #include "test/common/http/custom_header_extension.h"
+#include "test/extensions/filters/network/common/fuzz/utils/fakes.h"
+#include "test/server/utility.h"
 #include "test/test_common/logging.h"
 #include "test/test_common/test_runtime.h"
 
@@ -3080,10 +3082,113 @@ TEST_F(HttpConnectionManagerImplTest, TestStopAllIterationAndBufferOnEncodingPat
   encoder_filters_[1]->callbacks_->continueEncoding();
 }
 
+TEST_F(HttpConnectionManagerImplTest, InboundOnlyDrainNoConnectionCloseForOutbound) {
+  std::string yaml = R"EOF(
+address:
+  socket_address: { address: 127.0.0.1, port_value: 1234 }
+metadata: { filter_metadata: { com.bar.foo: { baz: test_value } } }
+traffic_direction: OUTBOUND
+  )EOF";
+  auto cfg = Server::parseListenerFromV3Yaml(yaml);
+  const Network::ListenerInfo& listener_info = Server::Configuration::FakeListenerInfo(cfg);
+  EXPECT_CALL(factory_context_, listenerInfo()).WillOnce(ReturnRef(listener_info));
+  setup();
+
+  // In this scenario, we have an inbound only drain, but the conn manager for an outbound listener
+  // is checking to see if it should drain. We set the expectation here that the answer is no,
+  // so we SHOULDN'T see a connection close header.
+  EXPECT_CALL(drain_close_, drainClose(Network::DrainDirection::All)).WillOnce(Return(false));
+
+  std::shared_ptr<MockStreamDecoderFilter> filter(new NiceMock<MockStreamDecoderFilter>());
+  EXPECT_CALL(filter_factory_, createFilterChain(_))
+      .WillOnce(Invoke([&](FilterChainManager& manager) -> bool {
+        auto factory = createDecoderFilterFactoryCb(StreamDecoderFilterSharedPtr{filter});
+        manager.applyFilterFactoryCb({}, factory);
+        return true;
+      }));
+
+  EXPECT_CALL(*codec_, dispatch(_))
+      .WillRepeatedly(Invoke([&](Buffer::Instance& data) -> Http::Status {
+        decoder_ = &conn_manager_->newStream(response_encoder_);
+        RequestHeaderMapPtr headers{new TestRequestHeaderMapImpl{{":authority", "host"},
+                                                                 {":path", "/"},
+                                                                 {":method", "GET"},
+                                                                 {"connection", "keep-alive"}}};
+        decoder_->decodeHeaders(std::move(headers), true);
+
+        ResponseHeaderMapPtr response_headers{new TestResponseHeaderMapImpl{{":status", "200"}}};
+        filter->callbacks_->streamInfo().setResponseCodeDetails("");
+        filter->callbacks_->encodeHeaders(std::move(response_headers), true, "details");
+
+        data.drain(4);
+        return Http::okStatus();
+      }));
+
+  EXPECT_CALL(response_encoder_, encodeHeaders(_, true))
+      .WillOnce(Invoke([](const ResponseHeaderMap& headers, bool) -> void {
+        EXPECT_NE("close", headers.getConnectionValue());
+      }));
+
+  Buffer::OwnedImpl fake_input;
+  conn_manager_->onData(fake_input, false);
+}
+
+TEST_F(HttpConnectionManagerImplTest, InboundOnlyDrainConnectionCloseForInbound) {
+  std::string yaml = R"EOF(
+address:
+  socket_address: { address: 127.0.0.1, port_value: 1234 }
+metadata: { filter_metadata: { com.bar.foo: { baz: test_value } } }
+traffic_direction: INBOUND
+  )EOF";
+  auto cfg = Server::parseListenerFromV3Yaml(yaml);
+  const Network::ListenerInfo& listener_info = Server::Configuration::FakeListenerInfo(cfg);
+  EXPECT_CALL(factory_context_, listenerInfo()).WillOnce(ReturnRef(listener_info));
+  setup();
+
+  // In this scenario, we have an inbound only drain, and the conn manager for an inbound listener
+  // is checking to see if it should drain. We set the expectation here that the answer is yes,
+  // so we SHOULD see a connection close header.
+  EXPECT_CALL(drain_close_, drainClose(Network::DrainDirection::InboundOnly))
+      .WillOnce(Return(true));
+
+  std::shared_ptr<MockStreamDecoderFilter> filter(new NiceMock<MockStreamDecoderFilter>());
+  EXPECT_CALL(filter_factory_, createFilterChain(_))
+      .WillOnce(Invoke([&](FilterChainManager& manager) -> bool {
+        auto factory = createDecoderFilterFactoryCb(StreamDecoderFilterSharedPtr{filter});
+        manager.applyFilterFactoryCb({}, factory);
+        return true;
+      }));
+
+  EXPECT_CALL(*codec_, dispatch(_))
+      .WillRepeatedly(Invoke([&](Buffer::Instance& data) -> Http::Status {
+        decoder_ = &conn_manager_->newStream(response_encoder_);
+        RequestHeaderMapPtr headers{new TestRequestHeaderMapImpl{{":authority", "host"},
+                                                                 {":path", "/"},
+                                                                 {":method", "GET"},
+                                                                 {"connection", "keep-alive"}}};
+        decoder_->decodeHeaders(std::move(headers), true);
+
+        ResponseHeaderMapPtr response_headers{new TestResponseHeaderMapImpl{{":status", "200"}}};
+        filter->callbacks_->streamInfo().setResponseCodeDetails("");
+        filter->callbacks_->encodeHeaders(std::move(response_headers), true, "details");
+
+        data.drain(4);
+        return Http::okStatus();
+      }));
+
+  EXPECT_CALL(response_encoder_, encodeHeaders(_, true))
+      .WillOnce(Invoke([](const ResponseHeaderMap& headers, bool) -> void {
+        EXPECT_EQ("close", headers.getConnectionValue());
+      }));
+
+  Buffer::OwnedImpl fake_input;
+  conn_manager_->onData(fake_input, false);
+}
+
 TEST_F(HttpConnectionManagerImplTest, DisableKeepAliveWhenDraining) {
   setup();
 
-  EXPECT_CALL(drain_close_, drainClose()).WillOnce(Return(true));
+  EXPECT_CALL(drain_close_, drainClose(Network::DrainDirection::All)).WillOnce(Return(true));
 
   std::shared_ptr<MockStreamDecoderFilter> filter(new NiceMock<MockStreamDecoderFilter>());
   EXPECT_CALL(filter_factory_, createFilterChain(_))

--- a/test/common/http/conn_manager_impl_test_base.cc
+++ b/test/common/http/conn_manager_impl_test_base.cc
@@ -3,11 +3,13 @@
 #include "source/extensions/request_id/uuid/config.h"
 
 #include "test/common/http/xff_extension.h"
+#include "test/extensions/filters/network/common/fuzz/utils/fakes.h"
 
 using testing::AtLeast;
 using testing::InSequence;
 using testing::InvokeWithoutArgs;
 using testing::Return;
+using testing::ReturnRef;
 
 namespace Envoy {
 namespace Http {
@@ -198,6 +200,9 @@ void HttpConnectionManagerImplMixin::setup(const SetupOpts& opts) {
       .WillByDefault([&](auto, auto callback) {
         return filter_callbacks_.connection_.dispatcher_.createTimer(callback).release();
       });
+
+  const Network::ListenerInfo& listener_info = Server::Configuration::FakeListenerInfo();
+  ON_CALL(factory_context_, listenerInfo()).WillByDefault(ReturnRef(listener_info));
   filter_callbacks_.connection_.stream_info_.downstream_connection_info_provider_->setLocalAddress(
       std::make_shared<Network::Address::Ipv4Instance>("127.0.0.1", 443));
   filter_callbacks_.connection_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(
@@ -211,7 +216,7 @@ void HttpConnectionManagerImplMixin::setup(const SetupOpts& opts) {
   conn_manager_ = std::make_unique<ConnectionManagerImpl>(
       std::make_shared<ConnectionManagerConfigProxyObject>(*this), drain_close_, random_,
       http_context_, runtime_, local_info_, cluster_manager_, overload_manager_,
-      test_time_.timeSystem());
+      test_time_.timeSystem(), factory_context_.listenerInfo().direction());
 
   conn_manager_->initializeReadFilterCallbacks(filter_callbacks_);
 

--- a/test/common/http/hcm_router_fuzz_test.cc
+++ b/test/common/http/hcm_router_fuzz_test.cc
@@ -508,7 +508,8 @@ public:
   void fuzz(const FuzzCase& input) {
     hcm_ = std::make_unique<ConnectionManagerImpl>(
         hcm_config_, drain_close_, random_, hcm_config_->http_context_, runtime_, local_info_,
-        hcm_config_->cm_, overload_manager_, hcm_config_->time_system_);
+        hcm_config_->cm_, overload_manager_, hcm_config_->time_system_,
+        envoy::config::core::v3::TrafficDirection::UNSPECIFIED);
     hcm_->initializeReadFilterCallbacks(filter_callbacks_);
     Buffer::OwnedImpl data;
     hcm_->onData(data, false);

--- a/test/common/listener_manager/filter_chain_manager_impl_test.cc
+++ b/test/common/listener_manager/filter_chain_manager_impl_test.cc
@@ -282,15 +282,15 @@ TEST_P(FilterChainManagerImplTest, CreatedFilterChainFactoryContextHasIndependen
   EXPECT_CALL(mock_server_context, drainManager).WillRepeatedly(ReturnRef(not_a_draining_manager));
   EXPECT_CALL(parent_context_, serverFactoryContext).WillRepeatedly(ReturnRef(mock_server_context));
 
-  EXPECT_FALSE(context0->drainDecision().drainClose());
-  EXPECT_FALSE(context1->drainDecision().drainClose());
+  EXPECT_FALSE(context0->drainDecision().drainClose(Network::DrainDirection::All));
+  EXPECT_FALSE(context1->drainDecision().drainClose(Network::DrainDirection::All));
 
   // Drain filter chain 0
   auto* context_impl_0 = dynamic_cast<PerFilterChainFactoryContextImpl*>(context0.get());
   context_impl_0->startDraining();
 
-  EXPECT_TRUE(context0->drainDecision().drainClose());
-  EXPECT_FALSE(context1->drainDecision().drainClose());
+  EXPECT_TRUE(context0->drainDecision().drainClose(Network::DrainDirection::All));
+  EXPECT_FALSE(context1->drainDecision().drainClose(Network::DrainDirection::All));
 }
 
 TEST_P(FilterChainManagerImplTest, DuplicateFilterChainMatchFails) {

--- a/test/common/listener_manager/listener_manager_impl_test.cc
+++ b/test/common/listener_manager/listener_manager_impl_test.cc
@@ -153,7 +153,8 @@ public:
     }
     EXPECT_CALL(*worker_, addListener(_, _, _, _, _));
     EXPECT_CALL(*worker_, stopListener(_, _, _));
-    EXPECT_CALL(*old_listener_handle->drain_manager_, startDrainSequence(_));
+    EXPECT_CALL(*old_listener_handle->drain_manager_,
+                startDrainSequence(Network::DrainDirection::All, _));
 
     EXPECT_TRUE(addOrUpdateListener(new_listener_proto));
 
@@ -170,7 +171,8 @@ public:
 
     EXPECT_CALL(*worker_, stopListener(_, _, _));
     EXPECT_CALL(socket, close());
-    EXPECT_CALL(*listener_handle->drain_manager_, startDrainSequence(_));
+    EXPECT_CALL(*listener_handle->drain_manager_,
+                startDrainSequence(Network::DrainDirection::All, _));
     EXPECT_TRUE(manager_->removeListener(listener_proto.name()));
 
     EXPECT_CALL(*worker_, removeListener(_, _));
@@ -1735,7 +1737,8 @@ dynamic_listeners:
   EXPECT_CALL(*duplicated_socket, duplicate());
   EXPECT_CALL(*worker_, addListener(_, _, _, _, _));
   EXPECT_CALL(*worker_, stopListener(_, _, _));
-  EXPECT_CALL(*listener_foo_update1->drain_manager_, startDrainSequence(_));
+  EXPECT_CALL(*listener_foo_update1->drain_manager_,
+              startDrainSequence(Network::DrainDirection::All, _));
   EXPECT_TRUE(addOrUpdateListener(parseListenerFromV3Yaml(listener_foo_yaml), "version3", true));
   worker_->callAddCompletion();
   checkStats(__LINE__, 1, 2, 0, 0, 1, 1, 0);
@@ -2409,7 +2412,7 @@ filter_chains:
         ASSERT_TRUE(completion != nullptr);
         stop_completion = std::move(completion);
       }));
-  EXPECT_CALL(*listener_foo->drain_manager_, startDrainSequence(_));
+  EXPECT_CALL(*listener_foo->drain_manager_, startDrainSequence(Network::DrainDirection::All, _));
   EXPECT_TRUE(manager_->removeListener("foo"));
   checkStats(__LINE__, 1, 0, 1, 0, 0, 1, 0);
   EXPECT_CALL(*worker_, removeListener(_, _));
@@ -2471,7 +2474,7 @@ filter_chains:
         ASSERT_TRUE(completion != nullptr);
         stop_completion = std::move(completion);
       }));
-  EXPECT_CALL(*listener_foo->drain_manager_, startDrainSequence(_));
+  EXPECT_CALL(*listener_foo->drain_manager_, startDrainSequence(Network::DrainDirection::All, _));
   EXPECT_TRUE(manager_->removeListener("foo"));
   checkStats(__LINE__, 1, 0, 1, 0, 0, 1, 0);
   EXPECT_CALL(*worker_, removeListener(_, _));
@@ -2526,7 +2529,7 @@ filter_chains:
   // Remove foo into draining.
   EXPECT_CALL(*worker_, stopListener(_, _, _));
   EXPECT_CALL(*listener_factory_.socket_, close());
-  EXPECT_CALL(*listener_foo->drain_manager_, startDrainSequence(_));
+  EXPECT_CALL(*listener_foo->drain_manager_, startDrainSequence(Network::DrainDirection::All, _));
   EXPECT_TRUE(manager_->removeListener("foo"));
   checkStats(__LINE__, 1, 0, 1, 0, 0, 1, 0);
   EXPECT_CALL(*worker_, removeListener(_, _));
@@ -2580,7 +2583,7 @@ filter_chains:
   // Remove foo into draining.
   EXPECT_CALL(*worker_, stopListener(_, _, _));
   EXPECT_CALL(*listener_factory_.socket_, close()).Times(2);
-  EXPECT_CALL(*listener_foo->drain_manager_, startDrainSequence(_));
+  EXPECT_CALL(*listener_foo->drain_manager_, startDrainSequence(Network::DrainDirection::All, _));
   EXPECT_TRUE(manager_->removeListener("foo"));
   checkStats(__LINE__, 1, 0, 1, 0, 0, 1, 0);
   EXPECT_CALL(*worker_, removeListener(_, _));
@@ -2681,12 +2684,14 @@ filter_chains:
 
   worker_->callAddCompletion();
 
-  EXPECT_CALL(*listener_foo->drain_manager_, drainClose()).WillOnce(Return(false));
-  EXPECT_CALL(server_.drain_manager_, drainClose()).WillOnce(Return(false));
-  EXPECT_FALSE(listener_foo->context_->drainDecision().drainClose());
+  EXPECT_CALL(*listener_foo->drain_manager_, drainClose(Network::DrainDirection::All))
+      .WillOnce(Return(false));
+  EXPECT_CALL(server_.drain_manager_, drainClose(Network::DrainDirection::All))
+      .WillOnce(Return(false));
+  EXPECT_FALSE(listener_foo->context_->drainDecision().drainClose(Network::DrainDirection::All));
 
   EXPECT_CALL(*worker_, stopListener(_, _, _));
-  EXPECT_CALL(*listener_foo->drain_manager_, startDrainSequence(_));
+  EXPECT_CALL(*listener_foo->drain_manager_, startDrainSequence(Network::DrainDirection::All, _));
 
   EXPECT_TRUE(manager_->removeListener("foo"));
 
@@ -2943,26 +2948,31 @@ filter_chains:
   worker_->callAddCompletion();
   checkStats(__LINE__, 1, 0, 0, 0, 1, 0, 0);
 
-  EXPECT_CALL(*listener_foo->drain_manager_, drainClose()).WillOnce(Return(false));
-  EXPECT_CALL(server_.drain_manager_, drainClose()).WillOnce(Return(false));
-  EXPECT_FALSE(listener_foo->context_->drainDecision().drainClose());
+  EXPECT_CALL(*listener_foo->drain_manager_, drainClose(Network::DrainDirection::All))
+      .WillOnce(Return(false));
+  EXPECT_CALL(server_.drain_manager_, drainClose(Network::DrainDirection::All))
+      .WillOnce(Return(false));
+  EXPECT_FALSE(listener_foo->context_->drainDecision().drainClose(Network::DrainDirection::All));
 
   EXPECT_CALL(*worker_, stopListener(_, _, _));
-  EXPECT_CALL(*listener_foo->drain_manager_, startDrainSequence(_));
+  EXPECT_CALL(*listener_foo->drain_manager_, startDrainSequence(Network::DrainDirection::All, _));
   EXPECT_TRUE(manager_->removeListener("foo"));
   checkStats(__LINE__, 1, 0, 1, 0, 0, 1, 0);
 
   // NOTE: || short circuit here prevents the server drain manager from getting called.
-  EXPECT_CALL(*listener_foo->drain_manager_, drainClose()).WillOnce(Return(true));
-  EXPECT_TRUE(listener_foo->context_->drainDecision().drainClose());
+  EXPECT_CALL(*listener_foo->drain_manager_, drainClose(Network::DrainDirection::All))
+      .WillOnce(Return(true));
+  EXPECT_TRUE(listener_foo->context_->drainDecision().drainClose(Network::DrainDirection::All));
 
   EXPECT_CALL(*worker_, removeListener(_, _));
   listener_foo->drain_manager_->drain_sequence_completion_();
   checkStats(__LINE__, 1, 0, 1, 0, 0, 1, 0);
 
-  EXPECT_CALL(*listener_foo->drain_manager_, drainClose()).WillOnce(Return(false));
-  EXPECT_CALL(server_.drain_manager_, drainClose()).WillOnce(Return(true));
-  EXPECT_TRUE(listener_foo->context_->drainDecision().drainClose());
+  EXPECT_CALL(*listener_foo->drain_manager_, drainClose(Network::DrainDirection::All))
+      .WillOnce(Return(false));
+  EXPECT_CALL(server_.drain_manager_, drainClose(Network::DrainDirection::All))
+      .WillOnce(Return(true));
+  EXPECT_TRUE(listener_foo->context_->drainDecision().drainClose(Network::DrainDirection::All));
 
   EXPECT_CALL(*listener_foo, onDestroy());
   worker_->callRemovalCompletion();
@@ -3038,7 +3048,7 @@ filter_chains:
   EXPECT_CALL(*listener_foo_update1, onDestroy());
   EXPECT_CALL(*worker_, stopListener(_, _, _));
   EXPECT_CALL(*listener_factory_.socket_, close());
-  EXPECT_CALL(*listener_foo->drain_manager_, startDrainSequence(_));
+  EXPECT_CALL(*listener_foo->drain_manager_, startDrainSequence(Network::DrainDirection::All, _));
   EXPECT_TRUE(manager_->removeListener("foo"));
   checkStats(__LINE__, 2, 1, 2, 0, 0, 1, 0);
   EXPECT_CALL(*worker_, removeListener(_, _));
@@ -6958,7 +6968,8 @@ per_connection_buffer_limit_bytes: 10
   ListenerHandle* listener_foo_update2 = expectListenerCreate(false, true);
   EXPECT_CALL(*worker_, addListener(_, _, _, _, _));
   EXPECT_CALL(*worker_, stopListener(_, _, _));
-  EXPECT_CALL(*listener_foo_update1->drain_manager_, startDrainSequence(_));
+  EXPECT_CALL(*listener_foo_update1->drain_manager_,
+              startDrainSequence(Network::DrainDirection::All, _));
   EXPECT_TRUE(addOrUpdateListener(parseListenerFromV3Yaml(listener_foo_yaml), "version3", true));
   worker_->callAddCompletion();
   checkStats(__LINE__, 1, 2, 0, 0, 1, 1, 0);
@@ -7237,7 +7248,7 @@ filter_chains:
   EXPECT_CALL(*listener_foo_update1, onDestroy());
   EXPECT_CALL(*worker_, stopListener(_, _, _));
   EXPECT_CALL(*listener_factory_.socket_, close());
-  EXPECT_CALL(*listener_foo->drain_manager_, startDrainSequence(_));
+  EXPECT_CALL(*listener_foo->drain_manager_, startDrainSequence(Network::DrainDirection::All, _));
   EXPECT_TRUE(manager_->removeListener("foo"));
   checkStats(__LINE__, 1, 1, 1, 0, 0, 1, 0);
   EXPECT_CALL(*worker_, removeListener(_, _));
@@ -7599,7 +7610,8 @@ filter_chains:
         ASSERT_TRUE(completion != nullptr);
         stop_completion = std::move(completion);
       }));
-  EXPECT_CALL(*listener_foo_update1->drain_manager_, startDrainSequence(_));
+  EXPECT_CALL(*listener_foo_update1->drain_manager_,
+              startDrainSequence(Network::DrainDirection::All, _));
   EXPECT_TRUE(manager_->removeListener("foo"));
 
   EXPECT_CALL(*worker_, removeListener(_, _));
@@ -7704,7 +7716,8 @@ filter_chains:
         ASSERT_TRUE(completion != nullptr);
         stop_completion = std::move(completion);
       }));
-  EXPECT_CALL(*listener_foo_update1->drain_manager_, startDrainSequence(_));
+  EXPECT_CALL(*listener_foo_update1->drain_manager_,
+              startDrainSequence(Network::DrainDirection::All, _));
   EXPECT_TRUE(manager_->removeListener("foo"));
 
   EXPECT_CALL(*worker_, removeListener(_, _));

--- a/test/extensions/filters/http/health_check/health_check_integration_test.cc
+++ b/test/extensions/filters/http/health_check/health_check_integration_test.cc
@@ -32,7 +32,7 @@ TEST_P(HealthCheckIntegrationTest, DrainCloseGradual) {
 
   absl::Notification drain_sequence_started;
   test_server_->server().dispatcher().post([this, &drain_sequence_started]() {
-    test_server_->drainManager().startDrainSequence([] {});
+    test_server_->drainManager().startDrainSequence(Network::DrainDirection::All, [] {});
     drain_sequence_started.Notify();
   });
   drain_sequence_started.WaitForNotification();
@@ -65,7 +65,7 @@ TEST_P(HealthCheckIntegrationTest, DrainCloseImmediate) {
 
   absl::Notification drain_sequence_started;
   test_server_->server().dispatcher().post([this, &drain_sequence_started]() {
-    test_server_->drainManager().startDrainSequence([] {});
+    test_server_->drainManager().startDrainSequence(Network::DrainDirection::All, [] {});
     drain_sequence_started.Notify();
   });
   drain_sequence_started.WaitForNotification();

--- a/test/extensions/filters/network/common/fuzz/utils/fakes.h
+++ b/test/extensions/filters/network/common/fuzz/utils/fakes.h
@@ -10,20 +10,26 @@ namespace Configuration {
 
 class FakeListenerInfo : public Network::ListenerInfo {
 public:
+  explicit FakeListenerInfo(const envoy::config::listener::v3::Listener& config)
+      : metadata_(config.metadata()), direction_(config.traffic_direction()),
+        is_quic_(config.udp_listener_config().has_quic_options()),
+        bypass_overload_manager_(config.bypass_overload_manager()) {}
+  FakeListenerInfo() = default;
   const envoy::config::core::v3::Metadata& metadata() const override {
     return metadata_.proto_metadata_;
   }
   const Envoy::Config::TypedMetadata& typedMetadata() const override {
     return metadata_.typed_metadata_;
   }
-  envoy::config::core::v3::TrafficDirection direction() const override {
-    return envoy::config::core::v3::UNSPECIFIED;
-  }
-  bool isQuic() const override { return false; }
-  bool shouldBypassOverloadManager() const override { return false; }
+  envoy::config::core::v3::TrafficDirection direction() const override { return direction_; }
+  bool isQuic() const override { return is_quic_; }
+  bool shouldBypassOverloadManager() const override { return bypass_overload_manager_; }
 
 private:
   Envoy::Config::MetadataPack<Envoy::Network::ListenerTypedMetadataFactory> metadata_;
+  envoy::config::core::v3::TrafficDirection direction_ = envoy::config::core::v3::UNSPECIFIED;
+  const bool is_quic_ = false;
+  const bool bypass_overload_manager_ = false;
 };
 
 class FakeFactoryContext : public MockFactoryContext {

--- a/test/extensions/filters/network/generic_proxy/proxy_test.cc
+++ b/test/extensions/filters/network/generic_proxy/proxy_test.cc
@@ -1059,7 +1059,8 @@ TEST_F(FilterTest, UpstreamResponseAfterPreviousUpstreamResponse) {
 
   auto active_stream = filter_->activeStreamsForTest().begin()->get();
 
-  EXPECT_CALL(factory_context_.drain_manager_, drainClose()).WillOnce(Return(false));
+  EXPECT_CALL(factory_context_.drain_manager_, drainClose(Network::DrainDirection::All))
+      .WillOnce(Return(false));
   EXPECT_CALL(filter_callbacks_.connection_.dispatcher_, deferredDelete_(_));
 
   // Response filter chain is stopped by the first filter.
@@ -1100,7 +1101,8 @@ TEST_F(FilterTest, UpstreamResponseAfterPreviousLocalReply) {
 
   auto active_stream = filter_->activeStreamsForTest().begin()->get();
 
-  EXPECT_CALL(factory_context_.drain_manager_, drainClose()).WillOnce(Return(false));
+  EXPECT_CALL(factory_context_.drain_manager_, drainClose(Network::DrainDirection::All))
+      .WillOnce(Return(false));
   EXPECT_CALL(filter_callbacks_.connection_.dispatcher_, deferredDelete_(_));
 
   // Response filter chain of local reply is stopped by the first filter.
@@ -1142,7 +1144,8 @@ TEST_F(FilterTest, SendLocalReplyAfterPreviousLocalReply) {
 
   auto active_stream = filter_->activeStreamsForTest().begin()->get();
 
-  EXPECT_CALL(factory_context_.drain_manager_, drainClose()).WillOnce(Return(false));
+  EXPECT_CALL(factory_context_.drain_manager_, drainClose(Network::DrainDirection::All))
+      .WillOnce(Return(false));
   EXPECT_CALL(filter_callbacks_.connection_.dispatcher_, deferredDelete_(_));
 
   // Response filter chain of local reply is stopped by the first filter.
@@ -1198,7 +1201,8 @@ TEST_F(FilterTest, SendLocalReplyAfterPreviousUpstreamResponseHeaderIsSent) {
 
   auto active_stream = filter_->activeStreamsForTest().begin()->get();
 
-  EXPECT_CALL(factory_context_.drain_manager_, drainClose()).WillOnce(Return(false));
+  EXPECT_CALL(factory_context_.drain_manager_, drainClose(Network::DrainDirection::All))
+      .WillOnce(Return(false));
   EXPECT_CALL(filter_callbacks_.connection_.dispatcher_, deferredDelete_(_));
 
   testing::Sequence s;
@@ -1305,7 +1309,8 @@ TEST_F(FilterTest, ActiveStreamSendLocalReply) {
                     "response-value - 2 test_detail"));
 
   // Check the drain manager.
-  EXPECT_CALL(factory_context_.drain_manager_, drainClose()).WillOnce(Return(false));
+  EXPECT_CALL(factory_context_.drain_manager_, drainClose(Network::DrainDirection::All))
+      .WillOnce(Return(false));
 
   filter_->onDecodingSuccess(std::move(request));
 
@@ -1391,7 +1396,8 @@ TEST_F(FilterTest, ActiveStreamSendLocalReplyWhenProcessingBody) {
                     "response-value - 2 test_detail"));
 
   // Check the drain manager.
-  EXPECT_CALL(factory_context_.drain_manager_, drainClose()).WillOnce(Return(false));
+  EXPECT_CALL(factory_context_.drain_manager_, drainClose(Network::DrainDirection::All))
+      .WillOnce(Return(false));
 
   auto request_frame = std::make_unique<FakeStreamCodecFactory::FakeCommonFrame>();
   filter_->onDecodingSuccess(std::move(request_frame));
@@ -1488,7 +1494,8 @@ TEST_F(FilterTest, ActiveStreamSendLocalReplyWhenTransferringBody) {
                     "response-value - 2 test_detail"));
 
   // Check the drain manager.
-  EXPECT_CALL(factory_context_.drain_manager_, drainClose()).WillOnce(Return(false));
+  EXPECT_CALL(factory_context_.drain_manager_, drainClose(Network::DrainDirection::All))
+      .WillOnce(Return(false));
 
   auto request_frame = std::make_unique<FakeStreamCodecFactory::FakeCommonFrame>();
   filter_->onDecodingSuccess(std::move(request_frame));
@@ -1590,7 +1597,8 @@ TEST_F(FilterTest, NewStreamAndReplyNormally) {
               write("host-value /path-value method-value protocol-value request-value "
                     "response-value - 0 via_upstream"));
 
-  EXPECT_CALL(factory_context_.drain_manager_, drainClose()).WillOnce(Return(false));
+  EXPECT_CALL(factory_context_.drain_manager_, drainClose(Network::DrainDirection::All))
+      .WillOnce(Return(false));
   EXPECT_CALL(filter_callbacks_.connection_.dispatcher_, deferredDelete_(_));
 
   auto response = std::make_unique<FakeStreamCodecFactory::FakeResponse>();
@@ -1661,7 +1669,8 @@ TEST_F(FilterTest, NewStreamAndReplyNormallyWithMultipleFrames) {
               write("host-value /path-value method-value protocol-value request-value "
                     "response-value - 123 via_upstream"));
 
-  EXPECT_CALL(factory_context_.drain_manager_, drainClose()).WillOnce(Return(false));
+  EXPECT_CALL(factory_context_.drain_manager_, drainClose(Network::DrainDirection::All))
+      .WillOnce(Return(false));
   EXPECT_CALL(filter_callbacks_.connection_.dispatcher_, deferredDelete_(_));
 
   EXPECT_CALL(filter_callbacks_.connection_, write(BufferStringEqual("test"), false)).Times(2);
@@ -1727,7 +1736,8 @@ TEST_F(FilterTest, NewStreamAndReplyNormallyWithDrainClose) {
         return EncodingResult{4};
       }));
 
-  EXPECT_CALL(factory_context_.drain_manager_, drainClose()).WillOnce(Return(true));
+  EXPECT_CALL(factory_context_.drain_manager_, drainClose(Network::DrainDirection::All))
+      .WillOnce(Return(true));
   EXPECT_CALL(filter_callbacks_.connection_.dispatcher_, deferredDelete_(_));
   EXPECT_CALL(filter_callbacks_.connection_, close(Network::ConnectionCloseType::FlushWrite));
 
@@ -1775,7 +1785,8 @@ TEST_F(FilterTest, NewStreamAndReplyNormallyWithStreamDrainClose) {
 
   // The drain close of factory_context_.drain_manager_ is false, but the drain close of
   // active_stream is true.
-  EXPECT_CALL(factory_context_.drain_manager_, drainClose()).WillOnce(Return(false));
+  EXPECT_CALL(factory_context_.drain_manager_, drainClose(Network::DrainDirection::All))
+      .WillOnce(Return(false));
   EXPECT_CALL(filter_callbacks_.connection_.dispatcher_, deferredDelete_(_));
   EXPECT_CALL(filter_callbacks_.connection_, close(Network::ConnectionCloseType::FlushWrite));
 
@@ -1835,7 +1846,8 @@ TEST_F(FilterTest, NewStreamAndReplyNormallyWithTracing) {
         return EncodingResult{4};
       }));
 
-  EXPECT_CALL(factory_context_.drain_manager_, drainClose()).WillOnce(Return(false));
+  EXPECT_CALL(factory_context_.drain_manager_, drainClose(Network::DrainDirection::All))
+      .WillOnce(Return(false));
   EXPECT_CALL(filter_callbacks_.connection_.dispatcher_, deferredDelete_(_));
 
   auto response = std::make_unique<FakeStreamCodecFactory::FakeResponse>();
@@ -1895,7 +1907,8 @@ TEST_F(FilterTest, NewStreamAndReplyNormallyWithTracingAndSamplingToTrue) {
         return EncodingResult{4};
       }));
 
-  EXPECT_CALL(factory_context_.drain_manager_, drainClose()).WillOnce(Return(false));
+  EXPECT_CALL(factory_context_.drain_manager_, drainClose(Network::DrainDirection::All))
+      .WillOnce(Return(false));
   EXPECT_CALL(filter_callbacks_.connection_.dispatcher_, deferredDelete_(_));
 
   auto response = std::make_unique<FakeStreamCodecFactory::FakeResponse>();

--- a/test/extensions/filters/network/mongo_proxy/proxy_test.cc
+++ b/test/extensions/filters/network/mongo_proxy/proxy_test.cc
@@ -569,7 +569,7 @@ TEST_F(MongoProxyFilterTest, ConcurrentQueryWithDrainClose) {
     message->documents().push_back(Bson::DocumentImpl::create()->addString("hello", "world"));
     ON_CALL(runtime_.snapshot_, featureEnabled("mongo.drain_close_enabled", 100))
         .WillByDefault(Return(true));
-    EXPECT_CALL(drain_decision_, drainClose()).WillOnce(Return(true));
+    EXPECT_CALL(drain_decision_, drainClose(Network::DrainDirection::All)).WillOnce(Return(true));
     drain_timer = new Event::MockTimer(&read_filter_callbacks_.connection_.dispatcher_);
     EXPECT_CALL(*drain_timer, enableTimer(std::chrono::milliseconds(0), _));
     filter_->callbacks_->decodeReply(std::move(message));

--- a/test/extensions/filters/network/redis_proxy/proxy_filter_test.cc
+++ b/test/extensions/filters/network/redis_proxy/proxy_filter_test.cc
@@ -398,7 +398,7 @@ TEST_F(RedisProxyFilterTestWithTwoCallbacks, OutOfOrderResponseWithDrainClose) {
   EXPECT_CALL(*encoder_, encode(Ref(*response1), _));
   EXPECT_CALL(*encoder_, encode(Ref(*response2_ptr), _));
   EXPECT_CALL(filter_callbacks_.connection_, write(_, _));
-  EXPECT_CALL(drain_decision_, drainClose()).WillOnce(Return(true));
+  EXPECT_CALL(drain_decision_, drainClose(Network::DrainDirection::All)).WillOnce(Return(true));
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("redis.drain_close_enabled", 100))
       .WillOnce(Return(true));
   EXPECT_CALL(filter_callbacks_.connection_, close(Network::ConnectionCloseType::FlushWrite));

--- a/test/extensions/filters/network/thrift_proxy/conn_manager_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/conn_manager_test.cc
@@ -451,7 +451,7 @@ stat_prefix: test
     TestScopedRuntime scoped_runtime;
 
     if (draining) {
-      EXPECT_CALL(drain_decision_, drainClose()).WillOnce(Return(true));
+      EXPECT_CALL(drain_decision_, drainClose(Network::DrainDirection::All)).WillOnce(Return(true));
     }
 
     initializeFilter(defaultYamlConfig(true));
@@ -2176,7 +2176,7 @@ TEST_F(ThriftConnectionManagerTest, TransportEndWhenRemoteClose) {
   TestScopedRuntime scoped_runtime;
 
   // We want the Drain header to be set by RemoteClose which triggers end downstream in local reply.
-  EXPECT_CALL(drain_decision_, drainClose()).WillOnce(Return(false));
+  EXPECT_CALL(drain_decision_, drainClose(Network::DrainDirection::All)).WillOnce(Return(false));
 
   initializeFilter();
   writeComplexFramedBinaryMessage(buffer_, MessageType::Call, 0x0F);

--- a/test/integration/drain_close_integration_test.cc
+++ b/test/integration/drain_close_integration_test.cc
@@ -16,7 +16,7 @@ TEST_P(DrainCloseIntegrationTest, DrainCloseGradual) {
 
   absl::Notification drain_sequence_started;
   test_server_->server().dispatcher().post([this, &drain_sequence_started]() {
-    test_server_->drainManager().startDrainSequence([] {});
+    test_server_->drainManager().startDrainSequence(Network::DrainDirection::All, [] {});
     drain_sequence_started.Notify();
   });
   drain_sequence_started.WaitForNotification();
@@ -50,7 +50,7 @@ TEST_P(DrainCloseIntegrationTest, DrainCloseImmediate) {
 
   absl::Notification drain_sequence_started;
   test_server_->server().dispatcher().post([this, &drain_sequence_started]() {
-    test_server_->drainManager().startDrainSequence([] {});
+    test_server_->drainManager().startDrainSequence(Network::DrainDirection::All, [] {});
     drain_sequence_started.Notify();
   });
   drain_sequence_started.WaitForNotification();

--- a/test/integration/http2_flood_integration_test.cc
+++ b/test/integration/http2_flood_integration_test.cc
@@ -291,7 +291,7 @@ Http2FloodMitigationTest::prefillOutboundUpstreamQueue(uint32_t frame_count) {
 void Http2FloodMitigationTest::triggerListenerDrain() {
   absl::Notification drain_sequence_started;
   test_server_->server().dispatcher().post([this, &drain_sequence_started]() {
-    test_server_->drainManager().startDrainSequence([] {});
+    test_server_->drainManager().startDrainSequence(Network::DrainDirection::All, [] {});
     drain_sequence_started.Notify();
   });
   drain_sequence_started.WaitForNotification();

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -199,7 +199,8 @@ public:
   ~MockDrainDecision() override;
 
   MOCK_METHOD(bool, drainClose, (Network::DrainDirection direction), (const));
-  MOCK_METHOD(Common::CallbackHandlePtr, addOnDrainCloseCb, (Network::DrainDirection direction, DrainCloseCb cb), (const, override));
+  MOCK_METHOD(Common::CallbackHandlePtr, addOnDrainCloseCb,
+              (Network::DrainDirection direction, DrainCloseCb cb), (const, override));
 };
 
 class MockListenerFilter : public ListenerFilter {

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -198,8 +198,8 @@ public:
   MockDrainDecision();
   ~MockDrainDecision() override;
 
-  MOCK_METHOD(bool, drainClose, (), (const));
-  MOCK_METHOD(Common::CallbackHandlePtr, addOnDrainCloseCb, (DrainCloseCb cb), (const, override));
+  MOCK_METHOD(bool, drainClose, (Network::DrainDirection direction), (const));
+  MOCK_METHOD(Common::CallbackHandlePtr, addOnDrainCloseCb, (Network::DrainDirection direction, DrainCloseCb cb), (const, override));
 };
 
 class MockListenerFilter : public ListenerFilter {

--- a/test/mocks/server/drain_manager.cc
+++ b/test/mocks/server/drain_manager.cc
@@ -9,10 +9,12 @@ namespace Envoy {
 namespace Server {
 
 using ::testing::_;
+using ::testing::DoAll;
 using ::testing::SaveArg;
 
 MockDrainManager::MockDrainManager() {
-  ON_CALL(*this, startDrainSequence(_)).WillByDefault(SaveArg<0>(&drain_sequence_completion_));
+  ON_CALL(*this, startDrainSequence(_, _))
+      .WillByDefault(DoAll(SaveArg<0>(&drain_direction_), SaveArg<1>(&drain_sequence_completion_)));
 }
 
 MockDrainManager::~MockDrainManager() = default;

--- a/test/mocks/server/drain_manager.h
+++ b/test/mocks/server/drain_manager.h
@@ -26,11 +26,12 @@ public:
   MOCK_METHOD(bool, draining, (Network::DrainDirection direction), (const));
   MOCK_METHOD(void, startParentShutdownSequence, ());
   MOCK_METHOD(void, startDrainSequence,
-    (Network::DrainDirection direction, std::function<void()> completion));
+              (Network::DrainDirection direction, std::function<void()> completion));
 
   // Network::DrainDecision
   MOCK_METHOD(bool, drainClose, (Network::DrainDirection direction), (const));
-  MOCK_METHOD(Common::CallbackHandlePtr, addOnDrainCloseCb, (Network::DrainDirection direction, DrainCloseCb cb), (const, override));
+  MOCK_METHOD(Common::CallbackHandlePtr, addOnDrainCloseCb,
+              (Network::DrainDirection direction, DrainCloseCb cb), (const, override));
 
   std::function<void()> drain_sequence_completion_;
   Network::DrainDirection drain_direction_;

--- a/test/mocks/server/drain_manager.h
+++ b/test/mocks/server/drain_manager.h
@@ -23,15 +23,17 @@ public:
   MOCK_METHOD(DrainManagerPtr, createChildManager,
               (Event::Dispatcher&, envoy::config::listener::v3::Listener::DrainType), (override));
   MOCK_METHOD(DrainManagerPtr, createChildManager, (Event::Dispatcher&), (override));
-  MOCK_METHOD(bool, draining, (), (const));
+  MOCK_METHOD(bool, draining, (Network::DrainDirection direction), (const));
   MOCK_METHOD(void, startParentShutdownSequence, ());
-  MOCK_METHOD(void, startDrainSequence, (std::function<void()> completion));
+  MOCK_METHOD(void, startDrainSequence,
+    (Network::DrainDirection direction, std::function<void()> completion));
 
   // Network::DrainDecision
-  MOCK_METHOD(bool, drainClose, (), (const));
-  MOCK_METHOD(Common::CallbackHandlePtr, addOnDrainCloseCb, (DrainCloseCb cb), (const, override));
+  MOCK_METHOD(bool, drainClose, (Network::DrainDirection direction), (const));
+  MOCK_METHOD(Common::CallbackHandlePtr, addOnDrainCloseCb, (Network::DrainDirection direction, DrainCloseCb cb), (const, override));
 
   std::function<void()> drain_sequence_completion_;
+  Network::DrainDirection drain_direction_;
 };
 } // namespace Server
 } // namespace Envoy

--- a/test/server/drain_manager_impl_test.cc
+++ b/test/server/drain_manager_impl_test.cc
@@ -60,14 +60,17 @@ protected:
       return absl::OkStatus();
     }));
 
-    auto before_handle = drain_manager.addOnDrainCloseCb(cb_before_drain.AsStdFunction());
-    drain_manager.startDrainSequence([] {});
+    auto before_handle = drain_manager.addOnDrainCloseCb(Network::DrainDirection::All,
+                                                         cb_before_drain.AsStdFunction());
+    drain_manager.startDrainSequence(Network::DrainDirection::All, [] {});
 
     server_.api_.time_system_.advanceTimeWait(std::chrono::milliseconds(10));
-    auto after_handle1 = drain_manager.addOnDrainCloseCb(cb_after_drain1.AsStdFunction());
+    auto after_handle1 = drain_manager.addOnDrainCloseCb(Network::DrainDirection::All,
+                                                         cb_after_drain1.AsStdFunction());
 
     server_.api_.time_system_.advanceTimeWait(delay);
-    auto after_handle2 = drain_manager.addOnDrainCloseCb(cb_after_drain2.AsStdFunction());
+    auto after_handle2 = drain_manager.addOnDrainCloseCb(Network::DrainDirection::All,
+                                                         cb_after_drain2.AsStdFunction());
 
     EXPECT_EQ(after_handle1, nullptr);
     EXPECT_EQ(after_handle2, nullptr);
@@ -231,12 +234,13 @@ TEST_P(DrainManagerImplTest, OnDrainCallbacks) {
         EXPECT_CALL(cb, Call(std::chrono::milliseconds{0}));
       }
 
-      cb_handles[i] = drain_manager.addOnDrainCloseCb(cb.AsStdFunction());
+      cb_handles[i] =
+          drain_manager.addOnDrainCloseCb(Network::DrainDirection::All, cb.AsStdFunction());
     }
-    drain_manager.startDrainSequence([] {});
+    drain_manager.startDrainSequence(Network::DrainDirection::All, [] {});
   }
 
-  EXPECT_TRUE(drain_manager.draining());
+  EXPECT_TRUE(drain_manager.draining(Network::DrainDirection::All));
 }
 
 INSTANTIATE_TEST_SUITE_P(DrainStrategies, DrainManagerImplTest, testing::Bool());
@@ -267,12 +271,13 @@ TEST_F(DrainManagerImplTest, OnDrainCallbacksManyGradualSteps) {
         return absl::OkStatus();
       }));
 
-      cb_handles[i] = drain_manager.addOnDrainCloseCb(cb.AsStdFunction());
+      cb_handles[i] =
+          drain_manager.addOnDrainCloseCb(Network::DrainDirection::All, cb.AsStdFunction());
     }
-    drain_manager.startDrainSequence([] {});
+    drain_manager.startDrainSequence(Network::DrainDirection::All, [] {});
   }
 
-  EXPECT_TRUE(drain_manager.draining());
+  EXPECT_TRUE(drain_manager.draining(Network::DrainDirection::All));
 }
 
 // Test gradual draining when the number of callbacks does not evenly divide into
@@ -301,13 +306,14 @@ TEST_F(DrainManagerImplTest, OnDrainCallbacksNonEvenlyDividedSteps) {
         return absl::OkStatus();
       }));
 
-      cb_handles[i] = drain_manager.addOnDrainCloseCb(cb.AsStdFunction());
+      cb_handles[i] =
+          drain_manager.addOnDrainCloseCb(Network::DrainDirection::All, cb.AsStdFunction());
     }
 
-    drain_manager.startDrainSequence([] {});
+    drain_manager.startDrainSequence(Network::DrainDirection::All, [] {});
   }
 
-  EXPECT_TRUE(drain_manager.draining());
+  EXPECT_TRUE(drain_manager.draining(Network::DrainDirection::All));
 }
 
 // Validate the expected behavior when a drain-close callback is registered
@@ -342,9 +348,11 @@ TEST_F(DrainManagerImplTest, RegisterCallbackAfterDrainBeginImmediateStrategy) {
     return absl::OkStatus();
   }));
 
-  auto before_handle = drain_manager.addOnDrainCloseCb(cb_before_drain.AsStdFunction());
-  drain_manager.startDrainSequence([] {});
-  auto after_handle = drain_manager.addOnDrainCloseCb(cb_after_drain.AsStdFunction());
+  auto before_handle = drain_manager.addOnDrainCloseCb(Network::DrainDirection::All,
+                                                       cb_before_drain.AsStdFunction());
+  drain_manager.startDrainSequence(Network::DrainDirection::All, [] {});
+  auto after_handle =
+      drain_manager.addOnDrainCloseCb(Network::DrainDirection::All, cb_after_drain.AsStdFunction());
   EXPECT_EQ(after_handle, nullptr);
 }
 
@@ -359,15 +367,15 @@ TEST_F(DrainManagerImplTest, ParentDestructedBeforeChildren) {
   auto child_a = parent->createChildManager(server_.dispatcher());
   auto child_b = parent->createChildManager(server_.dispatcher());
 
-  EXPECT_FALSE(parent->draining());
-  EXPECT_FALSE(child_a->draining());
-  EXPECT_FALSE(child_b->draining());
+  EXPECT_FALSE(parent->draining(Network::DrainDirection::All));
+  EXPECT_FALSE(child_a->draining(Network::DrainDirection::All));
+  EXPECT_FALSE(child_b->draining(Network::DrainDirection::All));
 
   parent.reset();
 
   // parent destruction should not effect drain state
-  EXPECT_FALSE(child_a->draining());
-  EXPECT_FALSE(child_b->draining());
+  EXPECT_FALSE(child_a->draining(Network::DrainDirection::All));
+  EXPECT_FALSE(child_b->draining(Network::DrainDirection::All));
 
   // Further children creation (from existing children) is still possible
   auto child_a1 = child_a->createChildManager(server_.dispatcher());
@@ -387,10 +395,10 @@ TEST_F(DrainManagerImplTest, ParentDestructedBeforeChildren) {
     called += 1;
     return absl::OkStatus();
   }));
-  auto handle_a1 = child_a1->addOnDrainCloseCb(cb_a1.AsStdFunction());
-  auto handle_b1 = child_b1->addOnDrainCloseCb(cb_b1.AsStdFunction());
-  child_a->startDrainSequence([] {});
-  child_b->startDrainSequence([] {});
+  auto handle_a1 = child_a1->addOnDrainCloseCb(Network::DrainDirection::All, cb_a1.AsStdFunction());
+  auto handle_b1 = child_b1->addOnDrainCloseCb(Network::DrainDirection::All, cb_b1.AsStdFunction());
+  child_a->startDrainSequence(Network::DrainDirection::All, [] {});
+  child_b->startDrainSequence(Network::DrainDirection::All, [] {});
   EXPECT_EQ(called, 2);
 
   // It is safe to clean up children
@@ -434,15 +442,15 @@ TEST_F(DrainManagerImplTest, DrainingCascadesThroughAllNodesInTree) {
       return absl::OkStatus();
     }));
   }
-  auto handle_a = a.addOnDrainCloseCb(cbs[0].AsStdFunction());
-  auto handle_b = b->addOnDrainCloseCb(cbs[1].AsStdFunction());
-  auto handle_c = c->addOnDrainCloseCb(cbs[2].AsStdFunction());
-  auto handle_d = d->addOnDrainCloseCb(cbs[3].AsStdFunction());
-  auto handle_e = e->addOnDrainCloseCb(cbs[4].AsStdFunction());
-  auto handle_f = f->addOnDrainCloseCb(cbs[5].AsStdFunction());
-  auto handle_g = g->addOnDrainCloseCb(cbs[6].AsStdFunction());
+  auto handle_a = a.addOnDrainCloseCb(Network::DrainDirection::All, cbs[0].AsStdFunction());
+  auto handle_b = b->addOnDrainCloseCb(Network::DrainDirection::All, cbs[1].AsStdFunction());
+  auto handle_c = c->addOnDrainCloseCb(Network::DrainDirection::All, cbs[2].AsStdFunction());
+  auto handle_d = d->addOnDrainCloseCb(Network::DrainDirection::All, cbs[3].AsStdFunction());
+  auto handle_e = e->addOnDrainCloseCb(Network::DrainDirection::All, cbs[4].AsStdFunction());
+  auto handle_f = f->addOnDrainCloseCb(Network::DrainDirection::All, cbs[5].AsStdFunction());
+  auto handle_g = g->addOnDrainCloseCb(Network::DrainDirection::All, cbs[6].AsStdFunction());
 
-  a.startDrainSequence([] {});
+  a.startDrainSequence(Network::DrainDirection::All, [] {});
   EXPECT_EQ(call_count, 7);
 }
 
@@ -492,12 +500,12 @@ TEST_F(DrainManagerImplTest, DrainingIsIndependentToNeighbors) {
   EXPECT_CALL(cb_f, Call(_)).Times(0);
   EXPECT_CALL(cb_g, Call(_)).Times(0);
 
-  auto handle_d = d->addOnDrainCloseCb(cb_d.AsStdFunction());
-  auto handle_e = e->addOnDrainCloseCb(cb_e.AsStdFunction());
-  auto handle_f = f->addOnDrainCloseCb(cb_f.AsStdFunction());
-  auto handle_g = g->addOnDrainCloseCb(cb_g.AsStdFunction());
+  auto handle_d = d->addOnDrainCloseCb(Network::DrainDirection::All, cb_d.AsStdFunction());
+  auto handle_e = e->addOnDrainCloseCb(Network::DrainDirection::All, cb_e.AsStdFunction());
+  auto handle_f = f->addOnDrainCloseCb(Network::DrainDirection::All, cb_f.AsStdFunction());
+  auto handle_g = g->addOnDrainCloseCb(Network::DrainDirection::All, cb_g.AsStdFunction());
 
-  b->startDrainSequence([] {});
+  b->startDrainSequence(Network::DrainDirection::All, [] {});
   EXPECT_EQ(call_count, 2);
 }
 
@@ -526,12 +534,12 @@ TEST_F(DrainManagerImplTest, DrainOnlyCascadesDownwards) {
     call_count++;
     return absl::OkStatus();
   }));
-  auto handle_a = a.addOnDrainCloseCb(cb_a.AsStdFunction());
-  auto handle_b = b->addOnDrainCloseCb(cb_b.AsStdFunction());
-  auto handle_c = c->addOnDrainCloseCb(cb_c.AsStdFunction());
+  auto handle_a = a.addOnDrainCloseCb(Network::DrainDirection::All, cb_a.AsStdFunction());
+  auto handle_b = b->addOnDrainCloseCb(Network::DrainDirection::All, cb_b.AsStdFunction());
+  auto handle_c = c->addOnDrainCloseCb(Network::DrainDirection::All, cb_c.AsStdFunction());
 
   // drain the middle of the tree
-  b->startDrainSequence([] {});
+  b->startDrainSequence(Network::DrainDirection::All, [] {});
   EXPECT_EQ(call_count, 2);
 }
 
@@ -554,13 +562,13 @@ TEST_F(DrainManagerImplTest, DrainChildExplicitlyAfterParent) {
     call_count++;
     return absl::OkStatus();
   }));
-  auto handle_a = a.addOnDrainCloseCb(cb.AsStdFunction());
-  auto handle_b = b->addOnDrainCloseCb(cb.AsStdFunction());
-  auto handle_c = c->addOnDrainCloseCb(cb.AsStdFunction());
+  auto handle_a = a.addOnDrainCloseCb(Network::DrainDirection::All, cb.AsStdFunction());
+  auto handle_b = b->addOnDrainCloseCb(Network::DrainDirection::All, cb.AsStdFunction());
+  auto handle_c = c->addOnDrainCloseCb(Network::DrainDirection::All, cb.AsStdFunction());
 
   // Drain the parent, then the child
-  a.startDrainSequence([&] {});
-  b->startDrainSequence([&] {});
+  a.startDrainSequence(Network::DrainDirection::All, [&] {});
+  b->startDrainSequence(Network::DrainDirection::All, [&] {});
   EXPECT_EQ(call_count, 3);
 }
 
@@ -583,13 +591,13 @@ TEST_F(DrainManagerImplTest, DrainParentAfterChild) {
     call_count++;
     return absl::OkStatus();
   }));
-  auto handle_a = a.addOnDrainCloseCb(cb.AsStdFunction());
-  auto handle_b = b->addOnDrainCloseCb(cb.AsStdFunction());
-  auto handle_c = c->addOnDrainCloseCb(cb.AsStdFunction());
+  auto handle_a = a.addOnDrainCloseCb(Network::DrainDirection::All, cb.AsStdFunction());
+  auto handle_b = b->addOnDrainCloseCb(Network::DrainDirection::All, cb.AsStdFunction());
+  auto handle_c = c->addOnDrainCloseCb(Network::DrainDirection::All, cb.AsStdFunction());
 
   // Drain the child, then the parent
-  b->startDrainSequence([] {});
-  a.startDrainSequence([] {});
+  b->startDrainSequence(Network::DrainDirection::All, [] {});
+  a.startDrainSequence(Network::DrainDirection::All, [] {});
   EXPECT_EQ(call_count, 3);
 }
 

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -703,18 +703,20 @@ TEST_P(ServerInstanceImplWorkersTest, DrainCloseAfterWorkersStarted) {
   // infinite drainClose spin-loop (mimicing high traffic) is running before we
   // initiate the drain sequence.
   auto drain_thread = Thread::threadFactoryForTest().createThread([&] {
-    bool closed = drain_manager.drainClose();
+    bool closed = drain_manager.drainClose(Network::DrainDirection::All);
     drain_closes_started.Notify();
     while (!closed) {
-      closed = drain_manager.drainClose();
+      closed = drain_manager.drainClose(Network::DrainDirection::All);
     }
   });
   drain_closes_started.WaitForNotification();
 
   // Now that we are starting to try to call drainClose, we'll start the drain sequence, then
   // wait for that to complete.
-  server_->dispatcher().post(
-      [&] { drain_manager.startDrainSequence([&drain_complete]() { drain_complete.Notify(); }); });
+  server_->dispatcher().post([&] {
+    drain_manager.startDrainSequence(Network::DrainDirection::All,
+                                     [&drain_complete]() { drain_complete.Notify(); });
+  });
 
   drain_complete.WaitForNotification();
   drain_thread->join();


### PR DESCRIPTION
Trying #37873 again to get to the bottom of the flakes that caused us to need to revert. This got a lot more complex after #38333, so I may need @yanavlasov to help me out with the proper semantics

Commit Message: 
```
Fixes https://github.com/envoyproxy/envoy/issues/35020. The inbound_only query param for the drain_listeners admin
endpoint doesn't work with the graceful query parameter. As a result,
outbound listeners will send connection: close headers to upstreams
which is undesired. This PR adds the ability for drain_manager to drain
in a single direction.
```
Additional Description:
Risk Level: Medium
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
