### PR TITLE
deps: bump up icu to v77.1

### DIFF
--- a/bazel/foreign_cc/BUILD
+++ b/bazel/foreign_cc/BUILD
@@ -203,6 +203,8 @@ configure_make(
         "CFLAGS": "-fPIC",
         "LIBS": "-l:libstdc++.a",
         "ICU_DATA_FILTER_FILE": "$(execpath //bazel/foreign_cc:icu_data_filter.json)",
+        "ARFLAGS": "r",
+        "MAKEFLAGS": "ARFLAGS=r",
     },
     lib_source = "@com_github_unicode_org_icu//:all",
     out_static_libs = [

--- a/bazel/foreign_cc/icu.patch
+++ b/bazel/foreign_cc/icu.patch
@@ -1,12 +1,36 @@
-diff --git a/WORKSPACE b/WORKSPACE
-deleted file mode 100644
-index e69de29..0000000
+From 35303f765af1878ba4d7dcff861b903b7219ebcf Mon Sep 17 00:00:00 2001
+From: Rohit Agrawal <rohit.agrawal@databricks.com>
+Date: Tue, 29 Apr 2025 05:00:46 -0700
+Subject: [PATCH 1/2] Fix BUILD Files
+
+---
+ icu4c/source/common/BUILD.bazel             | 1218 -------------------
+ icu4c/source/data/unidata/norm2/BUILD.bazel |   13 -
+ icu4c/source/i18n/BUILD.bazel               |  130 --
+ icu4c/source/icudefs.mk.in                  |    2 +-
+ icu4c/source/tools/gennorm2/BUILD.bazel     |   39 -
+ icu4c/source/tools/toolutil/BUILD.bazel     |  126 --
+ tools/unicode/c/genprops/BUILD.bazel        |   50 -
+ tools/unicode/c/genuca/BUILD.bazel          |   52 -
+ vendor/double-conversion/upstream/BUILD     |   78 --
+ vendor/double-conversion/upstream/WORKSPACE |    1 -
+ 10 files changed, 1 insertion(+), 1708 deletions(-)
+ delete mode 100644 icu4c/source/common/BUILD.bazel
+ delete mode 100644 icu4c/source/data/unidata/norm2/BUILD.bazel
+ delete mode 100644 icu4c/source/i18n/BUILD.bazel
+ delete mode 100644 icu4c/source/tools/gennorm2/BUILD.bazel
+ delete mode 100644 icu4c/source/tools/toolutil/BUILD.bazel
+ delete mode 100644 tools/unicode/c/genprops/BUILD.bazel
+ delete mode 100644 tools/unicode/c/genuca/BUILD.bazel
+ delete mode 100644 vendor/double-conversion/upstream/BUILD
+ delete mode 100644 vendor/double-conversion/upstream/WORKSPACE
+
 diff --git a/icu4c/source/common/BUILD.bazel b/icu4c/source/common/BUILD.bazel
 deleted file mode 100644
-index e385d3b..0000000
+index 3ecae30c437f..000000000000
 --- a/icu4c/source/common/BUILD.bazel
 +++ /dev/null
-@@ -1,1213 +0,0 @@
+@@ -1,1218 +0,0 @@
 -# © 2021 and later: Unicode, Inc. and others.
 -# License & terms of use: http://www.unicode.org/copyright.html
 -
@@ -351,6 +375,7 @@ index e385d3b..0000000
 -        "dictionarydata.cpp",
 -        "filteredbrk.cpp",
 -        "lstmbe.cpp",
+-        "mlbe.cpp",
 -        "rbbi.cpp",
 -        "rbbi_cache.cpp",
 -        "rbbidata.cpp",
@@ -611,12 +636,16 @@ index e385d3b..0000000
 -        "locbased.cpp",
 -        "locid.cpp",
 -        "loclikely.cpp",
+-        "loclikelysubtags.cpp",
 -        "locmap.cpp",
+-        "lsr.cpp",
 -        "resbund.cpp",
 -        "resource.cpp",
 -        "uloc.cpp",
 -        "uloc_tag.cpp",
 -        "uloc_keytype.cpp",
+-        "ulocale.cpp",
+-        "ulocbuilder.cpp",
 -        "uresbund.cpp",
 -        "uresdata.cpp",
 -        "wintz.cpp",
@@ -1222,7 +1251,7 @@ index e385d3b..0000000
 -)
 diff --git a/icu4c/source/data/unidata/norm2/BUILD.bazel b/icu4c/source/data/unidata/norm2/BUILD.bazel
 deleted file mode 100644
