### PR TITLE
common: fix uninitialized memory access in UnionStringBase constructor

### DIFF
--- a/envoy/common/union_string.h
+++ b/envoy/common/union_string.h
@@ -63,7 +63,7 @@ public:
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wuninitialized"
 #endif
-  UnionStringBase() : buffer_(InlinedStringVector()) {
+  UnionStringBase() : buffer_(std::in_place_type<InlinedStringVector>) {
 #if defined(__GNUC__)
 #pragma GCC diagnostic pop
 #endif


### PR DESCRIPTION
## Description

The `UnionStringBase` constructor initializes its variant buffer by creating and moving a temporary InlinedStringVector, which seems to be triggering a compiler warning about uninitialized memory access after recent upgrade of Abseil. It's causeing build failures when `-Werror=uninitialized` is being used.

This PR fixes the issue by using `std::in_place_type` to directly construct the `InlinedStringVector` inside the variant without creating a temporary and properly initializing all members in place.

---

**Commit Message:** common: fix uninitialized memory access in UnionStringBase constructor
**Additional Description:** Fixes an issue in union_string
**Risk Level:** Low
**Testing:** Existing tests pass
**Docs Changes:** N/A
**Release Notes:** N/A
**Platform Specific Features:** N/A