### PR TITLE
Use posix_memalign/free in AlignedAllocator for ANDROID_API<28.

### DIFF
--- a/source/common/memory/aligned_allocator.h
+++ b/source/common/memory/aligned_allocator.h
@@ -1,12 +1,10 @@
 #pragma once
 
-#ifdef __ANDROID_API__
-#if __ANDROID_API__ < 28
+#if defined(__ANDROID_API__) && __ANDROID_API__ < 28
 #include <stdlib.h>
 
 #define ALIGNED_ALLOCATOR_USE_POSIX_MEMALIGN 1
-#endif // __ANDROID_API__ < 28
-#endif // ifdef __ANDROID_API__
+#endif // if defined(__ANDROID_API__) && __ANDROID_API__ < 28
 
 #include <cstddef>
 #include <cstdlib>


### PR DESCRIPTION
std::aligned_alloc is not available for ANDROID_API<28, this change switch it to posix_memalign/free instead.


Commit Message: Use posix_memalign/free in AlignedAllocator for ANDROID_API<28.
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
