### PR TITLE
dfp: Don't filter IP address families from the DNS cache

### DIFF
--- a/mobile/library/common/internal_engine.cc
+++ b/mobile/library/common/internal_engine.cc
@@ -381,7 +381,9 @@ void InternalEngine::handleNetworkChange(const int network_type, const bool has_
   envoy_netconf_t configuration =
       Network::ConnectivityManagerImpl::setPreferredNetwork(network_type);
   if (Runtime::runtimeFeatureEnabled(
-          "envoy.reloadable_features.dns_cache_set_ip_version_to_remove")) {
+          "envoy.reloadable_features.dns_cache_set_ip_version_to_remove") ||
+      Runtime::runtimeFeatureEnabled(
+          "envoy.reloadable_features.dns_cache_filter_unusable_ip_version")) {
     // The IP version to remove flag must be set first before refreshing the DNS cache so that
     // the DNS cache will be updated with whether or not the IPv6 addresses will need to be
     // removed.

--- a/mobile/test/common/integration/client_integration_test.cc
+++ b/mobile/test/common/integration/client_integration_test.cc
@@ -1453,6 +1453,21 @@ TEST_P(ClientIntegrationTest, OnNetworkChanged) {
 }
 
 // This test is simply to test the IPv6 connectivity check and DNS refresh and make sure the code
+// doesn't crash. It doesn't really test the actual network change event, but it does ensure that
+// requests/responses still work in the presence of IP version filtering.
+TEST_P(ClientIntegrationTest, OnNetworkChangedFilterUnsableIps) {
+  builder_.addRuntimeGuard("dns_cache_set_ip_version_to_remove", false);
+  builder_.addRuntimeGuard("dns_cache_filter_unusable_ip_version", true);
+  builder_.setDisableDnsRefreshOnNetworkChange(true);
+  initialize();
+  internalEngine()->onDefaultNetworkChanged(1);
+  basicTest();
+  if (upstreamProtocol() == Http::CodecType::HTTP1) {
+    ASSERT_EQ(cc_.on_complete_received_byte_count_, 67);
+  }
+}
+
+// This test is simply to test the IPv6 connectivity check and DNS refresh and make sure the code
 // doesn't crash. It doesn't really test the actual network change event.
 TEST_P(ClientIntegrationTest, OnNetworkChangeEvent) {
   builder_.addRuntimeGuard("dns_cache_set_ip_version_to_remove", true);

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -148,6 +148,8 @@ FALSE_RUNTIME_GUARD(envoy_reloadable_features_reresolve_if_no_connections);
 FALSE_RUNTIME_GUARD(envoy_restart_features_xds_failover_support);
 // TODO(fredyw): evaluate and either make this a config knob or remove.
 FALSE_RUNTIME_GUARD(envoy_reloadable_features_dns_cache_set_ip_version_to_remove);
+// TODO(abeyad): evaluate and either make this the default or remove.
+FALSE_RUNTIME_GUARD(envoy_reloadable_features_dns_cache_filter_unusable_ip_version);
 // TODO(alyssawilk): evaluate and make this a config knob or remove.
 FALSE_RUNTIME_GUARD(envoy_reloadable_features_reset_brokenness_on_nework_change);
 // TODO(alyssawilk): evaluate and make this a config knob or remove.

--- a/source/extensions/clusters/dynamic_forward_proxy/cluster.cc
+++ b/source/extensions/clusters/dynamic_forward_proxy/cluster.cc
@@ -292,13 +292,13 @@ absl::Status Cluster::addOrUpdateHost(
              host_map_it->second.logical_host_->address());
       ENVOY_LOG(debug, "updating dfproxy cluster host address '{}'", host);
       host_map_it->second.logical_host_->setNewAddresses(
-          host_info->address(), host_info->addressList(), dummy_lb_endpoint_);
+          host_info->address(), host_info->addressList(/*filtered=*/true), dummy_lb_endpoint_);
       return absl::OkStatus();
     }
 
     ENVOY_LOG(debug, "adding new dfproxy cluster host '{}'", host);
     auto host_or_error = Upstream::LogicalHost::create(
-        info(), std::string{host}, host_info->address(), host_info->addressList(),
+        info(), std::string{host}, host_info->address(), host_info->addressList(/*filtered=*/true),
         dummy_locality_lb_endpoint_, dummy_lb_endpoint_, nullptr, time_source_);
     RETURN_IF_NOT_OK_REF(host_or_error.status());
 

