### PR TITLE
docs: address typos in the string matcher docs

### DIFF
--- a/api/envoy/type/matcher/v3/string.proto
+++ b/api/envoy/type/matcher/v3/string.proto
@@ -38,7 +38,10 @@ message StringMatcher {
     string exact = 1;
 
     // The input string must have the prefix specified here.
-    // Note: empty prefix is not allowed, please use regex instead.
+    //
+    // .. note::
+    //
+    //  Empty prefix match is not allowed, please use ``safe_regex`` instead.
     //
     // Examples:
     //
@@ -46,7 +49,10 @@ message StringMatcher {
     string prefix = 2 [(validate.rules).string = {min_len: 1}];
 
     // The input string must have the suffix specified here.
-    // Note: empty prefix is not allowed, please use regex instead.
+    //
+    // .. note::
+    //
+    //  Empty suffix match is not allowed, please use ``safe_regex`` instead.
     //
     // Examples:
     //
@@ -57,7 +63,10 @@ message StringMatcher {
     RegexMatcher safe_regex = 5 [(validate.rules).message = {required: true}];
 
     // The input string must have the substring specified here.
-    // Note: empty contains match is not allowed, please use regex instead.
+    //
+    // .. note::
+    //
+    //  Empty contains match is not allowed, please use ``safe_regex`` instead.
     //
     // Examples:
     //
@@ -69,9 +78,10 @@ message StringMatcher {
     xds.core.v3.TypedExtensionConfig custom = 8;
   }
 
-  // If true, indicates the exact/prefix/suffix/contains matching should be case insensitive. This
-  // has no effect for the safe_regex match.
-  // For example, the matcher ``data`` will match both input string ``Data`` and ``data`` if set to true.
+  // If ``true``, indicates the exact/prefix/suffix/contains matching should be case insensitive. This
+  // has no effect for the ``safe_regex`` match.
+  // For example, the matcher ``data`` will match both input string ``Data`` and ``data`` if this option
+  // is set to ``true``.
   bool ignore_case = 6;
 }
 


### PR DESCRIPTION
## Description

This PR addresses some typos in the String Matcher docs. We have addressed the typo in the docs for `suffix` matcher where in the note it was still incorrectly pointing out that `prefix` can't be empty. It also switched the note annotation to use the newer way.

---

**Commit Message:** docs: address typos in the string matcher docs
**Additional Description:** This PR addresses some typos in the String Matcher docs.
**Risk Level:** N/A
**Testing:** N/A
**Docs Changes:** N/A
**Release Notes:** N/A