### PR TITLE
use PercentEncoding library instead of incomplete ad-hoc mapping

### DIFF
--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -1286,7 +1286,7 @@ bool shouldPercentEncodeChar(char c) { return testCharInTable(kUrlEncodedCharTab
 bool shouldPercentDecodeChar(char c) { return testCharInTable(kUrlDecodedCharTable, c); }
 } // namespace
 
-std::string Utility::PercentEncoding::urlEncodeQueryParameter(absl::string_view value) {
+std::string Utility::PercentEncoding::urlEncode(absl::string_view value) {
   std::string encoded;
   encoded.reserve(value.size());
   for (char ch : value) {

--- a/source/common/http/utility.h
+++ b/source/common/http/utility.h
@@ -149,7 +149,7 @@ public:
    *
    * NOTE: the space character is encoded as %20, NOT as the + character
    */
-  static std::string urlEncodeQueryParameter(absl::string_view value);
+  static std::string urlEncode(absl::string_view value);
 
   /**
    * Exactly the same as above, but returns false when it finds a character that should be %-encoded

--- a/source/common/tls/BUILD
+++ b/source/common/tls/BUILD
@@ -21,6 +21,7 @@ envoy_cc_library(
         ":utility_lib",
         "//source/common/common:assert_lib",
         "//source/common/common:minimal_logger_lib",
+        "//source/common/http:utility_lib",
     ],
 )
 

--- a/source/common/tls/connection_info_impl_base.cc
+++ b/source/common/tls/connection_info_impl_base.cc
@@ -177,7 +177,7 @@ const std::string& ConnectionInfoImplBase::urlEncodedPemEncodedPeerCertificate()
         size_t length;
         RELEASE_ASSERT(BIO_mem_contents(buf.get(), &output, &length) == 1, "");
         absl::string_view pem(reinterpret_cast<const char*>(output), length);
-        return Envoy::Http::Utility::PercentEncoding::urlEncodeQueryParameter(pem);
+        return Envoy::Http::Utility::PercentEncoding::urlEncode(pem);
       });
 }
 
@@ -201,8 +201,7 @@ const std::string& ConnectionInfoImplBase::urlEncodedPemEncodedPeerCertificateCh
           RELEASE_ASSERT(BIO_mem_contents(buf.get(), &output, &length) == 1, "");
 
           absl::string_view pem(reinterpret_cast<const char*>(output), length);
-          absl::StrAppend(&result,
-                          Envoy::Http::Utility::PercentEncoding::urlEncodeQueryParameter(pem));
+          absl::StrAppend(&result, Envoy::Http::Utility::PercentEncoding::urlEncode(pem));
         }
         return result;
       });

--- a/source/common/tls/connection_info_impl_base.cc
+++ b/source/common/tls/connection_info_impl_base.cc
@@ -3,6 +3,7 @@
 #include <openssl/stack.h>
 
 #include "source/common/common/hex.h"
+#include "source/common/http/utility.h"
 
 #include "absl/strings/str_replace.h"
 #include "openssl/err.h"
@@ -176,8 +177,7 @@ const std::string& ConnectionInfoImplBase::urlEncodedPemEncodedPeerCertificate()
         size_t length;
         RELEASE_ASSERT(BIO_mem_contents(buf.get(), &output, &length) == 1, "");
         absl::string_view pem(reinterpret_cast<const char*>(output), length);
-        return absl::StrReplaceAll(
-            pem, {{"\n", "%0A"}, {" ", "%20"}, {"+", "%2B"}, {"/", "%2F"}, {"=", "%3D"}});
+        return Envoy::Http::Utility::PercentEncoding::urlEncodeQueryParameter(pem);
       });
 }
 
@@ -201,10 +201,8 @@ const std::string& ConnectionInfoImplBase::urlEncodedPemEncodedPeerCertificateCh
           RELEASE_ASSERT(BIO_mem_contents(buf.get(), &output, &length) == 1, "");
 
           absl::string_view pem(reinterpret_cast<const char*>(output), length);
-          absl::StrAppend(
-              &result,
-              absl::StrReplaceAll(
-                  pem, {{"\n", "%0A"}, {" ", "%20"}, {"+", "%2B"}, {"/", "%2F"}, {"=", "%3D"}}));
+          absl::StrAppend(&result,
+                          Envoy::Http::Utility::PercentEncoding::urlEncodeQueryParameter(pem));
         }
         return result;
       });

--- a/source/extensions/common/aws/signer_base_impl.cc
+++ b/source/extensions/common/aws/signer_base_impl.cc
@@ -183,9 +183,8 @@ void SignerBaseImpl::createQueryParams(Envoy::Http::Utility::QueryParamsMulti& q
   // These three parameters can contain characters that require URL encoding
   if (session_token.has_value()) {
     // X-Amz-Security-Token
-    query_params.add(
-        SignatureQueryParameterValues::AmzSecurityToken,
-        Envoy::Http::Utility::PercentEncoding::urlEncodeQueryParameter(session_token.value()));
+    query_params.add(SignatureQueryParameterValues::AmzSecurityToken,
+                     Envoy::Http::Utility::PercentEncoding::urlEncode(session_token.value()));
   }
   // X-Amz-Credential
   query_params.add(SignatureQueryParameterValues::AmzCredential,

--- a/source/extensions/filters/http/grpc_json_reverse_transcoder/utils.cc
+++ b/source/extensions/filters/http/grpc_json_reverse_transcoder/utils.cc
@@ -118,7 +118,7 @@ void BuildQueryParamString(const nlohmann::json& object,
       value = object.dump();
     }
     absl::StrAppend(query_string, query_string->empty() ? "" : "&", prefix, "=",
-                    Envoy::Http::Utility::PercentEncoding::urlEncodeQueryParameter(value));
+                    Envoy::Http::Utility::PercentEncoding::urlEncode(value));
     return;
   }
 

--- a/source/extensions/filters/http/oauth2/filter.cc
+++ b/source/extensions/filters/http/oauth2/filter.cc
@@ -102,7 +102,7 @@ authScopesList(const Protobuf::RepeatedPtrField<std::string>& auth_scopes_protos
 std::string encodeResourceList(const Protobuf::RepeatedPtrField<std::string>& resources_protos) {
   std::string result = "";
   for (const auto& resource : resources_protos) {
-    result += "&resource=" + Http::Utility::PercentEncoding::urlEncodeQueryParameter(resource);
+    result += "&resource=" + Http::Utility::PercentEncoding::urlEncode(resource);
   }
   return result;
 }
@@ -161,8 +161,7 @@ Http::Utility::QueryParamsMulti buildAutorizationQueryParams(
   query_params.overwrite("client_id", proto_config.credentials().client_id());
   query_params.overwrite("response_type", "code");
   std::string scopes_list = absl::StrJoin(authScopesList(proto_config.auth_scopes()), " ");
-  query_params.overwrite("scope",
-                         Http::Utility::PercentEncoding::urlEncodeQueryParameter(scopes_list));
+  query_params.overwrite("scope", Http::Utility::PercentEncoding::urlEncode(scopes_list));
   return query_params;
 }
 
@@ -627,8 +626,7 @@ void OAuth2Filter::redirectToOAuthServer(Http::RequestHeaderMap& headers) {
       Formatter::FormatterImpl::create(config_->redirectUri()), Formatter::FormatterPtr);
   const auto redirect_uri =
       formatter->formatWithContext({&headers}, decoder_callbacks_->streamInfo());
-  const std::string escaped_redirect_uri =
-      Http::Utility::PercentEncoding::urlEncodeQueryParameter(redirect_uri);
+  const std::string escaped_redirect_uri = Http::Utility::PercentEncoding::urlEncode(redirect_uri);
   query_params.overwrite(queryParamsRedirectUri, escaped_redirect_uri);
 
   // Copy the authorization endpoint URL to replace its query params.

--- a/test/common/http/utility_test.cc
+++ b/test/common/http/utility_test.cc
@@ -1841,7 +1841,7 @@ TEST(PercentEncoding, DecodingUrlEncodedQueryParameter) {
 }
 
 TEST(PercentEncoding, UrlEncodingQueryParameter) {
-  EXPECT_EQ(Utility::PercentEncoding::urlEncodeQueryParameter(absl::string_view(
+  EXPECT_EQ(Utility::PercentEncoding::urlEncode(absl::string_view(
                 "\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0A\x0B\x0C\x0D\x0E\x0F"
                 "\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1A\x1B\x1C\x1D\x1E\x1F"
                 "\x20\x21\x22\x23\x24\x25\x26\x27\x28\x29\x2A\x2B\x2C\x2D\x2E\x2F"


### PR DESCRIPTION
Commit Message: use PercentEncoding library instead of incomplete ad-hoc mapping
Additional Description:

I'm pretty sure this is a no-op since pem certificates are base-64 encoded. But there's no reason to use absl::StrReplaceAll here with an incomplete, ad-hoc url-encoding character set instead of the optimized, complete percent encoding library function.

AFAICT there is nothing query parameter specific in the implementation of urlEncodeQueryParameter. Query parameters are url-encoded the same way any other data would be url-encoded.

Same as #38749 