### PR TITLE
Cleanup before freeing FakeStream to prevent use-after-free

### DIFF
--- a/test/integration/multiplexed_integration_test.cc
+++ b/test/integration/multiplexed_integration_test.cc
@@ -2924,6 +2924,7 @@ TEST_P(Http2FrameIntegrationTest, SendGoAwayNotTriggerredByDecodingFilter) {
   FakeStreamPtr upstream_request;
   ASSERT_TRUE(fake_upstream_connection_->waitForNewStream(*dispatcher_, upstream_request));
   ASSERT_TRUE(upstream_request->waitForEndStream(*dispatcher_));
+  cleanupUpstreamAndDownstream();
   tcp_client_->close();
 }
 


### PR DESCRIPTION
Commit Message:

In SendGoAwayNotTriggerredByDecodingFilter it could happen that FakeStream will get destroyed (when the test ends) before FakeUpstream dispatcher thread (FakeUpstream::threadRoutine()) exits or before all processing on the connection is complete.

That leads to a situation when FakeUpstream dispatcher thread may try to call into the FakeStream::onResetStream when connection established by the test gets terminated *after* FakeStream was already destroyed.

This triggers MSAN issue on clang-18 pretty consistently, though I don't think it's deterministic and could potentially happen on clang-14 currently used by Envoy CIs.

This change makes sure that we do cleanup before exiting the test, thus preventing the use-after-free issue.

Additional Description:

Related to https://github.com/envoyproxy/envoy/issues/37911 and fixes one of the issues that block clang-18 adoption in Envoy CI.

Risk Level: low
Testing: `do_ci.sh msan` using Envoy CI image with clang-18
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a