### PR TITLE
fips: prefer self-reported status over a build flag

### DIFF
--- a/source/common/version/BUILD
+++ b/source/common/version/BUILD
@@ -59,10 +59,7 @@ envoy_cc_library(
     name = "version_lib",
     srcs = ["version.cc"],
     copts = envoy_select_boringssl(
-        [
-            "-DENVOY_SSL_VERSION=\\\"BoringSSL-FIPS\\\"",
-            "-DENVOY_SSL_FIPS",
-        ],
+        ["-DENVOY_SSL_VERSION=\\\"BoringSSL-FIPS\\\""],
         ["-DENVOY_SSL_VERSION=\\\"BoringSSL\\\""],
     ),
     external_deps = ["ssl"],

--- a/source/common/version/version.cc
+++ b/source/common/version/version.cc
@@ -11,10 +11,7 @@
 #include "absl/strings/numbers.h"
 #include "absl/strings/str_split.h"
 #include "absl/strings/string_view.h"
-
-#ifdef ENVOY_SSL_FIPS
 #include "openssl/crypto.h"
-#endif
 
 extern const char build_scm_revision[];
 extern const char build_scm_status[];
@@ -40,14 +37,7 @@ const envoy::config::core::v3::BuildVersion& VersionInfo::buildVersion() {
   return *result;
 }
 
-bool VersionInfo::sslFipsCompliant() {
-#ifdef ENVOY_SSL_FIPS
-  RELEASE_ASSERT(FIPS_mode() == 1, "FIPS mode must be enabled in Envoy FIPS configuration.");
-  return true;
-#else
-  return false;
-#endif
-}
+bool VersionInfo::sslFipsCompliant() { return FIPS_mode() == 1; }
 
 const std::string& VersionInfo::buildType() {
 #ifdef NDEBUG


### PR DESCRIPTION
Change-Id: I27552abf959a501cd592fe7fa1e5ac7d67e4ddff

Commit Message: Directly pass through boringssl's `FIPS_mode` status instead of depending on the build flag. This is useful when boringssl is forced to compile in the FIPS mode (e.g. by source code modification to set the build flag).
Additional Description: none
Risk Level: low, a release assert was already present.
Testing: yes
Docs Changes: none
Release Notes: none