### PR TITLE
chore: move expiration format for use in multiple providers

### DIFF
--- a/source/extensions/common/aws/credential_providers/container_credentials_provider.h
+++ b/source/extensions/common/aws/credential_providers/container_credentials_provider.h
@@ -1,6 +1,4 @@
 #pragma once
-
-#include "source/extensions/common/aws/cached_credentials_provider_base.h"
 #include "source/extensions/common/aws/metadata_credentials_provider_base.h"
 
 namespace Envoy {
@@ -12,7 +10,6 @@ constexpr char AWS_CONTAINER_CREDENTIALS_RELATIVE_URI[] = "AWS_CONTAINER_CREDENT
 constexpr char AWS_CONTAINER_CREDENTIALS_FULL_URI[] = "AWS_CONTAINER_CREDENTIALS_FULL_URI";
 constexpr char AWS_CONTAINER_AUTHORIZATION_TOKEN[] = "AWS_CONTAINER_AUTHORIZATION_TOKEN";
 constexpr char AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE[] = "AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE";
-constexpr char EXPIRATION_FORMAT[] = "%E4Y-%m-%dT%H:%M:%S%z";
 constexpr char CONTAINER_EXPIRATION[] = "Expiration";
 constexpr char CONTAINER_METADATA_HOST[] = "169.254.170.2:80";
 constexpr char CONTAINER_METADATA_CLUSTER[] = "ecs_task_metadata_server_internal";

--- a/source/extensions/common/aws/metadata_credentials_provider_base.h
+++ b/source/extensions/common/aws/metadata_credentials_provider_base.h
@@ -14,6 +14,7 @@ constexpr std::chrono::seconds REFRESH_GRACE_PERIOD{5};
 constexpr char ACCESS_KEY_ID[] = "AccessKeyId";
 constexpr char SECRET_ACCESS_KEY[] = "SecretAccessKey";
 constexpr char TOKEN[] = "Token";
+constexpr char EXPIRATION_FORMAT[] = "%E4Y-%m-%dT%H:%M:%S%z";
 
 #define ALL_METADATACREDENTIALSPROVIDER_STATS(COUNTER, GAUGE)                                      \
   COUNTER(credential_refreshes_performed)                                                          \
@@ -130,7 +131,7 @@ protected:
   // Are credentials pending?
   std::atomic<bool> credentials_pending_ = true;
   Thread::MutexBasicLockable mu_;
-  std::list<CredentialSubscriberCallbacks*> credentials_subscribers_ ABSL_GUARDED_BY(mu_) = {};
+  std::list<CredentialSubscriberCallbacks*> credentials_subscribers_ ABSL_GUARDED_BY(mu_);
 };
 
 } // namespace Aws


### PR DESCRIPTION
Commit Message: chore: move expiration format for use in multiple providers
Additional Description: Minor fix to relocate a common string from inside container credential provider to metadata credential provider, and address a couple of clang18 warnings
Risk Level: Negligible
Testing: 
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
