### PR TITLE
aws: minor refactor of CredentialsProviderChain

### DIFF
--- a/source/extensions/common/aws/BUILD
+++ b/source/extensions/common/aws/BUILD
@@ -106,7 +106,7 @@ envoy_cc_library(
 
 envoy_cc_library(
     name = "credentials_provider_interface",
-    hdrs = ["credentials_provider.h"],
+    hdrs = ["credentials_provider.h", "credentials_provider_impl.h"],
     deps = [
         "@com_google_absl//absl/types:optional",
     ],

--- a/source/extensions/common/aws/credentials_provider.h
+++ b/source/extensions/common/aws/credentials_provider.h
@@ -5,6 +5,8 @@
 
 #include "envoy/common/pure.h"
 
+#include "source/common/common/logger.h"
+
 #include "absl/strings/string_view.h"
 #include "absl/types/optional.h"
 
@@ -71,6 +73,23 @@ public:
 using CredentialsConstSharedPtr = std::shared_ptr<const Credentials>;
 using CredentialsConstUniquePtr = std::unique_ptr<const Credentials>;
 using CredentialsProviderSharedPtr = std::shared_ptr<CredentialsProvider>;
+
+/**
+ * AWS credentials provider chain, able to fallback between multiple credential providers.
+ */
+class CredentialsProviderChain : public Logger::Loggable<Logger::Id::aws> {
+public:
+  void add(const CredentialsProviderSharedPtr& credentials_provider) {
+    providers_.emplace_back(credentials_provider);
+  }
+
+  Credentials getCredentials();
+
+protected:
+  std::list<CredentialsProviderSharedPtr> providers_;
+};
+
+using CredentialsProviderChainSharedPtr = std::shared_ptr<CredentialsProviderChain>;
 
 } // namespace Aws
 } // namespace Common

--- a/source/extensions/common/aws/credentials_provider_impl.h
+++ b/source/extensions/common/aws/credentials_provider_impl.h
@@ -316,24 +316,6 @@ private:
   void extractCredentials(const std::string&& credential_document_value);
 };
 
