### PR TITLE
remove senseless getTransportSocketFactoryContext

### DIFF
--- a/contrib/sip_proxy/filters/network/source/utility.h
+++ b/contrib/sip_proxy/filters/network/source/utility.h
@@ -155,12 +155,7 @@ public:
 class Utility {
 public:
   static const std::string& localAddress(Server::Configuration::FactoryContext& context) {
-    return context.getTransportSocketFactoryContext()
-        .serverFactoryContext()
-        .localInfo()
-        .address()
-        ->ip()
-        ->addressAsString();
+    return context.serverFactoryContext().localInfo().address()->ip()->addressAsString();
   }
 };
 

--- a/contrib/sip_proxy/filters/network/test/conn_manager_test.cc
+++ b/contrib/sip_proxy/filters/network/test/conn_manager_test.cc
@@ -78,9 +78,7 @@ public:
       config_->custom_filter_ = custom_filter_;
     }
 
-    EXPECT_CALL(context_, getTransportSocketFactoryContext())
-        .WillRepeatedly(testing::ReturnRef(factory_context_));
-    EXPECT_CALL(factory_context_.server_context_, localInfo())
+    EXPECT_CALL(context_.server_factory_context_, localInfo())
         .WillRepeatedly(testing::ReturnRef(local_info_));
     ON_CALL(random_, random()).WillByDefault(Return(42));
     filter_ = std::make_unique<ConnectionManager>(
@@ -450,7 +448,6 @@ settings:
   }
 
   NiceMock<Server::Configuration::MockFactoryContext> context_;
-  NiceMock<Server::Configuration::MockTransportSocketFactoryContext> factory_context_;
   NiceMock<LocalInfo::MockLocalInfo> local_info_;
   std::shared_ptr<SipFilters::MockDecoderFilter> decoder_filter_;
   Stats::TestUtil::TestStore store_;

--- a/contrib/sip_proxy/filters/network/test/router_test.cc
+++ b/contrib/sip_proxy/filters/network/test/router_test.cc
@@ -103,9 +103,7 @@ public:
         extensionProtocolOptions(_))
         .WillRepeatedly(Return(options));
 
-    EXPECT_CALL(context_, getTransportSocketFactoryContext())
-        .WillRepeatedly(testing::ReturnRef(factory_context_));
-    EXPECT_CALL(factory_context_.server_context_, localInfo())
+    EXPECT_CALL(context_.server_factory_context_, localInfo())
         .WillRepeatedly(testing::ReturnRef(local_info_));
 
     transaction_infos_ = std::make_shared<TransactionInfos>();
@@ -325,7 +323,6 @@ public:
   NiceMock<SipFilters::MockDecoderFilterCallbacks> callbacks_;
   NiceMock<MockRoute>* route_{};
   NiceMock<MockRouteEntry> route_entry_;
-  NiceMock<Server::Configuration::MockTransportSocketFactoryContext> factory_context_;
   NiceMock<LocalInfo::MockLocalInfo> local_info_;
   NiceMock<Upstream::MockHostDescription>* host_{};
   Tcp::ConnectionPool::ConnectionStatePtr conn_state_;

--- a/contrib/sxg/filters/http/source/BUILD
+++ b/contrib/sxg/filters/http/source/BUILD
@@ -44,6 +44,7 @@ envoy_cc_contrib_extension(
         ":sxg_lib",
         "//envoy/registry",
         "//source/extensions/filters/http/common:factory_base_lib",
+        "//source/server:transport_socket_config_lib",
         "@envoy_api//contrib/envoy/extensions/filters/http/sxg/v3alpha:pkg_cc_proto",
     ],
 )

--- a/contrib/sxg/filters/http/test/config_test.cc
+++ b/contrib/sxg/filters/http/test/config_test.cc
@@ -42,12 +42,10 @@ void expectCreateFilter(std::string yaml, bool is_sds_config) {
             envoy::extensions::transport_sockets::tls::v3::GenericSecret())));
   }
   EXPECT_CALL(context, messageValidationVisitor());
-  EXPECT_CALL(context.server_factory_context_, clusterManager());
   EXPECT_CALL(context, scope());
   EXPECT_CALL(context.server_factory_context_, timeSource());
   EXPECT_CALL(context.server_factory_context_, api());
   EXPECT_CALL(context, initManager()).Times(2);
-  EXPECT_CALL(context, getTransportSocketFactoryContext());
   Http::FilterFactoryCb cb =
       factory.createFilterFactoryFromProto(*proto_config, "stats", context).value();
   Http::MockFilterChainFactoryCallbacks filter_callback;

