### PR TITLE
Add grpc status to ExtAuthzLoggingInfo in ext authz http filter

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -13,5 +13,8 @@ removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`
 
 new_features:
+- area: ext_authz
+  change: |
+    Added ``grpc_status`` to ``ExtAuthzLoggingInfo`` in ext_authz http filter.
 
 deprecated:

--- a/source/extensions/filters/common/ext_authz/ext_authz.h
+++ b/source/extensions/filters/common/ext_authz/ext_authz.h
@@ -126,6 +126,10 @@ struct Response {
   // A set of metadata returned by the authorization server, that will be emitted as filter's
   // dynamic metadata that other filters can leverage.
   ProtobufWkt::Struct dynamic_metadata{};
+
+  // The gRPC status returned by the authorization server when it is making a
+  // gRPC call.
+  absl::optional<Grpc::Status::GrpcStatus> grpc_status{absl::nullopt};
 };
 
 using ResponsePtr = std::unique_ptr<Response>;

--- a/source/extensions/filters/common/ext_authz/ext_authz_grpc_impl.cc
+++ b/source/extensions/filters/common/ext_authz/ext_authz_grpc_impl.cc
@@ -107,6 +107,7 @@ void GrpcClientImpl::onSuccess(std::unique_ptr<envoy::service::auth::v3::CheckRe
                                Tracing::Span& span) {
   ENVOY_LOG(trace, "Received CheckResponse: {}", response->DebugString());
   ResponsePtr authz_response = std::make_unique<Response>(Response{});
+  authz_response->grpc_status = response->status().code();
   if (response->status().code() == Grpc::Status::WellKnownGrpcStatus::Ok) {
     span.setTag(TracingConstants::get().TraceStatus, TracingConstants::get().TraceOk);
     authz_response->status = CheckStatus::OK;
@@ -151,6 +152,7 @@ void GrpcClientImpl::onFailure(Grpc::Status::GrpcStatus status, const std::strin
   Response response{};
   response.status = CheckStatus::Error;
   response.status_code = Http::Code::Forbidden;
+  response.grpc_status = status;
   callbacks_->onComplete(std::make_unique<Response>(response));
   callbacks_ = nullptr;
 }

--- a/source/extensions/filters/http/ext_authz/ext_authz.cc
+++ b/source/extensions/filters/http/ext_authz/ext_authz.cc
@@ -410,13 +410,18 @@ void Filter::setDecoderFilterCallbacks(Http::StreamDecoderFilterCallbacks& callb
   decoder_callbacks_ = &callbacks;
 }
 
-void Filter::updateLoggingInfo() {
+void Filter::updateLoggingInfo(
+    const absl::optional<Grpc::Status::GrpcStatus>& grpc_status) {
   if (!config_->emitFilterStateStats()) {
     return;
   }
 
   if (logging_info_ == nullptr) {
     return;
+  }
+
+  if (grpc_status.has_value()) {
+    logging_info_->setGrpcStatus(grpc_status.value());
   }
 
   // Latency is the only stat available if we aren't using envoy grpc.
@@ -472,7 +477,7 @@ void Filter::onComplete(Filters::Common::ExtAuthz::ResponsePtr&& response) {
   using Filters::Common::ExtAuthz::CheckStatus;
   Stats::StatName empty_stat_name;
 
-  updateLoggingInfo();
+  updateLoggingInfo(response->grpc_status);
 
   if (!response->dynamic_metadata.fields().empty()) {
     if (!config_->enableDynamicMetadataIngestion()) {

--- a/source/extensions/filters/http/ext_authz/ext_authz.cc
+++ b/source/extensions/filters/http/ext_authz/ext_authz.cc
@@ -410,8 +410,7 @@ void Filter::setDecoderFilterCallbacks(Http::StreamDecoderFilterCallbacks& callb
   decoder_callbacks_ = &callbacks;
 }
 
-void Filter::updateLoggingInfo(
-    const absl::optional<Grpc::Status::GrpcStatus>& grpc_status) {
+void Filter::updateLoggingInfo(const absl::optional<Grpc::Status::GrpcStatus>& grpc_status) {
   if (!config_->emitFilterStateStats()) {
     return;
   }

--- a/source/extensions/filters/http/ext_authz/ext_authz.h
+++ b/source/extensions/filters/http/ext_authz/ext_authz.h
@@ -76,9 +76,7 @@ public:
     upstream_host_ = std::move(upstream_host);
   }
   // Sets the gRPC status returned by the authorization server when it is making a gRPC call.
-  void setGrpcStatus(const Grpc::Status::GrpcStatus& grpc_status) {
-    grpc_status_ = grpc_status;
-  }
+  void setGrpcStatus(const Grpc::Status::GrpcStatus& grpc_status) { grpc_status_ = grpc_status; }
 
   bool hasFieldSupport() const override { return true; }
   Envoy::StreamInfo::FilterState::Object::FieldType

--- a/source/extensions/filters/http/ext_authz/ext_authz.h
+++ b/source/extensions/filters/http/ext_authz/ext_authz.h
@@ -63,6 +63,8 @@ public:
   absl::optional<uint64_t> bytesReceived() const { return bytes_received_; }
   Upstream::ClusterInfoConstSharedPtr clusterInfo() const { return cluster_info_; }
   Upstream::HostDescriptionConstSharedPtr upstreamHost() const { return upstream_host_; }
+  // Gets the gRPC status returned by the authorization server when it is making a gRPC call.
+  const absl::optional<Grpc::Status::GrpcStatus>& grpcStatus() const { return grpc_status_; }
 
   void setLatency(std::chrono::microseconds ms) { latency_ = ms; };
   void setBytesSent(uint64_t bytes_sent) { bytes_sent_ = bytes_sent; }
@@ -72,6 +74,10 @@ public:
   }
   void setUpstreamHost(Upstream::HostDescriptionConstSharedPtr upstream_host) {
     upstream_host_ = std::move(upstream_host);
+  }
+  // Sets the gRPC status returned by the authorization server when it is making a gRPC call.
+  void setGrpcStatus(const Grpc::Status::GrpcStatus& grpc_status) {
+    grpc_status_ = grpc_status;
   }
 
   bool hasFieldSupport() const override { return true; }
@@ -102,6 +108,8 @@ private:
   absl::optional<uint64_t> bytes_received_;
   Upstream::ClusterInfoConstSharedPtr cluster_info_;
   Upstream::HostDescriptionConstSharedPtr upstream_host_;
+  // The gRPC status returned by the authorization server when it is making a gRPC call.
+  absl::optional<Grpc::Status::GrpcStatus> grpc_status_;
 };
 
 /**
@@ -382,7 +390,7 @@ private:
   void initiateCall(const Http::RequestHeaderMap& headers);
   void continueDecoding();
   bool isBufferFull(uint64_t num_bytes_processing) const;
-  void updateLoggingInfo();
+  void updateLoggingInfo(const absl::optional<Grpc::Status::GrpcStatus>& grpc_status);
 
   // This holds a set of flags defined in per-route configuration.
   struct PerRouteFlags {

--- a/test/extensions/filters/common/ext_authz/ext_authz_grpc_impl_test.cc
+++ b/test/extensions/filters/common/ext_authz/ext_authz_grpc_impl_test.cc
@@ -78,12 +78,13 @@ TEST_F(ExtAuthzGrpcClientTest, AuthorizationOk) {
   // check_response's http_response value (either OkHttpResponse or DeniedHttpResponse) the dynamic
   // metadata is set to be equal to the check response's dynamic metadata.
   check_response->mutable_dynamic_metadata()->MergeFrom(expected_dynamic_metadata);
-
-  status->set_code(Grpc::Status::WellKnownGrpcStatus::Ok);
+  const auto grpc_status = Grpc::Status::WellKnownGrpcStatus::Ok;
+  status->set_code(grpc_status);
 
   // This is the expected authz response.
   auto authz_response = Response{};
   authz_response.status = CheckStatus::OK;
+  authz_response.grpc_status = grpc_status;
 
   authz_response.dynamic_metadata = expected_dynamic_metadata;
 
@@ -123,11 +124,12 @@ TEST_F(ExtAuthzGrpcClientTest, AuthorizationOkWithAllAtributes) {
   const auto expected_headers = TestCommon::makeHeaderValueOption({{"foo", "bar", false}});
   const auto expected_downstream_headers = TestCommon::makeHeaderValueOption(
       {{"authorized-by", "TestAuthService", false}, {"cookie", "authtoken=1234", true}});
+  const auto grpc_status = Grpc::Status::WellKnownGrpcStatus::Ok;
   auto check_response =
-      TestCommon::makeCheckResponse(Grpc::Status::WellKnownGrpcStatus::Ok, envoy::type::v3::OK,
+      TestCommon::makeCheckResponse(grpc_status, envoy::type::v3::OK,
                                     empty_body, expected_headers, expected_downstream_headers);
   auto authz_response = TestCommon::makeAuthzResponse(
-      CheckStatus::OK, Http::Code::OK, empty_body, expected_headers, expected_downstream_headers);
+      CheckStatus::OK, Http::Code::OK, empty_body, expected_headers, expected_downstream_headers, grpc_status);
 
   envoy::service::auth::v3::CheckRequest request;
   expectCallSend(request);
@@ -151,11 +153,12 @@ TEST_F(ExtAuthzGrpcClientTest, IndifferentToInvalidHeaders) {
   const auto expected_headers = TestCommon::makeHeaderValueOption({{"foo", "bar", false}});
   const auto expected_downstream_headers = TestCommon::makeHeaderValueOption(
       {{"invalid-key\n\n\n\n\n", "TestAuthService", false}, {"cookie", "authtoken=1234", true}});
+  const auto grpc_status = Grpc::Status::WellKnownGrpcStatus::Ok;
   auto check_response =
-      TestCommon::makeCheckResponse(Grpc::Status::WellKnownGrpcStatus::Ok, envoy::type::v3::OK,
+      TestCommon::makeCheckResponse(grpc_status, envoy::type::v3::OK,
                                     empty_body, expected_headers, expected_downstream_headers);
   auto authz_response = TestCommon::makeAuthzResponse(
-      CheckStatus::OK, Http::Code::OK, empty_body, expected_headers, expected_downstream_headers);
+      CheckStatus::OK, Http::Code::OK, empty_body, expected_headers, expected_downstream_headers, grpc_status);
 
   envoy::service::auth::v3::CheckRequest request;
   expectCallSend(request);
@@ -176,9 +179,11 @@ TEST_F(ExtAuthzGrpcClientTest, AuthorizationDenied) {
 
   auto check_response = std::make_unique<envoy::service::auth::v3::CheckResponse>();
   auto status = check_response->mutable_status();
-  status->set_code(Grpc::Status::WellKnownGrpcStatus::PermissionDenied);
+  const auto grpc_status = Grpc::Status::WellKnownGrpcStatus::PermissionDenied;
+  status->set_code(grpc_status);
   auto authz_response = Response{};
   authz_response.status = CheckStatus::Denied;
+  authz_response.grpc_status = grpc_status;
 
   envoy::service::auth::v3::CheckRequest request;
   expectCallSend(request);
@@ -200,9 +205,11 @@ TEST_F(ExtAuthzGrpcClientTest, AuthorizationDeniedGrpcUnknownStatus) {
 
   auto check_response = std::make_unique<envoy::service::auth::v3::CheckResponse>();
   auto status = check_response->mutable_status();
-  status->set_code(Grpc::Status::WellKnownGrpcStatus::Unknown);
+  const auto grpc_status = Grpc::Status::WellKnownGrpcStatus::Unknown;
+  status->set_code(grpc_status);
   auto authz_response = Response{};
   authz_response.status = CheckStatus::Denied;
+  authz_response.grpc_status = grpc_status;
 
   envoy::service::auth::v3::CheckRequest request;
   expectCallSend(request);
@@ -226,12 +233,13 @@ TEST_F(ExtAuthzGrpcClientTest, AuthorizationDeniedWithAllAttributes) {
   const auto expected_headers =
       TestCommon::makeHeaderValueOption({{"foo", "bar", false}, {"foobar", "bar", true}});
   const auto expected_downstream_headers = TestCommon::makeHeaderValueOption({});
+  const auto grpc_status = Grpc::Status::WellKnownGrpcStatus::PermissionDenied;
   auto check_response = TestCommon::makeCheckResponse(
-      Grpc::Status::WellKnownGrpcStatus::PermissionDenied, envoy::type::v3::Unauthorized,
+      grpc_status, envoy::type::v3::Unauthorized,
       expected_body, expected_headers, expected_downstream_headers);
   auto authz_response =
       TestCommon::makeAuthzResponse(CheckStatus::Denied, Http::Code::Unauthorized, expected_body,
-                                    expected_headers, expected_downstream_headers);
+                                    expected_headers, expected_downstream_headers, grpc_status);
 
   envoy::service::auth::v3::CheckRequest request;
   expectCallSend(request);
@@ -257,14 +265,15 @@ TEST_F(ExtAuthzGrpcClientTest, AuthorizationDeniedWithEmptyDeniedResponseStatus)
   const auto expected_headers =
       TestCommon::makeHeaderValueOption({{"foo", "bar", false}, {"foobar", "bar", true}});
   const auto expected_downstream_headers = TestCommon::makeHeaderValueOption({});
+  const auto grpc_status = Grpc::Status::WellKnownGrpcStatus::PermissionDenied;
   auto check_response = TestCommon::makeCheckResponse(
-      Grpc::Status::WellKnownGrpcStatus::PermissionDenied, envoy::type::v3::Empty, expected_body,
+      grpc_status, envoy::type::v3::Empty, expected_body,
       expected_headers, expected_downstream_headers);
   // When the check response gives unknown denied response HTTP status code, the filter sets the
   // response HTTP status code with 403 Forbidden (default).
   auto authz_response =
       TestCommon::makeAuthzResponse(CheckStatus::Denied, Http::Code::Forbidden, expected_body,
-                                    expected_headers, expected_downstream_headers);
+                                    expected_headers, expected_downstream_headers, grpc_status);
 
   envoy::service::auth::v3::CheckRequest request;
   expectCallSend(request);
@@ -284,13 +293,18 @@ TEST_F(ExtAuthzGrpcClientTest, AuthorizationDeniedWithEmptyDeniedResponseStatus)
 TEST_F(ExtAuthzGrpcClientTest, UnknownError) {
   initialize();
 
+  const auto grpc_status = Grpc::Status::WellKnownGrpcStatus::Unknown;
+  auto authz_response = Response{};
+  authz_response.status = CheckStatus::Error;
+  authz_response.grpc_status = grpc_status;
+
   envoy::service::auth::v3::CheckRequest request;
   expectCallSend(request);
   client_->check(request_callbacks_, request, Tracing::NullSpan::instance(), stream_info_);
 
   EXPECT_CALL(request_callbacks_,
-              onComplete_(WhenDynamicCastTo<ResponsePtr&>(AuthzErrorResponse(CheckStatus::Error))));
-  client_->onFailure(Grpc::Status::Unknown, "", span_);
+              onComplete_(WhenDynamicCastTo<ResponsePtr&>(AuthzErrorResponse(authz_response))));
+  client_->onFailure(grpc_status, "", span_);
 }
 
 // Test the client when the request is canceled.
@@ -309,13 +323,18 @@ TEST_F(ExtAuthzGrpcClientTest, CancelledAuthorizationRequest) {
 TEST_F(ExtAuthzGrpcClientTest, AuthorizationRequestTimeout) {
   initialize();
 
+  const auto grpc_status = Grpc::Status::DeadlineExceeded;
+  auto authz_response = Response{};
+  authz_response.status = CheckStatus::Error;
+  authz_response.grpc_status = grpc_status;
+
   envoy::service::auth::v3::CheckRequest request;
   expectCallSend(request);
   client_->check(request_callbacks_, request, Tracing::NullSpan::instance(), stream_info_);
 
   EXPECT_CALL(request_callbacks_,
-              onComplete_(WhenDynamicCastTo<ResponsePtr&>(AuthzErrorResponse(CheckStatus::Error))));
-  client_->onFailure(Grpc::Status::DeadlineExceeded, "", span_);
+              onComplete_(WhenDynamicCastTo<ResponsePtr&>(AuthzErrorResponse(authz_response))));
+  client_->onFailure(grpc_status, "", span_);
 }
 
 // Test the client when an OK response is received with dynamic metadata in that OK response.
@@ -337,12 +356,14 @@ TEST_F(ExtAuthzGrpcClientTest, AuthorizationOkWithDynamicMetadata) {
   check_response->mutable_ok_response()->mutable_dynamic_metadata()->MergeFrom(
       overridden_dynamic_metadata);
 
-  status->set_code(Grpc::Status::WellKnownGrpcStatus::Ok);
+  const auto grpc_status = Grpc::Status::WellKnownGrpcStatus::Ok;
+  status->set_code(grpc_status);
 
   // This is the expected authz response.
   auto authz_response = Response{};
   authz_response.status = CheckStatus::OK;
   authz_response.dynamic_metadata = overridden_dynamic_metadata;
+  authz_response.grpc_status = grpc_status;
 
   envoy::service::auth::v3::CheckRequest request;
   expectCallSend(request);
@@ -364,7 +385,8 @@ TEST_F(ExtAuthzGrpcClientTest, AuthorizationOkWithQueryParameters) {
   auto check_response = std::make_unique<envoy::service::auth::v3::CheckResponse>();
   auto status = check_response->mutable_status();
 
-  status->set_code(Grpc::Status::WellKnownGrpcStatus::Ok);
+  const auto grpc_status = Grpc::Status::WellKnownGrpcStatus::Ok;
+  status->set_code(grpc_status);
 
   const Http::Utility::QueryParamsVector query_parameters_to_set{{"add-me", "yes"}};
   for (const auto& [key, value] : query_parameters_to_set) {
@@ -383,6 +405,7 @@ TEST_F(ExtAuthzGrpcClientTest, AuthorizationOkWithQueryParameters) {
   authz_response.status = CheckStatus::OK;
   authz_response.query_parameters_to_set = {{"add-me", "yes"}};
   authz_response.query_parameters_to_remove = {"remove-me"};
+  authz_response.grpc_status = grpc_status;
 
   envoy::service::auth::v3::CheckRequest request;
   expectCallSend(request);
@@ -436,6 +459,7 @@ ok_response:
       .response_headers_to_overwrite_if_exists =
           UnsafeHeaderVector{{"overwrite-if-exists", "overwrite-if-exists-value"}},
       .status_code = Http::Code::OK,
+      .grpc_status = Grpc::Status::WellKnownGrpcStatus::Ok,
   };
 
   envoy::service::auth::v3::CheckRequest request;

--- a/test/extensions/filters/common/ext_authz/ext_authz_grpc_impl_test.cc
+++ b/test/extensions/filters/common/ext_authz/ext_authz_grpc_impl_test.cc
@@ -125,11 +125,11 @@ TEST_F(ExtAuthzGrpcClientTest, AuthorizationOkWithAllAtributes) {
   const auto expected_downstream_headers = TestCommon::makeHeaderValueOption(
       {{"authorized-by", "TestAuthService", false}, {"cookie", "authtoken=1234", true}});
   const auto grpc_status = Grpc::Status::WellKnownGrpcStatus::Ok;
-  auto check_response =
-      TestCommon::makeCheckResponse(grpc_status, envoy::type::v3::OK,
-                                    empty_body, expected_headers, expected_downstream_headers);
-  auto authz_response = TestCommon::makeAuthzResponse(
-      CheckStatus::OK, Http::Code::OK, empty_body, expected_headers, expected_downstream_headers, grpc_status);
+  auto check_response = TestCommon::makeCheckResponse(
+      grpc_status, envoy::type::v3::OK, empty_body, expected_headers, expected_downstream_headers);
+  auto authz_response =
+      TestCommon::makeAuthzResponse(CheckStatus::OK, Http::Code::OK, empty_body, expected_headers,
+                                    expected_downstream_headers, grpc_status);
 
   envoy::service::auth::v3::CheckRequest request;
   expectCallSend(request);
@@ -154,11 +154,11 @@ TEST_F(ExtAuthzGrpcClientTest, IndifferentToInvalidHeaders) {
   const auto expected_downstream_headers = TestCommon::makeHeaderValueOption(
       {{"invalid-key\n\n\n\n\n", "TestAuthService", false}, {"cookie", "authtoken=1234", true}});
   const auto grpc_status = Grpc::Status::WellKnownGrpcStatus::Ok;
-  auto check_response =
-      TestCommon::makeCheckResponse(grpc_status, envoy::type::v3::OK,
-                                    empty_body, expected_headers, expected_downstream_headers);
-  auto authz_response = TestCommon::makeAuthzResponse(
-      CheckStatus::OK, Http::Code::OK, empty_body, expected_headers, expected_downstream_headers, grpc_status);
+  auto check_response = TestCommon::makeCheckResponse(
+      grpc_status, envoy::type::v3::OK, empty_body, expected_headers, expected_downstream_headers);
+  auto authz_response =
+      TestCommon::makeAuthzResponse(CheckStatus::OK, Http::Code::OK, empty_body, expected_headers,
+                                    expected_downstream_headers, grpc_status);
 
   envoy::service::auth::v3::CheckRequest request;
   expectCallSend(request);
@@ -234,9 +234,9 @@ TEST_F(ExtAuthzGrpcClientTest, AuthorizationDeniedWithAllAttributes) {
       TestCommon::makeHeaderValueOption({{"foo", "bar", false}, {"foobar", "bar", true}});
   const auto expected_downstream_headers = TestCommon::makeHeaderValueOption({});
   const auto grpc_status = Grpc::Status::WellKnownGrpcStatus::PermissionDenied;
-  auto check_response = TestCommon::makeCheckResponse(
-      grpc_status, envoy::type::v3::Unauthorized,
-      expected_body, expected_headers, expected_downstream_headers);
+  auto check_response =
+      TestCommon::makeCheckResponse(grpc_status, envoy::type::v3::Unauthorized, expected_body,
+                                    expected_headers, expected_downstream_headers);
   auto authz_response =
       TestCommon::makeAuthzResponse(CheckStatus::Denied, Http::Code::Unauthorized, expected_body,
                                     expected_headers, expected_downstream_headers, grpc_status);
@@ -266,9 +266,9 @@ TEST_F(ExtAuthzGrpcClientTest, AuthorizationDeniedWithEmptyDeniedResponseStatus)
       TestCommon::makeHeaderValueOption({{"foo", "bar", false}, {"foobar", "bar", true}});
   const auto expected_downstream_headers = TestCommon::makeHeaderValueOption({});
   const auto grpc_status = Grpc::Status::WellKnownGrpcStatus::PermissionDenied;
-  auto check_response = TestCommon::makeCheckResponse(
-      grpc_status, envoy::type::v3::Empty, expected_body,
-      expected_headers, expected_downstream_headers);
+  auto check_response =
+      TestCommon::makeCheckResponse(grpc_status, envoy::type::v3::Empty, expected_body,
+                                    expected_headers, expected_downstream_headers);
   // When the check response gives unknown denied response HTTP status code, the filter sets the
   // response HTTP status code with 403 Forbidden (default).
   auto authz_response =

--- a/test/extensions/filters/common/ext_authz/ext_authz_http_impl_test.cc
+++ b/test/extensions/filters/common/ext_authz/ext_authz_http_impl_test.cc
@@ -579,10 +579,13 @@ TEST_F(ExtAuthzHttpClientTest, AuthorizationDeniedAndAllowedClientHeaders) {
 TEST_F(ExtAuthzHttpClientTest, AuthorizationRequestError) {
   envoy::service::auth::v3::CheckRequest request;
 
+  auto authz_response = Response{};
+  authz_response.status = CheckStatus::Error;
+
   client_->check(request_callbacks_, request, parent_span_, stream_info_);
 
   EXPECT_CALL(request_callbacks_,
-              onComplete_(WhenDynamicCastTo<ResponsePtr&>(AuthzErrorResponse(CheckStatus::Error))));
+              onComplete_(WhenDynamicCastTo<ResponsePtr&>(AuthzErrorResponse(authz_response))));
   client_->onFailure(async_request_, Http::AsyncClient::FailureReason::Reset);
 }
 
@@ -592,10 +595,13 @@ TEST_F(ExtAuthzHttpClientTest, AuthorizationRequest5xxError) {
       Http::ResponseHeaderMapPtr{new Http::TestResponseHeaderMapImpl{{":status", "503"}}}));
   envoy::service::auth::v3::CheckRequest request;
 
+  auto authz_response = Response{};
+  authz_response.status = CheckStatus::Error;
+
   client_->check(request_callbacks_, request, parent_span_, stream_info_);
 
   EXPECT_CALL(request_callbacks_,
-              onComplete_(WhenDynamicCastTo<ResponsePtr&>(AuthzErrorResponse(CheckStatus::Error))));
+              onComplete_(WhenDynamicCastTo<ResponsePtr&>(AuthzErrorResponse(authz_response))));
   client_->onSuccess(async_request_, std::move(check_response));
 }
 
@@ -614,10 +620,13 @@ TEST_F(ExtAuthzHttpClientTest, CancelledAuthorizationRequest) {
 TEST_F(ExtAuthzHttpClientTest, NoCluster) {
   InSequence s;
 
+  auto authz_response = Response{};
+  authz_response.status = CheckStatus::Error;
+
   EXPECT_CALL(cm_, getThreadLocalCluster(Eq("ext_authz"))).WillOnce(Return(nullptr));
   EXPECT_CALL(cm_.thread_local_cluster_, httpAsyncClient()).Times(0);
   EXPECT_CALL(request_callbacks_,
-              onComplete_(WhenDynamicCastTo<ResponsePtr&>(AuthzErrorResponse(CheckStatus::Error))));
+              onComplete_(WhenDynamicCastTo<ResponsePtr&>(AuthzErrorResponse(authz_response))));
   client_->check(request_callbacks_, envoy::service::auth::v3::CheckRequest{}, parent_span_,
                  stream_info_);
 }

--- a/test/extensions/filters/common/ext_authz/test_common.cc
+++ b/test/extensions/filters/common/ext_authz/test_common.cc
@@ -88,10 +88,14 @@ CheckResponsePtr TestCommon::makeCheckResponse(Grpc::Status::GrpcStatus response
 Response TestCommon::makeAuthzResponse(CheckStatus status, Http::Code status_code,
                                        const std::string& body,
                                        const HeaderValueOptionVector& headers,
-                                       const HeaderValueOptionVector& downstream_headers) {
+                                       const HeaderValueOptionVector& downstream_headers,
+                                       const absl::optional<Grpc::Status::GrpcStatus>& grpc_status) {
   auto authz_response = Response{};
   authz_response.status = status;
   authz_response.status_code = status_code;
+  if (grpc_status.has_value()) {
+    authz_response.grpc_status = grpc_status;
+  }
   if (!body.empty()) {
     authz_response.body = body;
   }

--- a/test/extensions/filters/common/ext_authz/test_common.cc
+++ b/test/extensions/filters/common/ext_authz/test_common.cc
@@ -85,11 +85,11 @@ CheckResponsePtr TestCommon::makeCheckResponse(Grpc::Status::GrpcStatus response
   return response;
 }
 
-Response TestCommon::makeAuthzResponse(CheckStatus status, Http::Code status_code,
-                                       const std::string& body,
-                                       const HeaderValueOptionVector& headers,
-                                       const HeaderValueOptionVector& downstream_headers,
-                                       const absl::optional<Grpc::Status::GrpcStatus>& grpc_status) {
+Response
+TestCommon::makeAuthzResponse(CheckStatus status, Http::Code status_code, const std::string& body,
+                              const HeaderValueOptionVector& headers,
+                              const HeaderValueOptionVector& downstream_headers,
+                              const absl::optional<Grpc::Status::GrpcStatus>& grpc_status) {
   auto authz_response = Response{};
   authz_response.status = status;
   authz_response.status_code = status_code;

--- a/test/extensions/filters/common/ext_authz/test_common.h
+++ b/test/extensions/filters/common/ext_authz/test_common.h
@@ -47,7 +47,8 @@ public:
   makeAuthzResponse(CheckStatus status, Http::Code status_code = Http::Code::OK,
                     const std::string& body = std::string{},
                     const HeaderValueOptionVector& headers = HeaderValueOptionVector{},
-                    const HeaderValueOptionVector& downstream_headers = HeaderValueOptionVector{});
+                    const HeaderValueOptionVector& downstream_headers = HeaderValueOptionVector{},
+                    const absl::optional<Grpc::Status::GrpcStatus>& grpc_status = absl::nullopt);
 
   static HeaderValueOptionVector makeHeaderValueOption(KeyValueOptionVector&& headers);
 
@@ -60,7 +61,7 @@ public:
                                               const std::vector<std::string>& rhs);
 };
 
-MATCHER_P(AuthzErrorResponse, status, "") {
+MATCHER_P(AuthzErrorResponse, response, "") {
   // These fields should be always empty when the status is an error.
   if (!arg->headers_to_add.empty() || !arg->headers_to_append.empty() || !arg->body.empty()) {
     return false;
@@ -69,10 +70,11 @@ MATCHER_P(AuthzErrorResponse, status, "") {
   if (arg->status_code != Http::Code::Forbidden) {
     return false;
   }
-  return arg->status == status;
+  return arg->status == response.status;
 }
 
 MATCHER_P(AuthzResponseNoAttributes, response, "") {
+  const bool equal_grpc_status = arg->grpc_status == response.grpc_status;
   const bool equal_status = arg->status == response.status;
   const bool equal_metadata =
       TestUtility::protoEqual(arg->dynamic_metadata, response.dynamic_metadata);
@@ -84,10 +86,13 @@ MATCHER_P(AuthzResponseNoAttributes, response, "") {
                      << arg->dynamic_metadata.DebugString()
                      << "=======================================================================\n";
   }
-  return equal_status && equal_metadata;
+  return equal_grpc_status && equal_status && equal_metadata;
 }
 
 MATCHER_P(AuthzDeniedResponse, response, "") {
+  if (arg->grpc_status != response.grpc_status) {
+    return false;
+  }
   if (arg->status != response.status) {
     return false;
   }
@@ -103,6 +108,10 @@ MATCHER_P(AuthzDeniedResponse, response, "") {
 
 MATCHER_P(AuthzOkResponse, response, "") {
   if (arg->status != response.status) {
+    return false;
+  }
+
+  if (arg->grpc_status != response.grpc_status) {
     return false;
   }
 

--- a/test/extensions/filters/http/ext_authz/ext_authz_integration_test.cc
+++ b/test/extensions/filters/http/ext_authz/ext_authz_integration_test.cc
@@ -17,11 +17,11 @@
 #include "absl/strings/str_format.h"
 #include "gtest/gtest.h"
 
+using test::integration::filters::LoggingTestFilterConfig;
 using testing::AssertionResult;
 using testing::Not;
 using testing::TestWithParam;
 using testing::ValuesIn;
-using test::integration::filters::LoggingTestFilterConfig;
 
 namespace Envoy {
 

--- a/test/extensions/filters/http/ext_authz/ext_authz_integration_test.cc
+++ b/test/extensions/filters/http/ext_authz/ext_authz_integration_test.cc
@@ -21,6 +21,7 @@ using testing::AssertionResult;
 using testing::Not;
 using testing::TestWithParam;
 using testing::ValuesIn;
+using test::integration::filters::LoggingTestFilterConfig;
 
 namespace Envoy {
 
@@ -161,13 +162,14 @@ public:
       config_helper_.prependFilter(MessageUtil::getJsonStringFromMessageOrError(ext_authz_filter));
 
       if (emitFilterStateStats()) {
-        test::integration::filters::LoggingTestFilterConfig logging_filter_config;
+        LoggingTestFilterConfig logging_filter_config;
         logging_filter_config.set_logging_id("envoy.filters.http.ext_authz");
         logging_filter_config.set_upstream_cluster_name("ext_authz_cluster");
         logging_filter_config.set_expect_stats(opts.expect_stats_override.value_or(true));
         logging_filter_config.set_expect_envoy_grpc_specific_stats(clientType() ==
                                                                    Grpc::ClientType::EnvoyGrpc);
         logging_filter_config.set_expect_response_bytes(opts.stats_expect_response_bytes);
+        logging_filter_config.set_expect_grpc_status(ext_authz_grpc_status_);
 
         // Set the same filter metadata to the ext authz filter and the logging test filter.
         *(*logging_filter_config.mutable_filter_metadata()->mutable_fields())["foo"]
@@ -655,6 +657,7 @@ attributes:
   FakeHttpConnectionPtr fake_ext_authz_connection_;
   FakeStreamPtr ext_authz_request_;
   IntegrationStreamDecoderPtr response_;
+  LoggingTestFilterConfig::GrpcStatus ext_authz_grpc_status_ = LoggingTestFilterConfig::OK;
 
   Buffer::OwnedImpl request_body_;
   const uint64_t response_size_ = 512;
@@ -1190,6 +1193,7 @@ TEST_P(ExtAuthzGrpcIntegrationTest, TimeoutFailClosed) {
   opts.stats_expect_response_bytes = false;
   opts.failure_mode_allow = false;
   opts.timeout_ms = 1;
+  ext_authz_grpc_status_ = LoggingTestFilterConfig::UNAVAILABLE;
   initializeConfig(opts);
 
   // Use h1, set up the test.
@@ -1268,6 +1272,7 @@ TEST_P(ExtAuthzGrpcIntegrationTest, TimeoutFailOpen) {
   init_opts.stats_expect_response_bytes = false;
   init_opts.failure_mode_allow = true;
   init_opts.timeout_ms = 1;
+  ext_authz_grpc_status_ = LoggingTestFilterConfig::UNAVAILABLE;
   initializeConfig(init_opts);
 
   // Use h1, set up the test.

--- a/test/extensions/filters/http/ext_authz/ext_authz_test.cc
+++ b/test/extensions/filters/http/ext_authz/ext_authz_test.cc
@@ -372,6 +372,10 @@ public:
     EXPECT_EQ(actual.clusterInfo(), expected.clusterInfo());
     EXPECT_EQ(actual.bytesSent(), expected.bytesSent());
     EXPECT_EQ(actual.bytesReceived(), expected.bytesReceived());
+    EXPECT_EQ(actual.grpcStatus().has_value(), expected.grpcStatus().has_value());
+    if (expected.grpcStatus().has_value()) {
+      EXPECT_EQ(actual.grpcStatus().value(), expected.grpcStatus().value());
+    }
 
     ASSERT_EQ(actual.filterMetadata().has_value(), expected.filterMetadata().has_value());
     if (expected.filterMetadata().has_value()) {
@@ -4017,6 +4021,10 @@ TEST_P(HttpFilterTestParam, DisableRequestBodyBufferingOnRoute) {
 TEST_P(EmitFilterStateTest, OkResponse) {
   Filters::Common::ExtAuthz::Response response{};
   response.status = Filters::Common::ExtAuthz::CheckStatus::OK;
+  if (!std::get<0>(GetParam()) && std::get<1>(GetParam())) {
+    response.grpc_status = Grpc::Status::WellKnownGrpcStatus::Ok;
+    expected_output_.setGrpcStatus(Grpc::Status::WellKnownGrpcStatus::Ok);
+  }
 
   test(response);
 }
@@ -4024,6 +4032,10 @@ TEST_P(EmitFilterStateTest, OkResponse) {
 TEST_P(EmitFilterStateTest, Error) {
   Filters::Common::ExtAuthz::Response response{};
   response.status = Filters::Common::ExtAuthz::CheckStatus::Error;
+  if (!std::get<0>(GetParam()) && std::get<1>(GetParam())) {
+    response.grpc_status = Grpc::Status::WellKnownGrpcStatus::Canceled;
+    expected_output_.setGrpcStatus(Grpc::Status::WellKnownGrpcStatus::Canceled);
+  }
 
   test(response);
 }
@@ -4031,6 +4043,10 @@ TEST_P(EmitFilterStateTest, Error) {
 TEST_P(EmitFilterStateTest, Denied) {
   Filters::Common::ExtAuthz::Response response{};
   response.status = Filters::Common::ExtAuthz::CheckStatus::Denied;
+  if (!std::get<0>(GetParam()) && std::get<1>(GetParam())) {
+    response.grpc_status = Grpc::Status::WellKnownGrpcStatus::PermissionDenied;
+    expected_output_.setGrpcStatus(Grpc::Status::WellKnownGrpcStatus::PermissionDenied);
+  }
 
   test(response);
 }
@@ -4048,6 +4064,10 @@ TEST_P(EmitFilterStateTest, NullStreamInfo) {
 
   Filters::Common::ExtAuthz::Response response{};
   response.status = Filters::Common::ExtAuthz::CheckStatus::OK;
+  if (!std::get<0>(GetParam()) && std::get<1>(GetParam())) {
+    response.grpc_status = Grpc::Status::WellKnownGrpcStatus::Ok;
+    expected_output_.setGrpcStatus(Grpc::Status::WellKnownGrpcStatus::Ok);
+  }
 
   test(response);
 }
@@ -4067,6 +4087,10 @@ TEST_P(EmitFilterStateTest, NullStreamInfoFields) {
 
   Filters::Common::ExtAuthz::Response response{};
   response.status = Filters::Common::ExtAuthz::CheckStatus::OK;
+  if (!std::get<0>(GetParam()) && std::get<1>(GetParam())) {
+    response.grpc_status = Grpc::Status::WellKnownGrpcStatus::Ok;
+    expected_output_.setGrpcStatus(Grpc::Status::WellKnownGrpcStatus::Ok);
+  }
 
   test(response);
 }
@@ -4082,6 +4106,10 @@ TEST_P(EmitFilterStateTest, NullUpstreamHost) {
 
   Filters::Common::ExtAuthz::Response response{};
   response.status = Filters::Common::ExtAuthz::CheckStatus::OK;
+  if (!std::get<0>(GetParam()) && std::get<1>(GetParam())) {
+    response.grpc_status = Grpc::Status::WellKnownGrpcStatus::Ok;
+    expected_output_.setGrpcStatus(Grpc::Status::WellKnownGrpcStatus::Ok);
+  }
 
   test(response);
 }
@@ -4100,6 +4128,10 @@ TEST_P(EmitFilterStateTest, PreexistingFilterStateDifferentTypeMutable) {
 
   Filters::Common::ExtAuthz::Response response{};
   response.status = Filters::Common::ExtAuthz::CheckStatus::OK;
+  if (!std::get<0>(GetParam()) && std::get<1>(GetParam())) {
+    response.grpc_status = Grpc::Status::WellKnownGrpcStatus::Ok;
+    expected_output_.setGrpcStatus(Grpc::Status::WellKnownGrpcStatus::Ok);
+  }
 
   test(response);
 }
@@ -4117,6 +4149,10 @@ TEST_P(EmitFilterStateTest, PreexistingFilterStateSameTypeMutable) {
 
   Filters::Common::ExtAuthz::Response response{};
   response.status = Filters::Common::ExtAuthz::CheckStatus::OK;
+  if (!std::get<0>(GetParam()) && std::get<1>(GetParam())) {
+    response.grpc_status = Grpc::Status::WellKnownGrpcStatus::Ok;
+    expected_output_.setGrpcStatus(Grpc::Status::WellKnownGrpcStatus::Ok);
+  }
 
   test(response);
 }

--- a/test/extensions/filters/http/ext_authz/logging_test_filter.cc
+++ b/test/extensions/filters/http/ext_authz/logging_test_filter.cc
@@ -19,15 +19,57 @@ namespace Extensions {
 namespace HttpFilters {
 namespace ExternalProcessing {
 
+using test::integration::filters::LoggingTestFilterConfig;
+
+Grpc::Status::WellKnownGrpcStatus GrpcStatusFromProto(LoggingTestFilterConfig::GrpcStatus grpc_status) {
+  switch (grpc_status) {
+    case LoggingTestFilterConfig::OK:
+      return Grpc::Status::WellKnownGrpcStatus::Ok;
+    case LoggingTestFilterConfig::CANCELLED:
+      return Grpc::Status::WellKnownGrpcStatus::Canceled;
+    case LoggingTestFilterConfig::UNKNOWN:
+      return Grpc::Status::WellKnownGrpcStatus::Unknown;
+    case LoggingTestFilterConfig::INVALID_ARGUMENT:
+      return Grpc::Status::WellKnownGrpcStatus::InvalidArgument;
+    case LoggingTestFilterConfig::DEADLINE_EXCEEDED:
+      return Grpc::Status::WellKnownGrpcStatus::DeadlineExceeded;
+    case LoggingTestFilterConfig::NOT_FOUND:
+      return Grpc::Status::WellKnownGrpcStatus::NotFound;
+    case LoggingTestFilterConfig::ALREADY_EXISTS:
+      return Grpc::Status::WellKnownGrpcStatus::AlreadyExists;
+    case LoggingTestFilterConfig::PERMISSION_DENIED:
+      return Grpc::Status::WellKnownGrpcStatus::PermissionDenied;
+    case LoggingTestFilterConfig::RESOURCE_EXHAUSTED:
+      return Grpc::Status::WellKnownGrpcStatus::ResourceExhausted;
+    case LoggingTestFilterConfig::FAILED_PRECONDITION:
+      return Grpc::Status::WellKnownGrpcStatus::FailedPrecondition;
+    case LoggingTestFilterConfig::ABORTED:
+      return Grpc::Status::WellKnownGrpcStatus::Aborted;
+    case LoggingTestFilterConfig::OUT_OF_RANGE:
+      return Grpc::Status::WellKnownGrpcStatus::OutOfRange;
+    case LoggingTestFilterConfig::UNIMPLEMENTED:
+      return Grpc::Status::WellKnownGrpcStatus::Unimplemented;
+    case LoggingTestFilterConfig::INTERNAL:
+      return Grpc::Status::WellKnownGrpcStatus::Internal;
+    case LoggingTestFilterConfig::UNAVAILABLE:
+      return Grpc::Status::WellKnownGrpcStatus::Unavailable;
+    case LoggingTestFilterConfig::DATA_LOSS:
+      return Grpc::Status::WellKnownGrpcStatus::DataLoss;
+    case LoggingTestFilterConfig::UNAUTHENTICATED:
+      return Grpc::Status::WellKnownGrpcStatus::Unauthenticated;
+    default:
+      return Grpc::Status::WellKnownGrpcStatus::InvalidCode;
+  }
+}
+
 // A test filter that retrieve the logging info on encodeComplete.
 class LoggingTestFilter : public Http::PassThroughFilter {
 public:
-  LoggingTestFilter(const std::string& logging_id, const std::string& cluster_name,
-                    bool expect_stats, bool expect_envoy_grpc_specific_stats,
-                    bool expect_response_bytes, const ProtobufWkt::Struct& filter_metadata)
-      : logging_id_(logging_id), expected_cluster_name_(cluster_name), expect_stats_(expect_stats),
-        expect_envoy_grpc_specific_stats_(expect_envoy_grpc_specific_stats),
-        expect_response_bytes_(expect_response_bytes), filter_metadata_(filter_metadata) {}
+  LoggingTestFilter(const LoggingTestFilterConfig& proto_config)
+      : logging_id_(proto_config.logging_id()), expected_cluster_name_(proto_config.upstream_cluster_name()), expect_stats_(proto_config.expect_stats()),
+        expect_envoy_grpc_specific_stats_(proto_config.expect_envoy_grpc_specific_stats()),
+        expect_response_bytes_(proto_config.expect_response_bytes()), filter_metadata_(proto_config.filter_metadata()),
+        expect_grpc_status_(proto_config.expect_grpc_status()) {}
   void encodeComplete() override {
     ASSERT(decoder_callbacks_ != nullptr);
     const Envoy::StreamInfo::FilterStateSharedPtr& filter_state =
@@ -62,6 +104,13 @@ public:
       }
       ASSERT_NE(ext_authz_logging_info->upstreamHost(), nullptr);
       EXPECT_EQ(ext_authz_logging_info->upstreamHost()->cluster().name(), expected_cluster_name_);
+      if (expect_grpc_status_ != LoggingTestFilterConfig::UNSPECIFIED) {
+        ASSERT_TRUE(ext_authz_logging_info->grpcStatus().has_value());
+        EXPECT_EQ(ext_authz_logging_info->grpcStatus(),
+        GrpcStatusFromProto(expect_grpc_status_));
+      } else {
+        EXPECT_FALSE(ext_authz_logging_info->grpcStatus().has_value());
+      }
     }
   }
 

--- a/test/extensions/filters/http/ext_authz/logging_test_filter.cc
+++ b/test/extensions/filters/http/ext_authz/logging_test_filter.cc
@@ -21,44 +21,45 @@ namespace ExternalProcessing {
 
 using test::integration::filters::LoggingTestFilterConfig;
 
-Grpc::Status::WellKnownGrpcStatus GrpcStatusFromProto(LoggingTestFilterConfig::GrpcStatus grpc_status) {
+Grpc::Status::WellKnownGrpcStatus
+GrpcStatusFromProto(LoggingTestFilterConfig::GrpcStatus grpc_status) {
   switch (grpc_status) {
-    case LoggingTestFilterConfig::OK:
-      return Grpc::Status::WellKnownGrpcStatus::Ok;
-    case LoggingTestFilterConfig::CANCELLED:
-      return Grpc::Status::WellKnownGrpcStatus::Canceled;
-    case LoggingTestFilterConfig::UNKNOWN:
-      return Grpc::Status::WellKnownGrpcStatus::Unknown;
-    case LoggingTestFilterConfig::INVALID_ARGUMENT:
-      return Grpc::Status::WellKnownGrpcStatus::InvalidArgument;
-    case LoggingTestFilterConfig::DEADLINE_EXCEEDED:
-      return Grpc::Status::WellKnownGrpcStatus::DeadlineExceeded;
-    case LoggingTestFilterConfig::NOT_FOUND:
-      return Grpc::Status::WellKnownGrpcStatus::NotFound;
-    case LoggingTestFilterConfig::ALREADY_EXISTS:
-      return Grpc::Status::WellKnownGrpcStatus::AlreadyExists;
-    case LoggingTestFilterConfig::PERMISSION_DENIED:
-      return Grpc::Status::WellKnownGrpcStatus::PermissionDenied;
-    case LoggingTestFilterConfig::RESOURCE_EXHAUSTED:
-      return Grpc::Status::WellKnownGrpcStatus::ResourceExhausted;
-    case LoggingTestFilterConfig::FAILED_PRECONDITION:
-      return Grpc::Status::WellKnownGrpcStatus::FailedPrecondition;
-    case LoggingTestFilterConfig::ABORTED:
-      return Grpc::Status::WellKnownGrpcStatus::Aborted;
-    case LoggingTestFilterConfig::OUT_OF_RANGE:
-      return Grpc::Status::WellKnownGrpcStatus::OutOfRange;
-    case LoggingTestFilterConfig::UNIMPLEMENTED:
-      return Grpc::Status::WellKnownGrpcStatus::Unimplemented;
-    case LoggingTestFilterConfig::INTERNAL:
-      return Grpc::Status::WellKnownGrpcStatus::Internal;
-    case LoggingTestFilterConfig::UNAVAILABLE:
-      return Grpc::Status::WellKnownGrpcStatus::Unavailable;
-    case LoggingTestFilterConfig::DATA_LOSS:
-      return Grpc::Status::WellKnownGrpcStatus::DataLoss;
-    case LoggingTestFilterConfig::UNAUTHENTICATED:
-      return Grpc::Status::WellKnownGrpcStatus::Unauthenticated;
-    default:
-      return Grpc::Status::WellKnownGrpcStatus::InvalidCode;
+  case LoggingTestFilterConfig::OK:
+    return Grpc::Status::WellKnownGrpcStatus::Ok;
+  case LoggingTestFilterConfig::CANCELLED:
+    return Grpc::Status::WellKnownGrpcStatus::Canceled;
+  case LoggingTestFilterConfig::UNKNOWN:
+    return Grpc::Status::WellKnownGrpcStatus::Unknown;
+  case LoggingTestFilterConfig::INVALID_ARGUMENT:
+    return Grpc::Status::WellKnownGrpcStatus::InvalidArgument;
+  case LoggingTestFilterConfig::DEADLINE_EXCEEDED:
+    return Grpc::Status::WellKnownGrpcStatus::DeadlineExceeded;
+  case LoggingTestFilterConfig::NOT_FOUND:
+    return Grpc::Status::WellKnownGrpcStatus::NotFound;
+  case LoggingTestFilterConfig::ALREADY_EXISTS:
+    return Grpc::Status::WellKnownGrpcStatus::AlreadyExists;
+  case LoggingTestFilterConfig::PERMISSION_DENIED:
+    return Grpc::Status::WellKnownGrpcStatus::PermissionDenied;
+  case LoggingTestFilterConfig::RESOURCE_EXHAUSTED:
+    return Grpc::Status::WellKnownGrpcStatus::ResourceExhausted;
+  case LoggingTestFilterConfig::FAILED_PRECONDITION:
+    return Grpc::Status::WellKnownGrpcStatus::FailedPrecondition;
+  case LoggingTestFilterConfig::ABORTED:
+    return Grpc::Status::WellKnownGrpcStatus::Aborted;
+  case LoggingTestFilterConfig::OUT_OF_RANGE:
+    return Grpc::Status::WellKnownGrpcStatus::OutOfRange;
+  case LoggingTestFilterConfig::UNIMPLEMENTED:
+    return Grpc::Status::WellKnownGrpcStatus::Unimplemented;
+  case LoggingTestFilterConfig::INTERNAL:
+    return Grpc::Status::WellKnownGrpcStatus::Internal;
+  case LoggingTestFilterConfig::UNAVAILABLE:
+    return Grpc::Status::WellKnownGrpcStatus::Unavailable;
+  case LoggingTestFilterConfig::DATA_LOSS:
+    return Grpc::Status::WellKnownGrpcStatus::DataLoss;
+  case LoggingTestFilterConfig::UNAUTHENTICATED:
+    return Grpc::Status::WellKnownGrpcStatus::Unauthenticated;
+  default:
+    return Grpc::Status::WellKnownGrpcStatus::InvalidCode;
   }
 }
 
@@ -66,9 +67,12 @@ Grpc::Status::WellKnownGrpcStatus GrpcStatusFromProto(LoggingTestFilterConfig::G
 class LoggingTestFilter : public Http::PassThroughFilter {
 public:
   LoggingTestFilter(const LoggingTestFilterConfig& proto_config)
-      : logging_id_(proto_config.logging_id()), expected_cluster_name_(proto_config.upstream_cluster_name()), expect_stats_(proto_config.expect_stats()),
+      : logging_id_(proto_config.logging_id()),
+        expected_cluster_name_(proto_config.upstream_cluster_name()),
+        expect_stats_(proto_config.expect_stats()),
         expect_envoy_grpc_specific_stats_(proto_config.expect_envoy_grpc_specific_stats()),
-        expect_response_bytes_(proto_config.expect_response_bytes()), filter_metadata_(proto_config.filter_metadata()),
+        expect_response_bytes_(proto_config.expect_response_bytes()),
+        filter_metadata_(proto_config.filter_metadata()),
         expect_grpc_status_(proto_config.expect_grpc_status()) {}
   void encodeComplete() override {
     ASSERT(decoder_callbacks_ != nullptr);
@@ -106,8 +110,7 @@ public:
       EXPECT_EQ(ext_authz_logging_info->upstreamHost()->cluster().name(), expected_cluster_name_);
       if (expect_grpc_status_ != LoggingTestFilterConfig::UNSPECIFIED) {
         ASSERT_TRUE(ext_authz_logging_info->grpcStatus().has_value());
-        EXPECT_EQ(ext_authz_logging_info->grpcStatus(),
-        GrpcStatusFromProto(expect_grpc_status_));
+        EXPECT_EQ(ext_authz_logging_info->grpcStatus(), GrpcStatusFromProto(expect_grpc_status_));
       } else {
         EXPECT_FALSE(ext_authz_logging_info->grpcStatus().has_value());
       }
@@ -121,21 +124,20 @@ private:
   const bool expect_envoy_grpc_specific_stats_;
   const bool expect_response_bytes_;
   const absl::optional<ProtobufWkt::Struct> filter_metadata_;
+  // The gRPC status returned by the authorization server when it is making a gRPC call.
+  const LoggingTestFilterConfig::GrpcStatus expect_grpc_status_;
 };
 
-class LoggingTestFilterFactory : public Extensions::HttpFilters::Common::FactoryBase<
-                                     test::integration::filters::LoggingTestFilterConfig> {
+class LoggingTestFilterFactory
+    : public Extensions::HttpFilters::Common::FactoryBase<LoggingTestFilterConfig> {
 public:
   LoggingTestFilterFactory() : FactoryBase("logging-test-filter") {};
 
-  Http::FilterFactoryCb createFilterFactoryFromProtoTyped(
-      const test::integration::filters::LoggingTestFilterConfig& proto_config, const std::string&,
-      Server::Configuration::FactoryContext&) override {
+  Http::FilterFactoryCb
+  createFilterFactoryFromProtoTyped(const LoggingTestFilterConfig& proto_config, const std::string&,
+                                    Server::Configuration::FactoryContext&) override {
     return [=](Http::FilterChainFactoryCallbacks& callbacks) -> void {
-      callbacks.addStreamFilter(std::make_shared<LoggingTestFilter>(
-          proto_config.logging_id(), proto_config.upstream_cluster_name(),
-          proto_config.expect_stats(), proto_config.expect_envoy_grpc_specific_stats(),
-          proto_config.expect_response_bytes(), proto_config.filter_metadata()));
+      callbacks.addStreamFilter(std::make_shared<LoggingTestFilter>(proto_config));
     };
   }
 };

--- a/test/extensions/filters/http/ext_authz/logging_test_filter.proto
+++ b/test/extensions/filters/http/ext_authz/logging_test_filter.proto
@@ -11,4 +11,44 @@ message LoggingTestFilterConfig {
   bool expect_envoy_grpc_specific_stats = 4;
   bool expect_response_bytes = 5;
   google.protobuf.Struct filter_metadata = 6;
+
+  enum GrpcStatus {
+    // GRPC status is not specified.
+    UNSPECIFIED = 0;
+    // The RPC completed successfully.
+    OK = 1;
+    // The RPC was canceled.
+    CANCELLED = 2;
+    // Some unknown error occurred.
+    UNKNOWN = 3;
+    // An argument to the RPC was invalid.
+    INVALID_ARGUMENT = 4;
+    // The deadline for the RPC expired before the RPC completed.
+    DEADLINE_EXCEEDED = 5;
+    // Some resource for the RPC was not found.
+    NOT_FOUND = 6;
+    // A resource the RPC attempted to create already exists.
+    ALREADY_EXISTS = 7;
+    // Permission was denied for the RPC.
+    PERMISSION_DENIED = 8;
+    // Some resource is exhausted, resulting in RPC failure.
+    RESOURCE_EXHAUSTED = 9;
+    // Some precondition for the RPC failed.
+    FAILED_PRECONDITION = 10;
+    // The RPC was aborted.
+    ABORTED = 11;
+    // Some operation was requested outside of a legal range.
+    OUT_OF_RANGE = 12;
+    // The RPC requested was not implemented.
+    UNIMPLEMENTED = 13;
+    // Some internal error occurred.
+    INTERNAL = 14;
+    // The RPC endpoint is current unavailable.
+    UNAVAILABLE = 15;
+    // There was some data loss resulting in RPC failure.
+    DATA_LOSS = 16;
+    // The RPC does not have required credentials for the RPC to succeed.
+    UNAUTHENTICATED = 17;
+  }
+  GrpcStatus expect_grpc_status = 7;
 }


### PR DESCRIPTION
Commit Message: Add grpc status to ExtAuthzLoggingInfo in ext authz http filter
Additional Description: 
If the gRPC is used, there will be gRPC status available. Add grpc status to ExtAuthzLoggingInfo in ext authz http filter for logging purpose.

Risk Level: none
Testing: unit & integration tests
Docs Changes: none
Release Notes: changelog updated
Platform Specific Features: n/a
