### PR TITLE
Adding support for response codes which should not undergo compression in the Compression filter.

### DIFF
--- a/api/envoy/extensions/filters/http/compressor/v3/compressor.proto
+++ b/api/envoy/extensions/filters/http/compressor/v3/compressor.proto
@@ -70,8 +70,12 @@ message Compressor {
 
     // Set of response codes for which compression is disabled, e.g. 206 Partial Content should not
     // be compressed.
-    repeated uint32 uncompressible_response_codes = 4 [(validate.rules).repeated.items.uint32 = {lt: 600 gte: 200}, (validate.rules).repeated.unique = true];
+    repeated uint32 uncompressible_response_codes = 4 [(validate.rules).repeated = {
+      unique: true
+      items {uint32 {lt: 600 gte: 200}}
+    }];
   }
+
   // Minimum response length, in bytes, which will trigger compression. The default value is 30.
   google.protobuf.UInt32Value content_length = 1
       [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];

--- a/api/envoy/extensions/filters/http/compressor/v3/compressor.proto
+++ b/api/envoy/extensions/filters/http/compressor/v3/compressor.proto
@@ -44,10 +44,6 @@ message Compressor {
     // "application/xhtml+xml", "image/svg+xml", "text/css", "text/html", "text/plain", "text/xml"
     // and their synonyms.
     repeated string content_type = 3;
-
-    // Set of response codes for which compression is disabled, e.g. 206 Partial Content should not
-    // be compressed.
-    repeated google.protobuf.UInt32Value uncompressible_response_code = 4;
   }
 
   // Configuration for filter behavior on the request direction.
@@ -71,8 +67,11 @@ message Compressor {
     //    To avoid interfering with other compression filters in the same chain use this option in
     //    the filter closest to the upstream.
     bool remove_accept_encoding_header = 3;
-  }
 
+    // Set of response codes for which compression is disabled, e.g. 206 Partial Content should not
+    // be compressed.
+    repeated google.protobuf.UInt32Value uncompressible_response_code = 4;
+  }
   // Minimum response length, in bytes, which will trigger compression. The default value is 30.
   google.protobuf.UInt32Value content_length = 1
       [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];

--- a/api/envoy/extensions/filters/http/compressor/v3/compressor.proto
+++ b/api/envoy/extensions/filters/http/compressor/v3/compressor.proto
@@ -70,7 +70,7 @@ message Compressor {
 
     // Set of response codes for which compression is disabled, e.g. 206 Partial Content should not
     // be compressed.
-    repeated google.protobuf.UInt32Value uncompressible_response_code = 4;
+    repeated uint32 uncompressible_response_code = 4 [(validate.rules).repeated.items.uint32 = {lt: 600 gte: 200}];
   }
   // Minimum response length, in bytes, which will trigger compression. The default value is 30.
   google.protobuf.UInt32Value content_length = 1

--- a/api/envoy/extensions/filters/http/compressor/v3/compressor.proto
+++ b/api/envoy/extensions/filters/http/compressor/v3/compressor.proto
@@ -70,7 +70,7 @@ message Compressor {
 
     // Set of response codes for which compression is disabled, e.g. 206 Partial Content should not
     // be compressed.
-    repeated uint32 uncompressible_response_code = 4 [(validate.rules).repeated.items.uint32 = {lt: 600 gte: 200}];
+    repeated uint32 uncompressible_response_codes = 4 [(validate.rules).repeated.items.uint32 = {lt: 600 gte: 200}];
   }
   // Minimum response length, in bytes, which will trigger compression. The default value is 30.
   google.protobuf.UInt32Value content_length = 1

--- a/api/envoy/extensions/filters/http/compressor/v3/compressor.proto
+++ b/api/envoy/extensions/filters/http/compressor/v3/compressor.proto
@@ -70,7 +70,7 @@ message Compressor {
 
     // Set of response codes for which compression is disabled, e.g. 206 Partial Content should not
     // be compressed.
-    repeated uint32 uncompressible_response_codes = 4 [(validate.rules).repeated.items.uint32 = {lt: 600 gte: 200}];
+    repeated uint32 uncompressible_response_codes = 4 [(validate.rules).repeated.items.uint32 = {lt: 600 gte: 200}, (validate.rules).repeated.unique = true];
   }
   // Minimum response length, in bytes, which will trigger compression. The default value is 30.
   google.protobuf.UInt32Value content_length = 1

--- a/api/envoy/extensions/filters/http/compressor/v3/compressor.proto
+++ b/api/envoy/extensions/filters/http/compressor/v3/compressor.proto
@@ -44,6 +44,10 @@ message Compressor {
     // "application/xhtml+xml", "image/svg+xml", "text/css", "text/html", "text/plain", "text/xml"
     // and their synonyms.
     repeated string content_type = 3;
+
+    // Set of response codes for which compression is disabled, e.g. 206 Partial Content should not
+    // be compressed.
+    repeated google.protobuf.UInt32Value uncompressible_response_code = 4;
   }
 
   // Configuration for filter behavior on the request direction.

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -225,7 +225,8 @@ new_features:
     control the route cache clearing behavior in the Lua filter.
 - area: compressor
   change: |
