### PR TITLE
Fix coverage reports for ext_proc tests

### DIFF
--- a/source/extensions/filters/http/ext_proc/BUILD
+++ b/source/extensions/filters/http/ext_proc/BUILD
@@ -48,8 +48,8 @@ envoy_cc_library(
 
 envoy_cc_library(
     name = "client_lib",
-    hdrs = ["client_impl.h"],
     srcs = ["client_impl.cc"],
+    hdrs = ["client_impl.h"],
     deps = [
         "//envoy/grpc:async_client_manager_interface",
         "//source/common/http:sidestream_watermark_lib",

--- a/source/extensions/filters/http/ext_proc/BUILD
+++ b/source/extensions/filters/http/ext_proc/BUILD
@@ -49,6 +49,7 @@ envoy_cc_library(
 envoy_cc_library(
     name = "client_lib",
     hdrs = ["client_impl.h"],
+    srcs = ["client_impl.cc"],
     deps = [
         "//envoy/grpc:async_client_manager_interface",
         "//source/common/http:sidestream_watermark_lib",

--- a/source/extensions/filters/http/ext_proc/client_impl.cc
+++ b/source/extensions/filters/http/ext_proc/client_impl.cc
@@ -1,0 +1,21 @@
+#include "source/extensions/filters/http/ext_proc/client_impl.h"
+
+#include "source/extensions/filters/common/ext_proc/grpc_client_impl.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace ExternalProcessing {
+
+ExternalProcessorClientPtr
+createExternalProcessorClient(Grpc::AsyncClientManager& client_manager, Stats::Scope& scope) {
+  static constexpr char kExternalMethod[] = "envoy.service.ext_proc.v3.ExternalProcessor.Process";
+  return std::make_unique<
+      CommonExtProc::ProcessorClientImpl<ProcessingRequest, ProcessingResponse>>(
+      client_manager, scope, kExternalMethod);
+}
+
+} // namespace ExternalProcessing
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/http/ext_proc/client_impl.cc
+++ b/source/extensions/filters/http/ext_proc/client_impl.cc
@@ -7,8 +7,8 @@ namespace Extensions {
 namespace HttpFilters {
 namespace ExternalProcessing {
 
-ExternalProcessorClientPtr
-createExternalProcessorClient(Grpc::AsyncClientManager& client_manager, Stats::Scope& scope) {
+ExternalProcessorClientPtr createExternalProcessorClient(Grpc::AsyncClientManager& client_manager,
+                                                         Stats::Scope& scope) {
   static constexpr char kExternalMethod[] = "envoy.service.ext_proc.v3.ExternalProcessor.Process";
   return std::make_unique<
       CommonExtProc::ProcessorClientImpl<ProcessingRequest, ProcessingResponse>>(

--- a/source/extensions/filters/http/ext_proc/client_impl.h
+++ b/source/extensions/filters/http/ext_proc/client_impl.h
@@ -32,8 +32,8 @@ using ExternalProcessorClientPtr = std::unique_ptr<ExternalProcessorClient>;
 
 using ClientBasePtr = CommonExtProc::ClientBasePtr<ProcessingRequest, ProcessingResponse>;
 
-ExternalProcessorClientPtr
-createExternalProcessorClient(Grpc::AsyncClientManager& client_manager, Stats::Scope& scope);
+ExternalProcessorClientPtr createExternalProcessorClient(Grpc::AsyncClientManager& client_manager,
+                                                         Stats::Scope& scope);
 
 } // namespace ExternalProcessing
 } // namespace HttpFilters

--- a/source/extensions/filters/http/ext_proc/client_impl.h
+++ b/source/extensions/filters/http/ext_proc/client_impl.h
@@ -9,7 +9,6 @@
 
 #include "source/common/http/sidestream_watermark.h"
 #include "source/extensions/filters/common/ext_proc/grpc_client.h"
-#include "source/extensions/filters/common/ext_proc/grpc_client_impl.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -33,13 +32,8 @@ using ExternalProcessorClientPtr = std::unique_ptr<ExternalProcessorClient>;
 
 using ClientBasePtr = CommonExtProc::ClientBasePtr<ProcessingRequest, ProcessingResponse>;
 
-inline ExternalProcessorClientPtr
-createExternalProcessorClient(Grpc::AsyncClientManager& client_manager, Stats::Scope& scope) {
-  static constexpr char kExternalMethod[] = "envoy.service.ext_proc.v3.ExternalProcessor.Process";
-  return std::make_unique<
-      CommonExtProc::ProcessorClientImpl<ProcessingRequest, ProcessingResponse>>(
-      client_manager, scope, kExternalMethod);
-}
+ExternalProcessorClientPtr
+createExternalProcessorClient(Grpc::AsyncClientManager& client_manager, Stats::Scope& scope);
 
 } // namespace ExternalProcessing
 } // namespace HttpFilters

--- a/test/per_file_coverage.sh
+++ b/test/per_file_coverage.sh
@@ -27,7 +27,6 @@ declare -a KNOWN_LOW_COVERAGE=(
 "source/extensions/common/tap:94.6"
 "source/extensions/common/wasm:95.3" # flaky: be careful adjusting
 "source/extensions/common/wasm/ext:92.0"
-"source/extensions/filters/common/ext_proc:85.6" # comment is counted by LCOV #37911
 "source/extensions/filters/common/fault:94.5"
 "source/extensions/filters/common/rbac:92.6"
 "source/extensions/filters/http/cache:95.9"


### PR DESCRIPTION
Commit Message:

In #38898 @botengyao added an exception for the ext_proc tests for coverage. That's because clang source based coverage reported missing coverage for the comments (the desirable behavior here is that comments are not counted in the coverage reports).

Digging through it, what I realized is that for only some tests report counters for the comments. And all the tests that report thos bogus counters don't actually exercise the affected code.

I still don't fully understand what triggers the issue here, but that observation suggests a workaround that this PR implements. I basically remove dependency on the grpc_client_impl.h from the tests that don't need it.

I started a thread on LLVM discussions (https://discourse.llvm.org/t/llvm-source-based-coverage-sometimes-generates-counter-for-comments/85730), but given that I couldn't come up with a small enough reproducer, I don't think that we can resolve it quickly.

That being said, removing unnecessary includes and moving functions from headers to cc files is in general a good strategy as it reduces depndencies between translation units and reduces the amount of work compiler has to do, so I think we can still push this workaround upstream, even though I don't have a root cause for the problem.

Additional Description:

It was reported in #37911, but other than that I don't think it's relevant.

Risk Level: n/a
Testing: regular CI tests, but with coverage targets changed to remove the exception for the ext_proc.
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
