### PR TITLE
Fix access logger not erroring on failure to open file

### DIFF
--- a/source/common/access_log/access_log_manager_impl.cc
+++ b/source/common/access_log/access_log_manager_impl.cc
@@ -41,7 +41,7 @@ AccessLogManagerImpl::createAccessLog(const Filesystem::FilePathAndType& file_in
   }
 
   Api::IoCallBoolResult open_result = file->open(default_flags);
-  if (!open_result.return_value_) {
+  if (!open_result.ok()) {
     return absl::InvalidArgumentError(fmt::format("unable to open file '{}': {}", file_name,
                                                   open_result.err_->getErrorDetails()));
   }

--- a/test/common/access_log/access_log_manager_impl_test.cc
+++ b/test/common/access_log/access_log_manager_impl_test.cc
@@ -68,7 +68,8 @@ protected:
 };
 
 TEST_F(AccessLogManagerImplTest, BadFile) {
-  EXPECT_CALL(*file_, open_(_)).WillOnce(Return(ByMove(Filesystem::resultFailure<bool>(false, 0))));
+  EXPECT_CALL(*file_, open_(_))
+      .WillOnce(Return(ByMove(Filesystem::resultFailure<bool>(false, -1))));
   EXPECT_FALSE(
       access_log_manager_
           .createAccessLog(Filesystem::FilePathAndType{Filesystem::DestinationType::File, "foo"})


### PR DESCRIPTION
Commit Message: Fix access logger not erroring on failure to open file
Additional Description: It checked result_value to see if there's an error, instead of checking the error state, and the value is -1 on error so is 'truthy'. Test coverage didn't catch it because it used a mock filesystem and returned an unrealistic response.
Risk Level: Might break people's configs where they have broken log configuration and didn't actually care.
Testing: Existing coverage, also fixed against regression.
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