-    Added (:ref:`uncompressible_response_codes <envoy_v3_api_field_extensions.filters.http.compressor.v3.Compressor.ResponseDirectionConfig.uncompressible_response_codes>`)
+    Added
+    (:ref:`uncompressible_response_codes <envoy_v3_api_field_extensions.filters.http.compressor.v3.Compressor.ResponseDirectionConfig.uncompressible_response_codes>`)
     to Compressor Filter which allows configuration of a list of response codes for which the compression will be skipped.
 - area: jwt_authn
   change: |

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -225,8 +225,8 @@ new_features:
     control the route cache clearing behavior in the Lua filter.
 - area: compressor
   change: |
-    Added
-    (:ref:`uncompressible_response_codes <envoy_v3_api_field_extensions.filters.http.compressor.v3.Compressor.ResponseDirectionConfig.uncompressible_response_codes>`)
+    Added (:ref:`uncompressible_response_codes
+    <envoy_v3_api_field_extensions.filters.http.compressor.v3.Compressor.ResponseDirectionConfig.uncompressible_response_codes>`)
     to Compressor Filter which allows configuration of a list of response codes for which the compression will be skipped.
 - area: jwt_authn
   change: |

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -223,6 +223,11 @@ new_features:
   change: |
     Added :ref:`clear_route_cache <envoy_v3_api_field_extensions.filters.http.lua.v3.Lua.clear_route_cache>` support to
     control the route cache clearing behavior in the Lua filter.
+- area: compressor
+  change: |
+    Compressor Filter now allows configuration of a list of response codes for which the compression will be skipped
+    (:ref:`uncompressible_response_codes <envoy_v3_api_field_extensions.filters.http.compressor.v3.Compressor.ResponseDirectionConfig.uncompressible_response_codes>`).
+    Adding 206 (Partial Content) to the list prevents content-encoding change after a range of the original content was received.
 - area: jwt_authn
   change: |
     Added :ref:`jwt_max_token_size <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtCacheConfig.jwt_max_token_size>` to make

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -225,9 +225,8 @@ new_features:
     control the route cache clearing behavior in the Lua filter.
 - area: compressor
   change: |
-    Compressor Filter now allows configuration of a list of response codes for which the compression will be skipped
-    (:ref:`uncompressible_response_codes <envoy_v3_api_field_extensions.filters.http.compressor.v3.Compressor.ResponseDirectionConfig.uncompressible_response_codes>`).
-    Adding 206 (Partial Content) to the list prevents content-encoding change after a range of the original content was received.
+    Added (:ref:`uncompressible_response_codes <envoy_v3_api_field_extensions.filters.http.compressor.v3.Compressor.ResponseDirectionConfig.uncompressible_response_codes>`)
+    to Compressor Filter which allows configuration of a list of response codes for which the compression will be skipped.
 - area: jwt_authn
   change: |
     Added :ref:`jwt_max_token_size <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtCacheConfig.jwt_max_token_size>` to make

--- a/docs/root/configuration/http/http_filters/_include/compressor-filter.yaml
+++ b/docs/root/configuration/http/http_filters/_include/compressor-filter.yaml
@@ -45,7 +45,7 @@ static_resources:
                   - text/html
                   - application/json
                 disable_on_etag_header: true
-                uncompressible_response_code:
+                uncompressible_response_codes:
               request_direction_config:
                 common_config:
                   enabled:

--- a/docs/root/configuration/http/http_filters/_include/compressor-filter.yaml
+++ b/docs/root/configuration/http/http_filters/_include/compressor-filter.yaml
@@ -44,8 +44,8 @@ static_resources:
                   content_type:
                   - text/html
                   - application/json
-                  uncompressible_response_code:
                 disable_on_etag_header: true
+                uncompressible_response_code:
               request_direction_config:
                 common_config:
                   enabled:

--- a/docs/root/configuration/http/http_filters/_include/compressor-filter.yaml
+++ b/docs/root/configuration/http/http_filters/_include/compressor-filter.yaml
@@ -44,6 +44,7 @@ static_resources:
                   content_type:
                   - text/html
                   - application/json
+                  uncompressible_response_code:
                 disable_on_etag_header: true
               request_direction_config:
                 common_config:

--- a/docs/root/configuration/http/http_filters/compressor_filter.rst
+++ b/docs/root/configuration/http/http_filters/compressor_filter.rst
@@ -81,6 +81,7 @@ By *default* response compression is enabled, but it will be *skipped* when:
 - A response does **not** contain a ``content-length`` or ``transfer-encoding`` headers.
 - Response size is smaller than 30 bytes (only applicable when ``transfer-encoding``
   is not chunked).
