### PR TITLE
Fix local FIPS builds of BoringSSL in Envoy

### DIFF
--- a/bazel/external/boringssl_fips.genrule_cmd
+++ b/bazel/external/boringssl_fips.genrule_cmd
@@ -60,6 +60,9 @@ fi
 for pem in $(ls ssl/test/runner/*.pem);
   do cp --dereference ${pem} tmp.pem; cp --remove-destination tmp.pem ${pem}; rm tmp.pem;
 done
+for data in $(ls ssl/test/runner/hpke/testdata/*);
+  do cp --dereference ${data} tmp; cp --remove-destination tmp ${data}; rm tmp;
+done
 
 # Ninja
 VERSION=1.10.2

--- a/bazel/external/boringssl_fips.genrule_cmd
+++ b/bazel/external/boringssl_fips.genrule_cmd
@@ -60,9 +60,9 @@ fi
 for pem in $(ls ssl/test/runner/*.pem);
   do cp --dereference ${pem} tmp.pem; cp --remove-destination tmp.pem ${pem}; rm tmp.pem;
 done
-for data in $(ls ssl/test/runner/hpke/testdata/*);
-  do cp --dereference ${data} tmp; cp --remove-destination tmp ${data}; rm tmp;
-done
+#for data in $(ls ssl/test/runner/hpke/testdata/*);
+#  do cp --dereference ${data} tmp; cp --remove-destination tmp ${data}; rm tmp;
+#done
 
 # Ninja
 VERSION=1.10.2

--- a/bazel/external/boringssl_fips.genrule_cmd
+++ b/bazel/external/boringssl_fips.genrule_cmd
@@ -60,9 +60,9 @@ fi
 for pem in $(ls ssl/test/runner/*.pem);
   do cp --dereference ${pem} tmp.pem; cp --remove-destination tmp.pem ${pem}; rm tmp.pem;
 done
-#for data in $(ls ssl/test/runner/hpke/testdata/*);
-#  do cp --dereference ${data} tmp; cp --remove-destination tmp ${data}; rm tmp;
-#done
+for testdata in $(ls ssl/test/runner/hpke/testdata/*.json);
+  do cp --dereference ${testdata} tmp.json; cp --remove-destination tmp.json ${testdata}; rm tmp.json;
+done
 
 # Ninja
 VERSION=1.10.2


### PR DESCRIPTION
Commit Message:

There is a bad interaction between Bazel and Go file embedding. Basically, Go file embedding does not allow embedding non-regular files (like symlinks), but when building things locally with Bazel it instead of copying all the required files into the directory where the action is executed creates symbolic links instead, which breaks Go.

We worked around known cases of this issue in the BoringSSL FIPS build script by copying files that we know are embedded and therefore will break Bazel build. However, after updating BoringSSL version it seems like we now have some new cases of this issues and this PR tries to address that.

NOTE: There was a proper workaround implemented for this on Go side that would not require us to play whackamole (
https://go-review.googlesource.com/c/go/+/647315), but it was only recently submitted and haven't made its way into Go release yet (probably the next Go release, 1.25 will have this included and we would be able to tell Go to follow symbolic links).

NOTE: There is also a way to tell Bazel to create hard links instead of symbolic links, but that comes with some caveats that I don't fully understand and therefore will not suggest.

Additional Description:

I hit this issue while working on #39160 to fix #39148, but other than that the issue seem to be unrelated.

I don't know for sure why this wasn't caught by the CI, but my guess here is that RBE builds (which is what our CI mostly does) are slightly different from plain local Bazel builds. My speculation is that where local Bazel would create a symlink, remote build backends will just create a proper copy and that's why this does not affect our CI.

What is certain is that Envoy CI does do FIPS builds (see https://github.com/envoyproxy/envoy/blob/4f7623416d1e20d05be43750034ce5e0365f51e3/.bazelrc#L386) and does not hit this issue, while local builds (`./ci/run_envoy_docker.sh './ci/do_ci.sh release.server_only'` with `--define boringssl=fips` in `user.bazelrc`) do hit this issue, so the issue is real and not a reasult of a development environment setup.

Risk Level: low
Testing: by building locally in FIPS mode.
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
