### PR TITLE
message visitor: use dynamic visitor after main loop started

### DIFF
--- a/envoy/server/instance.h
+++ b/envoy/server/instance.h
@@ -261,6 +261,12 @@ public:
   virtual ProtobufMessage::ValidationContext& messageValidationContext() PURE;
 
   /**
+   * @return ProtobufMessage::ValidationVistior& validation visitor for configuration
+   *         messages.
+   */
+  virtual ProtobufMessage::ValidationVisitor& messageValidationVisitor() PURE;
+
+  /**
    * @return const StatsConfig& the configuration of server stats.
    */
   virtual Configuration::StatsConfig& statsConfig() PURE;

--- a/source/server/config_validation/server.h
+++ b/source/server/config_validation/server.h
@@ -121,6 +121,9 @@ public:
   ProtobufMessage::ValidationContext& messageValidationContext() override {
     return validation_context_;
   }
+  ProtobufMessage::ValidationVisitor& messageValidationVisitor() override {
+    return validation_context_.staticValidationVisitor();
+  }
   bool enableReusePortDefault() override { return true; }
 
   Configuration::StatsConfig& statsConfig() override { return config_.statsConfig(); }

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -1015,6 +1015,9 @@ void InstanceBase::run() {
     watchdog = main_thread_guard_dog_->createWatchDog(api_->threadFactory().currentThreadId(),
                                                       "main_thread", *dispatcher_);
   }
+
+  main_dispatch_loop_started_.store(true);
+
   dispatcher_->post([this] { notifyCallbacksForStage(Stage::Startup); });
   dispatcher_->run(Event::Dispatcher::RunType::Block);
   ENVOY_LOG(info, "main dispatch loop exited");

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -220,14 +220,7 @@ public:
   Stats::Scope& statsScope() override { return *server_scope_; }
   Init::Manager& initManager() override { return server_.initManager(); }
   ProtobufMessage::ValidationVisitor& messageValidationVisitor() override {
-    // Server has two message validation visitors, one for static and
-    // other for dynamic configuration. Choose the dynamic validation
-    // visitor if server's init manager indicates that the server is
-    // in the Initialized state, as this state is engaged right after
-    // the static configuration (e.g., bootstrap) has been completed.
-    return initManager().state() == Init::Manager::State::Initialized
-               ? server_.messageValidationContext().dynamicValidationVisitor()
-               : server_.messageValidationContext().staticValidationVisitor();
+    return server_.messageValidationVisitor();
   }
 
 private:
@@ -321,6 +314,14 @@ public:
   ProtobufMessage::ValidationContext& messageValidationContext() override {
     return validation_context_;
   }
+  ProtobufMessage::ValidationVisitor& messageValidationVisitor() override {
+    // Server has two message validation visitors, one for static and
+    // other for dynamic configuration. Choose the dynamic validation
+    // visitor if server main dispatch loop started, as if all configuration
+    // after main dispatch loop started should be dynamic.
+    return main_dispatch_loop_started_.load() ? validation_context_.dynamicValidationVisitor()
+                                              : validation_context_.staticValidationVisitor();
+  }
   void setDefaultTracingConfig(const envoy::config::trace::v3::Tracing& tracing_config) override {
     http_context_.setDefaultTracingConfig(tracing_config);
   }
@@ -375,6 +376,7 @@ private:
   bool shutdown_{false};
   const Options& options_;
   ProtobufMessage::ProdValidationContextImpl validation_context_;
+  std::atomic<bool> main_dispatch_loop_started_{false};
   TimeSource& time_source_;
   // Delete local_info_ as late as possible as some members below may reference it during their
   // destruction.

--- a/test/mocks/server/instance.cc
+++ b/test/mocks/server/instance.cc
@@ -51,6 +51,8 @@ MockInstance::MockInstance()
   ON_CALL(*this, overloadManager()).WillByDefault(ReturnRef(overload_manager_));
   ON_CALL(*this, nullOverloadManager()).WillByDefault(ReturnRef(null_overload_manager_));
   ON_CALL(*this, messageValidationContext()).WillByDefault(ReturnRef(validation_context_));
+  ON_CALL(*this, messageValidationVisitor())
+      .WillByDefault(ReturnRef(validation_context_.static_validation_visitor_));
   ON_CALL(*this, statsConfig()).WillByDefault(ReturnRef(*stats_config_));
   ON_CALL(*this, regexEngine()).WillByDefault(ReturnRef(regex_engine_));
   ON_CALL(*this, serverFactoryContext()).WillByDefault(ReturnRef(*server_factory_context_));

--- a/test/mocks/server/instance.h
+++ b/test/mocks/server/instance.h
@@ -60,6 +60,7 @@ public:
   MOCK_METHOD(Regex::Engine&, regexEngine, ());
   MOCK_METHOD(void, flushStats, ());
   MOCK_METHOD(ProtobufMessage::ValidationContext&, messageValidationContext, ());
+  MOCK_METHOD(ProtobufMessage::ValidationVisitor&, messageValidationVisitor, ());
   MOCK_METHOD(Configuration::ServerFactoryContext&, serverFactoryContext, ());
   MOCK_METHOD(Configuration::TransportSocketFactoryContext&, transportSocketFactoryContext, ());
   MOCK_METHOD(bool, enableReusePortDefault, ());


### PR DESCRIPTION
Commit Message: message visitor: use dynamic visitor after main loop started
Additional Description:

To close [#31073](https://github.com/envoyproxy/envoy/issues/31073).

The Envoy has two different proto message visitors: static visitor for static configuration and dynamic visitor for dynamic configuration. By default, the only difference is that the static message visitor will reject unknown fields.

The ServerFactoryContext will provide dynamic visitor after the server is initialized.
And the FactoryContext and ClusterFactoryContext will provide dynamic visitor if the related listeners/clusters are added by the xDS API.

The visitor should be selected depends on the scope of xDS configuration. For example, embedded route config should use the visitor provided by the FactoryContext (The value of `FactoryContext.messageValidationVistior()` depends if the listener is static listener or dynamic listener) and dynamic route config should always used dynamic visitor.

But as I said in the #31073, there are lots of misuse and actually it's hard for most developers to understand the subtle difference between the `ServerFactoryContext.messageValidationVistior()` and `FactoryContext.messageValidationVistior()`  or `ClusterFactoryContext.messageValidationVistior()`. (At the short time before the server is initialized, the visitor of listeners/clusters that added by LDS/CDS will different with the visitor of server. :( )

This PR make a minor change to the ServerFactoryContext to let it return dynamic visitor if the main dispatch loop started.

Risk Level: mid, core code change.
Testing: n/a.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.