### PR TITLE
thrift_proxy: proto to support map in payload_to_metadata filter

### DIFF
--- a/api/envoy/extensions/filters/network/thrift_proxy/filters/payload_to_metadata/v3/BUILD
+++ b/api/envoy/extensions/filters/network/thrift_proxy/filters/payload_to_metadata/v3/BUILD
@@ -8,5 +8,6 @@ api_proto_package(
     deps = [
         "//envoy/type/matcher/v3:pkg",
         "@com_github_cncf_xds//udpa/annotations:pkg",
+        "@com_github_cncf_xds//xds/annotations/v3:pkg",
     ],
 )

--- a/api/envoy/extensions/filters/network/thrift_proxy/filters/payload_to_metadata/v3/payload_to_metadata.proto
+++ b/api/envoy/extensions/filters/network/thrift_proxy/filters/payload_to_metadata/v3/payload_to_metadata.proto
@@ -4,6 +4,8 @@ package envoy.extensions.filters.network.thrift_proxy.filters.payload_to_metadat
 
 import "envoy/type/matcher/v3/regex.proto";
 
+import "google/protobuf/struct.proto";
+
 import "udpa/annotations/status.proto";
 import "validate/validate.proto";
 

--- a/api/envoy/extensions/filters/network/thrift_proxy/filters/payload_to_metadata/v3/payload_to_metadata.proto
+++ b/api/envoy/extensions/filters/network/thrift_proxy/filters/payload_to_metadata/v3/payload_to_metadata.proto
@@ -6,6 +6,8 @@ import "envoy/type/matcher/v3/regex.proto";
 
 import "google/protobuf/struct.proto";
 
+import "xds/annotations/v3/status.proto";
+
 import "udpa/annotations/status.proto";
 import "validate/validate.proto";
 

--- a/api/envoy/extensions/filters/network/thrift_proxy/filters/payload_to_metadata/v3/payload_to_metadata.proto
+++ b/api/envoy/extensions/filters/network/thrift_proxy/filters/payload_to_metadata/v3/payload_to_metadata.proto
@@ -84,6 +84,7 @@ message PayloadToMetadata {
     KeyValuePair on_missing = 5;
   }
 
+  // The selector to parse thrift struct field
   message FieldSelector {
     // field name to log
     string name = 1 [(validate.rules).string = {min_len: 1}];
@@ -91,8 +92,26 @@ message PayloadToMetadata {
     // field id to match
     int32 id = 2 [(validate.rules).int32 = {lte: 32767 gte: -32768}];
 
-    // next node of the field selector
+    // next node of the field selector -- this takes precedence over the map_child.
     FieldSelector child = 3;
+
+    // next node of the map selector
+    // [#not-implemented-hide:]
+    MapSelector map_child = 4;
+  }
+
+  // The selector to parse thrift map field
+  message MapSelector {
+    option (xds.annotations.v3.message_status).work_in_progress = true;
+
+    // map key to match -- only primitive types are supported.
+    google.protobuf.Value key = 1 [(validate.rules).message = {required: true}];
+
+    // next node of the field selector -- this takes precedence over the map_child.
+    FieldSelector child = 2;
+
+    // next node of the map selector
+    MapSelector map_child = 3;
   }
 
   // The list of rules to apply to requests.


### PR DESCRIPTION
Commit Message:
thrift has four types of container: `struct`, `map`, `list` and `set`.
`struct` parsing is already supported at day 1 and now we have intention to support `map`.

Would add more document during implementation PR, but here's the idea

thrift schema
```
struct PriceMap {
  1: map<string, int> prices
}

service Register {
  void registerPriceMap(1: PriceMap priceMap, 2:string currency);
}

````
 we have this config to extract the map of key `rubber_duck` string

```
request_rules:
- method_name: registerPriceMap
  field_selector:
    name: priceMap
    id: 1
    child:
      name: prices
      id: 1
      map_child:
        key: "rubber_duck"
```

We use a protobuf value as a key but per apache thrift guild https://thrift.apache.org/docs/types only primitive key types are suggested. We'll support string as the first implementation.

Given `oneof` is not suggested, the filter takes `field_selector` first. If it's null, it'll use `map_selector`. If it's still null, it means it's the leaf we want to extract.

Additional Description:
Risk Level: no, just adding proto
Testing: ci
