### PR TITLE
rate limit - add unit_multiplier

### DIFF
--- a/api/envoy/service/ratelimit/v3/rls.proto
+++ b/api/envoy/service/ratelimit/v3/rls.proto
@@ -112,6 +112,12 @@ message RateLimitResponse {
 
     // The unit of time.
     Unit unit = 2;
+
+    // The multiplier for the unit of time.
+    // This value multiplies the base unit of time to define a custom time period for the rate limit.
+    // For example, if the unit is set to MINUTE and the unit_multiplier is set to 5, the rate limit
+    // will be applied over a 5-minute period.
+    uint32 unit_multiplier = 4;
   }
 
   // Cacheable quota for responses.

--- a/source/extensions/filters/http/ratelimit/ratelimit_headers.cc
+++ b/source/extensions/filters/http/ratelimit/ratelimit_headers.cc
@@ -29,7 +29,7 @@ Http::ResponseHeaderMapPtr XRateLimitHeaderUtils::create(
         status.limit_remaining() < min_remaining_limit_status.value().limit_remaining()) {
       min_remaining_limit_status.emplace(status);
     }
-    const uint32_t window = convertRateLimitUnit(status.current_limit().unit());
+    const uint32_t window = convertRateLimitUnit(status.current_limit().unit(), status.current_limit().unit_multiplier());
     // Constructing the quota-policy per RFC
     // https://tools.ietf.org/id/draft-polli-ratelimit-headers-02.html#name-ratelimit-limit
     // Example of the result: `, 10;w=1;name="per-ip", 1000;w=3600`
@@ -65,22 +65,22 @@ Http::ResponseHeaderMapPtr XRateLimitHeaderUtils::create(
 }
 
 uint32_t XRateLimitHeaderUtils::convertRateLimitUnit(
-    const envoy::service::ratelimit::v3::RateLimitResponse::RateLimit::Unit unit) {
+    const envoy::service::ratelimit::v3::RateLimitResponse::RateLimit::Unit unit, const uint32_t unit_multiplier) {
   switch (unit) {
   case envoy::service::ratelimit::v3::RateLimitResponse::RateLimit::SECOND:
-    return 1;
+    return 1 * unit_multiplier;
   case envoy::service::ratelimit::v3::RateLimitResponse::RateLimit::MINUTE:
-    return 60;
+    return 60 * unit_multiplier;
   case envoy::service::ratelimit::v3::RateLimitResponse::RateLimit::HOUR:
-    return 60 * 60;
+    return 60 * 60 * unit_multiplier;
   case envoy::service::ratelimit::v3::RateLimitResponse::RateLimit::DAY:
-    return 24 * 60 * 60;
+    return 24 * 60 * 60 * unit_multiplier;
   case envoy::service::ratelimit::v3::RateLimitResponse::RateLimit::WEEK:
-    return 7 * 24 * 60 * 60;
+    return 7 * 24 * 60 * 60 * unit_multiplier;
   case envoy::service::ratelimit::v3::RateLimitResponse::RateLimit::MONTH:
-    return 30 * 24 * 60 * 60;
+    return 30 * 24 * 60 * 60 * unit_multiplier;
   case envoy::service::ratelimit::v3::RateLimitResponse::RateLimit::YEAR:
-    return 365 * 24 * 60 * 60;
+    return 365 * 24 * 60 * 60 * unit_multiplier;
   case envoy::service::ratelimit::v3::RateLimitResponse::RateLimit::UNKNOWN:
   default:
     return 0;

--- a/source/extensions/filters/http/ratelimit/ratelimit_headers.h
+++ b/source/extensions/filters/http/ratelimit/ratelimit_headers.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "source/extensions/filters/common/ratelimit/ratelimit.h"
+#include <cstdint>
 
 namespace Envoy {
 namespace Extensions {
@@ -13,7 +14,7 @@ public:
 
 private:
   static uint32_t
-  convertRateLimitUnit(envoy::service::ratelimit::v3::RateLimitResponse::RateLimit::Unit unit);
+  convertRateLimitUnit(envoy::service::ratelimit::v3::RateLimitResponse::RateLimit::Unit unit, uint32_t unit_multiplier);
 };
 
 } // namespace RateLimitFilter

--- a/test/extensions/filters/common/ratelimit/utils.h
+++ b/test/extensions/filters/common/ratelimit/utils.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <vector>
 
 #include "envoy/service/ratelimit/v3/rls.pb.h"
@@ -10,7 +11,8 @@ namespace RateLimit {
 inline envoy::service::ratelimit::v3::RateLimitResponse_DescriptorStatus
 buildDescriptorStatus(uint32_t requests_per_unit,
                       envoy::service::ratelimit::v3::RateLimitResponse_RateLimit_Unit unit,
-                      std::string name, uint32_t limit_remaining, uint32_t seconds_until_reset) {
+                      std::string name, uint32_t limit_remaining, uint32_t seconds_until_reset,
+                      uint32_t unit_multiplier = 1) {
   envoy::service::ratelimit::v3::RateLimitResponse_DescriptorStatus statusMsg;
   statusMsg.set_limit_remaining(limit_remaining);
   statusMsg.mutable_duration_until_reset()->set_seconds(seconds_until_reset);
@@ -19,6 +21,7 @@ buildDescriptorStatus(uint32_t requests_per_unit,
         statusMsg.mutable_current_limit();
     limitMsg->set_requests_per_unit(requests_per_unit);
     limitMsg->set_unit(unit);
+    limitMsg->set_unit_multiplier(unit_multiplier);
     limitMsg->set_name(name);
   }
   return statusMsg;

--- a/test/extensions/filters/http/ratelimit/ratelimit_test.cc
+++ b/test/extensions/filters/http/ratelimit/ratelimit_test.cc
@@ -438,7 +438,7 @@ TEST_F(HttpRateLimitFilterTest, OkResponseWithFilterHeaders) {
 
   auto descriptor_statuses = {
       Envoy::RateLimit::buildDescriptorStatus(
-          1, envoy::service::ratelimit::v3::RateLimitResponse::RateLimit::MINUTE, "first", 2, 3),
+          1, envoy::service::ratelimit::v3::RateLimitResponse::RateLimit::MINUTE, "first", 2, 3, 8),
       Envoy::RateLimit::buildDescriptorStatus(
           4, envoy::service::ratelimit::v3::RateLimitResponse::RateLimit::HOUR, "second", 5, 6)};
   auto descriptor_statuses_ptr =
@@ -447,7 +447,7 @@ TEST_F(HttpRateLimitFilterTest, OkResponseWithFilterHeaders) {
                                std::move(descriptor_statuses_ptr), nullptr, nullptr, "", nullptr);
 
   Http::TestResponseHeaderMapImpl expected_headers{
-      {"x-ratelimit-limit", "1, 1;w=60;name=\"first\", 4;w=3600;name=\"second\""},
+      {"x-ratelimit-limit", "1, 1;w=480;name=\"first\", 4;w=3600;name=\"second\""},
       {"x-ratelimit-remaining", "2"},
       {"x-ratelimit-reset", "3"}};
   Http::TestResponseHeaderMapImpl response_headers;


### PR DESCRIPTION
Commit Message: add a unit multiplier field to rls proto
Additional Description: so that we can configure rate limits for n minutes/days etc.
Risk Level: Low
Testing: todo
Docs Changes: todo
Release Notes: todo
Fixes: https://github.com/envoyproxy/envoy/issues/33277