### PR TITLE
api: removes 'wip' from dynamic_modules

### DIFF
--- a/api/envoy/extensions/dynamic_modules/v3/BUILD
+++ b/api/envoy/extensions/dynamic_modules/v3/BUILD
@@ -5,8 +5,5 @@ load("@envoy_api//bazel:api_build_system.bzl", "api_proto_package")
 licenses(["notice"])  # Apache 2
 
 api_proto_package(
-    deps = [
-        "@com_github_cncf_xds//udpa/annotations:pkg",
-        "@com_github_cncf_xds//xds/annotations/v3:pkg",
-    ],
+    deps = ["@com_github_cncf_xds//udpa/annotations:pkg"],
 )

--- a/api/envoy/extensions/dynamic_modules/v3/dynamic_modules.proto
+++ b/api/envoy/extensions/dynamic_modules/v3/dynamic_modules.proto
@@ -29,8 +29,6 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // this restriction and hopefully provide a wider compatibility guarantee. Until then, Envoy
 // checks the hash of the ABI header files to ensure that the dynamic modules are built against the
 // same version of the ABI.
-//
-// Currently, the implementation is work in progress and not usable.
 message DynamicModuleConfig {
   // The name of the dynamic module. The client is expected to have some configuration indicating where to search for the module.
   // In Envoy, the search path can only be configured via the environment variable ``ENVOY_DYNAMIC_MODULES_SEARCH_PATH``.

--- a/api/envoy/extensions/dynamic_modules/v3/dynamic_modules.proto
+++ b/api/envoy/extensions/dynamic_modules/v3/dynamic_modules.proto
@@ -12,7 +12,6 @@ option java_outer_classname = "DynamicModulesProto";
 option java_multiple_files = true;
 option go_package = "github.com/envoyproxy/go-control-plane/envoy/extensions/dynamic_modules/v3;dynamic_modulesv3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
-option (xds.annotations.v3.file_status).work_in_progress = true;
 
 // [#protodoc-title: Dynamic Modules common configuration]
 

--- a/api/envoy/extensions/dynamic_modules/v3/dynamic_modules.proto
+++ b/api/envoy/extensions/dynamic_modules/v3/dynamic_modules.proto
@@ -2,8 +2,6 @@ syntax = "proto3";
 
 package envoy.extensions.dynamic_modules.v3;
 
-import "xds/annotations/v3/status.proto";
-
 import "udpa/annotations/status.proto";
 import "validate/validate.proto";
 

--- a/api/envoy/extensions/filters/http/dynamic_modules/v3/BUILD
+++ b/api/envoy/extensions/filters/http/dynamic_modules/v3/BUILD
@@ -8,6 +8,5 @@ api_proto_package(
     deps = [
         "//envoy/extensions/dynamic_modules/v3:pkg",
         "@com_github_cncf_xds//udpa/annotations:pkg",
-        "@com_github_cncf_xds//xds/annotations/v3:pkg",
     ],
 )

--- a/api/envoy/extensions/filters/http/dynamic_modules/v3/dynamic_modules.proto
+++ b/api/envoy/extensions/filters/http/dynamic_modules/v3/dynamic_modules.proto
@@ -22,8 +22,6 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 //
 // A module can be loaded by multiple HTTP filters, hence the program can be structured in a way that
 // the module is loaded only once and shared across multiple filters providing multiple functionalities.
-//
-// Currently, the implementation is work in progress and not usable.
 message DynamicModuleFilter {
   // Specifies the shared-object level configuration.
   envoy.extensions.dynamic_modules.v3.DynamicModuleConfig dynamic_module_config = 1;

--- a/api/envoy/extensions/filters/http/dynamic_modules/v3/dynamic_modules.proto
+++ b/api/envoy/extensions/filters/http/dynamic_modules/v3/dynamic_modules.proto
@@ -15,7 +15,6 @@ option java_outer_classname = "DynamicModulesProto";
 option java_multiple_files = true;
 option go_package = "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/dynamic_modules/v3;dynamic_modulesv3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
-option (xds.annotations.v3.file_status).work_in_progress = true;
 
 // [#protodoc-title: HTTP filter for dynamic modules]
 // [#extension: envoy.filters.http.dynamic_modules]

--- a/api/envoy/extensions/filters/http/dynamic_modules/v3/dynamic_modules.proto
+++ b/api/envoy/extensions/filters/http/dynamic_modules/v3/dynamic_modules.proto
@@ -6,8 +6,6 @@ import "envoy/extensions/dynamic_modules/v3/dynamic_modules.proto";
 
 import "google/protobuf/any.proto";
 
-import "xds/annotations/v3/status.proto";
-
 import "udpa/annotations/status.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.filters.http.dynamic_modules.v3";


### PR DESCRIPTION
Commit Message: api: removes 'wip' from dynamic_modules
Additional Description:

The dynamic modules API was introduced 6 months ago in #36448 and at the time we didn't have either an implementation or confidence on the configuration API, so it has been marked WIP just in case. 

Now that the initial implementation is done, and the documentation as well as the example repository is hosted at envoyproxy/dynamic-modules-examples, early adopters have already tried it out and we haven't heard any concern about the configuration API, so this commit removes the WIP marker towards the next release of Envoy v1.34.

Note that the extension itself is still in alpha, it follows the same caveat like any other alpha extensions.

Risk Level: low
Testing: existing tests.
Docs Changes: Already done in the past commits
Release Notes: Already done in the past commits
Platform Specific Features: n/a
