### PR TITLE
Shard quic_http_integration_test to reduce flakines under msan

### DIFF
--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -2626,6 +2626,7 @@ envoy_cc_test(
     #   https://github.com/envoyproxy/envoy/pull/13713/files#r512160087
     # Each of these tests exceeds 20s;
     # QuicHttpIntegrationTests/QuicHttpIntegrationTest.MultipleQuicConnections[With|No]BPF*
+    shard_count = 5,
     tags = [
         "cpu:3",
         "fails_on_clang_cl",


### PR DESCRIPTION
Commit Message:

When switching to clang-18 we hit an increased rate of flakines for this test. Looking at the test under perf I could see this entry:

```
60.32%    60.30%  quic_http_integ  quic_http_integration_test  [.]
   __sanitizer::StackDepotBase<__sanitizer::StackDepotNode, 1,
20>::Put(__sanitizer::StackTrace, bool*)
```

So significant time is spent inside the MSAN runtime library. What is StackDepotBase? From what I can see this is a structure used to keep track of stacktraces of places in the program that allocate and write to various memory locations (that's part of the origin tracking feature of the MSAN).

The important part is that underneath StackDepotBase has a fixed size (2^20 entries) chaining hash table. And over time, this hash table gets more and more entries and therefore we get more and more collisions, which slows down the program more and more the longer it runs.

Why is it a problem with clang-18, but not with clang-14 that we currently use?

MSAN coverage in clang-18 is higher (better), so it records more stacktraces. However, even in clang-14 StackDepotNode::Put actually takes a significant amount of resources:

```
18.61%    18.61%  quic_http_integ  quic_http_integration_test  [.]
   __sanitizer::StackDepotBase<__sanitizer::StackDepotNode, 1,
20>::Put(__sanitizer::StackTrace, bool*)
```

There are a few ways we can deal with this particular issue:

1. I can tweak timeouts in the individual tests (that would be just a couple of test cases in quic_http_integration_test) to avoid hitting this issue.
2. We can disable origin tracking, but origin tracking is very useful when debugging MSAN findings, so I would like to keep it.

However, I think we have an even better way to deal with this issue - shard long running tests. Sharding the test to smaller bits to avoid cluttering the MSAN stacktrace hashtable. That addresses the problem on clang-18, but even in clang-14 it will reduce both memory and CPU consumption of long running tests. That's what this change does.

Additional Description:

Related to https://github.com/envoyproxy/envoy/issues/37911 and fixes one of the issues that block clang-18 adoption in Envoy CI (specifically addresses one of the failures in https://github.com/envoyproxy/envoy/pull/38571).

Risk Level: Low
Testing: running the test under clang-14 and clang-18
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a

+cc @phlax 