### PR TITLE
context: replace transport socket context with generic context

### DIFF
--- a/contrib/tap_sinks/udp_sink/source/config.cc
+++ b/contrib/tap_sinks/udp_sink/source/config.cc
@@ -10,24 +10,14 @@ namespace Extensions {
 namespace TapSinks {
 namespace UDP {
 
-TapCommon::SinkPtr UdpTapSinkFactory::createTransportSinkPtr(
-    const Protobuf::Message& config,
-    Server::Configuration::TransportSocketFactoryContext& tsf_context) {
+TapCommon::SinkPtr
+UdpTapSinkFactory::createSinkPtr(const Protobuf::Message& config,
+                                 Server::Configuration::GenericFactoryContext& context) {
   ENVOY_LOG_MISC(trace, "{}: Create UDP sink in transport context", __func__);
   return std::make_unique<UdpTapSink>(
       MessageUtil::downcastAndValidate<
           const envoy::extensions::tap_sinks::udp_sink::v3alpha::UdpSink&>(
-          config, tsf_context.messageValidationVisitor()));
-}
-
-TapCommon::SinkPtr
-UdpTapSinkFactory::createHttpSinkPtr(const Protobuf::Message& config,
-                                     Server::Configuration::FactoryContext& http_context) {
-  ENVOY_LOG_MISC(trace, "{}: Create UDP sink in http context", __func__);
-  return std::make_unique<UdpTapSink>(
-      MessageUtil::downcastAndValidate<
-          const envoy::extensions::tap_sinks::udp_sink::v3alpha::UdpSink&>(
-          config, http_context.messageValidationVisitor()));
+          config, context.messageValidationVisitor()));
 }
 
 REGISTER_FACTORY(UdpTapSinkFactory, TapCommon::TapSinkFactory);

--- a/contrib/tap_sinks/udp_sink/source/config.h
+++ b/contrib/tap_sinks/udp_sink/source/config.h
@@ -19,11 +19,8 @@ public:
     return std::make_unique<envoy::extensions::tap_sinks::udp_sink::v3alpha::UdpSink>();
   }
   TapCommon::SinkPtr
-  createHttpSinkPtr(const Protobuf::Message& config,
-                    Server::Configuration::FactoryContext& http_context) override;
-  TapCommon::SinkPtr createTransportSinkPtr(
-      const Protobuf::Message& config,
-      Server::Configuration::TransportSocketFactoryContext& tsf_context) override;
+  createSinkPtr(const Protobuf::Message& config,
+                Server::Configuration::GenericFactoryContext& tsf_context) override;
 };
 
 } // namespace UDP