-index 049e19b..0000000
+index 06e054ea3551..000000000000
 --- a/icu4c/source/data/unidata/norm2/BUILD.bazel
 +++ /dev/null
 @@ -1,13 +0,0 @@
@@ -1237,11 +1266,11 @@ index 049e19b..0000000
 -)
 -
 -exports_files([
--    "nfc.txt", "nfkc.txt", "nfkc_cf.txt", "uts46.txt",
+-    "nfc.txt", "nfkc.txt", "nfkc_cf.txt", "nfkc_scf.txt", "uts46.txt",
 -])
 diff --git a/icu4c/source/i18n/BUILD.bazel b/icu4c/source/i18n/BUILD.bazel
 deleted file mode 100644
-index 2d85cdb..0000000
+index 2d85cdb180e1..000000000000
 --- a/icu4c/source/i18n/BUILD.bazel
 +++ /dev/null
 @@ -1,130 +0,0 @@
@@ -1376,7 +1405,7 @@ index 2d85cdb..0000000
 -    ],
 -)
 diff --git a/icu4c/source/icudefs.mk.in b/icu4c/source/icudefs.mk.in
-index 2c35816..4ad6f52 100644
+index 251e020903e5..b49c9a459032 100644
 --- a/icu4c/source/icudefs.mk.in
 +++ b/icu4c/source/icudefs.mk.in
 @@ -117,7 +117,7 @@ EXEEXT = @EXEEXT@
@@ -1388,39 +1417,9 @@ index 2c35816..4ad6f52 100644
  RANLIB = @RANLIB@
  COMPILE_LINK_ENVVAR = @COMPILE_LINK_ENVVAR@
  UCLN_NO_AUTO_CLEANUP = @UCLN_NO_AUTO_CLEANUP@
-diff --git a/icu4c/source/stubdata/BUILD.bazel b/icu4c/source/stubdata/BUILD.bazel
-deleted file mode 100644
-index 20344ef..0000000
---- a/icu4c/source/stubdata/BUILD.bazel
-+++ /dev/null
-@@ -1,24 +0,0 @@
--# © 2021 and later: Unicode, Inc. and others.
--# License & terms of use: http://www.unicode.org/copyright.html
--
--# This file defines Bazel targets for the ICU4C "stubdata" library header and source files.
--
--load("@rules_cc//cc:defs.bzl", "cc_library")
--
--package(
--    default_visibility = ["//visibility:public"],
--)
--
--# When compiling code in the `common` dir, the constant
--# `U_COMMON_IMPLEMENTATION` needs to be defined. See 
--# https://unicode-org.github.io/icu/userguide/howtouseicu#c-with-your-own-build-system .
--
--cc_library(
--    name = "stubdata",
--    srcs = ["stubdata.cpp"],
--    hdrs = ["stubdata.h"],
--    deps = ["//icu4c/source/common:headers"],
--    local_defines = [
--        "U_COMMON_IMPLEMENTATION",
--    ],
--)
 diff --git a/icu4c/source/tools/gennorm2/BUILD.bazel b/icu4c/source/tools/gennorm2/BUILD.bazel
 deleted file mode 100644
-index c602897..0000000
+index c602897bafc1..000000000000
 --- a/icu4c/source/tools/gennorm2/BUILD.bazel
 +++ /dev/null
 @@ -1,39 +0,0 @@
@@ -1465,7 +1464,7 @@ index c602897..0000000
 -)
 diff --git a/icu4c/source/tools/toolutil/BUILD.bazel b/icu4c/source/tools/toolutil/BUILD.bazel
 deleted file mode 100644
