### PR TITLE
deps: bump up boring_ssl to 135.0.7049.84

### DIFF
--- a/bazel/boringssl_fips.patch
+++ b/bazel/boringssl_fips.patch
@@ -1,16 +1,15 @@
-From 20966b68881ab9ce3395d0d3fa83066a234f26be Mon Sep 17 00:00:00 2001
-From: Kuat Yessenov <kuat@google.com>
-Date: Fri, 4 Apr 2025 16:37:00 +0000
-Subject: [PATCH] remove interfering Bazel files
+From 6d46e1e3377f02d7039e73c649df47f55922f8af Mon Sep 17 00:00:00 2001
+From: Rohit Agrawal <rohit.agrawal@databricks.com>
+Date: Mon, 14 Apr 2025 10:15:18 -0700
+Subject: [PATCH] Remove Interfering Bazel Files
 
-Signed-off-by: Kuat Yessenov <kuat@google.com>
 ---
  .bazelignore                                  |   2 -
- third_party/googletest/BUILD.bazel            | 219 -------
- third_party/googletest/WORKSPACE              |  27 -
+ third_party/googletest/BUILD.bazel            | 236 -------
+ third_party/googletest/WORKSPACE              |  61 --
  .../googletest/googlemock/test/BUILD.bazel    | 118 ----
- .../googletest/googletest/test/BUILD.bazel    | 595 ------------------
- 5 files changed, 961 deletions(-)
+ .../googletest/googletest/test/BUILD.bazel    | 629 ------------------
+ 5 files changed, 1046 deletions(-)
  delete mode 100644 .bazelignore
  delete mode 100644 third_party/googletest/BUILD.bazel
  delete mode 100644 third_party/googletest/WORKSPACE
@@ -19,7 +18,7 @@ Signed-off-by: Kuat Yessenov <kuat@google.com>
 
 diff --git a/.bazelignore b/.bazelignore
 deleted file mode 100644
-index 9dad64c6a..000000000
+index 9dad64c6aa..0000000000
 --- a/.bazelignore
 +++ /dev/null
 @@ -1,2 +0,0 @@
@@ -27,10 +26,10 @@ index 9dad64c6a..000000000
 -util/bazel-example
 diff --git a/third_party/googletest/BUILD.bazel b/third_party/googletest/BUILD.bazel
 deleted file mode 100644
-index b1e3b7fba..000000000
+index 0306468e7f..0000000000
 --- a/third_party/googletest/BUILD.bazel
 +++ /dev/null
-@@ -1,219 +0,0 @@
+@@ -1,236 +0,0 @@
 -# Copyright 2017 Google Inc.
 -# All Rights Reserved.
 -#
@@ -87,6 +86,12 @@ index b1e3b7fba..000000000
 -config_setting(
 -    name = "openbsd",
 -    constraint_values = ["@platforms//os:openbsd"],
+-)
+-
+-# NOTE: Fuchsia is not an officially supported platform.
+-config_setting(
+-    name = "fuchsia",
+-    constraint_values = ["@platforms//os:fuchsia"],
 -)
 -
 -config_setting(
@@ -165,19 +170,30 @@ index b1e3b7fba..000000000
 -    }),
 -    deps = select({
 -        ":has_absl": [
--            "@com_google_absl//absl/container:flat_hash_set",
--            "@com_google_absl//absl/debugging:failure_signal_handler",
--            "@com_google_absl//absl/debugging:stacktrace",
--            "@com_google_absl//absl/debugging:symbolize",
--            "@com_google_absl//absl/flags:flag",
--            "@com_google_absl//absl/flags:parse",
--            "@com_google_absl//absl/flags:reflection",
--            "@com_google_absl//absl/flags:usage",
--            "@com_google_absl//absl/strings",
--            "@com_google_absl//absl/types:any",
--            "@com_google_absl//absl/types:optional",
--            "@com_google_absl//absl/types:variant",
--            "@com_googlesource_code_re2//:re2",
+-            "@abseil-cpp//absl/container:flat_hash_set",
+-            "@abseil-cpp//absl/debugging:failure_signal_handler",
+-            "@abseil-cpp//absl/debugging:stacktrace",
+-            "@abseil-cpp//absl/debugging:symbolize",
+-            "@abseil-cpp//absl/flags:flag",
+-            "@abseil-cpp//absl/flags:parse",
+-            "@abseil-cpp//absl/flags:reflection",
+-            "@abseil-cpp//absl/flags:usage",
+-            "@abseil-cpp//absl/strings",
+-            "@abseil-cpp//absl/types:any",
+-            "@abseil-cpp//absl/types:optional",
+-            "@abseil-cpp//absl/types:variant",
+-            "@re2//:re2",
+-        ],
+-        "//conditions:default": [],
+-    }) + select({
+-        # `gtest-death-test.cc` has `EXPECT_DEATH` that spawns a process,
+-        # expects it to crash and inspects its logs with the given matcher,
+-        # so that's why these libraries are needed.
+-        # Otherwise, builds targeting Fuchsia would fail to compile.
+-        ":fuchsia": [
+-            "@fuchsia_sdk//pkg/fdio",
+-            "@fuchsia_sdk//pkg/syslog",
+-            "@fuchsia_sdk//pkg/zx",
 -        ],
 -        "//conditions:default": [],
 -    }),
