### PR TITLE
rate_limit_quota: preview mode for matchers

### DIFF
--- a/api/envoy/extensions/filters/http/rate_limit_quota/v3/rate_limit_quota.proto
+++ b/api/envoy/extensions/filters/http/rate_limit_quota/v3/rate_limit_quota.proto
@@ -165,7 +165,7 @@ message RateLimitQuotaOverride {
 // ``bucket_matchers`` matcher tree to assign the matched requests to the Quota Bucket.
 // Usage example: :ref:`RateLimitQuotaFilterConfig.bucket_matchers
 // <envoy_v3_api_field_extensions.filters.http.rate_limit_quota.v3.RateLimitQuotaFilterConfig.bucket_matchers>`.
-// [#next-free-field: 6]
+// [#next-free-field: 7]
 message RateLimitQuotaBucketSettings {
   // Configures the behavior after the first request has been matched to the bucket, and before the
   // the RLQS server returns the first quota assignment.
@@ -420,4 +420,11 @@ message RateLimitQuotaBucketSettings {
   // :ref:`AbandonAction <envoy_v3_api_msg_service.rate_limit_quota.v3.RateLimitQuotaResponse.BucketAction.AbandonAction>`
   // message.
   ExpiredAssignmentBehavior expired_assignment_behavior = 5;
+
+  // If set, the filter will not enforce the resulting rate limiting decision
+  // from this action, but will still record & log the bucket's usage. The
+  // filter will continue matching evluations for the request, if possible. The
+  // first matched, non-preview action or the no-match-action will then be
+  // enforced as normal.
+  bool preview_mode = 6;
 }

--- a/envoy/matcher/matcher.h
+++ b/envoy/matcher/matcher.h
@@ -154,6 +154,9 @@ public:
   struct MatchResult {
     const MatchState match_state_;
     const absl::optional<OnMatch<DataType>> on_match_;
+    // Non-null if the match was completed and the match tree can be re-entered to check for
+    // additional matches from where the initial matching stopped.
+    std::unique_ptr<MatchTree<DataType>> matcher_reentrant_ = nullptr;
   };
 
   // Attempts to match against the matching data (which should contain all the data requested via

--- a/source/common/matcher/list_matcher.h
+++ b/source/common/matcher/list_matcher.h
@@ -4,9 +4,12 @@
 
 #include "source/common/matcher/field_matcher.h"
 
+#include "absl/types/optional.h"
+
 namespace Envoy {
 namespace Matcher {
 
+template <class DataType> class ListMatcherReentrant;
 /**
  * A match tree that iterates over a list of matchers to find the first one that matches. If one
  * does, the MatchResult will be the one specified by the individual matcher.
@@ -16,7 +19,21 @@ public:
   explicit ListMatcher(absl::optional<OnMatch<DataType>> on_no_match) : on_no_match_(on_no_match) {}
 
   typename MatchTree<DataType>::MatchResult match(const DataType& matching_data) override {
-    for (const auto& matcher : matchers_) {
+    return match(matching_data, matchers_, on_no_match_);
+  }
+
+  void addMatcher(FieldMatcherPtr<DataType>&& matcher, OnMatch<DataType> action) {
+    matchers_.push_back({std::move(matcher), std::move(action)});
+  }
+
+  // Static helper with specifiable starting index.
+  // Static helper with specifiable starting index.
+  static typename MatchTree<DataType>::MatchResult
+  match(const DataType& matching_data,
+        std::vector<std::pair<FieldMatcherPtr<DataType>, OnMatch<DataType>>>& matchers,
+        absl::optional<OnMatch<DataType>> on_no_match, int starting_index = 0) {
+    for (size_t i = starting_index; i < matchers.size(); ++i) {
+      const auto& matcher = matchers.at(i);
       const auto maybe_match = matcher.first->match(matching_data);
 
       // One of the matchers don't have enough information, bail on evaluating the match.
@@ -25,20 +42,37 @@ public:
       }
 
       if (maybe_match.result()) {
-        return {MatchState::MatchComplete, matcher.second};
+        // If not at the end of the list, support the option to re-enter from the next index.
+        return {MatchState::MatchComplete, matcher.second,
+                std::make_unique<ListMatcherReentrant<DataType>>(&matchers, on_no_match, i + 1)};
       }
     }
-
-    return {MatchState::MatchComplete, on_no_match_};
-  }
-
-  void addMatcher(FieldMatcherPtr<DataType>&& matcher, OnMatch<DataType> action) {
-    matchers_.push_back({std::move(matcher), std::move(action)});
+    return {MatchState::MatchComplete, on_no_match};
   }
 
 private:
   absl::optional<OnMatch<DataType>> on_no_match_;
   std::vector<std::pair<FieldMatcherPtr<DataType>, OnMatch<DataType>>> matchers_;
+};
+
+// Referential class to allow for re-entry into a ListMatcher after an initial match.
+template <class DataType> class ListMatcherReentrant : public MatchTree<DataType> {
+public:
+  explicit ListMatcherReentrant(
+      std::vector<std::pair<FieldMatcherPtr<DataType>, OnMatch<DataType>>>* parent_matchers,
+      absl::optional<OnMatch<DataType>> on_no_match, int starting_index)
+      : parent_matchers_(parent_matchers), on_no_match_(on_no_match),
+        starting_index_(starting_index) {}
+
+  typename MatchTree<DataType>::MatchResult match(const DataType& matching_data) override {
+    return ListMatcher<DataType>::match(matching_data, *parent_matchers_, on_no_match_,
+                                        starting_index_);
+  }
+
+private:
+  std::vector<std::pair<FieldMatcherPtr<DataType>, OnMatch<DataType>>>* parent_matchers_;
+  absl::optional<OnMatch<DataType>> on_no_match_;
+  int starting_index_;
 };
 
 } // namespace Matcher

--- a/test/common/matcher/list_matcher_test.cc
+++ b/test/common/matcher/list_matcher_test.cc
@@ -31,6 +31,35 @@ TEST(ListMatcherTest, MissingData) {
   EXPECT_FALSE(matcher.match(TestData()).on_match_.has_value());
   EXPECT_EQ(matcher.match(TestData()).match_state_, MatchState::UnableToMatch);
 }
+
+TEST(ListMatcherTest, Reentry) {
+  Envoy::Matcher::ListMatcher<TestData> matcher(stringOnMatch<TestData>("on no match"));
+
+  matcher.addMatcher(createSingleMatcher("string", [](auto) { return true; }),
+                     stringOnMatch<TestData>("match 1"));
+  matcher.addMatcher(createSingleMatcher("string", [](auto) { return false; }),
+                     stringOnMatch<TestData>("no match 1"));
+  matcher.addMatcher(createSingleMatcher("string", [](auto) { return true; }),
+                     stringOnMatch<TestData>("match 2"));
+  matcher.addMatcher(createSingleMatcher("string", [](auto) { return false; }),
+                     stringOnMatch<TestData>("no match 2"));
+
+  // Expect re-entry option to be available for indices 1-3.
+  MatchTree<TestData>::MatchResult result_1 = matcher.match(TestData());
+  verifyImmediateMatch(result_1, "match 1");
+  ASSERT_NE(result_1.matcher_reentrant_, nullptr);
+
+  // Expect re-entry to hit the second match & return another re-entry option for index 3.
+  MatchTree<TestData>::MatchResult result_2 = result_1.matcher_reentrant_->match(TestData());
+  verifyImmediateMatch(result_2, "match 2");
+  ASSERT_NE(result_2.matcher_reentrant_, nullptr);
+
+  // Expect a third match to miss index 3 and return the on_no_match action.
+  MatchTree<TestData>::MatchResult result_3 = result_2.matcher_reentrant_->match(TestData());
+  verifyImmediateMatch(result_3, "on no match");
+  EXPECT_EQ(result_3.matcher_reentrant_, nullptr);
+}
+
 } // namespace
 } // namespace Matcher
 } // namespace Envoy

--- a/test/common/matcher/matcher_test.cc
+++ b/test/common/matcher/matcher_test.cc
@@ -643,5 +643,62 @@ TEST_F(MatcherTest, RecursiveMatcherCannotMatch) {
   EXPECT_EQ(recursive_result.match_state_, MatchState::UnableToMatch);
   EXPECT_EQ(recursive_result.result_, nullptr);
 }
+
+TEST_F(MatcherTest, ReentryWithRecursiveMatcher) {
+  auto top_matcher = std::make_shared<Envoy::Matcher::ListMatcher<TestData>>(
+      stringOnMatch<TestData>("on no match"));
+  auto parent_matcher_1 = std::make_shared<Envoy::Matcher::ListMatcher<TestData>>(
+      stringOnMatch<TestData>("on no match - nested - 1"));
+  parent_matcher_1->addMatcher(createSingleMatcher("string", [](auto) { return true; }),
+                               stringOnMatch<TestData>("match 1"));
+  parent_matcher_1->addMatcher(createSingleMatcher("string", [](auto) { return false; }),
+                               stringOnMatch<TestData>("no match 1"));
+  parent_matcher_1->addMatcher(createSingleMatcher("string", [](auto) { return true; }),
+                               stringOnMatch<TestData>("match 2"));
+  OnMatch<TestData> on_match_1{{}, /*matcher=*/parent_matcher_1};
+  top_matcher->addMatcher(createSingleMatcher("string", [](auto) { return true; }), on_match_1);
+
+  auto parent_matcher_2 = std::make_shared<Envoy::Matcher::ListMatcher<TestData>>(std::nullopt);
+  parent_matcher_2->addMatcher(createSingleMatcher("string", [](auto) { return true; }),
+                               stringOnMatch<TestData>("match 3"));
+  parent_matcher_2->addMatcher(createSingleMatcher("string", [](auto) { return false; }),
+                               stringOnMatch<TestData>("no match 2"));
+  parent_matcher_2->addMatcher(createSingleMatcher("string", [](auto) { return true; }),
+                               stringOnMatch<TestData>("match 4"));
+  OnMatch<TestData> on_match_2{{}, /*matcher=*/parent_matcher_2};
+  top_matcher->addMatcher(createSingleMatcher("string", [](auto) { return true; }), on_match_2);
+
+  // Expect to hit each match once via repeated re-entry, including the recursive on-no-match.
+  ReenterableMatchEvaluator<TestData> reenterable_matcher(top_matcher);
+  MaybeMatchResult result_1 = reenterable_matcher.evaluateMatch(TestData());
+  EXPECT_EQ(result_1.match_state_, MatchState::MatchComplete);
+  ASSERT_NE(result_1.result_, nullptr);
+  EXPECT_EQ(result_1.result_().get()->getTyped<StringAction>().string_, "match 1");
+  MaybeMatchResult result_2 = reenterable_matcher.evaluateMatch(TestData());
+  EXPECT_EQ(result_2.match_state_, MatchState::MatchComplete);
+  ASSERT_NE(result_2.result_, nullptr);
+  EXPECT_EQ(result_2.result_().get()->getTyped<StringAction>().string_, "match 2");
+  MaybeMatchResult on_no_match_result_1 = reenterable_matcher.evaluateMatch(TestData());
+  EXPECT_EQ(on_no_match_result_1.match_state_, MatchState::MatchComplete);
+  ASSERT_NE(on_no_match_result_1.result_, nullptr);
+  EXPECT_EQ(on_no_match_result_1.result_().get()->getTyped<StringAction>().string_,
+            "on no match - nested - 1");
+  MaybeMatchResult result_3 = reenterable_matcher.evaluateMatch(TestData());
+  EXPECT_EQ(result_3.match_state_, MatchState::MatchComplete);
+  ASSERT_NE(result_3.result_, nullptr);
+  EXPECT_EQ(result_3.result_().get()->getTyped<StringAction>().string_, "match 3");
+  MaybeMatchResult result_4 = reenterable_matcher.evaluateMatch(TestData());
+  EXPECT_EQ(result_4.match_state_, MatchState::MatchComplete);
+  ASSERT_NE(result_4.result_, nullptr);
+  EXPECT_EQ(result_4.result_().get()->getTyped<StringAction>().string_, "match 4");
+  MaybeMatchResult on_no_match_result_2 = reenterable_matcher.evaluateMatch(TestData());
+  EXPECT_EQ(on_no_match_result_2.match_state_, MatchState::MatchComplete);
+  ASSERT_NE(on_no_match_result_2.result_, nullptr);
+  EXPECT_EQ(on_no_match_result_2.result_().get()->getTyped<StringAction>().string_, "on no match");
+  MaybeMatchResult no_remaining_reentrants_result = reenterable_matcher.evaluateMatch(TestData());
+  EXPECT_EQ(no_remaining_reentrants_result.match_state_, MatchState::MatchComplete);
+  EXPECT_EQ(no_remaining_reentrants_result.result_, nullptr);
+}
+
 } // namespace Matcher
 } // namespace Envoy