-index 276c857..0000000
+index 276c857f1246..000000000000
 --- a/icu4c/source/tools/toolutil/BUILD.bazel
 +++ /dev/null
 @@ -1,126 +0,0 @@
@@ -1597,7 +1596,7 @@ index 276c857..0000000
 -)
 diff --git a/tools/unicode/c/genprops/BUILD.bazel b/tools/unicode/c/genprops/BUILD.bazel
 deleted file mode 100644
-index a7c3b27..0000000
+index a7c3b2704993..000000000000
 --- a/tools/unicode/c/genprops/BUILD.bazel
 +++ /dev/null
 @@ -1,50 +0,0 @@
@@ -1653,7 +1652,7 @@ index a7c3b27..0000000
 -)
 diff --git a/tools/unicode/c/genuca/BUILD.bazel b/tools/unicode/c/genuca/BUILD.bazel
 deleted file mode 100644
-index 7da631d..0000000
+index 7da631d34085..000000000000
 --- a/tools/unicode/c/genuca/BUILD.bazel
 +++ /dev/null
 @@ -1,52 +0,0 @@
@@ -1709,10 +1708,135 @@ index 7da631d..0000000
 -    #   errCode=@0x7fffffffd738: U_ZERO_ERROR) at icu4c/source/common/umutex.h:143
 -    linkopts = ["-pthread"],
 -)
+diff --git a/vendor/double-conversion/upstream/BUILD b/vendor/double-conversion/upstream/BUILD
+deleted file mode 100644
+index 8c2eee564be6..000000000000
+--- a/vendor/double-conversion/upstream/BUILD
++++ /dev/null
+@@ -1,78 +0,0 @@
+-# Bazel(http://bazel.io) BUILD file
+-
+-load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+-
+-licenses(["notice"])
+-
+-exports_files(["LICENSE"])
+-
+-cc_library(
+-    name = "double-conversion",
+-    srcs = [
+-        "double-conversion/bignum.cc",
+-        "double-conversion/bignum-dtoa.cc",
+-        "double-conversion/cached-powers.cc",
+-        "double-conversion/double-to-string.cc",
+-        "double-conversion/fast-dtoa.cc",
+-        "double-conversion/fixed-dtoa.cc",
+-        "double-conversion/string-to-double.cc",
+-        "double-conversion/strtod.cc",
+-    ],
+-    hdrs = [
+-        "double-conversion/bignum.h",
+-        "double-conversion/bignum-dtoa.h",
+-        "double-conversion/cached-powers.h",
+-        "double-conversion/diy-fp.h",
+-        "double-conversion/double-conversion.h",
+-        "double-conversion/double-to-string.h",
+-        "double-conversion/fast-dtoa.h",
+-        "double-conversion/fixed-dtoa.h",
+-        "double-conversion/ieee.h",
+-        "double-conversion/string-to-double.h",
+-        "double-conversion/strtod.h",
+-        "double-conversion/utils.h",
+-    ],
+-    linkopts = [
+-        "-lm",
+-    ],
+-    visibility = ["//visibility:public"],
+-)
+-
+-cc_test(
+-    name = "cctest",
+-    srcs = [
+-        "test/cctest/cctest.cc",
+-        "test/cctest/cctest.h",
+-        "test/cctest/checks.h",
+-        "test/cctest/gay-fixed.cc",
+-        "test/cctest/gay-fixed.h",
+-        "test/cctest/gay-precision.cc",
+-        "test/cctest/gay-precision.h",
+-        "test/cctest/gay-shortest.cc",
+-        "test/cctest/gay-shortest.h",
+-        "test/cctest/gay-shortest-single.cc",
+-        "test/cctest/gay-shortest-single.h",
+-        "test/cctest/test-bignum.cc",
+-        "test/cctest/test-bignum-dtoa.cc",
+-        "test/cctest/test-conversions.cc",
+-        "test/cctest/test-diy-fp.cc",
+-        "test/cctest/test-dtoa.cc",
+-        "test/cctest/test-fast-dtoa.cc",
+-        "test/cctest/test-fixed-dtoa.cc",
+-        "test/cctest/test-ieee.cc",
+-        "test/cctest/test-strtod.cc",
+-    ],
+-    args = [
+-        "test-bignum",
+-        "test-bignum-dtoa",
+-        "test-conversions",
+-        "test-diy-fp",
+-        "test-dtoa",
+-        "test-fast-dtoa",
+-        "test-fixed-dtoa",
+-        "test-ieee",
+-        "test-strtod",
+-    ],
+-    visibility = ["//visibility:public"],
+-    deps = [":double-conversion"],
+-)
 diff --git a/vendor/double-conversion/upstream/WORKSPACE b/vendor/double-conversion/upstream/WORKSPACE
 deleted file mode 100644
-index 52106e7..0000000
+index 52106e7597b7..000000000000
 --- a/vendor/double-conversion/upstream/WORKSPACE
 +++ /dev/null
 @@ -1 +0,0 @@
 -# Bazel (http://bazel.io/) WORKSPACE file for double-conversion.
+
+From a6e5a43b8e6107929e8476f048c855b77f63377b Mon Sep 17 00:00:00 2001
+From: Rohit Agrawal <rohit.agrawal@databricks.com>
+Date: Sun, 4 May 2025 15:49:35 +0900
+Subject: [PATCH 2/2] More Patches
+
+---
+ icu4c/source/stubdata/BUILD.bazel | 24 ------------------------
+ 1 file changed, 24 deletions(-)
+ delete mode 100644 icu4c/source/stubdata/BUILD.bazel
+
+diff --git a/icu4c/source/stubdata/BUILD.bazel b/icu4c/source/stubdata/BUILD.bazel
+deleted file mode 100644
+index 20344ef49919..000000000000
+--- a/icu4c/source/stubdata/BUILD.bazel
++++ /dev/null
+@@ -1,24 +0,0 @@
+-# © 2021 and later: Unicode, Inc. and others.
+-# License & terms of use: http://www.unicode.org/copyright.html
+-
+-# This file defines Bazel targets for the ICU4C "stubdata" library header and source files.
+-
+-load("@rules_cc//cc:defs.bzl", "cc_library")
+-
+-package(
+-    default_visibility = ["//visibility:public"],
+-)
+-
+-# When compiling code in the `common` dir, the constant
+-# `U_COMMON_IMPLEMENTATION` needs to be defined. See 
+-# https://unicode-org.github.io/icu/userguide/howtouseicu#c-with-your-own-build-system .
+-
+-cc_library(
+-    name = "stubdata",
+-    srcs = ["stubdata.cpp"],
+-    hdrs = ["stubdata.h"],
+-    deps = ["//icu4c/source/common:headers"],
+-    local_defines = [
+-        "U_COMMON_IMPLEMENTATION",
+-    ],
+-)

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -440,13 +440,13 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         # from the icu source code, to prevent Bazel from treating the foreign library
         # as a Bazel project.
         # https://github.com/envoyproxy/envoy/issues/26395
-        version = "72-1",
-        sha256 = "43cbad628d98f37a3f95f6c34579f9144ef4bde60248fa6004a4f006d7487e69",
+        version = "77-1",
+        sha256 = "ded3a96f6b7236d160df30af46593165b9c78a4ec72a414aa63cf50614e4c14e",
         strip_prefix = "icu-release-{version}",
         urls = ["https://github.com/unicode-org/icu/archive/release-{version}.tar.gz"],
         use_category = ["dataplane_ext"],
         extensions = ["envoy.filters.http.language"],
-        release_date = "2022-10-18",
+        release_date = "2025-03-13",
         cpe = "N/A",
         license = "ICU",
         license_url = "https://github.com/unicode-org/icu/blob/release-{version}/icu4c/LICENSE",


### PR DESCRIPTION
## Description

This PR bumps up the version of `icu` to v77.1

---

**Commit Message:** deps: bump up icu to v77.1
**Additional Description:** Bump up the version of `icu` to v77.1
**Risk Level:** Low
**Testing:** CI
**Docs Changes:** N/A
**Release Notes:** N/A