### PR TITLE
mobile: Remove support for the c-ares DNS resolver

### DIFF
--- a/mobile/envoy_build_config/BUILD
+++ b/mobile/envoy_build_config/BUILD
@@ -58,10 +58,7 @@ envoy_cc_library(
             "@envoy//source/common/listener_manager:connection_handler_lib",
         ],
         "@envoy",
-    ) + select({
-        "@envoy//bazel:apple": [],
-        "//conditions:default": ["@envoy//source/extensions/network/dns_resolver/cares:config"],
-    }),
+    ),
 )
 
 envoy_cc_library(

--- a/mobile/envoy_build_config/extension_registry.cc
+++ b/mobile/envoy_build_config/extension_registry.cc
@@ -54,10 +54,6 @@
 #include "library/common/extensions/listener_managers/api_listener_manager/api_listener_manager.h"
 #include "library/common/extensions/retry/options/network_configuration/config.h"
 
-#if !defined(__APPLE__)
-#include "source/extensions/network/dns_resolver/cares/dns_impl.h"
-#endif
-
 namespace Envoy {
 
 void ExtensionRegistry::registerFactories() {
@@ -150,9 +146,6 @@ void ExtensionRegistry::registerFactories() {
   // Envoy Mobile uses the GetAddrInfo resolver for DNS lookups on android by default.
   // This could be compiled out for iOS.
   Network::forceRegisterGetAddrInfoDnsResolverFactory();
-#if !defined(__APPLE__)
-  Network::forceRegisterCaresDnsResolverFactory();
-#endif
 
   Network::Address::forceRegisterIpResolver();
 

--- a/mobile/library/cc/engine_builder.h
+++ b/mobile/library/cc/engine_builder.h
@@ -125,10 +125,6 @@ public:
   // value will be used.
   EngineBuilder& respectSystemProxySettings(bool value, int refresh_interval_secs = 10);
   EngineBuilder& setIosNetworkServiceType(int ios_network_service_type);
-#else
-  // Only android supports c_ares
-  EngineBuilder& setUseCares(bool use_cares);
-  EngineBuilder& addCaresFallbackResolver(std::string host, int port);
 #endif
 
   // This is separated from build() for the sake of testability
@@ -185,10 +181,6 @@ private:
   bool enforce_trust_chain_verification_ = true;
   std::string upstream_tls_sni_;
   bool enable_http3_ = true;
-#if !defined(__APPLE__)
-  bool use_cares_ = false;
-  std::vector<std::pair<std::string, int>> cares_fallback_resolvers_;
-#endif
   std::string http3_connection_options_ = "";
   std::string http3_client_connection_options_ = "";
   std::vector<std::pair<std::string, int>> quic_hints_;

--- a/mobile/library/java/io/envoyproxy/envoymobile/engine/AndroidEngineImpl.java
+++ b/mobile/library/java/io/envoyproxy/envoymobile/engine/AndroidEngineImpl.java
@@ -47,10 +47,6 @@ public class AndroidEngineImpl implements EnvoyEngine {
 
   @Override
   public EnvoyStatus runWithConfig(EnvoyConfiguration envoyConfiguration, String logLevel) {
-    if (envoyConfiguration.useCares) {
-      JniLibrary.initCares(
-          (ConnectivityManager)context.getSystemService(Context.CONNECTIVITY_SERVICE));
-    }
     return envoyEngine.runWithConfig(envoyConfiguration, logLevel);
   }
 

--- a/mobile/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
+++ b/mobile/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
@@ -38,8 +38,6 @@ public class EnvoyConfiguration {
   public final int dnsNumRetries;
   public final boolean enableDrainPostDnsRefresh;
   public final boolean enableHttp3;
-  public final boolean useCares;
-  public final List<Pair<String, String>> caresFallbackResolvers;
   public final String http3ConnectionOptions;
   public final String http3ClientConnectionOptions;
   public final Map<String, String> quicHints;
@@ -95,7 +93,6 @@ public class EnvoyConfiguration {
    *     DNS refresh.
    * @param enableHttp3                                   whether to enable experimental support for
    *     HTTP/3 (QUIC).
-   * @param useCares                                      whether to use the c_ares library for DNS
    * @param http3ConnectionOptions                        connection options to be used in HTTP/3.
    * @param http3ClientConnectionOptions                  client connection options to be used in
    *     HTTP/3.
@@ -130,8 +127,6 @@ public class EnvoyConfiguration {
    * @param keyValueStores                                platform key-value store implementations.
    * @param enablePlatformCertificatesValidation          whether to use the platform verifier.
    * @param upstreamTlsSni                                the upstream TLS socket SNI override.
-   * @param caresFallbackResolvers                        A list of host port pair that's used as
-   *     c-ares's fallback resolvers.
    * @param h3ConnectionKeepaliveInitialIntervalMilliseconds the initial keepalive ping timeout for
    * HTTP/3.
    */
@@ -141,20 +136,19 @@ public class EnvoyConfiguration {
       int dnsFailureRefreshSecondsBase, int dnsFailureRefreshSecondsMax, int dnsQueryTimeoutSeconds,
       int dnsMinRefreshSeconds, List<String> dnsPreresolveHostnames, boolean enableDNSCache,
       int dnsCacheSaveIntervalSeconds, int dnsNumRetries, boolean enableDrainPostDnsRefresh,
-      boolean enableHttp3, boolean useCares, String http3ConnectionOptions,
-      String http3ClientConnectionOptions, Map<String, Integer> quicHints,
-      List<String> quicCanonicalSuffixes, boolean enableGzipDecompression,
-      boolean enableBrotliDecompression, int numTimeoutsToTriggerPortMigration,
-      boolean enableSocketTagging, boolean enableInterfaceBinding,
-      int h2ConnectionKeepaliveIdleIntervalMilliseconds, int h2ConnectionKeepaliveTimeoutSeconds,
-      int maxConnectionsPerHost, int streamIdleTimeoutSeconds, int perTryIdleTimeoutSeconds,
-      String appVersion, String appId, TrustChainVerification trustChainVerification,
+      boolean enableHttp3, String http3ConnectionOptions, String http3ClientConnectionOptions,
+      Map<String, Integer> quicHints, List<String> quicCanonicalSuffixes,
+      boolean enableGzipDecompression, boolean enableBrotliDecompression,
+      int numTimeoutsToTriggerPortMigration, boolean enableSocketTagging,
+      boolean enableInterfaceBinding, int h2ConnectionKeepaliveIdleIntervalMilliseconds,
+      int h2ConnectionKeepaliveTimeoutSeconds, int maxConnectionsPerHost,
+      int streamIdleTimeoutSeconds, int perTryIdleTimeoutSeconds, String appVersion, String appId,
+      TrustChainVerification trustChainVerification,
       List<EnvoyNativeFilterConfig> nativeFilterChain,
       List<EnvoyHTTPFilterFactory> httpPlatformFilterFactories,
       Map<String, EnvoyStringAccessor> stringAccessors,
       Map<String, EnvoyKeyValueStore> keyValueStores, Map<String, Boolean> runtimeGuards,
       boolean enablePlatformCertificatesValidation, String upstreamTlsSni,
-      List<Pair<String, Integer>> caresFallbackResolvers,
       int h3ConnectionKeepaliveInitialIntervalMilliseconds) {
     JniLibrary.load();
     this.connectTimeoutSeconds = connectTimeoutSeconds;
@@ -171,12 +165,6 @@ public class EnvoyConfiguration {
     this.dnsNumRetries = dnsNumRetries;
     this.enableDrainPostDnsRefresh = enableDrainPostDnsRefresh;
     this.enableHttp3 = enableHttp3;
-    this.useCares = useCares;
-    this.caresFallbackResolvers = new ArrayList<>();
-    for (Pair<String, Integer> hostAndPort : caresFallbackResolvers) {
-      this.caresFallbackResolvers.add(
-          new Pair<String, String>(hostAndPort.first, String.valueOf(hostAndPort.second)));
-    }
     this.http3ConnectionOptions = http3ConnectionOptions;
     this.http3ClientConnectionOptions = http3ClientConnectionOptions;
     this.quicHints = new HashMap<>();
@@ -233,20 +221,18 @@ public class EnvoyConfiguration {
     byte[][] runtimeGuards = JniBridgeUtility.mapToJniBytes(this.runtimeGuards);
     byte[][] quicHints = JniBridgeUtility.mapToJniBytes(this.quicHints);
     byte[][] quicSuffixes = JniBridgeUtility.stringsToJniBytes(quicCanonicalSuffixes);
-    byte[][] caresFallbackResolvers =
-        JniBridgeUtility.listOfStringPairsToJniBytes(this.caresFallbackResolvers);
 
     return JniLibrary.createBootstrap(
         connectTimeoutSeconds, disableDnsRefreshOnFailure, disableDnsRefreshOnNetworkChange,
         dnsRefreshSeconds, dnsFailureRefreshSecondsBase, dnsFailureRefreshSecondsMax,
         dnsQueryTimeoutSeconds, dnsMinRefreshSeconds, dnsPreresolve, enableDNSCache,
         dnsCacheSaveIntervalSeconds, dnsNumRetries, enableDrainPostDnsRefresh, enableHttp3,
-        useCares, http3ConnectionOptions, http3ClientConnectionOptions, quicHints, quicSuffixes,
+        http3ConnectionOptions, http3ClientConnectionOptions, quicHints, quicSuffixes,
         enableGzipDecompression, enableBrotliDecompression, numTimeoutsToTriggerPortMigration,
         enableSocketTagging, enableInterfaceBinding, h2ConnectionKeepaliveIdleIntervalMilliseconds,
         h2ConnectionKeepaliveTimeoutSeconds, maxConnectionsPerHost, streamIdleTimeoutSeconds,
         perTryIdleTimeoutSeconds, appVersion, appId, enforceTrustChainVerification, filterChain,
-        enablePlatformCertificatesValidation, upstreamTlsSni, runtimeGuards, caresFallbackResolvers,
+        enablePlatformCertificatesValidation, upstreamTlsSni, runtimeGuards,
         h3ConnectionKeepaliveInitialIntervalMilliseconds);
   }
 }

--- a/mobile/library/java/io/envoyproxy/envoymobile/engine/JniLibrary.java
+++ b/mobile/library/java/io/envoyproxy/envoymobile/engine/JniLibrary.java
@@ -310,23 +310,16 @@ public class JniLibrary {
       long dnsFailureRefreshSecondsBase, long dnsFailureRefreshSecondsMax,
       long dnsQueryTimeoutSeconds, long dnsMinRefreshSeconds, byte[][] dnsPreresolveHostnames,
       boolean enableDNSCache, long dnsCacheSaveIntervalSeconds, int dnsNumRetries,
-      boolean enableDrainPostDnsRefresh, boolean enableHttp3, boolean useCares,
-      String http3ConnectionOptions, String http3ClientConnectionOptions, byte[][] quicHints,
-      byte[][] quicCanonicalSuffixes, boolean enableGzipDecompression,
-      boolean enableBrotliDecompression, int numTimeoutsToTriggerPortMigration,
-      boolean enableSocketTagging, boolean enableInterfaceBinding,
-      long h2ConnectionKeepaliveIdleIntervalMilliseconds, long h2ConnectionKeepaliveTimeoutSeconds,
-      long maxConnectionsPerHost, long streamIdleTimeoutSeconds, long perTryIdleTimeoutSeconds,
-      String appVersion, String appId, boolean trustChainVerification, byte[][] filterChain,
+      boolean enableDrainPostDnsRefresh, boolean enableHttp3, String http3ConnectionOptions,
+      String http3ClientConnectionOptions, byte[][] quicHints, byte[][] quicCanonicalSuffixes,
+      boolean enableGzipDecompression, boolean enableBrotliDecompression,
+      int numTimeoutsToTriggerPortMigration, boolean enableSocketTagging,
+      boolean enableInterfaceBinding, long h2ConnectionKeepaliveIdleIntervalMilliseconds,
+      long h2ConnectionKeepaliveTimeoutSeconds, long maxConnectionsPerHost,
+      long streamIdleTimeoutSeconds, long perTryIdleTimeoutSeconds, String appVersion, String appId,
+      boolean trustChainVerification, byte[][] filterChain,
       boolean enablePlatformCertificatesValidation, String upstreamTlsSni, byte[][] runtimeGuards,
-      byte[][] cares_fallback_resolvers, long h3ConnectionKeepaliveInitialIntervalMilliseconds);
-
-  /**
-   * Initializes c-ares.
-   * See <a
-   * href="https://c-ares.org/docs/ares_library_init_android.html">ares_library_init_android</a>.
-   */
-  public static native void initCares(ConnectivityManager connectivityManager);
+      long h3ConnectionKeepaliveInitialIntervalMilliseconds);
 
   /**
    * Returns true if the runtime feature is enabled.

--- a/mobile/library/java/org/chromium/net/impl/NativeCronvoyEngineBuilderImpl.java
+++ b/mobile/library/java/org/chromium/net/impl/NativeCronvoyEngineBuilderImpl.java
@@ -52,8 +52,6 @@ public class NativeCronvoyEngineBuilderImpl extends CronvoyEngineBuilderImpl {
   private Optional<Integer> mDnsNumRetries = Optional.empty();
   private final List<String> mDnsFallbackNameservers = Collections.emptyList();
   private final boolean mEnableDnsFilterUnroutableFamilies = true;
-  private boolean mUseCares = false;
-  private final List<Pair<String, Integer>> mCaresFallbackResolvers = new ArrayList<>();
   private boolean mEnableDrainPostDnsRefresh = false;
   private final boolean mEnableGzipDecompression = true;
   private final boolean mEnableSocketTag = true;
@@ -89,27 +87,6 @@ public class NativeCronvoyEngineBuilderImpl extends CronvoyEngineBuilderImpl {
    */
   public NativeCronvoyEngineBuilderImpl setEnableDrainPostDnsRefresh(boolean enable) {
     mEnableDrainPostDnsRefresh = enable;
-    return this;
-  }
-
-  /**
-   * Enable using the c_ares DNS resolver.
-   *
-   * @param enable If true, use c_ares.
-   */
-  public NativeCronvoyEngineBuilderImpl setUseCares(boolean enable) {
-    mUseCares = enable;
-    return this;
-  }
-
-  /**
-   * Add a fallback resolver to c_cares.
-   *
-   * @param host ip address string
-   * @param port port for the resolver
-   */
-  public NativeCronvoyEngineBuilderImpl addCaresFallbackResolver(String host, int port) {
-    mCaresFallbackResolvers.add(new Pair<String, Integer>(host, port));
     return this;
   }
 
@@ -305,13 +282,13 @@ public class NativeCronvoyEngineBuilderImpl extends CronvoyEngineBuilderImpl {
         mDnsRefreshSeconds, mDnsFailureRefreshSecondsBase, mDnsFailureRefreshSecondsMax,
         mDnsQueryTimeoutSeconds, mDnsMinRefreshSeconds, mDnsPreresolveHostnames, mEnableDNSCache,
         mDnsCacheSaveIntervalSeconds, mDnsNumRetries.orElse(-1), mEnableDrainPostDnsRefresh,
-        quicEnabled(), mUseCares, quicConnectionOptions(), quicClientConnectionOptions(),
-        quicHints(), quicCanonicalSuffixes(), mEnableGzipDecompression, brotliEnabled(),
+        quicEnabled(), quicConnectionOptions(), quicClientConnectionOptions(), quicHints(),
+        quicCanonicalSuffixes(), mEnableGzipDecompression, brotliEnabled(),
         numTimeoutsToTriggerPortMigration(), mEnableSocketTag, mEnableInterfaceBinding,
         mH2ConnectionKeepaliveIdleIntervalMilliseconds, mH2ConnectionKeepaliveTimeoutSeconds,
         mMaxConnectionsPerHost, mStreamIdleTimeoutSeconds, mPerTryIdleTimeoutSeconds, mAppVersion,
         mAppId, mTrustChainVerification, nativeFilterChain, platformFilterChain, stringAccessors,
         keyValueStores, mRuntimeGuards, mEnablePlatformCertificatesValidation, mUpstreamTlsSni,
-        mCaresFallbackResolvers, mH3ConnectionKeepaliveInitialIntervalMilliseconds);
+        mH3ConnectionKeepaliveInitialIntervalMilliseconds);
   }
 }

--- a/mobile/library/jni/jni_impl.cc
+++ b/mobile/library/jni/jni_impl.cc
@@ -137,19 +137,6 @@ extern "C" JNIEXPORT void JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibra
   delete internal_engine;
 }
 
-extern "C" JNIEXPORT void JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibrary_initCares(
-    JNIEnv* env, jclass, jobject connectivity_manager) {
-#if defined(__ANDROID_API__)
-  Envoy::JNI::JniHelper jni_helper(env);
-  ares_library_init_jvm(jni_helper.getJavaVm());
-  ares_library_init_android(connectivity_manager);
-#else
-  // For suppressing unused parameters.
-  (void)env;
-  (void)connectivity_manager;
-#endif
-}
-
 extern "C" JNIEXPORT jboolean JNICALL
 Java_io_envoyproxy_envoymobile_engine_JniLibrary_runtimeFeatureEnabled(JNIEnv* env, jclass,
                                                                        jstring feature_name) {
@@ -1147,26 +1134,27 @@ javaObjectArrayToStringPairVector(Envoy::JNI::JniHelper& jni_helper, jobjectArra
   return ret;
 }
 
-void configureBuilder(
-    Envoy::JNI::JniHelper& jni_helper, jlong connect_timeout_seconds,
-    jboolean disable_dns_refresh_on_failure, jboolean disable_dns_refresh_on_network_change,
-    jlong dns_refresh_seconds, jlong dns_failure_refresh_seconds_base,
-    jlong dns_failure_refresh_seconds_max, jlong dns_query_timeout_seconds,
-    jlong dns_min_refresh_seconds, jobjectArray dns_preresolve_hostnames, jboolean enable_dns_cache,
-    jlong dns_cache_save_interval_seconds, jint dns_num_retries,
-    jboolean enable_drain_post_dns_refresh, jboolean enable_http3, jboolean use_cares,
-    jstring http3_connection_options, jstring http3_client_connection_options,
-    jobjectArray quic_hints, jobjectArray quic_canonical_suffixes,
-    jboolean enable_gzip_decompression, jboolean enable_brotli_decompression,
-    jint num_timeouts_to_trigger_port_migration, jboolean enable_socket_tagging,
-    jboolean enable_interface_binding, jlong h2_connection_keepalive_idle_interval_milliseconds,
-    jlong h2_connection_keepalive_timeout_seconds, jlong max_connections_per_host,
-    jlong stream_idle_timeout_seconds, jlong per_try_idle_timeout_seconds, jstring app_version,
-    jstring app_id, jboolean trust_chain_verification, jobjectArray filter_chain,
-    jboolean enable_platform_certificates_validation, jstring upstream_tls_sni,
-    jobjectArray runtime_guards, jobjectArray cares_fallback_resolvers,
-    jlong h3_connection_keepalive_initial_interval_milliseconds,
-    Envoy::Platform::EngineBuilder& builder) {
+void configureBuilder(Envoy::JNI::JniHelper& jni_helper, jlong connect_timeout_seconds,
+                      jboolean disable_dns_refresh_on_failure,
+                      jboolean disable_dns_refresh_on_network_change, jlong dns_refresh_seconds,
+                      jlong dns_failure_refresh_seconds_base, jlong dns_failure_refresh_seconds_max,
+                      jlong dns_query_timeout_seconds, jlong dns_min_refresh_seconds,
+                      jobjectArray dns_preresolve_hostnames, jboolean enable_dns_cache,
+                      jlong dns_cache_save_interval_seconds, jint dns_num_retries,
+                      jboolean enable_drain_post_dns_refresh, jboolean enable_http3,
+                      jstring http3_connection_options, jstring http3_client_connection_options,
+                      jobjectArray quic_hints, jobjectArray quic_canonical_suffixes,
+                      jboolean enable_gzip_decompression, jboolean enable_brotli_decompression,
+                      jint num_timeouts_to_trigger_port_migration, jboolean enable_socket_tagging,
+                      jboolean enable_interface_binding,
+                      jlong h2_connection_keepalive_idle_interval_milliseconds,
+                      jlong h2_connection_keepalive_timeout_seconds, jlong max_connections_per_host,
+                      jlong stream_idle_timeout_seconds, jlong per_try_idle_timeout_seconds,
+                      jstring app_version, jstring app_id, jboolean trust_chain_verification,
+                      jobjectArray filter_chain, jboolean enable_platform_certificates_validation,
+                      jstring upstream_tls_sni, jobjectArray runtime_guards,
+                      jlong h3_connection_keepalive_initial_interval_milliseconds,
+                      Envoy::Platform::EngineBuilder& builder) {
   builder.addConnectTimeoutSeconds((connect_timeout_seconds));
   builder.setDisableDnsRefreshOnFailure(disable_dns_refresh_on_failure);
   builder.setDisableDnsRefreshOnNetworkChange(disable_dns_refresh_on_network_change);
@@ -1208,13 +1196,6 @@ void configureBuilder(
     builder.addQuicCanonicalSuffix(suffix);
   }
   builder.setNumTimeoutsToTriggerPortMigration(num_timeouts_to_trigger_port_migration);
-  builder.setUseCares(use_cares == JNI_TRUE);
-  if (use_cares == JNI_TRUE) {
-    auto resolvers = javaObjectArrayToStringPairVector(jni_helper, cares_fallback_resolvers);
-    for (const auto& [host, port] : resolvers) {
-      builder.addCaresFallbackResolver(host, stoi(port));
-    }
-  }
   builder.enableInterfaceBinding(enable_interface_binding == JNI_TRUE);
   builder.enableDrainPostDnsRefresh(enable_drain_post_dns_refresh == JNI_TRUE);
   builder.enforceTrustChainVerification(trust_chain_verification == JNI_TRUE);
@@ -1260,18 +1241,17 @@ extern "C" JNIEXPORT jlong JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibr
     jlong dns_query_timeout_seconds, jlong dns_min_refresh_seconds,
     jobjectArray dns_preresolve_hostnames, jboolean enable_dns_cache,
     jlong dns_cache_save_interval_seconds, jint dns_num_retries,
-    jboolean enable_drain_post_dns_refresh, jboolean enable_http3, jboolean use_cares,
-    jstring http3_connection_options, jstring http3_client_connection_options,
-    jobjectArray quic_hints, jobjectArray quic_canonical_suffixes,
-    jboolean enable_gzip_decompression, jboolean enable_brotli_decompression,
-    jint num_timeouts_to_trigger_port_migration, jboolean enable_socket_tagging,
-    jboolean enable_interface_binding, jlong h2_connection_keepalive_idle_interval_milliseconds,
+    jboolean enable_drain_post_dns_refresh, jboolean enable_http3, jstring http3_connection_options,
+    jstring http3_client_connection_options, jobjectArray quic_hints,
+    jobjectArray quic_canonical_suffixes, jboolean enable_gzip_decompression,
+    jboolean enable_brotli_decompression, jint num_timeouts_to_trigger_port_migration,
+    jboolean enable_socket_tagging, jboolean enable_interface_binding,
+    jlong h2_connection_keepalive_idle_interval_milliseconds,
     jlong h2_connection_keepalive_timeout_seconds, jlong max_connections_per_host,
     jlong stream_idle_timeout_seconds, jlong per_try_idle_timeout_seconds, jstring app_version,
     jstring app_id, jboolean trust_chain_verification, jobjectArray filter_chain,
     jboolean enable_platform_certificates_validation, jstring upstream_tls_sni,
-    jobjectArray runtime_guards, jobjectArray cares_fallback_resolvers,
-    jlong h3_connection_keepalive_initial_interval_milliseconds) {
+    jobjectArray runtime_guards, jlong h3_connection_keepalive_initial_interval_milliseconds) {
   Envoy::JNI::JniHelper jni_helper(env);
   Envoy::Platform::EngineBuilder builder;
 
@@ -1280,7 +1260,7 @@ extern "C" JNIEXPORT jlong JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibr
       disable_dns_refresh_on_network_change, dns_refresh_seconds, dns_failure_refresh_seconds_base,
       dns_failure_refresh_seconds_max, dns_query_timeout_seconds, dns_min_refresh_seconds,
       dns_preresolve_hostnames, enable_dns_cache, dns_cache_save_interval_seconds, dns_num_retries,
-      enable_drain_post_dns_refresh, enable_http3, use_cares, http3_connection_options,
+      enable_drain_post_dns_refresh, enable_http3, http3_connection_options,
       http3_client_connection_options, quic_hints, quic_canonical_suffixes,
       enable_gzip_decompression, enable_brotli_decompression,
       num_timeouts_to_trigger_port_migration, enable_socket_tagging, enable_interface_binding,
@@ -1288,7 +1268,7 @@ extern "C" JNIEXPORT jlong JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibr
       max_connections_per_host, stream_idle_timeout_seconds, per_try_idle_timeout_seconds,
       app_version, app_id, trust_chain_verification, filter_chain,
       enable_platform_certificates_validation, upstream_tls_sni, runtime_guards,
-      cares_fallback_resolvers, h3_connection_keepalive_initial_interval_milliseconds, builder);
+      h3_connection_keepalive_initial_interval_milliseconds, builder);
   return reinterpret_cast<intptr_t>(builder.generateBootstrap().release());
 }
 

--- a/mobile/library/kotlin/io/envoyproxy/envoymobile/EngineBuilder.kt
+++ b/mobile/library/kotlin/io/envoyproxy/envoymobile/EngineBuilder.kt
@@ -1,6 +1,5 @@
 package io.envoyproxy.envoymobile
 
-import android.util.Pair
 import io.envoyproxy.envoymobile.engine.EnvoyConfiguration
 import io.envoyproxy.envoymobile.engine.EnvoyConfiguration.TrustChainVerification
 import io.envoyproxy.envoymobile.engine.EnvoyEngine
@@ -41,8 +40,6 @@ open class EngineBuilder() {
   private var dnsNumRetries: Int? = null
   private var enableDrainPostDnsRefresh = false
   internal var enableHttp3 = true
-  internal var useCares = false
-  internal var caresFallbackResolvers = mutableListOf<Pair<String, Int>>()
   private var http3ConnectionOptions = ""
   private var http3ClientConnectionOptions = ""
   private var quicHints = mutableMapOf<String, Int>()
@@ -222,29 +219,6 @@ open class EngineBuilder() {
    */
   fun enableHttp3(enableHttp3: Boolean): EngineBuilder {
     this.enableHttp3 = enableHttp3
-    return this
-  }
-
-  /**
-   * Specify whether to use c_ares for dns resolution. Defaults to false.
-   *
-   * @param useCares whether or not to use c_ares
-   * @return This builder.
-   */
-  fun useCares(useCares: Boolean): EngineBuilder {
-    this.useCares = useCares
-    return this
-  }
-
-  /**
-   * Add fallback resolver to c_ares.
-   *
-   * @param host ip address string
-   * @param port port for the resolver
-   * @return This builder.
-   */
-  fun addCaresFallbackResolver(host: String, port: Int): EngineBuilder {
-    this.caresFallbackResolvers.add(Pair(host, port))
     return this
   }
 
@@ -569,7 +543,6 @@ open class EngineBuilder() {
         dnsNumRetries ?: -1,
         enableDrainPostDnsRefresh,
         enableHttp3,
-        useCares,
         http3ConnectionOptions,
         http3ClientConnectionOptions,
         quicHints,
@@ -594,7 +567,6 @@ open class EngineBuilder() {
         runtimeGuards,
         enablePlatformCertificatesValidation,
         upstreamTlsSni,
-        caresFallbackResolvers,
         h3ConnectionKeepaliveInitialIntervalMilliseconds,
       )
 

--- a/mobile/test/common/integration/client_integration_test.cc
+++ b/mobile/test/common/integration/client_integration_test.cc
@@ -253,17 +253,6 @@ TEST_P(ClientIntegrationTest, Basic) {
   }
 }
 
-#if not defined(__APPLE__)
-TEST_P(ClientIntegrationTest, BasicWithCares) {
-  builder_.setUseCares(true);
-  initialize();
-  basicTest();
-  if (upstreamProtocol() == Http::CodecType::HTTP1) {
-    ASSERT_EQ(cc_.on_complete_received_byte_count_, 67);
-  }
-}
-#endif
-
 // TODO(fredyw): Disable this until we support treating no DNS record as a failure in the Apple
 // resolver.
 #if not defined(__APPLE__)

--- a/mobile/test/java/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
+++ b/mobile/test/java/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
@@ -82,8 +82,6 @@ class EnvoyConfigurationTest {
     dnsNumRetries: Int? = 3,
     enableDrainPostDnsRefresh: Boolean = false,
     enableHttp3: Boolean = true,
-    enableCares: Boolean = false,
-    caresFallbackResolvers: MutableList<Pair<String, Int>> = mutableListOf(Pair("1.2.3.4", 88)),
     http3ConnectionOptions: String = "5RTO",
     http3ClientConnectionOptions: String = "MPQC",
     quicHints: Map<String, Int> = mapOf("www.abc.com" to 443, "www.def.com" to 443),
@@ -133,7 +131,6 @@ class EnvoyConfigurationTest {
       dnsNumRetries ?: -1,
       enableDrainPostDnsRefresh,
       enableHttp3,
-      enableCares,
       http3ConnectionOptions,
       http3ClientConnectionOptions,
       quicHints,
@@ -158,7 +155,6 @@ class EnvoyConfigurationTest {
       runtimeGuards,
       enablePlatformCertificatesValidation,
       upstreamTlsSni,
-      caresFallbackResolvers,
       h3ConnectionKeepaliveInitialIntervalMilliseconds,
     )
   }
@@ -240,7 +236,6 @@ class EnvoyConfigurationTest {
       enableDNSCache = true,
       dnsCacheSaveIntervalSeconds = 101,
       enableHttp3 = false,
-      enableCares = true,
       enableGzipDecompression = false,
       enableBrotliDecompression = true,
       enableSocketTagging = true,
@@ -261,11 +256,6 @@ class EnvoyConfigurationTest {
 
     // enableDrainPostDnsRefresh = true
     assertThat(resolvedTemplate).contains("enable_drain_post_dns_refresh: true")
-
-    // enableCares = true
-    assertThat(resolvedTemplate).contains("envoy.network.dns_resolver.cares")
-    assertThat(resolvedTemplate).contains("address: \"1.2.3.4\"");
-    assertThat(resolvedTemplate).contains("port_value: 88");
 
     // UDP GRO enabled by default
     assertThat(resolvedTemplate).contains("key: \"prefer_quic_client_udp_gro\" value { bool_value: true }")

--- a/mobile/test/kotlin/apps/experimental/MainActivity.kt
+++ b/mobile/test/kotlin/apps/experimental/MainActivity.kt
@@ -84,7 +84,6 @@ class MainActivity : Activity() {
             Log.d(TAG, "Event emitted: ${entry.key}, ${entry.value}")
           }
         })
-        .useCares(true)
         .build()
 
     recyclerView = findViewById<RecyclerView>(R.id.recycler_view)!!


### PR DESCRIPTION
Only the platform DNS resolvers are supported for Envoy Mobile. The default is to use the getaddrinfo resolver which is available on Posix platforms.