### PR TITLE
Don't link dynamically when running coverage

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -243,7 +243,7 @@ build:coverage --action_env=GCOV=llvm-profdata
 build:coverage --copt=-DNDEBUG
 # 1.5x original timeout + 300s for trace merger in all categories
 build:coverage --test_timeout=390,750,1500,5700
-build:coverage --define=dynamic_link_tests=true
+#build:coverage --define=dynamic_link_tests=true
 build:coverage --define=ENVOY_CONFIG_COVERAGE=1
 build:coverage --cxxopt="-DENVOY_CONFIG_COVERAGE=1"
 build:coverage --test_env=HEAPCHECK=


### PR DESCRIPTION
Commit Message:

The long story short, source-based coverage in clang does not seem to play well with dynamic linking when there are functions defined in header files included in multiple places (inline functions and class members).

The exact details are way above my head, but the visible effect is that some functions, that are in fact exercised during tests will be reported as not covered, because LLVM toolchain may in some circumstances fail to merge information about multiple versions of the same function.

You can refer to
https://discourse.llvm.org/t/llvm-cov-hash-mismatches-originating-from-class-methods-implemented-in-header-files/79832 for more information.

There are few ways to deal with this problem with different tradeoffs:

1. [this change] stop using dynamic linking and switch to static linking, this addresses the problem, since there will be no multiple versions of the same function, but we started using dynamic linking for coverage because we had issues with storage/caching in CI a while back, so it might potentially cause issues there
2. -femit-all-decls compile flag, can be used to work around the issue, it's good option because it could be applied to the whole repository via .bazelrc, but on the flip side, the compiler will have to do more work with this flag in place, increasing resource usage/reducing speed of the CI
3. We can move individual affected function definitions from the header files to cc files, that addresses the problem for the affected function and reduces the compilation time somewhat, but it will have to be done on a function-by-function basis and in some cases it's not possible to do at all.
4. Annotate affected function with `used` annotation, this will address the problem for that function and it's always possible, but just like in the option above it has to be done on function-by-function basis, and it will increase the work the compiler needs to do, because it's essentially an equivalent of -femit-all-decls, but applied to a single function and not the whole translation unit.

None of the options is great, and unfortunately even if the issue will get fixed upstream, it's not at all clear when the fix will be available in clang 18 if it will be available there at all.

Given that, I want to try the option 1, as "the most correct and future proof" option and see if the issues we tried to address by switching to dynamic linking for coverage tests are still affecting us.

Additional Description:

Related to https://github.com/envoyproxy/envoy/issues/37911 and fixes one of the issues in https://github.com/envoyproxy/envoy/pull/38093

Risk Level: Low
Testing: regular test runs
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a