--- a/envoy/server/factory_context.h
+++ b/envoy/server/factory_context.h
@@ -185,11 +185,6 @@ public:
   virtual ProcessContextOptRef processContext() PURE;
 
   /**
-   * @return TransportSocketFactoryContext which lifetime is no shorter than the server.
-   */
-  virtual TransportSocketFactoryContext& getTransportSocketFactoryContext() const PURE;
-
-  /**
    * @return the init manager of the cluster. This can be used for extensions that need
    *         to initialize after cluster manager init but before the server starts listening.
    *         All extensions should register themselves during configuration load. initialize()
@@ -300,11 +295,6 @@ public:
    * @return Stats::Scope& the listener's stats scope.
    */
   virtual Stats::Scope& listenerScope() PURE;
-
-  /**
-   * @return TransportSocketFactoryContext which lifetime is no shorter than the server.
-   */
-  virtual TransportSocketFactoryContext& getTransportSocketFactoryContext() const PURE;
 
   /**
    * @return const Network::DrainDecision& a drain decision that filters can use to determine if

--- a/source/common/listener_manager/filter_chain_manager_impl.cc
+++ b/source/common/listener_manager/filter_chain_manager_impl.cc
@@ -102,11 +102,6 @@ Configuration::ServerFactoryContext& PerFilterChainFactoryContextImpl::serverFac
   return parent_context_.serverFactoryContext();
 }
 
-Configuration::TransportSocketFactoryContext&
-PerFilterChainFactoryContextImpl::getTransportSocketFactoryContext() const {
-  return parent_context_.getTransportSocketFactoryContext();
-}
-
 Stats::Scope& PerFilterChainFactoryContextImpl::listenerScope() { return *filter_chain_scope_; }
 
 FilterChainManagerImpl::FilterChainManagerImpl(

--- a/source/common/listener_manager/filter_chain_manager_impl.h
+++ b/source/common/listener_manager/filter_chain_manager_impl.h
@@ -65,7 +65,6 @@ public:
   const Network::ListenerInfo& listenerInfo() const override;
   ProtobufMessage::ValidationVisitor& messageValidationVisitor() override;
   Configuration::ServerFactoryContext& serverFactoryContext() override;
-  Configuration::TransportSocketFactoryContext& getTransportSocketFactoryContext() const override;
   Stats::Scope& listenerScope() override;
 
   void startDraining() override { is_draining_.store(true); }

--- a/source/common/listener_manager/listener_impl.cc
+++ b/source/common/listener_manager/listener_impl.cc
@@ -929,10 +929,6 @@ ProtobufMessage::ValidationVisitor& PerListenerFactoryContextImpl::messageValida
 Configuration::ServerFactoryContext& PerListenerFactoryContextImpl::serverFactoryContext() {
   return listener_factory_context_base_->serverFactoryContext();
 }
-Configuration::TransportSocketFactoryContext&
-PerListenerFactoryContextImpl::getTransportSocketFactoryContext() const {
-  return listener_factory_context_base_->getTransportSocketFactoryContext();
-}
 Stats::Scope& PerListenerFactoryContextImpl::listenerScope() {
   return listener_factory_context_base_->listenerScope();
 }

--- a/source/common/listener_manager/listener_impl.h
+++ b/source/common/listener_manager/listener_impl.h
@@ -182,7 +182,6 @@ public:
   const Network::ListenerInfo& listenerInfo() const override;
   ProtobufMessage::ValidationVisitor& messageValidationVisitor() override;
   Configuration::ServerFactoryContext& serverFactoryContext() override;
-  Configuration::TransportSocketFactoryContext& getTransportSocketFactoryContext() const override;
 
   Stats::Scope& listenerScope() override;
 

--- a/source/extensions/filters/http/oauth2/BUILD
+++ b/source/extensions/filters/http/oauth2/BUILD
@@ -71,6 +71,7 @@ envoy_cc_extension(
         ":oauth_lib",
         "//envoy/registry",
         "//source/extensions/filters/http/common:factory_base_lib",
+        "//source/server:transport_socket_config_lib",
         "@envoy_api//envoy/extensions/filters/http/oauth2/v3:pkg_cc_proto",
     ],
 )

--- a/source/extensions/http/injected_credentials/generic/BUILD
+++ b/source/extensions/http/injected_credentials/generic/BUILD
@@ -28,6 +28,7 @@ envoy_cc_extension(
         "//source/common/http:headers_lib",
         "//source/extensions/http/injected_credentials/common:credential_factory_base_lib",
         "//source/extensions/http/injected_credentials/common:secret_reader_lib",
+        "//source/server:transport_socket_config_lib",
         "@envoy_api//envoy/extensions/http/injected_credentials/generic/v3:pkg_cc_proto",
     ],
 )

--- a/source/extensions/http/injected_credentials/generic/config.cc
+++ b/source/extensions/http/injected_credentials/generic/config.cc
@@ -4,6 +4,8 @@
 #include "envoy/secret/secret_provider.h"
 #include "envoy/upstream/cluster_manager.h"
 
+#include "source/server/transport_socket_config_impl.h"
+
 namespace Envoy {
 namespace Extensions {
 namespace Http {
@@ -13,14 +15,15 @@ namespace Generic {
 namespace {
 Secret::GenericSecretConfigProviderSharedPtr
 secretsProvider(const envoy::extensions::transport_sockets::tls::v3::SdsSecretConfig& config,
-                Secret::SecretManager& secret_manager,
-                Server::Configuration::TransportSocketFactoryContext& transport_socket_factory,
+                Server::Configuration::ServerFactoryContext& server_context,
                 Init::Manager& init_manager) {
   if (config.has_sds_config()) {
-    return secret_manager.findOrCreateGenericSecretProvider(config.sds_config(), config.name(),
-                                                            transport_socket_factory, init_manager);
+    Server::Configuration::TransportSocketFactoryContextImpl transport_socket_factory_context(
+        server_context, server_context.messageValidationVisitor());
+    return server_context.secretManager().findOrCreateGenericSecretProvider(
+        config.sds_config(), config.name(), transport_socket_factory_context, init_manager);
   } else {
-    return secret_manager.findStaticGenericSecretProvider(config.name());
+    return server_context.secretManager().findStaticGenericSecretProvider(config.name());
   }
 }
 } // namespace
@@ -30,18 +33,11 @@ GenericCredentialInjectorFactory::createCredentialInjectorFromProtoTyped(
     const Generic& config, const std::string& /*stats_prefix*/,
     Server::Configuration::ServerFactoryContext& context, Init::Manager& init_manager) {
   const auto& credential_secret = config.credential();
-  auto& cluster_manager = context.clusterManager();
-  auto& secret_manager = cluster_manager.clusterManagerFactory().secretManager();
-  auto& transport_socket_factory = context.getTransportSocketFactoryContext();
-  auto secret_provider =
-      secretsProvider(credential_secret, secret_manager, transport_socket_factory, init_manager);
+  auto secret_provider = secretsProvider(credential_secret, context, init_manager);
 
   auto secret_reader = std::make_shared<const Common::SDSSecretReader>(
       std::move(secret_provider), context.threadLocal(), context.api());
-  std::string header = config.header();
-  if (header.empty()) {
-    header = "Authorization";
-  }
+  const std::string header = config.header().empty() ? "Authorization" : config.header();
   return std::make_shared<GenericCredentialInjector>(header, secret_reader);
 }
 

