### PR TITLE
docs: link to the moved sandboxes example project

### DIFF
--- a/docs/root/start/sandboxes/index.rst
+++ b/docs/root/start/sandboxes/index.rst
@@ -13,7 +13,7 @@ Sandboxes
    `Pull Request <https://github.com/envoyproxy/envoy/pulls>`_ with the necessary changes
    should you be able to create one.
 
-   :repo:`See the sandbox developer documentation <examples/DEVELOPER.md>` for more information about
+   `See the sandbox developer documentation in the envoyproxy/examples project <https://github.com/envoyproxy/examples/blob/main/DEVELOPER.md>`_ for more information about
    creating your own sandbox.
 
 .. sidebar:: Compatibility


### PR DESCRIPTION
Commit Message: docs: link to the moved sandboxes example project
Additional Description: since the move of the sandboxes to the examples project the link to the getting started for developers has been broken.
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
