### PR TITLE
Link test binaries statically when run coverage

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -245,7 +245,6 @@ build:coverage --action_env=GCOV=llvm-profdata
 build:coverage --copt=-DNDEBUG
 # 1.5x original timeout + 300s for trace merger in all categories
 build:coverage --test_timeout=390,750,1500,5700
-build:coverage --define=dynamic_link_tests=true
 build:coverage --define=ENVOY_CONFIG_COVERAGE=1
 build:coverage --cxxopt="-DENVOY_CONFIG_COVERAGE=1"
 build:coverage --test_env=HEAPCHECK=
@@ -268,9 +267,11 @@ build:coverage --test_env=ENVOY_IP_TEST_VERSIONS=v4only
 build:test-coverage --test_arg="-l trace"
 build:test-coverage --test_arg="--log-path /dev/null"
 build:test-coverage --test_tag_filters=-nocoverage,-fuzz_target
+build:test-coverage --define=dynamic_link_tests=false
 build:fuzz-coverage --config=plain-fuzzer
 build:fuzz-coverage --run_under=@envoy//bazel/coverage:fuzz_coverage_wrapper.sh
 build:fuzz-coverage --test_tag_filters=-nocoverage
+build:fuzz-coverage --define=dynamic_link_tests=true
 
 build:cache-local --remote_cache=grpc://localhost:9092
 


### PR DESCRIPTION
Commit Message:

Static linking helps to work around the issue with LLVM/Clang source-based coverage (see
https://github.com/llvm/llvm-project/issues/32849).

This PR switches to static linking for just test coverage and does not do the same for fuzz coverage. That's because Envoy CI is hitting some resource constraints when building fuzz targets with coverage instrumentation.

We will fix that by striping the fuzz targets of some unncessary dependencies and switching to EngFlow backend for coverage builds and tests, but that will require addressing a couple of hard to understand issues, so, for now, I'm just switching the coverage tests to static linking and will follow up with the fuzz tests later once we addressed all the blockers and switched to EngFlow backend for coverage.

Additional Description:

https://github.com/envoyproxy/envoy/pull/39030 provides some context for EngFlow migration and https://github.com/envoyproxy/envoy/issues/39248 is a tracking bug.

Risk Level: low
Testing: regular Envoy CI
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a

+cc @phlax @yanavlasov 