### PR TITLE
Adjust comments to reflect new reality

### DIFF
--- a/test/integration/quic_http_integration_test.cc
+++ b/test/integration/quic_http_integration_test.cc
@@ -1342,7 +1342,7 @@ typed_config:
   static_cast<Extensions::TransportSockets::Tls::TimedCertValidatorFactory*>(cert_validator_factory)
       ->setExpectedPeerAddress(fmt::format(
           "{}:{}", Network::Test::getLoopbackAddressUrlString(version_), lookupPort("http")));
-  // Change the handshake timeout to be 500ms to fail the handshake while the cert validation is
+  // Change the handshake timeout to be 2000ms to fail the handshake while the cert validation is
   // pending.
   quic::QuicTime::Delta connect_timeout = quic::QuicTime::Delta::FromMilliseconds(2000);
   auto& persistent_info = static_cast<PersistentQuicInfoImpl&>(*quic_connection_persistent_info_);
@@ -1380,7 +1380,7 @@ typed_config:
   static_cast<Extensions::TransportSockets::Tls::TimedCertValidatorFactory*>(cert_validator_factory)
       ->setValidationTimeOutMs(std::chrono::milliseconds(2500));
   initialize();
-  // Change the handshake timeout to be 500ms to fail the handshake while the cert validation is
+  // Change the handshake timeout to be 2000ms to fail the handshake while the cert validation is
   // pending.
   quic::QuicTime::Delta connect_timeout = quic::QuicTime::Delta::FromMilliseconds(2000);
   auto& persistent_info = static_cast<PersistentQuicInfoImpl&>(*quic_connection_persistent_info_);


### PR DESCRIPTION
Risk Level: None; no functional change
Testing: CI; again, no functional change
