### PR TITLE
dynamic_modules: use addStreamFilter for dynamic_modules http filter callback

### DIFF
--- a/source/extensions/filters/http/dynamic_modules/factory.cc
+++ b/source/extensions/filters/http/dynamic_modules/factory.cc
@@ -42,8 +42,7 @@ absl::StatusOr<Http::FilterFactoryCb> DynamicModuleConfigFactory::createFilterFa
         std::make_shared<Envoy::Extensions::DynamicModules::HttpFilters::DynamicModuleHttpFilter>(
             config);
     filter->initializeInModuleFilter();
-    callbacks.addStreamDecoderFilter(filter);
-    callbacks.addStreamEncoderFilter(filter);
+    callbacks.addStreamFilter(filter);
   };
 }
 

--- a/test/extensions/dynamic_modules/http/factory_test.cc
+++ b/test/extensions/dynamic_modules/http/factory_test.cc
@@ -44,8 +44,7 @@ filter_config:
   auto factory_cb = result.value();
   Http::MockFilterChainFactoryCallbacks callbacks;
 
-  EXPECT_CALL(callbacks, addStreamDecoderFilter(testing::_));
-  EXPECT_CALL(callbacks, addStreamEncoderFilter(testing::_));
+  EXPECT_CALL(callbacks, addStreamFilter(testing::_));
   factory_cb(callbacks);
 }
 
@@ -74,8 +73,7 @@ filter_name: foo
   auto factory_cb = result.value();
   Http::MockFilterChainFactoryCallbacks callbacks;
 
-  EXPECT_CALL(callbacks, addStreamDecoderFilter(testing::_));
-  EXPECT_CALL(callbacks, addStreamEncoderFilter(testing::_));
+  EXPECT_CALL(callbacks, addStreamFilter(testing::_));
   factory_cb(callbacks);
 }
 
@@ -107,8 +105,7 @@ filter_config:
   auto factory_cb = result.value();
   Http::MockFilterChainFactoryCallbacks callbacks;
 
-  EXPECT_CALL(callbacks, addStreamDecoderFilter(testing::_));
-  EXPECT_CALL(callbacks, addStreamEncoderFilter(testing::_));
+  EXPECT_CALL(callbacks, addStreamFilter(testing::_));
   factory_cb(callbacks);
 }
 


### PR DESCRIPTION
Commit Message: use addStreamFilter for dynamic_modules http filter callback
Additional Description: Using addStreamDecoderFilter and addStreamEncoderFilter will cause filter to be added twice in filter manager, so that callback like onStreamComplete will be called twice for one filter. Using addStreamFilter can make sure that callback will only be called once for one filter.
Risk Level: low
Testing: unit test
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
