### PR TITLE
redis: fix segfault in redis cluster on empty dns response - Fixes #37769

### DIFF
--- a/source/extensions/clusters/redis/redis_cluster.cc
+++ b/source/extensions/clusters/redis/redis_cluster.cc
@@ -390,7 +390,7 @@ void RedisCluster::RedisDiscoverySession::resolveClusterHostnames(
               // A successful query can return an empty response, and we need to
               // guard against that before attempting to dereference the response.
               ENVOY_LOG(error, "DNS resolution for primary slot address {} returned no results",
-                slot.primary_hostname_);
+                        slot.primary_hostname_);
               resolve_timer_->enableTimer(parent_.cluster_refresh_rate_);
               return;
             }
@@ -447,7 +447,8 @@ void RedisCluster::RedisDiscoverySession::resolveReplicas(
           } else if (response.empty()) {
             // A successful query can return an empty response, and we need to
             // guard against that before attempting to dereference the response.
-            ENVOY_LOG(warn, "DNS resolution for cluster replica address {} returned no results", replica.first);
+            ENVOY_LOG(warn, "DNS resolution for cluster replica address {} returned no results",
+                      replica.first);
           } else {
             // Replica resolved
             slot.addReplica(Network::Utility::getAddressWithPort(

--- a/source/extensions/clusters/redis/redis_cluster.cc
+++ b/source/extensions/clusters/redis/redis_cluster.cc
@@ -386,6 +386,13 @@ void RedisCluster::RedisDiscoverySession::resolveClusterHostnames(
                         slot.primary_hostname_);
               resolve_timer_->enableTimer(parent_.cluster_refresh_rate_);
               return;
+            } else if (response.empty()) {
+              // A successful query can return an empty response, and we need to
+              // guard against that before attempting to dereference the response.
+              ENVOY_LOG(error, "DNS resolution for primary slot address {} returned no results",
+                slot.primary_hostname_);
+              resolve_timer_->enableTimer(parent_.cluster_refresh_rate_);
+              return;
             }
             // Primary slot address resolved
             slot.setPrimary(Network::Utility::getAddressWithPort(
@@ -437,6 +444,10 @@ void RedisCluster::RedisDiscoverySession::resolveReplicas(
           // We log a warn message.
           if (status != Network::DnsResolver::ResolutionStatus::Completed) {
             ENVOY_LOG(warn, "Unable to resolve cluster replica address {}", replica.first);
+          } else if (response.empty()) {
+            // A successful query can return an empty response, and we need to
+            // guard against that before attempting to dereference the response.
+            ENVOY_LOG(warn, "DNS resolution for cluster replica address {} returned no results", replica.first);
           } else {
             // Replica resolved
             slot.addReplica(Network::Utility::getAddressWithPort(


### PR DESCRIPTION
Commit Message: Fix a segmentation fault in redis cluster when the cluster primary/replica address lookups return an empty response.

Additional Description: An empty response can happen if there's a DNS timeout, because c-ares' E_TIMEOUT result is treated as if it was a successful response. There may be a bigger fix there to treat it more like a SERVFAIL response, but I'll leave that low-level change to someone who better knows Envoy's internals and the impacts of that change. This is a targeted fix because no matter what it seems safe to check for an empty list before accessing it.

Risk Level: Low

Testing: We were able to confirm this patch resolves the segmentation fault, but writing unit tests for this is a bit beyond me. I absolutely welcome any help in that department.

Docs Changes: N/A

Release Notes: N/A (I think)

Platform Specific Features: N/A

Fixes #37769
