### PR TITLE
fips: add compliance policy to TLS context

### DIFF
--- a/api/envoy/extensions/transport_sockets/tls/v3/common.proto
+++ b/api/envoy/extensions/transport_sockets/tls/v3/common.proto
@@ -53,7 +53,7 @@ message TlsParameters {
     //   * For TLS 1.2, only ECDHE_[RSA|ECDSA]_WITH_AES_*_GCM_SHA*.
     //   * For TLS 1.3, only AES-GCM
     //   * P-256 or P-384 for key agreement.
-    //   * For server signatures, only PKCS#1/PSS with SHA256/384/512, or ECDSA
+    //   * For server signatures, only ``PKCS#1/PSS`` with ``SHA256/384/512``, or ECDSA
     //     with P-256 or P-384.
     //
     // Note: this policy can be configured even if BoringSSL has not been built in

--- a/api/envoy/extensions/transport_sockets/tls/v3/common.proto
+++ b/api/envoy/extensions/transport_sockets/tls/v3/common.proto
@@ -45,6 +45,25 @@ message TlsParameters {
     TLSv1_3 = 4;
   }
 
+  enum CompliancePolicy {
+    NONE = 0;
+
+    // FIPS_202205 configures a TLS connection to use:
+    //   * TLS 1.2 or 1.3
+    //   * For TLS 1.2, only ECDHE_[RSA|ECDSA]_WITH_AES_*_GCM_SHA*.
+    //   * For TLS 1.3, only AES-GCM
+    //   * P-256 or P-384 for key agreement.
+    //   * For server signatures, only PKCS#1/PSS with SHA256/384/512, or ECDSA
+    //     with P-256 or P-384.
+    //
+    // Note: this policy can be configured even if BoringSSL has not been built in
+    // FIPS mode.
+    //
+    // Note: this setting aids with compliance with NIST requirements but does not
+    // guarantee it. Careful reading of SP 800-52r2 is recommended.
+    FIPS_202205 = 1;
+  }
+
   // Minimum TLS protocol version. By default, it's ``TLSv1_2`` for both clients and servers.
   //
   // TLS protocol versions below TLSv1_2 require setting compatible ciphers with the
@@ -157,25 +176,6 @@ message TlsParameters {
   //   rsa_pkcs1_sha1
   //   ecdsa_sha1
   repeated string signature_algorithms = 5;
-
-  enum CompliancePolicy {
-    NONE = 0;
-
-    // FIPS_202205 configures a TLS connection to use:
-    //   * TLS 1.2 or 1.3
-    //   * For TLS 1.2, only ECDHE_[RSA|ECDSA]_WITH_AES_*_GCM_SHA*.
-    //   * For TLS 1.3, only AES-GCM
-    //   * P-256 or P-384 for key agreement.
-    //   * For server signatures, only PKCS#1/PSS with SHA256/384/512, or ECDSA
-    //     with P-256 or P-384.
-    //
-    // Note: this policy can be configured even if BoringSSL has not been built in
-    // FIPS mode.
-    //
-    // Note: this setting aids with compliance with NIST requirements but does not
-    // guarantee it. Careful reading of SP 800-52r2 is recommended.
-    FIPS_202205 = 1;
-  };
 
   // Compliance policy configures various aspects of the TLS based on the given policy.
   // The policies are applied last during configuration and may override the other TLS

--- a/api/envoy/extensions/transport_sockets/tls/v3/common.proto
+++ b/api/envoy/extensions/transport_sockets/tls/v3/common.proto
@@ -49,6 +49,7 @@ message TlsParameters {
     NONE = 0;
 
     // FIPS_202205 configures a TLS connection to use:
+    //
     //   * TLS 1.2 or 1.3
     //   * For TLS 1.2, only ECDHE_[RSA|ECDSA]_WITH_AES_*_GCM_SHA*.
     //   * For TLS 1.3, only AES-GCM
@@ -56,11 +57,10 @@ message TlsParameters {
     //   * For server signatures, only ``PKCS#1/PSS`` with ``SHA256/384/512``, or ECDSA
     //     with P-256 or P-384.
     //
-    // Note: this policy can be configured even if BoringSSL has not been built in
-    // FIPS mode.
+    // .. attention::
     //
-    // Note: this setting aids with compliance with NIST requirements but does not
-    // guarantee it. Careful reading of SP 800-52r2 is recommended.
+    //   Please refer to `BoringSSL policies <https://boringssl.googlesource.com/boringssl/+/refs/tags/0.20240913.0/include/openssl/ssl.h#5608>`_
+    //   for details.
     FIPS_202205 = 1;
   }
 

--- a/api/envoy/extensions/transport_sockets/tls/v3/common.proto
+++ b/api/envoy/extensions/transport_sockets/tls/v3/common.proto
@@ -177,10 +177,10 @@ message TlsParameters {
   //   ecdsa_sha1
   repeated string signature_algorithms = 5;
 
-  // Compliance policy configures various aspects of the TLS based on the given policy.
+  // Compliance policies configure various aspects of the TLS based on the given policy.
   // The policies are applied last during configuration and may override the other TLS
-  // parameters.
-  CompliancePolicy compliance_policy = 6;
+  // parameters, or any previous policy.
+  repeated CompliancePolicy compliance_policies = 6 [(validate.rules).repeated = {max_items: 1}];
 }
 
 // BoringSSL private key method configuration. The private key methods are used for external

--- a/api/envoy/extensions/transport_sockets/tls/v3/common.proto
+++ b/api/envoy/extensions/transport_sockets/tls/v3/common.proto
@@ -24,7 +24,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Common TLS configuration]
 
-// [#next-free-field: 6]
+// [#next-free-field: 7]
 message TlsParameters {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.auth.TlsParameters";
 
@@ -157,6 +157,30 @@ message TlsParameters {
   //   rsa_pkcs1_sha1
   //   ecdsa_sha1
   repeated string signature_algorithms = 5;
+
+  enum CompliancePolicy {
+    NONE = 0;
+
+    // FIPS_202205 configures a TLS connection to use:
+    //   * TLS 1.2 or 1.3
+    //   * For TLS 1.2, only ECDHE_[RSA|ECDSA]_WITH_AES_*_GCM_SHA*.
+    //   * For TLS 1.3, only AES-GCM
+    //   * P-256 or P-384 for key agreement.
+    //   * For server signatures, only PKCS#1/PSS with SHA256/384/512, or ECDSA
+    //     with P-256 or P-384.
+    //
+    // Note: this policy can be configured even if BoringSSL has not been built in
+    // FIPS mode.
+    //
+    // Note: this setting aids with compliance with NIST requirements but does not
+    // guarantee it. Careful reading of SP 800-52r2 is recommended.
+    FIPS_202205 = 1;
+  };
+
+  // Compliance policy configures various aspects of the TLS based on the given policy.
+  // The policies are applied last during configuration and may override the other TLS
+  // parameters.
+  CompliancePolicy compliance_policy = 6;
 }
 
 // BoringSSL private key method configuration. The private key methods are used for external

--- a/api/envoy/extensions/transport_sockets/tls/v3/common.proto
+++ b/api/envoy/extensions/transport_sockets/tls/v3/common.proto
@@ -46,8 +46,6 @@ message TlsParameters {
   }
 
   enum CompliancePolicy {
-    NONE = 0;
-
     // FIPS_202205 configures a TLS connection to use:
     //
     //   * TLS 1.2 or 1.3
@@ -61,7 +59,7 @@ message TlsParameters {
     //
     //   Please refer to `BoringSSL policies <https://boringssl.googlesource.com/boringssl/+/refs/tags/0.20240913.0/include/openssl/ssl.h#5608>`_
     //   for details.
-    FIPS_202205 = 1;
+    FIPS_202205 = 0;
   }
 
   // Minimum TLS protocol version. By default, it's ``TLSv1_2`` for both clients and servers.

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -54,8 +54,8 @@ minor_behavior_changes:
     FIPS build is updated to use the same version of boringssl as the regular build, per the revised FedRAMP policy.
 - area: tls
   change: |
-    Added a :ref:`compliance policy
-    <envoy_v3_api_field_extensions.transport_sockets.tls.v3.TlsParameters.compliance_policy>`
+    Added :ref:`compliance policies
+    <envoy_v3_api_field_extensions.transport_sockets.tls.v3.TlsParameters.compliance_policies>`
     TLS parameter to enforce restrictions based on a given policy (e.g. FIPS).
 
 bug_fixes:

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -52,6 +52,11 @@ minor_behavior_changes:
 - area: tls
   change: |
     FIPS build is updated to use the same version of boringssl as the regular build, per the revised FedRAMP policy.
+- area: tls
+  change: |
+    Add a `compliance policy
+    <envoy_v3_api_field_extensions.transport_sockets.tls.v3.TlsParameters.compliance_policy>`
+    TLS parameter to enforce restrictions based on a given policy (e.g. FIPS).
 
 bug_fixes:
 # *Changes expected to improve the state of the world and are unlikely to have negative effects*

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -54,7 +54,7 @@ minor_behavior_changes:
     FIPS build is updated to use the same version of boringssl as the regular build, per the revised FedRAMP policy.
 - area: tls
   change: |
-    Add a `compliance policy
+    Added a :ref:`compliance policy
     <envoy_v3_api_field_extensions.transport_sockets.tls.v3.TlsParameters.compliance_policy>`
     TLS parameter to enforce restrictions based on a given policy (e.g. FIPS).
 

--- a/envoy/ssl/BUILD
+++ b/envoy/ssl/BUILD
@@ -39,6 +39,7 @@ envoy_cc_library(
         ":handshaker_interface",
         ":tls_certificate_config_interface",
         "//source/common/network:cidr_range_interface",
+        "@envoy_api//envoy/extensions/transport_sockets/tls/v3:pkg_cc_proto",
     ],
 )
 

--- a/envoy/ssl/context_config.h
+++ b/envoy/ssl/context_config.h
@@ -122,7 +122,8 @@ public:
   /**
    * @return the compiance policy for the TLS context.
    */
-  virtual envoy::extensions::transport_sockets::tls::v3::TlsParameters::CompliancePolicy
+  virtual absl::optional<
+      envoy::extensions::transport_sockets::tls::v3::TlsParameters::CompliancePolicy>
   compliancePolicy() const PURE;
 };
 

--- a/envoy/ssl/context_config.h
+++ b/envoy/ssl/context_config.h
@@ -19,14 +19,6 @@
 namespace Envoy {
 namespace Ssl {
 
-// CompliancePolicy is defined in BoringSSL to enforce NIST policy restrictions.
-enum class CompliancePolicy {
-  // No policy restrictions are applied.
-  None,
-  // This corresponds to `ssl_compliance_policy_fips_202205' in BoringSSL.
-  FIPS_202205,
-};
-
 /**
  * Supplies the configuration for an SSL context.
  */

--- a/envoy/ssl/context_config.h
+++ b/envoy/ssl/context_config.h
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include "envoy/common/pure.h"
+#include "envoy/extensions/transport_sockets/tls/v3/common.pb.h"
 #include "envoy/ssl/certificate_validation_context_config.h"
 #include "envoy/ssl/handshaker.h"
 #include "envoy/ssl/tls_certificate_config.h"
@@ -129,7 +130,8 @@ public:
   /**
    * @return the compiance policy for the TLS context.
    */
-  virtual CompliancePolicy compliancePolicy() const PURE;
+  virtual envoy::extensions::transport_sockets::tls::v3::TlsParameters::CompliancePolicy
+  compliancePolicy() const PURE;
 };
 
 class ClientContextConfig : public virtual ContextConfig {

--- a/envoy/ssl/context_config.h
+++ b/envoy/ssl/context_config.h
@@ -18,6 +18,14 @@
 namespace Envoy {
 namespace Ssl {
 
+// CompliancePolicy is defined in BoringSSL to enforce NIST policy restrictions.
+enum class CompliancePolicy {
+  // No policy restrictions are applied.
+  None,
+  // This corresponds to `ssl_compliance_policy_fips_202205' in BoringSSL.
+  FIPS_202205,
+};
+
 /**
  * Supplies the configuration for an SSL context.
  */
@@ -117,6 +125,11 @@ public:
    * @return the access log manager object reference
    */
   virtual AccessLog::AccessLogManager& accessLogManager() const PURE;
+
+  /**
+   * @return the compiance policy for the TLS context.
+   */
+  virtual CompliancePolicy compliancePolicy() const PURE;
 };
 
 class ClientContextConfig : public virtual ContextConfig {

--- a/source/common/tls/context_config_impl.cc
+++ b/source/common/tls/context_config_impl.cc
@@ -125,19 +125,6 @@ getCertificateValidationContextConfigProvider(
   }
 }
 
-Envoy::Ssl::CompliancePolicy compliancePolicyFromProto(
-    const envoy::extensions::transport_sockets::tls::v3::TlsParameters::CompliancePolicy& policy) {
-  switch (policy) {
-    using ProtoPolicy = envoy::extensions::transport_sockets::tls::v3::TlsParameters;
-  case ProtoPolicy::NONE:
-    return Envoy::Ssl::CompliancePolicy::None;
-  case ProtoPolicy::FIPS_202205:
-    return Envoy::Ssl::CompliancePolicy::FIPS_202205;
-  default:
-    PANIC("not reached");
-  }
-}
-
 } // namespace
 
 ContextConfigImpl::ContextConfigImpl(
@@ -167,7 +154,7 @@ ContextConfigImpl::ContextConfigImpl(
       max_protocol_version_(tlsVersionFromProto(config.tls_params().tls_maximum_protocol_version(),
                                                 default_max_protocol_version)),
       factory_context_(factory_context), tls_keylog_path_(config.key_log().path()),
-      compliance_policy_(compliancePolicyFromProto(config.tls_params().compliance_policy())) {
+      compliance_policy_(config.tls_params().compliance_policy()) {
   SET_AND_RETURN_IF_NOT_OK(creation_status, creation_status);
   auto list_or_error = Network::Address::IpList::create(config.key_log().local_address_range());
   SET_AND_RETURN_IF_NOT_OK(list_or_error.status(), creation_status);

--- a/source/common/tls/context_config_impl.cc
+++ b/source/common/tls/context_config_impl.cc
@@ -125,6 +125,20 @@ getCertificateValidationContextConfigProvider(
   }
 }
 
+absl::optional<envoy::extensions::transport_sockets::tls::v3::TlsParameters::CompliancePolicy>
+compliancePolicyFromProto(
+    const envoy::extensions::transport_sockets::tls::v3::TlsParameters& params) {
+  switch (params.compliance_policies_size()) {
+  case 0:
+    return absl::nullopt;
+  case 1:
+    return params.compliance_policies(0);
+  default:
+    IS_ENVOY_BUG("more than one policies are not supported");
+    return absl::nullopt;
+  }
+}
+
 } // namespace
 
 ContextConfigImpl::ContextConfigImpl(
@@ -154,7 +168,7 @@ ContextConfigImpl::ContextConfigImpl(
       max_protocol_version_(tlsVersionFromProto(config.tls_params().tls_maximum_protocol_version(),
                                                 default_max_protocol_version)),
       factory_context_(factory_context), tls_keylog_path_(config.key_log().path()),
-      compliance_policy_(config.tls_params().compliance_policy()) {
+      compliance_policy_(compliancePolicyFromProto(config.tls_params())) {
   SET_AND_RETURN_IF_NOT_OK(creation_status, creation_status);
   auto list_or_error = Network::Address::IpList::create(config.key_log().local_address_range());
   SET_AND_RETURN_IF_NOT_OK(list_or_error.status(), creation_status);

--- a/source/common/tls/context_config_impl.h
+++ b/source/common/tls/context_config_impl.h
@@ -27,7 +27,7 @@ public:
   const std::string& cipherSuites() const override { return cipher_suites_; }
   const std::string& ecdhCurves() const override { return ecdh_curves_; }
   const std::string& signatureAlgorithms() const override { return signature_algorithms_; }
-  envoy::extensions::transport_sockets::tls::v3::TlsParameters::CompliancePolicy
+  absl::optional<envoy::extensions::transport_sockets::tls::v3::TlsParameters::CompliancePolicy>
   compliancePolicy() const override {
     return compliance_policy_;
   }
@@ -120,7 +120,8 @@ private:
   const std::string tls_keylog_path_;
   std::unique_ptr<Network::Address::IpList> tls_keylog_local_;
   std::unique_ptr<Network::Address::IpList> tls_keylog_remote_;
-  const envoy::extensions::transport_sockets::tls::v3::TlsParameters::CompliancePolicy
+  const absl::optional<
+      envoy::extensions::transport_sockets::tls::v3::TlsParameters::CompliancePolicy>
       compliance_policy_;
 };
 

--- a/source/common/tls/context_config_impl.h
+++ b/source/common/tls/context_config_impl.h
@@ -27,7 +27,10 @@ public:
   const std::string& cipherSuites() const override { return cipher_suites_; }
   const std::string& ecdhCurves() const override { return ecdh_curves_; }
   const std::string& signatureAlgorithms() const override { return signature_algorithms_; }
-  Envoy::Ssl::CompliancePolicy compliancePolicy() const override { return compliance_policy_; }
+  envoy::extensions::transport_sockets::tls::v3::TlsParameters::CompliancePolicy
+  compliancePolicy() const override {
+    return compliance_policy_;
+  }
   // TODO(htuch): This needs to be made const again and/or zero copy and/or callers fixed.
   std::vector<std::reference_wrapper<const Envoy::Ssl::TlsCertificateConfig>>
   tlsCertificates() const override {
@@ -117,7 +120,8 @@ private:
   const std::string tls_keylog_path_;
   std::unique_ptr<Network::Address::IpList> tls_keylog_local_;
   std::unique_ptr<Network::Address::IpList> tls_keylog_remote_;
-  const Envoy::Ssl::CompliancePolicy compliance_policy_;
+  const envoy::extensions::transport_sockets::tls::v3::TlsParameters::CompliancePolicy
+      compliance_policy_;
 };
 
 class ClientContextConfigImpl : public ContextConfigImpl, public Envoy::Ssl::ClientContextConfig {

--- a/source/common/tls/context_config_impl.h
+++ b/source/common/tls/context_config_impl.h
@@ -27,6 +27,7 @@ public:
   const std::string& cipherSuites() const override { return cipher_suites_; }
   const std::string& ecdhCurves() const override { return ecdh_curves_; }
   const std::string& signatureAlgorithms() const override { return signature_algorithms_; }
+  Envoy::Ssl::CompliancePolicy compliancePolicy() const override { return compliance_policy_; }
   // TODO(htuch): This needs to be made const again and/or zero copy and/or callers fixed.
   std::vector<std::reference_wrapper<const Envoy::Ssl::TlsCertificateConfig>>
   tlsCertificates() const override {
@@ -116,6 +117,7 @@ private:
   const std::string tls_keylog_path_;
   std::unique_ptr<Network::Address::IpList> tls_keylog_local_;
   std::unique_ptr<Network::Address::IpList> tls_keylog_remote_;
+  const Envoy::Ssl::CompliancePolicy compliance_policy_;
 };
 
 class ClientContextConfigImpl : public ContextConfigImpl, public Envoy::Ssl::ClientContextConfig {

--- a/source/common/tls/context_impl.cc
+++ b/source/common/tls/context_impl.cc
@@ -351,6 +351,17 @@ ContextImpl::ContextImpl(Stats::Scope& scope, const Envoy::Ssl::ContextConfig& c
       SSL_CTX_set_keylog_callback(ctx, keylogCallback);
     }
   }
+
+  // Compliance policy must be applied last to have a defined behavior.
+  switch (config.compliancePolicy()) {
+  case Envoy::Ssl::CompliancePolicy::FIPS_202205:
+    for (auto& tls_context : tls_contexts_) {
+      SSL_CTX_set_compliance_policy(tls_context.ssl_ctx_.get(), ssl_compliance_policy_fips_202205);
+    }
+    break;
+  case Envoy::Ssl::CompliancePolicy::None:
+    break;
+  }
 }
 
 void ContextImpl::keylogCallback(const SSL* ssl, const char* line) {

--- a/source/common/tls/context_impl.cc
+++ b/source/common/tls/context_impl.cc
@@ -356,27 +356,27 @@ ContextImpl::ContextImpl(Stats::Scope& scope, const Envoy::Ssl::ContextConfig& c
   }
 
   // Compliance policy must be applied last to have a defined behavior.
-  switch (config.compliancePolicy()) {
-    using ProtoPolicy = envoy::extensions::transport_sockets::tls::v3::TlsParameters;
-  case ProtoPolicy::FIPS_202205:
-    if (!fips_mode) {
-      ENVOY_LOG(warn, "FIPS conformance policy applied on a non-FIPS build");
-    }
-    for (auto& tls_context : tls_contexts_) {
-      int rc = SSL_CTX_set_compliance_policy(tls_context.ssl_ctx_.get(),
-                                             ssl_compliance_policy_fips_202205);
-      if (rc != 1) {
-        creation_status = absl::InvalidArgumentError(
-            absl::StrCat("Failed to apply FIPS_202205 compliance policy: ",
-                         Utility::getLastCryptoError().value_or("")));
+  if (const auto policy = config.compliancePolicy(); policy.has_value()) {
+    switch (policy.value()) {
+      using ProtoPolicy = envoy::extensions::transport_sockets::tls::v3::TlsParameters;
+    case ProtoPolicy::FIPS_202205:
+      if (!fips_mode) {
+        ENVOY_LOG(warn, "FIPS conformance policy applied on a non-FIPS build");
       }
+      for (auto& tls_context : tls_contexts_) {
+        int rc = SSL_CTX_set_compliance_policy(tls_context.ssl_ctx_.get(),
+                                               ssl_compliance_policy_fips_202205);
+        if (rc != 1) {
+          creation_status = absl::InvalidArgumentError(
+              absl::StrCat("Failed to apply FIPS_202205 compliance policy: ",
+                           Utility::getLastCryptoError().value_or("")));
+        }
+      }
+      break;
+    default:
+      creation_status = absl::InvalidArgumentError("Unknown compliance policy");
+      return;
     }
-    break;
-  case ProtoPolicy::NONE:
-    break;
-  default:
-    creation_status = absl::InvalidArgumentError("Unknown compliance policy");
-    return;
   }
 }
 

--- a/source/common/tls/context_impl.cc
+++ b/source/common/tls/context_impl.cc
@@ -370,6 +370,7 @@ ContextImpl::ContextImpl(Stats::Scope& scope, const Envoy::Ssl::ContextConfig& c
           creation_status = absl::InvalidArgumentError(
               absl::StrCat("Failed to apply FIPS_202205 compliance policy: ",
                            Utility::getLastCryptoError().value_or("")));
+          return;
         }
       }
       break;

--- a/test/common/tls/ssl_socket_test.cc
+++ b/test/common/tls/ssl_socket_test.cc
@@ -5688,7 +5688,7 @@ TEST_P(SslSocketTest, CipherSuitesWithPolicy) {
   testUtilV2(test_options);
 
   // Client connects with an unsupported client cipher suite for a server policy, connection fails.
-  server_params->set_compliance_policy(
+  server_params->add_compliance_policies(
       envoy::extensions::transport_sockets::tls::v3::TlsParameters::FIPS_202205);
   updateFilterChain(tls_context, *filter_chain);
   TestUtilOptionsV2 error_test_options(listener, client, false, version_);

--- a/test/common/tls/ssl_socket_test.cc
+++ b/test/common/tls/ssl_socket_test.cc
@@ -5658,6 +5658,44 @@ TEST_P(SslSocketTest, CipherSuites) {
   client_params->clear_cipher_suites();
 }
 
+TEST_P(SslSocketTest, CipherSuitesWithPolicy) {
+  envoy::config::listener::v3::Listener listener;
+  envoy::config::listener::v3::FilterChain* filter_chain = listener.add_filter_chains();
+  envoy::extensions::transport_sockets::tls::v3::DownstreamTlsContext tls_context;
+
+  envoy::extensions::transport_sockets::tls::v3::TlsCertificate* server_cert =
+      tls_context.mutable_common_tls_context()->add_tls_certificates();
+  server_cert->mutable_certificate_chain()->set_filename(
+      TestEnvironment::substitute("{{ test_rundir }}/test/common/tls/test_data/san_dns_cert.pem"));
+  server_cert->mutable_private_key()->set_filename(
+      TestEnvironment::substitute("{{ test_rundir }}/test/common/tls/test_data/san_dns_key.pem"));
+  updateFilterChain(tls_context, *filter_chain);
+
+  envoy::extensions::transport_sockets::tls::v3::UpstreamTlsContext client;
+  envoy::extensions::transport_sockets::tls::v3::TlsParameters* client_params =
+      client.mutable_common_tls_context()->mutable_tls_params();
+  envoy::extensions::transport_sockets::tls::v3::TlsParameters* server_params =
+      tls_context.mutable_common_tls_context()->mutable_tls_params();
+
+  // Connection using a common cipher (client & server) succeeds.
+  client_params->clear_cipher_suites();
+  client_params->add_cipher_suites("ECDHE-RSA-CHACHA20-POLY1305");
+  server_params->clear_cipher_suites();
+  server_params->add_cipher_suites("ECDHE-RSA-CHACHA20-POLY1305");
+  server_params->add_cipher_suites("AES256-GCM-SHA384");
+  updateFilterChain(tls_context, *filter_chain);
+  TestUtilOptionsV2 test_options(listener, client, true, version_);
+  testUtilV2(test_options);
+
+  // Client connects with an unsupported client cipher suite for a server policy, connection fails.
+  server_params->set_compliance_policy(
+      envoy::extensions::transport_sockets::tls::v3::TlsParameters::FIPS_202205);
+  updateFilterChain(tls_context, *filter_chain);
+  TestUtilOptionsV2 error_test_options(listener, client, false, version_);
+  error_test_options.setExpectedServerStats("ssl.connection_error");
+  testUtilV2(error_test_options);
+}
+
 TEST_P(SslSocketTest, EcdhCurves) {
   envoy::config::listener::v3::Listener listener;
   envoy::config::listener::v3::FilterChain* filter_chain = listener.add_filter_chains();

--- a/test/mocks/ssl/mocks.cc
+++ b/test/mocks/ssl/mocks.cc
@@ -29,6 +29,7 @@ MockClientContextConfig::MockClientContextConfig() {
   ON_CALL(*this, tlsKeyLogLocal()).WillByDefault(testing::ReturnRef(iplist_));
   ON_CALL(*this, tlsKeyLogRemote()).WillByDefault(testing::ReturnRef(iplist_));
   ON_CALL(*this, tlsKeyLogPath()).WillByDefault(testing::ReturnRef(path_));
+  ON_CALL(*this, compliancePolicy()).WillByDefault(testing::Return(CompliancePolicy::None));
 }
 MockClientContextConfig::~MockClientContextConfig() = default;
 
@@ -44,6 +45,7 @@ MockServerContextConfig::MockServerContextConfig() {
   ON_CALL(*this, tlsKeyLogLocal()).WillByDefault(testing::ReturnRef(iplist_));
   ON_CALL(*this, tlsKeyLogRemote()).WillByDefault(testing::ReturnRef(iplist_));
   ON_CALL(*this, tlsKeyLogPath()).WillByDefault(testing::ReturnRef(path_));
+  ON_CALL(*this, compliancePolicy()).WillByDefault(testing::Return(CompliancePolicy::None));
 }
 MockServerContextConfig::~MockServerContextConfig() = default;
 

--- a/test/mocks/ssl/mocks.cc
+++ b/test/mocks/ssl/mocks.cc
@@ -29,7 +29,9 @@ MockClientContextConfig::MockClientContextConfig() {
   ON_CALL(*this, tlsKeyLogLocal()).WillByDefault(testing::ReturnRef(iplist_));
   ON_CALL(*this, tlsKeyLogRemote()).WillByDefault(testing::ReturnRef(iplist_));
   ON_CALL(*this, tlsKeyLogPath()).WillByDefault(testing::ReturnRef(path_));
-  ON_CALL(*this, compliancePolicy()).WillByDefault(testing::Return(CompliancePolicy::None));
+  ON_CALL(*this, compliancePolicy())
+      .WillByDefault(
+          testing::Return(envoy::extensions::transport_sockets::tls::v3::TlsParameters::NONE));
 }
 MockClientContextConfig::~MockClientContextConfig() = default;
 
@@ -45,7 +47,9 @@ MockServerContextConfig::MockServerContextConfig() {
   ON_CALL(*this, tlsKeyLogLocal()).WillByDefault(testing::ReturnRef(iplist_));
   ON_CALL(*this, tlsKeyLogRemote()).WillByDefault(testing::ReturnRef(iplist_));
   ON_CALL(*this, tlsKeyLogPath()).WillByDefault(testing::ReturnRef(path_));
-  ON_CALL(*this, compliancePolicy()).WillByDefault(testing::Return(CompliancePolicy::None));
+  ON_CALL(*this, compliancePolicy())
+      .WillByDefault(
+          testing::Return(envoy::extensions::transport_sockets::tls::v3::TlsParameters::NONE));
 }
 MockServerContextConfig::~MockServerContextConfig() = default;
 

--- a/test/mocks/ssl/mocks.cc
+++ b/test/mocks/ssl/mocks.cc
@@ -29,9 +29,7 @@ MockClientContextConfig::MockClientContextConfig() {
   ON_CALL(*this, tlsKeyLogLocal()).WillByDefault(testing::ReturnRef(iplist_));
   ON_CALL(*this, tlsKeyLogRemote()).WillByDefault(testing::ReturnRef(iplist_));
   ON_CALL(*this, tlsKeyLogPath()).WillByDefault(testing::ReturnRef(path_));
-  ON_CALL(*this, compliancePolicy())
-      .WillByDefault(
-          testing::Return(envoy::extensions::transport_sockets::tls::v3::TlsParameters::NONE));
+  ON_CALL(*this, compliancePolicy()).WillByDefault(testing::Return(absl::nullopt));
 }
 MockClientContextConfig::~MockClientContextConfig() = default;
 
@@ -47,9 +45,7 @@ MockServerContextConfig::MockServerContextConfig() {
   ON_CALL(*this, tlsKeyLogLocal()).WillByDefault(testing::ReturnRef(iplist_));
   ON_CALL(*this, tlsKeyLogRemote()).WillByDefault(testing::ReturnRef(iplist_));
   ON_CALL(*this, tlsKeyLogPath()).WillByDefault(testing::ReturnRef(path_));
-  ON_CALL(*this, compliancePolicy())
-      .WillByDefault(
-          testing::Return(envoy::extensions::transport_sockets::tls::v3::TlsParameters::NONE));
+  ON_CALL(*this, compliancePolicy()).WillByDefault(testing::Return(absl::nullopt));
 }
 MockServerContextConfig::~MockServerContextConfig() = default;
 

--- a/test/mocks/ssl/mocks.h
+++ b/test/mocks/ssl/mocks.h
@@ -123,7 +123,8 @@ public:
   MOCK_METHOD(const Network::Address::IpList&, tlsKeyLogRemote, (), (const));
   MOCK_METHOD(const std::string&, tlsKeyLogPath, (), (const));
   MOCK_METHOD(AccessLog::AccessLogManager&, accessLogManager, (), (const));
-  MOCK_METHOD(CompliancePolicy, compliancePolicy, (), (const));
+  MOCK_METHOD(envoy::extensions::transport_sockets::tls::v3::TlsParameters::CompliancePolicy,
+              compliancePolicy, (), (const));
   Ssl::HandshakerCapabilities capabilities_;
   std::string sni_{"default_sni.example.com"};
   std::string ciphers_{"RSA"};
@@ -168,7 +169,8 @@ public:
   MOCK_METHOD(const std::string&, tlsKeyLogPath, (), (const));
   MOCK_METHOD(AccessLog::AccessLogManager&, accessLogManager, (), (const));
   MOCK_METHOD(bool, fullScanCertsOnSNIMismatch, (), (const));
-  MOCK_METHOD(CompliancePolicy, compliancePolicy, (), (const));
+  MOCK_METHOD(envoy::extensions::transport_sockets::tls::v3::TlsParameters::CompliancePolicy,
+              compliancePolicy, (), (const));
 
   Ssl::HandshakerCapabilities capabilities_;
   std::string ciphers_{"RSA"};

--- a/test/mocks/ssl/mocks.h
+++ b/test/mocks/ssl/mocks.h
@@ -123,7 +123,8 @@ public:
   MOCK_METHOD(const Network::Address::IpList&, tlsKeyLogRemote, (), (const));
   MOCK_METHOD(const std::string&, tlsKeyLogPath, (), (const));
   MOCK_METHOD(AccessLog::AccessLogManager&, accessLogManager, (), (const));
-  MOCK_METHOD(envoy::extensions::transport_sockets::tls::v3::TlsParameters::CompliancePolicy,
+  MOCK_METHOD(absl::optional<
+                  envoy::extensions::transport_sockets::tls::v3::TlsParameters::CompliancePolicy>,
               compliancePolicy, (), (const));
   Ssl::HandshakerCapabilities capabilities_;
   std::string sni_{"default_sni.example.com"};
@@ -169,7 +170,8 @@ public:
   MOCK_METHOD(const std::string&, tlsKeyLogPath, (), (const));
   MOCK_METHOD(AccessLog::AccessLogManager&, accessLogManager, (), (const));
   MOCK_METHOD(bool, fullScanCertsOnSNIMismatch, (), (const));
-  MOCK_METHOD(envoy::extensions::transport_sockets::tls::v3::TlsParameters::CompliancePolicy,
+  MOCK_METHOD(absl::optional<
+                  envoy::extensions::transport_sockets::tls::v3::TlsParameters::CompliancePolicy>,
               compliancePolicy, (), (const));
 
   Ssl::HandshakerCapabilities capabilities_;

--- a/test/mocks/ssl/mocks.h
+++ b/test/mocks/ssl/mocks.h
@@ -123,6 +123,7 @@ public:
   MOCK_METHOD(const Network::Address::IpList&, tlsKeyLogRemote, (), (const));
   MOCK_METHOD(const std::string&, tlsKeyLogPath, (), (const));
   MOCK_METHOD(AccessLog::AccessLogManager&, accessLogManager, (), (const));
+  MOCK_METHOD(CompliancePolicy, compliancePolicy, (), (const));
   Ssl::HandshakerCapabilities capabilities_;
   std::string sni_{"default_sni.example.com"};
   std::string ciphers_{"RSA"};
@@ -167,6 +168,7 @@ public:
   MOCK_METHOD(const std::string&, tlsKeyLogPath, (), (const));
   MOCK_METHOD(AccessLog::AccessLogManager&, accessLogManager, (), (const));
   MOCK_METHOD(bool, fullScanCertsOnSNIMismatch, (), (const));
+  MOCK_METHOD(CompliancePolicy, compliancePolicy, (), (const));
 
   Ssl::HandshakerCapabilities capabilities_;
   std::string ciphers_{"RSA"};


### PR DESCRIPTION
Change-Id: Ie870267f35831663ee424dc8e4c5bc1132d19ba2

Commit Message: Add an xDS config to set BoringSSL compliance policy for FIPS. Since a given proxy is allowed to serve both FIPS and non-FIPS traffic, xDS is the appropriate configuration knob to support mixed serving.
Risk Level: low, new field
Testing: add a test to verify the policy restriction
Docs Changes: none
Release Notes: yes

Fixes #31746