### PR TITLE
quic: re-enable QUICHE for FIPS build and all the related tests

### DIFF
--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -298,7 +298,6 @@ selects.config_setting_group(
     name = "disable_http3",
     match_any = [
         ":disable_http3_setting",
-        ":boringssl_fips",
     ],
 )
 

--- a/bazel/external/quiche.BUILD
+++ b/bazel/external/quiche.BUILD
@@ -1511,7 +1511,6 @@ envoy_cc_library(
 envoy_cc_library(
     name = "quic_platform",
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quic_core_time_lib",
@@ -1526,7 +1525,6 @@ envoy_cc_library(
         "quiche/quic/platform/api/quic_hostname_utils.h",
     ],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_platform_hostname_utils",
@@ -1539,7 +1537,6 @@ envoy_cc_library(
         "quiche/quic/platform/api/quic_stack_trace.h",
     ],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_platform_stack_trace",
@@ -1552,7 +1549,6 @@ envoy_cc_library(
         "quiche/quic/platform/api/quic_server_stats.h",
     ],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_platform_server_stats",
@@ -1594,7 +1590,6 @@ envoy_cc_library(
         "quiche/quic/platform/api/quic_bug_tracker.h",
     ],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_platform_bug_tracker",
@@ -1605,7 +1600,6 @@ envoy_cc_library(
     name = "quic_platform_export",
     hdrs = ["quiche/quic/platform/api/quic_export.h"],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_platform_export",
@@ -1616,7 +1610,6 @@ envoy_cc_test_library(
     name = "quic_platform_expect_bug",
     hdrs = ["quiche/quic/platform/api/quic_expect_bug.h"],
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [":quiche_common_platform_expect_bug"],
 )
 
@@ -1624,7 +1617,6 @@ envoy_cc_library(
     name = "quic_platform_ip_address_family",
     hdrs = ["quiche/quic/platform/api/quic_ip_address_family.h"],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quic_platform_bug_tracker",
@@ -1637,7 +1629,6 @@ envoy_cc_library(
     srcs = ["quiche/common/quiche_ip_address_family.cc"],
     hdrs = ["quiche/common/quiche_ip_address_family.h"],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quic_platform_bug_tracker",
@@ -1663,7 +1654,6 @@ envoy_cc_library(
     hdrs = ["quiche/common/quiche_ip_address.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quic_platform_base",
@@ -1679,7 +1669,6 @@ envoy_cc_library(
         "//conditions:default": [],
     }),
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [":quiche_common_platform_udp_socket_platform"],
 )
 
@@ -1713,7 +1702,6 @@ envoy_cc_test_library(
     name = "quic_platform_test",
     hdrs = ["quiche/quic/platform/api/quic_test.h"],
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quic_platform_base",
         ":quiche_common_platform_test",
@@ -1725,7 +1713,6 @@ envoy_cc_test_library(
     name = "quic_platform_test_output",
     hdrs = ["quiche/quic/platform/api/quic_test_output.h"],
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [":quiche_common_platform_test_output"],
 )
 
@@ -1733,7 +1720,6 @@ envoy_cc_test_library(
     name = "quic_platform_thread",
     hdrs = ["quiche/quic/platform/api/quic_thread.h"],
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [":quiche_common_platform_thread"],
 )
 
@@ -1752,7 +1738,6 @@ envoy_cc_library(
     name = "quic_core_proto_cached_network_parameters_proto_header",
     hdrs = ["quiche/quic/core/proto/cached_network_parameters_proto.h"],
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [":quic_core_proto_cached_network_parameters_proto_cc"],
 )
 
@@ -1771,7 +1756,6 @@ envoy_cc_library(
     name = "quic_core_proto_source_address_token_proto_header",
     hdrs = ["quiche/quic/core/proto/source_address_token_proto.h"],
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [":quic_core_proto_source_address_token_proto_cc"],
 )
 
@@ -1789,7 +1773,6 @@ envoy_cc_library(
     name = "quic_core_proto_crypto_server_config_proto_header",
     hdrs = ["quiche/quic/core/proto/crypto_server_config_proto.h"],
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [":quic_core_proto_crypto_server_config_proto_cc"],
 )
 
@@ -1799,7 +1782,6 @@ envoy_cc_library(
     hdrs = ["quiche/quic/core/quic_ack_listener_interface.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quic_core_time_lib",
@@ -1834,7 +1816,6 @@ envoy_cc_library(
     hdrs = ["quiche/quic/core/quic_bandwidth.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quic_core_constants_lib",
@@ -1860,7 +1841,6 @@ envoy_cc_library(
     }),
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quic_core_linux_socket_utils_lib",
@@ -1886,7 +1866,6 @@ envoy_cc_library(
     }),
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quic_core_batch_writer_batch_writer_buffer_lib",
@@ -1906,7 +1885,6 @@ envoy_cc_test_library(
     }),
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quic_core_batch_writer_batch_writer_base_lib",
         ":quic_core_udp_socket_lib",
@@ -1930,7 +1908,6 @@ envoy_cc_library(
     }),
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":flow_label_lib",
@@ -1956,7 +1933,6 @@ envoy_cc_library(
     }),
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quic_core_batch_writer_batch_writer_base_lib",
@@ -1967,7 +1943,6 @@ envoy_cc_library(
 envoy_quic_cc_library(
     name = "quic_core_blocked_writer_interface_lib",
     hdrs = ["quiche/quic/core/quic_blocked_writer_interface.h"],
-    tags = ["nofips"],
     deps = [":quic_platform_export"],
 )
 
@@ -1988,7 +1963,6 @@ envoy_cc_test(
     srcs = ["quiche/quic/core/quic_blocked_writer_list_test.cc"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quic_core_blocked_writer_interface_lib",
         ":quic_core_blocked_writer_list_lib",
@@ -2413,7 +2387,6 @@ envoy_cc_library(
     hdrs = ["quiche/quic/core/quic_constants.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quic_core_types_lib",
@@ -2432,7 +2405,6 @@ envoy_cc_library(
     copts = quiche_copts,
     external_deps = ["ssl"],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_platform_logging",
@@ -2699,7 +2671,6 @@ envoy_cc_library(
     copts = quiche_copts,
     external_deps = ["ssl"],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [":quiche_common_random_lib"],
 )
@@ -2762,7 +2733,6 @@ envoy_cc_library(
         "quiche/common/simple_buffer_allocator.h",
     ],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_platform_export",
@@ -2776,7 +2746,6 @@ envoy_cc_library(
     hdrs = ["quiche/common/quiche_circular_deque.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quiche_common_platform",
         ":quiche_common_platform_export",
@@ -2790,7 +2759,6 @@ envoy_cc_library(
     copts = quiche_copts,
     external_deps = ["ssl"],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [":quiche_common_platform_logging"],
 )
@@ -2800,7 +2768,6 @@ envoy_cc_library(
     hdrs = ["quiche/common/quiche_status_utils.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/status",
@@ -2813,7 +2780,6 @@ envoy_cc_library(
     hdrs = ["quiche/common/wire_serialization.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quiche_common_buffer_allocator_lib",
         ":quiche_common_lib",
@@ -2828,7 +2794,6 @@ envoy_cc_library(
     hdrs = ["quiche/common/quiche_callbacks.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_platform_export",
@@ -2863,7 +2828,6 @@ envoy_cc_library(
     copts = quiche_copts,
     external_deps = ["ssl"],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quic_platform_base",
@@ -2876,7 +2840,6 @@ envoy_cc_library(
     hdrs = ["quiche/common/quiche_feature_flags_list.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
 )
 
@@ -2885,7 +2848,6 @@ envoy_cc_library(
     hdrs = ["quiche/common/quiche_protocol_flags_list.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
 )
 
@@ -2979,7 +2941,6 @@ envoy_cc_library(
         "//conditions:default": [],
     }),
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quic_core_constants_lib",
@@ -3283,7 +3244,6 @@ envoy_cc_library(
     hdrs = ["quiche/quic/core/quic_interval.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quic_platform_export",
@@ -3306,7 +3266,6 @@ envoy_cc_library(
     hdrs = ["quiche/quic/core/quic_interval_set.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quic_core_interval_lib",
@@ -3324,7 +3283,6 @@ envoy_cc_library(
     }),
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     deps = select({
         "@envoy//bazel:windows_x86_64": [],
         "@envoy//bazel:disable_http3": [],
@@ -3350,7 +3308,6 @@ envoy_cc_library(
     ],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quic_core_types_lib",
@@ -3387,7 +3344,6 @@ envoy_cc_library(
     }),
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     deps = select({
         "@envoy//bazel:windows_x86_64": [],
         "@envoy//bazel:disable_http3": [],
@@ -3447,7 +3403,6 @@ envoy_cc_library(
     }),
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quic_platform_export",
     ],
@@ -3465,7 +3420,6 @@ envoy_cc_library(
     }),
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quic_core_packet_writer_lib",
         ":quic_core_syscall_wrapper_lib",
@@ -3529,7 +3483,6 @@ envoy_cc_library(
     ],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quic_core_packets_lib",
@@ -3550,7 +3503,6 @@ envoy_cc_library(
     ],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":http2_core_priority_write_scheduler_lib",
@@ -3963,7 +3915,6 @@ envoy_cc_library(
     copts = quiche_copts,
     external_deps = ["ssl"],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quic_core_types_lib",
@@ -4155,7 +4106,6 @@ envoy_cc_library(
     hdrs = ["quiche/quic/core/quic_tag.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quic_platform_base",
@@ -4168,7 +4118,6 @@ envoy_cc_library(
     srcs = ["quiche/quic/core/quic_time.cc"],
     hdrs = ["quiche/quic/core/quic_time.h"],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [":quic_platform_base"],
 )
@@ -4224,7 +4173,6 @@ envoy_cc_library(
     copts = quiche_copts,
     external_deps = ["ssl"],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quic_core_crypto_random_lib",
@@ -4273,7 +4221,6 @@ envoy_cc_library(
         "//conditions:default": [],
     }),
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":flow_label_lib",
         ":quic_core_io_socket_lib",
@@ -4305,7 +4252,6 @@ envoy_cc_library(
     hdrs = ["quiche/quic/core/quic_utils.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quic_core_constants_lib",
@@ -4337,7 +4283,6 @@ envoy_cc_library(
     hdrs = ["quiche/quic/core/quic_versions.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quic_core_crypto_random_lib",
@@ -4644,7 +4589,6 @@ envoy_cc_library(
     name = "quiche_common_endian_lib",
     hdrs = ["quiche/common/quiche_endian.h"],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps =
         [
@@ -4658,7 +4602,6 @@ envoy_cc_library(
         "quiche/common/platform/api/quiche_client_stats.h",
     ],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [":quiche_common_platform_default_quiche_platform_impl_client_stats_impl_lib"],
 )
@@ -4676,7 +4619,6 @@ envoy_cc_test_library(
         "quiche/common/platform/api/quiche_system_event_loop.h",
     ],
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [":quiche_common_platform_default_quiche_platform_impl_system_event_loop_impl_lib"],
 )
 
@@ -4691,7 +4633,6 @@ envoy_cc_library(
     name = "quiche_common_platform_googleurl",
     hdrs = ["quiche/common/platform/api/quiche_googleurl.h"],
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [":quiche_common_platform_default_quiche_platform_impl_googleurl_impl_lib"],
 )
 
@@ -4700,7 +4641,6 @@ envoy_cc_library(
     srcs = ["quiche/common/platform/api/quiche_mem_slice.cc"],
     hdrs = ["quiche/common/platform/api/quiche_mem_slice.h"],
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quiche_common_buffer_allocator_lib",
         ":quiche_common_callbacks",
@@ -4725,7 +4665,6 @@ envoy_cc_library(
         "quiche/common/platform/api/quiche_iovec.h",
     ],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_platform_bug_tracker",
@@ -4740,7 +4679,6 @@ envoy_cc_library(
         "quiche/common/platform/api/quiche_bug_tracker.h",
     ],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_platform_export",
@@ -4761,7 +4699,6 @@ envoy_cc_library(
         "quiche/common/platform/api/quiche_logging.h",
     ],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_platform_export",
@@ -4801,7 +4738,6 @@ envoy_cc_library(
         "quiche/common/platform/api/quiche_hostname_utils.h",
     ],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_platform_export",
@@ -4816,7 +4752,6 @@ envoy_cc_test_library(
         "quiche/common/platform/api/quiche_thread.h",
     ],
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quiche_common_platform_export",
         "@envoy//test/common/quic/platform:quiche_thread_impl_lib",
@@ -4829,7 +4764,6 @@ envoy_cc_test_library(
         "quiche/common/platform/api/quiche_test_output.h",
     ],
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quiche_common_platform_export",
         "@envoy//test/common/quic/platform:quiche_test_output_impl_lib",
@@ -4842,7 +4776,6 @@ envoy_cc_test_library(
         "quiche/common/platform/api/quiche_expect_bug.h",
     ],
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quiche_common_platform_export",
         "@envoy//test/common/quic/platform:quiche_expect_bug_impl_lib",
@@ -4856,7 +4789,6 @@ envoy_cc_library(
         "//conditions:default": [],
     }),
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quic_core_types_lib",
@@ -4870,7 +4802,6 @@ envoy_cc_library(
     name = "quiche_common_platform_server_stats",
     hdrs = ["quiche/common/platform/api/quiche_server_stats.h"],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_platform_default_quiche_platform_impl_server_stats_impl_lib",
@@ -4890,7 +4821,6 @@ envoy_cc_library(
         "quiche/common/platform/api/quiche_stack_trace.h",
     ],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_platform_export",
@@ -4904,7 +4834,6 @@ envoy_cc_library(
         "quiche/common/platform/api/quiche_containers.h",
     ],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_platform_default_quiche_platform_impl_containers_impl_lib",
@@ -4938,7 +4867,6 @@ envoy_cc_library(
         "quiche/common/platform/api/quiche_testvalue.h",
     ],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_platform_export",
@@ -4956,7 +4884,6 @@ envoy_cc_library(
         "quiche/common/platform/api/quiche_time_utils.h",
     ],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_platform_bug_tracker",
@@ -5029,7 +4956,6 @@ envoy_cc_library(
         "quiche/common/platform/api/quiche_export.h",
     ],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         "@envoy//source/common/quic/platform:quiche_export_impl_lib",
@@ -5040,7 +4966,6 @@ envoy_cc_test_library(
     name = "quiche_common_platform_test",
     hdrs = ["quiche/common/platform/api/quiche_test.h"],
     repository = "@envoy",
-    tags = ["nofips"],
     deps = ["@envoy//test/common/quic/platform:quiche_test_impl_lib"],
 )
 
@@ -5049,7 +4974,6 @@ envoy_cc_test(
     srcs = ["quiche/common/platform/api/quiche_mem_slice_test.cc"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quiche_common_buffer_allocator_lib",
         ":quiche_common_platform",
@@ -5063,7 +4987,6 @@ envoy_cc_test(
     srcs = ["quiche/common/platform/api/quiche_time_utils_test.cc"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quiche_common_platform",
         ":quiche_common_platform_test",
@@ -5074,7 +4997,6 @@ envoy_cc_library(
     name = "quiche_common_print_elements_lib",
     hdrs = ["quiche/common/print_elements.h"],
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quiche_common_platform_export",
         "@com_google_absl//absl/container:inlined_vector",
@@ -5088,7 +5010,6 @@ envoy_cc_test_library(
         "quiche/common/test_tools/quiche_test_utils.h",
     ],
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quiche_common_platform",
         ":quiche_common_platform_googleurl",
@@ -5104,7 +5025,6 @@ envoy_cc_library(
     srcs = ["quiche/common/quiche_text_utils.cc"],
     hdrs = ["quiche/common/quiche_text_utils.h"],
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quiche_common_platform_export",
         "@com_google_absl//absl/hash",
@@ -5124,7 +5044,6 @@ envoy_cc_library(
         "quiche/common/quiche_linked_hash_map.h",
     ],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_endian_lib",
@@ -5137,7 +5056,6 @@ envoy_cc_library(
     srcs = ["quiche/common/quiche_simple_arena.cc"],
     hdrs = ["quiche/common/quiche_simple_arena.h"],
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quiche_common_platform_export",
         ":quiche_common_platform_logging",
@@ -5149,7 +5067,6 @@ envoy_cc_library(
     srcs = ["quiche/common/http/http_header_storage.cc"],
     hdrs = ["quiche/common/http/http_header_storage.h"],
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quiche_common_platform_export",
         ":quiche_common_platform_logging",
@@ -5162,7 +5079,6 @@ envoy_cc_library(
     srcs = ["quiche/common/http/http_header_block.cc"],
     hdrs = ["quiche/common/http/http_header_block.h"],
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quiche_common_lib",
         ":quiche_common_platform_export",
@@ -5176,7 +5092,6 @@ envoy_cc_test(
     name = "quiche_http_header_block_test",
     srcs = ["quiche/common/http/http_header_block_test.cc"],
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":http2_test_tools_test_utils_lib",
         ":quiche_common_platform_test",
@@ -5189,7 +5104,6 @@ envoy_cc_library(
     srcs = ["quiche/common/structured_headers.cc"],
     hdrs = ["quiche/common/structured_headers.h"],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_platform",
@@ -5213,7 +5127,6 @@ envoy_cc_test(
     ],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quiche_common_lib",
         ":quiche_common_mem_slice_storage",
@@ -5227,7 +5140,6 @@ envoy_cc_test(
         "quiche/http2/test_tools/http2_random_test.cc",
     ],
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":http2_test_tools_random",
         ":quiche_common_platform",
@@ -5257,7 +5169,6 @@ envoy_cc_test(
     }),
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quic_core_batch_writer_batch_writer_test_lib",
         ":quic_core_batch_writer_gso_batch_writer_lib",
@@ -5272,7 +5183,6 @@ envoy_cc_library(
     hdrs = ["quiche/quic/load_balancer/load_balancer_server_id.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quic_core_types_lib",
@@ -5315,7 +5225,6 @@ envoy_cc_library(
     name = "quiche_common_platform_lower_case_string",
     hdrs = ["quiche/common/platform/api/quiche_lower_case_string.h"],
     repository = "@envoy",
-    tags = ["nofips"],
     deps = ["@envoy//source/common/quic/platform:quiche_lower_case_string_impl_lib"],
 )
 
@@ -5323,7 +5232,6 @@ envoy_cc_library(
     name = "quiche_common_platform_header_policy",
     hdrs = ["quiche/common/platform/api/quiche_header_policy.h"],
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [":quiche_common_platform_default_quiche_platform_impl_header_policy_impl_lib"],
 )
 
@@ -5338,7 +5246,6 @@ envoy_cc_library(
     hdrs = ["quiche/balsa/balsa_enums.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [":quiche_common_platform_export"],
 )
@@ -5348,7 +5255,6 @@ envoy_cc_library(
     hdrs = ["quiche/balsa/balsa_visitor_interface.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quiche_balsa_balsa_enums_lib",
@@ -5361,7 +5267,6 @@ envoy_cc_library(
     hdrs = ["quiche/balsa/noop_balsa_visitor.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quiche_balsa_balsa_visitor_interface_lib",
@@ -5375,7 +5280,6 @@ envoy_cc_library(
     hdrs = ["quiche/balsa/standard_header_map.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quiche_common_text_utils_lib",
         "@com_google_absl//absl/container:flat_hash_set",
@@ -5388,7 +5292,6 @@ envoy_cc_library(
     hdrs = ["quiche/balsa/framer_interface.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [":quiche_common_platform_export"],
 )
 
@@ -5397,7 +5300,6 @@ envoy_cc_library(
     hdrs = ["quiche/balsa/http_validation_policy.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quiche_common_platform_export",
         ":quiche_common_platform_logging",
@@ -5409,7 +5311,6 @@ envoy_cc_library(
     hdrs = ["quiche/balsa/header_api.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quiche_common_callbacks",
         ":quiche_common_platform_export",
@@ -5424,7 +5325,6 @@ envoy_cc_library(
     hdrs = ["quiche/balsa/simple_buffer.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quiche_common_platform",
         ":quiche_common_platform_bug_tracker",
@@ -5439,7 +5339,6 @@ envoy_cc_test(
     srcs = ["quiche/balsa/simple_buffer_test.cc"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quiche_balsa_simple_buffer_lib",
         ":quiche_common_platform_expect_bug",
@@ -5454,7 +5353,6 @@ envoy_cc_library(
     hdrs = ["quiche/balsa/header_properties.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quiche_common_platform",
         ":quiche_common_platform_export",
@@ -5469,7 +5367,6 @@ envoy_cc_test(
     srcs = ["quiche/balsa/header_properties_test.cc"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quiche_balsa_header_properties_lib",
         ":quiche_common_platform_test",
@@ -5482,7 +5379,6 @@ envoy_cc_library(
     hdrs = ["quiche/balsa/balsa_headers.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quiche_balsa_balsa_enums_lib",
@@ -5528,7 +5424,6 @@ envoy_cc_library(
     hdrs = ["quiche/balsa/balsa_frame.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quiche_balsa_balsa_enums_lib",
@@ -5573,7 +5468,6 @@ envoy_cc_library(
     hdrs = ["quiche/web_transport/web_transport.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":common_http_http_header_block_lib",
         ":quiche_common_callbacks",

--- a/bazel/external/quiche.bzl
+++ b/bazel/external/quiche.bzl
@@ -32,7 +32,6 @@ def envoy_quiche_platform_impl_cc_library(
         deps = deps,
         repository = "@envoy",
         strip_include_prefix = "quiche/common/platform/default/",
-        tags = ["nofips"],
         visibility = ["//visibility:public"],
     )
 
@@ -48,7 +47,6 @@ def envoy_quiche_platform_impl_cc_test_library(
         deps = deps,
         repository = "@envoy",
         strip_include_prefix = "quiche/common/platform/default/",
-        tags = ["nofips"],
     )
 
 # Used for QUIC libraries
@@ -66,7 +64,7 @@ def envoy_quic_cc_library(
         hdrs = envoy_select_enable_http3(hdrs, "@envoy"),
         repository = "@envoy",
         copts = quiche_copts,
-        tags = ["nofips"] + tags,
+        tags = tags,
         visibility = ["//visibility:public"],
         defines = defines,
         external_deps = external_deps,
@@ -86,7 +84,7 @@ def envoy_quic_cc_test_library(
         hdrs = envoy_select_enable_http3(hdrs, "@envoy"),
         copts = quiche_copts,
         repository = "@envoy",
-        tags = ["nofips"] + tags,
+        tags = tags,
         external_deps = external_deps,
         deps = envoy_select_enable_http3(deps, "@envoy"),
     )

--- a/source/common/quic/BUILD
+++ b/source/common/quic/BUILD
@@ -21,7 +21,6 @@ envoy_cc_library(
     name = "envoy_quic_alarm_lib",
     srcs = ["envoy_quic_alarm.cc"],
     hdrs = ["envoy_quic_alarm.h"],
-    tags = ["nofips"],
     deps = [
         "//envoy/event:dispatcher_interface",
         "//envoy/event:timer_interface",
@@ -35,7 +34,6 @@ envoy_cc_library(
     name = "envoy_quic_alarm_factory_lib",
     srcs = ["envoy_quic_alarm_factory.cc"],
     hdrs = ["envoy_quic_alarm_factory.h"],
-    tags = ["nofips"],
     deps = [
         ":envoy_quic_alarm_lib",
         "@com_github_google_quiche//:quic_core_alarm_factory_lib",
@@ -49,7 +47,6 @@ envoy_cc_library(
     name = "envoy_quic_clock_lib",
     srcs = ["envoy_quic_clock.cc"],
     hdrs = ["envoy_quic_clock.h"],
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         "//envoy/event:dispatcher_interface",
@@ -60,7 +57,6 @@ envoy_cc_library(
 envoy_cc_library(
     name = "envoy_quic_connection_debug_visitor_factory_interface",
     hdrs = ["envoy_quic_connection_debug_visitor_factory_interface.h"],
-    tags = ["nofips"],
     deps = [
         "//envoy/common:optref_lib",
         "//envoy/common:pure_lib",
@@ -75,7 +71,6 @@ envoy_cc_library(
 envoy_cc_library(
     name = "envoy_quic_connection_helper_lib",
     hdrs = ["envoy_quic_connection_helper.h"],
-    tags = ["nofips"],
     deps = [
         ":envoy_quic_clock_lib",
         "@com_github_google_quiche//:quic_core_connection_lib",
@@ -87,7 +82,6 @@ envoy_cc_library(
     name = "quic_stat_names_lib",
     srcs = ["quic_stat_names.cc"],
     hdrs = ["quic_stat_names.h"],
-    tags = ["nofips"],
     deps = [
         "//envoy/stats:stats_interface",
         "//source/common/stats:symbol_table_lib",
@@ -100,7 +94,6 @@ envoy_cc_library(
     name = "envoy_quic_proof_source_base_lib",
     srcs = ["envoy_quic_proof_source_base.cc"],
     hdrs = ["envoy_quic_proof_source_base.h"],
-    tags = ["nofips"],
     deps = [
         ":envoy_quic_utils_lib",
         "@com_github_google_quiche//:quic_core_crypto_certificate_view_lib",
@@ -117,7 +110,6 @@ envoy_cc_library(
     srcs = ["envoy_quic_proof_source.cc"],
     hdrs = ["envoy_quic_proof_source.h"],
     external_deps = ["ssl"],
-    tags = ["nofips"],
     deps = [
         ":envoy_quic_proof_source_base_lib",
         ":envoy_quic_utils_lib",
@@ -136,7 +128,6 @@ envoy_cc_library(
     name = "envoy_quic_proof_verifier_base_lib",
     srcs = ["envoy_quic_proof_verifier_base.cc"],
     hdrs = ["envoy_quic_proof_verifier_base.h"],
-    tags = ["nofips"],
     deps = [
         ":envoy_quic_utils_lib",
         "@com_github_google_quiche//:quic_core_crypto_certificate_view_lib",
@@ -150,7 +141,6 @@ envoy_cc_library(
     name = "envoy_quic_proof_verifier_lib",
     srcs = ["envoy_quic_proof_verifier.cc"],
     hdrs = ["envoy_quic_proof_verifier.h"],
-    tags = ["nofips"],
     deps = [
         ":envoy_quic_proof_verifier_base_lib",
         ":envoy_quic_utils_lib",
@@ -164,7 +154,6 @@ envoy_cc_library(
     name = "envoy_quic_stream_lib",
     srcs = ["envoy_quic_stream.cc"],
     hdrs = ["envoy_quic_stream.h"],
-    tags = ["nofips"],
     deps = [
         ":envoy_quic_simulated_watermark_buffer_lib",
         ":envoy_quic_utils_lib",
@@ -187,7 +176,6 @@ envoy_cc_library(
     name = "client_connection_factory_lib",
     srcs = ["client_connection_factory_impl.cc"],
     hdrs = ["client_connection_factory_impl.h"],
-    tags = ["nofips"],
     deps = [
         ":envoy_quic_alarm_factory_lib",
         ":envoy_quic_client_session_lib",
@@ -211,7 +199,6 @@ envoy_cc_library(
         "client_codec_impl.h",
         "codec_impl.h",
     ],
-    tags = ["nofips"],
     deps = [
         ":envoy_quic_client_session_lib",
         ":envoy_quic_utils_lib",
@@ -228,7 +215,6 @@ envoy_cc_library(
         "codec_impl.h",
         "server_codec_impl.h",
     ],
-    tags = ["nofips"],
     deps = [
         ":envoy_quic_server_session_lib",
         ":envoy_quic_utils_lib",
@@ -244,7 +230,6 @@ envoy_cc_library(
     name = "quic_ssl_connection_info_lib",
     hdrs = ["quic_ssl_connection_info.h"],
     external_deps = ["ssl"],
-    tags = ["nofips"],
     deps = [
         "//source/common/tls:connection_info_impl_base_lib",
         "@com_github_google_quiche//:quic_core_session_lib",
@@ -255,7 +240,6 @@ envoy_cc_library(
     name = "quic_filter_manager_connection_lib",
     srcs = ["quic_filter_manager_connection_impl.cc"],
     hdrs = ["quic_filter_manager_connection_impl.h"],
-    tags = ["nofips"],
     deps = [
         ":envoy_quic_simulated_watermark_buffer_lib",
         ":quic_network_connection_lib",
@@ -285,7 +269,6 @@ envoy_cc_library(
         "envoy_quic_server_session.h",
         "envoy_quic_server_stream.h",
     ],
-    tags = ["nofips"],
     deps = [
         ":envoy_quic_connection_debug_visitor_factory_interface",
         ":envoy_quic_proof_source_lib",
@@ -319,7 +302,6 @@ envoy_cc_library(
         "envoy_quic_network_observer_registry_factory.h",
         "quic_network_connectivity_observer.h",
     ],
-    tags = ["nofips"],
     deps = [
         ":envoy_quic_client_connection_lib",
         ":envoy_quic_client_crypto_stream_factory_lib",
@@ -346,7 +328,6 @@ envoy_cc_library(
     hdrs = [
         "envoy_quic_network_observer_registry_factory.h",
     ],
-    tags = ["nofips"],
     deps = envoy_select_enable_http3([
         ":envoy_quic_client_session_lib",
     ]),
@@ -365,7 +346,6 @@ envoy_cc_library(
     name = "quic_network_connection_lib",
     srcs = ["quic_network_connection.cc"],
     hdrs = ["quic_network_connection.h"],
-    tags = ["nofips"],
     deps = [
         "//envoy/network:connection_interface",
     ],
@@ -375,7 +355,6 @@ envoy_cc_library(
     name = "envoy_quic_server_connection_lib",
     srcs = ["envoy_quic_server_connection.cc"],
     hdrs = ["envoy_quic_server_connection.h"],
-    tags = ["nofips"],
     deps = [
         ":quic_io_handle_wrapper_lib",
         ":quic_network_connection_lib",
@@ -391,7 +370,6 @@ envoy_cc_library(
     name = "envoy_quic_client_connection_lib",
     srcs = ["envoy_quic_client_connection.cc"],
     hdrs = ["envoy_quic_client_connection.h"],
-    tags = ["nofips"],
     deps = [
         ":envoy_quic_packet_writer_lib",
         ":quic_network_connection_lib",
@@ -408,7 +386,6 @@ envoy_cc_library(
     name = "envoy_quic_dispatcher_lib",
     srcs = ["envoy_quic_dispatcher.cc"],
     hdrs = ["envoy_quic_dispatcher.h"],
-    tags = ["nofips"],
     deps = [
         ":envoy_quic_connection_debug_visitor_factory_interface",
         ":envoy_quic_proof_source_lib",
@@ -432,7 +409,6 @@ envoy_cc_library(
     name = "active_quic_listener_lib",
     srcs = ["active_quic_listener.cc"],
     hdrs = ["active_quic_listener.h"],
-    tags = ["nofips"],
     deps = [
         ":envoy_quic_alarm_factory_lib",
         ":envoy_quic_connection_debug_visitor_factory_interface",
@@ -461,7 +437,6 @@ envoy_cc_library(
     srcs = ["envoy_quic_utils.cc"],
     hdrs = ["envoy_quic_utils.h"],
     external_deps = ["ssl"],
-    tags = ["nofips"],
     deps = [
         "//envoy/http:codec_interface",
         "//source/common/http:header_map_lib",
@@ -489,7 +464,6 @@ envoy_cc_library(
         "quic_client_transport_socket_factory.h",
         "quic_transport_socket_factory.h",
     ],
-    tags = ["nofips"],
     deps = [
         ":envoy_quic_proof_verifier_lib",
         "//envoy/network:transport_socket_interface",
@@ -514,7 +488,6 @@ envoy_cc_library(
     hdrs = [
         "quic_server_transport_socket_factory.h",
     ],
-    tags = ["nofips"],
     deps = [
         ":envoy_quic_proof_verifier_lib",
         ":quic_transport_socket_factory_lib",
@@ -536,7 +509,6 @@ envoy_cc_library(
 # All of these are needed for this extension to function.
 envoy_cc_library(
     name = "quic_client_factory_lib",
-    tags = ["nofips"],
     # QUICHE can't build against FIPS BoringSSL until the FIPS build
     # is on a new enough version to have QUIC support. Remove it from
     # the build until then. Re-enable as part of #7433.
@@ -567,7 +539,6 @@ envoy_cc_library(
 # All of these are needed for this extension to function.
 envoy_cc_library(
     name = "quic_server_factory_lib",
-    tags = ["nofips"],
     # QUICHE can't build against FIPS BoringSSL until the FIPS build
     # is on a new enough version to have QUIC support. Remove it from
     # the build until then. Re-enable as part of #7433.
@@ -587,7 +558,6 @@ envoy_cc_library(
     name = "envoy_quic_packet_writer_lib",
     srcs = ["envoy_quic_packet_writer.cc"],
     hdrs = ["envoy_quic_packet_writer.h"],
-    tags = ["nofips"],
     deps = [
         ":envoy_quic_utils_lib",
         "@com_github_google_quiche//:quic_core_packet_writer_lib",
@@ -602,7 +572,6 @@ envoy_cc_library(
         "//conditions:default": [],
     }),
     hdrs = ["udp_gso_batch_writer.h"],
-    tags = ["nofips"],
     deps = [
         ":envoy_quic_utils_lib",
         "//envoy/network:udp_packet_writer_handler_interface",
@@ -620,7 +589,6 @@ envoy_cc_library(
     name = "send_buffer_monitor_lib",
     srcs = ["send_buffer_monitor.cc"],
     hdrs = ["send_buffer_monitor.h"],
-    tags = ["nofips"],
     deps = [
         "//source/common/common:assert_lib",
         "@com_github_google_quiche//:quic_core_session_lib",
@@ -630,7 +598,6 @@ envoy_cc_library(
 envoy_cc_library(
     name = "envoy_quic_client_crypto_stream_factory_lib",
     hdrs = ["envoy_quic_client_crypto_stream_factory.h"],
-    tags = ["nofips"],
     deps = [
         "//envoy/common:optref_lib",
         "//envoy/config:typed_config_interface",
@@ -643,7 +610,6 @@ envoy_cc_library(
 envoy_cc_library(
     name = "envoy_quic_server_crypto_stream_factory_lib",
     hdrs = ["envoy_quic_server_crypto_stream_factory.h"],
-    tags = ["nofips"],
     deps = [
         "//envoy/config:typed_config_interface",
         "@com_github_google_quiche//:quic_core_http_spdy_session_lib",
@@ -654,7 +620,6 @@ envoy_cc_library(
 envoy_cc_library(
     name = "envoy_quic_proof_source_factory_interface",
     hdrs = ["envoy_quic_proof_source_factory_interface.h"],
-    tags = ["nofips"],
     deps = [
         "//envoy/config:typed_config_interface",
         "@com_github_google_quiche//:quic_core_crypto_proof_source_lib",
@@ -664,7 +629,6 @@ envoy_cc_library(
 envoy_cc_library(
     name = "envoy_quic_connection_id_generator_factory_interface",
     hdrs = ["envoy_quic_connection_id_generator_factory.h"],
-    tags = ["nofips"],
     deps = [
         "//envoy/config:typed_config_interface",
         "@com_github_google_quiche//:quic_core_connection_id_generator_interface_lib",
@@ -676,7 +640,6 @@ envoy_cc_library(
     name = "envoy_deterministic_connection_id_generator_lib",
     srcs = ["envoy_deterministic_connection_id_generator.cc"],
     hdrs = ["envoy_deterministic_connection_id_generator.h"],
-    tags = ["nofips"],
     deps = [
         ":envoy_quic_connection_id_generator_factory_interface",
         ":envoy_quic_utils_lib",
@@ -687,7 +650,6 @@ envoy_cc_library(
 envoy_cc_library(
     name = "envoy_quic_server_preferred_address_config_factory_interface",
     hdrs = ["envoy_quic_server_preferred_address_config_factory.h"],
-    tags = ["nofips"],
     deps = [
         "//envoy/config:typed_config_interface",
         "//envoy/network:address_interface",
@@ -700,7 +662,6 @@ envoy_cc_library(
     name = "quic_stats_gatherer",
     srcs = ["quic_stats_gatherer.cc"],
     hdrs = ["quic_stats_gatherer.h"],
-    tags = ["nofips"],
     deps = [
         "//envoy/access_log:access_log_interface",
         "//envoy/formatter:http_formatter_context_interface",

--- a/source/common/quic/platform/BUILD
+++ b/source/common/quic/platform/BUILD
@@ -82,7 +82,6 @@ envoy_quiche_platform_impl_cc_library(
         "quiche_bug_tracker_impl.h",
         "quiche_logging_impl.h",
     ],
-    tags = ["nofips"],
     deps = [
         "//source/common/common:assert_lib",
         "//source/common/common:utility_lib",
@@ -91,7 +90,6 @@ envoy_quiche_platform_impl_cc_library(
 
 envoy_quiche_platform_impl_cc_library(
     name = "quic_base_impl_lib",
-    tags = ["nofips"],
     deps = [
         ":quiche_flags_impl_lib",
         "//source/common/common:assert_lib",
@@ -111,7 +109,6 @@ envoy_quiche_platform_impl_cc_library(
     hdrs = [
         "quiche_iovec_impl.h",
     ],
-    tags = ["nofips"],
     deps = [
         "//envoy/common:base_includes",
     ],
@@ -122,7 +119,6 @@ envoy_quiche_platform_impl_cc_library(
     hdrs = [
         "quiche_stack_trace_impl.h",
     ],
-    tags = ["nofips"],
     deps = [
         "//source/server:backtrace_lib",
         "@com_github_google_quiche//:quiche_common_platform_export",
@@ -151,13 +147,11 @@ envoy_quiche_platform_impl_cc_library(
 envoy_quiche_platform_impl_cc_library(
     name = "quiche_lower_case_string_impl_lib",
     hdrs = ["quiche_lower_case_string_impl.h"],
-    tags = ["nofips"],
     deps = ["//envoy/http:header_map_interface"],
 )
 
 envoy_quiche_platform_impl_cc_library(
     name = "quiche_export_impl_lib",
     hdrs = ["quiche_export_impl.h"],
-    tags = ["nofips"],
     deps = ["@com_google_absl//absl/base"],
 )

--- a/source/common/quic/platform/mobile_impl/BUILD
+++ b/source/common/quic/platform/mobile_impl/BUILD
@@ -16,7 +16,6 @@ envoy_quiche_platform_impl_cc_library(
     hdrs = [
         "quiche_bug_tracker_impl.h",
     ],
-    tags = ["nofips"],
     deps = [
         "@com_github_google_quiche//:quiche_common_platform_logging",
     ],

--- a/source/extensions/quic/connection_debug_visitor/basic/BUILD
+++ b/source/extensions/quic/connection_debug_visitor/basic/BUILD
@@ -19,7 +19,6 @@ envoy_cc_library(
     name = "envoy_quic_connection_debug_visitor_basic_lib",
     srcs = ["envoy_quic_connection_debug_visitor_basic.cc"],
     hdrs = ["envoy_quic_connection_debug_visitor_basic.h"],
-    tags = ["nofips"],
     visibility = [
         "//source/common/quic:__subpackages__",
     ],
@@ -44,7 +43,6 @@ envoy_cc_extension(
         "//source/common/quic:__subpackages__",
         "//test:__subpackages__",
     ],
-    tags = ["nofips"],
     deps = select(
         {
             "//bazel:boringssl_fips": [],

--- a/source/extensions/quic/connection_debug_visitor/quic_stats/BUILD
+++ b/source/extensions/quic/connection_debug_visitor/quic_stats/BUILD
@@ -17,7 +17,6 @@ envoy_cc_library(
     name = "quic_stats_lib",
     srcs = ["quic_stats.cc"],
     hdrs = ["quic_stats.h"],
-    tags = ["nofips"],
     visibility = [
         "//test:__subpackages__",
     ],
@@ -36,7 +35,6 @@ envoy_cc_extension(
         "//source/common/quic:__subpackages__",
         "//test:__subpackages__",
     ],
-    tags = ["nofips"],
     deps = select(
         {
             "//bazel:boringssl_fips": [],

--- a/source/extensions/quic/connection_id_generator/deterministic/BUILD
+++ b/source/extensions/quic/connection_id_generator/deterministic/BUILD
@@ -19,7 +19,6 @@ envoy_cc_library(
     name = "envoy_deterministic_connection_id_generator_config_lib",
     srcs = ["envoy_deterministic_connection_id_generator_config.cc"],
     hdrs = ["envoy_deterministic_connection_id_generator_config.h"],
-    tags = ["nofips"],
     deps = [
         "//envoy/registry",
         "//source/common/quic:envoy_deterministic_connection_id_generator_lib",
@@ -34,7 +33,6 @@ envoy_cc_extension(
     extra_visibility = [
         "//source/common/quic:__subpackages__",
     ],
-    tags = ["nofips"],
     deps = select(
         {
             "//bazel:boringssl_fips": [],

--- a/source/extensions/quic/connection_id_generator/quic_lb/BUILD
+++ b/source/extensions/quic/connection_id_generator/quic_lb/BUILD
@@ -17,7 +17,6 @@ envoy_cc_library(
     name = "quic_lb_lib",
     srcs = ["quic_lb.cc"],
     hdrs = ["quic_lb.h"],
-    tags = ["nofips"],
     deps = [
         "//source/common/config:datasource_lib",
         "//source/common/quic:envoy_quic_connection_id_generator_factory_interface",
@@ -33,7 +32,6 @@ envoy_cc_library(
     name = "config_lib",
     srcs = ["config.cc"],
     hdrs = ["config.h"],
-    tags = ["nofips"],
     deps = [
         ":quic_lb_lib",
         "//envoy/registry",
@@ -45,7 +43,6 @@ envoy_cc_library(
 
 envoy_cc_extension(
     name = "quic_lb_config",
-    tags = ["nofips"],
     deps = select(
         {
             "//bazel:boringssl_fips": [],

--- a/source/extensions/quic/crypto_stream/BUILD
+++ b/source/extensions/quic/crypto_stream/BUILD
@@ -19,7 +19,6 @@ envoy_cc_library(
     name = "envoy_quic_crypto_server_stream_lib",
     srcs = ["envoy_quic_crypto_server_stream.cc"],
     hdrs = ["envoy_quic_crypto_server_stream.h"],
-    tags = ["nofips"],
     visibility = [
         "//source/common/quic:__subpackages__",
         "//test:__subpackages__",
@@ -38,7 +37,6 @@ envoy_cc_extension(
         "//source/common/quic:__subpackages__",
         "//test:__subpackages__",
     ],
-    tags = ["nofips"],
     deps = select(
         {
             "//bazel:boringssl_fips": [],
@@ -54,7 +52,6 @@ envoy_cc_library(
     name = "envoy_quic_crypto_client_stream_lib",
     srcs = ["envoy_quic_crypto_client_stream.cc"],
     hdrs = ["envoy_quic_crypto_client_stream.h"],
-    tags = ["nofips"],
     visibility = [
         "//source/common/quic:__subpackages__",
         "//test:__subpackages__",

--- a/source/extensions/quic/proof_source/BUILD
+++ b/source/extensions/quic/proof_source/BUILD
@@ -19,7 +19,6 @@ envoy_cc_library(
     name = "envoy_quic_proof_source_factory_impl_lib",
     srcs = ["envoy_quic_proof_source_factory_impl.cc"],
     hdrs = ["envoy_quic_proof_source_factory_impl.h"],
-    tags = ["nofips"],
     visibility = [
         "//source/common/quic:__subpackages__",
         "//test:__subpackages__",
@@ -38,7 +37,6 @@ envoy_cc_extension(
         "//source/common/quic:__subpackages__",
         "//test:__subpackages__",
     ],
-    tags = ["nofips"],
     deps = select(
         {
             "//bazel:boringssl_fips": [],

--- a/source/extensions/quic/server_preferred_address/BUILD
+++ b/source/extensions/quic/server_preferred_address/BUILD
@@ -19,7 +19,6 @@ envoy_cc_library(
     name = "server_preferred_address_lib",
     srcs = ["server_preferred_address.cc"],
     hdrs = ["server_preferred_address.h"],
-    tags = ["nofips"],
     deps = [
         "//source/common/quic:envoy_quic_server_preferred_address_config_factory_interface",
     ],
@@ -29,7 +28,6 @@ envoy_cc_library(
     name = "fixed_server_preferred_address_config_lib",
     srcs = ["fixed_server_preferred_address_config.cc"],
     hdrs = ["fixed_server_preferred_address_config.h"],
-    tags = ["nofips"],
     deps = [
         ":server_preferred_address_lib",
         "//envoy/registry",
@@ -45,7 +43,6 @@ envoy_cc_extension(
     extra_visibility = [
         "//test:__subpackages__",
     ],
-    tags = ["nofips"],
     deps = select(
         {
             "//bazel:boringssl_fips": [],
@@ -61,7 +58,6 @@ envoy_cc_library(
     name = "datasource_server_preferred_address_config_lib",
     srcs = ["datasource_server_preferred_address_config.cc"],
     hdrs = ["datasource_server_preferred_address_config.h"],
-    tags = ["nofips"],
     deps = [
         ":server_preferred_address_lib",
         "//envoy/registry",
@@ -75,7 +71,6 @@ envoy_cc_library(
 
 envoy_cc_extension(
     name = "datasource_server_preferred_address_config_factory_config",
-    tags = ["nofips"],
     deps = select(
         {
             "//bazel:boringssl_fips": [],

--- a/source/extensions/udp_packet_writer/gso/BUILD
+++ b/source/extensions/udp_packet_writer/gso/BUILD
@@ -21,7 +21,6 @@ envoy_cc_extension(
         "//source/server:__subpackages__",
         "//source/common/listener_manager:__subpackages__",
     ],
-    tags = ["nofips"],
     deps = [
         "//envoy/config:typed_config_interface",
         "//envoy/network:udp_packet_writer_handler_interface",

--- a/test/common/http/http3/BUILD
+++ b/test/common/http/http3/BUILD
@@ -13,7 +13,6 @@ envoy_cc_test(
     name = "conn_pool_test",
     srcs = envoy_select_enable_http3(["conn_pool_test.cc"]),
     rbe_pool = "6gig",
-    tags = ["nofips"],
     deps = envoy_select_enable_http3([
         "//source/common/event:dispatcher_lib",
         "//source/common/http/http3:conn_pool_lib",

--- a/test/common/listener_manager/BUILD
+++ b/test/common/listener_manager/BUILD
@@ -111,7 +111,6 @@ envoy_cc_test(
     name = "listener_manager_impl_quic_only_test",
     srcs = ["listener_manager_impl_quic_only_test.cc"],
     rbe_pool = "6gig",
-    tags = ["nofips"],
     deps = [
         ":listener_manager_impl_test_lib",
         "//source/common/formatter:formatter_extension_lib",

--- a/test/common/network/BUILD
+++ b/test/common/network/BUILD
@@ -277,7 +277,6 @@ envoy_cc_test(
     rbe_pool = "6gig",
     # Skipping as quiche quic_gso_batch_writer.h does not exist on Windows
     tags = [
-        "nofips",
         "skip_on_windows",
     ],
     deps = [

--- a/test/common/quic/BUILD
+++ b/test/common/quic/BUILD
@@ -16,7 +16,6 @@ envoy_cc_test(
     name = "envoy_quic_alarm_test",
     srcs = ["envoy_quic_alarm_test.cc"],
     rbe_pool = "6gig",
-    tags = ["nofips"],
     deps = [
         "//source/common/quic:envoy_quic_alarm_factory_lib",
         "//source/common/quic:envoy_quic_alarm_lib",
@@ -31,7 +30,6 @@ envoy_cc_test(
     name = "envoy_quic_clock_test",
     srcs = ["envoy_quic_clock_test.cc"],
     rbe_pool = "6gig",
-    tags = ["nofips"],
     deps = [
         "//source/common/quic:envoy_quic_clock_lib",
         "//test/test_common:simulated_time_system_lib",
@@ -44,7 +42,6 @@ envoy_cc_test(
     name = "envoy_quic_writer_test",
     srcs = ["envoy_quic_writer_test.cc"],
     rbe_pool = "6gig",
-    tags = ["nofips"],
     deps = [
         "//source/common/network:io_socket_error_lib",
         "//source/common/network:udp_packet_writer_handler_lib",
@@ -60,7 +57,6 @@ envoy_cc_test(
     name = "envoy_quic_proof_source_test",
     srcs = ["envoy_quic_proof_source_test.cc"],
     rbe_pool = "6gig",
-    tags = ["nofips"],
     deps = [
         ":test_utils_lib",
         "//source/common/quic:envoy_quic_proof_source_lib",
@@ -81,7 +77,6 @@ envoy_cc_test(
     name = "quic_filter_manager_connection_impl_test",
     srcs = ["quic_filter_manager_connection_impl_test.cc"],
     rbe_pool = "6gig",
-    tags = ["nofips"],
     deps = [
         "//source/common/quic:quic_filter_manager_connection_lib",
         "//test/mocks/event:event_mocks",
@@ -95,7 +90,6 @@ envoy_cc_test(
     name = "quic_stat_names_test",
     srcs = ["quic_stat_names_test.cc"],
     rbe_pool = "6gig",
-    tags = ["nofips"],
     deps = [
         "//source/common/quic:quic_stat_names_lib",
         "//source/common/stats:stats_lib",
@@ -108,7 +102,6 @@ envoy_cc_test(
     name = "envoy_quic_proof_verifier_test",
     srcs = ["envoy_quic_proof_verifier_test.cc"],
     rbe_pool = "6gig",
-    tags = ["nofips"],
     deps = [
         ":test_utils_lib",
         "//source/common/quic:envoy_quic_proof_verifier_lib",
@@ -127,7 +120,6 @@ envoy_cc_test(
     name = "envoy_quic_server_stream_test",
     srcs = ["envoy_quic_server_stream_test.cc"],
     rbe_pool = "6gig",
-    tags = ["nofips"],
     deps = [
         ":test_utils_lib",
         "//source/common/http:headers_lib",
@@ -150,7 +142,6 @@ envoy_cc_test(
     name = "envoy_quic_client_stream_test",
     srcs = ["envoy_quic_client_stream_test.cc"],
     rbe_pool = "6gig",
-    tags = ["nofips"],
     deps = [
         ":test_utils_lib",
         "//source/common/http:headers_lib",
@@ -171,7 +162,6 @@ envoy_cc_test(
     name = "envoy_quic_server_session_test",
     srcs = ["envoy_quic_server_session_test.cc"],
     rbe_pool = "6gig",
-    tags = ["nofips"],
     deps = [
         ":test_proof_source_lib",
         ":test_utils_lib",
@@ -200,7 +190,6 @@ envoy_cc_test(
     name = "envoy_quic_client_session_test",
     srcs = ["envoy_quic_client_session_test.cc"],
     rbe_pool = "6gig",
-    tags = ["nofips"],
     deps = [
         ":test_utils_lib",
         "//envoy/stats:stats_macros",
@@ -228,7 +217,6 @@ envoy_cc_test(
     name = "active_quic_listener_test",
     srcs = ["active_quic_listener_test.cc"],
     rbe_pool = "6gig",
-    tags = ["nofips"],
     deps = [
         ":test_proof_source_lib",
         ":test_utils_lib",
@@ -257,7 +245,6 @@ envoy_cc_test(
     name = "envoy_quic_dispatcher_test",
     srcs = ["envoy_quic_dispatcher_test.cc"],
     rbe_pool = "6gig",
-    tags = ["nofips"],
     deps = [
         ":test_proof_source_lib",
         ":test_utils_lib",
@@ -285,7 +272,6 @@ envoy_cc_test(
 envoy_cc_test_library(
     name = "test_proof_source_lib",
     hdrs = ["test_proof_source.h"],
-    tags = ["nofips"],
     deps = [
         "//source/common/quic:envoy_quic_proof_source_base_lib",
         "//test/mocks/network:network_mocks",
@@ -296,7 +282,6 @@ envoy_cc_test_library(
 envoy_cc_test_library(
     name = "test_proof_verifier_lib",
     hdrs = ["test_proof_verifier.h"],
-    tags = ["nofips"],
     deps = [
         "//source/common/quic:envoy_quic_proof_verifier_base_lib",
     ],
@@ -306,7 +291,6 @@ envoy_cc_test(
     name = "client_connection_factory_impl_test",
     srcs = ["client_connection_factory_impl_test.cc"],
     rbe_pool = "6gig",
-    tags = ["nofips"],
     deps = [
         "//source/common/event:dispatcher_lib",
         "//source/common/http/http3:conn_pool_lib",
@@ -332,7 +316,6 @@ envoy_cc_test(
     name = "quic_io_handle_wrapper_test",
     srcs = ["quic_io_handle_wrapper_test.cc"],
     rbe_pool = "6gig",
-    tags = ["nofips"],
     deps = [
         "//source/common/quic:quic_io_handle_wrapper_lib",
         "//test/mocks/api:api_mocks",
@@ -346,7 +329,6 @@ envoy_cc_test(
     name = "envoy_quic_utils_test",
     srcs = ["envoy_quic_utils_test.cc"],
     rbe_pool = "6gig",
-    tags = ["nofips"],
     deps = [
         "//source/common/quic:envoy_quic_utils_lib",
         "//test/mocks/api:api_mocks",
@@ -359,7 +341,6 @@ envoy_cc_test(
     name = "envoy_quic_simulated_watermark_buffer_test",
     srcs = ["envoy_quic_simulated_watermark_buffer_test.cc"],
     rbe_pool = "6gig",
-    tags = ["nofips"],
     deps = ["//source/common/quic:envoy_quic_simulated_watermark_buffer_lib"],
 )
 
@@ -367,7 +348,6 @@ envoy_cc_test_library(
     name = "test_utils_lib",
     hdrs = ["test_utils.h"],
     external_deps = ["bazel_runfiles"],
-    tags = ["nofips"],
     deps = [
         "//envoy/stream_info:stream_info_interface",
         "//source/common/quic:envoy_quic_client_connection_lib",
@@ -392,7 +372,6 @@ envoy_cc_test(
         "//test/common/tls/test_data:certs",
     ],
     rbe_pool = "6gig",
-    tags = ["nofips"],
     deps = [
         "//source/common/quic:quic_server_transport_socket_factory_lib",
         "//source/common/quic:quic_transport_socket_factory_lib",
@@ -408,7 +387,6 @@ envoy_cc_test(
     name = "http_datagram_handler_test",
     srcs = envoy_select_enable_http_datagrams(["http_datagram_handler_test.cc"]),
     rbe_pool = "6gig",
-    tags = ["nofips"],
     deps = envoy_select_enable_http_datagrams([
         "//source/common/quic:http_datagram_handler",
         "//test/mocks/buffer:buffer_mocks",
@@ -436,7 +414,6 @@ envoy_cc_test(
     name = "envoy_deterministic_connection_id_generator_test",
     srcs = ["envoy_deterministic_connection_id_generator_test.cc"],
     rbe_pool = "6gig",
-    tags = ["nofips"],
     deps = [
         ":connection_id_matchers",
         "//source/common/quic:envoy_deterministic_connection_id_generator_lib",
@@ -454,7 +431,6 @@ envoy_cc_test_library(
     name = "envoy_quic_h3_fuzz_helper_lib",
     srcs = ["envoy_quic_h3_fuzz_helper.cc"],
     hdrs = ["envoy_quic_h3_fuzz_helper.h"],
-    tags = ["nofips"],
     deps = [
         ":envoy_quic_h3_fuzz_proto_cc_proto",
         "//source/common/common:assert_lib",
@@ -467,7 +443,6 @@ envoy_cc_fuzz_test(
     srcs = ["envoy_quic_h3_fuzz_test.cc"],
     corpus = "envoy_quic_h3_fuzz_test_corpus",
     rbe_pool = "6gig",
-    tags = ["nofips"],
     deps = [
         ":envoy_quic_h3_fuzz_helper_lib",
         ":test_proof_source_lib",

--- a/test/common/quic/platform/BUILD
+++ b/test/common/quic/platform/BUILD
@@ -24,7 +24,6 @@ envoy_cc_test(
     }),
     data = ["//test/common/tls/test_data:certs"],
     rbe_pool = "6gig",
-    tags = ["nofips"],
     deps = [
         "//source/common/memory:stats_lib",
         "//source/common/quic/platform:quiche_flags_impl_lib",
@@ -50,7 +49,6 @@ envoy_cc_test(
 envoy_quiche_platform_impl_cc_test_library(
     name = "quiche_expect_bug_impl_lib",
     hdrs = ["quiche_expect_bug_impl.h"],
-    tags = ["nofips"],
     deps = [
         "@com_github_google_quiche//:quic_platform_base",
     ],
@@ -59,7 +57,6 @@ envoy_quiche_platform_impl_cc_test_library(
 envoy_quiche_platform_impl_cc_test_library(
     name = "quiche_thread_impl_lib",
     hdrs = ["quiche_thread_impl.h"],
-    tags = ["nofips"],
     deps = [
         "//envoy/thread:thread_interface",
         "//source/common/common:assert_lib",
@@ -71,7 +68,6 @@ envoy_quiche_platform_impl_cc_test_library(
     name = "quiche_test_output_impl_lib",
     srcs = ["quiche_test_output_impl.cc"],
     hdrs = ["quiche_test_output_impl.h"],
-    tags = ["nofips"],
     deps = [
         "//test/test_common:file_system_for_test_lib",
         "@com_github_google_quiche//:quic_platform_base",

--- a/test/extensions/quic/connection_debug_visitor/quic_stats/BUILD
+++ b/test/extensions/quic/connection_debug_visitor/quic_stats/BUILD
@@ -15,7 +15,6 @@ envoy_extension_cc_test(
     name = "quic_stats_test",
     srcs = ["quic_stats_test.cc"],
     extension_names = ["envoy.quic.connection_debug_visitor.quic_stats"],
-    tags = ["nofips"],
     deps = [
         "//source/extensions/quic/connection_debug_visitor/quic_stats:quic_stats_lib",
         "//test/mocks/event:event_mocks",
@@ -28,7 +27,6 @@ envoy_extension_cc_test(
     srcs = ["integration_test.cc"],
     extension_names = ["envoy.quic.connection_debug_visitor.quic_stats"],
     rbe_pool = "2core",
-    tags = ["nofips"],
     deps = [
         "//source/extensions/quic/connection_debug_visitor/quic_stats:config",
         "//test/integration:http_integration_lib",

--- a/test/extensions/quic/connection_id_generator/quic_lb/BUILD
+++ b/test/extensions/quic/connection_id_generator/quic_lb/BUILD
@@ -16,7 +16,6 @@ envoy_extension_cc_test(
     srcs = ["quic_lb_test.cc"],
     extension_names = ["envoy.quic.connection_id_generator.quic_lb"],
     rbe_pool = "6gig",
-    tags = ["nofips"],
     deps = [
         "//source/extensions/quic/connection_id_generator/quic_lb:quic_lb_lib",
         "//test/mocks/server:factory_context_mocks",
@@ -30,7 +29,6 @@ envoy_extension_cc_test(
     srcs = ["integration_test.cc"],
     extension_names = ["envoy.quic.connection_id_generator.quic_lb"],
     rbe_pool = "4core",
-    tags = ["nofips"],
     deps = [
         "//source/extensions/quic/connection_id_generator/quic_lb:quic_lb_config",
         "//test/integration:http_integration_lib",

--- a/test/extensions/quic/proof_source/BUILD
+++ b/test/extensions/quic/proof_source/BUILD
@@ -12,7 +12,6 @@ envoy_cc_test_library(
     name = "pending_proof_source_factory_impl_lib",
     srcs = ["pending_proof_source_factory_impl.cc"],
     hdrs = ["pending_proof_source_factory_impl.h"],
-    tags = ["nofips"],
     deps = [
         "//envoy/registry",
         "//source/common/quic:envoy_quic_proof_source_factory_interface",

--- a/test/extensions/quic/server_preferred_address/BUILD
+++ b/test/extensions/quic/server_preferred_address/BUILD
@@ -16,7 +16,6 @@ envoy_extension_cc_test(
     srcs = ["datasource_server_preferred_address_test.cc"],
     extension_names = ["envoy.quic.server_preferred_address.datasource"],
     rbe_pool = "6gig",
-    tags = ["nofips"],
     deps = [
         "//source/extensions/quic/server_preferred_address:datasource_server_preferred_address_config_lib",
         "//test/mocks/protobuf:protobuf_mocks",
@@ -29,7 +28,6 @@ envoy_extension_cc_test(
     srcs = ["fixed_server_preferred_address_test.cc"],
     extension_names = ["envoy.quic.server_preferred_address.fixed"],
     rbe_pool = "6gig",
-    tags = ["nofips"],
     deps = [
         "//source/extensions/quic/server_preferred_address:fixed_server_preferred_address_config_lib",
         "//test/mocks/protobuf:protobuf_mocks",

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -1485,7 +1485,6 @@ envoy_cc_test(
     shard_count = 2,
     tags = [
         "cpu:3",
-        "nofips",
     ],
     deps = [
         ":http_protocol_integration_lib",
@@ -2556,7 +2555,6 @@ envoy_cc_test(
     shard_count = 16,
     tags = [
         "cpu:4",
-        "nofips",
     ],
     deps = select({
         "//bazel:disable_http3": [],
@@ -2631,7 +2629,6 @@ envoy_cc_test(
         "cpu:3",
         "fails_on_clang_cl",
         "fails_on_windows",
-        "nofips",
     ],
     deps = envoy_select_enable_http3([
         ":quic_http_integration_test_lib",

--- a/test/integration/filters/BUILD
+++ b/test/integration/filters/BUILD
@@ -472,7 +472,6 @@ envoy_cc_test_library(
     srcs = [
         "pause_filter_for_quic.cc",
     ],
-    tags = ["nofips"],
     deps = [
         "//envoy/http:filter_interface",
         "//envoy/registry",


### PR DESCRIPTION
## Description

This PR re-enables all the QUIC tests for the FIPS build as the FIPS version Envoy uses now ([fips-20220613](https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4735)) has the interface that QUIC supports.

**Fixes:** [#7433](https://github.com/envoyproxy/envoy/issues/7433)

---

**Commit Message:** quic: re-enable QUICHE for FIPS build and all the related tests
**Additional Description:** Re-enable QUIC for FIPS build and un-gate all the related tests
**Risk Level:** Low
**Testing:** Existing Tests
**Docs Changes:** N/A
**Release Notes:** N/A