### PR TITLE
Stop compiler from inlining releaseAssertInAFunction in test

### DIFF
--- a/test/common/common/BUILD
+++ b/test/common/common/BUILD
@@ -63,6 +63,7 @@ envoy_cc_test(
         "//source/common/common:assert_lib",
         "//test/test_common:logging_lib",
         "//test/test_common:utility_lib",
+        "@com_google_absl//absl/base",
     ],
 )
 

--- a/test/common/common/assert_test.cc
+++ b/test/common/common/assert_test.cc
@@ -3,11 +3,12 @@
 #include "test/test_common/logging.h"
 #include "test/test_common/utility.h"
 
+#include "absl/base/attributes.h"
 #include "gtest/gtest.h"
 
 namespace Envoy {
 
-static void releaseAssertInAFunction() { RELEASE_ASSERT(0, ""); }
+static ABSL_ATTRIBUTE_NOINLINE void releaseAssertInAFunction() { RELEASE_ASSERT(0, ""); }
 
 TEST(ReleaseAssertDeathTest, VariousLogs) {
   EXPECT_DEATH({ RELEASE_ASSERT(0, ""); }, ".*assert failure: 0.*");


### PR DESCRIPTION
Commit Message:

It looks that assert tests were recently updated to validate that triggered asserts print a stack trace. However stacktraces that are produced depend on the compilation parameters and compiler, i.e., if compiler will decide to inline releaseAssertInAFunction it will not show up in the stack trace breaking the test, even though nothing is actually wrong.

That's exactly what I noticed when building Envoy using clang-18 as we are trying to move Envoy CI to clang-18.

This change adds an attribute to the releaseAssertInAFunction that would prevent commonly used compilers (and importantly clang specifically) from inlining the function and breaking the test.

Additional Description:

Related to https://github.com/envoyproxy/envoy/issues/37911 and fixes one of the issues that block clang-18 adoption in Envoy CI (specifically addresses one of the failures in https://github.com/envoyproxy/envoy/pull/38571).

Risk Level: low
Testing: building and running tests using clang-18
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
