### PR TITLE
ext_proc: explicitly encode append field in tests

### DIFF
--- a/test/extensions/filters/http/ext_proc/ext_proc_benchmark_test.cc
+++ b/test/extensions/filters/http/ext_proc/ext_proc_benchmark_test.cc
@@ -181,6 +181,7 @@ TEST_F(BenchmarkTest, AddRequestHeaderAndClose) {
                             ->mutable_response()
                             ->mutable_header_mutation()
                             ->add_set_headers();
+        new_hdr->mutable_append()->set_value(false);
         new_hdr->mutable_header()->set_key("x-envoy-benchmark");
         new_hdr->mutable_header()->set_raw_value("true");
         stream->Write(header_resp);
@@ -207,10 +208,10 @@ TEST_F(BenchmarkTest, AddResponseHeaderAndClose) {
         auto* new_hdr = response_out.mutable_response_headers()
                             ->mutable_response()
                             ->mutable_header_mutation()
-                            ->add_set_headers()
-                            ->mutable_header();
-        new_hdr->set_key("x-envoy-benchmark");
-        new_hdr->set_raw_value("true");
+                            ->add_set_headers();
+        new_hdr->mutable_append()->set_value(false);
+        new_hdr->mutable_header()->set_key("x-envoy-benchmark");
+        new_hdr->mutable_header()->set_raw_value("true");
         stream->Write(response_out);
       });
   initialize();

--- a/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
+++ b/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
@@ -617,6 +617,7 @@ protected:
     for (int i = 0; i < count; i++) {
       auto* headers = mutation.add_set_headers();
       auto str = absl::StrCat("x-test-header-internal-", std::to_string(i));
+      headers->mutable_append()->set_value(false);
       headers->mutable_header()->set_key(str);
       headers->mutable_header()->set_raw_value(str);
     }
@@ -633,6 +634,7 @@ protected:
         *grpc_upstreams_[0], true, [](const HttpHeaders&, HeadersResponse& headers_resp) {
           auto* content_length =
               headers_resp.mutable_response()->mutable_header_mutation()->add_set_headers();
+          content_length->mutable_append()->set_value(false);
           content_length->mutable_header()->set_key("content-length");
           content_length->mutable_header()->set_raw_value("13");
           return true;
@@ -860,7 +862,9 @@ protected:
       header_resp = response_header.mutable_request_headers();
     }
     auto* header_mutation = header_resp->mutable_response()->mutable_header_mutation();
-    auto* header = header_mutation->add_set_headers()->mutable_header();
+    auto *sh = header_mutation->add_set_headers();
+    auto* header = sh->mutable_header();
+    sh->mutable_append()->set_value(false);
     header->set_key("x-new-header");
     header->set_raw_value("new");
     processor_stream_->sendGrpcMessage(response_header);
