### PR TITLE
lua: use filter config name to get metadata first

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -52,6 +52,11 @@ minor_behavior_changes:
 - area: tls
   change: |
     FIPS build is updated to use the same version of boringssl as the regular build, per the revised FedRAMP policy.
+- area: lua
+  change: |
+    The ``metadata()`` of lua filter now will search the metadata by the :ref:`filter config name
+    <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpFilter.name>` first.
+    And if not found, it will search by the canonical name of the filter ``envoy.filters.http.lua``.
 
 bug_fixes:
 # *Changes expected to improve the state of the world and are unlikely to have negative effects*

--- a/docs/root/configuration/http/http_filters/_include/lua-filter.yaml
+++ b/docs/root/configuration/http/http_filters/_include/lua-filter.yaml
@@ -25,13 +25,13 @@ static_resources:
                   cluster: upstream_com
               metadata:
                 filter_metadata:
-                  envoy.filters.http.lua:
+                  lua-custom-name:
                     foo: bar
                     baz:
                     - bad
                     - baz
           http_filters:
-          - name: envoy.filters.http.lua
+          - name: lua-custom-name
             typed_config:
               "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
               default_source_code:

--- a/docs/root/configuration/http/http_filters/lua_filter.rst
+++ b/docs/root/configuration/http/http_filters/lua_filter.rst
@@ -476,8 +476,13 @@ body. May be nil.
   local metadata = handle:metadata()
 
 Returns the current route entry metadata. Note that the metadata should be specified
-under the filter name i.e. ``envoy.filters.http.lua``. Below is an example of a ``metadata`` in a
-:ref:`route entry <envoy_v3_api_msg_config.route.v3.Route>`.
+under the :ref:`filter config name
+<envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpFilter.name>`.
+If no entry could be find by the filter config name, then filter canonical name
+i.e. ``envoy.filters.http.lua`` will be used as alternative. But note this downgrade will be
+deprecated in the future.
+
+Below is an example of a ``metadata`` in a :ref:`route entry <envoy_v3_api_msg_config.route.v3.Route>`.
 
 .. literalinclude:: _include/lua-filter.yaml
     :language: yaml

--- a/source/extensions/filters/http/lua/lua_filter.cc
+++ b/source/extensions/filters/http/lua/lua_filter.cc
@@ -112,7 +112,12 @@ const ProtobufWkt::Struct& getMetadata(Http::StreamFilterCallbacks* callbacks) {
   const auto& metadata = callbacks->route()->metadata();
 
   {
-    const auto& filter_it = metadata.filter_metadata().find("envoy.filters.http.lua");
+    auto filter_it = metadata.filter_metadata().find(callbacks->filterConfigName());
+    if (filter_it != metadata.filter_metadata().end()) {
+      return filter_it->second;
+    }
+    // TODO(wbpcode): deprecate this in favor of the above.
+    filter_it = metadata.filter_metadata().find("envoy.filters.http.lua");
     if (filter_it != metadata.filter_metadata().end()) {
       return filter_it->second;
     }

--- a/test/extensions/filters/http/lua/lua_filter_test.cc
+++ b/test/extensions/filters/http/lua/lua_filter_test.cc
@@ -2087,18 +2087,27 @@ TEST_F(LuaHttpFilterTest, GetMetadataFromHandle) {
 
   const std::string METADATA{R"EOF(
     filter_metadata:
-      envoy.filters.http.lua:
+      lua-filter-config-name:
         foo.bar:
           name: foo
           prop: bar
         baz.bat:
           name: baz
           prop: bat
+      envoy.filters.http.lua:
+        foo.bar:
+          name: foo-xxx
+          prop: bar-xxx
+        baz.bat:
+          name: baz-xxx
+          prop: bat-xxx
   )EOF"};
 
   InSequence s;
   setup(SCRIPT);
   setupMetadata(METADATA);
+
+  ON_CALL(decoder_callbacks_, filterConfigName()).WillByDefault(Return("lua-filter-config-name"));
 
   Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
   EXPECT_LOG_CONTAINS_ALL_OF(Envoy::ExpectedLogMessages({
@@ -2106,6 +2115,46 @@ TEST_F(LuaHttpFilterTest, GetMetadataFromHandle) {
                                  {"trace", "bar"},
                                  {"trace", "baz"},
                                  {"trace", "bat"},
+                             }),
+                             {
+                               EXPECT_EQ(Http::FilterHeadersStatus::Continue,
+                                         filter_->decodeHeaders(request_headers, true));
+                             });
+  EXPECT_EQ(0, stats_store_.counter("test.lua.errors").value());
+}
+
+TEST_F(LuaHttpFilterTest, GetMetadataFromHandleWithCanonicalName) {
+  const std::string SCRIPT{R"EOF(
+    function envoy_on_request(request_handle)
+      request_handle:logTrace(request_handle:metadata():get("foo.bar")["name"])
+      request_handle:logTrace(request_handle:metadata():get("foo.bar")["prop"])
+      request_handle:logTrace(request_handle:metadata():get("baz.bat")["name"])
+      request_handle:logTrace(request_handle:metadata():get("baz.bat")["prop"])
+    end
+  )EOF"};
+
+  const std::string METADATA{R"EOF(
+      envoy.filters.http.lua:
+        foo.bar:
+          name: foo-xxx
+          prop: bar-xxx
+        baz.bat:
+          name: baz-xxx
+          prop: bat-xxx
+  )EOF"};
+
+  InSequence s;
+  setup(SCRIPT);
+  setupMetadata(METADATA);
+
+  ON_CALL(decoder_callbacks_, filterConfigName()).WillByDefault(Return("lua-filter-config-name"));
+
+  Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
+  EXPECT_LOG_CONTAINS_ALL_OF(Envoy::ExpectedLogMessages({
+                                 {"trace", "foo-xxx"},
+                                 {"trace", "bar-xxx"},
+                                 {"trace", "baz-xxx"},
+                                 {"trace", "bat-xxx"},
                              }),
                              {
                                EXPECT_EQ(Http::FilterHeadersStatus::Continue,


### PR DESCRIPTION
Commit Message: lua: use filter config name to get metadata first
Additional Description:

In the past, the envoy.filters.http.lua will always be used to search the metadata entry of route. Now, the filter config name will be use first.


Risk Level: low.
Testing: unit.
Docs Changes: added.
Release Notes: added.
Platform Specific Features: n/a.
