### PR TITLE
backport to rel1.32: http_inspector dynamic buffering #37002

### DIFF
--- a/source/extensions/filters/listener/http_inspector/config.cc
+++ b/source/extensions/filters/listener/http_inspector/config.cc
@@ -1,4 +1,3 @@
-#include "envoy/extensions/filters/listener/http_inspector/v3/http_inspector.pb.h"
 #include "envoy/extensions/filters/listener/http_inspector/v3/http_inspector.pb.validate.h"
 #include "envoy/registry/registry.h"
 #include "envoy/server/filter_config.h"

--- a/source/extensions/filters/listener/http_inspector/http_inspector.h
+++ b/source/extensions/filters/listener/http_inspector/http_inspector.h
@@ -52,7 +52,8 @@ public:
 
   const HttpInspectorStats& stats() const { return stats_; }
 
-  static constexpr uint32_t MAX_INSPECT_SIZE = 8192;
+  static constexpr uint32_t DEFAULT_INITIAL_BUFFER_SIZE = 8 * 1024;
+  static constexpr uint32_t MAX_INSPECT_SIZE = 64 * 1024;
 
 private:
   HttpInspectorStats stats_;
@@ -71,7 +72,7 @@ public:
   Network::FilterStatus onAccept(Network::ListenerFilterCallbacks& cb) override;
   Network::FilterStatus onData(Network::ListenerFilterBuffer& buffer) override;
 
-  size_t maxReadBytes() const override { return Config::MAX_INSPECT_SIZE; }
+  size_t maxReadBytes() const override { return requested_read_bytes_; }
 
 private:
   static const absl::string_view HTTP2_CONNECTION_PREFACE;
@@ -87,6 +88,7 @@ private:
   absl::string_view protocol_;
   http_parser parser_;
   static http_parser_settings settings_;
+  size_t requested_read_bytes_ = 0;
 };
 
 } // namespace HttpInspector


### PR DESCRIPTION
Backport PR #37002 to release 1.32

Commit Message:
http_inspector dynamic buffering
Additional Description:
Changed the buffering behavior of HttpInspector. Previously, a static buffer of 8KB was inspected, and anything larger (e.g. a GET request with >8KB of params) would fail. Now, there is a configurable initial_read_buffer_size in HttpInspector that, and if the HTTP version is not identified with that amount of request buffered, it will iteratively double up to 64KB.

Risk Level: low
Testing: Added unit tests.
