### PR TITLE
Workaround coverage issues observed on clang-18 (part 2)

### DIFF
--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -888,6 +888,18 @@ bool RouteEntryImplBase::evaluateTlsContextMatch(const StreamInfo::StreamInfo& s
   return matches;
 }
 
+bool RouteEntryImplBase::isRedirect() const {
+  if (!isDirectResponse()) {
+    return false;
+  }
+  if (redirect_config_ == nullptr) {
+    return false;
+  }
+  return !redirect_config_->host_redirect_.empty() || !redirect_config_->path_redirect_.empty() ||
+         !redirect_config_->prefix_rewrite_redirect_.empty() ||
+         redirect_config_->regex_rewrite_redirect_ != nullptr;
+}
+
 bool RouteEntryImplBase::matchRoute(const Http::RequestHeaderMap& headers,
                                     const StreamInfo::StreamInfo& stream_info,
                                     uint64_t random_value) const {

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -662,17 +662,7 @@ protected:
 public:
   bool isDirectResponse() const { return direct_response_code_.has_value(); }
 
-  bool isRedirect() const {
-    if (!isDirectResponse()) {
-      return false;
-    }
-    if (redirect_config_ == nullptr) {
-      return false;
-    }
-    return !redirect_config_->host_redirect_.empty() || !redirect_config_->path_redirect_.empty() ||
-           !redirect_config_->prefix_rewrite_redirect_.empty() ||
-           redirect_config_->regex_rewrite_redirect_ != nullptr;
-  }
+  bool isRedirect() const;
 
   bool matchRoute(const Http::RequestHeaderMap& headers, const StreamInfo::StreamInfo& stream_info,
                   uint64_t random_value) const;


### PR DESCRIPTION
Commit Message:

I described the problem with coverage and possible solutions to it in https://github.com/envoyproxy/envoy/issues/37911#issuecomment-2659837724.

TL;DR: clang source-based coverage (which is what we currently use) is subtly broken when dynamic linking is involved (which is what we currently do for coverage tests).

The issue shows itself as lack of coverage of some functions defined in a header file (class members, free-standing inline functions or function temapltes), even though there are tests that cover it.

The issue is a result of a bug in LLVM/Clang/coverage tooling (it's debatable where exactly is the bug fix should be): llvm/llvm-project#32849.

The issue symptoms are not very predictable, and can be affected by a bunch of factors starting from the order of linking and ending with optimization level of the compiler.

Migrating to clang-18 changed enough things that we started to see the issue, even though, from all I know the issue is not specific to clang-18 and exists even in the currently used by Envoy CI clang-14.

There are a few ways to work around/fix the issue, that could be considered:

1. Stop using dynamic linking - this will resolve the issue completely for Envoy codebase, but at the cost of potentially introducing other issues (historically Envoy coverage tests didn't use dynamic linking, but we switched to it to deal with some issues)
2. Force Clang to emit code for each function definition it sees even if it does not see it being used, either globally via -femit-all-decls compiler flag or locally, on per function basis, marking functions with used attribute.
3. Move affected functions from the header files to cc files.

NOTE: There is no upstream fix for the issue in Clang/LLVM, so I'm not mentioning it as an option at the moment.

This change moves implementation of RouteEntryImplBase::isRedirect from a header file to a cc file to deal with the coverage issue that affected this function on clang-18.

I've already submitted a very similar PR
(see https://github.com/envoyproxy/envoy/pull/38628), but I overlooked this function, so this is a followup.

Additional Description:

Related to https://github.com/envoyproxy/envoy/issues/37911 and fixes one of the issues that block clang-18 adoption in Envoy CI (specifically addresses one of the failures in https://github.com/envoyproxy/envoy/pull/38571).

Risk Level: low
Testing: running coverage tests with clang-18
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a