### PR TITLE
fix: fix local ratelimit spelling

### DIFF
--- a/source/extensions/filters/http/local_ratelimit/local_ratelimit.cc
+++ b/source/extensions/filters/http/local_ratelimit/local_ratelimit.cc
@@ -46,7 +46,7 @@ FilterConfig::FilterConfig(
                     Envoy::Runtime::FractionalPercent(config.filter_enabled(), runtime_))
               : absl::nullopt),
       filter_enforced_(
-          config.has_filter_enabled()
+          config.has_filter_enforced()
               ? absl::optional<Envoy::Runtime::FractionalPercent>(
                     Envoy::Runtime::FractionalPercent(config.filter_enforced(), runtime_))
               : absl::nullopt),

--- a/test/extensions/filters/http/local_ratelimit/filter_test.cc
+++ b/test/extensions/filters/http/local_ratelimit/filter_test.cc
@@ -56,22 +56,45 @@ enable_x_ratelimit_headers: {}
 // For instance, fmt::format(config_yaml, "1", "false") substitutes '1' and 'false' for 'max_tokens'
 // and 'local_rate_limit_per_downstream_connection' configurations, respectively.
 
+static constexpr absl::string_view simple_config_yaml_without_enforce = R"(
+  stat_prefix: test
+  token_bucket:
+    max_tokens: 1
+    tokens_per_fill: 1
+    fill_interval: 1000s
+  filter_enabled:
+    runtime_key: test_enabled
+    default_value:
+      numerator: 100
+      denominator: HUNDRED
+)";
+
 class FilterTest : public testing::Test {
 public:
   FilterTest() = default;
 
   void setupPerRoute(const std::string& yaml, const bool enabled = true, const bool enforced = true,
-                     const bool per_route = false) {
-    EXPECT_CALL(
-        factory_context_.runtime_loader_.snapshot_,
-        featureEnabled(absl::string_view("test_enabled"),
-                       testing::Matcher<const envoy::type::v3::FractionalPercent&>(Percent(100))))
-        .WillRepeatedly(testing::Return(enabled));
-    EXPECT_CALL(
-        factory_context_.runtime_loader_.snapshot_,
-        featureEnabled(absl::string_view("test_enforced"),
-                       testing::Matcher<const envoy::type::v3::FractionalPercent&>(Percent(100))))
-        .WillRepeatedly(testing::Return(enforced));
+                     const bool per_route = false, const bool has_enabled = true,
+                     const bool has_enforced = true) {
+    if (has_enabled) {
+      EXPECT_CALL(
+          factory_context_.runtime_loader_.snapshot_,
+          featureEnabled(absl::string_view("test_enabled"),
+                         testing::Matcher<const envoy::type::v3::FractionalPercent&>(Percent(100))))
+          .WillRepeatedly(testing::Return(enabled));
+    } else {
+      ASSERT(!enabled); // No filter_enabled and this should be false always.
+    }
+
+    if (has_enforced) {
+      EXPECT_CALL(
+          factory_context_.runtime_loader_.snapshot_,
+          featureEnabled(absl::string_view("test_enforced"),
+                         testing::Matcher<const envoy::type::v3::FractionalPercent&>(Percent(100))))
+          .WillRepeatedly(testing::Return(enforced));
+    } else {
+      ASSERT(!enforced); // No filter_enforced and this should be false always.
+    }
 
     ON_CALL(decoder_callbacks_, dispatcher()).WillByDefault(ReturnRef(dispatcher_));
     ON_CALL(decoder_callbacks_2_, dispatcher()).WillByDefault(ReturnRef(dispatcher_));
@@ -124,6 +147,14 @@ TEST_F(FilterTest, Disabled) {
   auto headers = Http::TestRequestHeaderMapImpl();
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(headers, false));
   EXPECT_EQ(0U, findCounter("test.http_local_rate_limit.enabled"));
+  EXPECT_EQ(0U, findCounter("test.http_local_rate_limit.enforced"));
+}
+
+TEST_F(FilterTest, NoEnforced) {
+  setupPerRoute(std::string(simple_config_yaml_without_enforce), true, false, false, true, false);
+  auto headers = Http::TestRequestHeaderMapImpl();
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(headers, false));
+  EXPECT_EQ(1U, findCounter("test.http_local_rate_limit.enabled"));
   EXPECT_EQ(0U, findCounter("test.http_local_rate_limit.enforced"));
 }
 


### PR DESCRIPTION
Commit Message: fix: fix local ratelimit spelling
Additional Description:

Fixed a bug where use the has_filter_enabled to check if the filter_enforced exists or not.

Risk Level: low.
Testing: unit.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.