### PR TITLE
access log: new access log interface to provide custom command parsers

### DIFF
--- a/envoy/access_log/BUILD
+++ b/envoy/access_log/BUILD
@@ -27,6 +27,7 @@ envoy_cc_library(
     hdrs = ["access_log_config.h"],
     deps = [
         "//envoy/access_log:access_log_interface",
+        "//envoy/formatter:substitution_formatter_interface",
         "//envoy/server:filter_config_interface",
         "//source/common/protobuf",
     ],

--- a/envoy/access_log/access_log_config.h
+++ b/envoy/access_log/access_log_config.h
@@ -4,6 +4,7 @@
 
 #include "envoy/access_log/access_log.h"
 #include "envoy/config/typed_config.h"
+#include "envoy/formatter/substitution_formatter.h"
 #include "envoy/server/filter_config.h"
 
 #include "source/common/protobuf/protobuf.h"
@@ -70,11 +71,13 @@ public:
    * @param filter filter to determine whether a particular request should be logged. If no filter
    * was specified in the configuration, argument will be nullptr.
    * @param context access log context through which persistent resources can be accessed.
+   * @param command_parsers vector of command parsers that provide by the caller to be used for
+   * parsing custom substitution commands.
    */
-  virtual AccessLog::InstanceBaseSharedPtr<Context>
-  createAccessLogInstance(const Protobuf::Message& config,
-                          AccessLog::FilterBasePtr<Context>&& filter,
-                          Server::Configuration::FactoryContext& context) PURE;
+  virtual AccessLog::InstanceBaseSharedPtr<Context> createAccessLogInstance(
+      const Protobuf::Message& config, AccessLog::FilterBasePtr<Context>&& filter,
+      Server::Configuration::FactoryContext& context,
+      std::vector<Formatter::CommandParserBasePtr<Context>> command_parsers = {}) PURE;
 
   std::string category() const override { return category_; }
 

--- a/envoy/access_log/access_log_config.h
+++ b/envoy/access_log/access_log_config.h
@@ -77,7 +77,7 @@ public:
   virtual AccessLog::InstanceBaseSharedPtr<Context> createAccessLogInstance(
       const Protobuf::Message& config, AccessLog::FilterBasePtr<Context>&& filter,
       Server::Configuration::FactoryContext& context,
-      std::vector<Formatter::CommandParserBasePtr<Context>> command_parsers = {}) PURE;
+      std::vector<Formatter::CommandParserBasePtr<Context>>&& command_parsers = {}) PURE;
 
   std::string category() const override { return category_; }
 

--- a/source/common/access_log/access_log_impl.cc
+++ b/source/common/access_log/access_log_impl.cc
@@ -328,8 +328,10 @@ bool MetadataFilter::evaluate(const Formatter::HttpFormatterContext&,
   return default_match_;
 }
 
-InstanceSharedPtr AccessLogFactory::fromProto(const envoy::config::accesslog::v3::AccessLog& config,
-                                              Server::Configuration::FactoryContext& context) {
+InstanceSharedPtr
+AccessLogFactory::fromProto(const envoy::config::accesslog::v3::AccessLog& config,
+                            Server::Configuration::FactoryContext& context,
+                            std::vector<Formatter::CommandParserPtr> command_parsers) {
   FilterPtr filter;
   if (config.has_filter()) {
     filter = FilterFactory::fromProto(config.filter(), context);
@@ -339,7 +341,8 @@ InstanceSharedPtr AccessLogFactory::fromProto(const envoy::config::accesslog::v3
   ProtobufTypes::MessagePtr message = Config::Utility::translateToFactoryConfig(
       config, context.messageValidationVisitor(), factory);
 
-  return factory.createAccessLogInstance(*message, std::move(filter), context);
+  return factory.createAccessLogInstance(*message, std::move(filter), context,
+                                         std::move(command_parsers));
 }
 
 } // namespace AccessLog

--- a/source/common/access_log/access_log_impl.cc
+++ b/source/common/access_log/access_log_impl.cc
@@ -331,7 +331,7 @@ bool MetadataFilter::evaluate(const Formatter::HttpFormatterContext&,
 InstanceSharedPtr
 AccessLogFactory::fromProto(const envoy::config::accesslog::v3::AccessLog& config,
                             Server::Configuration::FactoryContext& context,
-                            std::vector<Formatter::CommandParserPtr> command_parsers) {
+                            std::vector<Formatter::CommandParserPtr>&& command_parsers) {
   FilterPtr filter;
   if (config.has_filter()) {
     filter = FilterFactory::fromProto(config.filter(), context);

--- a/source/common/access_log/access_log_impl.h
+++ b/source/common/access_log/access_log_impl.h
@@ -268,7 +268,8 @@ public:
    * to create access log instances that need access to listener properties.
    */
   static InstanceSharedPtr fromProto(const envoy::config::accesslog::v3::AccessLog& config,
-                                     Server::Configuration::FactoryContext& context);
+                                     Server::Configuration::FactoryContext& context,
+                                     std::vector<Formatter::CommandParserPtr> command_parsers = {});
 };
 
 } // namespace AccessLog

--- a/source/common/access_log/access_log_impl.h
+++ b/source/common/access_log/access_log_impl.h
@@ -267,9 +267,10 @@ public:
    * Read a filter definition from proto and instantiate an Instance. This method is used
    * to create access log instances that need access to listener properties.
    */
-  static InstanceSharedPtr fromProto(const envoy::config::accesslog::v3::AccessLog& config,
-                                     Server::Configuration::FactoryContext& context,
-                                     std::vector<Formatter::CommandParserPtr> command_parsers = {});
+  static InstanceSharedPtr
+  fromProto(const envoy::config::accesslog::v3::AccessLog& config,
+            Server::Configuration::FactoryContext& context,
+            std::vector<Formatter::CommandParserPtr>&& command_parsers = {});
 };
 
 } // namespace AccessLog

