### PR TITLE
deps: bump up nlohmann JSON from v3.11.0 => v3.12.0

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -875,14 +875,14 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         project_name = "nlohmann JSON",
         project_desc = "Fast JSON parser/generator for C++",
         project_url = "https://nlohmann.github.io/json",
-        version = "3.11.3",
-        sha256 = "0d8ef5af7f9794e3263480193c491549b2ba6cc74bb018906202ada498a79406",
+        version = "3.12.0",
+        sha256 = "4b92eb0c06d10683f7447ce9406cb97cd4b453be18d7279320f7b2f025c10187",
         strip_prefix = "json-{version}",
         urls = ["https://github.com/nlohmann/json/archive/v{version}.tar.gz"],
         # This has replaced rapidJSON used in extensions and may also be a fast
         # replacement for protobuf JSON.
         use_category = ["controlplane", "dataplane_core"],
-        release_date = "2023-11-28",
+        release_date = "2025-04-11",
         cpe = "cpe:2.3:a:json-for-modern-cpp_project:json-for-modern-cpp:*",
         license = "MIT",
         license_url = "https://github.com/nlohmann/json/blob/v{version}/LICENSE.MIT",


### PR DESCRIPTION
## Description

This PR updates the nlohmann JSON from v3.11.0 to v3.12.0.

---

**Commit Message:** This PR updates the nlohmann JSON from v3.11.0 to v3.12.0.
**Additional Description:** Bump up the nlohmann JSON deps from v3.11.0 to v3.12.0. 
**Risk Level:** Low
**Testing:** CI
**Docs Changes:** N/A
**Release Notes:** N/A