### PR TITLE
kafka: set autoescape for Jinja templates

### DIFF
--- a/contrib/kafka/filters/network/source/protocol/generator.py
+++ b/contrib/kafka/filters/network/source/protocol/generator.py
@@ -822,6 +822,7 @@ class RenderingHelper:
         # Templates are resolved relatively to main start script, due to main & test templates being
         # stored in different directories.
         env = jinja2.Environment(
+            autoescape=jinja2.select_autoescape(['html', 'xml']),
             loader=jinja2.FileSystemLoader(
                 searchpath=os.path.dirname(os.path.abspath(sys.argv[0]))))
         env.filters['camel_case_to_snake_case'] = RenderingHelper.camel_case_to_snake_case

--- a/contrib/kafka/filters/network/source/serialization/generator.py
+++ b/contrib/kafka/filters/network/source/serialization/generator.py
@@ -53,6 +53,7 @@ class RenderingHelper:
         # Templates are resolved relatively to main start script, due to main & test templates being
         # stored in different directories.
         env = jinja2.Environment(
+            autoescape=jinja2.select_autoescape(['html', 'xml']),
             loader=jinja2.FileSystemLoader(
                 searchpath=os.path.dirname(os.path.abspath(sys.argv[0]))))
         return env.get_template(template)

--- a/contrib/kafka/filters/network/test/broker/integration_test/kafka_broker_integration_test.py
+++ b/contrib/kafka/filters/network/test/broker/integration_test/kafka_broker_integration_test.py
@@ -625,6 +625,7 @@ class RenderingHelper:
         # Templates are resolved relatively to main start script, due to main & test templates being
         # stored in different directories.
         env = jinja2.Environment(
+            autoescape=jinja2.select_autoescape(['html', 'xml']),
             loader=jinja2.FileSystemLoader(searchpath=os.path.dirname(os.path.abspath(__file__))))
         return env.get_template(template)
 

--- a/contrib/kafka/filters/network/test/mesh/integration_test/kafka_mesh_integration_test.py
+++ b/contrib/kafka/filters/network/test/mesh/integration_test/kafka_mesh_integration_test.py
@@ -738,6 +738,7 @@ class RenderingHelper:
         # Templates are resolved relatively to main start script, due to main & test templates being
         # stored in different directories.
         env = jinja2.Environment(
+            autoescape=jinja2.select_autoescape(['html', 'xml']),
             loader=jinja2.FileSystemLoader(searchpath=os.path.dirname(os.path.abspath(__file__))))
         return env.get_template(template)
 


### PR DESCRIPTION
Commit Message:     Autoescape protects web applications against most common cross-site-scripting (XSS) vulnerabilities.
While the output from Jinja templates in the Kafka module don't generate HTML, enabling autoescape for HTML/XML avoids tripping automatic security scanners.
Additional Description: There are more occurrences of Jinja templates that need fixing but those affect the docs generation and need a bigger CR, so I'll keep those for later.
Risk Level: Low
Testing: `./ci/do_ci.sh release.test_only` -- 3 tests failed, see below
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]

Failing tests. None of these is related to this PR and still fail locally without the patch.
```
//test/extensions/filters/http/dynamic_forward_proxy:legacy_proxy_filter_integration_test FAILED in 34.4s
  /build/bazel_root/base/execroot/envoy/bazel-out/k8-opt/testlogs/test/extensions/filters/http/dynamic_forward_proxy/legacy_proxy_filter_integration_test/test.log
//test/extensions/filters/http/dynamic_forward_proxy:proxy_filter_integration_test FAILED in 42.3s
  /build/bazel_root/base/execroot/envoy/bazel-out/k8-opt/testlogs/test/extensions/filters/http/dynamic_forward_proxy/proxy_filter_integration_test/test.log
//test/integration:quic_http_integration_test                            FAILED in 23.7s
  /build/bazel_root/base/execroot/envoy/bazel-out/k8-opt/testlogs/test/integration/quic_http_integration_test/test.log
```