+- A response code is on the list of uncompressible response codes, which is empty by default.
 
 Please note that in case the filter is configured to use a compression library extension
 other than gzip it looks for content encoding in the ``accept-encoding`` header provided by

--- a/source/extensions/filters/http/compressor/compressor_filter.cc
+++ b/source/extensions/filters/http/compressor/compressor_filter.cc
@@ -1,12 +1,14 @@
 #include "source/extensions/filters/http/compressor/compressor_filter.h"
+
 #include <cstdint>
 
-#include "absl/container/flat_hash_set.h"
-#include "absl/types/optional.h"
 #include "source/common/buffer/buffer_impl.h"
 #include "source/common/http/header_map_impl.h"
 #include "source/common/http/utility.h"
 #include "source/common/protobuf/protobuf.h"
+
+#include "absl/container/flat_hash_set.h"
+#include "absl/types/optional.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -84,9 +86,9 @@ CompressorFilterConfig::DirectionConfig::DirectionConfig(
     : compression_enabled_(proto_config.enabled(), runtime),
       min_content_length_{contentLengthUint(proto_config.min_content_length().value())},
       content_type_values_(contentTypeSet(proto_config.content_type())),
-      uncompressible_response_codes_(uncompressibleResponseCodesSet(proto_config.uncompressible_response_code())),
-      stats_{generateStats(stats_prefix, scope)} {
-}
+      uncompressible_response_codes_(
+          uncompressibleResponseCodesSet(proto_config.uncompressible_response_code())),
+      stats_{generateStats(stats_prefix, scope)} {}
 
 CompressorFilterConfig::CompressorFilterConfig(
     const envoy::extensions::filters::http::compressor::v3::Compressor& proto_config,
@@ -109,7 +111,8 @@ StringUtil::CaseUnorderedSet CompressorFilterConfig::DirectionConfig::contentTyp
                        : StringUtil::CaseUnorderedSet(types.cbegin(), types.cend());
 }
 
