### PR TITLE
Explicitly convert absl::string_view to std::string

### DIFF
--- a/source/extensions/filters/http/grpc_json_reverse_transcoder/filter_config.cc
+++ b/source/extensions/filters/http/grpc_json_reverse_transcoder/filter_config.cc
@@ -112,7 +112,7 @@ GrpcJsonReverseTranscoderConfig::ChangeBodyFieldName(absl::string_view message_n
   if (field_descriptor == nullptr) {
     return absl::InvalidArgumentError(absl::StrCat("No field named: ", body_field));
   }
-  return field_descriptor->json_name();
+  return std::string(field_descriptor->json_name());
 }
 
 bool GrpcJsonReverseTranscoderConfig::IsRequestNestedHttpBody(


### PR DESCRIPTION
Commit Message: Explicitly convert absl::string_view to std::string
Additional Description: Some of the compilers perform this conversion implicitly but some don't and throw build errors. So, explicitly converting absl::string_view to std::string.
Risk Level: low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
