### PR TITLE
Switch back to static linking for coverage tests

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -245,7 +245,18 @@ build:coverage --action_env=GCOV=llvm-profdata
 build:coverage --copt=-DNDEBUG
 # 1.5x original timeout + 300s for trace merger in all categories
 build:coverage --test_timeout=390,750,1500,5700
-build:coverage --define=dynamic_link_tests=true
+# We used to dynamically link Envoy tests when running coverage. Using dynamic linking apparently
+# reduced the footprint and build time. However, the problem with this approach is that clang has
+# an issue with coverage reporting when dynamic linking is used (see
+# https://github.com/envoyproxy/envoy/issues/37911#issuecomment-2659837724 for the details).
+#
+# After updating toolchain to a newer version and changes on the CI backend we use for building and
+# testing Envoy, we don't need to worry about the footprint as much anymore and we decided to switch
+# back to static linking to address the issues with the coverage.
+#
+# We can switch back to dynamic linking again once https://github.com/llvm/llvm-project/issues/32849
+# is addressed upstream in LLVM.
+build:coverage --define=dynamic_link_tests=false
 build:coverage --define=ENVOY_CONFIG_COVERAGE=1
 build:coverage --cxxopt="-DENVOY_CONFIG_COVERAGE=1"
 build:coverage --test_env=HEAPCHECK=

--- a/test/per_file_coverage.sh
+++ b/test/per_file_coverage.sh
@@ -27,6 +27,7 @@ declare -a KNOWN_LOW_COVERAGE=(
 "source/extensions/common/tap:94.6"
 "source/extensions/common/wasm:95.3" # flaky: be careful adjusting
 "source/extensions/common/wasm/ext:92.0"
+"source/extensions/filters/common/ext_proc:85.6" # comment is counted by LCOV #37911
 "source/extensions/filters/common/fault:94.5"
 "source/extensions/filters/common/rbac:92.6"
 "source/extensions/filters/http/cache:95.9"

--- a/test/per_file_coverage.sh
+++ b/test/per_file_coverage.sh
@@ -27,7 +27,6 @@ declare -a KNOWN_LOW_COVERAGE=(
 "source/extensions/common/tap:94.6"
 "source/extensions/common/wasm:95.3" # flaky: be careful adjusting
 "source/extensions/common/wasm/ext:92.0"
-"source/extensions/filters/common/ext_proc:85.6" # comment is counted by LCOV #37911
 "source/extensions/filters/common/fault:94.5"
 "source/extensions/filters/common/rbac:92.6"
 "source/extensions/filters/http/cache:95.9"


### PR DESCRIPTION
Commit Message:

This is a workaround for the LLVM issue that affects coverage (see https://github.com/llvm/llvm-project/issues/32849).

TL;DR: basically dynamic linking + definitions of functions in the headers result in mismatching checksums for coverage counters which in turn results in incorrect coverage reports.

The effects of this issue are not very deterministic (e.g., when the issue happens is affected by way to many factors to reliably predict or avoid the issue), that's why we haven't noticed it before, but during clang-18 migration the issue caused some coverage failures.

Switching to static linking should workardound the issue completely. Before migration to clang-18 we couldn't do it, because coverage tests just didn't build because we hit some relocation overflows. However since version 17 LLVM lld changed the order of sections in the produced binaries, which made relocations overflows way less likely in the code model used by default (which I think is "small").

NOTE: we could aslo try and switch to large code model, but not only it will result in slower code, I also don't think it's as well tested and supported as small code model, so we probably should not.

I removed coverage exception introduced by #38898, because with this change it's not needed anymore.

Additional Description: this change was made possible by #37911
Risk Level: low
Testing: running CI coverage tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
