### PR TITLE
Integration test waitForLength should reliably reset its state

### DIFF
--- a/test/integration/utility.h
+++ b/test/integration/utility.h
@@ -266,13 +266,14 @@ public:
 
     dispatcher_.run(Event::Dispatcher::RunType::Block);
 
+    length_to_wait_for_ = 0;
+    wait_for_length_ = false;
+
     if (timeout_timer->enabled()) {
       timeout_timer->disableTimer();
       return testing::AssertionSuccess();
     }
 
-    length_to_wait_for_ = 0;
-    wait_for_length_ = false;
     return testing::AssertionFailure() << "Timed out waiting for " << length << " bytes of data\n";
   }
 


### PR DESCRIPTION
Commit Message: Integration test waitForLength should reliably reset its state
Additional Description: Before this change, doing waitForLength(n) followed by waitForLength(n+1), when expecting two parts to read, provokes an assert.
Risk Level: None, test-only, and the only behavior change is a path that previous would assert.
Testing: Applied to an external extension's integration test to make it work.
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
