### PR TITLE
ci: skips envoy_api from clang-tidy

### DIFF
--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -348,8 +348,7 @@ case $CI_TARGET in
             CLANG_TIDY_TARGETS=(
                 //contrib/...
                 //source/...
-                //test/...
-                @envoy_api//...)
+                //test/...)
         fi
         echo "Running clang-tidy on ${CLANG_TIDY_TARGETS[*]}"
         bazel build \


### PR DESCRIPTION
envoy_api repo is for proto buf APIs and not the handwritten C++ code, so clang-tidy doesn't make sense for it.