### PR TITLE
network: add ext proc config check for processing mode and grpc services

### DIFF
--- a/test/extensions/filters/network/ext_proc/config_test.cc
+++ b/test/extensions/filters/network/ext_proc/config_test.cc
@@ -109,6 +109,47 @@ TEST(NetworkExtProcConfigTest, ConfigWithOptions) {
   cb(filter_manager);
 }
 
+// Test the config without a gRPC service.
+TEST(NetworkExtProcConfigFactoryTest, MissingGrpcService) {
+  envoy::extensions::filters::network::ext_proc::v3::NetworkExternalProcessor proto_config;
+
+  NiceMock<Server::Configuration::MockFactoryContext> context;
+  NetworkExtProcConfigFactory factory;
+
+  EXPECT_THROW_WITH_MESSAGE(auto cb = factory.createFilterFactoryFromProto(proto_config, context),
+                            EnvoyException, "A grpc_service must be configured");
+}
+
+// Test the config with both skiped modes.
+TEST(NetworkExtProcConfigFactoryTest, BothModesSkipped) {
+  envoy::extensions::filters::network::ext_proc::v3::NetworkExternalProcessor proto_config;
+  proto_config.mutable_grpc_service()->mutable_envoy_grpc()->set_cluster_name("ext_proc_server");
+
+  auto* processing_mode = proto_config.mutable_processing_mode();
+  processing_mode->set_process_read(
+      envoy::extensions::filters::network::ext_proc::v3::ProcessingMode::SKIP);
+  processing_mode->set_process_write(
+      envoy::extensions::filters::network::ext_proc::v3::ProcessingMode::SKIP);
+
+  NiceMock<Server::Configuration::MockFactoryContext> context;
+  NetworkExtProcConfigFactory factory;
+
+  EXPECT_THROW_WITH_MESSAGE(auto cb = factory.createFilterFactoryFromProto(proto_config, context),
+                            EnvoyException,
+                            "both read and write paths are skipped, at least one must be enabled.");
+}
+
+// Test the configs with default processing modes.
+TEST(NetworkExtProcConfigFactoryTest, DefaultProcessingMode) {
+  envoy::extensions::filters::network::ext_proc::v3::NetworkExternalProcessor proto_config;
+  proto_config.mutable_grpc_service()->mutable_envoy_grpc()->set_cluster_name("ext_proc_server");
+
+  NiceMock<Server::Configuration::MockFactoryContext> context;
+  NetworkExtProcConfigFactory factory;
+
+  EXPECT_NO_THROW(auto cb = factory.createFilterFactoryFromProto(proto_config, context));
+}
+
 } // namespace
 } // namespace ExtProc
 } // namespace NetworkFilters

--- a/test/extensions/filters/network/ext_proc/config_test.cc
+++ b/test/extensions/filters/network/ext_proc/config_test.cc
@@ -120,7 +120,7 @@ TEST(NetworkExtProcConfigFactoryTest, MissingGrpcService) {
                             EnvoyException, "A grpc_service must be configured");
 }
 
-// Test the config with both skiped modes.
+// Test the config with both SKIP modes.
 TEST(NetworkExtProcConfigFactoryTest, BothModesSkipped) {
   envoy::extensions::filters::network::ext_proc::v3::NetworkExternalProcessor proto_config;
   proto_config.mutable_grpc_service()->mutable_envoy_grpc()->set_cluster_name("ext_proc_server");

--- a/tools/code_format/config.yaml
+++ b/tools/code_format/config.yaml
@@ -192,6 +192,7 @@ paths:
     - source/extensions/filters/network/redis_proxy
     - source/extensions/filters/network/zookeeper_proxy
     - source/extensions/filters/network/ext_authz
+    - source/extensions/filters/network/ext_proc
     - source/extensions/filters/network/mongo_proxy
     - source/extensions/filters/network/thrift_proxy
     - source/extensions/filters/network/generic_proxy


### PR DESCRIPTION
Throw in this PR, but I think a better way is to change the interface of `createFilterFactoryFromProtoTyped` to return `absl:status` to avoid throw for network filters.

Commit Message:
Additional Description:
Risk Level: low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