--- a/contrib/tap_sinks/udp_sink/source/udp_sink_impl.h
+++ b/contrib/tap_sinks/udp_sink/source/udp_sink_impl.h
@@ -20,7 +20,7 @@ namespace TapCommon = Extensions::Common::Tap;
 class UdpTapSink : public TapCommon::Sink {
 public:
   UdpTapSink(const envoy::extensions::tap_sinks::udp_sink::v3alpha::UdpSink& config);
-  ~UdpTapSink();
+  ~UdpTapSink() override;
 
   // Sink
   TapCommon::PerTapSinkHandlePtr

--- a/contrib/tap_sinks/udp_sink/test/udp_sink_config_test.cc
+++ b/contrib/tap_sinks/udp_sink/test/udp_sink_config_test.cc
@@ -30,14 +30,15 @@ namespace TapCommon = Extensions::Common::Tap;
 class TestConfigImpl : public TapCommon::TapConfigBaseImpl {
 public:
   TestConfigImpl(const envoy::config::tap::v3::TapConfig& proto_config,
-                 Extensions::Common::Tap::Sink* admin_streamer, TapCommon::SinkContext context)
+                 Extensions::Common::Tap::Sink* admin_streamer,
+                 Server::Configuration::GenericFactoryContext& context)
       : TapCommon::TapConfigBaseImpl(std::move(proto_config), admin_streamer, context) {}
 };
 
 class UdpTapSinkConfigTest : public testing::Test {
 protected:
-  UdpTapSinkConfigTest() {}
-  ~UdpTapSinkConfigTest() {}
+  UdpTapSinkConfigTest() = default;
+  ~UdpTapSinkConfigTest() override = default;
 };
 
 TEST_F(UdpTapSinkConfigTest, AddTestConfigHttpContextForUdpSink) {

--- a/envoy/secret/secret_manager.h
+++ b/envoy/secret/secret_manager.h
@@ -10,7 +10,8 @@ namespace Envoy {
 
 namespace Server {
 namespace Configuration {
-class TransportSocketFactoryContext;
+class GenericFactoryContext;
+using TransportSocketFactoryContext = GenericFactoryContext;
 } // namespace Configuration
 } // namespace Server
 

--- a/envoy/server/factory_context.h
+++ b/envoy/server/factory_context.h
@@ -260,12 +260,12 @@ public:
    * @return ServerFactoryContext which lifetime is no shorter than the server and provides
    *         access to the server's resources.
    */
-  virtual ServerFactoryContext& serverFactoryContext() const PURE;
+  virtual ServerFactoryContext& serverFactoryContext() PURE;
 
   /**
    * @return ProtobufMessage::ValidationVisitor& validation visitor for configuration messages.
    */
-  virtual ProtobufMessage::ValidationVisitor& messageValidationVisitor() const PURE;
+  virtual ProtobufMessage::ValidationVisitor& messageValidationVisitor() PURE;
 
   /**
    * @return Init::Manager& the init manager of the server/listener/cluster/etc, depending on the
@@ -278,6 +278,13 @@ public:
    *         backend implementation.
    */
   virtual Stats::Scope& scope() PURE;
+
+  /**
+   * @return Stats::Scope& the stats scope of the server/listener/cluster/etc, depending on the
+   *         backend implementation.
+   * TODO(wbpcode): move all scope() calling to this method.
+   */
+  virtual Stats::Scope& statsScope() { return scope(); }
 };
 
 /**
@@ -361,7 +368,7 @@ public:
   /**
    * @return ServerFactoryContext which lifetime is no shorter than the server.
    */
-  virtual ServerFactoryContext& serverFactoryContext() const PURE;
+  virtual ServerFactoryContext& serverFactoryContext() PURE;
 
   /**
    * @return the init manager of the particular context. This can be used for extensions that need

--- a/envoy/server/transport_socket_config.h
+++ b/envoy/server/transport_socket_config.h
@@ -22,35 +22,7 @@ namespace Envoy {
 namespace Server {
 namespace Configuration {
 
-/**
- * Context passed to transport socket factory to access server resources.
- */
-class TransportSocketFactoryContext {
-public:
-  virtual ~TransportSocketFactoryContext() = default;
-
-  /**
-   * @return ServerFactoryContext& the server factory context.
-   */
-  virtual ServerFactoryContext& serverFactoryContext() PURE;
-
-  /**
-   * @return ProtobufMessage::ValidationVisitor& validation visitor for cluster configuration
-   * messages.
-   */
-  virtual ProtobufMessage::ValidationVisitor& messageValidationVisitor() PURE;
-
-  /**
-   * @return Stats::Scope& the transport socket's stats scope.
-   */
-  virtual Stats::Scope& statsScope() PURE;
-
-  /**
-   * @return the init manager of the particular context.
-   */
-  virtual Init::Manager& initManager() PURE;
-};
-
+using TransportSocketFactoryContext = GenericFactoryContext;
 using TransportSocketFactoryContextPtr = std::unique_ptr<TransportSocketFactoryContext>;
 
 class TransportSocketConfigFactory : public Config::TypedFactory {

--- a/envoy/ssl/private_key/private_key.h
+++ b/envoy/ssl/private_key/private_key.h
@@ -14,7 +14,8 @@ namespace Envoy {
 namespace Server {
 namespace Configuration {
 // Prevent a dependency loop with the forward declaration.
-class TransportSocketFactoryContext;
+class GenericFactoryContext;
+using TransportSocketFactoryContext = GenericFactoryContext;
 } // namespace Configuration
 } // namespace Server
 

--- a/source/common/listener_manager/filter_chain_manager_impl.cc
+++ b/source/common/listener_manager/filter_chain_manager_impl.cc
@@ -92,15 +92,13 @@ const Network::ListenerInfo& PerFilterChainFactoryContextImpl::listenerInfo() co
   return parent_context_.listenerInfo();
 }
 
-ProtobufMessage::ValidationVisitor&
-PerFilterChainFactoryContextImpl::messageValidationVisitor() const {
+ProtobufMessage::ValidationVisitor& PerFilterChainFactoryContextImpl::messageValidationVisitor() {
   return parent_context_.messageValidationVisitor();
 }
 
 Stats::Scope& PerFilterChainFactoryContextImpl::scope() { return *scope_; }
 
-Configuration::ServerFactoryContext&
-PerFilterChainFactoryContextImpl::serverFactoryContext() const {
+Configuration::ServerFactoryContext& PerFilterChainFactoryContextImpl::serverFactoryContext() {
   return parent_context_.serverFactoryContext();
 }
 

--- a/source/common/listener_manager/filter_chain_manager_impl.h
+++ b/source/common/listener_manager/filter_chain_manager_impl.h
@@ -63,8 +63,8 @@ public:
   Init::Manager& initManager() override;
   Stats::Scope& scope() override;
   const Network::ListenerInfo& listenerInfo() const override;
-  ProtobufMessage::ValidationVisitor& messageValidationVisitor() const override;
-  Configuration::ServerFactoryContext& serverFactoryContext() const override;
+  ProtobufMessage::ValidationVisitor& messageValidationVisitor() override;
+  Configuration::ServerFactoryContext& serverFactoryContext() override;
   Configuration::TransportSocketFactoryContext& getTransportSocketFactoryContext() const override;
   Stats::Scope& listenerScope() override;
 

--- a/source/common/listener_manager/listener_impl.cc
+++ b/source/common/listener_manager/listener_impl.cc
@@ -923,11 +923,10 @@ const Network::ListenerInfo& PerListenerFactoryContextImpl::listenerInfo() const
   return listener_factory_context_base_->listenerInfo();
 }
 
-ProtobufMessage::ValidationVisitor&
-PerListenerFactoryContextImpl::messageValidationVisitor() const {
+ProtobufMessage::ValidationVisitor& PerListenerFactoryContextImpl::messageValidationVisitor() {
   return listener_factory_context_base_->messageValidationVisitor();
 }
-Configuration::ServerFactoryContext& PerListenerFactoryContextImpl::serverFactoryContext() const {
+Configuration::ServerFactoryContext& PerListenerFactoryContextImpl::serverFactoryContext() {
   return listener_factory_context_base_->serverFactoryContext();
 }
 Configuration::TransportSocketFactoryContext&

--- a/source/common/listener_manager/listener_impl.h
+++ b/source/common/listener_manager/listener_impl.h
@@ -180,8 +180,8 @@ public:
   Init::Manager& initManager() override;
   Stats::Scope& scope() override;
   const Network::ListenerInfo& listenerInfo() const override;
-  ProtobufMessage::ValidationVisitor& messageValidationVisitor() const override;
-  Configuration::ServerFactoryContext& serverFactoryContext() const override;
+  ProtobufMessage::ValidationVisitor& messageValidationVisitor() override;
+  Configuration::ServerFactoryContext& serverFactoryContext() override;
   Configuration::TransportSocketFactoryContext& getTransportSocketFactoryContext() const override;
 
   Stats::Scope& listenerScope() override;

--- a/source/common/listener_manager/listener_manager_impl.h
+++ b/source/common/listener_manager/listener_manager_impl.h
@@ -32,7 +32,7 @@ namespace Envoy {
 namespace Server {
 
 namespace Configuration {
-class TransportSocketFactoryContextImpl;
+using TransportSocketFactoryContextImpl = Server::GenericFactoryContextImpl;
 }
 
 class ListenerFilterChainFactoryBuilder;

--- a/source/common/upstream/upstream_factory_context_impl.h
+++ b/source/common/upstream/upstream_factory_context_impl.h
@@ -17,7 +17,7 @@ public:
                              Init::Manager& init_manager, Stats::Scope& scope)
       : server_context_(context), init_manager_(init_manager), scope_(scope) {}
 
-  Server::Configuration::ServerFactoryContext& serverFactoryContext() const override {
+  Server::Configuration::ServerFactoryContext& serverFactoryContext() override {
     return server_context_;
   }
 

--- a/source/extensions/common/tap/tap.h
+++ b/source/extensions/common/tap/tap.h
@@ -77,9 +77,6 @@ public:
 };
 
 using SinkPtr = std::unique_ptr<Sink>;
-using SinkContext =
-    absl::variant<std::reference_wrapper<Server::Configuration::FactoryContext>,
-                  std::reference_wrapper<Server::Configuration::TransportSocketFactoryContext>>;
 
 /**
  * Abstract tap sink factory. Produces a factory that can instantiate SinkPtr objects
@@ -94,16 +91,8 @@ public:
    * @param config supplies the protobuf configuration for the sink factory
    * @param  http_context supplies HTTP context
    */
-  virtual SinkPtr createHttpSinkPtr(const Protobuf::Message& config,
-                                    Server::Configuration::FactoryContext& http_context) PURE;
-  /**
-   * Create a Sink that can be used for writing out data produced by the tap filter.
-   * @param config supplies the protobuf configuration for the sink factory
-   * @param tsf_context supplies the transport socket context
-   */
-  virtual SinkPtr
-  createTransportSinkPtr(const Protobuf::Message& config,
-                         Server::Configuration::TransportSocketFactoryContext& tsf_context) PURE;
+  virtual SinkPtr createSinkPtr(const Protobuf::Message& config,
+                                Server::Configuration::GenericFactoryContext& http_context) PURE;
 };
 
 using TapSinkFactoryPtr = std::unique_ptr<TapSinkFactory>;

--- a/source/extensions/common/tap/tap_config_base.cc
+++ b/source/extensions/common/tap/tap_config_base.cc
@@ -47,16 +47,14 @@ bool Utility::addBufferToProtoBytes(envoy::data::tap::v3::Body& output_body,
 }
 
 TapConfigBaseImpl::TapConfigBaseImpl(const envoy::config::tap::v3::TapConfig& proto_config,
-                                     Common::Tap::Sink* admin_streamer, SinkContext context)
+                                     Common::Tap::Sink* admin_streamer,
+                                     Server::Configuration::GenericFactoryContext& context)
     : max_buffered_rx_bytes_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(
           proto_config.output_config(), max_buffered_rx_bytes, DefaultMaxBufferedBytes)),
       max_buffered_tx_bytes_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(
           proto_config.output_config(), max_buffered_tx_bytes, DefaultMaxBufferedBytes)),
       streaming_(proto_config.output_config().streaming()) {
 
-  using TsfContextRef =
-      std::reference_wrapper<Server::Configuration::TransportSocketFactoryContext>;
-  using HttpContextRef = std::reference_wrapper<Server::Configuration::FactoryContext>;
   using ProtoOutputSink = envoy::config::tap::v3::OutputSink;
   auto& sinks = proto_config.output_config().sinks();
   ASSERT(sinks.size() == 1);
@@ -103,24 +101,10 @@ TapConfigBaseImpl::TapConfigBaseImpl(const envoy::config::tap::v3::TapConfig& pr
         Envoy::Config::Utility::getAndCheckFactory<TapSinkFactory>(sinks[0].custom_sink());
 
     // extract message validation visitor from the context and use it to define config
-    ProtobufTypes::MessagePtr config;
-    if (absl::holds_alternative<TsfContextRef>(context)) {
-      Server::Configuration::TransportSocketFactoryContext& tsf_context =
-          absl::get<TsfContextRef>(context).get();
-      config = Config::Utility::translateAnyToFactoryConfig(sinks[0].custom_sink().typed_config(),
-                                                            tsf_context.messageValidationVisitor(),
-                                                            tap_sink_factory);
-      sink_ = tap_sink_factory.createTransportSinkPtr(*config, tsf_context);
-    } else {
-      Server::Configuration::FactoryContext& http_context =
-          absl::get<HttpContextRef>(context).get();
-      config = Config::Utility::translateAnyToFactoryConfig(
-          sinks[0].custom_sink().typed_config(),
-          http_context.serverFactoryContext().messageValidationContext().staticValidationVisitor(),
-          tap_sink_factory);
-      sink_ = tap_sink_factory.createHttpSinkPtr(*config, http_context);
-    }
-
+    ProtobufTypes::MessagePtr config = Config::Utility::translateAnyToFactoryConfig(
+        sinks[0].custom_sink().typed_config(), context.messageValidationVisitor(),
+        tap_sink_factory);
+    sink_ = tap_sink_factory.createSinkPtr(*config, context);
     sink_to_use_ = sink_.get();
     break;
   }
@@ -148,16 +132,7 @@ TapConfigBaseImpl::TapConfigBaseImpl(const envoy::config::tap::v3::TapConfig& pr
                                      proto_config.DebugString()));
   }
 
-  Server::Configuration::CommonFactoryContext* server_context = nullptr;
-  if (absl::holds_alternative<TsfContextRef>(context)) {
-    Server::Configuration::TransportSocketFactoryContext& tsf_context =
-        absl::get<TsfContextRef>(context).get();
-    server_context = &tsf_context.serverFactoryContext();
-  } else {
-    Server::Configuration::FactoryContext& http_context = absl::get<HttpContextRef>(context).get();
-    server_context = &http_context.serverFactoryContext();
-  }
-  buildMatcher(match, matchers_, *server_context);
+  buildMatcher(match, matchers_, context.serverFactoryContext());
 }
 
 const Matcher& TapConfigBaseImpl::rootMatcher() const {

--- a/source/extensions/common/tap/tap_config_base.cc
+++ b/source/extensions/common/tap/tap_config_base.cc
@@ -221,8 +221,8 @@ void FilePerTapSink::FilePerTapSinkHandle::submitTrace(
     case envoy::config::tap::v3::OutputSink::PROTO_TEXT:
       path += MessageUtil::FileExtensions::get().ProtoText;
       break;
-    case envoy::config::tap::v3::OutputSink::JSON_BODY_AS_BYTES:
     case envoy::config::tap::v3::OutputSink::JSON_BODY_AS_STRING:
+    case envoy::config::tap::v3::OutputSink::JSON_BODY_AS_BYTES:
       path += MessageUtil::FileExtensions::get().Json;
       break;
     }
@@ -250,8 +250,8 @@ void FilePerTapSink::FilePerTapSinkHandle::submitTrace(
   case envoy::config::tap::v3::OutputSink::PROTO_TEXT:
     output_file_ << MessageUtil::toTextProto(*trace);
     break;
-  case envoy::config::tap::v3::OutputSink::JSON_BODY_AS_BYTES:
   case envoy::config::tap::v3::OutputSink::JSON_BODY_AS_STRING:
+  case envoy::config::tap::v3::OutputSink::JSON_BODY_AS_BYTES:
     output_file_ << MessageUtil::getJsonStringFromMessageOrError(*trace, true, true);
     break;
   }

--- a/source/extensions/common/tap/tap_config_base.h
+++ b/source/extensions/common/tap/tap_config_base.h
@@ -103,7 +103,8 @@ public:
 
 protected:
   TapConfigBaseImpl(const envoy::config::tap::v3::TapConfig& proto_config,
-                    Common::Tap::Sink* admin_streamer, SinkContext context);
+                    Common::Tap::Sink* admin_streamer,
+                    Server::Configuration::GenericFactoryContext& context);
 
 private:
   // This is the default setting for both RX/TX max buffered bytes. (This means that per tap, the

