### PR TITLE
ext_proc: adds optional config to force content-length instead of chunked transfer encoding during STREAMED and FULL_DUPLEX_STREAMED body processing

### DIFF
--- a/api/envoy/extensions/filters/http/ext_proc/v3/ext_proc.proto
+++ b/api/envoy/extensions/filters/http/ext_proc/v3/ext_proc.proto
@@ -339,6 +339,20 @@ message ExternalProcessor {
   // [#extension-category: envoy.http.ext_proc.response_processors]
   config.core.v3.TypedExtensionConfig on_processing_response = 23
       [(xds.annotations.v3.field_status).work_in_progress = true];
+
+  // Retain content length header for STREAMED and FULL_DUPLEX_STREAMED body processing modes.
+  //
+  // If enabled and a content length header is present Envoy will not switch to chunked transfer encoding
+  // for http1 codec. It is the responsibility of the side stream server to ensure a correct content length header is present.
+  //
+  // .. warning::
+  //   Retaining the content length header allows untrusted side stream servers to override the content length header.
+  //   This behavior can introduce serious security vulnerabilities, including HTTP request smuggling attacks.
+  //   Do not enable this feature when interacting with untrusted or potentially malicious side stream servers.
+  //   Use only in controlled environments with fully trusted side stream servers and a complete understanding of the 
+  //   security implications.
+  //
+  bool retain_content_length_header = 24;
 }
 
 // ExtProcHttpService is used for HTTP communication between the filter and the external processing service.

--- a/source/extensions/filters/http/ext_proc/ext_proc.h
+++ b/source/extensions/filters/http/ext_proc/ext_proc.h
@@ -223,6 +223,8 @@ public:
     return send_body_without_waiting_for_header_response_;
   }
 
+  bool retainContentLengthHeader() const { return retain_content_length_header_; }
+
   const ExtProcFilterStats& stats() const { return stats_; }
 
   const envoy::extensions::filters::http::ext_proc::v3::ProcessingMode& processingMode() const {
@@ -305,6 +307,7 @@ private:
   const uint32_t max_message_timeout_ms_;
   const absl::optional<const envoy::config::core::v3::GrpcService> grpc_service_;
   const bool send_body_without_waiting_for_header_response_;
+  const bool retain_content_length_header_;
 
   ExtProcFilterStats stats_;
   const envoy::extensions::filters::http::ext_proc::v3::ProcessingMode processing_mode_;

--- a/source/extensions/filters/http/ext_proc/processor_state.cc
+++ b/source/extensions/filters/http/ext_proc/processor_state.cc
@@ -114,7 +114,7 @@ absl::Status ProcessorState::processHeaderMutation(const CommonResponse& common_
       common_response.header_mutation(), *headers_,
       common_response.status() == CommonResponse::CONTINUE_AND_REPLACE,
       filter_.config().mutationChecker(), filter_.stats().rejected_header_mutations_,
-      shouldRemoveContentLength());
+      shouldRemoveContentLength(filter_.config().retainContentLengthHeader()));
   return mut_status;
 }
 


### PR DESCRIPTION
WIP TODO:

- [x]  Better naming for this config item.
- [ ] Clarification if a side stream server should be able to override the config (similar behavior as `send_body_without_waiting_for_header_response`
- [ ] Add test cases

Commit Message: Adds a new configuration knob `retain_content_length_header` to the ext_proc filter enabling that a side stream server can use STREAMED and FULL_DUPLEX_STREAMED body processing modes without envoy automatically switching to chunked transfer encoding for HTTP1 codec. If `retain_content_length_header` is set to `true` forces Envoy to keep the content length header (instead of switching to chunked encoding). 
Additional Description:
Risk Level: Low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue] #39035, #38291
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
