### PR TITLE
override host: fix the potential lifetime problem and improve the code

### DIFF
--- a/envoy/upstream/load_balancer.h
+++ b/envoy/upstream/load_balancer.h
@@ -145,6 +145,14 @@ public:
    */
   virtual Network::TransportSocketOptionsConstSharedPtr upstreamTransportSocketOptions() const PURE;
 
+  /**
+   * Upstream override host. The first element is the target host address and the second element is
+   * a boolean indicating whether the host should be selected strictly or not.
+   * If the host should be selected strictly and no valid host is found, the load balancer should
+   * return  nullptr.
+   * If the host should not be selected strictly, the load balancer will select another host is the
+   * target host is not valid.
+   */
   using OverrideHost = std::pair<absl::string_view, bool>;
   /**
    * Returns the host the load balancer should select directly. If the expected host exists and

--- a/source/common/http/filter_manager.cc
+++ b/source/common/http/filter_manager.cc
@@ -1946,12 +1946,18 @@ Buffer::BufferMemoryAccountSharedPtr ActiveStreamDecoderFilter::account() const 
 
 void ActiveStreamDecoderFilter::setUpstreamOverrideHost(
     Upstream::LoadBalancerContext::OverrideHost upstream_override_host) {
-  parent_.upstream_override_host_ = upstream_override_host;
+  parent_.upstream_override_host_.first.assign(upstream_override_host.first);
+  parent_.upstream_override_host_.second = upstream_override_host.second;
 }
 
 absl::optional<Upstream::LoadBalancerContext::OverrideHost>
 ActiveStreamDecoderFilter::upstreamOverrideHost() const {
-  return parent_.upstream_override_host_;
+  if (parent_.upstream_override_host_.first.empty()) {
+    return absl::nullopt;
+  }
+  return Upstream::LoadBalancerContext::OverrideHost{
+      absl::string_view(parent_.upstream_override_host_.first),
+      parent_.upstream_override_host_.second};
 }
 
 } // namespace Http

--- a/source/common/http/filter_manager.h
+++ b/source/common/http/filter_manager.h
@@ -1122,7 +1122,7 @@ private:
   std::list<DownstreamWatermarkCallbacks*> watermark_callbacks_;
   Network::Socket::OptionsSharedPtr upstream_options_ =
       std::make_shared<Network::Socket::Options>();
-  absl::optional<Upstream::LoadBalancerContext::OverrideHost> upstream_override_host_;
+  std::pair<std::string, bool> upstream_override_host_;
 
   // TODO(snowp): Once FM has been moved to its own file we'll make these private classes of FM,
   // at which point they no longer need to be friends.

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -2205,13 +2205,13 @@ void ClusterManagerImpl::ThreadLocalClusterManagerImpl::httpConnPoolIsIdle(
 HostSelectionResponse ClusterManagerImpl::ThreadLocalClusterManagerImpl::ClusterEntry::chooseHost(
     LoadBalancerContext* context) {
   auto cross_priority_host_map = priority_set_.crossPriorityHostMap();
-  HostConstSharedPtr host = HostUtility::selectOverrideHost(cross_priority_host_map.get(),
-                                                            override_host_statuses_, context);
-  if (host != nullptr) {
-    return {std::move(host)};
+  auto host_and_strict_mode = HostUtility::selectOverrideHost(cross_priority_host_map.get(),
+                                                              override_host_statuses_, context);
+  if (host_and_strict_mode.first != nullptr) {
+    return {std::move(host_and_strict_mode.first)};
   }
 
-  if (HostUtility::allowLBChooseHost(context)) {
+  if (!host_and_strict_mode.second) {
     Upstream::HostSelectionResponse host_selection = lb_->chooseHost(context);
     if (host_selection.host || host_selection.cancelable) {
       return host_selection;
@@ -2229,11 +2229,12 @@ HostSelectionResponse ClusterManagerImpl::ThreadLocalClusterManagerImpl::Cluster
 HostConstSharedPtr ClusterManagerImpl::ThreadLocalClusterManagerImpl::ClusterEntry::peekAnotherHost(
     LoadBalancerContext* context) {
   auto cross_priority_host_map = priority_set_.crossPriorityHostMap();
-  HostConstSharedPtr host = HostUtility::selectOverrideHost(cross_priority_host_map.get(),
-                                                            override_host_statuses_, context);
-  if (host != nullptr) {
-    return host;
+  auto host_and_strict_mode = HostUtility::selectOverrideHost(cross_priority_host_map.get(),
+                                                              override_host_statuses_, context);
+  if (host_and_strict_mode.first != nullptr) {
+    return std::move(host_and_strict_mode.first);
   }
+  // TODO(wbpcode): should we do strict mode check of override host here?
   return lb_->peekAnotherHost(context);
 }
 

--- a/source/common/upstream/host_utility.h
+++ b/source/common/upstream/host_utility.h
@@ -26,17 +26,20 @@ public:
   // A utility function to create override host status from lb config.
   static HostStatusSet createOverrideHostStatus(const CommonLbConfigProto& common_config);
 
-  // A utility function to select override host from host map according to load balancer context.
-  static HostConstSharedPtr selectOverrideHost(const HostMap* host_map, HostStatusSet status,
-                                               LoadBalancerContext* context);
+  /**
+   * A utility function to select override host from host map according to load balancer context.
+   *
+   * @return pair<HostConstSharedPtr, bool> the first element is the selected host and the second
+   *         element is a boolean indicating whether the host should be selected strictly or not.
+   */
+  static std::pair<HostConstSharedPtr, bool>
+  selectOverrideHost(const HostMap* host_map, HostStatusSet status, LoadBalancerContext* context);
 
   // Iterate over all per-endpoint metrics, for clusters with `per_endpoint_stats` enabled.
   static void
   forEachHostMetric(const ClusterManager& cluster_manager,
                     const std::function<void(Stats::PrimitiveCounterSnapshot&& metric)>& counter_cb,
                     const std::function<void(Stats::PrimitiveGaugeSnapshot&& metric)>& gauge_cb);
-
-  static bool allowLBChooseHost(LoadBalancerContext* context);
 };
 
 } // namespace Upstream

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -4742,7 +4742,7 @@ TEST_F(ClusterManagerImplTest, SelectOverrideHostTestNoOverrideHost) {
 
   auto to_create = new Tcp::ConnectionPool::MockInstance();
 
-  EXPECT_CALL(context, overrideHostToSelect()).Times(2).WillRepeatedly(Return(absl::nullopt));
+  EXPECT_CALL(context, overrideHostToSelect()).WillOnce(Return(absl::nullopt));
 
   EXPECT_CALL(factory_, allocateTcpConnPool_(_)).WillOnce(Return(to_create));
   EXPECT_CALL(*to_create, addIdleCallback(_));


### PR DESCRIPTION
Commit Message: override host: fix the potential lifetime problem and improve the code
Additional Description:

In the previous implmentation, the setUpstreamOverrideHost method will assume the caller will maintian the lifetime of the host address string. This is true for the stateful session filter, but it's false for the lua filter.

Ths PR change the implementation of setUpstreamOverrideHost to copy and store the host address into the filter chain manager to avoid potential lifetime problem.

This PR also add more comment to the upstream override host to make it more clear.

Risk Level: low.
Testing: n/a.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.