--- a/test/extensions/filters/http/rate_limit_quota/integration_test.cc
+++ b/test/extensions/filters/http/rate_limit_quota/integration_test.cc
@@ -46,6 +46,9 @@ using envoy::service::rate_limit_quota::v3::BucketId;
 using envoy::service::rate_limit_quota::v3::RateLimitQuotaResponse;
 using envoy::service::rate_limit_quota::v3::RateLimitQuotaUsageReports;
 using Protobuf::util::MessageDifferencer;
+using ::xds::type::matcher::v3::Matcher;
+using ValueBuilder = ::envoy::extensions::filters::http::rate_limit_quota::v3::
+    RateLimitQuotaBucketSettings::BucketIdBuilder::ValueBuilder;
 
 MATCHER_P2(ProtoEqIgnoringFieldAndOrdering, expected,
            /* const FieldDescriptor* */ ignored_field, "") {
@@ -73,6 +76,8 @@ struct ConfigOption {
   absl::optional<RateLimitStrategy> fallback_rate_limit_strategy = std::nullopt;
   int fallback_ttl_sec = 15;
   absl::optional<DenyResponseSettings> deny_response_settings = std::nullopt;
+  absl::optional<BucketId> custom_bucket_id = std::nullopt;
+  absl::optional<Matcher> preview_matcher = std::nullopt;
 };
 
 // These tests exercise the rate limit quota filter through Envoy's integration test
@@ -94,6 +99,64 @@ protected:
     for (int i = 0; i < 2; ++i) {
       grpc_upstreams_.push_back(&addFakeUpstream(Http::CodecType::HTTP2));
     }
+  }
+
+  void constructMatcher(const ConfigOption& config_option, Matcher& matcher_out,
+                        bool preview_mode = false) {
+    TestUtility::loadFromYaml(std::string(ValidMatcherConfig), matcher_out);
+
+    auto* mutable_config = matcher_out.mutable_matcher_list()
+                               ->mutable_matchers(0)
+                               ->mutable_on_match()
+                               ->mutable_action()
+                               ->mutable_typed_config();
+    ASSERT_TRUE(mutable_config->Is<::envoy::extensions::filters::http::rate_limit_quota::v3::
+                                       RateLimitQuotaBucketSettings>());
+
+    auto mutable_bucket_settings = MessageUtil::anyConvert<
+        ::envoy::extensions::filters::http::rate_limit_quota::v3::RateLimitQuotaBucketSettings>(
+        *mutable_config);
+
+    if (config_option.custom_bucket_id.has_value()) {
+      auto* bucket_id_builder =
+          mutable_bucket_settings.mutable_bucket_id_builder()->mutable_bucket_id_builder();
+      bucket_id_builder->clear();
+      for (const auto& [key, value] : config_option.custom_bucket_id->bucket()) {
+        ValueBuilder value_builder;
+        value_builder.set_string_value(value);
+        bucket_id_builder->insert({key, value_builder});
+      }
+    }
+
+    // Configure the no_assignment behavior.
+    if (config_option.no_assignment_blanket_rule.has_value()) {
+      mutable_bucket_settings.mutable_no_assignment_behavior()
+          ->mutable_fallback_rate_limit()
+          ->set_blanket_rule(*config_option.no_assignment_blanket_rule);
+    } else if (config_option.unsupported_no_assignment_strategy) {
+      auto* requests_per_time_unit = mutable_bucket_settings.mutable_no_assignment_behavior()
+                                         ->mutable_fallback_rate_limit()
+                                         ->mutable_requests_per_time_unit();
+      requests_per_time_unit->set_requests_per_time_unit(100);
+      requests_per_time_unit->set_time_unit(envoy::type::v3::RateLimitUnit::SECOND);
+    }
+
+    if (config_option.fallback_rate_limit_strategy.has_value()) {
+      *mutable_bucket_settings.mutable_expired_assignment_behavior()
+           ->mutable_fallback_rate_limit() = *config_option.fallback_rate_limit_strategy;
+      mutable_bucket_settings.mutable_expired_assignment_behavior()
+          ->mutable_expired_assignment_behavior_timeout()
+          ->set_seconds(config_option.fallback_ttl_sec);
+    }
+
+    if (config_option.deny_response_settings.has_value()) {
+      *mutable_bucket_settings.mutable_deny_response_settings() =
+          *config_option.deny_response_settings;
+    }
+    if (preview_mode)
+      mutable_bucket_settings.set_preview_mode(true);
+
+    mutable_config->PackFrom(mutable_bucket_settings);
   }
 
   void initializeConfig(ConfigOption config_option = {}, const std::string& log_format = "") {
@@ -135,46 +198,13 @@ protected:
       proto_config_.set_domain("cloud_12345_67890_rlqs");
 
       xds::type::matcher::v3::Matcher matcher;
-      TestUtility::loadFromYaml(std::string(ValidMatcherConfig), matcher);
+      constructMatcher(config_option, matcher);
 
-      auto* mutable_config = matcher.mutable_matcher_list()
-                                 ->mutable_matchers(0)
-                                 ->mutable_on_match()
-                                 ->mutable_action()
-                                 ->mutable_typed_config();
-      ASSERT_TRUE(mutable_config->Is<::envoy::extensions::filters::http::rate_limit_quota::v3::
-                                         RateLimitQuotaBucketSettings>());
-
-      auto mutable_bucket_settings = MessageUtil::anyConvert<
-          ::envoy::extensions::filters::http::rate_limit_quota::v3::RateLimitQuotaBucketSettings>(
-          *mutable_config);
-      // Configure the no_assignment behavior.
-      if (config_option.no_assignment_blanket_rule.has_value()) {
-        mutable_bucket_settings.mutable_no_assignment_behavior()
-            ->mutable_fallback_rate_limit()
-            ->set_blanket_rule(*config_option.no_assignment_blanket_rule);
-      } else if (config_option.unsupported_no_assignment_strategy) {
-        auto* requests_per_time_unit = mutable_bucket_settings.mutable_no_assignment_behavior()
-                                           ->mutable_fallback_rate_limit()
-                                           ->mutable_requests_per_time_unit();
-        requests_per_time_unit->set_requests_per_time_unit(100);
-        requests_per_time_unit->set_time_unit(envoy::type::v3::RateLimitUnit::SECOND);
+      // If given a preview matcher, set it first so that it evaluates
+      // before the non-preview matcher.
+      if (config_option.preview_matcher.has_value()) {
+        proto_config_.mutable_bucket_matchers()->MergeFrom(config_option.preview_matcher.value());
       }
-
-      if (config_option.fallback_rate_limit_strategy.has_value()) {
-        *mutable_bucket_settings.mutable_expired_assignment_behavior()
-             ->mutable_fallback_rate_limit() = *config_option.fallback_rate_limit_strategy;
-        mutable_bucket_settings.mutable_expired_assignment_behavior()
-            ->mutable_expired_assignment_behavior_timeout()
-            ->set_seconds(config_option.fallback_ttl_sec);
-      }
-
-      if (config_option.deny_response_settings.has_value()) {
-        *mutable_bucket_settings.mutable_deny_response_settings() =
-            *config_option.deny_response_settings;
-      }
-
-      mutable_config->PackFrom(mutable_bucket_settings);
       proto_config_.mutable_bucket_matchers()->MergeFrom(matcher);
 
       // Construct a configuration proto for our filter and then re-write it
@@ -795,6 +825,116 @@ TEST_P(RateLimitQuotaIntegrationTest, MultiDifferentRequestNoAssignementAllowAll
       RateLimitQuotaUsageReports::BucketQuotaUsage::GetDescriptor()->FindFieldByName(
           "time_elapsed");
   ASSERT_THAT(reports, ProtoEqIgnoringFieldAndOrdering(expected_reports, time_elapsed_desc));
+}
+
+// Test behaviors when a preview matcher executes before a non-preview matcher.
+// The preview matcher should be matched & its action evaluated, but resulting
+// deny decision should be ignored. The default matcher's bucket should instead
+// also be evaluated & its allow decision respected.
+TEST_P(RateLimitQuotaIntegrationTest, MultiSameRequestAllowAllPreviewDenyAll) {
+  Matcher preview_matcher;
+  BucketId preview_bucket_id;
+  preview_bucket_id.mutable_bucket()->insert(
+      {{"name", "prod"}, {"environment", "staging"}, {"group", "preview rule"}});
+  constructMatcher(
+      {
+          .no_assignment_blanket_rule = RateLimitStrategy::DENY_ALL,
+          .custom_bucket_id = preview_bucket_id,
+      },
+      preview_matcher, true);
+
+  initializeConfig({
+      .no_assignment_blanket_rule = RateLimitStrategy::ALLOW_ALL,
+      .preview_matcher = preview_matcher,
+  });
+  HttpIntegrationTest::initialize();
+  absl::flat_hash_map<std::string, std::string> custom_headers = {{"environment", "staging"},
+                                                                  {"group", "envoy"}};
+
+  BucketId actionable_bucket_id;
+  actionable_bucket_id.mutable_bucket()->insert(
+      {{"name", "prod"}, {"environment", "staging"}, {"group", "envoy"}});
+
+  // Expect usage reports for the preview & actionable buckets. The preview rule
+  // should report a blocked query, even though the blocking decision was not
+  // enforced.
+  RateLimitQuotaUsageReports expected_reports;
+  expected_reports.set_domain("cloud_12345_67890_rlqs");
+  auto* preview_usage = expected_reports.add_bucket_quota_usages();
+  preview_usage->set_num_requests_denied(1);
+  preview_usage->mutable_bucket_id()->CopyFrom(preview_bucket_id);
+  auto* actionable_usage = expected_reports.add_bucket_quota_usages();
+  actionable_usage->set_num_requests_allowed(1);
+  actionable_usage->mutable_bucket_id()->CopyFrom(actionable_bucket_id);
+
+  // First request is allowed by the default-open & triggers bucket the
+  // RLQS stream creation.
+  sendClientRequest(&custom_headers);
+
+  // Start the gRPC stream to RLQS server on the first request.
+  ASSERT_TRUE(grpc_upstreams_[0]->waitForHttpConnection(*dispatcher_, rlqs_connection_));
+  ASSERT_TRUE(rlqs_connection_->waitForNewStream(*dispatcher_, rlqs_stream_));
+  rlqs_stream_->startGrpcStream();
+
+  // RLQS stream is triggered by first bucket creation.
+  // The first request should be allowed by the no_assignment default-allow,
+  // regardless of the preview deny-all.
+  ASSERT_TRUE(expectAllowedRequest());
+
+  // First usage reports are sent when the RLQS buckets are each hit. This tests
+  // that each bucket triggers an initial usage report by combining them and
+  // validating the composite, so that we don't have to test for ordering.
+  RateLimitQuotaUsageReports combined_reports;
+  for (int i = 0; i < 2; ++i) {
+    RateLimitQuotaUsageReports init_reports;
+    ASSERT_TRUE(rlqs_stream_->waitForGrpcMessage(*dispatcher_, init_reports));
+
+    ASSERT_THAT(init_reports.bucket_quota_usages_size(), 1);
+    if (i == 0) {
+      combined_reports.MergeFrom(init_reports);
+    } else {
+      combined_reports.add_bucket_quota_usages()->MergeFrom(init_reports.bucket_quota_usages(0));
+    }
+  }
+
+  const Protobuf::FieldDescriptor* time_elapsed_desc =
+      RateLimitQuotaUsageReports::BucketQuotaUsage::GetDescriptor()->FindFieldByName(
+          "time_elapsed");
+  ASSERT_THAT(combined_reports,
+              ProtoEqIgnoringFieldAndOrdering(expected_reports, time_elapsed_desc));
+
+  // Build the assignments response.
+  RateLimitQuotaResponse rlqs_response;
+  auto* bucket_action = rlqs_response.add_bucket_action();
+  bucket_action->mutable_bucket_id()->CopyFrom(actionable_bucket_id);
+  auto* quota_assignment = bucket_action->mutable_quota_assignment_action();
+  quota_assignment->mutable_assignment_time_to_live()->set_seconds(120);
+  quota_assignment->mutable_rate_limit_strategy()->set_blanket_rule(RateLimitStrategy::ALLOW_ALL);
+  auto* preview_action = rlqs_response.add_bucket_action();
+  preview_action->mutable_bucket_id()->CopyFrom(preview_bucket_id);
+  auto* preview_assignment = preview_action->mutable_quota_assignment_action();
+  preview_assignment->mutable_assignment_time_to_live()->set_seconds(120);
+  preview_assignment->mutable_rate_limit_strategy()->set_blanket_rule(RateLimitStrategy::ALLOW_ALL);
+
+  // Send the response from RLQS server & give a little time for assignments to
+  // propagate.
+  rlqs_stream_->sendGrpcMessage(rlqs_response);
+  absl::SleepFor(absl::Seconds(0.5));
+
+  // Send one more request to test the preview matcher hitting a cached bucket.
+  sendClientRequest(&custom_headers);
+  ASSERT_TRUE(expectAllowedRequest());
+
+  // Expect the next usage report for the preview bucket to show an allowed
+  // request because of the cached assignment.
+  preview_usage->clear_num_requests_denied();
+  preview_usage->set_num_requests_allowed(1);
+
+  combined_reports.Clear();
+  simTime().advanceTimeWait(std::chrono::seconds(report_interval_sec_));
+  ASSERT_TRUE(rlqs_stream_->waitForGrpcMessage(*dispatcher_, combined_reports));
+  ASSERT_THAT(combined_reports,
+              ProtoEqIgnoringFieldAndOrdering(expected_reports, time_elapsed_desc));
 }
 
 TEST_P(RateLimitQuotaIntegrationTest, MultiDifferentRequestNoAssignementDenyAll) {

--- a/test/extensions/filters/http/rate_limit_quota/test_utils.h
+++ b/test/extensions/filters/http/rate_limit_quota/test_utils.h
@@ -45,6 +45,71 @@ inline constexpr absl::string_view ValidMatcherConfig = R"EOF(
             reporting_interval: 60s
   )EOF";
 
+inline constexpr absl::string_view ValidPreviewMatcherConfig = R"EOF(
+  matcher_list:
+    matchers:
+      # Assign requests with header['env'] set to 'staging' to the bucket { name: 'staging' }
+      predicate:
+        single_predicate:
+          input:
+            typed_config:
+              "@type": type.googleapis.com/envoy.type.matcher.v3.HttpRequestHeaderMatchInput
+              header_name: environment
+            name: "HttpRequestHeaderMatchInput"
+          value_match:
+            exact: staging
+      on_match:
+        action:
+          name: rate_limit_quota
+          typed_config:
+            "@type": type.googleapis.com/envoy.extensions.filters.http.rate_limit_quota.v3.RateLimitQuotaBucketSettings
+            bucket_id_builder:
+              bucket_id_builder:
+                "name":
+                    string_value: "prod"
+                "environment":
+                    custom_value:
+                      name: "test_1"
+                      typed_config:
+                        "@type": type.googleapis.com/envoy.type.matcher.v3.HttpRequestHeaderMatchInput
+                        header_name: environment
+                "group":
+                    custom_value:
+                      name: "test_2"
+                      typed_config:
+                        "@type": type.googleapis.com/envoy.type.matcher.v3.HttpRequestHeaderMatchInput
+                        header_name: group
+                "preview_name":
+                    string_value: "preview_test"
+            reporting_interval: 60s
+            preview_mode: true
+  on_no_match:
+    action:
+      name: rate_limit_quota
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.filters.http.rate_limit_quota.v3.RateLimitQuotaBucketSettings
+        bucket_id_builder:
+          bucket_id_builder:
+            "name":
+                string_value: "prod"
+            "environment":
+                custom_value:
+                  name: "test_1"
+                  typed_config:
+                    "@type": type.googleapis.com/envoy.type.matcher.v3.HttpRequestHeaderMatchInput
+                    header_name: environment
+            "group":
+                custom_value:
+                  name: "test_2"
+                  typed_config:
+                    "@type": type.googleapis.com/envoy.type.matcher.v3.HttpRequestHeaderMatchInput
+                    header_name: group
+        no_assignment_behavior:
+          fallback_rate_limit:
+            blanket_rule: DENY_ALL
+        reporting_interval: 5s
+  )EOF";
+
 inline constexpr absl::string_view InvalidMatcherConfig = R"EOF(
   matcher_list:
     matchers:


### PR DESCRIPTION
Commit Message:
- Preview matchers are provided to enable testing how a config would have treated incoming traffic if the match would have been enforced.
  - If matcher evaluation lands on a preview matcher, the matched bucket is processed as normal (bucket creation, usage aggregation & reporting, etc), but the allow/deny decision is only ever logged, not enforced.
    - After this, the filter re-enters the matcher tree, matching until it lands on an enforceable matcher (subsequent preview matchers are ignored, even if matched).
  - If evaluation lands on an enforceable matcher first, then there is no need for re-entry.
- If re-entry isn't supported for the given MatcherTree type, then the filter will stop after the first evaluation.

Additional Description: Branched from PR #38564 which provides the necessary re-entry interface for the MatcherTree and an implementation for ListMatcher
Risk Level: minor - all limited to in-development rate_limit_quota filter
Testing: Unit and integration
Docs Changes:
Release Notes:
Platform Specific Features:
