### PR TITLE
Modify devcontainer config to complete clang default

### DIFF
--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 BAZELRC_FILE=~/.bazelrc bazel/setup_clang.sh /opt/llvm
+echo "common --config=clang-libc++" >> ~/.bazelrc
 
 # Ideally we want this line so bazel doesn't pollute things outside of the devcontainer, but some of
 # API tooling (proto_sync) depends on symlink like bazel-bin.


### PR DESCRIPTION
Commit Message: Modify devcontainer config to complete clang default
Additional Description:
A fresh devcontainer before this change fails [for me] to compile `bazel build --announce_rc @com_envoyproxy_protoc_gen_validate//:protoc-gen-validate`.
This seems to be a bit of an ambiguous thing, in that an apparently identical container from `run_envoy_docker.sh` will build the same thing successfully, with identical bazelrc config according to the `--announce_rc` output - apparently in that container it defaults to a gcc config, while the devcontainer seemingly defaults to a weird incomplete partial clang config, which makes it try to link with `ld.lld` versus the gcc's `ld.gold` linker.
Since the clang config is already pushed by the devcontainer in a file that says "delete this if you don't want clang" at the top, it seems reasonable to make that same file forcibly use a more complete clang config which reliably works.
Risk Level: None, devcontainer only.
Testing: I tried a variety of things, this was the one that works and doesn't seem likely to unintentionally break something else.
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