@@ -252,11 +268,41 @@ index b1e3b7fba..000000000
 -)
 diff --git a/third_party/googletest/WORKSPACE b/third_party/googletest/WORKSPACE
 deleted file mode 100644
-index f819ffe61..000000000
+index 4c76102843..0000000000
 --- a/third_party/googletest/WORKSPACE
 +++ /dev/null
-@@ -1,27 +0,0 @@
--workspace(name = "com_google_googletest")
+@@ -1,61 +0,0 @@
+-# Copyright 2024 Google Inc.
+-# All Rights Reserved.
+-#
+-#
+-# Redistribution and use in source and binary forms, with or without
+-# modification, are permitted provided that the following conditions are
+-# met:
+-#
+-#     * Redistributions of source code must retain the above copyright
+-# notice, this list of conditions and the following disclaimer.
+-#     * Redistributions in binary form must reproduce the above
+-# copyright notice, this list of conditions and the following disclaimer
+-# in the documentation and/or other materials provided with the
+-# distribution.
+-#     * Neither the name of Google Inc. nor the names of its
+-# contributors may be used to endorse or promote products derived from
+-# this software without specific prior written permission.
+-#
+-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+-# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+-# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+-# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+-# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+-# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+-# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+-# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+-# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+-# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+-# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-
+-workspace(name = "googletest")
 -
 -load("//:googletest_deps.bzl", "googletest_deps")
 -googletest_deps()
@@ -264,28 +310,32 @@ index f819ffe61..000000000
 -load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 -
 -http_archive(
--  name = "rules_python",  # 2023-07-31T20:39:27Z
--  sha256 = "1250b59a33c591a1c4ba68c62e95fc88a84c334ec35a2e23f46cbc1b9a5a8b55",
--  strip_prefix = "rules_python-e355becc30275939d87116a4ec83dad4bb50d9e1",
--  urls = ["https://github.com/bazelbuild/rules_python/archive/e355becc30275939d87116a4ec83dad4bb50d9e1.zip"],
+-    name = "rules_python",
+-    sha256 = "9c6e26911a79fbf510a8f06d8eedb40f412023cf7fa6d1461def27116bff022c",
+-    strip_prefix = "rules_python-1.1.0",
+-    url = "https://github.com/bazelbuild/rules_python/releases/download/1.1.0/rules_python-1.1.0.tar.gz",
+-)
+-# https://github.com/bazelbuild/rules_python/releases/tag/1.1.0
+-load("@rules_python//python:repositories.bzl", "py_repositories")
+-py_repositories()
+-
+-http_archive(
+-  name = "bazel_skylib",
+-  sha256 = "cd55a062e763b9349921f0f5db8c3933288dc8ba4f76dd9416aac68acee3cb94",
+-  urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.5.0/bazel-skylib-1.5.0.tar.gz"],
 -)
 -
 -http_archive(
--  name = "bazel_skylib",  # 2023-05-31T19:24:07Z
--  sha256 = "08c0386f45821ce246bbbf77503c973246ed6ee5c3463e41efc197fa9bc3a7f4",
--  strip_prefix = "bazel-skylib-288731ef9f7f688932bd50e704a91a45ec185f9b",
--  urls = ["https://github.com/bazelbuild/bazel-skylib/archive/288731ef9f7f688932bd50e704a91a45ec185f9b.zip"],
--)
--
--http_archive(
--  name = "platforms",  # 2023-07-28T19:44:27Z
--  sha256 = "40eb313613ff00a5c03eed20aba58890046f4d38dec7344f00bb9a8867853526",
--  strip_prefix = "platforms-4ad40ef271da8176d4fc0194d2089b8a76e19d7b",
--  urls = ["https://github.com/bazelbuild/platforms/archive/4ad40ef271da8176d4fc0194d2089b8a76e19d7b.zip"],
+-    name = "platforms",
+-    urls = [
+-        "https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/0.0.10/platforms-0.0.10.tar.gz",
+-        "https://github.com/bazelbuild/platforms/releases/download/0.0.10/platforms-0.0.10.tar.gz",
+-    ],
+-    sha256 = "218efe8ee736d26a3572663b374a253c012b716d8af0c07e842e82f238a0a7ee",
 -)
 diff --git a/third_party/googletest/googlemock/test/BUILD.bazel b/third_party/googletest/googlemock/test/BUILD.bazel
 deleted file mode 100644
