### PR TITLE
dynamic_modules: add filter state support for http filter

### DIFF
--- a/source/extensions/dynamic_modules/abi.h
+++ b/source/extensions/dynamic_modules/abi.h
@@ -990,6 +990,50 @@ bool envoy_dynamic_module_callback_http_get_dynamic_metadata_string(
     envoy_dynamic_module_type_buffer_module_ptr key_ptr, size_t key_length,
     envoy_dynamic_module_type_buffer_envoy_ptr* result, size_t* result_length);
 
+// -------------------------- Filter State Callbacks ---------------------------
+
+/**
+ * envoy_dynamic_module_callback_http_set_filter_state_string is called by the module to set the
+ * string value of the filter state with the given key. If the filter state is not accessible, this
+ * returns false. If the key does not exist, it will be created.
+ *
+ * @param filter_envoy_ptr is the pointer to the DynamicModuleHttpFilter object of the
+ * corresponding HTTP filter.
+ * @param key_ptr is the key of the filter state.
+ * @param key_length is the length of the key.
+ * @param value_ptr is the string value of the filter state to be set.
+ * @param value_length is the length of the value.
+ * @return true if the operation is successful, false otherwise.
+ */
+bool envoy_dynamic_module_callback_http_set_filter_state_string(
+    envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr,
+    envoy_dynamic_module_type_buffer_module_ptr key_ptr, size_t key_length,
+    envoy_dynamic_module_type_buffer_module_ptr value_ptr, size_t value_length);
+
+/**
+ * envoy_dynamic_module_callback_http_get_filter_state_string is called by the module to get the  
+ * string value of the filter state with the given key. If the filter state is not accessible, the
+ * key does not exist or the value is not a string, this returns false. 
+ * 
+ * @param filter_envoy_ptr is the pointer to the DynamicModuleHttpFilter object of the
+ * corresponding HTTP filter.
+ * @param key_ptr is the key of the filter state.
+ * @param key_length is the length of the key.
+ * @param result_buffer_ptr is the pointer to the pointer variable where the pointer to the buffer
+ * of the value will be stored.
+ * @param result_buffer_length_ptr is the pointer to the variable where the length of the buffer
+ * will be stored.
+ * @return true if the operation is successful, false otherwise.
+ * 
+ * Note that the buffer pointed by the pointer stored in result is owned by Envoy, and
+ * they are guaranteed to be valid until the end of the current event hook unless the setter
+ * callback is called.
+ */
+bool envoy_dynamic_module_callback_http_get_filter_state_string(
+    envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr,
+    envoy_dynamic_module_type_buffer_module_ptr key_ptr, size_t key_length,
+    envoy_dynamic_module_type_buffer_envoy_ptr* result, size_t* result_length);
+
 // ------------------- Misc Callbacks for HTTP Filters -------------------------
 
 /**

--- a/source/extensions/dynamic_modules/abi.h
+++ b/source/extensions/dynamic_modules/abi.h
@@ -993,27 +993,27 @@ bool envoy_dynamic_module_callback_http_get_dynamic_metadata_string(
 // -------------------------- Filter State Callbacks ---------------------------
 
 /**
- * envoy_dynamic_module_callback_http_set_filter_state_string is called by the module to set the
- * string value of the filter state with the given key. If the filter state is not accessible, this
+ * envoy_dynamic_module_callback_http_set_filter_state_bytes is called by the module to set the
+ * bytes value of the filter state with the given key. If the filter state is not accessible, this
  * returns false. If the key does not exist, it will be created.
  *
  * @param filter_envoy_ptr is the pointer to the DynamicModuleHttpFilter object of the
  * corresponding HTTP filter.
  * @param key_ptr is the key of the filter state.
  * @param key_length is the length of the key.
- * @param value_ptr is the string value of the filter state to be set.
+ * @param value_ptr is the bytes value of the filter state to be set.
  * @param value_length is the length of the value.
  * @return true if the operation is successful, false otherwise.
  */
