### PR TITLE
Configurable print options for reverse transcoder

### DIFF
--- a/api/envoy/extensions/filters/http/grpc_json_reverse_transcoder/v3/transcoder.proto
+++ b/api/envoy/extensions/filters/http/grpc_json_reverse_transcoder/v3/transcoder.proto
@@ -17,7 +17,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // gRPC-JSON reverse transcoder :ref:`configuration overview <config_http_filters_grpc_json_reverse_transcoder>`.
 // [#extension: envoy.filters.http.grpc_json_reverse_transcoder]
 
-// [#next-free-field: 6]
+// [#next-free-field: 7]
 // ``GrpcJsonReverseTranscoder`` is the filter configuration for the gRPC JSON
 // reverse transcoder. The reverse transcoder acts as a bridge between a gRPC
 // client and an HTTP/JSON server, converting the gRPC request into HTTP/JSON
@@ -26,6 +26,68 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // :ref:`grpc_json_transcoder filter <config_http_filters_grpc_json_transcoder>`,
 // allowing a gRPC client to communicate with an HTTP/JSON server.
 message GrpcJsonReverseTranscoder {
+  message PrintOptions {
+    // Whether to always print primitive fields. By default primitive
+    // fields with default values will be omitted in JSON output. For
+    // example, an int32 field set to 0 will be omitted. Setting this flag to
+    // true will override the default behavior and print primitive fields
+    // regardless of their values. Defaults to false.
+    bool always_print_primitive_fields = 1;
+
+    // Whether to always print enums as ints. By default they are rendered
+    // as strings. Defaults to false.
+    bool always_print_enums_as_ints = 2;
+
+    // Whether to convert the proto field names to ``json_name`` annotation value, or lower camel case,
+    // in absence of ``json_name``. By default the field names will be preserved after conversion.
+    // Setting this flag will convert the field names to their canonical form. Defaults to false.
+    //
+    // Example:
+    //
+    // .. code-block:: proto
+    //
+    //     message Author {
+    //       int64 id = 1;
+    //       enum Gender {
+    //         UNKNOWN = 0;
+    //         MALE = 1;
+    //         FEMALE = 2;
+    //       };
+    //       Gender gender = 2;
+    //       string first_name = 3;
+    //       string last_name = 4 [json_name = "lname"];
+    //     }
+    //
+    // The above proto message after being transcoded to JSON with
+    // ``use_canonical_field_names`` set to ``false`` will have the
+    // field names same as in the proto message, as follows:
+    //
+    // .. code-block:: json
+    //
+    //     {
+    //       "id": "12345",
+    //       "gender": "MALE",
+    //       "first_name": "John",
+    //       "last_name": "Doe"
+    //     }
+    //
+    // and with the ``use_canonical_field_names`` set to ``true``, the
+    // transcoded JSON will have ``first_name`` converted to camelCase
+    // and ``last_name`` converted to its ``json_name`` annotation value,
+    // as follows:
+    //
+    // .. code-block:: json
+    //
+    //     {
+    //       "id": "12345",
+    //       "gender": "MALE",
+    //       "firstName": "John",
+    //       "lname": "Doe"
+    //     }
+    //
+    bool use_canonical_field_names = 3;
+  }
+
   // Supplies the filename of
   // :ref:`the proto descriptor set
   // <config_grpc_json_reverse_transcoder_generate_proto_descriptor_set>` for the gRPC services.
@@ -58,4 +120,9 @@ message GrpcJsonReverseTranscoder {
 
   // The name of the header field that has the API version of the request.
   string api_version_header = 5;
+
+  // Control options for upstream request JSON. These options are passed directly to
+  // `JsonPrintOptions <https://developers.google.com/protocol-buffers/docs/reference/cpp/
+  // google.protobuf.util.json_util#JsonPrintOptions>`_.
+  PrintOptions request_json_print_options = 6;
 }

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -5,6 +5,9 @@ behavior_changes:
 
 minor_behavior_changes:
 # *Changes that may cause incompatibilities for some users, but should not for most*
+- area: grpc-json
+  change: |
+    Make the :ref:`gRPC JSON transcoder filter's <config_http_filters_grpc_json_reverse_transcoder>` json print options configurable.
 
 bug_fixes:
 # *Changes expected to improve the state of the world and are unlikely to have negative effects*

--- a/docs/root/configuration/http/http_filters/grpc_json_reverse_transcoder_filter.rst
+++ b/docs/root/configuration/http/http_filters/grpc_json_reverse_transcoder_filter.rst
@@ -23,8 +23,10 @@ JSON mapping
 
 The protobuf to JSON mapping is defined `here <https://developers.google.com/protocol-buffers/docs/proto3#json>`_.
 
-* **NOTE:** The gRPC-JSON reverse transcoder ignores the ``json_name`` option and uses the proto field names
-  as the JSON names by default.
+* **NOTE:** The gRPC-JSON reverse transcoder uses the proto field names as the JSON field names by default.
+  This behavior can be overridden by setting ``use_canonical_field_names`` field to ``true``.
+  With this the transcoder will convert the proto field names to ``json_name`` annotation value,  or lower camel case
+  in absence of ``json_name`` annotation.
 
 .. _config_grpc_json_reverse_transcoder_generate_proto_descriptor_set:
 

--- a/source/extensions/filters/http/grpc_json_reverse_transcoder/filter_config.h
+++ b/source/extensions/filters/http/grpc_json_reverse_transcoder/filter_config.h
@@ -24,6 +24,7 @@
 // libraries as the grpc_json_transcoder filter, so the request and response
 // translators are reversed.
 using RequestTranslator = ::google::grpc::transcoding::ResponseToJsonTranslator;
+using RequestTranslateOptions = ::google::grpc::transcoding::JsonResponseTranslateOptions;
 using ResponseTranslator = ::google::grpc::transcoding::JsonRequestTranslator;
 using ::google::grpc::transcoding::MessageStream;
 using ::google::grpc::transcoding::Transcoder;
@@ -83,6 +84,11 @@ public:
                    TranscoderInputStream& request_input,
                    TranscoderInputStream& response_input) const;
 
