### PR TITLE
common: Disable pointer-size-alignment on SocketOptionImpl

### DIFF
--- a/source/common/memory/aligned_allocator.h
+++ b/source/common/memory/aligned_allocator.h
@@ -28,10 +28,15 @@ public:
     if (n == 0) {
       return nullptr;
     }
+// std::aligned_alloc is not available in the Android NDK until v28.
+#if defined(__ANDROID_API__) && __ANDROID_API__ < 28
+    return nullptr;
+#else
     std::size_t bytes = n * sizeof(T);
     // Ensure bytes is a multiple of Alignment, which is required by std::aligned_alloc.
     bytes = round_up_to_alignment(bytes);
     return static_cast<T*>(std::aligned_alloc(Alignment, bytes));
+#endif
   }
 
   void deallocate(T* p, std::size_t) noexcept {

--- a/source/common/network/socket_option_impl.h
+++ b/source/common/network/socket_option_impl.h
@@ -63,10 +63,14 @@ public:
 private:
   const envoy::config::core::v3::SocketOption::SocketState in_state_;
   const Network::SocketOptionName optname_;
+#if !defined(__ANDROID_API__) || __ANDROID_API__ >= 28
   // The vector's data() is used by the setsockopt syscall, which needs to be int-size-aligned on
   // some platforms, the AlignedAllocator here makes it pointer-size-aligned, which satisfies the
   // requirement, although it can be slightly over-aligned.
   const std::vector<uint8_t, Memory::AlignedAllocator<uint8_t, alignof(void*)>> value_;
+#else
+  const std::vector<uint8_t> value_;
+#endif
   // If present, specifies the socket type that this option applies to. Attempting to set this
   // option on a socket of a different type will be a no-op.
   absl::optional<Network::Socket::Type> socket_type_;

--- a/test/common/memory/aligned_allocator_test.cc
+++ b/test/common/memory/aligned_allocator_test.cc
@@ -9,6 +9,8 @@ namespace Envoy {
 namespace Memory {
 namespace {
 
+#if !defined(__ANDROID_API__) || __ANDROID_API__ >= 28
+
 TEST(AlignedAllocatorTest, AllocationSize) {
   using Alloc = AlignedAllocator<uint8_t, 8>;
   EXPECT_EQ(Alloc::round_up_to_alignment(0), 0);
@@ -48,6 +50,8 @@ TEST(AlignedAllocatorTest, Nullability) {
   EXPECT_EQ(alloc.allocate(0), nullptr);
   alloc.deallocate(nullptr, 0); // Should not crash
 }
+
+#endif // !defined(__ANDROID_API__) || __ANDROID_API__ >= 28
 
 } // namespace
 } // namespace Memory


### PR DESCRIPTION
https://github.com/envoyproxy/envoy/pull/38707 enabled a new aligned allocator using `std::aligned_alloc`. However, `std::aligned_alloc` is not available on the Android NDK we are using for Envoy Mobile, thereby causing Envoy Mobile Android CI to fail.

This PR temporarily disables the aligned allocator on Android until a more permanent solution is implemented.