### PR TITLE
[mobile]Expose proxy setting API to C++ engine

### DIFF
--- a/mobile/library/cc/engine.cc
+++ b/mobile/library/cc/engine.cc
@@ -1,5 +1,6 @@
 #include "engine.h"
 
+#include "absl/strings/string_view.h"
 #include "library/common/internal_engine.h"
 #include "library/common/types/c_types.h"
 
@@ -35,6 +36,10 @@ void Engine::onDefaultNetworkChanged(int network) { engine_->onDefaultNetworkCha
 void Engine::onDefaultNetworkUnavailable() { engine_->onDefaultNetworkUnavailable(); }
 
 void Engine::onDefaultNetworkAvailable() { engine_->onDefaultNetworkAvailable(); }
+
+envoy_status_t Engine::setProxySettings(absl::string_view host, const uint16_t port) {
+  return engine_->setProxySettings(host, port);
+}
 
 } // namespace Platform
 } // namespace Envoy

--- a/mobile/library/cc/engine.h
+++ b/mobile/library/cc/engine.h
@@ -2,6 +2,7 @@
 
 #include <functional>
 
+#include "absl/strings/string_view.h"
 #include "library/cc/stream_client.h"
 #include "library/common/types/c_types.h"
 
@@ -25,6 +26,7 @@ public:
   void onDefaultNetworkChanged(int network);
   void onDefaultNetworkUnavailable();
   void onDefaultNetworkAvailable();
+  envoy_status_t setProxySettings(absl::string_view host, const uint16_t port);
 
   envoy_status_t terminate();
   Envoy::InternalEngine* engine() { return engine_; }

--- a/mobile/library/common/internal_engine.cc
+++ b/mobile/library/common/internal_engine.cc
@@ -9,6 +9,7 @@
 #include "source/common/network/io_socket_handle_impl.h"
 #include "source/common/runtime/runtime_features.h"
 
+#include "absl/strings/string_view.h"
 #include "absl/synchronization/notification.h"
 #include "library/common/mobile_process_wide.h"
 #include "library/common/network/proxy_api.h"
@@ -321,7 +322,7 @@ InternalEngine::~InternalEngine() {
   }
 }
 
-envoy_status_t InternalEngine::setProxySettings(const char* hostname, const uint16_t port) {
+envoy_status_t InternalEngine::setProxySettings(absl::string_view hostname, const uint16_t port) {
   return dispatcher_->post([&, host = std::string(hostname), port]() -> void {
     connectivity_manager_->setProxySettings(Network::ProxySettings::parseHostAndPort(host, port));
   });

--- a/mobile/library/common/internal_engine.h
+++ b/mobile/library/common/internal_engine.h
@@ -8,6 +8,7 @@
 #include "source/common/common/posix/thread_impl.h"
 #include "source/common/common/thread.h"
 
+#include "absl/strings/string_view.h"
 #include "absl/synchronization/notification.h"
 #include "absl/types/optional.h"
 #include "extension_registry.h"
@@ -111,7 +112,7 @@ public:
 
   // These functions are wrappers around networkConnectivityManager functions, which hand off
   // to networkConnectivityManager after doing a dispatcher post (thread context switch)
-  envoy_status_t setProxySettings(const char* host, const uint16_t port);
+  envoy_status_t setProxySettings(absl::string_view host, const uint16_t port);
   envoy_status_t resetConnectivityState();
 
   /**

--- a/mobile/library/common/network/proxy_settings.cc
+++ b/mobile/library/common/network/proxy_settings.cc
@@ -8,8 +8,8 @@ namespace Envoy {
 namespace Network {
 
 ProxySettings::ProxySettings(absl::string_view host, const uint16_t port)
-    : address_(Envoy::Network::Utility::parseInternetAddressNoThrow(host, port)), hostname_(host),
-      port_(port) {}
+    : hostname_(host), port_(port),
+      address_(Envoy::Network::Utility::parseInternetAddressNoThrow(hostname_, port_)) {}
 
 /*static*/
 ProxySettingsConstSharedPtr ProxySettings::parseHostAndPort(absl::string_view host,

--- a/mobile/library/common/network/proxy_settings.cc
+++ b/mobile/library/common/network/proxy_settings.cc
@@ -2,15 +2,17 @@
 
 #include <memory>
 
+#include "absl/strings/string_view.h"
+
 namespace Envoy {
 namespace Network {
 
-ProxySettings::ProxySettings(const std::string& host, const uint16_t port)
+ProxySettings::ProxySettings(absl::string_view host, const uint16_t port)
     : address_(Envoy::Network::Utility::parseInternetAddressNoThrow(host, port)), hostname_(host),
       port_(port) {}
 
 /*static*/
-ProxySettingsConstSharedPtr ProxySettings::parseHostAndPort(const std::string& host,
+ProxySettingsConstSharedPtr ProxySettings::parseHostAndPort(absl::string_view host,
                                                             const uint16_t port) {
   if (host == "" && port == 0) {
     return nullptr;

--- a/mobile/library/common/network/proxy_settings.h
+++ b/mobile/library/common/network/proxy_settings.h
@@ -6,6 +6,7 @@
 
 #include "source/common/network/utility.h"
 
+#include "absl/strings/string_view.h"
 #include "absl/types/optional.h"
 
 namespace Envoy {
@@ -36,7 +37,7 @@ public:
    *             (i.e., Android) allow users to specify proxy using either one of these.
    * @param port The proxy port.
    */
-  ProxySettings(const std::string& host, const uint16_t port);
+  ProxySettings(absl::string_view host, const uint16_t port);
 
   /**
    * Parses given host and domain and creates proxy settings. Returns nullptr for an empty host
@@ -49,7 +50,7 @@ public:
    * @return The created proxy settings, nullptr if the passed host is an empty string and
    *         port is equal to 0.
    */
-  static ProxySettingsConstSharedPtr parseHostAndPort(const std::string& host, const uint16_t port);
+  static ProxySettingsConstSharedPtr parseHostAndPort(absl::string_view host, const uint16_t port);
 
   /**
    * Creates a ProxySettings instance to represent a direct connection (i.e. no proxy at all).

--- a/mobile/library/common/network/proxy_settings.h
+++ b/mobile/library/common/network/proxy_settings.h
@@ -122,9 +122,9 @@ public:
   bool operator!=(ProxySettings const& rhs) const;
 
 private:
-  Envoy::Network::Address::InstanceConstSharedPtr address_;
   std::string hostname_;
   uint16_t port_;
+  Envoy::Network::Address::InstanceConstSharedPtr address_;
 };
 
 /**


### PR DESCRIPTION
Commit Message: Expose proxy setting API to C++ engine
Additional Description: Also updated string arguments to use the modern absl::string_view
Risk Level: low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: mobile only
