### PR TITLE
Don't capture local objects by reference in lambda

### DIFF
--- a/test/integration/fake_upstream.cc
+++ b/test/integration/fake_upstream.cc
@@ -980,7 +980,7 @@ AssertionResult FakeUpstream::runOnDispatcherThreadAndWait(std::function<Asserti
 
 void FakeUpstream::runOnDispatcherThread(std::function<void()> cb) {
   ASSERT(!dispatcher_->isThreadSafe());
-  dispatcher_->post([&]() { cb(); });
+  dispatcher_->post([cb = std::move(cb)]() { cb(); });
 }
 
 void FakeUpstream::sendUdpDatagram(const std::string& buffer,


### PR DESCRIPTION
Commit Message:

In FakeUpstream class we capture local std::function by reference in lambda. That does not cause many problems in practice and it is not detected by the MSAN in clang-14 currently used by Envoy CI.

Still, it's not correct, and it does trigger a smarter MSAN in clang-18.

Additional Description:

Related to https://github.com/envoyproxy/envoy/issues/37911 and fixes one of the issues that block clang-18 adoption in Envoy CI.

Risk Level: Low
Testing: `do_ci.sh msan` using Envoy CI image with clang-18
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
