### PR TITLE
clang-tidy: do not call virtual method in ~SlotImpl

### DIFF
--- a/source/common/thread_local/thread_local_impl.cc
+++ b/source/common/thread_local/thread_local_impl.cc
@@ -47,7 +47,7 @@ InstanceImpl::SlotImpl::SlotImpl(InstanceImpl& parent, uint32_t index)
 InstanceImpl::SlotImpl::~SlotImpl() {
   // Do nothing if the parent is already shutdown. Return early here to avoid accessing the main
   // thread dispatcher because it may have been destroyed.
-  if (isShutdown()) {
+  if (isShutdownImpl()) {
     return;
   }
 

--- a/source/common/thread_local/thread_local_impl.h
+++ b/source/common/thread_local/thread_local_impl.h
@@ -48,7 +48,9 @@ private:
     void runOnAllThreads(const UpdateCb& cb, const std::function<void()>& complete_cb) override;
     bool currentThreadRegistered() override;
     void set(InitializeCb cb) override;
-    bool isShutdown() const override { return parent_.shutdown_; }
+    bool isShutdown() const override { return isShutdownImpl(); }
+    // We need to call isShutdown inside the destructor, so it must be non-virtual.
+    bool isShutdownImpl() const { return parent_.shutdown_; }
 
     InstanceImpl& parent_;
     const uint32_t index_;


### PR DESCRIPTION
contributes to #28566