### PR TITLE
docs: fix typo in configuration-dynamic-control-plane.rst

### DIFF
--- a/docs/root/start/quick-start/configuration-dynamic-control-plane.rst
+++ b/docs/root/start/quick-start/configuration-dynamic-control-plane.rst
@@ -8,7 +8,7 @@ configuration.
 
 There are a number of control planes compatible with Envoy's API, for example:
 
-- Within the Envoy project you an leverage `Envoy Gateway <https://gateway.envoyproxy.io/docs/>`_
+- Within the Envoy project you can leverage `Envoy Gateway <https://gateway.envoyproxy.io/docs/>`_
 - `Istio <https://istio.io>`_ provides a popular control plane for service meshes.
 
 You can find more control plane implementations, both CNCF Open Source control planes, and vendor provided control planes on the `Community page <https://www.envoyproxy.io/community>`_.


### PR DESCRIPTION
fix typo in configuration-dynamic-control-plane.rst

Risk Level: Low
Docs Changes: yes

