### PR TITLE
ratelimit: add support for emitting filter state stats for access logging

### DIFF
--- a/api/envoy/extensions/filters/http/ratelimit/v3/rate_limit.proto
+++ b/api/envoy/extensions/filters/http/ratelimit/v3/rate_limit.proto
@@ -23,7 +23,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // Rate limit :ref:`configuration overview <config_http_filters_rate_limit>`.
 // [#extension: envoy.filters.http.ratelimit]
 
-// [#next-free-field: 16]
+// [#next-free-field: 17]
 message RateLimit {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.http.rate_limit.v2.RateLimit";
@@ -149,6 +149,14 @@ message RateLimit {
   // the fraction of requests to enforce rate limits on. And the default percentage of the
   // runtime key is 100% for backwards compatibility.
   config.core.v3.RuntimeFractionalPercent filter_enforced = 15;
+
+  // When set to true, the filter will emit per-stream stats for access logging. These stats will be stored in the
+  // filter state under the filter name. The filter will emit latency, bytes sent/received, upstream host, and
+  // upstream cluster info.
+  //
+  // .. note::
+  //   Stats are only emitted to the filter state if a check request is actually made to the rate limit service.
+  bool emit_filter_state_stats = 16;
 }
 
 message RateLimitPerRoute {

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -406,5 +406,9 @@ new_features:
   change: |
     Added the close through the network filter manager support that allows a network filter to disable the close of connection. This
     behavior is controlled by runtime guard ``envoy.reloadable_features.connection_close_through_filter_manager``, and default is false.
+- area: ratelimit
+  change: |
+    Added :ref:`emit_filter_state_stats <envoy_v3_api_field_extensions.filters.http.ratelimit.v3.RateLimit.emit_filter_state_stats>`
+    which when true enables filter state stats for access logging.
 
 deprecated:

--- a/source/extensions/filters/common/ratelimit/ratelimit.h
+++ b/source/extensions/filters/common/ratelimit/ratelimit.h
@@ -92,6 +92,11 @@ public:
                      const std::vector<Envoy::RateLimit::Descriptor>& descriptors,
                      Tracing::Span& parent_span, OptRef<const StreamInfo::StreamInfo> stream_info,
                      uint32_t hits_addend) PURE;
+
+  /**
+   * Returns streamInfo of the current request if possible. By default just return a nullptr.
+   */
+  virtual StreamInfo::StreamInfo const* streamInfo() const { return nullptr; }
 };
 
 using ClientPtr = std::unique_ptr<Client>;

--- a/source/extensions/filters/common/ratelimit/ratelimit_impl.h
+++ b/source/extensions/filters/common/ratelimit/ratelimit_impl.h
@@ -59,6 +59,9 @@ public:
              const std::vector<Envoy::RateLimit::Descriptor>& descriptors,
              Tracing::Span& parent_span, OptRef<const StreamInfo::StreamInfo> stream_info,
              uint32_t hits_addend = 0) override;
+  StreamInfo::StreamInfo const* streamInfo() const override {
+    return request_ ? &request_->streamInfo() : nullptr;
+  }
 
   // Grpc::AsyncRequestCallbacks
   void onCreateInitialMetadata(Http::RequestHeaderMap&) override {}

