### PR TITLE
Add `ZoneAwareLoadBalancerBase::setLocalityWeightedBalancing` to enable locality aware host source selection.

### DIFF
--- a/source/extensions/load_balancing_policies/client_side_weighted_round_robin/client_side_weighted_round_robin_lb.cc
+++ b/source/extensions/load_balancing_policies/client_side_weighted_round_robin/client_side_weighted_round_robin_lb.cc
@@ -54,6 +54,8 @@ ClientSideWeightedRoundRobinLoadBalancer::WorkerLocalLb::WorkerLocalLb(
     : RoundRobinLoadBalancer(priority_set, local_priority_set, stats, runtime, random,
                              common_config,
                              /*round_robin_config=*/std::nullopt, time_source) {
+  // Explicitly enable locality weighted balancing.
+  setLocalityWeightedBalancing(true);
   if (tls_shim.has_value()) {
     apply_weights_cb_handle_ = tls_shim->apply_weights_cb_helper_.add([this](uint32_t priority) {
       refresh(priority);

--- a/source/extensions/load_balancing_policies/common/load_balancer_impl.h
+++ b/source/extensions/load_balancing_policies/common/load_balancer_impl.h
@@ -323,6 +323,13 @@ protected:
    */
   const HostVector& hostSourceToHosts(HostsSource hosts_source) const;
 
+  /**
+   * Explicitly enable locality weighted balancing.
+   */
+  void setLocalityWeightedBalancing(bool locality_weighted_balancing) {
+    locality_weighted_balancing_ = locality_weighted_balancing;
+  }
+
 private:
   enum class LocalityRoutingState {
     // Locality based routing is off.
@@ -431,7 +438,7 @@ private:
   const bool fail_traffic_on_panic_ : 1;
 
   // If locality weight aware routing is enabled.
-  const bool locality_weighted_balancing_ : 1;
+  bool locality_weighted_balancing_ : 1;
 
   friend class TestZoneAwareLoadBalancer;
 };


### PR DESCRIPTION
…le locality aware host source selection.

This makes `ClientSideWeightedRoundRobin` lb policy use the locality weights specified by EDS.

Testing: `bazel test //test/extensions/load_balancing_policies/client_side_weighted_round_robin:integration_test`

#39362 
