### PR TITLE
xds: refactor xds-resources-delegate and move it to xds-manager

### DIFF
--- a/envoy/config/BUILD
+++ b/envoy/config/BUILD
@@ -161,6 +161,7 @@ envoy_cc_library(
     hdrs = ["xds_manager.h"],
     deps = [
         ":xds_config_tracker_interface",
+        ":xds_resources_delegate_interface",
         "//envoy/upstream:cluster_manager_interface",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
     ],

--- a/envoy/config/xds_manager.h
+++ b/envoy/config/xds_manager.h
@@ -3,6 +3,7 @@
 #include "envoy/common/pure.h"
 #include "envoy/config/core/v3/config_source.pb.h"
 #include "envoy/config/xds_config_tracker.h"
+#include "envoy/config/xds_resources_delegate.h"
 #include "envoy/upstream/cluster_manager.h"
 
 #include "absl/status/status.h"
@@ -58,6 +59,15 @@ public:
    * @return the XdsConfigTracker if defined, or nullopt if not.
    */
   virtual OptRef<Config::XdsConfigTracker> xdsConfigTracker() PURE;
+
+  /**
+   * Returns the XdsResourcesDelegate if defined by the bootstrap.
+   * The object will be initialized (if configured) after the call to initialize().
+   * TODO(adisuissa): this method will be removed once all the ADS-related objects
+   * are moved out of the cluster-manager to the xds-manager.
+   * @return the XdsResourcesDelegate if defined, or nullopt if not.
+   */
+  virtual XdsResourcesDelegateOptRef xdsResourcesDelegate() PURE;
 };
 
 using XdsManagerPtr = std::unique_ptr<XdsManager>;

--- a/source/common/config/xds_manager_impl.cc
+++ b/source/common/config/xds_manager_impl.cc
@@ -13,6 +13,16 @@ absl::Status XdsManagerImpl::initialize(const envoy::config::bootstrap::v3::Boot
   ASSERT(cm != nullptr);
   cm_ = cm;
 
+  // Initialize the XdsResourceDelegate extension, if set on the bootstrap config.
+  if (bootstrap.has_xds_delegate_extension()) {
+    auto& factory = Config::Utility::getAndCheckFactory<XdsResourcesDelegateFactory>(
+        bootstrap.xds_delegate_extension());
+    xds_resources_delegate_ = factory.createXdsResourcesDelegate(
+        bootstrap.xds_delegate_extension().typed_config(),
+        validation_context_.dynamicValidationVisitor(), api_, main_thread_dispatcher_);
+  }
+
+  // Initialize the XdsConfigTracker extension, if set on the bootstrap config.
   if (bootstrap.has_xds_config_tracker_extension()) {
     auto& tracker_factory = Config::Utility::getAndCheckFactory<Config::XdsConfigTrackerFactory>(
         bootstrap.xds_config_tracker_extension());

--- a/source/common/config/xds_manager_impl.h
+++ b/source/common/config/xds_manager_impl.h
@@ -24,6 +24,10 @@ public:
     return makeOptRefFromPtr<Config::XdsConfigTracker>(xds_config_tracker_.get());
   }
 
+  XdsResourcesDelegateOptRef xdsResourcesDelegate() override {
+    return makeOptRefFromPtr<Config::XdsResourcesDelegate>(xds_resources_delegate_.get());
+  }
+
 private:
   // Validates (syntactically) the config_source by doing the PGV validation.
   absl::Status validateAdsConfig(const envoy::config::core::v3::ApiConfigSource& config_source);
@@ -31,6 +35,7 @@ private:
   Event::Dispatcher& main_thread_dispatcher_;
   Api::Api& api_;
   ProtobufMessage::ValidationContext& validation_context_;
+  XdsResourcesDelegatePtr xds_resources_delegate_;
   Config::XdsConfigTrackerPtr xds_config_tracker_;
   // The cm_ will only be valid after the cluster-manager is initialized.
   // Note that this implies that the xDS-manager must be shut down properly

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -954,8 +954,6 @@ private:
   std::unique_ptr<Config::SubscriptionFactoryImpl> subscription_factory_;
   ClusterSet primary_clusters_;
 
-  std::unique_ptr<Config::XdsResourcesDelegate> xds_resources_delegate_;
-
   bool initialized_{};
   bool ads_mux_initialized_{};
   std::atomic<bool> shutdown_{};

--- a/test/mocks/config/xds_manager.h
+++ b/test/mocks/config/xds_manager.h
@@ -19,6 +19,7 @@ public:
   MOCK_METHOD(absl::Status, setAdsConfigSource,
               (const envoy::config::core::v3::ApiConfigSource& config_source));
   MOCK_METHOD(OptRef<Config::XdsConfigTracker>, xdsConfigTracker, ());
+  MOCK_METHOD(XdsResourcesDelegateOptRef, xdsResourcesDelegate, ());
 };
 
 } // namespace Config


### PR DESCRIPTION
Commit Message: xds: refactor xds-resources-delegate and move it to xds-manager
Additional Description:
Follow up to #38242.
This PR moves the xDS-Resources-Delegate from the cluster-manager to the xds-manager.
Note that in this PR we add a getter for the xDS-Resources-Delegate, but that will be removed in the future when the rest of the xDS-related components are moved from the cluster-manager to the xds-manager.

Risk Level: low
Testing: N/A - original tests should cover functionallity.
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A