### PR TITLE
clang-tidy: fix error in test_listener_filter.h

### DIFF
--- a/test/integration/filters/test_listener_filter.h
+++ b/test/integration/filters/test_listener_filter.h
@@ -87,7 +87,7 @@ public:
 
 class TestFirstPacketReceivedFilterState : public StreamInfo::FilterState::Object {
 public:
-  explicit TestFirstPacketReceivedFilterState() {}
+  explicit TestFirstPacketReceivedFilterState() = default;
   static const absl::string_view key() { return "test.filter_state.quic_first_packet_received"; }
   void incrementPacketCount() { packet_count_++; }
   void setPacketLength(size_t packet_length) { packet_length_ = packet_length; }


### PR DESCRIPTION
This fixes the clang-tidy error in test_listener_filter.h as in  "use '= default' to define a trivial default constructor".

Contributes to #28566 
