### PR TITLE
golang: add callback method for http plugin config destruction (fixes #38557) 

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -273,6 +273,6 @@ new_features:
 - area: golang
   change: |
     added http golang filter config destroy callback. When a config gets deleted from envoy, the go plugin calls the
-    Destroy function on the config instance. config should implement the new 
+    Destroy function on the config instance. config should implement the new
     github.com/envoyproxy/envoy/contrib/golang/common/go/api.Config interface, implementing the Destroy function.
 deprecated:

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -273,6 +273,5 @@ new_features:
 - area: golang
   change: |
     added http golang filter config destroy callback. When a config gets deleted from envoy, the go plugin calls the
-    Destroy function on the config instance. config should implement the new
-    github.com/envoyproxy/envoy/contrib/golang/common/go/api.Config interface, implementing the Destroy function.
+    Destroy function on the config parser instance. This introduces a breaking change in the golang parser interface.
 deprecated:

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -272,7 +272,7 @@ new_features:
     default socket interface to support io_uring.
 - area: golang
   change: |
-    added http golang filter config destroy callback. When a config gets deleted from envoy, the go plugin calls the `Destroy` function on the config instance.
-    config should implement the new `github.com/envoyproxy/envoy/contrib/golang/common/go/api.Config` interface, implementing the Destroy function.
-
+    added http golang filter config destroy callback. When a config gets deleted from envoy, the go plugin calls the
+    Destroy function on the config instance. config should implement the new 
+    github.com/envoyproxy/envoy/contrib/golang/common/go/api.Config interface, implementing the Destroy function.
 deprecated:

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -270,5 +270,9 @@ new_features:
   change: |
     Added an :ref:`io_uring <envoy_v3_api_field_extensions.network.socket_interface.v3.DefaultSocketInterface.io_uring_options>` option in
     default socket interface to support io_uring.
+- area: golang
+  change: |
+    added http golang filter config destroy callback. When a config gets deleted from envoy, the go plugin calls the `Destroy` function on the config instance.
+    config should implement the new `github.com/envoyproxy/envoy/contrib/golang/common/go/api.Config` interface, implementing the Destroy function.
 
 deprecated:

--- a/contrib/golang/common/go/api/filter.go
+++ b/contrib/golang/common/go/api/filter.go
@@ -30,6 +30,9 @@ type (
 		PassThroughStreamEncoderFilter
 	}
 
+	// PassThroughStreamFilterConfigParser provides the no-op implementation of the StreamFilterConfigParser interface.
+	PassThroughStreamFilterConfigParser struct{}
+
 	// EmptyDownstreamFilter provides the no-op implementation of the DownstreamFilter interface
 	EmptyDownstreamFilter struct{}
 	// EmptyUpstreamFilter provides the no-op implementation of the UpstreamFilter interface
@@ -108,23 +111,29 @@ func (*PassThroughStreamFilter) OnDestroy(DestroyReason) {
 func (*PassThroughStreamFilter) OnStreamComplete() {
 }
 
-type Config interface {
-	// Called when the current config is deleted due to an update or removal of plugin.
-	// You can use this method is you store some resources in the config to be released later.
-	Destroy()
-}
-
 type StreamFilterConfigParser interface {
 	// Parse the proto message to any Go value, and return error to reject the config.
 	// This is called when Envoy receives the config from the control plane.
 	// Also, you can define Metrics through the callbacks, and the callbacks will be nil when parsing the route config.
-	// You can return a config implementing the Config interface if you need fine control over its lifecycle.
 	Parse(any *anypb.Any, callbacks ConfigCallbackHandler) (interface{}, error)
 	// Merge the two configs(filter level config or route level config) into one.
 	// May merge multi-level configurations, i.e. filter level, virtualhost level, router level and weighted cluster level,
 	// into a single one recursively, by invoking this method multiple times.
-	// You can return a config implementing the Config interface if you need fine control over its lifecycle.
 	Merge(parentConfig interface{}, childConfig interface{}) interface{}
+	// Called when the current config is deleted due to an update or removal of plugin.
+	// You can use this method if you store some resources in the config to be released later.
+	Destroy(config interface{})
+}
+
+func (*PassThroughStreamFilterConfigParser) Parse(*anypb.Any, ConfigCallbackHandler) (interface{}, error) {
+	return nil, nil
+}
+
+func (*PassThroughStreamFilterConfigParser) Merge(interface{}, interface{}) interface{} {
+	return nil
+}
+
+func (*PassThroughStreamFilterConfigParser) Destroy(interface{}) {
 }
 
 type StreamFilterFactory func(config interface{}, callbacks FilterCallbackHandler) StreamFilter

--- a/contrib/golang/common/go/api/filter.go
+++ b/contrib/golang/common/go/api/filter.go
@@ -108,6 +108,10 @@ func (*PassThroughStreamFilter) OnDestroy(DestroyReason) {
 func (*PassThroughStreamFilter) OnStreamComplete() {
 }
 
+type Config interface {
+	Destroy()
+}
+
 type StreamFilterConfigParser interface {
 	// Parse the proto message to any Go value, and return error to reject the config.
 	// This is called when Envoy receives the config from the control plane.

--- a/contrib/golang/common/go/api/filter.go
+++ b/contrib/golang/common/go/api/filter.go
@@ -109,6 +109,8 @@ func (*PassThroughStreamFilter) OnStreamComplete() {
 }
 
 type Config interface {
+	// Called when the current config is deleted due to an update or removal of plugin.
+	// You can use this method is you store some resources in the config to be released later.
 	Destroy()
 }
 
@@ -116,10 +118,12 @@ type StreamFilterConfigParser interface {
 	// Parse the proto message to any Go value, and return error to reject the config.
 	// This is called when Envoy receives the config from the control plane.
 	// Also, you can define Metrics through the callbacks, and the callbacks will be nil when parsing the route config.
+	// You can return a config implementing the Config interface if you need fine control over its lifecycle.
 	Parse(any *anypb.Any, callbacks ConfigCallbackHandler) (interface{}, error)
 	// Merge the two configs(filter level config or route level config) into one.
 	// May merge multi-level configurations, i.e. filter level, virtualhost level, router level and weighted cluster level,
 	// into a single one recursively, by invoking this method multiple times.
+	// You can return a config implementing the Config interface if you need fine control over its lifecycle.
 	Merge(parentConfig interface{}, childConfig interface{}) interface{}
 }
 

--- a/contrib/golang/filters/http/source/go/pkg/http/filtermanager.go
+++ b/contrib/golang/filters/http/source/go/pkg/http/filtermanager.go
@@ -45,6 +45,9 @@ func (p *nullParser) Merge(parentConfig interface{}, childConfig interface{}) in
 	return childConfig
 }
 
+func (p *nullParser) Destroy(config interface{}) {
+}
+
 var NullParser api.StreamFilterConfigParser = &nullParser{}
 
 // RegisterHttpFilterFactoryAndConfigParser registers the http filter factory and config parser for the specified plugin.
@@ -61,7 +64,7 @@ func RegisterHttpFilterFactoryAndConfigParser(name string, factory api.StreamFil
 }
 
 func getHttpFilterFactoryAndConfig(name string, configId uint64) (api.StreamFilterFactory, interface{}) {
-	config, ok := configCache.Load(configId)
+	config, ok := loadConfig(configId)
 	if !ok {
 		panic(fmt.Sprintf("config not found, plugin: %s, configId: %d", name, configId))
 	}

--- a/contrib/golang/filters/http/test/BUILD
+++ b/contrib/golang/filters/http/test/BUILD
@@ -19,6 +19,7 @@ envoy_cc_test(
     rbe_pool = "6gig",
     deps = [
         "//contrib/golang/filters/http/source:config",
+        "//contrib/golang/filters/http/test/test_data/destroyconfig:destroyconfig_test_lib",
         "//test/mocks/server:factory_context_mocks",
         "//test/test_common:utility_lib",
     ],

--- a/contrib/golang/filters/http/test/config_test.cc
+++ b/contrib/golang/filters/http/test/config_test.cc
@@ -119,7 +119,7 @@ TEST(GolangFilterConfigTest, GolangFilterDestroyConfig) {
   TestUtility::loadFromYaml(yaml_string, proto_config);
 
   auto dso_lib = Dso::DsoManager<Dso::HttpFilterDsoImpl>::load(
-    proto_config.library_id(), proto_config.library_path(), proto_config.plugin_name());
+      proto_config.library_id(), proto_config.library_path(), proto_config.plugin_name());
   auto config_ = new httpDestroyableConfig();
   config_->plugin_name_ptr = reinterpret_cast<unsigned long long>(DESTROYCONFIG.data());
   config_->plugin_name_len = DESTROYCONFIG.length();

--- a/contrib/golang/filters/http/test/config_test.cc
+++ b/contrib/golang/filters/http/test/config_test.cc
@@ -131,6 +131,7 @@ TEST(GolangFilterConfigTest, GolangFilterDestroyConfig) {
   auto config_id_ = dso_lib->envoyGoFilterNewHttpPluginConfig(config_);
   dso_lib->envoyGoFilterDestroyHttpPluginConfig(config_id_, 0);
   EXPECT_TRUE(config_->destroyed);
+  delete config_;
   cleanup();
 }
 

--- a/contrib/golang/filters/http/test/test_data/BUILD
+++ b/contrib/golang/filters/http/test/test_data/BUILD
@@ -21,6 +21,7 @@ go_binary(
         "//contrib/golang/filters/http/test/test_data/basic",
         "//contrib/golang/filters/http/test/test_data/buffer",
         "//contrib/golang/filters/http/test/test_data/bufferinjectdata",
+        "//contrib/golang/filters/http/test/test_data/destroyconfig",
         "//contrib/golang/filters/http/test/test_data/echo",
         "//contrib/golang/filters/http/test/test_data/metric",
         "//contrib/golang/filters/http/test/test_data/passthrough",

--- a/contrib/golang/filters/http/test/test_data/access_log/config.go
+++ b/contrib/golang/filters/http/test/test_data/access_log/config.go
@@ -17,6 +17,7 @@ type config struct {
 }
 
 type parser struct {
+	api.PassThroughStreamFilterConfigParser
 }
 
 func (p *parser) Parse(any *anypb.Any, callbacks api.ConfigCallbackHandler) (interface{}, error) {

--- a/contrib/golang/filters/http/test/test_data/add_data/config.go
+++ b/contrib/golang/filters/http/test/test_data/add_data/config.go
@@ -17,6 +17,7 @@ type config struct {
 }
 
 type parser struct {
+	api.PassThroughStreamFilterConfigParser
 }
 
 func (p *parser) Parse(any *anypb.Any, callbacks api.ConfigCallbackHandler) (interface{}, error) {

--- a/contrib/golang/filters/http/test/test_data/buffer/config.go
+++ b/contrib/golang/filters/http/test/test_data/buffer/config.go
@@ -17,6 +17,7 @@ type config struct {
 }
 
 type parser struct {
+	api.PassThroughStreamFilterConfigParser
 }
 
 func (p *parser) Parse(any *anypb.Any, callbacks api.ConfigCallbackHandler) (interface{}, error) {

--- a/contrib/golang/filters/http/test/test_data/bufferinjectdata/config.go
+++ b/contrib/golang/filters/http/test/test_data/bufferinjectdata/config.go
@@ -17,6 +17,7 @@ type config struct {
 }
 
 type parser struct {
+	api.PassThroughStreamFilterConfigParser
 }
 
 func (p *parser) Parse(any *anypb.Any, callbacks api.ConfigCallbackHandler) (interface{}, error) {

--- a/contrib/golang/filters/http/test/test_data/destroyconfig/BUILD
+++ b/contrib/golang/filters/http/test/test_data/destroyconfig/BUILD
@@ -1,0 +1,28 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load(
+    "@envoy//bazel:envoy_build_system.bzl",
+    "envoy_cc_test_library",
+)
+licenses(["notice"])  # Apache 2
+
+envoy_cc_test_library(
+    name = "destroyconfig_test_lib",
+    hdrs = ["destroyconfig.h"],
+)
+
+go_library(
+    name = "destroyconfig",
+    srcs = [
+        "config.go",
+        "destroyconfig.h",
+    ],
+    cgo = True,
+    importpath = "example.com/test-data/destroyconfig",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//contrib/golang/common/go/api",
+        "//contrib/golang/filters/http/source/go/pkg/http",
+        "@org_golang_google_protobuf//types/known/anypb",
+        "@org_golang_google_protobuf//types/known/structpb",
+    ],
+)

--- a/contrib/golang/filters/http/test/test_data/destroyconfig/BUILD
+++ b/contrib/golang/filters/http/test/test_data/destroyconfig/BUILD
@@ -8,6 +8,9 @@ licenses(["notice"])  # Apache 2
 envoy_cc_test_library(
     name = "destroyconfig_test_lib",
     hdrs = ["destroyconfig.h"],
+    deps = [
+        "//contrib/golang/common/dso:dso_lib",
+    ],
 )
 
 go_library(

--- a/contrib/golang/filters/http/test/test_data/destroyconfig/BUILD
+++ b/contrib/golang/filters/http/test/test_data/destroyconfig/BUILD
@@ -2,20 +2,27 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_test_library",
+    "envoy_contrib_package",
 )
+
 licenses(["notice"])  # Apache 2
+
+envoy_contrib_package()
 
 envoy_cc_test_library(
     name = "destroyconfig_test_lib",
-    hdrs = ["destroyconfig.h", "api.h"],
+    hdrs = [
+        "api.h",
+        "destroyconfig.h",
+    ],
 )
 
 go_library(
     name = "destroyconfig",
     srcs = [
+        "api.h",
         "config.go",
         "destroyconfig.h",
-        "api.h",
     ],
     cgo = True,
     importpath = "example.com/test-data/destroyconfig",

--- a/contrib/golang/filters/http/test/test_data/destroyconfig/BUILD
+++ b/contrib/golang/filters/http/test/test_data/destroyconfig/BUILD
@@ -1,16 +1,13 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load(
-    "@envoy//bazel:envoy_build_system.bzl",
+    "//bazel:envoy_build_system.bzl",
     "envoy_cc_test_library",
 )
 licenses(["notice"])  # Apache 2
 
 envoy_cc_test_library(
     name = "destroyconfig_test_lib",
-    hdrs = ["destroyconfig.h"],
-    deps = [
-        "//contrib/golang/common/dso:dso_lib",
-    ],
+    hdrs = ["destroyconfig.h", "api.h"],
 )
 
 go_library(
@@ -18,6 +15,7 @@ go_library(
     srcs = [
         "config.go",
         "destroyconfig.h",
+        "api.h",
     ],
     cgo = True,
     importpath = "example.com/test-data/destroyconfig",

--- a/contrib/golang/filters/http/test/test_data/destroyconfig/BUILD
+++ b/contrib/golang/filters/http/test/test_data/destroyconfig/BUILD
@@ -26,6 +26,5 @@ go_library(
         "//contrib/golang/common/go/api",
         "//contrib/golang/filters/http/source/go/pkg/http",
         "@org_golang_google_protobuf//types/known/anypb",
-        "@org_golang_google_protobuf//types/known/structpb",
     ],
 )

--- a/contrib/golang/filters/http/test/test_data/destroyconfig/api.h
+++ b/contrib/golang/filters/http/test/test_data/destroyconfig/api.h
@@ -1,0 +1,1 @@
+../../../../../common/go/api/api.h

--- a/contrib/golang/filters/http/test/test_data/destroyconfig/config.go
+++ b/contrib/golang/filters/http/test/test_data/destroyconfig/config.go
@@ -1,0 +1,61 @@
+package destroyconfig
+
+/*
+// ref https://github.com/golang/go/issues/25832
+
+#cgo CFLAGS: -I../api
+#cgo linux LDFLAGS: -Wl,-unresolved-symbols=ignore-all
+#cgo darwin LDFLAGS: -Wl,-undefined,dynamic_lookup
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "destroyconfig.h"
+
+*/
+import "C"
+import (
+	"google.golang.org/protobuf/types/known/anypb"
+	"unsafe"
+	"github.com/envoyproxy/envoy/contrib/golang/common/go/api"
+	"github.com/envoyproxy/envoy/contrib/golang/filters/http/source/go/pkg/http"
+)
+
+const Name = "destroyconfig"
+
+func init() {
+	http.SetHttpCAPI(&capi{})
+	http.RegisterHttpFilterFactoryAndConfigParser(Name, http.PassThroughFactory, &parser{})
+}
+
+var cfgPointer unsafe.Pointer
+
+type config struct {
+	cb api.ConfigCallbackHandler
+}
+
+func (c *config) Destroy() {
+	// call cApi.HttpDefineMetric to store the config pointer
+	c.cb.DefineCounterMetric("")
+	C.envoyGoConfigDestroy(cfgPointer)
+}
+
+type parser struct {
+	api.StreamFilterConfigParser
+}
+
+type capi struct {
+	api.HttpCAPI
+}
+
+func (c *capi) HttpConfigFinalize(_ unsafe.Pointer) {}
+
+func (c *capi) HttpDefineMetric(cfg unsafe.Pointer, metricType api.MetricType, name string) uint32 {
+	cfgPointer = cfg
+	return 0
+}
+
+func (p *parser) Parse(_ *anypb.Any, cb api.ConfigCallbackHandler) (interface{}, error) {
+	conf := &config{cb}
+	return conf, nil
+}

--- a/contrib/golang/filters/http/test/test_data/destroyconfig/config.go
+++ b/contrib/golang/filters/http/test/test_data/destroyconfig/config.go
@@ -9,10 +9,10 @@ package destroyconfig
 */
 import "C"
 import (
-	"google.golang.org/protobuf/types/known/anypb"
-	"unsafe"
 	"github.com/envoyproxy/envoy/contrib/golang/common/go/api"
 	"github.com/envoyproxy/envoy/contrib/golang/filters/http/source/go/pkg/http"
+	"google.golang.org/protobuf/types/known/anypb"
+	"unsafe"
 )
 
 const Name = "destroyconfig"

--- a/contrib/golang/filters/http/test/test_data/destroyconfig/config.go
+++ b/contrib/golang/filters/http/test/test_data/destroyconfig/config.go
@@ -1,14 +1,8 @@
 package destroyconfig
 
 /*
-// ref https://github.com/golang/go/issues/25832
-
-#cgo CFLAGS: -I../api
 #cgo linux LDFLAGS: -Wl,-unresolved-symbols=ignore-all
 #cgo darwin LDFLAGS: -Wl,-undefined,dynamic_lookup
-
-#include <stdlib.h>
-#include <string.h>
 
 #include "destroyconfig.h"
 
@@ -24,7 +18,6 @@ import (
 const Name = "destroyconfig"
 
 func init() {
-	http.SetHttpCAPI(&capi{})
 	http.RegisterHttpFilterFactoryAndConfigParser(Name, http.PassThroughFactory, &parser{})
 }
 
@@ -40,22 +33,23 @@ func (c *config) Destroy() {
 	C.envoyGoConfigDestroy(cfgPointer)
 }
 
-type parser struct {
-	api.StreamFilterConfigParser
-}
-
 type capi struct {
 	api.HttpCAPI
 }
 
 func (c *capi) HttpConfigFinalize(_ unsafe.Pointer) {}
 
-func (c *capi) HttpDefineMetric(cfg unsafe.Pointer, metricType api.MetricType, name string) uint32 {
+func (c *capi) HttpDefineMetric(cfg unsafe.Pointer, _ api.MetricType, _ string) uint32 {
 	cfgPointer = cfg
 	return 0
 }
 
+type parser struct {
+	api.StreamFilterConfigParser
+}
+
 func (p *parser) Parse(_ *anypb.Any, cb api.ConfigCallbackHandler) (interface{}, error) {
+	http.SetHttpCAPI(&capi{})
 	conf := &config{cb}
 	return conf, nil
 }

--- a/contrib/golang/filters/http/test/test_data/destroyconfig/destroyconfig.h
+++ b/contrib/golang/filters/http/test/test_data/destroyconfig/destroyconfig.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void envoyGoConfigDestroy(void* c);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif

--- a/contrib/golang/filters/http/test/test_data/destroyconfig/destroyconfig.h
+++ b/contrib/golang/filters/http/test/test_data/destroyconfig/destroyconfig.h
@@ -2,6 +2,7 @@
 // NOLINT(namespace-envoy)
 #pragma GCC diagnostic ignored "-Wold-style-cast"
 #include "api.h"
+
 #ifdef __cplusplus
 struct httpDestroyableConfig : httpConfig {
   int destroyed;

--- a/contrib/golang/filters/http/test/test_data/destroyconfig/destroyconfig.h
+++ b/contrib/golang/filters/http/test/test_data/destroyconfig/destroyconfig.h
@@ -1,14 +1,13 @@
 #pragma once
+// NOLINT(namespace-envoy)
 #pragma GCC diagnostic ignored "-Wold-style-cast"
-
+#include "api.h"
 #ifdef __cplusplus
-#include "contrib/golang/common/dso/api.h"
 struct httpDestroyableConfig : httpConfig {
     int destroyed;
 } ;
 extern "C" {
 #else
-#include "contrib/golang/common/go/api/api.h"
 typedef struct {
     httpConfig c;
     int destroyed;

--- a/contrib/golang/filters/http/test/test_data/destroyconfig/destroyconfig.h
+++ b/contrib/golang/filters/http/test/test_data/destroyconfig/destroyconfig.h
@@ -1,12 +1,14 @@
 #pragma once
 #pragma GCC diagnostic ignored "-Wold-style-cast"
-#include "contrib/golang/common/dso/api.h"
+
 #ifdef __cplusplus
+#include "contrib/golang/common/dso/api.h"
 struct httpDestroyableConfig : httpConfig {
     int destroyed;
 } ;
 extern "C" {
 #else
+#include "contrib/golang/common/go/api/api.h"
 typedef struct {
     httpConfig c;
     int destroyed;

--- a/contrib/golang/filters/http/test/test_data/destroyconfig/destroyconfig.h
+++ b/contrib/golang/filters/http/test/test_data/destroyconfig/destroyconfig.h
@@ -4,19 +4,19 @@
 #include "api.h"
 #ifdef __cplusplus
 struct httpDestroyableConfig : httpConfig {
-    int destroyed;
-} ;
+  int destroyed;
+};
 extern "C" {
 #else
 typedef struct {
-    httpConfig c;
-    int destroyed;
+  httpConfig c;
+  int destroyed;
 } httpDestroyableConfig;
 #endif
 
 void envoyGoConfigDestroy(void* c) {
-    httpDestroyableConfig* dc = (httpDestroyableConfig*)(c);
-    dc->destroyed = 1;
+  httpDestroyableConfig* dc = (httpDestroyableConfig*)(c);
+  dc->destroyed = 1;
 };
 
 #ifdef __cplusplus

--- a/contrib/golang/filters/http/test/test_data/destroyconfig/destroyconfig.h
+++ b/contrib/golang/filters/http/test/test_data/destroyconfig/destroyconfig.h
@@ -1,10 +1,22 @@
 #pragma once
-
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#include "contrib/golang/common/dso/api.h"
 #ifdef __cplusplus
+struct httpDestroyableConfig : httpConfig {
+    int destroyed;
+} ;
 extern "C" {
+#else
+typedef struct {
+    httpConfig c;
+    int destroyed;
+} httpDestroyableConfig;
 #endif
 
-void envoyGoConfigDestroy(void* c);
+void envoyGoConfigDestroy(void* c) {
+    httpDestroyableConfig* dc = (httpDestroyableConfig*)(c);
+    dc->destroyed = 1;
+};
 
 #ifdef __cplusplus
 } // extern "C"

--- a/contrib/golang/filters/http/test/test_data/echo/config.go
+++ b/contrib/golang/filters/http/test/test_data/echo/config.go
@@ -20,6 +20,7 @@ type config struct {
 }
 
 type parser struct {
+	api.PassThroughStreamFilterConfigParser
 }
 
 func (p *parser) Parse(any *anypb.Any, callbacks api.ConfigCallbackHandler) (interface{}, error) {

--- a/contrib/golang/filters/http/test/test_data/metric/config.go
+++ b/contrib/golang/filters/http/test/test_data/metric/config.go
@@ -22,6 +22,7 @@ type config struct {
 }
 
 type parser struct {
+	api.PassThroughStreamFilterConfigParser
 }
 
 func (p *parser) Parse(any *anypb.Any, callbacks api.ConfigCallbackHandler) (interface{}, error) {

--- a/contrib/golang/filters/http/test/test_data/plugins.go
+++ b/contrib/golang/filters/http/test/test_data/plugins.go
@@ -7,6 +7,7 @@ import (
 	_ "example.com/test-data/basic"
 	_ "example.com/test-data/buffer"
 	_ "example.com/test-data/bufferinjectdata"
+	_ "example.com/test-data/destroyconfig"
 	_ "example.com/test-data/echo"
 	_ "example.com/test-data/metric"
 	_ "example.com/test-data/passthrough"

--- a/contrib/golang/filters/http/test/test_data/property/config.go
+++ b/contrib/golang/filters/http/test/test_data/property/config.go
@@ -17,6 +17,7 @@ type config struct {
 }
 
 type parser struct {
+	api.PassThroughStreamFilterConfigParser
 }
 
 func (p *parser) Parse(any *anypb.Any, callbacks api.ConfigCallbackHandler) (interface{}, error) {

--- a/contrib/golang/filters/http/test/test_data/routeconfig/config.go
+++ b/contrib/golang/filters/http/test/test_data/routeconfig/config.go
@@ -33,6 +33,7 @@ type config struct {
 }
 
 type parser struct {
+	api.PassThroughStreamFilterConfigParser
 }
 
 func (p *parser) Parse(any *anypb.Any, callbacks api.ConfigCallbackHandler) (interface{}, error) {


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

**Commit Message:** [#38557] golang: add callback method for http plugin config destruction

**Additional Description:**

This enables fine grained control over the lifecycle of golang filter config in sync with C++.
Some use cases store states and resources in the config object that needs to be cleaned when config is deleted or renewed.
The current design breaks the config parser API by introducing a Destroy function in StreamFilterConfigParser. A PassThroughStreamFilterConfigParser is available to help code adaptation.
Given an existing parser
```
import "github.com/envoyproxy/envoy/contrib/golang/common/go/api"

type parser struct {
}

func (p *parser) Parse(any *anypb.Any, callbacks api.ConfigCallbackHandler) (interface{}, error) {
	...
}

func (p *parser) Merge(parent interface{}, child interface{}) interface{} {
	...
}
```
The new one just needs to compose with the passthrough
```
type parser struct {
	api.PassThroughStreamFilterConfigParser
}
```
**Risk Level:** Low

**Testing:** A test in config_test.cc was added to ensure Destroy function is being called on the config instance.

**Docs Changes:** none

**Release Notes:**

added http golang filter config destroy callback. When a config gets deleted from envoy, the go plugin calls the
Destroy function on the config parser instance. This introduces a breaking change in the golang parser interface.

Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
