### PR TITLE
core: unify uint32_t in connection pool clients and max_request_per_connection

### DIFF
--- a/envoy/upstream/upstream.h
+++ b/envoy/upstream/upstream.h
@@ -1039,11 +1039,11 @@ public:
   virtual bool maintenanceMode() const PURE;
 
   /**
-   * @return uint64_t the maximum number of outbound requests that a connection pool will make on
+   * @return uint32_t the maximum number of outbound requests that a connection pool will make on
    *         each upstream connection. This can be used to increase spread if the backends cannot
    *         tolerate imbalance. 0 indicates no maximum.
    */
-  virtual uint64_t maxRequestsPerConnection() const PURE;
+  virtual uint32_t maxRequestsPerConnection() const PURE;
 
   /**
    * @return uint32_t the maximum number of response headers. The default value is 100. Results in a

--- a/source/common/conn_pool/conn_pool_base.cc
+++ b/source/common/conn_pool/conn_pool_base.cc
@@ -793,7 +793,7 @@ void ConnPoolImplBase::onUpstreamReadyForEarlyData(ActiveClient& client) {
 }
 
 namespace {
-// Translate zero to UINT64_MAX so that the zero/unlimited case doesn't
+// Translate zero to UINT32_MAX so that the zero/unlimited case doesn't
 // have to be handled specially.
 uint32_t translateZeroToUnlimited(uint32_t limit) {
   return (limit != 0) ? limit : std::numeric_limits<uint32_t>::max();

--- a/source/common/http/conn_manager_config.h
+++ b/source/common/http/conn_manager_config.h
@@ -528,7 +528,7 @@ public:
   /**
    * @return maximum requests for downstream.
    */
