### PR TITLE
Fix useragent based request counter for http conn manager

### DIFF
--- a/envoy/access_log/access_log.h
+++ b/envoy/access_log/access_log.h
@@ -15,6 +15,8 @@
 namespace Envoy {
 namespace AccessLog {
 
+using LogContext = Formatter::Context;
+
 class AccessLogFile {
 public:
   virtual ~AccessLogFile() = default;
@@ -59,28 +61,26 @@ using AccessLogManagerPtr = std::unique_ptr<AccessLogManager>;
 using AccessLogType = envoy::data::accesslog::v3::AccessLogType;
 
 /**
- * Templated interface for access log filters.
+ * Interface for access log filters.
  */
-template <class Context> class FilterBase {
+class Filter {
 public:
-  virtual ~FilterBase() = default;
+  virtual ~Filter() = default;
 
   /**
    * Evaluate whether an access log should be written based on request and response data.
    * @return TRUE if the log should be written.
    */
-  virtual bool evaluate(const Context& context, const StreamInfo::StreamInfo& info) const PURE;
+  virtual bool evaluate(const LogContext& context, const StreamInfo::StreamInfo& info) const PURE;
 };
-template <class Context> using FilterBasePtr = std::unique_ptr<FilterBase<Context>>;
+using FilterPtr = std::unique_ptr<Filter>;
 
 /**
- * Templated interface for access log instances.
- * TODO(wbpcode): refactor existing access log instances and related other interfaces to use this
- * interface. See https://github.com/envoyproxy/envoy/issues/28773.
+ * Interface for access log instances.
  */
-template <class Context> class InstanceBase {
+class Instance {
 public:
-  virtual ~InstanceBase() = default;
+  virtual ~Instance() = default;
 
   /**
    * Log a completed request.
@@ -88,20 +88,8 @@ public:
    * @param stream_info supplies additional information about the request not
    * contained in the request headers.
    */
-  virtual void log(const Context& context, const StreamInfo::StreamInfo& stream_info) PURE;
+  virtual void log(const LogContext& context, const StreamInfo::StreamInfo& stream_info) PURE;
 };
-template <class Context> using InstanceBaseSharedPtr = std::shared_ptr<InstanceBase<Context>>;
-
-/**
- * Interface for HTTP access log filters.
- */
-using Filter = FilterBase<Formatter::HttpFormatterContext>;
-using FilterPtr = std::unique_ptr<Filter>;
-
-/**
- * Abstract access logger for HTTP requests and TCP connections.
- */
-using Instance = InstanceBase<Formatter::HttpFormatterContext>;
 using InstanceSharedPtr = std::shared_ptr<Instance>;
 using InstanceSharedPtrVector = std::vector<InstanceSharedPtr>;
 

--- a/envoy/access_log/access_log_config.h
+++ b/envoy/access_log/access_log_config.h
@@ -15,12 +15,8 @@ namespace AccessLog {
 /**
  * Extension filter factory that reads from ExtensionFilter proto.
  */
-template <class Context> class ExtensionFilterFactoryBase : public Config::TypedFactory {
+class ExtensionFilterFactory : public Config::TypedFactory {
 public:
-  ExtensionFilterFactoryBase() : category_(categoryByType()) {}
-
-  ~ExtensionFilterFactoryBase() override = default;
-
   /**
    * Create a particular extension filter implementation from a config proto. If the
    * implementation is unable to produce a filter with the provided parameters, it should throw an
@@ -29,40 +25,18 @@ public:
    * @param context supplies the factory context.
    * @return an instance of extension filter implementation from a config proto.
    */
-  virtual FilterBasePtr<Context>
-  createFilter(const envoy::config::accesslog::v3::ExtensionFilter& config,
-               Server::Configuration::FactoryContext& context) PURE;
+  virtual FilterPtr createFilter(const envoy::config::accesslog::v3::ExtensionFilter& config,
+                                 Server::Configuration::FactoryContext& context) PURE;
 
-  std::string category() const override { return category_; }
-
-private:
-  std::string categoryByType() {
-    if constexpr (std::is_same_v<Context, Formatter::HttpFormatterContext>) {
-      // This is a special case for the HTTP formatter context to ensure backwards compatibility.
-      return "envoy.access_loggers.extension_filters";
-    } else {
-      return fmt::format("envoy.{}.access_loggers.extension_filters", Context::category());
-    }
-  }
-
-  const std::string category_;
+  std::string category() const override { return "envoy.access_loggers.extension_filters"; }
 };
-
-/**
- * Extension filter factory that reads from ExtensionFilter proto.
- */
-using ExtensionFilterFactory = ExtensionFilterFactoryBase<Formatter::HttpFormatterContext>;
 
 /**
  * Implemented for each AccessLog::Instance and registered via Registry::registerFactory or the
  * convenience class RegisterFactory.
  */
-template <class Context> class AccessLogInstanceFactoryBase : public Config::TypedFactory {
+class AccessLogInstanceFactory : public Config::TypedFactory {
 public:
-  AccessLogInstanceFactoryBase() : category_(categoryByType()) {}
-
-  ~AccessLogInstanceFactoryBase() override = default;
-
   /**
    * Create a particular AccessLog::Instance implementation from a config proto. If the
    * implementation is unable to produce a factory with the provided parameters, it should throw an
@@ -74,27 +48,13 @@ public:
    * @param command_parsers vector of command parsers that provide by the caller to be used for
    * parsing custom substitution commands.
    */
-  virtual AccessLog::InstanceBaseSharedPtr<Context> createAccessLogInstance(
-      const Protobuf::Message& config, AccessLog::FilterBasePtr<Context>&& filter,
-      Server::Configuration::FactoryContext& context,
-      std::vector<Formatter::CommandParserBasePtr<Context>>&& command_parsers = {}) PURE;
+  virtual AccessLog::InstanceSharedPtr
+  createAccessLogInstance(const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
+                          Server::Configuration::FactoryContext& context,
+                          std::vector<Formatter::CommandParserPtr>&& command_parsers = {}) PURE;
 
-  std::string category() const override { return category_; }
-
-private:
-  std::string categoryByType() {
-    if constexpr (std::is_same_v<Context, Formatter::HttpFormatterContext>) {
-      // This is a special case for the HTTP formatter context to ensure backwards compatibility.
-      return "envoy.access_loggers";
-    } else {
-      return fmt::format("envoy.{}.access_loggers", Context::category());
-    }
-  }
-
-  const std::string category_;
+  std::string category() const override { return "envoy.access_loggers"; }
 };
-
-using AccessLogInstanceFactory = AccessLogInstanceFactoryBase<Formatter::HttpFormatterContext>;
 
 } // namespace AccessLog
 } // namespace Envoy

--- a/envoy/formatter/substitution_formatter.h
+++ b/envoy/formatter/substitution_formatter.h
@@ -5,18 +5,5 @@
 #include "envoy/http/header_map.h"
 
 namespace Envoy {
-namespace Formatter {
-
-using Formatter = FormatterBase<HttpFormatterContext>;
-using FormatterPtr = std::unique_ptr<Formatter>;
-using FormatterConstSharedPtr = std::shared_ptr<const Formatter>;
-
-using FormatterProvider = FormatterProviderBase<HttpFormatterContext>;
-using FormatterProviderPtr = std::unique_ptr<FormatterProvider>;
-
-using CommandParser = CommandParserBase<HttpFormatterContext>;
-using CommandParserPtr = std::unique_ptr<CommandParser>;
-using CommandParserFactory = CommandParserFactoryBase<HttpFormatterContext>;
-
-} // namespace Formatter
+namespace Formatter {} // namespace Formatter
 } // namespace Envoy

--- a/envoy/formatter/substitution_formatter_base.h
+++ b/envoy/formatter/substitution_formatter_base.h
@@ -6,6 +6,7 @@
 #include "envoy/access_log/access_log.h"
 #include "envoy/common/pure.h"
 #include "envoy/config/typed_config.h"
+#include "envoy/formatter/http_formatter_context.h"
 #include "envoy/registry/registry.h"
 #include "envoy/server/factory_context.h"
 #include "envoy/stream_info/stream_info.h"
@@ -14,11 +15,11 @@ namespace Envoy {
 namespace Formatter {
 
 /**
- * Template interface for multiple protocols/modules formatters.
+ * Interface for multiple protocols/modules formatters.
  */
-template <class FormatterContext> class FormatterBase {
+class Formatter {
 public:
-  virtual ~FormatterBase() = default;
+  virtual ~Formatter() = default;
 
   /**
    * Return a formatted substitution line.
@@ -26,19 +27,19 @@ public:
    * @param stream_info supplies the stream info.
    * @return std::string string containing the complete formatted substitution line.
    */
-  virtual std::string formatWithContext(const FormatterContext& context,
+  virtual std::string formatWithContext(const Context& context,
                                         const StreamInfo::StreamInfo& stream_info) const PURE;
 };
 
-template <class FormatterContext>
-using FormatterBasePtr = std::unique_ptr<FormatterBase<FormatterContext>>;
+using FormatterPtr = std::unique_ptr<Formatter>;
+using FormatterConstSharedPtr = std::shared_ptr<const Formatter>;
 
 /**
- * Template interface for multiple protocols/modules formatter providers.
+ * Interface for multiple protocols/modules formatter providers.
  */
-template <class FormatterContext> class FormatterProviderBase {
+class FormatterProvider {
 public:
-  virtual ~FormatterProviderBase() = default;
+  virtual ~FormatterProvider() = default;
 
   /**
    * Format the value with the given context and stream info.
@@ -48,8 +49,7 @@ public:
    *         the given context and stream info.
    */
   virtual absl::optional<std::string>
-  formatWithContext(const FormatterContext& context,
-                    const StreamInfo::StreamInfo& stream_info) const PURE;
+  formatWithContext(const Context& context, const StreamInfo::StreamInfo& stream_info) const PURE;
 
   /**
    * Format the value with the given context and stream info.
@@ -59,16 +59,15 @@ public:
    *         context and stream info.
    */
   virtual ProtobufWkt::Value
-  formatValueWithContext(const FormatterContext& context,
+  formatValueWithContext(const Context& context,
                          const StreamInfo::StreamInfo& stream_info) const PURE;
 };
 
-template <class FormatterContext>
-using FormatterProviderBasePtr = std::unique_ptr<FormatterProviderBase<FormatterContext>>;
+using FormatterProviderPtr = std::unique_ptr<FormatterProvider>;
 
-template <class FormatterContext> class CommandParserBase {
+class CommandParser {
 public:
-  virtual ~CommandParserBase() = default;
+  virtual ~CommandParser() = default;
 
   /**
    * Return a FormatterProviderBasePtr if command arg and max_length are correct for the formatter
@@ -80,15 +79,13 @@ public:
    *
    * @return FormattterProviderPtr substitution provider for the parsed command.
    */
-  virtual FormatterProviderBasePtr<FormatterContext>
-  parse(absl::string_view command, absl::string_view command_arg,
-        absl::optional<size_t> max_length) const PURE;
+  virtual FormatterProviderPtr parse(absl::string_view command, absl::string_view command_arg,
+                                     absl::optional<size_t> max_length) const PURE;
 };
 
-template <class FormatterContext>
-using CommandParserBasePtr = std::unique_ptr<CommandParserBase<FormatterContext>>;
+using CommandParserPtr = std::unique_ptr<CommandParser>;
 
-template <class FormatterContext> class CommandParserFactoryBase : public Config::TypedFactory {
+class CommandParserFactory : public Config::TypedFactory {
 public:
   /**
    * Creates a particular CommandParser implementation.
@@ -98,40 +95,30 @@ public:
    * @return CommandParserPtr the CommandParser which will be used in
    * SubstitutionFormatParser::parse() when evaluating an access log format string.
    */
-  virtual CommandParserBasePtr<FormatterContext>
+  virtual CommandParserPtr
   createCommandParserFromProto(const Protobuf::Message& config,
                                Server::Configuration::GenericFactoryContext& context) PURE;
 
-  std::string category() const override {
-    static constexpr absl::string_view HttpContextCategory = "http";
-    if constexpr (FormatterContext::category() == HttpContextCategory) {
-      return "envoy.formatter"; // Backward compatibility for HTTP.
-    } else {
-      return fmt::format("envoy.formatters.{}", FormatterContext::category());
-    }
-  }
+  std::string category() const override { return "envoy.formatter"; }
 };
 
-template <class FormatterContext>
-class BuiltInCommandParserFactoryBase : public Config::UntypedFactory {
+class BuiltInCommandParserFactory : public Config::UntypedFactory {
 public:
-  std::string category() const override {
-    return fmt::format("envoy.built_in_formatters.{}", FormatterContext::category());
-  }
+  std::string category() const override { return "envoy.built_in_formatters"; }
 
   /**
    * Creates a particular CommandParser implementation.
    */
-  virtual CommandParserBasePtr<FormatterContext> createCommandParser() const PURE;
+  virtual CommandParserPtr createCommandParser() const PURE;
 };
 
 /**
  * Helper class to get all built-in command parsers for a given formatter context.
  */
-template <class FormatterContext> class BuiltInCommandParserFactoryHelper {
+class BuiltInCommandParserFactoryHelper {
 public:
-  using Factory = BuiltInCommandParserFactoryBase<FormatterContext>;
-  using Parsers = std::vector<CommandParserBasePtr<FormatterContext>>;
+  using Factory = BuiltInCommandParserFactory;
+  using Parsers = std::vector<CommandParserPtr>;
 
   /**
    * Get all built-in command parsers for a given formatter context.
@@ -152,47 +139,6 @@ public:
     }());
   }
 };
-
-/**
- * Type placeholder for formatter providers that only require StreamInfo.
- */
-struct StreamInfoOnlyFormatterContext {
-  static constexpr absl::string_view category() { return "stream_info"; }
-};
-
-/**
- * Template specialization for formatter providers that only require StreamInfo.
- * The only difference from the main template is the providers inheriting from this class
- * will only take StreamInfo as input parameter.
- */
-template <> class FormatterProviderBase<StreamInfoOnlyFormatterContext> {
-public:
-  virtual ~FormatterProviderBase() = default;
-
-  /**
-   * Format the value with the given stream info.
-   * @param stream_info supplies the stream info.
-   * @return absl::optional<std::string> optional string containing a single value extracted from
-   *         the given stream info.
-   */
-  virtual absl::optional<std::string> format(const StreamInfo::StreamInfo& stream_info) const PURE;
-
-  /**
-   * Format the value with the given stream info.
-   * @param stream_info supplies the stream info.
-   * @return ProtobufWkt::Value containing a single value extracted from the given stream info.
-   */
-  virtual ProtobufWkt::Value formatValue(const StreamInfo::StreamInfo& stream_info) const PURE;
-};
-
-using StreamInfoFormatterProvider = FormatterProviderBase<StreamInfoOnlyFormatterContext>;
-using StreamInfoFormatterProviderPtr = FormatterProviderBasePtr<StreamInfoOnlyFormatterContext>;
-using StreamInfoCommandParser = CommandParserBase<StreamInfoOnlyFormatterContext>;
-using StreamInfoCommandParserPtr = CommandParserBasePtr<StreamInfoOnlyFormatterContext>;
-using BuiltInStreamInfoCommandParserFactory =
-    BuiltInCommandParserFactoryBase<StreamInfoOnlyFormatterContext>;
-using BuiltInStreamInfoCommandParserFactoryHelper =
-    BuiltInCommandParserFactoryHelper<StreamInfoOnlyFormatterContext>;
 
 } // namespace Formatter
 } // namespace Envoy

--- a/source/common/formatter/BUILD
+++ b/source/common/formatter/BUILD
@@ -35,6 +35,7 @@ envoy_cc_library(
 
 envoy_cc_library(
     name = "substitution_format_string_lib",
+    srcs = ["substitution_format_string.cc"],
     hdrs = ["substitution_format_string.h"],
     deps = [
         ":substitution_formatter_lib",

--- a/source/common/formatter/http_specific_formatter.cc
+++ b/source/common/formatter/http_specific_formatter.cc
@@ -271,21 +271,6 @@ GrpcStatusFormatter::formatValueWithContext(const HttpFormatterContext& context,
   PANIC_DUE_TO_CORRUPT_ENUM;
 }
 
-StreamInfoRequestHeaderFormatter::StreamInfoRequestHeaderFormatter(
-    const std::string& main_header, const std::string& alternative_header,
-    absl::optional<size_t> max_length)
-    : HeaderFormatter(main_header, alternative_header, max_length) {}
-
-absl::optional<std::string> StreamInfoRequestHeaderFormatter::formatWithContext(
-    const HttpFormatterContext&, const StreamInfo::StreamInfo& stream_info) const {
-  return HeaderFormatter::format(*stream_info.getRequestHeaders());
-}
-
-ProtobufWkt::Value StreamInfoRequestHeaderFormatter::formatValueWithContext(
-    const HttpFormatterContext&, const StreamInfo::StreamInfo& stream_info) const {
-  return HeaderFormatter::formatValue(*stream_info.getRequestHeaders());
-}
-
 QueryParameterFormatter::QueryParameterFormatter(absl::string_view parameter_key,
                                                  absl::optional<size_t> max_length)
     : parameter_key_(parameter_key), max_length_(max_length) {}
@@ -425,7 +410,7 @@ CommandParserPtr DefaultBuiltInHttpCommandParserFactory::createCommandParser() c
   return std::make_unique<BuiltInHttpCommandParser>();
 }
 
-REGISTER_FACTORY(DefaultBuiltInHttpCommandParserFactory, BuiltInHttpCommandParserFactory);
+REGISTER_FACTORY(DefaultBuiltInHttpCommandParserFactory, BuiltInCommandParserFactory);
 
 } // namespace Formatter
 } // namespace Envoy

--- a/source/common/formatter/http_specific_formatter.h
+++ b/source/common/formatter/http_specific_formatter.h
@@ -181,25 +181,6 @@ private:
   const Format format_;
 };
 
-/**
- * FormatterProvider for request headers from StreamInfo (rather than the request_headers param).
- * Purely for testing.
- */
-class StreamInfoRequestHeaderFormatter : public FormatterProvider, HeaderFormatter {
-public:
-  StreamInfoRequestHeaderFormatter(const std::string& main_header,
-                                   const std::string& alternative_header,
-                                   absl::optional<size_t> max_length);
-
-  // FormatterProvider
-  absl::optional<std::string>
-  formatWithContext(const HttpFormatterContext& context,
-                    const StreamInfo::StreamInfo& stream_info) const override;
-  ProtobufWkt::Value
-  formatValueWithContext(const HttpFormatterContext& context,
-                         const StreamInfo::StreamInfo& stream_info) const override;
-};
-
 class QueryParameterFormatter : public FormatterProvider {
 public:
   QueryParameterFormatter(absl::string_view parameter_key, absl::optional<size_t> max_length);
@@ -235,8 +216,7 @@ private:
   static const FormatterProviderLookupTbl& getKnownFormatters();
 };
 
-using BuiltInHttpCommandParserFactory = BuiltInCommandParserFactoryBase<HttpFormatterContext>;
-class DefaultBuiltInHttpCommandParserFactory : public BuiltInHttpCommandParserFactory {
+class DefaultBuiltInHttpCommandParserFactory : public BuiltInCommandParserFactory {
 public:
   std::string name() const override;
   CommandParserPtr createCommandParser() const override;

--- a/source/common/formatter/stream_info_formatter.cc
+++ b/source/common/formatter/stream_info_formatter.cc
@@ -2006,13 +2006,13 @@ const StreamInfoFormatterProviderLookupTable& getKnownStreamInfoFormatterProvide
                          });
 }
 
-class BuiltInStreamInfoCommandParser : public StreamInfoCommandParser {
+class BuiltInStreamInfoCommandParser : public CommandParser {
 public:
   BuiltInStreamInfoCommandParser() = default;
 
-  // StreamInfoCommandParser
-  StreamInfoFormatterProviderPtr parse(absl::string_view command, absl::string_view sub_command,
-                                       absl::optional<size_t> max_length) const override {
+  // CommandParser
+  FormatterProviderPtr parse(absl::string_view command, absl::string_view sub_command,
+                             absl::optional<size_t> max_length) const override {
 
     auto it = getKnownStreamInfoFormatterProviders().find(command);
 
@@ -2033,13 +2033,11 @@ std::string DefaultBuiltInStreamInfoCommandParserFactory::name() const {
   return "envoy.built_in_formatters.stream_info.default";
 }
 
-StreamInfoCommandParserPtr
-DefaultBuiltInStreamInfoCommandParserFactory::createCommandParser() const {
+CommandParserPtr DefaultBuiltInStreamInfoCommandParserFactory::createCommandParser() const {
   return std::make_unique<BuiltInStreamInfoCommandParser>();
 }
 
-REGISTER_FACTORY(DefaultBuiltInStreamInfoCommandParserFactory,
-                 BuiltInStreamInfoCommandParserFactory);
+REGISTER_FACTORY(DefaultBuiltInStreamInfoCommandParserFactory, BuiltInCommandParserFactory);
 
 } // namespace Formatter
 } // namespace Envoy

--- a/source/common/formatter/stream_info_formatter.h
+++ b/source/common/formatter/stream_info_formatter.h
@@ -19,6 +19,36 @@
 namespace Envoy {
 namespace Formatter {
 
+class StreamInfoFormatterProvider : public FormatterProvider {
+public:
+  // FormatterProvider
+  absl::optional<std::string>
+  formatWithContext(const Context&, const StreamInfo::StreamInfo& stream_info) const override {
+    return format(stream_info);
+  }
+  ProtobufWkt::Value
+  formatValueWithContext(const Context&, const StreamInfo::StreamInfo& stream_info) const override {
+    return formatValue(stream_info);
+  }
+
+  /**
+   * Format the value with the given stream info.
+   * @param stream_info supplies the stream info.
+   * @return absl::optional<std::string> optional string containing a single value extracted from
+   *         the given stream info.
+   */
+  virtual absl::optional<std::string> format(const StreamInfo::StreamInfo& stream_info) const PURE;
+
+  /**
+   * Format the value with the given stream info.
+   * @param stream_info supplies the stream info.
+   * @return ProtobufWkt::Value containing a single value extracted from the given stream info.
+   */
+  virtual ProtobufWkt::Value formatValue(const StreamInfo::StreamInfo& stream_info) const PURE;
+};
+
+using StreamInfoFormatterProviderPtr = std::unique_ptr<StreamInfoFormatterProvider>;
+
 using StreamInfoFormatterProviderCreateFunc =
     std::function<StreamInfoFormatterProviderPtr(absl::string_view, absl::optional<size_t>)>;
 
@@ -248,10 +278,10 @@ private:
   ProtobufWkt::Value str_;
 };
 
-class DefaultBuiltInStreamInfoCommandParserFactory : public BuiltInStreamInfoCommandParserFactory {
+class DefaultBuiltInStreamInfoCommandParserFactory : public BuiltInCommandParserFactory {
 public:
   std::string name() const override;
-  StreamInfoCommandParserPtr createCommandParser() const override;
+  CommandParserPtr createCommandParser() const override;
 };
 
 DECLARE_FACTORY(DefaultBuiltInStreamInfoCommandParserFactory);

--- a/source/common/formatter/substitution_format_string.cc
+++ b/source/common/formatter/substitution_format_string.cc
@@ -1,0 +1,78 @@
+#include "source/common/formatter/substitution_format_string.h"
+
+namespace Envoy {
+namespace Formatter {
+
+absl::StatusOr<std::vector<CommandParserPtr>> SubstitutionFormatStringUtils::parseFormatters(
+    const FormattersConfig& formatters, Server::Configuration::GenericFactoryContext& context,
+    std::vector<CommandParserPtr>&& commands_parsers) {
+  std::vector<CommandParserPtr> commands = std::move(commands_parsers);
+  for (const auto& formatter : formatters) {
+    auto* factory = Envoy::Config::Utility::getFactory<CommandParserFactory>(formatter);
+    if (!factory) {
+      return absl::InvalidArgumentError(absl::StrCat("Formatter not found: ", formatter.name()));
+    }
+    auto typed_config = Envoy::Config::Utility::translateAnyToFactoryConfig(
+        formatter.typed_config(), context.messageValidationVisitor(), *factory);
+    auto parser = factory->createCommandParserFromProto(*typed_config, context);
+    if (!parser) {
+      return absl::InvalidArgumentError(
+          absl::StrCat("Failed to create command parser: ", formatter.name()));
+    }
+    commands.push_back(std::move(parser));
+  }
+
+  return commands;
+}
+
+absl::StatusOr<FormatterPtr> SubstitutionFormatStringUtils::fromProtoConfig(
+    const envoy::config::core::v3::SubstitutionFormatString& config,
+    Server::Configuration::GenericFactoryContext& context,
+    std::vector<CommandParserPtr>&& command_parsers) {
+  // Instantiate formatter extensions.
+  auto commands = parseFormatters(config.formatters(), context, std::move(command_parsers));
+  RETURN_IF_NOT_OK_REF(commands.status());
+
+  switch (config.format_case()) {
+  case envoy::config::core::v3::SubstitutionFormatString::FormatCase::kTextFormat:
+    return FormatterImpl::create(config.text_format(), config.omit_empty_values(), *commands);
+  case envoy::config::core::v3::SubstitutionFormatString::FormatCase::kJsonFormat:
+    return createJsonFormatter(
+        config.json_format(), true, config.omit_empty_values(),
+        config.has_json_format_options() ? config.json_format_options().sort_properties() : false,
+        *commands);
+  case envoy::config::core::v3::SubstitutionFormatString::FormatCase::kTextFormatSource: {
+    auto data_source_or_error = Config::DataSource::read(config.text_format_source(), true,
+                                                         context.serverFactoryContext().api());
+    RETURN_IF_NOT_OK(data_source_or_error.status());
+    return FormatterImpl::create(*data_source_or_error, config.omit_empty_values(), *commands);
+  }
+  case envoy::config::core::v3::SubstitutionFormatString::FormatCase::FORMAT_NOT_SET:
+    PANIC_DUE_TO_PROTO_UNSET;
+  }
+
+  return nullptr;
+}
+
+FormatterPtr SubstitutionFormatStringUtils::createJsonFormatter(
+    const ProtobufWkt::Struct& struct_format, bool preserve_types, bool omit_empty_values,
+    bool sort_properties, const std::vector<CommandParserPtr>& commands) {
+
+// TODO(alyssawilk, wbpcode) when deprecating logging_with_fast_json_formatter
+// remove LegacyJsonFormatterImpl and StructFormatterBase
+#ifndef ENVOY_DISABLE_EXCEPTIONS
+  if (!Runtime::runtimeFeatureEnabled(
+          "envoy.reloadable_features.logging_with_fast_json_formatter")) {
+    return std::make_unique<LegacyJsonFormatterImpl>(struct_format, preserve_types,
+                                                     omit_empty_values, sort_properties, commands);
+  }
+#else
+  UNREFERENCED_PARAMETER(preserve_types);
+  UNREFERENCED_PARAMETER(sort_properties);
+#endif
+
+  return std::make_unique<JsonFormatterImpl>(struct_format, omit_empty_values, commands);
+}
+
+} // namespace Formatter
+} // namespace Envoy

--- a/source/common/formatter/substitution_format_string.h
+++ b/source/common/formatter/substitution_format_string.h
@@ -29,92 +29,25 @@ public:
   /**
    * Parse list of formatter configurations to commands.
    */
-  template <class FormatterContext = HttpFormatterContext>
-  static absl::StatusOr<std::vector<CommandParserBasePtr<FormatterContext>>>
+  static absl::StatusOr<std::vector<CommandParserPtr>>
   parseFormatters(const FormattersConfig& formatters,
                   Server::Configuration::GenericFactoryContext& context,
-                  std::vector<CommandParserBasePtr<FormatterContext>> commands_parsers = {}) {
-    std::vector<CommandParserBasePtr<FormatterContext>> commands = std::move(commands_parsers);
-    for (const auto& formatter : formatters) {
-      auto* factory =
-          Envoy::Config::Utility::getFactory<CommandParserFactoryBase<FormatterContext>>(formatter);
-      if (!factory) {
-        return absl::InvalidArgumentError(absl::StrCat("Formatter not found: ", formatter.name()));
-      }
-      auto typed_config = Envoy::Config::Utility::translateAnyToFactoryConfig(
-          formatter.typed_config(), context.messageValidationVisitor(), *factory);
-      auto parser = factory->createCommandParserFromProto(*typed_config, context);
-      if (!parser) {
-        return absl::InvalidArgumentError(
-            absl::StrCat("Failed to create command parser: ", formatter.name()));
-      }
-      commands.push_back(std::move(parser));
-    }
-
-    return commands;
-  }
+                  std::vector<CommandParserPtr>&& commands_parsers = {});
 
   /**
    * Generate a formatter object from config SubstitutionFormatString.
    */
-  template <class FormatterContext = HttpFormatterContext>
-  static absl::StatusOr<FormatterBasePtr<FormatterContext>>
+  static absl::StatusOr<FormatterPtr>
   fromProtoConfig(const envoy::config::core::v3::SubstitutionFormatString& config,
                   Server::Configuration::GenericFactoryContext& context,
-                  std::vector<CommandParserBasePtr<FormatterContext>>&& command_parsers = {}) {
-    // Instantiate formatter extensions.
-    auto commands =
-        parseFormatters<FormatterContext>(config.formatters(), context, std::move(command_parsers));
-    RETURN_IF_NOT_OK_REF(commands.status());
-
-    switch (config.format_case()) {
-    case envoy::config::core::v3::SubstitutionFormatString::FormatCase::kTextFormat:
-      return FormatterBaseImpl<FormatterContext>::create(config.text_format(),
-                                                         config.omit_empty_values(), *commands);
-    case envoy::config::core::v3::SubstitutionFormatString::FormatCase::kJsonFormat:
-      return createJsonFormatter<FormatterContext>(
-          config.json_format(), true, config.omit_empty_values(),
-          config.has_json_format_options() ? config.json_format_options().sort_properties() : false,
-          *commands);
-    case envoy::config::core::v3::SubstitutionFormatString::FormatCase::kTextFormatSource: {
-      auto data_source_or_error = Config::DataSource::read(config.text_format_source(), true,
-                                                           context.serverFactoryContext().api());
-      RETURN_IF_NOT_OK(data_source_or_error.status());
-      return FormatterBaseImpl<FormatterContext>::create(*data_source_or_error,
-                                                         config.omit_empty_values(), *commands);
-    }
-    case envoy::config::core::v3::SubstitutionFormatString::FormatCase::FORMAT_NOT_SET:
-      PANIC_DUE_TO_PROTO_UNSET;
-    }
-
-    return nullptr;
-  }
-
+                  std::vector<CommandParserPtr>&& command_parsers = {});
   /**
    * Generate a Json formatter object from proto::Struct config
    */
-  template <class FormatterContext = HttpFormatterContext>
-  static FormatterBasePtr<FormatterContext>
-  createJsonFormatter(const ProtobufWkt::Struct& struct_format, bool preserve_types,
-                      bool omit_empty_values, bool sort_properties,
-                      const std::vector<CommandParserBasePtr<FormatterContext>>& commands = {}) {
-
-// TODO(alyssawilk, wbpcode) when deprecating logging_with_fast_json_formatter
-// remove LegacyJsonFormatterBaseImpl and StructFormatterBase
-#ifndef ENVOY_DISABLE_EXCEPTIONS
-    if (!Runtime::runtimeFeatureEnabled(
-            "envoy.reloadable_features.logging_with_fast_json_formatter")) {
-      return std::make_unique<LegacyJsonFormatterBaseImpl<FormatterContext>>(
-          struct_format, preserve_types, omit_empty_values, sort_properties, commands);
-    }
-#else
-    UNREFERENCED_PARAMETER(preserve_types);
-    UNREFERENCED_PARAMETER(sort_properties);
-#endif
-
-    return std::make_unique<JsonFormatterImplBase<FormatterContext>>(struct_format,
-                                                                     omit_empty_values, commands);
-  }
+  static FormatterPtr createJsonFormatter(const ProtobufWkt::Struct& struct_format,
+                                          bool preserve_types, bool omit_empty_values,
+                                          bool sort_properties,
+                                          const std::vector<CommandParserPtr>& commands = {});
 };
 
 } // namespace Formatter

--- a/source/common/formatter/substitution_formatter.cc
+++ b/source/common/formatter/substitution_formatter.cc
@@ -3,7 +3,7 @@
 namespace Envoy {
 namespace Formatter {
 
-const re2::RE2& SubstitutionFormatParser::commandWithArgsRegex() {
+const re2::RE2& commandWithArgsRegex() {
   // The following regex is used to check validity of the formatter command and to
   // extract groups.
   // The formatter command has the following format:
@@ -53,6 +53,134 @@ const re2::RE2& SubstitutionFormatParser::commandWithArgsRegex() {
   // LENGTH group is 3.
   // clang-format on
 }
+
+// Helper class to write value to output buffer in JSON style.
+// NOTE: This helper class has duplicated logic with the Json::BufferStreamer class but
+// provides lower level of APIs to operate on the output buffer (like control the
+// delimiters). This is designed for special scenario of substitution formatter and
+// is not intended to be used by other parts of the code.
+class JsonStringSerializer {
+public:
+  using OutputBufferType = Json::StringOutput;
+  explicit JsonStringSerializer(std::string& output_buffer) : output_buffer_(output_buffer) {}
+
+  // Methods that be used to add JSON delimiter to output buffer.
+  void addMapBeginDelimiter() { output_buffer_.add(Json::Constants::MapBegin); }
+  void addMapEndDelimiter() { output_buffer_.add(Json::Constants::MapEnd); }
+  void addArrayBeginDelimiter() { output_buffer_.add(Json::Constants::ArrayBegin); }
+  void addArrayEndDelimiter() { output_buffer_.add(Json::Constants::ArrayEnd); }
+  void addElementsDelimiter() { output_buffer_.add(Json::Constants::Comma); }
+  void addKeyValueDelimiter() { output_buffer_.add(Json::Constants::Colon); }
+
+  // Methods that be used to add JSON key or value to output buffer.
+  void addString(absl::string_view value) { addSanitized(R"(")", value, R"(")"); }
+  /**
+   * Serializes a number.
+   */
+  void addNumber(double d) {
+    if (std::isnan(d)) {
+      output_buffer_.add(Json::Constants::Null);
+    } else {
+      Buffer::Util::serializeDouble(d, output_buffer_);
+    }
+  }
+  /**
+   * Serializes a integer number.
+   * NOTE: All numbers in JSON is float. When loading output of this serializer, the parser's
+   * implementation decides if the full precision of big integer could be preserved or not.
+   * See discussion here https://stackoverflow.com/questions/13502398/json-integers-limit-on-size
+   * and spec https://www.rfc-editor.org/rfc/rfc7159#section-6 for more details.
+   */
+  void addNumber(uint64_t i) { output_buffer_.add(absl::StrCat(i)); }
+  void addNumber(int64_t i) { output_buffer_.add(absl::StrCat(i)); }
+  void addBool(bool b) { output_buffer_.add(b ? Json::Constants::True : Json::Constants::False); }
+  void addNull() { output_buffer_.add(Json::Constants::Null); }
+
+  // Low-level methods that be used to provide a low-level control to buffer.
+  void addSanitized(absl::string_view prefix, absl::string_view value, absl::string_view suffix) {
+    output_buffer_.add(prefix, Json::sanitize(sanitize_buffer_, value), suffix);
+  }
+  void addRawString(absl::string_view value) { output_buffer_.add(value); }
+
+protected:
+  std::string sanitize_buffer_;
+  OutputBufferType output_buffer_;
+};
+
+// Helper class to parse the Json format configuration. The class will be used to parse
+// the JSON format configuration and convert it to a list of raw JSON pieces and
+// substitution format template strings. See comments below for more details.
+class JsonFormatBuilder {
+public:
+  struct FormatElement {
+    // Pre-sanitized JSON piece or a format template string that contains
+    // substitution commands.
+    std::string value_;
+    // Whether the value is a template string.
+    // If true, the value is a format template string that contains substitution commands.
+    // If false, the value is a pre-sanitized JSON piece.
+    bool is_template_;
+  };
+  using FormatElements = std::vector<FormatElement>;
+
+  /**
+   * Constructor of JsonFormatBuilder.
+   */
+  JsonFormatBuilder() = default;
+
+  /**
+   * Convert a proto struct format configuration to an array of raw JSON pieces and
+   * substitution format template strings.
+   *
+   * The keys, raw values, delimiters will be serialized as JSON string pieces (raw
+   * JSON strings) directly when loading the configuration.
+   * The substitution format template strings will be kept as template string pieces and
+   * will be parsed to formatter providers by the JsonFormatter.
+   *
+   * NOTE: This class is used to parse the configuration of the proto struct format
+   * and should only be used in the context of parsing the configuration.
+   *
+   * For example given the following proto struct format configuration:
+   *
+   *   json_format:
+   *     name: "value"
+   *     template: "%START_TIME%"
+   *     number: 2
+   *     bool: true
+   *     list:
+   *       - "list_raw_value"
+   *       - false
+   *       - "%EMIT_TIME%"
+   *     nested:
+   *       nested_name: "nested_value"
+   *
+   * It will be parsed to the following pieces:
+   *
+   *   - '{"name":"value","template":'                                      # Raw JSON piece.
+   *   - '%START_TIME%'                                                     # Format template piece.
+   *   - ',"number":2,"bool":true,"list":["list_raw_value",false,'          # Raw JSON piece.
+   *   - '%EMIT_TIME%'                                                      # Format template piece.
+   *   - '],"nested":{"nested_name":"nested_value"}}'                       # Raw JSON piece.
+   *
+   * Finally, join the raw JSON pieces and output of substitution formatters in order
+   * to construct the final JSON output.
+   *
+   * @param struct_format the proto struct format configuration.
+   */
+  FormatElements fromStruct(const ProtobufWkt::Struct& struct_format);
+
+private:
+  using ProtoDict = Protobuf::Map<std::string, ProtobufWkt::Value>;
+  using ProtoList = Protobuf::RepeatedPtrField<ProtobufWkt::Value>;
+
+  void formatValueToFormatElements(const ProtoDict& dict_value);
+  void formatValueToFormatElements(const ProtobufWkt::Value& value);
+  void formatValueToFormatElements(const ProtoList& list_value);
+
+  std::string buffer_;                       // JSON writer buffer.
+  JsonStringSerializer serializer_{buffer_}; // JSON serializer.
+  FormatElements elements_;                  // Parsed elements.
+};
 
 JsonFormatBuilder::FormatElements
 JsonFormatBuilder::fromStruct(const ProtobufWkt::Struct& struct_format) {
@@ -142,6 +270,183 @@ void JsonFormatBuilder::formatValueToFormatElements(const ProtoDict& dict_value)
     formatValueToFormatElements(sorted_fields[i].second->second);
   }
   serializer_.addMapEndDelimiter(); // Delimiter to end map.
+}
+
+absl::StatusOr<std::vector<FormatterProviderPtr>>
+SubstitutionFormatParser::parse(absl::string_view format,
+                                const std::vector<CommandParserPtr>& command_parsers) {
+  std::string current_token;
+  current_token.reserve(32);
+  std::vector<FormatterProviderPtr> formatters;
+
+  for (size_t pos = 0; pos < format.size();) {
+    if (format[pos] != '%') {
+      current_token.push_back(format[pos]);
+      pos++;
+      continue;
+    }
+
+    // escape '%%'
+    if (format.size() > pos + 1) {
+      if (format[pos + 1] == '%') {
+        current_token.push_back('%');
+        pos += 2;
+        continue;
+      }
+    }
+
+    if (!current_token.empty()) {
+      formatters.emplace_back(FormatterProviderPtr{new PlainStringFormatter(current_token)});
+      current_token.clear();
+    }
+
+    absl::string_view sub_format = format.substr(pos);
+    const size_t sub_format_size = sub_format.size();
+
+    absl::string_view command, command_arg;
+    absl::optional<size_t> max_len;
+
+    if (!re2::RE2::Consume(&sub_format, commandWithArgsRegex(), &command, &command_arg, &max_len)) {
+      return absl::InvalidArgumentError(fmt::format(
+          "Incorrect configuration: {}. Couldn't find valid command at position {}", format, pos));
+    }
+
+    bool added = false;
+
+    // First try the command parsers provided by the user. This allows the user to override
+    // built-in command parsers.
+    for (const auto& cmd : command_parsers) {
+      auto formatter = cmd->parse(command, command_arg, max_len);
+      if (formatter) {
+        formatters.push_back(std::move(formatter));
+        added = true;
+        break;
+      }
+    }
+
+    // Next, try the built-in command parsers.
+    if (!added) {
+      for (const auto& cmd : BuiltInCommandParserFactoryHelper::commandParsers()) {
+        auto formatter = cmd->parse(command, command_arg, max_len);
+        if (formatter) {
+          formatters.push_back(std::move(formatter));
+          added = true;
+          break;
+        }
+      }
+    }
+
+    if (!added) {
+      return absl::InvalidArgumentError(
+          fmt::format("Not supported field in StreamInfo: {}", command));
+    }
+
+    pos += (sub_format_size - sub_format.size());
+  }
+
+  if (!current_token.empty() || format.empty()) {
+    // Create a PlainStringFormatter with the final string literal. If the format string
+    // was empty, this creates a PlainStringFormatter with an empty string.
+    formatters.emplace_back(FormatterProviderPtr{new PlainStringFormatter(current_token)});
+  }
+
+  return formatters;
+}
+
+absl::StatusOr<std::unique_ptr<FormatterImpl>>
+FormatterImpl::create(absl::string_view format, bool omit_empty_values,
+                      const CommandParsers& command_parsers) {
+  absl::Status creation_status = absl::OkStatus();
+  auto ret = std::unique_ptr<FormatterImpl>(
+      new FormatterImpl(creation_status, format, omit_empty_values, command_parsers));
+  RETURN_IF_NOT_OK_REF(creation_status);
+  return ret;
+}
+
+std::string FormatterImpl::formatWithContext(const Context& context,
+                                             const StreamInfo::StreamInfo& stream_info) const {
+  std::string log_line;
+  log_line.reserve(256);
+
+  for (const auto& provider : providers_) {
+    const absl::optional<std::string> bit = provider->formatWithContext(context, stream_info);
+    // Add the formatted value if there is one. Otherwise add a default value
+    // of "-" if omit_empty_values_ is not set.
+    if (bit.has_value()) {
+      log_line += bit.value();
+    } else if (!omit_empty_values_) {
+      log_line += DefaultUnspecifiedValueStringView;
+    }
+  }
+
+  return log_line;
+}
+
+void stringValueToLogLine(const JsonFormatterImpl::Formatters& formatters, const Context& context,
+                          const StreamInfo::StreamInfo& info, JsonStringSerializer& serializer,
+                          bool omit_empty_values) {
+
+  serializer.addRawString(Json::Constants::DoubleQuote); // Start the JSON string.
+  for (const JsonFormatterImpl::Formatter& formatter : formatters) {
+    const absl::optional<std::string> value = formatter->formatWithContext(context, info);
+    if (!value.has_value()) {
+      // Add the empty value. This needn't be sanitized.
+      serializer.addRawString(omit_empty_values ? EMPTY_STRING : DefaultUnspecifiedValueStringView);
+      continue;
+    }
+    // Sanitize the string value and add it to the buffer. The string value will not be quoted
+    // since we handle the quoting by ourselves at the outer level.
+    serializer.addSanitized({}, value.value(), {});
+  }
+  serializer.addRawString(Json::Constants::DoubleQuote); // End the JSON string.
+}
+
+JsonFormatterImpl::JsonFormatterImpl(const ProtobufWkt::Struct& struct_format,
+                                     bool omit_empty_values, const CommandParsers& commands)
+    : omit_empty_values_(omit_empty_values) {
+  for (JsonFormatBuilder::FormatElement& element : JsonFormatBuilder().fromStruct(struct_format)) {
+    if (element.is_template_) {
+      parsed_elements_.emplace_back(
+          THROW_OR_RETURN_VALUE(SubstitutionFormatParser::parse(element.value_, commands),
+                                std::vector<FormatterProviderPtr>));
+    } else {
+      parsed_elements_.emplace_back(std::move(element.value_));
+    }
+  }
+}
+
+std::string JsonFormatterImpl::formatWithContext(const Context& context,
+                                                 const StreamInfo::StreamInfo& info) const {
+  std::string log_line;
+  log_line.reserve(2048);
+  JsonStringSerializer serializer(log_line); // Helper to serialize the value to log line.
+
+  for (const ParsedFormatElement& element : parsed_elements_) {
+    // 1. Handle the raw string element.
+    if (absl::holds_alternative<std::string>(element)) {
+      // The raw string element will be added to the buffer directly.
+      // It is sanitized when loading the configuration.
+      serializer.addRawString(absl::get<std::string>(element));
+      continue;
+    }
+
+    ASSERT(absl::holds_alternative<Formatters>(element));
+    const Formatters& formatters = absl::get<Formatters>(element);
+    ASSERT(!formatters.empty());
+
+    if (formatters.size() != 1) {
+      // 2. Handle the formatter element with multiple or zero providers.
+      stringValueToLogLine(formatters, context, info, serializer, omit_empty_values_);
+    } else {
+      // 3. Handle the formatter element with a single provider and value
+      //    type needs to be kept.
+      auto value = formatters[0]->formatValueWithContext(context, info);
+      Json::Utility::appendValueToString(value, log_line);
+    }
+  }
+
+  log_line.push_back('\n');
+  return log_line;
 }
 
 } // namespace Formatter

--- a/source/common/formatter/substitution_formatter.h
+++ b/source/common/formatter/substitution_formatter.h
@@ -28,17 +28,16 @@ namespace Formatter {
  * FormatterProvider for string literals. It ignores headers and stream info and returns string by
  * which it was initialized.
  */
-template <class FormatterContext>
-class PlainStringFormatterBase : public FormatterProviderBase<FormatterContext> {
+class PlainStringFormatter : public FormatterProvider {
 public:
-  PlainStringFormatterBase(absl::string_view str) { str_.set_string_value(str); }
+  PlainStringFormatter(absl::string_view str) { str_.set_string_value(str); }
 
-  // FormatterProviderBase
-  absl::optional<std::string> formatWithContext(const FormatterContext&,
+  // FormatterProvider
+  absl::optional<std::string> formatWithContext(const Context&,
                                                 const StreamInfo::StreamInfo&) const override {
     return str_.string_value();
   }
-  ProtobufWkt::Value formatValueWithContext(const FormatterContext&,
+  ProtobufWkt::Value formatValueWithContext(const Context&,
                                             const StreamInfo::StreamInfo&) const override {
     return str_;
   }
@@ -50,18 +49,17 @@ private:
 /**
  * FormatterProvider for numbers.
  */
-template <class FormatterContext>
-class PlainNumberFormatterBase : public FormatterProviderBase<FormatterContext> {
+class PlainNumberFormatter : public FormatterProvider {
 public:
-  PlainNumberFormatterBase(double num) { num_.set_number_value(num); }
+  PlainNumberFormatter(double num) { num_.set_number_value(num); }
 
-  // FormatterProviderBase
-  absl::optional<std::string> formatWithContext(const FormatterContext&,
+  // FormatterProvider
+  absl::optional<std::string> formatWithContext(const Context&,
                                                 const StreamInfo::StreamInfo&) const override {
     std::string str = absl::StrFormat("%g", num_.number_value());
     return str;
   }
-  ProtobufWkt::Value formatValueWithContext(const FormatterContext&,
+  ProtobufWkt::Value formatValueWithContext(const Context&,
                                             const StreamInfo::StreamInfo&) const override {
     return num_;
   }
@@ -71,139 +69,12 @@ private:
 };
 
 /**
- * FormatterProvider based on StreamInfo fields.
- */
-template <class FormatterContext>
-class StreamInfoFormatterWrapper : public FormatterProviderBase<FormatterContext> {
-public:
-  StreamInfoFormatterWrapper(StreamInfoFormatterProviderPtr formatter)
-      : formatter_(std::move(formatter)) {}
-
-  // FormatterProvider
-  absl::optional<std::string>
-  formatWithContext(const FormatterContext&,
-                    const StreamInfo::StreamInfo& stream_info) const override {
-    return formatter_->format(stream_info);
-  }
-  ProtobufWkt::Value
-  formatValueWithContext(const FormatterContext&,
-                         const StreamInfo::StreamInfo& stream_info) const override {
-    return formatter_->formatValue(stream_info);
-  }
-
-protected:
-  StreamInfoFormatterProviderPtr formatter_;
-};
-
-/**
  * Access log format parser.
  */
 class SubstitutionFormatParser {
 public:
-  template <class FormatterContext = HttpFormatterContext>
-  static absl::StatusOr<std::vector<FormatterProviderBasePtr<FormatterContext>>>
-  parse(absl::string_view format,
-        const std::vector<CommandParserBasePtr<FormatterContext>>& command_parsers = {}) {
-    std::string current_token;
-    current_token.reserve(32);
-    std::vector<FormatterProviderBasePtr<FormatterContext>> formatters;
-
-    for (size_t pos = 0; pos < format.size();) {
-      if (format[pos] != '%') {
-        current_token.push_back(format[pos]);
-        pos++;
-        continue;
-      }
-
-      // escape '%%'
-      if (format.size() > pos + 1) {
-        if (format[pos + 1] == '%') {
-          current_token.push_back('%');
-          pos += 2;
-          continue;
-        }
-      }
-
-      if (!current_token.empty()) {
-        formatters.emplace_back(FormatterProviderBasePtr<FormatterContext>{
-            new PlainStringFormatterBase<FormatterContext>(current_token)});
-        current_token.clear();
-      }
-
-      absl::string_view sub_format = format.substr(pos);
-      const size_t sub_format_size = sub_format.size();
-
-      absl::string_view command, command_arg;
-      absl::optional<size_t> max_len;
-
-      if (!re2::RE2::Consume(&sub_format, commandWithArgsRegex(), &command, &command_arg,
-                             &max_len)) {
-        return absl::InvalidArgumentError(
-            fmt::format("Incorrect configuration: {}. Couldn't find valid command at position {}",
-                        format, pos));
-      }
-
-      bool added = false;
-
-      // The order of the following parsers is because the historical behavior. And we keep it
-      // for backward compatibility.
-
-      // First, try the built-in command parsers.
-      for (const auto& cmd :
-           BuiltInCommandParserFactoryHelper<FormatterContext>::commandParsers()) {
-        auto formatter = cmd->parse(command, command_arg, max_len);
-        if (formatter) {
-          formatters.push_back(std::move(formatter));
-          added = true;
-          break;
-        }
-      }
-
-      // Next, try the command parsers provided by the user.
-      if (!added) {
-        for (const auto& cmd : command_parsers) {
-          auto formatter = cmd->parse(command, command_arg, max_len);
-          if (formatter) {
-            formatters.push_back(std::move(formatter));
-            added = true;
-            break;
-          }
-        }
-      }
-
-      // Finally, try the command parsers that are built-in and context-independent.
-      if (!added) {
-        for (const auto& cmd : BuiltInStreamInfoCommandParserFactoryHelper::commandParsers()) {
-          auto formatter = cmd->parse(command, command_arg, max_len);
-          if (formatter) {
-            formatters.push_back(std::make_unique<StreamInfoFormatterWrapper<FormatterContext>>(
-                std::move(formatter)));
-            added = true;
-            break;
-          }
-        }
-      }
-
-      if (!added) {
-        return absl::InvalidArgumentError(
-            fmt::format("Not supported field in StreamInfo: {}", command));
-      }
-
-      pos += (sub_format_size - sub_format.size());
-    }
-
-    if (!current_token.empty() || format.empty()) {
-      // Create a PlainStringFormatter with the final string literal. If the format string
-      // was empty, this creates a PlainStringFormatter with an empty string.
-      formatters.emplace_back(FormatterProviderBasePtr<FormatterContext>{
-          new PlainStringFormatterBase<FormatterContext>(current_token)});
-    }
-
-    return formatters;
-  }
-
-private:
-  static const re2::RE2& commandWithArgsRegex();
+  static absl::StatusOr<std::vector<FormatterProviderPtr>>
+  parse(absl::string_view format, const std::vector<CommandParserPtr>& command_parsers = {});
 };
 
 inline constexpr absl::string_view DefaultUnspecifiedValueStringView = "-";
@@ -211,273 +82,50 @@ inline constexpr absl::string_view DefaultUnspecifiedValueStringView = "-";
 /**
  * Composite formatter implementation.
  */
-template <class FormatterContext> class FormatterBaseImpl : public FormatterBase<FormatterContext> {
+class FormatterImpl : public Formatter {
 public:
-  using CommandParsers = std::vector<CommandParserBasePtr<FormatterContext>>;
+  using CommandParsers = std::vector<CommandParserPtr>;
 
-  static absl::StatusOr<std::unique_ptr<FormatterBaseImpl>>
+  static absl::StatusOr<std::unique_ptr<FormatterImpl>>
   create(absl::string_view format, bool omit_empty_values = false,
-         const CommandParsers& command_parsers = {}) {
-    absl::Status creation_status = absl::OkStatus();
-    auto ret = std::unique_ptr<FormatterBaseImpl>(
-        new FormatterBaseImpl(creation_status, format, omit_empty_values, command_parsers));
-    RETURN_IF_NOT_OK_REF(creation_status);
-    return ret;
-  }
+         const CommandParsers& command_parsers = {});
 
-  // FormatterBase
-  std::string formatWithContext(const FormatterContext& context,
-                                const StreamInfo::StreamInfo& stream_info) const override {
-    std::string log_line;
-    log_line.reserve(256);
-
-    for (const auto& provider : providers_) {
-      const absl::optional<std::string> bit = provider->formatWithContext(context, stream_info);
-      // Add the formatted value if there is one. Otherwise add a default value
-      // of "-" if omit_empty_values_ is not set.
-      if (bit.has_value()) {
-        log_line += bit.value();
-      } else if (!omit_empty_values_) {
-        log_line += DefaultUnspecifiedValueStringView;
-      }
-    }
-
-    return log_line;
-  }
+  // Formatter
+  std::string formatWithContext(const Context& context,
+                                const StreamInfo::StreamInfo& stream_info) const override;
 
 protected:
-  FormatterBaseImpl(absl::Status& creation_status, absl::string_view format,
-                    bool omit_empty_values = false)
+  FormatterImpl(absl::Status& creation_status, absl::string_view format,
+                bool omit_empty_values = false, const CommandParsers& command_parsers = {})
       : omit_empty_values_(omit_empty_values) {
-    auto providers_or_error = SubstitutionFormatParser::parse<FormatterContext>(format);
-    SET_AND_RETURN_IF_NOT_OK(providers_or_error.status(), creation_status);
-    providers_ = std::move(*providers_or_error);
-  }
-  FormatterBaseImpl(absl::Status& creation_status, absl::string_view format, bool omit_empty_values,
-                    const CommandParsers& command_parsers = {})
-      : omit_empty_values_(omit_empty_values) {
-    auto providers_or_error =
-        SubstitutionFormatParser::parse<FormatterContext>(format, command_parsers);
+    auto providers_or_error = SubstitutionFormatParser::parse(format, command_parsers);
     SET_AND_RETURN_IF_NOT_OK(providers_or_error.status(), creation_status);
     providers_ = std::move(*providers_or_error);
   }
 
 private:
   const bool omit_empty_values_;
-  std::vector<FormatterProviderBasePtr<FormatterContext>> providers_;
+  std::vector<FormatterProviderPtr> providers_;
 };
 
-// Helper class to write value to output buffer in JSON style.
-// NOTE: This helper class has duplicated logic with the Json::BufferStreamer class but
-// provides lower level of APIs to operate on the output buffer (like control the
-// delimiters). This is designed for special scenario of substitution formatter and
-// is not intended to be used by other parts of the code.
-class JsonStringSerializer {
+class JsonFormatterImpl : public Formatter {
 public:
-  using OutputBufferType = Json::StringOutput;
-  explicit JsonStringSerializer(std::string& output_buffer) : output_buffer_(output_buffer) {}
-
-  // Methods that be used to add JSON delimiter to output buffer.
-  void addMapBeginDelimiter() { output_buffer_.add(Json::Constants::MapBegin); }
-  void addMapEndDelimiter() { output_buffer_.add(Json::Constants::MapEnd); }
-  void addArrayBeginDelimiter() { output_buffer_.add(Json::Constants::ArrayBegin); }
-  void addArrayEndDelimiter() { output_buffer_.add(Json::Constants::ArrayEnd); }
-  void addElementsDelimiter() { output_buffer_.add(Json::Constants::Comma); }
-  void addKeyValueDelimiter() { output_buffer_.add(Json::Constants::Colon); }
-
-  // Methods that be used to add JSON key or value to output buffer.
-  void addString(absl::string_view value) { addSanitized(R"(")", value, R"(")"); }
-  /**
-   * Serializes a number.
-   */
-  void addNumber(double d) {
-    if (std::isnan(d)) {
-      output_buffer_.add(Json::Constants::Null);
-    } else {
-      Buffer::Util::serializeDouble(d, output_buffer_);
-    }
-  }
-  /**
-   * Serializes a integer number.
-   * NOTE: All numbers in JSON is float. When loading output of this serializer, the parser's
-   * implementation decides if the full precision of big integer could be preserved or not.
-   * See discussion here https://stackoverflow.com/questions/13502398/json-integers-limit-on-size
-   * and spec https://www.rfc-editor.org/rfc/rfc7159#section-6 for more details.
-   */
-  void addNumber(uint64_t i) { output_buffer_.add(absl::StrCat(i)); }
-  void addNumber(int64_t i) { output_buffer_.add(absl::StrCat(i)); }
-  void addBool(bool b) { output_buffer_.add(b ? Json::Constants::True : Json::Constants::False); }
-  void addNull() { output_buffer_.add(Json::Constants::Null); }
-
-  // Low-level methods that be used to provide a low-level control to buffer.
-  void addSanitized(absl::string_view prefix, absl::string_view value, absl::string_view suffix) {
-    output_buffer_.add(prefix, Json::sanitize(sanitize_buffer_, value), suffix);
-  }
-  void addRawString(absl::string_view value) { output_buffer_.add(value); }
-
-protected:
-  std::string sanitize_buffer_;
-  OutputBufferType output_buffer_;
-};
-
-// Helper class to parse the Json format configuration. The class will be used to parse
-// the JSON format configuration and convert it to a list of raw JSON pieces and
-// substitution format template strings. See comments below for more details.
-class JsonFormatBuilder {
-public:
-  struct FormatElement {
-    // Pre-sanitized JSON piece or a format template string that contains
-    // substitution commands.
-    std::string value_;
-    // Whether the value is a template string.
-    // If true, the value is a format template string that contains substitution commands.
-    // If false, the value is a pre-sanitized JSON piece.
-    bool is_template_;
-  };
-  using FormatElements = std::vector<FormatElement>;
-
-  /**
-   * Constructor of JsonFormatBuilder.
-   */
-  JsonFormatBuilder() = default;
-
-  /**
-   * Convert a proto struct format configuration to an array of raw JSON pieces and
-   * substitution format template strings.
-   *
-   * The keys, raw values, delimiters will be serialized as JSON string pieces (raw
-   * JSON strings) directly when loading the configuration.
-   * The substitution format template strings will be kept as template string pieces and
-   * will be parsed to formatter providers by the JsonFormatter.
-   *
-   * NOTE: This class is used to parse the configuration of the proto struct format
-   * and should only be used in the context of parsing the configuration.
-   *
-   * For example given the following proto struct format configuration:
-   *
-   *   json_format:
-   *     name: "value"
-   *     template: "%START_TIME%"
-   *     number: 2
-   *     bool: true
-   *     list:
-   *       - "list_raw_value"
-   *       - false
-   *       - "%EMIT_TIME%"
-   *     nested:
-   *       nested_name: "nested_value"
-   *
-   * It will be parsed to the following pieces:
-   *
-   *   - '{"name":"value","template":'                                      # Raw JSON piece.
-   *   - '%START_TIME%'                                                     # Format template piece.
-   *   - ',"number":2,"bool":true,"list":["list_raw_value",false,'          # Raw JSON piece.
-   *   - '%EMIT_TIME%'                                                      # Format template piece.
-   *   - '],"nested":{"nested_name":"nested_value"}}'                       # Raw JSON piece.
-   *
-   * Finally, join the raw JSON pieces and output of substitution formatters in order
-   * to construct the final JSON output.
-   *
-   * @param struct_format the proto struct format configuration.
-   */
-  FormatElements fromStruct(const ProtobufWkt::Struct& struct_format);
-
-private:
-  using ProtoDict = Protobuf::Map<std::string, ProtobufWkt::Value>;
-  using ProtoList = Protobuf::RepeatedPtrField<ProtobufWkt::Value>;
-
-  void formatValueToFormatElements(const ProtoDict& dict_value);
-  void formatValueToFormatElements(const ProtobufWkt::Value& value);
-  void formatValueToFormatElements(const ProtoList& list_value);
-
-  std::string buffer_;                       // JSON writer buffer.
-  JsonStringSerializer serializer_{buffer_}; // JSON serializer.
-  FormatElements elements_;                  // Parsed elements.
-};
-
-template <class FormatterContext>
-class JsonFormatterImplBase : public FormatterBase<FormatterContext> {
-public:
-  using CommandParsers = std::vector<CommandParserBasePtr<FormatterContext>>;
-  using Formatter = FormatterProviderBasePtr<FormatterContext>;
+  using CommandParsers = std::vector<CommandParserPtr>;
+  using Formatter = FormatterProviderPtr;
   using Formatters = std::vector<Formatter>;
 
-  JsonFormatterImplBase(const ProtobufWkt::Struct& struct_format, bool omit_empty_values,
-                        const CommandParsers& commands = {})
-      : omit_empty_values_(omit_empty_values) {
-    for (JsonFormatBuilder::FormatElement& element :
-         JsonFormatBuilder().fromStruct(struct_format)) {
-      if (element.is_template_) {
-        parsed_elements_.emplace_back(THROW_OR_RETURN_VALUE(
-            SubstitutionFormatParser::parse<FormatterContext>(element.value_, commands),
-            std::vector<FormatterProviderBasePtr<FormatterContext>>));
-      } else {
-        parsed_elements_.emplace_back(std::move(element.value_));
-      }
-    }
-  }
+  JsonFormatterImpl(const ProtobufWkt::Struct& struct_format, bool omit_empty_values,
+                    const CommandParsers& commands = {});
 
-  std::string formatWithContext(const FormatterContext& context,
-                                const StreamInfo::StreamInfo& info) const override {
-    std::string log_line;
-    log_line.reserve(2048);
-    JsonStringSerializer serializer(log_line); // Helper to serialize the value to log line.
-
-    for (const ParsedFormatElement& element : parsed_elements_) {
-      // 1. Handle the raw string element.
-      if (absl::holds_alternative<std::string>(element)) {
-        // The raw string element will be added to the buffer directly.
-        // It is sanitized when loading the configuration.
-        serializer.addRawString(absl::get<std::string>(element));
-        continue;
-      }
-
-      ASSERT(absl::holds_alternative<Formatters>(element));
-      const Formatters& formatters = absl::get<Formatters>(element);
-      ASSERT(!formatters.empty());
-
-      if (formatters.size() != 1) {
-        // 2. Handle the formatter element with multiple or zero providers.
-        stringValueToLogLine(formatters, context, info, serializer);
-      } else {
-        // 3. Handle the formatter element with a single provider and value
-        //    type needs to be kept.
-        auto value = formatters[0]->formatValueWithContext(context, info);
-        Json::Utility::appendValueToString(value, log_line);
-      }
-    }
-
-    log_line.push_back('\n');
-    return log_line;
-  }
+  // Formatter
+  std::string formatWithContext(const Context& context,
+                                const StreamInfo::StreamInfo& info) const override;
 
 private:
-  void stringValueToLogLine(const Formatters& formatters, const FormatterContext& context,
-                            const StreamInfo::StreamInfo& info,
-                            JsonStringSerializer& serializer) const {
-
-    serializer.addRawString(Json::Constants::DoubleQuote); // Start the JSON string.
-    for (const Formatter& formatter : formatters) {
-      const absl::optional<std::string> value = formatter->formatWithContext(context, info);
-      if (!value.has_value()) {
-        // Add the empty value. This needn't be sanitized.
-        serializer.addRawString(omit_empty_values_ ? EMPTY_STRING
-                                                   : DefaultUnspecifiedValueStringView);
-        continue;
-      }
-      // Sanitize the string value and add it to the buffer. The string value will not be quoted
-      // since we handle the quoting by ourselves at the outer level.
-      serializer.addSanitized({}, value.value(), {});
-    }
-    serializer.addRawString(Json::Constants::DoubleQuote); // End the JSON string.
-  }
-
   const bool omit_empty_values_;
   using ParsedFormatElement = absl::variant<std::string, Formatters>;
   std::vector<ParsedFormatElement> parsed_elements_;
 };
-
-using JsonFormatterImpl = JsonFormatterImplBase<HttpFormatterContext>;
 
 // Helper classes for StructFormatter::StructFormatMapVisitor.
 template <class... Ts> struct StructFormatMapVisitorHelper : Ts... { using Ts::operator()...; };
@@ -488,27 +136,27 @@ template <class... Ts> StructFormatMapVisitorHelper(Ts...) -> StructFormatMapVis
  * An formatter for structured log formats, which returns a Struct proto that
  * can be converted easily into multiple formats.
  */
-template <class FormatterContext> class StructFormatterBase {
+class StructFormatter {
 public:
-  using CommandParsers = std::vector<CommandParserBasePtr<FormatterContext>>;
-  using PlainNumber = PlainNumberFormatterBase<FormatterContext>;
-  using PlainString = PlainStringFormatterBase<FormatterContext>;
+  using CommandParsers = std::vector<CommandParserPtr>;
+  using PlainNumber = PlainNumberFormatter;
+  using PlainString = PlainStringFormatter;
 
-  StructFormatterBase(const ProtobufWkt::Struct& format_mapping, bool preserve_types,
-                      bool omit_empty_values, const CommandParsers& commands = {})
+  StructFormatter(const ProtobufWkt::Struct& format_mapping, bool preserve_types,
+                  bool omit_empty_values, const CommandParsers& commands = {})
       : omit_empty_values_(omit_empty_values), preserve_types_(preserve_types),
         struct_output_format_(FormatBuilder(commands).toFormatMapValue(format_mapping)) {}
 
-  ProtobufWkt::Struct formatWithContext(const FormatterContext& context,
+  ProtobufWkt::Struct formatWithContext(const Context& context,
                                         const StreamInfo::StreamInfo& info) const {
     StructFormatMapVisitor visitor{
-        [&](const std::vector<FormatterProviderBasePtr<FormatterContext>>& providers) {
+        [&](const std::vector<FormatterProviderPtr>& providers) {
           return providersCallback(providers, context, info);
         },
-        [&, this](const StructFormatterBase::StructFormatMapWrapper& format_map) {
+        [&, this](const StructFormatter::StructFormatMapWrapper& format_map) {
           return structFormatMapCallback(format_map, visitor);
         },
-        [&, this](const StructFormatterBase::StructFormatListWrapper& format_list) {
+        [&, this](const StructFormatter::StructFormatListWrapper& format_list) {
           return structFormatListCallback(format_list, visitor);
         },
     };
@@ -519,8 +167,8 @@ private:
   struct StructFormatMapWrapper;
   struct StructFormatListWrapper;
   using StructFormatValue =
-      absl::variant<const std::vector<FormatterProviderBasePtr<FormatterContext>>,
-                    const StructFormatMapWrapper, const StructFormatListWrapper>;
+      absl::variant<const std::vector<FormatterProviderPtr>, const StructFormatMapWrapper,
+                    const StructFormatListWrapper>;
   // Although not required for Struct/JSON, it is nice to have the order of
   // properties preserved between the format and the log entry, thus std::map.
   using StructFormatMap = std::map<std::string, StructFormatValue>;
@@ -536,23 +184,21 @@ private:
   };
 
   using StructFormatMapVisitor = StructFormatMapVisitorHelper<
-      const std::function<ProtobufWkt::Value(
-          const std::vector<FormatterProviderBasePtr<FormatterContext>>&)>,
-      const std::function<ProtobufWkt::Value(const StructFormatterBase::StructFormatMapWrapper&)>,
-      const std::function<ProtobufWkt::Value(const StructFormatterBase::StructFormatListWrapper&)>>;
+      const std::function<ProtobufWkt::Value(const std::vector<FormatterProviderPtr>&)>,
+      const std::function<ProtobufWkt::Value(const StructFormatter::StructFormatMapWrapper&)>,
+      const std::function<ProtobufWkt::Value(const StructFormatter::StructFormatListWrapper&)>>;
 
   // Methods for building the format map.
   class FormatBuilder {
   public:
     explicit FormatBuilder(const CommandParsers& commands) : commands_(commands) {}
-    absl::StatusOr<std::vector<FormatterProviderBasePtr<FormatterContext>>>
+    absl::StatusOr<std::vector<FormatterProviderPtr>>
     toFormatStringValue(const std::string& string_format) const {
-      return SubstitutionFormatParser::parse<FormatterContext>(string_format, commands_);
+      return SubstitutionFormatParser::parse(string_format, commands_);
     }
-    std::vector<FormatterProviderBasePtr<FormatterContext>>
-    toFormatNumberValue(double value) const {
-      std::vector<FormatterProviderBasePtr<FormatterContext>> formatters;
-      formatters.emplace_back(FormatterProviderBasePtr<FormatterContext>{new PlainNumber(value)});
+    std::vector<FormatterProviderPtr> toFormatNumberValue(double value) const {
+      std::vector<FormatterProviderPtr> formatters;
+      formatters.emplace_back(FormatterProviderPtr{new PlainNumber(value)});
       return formatters;
     }
     StructFormatMapWrapper toFormatMapValue(const ProtobufWkt::Struct& struct_format) const {
@@ -560,9 +206,9 @@ private:
       for (const auto& pair : struct_format.fields()) {
         switch (pair.second.kind_case()) {
         case ProtobufWkt::Value::kStringValue:
-          output->emplace(pair.first, THROW_OR_RETURN_VALUE(
-                                          toFormatStringValue(pair.second.string_value()),
-                                          std::vector<FormatterProviderBasePtr<FormatterContext>>));
+          output->emplace(pair.first,
+                          THROW_OR_RETURN_VALUE(toFormatStringValue(pair.second.string_value()),
+                                                std::vector<FormatterProviderPtr>));
           break;
 
         case ProtobufWkt::Value::kStructValue:
@@ -590,9 +236,8 @@ private:
       for (const auto& value : list_value_format.values()) {
         switch (value.kind_case()) {
         case ProtobufWkt::Value::kStringValue:
-          output->emplace_back(
-              THROW_OR_RETURN_VALUE(toFormatStringValue(value.string_value()),
-                                    std::vector<FormatterProviderBasePtr<FormatterContext>>));
+          output->emplace_back(THROW_OR_RETURN_VALUE(toFormatStringValue(value.string_value()),
+                                                     std::vector<FormatterProviderPtr>));
           break;
 
         case ProtobufWkt::Value::kStructValue:
@@ -621,10 +266,9 @@ private:
   };
 
   // Methods for doing the actual formatting.
-  ProtobufWkt::Value
-  providersCallback(const std::vector<FormatterProviderBasePtr<FormatterContext>>& providers,
-                    const FormatterContext& context,
-                    const StreamInfo::StreamInfo& stream_info) const {
+  ProtobufWkt::Value providersCallback(const std::vector<FormatterProviderPtr>& providers,
+                                       const Context& context,
+                                       const StreamInfo::StreamInfo& stream_info) const {
     ASSERT(!providers.empty());
     if (providers.size() == 1) {
       const auto& provider = providers.front();
@@ -660,7 +304,7 @@ private:
     return ValueUtil::stringValue(str);
   }
   ProtobufWkt::Value
-  structFormatMapCallback(const StructFormatterBase::StructFormatMapWrapper& format_map,
+  structFormatMapCallback(const StructFormatter::StructFormatMapWrapper& format_map,
                           const StructFormatMapVisitor& visitor) const {
     ProtobufWkt::Struct output;
     auto* fields = output.mutable_fields();
@@ -677,7 +321,7 @@ private:
     return ValueUtil::structValue(output);
   }
   ProtobufWkt::Value
-  structFormatListCallback(const StructFormatterBase::StructFormatListWrapper& format_list,
+  structFormatListCallback(const StructFormatter::StructFormatListWrapper& format_list,
                            const StructFormatMapVisitor& visitor) const {
     std::vector<ProtobufWkt::Value> output;
     for (const auto& val : *format_list.value_) {
@@ -696,22 +340,20 @@ private:
   const StructFormatMapWrapper struct_output_format_;
 };
 
-template <class FormatterContext>
-using StructFormatterBasePtr = std::unique_ptr<StructFormatterBase<FormatterContext>>;
+using StructFormatterPtr = std::unique_ptr<StructFormatter>;
 
-template <class FormatterContext>
-class LegacyJsonFormatterBaseImpl : public FormatterBase<FormatterContext> {
+class LegacyJsonFormatterImpl : public Formatter {
 public:
-  using CommandParsers = std::vector<CommandParserBasePtr<FormatterContext>>;
+  using CommandParsers = std::vector<CommandParserPtr>;
 
-  LegacyJsonFormatterBaseImpl(const ProtobufWkt::Struct& format_mapping, bool preserve_types,
-                              bool omit_empty_values, bool sort_properties,
-                              const CommandParsers& commands = {})
+  LegacyJsonFormatterImpl(const ProtobufWkt::Struct& format_mapping, bool preserve_types,
+                          bool omit_empty_values, bool sort_properties,
+                          const CommandParsers& commands = {})
       : struct_formatter_(format_mapping, preserve_types, omit_empty_values, commands),
         sort_properties_(sort_properties) {}
 
-  // FormatterBase
-  std::string formatWithContext(const FormatterContext& context,
+  // Formatter
+  std::string formatWithContext(const Context& context,
                                 const StreamInfo::StreamInfo& info) const override {
     const ProtobufWkt::Struct output_struct = struct_formatter_.formatWithContext(context, info);
 
@@ -730,17 +372,11 @@ public:
   }
 
 private:
-  const StructFormatterBase<FormatterContext> struct_formatter_;
+  const StructFormatter struct_formatter_;
   const bool sort_properties_;
 };
 
-using StructFormatter = StructFormatterBase<HttpFormatterContext>;
-using StructFormatterPtr = std::unique_ptr<StructFormatter>;
-using LegacyJsonFormatterImpl = LegacyJsonFormatterBaseImpl<HttpFormatterContext>;
 #endif // ENVOY_DISABLE_EXCEPTIONS
-
-// Aliases for backwards compatibility.
-using FormatterImpl = FormatterBaseImpl<HttpFormatterContext>;
 
 } // namespace Formatter
 } // namespace Envoy

--- a/source/common/http/user_agent.cc
+++ b/source/common/http/user_agent.cc
@@ -41,7 +41,6 @@ UserAgentStats::UserAgentStats(Stats::StatName prefix, Stats::StatName device, S
           scope, {prefix, device, context.downstream_cx_length_ms_},
           Stats::Histogram::Unit::Milliseconds)) {
   downstream_cx_total_.inc();
-  downstream_rq_total_.inc();
 }
 
 void UserAgent::initializeFromHeaders(const RequestHeaderMap& headers, Stats::StatName prefix,
@@ -58,6 +57,9 @@ void UserAgent::initializeFromHeaders(const RequestHeaderMap& headers, Stats::St
         stats_ = std::make_unique<UserAgentStats>(prefix, context_.android_, scope, context_);
       }
     }
+  }
+  if (stats_ != nullptr) {
+    stats_->downstream_rq_total_.inc();
   }
 }
 

--- a/source/common/http/user_agent.h
+++ b/source/common/http/user_agent.h
@@ -63,7 +63,8 @@ public:
 
   /**
    * Initialize the user agent from request headers. This is only done once and the user-agent
-   * is assumed to be the same for further requests.
+   * is assumed to be the same for further requests.  Downstream request counter is incremented for
+   * for each request.
    * @param headers supplies the request headers.
    * @param prefix supplies the stat prefix for the UA stats.
    * @param scope supplies the backing stat scope.

--- a/source/common/tcp_proxy/tcp_proxy.cc
+++ b/source/common/tcp_proxy/tcp_proxy.cc
@@ -766,10 +766,9 @@ TunnelingConfigHelperImpl::TunnelingConfigHelperImpl(
   envoy::config::core::v3::SubstitutionFormatString substitution_format_config;
   substitution_format_config.mutable_text_format_source()->set_inline_string(
       config_message.tunneling_config().hostname());
-  hostname_fmt_ =
-      THROW_OR_RETURN_VALUE(Formatter::SubstitutionFormatStringUtils::fromProtoConfig(
-                                substitution_format_config, context),
-                            Formatter::FormatterBasePtr<Formatter::HttpFormatterContext>);
+  hostname_fmt_ = THROW_OR_RETURN_VALUE(Formatter::SubstitutionFormatStringUtils::fromProtoConfig(
+                                            substitution_format_config, context),
+                                        Formatter::FormatterPtr);
 }
 
 std::string TunnelingConfigHelperImpl::host(const StreamInfo::StreamInfo& stream_info) const {

--- a/source/extensions/access_loggers/common/stream_access_log_common_impl.h
+++ b/source/extensions/access_loggers/common/stream_access_log_common_impl.h
@@ -22,7 +22,7 @@ createStreamAccessLogInstance(const Protobuf::Message& config, AccessLog::Filter
     formatter =
         THROW_OR_RETURN_VALUE(Formatter::SubstitutionFormatStringUtils::fromProtoConfig(
                                   fal_config.log_format(), context, std::move(command_parsers)),
-                              Formatter::FormatterBasePtr<Formatter::HttpFormatterContext>);
+                              Formatter::FormatterPtr);
   } else if (fal_config.access_log_format_case() ==
              T::AccessLogFormatCase::ACCESS_LOG_FORMAT_NOT_SET) {
     formatter = THROW_OR_RETURN_VALUE(

--- a/source/extensions/access_loggers/file/config.cc
+++ b/source/extensions/access_loggers/file/config.cc
@@ -37,10 +37,9 @@ AccessLog::InstanceSharedPtr FileAccessLogFactory::createAccessLogInstance(
     } else {
       envoy::config::core::v3::SubstitutionFormatString sff_config;
       sff_config.mutable_text_format_source()->set_inline_string(fal_config.format());
-      formatter =
-          THROW_OR_RETURN_VALUE(Formatter::SubstitutionFormatStringUtils::fromProtoConfig(
-                                    sff_config, context, std::move(command_parsers)),
-                                Formatter::FormatterBasePtr<Formatter::HttpFormatterContext>);
+      formatter = THROW_OR_RETURN_VALUE(Formatter::SubstitutionFormatStringUtils::fromProtoConfig(
+                                            sff_config, context, std::move(command_parsers)),
+                                        Formatter::FormatterPtr);
     }
     break;
   case envoy::extensions::access_loggers::file::v3::FileAccessLog::AccessLogFormatCase::kJsonFormat:
@@ -53,14 +52,14 @@ AccessLog::InstanceSharedPtr FileAccessLogFactory::createAccessLogInstance(
     *sff_config.mutable_json_format() = fal_config.typed_json_format();
     formatter = THROW_OR_RETURN_VALUE(Formatter::SubstitutionFormatStringUtils::fromProtoConfig(
                                           sff_config, context, std::move(command_parsers)),
-                                      Formatter::FormatterBasePtr<Formatter::HttpFormatterContext>);
+                                      Formatter::FormatterPtr);
     break;
   }
   case envoy::extensions::access_loggers::file::v3::FileAccessLog::AccessLogFormatCase::kLogFormat:
     formatter =
         THROW_OR_RETURN_VALUE(Formatter::SubstitutionFormatStringUtils::fromProtoConfig(
                                   fal_config.log_format(), context, std::move(command_parsers)),
-                              Formatter::FormatterBasePtr<Formatter::HttpFormatterContext>);
+                              Formatter::FormatterPtr);
     break;
   case envoy::extensions::access_loggers::file::v3::FileAccessLog::AccessLogFormatCase::
       ACCESS_LOG_FORMAT_NOT_SET:

--- a/source/extensions/access_loggers/fluentd/config.cc
+++ b/source/extensions/access_loggers/fluentd/config.cc
@@ -60,10 +60,10 @@ AccessLog::InstanceSharedPtr FluentdAccessLogFactory::createAccessLogInstance(
   // payload.
   // TODO(ohadvano): Improve the formatting operation by creating a dedicated formatter that
   //                 will directly serialize the record to msgpack payload.
-  auto commands = THROW_OR_RETURN_VALUE(
-      Formatter::SubstitutionFormatStringUtils::parseFormatters(proto_config.formatters(), context,
-                                                                std::move(command_parsers)),
-      std::vector<Formatter::CommandParserBasePtr<Formatter::HttpFormatterContext>>);
+  auto commands =
+      THROW_OR_RETURN_VALUE(Formatter::SubstitutionFormatStringUtils::parseFormatters(
+                                proto_config.formatters(), context, std::move(command_parsers)),
+                            std::vector<Formatter::CommandParserPtr>);
 
   Formatter::FormatterPtr json_formatter =
       Formatter::SubstitutionFormatStringUtils::createJsonFormatter(proto_config.record(), true,

--- a/source/extensions/access_loggers/open_telemetry/config.cc
+++ b/source/extensions/access_loggers/open_telemetry/config.cc
@@ -41,10 +41,10 @@ getAccessLoggerCacheSingleton(Server::Configuration::CommonFactoryContext& conte
       const envoy::extensions::access_loggers::open_telemetry::v3::OpenTelemetryAccessLogConfig&>(
       config, context.messageValidationVisitor());
 
-  auto commands = THROW_OR_RETURN_VALUE(
-      Formatter::SubstitutionFormatStringUtils::parseFormatters(proto_config.formatters(), context,
-                                                                std::move(command_parsers)),
-      std::vector<Formatter::CommandParserBasePtr<Formatter::HttpFormatterContext>>);
+  auto commands =
+      THROW_OR_RETURN_VALUE(Formatter::SubstitutionFormatStringUtils::parseFormatters(
+                                proto_config.formatters(), context, std::move(command_parsers)),
+                            std::vector<Formatter::CommandParserPtr>);
 
   return std::make_shared<AccessLog>(
       std::move(filter), proto_config, context.serverFactoryContext().threadLocal(),

--- a/source/extensions/filters/common/set_filter_state/filter_config.cc
+++ b/source/extensions/filters/common/set_filter_state/filter_config.cc
@@ -50,10 +50,9 @@ Config::parse(const Protobuf::RepeatedPtrField<FilterStateValueProto>& proto_val
       break;
     }
     value.skip_if_empty_ = proto_value.skip_if_empty();
-    value.value_ =
-        THROW_OR_RETURN_VALUE(Formatter::SubstitutionFormatStringUtils::fromProtoConfig(
-                                  proto_value.format_string(), context),
-                              Formatter::FormatterBasePtr<Formatter::HttpFormatterContext>);
+    value.value_ = THROW_OR_RETURN_VALUE(Formatter::SubstitutionFormatStringUtils::fromProtoConfig(
+                                             proto_value.format_string(), context),
+                                         Formatter::FormatterPtr);
     values.push_back(std::move(value));
   }
   return values;

--- a/source/extensions/filters/udp/udp_proxy/config.cc
+++ b/source/extensions/filters/udp/udp_proxy/config.cc
@@ -64,7 +64,7 @@ TunnelingConfigImpl::TunnelingConfigImpl(const TunnelingConfig& config,
   proxy_host_formatter_ =
       THROW_OR_RETURN_VALUE(Formatter::SubstitutionFormatStringUtils::fromProtoConfig(
                                 proxy_substitution_format_config, context),
-                            Formatter::FormatterBasePtr<Formatter::HttpFormatterContext>);
+                            Formatter::FormatterPtr);
 
   if (config.has_proxy_port()) {
     uint32_t port = config.proxy_port().value();
@@ -81,7 +81,7 @@ TunnelingConfigImpl::TunnelingConfigImpl(const TunnelingConfig& config,
   target_host_formatter_ =
       THROW_OR_RETURN_VALUE(Formatter::SubstitutionFormatStringUtils::fromProtoConfig(
                                 target_substitution_format_config, context),
-                            Formatter::FormatterBasePtr<Formatter::HttpFormatterContext>);
+                            Formatter::FormatterPtr);
 
   if (config.has_retry_options() && config.retry_options().has_backoff_options()) {
     const uint64_t base_interval_ms =

--- a/source/extensions/formatter/metadata/metadata.cc
+++ b/source/extensions/formatter/metadata/metadata.cc
@@ -132,9 +132,7 @@ MetadataFormatterCommandParser::parse(absl::string_view command, absl::string_vi
     }
 
     // Return a pointer to formatter provider.
-    return std::make_unique<
-        Envoy::Formatter::StreamInfoFormatterWrapper<Envoy::Formatter::HttpFormatterContext>>(
-        provider->second(filter_namespace, path, max_length));
+    return provider->second(filter_namespace, path, max_length);
   }
   return nullptr;
 }

--- a/source/extensions/http/custom_response/local_response_policy/local_response_policy.cc
+++ b/source/extensions/http/custom_response/local_response_policy/local_response_policy.cc
@@ -39,10 +39,9 @@ LocalResponsePolicy::LocalResponsePolicy(
   // by this PR and will be fixed in the future.
   Server::GenericFactoryContextImpl generic_context(context, context.messageValidationVisitor());
   if (config.has_body_format()) {
-    formatter_ =
-        THROW_OR_RETURN_VALUE(Formatter::SubstitutionFormatStringUtils::fromProtoConfig(
-                                  config.body_format(), generic_context),
-                              Formatter::FormatterBasePtr<Formatter::HttpFormatterContext>);
+    formatter_ = THROW_OR_RETURN_VALUE(Formatter::SubstitutionFormatStringUtils::fromProtoConfig(
+                                           config.body_format(), generic_context),
+                                       Formatter::FormatterPtr);
   }
 }
 

--- a/source/extensions/matching/actions/format_string/config.cc
+++ b/source/extensions/matching/actions/format_string/config.cc
@@ -34,7 +34,7 @@ ActionFactory::createActionFactoryCb(const Protobuf::Message& proto_config,
   Server::GenericFactoryContextImpl generic_context(context, validator);
   Formatter::FormatterConstSharedPtr formatter = THROW_OR_RETURN_VALUE(
       Formatter::SubstitutionFormatStringUtils::fromProtoConfig(config, generic_context),
-      Formatter::FormatterBasePtr<Formatter::HttpFormatterContext>);
+      Formatter::FormatterPtr);
   return [formatter]() { return std::make_unique<ActionImpl>(formatter); };
 }
 

--- a/test/common/http/user_agent_test.cc
+++ b/test/common/http/user_agent_test.cc
@@ -25,7 +25,8 @@ TEST(UserAgentTest, All) {
   Event::SimulatedTimeSystem time_system;
   Stats::HistogramCompletableTimespanImpl span(original_histogram, time_system);
 
-  EXPECT_CALL(stat_store.counter_, inc()).Times(5);
+  // We expect 4 downstream_rq_total increments, 2 downstream_cx_destroy_remote_active_rq increments
+  EXPECT_CALL(stat_store.counter_, inc()).Times(6);
   EXPECT_CALL(stat_store, counter("test.user_agent.ios.downstream_cx_total"));
   EXPECT_CALL(stat_store, counter("test.user_agent.ios.downstream_rq_total"));
   EXPECT_CALL(stat_store, counter("test.user_agent.ios.downstream_cx_destroy_remote_active_rq"));

--- a/test/extensions/access_loggers/file/config_test.cc
+++ b/test/extensions/access_loggers/file/config_test.cc
@@ -26,8 +26,7 @@ public:
   Formatter::FormatterProviderPtr parse(absl::string_view command, absl::string_view,
                                         absl::optional<size_t>) const override {
     if (command == "TEST_CUSTOM") {
-      return std::make_unique<Formatter::PlainStringFormatterBase<Formatter::HttpFormatterContext>>(
-          "custom");
+      return std::make_unique<Formatter::PlainStringFormatter>("custom");
     }
     return nullptr;
   }

--- a/test/extensions/formatter/metadata/metadata_test.cc
+++ b/test/extensions/formatter/metadata/metadata_test.cc
@@ -39,7 +39,7 @@ public:
     TestUtility::loadFromYaml(yaml, config_);
     return THROW_OR_RETURN_VALUE(
         Envoy::Formatter::SubstitutionFormatStringUtils::fromProtoConfig(config_, context_),
-        Envoy::Formatter::FormatterBasePtr<Envoy::Formatter::HttpFormatterContext>);
+        Envoy::Formatter::FormatterPtr);
   }
 
   Http::TestRequestHeaderMapImpl request_headers_;

--- a/tools/code_format/config.yaml
+++ b/tools/code_format/config.yaml
@@ -105,6 +105,7 @@ paths:
     - source/common/formatter/http_specific_formatter.cc
     - source/common/formatter/stream_info_formatter.cc
     - source/common/formatter/substitution_formatter.h
+    - source/common/formatter/substitution_formatter.cc
     - source/common/stats/tag_extractor_impl.cc
     - source/common/protobuf/yaml_utility.cc
     - source/common/protobuf/utility.cc


### PR DESCRIPTION
Currently user agent based downstream_req_total is not updated for every request, fix it to update for every request

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:  Fix useragent based request counter for http conn manager
Additional Description:
Risk Level: Low
Testing: Unit test
Docs Changes:
Release Notes: Fixes user agent based downstream request counter
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
