### PR TITLE
ci: Add trigger for Android and iOS CI jobs on source/common changes

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -182,6 +182,7 @@ run:
     - bazel/repository_locations.bzl
     - mobile/.bazelrc
     - mobile/**/*
+    - source/common/**/*
     - tools/code_format/check_format.py
   mobile-android-all:
     paths:
@@ -192,6 +193,7 @@ run:
     - bazel/repository_locations.bzl
     - mobile/.bazelrc
     - mobile/**/*
+    - source/common/**/*
     - tools/code_format/check_format.py
     push: never
   mobile-android-tests:
@@ -259,6 +261,7 @@ run:
     - bazel/repository_locations.bzl
     - mobile/.bazelrc
     - mobile/**/*
+    - source/common/**/*
     - tools/code_format/check_format.py
   mobile-ios-all:
     paths:
@@ -269,6 +272,7 @@ run:
     - bazel/repository_locations.bzl
     - mobile/.bazelrc
     - mobile/**/*
+    - source/common/**/*
     - tools/code_format/check_format.py
     push: never
   mobile-ios-tests:


### PR DESCRIPTION
There have been several instances that changes, particularily to source/* directories, have introduced C++ features not supported by the Android NDK or iOS XCode version for Envoy Mobile.  Without triggering the mobile Android and iOS jobs on those changes, we don't catch them until after the fact.

The latest example is the std::aligned_alloc PR: https://github.com/envoyproxy/envoy/pull/38707.

Which introduced build errors on Android that CI didn't catch at the time of the PR and only in a subsequent PR that triggered mobile CI: https://github.com/envoyproxy/envoy/actions/runs/13818727995/job/38658598098.

This change causes any changes to `source/common/` to trigger Android and iOS CI.  This is a start in allowing us to catch such changes in the PR making the changes.