### PR TITLE
Fix environment-dependent UnexpectedFormatCpuAllocatedLine test

### DIFF
--- a/test/extensions/resource_monitors/cpu_utilization/linux_cpu_stats_reader_test.cc
+++ b/test/extensions/resource_monitors/cpu_utilization/linux_cpu_stats_reader_test.cc
@@ -89,29 +89,50 @@ cpu1 1883161 620 375962 1448133 5963 0 85914 10 0 0
   EXPECT_EQ(cpu_times.total_time, 0);
 }
 
-TEST(LinuxContainerCpuStatsReader, ReadsCgroupContainerStats) {
-  Event::MockDispatcher dispatcher;
-  Api::ApiPtr api = Api::createApiForTest();
-  Server::MockOptions options;
-  Server::Configuration::ResourceMonitorFactoryContextImpl context(
-      dispatcher, options, *api, ProtobufMessage::getStrictValidationVisitor());
-  TimeSource& test_time_source = context.api().timeSource();
+class LinuxContainerCpuStatsReaderTest : public testing::Test {
+public:
+  LinuxContainerCpuStatsReaderTest()
+      : api_(Api::createApiForTest()),
+        context_(dispatcher_, options_, *api_, ProtobufMessage::getStrictValidationVisitor()),
+        cpu_allocated_path_(TestEnvironment::temporaryPath("cgroup_cpu_allocated_stats")),
+        cpu_times_path_(TestEnvironment::temporaryPath("cgroup_cpu_times_stats")) {
+    // We populate the files that LinuxContainerStatsReader tries to read with some default
+    // sane values, so the tests don't need to populate the files they don't actually care
+    // about keeping the test cases focused on what they actually want to test.
+    setCpuAllocated("2000\n");
+    setCpuTimes("1000\n");
+  }
 
-  const std::string temp_path_cpu_allocated =
-      TestEnvironment::temporaryPath("cgroup_cpu_allocated_stats");
-  AtomicFileUpdater file_updater_cpu_allocated(temp_path_cpu_allocated);
-  const std::string mock_contents_cpu_allocated = R"EOF(2000
-)EOF";
-  file_updater_cpu_allocated.update(mock_contents_cpu_allocated);
+  TimeSource& timeSource() { return context_.api().timeSource(); }
 
-  const std::string temp_path_cpu_times = TestEnvironment::temporaryPath("cgroup_cpu_times_stats");
-  AtomicFileUpdater file_updater_cpu_times(temp_path_cpu_times);
-  const std::string mock_contents_cpu_times = R"EOF(1000
-)EOF";
-  file_updater_cpu_times.update(mock_contents_cpu_times);
+  const std::string& cpuAllocatedPath() const { return cpu_allocated_path_; }
+  void setCpuAllocated(const std::string& contents) {
+    AtomicFileUpdater cpu_allocated(cpuAllocatedPath());
+    cpu_allocated.update(contents);
+  }
 
