### PR TITLE
dfp: Make the addressList() return a const reference

### DIFF
--- a/source/extensions/common/dynamic_forward_proxy/dns_cache.h
+++ b/source/extensions/common/dynamic_forward_proxy/dns_cache.h
@@ -51,7 +51,7 @@ public:
    * Returns the host's currently resolved address. These addresses may change periodically due to
    * async re-resolution.
    */
-  virtual std::vector<Network::Address::InstanceConstSharedPtr> addressList() const PURE;
+  virtual const std::vector<Network::Address::InstanceConstSharedPtr>& addressList() const PURE;
 
   /**
    * Returns the host that was actually resolved via DNS. If port was originally specified it will

--- a/source/extensions/common/dynamic_forward_proxy/dns_cache_impl.h
+++ b/source/extensions/common/dynamic_forward_proxy/dns_cache_impl.h
@@ -122,11 +122,9 @@ private:
       return address_;
     }
 
-    std::vector<Network::Address::InstanceConstSharedPtr> addressList() const override {
-      std::vector<Network::Address::InstanceConstSharedPtr> ret;
+    const std::vector<Network::Address::InstanceConstSharedPtr>& addressList() const override {
       absl::ReaderMutexLock lock{&resolve_lock_};
-      ret = address_list_;
-      return ret;
+      return address_list_;
     }
 
     const std::string& resolvedHost() const override { return resolved_host_; }

--- a/test/extensions/common/dynamic_forward_proxy/mocks.h
+++ b/test/extensions/common/dynamic_forward_proxy/mocks.h
@@ -94,7 +94,7 @@ public:
   ~MockDnsHostInfo() override;
 
   MOCK_METHOD(Network::Address::InstanceConstSharedPtr, address, (), (const));
-  MOCK_METHOD(std::vector<Network::Address::InstanceConstSharedPtr>, addressList, (), (const));
+  MOCK_METHOD(const std::vector<Network::Address::InstanceConstSharedPtr>&, addressList, (), (const));
   MOCK_METHOD(const std::string&, resolvedHost, (), (const));
   MOCK_METHOD(bool, isIpAddress, (), (const));
   MOCK_METHOD(void, touch, ());


### PR DESCRIPTION
Previously, addressList() would create a new copy of the vector for every invocation, even though it would only pass it around by const reference thereafter.