### PR TITLE
disable ASSERTs in header_parser_fuzz_test

### DIFF
--- a/test/common/router/header_parser_corpus/invalid_header_string
+++ b/test/common/router/header_parser_corpus/invalid_header_string
@@ -1,0 +1,96 @@
+headers_to_add {
+  header {
+    key: "?"
+    value: "%%UPSTREAM_METADATA([\"evoMETA||||||||tyy.typeN\"])%%UP"
+  }
+}
+headers_to_add {
+  header {
+    key: "?"
+    value: "%%UPSTREAM_METADAT([\"evoMETA||||||||tyy.typeN\"])%%UP"
+  }
+}
+headers_to_add {
+  header {
+    key: "4"
+    value: "%%UPSTREAM_METADATA([\"evoMETA||||||||tyy.typeN\"])%%peN\"])%%UP"
+  }
+}
+headers_to_add {
+  header {
+    key: "4"
+    value: "%%UPSTREAM_METADATA([\"evoMETA||||||||!                                                     fields {\\n                                                                key: \\\"<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<\\\\177\\\"\\n                                                                value {\\n                                                                  struct_value {\\n                                                                    fields {\\n                                                                      key: \\\"<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<\\\"\\n                                                                      value {\\n                                                                      }\\n                                                                    }\\n                                                                    fields {\\n                                                                      key: \\\"<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<\\\\177\\\"\\n                                                                      value {\\n                                                                        bool_value: false\\n                                                                      }\\n                                                                    }\\n                                                                    fields {\\n                                                                      key: \\\"<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<\\\\177\\\"\\n                               tyy.typeN\"])%%UP"
+  }
+}
+headers_to_add {
+  header {
+    key: "4"
+    value: "%%UPSTREAM_METADATA([\"evoMETA||||||||tyy.typeN\"])%%UP"
+  }
+}
+headers_to_add {
+  header {
+    key: "4"
+    value: "%%UPSTREAM_METADATA([\"evoMETA||||||||tyy.typeN\"])%%UP"
+  }
+}
+headers_to_add {
+  header {
+    key: "4"
+    value: "%%UPSTREAM_METADATA([\"evoMETA||||||||tyy.typeN\"]+%%UP"
+  }
+}
+headers_to_add {
+  header {
+    key: "4"
+    value: "%%UPSTREAM_METADATA([\"evoMETA||||||||tyy.typeN\"])%%UP"
+  }
+}
+headers_to_add {
+  header {
+    key: "4"
+    value: "%%UPSTREAM_METADATA([\"evoMA([\"evoMETA||||||||tyy.typeN\"])%%UP"
+  }
+}
+headers_to_add {
+  header {
+    key: "4"
+    value: "%%UPSTREAM_METADATA([\"evoMETA||||||||tyy.typeN\"])%%UP"
+  }
+}
+headers_to_add {
+  header {
+    key: "4"
+    value: "%%UPSTREAM_METADATA([\"evoMETA||||||||tyy.typeN\"])%%UP"
+  }
+}
+headers_to_add {
+  header {
+    key: "4"
+    value: "%%UPSTREAM_METADATA([\"evoMETA||||||||tyy.typeN\"])%%UP"
+  }
+}
+headers_to_add {
+  header {
+    key: "4"
+    value: "%%UPSTREAM_METADATA([\"evoMETA||||||||tyy.typeN\"])%%UP"
+  }
+}
+headers_to_add {
+  header {
+    key: "4"
+    value: "%%UPSTREAM_METADATA([\"evoMETA||||||||tyy.typeN\"])%%UP"
+  }
+}
+headers_to_add {
+  header {
+    key: "?"
+    value: "%%UPSTREAM_METADATA([\"evoMETA||||||||tyy.typeN\"])%%UP"
+  }
+}
+headers_to_add {
+  header {
+    key: "4"
+    value: "%%UPSTREAM_METADATA([\"evoMETA||||||||tyy.typeN\"])%%UP"
+  }
+}

--- a/test/common/router/header_parser_fuzz_test.cc
+++ b/test/common/router/header_parser_fuzz_test.cc
@@ -23,6 +23,7 @@ DEFINE_PROTO_FUZZER(const test::common::router::TestCase& input) {
     MockTimeSystem time_system_;
     std::unique_ptr<TestStreamInfo> test_stream_info =
         fromStreamInfo(input.stream_info(), time_system_);
+    Http::HeaderStringValidator::disable_validation_for_tests_ = true;
     parser_or_error.value()->evaluateHeaders(
         request_header_map, {&request_header_map, &response_header_map}, *test_stream_info);
     ENVOY_LOG_MISC(trace, "Success");


### PR DESCRIPTION
Commit Message: disable ASSERTs in header_parser_fuzz_test
Additional Description:

The asserts fail on the fuzz test case I add in this PR. These asserts have no effect in production, so sanitizing illegal characters in the fuzz input could hide crashes that would affect production. Therefore, we should disable these asserts in the fuzz test.

Risk Level: none
Testing: fuzz test improvement
Docs Changes: none
Release Notes: none