### PR TITLE
Fix devcontainer link issue

### DIFF
--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 BAZELRC_FILE=~/.bazelrc bazel/setup_clang.sh /opt/llvm
-echo "common --config=clang-libc++" >> ~/.bazelrc
+echo "build --config=clang" >> user.bazelrc
 
 # Ideally we want this line so bazel doesn't pollute things outside of the devcontainer, but some of
 # API tooling (proto_sync) depends on symlink like bazel-bin.


### PR DESCRIPTION
Additional Description: After recent PR #39082 devcontainer builds are failing due to linking issue. 
Risk Level: low
Testing: none
Docs Changes: none
Release Notes: none
Platform Specific Features: none
