### PR TITLE
Fix useragent based request counter for http conn manager

### DIFF
--- a/source/common/http/user_agent.cc
+++ b/source/common/http/user_agent.cc
@@ -41,7 +41,6 @@ UserAgentStats::UserAgentStats(Stats::StatName prefix, Stats::StatName device, S
           scope, {prefix, device, context.downstream_cx_length_ms_},
           Stats::Histogram::Unit::Milliseconds)) {
   downstream_cx_total_.inc();
-  downstream_rq_total_.inc();
 }
 
 void UserAgent::initializeFromHeaders(const RequestHeaderMap& headers, Stats::StatName prefix,
@@ -58,6 +57,9 @@ void UserAgent::initializeFromHeaders(const RequestHeaderMap& headers, Stats::St
         stats_ = std::make_unique<UserAgentStats>(prefix, context_.android_, scope, context_);
       }
     }
+  }
+  if (stats_ != nullptr) {
+    stats_->downstream_rq_total_.inc();
   }
 }
 

--- a/source/common/http/user_agent.h
+++ b/source/common/http/user_agent.h
@@ -63,7 +63,8 @@ public:
 
   /**
    * Initialize the user agent from request headers. This is only done once and the user-agent
-   * is assumed to be the same for further requests.
+   * is assumed to be the same for further requests.  Downstream request counter is incremented for
+   * for each request.
    * @param headers supplies the request headers.
    * @param prefix supplies the stat prefix for the UA stats.
    * @param scope supplies the backing stat scope.

--- a/test/common/http/user_agent_test.cc
+++ b/test/common/http/user_agent_test.cc
@@ -25,7 +25,8 @@ TEST(UserAgentTest, All) {
   Event::SimulatedTimeSystem time_system;
   Stats::HistogramCompletableTimespanImpl span(original_histogram, time_system);
 
-  EXPECT_CALL(stat_store.counter_, inc()).Times(5);
+  // We expect 4 downstream_rq_total increments, 2 downstream_cx_destroy_remote_active_rq increments
+  EXPECT_CALL(stat_store.counter_, inc()).Times(6);
   EXPECT_CALL(stat_store, counter("test.user_agent.ios.downstream_cx_total"));
   EXPECT_CALL(stat_store, counter("test.user_agent.ios.downstream_rq_total"));
   EXPECT_CALL(stat_store, counter("test.user_agent.ios.downstream_cx_destroy_remote_active_rq"));


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:  Fix useragent based request counter for http conn manager
Additional Description:
Risk Level: Low
Testing: Unit tests
Docs Changes:
Release Notes: Fixes user agent based downstream request counter
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
