### PR TITLE
vscode: add include_headers to tasks

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -24,13 +24,13 @@
     {
       "label": "Refresh Compilation Database",
       "type": "shell",
-      "command": "ENVOY_GEN_COMPDB_OPTIONS=\"--vscode\" ./ci/do_ci.sh refresh_compdb",
+      "command": "ENVOY_GEN_COMPDB_OPTIONS=\"--vscode --include_headers\" ./ci/do_ci.sh refresh_compdb",
       "problemMatcher": []
     },
     {
       "label": "Refresh Compilation Database Exclude Contrib",
       "type": "shell",
-      "command": "ENVOY_GEN_COMPDB_OPTIONS=\"--vscode --exclude_contrib\" ./ci/do_ci.sh refresh_compdb",
+      "command": "ENVOY_GEN_COMPDB_OPTIONS=\"--vscode --include_headers --exclude_contrib\" ./ci/do_ci.sh refresh_compdb",
       "problemMatcher": []
     },
     {


### PR DESCRIPTION
Commit Message: vscode: add include_headers to tasks
Additional Description: clangd with vscode devcontainer will often fail to infer the correct compile commands for a file.
This patch enables header file inclusion to the compile_commands.json which prevents the incorrect inference.
```
I[11:35:55.381] ASTWorker building file /workspaces/envoy/source/extensions/common/aws/credential_providers/assume_role_credentials_provider.h version 1 with command inferred from source/extensions/common/aws/credential_providers/config_credentials_provider.cc
...
I[11:36:15.439] ASTWorker building file /workspaces/envoy/source/extensions/common/aws/credential_providers/assume_role_credentials_provider.cc version 1 with command inferred from source/extensions/common/aws/credential_providers/config_credentials_provider.cc
```
Risk Level: Low
Testing:
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
