### PR TITLE
Fix Mac CI Build on M1

### DIFF
--- a/test/extensions/network/dns_resolver/apple/apple_dns_impl_test.cc
+++ b/test/extensions/network/dns_resolver/apple/apple_dns_impl_test.cc
@@ -120,7 +120,7 @@ public:
           absl::nullopt) {
     active_dns_query_ =
         resolver_->resolve(address, lookup_family,
-                           [=](DnsResolver::ResolutionStatus status, absl::string_view,
+                           [=, this](DnsResolver::ResolutionStatus status, absl::string_view,
                                std::list<DnsResponse>&& results) -> void {
                              EXPECT_EQ(expected_status, status);
                              if (expected_results) {
@@ -354,7 +354,7 @@ TEST_F(AppleDnsImplTest, DnsIpAddressVersionAllSupportsV4Only) {
 TEST_F(AppleDnsImplTest, DnsIpAddressVersionAllSupportsV6Only) {
   auto* dns_query =
       resolver_->resolve("ipv6.google.com", DnsLookupFamily::All,
-                         [=](DnsResolver::ResolutionStatus status, absl::string_view details,
+                         [=, this](DnsResolver::ResolutionStatus status, absl::string_view details,
                              std::list<DnsResponse>&& results) -> void {
                            EXPECT_EQ(DnsResolver::ResolutionStatus::Completed, status);
                            EXPECT_THAT(details, StartsWith("apple_dns_completed"));
@@ -385,7 +385,7 @@ TEST_F(AppleDnsImplTest, DnsIpAddressVersionV4OnlySupportsV6Only) {
 TEST_F(AppleDnsImplTest, DnsIpAddressVersionV6OnlySupportsV4Only) {
   auto* dns_query =
       resolver_->resolve("ipv4.google.com", DnsLookupFamily::V6Only,
-                         [=](DnsResolver::ResolutionStatus status, absl::string_view details,
+                         [=, this](DnsResolver::ResolutionStatus status, absl::string_view details,
                              std::list<DnsResponse>&& results) -> void {
                            EXPECT_EQ(DnsResolver::ResolutionStatus::Completed, status);
                            EXPECT_THAT(details, StartsWith("apple_dns_completed"));
@@ -403,7 +403,7 @@ TEST_F(AppleDnsImplTest, DnsIpAddressVersionV6OnlySupportsV4Only) {
 TEST_F(AppleDnsImplTest, DnsIpAddressVersionV6OnlySupportsV6Only) {
   auto* dns_query =
       resolver_->resolve("ipv6.google.com", DnsLookupFamily::V6Only,
-                         [=](DnsResolver::ResolutionStatus status, absl::string_view details,
+                         [=, this](DnsResolver::ResolutionStatus status, absl::string_view details,
                              std::list<DnsResponse>&& results) -> void {
                            EXPECT_EQ(DnsResolver::ResolutionStatus::Completed, status);
                            EXPECT_THAT(details, StartsWith("apple_dns_completed"));
@@ -428,7 +428,7 @@ TEST_F(AppleDnsImplTest, DnsIpAddressVersionAutoSupportsV4Only) {
 TEST_F(AppleDnsImplTest, DnsIpAddressVersionAutoSupportsV6Only) {
   auto* dns_query =
       resolver_->resolve("ipv6.google.com", DnsLookupFamily::Auto,
-                         [=](DnsResolver::ResolutionStatus status, absl::string_view details,
+                         [=, this](DnsResolver::ResolutionStatus status, absl::string_view details,
                              std::list<DnsResponse>&& results) -> void {
                            EXPECT_EQ(DnsResolver::ResolutionStatus::Completed, status);
                            EXPECT_THAT(details, StartsWith("apple_dns_completed"));
@@ -453,7 +453,7 @@ TEST_F(AppleDnsImplTest, DnsIpAddressVersionV4PreferredSupportsV4Only) {
 TEST_F(AppleDnsImplTest, DnsIpAddressVersionV4PreferredSupportsV6Only) {
   auto* dns_query =
       resolver_->resolve("ipv6.google.com", DnsLookupFamily::V4Preferred,
-                         [=](DnsResolver::ResolutionStatus status, absl::string_view details,
+                         [=, this](DnsResolver::ResolutionStatus status, absl::string_view details,
                              std::list<DnsResponse>&& results) -> void {
                            EXPECT_EQ(DnsResolver::ResolutionStatus::Completed, status);
                            EXPECT_THAT(details, StartsWith("apple_dns_completed"));

--- a/test/extensions/network/dns_resolver/apple/apple_dns_impl_test.cc
+++ b/test/extensions/network/dns_resolver/apple/apple_dns_impl_test.cc
@@ -121,7 +121,7 @@ public:
     active_dns_query_ =
         resolver_->resolve(address, lookup_family,
                            [=, this](DnsResolver::ResolutionStatus status, absl::string_view,
-                               std::list<DnsResponse>&& results) -> void {
+                                     std::list<DnsResponse>&& results) -> void {
                              EXPECT_EQ(expected_status, status);
                              if (expected_results) {
                                EXPECT_FALSE(results.empty());
@@ -355,7 +355,7 @@ TEST_F(AppleDnsImplTest, DnsIpAddressVersionAllSupportsV6Only) {
   auto* dns_query =
       resolver_->resolve("ipv6.google.com", DnsLookupFamily::All,
                          [=, this](DnsResolver::ResolutionStatus status, absl::string_view details,
-                             std::list<DnsResponse>&& results) -> void {
+                                   std::list<DnsResponse>&& results) -> void {
                            EXPECT_EQ(DnsResolver::ResolutionStatus::Completed, status);
                            EXPECT_THAT(details, StartsWith("apple_dns_completed"));
                            // On v4 only networks, there will be no results.
@@ -386,7 +386,7 @@ TEST_F(AppleDnsImplTest, DnsIpAddressVersionV6OnlySupportsV4Only) {
   auto* dns_query =
       resolver_->resolve("ipv4.google.com", DnsLookupFamily::V6Only,
                          [=, this](DnsResolver::ResolutionStatus status, absl::string_view details,
-                             std::list<DnsResponse>&& results) -> void {
+                                   std::list<DnsResponse>&& results) -> void {
                            EXPECT_EQ(DnsResolver::ResolutionStatus::Completed, status);
                            EXPECT_THAT(details, StartsWith("apple_dns_completed"));
                            for (const auto& result : results) {
@@ -404,7 +404,7 @@ TEST_F(AppleDnsImplTest, DnsIpAddressVersionV6OnlySupportsV6Only) {
   auto* dns_query =
       resolver_->resolve("ipv6.google.com", DnsLookupFamily::V6Only,
                          [=, this](DnsResolver::ResolutionStatus status, absl::string_view details,
-                             std::list<DnsResponse>&& results) -> void {
+                                   std::list<DnsResponse>&& results) -> void {
                            EXPECT_EQ(DnsResolver::ResolutionStatus::Completed, status);
                            EXPECT_THAT(details, StartsWith("apple_dns_completed"));
                            EXPECT_FALSE(results.empty());
@@ -429,7 +429,7 @@ TEST_F(AppleDnsImplTest, DnsIpAddressVersionAutoSupportsV6Only) {
   auto* dns_query =
       resolver_->resolve("ipv6.google.com", DnsLookupFamily::Auto,
                          [=, this](DnsResolver::ResolutionStatus status, absl::string_view details,
-                             std::list<DnsResponse>&& results) -> void {
+                                   std::list<DnsResponse>&& results) -> void {
                            EXPECT_EQ(DnsResolver::ResolutionStatus::Completed, status);
                            EXPECT_THAT(details, StartsWith("apple_dns_completed"));
                            // On v4 only networks, there will be no results.
@@ -454,7 +454,7 @@ TEST_F(AppleDnsImplTest, DnsIpAddressVersionV4PreferredSupportsV6Only) {
   auto* dns_query =
       resolver_->resolve("ipv6.google.com", DnsLookupFamily::V4Preferred,
                          [=, this](DnsResolver::ResolutionStatus status, absl::string_view details,
-                             std::list<DnsResponse>&& results) -> void {
+                                   std::list<DnsResponse>&& results) -> void {
                            EXPECT_EQ(DnsResolver::ResolutionStatus::Completed, status);
                            EXPECT_THAT(details, StartsWith("apple_dns_completed"));
                            // On v4 only networks, there will be no results.


### PR DESCRIPTION
This is similar to #36274

./ci/mac_ci_steps.sh fails with the following error on MacOS M4

```
Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
test/extensions/network/dns_resolver/apple/apple_dns_impl_test.cc:176:51: error: implicit capture of 'this' with a capture default of '=' is deprecated [-Werror,-Wdeprecated-this-capture]
  176 |                                    absl::StrSplit(active_dns_query_->getTraces(), ',');
      |                                                   ^
test/extensions/network/dns_resolver/apple/apple_dns_impl_test.cc:123:29: note: add an explicit capture of 'this' to capture '*this' by reference
  123 |                            [=](DnsResolver::ResolutionStatus status, absl::string_view,
      |                             ^
      |                              , this
test/extensions/network/dns_resolver/apple/apple_dns_impl_test.cc:367:28: error: implicit capture of 'this' with a capture default of '=' is deprecated [-Werror,-Wdeprecated-this-capture]
  367 |                            dispatcher_->exit();
      |                            ^
test/extensions/network/dns_resolver/apple/apple_dns_impl_test.cc:357:27: note: add an explicit capture of 'this' to capture '*this' by reference
  357 |                          [=](DnsResolver::ResolutionStatus status, absl::string_view details,
      |                           ^
      |                            , this
test/extensions/network/dns_resolver/apple/apple_dns_impl_test.cc:397:28: error: implicit capture of 'this' with a capture default of '=' is deprecated [-Werror,-Wdeprecated-this-capture]
  397 |                            dispatcher_->exit();
      |                            ^
test/extensions/network/dns_resolver/apple/apple_dns_impl_test.cc:388:27: note: add an explicit capture of 'this' to capture '*this' by reference
  388 |                          [=](DnsResolver::ResolutionStatus status, absl::string_view details,
      |                           ^
      |                            , this
test/extensions/network/dns_resolver/apple/apple_dns_impl_test.cc:416:28: error: implicit capture of 'this' with a capture default of '=' is deprecated [-Werror,-Wdeprecated-this-capture]
  416 |                            dispatcher_->exit();
      |                            ^
test/extensions/network/dns_resolver/apple/apple_dns_impl_test.cc:406:27: note: add an explicit capture of 'this' to capture '*this' by reference
  406 |                          [=](DnsResolver::ResolutionStatus status, absl::string_view details,
      |                           ^
      |                            , this
test/extensions/network/dns_resolver/apple/apple_dns_impl_test.cc:441:28: error: implicit capture of 'this' with a capture default of '=' is deprecated [-Werror,-Wdeprecated-this-capture]
  441 |                            dispatcher_->exit();
      |                            ^
test/extensions/network/dns_resolver/apple/apple_dns_impl_test.cc:431:27: note: add an explicit capture of 'this' to capture '*this' by reference
  431 |                          [=](DnsResolver::ResolutionStatus status, absl::string_view details,
      |                           ^
      |                            , this
test/extensions/network/dns_resolver/apple/apple_dns_impl_test.cc:466:28: error: implicit capture of 'this' with a capture default of '=' is deprecated [-Werror,-Wdeprecated-this-capture]
  466 |                            dispatcher_->exit();
      |                            ^
test/extensions/network/dns_resolver/apple/apple_dns_impl_test.cc:456:27: note: add an explicit capture of 'this' to capture '*this' by reference
  456 |                          [=](DnsResolver::ResolutionStatus status, absl::string_view details,
      |                           ^
      |                            , this
6 errors generated.
```

**This change based on #36274 fixes the build**

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
