### PR TITLE
Workaround coverage issues observed on clang-18

### DIFF
--- a/source/common/buffer/buffer_impl.cc
+++ b/source/common/buffer/buffer_impl.cc
@@ -23,6 +23,28 @@ thread_local absl::InlinedVector<Slice::StoragePtr,
                                  OwnedImpl::OwnedImplReservationSlicesOwnerMultiple::free_list_max_>
     OwnedImpl::OwnedImplReservationSlicesOwnerMultiple::free_list_;
 
+uint64_t Slice::prepend(const void* data, uint64_t size) {
+  const uint8_t* src = static_cast<const uint8_t*>(data);
+  uint64_t copy_size;
+  if (dataSize() == 0) {
+    // There is nothing in the slice, so put the data at the very end in case the caller
+    // later tries to prepend anything else in front of it.
+    copy_size = std::min(size, reservableSize());
+    reservable_ = capacity_;
+    data_ = capacity_ - copy_size;
+  } else {
+    if (data_ == 0) {
+      // There is content in the slice, and no space in front of it to write anything.
+      return 0;
+    }
+    // Write into the space in front of the slice's current content.
+    copy_size = std::min(size, data_);
+    data_ -= copy_size;
+  }
+  memcpy(base_ + data_, src + size - copy_size, copy_size); // NOLINT(safe-memcpy)
+  return copy_size;
+}
+
 void OwnedImpl::addImpl(const void* data, uint64_t size) {
   const char* src = static_cast<const char*>(data);
   bool new_slice_needed = slices_.empty();

--- a/source/common/buffer/buffer_impl.h
+++ b/source/common/buffer/buffer_impl.h
@@ -278,27 +278,7 @@ public:
    * @param size number of bytes to copy.
    * @return number of bytes copied (may be a smaller than size, may even be zero).
    */
-  uint64_t prepend(const void* data, uint64_t size) {
-    const uint8_t* src = static_cast<const uint8_t*>(data);
-    uint64_t copy_size;
-    if (dataSize() == 0) {
-      // There is nothing in the slice, so put the data at the very end in case the caller
-      // later tries to prepend anything else in front of it.
-      copy_size = std::min(size, reservableSize());
-      reservable_ = capacity_;
-      data_ = capacity_ - copy_size;
-    } else {
-      if (data_ == 0) {
-        // There is content in the slice, and no space in front of it to write anything.
-        return 0;
-      }
-      // Write into the space in front of the slice's current content.
-      copy_size = std::min(size, data_);
-      data_ -= copy_size;
-    }
-    memcpy(base_ + data_, src + size - copy_size, copy_size); // NOLINT(safe-memcpy)
-    return copy_size;
-  }
+  uint64_t prepend(const void* data, uint64_t size);
 
   /**
    * Describe the in-memory representation of the slice. For use

--- a/source/common/filter/config_discovery_impl.h
+++ b/source/common/filter/config_discovery_impl.h
@@ -558,24 +558,7 @@ private:
     }
   }
 
-  ProtobufTypes::MessagePtr dumpEcdsFilterConfigs(const Matchers::StringMatcher& name_matcher) {
-    auto config_dump = std::make_unique<envoy::admin::v3::EcdsConfigDump>();
-    for (const auto& subscription : subscriptions_) {
-      const auto& ecds_filter = subscription.second.lock();
-      if (!ecds_filter || !ecds_filter->lastConfig() || !name_matcher.match(ecds_filter->name())) {
-        continue;
-      }
-      envoy::config::core::v3::TypedExtensionConfig filter_config;
-      filter_config.set_name(ecds_filter->name());
-      MessageUtil::packFrom(*filter_config.mutable_typed_config(), *ecds_filter->lastConfig());
-      auto& filter_config_dump = *config_dump->mutable_ecds_filters()->Add();
-      filter_config_dump.mutable_ecds_filter()->PackFrom(filter_config);
-      filter_config_dump.set_version_info(ecds_filter->lastVersionInfo());
-      TimestampUtil::systemClockToTimestamp(ecds_filter->lastUpdated(),
-                                            *(filter_config_dump.mutable_last_updated()));
-    }
-    return config_dump;
-  }
+  ProtobufTypes::MessagePtr dumpEcdsFilterConfigs(const Matchers::StringMatcher& name_matcher);
 
   absl::flat_hash_map<std::string, std::weak_ptr<FilterConfigSubscription>> subscriptions_;
   Server::ConfigTracker::EntryOwnerPtr config_tracker_entry_;

--- a/source/extensions/common/wasm/ext/envoy_proxy_wasm_api.h
+++ b/source/extensions/common/wasm/ext/envoy_proxy_wasm_api.h
@@ -76,7 +76,17 @@ template <typename I> inline uint32_t align(uint32_t i) {
   return (i + sizeof(I) - 1) & ~(sizeof(I) - 1);
 }
 
-inline StatResult parseStatResults(std::string_view data) {
+// Used attribute is used here to work around a coverage issue in clang/llvm:
+// https://github.com/llvm/llvm-project/issues/32849.
+//
+// It's a temporary hack and is not supposed to be a permanent solution.
+// If we address the issue upstream in clang or migrate to static linking for coverage tests
+// we can drop this.
+//
+// Alternative to using used attribute here is to move the function definition to
+// the cc file. However, I didn't go for that, given that it looks that the function
+// was put in the header file intentionally.
+__attribute__((used)) inline StatResult parseStatResults(std::string_view data) {
   StatResult results;
   uint32_t data_len = 0;
   while (data_len < data.length()) {

--- a/source/extensions/filters/network/common/redis/BUILD
+++ b/source/extensions/filters/network/common/redis/BUILD
@@ -37,9 +37,11 @@ envoy_cc_library(
 
 envoy_cc_library(
     name = "supported_commands_lib",
+    srcs = ["supported_commands.cc"],
     hdrs = ["supported_commands.h"],
     deps = [
         "//source/common/common:macros",
+        "@com_google_absl//absl/container:flat_hash_set",
     ],
 )
 

--- a/source/extensions/filters/network/common/redis/supported_commands.cc
+++ b/source/extensions/filters/network/common/redis/supported_commands.cc
@@ -1,0 +1,21 @@
+#include "source/extensions/filters/network/common/redis/supported_commands.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace Common {
+namespace Redis {
+
+bool SupportedCommands::isSupportedCommand(const std::string& command) {
+  return (simpleCommands().contains(command) || evalCommands().contains(command) ||
+          hashMultipleSumResultCommands().contains(command) ||
+          transactionCommands().contains(command) || auth() == command || echo() == command ||
+          mget() == command || mset() == command || keys() == command || ping() == command ||
+          time() == command || quit() == command || select() == command);
+}
+
+} // namespace Redis
+} // namespace Common
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/network/common/redis/supported_commands.h
+++ b/source/extensions/filters/network/common/redis/supported_commands.h
@@ -131,13 +131,7 @@ struct SupportedCommands {
     return !writeCommands().contains(command);
   }
 
-  static bool isSupportedCommand(const std::string& command) {
-    return (simpleCommands().contains(command) || evalCommands().contains(command) ||
-            hashMultipleSumResultCommands().contains(command) ||
-            transactionCommands().contains(command) || auth() == command || echo() == command ||
-            mget() == command || mset() == command || keys() == command || ping() == command ||
-            time() == command || quit() == command || select() == command);
-  }
+  static bool isSupportedCommand(const std::string& command);
 };
 
 } // namespace Redis

--- a/source/extensions/load_balancing_policies/common/load_balancer_impl.cc
+++ b/source/extensions/load_balancing_policies/common/load_balancer_impl.cc
@@ -398,6 +398,21 @@ LoadBalancerBase::chooseHostSet(LoadBalancerContext* context, uint64_t hash) con
           priority_and_source.second};
 }
 
+uint64_t LoadBalancerBase::random(bool peeking) {
+  if (peeking) {
+    stashed_random_.push_back(random_.random());
+    return stashed_random_.back();
+  } else {
+    if (!stashed_random_.empty()) {
+      auto random = stashed_random_.front();
+      stashed_random_.pop_front();
+      return random;
+    } else {
+      return random_.random();
+    }
+  }
+}
+
 ZoneAwareLoadBalancerBase::ZoneAwareLoadBalancerBase(
     const PrioritySet& priority_set, const PrioritySet* local_priority_set, ClusterLbStats& stats,
     Runtime::Loader& runtime, Random::RandomGenerator& random, uint32_t healthy_panic_threshold,

--- a/source/extensions/load_balancing_policies/common/load_balancer_impl.h
+++ b/source/extensions/load_balancing_policies/common/load_balancer_impl.h
@@ -158,20 +158,7 @@ protected:
     return per_priority_load_.degraded_priority_load_.get()[priority];
   }
   bool isInPanic(uint32_t priority) const { return per_priority_panic_[priority]; }
-  uint64_t random(bool peeking) {
-    if (peeking) {
-      stashed_random_.push_back(random_.random());
-      return stashed_random_.back();
-    } else {
-      if (!stashed_random_.empty()) {
-        auto random = stashed_random_.front();
-        stashed_random_.pop_front();
-        return random;
-      } else {
-        return random_.random();
-      }
-    }
-  }
+  uint64_t random(bool peeking);
 
   ClusterLbStats& stats_;
   Runtime::Loader& runtime_;

--- a/source/extensions/load_balancing_policies/subset/subset_lb.cc
+++ b/source/extensions/load_balancing_policies/subset/subset_lb.cc
@@ -871,6 +871,33 @@ void SubsetLoadBalancer::PrioritySubsetImpl::update(uint32_t priority,
   }
 }
 
+void SubsetLoadBalancer::PriorityLbSubset::finalize(uint32_t priority, uint64_t seed) {
+  while (host_sets_.size() <= priority) {
+    host_sets_.push_back({HostHashSet(), HostHashSet()});
+  }
+  auto& [old_hosts, new_hosts] = host_sets_[priority];
+
+  HostVector added;
+  HostVector removed;
+
+  for (const auto& host : old_hosts) {
+    if (new_hosts.count(host) == 0) {
+      removed.emplace_back(host);
+    }
+  }
+
+  for (const auto& host : new_hosts) {
+    if (old_hosts.count(host) == 0) {
+      added.emplace_back(host);
+    }
+  }
+
+  subset_.update(priority, new_hosts, added, removed, seed);
+
+  old_hosts.swap(new_hosts);
+  new_hosts.clear();
+}
+
 SubsetLoadBalancer::LoadBalancerContextWrapper::LoadBalancerContextWrapper(
     LoadBalancerContext* wrapped,
     const std::set<std::string>& filtered_metadata_match_criteria_names)

--- a/source/extensions/load_balancing_policies/subset/subset_lb.h
+++ b/source/extensions/load_balancing_policies/subset/subset_lb.h
@@ -246,32 +246,7 @@ private:
     }
     // Called after pushHost. Update subset by the hosts that pushed in the pushHost. If no any host
     // is pushed then subset_ will be set to empty.
-    void finalize(uint32_t priority, uint64_t seed) override {
-      while (host_sets_.size() <= priority) {
-        host_sets_.push_back({HostHashSet(), HostHashSet()});
-      }
-      auto& [old_hosts, new_hosts] = host_sets_[priority];
-
-      HostVector added;
-      HostVector removed;
-
-      for (const auto& host : old_hosts) {
-        if (new_hosts.count(host) == 0) {
-          removed.emplace_back(host);
-        }
-      }
-
-      for (const auto& host : new_hosts) {
-        if (old_hosts.count(host) == 0) {
-          added.emplace_back(host);
-        }
-      }
-
-      subset_.update(priority, new_hosts, added, removed, seed);
-
-      old_hosts.swap(new_hosts);
-      new_hosts.clear();
-    }
+    void finalize(uint32_t priority, uint64_t seed) override;
 
     bool active() const override { return !subset_.empty(); }
 


### PR DESCRIPTION
Commit Message:

I described the problem with coverage and possible solutions to it in https://github.com/envoyproxy/envoy/issues/37911#issuecomment-2659837724.

TL;DR: clang source-based coverage (which is what we currently use) is subtly broken when dynamic linking is involved (which is what we currently do for coverage tests).

The issue shows itself as lack of coverage of some functions defined in a header file (class members, free-standing inline functions or function temapltes), even though there are tests that cover it.

The issue is a result of a bug in LLVM/Clang/coverage tooling (it's debatable where exactly is the bug fix should be): https://github.com/llvm/llvm-project/issues/32849.

The issue symptoms are not very predictable, and can be affected by a bunch of factors starting from the order of linking and ending with optimization level of the compiler.

Migrating to clang-18 changed enough things that we started to see the issue, even though, from all I know the issue is not specific to clang-18 and exists even in the currently used by Envoy CI clang-14.

There are a few ways to work around/fix the issue, that could be considered:

1. Stop using dynamic linking - this will resolve the issue completely for Envoy codebase, but at the cost of potentially introducing other issues (hustorically Envoy coverage tests didn't use dynamic linking, but we switched to it to deal with some issues)
2. Force Clang to emit code for each function definition it sees even if it does not see it being used, either globally via `-femit-all-decls` compiler flag or locally, on per function basis, marking functions with `used` attribute.
3. Move affected functions from the header files to cc files.

NOTE: There is no upstream fix for the issue in Clang/LLVM, so I'm not mentioning it as an option at the moment.

This change uses a combination of:

1. moving functions from header files to cc files [preferred]
2. marking functions with `used` attribute [when the above is not desirable]

The reason why I didn't go for more generic options are as follows:

1. It's good to move function definitions that don't have to be inlined to a cc file, it reduces build-time dependencies and the amount of work compiler needs to do;
2. The code does not build with `-femig-all-decls` and the build issues are significant enough, so that we cannot just patch our way out; plus it undoes a compiler build-time optimization (e.g., we will basically force the compiler to do work that might not be necessary)
3. We currently cannot use static linking for coverage tests, because it does not work due to relocation overflows (it could be addressed by migrating to clang-18, but on clang-14 it just does not work) and the effects on the Envoy CI are not clear (remember that dynamic linking was introduced to address other issues and we don't want those to return).

The only place where I used `used` attribute instead of moving function definition to a header file was in WASM code where the same code apparently was compiled both into Envoy and into a WASM binary, so I figured we can tolerate a `used` attribute in that case, given how uncommon that setup is. Though, I don't feel particularly strongly about it and can change things.

So this change does not address the issue with coverage completealy, but it improves coverage results on clang-18 significantly enough, where it would not be a concern and we can switch to clang-18. Once we are on clang-18 we are not only going to enjoy more extensive coverage results, but will be in position to consider static linking for coverage tests again to fix the issue permanently for us.

Additional Description:

Related to https://github.com/envoyproxy/envoy/issues/37911 and fixes one of the issues that block clang-18 adoption in Envoy CI (specifically addresses one of the failures in https://github.com/envoyproxy/envoy/pull/38571).

Risk Level: low (no functional changes)
Testing: running coverage tests with clang-18
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a

+cc @phlax 
