### PR TITLE
Typo fix for FULL_DUPLEX_STREAMED comments

### DIFF
--- a/api/envoy/extensions/filters/http/ext_proc/v3/processing_mode.proto
+++ b/api/envoy/extensions/filters/http/ext_proc/v3/processing_mode.proto
@@ -107,7 +107,6 @@ message ProcessingMode {
     //   :ref:`StreamedBodyResponse <envoy_v3_api_msg_service.ext_proc.v3.StreamedBodyResponse>`
     //   to Envoy in the body response.
     // * Envoy will stream the body chunks in the responses from the server to the upstream/downstream as they arrive.
-
     FULL_DUPLEX_STREAMED = 4;
   }
 


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Typo fix for FULL_DUPLEX_STREAMED comments
Additional Description: This is a small typo fix (just removes a newline) which will include the documentation for `FULL_DUPLEX_STREAMED` [here](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/http/ext_proc/v3/processing_mode.proto.html#enum-extensions-filters-http-ext-proc-v3-processingmode-bodysendmode) 

Risk Level: low
Testing: none