-index d4297c80f..000000000
+index d4297c80fe..0000000000
 --- a/third_party/googletest/googlemock/test/BUILD.bazel
 +++ /dev/null
 @@ -1,118 +0,0 @@
@@ -409,10 +459,10 @@ index d4297c80f..000000000
 -)
 diff --git a/third_party/googletest/googletest/test/BUILD.bazel b/third_party/googletest/googletest/test/BUILD.bazel
 deleted file mode 100644
-index 1890b6ff9..000000000
+index c561ef8b91..0000000000
 --- a/third_party/googletest/googletest/test/BUILD.bazel
 +++ /dev/null
-@@ -1,595 +0,0 @@
+@@ -1,629 +0,0 @@
 -# Copyright 2017 Google Inc.
 -# All Rights Reserved.
 -#
@@ -460,36 +510,38 @@ index 1890b6ff9..000000000
 -            "gtest-*.cc",
 -            "googletest-*.cc",
 -            "*.h",
--            "googletest/include/gtest/**/*.h",
 -        ],
 -        exclude = [
--            "gtest-unittest-api_test.cc",
--            "googletest/src/gtest-all.cc",
--            "gtest_all_test.cc",
--            "gtest-death-test_ex_test.cc",
--            "gtest-listener_test.cc",
--            "gtest-unittest-api_test.cc",
--            "googletest-param-test-test.cc",
--            "googletest-param-test2-test.cc",
+-            # go/keep-sorted start
+-            "googletest-break-on-failure-unittest_.cc",
 -            "googletest-catch-exceptions-test_.cc",
 -            "googletest-color-test_.cc",
+-            "googletest-death-test_ex_test.cc",
 -            "googletest-env-var-test_.cc",
+-            "googletest-fail-if-no-test-linked-test-with-disabled-test_.cc",
+-            "googletest-fail-if-no-test-linked-test-with-enabled-test_.cc",
 -            "googletest-failfast-unittest_.cc",
 -            "googletest-filter-unittest_.cc",
 -            "googletest-global-environment-unittest_.cc",
--            "googletest-break-on-failure-unittest_.cc",
+-            "googletest-list-tests-unittest_.cc",
 -            "googletest-listener-test.cc",
 -            "googletest-message-test.cc",
 -            "googletest-output-test_.cc",
--            "googletest-list-tests-unittest_.cc",
--            "googletest-shuffle-test_.cc",
--            "googletest-setuptestsuite-test_.cc",
--            "googletest-uninitialized-test_.cc",
--            "googletest-death-test_ex_test.cc",
--            "googletest-param-test-test",
--            "googletest-throw-on-failure-test_.cc",
 -            "googletest-param-test-invalid-name1-test_.cc",
 -            "googletest-param-test-invalid-name2-test_.cc",
+-            "googletest-param-test-test",
+-            "googletest-param-test-test.cc",
+-            "googletest-param-test2-test.cc",
+-            "googletest-setuptestsuite-test_.cc",
+-            "googletest-shuffle-test_.cc",
+-            "googletest-throw-on-failure-test_.cc",
+-            "googletest-uninitialized-test_.cc",
+-            "googletest/src/gtest-all.cc",
+-            "gtest-death-test_ex_test.cc",
+-            "gtest-listener_test.cc",
+-            "gtest-unittest-api_test.cc",
+-            "gtest_all_test.cc",
+-            # go/keep-sorted end
 -        ],
 -    ) + select({
 -        "//:windows": [],
@@ -739,6 +791,26 @@ index 1890b6ff9..000000000
 -    deps = ["//:gtest"],
 -)
 -
+-cc_binary(
+-    name = "googletest-fail-if-no-test-linked-test-without-test_",
+-    testonly = 1,
+-    deps = ["//:gtest_main"],
+-)
+-
+-cc_binary(
+-    name = "googletest-fail-if-no-test-linked-test-with-disabled-test_",
+-    testonly = 1,
+-    srcs = ["googletest-fail-if-no-test-linked-test-with-disabled-test_.cc"],
+-    deps = ["//:gtest_main"],
+-)
+-
+-cc_binary(
+-    name = "googletest-fail-if-no-test-linked-test-with-enabled-test_",
+-    testonly = 1,
+-    srcs = ["googletest-fail-if-no-test-linked-test-with-enabled-test_.cc"],
+-    deps = ["//:gtest_main"],
+-)
+-
 -cc_test(
 -    name = "gtest_skip_test",
 -    size = "small",
@@ -776,6 +848,18 @@ index 1890b6ff9..000000000
 -    size = "small",
 -    srcs = ["googletest-list-tests-unittest.py"],
 -    data = [":googletest-list-tests-unittest_"],
+-    deps = [":gtest_test_utils"],
+-)
+-
+-py_test(
+-    name = "googletest-fail-if-no-test-linked-test",
+-    size = "small",
+-    srcs = ["googletest-fail-if-no-test-linked-test.py"],
+-    data = [
+-        ":googletest-fail-if-no-test-linked-test-with-disabled-test_",
+-        ":googletest-fail-if-no-test-linked-test-with-enabled-test_",
+-        ":googletest-fail-if-no-test-linked-test-without-test_",
+-    ],
 -    deps = [":gtest_test_utils"],
 -)
 -
@@ -1008,6 +1092,3 @@ index 1890b6ff9..000000000
 -    ],
 -    deps = [":gtest_test_utils"],
 -)
