### PR TITLE
[TESTING/WIP] coverage: Reorder args to stop platform warning

### DIFF
--- a/test/run_envoy_bazel_coverage.sh
+++ b/test/run_envoy_bazel_coverage.sh
@@ -61,11 +61,9 @@ if [[ "${FUZZ_COVERAGE}" == "true" ]]; then
     COVERAGE_TARGETS=()
     while read -r line; do COVERAGE_TARGETS+=("$line"); done \
         <<< "$_targets"
-    BAZEL_COVERAGE_OPTIONS+=(
-        "--config=fuzz-coverage")
+    BAZEL_COVERAGE_OPTIONS=("--config=fuzz-coverage" "${BAZEL_COVERAGE_OPTIONS[@]}")
 else
-    BAZEL_COVERAGE_OPTIONS+=(
-        "--config=test-coverage")
+    BAZEL_COVERAGE_OPTIONS=("--config=test-coverage" "${BAZEL_COVERAGE_OPTIONS[@]}")
 fi
 
 # Output unusually long logs due to trace logging.


### PR DESCRIPTION
attempt to tackle:

```console
 WARNING: Remote Cache: FAILED_PRECONDITION: Command.Platform not set
java.io.IOException: io.grpc.StatusRuntimeException: FAILED_PRECONDITION: Command.Platform not set
	at com.google.devtools.build.lib.remote.GrpcCacheClient.lambda$uploadActionResult$11(GrpcCacheClient.java:328)
	at com.google.common.util.concurrent.AbstractCatchingFuture$AsyncCatchingFuture.doFallback(AbstractCatchingFuture.java:205)
	at com.google.common.util.concurrent.AbstractCatchingFuture$AsyncCatchingFuture.doFallback(AbstractCatchingFuture.java:192)
	at com.google.common.util.concurrent.AbstractCatchingFuture.run(AbstractCatchingFuture.java:134)
	at com.google.common.util.concurrent.DirectExecutor.execute(DirectExecutor.java:31)
	at com.google.common.util.concurrent.AbstractFuture.executeListener(AbstractFuture.java:1286)
	at com.google.common.util.concurrent.AbstractFuture.complete(AbstractFuture.java:1055)
	at com.google.common.util.concurrent.AbstractFuture.setException(AbstractFuture.java:807)
	at com.google.common.util.concurrent.SettableFuture.setException(SettableFuture.java:55)
	at com.google.devtools.build.lib.remote.util.RxFutures$2.onError(RxFutures.java:259)
	at io.reactivex.rxjava3.internal.operators.single.SingleFlatMap$SingleFlatMapCallback$FlatMapSingleObserver.onError(SingleFlatMap.java:117)
``` 