### PR TITLE
Update v8 patch to fix ASAN issue detected by clang-18

### DIFF
--- a/bazel/v8.patch
+++ b/bazel/v8.patch
@@ -71,6 +71,20 @@ index e957c0f..0327669 100644
          }),
          includes = ["include"],
          linkopts = select({
+diff --git a/src/compiler/control-equivalence.cc b/src/compiler/control-equivalence.cc
+index 4649cf0..6fc6e57 100644
+--- a/src/compiler/control-equivalence.cc
++++ b/src/compiler/control-equivalence.cc
+@@ -157,8 +157,8 @@ void ControlEquivalence::RunUndirectedDFS(Node* exit) {
+     // Pop node from stack when done with all inputs and uses.
+     DCHECK(entry.input == node->input_edges().end());
+     DCHECK(entry.use == node->use_edges().end());
+-    DFSPop(stack, node);
+     VisitPost(node, entry.parent_node, entry.direction);
++    DFSPop(stack, node);
+   }
+ }
+ 
 diff --git a/src/wasm/c-api.cc b/src/wasm/c-api.cc
 index 4473e20..65a6ec7 100644
 --- a/src/wasm/c-api.cc


### PR DESCRIPTION
Commit Message:

This is a workaround to help us migrate to clang-18 for Envoy CI. clang-18 detected a "use-after-free" type of issue in v8 code and that fails Envoy CI ASAN runs.

This issue was fixed upstream already (see
https://github.com/v8/v8/commit/df459f0e7eda0d1c50698284aab6f424057e076a) and updating v8 should resolve the problem. However for now I'm working around that with a patch update because:

1. Updating v8 will fix this problem, but might also introduce new issues, so I'd like to finish with clang-18 migration for now and update v8 once clang-18 migration is settled
2. v8 is a bit of special dependency, as Envoy does not use upstream v8 directly but instead relies on some kind of processed version, that's probably one of the reasons why we don't update v8 as often.

NOTE: I filed a bug to consider streamlining v8 updates to work on it once we are done with clang-18 migration:
https://github.com/envoyproxy/envoy/issues/38609

Additional Description:

Related to https://github.com/envoyproxy/envoy/issues/37911 and fixes one of the issues that block clang-18 adoption in Envoy CI (specifically addresses one of the failures in https://github.com/envoyproxy/envoy/pull/38571).

Risk Level: n/a
Testing: running ASAN tests with clang-18
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a

+cc @phlax 