### PR TITLE
Reverting EDFScheduler Build Method to Legacy Approach

### DIFF
--- a/source/extensions/load_balancing_policies/common/load_balancer_impl.cc
+++ b/source/extensions/load_balancing_policies/common/load_balancer_impl.cc
@@ -965,13 +965,30 @@ void EdfLoadBalancerBase::refresh(uint32_t priority) {
     // weighted 1. This is because currently we don't refresh host sets if only weights change.
     // We should probably change this to refresh at all times. See the comment in
     // BaseDynamicClusterImpl::updateDynamicHostList about this.
-    scheduler.edf_ = std::make_unique<EdfScheduler<Host>>(EdfScheduler<Host>::createWithPicks(
-        hosts,
-        // We use a fixed weight here. While the weight may change without
-        // notification, this will only be stale until this host is next picked,
-        // at which point it is reinserted into the EdfScheduler with its new
-        // weight in chooseHost().
-        [this](const Host& host) { return hostWeight(host); }, seed_));
+    scheduler.edf_ = std::make_unique<EdfScheduler<Host>>();
+
+    // Populate scheduler with host list.
+    // TODO(mattklein123): We must build the EDF schedule even if all of the hosts are currently
+    // weighted 1. This is because currently we don't refresh host sets if only weights change.
+    // We should probably change this to refresh at all times. See the comment in
+    // BaseDynamicClusterImpl::updateDynamicHostList about this.
+    for (const auto& host : hosts) {
+      // We use a fixed weight here. While the weight may change without
+      // notification, this will only be stale until this host is next picked,
+      // at which point it is reinserted into the EdfScheduler with its new
+      // weight in chooseHost().
+      scheduler.edf_->add(hostWeight(*host), host);
+    }
+
+    // Cycle through hosts to achieve the intended offset behavior.
+    // TODO(htuch): Consider how we can avoid biasing towards earlier hosts in the schedule across
+    // refreshes for the weighted case.
+    if (!hosts.empty()) {
+      for (uint32_t i = 0; i < seed_ % hosts.size(); ++i) {
+        auto host =
+            scheduler.edf_->pickAndAdd([this](const Host& host) { return hostWeight(host); });
+      }
+    }
   };
   // Populate EdfSchedulers for each valid HostsSource value for the host set at this priority.
   const auto& host_set = priority_set_.hostSetsPerPriority()[priority];


### PR DESCRIPTION
Commit Message: Reverting EDFScheduler Build Method to Legacy Approach
Fixes #Issue: https://github.com/envoyproxy/envoy/issues/38511