--- a/test/extensions/filters/http/ratelimit/BUILD
+++ b/test/extensions/filters/http/ratelimit/BUILD
@@ -1,6 +1,7 @@
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_package",
+    "envoy_proto_library",
 )
 load(
     "//test/extensions:extensions_build_system.bzl",
@@ -23,6 +24,7 @@ envoy_extension_cc_test(
         "//source/common/http:context_lib",
         "//source/common/http:headers_lib",
         "//source/extensions/filters/common/ratelimit:ratelimit_lib",
+        "//source/extensions/filters/http/ratelimit:config",
         "//source/extensions/filters/http/ratelimit:ratelimit_lib",
         "//test/extensions/filters/common/ratelimit:ratelimit_mocks",
         "//test/extensions/filters/common/ratelimit:ratelimit_utils",
@@ -84,4 +86,27 @@ envoy_extension_cc_test(
         "//test/mocks/http:http_mocks",
         "//test/test_common:utility_lib",
     ],
+)
+
+envoy_extension_cc_test(
+    name = "ratelimit_logging_info_test",
+    srcs = ["ratelimit_logging_info_test.cc"],
+    extension_names = ["envoy.filters.http.ratelimit"],
+    rbe_pool = "6gig",
+    deps = [
+        "//source/extensions/filters/common/ratelimit:ratelimit_lib",
+        "//source/extensions/filters/http/ratelimit:ratelimit_lib",
+        "//test/mocks/http:http_mocks",
+        "//test/mocks/local_info:local_info_mocks",
+        "//test/mocks/ratelimit:ratelimit_mocks",
+        "//test/mocks/server:factory_context_mocks",
+        "//test/mocks/upstream:cluster_info_mocks",
+        "//test/mocks/upstream:host_mocks",
+        "//test/test_common:utility_lib",
+    ],
+)
+
+envoy_proto_library(
+    name = "logging_test_filter_proto",
+    srcs = ["logging_test_filter.proto"],
 )

--- a/test/extensions/filters/http/ratelimit/logging_test_filter.cc
+++ b/test/extensions/filters/http/ratelimit/logging_test_filter.cc
@@ -1,0 +1,104 @@
+#include <string>
+
+#include "envoy/http/filter.h"
+#include "envoy/registry/registry.h"
+#include "envoy/server/filter_config.h"
+
+#include "source/extensions/filters/http/common/factory_base.h"
+#include "source/extensions/filters/http/common/pass_through_filter.h"
+#include "source/extensions/filters/http/ratelimit/ratelimit.h"
+
+#include "test/extensions/filters/http/ratelimit/logging_test_filter.pb.h"
+#include "test/extensions/filters/http/ratelimit/logging_test_filter.pb.validate.h"
+#include "test/test_common/utility.h"
+
+#include "gtest/gtest.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace RateLimitFilter {
+namespace Test {
+
+// A test filter that verifies the RateLimit logging info on encodeComplete.
+class LoggingTestFilter : public Http::PassThroughFilter {
+public:
+  LoggingTestFilter(const std::string& logging_id, const std::string& cluster_name,
+                    bool expect_stats, bool expect_envoy_grpc_specific_stats,
+                    bool expect_response_bytes)
+      : logging_id_(logging_id), expected_cluster_name_(cluster_name), expect_stats_(expect_stats),
+        expect_envoy_grpc_specific_stats_(expect_envoy_grpc_specific_stats),
+        expect_response_bytes_(expect_response_bytes) {}
+
+  void encodeComplete() override {
+    ASSERT(decoder_callbacks_ != nullptr);
+    const Envoy::StreamInfo::FilterStateSharedPtr& filter_state =
+        decoder_callbacks_->streamInfo().filterState();
+
+    ASSERT_EQ(filter_state->hasData<RateLimitLoggingInfo>(logging_id_), expect_stats_);
+    if (!expect_stats_) {
+      return;
+    }
+
+    const RateLimitLoggingInfo* ratelimit_logging_info =
+        filter_state->getDataReadOnly<RateLimitLoggingInfo>(logging_id_);
+
+    ASSERT_TRUE(ratelimit_logging_info->latency().has_value());
+    EXPECT_GT(ratelimit_logging_info->latency().value().count(), 0);
+
+    if (expect_envoy_grpc_specific_stats_) {
+      // If the stats exist, a request should always have been sent.
+      EXPECT_TRUE(ratelimit_logging_info->bytesSent().has_value());
+      EXPECT_GT(ratelimit_logging_info->bytesSent().value(), 0);
+
+      // A response may or may not have been received depending on the test.
+      if (expect_response_bytes_) {
+        EXPECT_TRUE(ratelimit_logging_info->bytesReceived().has_value());
+        EXPECT_GT(ratelimit_logging_info->bytesReceived().value(), 0);
+      } else {
+        if (ratelimit_logging_info->bytesReceived().has_value()) {
+          EXPECT_EQ(ratelimit_logging_info->bytesReceived().value(), 0);
+        }
+      }
+
+      ASSERT_NE(ratelimit_logging_info->clusterInfo(), nullptr);
+      EXPECT_EQ(ratelimit_logging_info->clusterInfo()->name(), expected_cluster_name_);
+      ASSERT_NE(ratelimit_logging_info->upstreamHost(), nullptr);
+    }
+  }
+
+private:
+  const std::string logging_id_;
+  const std::string expected_cluster_name_;
+  const bool expect_stats_;
+  const bool expect_envoy_grpc_specific_stats_;
+  const bool expect_response_bytes_;
+};
+
+class LoggingTestFilterFactory : public Extensions::HttpFilters::Common::FactoryBase<
+                                     test::integration::filters::LoggingTestFilterConfig> {
+public:
+  LoggingTestFilterFactory() : FactoryBase("test.ratelimit.logging_filter") {};
+
+  Http::FilterFactoryCb createFilterFactoryFromProtoTyped(
+      const test::integration::filters::LoggingTestFilterConfig& proto_config, const std::string&,
+      Server::Configuration::FactoryContext&) override {
+    return [=](Http::FilterChainFactoryCallbacks& callbacks) -> void {
+      callbacks.addStreamFilter(std::make_shared<LoggingTestFilter>(
+          proto_config.logging_id(), proto_config.expected_cluster_name(),
+          proto_config.expect_stats(), proto_config.expect_envoy_grpc_specific_stats(),
+          proto_config.expect_response_bytes()));
+    };
+  }
+};
+
+// Perform static registration
+static Registry::RegisterFactory<LoggingTestFilterFactory,
+                                 Server::Configuration::NamedHttpFilterConfigFactory>
+    register_;
+
+} // namespace Test
+} // namespace RateLimitFilter
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/test/extensions/filters/http/ratelimit/logging_test_filter.proto
+++ b/test/extensions/filters/http/ratelimit/logging_test_filter.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+
+package test.integration.filters;
+
+import "validate/validate.proto";
+
+message LoggingTestFilterConfig {
+  string logging_id = 1 [(validate.rules).string = {min_len: 1}];
+  string expected_cluster_name = 2 [(validate.rules).string = {min_len: 1}];
+  bool expect_stats = 3;
+  bool expect_envoy_grpc_specific_stats = 4;
+  bool expect_response_bytes = 5;
+}

--- a/test/extensions/filters/http/ratelimit/ratelimit_integration_test.cc
+++ b/test/extensions/filters/http/ratelimit/ratelimit_integration_test.cc
@@ -537,5 +537,29 @@ TEST_P(RatelimitIntegrationTest, OverLimitResponseHeadersToAdd) {
   EXPECT_EQ(nullptr, test_server_->counter("cluster.cluster_0.ratelimit.error"));
 }
 
+// Tests Ratelimit functionality with filter state stats enabled
+class RatelimitFilterStateStatsIntegrationTest : public RatelimitIntegrationTest {
+public:
+  RatelimitFilterStateStatsIntegrationTest() {
+    // Override the base filter config with filter state stats enabled
+    base_filter_config_ = R"EOF(
+      domain: some_domain
+      timeout: 0.5s
+      emit_filter_state_stats: true
+      response_headers_to_add:
+      - header:
+          key: x-global-ratelimit-service
+          value: rate_limit_service
+    )EOF";
+  }
+};
+
+INSTANTIATE_TEST_SUITE_P(IpVersionsClientType, RatelimitFilterStateStatsIntegrationTest,
+                         GRPC_CLIENT_INTEGRATION_PARAMS,
+                         Grpc::GrpcClientIntegrationParamTest::protocolTestParamsToString);
+
+// Test that basic rate limiting works with filter state stats
+TEST_P(RatelimitFilterStateStatsIntegrationTest, BasicFlow) { basicFlow(); }
+
 } // namespace
 } // namespace Envoy

--- a/test/extensions/filters/http/ratelimit/ratelimit_logging_info_test.cc
+++ b/test/extensions/filters/http/ratelimit/ratelimit_logging_info_test.cc
@@ -1,0 +1,319 @@
+#include "source/common/stream_info/filter_state_impl.h"
+#include "source/common/stream_info/uint32_accessor_impl.h"
+#include "source/extensions/filters/http/ratelimit/ratelimit.h"
+
+#include "test/mocks/http/mocks.h"
+#include "test/mocks/local_info/mocks.h"
+#include "test/mocks/ratelimit/mocks.h"
+#include "test/mocks/runtime/mocks.h"
+#include "test/mocks/stream_info/mocks.h"
+#include "test/mocks/tracing/mocks.h"
+#include "test/mocks/upstream/cluster_info.h"
+#include "test/mocks/upstream/host.h"
+#include "test/test_common/utility.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+using testing::_;
+using testing::Return;
+using testing::ReturnRef;
+using testing::SetArgReferee;
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace RateLimitFilter {
+namespace {
+
+// Forward declare the HitsAddendObjectFactory to test
+namespace {
+class HitsAddendObjectFactory : public StreamInfo::FilterState::ObjectFactory {
+public:
+  std::string name() const { return "envoy.ratelimit.hits_addend"; }
+  std::unique_ptr<StreamInfo::FilterState::Object> createFromBytes(absl::string_view data) const {
+    uint32_t hits_addend = 0;
+    if (absl::SimpleAtoi(data, &hits_addend)) {
+      return std::make_unique<StreamInfo::UInt32AccessorImpl>(hits_addend);
+    }
+    return nullptr;
+  }
+};
+} // namespace
+
+class RateLimitLoggingInfoTest : public testing::Test {
+protected:
+  RateLimitLoggingInfo logging_info_;
+  std::shared_ptr<NiceMock<Upstream::MockClusterInfo>> cluster_info_{
+      std::make_shared<NiceMock<Upstream::MockClusterInfo>>()};
+  std::shared_ptr<NiceMock<Upstream::MockHostDescription>> host_{
+      std::make_shared<NiceMock<Upstream::MockHostDescription>>()};
+};
+
+// Test default values
+TEST_F(RateLimitLoggingInfoTest, DefaultValues) {
+  EXPECT_FALSE(logging_info_.latency().has_value());
+  EXPECT_FALSE(logging_info_.bytesSent().has_value());
+  EXPECT_FALSE(logging_info_.bytesReceived().has_value());
+  EXPECT_EQ(nullptr, logging_info_.clusterInfo());
+  EXPECT_EQ(nullptr, logging_info_.upstreamHost());
+}
+
+// Test setting values
+TEST_F(RateLimitLoggingInfoTest, SetValues) {
+  const std::chrono::microseconds latency(100);
+  logging_info_.setLatency(latency);
+  EXPECT_EQ(latency, logging_info_.latency().value());
+
+  const uint64_t bytes_sent = 200;
+  logging_info_.setBytesSent(bytes_sent);
+  EXPECT_EQ(bytes_sent, logging_info_.bytesSent().value());
+
+  const uint64_t bytes_received = 300;
+  logging_info_.setBytesReceived(bytes_received);
+  EXPECT_EQ(bytes_received, logging_info_.bytesReceived().value());
+
+  logging_info_.setClusterInfo(cluster_info_);
+  EXPECT_EQ(cluster_info_.get(), logging_info_.clusterInfo().get());
+
+  logging_info_.setUpstreamHost(host_);
+  EXPECT_EQ(host_, logging_info_.upstreamHost());
+}
+
+// Test hasFieldSupport method
+TEST_F(RateLimitLoggingInfoTest, HasFieldSupport) { EXPECT_TRUE(logging_info_.hasFieldSupport()); }
+
+// Test filter state integration
+TEST_F(RateLimitLoggingInfoTest, FilterStateIntegration) {
+  const std::string filter_name = "http.ratelimit";
+  auto filter_state =
+      std::make_shared<StreamInfo::FilterStateImpl>(StreamInfo::FilterState::LifeSpan::FilterChain);
+
+  // Set logging info values
+  logging_info_.setLatency(std::chrono::microseconds(100));
+  logging_info_.setBytesSent(200);
+  logging_info_.setBytesReceived(300);
+  logging_info_.setClusterInfo(cluster_info_);
+  logging_info_.setUpstreamHost(host_);
+
+  // Store in filter state
+  filter_state->setData(filter_name, std::make_unique<RateLimitLoggingInfo>(logging_info_),
+                        StreamInfo::FilterState::StateType::ReadOnly);
+
+  // Verify retrieval
+  EXPECT_TRUE(filter_state->hasData<RateLimitLoggingInfo>(filter_name));
+  const auto* info = filter_state->getDataReadOnly<RateLimitLoggingInfo>(filter_name);
+  EXPECT_NE(nullptr, info);
+
+  // Verify stored values match original
+  EXPECT_EQ(logging_info_.latency(), info->latency());
+  EXPECT_EQ(logging_info_.bytesSent(), info->bytesSent());
+  EXPECT_EQ(logging_info_.bytesReceived(), info->bytesReceived());
+  EXPECT_EQ(logging_info_.clusterInfo(), info->clusterInfo());
+  EXPECT_EQ(logging_info_.upstreamHost(), info->upstreamHost());
+}
+
+class HitsAddendObjectFactoryTest : public testing::Test {
+protected:
+  HitsAddendObjectFactory factory_;
+};
+
+// Test HitsAddendObjectFactory name method
+TEST_F(HitsAddendObjectFactoryTest, Name) {
+  EXPECT_EQ("envoy.ratelimit.hits_addend", factory_.name());
+}
+
+// Test HitsAddendObjectFactory createFromBytes() method
+TEST_F(HitsAddendObjectFactoryTest, CreateFromBytes) {
+  // Valid case
+  {
+    std::string data = "123";
+    auto obj = factory_.createFromBytes(data);
+    ASSERT_NE(nullptr, obj);
+    auto* accessor = dynamic_cast<StreamInfo::UInt32Accessor*>(obj.get());
+    ASSERT_NE(nullptr, accessor);
+    EXPECT_EQ(123, accessor->value());
+  }
+
+  // Invalid case (not a number)
+  {
+    std::string data = "not_a_number";
+    auto obj = factory_.createFromBytes(data);
+    EXPECT_EQ(nullptr, obj);
+  }
+
+  // Empty string
+  {
+    std::string data = "";
+    auto obj = factory_.createFromBytes(data);
+    EXPECT_EQ(nullptr, obj);
+  }
+}
+
+// Test for the HitsAddendObjectFactory using Envoy filter state directly
+TEST_F(RateLimitLoggingInfoTest, HitsAddendFilterStateIntegration) {
+  // Create filter state
+  auto filter_state =
+      std::make_shared<StreamInfo::FilterStateImpl>(StreamInfo::FilterState::LifeSpan::FilterChain);
+
+  // Create and set hits_addend data
+  const std::string key = "envoy.ratelimit.hits_addend";
+  const std::string value = "42";
+  filter_state->setData(key, std::make_shared<StreamInfo::UInt32AccessorImpl>(42),
+                        StreamInfo::FilterState::StateType::ReadOnly);
+
+  // Verify retrieval
+  EXPECT_TRUE(filter_state->hasData<StreamInfo::UInt32Accessor>(key));
+  const auto* hits_addend = filter_state->getDataReadOnly<StreamInfo::UInt32Accessor>(key);
+  ASSERT_NE(nullptr, hits_addend);
+  EXPECT_EQ(42, hits_addend->value());
+
+  // Create a new HitsAddendObjectFactory directly
+  HitsAddendObjectFactory factory;
+
+  // Create object from bytes
+  auto obj = factory.createFromBytes(value);
+  ASSERT_NE(nullptr, obj);
+
+  // Verify value
+  auto* accessor = dynamic_cast<StreamInfo::UInt32Accessor*>(obj.get());
+  ASSERT_NE(nullptr, accessor);
+  EXPECT_EQ(42, accessor->value());
+}
+
+// Test edge case by setting a null cluster info
+TEST_F(RateLimitLoggingInfoTest, NullClusterInfo) {
+  Upstream::ClusterInfoConstSharedPtr null_cluster_info;
+  logging_info_.setClusterInfo(null_cluster_info);
+  EXPECT_EQ(nullptr, logging_info_.clusterInfo());
+}
+
+// Test edge case by setting a null upstream host
+TEST_F(RateLimitLoggingInfoTest, NullUpstreamHost) {
+  Upstream::HostDescriptionConstSharedPtr null_host;
+  logging_info_.setUpstreamHost(null_host);
+  EXPECT_EQ(nullptr, logging_info_.upstreamHost());
+}
+
+// Test setting extremely large values
+TEST_F(RateLimitLoggingInfoTest, LargeValues) {
+  const std::chrono::microseconds large_latency(std::numeric_limits<int64_t>::max());
+  logging_info_.setLatency(large_latency);
+  EXPECT_EQ(large_latency, logging_info_.latency().value());
+
+  const uint64_t large_bytes = std::numeric_limits<uint64_t>::max();
+  logging_info_.setBytesSent(large_bytes);
+  EXPECT_EQ(large_bytes, logging_info_.bytesSent().value());
+
+  logging_info_.setBytesReceived(large_bytes);
+  EXPECT_EQ(large_bytes, logging_info_.bytesReceived().value());
+}
+
+// Test for storing and retrieving multiple filter state objects
+TEST_F(RateLimitLoggingInfoTest, MultipleFilterStateObjects) {
+  auto filter_state =
+      std::make_shared<StreamInfo::FilterStateImpl>(StreamInfo::FilterState::LifeSpan::FilterChain);
+
+  // Set up logging info values
+  logging_info_.setLatency(std::chrono::microseconds(100));
+  logging_info_.setBytesSent(200);
+  logging_info_.setBytesReceived(300);
+
+  // Create a second logging info with different values
+  RateLimitLoggingInfo second_logging_info;
+  second_logging_info.setLatency(std::chrono::microseconds(500));
+  second_logging_info.setBytesSent(600);
+  second_logging_info.setBytesReceived(700);
+
+  // Store both in filter state with different names
+  const std::string first_filter_name = "ratelimit.first";
+  const std::string second_filter_name = "ratelimit.second";
+
+  filter_state->setData(first_filter_name, std::make_unique<RateLimitLoggingInfo>(logging_info_),
+                        StreamInfo::FilterState::StateType::ReadOnly);
+  filter_state->setData(second_filter_name,
+                        std::make_unique<RateLimitLoggingInfo>(second_logging_info),
+                        StreamInfo::FilterState::StateType::ReadOnly);
+
+  // Verify retrieval of first object
+  EXPECT_TRUE(filter_state->hasData<RateLimitLoggingInfo>(first_filter_name));
+  const auto* info1 = filter_state->getDataReadOnly<RateLimitLoggingInfo>(first_filter_name);
+  ASSERT_NE(nullptr, info1);
+  EXPECT_EQ(
+      100, std::chrono::duration_cast<std::chrono::microseconds>(info1->latency().value()).count());
+  EXPECT_EQ(200, info1->bytesSent().value());
+  EXPECT_EQ(300, info1->bytesReceived().value());
+
+  // Verify retrieval of second object
+  EXPECT_TRUE(filter_state->hasData<RateLimitLoggingInfo>(second_filter_name));
+  const auto* info2 = filter_state->getDataReadOnly<RateLimitLoggingInfo>(second_filter_name);
+  ASSERT_NE(nullptr, info2);
+  EXPECT_EQ(
+      500, std::chrono::duration_cast<std::chrono::microseconds>(info2->latency().value()).count());
+  EXPECT_EQ(600, info2->bytesSent().value());
+  EXPECT_EQ(700, info2->bytesReceived().value());
+}
+
+// Test the copy constructor
+TEST_F(RateLimitLoggingInfoTest, CopyConstructor) {
+  // Set up original values
+  const std::chrono::microseconds latency(123);
+  logging_info_.setLatency(latency);
+  logging_info_.setBytesSent(456);
+  logging_info_.setBytesReceived(789);
+  logging_info_.setClusterInfo(cluster_info_);
+  logging_info_.setUpstreamHost(host_);
+
+  // Create a copy
+  RateLimitLoggingInfo copy(logging_info_);
+
+  // Verify all values were copied correctly
+  EXPECT_EQ(latency, copy.latency().value());
+  EXPECT_EQ(456, copy.bytesSent().value());
+  EXPECT_EQ(789, copy.bytesReceived().value());
+  EXPECT_EQ(cluster_info_.get(), copy.clusterInfo().get());
+  EXPECT_EQ(host_, copy.upstreamHost());
+}
+
+// This test specifically triggers the HitsAddendObjectFactory's createFromBytes() with invalid
+// input
+TEST_F(HitsAddendObjectFactoryTest, InvalidInputHandling) {
+  // Test with negative number (should fail)
+  {
+    std::string data = "-5";
+    auto obj = factory_.createFromBytes(data);
+    // Should return nullptr for negative numbers
+    EXPECT_EQ(nullptr, obj);
+  }
+
+  // Test with valid uint32_t max value
+  {
+    std::string data = "4294967295"; // Max value for uint32_t
+    auto obj = factory_.createFromBytes(data);
+    ASSERT_NE(nullptr, obj);
+    auto* accessor = dynamic_cast<StreamInfo::UInt32Accessor*>(obj.get());
+    ASSERT_NE(nullptr, accessor);
+    EXPECT_EQ(4294967295, accessor->value());
+  }
+
+  // Test with invalid very large number
+  {
+    std::string data = "18446744073709551615"; // uint64_t max value
+    auto obj = factory_.createFromBytes(data);
+    // The implementation likely can't handle this large value so we just verify that it doesn't
+    // crash
+    if (obj != nullptr) {
+      auto* accessor = dynamic_cast<StreamInfo::UInt32Accessor*>(obj.get());
+      if (accessor != nullptr) {
+        // Just access the value to make sure it doesn't crash
+        accessor->value();
+      }
+    }
+  }
+}
+
+} // namespace
+} // namespace RateLimitFilter
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy


### PR DESCRIPTION
##Description

This PR adds support for emitting rate limiting stats to the filter state, accessible via access logs. It allows users to collect details about the rate limit service interactions, including latency measurements, bytes sent/received, and upstream host information.

This PR adds a new configuration option called `emit_filter_state_stats` to the rate limit filter which, when enabled, stores detailed statistics about each rate limit request in the filter state. This data can then be accessed via access logs for monitoring and performance analysis.

This feature could be valuable for tracking the performance overhead introduced by rate limiting operations in production environments and helps users better understand and optimize their rate limiting configuration.

**Fixes:** #39018

---

**Commit Message:** Add filter state statistics collection for rate limit filter
**Additional Description:** This PR adds a new configuration option called `emit_filter_state_stats` which, when enabled, stores rate limit statistics in filter state. The statistics include latency measurements, bytes sent/received, upstream host info, and cluster info. These statistics can be accessed via access logs for monitoring purposes.
**Risk Level:** Low
**Testing:** Added integration tests
**Docs Changes:** Added
**Release Notes:** Added