### PR TITLE
health_check: clarify docs about missing cluster and add test

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -251,7 +251,7 @@ extensions/filters/http/oauth2 @derekargueta @mattklein123
 /*/extensions/compression/zstd @rainingmaster @mattklein123
 # cel
 /*/extensions/access_loggers/filters/cel @kyessenov @douglas-reid @adisuissa
-# health cehck
+# health check
 /*/extensions/filters/http/health_check @mattklein123 @adisuissa
 # lua
 /*/extensions/filters/http/lua @mattklein123 @wbpcode

--- a/api/envoy/extensions/filters/http/health_check/v3/health_check.proto
+++ b/api/envoy/extensions/filters/http/health_check/v3/health_check.proto
@@ -38,7 +38,8 @@ message HealthCheck {
 
   // If operating in non-pass-through mode, specifies a set of upstream cluster
   // names and the minimum percentage of servers in each of those clusters that
-  // must be healthy or degraded in order for the filter to return a 200.
+  // must be healthy or degraded in order for the filter to return a 200. If any of
+  // the clusters configured here does not exist, the filter will not return a 200.
   //
   // .. note::
   //


### PR DESCRIPTION
The filter has always treated a missing cluster in `cluster_min_healthy_percentages` as a failure. Documenting and adding a test for this case.

Risk Level: None
Testing: added test