### PR TITLE
Remove code owner for Redis filter

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -75,11 +75,11 @@ extensions/filters/common/original_src @klarose @mattklein123
 # UDP packet writer
 /*/extensions/udp_packet_writer/ @danzh2010 @ryantheoptimist
 # redis cluster extension
-/*/extensions/clusters/redis @msukalski @henryyyang @mattklein123 @weisisea
-/*/extensions/common/redis @msukalski @henryyyang @mattklein123 @weisisea
-/*/extensions/health_checkers/redis @weisisea @mattklein123
-/*/extensions/filters/network/redis_proxy @weisisea @mattklein123
-/*/extensions/filters/network/common/redis @weisisea @mattklein123
+/*/extensions/clusters/redis @msukalski @henryyyang @mattklein123
+/*/extensions/common/redis @msukalski @henryyyang @mattklein123
+/*/extensions/health_checkers/redis @mattklein123
+/*/extensions/filters/network/redis_proxy @mattklein123
+/*/extensions/filters/network/common/redis @mattklein123
 # dynamic forward proxy
 /*/extensions/clusters/dynamic_forward_proxy @mattklein123 @ryantheoptimist
 /*/extensions/common/dynamic_forward_proxy @mattklein123 @ryantheoptimist


### PR DESCRIPTION
Thanks for letting me be the owner for Redis filter in the last couple of years, but finding it a little challenging to continue as I'm not working on the Redis filter any more in my job. Hope to re-join the community in the future!

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
