### PR TITLE
rate-limit: remove unique_ptr from the rate-limit-policy-entry vector

### DIFF
--- a/source/common/router/router_ratelimit.h
+++ b/source/common/router/router_ratelimit.h
@@ -279,7 +279,7 @@ public:
 
 private:
   const std::string disable_key_;
-  uint64_t stage_;
+  const uint64_t stage_;
   std::vector<RateLimit::DescriptorProducerPtr> actions_;
   absl::optional<RateLimitOverrideActionPtr> limit_override_ = absl::nullopt;
   const bool apply_on_stream_done_ = false;
@@ -301,7 +301,7 @@ public:
   bool empty() const override { return rate_limit_entries_.empty(); }
 
 private:
-  std::vector<std::unique_ptr<RateLimitPolicyEntry>> rate_limit_entries_;
+  std::vector<RateLimitPolicyEntryImpl> rate_limit_entries_;
   std::vector<std::vector<std::reference_wrapper<const RateLimitPolicyEntry>>>
       rate_limit_entries_reference_;
   // The maximum stage number supported. This value should match the maximum stage number in


### PR DESCRIPTION
Commit Message: rate-limit: remove unique_ptr from the rate-limit-policy-entry vector
Additional Description:
Minor refactor that converts rate-limit-policy-entry from vector<unique_ptr> to vector.

Risk Level: low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A