### PR TITLE
Support for MatcherTree Re-Entry

### DIFF
--- a/envoy/matcher/matcher.h
+++ b/envoy/matcher/matcher.h
@@ -154,6 +154,9 @@ public:
   struct MatchResult {
     const MatchState match_state_;
     const absl::optional<OnMatch<DataType>> on_match_;
+    // Non-null if the match was completed and the match tree can be re-entered to check for
+    // additional matches from where the initial matching stopped.
+    std::unique_ptr<MatchTree<DataType>> matcher_reentrant_ = nullptr;
   };
 
   // Attempts to match against the matching data (which should contain all the data requested via

--- a/source/common/matcher/list_matcher.h
+++ b/source/common/matcher/list_matcher.h
@@ -4,9 +4,12 @@
 
 #include "source/common/matcher/field_matcher.h"
 
+#include "absl/types/optional.h"
+
 namespace Envoy {
 namespace Matcher {
 
+template <class DataType> class ListMatcherReentrant;
 /**
  * A match tree that iterates over a list of matchers to find the first one that matches. If one
  * does, the MatchResult will be the one specified by the individual matcher.
@@ -16,7 +19,21 @@ public:
   explicit ListMatcher(absl::optional<OnMatch<DataType>> on_no_match) : on_no_match_(on_no_match) {}
 
   typename MatchTree<DataType>::MatchResult match(const DataType& matching_data) override {
-    for (const auto& matcher : matchers_) {
+    return match(matching_data, matchers_, on_no_match_);
+  }
+
+  void addMatcher(FieldMatcherPtr<DataType>&& matcher, OnMatch<DataType> action) {
+    matchers_.push_back({std::move(matcher), std::move(action)});
+  }
+
+  // Static helper with specifiable starting index.
+  // Static helper with specifiable starting index.
+  static typename MatchTree<DataType>::MatchResult
+  match(const DataType& matching_data,
+        std::vector<std::pair<FieldMatcherPtr<DataType>, OnMatch<DataType>>>& matchers,
+        absl::optional<OnMatch<DataType>> on_no_match, int starting_index = 0) {
+    for (size_t i = starting_index; i < matchers.size(); ++i) {
+      const auto& matcher = matchers.at(i);
       const auto maybe_match = matcher.first->match(matching_data);
 
       // One of the matchers don't have enough information, bail on evaluating the match.
@@ -25,20 +42,37 @@ public:
       }
 
       if (maybe_match.result()) {
-        return {MatchState::MatchComplete, matcher.second};
+        // If not at the end of the list, support the option to re-enter from the next index.
+        return {MatchState::MatchComplete, matcher.second,
+                std::make_unique<ListMatcherReentrant<DataType>>(&matchers, on_no_match, i + 1)};
       }
     }
-
-    return {MatchState::MatchComplete, on_no_match_};
-  }
-
-  void addMatcher(FieldMatcherPtr<DataType>&& matcher, OnMatch<DataType> action) {
-    matchers_.push_back({std::move(matcher), std::move(action)});
+    return {MatchState::MatchComplete, on_no_match};
   }
 
 private:
   absl::optional<OnMatch<DataType>> on_no_match_;
   std::vector<std::pair<FieldMatcherPtr<DataType>, OnMatch<DataType>>> matchers_;
+};
+
+// Referential class to allow for re-entry into a ListMatcher after an initial match.
+template <class DataType> class ListMatcherReentrant : public MatchTree<DataType> {
+public:
+  explicit ListMatcherReentrant(
+      std::vector<std::pair<FieldMatcherPtr<DataType>, OnMatch<DataType>>>* parent_matchers,
+      absl::optional<OnMatch<DataType>> on_no_match, int starting_index)
+      : parent_matchers_(parent_matchers), on_no_match_(on_no_match),
+        starting_index_(starting_index) {}
+
+  typename MatchTree<DataType>::MatchResult match(const DataType& matching_data) override {
+    return ListMatcher<DataType>::match(matching_data, *parent_matchers_, on_no_match_,
+                                        starting_index_);
+  }
+
+private:
+  std::vector<std::pair<FieldMatcherPtr<DataType>, OnMatch<DataType>>>* parent_matchers_;
+  absl::optional<OnMatch<DataType>> on_no_match_;
+  int starting_index_;
 };
 
 } // namespace Matcher

--- a/test/common/matcher/list_matcher_test.cc
+++ b/test/common/matcher/list_matcher_test.cc
@@ -31,6 +31,35 @@ TEST(ListMatcherTest, MissingData) {
   EXPECT_FALSE(matcher.match(TestData()).on_match_.has_value());
   EXPECT_EQ(matcher.match(TestData()).match_state_, MatchState::UnableToMatch);
 }
+
+TEST(ListMatcherTest, Reentry) {
+  Envoy::Matcher::ListMatcher<TestData> matcher(stringOnMatch<TestData>("on no match"));
+
+  matcher.addMatcher(createSingleMatcher("string", [](auto) { return true; }),
+                     stringOnMatch<TestData>("match 1"));
+  matcher.addMatcher(createSingleMatcher("string", [](auto) { return false; }),
+                     stringOnMatch<TestData>("no match 1"));
+  matcher.addMatcher(createSingleMatcher("string", [](auto) { return true; }),
+                     stringOnMatch<TestData>("match 2"));
+  matcher.addMatcher(createSingleMatcher("string", [](auto) { return false; }),
+                     stringOnMatch<TestData>("no match 2"));
+
+  // Expect re-entry option to be available for indices 1-3.
+  MatchTree<TestData>::MatchResult result_1 = matcher.match(TestData());
+  verifyImmediateMatch(result_1, "match 1");
+  ASSERT_NE(result_1.matcher_reentrant_, nullptr);
+
+  // Expect re-entry to hit the second match & return another re-entry option for index 3.
+  MatchTree<TestData>::MatchResult result_2 = result_1.matcher_reentrant_->match(TestData());
+  verifyImmediateMatch(result_2, "match 2");
+  ASSERT_NE(result_2.matcher_reentrant_, nullptr);
+
+  // Expect a third match to miss index 3 and return the on_no_match action.
+  MatchTree<TestData>::MatchResult result_3 = result_2.matcher_reentrant_->match(TestData());
+  verifyImmediateMatch(result_3, "on no match");
+  EXPECT_EQ(result_3.matcher_reentrant_, nullptr);
+}
+
 } // namespace
 } // namespace Matcher
 } // namespace Envoy

--- a/test/common/matcher/matcher_test.cc
+++ b/test/common/matcher/matcher_test.cc
@@ -643,5 +643,62 @@ TEST_F(MatcherTest, RecursiveMatcherCannotMatch) {
   EXPECT_EQ(recursive_result.match_state_, MatchState::UnableToMatch);
   EXPECT_EQ(recursive_result.result_, nullptr);
 }
+
+TEST_F(MatcherTest, ReentryWithRecursiveMatcher) {
+  auto top_matcher = std::make_shared<Envoy::Matcher::ListMatcher<TestData>>(
+      stringOnMatch<TestData>("on no match"));
+  auto parent_matcher_1 = std::make_shared<Envoy::Matcher::ListMatcher<TestData>>(
+      stringOnMatch<TestData>("on no match - nested - 1"));
+  parent_matcher_1->addMatcher(createSingleMatcher("string", [](auto) { return true; }),
+                               stringOnMatch<TestData>("match 1"));
+  parent_matcher_1->addMatcher(createSingleMatcher("string", [](auto) { return false; }),
+                               stringOnMatch<TestData>("no match 1"));
+  parent_matcher_1->addMatcher(createSingleMatcher("string", [](auto) { return true; }),
+                               stringOnMatch<TestData>("match 2"));
+  OnMatch<TestData> on_match_1{{}, /*matcher=*/parent_matcher_1};
+  top_matcher->addMatcher(createSingleMatcher("string", [](auto) { return true; }), on_match_1);
+
+  auto parent_matcher_2 = std::make_shared<Envoy::Matcher::ListMatcher<TestData>>(std::nullopt);
+  parent_matcher_2->addMatcher(createSingleMatcher("string", [](auto) { return true; }),
+                               stringOnMatch<TestData>("match 3"));
+  parent_matcher_2->addMatcher(createSingleMatcher("string", [](auto) { return false; }),
+                               stringOnMatch<TestData>("no match 2"));
+  parent_matcher_2->addMatcher(createSingleMatcher("string", [](auto) { return true; }),
+                               stringOnMatch<TestData>("match 4"));
+  OnMatch<TestData> on_match_2{{}, /*matcher=*/parent_matcher_2};
+  top_matcher->addMatcher(createSingleMatcher("string", [](auto) { return true; }), on_match_2);
+
+  // Expect to hit each match once via repeated re-entry, including the recursive on-no-match.
+  ReenterableMatchEvaluator<TestData> reenterable_matcher(top_matcher);
+  MaybeMatchResult result_1 = reenterable_matcher.evaluateMatch(TestData());
+  EXPECT_EQ(result_1.match_state_, MatchState::MatchComplete);
+  ASSERT_NE(result_1.result_, nullptr);
+  EXPECT_EQ(result_1.result_().get()->getTyped<StringAction>().string_, "match 1");
+  MaybeMatchResult result_2 = reenterable_matcher.evaluateMatch(TestData());
+  EXPECT_EQ(result_2.match_state_, MatchState::MatchComplete);
+  ASSERT_NE(result_2.result_, nullptr);
+  EXPECT_EQ(result_2.result_().get()->getTyped<StringAction>().string_, "match 2");
+  MaybeMatchResult on_no_match_result_1 = reenterable_matcher.evaluateMatch(TestData());
+  EXPECT_EQ(on_no_match_result_1.match_state_, MatchState::MatchComplete);
+  ASSERT_NE(on_no_match_result_1.result_, nullptr);
+  EXPECT_EQ(on_no_match_result_1.result_().get()->getTyped<StringAction>().string_,
+            "on no match - nested - 1");
+  MaybeMatchResult result_3 = reenterable_matcher.evaluateMatch(TestData());
+  EXPECT_EQ(result_3.match_state_, MatchState::MatchComplete);
+  ASSERT_NE(result_3.result_, nullptr);
+  EXPECT_EQ(result_3.result_().get()->getTyped<StringAction>().string_, "match 3");
+  MaybeMatchResult result_4 = reenterable_matcher.evaluateMatch(TestData());
+  EXPECT_EQ(result_4.match_state_, MatchState::MatchComplete);
+  ASSERT_NE(result_4.result_, nullptr);
+  EXPECT_EQ(result_4.result_().get()->getTyped<StringAction>().string_, "match 4");
+  MaybeMatchResult on_no_match_result_2 = reenterable_matcher.evaluateMatch(TestData());
+  EXPECT_EQ(on_no_match_result_2.match_state_, MatchState::MatchComplete);
+  ASSERT_NE(on_no_match_result_2.result_, nullptr);
+  EXPECT_EQ(on_no_match_result_2.result_().get()->getTyped<StringAction>().string_, "on no match");
+  MaybeMatchResult no_remaining_reentrants_result = reenterable_matcher.evaluateMatch(TestData());
+  EXPECT_EQ(no_remaining_reentrants_result.match_state_, MatchState::MatchComplete);
+  EXPECT_EQ(no_remaining_reentrants_result.result_, nullptr);
+}
+
 } // namespace Matcher
 } // namespace Envoy


### PR DESCRIPTION
Commit Message: 
Add support for re-entry into a MatcherTree, which can be enabled for specific classes as appropriate. This allows for continuing evaluation of an input against the remainder of a MatcherTree when both a) the MatcherTree type could feasibly match a single input to multiple matchers, and b) having additional matches is relevant to the calling filter.

Included is the implementation for ListMatcher as an example. Separate PRs will follow with implementations for other MatcherTree children classes where appropriate: e.g. PrefixMapMatcher will support re-entry but it wouldn't make sense for ExactMapMatcher.

Additional Description: An example of how this can be used can be found in a branching PR #38576, enabling a preview / darklaunch mode for matchers in the rate_limit_quota filter.

Risk Level: Moderate - changes to common library, though no changes to existing behaviors
Testing: Unit & integration testing
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
