### PR TITLE
stream info: custom flag support

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -170,6 +170,10 @@ new_features:
   change: |
     Added ``QUERY_PARAM`` support for substitution formatter. See :ref:`access log formatter <config_access_log_format>`
     for more details.
+- area: formatter
+  change: |
+    Added ``CUSTOM_FLAGS`` support for substitution formatter. See :ref:`access log formatter <config_access_log_format>`
+    for more details.
 - area: http
   change: |
     Added :ref:`max_metadata_size <envoy_v3_api_field_config.core.v3.Http2ProtocolOptions.max_metadata_size>` to make

--- a/docs/root/configuration/observability/access_log/usage.rst
+++ b/docs/root/configuration/observability/access_log/usage.rst
@@ -1390,3 +1390,7 @@ UDP
     Z is an optional parameter denoting string truncation up to Z characters long.
   TCP/UDP
     Not implemented ("-").
+
+%CUSTOM_FLAGS%
+  Custom flags set into the stream info. This could be used to log any custom event from the filters.
+  Multiple flags are separated by comma.

--- a/envoy/stream_info/stream_info.h
+++ b/envoy/stream_info/stream_info.h
@@ -656,6 +656,15 @@ public:
   virtual void
   setConnectionTerminationDetails(absl::string_view connection_termination_details) PURE;
 
+  /*
+   * @param short string type flag to indicate the noteworthy event of this stream. Mutliple flags
+   * could be added and will be concatenated with comma. It should not contain any empty or space
+   * characters (' ', '\t', '\f', '\v', '\n', '\r').
+   *
+   * The short string should not duplicate with the any registered response flags.
+   */
+  virtual void addCustomFlag(absl::string_view) PURE;
+
   /**
    * @return std::string& the name of the route. The name is get from the route() and it is
    *         empty if there is no route.
@@ -807,6 +816,11 @@ public:
    * flag. Only flags that are declared in the enum CoreResponseFlag type are supported.
    */
   virtual uint64_t legacyResponseFlags() const PURE;
