### PR TITLE
dns: Allow getaddrinfo to run in a thread pool

### DIFF
--- a/api/envoy/extensions/network/dns_resolver/getaddrinfo/v3/getaddrinfo_dns_resolver.proto
+++ b/api/envoy/extensions/network/dns_resolver/getaddrinfo/v3/getaddrinfo_dns_resolver.proto
@@ -20,16 +20,13 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 //
 // .. attention::
 //
-//   This resolver uses a single background thread to do resolutions. As such, it is not currently
-//   advised for use in situations requiring a high resolution rate. A thread pool can be added
-//   in the future if needed.
-//
-// .. attention::
-//
 //   Resolutions currently use a hard coded TTL of 60s because the getaddrinfo() API does not
 //   provide the actual TTL. Configuration for this can be added in the future if needed.
 message GetAddrInfoDnsResolverConfig {
   // Specifies the number of retries before the resolver gives up. If not specified, the resolver will
   // retry indefinitely until it succeeds or the DNS query times out.
   google.protobuf.UInt32Value num_retries = 1;
+
+  // Specifies the number of threads used to resolve pending DNS queries. If not specified, one thread is used.
+  google.protobuf.UInt32Value num_resolver_threads = 2;
 }

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -22,6 +22,10 @@ minor_behavior_changes:
   change: |
     Precompile regexes in cel expressions. This can be disabled by setting the runtime guard
     ``envoy.reloadable_features.enable_cel_regex_precompilation`` to false.
+- area dns
+  change: |
+    Allow getaddrinfo to be configured to run by a thread pool, controlled by :ref: `num_resolver_threads
+    <envoy_v3_api_field_extensions.network.dns_resolver.getaddrinfo.v3.GetAddrInfoDnsResolverConfig.num_resolver_threads>`.
 
 bug_fixes:
 # *Changes expected to improve the state of the world and are unlikely to have negative effects*

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -24,7 +24,7 @@ minor_behavior_changes:
     ``envoy.reloadable_features.enable_cel_regex_precompilation`` to false.
 - area: dns
   change: |
