### PR TITLE
Graceful close of ext_proc gRPC side streams

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -80,6 +80,14 @@ bug_fixes:
     Before the :scheme header was always 'http'.
     This behavioral change can be temporarily reverted by setting runtime guard
     ``envoy.reloadable_features.jwt_fetcher_use_scheme_from_uri`` to false.
+- area: ext_proc
+  change: |
+    Implemented graceful close of gRPC side streams, where the client half-closes its stream and waits
+    (with timeout) for the server to half-close its stream.
+    This behavioral change is disabled by default and can be enabled by setting runtime guard
+    ``envoy.reloadable_features.ext_proc_graceful_grpc_close`` to true.
+    The remote close timeout is 1 second by default and can be chnaged by setting the
+    ``envoy.filters.http.ext_proc.remote_close_timeout_milliseconds`` runtime value.
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/envoy/grpc/async_client.h
+++ b/envoy/grpc/async_client.h
@@ -65,6 +65,12 @@ public:
    */
   virtual void resetStream() PURE;
 
+  /**
+   * Half-close client gRPC stream and wait for the server to half-close its stream.
+   * The server is expected to hafl-close within the interval specific in the StreamOptions.
+   */
+  virtual void waitForRemoteCloseAndDelete() PURE;
+
   /***
    * @returns if the stream has enough buffered outbound data to be over the configured buffer
    * limits

--- a/envoy/http/async_client.h
+++ b/envoy/http/async_client.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <chrono>
+#include <functional>
 #include <memory>
 
 #include "envoy/buffer/buffer.h"
@@ -383,6 +384,14 @@ public:
       sidestream_watermark_callbacks = callbacks;
       return *this;
     }
+    StreamOptions& setOnDeleteCallbacksForTestOnly(std::function<void()> callback) {
+      on_delete_callback_for_test_only = callback;
+      return *this;
+    }
+    StreamOptions& setRemoteCloseTimeout(std::chrono::milliseconds timeout) {
+      remote_close_timeout = timeout;
+      return *this;
+    }
 
     // For gmock test
     bool operator==(const StreamOptions& src) const {
@@ -443,6 +452,15 @@ public:
     absl::optional<bool> sampled_{true};
     // The pointer to sidestream watermark callbacks. Optional, nullptr by default.
     Http::SidestreamWatermarkCallbacks* sidestream_watermark_callbacks = nullptr;
+
+    // The amount of tiem to wait for server to half-close its stream after client
+    // has half-closed its stream.
+    // Defaults to 1 second.
+    std::chrono::milliseconds remote_close_timeout{1000};
+
+    // This callback is invoked when AsyncStream object is deleted.
+    // Test only use to validate deferred deletion.
+    std::function<void()> on_delete_callback_for_test_only;
   };
 
   /**

--- a/source/common/grpc/async_client_impl.h
+++ b/source/common/grpc/async_client_impl.h
@@ -72,6 +72,7 @@ public:
   AsyncStreamImpl(AsyncClientImpl& parent, absl::string_view service_full_name,
                   absl::string_view method_name, RawAsyncStreamCallbacks& callbacks,
                   const Http::AsyncClient::StreamOptions& options);
+  ~AsyncStreamImpl() override;
 
   virtual void initialize(bool buffer_body_for_retry);
 
@@ -81,6 +82,7 @@ public:
   void onTrailers(Http::ResponseTrailerMapPtr&& trailers) override;
   void onComplete() override;
   void onReset() override;
+  void waitForRemoteCloseAndDelete() override;
 
   // Grpc::AsyncStream
   void sendMessageRaw(Buffer::InstancePtr&& request, bool end_stream) override;
@@ -129,10 +131,12 @@ private:
   RawAsyncStreamCallbacks& callbacks_;
   Http::AsyncClient::StreamOptions options_;
   bool http_reset_{};
+  bool waiting_to_delete_on_remote_close_{};
   Http::AsyncClient::Stream* stream_{};
   Decoder decoder_;
   // This is a member to avoid reallocation on every onData().
   std::vector<Frame> decoded_frames_;
+  Event::TimerPtr remote_close_timer_;
 
   friend class AsyncClientImpl;
 };

--- a/source/common/grpc/google_async_client_impl.h
+++ b/source/common/grpc/google_async_client_impl.h
@@ -229,6 +229,7 @@ public:
   void sendMessageRaw(Buffer::InstancePtr&& request, bool end_stream) override;
   void closeStream() override;
   void resetStream() override;
+  void waitForRemoteCloseAndDelete() override;
   // While the Google-gRPC code doesn't use Envoy watermark buffers, the logical
   // analog is to make sure that the aren't too many bytes in the pending write
   // queue.
@@ -297,7 +298,7 @@ private:
   std::string service_full_name_;
   std::string method_name_;
   RawAsyncStreamCallbacks& callbacks_;
-  const Http::AsyncClient::StreamOptions& options_;
+  const Http::AsyncClient::StreamOptions options_;
   grpc::ClientContext ctxt_;
   std::unique_ptr<grpc::GenericClientAsyncReaderWriter> rw_;
   std::queue<PendingMessage> write_pending_queue_;
@@ -315,6 +316,7 @@ private:
   // Have we entered CQ draining state? If so, we're just waiting for all our
   // ops on the CQ to drain away before freeing the stream.
   bool draining_cq_{};
+  bool waiting_to_delete_on_remote_close_{};
   // Count of the tags in-flight. This must hit zero before the stream can be
   // freed.
   uint32_t inflight_tags_{};
@@ -328,6 +330,7 @@ private:
   std::deque<std::pair<GoogleAsyncTag::Operation, bool>>
       completed_ops_ ABSL_GUARDED_BY(completed_ops_lock_);
   Thread::MutexBasicLockable completed_ops_lock_;
+  Event::TimerPtr remote_close_timer_;
 
   friend class GoogleAsyncClientImpl;
   friend class GoogleAsyncClientThreadLocal;

--- a/source/common/grpc/typed_async_client.h
+++ b/source/common/grpc/typed_async_client.h
@@ -40,6 +40,7 @@ public:
   }
   void closeStream() { stream_->closeStream(); }
   void resetStream() { stream_->resetStream(); }
+  void waitForRemoteCloseAndDelete() { stream_->waitForRemoteCloseAndDelete(); }
   bool isAboveWriteBufferHighWatermark() const {
     return stream_->isAboveWriteBufferHighWatermark();
   }

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -174,6 +174,8 @@ FALSE_RUNTIME_GUARD(envoy_reloadable_features_dns_nodata_noname_is_success);
 // https://github.com/envoyproxy/envoy/blob/main/api/envoy/extensions/transport_sockets/tls/v3/tls.proto#L29.
 FALSE_RUNTIME_GUARD(envoy_reloadable_features_quic_disable_client_early_data);
 
+FALSE_RUNTIME_GUARD(envoy_reloadable_features_ext_proc_graceful_grpc_close);
+
 // Block of non-boolean flags. Use of int flags is deprecated. Do not add more.
 ABSL_FLAG(uint64_t, re2_max_program_size_error_level, 100, ""); // NOLINT
 ABSL_FLAG(uint64_t, re2_max_program_size_warn_level,            // NOLINT

--- a/source/extensions/filters/http/ext_proc/client.h
+++ b/source/extensions/filters/http/ext_proc/client.h
@@ -24,6 +24,7 @@ public:
                     bool end_stream) PURE;
   // Idempotent close. Return true if it actually closed.
   virtual bool close() PURE;
+  virtual bool halfCloseAndDeleteOnRemoteClose() PURE;
   virtual const StreamInfo::StreamInfo& streamInfo() const PURE;
   virtual StreamInfo::StreamInfo& streamInfo() PURE;
   virtual void notifyFilterDestroy() PURE;

--- a/source/extensions/filters/http/ext_proc/client_impl.h
+++ b/source/extensions/filters/http/ext_proc/client_impl.h
@@ -57,6 +57,7 @@ public:
   // Close the stream. This is idempotent and will return true if we
   // actually closed it.
   bool close() override;
+  bool halfCloseAndDeleteOnRemoteClose() override;
 
   void notifyFilterDestroy() override {
     // When the filter object is being destroyed,  `callbacks_` (which is a OptRef to filter object)

--- a/source/extensions/filters/http/ext_proc/ext_proc.cc
+++ b/source/extensions/filters/http/ext_proc/ext_proc.cc
@@ -47,6 +47,9 @@ using Http::ResponseTrailerMap;
 constexpr absl::string_view ErrorPrefix = "ext_proc_error";
 constexpr int DefaultImmediateStatus = 200;
 constexpr absl::string_view FilterName = "envoy.filters.http.ext_proc";
+constexpr absl::string_view RemoteCloseTimeout =
+    "envoy.filters.http.ext_proc.remote_close_timeout_milliseconds";
+constexpr int32_t DefaultRemoteCloseTimeoutMilliseconds = 1000;
 
 absl::optional<ProcessingMode> initProcessingMode(const ExtProcPerRoute& config) {
   if (!config.disabled() && config.has_overrides() && config.overrides().has_processing_mode()) {
@@ -214,7 +217,8 @@ FilterConfig::FilterConfig(const ExternalProcessor& config,
       disable_immediate_response_(config.disable_immediate_response()),
       allowed_headers_(initHeaderMatchers(config.forward_rules().allowed_headers(), context)),
       disallowed_headers_(initHeaderMatchers(config.forward_rules().disallowed_headers(), context)),
-      is_upstream_(is_upstream),
+      is_upstream_(is_upstream), graceful_grpc_close_(Runtime::runtimeFeatureEnabled(
+                                     "envoy.reloadable_features.ext_proc_graceful_grpc_close")),
       untyped_forwarding_namespaces_(
           config.metadata_options().forwarding_namespaces().untyped().begin(),
           config.metadata_options().forwarding_namespaces().untyped().end()),
@@ -231,7 +235,9 @@ FilterConfig::FilterConfig(const ExternalProcessor& config,
       immediate_mutation_checker_(context.regexEngine()),
       on_processing_response_factory_cb_(
           createOnProcessingResponseCb(config, context, stats_prefix)),
-      thread_local_stream_manager_slot_(context.threadLocal().allocateSlot()) {
+      thread_local_stream_manager_slot_(context.threadLocal().allocateSlot()),
+      remote_close_timeout_(context.runtime().snapshot().getInteger(
+          RemoteCloseTimeout, DefaultRemoteCloseTimeoutMilliseconds)) {
 
   if (config.disable_clear_route_cache()) {
     route_cache_action_ = ExternalProcessor::RETAIN;
@@ -408,7 +414,8 @@ Filter::StreamOpenState Filter::openStream() {
                        .setParentSpan(decoder_callbacks_->activeSpan())
                        .setParentContext(grpc_context)
                        .setBufferBodyForRetry(grpc_service_.has_retry_policy())
-                       .setSampled(absl::nullopt);
+                       .setSampled(absl::nullopt)
+                       .setRemoteCloseTimeout(config_->remoteCloseTimeout());
 
     ExternalProcessorClient* grpc_client = dynamic_cast<ExternalProcessorClient*>(client_.get());
     ExternalProcessorStreamPtr stream_object =
@@ -437,6 +444,23 @@ void Filter::closeStream() {
   if (stream_) {
     ENVOY_STREAM_LOG(debug, "Calling close on stream", *decoder_callbacks_);
     if (stream_->close()) {
+      stats_.streams_closed_.inc();
+    }
+    config_->threadLocalStreamManager().erase(stream_);
+    stream_ = nullptr;
+  } else {
+    ENVOY_STREAM_LOG(debug, "Stream already closed", *decoder_callbacks_);
+  }
+}
+
+void Filter::halfCloseAndWaitForRemoteClose() {
+  if (!config_->grpcService().has_value()) {
+    return;
+  }
+
+  if (stream_) {
+    ENVOY_STREAM_LOG(debug, "Calling half-close on stream", *decoder_callbacks_);
+    if (stream_->halfCloseAndDeleteOnRemoteClose()) {
       stats_.streams_closed_.inc();
     }
     config_->threadLocalStreamManager().erase(stream_);
@@ -478,8 +502,12 @@ void Filter::onDestroy() {
     // Second, perform stream deferred closure.
     deferredCloseStream();
   } else {
-    // Perform immediate close on the stream otherwise.
-    closeStream();
+    if (config_->gracefulGrpcClose()) {
+      halfCloseAndWaitForRemoteClose();
+    } else {
+      // Perform immediate close on the stream otherwise.
+      closeStream();
+    }
   }
 }
 
@@ -1367,7 +1395,11 @@ void Filter::onReceiveMessage(std::unique_ptr<ProcessingResponse>&& r) {
       ENVOY_STREAM_LOG(debug, "Sending immediate response", *decoder_callbacks_);
       processing_complete_ = true;
       onFinishProcessorCalls(Grpc::Status::Ok);
-      closeStream();
+      if (config_->gracefulGrpcClose()) {
+        halfCloseAndWaitForRemoteClose();
+      } else {
+        closeStream();
+      }
       if (on_processing_response_) {
         on_processing_response_->afterReceivingImmediateResponse(*response, processing_status,
                                                                  decoder_callbacks_->streamInfo());

--- a/source/extensions/filters/http/ext_proc/ext_proc.h
+++ b/source/extensions/filters/http/ext_proc/ext_proc.h
@@ -281,6 +281,10 @@ public:
     return grpc_service_;
   }
 
+  bool gracefulGrpcClose() const { return graceful_grpc_close_; }
+
+  std::chrono::milliseconds remoteCloseTimeout() const { return remote_close_timeout_; }
+
   std::unique_ptr<OnProcessingResponse> createOnProcessingResponse() const;
 
 private:
@@ -317,6 +321,7 @@ private:
   const std::vector<Matchers::StringMatcherPtr> disallowed_headers_;
   // is_upstream_ is true if ext_proc filter is in the upstream filter chain.
   const bool is_upstream_;
+  const bool graceful_grpc_close_;
   const std::vector<std::string> untyped_forwarding_namespaces_;
   const std::vector<std::string> typed_forwarding_namespaces_;
   const std::vector<std::string> untyped_receiving_namespaces_;
@@ -329,6 +334,7 @@ private:
   const std::function<std::unique_ptr<OnProcessingResponse>()> on_processing_response_factory_cb_;
 
   ThreadLocal::SlotPtr thread_local_stream_manager_slot_;
+  const std::chrono::milliseconds remote_close_timeout_;
 };
 
 using FilterConfigSharedPtr = std::shared_ptr<FilterConfig>;
@@ -470,6 +476,7 @@ private:
   void mergePerRouteConfig();
   StreamOpenState openStream();
   void closeStream();
+  void halfCloseAndWaitForRemoteClose();
 
   void onFinishProcessorCalls(Grpc::Status::GrpcStatus call_status);
   void clearAsyncState();

--- a/test/common/grpc/grpc_client_integration_test.cc
+++ b/test/common/grpc/grpc_client_integration_test.cc
@@ -109,6 +109,54 @@ TEST_P(GrpcClientIntegrationTest, BasicStream) {
   stream->waitForReset();
 }
 
+TEST_P(GrpcClientIntegrationTest, BasicStreamWithGracefulClose) {
+  initialize();
+  auto stream = createStream(empty_metadata_);
+  stream->sendRequest();
+  stream->sendServerInitialMetadata(empty_metadata_);
+  stream->sendReply();
+  stream->closeStream();
+  stream->sendServerTrailers(Status::WellKnownGrpcStatus::Ok, "", empty_metadata_);
+  dispatcher_helper_.runDispatcher();
+}
+
+TEST_P(GrpcClientIntegrationTest, BasicStreamDeleteOnRemoteClose) {
+  setOnDeleteCallback();
+  initialize();
+  auto stream = createStream(empty_metadata_);
+  stream->sendRequest();
+  stream->sendServerInitialMetadata(empty_metadata_);
+  stream->sendReply();
+  stream->runDispatcherUntilResponseReceived();
+
+  stream->closeStream();
+  stream->waitForRemoteCloseAndDelete();
+  stream->encodeServerTrailers(Status::WellKnownGrpcStatus::Ok, "", empty_metadata_);
+  runDispatcherUntilStreamDeletion();
+}
+
+TEST_P(GrpcClientIntegrationTest, BasicStreamDeleteOnTimeout) {
+  // Make remote close timeout small, so that the test does not timeout.
+  remote_close_timeout_ = std::chrono::milliseconds(100);
+  setOnDeleteCallback();
+  initialize();
+  auto stream = createStream(empty_metadata_);
+  stream->sendRequest();
+  stream->sendServerInitialMetadata(empty_metadata_);
+  stream->sendReply();
+  stream->runDispatcherUntilResponseReceived();
+
+  stream->closeStream();
+  stream->waitForRemoteCloseAndDelete();
+  runDispatcherUntilStreamDeletion();
+  // Stream is reset if remote close timer expires.
+  if (clientType() == ClientType::EnvoyGrpc) {
+    // Envoy gRPC based AsyncGrpcClient also increments a counter.
+    EXPECT_EQ(
+        cm_.thread_local_cluster_.cluster_.info_->trafficStats()->upstream_rq_tx_reset_.value(), 1);
+  }
+}
+
 // Validate that a simple request-reply stream works.
 TEST_P(GrpcClientIntegrationTest, BasicStreamGracefulClose) {
   initialize();

--- a/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
+++ b/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
@@ -1088,6 +1088,87 @@ TEST_P(ExtProcIntegrationTest, GetAndFailStreamOnResponse) {
   verifyDownstreamResponse(*response, 500);
 }
 
+TEST_P(ExtProcIntegrationTest, OnlyRequestHeadersResetOnServerMessage) {
+  // Skip the header processing on response path.
+  proto_config_.mutable_processing_mode()->set_response_header_mode(ProcessingMode::SKIP);
+  initializeConfig();
+  HttpIntegrationTest::initialize();
+  auto response = sendDownstreamRequestWithBody("body", absl::nullopt);
+
+  processRequestHeadersMessage(
+      *grpc_upstreams_[0], true, [](const HttpHeaders&, HeadersResponse& headers_resp) {
+        // The response does not really matter, it just needs to be non-empty.
+        auto response_header_mutation = headers_resp.mutable_response()->mutable_header_mutation();
+        auto* mut1 = response_header_mutation->add_set_headers();
+        mut1->mutable_header()->set_key("x-new-header");
+        mut1->mutable_header()->set_raw_value("new");
+        return true;
+      });
+
+  ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, fake_upstream_connection_));
+  ASSERT_TRUE(fake_upstream_connection_->waitForNewStream(*dispatcher_, upstream_request_));
+  ASSERT_TRUE(upstream_request_->waitForEndStream(*dispatcher_));
+  EXPECT_EQ(upstream_request_->bodyLength(), 4);
+
+  EXPECT_THAT(upstream_request_->headers(), SingleHeaderValueIs("x-new-header", "new"));
+
+  upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, false);
+  upstream_request_->encodeData(100, true);
+
+  verifyDownstreamResponse(*response, 200);
+
+  // By default ext_proc will close and reset side stream when it finished processing downstream
+  // request.
+  EXPECT_TRUE(processor_stream_->waitForReset());
+  // In case of Envoy gRPC client the cluster reset stat will be incremented
+  if (IsEnvoyGrpc()) {
+    test_server_->waitForCounterGe("cluster.ext_proc_server_0.upstream_rq_tx_reset", 1);
+  }
+}
+
+TEST_P(ExtProcIntegrationTest, OnlyRequestHeadersGracefulClose) {
+  scoped_runtime_.mergeValues({{"envoy.reloadable_features.ext_proc_graceful_grpc_close", "true"}});
+  // Make remote close timeout long, so that test times out and fails if it is hit.
+  scoped_runtime_.mergeValues(
+      {{"envoy.filters.http.ext_proc.remote_close_timeout_milliseconds", "60000"}});
+  // Skip the header processing on response path.
+  proto_config_.mutable_processing_mode()->set_response_header_mode(ProcessingMode::SKIP);
+  initializeConfig();
+  HttpIntegrationTest::initialize();
+  auto response = sendDownstreamRequestWithBody("body", absl::nullopt);
+
+  processRequestHeadersMessage(
+      *grpc_upstreams_[0], true, [](const HttpHeaders&, HeadersResponse& headers_resp) {
+        // The response does not really matter, it just needs to be non-empty.
+        auto response_header_mutation = headers_resp.mutable_response()->mutable_header_mutation();
+        auto* mut1 = response_header_mutation->add_set_headers();
+        mut1->mutable_header()->set_key("x-new-header");
+        mut1->mutable_header()->set_raw_value("new");
+        return true;
+      });
+
+  ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, fake_upstream_connection_));
+  ASSERT_TRUE(fake_upstream_connection_->waitForNewStream(*dispatcher_, upstream_request_));
+  ASSERT_TRUE(upstream_request_->waitForEndStream(*dispatcher_));
+  EXPECT_EQ(upstream_request_->bodyLength(), 4);
+
+  EXPECT_THAT(upstream_request_->headers(), SingleHeaderValueIs("x-new-header", "new"));
+
+  upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, false);
+  upstream_request_->encodeData(100, true);
+
+  verifyDownstreamResponse(*response, 200);
+
+  // With graceful gRPC  close enabled, the client sends END_STREAM and waits for server to send
+  // trailers.
+  EXPECT_TRUE(processor_stream_->waitForEndStream(*dispatcher_));
+  processor_stream_->finishGrpcStream(Grpc::Status::Ok);
+  if (IsEnvoyGrpc()) {
+    // There should be no resets
+    EXPECT_EQ(test_server_->counter("cluster.ext_proc_server_0.upstream_rq_tx_reset")->value(), 0);
+  }
+}
+
 TEST_P(ExtProcIntegrationTest, OnlyRequestHeadersServerHalfClosesFirst) {
   // Skip the header processing on response path.
   proto_config_.mutable_processing_mode()->set_response_header_mode(ProcessingMode::SKIP);
@@ -2183,7 +2264,6 @@ TEST_P(ExtProcIntegrationTest, GetAndRespondImmediately) {
 
   // ext_proc will immediately close side stream in this case, which causes it to be reset,
   // since side stream codec had not yet observed server trailers.
-  // TODO(yanavlasov): Separate lifetimes of ext_proc and sidestream.
   EXPECT_TRUE(processor_stream_->waitForReset());
 
   verifyDownstreamResponse(*response, 401);
@@ -2191,6 +2271,78 @@ TEST_P(ExtProcIntegrationTest, GetAndRespondImmediately) {
   EXPECT_THAT(response->headers(), SingleHeaderValueIs("content-type", "application/json"));
   EXPECT_EQ("{\"reason\": \"Not authorized\"}", response->body());
 }
+
+TEST_P(ExtProcIntegrationTest, GetAndRespondImmediatelyGracefulClose) {
+  scoped_runtime_.mergeValues({{"envoy.reloadable_features.ext_proc_graceful_grpc_close", "true"}});
+  // Make remote close timeout long, so that test times out and fails if it is hit.
+  scoped_runtime_.mergeValues(
+      {{"envoy.filters.http.ext_proc.remote_close_timeout_milliseconds", "60000"}});
+  initializeConfig();
+  HttpIntegrationTest::initialize();
+  auto response = sendDownstreamRequest(absl::nullopt);
+
+  processAndRespondImmediately(*grpc_upstreams_[0], true, [](ImmediateResponse& immediate) {
+    immediate.mutable_status()->set_code(envoy::type::v3::StatusCode::Unauthorized);
+    immediate.set_body("{\"reason\": \"Not authorized\"}");
+    immediate.set_details("Failed because you are not authorized");
+    auto* hdr1 = immediate.mutable_headers()->add_set_headers();
+    hdr1->mutable_header()->set_key("x-failure-reason");
+    hdr1->mutable_header()->set_raw_value("testing");
+    auto* hdr2 = immediate.mutable_headers()->add_set_headers();
+    hdr2->mutable_header()->set_key("content-type");
+    hdr2->mutable_header()->set_raw_value("application/json");
+  });
+
+  // ext_proc will immediately half close side stream in this case. Server can then send trailers to
+  // fully close the stream.
+  EXPECT_TRUE(processor_stream_->waitForEndStream(*dispatcher_));
+  processor_stream_->finishGrpcStream(Grpc::Status::Ok);
+
+  verifyDownstreamResponse(*response, 401);
+  EXPECT_THAT(response->headers(), SingleHeaderValueIs("x-failure-reason", "testing"));
+  EXPECT_THAT(response->headers(), SingleHeaderValueIs("content-type", "application/json"));
+  EXPECT_EQ("{\"reason\": \"Not authorized\"}", response->body());
+  if (IsEnvoyGrpc()) {
+    // There should be no resets
+    EXPECT_EQ(test_server_->counter("cluster.ext_proc_server_0.upstream_rq_tx_reset")->value(), 0);
+  }
+}
+
+TEST_P(ExtProcIntegrationTest, GetAndRespondImmediatelyGracefulCloseNoServerTrailers) {
+  scoped_runtime_.mergeValues({{"envoy.reloadable_features.ext_proc_graceful_grpc_close", "true"}});
+  // Make remote close timeout short, so that test does not time out.
+  scoped_runtime_.mergeValues(
+      {{"envoy.filters.http.ext_proc.remote_close_timeout_milliseconds", "100"}});
+  initializeConfig();
+  HttpIntegrationTest::initialize();
+  auto response = sendDownstreamRequest(absl::nullopt);
+
+  processAndRespondImmediately(*grpc_upstreams_[0], true, [](ImmediateResponse& immediate) {
+    immediate.mutable_status()->set_code(envoy::type::v3::StatusCode::Unauthorized);
+    immediate.set_body("{\"reason\": \"Not authorized\"}");
+    immediate.set_details("Failed because you are not authorized");
+    auto* hdr1 = immediate.mutable_headers()->add_set_headers();
+    hdr1->mutable_header()->set_key("x-failure-reason");
+    hdr1->mutable_header()->set_raw_value("testing");
+    auto* hdr2 = immediate.mutable_headers()->add_set_headers();
+    hdr2->mutable_header()->set_key("content-type");
+    hdr2->mutable_header()->set_raw_value("application/json");
+  });
+
+  // ext_proc will immediately half close side stream in this case.
+  EXPECT_TRUE(processor_stream_->waitForEndStream(*dispatcher_));
+  // However server fails to send trailers
+
+  verifyDownstreamResponse(*response, 401);
+  EXPECT_THAT(response->headers(), SingleHeaderValueIs("x-failure-reason", "testing"));
+  EXPECT_THAT(response->headers(), SingleHeaderValueIs("content-type", "application/json"));
+  EXPECT_EQ("{\"reason\": \"Not authorized\"}", response->body());
+
+  // Since the server did not send trailers, gRPC client will reset the stream after remote close
+  // timer expires.
+  EXPECT_TRUE(processor_stream_->waitForReset());
+}
+
 TEST_P(ExtProcIntegrationTest, GetAndRespondImmediatelyWithLogging) {
   ConfigOptions config_option = {};
   config_option.add_logging_filter = true;

--- a/test/mocks/grpc/mocks.h
+++ b/test/mocks/grpc/mocks.h
@@ -39,6 +39,7 @@ public:
   MOCK_METHOD(void, sendMessageRaw_, (Buffer::InstancePtr & request, bool end_stream));
   MOCK_METHOD(void, closeStream, ());
   MOCK_METHOD(void, resetStream, ());
+  MOCK_METHOD(void, waitForRemoteCloseAndDelete, ());
   MOCK_METHOD(bool, isAboveWriteBufferHighWatermark, (), (const));
   MOCK_METHOD(const StreamInfo::StreamInfo&, streamInfo, (), (const));
   MOCK_METHOD(StreamInfo::StreamInfo&, streamInfo, (), ());


### PR DESCRIPTION
Commit Message:
Implemented graceful close of gRPC side streams, where the client half-closes its stream and waits  (with timeout) for the server to half-close its stream.

This behavioral change is disabled by default and can be enabled by setting runtime guard ``envoy.reloadable_features.ext_proc_graceful_grpc_close`` to true.

The remote close timeout is 1 second by default and can be chnaged by setting the ``envoy.filters.http.ext_proc.remote_close_timeout_milliseconds`` runtime value.

Additional Description:
Currently ext_proc gRPC side streams are always reset with RST_STREAM. This leads to two problems:
1. Poor observability of error conditions on side streams, as all streams end with RST_STREAM.
2. Envoy never receives trailers with gRPC status and metadata from the server, since the stream is reset before it. The trailing metadata contains billing information and may contain load reports which are now lost.

Risk Level: Low, behavior disabled by default
Testing: Unit Tests
Docs Changes: N/A
Release Notes: Yes
Platform Specific Features: N/A
Runtime guard: envoy.reloadable_features.ext_proc_graceful_grpc_close
