### PR TITLE
socket: Add network namespace parameter to SocketAddress proto

### DIFF
--- a/api/envoy/config/core/v3/address.proto
+++ b/api/envoy/config/core/v3/address.proto
@@ -50,7 +50,7 @@ message EnvoyInternalAddress {
   string endpoint_id = 2;
 }
 
-// [#next-free-field: 7]
+// [#next-free-field: 8]
 message SocketAddress {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.core.SocketAddress";
 
@@ -97,6 +97,11 @@ message SocketAddress {
   // allow both IPv4 and IPv6 connections, with peer IPv4 addresses mapped into
   // IPv6 space as ``::FFFF:<IPv4-address>``.
   bool ipv4_compat = 6;
+
+  // The Linux network namespace to bind the socket to. If this is set, Envoy will
+  // create the socket in the specified network namespace. Only supported on Linux.
+  // [#not-implemented-hide:]
+  string network_namespace_filepath = 7;
 }
 
 message TcpKeepalive {

--- a/test/common/upstream/health_checker_impl_test.cc
+++ b/test/common/upstream/health_checker_impl_test.cc
@@ -6547,47 +6547,54 @@ TEST(HealthCheckEventLoggerImplTest, All) {
   std::unique_ptr<HealthCheckEventLoggerImpl> event_logger =
       *HealthCheckEventLoggerImpl::create(health_check_config, context);
 
-  EXPECT_CALL(*file, write(absl::string_view{
-                         "{\"health_checker_type\":\"HTTP\",\"host\":{\"socket_address\":{"
-                         "\"protocol\":\"TCP\",\"address\":\"10.0.0.1\",\"port_value\":443,"
-                         "\"resolver_name\":\"\",\"ipv4_compat\":false}},"
-                         "\"cluster_name\":\"fake_cluster\","
-                         "\"eject_unhealthy_event\":{\"failure_type\":\"ACTIVE\"},"
-                         "\"timestamp\":\"2009-02-13T23:31:31.234Z\","
-                         "\"metadata\":{\"filter_metadata\":{},\"typed_filter_metadata\":{}},"
-                         "\"locality\":{\"region\":\"\",\"zone\":\"\",\"sub_zone\":\"\"}}\n"}));
+  EXPECT_CALL(
+      *file,
+      write(absl::string_view{
+          "{\"health_checker_type\":\"HTTP\",\"host\":{\"socket_address\":{"
+          "\"protocol\":\"TCP\",\"address\":\"10.0.0.1\",\"port_value\":443,"
+          "\"resolver_name\":\"\",\"ipv4_compat\":false,\"network_namespace_filepath\":\"\"}},"
+          "\"cluster_name\":\"fake_cluster\","
+          "\"eject_unhealthy_event\":{\"failure_type\":\"ACTIVE\"},"
+          "\"timestamp\":\"2009-02-13T23:31:31.234Z\","
+          "\"metadata\":{\"filter_metadata\":{},\"typed_filter_metadata\":{}},"
+          "\"locality\":{\"region\":\"\",\"zone\":\"\",\"sub_zone\":\"\"}}\n"}));
   event_logger->logEjectUnhealthy(envoy::data::core::v3::HTTP, host, envoy::data::core::v3::ACTIVE);
 
-  EXPECT_CALL(*file, write(absl::string_view{
-                         "{\"health_checker_type\":\"HTTP\",\"host\":{\"socket_address\":{"
-                         "\"protocol\":\"TCP\",\"address\":\"10.0.0.1\",\"port_value\":443,"
-                         "\"resolver_name\":\"\","
-                         "\"ipv4_compat\":false}},\"cluster_name\":\"fake_"
-                         "cluster\",\"add_healthy_event\":{\"first_check\":false},"
-                         "\"timestamp\":\"2009-02-13T23:31:31.234Z\","
-                         "\"metadata\":"
-                         "{\"filter_metadata\":{},\"typed_filter_metadata\":{}},\"locality\":"
-                         "{\"region\":\"\",\"zone\":\"\",\"sub_zone\":\"\"}}\n"}));
+  EXPECT_CALL(
+      *file,
+      write(absl::string_view{
+          "{\"health_checker_type\":\"HTTP\",\"host\":{\"socket_address\":{"
+          "\"protocol\":\"TCP\",\"address\":\"10.0.0.1\",\"port_value\":443,"
+          "\"resolver_name\":\"\","
+          "\"ipv4_compat\":false,\"network_namespace_filepath\":\"\"}},\"cluster_name\":\"fake_"
+          "cluster\",\"add_healthy_event\":{\"first_check\":false},"
+          "\"timestamp\":\"2009-02-13T23:31:31.234Z\","
+          "\"metadata\":"
+          "{\"filter_metadata\":{},\"typed_filter_metadata\":{}},\"locality\":"
+          "{\"region\":\"\",\"zone\":\"\",\"sub_zone\":\"\"}}\n"}));
   event_logger->logAddHealthy(envoy::data::core::v3::HTTP, host, false);
 
-  EXPECT_CALL(*file, write(absl::string_view{
-                         "{\"health_checker_type\":\"HTTP\",\"host\":{\"socket_address\":{"
-                         "\"protocol\":\"TCP\",\"address\":\"10.0.0.1\",\"port_value\":443,"
-                         "\"resolver_name\":\"\","
-                         "\"ipv4_compat\":false}},\"cluster_name\":\"fake_"
-                         "cluster\","
-                         "\"timestamp\":\"2009-02-13T23:31:31.234Z\","
-                         "\"metadata\":"
-                         "{\"filter_metadata\":{},\"typed_filter_metadata\":{}},\"locality\":"
-                         "{\"region\":\"\",\"zone\":\"\",\"sub_zone\":\"\"},"
-                         "\"successful_health_check_event\":{}}\n"}));
+  EXPECT_CALL(
+      *file,
+      write(absl::string_view{
+          "{\"health_checker_type\":\"HTTP\",\"host\":{\"socket_address\":{"
+          "\"protocol\":\"TCP\",\"address\":\"10.0.0.1\",\"port_value\":443,"
+          "\"resolver_name\":\"\","
+          "\"ipv4_compat\":false,\"network_namespace_filepath\":\"\"}},\"cluster_name\":\"fake_"
+          "cluster\","
+          "\"timestamp\":\"2009-02-13T23:31:31.234Z\","
+          "\"metadata\":"
+          "{\"filter_metadata\":{},\"typed_filter_metadata\":{}},\"locality\":"
+          "{\"region\":\"\",\"zone\":\"\",\"sub_zone\":\"\"},"
+          "\"successful_health_check_event\":{}}\n"}));
   event_logger->logSuccessfulHealthCheck(envoy::data::core::v3::HTTP, host);
 
   EXPECT_CALL(*file, write(absl::string_view{
                          "{\"health_checker_type\":\"HTTP\",\"host\":{\"socket_address\":{"
                          "\"protocol\":\"TCP\",\"address\":\"10.0.0.1\",\"port_value\":443,"
                          "\"resolver_name\":\"\","
-                         "\"ipv4_compat\":false}},\"cluster_name\":\"fake_cluster\","
+                         "\"ipv4_compat\":false,\"network_namespace_filepath\":\"\"}},\"cluster_"
+                         "name\":\"fake_cluster\","
                          "\"timestamp\":\"2009-02-13T23:31:31.234Z\","
                          "\"health_check_failure_event\":{\"failure_type\":\"ACTIVE\","
                          "\"first_check\":false},"
@@ -6600,7 +6607,8 @@ TEST(HealthCheckEventLoggerImplTest, All) {
                          "{\"health_checker_type\":\"HTTP\",\"host\":{\"socket_address\":{"
                          "\"protocol\":\"TCP\",\"address\":\"10.0.0.1\",\"port_value\":443,"
                          "\"resolver_name\":\"\","
-                         "\"ipv4_compat\":false}},\"cluster_name\":\"fake_cluster\","
+                         "\"ipv4_compat\":false,\"network_namespace_filepath\":\"\"}},\"cluster_"
+                         "name\":\"fake_cluster\","
                          "\"timestamp\":\"2009-02-13T23:31:31.234Z\","
                          "\"degraded_healthy_host\":{},"
                          "\"metadata\":{\"filter_metadata\":{},\"typed_filter_metadata\":{}},"
@@ -6611,7 +6619,8 @@ TEST(HealthCheckEventLoggerImplTest, All) {
                          "{\"health_checker_type\":\"HTTP\",\"host\":{\"socket_address\":{"
                          "\"protocol\":\"TCP\",\"address\":\"10.0.0.1\",\"port_value\":443,"
                          "\"resolver_name\":\"\","
-                         "\"ipv4_compat\":false}},\"cluster_name\":\"fake_cluster\","
+                         "\"ipv4_compat\":false,\"network_namespace_filepath\":\"\"}},\"cluster_"
+                         "name\":\"fake_cluster\","
                          "\"timestamp\":\"2009-02-13T23:31:31.234Z\","
                          "\"no_longer_degraded_host\":{},"
                          "\"metadata\":{\"filter_metadata\":{},\"typed_filter_metadata\":{}},"
@@ -6653,7 +6662,8 @@ TEST(HealthCheckEventLoggerImplTest, OneEventLogger) {
       file_log_data.value(),
       "{\"health_checker_type\":\"HTTP\",\"host\":{\"socket_address\":{"
       "\"protocol\":\"TCP\",\"address\":\"10.0.0.1\",\"port_value\":443,\"resolver_name\":\"\","
-      "\"ipv4_compat\":false}},\"cluster_name\":\"fake_cluster\","
+      "\"ipv4_compat\":false,\"network_namespace_filepath\":\"\"}},\"cluster_name\":\"fake_"
+      "cluster\","
       "\"eject_unhealthy_event\":{\"failure_type\":\"ACTIVE\"},"
       "\"timestamp\":\"2009-02-13T23:31:31.234Z\","
       "\"metadata\":{\"filter_metadata\":{},\"typed_filter_metadata\":{}},"
@@ -6664,7 +6674,7 @@ TEST(HealthCheckEventLoggerImplTest, OneEventLogger) {
       file_log_data.value(),
       "{\"health_checker_type\":\"HTTP\",\"host\":{\"socket_address\":{"
       "\"protocol\":\"TCP\",\"address\":\"10.0.0.1\",\"port_value\":443,\"resolver_name\":\"\","
-      "\"ipv4_compat\":false}},\"cluster_name\":\"fake_"
+      "\"ipv4_compat\":false,\"network_namespace_filepath\":\"\"}},\"cluster_name\":\"fake_"
       "cluster\",\"add_healthy_event\":{\"first_check\":false},"
       "\"timestamp\":\"2009-02-13T23:31:31.234Z\","
       "\"metadata\":"
@@ -6676,7 +6686,7 @@ TEST(HealthCheckEventLoggerImplTest, OneEventLogger) {
       file_log_data.value(),
       "{\"health_checker_type\":\"HTTP\",\"host\":{\"socket_address\":{"
       "\"protocol\":\"TCP\",\"address\":\"10.0.0.1\",\"port_value\":443,\"resolver_name\":\"\","
-      "\"ipv4_compat\":false}},\"cluster_name\":\"fake_"
+      "\"ipv4_compat\":false,\"network_namespace_filepath\":\"\"}},\"cluster_name\":\"fake_"
       "cluster\",\"timestamp\":\"2009-02-13T23:31:31.234Z\","
       "\"metadata\":"
       "{\"filter_metadata\":{},\"typed_filter_metadata\":{}},\"locality\":"
@@ -6688,7 +6698,8 @@ TEST(HealthCheckEventLoggerImplTest, OneEventLogger) {
       file_log_data.value(),
       "{\"health_checker_type\":\"HTTP\",\"host\":{\"socket_address\":{"
       "\"protocol\":\"TCP\",\"address\":\"10.0.0.1\",\"port_value\":443,\"resolver_name\":\"\","
-      "\"ipv4_compat\":false}},\"cluster_name\":\"fake_cluster\","
+      "\"ipv4_compat\":false,\"network_namespace_filepath\":\"\"}},\"cluster_name\":\"fake_"
+      "cluster\","
       "\"timestamp\":\"2009-02-13T23:31:31.234Z\","
       "\"health_check_failure_event\":{\"failure_type\":\"ACTIVE\","
       "\"first_check\":false},"
@@ -6700,7 +6711,8 @@ TEST(HealthCheckEventLoggerImplTest, OneEventLogger) {
       file_log_data.value(),
       "{\"health_checker_type\":\"HTTP\",\"host\":{\"socket_address\":{"
       "\"protocol\":\"TCP\",\"address\":\"10.0.0.1\",\"port_value\":443,\"resolver_name\":\"\","
-      "\"ipv4_compat\":false}},\"cluster_name\":\"fake_cluster\","
+      "\"ipv4_compat\":false,\"network_namespace_filepath\":\"\"}},\"cluster_name\":\"fake_"
+      "cluster\","
       "\"timestamp\":\"2009-02-13T23:31:31.234Z\","
       "\"degraded_healthy_host\":{},"
       "\"metadata\":{\"filter_metadata\":{},\"typed_filter_metadata\":{}},"
@@ -6711,7 +6723,8 @@ TEST(HealthCheckEventLoggerImplTest, OneEventLogger) {
       file_log_data.value(),
       "{\"health_checker_type\":\"HTTP\",\"host\":{\"socket_address\":{"
       "\"protocol\":\"TCP\",\"address\":\"10.0.0.1\",\"port_value\":443,\"resolver_name\":\"\","
-      "\"ipv4_compat\":false}},\"cluster_name\":\"fake_cluster\","
+      "\"ipv4_compat\":false,\"network_namespace_filepath\":\"\"}},\"cluster_name\":\"fake_"
+      "cluster\","
       "\"timestamp\":\"2009-02-13T23:31:31.234Z\","
       "\"no_longer_degraded_host\":{},"
       "\"metadata\":{\"filter_metadata\":{},\"typed_filter_metadata\":{}},"

--- a/test/extensions/health_check/event_sinks/file/file_sink_impl_test.cc
+++ b/test/extensions/health_check/event_sinks/file/file_sink_impl_test.cc
@@ -75,7 +75,7 @@ TEST(HealthCheckEventFileSink, logTest) {
       file_log_data.value(),
       "{\"health_checker_type\":\"HTTP\",\"host\":{\"socket_address\":{"
       "\"protocol\":\"TCP\",\"address\":\"10.0.0.1\",\"port_value\":443,\"resolver_name\":\"\","
-      "\"ipv4_compat\":false}},\"cluster_name\":\"fake_"
+      "\"ipv4_compat\":false,\"network_namespace_filepath\":\"\"}},\"cluster_name\":\"fake_"
       "cluster\",\"eject_unhealthy_event\":{\"failure_type\":\"ACTIVE\"},"
       "\"timestamp\":\"2009-02-13T23:31:31.234Z\"}\n");
 
@@ -101,7 +101,7 @@ TEST(HealthCheckEventFileSink, logTest) {
       file_log_data.value(),
       "{\"health_checker_type\":\"HTTP\",\"host\":{\"socket_address\":{"
       "\"protocol\":\"TCP\",\"address\":\"10.0.0.1\",\"port_value\":443,\"resolver_name\":\"\","
-      "\"ipv4_compat\":false}},\"cluster_name\":\"fake_"
+      "\"ipv4_compat\":false,\"network_namespace_filepath\":\"\"}},\"cluster_name\":\"fake_"
       "cluster\",\"add_healthy_event\":{\"first_check\":false},\"timestamp\":"
       "\"2009-02-13T23:31:31.234Z\"}\n");
 }


### PR DESCRIPTION
Extends SocketAddress to allow us to specify the network namespace of the socket. This is an API-only change and it is hidden, since there is no implementation.

Addresses https://github.com/envoyproxy/envoy/issues/38947