### PR TITLE
conn pool: fix preconnect math

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -58,6 +58,12 @@ bug_fixes:
   change: |
     Fixed OAuth2 credential injector to send scope (if specified) to authorization server when requesting new access
     token using ``client_credentials`` flow.
+- area: connection pool
+  change: |
+    Fixed a bug in :ref:`preconnecting <envoy_v3_api_msg_config.cluster.v3.Cluster.PreconnectPolicy>` where established connection
+    unused capacity was not considered in the logic to establish new connections, resulting in new connections anytime there was not
+    a connection currently in the process of being established. This resulted in far too many connections being established, with the only
+    bounds being cluster circuit breaker limits or upstream service limits.
 - area: ext_authz
   change: |
     Removed validation constraint on :ref:`disabled <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute.disabled>` so

--- a/source/common/conn_pool/conn_pool_base.cc
+++ b/source/common/conn_pool/conn_pool_base.cc
@@ -114,9 +114,10 @@ bool ConnPoolImplBase::shouldCreateNewConnection(float global_preconnect_ratio) 
                       connecting_and_connected_stream_capacity_, global_preconnect_ratio, true);
     ENVOY_LOG(trace,
               "predictive shouldCreateNewConnection returns {} for pending {} active {} "
-              "current_capacity {} ratio {}",
+              "connecting_and_connected_capacity {} connecting_capacity {} ratio {}",
               result, pending_streams_.size(), num_active_streams_,
-              connecting_and_connected_stream_capacity_, global_preconnect_ratio);
+              connecting_and_connected_stream_capacity_, connecting_stream_capacity_,
+              global_preconnect_ratio);
     return result;
   } else {
     // Ensure this local pool has adequate connections for the given load.
@@ -129,9 +130,10 @@ bool ConnPoolImplBase::shouldCreateNewConnection(float global_preconnect_ratio) 
                       connecting_and_connected_stream_capacity_, perUpstreamPreconnectRatio());
     ENVOY_LOG(trace,
               "per-upstream shouldCreateNewConnection returns {} for pending {} active {} "
-              "connecting_capacity {} ratio {}",
+              "connecting_and_connected_capacity {} connecting_capacity {} ratio {}",
               result, pending_streams_.size(), num_active_streams_,
-              connecting_and_connected_stream_capacity_, perUpstreamPreconnectRatio());
+              connecting_and_connected_stream_capacity_, connecting_stream_capacity_,
+              perUpstreamPreconnectRatio());
     return result;
   }
 }