--- a/source/extensions/clusters/dynamic_forward_proxy/cluster.cc
+++ b/source/extensions/clusters/dynamic_forward_proxy/cluster.cc
@@ -288,8 +288,6 @@ absl::Status Cluster::addOrUpdateHost(
       //                     cluster would create multiple logical hosts based on those addresses.
       //                     We will leave this is a follow up depending on need.
       ASSERT(host_info == host_map_it->second.shared_host_info_);
-      ASSERT(host_map_it->second.shared_host_info_->address() !=
-             host_map_it->second.logical_host_->address());
       ENVOY_LOG(debug, "updating dfproxy cluster host address '{}'", host);
       host_map_it->second.logical_host_->setNewAddresses(
           host_info->address(), host_info->addressList(/*filtered=*/true), dummy_lb_endpoint_);

--- a/source/extensions/common/dynamic_forward_proxy/dns_cache.h
+++ b/source/extensions/common/dynamic_forward_proxy/dns_cache.h
@@ -50,8 +50,13 @@ public:
   /**
    * Returns the host's currently resolved address. These addresses may change periodically due to
    * async re-resolution.
+   *
+   * If `filtered` is true and the runtime guard
+   * `envoy.reloadable_features.dns_cache_filter_unusable_ip_version` is true, return a filtered
+   * list where the IP addresses of IP families unsupported on the current network are removed.
    */
-  virtual std::vector<Network::Address::InstanceConstSharedPtr> addressList() const PURE;
+  virtual std::vector<Network::Address::InstanceConstSharedPtr>
+  addressList(bool filtered) const PURE;
 
   /**
    * Returns the host that was actually resolved via DNS. If port was originally specified it will
@@ -281,6 +286,11 @@ public:
    * addresses.
    */
   virtual void setIpVersionToRemove(absl::optional<Network::Address::IpVersion> ip_version) PURE;
+
+  /**
+   * Gets the `IpVersion` addresses to be removed from the DNS response.
+   */
+  virtual absl::optional<Network::Address::IpVersion> getIpVersionToRemove() PURE;
 
   /**
    * Stops the DNS cache background tasks by canceling the pending queries and stopping the timeout

--- a/source/extensions/common/dynamic_forward_proxy/dns_cache_impl.cc
+++ b/source/extensions/common/dynamic_forward_proxy/dns_cache_impl.cc
@@ -345,8 +345,37 @@ void DnsCacheImpl::forceRefreshHosts() {
 }
 
 void DnsCacheImpl::setIpVersionToRemove(absl::optional<Network::Address::IpVersion> ip_version) {
+  bool has_changed = false;
+  {
+    absl::MutexLock lock{&ip_version_to_remove_lock_};
+    has_changed = ip_version_to_remove_ != ip_version;
+    ip_version_to_remove_ = ip_version;
+  }
+
+  if (has_changed && Runtime::runtimeFeatureEnabled(
+                         "envoy.reloadable_features.dns_cache_filter_unusable_ip_version")) {
+    // The IP version to remove has changed, so we need to refresh all logical hosts in the DFP
+    // cluster so they filter out the unsupported/unusable IP addresses from their address list.
+    absl::ReaderMutexLock reader_lock{&primary_hosts_lock_};
+    for (auto& primary_host : primary_hosts_) {
+      for (auto* callbacks : update_callbacks_) {
+        auto status = callbacks->callbacks_.onDnsHostAddOrUpdate(primary_host.first,
+                                                                 primary_host.second->host_info_);
+        if (!status.ok()) {
+          // TODO(abeyad): Do something better with a failure status.
+          ENVOY_LOG(warn, "Failed to update DFP host after IP version update due to {}",
+                    status.message());
+        }
+      }
+    }
+    ENVOY_LOG(debug, "refresh all logical hosts in host map, unsupported IP version {}",
+              ip_version.has_value() ? absl::StrCat("'", *ip_version, "'") : "none");
+  }
+}
+
+absl::optional<Network::Address::IpVersion> DnsCacheImpl::getIpVersionToRemove() {
   absl::MutexLock lock{&ip_version_to_remove_lock_};
-  ip_version_to_remove_ = ip_version;
+  return ip_version_to_remove_;
 }
 
 void DnsCacheImpl::stop() {
@@ -464,13 +493,6 @@ void DnsCacheImpl::finishResolve(const std::string& host,
     }
   }
 
-  // If the DNS resolver successfully resolved with an empty response list, the dns cache does not
-  // update. This ensures that a potentially previously resolved address does not stabilize back to
-  // 0 hosts.
-  const auto new_address =
-      !response.empty() ? Network::Utility::getAddressWithPort(
-                              *(response.front().addrInfo().address_), primary_host_info->port_)
-                        : nullptr;
   auto address_list = DnsUtils::generateAddressList(response, primary_host_info->port_);
   // Only the change the address if:
   // 1) The new address is valid &&
@@ -487,10 +509,14 @@ void DnsCacheImpl::finishResolve(const std::string& host,
   }
   std::chrono::seconds dns_ttl =
       std::chrono::duration_cast<std::chrono::seconds>(refresh_interval_);
-  if (new_address) {
+
+  // If the DNS resolver successfully resolved with an empty response list, the dns cache does not
+  // update. This ensures that a potentially previously resolved address does not stabilize back to
+  // 0 hosts.
+  if (!address_list.empty()) {
     // Update the cache entry and staleness any time the ttl changes.
     if (!from_cache) {
-      addCacheEntry(host, new_address, address_list, response.front().addrInfo().ttl_);
+      addCacheEntry(host, address_list, response.front().addrInfo().ttl_);
     }
     // Arbitrarily cap DNS re-resolution at min_refresh_interval_ to avoid constant DNS queries.
     dns_ttl = std::max<std::chrono::seconds>(
@@ -499,22 +525,23 @@ void DnsCacheImpl::finishResolve(const std::string& host,
     primary_host_info->host_info_->updateStale(resolution_time.value(), dns_ttl);
   }
 
-  bool changed_to_non_null_address =
-      (new_address != nullptr &&
-       (current_address == nullptr || *current_address != *new_address ||
-        DnsUtils::listChanged(address_list, primary_host_info->host_info_->addressList())));
+  bool should_update_cache =
+      !address_list.empty() &&
+      DnsUtils::listChanged(address_list,
+                            primary_host_info->host_info_->addressList(/*filtered=*/false));
   // If this was a proxy lookup it's OK to send a null address resolution as
   // long as this isn't a transition from non-null to null address.
