### PR TITLE
formatter: make the CEL and METADATA as built in formatter

### DIFF
--- a/api/envoy/extensions/formatter/cel/v3/cel.proto
+++ b/api/envoy/extensions/formatter/cel/v3/cel.proto
@@ -31,5 +31,9 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // * ``%CEL(request.headers['x-log-mtls'] || request.url_path.contains('v1beta3'))%``
 
 // Configuration for the CEL formatter.
+//
+// .. warning::
+//   This extension is treated as built-in extension and will be enabled by default now.
+//   It is unnecessary to configure this extension.
 message Cel {
 }

--- a/api/envoy/extensions/formatter/metadata/v3/metadata.proto
+++ b/api/envoy/extensions/formatter/metadata/v3/metadata.proto
@@ -56,6 +56,9 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 //    METADATA(DYNAMIC:NAMESPACE:KEY):Z is equivalent to :ref:`DYNAMIC_METADATA(NAMESPACE:KEY):Z<config_access_log_format_dynamic_metadata>`
 //    METADATA(CLUSTER:NAMESPACE:KEY):Z is equivalent to :ref:`CLUSTER_METADATA(NAMESPACE:KEY):Z<config_access_log_format_cluster_metadata>`
 //    METADATA(UPSTREAM_HOST:NAMESPACE:KEY):Z is equivalent to :ref:`UPSTREAM_METADATA(NAMESPACE:KEY):Z<config_access_log_format_upstream_host_metadata>`
-
+//
+// .. warning::
+//   This extension is treated as built-in extension and will be enabled by default now.
+//   It is unnecessary to configure this extension.
 message Metadata {
 }

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -35,6 +35,10 @@ minor_behavior_changes:
     AWS request signing and AWS Lambda extensions will now no longer return empty credentials (and fail to sign) when
     credentials are still pending from the async credential providers. If all providers are unable to retrieve credentials
     then the original behaviour with a signing failure will occur.
+- area: formatter
+  change: |
+    The formatter ``%CEL%`` and ``%METADATA%`` will be treated as built-in formatters and could be used directly in the
+    substitution format string if the related extensions are linked.
 
 bug_fixes:
 # *Changes expected to improve the state of the world and are unlikely to have negative effects*

--- a/source/extensions/formatter/cel/BUILD
+++ b/source/extensions/formatter/cel/BUILD
@@ -43,6 +43,10 @@ envoy_cc_extension(
             "-DUSE_CEL_PARSER",
         ],
     }),
+    # Ensure this could be used in tests.
+    extra_visibility = [
+        "//test:__subpackages__",
+    ],
     deps = [
         "//envoy/registry",
         "//source/extensions/formatter/cel:cel_lib",

--- a/source/extensions/formatter/cel/cel.cc
+++ b/source/extensions/formatter/cel/cel.cc
@@ -63,8 +63,12 @@ CELFormatterCommandParser::parse(absl::string_view command, absl::string_view su
                            parse_status.status().ToString());
     }
 
-    return std::make_unique<CELFormatter>(local_info_, expr_builder_, parse_status.value().expr(),
-                                          max_length);
+    Server::Configuration::ServerFactoryContext& context =
+        Server::Configuration::ServerFactoryContextInstance::get();
+
+    return std::make_unique<CELFormatter>(context.localInfo(),
+                                          Extensions::Filters::Common::Expr::getBuilder(context),
+                                          parse_status.value().expr(), max_length);
   }
 
   return nullptr;

--- a/source/extensions/formatter/cel/cel.h
+++ b/source/extensions/formatter/cel/cel.h
@@ -34,16 +34,10 @@ private:
 
 class CELFormatterCommandParser : public ::Envoy::Formatter::CommandParser {
 public:
-  CELFormatterCommandParser(Server::Configuration::CommonFactoryContext& context)
-      : local_info_(context.localInfo()),
-        expr_builder_(Extensions::Filters::Common::Expr::getBuilder(context)){};
+  CELFormatterCommandParser() = default;
   ::Envoy::Formatter::FormatterProviderPtr parse(absl::string_view command,
                                                  absl::string_view subcommand,
                                                  absl::optional<size_t> max_length) const override;
-
-private:
-  const ::Envoy::LocalInfo::LocalInfo& local_info_;
-  Extensions::Filters::Common::Expr::BuilderInstanceSharedPtr expr_builder_;
 };
 
 } // namespace Formatter

