### PR TITLE
listener_impl: preparation for inconsistent config and hash

### DIFF
--- a/source/common/listener_manager/filter_chain_manager_impl.h
+++ b/source/common/listener_manager/filter_chain_manager_impl.h
@@ -169,6 +169,9 @@ public:
   const Network::DrainableFilterChainSharedPtr& defaultFilterChain() const {
     return default_filter_chain_;
   }
+  void dumpFcdsFilterChains(envoy::config::listener::v3::Listener&) const {
+    IS_ENVOY_BUG("Unexpected function call: FCDS is not implemented");
+  }
 
 private:
   absl::Status convertIPsToTries();

--- a/source/common/listener_manager/listener_impl.cc
+++ b/source/common/listener_manager/listener_impl.cc
@@ -70,6 +70,7 @@ bool shouldBindToPort(const envoy::config::listener::v3::Listener& config) {
   return PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, bind_to_port, true) &&
          PROTOBUF_GET_WRAPPED_OR_DEFAULT(config.deprecated_v1(), bind_to_port, true);
 }
+
 } // namespace
 
 absl::StatusOr<std::unique_ptr<ListenSocketFactoryImpl>> ListenSocketFactoryImpl::create(
@@ -295,7 +296,7 @@ ListenerImpl::ListenerImpl(const envoy::config::listener::v3::Listener& config,
       per_connection_buffer_limit_bytes_(
           PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, per_connection_buffer_limit_bytes, 1024 * 1024)),
       listener_tag_(parent_.factory_->nextListenerTag()), name_(name),
-      added_via_api_(added_via_api), workers_started_(workers_started), hash_(hash),
+      added_via_api_(added_via_api), workers_started_(workers_started), maybe_stale_hash_(hash),
       tcp_backlog_size_(
           PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, tcp_backlog_size, ENVOY_TCP_BACKLOG_SIZE)),
       max_connections_to_accept_per_socket_event_(
@@ -310,7 +311,7 @@ ListenerImpl::ListenerImpl(const envoy::config::listener::v3::Listener& config,
                             [this]() { dynamic_init_manager_->initialize(local_init_watcher_); }),
       dynamic_init_manager_(std::make_unique<Init::ManagerImpl>(
           fmt::format("Listener-local-init-manager {} {}", name, hash))),
-      config_(config), version_info_(version_info),
+      config_maybe_partial_filter_chains_(config), version_info_(version_info),
       listener_filters_timeout_(
           PROTOBUF_GET_MS_OR_DEFAULT(config, listener_filters_timeout, 15000)),
       continue_on_listener_filters_timeout_(config.continue_on_listener_filters_timeout()),
@@ -433,7 +434,7 @@ ListenerImpl::ListenerImpl(ListenerImpl& origin,
       per_connection_buffer_limit_bytes_(
           PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, per_connection_buffer_limit_bytes, 1024 * 1024)),
       listener_tag_(origin.listener_tag_), name_(name), added_via_api_(added_via_api),
-      workers_started_(workers_started), hash_(hash),
+      workers_started_(workers_started), maybe_stale_hash_(hash),
       tcp_backlog_size_(
           PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, tcp_backlog_size, ENVOY_TCP_BACKLOG_SIZE)),
       max_connections_to_accept_per_socket_event_(
@@ -448,7 +449,7 @@ ListenerImpl::ListenerImpl(ListenerImpl& origin,
       listener_init_target_("", nullptr),
       dynamic_init_manager_(std::make_unique<Init::ManagerImpl>(
           fmt::format("Listener-local-init-manager {} {}", name, hash))),
-      config_(config), version_info_(version_info),
+      config_maybe_partial_filter_chains_(config), version_info_(version_info),
       listen_socket_options_list_(origin.listen_socket_options_list_),
       listener_filters_timeout_(
           PROTOBUF_GET_MS_OR_DEFAULT(config, listener_filters_timeout, 15000)),
@@ -978,9 +979,23 @@ bool ListenerImpl::createQuicListenerFilterChain(Network::QuicListenerFilterMana
   return false;
 }
 
+void ListenerImpl::dumpConfig(ProtobufWkt::Any& dump) const {
+  if (!configInternal().has_fcds_config()) {
+    // If FCDS is not used, the config is expected to have the full filter chain list.
+    dump.PackFrom(config_maybe_partial_filter_chains_);
+    return;
+  }
+
+  envoy::config::listener::v3::Listener config(config_maybe_partial_filter_chains_);
+  // If FCDS is used, the filter chain manager is expected to have the full filter chain list.
+  filter_chain_manager_->dumpFcdsFilterChains(config);
+  dump.PackFrom(config);
+}
+
 void ListenerImpl::debugLog(const std::string& message) {
   UNREFERENCED_PARAMETER(message);
-  ENVOY_LOG(debug, "{}: name={}, hash={}, tag={}, address={}", message, name_, hash_, listener_tag_,
+  ENVOY_LOG(debug, "{}: name={}, original_hash={}, tag={}, address={}", message, name_,
+            maybe_stale_hash_, listener_tag_,
             absl::StrJoin(addresses_, ",", Network::AddressStrFormatter()));
 }
 
@@ -1008,7 +1023,7 @@ ListenerImpl::~ListenerImpl() {
 Init::Manager& ListenerImpl::initManager() { return *dynamic_init_manager_; }
 
 absl::Status ListenerImpl::addSocketFactory(Network::ListenSocketFactoryPtr&& socket_factory) {
-  RETURN_IF_NOT_OK(buildConnectionBalancer(config(), *socket_factory->localAddress()));
+  RETURN_IF_NOT_OK(buildConnectionBalancer(configInternal(), *socket_factory->localAddress()));
   if (buildUdpListenerWorkerRouter(*socket_factory->localAddress(),
                                    parent_.server_.options().concurrency())) {
     parent_.server_.hotRestart().registerUdpForwardingListener(socket_factory->localAddress(),
@@ -1026,6 +1041,12 @@ bool ListenerImpl::supportUpdateFilterChain(const envoy::config::listener::v3::L
     return false;
   }
 
+  // If FCDS is used, LDS updates will cause full listener update. It's expected that if FCDS is
+  // used, dynamic filter chain updates will be applied using FCDS rather than LDS.
+  if (configInternal().has_fcds_config()) {
+    return false;
+  }
+
   // Full listener update currently rejects tcp listener having 0 filter chain.
   // In place filter chain update could survive under zero filter chain but we should keep the
   // same behavior for now. This also guards the below filter chain access.
@@ -1034,11 +1055,11 @@ bool ListenerImpl::supportUpdateFilterChain(const envoy::config::listener::v3::L
   }
 
   // See buildProxyProtocolListenerFilter().
-  if (usesProxyProto(config()) ^ usesProxyProto(new_config)) {
+  if (usesProxyProto(configInternal()) ^ usesProxyProto(new_config)) {
     return false;
   }
 
-  if (ListenerMessageUtil::filterChainOnlyChange(config(), new_config)) {
+  if (ListenerMessageUtil::filterChainOnlyChange(configInternal(), new_config)) {
     // We need to calculate the reuse port's default value then ensure whether it is changed or not.
     // Since reuse port's default value isn't the YAML bool field default value. When
     // `enable_reuse_port` is specified, `ListenerMessageUtil::filterChainOnlyChange` use the YAML
@@ -1151,7 +1172,7 @@ bool ListenerImpl::hasCompatibleAddress(const ListenerImpl& other) const {
   }
 
   // Third, check if the listener has the same socket options.
-  return ListenerMessageUtil::socketOptionsEqual(config(), other.config());
+  return ListenerMessageUtil::socketOptionsEqual(configInternal(), other.configInternal());
 }
 
 bool ListenerImpl::hasDuplicatedAddress(const ListenerImpl& other) const {

--- a/source/common/listener_manager/listener_impl.h
+++ b/source/common/listener_manager/listener_impl.h
@@ -244,17 +244,23 @@ public:
   /**
    * Helper functions to determine whether a listener is blocked for update or remove.
    */
-  bool blockUpdate(uint64_t new_hash) { return new_hash == hash_ || !added_via_api_; }
+  bool blockLdsUpdate(uint64_t new_hash) {
+    // Receiving LDS update with FCDS config will cause full listener update. Therefore,
+    // we should not block the update if FCDS is configured, regardless of the hash.
+    return (!configInternal().has_fcds_config() && new_hash == maybe_stale_hash_) ||
+           !added_via_api_;
+  }
   bool blockRemove() { return !added_via_api_; }
 
   const std::vector<Network::Address::InstanceConstSharedPtr>& addresses() const {
     return addresses_;
   }
-  const envoy::config::listener::v3::Listener& config() const { return config_; }
+  const std::string& configName() const { return configInternal().name(); }
   const std::vector<Network::ListenSocketFactoryPtr>& getSocketFactories() const {
     return socket_factories_;
   }
   void debugLog(const std::string& message);
+  void dumpConfig(ProtobufWkt::Any& dump) const;
   void initialize();
   DrainManager& localDrainManager() const {
     return listener_factory_context_->listener_factory_context_base_->drainManager();
@@ -421,6 +427,12 @@ private:
     ensureSocketOptions(options);
     Network::Socket::appendOptions(options, append_options);
   }
+  // configInternal returns the listener config. If FCDS is enabled, the config filter chain
+  // is expected to be partial and only contain filter chains added statically or with LDS.
+  // If FCDS is enabled, avoid using the config object for decisions based on filter chains.
+  const envoy::config::listener::v3::Listener& configInternal() const {
+    return config_maybe_partial_filter_chains_;
+  }
 
   ListenerManagerImpl& parent_;
   std::vector<Network::Address::InstanceConstSharedPtr> addresses_;
@@ -435,7 +447,11 @@ private:
   const std::string name_;
   const bool added_via_api_;
   const bool workers_started_;
-  const uint64_t hash_;
+  // Note: when FCDS is enabled and filter chains change, the stored hash may become stale.
+  // We deliberately skip recomputing it for performance, since the hash is only used
+  // to decide on in-place LDS updates, and when FCDS is configured, LDS update force a full
+  // listener update anyway.
+  const uint64_t maybe_stale_hash_;
   const uint32_t tcp_backlog_size_;
   const uint32_t max_connections_to_accept_per_socket_event_;
   ProtobufMessage::ValidationVisitor& validation_visitor_;
@@ -452,7 +468,10 @@ private:
   std::vector<Network::UdpListenerFilterFactoryCb> udp_listener_filter_factories_;
   Filter::QuicListenerFilterFactoriesList quic_listener_filter_factories_;
   AccessLog::InstanceSharedPtrVector access_logs_;
-  const envoy::config::listener::v3::Listener config_;
+  // When FCDS is enabled for the listener, config_maybe_partial_filter_chains_ is inconsistent with
+  // the state of filter chains, as these can change during the lifetime of the listener. Keeping
+  // the config object consistent for every FCDS update has significant performance penalty.
+  const envoy::config::listener::v3::Listener config_maybe_partial_filter_chains_;
   const std::string version_info_;
   // Using std::vector instead of hash map for supporting multiple zero port addresses.
   std::vector<Network::Socket::OptionsSharedPtr> listen_socket_options_list_;


### PR DESCRIPTION
Additional Description: Early refactor to support #39141. When using FCDS, the ``config_`` object that ``ListenerImpl`` contains may become stale, as it only has the filter chains added statically or using LDS. This PR makes small refactor and renaming to indicate that the ``config_`` object may become stale. Additionally, this PR removes the ``config()`` method of ``ListenerImpl`` as whoever uses this may not know the state of the config.

Risk Level: low
Testing: none
Docs Changes: none
Release Notes: none
Platform Specific Features: none