### PR TITLE
Add unit tests for CredentialsProviderChain::onCredentialUpdate

### DIFF
--- a/test/extensions/common/aws/credentials_provider_test.cc
+++ b/test/extensions/common/aws/credentials_provider_test.cc
@@ -8,7 +8,9 @@
 #include "gtest/gtest.h"
 
 using Envoy::Extensions::Common::Aws::MetadataFetcherPtr;
+using testing::MockFunction;
 using testing::Return;
+
 namespace Envoy {
 namespace Extensions {
 namespace Common {
@@ -188,6 +190,52 @@ TEST_F(AsyncCredentialHandlingTest, ChainCallbackCalledWhenCredentialsReturned) 
   // We now have credentials so sign should complete immediately
   auto result = signer->sign(*message_, false, "");
   ASSERT_TRUE(result.ok());
+}
+
+class ControlledCredentialsProvider : public CredentialsProvider {
+public:
+  ControlledCredentialsProvider(CredentialSubscriberCallbacks* cb) : cb_(cb) {}
+  ~ControlledCredentialsProvider() override {}
+
+  Credentials getCredentials() override {
+    Thread::LockGuard guard(mu_);
+    return credentials_;
+  }
+
+  bool credentialsPending() override {
+    Thread::LockGuard guard(mu_);
+    return pending_;
+  }
+
+  std::string providerName() override { return "Controlled Credentials Provider"; }
+
+  void refresh(const Credentials& credentials) {
+    {
+      Thread::LockGuard guard(mu_);
+      credentials_ = credentials;
+      pending_ = false;
+    }
+    if (cb_) {
+      cb_->onCredentialUpdate();
+    }
+  }
+
+private:
+  CredentialSubscriberCallbacks* cb_;
+  Thread::MutexBasicLockable mu_;
+  Credentials credentials_ ABSL_GUARDED_BY(mu_);
+  bool pending_ ABSL_GUARDED_BY(mu_) = true;
+};
+
+TEST_F(AsyncCredentialHandlingTest, SignerCallbacksCalledWhenCredentialsReturned) {
+  MockFunction<void()> signer_callback;
+  EXPECT_CALL(signer_callback, Call());
+
+  auto chain = std::make_shared<CredentialsProviderChain>();
+  auto provider = std::make_shared<ControlledCredentialsProvider>(chain.get());
+  chain->add(provider);
+  ASSERT_TRUE(chain->addCallbackIfChainCredentialsPending(signer_callback.AsStdFunction()));
+  provider->refresh(Credentials());
 }
 
 TEST_F(AsyncCredentialHandlingTest, SubscriptionsCleanedUp) {


### PR DESCRIPTION
Commit Message:

I'm trying to migrate Envoy CI coverage runs from the current Google RBE backends to EngFlow (there is a long story behind that, which I will not cover here).

When we tried to do it last time we hit an issue that on EngFlow for some part of the codebase coverage fell below the threshold and caused CI failures. AWS signer/credential providers code was among those.

Looking at the diff in coverage report before and after, I figured out that coverage for CredentialsProviderChain::onCredentialUpdate was missing.

So how come this code is covered when we use Google RBE backends and not covered when we use EngFlow? While it's hard to conclusively confirm what was the issue in that particular failed EngFlow coverage run, because coverage runs don't show test logs, I believe that the coverage for this part of the code is not completely deterministic and depends on timing.

Currently CredentialsProviderChain::onCredentialUpdate can only be exercised by
//test/extensions/filters/http/aws_request_signing:aws_request_signing_integration_test. However the test may pass without ever triggering
https://github.com/envoyproxy/envoy/blob/bef281049e4a914f573168e87618335fb7384a50/source/extensions/common/aws/credentials_provider.cc#L66-L79. That's because the test only waits for the metric that reports successful credential refreshes to be incremented, but that could happen before credentials have been pushed to all threads and onCredentialUpdate is called.

I could pretty consistently reproduce this by making the following changes:

1. add RELEASE_ASSERT(false, "got you!"); to https://github.com/envoyproxy/envoy/blob/bef281049e4a914f573168e87618335fb7384a50/source/extensions/common/aws/credentials_provider.cc#L65 to make sure that the tests that reach this part of the code fail
2. add absl::SleepFor(absl::Seconds(1)); to https://github.com/envoyproxy/envoy/blob/bef281049e4a914f573168e87618335fb7384a50/source/extensions/common/aws/metadata_credentials_provider_base.cc#L119 to introduce an artifical delay.

When I run //test/extensions/filters/http/aws_request_signing:aws_request_signing_integration_test with those changes I repeatedly got the test passing, which demonstrates that https://github.com/envoyproxy/envoy/blob/bef281049e4a914f573168e87618335fb7384a50/source/extensions/common/aws/credentials_provider.cc#L66-L79 was never exercised, so the RELEASE_ASSERT never triggered.

This PR adds a simple and deterministic unit test that exercies onCredentialUpdate. This will allow us to get deterministic coverage results.

NOTE: Alternatively, we could consider changing the code to only increment the metric after the credentials propagated to all the worker threads, but that change will be more invasive than a simple unit test.

Additional Description:

I'm doing this change to allow us to finish migration of the coverage tests to EngFLow. https://github.com/envoyproxy/envoy/pull/39030 provides some context for why this migration is needed and https://github.com/envoyproxy/envoy/issues/39248 is a tracking bug.

Risk Level: low
Testing: manually by running the test locally and confirming that it covers the relevant part of the code
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a

+cc @phlax 