### PR TITLE
oauth2: route level oauth2 support

### DIFF
--- a/source/extensions/filters/http/oauth2/config.h
+++ b/source/extensions/filters/http/oauth2/config.h
@@ -6,6 +6,7 @@
 #include "envoy/extensions/filters/http/oauth2/v3/oauth.pb.validate.h"
 
 #include "source/extensions/filters/http/common/factory_base.h"
+#include "source/extensions/filters/http/oauth2/filter.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -21,6 +22,11 @@ public:
   createFilterFactoryFromProtoTyped(const envoy::extensions::filters::http::oauth2::v3::OAuth2&,
                                     const std::string&,
                                     Server::Configuration::FactoryContext&) override;
+
+  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
+  createRouteSpecificFilterConfigTyped(const envoy::extensions::filters::http::oauth2::v3::OAuth2&,
+                                       Server::Configuration::ServerFactoryContext&,
+                                       ProtobufMessage::ValidationVisitor&) override;
 };
 
 } // namespace Oauth2

--- a/test/extensions/filters/http/oauth2/config_test.cc
+++ b/test/extensions/filters/http/oauth2/config_test.cc
@@ -137,7 +137,7 @@ config:
   EXPECT_CALL(context.server_factory_context_, clusterManager()).Times(2);
   EXPECT_CALL(context, scope());
   EXPECT_CALL(context.server_factory_context_, timeSource());
-  EXPECT_CALL(context, initManager()).Times(2);
+  EXPECT_CALL(context, initManager());
   EXPECT_CALL(context, getTransportSocketFactoryContext());
   Http::FilterFactoryCb cb =
       factory.createFilterFactoryFromProto(*proto_config, "stats", context).value();
@@ -152,18 +152,6 @@ TEST(ConfigTest, InvalidTokenSecret) {
 
 TEST(ConfigTest, InvalidHmacSecret) {
   expectInvalidSecretConfig("hmac", "invalid HMAC secret configuration");
-}
-
-TEST(ConfigTest, CreateFilterMissingConfig) {
-  OAuth2Config config;
-
-  envoy::extensions::filters::http::oauth2::v3::OAuth2 proto_config;
-
-  NiceMock<Server::Configuration::MockFactoryContext> factory_context;
-  const auto result =
-      config.createFilterFactoryFromProtoTyped(proto_config, "whatever", factory_context);
-  EXPECT_FALSE(result.ok());
-  EXPECT_EQ(result.status().message(), "config must be present for global config");
 }
 
 TEST(ConfigTest, WrongCookieName) {


### PR DESCRIPTION
Commit Message: oauth2: route level oauth2 support
Additional Description:

Now, it's impossible to configure different oauth2 in specific route. This PR provides related support.


Risk Level: low.
Testing: wait.
Docs Changes: n/a.
Release Notes: wait.
Platform Specific Features: n/a.