### PR TITLE
Add a fuzz test for ORCA parser.

### DIFF
--- a/test/common/orca/BUILD
+++ b/test/common/orca/BUILD
@@ -1,7 +1,9 @@
 load(
     "//bazel:envoy_build_system.bzl",
+    "envoy_cc_fuzz_test",
     "envoy_cc_test",
     "envoy_package",
+    "envoy_proto_library",
 )
 
 licenses(["notice"])  # Apache 2
@@ -31,6 +33,34 @@ envoy_cc_test(
     deps = [
         "//source/common/common:base64_lib",
         "//source/common/orca:orca_parser",
+        "//test/test_common:status_utility_lib",
+        "//test/test_common:utility_lib",
+        "@com_github_cncf_xds//xds/data/orca/v3:pkg_cc_proto",
+        "@com_github_fmtlib_fmt//:fmtlib",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/strings",
+    ],
+)
+
+envoy_proto_library(
+    name = "orca_parser_fuzz_proto",
+    srcs = ["orca_parser_fuzz.proto"],
+    deps = [
+        "//test/fuzz:common_proto",
+        "@envoy_api//envoy/extensions/load_balancing_policies/client_side_weighted_round_robin/v3:pkg",
+    ],
+)
+
+envoy_cc_fuzz_test(
+    name = "orca_parser_fuzz_test",
+    srcs = ["orca_parser_fuzz_test.cc"],
+    corpus = "orca_parser_corpus",
+    rbe_pool = "6gig",
+    deps = [
+        ":orca_parser_fuzz_proto_cc_proto",
+        "//source/common/common:base64_lib",
+        "//source/common/orca:orca_parser",
+        "//test/fuzz:utility_lib",
         "//test/test_common:status_utility_lib",
         "//test/test_common:utility_lib",
         "@com_github_cncf_xds//xds/data/orca/v3:pkg_cc_proto",

--- a/test/common/orca/orca_parser_corpus/foo_bar
+++ b/test/common/orca/orca_parser_corpus/foo_bar
@@ -1,0 +1,2 @@
+header_name: foo
+header_value: bar

--- a/test/common/orca/orca_parser_corpus/foo_bar
+++ b/test/common/orca/orca_parser_corpus/foo_bar
@@ -1,2 +1,6 @@
-header_name: foo
-header_value: bar
+response_headers {
+  headers {
+    key: "foo"
+    value: "bar"
+  }
+}

--- a/test/common/orca/orca_parser_corpus/invalid_json
+++ b/test/common/orca/orca_parser_corpus/invalid_json
@@ -1,0 +1,2 @@
+header_name: endpoint-load-metrics
+header_value: JSON {"cpu_utilization': 0.7, 

--- a/test/common/orca/orca_parser_corpus/invalid_json
+++ b/test/common/orca/orca_parser_corpus/invalid_json
@@ -1,2 +1,8 @@
 header_name: endpoint-load-metrics
 header_value: JSON {"cpu_utilization': 0.7, 
+response_headers {
+  headers {
+    key: "endpoint-load-metrics"
+    value: "JSON {\"cpu_utilization\': 0.7,"
+  }
+}

--- a/test/common/orca/orca_parser_corpus/valid_bin
+++ b/test/common/orca/orca_parser_corpus/valid_bin
@@ -1,0 +1,9 @@
+header_name: endpoint-load-metrics-bin
+  # This decodes and deserializes to the following proto:
+  # cpu_utilization: 0.4
+  # rps_fractional: 50
+  # named_metrics {
+  #  key: "foo"
+  #  value: 0.5
+  # }
+header_value: CZqZmZmZmdk/MQAAAAAAAElAQg4KA2ZvbxEAAAAAAADgPw==

--- a/test/common/orca/orca_parser_corpus/valid_bin
+++ b/test/common/orca/orca_parser_corpus/valid_bin
@@ -1,9 +1,13 @@
-header_name: endpoint-load-metrics-bin
-  # This decodes and deserializes to the following proto:
-  # cpu_utilization: 0.4
-  # rps_fractional: 50
-  # named_metrics {
-  #  key: "foo"
-  #  value: 0.5
-  # }
-header_value: CZqZmZmZmdk/MQAAAAAAAElAQg4KA2ZvbxEAAAAAAADgPw==
+response_headers {
+  headers {
+    key: "endpoint-load-metrics-bin"
+    # This decodes and deserializes to the following proto:
+    # cpu_utilization: 0.4
+    # rps_fractional: 50
+    # named_metrics {
+    #  key: "foo"
+    #  value: 0.5
+    # }
+    value: "CZqZmZmZmdk/MQAAAAAAAElAQg4KA2ZvbxEAAAAAAADgPw=="
+  }
+}

--- a/test/common/orca/orca_parser_corpus/valid_bin2
+++ b/test/common/orca/orca_parser_corpus/valid_bin2
@@ -1,0 +1,9 @@
+header_name: endpoint-load-metrics
+  # This decodes and deserializes to the following proto:
+  # cpu_utilization: 0.4
+  # rps_fractional: 50
+  # named_metrics {
+  #  key: "foo"
+  #  value: 0.5
+  # }
+header_value: BIN CZqZmZmZmdk/MQAAAAAAAElAQg4KA2ZvbxEAAAAAAADgPw==

--- a/test/common/orca/orca_parser_corpus/valid_bin2
+++ b/test/common/orca/orca_parser_corpus/valid_bin2
@@ -1,9 +1,13 @@
-header_name: endpoint-load-metrics
-  # This decodes and deserializes to the following proto:
-  # cpu_utilization: 0.4
-  # rps_fractional: 50
-  # named_metrics {
-  #  key: "foo"
-  #  value: 0.5
-  # }
-header_value: BIN CZqZmZmZmdk/MQAAAAAAAElAQg4KA2ZvbxEAAAAAAADgPw==
+response_headers {
+  headers {
+    key: "endpoint-load-metrics"
+    # This decodes and deserializes to the following proto:
+    # cpu_utilization: 0.4
+    # rps_fractional: 50
+    # named_metrics {
+    #  key: "foo"
+    #  value: 0.5
+    # }
+    value: "BIN CZqZmZmZmdk/MQAAAAAAAElAQg4KA2ZvbxEAAAAAAADgPw=="
+  }
+}

--- a/test/common/orca/orca_parser_corpus/valid_json
+++ b/test/common/orca/orca_parser_corpus/valid_json
@@ -1,2 +1,9 @@
-header_name: endpoint-load-metrics
-header_value: JSON {"cpu_utilization": 0.7, "application_utilization": 0.8, "mem_utilization": 0.9, "rps_fractional": 1000, "eps": 2, "named_metrics": {"foo": 123, "bar": 0.2}
+response_headers {
+  headers {
+    key: "endpoint-load-metrics"
+    value: "{\"cpu_utilization\": 0.7, \"application_utilization\": 0.8, "
+           "\"mem_utilization\": 0.9, \"rps_fractional\": 1000, \"eps\": 2, "
+           "\"named_metrics\": {\"foo\": 123,\"bar\": 0.2}, "
+           "\"utilization\": {\"total\": 0.5}}"
+  }
+}

--- a/test/common/orca/orca_parser_corpus/valid_json
+++ b/test/common/orca/orca_parser_corpus/valid_json
@@ -1,0 +1,2 @@
+header_name: endpoint-load-metrics
+header_value: JSON {"cpu_utilization": 0.7, "application_utilization": 0.8, "mem_utilization": 0.9, "rps_fractional": 1000, "eps": 2, "named_metrics": {"foo": 123, "bar": 0.2}

--- a/test/common/orca/orca_parser_corpus/valid_text
+++ b/test/common/orca/orca_parser_corpus/valid_text
@@ -1,0 +1,2 @@
+header_name: endpoint-load-metrics
+header_value: TEXT cpu_utilization=0.7,application_utilization=0.8,mem_utilization=0.9,rps_fractional=1000,eps=2,named_metrics.foo=123,named_metrics.bar=0.2,utilization.total=0.5

--- a/test/common/orca/orca_parser_corpus/valid_text
+++ b/test/common/orca/orca_parser_corpus/valid_text
@@ -1,2 +1,6 @@
-header_name: endpoint-load-metrics
-header_value: TEXT cpu_utilization=0.7,application_utilization=0.8,mem_utilization=0.9,rps_fractional=1000,eps=2,named_metrics.foo=123,named_metrics.bar=0.2,utilization.total=0.5
+response_headers {
+  headers {
+    key: "endpoint-load-metrics"
+    value: "TEXT cpu_utilization=0.7,application_utilization=0.8,mem_utilization=0.9,rps_fractional=1000,eps=2,named_metrics.foo=123,named_metrics.bar=0.2,utilization.total=0.5"
+  }
+}

--- a/test/common/orca/orca_parser_fuzz.proto
+++ b/test/common/orca/orca_parser_fuzz.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+
+package test.common.upstream;
+
+import "validate/validate.proto";
+import "envoy/extensions/load_balancing_policies/client_side_weighted_round_robin/v3/client_side_weighted_round_robin.proto";
+
+message OrcaParserTestCase {
+  string header_name = 1 [(validate.rules).string = {pattern: "([A-Za-z0-9-]+)$", max_bytes: 50}];
+  string header_value = 2 [(validate.rules).string = {pattern: "([^\0^\r^\n]+)$"}];
+}

--- a/test/common/orca/orca_parser_fuzz.proto
+++ b/test/common/orca/orca_parser_fuzz.proto
@@ -6,6 +6,6 @@ import "validate/validate.proto";
 import "envoy/extensions/load_balancing_policies/client_side_weighted_round_robin/v3/client_side_weighted_round_robin.proto";
 
 message OrcaParserTestCase {
-  string header_name = 1 [(validate.rules).string = {pattern: "([A-Za-z0-9-]+)$", max_bytes: 50}];
+  string header_name = 1 [(validate.rules).string = {pattern: "([A-Za-z0-9-]+)$", max_bytes: 60000}];
   string header_value = 2 [(validate.rules).string = {pattern: "([^\0^\r^\n]+)$"}];
 }

--- a/test/common/orca/orca_parser_fuzz.proto
+++ b/test/common/orca/orca_parser_fuzz.proto
@@ -6,6 +6,7 @@ import "validate/validate.proto";
 import "envoy/extensions/load_balancing_policies/client_side_weighted_round_robin/v3/client_side_weighted_round_robin.proto";
 
 message OrcaParserTestCase {
-  string header_name = 1 [(validate.rules).string = {pattern: "([A-Za-z0-9-]+)$", max_bytes: 60000}];
+  string header_name = 1
+      [(validate.rules).string = {pattern: "([A-Za-z0-9-]+)$", max_bytes: 60000}];
   string header_value = 2 [(validate.rules).string = {pattern: "([^\0^\r^\n]+)$"}];
 }

--- a/test/common/orca/orca_parser_fuzz.proto
+++ b/test/common/orca/orca_parser_fuzz.proto
@@ -3,10 +3,8 @@ syntax = "proto3";
 package test.common.upstream;
 
 import "validate/validate.proto";
-import "envoy/extensions/load_balancing_policies/client_side_weighted_round_robin/v3/client_side_weighted_round_robin.proto";
+import "test/fuzz/common.proto";
 
 message OrcaParserTestCase {
-  string header_name = 1
-      [(validate.rules).string = {pattern: "([A-Za-z0-9-]+)$", max_bytes: 60000}];
-  string header_value = 2 [(validate.rules).string = {pattern: "([^\0^\r^\n]+)$"}];
+  test.fuzz.Headers response_headers = 1 [(validate.rules).message.required = true];
 }

--- a/test/common/orca/orca_parser_fuzz_test.cc
+++ b/test/common/orca/orca_parser_fuzz_test.cc
@@ -24,7 +24,10 @@ DEFINE_PROTO_FUZZER(const test::common::upstream::OrcaParserTestCase& input) {
   }
 
   // Try to parse the load report, expect no crash.
-  Http::TestResponseHeaderMapImpl headers{{input.header_name(), input.header_value()}};
+  Http::TestResponseHeaderMapImpl headers;
+  for (const auto& header : input.response_headers().headers()) {
+    headers.addCopy(header.key(), header.value());
+  }
   auto ignored_load_report = Orca::parseOrcaLoadReportHeaders(headers);
 }
 

--- a/test/common/orca/orca_parser_fuzz_test.cc
+++ b/test/common/orca/orca_parser_fuzz_test.cc
@@ -1,0 +1,32 @@
+#include <limits>
+
+#include "source/common/common/base64.h"
+#include "source/common/orca/orca_parser.h"
+
+#include "test/common/orca/orca_parser_fuzz.pb.validate.h"
+#include "test/fuzz/fuzz_runner.h"
+#include "test/test_common/status_utility.h"
+#include "test/test_common/utility.h"
+
+#include "absl/status/status.h"
+#include "absl/strings/str_cat.h"
+#include "xds/data/orca/v3/orca_load_report.pb.h"
+
+namespace Envoy {
+namespace Upstream {
+
+DEFINE_PROTO_FUZZER(const test::common::upstream::OrcaParserTestCase& input) {
+  try {
+    TestUtility::validate(input);
+  } catch (const ProtoValidationException& e) {
+    ENVOY_LOG_MISC(debug, "ProtoValidationException: {}", e.what());
+    return;
+  }
+
+  // Try to parse the load report, expect no crash.
+  Http::TestResponseHeaderMapImpl headers{{input.header_name(), input.header_value()}};
+  auto ignored_load_report = Orca::parseOrcaLoadReportHeaders(headers);
+}
+
+} // namespace Upstream
+} // namespace Envoy


### PR DESCRIPTION
Commit Message: Add a fuzz test for ORCA parser..

See #35422 for ORCA parser implementation and #6614 for background.

Risk Level: Low
Testing: Fuzz.
Docs Changes: N/A
Release Notes: N/A
Tested: `bazel run //test/common/orca:orca_parser_fuzz_test  --config asan-fuzzer --linkopt=-lc++ -- test/common/orca/orca_parser_corpus`

CC @blake-snyder @adisuissa @wbpcode

