### PR TITLE
make UpstreamAddress an InstanceAccessor

### DIFF
--- a/source/common/stream_info/upstream_address.h
+++ b/source/common/stream_info/upstream_address.h
@@ -11,13 +11,13 @@ namespace StreamInfo {
 /*
  * A FilterState object that wraps a network address shared pointer.
  */
-class UpstreamAddress : public FilterState::Object {
+class UpstreamAddress : public Network::Address::InstanceAccessor {
 public:
+  UpstreamAddress(Network::Address::InstanceConstSharedPtr ip)
+      : Network::Address::InstanceAccessor(ip) {}
   static const std::string& key() {
     CONSTRUCT_ON_FIRST_USE(std::string, "envoy.stream.upstream_address");
   }
-
-  Network::Address::InstanceConstSharedPtr address_;
 };
 
 } // namespace StreamInfo

--- a/source/extensions/filters/common/rbac/matchers/upstream_ip_port.cc
+++ b/source/extensions/filters/common/rbac/matchers/upstream_ip_port.cc
@@ -47,7 +47,7 @@ bool UpstreamIpPortMatcher::matches(const Network::Connection&,
   }
 
   if (cidr_) {
-    if (cidr_->isInRange(*address_obj->address_)) {
+    if (cidr_->isInRange(*address_obj->getIp())) {
       ENVOY_LOG(debug, "UpstreamIpPort matcher for cidr range: {} evaluated to: true",
                 cidr_->asString());
 
@@ -59,7 +59,7 @@ bool UpstreamIpPortMatcher::matches(const Network::Connection&,
   }
 
   if (port_) {
-    const auto port = address_obj->address_->ip()->port();
+    const auto port = address_obj->getIp()->ip()->port();
     if (port >= port_->start() && port <= port_->end()) {
       ENVOY_LOG(debug, "UpstreamIpPort matcher for port range: [{}, {}] evaluated to: true",
                 port_->start(), port_->end());

--- a/source/extensions/filters/http/dynamic_forward_proxy/proxy_filter.cc
+++ b/source/extensions/filters/http/dynamic_forward_proxy/proxy_filter.cc
@@ -386,12 +386,9 @@ void ProxyFilter::addHostAddressToFilterState(
   const Envoy::StreamInfo::FilterStateSharedPtr& filter_state =
       decoder_callbacks_->streamInfo().filterState();
 
-  auto address_obj = std::make_unique<StreamInfo::UpstreamAddress>();
-  address_obj->address_ = address;
-
-  filter_state->setData(StreamInfo::UpstreamAddress::key(), std::move(address_obj),
-                        StreamInfo::FilterState::StateType::Mutable,
-                        StreamInfo::FilterState::LifeSpan::Request);
+  filter_state->setData(
+      StreamInfo::UpstreamAddress::key(), std::make_unique<StreamInfo::UpstreamAddress>(address),
+      StreamInfo::FilterState::StateType::Mutable, StreamInfo::FilterState::LifeSpan::Request);
 }
 
 void ProxyFilter::onLoadClusterComplete() {

--- a/source/extensions/filters/network/sni_dynamic_forward_proxy/proxy_filter.cc
+++ b/source/extensions/filters/network/sni_dynamic_forward_proxy/proxy_filter.cc
@@ -136,8 +136,7 @@ void ProxyFilter::addHostAddressToFilterState(
   ENVOY_CONN_LOG(trace, "Adding resolved host {} to filter state", read_callbacks_->connection(),
                  address->asString());
 
-  auto address_obj = std::make_unique<StreamInfo::UpstreamAddress>();
-  address_obj->address_ = address;
+  auto address_obj = std::make_unique<StreamInfo::UpstreamAddress>(address);
 
   read_callbacks_->connection().streamInfo().filterState()->setData(
       StreamInfo::UpstreamAddress::key(), std::move(address_obj),

--- a/test/extensions/filters/http/dynamic_forward_proxy/proxy_filter_test.cc
+++ b/test/extensions/filters/http/dynamic_forward_proxy/proxy_filter_test.cc
@@ -621,9 +621,8 @@ TEST_F(UpstreamResolvedHostFilterStateHelper, UpdateResolvedHostFilterStateMetad
   // Pre-populate the filter state with an address.
   auto& filter_state = callbacks_.streamInfo().filterState();
   const auto pre_address = Network::Utility::parseInternetAddressNoThrow("1.2.3.3", 80);
-  auto address_obj = std::make_unique<StreamInfo::UpstreamAddress>();
-  address_obj->address_ = pre_address;
-  filter_state->setData(StreamInfo::UpstreamAddress::key(), std::move(address_obj),
+  filter_state->setData(StreamInfo::UpstreamAddress::key(),
+                        std::make_unique<StreamInfo::UpstreamAddress>(pre_address),
                         StreamInfo::FilterState::StateType::Mutable,
                         StreamInfo::FilterState::LifeSpan::Request);
 
@@ -664,8 +663,8 @@ TEST_F(UpstreamResolvedHostFilterStateHelper, UpdateResolvedHostFilterStateMetad
           StreamInfo::UpstreamAddress::key());
 
   // Verify the data
-  EXPECT_TRUE(updated_address_obj->address_);
-  EXPECT_EQ(updated_address_obj->address_->asStringView(), host_info->address_->asStringView());
+  EXPECT_TRUE(updated_address_obj->getIp());
+  EXPECT_EQ(updated_address_obj->getIp()->asStringView(), host_info->address_->asStringView());
 
   filter_->onDestroy();
 }

--- a/test/extensions/filters/http/rbac/rbac_filter_test.cc
+++ b/test/extensions/filters/http/rbac/rbac_filter_test.cc
@@ -1168,18 +1168,12 @@ public:
 
   void upstreamIpTestsFilterStateSetup(NiceMock<Http::MockStreamDecoderFilterCallbacks>& callback,
                                        const std::vector<std::string>& upstream_ips) {
-    auto address_obj = std::make_unique<StreamInfo::UpstreamAddress>();
-
-    for (const auto& ip : upstream_ips) {
-      Network::Address::InstanceConstSharedPtr address =
-          Envoy::Network::Utility::parseInternetAddressAndPortNoThrow(ip, false);
-
-      address_obj->address_ = address;
-    }
-
     // Set the filter state data.
     callback.streamInfo().filterState()->setData(
-        StreamInfo::UpstreamAddress::key(), std::move(address_obj),
+        StreamInfo::UpstreamAddress::key(),
+        std::make_unique<StreamInfo::UpstreamAddress>(
+            Envoy::Network::Utility::parseInternetAddressAndPortNoThrow(upstream_ips.back(),
+                                                                        false)),
         StreamInfo::FilterState::StateType::ReadOnly, StreamInfo::FilterState::LifeSpan::Request);
   }
 };

--- a/test/extensions/filters/network/sni_dynamic_forward_proxy/proxy_filter_test.cc
+++ b/test/extensions/filters/network/sni_dynamic_forward_proxy/proxy_filter_test.cc
@@ -345,10 +345,10 @@ public:
 TEST_F(UpstreamResolvedHostFilterStateHelper, UpdateResolvedHostFilterStateMetadata) {
   // Pre-populate the filter state with an address.
   const auto pre_address = Network::Utility::parseInternetAddressNoThrow("1.2.3.3", 443);
-  auto address_obj = std::make_unique<StreamInfo::UpstreamAddress>();
-  address_obj->address_ = pre_address;
   connection_.streamInfo().filterState()->setData(
-      StreamInfo::UpstreamAddress::key(), std::move(address_obj),
+      StreamInfo::UpstreamAddress::key(),
+      std::make_unique<StreamInfo::UpstreamAddress>(
+          Network::Utility::parseInternetAddressNoThrow("1.2.3.3", 443)),
       StreamInfo::FilterState::StateType::Mutable, StreamInfo::FilterState::LifeSpan::Connection);
 
   InSequence s;
@@ -379,8 +379,8 @@ TEST_F(UpstreamResolvedHostFilterStateHelper, UpdateResolvedHostFilterStateMetad
           StreamInfo::UpstreamAddress::key());
 
   // Verify the data
-  EXPECT_TRUE(updated_address_obj->address_);
-  EXPECT_EQ(updated_address_obj->address_->asStringView(), host_info->address_->asStringView());
+  EXPECT_TRUE(updated_address_obj->getIp());
+  EXPECT_EQ(updated_address_obj->getIp()->asStringView(), host_info->address_->asStringView());
 }
 
 // Tests if address set is populated in the filter state when an upstream host is resolved


### PR DESCRIPTION
Commit Message: make UpstreamAddress an InstanceAccessor
Additional Description: this will allow matching on UpstreamAddress with a filter-state IP range matcher It can then be used with `matcher_tree` or within RBAC matching. In a followup PR it will also be possible to simplify the UpstreamIpPortMatcher in RBAC to use a filter state matcher directly.

For us, we can then use it to match on the route depending the the upstream IP set by dynamic_forward_proxy http filter

Risk Level: Low
Testing: Yes
Docs Changes: No
Release Notes: No
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]

