### PR TITLE
fix: Add Sec-WebSocket-Key and Sec-WebSocket-Version headers when proxying WebSocket from HTTP/2 to HTTP/1

### DIFF
--- a/envoy/http/header_map.h
+++ b/envoy/http/header_map.h
@@ -252,6 +252,8 @@ private:
   HEADER_FUNC(ProxyConnection)                                                                     \
   HEADER_FUNC(ProxyStatus)                                                                         \
   HEADER_FUNC(RequestId)                                                                           \
+  HEADER_FUNC(SecWebSocketKey)                                                                     \
+  HEADER_FUNC(SecWebSocketVersion)                                                                 \
   HEADER_FUNC(TransferEncoding)                                                                    \
   HEADER_FUNC(Upgrade)                                                                             \
   HEADER_FUNC(Via)

--- a/source/common/http/BUILD
+++ b/source/common/http/BUILD
@@ -535,6 +535,7 @@ envoy_cc_library(
         "//envoy/http:query_params_interface",
         "//source/common/buffer:buffer_lib",
         "//source/common/common:assert_lib",
+        "//source/common/common:base64_lib",
         "//source/common/common:empty_string",
         "//source/common/common:enum_to_int",
         "//source/common/common:utility_lib",

--- a/source/common/http/headers.h
+++ b/source/common/http/headers.h
@@ -228,6 +228,8 @@ public:
   const LowerCaseString Range{"range"};
   const LowerCaseString RequestId{"x-request-id"};
   const LowerCaseString Scheme{":scheme"};
+  const LowerCaseString SecWebSocketKey{"sec-websocket-key"};
+  const LowerCaseString SecWebSocketVersion{"sec-websocket-version"};
   const LowerCaseString Server{"server"};
   const LowerCaseString SetCookie{"set-cookie"};
   const LowerCaseString Status{":status"};

--- a/source/common/http/utility.h
+++ b/source/common/http/utility.h
@@ -719,6 +719,13 @@ bool schemeIsHttps(const absl::string_view scheme);
 std::string newUri(::Envoy::OptRef<const RedirectConfig> redirect_config,
                    const Http::RequestHeaderMap& headers);
 
+/**
+  * Generates a Sec-WebSocket-Key as per the WebSocket protocol.
+  * The key is a randomly generated 16-byte value encoded in Base64.
+  * @return std::string A Base64-encoded Sec-WebSocket-Key.
+  */
+std::string generateSecWebSocketKey();
+
 } // namespace Utility
 } // namespace Http
 } // namespace Envoy


### PR DESCRIPTION
Commit Message:
Implement addition of Sec-WebSocket-Key and Sec-WebSocket-Version headers when Envoy proxies WebSocket requests from HTTP/2 to HTTP/1.
Ensure proper WebSocket upgrade headers are added in compliance with RFC 6455 during HTTP/2 to HTTP/1 proxying.

**Note: Sec-WebSocket-Accept header verification is not yet implemented in this PR.**

Additional Description:
This PR implements the automatic addition of Sec-WebSocket-Key and Sec-WebSocket-Version request headers when the WebSocket protocol is requested by HTTP/2 client in Envoy and proxied to HTTP/1 backend to comply with RFC 6455 standard.
When the client uses HTTP/2 to make a WebSocket connection with Envoy, Envoy needs to ensure that the WebSocket handshake request contains Sec-WebSocket-Key and Sec-WebSocket-Version request headers when proxied to the HTTP/1 backend. According to RFC 6455, these headers must be included when the client initiates a WebSocket handshake.
Specific implementation:
Sec-WebSocket-Key processing: Envoy will generate a Sec-WebSocket-Key for each WebSocket request and add it to the request header.
Sec-WebSocket-Version processing: Envoy will set Sec-WebSocket-Version to 13, which is the version required by the current WebSocket protocol standard.

Risk Level: 
Medium: This functionality involves handling WebSocket headers, which can impact the correctness of WebSocket handshakes. Proper verification and handling are necessary.

Testing: 
Manual testing has been conducted in a local environment to verify that Sec-WebSocket-Key and Sec-WebSocket-Version headers are correctly added during the WebSocket handshake from HTTP/2 to HTTP/1.

Automated tests will be added in a follow-up PR to ensure comprehensive coverage and future maintainability.

Docs Changes: None
Release Notes: None
Platform Specific Features: None
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