-  LinuxContainerCpuStatsReader container_stats_reader(test_time_source, temp_path_cpu_allocated,
-                                                      temp_path_cpu_times);
+  const std::string& cpuTimesPath() const { return cpu_times_path_; }
+  void setCpuTimes(const std::string& contents) {
+    AtomicFileUpdater cpu_times(cpuTimesPath());
+    cpu_times.update(contents);
+  }
+
+private:
+  Event::MockDispatcher dispatcher_;
+  Api::ApiPtr api_;
+  Server::MockOptions options_;
+  Server::Configuration::ResourceMonitorFactoryContextImpl context_;
+  std::string cpu_allocated_path_;
+  std::string cpu_times_path_;
+};
+
+TEST_F(LinuxContainerCpuStatsReaderTest, ReadsCgroupContainerStats) {
+  TimeSource& test_time_source = timeSource();
+  setCpuAllocated("2000\n");
+  setCpuTimes("1000\n");
+
+  LinuxContainerCpuStatsReader container_stats_reader(test_time_source, cpuAllocatedPath(),
+                                                      cpuTimesPath());
   CpuTimes envoy_container_stats = container_stats_reader.getCpuTimes();
 
   const uint64_t current_monotonic_time = std::chrono::duration_cast<std::chrono::nanoseconds>(
@@ -123,103 +144,50 @@ TEST(LinuxContainerCpuStatsReader, ReadsCgroupContainerStats) {
   EXPECT_GT(time_diff_ns, 0);
 }
 
-TEST(LinuxContainerCpuStatsReader, CannotReadFileCpuAllocated) {
-  Event::MockDispatcher dispatcher;
-  Api::ApiPtr api = Api::createApiForTest();
-  Server::MockOptions options;
-  Server::Configuration::ResourceMonitorFactoryContextImpl context(
-      dispatcher, options, *api, ProtobufMessage::getStrictValidationVisitor());
-  TimeSource& test_time_source = context.api().timeSource();
-
+TEST_F(LinuxContainerCpuStatsReaderTest, CannotReadFileCpuAllocated) {
+  TimeSource& test_time_source = timeSource();
   const std::string temp_path_cpu_allocated =
-      TestEnvironment::temporaryPath("container_cpu_allocated_not_exists");
-
-  const std::string temp_path_cpu_times = TestEnvironment::temporaryPath("container_cpu_times");
-  AtomicFileUpdater file_updater_cpu_times(temp_path_cpu_times);
-  const std::string cpu_times_contents = R"EOF(100000
-)EOF";
-  file_updater_cpu_times.update(cpu_times_contents);
-
-  LinuxContainerCpuStatsReader container_stats_reader(test_time_source, temp_path_cpu_allocated,
-                                                      temp_path_cpu_times);
-  CpuTimes envoy_container_stats = container_stats_reader.getCpuTimes();
-  EXPECT_FALSE(envoy_container_stats.is_valid);
-  EXPECT_EQ(envoy_container_stats.work_time, 0);
-  EXPECT_EQ(envoy_container_stats.total_time, 0);
-}
-
-TEST(LinuxContainerCpuStatsReader, CannotReadFileCpuTimes) {
-  Event::MockDispatcher dispatcher;
-  Api::ApiPtr api = Api::createApiForTest();
-  Server::MockOptions options;
-  Server::Configuration::ResourceMonitorFactoryContextImpl context(
-      dispatcher, options, *api, ProtobufMessage::getStrictValidationVisitor());
-  TimeSource& test_time_source = context.api().timeSource();
-
-  const std::string temp_path_cpu_allocated =
-      TestEnvironment::temporaryPath("container_cpu_allocated");
-  AtomicFileUpdater file_updater_cpu_allocated(temp_path_cpu_allocated);
-  const std::string cpu_allocated_contents = R"EOF(1000101
-)EOF";
-  file_updater_cpu_allocated.update(cpu_allocated_contents);
-
-  const std::string temp_path_cpu_times =
       TestEnvironment::temporaryPath("container_cpu_times_not_exists");
 
   LinuxContainerCpuStatsReader container_stats_reader(test_time_source, temp_path_cpu_allocated,
-                                                      temp_path_cpu_times);
+                                                      cpuTimesPath());
   CpuTimes envoy_container_stats = container_stats_reader.getCpuTimes();
   EXPECT_FALSE(envoy_container_stats.is_valid);
   EXPECT_EQ(envoy_container_stats.work_time, 0);
   EXPECT_EQ(envoy_container_stats.total_time, 0);
 }
 
-TEST(LinuxContainerCpuStatsReader, UnexpectedFormatCpuAllocatedLine) {
-  Event::MockDispatcher dispatcher;
-  Api::ApiPtr api = Api::createApiForTest();
-  Server::MockOptions options;
-  Server::Configuration::ResourceMonitorFactoryContextImpl context(
-      dispatcher, options, *api, ProtobufMessage::getStrictValidationVisitor());
-  TimeSource& test_time_source = context.api().timeSource();
-
-  const std::string temp_path_cpu_allocated =
-      TestEnvironment::temporaryPath("container_cpu_allocated_unexpected_format");
-  AtomicFileUpdater file_updater_cpu_allocated(temp_path_cpu_allocated);
-  const std::string cpu_allocated_contents = R"EOF(notanumb3r
-)EOF";
-  file_updater_cpu_allocated.update(cpu_allocated_contents);
-
-  LinuxContainerCpuStatsReader container_stats_reader(test_time_source, temp_path_cpu_allocated);
-  CpuTimes envoy_container_stats = container_stats_reader.getCpuTimes();
-  EXPECT_FALSE(envoy_container_stats.is_valid);
-  EXPECT_EQ(envoy_container_stats.work_time, 0);
-  EXPECT_EQ(envoy_container_stats.total_time, 0);
-}
-
-TEST(LinuxContainerCpuStatsReader, UnexpectedFormatCpuTimesLine) {
-  Event::MockDispatcher dispatcher;
-  Api::ApiPtr api = Api::createApiForTest();
-  Server::MockOptions options;
-  Server::Configuration::ResourceMonitorFactoryContextImpl context(
-      dispatcher, options, *api, ProtobufMessage::getStrictValidationVisitor());
-  TimeSource& test_time_source = context.api().timeSource();
-
-  const std::string temp_path_cpu_allocated =
-      TestEnvironment::temporaryPath("container_cpu_allocated");
-  AtomicFileUpdater file_updater_cpu_allocated(temp_path_cpu_allocated);
-  const std::string cpu_allocated_contents = R"EOF(1000101
-)EOF";
-  file_updater_cpu_allocated.update(cpu_allocated_contents);
-
+TEST_F(LinuxContainerCpuStatsReaderTest, CannotReadFileCpuTimes) {
+  TimeSource& test_time_source = timeSource();
   const std::string temp_path_cpu_times =
-      TestEnvironment::temporaryPath("container_cpu_times_unexpected_format");
-  AtomicFileUpdater file_update_cpu_times(temp_path_cpu_times);
-  const std::string cpu_times_contents = R"EOF(notanumb3r
-)EOF";
-  file_update_cpu_times.update(cpu_times_contents);
+      TestEnvironment::temporaryPath("container_cpu_times_not_exists");
 
