### PR TITLE
bootstrap: allow to fail listener health check at startup

### DIFF
--- a/api/envoy/config/bootstrap/v3/bootstrap.proto
+++ b/api/envoy/config/bootstrap/v3/bootstrap.proto
@@ -419,7 +419,7 @@ message Bootstrap {
 
 // Administration interface :ref:`operations documentation
 // <operations_admin_interface>`.
-// [#next-free-field: 7]
+// [#next-free-field: 8]
 message Admin {
   option (udpa.annotations.versioning).previous_message_type = "envoy.config.bootstrap.v2.Admin";
 
@@ -449,6 +449,9 @@ message Admin {
   // Indicates whether :ref:`global_downstream_max_connections <config_overload_manager_limiting_connections>`
   // should apply to the admin interface or not.
   bool ignore_global_conn_limit = 6;
+
+  // Fails listener health checks at startup to be alter enabled through admin interface.
+  bool fail_startup_listener_health = 7;
 }
 
 // Cluster manager :ref:`architecture overview <arch_overview_cluster_manager>`.

--- a/envoy/server/configuration.h
+++ b/envoy/server/configuration.h
@@ -158,6 +158,11 @@ public:
    * limit.
    */
   virtual bool ignoreGlobalConnLimit() const PURE;
+
+  /**
+   * @return bool whether to fail listener health checks at startup.
+   */
+  virtual bool failStartupListenerHealth() const PURE;
 };
 
 /**

--- a/source/server/admin/admin.cc
+++ b/source/server/admin/admin.cc
@@ -106,7 +106,7 @@ Http::HeaderValidatorFactoryPtr createHeaderValidatorFactory(
 } // namespace
 
 AdminImpl::AdminImpl(const std::string& profile_path, Server::Instance& server,
-                     bool ignore_global_conn_limit)
+                     bool ignore_global_conn_limit, bool fail_startup_listener_health)
     : server_(server), listener_info_(std::make_shared<ListenerInfoImpl>()),
       factory_context_(server, listener_info_),
       request_id_extension_(Extensions::RequestId::UUIDRequestIDExtension::defaultInstance(
@@ -269,7 +269,8 @@ AdminImpl::AdminImpl(const std::string& profile_path, Server::Instance& server,
       admin_filter_chain_(std::make_shared<AdminFilterChain>()),
       local_reply_(LocalReply::Factory::createDefault()),
       ignore_global_conn_limit_(ignore_global_conn_limit),
-      header_validator_factory_(createHeaderValidatorFactory(server.serverFactoryContext())) {
+      header_validator_factory_(createHeaderValidatorFactory(server.serverFactoryContext())),
+      fail_startup_listener_health_(fail_startup_listener_health) {
 #ifndef NDEBUG
   // Verify that no duplicate handlers exist.
   absl::flat_hash_set<absl::string_view> handlers;

--- a/source/server/admin/admin.h
+++ b/source/server/admin/admin.h
@@ -71,7 +71,7 @@ class AdminImpl : public Admin,
                   Logger::Loggable<Logger::Id::admin> {
 public:
   AdminImpl(const std::string& profile_path, Server::Instance& server,
-            bool ignore_global_conn_limit);
+            bool ignore_global_conn_limit, bool fail_startup_listener_health);
 
   Http::Code runCallback(Http::ResponseHeaderMap& response_headers, Buffer::Instance& response,
                          AdminStream& admin_stream);
@@ -500,6 +500,7 @@ private:
   const bool ignore_global_conn_limit_;
   std::unique_ptr<HttpConnectionManagerProto::ProxyStatusConfig> proxy_status_config_;
   const Http::HeaderValidatorFactoryPtr header_validator_factory_;
+  const bool fail_startup_listener_health_;
 };
 
 } // namespace Server

--- a/source/server/configuration_impl.cc
+++ b/source/server/configuration_impl.cc
@@ -261,6 +261,7 @@ InitialImpl::InitialImpl(const envoy::config::bootstrap::v3::Bootstrap& bootstra
         Network::SocketOptionFactory::buildLiteralOptions(admin.socket_options()));
   }
   admin_.ignore_global_conn_limit_ = admin.ignore_global_conn_limit();
+  admin_.fail_startup_listener_health_ = admin.fail_startup_listener_health();
 
   if (!bootstrap.flags_path().empty()) {
     flags_path_ = bootstrap.flags_path();

--- a/source/server/configuration_impl.h
+++ b/source/server/configuration_impl.h
@@ -213,12 +213,14 @@ private:
     Network::Socket::OptionsSharedPtr socketOptions() override { return socket_options_; }
     AccessLog::InstanceSharedPtrVector accessLogs() const override { return access_logs_; }
     bool ignoreGlobalConnLimit() const override { return ignore_global_conn_limit_; }
+    bool failStartupListenerHealth() const override { return fail_startup_listener_health_; }
 
     std::string profile_path_;
     AccessLog::InstanceSharedPtrVector access_logs_;
     Network::Address::InstanceConstSharedPtr address_;
     Network::Socket::OptionsSharedPtr socket_options_;
     bool ignore_global_conn_limit_;
+    bool fail_startup_listener_health_;
   };
 
   AdminImpl admin_;

--- a/test/server/admin/admin_instance.cc
+++ b/test/server/admin/admin_instance.cc
@@ -9,7 +9,7 @@ namespace Server {
 
 AdminInstanceTest::AdminInstanceTest()
     : cpu_profile_path_(TestEnvironment::temporaryPath("envoy.prof")),
-      admin_(cpu_profile_path_, server_, false), request_headers_{{":path", "/"}},
+      admin_(cpu_profile_path_, server_, false, false), request_headers_{{":path", "/"}},
       admin_filter_(admin_) {
   AccessLog::InstanceSharedPtrVector access_logs;
   Filesystem::FilePathAndType file_info{Filesystem::DestinationType::File, "/dev/null"};

--- a/test/server/admin/admin_test.cc
+++ b/test/server/admin/admin_test.cc
@@ -78,7 +78,7 @@ TEST_P(AdminInstanceTest, WriteAddressToFile) {
 
 TEST_P(AdminInstanceTest, AdminAddress) {
   server_.options_.admin_address_path_ = TestEnvironment::temporaryPath("admin.address");
-  AdminImpl admin_address_out_path(cpu_profile_path_, server_, false);
+  AdminImpl admin_address_out_path(cpu_profile_path_, server_, false, false);
   AccessLog::InstanceSharedPtrVector access_logs;
   Filesystem::FilePathAndType file_info{Filesystem::DestinationType::File, "/dev/null"};
   access_logs.emplace_back(new Extensions::AccessLoggers::File::FileAccessLog(
@@ -93,7 +93,7 @@ TEST_P(AdminInstanceTest, AdminAddress) {
 TEST_P(AdminInstanceTest, AdminBadAddressOutPath) {
   server_.options_.admin_address_path_ =
       TestEnvironment::temporaryPath("some/unlikely/bad/path/admin.address");
-  AdminImpl admin_bad_address_out_path(cpu_profile_path_, server_, false);
+  AdminImpl admin_bad_address_out_path(cpu_profile_path_, server_, false, false);
   AccessLog::InstanceSharedPtrVector access_logs;
   Filesystem::FilePathAndType file_info{Filesystem::DestinationType::File, "/dev/null"};
   access_logs.emplace_back(new Extensions::AccessLoggers::File::FileAccessLog(

--- a/test/server/admin/profiling_handler_test.cc
+++ b/test/server/admin/profiling_handler_test.cc
@@ -67,7 +67,7 @@ TEST_P(AdminInstanceTest, AdminHeapProfiler) {
 TEST_P(AdminInstanceTest, AdminBadProfiler) {
   Buffer::OwnedImpl data;
   AdminImpl admin_bad_profile_path(TestEnvironment::temporaryPath("some/unlikely/bad/path.prof"),
-                                   server_, false);
+                                   server_, false, false);
   Http::TestResponseHeaderMapImpl header_map;
   request_headers_.setMethod(Http::Headers::get().MethodValues.Post);
   request_headers_.setPath("/cpuprofiler?enable=y");

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -1770,6 +1770,16 @@ TEST_P(ServerInstanceImplTest, TextApplicationLog) {
   ENVOY_LOG_MISC(info, "hello");
 }
 
+TEST_P(ServerInstanceImplTest, AdminStartupHealth) {
+  initialize("test/server/test_data/server/empty_bootstrap.yaml");
+  EXPECT_FALSE(server_->healthCheckFailed());
+}
+
+TEST_P(ServerInstanceImplTest, AdminFailStartupHealth) {
+  initialize("test/server/test_data/server/bootstrap_fail_startup_health.yaml");
+  EXPECT_TRUE(server_->healthCheckFailed());
+}
+
 } // namespace
 } // namespace Server
 } // namespace Envoy

--- a/test/server/test_data/server/bootstrap_fail_startup_health.yaml
+++ b/test/server/test_data/server/bootstrap_fail_startup_health.yaml
@@ -1,0 +1,2 @@
+admin:
+  fail_startup_listener_health: true


### PR DESCRIPTION
Commit Message:

This PR allows to start healthcheck filter with failed status.

Additional Description:

In some setup, Envoy acts as backend for a downstream proxy. At startup, it is useful to wait for the xDS config coming from the control plane, and run some readiness checks, before enabling the healthcheck.
This allows to be in a better control when we can actually allow traffic to be received.

For example we face races where the listeners becomes available but part of our pod setup is not yet ready. We therefore need more control to be able to decide when we allow traffic to come in.

with this feature turned on, the workflow will be:

- pod receives xDS configuration from control plane - listener HC are failed
- our (k8s) script will operate our readiness checks:
  - if it succeeds, we finish by enabling listener HC
  - if it fails, we don't enable listener HC

It allows us to be more in control of when we start receiving traffic for each new pod.

Risk Level: Low
Testing:

Envoy bootstrap config:
```
{
 admin:
  fail_startup_listener_health: true
}
```

Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