-    Allow getaddrinfo to be configured to run by a thread pool, controlled by :ref: `num_resolver_threads
+    Allow getaddrinfo to be configured to run by a thread pool, controlled by :ref:`num_resolver_threads
     <envoy_v3_api_field_extensions.network.dns_resolver.getaddrinfo.v3.GetAddrInfoDnsResolverConfig.num_resolver_threads>`.
 
 bug_fixes:

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -22,7 +22,7 @@ minor_behavior_changes:
   change: |
     Precompile regexes in cel expressions. This can be disabled by setting the runtime guard
     ``envoy.reloadable_features.enable_cel_regex_precompilation`` to false.
-- area dns
+- area: dns
   change: |
     Allow getaddrinfo to be configured to run by a thread pool, controlled by :ref: `num_resolver_threads
     <envoy_v3_api_field_extensions.network.dns_resolver.getaddrinfo.v3.GetAddrInfoDnsResolverConfig.num_resolver_threads>`.

--- a/source/extensions/network/dns_resolver/getaddrinfo/getaddrinfo.cc
+++ b/source/extensions/network/dns_resolver/getaddrinfo/getaddrinfo.cc
@@ -40,7 +40,6 @@ GetAddrInfoDnsResolver::~GetAddrInfoDnsResolver() {
   {
     absl::MutexLock guard(&mutex_);
     shutting_down_ = true;
-    // Signal all waiting threads to wake up and check the shutting_down_ flag.
     pending_queries_.clear();
   }
 

--- a/source/extensions/network/dns_resolver/getaddrinfo/getaddrinfo.cc
+++ b/source/extensions/network/dns_resolver/getaddrinfo/getaddrinfo.cc
@@ -21,6 +21,8 @@ private:
 
 } // namespace
 
+constexpr uint32_t kThreadCap = 10;
+
 GetAddrInfoDnsResolver::GetAddrInfoDnsResolver(
     const envoy::extensions::network::dns_resolver::getaddrinfo::v3::GetAddrInfoDnsResolverConfig&
         config,
@@ -28,9 +30,7 @@ GetAddrInfoDnsResolver::GetAddrInfoDnsResolver(
     : config_(config), dispatcher_(dispatcher), api_(api) {
   uint32_t num_threads =
       config_.has_num_resolver_threads() ? config_.num_resolver_threads().value() : 1;
-  uint32_t hardware_cap = std::thread::hardware_concurrency();
-  uint32_t thread_cap = hardware_cap > 0 ? hardware_cap : 1;
-  num_threads = std::min(num_threads, thread_cap);
+  num_threads = std::min(num_threads, kThreadCap);
   ENVOY_LOG(debug, "Starting getaddrinfo resolver with {} threads", num_threads);
   resolver_threads_.reserve(num_threads);
   for (uint32_t i = 0; i < num_threads; i++) {

--- a/source/extensions/network/dns_resolver/getaddrinfo/getaddrinfo.cc
+++ b/source/extensions/network/dns_resolver/getaddrinfo/getaddrinfo.cc
@@ -27,7 +27,10 @@ GetAddrInfoDnsResolver::GetAddrInfoDnsResolver(
     Event::Dispatcher& dispatcher, Api::Api& api)
     : config_(config), dispatcher_(dispatcher), api_(api) {
   uint32_t num_threads =
-      config_.has_num_resolver_threads() ? 1 : config_.num_resolver_threads().value();
+      config_.has_num_resolver_threads() ? config_.num_resolver_threads().value() : 1;
+  uint32_t hardware_cap = std::thread::hardware_concurrency();
+  uint32_t thread_cap = hardware_cap > 0 ? hardware_cap : 1;
+  num_threads = std::min(num_threads, thread_cap);
   ENVOY_LOG(debug, "Starting getaddrinfo resolver with {} threads", num_threads);
   resolver_threads_.reserve(num_threads);
   for (uint32_t i = 0; i < num_threads; i++) {

--- a/source/extensions/network/dns_resolver/getaddrinfo/getaddrinfo.h
+++ b/source/extensions/network/dns_resolver/getaddrinfo/getaddrinfo.h
@@ -107,6 +107,7 @@ protected:
 
   envoy::extensions::network::dns_resolver::getaddrinfo::v3::GetAddrInfoDnsResolverConfig config_;
   Event::Dispatcher& dispatcher_;
+  Api::Api& api_;
   absl::Mutex mutex_;
   std::list<PendingQueryInfo> pending_queries_ ABSL_GUARDED_BY(mutex_);
   bool shutting_down_ ABSL_GUARDED_BY(mutex_){};

--- a/source/extensions/network/dns_resolver/getaddrinfo/getaddrinfo.h
+++ b/source/extensions/network/dns_resolver/getaddrinfo/getaddrinfo.h
@@ -33,9 +33,7 @@ public:
   GetAddrInfoDnsResolver(
       const envoy::extensions::network::dns_resolver::getaddrinfo::v3::GetAddrInfoDnsResolverConfig&
           config,
-      Event::Dispatcher& dispatcher, Api::Api& api)
-      : config_(config), dispatcher_(dispatcher),
-        resolver_thread_(api.threadFactory().createThread([this] { resolveThreadRoutine(); })) {}
+      Event::Dispatcher& dispatcher, Api::Api& api);
 
   ~GetAddrInfoDnsResolver() override;
 
@@ -48,7 +46,8 @@ protected:
   class PendingQuery : public ActiveDnsQuery {
   public:
     PendingQuery(const std::string& dns_name, DnsLookupFamily dns_lookup_family, ResolveCb callback)
-        : dns_name_(dns_name), dns_lookup_family_(dns_lookup_family), callback_(callback) {}
+        : dns_name_(dns_name), dns_lookup_family_(dns_lookup_family),
+          callback_(std::move(callback)) {}
 
     void cancel(CancelReason) override {
       ENVOY_LOG(debug, "cancelling query [{}]", dns_name_);
@@ -111,9 +110,9 @@ protected:
   absl::Mutex mutex_;
   std::list<PendingQueryInfo> pending_queries_ ABSL_GUARDED_BY(mutex_);
   bool shutting_down_ ABSL_GUARDED_BY(mutex_){};
-  // The resolver thread must be initialized last so that the above members are already fully
+  // The resolvers thread must be initialized last so that the above members are already fully
   // initialized.
-  const Thread::ThreadPtr resolver_thread_;
+  std::vector<Thread::ThreadPtr> resolver_threads_;
 };
 
 // getaddrinfo DNS resolver factory

--- a/test/extensions/network/dns_resolver/getaddrinfo/getaddrinfo_test.cc
+++ b/test/extensions/network/dns_resolver/getaddrinfo/getaddrinfo_test.cc
@@ -138,20 +138,6 @@ TEST_F(GetAddrInfoDnsImplTest, LocalhostResolve) {
                            dispatcher_->exit();
                          });
 
-  active_dns_query_ =
-      resolver_->resolve("localhost", DnsLookupFamily::All,
-                         [this](DnsResolver::ResolutionStatus status, absl::string_view,
-                                std::list<DnsResponse>&& response) {
-                           verifyRealGaiResponse(status, std::move(response));
-                           std::vector<std::string> traces =
-                               absl::StrSplit(active_dns_query_->getTraces(), ',');
-                           EXPECT_THAT(traces, ElementsAre(HasTrace(GetAddrInfoTrace::NotStarted),
-                                                           HasTrace(GetAddrInfoTrace::Starting),
-                                                           HasTrace(GetAddrInfoTrace::Success),
-                                                           HasTrace(GetAddrInfoTrace::Callback)));
-                           dispatcher_->exit();
-                         });
-
   dispatcher_->run(Event::Dispatcher::RunType::RunUntilExit);
 }
 


### PR DESCRIPTION
Commit Message: Allow getaddrinfo to run in a thread pool. The number of worker threads can be configured.
Additional Description: There's also a minor change to std::move() callbacks for better code performance.
Risk Level: low
Testing: manual test and unit tests
Docs Changes: n/a
Release Notes: added
