### PR TITLE
cds: clarify misleading/incomplete `info` logs

### DIFF
--- a/source/common/upstream/cds_api_helper.cc
+++ b/source/common/upstream/cds_api_helper.cc
@@ -84,7 +84,7 @@ CdsApiHelper::onConfigUpdate(const std::vector<Config::DecodedResourceRef>& adde
   ENVOY_LOG(
       info,
       "{}: added/updated {} cluster(s) (skipped {} unmodified cluster(s)); removed {} cluster(s)",
-      name_, added_or_updated, removed, skipped);
+      name_, added_or_updated, skipped, removed);
 
   if (any_applied) {
     system_version_info_ = system_version_info;

--- a/source/common/upstream/cds_api_helper.cc
+++ b/source/common/upstream/cds_api_helper.cc
@@ -28,7 +28,7 @@ CdsApiHelper::onConfigUpdate(const std::vector<Config::DecodedResourceRef>& adde
     maybe_resume_eds_leds_sds = cm_.adsMux()->pause(paused_xds_types);
   }
 
-  ENVOY_LOG(debug, "{}: add {} cluster(s), remove {} cluster(s)", name_, added_resources.size(),
+  ENVOY_LOG(info, "{}: response indicates {} added/updated cluster(s), {} removed cluster(s); applying changes", name_, added_resources.size(),
             removed_resources.size());
 
   std::vector<std::string> exception_msgs;
@@ -81,7 +81,7 @@ CdsApiHelper::onConfigUpdate(const std::vector<Config::DecodedResourceRef>& adde
 
   ENVOY_LOG(
       info,
-      "{}: added/updated {} cluster(s), removed {} cluster(s), skipped {} unmodified cluster(s)",
+      "{}: added/updated {} cluster(s) (skipped {} unmodified cluster(s)); removed {} cluster(s)",
       name_, added_or_updated, removed, skipped);
 
   if (any_applied) {

--- a/source/common/upstream/cds_api_helper.cc
+++ b/source/common/upstream/cds_api_helper.cc
@@ -28,7 +28,7 @@ CdsApiHelper::onConfigUpdate(const std::vector<Config::DecodedResourceRef>& adde
     maybe_resume_eds_leds_sds = cm_.adsMux()->pause(paused_xds_types);
   }
 
-  ENVOY_LOG(info, "{}: add {} cluster(s), remove {} cluster(s)", name_, added_resources.size(),
+  ENVOY_LOG(debug, "{}: add {} cluster(s), remove {} cluster(s)", name_, added_resources.size(),
             removed_resources.size());
 
   std::vector<std::string> exception_msgs;
@@ -70,15 +70,19 @@ CdsApiHelper::onConfigUpdate(const std::vector<Config::DecodedResourceRef>& adde
           { exception_msgs.push_back(fmt::format("{}: {}", cluster_name, e.what())); });
   }
 
+  uint32_t removed = 0;
   for (const auto& resource_name : removed_resources) {
     if (cm_.removeCluster(resource_name)) {
       any_applied = true;
       ENVOY_LOG(debug, "{}: remove cluster '{}'", name_, resource_name);
+      ++removed;
     }
   }
 
-  ENVOY_LOG(info, "{}: added/updated {} cluster(s), skipped {} unmodified cluster(s)", name_,
-            added_or_updated, skipped);
+  ENVOY_LOG(
+      info,
+      "{}: added/updated {} cluster(s), removed {} cluster(s), skipped {} unmodified cluster(s)",
+      name_, added_or_updated, removed, skipped);
 
   if (any_applied) {
     system_version_info_ = system_version_info;

--- a/source/common/upstream/cds_api_helper.cc
+++ b/source/common/upstream/cds_api_helper.cc
@@ -28,8 +28,10 @@ CdsApiHelper::onConfigUpdate(const std::vector<Config::DecodedResourceRef>& adde
     maybe_resume_eds_leds_sds = cm_.adsMux()->pause(paused_xds_types);
   }
 
-  ENVOY_LOG(info, "{}: response indicates {} added/updated cluster(s), {} removed cluster(s); applying changes", name_, added_resources.size(),
-            removed_resources.size());
+  ENVOY_LOG(
+      info,
+      "{}: response indicates {} added/updated cluster(s), {} removed cluster(s); applying changes",
+      name_, added_resources.size(), removed_resources.size());
 
   std::vector<std::string> exception_msgs;
   absl::flat_hash_set<std::string> cluster_names(added_resources.size());


### PR DESCRIPTION
Clarify the log message that counts inputs to `onConfigUpdate` to say that its numbers are derived from the CDS response.  The existing message was especially confusing for SotW because you don't indicate removed responses in SotW as you do in delta: Envoy just finds every cluster not present in the CDS response (including non-CDS clusters!) and calls them "removed", which can be confusing/alarming if you don't know what the code emitting the log message is actually doing.

And improve the log message that actually counts what changes were applied to include removals, to match what the first one is logging.