### PR TITLE
Switch coverage CI targets to EngFlow

### DIFF
--- a/.github/workflows/_check_coverage.yml
+++ b/.github/workflows/_check_coverage.yml
@@ -8,8 +8,6 @@ on:
     secrets:
       gcs-cache-key:
         required: true
-      gcp-key:
-        required: true
 
     inputs:
       gcs-cache-bucket:
@@ -31,14 +29,13 @@ jobs:
   coverage:
     secrets:
       gcs-cache-key: ${{ secrets.gcs-cache-key }}
-      gcp-key: ${{ secrets.gcp-key }}
     permissions:
       contents: read
       packages: read
     uses: ./.github/workflows/_run.yml
     name: ${{ matrix.name ||matrix.target }}
     with:
-      # bazel-extra: '--config=remote-envoy-engflow'
+      bazel-extra: '--config=remote-envoy-engflow'
       cache-build-image: ${{ fromJSON(inputs.request).request.build-image.default }}
       concurrency-suffix: -${{ matrix.target }}
       diskspace-hack: ${{ matrix.diskspace-hack && true || false }}
@@ -50,7 +47,6 @@ jobs:
         lower than limit
       gcs-cache-bucket: ${{ inputs.gcs-cache-bucket }}
       rbe: true
-      rbe-google: true
       request: ${{ inputs.request }}
       runs-on: ${{ fromJSON(inputs.request).config.ci.agent-ubuntu }}
       steps-post: |

--- a/.github/workflows/_check_coverage.yml
+++ b/.github/workflows/_check_coverage.yml
@@ -8,6 +8,8 @@ on:
     secrets:
       gcs-cache-key:
         required: true
+      gcp-key:
+        required: true
 
     inputs:
       gcs-cache-bucket:
@@ -29,6 +31,7 @@ jobs:
   coverage:
     secrets:
       gcs-cache-key: ${{ secrets.gcs-cache-key }}
+      gcp-key: ${{ secrets.gcp-key }}
     permissions:
       contents: read
       packages: read

--- a/.github/workflows/envoy-checks.yml
+++ b/.github/workflows/envoy-checks.yml
@@ -64,6 +64,7 @@ jobs:
   coverage:
     secrets:
       gcs-cache-key: ${{ secrets.GCS_CACHE_KEY }}
+      gcp-key: ${{ fromJSON(needs.load.outputs.trusted) && secrets.GCP_SERVICE_ACCOUNT_KEY_TRUSTED || secrets.GCP_SERVICE_ACCOUNT_KEY }}
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/envoy-checks.yml
+++ b/.github/workflows/envoy-checks.yml
@@ -64,7 +64,6 @@ jobs:
   coverage:
     secrets:
       gcs-cache-key: ${{ secrets.GCS_CACHE_KEY }}
-      gcp-key: ${{ fromJSON(needs.load.outputs.trusted) && secrets.GCP_SERVICE_ACCOUNT_KEY_TRUSTED || secrets.GCP_SERVICE_ACCOUNT_KEY }}
     permissions:
       actions: read
       contents: read


### PR DESCRIPTION
Commit Message:

Currently Envoy CI uses different RBE backends for different CI targets. EngFlow is one of available backends and we want to migrate most if not all targets to EngFlow.

Other than just making the overall CI setup simpler, EngFlow appear to offer more powerful build grid machines at the moment, plus some additional nice features like automatically scaling memory when build tasks don't fit into available memory.

One specific reason why I'd like to migrate coverage targets to EngFlow is because I want to switch them to static linking to workaround a bug in Clang/LLVM source-based coverage (see llvm/llvm-project#32849).

With currently used Google RBE backend we are having issues with fuzzing coverage tests, as fuzzing tests include a lot of extensions and together with coverage instrumentation it pushes linker memory footrpint way to high and causing OOMs.

Our approach to solving this particular problem is two-fold:

1. I want to migrate to EngFlow that can offer bigger machines (and it aligns with the general direction for Envoy CI to migrate to EngFlow.
2. I want to optimize our fuzzing targets a little bit by cutting out some unnecessary bits and reducing the number of libraries that linker need to link together (on top of reducing the amount of time it takes to build things and similar benefits).

This particular PR takes care of the first part.

Additional Description:

Some relevant discussions can be found in https://github.com/envoyproxy/envoy/pull/39030 which prompted me to work on this in the first place. And I will use https://github.com/envoyproxy/envoy/issues/39248 as a tracking bug for the coverage changes.

Risk Level: medium (it could break CI and cause disruption, but rolling it back should be easy)
Testing: I applied the same change in the envoy-ci-staging repo and created a test PR to see if EngFlow is used for coverage. The setup between envoy-ci-staging and envoy repo is not exactly the same, so I could have missed something.

Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a

+cc @phlax 