-bool envoy_dynamic_module_callback_http_set_filter_state_string(
+bool envoy_dynamic_module_callback_http_set_filter_state_bytes(
     envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr,
     envoy_dynamic_module_type_buffer_module_ptr key_ptr, size_t key_length,
     envoy_dynamic_module_type_buffer_module_ptr value_ptr, size_t value_length);
 
 /**
- * envoy_dynamic_module_callback_http_get_filter_state_string is called by the module to get the
- * string value of the filter state with the given key. If the filter state is not accessible, the
- * key does not exist or the value is not a string, this returns false.
+ * envoy_dynamic_module_callback_http_get_filter_state_bytes is called by the module to get the
+ * bytes value of the filter state with the given key. If the filter state is not accessible, the
+ * key does not exist or the value is not bytes, this returns false.
  *
  * @param filter_envoy_ptr is the pointer to the DynamicModuleHttpFilter object of the
  * corresponding HTTP filter.
@@ -1029,7 +1029,7 @@ bool envoy_dynamic_module_callback_http_set_filter_state_string(
  * they are guaranteed to be valid until the end of the current event hook unless the setter
  * callback is called.
  */
-bool envoy_dynamic_module_callback_http_get_filter_state_string(
+bool envoy_dynamic_module_callback_http_get_filter_state_bytes(
     envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr,
     envoy_dynamic_module_type_buffer_module_ptr key_ptr, size_t key_length,
     envoy_dynamic_module_type_buffer_envoy_ptr* result, size_t* result_length);

--- a/source/extensions/dynamic_modules/abi.h
+++ b/source/extensions/dynamic_modules/abi.h
@@ -1011,10 +1011,10 @@ bool envoy_dynamic_module_callback_http_set_filter_state_string(
     envoy_dynamic_module_type_buffer_module_ptr value_ptr, size_t value_length);
 
 /**
- * envoy_dynamic_module_callback_http_get_filter_state_string is called by the module to get the  
+ * envoy_dynamic_module_callback_http_get_filter_state_string is called by the module to get the
  * string value of the filter state with the given key. If the filter state is not accessible, the
- * key does not exist or the value is not a string, this returns false. 
- * 
+ * key does not exist or the value is not a string, this returns false.
+ *
  * @param filter_envoy_ptr is the pointer to the DynamicModuleHttpFilter object of the
  * corresponding HTTP filter.
  * @param key_ptr is the key of the filter state.
@@ -1024,7 +1024,7 @@ bool envoy_dynamic_module_callback_http_set_filter_state_string(
  * @param result_buffer_length_ptr is the pointer to the variable where the length of the buffer
  * will be stored.
  * @return true if the operation is successful, false otherwise.
- * 
+ *
  * Note that the buffer pointed by the pointer stored in result is owned by Envoy, and
  * they are guaranteed to be valid until the end of the current event hook unless the setter
  * callback is called.

--- a/source/extensions/dynamic_modules/abi_version.h
+++ b/source/extensions/dynamic_modules/abi_version.h
@@ -6,7 +6,7 @@ namespace DynamicModules {
 #endif
 // This is the ABI version calculated as a sha256 hash of the ABI header files. When the ABI
 // changes, this value must change, and the correctness of this value is checked by the test.
-const char* kAbiVersion = "cf448e788b7b565ef583167d94489c93320c234224a50fa4a92f096f2467038d";
+const char* kAbiVersion = "03ac4493600edcfa40485ac3ccbc8ae01703b6aa7abe2d4bf8c4f4deda1c63da";
 
 #ifdef __cplusplus
 } // namespace DynamicModules

--- a/source/extensions/dynamic_modules/abi_version.h
+++ b/source/extensions/dynamic_modules/abi_version.h
@@ -6,7 +6,7 @@ namespace DynamicModules {
 #endif
 // This is the ABI version calculated as a sha256 hash of the ABI header files. When the ABI
 // changes, this value must change, and the correctness of this value is checked by the test.
-const char* kAbiVersion = "0b3212146514a1e01c16f23a6d811431a2db2757ab341aef0abc506b92f0f79a";
+const char* kAbiVersion = "0874b1e9587ef1dbd355ffde32f3caf424cb819df552de4833b2ed5b8996c18b";
 
 #ifdef __cplusplus
 } // namespace DynamicModules

--- a/source/extensions/dynamic_modules/abi_version.h
+++ b/source/extensions/dynamic_modules/abi_version.h
@@ -6,7 +6,7 @@ namespace DynamicModules {
 #endif
 // This is the ABI version calculated as a sha256 hash of the ABI header files. When the ABI
 // changes, this value must change, and the correctness of this value is checked by the test.
-const char* kAbiVersion = "03ac4493600edcfa40485ac3ccbc8ae01703b6aa7abe2d4bf8c4f4deda1c63da";
+const char* kAbiVersion = "0b3212146514a1e01c16f23a6d811431a2db2757ab341aef0abc506b92f0f79a";
 
 #ifdef __cplusplus
 } // namespace DynamicModules

--- a/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
@@ -390,6 +390,16 @@ pub trait EnvoyHttpFilter {
   /// Returns true if the operation is successful.
   fn set_dynamic_metadata_string(&mut self, namespace: &str, key: &str, value: &str) -> bool;
 
+  /// Get the string-typed filter state value with the given key.
+  /// If the filter state is not found or is the wrong type, this returns `None`.
+  fn get_filter_state_string<'a>(&'a self, key: &str) -> Option<EnvoyBuffer<'a>>;
+
+  /// Set the string-typed filter state value with the given key.
+  /// If the filter state is not found, this will create a new filter state.
+  ///
+  /// Returns true if the operation is successful.
+  fn set_filter_state_string(&mut self, key: &str, value: &str) -> bool;
+
   /// Get the currently buffered request body. The body is represented as a list of [`EnvoyBuffer`].
   /// Memory contents pointed by each [`EnvoyBuffer`] is mutable and can be modified in place.
   /// However, the vector itself is a "copied view". For example, adding or removing
@@ -784,6 +794,43 @@ impl EnvoyHttpFilter for EnvoyHttpFilterImpl {
         self.raw_ptr,
         namespace_ptr as *const _ as *mut _,
         namespace_size,
+        key_ptr as *const _ as *mut _,
+        key_size,
+        value_ptr as *const _ as *mut _,
+        value_size,
+      )
+    }
+  }
+
+  fn get_filter_state_string(&self, key: &str) -> Option<EnvoyBuffer> {
+    let key_ptr = key.as_ptr();
+    let key_size = key.len();
+    let mut result_ptr: *const u8 = std::ptr::null();
+    let mut result_size: usize = 0;
+    let success = unsafe {
+      abi::envoy_dynamic_module_callback_http_get_filter_state_string(
+        self.raw_ptr,
+        key_ptr as *const _ as *mut _,
+        key_size,
+        &mut result_ptr as *mut _ as *mut _,
+        &mut result_size as *mut _ as *mut _,
+      )
+    };
+    if success {
+      Some(unsafe { EnvoyBuffer::new_from_raw(result_ptr, result_size) })
+    } else {
+      None
+    }
+  }
+
+  fn set_filter_state_string(&mut self, key: &str, value: &str) -> bool {
+    let key_ptr = key.as_ptr();
+    let key_size = key.len();
+    let value_ptr = value.as_ptr();
+    let value_size = value.len();
+    unsafe {
+      abi::envoy_dynamic_module_callback_http_set_filter_state_string(
+        self.raw_ptr,
         key_ptr as *const _ as *mut _,
         key_size,
         value_ptr as *const _ as *mut _,

--- a/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
@@ -390,15 +390,15 @@ pub trait EnvoyHttpFilter {
   /// Returns true if the operation is successful.
   fn set_dynamic_metadata_string(&mut self, namespace: &str, key: &str, value: &str) -> bool;
 
-  /// Get the string-typed filter state value with the given key.
+  /// Get the bytes-typed filter state value with the given key.
   /// If the filter state is not found or is the wrong type, this returns `None`.
-  fn get_filter_state_string<'a>(&'a self, key: &str) -> Option<EnvoyBuffer<'a>>;
+  fn get_filter_state_bytes<'a>(&'a self, key: &[u8]) -> Option<EnvoyBuffer<'a>>;
 
-  /// Set the string-typed filter state value with the given key.
+  /// Set the bytes-typed filter state value with the given key.
   /// If the filter state is not found, this will create a new filter state.
   ///
   /// Returns true if the operation is successful.
-  fn set_filter_state_string(&mut self, key: &str, value: &str) -> bool;
+  fn set_filter_state_bytes(&mut self, key: &[u8], value: &[u8]) -> bool;
 
   /// Get the currently buffered request body. The body is represented as a list of [`EnvoyBuffer`].
   /// Memory contents pointed by each [`EnvoyBuffer`] is mutable and can be modified in place.
@@ -802,13 +802,13 @@ impl EnvoyHttpFilter for EnvoyHttpFilterImpl {
     }
   }
 
-  fn get_filter_state_string(&self, key: &str) -> Option<EnvoyBuffer> {
+  fn get_filter_state_bytes(&self, key: &[u8]) -> Option<EnvoyBuffer> {
     let key_ptr = key.as_ptr();
     let key_size = key.len();
     let mut result_ptr: *const u8 = std::ptr::null();
     let mut result_size: usize = 0;
     let success = unsafe {
-      abi::envoy_dynamic_module_callback_http_get_filter_state_string(
+      abi::envoy_dynamic_module_callback_http_get_filter_state_bytes(
         self.raw_ptr,
         key_ptr as *const _ as *mut _,
         key_size,
@@ -823,13 +823,13 @@ impl EnvoyHttpFilter for EnvoyHttpFilterImpl {
     }
   }
 
-  fn set_filter_state_string(&mut self, key: &str, value: &str) -> bool {
+  fn set_filter_state_bytes(&mut self, key: &[u8], value: &[u8]) -> bool {
     let key_ptr = key.as_ptr();
     let key_size = key.len();
     let value_ptr = value.as_ptr();
     let value_size = value.len();
     unsafe {
-      abi::envoy_dynamic_module_callback_http_set_filter_state_string(
+      abi::envoy_dynamic_module_callback_http_set_filter_state_bytes(
         self.raw_ptr,
         key_ptr as *const _ as *mut _,
         key_size,

--- a/source/extensions/filters/http/dynamic_modules/BUILD
+++ b/source/extensions/filters/http/dynamic_modules/BUILD
@@ -56,6 +56,7 @@ envoy_cc_library(
     deps = [
         ":filter_lib",
         "//source/common/http:utility_lib",
+        "//source/common/router:string_accessor_lib",
         "//source/extensions/dynamic_modules:dynamic_modules_lib",
         "//source/extensions/filters/http/common:pass_through_filter_lib",
     ],

--- a/source/extensions/filters/http/dynamic_modules/abi_impl.cc
+++ b/source/extensions/filters/http/dynamic_modules/abi_impl.cc
@@ -375,7 +375,7 @@ bool envoy_dynamic_module_callback_http_get_dynamic_metadata_string(
   return true;
 }
 
-bool envoy_dynamic_module_callback_http_set_filter_state_string(
+bool envoy_dynamic_module_callback_http_set_filter_state_bytes(
     envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr,
     envoy_dynamic_module_type_buffer_module_ptr key_ptr, size_t key_length,
     envoy_dynamic_module_type_buffer_module_ptr value_ptr, size_t value_length) {
@@ -394,7 +394,7 @@ bool envoy_dynamic_module_callback_http_set_filter_state_string(
   return true;
 }
 
-bool envoy_dynamic_module_callback_http_get_filter_state_string(
+bool envoy_dynamic_module_callback_http_get_filter_state_bytes(
     envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr,
     envoy_dynamic_module_type_buffer_module_ptr key_ptr, size_t key_length,
     envoy_dynamic_module_type_buffer_envoy_ptr* result, size_t* result_length) {
@@ -412,7 +412,7 @@ bool envoy_dynamic_module_callback_http_get_filter_state_string(
                         fmt::format("key not found in filter state", key_view));
     return false;
   }
-  auto str = filter_state->asString();
+  absl::string_view str = filter_state->asString();
   *result = const_cast<char*>(str.data());
   *result_length = str.size();
   return true;

--- a/source/extensions/filters/http/dynamic_modules/abi_impl.cc
+++ b/source/extensions/filters/http/dynamic_modules/abi_impl.cc
@@ -1,4 +1,5 @@
 #include "source/common/http/utility.h"
+#include "source/common/router/string_accessor_impl.h"
 #include "source/extensions/dynamic_modules/abi.h"
 #include "source/extensions/filters/http/dynamic_modules/filter.h"
 
@@ -371,6 +372,48 @@ bool envoy_dynamic_module_callback_http_get_dynamic_metadata_string(
   const auto& value = key_metadata->string_value();
   *result = const_cast<char*>(value.data());
   *result_length = value.size();
+  return true;
+}
+
+bool envoy_dynamic_module_callback_http_set_filter_state_string(
+  envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr,
+  envoy_dynamic_module_type_buffer_module_ptr key_ptr, size_t key_length,
+  envoy_dynamic_module_type_buffer_module_ptr value_ptr, size_t value_length) {
+  auto filter = static_cast<DynamicModuleHttpFilter*>(filter_envoy_ptr);
+  auto stream_info = filter->streamInfo();
+  if (!stream_info) {
+    ENVOY_LOG_TO_LOGGER(Envoy::Logger::Registry::getLog(Envoy::Logger::Id::dynamic_modules), debug,
+                        "stream info is not available");
+    return false;
+  }
+  absl::string_view key_view(static_cast<const char*>(key_ptr), key_length);
+  absl::string_view value_view(static_cast<const char*>(value_ptr), value_length);
+  stream_info->filterState()->setData(key_view, std::make_unique<Router::StringAccessorImpl>(value_view),
+                                     StreamInfo::FilterState::StateType::ReadOnly);
+  return true;
+}
+
+bool envoy_dynamic_module_callback_http_get_filter_state_string(
+  envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr,
+  envoy_dynamic_module_type_buffer_module_ptr key_ptr, size_t key_length,
+  envoy_dynamic_module_type_buffer_envoy_ptr* result, size_t* result_length) {
+  auto filter = static_cast<DynamicModuleHttpFilter*>(filter_envoy_ptr);
+  auto stream_info = filter->streamInfo();
+  if (!stream_info) {
+    ENVOY_LOG_TO_LOGGER(Envoy::Logger::Registry::getLog(Envoy::Logger::Id::dynamic_modules), debug,
+                        "stream info is not available");
+    return false;
+  }
+  absl::string_view key_view(static_cast<const char*>(key_ptr), key_length);
+  auto filter_state = stream_info->filterState()->getDataReadOnly<Router::StringAccessor>(key_view);
+  if (!filter_state) {
+    ENVOY_LOG_TO_LOGGER(Envoy::Logger::Registry::getLog(Envoy::Logger::Id::dynamic_modules), debug,
+                        fmt::format("key not found in filter state", key_view));
+    return false;
+  }
+  auto str = filter_state->asString();
+  *result = const_cast<char*>(str.data());
+  *result_length = str.size();
   return true;
 }
 

--- a/source/extensions/filters/http/dynamic_modules/abi_impl.cc
+++ b/source/extensions/filters/http/dynamic_modules/abi_impl.cc
@@ -376,9 +376,9 @@ bool envoy_dynamic_module_callback_http_get_dynamic_metadata_string(
 }
 
 bool envoy_dynamic_module_callback_http_set_filter_state_string(
-  envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr,
-  envoy_dynamic_module_type_buffer_module_ptr key_ptr, size_t key_length,
-  envoy_dynamic_module_type_buffer_module_ptr value_ptr, size_t value_length) {
+    envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr,
+    envoy_dynamic_module_type_buffer_module_ptr key_ptr, size_t key_length,
+    envoy_dynamic_module_type_buffer_module_ptr value_ptr, size_t value_length) {
   auto filter = static_cast<DynamicModuleHttpFilter*>(filter_envoy_ptr);
   auto stream_info = filter->streamInfo();
   if (!stream_info) {
@@ -388,15 +388,16 @@ bool envoy_dynamic_module_callback_http_set_filter_state_string(
   }
   absl::string_view key_view(static_cast<const char*>(key_ptr), key_length);
   absl::string_view value_view(static_cast<const char*>(value_ptr), value_length);
-  stream_info->filterState()->setData(key_view, std::make_unique<Router::StringAccessorImpl>(value_view),
-                                     StreamInfo::FilterState::StateType::ReadOnly);
+  stream_info->filterState()->setData(key_view,
+                                      std::make_unique<Router::StringAccessorImpl>(value_view),
+                                      StreamInfo::FilterState::StateType::ReadOnly);
   return true;
 }
 
 bool envoy_dynamic_module_callback_http_get_filter_state_string(
-  envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr,
-  envoy_dynamic_module_type_buffer_module_ptr key_ptr, size_t key_length,
-  envoy_dynamic_module_type_buffer_envoy_ptr* result, size_t* result_length) {
+    envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr,
+    envoy_dynamic_module_type_buffer_module_ptr key_ptr, size_t key_length,
+    envoy_dynamic_module_type_buffer_envoy_ptr* result, size_t* result_length) {
   auto filter = static_cast<DynamicModuleHttpFilter*>(filter_envoy_ptr);
   auto stream_info = filter->streamInfo();
   if (!stream_info) {

--- a/test/extensions/dynamic_modules/http/BUILD
+++ b/test/extensions/dynamic_modules/http/BUILD
@@ -45,6 +45,7 @@ envoy_cc_test(
     # http_mocks needs this.
     rbe_pool = "6gig",
     deps = [
+        "//source/common/router:string_accessor_lib",
         "//source/extensions/filters/http/dynamic_modules:abi_impl",
         "//source/extensions/filters/http/dynamic_modules:filter_lib",
         "//test/extensions/dynamic_modules:util",

--- a/test/extensions/dynamic_modules/http/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/http/abi_impl_test.cc
@@ -482,6 +482,46 @@ TEST(ABIImpl, dynamic_metadata) {
       &filter, namespace_ptr, namespace_length, key_ptr, key_length, &result_number));
 }
 
+TEST(ABIImpl, filter_state) {
+    DynamicModuleHttpFilter filter{nullptr};
+    const std::string key_str = "key";
+    envoy_dynamic_module_type_buffer_module_ptr key_ptr = const_cast<char*>(key_str.data());
+    size_t key_length = key_str.size();
+    const std::string value_str = "value";
+    envoy_dynamic_module_type_buffer_module_ptr value_ptr = const_cast<char*>(value_str.data());
+    size_t value_length = value_str.size();
+    char* result_str_ptr = nullptr;
+    size_t result_str_length = 0;
+
+    // No stream info.
+    EXPECT_FALSE(envoy_dynamic_module_callback_http_set_filter_state_string(
+        &filter, key_ptr, key_length, value_ptr, value_length));
+    EXPECT_FALSE(envoy_dynamic_module_callback_http_get_filter_state_string(
+        &filter, key_ptr, key_length, &result_str_ptr, &result_str_length));
+
+    // With stream info but non existing key.
+    const char* non_existing_key = "non_existing";
+    envoy_dynamic_module_type_buffer_module_ptr non_existing_key_ptr =
+        const_cast<char*>(non_existing_key);
+    size_t non_existing_key_length = strlen(non_existing_key);
+    Http::MockStreamDecoderFilterCallbacks callbacks;
+    StreamInfo::MockStreamInfo stream_info;
+    EXPECT_CALL(callbacks, streamInfo()).WillRepeatedly(testing::ReturnRef(stream_info));
+    EXPECT_CALL(stream_info, filterState())
+        .WillRepeatedly(testing::ReturnRef(stream_info.filter_state_));
+    filter.setDecoderFilterCallbacks(callbacks);
+    EXPECT_TRUE(envoy_dynamic_module_callback_http_set_filter_state_string(
+        &filter, key_ptr, key_length, value_ptr, value_length));
+    EXPECT_FALSE(envoy_dynamic_module_callback_http_get_filter_state_string(
+        &filter, non_existing_key_ptr, non_existing_key_length, &result_str_ptr, &result_str_length));
+
+    // With key.
+    EXPECT_TRUE(envoy_dynamic_module_callback_http_get_filter_state_string(
+        &filter, key_ptr, key_length, &result_str_ptr, &result_str_length));
+    EXPECT_EQ(result_str_length, value_length);
+    EXPECT_EQ(std::string(result_str_ptr, result_str_length), value_str);
+}
+
 std::string
 bufferVectorToString(const std::vector<envoy_dynamic_module_type_envoy_buffer>& buffer_vector) {
   std::string result;

--- a/test/extensions/dynamic_modules/http/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/http/abi_impl_test.cc
@@ -494,9 +494,9 @@ TEST(ABIImpl, filter_state) {
   size_t result_str_length = 0;
 
   // No stream info.
-  EXPECT_FALSE(envoy_dynamic_module_callback_http_set_filter_state_string(
+  EXPECT_FALSE(envoy_dynamic_module_callback_http_set_filter_state_bytes(
       &filter, key_ptr, key_length, value_ptr, value_length));
-  EXPECT_FALSE(envoy_dynamic_module_callback_http_get_filter_state_string(
+  EXPECT_FALSE(envoy_dynamic_module_callback_http_get_filter_state_bytes(
       &filter, key_ptr, key_length, &result_str_ptr, &result_str_length));
 
   // With stream info but non existing key.
@@ -510,13 +510,13 @@ TEST(ABIImpl, filter_state) {
   EXPECT_CALL(stream_info, filterState())
       .WillRepeatedly(testing::ReturnRef(stream_info.filter_state_));
   filter.setDecoderFilterCallbacks(callbacks);
-  EXPECT_TRUE(envoy_dynamic_module_callback_http_set_filter_state_string(
+  EXPECT_TRUE(envoy_dynamic_module_callback_http_set_filter_state_bytes(
       &filter, key_ptr, key_length, value_ptr, value_length));
-  EXPECT_FALSE(envoy_dynamic_module_callback_http_get_filter_state_string(
+  EXPECT_FALSE(envoy_dynamic_module_callback_http_get_filter_state_bytes(
       &filter, non_existing_key_ptr, non_existing_key_length, &result_str_ptr, &result_str_length));
 
   // With key.
-  EXPECT_TRUE(envoy_dynamic_module_callback_http_get_filter_state_string(
+  EXPECT_TRUE(envoy_dynamic_module_callback_http_get_filter_state_bytes(
       &filter, key_ptr, key_length, &result_str_ptr, &result_str_length));
   EXPECT_EQ(result_str_length, value_length);
   EXPECT_EQ(std::string(result_str_ptr, result_str_length), value_str);

--- a/test/extensions/dynamic_modules/http/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/http/abi_impl_test.cc
@@ -483,43 +483,43 @@ TEST(ABIImpl, dynamic_metadata) {
 }
 
 TEST(ABIImpl, filter_state) {
-    DynamicModuleHttpFilter filter{nullptr};
-    const std::string key_str = "key";
-    envoy_dynamic_module_type_buffer_module_ptr key_ptr = const_cast<char*>(key_str.data());
-    size_t key_length = key_str.size();
-    const std::string value_str = "value";
-    envoy_dynamic_module_type_buffer_module_ptr value_ptr = const_cast<char*>(value_str.data());
-    size_t value_length = value_str.size();
-    char* result_str_ptr = nullptr;
-    size_t result_str_length = 0;
+  DynamicModuleHttpFilter filter{nullptr};
+  const std::string key_str = "key";
+  envoy_dynamic_module_type_buffer_module_ptr key_ptr = const_cast<char*>(key_str.data());
+  size_t key_length = key_str.size();
+  const std::string value_str = "value";
+  envoy_dynamic_module_type_buffer_module_ptr value_ptr = const_cast<char*>(value_str.data());
+  size_t value_length = value_str.size();
+  char* result_str_ptr = nullptr;
+  size_t result_str_length = 0;
 
-    // No stream info.
-    EXPECT_FALSE(envoy_dynamic_module_callback_http_set_filter_state_string(
-        &filter, key_ptr, key_length, value_ptr, value_length));
-    EXPECT_FALSE(envoy_dynamic_module_callback_http_get_filter_state_string(
-        &filter, key_ptr, key_length, &result_str_ptr, &result_str_length));
+  // No stream info.
+  EXPECT_FALSE(envoy_dynamic_module_callback_http_set_filter_state_string(
+      &filter, key_ptr, key_length, value_ptr, value_length));
+  EXPECT_FALSE(envoy_dynamic_module_callback_http_get_filter_state_string(
+      &filter, key_ptr, key_length, &result_str_ptr, &result_str_length));
 
-    // With stream info but non existing key.
-    const char* non_existing_key = "non_existing";
-    envoy_dynamic_module_type_buffer_module_ptr non_existing_key_ptr =
-        const_cast<char*>(non_existing_key);
-    size_t non_existing_key_length = strlen(non_existing_key);
-    Http::MockStreamDecoderFilterCallbacks callbacks;
-    StreamInfo::MockStreamInfo stream_info;
-    EXPECT_CALL(callbacks, streamInfo()).WillRepeatedly(testing::ReturnRef(stream_info));
-    EXPECT_CALL(stream_info, filterState())
-        .WillRepeatedly(testing::ReturnRef(stream_info.filter_state_));
-    filter.setDecoderFilterCallbacks(callbacks);
-    EXPECT_TRUE(envoy_dynamic_module_callback_http_set_filter_state_string(
-        &filter, key_ptr, key_length, value_ptr, value_length));
-    EXPECT_FALSE(envoy_dynamic_module_callback_http_get_filter_state_string(
-        &filter, non_existing_key_ptr, non_existing_key_length, &result_str_ptr, &result_str_length));
+  // With stream info but non existing key.
+  const char* non_existing_key = "non_existing";
+  envoy_dynamic_module_type_buffer_module_ptr non_existing_key_ptr =
+      const_cast<char*>(non_existing_key);
+  size_t non_existing_key_length = strlen(non_existing_key);
+  Http::MockStreamDecoderFilterCallbacks callbacks;
+  StreamInfo::MockStreamInfo stream_info;
+  EXPECT_CALL(callbacks, streamInfo()).WillRepeatedly(testing::ReturnRef(stream_info));
+  EXPECT_CALL(stream_info, filterState())
+      .WillRepeatedly(testing::ReturnRef(stream_info.filter_state_));
+  filter.setDecoderFilterCallbacks(callbacks);
+  EXPECT_TRUE(envoy_dynamic_module_callback_http_set_filter_state_string(
+      &filter, key_ptr, key_length, value_ptr, value_length));
+  EXPECT_FALSE(envoy_dynamic_module_callback_http_get_filter_state_string(
+      &filter, non_existing_key_ptr, non_existing_key_length, &result_str_ptr, &result_str_length));
 
-    // With key.
-    EXPECT_TRUE(envoy_dynamic_module_callback_http_get_filter_state_string(
-        &filter, key_ptr, key_length, &result_str_ptr, &result_str_length));
-    EXPECT_EQ(result_str_length, value_length);
-    EXPECT_EQ(std::string(result_str_ptr, result_str_length), value_str);
+  // With key.
+  EXPECT_TRUE(envoy_dynamic_module_callback_http_get_filter_state_string(
+      &filter, key_ptr, key_length, &result_str_ptr, &result_str_length));
+  EXPECT_EQ(result_str_length, value_length);
+  EXPECT_EQ(std::string(result_str_ptr, result_str_length), value_str);
 }
 
 std::string

--- a/test/extensions/dynamic_modules/http/filter_test.cc
+++ b/test/extensions/dynamic_modules/http/filter_test.cc
@@ -1,3 +1,4 @@
+#include "source/common/router/string_accessor_impl.h"
 #include "source/extensions/filters/http/dynamic_modules/filter.h"
 
 #include "test/extensions/dynamic_modules/util.h"
@@ -54,7 +55,7 @@ TEST_P(DynamicModuleTestLanguages, Nop) {
   filter->onDestroy();
 }
 
-TEST(DynamiModulesTest, HeaderCallbacks) {
+TEST(DynamicModulesTest, HeaderCallbacks) {
   const std::string filter_name = "header_callbacks";
   const std::string filter_config = "";
   // TODO: Add non-Rust test program once we have non-Rust SDK.
@@ -101,7 +102,7 @@ TEST(DynamiModulesTest, HeaderCallbacks) {
   filter->onDestroy();
 }
 
-TEST(DynamiModulesTest, DynamicMetadataCallbacks) {
+TEST(DynamicModulesTest, DynamicMetadataCallbacks) {
   const std::string filter_name = "dynamic_metadata_callbacks";
   const std::string filter_config = "";
   // TODO: Add non-Rust test program once we have non-Rust SDK.
@@ -159,7 +160,73 @@ TEST(DynamiModulesTest, DynamicMetadataCallbacks) {
   filter->onDestroy();
 }
 
-TEST(DynamiModulesTest, BodyCallbacks) {
+TEST(DynamicModulesTest, FilterStateCallbacks) {
+  const std::string filter_name = "filter_state_callbacks";
+  const std::string filter_config = "";
+  // TODO: Add non-Rust test program once we have non-Rust SDK.
+  auto dynamic_module = newDynamicModule(testSharedObjectPath("http", "rust"), false);
+  if (!dynamic_module.ok()) {
+    ENVOY_LOG_MISC(debug, "Failed to load dynamic module: {}", dynamic_module.status().message());
+  }
+  EXPECT_TRUE(dynamic_module.ok());
+
+  auto filter_config_or_status =
+      Envoy::Extensions::DynamicModules::HttpFilters::newDynamicModuleHttpFilterConfig(
+          filter_name, filter_config, std::move(dynamic_module.value()));
+  EXPECT_TRUE(filter_config_or_status.ok());
+
+  auto filter = std::make_shared<DynamicModuleHttpFilter>(filter_config_or_status.value());
+  filter->initializeInModuleFilter();
+
+  Http::MockStreamDecoderFilterCallbacks callbacks;
+  StreamInfo::MockStreamInfo stream_info;
+  EXPECT_CALL(callbacks, streamInfo()).WillRepeatedly(testing::ReturnRef(stream_info));
+  EXPECT_CALL(stream_info, filterState())
+      .WillRepeatedly(testing::ReturnRef(stream_info.filter_state_));
+  filter->setDecoderFilterCallbacks(callbacks);
+
+  Http::TestRequestHeaderMapImpl request_headers{};
+  Http::TestRequestTrailerMapImpl request_trailers{};
+  Http::TestResponseHeaderMapImpl response_headers{};
+  Http::TestResponseTrailerMapImpl response_trailers{};
+  Buffer::OwnedImpl data;
+  EXPECT_EQ(FilterHeadersStatus::Continue, filter->decodeHeaders(request_headers, false));
+  EXPECT_EQ(FilterDataStatus::Continue, filter->decodeData(data, false));
+  EXPECT_EQ(FilterTrailersStatus::Continue, filter->decodeTrailers(request_trailers));
+  EXPECT_EQ(FilterHeadersStatus::Continue, filter->encodeHeaders(response_headers, false));
+  EXPECT_EQ(FilterDataStatus::Continue, filter->encodeData(data, false));
+  EXPECT_EQ(FilterTrailersStatus::Continue, filter->encodeTrailers(response_trailers));
+
+  // Check filter state set by the filter during even hooks.
+  const auto* req_header_value = stream_info.filterState()->getDataReadOnly<Router::StringAccessor>("req_header_key");
+  ASSERT_NE(req_header_value, nullptr);
+  EXPECT_EQ(req_header_value->serializeAsString(), "req_header_value");
+  const auto* req_body_value = stream_info.filterState()->getDataReadOnly<Router::StringAccessor>("req_body_key");
+  ASSERT_NE(req_body_value, nullptr);
+  EXPECT_EQ(req_body_value->serializeAsString(), "req_body_value");
+  const auto* req_trailer_value = stream_info.filterState()->getDataReadOnly<Router::StringAccessor>("req_trailer_key");
+  ASSERT_NE(req_trailer_value, nullptr);
+  EXPECT_EQ(req_trailer_value->serializeAsString(), "req_trailer_value");
+  const auto* res_header_value = stream_info.filterState()->getDataReadOnly<Router::StringAccessor>("res_header_key");
+  ASSERT_NE(res_header_value, nullptr);
+  EXPECT_EQ(res_header_value->serializeAsString(), "res_header_value");
+  const auto* res_body_value = stream_info.filterState()->getDataReadOnly<Router::StringAccessor>("res_body_key");
+  ASSERT_NE(res_body_value, nullptr);
+  EXPECT_EQ(res_body_value->serializeAsString(), "res_body_value");
+  const auto* res_trailer_value = stream_info.filterState()->getDataReadOnly<Router::StringAccessor>("res_trailer_key");
+  ASSERT_NE(res_trailer_value, nullptr);
+  EXPECT_EQ(res_trailer_value->serializeAsString(), "res_trailer_value");
+  // There is no filter state named key set by the filter.
+  const auto* value = stream_info.filterState()->getDataReadOnly<Router::StringAccessor>("key");
+  ASSERT_EQ(value, nullptr);
+
+  filter->onStreamComplete();
+  const auto* stream_complete_value = stream_info.filterState()->getDataReadOnly<Router::StringAccessor>("stream_complete_key");
+  ASSERT_NE(stream_complete_value, nullptr);
+  EXPECT_EQ(stream_complete_value->serializeAsString(), "stream_complete_value");
+}
+
+TEST(DynamicModulesTest, BodyCallbacks) {
   const std::string filter_name = "body_callbacks";
   const std::string filter_config = "";
   // TODO: Add non-Rust test program once we have non-Rust SDK.

--- a/test/extensions/dynamic_modules/http/filter_test.cc
+++ b/test/extensions/dynamic_modules/http/filter_test.cc
@@ -198,22 +198,28 @@ TEST(DynamicModulesTest, FilterStateCallbacks) {
   EXPECT_EQ(FilterTrailersStatus::Continue, filter->encodeTrailers(response_trailers));
 
   // Check filter state set by the filter during even hooks.
-  const auto* req_header_value = stream_info.filterState()->getDataReadOnly<Router::StringAccessor>("req_header_key");
+  const auto* req_header_value =
+      stream_info.filterState()->getDataReadOnly<Router::StringAccessor>("req_header_key");
   ASSERT_NE(req_header_value, nullptr);
   EXPECT_EQ(req_header_value->serializeAsString(), "req_header_value");
-  const auto* req_body_value = stream_info.filterState()->getDataReadOnly<Router::StringAccessor>("req_body_key");
+  const auto* req_body_value =
+      stream_info.filterState()->getDataReadOnly<Router::StringAccessor>("req_body_key");
   ASSERT_NE(req_body_value, nullptr);
   EXPECT_EQ(req_body_value->serializeAsString(), "req_body_value");
-  const auto* req_trailer_value = stream_info.filterState()->getDataReadOnly<Router::StringAccessor>("req_trailer_key");
+  const auto* req_trailer_value =
+      stream_info.filterState()->getDataReadOnly<Router::StringAccessor>("req_trailer_key");
   ASSERT_NE(req_trailer_value, nullptr);
   EXPECT_EQ(req_trailer_value->serializeAsString(), "req_trailer_value");
-  const auto* res_header_value = stream_info.filterState()->getDataReadOnly<Router::StringAccessor>("res_header_key");
+  const auto* res_header_value =
+      stream_info.filterState()->getDataReadOnly<Router::StringAccessor>("res_header_key");
   ASSERT_NE(res_header_value, nullptr);
   EXPECT_EQ(res_header_value->serializeAsString(), "res_header_value");
-  const auto* res_body_value = stream_info.filterState()->getDataReadOnly<Router::StringAccessor>("res_body_key");
+  const auto* res_body_value =
+      stream_info.filterState()->getDataReadOnly<Router::StringAccessor>("res_body_key");
   ASSERT_NE(res_body_value, nullptr);
   EXPECT_EQ(res_body_value->serializeAsString(), "res_body_value");
-  const auto* res_trailer_value = stream_info.filterState()->getDataReadOnly<Router::StringAccessor>("res_trailer_key");
+  const auto* res_trailer_value =
+      stream_info.filterState()->getDataReadOnly<Router::StringAccessor>("res_trailer_key");
   ASSERT_NE(res_trailer_value, nullptr);
   EXPECT_EQ(res_trailer_value->serializeAsString(), "res_trailer_value");
   // There is no filter state named key set by the filter.
@@ -221,7 +227,8 @@ TEST(DynamicModulesTest, FilterStateCallbacks) {
   ASSERT_EQ(value, nullptr);
 
   filter->onStreamComplete();
-  const auto* stream_complete_value = stream_info.filterState()->getDataReadOnly<Router::StringAccessor>("stream_complete_key");
+  const auto* stream_complete_value =
+      stream_info.filterState()->getDataReadOnly<Router::StringAccessor>("stream_complete_key");
   ASSERT_NE(stream_complete_value, nullptr);
   EXPECT_EQ(stream_complete_value->serializeAsString(), "stream_complete_value");
 }


### PR DESCRIPTION
Commit Message: add filter state support for dynamic modules http filter
Additional Description: With filter state support, dynamic modules rust filter can get filter state from envoy
Risk Level: low
Testing: unit test
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
