### PR TITLE
Ext_Proc: Encode filter protocol configuration and send to the server

### DIFF
--- a/api/envoy/service/ext_proc/v3/external_processor.proto
+++ b/api/envoy/service/ext_proc/v3/external_processor.proto
@@ -147,7 +147,6 @@ message ProcessingRequest {
   //
   bool observability_mode = 10;
 
-  // [#not-implemented-hide:]
   // Specify the filter protocol configurations to be sent to the server.
   // ``protocol_config`` is only encoded in the first ``ProcessingRequest`` message from the client to the server.
   ProtocolConfiguration protocol_config = 11;

--- a/source/extensions/filters/http/ext_proc/ext_proc.cc
+++ b/source/extensions/filters/http/ext_proc/ext_proc.cc
@@ -750,8 +750,8 @@ void Filter::encodeProtocolConfig(ProcessingRequest& req) {
     protocol_config->set_send_body_without_waiting_for_header_response(
         config_->sendBodyWithoutWaitingForHeaderResponse());
     protocol_config_encoded_ = true;
-    ENVOY_STREAM_LOG(debug, "Filter protocol configurations encoded {}",
-                     *decoder_callbacks_, protocol_config->DebugString());
+    ENVOY_STREAM_LOG(debug, "Filter protocol configurations encoded {}", *decoder_callbacks_,
+                     protocol_config->DebugString());
   }
 }
 

--- a/source/extensions/filters/http/ext_proc/ext_proc.cc
+++ b/source/extensions/filters/http/ext_proc/ext_proc.cc
@@ -741,6 +741,20 @@ FilterDataStatus Filter::onData(ProcessorState& state, Buffer::Instance& data, b
   return result;
 }
 
+void Filter::encodeProtocolConfig(ProcessingRequest& req) {
+  ENVOY_STREAM_LOG(debug, "Trying to encode filter protocol configurations", *decoder_callbacks_);
+  if (!protocol_config_encoded_ && !config_->observabilityMode()) {
+    auto* protocol_config = req.mutable_protocol_config();
+    protocol_config->set_request_body_mode(config_->processingMode().request_body_mode());
+    protocol_config->set_response_body_mode(config_->processingMode().response_body_mode());
+    protocol_config->set_send_body_without_waiting_for_header_response(
+        config_->sendBodyWithoutWaitingForHeaderResponse());
+    protocol_config_encoded_ = true;
+    ENVOY_STREAM_LOG(debug, "Filter protocol configurations encoded {}",
+                     *decoder_callbacks_, protocol_config->DebugString());
+  }
+}
+
 ProcessingRequest Filter::buildHeaderRequest(ProcessorState& state,
                                              Http::RequestOrResponseHeaderMap& headers,
                                              bool end_stream, bool observability_mode) {
@@ -754,6 +768,8 @@ ProcessingRequest Filter::buildHeaderRequest(ProcessorState& state,
   MutationUtils::headersToProto(headers, config_->allowedHeaders(), config_->disallowedHeaders(),
                                 *headers_req->mutable_headers());
   headers_req->set_end_of_stream(end_stream);
+  encodeProtocolConfig(req);
+
   return req;
 }
 
@@ -992,6 +1008,7 @@ ProcessingRequest Filter::setupBodyChunk(ProcessorState& state, const Buffer::In
   auto* body_req = state.mutableBody(req);
   body_req->set_end_of_stream(end_stream);
   body_req->set_body(data.toString());
+  encodeProtocolConfig(req);
   return req;
 }
 
@@ -1029,6 +1046,7 @@ void Filter::sendTrailers(ProcessorState& state, const Http::HeaderMap& trailers
                                config_->messageTimeout(), callback_state);
     ENVOY_STREAM_LOG(debug, "Sending trailers message", *decoder_callbacks_);
   }
+  encodeProtocolConfig(req);
 
   sendRequest(std::move(req), false);
   stats_.stream_msgs_sent_.inc();

--- a/source/extensions/filters/http/ext_proc/ext_proc.h
+++ b/source/extensions/filters/http/ext_proc/ext_proc.h
@@ -515,6 +515,8 @@ private:
 
   void sendRequest(envoy::service::ext_proc::v3::ProcessingRequest&& req, bool end_stream);
 