+  // Changes the body field to its `json_name` value or to camelCase if the filter
+  // is not configured to preserve the proto field names.
+  absl::StatusOr<std::string> ChangeBodyFieldName(absl::string_view path,
+                                                  absl::string_view body_field) const;
+
   absl::optional<uint32_t> max_request_body_size_;
   absl::optional<uint32_t> max_response_body_size_;
   absl::optional<std::string> api_version_header_;
@@ -90,6 +96,7 @@ public:
 private:
   Protobuf::DescriptorPool descriptor_pool_;
   std::unique_ptr<TypeHelper> type_helper_;
+  RequestTranslateOptions request_translate_options_;
 };
 
 } // namespace GrpcJsonReverseTranscoder

--- a/test/proto/bookstore.proto
+++ b/test/proto/bookstore.proto
@@ -24,6 +24,13 @@ service Bookstore {
       body: "shelf"
     };
   }
+  // Update an existing shelf
+  rpc UpdateShelf(UpdateShelfRequest) returns (Shelf) {
+    option (google.api.http) = {
+      put: "/shelves/{new_shelf.id}"
+      body: "new_shelf"
+    };
+  }
   // Creates a new shelf in the bookstore via a mapped package.service.method as its HTTP path.
   rpc CreateShelfWithPackageServiceAndMethod(CreateShelfRequest) returns (Shelf) {
     option (google.api.http) = {
@@ -97,6 +104,13 @@ service Bookstore {
   rpc GetAuthor(GetAuthorRequest) returns (Author) {
     option (google.api.http) = {
       get: "/authors/{author}"
+    };
+  }
+  // Updates an Author
+  rpc UpdateAuthor(UpdateAuthorRequest) returns (Author) {
+    option (google.api.http) = {
+      patch: "/authors/{author.id}"
+      body: "author"
     };
   }
   // Echo an Author to test enum encode/decode.
@@ -200,6 +214,15 @@ service ServiceWithResponseBody {
   }
 }
 
+service ServiceWithInvalidRequestBody {
+  rpc UpdateAuthor(UpdateAuthorRequest) returns (Author) {
+    option (google.api.http) = {
+      patch: "/authors/{author.id}"
+      body: "authors"
+    };
+  }
+}
+
 service ServiceWithInvalidRequestBodyPath {
   rpc EchoStruct(EchoStructReqResp) returns (EchoStructReqResp) {
     option (google.api.http) = {
@@ -278,6 +301,12 @@ message CreateShelfRequest {
   Shelf shelf = 1;
 }
 
+// Request message for UpdateShelf method.
+message UpdateShelfRequest {
+  // The self resource to update
+  Shelf new_shelf = 1;
+}
+
 // Request message for GetShelf method.
 message GetShelfRequest {
   // The ID of the shelf resource to retrieve.
@@ -348,6 +377,10 @@ message DeleteBookRequest {
 message GetAuthorRequest {
   // The ID of the author resource to retrieve.
   int64 author = 1;
+}
+
+message UpdateAuthorRequest {
+  Author author = 1 [json_name = "authorDetails"];
 }
 
 message EchoBodyRequest {


### PR DESCRIPTION
Commit Message: Make json print option configurable for gRPC JSON reverse transcoder
Additional Description: The print options for transcoding from protobuf to json were initially set to a default value with no optional available for the user to configure them. This PR make those options configurable via the filter config.
Risk Level: Low
Testing: Add the unit tests to test the feature.
Docs Changes: Removes the details about the restriction.
Release Notes: Added the notes about this to the changelog.
Platform Specific Features: N/A