### PR TITLE
dynamic_modules: fixes crash when config init failed

### DIFF
--- a/source/extensions/filters/http/dynamic_modules/filter_config.cc
+++ b/source/extensions/filters/http/dynamic_modules/filter_config.cc
@@ -13,7 +13,11 @@ DynamicModuleHttpFilterConfig::DynamicModuleHttpFilterConfig(
       filter_config_(filter_config), dynamic_module_(std::move(dynamic_module)) {};
 
 DynamicModuleHttpFilterConfig::~DynamicModuleHttpFilterConfig() {
-  (*on_http_filter_config_destroy_)(in_module_config_);
+  // When the initialization of the dynamic module fails, the in_module_config_ is nullptr,
+  // and there's nothing to destroy from the module's point of view.
+  if (on_http_filter_config_destroy_) {
+    (*on_http_filter_config_destroy_)(in_module_config_);
+  }
 };
 
 absl::StatusOr<DynamicModuleHttpFilterConfigSharedPtr>

--- a/test/extensions/dynamic_modules/http/filter_test.cc
+++ b/test/extensions/dynamic_modules/http/filter_test.cc
@@ -61,7 +61,6 @@ TEST_P(DynamicModuleTestLanguages, Nop) {
 }
 
 TEST(DynamicModulesTest, NonExistentFilter) {
-  // TODO: Add non-Rust test program once we have non-Rust SDK.
   auto dynamic_module = newDynamicModule(testSharedObjectPath("http", "rust"), false);
   EXPECT_TRUE(dynamic_module.ok()) << dynamic_module.status().message();
   NiceMock<Server::Configuration::MockServerFactoryContext> context;

--- a/test/extensions/dynamic_modules/http/filter_test.cc
+++ b/test/extensions/dynamic_modules/http/filter_test.cc
@@ -60,6 +60,18 @@ TEST_P(DynamicModuleTestLanguages, Nop) {
   filter->onDestroy();
 }
 
+TEST(DynamicModulesTest, NonExistentFilter) {
+  // TODO: Add non-Rust test program once we have non-Rust SDK.
+  auto dynamic_module = newDynamicModule(testSharedObjectPath("http", "rust"), false);
+  EXPECT_TRUE(dynamic_module.ok()) << dynamic_module.status().message();
+  NiceMock<Server::Configuration::MockServerFactoryContext> context;
+  auto filter_config_or_status = newDynamicModuleHttpFilterConfig(
+      "non_existent", "", std::move(dynamic_module.value()), context);
+  EXPECT_FALSE(filter_config_or_status.ok());
+  EXPECT_THAT(filter_config_or_status.status().message(),
+              testing::HasSubstr("Failed to initialize dynamic module"));
+}
+
 TEST(DynamicModulesTest, HeaderCallbacks) {
   const std::string filter_name = "header_callbacks";
   const std::string filter_config = "";

--- a/test/extensions/dynamic_modules/http/filter_test.cc
+++ b/test/extensions/dynamic_modules/http/filter_test.cc
@@ -60,12 +60,12 @@ TEST_P(DynamicModuleTestLanguages, Nop) {
   filter->onDestroy();
 }
 
-TEST(DynamicModulesTest, NonExistentFilter) {
+TEST(DynamicModulesTest, ConfigInitializationFailure) {
   auto dynamic_module = newDynamicModule(testSharedObjectPath("http", "rust"), false);
   EXPECT_TRUE(dynamic_module.ok()) << dynamic_module.status().message();
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   auto filter_config_or_status = newDynamicModuleHttpFilterConfig(
-      "non_existent", "", std::move(dynamic_module.value()), context);
+      "config_init_failure", "", std::move(dynamic_module.value()), context);
   EXPECT_FALSE(filter_config_or_status.ok());
   EXPECT_THAT(filter_config_or_status.status().message(),
               testing::HasSubstr("Failed to initialize dynamic module"));

--- a/test/extensions/dynamic_modules/test_data/rust/http.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/http.rs
@@ -24,6 +24,7 @@ fn new_http_filter_config_fn<EC: EnvoyHttpFilterConfig, EHF: EnvoyHttpFilter>(
     "dynamic_metadata_callbacks" => Some(Box::new(DynamicMetadataCallbacksFilterConfig {})),
     "filter_state_callbacks" => Some(Box::new(FilterStateCallbacksFilterConfig {})),
     "body_callbacks" => Some(Box::new(BodyCallbacksFilterConfig {})),
+    "non_existent" => None,
     _ => panic!("Unknown filter name: {}", name),
   }
 }

--- a/test/extensions/dynamic_modules/test_data/rust/http.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/http.rs
@@ -24,7 +24,7 @@ fn new_http_filter_config_fn<EC: EnvoyHttpFilterConfig, EHF: EnvoyHttpFilter>(
     "dynamic_metadata_callbacks" => Some(Box::new(DynamicMetadataCallbacksFilterConfig {})),
     "filter_state_callbacks" => Some(Box::new(FilterStateCallbacksFilterConfig {})),
     "body_callbacks" => Some(Box::new(BodyCallbacksFilterConfig {})),
-    "non_existent" => None,
+    "config_init_failure" => None,
     _ => panic!("Unknown filter name: {}", name),
   }
 }


### PR DESCRIPTION
Commit Message: dynamic_modules: fixes crash when config init failed
Additional Description:
Previously, there was a bug around the handling of config initialization failure which resulted in a crash, and this commit fixes that. Note that the crash is not as serious as it seems in the sense that this is not caused by downstream inputs, but by a wrong configuration passed by Envoy control planes (or static config).

Risk Level: low
Testing: done
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a