-  virtual uint64_t maxRequestsPerConnection() const PURE;
+  virtual uint32_t maxRequestsPerConnection() const PURE;
   /**
    * @return the config describing if/how to write the Proxy-Status HTTP response header.
    * If nullptr, don't write the Proxy-Status HTTP response header.

--- a/source/common/http/conn_pool_base.cc
+++ b/source/common/http/conn_pool_base.cc
@@ -95,7 +95,7 @@ void HttpConnPoolImplBase::onPoolReady(Envoy::ConnectionPool::ActiveClient& clie
 
 // All streams are 2^31. Client streams are half that, minus stream 0. Just to be on the safe
 // side we do 2^29.
-static const uint64_t DEFAULT_MAX_STREAMS = (1 << 29);
+static const uint32_t DEFAULT_MAX_STREAMS = (1 << 29);
 
 void MultiplexedActiveClientBase::onGoAway(Http::GoAwayErrorCode) {
   ENVOY_CONN_LOG(debug, "remote goaway", *codec_client_);
@@ -182,7 +182,7 @@ void MultiplexedActiveClientBase::onStreamReset(Http::StreamResetReason reason) 
   }
 }
 
-uint64_t MultiplexedActiveClientBase::maxStreamsPerConnection(uint64_t max_streams_config) {
+uint32_t MultiplexedActiveClientBase::maxStreamsPerConnection(uint64_t max_streams_config) {
   return (max_streams_config != 0) ? max_streams_config : DEFAULT_MAX_STREAMS;
 }
 

--- a/source/common/http/conn_pool_base.cc
+++ b/source/common/http/conn_pool_base.cc
@@ -95,7 +95,7 @@ void HttpConnPoolImplBase::onPoolReady(Envoy::ConnectionPool::ActiveClient& clie
 
 // All streams are 2^31. Client streams are half that, minus stream 0. Just to be on the safe
 // side we do 2^29.
-static const uint32_t DEFAULT_MAX_STREAMS = (1 << 29);
+constexpr uint32_t DEFAULT_MAX_STREAMS = 1U << 29;
 
 void MultiplexedActiveClientBase::onGoAway(Http::GoAwayErrorCode) {
   ENVOY_CONN_LOG(debug, "remote goaway", *codec_client_);

--- a/source/common/http/conn_pool_base.cc
+++ b/source/common/http/conn_pool_base.cc
@@ -182,7 +182,7 @@ void MultiplexedActiveClientBase::onStreamReset(Http::StreamResetReason reason) 
   }
 }
 
-uint32_t MultiplexedActiveClientBase::maxStreamsPerConnection(uint64_t max_streams_config) {
+uint32_t MultiplexedActiveClientBase::maxStreamsPerConnection(uint32_t max_streams_config) {
   return (max_streams_config != 0) ? max_streams_config : DEFAULT_MAX_STREAMS;
 }
 

--- a/source/common/http/conn_pool_base.h
+++ b/source/common/http/conn_pool_base.h
@@ -105,9 +105,9 @@ private:
 // An implementation of Envoy::ConnectionPool::ActiveClient for HTTP/1.1 and HTTP/2
 class ActiveClient : public Envoy::ConnectionPool::ActiveClient {
 public:
-  ActiveClient(HttpConnPoolImplBase& parent, uint64_t lifetime_stream_limit,
-               uint64_t effective_concurrent_stream_limit,
-               uint64_t configured_concurrent_stream_limit,
+  ActiveClient(HttpConnPoolImplBase& parent, uint32_t lifetime_stream_limit,
+               uint32_t effective_concurrent_stream_limit,
+               uint32_t configured_concurrent_stream_limit,
                OptRef<Upstream::Host::CreateConnectionData> opt_data)
       : Envoy::ConnectionPool::ActiveClient(parent, lifetime_stream_limit,
                                             effective_concurrent_stream_limit,

--- a/source/common/http/conn_pool_base.h
+++ b/source/common/http/conn_pool_base.h
@@ -207,7 +207,7 @@ public:
                               OptRef<Upstream::Host::CreateConnectionData> data);
   ~MultiplexedActiveClientBase() override = default;
   // Caps max streams per connection below 2^31 to prevent overflow.
-  static uint64_t maxStreamsPerConnection(uint64_t max_streams_config);
+  static uint32_t maxStreamsPerConnection(uint32_t max_streams_config);
 
   // ConnPoolImpl::ActiveClient
   bool closingWithIncompleteStream() const override;

--- a/source/common/http/http2/conn_pool.cc
+++ b/source/common/http/http2/conn_pool.cc
@@ -28,7 +28,7 @@ uint32_t ActiveClient::calculateInitialStreamsLimit(
       initial_streams = cached_concurrency;
     }
   }
-  uint64_t max_requests = MultiplexedActiveClientBase::maxStreamsPerConnection(
+  uint32_t max_requests = MultiplexedActiveClientBase::maxStreamsPerConnection(
       host->cluster().maxRequestsPerConnection());
   if (max_requests < initial_streams) {
     initial_streams = max_requests;

--- a/source/common/tcp/conn_pool.cc
+++ b/source/common/tcp/conn_pool.cc
@@ -13,7 +13,7 @@ namespace Tcp {
 
 ActiveTcpClient::ActiveTcpClient(Envoy::ConnectionPool::ConnPoolImplBase& parent,
                                  const Upstream::HostConstSharedPtr& host,
-                                 uint64_t concurrent_stream_limit,
+                                 uint32_t concurrent_stream_limit,
                                  absl::optional<std::chrono::milliseconds> idle_timeout)
     : Envoy::ConnectionPool::ActiveClient(parent, host->cluster().maxRequestsPerConnection(),
                                           concurrent_stream_limit),

--- a/source/common/tcp/conn_pool.h
+++ b/source/common/tcp/conn_pool.h
@@ -87,7 +87,7 @@ public:
   };
 
   ActiveTcpClient(Envoy::ConnectionPool::ConnPoolImplBase& parent,
-                  const Upstream::HostConstSharedPtr& host, uint64_t concurrent_stream_limit,
+                  const Upstream::HostConstSharedPtr& host, uint32_t concurrent_stream_limit,
                   absl::optional<std::chrono::milliseconds> idle_timeout);
   ~ActiveTcpClient() override;
 

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -933,7 +933,7 @@ public:
     return *upstream_config_;
   }
   bool maintenanceMode() const override;
-  uint64_t maxRequestsPerConnection() const override { return max_requests_per_connection_; }
+  uint32_t maxRequestsPerConnection() const override { return max_requests_per_connection_; }
   uint32_t maxResponseHeadersCount() const override { return max_response_headers_count_; }
   absl::optional<uint16_t> maxResponseHeadersKb() const override {
     return max_response_headers_kb_;
@@ -1111,7 +1111,7 @@ private:
       extension_protocol_options_;
   const std::shared_ptr<const HttpProtocolOptionsConfigImpl> http_protocol_options_;
   const std::shared_ptr<const TcpProtocolOptionsConfigImpl> tcp_protocol_options_;
-  const uint64_t max_requests_per_connection_;
+  const uint32_t max_requests_per_connection_;
   const std::chrono::milliseconds connect_timeout_;
   OptionalTimeouts optional_timeouts_;
   const float per_upstream_preconnect_ratio_;

--- a/source/extensions/filters/network/http_connection_manager/config.h
+++ b/source/extensions/filters/network/http_connection_manager/config.h
@@ -255,7 +255,7 @@ public:
     return early_header_mutation_extensions_;
   }
 
-  uint64_t maxRequestsPerConnection() const override { return max_requests_per_connection_; }
+  uint32_t maxRequestsPerConnection() const override { return max_requests_per_connection_; }
   const HttpConnectionManagerProto::ProxyStatusConfig* proxyStatusConfig() const override {
     return proxy_status_config_.get();
   }

--- a/source/extensions/filters/network/thrift_proxy/config.h
+++ b/source/extensions/filters/network/thrift_proxy/config.h
@@ -87,7 +87,7 @@ public:
   ProtocolPtr createProtocol() override;
   Router::Config& routerConfig() override { return *this; }
   bool payloadPassthrough() const override { return payload_passthrough_; }
-  uint64_t maxRequestsPerConnection() const override { return max_requests_per_connection_; }
+  uint32_t maxRequestsPerConnection() const override { return max_requests_per_connection_; }
   const AccessLog::InstanceSharedPtrVector& accessLogs() const override { return access_logs_; }
   bool headerKeysPreserveCase() const override { return header_keys_preserve_case_; }
 
@@ -105,7 +105,7 @@ private:
   std::list<ThriftFilters::FilterFactoryCb> filter_factories_;
   const bool payload_passthrough_;
 
-  const uint64_t max_requests_per_connection_{};
+  const uint32_t max_requests_per_connection_{};
   AccessLog::InstanceSharedPtrVector access_logs_;
   const bool header_keys_preserve_case_;
 };

--- a/source/extensions/filters/network/thrift_proxy/conn_manager.h
+++ b/source/extensions/filters/network/thrift_proxy/conn_manager.h
@@ -41,7 +41,7 @@ public:
   virtual ProtocolPtr createProtocol() PURE;
   virtual Router::Config& routerConfig() PURE;
   virtual bool payloadPassthrough() const PURE;
-  virtual uint64_t maxRequestsPerConnection() const PURE;
+  virtual uint32_t maxRequestsPerConnection() const PURE;
   virtual const AccessLog::InstanceSharedPtrVector& accessLogs() const PURE;
   virtual bool headerKeysPreserveCase() const PURE;
 };

--- a/source/server/admin/admin.h
+++ b/source/server/admin/admin.h
@@ -220,7 +220,7 @@ public:
   void closeSocket() override;
   void addListenerToHandler(Network::ConnectionHandler* handler) override;
 
-  uint64_t maxRequestsPerConnection() const override { return 0; }
+  uint32_t maxRequestsPerConnection() const override { return 0; }
   const HttpConnectionManagerProto::ProxyStatusConfig* proxyStatusConfig() const override {
     return proxy_status_config_.get();
   }

--- a/test/common/http/conn_manager_impl_fuzz_test.cc
+++ b/test/common/http/conn_manager_impl_fuzz_test.cc
@@ -235,7 +235,7 @@ public:
   const std::vector<Http::EarlyHeaderMutationPtr>& earlyHeaderMutationExtensions() const override {
     return early_header_mutations_;
   }
-  uint64_t maxRequestsPerConnection() const override { return 0; }
+  uint32_t maxRequestsPerConnection() const override { return 0; }
   const HttpConnectionManagerProto::ProxyStatusConfig* proxyStatusConfig() const override {
     return proxy_status_config_.get();
   }

--- a/test/common/http/conn_manager_impl_test_base.cc
+++ b/test/common/http/conn_manager_impl_test_base.cc
@@ -130,7 +130,7 @@ public:
     return parent_.earlyHeaderMutationExtensions();
   }
   bool shouldStripTrailingHostDot() const override { return parent_.shouldStripTrailingHostDot(); }
-  uint64_t maxRequestsPerConnection() const override { return parent_.maxRequestsPerConnection(); }
+  uint32_t maxRequestsPerConnection() const override { return parent_.maxRequestsPerConnection(); }
   const HttpConnectionManagerProto::ProxyStatusConfig* proxyStatusConfig() const override {
     return parent_.proxyStatusConfig();
   }

--- a/test/common/http/conn_manager_impl_test_base.h
+++ b/test/common/http/conn_manager_impl_test_base.h
@@ -201,7 +201,7 @@ public:
   const std::vector<Http::EarlyHeaderMutationPtr>& earlyHeaderMutationExtensions() const override {
     return early_header_mutations_;
   }
-  uint64_t maxRequestsPerConnection() const override { return max_requests_per_connection_; }
+  uint32_t maxRequestsPerConnection() const override { return max_requests_per_connection_; }
   const HttpConnectionManagerProto::ProxyStatusConfig* proxyStatusConfig() const override {
     return proxy_status_config_.get();
   }
@@ -280,7 +280,7 @@ public:
   absl::optional<std::string> user_agent_;
   uint32_t max_request_headers_kb_{Http::DEFAULT_MAX_REQUEST_HEADERS_KB};
   uint32_t max_request_headers_count_{Http::DEFAULT_MAX_HEADERS_COUNT};
-  uint64_t max_requests_per_connection_{};
+  uint32_t max_requests_per_connection_{};
   absl::optional<std::chrono::milliseconds> idle_timeout_;
   absl::optional<std::chrono::milliseconds> max_connection_duration_;
   bool http1_safe_max_connection_duration_{false};

--- a/test/config/utility.cc
+++ b/test/config/utility.cc
@@ -1210,7 +1210,7 @@ void ConfigHelper::disableDelayClose() {
              hcm) { hcm.mutable_delayed_close_timeout()->set_nanos(0); });
 }
 
-void ConfigHelper::setDownstreamMaxRequestsPerConnection(uint64_t max_requests_per_connection) {
+void ConfigHelper::setDownstreamMaxRequestsPerConnection(uint32_t max_requests_per_connection) {
   addConfigModifier(
       [max_requests_per_connection](
           envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&

--- a/test/config/utility.h
+++ b/test/config/utility.h
@@ -327,7 +327,7 @@ public:
   void disableDelayClose();
 
   // Set the max_requests_per_connection for downstream through the HttpConnectionManager.
-  void setDownstreamMaxRequestsPerConnection(uint64_t max_requests_per_connection);
+  void setDownstreamMaxRequestsPerConnection(uint32_t max_requests_per_connection);
 
   envoy::config::route::v3::VirtualHost createVirtualHost(const char* host, const char* route = "/",
                                                           const char* cluster = "cluster_0");

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -699,7 +699,7 @@ public:
   const std::vector<Http::EarlyHeaderMutationPtr>& earlyHeaderMutationExtensions() const override {
     return early_header_mutation_extensions_;
   }
-  MOCK_METHOD(uint64_t, maxRequestsPerConnection, (), (const));
+  MOCK_METHOD(uint32_t, maxRequestsPerConnection, (), (const));
   MOCK_METHOD(const HttpConnectionManagerProto::ProxyStatusConfig*, proxyStatusConfig, (), (const));
   MOCK_METHOD(ServerHeaderValidatorPtr, makeHeaderValidator, (Protocol protocol));
   MOCK_METHOD(bool, appendLocalOverload, (), (const));

--- a/test/mocks/upstream/cluster_info.h
+++ b/test/mocks/upstream/cluster_info.h
@@ -129,7 +129,7 @@ public:
   MOCK_METHOD(bool, maintenanceMode, (), (const));
   MOCK_METHOD(uint32_t, maxResponseHeadersCount, (), (const));
   MOCK_METHOD(absl::optional<uint16_t>, maxResponseHeadersKb, (), (const));
-  MOCK_METHOD(uint64_t, maxRequestsPerConnection, (), (const));
+  MOCK_METHOD(uint32_t, maxRequestsPerConnection, (), (const));
   MOCK_METHOD(const std::string&, name, (), (const));
   MOCK_METHOD(const std::string&, observabilityName, (), (const));
   MOCK_METHOD(ResourceManager&, resourceManager, (ResourcePriority priority), (const));
@@ -186,7 +186,7 @@ public:
   envoy::config::core::v3::Http3ProtocolOptions http3_options_;
   envoy::config::core::v3::HttpProtocolOptions common_http_protocol_options_;
   ProtocolOptionsConfigConstSharedPtr extension_protocol_options_;
-  uint64_t max_requests_per_connection_{};
+  uint32_t max_requests_per_connection_{};
   uint32_t max_response_headers_count_{Http::DEFAULT_MAX_HEADERS_COUNT};
   NiceMock<Stats::MockIsolatedStatsStore> stats_store_;
   ClusterTrafficStatNames traffic_stat_names_;

--- a/test/mocks/upstream/cluster_info.h
+++ b/test/mocks/upstream/cluster_info.h
@@ -186,7 +186,7 @@ public:
   envoy::config::core::v3::Http3ProtocolOptions http3_options_;
   envoy::config::core::v3::HttpProtocolOptions common_http_protocol_options_;
   ProtocolOptionsConfigConstSharedPtr extension_protocol_options_;
-  uint64_t max_requests_per_connection_{};
+  uint32_t max_requests_per_connection_{};
   uint32_t max_response_headers_count_{Http::DEFAULT_MAX_HEADERS_COUNT};
   NiceMock<Stats::MockIsolatedStatsStore> stats_store_;
   ClusterTrafficStatNames traffic_stat_names_;

--- a/test/mocks/upstream/cluster_info.h
+++ b/test/mocks/upstream/cluster_info.h
@@ -186,7 +186,7 @@ public:
   envoy::config::core::v3::Http3ProtocolOptions http3_options_;
   envoy::config::core::v3::HttpProtocolOptions common_http_protocol_options_;
   ProtocolOptionsConfigConstSharedPtr extension_protocol_options_;
-  uint32_t max_requests_per_connection_{};
+  uint64_t max_requests_per_connection_{};
   uint32_t max_response_headers_count_{Http::DEFAULT_MAX_HEADERS_COUNT};
   NiceMock<Stats::MockIsolatedStatsStore> stats_store_;
   ClusterTrafficStatNames traffic_stat_names_;


### PR DESCRIPTION
1. `max_requests_per_connection` is `uint32Value` in the http options and cluster configs, so no need to use `uint64_t`
2. clean up for both HTTP and TCP active clients in the connection pool to avoid `uint64_t` for any limits and the base `Envoy::ConnectionPool::ActiveClient`are all `uint32_t`.
3. correct comments and other changes for the default.

Commit Message:
Additional Description:
Risk Level: low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
