### PR TITLE
jwt_authn: Fix jwt_authn stat_prefix

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -36,6 +36,9 @@ minor_behavior_changes:
 
 bug_fixes:
 # *Changes expected to improve the state of the world and are unlikely to have negative effects*
+- area: jwt_authn
+  change: |
+    Fixed :ref:`stat_prefix <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtAuthentication.stat_prefix>` not being applied.
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/source/extensions/filters/http/jwt_authn/filter_config.cc
+++ b/source/extensions/filters/http/jwt_authn/filter_config.cc
@@ -17,7 +17,7 @@ FilterConfigImpl::FilterConfigImpl(
     envoy::extensions::filters::http::jwt_authn::v3::JwtAuthentication proto_config,
     const std::string& stats_prefix, Server::Configuration::FactoryContext& context)
     : proto_config_(std::move(proto_config)),
-      stats_(generateStats(stats_prefix, proto_config.stat_prefix(), context.scope())),
+      stats_(generateStats(stats_prefix, proto_config_.stat_prefix(), context.scope())),
       cm_(context.serverFactoryContext().clusterManager()),
       time_source_(context.serverFactoryContext().mainThreadDispatcher().timeSource()) {
 

--- a/test/extensions/filters/http/jwt_authn/filter_integration_test.cc
+++ b/test/extensions/filters/http/jwt_authn/filter_integration_test.cc
@@ -615,7 +615,7 @@ TEST_P(RemoteJwksIntegrationTest, WithGoodTokenAsyncFetchFast) {
   // the first request will trigger a second jwks fetch, this is not expected, test will fail.
   // To avoid such race condition, before making the first request, wait for the first
   // fetch stats to be updated.
-  test_server_->waitForCounterGe("http.config_test.jwt_authn.jwks_fetch_success", 1);
+  test_server_->waitForCounterGe("http.config_test.jwt_authn.fooprefix.jwks_fetch_success", 1);
 
   codec_client_ = makeHttpConnection(lookupPort("http"));
 

--- a/test/extensions/filters/http/jwt_authn/filter_test.cc
+++ b/test/extensions/filters/http/jwt_authn/filter_test.cc
@@ -27,7 +27,8 @@ public:
 };
 
 JwtAuthnFilterStats generateMockStats(Stats::Scope& scope) {
-  return {ALL_JWT_AUTHN_FILTER_STATS(POOL_COUNTER_PREFIX(scope, ""))};
+  const std::string final_prefix = absl::StrCat("test.", "jwt_authn.", "foo");
+  return {ALL_JWT_AUTHN_FILTER_STATS(POOL_COUNTER_PREFIX(scope, final_prefix))};
 }
 
 class MockFilterConfig : public FilterConfig {
@@ -92,7 +93,7 @@ TEST_F(FilterTest, InlineOK) {
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(headers, false));
   Http::MetadataMap metadata_map{{"metadata", "metadata"}};
   EXPECT_EQ(Http::FilterMetadataStatus::Continue, filter_->decodeMetadata(metadata_map));
-  EXPECT_EQ(1U, mock_config_->stats().allowed_.value());
+  EXPECT_EQ(1U, mock_config_->stats_store_.counter("test.jwt_authn.foo.allowed").value());
 
   Buffer::OwnedImpl data("");
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(data, false));

--- a/test/extensions/filters/http/jwt_authn/test_common.h
+++ b/test/extensions/filters/http/jwt_authn/test_common.h
@@ -109,7 +109,7 @@ providers:
         cluster: pubkey_cluster
         timeout:
           seconds: 5
-
+stat_prefix: "fooprefix"
 )";
 
 // Provider config with various subject constraints
@@ -143,6 +143,7 @@ providers:
         cluster: pubkey_cluster
         timeout:
           seconds: 5
+stat_prefix: "fooprefix"
 )";
 
 // A good config.
@@ -184,6 +185,7 @@ rules:
   requires:
     provider_name: "example_provider"
 bypass_cors_preflight: true
+stat_prefix: "fooprefix"
 )";
 
 // Config with claim_to_headers and clear_route_cache.
@@ -213,6 +215,7 @@ rules:
   requires:
     provider_name: "example_provider"
 bypass_cors_preflight: true
+stat_prefix: "fooprefix"
 )";
 
 // Config with payload_in_metadata and clear_route_cache.
@@ -240,6 +243,7 @@ rules:
   requires:
     provider_name: "example_provider"
 bypass_cors_preflight: true
+stat_prefix: "fooprefix"
 )";
 
 const char ExampleConfigWithRegEx[] = R"(
@@ -270,6 +274,7 @@ rules:
   requires:
     provider_name: "example_provider"
 bypass_cors_preflight: true
+stat_prefix: "fooprefix"
 )";
 
 // The name of provider for above config.


### PR DESCRIPTION
https://github.com/envoyproxy/envoy/pull/38977 added support for jwt_authn stat prefix, but it didn't actually work. This fixes that.

Commit Message: Fixes jwt_authn stat prefix
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes: Fixed :ref:`stat_prefix <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtAuthentication.stat_prefix>` not being applied.
Platform Specific Features:
