### PR TITLE
docs: add some clarifications and use proper note annotations in clusters docs

### DIFF
--- a/api/envoy/admin/v3/clusters.proto
+++ b/api/envoy/admin/v3/clusters.proto
@@ -41,22 +41,24 @@ message ClusterStatus {
   bool added_via_api = 2;
 
   // The success rate threshold used in the last interval.
-  // If
-  // :ref:`outlier_detection.split_external_local_origin_errors<envoy_v3_api_field_config.cluster.v3.OutlierDetection.split_external_local_origin_errors>`
-  // is ``false``, all errors: externally and locally generated were used to calculate the threshold.
-  // If
-  // :ref:`outlier_detection.split_external_local_origin_errors<envoy_v3_api_field_config.cluster.v3.OutlierDetection.split_external_local_origin_errors>`
-  // is ``true``, only externally generated errors were used to calculate the threshold.
-  // The threshold is used to eject hosts based on their success rate. See
-  // :ref:`Cluster outlier detection <arch_overview_outlier_detection>` documentation for details.
   //
-  // Note: this field may be omitted in any of the three following cases:
+  // * If :ref:`outlier_detection.split_external_local_origin_errors<envoy_v3_api_field_config.cluster.v3.OutlierDetection.split_external_local_origin_errors>`
+  //   is ``false``, all errors: externally and locally generated were used to calculate the threshold.
+  // * If :ref:`outlier_detection.split_external_local_origin_errors<envoy_v3_api_field_config.cluster.v3.OutlierDetection.split_external_local_origin_errors>`
+  //   is ``true``, only externally generated errors were used to calculate the threshold.
   //
-  // 1. There were not enough hosts with enough request volume to proceed with success rate based
-  //    outlier ejection.
-  // 2. The threshold is computed to be < 0 because a negative value implies that there was no
-  //    threshold for that interval.
-  // 3. Outlier detection is not enabled for this cluster.
+  // The threshold is used to eject hosts based on their success rate. For more information, see the
+  // :ref:`Cluster outlier detection <arch_overview_outlier_detection>` documentation.
+  //
+  // .. note::
+  //
+  //   This field may be omitted in any of the three following cases:
+  //
+  //   1. There were not enough hosts with enough request volume to proceed with success rate based outlier ejection.
+  //   2. The threshold is computed to be < 0 because a negative value implies that there was no threshold for that
+  //      interval.
+  //   3. Outlier detection is not enabled for this cluster.
+  //
   type.v3.Percent success_rate_ejection_threshold = 3;
 
   // Mapping from host address to the host's current status.
@@ -67,16 +69,18 @@ message ClusterStatus {
   // This field should be interpreted only when
   // :ref:`outlier_detection.split_external_local_origin_errors<envoy_v3_api_field_config.cluster.v3.OutlierDetection.split_external_local_origin_errors>`
   // is ``true``. The threshold is used to eject hosts based on their success rate.
-  // See :ref:`Cluster outlier detection <arch_overview_outlier_detection>` documentation for
-  // details.
   //
-  // Note: this field may be omitted in any of the three following cases:
+  // For more information, see the :ref:`Cluster outlier detection <arch_overview_outlier_detection>` documentation.
   //
-  // 1. There were not enough hosts with enough request volume to proceed with success rate based
-  //    outlier ejection.
-  // 2. The threshold is computed to be < 0 because a negative value implies that there was no
-  //    threshold for that interval.
-  // 3. Outlier detection is not enabled for this cluster.
+  // .. note::
+  //
+  //   This field may be omitted in any of the three following cases:
+  //
+  //   1. There were not enough hosts with enough request volume to proceed with success rate based outlier ejection.
+  //   2. The threshold is computed to be < 0 because a negative value implies that there was no threshold for that
+  //      interval.
+  //   3. Outlier detection is not enabled for this cluster.
+  //
   type.v3.Percent local_origin_success_rate_ejection_threshold = 5;
 
   // :ref:`Circuit breaking <arch_overview_circuit_break>` settings of the cluster.
@@ -103,19 +107,20 @@ message HostStatus {
   // The host's current health status.
   HostHealthStatus health_status = 3;
 
-  // Request success rate for this host over the last calculated interval.
-  // If
-  // :ref:`outlier_detection.split_external_local_origin_errors<envoy_v3_api_field_config.cluster.v3.OutlierDetection.split_external_local_origin_errors>`
-  // is ``false``, all errors: externally and locally generated were used in success rate
-  // calculation. If
-  // :ref:`outlier_detection.split_external_local_origin_errors<envoy_v3_api_field_config.cluster.v3.OutlierDetection.split_external_local_origin_errors>`
-  // is ``true``, only externally generated errors were used in success rate calculation.
-  // See :ref:`Cluster outlier detection <arch_overview_outlier_detection>` documentation for
-  // details.
+  // The success rate for this host during the last measurement interval.
   //
-  // Note: the message will not be present if host did not have enough request volume to calculate
-  // success rate or the cluster did not have enough hosts to run through success rate outlier
-  // ejection.
+  // * If :ref:`outlier_detection.split_external_local_origin_errors<envoy_v3_api_field_config.cluster.v3.OutlierDetection.split_external_local_origin_errors>`
+  //   is ``false``, all errors: externally and locally generated were used in success rate calculation.
+  // * If :ref:`outlier_detection.split_external_local_origin_errors<envoy_v3_api_field_config.cluster.v3.OutlierDetection.split_external_local_origin_errors>`
+  //   is ``true``, only externally generated errors were used in success rate calculation.
+  //
+  // For more information, see the :ref:`Cluster outlier detection <arch_overview_outlier_detection>` documentation.
+  //
+  // .. note::
+  //
+  //   The message will be missing if the host didn't receive enough traffic to calculate a reliable success rate, or
+  //   if the cluster had too few hosts to apply outlier ejection based on success rate.
+  //
   type.v3.Percent success_rate = 4;
 
   // The host's weight. If not configured, the value defaults to 1.
@@ -127,18 +132,20 @@ message HostStatus {
   // The host's priority. If not configured, the value defaults to 0 (highest priority).
   uint32 priority = 7;
 
-  // Request success rate for this host over the last calculated
-  // interval when only locally originated errors are taken into account and externally originated
-  // errors were treated as success.
-  // This field should be interpreted only when
-  // :ref:`outlier_detection.split_external_local_origin_errors<envoy_v3_api_field_config.cluster.v3.OutlierDetection.split_external_local_origin_errors>`
-  // is ``true``.
-  // See :ref:`Cluster outlier detection <arch_overview_outlier_detection>` documentation for
-  // details.
+  // The success rate for this host during the last interval, considering only locally generated errors. Externally
+  // generated errors are treated as successes.
   //
-  // Note: the message will not be present if host did not have enough request volume to calculate
-  // success rate or the cluster did not have enough hosts to run through success rate outlier
-  // ejection.
+  // This field is only relevant when
+  // :ref:`outlier_detection.split_external_local_origin_errors<envoy_v3_api_field_config.cluster.v3.OutlierDetection.split_external_local_origin_errors>`
+  // is set to ``true``.
+  //
+  // For more information, see the :ref:`Cluster outlier detection <arch_overview_outlier_detection>` documentation.
+  //
+  // .. note::
+  //
+  //   The message will be missing if the host didn’t receive enough traffic to compute a success rate, or if the
+  //   cluster didn’t have enough hosts to perform outlier ejection based on success rate.
+  //
   type.v3.Percent local_origin_success_rate = 8;
 
   // locality of the host.


### PR DESCRIPTION
## Description

This PR add some clarification and change the clusters doc to use proper note annotations.

<img width="934" alt="Screenshot 2025-04-12 at 16 58 54" src="https://github.com/user-attachments/assets/2e2bbe02-cff1-4ce7-9b5b-a52ae48d8c89" />

**Preview Link:** https://storage.googleapis.com/envoy-pr/66be614/docs/api-v3/admin/v3/clusters.proto.html

---

**Commit Message:** docs: add some clarifications and use proper note annotations in clusters docs
**Additional Description:** Change the docs to use proper note annotations.
**Risk Level:** N/A
**Testing:** N/A
**Docs Changes:** N/A
**Release Notes:** N/A