### PR TITLE
test: fix test to pass if gRPC returns UNKNOWN instead of an invalid code

### DIFF
--- a/test/common/grpc/grpc_client_integration_test_harness.h
+++ b/test/common/grpc/grpc_client_integration_test_harness.h
@@ -163,11 +163,9 @@ public:
     if (grpc_status == Status::WellKnownGrpcStatus::InvalidCode) {
       EXPECT_CALL(*this, onRemoteClose(_, _)).WillExitIfNeeded();
     } else if (grpc_status > Status::WellKnownGrpcStatus::MaximumKnown) {
-      EXPECT_CALL(*this, onRemoteClose(
-                            testing::AnyOf(
-                                Status::WellKnownGrpcStatus::InvalidCode,
-                                Status::WellKnownGrpcStatus::Unknown),
-                            _))
+      EXPECT_CALL(*this, onRemoteClose(testing::AnyOf(Status::WellKnownGrpcStatus::InvalidCode,
+                                                      Status::WellKnownGrpcStatus::Unknown),
+                                       _))
           .WillExitIfNeeded();
     } else {
       EXPECT_CALL(*this, onRemoteClose(grpc_status, _)).WillExitIfNeeded();

--- a/test/common/grpc/grpc_client_integration_test_harness.h
+++ b/test/common/grpc/grpc_client_integration_test_harness.h
@@ -163,7 +163,11 @@ public:
     if (grpc_status == Status::WellKnownGrpcStatus::InvalidCode) {
       EXPECT_CALL(*this, onRemoteClose(_, _)).WillExitIfNeeded();
     } else if (grpc_status > Status::WellKnownGrpcStatus::MaximumKnown) {
-      EXPECT_CALL(*this, onRemoteClose(Status::WellKnownGrpcStatus::InvalidCode, _))
+      EXPECT_CALL(*this, onRemoteClose(
+                            testing::AnyOf(
+                                Status::WellKnownGrpcStatus::InvalidCode,
+                                Status::WellKnownGrpcStatus::Unknown),
+                            _))
           .WillExitIfNeeded();
     } else {
       EXPECT_CALL(*this, onRemoteClose(grpc_status, _)).WillExitIfNeeded();


### PR DESCRIPTION
Commit Message: test: fix test to pass if gRPC returns UNKNOWN instead of an invalid code
Additional Description: As per the [gRPC status codes doc](https://github.com/grpc/grpc/blob/master/doc/statuscodes.md), gRPC implementations may either pass through invalid status codes or convert them to UNKNOWN.  Currently, gRPC C++ passes them through, but in the future we will instead convert them to UNKNOWN.  This change fixes Envoy's test to pass with either behavior, so that when this change happens in gRPC, it will not break Envoy.
Risk Level: Low
Testing: CI
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A