### PR TITLE
Mark `envoy.extensions.load_balancing_policies.client_side_weighted_round_robin.v3.ClientSideWeightedRoundRobin` as `alpha`

### DIFF
--- a/source/extensions/extensions_metadata.yaml
+++ b/source/extensions/extensions_metadata.yaml
@@ -1717,7 +1717,7 @@ envoy.load_balancing_policies.client_side_weighted_round_robin:
   categories:
   - envoy.load_balancing_policies
   security_posture: unknown
-  status: wip
+  status: alpha
   type_urls:
   - envoy.extensions.load_balancing_policies.client_side_weighted_round_robin.v3.ClientSideWeightedRoundRobin
 envoy.http.early_header_mutation.header_mutation:


### PR DESCRIPTION
Commit Message: Mark `ClientSideWeightedRoundRobin` LB policy as `alpha`.

Risk Level: Low
Release Notes: Mark `ClientSideWeightedRoundRobin` LB policy as `alpha`.

#34777