### PR TITLE
cds: set config_reload and config_reload_time_ms

### DIFF
--- a/source/common/upstream/cds_api_helper.cc
+++ b/source/common/upstream/cds_api_helper.cc
@@ -14,7 +14,7 @@
 namespace Envoy {
 namespace Upstream {
 
-std::vector<std::string>
+std::pair<uint32_t, std::vector<std::string>>
 CdsApiHelper::onConfigUpdate(const std::vector<Config::DecodedResourceRef>& added_resources,
                              const Protobuf::RepeatedPtrField<std::string>& removed_resources,
                              const std::string& system_version_info) {
@@ -83,7 +83,7 @@ CdsApiHelper::onConfigUpdate(const std::vector<Config::DecodedResourceRef>& adde
   if (any_applied) {
     system_version_info_ = system_version_info;
   }
-  return exception_msgs;
+  return std::pair{added_or_updated, exception_msgs};
 }
 
 } // namespace Upstream

--- a/source/common/upstream/cds_api_helper.h
+++ b/source/common/upstream/cds_api_helper.h
@@ -27,9 +27,10 @@ public:
    * @param added_resources clusters newly added since the previous fetch.
    * @param removed_resources names of clusters that this fetch instructed to be removed.
    * @param system_version_info aggregate response data "version", for debugging.
-   * @return std::vector<std::string> a list of errors that occurred while updating the clusters.
+   * @return std::pair<uint32_t, std::vector<std::string>> the actual number of added or updated
+   * clusters and a list of errors that occurred while updating the clusters.
    */
-  std::vector<std::string>
+  std::pair<uint32_t, std::vector<std::string>>
   onConfigUpdate(const std::vector<Config::DecodedResourceRef>& added_resources,
                  const Protobuf::RepeatedPtrField<std::string>& removed_resources,
                  const std::string& system_version_info);

--- a/source/common/upstream/cds_api_impl.cc
+++ b/source/common/upstream/cds_api_impl.cc
@@ -11,10 +11,11 @@ namespace Upstream {
 absl::StatusOr<CdsApiPtr>
 CdsApiImpl::create(const envoy::config::core::v3::ConfigSource& cds_config,
                    const xds::core::v3::ResourceLocator* cds_resources_locator, ClusterManager& cm,
-                   Stats::Scope& scope, ProtobufMessage::ValidationVisitor& validation_visitor) {
+                   Stats::Scope& scope, ProtobufMessage::ValidationVisitor& validation_visitor,
+                   Server::Configuration::ServerFactoryContext& factory_context) {
   absl::Status creation_status = absl::OkStatus();
   auto ret = CdsApiPtr{new CdsApiImpl(cds_config, cds_resources_locator, cm, scope,
-                                      validation_visitor, creation_status)};
+                                      validation_visitor, factory_context, creation_status)};
   RETURN_IF_NOT_OK(creation_status);
   return ret;
 }
@@ -23,10 +24,13 @@ CdsApiImpl::CdsApiImpl(const envoy::config::core::v3::ConfigSource& cds_config,
                        const xds::core::v3::ResourceLocator* cds_resources_locator,
                        ClusterManager& cm, Stats::Scope& scope,
                        ProtobufMessage::ValidationVisitor& validation_visitor,
+                       Server::Configuration::ServerFactoryContext& factory_context,
                        absl::Status& creation_status)
     : Envoy::Config::SubscriptionBase<envoy::config::cluster::v3::Cluster>(validation_visitor,
                                                                            "name"),
-      helper_(cm, "cds"), cm_(cm), scope_(scope.createScope("cluster_manager.cds.")) {
+      helper_(cm, "cds"), cm_(cm), scope_(scope.createScope("cluster_manager.cds.")),
+      factory_context_(factory_context),
+      stats_({ALL_CDS_STATS(POOL_COUNTER(*scope_), POOL_GAUGE(*scope_))}) {
   const auto resource_name = getResourceName();
   absl::StatusOr<Config::SubscriptionPtr> subscription_or_error;
   if (cds_resources_locator == nullptr) {
@@ -67,12 +71,16 @@ absl::Status
 CdsApiImpl::onConfigUpdate(const std::vector<Config::DecodedResourceRef>& added_resources,
                            const Protobuf::RepeatedPtrField<std::string>& removed_resources,
                            const std::string& system_version_info) {
-  auto exception_msgs =
+  auto [added_or_updated, exception_msgs] =
       helper_.onConfigUpdate(added_resources, removed_resources, system_version_info);
   runInitializeCallbackIfAny();
   if (!exception_msgs.empty()) {
     return absl::InvalidArgumentError(
         fmt::format("Error adding/updating cluster(s) {}", absl::StrJoin(exception_msgs, ", ")));
+  }
+  if (added_or_updated > 0) {
+    stats_.config_reload_.inc();
+    stats_.config_reload_time_ms_.set(DateUtil::nowToMilliseconds(factory_context_.timeSource()));
   }
   return absl::OkStatus();
 }

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -2456,7 +2456,8 @@ ProdClusterManagerFactory::createCds(const envoy::config::core::v3::ConfigSource
                                      ClusterManager& cm) {
   // TODO(htuch): Differentiate static vs. dynamic validation visitors.
   return CdsApiImpl::create(cds_config, cds_resources_locator, cm, *stats_.rootScope(),
-                            context_.messageValidationContext().dynamicValidationVisitor());
+                            context_.messageValidationContext().dynamicValidationVisitor(),
+                            context_);
 }
 
 } // namespace Upstream

--- a/source/common/upstream/od_cds_api_impl.cc
+++ b/source/common/upstream/od_cds_api_impl.cc
@@ -57,7 +57,7 @@ absl::Status
 OdCdsApiImpl::onConfigUpdate(const std::vector<Config::DecodedResourceRef>& added_resources,
                              const Protobuf::RepeatedPtrField<std::string>& removed_resources,
                              const std::string& system_version_info) {
-  auto exception_msgs =
+  auto [_, exception_msgs] =
       helper_.onConfigUpdate(added_resources, removed_resources, system_version_info);
   sendAwaiting();
   status_ = StartStatus::InitialFetchDone;

--- a/test/common/upstream/cds_api_impl_test.cc
+++ b/test/common/upstream/cds_api_impl_test.cc
@@ -6,6 +6,7 @@
 #include "envoy/config/cluster/v3/cluster.pb.h"
 #include "envoy/config/core/v3/config_source.pb.h"
 #include "envoy/service/discovery/v3/discovery.pb.h"
+#include "envoy/stats/scope.h"
 
 #include "source/common/config/utility.h"
 #include "source/common/protobuf/utility.h"
@@ -13,6 +14,7 @@
 
 #include "test/common/upstream/utility.h"
 #include "test/mocks/protobuf/mocks.h"
+#include "test/mocks/server/instance.h"
 #include "test/mocks/upstream/cluster_manager.h"
 #include "test/mocks/upstream/cluster_priority_set.h"
 #include "test/test_common/printers.h"
@@ -37,7 +39,8 @@ class CdsApiImplTest : public testing::Test {
 protected:
   void setup() {
     envoy::config::core::v3::ConfigSource cds_config;
-    cds_ = *CdsApiImpl::create(cds_config, nullptr, cm_, *store_.rootScope(), validation_visitor_);
+    cds_ = *CdsApiImpl::create(cds_config, nullptr, cm_, *scope_.rootScope(), validation_visitor_,
+                               server_factory_context_);
     cds_->setInitializedCb([this]() -> void { initialized_.ready(); });
 
     EXPECT_CALL(*cm_.subscription_factory_.subscription_, start(_));
@@ -70,11 +73,12 @@ protected:
 
   NiceMock<MockClusterManager> cm_;
   Upstream::MockClusterMockPrioritySet mock_cluster_;
-  Stats::IsolatedStoreImpl store_;
   CdsApiPtr cds_;
   Config::SubscriptionCallbacks* cds_callbacks_{};
   ReadyWatcher initialized_;
   NiceMock<ProtobufMessage::MockValidationVisitor> validation_visitor_;
+  NiceMock<Server::Configuration::MockServerFactoryContext> server_factory_context_;
+  NiceMock<Stats::MockIsolatedStatsStore> scope_;
 };
 
 // Regression test against only updating versionInfo() if at least one cluster
@@ -150,6 +154,10 @@ TEST_F(CdsApiImplTest, EmptyConfigUpdate) {
   EXPECT_CALL(initialized_, ready());
 
   EXPECT_TRUE(cds_callbacks_->onConfigUpdate({}, "").ok());
+  EXPECT_EQ(0UL, scope_.counter("cluster_manager.cds.config_reload").value());
+  EXPECT_EQ(
+      0UL,
+      scope_.findGaugeByString("cluster_manager.cds.config_reload_time_ms").value().get().value());
 }
 
 TEST_F(CdsApiImplTest, ConfigUpdateWith2ValidClusters) {
@@ -320,6 +328,10 @@ resources:
       cds_callbacks_->onConfigUpdate(decoded_resources_2.refvec_, response2.version_info()).ok());
 
   EXPECT_EQ("1", cds_->versionInfo());
+  EXPECT_EQ(2UL, scope_.counter("cluster_manager.cds.config_reload").value());
+  EXPECT_TRUE(
+      scope_.findGaugeByString("cluster_manager.cds.config_reload_time_ms").value().get().value() >
+      0UL);
 }
 
 // Validate behavior when the config is delivered but it fails PGV validation.

--- a/test/common/upstream/cds_api_impl_test.cc
+++ b/test/common/upstream/cds_api_impl_test.cc
@@ -73,12 +73,12 @@ protected:
 
   NiceMock<MockClusterManager> cm_;
   Upstream::MockClusterMockPrioritySet mock_cluster_;
+  NiceMock<Server::Configuration::MockServerFactoryContext> server_factory_context_;
+  NiceMock<Stats::MockIsolatedStatsStore> scope_;
   CdsApiPtr cds_;
   Config::SubscriptionCallbacks* cds_callbacks_{};
   ReadyWatcher initialized_;
   NiceMock<ProtobufMessage::MockValidationVisitor> validation_visitor_;
-  NiceMock<Server::Configuration::MockServerFactoryContext> server_factory_context_;
-  NiceMock<Stats::MockIsolatedStatsStore> scope_;
 };
 
 // Regression test against only updating versionInfo() if at least one cluster


### PR DESCRIPTION
Commit Message: Records config_reload and config_reload_time_ms statistics when cds makes a non-empty update. 
Additional Description: N/A
Risk Level: Low
Testing: Unit tests have been updated to validate that the new stats are properly set.
Docs Changes: N/A
Release Notes: N/A 
Platform Specific Features: N/A

#38490 