### PR TITLE
Shard test/common/router/corpus_from_config_impl.sh

### DIFF
--- a/test/common/router/corpus_from_config_impl.sh
+++ b/test/common/router/corpus_from_config_impl.sh
@@ -3,11 +3,14 @@
 # Helper shell script for :corpus_from_config_impl genrule in BUILD.
 
 # Set NORUNFILES so test/main doesn't fail when runfiles manifest is not found.
-if ! TEXT=$(NORUNFILES=1 "$@" 2>&1); then
-   echo "$TEXT"
-   echo "Router test failed to pass: debug logs above"
-   exit 1
-fi
+SHARDS=5
+for INDEX in $(seq 0 $((SHARDS-1))) ; do
+  if ! TEXT=$(NORUNFILES=1 GTEST_TOTAL_SHARDS=$SHARDS GTEST_SHARD_INDEX=$INDEX "$@" 2>&1); then
+    echo "$TEXT"
+    echo "Router test failed to pass: debug logs above"
+    exit 1
+  fi
+done
 
 set -e
 


### PR DESCRIPTION
Commit Message:

I'm working on addressing the issues coming up when building Envoy with clang-18 (currently used clang version is 14). One of the issues is that Envoy CI MSAN hits OOMs with clang-18 and
test/common/router/corpus_from_config_impl.sh is one of the things that hits the memory constraints.

The problem appears to be that clang-18 MSAN instrumentation is much more detailed and when running
test/common/router:config_impl_test_static MSAN itself (not the test logic) has to allocate a large amount of memory. In my tests it needed over 10GiB of memory which is a problem.

Envoy CI workers can go up to 6GiB currently, so such a large test does not fit. And for completenes, with clang-14 the same binary used around 4GiBs.

NOTE: I verified that the test itself does not have memory leaks and without MSAN consumes a reasonable amount of memory (e.g., less than 100MiB of RSS). So it indeed seem to be a patahlogical behavior of MSAN for the workload created by the test.

I noticed that MSAN footprint seem to be increasing over time, so the longer the binary runs the larger the RSS becomes. This is true for both clang-14 and clang-18.

That suggests that we can deal with the issue by sharding the tests and running one shard at a time, restarting the binary (basically the way shareded tests normally work with gtest).

In this change I changed the script to split/shard the tests in 5 groups, it was enough to overcome the OOM issue, but other than that the shard number is arbitrary.

I also considered disabling origin tracking as it would reduce MSAN memory footprint, but:

1. it wasn't enough of a reduction
2. origin infromation is useful for debugging msan failures

So all-in-all, sharding seem to be the most straighforward way of dealing with the issue.

Additional Description:

Related to https://github.com/envoyproxy/envoy/issues/37911 and fixes one of the issues that block clang-18 adoption in Envoy CI.

Risk Level: low
Testing: running msan + regular CI tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
