### PR TITLE
http: minor perf improvement for h1 ignored upgrades

### DIFF
--- a/source/common/http/http1/settings.cc
+++ b/source/common/http/http1/settings.cc
@@ -23,6 +23,7 @@ Http1Settings parseHttp1Settings(const envoy::config::core::v3::Http1ProtocolOpt
 
   if (!config.ignore_http_11_upgrade().empty()) {
     std::vector<Matchers::StringMatcherPtr> matchers;
+    matchers.reserve(config.ignore_http_11_upgrade_size());
     for (const auto& matcher : config.ignore_http_11_upgrade()) {
       matchers.emplace_back(std::make_unique<Envoy::Matchers::StringMatcherImpl>(matcher, context));
     }

--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -672,7 +672,7 @@ void Utility::removeUpgrade(RequestOrResponseHeaderMap& headers,
 }
 
 void Utility::removeConnectionUpgrade(RequestOrResponseHeaderMap& headers,
-                                      StringUtil::CaseUnorderedSet tokens_to_remove) {
+                                      const StringUtil::CaseUnorderedSet& tokens_to_remove) {
   if (headers.Connection()) {
     const std::string new_value =
         StringUtil::removeTokens(headers.getConnectionValue(), ",", tokens_to_remove, ",");

--- a/source/common/http/utility.h
+++ b/source/common/http/utility.h
@@ -327,7 +327,7 @@ void removeUpgrade(RequestOrResponseHeaderMap& headers,
  * set of values. Removes the `Connection` header if it only contains `tokens_to_remove`.
  */
 void removeConnectionUpgrade(RequestOrResponseHeaderMap& headers,
-                             StringUtil::CaseUnorderedSet tokens_to_remove);
+                             const StringUtil::CaseUnorderedSet& tokens_to_remove);
 
 struct EncodeFunctions {
   // Function to modify locally generated response headers.


### PR DESCRIPTION
Commit Message: http: minor perf improvement for h1 ignored upgrades
Additional Description:
Followup to #37642 - minor perf improvements when h/1 ignored upgrades are used.

Risk Level: low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A