### PR TITLE
refactor: setting some data members as const

### DIFF
--- a/envoy/runtime/runtime.h
+++ b/envoy/runtime/runtime.h
@@ -236,7 +236,7 @@ public:
    *         the calling routine, but may be overwritten on a future event loop cycle so should be
    *         fetched again when needed. This may only be called from worker threads.
    */
-  virtual const Snapshot& snapshot() PURE;
+  virtual const Snapshot& snapshot() const PURE;
 
   /**
    * @return shared_ptr<const Snapshot> the current snapshot. This function may safely be called

--- a/envoy/upstream/upstream.h
+++ b/envoy/upstream/upstream.h
@@ -1131,7 +1131,8 @@ public:
   /**
    * @return std::shared_ptr<UpstreamLocalAddressSelector> as upstream local address selector.
    */
-  virtual UpstreamLocalAddressSelectorConstSharedPtr getUpstreamLocalAddressSelector() const PURE;
+  virtual const UpstreamLocalAddressSelectorConstSharedPtr
+  getUpstreamLocalAddressSelector() const PURE;
 
   /**
    * @return const envoy::config::core::v3::Metadata& the configuration metadata for this cluster.

--- a/source/common/runtime/runtime_impl.cc
+++ b/source/common/runtime/runtime_impl.cc
@@ -666,7 +666,7 @@ absl::Status LoaderImpl::loadNewSnapshot() {
   return absl::OkStatus();
 }
 
-const Snapshot& LoaderImpl::snapshot() {
+const Snapshot& LoaderImpl::snapshot() const {
   ASSERT(tls_->currentThreadRegistered(),
          "snapshot can only be called from a worker thread or after the main thread is registered");
   return tls_->getTyped<Snapshot>();

--- a/source/common/runtime/runtime_impl.h
+++ b/source/common/runtime/runtime_impl.h
@@ -223,7 +223,7 @@ public:
 
   // Runtime::Loader
   absl::Status initialize(Upstream::ClusterManager& cm) override;
-  const Snapshot& snapshot() override;
+  const Snapshot& snapshot() const override;
   SnapshotConstSharedPtr threadsafeSnapshot() override;
   absl::Status mergeValues(const absl::node_hash_map<std::string, std::string>& values) override;
   void startRtdsSubscriptions(ReadyCallback on_done) override;

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -641,7 +641,7 @@ private:
                                         const LocalityWeights& locality_weights,
                                         uint32_t overprovisioning_factor);
 
-  uint32_t priority_;
+  const uint32_t priority_;
   uint32_t overprovisioning_factor_;
   bool weighted_priority_health_;
   HostVectorConstSharedPtr hosts_;
@@ -977,7 +977,8 @@ public:
 
   bool perEndpointStatsEnabled() const override { return per_endpoint_stats_; }
 
-  UpstreamLocalAddressSelectorConstSharedPtr getUpstreamLocalAddressSelector() const override {
+  const UpstreamLocalAddressSelectorConstSharedPtr
+  getUpstreamLocalAddressSelector() const override {
     return upstream_local_address_selector_;
   }
   using DefaultMetadata = ConstSingleton<envoy::config::core::v3::Metadata>;
@@ -1103,10 +1104,10 @@ private:
   ::Envoy::Http::HeaderValidatorStats& getHeaderValidatorStats(Http::Protocol protocol) const;
 #endif
 
-  Runtime::Loader& runtime_;
+  const Runtime::Loader& runtime_;
   const std::string name_;
-  std::unique_ptr<const std::string> observability_name_;
-  std::unique_ptr<const std::string> eds_service_name_;
+  const std::unique_ptr<const std::string> observability_name_;
+  const std::unique_ptr<const std::string> eds_service_name_;
   const absl::flat_hash_map<std::string, ProtocolOptionsConfigConstSharedPtr>
       extension_protocol_options_;
   const std::shared_ptr<const HttpProtocolOptionsConfigImpl> http_protocol_options_;
@@ -1128,15 +1129,15 @@ private:
   const uint64_t features_;
   mutable ResourceManagers resource_managers_;
   const std::string maintenance_mode_runtime_key_;
-  UpstreamLocalAddressSelectorConstSharedPtr upstream_local_address_selector_;
-  std::unique_ptr<envoy::config::core::v3::TypedExtensionConfig> upstream_config_;
-  std::unique_ptr<const envoy::config::core::v3::Metadata> metadata_;
-  std::unique_ptr<ClusterTypedMetadata> typed_metadata_;
+  const UpstreamLocalAddressSelectorConstSharedPtr upstream_local_address_selector_;
+  const std::unique_ptr<const envoy::config::core::v3::TypedExtensionConfig> upstream_config_;
+  const std::unique_ptr<const envoy::config::core::v3::Metadata> metadata_;
+  const std::unique_ptr<ClusterTypedMetadata> typed_metadata_;
   LoadBalancerConfigPtr load_balancer_config_;
   TypedLoadBalancerFactory* load_balancer_factory_ = nullptr;
   const std::shared_ptr<const envoy::config::cluster::v3::Cluster::CommonLbConfig>
       common_lb_config_;
-  std::unique_ptr<const envoy::config::cluster::v3::Cluster::CustomClusterType> cluster_type_;
+  const std::unique_ptr<const envoy::config::cluster::v3::Cluster::CustomClusterType> cluster_type_;
   // TODO(ohadvano): http_filter_config_provider_manager_ and
   // network_filter_config_provider_manager_ should be maintained in the ClusterManager object as
   // a singleton. This is currently not possible due to circular dependency (filter config
@@ -1152,9 +1153,10 @@ private:
   mutable Http::Http2::CodecStats::AtomicPtr http2_codec_stats_;
   mutable Http::Http3::CodecStats::AtomicPtr http3_codec_stats_;
   UpstreamFactoryContextImpl upstream_context_;
-  std::unique_ptr<envoy::config::cluster::v3::UpstreamConnectionOptions::HappyEyeballsConfig>
+  const std::unique_ptr<
+      const envoy::config::cluster::v3::UpstreamConnectionOptions::HappyEyeballsConfig>
       happy_eyeballs_config_;
-  const std::unique_ptr<Envoy::Orca::LrsReportMetricNames> lrs_report_metric_names_;
+  const std::unique_ptr<const Envoy::Orca::LrsReportMetricNames> lrs_report_metric_names_;
 
   // Keep small values like bools and enums at the end of the class to reduce
   // overhead via alignment

--- a/test/mocks/runtime/mocks.h
+++ b/test/mocks/runtime/mocks.h
@@ -62,7 +62,7 @@ public:
   ~MockLoader() override;
 
   MOCK_METHOD(absl::Status, initialize, (Upstream::ClusterManager & cm));
-  MOCK_METHOD(const Snapshot&, snapshot, ());
+  MOCK_METHOD(const Snapshot&, snapshot, (), (const));
   MOCK_METHOD(SnapshotConstSharedPtr, threadsafeSnapshot, ());
   MOCK_METHOD(absl::Status, mergeValues, ((const absl::node_hash_map<std::string, std::string>&)));
   MOCK_METHOD(void, startRtdsSubscriptions, (ReadyCallback));

--- a/test/mocks/upstream/cluster_info.h
+++ b/test/mocks/upstream/cluster_info.h
@@ -143,7 +143,7 @@ public:
   MOCK_METHOD(ClusterRequestResponseSizeStatsOptRef, requestResponseSizeStats, (), (const));
   MOCK_METHOD(ClusterTimeoutBudgetStatsOptRef, timeoutBudgetStats, (), (const));
   MOCK_METHOD(bool, perEndpointStatsEnabled, (), (const));
-  MOCK_METHOD(UpstreamLocalAddressSelectorConstSharedPtr, getUpstreamLocalAddressSelector, (),
+  MOCK_METHOD(const UpstreamLocalAddressSelectorConstSharedPtr, getUpstreamLocalAddressSelector, (),
               (const));
   MOCK_METHOD(const envoy::config::core::v3::Metadata&, metadata, (), (const));
   MOCK_METHOD(const Envoy::Config::TypedMetadata&, typedMetadata, (), (const));


### PR DESCRIPTION
Commit Message: refactor: setting some data members as const
Additional Description:
Internal cleanup. Some data members and methods should be declared as const.
This PR doesn't modify the intent, just adds `const` qualifiers in some cases.

Risk Level: low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A