-/**
- * AWS credentials provider chain, able to fallback between multiple credential providers.
- */
-class CredentialsProviderChain : public CredentialsProvider,
-                                 public Logger::Loggable<Logger::Id::aws> {
-public:
-  ~CredentialsProviderChain() override = default;
-
-  void add(const CredentialsProviderSharedPtr& credentials_provider) {
-    providers_.emplace_back(credentials_provider);
-  }
-
-  Credentials getCredentials() override;
-
-protected:
-  std::list<CredentialsProviderSharedPtr> providers_;
-};
-
 class CredentialsProviderChainFactories {
 public:
   virtual ~CredentialsProviderChainFactories() = default;

--- a/source/extensions/common/aws/signer_base_impl.h
+++ b/source/extensions/common/aws/signer_base_impl.h
@@ -63,7 +63,7 @@ using AwsSigningHeaderExclusionVector = std::vector<envoy::type::matcher::v3::St
 class SignerBaseImpl : public Signer, public Logger::Loggable<Logger::Id::aws> {
 public:
   SignerBaseImpl(absl::string_view service_name, absl::string_view region,
-                 const CredentialsProviderSharedPtr& credentials_provider,
+                 const CredentialsProviderChainSharedPtr& credentials_provider,
                  Server::Configuration::CommonFactoryContext& context,
                  const AwsSigningHeaderExclusionVector& matcher_config,
                  const bool query_string = false,
@@ -151,7 +151,7 @@ protected:
       Http::Headers::get().ForwardedFor.get(), Http::Headers::get().ForwardedProto.get(),
       "x-amzn-trace-id"};
   std::vector<Matchers::StringMatcherPtr> excluded_header_matchers_;
-  CredentialsProviderSharedPtr credentials_provider_;
+  CredentialsProviderChainSharedPtr credentials_provider_;
   const bool query_string_;
   const uint16_t expiration_time_;
   TimeSource& time_source_;

--- a/source/extensions/common/aws/sigv4_signer_impl.h
+++ b/source/extensions/common/aws/sigv4_signer_impl.h
@@ -45,7 +45,7 @@ class SigV4SignerImpl : public SignerBaseImpl {
 
 public:
   SigV4SignerImpl(absl::string_view service_name, absl::string_view region,
-                  const CredentialsProviderSharedPtr& credentials_provider,
+                  const CredentialsProviderChainSharedPtr& credentials_provider,
                   Server::Configuration::CommonFactoryContext& context,
                   const AwsSigningHeaderExclusionVector& matcher_config,
                   const bool query_string = false,

--- a/source/extensions/common/aws/sigv4a_signer_impl.h
+++ b/source/extensions/common/aws/sigv4a_signer_impl.h
@@ -57,7 +57,7 @@ class SigV4ASignerImpl : public SignerBaseImpl {
 public:
   SigV4ASignerImpl(
       absl::string_view service_name, absl::string_view region,
-      const CredentialsProviderSharedPtr& credentials_provider,
+      const CredentialsProviderChainSharedPtr& credentials_provider,
       Server::Configuration::CommonFactoryContext& context,
       const AwsSigningHeaderExclusionVector& matcher_config, const bool query_string = false,
       const uint16_t expiration_time = SignatureQueryParameterValues::DefaultExpiration)

--- a/source/extensions/filters/http/aws_lambda/config.h
+++ b/source/extensions/filters/http/aws_lambda/config.h
@@ -20,7 +20,7 @@ public:
   AwsLambdaFilterFactory() : DualFactoryBase("envoy.filters.http.aws_lambda") {}
 
 protected:
-  Extensions::Common::Aws::CredentialsProviderSharedPtr getCredentialsProvider(
+  Extensions::Common::Aws::CredentialsProviderChainSharedPtr getCredentialsProvider(
       const envoy::extensions::filters::http::aws_lambda::v3::Config& proto_config,
       Server::Configuration::ServerFactoryContext& server_context, const std::string& region) const;
 

--- a/source/extensions/filters/http/aws_request_signing/config.cc
+++ b/source/extensions/filters/http/aws_request_signing/config.cc
@@ -101,7 +101,7 @@ AwsRequestSigningFilterFactory::createSigner(
     region = regionOpt.value();
   }
 
-  absl::StatusOr<Envoy::Extensions::Common::Aws::CredentialsProviderSharedPtr>
+  absl::StatusOr<Envoy::Extensions::Common::Aws::CredentialsProviderChainSharedPtr>
       credentials_provider =
           absl::InvalidArgumentError("No credentials provider settings configured.");
 
@@ -115,9 +115,12 @@ AwsRequestSigningFilterFactory::createSigner(
       // If inline credential provider is set, use it instead of the default or custom credentials
       // chain
       const auto& inline_credential = config.credential_provider().inline_credential();
-      credentials_provider = std::make_shared<Extensions::Common::Aws::InlineCredentialProvider>(
+      credentials_provider = std::make_shared<Extensions::Common::Aws::CredentialsProviderChain>();
+      auto inline_provider = std::make_shared<Extensions::Common::Aws::InlineCredentialProvider>(
           inline_credential.access_key_id(), inline_credential.secret_access_key(),
           inline_credential.session_token());
+      credentials_provider.value()->add(inline_provider);
+
     } else if (config.credential_provider().custom_credential_provider_chain()) {
       // Custom credential provider chain
       if (has_credential_provider_settings) {


### PR DESCRIPTION
Commit Message: aws: minor refactor of CredentialsProviderChain and its usage
Additional Description: supports work on https://github.com/envoyproxy/envoy/pull/38360 . Chains were being used interchangeably with CredentialProvider , which was likely its original intended usage but makes distinguishing them from each other impossible. No use case exists for a provider without a chain.
Risk Level: Negligible
Testing: Unit
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
