### PR TITLE
listener: fixed a bug where the addresses cannot be updated partially

### DIFF
--- a/api/envoy/config/listener/v3/listener.proto
+++ b/api/envoy/config/listener/v3/listener.proto
@@ -247,10 +247,10 @@ message Listener {
   google.protobuf.BoolValue freebind = 11;
 
   // Additional socket options that may not be present in Envoy source code or
-  // precompiled binaries. The socket options can be updated for a listener when
+  // precompiled binaries.
+  // It is not allowed to update the socket options for any existing address if
   // :ref:`enable_reuse_port <envoy_v3_api_field_config.listener.v3.Listener.enable_reuse_port>`
-  // is ``true``. Otherwise, if socket options change during a listener update the update will be rejected
-  // to make it clear that the options were not updated.
+  // is ``false`` to avoid the conflict when creating new sockets for the listener.
   repeated core.v3.SocketOption socket_options = 13;
 
   // Whether the listener should accept TCP Fast Open (TFO) connections.

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -82,7 +82,7 @@ bug_fixes:
     ``envoy.reloadable_features.jwt_fetcher_use_scheme_from_uri`` to false.
 - area: listener
   change: |
-    Fixed a bug where the addresses cannot be updated partially even the reuse port is enabled.
+    Fixed a bug where the addresses cannot be updated partially even if the reuse port is enabled.
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -80,6 +80,9 @@ bug_fixes:
     Before the :scheme header was always 'http'.
     This behavioral change can be temporarily reverted by setting runtime guard
     ``envoy.reloadable_features.jwt_fetcher_use_scheme_from_uri`` to false.
+- area: listener
+  change: |
+    Fixed a bug where the addresses cannot be updated partially even the reuse port is enabled.
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/source/common/listener_manager/listener_impl.cc
+++ b/source/common/listener_manager/listener_impl.cc
@@ -1128,15 +1128,13 @@ bool ListenerImpl::getReusePortOrDefault(Server::Instance& server,
   return initial_reuse_port_value;
 }
 
-bool ListenerImpl::socketOptionsEqual(const ListenerImpl& other) const {
-  return ListenerMessageUtil::socketOptionsEqual(config(), other.config());
-}
-
 bool ListenerImpl::hasCompatibleAddress(const ListenerImpl& other) const {
-  if ((socket_type_ != other.socket_type_) || (addresses_.size() != other.addresses().size())) {
+  // First, check if the listener has the same socket type and the same number of addresses.
+  if (socket_type_ != other.socket_type_ || addresses_.size() != other.addresses().size()) {
     return false;
   }
 
+  // Second, check if the listener has the same addresses.
   // The listener support listening on the zero port address for test. Multiple zero
   // port addresses are also supported. For comparing two listeners with multiple
   // zero port addresses, only need to ensure there are the same number of zero
@@ -1153,17 +1151,12 @@ bool ListenerImpl::hasCompatibleAddress(const ListenerImpl& other) const {
     }
     other_addresses.erase(iter);
   }
-  return true;
+
+  // Third, check if the listener has the same socket options.
+  return ListenerMessageUtil::socketOptionsEqual(config(), other.config());
 }
 
 bool ListenerImpl::hasDuplicatedAddress(const ListenerImpl& other) const {
-  // Skip the duplicate address check if this is the case of a listener update with new socket
-  // options.
-  if ((name_ == other.name_) &&
-      !ListenerMessageUtil::socketOptionsEqual(config(), other.config())) {
-    return false;
-  }
-
   if (socket_type_ != other.socket_type_) {
     return false;
   }

--- a/source/common/listener_manager/listener_impl.h
+++ b/source/common/listener_manager/listener_impl.h
@@ -270,8 +270,6 @@ public:
                                     const envoy::config::listener::v3::Listener& config,
                                     Network::Socket::Type socket_type);
 
-  // Compare whether two listeners have different socket options.
-  bool socketOptionsEqual(const ListenerImpl& other) const;
   // Check whether a new listener can share sockets with this listener.
   bool hasCompatibleAddress(const ListenerImpl& other) const;
   // Check whether a new listener has duplicated listening address this listener.

--- a/source/common/listener_manager/listener_manager_impl.cc
+++ b/source/common/listener_manager/listener_manager_impl.cc
@@ -1143,11 +1143,11 @@ absl::Status ListenerManagerImpl::setNewOrDrainingSocketFactory(const std::strin
   if (hasListenerWithDuplicatedAddress(warming_listeners_, listener) ||
       hasListenerWithDuplicatedAddress(active_listeners_, listener)) {
     const std::string message =
-        fmt::format("error adding listener: '{}' has duplicate address '{}' as existing listener",
+        fmt::format("error adding listener: '{}' has duplicate address '{}' as existing listener, "
+                    "to check if the listener has duplicated addresses with other listeners or "
+                    "'enable_reuse_port' is set to 'false' for the listener",
                     name, absl::StrJoin(listener.addresses(), ",", Network::AddressStrFormatter()));
     ENVOY_LOG(warn, "{}", message);
-    ENVOY_LOG(warn, "To check if the listener has duplicated addresses with other listeners or "
-                    "'enable_reuse_port' is set to 'false' for the listener");
     return absl::InvalidArgumentError(message);
   }
 

--- a/source/common/listener_manager/listener_manager_impl.cc
+++ b/source/common/listener_manager/listener_manager_impl.cc
@@ -640,8 +640,8 @@ bool ListenerManagerImpl::hasListenerWithDuplicatedAddress(const ListenerList& l
     if (listener.reusePort() && existing_listener->name() == listener.name()) {
       // If reuse port is enabled, we can skip the check between different versions of the
       // same listener as they can create their own sockets anyway.
-      // If reuse port is disabled, the duplicated addresses check is necessary to ensure
-      // there is no address conflict between this two versions.
+      // If reuse port is disabled, the duplicated addresses check is necessary to to avoid
+      // attempting to bind to the same address when creating new sockets for the listener.
       continue;
     }
 
@@ -1146,6 +1146,8 @@ absl::Status ListenerManagerImpl::setNewOrDrainingSocketFactory(const std::strin
         fmt::format("error adding listener: '{}' has duplicate address '{}' as existing listener",
                     name, absl::StrJoin(listener.addresses(), ",", Network::AddressStrFormatter()));
     ENVOY_LOG(warn, "{}", message);
+    ENVOY_LOG(warn, "To check if the listener has duplicated addresses with other listeners or "
+                    "'enable_reuse_port' is set to 'false' for the listener");
     return absl::InvalidArgumentError(message);
   }
 

--- a/source/common/listener_manager/listener_manager_impl.cc
+++ b/source/common/listener_manager/listener_manager_impl.cc
@@ -637,11 +637,11 @@ bool ListenerManagerImpl::hasListenerWithDuplicatedAddress(const ListenerList& l
   // Check if the listener has duplicated address with existing listeners.
 
   for (const auto& existing_listener : listener_list) {
-    // If reuse port is enabled, we can skip the check between different versions of the same
-    // listener.
-    // If reuse port is disabled, the duplicated addresses checking is necessary to ensure we
-    // can create new sockets for the new version of the listener as expected.
     if (listener.reusePort() && existing_listener->name() == listener.name()) {
+      // If reuse port is enabled, we can skip the check between different versions of the
+      // same listener as they can create their own sockets anyway.
+      // If reuse port is disabled, the duplicated addresses check is necessary to ensure
+      // there is no address conflict between this two versions.
       continue;
     }
 

--- a/test/common/listener_manager/listener_manager_impl_test.cc
+++ b/test/common/listener_manager/listener_manager_impl_test.cc
@@ -249,7 +249,9 @@ filter_chains:
   addOrUpdateListener(parseListenerFromV3Yaml(yaml1));
   EXPECT_THROW_WITH_MESSAGE(
       addOrUpdateListener(parseListenerFromV3Yaml(yaml2)), EnvoyException,
-      "error adding listener: 'bar' has duplicate address '127.0.0.1:1234' as existing listener");
+      "error adding listener: 'bar' has duplicate address '127.0.0.1:1234' as existing listener, "
+      "to check if the listener has duplicated addresses with other listeners or "
+      "'enable_reuse_port' is set to 'false' for the listener");
 }
 
 TEST_P(ListenerManagerImplWithRealFiltersTest, DuplicateNonIPAddressNotAllowed) {
@@ -276,7 +278,9 @@ filter_chains:
   addOrUpdateListener(parseListenerFromV3Yaml(yaml1));
   EXPECT_THROW_WITH_MESSAGE(
       addOrUpdateListener(parseListenerFromV3Yaml(yaml2)), EnvoyException,
-      "error adding listener: 'bar' has duplicate address '/path' as existing listener");
+      "error adding listener: 'bar' has duplicate address '/path' as existing listener, to check "
+      "if the listener has duplicated addresses with other listeners or 'enable_reuse_port' is set "
+      "to 'false' for the listener");
 }
 
 TEST_P(ListenerManagerImplWithRealFiltersTest, MultipleAddressesDuplicatePortNotAllowed) {
@@ -316,7 +320,9 @@ filter_chains:
   addOrUpdateListener(parseListenerFromV3Yaml(yaml1));
   EXPECT_THROW_WITH_MESSAGE(addOrUpdateListener(parseListenerFromV3Yaml(yaml2)), EnvoyException,
                             "error adding listener: 'bar' has duplicate address "
-                            "'127.0.0.1:1234,127.0.0.3:1234' as existing listener");
+                            "'127.0.0.1:1234,127.0.0.3:1234' as existing listener, to check if the "
+                            "listener has duplicated addresses with other listeners or "
+                            "'enable_reuse_port' is set to 'false' for the listener");
 }
 
 TEST_P(ListenerManagerImplWithRealFiltersTest,
@@ -356,9 +362,11 @@ filter_chains:
   )EOF";
 
   addOrUpdateListener(parseListenerFromV3Yaml(yaml1));
-  EXPECT_THROW_WITH_MESSAGE(addOrUpdateListener(parseListenerFromV3Yaml(yaml2)), EnvoyException,
-                            "error adding listener: 'bar' has duplicate address "
-                            "'127.0.0.1:0,127.0.0.3:0' as existing listener");
+  EXPECT_THROW_WITH_MESSAGE(
+      addOrUpdateListener(parseListenerFromV3Yaml(yaml2)), EnvoyException,
+      "error adding listener: 'bar' has duplicate address "
+      "'127.0.0.1:0,127.0.0.3:0' as existing listener, to check if the listener has duplicated "
+      "addresses with other listeners or 'enable_reuse_port' is set to 'false' for the listener");
 }
 
 TEST_P(ListenerManagerImplWithRealFiltersTest, AllowCreateListenerWithMutipleZeroPorts) {
@@ -401,6 +409,7 @@ filter_chains:
 }
 
 TEST_P(ListenerManagerImplWithRealFiltersTest, AllowAddressesUpdatePartially) {
+  // Update one of the addresses from '127.0.0.2:1000' to '127.0.0.3:2000'.
   const std::string yaml1 = R"EOF(
 name: foo
 address:
@@ -441,6 +450,8 @@ filter_chains:
 
 TEST_P(ListenerManagerImplWithRealFiltersTest,
        AllowUpdateSocketOptionsIfNotDuplicatedEvenReusePortIsDisabled) {
+  // All addresses are different, so it should be allowed to update socket options even
+  // reuse port is disabled.
   const std::string yaml1 = R"EOF(
 name: foo
 address:
@@ -2384,7 +2395,9 @@ filter_chains:
   )EOF";
 
   const std::string expected_error_message =
-      "error adding listener: 'bar' has duplicate address '127.0.0.1:1234' as existing listener";
+      "error adding listener: 'bar' has duplicate address '127.0.0.1:1234' as existing listener, "
+      "to check if the listener has duplicated addresses with other listeners or "
+      "'enable_reuse_port' is set to 'false' for the listener";
   testListenerUpdateWithSocketOptionsChangeRejected(listener_origin, listener_updated,
                                                     expected_error_message);
 }
@@ -3422,7 +3435,9 @@ filter_chains:
   EXPECT_CALL(*listener_bar, onDestroy());
   EXPECT_THROW_WITH_MESSAGE(
       addOrUpdateListener(parseListenerFromV3Yaml(listener_bar_yaml)), EnvoyException,
-      "error adding listener: 'bar' has duplicate address '0.0.0.0:1234' as existing listener");
+      "error adding listener: 'bar' has duplicate address '0.0.0.0:1234' as existing listener, to "
+      "check if the listener has duplicated addresses with other listeners or 'enable_reuse_port' "
+      "is set to 'false' for the listener");
 
   // Move foo to active and then try to add again. This should still fail.
   EXPECT_CALL(*worker_, addListener(_, _, _, _, _));
