### PR TITLE
Fixes to support compiler clang 20.1.*

### DIFF
--- a/source/common/formatter/substitution_formatter.h
+++ b/source/common/formatter/substitution_formatter.h
@@ -186,9 +186,9 @@ private:
   };
 
   using StructFormatMapVisitor = StructFormatMapVisitorHelper<
-      const std::function<ProtobufWkt::Value(const std::vector<FormatterProviderPtr>&)>,
-      const std::function<ProtobufWkt::Value(const StructFormatter::StructFormatMapWrapper&)>,
-      const std::function<ProtobufWkt::Value(const StructFormatter::StructFormatListWrapper&)>>;
+      std::function<ProtobufWkt::Value(const std::vector<FormatterProviderPtr>&)>,
+      std::function<ProtobufWkt::Value(const StructFormatter::StructFormatMapWrapper&)>,
+      std::function<ProtobufWkt::Value(const StructFormatter::StructFormatListWrapper&)>>;
 
   // Methods for building the format map.
   class FormatBuilder {

--- a/source/extensions/access_loggers/open_telemetry/substitution_formatter.h
+++ b/source/extensions/access_loggers/open_telemetry/substitution_formatter.h
@@ -53,11 +53,11 @@ private:
   };
 
   using OpenTelemetryFormatMapVisitor = OpenTelemetryFormatMapVisitorHelper<
-      const std::function<::opentelemetry::proto::common::v1::AnyValue(
+      std::function<::opentelemetry::proto::common::v1::AnyValue(
           const std::vector<Formatter::FormatterProviderPtr>&)>,
-      const std::function<::opentelemetry::proto::common::v1::AnyValue(
+      std::function<::opentelemetry::proto::common::v1::AnyValue(
           const OpenTelemetryFormatter::OpenTelemetryFormatMapWrapper&)>,
-      const std::function<::opentelemetry::proto::common::v1::AnyValue(
+      std::function<::opentelemetry::proto::common::v1::AnyValue(
           const OpenTelemetryFormatter::OpenTelemetryFormatListWrapper&)>>;
 
   // Methods for building the format map.


### PR DESCRIPTION
Commit Message:
With clang 20.1.* the following code is not compiling due to a `-Wignored-qualifiers` getting promoted into an error. This was changed in [clang 20.1.0](https://releases.llvm.org/20.1.0/tools/clang/docs/ReleaseNotes.html#id242) in the commit https://github.com/llvm/llvm-project/commit/cac67d39362b23466708e464c00ce84abe16bece

See also a simplified example here https://godbolt.org/z/3eWbhsqWM

Additional Description:
Risk Level: Pretty small, based on the LLVM commit the `const` was already ignored.
Testing: Unit
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A