### PR TITLE
mobile: Adds a runtime guard to drain connections on network change

### DIFF
--- a/mobile/library/common/network/connectivity_manager.h
+++ b/mobile/library/common/network/connectivity_manager.h
@@ -159,6 +159,7 @@ public:
    * @param configuration_key, key provided by this class representing the current configuration.
    * @param drain_connections, request that connections be drained after next DNS resolution.
    */
+  // TODO(abeyad): Remove the `drain_connections` parameter.
   virtual void refreshDns(envoy_netconf_t configuration_key, bool drain_connections) PURE;
 
   /**

--- a/mobile/test/java/org/chromium/net/CronetHttp3Test.java
+++ b/mobile/test/java/org/chromium/net/CronetHttp3Test.java
@@ -98,7 +98,7 @@ public class CronetHttp3Test {
     // Set up the Envoy engine.
     NativeCronvoyEngineBuilderImpl nativeCronetEngineBuilder =
         new NativeCronvoyEngineBuilderImpl(ApplicationProvider.getApplicationContext());
-    nativeCronetEngineBuilder.addRuntimeGuard("drain_pools_on_network_change",
+    nativeCronetEngineBuilder.addRuntimeGuard("drain_conn_pools_on_network_change",
                                               drainOnNetworkChange);
     nativeCronetEngineBuilder.addRuntimeGuard("reset_brokenness_on_nework_change",
                                               resetBrokennessOnNetworkChange);

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -141,7 +141,7 @@ FALSE_RUNTIME_GUARD(envoy_reloadable_features_dns_cache_set_ip_version_to_remove
 FALSE_RUNTIME_GUARD(envoy_reloadable_features_dns_cache_filter_unusable_ip_version);
 // TODO(alyssawilk): evaluate and make this a config knob or remove.
 FALSE_RUNTIME_GUARD(envoy_reloadable_features_reset_brokenness_on_nework_change);
-// TODO(alyssawilk): evaluate and make this a config knob or remove.
+// TODO(abeyad): Remove this; it's used in experiments but has no associated source code usage.
 FALSE_RUNTIME_GUARD(envoy_reloadable_features_drain_pools_on_network_change);
 // TODO(fredyw): evaluate and either make this a config knob or remove.
 FALSE_RUNTIME_GUARD(envoy_reloadable_features_quic_no_tcp_delay);
@@ -170,6 +170,8 @@ FALSE_RUNTIME_GUARD(envoy_reloadable_features_use_network_type_socket_option);
 FALSE_RUNTIME_GUARD(envoy_reloadable_features_quic_disable_client_early_data);
 
 FALSE_RUNTIME_GUARD(envoy_reloadable_features_ext_proc_graceful_grpc_close);
+// TODO(abeyad): Evaluate and either remove or make the default.
+FALSE_RUNTIME_GUARD(envoy_reloadable_features_drain_conn_pools_on_network_change);
 
 // Block of non-boolean flags. Use of int flags is deprecated. Do not add more.
 ABSL_FLAG(uint64_t, re2_max_program_size_error_level, 100, ""); // NOLINT


### PR DESCRIPTION
This commit adds a FALSE runtime guard
`drain_conn_pools_on_network_change` to drain network connections on network change events when DNS refresh on network change is disabled.

The preference is to *not* refresh DNS on network change but to drain the connections only.  Right now, refreshing DNS is the only way to drain connections too, but the goal of this commit is to decouple the two operations and experiment with both.