@@ -891,7 +895,9 @@ protected:
   void serverSendTrailerRespDuplexStreamed() {
     ProcessingResponse response_trailer;
     auto* trailer_resp = response_trailer.mutable_request_trailers()->mutable_header_mutation();
-    auto* header = trailer_resp->add_set_headers()->mutable_header();
+    auto *sh = trailer_resp->add_set_headers();
+    sh->mutable_append()->set_value(false);
+    auto* header = sh->mutable_header();
     header->set_key("x-new-trailer");
     header->set_raw_value("new");
     processor_stream_->sendGrpcMessage(response_trailer);
@@ -1181,6 +1187,7 @@ TEST_P(ExtProcIntegrationTest, OnlyRequestHeadersResetOnServerMessage) {
         // The response does not really matter, it just needs to be non-empty.
         auto response_header_mutation = headers_resp.mutable_response()->mutable_header_mutation();
         auto* mut1 = response_header_mutation->add_set_headers();
+        mut1->mutable_append()->set_value(false);
         mut1->mutable_header()->set_key("x-new-header");
         mut1->mutable_header()->set_raw_value("new");
         return true;
@@ -1223,6 +1230,7 @@ TEST_P(ExtProcIntegrationTest, OnlyRequestHeadersGracefulClose) {
         // The response does not really matter, it just needs to be non-empty.
         auto response_header_mutation = headers_resp.mutable_response()->mutable_header_mutation();
         auto* mut1 = response_header_mutation->add_set_headers();
+        mut1->mutable_append()->set_value(false);
         mut1->mutable_header()->set_key("x-new-header");
         mut1->mutable_header()->set_raw_value("new");
         return true;
@@ -1262,6 +1270,7 @@ TEST_P(ExtProcIntegrationTest, OnlyRequestHeadersServerHalfClosesFirst) {
         // The response does not really matter, it just needs to be non-empty.
         auto response_header_mutation = headers_resp.mutable_response()->mutable_header_mutation();
         auto* mut1 = response_header_mutation->add_set_headers();
+        mut1->mutable_append()->set_value(false);
         mut1->mutable_header()->set_key("x-new-header");
         mut1->mutable_header()->set_raw_value("new");
         return true;
@@ -1343,6 +1352,7 @@ TEST_P(ExtProcIntegrationTest, GetAndSetHeaders) {
 
         auto response_header_mutation = headers_resp.mutable_response()->mutable_header_mutation();
         auto* mut1 = response_header_mutation->add_set_headers();
+        mut1->mutable_append()->set_value(false);
         mut1->mutable_header()->set_key("x-new-header");
         mut1->mutable_header()->set_raw_value("new");
         response_header_mutation->add_remove_headers("x-remove-this");
@@ -1427,6 +1437,7 @@ TEST_P(ExtProcIntegrationTest, SetHostHeaderRoutingSucceeded) {
 
         // Set host header to match the domain of virtual host in routing configuration.
         auto* mut = response_header_mutation->add_set_headers();
+        mut->mutable_append()->set_value(false);
         mut->mutable_header()->set_key(":authority");
         mut->mutable_header()->set_raw_value(vhost_domain);
 
@@ -1488,6 +1499,7 @@ TEST_P(ExtProcIntegrationTest, SetHostHeaderRoutingFailed) {
         // Set host header to the wrong value that doesn't match the domain of virtual host in route
         // configuration.
         auto* mut1 = response_header_mutation->add_set_headers();
+        mut1->mutable_append()->set_value(false);
         mut1->mutable_header()->set_key(":authority");
         mut1->mutable_header()->set_raw_value("wrong_host");
 
@@ -1518,18 +1530,22 @@ TEST_P(ExtProcIntegrationTest, GetAndSetPathHeader) {
 
         auto response_header_mutation = headers_resp.mutable_response()->mutable_header_mutation();
         auto* mut1 = response_header_mutation->add_set_headers();
+        mut1->mutable_append()->set_value(false);
         mut1->mutable_header()->set_key(":path");
         mut1->mutable_header()->set_raw_value("/mutated_path/bluh");
 
         auto* mut2 = response_header_mutation->add_set_headers();
+        mut2->mutable_append()->set_value(false);
         mut2->mutable_header()->set_key(":scheme");
         mut2->mutable_header()->set_raw_value("https");
 
         auto* mut3 = response_header_mutation->add_set_headers();
+        mut3->mutable_append()->set_value(false);
         mut3->mutable_header()->set_key(":authority");
         mut3->mutable_header()->set_raw_value("new_host");
 
         auto* mut4 = response_header_mutation->add_set_headers();
+        mut4->mutable_append()->set_value(false);
         mut4->mutable_header()->set_key(":method");
         mut4->mutable_header()->set_raw_value("POST");
         return true;
@@ -1572,6 +1588,7 @@ TEST_P(ExtProcIntegrationTest, GetAndSetHeadersWithLogging) {
       *grpc_upstreams_[0], true, [](const HttpHeaders&, HeadersResponse& headers_resp) {
         auto response_header_mutation = headers_resp.mutable_response()->mutable_header_mutation();
         auto* mut1 = response_header_mutation->add_set_headers();
+        mut1->mutable_append()->set_value(false);
         mut1->mutable_header()->set_key("x-new-header");
         mut1->mutable_header()->set_raw_value("new");
         return true;
@@ -1679,6 +1696,7 @@ TEST_P(ExtProcIntegrationTest, GetAndSetHeadersNonUtf8WithValueInBytes) {
         auto response_header_mutation = headers_resp.mutable_response()->mutable_header_mutation();
         response_header_mutation->add_remove_headers("x-bad-utf8");
         auto* mut1 = response_header_mutation->add_set_headers();
+        mut1->mutable_append()->set_value(false);
         mut1->mutable_header()->set_key("x-new-utf8");
         // Construct a non-utf8 header value and send back to Envoy.
         std::string invalid_unicode("valid_prefix");
@@ -1836,6 +1854,7 @@ TEST_P(ExtProcIntegrationTest, RemoveResponseContentLengthAfterBodyProcessing) {
       *grpc_upstreams_[0], true, [](const HttpHeaders&, HeadersResponse& headers_resp) {
         auto* content_length =
             headers_resp.mutable_response()->mutable_header_mutation()->add_set_headers();
+        content_length->mutable_append()->set_value(false);
         content_length->mutable_header()->set_key("content-length");
         content_length->mutable_header()->set_raw_value("13");
         return true;
@@ -1871,6 +1890,7 @@ TEST_P(ExtProcIntegrationTest, MismatchedContentLengthAndBodyLength) {
       *grpc_upstreams_[0], true, [&](const HttpHeaders&, HeadersResponse& headers_resp) {
         auto* content_length =
             headers_resp.mutable_response()->mutable_header_mutation()->add_set_headers();
+        content_length->mutable_append()->set_value(false);
         content_length->mutable_header()->set_key("content-length");
         content_length->mutable_header()->set_raw_value(absl::StrCat(set_content_length));
         return true;
@@ -1904,9 +1924,11 @@ TEST_P(ExtProcIntegrationTest, GetAndSetHeadersOnResponse) {
       *grpc_upstreams_[0], false, [](const HttpHeaders&, HeadersResponse& headers_resp) {
         auto* response_mutation = headers_resp.mutable_response()->mutable_header_mutation();
         auto* add1 = response_mutation->add_set_headers();
+        add1->mutable_append()->set_value(false);
         add1->mutable_header()->set_key("x-response-processed");
         add1->mutable_header()->set_raw_value("1");
         auto* add2 = response_mutation->add_set_headers();
+        add2->mutable_append()->set_value(false);
         add2->mutable_header()->set_key(":status");
         add2->mutable_header()->set_raw_value("201");
         return true;
@@ -1935,9 +1957,11 @@ TEST_P(ExtProcIntegrationTest, GetAndSetHeadersOnResponseBadStatus) {
       *grpc_upstreams_[0], false, [](const HttpHeaders&, HeadersResponse& headers_resp) {
         auto* response_mutation = headers_resp.mutable_response()->mutable_header_mutation();
         auto* add1 = response_mutation->add_set_headers();
+        add1->mutable_append()->set_value(false);
         add1->mutable_header()->set_key("x-response-processed");
         add1->mutable_header()->set_raw_value("1");
         auto* add2 = response_mutation->add_set_headers();
+        add2->mutable_append()->set_value(false);
         add2->mutable_header()->set_key(":status");
         add2->mutable_header()->set_raw_value("100");
         return true;
@@ -1964,9 +1988,11 @@ TEST_P(ExtProcIntegrationTest, GetAndSetHeadersOnResponseTwoStatuses) {
       *grpc_upstreams_[0], false, [](const HttpHeaders&, HeadersResponse& headers_resp) {
         auto* response_mutation = headers_resp.mutable_response()->mutable_header_mutation();
         auto* add1 = response_mutation->add_set_headers();
+        add1->mutable_append()->set_value(false);
         add1->mutable_header()->set_key("x-response-processed");
         add1->mutable_header()->set_raw_value("1");
         auto* add2 = response_mutation->add_set_headers();
+        add2->mutable_append()->set_value(false);
         add2->mutable_header()->set_key(":status");
         add2->mutable_header()->set_raw_value("201");
         auto* add3 = response_mutation->add_set_headers();
@@ -2002,6 +2028,7 @@ TEST_P(ExtProcIntegrationTest, GetAndSetHeadersAndTrailersOnResponse) {
         EXPECT_THAT(trailers.trailers(), HeaderProtosEqual(expected_trailers));
         auto* trailer_mut = resp.mutable_header_mutation();
         auto* trailer_add = trailer_mut->add_set_headers();
+        trailer_add->mutable_append()->set_value(false);
         trailer_add->mutable_header()->set_key("x-modified-trailers");
         trailer_add->mutable_header()->set_raw_value("xxx");
         return true;
@@ -2034,6 +2061,7 @@ TEST_P(ExtProcIntegrationTest, DISABLED_GetAndSetTrailersIncorrectlyOnResponse) 
   processResponseTrailersMessage(
       *grpc_upstreams_[0], false, [](const HttpTrailers&, TrailersResponse& resp) {
         auto* trailer_add = resp.mutable_header_mutation()->add_set_headers();
+        trailer_add->mutable_append()->set_value(false);
         trailer_add->mutable_header()->set_key("x-modified-trailers");
         trailer_add->mutable_header()->set_raw_value("xxx");
         return true;
@@ -2059,6 +2087,7 @@ TEST_P(ExtProcIntegrationTest, GetAndSetOnlyTrailersOnResponse) {
         EXPECT_THAT(trailers.trailers(), HeaderProtosEqual(expected_trailers));
         auto* trailer_mut = resp.mutable_header_mutation();
         auto* trailer_add = trailer_mut->add_set_headers();
+        trailer_add->mutable_append()->set_value(false);
         trailer_add->mutable_header()->set_key("x-modified-trailers");
         trailer_add->mutable_header()->set_raw_value("xxx");
         return true;
@@ -2087,6 +2116,7 @@ TEST_P(ExtProcIntegrationTest, GetAndSetBodyAndHeadersOnResponse) {
       *grpc_upstreams_[0], false, [](const HttpHeaders&, HeadersResponse& headers_resp) {
         auto* content_length =
             headers_resp.mutable_response()->mutable_header_mutation()->add_set_headers();
+        content_length->mutable_append()->set_value(false);
         content_length->mutable_header()->set_key("content-length");
         content_length->mutable_header()->set_raw_value("13");
         return true;
@@ -2100,6 +2130,7 @@ TEST_P(ExtProcIntegrationTest, GetAndSetBodyAndHeadersOnResponse) {
         body_mut->set_body("Hello, World!");
         auto* header_mut = body_resp.mutable_response()->mutable_header_mutation();
         auto* header_add = header_mut->add_set_headers();
+        header_add->mutable_append()->set_value(false);
         header_add->mutable_header()->set_key("x-testing-response-header");
         header_add->mutable_header()->set_raw_value("Yes");
         return true;
@@ -2151,6 +2182,7 @@ TEST_P(ExtProcIntegrationTest, GetAndSetBodyAndHeadersOnResponsePartialBuffered)
       *grpc_upstreams_[0], false, [](const HttpHeaders&, HeadersResponse& headers_resp) {
         auto* content_length =
             headers_resp.mutable_response()->mutable_header_mutation()->add_set_headers();
+        content_length->mutable_append()->set_value(false);
         content_length->mutable_header()->set_key("content-length");
         content_length->mutable_header()->set_raw_value("100");
         return true;
@@ -2161,6 +2193,7 @@ TEST_P(ExtProcIntegrationTest, GetAndSetBodyAndHeadersOnResponsePartialBuffered)
         EXPECT_TRUE(body.end_of_stream());
         auto* header_mut = body_resp.mutable_response()->mutable_header_mutation();
         auto* header_add = header_mut->add_set_headers();
+        header_add->mutable_append()->set_value(false);
         header_add->mutable_header()->set_key("x-testing-response-header");
         header_add->mutable_header()->set_raw_value("Yes");
         return true;
@@ -2198,6 +2231,7 @@ TEST_P(ExtProcIntegrationTest, GetAndSetBodyAndHeadersAndTrailersOnResponse) {
         EXPECT_THAT(trailers.trailers(), HeaderProtosEqual(expected_trailers));
         auto* trailer_mut = resp.mutable_header_mutation();
         auto* trailer_add = trailer_mut->add_set_headers();
+        trailer_add->mutable_append()->set_value(false);
         trailer_add->mutable_header()->set_key("x-modified-trailers");
         trailer_add->mutable_header()->set_raw_value("xxx");
         return true;
@@ -2261,6 +2295,7 @@ TEST_P(ExtProcIntegrationTest, GetAndSetBodyAndHeadersOnBigResponse) {
         EXPECT_TRUE(body.end_of_stream());
         auto* header_mut = body_resp.mutable_response()->mutable_header_mutation();
         auto* header_add = header_mut->add_set_headers();
+        header_add->mutable_append()->set_value(false);
         header_add->mutable_header()->set_key("x-testing-response-header");
         header_add->mutable_header()->set_raw_value("Yes");
         return true;
@@ -2284,6 +2319,7 @@ TEST_P(ExtProcIntegrationTest, GetAndSetBodyOnBoth) {
       *grpc_upstreams_[0], true, [](const HttpHeaders&, HeadersResponse& headers_resp) {
         auto* content_length =
             headers_resp.mutable_response()->mutable_header_mutation()->add_set_headers();
+        content_length->mutable_append()->set_value(false);
         content_length->mutable_header()->set_key("content-length");
         content_length->mutable_header()->set_raw_value("13");
         return true;
@@ -2330,6 +2366,7 @@ TEST_P(ExtProcIntegrationTest, ProcessingModeResponseOnly) {
       *grpc_upstreams_[0], true, [](const HttpHeaders&, HeadersResponse& headers_resp) {
         auto* response_mutation = headers_resp.mutable_response()->mutable_header_mutation();
         auto* add1 = response_mutation->add_set_headers();
+        add1->mutable_append()->set_value(false);
         add1->mutable_header()->set_key("x-response-processed");
         add1->mutable_header()->set_raw_value("1");
         return true;
@@ -2353,9 +2390,11 @@ TEST_P(ExtProcIntegrationTest, GetAndRespondImmediately) {
     immediate.set_body("{\"reason\": \"Not authorized\"}");
     immediate.set_details("Failed because you are not authorized");
     auto* hdr1 = immediate.mutable_headers()->add_set_headers();
+    hdr1->mutable_append()->set_value(false);
     hdr1->mutable_header()->set_key("x-failure-reason");
     hdr1->mutable_header()->set_raw_value("testing");
     auto* hdr2 = immediate.mutable_headers()->add_set_headers();
+    hdr2->mutable_append()->set_value(false);
     hdr2->mutable_header()->set_key("content-type");
     hdr2->mutable_header()->set_raw_value("application/json");
   });
@@ -2384,9 +2423,11 @@ TEST_P(ExtProcIntegrationTest, GetAndRespondImmediatelyGracefulClose) {
     immediate.set_body("{\"reason\": \"Not authorized\"}");
     immediate.set_details("Failed because you are not authorized");
     auto* hdr1 = immediate.mutable_headers()->add_set_headers();
+    hdr1->mutable_append()->set_value(false);
     hdr1->mutable_header()->set_key("x-failure-reason");
     hdr1->mutable_header()->set_raw_value("testing");
     auto* hdr2 = immediate.mutable_headers()->add_set_headers();
+    hdr2->mutable_append()->set_value(false);
     hdr2->mutable_header()->set_key("content-type");
     hdr2->mutable_header()->set_raw_value("application/json");
   });
@@ -2420,9 +2461,11 @@ TEST_P(ExtProcIntegrationTest, GetAndRespondImmediatelyGracefulCloseNoServerTrai
     immediate.set_body("{\"reason\": \"Not authorized\"}");
     immediate.set_details("Failed because you are not authorized");
     auto* hdr1 = immediate.mutable_headers()->add_set_headers();
+    hdr1->mutable_append()->set_value(false);
     hdr1->mutable_header()->set_key("x-failure-reason");
     hdr1->mutable_header()->set_raw_value("testing");
     auto* hdr2 = immediate.mutable_headers()->add_set_headers();
+    hdr2->mutable_append()->set_value(false);
     hdr2->mutable_header()->set_key("content-type");
     hdr2->mutable_header()->set_raw_value("application/json");
   });
@@ -2453,9 +2496,11 @@ TEST_P(ExtProcIntegrationTest, GetAndRespondImmediatelyWithLogging) {
     immediate.set_body("{\"reason\": \"Not authorized\"}");
     immediate.set_details("Failed because you are not authorized");
     auto* hdr1 = immediate.mutable_headers()->add_set_headers();
+    hdr1->mutable_append()->set_value(false);
     hdr1->mutable_header()->set_key("x-failure-reason");
     hdr1->mutable_header()->set_raw_value("testing");
     auto* hdr2 = immediate.mutable_headers()->add_set_headers();
+    hdr2->mutable_append()->set_value(false);
     hdr2->mutable_header()->set_key("content-type");
     hdr2->mutable_header()->set_raw_value("application/json");
   });
@@ -2474,6 +2519,7 @@ TEST_P(ExtProcIntegrationTest, GetAndRespondImmediatelyWithInvalidCharacter) {
   processAndRespondImmediately(*grpc_upstreams_[0], true, [](ImmediateResponse& immediate) {
     immediate.mutable_status()->set_code(envoy::type::v3::StatusCode::Unauthorized);
     auto* hdr = immediate.mutable_headers()->add_set_headers();
+    hdr->mutable_append()->set_value(false);
     hdr->mutable_header()->set_key("x-failure-reason\n");
     hdr->mutable_header()->set_raw_value("testing");
   });
@@ -2515,6 +2561,7 @@ TEST_P(ExtProcIntegrationTest, GetAndRespondImmediatelyOnStreamedRequestBody) {
   processRequestHeadersMessage(
       *grpc_upstreams_[0], true, [](const HttpHeaders&, HeadersResponse& resp) {
         auto* hdr = resp.mutable_response()->mutable_header_mutation()->add_set_headers();
+        hdr->mutable_append()->set_value(false);
         hdr->mutable_header()->set_key("foo");
         hdr->mutable_header()->set_raw_value("bar");
         return true;
@@ -2548,6 +2595,7 @@ TEST_P(ExtProcIntegrationTest, GetAndRespondImmediatelyOnStreamedResponseBody) {
   processResponseHeadersMessage(
       *grpc_upstreams_[0], false, [](const HttpHeaders&, HeadersResponse& resp) {
         auto* hdr = resp.mutable_response()->mutable_header_mutation()->add_set_headers();
+        hdr->mutable_append()->set_value(false);
         hdr->mutable_header()->set_key("foo");
         hdr->mutable_header()->set_raw_value("bar");
         return true;
@@ -2716,6 +2764,7 @@ TEST_P(ExtProcIntegrationTest, GetAndRespondImmediatelyWithSystemHeaderMutation)
     immediate.mutable_status()->set_code(envoy::type::v3::StatusCode::Unauthorized);
     auto* hdr = immediate.mutable_headers()->add_set_headers();
     // Adding system header in the ext_proc response.
+    hdr->mutable_append()->set_value(false);
     hdr->mutable_header()->set_key(":foo");
     hdr->mutable_header()->set_raw_value("bar");
   });
@@ -2736,6 +2785,7 @@ TEST_P(ExtProcIntegrationTest, GetAndRespondImmediatelyWithEnvoyHeaderMutation) 
     immediate.mutable_status()->set_code(envoy::type::v3::StatusCode::Unauthorized);
     auto* hdr = immediate.mutable_headers()->add_set_headers();
     // Adding x-envoy header is not allowed.
+    hdr->mutable_append()->set_value(false);
     hdr->mutable_header()->set_key("x-envoy-foo");
     hdr->mutable_header()->set_raw_value("bar");
   });
@@ -2753,9 +2803,11 @@ TEST_P(ExtProcIntegrationTest, GetAndImmediateRespondMutationAllowEnvoy) {
   processAndRespondImmediately(*grpc_upstreams_[0], true, [](ImmediateResponse& immediate) {
     immediate.mutable_status()->set_code(envoy::type::v3::StatusCode::Unauthorized);
     auto* hdr = immediate.mutable_headers()->add_set_headers();
+    hdr->mutable_append()->set_value(false);
     hdr->mutable_header()->set_key("x-envoy-foo");
     hdr->mutable_header()->set_raw_value("bar");
     auto* hdr1 = immediate.mutable_headers()->add_set_headers();
+    hdr1->mutable_append()->set_value(false);
     hdr1->mutable_header()->set_key("host");
     hdr1->mutable_header()->set_raw_value("test");
   });
@@ -2779,6 +2831,7 @@ TEST_P(ExtProcIntegrationTest, GetAndIncorrectlyModifyHeaderOnBody) {
       *grpc_upstreams_[0], false, [](const HttpBody& body, BodyResponse& response) {
         EXPECT_TRUE(body.end_of_stream());
         auto* mut = response.mutable_response()->mutable_header_mutation()->add_set_headers();
+        mut->mutable_append()->set_value(false);
         mut->mutable_header()->set_key(":scheme");
         mut->mutable_header()->set_raw_value("tcp");
         return true;
@@ -2801,6 +2854,7 @@ TEST_P(ExtProcIntegrationTest, GetAndIncorrectlyModifyHeaderOnBodyPartialBuffer)
       *grpc_upstreams_[0], false, [](const HttpBody& body, BodyResponse& response) {
         EXPECT_TRUE(body.end_of_stream());
         auto* mut = response.mutable_response()->mutable_header_mutation()->add_set_headers();
+        mut->mutable_append()->set_value(false);
         mut->mutable_header()->set_key(":scheme");
         mut->mutable_header()->set_raw_value("tcp");
         return true;
@@ -2821,9 +2875,11 @@ TEST_P(ExtProcIntegrationTest, ConvertGetToPost) {
       *grpc_upstreams_[0], true, [](const HttpHeaders&, HeadersResponse& headers_resp) {
         auto* header_mut = headers_resp.mutable_response()->mutable_header_mutation();
         auto* method = header_mut->add_set_headers();
+        method->mutable_append()->set_value(false);
         method->mutable_header()->set_key(":method");
         method->mutable_header()->set_raw_value("POST");
         auto* content_type = header_mut->add_set_headers();
+        content_type->mutable_append()->set_value(false);
         content_type->mutable_header()->set_key("content-type");
         content_type->mutable_header()->set_raw_value("text/plain");
         headers_resp.mutable_response()->mutable_body_mutation()->set_body("Hello, Server!");
@@ -3465,9 +3521,11 @@ TEST_P(ExtProcIntegrationTest, PerRouteGrpcService) {
       *grpc_upstreams_[1], false, [](const HttpHeaders&, HeadersResponse& headers_resp) {
         auto* response_mutation = headers_resp.mutable_response()->mutable_header_mutation();
         auto* add1 = response_mutation->add_set_headers();
+        add1->mutable_append()->set_value(false);
         add1->mutable_header()->set_key("x-response-processed");
         add1->mutable_header()->set_raw_value("1");
         auto* add2 = response_mutation->add_set_headers();
+        add2->mutable_append()->set_value(false);
         add2->mutable_header()->set_key(":status");
         add2->mutable_header()->set_raw_value("201");
         return true;
@@ -3542,6 +3600,7 @@ TEST_P(ExtProcIntegrationTest, RequestAndResponseMessageNewTimeoutWithHeaderMuta
         // Server sends back response with the header mutation instructions.
         auto response_header_mutation = headers_resp.mutable_response()->mutable_header_mutation();
         auto* mut1 = response_header_mutation->add_set_headers();
+        mut1->mutable_append()->set_value(false);
         mut1->mutable_header()->set_key("x-new-header");
         mut1->mutable_header()->set_raw_value("new");
         response_header_mutation->add_remove_headers("x-remove-this");
@@ -3906,6 +3965,7 @@ TEST_P(ExtProcIntegrationTest, GetAndSetBodyOnBothWithClearRouteCache) {
       *grpc_upstreams_[0], true, [](const HttpHeaders&, HeadersResponse& headers_resp) {
         auto* content_length =
             headers_resp.mutable_response()->mutable_header_mutation()->add_set_headers();
+        content_length->mutable_append()->set_value(false);
         content_length->mutable_header()->set_key("content-length");
         content_length->mutable_header()->set_raw_value("13");
         headers_resp.mutable_response()->set_clear_route_cache(true);
@@ -3938,6 +3998,7 @@ TEST_P(ExtProcIntegrationTest, GetAndSetBodyOnBothWithClearRouteCache) {
         EXPECT_TRUE(body.end_of_stream());
         auto* header_mut = body_resp.mutable_response()->mutable_header_mutation();
         auto* header_add = header_mut->add_set_headers();
+        header_add->mutable_append()->set_value(false);
         header_add->mutable_header()->set_key("x-testing-response-header");
         header_add->mutable_header()->set_raw_value("Yes");
         body_resp.mutable_response()->set_clear_route_cache(true);
@@ -4487,6 +4548,7 @@ TEST_P(ExtProcIntegrationTest, GetAndSetHeadersUpstream) {
         EXPECT_THAT(headers.headers(), HeaderProtosEqual(expected_request_headers));
         auto response_header_mutation = headers_resp.mutable_response()->mutable_header_mutation();
         auto* mut1 = response_header_mutation->add_set_headers();
+        mut1->mutable_append()->set_value(false);
         mut1->mutable_header()->set_key("x-new-header");
         mut1->mutable_header()->set_raw_value("new");
         response_header_mutation->add_remove_headers("x-remove-this");
@@ -4552,6 +4614,7 @@ TEST_P(ExtProcIntegrationTest, RetryOnResponseError) {
                          ->mutable_response()
                          ->mutable_header_mutation()
                          ->add_set_headers();
+  new_header->mutable_append()->set_value(false);
   new_header->mutable_header()->set_key("foo");
   new_header->mutable_header()->set_raw_value("bluh");
   processor_stream_->sendGrpcMessage(processing_response);
@@ -4627,6 +4690,7 @@ TEST_P(ExtProcIntegrationTest, RetryOnDifferentHost) {
                          ->mutable_response()
                          ->mutable_header_mutation()
                          ->add_set_headers();
+  new_header->mutable_append()->set_value(false);
   new_header->mutable_header()->set_key("foo");
   new_header->mutable_header()->set_raw_value("bluh");
   processor_stream_2->sendGrpcMessage(processing_response);
@@ -4663,6 +4727,7 @@ TEST_P(ExtProcIntegrationTest, ObservabilityModeWithHeader) {
         // Try to mutate the header.
         auto* response_mutation = headers_resp.mutable_response()->mutable_header_mutation();
         auto* add1 = response_mutation->add_set_headers();
+        add1->mutable_append()->set_value(false);
         add1->mutable_header()->set_key("x-response-processed");
         add1->mutable_header()->set_raw_value("1");
         return true;
@@ -4776,6 +4841,7 @@ TEST_P(ExtProcIntegrationTest, ObservabilityModeWithTrailer) {
         // Try to mutate the trailer
         auto* trailer_mut = resp.mutable_header_mutation();
         auto* trailer_add = trailer_mut->add_set_headers();
+        trailer_add->mutable_append()->set_value(false);
         trailer_add->mutable_header()->set_key("x-modified-trailers");
         trailer_add->mutable_header()->set_raw_value("xxx");
         return true;
@@ -4954,6 +5020,7 @@ TEST_P(ExtProcIntegrationTest, GetAndSetHeadersUpstreamObservabilityMode) {
         EXPECT_THAT(headers.headers(), HeaderProtosEqual(expected_request_headers));
         auto response_header_mutation = headers_resp.mutable_response()->mutable_header_mutation();
         auto* mut1 = response_header_mutation->add_set_headers();
+        mut1->mutable_append()->set_value(false);
         mut1->mutable_header()->set_key("x-new-header");
         mut1->mutable_header()->set_raw_value("new");
         response_header_mutation->add_remove_headers("x-remove-this");
@@ -5026,6 +5093,7 @@ TEST_P(ExtProcIntegrationTest, DISABLED_GetAndSetHeadersUpstreamObservabilityMod
         EXPECT_THAT(headers.headers(), HeaderProtosEqual(expected_request_headers));
         auto response_header_mutation = headers_resp.mutable_response()->mutable_header_mutation();
         auto* mut1 = response_header_mutation->add_set_headers();
+        mut1->mutable_append()->set_value(false);
         mut1->mutable_header()->set_key("x-new-header");
         mut1->mutable_header()->set_raw_value("new");
         response_header_mutation->add_remove_headers("x-remove-this");
@@ -5210,6 +5278,7 @@ TEST_P(ExtProcIntegrationTest, SendBodyBeforeHeaderRespStreamedBasicTest) {
 
         auto response_header_mutation = headers_resp.mutable_response()->mutable_header_mutation();
         auto* mut1 = response_header_mutation->add_set_headers();
+        mut1->mutable_append()->set_value(false);
         mut1->mutable_header()->set_key("x-new-header");
         mut1->mutable_header()->set_raw_value("new");
         response_header_mutation->add_remove_headers("x-remove-this");
@@ -5320,6 +5389,7 @@ TEST_P(ExtProcIntegrationTest, ServerWaitForBodyBeforeSendsHeaderRespStreamedTes
   auto* header_resp = response_header.mutable_request_headers();
   auto header_mutation = header_resp->mutable_response()->mutable_header_mutation();
   auto* mut = header_mutation->add_set_headers();
+  mut->mutable_append()->set_value(false);
   mut->mutable_header()->set_key("x-new-header");
   mut->mutable_header()->set_raw_value("new");
   processor_stream_->sendGrpcMessage(response_header);

--- a/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
+++ b/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
@@ -862,7 +862,7 @@ protected:
       header_resp = response_header.mutable_request_headers();
     }
     auto* header_mutation = header_resp->mutable_response()->mutable_header_mutation();
-    auto *sh = header_mutation->add_set_headers();
+    auto* sh = header_mutation->add_set_headers();
     auto* header = sh->mutable_header();
     sh->mutable_append()->set_value(false);
     header->set_key("x-new-header");
@@ -895,7 +895,7 @@ protected:
   void serverSendTrailerRespDuplexStreamed() {
     ProcessingResponse response_trailer;
     auto* trailer_resp = response_trailer.mutable_request_trailers()->mutable_header_mutation();
-    auto *sh = trailer_resp->add_set_headers();
+    auto* sh = trailer_resp->add_set_headers();
     sh->mutable_append()->set_value(false);
     auto* header = sh->mutable_header();
     header->set_key("x-new-trailer");

--- a/test/extensions/filters/http/ext_proc/filter_test.cc
+++ b/test/extensions/filters/http/ext_proc/filter_test.cc
@@ -797,6 +797,7 @@ TEST_F(HttpFilterTest, PostAndChangeHeaders) {
 
     auto* resp_headers_mut = header_resp.mutable_response()->mutable_header_mutation();
     auto* resp_add1 = resp_headers_mut->add_set_headers();
+    resp_add1->mutable_append()->set_value(false);
     resp_add1->mutable_header()->set_key("x-new-header");
     resp_add1->mutable_header()->set_raw_value("new");
   });
@@ -848,6 +849,7 @@ TEST_F(HttpFilterTest, PostAndRespondImmediately) {
   immediate_response->set_details("Got a bad request");
   auto* immediate_headers = immediate_response->mutable_headers();
   auto* hdr1 = immediate_headers->add_set_headers();
+  hdr1->mutable_append()->set_value(false);
   hdr1->mutable_header()->set_key("content-type");
   hdr1->mutable_header()->set_raw_value("text/plain");
   auto* hdr2 = immediate_headers->add_set_headers();
@@ -903,6 +905,7 @@ TEST_F(HttpFilterTest, PostAndRespondImmediatelyWithDisabledConfig) {
   immediate_response->set_details("Got a bad request");
   auto* immediate_headers = immediate_response->mutable_headers();
   auto* hdr1 = immediate_headers->add_set_headers();
+  hdr1->mutable_append()->set_value(false);
   hdr1->mutable_header()->set_key("content-type");
   hdr1->mutable_header()->set_raw_value("text/plain");
   stream_callbacks_->onReceiveMessage(std::move(resp1));
@@ -2924,6 +2927,7 @@ TEST_F(HttpFilterTest, ClearRouteCacheHeaderMutation) {
   processRequestHeaders(false, [](const HttpHeaders&, ProcessingResponse&, HeadersResponse& resp) {
     auto* resp_headers_mut = resp.mutable_response()->mutable_header_mutation();
     auto* resp_add = resp_headers_mut->add_set_headers();
+    resp_add->mutable_append()->set_value(false);
     resp_add->mutable_header()->set_key("x-new-header");
     resp_add->mutable_header()->set_raw_value("new");
     resp.mutable_response()->set_clear_route_cache(true);
@@ -2941,6 +2945,7 @@ TEST_F(HttpFilterTest, ClearRouteCacheHeaderMutation) {
   processResponseBody([](const HttpBody&, ProcessingResponse&, BodyResponse& resp) {
     auto* resp_headers_mut = resp.mutable_response()->mutable_header_mutation();
     auto* resp_add = resp_headers_mut->add_set_headers();
+    resp_add->mutable_append()->set_value(false);
     resp_add->mutable_header()->set_key("x-new-header");
     resp_add->mutable_header()->set_raw_value("new");
     resp.mutable_response()->set_clear_route_cache(true);
@@ -2974,6 +2979,7 @@ TEST_F(HttpFilterTest, ClearRouteCacheDisabledHeaderMutation) {
   processRequestHeaders(false, [](const HttpHeaders&, ProcessingResponse&, HeadersResponse& resp) {
     auto* resp_headers_mut = resp.mutable_response()->mutable_header_mutation();
     auto* resp_add = resp_headers_mut->add_set_headers();
+    resp_add->mutable_append()->set_value(false);
     resp_add->mutable_header()->set_key("x-new-header");
     resp_add->mutable_header()->set_raw_value("new");
     resp.mutable_response()->set_clear_route_cache(true);
@@ -2991,6 +2997,7 @@ TEST_F(HttpFilterTest, ClearRouteCacheDisabledHeaderMutation) {
   processResponseBody([](const HttpBody&, ProcessingResponse&, BodyResponse& resp) {
     auto* resp_headers_mut = resp.mutable_response()->mutable_header_mutation();
     auto* resp_add = resp_headers_mut->add_set_headers();
+    resp_add->mutable_append()->set_value(false);
     resp_add->mutable_header()->set_key("x-new-header");
     resp_add->mutable_header()->set_raw_value("new");
     resp.mutable_response()->set_clear_route_cache(true);
@@ -3096,6 +3103,7 @@ TEST_F(HttpFilterTest, FilterRouteCacheActionSetToClearHeaderMutation) {
   processRequestHeaders(false, [](const HttpHeaders&, ProcessingResponse&, HeadersResponse& resp) {
     auto* resp_headers_mut = resp.mutable_response()->mutable_header_mutation();
     auto* resp_add = resp_headers_mut->add_set_headers();
+    resp_add->mutable_append()->set_value(false);
     resp_add->mutable_header()->set_key("x-new-header");
     resp_add->mutable_header()->set_raw_value("new");
   });
@@ -3175,6 +3183,7 @@ TEST_F(HttpFilterTest, FilterRouteCacheActionSetToRetainWithHeaderMutation) {
   processRequestHeaders(false, [](const HttpHeaders&, ProcessingResponse&, HeadersResponse& resp) {
     auto* resp_headers_mut = resp.mutable_response()->mutable_header_mutation();
     auto* resp_add = resp_headers_mut->add_set_headers();
+    resp_add->mutable_append()->set_value(false);
     resp_add->mutable_header()->set_key("x-new-header");
     resp_add->mutable_header()->set_raw_value("new");
     resp.mutable_response()->set_clear_route_cache(true);
@@ -3203,6 +3212,7 @@ TEST_F(HttpFilterTest, FilterRouteCacheActionSetToRetainResponseNotWithHeaderMut
   processRequestHeaders(false, [](const HttpHeaders&, ProcessingResponse&, HeadersResponse& resp) {
     auto* resp_headers_mut = resp.mutable_response()->mutable_header_mutation();
     auto* resp_add = resp_headers_mut->add_set_headers();
+    resp_add->mutable_append()->set_value(false);
     resp_add->mutable_header()->set_key("x-new-header");
     resp_add->mutable_header()->set_raw_value("new");
   });
@@ -3234,6 +3244,7 @@ TEST_F(HttpFilterTest, ReplaceRequest) {
       false, [](const HttpHeaders&, ProcessingResponse&, HeadersResponse& hdrs_resp) {
         hdrs_resp.mutable_response()->set_status(CommonResponse::CONTINUE_AND_REPLACE);
         auto* hdr = hdrs_resp.mutable_response()->mutable_header_mutation()->add_set_headers();
+        hdr->mutable_append()->set_value(false);
         hdr->mutable_header()->set_key(":method");
         hdr->mutable_header()->set_raw_value("POST");
         hdrs_resp.mutable_response()->mutable_body_mutation()->set_body("Hello, World!");
@@ -3295,6 +3306,7 @@ TEST_F(HttpFilterTest, ReplaceCompleteResponseBuffered) {
       false, [](const HttpHeaders&, ProcessingResponse&, HeadersResponse& hdrs_resp) {
         hdrs_resp.mutable_response()->set_status(CommonResponse::CONTINUE_AND_REPLACE);
         auto* hdr = hdrs_resp.mutable_response()->mutable_header_mutation()->add_set_headers();
+        hdr->mutable_append()->set_value(false);
         hdr->mutable_header()->set_key("x-test-header");
         hdr->mutable_header()->set_raw_value("true");
         hdrs_resp.mutable_response()->mutable_body_mutation()->set_body("Hello, World!");
@@ -3498,6 +3510,7 @@ TEST_F(HttpFilterTest, IgnoreInvalidHeaderMutations) {
         auto headers_mut = header_resp.mutable_response()->mutable_header_mutation();
         auto add1 = headers_mut->add_set_headers();
         // Not allowed to change the "host" header by default
+        add1->mutable_append()->set_value(false);
         add1->mutable_header()->set_key("Host");
         add1->mutable_header()->set_raw_value("wrong:1234");
         // Not allowed to remove x-envoy headers by default.
@@ -3546,6 +3559,7 @@ TEST_F(HttpFilterTest, FailOnInvalidHeaderMutations) {
       resp1->mutable_request_headers()->mutable_response()->mutable_header_mutation();
   auto add1 = headers_mut->add_set_headers();
   // Not allowed to change the "host" header by default
+  add1->mutable_append()->set_value(false);
   add1->mutable_header()->set_key("Host");
   add1->mutable_header()->set_raw_value("wrong:1234");
   // Not allowed to remove x-envoy headers by default.
@@ -3590,9 +3604,11 @@ TEST_F(HttpFilterTest, ResponseTrailerMutationExceedSizeLimit) {
         // The trailer mutation in the response does not exceed the count limit 100 or the
         // size limit 2kb. But the result header map size exceeds the count limit 2kb.
         auto add1 = headers_mut->add_set_headers();
+        add1->mutable_append()->set_value(false);
         add1->mutable_header()->set_key("x-new-header-0123456789");
         add1->mutable_header()->set_raw_value("new-header-0123456789");
         auto add2 = headers_mut->add_set_headers();
+        add2->mutable_append()->set_value(false);
         add2->mutable_header()->set_key("x-some-other-header-0123456789");
         add2->mutable_header()->set_raw_value("some-new-header-0123456789");
       },
@@ -4753,6 +4769,7 @@ TEST_F(HttpFilterTest, ClearRouteCacheHeaderMutationUpstreamIgnored) {
   processRequestHeaders(false, [](const HttpHeaders&, ProcessingResponse&, HeadersResponse& resp) {
     auto* resp_headers_mut = resp.mutable_response()->mutable_header_mutation();
     auto* resp_add = resp_headers_mut->add_set_headers();
+    resp_add->mutable_append()->set_value(false);
     resp_add->mutable_header()->set_key("x-new-header");
     resp_add->mutable_header()->set_raw_value("new");
     resp.mutable_response()->set_clear_route_cache(true);
@@ -4796,6 +4813,7 @@ TEST_F(HttpFilterTest, PostAndRespondImmediatelyUpstream) {
   immediate_response->set_details("Got a bad request");
   auto* immediate_headers = immediate_response->mutable_headers();
   auto* hdr1 = immediate_headers->add_set_headers();
+  hdr1->mutable_append()->set_value(false);
   hdr1->mutable_header()->set_key("content-type");
   hdr1->mutable_header()->set_raw_value("text/plain");
   stream_callbacks_->onReceiveMessage(std::move(resp1));
@@ -5090,9 +5108,11 @@ TEST_F(HttpFilter2Test, LastDecodeDataCallExceedsStreamBufferLimitWouldJustRaise
         auto* headers_response = response->mutable_request_headers();
         auto* hdr =
             headers_response->mutable_response()->mutable_header_mutation()->add_set_headers();
+        hdr->mutable_append()->set_value(false);
         hdr->mutable_header()->set_key("foo");
         hdr->mutable_header()->set_raw_value("gift-from-external-server");
         hdr = headers_response->mutable_response()->mutable_header_mutation()->add_set_headers();
+        hdr->mutable_append()->set_value(false);
         hdr->mutable_header()->set_key(":path");
         hdr->mutable_header()->set_raw_value("/mutated_path/bluh");
         HttpFilterTest::stream_callbacks_->onReceiveMessage(std::move(response));
@@ -5195,9 +5215,11 @@ TEST_F(HttpFilter2Test, LastEncodeDataCallExceedsStreamBufferLimitWouldJustRaise
         auto* headers_response = response->mutable_response_headers();
         auto* hdr =
             headers_response->mutable_response()->mutable_header_mutation()->add_set_headers();
+        hdr->mutable_append()->set_value(false);
         hdr->mutable_header()->set_key("foo");
         hdr->mutable_header()->set_raw_value("gift-from-external-server");
         hdr = headers_response->mutable_response()->mutable_header_mutation()->add_set_headers();
+        hdr->mutable_append()->set_value(false);
         hdr->mutable_header()->set_key("new_response_header");
         hdr->mutable_header()->set_raw_value("bluh");
         HttpFilterTest::stream_callbacks_->onReceiveMessage(std::move(response));
@@ -5296,6 +5318,7 @@ TEST_F(HttpFilterTest, ResponseHeaderMutationErrors) {
     auto* header_mut =
         resp.mutable_response_headers()->mutable_response()->mutable_header_mutation();
     auto* header = header_mut->add_set_headers();
+    header->mutable_append()->set_value(false);
     header->mutable_header()->set_key(":scheme");
     header->mutable_header()->set_raw_value("invalid");
   });
@@ -5400,6 +5423,7 @@ TEST_F(HttpFilterTest, OnProcessingResponseHeaders) {
 
     auto* resp_headers_mut = header_resp.mutable_response()->mutable_header_mutation();
     auto* resp_add1 = resp_headers_mut->add_set_headers();
+    resp_add1->mutable_append()->set_value(false);
     resp_add1->mutable_header()->set_key("x-new-header");
     resp_add1->mutable_header()->set_raw_value("new");
   });
@@ -5537,6 +5561,7 @@ TEST_F(HttpFilterTest, SaveProcessingResponseHeaders) {
 
     auto* resp_headers_mut = header_resp.mutable_response()->mutable_header_mutation();
     auto* resp_add1 = resp_headers_mut->add_set_headers();
+    resp_add1->mutable_append()->set_value(false);
     resp_add1->mutable_header()->set_key("x-new-header");
     resp_add1->mutable_header()->set_raw_value("new");
   });
@@ -5717,6 +5742,7 @@ TEST_F(HttpFilterTest, SaveImmediateResponse) {
   immediate_response->set_details("Got a bad request");
   auto* immediate_headers = immediate_response->mutable_headers();
   auto* hdr1 = immediate_headers->add_set_headers();
+  hdr1->mutable_append()->set_value(false);
   hdr1->mutable_header()->set_key("content-type");
   hdr1->mutable_header()->set_raw_value("text/plain");
   auto* hdr2 = immediate_headers->add_set_headers();
@@ -5828,6 +5854,7 @@ TEST_F(HttpFilterTest, DontSaveImmediateResponse) {
   immediate_response->set_details("Got a bad request");
   auto* immediate_headers = immediate_response->mutable_headers();
   auto* hdr1 = immediate_headers->add_set_headers();
+  hdr1->mutable_append()->set_value(false);
   hdr1->mutable_header()->set_key("content-type");
   hdr1->mutable_header()->set_raw_value("text/plain");
   stream_callbacks_->onReceiveMessage(std::move(resp1));
@@ -5886,6 +5913,7 @@ TEST_F(HttpFilterTest, DontSaveImmediateResponseOnError) {
   immediate_response->set_details("Got a bad request");
   auto* immediate_headers = immediate_response->mutable_headers();
   auto* hdr1 = immediate_headers->add_set_headers();
+  hdr1->mutable_append()->set_value(false);
   hdr1->mutable_header()->set_key("content-type");
   hdr1->mutable_header()->set_raw_value("text/plain");
   stream_callbacks_->onReceiveMessage(std::move(resp1));
@@ -6008,6 +6036,7 @@ TEST_F(HttpFilterTest, SaveResponseTrailers) {
       [](const HttpTrailers&, ProcessingResponse&, TrailersResponse& trailers_resp) {
         auto headers_mut = trailers_resp.mutable_header_mutation();
         auto* resp_add1 = headers_mut->add_set_headers();
+        resp_add1->mutable_append()->set_value(false);
         resp_add1->mutable_header()->set_key("x-new-header1");
         resp_add1->mutable_header()->set_raw_value("new");
       },

--- a/test/extensions/filters/http/ext_proc/http_client/ext_proc_http_integration_test.cc
+++ b/test/extensions/filters/http/ext_proc/http_client/ext_proc_http_integration_test.cc
@@ -351,6 +351,7 @@ TEST_P(ExtProcHttpClientIntegrationTest, GetAndSetHeadersWithMutation) {
 
         auto response_header_mutation = headers_resp.mutable_response()->mutable_header_mutation();
         auto* mut1 = response_header_mutation->add_set_headers();
+        mut1->mutable_append()->set_value(false);
         mut1->mutable_header()->set_key("x-new-header");
         mut1->mutable_header()->set_raw_value("new");
         response_header_mutation->add_remove_headers("x-remove-this");
@@ -462,6 +463,7 @@ TEST_P(ExtProcHttpClientIntegrationTest, SentHeadersInBothDirection) {
 
         auto response_header_mutation = headers_resp.mutable_response()->mutable_header_mutation();
         auto* mut1 = response_header_mutation->add_set_headers();
+        mut1->mutable_append()->set_value(false);
         mut1->mutable_header()->set_key("x-new-header");
         mut1->mutable_header()->set_raw_value("new");
         return true;

--- a/test/extensions/filters/http/ext_proc/mutation_utils_test.cc
+++ b/test/extensions/filters/http/ext_proc/mutation_utils_test.cc
@@ -86,11 +86,11 @@ TEST_F(MutationUtilsTest, TestApplyMutations) {
   s->mutable_header()->set_key("x-replace-this");
   s->mutable_header()->set_raw_value("no");
   s = mutation.add_set_headers();
+  s->mutable_append()->set_value(false);
   s->mutable_header()->set_key(":status");
   s->mutable_header()->set_raw_value("418");
-  // Default of "append" is "false" and mutations
-  // are applied in order.
   s = mutation.add_set_headers();
+  s->mutable_append()->set_value(false);
   s->mutable_header()->set_key("x-replace-this");
   s->mutable_header()->set_raw_value("nope");
   // Incomplete structures should be ignored
@@ -107,30 +107,38 @@ TEST_F(MutationUtilsTest, TestApplyMutations) {
   // Attempts to set method, host, authority, and x-envoy headers
   // should be ignored until we explicitly allow them.
   s = mutation.add_set_headers();
+  s->mutable_append()->set_value(false);
   s->mutable_header()->set_key("host");
   s->mutable_header()->set_raw_value("invalid:123");
   s = mutation.add_set_headers();
+  s->mutable_append()->set_value(false);
   s->mutable_header()->set_key("Host");
   s->mutable_header()->set_raw_value("invalid:456");
   s = mutation.add_set_headers();
+  s->mutable_append()->set_value(false);
   s->mutable_header()->set_key(":authority");
   s->mutable_header()->set_raw_value("invalid:789");
   s = mutation.add_set_headers();
+  s->mutable_append()->set_value(false);
   s->mutable_header()->set_key(":method");
   s->mutable_header()->set_raw_value("PATCH");
   s = mutation.add_set_headers();
+  s->mutable_append()->set_value(false);
   s->mutable_header()->set_key(":scheme");
   s->mutable_header()->set_raw_value("http");
   s = mutation.add_set_headers();
+  s->mutable_append()->set_value(false);
   s->mutable_header()->set_key("X-Envoy-StrangeThing");
   s->mutable_header()->set_raw_value("Yes");
 
   // Attempts to set the status header out of range should
   // also be ignored.
   s = mutation.add_set_headers();
+  s->mutable_append()->set_value(false);
   s->mutable_header()->set_key(":status");
   s->mutable_header()->set_raw_value("This is not even an integer");
   s = mutation.add_set_headers();
+  s->mutable_append()->set_value(false);
   s->mutable_header()->set_key(":status");
   s->mutable_header()->set_raw_value("100");
 
@@ -169,6 +177,7 @@ TEST_F(MutationUtilsTest, TestNonAppendableHeaders) {
   s->mutable_header()->set_key(":path");
   s->mutable_header()->set_raw_value("/foo");
   s = mutation.add_set_headers();
+  s->mutable_append()->set_value(false);
   s->mutable_header()->set_key(":status");
   s->mutable_header()->set_raw_value("400");
   // These two should be ignored since we ignore attempts
@@ -207,6 +216,7 @@ TEST_F(MutationUtilsTest, TestSetHeaderWithInvalidCharacter) {
   envoy::service::ext_proc::v3::HeaderMutation mutation;
   auto* s = mutation.add_set_headers();
   // Test header key contains invalid character.
+  s->mutable_append()->set_value(false);
   s->mutable_header()->set_key("x-append-this\n");
   s->mutable_header()->set_raw_value("value");
   EXPECT_CALL(rejections, inc());
@@ -216,6 +226,7 @@ TEST_F(MutationUtilsTest, TestSetHeaderWithInvalidCharacter) {
   mutation.Clear();
   s = mutation.add_set_headers();
   // Test header value contains invalid character.
+  s->mutable_append()->set_value(false);
   s->mutable_header()->set_key("x-append-this");
   s->mutable_header()->set_raw_value("value\r");
   EXPECT_CALL(rejections, inc());
@@ -236,6 +247,7 @@ TEST_F(MutationUtilsTest, TestSetHeaderWithContentLength) {
   envoy::service::ext_proc::v3::HeaderMutation mutation;
   auto* s = mutation.add_set_headers();
   // Test header key contains content_length.
+  s->mutable_append()->set_value(false);
   s->mutable_header()->set_key("content-length");
   s->mutable_header()->set_raw_value("10");
 


### PR DESCRIPTION
WKT field should always be explicitly encoded based on the API guide: https://github.com/envoyproxy/envoy/blob/main/api/API_VERSIONING.md#backwards-compatibility

Fix ext_proc filter tests which are not encoding WKT "append" field explicitly: https://github.com/envoyproxy/envoy/blob/277a594b99a75f8b4c5bfbea54f0694bf7e9c672/api/envoy/config/core/v3/base.proto#L469

This PR is part of the efforts to force the ext_proc servers to explicitly encode "append", which will be the starting point to support "append_action".