### PR TITLE
listener: advise setting max_connections_accept_per_socket_event

### DIFF
--- a/api/envoy/config/listener/v3/listener.proto
+++ b/api/envoy/config/listener/v3/listener.proto
@@ -355,8 +355,8 @@ message Listener {
   //
   // .. note::
   //
-  // It is recommended to lower this value for better overload management and reduced per-event cost.
-  // Setting it to 1 is a viable option with no noticeable impact on performance.
+  //  It is recommended to lower this value for better overload management and reduced per-event cost.
+  //  Setting it to 1 is a viable option with no noticeable impact on performance.
   google.protobuf.UInt32Value max_connections_to_accept_per_socket_event = 34
       [(validate.rules).uint32 = {gt: 0}];
 

--- a/api/envoy/config/listener/v3/listener.proto
+++ b/api/envoy/config/listener/v3/listener.proto
@@ -352,6 +352,11 @@ message Listener {
   // accepted in later event loop iterations.
   // If no value is provided Envoy will accept all connections pending accept
   // from the kernel.
+  //
+  // .. note::
+  //
+  // It is recommended to lower this value for better overload management and reduced per-event cost.
+  // Setting it to 1 is a viable option with no noticeable impact on performance.
   google.protobuf.UInt32Value max_connections_to_accept_per_socket_event = 34
       [(validate.rules).uint32 = {gt: 0}];
 


### PR DESCRIPTION
setting max_connections_accept_per_socket_event value will limit the cost of per event and benefit overload management without impact of the performance. 

Commit Message:
Additional Description:
Risk Level: low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
