### PR TITLE
OAuth2: RP initiated logout

### DIFF
--- a/api/envoy/extensions/filters/http/oauth2/v3/oauth.proto
+++ b/api/envoy/extensions/filters/http/oauth2/v3/oauth.proto
@@ -152,7 +152,6 @@ message OAuth2Config {
   // For more information, see https://openid.net/specs/openid-connect-rpinitiated-1_0.html
   //
   // If configured, the OAuth2 filter will redirect users to this endpoint when they access the signout_path.
-  // [#not-implemented-hide:]
   string end_session_endpoint = 23;
 
   // Credentials used for OAuth.

--- a/api/envoy/extensions/filters/http/oauth2/v3/oauth.proto
+++ b/api/envoy/extensions/filters/http/oauth2/v3/oauth.proto
@@ -126,7 +126,7 @@ message OAuth2Credentials {
 
 // OAuth config
 //
-// [#next-free-field: 23]
+// [#next-free-field: 24]
 message OAuth2Config {
   enum AuthType {
     // The ``client_id`` and ``client_secret`` will be sent in the URL encoded request body.
@@ -145,6 +145,15 @@ message OAuth2Config {
 
   // The endpoint redirect to for authorization in response to unauthorized requests.
   string authorization_endpoint = 2 [(validate.rules).string = {min_len: 1}];
+
+  // The endpoint at the authorization server to request the user be logged out of the Authorization server.
+  // This field is optional and should be set only if openid is in the auth_scopes and the authorization server
+  // supports the OpenID Connect RP-Initiated Logout specification.
+  // For more information, see https://openid.net/specs/openid-connect-rpinitiated-1_0.html
+  //
+  // If configured, the OAuth2 filter will redirect users to this endpoint when they access the signout_path.
+  // [#not-implemented-hide:]
+  string end_session_endpoint = 23;
 
   // Credentials used for OAuth.
   OAuth2Credentials credentials = 3 [(validate.rules).message = {required: true}];

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -159,7 +159,10 @@ new_features:
     ``local_ratelimit`` will return ``x-ratelimit-reset`` header when the rate limit is exceeded.
 - area: oauth2
   change: |
-    Added ``end_session_endpoint`` to the oauth2 filter to support OIDC RP initiated logout. This field is only used when
-    ``openid`` is in the ``auth_scopes`` field. If configured, the OAuth2 filter will redirect users to this endpoint when
-    they access the signout_path. This allows users to be logged out of the Authorization server.
+    Added :ref:`end_session_endpoint <envoy_v3_api_field_extensions.filters.http.oauth2.v3.OAuth2Config.end_session_endpoint>`
+    to the oauth2 filter to support OIDC RP initiated logout. This field is only used when
+    ``openid`` is in the :ref:`auth_scopes <envoy_v3_api_field_extensions.filters.http.oauth2.v3.OAuth2Config.auth_scopes>` field.
+    If configured, the OAuth2 filter will redirect users to this endpoint when they access the
+    :ref:`signout_path <envoy_v3_api_field_extensions.filters.http.oauth2.v3.OAuth2Config.signout_path>`. This allows users to
+    be logged out of the Authorization server.
 deprecated:

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -160,6 +160,6 @@ new_features:
 - area: oauth2
   change: |
     Added ``end_session_endpoint`` to the oauth2 filter to support OIDC RP initiated logout. This field is only used when
-    `openid` is in the ``auth_scopes`` field. If configured, the OAuth2 filter will redirect users to this endpoint when
+    ``openid`` is in the ``auth_scopes`` field. If configured, the OAuth2 filter will redirect users to this endpoint when
     they access the signout_path. This allows users to be logged out of the Authorization server.
 deprecated:

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -157,5 +157,9 @@ new_features:
 - area: local_ratelimit
   change: |
     ``local_ratelimit`` will return ``x-ratelimit-reset`` header when the rate limit is exceeded.
-
+- area: oauth2
+  change: |
+    Added ``end_session_endpoint`` to the oauth2 filter to support OIDC RP initiated logout. This field is only used when
+    `openid` is in the ``auth_scopes`` field. If configured, the OAuth2 filter will redirect users to this endpoint when
+    they access the signout_path. This allows users to be logged out of the Authorization server.
 deprecated:

--- a/source/extensions/filters/http/oauth2/filter.h
+++ b/source/extensions/filters/http/oauth2/filter.h
@@ -144,6 +144,7 @@ public:
   }
   const HttpUri& oauthTokenEndpoint() const { return oauth_token_endpoint_; }
   const Http::Utility::Url& authorizationEndpointUrl() const { return authorization_endpoint_url_; }
+  const std::string& endSessionEndpoint() const { return end_session_endpoint_; }
   const Http::Utility::QueryParamsMulti& authorizationQueryParams() const {
     return authorization_query_params_;
   }
@@ -205,6 +206,7 @@ private:
   // Owns the data exposed by authorization_endpoint_url_.
   const std::string authorization_endpoint_;
   Http::Utility::Url authorization_endpoint_url_;
+  const std::string end_session_endpoint_;
   const Http::Utility::QueryParamsMulti authorization_query_params_;
   const std::string client_id_;
   const std::string redirect_uri_;

--- a/test/extensions/filters/http/oauth2/config_test.cc
+++ b/test/extensions/filters/http/oauth2/config_test.cc
@@ -422,6 +422,88 @@ config:
   EXPECT_TRUE(result.ok());
 }
 
+TEST(ConfigTest, EndSessionEndpointWithOpenId) {
+  const std::string yaml = R"EOF(
+    config:
+      token_endpoint:
+        cluster: foo
+        uri: oauth.com/token
+        timeout: 3s
+      credentials:
+        client_id: "secret"
+        token_secret:
+          name: token
+        hmac_secret:
+          name: hmac
+      authorization_endpoint: https://oauth.com/oauth/authorize/
+      end_session_endpoint: https://oauth.com/oauth/logout
+      auth_scopes: openid
+      redirect_uri: "%REQ(x-forwarded-proto)%://%REQ(:authority)%/callback"
+      redirect_path_matcher:
+        path:
+          exact: /callback
+      signout_path:
+        path:
+          exact: /signout
+      )EOF";
+
+  OAuth2Config factory;
+  ProtobufTypes::MessagePtr proto_config = factory.createEmptyConfigProto();
+  TestUtility::loadFromYaml(yaml, *proto_config);
+  NiceMock<Server::Configuration::MockFactoryContext> context;
+  context.server_factory_context_.cluster_manager_.initializeClusters({"foo"}, {});
+
+  auto& secret_manager =
+      context.server_factory_context_.cluster_manager_.cluster_manager_factory_.secretManager();
+  ON_CALL(secret_manager, findStaticGenericSecretProvider(_))
+      .WillByDefault(Return(std::make_shared<Secret::GenericSecretConfigProviderImpl>(
+          envoy::extensions::transport_sockets::tls::v3::GenericSecret())));
+
+  const auto result = factory.createFilterFactoryFromProto(*proto_config, "stats", context);
+  EXPECT_TRUE(result.ok());
+}
+
+TEST(ConfigTest, EndSessionEndpointWithoutOpenId) {
+  const std::string yaml = R"EOF(
+    config:
+      token_endpoint:
+        cluster: foo
+        uri: oauth.com/token
+        timeout: 3s
+      credentials:
+        client_id: "secret"
+        token_secret:
+          name: token
+        hmac_secret:
+          name: hmac
+      authorization_endpoint: https://oauth.com/oauth/authorize/
+      end_session_endpoint: https://oauth.com/oauth/logout
+      redirect_uri: "%REQ(x-forwarded-proto)%://%REQ(:authority)%/callback"
+      redirect_path_matcher:
+        path:
+          exact: /callback
+      signout_path:
+        path:
+          exact: /signout
+      )EOF";
+
+  OAuth2Config factory;
+  ProtobufTypes::MessagePtr proto_config = factory.createEmptyConfigProto();
+  TestUtility::loadFromYaml(yaml, *proto_config);
+  NiceMock<Server::Configuration::MockFactoryContext> context;
+  context.server_factory_context_.cluster_manager_.initializeClusters({"foo"}, {});
+
+  auto& secret_manager =
+      context.server_factory_context_.cluster_manager_.cluster_manager_factory_.secretManager();
+  ON_CALL(secret_manager, findStaticGenericSecretProvider(_))
+      .WillByDefault(Return(std::make_shared<Secret::GenericSecretConfigProviderImpl>(
+          envoy::extensions::transport_sockets::tls::v3::GenericSecret())));
+
+  EXPECT_THROW_WITH_MESSAGE(
+      factory.createFilterFactoryFromProto(*proto_config, "stats", context).value(), EnvoyException,
+      "OAuth2 filter: end session endpoint is only supported for OpenID Connect.");
+}
+
 } // namespace Oauth2
 } // namespace HttpFilters
 } // namespace Extensions

