### PR TITLE
Drop fuzz_coverage target from CI

### DIFF
--- a/.github/workflows/_check_coverage.yml
+++ b/.github/workflows/_check_coverage.yml
@@ -77,5 +77,3 @@ jobs:
           diskspace-hack: true
           diskspace-hack-paths: |
             /opt/hostedtoolcache
-        - target: fuzz_coverage
-          name: Fuzz coverage


### PR DESCRIPTION
Commit Message:

I'm trying to switch back to static linking for coverage tests in Envoy CI to work around a bug in Clang/LLVM (see
https://github.com/llvm/llvm-project/issues/32849).

However the change that switches to static linking fails `fuzz_coverage` with what seems like some kind of resource constraint (e.g., linker gets killed, I suspect, as a result of OOM, since static linking requires more resources).

@yanavalsov suggested that fuzz_coverage target might not be the best way to measure fuzzing coverage (see
https://github.com/envoyproxy/envoy/pull/39030#issuecomment-2807912729) and given that I think we should at least consider disabling it until we can make it better. That's what this PR does.

NOTE: @phlax also mention that he did some work to migrate coverage to EngFlow builds in the past and there might be PR that we could finish that will migrate fuzz_coverage to EngFlow. There is a chance that it will address the issue - I'm mentioning it here to give a complete overview of the possible alternatives here.

Additional Description:

You can find some related discussion in https://github.com/envoyproxy/envoy/pull/39030 (specifically https://github.com/envoyproxy/envoy/pull/39030#issuecomment-2807912729, https://github.com/envoyproxy/envoy/pull/39030#issuecomment-2810222059, https://github.com/envoyproxy/envoy/pull/39030#issuecomment-2819632230, https://github.com/envoyproxy/envoy/pull/39030#issuecomment-2821313281 and https://github.com/envoyproxy/envoy/pull/39030#issuecomment-2834492658).

@phlax suggested in slack that @adisuissa might be the person more familiar with the coverage targets in Envoy CI and should be involved.

Risk Level: low (in the sense that disabling this target on CI should not break anything, but let's discuss if there are some strategic risks with disabling this test target).
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A

+cc @phlax @yanavlasov @adisuissa 