### PR TITLE
WIP: ci: use oracle-hosted gha runners

### DIFF
--- a/.github/workflows/_precheck_publish.yml
+++ b/.github/workflows/_precheck_publish.yml
@@ -71,7 +71,7 @@ jobs:
           bazel-extra: >-
             --config=remote-cache-envoy-engflow
           rbe: false
-          runs-on: envoy-arm64-large
+          runs-on: oracle-32cpu-128gb-arm64
           timeout-minutes: 180
         - target: docs
           name: Docs

--- a/.github/workflows/_publish_build.yml
+++ b/.github/workflows/_publish_build.yml
@@ -76,7 +76,7 @@ jobs:
           bazel-extra: >-
             --config=remote-cache-envoy-engflow
           rbe: false
-          runs-on: envoy-arm64-medium
+          runs-on: oracle-16cpu-64gb-arm64
 
   distribution:
     permissions:

--- a/.github/workflows/_request_cache_bazel.yml
+++ b/.github/workflows/_request_cache_bazel.yml
@@ -70,7 +70,7 @@ jobs:
       name: Setup GCP
       with:
         key: ${{ secrets.gcs-cache-key }}
-        force-install: ${{ contains(fromJSON('["envoy-arm64-medium", "github-arm64-2c-8gb"]'), inputs.runs-on) }}
+        force-install: ${{ contains(fromJSON('["oracle-16cpu-64gb-arm64", "oracle-2cpu-8gb-arm64"]'), inputs.runs-on) }}
     - run: |
         # Simulate container build directory
         sudo mkdir /build

--- a/.github/workflows/_run.yml
+++ b/.github/workflows/_run.yml
@@ -262,7 +262,7 @@ jobs:
       if: ${{ inputs.gcs-cache-bucket }}
       with:
         key: ${{ secrets.gcs-cache-key }}
-        force-install: ${{ contains(fromJSON('["envoy-arm64-medium", "github-arm64-2c-8gb"]'), inputs.runs-on) }}
+        force-install: ${{ contains(fromJSON('["oracle-16cpu-64gb-arm64", "github-arm64-2c-8gb"]'), inputs.runs-on) }}
     - uses: envoyproxy/toolshed/gh-actions/cache/restore@actions-v0.3.15
       if: ${{ inputs.gcs-cache-bucket }}
       name: >-


### PR DESCRIPTION
CNCF has hosted ephemeral GitHub runners in Oracle that we're wanting projects to use rather than the GitHub hosted ones, which are now incur a cost to use. This PR is currently a WIP to work through any tests that break or dependencies that may be missing. <3

cc @krook @robertkielty

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: use oracle-hosted gha runners
Additional Description: This updates the GitHub workflows to use the GitHub ARC-managed runners in Oracle
Risk Level: Medium
Testing: This PR is to test the change :) 
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
