### PR TITLE
docs: remove incorrect docs about static clusters not being able to be EDS

### DIFF
--- a/api/envoy/config/bootstrap/v3/bootstrap.proto
+++ b/api/envoy/config/bootstrap/v3/bootstrap.proto
@@ -57,9 +57,7 @@ message Bootstrap {
     // If a network based configuration source is specified for :ref:`cds_config
     // <envoy_v3_api_field_config.bootstrap.v3.Bootstrap.DynamicResources.cds_config>`, it's necessary
     // to have some initial cluster definitions available to allow Envoy to know
-    // how to speak to the management server. These cluster definitions may not
-    // use :ref:`EDS <arch_overview_dynamic_config_eds>` (i.e. they should be static
-    // IP or DNS-based).
+    // how to speak to the management server.
     repeated cluster.v3.Cluster clusters = 2;
 
     // These static secrets can be used by :ref:`SdsSecretConfig


### PR DESCRIPTION
The deleted sentence is not correct in that you can at least use an EDS cluster that matches `cluster_manager.local_cluster_name`. We are running Envoy in such a configuration. See [this
comment](https://github.com/envoyproxy/envoy/issues/37867#issuecomment-2773064429) for details.