### PR TITLE
Add /*/ prefix to oauth2 owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -172,7 +172,7 @@ extensions/filters/common/original_src @klarose @mattklein123
 extensions/upstreams/http @yanavlasov @mattklein123
 extensions/upstreams/tcp @ggreenway @mattklein123
 # OAuth2
-extensions/filters/http/oauth2 @derekargueta @mattklein123
+/*/extensions/filters/http/oauth2 @derekargueta @mattklein123
 # HTTP Local Rate Limit
 /*/extensions/filters/http/local_ratelimit @mattklein123 @wbpcode
 /*/extensions/filters/common/local_ratelimit @mattklein123 @wbpcode


### PR DESCRIPTION
I noticed this since https://github.com/envoyproxy/envoy/pull/39213 is being ready for review but no reviewers are requested