### PR TITLE
build: Preserve the env in `envoy_directory_genrule`

### DIFF
--- a/bazel/envoy_build_system.bzl
+++ b/bazel/envoy_build_system.bzl
@@ -97,6 +97,7 @@ def _envoy_directory_genrule_impl(ctx):
         outputs = [tree],
         command = "mkdir -p " + tree.path + " && " + ctx.expand_location(ctx.attr.cmd),
         env = {"GENRULE_OUTPUT_DIR": tree.path},
+        use_default_shell_env = True,
         toolchain = None,
     )
     return [DefaultInfo(files = depset([tree]))]


### PR DESCRIPTION
The external variables - including those set by `--action_env` were not being preserved within `envoy_directory_genrule` invokations.

Setting `use_default_shell_env` makes it honor existing variables.

Example of running a test:

Before this change:
```
(cd /build/bazel_root/base/execroot/envoy && \
   exec env - \
     GENRULE_OUTPUT_DIR=bazel-out/k8-fastbuild/bin/test/common/router/corpus_from_config_impl.outputs \
   /bin/bash -c 'mkdir -p bazel-out/k8-fastbuild/bin/test/common/router/corpus_from_config_impl.outputs && bazel-out/k8-fastbuild/bin/test/common/router/corpus_from_config_impl_sh bazel-out/k8-fastbuild/bin/test/common/router/config_impl_test_static')
...
```

After this change:
```
(cd /build/bazel_root/base/execroot/envoy && \
  exec env - \
    BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1 \
    BAZEL_LINKLIBS=-l%:libstdc++.a \
    BAZEL_LINKOPTS=-lm \
    CC=clang \
    CXX=clang++ \
    GENRULE_OUTPUT_DIR=bazel-out/k8-fastbuild/bin/test/common/router/corpus_from_config_impl.outputs \
    PATH=/bin:/usr/bin:/usr/local/bin \
  /bin/bash -c 'mkdir -p bazel-out/k8-fastbuild/bin/test/common/router/corpus_from_config_impl.outputs && bazel-out/k8-fastbuild/bin/test/common/router/corpus_from_config_impl_sh bazel-out/k8-fastbuild/bin/test/common/router/config_impl_test_static')
...
```
