### PR TITLE
Make compdb work with native macos

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -219,7 +219,7 @@ build:libc++ --config=clang
 build:libc++ --action_env=CXXFLAGS=-stdlib=libc++
 build:libc++ --action_env=LDFLAGS=-stdlib=libc++
 build:libc++ --action_env=BAZEL_CXXOPTS=-stdlib=libc++
-build:libc++ --action_env=BAZEL_LINKLIBS=-l%:libc++.a:-l%:libc++abi.a
+build:linux-libc++ --action_env=BAZEL_LINKLIBS=-l%:libc++.a:-l%:libc++abi.a
 build:libc++ --action_env=BAZEL_LINKOPTS=-lm:-pthread
 build:libc++ --define force_libcpp=enabled
 build:clang-libc++ --config=libc++

--- a/bazel/foreign_cc/BUILD
+++ b/bazel/foreign_cc/BUILD
@@ -72,6 +72,10 @@ make(
         "MOREFLAGS='-fPIC'",
         "BUILD_SHARED=no",
     ],
+    env = select({
+        "@platforms//os:macos": {"AR": "ar"},
+        "//conditions:default": {},
+    }),
     lib_source = "@com_github_lz4_lz4//:all",
     out_static_libs = [
         "liblz4.a",
@@ -201,9 +205,11 @@ configure_make(
     env = {
         "CXXFLAGS": "-fPIC -DU_CHARSET_IS_UTF8=1 -DU_USING_ICU_NAMESPACE=0 -DUCONFIG_ONLY_HTML_CONVERSION=1 -DUCONFIG_NO_LEGACY_CONVERSION=1 -DUCONFIG_NO_BREAK_ITERATION=1 -DUCONFIG_NO_COLLATION=1 -DUCONFIG_NO_FORMATTING=1 -DUCONFIG_NO_TRANSLITERATION=1 -DUCONFIG_NO_REGULAR_EXPRESSIONS=1",
         "CFLAGS": "-fPIC",
-        "LIBS": "-l:libstdc++.a",
         "ICU_DATA_FILTER_FILE": "$(execpath //bazel/foreign_cc:icu_data_filter.json)",
-    },
+    } | select({
+        "@platforms//os:macos": {"AR": "ar"},
+        "//conditions:default": {"LIBS": "-l:libstdc++.a"},
+    }),
     lib_source = "@com_github_unicode_org_icu//:all",
     out_static_libs = [
         "libicuuc.a",
@@ -443,6 +449,10 @@ envoy_cmake(
         # Reference: https://github.com/zlib-ng/zlib-ng#advanced-build-options.
         "UNALIGNED_OK": "off",
     },
+    env = select({
+        "@platforms//os:macos": {"CFLAGS": "-Wno-implicit-function-declaration"},
+        "//conditions:default": {},
+    }),
     lib_source = select({
         "//bazel:zlib_ng": "@com_github_zlib_ng_zlib_ng//:all",
         "//conditions:default": "@net_zlib//:all",

--- a/contrib/hyperscan/matching/input_matchers/source/BUILD
+++ b/contrib/hyperscan/matching/input_matchers/source/BUILD
@@ -93,8 +93,8 @@ envoy_cc_contrib_extension(
     srcs = ["config.cc"],
     hdrs = ["config.h"],
     defines = select({
-        "//bazel:linux_x86_64": [],
-        "//bazel:linux_aarch64": [],
+        "@platforms//cpu:x86_64": [],
+        "@platforms//cpu:aarch64": [],
         "//conditions:default": [
             "HYPERSCAN_DISABLED=1",
         ],
@@ -106,10 +106,10 @@ envoy_cc_contrib_extension(
         "//source/common/protobuf:utility_lib",
         "@envoy_api//contrib/envoy/extensions/matching/input_matchers/hyperscan/v3alpha:pkg_cc_proto",
     ] + select({
-        "//bazel:linux_x86_64": [
+        "@platforms//cpu:x86_64": [
             ":hyperscan_matcher_lib",
         ],
-        "//bazel:linux_aarch64": [
+        "@platforms//cpu:aarch64": [
             ":vectorscan_matcher_lib",
         ],
         "//conditions:default": [

--- a/contrib/hyperscan/matching/input_matchers/test/BUILD
+++ b/contrib/hyperscan/matching/input_matchers/test/BUILD
@@ -28,10 +28,10 @@ envoy_cc_test(
         "//test/mocks/thread_local:thread_local_mocks",
         "//test/test_common:utility_lib",
     ] + select({
-        "//bazel:linux_x86_64": [
+        "@platforms//cpu:x86_64": [
             "//contrib/hyperscan/matching/input_matchers/source:hyperscan_matcher_lib",
         ],
-        "//bazel:linux_aarch64": [
+        "@platforms//cpu:aarch64": [
             "//contrib/hyperscan/matching/input_matchers/source:vectorscan_matcher_lib",
         ],
     }),
@@ -46,10 +46,10 @@ envoy_cc_benchmark_binary(
         "@com_github_google_benchmark//:benchmark",
         "@com_googlesource_code_re2//:re2",
     ] + select({
-        "//bazel:linux_x86_64": [
+        "@platforms//cpu:x86_64": [
             "//contrib/hyperscan/matching/input_matchers/source:hyperscan",
         ],
-        "//bazel:linux_aarch64": [
+        "@platforms//cpu:aarch64": [
             "//contrib/hyperscan/matching/input_matchers/source:vectorscan",
         ],
     }),
@@ -66,10 +66,10 @@ envoy_cc_benchmark_binary(
         "//test/mocks/event:event_mocks",
         "@com_github_google_benchmark//:benchmark",
     ] + select({
-        "//bazel:linux_x86_64": [
+        "@platforms//cpu:x86_64": [
             "//contrib/hyperscan/matching/input_matchers/source:hyperscan_matcher_lib",
         ],
-        "//bazel:linux_aarch64": [
+        "@platforms//cpu:aarch64": [
             "//contrib/hyperscan/matching/input_matchers/source:vectorscan_matcher_lib",
         ],
     }),

--- a/contrib/hyperscan/regex_engines/source/BUILD
+++ b/contrib/hyperscan/regex_engines/source/BUILD
@@ -16,10 +16,10 @@ envoy_cc_library(
     deps = [
         "//envoy/common:regex_interface",
     ] + select({
-        "//bazel:linux_x86_64": [
+        "@platforms//cpu:x86_64": [
             "//contrib/hyperscan/matching/input_matchers/source:hyperscan_matcher_lib",
         ],
-        "//bazel:linux_aarch64": [
+        "@platforms//cpu:aarch64": [
             "//contrib/hyperscan/matching/input_matchers/source:vectorscan_matcher_lib",
         ],
     }),
@@ -30,8 +30,8 @@ envoy_cc_contrib_extension(
     srcs = ["config.cc"],
     hdrs = ["config.h"],
     defines = select({
-        "//bazel:linux_x86_64": [],
-        "//bazel:linux_aarch64": [],
+        "@platforms//cpu:x86_64": [],
+        "@platforms//cpu:aarch64": [],
         "//conditions:default": [
             "HYPERSCAN_DISABLED=1",
         ],
@@ -40,10 +40,10 @@ envoy_cc_contrib_extension(
         "//envoy/common:regex_interface",
         "@envoy_api//contrib/envoy/extensions/regex_engines/hyperscan/v3alpha:pkg_cc_proto",
     ] + select({
-        "//bazel:linux_x86_64": [
+        "@platforms//cpu:x86_64": [
             ":regex_lib",
         ],
-        "//bazel:linux_aarch64": [
+        "@platforms//cpu:aarch64": [
             ":regex_lib",
         ],
         "//conditions:default": [

--- a/contrib/vcl/source/BUILD
+++ b/contrib/vcl/source/BUILD
@@ -74,6 +74,7 @@ envoy_cmake(
         "cpu:16",
         "skip_on_windows",
     ],
+    target_compatible_with = ["@platforms//os:linux"],
     targets = [
         "vppcom",
     ],


### PR DESCRIPTION
This makes the full envoy buildable on macOS (compdb, debug, opt, format check/fix...).

I opened this as a draft if anyone is interested of merging it. It does not solve the problem that new changes can break the macOS build. This is a best effort.