### PR TITLE
listener: allow rebuild listener if the num of addresses are not changed but values are changed

### DIFF
--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -490,10 +490,10 @@ case $CI_TARGET in
         # This doesn't go into CI but is available for developer convenience.
         echo "bazel fastbuild build with tests..."
         echo "Building..."
-        bazel_envoy_binary_build fastbuild
+        # bazel_envoy_binary_build fastbuild
         echo "Testing ${TEST_TARGETS[*]}"
         bazel test "${BAZEL_BUILD_OPTIONS[@]}" \
-              -c fastbuild "${TEST_TARGETS[@]}"
+              -c fastbuild //test/common/listener_manager:listener_manager_impl_test
         ;;
 
     dev.contrib)

--- a/source/common/listener_manager/listener_impl.cc
+++ b/source/common/listener_manager/listener_impl.cc
@@ -1133,7 +1133,8 @@ bool ListenerImpl::socketOptionsEqual(const ListenerImpl& other) const {
 }
 
 bool ListenerImpl::hasCompatibleAddress(const ListenerImpl& other) const {
-  if ((socket_type_ != other.socket_type_) || (addresses_.size() != other.addresses().size())) {
+  if ((socket_type_ != other.socket_type_) || (addresses_.size() != other.addresses().size()) ||
+      !ListenerMessageUtil::socketOptionsEqual(config(), other.config())) {
     return false;
   }
 
@@ -1157,13 +1158,6 @@ bool ListenerImpl::hasCompatibleAddress(const ListenerImpl& other) const {
 }
 
 bool ListenerImpl::hasDuplicatedAddress(const ListenerImpl& other) const {
-  // Skip the duplicate address check if this is the case of a listener update with new socket
-  // options.
-  if ((name_ == other.name_) &&
-      !ListenerMessageUtil::socketOptionsEqual(config(), other.config())) {
-    return false;
-  }
-
   if (socket_type_ != other.socket_type_) {
     return false;
   }

--- a/source/common/listener_manager/listener_manager_impl.cc
+++ b/source/common/listener_manager/listener_manager_impl.cc
@@ -642,6 +642,11 @@ absl::StatusOr<bool> ListenerManagerImpl::addOrUpdateListenerInternal(
 bool ListenerManagerImpl::hasListenerWithDuplicatedAddress(const ListenerList& list,
                                                            const ListenerImpl& listener) {
   for (const auto& existing_listener : list) {
+    // Skip if the listener is the same. It's because that the listener
+    // with same name was proven to be incompatible.
+    if (existing_listener->name() == listener.name()) {
+      continue;
+    }
     if (existing_listener->hasDuplicatedAddress(listener)) {
       return true;
     }

--- a/source/common/listener_manager/listener_manager_impl.cc
+++ b/source/common/listener_manager/listener_manager_impl.cc
@@ -525,8 +525,12 @@ ListenerManagerImpl::setupSocketFactoryForListener(ListenerImpl& new_listener,
                     "when the reuse port isn't enabled",
                     new_listener.name()));
   }
-
-  if (!(existing_listener.hasCompatibleAddress(new_listener) && same_socket_options)) {
+  if (existing_listener.hasDuplicatedAddress(new_listener) && new_listener.reusePort() == false) {
+    return absl::InvalidArgumentError(fmt::format("Listener {}: doesn't support update addresses "
+                                                  "when the reuse port isn't enabled",
+                                                  new_listener.name()));
+  }
+  if (!existing_listener.hasCompatibleAddress(new_listener)) {
     RETURN_IF_NOT_OK(setNewOrDrainingSocketFactory(new_listener.name(), new_listener));
   } else {
     RETURN_IF_NOT_OK(new_listener.cloneSocketFactoryFrom(existing_listener));

--- a/test/common/listener_manager/listener_manager_impl_test.cc
+++ b/test/common/listener_manager/listener_manager_impl_test.cc
@@ -400,6 +400,46 @@ filter_chains:
   addOrUpdateListener(parseListenerFromV3Yaml(yaml2));
 }
 
+TEST_P(ListenerManagerImplWithRealFiltersTest,
+       AllowUpdateListenerWithSameNumberPortsButPortNumberChanged) {
+  const std::string yaml1 = R"EOF(
+name: foo
+address:
+  socket_address:
+    address: 127.0.0.1
+    port_value: 1000
+additional_addresses:
+- address:
+    socket_address:
+      address: 127.0.0.2
+      port_value: 1000
+filter_chains:
+- filters: []
+  name: foo
+  )EOF";
+
+  const std::string yaml2 = R"EOF(
+name: foo
+address:
+  socket_address:
+    address: 127.0.0.1
+    port_value: 1000
+additional_addresses:
+- address:
+    socket_address:
+      address: 127.0.0.2
+      port_value: 2000
+filter_chains:
+- filters: []
+  name: foo
+  )EOF";
+
+  EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0)).Times(2);
+  addOrUpdateListener(parseListenerFromV3Yaml(yaml1));
+  EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0)).Times(2);
+  addOrUpdateListener(parseListenerFromV3Yaml(yaml2));
+}
+
 TEST_P(ListenerManagerImplWithRealFiltersTest, SetListenerPerConnectionBufferLimit) {
   const std::string yaml = R"EOF(
 address:


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: listener: allow rebuild listener if the num of addresses are not changed but values are changed
Additional Description:
When updating a Listener with the same name via LDS, the update gets rejected if the number of contained ports remains unchanged.

For example, consider the following existing Listener:
```yaml
name: foo
address:
  socket_address:
    address: 127.0.0.1
    port_value: 1000
additional_addresses:
- address:
    socket_address:
      address: 127.0.0.2
      port_value: 1000
```

If the Listener is updated as follows:
```yaml
name: foo
address:
  socket_address:
    address: 127.0.0.1
    port_value: 2000
additional_addresses:
- address:
    socket_address:
      address: 127.0.0.2
      port_value: 1000
```
But it's rejected.

We expect it should work: As long as there is no other Listener with conflicting ports, the existing Listener with the same name should be drained and then reconfigured instead of being outright rejected.

This fix involves a small-scale refactoring to consolidate the role of `hasCompatibleAddress()` to detect whether the update with the same name listener includes SocketOption change, and the role of `isDuplicatedAddress` to detect whether the provided listeners include address change or not.

Risk Level: Low
Testing: Unit
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
