### PR TITLE
Map the whole 2xx range to OK gRPC response status

### DIFF
--- a/source/extensions/filters/http/grpc_json_reverse_transcoder/filter.cc
+++ b/source/extensions/filters/http/grpc_json_reverse_transcoder/filter.cc
@@ -218,7 +218,7 @@ bool GrpcJsonReverseTranscoderFilter::CheckAndRejectIfResponseTranscoderFailed()
 Status::GrpcStatus
 GrpcJsonReverseTranscoderFilter::GrpcStatusFromHeaders(ResponseHeaderMap& headers) {
   const auto http_response_status = Http::Utility::getResponseStatus(headers);
-  if (http_response_status == 200) {
+  if (http_response_status >= 200 && http_response_status <= 299) {
     return Status::WellKnownGrpcStatus::Ok;
   } else {
     is_non_ok_response_ = true;


### PR DESCRIPTION
Commit Message: Map the whole 2xx HTTP range to OK gRPC response status
Additional Description: The reverse transcoder currently maps only 200 to OK status. This PR maps the whole range of 2xx status codes to the OK gRPC response status.
Risk Level: low
Testing: Added unit test to test the change
Docs Changes: n/a
Release Notes: n/a