### PR TITLE
dynamic_modules: adds support for header removal

### DIFF
--- a/source/extensions/dynamic_modules/abi.h
+++ b/source/extensions/dynamic_modules/abi.h
@@ -580,13 +580,13 @@ bool envoy_dynamic_module_callback_http_get_response_trailers(
  * envoy_dynamic_module_callback_http_set_request_header is called by the module to set
  * the value of the request header with the given key. If the header does not exist, it will be
  * created. If the header already exists, all existing values will be removed and the new value will
- * be set.
+ * be set. When the given value is null, the header will be removed if the key exists.
  *
  * @param filter_envoy_ptr is the pointer to the DynamicModuleHttpFilter object of the
  * corresponding HTTP filter.
  * @param key is the key of the header.
  * @param key_length is the length of the key.
- * @param value is the value of the header.
+ * @param value is the pointer to the buffer of the value. It can be null to remove the header.
  * @param value_length is the length of the value.
  * @return true if the operation is successful, false otherwise.
  *

--- a/source/extensions/dynamic_modules/abi_version.h
+++ b/source/extensions/dynamic_modules/abi_version.h
@@ -6,7 +6,7 @@ namespace DynamicModules {
 #endif
 // This is the ABI version calculated as a sha256 hash of the ABI header files. When the ABI
 // changes, this value must change, and the correctness of this value is checked by the test.
-const char* kAbiVersion = "9e0126c182a3b4b5cae6f6e4a24246bdafa024e2831e0754df49ec3ccc909b38";
+const char* kAbiVersion = "597edaf69df3725fab3936e15a0fc3a8c23a0da209671221f4a21e56bd4598b1";
 
 #ifdef __cplusplus
 } // namespace DynamicModules

--- a/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
@@ -250,6 +250,11 @@ pub trait EnvoyHttpFilter {
   /// Returns true if the header is set successfully.
   fn set_request_header(&mut self, key: &str, value: &[u8]) -> bool;
 
+  /// Remove the request header with the given key.
+  ///
+  /// Returns true if the header is removed successfully.
+  fn remove_request_header(&mut self, key: &str) -> bool;
+
   /// Get the value of the request trailer with the given key.
   /// If the trailer is not found, this returns `None`.
   ///
@@ -276,6 +281,11 @@ pub trait EnvoyHttpFilter {
   ///
   /// Returns true if the trailer is set successfully.
   fn set_request_trailer(&mut self, key: &str, value: &[u8]) -> bool;
+
+  /// Remove the request trailer with the given key.
+  ///
+  /// Returns true if the trailer is removed successfully.
+  fn remove_request_trailer(&mut self, key: &str) -> bool;
 
   /// Get the value of the response header with the given key.
   /// If the header is not found, this returns `None`.
@@ -304,6 +314,11 @@ pub trait EnvoyHttpFilter {
   /// Returns true if the header is set successfully.
   fn set_response_header(&mut self, key: &str, value: &[u8]) -> bool;
 
+  /// Remove the response header with the given key.
+  ///
+  /// Returns true if the header is removed successfully.
+  fn remove_response_header(&mut self, key: &str) -> bool;
+
   /// Get the value of the response trailer with the given key.
   /// If the trailer is not found, this returns `None`.
   ///
@@ -329,6 +344,11 @@ pub trait EnvoyHttpFilter {
   ///
   /// Returns true if the operation is successful.
   fn set_response_trailer(&mut self, key: &str, value: &[u8]) -> bool;
+
+  /// Remove the response trailer with the given key.
+  ///
+  /// Returns true if the trailer is removed successfully.
+  fn remove_response_trailer(&mut self, key: &str) -> bool;
 
   /// Send a response to the downstream with the given status code, headers, and body.
   ///
@@ -830,6 +850,62 @@ impl EnvoyHttpFilter for EnvoyHttpFilterImpl {
 
   fn clear_route_cache(&mut self) {
     unsafe { abi::envoy_dynamic_module_callback_http_clear_route_cache(self.raw_ptr) }
+  }
+
+  fn remove_request_header(&mut self, key: &str) -> bool {
+    let key_ptr = key.as_ptr();
+    let key_size = key.len();
+    unsafe {
+      abi::envoy_dynamic_module_callback_http_set_request_header(
+        self.raw_ptr,
+        key_ptr as *const _ as *mut _,
+        key_size,
+        std::ptr::null_mut(),
+        0,
+      )
+    }
+  }
+
+  fn remove_request_trailer(&mut self, key: &str) -> bool {
+    let key_ptr = key.as_ptr();
+    let key_size = key.len();
+    unsafe {
+      abi::envoy_dynamic_module_callback_http_set_request_trailer(
+        self.raw_ptr,
+        key_ptr as *const _ as *mut _,
+        key_size,
+        std::ptr::null_mut(),
+        0,
+      )
+    }
+  }
+
+  fn remove_response_header(&mut self, key: &str) -> bool {
+    let key_ptr = key.as_ptr();
+    let key_size = key.len();
+    unsafe {
+      abi::envoy_dynamic_module_callback_http_set_response_header(
+        self.raw_ptr,
+        key_ptr as *const _ as *mut _,
+        key_size,
+        std::ptr::null_mut(),
+        0,
+      )
+    }
+  }
+
+  fn remove_response_trailer(&mut self, key: &str) -> bool {
+    let key_ptr = key.as_ptr();
+    let key_size = key.len();
+    unsafe {
+      abi::envoy_dynamic_module_callback_http_set_response_trailer(
+        self.raw_ptr,
+        key_ptr as *const _ as *mut _,
+        key_size,
+        std::ptr::null_mut(),
+        0,
+      )
+    }
   }
 }
 

--- a/source/extensions/filters/http/dynamic_modules/abi_impl.cc
+++ b/source/extensions/filters/http/dynamic_modules/abi_impl.cc
@@ -77,7 +77,7 @@ bool setHeaderValueImpl(Http::HeaderMap* map, envoy_dynamic_module_type_buffer_m
     return false;
   }
   absl::string_view key_view(key, key_length);
-  if (value == nullptr || value_length == 0) {
+  if (value == nullptr) {
     map->remove(Envoy::Http::LowerCaseString(key_view));
     return true;
   }

--- a/source/extensions/filters/http/dynamic_modules/abi_impl.cc
+++ b/source/extensions/filters/http/dynamic_modules/abi_impl.cc
@@ -77,6 +77,10 @@ bool setHeaderValueImpl(Http::HeaderMap* map, envoy_dynamic_module_type_buffer_m
     return false;
   }
   absl::string_view key_view(key, key_length);
+  if (value == nullptr || value_length == 0) {
+    map->remove(Envoy::Http::LowerCaseString(key_view));
+    return true;
+  }
   absl::string_view value_view(value, value_length);
   // TODO: we might want to avoid copying the key here by trusting the key is already lower case.
   map->setCopy(Envoy::Http::LowerCaseString(key_view), value_view);

--- a/test/extensions/dynamic_modules/http/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/http/abi_impl_test.cc
@@ -225,6 +225,14 @@ TEST_P(DynamicModuleHttpFilterSetHeaderValueTest, SetHeaderValue) {
   auto values3 = header_map->get(Envoy::Http::LowerCaseString(key3));
   EXPECT_EQ(values3.size(), 1);
   EXPECT_EQ(values3[0]->value().getStringView(), value3);
+
+  // Remove the key by passing null value.
+  const std::string remove_key = "single";
+  envoy_dynamic_module_type_buffer_envoy_ptr remove_key_ptr = const_cast<char*>(remove_key.data());
+  size_t remove_key_length = remove_key.size();
+  EXPECT_TRUE(callback(filter_.get(), remove_key_ptr, remove_key_length, nullptr, 0));
+  auto removed_values = header_map->get(Envoy::Http::LowerCaseString(remove_key));
+  EXPECT_EQ(removed_values.size(), 0);
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/test/extensions/dynamic_modules/http/filter_test.cc
+++ b/test/extensions/dynamic_modules/http/filter_test.cc
@@ -82,7 +82,7 @@ TEST(DynamiModulesTest, HeaderCallbacks) {
   filter->setDecoderFilterCallbacks(callbacks);
 
   std::initializer_list<std::pair<std::string, std::string>> headers = {
-      {"single", "value"}, {"multi", "value1"}, {"multi", "value2"}};
+      {"single", "value"}, {"multi", "value1"}, {"multi", "value2"}, {"to-be-deleted", "value"}};
   Http::TestRequestHeaderMapImpl request_headers{headers};
   Http::TestRequestTrailerMapImpl request_trailers{headers};
   Http::TestResponseHeaderMapImpl response_headers{headers};

--- a/test/extensions/dynamic_modules/test_data/rust/http.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/http.rs
@@ -73,6 +73,7 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for HeaderCallbacksFilter {
       .get_request_header_value("new")
       .expect("header new not found");
     assert_eq!(new_value.as_slice(), b"value");
+    envoy_filter.remove_request_header("to-be-deleted");
 
     // Test all getter API.
     let all_headers = envoy_filter.get_request_headers();
@@ -123,6 +124,7 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for HeaderCallbacksFilter {
       .get_request_trailer_value("new")
       .expect("trailer new not found");
     assert_eq!(&new_value.as_slice(), b"value");
+    envoy_filter.remove_request_trailer("to-be-deleted");
 
     // Test all getter API.
     let all_trailers = envoy_filter.get_request_trailers();
@@ -166,6 +168,7 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for HeaderCallbacksFilter {
       .get_response_header_value("new")
       .expect("header new not found");
     assert_eq!(&new_value.as_slice(), b"value");
+    envoy_filter.remove_response_header("to-be-deleted");
 
     // Test all getter API.
     let all_headers = envoy_filter.get_response_headers();
@@ -216,6 +219,7 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for HeaderCallbacksFilter {
       .get_response_trailer_value("new")
       .expect("trailer new not found");
     assert_eq!(&new_value.as_slice(), b"value");
+    envoy_filter.remove_response_trailer("to-be-deleted");
 
     // Test all getter API.
     let all_trailers = envoy_filter.get_response_trailers();

--- a/test/extensions/dynamic_modules/test_data/rust/http_test.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/http_test.rs
@@ -46,6 +46,12 @@ fn test_header_callbacks_filter_on_request_headers() {
     .once();
 
   envoy_filter
+    .expect_remove_request_header()
+    .withf(|name| name == "to-be-deleted")
+    .return_const(true)
+    .once();
+
+  envoy_filter
     .expect_get_request_header_value()
     .withf(|name| name == "new")
     .returning(|_| Some(EnvoyBuffer::new("value")))
@@ -69,7 +75,7 @@ fn test_header_callbacks_filter_on_request_headers() {
 }
 
 #[test]
-fn test_header_callbacks_on_request_headers_local_resp() {
+fn test_send_response_filter() {
   let mut f = SendResponseFilter {};
   let mut envoy_filter = MockEnvoyHttpFilter::default();
 


### PR DESCRIPTION
Commit Message: dynamic_modules: adds support for header removal
Additional Description:

This allows dynamic modules to remove headers/trailers by allowing setter callbacks to accept null pointer values.

Risk Level: low
Testing: done
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
