### PR TITLE
When calling std::move use the name qualified with namespace instead of plain move

### DIFF
--- a/test/extensions/filters/http/local_ratelimit/local_ratelimit_integration_test.cc
+++ b/test/extensions/filters/http/local_ratelimit/local_ratelimit_integration_test.cc
@@ -165,13 +165,13 @@ protected:
     auto response = makeRequest(cluster);
     waitForNextUpstreamRequest();
     upstream_request_->encodeHeaders(default_response_headers_, 1);
-    verifyResponse(move(response), expected_status, expected_body_size);
+    verifyResponse(std::move(response), expected_status, expected_body_size);
     EXPECT_TRUE(upstream_request_->complete());
     EXPECT_EQ(0U, upstream_request_->bodyLength());
   }
   void sendRateLimitedRequest(const std::string& cluster) {
     auto response = makeRequest(cluster);
-    verifyResponse(move(response), "429",
+    verifyResponse(std::move(response), "429",
                    18); // 18 is the expected body size for rate-limited responses.
   }
 


### PR DESCRIPTION
Commit Message:

Unlike with swap, calling move without std:: is considered a somewhat bad practice. The concern revolves around C++ ADL and the fact that move is, unfortunately, a rather commonly used name. You can read some discussion on that in https://reviews.llvm.org/D119670?id=408276.

The reason why I want to fix it is that when I try to build and run Envoy tests with clang-18, uses of std::move without std::qualifier trigger unqualified-std-cast-call warning that is convered into an error.

We can disable the warning, but given that the fix is small, generally makes sense and does not cause troublems, I though it might be better to just submit a small fix like this.

NOTE: I grepped through Envoy codebase, and local ratelimit integration tests seem to be the only two occurances where std::move is called without namespace qualifiers.

Additional Description:

Related to https://github.com/envoyproxy/envoy/issues/37911 and fixes one of the issues that block clang-18 adoption in Envoy CI.

Risk Level: Low
Testing: Regular presubmits on CI + building locally using clang-18
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