--- a/source/server/BUILD
+++ b/source/server/BUILD
@@ -525,6 +525,7 @@ envoy_cc_library(
     name = "transport_socket_config_lib",
     hdrs = ["transport_socket_config_impl.h"],
     deps = [
+        ":generic_factory_context_lib",
         "//envoy/server:transport_socket_config_interface",
     ],
 )

--- a/source/server/factory_context_impl.cc
+++ b/source/server/factory_context_impl.cc
@@ -12,11 +12,11 @@ FactoryContextImplBase::FactoryContextImplBase(
   ASSERT(listener_info_ != nullptr);
 }
 
-Configuration::ServerFactoryContext& FactoryContextImplBase::serverFactoryContext() const {
+Configuration::ServerFactoryContext& FactoryContextImplBase::serverFactoryContext() {
   return server_.serverFactoryContext();
 }
 
-ProtobufMessage::ValidationVisitor& FactoryContextImplBase::messageValidationVisitor() const {
+ProtobufMessage::ValidationVisitor& FactoryContextImplBase::messageValidationVisitor() {
   return validation_visitor_;
 }
 

--- a/source/server/factory_context_impl.h
+++ b/source/server/factory_context_impl.h
@@ -16,9 +16,9 @@ public:
                          const Network::ListenerInfoConstSharedPtr& listener_info);
 
   // Configuration::FactoryContext
-  Configuration::ServerFactoryContext& serverFactoryContext() const override;
+  Configuration::ServerFactoryContext& serverFactoryContext() override;
   Stats::Scope& scope() override;
-  ProtobufMessage::ValidationVisitor& messageValidationVisitor() const override;
+  ProtobufMessage::ValidationVisitor& messageValidationVisitor() override;
   Configuration::TransportSocketFactoryContext& getTransportSocketFactoryContext() const override;
   const Network::ListenerInfo& listenerInfo() const override;
 

--- a/source/server/generic_factory_context.cc
+++ b/source/server/generic_factory_context.cc
@@ -6,26 +6,29 @@ namespace Server {
 GenericFactoryContextImpl::GenericFactoryContextImpl(
     Server::Configuration::ServerFactoryContext& server_context,
     ProtobufMessage::ValidationVisitor& validation_visitor)
-    : server_context_(server_context), validation_visitor_(validation_visitor),
-      scope_(server_context.serverScope()), init_manager_(server_context.initManager()) {}
+    : server_context_(server_context), stats_scope_(server_context.serverScope()),
+      validation_visitor_(validation_visitor), init_manager_(&server_context.initManager()) {}
 
 GenericFactoryContextImpl::GenericFactoryContextImpl(
     Server::Configuration::GenericFactoryContext& generic_context)
     : server_context_(generic_context.serverFactoryContext()),
+      stats_scope_(generic_context.scope()),
       validation_visitor_(generic_context.messageValidationVisitor()),
-      scope_(generic_context.scope()), init_manager_(generic_context.initManager()) {}
+      init_manager_(&generic_context.initManager()) {}
 
 // Server::Configuration::GenericFactoryContext
-Server::Configuration::ServerFactoryContext&
-GenericFactoryContextImpl::serverFactoryContext() const {
+Server::Configuration::ServerFactoryContext& GenericFactoryContextImpl::serverFactoryContext() {
   return server_context_;
 }
-ProtobufMessage::ValidationVisitor& GenericFactoryContextImpl::messageValidationVisitor() const {
+ProtobufMessage::ValidationVisitor& GenericFactoryContextImpl::messageValidationVisitor() {
   return validation_visitor_;
 }
 
-Stats::Scope& GenericFactoryContextImpl::scope() { return scope_; }
-Init::Manager& GenericFactoryContextImpl::initManager() { return init_manager_; }
+Stats::Scope& GenericFactoryContextImpl::scope() { return stats_scope_; }
+Init::Manager& GenericFactoryContextImpl::initManager() {
+  ASSERT(init_manager_ != nullptr);
+  return *init_manager_;
+}
 
 } // namespace Server
 } // namespace Envoy

--- a/source/server/generic_factory_context.h
+++ b/source/server/generic_factory_context.h
@@ -11,18 +11,29 @@ public:
                             ProtobufMessage::ValidationVisitor& validation_visitor);
   GenericFactoryContextImpl(Server::Configuration::GenericFactoryContext& generic_context);
 
+  GenericFactoryContextImpl(Server::Configuration::ServerFactoryContext& server_context,
+                            Stats::Scope& stats_scope,
+                            ProtobufMessage::ValidationVisitor& validation_visitor,
+                            Init::Manager* init_manager = nullptr)
+      : server_context_(server_context), stats_scope_(stats_scope),
+        validation_visitor_(validation_visitor), init_manager_(init_manager) {}
+
   // Server::Configuration::GenericFactoryContext
-  Server::Configuration::ServerFactoryContext& serverFactoryContext() const override;
-  ProtobufMessage::ValidationVisitor& messageValidationVisitor() const override;
+  Server::Configuration::ServerFactoryContext& serverFactoryContext() override;
   Stats::Scope& scope() override;
+  ProtobufMessage::ValidationVisitor& messageValidationVisitor() override;
   Init::Manager& initManager() override;
+
+  void setInitManager(Init::Manager& init_manager) { init_manager_ = &init_manager; }
 
 private:
   Server::Configuration::ServerFactoryContext& server_context_;
+  Stats::Scope& stats_scope_;
   ProtobufMessage::ValidationVisitor& validation_visitor_;
-  Stats::Scope& scope_;
-  Init::Manager& init_manager_;
+  Init::Manager* init_manager_{};
 };
+
+using GenericFactoryContextImplPtr = std::unique_ptr<GenericFactoryContextImpl>;
 
 } // namespace Server
 } // namespace Envoy

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -188,7 +188,7 @@ public:
   ProtobufMessage::ValidationContext& messageValidationContext() override {
     return server_.messageValidationContext();
   }
