### PR TITLE
Add support Redis custom commands in Redis Proxy

### DIFF
--- a/api/envoy/config/filter/network/redis_proxy/v2/redis_proxy.proto
+++ b/api/envoy/config/filter/network/redis_proxy/v2/redis_proxy.proto
@@ -25,7 +25,7 @@ option (udpa.annotations.file_status).package_version_status = FROZEN;
 // Redis Proxy :ref:`configuration overview <config_network_filters_redis_proxy>`.
 // [#extension: envoy.filters.network.redis_proxy]
 
-// [#next-free-field: 8]
+// [#next-free-field: 7]
 message RedisProxy {
   // Redis connection pool settings.
   // [#next-free-field: 9]
@@ -234,10 +234,6 @@ message RedisProxy {
   // client. If an AUTH command is received when the password is not set, then an "ERR Client sent
   // AUTH, but no password is set" error will be returned.
   api.v2.core.DataSource downstream_auth_password = 6 [(udpa.annotations.sensitive) = true];
-
-  // A List of custom command names already defined on Redis other than the already supported commands,
-  // the list of commands mentioned below will get passed on to Redis.
-  repeated string redis_custom_command_names = 7;
 }
 
 // RedisProtocolOptions specifies Redis upstream protocol options. This object is used in

--- a/api/envoy/config/filter/network/redis_proxy/v2/redis_proxy.proto
+++ b/api/envoy/config/filter/network/redis_proxy/v2/redis_proxy.proto
@@ -25,7 +25,7 @@ option (udpa.annotations.file_status).package_version_status = FROZEN;
 // Redis Proxy :ref:`configuration overview <config_network_filters_redis_proxy>`.
 // [#extension: envoy.filters.network.redis_proxy]
 
-// [#next-free-field: 7]
+// [#next-free-field: 8]
 message RedisProxy {
   // Redis connection pool settings.
   // [#next-free-field: 9]
@@ -234,6 +234,10 @@ message RedisProxy {
   // client. If an AUTH command is received when the password is not set, then an "ERR Client sent
   // AUTH, but no password is set" error will be returned.
   api.v2.core.DataSource downstream_auth_password = 6 [(udpa.annotations.sensitive) = true];
+
+  // A List of custom command names already defined on Redis other than the already supported commands,
+  // the list of commands mentioned below will get passed on to Redis.
+  repeated string redis_custom_command_names = 7;
 }
 
 // RedisProtocolOptions specifies Redis upstream protocol options. This object is used in

--- a/api/envoy/extensions/filters/network/redis_proxy/v3/redis_proxy.proto
+++ b/api/envoy/extensions/filters/network/redis_proxy/v3/redis_proxy.proto
@@ -26,7 +26,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // Redis Proxy :ref:`configuration overview <config_network_filters_redis_proxy>`.
 // [#extension: envoy.filters.network.redis_proxy]
 
-// [#next-free-field: 11]
+// [#next-free-field: 12]
 message RedisProxy {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.network.redis_proxy.v2.RedisProxy";
@@ -363,6 +363,10 @@ message RedisProxy {
   // If this setting is set together with ``downstream_auth_username`` and ``downstream_auth_password``, the external auth service will be source of truth, but those fields will still be used for downstream authentication to the cluster.
   // The API is defined by :ref:`RedisProxyExternalAuthRequest <envoy_v3_api_msg_service.redis_auth.v3.RedisProxyExternalAuthRequest>`.
   RedisExternalAuthProvider external_auth_provider = 10;
+
+  // A List of custom command names already defined on Redis other than the already supported commands,
+// the list of commands mentioned below will get passed on to Redis.
+  repeated string redis_custom_command_names = 11;
 }
 
 // RedisProtocolOptions specifies Redis upstream protocol options. This object is used in

--- a/api/envoy/extensions/filters/network/redis_proxy/v3/redis_proxy.proto
+++ b/api/envoy/extensions/filters/network/redis_proxy/v3/redis_proxy.proto
@@ -365,7 +365,7 @@ message RedisProxy {
   RedisExternalAuthProvider external_auth_provider = 10;
 
   // A List of custom command names already defined on Redis other than the already supported commands,
-// the list of commands mentioned below will get passed on to Redis.
+  // the list of commands mentioned below will get passed on to Redis.
   repeated string redis_custom_command_names = 11;
 }
 

--- a/source/extensions/filters/network/redis_proxy/command_splitter.h
+++ b/source/extensions/filters/network/redis_proxy/command_splitter.h
@@ -96,7 +96,7 @@ public:
   virtual SplitRequestPtr
   makeRequest(Common::Redis::RespValuePtr&& request, SplitCallbacks& callbacks,
               Event::Dispatcher& dispatcher, const StreamInfo::StreamInfo& stream_info,
-              absl::flat_hash_set<std::string> redis_custom_command_names) PURE;
+              const absl::flat_hash_set<std::string>& redis_custom_command_names) PURE;
 };
 
 } // namespace CommandSplitter

--- a/source/extensions/filters/network/redis_proxy/command_splitter.h
+++ b/source/extensions/filters/network/redis_proxy/command_splitter.h
@@ -88,13 +88,15 @@ public:
    * @param callbacks supplies the split request completion callbacks.
    * @param dispatcher supplies dispatcher used for delay fault timer.
    * @param stream_info reference to the stream info used for formatting the key.
+   * @param redis_custom_command_names the list of custom commands supported by Redis.
    * @return SplitRequestPtr a handle to the active request or nullptr if the request has already
    *         been satisfied (via onResponse() being called). The splitter ALWAYS calls
    *         onResponse() for a given request.
    */
   virtual SplitRequestPtr makeRequest(Common::Redis::RespValuePtr&& request,
                                       SplitCallbacks& callbacks, Event::Dispatcher& dispatcher,
-                                      const StreamInfo::StreamInfo& stream_info) PURE;
+                                      const StreamInfo::StreamInfo& stream_info,
+                                      absl::flat_hash_set<std::string> redis_custom_command_names) PURE;
 };
 
 } // namespace CommandSplitter

--- a/source/extensions/filters/network/redis_proxy/command_splitter.h
+++ b/source/extensions/filters/network/redis_proxy/command_splitter.h
@@ -93,10 +93,10 @@ public:
    *         been satisfied (via onResponse() being called). The splitter ALWAYS calls
    *         onResponse() for a given request.
    */
-  virtual SplitRequestPtr makeRequest(Common::Redis::RespValuePtr&& request,
-                                      SplitCallbacks& callbacks, Event::Dispatcher& dispatcher,
-                                      const StreamInfo::StreamInfo& stream_info,
-                                      absl::flat_hash_set<std::string> redis_custom_command_names) PURE;
+  virtual SplitRequestPtr
+  makeRequest(Common::Redis::RespValuePtr&& request, SplitCallbacks& callbacks,
+              Event::Dispatcher& dispatcher, const StreamInfo::StreamInfo& stream_info,
+              absl::flat_hash_set<std::string> redis_custom_command_names) PURE;
 };
 
 } // namespace CommandSplitter

