### PR TITLE
wasm: fix possible crash when resetting context after vm panic

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -130,6 +130,9 @@ bug_fixes:
     Fixes an Envoy crash issue when a local reply is sent.
     This change can be temporarily reverted by setting runtime guard
     ``envoy_reloadable_features_router_filter_resetall_on_local_reply`` to ``false``.
+- area: wasm
+  change: |
+    Fixed a bug where the wasm context deletion may result in a crash when the VM is paniced.
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/source/extensions/common/wasm/context.cc
+++ b/source/extensions/common/wasm/context.cc
@@ -1315,13 +1315,19 @@ WasmResult Context::getMetric(uint32_t metric_id, uint64_t* result_uint64_ptr) {
 Context::~Context() {
   // Cancel any outstanding requests.
   for (auto& p : http_request_) {
-    p.second.request_->cancel();
+    if (p.second.request_ != nullptr) {
+      p.second.request_->cancel();
+    }
   }
   for (auto& p : grpc_call_request_) {
-    p.second.request_->cancel();
+    if (p.second.request_ != nullptr) {
+      p.second.request_->cancel();
+    }
   }
   for (auto& p : grpc_stream_) {
-    p.second.stream_->resetStream();
+    if (p.second.stream_ != nullptr) {
+      p.second.stream_->resetStream();
+    }
   }
 }
 

--- a/source/extensions/common/wasm/context.h
+++ b/source/extensions/common/wasm/context.h
@@ -299,10 +299,12 @@ protected:
     // Http::AsyncClient::Callbacks
     void onSuccess(const Http::AsyncClient::Request&,
                    Envoy::Http::ResponseMessagePtr&& response) override {
+      request_ = nullptr;
       context_->onHttpCallSuccess(token_, std::move(response));
     }
     void onFailure(const Http::AsyncClient::Request&,
                    Http::AsyncClient::FailureReason reason) override {
+      request_ = nullptr;
       context_->onHttpCallFailure(token_, reason);
     }
     void
@@ -320,10 +322,12 @@ protected:
       context_->onGrpcCreateInitialMetadata(token_, initial_metadata);
     }
     void onSuccessRaw(::Envoy::Buffer::InstancePtr&& response, Tracing::Span& /* span */) override {
+      request_ = nullptr;
       context_->onGrpcReceiveWrapper(token_, std::move(response));
     }
     void onFailure(Grpc::Status::GrpcStatus status, const std::string& message,
                    Tracing::Span& /* span */) override {
+      request_ = nullptr;
       context_->onGrpcCloseWrapper(token_, status, message);
     }
 
@@ -350,6 +354,7 @@ protected:
     }
     void onRemoteClose(Grpc::Status::GrpcStatus status, const std::string& message) override {
       remote_closed_ = true;
+      stream_ = nullptr;
       context_->onGrpcCloseWrapper(token_, status, message);
     }
 


### PR DESCRIPTION
Commit Message: wasm: fix possible crash when resetting context after vm panic
Additional Description:

If the wasm plugin send a http call out and panic before the response. Then when the response is arrived, the clean up in the `addAfterVmCallAction` will bypassed. Then, a dirty pending request pointer will be kept in the Context object.

When the Context is destroyed because configuration update or vm reload, the the dangling pointer will crash envoy.

Risk Level: low.
Testing: n/a.
Docs Changes: n/a.
Release Notes: added.
Platform Specific Features: n/a.