### PR TITLE
fuzzing: fix a fuzzers issue to support exceptions

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -458,6 +458,7 @@ build:asan-fuzzer --config=clang-asan
 build:asan-fuzzer --copt=-fno-omit-frame-pointer
 # Remove UBSAN halt_on_error to avoid crashing on protobuf errors.
 build:asan-fuzzer --test_env=UBSAN_OPTIONS=print_stacktrace=1
+build:asan-fuzzer --linkopt=-lc++
 
 build:oss-fuzz --config=fuzzing
 build:oss-fuzz --define=FUZZING_ENGINE=oss-fuzz


### PR DESCRIPTION
Commit Message: fuzzing: fix a fuzzers issue to support exceptions
Additional Description:
When trying to build and run fuzzers that may throw an exception (e.g., `bazel build //test/common/http:path_utility_fuzz_test --config=asan-fuzzer`) the following error occurs:
```
$ bazel-bin/test/common/http/path_utility_fuzz_test /tmp/corpus
INFO: found LLVMFuzzerCustomMutator (0x555ec3b27058). Disabling -len_control by default.
INFO: Running with entropic power schedule (0xFF, 100).
INFO: Seed: 3031084950
INFO: Loaded 1 modules   (2436830 inline 8-bit counters): 2436830 [0x555ecf049c40, 0x555ecf29cb1e),
INFO: Loaded 1 PC tables (2436830 PCs): 2436830 [0x555ecf29cb20,0x555ed17cb900),
INFO:        5 files found in /tmp/corpus
INFO: -max_len is not provided; libFuzzer will not generate inputs larger than 4096 bytes
INFO: seed corpus: files: 5 min: 91b max: 332b total: 1208b rss: 357Mb
libc++abi: terminating due to uncaught exception of type Envoy::EnvoyException
==3072858== ERROR: libFuzzer: deadly signal
    #0 0x555ec3ae0911 in __sanitizer_print_stack_trace (/usr/local/google/home/adip/.cache/bazel/_bazel_adip/8e88866af51670ff1222d99304421e7c/execroot/envoy/bazel-out/k8-fastbuild/bin/test/common/http/path_utility_fuzz_test+0xa49f911)
    #1 0x555ec39e56b8 in fuzzer::PrintStackTrace() cxa_noexception.cpp
    #2 0x555ec39c8a53 in fuzzer::Fuzzer::CrashCallback() cxa_noexception.cpp
    #3 0x7f5506763e1f  (/lib/x86_64-linux-gnu/libc.so.6+0x3fe1f) (BuildId: ea119b374e0f8f858c82ad03a9542414f9ea1c8c)
    #4 0x7f55067b7e5b in __pthread_kill_implementation nptl/pthread_kill.c:43:17
    #5 0x7f5506763d81 in raise signal/../sysdeps/posix/raise.c:26:13
    #6 0x7f550674c4ef in abort stdlib/abort.c:79:7
    #7 0x555ecc751905 in abort_message abort_message.cpp
    #8 0x555ecc751ae2 in demangling_terminate_handler() cxa_default_handlers.cpp
    #9 0x555ecc7519a2 in std::__terminate(void (*)()) cxa_handlers.cpp
    #10 0x555ecc750fd5 in __cxxabiv1::failed_throw(__cxxabiv1::__cxa_exception*) cxa_exception.cpp
    #11 0x555ecc750fbf in __cxa_throw (/usr/local/google/home/adip/.cache/bazel/_bazel_adip/8e88866af51670ff1222d99304421e7c/execroot/envoy/bazel-out/k8-fastbuild/bin/test/common/http/path_utility_fuzz_test+0x1310ffbf)
    #12 0x555ec97f5a1f in Envoy::ProtoExceptionUtil::throwProtoValidationException(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, google::protobuf::Message const&) (/usr/local/google/home/adip/.cache/bazel/_bazel_adip/8e88866af51670ff1222d99304421e7c/execroot/envoy/bazel-out/k8-fastbuild/bin/test/common/http/path_utility_fuzz_test+0x101b4a1f)
    #13 0x555ec3b87a1c in void Envoy::MessageUtil::validate<test::common::http::PathUtilityTestCase>(test::common::http::PathUtilityTestCase const&, Envoy::ProtobufMessage::ValidationVisitor&, bool) (/usr/local/google/home/adip/.cache/bazel/_bazel_adip/8e88866af51670ff1222d99304421e7c/execroot/envoy/bazel-out/k8-fastbuild/bin/test/common/http/path_utility_fuzz_test+0xa546a1c)
    #14 0x555ec3b277be in LLVMFuzzerTestOneInput (/usr/local/google/home/adip/.cache/bazel/_bazel_adip/8e88866af51670ff1222d99304421e7c/execroot/envoy/bazel-out/k8-fastbuild/bin/test/common/http/path_utility_fuzz_test+0xa4e67be)
    #15 0x555ec39c9f60 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) cxa_noexception.cpp
    #16 0x555ec39c9785 in fuzzer::Fuzzer::RunOne(unsigned char const*, unsigned long, bool, fuzzer::InputInfo*, bool, bool*) cxa_noexception.cpp
    #17 0x555ec39cb712 in fuzzer::Fuzzer::ReadAndExecuteSeedCorpora(std::__Fuzzer::vector<fuzzer::SizedFile, std::__Fuzzer::allocator<fuzzer::SizedFile>>&) cxa_noexception.cpp
    #18 0x555ec39cba02 in fuzzer::Fuzzer::Loop(std::__Fuzzer::vector<fuzzer::SizedFile, std::__Fuzzer::allocator<fuzzer::SizedFile>>&) cxa_noexception.cpp
    #19 0x555ec39b9eeb in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) cxa_noexception.cpp
    #20 0x555ec39e5f12 in main (/usr/local/google/home/adip/.cache/bazel/_bazel_adip/8e88866af51670ff1222d99304421e7c/execroot/envoy/bazel-out/k8-fastbuild/bin/test/common/http/path_utility_fuzz_test+0xa3a4f12)
    #21 0x7f550674dd67 in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #22 0x7f550674de24 in __libc_start_main csu/../csu/libc-start.c:360:3
    #23 0x555ec39ac720 in _start (/usr/local/google/home/adip/.cache/bazel/_bazel_adip/8e88866af51670ff1222d99304421e7c/execroot/envoy/bazel-out/k8-fastbuild/bin/test/common/http/path_utility_fuzz_test+0xa36b720)

NOTE: libFuzzer has rudimentary signal handlers.
      Combine libFuzzer with AddressSanitizer or similar for better crash reports.
SUMMARY: libFuzzer: deadly signal
```

This PR adds a linking flag to allow the fuzzers to properly handle exceptions.

Risk Level: low - fuzzers only
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
