### PR TITLE
clang-tidy: fixes invalid case style in LinuxContainerCpuStatsReader

### DIFF
--- a/source/extensions/resource_monitors/cpu_utilization/linux_cpu_stats_reader.h
+++ b/source/extensions/resource_monitors/cpu_utilization/linux_cpu_stats_reader.h
@@ -27,7 +27,7 @@ private:
 class LinuxContainerCpuStatsReader : public CpuStatsReader {
 public:
   LinuxContainerCpuStatsReader(
-      TimeSource& time_source_,
+      TimeSource& time_source,
       const std::string& linux_cgroup_cpu_allocated_file = LINUX_CGROUP_CPU_ALLOCATED_FILE,
       const std::string& linux_cgroup_cpu_times_file = LINUX_CGROUP_CPU_TIMES_FILE);
   CpuTimes getCpuTimes() override;


### PR DESCRIPTION
contributes to #28566