### PR TITLE
fix: credential injector init manager

### DIFF
--- a/source/extensions/filters/http/credential_injector/config.cc
+++ b/source/extensions/filters/http/credential_injector/config.cc
@@ -34,7 +34,7 @@ CredentialInjectorFilterFactory::createFilterFactoryFromProtoTyped(
       *config_factory);
   CredentialInjectorSharedPtr credential_injector =
       config_factory->createCredentialInjectorFromProto(
-          *message, stats_prefix + "credential_injector.", context);
+          *message, stats_prefix + "credential_injector.", context, dual_info.init_manager);
 
   FilterConfigSharedPtr config =
       std::make_shared<FilterConfig>(std::move(credential_injector), proto_config.overwrite(),

--- a/source/extensions/http/injected_credentials/common/factory.h
+++ b/source/extensions/http/injected_credentials/common/factory.h
@@ -13,10 +13,9 @@ namespace Common {
 
 class NamedCredentialInjectorConfigFactory : public Config::TypedFactory {
 public:
-  virtual CredentialInjectorSharedPtr
-  createCredentialInjectorFromProto(const Protobuf::Message& config,
-                                    const std::string& stats_prefix,
-                                    Server::Configuration::ServerFactoryContext& context) PURE;
+  virtual CredentialInjectorSharedPtr createCredentialInjectorFromProto(
+      const Protobuf::Message& config, const std::string& stats_prefix,
+      Server::Configuration::ServerFactoryContext& context, Init::Manager& init_manager) PURE;
 
   std::string category() const override { return "envoy.http.injected_credentials"; }
 };

--- a/source/extensions/http/injected_credentials/common/factory_base.h
+++ b/source/extensions/http/injected_credentials/common/factory_base.h
@@ -14,14 +14,13 @@ namespace Common {
 template <class ConfigProto>
 class CredentialInjectorFactoryBase : public NamedCredentialInjectorConfigFactory {
 public:
-  CredentialInjectorSharedPtr
-  createCredentialInjectorFromProto(const Protobuf::Message& proto_config,
-                                    const std::string& stats_prefix,
-                                    Server::Configuration::ServerFactoryContext& context) override {
+  CredentialInjectorSharedPtr createCredentialInjectorFromProto(
+      const Protobuf::Message& proto_config, const std::string& stats_prefix,
+      Server::Configuration::ServerFactoryContext& context, Init::Manager& init_manager) override {
     return createCredentialInjectorFromProtoTyped(
         MessageUtil::downcastAndValidate<const ConfigProto&>(proto_config,
                                                              context.messageValidationVisitor()),
-        stats_prefix, context);
+        stats_prefix, context, init_manager);
   }
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override {
@@ -36,7 +35,8 @@ protected:
 private:
   virtual CredentialInjectorSharedPtr
   createCredentialInjectorFromProtoTyped(const ConfigProto&, const std::string&,
-                                         Server::Configuration::ServerFactoryContext&) PURE;
+                                         Server::Configuration::ServerFactoryContext&,
+                                         Init::Manager& init_manager) PURE;
 
   const std::string name_;
 };

--- a/source/extensions/http/injected_credentials/generic/config.cc
+++ b/source/extensions/http/injected_credentials/generic/config.cc
@@ -28,13 +28,13 @@ secretsProvider(const envoy::extensions::transport_sockets::tls::v3::SdsSecretCo
 Common::CredentialInjectorSharedPtr
 GenericCredentialInjectorFactory::createCredentialInjectorFromProtoTyped(
     const Generic& config, const std::string& /*stats_prefix*/,
-    Server::Configuration::ServerFactoryContext& context) {
+    Server::Configuration::ServerFactoryContext& context, Init::Manager& init_manager) {
   const auto& credential_secret = config.credential();
   auto& cluster_manager = context.clusterManager();
   auto& secret_manager = cluster_manager.clusterManagerFactory().secretManager();
   auto& transport_socket_factory = context.getTransportSocketFactoryContext();
-  auto secret_provider = secretsProvider(credential_secret, secret_manager,
-                                         transport_socket_factory, context.initManager());
+  auto secret_provider =
+      secretsProvider(credential_secret, secret_manager, transport_socket_factory, init_manager);
 
   auto secret_reader = std::make_shared<const Common::SDSSecretReader>(
       std::move(secret_provider), context.threadLocal(), context.api());

--- a/source/extensions/http/injected_credentials/generic/config.h
+++ b/source/extensions/http/injected_credentials/generic/config.h
@@ -22,9 +22,10 @@ public:
       : CredentialInjectorFactoryBase("envoy.http.injected_credentials.generic") {}
 
 private:
-  Common::CredentialInjectorSharedPtr createCredentialInjectorFromProtoTyped(
-      const Generic& config, const std::string& stats_prefix,
-      Server::Configuration::ServerFactoryContext& context) override;
+  Common::CredentialInjectorSharedPtr
+  createCredentialInjectorFromProtoTyped(const Generic& config, const std::string& stats_prefix,
+                                         Server::Configuration::ServerFactoryContext& context,
+                                         Init::Manager& init_manager) override;
 };
 
 DECLARE_FACTORY(GenericCredentialInjectorFactory);

--- a/source/extensions/http/injected_credentials/oauth2/config.cc
+++ b/source/extensions/http/injected_credentials/oauth2/config.cc
@@ -28,12 +28,12 @@ secretsProvider(const envoy::extensions::transport_sockets::tls::v3::SdsSecretCo
 Common::CredentialInjectorSharedPtr
 OAuth2CredentialInjectorFactory::createCredentialInjectorFromProtoTyped(
     const OAuth2& config, const std::string& stats_prefix,
-    Server::Configuration::ServerFactoryContext& context) {
+    Server::Configuration::ServerFactoryContext& context, Init::Manager& init_manager) {
 
   switch (config.flow_type_case()) {
   case envoy::extensions::http::injected_credentials::oauth2::v3::OAuth2::FlowTypeCase::
       kClientCredentials:
-    return createOauth2ClientCredentialInjector(config, stats_prefix, context);
+    return createOauth2ClientCredentialInjector(config, stats_prefix, context, init_manager);
   case envoy::extensions::http::injected_credentials::oauth2::v3::OAuth2::FlowTypeCase::
       FLOW_TYPE_NOT_SET:
     throw EnvoyException("OAuth2 flow type not set");
@@ -44,15 +44,15 @@ OAuth2CredentialInjectorFactory::createCredentialInjectorFromProtoTyped(
 Common::CredentialInjectorSharedPtr
 OAuth2CredentialInjectorFactory::createOauth2ClientCredentialInjector(
     const OAuth2& proto_config, const std::string& stats_prefix,
-    Server::Configuration::ServerFactoryContext& context) {
+    Server::Configuration::ServerFactoryContext& context, Init::Manager& init_manager) {
   auto& cluster_manager = context.clusterManager();
   auto& secret_manager = cluster_manager.clusterManagerFactory().secretManager();
   auto& transport_socket_factory = context.getTransportSocketFactoryContext();
 
   const auto& client_secret_secret = proto_config.client_credentials().client_secret();
 
-  auto client_secret_provider = secretsProvider(client_secret_secret, secret_manager,
-                                                transport_socket_factory, context.initManager());
+  auto client_secret_provider =
+      secretsProvider(client_secret_secret, secret_manager, transport_socket_factory, init_manager);
   if (client_secret_provider == nullptr) {
     throw EnvoyException("Invalid oauth2 client secret configuration");
   }

--- a/source/extensions/http/injected_credentials/oauth2/config.h
+++ b/source/extensions/http/injected_credentials/oauth2/config.h
@@ -22,10 +22,12 @@ public:
       : CredentialInjectorFactoryBase("envoy.http.injected_credentials.oauth2") {}
   Common::CredentialInjectorSharedPtr
   createOauth2ClientCredentialInjector(const OAuth2& proto_config, const std::string& stats_prefix,
-                                       Server::Configuration::ServerFactoryContext& context);
-  Common::CredentialInjectorSharedPtr createCredentialInjectorFromProtoTyped(
-      const OAuth2& config, const std::string& stats_prefix,
-      Server::Configuration::ServerFactoryContext& context) override;
+                                       Server::Configuration::ServerFactoryContext& context,
+                                       Init::Manager& init_manager);
+  Common::CredentialInjectorSharedPtr
+  createCredentialInjectorFromProtoTyped(const OAuth2& config, const std::string& stats_prefix,
+                                         Server::Configuration::ServerFactoryContext& context,
+                                         Init::Manager& init_manager) override;
 };
 
 DECLARE_FACTORY(OAuth2CredentialInjectorFactory);

--- a/test/extensions/http/credential_injector/oauth2/config_test.cc
+++ b/test/extensions/http/credential_injector/oauth2/config_test.cc
@@ -18,9 +18,10 @@ TEST(Config, OAuth2FlowTypeUnset) {
   proto_config.mutable_token_fetch_retry_interval()->set_seconds(1);
   OAuth2CredentialInjectorFactory factory;
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
+  NiceMock<Init::MockManager> init_manager;
 
   EXPECT_THROW_WITH_REGEX(
-      factory.createCredentialInjectorFromProtoTyped(proto_config, "stats", context),
+      factory.createCredentialInjectorFromProtoTyped(proto_config, "stats", context, init_manager),
       EnvoyException, "OAuth2 flow type not set");
 }
 
@@ -42,12 +43,13 @@ TEST(Config, NullClientSecret) {
   NiceMock<Server::Configuration::MockServerFactoryContext> server_factory_context;
   NiceMock<Server::Configuration::MockTransportSocketFactoryContext>
       transport_socket_factory_context;
+  NiceMock<Init::MockManager> init_manager;
   ON_CALL(server_factory_context, getTransportSocketFactoryContext())
       .WillByDefault(ReturnRef(transport_socket_factory_context));
 
-  EXPECT_THROW_WITH_REGEX(
-      factory.createOauth2ClientCredentialInjector(proto_config, "stats", server_factory_context),
-      EnvoyException, "Invalid oauth2 client secret configuration");
+  EXPECT_THROW_WITH_REGEX(factory.createOauth2ClientCredentialInjector(
+                              proto_config, "stats", server_factory_context, init_manager),
+                          EnvoyException, "Invalid oauth2 client secret configuration");
 }
 
 } // namespace OAuth2


### PR DESCRIPTION
fix: https://github.com/envoyproxy/gateway/pull/5496#discussion_r1998304248

We should use the initManager in the DualInfo because the Credential Injector can be used for both HCM filter and upstream filter. Using the initManger from the ServerFactoryContext for HCM filter causes the secret to be added to the server initManager when it's already in the initialized state.

Change log should not be required as this fixes a bug introduced in [a RP](https://github.com/envoyproxy/envoy/pull/38398) that just merged after v1.33.0 .

@yanavlasov 