@@ -3433,7 +3448,9 @@ filter_chains:
   EXPECT_CALL(*listener_bar, onDestroy());
   EXPECT_THROW_WITH_MESSAGE(
       addOrUpdateListener(parseListenerFromV3Yaml(listener_bar_yaml)), EnvoyException,
-      "error adding listener: 'bar' has duplicate address '0.0.0.0:1234' as existing listener");
+      "error adding listener: 'bar' has duplicate address '0.0.0.0:1234' as existing listener, to "
+      "check if the listener has duplicated addresses with other listeners or 'enable_reuse_port' "
+      "is set to 'false' for the listener");
 
   EXPECT_CALL(*listener_foo, onDestroy());
 }

--- a/test/common/listener_manager/listener_manager_impl_test.cc
+++ b/test/common/listener_manager/listener_manager_impl_test.cc
@@ -400,7 +400,7 @@ filter_chains:
   addOrUpdateListener(parseListenerFromV3Yaml(yaml2));
 }
 
-TEST_P(ListenerManagerImplWithRealFiltersTest, AllowAddressesUpdateParitially) {
+TEST_P(ListenerManagerImplWithRealFiltersTest, AllowAddressesUpdatePartially) {
   const std::string yaml1 = R"EOF(
 name: foo
 address:


### PR DESCRIPTION
Commit Message: listener: fixed a bug where the addresses cannot be updated partially
Additional Description:

To close https://github.com/envoyproxy/envoy/issues/37373. The #37373 was opened for a while and there is some related PR try to fixed it. See #37396 #38530. Thanks for the great contribution from @Shikugawa and @bbassingthwaite.

Their works is great and make sense. But I want a clean patch to fixed all LDS updating problems (not only the #37373). The exist logic and checks are pretty confusing and hard to maintain. So, I think we'd better to do complete refactring/clean up rather than only fix the #37373. So, I created this PR.

---

If we treat the addresses self and socket options as a whole entity. The rules of LDS updating of same Listener is pretty simple:
1. If the whole entity is completely same: clone the sockets and no matter reuse port is enabled or not.
2. If the whole entity is completely different: create new sockets and not matter resue port is enabled or not.
3. If the whole entity is partially updated: create new sockets and require reuse port to true.

The conditional duplicated addresses checking (of different versions of same listener) could cover 2 and 3 easily. If the reuse port is enabled, we can skip the check because we can create new sockets anyway. If the resue port is disabled, we need this check and partially updating will be rejected or if all addresses are different, the update still could be accpeted.

Risk Level: mid. core code change. It would be better to let two senior maintainers to check this PR.
Testing: unit.
Docs Changes: n/a.
Release Notes: added.
Platform Specific Features: n/a.