@@ -162,7 +164,6 @@ ConnPoolImplBase::ConnectionResult
 ConnPoolImplBase::tryCreateNewConnection(float global_preconnect_ratio) {
   // There are already enough Connecting connections for the number of queued streams.
   if (!shouldCreateNewConnection(global_preconnect_ratio)) {
-    ENVOY_LOG(trace, "not creating a new connection, shouldCreateNewConnection returned false.");
     return ConnectionResult::ShouldNotConnect;
   }
   ENVOY_LOG(trace, "creating new preconnect connection");

--- a/source/common/conn_pool/conn_pool_base.h
+++ b/source/common/conn_pool/conn_pool_base.h
@@ -398,6 +398,8 @@ private:
   // Prerequisite: the given clients shouldn't be idle.
   void drainClients(std::list<ActiveClientPtr>& clients);
 
+  void assertCapacityCountsAreCorrect();
+
   std::list<PendingStreamPtr> pending_streams_;
 
   // The number of streams currently attached to clients.

--- a/source/common/conn_pool/conn_pool_base.h
+++ b/source/common/conn_pool/conn_pool_base.h
@@ -402,12 +402,12 @@ private:
 
   std::list<PendingStreamPtr> pending_streams_;
 
-  // The number of streams currently attached to clients.
-  uint32_t num_active_streams_{0};
-
   // The number of streams that can be immediately dispatched from the current
   // `ready_clients_` plus `connecting_stream_capacity_`.
-  int32_t connecting_and_connected_stream_capacity_{0};
+  int64_t connecting_and_connected_stream_capacity_{0};
+
+  // The number of streams currently attached to clients.
+  uint32_t num_active_streams_{0};
 
   // Whether the connection pool is currently in the process of closing
   // all connections so that it can be gracefully deleted.

--- a/source/common/conn_pool/conn_pool_base.h
+++ b/source/common/conn_pool/conn_pool_base.h
@@ -286,9 +286,11 @@ public:
 
   void decrClusterStreamCapacity(uint32_t delta) {
     state_.decrConnectingAndConnectedStreamCapacity(delta);
+    connecting_and_connected_stream_capacity_ -= delta;
   }
   void incrClusterStreamCapacity(uint32_t delta) {
     state_.incrConnectingAndConnectedStreamCapacity(delta);
+    connecting_and_connected_stream_capacity_ += delta;
   }
   void dumpState(std::ostream& os, int indent_level = 0) const {
     const char* spaces = spacesForLevel(indent_level);
@@ -400,6 +402,10 @@ private:
 
   // The number of streams currently attached to clients.
   uint32_t num_active_streams_{0};
+
+  // The number of streams that can be immediately dispatched from the current
+  // `ready_clients_` plus `connecting_stream_capacity_`.
+  int32_t connecting_and_connected_stream_capacity_{0};
 
   // Whether the connection pool is currently in the process of closing
   // all connections so that it can be gracefully deleted.

--- a/test/integration/protocol_integration_test.cc
+++ b/test/integration/protocol_integration_test.cc
@@ -4703,9 +4703,9 @@ TEST_P(ProtocolIntegrationTest, BufferContinue) {
   waitForNextUpstreamRequest();
 
   // Send the response headers.
-  upstream_request_->encodeHeaders(
-      default_response_headers_,
-      false); // Now send an overly large response body. At some point, too much data will
+  upstream_request_->encodeHeaders(default_response_headers_, false);
+
+  // Now send an overly large response body. At some point, too much data will
   // be buffered, the stream will be reset, and the connection will disconnect.
   upstream_request_->encodeData(512, false);
   upstream_request_->encodeData(1024 * 100, false);
@@ -5374,8 +5374,8 @@ TEST_P(ProtocolIntegrationTest, H2UpstreamHalfCloseBeforeH1Downstream) {
   tcp_client->waitForData("\r\n0\r\n\r\n", false);
   ASSERT_TRUE(tcp_client->connected());
 
-  // Now write data into downstream client after upstream has completed its response and verify
-  // that upstream receives it.
+  // Now write data into downstream client after upstream has completed its response and verify that
+  // upstream receives it.
   ASSERT_TRUE(tcp_client->write(absl::StrCat("80\r\n", std::string(0x80, 'A'), "\r\n0\r\n\r\n"),
                                 false, false));
 

--- a/test/integration/protocol_integration_test.cc
+++ b/test/integration/protocol_integration_test.cc
@@ -3142,24 +3142,72 @@ TEST_P(DownstreamProtocolIntegrationTest, ConnDurationTimeoutNoHttpRequest) {
   test_server_->waitForCounterGe("http.config_test.downstream_cx_max_duration_reached", 1);
 }
 
-TEST_P(DownstreamProtocolIntegrationTest, TestPreconnect) {
-  config_helper_.addConfigModifier([](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
+TEST_P(ProtocolIntegrationTest, TestPreconnect) {
+  config_helper_.addConfigModifier([this](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
     auto* cluster = bootstrap.mutable_static_resources()->mutable_clusters(0);
-    cluster->mutable_preconnect_policy()->mutable_per_upstream_preconnect_ratio()->set_value(1.5);
+    cluster->mutable_preconnect_policy()->mutable_per_upstream_preconnect_ratio()->set_value(2.0);
+
+    if (upstreamProtocol() == Http::CodecType::HTTP2) {
+      ConfigHelper::HttpProtocolOptions protocol_options;
+      protocol_options.mutable_explicit_http_config()
+          ->mutable_http2_protocol_options()
+          ->mutable_max_concurrent_streams()
+          ->set_value(4);
+      ConfigHelper::setProtocolOptions(*cluster, protocol_options);
+    }
   });
+  autonomous_upstream_ = true;
   initialize();
+
+  // First request should cause initial connections to be setup, enough for no more connections when
+  // request concurrency doesn't exceed 1.
   codec_client_ = makeHttpConnection(lookupPort("http"));
-  auto response =
-      sendRequestAndWaitForResponse(default_request_headers_, 0, default_response_headers_, 0);
-  FakeHttpConnectionPtr fake_upstream_connection_two;
-  if (upstreamProtocol() == Http::CodecType::HTTP1) {
-    // For HTTP/1.1 there should be a preconnected connection.
-    ASSERT_TRUE(
-        fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, fake_upstream_connection_two));
-  } else {
-    // For HTTP/2, the original connection can accommodate two requests.
-    ASSERT_FALSE(fake_upstreams_[0]->waitForHttpConnection(
-        *dispatcher_, fake_upstream_connection_two, std::chrono::milliseconds(5)));
+  {
+    auto response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
+    ASSERT_TRUE(response->waitForEndStream());
+  }
+
+  // Preconnect is set to 2. Http 1 allows 1 request per connection so it requires 2 connections,
+  // and http is configured for 4 so it requires only 1 connection.
+  uint32_t expected_upstream_cx = (upstreamProtocol() == Http::CodecType::HTTP1) ? 2 : 1;
+  test_server_->waitForCounterEq("cluster.cluster_0.upstream_cx_total", expected_upstream_cx);
+  test_server_->waitForGaugeEq("cluster.cluster_0.upstream_cx_active", expected_upstream_cx);
+
+  // Make several non-concurrent requests. The concurrency is only 1, so there should only be 1 or 2
+  // upstream connections, already established by the first request.
+  for (uint32_t i = 0; i < 10; i++) {
+    auto response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
+    ASSERT_TRUE(response->waitForEndStream());
+  }
+
+  test_server_->waitForCounterEq("cluster.cluster_0.upstream_cx_total", expected_upstream_cx);
+  test_server_->waitForGaugeEq("cluster.cluster_0.upstream_cx_active", expected_upstream_cx);
+
+  if (GetParam().downstream_protocol == Http::CodecType::HTTP1) {
+    // The rest of the test requires multiple concurrent requests and isn't written to use multiple
+    // downstream connections.
+    return;
+  }
+
+  std::vector<std::pair<Http::RequestEncoder&, IntegrationStreamDecoderPtr>> responses;
+
+  // Create concurrent requests and validate that the connection counts are correct.
+  constexpr uint32_t concurrent_requests = 10;
+  for (uint32_t i = 0; i < concurrent_requests; i++) {
+    // Create an outstanding request that doesn't complete.
+    responses.push_back(codec_client_->startRequest(default_request_headers_));
+  }
+
+  expected_upstream_cx = (upstreamProtocol() == Http::CodecType::HTTP1)
+                             ? (concurrent_requests * 2)
+                             : (concurrent_requests * 2 / 4);
+
+  test_server_->waitForCounterEq("cluster.cluster_0.upstream_cx_total", expected_upstream_cx);
+  test_server_->waitForGaugeEq("cluster.cluster_0.upstream_cx_active", expected_upstream_cx);
+
+  for (auto& response : responses) {
+    codec_client_->sendData(response.first, 0, true);
+    ASSERT_TRUE(response.second->waitForEndStream());
   }
 }
 
@@ -4655,9 +4703,9 @@ TEST_P(ProtocolIntegrationTest, BufferContinue) {
   waitForNextUpstreamRequest();
 
   // Send the response headers.
-  upstream_request_->encodeHeaders(default_response_headers_, false);
-
-  // Now send an overly large response body. At some point, too much data will
+  upstream_request_->encodeHeaders(
+      default_response_headers_,
+      false); // Now send an overly large response body. At some point, too much data will
   // be buffered, the stream will be reset, and the connection will disconnect.
   upstream_request_->encodeData(512, false);
   upstream_request_->encodeData(1024 * 100, false);
@@ -5326,8 +5374,8 @@ TEST_P(ProtocolIntegrationTest, H2UpstreamHalfCloseBeforeH1Downstream) {
   tcp_client->waitForData("\r\n0\r\n\r\n", false);
   ASSERT_TRUE(tcp_client->connected());
 
-  // Now write data into downstream client after upstream has completed its response and verify that
-  // upstream receives it.
+  // Now write data into downstream client after upstream has completed its response and verify
+  // that upstream receives it.
   ASSERT_TRUE(tcp_client->write(absl::StrCat("80\r\n", std::string(0x80, 'A'), "\r\n0\r\n\r\n"),
                                 false, false));
 


### PR DESCRIPTION
The preconnect logic was only counting currently connecting capacity, not established connections with unused capacity, in the calculation of whether new preconnect connections are needed. This resulted in new connections anytime there wasn't an in-progress connection, resulting in far too many connections being established.

Risk Level: Low
Testing: Added new tests, expanded existing tests
Docs Changes: No changes to existing documentation needed
Release Notes: Added
Platform Specific Features: None
Optional Runtime guard: This is a behavior change, but the existing behavior is so broken that I don't think anyone is using it, so I did not add a guard.