### PR TITLE
feat(request_id): set request id when it's set but empty

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -25,6 +25,11 @@ minor_behavior_changes:
 - area: cel
   change: |
     Support extension regex fuctions(e.g. ``re.extract``, ``re.capture`, ``re.captureN``) in CEL.
+- area: tracing
+  change: |
+    :ref:`generate_request_id
+    <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.generate_request_id>`
+    will generate a request id on non-present and now on empty ``x-request-id`` header.
 
 bug_fixes:
 # *Changes expected to improve the state of the world and are unlikely to have negative effects*

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -25,7 +25,7 @@ minor_behavior_changes:
 - area: cel
   change: |
     Support extension regex fuctions(e.g. ``re.extract``, ``re.capture`, ``re.captureN``) in CEL.
-- area: tracing
+- area: http
   change: |
     :ref:`generate_request_id
     <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.generate_request_id>`

--- a/source/extensions/request_id/uuid/config.cc
+++ b/source/extensions/request_id/uuid/config.cc
@@ -16,7 +16,7 @@ void UUIDRequestIDExtension::set(Http::RequestHeaderMap& request_headers, bool e
   const Http::HeaderEntry* request_id_header = request_headers.RequestId();
 
   // No request ID then set new one anyway.
-  if (request_id_header == nullptr) {
+  if (request_id_header == nullptr || request_id_header->value().empty()) {
     request_headers.setRequestId(random_.uuid());
     return;
   }

--- a/test/extensions/request_id/uuid/config_test.cc
+++ b/test/extensions/request_id/uuid/config_test.cc
@@ -165,8 +165,8 @@ TEST(UUIDRequestIDExtensionTest, GetRequestIdAndModRequestIDBy) {
   EXPECT_EQ(15, uuid_utils.getInteger(request_headers).value());
 
   request_headers.setRequestId("");
-  EXPECT_EQ("", uuid_utils.get(request_headers).value());
-  EXPECT_FALSE(uuid_utils.getInteger(request_headers).has_value());
+  EXPECT_TRUE(uuid_utils.get(request_headers));
+  EXPECT_TRUE(uuid_utils.getInteger(request_headers).has_value());
 
   request_headers.setRequestId("000000ff-0000-0000-0000-000000000000");
   EXPECT_EQ("000000ff-0000-0000-0000-000000000000", uuid_utils.get(request_headers).value());

--- a/test/extensions/request_id/uuid/config_test.cc
+++ b/test/extensions/request_id/uuid/config_test.cc
@@ -85,7 +85,6 @@ TEST(UUIDRequestIDExtensionTest, SetRequestID) {
   }
 }
 
-
 TEST(UUIDRequestIDExtensionTest, SetRequestIDWhenEmpty) {
   testing::StrictMock<Random::MockRandomGenerator> random;
   UUIDRequestIDExtension uuid_utils(envoy::extensions::request_id::uuid::v3::UuidRequestIdConfig(),

--- a/test/extensions/request_id/uuid/config_test.cc
+++ b/test/extensions/request_id/uuid/config_test.cc
@@ -211,7 +211,7 @@ TEST(UUIDRequestIDExtensionTest, GetRequestIdAndModRequestIDBy) {
   EXPECT_EQ(15, uuid_utils.getInteger(request_headers).value());
 
   request_headers.setRequestId("");
-  EXPECT_FALSE(uuid_utils.get(request_headers));
+  EXPECT_EQ("", uuid_utils.get(request_headers).value());
   EXPECT_FALSE(uuid_utils.getInteger(request_headers).has_value());
 
   request_headers.setRequestId("000000ff-0000-0000-0000-000000000000");


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: `feat(request_id): set request id when it's set but empty`
Risk Level: Low
Testing: Yes
Docs Changes: N/A
Release Notes:
  * `generate_request_id` will generate a request id on non-present and empty `x-request-id` header.

Fixes #38445