--- a/source/common/formatter/substitution_format_string.h
+++ b/source/common/formatter/substitution_format_string.h
@@ -61,10 +61,10 @@ public:
   static absl::StatusOr<FormatterBasePtr<FormatterContext>>
   fromProtoConfig(const envoy::config::core::v3::SubstitutionFormatString& config,
                   Server::Configuration::GenericFactoryContext& context,
-                  std::vector<CommandParserBasePtr<FormatterContext>> commands_parsers = {}) {
+                  std::vector<CommandParserBasePtr<FormatterContext>>&& command_parsers = {}) {
     // Instantiate formatter extensions.
-    auto commands = parseFormatters<FormatterContext>(config.formatters(), context,
-                                                      std::move(commands_parsers));
+    auto commands =
+        parseFormatters<FormatterContext>(config.formatters(), context, std::move(command_parsers));
     RETURN_IF_NOT_OK_REF(commands.status());
 
     switch (config.format_case()) {

--- a/source/common/formatter/substitution_format_string.h
+++ b/source/common/formatter/substitution_format_string.h
@@ -32,8 +32,9 @@ public:
   template <class FormatterContext = HttpFormatterContext>
   static absl::StatusOr<std::vector<CommandParserBasePtr<FormatterContext>>>
   parseFormatters(const FormattersConfig& formatters,
-                  Server::Configuration::GenericFactoryContext& context) {
-    std::vector<CommandParserBasePtr<FormatterContext>> commands;
+                  Server::Configuration::GenericFactoryContext& context,
+                  std::vector<CommandParserBasePtr<FormatterContext>> commands_parsers = {}) {
+    std::vector<CommandParserBasePtr<FormatterContext>> commands = std::move(commands_parsers);
     for (const auto& formatter : formatters) {
       auto* factory =
           Envoy::Config::Utility::getFactory<CommandParserFactoryBase<FormatterContext>>(formatter);
@@ -59,10 +60,13 @@ public:
   template <class FormatterContext = HttpFormatterContext>
   static absl::StatusOr<FormatterBasePtr<FormatterContext>>
   fromProtoConfig(const envoy::config::core::v3::SubstitutionFormatString& config,
-                  Server::Configuration::GenericFactoryContext& context) {
+                  Server::Configuration::GenericFactoryContext& context,
+                  std::vector<CommandParserBasePtr<FormatterContext>> commands_parsers = {}) {
     // Instantiate formatter extensions.
-    auto commands = parseFormatters<FormatterContext>(config.formatters(), context);
+    auto commands = parseFormatters<FormatterContext>(config.formatters(), context,
+                                                      std::move(commands_parsers));
     RETURN_IF_NOT_OK_REF(commands.status());
+
     switch (config.format_case()) {
     case envoy::config::core::v3::SubstitutionFormatString::FormatCase::kTextFormat:
       return FormatterBaseImpl<FormatterContext>::create(config.text_format(),

--- a/source/extensions/access_loggers/common/stream_access_log_common_impl.h
+++ b/source/extensions/access_loggers/common/stream_access_log_common_impl.h
@@ -13,14 +13,16 @@ namespace AccessLoggers {
 template <class T, Filesystem::DestinationType destination_type>
 AccessLog::InstanceSharedPtr
 createStreamAccessLogInstance(const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
-                              Server::Configuration::FactoryContext& context) {
+                              Server::Configuration::FactoryContext& context,
+                              std::vector<Formatter::CommandParserPtr> commands_parsers = {}) {
   const auto& fal_config =
       MessageUtil::downcastAndValidate<const T&>(config, context.messageValidationVisitor());
   Formatter::FormatterPtr formatter;
   if (fal_config.access_log_format_case() == T::AccessLogFormatCase::kLogFormat) {
-    formatter = THROW_OR_RETURN_VALUE(
-        Formatter::SubstitutionFormatStringUtils::fromProtoConfig(fal_config.log_format(), context),
-        Formatter::FormatterBasePtr<Formatter::HttpFormatterContext>);
+    formatter =
+        THROW_OR_RETURN_VALUE(Formatter::SubstitutionFormatStringUtils::fromProtoConfig(
+                                  fal_config.log_format(), context, std::move(commands_parsers)),
+                              Formatter::FormatterBasePtr<Formatter::HttpFormatterContext>);
   } else if (fal_config.access_log_format_case() ==
              T::AccessLogFormatCase::ACCESS_LOG_FORMAT_NOT_SET) {
     formatter = THROW_OR_RETURN_VALUE(

--- a/source/extensions/access_loggers/common/stream_access_log_common_impl.h
+++ b/source/extensions/access_loggers/common/stream_access_log_common_impl.h
@@ -14,14 +14,14 @@ template <class T, Filesystem::DestinationType destination_type>
 AccessLog::InstanceSharedPtr
 createStreamAccessLogInstance(const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
                               Server::Configuration::FactoryContext& context,
-                              std::vector<Formatter::CommandParserPtr> commands_parsers = {}) {
+                              std::vector<Formatter::CommandParserPtr>&& command_parsers = {}) {
   const auto& fal_config =
       MessageUtil::downcastAndValidate<const T&>(config, context.messageValidationVisitor());
   Formatter::FormatterPtr formatter;
   if (fal_config.access_log_format_case() == T::AccessLogFormatCase::kLogFormat) {
     formatter =
         THROW_OR_RETURN_VALUE(Formatter::SubstitutionFormatStringUtils::fromProtoConfig(
-                                  fal_config.log_format(), context, std::move(commands_parsers)),
+                                  fal_config.log_format(), context, std::move(command_parsers)),
                               Formatter::FormatterBasePtr<Formatter::HttpFormatterContext>);
   } else if (fal_config.access_log_format_case() ==
              T::AccessLogFormatCase::ACCESS_LOG_FORMAT_NOT_SET) {

--- a/source/extensions/access_loggers/file/config.cc
+++ b/source/extensions/access_loggers/file/config.cc
@@ -22,7 +22,7 @@ namespace File {
 AccessLog::InstanceSharedPtr FileAccessLogFactory::createAccessLogInstance(
     const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
     Server::Configuration::FactoryContext& context,
-    std::vector<Formatter::CommandParserPtr> command_parsers) {
+    std::vector<Formatter::CommandParserPtr>&& command_parsers) {
   const auto& fal_config = MessageUtil::downcastAndValidate<
       const envoy::extensions::access_loggers::file::v3::FileAccessLog&>(
       config, context.messageValidationVisitor());

--- a/source/extensions/access_loggers/file/config.cc
+++ b/source/extensions/access_loggers/file/config.cc
@@ -19,10 +19,10 @@ namespace Extensions {
 namespace AccessLoggers {
 namespace File {
 
-AccessLog::InstanceSharedPtr
-FileAccessLogFactory::createAccessLogInstance(const Protobuf::Message& config,
-                                              AccessLog::FilterPtr&& filter,
-                                              Server::Configuration::FactoryContext& context) {
+AccessLog::InstanceSharedPtr FileAccessLogFactory::createAccessLogInstance(
+    const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
+    Server::Configuration::FactoryContext& context,
+    std::vector<Formatter::CommandParserPtr> command_parsers) {
   const auto& fal_config = MessageUtil::downcastAndValidate<
       const envoy::extensions::access_loggers::file::v3::FileAccessLog&>(
       config, context.messageValidationVisitor());
@@ -37,28 +37,30 @@ FileAccessLogFactory::createAccessLogInstance(const Protobuf::Message& config,
     } else {
       envoy::config::core::v3::SubstitutionFormatString sff_config;
       sff_config.mutable_text_format_source()->set_inline_string(fal_config.format());
-      formatter = THROW_OR_RETURN_VALUE(
-          Formatter::SubstitutionFormatStringUtils::fromProtoConfig(sff_config, context),
-          Formatter::FormatterBasePtr<Formatter::HttpFormatterContext>);
+      formatter =
+          THROW_OR_RETURN_VALUE(Formatter::SubstitutionFormatStringUtils::fromProtoConfig(
+                                    sff_config, context, std::move(command_parsers)),
+                                Formatter::FormatterBasePtr<Formatter::HttpFormatterContext>);
     }
     break;
   case envoy::extensions::access_loggers::file::v3::FileAccessLog::AccessLogFormatCase::kJsonFormat:
     formatter = Formatter::SubstitutionFormatStringUtils::createJsonFormatter(
-        fal_config.json_format(), false, false, false);
+        fal_config.json_format(), false, false, false, command_parsers);
     break;
   case envoy::extensions::access_loggers::file::v3::FileAccessLog::AccessLogFormatCase::
       kTypedJsonFormat: {
     envoy::config::core::v3::SubstitutionFormatString sff_config;
     *sff_config.mutable_json_format() = fal_config.typed_json_format();
-    formatter = THROW_OR_RETURN_VALUE(
-        Formatter::SubstitutionFormatStringUtils::fromProtoConfig(sff_config, context),
-        Formatter::FormatterBasePtr<Formatter::HttpFormatterContext>);
+    formatter = THROW_OR_RETURN_VALUE(Formatter::SubstitutionFormatStringUtils::fromProtoConfig(
+                                          sff_config, context, std::move(command_parsers)),
+                                      Formatter::FormatterBasePtr<Formatter::HttpFormatterContext>);
     break;
   }
   case envoy::extensions::access_loggers::file::v3::FileAccessLog::AccessLogFormatCase::kLogFormat:
-    formatter = THROW_OR_RETURN_VALUE(
-        Formatter::SubstitutionFormatStringUtils::fromProtoConfig(fal_config.log_format(), context),
-        Formatter::FormatterBasePtr<Formatter::HttpFormatterContext>);
+    formatter =
+        THROW_OR_RETURN_VALUE(Formatter::SubstitutionFormatStringUtils::fromProtoConfig(
+                                  fal_config.log_format(), context, std::move(command_parsers)),
+                              Formatter::FormatterBasePtr<Formatter::HttpFormatterContext>);
     break;
   case envoy::extensions::access_loggers::file::v3::FileAccessLog::AccessLogFormatCase::
       ACCESS_LOG_FORMAT_NOT_SET:

--- a/source/extensions/access_loggers/file/config.h
+++ b/source/extensions/access_loggers/file/config.h
@@ -15,7 +15,7 @@ public:
   AccessLog::InstanceSharedPtr
   createAccessLogInstance(const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
                           Server::Configuration::FactoryContext& context,
-                          std::vector<Formatter::CommandParserPtr> command_parsers = {}) override;
+                          std::vector<Formatter::CommandParserPtr>&& command_parsers = {}) override;
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override;
 

--- a/source/extensions/access_loggers/file/config.h
+++ b/source/extensions/access_loggers/file/config.h
@@ -14,7 +14,8 @@ class FileAccessLogFactory : public AccessLog::AccessLogInstanceFactory {
 public:
   AccessLog::InstanceSharedPtr
   createAccessLogInstance(const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
-                          Server::Configuration::FactoryContext& context) override;
+                          Server::Configuration::FactoryContext& context,
+                          std::vector<Formatter::CommandParserPtr> command_parsers = {}) override;
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override;
 

--- a/source/extensions/access_loggers/fluentd/config.cc
+++ b/source/extensions/access_loggers/fluentd/config.cc
@@ -34,7 +34,7 @@ getAccessLoggerCacheSingleton(Server::Configuration::ServerFactoryContext& conte
 AccessLog::InstanceSharedPtr FluentdAccessLogFactory::createAccessLogInstance(
     const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
     Server::Configuration::FactoryContext& context,
-    std::vector<Formatter::CommandParserPtr> commands_parsers) {
+    std::vector<Formatter::CommandParserPtr>&& command_parsers) {
   const auto& proto_config = MessageUtil::downcastAndValidate<
       const envoy::extensions::access_loggers::fluentd::v3::FluentdAccessLogConfig&>(
       config, context.messageValidationVisitor());
@@ -62,7 +62,7 @@ AccessLog::InstanceSharedPtr FluentdAccessLogFactory::createAccessLogInstance(
   //                 will directly serialize the record to msgpack payload.
   auto commands = THROW_OR_RETURN_VALUE(
       Formatter::SubstitutionFormatStringUtils::parseFormatters(proto_config.formatters(), context,
-                                                                std::move(commands_parsers)),
+                                                                std::move(command_parsers)),
       std::vector<Formatter::CommandParserBasePtr<Formatter::HttpFormatterContext>>);
 
   Formatter::FormatterPtr json_formatter =

--- a/source/extensions/access_loggers/fluentd/config.cc
+++ b/source/extensions/access_loggers/fluentd/config.cc
@@ -31,10 +31,10 @@ getAccessLoggerCacheSingleton(Server::Configuration::ServerFactoryContext& conte
       /* pin = */ true);
 }
 
-AccessLog::InstanceSharedPtr
-FluentdAccessLogFactory::createAccessLogInstance(const Protobuf::Message& config,
-                                                 AccessLog::FilterPtr&& filter,
-                                                 Server::Configuration::FactoryContext& context) {
+AccessLog::InstanceSharedPtr FluentdAccessLogFactory::createAccessLogInstance(
+    const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
+    Server::Configuration::FactoryContext& context,
+    std::vector<Formatter::CommandParserPtr> commands_parsers) {
   const auto& proto_config = MessageUtil::downcastAndValidate<
       const envoy::extensions::access_loggers::fluentd::v3::FluentdAccessLogConfig&>(
       config, context.messageValidationVisitor());
@@ -61,7 +61,8 @@ FluentdAccessLogFactory::createAccessLogInstance(const Protobuf::Message& config
   // TODO(ohadvano): Improve the formatting operation by creating a dedicated formatter that
   //                 will directly serialize the record to msgpack payload.
   auto commands = THROW_OR_RETURN_VALUE(
-      Formatter::SubstitutionFormatStringUtils::parseFormatters(proto_config.formatters(), context),
+      Formatter::SubstitutionFormatStringUtils::parseFormatters(proto_config.formatters(), context,
+                                                                std::move(commands_parsers)),
       std::vector<Formatter::CommandParserBasePtr<Formatter::HttpFormatterContext>>);
 
   Formatter::FormatterPtr json_formatter =

--- a/source/extensions/access_loggers/fluentd/config.h
+++ b/source/extensions/access_loggers/fluentd/config.h
@@ -15,7 +15,7 @@ public:
   AccessLog::InstanceSharedPtr
   createAccessLogInstance(const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
                           Server::Configuration::FactoryContext& context,
-                          std::vector<Formatter::CommandParserPtr> commands_parsers = {}) override;
+                          std::vector<Formatter::CommandParserPtr>&& command_parsers = {}) override;
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override;
 

--- a/source/extensions/access_loggers/fluentd/config.h
+++ b/source/extensions/access_loggers/fluentd/config.h
@@ -14,7 +14,8 @@ class FluentdAccessLogFactory : public AccessLog::AccessLogInstanceFactory {
 public:
   AccessLog::InstanceSharedPtr
   createAccessLogInstance(const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
-                          Server::Configuration::FactoryContext& context) override;
+                          Server::Configuration::FactoryContext& context,
+                          std::vector<Formatter::CommandParserPtr> commands_parsers = {}) override;
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override;
 

--- a/source/extensions/access_loggers/grpc/http_config.cc
+++ b/source/extensions/access_loggers/grpc/http_config.cc
@@ -18,10 +18,9 @@ namespace Extensions {
 namespace AccessLoggers {
 namespace HttpGrpc {
 
-AccessLog::InstanceSharedPtr
-HttpGrpcAccessLogFactory::createAccessLogInstance(const Protobuf::Message& config,
-                                                  AccessLog::FilterPtr&& filter,
-                                                  Server::Configuration::FactoryContext& context) {
+AccessLog::InstanceSharedPtr HttpGrpcAccessLogFactory::createAccessLogInstance(
+    const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
+    Server::Configuration::FactoryContext& context, std::vector<Formatter::CommandParserPtr>) {
   GrpcCommon::validateProtoDescriptors();
 
   const auto& proto_config = MessageUtil::downcastAndValidate<

--- a/source/extensions/access_loggers/grpc/http_config.cc
+++ b/source/extensions/access_loggers/grpc/http_config.cc
@@ -20,7 +20,7 @@ namespace HttpGrpc {
 
 AccessLog::InstanceSharedPtr HttpGrpcAccessLogFactory::createAccessLogInstance(
     const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
-    Server::Configuration::FactoryContext& context, std::vector<Formatter::CommandParserPtr>) {
+    Server::Configuration::FactoryContext& context, std::vector<Formatter::CommandParserPtr>&&) {
   GrpcCommon::validateProtoDescriptors();
 
   const auto& proto_config = MessageUtil::downcastAndValidate<

--- a/source/extensions/access_loggers/grpc/http_config.h
+++ b/source/extensions/access_loggers/grpc/http_config.h
@@ -17,7 +17,7 @@ public:
   AccessLog::InstanceSharedPtr
   createAccessLogInstance(const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
                           Server::Configuration::FactoryContext& context,
-                          std::vector<Formatter::CommandParserPtr> = {}) override;
+                          std::vector<Formatter::CommandParserPtr>&& = {}) override;
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override;
 

--- a/source/extensions/access_loggers/grpc/http_config.h
+++ b/source/extensions/access_loggers/grpc/http_config.h
@@ -16,7 +16,8 @@ class HttpGrpcAccessLogFactory : public AccessLog::AccessLogInstanceFactory {
 public:
   AccessLog::InstanceSharedPtr
   createAccessLogInstance(const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
-                          Server::Configuration::FactoryContext& context) override;
+                          Server::Configuration::FactoryContext& context,
+                          std::vector<Formatter::CommandParserPtr> = {}) override;
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override;
 

--- a/source/extensions/access_loggers/grpc/tcp_config.cc
+++ b/source/extensions/access_loggers/grpc/tcp_config.cc
@@ -20,7 +20,7 @@ namespace TcpGrpc {
 
 AccessLog::InstanceSharedPtr TcpGrpcAccessLogFactory::createAccessLogInstance(
     const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
-    Server::Configuration::FactoryContext& context, std::vector<Formatter::CommandParserPtr>) {
+    Server::Configuration::FactoryContext& context, std::vector<Formatter::CommandParserPtr>&&) {
   GrpcCommon::validateProtoDescriptors();
 
   const auto& proto_config = MessageUtil::downcastAndValidate<

--- a/source/extensions/access_loggers/grpc/tcp_config.cc
+++ b/source/extensions/access_loggers/grpc/tcp_config.cc
@@ -18,10 +18,9 @@ namespace Extensions {
 namespace AccessLoggers {
 namespace TcpGrpc {
 
-AccessLog::InstanceSharedPtr
-TcpGrpcAccessLogFactory::createAccessLogInstance(const Protobuf::Message& config,
-                                                 AccessLog::FilterPtr&& filter,
-                                                 Server::Configuration::FactoryContext& context) {
+AccessLog::InstanceSharedPtr TcpGrpcAccessLogFactory::createAccessLogInstance(
+    const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
+    Server::Configuration::FactoryContext& context, std::vector<Formatter::CommandParserPtr>) {
   GrpcCommon::validateProtoDescriptors();
 
   const auto& proto_config = MessageUtil::downcastAndValidate<

--- a/source/extensions/access_loggers/grpc/tcp_config.h
+++ b/source/extensions/access_loggers/grpc/tcp_config.h
@@ -16,7 +16,8 @@ class TcpGrpcAccessLogFactory : public AccessLog::AccessLogInstanceFactory {
 public:
   AccessLog::InstanceSharedPtr
   createAccessLogInstance(const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
-                          Server::Configuration::FactoryContext& context) override;
+                          Server::Configuration::FactoryContext& context,
+                          std::vector<Formatter::CommandParserPtr> = {}) override;
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override;
 

--- a/source/extensions/access_loggers/grpc/tcp_config.h
+++ b/source/extensions/access_loggers/grpc/tcp_config.h
@@ -17,7 +17,7 @@ public:
   AccessLog::InstanceSharedPtr
   createAccessLogInstance(const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
                           Server::Configuration::FactoryContext& context,
-                          std::vector<Formatter::CommandParserPtr> = {}) override;
+                          std::vector<Formatter::CommandParserPtr>&& = {}) override;
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override;
 

--- a/source/extensions/access_loggers/open_telemetry/config.cc
+++ b/source/extensions/access_loggers/open_telemetry/config.cc
@@ -31,10 +31,10 @@ getAccessLoggerCacheSingleton(Server::Configuration::CommonFactoryContext& conte
       });
 }
 
-::Envoy::AccessLog::InstanceSharedPtr
-AccessLogFactory::createAccessLogInstance(const Protobuf::Message& config,
-                                          ::Envoy::AccessLog::FilterPtr&& filter,
-                                          Server::Configuration::FactoryContext& context) {
+::Envoy::AccessLog::InstanceSharedPtr AccessLogFactory::createAccessLogInstance(
+    const Protobuf::Message& config, ::Envoy::AccessLog::FilterPtr&& filter,
+    Server::Configuration::FactoryContext& context,
+    std::vector<Formatter::CommandParserPtr> commands_parsers) {
   validateProtoDescriptors();
 
   const auto& proto_config = MessageUtil::downcastAndValidate<
@@ -42,7 +42,8 @@ AccessLogFactory::createAccessLogInstance(const Protobuf::Message& config,
       config, context.messageValidationVisitor());
 
   auto commands = THROW_OR_RETURN_VALUE(
-      Formatter::SubstitutionFormatStringUtils::parseFormatters(proto_config.formatters(), context),
+      Formatter::SubstitutionFormatStringUtils::parseFormatters(proto_config.formatters(), context,
+                                                                std::move(commands_parsers)),
       std::vector<Formatter::CommandParserBasePtr<Formatter::HttpFormatterContext>>);
 
   return std::make_shared<AccessLog>(

--- a/source/extensions/access_loggers/open_telemetry/config.cc
+++ b/source/extensions/access_loggers/open_telemetry/config.cc
@@ -34,7 +34,7 @@ getAccessLoggerCacheSingleton(Server::Configuration::CommonFactoryContext& conte
 ::Envoy::AccessLog::InstanceSharedPtr AccessLogFactory::createAccessLogInstance(
     const Protobuf::Message& config, ::Envoy::AccessLog::FilterPtr&& filter,
     Server::Configuration::FactoryContext& context,
-    std::vector<Formatter::CommandParserPtr> commands_parsers) {
+    std::vector<Formatter::CommandParserPtr>&& command_parsers) {
   validateProtoDescriptors();
 
   const auto& proto_config = MessageUtil::downcastAndValidate<
@@ -43,7 +43,7 @@ getAccessLoggerCacheSingleton(Server::Configuration::CommonFactoryContext& conte
 
   auto commands = THROW_OR_RETURN_VALUE(
       Formatter::SubstitutionFormatStringUtils::parseFormatters(proto_config.formatters(), context,
-                                                                std::move(commands_parsers)),
+                                                                std::move(command_parsers)),
       std::vector<Formatter::CommandParserBasePtr<Formatter::HttpFormatterContext>>);
 
   return std::make_shared<AccessLog>(

--- a/source/extensions/access_loggers/open_telemetry/config.h
+++ b/source/extensions/access_loggers/open_telemetry/config.h
@@ -17,7 +17,7 @@ public:
   ::Envoy::AccessLog::InstanceSharedPtr
   createAccessLogInstance(const Protobuf::Message& config, ::Envoy::AccessLog::FilterPtr&& filter,
                           Server::Configuration::FactoryContext& context,
-                          std::vector<Formatter::CommandParserPtr> commands_parsers = {}) override;
+                          std::vector<Formatter::CommandParserPtr>&& command_parsers = {}) override;
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override;
 

--- a/source/extensions/access_loggers/open_telemetry/config.h
+++ b/source/extensions/access_loggers/open_telemetry/config.h
@@ -16,7 +16,8 @@ class AccessLogFactory : public Envoy::AccessLog::AccessLogInstanceFactory {
 public:
   ::Envoy::AccessLog::InstanceSharedPtr
   createAccessLogInstance(const Protobuf::Message& config, ::Envoy::AccessLog::FilterPtr&& filter,
-                          Server::Configuration::FactoryContext& context) override;
+                          Server::Configuration::FactoryContext& context,
+                          std::vector<Formatter::CommandParserPtr> commands_parsers = {}) override;
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override;
 

--- a/source/extensions/access_loggers/stream/config.cc
+++ b/source/extensions/access_loggers/stream/config.cc
@@ -20,13 +20,14 @@ namespace Extensions {
 namespace AccessLoggers {
 namespace File {
 
-AccessLog::InstanceSharedPtr
-StdoutAccessLogFactory::createAccessLogInstance(const Protobuf::Message& config,
-                                                AccessLog::FilterPtr&& filter,
-                                                Server::Configuration::FactoryContext& context) {
+AccessLog::InstanceSharedPtr StdoutAccessLogFactory::createAccessLogInstance(
+    const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
+    Server::Configuration::FactoryContext& context,
+    std::vector<Formatter::CommandParserPtr> commands_parsers) {
   return AccessLoggers::createStreamAccessLogInstance<
       envoy::extensions::access_loggers::stream::v3::StdoutAccessLog,
-      Filesystem::DestinationType::Stdout>(config, std::move(filter), context);
+      Filesystem::DestinationType::Stdout>(config, std::move(filter), context,
+                                           std::move(commands_parsers));
 }
 
 ProtobufTypes::MessagePtr StdoutAccessLogFactory::createEmptyConfigProto() {
@@ -42,13 +43,14 @@ std::string StdoutAccessLogFactory::name() const { return "envoy.access_loggers.
 LEGACY_REGISTER_FACTORY(StdoutAccessLogFactory, AccessLog::AccessLogInstanceFactory,
                         "envoy.stdout_access_log");
 
-AccessLog::InstanceSharedPtr
-StderrAccessLogFactory::createAccessLogInstance(const Protobuf::Message& config,
-                                                AccessLog::FilterPtr&& filter,
-                                                Server::Configuration::FactoryContext& context) {
+AccessLog::InstanceSharedPtr StderrAccessLogFactory::createAccessLogInstance(
+    const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
+    Server::Configuration::FactoryContext& context,
+    std::vector<Formatter::CommandParserPtr> commands_parsers) {
   return createStreamAccessLogInstance<
       envoy::extensions::access_loggers::stream::v3::StderrAccessLog,
-      Filesystem::DestinationType::Stderr>(config, std::move(filter), context);
+      Filesystem::DestinationType::Stderr>(config, std::move(filter), context,
+                                           std::move(commands_parsers));
 }
 
 ProtobufTypes::MessagePtr StderrAccessLogFactory::createEmptyConfigProto() {

--- a/source/extensions/access_loggers/stream/config.cc
+++ b/source/extensions/access_loggers/stream/config.cc
@@ -23,11 +23,11 @@ namespace File {
 AccessLog::InstanceSharedPtr StdoutAccessLogFactory::createAccessLogInstance(
     const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
     Server::Configuration::FactoryContext& context,
-    std::vector<Formatter::CommandParserPtr> commands_parsers) {
+    std::vector<Formatter::CommandParserPtr>&& command_parsers) {
   return AccessLoggers::createStreamAccessLogInstance<
       envoy::extensions::access_loggers::stream::v3::StdoutAccessLog,
       Filesystem::DestinationType::Stdout>(config, std::move(filter), context,
-                                           std::move(commands_parsers));
+                                           std::move(command_parsers));
 }
 
 ProtobufTypes::MessagePtr StdoutAccessLogFactory::createEmptyConfigProto() {
@@ -46,11 +46,11 @@ LEGACY_REGISTER_FACTORY(StdoutAccessLogFactory, AccessLog::AccessLogInstanceFact
 AccessLog::InstanceSharedPtr StderrAccessLogFactory::createAccessLogInstance(
     const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
     Server::Configuration::FactoryContext& context,
-    std::vector<Formatter::CommandParserPtr> commands_parsers) {
+    std::vector<Formatter::CommandParserPtr>&& command_parsers) {
   return createStreamAccessLogInstance<
       envoy::extensions::access_loggers::stream::v3::StderrAccessLog,
       Filesystem::DestinationType::Stderr>(config, std::move(filter), context,
-                                           std::move(commands_parsers));
+                                           std::move(command_parsers));
 }
 
 ProtobufTypes::MessagePtr StderrAccessLogFactory::createEmptyConfigProto() {

--- a/source/extensions/access_loggers/stream/config.h
+++ b/source/extensions/access_loggers/stream/config.h
@@ -14,7 +14,8 @@ class StdoutAccessLogFactory : public AccessLog::AccessLogInstanceFactory {
 public:
   AccessLog::InstanceSharedPtr
   createAccessLogInstance(const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
-                          Server::Configuration::FactoryContext& context) override;
+                          Server::Configuration::FactoryContext& context,
+                          std::vector<Formatter::CommandParserPtr> commands_parsers = {}) override;
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override;
 
@@ -28,7 +29,8 @@ class StderrAccessLogFactory : public AccessLog::AccessLogInstanceFactory {
 public:
   AccessLog::InstanceSharedPtr
   createAccessLogInstance(const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
-                          Server::Configuration::FactoryContext& context) override;
+                          Server::Configuration::FactoryContext& context,
+                          std::vector<Formatter::CommandParserPtr> commands_parsers = {}) override;
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override;
 

--- a/source/extensions/access_loggers/stream/config.h
+++ b/source/extensions/access_loggers/stream/config.h
@@ -15,7 +15,7 @@ public:
   AccessLog::InstanceSharedPtr
   createAccessLogInstance(const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
                           Server::Configuration::FactoryContext& context,
-                          std::vector<Formatter::CommandParserPtr> commands_parsers = {}) override;
+                          std::vector<Formatter::CommandParserPtr>&& command_parsers = {}) override;
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override;
 
@@ -30,7 +30,7 @@ public:
   AccessLog::InstanceSharedPtr
   createAccessLogInstance(const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
                           Server::Configuration::FactoryContext& context,
-                          std::vector<Formatter::CommandParserPtr> commands_parsers = {}) override;
+                          std::vector<Formatter::CommandParserPtr>&& command_parsers = {}) override;
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override;
 

--- a/source/extensions/access_loggers/wasm/config.cc
+++ b/source/extensions/access_loggers/wasm/config.cc
@@ -14,10 +14,9 @@ namespace Extensions {
 namespace AccessLoggers {
 namespace Wasm {
 
-AccessLog::InstanceSharedPtr
-WasmAccessLogFactory::createAccessLogInstance(const Protobuf::Message& proto_config,
-                                              AccessLog::FilterPtr&& filter,
-                                              Server::Configuration::FactoryContext& context) {
+AccessLog::InstanceSharedPtr WasmAccessLogFactory::createAccessLogInstance(
+    const Protobuf::Message& proto_config, AccessLog::FilterPtr&& filter,
+    Server::Configuration::FactoryContext& context, std::vector<Formatter::CommandParserPtr>) {
   const auto& config = MessageUtil::downcastAndValidate<
       const envoy::extensions::access_loggers::wasm::v3::WasmAccessLog&>(
       proto_config, context.messageValidationVisitor());

--- a/source/extensions/access_loggers/wasm/config.cc
+++ b/source/extensions/access_loggers/wasm/config.cc
@@ -16,7 +16,7 @@ namespace Wasm {
 
 AccessLog::InstanceSharedPtr WasmAccessLogFactory::createAccessLogInstance(
     const Protobuf::Message& proto_config, AccessLog::FilterPtr&& filter,
-    Server::Configuration::FactoryContext& context, std::vector<Formatter::CommandParserPtr>) {
+    Server::Configuration::FactoryContext& context, std::vector<Formatter::CommandParserPtr>&&) {
   const auto& config = MessageUtil::downcastAndValidate<
       const envoy::extensions::access_loggers::wasm::v3::WasmAccessLog&>(
       proto_config, context.messageValidationVisitor());

--- a/source/extensions/access_loggers/wasm/config.h
+++ b/source/extensions/access_loggers/wasm/config.h
@@ -18,7 +18,7 @@ public:
   AccessLog::InstanceSharedPtr
   createAccessLogInstance(const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
                           Server::Configuration::FactoryContext& context,
-                          std::vector<Formatter::CommandParserPtr> = {}) override;
+                          std::vector<Formatter::CommandParserPtr>&& = {}) override;
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override;
 

--- a/source/extensions/access_loggers/wasm/config.h
+++ b/source/extensions/access_loggers/wasm/config.h
@@ -17,7 +17,8 @@ class WasmAccessLogFactory : public AccessLog::AccessLogInstanceFactory,
 public:
   AccessLog::InstanceSharedPtr
   createAccessLogInstance(const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
-                          Server::Configuration::FactoryContext& context) override;
+                          Server::Configuration::FactoryContext& context,
+                          std::vector<Formatter::CommandParserPtr> = {}) override;
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override;
 

--- a/source/extensions/filters/network/generic_proxy/file_access_log.h
+++ b/source/extensions/filters/network/generic_proxy/file_access_log.h
@@ -42,10 +42,10 @@ public:
   FileAccessLogFactoryBase()
       : name_(fmt::format("envoy.{}.access_loggers.file", Context::category())) {}
 
-  AccessLog::InstanceBaseSharedPtr<Context>
-  createAccessLogInstance(const Protobuf::Message& config,
-                          AccessLog::FilterBasePtr<Context>&& filter,
-                          Server::Configuration::FactoryContext& context) override {
+  AccessLog::InstanceBaseSharedPtr<Context> createAccessLogInstance(
+      const Protobuf::Message& config, AccessLog::FilterBasePtr<Context>&& filter,
+      Server::Configuration::FactoryContext& context,
+      std::vector<Formatter::CommandParserBasePtr<Context>> command_parsers = {}) override {
     const auto& typed_config = MessageUtil::downcastAndValidate<
         const envoy::extensions::access_loggers::file::v3::FileAccessLog&>(
         config, context.messageValidationVisitor());
@@ -60,29 +60,31 @@ public:
         envoy::config::core::v3::SubstitutionFormatString sff_config;
         sff_config.mutable_text_format_source()->set_inline_string(typed_config.format());
         formatter = THROW_OR_RETURN_VALUE(
-            Formatter::SubstitutionFormatStringUtils::fromProtoConfig<Context>(sff_config, context),
+            Formatter::SubstitutionFormatStringUtils::fromProtoConfig<Context>(
+                sff_config, context, std::move(command_parsers)),
             Formatter::FormatterBasePtr<Context>);
       }
       break;
     case envoy::extensions::access_loggers::file::v3::FileAccessLog::AccessLogFormatCase::
         kJsonFormat:
       formatter = Formatter::SubstitutionFormatStringUtils::createJsonFormatter<Context>(
-          typed_config.json_format(), false, false, false);
+          typed_config.json_format(), false, false, false, command_parsers);
       break;
     case envoy::extensions::access_loggers::file::v3::FileAccessLog::AccessLogFormatCase::
         kTypedJsonFormat: {
       envoy::config::core::v3::SubstitutionFormatString sff_config;
       *sff_config.mutable_json_format() = typed_config.typed_json_format();
-      formatter = THROW_OR_RETURN_VALUE(
-          Formatter::SubstitutionFormatStringUtils::fromProtoConfig<Context>(sff_config, context),
-          Formatter::FormatterBasePtr<Context>);
+      formatter =
+          THROW_OR_RETURN_VALUE(Formatter::SubstitutionFormatStringUtils::fromProtoConfig<Context>(
+                                    sff_config, context, std::move(command_parsers)),
+                                Formatter::FormatterBasePtr<Context>);
       break;
     }
     case envoy::extensions::access_loggers::file::v3::FileAccessLog::AccessLogFormatCase::
         kLogFormat:
       formatter =
           THROW_OR_RETURN_VALUE(Formatter::SubstitutionFormatStringUtils::fromProtoConfig<Context>(
-                                    typed_config.log_format(), context),
+                                    typed_config.log_format(), context, std::move(command_parsers)),
                                 Formatter::FormatterBasePtr<Context>);
       break;
     case envoy::extensions::access_loggers::file::v3::FileAccessLog::AccessLogFormatCase::

--- a/source/extensions/filters/network/generic_proxy/file_access_log.h
+++ b/source/extensions/filters/network/generic_proxy/file_access_log.h
@@ -45,7 +45,7 @@ public:
   AccessLog::InstanceBaseSharedPtr<Context> createAccessLogInstance(
       const Protobuf::Message& config, AccessLog::FilterBasePtr<Context>&& filter,
       Server::Configuration::FactoryContext& context,
-      std::vector<Formatter::CommandParserBasePtr<Context>> command_parsers = {}) override {
+      std::vector<Formatter::CommandParserBasePtr<Context>>&& command_parsers = {}) override {
     const auto& typed_config = MessageUtil::downcastAndValidate<
         const envoy::extensions::access_loggers::file::v3::FileAccessLog&>(
         config, context.messageValidationVisitor());

--- a/test/extensions/access_loggers/file/config_test.cc
+++ b/test/extensions/access_loggers/file/config_test.cc
@@ -21,6 +21,18 @@ namespace AccessLoggers {
 namespace File {
 namespace {
 
+class TestCustomCommandParser : public Formatter::CommandParser {
+public:
+  Formatter::FormatterProviderPtr parse(absl::string_view command, absl::string_view,
+                                        absl::optional<size_t>) const override {
+    if (command == "TEST_CUSTOM") {
+      return std::make_unique<Formatter::PlainStringFormatterBase<Formatter::HttpFormatterContext>>(
+          "custom");
+    }
+    return nullptr;
+  }
+};
+
 TEST(FileAccessLogNegativeTest, ValidateFail) {
   NiceMock<Server::Configuration::MockFactoryContext> context;
 
@@ -47,7 +59,8 @@ class FileAccessLogTest : public testing::Test {
 public:
   FileAccessLogTest() = default;
 
-  void runTest(const std::string& yaml, absl::string_view expected, bool is_json) {
+  void runTest(const std::string& yaml, absl::string_view expected, bool is_json,
+               std::vector<Formatter::CommandParserPtr> command_parsers = {}) {
     envoy::extensions::access_loggers::file::v3::FileAccessLog fal_config;
     TestUtility::loadFromYaml(yaml, fal_config);
 
@@ -59,7 +72,8 @@ public:
     EXPECT_CALL(context_.server_factory_context_.access_log_manager_, createAccessLog(file_info))
         .WillOnce(Return(file));
 
-    AccessLog::InstanceSharedPtr logger = AccessLog::AccessLogFactory::fromProto(config, context_);
+    AccessLog::InstanceSharedPtr logger =
+        AccessLog::AccessLogFactory::fromProto(config, context_, std::move(command_parsers));
 
     absl::Time abslStartTime =
         TestUtility::parseTime("Dec 18 01:50:34 2018 GMT", "%b %e %H:%M:%S %Y GMT");
@@ -174,6 +188,42 @@ TEST_F(FileAccessLogTest, LogFormatJson) {
     "code": 200
 })",
       true);
+}
+
+TEST_F(FileAccessLogTest, LogFormatJsonWithCustomCommands) {
+  const std::string format_yaml = R"(
+    path: "/foo"
+    log_format:
+      json_format:
+        custom: "%TEST_CUSTOM%"
+        text: "plain text"
+        path: "%REQ(:path)%"
+  )";
+
+  envoy::extensions::access_loggers::file::v3::FileAccessLog fal_config;
+  TestUtility::loadFromYaml(format_yaml, fal_config);
+
+  {
+    // No custom command parsers and the formatter should fail.
+    envoy::config::accesslog::v3::AccessLog config;
+    config.mutable_typed_config()->PackFrom(fal_config);
+    config.set_name("file");
+
+    EXPECT_THROW_WITH_MESSAGE(AccessLog::AccessLogFactory::fromProto(config, context_),
+                              EnvoyException, "Not supported field in StreamInfo: TEST_CUSTOM");
+  }
+
+  {
+    std::vector<Formatter::CommandParserPtr> command_parsers;
+    command_parsers.push_back(std::make_unique<TestCustomCommandParser>());
+
+    runTest(format_yaml, R"({
+      "custom": "custom",
+      "text": "plain text",
+      "path": "/bar/foo",
+  })",
+            true, std::move(command_parsers));
+  }
 }
 
 } // namespace

--- a/test/extensions/access_loggers/file/config_test.cc
+++ b/test/extensions/access_loggers/file/config_test.cc
@@ -60,7 +60,7 @@ public:
   FileAccessLogTest() = default;
 
   void runTest(const std::string& yaml, absl::string_view expected, bool is_json,
-               std::vector<Formatter::CommandParserPtr> command_parsers = {}) {
+               std::vector<Formatter::CommandParserPtr>&& command_parsers = {}) {
     envoy::extensions::access_loggers::file::v3::FileAccessLog fal_config;
     TestUtility::loadFromYaml(yaml, fal_config);
 
@@ -214,7 +214,7 @@ TEST_F(FileAccessLogTest, LogFormatJsonWithCustomCommands) {
   }
 
   {
-    std::vector<Formatter::CommandParserPtr> command_parsers;
+    std::vector<Formatter::CommandParserPtr>&& command_parsers;
     command_parsers.push_back(std::make_unique<TestCustomCommandParser>());
 
     runTest(format_yaml, R"({

--- a/test/extensions/access_loggers/file/config_test.cc
+++ b/test/extensions/access_loggers/file/config_test.cc
@@ -214,7 +214,7 @@ TEST_F(FileAccessLogTest, LogFormatJsonWithCustomCommands) {
   }
 
   {
-    std::vector<Formatter::CommandParserPtr>&& command_parsers;
+    std::vector<Formatter::CommandParserPtr> command_parsers;
     command_parsers.push_back(std::make_unique<TestCustomCommandParser>());
 
     runTest(format_yaml, R"({

--- a/test/integration/fake_access_log.h
+++ b/test/integration/fake_access_log.h
@@ -31,7 +31,7 @@ public:
   AccessLog::InstanceSharedPtr
   createAccessLogInstance(const Protobuf::Message&, AccessLog::FilterPtr&&,
                           Server::Configuration::FactoryContext&,
-                          std::vector<Formatter::CommandParserPtr> = {}) override {
+                          std::vector<Formatter::CommandParserPtr>&& = {}) override {
     std::lock_guard<std::mutex> guard(log_callback_lock_);
     auto access_log_instance = std::make_shared<FakeAccessLog>(log_cb_);
     access_log_instances_.push_back(access_log_instance);

--- a/test/integration/fake_access_log.h
+++ b/test/integration/fake_access_log.h
@@ -30,7 +30,8 @@ class FakeAccessLogFactory : public AccessLog::AccessLogInstanceFactory {
 public:
   AccessLog::InstanceSharedPtr
   createAccessLogInstance(const Protobuf::Message&, AccessLog::FilterPtr&&,
-                          Server::Configuration::FactoryContext&) override {
+                          Server::Configuration::FactoryContext&,
+                          std::vector<Formatter::CommandParserPtr> = {}) override {
     std::lock_guard<std::mutex> guard(log_callback_lock_);
     auto access_log_instance = std::make_shared<FakeAccessLog>(log_cb_);
     access_log_instances_.push_back(access_log_instance);

--- a/test/integration/typed_metadata_integration_test.cc
+++ b/test/integration/typed_metadata_integration_test.cc
@@ -54,7 +54,8 @@ class TestAccessLogFactory : public AccessLog::AccessLogInstanceFactory {
 public:
   AccessLog::InstanceSharedPtr
   createAccessLogInstance(const Protobuf::Message&, AccessLog::FilterPtr&&,
-                          Server::Configuration::FactoryContext& context) override {
+                          Server::Configuration::FactoryContext& context,
+                          std::vector<Formatter::CommandParserPtr> = {}) override {
     // Check that expected listener metadata is present
     EXPECT_EQ(1, context.listenerInfo().metadata().typed_filter_metadata().size());
     const auto iter = context.listenerInfo().metadata().typed_filter_metadata().find(

--- a/test/integration/typed_metadata_integration_test.cc
+++ b/test/integration/typed_metadata_integration_test.cc
@@ -55,7 +55,7 @@ public:
   AccessLog::InstanceSharedPtr
   createAccessLogInstance(const Protobuf::Message&, AccessLog::FilterPtr&&,
                           Server::Configuration::FactoryContext& context,
-                          std::vector<Formatter::CommandParserPtr> = {}) override {
+                          std::vector<Formatter::CommandParserPtr>&& = {}) override {
     // Check that expected listener metadata is present
     EXPECT_EQ(1, context.listenerInfo().metadata().typed_filter_metadata().size());
     const auto iter = context.listenerInfo().metadata().typed_filter_metadata().find(


### PR DESCRIPTION
Commit Message: access log: new access log interface to provide custom command parsers
Additional Description:

Part of https://github.com/envoyproxy/envoy/pull/38164. This extend the interface of access logger. Now the caller could provides some custom commands parsers to the logger directly.

By this way, the different loggers dependents (generic proxy, thrift proxy, mongo proxy, etc) could support different custom formatter command by them self and needn't to extend new formatter extension.

Risk Level: low.
Testing: unit.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.