### PR TITLE
[mobile]Add envoy mobile config to set number of threads for getaddrinfo

### DIFF
--- a/mobile/library/cc/engine_builder.cc
+++ b/mobile/library/cc/engine_builder.cc
@@ -135,6 +135,11 @@ EngineBuilder& EngineBuilder::setDnsNumRetries(uint32_t dns_num_retries) {
   return *this;
 }
 
+EngineBuilder& EngineBuilder::setGetaddrinfoNumThreads(uint32_t num_threads) {
+  getaddrinfo_num_threads_ = num_threads;
+  return *this;
+}
+
 EngineBuilder& EngineBuilder::addDnsPreresolveHostnames(const std::vector<std::string>& hostnames) {
   // Add a default port of 443 for all hosts. We'll eventually change this API so it takes a single
   // {host, pair} and it can be called multiple times.
@@ -532,6 +537,7 @@ std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> EngineBuilder::generate
     if (dns_num_retries_.has_value()) {
       resolver_config.mutable_num_retries()->set_value(*dns_num_retries_);
     }
+    resolver_config.mutable_num_resolver_threads()->set_value(getaddrinfo_num_threads_);
     dns_cache_config->mutable_typed_dns_resolver_config()->set_name(
         "envoy.network.dns_resolver.getaddrinfo");
     dns_cache_config->mutable_typed_dns_resolver_config()->mutable_typed_config()->PackFrom(

--- a/mobile/library/cc/engine_builder.h
+++ b/mobile/library/cc/engine_builder.h
@@ -44,6 +44,7 @@ public:
   EngineBuilder& setDisableDnsRefreshOnNetworkChange(bool disable_dns_refresh_on_network_change);
   EngineBuilder& addDnsMinRefreshSeconds(int dns_min_refresh_seconds);
   EngineBuilder& setDnsNumRetries(uint32_t dns_num_retries);
+  EngineBuilder& setGetaddrinfoNumThreads(uint32_t num_threads);
   EngineBuilder& addMaxConnectionsPerHost(int max_connections_per_host);
   EngineBuilder& addH2ConnectionKeepaliveIdleIntervalMilliseconds(
       int h2_connection_keepalive_idle_interval_milliseconds);
@@ -157,6 +158,7 @@ private:
   bool disable_dns_refresh_on_failure_{false};
   bool disable_dns_refresh_on_network_change_{false};
   absl::optional<uint32_t> dns_num_retries_ = 3;
+  uint32_t getaddrinfo_num_threads_ = 1;
   int h2_connection_keepalive_idle_interval_milliseconds_ = 100000000;
   int h2_connection_keepalive_timeout_seconds_ = 15;
   std::string app_version_ = "unspecified";


### PR DESCRIPTION
Commit Message: Add envoy mobile config to set number of threads for getaddrinfo
Additional Description: n/a
Risk Level: low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: mobile only
