### PR TITLE
http/transport tap: Support PROTO_TEXT format in UDP sink 

### DIFF
--- a/contrib/tap_sinks/udp_sink/source/udp_sink_impl.cc
+++ b/contrib/tap_sinks/udp_sink/source/udp_sink_impl.cc
@@ -46,13 +46,13 @@ void UdpTapSink::UdpTapSinkHandle::submitTrace(TapCommon::TraceWrapperPtr&& trac
   case envoy::config::tap::v3::OutputSink::PROTO_BINARY:
     FALLTHRU;
   case envoy::config::tap::v3::OutputSink::PROTO_BINARY_LENGTH_DELIMITED:
-    FALLTHRU;
-  case envoy::config::tap::v3::OutputSink::PROTO_TEXT:
     // will implement above format if it is needed.
     ENVOY_LOG_MISC(debug,
                    "{}: Not support PROTO_BINARY, PROTO_BINARY_LENGTH_DELIMITED,  PROTO_TEXT",
                    __func__);
     break;
+  case envoy::config::tap::v3::OutputSink::PROTO_TEXT:
+    FALLTHRU;
   case envoy::config::tap::v3::OutputSink::JSON_BODY_AS_BYTES:
     FALLTHRU;
   case envoy::config::tap::v3::OutputSink::JSON_BODY_AS_STRING: {
@@ -60,7 +60,12 @@ void UdpTapSink::UdpTapSinkHandle::submitTrace(TapCommon::TraceWrapperPtr&& trac
       ENVOY_LOG_MISC(debug, "{}: udp writter isn't created yet", __func__);
       break;
     }
-    std::string json_string = MessageUtil::getJsonStringFromMessageOrError(*trace, true, false);
+    std::string json_string;
+    if (format == envoy::config::tap::v3::OutputSink::PROTO_TEXT) {
+      json_string = MessageUtil::toTextProto(*trace);
+    } else {
+      json_string = MessageUtil::getJsonStringFromMessageOrError(*trace, true, false);
+    }
     Buffer::OwnedImpl udp_data(std::move(json_string));
     Api::IoCallUint64Result write_result =
         parent_.udp_packet_writer_->writePacket(udp_data, nullptr, *parent_.udp_server_address_);

--- a/contrib/tap_sinks/udp_sink/source/udp_sink_impl.cc
+++ b/contrib/tap_sinks/udp_sink/source/udp_sink_impl.cc
@@ -47,8 +47,7 @@ void UdpTapSink::UdpTapSinkHandle::submitTrace(TapCommon::TraceWrapperPtr&& trac
     FALLTHRU;
   case envoy::config::tap::v3::OutputSink::PROTO_BINARY_LENGTH_DELIMITED:
     // will implement above format if it is needed.
-    ENVOY_LOG_MISC(debug,
-                   "{}: Not support PROTO_BINARY, PROTO_BINARY_LENGTH_DELIMITED,  PROTO_TEXT",
+    ENVOY_LOG_MISC(debug, "{}: Not support PROTO_BINARY and PROTO_BINARY_LENGTH_DELIMITEDT",
                    __func__);
     break;
   case envoy::config::tap::v3::OutputSink::PROTO_TEXT:

--- a/contrib/tap_sinks/udp_sink/test/udp_sink_test.cc
+++ b/contrib/tap_sinks/udp_sink/test/udp_sink_test.cc
@@ -144,7 +144,7 @@ public:
   }
 };
 
-TEST_F(UdpTapSinkTest, TestSubmitTraceSendOk) {
+TEST_F(UdpTapSinkTest, TestSubmitTraceSendOkForJSON_BODY_AS_STRING) {
   // Construct UdpTapSink object
   envoy::extensions::tap_sinks::udp_sink::v3alpha::UdpSink loc_udp_sink;
   auto* socket_address = loc_udp_sink.mutable_udp_address();
@@ -167,7 +167,7 @@ TEST_F(UdpTapSinkTest, TestSubmitTraceSendOk) {
                             envoy::config::tap::v3::OutputSink::JSON_BODY_AS_STRING);
 }
 
-TEST_F(UdpTapSinkTest, TestSubmitTraceSendNotOk) {
+TEST_F(UdpTapSinkTest, TestSubmitTraceSendNotOkForJSON_BODY_AS_STRING) {
   // Construct UdpTapSink object
   envoy::extensions::tap_sinks::udp_sink::v3alpha::UdpSink loc_udp_sink;
   auto* socket_address = loc_udp_sink.mutable_udp_address();
@@ -190,7 +190,7 @@ TEST_F(UdpTapSinkTest, TestSubmitTraceSendNotOk) {
                             envoy::config::tap::v3::OutputSink::JSON_BODY_AS_STRING);
 }
 
-TEST_F(UdpTapSinkTest, TestSubmitTraceSendforPROTOTEXTOk) {
+TEST_F(UdpTapSinkTest, TestSubmitTraceSendOkforPROTOTEXT) {
   // Construct UdpTapSink object
   envoy::extensions::tap_sinks::udp_sink::v3alpha::UdpSink loc_udp_sink;
   auto* socket_address = loc_udp_sink.mutable_udp_address();

--- a/contrib/tap_sinks/udp_sink/test/udp_sink_test.cc
+++ b/contrib/tap_sinks/udp_sink/test/udp_sink_test.cc
@@ -144,7 +144,7 @@ public:
   }
 };
 
-TEST_F(UdpTapSinkTest, TestSubmitTraceSendOkForJSON_BODY_AS_STRING) {
+TEST_F(UdpTapSinkTest, TestSubmitTraceSendOkForJsonBodyAsString) {
   // Construct UdpTapSink object
   envoy::extensions::tap_sinks::udp_sink::v3alpha::UdpSink loc_udp_sink;
   auto* socket_address = loc_udp_sink.mutable_udp_address();
@@ -167,7 +167,7 @@ TEST_F(UdpTapSinkTest, TestSubmitTraceSendOkForJSON_BODY_AS_STRING) {
                             envoy::config::tap::v3::OutputSink::JSON_BODY_AS_STRING);
 }
 
-TEST_F(UdpTapSinkTest, TestSubmitTraceSendNotOkForJSON_BODY_AS_STRING) {
+TEST_F(UdpTapSinkTest, TestSubmitTraceSendNotOkForJsonBodyAsString) {
   // Construct UdpTapSink object
   envoy::extensions::tap_sinks::udp_sink::v3alpha::UdpSink loc_udp_sink;
   auto* socket_address = loc_udp_sink.mutable_udp_address();
@@ -190,7 +190,7 @@ TEST_F(UdpTapSinkTest, TestSubmitTraceSendNotOkForJSON_BODY_AS_STRING) {
                             envoy::config::tap::v3::OutputSink::JSON_BODY_AS_STRING);
 }
 
-TEST_F(UdpTapSinkTest, TestSubmitTraceSendOkforPROTOTEXT) {
+TEST_F(UdpTapSinkTest, TestSubmitTraceSendOkforProtoText) {
   // Construct UdpTapSink object
   envoy::extensions::tap_sinks::udp_sink::v3alpha::UdpSink loc_udp_sink;
   auto* socket_address = loc_udp_sink.mutable_udp_address();

--- a/contrib/tap_sinks/udp_sink/test/udp_sink_test.cc
+++ b/contrib/tap_sinks/udp_sink/test/udp_sink_test.cc
@@ -99,9 +99,6 @@ TEST_F(UdpTapSinkTest, TestSubmitTraceForNotSUpportedFormat) {
   // case2 format PROTO_BINARY_LENGTH_DELIMITED
   local_handle->submitTrace(std::move(local_buffered_trace),
                             envoy::config::tap::v3::OutputSink::PROTO_BINARY_LENGTH_DELIMITED);
-  // case3 format PROTO_TEXT
-  local_handle->submitTrace(std::move(local_buffered_trace),
-                            envoy::config::tap::v3::OutputSink::PROTO_TEXT);
 }
 
 // In order to control the return value of writePacket, then
@@ -191,6 +188,29 @@ TEST_F(UdpTapSinkTest, TestSubmitTraceSendNotOk) {
       Extensions::Common::Tap::makeTraceWrapper();
   local_handle->submitTrace(std::move(local_buffered_trace),
                             envoy::config::tap::v3::OutputSink::JSON_BODY_AS_STRING);
+}
+
+TEST_F(UdpTapSinkTest, TestSubmitTraceSendforPROTOTEXTOk) {
+  // Construct UdpTapSink object
+  envoy::extensions::tap_sinks::udp_sink::v3alpha::UdpSink loc_udp_sink;
+  auto* socket_address = loc_udp_sink.mutable_udp_address();
+  socket_address->set_protocol(envoy::config::core::v3::SocketAddress::UDP);
+  socket_address->set_port_value(8080);
+  socket_address->set_address("127.0.0.1");
+  UtSpecialUdpTapSink loc_udp_tap_sink(loc_udp_sink);
+
+  std::unique_ptr<MockUdpPacketWriterNew> local_UdpPacketWriter =
+      std::make_unique<MockUdpPacketWriterNew>(true);
+  loc_udp_tap_sink.replaceOrigUdpPacketWriter(std::move(local_UdpPacketWriter));
+
+  // Create UdpTapSinkHandle
+  TapCommon::PerTapSinkHandlePtr local_handle =
+      loc_udp_tap_sink.createPerTapSinkHandle(99, ProtoOutputSink::OutputSinkTypeCase::kCustomSink);
+
+  Extensions::Common::Tap::TraceWrapperPtr local_buffered_trace =
+      Extensions::Common::Tap::makeTraceWrapper();
+  local_handle->submitTrace(std::move(local_buffered_trace),
+                            envoy::config::tap::v3::OutputSink::PROTO_TEXT);
 }
 
 } // namespace UDP


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Support PROTO_TEXT format in UDP sink 
Additional Description:
New request from custom, it needs raw format http2 message.
if use format JSON_BODY_AS_BYTES, then the http2  message is encoded as base64, then server side has to base64 decode to get raw http2 message.
if use format  PROTO_TEXT, then server side get raw http2 message which doesn't need run base64 decode to save CPU time
Based above reason, add format PROTO_TEXT in UDP sink to meet raw http2 message  needs.
if it set JSON_
Risk Level:low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
