### PR TITLE
quic: Update the reset reason mappings for QUIC_STREAM_CANCELLED

### DIFF
--- a/source/common/quic/envoy_quic_utils.cc
+++ b/source/common/quic/envoy_quic_utils.cc
@@ -95,7 +95,7 @@ quic::QuicRstStreamErrorCode envoyResetReasonToQuicRstError(Http::StreamResetRea
   case Http::StreamResetReason::LocalReset:
     return quic::QUIC_STREAM_REQUEST_REJECTED;
   case Http::StreamResetReason::OverloadManager:
-    return quic::QUIC_STREAM_CANCELLED;
+    return quic::QUIC_STREAM_EXCESSIVE_LOAD;
   case Http::StreamResetReason::ProtocolError:
     return quic::QUIC_STREAM_GENERAL_PROTOCOL_ERROR;
   case Http::StreamResetReason::Overflow:
@@ -121,12 +121,11 @@ Http::StreamResetReason quicRstErrorToEnvoyLocalResetReason(quic::QuicRstStreamE
   case quic::QUIC_STREAM_CONNECTION_ERROR:
     return Http::StreamResetReason::LocalConnectionFailure;
   case quic::QUIC_STREAM_NO_ERROR:
+  case quic::QUIC_STREAM_CANCELLED:
   case quic::QUIC_STREAM_EXCESSIVE_LOAD:
   case quic::QUIC_HEADERS_TOO_LARGE:
   case quic::QUIC_STREAM_REQUEST_REJECTED:
     return Http::StreamResetReason::LocalReset;
-  case quic::QUIC_STREAM_CANCELLED:
-    return Http::StreamResetReason::OverloadManager;
   default:
     return Http::StreamResetReason::ProtocolError;
   }
@@ -141,13 +140,12 @@ Http::StreamResetReason quicRstErrorToEnvoyRemoteResetReason(quic::QuicRstStream
   case quic::QUIC_STREAM_CONNECT_ERROR:
     return Http::StreamResetReason::ConnectError;
   case quic::QUIC_STREAM_NO_ERROR:
+  case quic::QUIC_STREAM_CANCELLED:
   case quic::QUIC_STREAM_REQUEST_REJECTED:
   case quic::QUIC_STREAM_UNKNOWN_APPLICATION_ERROR_CODE:
   case quic::QUIC_STREAM_EXCESSIVE_LOAD:
   case quic::QUIC_HEADERS_TOO_LARGE:
     return Http::StreamResetReason::RemoteReset;
-  case quic::QUIC_STREAM_CANCELLED:
-    return Http::StreamResetReason::OverloadManager;
   case quic::QUIC_STREAM_GENERAL_PROTOCOL_ERROR:
   default:
     return Http::StreamResetReason::ProtocolError;

--- a/test/common/quic/envoy_quic_utils_test.cc
+++ b/test/common/quic/envoy_quic_utils_test.cc
@@ -265,6 +265,8 @@ TEST(EnvoyQuicUtilsTest, HeaderMapMaxSizeLimit) {
 TEST(EnvoyQuicUtilsTest, EnvoyResetReasonToQuicResetErrorCodeImpossibleCases) {
   EXPECT_ENVOY_BUG(envoyResetReasonToQuicRstError(Http::StreamResetReason::Overflow),
                    "Resource overflow ");
+  EXPECT_ENVOY_BUG(envoyResetReasonToQuicRstError(Http::StreamResetReason::OverflowManager),
+                   "Resource overflow ");
   EXPECT_ENVOY_BUG(
       envoyResetReasonToQuicRstError(Http::StreamResetReason::RemoteRefusedStreamReset),
       "Remote reset ");
@@ -276,10 +278,14 @@ TEST(EnvoyQuicUtilsTest, EnvoyResetReasonToQuicResetErrorCodeImpossibleCases) {
 TEST(EnvoyQuicUtilsTest, QuicResetErrorToEnvoyResetReason) {
   EXPECT_EQ(quicRstErrorToEnvoyLocalResetReason(quic::QUIC_STREAM_NO_ERROR),
             Http::StreamResetReason::LocalReset);
+  EXPECT_EQ(quicRstErrorToEnvoyLocalResetReason(quic::QUIC_STREAM_CANCELLED),
+            Http::StreamResetReason::LocalReset);
   EXPECT_EQ(quicRstErrorToEnvoyRemoteResetReason(quic::QUIC_STREAM_CONNECTION_ERROR),
             Http::StreamResetReason::ConnectionTermination);
   EXPECT_EQ(quicRstErrorToEnvoyRemoteResetReason(quic::QUIC_STREAM_CONNECT_ERROR),
             Http::StreamResetReason::ConnectError);
+  EXPECT_EQ(quicRstErrorToEnvoyRemoteResetReason(quic::QUIC_STREAM_CANCELLED),
+            Http::StreamResetReason::RemoteReset);
 }
 
 TEST(EnvoyQuicUtilsTest, CreateConnectionSocket) {

--- a/test/common/quic/envoy_quic_utils_test.cc
+++ b/test/common/quic/envoy_quic_utils_test.cc
@@ -262,10 +262,29 @@ TEST(EnvoyQuicUtilsTest, HeaderMapMaxSizeLimit) {
   EXPECT_EQ(response_trailer->maxHeadersKb(), 60);
 }
 
+TEST(EnvoyQuicUtilsTest, EnvoyResetReasonToQuicResetErrorCode) {
+  EXPECT_EQ(envoyResetReasonToQuicRstError(Http::StreamResetReason::OverloadManager),
+            quic::QUIC_STREAM_EXCESSIVE_LOAD);
+  EXPECT_EQ(envoyResetReasonToQuicRstError(Http::StreamResetReason::LocalRefusedStreamReset),
+            quic::QUIC_REFUSED_STREAM);
+  EXPECT_EQ(envoyResetReasonToQuicRstError(Http::StreamResetReason::LocalConnectionFailure),
+            quic::QUIC_STREAM_CONNECTION_ERROR);
+  EXPECT_EQ(envoyResetReasonToQuicRstError(Http::StreamResetReason::RemoteConnectionFailure),
+            quic::QUIC_STREAM_CONNECTION_ERROR);
+  EXPECT_EQ(envoyResetReasonToQuicRstError(Http::StreamResetReason::ConnectionTimeout),
+            quic::QUIC_STREAM_CONNECTION_ERROR);
+  EXPECT_EQ(envoyResetReasonToQuicRstError(Http::StreamResetReason::ConnectionTermination),
+            quic::QUIC_STREAM_CONNECTION_ERROR);
+  EXPECT_EQ(envoyResetReasonToQuicRstError(Http::StreamResetReason::ConnectError),
+            quic::QUIC_STREAM_CONNECT_ERROR);
+  EXPECT_EQ(envoyResetReasonToQuicRstError(Http::StreamResetReason::LocalReset),
+            quic::QUIC_STREAM_REQUEST_REJECTED);
+  EXPECT_EQ(envoyResetReasonToQuicRstError(Http::StreamResetReason::ProtocolError),
+            quic::QUIC_STREAM_GENERAL_PROTOCOL_ERROR);
+}
+
 TEST(EnvoyQuicUtilsTest, EnvoyResetReasonToQuicResetErrorCodeImpossibleCases) {
   EXPECT_ENVOY_BUG(envoyResetReasonToQuicRstError(Http::StreamResetReason::Overflow),
-                   "Resource overflow ");
-  EXPECT_ENVOY_BUG(envoyResetReasonToQuicRstError(Http::StreamResetReason::OverflowManager),
                    "Resource overflow ");
   EXPECT_ENVOY_BUG(
       envoyResetReasonToQuicRstError(Http::StreamResetReason::RemoteRefusedStreamReset),

--- a/test/integration/buffer_accounting_integration_test.cc
+++ b/test/integration/buffer_accounting_integration_test.cc
@@ -578,10 +578,7 @@ TEST_P(ProtocolsBufferWatermarksTest, ResettingStreamUnregistersAccount) {
       ASSERT_TRUE(codec_client_->waitForDisconnect(std::chrono::milliseconds(10000)));
     } else {
       ASSERT_TRUE(response1->waitForReset());
-      EXPECT_EQ(response1->resetReason(),
-                (std::get<0>(GetParam()).downstream_protocol == Http::CodecType::HTTP2
-                     ? Http::StreamResetReason::RemoteReset
-                     : Http::StreamResetReason::OverloadManager));
+      EXPECT_EQ(response1->resetReason(), Http::StreamResetReason::RemoteReset);
     }
 
     // Wait for the upstream request to receive the reset to avoid a race when


### PR DESCRIPTION
Previously, the QUICHE error `quic::QUIC_STREAM_CANCELLED` was mapped to `StreamResetReason::OverloadManager`, but that was a questionable choice because the OverloadManager has specific implications (like dealing with overload and memory management of buffers).

This commit changes two things:
 1. `quic::QUIC_STREAM_CANCELLED` is mapped to either `LocalReset` or `RemoteReset`.
 2. `StreamResetReason::OverloadManager` is mapped to `quic::QUIC_STREAM_EXCESSIVE_LOAD`, which seems like a more appropriate choice to convey the semantics of the overload manager behavior.

Risk Level: Low
Testing: Unit/Integration
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