-absl::flat_hash_set<uint32_t> CompressorFilterConfig::DirectionConfig::uncompressibleResponseCodesSet(
+absl::flat_hash_set<uint32_t>
+CompressorFilterConfig::DirectionConfig::uncompressibleResponseCodesSet(
     const Protobuf::RepeatedPtrField<google::protobuf::UInt32Value>& codes) {
   absl::flat_hash_set<uint32_t> result;
   for (const google::protobuf::UInt32Value& code : codes) {
@@ -584,17 +587,18 @@ bool CompressorFilterConfig::DirectionConfig::areAllResponseCodesCompressible() 
   return uncompressible_response_codes_.empty();
 }
 
-bool CompressorFilterConfig::DirectionConfig::isResponseCodeCompressible(uint32_t response_code) const {
+bool CompressorFilterConfig::DirectionConfig::isResponseCodeCompressible(
+    uint32_t response_code) const {
   return !uncompressible_response_codes_.contains(response_code);
 }
 
-bool CompressorFilter::isResponseCodeCompressible(const CompressorFilterConfig::ResponseDirectionConfig& config) const {
+bool CompressorFilter::isResponseCodeCompressible(
+    const CompressorFilterConfig::ResponseDirectionConfig& config) const {
   if (config.areAllResponseCodesCompressible()) {
     return true;
   }
 
-  absl::optional<uint32_t> response_code =
-      decoder_callbacks_->streamInfo().responseCode();
+  absl::optional<uint32_t> response_code = decoder_callbacks_->streamInfo().responseCode();
   if (!response_code.has_value()) {
     return true;
   }

--- a/source/extensions/filters/http/compressor/compressor_filter.cc
+++ b/source/extensions/filters/http/compressor/compressor_filter.cc
@@ -142,7 +142,7 @@ CompressorFilterConfig::ResponseDirectionConfig::ResponseDirectionConfig(
               ? proto_config.response_direction_config().remove_accept_encoding_header()
               : proto_config.remove_accept_encoding_header()),
       uncompressible_response_codes_(uncompressibleResponseCodesSet(
-          proto_config.response_direction_config().uncompressible_response_code())),
+          proto_config.response_direction_config().uncompressible_response_codes())),
       response_stats_{generateResponseStats(stats_prefix, scope)} {}
 
 const envoy::extensions::filters::http::compressor::v3::Compressor::CommonDirectionConfig

--- a/source/extensions/filters/http/compressor/compressor_filter.cc
+++ b/source/extensions/filters/http/compressor/compressor_filter.cc
@@ -121,6 +121,11 @@ CompressorFilterConfig::RequestDirectionConfig::RequestDirectionConfig(
                       stats_prefix + "request.", scope, runtime),
       is_set_{proto_config.has_request_direction_config()} {}
 
+absl::flat_hash_set<uint32_t>
+uncompressibleResponseCodesSet(const Protobuf::RepeatedField<uint32_t>& codes) {
+  return {codes.begin(), codes.end()};
+}
+
 CompressorFilterConfig::ResponseDirectionConfig::ResponseDirectionConfig(
     const envoy::extensions::filters::http::compressor::v3::Compressor& proto_config,
     const std::string& stats_prefix, Stats::Scope& scope, Runtime::Loader& runtime)
@@ -165,12 +170,6 @@ CompressorFilterConfig::ResponseDirectionConfig::commonConfig(
       new envoy::config::core::v3::RuntimeFeatureFlag(proto_config.runtime_enabled()));
   // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
   return config;
-}
-
-absl::flat_hash_set<uint32_t>
-CompressorFilterConfig::ResponseDirectionConfig::uncompressibleResponseCodesSet(
-    const Protobuf::RepeatedField<uint32_t>& codes) {
-  return {codes.begin(), codes.end()};
 }
 
 Envoy::Compression::Compressor::CompressorPtr CompressorFilterConfig::makeCompressor() {

--- a/source/extensions/filters/http/compressor/compressor_filter.cc
+++ b/source/extensions/filters/http/compressor/compressor_filter.cc
@@ -284,9 +284,8 @@ void CompressorFilter::setDecoderFilterCallbacks(Http::StreamDecoderFilterCallba
   }
 }
 
-bool isResponseCodeCompressible(
-    const Http::ResponseHeaderMap& headers,
-    const CompressorFilterConfig::ResponseDirectionConfig& config) {
+bool isResponseCodeCompressible(const Http::ResponseHeaderMap& headers,
+                                const CompressorFilterConfig::ResponseDirectionConfig& config) {
   if (config.areAllResponseCodesCompressible()) {
     return true;
   }

--- a/source/extensions/filters/http/compressor/compressor_filter.cc
+++ b/source/extensions/filters/http/compressor/compressor_filter.cc
@@ -136,8 +136,8 @@ CompressorFilterConfig::ResponseDirectionConfig::ResponseDirectionConfig(
           proto_config.has_response_direction_config()
               ? proto_config.response_direction_config().remove_accept_encoding_header()
               : proto_config.remove_accept_encoding_header()),
-      uncompressible_response_codes_(
-          uncompressibleResponseCodesSet(proto_config.response_direction_config().uncompressible_response_code())),
+      uncompressible_response_codes_(uncompressibleResponseCodesSet(
+          proto_config.response_direction_config().uncompressible_response_code())),
       response_stats_{generateResponseStats(stats_prefix, scope)} {}
 
 const envoy::extensions::filters::http::compressor::v3::Compressor::CommonDirectionConfig
@@ -169,12 +169,8 @@ CompressorFilterConfig::ResponseDirectionConfig::commonConfig(
 
 absl::flat_hash_set<uint32_t>
 CompressorFilterConfig::ResponseDirectionConfig::uncompressibleResponseCodesSet(
-    const Protobuf::RepeatedPtrField<Protobuf::UInt32Value>& codes) {
-  absl::flat_hash_set<uint32_t> result;
-  for (const Protobuf::UInt32Value& code : codes) {
-    result.insert(code.value());
-  }
-  return result;
+    const Protobuf::RepeatedField<uint32_t>& codes) {
+  return {codes.begin(), codes.end()};
 }
 
 Envoy::Compression::Compressor::CompressorPtr CompressorFilterConfig::makeCompressor() {

--- a/source/extensions/filters/http/compressor/compressor_filter.cc
+++ b/source/extensions/filters/http/compressor/compressor_filter.cc
@@ -113,9 +113,9 @@ StringUtil::CaseUnorderedSet CompressorFilterConfig::DirectionConfig::contentTyp
 
 absl::flat_hash_set<uint32_t>
 CompressorFilterConfig::DirectionConfig::uncompressibleResponseCodesSet(
-    const Protobuf::RepeatedPtrField<google::protobuf::UInt32Value>& codes) {
+    const Protobuf::RepeatedPtrField<Protobuf::UInt32Value>& codes) {
   absl::flat_hash_set<uint32_t> result;
-  for (const google::protobuf::UInt32Value& code : codes) {
+  for (const Protobuf::UInt32Value& code : codes) {
     result.insert(code.value());
   }
   return result;

--- a/source/extensions/filters/http/compressor/compressor_filter.h
+++ b/source/extensions/filters/http/compressor/compressor_filter.h
@@ -80,6 +80,8 @@ public:
     uint32_t minimumLength() const { return min_content_length_; }
     bool isMinimumContentLength(const Http::RequestOrResponseHeaderMap& headers) const;
     bool isContentTypeAllowed(const Http::RequestOrResponseHeaderMap& headers) const;
+    bool areAllResponseCodesCompressible() const;
+    bool isResponseCodeCompressible(uint32_t response_code) const;
 
   protected:
     const Runtime::FeatureFlag compression_enabled_;
@@ -94,8 +96,12 @@ public:
     static StringUtil::CaseUnorderedSet
     contentTypeSet(const Protobuf::RepeatedPtrField<std::string>& types);
 
+    static absl::flat_hash_set<uint32_t>
+    uncompressibleResponseCodesSet(const Protobuf::RepeatedPtrField<google::protobuf::UInt32Value>& codes);
+
     const uint32_t min_content_length_;
     const StringUtil::CaseUnorderedSet content_type_values_;
+    const absl::flat_hash_set<uint32_t> uncompressible_response_codes_;
     const CompressorStats stats_;
   };
 
@@ -206,6 +212,7 @@ private:
   bool isAcceptEncodingAllowed(bool maybe_compress, const Http::ResponseHeaderMap& headers) const;
   bool isEtagAllowed(Http::ResponseHeaderMap& headers) const;
   bool isTransferEncodingAllowed(Http::RequestOrResponseHeaderMap& headers) const;
+  bool isResponseCodeCompressible(const CompressorFilterConfig::ResponseDirectionConfig& config) const;
 
   void sanitizeEtagHeader(Http::ResponseHeaderMap& headers);
   void insertVaryHeader(Http::ResponseHeaderMap& headers);

--- a/source/extensions/filters/http/compressor/compressor_filter.h
+++ b/source/extensions/filters/http/compressor/compressor_filter.h
@@ -131,7 +131,7 @@ public:
     }
 
     static absl::flat_hash_set<uint32_t>
-    uncompressibleResponseCodesSet(const Protobuf::RepeatedPtrField<Protobuf::UInt32Value>& codes);
+    uncompressibleResponseCodesSet(const Protobuf::RepeatedField<uint32_t>& codes);
 
     // TODO(rojkov): delete this translation function once the deprecated fields
     // are removed from envoy::extensions::filters::http::compressor::v3::Compressor.

--- a/source/extensions/filters/http/compressor/compressor_filter.h
+++ b/source/extensions/filters/http/compressor/compressor_filter.h
@@ -96,8 +96,8 @@ public:
     static StringUtil::CaseUnorderedSet
     contentTypeSet(const Protobuf::RepeatedPtrField<std::string>& types);
 
-    static absl::flat_hash_set<uint32_t>
-    uncompressibleResponseCodesSet(const Protobuf::RepeatedPtrField<google::protobuf::UInt32Value>& codes);
+    static absl::flat_hash_set<uint32_t> uncompressibleResponseCodesSet(
+        const Protobuf::RepeatedPtrField<google::protobuf::UInt32Value>& codes);
 
     const uint32_t min_content_length_;
     const StringUtil::CaseUnorderedSet content_type_values_;
@@ -212,7 +212,8 @@ private:
   bool isAcceptEncodingAllowed(bool maybe_compress, const Http::ResponseHeaderMap& headers) const;
   bool isEtagAllowed(Http::ResponseHeaderMap& headers) const;
   bool isTransferEncodingAllowed(Http::RequestOrResponseHeaderMap& headers) const;
-  bool isResponseCodeCompressible(const CompressorFilterConfig::ResponseDirectionConfig& config) const;
+  bool
+  isResponseCodeCompressible(const CompressorFilterConfig::ResponseDirectionConfig& config) const;
 
   void sanitizeEtagHeader(Http::ResponseHeaderMap& headers);
   void insertVaryHeader(Http::ResponseHeaderMap& headers);

--- a/source/extensions/filters/http/compressor/compressor_filter.h
+++ b/source/extensions/filters/http/compressor/compressor_filter.h
@@ -213,7 +213,8 @@ private:
   bool isEtagAllowed(Http::ResponseHeaderMap& headers) const;
   bool isTransferEncodingAllowed(Http::RequestOrResponseHeaderMap& headers) const;
   bool
-  isResponseCodeCompressible(const CompressorFilterConfig::ResponseDirectionConfig& config) const;
+  isResponseCodeCompressible(const Http::ResponseHeaderMap& headers,
+                             const CompressorFilterConfig::ResponseDirectionConfig& config) const;
 
   void sanitizeEtagHeader(Http::ResponseHeaderMap& headers);
   void insertVaryHeader(Http::ResponseHeaderMap& headers);

--- a/source/extensions/filters/http/compressor/compressor_filter.h
+++ b/source/extensions/filters/http/compressor/compressor_filter.h
@@ -96,8 +96,8 @@ public:
     static StringUtil::CaseUnorderedSet
     contentTypeSet(const Protobuf::RepeatedPtrField<std::string>& types);
 
-    static absl::flat_hash_set<uint32_t> uncompressibleResponseCodesSet(
-        const Protobuf::RepeatedPtrField<google::protobuf::UInt32Value>& codes);
+    static absl::flat_hash_set<uint32_t>
+    uncompressibleResponseCodesSet(const Protobuf::RepeatedPtrField<Protobuf::UInt32Value>& codes);
 
     const uint32_t min_content_length_;
     const StringUtil::CaseUnorderedSet content_type_values_;

--- a/source/extensions/filters/http/compressor/compressor_filter.h
+++ b/source/extensions/filters/http/compressor/compressor_filter.h
@@ -130,9 +130,6 @@ public:
       return ResponseCompressorStats{RESPONSE_COMPRESSOR_STATS(POOL_COUNTER_PREFIX(scope, prefix))};
     }
 
-    static absl::flat_hash_set<uint32_t>
-    uncompressibleResponseCodesSet(const Protobuf::RepeatedField<uint32_t>& codes);
-
     // TODO(rojkov): delete this translation function once the deprecated fields
     // are removed from envoy::extensions::filters::http::compressor::v3::Compressor.
     static const envoy::extensions::filters::http::compressor::v3::Compressor::CommonDirectionConfig

--- a/source/extensions/filters/http/compressor/compressor_filter.h
+++ b/source/extensions/filters/http/compressor/compressor_filter.h
@@ -80,8 +80,6 @@ public:
     uint32_t minimumLength() const { return min_content_length_; }
     bool isMinimumContentLength(const Http::RequestOrResponseHeaderMap& headers) const;
     bool isContentTypeAllowed(const Http::RequestOrResponseHeaderMap& headers) const;
-    bool areAllResponseCodesCompressible() const;
-    bool isResponseCodeCompressible(uint32_t response_code) const;
 
   protected:
     const Runtime::FeatureFlag compression_enabled_;
@@ -96,12 +94,8 @@ public:
     static StringUtil::CaseUnorderedSet
     contentTypeSet(const Protobuf::RepeatedPtrField<std::string>& types);
 
-    static absl::flat_hash_set<uint32_t>
-    uncompressibleResponseCodesSet(const Protobuf::RepeatedPtrField<Protobuf::UInt32Value>& codes);
-
     const uint32_t min_content_length_;
     const StringUtil::CaseUnorderedSet content_type_values_;
-    const absl::flat_hash_set<uint32_t> uncompressible_response_codes_;
     const CompressorStats stats_;
   };
 
@@ -127,12 +121,17 @@ public:
     const ResponseCompressorStats& responseStats() const { return response_stats_; }
     bool disableOnEtagHeader() const { return disable_on_etag_header_; }
     bool removeAcceptEncodingHeader() const { return remove_accept_encoding_header_; }
+    bool areAllResponseCodesCompressible() const;
+    bool isResponseCodeCompressible(uint32_t response_code) const;
 
   private:
     static ResponseCompressorStats generateResponseStats(const std::string& prefix,
                                                          Stats::Scope& scope) {
       return ResponseCompressorStats{RESPONSE_COMPRESSOR_STATS(POOL_COUNTER_PREFIX(scope, prefix))};
     }
+
+    static absl::flat_hash_set<uint32_t>
+    uncompressibleResponseCodesSet(const Protobuf::RepeatedPtrField<Protobuf::UInt32Value>& codes);
 
     // TODO(rojkov): delete this translation function once the deprecated fields
     // are removed from envoy::extensions::filters::http::compressor::v3::Compressor.
@@ -141,6 +140,7 @@ public:
 
     const bool disable_on_etag_header_;
     const bool remove_accept_encoding_header_;
+    const absl::flat_hash_set<uint32_t> uncompressible_response_codes_;
     const ResponseCompressorStats response_stats_;
   };
 

--- a/source/extensions/filters/http/compressor/compressor_filter.h
+++ b/source/extensions/filters/http/compressor/compressor_filter.h
@@ -209,9 +209,6 @@ private:
   bool isAcceptEncodingAllowed(bool maybe_compress, const Http::ResponseHeaderMap& headers) const;
   bool isEtagAllowed(Http::ResponseHeaderMap& headers) const;
   bool isTransferEncodingAllowed(Http::RequestOrResponseHeaderMap& headers) const;
-  bool
-  isResponseCodeCompressible(const Http::ResponseHeaderMap& headers,
-                             const CompressorFilterConfig::ResponseDirectionConfig& config) const;
 
   void sanitizeEtagHeader(Http::ResponseHeaderMap& headers);
   void insertVaryHeader(Http::ResponseHeaderMap& headers);

--- a/test/extensions/filters/http/compressor/compressor_filter_integration_test.cc
+++ b/test/extensions/filters/http/compressor/compressor_filter_integration_test.cc
@@ -118,8 +118,8 @@ public:
             content_type:
               - text/html
               - application/json
-            uncompressible_response_code:
-              - 206
+          uncompressible_response_code:
+            - 206
         request_direction_config:
           common_config:
             enabled:

--- a/test/extensions/filters/http/compressor/compressor_filter_integration_test.cc
+++ b/test/extensions/filters/http/compressor/compressor_filter_integration_test.cc
@@ -97,7 +97,7 @@ public:
     EXPECT_TRUE(upstream_request_->complete());
     EXPECT_EQ(0U, upstream_request_->bodyLength());
     EXPECT_TRUE(response->complete());
-    EXPECT_EQ("200", response->headers().getStatusValue());
+    EXPECT_EQ(response_headers.getStatusValue(), response->headers().getStatusValue());
     ASSERT_TRUE(response->headers().get(Http::CustomHeaders::get().ContentEncoding).empty());
     ASSERT_EQ(content_length, response->body().size());
     EXPECT_EQ(response->body(), std::string(content_length, 'a'));
@@ -118,6 +118,8 @@ public:
             content_type:
               - text/html
               - application/json
+            uncompressible_response_code:
+              - 206
         request_direction_config:
           common_config:
             enabled:
@@ -305,6 +307,21 @@ TEST_P(CompressorIntegrationTest, SkipOnContentType) {
                                                            {":authority", "host"},
                                                            {"accept-encoding", "deflate, gzip"}},
                             Http::TestResponseHeaderMapImpl{{":status", "200"},
+                                                            {"content-length", "128"},
+                                                            {"content-type", "application/xml"}});
+}
+
+/**
+ * Exercises filter when upstream responds with restricted response code value.
+ */
+TEST_P(CompressorIntegrationTest, SkipOnUncompressibleResponseCode) {
+  initializeFilter(full_config);
+  doRequestAndNoCompression(Http::TestRequestHeaderMapImpl{{":method", "GET"},
+                                                           {":path", "/test/long/url"},
+                                                           {":scheme", "http"},
+                                                           {":authority", "host"},
+                                                           {"accept-encoding", "deflate, gzip"}},
+                            Http::TestResponseHeaderMapImpl{{":status", "206"},
                                                             {"content-length", "128"},
                                                             {"content-type", "application/xml"}});
 }

--- a/test/extensions/filters/http/compressor/compressor_filter_integration_test.cc
+++ b/test/extensions/filters/http/compressor/compressor_filter_integration_test.cc
@@ -118,7 +118,7 @@ public:
             content_type:
               - text/html
               - application/json
-          uncompressible_response_code:
+          uncompressible_response_codes:
             - 206
         request_direction_config:
           common_config:

--- a/test/extensions/filters/http/compressor/compressor_filter_integration_test.cc
+++ b/test/extensions/filters/http/compressor/compressor_filter_integration_test.cc
@@ -320,9 +320,11 @@ TEST_P(CompressorIntegrationTest, SkipOnUncompressibleResponseCode) {
                                                            {":path", "/test/long/url"},
                                                            {":scheme", "http"},
                                                            {":authority", "host"},
-                                                           {"accept-encoding", "deflate, gzip"}},
+                                                           {"accept-encoding", "deflate, gzip"},
+                                                           {"range", "bytes=100-227"}},
                             Http::TestResponseHeaderMapImpl{{":status", "206"},
                                                             {"content-length", "128"},
+                                                            {"content-range", "bytes=100-227/567"},
                                                             {"content-type", "application/xml"}});
 }
 

