### PR TITLE
eds: fix crash for invalid configuration (#39083)

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -8,6 +8,9 @@ minor_behavior_changes:
 
 bug_fixes:
 # *Changes expected to improve the state of the world and are unlikely to have negative effects*
+- area: eds
+  change: |
+    Fixed crash when creating an EDS cluster with invalid configuration.
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/source/extensions/clusters/eds/eds.cc
+++ b/source/extensions/clusters/eds/eds.cc
@@ -35,6 +35,7 @@ EdsClusterImpl::EdsClusterImpl(const envoy::config::cluster::v3::Cluster& cluste
           Runtime::runtimeFeatureEnabled("envoy.restart_features.use_eds_cache_for_ads")
               ? cluster_context.clusterManager().edsResourcesCache()
               : absl::nullopt) {
+  RETURN_ONLY_IF_NOT_OK_REF(creation_status);
   Event::Dispatcher& dispatcher = cluster_context.serverFactoryContext().mainThreadDispatcher();
   assignment_timeout_ = dispatcher.createTimer([this]() -> void { onAssignmentTimeout(); });
   const auto& eds_config = cluster.eds_cluster_config().eds_config();


### PR DESCRIPTION
There was missing error handling when this code was changed to not use execeptions. The `info_` pointer may be nullptr if the `creation_status` is not succesful, which is dereferenced to get a stats scope.