-  LinuxContainerCpuStatsReader container_stats_reader(test_time_source, temp_path_cpu_allocated,
+  LinuxContainerCpuStatsReader container_stats_reader(test_time_source, cpuAllocatedPath(),
                                                       temp_path_cpu_times);
+  CpuTimes envoy_container_stats = container_stats_reader.getCpuTimes();
+  EXPECT_FALSE(envoy_container_stats.is_valid);
+  EXPECT_EQ(envoy_container_stats.work_time, 0);
+  EXPECT_EQ(envoy_container_stats.total_time, 0);
+}
+
+TEST_F(LinuxContainerCpuStatsReaderTest, UnexpectedFormatCpuAllocatedLine) {
+  TimeSource& test_time_source = timeSource();
+  setCpuAllocated("notanumb3r\n");
+
+  LinuxContainerCpuStatsReader container_stats_reader(test_time_source, cpuAllocatedPath(),
+                                                      cpuTimesPath());
+  CpuTimes envoy_container_stats = container_stats_reader.getCpuTimes();
+  EXPECT_FALSE(envoy_container_stats.is_valid);
+  EXPECT_EQ(envoy_container_stats.work_time, 0);
+  EXPECT_EQ(envoy_container_stats.total_time, 0);
+}
+
+TEST_F(LinuxContainerCpuStatsReaderTest, UnexpectedFormatCpuTimesLine) {
+  TimeSource& test_time_source = timeSource();
+  setCpuTimes("notanumb3r\n");
+
+  LinuxContainerCpuStatsReader container_stats_reader(test_time_source, cpuAllocatedPath(),
+                                                      cpuTimesPath());
   CpuTimes envoy_container_stats = container_stats_reader.getCpuTimes();
   EXPECT_FALSE(envoy_container_stats.is_valid);
   EXPECT_EQ(envoy_container_stats.work_time, 0);


### PR DESCRIPTION
Commit Message:

LinuxContainerCpuStatsReader that this test exercises takes two file paths (CPU allocation path and CPU times path) in constructor and both of those construcotr arguments have default values that point to some cgroup files that may or may not exist in the system where the test runs.

When you don't explicitly provide both paths in the constructor in test LinuxContainerCpuStatsReader will fallback to the default value and will try to read and parse the actual cgroup CPU times file /sys/fs/cgroup/cpu/cpuacct.usage and if the file does not exist it will fail.

That's exactly the problem with UnexpectedFormatCpuAllocatedLine test. When it creates LinuxContainerCpuStatsReader it explicitly provides a path to a test CPU allocation file, but does not provide a path to a test CPU times file (which is understandble give that the test does not care about the content of the CPU times file).

However the implementation of LinuxContainerCpuStatsReader::getCpuTimes is such that if it fails to read any of those files the functio returns a failure.

This makes this test somewhat non-deterministic in the sense that the lines of code that this test exercises depend on the environment and whether /sys/fs/cgroup/cpu/cpuacct.usage exists.

This issue affected Envoy coverage tests when we tried to migrate them from Google RBE backend to EngFlow. The same test worked fine and produced 100% coverage for LinuxContainerCpuStatsReader on Google RBE backends, but when we migrated to EngFlow the coverage changed and triggered a coverage test failure.

This PR refactors the test a bit to make sure that both CPU allocation CPU times files are always available and valid, unless the test explicitly overrides it.

I would also argue that this change makes the tests a bit easier to read as it removes the irrelvant boilerplate to a fixture constructor.

Additional Description:

I'm doing this change to allow us to finish migration of the coverage tests to EngFLow. https://github.com/envoyproxy/envoy/pull/39030 provides some context for why this migration is needed and https://github.com/envoyproxy/envoy/issues/39248 is a tracking bug.

Risk Level: low
Testing: manually running coverage tests and confirming that it fixes the issue.
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a

+cc @phlax 