--- a/test/extensions/filters/http/compressor/compressor_filter_test.cc
+++ b/test/extensions/filters/http/compressor/compressor_filter_test.cc
@@ -1,9 +1,13 @@
 #include "source/extensions/filters/http/compressor/compressor_filter.h"
 
+#include <sys/types.h>
+
+#include "absl/strings/str_join.h"
 #include "test/mocks/compression/compressor/mocks.h"
 #include "test/mocks/http/mocks.h"
 #include "test/mocks/runtime/mocks.h"
 #include "test/mocks/stats/mocks.h"
+#include "test/mocks/stream_info/mocks.h"
 #include "test/test_common/utility.h"
 
 #include "gtest/gtest.h"
@@ -181,6 +185,7 @@ public:
   NiceMock<Runtime::MockLoader> runtime_;
   NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks_;
   NiceMock<Http::MockStreamEncoderFilterCallbacks> encoder_callbacks_;
+  NiceMock<StreamInfo::MockStreamInfo> stream_info_;
 };
 
 enum class PerRouteConfig { None, Empty, Enabled, Disabled };
@@ -737,6 +742,68 @@ TEST_P(IsContentTypeAllowedTest, Validate) {
   doResponse(headers, should_compress, false);
   EXPECT_EQ(should_compress ? 0 : 1,
             stats_.counter("test.compressor.test.test.header_not_valid").value());
+  EXPECT_EQ(should_compress, headers.has("vary"));
+}
+
+class IsResponseCodeAllowedTest
+    : public CompressorFilterTest,
+      public testing::WithParamInterface<std::tuple<uint32_t, bool, bool, std::vector<uint32_t>>> {};
+
+INSTANTIATE_TEST_SUITE_P(
+    IsResponseCodeAllowedTestSuite, IsResponseCodeAllowedTest,
+    testing::Values(
+        std::make_tuple(200, true, true, std::vector<uint32_t>{ 206 }),
+        std::make_tuple(206, false, true, std::vector<uint32_t>{ 206 }),
+        std::make_tuple(200, true, false, std::vector<uint32_t>{}),
+        std::make_tuple(200, true, true, std::vector<uint32_t>{}),
+        std::make_tuple(206, true, false, std::vector<uint32_t>{}),
+        std::make_tuple(206, true, true, std::vector<uint32_t>{}),
+        std::make_tuple(206, false, true, std::vector<uint32_t>{ 404, 206}),
+        std::make_tuple(200, true, true, std::vector<uint32_t>{ 404, 206})
+      ));
+
+TEST_P(IsResponseCodeAllowedTest, Validate) {
+  const uint32_t response_code = std::get<0>(GetParam());
+  const bool should_compress = std::get<1>(GetParam());
+  const bool is_custom_config = std::get<2>(GetParam());
+  const std::vector<uint32_t>& uncompressible_response_codes = std::get<3>(GetParam());
+
+  if (is_custom_config) {
+    setUpFilter(fmt::format(R"EOF(
+    {{
+      "response_direction_config": {{
+        "common_config": {{
+          "enabled": {{
+            "default_value": true,
+          }},
+          "uncompressible_response_code": [
+            {}
+          ]
+        }}
+      }},
+      "compressor_library": {{
+        "name": "test",
+        "typed_config": {{
+          "@type": "type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip"
+        }}
+      }}
+    }})EOF", absl::StrJoin(uncompressible_response_codes, ", ")));
+    response_stats_prefix_ = "response.";
+  }
+
+  auto filter_state = decoder_callbacks_.streamInfo().filterState();
+  ON_CALL(decoder_callbacks_, streamInfo())
+        .WillByDefault(ReturnRef(stream_info_));
+  ON_CALL(stream_info_, filterState())
+        .WillByDefault(testing::ReturnRef(filter_state));
+  ON_CALL(stream_info_, responseCode())
+        .WillByDefault(Return(absl::optional<uint32_t>(response_code)));
+
+  doRequestNoCompression({{":method", "get"}, {"accept-encoding", "test, deflate"}});
+  Http::TestResponseHeaderMapImpl headers{
+      {":method", "get"}, {"content-length", "256"}};
+  doResponse(headers, should_compress);
+
   EXPECT_EQ(should_compress, headers.has("vary"));
 }
 

--- a/test/extensions/filters/http/compressor/compressor_filter_test.cc
+++ b/test/extensions/filters/http/compressor/compressor_filter_test.cc
@@ -791,14 +791,9 @@ TEST_P(IsResponseCodeAllowedTest, Validate) {
     response_stats_prefix_ = "response.";
   }
 
-  auto filter_state = decoder_callbacks_.streamInfo().filterState();
-  ON_CALL(decoder_callbacks_, streamInfo()).WillByDefault(ReturnRef(stream_info_));
-  ON_CALL(stream_info_, filterState()).WillByDefault(testing::ReturnRef(filter_state));
-  ON_CALL(stream_info_, responseCode())
-      .WillByDefault(Return(absl::optional<uint32_t>(response_code)));
-
   doRequestNoCompression({{":method", "get"}, {"accept-encoding", "test, deflate"}});
-  Http::TestResponseHeaderMapImpl headers{{":method", "get"}, {"content-length", "256"}};
+  Http::TestResponseHeaderMapImpl headers{
+      {":method", "get"}, {"content-length", "256"}, {":status", std::to_string(response_code)}};
   doResponse(headers, should_compress);
 
   EXPECT_EQ(should_compress, headers.has("vary"));

--- a/test/extensions/filters/http/compressor/compressor_filter_test.cc
+++ b/test/extensions/filters/http/compressor/compressor_filter_test.cc
@@ -775,10 +775,10 @@ TEST_P(IsResponseCodeAllowedTest, Validate) {
           "enabled": {{
             "default_value": true,
           }},
-          "uncompressible_response_code": [
-            {}
-          ]
-        }}
+        }},
+        "uncompressible_response_code": [
+          {}
+        ]
       }},
       "compressor_library": {{
         "name": "test",

--- a/test/extensions/filters/http/compressor/compressor_filter_test.cc
+++ b/test/extensions/filters/http/compressor/compressor_filter_test.cc
@@ -776,7 +776,7 @@ TEST_P(IsResponseCodeAllowedTest, Validate) {
             "default_value": true,
           }},
         }},
-        "uncompressible_response_code": [
+        "uncompressible_response_codes": [
           {}
         ]
       }},


### PR DESCRIPTION
Commit Message: Adding support for response codes which should not undergo compression in the Compression filter.
Additional Description: Certain response codes should cause the compression to be skipped, such as 206 Partial Content. This is because compression changes the encoding, whereas range requests, which result in 206, should refer to the encoding, so the compression cannot be applied on top of 206 response.
Risk Level: Low (small optional feature)
Testing: Unit test + Integration Test
Docs Changes: docs/root/configuration/http/http_filters/compressor_filter.rst
Release Notes: Compressor Filter now allows configuration of a list of response codes for which the compression will be skipped . Adding 206 (Partial Content) to the list prevents content-encoding change after a range of the original content was received.
Platform Specific Features: N/A

[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
