### PR TITLE
When building with gperftools always link the library

### DIFF
--- a/bazel/foreign_cc/BUILD
+++ b/bazel/foreign_cc/BUILD
@@ -54,6 +54,7 @@ configure_make(
     targets = [
         "install-libLTLIBRARIES install-perftoolsincludeHEADERS",
     ],
+    alwayslink = True,
 )
 
 # Workaround for https://github.com/bazelbuild/rules_foreign_cc/issues/227


### PR DESCRIPTION
Commit Message:

There is a known issue in gperftools - when linking statically profiling triggered by environment variables does not work, because linker does not see the right profiling functions used and eliminates them completely.

I'm not entirely sure why the issues has not been fixed after all this time, but it's relatively well documented (see
https://github.com/gperftools/gperftools/issues/961, https://github.com/gperftools/gperftools/issues/415, etc).

There are a few ways to address the issues:

1. Link dynamically, this way linker would not have enough information to eliminate "unused" functions, because it cannot actually tell if they are trully unused
2. Explicitly tell linker that some functions must be preserved using -Wl,--undefined=<function name>
3. Use --whole-archive to prevent linker from eliminating functions it deems "unused".

This change goes for the third option as the least fragile, linkalways=True, when it works, instructs linker to use --whole-archive on the library marked with linkalways=True.

NOTE: linkalways=True does not work on cc_library when the source is a static archive (i.e., *.a file instead of *.h, *.cc), but to my surprise it works as expected in configure_make.

Additional Description:

I spotted the issue during debugging MSAN OOMs for https://github.com/envoyproxy/envoy/pull/38562 (related to https://github.com/envoyproxy/envoy/issues/37911). Envoy docs have instructions for running heap profiler in https://github.com/envoyproxy/envoy/blob/main/bazel/PPROF.md, but because of the issue with static linking in gperftools those don't work and this changes fixes it.

Risk Level: low
Testing: Running tests with HEAPPROFILE env variable
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a