### PR TITLE
Prevent out-of-bounds access in `EdfLoadBalancerBase::refresh()`.

### DIFF
--- a/source/extensions/load_balancing_policies/client_side_weighted_round_robin/client_side_weighted_round_robin_lb.h
+++ b/source/extensions/load_balancing_policies/client_side_weighted_round_robin/client_side_weighted_round_robin_lb.h
@@ -138,7 +138,7 @@ public:
   // Thread local shim to store callbacks for weight updates of worker local lb.
   class ThreadLocalShim : public Envoy::ThreadLocal::ThreadLocalObject {
   public:
-    Common::CallbackManager<uint32_t> apply_weights_cb_helper_;
+    Common::CallbackManager<> apply_weights_cb_helper_;
   };
 
   // This class is used to handle the load balancing on the worker thread.
@@ -171,7 +171,7 @@ public:
 
     bool recreateOnHostChange() const override { return false; }
 
-    void applyWeightsToAllWorkers(uint32_t priority);
+    void applyWeightsToAllWorkers();
 
     std::unique_ptr<Envoy::ThreadLocal::TypedSlot<ThreadLocalShim>> tls_;
 

--- a/source/extensions/load_balancing_policies/common/load_balancer_impl.cc
+++ b/source/extensions/load_balancing_policies/common/load_balancer_impl.cc
@@ -920,6 +920,10 @@ void EdfLoadBalancerBase::recalculateHostsInSlowStart(const HostVector& hosts) {
 }
 
 void EdfLoadBalancerBase::refresh(uint32_t priority) {
+  // It is possible that the hostSet for the given priority has been removed.
+  if (priority >= priority_set_.hostSetsPerPriority().size()) {
+    return;
+  }
   const auto add_hosts_source = [this](HostsSource source, const HostVector& hosts) {
     // Nuke existing scheduler if it exists.
     auto& scheduler = scheduler_[source] = Scheduler{};


### PR DESCRIPTION
- Add check to `EdfLoadBalancerBase::refresh()` to ensure that `priority_set_` has a `HostSet` for passed `priority`.
- Don't pass `priority` from the main thread to `ClientSideWeightedRoundRobin::WorkerLocalLb` to avoid races.
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Risk Level: Low
Testing: Added `ClientSideWeightedRoundRobinLoadBalancerTest::RefreshWorkerWithRemovedHostSetsForPriority`
Docs Changes: n/a

#34777 
