### PR TITLE
Ensure SocketOptionImpl.value_.data() is pointer-size-aligned.

### DIFF
--- a/source/common/memory/BUILD
+++ b/source/common/memory/BUILD
@@ -9,6 +9,13 @@ licenses(["notice"])  # Apache 2
 envoy_package()
 
 envoy_cc_library(
+    name = "aligned_allocator_lib",
+    hdrs = ["aligned_allocator.h"],
+    deps = [
+    ],
+)
+
+envoy_cc_library(
     name = "stats_lib",
     srcs = ["stats.cc"],
     hdrs = ["stats.h"],

--- a/source/common/memory/aligned_allocator.h
+++ b/source/common/memory/aligned_allocator.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdlib>
+
+namespace Envoy {
+namespace Memory {
+
+// Custom allocator using std::aligned_alloc to allocate |T|s at |Alignment|.
+template <typename T, std::size_t Alignment> class AlignedAllocator {
+public:
+  static_assert((Alignment & (Alignment - 1)) == 0, "Alignment must be a power of 2");
+  using value_type = T;
+
+  AlignedAllocator() noexcept = default;
+
+  // Copy constructor for rebind compatibility.
+  template <typename U> explicit AlignedAllocator(const AlignedAllocator<U, Alignment>&) noexcept {}
+
+  static std::size_t round_up_to_alignment(std::size_t bytes) {
+    return (bytes + Alignment - 1) & ~(Alignment - 1);
+  }
+
+  // Allocate aligned memory.
+  // This never throws std::bad_alloc, it returns nullptr on failure.
+  T* allocate(std::size_t n) {
+    // STL containers never call allocate with n=0.
+    if (n == 0) {
+      return nullptr;
+    }
+    std::size_t bytes = n * sizeof(T);
+    // Ensure bytes is a multiple of Alignment, which is required by std::aligned_alloc.
+    bytes = round_up_to_alignment(bytes);
+    return static_cast<T*>(std::aligned_alloc(Alignment, bytes));
+  }
+
+  void deallocate(T* p, std::size_t) noexcept {
+    if (p != nullptr) {
+      std::free(p);
+    }
+  }
+
+  // Equality operators (required for allocator_traits)
+  template <typename U> bool operator==(const AlignedAllocator<U, Alignment>&) const noexcept {
+    return true;
+  }
+
+  template <typename U> bool operator!=(const AlignedAllocator<U, Alignment>&) const noexcept {
+    return false;
+  }
+
+  // Satisfy libc++ requirement.
+  template <typename U> struct rebind { using other = AlignedAllocator<U, Alignment>; };
+};
+
+} // namespace Memory
+} // namespace Envoy

--- a/source/common/network/BUILD
+++ b/source/common/network/BUILD
@@ -421,6 +421,7 @@ envoy_cc_library(
         "//source/common/common:minimal_logger_lib",
         "//source/common/common:scalar_to_byte_vector_lib",
         "//source/common/common:utility_lib",
+        "//source/common/memory:aligned_allocator_lib",
         "@com_google_absl//absl/types:optional",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
     ],

--- a/test/common/memory/BUILD
+++ b/test/common/memory/BUILD
@@ -10,6 +10,13 @@ licenses(["notice"])  # Apache 2
 envoy_package()
 
 envoy_cc_test(
+    name = "aligned_allocator_test",
+    srcs = ["aligned_allocator_test.cc"],
+    rbe_pool = "6gig",
+    deps = ["//source/common/memory:aligned_allocator_lib"],
+)
+
+envoy_cc_test(
     name = "debug_test",
     srcs = ["debug_test.cc"],
     rbe_pool = "6gig",

--- a/test/common/memory/aligned_allocator_test.cc
+++ b/test/common/memory/aligned_allocator_test.cc
@@ -1,0 +1,54 @@
+#include <array>
+#include <vector>
+
+#include "source/common/memory/aligned_allocator.h"
+
+#include "gtest/gtest.h"
+
+namespace Envoy {
+namespace Memory {
+namespace {
+
+TEST(AlignedAllocatorTest, AllocationSize) {
+  using Alloc = AlignedAllocator<uint8_t, 8>;
+  EXPECT_EQ(Alloc::round_up_to_alignment(0), 0);
+  EXPECT_EQ(Alloc::round_up_to_alignment(1), 8);
+  EXPECT_EQ(Alloc::round_up_to_alignment(2), 8);
+  EXPECT_EQ(Alloc::round_up_to_alignment(4), 8);
+  EXPECT_EQ(Alloc::round_up_to_alignment(7), 8);
+  EXPECT_EQ(Alloc::round_up_to_alignment(8), 8);
+  EXPECT_EQ(Alloc::round_up_to_alignment(9), 16);
+  EXPECT_EQ(Alloc::round_up_to_alignment(12), 16);
+  EXPECT_EQ(Alloc::round_up_to_alignment(15), 16);
+  EXPECT_EQ(Alloc::round_up_to_alignment(16), 16);
+  EXPECT_EQ(Alloc::round_up_to_alignment(17), 24);
+}
+
+TEST(AlignedAllocatorTest, Allocation) {
+  AlignedAllocator<uint8_t, alignof(void*)> alloc;
+  for (int i = 0; i < 1000; ++i) {
+    const std::size_t n = i + 1;
+    uint8_t* p = alloc.allocate(n);
+    EXPECT_EQ(reinterpret_cast<uintptr_t>(p) % alignof(void*), 0);
+    alloc.deallocate(p, n);
+  }
+}
+
+TEST(AlignedAllocatorTest, AllocationInVector) {
+  using AlignedVector = std::vector<uint8_t, AlignedAllocator<uint8_t, alignof(void*)>>;
+  for (int i = 0; i < 1000; ++i) {
+    std::array<char, 4> a;
+    AlignedVector v(a.begin(), a.end());
+    EXPECT_EQ(reinterpret_cast<uintptr_t>(v.data()) % alignof(void*), 0);
+  }
+}
+
+TEST(AlignedAllocatorTest, Nullability) {
+  AlignedAllocator<uint8_t, alignof(void*)> alloc;
+  EXPECT_EQ(alloc.allocate(0), nullptr);
+  alloc.deallocate(nullptr, 0); // Should not crash
+}
+
+} // namespace
+} // namespace Memory
+} // namespace Envoy


### PR DESCRIPTION
This should fix https://github.com/envoyproxy/envoy/issues/7968 for good.

Commit Message: Ensure SocketOptionImpl.value_.data() is pointer-size-aligned.
Additional Description:
Risk Level: None
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:

