### PR TITLE
[cel] Enable precompilation of regexes in cel expressions

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -18,6 +18,10 @@ minor_behavior_changes:
 - area: grpc-json
   change: |
     Make the :ref:`gRPC JSON transcoder filter's <config_http_filters_grpc_json_reverse_transcoder>` json print options configurable.
+- area: cel
+  change: |
+    Precompile regexes in cel expressions. This can be disabled by setting the runtime guard 
+    ``envoy.reloadable_features.enable_cel_regex_precompilation`` to false.
 
 bug_fixes:
 # *Changes expected to improve the state of the world and are unlikely to have negative effects*

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -104,6 +104,7 @@ RUNTIME_GUARD(envoy_reloadable_features_xds_prevent_resource_copy);
 RUNTIME_GUARD(envoy_restart_features_fix_dispatcher_approximate_now);
 RUNTIME_GUARD(envoy_restart_features_skip_backing_cluster_check_for_sds);
 RUNTIME_GUARD(envoy_restart_features_use_eds_cache_for_ads);
+RUNTIME_GUARD(envoy_reloadable_features_enable_cel_regex_precompilation);
 
 // Begin false flags. Most of them should come with a TODO to flip true.
 

--- a/source/extensions/filters/common/expr/BUILD
+++ b/source/extensions/filters/common/expr/BUILD
@@ -18,6 +18,7 @@ envoy_cc_library(
         "//envoy/singleton:manager_interface",
         "//source/common/http:utility_lib",
         "//source/common/protobuf",
+        "//source/common/runtime:runtime_features_lib",
         "@com_github_cncf_xds//xds/type/v3:pkg_cc_proto",
         "@com_google_cel_cpp//eval/public:activation",
         "@com_google_cel_cpp//eval/public:builtin_func_registrar",

--- a/source/extensions/filters/common/expr/evaluator.cc
+++ b/source/extensions/filters/common/expr/evaluator.cc
@@ -4,6 +4,7 @@
 #include "envoy/singleton/manager.h"
 
 #include "extensions/regex_functions.h"
+#include "source/common/runtime/runtime_features.h"
 
 #include "cel/expr/syntax.pb.h"
 #include "eval/public/builtin_func_registrar.h"
@@ -111,6 +112,11 @@ BuilderPtr createBuilder(Protobuf::Arena* arena) {
   options.enable_string_conversion = false;
   options.enable_string_concat = false;
   options.enable_list_concat = false;
+
+  // Performance-oriented defaults
+  if (Runtime::runtimeFeatureEnabled("envoy.reloadable_features.enable_cel_regex_precompilation")) {
+    options.enable_regex_precompilation = true;
+  }
 
   // Enable constant folding (performance optimization)
   if (arena != nullptr) {


### PR DESCRIPTION


Commit Message:
Additional Description:
Risk Level: Low
Testing:
Docs Changes:
Release Notes: Added
Platform Specific Features:
[Optional Runtime guard:]  envoy.reloadable_features.enable_cel_regex_precompilation

