### PR TITLE
aws: (chore) remove redundant metadata inheritance

### DIFF
--- a/source/extensions/common/aws/cached_credentials_provider_base.h
+++ b/source/extensions/common/aws/cached_credentials_provider_base.h
@@ -9,8 +9,6 @@ namespace Extensions {
 namespace Common {
 namespace Aws {
 
-constexpr std::chrono::hours REFRESH_INTERVAL{1};
-
 class CachedCredentialsProviderBase : public CredentialsProvider,
                                       public Logger::Loggable<Logger::Id::aws> {
 public:

--- a/source/extensions/common/aws/credential_providers/container_credentials_provider.cc
+++ b/source/extensions/common/aws/credential_providers/container_credentials_provider.cc
@@ -16,7 +16,6 @@ ContainerCredentialsProvider::ContainerCredentialsProvider(
                                       initialization_timer),
       credential_uri_(credential_uri), authorization_token_(authorization_token) {}
 
-
 void ContainerCredentialsProvider::refresh() {
 
   absl::string_view host, path;

--- a/source/extensions/common/aws/credential_providers/container_credentials_provider.cc
+++ b/source/extensions/common/aws/credential_providers/container_credentials_provider.cc
@@ -16,16 +16,6 @@ ContainerCredentialsProvider::ContainerCredentialsProvider(
                                       initialization_timer),
       credential_uri_(credential_uri), authorization_token_(authorization_token) {}
 
-bool ContainerCredentialsProvider::needsRefresh() {
-  const auto now = api_.timeSource().systemTime();
-  auto expired = (now - last_updated_ > REFRESH_INTERVAL);
-
-  if (expiration_time_.has_value()) {
-    return expired || (expiration_time_.value() - now < REFRESH_GRACE_PERIOD);
-  } else {
-    return expired;
-  }
-}
 
 void ContainerCredentialsProvider::refresh() {
 

--- a/source/extensions/common/aws/credential_providers/container_credentials_provider.h
+++ b/source/extensions/common/aws/credential_providers/container_credentials_provider.h
@@ -41,7 +41,6 @@ private:
   const std::string credential_uri_;
   const std::string authorization_token_;
 
-  bool needsRefresh() override;
   void refresh() override;
   void extractCredentials(const std::string&& credential_document_value);
 };

--- a/source/extensions/common/aws/credential_providers/instance_profile_credentials_provider.cc
+++ b/source/extensions/common/aws/credential_providers/instance_profile_credentials_provider.cc
@@ -14,10 +14,6 @@ InstanceProfileCredentialsProvider::InstanceProfileCredentialsProvider(
                                       create_metadata_fetcher_cb, refresh_state,
                                       initialization_timer) {}
 
-bool InstanceProfileCredentialsProvider::needsRefresh() {
-  return api_.timeSource().systemTime() - last_updated_ > REFRESH_INTERVAL;
-}
-
 void InstanceProfileCredentialsProvider::refresh() {
 
   ENVOY_LOG(debug, "Getting AWS credentials from the EC2MetadataService");

--- a/source/extensions/common/aws/credential_providers/instance_profile_credentials_provider.h
+++ b/source/extensions/common/aws/credential_providers/instance_profile_credentials_provider.h
@@ -38,7 +38,6 @@ public:
   std::string providerName() override { return "InstanceProfileCredentialsProvider"; };
 
 private:
-  bool needsRefresh() override;
   void refresh() override;
   void fetchInstanceRoleAsync(const std::string&& token);
   void fetchCredentialFromInstanceRoleAsync(const std::string&& instance_role,

--- a/source/extensions/common/aws/credential_providers/webidentity_credentials_provider.h
+++ b/source/extensions/common/aws/credential_providers/webidentity_credentials_provider.h
@@ -48,9 +48,6 @@ private:
   const std::string role_arn_;
   const std::string role_session_name_;
 
-  // This is required because of the base class handling non-async case, which can never be used for
-  // web identity provider
-  bool needsRefresh() override { return true; };
   void refresh() override;
   void extractCredentials(const std::string&& credential_document_value);
 };

--- a/source/extensions/common/aws/credentials_provider.h
+++ b/source/extensions/common/aws/credentials_provider.h
@@ -17,6 +17,7 @@ namespace Aws {
 constexpr char AWS_ACCESS_KEY_ID[] = "AWS_ACCESS_KEY_ID";
 constexpr char AWS_SECRET_ACCESS_KEY[] = "AWS_SECRET_ACCESS_KEY";
 constexpr char AWS_SESSION_TOKEN[] = "AWS_SESSION_TOKEN";
+constexpr std::chrono::hours REFRESH_INTERVAL{1};
 
 /**
  * AWS credentials containers

--- a/source/extensions/common/aws/metadata_credentials_provider_base.cc
+++ b/source/extensions/common/aws/metadata_credentials_provider_base.cc
@@ -51,10 +51,8 @@ void MetadataCredentialsProviderBase::credentialsRetrievalError() {
   handleFetchDone();
 }
 
-// Async provider uses its own refresh mechanism. Calling refreshIfNeeded() here is not thread safe.
 bool MetadataCredentialsProviderBase::credentialsPending() { return credentials_pending_; }
 
-// Async provider uses its own refresh mechanism. Calling refreshIfNeeded() here is not thread safe.
 Credentials MetadataCredentialsProviderBase::getCredentials() {
 
   if (tls_slot_) {

--- a/source/extensions/common/aws/metadata_credentials_provider_base.h
+++ b/source/extensions/common/aws/metadata_credentials_provider_base.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "source/extensions/common/aws/aws_cluster_manager.h"
-#include "source/extensions/common/aws/cached_credentials_provider_base.h"
 #include "source/extensions/common/aws/credentials_provider.h"
 #include "source/extensions/common/aws/metadata_fetcher.h"
 
@@ -32,7 +31,7 @@ struct MetadataCredentialsProviderStats {
 using CreateMetadataFetcherCb =
     std::function<MetadataFetcherPtr(Upstream::ClusterManager&, absl::string_view)>;
 
-class MetadataCredentialsProviderBase : public CachedCredentialsProviderBase,
+class MetadataCredentialsProviderBase : public CredentialsProvider,
                                         public AwsManagedClusterUpdateCallbacks {
 public:
   friend class MetadataCredentialsProviderBaseFriend;
@@ -83,6 +82,8 @@ protected:
 
   // Set Credentials shared_ptr on all threads.
   void setCredentialsToAllThreads(CredentialsConstUniquePtr&& creds);
+
+  virtual void refresh() PURE;
 
   Api::Api& api_;
   // The optional server factory context.

--- a/source/extensions/common/aws/metadata_credentials_provider_base.h
+++ b/source/extensions/common/aws/metadata_credentials_provider_base.h
@@ -32,6 +32,7 @@ using CreateMetadataFetcherCb =
     std::function<MetadataFetcherPtr(Upstream::ClusterManager&, absl::string_view)>;
 
 class MetadataCredentialsProviderBase : public CredentialsProvider,
+                                        public Logger::Loggable<Logger::Id::aws>,
                                         public AwsManagedClusterUpdateCallbacks {
 public:
   friend class MetadataCredentialsProviderBaseFriend;

--- a/test/extensions/common/aws/credential_providers/webidentity_credentials_provider_test.cc
+++ b/test/extensions/common/aws/credential_providers/webidentity_credentials_provider_test.cc
@@ -617,32 +617,6 @@ TEST_F(WebIdentityCredentialsProviderTest, UnexpectedResponseDuringStartup) {
   EXPECT_FALSE(credentials.sessionToken().has_value());
 }
 
-TEST_F(WebIdentityCredentialsProviderTest, Coverage) {
-
-  // Setup timer.
-  timer_ = new NiceMock<Event::MockTimer>(&context_.dispatcher_);
-  expectDocument(200, std::move(R"EOF(
-{
-  "AssumeRoleWithWebIdentityResponse": {
-    "UnexpectedResponse": ""
-  }
-}
-)EOF"));
-
-  setupProvider(MetadataFetcher::MetadataReceiver::RefreshState::FirstRefresh,
-                std::chrono::seconds(2));
-  timer_->enableTimer(std::chrono::milliseconds(1), nullptr);
-
-  EXPECT_CALL(*timer_, enableTimer(std::chrono::milliseconds(std::chrono::seconds(2)), nullptr));
-
-  // Kick off a refresh
-  auto provider_friend = MetadataCredentialsProviderBaseFriend(provider_);
-  provider_friend.onClusterAddOrUpdate();
-  timer_->invokeCallback();
-
-  EXPECT_TRUE(provider_friend.needsRefresh());
-}
-
 } // namespace Aws
 } // namespace Common
 } // namespace Extensions

--- a/test/extensions/common/aws/mocks.h
+++ b/test/extensions/common/aws/mocks.h
@@ -159,7 +159,6 @@ public:
 
   void onClusterAddOrUpdate() { return provider_->onClusterAddOrUpdate(); }
   std::shared_ptr<MetadataCredentialsProviderBase> provider_;
-  bool needsRefresh() { return provider_->needsRefresh(); };
 };
 
 } // namespace Aws


### PR DESCRIPTION
Commit Message: aws: (chore) remove redundant metadata inheritance
Additional Description: Metadata inherited from cached credentials provider, which is no longer required due to curl deprecation. This patch removes the unused needsrefresh calls and test cases from metadata credential providers.
Risk Level: Low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
