### PR TITLE
Fix ext_proc documentation for FULL_DUPLEX_STREAMED support

### DIFF
--- a/api/envoy/service/ext_proc/v3/external_processor.proto
+++ b/api/envoy/service/ext_proc/v3/external_processor.proto
@@ -154,10 +154,10 @@ message ProcessingRequest {
 }
 
 // This represents the different types of messages the server may send back to Envoy
-// if the ``observability_mode`` field in the received ProcessingRequest is set to false.
+// when the ``observability_mode`` field in the received ProcessingRequest is set to false.
 //
-// * If the corresponding body :ref:`processing_mode
-//   <envoy_v3_api_field_extensions.filters.http.ext_proc.v3.ProcessingMode>`
+// * If the corresponding ``BodySendMode`` in the
+//   :ref:`processing_mode <envoy_v3_api_field_extensions.filters.http.ext_proc.v3.ExternalProcessor.processing_mode>`
 //   is not set to ``FULL_DUPLEX_STREAMED``, then for every received ProcessingRequest,
 //   the server must send back exactly one ProcessingResponse message.
 // * If it is set to ``FULL_DUPLEX_STREAMED``, the server must follow the API defined

--- a/api/envoy/service/ext_proc/v3/external_processor.proto
+++ b/api/envoy/service/ext_proc/v3/external_processor.proto
@@ -31,9 +31,10 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // 2. The service sends back a ProcessingResponse message that directs Envoy
 //    to either stop processing, continue without it, or send it the
 //    next chunk of the message body.
-// 3. If so requested, Envoy sends the server chunks of the message body,
-//    or the entire body at once. In either case, the server sends back
-//    a ProcessingResponse after each message it receives.
+// 3. If so requested, Envoy sends the server the message body in chunks,
+//    or the entire body at once. In either case, the server may send back
+//    a ProcessingResponse for each message it receives, or wait for certain amount
+//    of body chunks received before streams back the ProcessingResponse messages.
 // 4. If so requested, Envoy sends the server the HTTP trailers,
 //    and the server sends back a ProcessingResponse.
 // 5. At this point, request processing is done, and we pick up again
@@ -152,8 +153,15 @@ message ProcessingRequest {
   ProtocolConfiguration protocol_config = 11;
 }
 
-// For every ProcessingRequest received by the server with the ``observability_mode`` field
-// set to false, the server must send back exactly one ProcessingResponse message.
+// This represents the different types of messages the server may send back to Envoy
+// if the ``observability_mode`` field in the received ProcessingRequest is set to false.
+//
+// * If the corresponding body :ref:`processing_mode
+//   <envoy_v3_api_field_extensions.filters.http.ext_proc.v3.ProcessingMode>`
+//   is not set to ``FULL_DUPLEX_STREAMED``, then for every received ProcessingRequest,
+//   the server must send back exactly one ProcessingResponse message.
+// * If it is set to ``FULL_DUPLEX_STREAMED``, the server must follow the API defined
+//   for this mode to send the ProcessingResponse messages.
 // [#next-free-field: 11]
 message ProcessingResponse {
   // The response type that is sent by the server.


### PR DESCRIPTION
This PR is to fix some stale ext_proc documentation issue.

There are some ext_proc documentation are only appropriate for 1x1 mode. With the MxN support added in https://github.com/envoyproxy/envoy/pull/34942, those docs need to be fixed.