--- 
-2.49.0.504.g3bcea36a83-goog
-

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -134,13 +134,13 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         # 1. Open https://chromiumdash.appspot.com/releases?platform=Linux and find the latest Stable release.
         # 2. In the info for that release, open the "Branch Base Commit" link, then open DEPS, and use the <boringssl_revision>.
         #
-        # chromium-130.0.6723.69 (linux/stable)
-        version = "58f3bc83230d2958bb9710bc910972c4f5d382dc",
-        sha256 = "50db81f25e3ee0f90b95182fc244ceb58aefbac59456bf3f55f1c519c5584d71",
+        # chromium-135.0.7049.84 (linux/stable)
+        version = "673e61fc215b178a90c0e67858bbf162c8158993",
+        sha256 = "5f84f1d01a278a5cadf51acc11a0c4519f2f57277cff33d154917083c68463b4",
         strip_prefix = "boringssl-{version}",
         urls = ["https://github.com/google/boringssl/archive/{version}.tar.gz"],
         use_category = ["controlplane", "dataplane_core"],
-        release_date = "2024-09-13",
+        release_date = "2025-02-28",
         cpe = "cpe:2.3:a:google:boringssl:*",
         license = "Mixed",
         license_url = "https://github.com/google/boringssl/blob/{version}/LICENSE",


### PR DESCRIPTION
## Description

This PR bumps up Boring SSL from **v130.0.6723.69** to **v135.0.7049.84**

---

**Commit Message:** deps: bump up `boring_ssl` to 135.0.7049.84
**Additional Description:** Bump up Bring SSL version from **v130.0.6723.69** to **v135.0.7049.84**
**Risk Level:** Low
**Testing:** CI
**Docs Changes:** N/A
**Release Notes:** N/A