### PR TITLE
Add min_size option when forcing LocalityDirect in zone-aware-routing

### DIFF
--- a/api/envoy/extensions/load_balancing_policies/common/v3/BUILD
+++ b/api/envoy/extensions/load_balancing_policies/common/v3/BUILD
@@ -6,6 +6,7 @@ licenses(["notice"])  # Apache 2
 
 api_proto_package(
     deps = [
+        "//envoy/annotations:pkg",
         "//envoy/config/core/v3:pkg",
         "//envoy/type/v3:pkg",
         "@com_github_cncf_xds//udpa/annotations:pkg",

--- a/api/envoy/extensions/load_balancing_policies/common/v3/common.proto
+++ b/api/envoy/extensions/load_balancing_policies/common/v3/common.proto
@@ -22,6 +22,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 message LocalityLbConfig {
   // Configuration for :ref:`zone aware routing
   // <arch_overview_load_balancing_zone_aware_routing>`.
+  // [#next-free-field: 6]
   message ZoneAwareLbConfig {
     // Configures percentage of requests that will be considered for zone aware routing
     // if zone aware routing is configured. If not specified, the default is 100%.
@@ -42,8 +43,22 @@ message LocalityLbConfig {
     // failing service.
     bool fail_traffic_on_panic = 3;
 
-    // If set to true, Envoy will force LocalityDirect routing if a local locality exists.
-    bool force_locality_direct_routing = 4;
+    // If set to true, Envoy will always route traffic to the local zone regardless of the
+    // upstream zone structure. In Envoy's default configuration, traffic is distributed proportionally
+    // across all upstream hosts while trying to maximize local routing when possible. The approach
+    // with force_local_zone aims to be more predictable and if there are upstream hosts in the local
+    // zone, they will receive all traffic.
+    // * :ref:`runtime values <config_cluster_manager_cluster_runtime_zone_routing>`.
+    // * :ref:`Zone aware routing support <arch_overview_load_balancing_zone_aware_routing>`.
+    bool force_local_zone = 4;
+
+    // Configures the minimum number of upstream hosts in the local zone required when force_local_zone
+    // is enabled. If the number of upstream hosts in the local zone is less than the specified value,
+    // Envoy will fall back to the default proportional-based distribution across localities.
+    // If not specified, the default is 1.
+    // * :ref:`runtime values <config_cluster_manager_cluster_runtime_zone_routing>`.
+    // * :ref:`Zone aware routing support <arch_overview_load_balancing_zone_aware_routing>`.
+    google.protobuf.UInt64Value force_local_zone_min_size = 5;
   }
 
   // Configuration for :ref:`locality weighted load balancing

--- a/api/envoy/extensions/load_balancing_policies/common/v3/common.proto
+++ b/api/envoy/extensions/load_balancing_policies/common/v3/common.proto
@@ -58,7 +58,7 @@ message LocalityLbConfig {
     // If not specified, the default is 1.
     // * :ref:`runtime values <config_cluster_manager_cluster_runtime_zone_routing>`.
     // * :ref:`Zone aware routing support <arch_overview_load_balancing_zone_aware_routing>`.
-    google.protobuf.UInt64Value force_local_zone_min_size = 5;
+    google.protobuf.UInt32Value force_local_zone_min_size = 5;
   }
 
   // Configuration for :ref:`locality weighted load balancing

--- a/api/envoy/extensions/load_balancing_policies/common/v3/common.proto
+++ b/api/envoy/extensions/load_balancing_policies/common/v3/common.proto
@@ -43,22 +43,26 @@ message LocalityLbConfig {
     // failing service.
     bool fail_traffic_on_panic = 3;
 
-    // If set to true, Envoy will always route traffic to the local zone regardless of the
+    // If set to true, Envoy will force LocalityDirect routing if a local locality exists.
+    bool force_locality_direct_routing = 4 [deprecated = true];
+
+    // Configures Envoy to always route requests to the local zone regardless of the
     // upstream zone structure. In Envoy's default configuration, traffic is distributed proportionally
     // across all upstream hosts while trying to maximize local routing when possible. The approach
     // with force_local_zone aims to be more predictable and if there are upstream hosts in the local
     // zone, they will receive all traffic.
     // * :ref:`runtime values <config_cluster_manager_cluster_runtime_zone_routing>`.
     // * :ref:`Zone aware routing support <arch_overview_load_balancing_zone_aware_routing>`.
-    bool force_local_zone = 4;
-
-    // Configures the minimum number of upstream hosts in the local zone required when force_local_zone
-    // is enabled. If the number of upstream hosts in the local zone is less than the specified value,
-    // Envoy will fall back to the default proportional-based distribution across localities.
-    // If not specified, the default is 1.
-    // * :ref:`runtime values <config_cluster_manager_cluster_runtime_zone_routing>`.
-    // * :ref:`Zone aware routing support <arch_overview_load_balancing_zone_aware_routing>`.
-    google.protobuf.UInt32Value force_local_zone_min_size = 5;
+    message ForceLocalZone {
+      // Configures the minimum number of upstream hosts in the local zone required when force_local_zone
+      // is enabled. If the number of upstream hosts in the local zone is less than the specified value,
+      // Envoy will fall back to the default proportional-based distribution across localities.
+      // If not specified, the default is 1.
+      // * :ref:`runtime values <config_cluster_manager_cluster_runtime_zone_routing>`.
+      // * :ref:`Zone aware routing support <arch_overview_load_balancing_zone_aware_routing>`.
+      google.protobuf.UInt32Value min_size = 1;
+    }
+    ForceLocalZone force_local_zone = 5;
   }
 
   // Configuration for :ref:`locality weighted load balancing

--- a/api/envoy/extensions/load_balancing_policies/common/v3/common.proto
+++ b/api/envoy/extensions/load_balancing_policies/common/v3/common.proto
@@ -8,6 +8,7 @@ import "envoy/type/v3/percent.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 
+import "envoy/annotations/deprecation.proto";
 import "udpa/annotations/status.proto";
 import "validate/validate.proto";
 
@@ -24,6 +25,23 @@ message LocalityLbConfig {
   // <arch_overview_load_balancing_zone_aware_routing>`.
   // [#next-free-field: 6]
   message ZoneAwareLbConfig {
+    // Configures Envoy to always route requests to the local zone regardless of the
+    // upstream zone structure. In Envoy's default configuration, traffic is distributed proportionally
+    // across all upstream hosts while trying to maximize local routing when possible. The approach
+    // with force_local_zone aims to be more predictable and if there are upstream hosts in the local
+    // zone, they will receive all traffic.
+    // * :ref:`runtime values <config_cluster_manager_cluster_runtime_zone_routing>`.
+    // * :ref:`Zone aware routing support <arch_overview_load_balancing_zone_aware_routing>`.
+    message ForceLocalZone {
+      // Configures the minimum number of upstream hosts in the local zone required when force_local_zone
+      // is enabled. If the number of upstream hosts in the local zone is less than the specified value,
+      // Envoy will fall back to the default proportional-based distribution across localities.
+      // If not specified, the default is 1.
+      // * :ref:`runtime values <config_cluster_manager_cluster_runtime_zone_routing>`.
+      // * :ref:`Zone aware routing support <arch_overview_load_balancing_zone_aware_routing>`.
+      google.protobuf.UInt32Value min_size = 1;
+    }
+
     // Configures percentage of requests that will be considered for zone aware routing
     // if zone aware routing is configured. If not specified, the default is 100%.
     // * :ref:`runtime values <config_cluster_manager_cluster_runtime_zone_routing>`.
@@ -44,24 +62,9 @@ message LocalityLbConfig {
     bool fail_traffic_on_panic = 3;
 
     // If set to true, Envoy will force LocalityDirect routing if a local locality exists.
-    bool force_locality_direct_routing = 4 [deprecated = true];
+    bool force_locality_direct_routing = 4
+        [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
 
-    // Configures Envoy to always route requests to the local zone regardless of the
-    // upstream zone structure. In Envoy's default configuration, traffic is distributed proportionally
-    // across all upstream hosts while trying to maximize local routing when possible. The approach
-    // with force_local_zone aims to be more predictable and if there are upstream hosts in the local
-    // zone, they will receive all traffic.
-    // * :ref:`runtime values <config_cluster_manager_cluster_runtime_zone_routing>`.
-    // * :ref:`Zone aware routing support <arch_overview_load_balancing_zone_aware_routing>`.
-    message ForceLocalZone {
-      // Configures the minimum number of upstream hosts in the local zone required when force_local_zone
-      // is enabled. If the number of upstream hosts in the local zone is less than the specified value,
-      // Envoy will fall back to the default proportional-based distribution across localities.
-      // If not specified, the default is 1.
-      // * :ref:`runtime values <config_cluster_manager_cluster_runtime_zone_routing>`.
-      // * :ref:`Zone aware routing support <arch_overview_load_balancing_zone_aware_routing>`.
-      google.protobuf.UInt32Value min_size = 1;
-    }
     ForceLocalZone force_local_zone = 5;
   }
 

--- a/docs/root/configuration/upstream/cluster_manager/cluster_runtime.rst
+++ b/docs/root/configuration/upstream/cluster_manager/cluster_runtime.rst
@@ -166,9 +166,15 @@ upstream.zone_routing.min_cluster_size
   is 6. If the upstream cluster size is smaller than *min_cluster_size* zone aware routing will not
   be performed.
 
-upstream.zone_routing.force_locality_direct_routing
+upstream.zone_routing.force_local_zone
   When set to true, forces Envoy to always send traffic to the local zone. This overrides the default
-  behavior that attempts to balance traffic evenly across all zones among other cluster members.
+  behavior that attempts to balance traffic evenly across all upstream hosts.
+
+upstream.zone_routing.force_local_zone_min_size
+  Minimal number of the upstream hosts in the local zone for *force_local_zone* to be respected. Default value
+  is 1. If the upstream zone size is smaller than *force_local_zone_min_size* routing logic falls back to
+  default zone aware routing behavior.
+  be performed.
 
 Circuit breaking
 ----------------

--- a/docs/root/configuration/upstream/cluster_manager/cluster_runtime.rst
+++ b/docs/root/configuration/upstream/cluster_manager/cluster_runtime.rst
@@ -174,7 +174,6 @@ upstream.zone_routing.force_local_zone_min_size
   Minimal number of the upstream hosts in the local zone for *force_local_zone* to be respected. Default value
   is 1. If the upstream zone size is smaller than *force_local_zone_min_size* routing logic falls back to
   default zone aware routing behavior.
-  be performed.
 
 Circuit breaking
 ----------------

--- a/docs/root/configuration/upstream/cluster_manager/cluster_runtime.rst
+++ b/docs/root/configuration/upstream/cluster_manager/cluster_runtime.rst
@@ -166,14 +166,10 @@ upstream.zone_routing.min_cluster_size
   is 6. If the upstream cluster size is smaller than *min_cluster_size* zone aware routing will not
   be performed.
 
-upstream.zone_routing.force_local_zone
-  When set to true, forces Envoy to always send traffic to the local zone. This overrides the default
-  behavior that attempts to balance traffic evenly across all upstream hosts.
-
-upstream.zone_routing.force_local_zone_min_size
-  Minimal number of the upstream hosts in the local zone for *force_local_zone* to be respected. Default value
-  is 1. If the upstream zone size is smaller than *force_local_zone_min_size* routing logic falls back to
-  default zone aware routing behavior.
+upstream.zone_routing.force_local_zone.min_size
+  Enables *force_local_zone* and configures the minimum number of the upstream hosts in the local zone for
+  *force_local_zone* to be respected. If the upstream zone size is smaller than *force_local_zone_min_size*
+  routing logic falls back to default zone aware routing behavior.
 
 Circuit breaking
 ----------------

--- a/source/extensions/load_balancing_policies/common/load_balancer_impl.cc
+++ b/source/extensions/load_balancing_policies/common/load_balancer_impl.cc
@@ -26,8 +26,9 @@ namespace Upstream {
 namespace {
 static const std::string RuntimeZoneEnabled = "upstream.zone_routing.enabled";
 static const std::string RuntimeMinClusterSize = "upstream.zone_routing.min_cluster_size";
-static const std::string RuntimeForceDirectRouting =
-    "upstream.zone_routing.force_locality_direct_routing";
+static const std::string RuntimeForceLocalZone = "upstream.zone_routing.force_local_zone";
+static const std::string RuntimeForceLocalZoneMinSize =
+    "upstream.zone_routing.force_local_zone_min_size";
 static const std::string RuntimePanicThreshold = "upstream.healthy_panic_threshold";
 
 // Returns true if the weights of all the hosts in the HostVector are equal.
@@ -425,6 +426,11 @@ ZoneAwareLoadBalancerBase::ZoneAwareLoadBalancerBase(
                             ? PROTOBUF_GET_WRAPPED_OR_DEFAULT(
                                   locality_config->zone_aware_lb_config(), min_cluster_size, 6U)
                             : 6U),
+      force_local_zone_min_size_(
+          locality_config.has_value()
+              ? PROTOBUF_GET_WRAPPED_OR_DEFAULT(locality_config->zone_aware_lb_config(),
+                                                force_local_zone_min_size, 1U)
+              : 1U),
       routing_enabled_(locality_config.has_value()
                            ? PROTOBUF_PERCENT_TO_ROUNDED_INTEGER_OR_DEFAULT(
                                  locality_config->zone_aware_lb_config(), routing_enabled, 100, 100)
@@ -432,10 +438,9 @@ ZoneAwareLoadBalancerBase::ZoneAwareLoadBalancerBase(
       fail_traffic_on_panic_(locality_config.has_value()
                                  ? locality_config->zone_aware_lb_config().fail_traffic_on_panic()
                                  : false),
-      force_locality_direct_routing_(
-          locality_config.has_value()
-              ? locality_config->zone_aware_lb_config().force_locality_direct_routing()
-              : false),
+      force_local_zone_(locality_config.has_value()
+                            ? locality_config->zone_aware_lb_config().force_local_zone()
+                            : false),
       locality_weighted_balancing_(locality_config.has_value() &&
                                    locality_config->has_locality_weighted_lb_config()) {
   ASSERT(!priority_set.hostSetsPerPriority().empty());
@@ -501,17 +506,21 @@ void ZoneAwareLoadBalancerBase::regenerateLocalityRoutingStructures() {
   auto locality_percentages =
       calculateLocalityPercentages(localHostsPerLocality, upstreamHostsPerLocality);
 
-  const bool force_locality_direct_routing =
-      runtime_.snapshot().getBoolean(RuntimeForceDirectRouting, force_locality_direct_routing_);
+  const bool force_local_zone =
+      runtime_.snapshot().getBoolean(RuntimeForceLocalZone, force_local_zone_);
+  const uint64_t force_local_zone_min_size =
+      runtime_.snapshot().getInteger(RuntimeForceLocalZoneMinSize, force_local_zone_min_size_);
 
   if (upstreamHostsPerLocality.hasLocalLocality()) {
     // If we have lower percent of hosts in the local cluster in the same locality,
     // we can push all of the requests directly to upstream cluster in the same locality.
     if ((locality_percentages[0].upstream_percentage > 0 &&
          locality_percentages[0].upstream_percentage >= locality_percentages[0].local_percentage) ||
-        // When force_locality_direct_routing is enabled, always use LocalityDirect
-        // routing if a healthy local host exists.
-        force_locality_direct_routing) {
+        // When force_local_zone is enabled, always use LocalityDirect routing if there are enough
+        // healthy upstreams in the local locality as determined by force_local_zone_min_size is
+        // met.
+        (force_local_zone &&
+         upstreamHostsPerLocality.get()[0].size() >= force_local_zone_min_size)) {
       state.locality_routing_state_ = LocalityRoutingState::LocalityDirect;
       return;
     }
@@ -584,12 +593,12 @@ bool ZoneAwareLoadBalancerBase::earlyExitNonLocalityRouting() {
     return true;
   }
 
-  const bool force_locality_direct_routing =
-      runtime_.snapshot().getBoolean(RuntimeForceDirectRouting, force_locality_direct_routing_);
+  const bool force_local_zone =
+      runtime_.snapshot().getBoolean(RuntimeForceLocalZone, force_local_zone_);
 
   // Do not perform locality routing if there are too few local localities for zone routing to have
   // an effect.
-  if (localHostSet().hostsPerLocality().get().size() < 2 && !force_locality_direct_routing) {
+  if (localHostSet().hostsPerLocality().get().size() < 2 && !force_local_zone) {
     return true;
   }
 

--- a/source/extensions/load_balancing_policies/common/load_balancer_impl.cc
+++ b/source/extensions/load_balancing_policies/common/load_balancer_impl.cc
@@ -508,7 +508,7 @@ void ZoneAwareLoadBalancerBase::regenerateLocalityRoutingStructures() {
 
   const bool force_local_zone =
       runtime_.snapshot().getBoolean(RuntimeForceLocalZone, force_local_zone_);
-  const uint64_t force_local_zone_min_size =
+  const uint32_t force_local_zone_min_size =
       runtime_.snapshot().getInteger(RuntimeForceLocalZoneMinSize, force_local_zone_min_size_);
 
   if (upstreamHostsPerLocality.hasLocalLocality()) {

--- a/source/extensions/load_balancing_policies/common/load_balancer_impl.cc
+++ b/source/extensions/load_balancing_policies/common/load_balancer_impl.cc
@@ -26,9 +26,8 @@ namespace Upstream {
 namespace {
 static const std::string RuntimeZoneEnabled = "upstream.zone_routing.enabled";
 static const std::string RuntimeMinClusterSize = "upstream.zone_routing.min_cluster_size";
-static const std::string RuntimeForceLocalZone = "upstream.zone_routing.force_local_zone";
 static const std::string RuntimeForceLocalZoneMinSize =
-    "upstream.zone_routing.force_local_zone_min_size";
+    "upstream.zone_routing.force_local_zone.min_size";
 static const std::string RuntimePanicThreshold = "upstream.healthy_panic_threshold";
 
 // Returns true if the weights of all the hosts in the HostVector are equal.
@@ -426,11 +425,24 @@ ZoneAwareLoadBalancerBase::ZoneAwareLoadBalancerBase(
                             ? PROTOBUF_GET_WRAPPED_OR_DEFAULT(
                                   locality_config->zone_aware_lb_config(), min_cluster_size, 6U)
                             : 6U),
-      force_local_zone_min_size_(
-          locality_config.has_value()
-              ? PROTOBUF_GET_WRAPPED_OR_DEFAULT(locality_config->zone_aware_lb_config(),
-                                                force_local_zone_min_size, 1U)
-              : 1U),
+      force_local_zone_min_size_([&]() -> absl::optional<uint32_t> {
+        // Check runtime value first
+        if (auto rt = runtime_.snapshot().getInteger(RuntimeForceLocalZoneMinSize, 0); rt > 0) {
+          return static_cast<uint32_t>(rt);
+        }
+
+        // ForceLocalZone proto field supersedes deprecated ForceLocalityDirectRouting
+        if (locality_config.has_value()) {
+          if (locality_config->zone_aware_lb_config().has_force_local_zone()) {
+            return PROTOBUF_GET_WRAPPED_OR_DEFAULT(
+                locality_config->zone_aware_lb_config().force_local_zone(), min_size, 1U);
+          }
+          if (locality_config->zone_aware_lb_config().force_locality_direct_routing()) {
+            return 1U;
+          }
+        }
+        return absl::nullopt;
+      }()),
       routing_enabled_(locality_config.has_value()
                            ? PROTOBUF_PERCENT_TO_ROUNDED_INTEGER_OR_DEFAULT(
                                  locality_config->zone_aware_lb_config(), routing_enabled, 100, 100)
@@ -438,9 +450,6 @@ ZoneAwareLoadBalancerBase::ZoneAwareLoadBalancerBase(
       fail_traffic_on_panic_(locality_config.has_value()
                                  ? locality_config->zone_aware_lb_config().fail_traffic_on_panic()
                                  : false),
-      force_local_zone_(locality_config.has_value()
-                            ? locality_config->zone_aware_lb_config().force_local_zone()
-                            : false),
       locality_weighted_balancing_(locality_config.has_value() &&
                                    locality_config->has_locality_weighted_lb_config()) {
   ASSERT(!priority_set.hostSetsPerPriority().empty());
@@ -506,11 +515,6 @@ void ZoneAwareLoadBalancerBase::regenerateLocalityRoutingStructures() {
   auto locality_percentages =
       calculateLocalityPercentages(localHostsPerLocality, upstreamHostsPerLocality);
 
-  const bool force_local_zone =
-      runtime_.snapshot().getBoolean(RuntimeForceLocalZone, force_local_zone_);
-  const uint32_t force_local_zone_min_size =
-      runtime_.snapshot().getInteger(RuntimeForceLocalZoneMinSize, force_local_zone_min_size_);
-
   if (upstreamHostsPerLocality.hasLocalLocality()) {
     // If we have lower percent of hosts in the local cluster in the same locality,
     // we can push all of the requests directly to upstream cluster in the same locality.
@@ -519,8 +523,8 @@ void ZoneAwareLoadBalancerBase::regenerateLocalityRoutingStructures() {
         // When force_local_zone is enabled, always use LocalityDirect routing if there are enough
         // healthy upstreams in the local locality as determined by force_local_zone_min_size is
         // met.
-        (force_local_zone &&
-         upstreamHostsPerLocality.get()[0].size() >= force_local_zone_min_size)) {
+        (force_local_zone_min_size_.has_value() &&
+         upstreamHostsPerLocality.get()[0].size() >= *force_local_zone_min_size_)) {
       state.locality_routing_state_ = LocalityRoutingState::LocalityDirect;
       return;
     }
@@ -593,12 +597,10 @@ bool ZoneAwareLoadBalancerBase::earlyExitNonLocalityRouting() {
     return true;
   }
 
-  const bool force_local_zone =
-      runtime_.snapshot().getBoolean(RuntimeForceLocalZone, force_local_zone_);
-
   // Do not perform locality routing if there are too few local localities for zone routing to have
-  // an effect.
-  if (localHostSet().hostsPerLocality().get().size() < 2 && !force_local_zone) {
+  // an effect. Skipped when ForceLocalZone is enabled.
+  if (!force_local_zone_min_size_.has_value() &&
+      localHostSet().hostsPerLocality().get().size() < 2) {
     return true;
   }
 

--- a/source/extensions/load_balancing_policies/common/load_balancer_impl.h
+++ b/source/extensions/load_balancing_policies/common/load_balancer_impl.h
@@ -425,10 +425,11 @@ private:
 
   // Config for zone aware routing.
   const uint64_t min_cluster_size_;
+  const uint64_t force_local_zone_min_size_;
   // Keep small members (bools and enums) at the end of class, to reduce alignment overhead.
   const uint32_t routing_enabled_;
   const bool fail_traffic_on_panic_ : 1;
-  const bool force_locality_direct_routing_ : 1;
+  const bool force_local_zone_ : 1;
 
   // If locality weight aware routing is enabled.
   const bool locality_weighted_balancing_ : 1;

--- a/source/extensions/load_balancing_policies/common/load_balancer_impl.h
+++ b/source/extensions/load_balancing_policies/common/load_balancer_impl.h
@@ -425,7 +425,7 @@ private:
 
   // Config for zone aware routing.
   const uint64_t min_cluster_size_;
-  const uint64_t force_local_zone_min_size_;
+  const uint32_t force_local_zone_min_size_;
   // Keep small members (bools and enums) at the end of class, to reduce alignment overhead.
   const uint32_t routing_enabled_;
   const bool fail_traffic_on_panic_ : 1;

--- a/source/extensions/load_balancing_policies/common/load_balancer_impl.h
+++ b/source/extensions/load_balancing_policies/common/load_balancer_impl.h
@@ -425,11 +425,10 @@ private:
 
   // Config for zone aware routing.
   const uint64_t min_cluster_size_;
-  const uint32_t force_local_zone_min_size_;
+  const absl::optional<uint32_t> force_local_zone_min_size_;
   // Keep small members (bools and enums) at the end of class, to reduce alignment overhead.
   const uint32_t routing_enabled_;
   const bool fail_traffic_on_panic_ : 1;
-  const bool force_local_zone_ : 1;
 
   // If locality weight aware routing is enabled.
   const bool locality_weighted_balancing_ : 1;

--- a/test/common/upstream/load_balancer_simulation_test.cc
+++ b/test/common/upstream/load_balancer_simulation_test.cc
@@ -202,6 +202,8 @@ public:
         .WillByDefault(Return(50U));
     ON_CALL(runtime_.snapshot_, featureEnabled("upstream.zone_routing.enabled", 100))
         .WillByDefault(Return(true));
+    ON_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.force_local_zone.min_size", 0))
+        .WillByDefault(Return(0));
     ON_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.min_cluster_size", 6))
         .WillByDefault(Return(6));
   }

--- a/test/common/upstream/load_balancer_simulation_test.cc
+++ b/test/common/upstream/load_balancer_simulation_test.cc
@@ -202,6 +202,9 @@ public:
         .WillByDefault(Return(50U));
     ON_CALL(runtime_.snapshot_, featureEnabled("upstream.zone_routing.enabled", 100))
         .WillByDefault(Return(true));
+    EXPECT_CALL(runtime_.snapshot_,
+                getInteger("upstream.zone_routing.force_local_zone_min_size", 1))
+        .WillRepeatedly(Return(1));
     ON_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.min_cluster_size", 6))
         .WillByDefault(Return(6));
   }

--- a/test/common/upstream/load_balancer_simulation_test.cc
+++ b/test/common/upstream/load_balancer_simulation_test.cc
@@ -202,9 +202,8 @@ public:
         .WillByDefault(Return(50U));
     ON_CALL(runtime_.snapshot_, featureEnabled("upstream.zone_routing.enabled", 100))
         .WillByDefault(Return(true));
-    EXPECT_CALL(runtime_.snapshot_,
-                getInteger("upstream.zone_routing.force_local_zone_min_size", 1))
-        .WillRepeatedly(Return(1));
+    ON_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.force_local_zone_min_size", 1))
+        .WillByDefault(Return(1));
     ON_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.min_cluster_size", 6))
         .WillByDefault(Return(6));
   }

--- a/test/common/upstream/load_balancer_simulation_test.cc
+++ b/test/common/upstream/load_balancer_simulation_test.cc
@@ -202,8 +202,6 @@ public:
         .WillByDefault(Return(50U));
     ON_CALL(runtime_.snapshot_, featureEnabled("upstream.zone_routing.enabled", 100))
         .WillByDefault(Return(true));
-    ON_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.force_local_zone_min_size", 1))
-        .WillByDefault(Return(1));
     ON_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.min_cluster_size", 6))
         .WillByDefault(Return(6));
   }

--- a/test/extensions/load_balancing_policies/random/random_lb_simulation_test.cc
+++ b/test/extensions/load_balancing_policies/random/random_lb_simulation_test.cc
@@ -40,6 +40,9 @@ public:
         .WillByDefault(Return(50U));
     ON_CALL(runtime_.snapshot_, featureEnabled("upstream.zone_routing.enabled", 100))
         .WillByDefault(Return(true));
+    EXPECT_CALL(runtime_.snapshot_,
+                getInteger("upstream.zone_routing.force_local_zone.min_size", 0))
+        .WillRepeatedly(Return(0));
     ON_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.min_cluster_size", 6))
         .WillByDefault(Return(6));
   }

--- a/test/extensions/load_balancing_policies/random/random_lb_simulation_test.cc
+++ b/test/extensions/load_balancing_policies/random/random_lb_simulation_test.cc
@@ -40,6 +40,9 @@ public:
         .WillByDefault(Return(50U));
     ON_CALL(runtime_.snapshot_, featureEnabled("upstream.zone_routing.enabled", 100))
         .WillByDefault(Return(true));
+    EXPECT_CALL(runtime_.snapshot_,
+                getInteger("upstream.zone_routing.force_local_zone_min_size", 1))
+        .WillRepeatedly(Return(1));
     ON_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.min_cluster_size", 6))
         .WillByDefault(Return(6));
   }

--- a/test/extensions/load_balancing_policies/random/random_lb_simulation_test.cc
+++ b/test/extensions/load_balancing_policies/random/random_lb_simulation_test.cc
@@ -40,9 +40,6 @@ public:
         .WillByDefault(Return(50U));
     ON_CALL(runtime_.snapshot_, featureEnabled("upstream.zone_routing.enabled", 100))
         .WillByDefault(Return(true));
-    EXPECT_CALL(runtime_.snapshot_,
-                getInteger("upstream.zone_routing.force_local_zone_min_size", 1))
-        .WillRepeatedly(Return(1));
     ON_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.min_cluster_size", 6))
         .WillByDefault(Return(6));
   }

--- a/test/extensions/load_balancing_policies/round_robin/round_robin_lb_test.cc
+++ b/test/extensions/load_balancing_policies/round_robin/round_robin_lb_test.cc
@@ -6,6 +6,7 @@ namespace Envoy {
 namespace Upstream {
 namespace {
 
+using testing::AtLeast;
 using testing::Return;
 using testing::ReturnRef;
 
@@ -657,6 +658,8 @@ TEST_P(RoundRobinLoadBalancerTest, ZoneAwareSmallCluster) {
       .WillRepeatedly(Return(50));
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("upstream.zone_routing.enabled", 98))
       .WillRepeatedly(Return(true));
+  EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.force_local_zone_min_size", 1))
+      .WillRepeatedly(Return(1));
   EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.min_cluster_size", 7))
       .WillRepeatedly(Return(7));
 
@@ -722,6 +725,8 @@ TEST_P(RoundRobinLoadBalancerTest, ZoneAwareZonesMismatched) {
       .WillRepeatedly(Return(50));
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("upstream.zone_routing.enabled", 100))
       .WillRepeatedly(Return(true));
+  EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.force_local_zone_min_size", 1))
+      .WillRepeatedly(Return(1));
   EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.min_cluster_size", 2))
       .WillRepeatedly(Return(2));
 
@@ -848,6 +853,8 @@ TEST_P(RoundRobinLoadBalancerTest, ZoneAwareResidualsMismatched) {
       .WillRepeatedly(Return(50));
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("upstream.zone_routing.enabled", 100))
       .WillRepeatedly(Return(true));
+  EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.force_local_zone_min_size", 1))
+      .WillRepeatedly(Return(1));
   EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.min_cluster_size", 6))
       .WillRepeatedly(Return(6));
 
@@ -926,6 +933,8 @@ TEST_P(RoundRobinLoadBalancerTest, ZoneAwareDifferentZoneSize) {
       .WillRepeatedly(Return(50));
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("upstream.zone_routing.enabled", 98))
       .WillRepeatedly(Return(true));
+  EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.force_local_zone_min_size", 1))
+      .WillRepeatedly(Return(1));
   EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.min_cluster_size", 3))
       .WillRepeatedly(Return(3));
 
@@ -970,6 +979,8 @@ TEST_P(RoundRobinLoadBalancerTest, ZoneAwareRoutingLargeZoneSwitchOnOff) {
       .WillRepeatedly(Return(50));
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("upstream.zone_routing.enabled", 100))
       .WillRepeatedly(Return(true));
+  EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.force_local_zone_min_size", 1))
+      .WillRepeatedly(Return(1));
   EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.min_cluster_size", 6))
       .WillRepeatedly(Return(3));
 
@@ -1028,6 +1039,8 @@ TEST_P(RoundRobinLoadBalancerTest, ZoneAwareRoutingSmallZone) {
       .WillRepeatedly(Return(50));
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("upstream.zone_routing.enabled", 100))
       .WillRepeatedly(Return(true));
+  EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.force_local_zone_min_size", 1))
+      .WillRepeatedly(Return(1));
   EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.min_cluster_size", 6))
       .WillRepeatedly(Return(5));
 
@@ -1088,6 +1101,8 @@ TEST_P(RoundRobinLoadBalancerTest, ZoneAwareNoMatchingZones) {
       .WillRepeatedly(Return(50));
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("upstream.zone_routing.enabled", 100))
       .WillRepeatedly(Return(true));
+  EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.force_local_zone_min_size", 1))
+      .WillRepeatedly(Return(1));
   EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.min_cluster_size", 6))
       .WillRepeatedly(Return(3));
 
@@ -1143,6 +1158,8 @@ TEST_P(RoundRobinLoadBalancerTest, NoZoneAwareNotEnoughLocalZones) {
       .WillRepeatedly(Return(50));
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("upstream.zone_routing.enabled", 100))
       .WillRepeatedly(Return(true));
+  EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.force_local_zone_min_size", 1))
+      .WillRepeatedly(Return(1));
   EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.min_cluster_size", 6))
       .WillRepeatedly(Return(2));
 
@@ -1187,6 +1204,8 @@ TEST_P(RoundRobinLoadBalancerTest, NoZoneAwareNotEnoughUpstreamZones) {
       .WillRepeatedly(Return(50));
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("upstream.zone_routing.enabled", 100))
       .WillRepeatedly(Return(true));
+  EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.force_local_zone_min_size", 1))
+      .WillRepeatedly(Return(1));
   EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.min_cluster_size", 6))
       .WillRepeatedly(Return(1));
 
@@ -1244,7 +1263,7 @@ TEST_P(RoundRobinLoadBalancerTest, ZoneAwareForceLocalityDirect) {
   common_config_.mutable_healthy_panic_threshold()->set_value(50);
   round_robin_lb_policy_.mutable_locality_lb_config()
       ->mutable_zone_aware_lb_config()
-      ->set_force_locality_direct_routing(false);
+      ->set_force_local_zone(false);
   round_robin_lb_policy_.mutable_locality_lb_config()
       ->mutable_zone_aware_lb_config()
       ->mutable_routing_enabled()
@@ -1259,6 +1278,11 @@ TEST_P(RoundRobinLoadBalancerTest, ZoneAwareForceLocalityDirect) {
       .WillRepeatedly(Return(true));
   EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.min_cluster_size", 3))
       .WillRepeatedly(Return(3));
+  EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.force_local_zone_min_size", 1))
+      .WillOnce(Return(1));
+  EXPECT_CALL(runtime_.snapshot_, getBoolean("upstream.zone_routing.force_local_zone", false))
+      .Times(2)
+      .WillRepeatedly(Return(false));
 
   init(true, false, false);
   updateHosts(hosts, local_hosts_per_locality);
@@ -1270,12 +1294,41 @@ TEST_P(RoundRobinLoadBalancerTest, ZoneAwareForceLocalityDirect) {
 
   round_robin_lb_policy_.mutable_locality_lb_config()
       ->mutable_zone_aware_lb_config()
-      ->set_force_locality_direct_routing(true);
+      ->set_force_local_zone(true);
+  round_robin_lb_policy_.mutable_locality_lb_config()
+      ->mutable_zone_aware_lb_config()
+      ->mutable_force_local_zone_min_size()
+      ->set_value(2);
+  EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.force_local_zone_min_size", 2))
+      .WillOnce(Return(2));
+  EXPECT_CALL(runtime_.snapshot_, getBoolean("upstream.zone_routing.force_local_zone", true))
+      .Times(2)
+      .WillRepeatedly(Return(true));
+
   init(true, false, false);
   updateHosts(hosts, local_hosts_per_locality);
 
-  // Expect zone-aware routing direct mode when force_locality_direct_routing is enabled
-  // and that upstream host in zone c is not selected
+  // Expect zone-aware routing residual mode when force_local_zone_min_size is
+  // not met (only 1 host in upstream zone)
+  EXPECT_EQ(hostSet().healthy_hosts_per_locality_->get()[0][0], lb_->chooseHost(nullptr).host);
+  EXPECT_EQ(0U, stats_.lb_zone_routing_all_directly_.value());
+  EXPECT_EQ(2U, stats_.lb_zone_routing_sampled_.value());
+  round_robin_lb_policy_.mutable_locality_lb_config()
+      ->mutable_zone_aware_lb_config()
+      ->mutable_force_local_zone_min_size()
+      ->set_value(1);
+  EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.force_local_zone_min_size", 1))
+      .WillOnce(Return(1));
+  EXPECT_CALL(runtime_.snapshot_, getBoolean("upstream.zone_routing.force_local_zone", true))
+      .Times(2)
+      .WillRepeatedly(Return(true));
+
+  init(true, false, false);
+  updateHosts(hosts, local_hosts_per_locality);
+
+  // Expect zone-aware routing direct mode when force_local_zone is enabled
+  // and force_local_zone_min_size is met.
+  // Also expect that upstream host in zone c is never selected.
   uint64_t direct_counter = stats_.lb_zone_routing_all_directly_.value();
   for (int i = 0; i < 10; ++i) {
     HostConstSharedPtr selected_host = lb_->chooseHost(nullptr).host;
@@ -1355,6 +1408,8 @@ TEST_P(RoundRobinLoadBalancerTest, ZoneAwareEmptyLocalities) {
       .WillRepeatedly(Return(50));
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("upstream.zone_routing.enabled", 100))
       .WillRepeatedly(Return(true));
+  EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.force_local_zone_min_size", 1))
+      .WillRepeatedly(Return(1));
   EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.min_cluster_size", 6))
       .WillRepeatedly(Return(3));
 
@@ -1429,6 +1484,8 @@ TEST_P(RoundRobinLoadBalancerTest, LowPrecisionForDistribution) {
       .WillRepeatedly(Return(50));
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("upstream.zone_routing.enabled", 100))
       .WillRepeatedly(Return(true));
+  EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.force_local_zone_min_size", 1))
+      .WillRepeatedly(Return(1));
   EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.min_cluster_size", 6))
       .WillRepeatedly(Return(1));
 
@@ -1542,6 +1599,8 @@ TEST_P(RoundRobinLoadBalancerTest, NoZoneAwareRoutingLocalEmpty) {
       .WillOnce(Return(50));
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("upstream.zone_routing.enabled", 100))
       .WillOnce(Return(true));
+  EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.force_local_zone_min_size", 1))
+      .WillRepeatedly(Return(1));
   EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.min_cluster_size", 6))
       .WillOnce(Return(1));
 
@@ -1586,6 +1645,8 @@ TEST_P(RoundRobinLoadBalancerTest, NoZoneAwareRoutingLocalEmptyFailTrafficOnPani
       .WillOnce(Return(50));
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("upstream.zone_routing.enabled", 100))
       .WillOnce(Return(true));
+  EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.force_local_zone_min_size", 1))
+      .WillRepeatedly(Return(1));
   EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.min_cluster_size", 6))
       .WillOnce(Return(1));
 

--- a/test/extensions/load_balancing_policies/round_robin/round_robin_lb_test.cc
+++ b/test/extensions/load_balancing_policies/round_robin/round_robin_lb_test.cc
@@ -658,8 +658,6 @@ TEST_P(RoundRobinLoadBalancerTest, ZoneAwareSmallCluster) {
       .WillRepeatedly(Return(50));
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("upstream.zone_routing.enabled", 98))
       .WillRepeatedly(Return(true));
-  EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.force_local_zone_min_size", 1))
-      .WillRepeatedly(Return(1));
   EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.min_cluster_size", 7))
       .WillRepeatedly(Return(7));
 
@@ -725,8 +723,6 @@ TEST_P(RoundRobinLoadBalancerTest, ZoneAwareZonesMismatched) {
       .WillRepeatedly(Return(50));
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("upstream.zone_routing.enabled", 100))
       .WillRepeatedly(Return(true));
-  EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.force_local_zone_min_size", 1))
-      .WillRepeatedly(Return(1));
   EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.min_cluster_size", 2))
       .WillRepeatedly(Return(2));
 
@@ -853,8 +849,6 @@ TEST_P(RoundRobinLoadBalancerTest, ZoneAwareResidualsMismatched) {
       .WillRepeatedly(Return(50));
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("upstream.zone_routing.enabled", 100))
       .WillRepeatedly(Return(true));
-  EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.force_local_zone_min_size", 1))
-      .WillRepeatedly(Return(1));
   EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.min_cluster_size", 6))
       .WillRepeatedly(Return(6));
 
@@ -933,8 +927,6 @@ TEST_P(RoundRobinLoadBalancerTest, ZoneAwareDifferentZoneSize) {
       .WillRepeatedly(Return(50));
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("upstream.zone_routing.enabled", 98))
       .WillRepeatedly(Return(true));
-  EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.force_local_zone_min_size", 1))
-      .WillRepeatedly(Return(1));
   EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.min_cluster_size", 3))
       .WillRepeatedly(Return(3));
 
@@ -979,8 +971,6 @@ TEST_P(RoundRobinLoadBalancerTest, ZoneAwareRoutingLargeZoneSwitchOnOff) {
       .WillRepeatedly(Return(50));
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("upstream.zone_routing.enabled", 100))
       .WillRepeatedly(Return(true));
-  EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.force_local_zone_min_size", 1))
-      .WillRepeatedly(Return(1));
   EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.min_cluster_size", 6))
       .WillRepeatedly(Return(3));
 
@@ -1039,8 +1029,6 @@ TEST_P(RoundRobinLoadBalancerTest, ZoneAwareRoutingSmallZone) {
       .WillRepeatedly(Return(50));
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("upstream.zone_routing.enabled", 100))
       .WillRepeatedly(Return(true));
-  EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.force_local_zone_min_size", 1))
-      .WillRepeatedly(Return(1));
   EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.min_cluster_size", 6))
       .WillRepeatedly(Return(5));
 
@@ -1101,8 +1089,6 @@ TEST_P(RoundRobinLoadBalancerTest, ZoneAwareNoMatchingZones) {
       .WillRepeatedly(Return(50));
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("upstream.zone_routing.enabled", 100))
       .WillRepeatedly(Return(true));
-  EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.force_local_zone_min_size", 1))
-      .WillRepeatedly(Return(1));
   EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.min_cluster_size", 6))
       .WillRepeatedly(Return(3));
 
@@ -1158,8 +1144,6 @@ TEST_P(RoundRobinLoadBalancerTest, NoZoneAwareNotEnoughLocalZones) {
       .WillRepeatedly(Return(50));
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("upstream.zone_routing.enabled", 100))
       .WillRepeatedly(Return(true));
-  EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.force_local_zone_min_size", 1))
-      .WillRepeatedly(Return(1));
   EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.min_cluster_size", 6))
       .WillRepeatedly(Return(2));
 
@@ -1204,8 +1188,6 @@ TEST_P(RoundRobinLoadBalancerTest, NoZoneAwareNotEnoughUpstreamZones) {
       .WillRepeatedly(Return(50));
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("upstream.zone_routing.enabled", 100))
       .WillRepeatedly(Return(true));
-  EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.force_local_zone_min_size", 1))
-      .WillRepeatedly(Return(1));
   EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.min_cluster_size", 6))
       .WillRepeatedly(Return(1));
 
@@ -1263,9 +1245,6 @@ TEST_P(RoundRobinLoadBalancerTest, ZoneAwareForceLocalityDirect) {
   common_config_.mutable_healthy_panic_threshold()->set_value(50);
   round_robin_lb_policy_.mutable_locality_lb_config()
       ->mutable_zone_aware_lb_config()
-      ->set_force_local_zone(false);
-  round_robin_lb_policy_.mutable_locality_lb_config()
-      ->mutable_zone_aware_lb_config()
       ->mutable_routing_enabled()
       ->set_value(100);
   round_robin_lb_policy_.mutable_locality_lb_config()
@@ -1278,11 +1257,6 @@ TEST_P(RoundRobinLoadBalancerTest, ZoneAwareForceLocalityDirect) {
       .WillRepeatedly(Return(true));
   EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.min_cluster_size", 3))
       .WillRepeatedly(Return(3));
-  EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.force_local_zone_min_size", 1))
-      .WillOnce(Return(1));
-  EXPECT_CALL(runtime_.snapshot_, getBoolean("upstream.zone_routing.force_local_zone", false))
-      .Times(2)
-      .WillRepeatedly(Return(false));
 
   init(true, false, false);
   updateHosts(hosts, local_hosts_per_locality);
@@ -1294,16 +1268,12 @@ TEST_P(RoundRobinLoadBalancerTest, ZoneAwareForceLocalityDirect) {
 
   round_robin_lb_policy_.mutable_locality_lb_config()
       ->mutable_zone_aware_lb_config()
-      ->set_force_local_zone(true);
-  round_robin_lb_policy_.mutable_locality_lb_config()
-      ->mutable_zone_aware_lb_config()
-      ->mutable_force_local_zone_min_size()
+      ->mutable_force_local_zone()
+      ->mutable_min_size()
       ->set_value(2);
-  EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.force_local_zone_min_size", 2))
+
+  EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.force_local_zone.min_size", 2))
       .WillOnce(Return(2));
-  EXPECT_CALL(runtime_.snapshot_, getBoolean("upstream.zone_routing.force_local_zone", true))
-      .Times(2)
-      .WillRepeatedly(Return(true));
 
   init(true, false, false);
   updateHosts(hosts, local_hosts_per_locality);
@@ -1315,13 +1285,9 @@ TEST_P(RoundRobinLoadBalancerTest, ZoneAwareForceLocalityDirect) {
   EXPECT_EQ(2U, stats_.lb_zone_routing_sampled_.value());
   round_robin_lb_policy_.mutable_locality_lb_config()
       ->mutable_zone_aware_lb_config()
-      ->mutable_force_local_zone_min_size()
+      ->mutable_force_local_zone()
+      ->mutable_min_size()
       ->set_value(1);
-  EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.force_local_zone_min_size", 1))
-      .WillOnce(Return(1));
-  EXPECT_CALL(runtime_.snapshot_, getBoolean("upstream.zone_routing.force_local_zone", true))
-      .Times(2)
-      .WillRepeatedly(Return(true));
 
   init(true, false, false);
   updateHosts(hosts, local_hosts_per_locality);
@@ -1408,8 +1374,6 @@ TEST_P(RoundRobinLoadBalancerTest, ZoneAwareEmptyLocalities) {
       .WillRepeatedly(Return(50));
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("upstream.zone_routing.enabled", 100))
       .WillRepeatedly(Return(true));
-  EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.force_local_zone_min_size", 1))
-      .WillRepeatedly(Return(1));
   EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.min_cluster_size", 6))
       .WillRepeatedly(Return(3));
 
@@ -1484,8 +1448,6 @@ TEST_P(RoundRobinLoadBalancerTest, LowPrecisionForDistribution) {
       .WillRepeatedly(Return(50));
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("upstream.zone_routing.enabled", 100))
       .WillRepeatedly(Return(true));
-  EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.force_local_zone_min_size", 1))
-      .WillRepeatedly(Return(1));
   EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.min_cluster_size", 6))
       .WillRepeatedly(Return(1));
 
@@ -1599,8 +1561,6 @@ TEST_P(RoundRobinLoadBalancerTest, NoZoneAwareRoutingLocalEmpty) {
       .WillOnce(Return(50));
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("upstream.zone_routing.enabled", 100))
       .WillOnce(Return(true));
-  EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.force_local_zone_min_size", 1))
-      .WillRepeatedly(Return(1));
   EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.min_cluster_size", 6))
       .WillOnce(Return(1));
 
@@ -1645,8 +1605,6 @@ TEST_P(RoundRobinLoadBalancerTest, NoZoneAwareRoutingLocalEmptyFailTrafficOnPani
       .WillOnce(Return(50));
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("upstream.zone_routing.enabled", 100))
       .WillOnce(Return(true));
-  EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.force_local_zone_min_size", 1))
-      .WillRepeatedly(Return(1));
   EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.min_cluster_size", 6))
       .WillOnce(Return(1));
 

--- a/test/extensions/load_balancing_policies/round_robin/round_robin_lb_test.cc
+++ b/test/extensions/load_balancing_policies/round_robin/round_robin_lb_test.cc
@@ -6,7 +6,6 @@ namespace Envoy {
 namespace Upstream {
 namespace {
 
-using testing::AtLeast;
 using testing::Return;
 using testing::ReturnRef;
 
@@ -658,6 +657,8 @@ TEST_P(RoundRobinLoadBalancerTest, ZoneAwareSmallCluster) {
       .WillRepeatedly(Return(50));
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("upstream.zone_routing.enabled", 98))
       .WillRepeatedly(Return(true));
+  EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.force_local_zone.min_size", 0))
+      .WillRepeatedly(Return(0));
   EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.min_cluster_size", 7))
       .WillRepeatedly(Return(7));
 
@@ -723,6 +724,8 @@ TEST_P(RoundRobinLoadBalancerTest, ZoneAwareZonesMismatched) {
       .WillRepeatedly(Return(50));
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("upstream.zone_routing.enabled", 100))
       .WillRepeatedly(Return(true));
+  EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.force_local_zone.min_size", 0))
+      .WillRepeatedly(Return(0));
   EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.min_cluster_size", 2))
       .WillRepeatedly(Return(2));
 
@@ -849,6 +852,8 @@ TEST_P(RoundRobinLoadBalancerTest, ZoneAwareResidualsMismatched) {
       .WillRepeatedly(Return(50));
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("upstream.zone_routing.enabled", 100))
       .WillRepeatedly(Return(true));
+  EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.force_local_zone.min_size", 0))
+      .WillRepeatedly(Return(0));
   EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.min_cluster_size", 6))
       .WillRepeatedly(Return(6));
 
@@ -927,6 +932,8 @@ TEST_P(RoundRobinLoadBalancerTest, ZoneAwareDifferentZoneSize) {
       .WillRepeatedly(Return(50));
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("upstream.zone_routing.enabled", 98))
       .WillRepeatedly(Return(true));
+  EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.force_local_zone.min_size", 0))
+      .WillRepeatedly(Return(0));
   EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.min_cluster_size", 3))
       .WillRepeatedly(Return(3));
 
@@ -971,6 +978,8 @@ TEST_P(RoundRobinLoadBalancerTest, ZoneAwareRoutingLargeZoneSwitchOnOff) {
       .WillRepeatedly(Return(50));
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("upstream.zone_routing.enabled", 100))
       .WillRepeatedly(Return(true));
+  EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.force_local_zone.min_size", 0))
+      .WillRepeatedly(Return(0));
   EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.min_cluster_size", 6))
       .WillRepeatedly(Return(3));
 
@@ -1029,6 +1038,8 @@ TEST_P(RoundRobinLoadBalancerTest, ZoneAwareRoutingSmallZone) {
       .WillRepeatedly(Return(50));
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("upstream.zone_routing.enabled", 100))
       .WillRepeatedly(Return(true));
+  EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.force_local_zone.min_size", 0))
+      .WillRepeatedly(Return(0));
   EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.min_cluster_size", 6))
       .WillRepeatedly(Return(5));
 
@@ -1089,6 +1100,8 @@ TEST_P(RoundRobinLoadBalancerTest, ZoneAwareNoMatchingZones) {
       .WillRepeatedly(Return(50));
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("upstream.zone_routing.enabled", 100))
       .WillRepeatedly(Return(true));
+  EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.force_local_zone.min_size", 0))
+      .WillRepeatedly(Return(0));
   EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.min_cluster_size", 6))
       .WillRepeatedly(Return(3));
 
@@ -1144,6 +1157,8 @@ TEST_P(RoundRobinLoadBalancerTest, NoZoneAwareNotEnoughLocalZones) {
       .WillRepeatedly(Return(50));
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("upstream.zone_routing.enabled", 100))
       .WillRepeatedly(Return(true));
+  EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.force_local_zone.min_size", 0))
+      .WillRepeatedly(Return(0));
   EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.min_cluster_size", 6))
       .WillRepeatedly(Return(2));
 
@@ -1188,6 +1203,8 @@ TEST_P(RoundRobinLoadBalancerTest, NoZoneAwareNotEnoughUpstreamZones) {
       .WillRepeatedly(Return(50));
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("upstream.zone_routing.enabled", 100))
       .WillRepeatedly(Return(true));
+  EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.force_local_zone.min_size", 0))
+      .WillRepeatedly(Return(0));
   EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.min_cluster_size", 6))
       .WillRepeatedly(Return(1));
 
@@ -1255,6 +1272,8 @@ TEST_P(RoundRobinLoadBalancerTest, ZoneAwareForceLocalityDirect) {
       .WillRepeatedly(Return(50));
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("upstream.zone_routing.enabled", 100))
       .WillRepeatedly(Return(true));
+  EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.force_local_zone.min_size", 0))
+      .WillRepeatedly(Return(0));
   EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.min_cluster_size", 3))
       .WillRepeatedly(Return(3));
 
@@ -1271,9 +1290,6 @@ TEST_P(RoundRobinLoadBalancerTest, ZoneAwareForceLocalityDirect) {
       ->mutable_force_local_zone()
       ->mutable_min_size()
       ->set_value(2);
-
-  EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.force_local_zone.min_size", 2))
-      .WillOnce(Return(2));
 
   init(true, false, false);
   updateHosts(hosts, local_hosts_per_locality);
@@ -1374,6 +1390,8 @@ TEST_P(RoundRobinLoadBalancerTest, ZoneAwareEmptyLocalities) {
       .WillRepeatedly(Return(50));
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("upstream.zone_routing.enabled", 100))
       .WillRepeatedly(Return(true));
+  EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.force_local_zone.min_size", 0))
+      .WillRepeatedly(Return(0));
   EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.min_cluster_size", 6))
       .WillRepeatedly(Return(3));
 
@@ -1448,6 +1466,8 @@ TEST_P(RoundRobinLoadBalancerTest, LowPrecisionForDistribution) {
       .WillRepeatedly(Return(50));
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("upstream.zone_routing.enabled", 100))
       .WillRepeatedly(Return(true));
+  EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.force_local_zone.min_size", 0))
+      .WillRepeatedly(Return(0));
   EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.min_cluster_size", 6))
       .WillRepeatedly(Return(1));
 
@@ -1561,6 +1581,8 @@ TEST_P(RoundRobinLoadBalancerTest, NoZoneAwareRoutingLocalEmpty) {
       .WillOnce(Return(50));
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("upstream.zone_routing.enabled", 100))
       .WillOnce(Return(true));
+  EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.force_local_zone.min_size", 0))
+      .WillRepeatedly(Return(0));
   EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.min_cluster_size", 6))
       .WillOnce(Return(1));
 
@@ -1605,6 +1627,8 @@ TEST_P(RoundRobinLoadBalancerTest, NoZoneAwareRoutingLocalEmptyFailTrafficOnPani
       .WillOnce(Return(50));
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("upstream.zone_routing.enabled", 100))
       .WillOnce(Return(true));
+  EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.force_local_zone.min_size", 0))
+      .WillRepeatedly(Return(0));
   EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.min_cluster_size", 6))
       .WillOnce(Return(1));
 

--- a/test/extensions/load_balancing_policies/subset/subset_test.cc
+++ b/test/extensions/load_balancing_policies/subset/subset_test.cc
@@ -1727,6 +1727,8 @@ TEST_F(SubsetLoadBalancerTest, ZoneAwareFallback) {
       .WillRepeatedly(Return(50));
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("upstream.zone_routing.enabled", 100))
       .WillRepeatedly(Return(true));
+  EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.force_local_zone.min_size", 0))
+      .WillRepeatedly(Return(0));
   EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.min_cluster_size", 6))
       .WillRepeatedly(Return(2));
 
@@ -1772,6 +1774,8 @@ TEST_P(SubsetLoadBalancerTest, ZoneAwareFallbackAfterUpdate) {
       .WillRepeatedly(Return(50));
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("upstream.zone_routing.enabled", 100))
       .WillRepeatedly(Return(true));
+  EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.force_local_zone.min_size", 0))
+      .WillRepeatedly(Return(0));
   EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.min_cluster_size", 6))
       .WillRepeatedly(Return(2));
 
@@ -1838,6 +1842,8 @@ TEST_F(SubsetLoadBalancerTest, ZoneAwareFallbackDefaultSubset) {
       .WillRepeatedly(Return(50));
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("upstream.zone_routing.enabled", 100))
       .WillRepeatedly(Return(true));
+  EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.force_local_zone.min_size", 0))
+      .WillRepeatedly(Return(0));
   EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.min_cluster_size", 6))
       .WillRepeatedly(Return(2));
 
@@ -1895,6 +1901,8 @@ TEST_P(SubsetLoadBalancerTest, ZoneAwareFallbackDefaultSubsetAfterUpdate) {
       .WillRepeatedly(Return(50));
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("upstream.zone_routing.enabled", 100))
       .WillRepeatedly(Return(true));
+  EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.force_local_zone.min_size", 0))
+      .WillRepeatedly(Return(0));
   EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.min_cluster_size", 6))
       .WillRepeatedly(Return(2));
 
@@ -1965,6 +1973,8 @@ TEST_F(SubsetLoadBalancerTest, ZoneAwareBalancesSubsets) {
       .WillRepeatedly(Return(50));
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("upstream.zone_routing.enabled", 100))
       .WillRepeatedly(Return(true));
+  EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.force_local_zone.min_size", 0))
+      .WillRepeatedly(Return(0));
   EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.min_cluster_size", 6))
       .WillRepeatedly(Return(2));
 
@@ -2020,6 +2030,8 @@ TEST_P(SubsetLoadBalancerTest, ZoneAwareBalancesSubsetsAfterUpdate) {
       .WillRepeatedly(Return(50));
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("upstream.zone_routing.enabled", 100))
       .WillRepeatedly(Return(true));
+  EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.force_local_zone.min_size", 0))
+      .WillRepeatedly(Return(0));
   EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.min_cluster_size", 6))
       .WillRepeatedly(Return(2));
 
@@ -2092,6 +2104,8 @@ TEST_F(SubsetLoadBalancerTest, ZoneAwareComplicatedBalancesSubsets) {
       .WillRepeatedly(Return(50));
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("upstream.zone_routing.enabled", 100))
       .WillRepeatedly(Return(true));
+  EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.force_local_zone.min_size", 0))
+      .WillRepeatedly(Return(0));
   EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.min_cluster_size", 6))
       .WillRepeatedly(Return(2));
 
@@ -2159,6 +2173,8 @@ TEST_P(SubsetLoadBalancerTest, ZoneAwareComplicatedBalancesSubsetsAfterUpdate) {
       .WillRepeatedly(Return(50));
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("upstream.zone_routing.enabled", 100))
       .WillRepeatedly(Return(true));
+  EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.force_local_zone.min_size", 0))
+      .WillRepeatedly(Return(0));
   EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.min_cluster_size", 6))
       .WillRepeatedly(Return(2));
 

--- a/test/extensions/load_balancing_policies/subset/subset_test.cc
+++ b/test/extensions/load_balancing_policies/subset/subset_test.cc
@@ -1727,6 +1727,8 @@ TEST_F(SubsetLoadBalancerTest, ZoneAwareFallback) {
       .WillRepeatedly(Return(50));
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("upstream.zone_routing.enabled", 100))
       .WillRepeatedly(Return(true));
+  EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.force_local_zone_min_size", 1))
+      .WillRepeatedly(Return(1));
   EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.min_cluster_size", 6))
       .WillRepeatedly(Return(2));
 
@@ -1772,6 +1774,8 @@ TEST_P(SubsetLoadBalancerTest, ZoneAwareFallbackAfterUpdate) {
       .WillRepeatedly(Return(50));
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("upstream.zone_routing.enabled", 100))
       .WillRepeatedly(Return(true));
+  EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.force_local_zone_min_size", 1))
+      .WillRepeatedly(Return(1));
   EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.min_cluster_size", 6))
       .WillRepeatedly(Return(2));
 
@@ -1838,6 +1842,8 @@ TEST_F(SubsetLoadBalancerTest, ZoneAwareFallbackDefaultSubset) {
       .WillRepeatedly(Return(50));
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("upstream.zone_routing.enabled", 100))
       .WillRepeatedly(Return(true));
+  EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.force_local_zone_min_size", 1))
+      .WillRepeatedly(Return(1));
   EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.min_cluster_size", 6))
       .WillRepeatedly(Return(2));
 
@@ -1895,6 +1901,8 @@ TEST_P(SubsetLoadBalancerTest, ZoneAwareFallbackDefaultSubsetAfterUpdate) {
       .WillRepeatedly(Return(50));
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("upstream.zone_routing.enabled", 100))
       .WillRepeatedly(Return(true));
+  EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.force_local_zone_min_size", 1))
+      .WillRepeatedly(Return(1));
   EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.min_cluster_size", 6))
       .WillRepeatedly(Return(2));
 
@@ -1965,6 +1973,8 @@ TEST_F(SubsetLoadBalancerTest, ZoneAwareBalancesSubsets) {
       .WillRepeatedly(Return(50));
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("upstream.zone_routing.enabled", 100))
       .WillRepeatedly(Return(true));
+  EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.force_local_zone_min_size", 1))
+      .WillRepeatedly(Return(1));
   EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.min_cluster_size", 6))
       .WillRepeatedly(Return(2));
 
@@ -2020,6 +2030,8 @@ TEST_P(SubsetLoadBalancerTest, ZoneAwareBalancesSubsetsAfterUpdate) {
       .WillRepeatedly(Return(50));
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("upstream.zone_routing.enabled", 100))
       .WillRepeatedly(Return(true));
+  EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.force_local_zone_min_size", 1))
+      .WillRepeatedly(Return(1));
   EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.min_cluster_size", 6))
       .WillRepeatedly(Return(2));
 
@@ -2092,6 +2104,8 @@ TEST_F(SubsetLoadBalancerTest, ZoneAwareComplicatedBalancesSubsets) {
       .WillRepeatedly(Return(50));
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("upstream.zone_routing.enabled", 100))
       .WillRepeatedly(Return(true));
+  EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.force_local_zone_min_size", 1))
+      .WillRepeatedly(Return(1));
   EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.min_cluster_size", 6))
       .WillRepeatedly(Return(2));
 
@@ -2159,6 +2173,8 @@ TEST_P(SubsetLoadBalancerTest, ZoneAwareComplicatedBalancesSubsetsAfterUpdate) {
       .WillRepeatedly(Return(50));
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("upstream.zone_routing.enabled", 100))
       .WillRepeatedly(Return(true));
+  EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.force_local_zone_min_size", 1))
+      .WillRepeatedly(Return(1));
   EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.min_cluster_size", 6))
       .WillRepeatedly(Return(2));
 

--- a/test/extensions/load_balancing_policies/subset/subset_test.cc
+++ b/test/extensions/load_balancing_policies/subset/subset_test.cc
@@ -1727,8 +1727,6 @@ TEST_F(SubsetLoadBalancerTest, ZoneAwareFallback) {
       .WillRepeatedly(Return(50));
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("upstream.zone_routing.enabled", 100))
       .WillRepeatedly(Return(true));
-  EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.force_local_zone_min_size", 1))
-      .WillRepeatedly(Return(1));
   EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.min_cluster_size", 6))
       .WillRepeatedly(Return(2));
 
@@ -1774,8 +1772,6 @@ TEST_P(SubsetLoadBalancerTest, ZoneAwareFallbackAfterUpdate) {
       .WillRepeatedly(Return(50));
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("upstream.zone_routing.enabled", 100))
       .WillRepeatedly(Return(true));
-  EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.force_local_zone_min_size", 1))
-      .WillRepeatedly(Return(1));
   EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.min_cluster_size", 6))
       .WillRepeatedly(Return(2));
 
@@ -1842,8 +1838,6 @@ TEST_F(SubsetLoadBalancerTest, ZoneAwareFallbackDefaultSubset) {
       .WillRepeatedly(Return(50));
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("upstream.zone_routing.enabled", 100))
       .WillRepeatedly(Return(true));
-  EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.force_local_zone_min_size", 1))
-      .WillRepeatedly(Return(1));
   EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.min_cluster_size", 6))
       .WillRepeatedly(Return(2));
 
@@ -1901,8 +1895,6 @@ TEST_P(SubsetLoadBalancerTest, ZoneAwareFallbackDefaultSubsetAfterUpdate) {
       .WillRepeatedly(Return(50));
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("upstream.zone_routing.enabled", 100))
       .WillRepeatedly(Return(true));
-  EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.force_local_zone_min_size", 1))
-      .WillRepeatedly(Return(1));
   EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.min_cluster_size", 6))
       .WillRepeatedly(Return(2));
 
@@ -1973,8 +1965,6 @@ TEST_F(SubsetLoadBalancerTest, ZoneAwareBalancesSubsets) {
       .WillRepeatedly(Return(50));
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("upstream.zone_routing.enabled", 100))
       .WillRepeatedly(Return(true));
-  EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.force_local_zone_min_size", 1))
-      .WillRepeatedly(Return(1));
   EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.min_cluster_size", 6))
       .WillRepeatedly(Return(2));
 
@@ -2030,8 +2020,6 @@ TEST_P(SubsetLoadBalancerTest, ZoneAwareBalancesSubsetsAfterUpdate) {
       .WillRepeatedly(Return(50));
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("upstream.zone_routing.enabled", 100))
       .WillRepeatedly(Return(true));
-  EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.force_local_zone_min_size", 1))
-      .WillRepeatedly(Return(1));
   EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.min_cluster_size", 6))
       .WillRepeatedly(Return(2));
 
@@ -2104,8 +2092,6 @@ TEST_F(SubsetLoadBalancerTest, ZoneAwareComplicatedBalancesSubsets) {
       .WillRepeatedly(Return(50));
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("upstream.zone_routing.enabled", 100))
       .WillRepeatedly(Return(true));
-  EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.force_local_zone_min_size", 1))
-      .WillRepeatedly(Return(1));
   EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.min_cluster_size", 6))
       .WillRepeatedly(Return(2));
 
@@ -2173,8 +2159,6 @@ TEST_P(SubsetLoadBalancerTest, ZoneAwareComplicatedBalancesSubsetsAfterUpdate) {
       .WillRepeatedly(Return(50));
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("upstream.zone_routing.enabled", 100))
       .WillRepeatedly(Return(true));
-  EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.force_local_zone_min_size", 1))
-      .WillRepeatedly(Return(1));
   EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.min_cluster_size", 6))
       .WillRepeatedly(Return(2));
 


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Add force_local_zone to zone-aware routing with min_size option and deprecate force_locality_direct_routing.
Additional Description: Follow-up to https://github.com/envoyproxy/envoy/pull/38756. Adds minimum zone size parameter as a gate to forcing LocalityDirect mode in zone-aware-routing and renames force_locality_direct_routing to force_local_zone.
Risk Level:
Testing:
Docs Changes: Yes
Release Notes:
Platform Specific Features:

Fixes #38561