--- a/source/extensions/http/injected_credentials/oauth2/BUILD
+++ b/source/extensions/http/injected_credentials/oauth2/BUILD
@@ -42,6 +42,7 @@ envoy_cc_extension(
         "//source/common/http:headers_lib",
         "//source/extensions/http/injected_credentials/common:credential_factory_base_lib",
         "//source/extensions/http/injected_credentials/common:secret_reader_lib",
+        "//source/server:transport_socket_config_lib",
         "@envoy_api//envoy/extensions/http/injected_credentials/oauth2/v3:pkg_cc_proto",
     ],
 )

--- a/source/extensions/quic/connection_id_generator/quic_lb/BUILD
+++ b/source/extensions/quic/connection_id_generator/quic_lb/BUILD
@@ -22,6 +22,7 @@ envoy_cc_library(
         "//source/common/config:datasource_lib",
         "//source/common/quic:envoy_quic_connection_id_generator_factory_interface",
         "//source/common/quic:envoy_quic_utils_lib",
+        "//source/server:transport_socket_config_lib",
         "@com_github_google_quiche//:quic_load_balancer_config_lib",
         "@com_github_google_quiche//:quic_load_balancer_encoder_lib",
         "@com_github_google_quiche//:quic_load_balancer_server_id_lib",

--- a/source/server/factory_context_impl.cc
+++ b/source/server/factory_context_impl.cc
@@ -22,11 +22,6 @@ ProtobufMessage::ValidationVisitor& FactoryContextImplBase::messageValidationVis
 
 Stats::Scope& FactoryContextImplBase::scope() { return *scope_; }
 
-Configuration::TransportSocketFactoryContext&
-FactoryContextImplBase::getTransportSocketFactoryContext() const {
-  return server_.transportSocketFactoryContext();
-}
-
 Stats::Scope& FactoryContextImplBase::listenerScope() { return *listener_scope_; }
 
 const Network::ListenerInfo& FactoryContextImplBase::listenerInfo() const {

--- a/source/server/factory_context_impl.h
+++ b/source/server/factory_context_impl.h
@@ -19,7 +19,6 @@ public:
   Configuration::ServerFactoryContext& serverFactoryContext() override;
   Stats::Scope& scope() override;
   ProtobufMessage::ValidationVisitor& messageValidationVisitor() override;
-  Configuration::TransportSocketFactoryContext& getTransportSocketFactoryContext() const override;
   const Network::ListenerInfo& listenerInfo() const override;
 
   Stats::Scope& listenerScope() override;

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -188,9 +188,6 @@ public:
   ProtobufMessage::ValidationContext& messageValidationContext() override {
     return server_.messageValidationContext();
   }
-  Configuration::TransportSocketFactoryContext& getTransportSocketFactoryContext() const override {
-    return server_.transportSocketFactoryContext();
-  };
   Envoy::Runtime::Loader& runtime() override { return server_.runtime(); }
   Stats::Scope& scope() override { return *server_scope_; }
   Stats::Scope& serverScope() override { return *server_scope_; }

--- a/test/common/listener_manager/listener_manager_impl_test.cc
+++ b/test/common/listener_manager/listener_manager_impl_test.cc
@@ -5890,8 +5890,6 @@ TEST_P(ListenerManagerImplWithRealFiltersTest, OriginalDstFilter) {
   ListenerFactoryContextBaseImpl& parent_context =
       static_cast<PerListenerFactoryContextImpl*>(listener_factory_context)->parentFactoryContext();
   EXPECT_EQ(&listener_factory_context->initManager(), &listener.initManager());
-  EXPECT_EQ(&listener_factory_context->getTransportSocketFactoryContext(),
-            &parent_context.getTransportSocketFactoryContext());
 
   Network::FilterChainFactory& filterChainFactory = listener.filterChainFactory();
   Network::MockListenerFilterManager manager;

--- a/test/extensions/filters/http/oauth2/config_test.cc
+++ b/test/extensions/filters/http/oauth2/config_test.cc
@@ -138,7 +138,6 @@ config:
   EXPECT_CALL(context, scope());
   EXPECT_CALL(context.server_factory_context_, timeSource());
   EXPECT_CALL(context, initManager()).Times(2);
-  EXPECT_CALL(context, getTransportSocketFactoryContext());
   Http::FilterFactoryCb cb =
       factory.createFilterFactoryFromProto(*proto_config, "stats", context).value();
   Http::MockFilterChainFactoryCallbacks filter_callback;

--- a/test/extensions/http/credential_injector/oauth2/config_test.cc
+++ b/test/extensions/http/credential_injector/oauth2/config_test.cc
@@ -40,11 +40,7 @@ TEST(Config, NullClientSecret) {
   TestUtility::loadFromYaml(yaml_string, proto_config);
   OAuth2CredentialInjectorFactory factory;
   NiceMock<Server::Configuration::MockServerFactoryContext> server_factory_context;
-  NiceMock<Server::Configuration::MockTransportSocketFactoryContext>
-      transport_socket_factory_context;
   NiceMock<Init::MockManager> init_manager;
-  ON_CALL(server_factory_context, getTransportSocketFactoryContext())
-      .WillByDefault(ReturnRef(transport_socket_factory_context));
 
   EXPECT_THROW_WITH_REGEX(factory.createOauth2ClientCredentialInjector(
                               proto_config, "stats", server_factory_context, init_manager),

--- a/test/integration/sds_generic_secret_integration_test.cc
+++ b/test/integration/sds_generic_secret_integration_test.cc
@@ -71,13 +71,13 @@ public:
   absl::StatusOr<Http::FilterFactoryCb>
   createFilter(const std::string&,
                Server::Configuration::FactoryContext& factory_context) override {
+
     auto secret_provider =
         factory_context.serverFactoryContext()
             .clusterManager()
             .clusterManagerFactory()
             .secretManager()
-            .findOrCreateGenericSecretProvider(config_source_, "encryption_key",
-                                               factory_context.getTransportSocketFactoryContext(),
+            .findOrCreateGenericSecretProvider(config_source_, "encryption_key", factory_context,
                                                factory_context.initManager());
     return
         [&factory_context, secret_provider](Http::FilterChainFactoryCallbacks& callbacks) -> void {

--- a/test/mocks/server/factory_context.cc
+++ b/test/mocks/server/factory_context.cc
@@ -20,8 +20,6 @@ MockFactoryContext::MockFactoryContext() {
   ON_CALL(*this, messageValidationVisitor())
       .WillByDefault(ReturnRef(ProtobufMessage::getStrictValidationVisitor()));
 
-  ON_CALL(*this, getTransportSocketFactoryContext())
-      .WillByDefault(ReturnRef(transport_socket_factory_context_));
   ON_CALL(*this, drainDecision()).WillByDefault(ReturnRef(drain_manager_));
   ON_CALL(*this, listenerScope()).WillByDefault(ReturnRef(*listener_store_.rootScope()));
 }

--- a/test/mocks/server/factory_context.h
+++ b/test/mocks/server/factory_context.h
@@ -27,13 +27,11 @@ public:
   MOCK_METHOD(ProtobufMessage::ValidationVisitor&, messageValidationVisitor, ());
 
   // Server::Configuration::FactoryContext
-  MOCK_METHOD(TransportSocketFactoryContext&, getTransportSocketFactoryContext, (), (const));
   MOCK_METHOD(const Network::DrainDecision&, drainDecision, ());
   MOCK_METHOD(Stats::Scope&, listenerScope, ());
   MOCK_METHOD(const Network::ListenerInfo&, listenerInfo, (), (const));
 
   testing::NiceMock<MockServerFactoryContext> server_factory_context_;
-  testing::NiceMock<MockTransportSocketFactoryContext> transport_socket_factory_context_;
   testing::NiceMock<Init::MockManager> init_manager_;
   testing::NiceMock<Stats::MockIsolatedStatsStore> store_;
   Stats::Scope& scope_{*store_.rootScope()};

--- a/test/mocks/server/listener_factory_context.h
+++ b/test/mocks/server/listener_factory_context.h
@@ -22,7 +22,6 @@ public:
   ~MockListenerFactoryContext() override;
 
   MOCK_METHOD(ServerFactoryContext&, serverFactoryContext, ());
-  MOCK_METHOD(TransportSocketFactoryContext&, getTransportSocketFactoryContext, (), (const));
   MOCK_METHOD(const Network::DrainDecision&, drainDecision, ());
   MOCK_METHOD(Init::Manager&, initManager, ());
   MOCK_METHOD(Stats::Scope&, scope, ());

--- a/test/mocks/server/server_factory_context.h
+++ b/test/mocks/server/server_factory_context.h
@@ -76,8 +76,6 @@ public:
   MOCK_METHOD(ProtobufMessage::ValidationContext&, messageValidationContext, ());
   MOCK_METHOD(ProtobufMessage::ValidationVisitor&, messageValidationVisitor, ());
   MOCK_METHOD(Api::Api&, api, ());
-  MOCK_METHOD(TransportSocketFactoryContext&, getTransportSocketFactoryContext, (),
-              (const, override));
   MOCK_METHOD(Secret::SecretManager&, secretManager, ());
   MOCK_METHOD(Ssl::ContextManager&, sslContextManager, ());
   Http::Context& httpContext() override { return http_context_; }
@@ -179,8 +177,6 @@ public:
   MOCK_METHOD(ProtobufMessage::ValidationContext&, messageValidationContext, ());
   MOCK_METHOD(ProtobufMessage::ValidationVisitor&, messageValidationVisitor, ());
   MOCK_METHOD(Api::Api&, api, ());
-  MOCK_METHOD(TransportSocketFactoryContext&, getTransportSocketFactoryContext, (),
-              (const, override));
   MOCK_METHOD(Http::Context&, httpContext, ());
   MOCK_METHOD(Grpc::Context&, grpcContext, ());
   MOCK_METHOD(Router::Context&, routerContext, ());

--- a/test/server/admin/admin_factory_context_test.cc
+++ b/test/server/admin/admin_factory_context_test.cc
@@ -16,7 +16,6 @@ TEST(AdminFactoryContextTest, AdminFactoryContextTest) {
   AdminFactoryContext context(server, listener_info);
 
   context.serverFactoryContext();
-  context.getTransportSocketFactoryContext();
   context.scope();
   context.listenerScope();
   context.listenerInfo().isQuic();


### PR DESCRIPTION
Commit Message: remove senseless getTransportSocketFactoryContext
Additional Description:

The getTransportSocketFactoryContext actually make no sense because it always return the one in the server.

See [#26476](https://github.com/envoyproxy/envoy/issues/26476)

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
