### PR TITLE
quic: Populate counter downstream_cx_tx_bytes_total for HTTP/3.

### DIFF
--- a/source/common/quic/BUILD
+++ b/source/common/quic/BUILD
@@ -383,6 +383,7 @@ envoy_cc_library(
         "//source/common/network:listen_socket_lib",
         "//source/common/quic:envoy_quic_utils_lib",
         "@com_github_google_quiche//:quic_core_connection_lib",
+        "@com_github_google_quiche//:quic_core_packet_writer_lib",
         "@com_github_google_quiche//:quic_core_packets_lib",
     ],
 )

--- a/source/common/quic/envoy_quic_server_connection.h
+++ b/source/common/quic/envoy_quic_server_connection.h
@@ -157,6 +157,8 @@ protected:
   void OnEffectivePeerMigrationValidated(bool is_migration_linkable) override;
 
 private:
+  // Called when a packet is written to the packet writer.
+  void OnWritePacketDone(size_t packet_size, const quic::WriteResult& result);
   std::unique_ptr<QuicListenerFilterManagerImpl> listener_filter_manager_;
   bool first_packet_received_ = false;
 };

--- a/source/common/quic/quic_network_connection.h
+++ b/source/common/quic/quic_network_connection.h
@@ -43,7 +43,10 @@ public:
   uint64_t id() const;
 
 protected:
+  // REQUIRES: hasConnectionStats() == true.
   Network::Connection::ConnectionStats& connectionStats() const { return *connection_stats_; }
+
+  bool hasConnectionStats() const { return connection_stats_ != nullptr; }
 
   void setConnectionSocket(Network::ConnectionSocketPtr&& connection_socket) {
     connection_sockets_.push_back(std::move(connection_socket));

--- a/test/common/quic/envoy_quic_dispatcher_test.cc
+++ b/test/common/quic/envoy_quic_dispatcher_test.cc
@@ -33,6 +33,7 @@
 #include "quiche/quic/test_tools/quic_dispatcher_peer.h"
 #include "quiche/quic/test_tools/quic_test_utils.h"
 
+using testing::AnyNumber;
 using testing::Invoke;
 using testing::Return;
 using testing::ReturnRef;
@@ -211,6 +212,7 @@ public:
           // Stop iteration to avoid calling getRead/WriteBuffer().
           .WillOnce(Return(Network::FilterStatus::StopIteration));
       EXPECT_CALL(network_connection_callbacks_, onEvent(Network::ConnectionEvent::LocalClose));
+      EXPECT_CALL(write_total_, add(_)).Times(AnyNumber());
     }
 
   private:
@@ -219,7 +221,8 @@ public:
     Network::MockConnectionCallbacks network_connection_callbacks_;
     testing::StrictMock<Stats::MockCounter> read_total_;
     testing::StrictMock<Stats::MockGauge> read_current_;
-    testing::StrictMock<Stats::MockCounter> write_total_;
+    // Currently QUIC only populates write_total_.
+    testing::NiceMock<Stats::MockCounter> write_total_;
     testing::StrictMock<Stats::MockGauge> write_current_;
 
     Filter::NetworkFilterFactoriesList filter_factory_;
@@ -271,7 +274,8 @@ TEST_P(EnvoyQuicDispatcherTest, CloseConnectionDuringNetworkFilterInstallation) 
   Network::MockConnectionCallbacks network_connection_callbacks;
   testing::StrictMock<Stats::MockCounter> read_total;
   testing::StrictMock<Stats::MockGauge> read_current;
-  testing::StrictMock<Stats::MockCounter> write_total;
+  testing::NiceMock<Stats::MockCounter> write_total;
+  EXPECT_CALL(write_total, add(_)).Times(AnyNumber());
   testing::StrictMock<Stats::MockGauge> write_current;
 
   Filter::NetworkFilterFactoriesList filter_factory;
@@ -433,7 +437,8 @@ TEST_P(EnvoyQuicDispatcherTest, CloseWithGivenFilterChain) {
   Network::MockConnectionCallbacks network_connection_callbacks;
   testing::StrictMock<Stats::MockCounter> read_total;
   testing::StrictMock<Stats::MockGauge> read_current;
-  testing::StrictMock<Stats::MockCounter> write_total;
+  testing::NiceMock<Stats::MockCounter> write_total;
+  EXPECT_CALL(write_total, add(_)).Times(AnyNumber());
   testing::StrictMock<Stats::MockGauge> write_current;
 
   Filter::NetworkFilterFactoriesList filter_factory;

--- a/test/common/quic/envoy_quic_server_session_test.cc
+++ b/test/common/quic/envoy_quic_server_session_test.cc
@@ -185,6 +185,7 @@ public:
           return quic::WriteResult{quic::WRITE_STATUS_OK, static_cast<int>(buf_len)};
         }));
     ON_CALL(crypto_stream_helper_, CanAcceptClientHello(_, _, _, _, _)).WillByDefault(Return(true));
+    EXPECT_CALL(write_total_, add(_)).Times(AnyNumber());
     EXPECT_CALL(*debug_visitor_factory_.mock_debug_visitor_, OnConnectionClosed(_, _));
   }
 
@@ -273,7 +274,8 @@ protected:
   Http::MockServerConnectionCallbacks http_connection_callbacks_;
   testing::StrictMock<Stats::MockCounter> read_total_;
   testing::StrictMock<Stats::MockGauge> read_current_;
-  testing::StrictMock<Stats::MockCounter> write_total_;
+  // Currently QUIC only populates write_total_.
+  testing::NiceMock<Stats::MockCounter> write_total_;
   testing::StrictMock<Stats::MockGauge> write_current_;
   Http::ServerConnectionPtr http_connection_;
   Http::Http3::CodecStats stats_;


### PR DESCRIPTION
Commit Message: Populate counter downstream_cx_tx_bytes_total for HTTP/3.
Additional Description:
Risk Level: Low
Testing: Added DownstreamProtocolIntegrationTest.DownstreamCxStats
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
