### PR TITLE
dynamic_modules: prevent reentrance on local reply

### DIFF
--- a/source/extensions/filters/http/dynamic_modules/filter.cc
+++ b/source/extensions/filters/http/dynamic_modules/filter.cc
@@ -65,6 +65,9 @@ Filter1xxHeadersStatus DynamicModuleHttpFilter::encode1xxHeaders(ResponseHeaderM
 
 FilterHeadersStatus DynamicModuleHttpFilter::encodeHeaders(ResponseHeaderMap& headers,
                                                            bool end_of_stream) {
+  if (sent_local_reply_) { // See the comment on the flag.
+    return FilterHeadersStatus::Continue;
+  }
   response_headers_ = &headers;
   const envoy_dynamic_module_type_on_http_filter_response_headers_status status =
       config_->on_http_filter_response_headers_(thisAsVoidPtr(), in_module_filter_, end_of_stream);
@@ -72,6 +75,9 @@ FilterHeadersStatus DynamicModuleHttpFilter::encodeHeaders(ResponseHeaderMap& he
 };
 
 FilterDataStatus DynamicModuleHttpFilter::encodeData(Buffer::Instance& chunk, bool end_of_stream) {
+  if (sent_local_reply_) { // See the comment on the flag.
+    return FilterDataStatus::Continue;
+  }
   if (end_of_stream && encoder_callbacks_->encodingBuffer()) {
     // To make the very last chunk of the body available to the filter when buffering is enabled,
     // we need to call addEncodedData. See the code comment there for more details.
@@ -85,6 +91,9 @@ FilterDataStatus DynamicModuleHttpFilter::encodeData(Buffer::Instance& chunk, bo
 };
 
 FilterTrailersStatus DynamicModuleHttpFilter::encodeTrailers(ResponseTrailerMap& trailers) {
+  if (sent_local_reply_) { // See the comment on the flag.
+    return FilterTrailersStatus::Continue;
+  }
   response_trailers_ = &trailers;
   const envoy_dynamic_module_type_on_http_filter_response_trailers_status status =
       config_->on_http_filter_response_trailers_(thisAsVoidPtr(), in_module_filter_);
@@ -100,6 +109,7 @@ void DynamicModuleHttpFilter::sendLocalReply(
     std::function<void(ResponseHeaderMap& headers)> modify_headers,
     const absl::optional<Grpc::Status::GrpcStatus> grpc_status, absl::string_view details) {
   decoder_callbacks_->sendLocalReply(code, body, modify_headers, grpc_status, details);
+  sent_local_reply_ = true;
 }
 
 void DynamicModuleHttpFilter::encodeComplete() {};

--- a/source/extensions/filters/http/dynamic_modules/filter.h
+++ b/source/extensions/filters/http/dynamic_modules/filter.h
@@ -108,6 +108,13 @@ private:
    */
   void destroy();
 
+  // This helps to avoid reentering the module when sending a local reply. For example, if
+  // sendLocalReply() is called, encodeHeaders and encodeData will be called again inline on top of
+  // the stack calling it, which can be problematic. For example, with Rust, that might cause
+  // multiple mutable borrows of the same object. In practice, a module shouldn't need encodeHeaders
+  // and encodeData to be called for local reply contents, so we just skip them with this flag.
+  bool sent_local_reply_ = false;
+
   const DynamicModuleHttpFilterConfigSharedPtr config_ = nullptr;
   envoy_dynamic_module_type_http_filter_module_ptr in_module_filter_ = nullptr;
 };


### PR DESCRIPTION
Commit Message: dynamic_modules: prevent reentrance on local reply
Additional Description:

LocalReply of the stream callbacks can cause a reentrance. For example, it causes encodeHeaders to be called inline on top of the call to LocalReply. That causes a few problems e.g. multiple mutable references in Rust. In practice, modules won't need these callbacks to be called again since at the callsite of LocalReply, they already know all the details. This adds a boolean flag to prevent that and added a test that would fail otherwise. Note that this behavior matches the one of Wasm extension.

Risk Level: low
Testing: done
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features:
