### PR TITLE
redis_proxy: fix infinite loop in shardSize(), adding an upper limit and returning the number of unique hosts

### DIFF
--- a/source/extensions/filters/network/redis_proxy/conn_pool_impl.cc
+++ b/source/extensions/filters/network/redis_proxy/conn_pool_impl.cc
@@ -288,6 +288,7 @@ uint16_t InstanceImpl::ThreadLocalPool::shardSize() {
 
   Common::Redis::RespValue request;
   absl::flat_hash_set<Upstream::HostConstSharedPtr> unique_hosts;
+  unique_hosts.reserve(Envoy::Extensions::Clusters::Redis::MaxSlot);
   for (uint16_t size = 0; size < Envoy::Extensions::Clusters::Redis::MaxSlot; size++) {
     Clusters::Redis::RedisSpecifyShardContextImpl lb_context(
         size, request, Common::Redis::Client::ReadPolicy::Primary);

--- a/source/extensions/filters/network/redis_proxy/conn_pool_impl.cc
+++ b/source/extensions/filters/network/redis_proxy/conn_pool_impl.cc
@@ -287,7 +287,7 @@ uint16_t InstanceImpl::ThreadLocalPool::shardSize() {
   }
 
   Common::Redis::RespValue request;
-  std::set<Upstream::HostConstSharedPtr> uniqueHosts;
+  absl::flat_hash_set<Upstream::HostConstSharedPtr> unique_hosts;
   for (uint16_t size = 0; size < Envoy::Extensions::Clusters::Redis::MaxSlot; size++) {
     Clusters::Redis::RedisSpecifyShardContextImpl lb_context(
         size, request, Common::Redis::Client::ReadPolicy::Primary);
@@ -296,9 +296,9 @@ uint16_t InstanceImpl::ThreadLocalPool::shardSize() {
     if (!host) {
       return size;
     }
-    uniqueHosts.insert(host);
+    unique_hosts.insert(host);
   }
-  return static_cast<uint16_t>(uniqueHosts.size());
+  return static_cast<uint16_t>(unique_hosts.size());
 }
 
 Common::Redis::Client::PoolRequest*

--- a/source/extensions/filters/network/redis_proxy/conn_pool_impl.cc
+++ b/source/extensions/filters/network/redis_proxy/conn_pool_impl.cc
@@ -297,7 +297,7 @@ uint16_t InstanceImpl::ThreadLocalPool::shardSize() {
     if (!host) {
       return size;
     }
-    unique_hosts.insert(host);
+    unique_hosts.insert(std::move(host));
   }
   return static_cast<uint16_t>(unique_hosts.size());
 }

--- a/test/extensions/filters/network/redis_proxy/conn_pool_impl_test.cc
+++ b/test/extensions/filters/network/redis_proxy/conn_pool_impl_test.cc
@@ -478,7 +478,9 @@ TEST_F(RedisConnPoolImplTest, ShardSizeDuplicateHosts) {
             EXPECT_EQ(context->downstreamConnection(), nullptr);
             return mock_hosts[call_count++ % max_hosts];
           }));
+  // shardSize() should only count max_hosts, ignoring duplicates
   EXPECT_EQ(conn_pool_->shardSize(), max_hosts);
+  EXPECT_GT(call_count, max_hosts);
 
   tls_.shutdownThread();
 };

--- a/test/extensions/filters/network/redis_proxy/conn_pool_impl_test.cc
+++ b/test/extensions/filters/network/redis_proxy/conn_pool_impl_test.cc
@@ -456,6 +456,33 @@ TEST_F(RedisConnPoolImplTest, ShardNoHost) {
   tls_.shutdownThread();
 };
 
+TEST_F(RedisConnPoolImplTest, ShardSizeDuplicateHosts) {
+  InSequence s;
+
+  setup();
+
+  Common::Redis::RespValueSharedPtr value = std::make_shared<Common::Redis::RespValue>();
+  MockPoolCallbacks callbacks;
+
+  uint16_t max_hosts = 5;
+  std::vector<std::shared_ptr<NiceMock<Upstream::MockHost>>> mock_hosts;
+  for (uint16_t i = 0; i < max_hosts; i++) {
+    mock_hosts.push_back(std::make_shared<NiceMock<Upstream::MockHost>>());
+  }
+
+  uint16_t call_count = 0;
+  EXPECT_CALL(cm_.thread_local_cluster_.lb_, chooseHost(_))
+      .WillRepeatedly(
+          Invoke([&](Upstream::LoadBalancerContext* context) -> Upstream::HostConstSharedPtr {
+            EXPECT_EQ(context->metadataMatchCriteria(), nullptr);
+            EXPECT_EQ(context->downstreamConnection(), nullptr);
+            return mock_hosts[call_count++ % max_hosts];
+          }));
+  EXPECT_EQ(conn_pool_->shardSize(), max_hosts);
+
+  tls_.shutdownThread();
+};
+
 TEST_F(RedisConnPoolImplTest, BasicRespVariant) {
   InSequence s;
 


### PR DESCRIPTION
Commit Message: redis proxy: fix infinite loop in shardSize(), adding an upper limit and returning unique hosts

Additional Description: 
The KEYS command caused Envoy's redis_proxy to hang indefinitely
because the shardSize() function would enter an infinite loop when
chooseHost() never returned nullptr. This prevented Envoy from being
terminated with TERM or INT signals. This fix introduces an upper bound
(MaxSlot) on the loop and keeps track of unique hosts returned by
chooseHost(). Once the loop completes, shardSize() correctly returns
the number of shards instead of 0, preventing the infinite loop.

Risk Level: Low

Testing: added a unit test to make sure shardSize() does not count duplicate hosts and an integration test for a simple Keys Request. Both of these tests failed prior to this fix.

Docs Changes:
Release Notes:
Platform Specific Features:

Fixes #38508