+  void encodeProtocolConfig(envoy::service::ext_proc::v3::ProcessingRequest& req);
+
   const FilterConfigSharedPtr config_;
   const ClientBasePtr client_;
   ExtProcFilterStats stats_;
@@ -549,6 +551,9 @@ private:
 
   // Set to true when the mergePerRouteConfig() method has been called.
   bool route_config_merged_ = false;
+
+  // If true, the protocol configurations are already sent to the server.
+  bool protocol_config_encoded_ = false;
 };
 
 extern std::string responseCaseToString(

--- a/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
+++ b/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
@@ -44,6 +44,7 @@ using envoy::service::ext_proc::v3::HttpTrailers;
 using envoy::service::ext_proc::v3::ImmediateResponse;
 using envoy::service::ext_proc::v3::ProcessingRequest;
 using envoy::service::ext_proc::v3::ProcessingResponse;
+using envoy::service::ext_proc::v3::ProtocolConfiguration;
 using envoy::service::ext_proc::v3::TrailersResponse;
 using Extensions::HttpFilters::ExternalProcessing::DEFAULT_DEFERRED_CLOSE_TIMEOUT_MS;
 using Extensions::HttpFilters::ExternalProcessing::HasNoHeader;
@@ -219,6 +220,14 @@ protected:
     ASSERT_TRUE(cfg_any.PackFrom(cfg));
     vh.mutable_typed_per_filter_config()->insert(
         MapPair<std::string, Any>("envoy.filters.http.ext_proc", cfg_any));
+  }
+
+  void protocolConfigEncoding(ProcessingRequest& request) {
+    protocol_config_encoded_ = false;
+    if (request.has_protocol_config()) {
+      protocol_config_encoded_ = true;
+      protocol_config_ = request.protocol_config();
+    }
   }
 
   IntegrationStreamDecoderPtr sendDownstreamRequest(
@@ -397,6 +406,8 @@ protected:
     }
     ASSERT_TRUE(processor_stream_->waitForGrpcMessage(*dispatcher_, request));
     ASSERT_TRUE(request.has_response_headers());
+    protocolConfigEncoding(request);
+
     if (first_message) {
       processor_stream_->startGrpcStream();
     }
@@ -419,6 +430,8 @@ protected:
     }
     ASSERT_TRUE(processor_stream_->waitForGrpcMessage(*dispatcher_, request));
     ASSERT_TRUE(request.has_request_body());
+    protocolConfigEncoding(request);
+
     if (first_message) {
       processor_stream_->startGrpcStream();
     }
@@ -449,6 +462,8 @@ protected:
     }
     ASSERT_TRUE(processor_stream_->waitForGrpcMessage(*dispatcher_, request));
     ASSERT_TRUE(request.has_response_body());
+    protocolConfigEncoding(request);
+
     if (first_message) {
       processor_stream_->startGrpcStream();
     }
@@ -828,6 +843,8 @@ protected:
   }
 
   envoy::extensions::filters::http::ext_proc::v3::ExternalProcessor proto_config_{};
+  bool protocol_config_encoded_ = false;
+  ProtocolConfiguration protocol_config_{};
   uint32_t max_message_timeout_ms_{0};
   std::vector<FakeUpstream*> grpc_upstreams_;
   FakeHttpConnectionPtr processor_connection_;
@@ -5119,6 +5136,30 @@ TEST_P(ExtProcIntegrationTest, SendBodyBeforeHeaderRespStreamedNotSendTrailerTes
   handleUpstreamRequest(100);
   processResponseHeadersMessage(*grpc_upstreams_[0], false, absl::nullopt);
   processResponseBodyMessage(*grpc_upstreams_[0], false, absl::nullopt);
+  verifyDownstreamResponse(*response, 200);
+}
+
+TEST_P(ExtProcIntegrationTest, ProtocolConfigurationEncodingTest) {
+  proto_config_.mutable_processing_mode()->set_request_header_mode(ProcessingMode::SKIP);
+  proto_config_.mutable_processing_mode()->set_request_body_mode(ProcessingMode::STREAMED);
+  proto_config_.mutable_processing_mode()->set_response_header_mode(ProcessingMode::SEND);
+  proto_config_.mutable_processing_mode()->set_response_body_mode(ProcessingMode::STREAMED);
+  proto_config_.set_send_body_without_waiting_for_header_response(true);
+  initializeConfig();
+  HttpIntegrationTest::initialize();
+  auto response = sendDownstreamRequestWithBodyAndTrailer("hello world");
+  // processRequestHeadersMessage(*grpc_upstreams_[0], true, absl::nullopt);
+  processRequestBodyMessage(*grpc_upstreams_[0], true, absl::nullopt);
+  EXPECT_TRUE(protocol_config_encoded_);
+  EXPECT_EQ(protocol_config_.request_body_mode(), ProcessingMode::STREAMED);
+  EXPECT_EQ(protocol_config_.response_body_mode(), ProcessingMode::STREAMED);
+  EXPECT_TRUE(protocol_config_.send_body_without_waiting_for_header_response());
+
+  handleUpstreamRequest(100);
+  processResponseHeadersMessage(*grpc_upstreams_[0], false, absl::nullopt);
+  EXPECT_FALSE(protocol_config_encoded_);
+  processResponseBodyMessage(*grpc_upstreams_[0], false, absl::nullopt);
+  EXPECT_FALSE(protocol_config_encoded_);
   verifyDownstreamResponse(*response, 200);
 }
 

--- a/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
+++ b/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
@@ -364,6 +364,7 @@ protected:
     }
     ASSERT_TRUE(processor_stream_->waitForGrpcMessage(*dispatcher_, request));
     ASSERT_TRUE(request.has_request_headers());
+    protocolConfigEncoding(request);
     if (first_message) {
       processor_stream_->startGrpcStream();
     }
@@ -5148,7 +5149,6 @@ TEST_P(ExtProcIntegrationTest, ProtocolConfigurationEncodingTest) {
   initializeConfig();
   HttpIntegrationTest::initialize();
   auto response = sendDownstreamRequestWithBodyAndTrailer("hello world");
-  // processRequestHeadersMessage(*grpc_upstreams_[0], true, absl::nullopt);
   processRequestBodyMessage(*grpc_upstreams_[0], true, absl::nullopt);
   EXPECT_TRUE(protocol_config_encoded_);
   EXPECT_EQ(protocol_config_.request_body_mode(), ProcessingMode::STREAMED);

--- a/test/extensions/filters/http/ext_proc/filter_test.cc
+++ b/test/extensions/filters/http/ext_proc/filter_test.cc
@@ -685,6 +685,10 @@ TEST_F(HttpFilterTest, SimplestPost) {
   request_headers_.addCopy(LowerCaseString("x-some-other-header"), "yes");
 
   EXPECT_EQ(FilterHeadersStatus::StopIteration, filter_->decodeHeaders(request_headers_, false));
+  EXPECT_TRUE(last_request_.has_protocol_config());
+  EXPECT_EQ(last_request_.protocol_config().request_body_mode(), ProcessingMode::NONE);
+  EXPECT_EQ(last_request_.protocol_config().response_body_mode(), ProcessingMode::NONE);
+  EXPECT_FALSE(last_request_.protocol_config().send_body_without_waiting_for_header_response());
   processRequestHeaders(false,
                         [](const HttpHeaders& header_req, ProcessingResponse&, HeadersResponse&) {
                           EXPECT_FALSE(header_req.end_of_stream());
@@ -707,6 +711,7 @@ TEST_F(HttpFilterTest, SimplestPost) {
   response_headers_.addCopy(LowerCaseString("content-length"), "3");
 
   EXPECT_EQ(FilterHeadersStatus::StopIteration, filter_->encodeHeaders(response_headers_, false));
+  EXPECT_FALSE(last_request_.has_protocol_config());
   processResponseHeaders(
       false, [](const HttpHeaders& header_resp, ProcessingResponse&, HeadersResponse&) {
         EXPECT_FALSE(header_resp.end_of_stream());
@@ -1812,18 +1817,23 @@ TEST_F(HttpFilterTest, StreamingSendDataRandomGrpcLatency) {
   Buffer::OwnedImpl req_data("foo");
   // Latency 50 80 60 30 100.
   EXPECT_EQ(FilterDataStatus::Continue, filter_->decodeData(req_data, false));
+  EXPECT_TRUE(last_request_.has_protocol_config());
   processRequestBody(absl::nullopt, false, std::chrono::microseconds(50));
 
   EXPECT_EQ(FilterDataStatus::Continue, filter_->decodeData(req_data, false));
+  EXPECT_FALSE(last_request_.has_protocol_config());
   processRequestBody(absl::nullopt, false, std::chrono::microseconds(80));
 
   EXPECT_EQ(FilterDataStatus::Continue, filter_->decodeData(req_data, false));
+  EXPECT_FALSE(last_request_.has_protocol_config());
   processRequestBody(absl::nullopt, false, std::chrono::microseconds(60));
 
   EXPECT_EQ(FilterDataStatus::Continue, filter_->decodeData(req_data, false));
+  EXPECT_FALSE(last_request_.has_protocol_config());
   processRequestBody(absl::nullopt, false, std::chrono::microseconds(30));
 
   EXPECT_EQ(FilterDataStatus::Continue, filter_->decodeData(req_data, false));
+  EXPECT_FALSE(last_request_.has_protocol_config());
   processRequestBody(absl::nullopt, false, std::chrono::microseconds(100));
 
   EXPECT_EQ(FilterTrailersStatus::Continue, filter_->decodeTrailers(request_trailers_));
@@ -1873,6 +1883,7 @@ TEST_F(HttpFilterTest, PostStreamingBodies) {
 
   EXPECT_CALL(decoder_callbacks_, decodingBuffer()).WillRepeatedly(Return(nullptr));
   EXPECT_EQ(FilterHeadersStatus::StopIteration, filter_->decodeHeaders(request_headers_, false));
+  EXPECT_TRUE(last_request_.has_protocol_config());
   processRequestHeaders(false, absl::nullopt);
   // Test content-length header is removed in request in streamed mode.
   EXPECT_EQ(request_headers_.ContentLength(), nullptr);
@@ -1891,6 +1902,7 @@ TEST_F(HttpFilterTest, PostStreamingBodies) {
   want_request_body.add(req_chunk_1.toString());
   EXPECT_EQ(FilterDataStatus::StopIterationNoBuffer, filter_->decodeData(req_chunk_1, true));
   got_request_body.move(req_chunk_1);
+  EXPECT_FALSE(last_request_.has_protocol_config());
   processRequestBody(absl::nullopt);
   EXPECT_EQ(want_request_body.toString(), got_request_body.toString());
   EXPECT_FALSE(decoding_watermarked);
@@ -1903,6 +1915,7 @@ TEST_F(HttpFilterTest, PostStreamingBodies) {
   setUpEncodingWatermarking(encoding_watermarked);
   EXPECT_CALL(encoder_callbacks_, encodingBuffer()).WillRepeatedly(Return(nullptr));
   EXPECT_EQ(FilterHeadersStatus::StopIteration, filter_->encodeHeaders(response_headers_, false));
+  EXPECT_FALSE(last_request_.has_protocol_config());
   processResponseHeaders(false, absl::nullopt);
   // Test content-length header is removed in response in streamed mode.
   EXPECT_EQ(response_headers_.ContentLength(), nullptr);
@@ -1919,6 +1932,7 @@ TEST_F(HttpFilterTest, PostStreamingBodies) {
     want_response_body.add(resp_chunk.toString());
     EXPECT_EQ(FilterDataStatus::Continue, filter_->encodeData(resp_chunk, false));
     got_response_body.move(resp_chunk);
+    EXPECT_FALSE(last_request_.has_protocol_config());
     processResponseBody(absl::nullopt, false);
   }
 
@@ -2570,7 +2584,6 @@ TEST_F(HttpFilterTest, ProcessingModeOverrideResponseHeadersDefault) {
   )EOF");
   EXPECT_EQ(filter_->config().allowModeOverride(), true);
   EXPECT_EQ(FilterHeadersStatus::StopIteration, filter_->decodeHeaders(request_headers_, false));
-
   // Override header processing with DEFAULT.
   processRequestHeaders(false,
                         [](const HttpHeaders&, ProcessingResponse& response, HeadersResponse&) {
@@ -2586,7 +2599,6 @@ TEST_F(HttpFilterTest, ProcessingModeOverrideResponseHeadersDefault) {
   response_headers_.addCopy(LowerCaseString(":status"), "200");
   response_headers_.addCopy(LowerCaseString("content-type"), "text/plain");
   EXPECT_EQ(FilterHeadersStatus::StopIteration, filter_->encodeHeaders(response_headers_, false));
-
   processResponseHeaders(false, [](const HttpHeaders& header_resp, ProcessingResponse&,
                                    HeadersResponse&) {
     EXPECT_FALSE(header_resp.end_of_stream());
@@ -3566,10 +3578,12 @@ TEST_F(HttpFilterTest, ResponseTrailerMutationExceedSizeLimit) {
   response_headers_.addCopy(LowerCaseString(":status"), "200");
 
   EXPECT_EQ(FilterHeadersStatus::StopIteration, filter_->encodeHeaders(response_headers_, false));
+  EXPECT_TRUE(last_request_.has_protocol_config());
   processResponseHeaders(false, absl::nullopt);
   // Construct a large trailer message to be close to the HCM size limit.
   resp_trailers_.addCopy(LowerCaseString("x-some-trailer"), std::string(1950, 'a'));
   EXPECT_EQ(FilterTrailersStatus::StopIteration, filter_->encodeTrailers(resp_trailers_));
+  EXPECT_FALSE(last_request_.has_protocol_config());
   processResponseTrailers(
       [](const HttpTrailers&, ProcessingResponse&, TrailersResponse& trailer_resp) {
         auto headers_mut = trailer_resp.mutable_header_mutation();
@@ -4148,6 +4162,8 @@ TEST_F(HttpFilterTest, HeaderRespReceivedBeforeBody) {
   bool encoding_watermarked = false;
   setUpEncodingWatermarking(encoding_watermarked);
   EXPECT_EQ(FilterHeadersStatus::StopIteration, filter_->encodeHeaders(response_headers_, false));
+
+
   // Header response arrives before any body data.
   processResponseHeaders(false, absl::nullopt);
 
@@ -4214,6 +4230,11 @@ TEST_F(HttpFilterTest, HeaderRespReceivedAfterBodySent) {
   bool encoding_watermarked = false;
   setUpEncodingWatermarking(encoding_watermarked);
   EXPECT_EQ(FilterHeadersStatus::StopIteration, filter_->encodeHeaders(response_headers_, false));
+
+  EXPECT_TRUE(last_request_.has_protocol_config());
+  EXPECT_EQ(last_request_.protocol_config().request_body_mode(), ProcessingMode::NONE);
+  EXPECT_EQ(last_request_.protocol_config().response_body_mode(), ProcessingMode::STREAMED);
+  EXPECT_TRUE(last_request_.protocol_config().send_body_without_waiting_for_header_response());
 
   Buffer::OwnedImpl want_response_body;
   Buffer::OwnedImpl got_response_body;
@@ -4552,6 +4573,7 @@ TEST_F(HttpFilterTest, DuplexStreamedBodyProcessingTestWithHeaderAndTrailer) {
   request_headers_.addCopy(LowerCaseString("content-type"), "text/plain");
 
   EXPECT_EQ(FilterHeadersStatus::StopIteration, filter_->decodeHeaders(request_headers_, false));
+  EXPECT_TRUE(last_request_.has_protocol_config());
   processRequestHeaders(false, absl::nullopt);
 
   response_headers_.addCopy(LowerCaseString(":status"), "200");
@@ -4577,6 +4599,7 @@ TEST_F(HttpFilterTest, DuplexStreamedBodyProcessingTestWithHeaderAndTrailer) {
 
   EXPECT_EQ(FilterTrailersStatus::StopIteration, filter_->encodeTrailers(response_trailers_));
 
+  EXPECT_FALSE(last_request_.has_protocol_config());
   // Server now sends back response.
   processResponseHeadersAfterTrailer(absl::nullopt);
   processResponseBodyStreamedAfterTrailer(" AAAAA ", want_response_body);

--- a/test/extensions/filters/http/ext_proc/filter_test.cc
+++ b/test/extensions/filters/http/ext_proc/filter_test.cc
@@ -4163,7 +4163,6 @@ TEST_F(HttpFilterTest, HeaderRespReceivedBeforeBody) {
   setUpEncodingWatermarking(encoding_watermarked);
   EXPECT_EQ(FilterHeadersStatus::StopIteration, filter_->encodeHeaders(response_headers_, false));
 
-
   // Header response arrives before any body data.
   processResponseHeaders(false, absl::nullopt);
 


### PR DESCRIPTION
This is the follow up PR for: https://github.com/envoyproxy/envoy/pull/38755.
It encodes the ext_proc filter protocol configuration and sends to the server.
The encoding only happens in the first gRPC message.