### PR TITLE
ci: Only collect logs if the logs dir exist

### DIFF
--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -66,12 +66,15 @@ function bazel_with_collection() {
   declare BAZEL_STATUS="${PIPESTATUS[0]}"
   if [ "${BAZEL_STATUS}" != "0" ]
   then
-    pushd bazel-testlogs
-    failed_logs=$(grep "  /build.*test.log" "${BAZEL_OUTPUT}" | sed -e 's/  \/build.*\/testlogs\/\(.*\)/\1/')
-    while read -r f; do
-      cp --parents -f "$f" "${ENVOY_FAILED_TEST_LOGS}"
-    done <<< "$failed_logs"
-    popd
+    if [ -d bazel-testlogs ]
+    then
+        pushd bazel-testlogs
+        failed_logs=$(grep "  /build.*test.log" "${BAZEL_OUTPUT}" | sed -e 's/  \/build.*\/testlogs\/\(.*\)/\1/')
+        while read -r f; do
+        cp --parents -f "$f" "${ENVOY_FAILED_TEST_LOGS}"
+        done <<< "$failed_logs"
+        popd
+    fi
     exit "${BAZEL_STATUS}"
   fi
   collect_build_profile "$1"


### PR DESCRIPTION
Failures can happen before tests actually execute, in those cases do not attempt to collect anything, otherwise we get this error:

```
./ci/do_ci.sh: line 125: pushd: bazel-testlogs: No such file or directory
```
