### PR TITLE
Add findMatchingPrefixes to TrieLookupTable

### DIFF
--- a/source/common/common/trie_lookup_table.h
+++ b/source/common/common/trie_lookup_table.h
@@ -144,6 +144,28 @@ public:
   }
 
   /**
+   * Returns the set of entries that are prefixes of the specified key, longest last.
+   * Complexity is O(min(longest key prefix, key length)).
+   * @param key the key used to find.
+   * @return a vector of values whose keys are a prefix of the specified key, longest last.
+   */
+  absl::InlinedVector<Value, 4> findMatchingPrefixes(absl::string_view key) const {
+    absl::InlinedVector<Value, 4> result;
+    int32_t current = 0;
+
+    for (uint8_t c : key) {
+      current = getChildIndex(current, c);
+
+      if (current == NoNode) {
+        return result;
+      } else if (nodes_[current].value_) {
+        result.push_back(nodes_[current].value_);
+      }
+    }
+    return result;
+  }
+
+  /**
    * Finds the entry with the longest key that is a prefix of the specified key.
    * Complexity is O(min(longest key prefix, key length)).
    * @param key the key used to find.

--- a/test/common/common/trie_lookup_table_test.cc
+++ b/test/common/common/trie_lookup_table_test.cc
@@ -1,6 +1,9 @@
 #include "source/common/common/trie_lookup_table.h"
 
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
+
+using testing::ElementsAre;
 
 namespace Envoy {
 
@@ -43,26 +46,38 @@ TEST(TrieLookupTable, LongestPrefix) {
 
   EXPECT_EQ(cstr_a, trie.find("foo"));
   EXPECT_EQ(cstr_a, trie.findLongestPrefix("foo"));
+  EXPECT_THAT(trie.findMatchingPrefixes("foo"), ElementsAre(cstr_a));
   EXPECT_EQ(cstr_a, trie.findLongestPrefix("foosball"));
+  EXPECT_THAT(trie.findMatchingPrefixes("foosball"), ElementsAre(cstr_a));
   EXPECT_EQ(cstr_a, trie.findLongestPrefix("foo/"));
+  EXPECT_THAT(trie.findMatchingPrefixes("foo/"), ElementsAre(cstr_a));
   EXPECT_EQ(cstr_d, trie.findLongestPrefix("foo/bar"));
+  EXPECT_THAT(trie.findMatchingPrefixes("foo/bar"), ElementsAre(cstr_a, cstr_d));
   EXPECT_EQ(cstr_d, trie.findLongestPrefix("foo/bar/zzz"));
+  EXPECT_THAT(trie.findMatchingPrefixes("foo/bar/zzz"), ElementsAre(cstr_a, cstr_d));
 
   EXPECT_EQ(cstr_b, trie.find("bar"));
   EXPECT_EQ(cstr_b, trie.findLongestPrefix("bar"));
+  EXPECT_THAT(trie.findMatchingPrefixes("bar"), ElementsAre(cstr_b));
   EXPECT_EQ(cstr_b, trie.findLongestPrefix("baritone"));
+  EXPECT_THAT(trie.findMatchingPrefixes("baritone"), ElementsAre(cstr_b));
   EXPECT_EQ(cstr_c, trie.findLongestPrefix("barometer"));
+  EXPECT_THAT(trie.findMatchingPrefixes("barometer"), ElementsAre(cstr_b, cstr_c));
 
   EXPECT_EQ(cstr_e, trie.find("barn"));
   EXPECT_EQ(cstr_e, trie.findLongestPrefix("barnacle"));
+  EXPECT_THAT(trie.findMatchingPrefixes("barnacle"), ElementsAre(cstr_b, cstr_e));
 
   EXPECT_EQ(cstr_f, trie.find("barp"));
   EXPECT_EQ(cstr_f, trie.findLongestPrefix("barpomus"));
+  EXPECT_THAT(trie.findMatchingPrefixes("barpomus"), ElementsAre(cstr_b, cstr_f));
 
   EXPECT_EQ(nullptr, trie.find("toto"));
   EXPECT_EQ(nullptr, trie.findLongestPrefix("toto"));
+  EXPECT_THAT(trie.findMatchingPrefixes("toto"), ElementsAre());
   EXPECT_EQ(nullptr, trie.find(" "));
   EXPECT_EQ(nullptr, trie.findLongestPrefix(" "));
+  EXPECT_THAT(trie.findMatchingPrefixes(" "), ElementsAre());
 }
 
 TEST(TrieLookupTable, VeryDeepTrieDoesNotStackOverflowOnDestructor) {


### PR DESCRIPTION
Commit Message: Add findMatchingPrefixes to TrieLookupTable
Additional Description: This is a small step towards #38726 and/or #38986, which both want to walk up the set of "worse matches" on a subtree miss.
Risk Level: None on its own, not yet used.
Testing: Added test cases.
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