--- a/test/extensions/filters/http/oauth2/config_test.cc
+++ b/test/extensions/filters/http/oauth2/config_test.cc
@@ -453,8 +453,9 @@ TEST(ConfigTest, EndSessionEndpointWithOpenId) {
   NiceMock<Server::Configuration::MockFactoryContext> context;
   context.server_factory_context_.cluster_manager_.initializeClusters({"foo"}, {});
 
-  auto& secret_manager =
-      context.server_factory_context_.cluster_manager_.cluster_manager_factory_.secretManager();
+  NiceMock<Secret::MockSecretManager> secret_manager;
+  ON_CALL(context.server_factory_context_, secretManager())
+      .WillByDefault(ReturnRef(secret_manager));
   ON_CALL(secret_manager, findStaticGenericSecretProvider(_))
       .WillByDefault(Return(std::make_shared<Secret::GenericSecretConfigProviderImpl>(
           envoy::extensions::transport_sockets::tls::v3::GenericSecret())));
@@ -493,8 +494,9 @@ TEST(ConfigTest, EndSessionEndpointWithoutOpenId) {
   NiceMock<Server::Configuration::MockFactoryContext> context;
   context.server_factory_context_.cluster_manager_.initializeClusters({"foo"}, {});
 
-  auto& secret_manager =
-      context.server_factory_context_.cluster_manager_.cluster_manager_factory_.secretManager();
+  NiceMock<Secret::MockSecretManager> secret_manager;
+  ON_CALL(context.server_factory_context_, secretManager())
+      .WillByDefault(ReturnRef(secret_manager));
   ON_CALL(secret_manager, findStaticGenericSecretProvider(_))
       .WillByDefault(Return(std::make_shared<Secret::GenericSecretConfigProviderImpl>(
           envoy::extensions::transport_sockets::tls::v3::GenericSecret())));

--- a/tools/spelling/spelling_dictionary.txt
+++ b/tools/spelling/spelling_dictionary.txt
@@ -1070,6 +1070,7 @@ oneof
 oneway
 oob
 opcode
+openid
 openssl
 opentracing
 optimizations
@@ -1305,6 +1306,7 @@ sigactions
 sigaltstack
 siginfo
 signalstack
+signout
 sigv
 sigv4
 sigv4a


### PR DESCRIPTION
Commit Message: Add support for [OpenID Connect RP-Initiated Logout](https://openid.net/specs/openid-connect-rpinitiated-1_0.html) to the OAuth2 filter. This allows Relying Party(Envoy OAuth2 filter, in our case) to request that an OpenID Provider log out the End-User.
Additional Description:
Risk Level: low
Testing: unit test, also verified manually with keycloak.
Docs Changes: yes
Release Notes: yes
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #39373]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