--- a/source/extensions/formatter/cel/config.cc
+++ b/source/extensions/formatter/cel/config.cc
@@ -8,10 +8,14 @@ namespace Envoy {
 namespace Extensions {
 namespace Formatter {
 
-::Envoy::Formatter::CommandParserPtr CELFormatterFactory::createCommandParserFromProto(
-    const Protobuf::Message&, Server::Configuration::GenericFactoryContext& context) {
+::Envoy::Formatter::CommandParserPtr
+CELFormatterFactory::createCommandParserFromProto(const Protobuf::Message&,
+                                                  Server::Configuration::GenericFactoryContext&) {
 #if defined(USE_CEL_PARSER)
-  return std::make_unique<CELFormatterCommandParser>(context.serverFactoryContext());
+  ENVOY_LOG_TO_LOGGER(Logger::Registry::getLog(Logger::Id::config), warn,
+                      "'CEL' formatter is treated as a built-in formatter and does not "
+                      "require configuration.");
+  return std::make_unique<CELFormatterCommandParser>();
 #else
   UNREFERENCED_PARAMETER(context);
   throw EnvoyException("CEL is not available for use in this environment.");
@@ -25,6 +29,17 @@ ProtobufTypes::MessagePtr CELFormatterFactory::createEmptyConfigProto() {
 std::string CELFormatterFactory::name() const { return "envoy.formatter.cel"; }
 
 REGISTER_FACTORY(CELFormatterFactory, ::Envoy::Formatter::CommandParserFactory);
+
+class BuiltInCELFormatterFactory : public Envoy::Formatter::BuiltInCommandParserFactory {
+public:
+  std::string name() const override { return "envoy.built_in_formatters.cel"; }
+
+  ::Envoy::Formatter::CommandParserPtr createCommandParser() const override {
+    return std::make_unique<CELFormatterCommandParser>();
+  }
+};
+
+REGISTER_FACTORY(BuiltInCELFormatterFactory, Envoy::Formatter::BuiltInCommandParserFactory);
 
 } // namespace Formatter
 } // namespace Extensions

--- a/source/extensions/formatter/metadata/config.cc
+++ b/source/extensions/formatter/metadata/config.cc
@@ -10,6 +10,9 @@ namespace Formatter {
 
 ::Envoy::Formatter::CommandParserPtr MetadataFormatterFactory::createCommandParserFromProto(
     const Protobuf::Message&, Server::Configuration::GenericFactoryContext&) {
+  ENVOY_LOG_TO_LOGGER(Logger::Registry::getLog(Logger::Id::config), warn,
+                      "'METADATA' formatter is treated as a built-in formatter and does not "
+                      "require configuration.");
   return std::make_unique<MetadataFormatterCommandParser>();
 }
 
@@ -20,6 +23,17 @@ ProtobufTypes::MessagePtr MetadataFormatterFactory::createEmptyConfigProto() {
 std::string MetadataFormatterFactory::name() const { return "envoy.formatter.metadata"; }
 
 REGISTER_FACTORY(MetadataFormatterFactory, ::Envoy::Formatter::CommandParserFactory);
+
+class BuiltInMetadataFormatterFactory : public Envoy::Formatter::BuiltInCommandParserFactory {
+public:
+  std::string name() const override { return "envoy.built_in_formatters.metadata"; }
+
+  ::Envoy::Formatter::CommandParserPtr createCommandParser() const override {
+    return std::make_unique<MetadataFormatterCommandParser>();
+  }
+};
+
+REGISTER_FACTORY(BuiltInMetadataFormatterFactory, Envoy::Formatter::BuiltInCommandParserFactory);
 
 } // namespace Formatter
 } // namespace Extensions

--- a/test/extensions/access_loggers/open_telemetry/substitution_formatter_test.cc
+++ b/test/extensions/access_loggers/open_telemetry/substitution_formatter_test.cc
@@ -895,6 +895,8 @@ TEST(SubstitutionFormatterTest, OpenTelemetryFormatterMultiTokenTest) {
 TEST(SubstitutionFormatterTest, CELFormatterTest) {
   {
     NiceMock<Server::Configuration::MockFactoryContext> context;
+    ScopedThreadLocalServerContextSetter server_context_setter(context.server_factory_context_);
+
     StreamInfo::MockStreamInfo stream_info;
     Http::TestRequestHeaderMapImpl request_header{{"some_request_header", "SOME_REQUEST_HEADER"}};
     Http::TestResponseHeaderMapImpl response_header{
@@ -909,10 +911,6 @@ TEST(SubstitutionFormatterTest, CELFormatterTest) {
           - key: "cel_field"
             value:
               string_value: "%CEL(request.headers['some_request_header'])% %CEL(response.headers['some_response_header'])%"
-      formatters:
-        - name: envoy.formatter.cel
-          typed_config:
-            "@type": type.googleapis.com/envoy.extensions.formatter.cel.v3.Cel
     )EOF",
                               otel_config);
     auto commands = *Formatter::SubstitutionFormatStringUtils::parseFormatters(

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -2660,6 +2660,7 @@ envoy_cc_test(
     ],
     deps = [
         ":http_integration_lib",
+        "//source/extensions/formatter/cel:config",
         "//test/test_common:utility_lib",
         "@envoy_api//envoy/extensions/access_loggers/file/v3:pkg_cc_proto",
     ],

--- a/test/integration/access_log_integration_test.cc
+++ b/test/integration/access_log_integration_test.cc
@@ -23,10 +23,10 @@ INSTANTIATE_TEST_SUITE_P(IpVersions, AccessLogIntegrationTest,
                          TestUtility::ipTestParamsToString);
 
 TEST_P(AccessLogIntegrationTest, DownstreamDisconnectBeforeHeadersResponseCode) {
-  useAccessLog("RESPONSE_CODE=%RESPONSE_CODE%");
+  useAccessLog("RESPONSE_CODE=%RESPONSE_CODE%;CEL_METHOD=%CEL(request.headers[':method'])%");
   testRouterDownstreamDisconnectBeforeRequestComplete();
   std::string log = waitForAccessLog(access_log_name_);
-  EXPECT_THAT(log, HasSubstr("RESPONSE_CODE=0"));
+  EXPECT_THAT(log, HasSubstr("RESPONSE_CODE=0;CEL_METHOD=GET"));
 }
 
 TEST_P(AccessLogIntegrationTest, ShouldReplaceInvalidUtf8) {

--- a/test/test_common/BUILD
+++ b/test/test_common/BUILD
@@ -136,6 +136,7 @@ envoy_cc_test_library(
         "//envoy/buffer:buffer_interface",
         "//envoy/http:codec_interface",
         "//envoy/network:address_interface",
+        "//envoy/server:factory_context_interface",
         "//envoy/server/overload:thread_local_overload_state",
         "//envoy/tracing:trace_context_interface",
         "//source/common/api:api_lib",

--- a/test/test_common/utility.h
+++ b/test/test_common/utility.h
@@ -9,6 +9,7 @@
 #include "envoy/api/api.h"
 #include "envoy/buffer/buffer.h"
 #include "envoy/network/address.h"
+#include "envoy/server/factory_context.h"
 #include "envoy/stats/stats.h"
 #include "envoy/stats/store.h"
 #include "envoy/thread/thread.h"
@@ -1399,5 +1400,20 @@ MATCHER_P(JsonStringEq, expected, "") {
   do {                                                                                             \
   } while (0)
 #endif
+
+/**
+ * ScopedThreadLocalSingletonSetter is a helper class for setting a thread local server context for
+ * the duration of the lifetime of the object. The backing instance of singleton is owned by the
+ * caller.
+ */
+class ScopedThreadLocalServerContextSetter {
+public:
+  ~ScopedThreadLocalServerContextSetter() {
+    Server::Configuration::ServerFactoryContextInstance::clear();
+  }
+  ScopedThreadLocalServerContextSetter(Server::Configuration::ServerFactoryContext& context) {
+    Server::Configuration::ServerFactoryContextInstance::initialize(&context);
+  }
+};
 
 } // namespace Envoy


### PR DESCRIPTION
Commit Message: formatter: make the CEL and METADATA as built in formatter
Additional Description:

This make the CEL and METADATA as built in formatter and could be used everywhere. Now, we needn't to configure it. After this PR, it's possible to use CEL at the header mutation which would be helpful.

Risk Level: low.
Testing: unit/integration.
Docs Changes: added.
Release Notes: added.
Platform Specific Features: n/a.