+
+  /**
+   * @return all stream flags that are added.
+   */
+  virtual absl::string_view customFlags() const PURE;
 
   /**
    * @return whether the request is a health check request or not.

--- a/source/common/formatter/stream_info_formatter.cc
+++ b/source/common/formatter/stream_info_formatter.cc
@@ -1048,6 +1048,14 @@ const StreamInfoFormatterProviderLookupTable& getKnownStreamInfoFormatterProvide
                                [](absl::string_view sub_command, absl::optional<size_t>) {
                                  return CommonDurationFormatter::create(sub_command);
                                }}},
+                             {"CUSTOM_FLAGS",
+                              {CommandSyntaxChecker::COMMAND_ONLY,
+                               [](absl::string_view, absl::optional<size_t>) {
+                                 return std::make_unique<StreamInfoStringFormatterProvider>(
+                                     [](const StreamInfo::StreamInfo& stream_info) {
+                                       return std::string(stream_info.customFlags());
+                                     });
+                               }}},
                              {"RESPONSE_FLAGS",
                               {CommandSyntaxChecker::COMMAND_ONLY,
                                [](absl::string_view, absl::optional<size_t>) {

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -1017,7 +1017,7 @@ void ConnectionManagerImpl::ActiveStream::chargeStats(const ResponseHeaderMap& h
   uint64_t response_code = Utility::getResponseStatus(headers);
   filter_manager_.streamInfo().setResponseCode(response_code);
 
-  if (filter_manager_.streamInfo().health_check_request_) {
+  if (filter_manager_.streamInfo().healthCheck()) {
     return;
   }
 

--- a/source/common/stream_info/stream_info_impl.h
+++ b/source/common/stream_info/stream_info_impl.h
@@ -192,6 +192,18 @@ struct StreamInfoImpl : public StreamInfo {
     return {*downstream_timing_};
   }
 
+  void addCustomFlag(absl::string_view flag) override {
+    ASSERT(!ResponseFlagUtils::responseFlagsMap().contains(flag));
+    ASSERT(!StringUtil::hasEmptySpace(flag));
+    if (stream_flags_.empty()) {
+      stream_flags_.append(flag);
+    } else {
+      stream_flags_.push_back(',');
+      stream_flags_.append(flag);
+    }
+  }
+  absl::string_view customFlags() const override { return stream_flags_; }
+
   void addBytesReceived(uint64_t bytes_received) override { bytes_received_ += bytes_received; }
 
   uint64_t bytesReceived() const override { return bytes_received_; }
@@ -389,6 +401,7 @@ struct StreamInfoImpl : public StreamInfo {
     setFromForRecreateStream(info);
     virtual_cluster_name_ = info.virtualClusterName();
     response_code_ = info.responseCode();
+    stream_flags_.assign(info.customFlags().data(), info.customFlags().size());
     response_code_details_ = info.responseCodeDetails();
     connection_termination_details_ = info.connectionTerminationDetails();
     upstream_info_ = info.upstreamInfo();
@@ -463,7 +476,7 @@ private:
 
 public:
   absl::InlinedVector<ResponseFlag, 4> response_flags_{};
-  bool health_check_request_{};
+  std::string stream_flags_;
   Router::RouteConstSharedPtr route_;
   envoy::config::core::v3::Metadata metadata_{};
   FilterStateSharedPtr filter_state_;
@@ -481,24 +494,25 @@ private:
   }
 
   std::shared_ptr<UpstreamInfo> upstream_info_;
-  uint64_t bytes_received_{};
-  uint64_t bytes_retransmitted_{};
-  uint64_t packets_retransmitted_{};
-  uint64_t bytes_sent_{};
   const Network::ConnectionInfoProviderSharedPtr downstream_connection_info_provider_;
   const Http::RequestHeaderMap* request_headers_{};
   StreamIdProviderSharedPtr stream_id_provider_;
   absl::optional<DownstreamTiming> downstream_timing_;
   absl::optional<Upstream::ClusterInfoConstSharedPtr> upstream_cluster_info_;
-  Tracing::Reason trace_reason_;
   // Default construct the object because upstream stream is not constructed in some cases.
   BytesMeterSharedPtr upstream_bytes_meter_{std::make_shared<BytesMeter>()};
   BytesMeterSharedPtr downstream_bytes_meter_;
-  bool is_shadow_{false};
   std::string downstream_transport_failure_reason_;
+  OptRef<const StreamInfo> parent_stream_info_;
+  uint64_t bytes_received_{};
+  uint64_t bytes_retransmitted_{};
+  uint64_t packets_retransmitted_{};
+  uint64_t bytes_sent_{};
+  Tracing::Reason trace_reason_;
+  bool health_check_request_{};
   bool should_scheme_match_upstream_{false};
   bool should_drain_connection_{false};
-  OptRef<const StreamInfo> parent_stream_info_;
+  bool is_shadow_{false};
 };
 
 } // namespace StreamInfo

--- a/source/common/stream_info/stream_info_impl.h
+++ b/source/common/stream_info/stream_info_impl.h
@@ -195,14 +195,14 @@ struct StreamInfoImpl : public StreamInfo {
   void addCustomFlag(absl::string_view flag) override {
     ASSERT(!ResponseFlagUtils::responseFlagsMap().contains(flag));
     ASSERT(!StringUtil::hasEmptySpace(flag));
-    if (stream_flags_.empty()) {
-      stream_flags_.append(flag);
+    if (custom_flags_.empty()) {
+      custom_flags_.append(flag.data(), flag.size());
     } else {
-      stream_flags_.push_back(',');
-      stream_flags_.append(flag);
+      custom_flags_.push_back(',');
+      custom_flags_.append(flag.data(), flag.size());
     }
   }
-  absl::string_view customFlags() const override { return stream_flags_; }
+  absl::string_view customFlags() const override { return custom_flags_; }
 
   void addBytesReceived(uint64_t bytes_received) override { bytes_received_ += bytes_received; }
 
@@ -401,7 +401,7 @@ struct StreamInfoImpl : public StreamInfo {
     setFromForRecreateStream(info);
     virtual_cluster_name_ = info.virtualClusterName();
     response_code_ = info.responseCode();
-    stream_flags_.assign(info.customFlags().data(), info.customFlags().size());
+    custom_flags_.assign(info.customFlags().data(), info.customFlags().size());
     response_code_details_ = info.responseCodeDetails();
     connection_termination_details_ = info.connectionTerminationDetails();
     upstream_info_ = info.upstreamInfo();
@@ -476,7 +476,7 @@ private:
 
 public:
   absl::InlinedVector<ResponseFlag, 4> response_flags_{};
-  std::string stream_flags_;
+  std::string custom_flags_;
   Router::RouteConstSharedPtr route_;
   envoy::config::core::v3::Metadata metadata_{};
   FilterStateSharedPtr filter_state_;

--- a/test/common/access_log/access_log_impl_test.cc
+++ b/test/common/access_log/access_log_impl_test.cc
@@ -495,7 +495,7 @@ typed_config:
   InstanceSharedPtr log = AccessLogFactory::fromProto(parseAccessLogFromV3Yaml(yaml), context_);
 
   Http::TestRequestHeaderMapImpl header_map{};
-  stream_info_.health_check_request_ = true;
+  stream_info_.healthCheck(true);
   EXPECT_CALL(*file_, write(_)).Times(0);
 
   log->log({&header_map, &response_headers_, &response_trailers_}, stream_info_);
@@ -615,7 +615,7 @@ typed_config:
   {
     EXPECT_CALL(*file_, write(_)).Times(0);
     Http::TestRequestHeaderMapImpl header_map{};
-    stream_info_.health_check_request_ = true;
+    stream_info_.healthCheck(true);
     log->log({&header_map, &response_headers_, &response_trailers_}, stream_info_);
   }
 }
@@ -694,7 +694,7 @@ typed_config:
   {
     EXPECT_CALL(*file_, write(_)).Times(0);
     Http::TestRequestHeaderMapImpl header_map{};
-    stream_info_.health_check_request_ = true;
+    stream_info_.healthCheck(true);
 
     log->log({&header_map, &response_headers_, &response_trailers_}, stream_info_);
   }

--- a/test/common/formatter/substitution_formatter_test.cc
+++ b/test/common/formatter/substitution_formatter_test.cc
@@ -581,6 +581,15 @@ TEST(SubstitutionFormatterTest, streamInfoFormatter) {
   }
 
   {
+    StreamInfoFormatter custom_flags_format("CUSTOM_FLAGS");
+    stream_info.addCustomFlag("flag1");
+    stream_info.addCustomFlag("flag2");
+    EXPECT_EQ("flag1,flag2", custom_flags_format.formatWithContext({}, stream_info));
+    EXPECT_THAT(custom_flags_format.formatValueWithContext({}, stream_info),
+                ProtoEq(ValueUtil::stringValue("flag1,flag2")));
+  }
+
+  {
     StreamInfoFormatter response_flags_format("RESPONSE_FLAGS");
     stream_info.setResponseFlag(StreamInfo::CoreResponseFlag::LocalReset);
     EXPECT_EQ("LR", response_flags_format.formatWithContext({}, stream_info));

--- a/test/common/stream_info/stream_info_impl_test.cc
+++ b/test/common/stream_info/stream_info_impl_test.cc
@@ -432,6 +432,8 @@ TEST_F(StreamInfoImplTest, SetFrom) {
   s1.setDownstreamTransportFailureReason("error");
   s1.addBytesSent(1);
   s1.setIsShadow(true);
+  s1.addCustomFlag("test_flag");
+  s1.addCustomFlag("test_flag2");
 
 #ifdef __clang__
 #if defined(__linux__)
@@ -488,6 +490,8 @@ TEST_F(StreamInfoImplTest, SetFrom) {
   EXPECT_EQ(s1.getUpstreamBytesMeter(), s2.getUpstreamBytesMeter());
   EXPECT_EQ(s1.bytesSent(), s2.bytesSent());
   EXPECT_EQ(s1.isShadow(), s2.isShadow());
+  EXPECT_EQ(s1.customFlags(), s2.customFlags());
+  EXPECT_EQ("test_flag,test_flag2", s1.customFlags());
 }
 
 TEST_F(StreamInfoImplTest, DynamicMetadataTest) {

--- a/test/mocks/stream_info/mocks.cc
+++ b/test/mocks/stream_info/mocks.cc
@@ -205,6 +205,17 @@ MockStreamInfo::MockStreamInfo()
         upstream_cluster_info_ = std::move(cluster_info);
       }));
   ON_CALL(*this, upstreamClusterInfo()).WillByDefault(ReturnPointee(&upstream_cluster_info_));
+  ON_CALL(*this, addCustomFlag(_)).WillByDefault(Invoke([this](absl::string_view flag) {
+    if (stream_flags_.empty()) {
+      stream_flags_.append(flag);
+    } else {
+      stream_flags_.push_back(',');
+      stream_flags_.append(flag);
+    }
+  }));
+  ON_CALL(*this, customFlags()).WillByDefault(Invoke([this]() {
+    return absl::string_view(stream_flags_);
+  }));
 }
 
 MockStreamInfo::~MockStreamInfo() = default;

--- a/test/mocks/stream_info/mocks.h
+++ b/test/mocks/stream_info/mocks.h
@@ -175,6 +175,8 @@ public:
   MOCK_METHOD(void, setParentStreamInfo, (const StreamInfo&), ());
   MOCK_METHOD(void, clearParentStreamInfo, ());
   MOCK_METHOD(OptRef<const StreamInfo>, parentStreamInfo, (), (const));
+  MOCK_METHOD(void, addCustomFlag, (absl::string_view));
+  MOCK_METHOD(absl::string_view, customFlags, (), (const));
 
   Envoy::Event::SimulatedTimeSystem ts_;
   SystemTime start_time_;
@@ -200,6 +202,7 @@ public:
   absl::optional<std::string> virtual_cluster_name_;
   DownstreamTiming downstream_timing_;
   std::string downstream_transport_failure_reason_;
+  std::string stream_flags_;
 };
 
 } // namespace StreamInfo


### PR DESCRIPTION
Commit Message: stream info: custom flag support
Additional Description:

The response flags is a great design to help debugging and observing the Envoy. And we also support to register custom response flag to indicate the custom event.

However, for the dynamic extension which doesn't be linked to the binnary initially, it's impossible to use the response flag to indicate their custom event because they cannot register their response flag.

This PR add a simple custom flag to the stream info. The envoy cannot ensure the custom flags won't be duplicated or the custom flags have stable meaning. But it's still make big sense for dynamic extensions. They now have a convenient way to record their event.

Risk Level: low.
Testing: unit.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.