-  TransportSocketFactoryContext& getTransportSocketFactoryContext() const override {
+  Configuration::TransportSocketFactoryContext& getTransportSocketFactoryContext() const override {
     return server_.transportSocketFactoryContext();
   };
   Envoy::Runtime::Loader& runtime() override { return server_.runtime(); }

--- a/source/server/transport_socket_config_impl.h
+++ b/source/server/transport_socket_config_impl.h
@@ -1,48 +1,14 @@
 #pragma once
 
 #include "envoy/server/transport_socket_config.h"
-#include "envoy/stats/scope.h"
+
+#include "source/server/generic_factory_context.h"
 
 namespace Envoy {
 namespace Server {
 namespace Configuration {
 
-/**
- * Implementation of TransportSocketFactoryContext.
- */
-class TransportSocketFactoryContextImpl : public TransportSocketFactoryContext {
-public:
-  TransportSocketFactoryContextImpl(Server::Configuration::ServerFactoryContext& server_context,
-                                    Stats::Scope& stats_scope,
-                                    ProtobufMessage::ValidationVisitor& validation_visitor)
-      : server_context_(server_context), stats_scope_(stats_scope),
-        validation_visitor_(validation_visitor) {}
-
-  /**
-   * Pass an init manager to register dynamic secret provider.
-   * @param init_manager instance of init manager.
-   */
-  void setInitManager(Init::Manager& init_manager) { init_manager_ = &init_manager; }
-
-  // TransportSocketFactoryContext
-  ServerFactoryContext& serverFactoryContext() override { return server_context_; }
-  ProtobufMessage::ValidationVisitor& messageValidationVisitor() override {
-    return validation_visitor_;
-  }
-  Stats::Scope& statsScope() override { return stats_scope_; }
-  Init::Manager& initManager() override {
-    ASSERT(init_manager_ != nullptr);
-    return *init_manager_;
-  }
-
-private:
-  Server::Configuration::ServerFactoryContext& server_context_;
-  Stats::Scope& stats_scope_;
-  ProtobufMessage::ValidationVisitor& validation_visitor_;
-
-  Init::Manager* init_manager_{};
-};
-
+using TransportSocketFactoryContextImpl = GenericFactoryContextImpl;
 using TransportSocketFactoryContextImplPtr = std::unique_ptr<TransportSocketFactoryContextImpl>;
 
 } // namespace Configuration

--- a/test/extensions/common/dynamic_forward_proxy/dns_cache_impl_test.cc
+++ b/test/extensions/common/dynamic_forward_proxy/dns_cache_impl_test.cc
@@ -53,8 +53,7 @@ public:
       }
     }
 
-    EXPECT_CALL(context_.server_factory_context_.dispatcher_, isThreadSafe)
-        .WillRepeatedly(Return(true));
+    EXPECT_CALL(context_.server_context_.dispatcher_, isThreadSafe).WillRepeatedly(Return(true));
 
     EXPECT_CALL(dns_resolver_factory_, createDnsResolver(_, _, _))
         .WillRepeatedly(Return(resolver_));
@@ -207,10 +206,8 @@ TEST_F(DnsCacheImplTest, ResolveSuccess) {
 
   MockLoadDnsCacheEntryCallbacks callbacks;
   Network::DnsResolver::ResolveCb resolve_cb;
-  Event::MockTimer* resolve_timer =
-      new Event::MockTimer(&context_.server_factory_context_.dispatcher_);
-  Event::MockTimer* timeout_timer =
-      new Event::MockTimer(&context_.server_factory_context_.dispatcher_);
+  Event::MockTimer* resolve_timer = new Event::MockTimer(&context_.server_context_.dispatcher_);
+  Event::MockTimer* timeout_timer = new Event::MockTimer(&context_.server_context_.dispatcher_);
   EXPECT_CALL(*timeout_timer, enableTimer(std::chrono::milliseconds(5000), nullptr));
   EXPECT_CALL(*resolver_, resolve("foo.com", _, _))
       .WillOnce(DoAll(SaveArg<2>(&resolve_cb), Return(&resolver_->active_query_)));
@@ -300,10 +297,8 @@ TEST_F(DnsCacheImplTest, ForceRefresh) {
 
   MockLoadDnsCacheEntryCallbacks callbacks;
   Network::DnsResolver::ResolveCb resolve_cb;
-  Event::MockTimer* resolve_timer =
-      new Event::MockTimer(&context_.server_factory_context_.dispatcher_);
-  Event::MockTimer* timeout_timer =
-      new Event::MockTimer(&context_.server_factory_context_.dispatcher_);
+  Event::MockTimer* resolve_timer = new Event::MockTimer(&context_.server_context_.dispatcher_);
+  Event::MockTimer* timeout_timer = new Event::MockTimer(&context_.server_context_.dispatcher_);
   EXPECT_CALL(*timeout_timer, enableTimer(std::chrono::milliseconds(5000), nullptr));
   EXPECT_CALL(*resolver_, resolve("foo.com", _, _))
       .WillOnce(DoAll(SaveArg<2>(&resolve_cb), Return(&resolver_->active_query_)));
@@ -339,10 +334,8 @@ TEST_F(DnsCacheImplTest, Stop) {
 
   MockLoadDnsCacheEntryCallbacks callbacks;
   Network::DnsResolver::ResolveCb resolve_cb;
-  Event::MockTimer* resolve_timer =
-      new Event::MockTimer(&context_.server_factory_context_.dispatcher_);
-  Event::MockTimer* timeout_timer =
-      new Event::MockTimer(&context_.server_factory_context_.dispatcher_);
+  Event::MockTimer* resolve_timer = new Event::MockTimer(&context_.server_context_.dispatcher_);
+  Event::MockTimer* timeout_timer = new Event::MockTimer(&context_.server_context_.dispatcher_);
   EXPECT_CALL(*timeout_timer, enableTimer(std::chrono::milliseconds(5000), nullptr));
   EXPECT_CALL(*resolver_, resolve("foo.com", _, _))
       .WillOnce(DoAll(SaveArg<2>(&resolve_cb), Return(&resolver_->active_query_)));
@@ -373,10 +366,8 @@ TEST_F(DnsCacheImplTest, Ipv4Address) {
 
   MockLoadDnsCacheEntryCallbacks callbacks;
   Network::DnsResolver::ResolveCb resolve_cb;
-  Event::MockTimer* resolve_timer =
-      new Event::MockTimer(&context_.server_factory_context_.dispatcher_);
-  Event::MockTimer* timeout_timer =
-      new Event::MockTimer(&context_.server_factory_context_.dispatcher_);
+  Event::MockTimer* resolve_timer = new Event::MockTimer(&context_.server_context_.dispatcher_);
+  Event::MockTimer* timeout_timer = new Event::MockTimer(&context_.server_context_.dispatcher_);
   EXPECT_CALL(*timeout_timer, enableTimer(std::chrono::milliseconds(5000), nullptr));
   EXPECT_CALL(*resolver_, resolve("127.0.0.1", _, _))
       .WillOnce(DoAll(SaveArg<2>(&resolve_cb), Return(&resolver_->active_query_)));
@@ -407,10 +398,8 @@ TEST_F(DnsCacheImplTest, Ipv4AddressWithPort) {
 
   MockLoadDnsCacheEntryCallbacks callbacks;
   Network::DnsResolver::ResolveCb resolve_cb;
-  Event::MockTimer* resolve_timer =
-      new Event::MockTimer(&context_.server_factory_context_.dispatcher_);
-  Event::MockTimer* timeout_timer =
-      new Event::MockTimer(&context_.server_factory_context_.dispatcher_);
+  Event::MockTimer* resolve_timer = new Event::MockTimer(&context_.server_context_.dispatcher_);
+  Event::MockTimer* timeout_timer = new Event::MockTimer(&context_.server_context_.dispatcher_);
   EXPECT_CALL(*timeout_timer, enableTimer(std::chrono::milliseconds(5000), nullptr));
   EXPECT_CALL(*resolver_, resolve("127.0.0.1", _, _))
       .WillOnce(DoAll(SaveArg<2>(&resolve_cb), Return(&resolver_->active_query_)));
@@ -441,10 +430,8 @@ TEST_F(DnsCacheImplTest, Ipv6Address) {
 
   MockLoadDnsCacheEntryCallbacks callbacks;
   Network::DnsResolver::ResolveCb resolve_cb;
-  Event::MockTimer* resolve_timer =
-      new Event::MockTimer(&context_.server_factory_context_.dispatcher_);
-  Event::MockTimer* timeout_timer =
-      new Event::MockTimer(&context_.server_factory_context_.dispatcher_);
+  Event::MockTimer* resolve_timer = new Event::MockTimer(&context_.server_context_.dispatcher_);
+  Event::MockTimer* timeout_timer = new Event::MockTimer(&context_.server_context_.dispatcher_);
   EXPECT_CALL(*timeout_timer, enableTimer(std::chrono::milliseconds(5000), nullptr));
   EXPECT_CALL(*resolver_, resolve("::1", _, _))
       .WillOnce(DoAll(SaveArg<2>(&resolve_cb), Return(&resolver_->active_query_)));
@@ -472,10 +459,8 @@ TEST_F(DnsCacheImplTest, Ipv6AddressWithPort) {
 
   MockLoadDnsCacheEntryCallbacks callbacks;
   Network::DnsResolver::ResolveCb resolve_cb;
-  Event::MockTimer* resolve_timer =
-      new Event::MockTimer(&context_.server_factory_context_.dispatcher_);
-  Event::MockTimer* timeout_timer =
-      new Event::MockTimer(&context_.server_factory_context_.dispatcher_);
+  Event::MockTimer* resolve_timer = new Event::MockTimer(&context_.server_context_.dispatcher_);
+  Event::MockTimer* timeout_timer = new Event::MockTimer(&context_.server_context_.dispatcher_);
   EXPECT_CALL(*timeout_timer, enableTimer(std::chrono::milliseconds(5000), nullptr));
   EXPECT_CALL(*resolver_, resolve("::1", _, _))
       .WillOnce(DoAll(SaveArg<2>(&resolve_cb), Return(&resolver_->active_query_)));
@@ -503,10 +488,8 @@ TEST_F(DnsCacheImplTest, TTL) {
 
   MockLoadDnsCacheEntryCallbacks callbacks;
   Network::DnsResolver::ResolveCb resolve_cb;
-  Event::MockTimer* resolve_timer =
-      new Event::MockTimer(&context_.server_factory_context_.dispatcher_);
-  Event::MockTimer* timeout_timer =
-      new Event::MockTimer(&context_.server_factory_context_.dispatcher_);
+  Event::MockTimer* resolve_timer = new Event::MockTimer(&context_.server_context_.dispatcher_);
+  Event::MockTimer* timeout_timer = new Event::MockTimer(&context_.server_context_.dispatcher_);
   EXPECT_CALL(*timeout_timer, enableTimer(std::chrono::milliseconds(5000), nullptr));
   EXPECT_CALL(*resolver_, resolve("foo.com", _, _))
       .WillOnce(DoAll(SaveArg<2>(&resolve_cb), Return(&resolver_->active_query_)));
@@ -564,8 +547,8 @@ TEST_F(DnsCacheImplTest, TTL) {
              1 /* added */, 1 /* removed */, 0 /* num hosts */);
 
   // Make sure we don't get a cache hit the next time the host is requested.
-  new Event::MockTimer(&context_.server_factory_context_.dispatcher_); // resolve_timer
-  timeout_timer = new Event::MockTimer(&context_.server_factory_context_.dispatcher_);
+  new Event::MockTimer(&context_.server_context_.dispatcher_); // resolve_timer
+  timeout_timer = new Event::MockTimer(&context_.server_context_.dispatcher_);
   EXPECT_CALL(*timeout_timer, enableTimer(std::chrono::milliseconds(5000), nullptr));
   EXPECT_CALL(*resolver_, resolve("foo.com", _, _))
       .WillOnce(DoAll(SaveArg<2>(&resolve_cb), Return(&resolver_->active_query_)));
@@ -585,10 +568,8 @@ TEST_F(DnsCacheImplTest, TTLWithMinRefreshRate) {
 
   MockLoadDnsCacheEntryCallbacks callbacks;
   Network::DnsResolver::ResolveCb resolve_cb;
-  Event::MockTimer* resolve_timer =
-      new Event::MockTimer(&context_.server_factory_context_.dispatcher_);
-  Event::MockTimer* timeout_timer =
-      new Event::MockTimer(&context_.server_factory_context_.dispatcher_);
+  Event::MockTimer* resolve_timer = new Event::MockTimer(&context_.server_context_.dispatcher_);
+  Event::MockTimer* timeout_timer = new Event::MockTimer(&context_.server_context_.dispatcher_);
   EXPECT_CALL(*timeout_timer, enableTimer(std::chrono::milliseconds(5000), nullptr));
   EXPECT_CALL(*resolver_, resolve("foo.com", _, _))
       .WillOnce(DoAll(SaveArg<2>(&resolve_cb), Return(&resolver_->active_query_)));
@@ -622,10 +603,8 @@ TEST_F(DnsCacheImplTest, TTLWithCustomParameters) {
 
   MockLoadDnsCacheEntryCallbacks callbacks;
   Network::DnsResolver::ResolveCb resolve_cb;
-  Event::MockTimer* resolve_timer =
-      new Event::MockTimer(&context_.server_factory_context_.dispatcher_);
-  Event::MockTimer* timeout_timer =
-      new Event::MockTimer(&context_.server_factory_context_.dispatcher_);
+  Event::MockTimer* resolve_timer = new Event::MockTimer(&context_.server_context_.dispatcher_);
+  Event::MockTimer* timeout_timer = new Event::MockTimer(&context_.server_context_.dispatcher_);
   EXPECT_CALL(*timeout_timer, enableTimer(std::chrono::milliseconds(1000), nullptr));
   EXPECT_CALL(*resolver_, resolve("foo.com", _, _))
       .WillOnce(DoAll(SaveArg<2>(&resolve_cb), Return(&resolver_->active_query_)));
@@ -676,17 +655,16 @@ TEST_F(DnsCacheImplTest, InlineResolve) {
 
   MockLoadDnsCacheEntryCallbacks callbacks;
   Event::PostCb post_cb;
-  EXPECT_CALL(context_.server_factory_context_.dispatcher_, post(_))
-      .WillOnce([&post_cb](Event::PostCb cb) { post_cb = std::move(cb); });
+  EXPECT_CALL(context_.server_context_.dispatcher_, post(_)).WillOnce([&post_cb](Event::PostCb cb) {
+    post_cb = std::move(cb);
+  });
   auto result = dns_cache_->loadDnsCacheEntry("localhost", 80, false, callbacks);
   EXPECT_EQ(DnsCache::LoadDnsCacheEntryStatus::Loading, result.status_);
   EXPECT_NE(result.handle_, nullptr);
   EXPECT_EQ(absl::nullopt, result.host_info_);
 
-  Event::MockTimer* resolve_timer =
-      new Event::MockTimer(&context_.server_factory_context_.dispatcher_);
-  Event::MockTimer* timeout_timer =
-      new Event::MockTimer(&context_.server_factory_context_.dispatcher_);
+  Event::MockTimer* resolve_timer = new Event::MockTimer(&context_.server_context_.dispatcher_);
+  Event::MockTimer* timeout_timer = new Event::MockTimer(&context_.server_context_.dispatcher_);
   EXPECT_CALL(*timeout_timer, enableTimer(std::chrono::milliseconds(5000), nullptr));
   EXPECT_CALL(*resolver_, resolve("localhost", _, _))
       .WillOnce(Invoke([](const std::string&, Network::DnsLookupFamily,
@@ -716,10 +694,8 @@ TEST_F(DnsCacheImplTest, EnableResolveTimeout) {
 
   MockLoadDnsCacheEntryCallbacks callbacks;
   Network::DnsResolver::ResolveCb resolve_cb;
-  Event::MockTimer* refresh_timer =
-      new Event::MockTimer(&context_.server_factory_context_.dispatcher_);
-  Event::MockTimer* timeout_timer =
-      new Event::MockTimer(&context_.server_factory_context_.dispatcher_);
+  Event::MockTimer* refresh_timer = new Event::MockTimer(&context_.server_context_.dispatcher_);
+  Event::MockTimer* timeout_timer = new Event::MockTimer(&context_.server_context_.dispatcher_);
   EXPECT_CALL(*timeout_timer, enableTimer(std::chrono::milliseconds(5000), nullptr));
   EXPECT_CALL(*resolver_, resolve("foo.com", _, _))
       .WillOnce(DoAll(SaveArg<2>(&resolve_cb), Return(&resolver_->active_query_)));
@@ -754,11 +730,9 @@ TEST_F(DnsCacheImplTest, DisableResolveTimeout) {
 
   MockLoadDnsCacheEntryCallbacks callbacks;
   Network::DnsResolver::ResolveCb resolve_cb;
-  Event::MockTimer* refresh_timer =
-      new Event::MockTimer(&context_.server_factory_context_.dispatcher_);
+  Event::MockTimer* refresh_timer = new Event::MockTimer(&context_.server_context_.dispatcher_);
   (void)refresh_timer; // Silent unused warning.
-  Event::MockTimer* timeout_timer =
-      new Event::MockTimer(&context_.server_factory_context_.dispatcher_);
+  Event::MockTimer* timeout_timer = new Event::MockTimer(&context_.server_context_.dispatcher_);
   (void)timeout_timer; // Silent unused warning.
   EXPECT_CALL(*resolver_, resolve("foo.com", _, _))
       .WillOnce(DoAll(SaveArg<2>(&resolve_cb), Return(&resolver_->active_query_)));
@@ -779,10 +753,8 @@ TEST_F(DnsCacheImplTest, ResolveFailure) {
 
   MockLoadDnsCacheEntryCallbacks callbacks;
   Network::DnsResolver::ResolveCb resolve_cb;
-  Event::MockTimer* resolve_timer =
-      new Event::MockTimer(&context_.server_factory_context_.dispatcher_);
-  Event::MockTimer* timeout_timer =
-      new Event::MockTimer(&context_.server_factory_context_.dispatcher_);
+  Event::MockTimer* resolve_timer = new Event::MockTimer(&context_.server_context_.dispatcher_);
+  Event::MockTimer* timeout_timer = new Event::MockTimer(&context_.server_context_.dispatcher_);
   EXPECT_CALL(*timeout_timer, enableTimer(std::chrono::milliseconds(5000), nullptr));
   EXPECT_CALL(*resolver_, resolve("foo.com", _, _))
       .WillOnce(DoAll(SaveArg<2>(&resolve_cb), Return(&resolver_->active_query_)));
@@ -831,10 +803,8 @@ TEST_F(DnsCacheImplTest, ResolveFailureAfterResolveSuccess) {
 
   MockLoadDnsCacheEntryCallbacks callbacks;
   Network::DnsResolver::ResolveCb resolve_cb;
-  Event::MockTimer* resolve_timer =
-      new Event::MockTimer(&context_.server_factory_context_.dispatcher_);
-  Event::MockTimer* timeout_timer =
-      new Event::MockTimer(&context_.server_factory_context_.dispatcher_);
+  Event::MockTimer* resolve_timer = new Event::MockTimer(&context_.server_context_.dispatcher_);
+  Event::MockTimer* timeout_timer = new Event::MockTimer(&context_.server_context_.dispatcher_);
   EXPECT_CALL(*timeout_timer, enableTimer(std::chrono::milliseconds(5000), nullptr));
   EXPECT_CALL(*resolver_, resolve("foo.com", _, _))
       .WillOnce(DoAll(SaveArg<2>(&resolve_cb), Return(&resolver_->active_query_)));
@@ -905,11 +875,10 @@ TEST_F(DnsCacheImplTest, DisableRefreshOnFailureContainsFailedHost) {
 
   MockLoadDnsCacheEntryCallbacks callbacks;
   Network::DnsResolver::ResolveCb resolve_cb;
-  Event::MockTimer* refresh_timer =
-      new Event::MockTimer(&context_.server_factory_context_.dispatcher_);
+  Event::MockTimer* refresh_timer = new Event::MockTimer(&context_.server_context_.dispatcher_);
   (void)refresh_timer; // Silent unused warning.
   Event::MockTimer* query_timeout_timer =
-      new Event::MockTimer(&context_.server_factory_context_.dispatcher_);
+      new Event::MockTimer(&context_.server_context_.dispatcher_);
   EXPECT_CALL(*query_timeout_timer, enableTimer(std::chrono::milliseconds(5000), nullptr));
   EXPECT_CALL(*resolver_, resolve("foo.com", _, _))
       .WillOnce(DoAll(SaveArg<2>(&resolve_cb), Return(&resolver_->active_query_)));
@@ -931,9 +900,9 @@ TEST_F(DnsCacheImplTest, DisableRefreshOnFailureContainsFailedHost) {
              1 /* added */, 0 /* removed */, 1 /* num hosts */);
 
   // The previous resolution was a failure, so this should result in a cache miss.
-  refresh_timer = new Event::MockTimer(&context_.server_factory_context_.dispatcher_);
+  refresh_timer = new Event::MockTimer(&context_.server_context_.dispatcher_);
   (void)refresh_timer; // Silent unused warning.
-  query_timeout_timer = new Event::MockTimer(&context_.server_factory_context_.dispatcher_);
+  query_timeout_timer = new Event::MockTimer(&context_.server_context_.dispatcher_);
   EXPECT_CALL(*query_timeout_timer, enableTimer(std::chrono::milliseconds(5000), nullptr));
   EXPECT_CALL(*resolver_, resolve("foo.com", _, _))
       .WillOnce(DoAll(SaveArg<2>(&resolve_cb), Return(&resolver_->active_query_)));
@@ -961,10 +930,9 @@ TEST_F(DnsCacheImplTest, DisableRefreshOnFailureContainsSuccessfulHost) {
 
   MockLoadDnsCacheEntryCallbacks callbacks;
   Network::DnsResolver::ResolveCb resolve_cb;
-  Event::MockTimer* refresh_timer =
-      new Event::MockTimer(&context_.server_factory_context_.dispatcher_);
+  Event::MockTimer* refresh_timer = new Event::MockTimer(&context_.server_context_.dispatcher_);
   Event::MockTimer* query_timeout_timer =
-      new Event::MockTimer(&context_.server_factory_context_.dispatcher_);
+      new Event::MockTimer(&context_.server_context_.dispatcher_);
   EXPECT_CALL(*query_timeout_timer, enableTimer(std::chrono::milliseconds(5000), nullptr));
   EXPECT_CALL(*resolver_, resolve("foo.com", _, _))
       .WillOnce(DoAll(SaveArg<2>(&resolve_cb), Return(&resolver_->active_query_)));
@@ -1013,10 +981,8 @@ TEST_F(DnsCacheImplTest, ResolveFailureWithFailureRefreshRate) {
 
   MockLoadDnsCacheEntryCallbacks callbacks;
   Network::DnsResolver::ResolveCb resolve_cb;
-  Event::MockTimer* resolve_timer =
-      new Event::MockTimer(&context_.server_factory_context_.dispatcher_);
-  Event::MockTimer* timeout_timer =
-      new Event::MockTimer(&context_.server_factory_context_.dispatcher_);
+  Event::MockTimer* resolve_timer = new Event::MockTimer(&context_.server_context_.dispatcher_);
+  Event::MockTimer* timeout_timer = new Event::MockTimer(&context_.server_context_.dispatcher_);
   EXPECT_CALL(*timeout_timer, enableTimer(std::chrono::milliseconds(5000), nullptr));
   EXPECT_CALL(*resolver_, resolve("foo.com", _, _))
       .WillOnce(DoAll(SaveArg<2>(&resolve_cb), Return(&resolver_->active_query_)));
@@ -1033,7 +999,7 @@ TEST_F(DnsCacheImplTest, ResolveFailureWithFailureRefreshRate) {
   EXPECT_CALL(update_callbacks_,
               onDnsResolutionComplete("foo.com:80", DnsHostInfoAddressIsNull(),
                                       Network::DnsResolver::ResolutionStatus::Failure));
-  ON_CALL(context_.server_factory_context_.api_.random_, random()).WillByDefault(Return(8000));
+  ON_CALL(context_.server_context_.api_.random_, random()).WillByDefault(Return(8000));
   EXPECT_CALL(*resolve_timer, enableTimer(std::chrono::milliseconds(1000), _));
   resolve_cb(Network::DnsResolver::ResolutionStatus::Failure, "", TestUtility::makeDnsResponse({}));
   checkStats(1 /* attempt */, 0 /* success */, 1 /* failure */, 0 /* address changed */,
@@ -1068,10 +1034,8 @@ TEST_F(DnsCacheImplTest, ResolveFailureAfterResolveSuccessWithFailureRefreshRate
 
   MockLoadDnsCacheEntryCallbacks callbacks;
   Network::DnsResolver::ResolveCb resolve_cb;
-  Event::MockTimer* resolve_timer =
-      new Event::MockTimer(&context_.server_factory_context_.dispatcher_);
-  Event::MockTimer* timeout_timer =
-      new Event::MockTimer(&context_.server_factory_context_.dispatcher_);
+  Event::MockTimer* resolve_timer = new Event::MockTimer(&context_.server_context_.dispatcher_);
+  Event::MockTimer* timeout_timer = new Event::MockTimer(&context_.server_context_.dispatcher_);
   EXPECT_CALL(*timeout_timer, enableTimer(std::chrono::milliseconds(5000), nullptr));
   EXPECT_CALL(*resolver_, resolve("foo.com", _, _))
       .WillOnce(DoAll(SaveArg<2>(&resolve_cb), Return(&resolver_->active_query_)));
@@ -1116,7 +1080,7 @@ TEST_F(DnsCacheImplTest, ResolveFailureAfterResolveSuccessWithFailureRefreshRate
               onDnsResolutionComplete("foo.com:80",
                                       DnsHostInfoEquals("10.0.0.1:80", "foo.com", false),
                                       Network::DnsResolver::ResolutionStatus::Failure));
-  ON_CALL(context_.server_factory_context_.api_.random_, random()).WillByDefault(Return(5000));
+  ON_CALL(context_.server_context_.api_.random_, random()).WillByDefault(Return(5000));
   EXPECT_CALL(*resolve_timer,
               enableTimer(std::chrono::milliseconds(1000),
                           _)); // 5000 % 2000(base_interval) and not 5000 % 6000(ttl)
@@ -1142,10 +1106,8 @@ TEST_F(DnsCacheImplTest, ResolveSuccessWithEmptyResult) {
 
   MockLoadDnsCacheEntryCallbacks callbacks;
   Network::DnsResolver::ResolveCb resolve_cb;
-  Event::MockTimer* resolve_timer =
-      new Event::MockTimer(&context_.server_factory_context_.dispatcher_);
-  Event::MockTimer* timeout_timer =
-      new Event::MockTimer(&context_.server_factory_context_.dispatcher_);
+  Event::MockTimer* resolve_timer = new Event::MockTimer(&context_.server_context_.dispatcher_);
+  Event::MockTimer* timeout_timer = new Event::MockTimer(&context_.server_context_.dispatcher_);
   EXPECT_CALL(*timeout_timer, enableTimer(std::chrono::milliseconds(5000), nullptr));
   EXPECT_CALL(*resolver_, resolve("foo.com", _, _))
       .WillOnce(DoAll(SaveArg<2>(&resolve_cb), Return(&resolver_->active_query_)));
@@ -1536,10 +1498,8 @@ TEST_F(DnsCacheImplTest, SetIpVersionToRemoveYieldsNonEmptyResponseWithFilter) {
 
   MockLoadDnsCacheEntryCallbacks callbacks;
   Network::DnsResolver::ResolveCb resolve_cb;
-  Event::MockTimer* resolve_timer =
-      new Event::MockTimer(&context_.server_factory_context_.dispatcher_);
-  Event::MockTimer* timeout_timer =
-      new Event::MockTimer(&context_.server_factory_context_.dispatcher_);
+  Event::MockTimer* resolve_timer = new Event::MockTimer(&context_.server_context_.dispatcher_);
+  Event::MockTimer* timeout_timer = new Event::MockTimer(&context_.server_context_.dispatcher_);
 
   // Set IPv6 to be removed.
   dns_cache_->setIpVersionToRemove(Network::Address::IpVersion::v6);
@@ -1591,10 +1551,8 @@ TEST_F(DnsCacheImplTest, SetIpVersionToRemoveYieldsNonEmptyResponse) {
 
   MockLoadDnsCacheEntryCallbacks callbacks;
   Network::DnsResolver::ResolveCb resolve_cb;
-  Event::MockTimer* resolve_timer =
-      new Event::MockTimer(&context_.server_factory_context_.dispatcher_);
-  Event::MockTimer* timeout_timer =
-      new Event::MockTimer(&context_.server_factory_context_.dispatcher_);
+  Event::MockTimer* resolve_timer = new Event::MockTimer(&context_.server_context_.dispatcher_);
+  Event::MockTimer* timeout_timer = new Event::MockTimer(&context_.server_context_.dispatcher_);
 
   // Set the IPv6 to be removed.
   dns_cache_->setIpVersionToRemove(Network::Address::IpVersion::v6);
@@ -1681,10 +1639,8 @@ TEST_F(DnsCacheImplTest, SetIpVersionToRemoveYieldsEmptyResponse) {
 
   MockLoadDnsCacheEntryCallbacks callbacks;
   Network::DnsResolver::ResolveCb resolve_cb;
-  Event::MockTimer* resolve_timer =
-      new Event::MockTimer(&context_.server_factory_context_.dispatcher_);
-  Event::MockTimer* timeout_timer =
-      new Event::MockTimer(&context_.server_factory_context_.dispatcher_);
+  Event::MockTimer* resolve_timer = new Event::MockTimer(&context_.server_context_.dispatcher_);
+  Event::MockTimer* timeout_timer = new Event::MockTimer(&context_.server_context_.dispatcher_);
   EXPECT_CALL(*timeout_timer, enableTimer(std::chrono::milliseconds(5000), nullptr));
   EXPECT_CALL(*resolver_, resolve("foo.com", _, _))
       .WillOnce(DoAll(SaveArg<2>(&resolve_cb), Return(&resolver_->active_query_)));
@@ -1722,10 +1678,8 @@ TEST_F(DnsCacheImplTest, SetIpVersionToRemoveIgnoreIPv4LoopbackAddress) {
 
   MockLoadDnsCacheEntryCallbacks callbacks;
   Network::DnsResolver::ResolveCb resolve_cb;
-  Event::MockTimer* resolve_timer =
-      new Event::MockTimer(&context_.server_factory_context_.dispatcher_);
-  Event::MockTimer* timeout_timer =
-      new Event::MockTimer(&context_.server_factory_context_.dispatcher_);
+  Event::MockTimer* resolve_timer = new Event::MockTimer(&context_.server_context_.dispatcher_);
+  Event::MockTimer* timeout_timer = new Event::MockTimer(&context_.server_context_.dispatcher_);
 
   // Set the IPv4 to be removed.
   dns_cache_->setIpVersionToRemove(Network::Address::IpVersion::v4);
@@ -1766,10 +1720,8 @@ TEST_F(DnsCacheImplTest, SetIpVersionToRemoveIgnoreIPv6LoopbackAddress) {
 
   MockLoadDnsCacheEntryCallbacks callbacks;
   Network::DnsResolver::ResolveCb resolve_cb;
-  Event::MockTimer* resolve_timer =
-      new Event::MockTimer(&context_.server_factory_context_.dispatcher_);
-  Event::MockTimer* timeout_timer =
-      new Event::MockTimer(&context_.server_factory_context_.dispatcher_);
+  Event::MockTimer* resolve_timer = new Event::MockTimer(&context_.server_context_.dispatcher_);
+  Event::MockTimer* timeout_timer = new Event::MockTimer(&context_.server_context_.dispatcher_);
 
   // Set the IPv6 to be removed.
   dns_cache_->setIpVersionToRemove(Network::Address::IpVersion::v6);
@@ -2045,7 +1997,7 @@ TEST(UtilityTest, PrepareDnsRefreshStrategy) {
 
 TEST_F(DnsCacheImplTest, ResolveSuccessWithCaching) {
   auto* time_source = new NiceMock<MockTimeSystem>();
-  context_.server_factory_context_.dispatcher_.time_system_.reset(time_source);
+  context_.server_context_.dispatcher_.time_system_.reset(time_source);
 
   // Configure the cache.
   MockKeyValueStoreFactory factory;
@@ -2060,7 +2012,7 @@ TEST_F(DnsCacheImplTest, ResolveSuccessWithCaching) {
     // Make sure there's an attempt to load from the key value store.
     EXPECT_CALL(*store, iterate(_));
     // Make sure the result is sent to the worker threads.
-    EXPECT_CALL(context_.server_factory_context_.thread_local_, runOnAllThreads(_)).Times(2);
+    EXPECT_CALL(context_.server_context_.thread_local_, runOnAllThreads(_)).Times(2);
     return ret;
   }));
 
@@ -2076,10 +2028,8 @@ TEST_F(DnsCacheImplTest, ResolveSuccessWithCaching) {
 
   MockLoadDnsCacheEntryCallbacks callbacks;
   Network::DnsResolver::ResolveCb resolve_cb;
-  Event::MockTimer* resolve_timer =
-      new Event::MockTimer(&context_.server_factory_context_.dispatcher_);
-  Event::MockTimer* timeout_timer =
-      new Event::MockTimer(&context_.server_factory_context_.dispatcher_);
+  Event::MockTimer* resolve_timer = new Event::MockTimer(&context_.server_context_.dispatcher_);
+  Event::MockTimer* timeout_timer = new Event::MockTimer(&context_.server_context_.dispatcher_);
   EXPECT_CALL(*timeout_timer, enableTimer(std::chrono::milliseconds(5000), nullptr));
   EXPECT_CALL(*resolver_, resolve("foo.com", _, _))
       .WillOnce(DoAll(SaveArg<2>(&resolve_cb), Return(&resolver_->active_query_)));
@@ -2181,7 +2131,7 @@ TEST_F(DnsCacheImplTest, ResolveSuccessWithCaching) {
 
 TEST_F(DnsCacheImplTest, CacheLoad) {
   auto* time_source = new NiceMock<MockTimeSystem>();
-  context_.server_factory_context_.dispatcher_.time_system_.reset(time_source);
+  context_.server_context_.dispatcher_.time_system_.reset(time_source);
 
   // Configure the cache.
   MockKeyValueStoreFactory factory;
@@ -2266,7 +2216,7 @@ TEST(NoramlizeHost, NormalizeHost) {
 
 TEST_F(DnsCacheImplTest, SingleAddressCache) {
   auto* time_source = new NiceMock<MockTimeSystem>();
-  context_.server_factory_context_.dispatcher_.time_system_.reset(time_source);
+  context_.server_context_.dispatcher_.time_system_.reset(time_source);
 
   MockKeyValueStoreFactory factory;
   EXPECT_CALL(factory, createEmptyConfigProto()).WillRepeatedly(Invoke([]() {
@@ -2306,7 +2256,7 @@ TEST_F(DnsCacheImplTest, SingleAddressCache) {
 
 TEST_F(DnsCacheImplTest, CacheLoadParsingErrors) {
   auto* time_source = new NiceMock<MockTimeSystem>();
-  context_.server_factory_context_.dispatcher_.time_system_.reset(time_source);
+  context_.server_context_.dispatcher_.time_system_.reset(time_source);
 
   // Configure the cache
   MockKeyValueStoreFactory factory;
@@ -2343,8 +2293,8 @@ TEST_F(DnsCacheImplTest, CacheLoadParsingErrors) {
       envoy::extensions::key_value::file_based::v3::FileBasedKeyValueStoreConfig());
 
   // Create the timers but let NiceMock handle all the expectations
-  new NiceMock<Event::MockTimer>(&context_.server_factory_context_.dispatcher_);
-  new NiceMock<Event::MockTimer>(&context_.server_factory_context_.dispatcher_);
+  new NiceMock<Event::MockTimer>(&context_.server_context_.dispatcher_);
+  new NiceMock<Event::MockTimer>(&context_.server_context_.dispatcher_);
 
   initialize();
   ASSERT(store != nullptr);

--- a/test/extensions/common/tap/admin_test.cc
+++ b/test/extensions/common/tap/admin_test.cc
@@ -156,14 +156,9 @@ public:
   MockTapSinkFactory() = default;
   ~MockTapSinkFactory() override = default;
 
-  MOCK_METHOD(SinkPtr, createHttpSinkPtr,
-              (const Protobuf::Message& config, Server::Configuration::FactoryContext&),
+  MOCK_METHOD(SinkPtr, createSinkPtr,
+              (const Protobuf::Message& config, Server::Configuration::GenericFactoryContext&),
               (override));
-  MOCK_METHOD(SinkPtr, createTransportSinkPtr,
-              (const Protobuf::Message& config,
-               Server::Configuration::TransportSocketFactoryContext&),
-              (override));
-
   MOCK_METHOD(std::string, name, (), (const, override));
   MOCK_METHOD(ProtobufTypes::MessagePtr, createEmptyConfigProto, (), (override));
 };
@@ -171,10 +166,12 @@ public:
 class TestConfigImpl : public TapConfigBaseImpl {
 public:
   TestConfigImpl(const envoy::config::tap::v3::TapConfig& proto_config,
-                 Extensions::Common::Tap::Sink* admin_streamer, SinkContext context)
+                 Extensions::Common::Tap::Sink* admin_streamer,
+                 Server::Configuration::GenericFactoryContext& context)
       : TapConfigBaseImpl(std::move(proto_config), admin_streamer, context) {}
 };
-TEST(TypedExtensionConfigTest, AddTestConfigHttpContext) {
+
+TEST(TypedExtensionConfigTest, AddTestConfig) {
   const std::string tap_config_yaml =
       R"EOF(
   match:
@@ -196,41 +193,11 @@ TEST(TypedExtensionConfigTest, AddTestConfigHttpContext) {
       .WillRepeatedly(Invoke([]() -> ProtobufTypes::MessagePtr {
         return std::make_unique<ProtobufWkt::StringValue>();
       }));
-  EXPECT_CALL(factory_impl, createHttpSinkPtr(_, _));
+  EXPECT_CALL(factory_impl, createSinkPtr(_, _));
 
   Registry::InjectFactory<TapSinkFactory> factory(factory_impl);
 
-  NiceMock<Server::Configuration::MockFactoryContext> factory_context;
-  TestConfigImpl(tap_config, nullptr, factory_context);
-}
-
-TEST(TypedExtensionConfigTest, AddTestConfigTransportSocketContext) {
-  const std::string tap_config_yaml =
-      R"EOF(
-  match:
-    any_match: true
-  output_config:
-    sinks:
-      - format: PROTO_BINARY
-        custom_sink:
-          name: custom_sink
-          typed_config:
-            "@type": type.googleapis.cm/google.protobuf.StringValue
-)EOF";
-  envoy::config::tap::v3::TapConfig tap_config;
-  TestUtility::loadFromYaml(tap_config_yaml, tap_config);
-
-  MockTapSinkFactory factory_impl;
-  EXPECT_CALL(factory_impl, name).Times(AtLeast(1));
-  EXPECT_CALL(factory_impl, createEmptyConfigProto)
-      .WillRepeatedly(Invoke([]() -> ProtobufTypes::MessagePtr {
-        return std::make_unique<ProtobufWkt::StringValue>();
-      }));
-  EXPECT_CALL(factory_impl, createTransportSinkPtr(_, _));
-
-  Registry::InjectFactory<TapSinkFactory> factory(factory_impl);
-
-  NiceMock<Server::Configuration::MockTransportSocketFactoryContext> factory_context;
+  NiceMock<Server::Configuration::MockGenericFactoryContext> factory_context;
   TestConfigImpl(tap_config, nullptr, factory_context);
 }
 
@@ -256,7 +223,7 @@ TEST(TypedExtensionConfigTest, BufferedAdminNoAdminStreamerRejected) {
       }));
   Registry::InjectFactory<TapSinkFactory> factory(factory_impl);
 
-  NiceMock<Server::Configuration::MockTransportSocketFactoryContext> factory_context;
+  NiceMock<Server::Configuration::MockGenericFactoryContext> factory_context;
   EXPECT_THROW_WITH_MESSAGE(
       TestConfigImpl(tap_config, nullptr, factory_context), EnvoyException,
       "Output sink type BufferedAdmin requires that the admin output will be configured via admin");
@@ -284,7 +251,7 @@ TEST(TypedExtensionConfigTest, StreamingAdminNoAdminStreamerRejected) {
       }));
   Registry::InjectFactory<TapSinkFactory> factory(factory_impl);
 
-  NiceMock<Server::Configuration::MockTransportSocketFactoryContext> factory_context;
+  NiceMock<Server::Configuration::MockGenericFactoryContext> factory_context;
   EXPECT_THROW_WITH_MESSAGE(TestConfigImpl(tap_config, nullptr, factory_context), EnvoyException,
                             "Output sink type StreamingAdmin requires that the admin output will "
                             "be configured via admin");
@@ -361,6 +328,8 @@ TEST_F(AdminHandlerTest, CloseMidStream) {
   // Direct access to the handle is required so we can submit traces directly
   PerTapSinkHandlePtr sinkHandle =
       handler_->createPerTapSinkHandle(0, ProtoOutputSink::OutputSinkTypeCase::kStreamingAdmin);
+
+  EXPECT_EQ(nullptr, attachedRequest()->traceBuffer());
 
   EXPECT_CALL(main_thread_dispatcher_, post(_)).Times(2);
   main_thread_dispatcher_.post([this] { attachedRequest().reset(); });

--- a/test/extensions/filters/network/common/fuzz/utils/fakes.h
+++ b/test/extensions/filters/network/common/fuzz/utils/fakes.h
@@ -38,7 +38,7 @@ public:
   Init::Manager& initManager() override { return init_manager_; }
   Stats::Scope& scope() override { return scope_; }
   Stats::Scope& listenerScope() override { return listener_scope_; }
-  ProtobufMessage::ValidationVisitor& messageValidationVisitor() const override {
+  ProtobufMessage::ValidationVisitor& messageValidationVisitor() override {
     return ProtobufMessage::getStrictValidationVisitor();
   }
   const Network::ListenerInfo& listenerInfo() const override { return listener_info_; }

--- a/test/mocks/server/factory_context.h
+++ b/test/mocks/server/factory_context.h
@@ -21,10 +21,10 @@ public:
   ~MockFactoryContext() override;
 
   // Server::Configuration::GenericFactoryContext
-  MOCK_METHOD(ServerFactoryContext&, serverFactoryContext, (), (const));
+  MOCK_METHOD(ServerFactoryContext&, serverFactoryContext, ());
   MOCK_METHOD(Init::Manager&, initManager, ());
   MOCK_METHOD(Stats::Scope&, scope, ());
-  MOCK_METHOD(ProtobufMessage::ValidationVisitor&, messageValidationVisitor, (), (const));
+  MOCK_METHOD(ProtobufMessage::ValidationVisitor&, messageValidationVisitor, ());
 
   // Server::Configuration::FactoryContext
   MOCK_METHOD(TransportSocketFactoryContext&, getTransportSocketFactoryContext, (), (const));
@@ -46,7 +46,7 @@ class MockUpstreamFactoryContext : public UpstreamFactoryContext {
 public:
   MockUpstreamFactoryContext();
 
-  MOCK_METHOD(ServerFactoryContext&, serverFactoryContext, (), (const));
+  MOCK_METHOD(ServerFactoryContext&, serverFactoryContext, ());
   MOCK_METHOD(Init::Manager&, initManager, ());
   MOCK_METHOD(Stats::Scope&, scope, ());
   testing::NiceMock<Init::MockManager> init_manager_;

--- a/test/mocks/server/listener_factory_context.h
+++ b/test/mocks/server/listener_factory_context.h
@@ -21,14 +21,14 @@ public:
   MockListenerFactoryContext();
   ~MockListenerFactoryContext() override;
 
-  MOCK_METHOD(ServerFactoryContext&, serverFactoryContext, (), (const));
+  MOCK_METHOD(ServerFactoryContext&, serverFactoryContext, ());
   MOCK_METHOD(TransportSocketFactoryContext&, getTransportSocketFactoryContext, (), (const));
   MOCK_METHOD(const Network::DrainDecision&, drainDecision, ());
   MOCK_METHOD(Init::Manager&, initManager, ());
   MOCK_METHOD(Stats::Scope&, scope, ());
   MOCK_METHOD(Stats::Scope&, listenerScope, ());
   MOCK_METHOD(envoy::config::core::v3::TrafficDirection, direction, (), (const));
-  MOCK_METHOD(ProtobufMessage::ValidationVisitor&, messageValidationVisitor, (), (const));
+  MOCK_METHOD(ProtobufMessage::ValidationVisitor&, messageValidationVisitor, ());
   MOCK_METHOD(const Network::ListenerInfo&, listenerInfo, (), (const));
 
   testing::NiceMock<MockServerFactoryContext> server_factory_context_;

--- a/test/mocks/server/server_factory_context.cc
+++ b/test/mocks/server/server_factory_context.cc
@@ -60,22 +60,13 @@ MockStatsConfig::~MockStatsConfig() = default;
 MockGenericFactoryContext::~MockGenericFactoryContext() = default;
 
 MockGenericFactoryContext::MockGenericFactoryContext() {
-  ON_CALL(*this, serverFactoryContext()).WillByDefault(ReturnRef(server_factory_context_));
-  ON_CALL(*this, scope()).WillByDefault(ReturnRef(*store_.rootScope()));
-  ON_CALL(*this, initManager()).WillByDefault(ReturnRef(init_manager_));
-  ON_CALL(*this, messageValidationVisitor())
-      .WillByDefault(ReturnRef(ProtobufMessage::getStrictValidationVisitor()));
-}
-
-MockTransportSocketFactoryContext::MockTransportSocketFactoryContext() {
   ON_CALL(*this, serverFactoryContext()).WillByDefault(ReturnRef(server_context_));
+  ON_CALL(*this, scope()).WillByDefault(ReturnRef(*store_.rootScope()));
   ON_CALL(*this, statsScope()).WillByDefault(ReturnRef(*store_.rootScope()));
   ON_CALL(*this, initManager()).WillByDefault(ReturnRef(init_manager_));
   ON_CALL(*this, messageValidationVisitor())
       .WillByDefault(ReturnRef(ProtobufMessage::getStrictValidationVisitor()));
 }
-
-MockTransportSocketFactoryContext::~MockTransportSocketFactoryContext() = default;
 
 } // namespace Configuration
 } // namespace Server

--- a/test/mocks/server/server_factory_context.h
+++ b/test/mocks/server/server_factory_context.h
@@ -141,30 +141,18 @@ public:
   MockGenericFactoryContext();
   ~MockGenericFactoryContext() override;
 
-  MOCK_METHOD(ServerFactoryContext&, serverFactoryContext, (), (const));
-  MOCK_METHOD(ProtobufMessage::ValidationVisitor&, messageValidationVisitor, (), (const));
-  MOCK_METHOD(Stats::Scope&, scope, ());
-  MOCK_METHOD(Init::Manager&, initManager, ());
-
-  NiceMock<MockServerFactoryContext> server_factory_context_;
-  testing::NiceMock<Stats::MockIsolatedStatsStore> store_;
-  testing::NiceMock<Init::MockManager> init_manager_;
-};
-
-class MockTransportSocketFactoryContext : public TransportSocketFactoryContext {
-public:
-  MockTransportSocketFactoryContext();
-  ~MockTransportSocketFactoryContext() override;
-
   MOCK_METHOD(ServerFactoryContext&, serverFactoryContext, ());
   MOCK_METHOD(ProtobufMessage::ValidationVisitor&, messageValidationVisitor, ());
+  MOCK_METHOD(Stats::Scope&, scope, ());
   MOCK_METHOD(Stats::Scope&, statsScope, ());
   MOCK_METHOD(Init::Manager&, initManager, ());
 
-  testing::NiceMock<MockServerFactoryContext> server_context_;
+  NiceMock<MockServerFactoryContext> server_context_;
   testing::NiceMock<Stats::MockIsolatedStatsStore> store_;
   testing::NiceMock<Init::MockManager> init_manager_;
 };
+
+using MockTransportSocketFactoryContext = MockGenericFactoryContext;
 
 // Stateless mock ServerFactoryContext for cases where it needs to be used concurrently in different
 // threads. Global state in the MockServerFactoryContext causes thread safety issues in this case.

--- a/test/per_file_coverage.sh
+++ b/test/per_file_coverage.sh
@@ -26,7 +26,7 @@ declare -a KNOWN_LOW_COVERAGE=(
 "source/extensions/common/aws:96.3"
 "source/extensions/common/aws/credential_providers:94.4"
 "source/extensions/common/proxy_protocol:93.8" # Adjusted for security patch
-"source/extensions/common/tap:94.4"
+"source/extensions/common/tap:94.6"
 "source/extensions/common/wasm:95.3" # flaky: be careful adjusting
 "source/extensions/common/wasm/ext:92.0"
 "source/extensions/filters/common/fault:94.5"

--- a/test/per_file_coverage.sh
+++ b/test/per_file_coverage.sh
@@ -26,7 +26,7 @@ declare -a KNOWN_LOW_COVERAGE=(
 "source/extensions/common/aws:96.3"
 "source/extensions/common/aws/credential_providers:94.4"
 "source/extensions/common/proxy_protocol:93.8" # Adjusted for security patch
-"source/extensions/common/tap:94.6"
+"source/extensions/common/tap:94.4"
 "source/extensions/common/wasm:95.3" # flaky: be careful adjusting
 "source/extensions/common/wasm/ext:92.0"
 "source/extensions/filters/common/fault:94.5"


### PR DESCRIPTION
Commit Message: context: replace transport socket context with generic context

Additional Description:

Now the transport factory context share same interface with generic context. We removed the transport socket factory context and use generic factory context as althernative.

This PR:
1. removed TransportSocketFactoryContext and implementation and make it an alias of generic factory context.

Risk Level: low. mainly simple symbol replacement.
Testing: n/a.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.