### PR TITLE
oauth2: remove OAUTH_NONCE build trail dead code

### DIFF
--- a/source/extensions/filters/http/oauth2/filter.cc
+++ b/source/extensions/filters/http/oauth2/filter.cc
@@ -994,9 +994,6 @@ std::string OAuth2Filter::BuildCookieTail(int cookie_type) const {
     same_site = getSameSiteString(config_->refreshTokenCookieSettings().same_site_);
     expires_time = expires_refresh_token_in_;
     break;
-  case 6: // OAUTH_NONCE TYPE
-    same_site = getSameSiteString(config_->refreshTokenCookieSettings().same_site_);
-    break;
   }
 
   std::string cookie_tail = fmt::format(CookieTailHttpOnlyFormatString, expires_time, same_site);


### PR DESCRIPTION
 it is clear that it is a dead&wrong code, and the oauth_nonce is only used in `redirectToOAuthServer`

Commit Message:
Additional Description:
Risk Level: low
Fixes:#38799
Testing:
Docs Changes:
Release Notes:
