### PR TITLE
listener-manager: remove unique_ptr from the failure-state vector

### DIFF
--- a/envoy/server/listener_manager.h
+++ b/envoy/server/listener_manager.h
@@ -257,7 +257,7 @@ public:
    * Inform the listener manager that the update has completed, and informs the listener of any
    * errors handled by the reload source.
    */
-  using FailureStates = std::vector<std::unique_ptr<envoy::admin::v3::UpdateFailureState>>;
+  using FailureStates = std::vector<envoy::admin::v3::UpdateFailureState>;
   virtual void endListenerUpdate(FailureStates&& failure_states) PURE;
 
   // TODO(junr03): once ApiListeners support warming and draining, this function should return a

--- a/source/common/listener_manager/lds_api.cc
+++ b/source/common/listener_manager/lds_api.cc
@@ -80,11 +80,11 @@ LdsApiImpl::onConfigUpdate(const std::vector<Config::DecodedResourceRef>& added_
     absl::string_view listener_name = EMPTY_STRING;
 
     auto onError = [&](std::string error_message) {
-      failure_state.push_back(std::make_unique<envoy::admin::v3::UpdateFailureState>());
+      failure_state.emplace_back(envoy::admin::v3::UpdateFailureState());
       auto& state = failure_state.back();
-      state->set_details(error_message);
+      state.set_details(error_message);
 #if defined(ENVOY_ENABLE_FULL_PROTOS)
-      state->mutable_failed_configuration()->PackFrom(resource.get().resource());
+      state.mutable_failed_configuration()->PackFrom(resource.get().resource());
 #endif
       absl::StrAppend(&message, listener_name, ": ", error_message, "\n");
     };

--- a/source/common/listener_manager/listener_manager_impl.cc
+++ b/source/common/listener_manager/listener_manager_impl.cc
@@ -441,7 +441,7 @@ ListenerManagerImpl::dumpListenerConfigs(const Matchers::StringMatcher& name_mat
 
   // Dump errors not associated with named listeners.
   for (const auto& error : overall_error_state_) {
-    config_dump->add_dynamic_listeners()->mutable_error_state()->CopyFrom(*error);
+    config_dump->add_dynamic_listeners()->mutable_error_state()->CopyFrom(error);
   }
 
   return config_dump;

--- a/test/common/listener_manager/listener_manager_impl_test.cc
+++ b/test/common/listener_manager/listener_manager_impl_test.cc
@@ -3007,9 +3007,9 @@ dynamic_listeners:
 
   // Now have an external update with errors and make sure it gets dumped.
   ListenerManager::FailureStates non_empty_failure_state;
-  non_empty_failure_state.push_back(std::make_unique<envoy::admin::v3::UpdateFailureState>());
+  non_empty_failure_state.emplace_back(envoy::admin::v3::UpdateFailureState());
   auto& state = non_empty_failure_state.back();
-  state->set_details("foo");
+  state.set_details("foo");
   manager_->beginListenerUpdate();
   manager_->endListenerUpdate(std::move(non_empty_failure_state));
   checkConfigDump(R"EOF(


### PR DESCRIPTION
Commit Message: listener-manager: remove unique_ptr from the failure-state vector
Additional Description:
Minor refactor that converts listener-manager failure-state from `vector<unique_ptr<T>>` to `vector<T>`.

Risk Level: low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
