### PR TITLE
mobile: Improvements to handling network change events

### DIFF
--- a/mobile/library/cc/engine.cc
+++ b/mobile/library/cc/engine.cc
@@ -26,6 +26,10 @@ std::string Engine::dumpStats() { return engine_->dumpStats(); }
 
 envoy_status_t Engine::terminate() { return engine_->terminate(); }
 
+void Engine::onDefaultNetworkChangeEvent(int network) {
+  engine_->onDefaultNetworkChangeEvent(network);
+}
+
 void Engine::onDefaultNetworkChanged(int network) { engine_->onDefaultNetworkChanged(network); }
 
 void Engine::onDefaultNetworkUnavailable() { engine_->onDefaultNetworkUnavailable(); }

--- a/mobile/library/cc/engine.h
+++ b/mobile/library/cc/engine.h
@@ -20,6 +20,8 @@ public:
 
   std::string dumpStats();
   StreamClientSharedPtr streamClient();
+  void onDefaultNetworkChangeEvent(int network);
+  // TODO(abeyad): Remove once migrated to onDefaultNetworkChangeEvent().
   void onDefaultNetworkChanged(int network);
   void onDefaultNetworkUnavailable();
   void onDefaultNetworkAvailable();

--- a/mobile/library/common/internal_engine.cc
+++ b/mobile/library/common/internal_engine.cc
@@ -66,11 +66,9 @@ bool areIpAddressesDifferent(const Network::Address::InstanceConstSharedPtr& add
   if (addr->ip()->version() == Network::Address::IpVersion::v6) {
     // Both are IPv6 but the addresses are different.
     return addr->ip()->ipv6()->address() != prev_addr->ip()->ipv6()->address();
-  } else {
-    // Both are IPv4 but the addresses are different.
-    return addr->ip()->ipv4()->address() != prev_addr->ip()->ipv4()->address();
   }
-  return false;
+  // Both are IPv4 but the addresses are different.
+  return addr->ip()->ipv4()->address() != prev_addr->ip()->ipv4()->address();
 }
 } // namespace
 
@@ -542,11 +540,10 @@ Network::Address::InstanceConstSharedPtr InternalEngine::probeAndGetLocalAddr(in
     }
     ENVOY_LOG(trace, "Found {} connectivity.", domain == AF_INET6 ? "IPv6" : "IPv4");
     return *address_or_error;
-  } else {
-    ENVOY_LOG(trace, "No {} connectivity found with errno: {}.",
-              domain == AF_INET6 ? "IPv6" : "IPv4", connect_result.errno_);
-    return nullptr;
   }
+  ENVOY_LOG(trace, "No {} connectivity found with errno: {}.", domain == AF_INET6 ? "IPv6" : "IPv4",
+            connect_result.errno_);
+  return nullptr;
 }
 
 } // namespace Envoy

