### PR TITLE
fix format-api not working on macos with llvm19

### DIFF
--- a/bazel/foreign_cc/BUILD
+++ b/bazel/foreign_cc/BUILD
@@ -442,6 +442,9 @@ envoy_cmake(
         # Reference: https://github.com/zlib-ng/zlib-ng#advanced-build-options.
         "UNALIGNED_OK": "off",
     },
+    copts = [
+        "-std=c90",
+    ],
     lib_source = select({
         "//bazel:zlib_ng": "@com_github_zlib_ng_zlib_ng//:all",
         "//conditions:default": "@net_zlib//:all",

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -322,7 +322,9 @@ case $CI_TARGET in
         ;;
 
     format-api|check_and_fix_proto_format)
-        setup_clang_toolchain
+        if [[ -z "$CLANG_TOOLCHAIN_SETUP" ]]; then
+            setup_clang_toolchain
+        fi
         echo "Check and fix proto format ..."
         "${ENVOY_SRCDIR}/ci/check_and_fix_format.sh"
         ;;


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: this make you able to run `CLANG_TOOLCHAIN_SETUP=0 ./ci/do_ci.sh format-api` on mac with llvm19
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
