### PR TITLE
fine-grain-logger: use memory order acquire and release

### DIFF
--- a/source/common/common/fine_grain_logger.cc
+++ b/source/common/common/fine_grain_logger.cc
@@ -52,7 +52,7 @@ void FineGrainLogContext::initFineGrainLogger(const std::string& key,
   } else {
     target = it->second.get();
   }
-  logger.store(target);
+  logger.store(target, std::memory_order_release);
 }
 
 bool FineGrainLogContext::setFineGrainLogger(absl::string_view key, level_enum log_level)

--- a/source/common/common/fine_grain_logger.h
+++ b/source/common/common/fine_grain_logger.h
@@ -197,10 +197,10 @@ FineGrainLogContext& getFineGrainLogContext();
 #define FINE_GRAIN_LOGGER()                                                                        \
   ([]() -> spdlog::logger* {                                                                       \
     static std::atomic<spdlog::logger*> flogger{nullptr};                                          \
-    spdlog::logger* local_flogger = flogger.load(std::memory_order_relaxed);                       \
+    spdlog::logger* local_flogger = flogger.load(std::memory_order_acquire);                       \
     if (!local_flogger) {                                                                          \
       ::Envoy::getFineGrainLogContext().initFineGrainLogger(__FILE__, flogger);                    \
-      local_flogger = flogger.load(std::memory_order_relaxed);                                     \
+      local_flogger = flogger.load(std::memory_order_acquire);                                     \
     }                                                                                              \
     return local_flogger;                                                                          \
   }())


### PR DESCRIPTION
## Benchmark Results

> **Note**:  
> - `0` means **no log print**.  
> - `1` means **log printed**.

## Before the Change

### fineGrainLogFastPath

| Benchmark                                             | Time             | CPU Time         | Iterations |
|-------------------------------------------------------|------------------|------------------|------------:|
| fineGrainLogFastPath/1024/0                           | 17,527 ns        | 17,523 ns        | 39,987      |
| fineGrainLogFastPath/1024/1                           | 15,710,231 ns    | 15,709,650 ns    | 36          |
| fineGrainLogFastPath/1024/0/process_time/threads:20   | 33,012 ns        | 391,443 ns       | 1,700       |
| fineGrainLogFastPath/1024/1/process_time/threads:20   | 440,901,766 ns   | 615,822,136 ns   | 20          |
| fineGrainLogFastPath/1024/0/process_time/threads:200  | 44,216 ns        | 682,411 ns       | 1,000       |
| fineGrainLogFastPath/1024/1/process_time/threads:200  | 4,721,730,616 ns | 6,598,059,129 ns | 200         |

### envoyNormal

| Benchmark                                             | Time             | CPU Time         | Iterations |
|-------------------------------------------------------|------------------|------------------|------------:|
| envoyNormal/1024/0                                    | 31,961 ns        | 31,957 ns        | 22,288      |
| envoyNormal/1024/1                                    | 15,099,362 ns    | 15,097,983 ns    | 47          |
| envoyNormal/1024/0/process_time/threads:20            | 65,987 ns        | 737,439 ns       | 920         |
| envoyNormal/1024/1/process_time/threads:20            | 480,386,566 ns   | 663,952,979 ns   | 20          |
| envoyNormal/1024/0/process_time/threads:200           | 69,921 ns        | 944,208 ns       | 800         |
| envoyNormal/1024/1/process_time/threads:200           | 4,727,602,320 ns | 6,757,753,833 ns | 200         |

---

## After the Change

### fineGrainLogFastPath

| Benchmark                                             | Time             | CPU Time         | Iterations |
|-------------------------------------------------------|------------------|------------------|------------:|
| fineGrainLogFastPath/1024/0                           | 18,155 ns        | 18,154 ns        | 36,369      |
| fineGrainLogFastPath/1024/1                           | 14,707,686 ns    | 14,707,323 ns    | 43          |
| fineGrainLogFastPath/1024/0/process_time/threads:20   | 46,124 ns        | 519,514 ns       | 1,340       |
| fineGrainLogFastPath/1024/1/process_time/threads:20   | 474,500,426 ns   | 695,355,685 ns   | 20          |
| fineGrainLogFastPath/1024/0/process_time/threads:200  | 45,435 ns        | 810,393 ns       | 1,000       |
| fineGrainLogFastPath/1024/1/process_time/threads:200  | 4,617,120,073 ns | 6,527,850,453 ns | 200         |

### envoyNormal

| Benchmark                                             | Time             | CPU Time         | Iterations |
|-------------------------------------------------------|------------------|------------------|------------:|
| envoyNormal/1024/0                                    | 32,234 ns        | 32,228 ns        | 21,982      |
| envoyNormal/1024/1                                    | 15,193,562 ns    | 15,191,464 ns    | 45          |
| envoyNormal/1024/0/process_time/threads:20            | 64,439 ns        | 1,018,024 ns     | 1,280       |
| envoyNormal/1024/1/process_time/threads:20            | 455,698,260 ns   | 629,993,251 ns   | 20          |
| envoyNormal/1024/0/process_time/threads:200           | 73,429 ns        | 975,235 ns       | 600         |
| envoyNormal/1024/1/process_time/threads:200           | 4,875,159,818 ns | 6,878,406,078 ns | 200         |


The fast path logging performance slightly regressed but ignorable after the change.
However, it remains faster than the existing envoyNormal component logger in the same threaded configuration.

Commit Message:
Additional Description:
Risk Level: low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
