### PR TITLE
original_dst: add batched host updates

### DIFF
--- a/api/envoy/config/cluster/v3/cluster.proto
+++ b/api/envoy/config/cluster/v3/cluster.proto
@@ -527,6 +527,7 @@ message Cluster {
   // :ref:`Original Destination <arch_overview_load_balancing_types_original_destination>`
   // load balancing policy.
   // [#extension: envoy.clusters.original_dst]
+  // [#next-free-field: 6]
   message OriginalDstLbConfig {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.api.v2.Cluster.OriginalDstLbConfig";
@@ -556,6 +557,13 @@ message Cluster {
     // The dynamic metadata key to override destination address.
     // First the request metadata is considered, then the connection one.
     type.metadata.v3.MetadataKey metadata_key = 4;
+
+    // Enables batching of multiple host updates that are received across callbacks into a
+    // single update at the specified interval. This batching helps prevent performance
+    // bottlenecks caused by frequent cluster updates, especially for large clusters with
+    // frequent new hosts.
+    // If not specified, batching is disabled.
+    google.protobuf.Duration batch_update_interval = 5;
   }
 
   // Common configuration for all load balancer implementations.

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -270,5 +270,11 @@ new_features:
   change: |
     Added an :ref:`io_uring <envoy_v3_api_field_extensions.network.socket_interface.v3.DefaultSocketInterface.io_uring_options>` option in
     default socket interface to support io_uring.
+- area: original_dst
+  change: |
+    Added support for batching host updates in original_dst cluster using
+    :ref:`batch_update_interval <envoy_v3_api_field_config.cluster.v3.Cluster.OriginalDstLbConfig.batch_update_interval>`.
+    This feature helps prevent performance bottlenecks by consolidating multiple host updates into single updates at
+    specified intervals, which is particularly beneficial for large clusters with frequent updates.
 
 deprecated:


### PR DESCRIPTION
Commit Message: Add batched host updates in original_dst cluster

Additional Description: Adds batching support for host updates in original_dst clusters to address performance bottlenecks on the main thread. With high fan-out clients with large numbers of active connections (e.g. 60k) and high unique host-port connection rates (e.g. 3k/s), the current per-connection addHost callbacks create significant pressure on the main thread. Each callback triggers a host map copy and priority set update, which is CPU heavy and impacts critical operations like metrics collection + health checks on the main thread.

The new `batch_update_interval` configuration option allows consolidating these updates into periodic batches, significantly reducing main thread overhead. This has been production-tested for 6+ months with positive results.

Risk Level: Low
Testing: Unit tests
Docs Changes: proto docs
Release Notes: None
Platform Specific Features: None