-  bool proxying_and_didnt_unresolve = is_proxy_lookup && !current_address;
+  should_update_cache |= is_proxy_lookup && !current_address;
 
-  if (changed_to_non_null_address || proxying_and_didnt_unresolve) {
+  if (should_update_cache) {
+    primary_host_info->host_info_->setAddresses(std::move(address_list), details_with_maybe_trace,
+                                                status);
     ENVOY_LOG_EVENT(debug, "dns_cache_update_address",
                     "host '{}' address has changed from {} to {}", host,
                     current_address ? current_address->asStringView() : "<empty>",
-                    new_address ? new_address->asStringView() : "<empty>");
-    primary_host_info->host_info_->setAddresses(new_address, std::move(address_list));
-    primary_host_info->host_info_->setDetails(details_with_maybe_trace);
-    primary_host_info->host_info_->setResolutionStatus(status);
+                    primary_host_info->host_info_->address()
+                        ? primary_host_info->host_info_->address()->asStringView()
+                        : "<empty>");
 
     absl::Status host_status = runAddUpdateCallbacks(host, primary_host_info->host_info_);
     ENVOY_BUG(host_status.ok(),
@@ -616,8 +643,7 @@ DnsCacheImpl::PrimaryHostInfo::PrimaryHostInfo(DnsCacheImpl& parent,
     : parent_(parent), port_(port),
       refresh_timer_(parent.main_thread_dispatcher_.createTimer(refresh_timer_cb)),
       timeout_timer_(parent.main_thread_dispatcher_.createTimer(timeout_timer_cb)),
-      host_info_(std::make_shared<DnsHostInfoImpl>(parent.main_thread_dispatcher_.timeSource(),
-                                                   host_to_resolve, is_ip_address)),
+      host_info_(std::make_shared<DnsHostInfoImpl>(parent, host_to_resolve, is_ip_address)),
       failure_backoff_strategy_(
           Config::Utility::prepareDnsRefreshStrategy<
               envoy::extensions::common::dynamic_forward_proxy::v3::DnsCacheConfig>(
@@ -632,23 +658,18 @@ DnsCacheImpl::PrimaryHostInfo::~PrimaryHostInfo() {
 }
 
 void DnsCacheImpl::addCacheEntry(
-    const std::string& host, const Network::Address::InstanceConstSharedPtr& address,
+    const std::string& host,
     const std::vector<Network::Address::InstanceConstSharedPtr>& address_list,
     const std::chrono::seconds ttl) {
-  if (!key_value_store_) {
+  if (!key_value_store_ || address_list.empty()) {
     return;
   }
   MonotonicTime now = main_thread_dispatcher_.timeSource().monotonicTime();
   uint64_t seconds_since_epoch =
       std::chrono::duration_cast<std::chrono::seconds>(now.time_since_epoch()).count();
-  std::string value;
-  if (address_list.empty()) {
-    value = absl::StrCat(address->asString(), "|", ttl.count(), "|", seconds_since_epoch);
-  } else {
-    value = absl::StrJoin(address_list, "\n", [&](std::string* out, const auto& addr) {
-      absl::StrAppend(out, addr->asString(), "|", ttl.count(), "|", seconds_since_epoch);
-    });
-  }
+  std::string value = absl::StrJoin(address_list, "\n", [&](std::string* out, const auto& addr) {
+    absl::StrAppend(out, addr->asString(), "|", ttl.count(), "|", seconds_since_epoch);
+  });
   key_value_store_->addOrUpdate(host, value, absl::nullopt);
 }
 
@@ -728,6 +749,113 @@ void DnsCacheImpl::loadCacheEntries(
     return KeyValueStore::Iterate::Continue;
   };
   key_value_store_->iterate(load);
+}
+
+DnsCacheImpl::DnsHostInfoImpl::DnsHostInfoImpl(DnsCacheImpl& parent,
+                                               absl::string_view resolved_host, bool is_ip_address)
+    : parent_(parent), resolved_host_(resolved_host), is_ip_address_(is_ip_address),
+      stale_at_time_(parent_.main_thread_dispatcher_.timeSource().monotonicTime()) {
+  touch();
+}
+
+Network::Address::InstanceConstSharedPtr DnsCacheImpl::DnsHostInfoImpl::address() const {
+  if (Runtime::runtimeFeatureEnabled(
+          "envoy.reloadable_features.dns_cache_filter_unusable_ip_version")) {
+    auto ip_version_to_remove = parent_.getIpVersionToRemove();
+    absl::ReaderMutexLock lock{&resolve_lock_};
+    for (const auto& address : address_list_) {
+      if (!ip_version_to_remove || address->ip()->version() != *ip_version_to_remove) {
+        return address;
+      }
+    }
+    return nullptr;
+  }
+  absl::ReaderMutexLock lock{&resolve_lock_};
+  return !address_list_.empty() ? address_list_.front() : nullptr;
+}
+
+std::vector<Network::Address::InstanceConstSharedPtr>
+DnsCacheImpl::DnsHostInfoImpl::addressList(const bool filtered) const {
+  if (filtered && Runtime::runtimeFeatureEnabled(
+                      "envoy.reloadable_features.dns_cache_filter_unusable_ip_version")) {
+    auto ip_version_to_remove = parent_.getIpVersionToRemove();
+    if (ip_version_to_remove.has_value()) {
+      std::vector<Network::Address::InstanceConstSharedPtr> ret;
+      absl::ReaderMutexLock lock{&resolve_lock_};
+      for (const auto& address : address_list_) {
+        if (address->ip()->version() != *ip_version_to_remove) {
+          ret.push_back(address);
+        }
+      }
+      return ret;
+    }
+  }
+  std::vector<Network::Address::InstanceConstSharedPtr> ret;
+  absl::ReaderMutexLock lock{&resolve_lock_};
+  ret = address_list_;
+  return ret;
+}
+
+const std::string& DnsCacheImpl::DnsHostInfoImpl::resolvedHost() const { return resolved_host_; }
+
+bool DnsCacheImpl::DnsHostInfoImpl::isIpAddress() const { return is_ip_address_; }
+
+void DnsCacheImpl::DnsHostInfoImpl::touch() {
+  last_used_time_ = parent_.main_thread_dispatcher_.timeSource().monotonicTime().time_since_epoch();
+}
+
+void DnsCacheImpl::DnsHostInfoImpl::updateStale(MonotonicTime resolution_time,
+                                                std::chrono::seconds ttl) {
+  stale_at_time_ = resolution_time + ttl;
+}
+
+bool DnsCacheImpl::DnsHostInfoImpl::isStale() {
+  return parent_.main_thread_dispatcher_.timeSource().monotonicTime() >
+         static_cast<MonotonicTime>(stale_at_time_);
+}
+
+void DnsCacheImpl::DnsHostInfoImpl::setAddresses(
+    std::vector<Network::Address::InstanceConstSharedPtr>&& list, absl::string_view details,
+    Network::DnsResolver::ResolutionStatus resolution_status) {
+  absl::WriterMutexLock lock{&resolve_lock_};
+  address_list_ = std::move(list);
+  details_ = details;
+  resolution_status_ = resolution_status;
+}
+
+void DnsCacheImpl::DnsHostInfoImpl::setDetails(absl::string_view details) {
+  absl::WriterMutexLock lock{&resolve_lock_};
+  details_ = details;
+}
+
+std::string DnsCacheImpl::DnsHostInfoImpl::details() {
+  absl::ReaderMutexLock lock{&resolve_lock_};
+  return details_;
+}
+
+std::chrono::steady_clock::duration DnsCacheImpl::DnsHostInfoImpl::lastUsedTime() const {
+  return last_used_time_.load();
+}
+
+bool DnsCacheImpl::DnsHostInfoImpl::firstResolveComplete() const {
+  absl::ReaderMutexLock lock{&resolve_lock_};
+  return first_resolve_complete_;
+}
+
+void DnsCacheImpl::DnsHostInfoImpl::setFirstResolveComplete() {
+  absl::WriterMutexLock lock{&resolve_lock_};
+  first_resolve_complete_ = true;
+}
+
+void DnsCacheImpl::DnsHostInfoImpl::setResolutionStatus(
+    Network::DnsResolver::ResolutionStatus resolution_status) {
+  absl::WriterMutexLock lock{&resolve_lock_};
+  resolution_status_ = resolution_status;
+}
+
+Network::DnsResolver::ResolutionStatus DnsCacheImpl::DnsHostInfoImpl::resolutionStatus() const {
+  absl::WriterMutexLock lock{&resolve_lock_};
+  return resolution_status_;
 }
 
 } // namespace DynamicForwardProxy

--- a/source/extensions/common/dynamic_forward_proxy/dns_cache_impl.cc
+++ b/source/extensions/common/dynamic_forward_proxy/dns_cache_impl.cc
@@ -345,6 +345,7 @@ void DnsCacheImpl::forceRefreshHosts() {
 }
 
 void DnsCacheImpl::setIpVersionToRemove(absl::optional<Network::Address::IpVersion> ip_version) {
+        std::cerr << "==> AAB setIpVersionToRemove" << std::endl;
   bool has_changed = false;
   {
     absl::MutexLock lock{&ip_version_to_remove_lock_};
@@ -359,6 +360,7 @@ void DnsCacheImpl::setIpVersionToRemove(absl::optional<Network::Address::IpVersi
     absl::ReaderMutexLock reader_lock{&primary_hosts_lock_};
     for (auto& primary_host : primary_hosts_) {
       for (auto* callbacks : update_callbacks_) {
+        std::cerr << "==> AAB onDnsHostAddOrUpdate: 1" << std::endl;
         auto status = callbacks->callbacks_.onDnsHostAddOrUpdate(primary_host.first,
                                                                  primary_host.second->host_info_);
         if (!status.ok()) {
@@ -586,6 +588,7 @@ void DnsCacheImpl::finishResolve(const std::string& host,
 absl::Status DnsCacheImpl::runAddUpdateCallbacks(const std::string& host,
                                                  const DnsHostInfoSharedPtr& host_info) {
   for (auto* callbacks : update_callbacks_) {
+    std::cerr << "==> AAB onDnsHostAddOrUpdate: 2" << std::endl;
     RETURN_IF_NOT_OK(callbacks->callbacks_.onDnsHostAddOrUpdate(host, host_info));
   }
   return absl::OkStatus();

--- a/test/extensions/clusters/dynamic_forward_proxy/cluster_test.cc
+++ b/test/extensions/clusters/dynamic_forward_proxy/cluster_test.cc
@@ -105,7 +105,7 @@ public:
 
     // Allow touch() to still be strict.
     EXPECT_CALL(*host_map_[host], address()).Times(AtLeast(0));
-    EXPECT_CALL(*host_map_[host], addressList()).Times(AtLeast(0));
+    EXPECT_CALL(*host_map_[host], addressList(_)).Times(AtLeast(0));
     EXPECT_CALL(*host_map_[host], isIpAddress()).Times(AtLeast(0));
     EXPECT_CALL(*host_map_[host], resolvedHost()).Times(AtLeast(0));
   }

--- a/test/extensions/common/dynamic_forward_proxy/dns_cache_impl_test.cc
+++ b/test/extensions/common/dynamic_forward_proxy/dns_cache_impl_test.cc
@@ -1527,6 +1527,106 @@ TEST_F(DnsCacheImplTest, NoDefaultSearchDomainOptionUnSet) {
   EXPECT_EQ(false, cares.dns_resolver_options().no_default_search_domain());
 }
 
+TEST_F(DnsCacheImplTest, SetIpVersionToRemoveYieldsNonEmptyResponseWithFilter) {
+  scoped_runtime_.mergeValues(
+      {{"envoy.reloadable_features.dns_cache_filter_unusable_ip_version", "true"}});
+
+  initialize();
+  InSequence s;
+
+  MockLoadDnsCacheEntryCallbacks callbacks;
+  Network::DnsResolver::ResolveCb resolve_cb;
+  Event::MockTimer* resolve_timer =
+      new Event::MockTimer(&context_.server_factory_context_.dispatcher_);
+  Event::MockTimer* timeout_timer =
+      new Event::MockTimer(&context_.server_factory_context_.dispatcher_);
+
+  // Set the IPv6 to be removed.
+  dns_cache_->setIpVersionToRemove(Network::Address::IpVersion::v6);
+  EXPECT_CALL(*timeout_timer, enableTimer(std::chrono::milliseconds(5000), nullptr));
+  EXPECT_CALL(*resolver_, resolve("foo.com", _, _))
+      .WillOnce(DoAll(SaveArg<2>(&resolve_cb), Return(&resolver_->active_query_)));
+  auto result = dns_cache_->loadDnsCacheEntry("foo.com", 80, false, callbacks);
+  EXPECT_EQ(DnsCache::LoadDnsCacheEntryStatus::Loading, result.status_);
+  EXPECT_NE(result.handle_, nullptr);
+  EXPECT_EQ(absl::nullopt, result.host_info_);
+  EXPECT_CALL(*timeout_timer, disableTimer());
+  //   EXPECT_CALL(callbacks,
+  //               onLoadDnsCacheComplete(DnsHostInfoEquals("127.0.0.2:80", "foo.com", false)));
+  //   EXPECT_CALL(update_callbacks_,
+  //               onDnsResolutionComplete("foo.com:80",
+  //                                       DnsHostInfoEquals("127.0.0.2:80", "foo.com", false),
+  //                                       Network::DnsResolver::ResolutionStatus::Completed));
+  std::cerr << "==> AAB TEST 9" << std::endl;
+  EXPECT_CALL(
+      update_callbacks_,
+      onDnsHostAddOrUpdate("foo.com:80", DnsHostInfoEquals("127.0.0.2:80", "foo.com", false)));
+  EXPECT_CALL(callbacks,
+              onLoadDnsCacheComplete(DnsHostInfoEquals("127.0.0.2:80", "foo.com", false)));
+  EXPECT_CALL(update_callbacks_,
+              onDnsResolutionComplete("foo.com:80",
+                                      DnsHostInfoEquals("127.0.0.2:80", "foo.com", false),
+                                      Network::DnsResolver::ResolutionStatus::Completed));
+  EXPECT_CALL(*resolve_timer, enableTimer(std::chrono::milliseconds(dns_ttl_), _));
+  resolve_cb(Network::DnsResolver::ResolutionStatus::Completed, "",
+             TestUtility::makeDnsResponse({"127.0.0.2", "::2"}));
+  // Verify that only the address is now set to an IPv4.
+  result = dns_cache_->loadDnsCacheEntry("foo.com", 80, false, callbacks);
+  EXPECT_EQ(DnsCache::LoadDnsCacheEntryStatus::InCache, result.status_);
+  EXPECT_EQ(result.handle_, nullptr);
+  ASSERT_NE(absl::nullopt, result.host_info_);
+  EXPECT_THAT(*result.host_info_, DnsHostInfoEquals("127.0.0.2:80", "foo.com", false));
+
+  std::cerr << "==> AAB TEST 10" << std::endl;
+  // Force refresh the hosts and set the IPv4 to be removed.
+  EXPECT_CALL(update_callbacks_,
+              onDnsHostAddOrUpdate("foo.com:80", DnsHostInfoEquals("[::2]:80", "foo.com", false)));
+  dns_cache_->setIpVersionToRemove(Network::Address::IpVersion::v4);
+  std::cerr << "==> AAB TEST 11" << std::endl;
+  EXPECT_CALL(*resolver_, resetNetworking());
+  EXPECT_CALL(*timeout_timer, enabled()).Times(AtLeast(0));
+  EXPECT_CALL(*resolve_timer, enableTimer(std::chrono::milliseconds(0), _));
+  EXPECT_CALL(*timeout_timer, disableTimer());
+  EXPECT_CALL(update_callbacks_,
+              onDnsHostAddOrUpdate("foo.com:80", DnsHostInfoEquals("[::2]:80", "foo.com", false)));
+  EXPECT_CALL(update_callbacks_,
+              onDnsResolutionComplete("foo.com:80", DnsHostInfoEquals("[::2]:80", "foo.com", false),
+                                      Network::DnsResolver::ResolutionStatus::Completed));
+  EXPECT_CALL(*resolve_timer, enableTimer(std::chrono::milliseconds(dns_ttl_), _));
+  dns_cache_->forceRefreshHosts();
+  resolve_cb(Network::DnsResolver::ResolutionStatus::Completed, "",
+             TestUtility::makeDnsResponse({"127.0.0.2", "::2"}));
+  // Verify that only the address is now set to an IPv6.
+  result = dns_cache_->loadDnsCacheEntry("foo.com", 80, false, callbacks);
+  EXPECT_EQ(DnsCache::LoadDnsCacheEntryStatus::InCache, result.status_);
+  EXPECT_EQ(result.handle_, nullptr);
+  ASSERT_NE(absl::nullopt, result.host_info_);
+  EXPECT_THAT(*result.host_info_, DnsHostInfoEquals("[::2]:80", "foo.com", false));
+
+  // Force refresh the hosts and set the IP version to be removed to empty.
+  dns_cache_->setIpVersionToRemove(absl::nullopt);
+  EXPECT_CALL(*timeout_timer, enabled()).Times(AtLeast(0));
+  EXPECT_CALL(*resolve_timer, enableTimer(std::chrono::milliseconds(0), _));
+  EXPECT_CALL(*timeout_timer, disableTimer());
+  EXPECT_CALL(
+      update_callbacks_,
+      onDnsHostAddOrUpdate("foo.com:80", DnsHostInfoEquals("127.0.0.2:80", "foo.com", false)));
+  EXPECT_CALL(update_callbacks_,
+              onDnsResolutionComplete("foo.com:80",
+                                      DnsHostInfoEquals("127.0.0.2:80", "foo.com", false),
+                                      Network::DnsResolver::ResolutionStatus::Completed));
+  EXPECT_CALL(*resolve_timer, enableTimer(std::chrono::milliseconds(dns_ttl_), _));
+  dns_cache_->forceRefreshHosts();
+  resolve_cb(Network::DnsResolver::ResolutionStatus::Completed, "",
+             TestUtility::makeDnsResponse({"127.0.0.2", "::2"}));
+  // Verify that only the address is now set to an IPv4 (the first entry in the DNS response).
+  result = dns_cache_->loadDnsCacheEntry("foo.com", 80, false, callbacks);
+  EXPECT_EQ(DnsCache::LoadDnsCacheEntryStatus::InCache, result.status_);
+  EXPECT_EQ(result.handle_, nullptr);
+  ASSERT_NE(absl::nullopt, result.host_info_);
+  EXPECT_THAT(*result.host_info_, DnsHostInfoEquals("127.0.0.2:80", "foo.com", false));
+}
+
 TEST_F(DnsCacheImplTest, SetIpVersionToRemoveYieldsNonEmptyResponse) {
   scoped_runtime_.mergeValues(
       {{"envoy.reloadable_features.dns_cache_set_ip_version_to_remove", "true"}});

--- a/test/extensions/common/dynamic_forward_proxy/dns_cache_impl_test.cc
+++ b/test/extensions/common/dynamic_forward_proxy/dns_cache_impl_test.cc
@@ -2167,7 +2167,7 @@ TEST_F(DnsCacheImplTest, CacheLoad) {
     EXPECT_EQ(DnsCache::LoadDnsCacheEntryStatus::InCache, result.status_);
     EXPECT_EQ(result.handle_, nullptr);
     EXPECT_NE(absl::nullopt, result.host_info_);
-    EXPECT_EQ(1, result.host_info_.value()->addressList().size());
+    EXPECT_EQ(1, result.host_info_.value()->addressList(/*filtered=*/false).size());
   }
 
   {
@@ -2176,7 +2176,7 @@ TEST_F(DnsCacheImplTest, CacheLoad) {
     EXPECT_EQ(DnsCache::LoadDnsCacheEntryStatus::InCache, result.status_);
     EXPECT_EQ(result.handle_, nullptr);
     ASSERT_NE(absl::nullopt, result.host_info_);
-    EXPECT_EQ(2, result.host_info_.value()->addressList().size());
+    EXPECT_EQ(2, result.host_info_.value()->addressList(/*filtered=*/false).size());
   }
 }
 
@@ -2246,7 +2246,7 @@ TEST_F(DnsCacheImplTest, SingleAddressCache) {
   auto result = dns_cache_->loadDnsCacheEntry("foo.com", 80, false, callbacks);
   EXPECT_EQ(DnsCache::LoadDnsCacheEntryStatus::InCache, result.status_);
   ASSERT_NE(absl::nullopt, result.host_info_);
-  EXPECT_EQ(1, result.host_info_.value()->addressList().size());
+  EXPECT_EQ(1, result.host_info_.value()->addressList(/*filtered=*/false).size());
 }
 
 TEST_F(DnsCacheImplTest, CacheLoadParsingErrors) {

--- a/test/extensions/common/dynamic_forward_proxy/dns_cache_impl_test.cc
+++ b/test/extensions/common/dynamic_forward_proxy/dns_cache_impl_test.cc
@@ -1541,7 +1541,7 @@ TEST_F(DnsCacheImplTest, SetIpVersionToRemoveYieldsNonEmptyResponseWithFilter) {
   Event::MockTimer* timeout_timer =
       new Event::MockTimer(&context_.server_factory_context_.dispatcher_);
 
-  // Set the IPv6 to be removed.
+  // Set IPv6 to be removed.
   dns_cache_->setIpVersionToRemove(Network::Address::IpVersion::v6);
   EXPECT_CALL(*timeout_timer, enableTimer(std::chrono::milliseconds(5000), nullptr));
   EXPECT_CALL(*resolver_, resolve("foo.com", _, _))
@@ -1551,13 +1551,6 @@ TEST_F(DnsCacheImplTest, SetIpVersionToRemoveYieldsNonEmptyResponseWithFilter) {
   EXPECT_NE(result.handle_, nullptr);
   EXPECT_EQ(absl::nullopt, result.host_info_);
   EXPECT_CALL(*timeout_timer, disableTimer());
-  //   EXPECT_CALL(callbacks,
-  //               onLoadDnsCacheComplete(DnsHostInfoEquals("127.0.0.2:80", "foo.com", false)));
-  //   EXPECT_CALL(update_callbacks_,
-  //               onDnsResolutionComplete("foo.com:80",
-  //                                       DnsHostInfoEquals("127.0.0.2:80", "foo.com", false),
-  //                                       Network::DnsResolver::ResolutionStatus::Completed));
-  std::cerr << "==> AAB TEST 9" << std::endl;
   EXPECT_CALL(
       update_callbacks_,
       onDnsHostAddOrUpdate("foo.com:80", DnsHostInfoEquals("127.0.0.2:80", "foo.com", false)));
@@ -1577,54 +1570,16 @@ TEST_F(DnsCacheImplTest, SetIpVersionToRemoveYieldsNonEmptyResponseWithFilter) {
   ASSERT_NE(absl::nullopt, result.host_info_);
   EXPECT_THAT(*result.host_info_, DnsHostInfoEquals("127.0.0.2:80", "foo.com", false));
 
-  std::cerr << "==> AAB TEST 10" << std::endl;
-  // Force refresh the hosts and set the IPv4 to be removed.
+  // Set IPv4 to be removed.
   EXPECT_CALL(update_callbacks_,
               onDnsHostAddOrUpdate("foo.com:80", DnsHostInfoEquals("[::2]:80", "foo.com", false)));
   dns_cache_->setIpVersionToRemove(Network::Address::IpVersion::v4);
-  std::cerr << "==> AAB TEST 11" << std::endl;
-  EXPECT_CALL(*resolver_, resetNetworking());
-  EXPECT_CALL(*timeout_timer, enabled()).Times(AtLeast(0));
-  EXPECT_CALL(*resolve_timer, enableTimer(std::chrono::milliseconds(0), _));
-  EXPECT_CALL(*timeout_timer, disableTimer());
-  EXPECT_CALL(update_callbacks_,
-              onDnsHostAddOrUpdate("foo.com:80", DnsHostInfoEquals("[::2]:80", "foo.com", false)));
-  EXPECT_CALL(update_callbacks_,
-              onDnsResolutionComplete("foo.com:80", DnsHostInfoEquals("[::2]:80", "foo.com", false),
-                                      Network::DnsResolver::ResolutionStatus::Completed));
-  EXPECT_CALL(*resolve_timer, enableTimer(std::chrono::milliseconds(dns_ttl_), _));
-  dns_cache_->forceRefreshHosts();
-  resolve_cb(Network::DnsResolver::ResolutionStatus::Completed, "",
-             TestUtility::makeDnsResponse({"127.0.0.2", "::2"}));
-  // Verify that only the address is now set to an IPv6.
-  result = dns_cache_->loadDnsCacheEntry("foo.com", 80, false, callbacks);
-  EXPECT_EQ(DnsCache::LoadDnsCacheEntryStatus::InCache, result.status_);
-  EXPECT_EQ(result.handle_, nullptr);
-  ASSERT_NE(absl::nullopt, result.host_info_);
-  EXPECT_THAT(*result.host_info_, DnsHostInfoEquals("[::2]:80", "foo.com", false));
 
-  // Force refresh the hosts and set the IP version to be removed to empty.
-  dns_cache_->setIpVersionToRemove(absl::nullopt);
-  EXPECT_CALL(*timeout_timer, enabled()).Times(AtLeast(0));
-  EXPECT_CALL(*resolve_timer, enableTimer(std::chrono::milliseconds(0), _));
-  EXPECT_CALL(*timeout_timer, disableTimer());
+  // Set the IP version to be removed to empty.
   EXPECT_CALL(
       update_callbacks_,
       onDnsHostAddOrUpdate("foo.com:80", DnsHostInfoEquals("127.0.0.2:80", "foo.com", false)));
-  EXPECT_CALL(update_callbacks_,
-              onDnsResolutionComplete("foo.com:80",
-                                      DnsHostInfoEquals("127.0.0.2:80", "foo.com", false),
-                                      Network::DnsResolver::ResolutionStatus::Completed));
-  EXPECT_CALL(*resolve_timer, enableTimer(std::chrono::milliseconds(dns_ttl_), _));
-  dns_cache_->forceRefreshHosts();
-  resolve_cb(Network::DnsResolver::ResolutionStatus::Completed, "",
-             TestUtility::makeDnsResponse({"127.0.0.2", "::2"}));
-  // Verify that only the address is now set to an IPv4 (the first entry in the DNS response).
-  result = dns_cache_->loadDnsCacheEntry("foo.com", 80, false, callbacks);
-  EXPECT_EQ(DnsCache::LoadDnsCacheEntryStatus::InCache, result.status_);
-  EXPECT_EQ(result.handle_, nullptr);
-  ASSERT_NE(absl::nullopt, result.host_info_);
-  EXPECT_THAT(*result.host_info_, DnsHostInfoEquals("127.0.0.2:80", "foo.com", false));
+  dns_cache_->setIpVersionToRemove(absl::nullopt);
 }
 
 TEST_F(DnsCacheImplTest, SetIpVersionToRemoveYieldsNonEmptyResponse) {

--- a/test/extensions/common/dynamic_forward_proxy/mocks.cc
+++ b/test/extensions/common/dynamic_forward_proxy/mocks.cc
@@ -30,7 +30,7 @@ MockDnsCacheManager::~MockDnsCacheManager() = default;
 
 MockDnsHostInfo::MockDnsHostInfo() {
   ON_CALL(*this, address()).WillByDefault(ReturnPointee(&address_));
-  ON_CALL(*this, addressList()).WillByDefault(ReturnPointee(&address_list_));
+  ON_CALL(*this, addressList(_)).WillByDefault(ReturnPointee(&address_list_));
   ON_CALL(*this, resolvedHost()).WillByDefault(ReturnRef(resolved_host_));
 }
 MockDnsHostInfo::~MockDnsHostInfo() = default;

--- a/test/extensions/common/dynamic_forward_proxy/mocks.h
+++ b/test/extensions/common/dynamic_forward_proxy/mocks.h
@@ -65,6 +65,7 @@ public:
   MOCK_METHOD(Upstream::ResourceAutoIncDec*, canCreateDnsRequest_, ());
   MOCK_METHOD(void, forceRefreshHosts, ());
   MOCK_METHOD(void, setIpVersionToRemove, (absl::optional<Network::Address::IpVersion>));
+  MOCK_METHOD(absl::optional<Network::Address::IpVersion>, getIpVersionToRemove, ());
   MOCK_METHOD(void, stop, ());
 };
 
@@ -94,7 +95,7 @@ public:
   ~MockDnsHostInfo() override;
 
   MOCK_METHOD(Network::Address::InstanceConstSharedPtr, address, (), (const));
-  MOCK_METHOD(std::vector<Network::Address::InstanceConstSharedPtr>, addressList, (), (const));
+  MOCK_METHOD(std::vector<Network::Address::InstanceConstSharedPtr>, addressList, (bool), (const));
   MOCK_METHOD(const std::string&, resolvedHost, (), (const));
   MOCK_METHOD(bool, isIpAddress, (), (const));
   MOCK_METHOD(void, touch, ());


### PR DESCRIPTION
In Mobile, whenever there is a network change, there's a check to see if there is IPv6 connectivity on the current network. If there is no IPv6 connectivity and the `dns_cache_set_ip_version_to_remove` runtime guard is true, the IPv6 addresses would get filtered out from the DNS lookup response.

This is problematic because if there is a network change and the device now has IPv6 connectivity, the DNS cache will have filtered out the IPv6 addresses already and won't be able to use them to connect to the peer.

This change fixes the issue by storing all resolved IP addresses in the DNS cache, and only filtering out the IP address families that don't have connectivity in the DFP cluster. This has the further benefit of avoiding having to re-resolve DNS host entries whenever there is a network change.

The change is guarded by `envoy.reloadable_features.dns_cache_filter_unusable_ip_version`, which defaults to false.

Risk Level: low (runtime guarded)
Testing: Unit/Integration
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
Runtime guard: envoy.reloadable_features.dns_cache_filter_unusable_ip_version