--- a/mobile/library/common/internal_engine.cc
+++ b/mobile/library/common/internal_engine.cc
@@ -17,13 +17,60 @@
 namespace Envoy {
 namespace {
 constexpr absl::Duration ENGINE_RUNNING_TIMEOUT = absl::Seconds(30);
-// Google DNS address used for IPv6 probes.
-constexpr absl::string_view IPV6_PROBE_ADDRESS = "2001:4860:4860::8888";
-constexpr uint32_t IPV6_PROBE_PORT = 53;
 
 // There is only one shared MobileProcessWide instance for all Envoy Mobile engines.
 MobileProcessWide& initOnceMobileProcessWide(const OptionsImplBase& options) {
   MUTABLE_CONSTRUCT_ON_FIRST_USE(MobileProcessWide, options);
+}
+
+Network::Address::InstanceConstSharedPtr ipv6ProbeAddr() {
+  // Use Google DNS IPv6 address for IPv6 probes.
+  CONSTRUCT_ON_FIRST_USE(Network::Address::InstanceConstSharedPtr,
+                         new Network::Address::Ipv6Instance("2001:4860:4860::8888", 53));
+}
+
+Network::Address::InstanceConstSharedPtr ipv4ProbeAddr() {
+  // Use Google DNS IPv4 address for IPv4 probes.
+  CONSTRUCT_ON_FIRST_USE(Network::Address::InstanceConstSharedPtr,
+                         new Network::Address::Ipv4Instance("8.8.8.8", 53));
+}
+
+bool hasNetworkChanged(int network_type, int prev_network_type) {
+  // The network types are both cellular and don't differ in the Network::Generic (e.g. VPN) flag,
+  // so don't consider it a network change. If the previous and current network types differ, it's a
+  // difference in cellular network subtypes (e.g. 4G to 5G).
+  if ((network_type & static_cast<int>(NetworkType::WWAN)) &&
+      (prev_network_type & static_cast<int>(NetworkType::WWAN)) &&
+      (network_type & static_cast<int>(NetworkType::Generic)) ==
+          (prev_network_type & static_cast<int>(NetworkType::Generic))) {
+    return false;
+  }
+  // Otherwise, if the current network type is different from the previous network type, it's a
+  // network change.
+  return network_type != prev_network_type;
+}
+
+bool areIpAddressesDifferent(const Network::Address::InstanceConstSharedPtr& addr,
+                             const Network::Address::InstanceConstSharedPtr& prev_addr) {
+  if (addr == nullptr && prev_addr == nullptr) {
+    return false;
+  }
+  if (addr == nullptr || prev_addr == nullptr) {
+    // Change in presence of an IP address is treated as a difference.
+    return true;
+  }
+  if (addr->ip()->version() != prev_addr->ip()->version()) {
+    // IP address versions are different.
+    return true;
+  }
+  if (addr->ip()->version() == Network::Address::IpVersion::v6) {
+    // Both are IPv6 but the addresses are different.
+    return addr->ip()->ipv6()->address() != prev_addr->ip()->ipv6()->address();
+  } else {
+    // Both are IPv4 but the addresses are different.
+    return addr->ip()->ipv4()->address() != prev_addr->ip()->ipv4()->address();
+  }
+  return false;
 }
 } // namespace
 
@@ -173,7 +220,7 @@ envoy_status_t InternalEngine::main(std::shared_ptr<OptionsImplBase> options) {
           connectivity_manager_ = Network::ConnectivityManagerFactory{generic_context}.get();
           if (Runtime::runtimeFeatureEnabled(
                   "envoy.reloadable_features.dns_cache_set_ip_version_to_remove")) {
-            if (!hasIpV6Connectivity()) {
+            if (probeAndGetLocalAddr(AF_INET6) != nullptr) {
               connectivity_manager_->dnsCache()->setIpVersionToRemove(
                   {Network::Address::IpVersion::v6});
             }
@@ -288,54 +335,83 @@ envoy_status_t InternalEngine::resetConnectivityState() {
 
 void InternalEngine::onDefaultNetworkAvailable() {
   ENVOY_LOG_MISC(trace, "Calling the default network available callback");
+  // TODO(abeyad): Add a call to re-add DNS records for refreshing based on their TTL.
 }
 
+void InternalEngine::onDefaultNetworkChangeEvent(const int network_type) {
+  ENVOY_LOG_MISC(trace, "Calling the default network change event callback");
+
+  dispatcher_->post([&, network_type]() -> void {
+    Network::Address::InstanceConstSharedPtr local_addr = probeAndGetLocalAddr(AF_INET6);
+    const bool has_ipv6_connectivity = local_addr != nullptr;
+    if (local_addr == nullptr) {
+      // If there's no IPv6 connectivity, get the IPv4 local address.
+      local_addr = probeAndGetLocalAddr(AF_INET);
+    }
+
+    if (hasNetworkChanged(network_type, prev_network_type_) ||
+        areIpAddressesDifferent(local_addr, prev_local_addr_)) {
+      // If the IP addresses are not the same between network change events, or the network type
+      // changed and it's not just a cellular subtype change (e.g. 4g to 5g), then assume there was
+      // an actual network change.
+      handleNetworkChange(network_type, has_ipv6_connectivity);
+    }
+
+    prev_network_type_ = network_type;
+    prev_local_addr_ = local_addr;
+
+    ENVOY_LOG_MISC(trace, "Finished the network changed callback");
+  });
+}
+
+// TODO(abeyad): Delete this function after onDefaultNetworkChangeEvent() is tested and becomes the
+// default.
 void InternalEngine::onDefaultNetworkChanged(int network) {
   ENVOY_LOG_MISC(trace, "Calling the default network changed callback");
   dispatcher_->post([&, network]() -> void {
-    envoy_netconf_t configuration = Network::ConnectivityManagerImpl::setPreferredNetwork(network);
-    if (Runtime::runtimeFeatureEnabled(
-            "envoy.reloadable_features.dns_cache_set_ip_version_to_remove")) {
-      // The IP version to remove flag must be set first before refreshing the DNS cache so that
-      // the DNS cache will be updated with whether or not the IPv6 addresses will need to be
-      // removed.
-      if (!hasIpV6Connectivity()) {
-        connectivity_manager_->dnsCache()->setIpVersionToRemove({Network::Address::IpVersion::v6});
-      } else {
-        connectivity_manager_->dnsCache()->setIpVersionToRemove(absl::nullopt);
-      }
-    }
-    if (Runtime::runtimeFeatureEnabled("envoy.reloadable_features.drain_pools_on_network_change")) {
-      ENVOY_LOG_EVENT(debug, "netconf_immediate_drain", "DrainAllHosts");
-      connectivity_manager_->clusterManager().drainConnections(
-          [](const Upstream::Host&) { return true; });
-    }
-    if (Runtime::runtimeFeatureEnabled(
-            "envoy.reloadable_features.reset_brokenness_on_nework_change")) {
-      Http::HttpServerPropertiesCacheManager& cache_manager =
-          server_->httpServerPropertiesCacheManager();
-
-      Http::HttpServerPropertiesCacheManager::CacheFn clear_brokenness =
-          [](Http::HttpServerPropertiesCache& cache) { cache.resetBrokenness(); };
-      cache_manager.forEachThreadLocalCache(clear_brokenness);
-    }
-    if (Runtime::runtimeFeatureEnabled("envoy.reloadable_features.quic_no_tcp_delay")) {
-      Http::HttpServerPropertiesCacheManager& cache_manager =
-          server_->httpServerPropertiesCacheManager();
-
-      Http::HttpServerPropertiesCacheManager::CacheFn reset_status =
-          [](Http::HttpServerPropertiesCache& cache) { cache.resetStatus(); };
-      cache_manager.forEachThreadLocalCache(reset_status);
-    }
-    if (!disable_dns_refresh_on_network_change_) {
-      connectivity_manager_->refreshDns(configuration, true);
-    }
+    handleNetworkChange(network, probeAndGetLocalAddr(AF_INET6) != nullptr);
   });
 }
 
 void InternalEngine::onDefaultNetworkUnavailable() {
   ENVOY_LOG_MISC(trace, "Calling the default network unavailable callback");
   dispatcher_->post([&]() -> void { connectivity_manager_->dnsCache()->stop(); });
+}
+
+void InternalEngine::handleNetworkChange(const int network_type, const bool has_ipv6_connectivity) {
+  envoy_netconf_t configuration =
+      Network::ConnectivityManagerImpl::setPreferredNetwork(network_type);
+  if (Runtime::runtimeFeatureEnabled(
+          "envoy.reloadable_features.dns_cache_set_ip_version_to_remove")) {
+    // The IP version to remove flag must be set first before refreshing the DNS cache so that
+    // the DNS cache will be updated with whether or not the IPv6 addresses will need to be
+    // removed.
+    if (has_ipv6_connectivity) {
+      connectivity_manager_->dnsCache()->setIpVersionToRemove({Network::Address::IpVersion::v6});
+    } else {
+      connectivity_manager_->dnsCache()->setIpVersionToRemove(absl::nullopt);
+    }
+  }
+  if (Runtime::runtimeFeatureEnabled(
+          "envoy.reloadable_features.reset_brokenness_on_nework_change")) {
+    Http::HttpServerPropertiesCacheManager& cache_manager =
+        server_->httpServerPropertiesCacheManager();
+
+    Http::HttpServerPropertiesCacheManager::CacheFn clear_brokenness =
+        [](Http::HttpServerPropertiesCache& cache) { cache.resetBrokenness(); };
+    cache_manager.forEachThreadLocalCache(clear_brokenness);
+  }
+  if (Runtime::runtimeFeatureEnabled("envoy.reloadable_features.quic_no_tcp_delay")) {
+    Http::HttpServerPropertiesCacheManager& cache_manager =
+        server_->httpServerPropertiesCacheManager();
+
+    Http::HttpServerPropertiesCacheManager::CacheFn reset_status =
+        [](Http::HttpServerPropertiesCache& cache) { cache.resetStatus(); };
+    cache_manager.forEachThreadLocalCache(reset_status);
+  }
+  if (!disable_dns_refresh_on_network_change_) {
+    connectivity_manager_->refreshDns(configuration, true);
+  }
 }
 
 envoy_status_t InternalEngine::recordCounterInc(absl::string_view elements, envoy_stats_tags tags,
@@ -441,32 +517,36 @@ void InternalEngine::logInterfaces(absl::string_view event,
   ENVOY_LOG_EVENT(debug, event, "{}", all_names_printer(interfaces));
 }
 
-bool InternalEngine::hasIpV6Connectivity() {
-  // This probing IPv6 logic is borrowed from Chromium.
+Network::Address::InstanceConstSharedPtr InternalEngine::probeAndGetLocalAddr(int domain) {
+  // This probing logic is borrowed from Chromium.
   // -
   // https://source.chromium.org/chromium/chromium/src/+/main:net/dns/host_resolver_manager.cc;l=154-157;drc=7b232da0f22e8cdf555d43c52b6491baeb87f729
   // -
   // https://source.chromium.org/chromium/chromium/src/+/main:net/dns/host_resolver_manager.cc;l=1467-1488;drc=7b232da0f22e8cdf555d43c52b6491baeb87f729
-  ENVOY_LOG(trace, "Checking for IPv6 connectivity.");
-  int domain = AF_INET6;
+  ENVOY_LOG(trace, "Checking for {} connectivity.", domain == AF_INET6 ? "IPv6" : "IPv4");
   const Api::SysCallSocketResult socket_result =
       Api::OsSysCallsSingleton::get().socket(domain, SOCK_DGRAM, /* protocol= */ 0);
   if (!SOCKET_VALID(socket_result.return_value_)) {
     ENVOY_LOG(trace, "Unable to create a datagram socket with errno: {}.", socket_result.errno_);
-    return false;
+    return nullptr;
   }
-  Network::IoSocketHandleImpl socket_handle(socket_result.return_value_, /* socket_v6only= */ true,
-                                            {domain});
+  Network::IoSocketHandleImpl socket_handle(socket_result.return_value_,
+                                            /* socket_v6only= */ domain == AF_INET6, {domain});
   Api::SysCallIntResult connect_result =
-      socket_handle.connect(std::make_shared<Network::Address::Ipv6Instance>(
-          std::string(IPV6_PROBE_ADDRESS), IPV6_PROBE_PORT));
-  bool has_ipv6_connectivity = connect_result.return_value_ == 0;
-  if (has_ipv6_connectivity) {
-    ENVOY_LOG(trace, "Found IPv6 connectivity.");
+      socket_handle.connect(domain == AF_INET6 ? ipv6ProbeAddr() : ipv4ProbeAddr());
+  if (connect_result.return_value_ == 0) {
+    auto address_or_error = socket_handle.localAddress();
+    if (!address_or_error.status().ok()) {
+      ENVOY_LOG(trace, "Local address error: {}", address_or_error.status().message());
+      return nullptr;
+    }
+    ENVOY_LOG(trace, "Found {} connectivity.", domain == AF_INET6 ? "IPv6" : "IPv4");
+    return *address_or_error;
   } else {
-    ENVOY_LOG(trace, "No IPv6 connectivity found with errno: {}.", connect_result.errno_);
+    ENVOY_LOG(trace, "No {} connectivity found with errno: {}.",
+              domain == AF_INET6 ? "IPv6" : "IPv4", connect_result.errno_);
+    return nullptr;
   }
-  return has_ipv6_connectivity;
 }
 
 } // namespace Envoy

--- a/mobile/library/common/internal_engine.h
+++ b/mobile/library/common/internal_engine.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "envoy/network/address.h"
 #include "envoy/server/lifecycle_notifier.h"
 
 #include "source/common/common/logger.h"
@@ -120,16 +121,21 @@ public:
   void onDefaultNetworkAvailable();
 
   /**
-   * This function does the following when the default network was changed.
+   * TODO(abeyad): Remove once migrated to using onDefaultNetworkChangeEvent().
+   * The callback that gets executed when the mobile device network monitor receives a network
+   * change event.
    *
-   * - Sets the preferred network.
-   * - Check for IPv6 connectivity. If there is no IPv6 no connectivity, it will call
-   *   `setIpVersionToRemove` in the DNS cache implementation to remove the IPv6 addresses from
-   *   the DNS response in the subsequent DNS resolutions.
-   * - Force refresh the hosts in the DNS cache (will take `setIpVersionToRemove` into account).
-   * - Optionally (if configured) clear HTTP/3 broken status.
+   * @param network the network type that is now the default network.
    */
   void onDefaultNetworkChanged(int network);
+
+  /**
+   * The callback that gets executed when the mobile device network monitor receives a network
+   * change event.
+   *
+   * @param network_type the network type that is now the default network.
+   */
+  void onDefaultNetworkChangeEvent(int network_type);
 
   /**
    * This functions does the following when the default network is unavailable.
@@ -175,8 +181,18 @@ private:
   envoy_status_t main(std::shared_ptr<OptionsImplBase> options);
   static void logInterfaces(absl::string_view event,
                             std::vector<Network::InterfacePair>& interfaces);
-  /** Returns true if there is IPv6 connectivity. */
-  static bool hasIpV6Connectivity();
+
+  // Called when it's been determined that the default network has changed. Executes the following
+  // actions:
+  //  - Sets the preferred network.
+  //  - If no IPv6 connectivity, tells the DNS cache to remove IPv6 addresses from host entries.
+  //  - Clear HTTP/3 broken status.
+  //  - Force refresh DNS cache.
+  void handleNetworkChange(int network_type, bool has_ipv6_connectivity);
+
+  // Probe for connectivity for the provided `domain` and get a pointer to the local address. If
+  // there is no connectivity for the `domain`, a null pointer will be returned.
+  static Network::Address::InstanceConstSharedPtr probeAndGetLocalAddr(int domain);
 
   Thread::PosixThreadFactoryPtr thread_factory_;
   Event::Dispatcher* event_dispatcher_{};
@@ -204,6 +220,8 @@ private:
   bool terminated_{false};
   absl::Notification engine_running_;
   bool disable_dns_refresh_on_network_change_;
+  int prev_network_type_{0};
+  Network::Address::InstanceConstSharedPtr prev_local_addr_{nullptr};
 };
 
 } // namespace Envoy

--- a/mobile/test/common/integration/client_integration_test.cc
+++ b/mobile/test/common/integration/client_integration_test.cc
@@ -16,13 +16,13 @@
 #include "test/test_common/registry.h"
 #include "test/test_common/test_random_generator.h"
 
+#include "absl/synchronization/notification.h"
 #include "extension_registry.h"
 #include "library/common/bridge/utility.h"
 #include "library/common/http/header_utility.h"
 #include "library/common/internal_engine.h"
 #include "library/common/network/proxy_settings.h"
 #include "library/common/types/c_types.h"
-#include "absl/synchronization/notification.h"
 
 using testing::_;
 using testing::AnyNumber;

--- a/mobile/test/common/integration/client_integration_test.cc
+++ b/mobile/test/common/integration/client_integration_test.cc
@@ -370,6 +370,7 @@ TEST_P(ClientIntegrationTest, HandleNetworkChangeEvents) {
   internalEngine()->onDefaultNetworkChangeEvent(network);
   handled_network_changes[current_change_event].WaitForNotification();
   EXPECT_TRUE(found_force_dns_refresh);
+  EXPECT_EQ(4, current_change_event);
 }
 
 TEST_P(ClientIntegrationTest, LargeResponse) {

--- a/mobile/test/common/integration/client_integration_test.cc
+++ b/mobile/test/common/integration/client_integration_test.cc
@@ -22,6 +22,7 @@
 #include "library/common/internal_engine.h"
 #include "library/common/network/proxy_settings.h"
 #include "library/common/types/c_types.h"
+#include "absl/synchronization/notification.h"
 
 using testing::_;
 using testing::AnyNumber;
@@ -78,7 +79,7 @@ public:
   }
 
   void initialize() override {
-    builder_.setLogLevel(Logger::Logger::debug);
+    builder_.setLogLevel(Logger::Logger::trace);
     builder_.addRuntimeGuard("dns_cache_set_ip_version_to_remove", true);
     builder_.addRuntimeGuard("quic_no_tcp_delay", true);
 
@@ -267,7 +268,6 @@ TEST_P(ClientIntegrationTest, BasicWithCares) {
 // resolver.
 #if not defined(__APPLE__)
 TEST_P(ClientIntegrationTest, DisableDnsRefreshOnFailure) {
-  builder_.setLogLevel(Logger::Logger::debug);
   std::atomic<bool> found_cache_miss{false};
   auto logger = std::make_unique<EnvoyLogger>();
   logger->on_log_ = [&](Logger::Logger::Levels, const std::string& msg) {
@@ -297,7 +297,6 @@ TEST_P(ClientIntegrationTest, DisableDnsRefreshOnFailure) {
 #endif
 
 TEST_P(ClientIntegrationTest, DisableDnsRefreshOnNetworkChange) {
-  builder_.setLogLevel(Logger::Logger::debug);
   std::atomic<bool> found_force_dns_refresh{false};
   auto logger = std::make_unique<EnvoyLogger>();
   logger->on_log_ = [&](Logger::Logger::Levels, const std::string& msg) {
@@ -312,6 +311,65 @@ TEST_P(ClientIntegrationTest, DisableDnsRefreshOnNetworkChange) {
   internalEngine()->onDefaultNetworkChanged(1);
 
   EXPECT_FALSE(found_force_dns_refresh);
+}
+
+TEST_P(ClientIntegrationTest, HandleNetworkChangeEvents) {
+  std::atomic<bool> found_force_dns_refresh{false};
+  std::vector<absl::Notification> handled_network_changes(5);
+  std::atomic<int> current_change_event{0};
+  auto logger = std::make_unique<EnvoyLogger>();
+  logger->on_log_ = [&](Logger::Logger::Levels, const std::string& msg) {
+    if (msg.find("beginning DNS cache force refresh") != std::string::npos) {
+      found_force_dns_refresh = true;
+    } else if (msg.find("Finished the network changed callback") != std::string::npos) {
+      handled_network_changes[current_change_event].Notify();
+    }
+  };
+  builder_.setLogger(std::move(logger));
+  builder_.setDisableDnsRefreshOnNetworkChange(false);
+  initialize();
+
+  // Set the network type to WIFI. This should trigger a network change.
+  int network = static_cast<int>(NetworkType::WLAN);
+  internalEngine()->onDefaultNetworkChangeEvent(network);
+  handled_network_changes[current_change_event].WaitForNotification();
+  EXPECT_TRUE(found_force_dns_refresh);
+  found_force_dns_refresh = false;
+  ++current_change_event;
+
+  // Set the network type to Cellular 4G. This should trigger a network change.
+  network = static_cast<int>(NetworkType::WWAN);
+  network |= static_cast<int>(NetworkType::WWAN_4G);
+  internalEngine()->onDefaultNetworkChangeEvent(network);
+  handled_network_changes[current_change_event].WaitForNotification();
+  EXPECT_TRUE(found_force_dns_refresh);
+  found_force_dns_refresh = false;
+  ++current_change_event;
+
+  // Set the network type to Cellular 5G. This should not trigger a network change, because the
+  // previous network type was still Cellular.
+  network = static_cast<int>(NetworkType::WWAN);
+  network |= static_cast<int>(NetworkType::WWAN_5G);
+  internalEngine()->onDefaultNetworkChangeEvent(network);
+  handled_network_changes[current_change_event].WaitForNotification();
+  EXPECT_FALSE(found_force_dns_refresh);
+  found_force_dns_refresh = false;
+  ++current_change_event;
+
+  // Set the network type back to WIFI. This should trigger a network change.
+  network = static_cast<int>(NetworkType::WLAN);
+  internalEngine()->onDefaultNetworkChangeEvent(network);
+  handled_network_changes[current_change_event].WaitForNotification();
+  EXPECT_TRUE(found_force_dns_refresh);
+  found_force_dns_refresh = false;
+  ++current_change_event;
+
+  // Set the network type to WIFI, but with a VPN. This should trigger a network change.
+  network = static_cast<int>(NetworkType::WLAN);
+  network |= static_cast<int>(NetworkType::Generic);
+  internalEngine()->onDefaultNetworkChangeEvent(network);
+  handled_network_changes[current_change_event].WaitForNotification();
+  EXPECT_TRUE(found_force_dns_refresh);
 }
 
 TEST_P(ClientIntegrationTest, LargeResponse) {
@@ -1290,7 +1348,6 @@ TEST_P(ClientIntegrationTest, ResetWithBidiTraffic) {
 TEST_P(ClientIntegrationTest, ResetWithBidiTrafficExplicitData) {
   explicit_flow_control_ = true;
   autonomous_upstream_ = false;
-  builder_.setLogLevel(Logger::Logger::debug);
   initialize();
   ConditionalInitializer headers_callback;
 
@@ -1389,6 +1446,21 @@ TEST_P(ClientIntegrationTest, OnNetworkChanged) {
   builder_.addRuntimeGuard("dns_cache_set_ip_version_to_remove", true);
   initialize();
   internalEngine()->onDefaultNetworkChanged(1);
+  basicTest();
+  if (upstreamProtocol() == Http::CodecType::HTTP1) {
+    ASSERT_EQ(cc_.on_complete_received_byte_count_, 67);
+  }
+}
+
+// This test is simply to test the IPv6 connectivity check and DNS refresh and make sure the code
+// doesn't crash. It doesn't really test the actual network change event.
+TEST_P(ClientIntegrationTest, OnNetworkChangeEvent) {
+  builder_.addRuntimeGuard("dns_cache_set_ip_version_to_remove", true);
+  initialize();
+  int network = 0;
+  network |= static_cast<int>(NetworkType::WWAN);
+  network |= static_cast<int>(NetworkType::WWAN_5G);
+  internalEngine()->onDefaultNetworkChangeEvent(network);
   basicTest();
   if (upstreamProtocol() == Http::CodecType::HTTP1) {
     ASSERT_EQ(cc_.on_complete_received_byte_count_, 67);

--- a/mobile/test/java/org/chromium/net/CronetHttp3Test.java
+++ b/mobile/test/java/org/chromium/net/CronetHttp3Test.java
@@ -348,7 +348,7 @@ public class CronetHttp3Test {
 
     // There should still only be one HTTP/3 connection.
     postStats = cronvoyEngine.getEnvoyEngine().dumpStats();
-    assertTrue(postStats.contains("cluster.base.upstream_cx_http3_total: 2"));
+    assertTrue(postStats.contains("cluster.base.upstream_cx_http3_total: 1"));
   }
 
   @Test


### PR DESCRIPTION
Envoy Mobile's network change event handling relied on the underlying operating system's network change monitor APIs to receive events of a network change. On platforms like iOS, the network change monitor callbacks get invoked on many sorts of network events, even those that don't result in an actual network change. In addition, the network monitor APIs don't always give fine granularity change events. For example, on iOS, if the device switches from one Wifi network to another, a network change event will fire but both times the type will be Wifi, so there's no way to distinguish that we actually changed networks. When Envoy Mobile detects a network change, it does some potentially costly operations, such as draining existing network connections, refreshing the DNS cache, resetting the QUIC brokenness cache, etc, which should be avoided unless a real network change occurred.

This change solves the problem by determining a network change through two characteristics:
 1. If the network change event resulted in a local network interface when connecting a UDP socket, then Envoy Mobile will regard the network event as an actual network change. In other words, if calling connect() on a UDP socket results in a different local IP address, it's considered a different network.
 2. If the network type is different (e.g. Wifi to Cellular) and within Cellular, it's not just a change from one Cellular subtype to another (e.g. 4G to 5G). The reason is that Cellular subtype changes do not result in different network properties, so they should be treated as being on the same network.

Using the above two criteria, Envoy Mobile can take the more costly changes like draining network connections only when a true network change occurred on the device.