### PR TITLE
Disable exceptions in spdlog

### DIFF
--- a/bazel/external/spdlog.BUILD
+++ b/bazel/external/spdlog.BUILD
@@ -5,7 +5,10 @@ cc_library(
     hdrs = glob([
         "include/**/*.h",
     ]),
-    defines = ["SPDLOG_FMT_EXTERNAL"],
+    defines = [
+        "SPDLOG_FMT_EXTERNAL",
+        "SPDLOG_NO_EXCEPTIONS",
+    ],
     includes = ["include"],
     visibility = ["//visibility:public"],
     deps = ["@com_github_fmtlib_fmt//:fmtlib"],

--- a/source/extensions/compression/gzip/decompressor/zlib_decompressor_impl.cc
+++ b/source/extensions/compression/gzip/decompressor/zlib_decompressor_impl.cc
@@ -87,7 +87,7 @@ bool ZlibDecompressorImpl::inflateNext() {
     ENVOY_LOG(trace,
               "zlib decompression error: {}, msg: {}. Error codes are defined in "
               "https://www.zlib.net/manual.html",
-              result, zstream_ptr_->msg);
+              result, zstream_ptr_->msg ? zstream_ptr_->msg : "nullptr");
     chargeErrorStats(result);
     return false;
   }


### PR DESCRIPTION
Commit Message:
This should have been done originally, since this is a risk on the dataplane if input to spdlog causes an exception. It is better to produce a truncated log output than crash.

Risk Level: Low, we do not rely on exceptions in spdlog
Testing: unit tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
