### PR TITLE
Make stderr and stdout not require presence of /dev/stderr and /dev/stdout

### DIFF
--- a/source/common/filesystem/posix/filesystem_impl.cc
+++ b/source/common/filesystem/posix/filesystem_impl.cc
@@ -46,7 +46,14 @@ Api::IoCallBoolResult FileImplPosix::open(FlagSet in) {
   if (isOpen()) {
     return resultSuccess(true);
   }
-
+  if (destinationType() == DestinationType::Stdout) {
+    fd_ = ::dup(fileno(stdout));
+    return fd_ != -1 ? resultSuccess(true) : resultFailure(false, errno);
+  }
+  if (destinationType() == DestinationType::Stderr) {
+    fd_ = ::dup(fileno(stderr));
+    return fd_ != -1 ? resultSuccess(true) : resultFailure(false, errno);
+  }
   const auto flags_and_mode = translateFlag(in);
   fd_ = ::open(path().c_str(), flags_and_mode.flags_, flags_and_mode.mode_);
   return fd_ != -1 ? resultSuccess(true) : resultFailure(false, errno);


### PR DESCRIPTION
Commit Message: Make stderr and stdout not require presence of /dev/stderr and /dev/stdout
Additional Description: Not every environment has `/dev/stderr` and `/dev/stdout` - it turns out bazel sandboxes sometimes do not, which, combined with using `StdoutAccessLog`, results in a surprising behavior where the startup info logs are logged, but none of the access logs are - but if the same thing is run *not* in that sandbox, everything is logged.
Risk Level: Very small. Accessing stderr and stdout via duplicating the standard file handles should be the same behavior as the other behavior when it's not broken.
Testing: Existing `filesystem_impl_test` already tests stderr and stdout files.
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