--- a/source/extensions/filters/network/redis_proxy/command_splitter_impl.cc
+++ b/source/extensions/filters/network/redis_proxy/command_splitter_impl.cc
@@ -735,7 +735,7 @@ InstanceImpl::InstanceImpl(RouterPtr&& router, Stats::Scope& scope, const std::s
 SplitRequestPtr
 InstanceImpl::makeRequest(Common::Redis::RespValuePtr&& request, SplitCallbacks& callbacks,
                           Event::Dispatcher& dispatcher, const StreamInfo::StreamInfo& stream_info,
-                          absl::flat_hash_set<std::string> redis_custom_command_names) {
+                          const absl::flat_hash_set<std::string>& redis_custom_command_names) {
   if ((request->type() != Common::Redis::RespType::Array) || request->asArray().empty()) {
     onInvalidRequest(callbacks);
     return nullptr;

--- a/source/extensions/filters/network/redis_proxy/command_splitter_impl.cc
+++ b/source/extensions/filters/network/redis_proxy/command_splitter_impl.cc
@@ -751,8 +751,8 @@ InstanceImpl::makeRequest(Common::Redis::RespValuePtr&& request, SplitCallbacks&
   std::string command_name = absl::AsciiStrToLower(request->asArray()[0].asString());
   // Compatible with redis behavior, if there is an unsupported command, return immediately,
   // this action must be performed before verifying auth, some redis clients rely on this behavior.
-  if (!Common::Redis::SupportedCommands::isSupportedCommand(command_name) ||
-      redis_custom_command_names.contains(command_name)) {
+  if (!Common::Redis::SupportedCommands::isSupportedCommand(command_name) &&
+      !redis_custom_command_names.contains(command_name)) {
     stats_.unsupported_command_.inc();
     callbacks.onResponse(Common::Redis::Utility::makeError(fmt::format(
         "ERR unknown command '{}', with args beginning with: {}", request->asArray()[0].asString(),

--- a/source/extensions/filters/network/redis_proxy/command_splitter_impl.cc
+++ b/source/extensions/filters/network/redis_proxy/command_splitter_impl.cc
@@ -732,10 +732,10 @@ InstanceImpl::InstanceImpl(RouterPtr&& router, Stats::Scope& scope, const std::s
   }
 }
 
-SplitRequestPtr InstanceImpl::makeRequest(Common::Redis::RespValuePtr&& request,
-                                          SplitCallbacks& callbacks, Event::Dispatcher& dispatcher,
-                                          const StreamInfo::StreamInfo& stream_info,
-                                          absl::flat_hash_set<std::string> redis_custom_command_names) {
+SplitRequestPtr
+InstanceImpl::makeRequest(Common::Redis::RespValuePtr&& request, SplitCallbacks& callbacks,
+                          Event::Dispatcher& dispatcher, const StreamInfo::StreamInfo& stream_info,
+                          absl::flat_hash_set<std::string> redis_custom_command_names) {
   if ((request->type() != Common::Redis::RespType::Array) || request->asArray().empty()) {
     onInvalidRequest(callbacks);
     return nullptr;
@@ -751,7 +751,8 @@ SplitRequestPtr InstanceImpl::makeRequest(Common::Redis::RespValuePtr&& request,
   std::string command_name = absl::AsciiStrToLower(request->asArray()[0].asString());
   // Compatible with redis behavior, if there is an unsupported command, return immediately,
   // this action must be performed before verifying auth, some redis clients rely on this behavior.
-  if (!Common::Redis::SupportedCommands::isSupportedCommand(command_name) || redis_custom_command_names.contains(command_name)) {
+  if (!Common::Redis::SupportedCommands::isSupportedCommand(command_name) ||
+      redis_custom_command_names.contains(command_name)) {
     stats_.unsupported_command_.inc();
     callbacks.onResponse(Common::Redis::Utility::makeError(fmt::format(
         "ERR unknown command '{}', with args beginning with: {}", request->asArray()[0].asString(),

--- a/source/extensions/filters/network/redis_proxy/command_splitter_impl.h
+++ b/source/extensions/filters/network/redis_proxy/command_splitter_impl.h
@@ -389,7 +389,8 @@ public:
   // RedisProxy::CommandSplitter::Instance
   SplitRequestPtr makeRequest(Common::Redis::RespValuePtr&& request, SplitCallbacks& callbacks,
                               Event::Dispatcher& dispatcher,
-                              const StreamInfo::StreamInfo& stream_info) override;
+                              const StreamInfo::StreamInfo& stream_info,
+                              absl::flat_hash_set<std::string> redis_custom_command_names) override;
 
 private:
   friend class RedisCommandSplitterImplTest;

--- a/source/extensions/filters/network/redis_proxy/command_splitter_impl.h
+++ b/source/extensions/filters/network/redis_proxy/command_splitter_impl.h
@@ -387,10 +387,10 @@ public:
                Common::Redis::FaultManagerPtr&& fault_manager);
 
   // RedisProxy::CommandSplitter::Instance
-  SplitRequestPtr makeRequest(Common::Redis::RespValuePtr&& request, SplitCallbacks& callbacks,
-                              Event::Dispatcher& dispatcher,
-                              const StreamInfo::StreamInfo& stream_info,
-                              absl::flat_hash_set<std::string> redis_custom_command_names) override;
+  SplitRequestPtr
+  makeRequest(Common::Redis::RespValuePtr&& request, SplitCallbacks& callbacks,
+              Event::Dispatcher& dispatcher, const StreamInfo::StreamInfo& stream_info,
+              const absl::flat_hash_set<std::string>& redis_custom_command_names) override;
 
 private:
   friend class RedisCommandSplitterImplTest;

--- a/source/extensions/filters/network/redis_proxy/proxy_filter.cc
+++ b/source/extensions/filters/network/redis_proxy/proxy_filter.cc
@@ -30,7 +30,7 @@ ProxyFilterConfig::ProxyFilterConfig(
       external_auth_expiration_enabled_(external_auth_enabled_ &&
                                         config.external_auth_provider().enable_auth_expiration()),
       dns_cache_manager_(cache_manager_factory.get()), dns_cache_(getCache(config)),
-      time_source_(time_source) {
+      time_source_(time_source), redis_custom_command_names_(config.redis_custom_command_names()) {
 
   if (config.settings().enable_redirection() && !config.settings().has_dns_cache_config()) {
     ENVOY_LOG(warn, "redirections without DNS lookups enabled might cause client errors, set the "
@@ -123,7 +123,7 @@ void ProxyFilter::onRespValue(Common::Redis::RespValuePtr&& value) {
 void ProxyFilter::processRespValue(Common::Redis::RespValuePtr&& value, PendingRequest& request) {
   CommandSplitter::SplitRequestPtr split =
       splitter_.makeRequest(std::move(value), request, callbacks_->connection().dispatcher(),
-                            callbacks_->connection().streamInfo());
+                            callbacks_->connection().streamInfo(), config_->redis_custom_command_names_);
   if (split) {
     // The splitter can immediately respond and destroy the pending request. Only store the handle
     // if the request is still alive.

--- a/source/extensions/filters/network/redis_proxy/proxy_filter.cc
+++ b/source/extensions/filters/network/redis_proxy/proxy_filter.cc
@@ -30,8 +30,7 @@ ProxyFilterConfig::ProxyFilterConfig(
       external_auth_expiration_enabled_(external_auth_enabled_ &&
                                         config.external_auth_provider().enable_auth_expiration()),
       dns_cache_manager_(cache_manager_factory.get()), dns_cache_(getCache(config)),
-      redis_custom_command_names_(
-        absl::flat_hash_set<std::string>(
+      redis_custom_command_names_(absl::flat_hash_set<std::string>(
           config.redis_custom_command_names().begin(), config.redis_custom_command_names().end())),
       time_source_(time_source) {
 
@@ -124,9 +123,9 @@ void ProxyFilter::onRespValue(Common::Redis::RespValuePtr&& value) {
 }
 
 void ProxyFilter::processRespValue(Common::Redis::RespValuePtr&& value, PendingRequest& request) {
-  CommandSplitter::SplitRequestPtr split =
-      splitter_.makeRequest(std::move(value), request, callbacks_->connection().dispatcher(),
-                            callbacks_->connection().streamInfo(), config_->redis_custom_command_names_);
+  CommandSplitter::SplitRequestPtr split = splitter_.makeRequest(
+      std::move(value), request, callbacks_->connection().dispatcher(),
+      callbacks_->connection().streamInfo(), config_->redis_custom_command_names_);
   if (split) {
     // The splitter can immediately respond and destroy the pending request. Only store the handle
     // if the request is still alive.

--- a/source/extensions/filters/network/redis_proxy/proxy_filter.cc
+++ b/source/extensions/filters/network/redis_proxy/proxy_filter.cc
@@ -30,7 +30,10 @@ ProxyFilterConfig::ProxyFilterConfig(
       external_auth_expiration_enabled_(external_auth_enabled_ &&
                                         config.external_auth_provider().enable_auth_expiration()),
       dns_cache_manager_(cache_manager_factory.get()), dns_cache_(getCache(config)),
-      time_source_(time_source), redis_custom_command_names_(config.redis_custom_command_names()) {
+      redis_custom_command_names_(
+        absl::flat_hash_set<std::string>(
+          config.redis_custom_command_names().begin(), config.redis_custom_command_names().end())),
+      time_source_(time_source) {
 
   if (config.settings().enable_redirection() && !config.settings().has_dns_cache_config()) {
     ENVOY_LOG(warn, "redirections without DNS lookups enabled might cause client errors, set the "

--- a/source/extensions/filters/network/redis_proxy/proxy_filter.h
+++ b/source/extensions/filters/network/redis_proxy/proxy_filter.h
@@ -66,11 +66,12 @@ public:
   TimeSource& timeSource() const { return time_source_; };
   const bool external_auth_enabled_;
   const bool external_auth_expiration_enabled_;
-  const absl::flat_hash_set<std::string> redis_custom_command_names_;
 
   // DNS cache used for ASK/MOVED responses.
   const Extensions::Common::DynamicForwardProxy::DnsCacheManagerSharedPtr dns_cache_manager_;
   const Extensions::Common::DynamicForwardProxy::DnsCacheSharedPtr dns_cache_{nullptr};
+
+  const absl::flat_hash_set<std::string> redis_custom_command_names_;
 
 private:
   static ProxyStats generateStats(const std::string& prefix, Stats::Scope& scope);

--- a/source/extensions/filters/network/redis_proxy/proxy_filter.h
+++ b/source/extensions/filters/network/redis_proxy/proxy_filter.h
@@ -66,6 +66,7 @@ public:
   TimeSource& timeSource() const { return time_source_; };
   const bool external_auth_enabled_;
   const bool external_auth_expiration_enabled_;
+  const absl::flat_hash_set<std::string> redis_custom_command_names_;
 
   // DNS cache used for ASK/MOVED responses.
   const Extensions::Common::DynamicForwardProxy::DnsCacheManagerSharedPtr dns_cache_manager_;

--- a/test/extensions/filters/network/redis_proxy/command_lookup_speed_test.cc
+++ b/test/extensions/filters/network/redis_proxy/command_lookup_speed_test.cc
@@ -65,13 +65,15 @@ public:
     for (const std::string& command : Common::Redis::SupportedCommands::simpleCommands()) {
       Common::Redis::RespValuePtr request{new Common::Redis::RespValue()};
       makeBulkStringArray(*request, {command, "hello"});
-      splitter_.makeRequest(std::move(request), callbacks_, dispatcher_, stream_info_, custom_command_names_);
+      splitter_.makeRequest(std::move(request), callbacks_, dispatcher_, stream_info_,
+                            custom_command_names_);
     }
 
     for (const std::string& command : Common::Redis::SupportedCommands::evalCommands()) {
       Common::Redis::RespValuePtr request{new Common::Redis::RespValue()};
       makeBulkStringArray(*request, {command, "hello"});
-      splitter_.makeRequest(std::move(request), callbacks_, dispatcher_, stream_info_, custom_command_names_);
+      splitter_.makeRequest(std::move(request), callbacks_, dispatcher_, stream_info_,
+                            custom_command_names_);
     }
   }
 

--- a/test/extensions/filters/network/redis_proxy/command_lookup_speed_test.cc
+++ b/test/extensions/filters/network/redis_proxy/command_lookup_speed_test.cc
@@ -65,13 +65,13 @@ public:
     for (const std::string& command : Common::Redis::SupportedCommands::simpleCommands()) {
       Common::Redis::RespValuePtr request{new Common::Redis::RespValue()};
       makeBulkStringArray(*request, {command, "hello"});
-      splitter_.makeRequest(std::move(request), callbacks_, dispatcher_, stream_info_);
+      splitter_.makeRequest(std::move(request), callbacks_, dispatcher_, stream_info_, custom_command_names_);
     }
 
     for (const std::string& command : Common::Redis::SupportedCommands::evalCommands()) {
       Common::Redis::RespValuePtr request{new Common::Redis::RespValue()};
       makeBulkStringArray(*request, {command, "hello"});
-      splitter_.makeRequest(std::move(request), callbacks_, dispatcher_, stream_info_);
+      splitter_.makeRequest(std::move(request), callbacks_, dispatcher_, stream_info_, custom_command_names_);
     }
   }
 
@@ -90,6 +90,7 @@ public:
       std::make_unique<NiceMock<MockFaultManager>>(fault_manager_)};
   NoOpSplitCallbacks callbacks_;
   CommandSplitter::SplitRequestPtr handle_;
+  absl::flat_hash_set<std::string> custom_command_names_;
 };
 
 } // namespace RedisProxy

--- a/test/extensions/filters/network/redis_proxy/mocks.h
+++ b/test/extensions/filters/network/redis_proxy/mocks.h
@@ -142,11 +142,12 @@ public:
   MockInstance();
   ~MockInstance() override;
 
-  SplitRequestPtr makeRequest(Common::Redis::RespValuePtr&& request, SplitCallbacks& callbacks,
-                              Event::Dispatcher& dispatcher,
-                              const StreamInfo::StreamInfo& stream_info,
-                              const absl::flat_hash_set<std::string> redis_custom_command_names) override {
-    return SplitRequestPtr{makeRequest_(*request, callbacks, dispatcher, stream_info, redis_custom_command_names)};
+  SplitRequestPtr
+  makeRequest(Common::Redis::RespValuePtr&& request, SplitCallbacks& callbacks,
+              Event::Dispatcher& dispatcher, const StreamInfo::StreamInfo& stream_info,
+              const absl::flat_hash_set<std::string> redis_custom_command_names) override {
+    return SplitRequestPtr{
+        makeRequest_(*request, callbacks, dispatcher, stream_info, redis_custom_command_names)};
   }
   MOCK_METHOD(SplitRequest*, makeRequest_,
               (const Common::Redis::RespValue& request, SplitCallbacks& callbacks,

--- a/test/extensions/filters/network/redis_proxy/mocks.h
+++ b/test/extensions/filters/network/redis_proxy/mocks.h
@@ -145,7 +145,7 @@ public:
   SplitRequestPtr
   makeRequest(Common::Redis::RespValuePtr&& request, SplitCallbacks& callbacks,
               Event::Dispatcher& dispatcher, const StreamInfo::StreamInfo& stream_info,
-              const absl::flat_hash_set<std::string> redis_custom_command_names) override {
+              const absl::flat_hash_set<std::string>& redis_custom_command_names) override {
     return SplitRequestPtr{
         makeRequest_(*request, callbacks, dispatcher, stream_info, redis_custom_command_names)};
   }

--- a/test/extensions/filters/network/redis_proxy/mocks.h
+++ b/test/extensions/filters/network/redis_proxy/mocks.h
@@ -144,12 +144,14 @@ public:
 
   SplitRequestPtr makeRequest(Common::Redis::RespValuePtr&& request, SplitCallbacks& callbacks,
                               Event::Dispatcher& dispatcher,
-                              const StreamInfo::StreamInfo& stream_info) override {
-    return SplitRequestPtr{makeRequest_(*request, callbacks, dispatcher, stream_info)};
+                              const StreamInfo::StreamInfo& stream_info,
+                              const absl::flat_hash_set<std::string> redis_custom_command_names) override {
+    return SplitRequestPtr{makeRequest_(*request, callbacks, dispatcher, stream_info, redis_custom_command_names)};
   }
   MOCK_METHOD(SplitRequest*, makeRequest_,
               (const Common::Redis::RespValue& request, SplitCallbacks& callbacks,
-               Event::Dispatcher& dispatcher, const StreamInfo::StreamInfo& stream_info));
+               Event::Dispatcher& dispatcher, const StreamInfo::StreamInfo& stream_info,
+               const absl::flat_hash_set<std::string> redis_custom_command_names));
 };
 
 } // namespace CommandSplitter


### PR DESCRIPTION
This change adds the support for providing custom commands defined in Redis as an input to the Redis Proxy filter, the proxy along with all the existing command allows the additional commands provided to be passed as it is to Redis.

Commit Message:
Additional Description:
Risk Level:
Testing: UT
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
Issue: https://github.com/envoyproxy/envoy/issues/37804
Fixes: #37804
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
