### PR TITLE
Encoding some ext_proc filter configuration in the ProcessingRequest message

### DIFF
--- a/api/envoy/service/ext_proc/v3/external_processor.proto
+++ b/api/envoy/service/ext_proc/v3/external_processor.proto
@@ -61,11 +61,13 @@ service ExternalProcessor {
 message FilterConfigToSend {
   // Specify the request body processing mode. This ``request_body_mode`` helps the server
   // to take appropriate actions after receiving a ``ProcessingRequest`` from the request direction.
-  envoy.extensions.filters.http.ext_proc.v3.ProcessingMode.BodySendMode request_body_mode = 1 [(validate.rules).enum = {defined_only: true}];
+  envoy.extensions.filters.http.ext_proc.v3.ProcessingMode.BodySendMode request_body_mode = 1
+      [(validate.rules).enum = {defined_only: true}];
 
   // Specify the response body processing mode. This ``response_body_mode`` helps the server
   // to take appropriate actions after receiving a ``ProcessingRequest`` from the response direction.
-  envoy.extensions.filters.http.ext_proc.v3.ProcessingMode.BodySendMode response_body_mode = 2 [(validate.rules).enum = {defined_only: true}];
+  envoy.extensions.filters.http.ext_proc.v3.ProcessingMode.BodySendMode response_body_mode = 2
+      [(validate.rules).enum = {defined_only: true}];
 }
 
 // This represents the different types of messages that Envoy can send

--- a/api/envoy/service/ext_proc/v3/external_processor.proto
+++ b/api/envoy/service/ext_proc/v3/external_processor.proto
@@ -59,19 +59,19 @@ service ExternalProcessor {
 // This message specifies the filter protocol configurations which will be sent to the ext_proc
 // server in a :ref:`ProcessingRequest <envoy_v3_api_msg_service.ext_proc.v3.ProcessingRequest>`.
 // If the server does not support these protocol configurations, it may choose to close the gRPC stream.
-// If the server supports these protocol configurations, they should respond based on the API specification.
+// If the server supports these protocol configurations, it should respond based on the API specification.
 message ProtocolConfiguration {
   // Specify whether the filter
   // :ref:`request_body_mode <envoy_v3_api_field_extensions.filters.http.ext_proc.v3.ProcessingMode.request_body_mode>`
   // is set to FULL_DUPLEX_STREAMED. A "true" means Envoy is operating in the FULL_DUPLEX_STREAMED
-  // body mode in the request direction. The server need to operate in that mode as well.
+  // body mode in the request direction. The server needs to operate in that mode as well.
   // A "false" means Envoy is expecting a response for each request it sends.
   bool is_request_body_mode_full_duplex = 1;
 
   // Specify whether the filter
   // :ref:`response_body_mode <envoy_v3_api_field_extensions.filters.http.ext_proc.v3.ProcessingMode.response_body_mode>`
   // is set to FULL_DUPLEX_STREAMED. A "true" means Envoy is operating in the FULL_DUPLEX_STREAMED
-  // body mode in the response direction. The server need to operate in that mode as well.
+  // body mode in the response direction. The server needs to operate in that mode as well.
   // A "false" means Envoy is expecting a response for each request it sends.
 
   bool is_response_body_mode_full_duplex = 2;

--- a/api/envoy/service/ext_proc/v3/external_processor.proto
+++ b/api/envoy/service/ext_proc/v3/external_processor.proto
@@ -139,6 +139,7 @@ message ProcessingRequest {
   //
   bool observability_mode = 10;
 
+  // [#not-implemented-hide:]
   // The filter protocol configurations to be sent to the server.
   ProtocolConfiguration protocol_config = 11;
 }

--- a/api/envoy/service/ext_proc/v3/external_processor.proto
+++ b/api/envoy/service/ext_proc/v3/external_processor.proto
@@ -77,7 +77,7 @@ message ProtocolConfiguration {
 
   // Specify whether the filter :ref:`send_body_without_waiting_for_header_response
   // <envoy_v3_api_field_extensions.filters.http.ext_proc.v3.ExternalProcessor.send_body_without_waiting_for_header_response>`
-  // flag is set. If Envoy is waiting for a header response for the server, Setting ``true`` means Envoy will send body to
+  // flag is set. If Envoy is waiting for a header response from the server, setting ``true`` means Envoy will send body to
   // the server as they arrive. Setting ``false`` means Envoy will buffer the arrived data and not send it to the server.
   bool send_body_without_waiting_for_header_response = 3;
 }

--- a/api/envoy/service/ext_proc/v3/external_processor.proto
+++ b/api/envoy/service/ext_proc/v3/external_processor.proto
@@ -73,8 +73,8 @@ message ProtocolConfiguration {
 
   // Specify the filter configuration :ref:`send_body_without_waiting_for_header_response
   // <envoy_v3_api_field_extensions.filters.http.ext_proc.v3.ExternalProcessor.send_body_without_waiting_for_header_response>`
-  // If Envoy is waiting for a header response from the server, setting ``true`` means Envoy will send body to the server
-  // as they arrive. Setting ``false`` means Envoy will buffer the arrived data and not send it to the server immediately.
+  // If the client is waiting for a header response from the server, setting ``true`` means the client will send body to the server
+  // as they arrive. Setting ``false`` means the client will buffer the arrived data and not send it to the server immediately.
   bool send_body_without_waiting_for_header_response = 3;
 }
 
@@ -149,7 +149,7 @@ message ProcessingRequest {
 
   // [#not-implemented-hide:]
   // Specify the filter protocol configurations to be sent to the server.
-  // ``protocol_config`` is only encoded in the first ``ProcessingRequest`` message from Envoy to the server.
+  // ``protocol_config`` is only encoded in the first ``ProcessingRequest`` message from the client to the server.
   ProtocolConfiguration protocol_config = 11;
 }
 

--- a/api/envoy/service/ext_proc/v3/external_processor.proto
+++ b/api/envoy/service/ext_proc/v3/external_processor.proto
@@ -59,27 +59,26 @@ service ExternalProcessor {
 // This message specifies the filter protocol configurations which will be sent to the ext_proc
 // server in a :ref:`ProcessingRequest <envoy_v3_api_msg_service.ext_proc.v3.ProcessingRequest>`.
 // If the server does not support these protocol configurations, it may choose to close the gRPC stream.
-// If the server supports these protocol configurations, it should respond based on the API specification.
+// If the server supports these protocol configurations, it should respond based on the API specifications.
 message ProtocolConfiguration {
   // Specify whether the filter
   // :ref:`request_body_mode <envoy_v3_api_field_extensions.filters.http.ext_proc.v3.ProcessingMode.request_body_mode>`
-  // is set to FULL_DUPLEX_STREAMED. A "true" means Envoy is operating in the FULL_DUPLEX_STREAMED
+  // is set to ``FULL_DUPLEX_STREAMED``. Setting ``true`` means Envoy is operating in the ``FULL_DUPLEX_STREAMED``
   // body mode in the request direction. The server needs to operate in that mode as well.
-  // A "false" means Envoy is expecting a response for each request it sends.
+  // Setting ``false`` means Envoy is expecting a response for each request it sends.
   bool is_request_body_mode_full_duplex = 1;
 
   // Specify whether the filter
   // :ref:`response_body_mode <envoy_v3_api_field_extensions.filters.http.ext_proc.v3.ProcessingMode.response_body_mode>`
-  // is set to FULL_DUPLEX_STREAMED. A "true" means Envoy is operating in the FULL_DUPLEX_STREAMED
+  // is set to ``FULL_DUPLEX_STREAMED``. Setting ``true`` means Envoy is operating in the ``FULL_DUPLEX_STREAMED``
   // body mode in the response direction. The server needs to operate in that mode as well.
-  // A "false" means Envoy is expecting a response for each request it sends.
-
+  // Setting ``false`` means Envoy is expecting a response for each request it sends.
   bool is_response_body_mode_full_duplex = 2;
 
   // Specify whether the filter :ref:`send_body_without_waiting_for_header_response
   // <envoy_v3_api_field_extensions.filters.http.ext_proc.v3.ExternalProcessor.send_body_without_waiting_for_header_response>`
-  // flag is set. If Envoy is waiting for a header response for the server, a "true" means Envoy will send body to the server
-  // as they arrive. A "false" means Envoy will buffer the arrived data and not send it to the server.
+  // flag is set. If Envoy is waiting for a header response for the server, Setting ``true`` means Envoy will send body to
+  // the server as they arrive. Setting ``false`` means Envoy will buffer the arrived data and not send it to the server.
   bool send_body_without_waiting_for_header_response = 3;
 }
 

--- a/api/envoy/service/ext_proc/v3/external_processor.proto
+++ b/api/envoy/service/ext_proc/v3/external_processor.proto
@@ -58,22 +58,28 @@ service ExternalProcessor {
 
 // This message specifies the filter protocol configurations which will be sent to the ext_proc
 // server in a :ref:`ProcessingRequest <envoy_v3_api_msg_service.ext_proc.v3.ProcessingRequest>`.
+// If the server does not support these protocol configurations, it may choose to close the gRPC stream.
+// If the server supports these protocol configurations, they should respond based on the API specification.
 message ProtocolConfiguration {
   // Specify whether the filter
   // :ref:`request_body_mode <envoy_v3_api_field_extensions.filters.http.ext_proc.v3.ProcessingMode.request_body_mode>`
-  // is set to FULL_DUPLEX_STREAMED. This helps the server to take appropriate actions after receiving a
-  // ``ProcessingRequest`` from the request direction.
+  // is set to FULL_DUPLEX_STREAMED. A "true" means Envoy is operating in the FULL_DUPLEX_STREAMED
+  // body mode in the request direction. The server need to operate in that mode as well.
+  // A "false" means Envoy is expecting a response for each request it sends.
   bool is_request_body_mode_full_duplex = 1;
 
   // Specify whether the filter
   // :ref:`response_body_mode <envoy_v3_api_field_extensions.filters.http.ext_proc.v3.ProcessingMode.response_body_mode>`
-  // is set to FULL_DUPLEX_STREAMED. This helps the server to take appropriate actions after receiving a
-  // ``ProcessingRequest`` from the response direction.
+  // is set to FULL_DUPLEX_STREAMED. A "true" means Envoy is operating in the FULL_DUPLEX_STREAMED
+  // body mode in the response direction. The server need to operate in that mode as well.
+  // A "false" means Envoy is expecting a response for each request it sends.
+
   bool is_response_body_mode_full_duplex = 2;
 
   // Specify whether the filter :ref:`send_body_without_waiting_for_header_response
   // <envoy_v3_api_field_extensions.filters.http.ext_proc.v3.ExternalProcessor.send_body_without_waiting_for_header_response>`
-  // flag is set.
+  // flag is set. If Envoy is waiting for a header response for the server, a "true" means Envoy will send body to the server
+  // as they arrive. A "false" means Envoy will buffer the arrived data and not send it to the server.
   bool send_body_without_waiting_for_header_response = 3;
 }
 

--- a/api/envoy/service/ext_proc/v3/external_processor.proto
+++ b/api/envoy/service/ext_proc/v3/external_processor.proto
@@ -59,15 +59,22 @@ service ExternalProcessor {
 // This message specifies the filter protocol configurations which will be sent to the ext_proc
 // server in a :ref:`ProcessingRequest <envoy_v3_api_msg_service.ext_proc.v3.ProcessingRequest>`.
 message ProtocolConfiguration {
-  // Specify whether the filter request body processing mode is FULL_DUPLEX_STREAMED.
-  // This helps the server to take appropriate actions after receiving a
+  // Specify whether the filter
+  // :ref:`request_body_mode <envoy_v3_api_field_extensions.filters.http.ext_proc.v3.ProcessingMode.request_body_mode>`
+  // is set to FULL_DUPLEX_STREAMED. This helps the server to take appropriate actions after receiving a
   // ``ProcessingRequest`` from the request direction.
   bool is_request_body_mode_full_duplex = 1;
 
-  // Specify whether the filter response body processing mode is FULL_DUPLEX_STREAMED.
-  // This helps the server to take appropriate actions after receiving a
+  // Specify whether the filter
+  // :ref:`response_body_mode <envoy_v3_api_field_extensions.filters.http.ext_proc.v3.ProcessingMode.response_body_mode>`
+  // is set to FULL_DUPLEX_STREAMED. This helps the server to take appropriate actions after receiving a
   // ``ProcessingRequest`` from the response direction.
   bool is_response_body_mode_full_duplex = 2;
+
+  // Specify whether the filter :ref:`send_body_without_waiting_for_header_response
+  // <envoy_v3_api_field_extensions.filters.http.ext_proc.v3.ExternalProcessor.send_body_without_waiting_for_header_response>`
+  // flag is set.
+  bool send_body_without_waiting_for_header_response = 3;
 }
 
 // This represents the different types of messages that Envoy can send

--- a/api/envoy/service/ext_proc/v3/external_processor.proto
+++ b/api/envoy/service/ext_proc/v3/external_processor.proto
@@ -61,24 +61,20 @@ service ExternalProcessor {
 // If the server does not support these protocol configurations, it may choose to close the gRPC stream.
 // If the server supports these protocol configurations, it should respond based on the API specifications.
 message ProtocolConfiguration {
-  // Specify whether the filter
-  // :ref:`request_body_mode <envoy_v3_api_field_extensions.filters.http.ext_proc.v3.ProcessingMode.request_body_mode>`
-  // is set to ``FULL_DUPLEX_STREAMED``. Setting ``true`` means Envoy is operating in the ``FULL_DUPLEX_STREAMED``
-  // body mode in the request direction. The server needs to operate in that mode as well.
-  // Setting ``false`` means Envoy is expecting a response for each request it sends.
-  bool is_request_body_mode_full_duplex = 1;
+  // Specify the filter configuration :ref:`request_body_mode
+  // <envoy_v3_api_field_extensions.filters.http.ext_proc.v3.ProcessingMode.request_body_mode>`
+  envoy.extensions.filters.http.ext_proc.v3.ProcessingMode.BodySendMode request_body_mode = 1
+      [(validate.rules).enum = {defined_only: true}];
 
-  // Specify whether the filter
-  // :ref:`response_body_mode <envoy_v3_api_field_extensions.filters.http.ext_proc.v3.ProcessingMode.response_body_mode>`
-  // is set to ``FULL_DUPLEX_STREAMED``. Setting ``true`` means Envoy is operating in the ``FULL_DUPLEX_STREAMED``
-  // body mode in the response direction. The server needs to operate in that mode as well.
-  // Setting ``false`` means Envoy is expecting a response for each request it sends.
-  bool is_response_body_mode_full_duplex = 2;
+  // Specify the filter configuration :ref:`response_body_mode
+  // <envoy_v3_api_field_extensions.filters.http.ext_proc.v3.ProcessingMode.response_body_mode>`
+  envoy.extensions.filters.http.ext_proc.v3.ProcessingMode.BodySendMode response_body_mode = 2
+      [(validate.rules).enum = {defined_only: true}];
 
-  // Specify whether the filter :ref:`send_body_without_waiting_for_header_response
+  // Specify the filter configuration :ref:`send_body_without_waiting_for_header_response
   // <envoy_v3_api_field_extensions.filters.http.ext_proc.v3.ExternalProcessor.send_body_without_waiting_for_header_response>`
-  // flag is set. If Envoy is waiting for a header response from the server, setting ``true`` means Envoy will send body to
-  // the server as they arrive. Setting ``false`` means Envoy will buffer the arrived data and not send it to the server.
+  // If Envoy is waiting for a header response from the server, setting ``true`` means Envoy will send body to the server
+  // as they arrive. Setting ``false`` means Envoy will buffer the arrived data and not send it to the server immediately.
   bool send_body_without_waiting_for_header_response = 3;
 }
 
@@ -152,7 +148,8 @@ message ProcessingRequest {
   bool observability_mode = 10;
 
   // [#not-implemented-hide:]
-  // The filter protocol configurations to be sent to the server.
+  // Specify the filter protocol configurations to be sent to the server.
+  // ``protocol_config`` is only encoded in the first ``ProcessingRequest`` message from Envoy to the server.
   ProtocolConfiguration protocol_config = 11;
 }
 

--- a/api/envoy/service/ext_proc/v3/external_processor.proto
+++ b/api/envoy/service/ext_proc/v3/external_processor.proto
@@ -56,9 +56,21 @@ service ExternalProcessor {
   }
 }
 
+// This message specify the ext_proc filter configurations which will be sent to the ext_proc server in a
+// :ref:`ProcessingRequest <envoy_v3_api_msg_service.ext_proc.v3.ProcessingRequest>`.
+message FilterConfigToSend {
+  // Specify the request body processing mode. This ``request_body_mode`` helps the server
+  // to take appropriate actions after receiving a ``ProcessingRequest`` from the request direction.
+  envoy.extensions.filters.http.ext_proc.v3.ProcessingMode.BodySendMode request_body_mode = 1 [(validate.rules).enum = {defined_only: true}];
+
+  // Specify the response body processing mode. This ``response_body_mode`` helps the server
+  // to take appropriate actions after receiving a ``ProcessingRequest`` from the response direction.
+  envoy.extensions.filters.http.ext_proc.v3.ProcessingMode.BodySendMode response_body_mode = 2 [(validate.rules).enum = {defined_only: true}];
+}
+
 // This represents the different types of messages that Envoy can send
 // to an external processing server.
-// [#next-free-field: 11]
+// [#next-free-field: 12]
 message ProcessingRequest {
   reserved 1;
 
@@ -124,6 +136,9 @@ message ProcessingRequest {
   //   are needed.
   //
   bool observability_mode = 10;
+
+  // The filter configuration to be sent to the server.
+  FilterConfigToSend filter_config = 11;
 }
 
 // For every ProcessingRequest received by the server with the ``observability_mode`` field

--- a/api/envoy/service/ext_proc/v3/external_processor.proto
+++ b/api/envoy/service/ext_proc/v3/external_processor.proto
@@ -56,18 +56,18 @@ service ExternalProcessor {
   }
 }
 
-// This message specify the ext_proc filter configurations which will be sent to the ext_proc server in a
-// :ref:`ProcessingRequest <envoy_v3_api_msg_service.ext_proc.v3.ProcessingRequest>`.
-message FilterConfigToSend {
-  // Specify the request body processing mode. This ``request_body_mode`` helps the server
-  // to take appropriate actions after receiving a ``ProcessingRequest`` from the request direction.
-  envoy.extensions.filters.http.ext_proc.v3.ProcessingMode.BodySendMode request_body_mode = 1
-      [(validate.rules).enum = {defined_only: true}];
+// This message specifies the filter protocol configurations which will be sent to the ext_proc
+// server in a :ref:`ProcessingRequest <envoy_v3_api_msg_service.ext_proc.v3.ProcessingRequest>`.
+message ProtocolConfiguration {
+  // Specify whether the filter request body processing mode is FULL_DUPLEX_STREAMED.
+  // This helps the server to take appropriate actions after receiving a
+  // ``ProcessingRequest`` from the request direction.
+  bool is_request_body_mode_full_duplex = 1;
 
-  // Specify the response body processing mode. This ``response_body_mode`` helps the server
-  // to take appropriate actions after receiving a ``ProcessingRequest`` from the response direction.
-  envoy.extensions.filters.http.ext_proc.v3.ProcessingMode.BodySendMode response_body_mode = 2
-      [(validate.rules).enum = {defined_only: true}];
+  // Specify whether the filter response body processing mode is FULL_DUPLEX_STREAMED.
+  // This helps the server to take appropriate actions after receiving a
+  // ``ProcessingRequest`` from the response direction.
+  bool is_response_body_mode_full_duplex = 2;
 }
 
 // This represents the different types of messages that Envoy can send
@@ -139,8 +139,8 @@ message ProcessingRequest {
   //
   bool observability_mode = 10;
 
-  // The filter configuration to be sent to the server.
-  FilterConfigToSend filter_config = 11;
+  // The filter protocol configurations to be sent to the server.
+  ProtocolConfiguration protocol_config = 11;
 }
 
 // For every ProcessingRequest received by the server with the ``observability_mode`` field


### PR DESCRIPTION
This is the API part change of encoding some ext_proc filter configuration in the ProcessingRequest message.

Encoding such filter configurations when sending ProcessingRequest message to the ext_proc server helps the server to take right action with it, like send response immediately, or buffer the request.
