### PR TITLE
Downgrade connection-ID and worker-index mismatch from assert to error.

### DIFF
--- a/source/common/quic/active_quic_listener.cc
+++ b/source/common/quic/active_quic_listener.cc
@@ -8,6 +8,7 @@
 #include "envoy/extensions/quic/proof_source/v3/proof_source.pb.h"
 #include "envoy/network/exception.h"
 
+#include "source/common/common/logger.h"
 #include "source/common/config/utility.h"
 #include "source/common/http/utility.h"
 #include "source/common/network/socket_option_impl.h"
@@ -223,7 +224,11 @@ void ActiveQuicListener::shutdownListener(const Network::ExtraShutdownListenerOp
 
 uint32_t ActiveQuicListener::destination(const Network::UdpRecvData& data) const {
   if (kernel_worker_routing_) {
-    ASSERT(select_connection_id_worker_(*data.buffer_, worker_index_) == worker_index_);
+    uint32_t expected_worker_index = select_connection_id_worker_(*data.buffer_, worker_index_);
+    if (expected_worker_index != worker_index_) {
+      ENVOY_LOG_EVERY_POW_2(error, "Mismacthed worker index. expected {}, actual {}",
+                            expected_worker_index, worker_index_);
+    }
 
     // The kernel has already routed the packet correctly. Make it stay on the current worker.
     return worker_index_;

--- a/source/common/quic/active_quic_listener.cc
+++ b/source/common/quic/active_quic_listener.cc
@@ -230,7 +230,8 @@ uint32_t ActiveQuicListener::destination(const Network::UdpRecvData& data) const
                             expected_worker_index, worker_index_);
     }
 
-    // The kernel has already routed the packet correctly. Make it stay on the current worker.
+    // Any mismatch should only happen in the very short period when kernel worker routing is being
+    // setup. Make it stay on the current worker and ignore the edge case.
     return worker_index_;
   }
 

--- a/source/common/quic/envoy_quic_server_session.cc
+++ b/source/common/quic/envoy_quic_server_session.cc
@@ -193,14 +193,13 @@ void EnvoyQuicServerSession::setHttp3Options(
     const uint64_t max_interval =
         PROTOBUF_GET_MS_OR_DEFAULT(http3_options_->quic_protocol_options().connection_keepalive(),
                                    max_interval, quic::kPingTimeoutSecs);
-    if (max_interval == 0) {
-      return;
-    }
-    if (initial_interval > 0) {
-      connection()->set_keep_alive_ping_timeout(
-          quic::QuicTime::Delta::FromMilliseconds(max_interval));
-      connection()->set_initial_retransmittable_on_wire_timeout(
-          quic::QuicTime::Delta::FromMilliseconds(initial_interval));
+    if (max_interval != 0) {
+      if (initial_interval > 0) {
+        connection()->set_keep_alive_ping_timeout(
+            quic::QuicTime::Delta::FromMilliseconds(max_interval));
+        connection()->set_initial_retransmittable_on_wire_timeout(
+            quic::QuicTime::Delta::FromMilliseconds(initial_interval));
+      }
     }
   }
   set_allow_extended_connect(http3_options_->allow_extended_connect());

--- a/test/common/quic/envoy_quic_server_session_test.cc
+++ b/test/common/quic/envoy_quic_server_session_test.cc
@@ -1116,6 +1116,19 @@ TEST_F(EnvoyQuicServerSessionTest, DisableQpack) {
   installReadFilter();
 }
 
+TEST_F(EnvoyQuicServerSessionTest, Http3OptionsTest) {
+  envoy::config::core::v3::Http3ProtocolOptions http3_options;
+  auto* quic_options = http3_options.mutable_quic_protocol_options();
+  quic_options->mutable_connection_keepalive()->mutable_max_interval()->set_seconds(0);
+  http3_options.set_allow_extended_connect(false);
+
+  envoy_quic_session_.setHttp3Options(http3_options);
+
+  EXPECT_FALSE(envoy_quic_session_.allow_extended_connect());
+
+  installReadFilter();
+}
+
 class EnvoyQuicServerSessionTestWillNotInitialize : public EnvoyQuicServerSessionTest {
   void SetUp() override {}
   void TearDown() override {


### PR DESCRIPTION
Commit Message: Downgrade connection-ID and worker-index mismatch from assert to error when kernel_worker_routing_ is true.
Additional Description: kernel_worker_routing is not enabled atomically on the server side. If there is a QUIC client talking to server during the kernel_worker_routing setup, the cid and worker-index mismatch assertion can trigger, which is not desirable. If packet routing is not working as intended, the new error will show up in logs. 
Risk Level: LOW
