### PR TITLE
Add seed corpus for the reverse transcoder

### DIFF
--- a/test/extensions/filters/http/common/fuzz/BUILD
+++ b/test/extensions/filters/http/common/fuzz/BUILD
@@ -58,6 +58,7 @@ envoy_cc_test_library(
         "//test/test_common:registry_lib",
         "//test/test_common:test_runtime_lib",
         "@envoy_api//envoy/extensions/filters/http/file_system_buffer/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/filters/http/grpc_json_reverse_transcoder/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/filters/http/grpc_json_transcoder/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/filters/http/jwt_authn/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/filters/http/tap/v3:pkg_cc_proto",

--- a/test/extensions/filters/http/common/fuzz/filter_corpus/grpc_reverse_transcoding_decode_encode
+++ b/test/extensions/filters/http/common/fuzz/filter_corpus/grpc_reverse_transcoding_decode_encode
@@ -1,0 +1,43 @@
+config {
+  name: "envoy.filters.http.grpc_json_reverse_transcoder"
+}
+
+data {
+  headers {
+    headers {
+      key: ":method"
+      value: "POST"
+    }
+    headers {
+      key: ":path"
+      value: "/bookstore.Bookstore/CreateShelf"
+    }
+    headers {
+      key: "content-type"
+      value: "application/grpc"
+    }
+  }
+  proto_body {
+    message {
+      [type.googleapis.com/bookstore.CreateShelfRequest] {
+        shelf {
+          id: 12
+          theme: "Kids"
+        }
+      }
+    }
+    chunk_size: 1
+  }
+}
+
+upstream_data {
+  headers {
+    headers {
+      key: "content-type"
+      value: "application/json"
+    }
+  }
+  http_body {
+    data: "{\"id\": 12, \"theme\": \"Kids\"}"
+  }
+}


### PR DESCRIPTION
Commit Message: Add seed corpus for grpc json reverse transcoder fuzz testing.
Additional Description: This PR adds a corpus seed to fuzz test the reverse transcoder.
Risk Level: None, as this only enables fuzz testing for the reverse transcoder.
Testing: n/a as this change itself adds the test
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a