### PR TITLE
golang extension: implement GetAllHeaders in the cluster_specifier plugin.

### DIFF
--- a/contrib/golang/router/cluster_specifier/source/cgo.cc
+++ b/contrib/golang/router/cluster_specifier/source/cgo.cc
@@ -25,6 +25,16 @@ absl::string_view referGoString(void* str) {
 extern "C" {
 #endif
 
+// Returns the number of headers in the request.
+uint64_t envoyGoClusterSpecifierGetNumHeaders(unsigned long long header_ptr) {
+  return reinterpret_cast<Http::RequestHeaderMap*>(header_ptr)->size();
+}
+
+// Returns the total byte size of the request headers.
+uint64_t envoyGoClusterSpecifierGetHeadersByteSize(unsigned long long header_ptr) {
+  return reinterpret_cast<Http::RequestHeaderMap*>(header_ptr)->byteSize();
+}
+
 // Get the value of the specified header key from the request header map.
 // Only use the first value when there are multiple values associated with the key.
 int envoyGoClusterSpecifierGetHeader(unsigned long long header_ptr, void* key, void* value) {
@@ -40,6 +50,41 @@ int envoyGoClusterSpecifierGetHeader(unsigned long long header_ptr, void* key, v
     return static_cast<int>(GetHeaderResult::Found);
   }
   return static_cast<int>(GetHeaderResult::Mising);
+}
+
+// Copies the request headers from `header_ptr` into the provided buffer `buf` and populates `strs`
+// with the string metadata of each key and value. `strs` points into `buf` which stores
+// concatenated raw header bytes in the format `key1val1key2val2...`. Note the buffer should
+// be allocated with sufficient memory to store the headers and `strs` is expected to be of length
+// twice the number of headers.
+void envoyGoClusterSpecifierGetAllHeaders(unsigned long long header_ptr, void* strs, void* buf) {
+  auto headers = reinterpret_cast<Http::RequestHeaderMap*>(header_ptr);
+  auto go_strs = reinterpret_cast<GoString*>(strs);
+  auto go_buf = reinterpret_cast<char*>(buf);
+  auto i = 0;
+  headers->iterate(
+      [&i, &go_strs, &go_buf](const Http::HeaderEntry& header) -> Http::HeaderMap::Iterate {
+        auto key = header.key().getStringView();
+        auto value = header.value().getStringView();
+
+        auto len = key.length();
+        go_strs[i].n = len;
+        go_strs[i].p = go_buf;
+        // go_buf is allocated in go heap memory with sufficient space for all headers.
+        memcpy(go_buf, key.data(), len); // NOLINT(safe-memcpy)
+        go_buf += len;
+        i++;
+
+        len = value.length();
+        go_strs[i].n = len;
+        if (len > 0) {
+          go_strs[i].p = go_buf;
+          memcpy(go_buf, value.data(), len); // NOLINT(safe-memcpy)
+          go_buf += len;
+        }
+        i++;
+        return Http::HeaderMap::Iterate::Continue;
+      });
 }
 
 // Log the message with the error level.

--- a/contrib/golang/router/cluster_specifier/source/cgo.cc
+++ b/contrib/golang/router/cluster_specifier/source/cgo.cc
@@ -25,14 +25,14 @@ absl::string_view referGoString(void* str) {
 extern "C" {
 #endif
 
-// Returns the number of headers in the request.
-uint64_t envoyGoClusterSpecifierGetNumHeaders(unsigned long long header_ptr) {
-  return reinterpret_cast<Http::RequestHeaderMap*>(header_ptr)->size();
-}
-
-// Returns the total byte size of the request headers.
-uint64_t envoyGoClusterSpecifierGetHeadersByteSize(unsigned long long header_ptr) {
-  return reinterpret_cast<Http::RequestHeaderMap*>(header_ptr)->byteSize();
+// Assigns the number of request headers and their total byte size to the provided uint64 pointers.
+void envoyGoClusterSpecifierGetNumHeadersAndByteSize(unsigned long long header_ptr,
+                                                     void* header_num, void* byte_size) {
+  auto header = reinterpret_cast<Http::RequestHeaderMap*>(header_ptr);
+  auto go_header_num = reinterpret_cast<GoUint64*>(header_num);
+  auto go_byte_size = reinterpret_cast<GoUint64*>(byte_size);
+  *go_header_num = header->size();
+  *go_byte_size = header->byteSize();
 }
 
 // Get the value of the specified header key from the request header map.

--- a/contrib/golang/router/cluster_specifier/source/go/pkg/api/capi.go
+++ b/contrib/golang/router/cluster_specifier/source/go/pkg/api/capi.go
@@ -19,5 +19,6 @@ package api
 
 type HttpCAPI interface {
 	HttpGetHeader(headerPtr uint64, key *string, value *string) bool
+	HttpGetAllHeaders(headerPtr uint64) map[string][]string
 	HttpLogError(pluginPtr uint64, msg *string)
 }

--- a/contrib/golang/router/cluster_specifier/source/go/pkg/api/cluster.go
+++ b/contrib/golang/router/cluster_specifier/source/go/pkg/api/cluster.go
@@ -37,4 +37,7 @@ type RequestHeaderMap interface {
 	// Get value of key
 	// If multiple values associated with this key, first one will be returned.
 	Get(key string) (string, bool)
+
+	// Get all the request headers mapped to their corresponding values.
+	GetAllHeaders() map[string][]string
 }

--- a/contrib/golang/router/cluster_specifier/source/go/pkg/cluster_specifier/api.h
+++ b/contrib/golang/router/cluster_specifier/source/go/pkg/cluster_specifier/api.h
@@ -6,10 +6,8 @@
 extern "C" {
 #endif
 
-#include <stdint.h> // NOLINT(modernize-deprecated-headers)
-
-uint64_t envoyGoClusterSpecifierGetNumHeaders(unsigned long long header_ptr);
-uint64_t envoyGoClusterSpecifierGetHeadersByteSize(unsigned long long header_ptr);
+void envoyGoClusterSpecifierGetNumHeadersAndByteSize(unsigned long long header_ptr,
+                                                     void* header_num, void* byte_size);
 int envoyGoClusterSpecifierGetHeader(unsigned long long header_ptr, void* key, void* value);
 void envoyGoClusterSpecifierLogError(unsigned long long plugin_ptr, void* msg);
 void envoyGoClusterSpecifierGetAllHeaders(unsigned long long header_ptr, void* strs, void* buf);

--- a/contrib/golang/router/cluster_specifier/source/go/pkg/cluster_specifier/api.h
+++ b/contrib/golang/router/cluster_specifier/source/go/pkg/cluster_specifier/api.h
@@ -6,8 +6,13 @@
 extern "C" {
 #endif
 
+#include <stdint.h> // NOLINT(modernize-deprecated-headers)
+
+uint64_t envoyGoClusterSpecifierGetNumHeaders(unsigned long long header_ptr);
+uint64_t envoyGoClusterSpecifierGetHeadersByteSize(unsigned long long header_ptr);
 int envoyGoClusterSpecifierGetHeader(unsigned long long header_ptr, void* key, void* value);
 void envoyGoClusterSpecifierLogError(unsigned long long plugin_ptr, void* msg);
+void envoyGoClusterSpecifierGetAllHeaders(unsigned long long header_ptr, void* strs, void* buf);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/contrib/golang/router/cluster_specifier/source/go/pkg/cluster_specifier/capi_impl.go
+++ b/contrib/golang/router/cluster_specifier/source/go/pkg/cluster_specifier/capi_impl.go
@@ -46,8 +46,9 @@ func (c *httpCApiImpl) HttpGetHeader(headerPtr uint64, key *string, value *strin
 }
 
 func (c *httpCApiImpl) HttpGetAllHeaders(headerPtr uint64) map[string][]string {
-	headerNum := uint64(C.envoyGoClusterSpecifierGetNumHeaders(C.ulonglong(headerPtr)))
-	headerBytes := uint64(C.envoyGoClusterSpecifierGetHeadersByteSize(C.ulonglong(headerPtr)))
+	var headerNum uint64
+	var headerBytes uint64
+	C.envoyGoClusterSpecifierGetNumHeadersAndByteSize(C.ulonglong(headerPtr), unsafe.Pointer(&headerNum), unsafe.Pointer(&headerBytes))
 
 	m := make(map[string][]string, headerNum)
 	if headerNum == 0 {

--- a/contrib/golang/router/cluster_specifier/source/go/pkg/cluster_specifier/capi_impl.go
+++ b/contrib/golang/router/cluster_specifier/source/go/pkg/cluster_specifier/capi_impl.go
@@ -30,6 +30,7 @@ package cluster_specifier
 */
 import "C"
 import (
+	"runtime"
 	"unsafe"
 
 	"github.com/envoyproxy/envoy/contrib/golang/router/cluster_specifier/source/go/pkg/api"
@@ -42,6 +43,33 @@ type httpCApiImpl struct{}
 func (c *httpCApiImpl) HttpGetHeader(headerPtr uint64, key *string, value *string) bool {
 	found := C.envoyGoClusterSpecifierGetHeader(C.ulonglong(headerPtr), unsafe.Pointer(key), unsafe.Pointer(value))
 	return int(found) == foundHeaderValue
+}
+
+func (c *httpCApiImpl) HttpGetAllHeaders(headerPtr uint64) map[string][]string {
+	headerNum := uint64(C.envoyGoClusterSpecifierGetNumHeaders(C.ulonglong(headerPtr)))
+	headerBytes := uint64(C.envoyGoClusterSpecifierGetHeadersByteSize(C.ulonglong(headerPtr)))
+
+	m := make(map[string][]string, headerNum)
+	if headerNum == 0 {
+		return m
+	}
+
+	strs := make([]string, headerNum*2)
+	buf := make([]byte, headerBytes)
+	C.envoyGoClusterSpecifierGetAllHeaders(C.ulonglong(headerPtr), unsafe.Pointer(unsafe.SliceData(strs)), unsafe.Pointer(unsafe.SliceData(buf)))
+
+	for i := uint64(0); i < headerNum*2; i += 2 {
+		key := strs[i]
+		value := strs[i+1]
+
+		if v, found := m[key]; !found {
+			m[key] = []string{value}
+		} else {
+			m[key] = append(v, value)
+		}
+	}
+	runtime.KeepAlive(buf)
+	return m
 }
 
 func (c *httpCApiImpl) HttpLogError(pluginPtr uint64, msg *string) {

--- a/contrib/golang/router/cluster_specifier/source/go/pkg/cluster_specifier/type.go
+++ b/contrib/golang/router/cluster_specifier/source/go/pkg/cluster_specifier/type.go
@@ -32,3 +32,7 @@ func (h *httpHeaderMap) Get(key string) (string, bool) {
 	found := cAPI.HttpGetHeader(h.headerPtr, &key, &value)
 	return value, found
 }
+
+func (h *httpHeaderMap) GetAllHeaders() map[string][]string {
+	return cAPI.HttpGetAllHeaders(h.headerPtr)
+}

--- a/contrib/golang/router/cluster_specifier/test/test_data/simple/plugin.go
+++ b/contrib/golang/router/cluster_specifier/test/test_data/simple/plugin.go
@@ -12,6 +12,19 @@ type clusterSpecifier struct {
 	panicPrefix   string
 }
 
+func headerHasTrueValue(headers map[string][]string, key string) bool {
+	values, ok := headers[key]
+	if !ok {
+		return false
+	}
+	for _, element := range values {
+		if element == "true" {
+			return true
+		}
+	}
+	return false
+}
+
 func (s *clusterSpecifier) Cluster(header api.RequestHeaderMap) string {
 	path, _ := header.Get(":path")
 
@@ -28,6 +41,10 @@ func (s *clusterSpecifier) Cluster(header api.RequestHeaderMap) string {
 	// panic, will using the default_cluster in the C++ side.
 	if strings.HasPrefix(path, s.panicPrefix) {
 		panic("test")
+	}
+
+	if headerHasTrueValue(header.GetAllHeaders(), "custom_header_1") {
+		return "cluster_unknown"
 	}
 
 	return "cluster_0"


### PR DESCRIPTION
Commit Message:
golang extension: implement GetAllHeaders in the cluster_specifier plugin.
Fixes: #38644

Additional Description:
- This is my first time working with Envoy and Cgo so there may be better ways to implement this. I used [copyHeaderMapToGo](https://github.com/envoyproxy/envoy/blob/61809bc1377543e3e6493157ab8fc96070867179/contrib/golang/upstreams/http/tcp/source/upstream_request.cc#L384-L414) as a reference for this implementation.

Risk Level: Low
Testing: Integration testing - I would prefer to add some unit testing as well for the Go -> Cgo code, but I didn't see existing examples of this so I wasn't sure if it's common practice.
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A