### PR TITLE
docs: Fix RST formatting for AWS credentials documentation

### DIFF
--- a/docs/root/configuration/http/http_filters/_include/aws_credentials.rst
+++ b/docs/root/configuration/http/http_filters/_include/aws_credentials.rst
@@ -36,7 +36,7 @@ secret access key (the session token is optional).
 
       When ``signing_algorithm: AWS_SIGV4A`` is set, the STS cluster host is determined as follows:
 
-      * If your ``region``` (set via profile, environment, or inline) is configured as a SigV4A region set **AND**
+      * If your ``region`` (set via profile, environment, or inline) is configured as a SigV4A region set **AND**
         contains a wildcard in the first region:
 
         - Standard endpoint: ``sts.amazonaws.com``


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: docs: Fix RST formatting for AWS credentials documentation
Additional Description: Fix backtick formatting in AWS credentials documentation that was causing incorrect rendering in markdown preview. This improves readability of the SigV4A region configuration section. See https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/aws_request_signing_filter.html for the current format.
Risk Level: 
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
