### PR TITLE
use server factory context as priority

### DIFF
--- a/contrib/golang/filters/http/source/golang_filter.cc
+++ b/contrib/golang/filters/http/source/golang_filter.cc
@@ -595,7 +595,7 @@ CAPIStatus Filter::injectData(ProcessorState& state, absl::string_view data) {
     if (!weak_ptr.expired() && !hasDestroyed()) {
       ENVOY_LOG(debug, "golang filter inject data to filter chain, length: {}",
                 data_to_write->length());
-      state.injectDataToFilterChain(*data_to_write.get(), false);
+      state.injectDataToFilterChain(*data_to_write, false);
     } else {
       ENVOY_LOG(debug, "golang filter has gone or destroyed in injectData event");
     }
@@ -1784,14 +1784,13 @@ uint64_t RoutePluginConfig::getMergedConfigId(uint64_t parent_id) {
 namespace {
 Secret::GenericSecretConfigProviderSharedPtr
 secretsProvider(const envoy::extensions::transport_sockets::tls::v3::SdsSecretConfig& config,
-                Secret::SecretManager& secret_manager,
-                Server::Configuration::TransportSocketFactoryContext& transport_socket_factory,
+                Server::Configuration::ServerFactoryContext& server_context,
                 Init::Manager& init_manager) {
   if (config.has_sds_config()) {
-    return secret_manager.findOrCreateGenericSecretProvider(config.sds_config(), config.name(),
-                                                            transport_socket_factory, init_manager);
+    return server_context.secretManager().findOrCreateGenericSecretProvider(
+        config.sds_config(), config.name(), server_context, init_manager);
   } else {
-    return secret_manager.findStaticGenericSecretProvider(config.name());
+    return server_context.secretManager().findStaticGenericSecretProvider(config.name());
   }
 }
 } // namespace
@@ -1800,19 +1799,16 @@ SecretReader::SecretReader(
     const envoy::extensions::filters::http::golang::v3alpha::Config& proto_config,
     Server::Configuration::FactoryContext& context) {
   if (proto_config.generic_secrets_size() > 0) {
-    auto& secret_manager =
-        context.serverFactoryContext().clusterManager().clusterManagerFactory().secretManager();
-    auto& transport_socket_factory = context.getTransportSocketFactoryContext();
+    auto& server_context = context.serverFactoryContext();
     auto& init_manager = context.initManager();
-    auto& tls = context.serverFactoryContext().threadLocal();
-    auto& api = context.serverFactoryContext().api();
+    auto& tls = server_context.threadLocal();
+    auto& api = server_context.api();
     for (auto& secret : proto_config.generic_secrets()) {
       // Check here to avoid creating unecessary sds provider
       if (secrets_.contains(secret.name())) {
         throw EnvoyException(absl::StrCat("duplicate secret ", secret.name()));
       }
-      auto secret_provider =
-          secretsProvider(secret, secret_manager, transport_socket_factory, init_manager);
+      auto secret_provider = secretsProvider(secret, server_context, init_manager);
       if (secret_provider == nullptr) {
         throw EnvoyException(absl::StrCat("no secret provider found for ", secret.name()));
       }

--- a/contrib/golang/filters/http/test/config_test.cc
+++ b/contrib/golang/filters/http/test/config_test.cc
@@ -175,8 +175,10 @@ TEST(GolangFilterConfigTest, GolangFilterWithDuplicateSecret) {
   envoy::extensions::filters::http::golang::v3alpha::Config proto_config;
   TestUtility::loadFromYaml(yaml_string, proto_config);
   NiceMock<Server::Configuration::MockFactoryContext> context;
-  auto& secret_manager =
-      context.server_factory_context_.cluster_manager_.cluster_manager_factory_.secretManager();
+
+  NiceMock<Secret::MockSecretManager> secret_manager;
+  ON_CALL(context.server_factory_context_, secretManager())
+      .WillByDefault(ReturnRef(secret_manager));
   ON_CALL(secret_manager, findStaticGenericSecretProvider(_))
       .WillByDefault(testing::Return(std::make_shared<Secret::GenericSecretConfigProviderImpl>(
           envoy::extensions::transport_sockets::tls::v3::GenericSecret())));

--- a/contrib/sxg/filters/http/source/config.cc
+++ b/contrib/sxg/filters/http/source/config.cc
@@ -22,14 +22,13 @@ namespace SXG {
 namespace {
 Secret::GenericSecretConfigProviderSharedPtr
 secretsProvider(const envoy::extensions::transport_sockets::tls::v3::SdsSecretConfig& config,
-                Secret::SecretManager& secret_manager,
-                Server::Configuration::TransportSocketFactoryContext& transport_socket_factory,
+                Server::Configuration::ServerFactoryContext& server_context,
                 Init::Manager& init_manager) {
   if (config.has_sds_config()) {
-    return secret_manager.findOrCreateGenericSecretProvider(config.sds_config(), config.name(),
-                                                            transport_socket_factory, init_manager);
+    return server_context.secretManager().findOrCreateGenericSecretProvider(
+        config.sds_config(), config.name(), server_context, init_manager);
   } else {
-    return secret_manager.findStaticGenericSecretProvider(config.name());
+    return server_context.secretManager().findStaticGenericSecretProvider(config.name());
   }
 }
 } // namespace
@@ -42,16 +41,13 @@ Http::FilterFactoryCb FilterFactory::createFilterFactoryFromProtoTyped(
 
   auto& server_context = context.serverFactoryContext();
 
-  auto& cluster_manager = server_context.clusterManager();
-  auto& secret_manager = cluster_manager.clusterManagerFactory().secretManager();
-  auto& transport_socket_factory = context.getTransportSocketFactoryContext();
   auto secret_provider_certificate =
-      secretsProvider(certificate, secret_manager, transport_socket_factory, context.initManager());
+      secretsProvider(certificate, server_context, context.initManager());
   if (secret_provider_certificate == nullptr) {
     throw EnvoyException("invalid certificate secret configuration");
   }
   auto secret_provider_private_key =
-      secretsProvider(private_key, secret_manager, transport_socket_factory, context.initManager());
+      secretsProvider(private_key, server_context, context.initManager());
   if (secret_provider_private_key == nullptr) {
     throw EnvoyException("invalid private_key secret configuration");
   }

--- a/contrib/sxg/filters/http/test/filter_test.cc
+++ b/contrib/sxg/filters/http/test/filter_test.cc
@@ -374,11 +374,11 @@ TEST_F(FilterTest, SdsDynamicGenericSecret) {
       }));
 
   auto certificate_secret_provider = secret_manager.findOrCreateGenericSecretProvider(
-      config_source, "certificate", secret_context, init_manager);
+      config_source, "certificate", secret_context.server_context_, init_manager);
   auto certificate_callback =
       secret_context.server_context_.cluster_manager_.subscription_factory_.callbacks_;
   auto private_key_secret_provider = secret_manager.findOrCreateGenericSecretProvider(
-      config_source, "private_key", secret_context, init_manager);
+      config_source, "private_key", secret_context.server_context_, init_manager);
   auto private_key_callback =
       secret_context.server_context_.cluster_manager_.subscription_factory_.callbacks_;
 

--- a/envoy/secret/secret_manager.h
+++ b/envoy/secret/secret_manager.h
@@ -10,8 +10,7 @@ namespace Envoy {
 
 namespace Server {
 namespace Configuration {
-class GenericFactoryContext;
-using TransportSocketFactoryContext = GenericFactoryContext;
+class ServerFactoryContext;
 } // namespace Configuration
 } // namespace Server
 
@@ -106,10 +105,11 @@ public:
    * secret provider.
    * @return TlsCertificateConfigProviderSharedPtr the dynamic TLS secret provider.
    */
-  virtual TlsCertificateConfigProviderSharedPtr findOrCreateTlsCertificateProvider(
-      const envoy::config::core::v3::ConfigSource& config_source, const std::string& config_name,
-      Server::Configuration::TransportSocketFactoryContext& secret_provider_context,
-      Init::Manager& init_manager) PURE;
+  virtual TlsCertificateConfigProviderSharedPtr
+  findOrCreateTlsCertificateProvider(const envoy::config::core::v3::ConfigSource& config_source,
+                                     const std::string& config_name,
+                                     Server::Configuration::ServerFactoryContext& server_context,
+                                     Init::Manager& init_manager) PURE;
 
   /**
    * Finds and returns a dynamic secret provider associated to SDS config. Create
@@ -125,7 +125,7 @@ public:
   virtual CertificateValidationContextConfigProviderSharedPtr
   findOrCreateCertificateValidationContextProvider(
       const envoy::config::core::v3::ConfigSource& config_source, const std::string& config_name,
-      Server::Configuration::TransportSocketFactoryContext& secret_provider_context,
+      Server::Configuration::ServerFactoryContext& server_context,
       Init::Manager& init_manager) PURE;
 
   /**
@@ -142,7 +142,7 @@ public:
   virtual TlsSessionTicketKeysConfigProviderSharedPtr
   findOrCreateTlsSessionTicketKeysContextProvider(
       const envoy::config::core::v3::ConfigSource& config_source, const std::string& config_name,
-      Server::Configuration::TransportSocketFactoryContext& secret_provider_context,
+      Server::Configuration::ServerFactoryContext& server_context,
       Init::Manager& init_manager) PURE;
 
   /**
@@ -155,10 +155,11 @@ public:
    * secret provider.
    * @return GenericSecretConfigProviderSharedPtr the dynamic generic secret provider.
    */
-  virtual GenericSecretConfigProviderSharedPtr findOrCreateGenericSecretProvider(
-      const envoy::config::core::v3::ConfigSource& config_source, const std::string& config_name,
-      Server::Configuration::TransportSocketFactoryContext& secret_provider_context,
-      Init::Manager& init_manager) PURE;
+  virtual GenericSecretConfigProviderSharedPtr
+  findOrCreateGenericSecretProvider(const envoy::config::core::v3::ConfigSource& config_source,
+                                    const std::string& config_name,
+                                    Server::Configuration::ServerFactoryContext& server_context,
+                                    Init::Manager& init_manager) PURE;
 };
 
 using SecretManagerPtr = std::unique_ptr<SecretManager>;

--- a/source/common/secret/sds_api.cc
+++ b/source/common/secret/sds_api.cc
@@ -223,20 +223,20 @@ uint64_t SdsApi::getHashForFiles(const FileContentMap& files) {
   return hash;
 }
 
-TlsCertificateSdsApiSharedPtr TlsCertificateSdsApi::create(
-    Server::Configuration::TransportSocketFactoryContext& secret_provider_context,
-    const envoy::config::core::v3::ConfigSource& sds_config, const std::string& sds_config_name,
-    std::function<void()> destructor_cb) {
+TlsCertificateSdsApiSharedPtr
+TlsCertificateSdsApi::create(Server::Configuration::ServerFactoryContext& server_context,
+                             const envoy::config::core::v3::ConfigSource& sds_config,
+                             const std::string& sds_config_name,
+                             std::function<void()> destructor_cb) {
   // We need to do this early as we invoke the subscription factory during initialization, which
   // is too late to throw.
-  auto& server_context = secret_provider_context.serverFactoryContext();
   THROW_IF_NOT_OK(
       Config::Utility::checkLocalInfo("TlsCertificateSdsApi", server_context.localInfo()));
   return std::make_shared<TlsCertificateSdsApi>(
       sds_config, sds_config_name, server_context.clusterManager().subscriptionFactory(),
-      server_context.mainThreadDispatcher().timeSource(),
-      secret_provider_context.messageValidationVisitor(), server_context.serverScope().store(),
-      destructor_cb, server_context.mainThreadDispatcher(), server_context.api());
+      server_context.mainThreadDispatcher().timeSource(), server_context.messageValidationVisitor(),
+      server_context.serverScope().store(), destructor_cb, server_context.mainThreadDispatcher(),
+      server_context.api());
 }
 
 ABSL_MUST_USE_RESULT Common::CallbackHandlePtr
@@ -289,19 +289,18 @@ void TlsCertificateSdsApi::resolveSecret(const FileContentMap& files) {
 }
 
 CertificateValidationContextSdsApiSharedPtr CertificateValidationContextSdsApi::create(
-    Server::Configuration::TransportSocketFactoryContext& secret_provider_context,
+    Server::Configuration::ServerFactoryContext& server_context,
     const envoy::config::core::v3::ConfigSource& sds_config, const std::string& sds_config_name,
     std::function<void()> destructor_cb) {
   // We need to do this early as we invoke the subscription factory during initialization, which
   // is too late to throw.
-  auto& server_context = secret_provider_context.serverFactoryContext();
   THROW_IF_NOT_OK(Config::Utility::checkLocalInfo("CertificateValidationContextSdsApi",
                                                   server_context.localInfo()));
   return std::make_shared<CertificateValidationContextSdsApi>(
       sds_config, sds_config_name, server_context.clusterManager().subscriptionFactory(),
-      server_context.mainThreadDispatcher().timeSource(),
-      secret_provider_context.messageValidationVisitor(), server_context.serverScope().store(),
-      destructor_cb, server_context.mainThreadDispatcher(), server_context.api());
+      server_context.mainThreadDispatcher().timeSource(), server_context.messageValidationVisitor(),
+      server_context.serverScope().store(), destructor_cb, server_context.mainThreadDispatcher(),
+      server_context.api());
 }
 
 ABSL_MUST_USE_RESULT Common::CallbackHandlePtr
@@ -362,20 +361,20 @@ std::vector<std::string> CertificateValidationContextSdsApi::getDataSourceFilena
   return files;
 }
 
-TlsSessionTicketKeysSdsApiSharedPtr TlsSessionTicketKeysSdsApi::create(
-    Server::Configuration::TransportSocketFactoryContext& secret_provider_context,
-    const envoy::config::core::v3::ConfigSource& sds_config, const std::string& sds_config_name,
-    std::function<void()> destructor_cb) {
+TlsSessionTicketKeysSdsApiSharedPtr
+TlsSessionTicketKeysSdsApi::create(Server::Configuration::ServerFactoryContext& server_context,
+                                   const envoy::config::core::v3::ConfigSource& sds_config,
+                                   const std::string& sds_config_name,
+                                   std::function<void()> destructor_cb) {
   // We need to do this early as we invoke the subscription factory during initialization, which
   // is too late to throw.
-  auto& server_context = secret_provider_context.serverFactoryContext();
   THROW_IF_NOT_OK(
       Config::Utility::checkLocalInfo("TlsSessionTicketKeysSdsApi", server_context.localInfo()));
   return std::make_shared<TlsSessionTicketKeysSdsApi>(
       sds_config, sds_config_name, server_context.clusterManager().subscriptionFactory(),
-      server_context.mainThreadDispatcher().timeSource(),
-      secret_provider_context.messageValidationVisitor(), server_context.serverScope().store(),
-      destructor_cb, server_context.mainThreadDispatcher(), server_context.api());
+      server_context.mainThreadDispatcher().timeSource(), server_context.messageValidationVisitor(),
+      server_context.serverScope().store(), destructor_cb, server_context.mainThreadDispatcher(),
+      server_context.api());
 }
 
 ABSL_MUST_USE_RESULT Common::CallbackHandlePtr
@@ -400,20 +399,20 @@ void TlsSessionTicketKeysSdsApi::validateConfig(
 
 std::vector<std::string> TlsSessionTicketKeysSdsApi::getDataSourceFilenames() { return {}; }
 
-GenericSecretSdsApiSharedPtr GenericSecretSdsApi::create(
-    Server::Configuration::TransportSocketFactoryContext& secret_provider_context,
-    const envoy::config::core::v3::ConfigSource& sds_config, const std::string& sds_config_name,
-    std::function<void()> destructor_cb) {
+GenericSecretSdsApiSharedPtr
+GenericSecretSdsApi::create(Server::Configuration::ServerFactoryContext& server_context,
+                            const envoy::config::core::v3::ConfigSource& sds_config,
+                            const std::string& sds_config_name,
+                            std::function<void()> destructor_cb) {
   // We need to do this early as we invoke the subscription factory during initialization, which
   // is too late to throw.
-  auto& server_context = secret_provider_context.serverFactoryContext();
   THROW_IF_NOT_OK(
       Config::Utility::checkLocalInfo("GenericSecretSdsApi", server_context.localInfo()));
   return std::make_shared<GenericSecretSdsApi>(
       sds_config, sds_config_name, server_context.clusterManager().subscriptionFactory(),
-      server_context.mainThreadDispatcher().timeSource(),
-      secret_provider_context.messageValidationVisitor(), server_context.serverScope().store(),
-      destructor_cb, server_context.mainThreadDispatcher(), server_context.api());
+      server_context.mainThreadDispatcher().timeSource(), server_context.messageValidationVisitor(),
+      server_context.serverScope().store(), destructor_cb, server_context.mainThreadDispatcher(),
+      server_context.api());
 }
 
 void GenericSecretSdsApi::validateConfig(

--- a/source/common/secret/sds_api.h
+++ b/source/common/secret/sds_api.h
@@ -133,7 +133,7 @@ using GenericSecretSdsApiSharedPtr = std::shared_ptr<GenericSecretSdsApi>;
 class TlsCertificateSdsApi : public SdsApi, public TlsCertificateConfigProvider {
 public:
   static TlsCertificateSdsApiSharedPtr
-  create(Server::Configuration::TransportSocketFactoryContext& secret_provider_context,
+  create(Server::Configuration::ServerFactoryContext& server_context,
          const envoy::config::core::v3::ConfigSource& sds_config,
          const std::string& sds_config_name, std::function<void()> destructor_cb);
 
@@ -184,7 +184,7 @@ class CertificateValidationContextSdsApi : public SdsApi,
                                            public CertificateValidationContextConfigProvider {
 public:
   static CertificateValidationContextSdsApiSharedPtr
-  create(Server::Configuration::TransportSocketFactoryContext& secret_provider_context,
+  create(Server::Configuration::ServerFactoryContext& server_context,
          const envoy::config::core::v3::ConfigSource& sds_config,
          const std::string& sds_config_name, std::function<void()> destructor_cb);
   CertificateValidationContextSdsApi(const envoy::config::core::v3::ConfigSource& sds_config,
@@ -240,7 +240,7 @@ private:
 class TlsSessionTicketKeysSdsApi : public SdsApi, public TlsSessionTicketKeysConfigProvider {
 public:
   static TlsSessionTicketKeysSdsApiSharedPtr
-  create(Server::Configuration::TransportSocketFactoryContext& secret_provider_context,
+  create(Server::Configuration::ServerFactoryContext& server_context,
          const envoy::config::core::v3::ConfigSource& sds_config,
          const std::string& sds_config_name, std::function<void()> destructor_cb);
 
@@ -292,7 +292,7 @@ private:
 class GenericSecretSdsApi : public SdsApi, public GenericSecretConfigProvider {
 public:
   static GenericSecretSdsApiSharedPtr
-  create(Server::Configuration::TransportSocketFactoryContext& secret_provider_context,
+  create(Server::Configuration::ServerFactoryContext& server_context,
          const envoy::config::core::v3::ConfigSource& sds_config,
          const std::string& sds_config_name, std::function<void()> destructor_cb);
 

--- a/source/common/secret/secret_manager_impl.cc
+++ b/source/common/secret/secret_manager_impl.cc
@@ -129,36 +129,32 @@ GenericSecretConfigProviderSharedPtr SecretManagerImpl::createInlineGenericSecre
 
 TlsCertificateConfigProviderSharedPtr SecretManagerImpl::findOrCreateTlsCertificateProvider(
     const envoy::config::core::v3::ConfigSource& sds_config_source, const std::string& config_name,
-    Server::Configuration::TransportSocketFactoryContext& secret_provider_context,
-    Init::Manager& init_manager) {
-  return certificate_providers_.findOrCreate(sds_config_source, config_name,
-                                             secret_provider_context, init_manager);
+    Server::Configuration::ServerFactoryContext& server_context, Init::Manager& init_manager) {
+  return certificate_providers_.findOrCreate(sds_config_source, config_name, server_context,
+                                             init_manager);
 }
 
 CertificateValidationContextConfigProviderSharedPtr
 SecretManagerImpl::findOrCreateCertificateValidationContextProvider(
     const envoy::config::core::v3::ConfigSource& sds_config_source, const std::string& config_name,
-    Server::Configuration::TransportSocketFactoryContext& secret_provider_context,
-    Init::Manager& init_manager) {
-  return validation_context_providers_.findOrCreate(sds_config_source, config_name,
-                                                    secret_provider_context, init_manager);
+    Server::Configuration::ServerFactoryContext& server_context, Init::Manager& init_manager) {
+  return validation_context_providers_.findOrCreate(sds_config_source, config_name, server_context,
+                                                    init_manager);
 }
 
 TlsSessionTicketKeysConfigProviderSharedPtr
 SecretManagerImpl::findOrCreateTlsSessionTicketKeysContextProvider(
     const envoy::config::core::v3::ConfigSource& sds_config_source, const std::string& config_name,
-    Server::Configuration::TransportSocketFactoryContext& secret_provider_context,
-    Init::Manager& init_manager) {
-  return session_ticket_keys_providers_.findOrCreate(sds_config_source, config_name,
-                                                     secret_provider_context, init_manager);
+    Server::Configuration::ServerFactoryContext& server_context, Init::Manager& init_manager) {
+  return session_ticket_keys_providers_.findOrCreate(sds_config_source, config_name, server_context,
+                                                     init_manager);
 }
 
 GenericSecretConfigProviderSharedPtr SecretManagerImpl::findOrCreateGenericSecretProvider(
     const envoy::config::core::v3::ConfigSource& sds_config_source, const std::string& config_name,
-    Server::Configuration::TransportSocketFactoryContext& secret_provider_context,
-    Init::Manager& init_manager) {
-  return generic_secret_providers_.findOrCreate(sds_config_source, config_name,
-                                                secret_provider_context, init_manager);
+    Server::Configuration::ServerFactoryContext& server_context, Init::Manager& init_manager) {
+  return generic_secret_providers_.findOrCreate(sds_config_source, config_name, server_context,
+                                                init_manager);
 }
 
 ProtobufTypes::MessagePtr

--- a/source/common/tls/context_config_impl.cc
+++ b/source/common/tls/context_config_impl.cc
@@ -50,7 +50,8 @@ std::vector<Secret::TlsCertificateConfigProviderSharedPtr> getTlsCertificateConf
                                 .secretManager()
                                 .findOrCreateTlsCertificateProvider(
                                     sds_secret_config.sds_config(), sds_secret_config.name(),
-                                    factory_context, factory_context.initManager()));
+                                    factory_context.serverFactoryContext(),
+                                    factory_context.initManager()));
       } else {
         // Load static secret.
         auto secret_provider =
@@ -77,9 +78,9 @@ Secret::CertificateValidationContextConfigProviderSharedPtr getProviderFromSds(
     // Fetch dynamic secret.
     return factory_context.serverFactoryContext()
         .secretManager()
-        .findOrCreateCertificateValidationContextProvider(sds_secret_config.sds_config(),
-                                                          sds_secret_config.name(), factory_context,
-                                                          factory_context.initManager());
+        .findOrCreateCertificateValidationContextProvider(
+            sds_secret_config.sds_config(), sds_secret_config.name(),
+            factory_context.serverFactoryContext(), factory_context.initManager());
   } else {
     // Load static secret.
     auto secret_provider =

--- a/source/common/tls/server_context_config_impl.cc
+++ b/source/common/tls/server_context_config_impl.cc
@@ -44,8 +44,8 @@ Secret::TlsSessionTicketKeysConfigProviderSharedPtr getTlsSessionTicketKeysConfi
       return factory_context.serverFactoryContext()
           .secretManager()
           .findOrCreateTlsSessionTicketKeysContextProvider(
-              sds_secret_config.sds_config(), sds_secret_config.name(), factory_context,
-              factory_context.initManager());
+              sds_secret_config.sds_config(), sds_secret_config.name(),
+              factory_context.serverFactoryContext(), factory_context.initManager());
     } else {
       // Load static secret.
       auto secret_provider =

--- a/source/extensions/http/injected_credentials/generic/config.cc
+++ b/source/extensions/http/injected_credentials/generic/config.cc
@@ -13,14 +13,13 @@ namespace Generic {
 namespace {
 Secret::GenericSecretConfigProviderSharedPtr
 secretsProvider(const envoy::extensions::transport_sockets::tls::v3::SdsSecretConfig& config,
-                Secret::SecretManager& secret_manager,
-                Server::Configuration::TransportSocketFactoryContext& transport_socket_factory,
+                Server::Configuration::ServerFactoryContext& server_context,
                 Init::Manager& init_manager) {
   if (config.has_sds_config()) {
-    return secret_manager.findOrCreateGenericSecretProvider(config.sds_config(), config.name(),
-                                                            transport_socket_factory, init_manager);
+    return server_context.secretManager().findOrCreateGenericSecretProvider(
+        config.sds_config(), config.name(), server_context, init_manager);
   } else {
-    return secret_manager.findStaticGenericSecretProvider(config.name());
+    return server_context.secretManager().findStaticGenericSecretProvider(config.name());
   }
 }
 } // namespace
@@ -30,11 +29,8 @@ GenericCredentialInjectorFactory::createCredentialInjectorFromProtoTyped(
     const Generic& config, const std::string& /*stats_prefix*/,
     Server::Configuration::ServerFactoryContext& context, Init::Manager& init_manager) {
   const auto& credential_secret = config.credential();
-  auto& cluster_manager = context.clusterManager();
-  auto& secret_manager = cluster_manager.clusterManagerFactory().secretManager();
-  auto& transport_socket_factory = context.getTransportSocketFactoryContext();
-  auto secret_provider =
-      secretsProvider(credential_secret, secret_manager, transport_socket_factory, init_manager);
+
+  auto secret_provider = secretsProvider(credential_secret, context, init_manager);
 
   auto secret_reader = std::make_shared<const Common::SDSSecretReader>(
       std::move(secret_provider), context.threadLocal(), context.api());

--- a/source/extensions/http/injected_credentials/oauth2/config.cc
+++ b/source/extensions/http/injected_credentials/oauth2/config.cc
@@ -13,14 +13,13 @@ namespace OAuth2 {
 namespace {
 Secret::GenericSecretConfigProviderSharedPtr
 secretsProvider(const envoy::extensions::transport_sockets::tls::v3::SdsSecretConfig& config,
-                Secret::SecretManager& secret_manager,
-                Server::Configuration::TransportSocketFactoryContext& transport_socket_factory,
+                Server::Configuration::ServerFactoryContext& server_context,
                 Init::Manager& init_manager) {
   if (config.has_sds_config()) {
-    return secret_manager.findOrCreateGenericSecretProvider(config.sds_config(), config.name(),
-                                                            transport_socket_factory, init_manager);
+    return server_context.secretManager().findOrCreateGenericSecretProvider(
+        config.sds_config(), config.name(), server_context, init_manager);
   } else {
-    return secret_manager.findStaticGenericSecretProvider(config.name());
+    return server_context.secretManager().findStaticGenericSecretProvider(config.name());
   }
 }
 } // namespace
@@ -46,13 +45,10 @@ OAuth2CredentialInjectorFactory::createOauth2ClientCredentialInjector(
     const OAuth2& proto_config, const std::string& stats_prefix,
     Server::Configuration::ServerFactoryContext& context, Init::Manager& init_manager) {
   auto& cluster_manager = context.clusterManager();
-  auto& secret_manager = cluster_manager.clusterManagerFactory().secretManager();
-  auto& transport_socket_factory = context.getTransportSocketFactoryContext();
 
   const auto& client_secret_secret = proto_config.client_credentials().client_secret();
 
-  auto client_secret_provider =
-      secretsProvider(client_secret_secret, secret_manager, transport_socket_factory, init_manager);
+  auto client_secret_provider = secretsProvider(client_secret_secret, context, init_manager);
   if (client_secret_provider == nullptr) {
     throw EnvoyException("Invalid oauth2 client secret configuration");
   }

--- a/source/extensions/quic/connection_id_generator/quic_lb/quic_lb.cc
+++ b/source/extensions/quic/connection_id_generator/quic_lb/quic_lb.cc
@@ -125,17 +125,15 @@ QuicLbConnectionIdGenerator::ThreadLocalData::updateKeyAndVersion(absl::string_v
 
 namespace {
 
-Secret::GenericSecretConfigProviderSharedPtr secretsProvider(
-    const envoy::extensions::transport_sockets::tls::v3::SdsSecretConfig& config,
-    Server::Configuration::TransportSocketFactoryContext& transport_socket_factory_context,
-    Init::Manager& init_manager) {
-  Secret::SecretManager& secret_manager =
-      transport_socket_factory_context.serverFactoryContext().secretManager();
+Secret::GenericSecretConfigProviderSharedPtr
+secretsProvider(const envoy::extensions::transport_sockets::tls::v3::SdsSecretConfig& config,
+                Server::Configuration::ServerFactoryContext& server_context,
+                Init::Manager& init_manager) {
   if (config.has_sds_config()) {
-    return secret_manager.findOrCreateGenericSecretProvider(
-        config.sds_config(), config.name(), transport_socket_factory_context, init_manager);
+    return server_context.secretManager().findOrCreateGenericSecretProvider(
+        config.sds_config(), config.name(), server_context, init_manager);
   } else {
-    return secret_manager.findStaticGenericSecretProvider(config.name());
+    return server_context.secretManager().findStaticGenericSecretProvider(config.name());
   }
 }
 
@@ -254,9 +252,8 @@ Factory::create(const envoy::extensions::quic::connection_id_generator::quic_lb:
         return result.value();
       });
 
-  ret->secrets_provider_ =
-      secretsProvider(config.encryption_parameters(), context.getTransportSocketFactoryContext(),
-                      context.initManager());
+  ret->secrets_provider_ = secretsProvider(config.encryption_parameters(),
+                                           context.serverFactoryContext(), context.initManager());
   if (ret->secrets_provider_ == nullptr) {
     return absl::InvalidArgumentError("invalid encryption_parameters config");
   }

--- a/test/common/secret/secret_manager_impl_test.cc
+++ b/test/common/secret/secret_manager_impl_test.cc
@@ -306,7 +306,7 @@ api_config_source:
       ->set_value(Base64::decode("CjUKMy92YXIvcnVuL3NlY3JldHMva3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3Vud"
                                  "C90b2tlbhILeC10b2tlbi1iaW4="));
   auto secret_provider1 = secret_manager->findOrCreateTlsCertificateProvider(
-      config_source, "abc.com", secret_context, init_manager);
+      config_source, "abc.com", secret_context.server_context_, init_manager);
 
   // The base64 encoded proto binary is identical to the one above, but in different field order.
   // It is also identical to the YAML below.
@@ -319,7 +319,7 @@ api_config_source:
       ->set_value(Base64::decode("Egt4LXRva2VuLWJpbgo1CjMvdmFyL3J1bi9zZWNyZXRzL2t1YmVybmV0ZXMuaW8vc"
                                  "2VydmljZWFjY291bnQvdG9rZW4="));
   auto secret_provider2 = secret_manager->findOrCreateTlsCertificateProvider(
-      config_source, "abc.com", secret_context, init_manager);
+      config_source, "abc.com", secret_context.server_context_, init_manager);
 
   API_NO_BOOST(envoy::config::grpc_credential::v2alpha::FileBasedMetadataConfig)
   file_based_metadata_config;
@@ -337,7 +337,7 @@ secret_data:
       ->mutable_typed_config()
       ->PackFrom(file_based_metadata_config);
   auto secret_provider3 = secret_manager->findOrCreateTlsCertificateProvider(
-      config_source, "abc.com", secret_context, init_manager);
+      config_source, "abc.com", secret_context.server_context_, init_manager);
 
   EXPECT_EQ(secret_provider1, secret_provider2);
   EXPECT_EQ(secret_provider2, secret_provider3);
@@ -366,7 +366,7 @@ TEST_F(SecretManagerImplTest, SdsDynamicSecretUpdateSuccess) {
   EXPECT_CALL(secret_context.server_context_, api()).WillRepeatedly(ReturnRef(*api_));
 
   auto secret_provider = secret_manager->findOrCreateTlsCertificateProvider(
-      config_source, "abc.com", secret_context, init_manager);
+      config_source, "abc.com", secret_context.server_context_, init_manager);
   const std::string yaml =
       R"EOF(
 name: "abc.com"
@@ -418,7 +418,7 @@ TEST_F(SecretManagerImplTest, SdsDynamicGenericSecret) {
       }));
 
   auto secret_provider = secret_manager->findOrCreateGenericSecretProvider(
-      config_source, "encryption_key", secret_context, init_manager);
+      config_source, "encryption_key", secret_context.server_context_, init_manager);
 
   const std::string yaml = R"EOF(
 name: "encryption_key"
@@ -463,7 +463,7 @@ TEST_F(SecretManagerImplTest, ConfigDumpHandler) {
   EXPECT_CALL(secret_context.server_context_, localInfo()).WillRepeatedly(ReturnRef(local_info));
 
   auto secret_provider = secret_manager->findOrCreateTlsCertificateProvider(
-      config_source, "abc.com", secret_context, init_manager);
+      config_source, "abc.com", secret_context.server_context_, init_manager);
   const std::string yaml =
       R"EOF(
 name: "abc.com"
@@ -516,7 +516,7 @@ dynamic_active_secrets:
   // Add a dynamic tls validation context provider.
   time_system_.setSystemTime(std::chrono::milliseconds(1234567899000));
   auto context_secret_provider = secret_manager->findOrCreateCertificateValidationContextProvider(
-      config_source, "abc.com.validation", secret_context, init_manager);
+      config_source, "abc.com.validation", secret_context.server_context_, init_manager);
   const std::string validation_yaml = R"EOF(
 name: "abc.com.validation"
 validation_context:
@@ -570,7 +570,7 @@ dynamic_active_secrets:
   // Add a dynamic tls session ticket encryption keys context provider.
   time_system_.setSystemTime(std::chrono::milliseconds(1234567899000));
   auto stek_secret_provider = secret_manager->findOrCreateTlsSessionTicketKeysContextProvider(
-      config_source, "abc.com.stek", secret_context, init_manager);
+      config_source, "abc.com.stek", secret_context.server_context_, init_manager);
   const std::string stek_yaml = R"EOF(
 name: "abc.com.stek"
 session_ticket_keys:
@@ -637,7 +637,7 @@ dynamic_active_secrets:
   // Add a dynamic generic secret provider.
   time_system_.setSystemTime(std::chrono::milliseconds(1234567900000));
   auto generic_secret_provider = secret_manager->findOrCreateGenericSecretProvider(
-      config_source, "signing_key", secret_context, init_manager);
+      config_source, "signing_key", secret_context.server_context_, init_manager);
 
   const std::string generic_secret_yaml = R"EOF(
 name: "signing_key"
@@ -738,7 +738,7 @@ TEST_F(SecretManagerImplTest, ConfigDumpHandlerWarmingSecrets) {
   EXPECT_CALL(secret_context.server_context_, localInfo()).WillRepeatedly(ReturnRef(local_info));
 
   auto secret_provider = secret_manager->findOrCreateTlsCertificateProvider(
-      config_source, "abc.com", secret_context, init_manager);
+      config_source, "abc.com", secret_context.server_context_, init_manager);
   const std::string expected_secrets_config_dump = R"EOF(
 dynamic_warming_secrets:
 - name: "abc.com"
@@ -757,7 +757,7 @@ dynamic_warming_secrets:
 
   time_system_.setSystemTime(std::chrono::milliseconds(1234567899000));
   auto context_secret_provider = secret_manager->findOrCreateCertificateValidationContextProvider(
-      config_source, "abc.com.validation", secret_context, init_manager);
+      config_source, "abc.com.validation", secret_context.server_context_, init_manager);
   init_target_handle->initialize(init_watcher);
   const std::string updated_config_dump = R"EOF(
 dynamic_warming_secrets:
@@ -784,7 +784,7 @@ dynamic_warming_secrets:
 
   time_system_.setSystemTime(std::chrono::milliseconds(1234567899000));
   auto stek_secret_provider = secret_manager->findOrCreateTlsSessionTicketKeysContextProvider(
-      config_source, "abc.com.stek", secret_context, init_manager);
+      config_source, "abc.com.stek", secret_context.server_context_, init_manager);
   init_target_handle->initialize(init_watcher);
   const std::string updated_once_more_config_dump = R"EOF(
 dynamic_warming_secrets:
@@ -819,7 +819,7 @@ dynamic_warming_secrets:
 
   time_system_.setSystemTime(std::chrono::milliseconds(1234567900000));
   auto generic_secret_provider = secret_manager->findOrCreateGenericSecretProvider(
-      config_source, "signing_key", secret_context, init_manager);
+      config_source, "signing_key", secret_context.server_context_, init_manager);
   init_target_handle->initialize(init_watcher);
   const std::string config_dump_with_generic_secret = R"EOF(
 dynamic_warming_secrets:
@@ -1089,7 +1089,7 @@ TEST_F(SecretManagerImplTest, SdsDynamicSecretPrivateKeyProviderUpdateSuccess) {
   EXPECT_CALL(secret_context.server_context_, api()).WillRepeatedly(ReturnRef(*api_));
 
   auto secret_provider = secret_manager->findOrCreateTlsCertificateProvider(
-      config_source, "abc.com", secret_context, init_manager);
+      config_source, "abc.com", secret_context.server_context_, init_manager);
   const std::string yaml =
       R"EOF(
 name: "abc.com"

--- a/test/common/secret/secret_manager_impl_test.cc
+++ b/test/common/secret/secret_manager_impl_test.cc
@@ -408,7 +408,8 @@ TEST_F(SecretManagerImplTest, SdsDynamicGenericSecret) {
 
   EXPECT_CALL(secret_context.server_context_, mainThreadDispatcher())
       .WillRepeatedly(ReturnRef(*dispatcher_));
-  EXPECT_CALL(secret_context, messageValidationVisitor()).WillOnce(ReturnRef(validation_visitor));
+  EXPECT_CALL(secret_context.server_context_, messageValidationVisitor())
+      .WillOnce(ReturnRef(validation_visitor));
   EXPECT_CALL(secret_context, initManager()).Times(0);
   EXPECT_CALL(secret_context.server_context_, localInfo()).WillOnce(ReturnRef(local_info));
   EXPECT_CALL(secret_context.server_context_, api()).WillRepeatedly(ReturnRef(*api_));

--- a/test/extensions/filters/http/oauth2/config_test.cc
+++ b/test/extensions/filters/http/oauth2/config_test.cc
@@ -127,8 +127,9 @@ config:
   context.server_factory_context_.cluster_manager_.initializeClusters({"foo"}, {});
 
   // This returns non-nullptr for token_secret and hmac_secret.
-  auto& secret_manager =
-      context.server_factory_context_.cluster_manager_.cluster_manager_factory_.secretManager();
+  NiceMock<Secret::MockSecretManager> secret_manager;
+  ON_CALL(context.server_factory_context_, secretManager())
+      .WillByDefault(ReturnRef(secret_manager));
   ON_CALL(secret_manager, findStaticGenericSecretProvider(_))
       .WillByDefault(Return(std::make_shared<Secret::GenericSecretConfigProviderImpl>(
           envoy::extensions::transport_sockets::tls::v3::GenericSecret())));
@@ -138,7 +139,6 @@ config:
   EXPECT_CALL(context, scope());
   EXPECT_CALL(context.server_factory_context_, timeSource());
   EXPECT_CALL(context, initManager()).Times(2);
-  EXPECT_CALL(context, getTransportSocketFactoryContext());
   Http::FilterFactoryCb cb =
       factory.createFilterFactoryFromProto(*proto_config, "stats", context).value();
   Http::MockFilterChainFactoryCallbacks filter_callback;
@@ -266,8 +266,9 @@ config:
   context.server_factory_context_.cluster_manager_.initializeClusters({"foo"}, {});
 
   // This returns non-nullptr for token_secret and hmac_secret.
-  auto& secret_manager =
-      context.server_factory_context_.cluster_manager_.cluster_manager_factory_.secretManager();
+  NiceMock<Secret::MockSecretManager> secret_manager;
+  ON_CALL(context.server_factory_context_, secretManager())
+      .WillByDefault(ReturnRef(secret_manager));
   ON_CALL(secret_manager, findStaticGenericSecretProvider(_))
       .WillByDefault(Return(std::make_shared<Secret::GenericSecretConfigProviderImpl>(
           envoy::extensions::transport_sockets::tls::v3::GenericSecret())));
@@ -322,8 +323,9 @@ config:
   NiceMock<Server::Configuration::MockFactoryContext> context;
   context.server_factory_context_.cluster_manager_.initializeClusters({"foo"}, {});
 
-  auto& secret_manager =
-      context.server_factory_context_.cluster_manager_.cluster_manager_factory_.secretManager();
+  NiceMock<Secret::MockSecretManager> secret_manager;
+  ON_CALL(context.server_factory_context_, secretManager())
+      .WillByDefault(ReturnRef(secret_manager));
   ON_CALL(secret_manager, findStaticGenericSecretProvider(_))
       .WillByDefault(Return(std::make_shared<Secret::GenericSecretConfigProviderImpl>(
           envoy::extensions::transport_sockets::tls::v3::GenericSecret())));
@@ -368,8 +370,9 @@ config:
   NiceMock<Server::Configuration::MockFactoryContext> context;
   context.server_factory_context_.cluster_manager_.initializeClusters({"foo"}, {});
 
-  auto& secret_manager =
-      context.server_factory_context_.cluster_manager_.cluster_manager_factory_.secretManager();
+  NiceMock<Secret::MockSecretManager> secret_manager;
+  ON_CALL(context.server_factory_context_, secretManager())
+      .WillByDefault(ReturnRef(secret_manager));
   ON_CALL(secret_manager, findStaticGenericSecretProvider(_))
       .WillByDefault(Return(std::make_shared<Secret::GenericSecretConfigProviderImpl>(
           envoy::extensions::transport_sockets::tls::v3::GenericSecret())));

--- a/test/extensions/filters/http/oauth2/config_test.cc
+++ b/test/extensions/filters/http/oauth2/config_test.cc
@@ -63,8 +63,9 @@ config:
   TestUtility::loadFromYaml(yaml, *proto_config);
   NiceMock<Server::Configuration::MockFactoryContext> context;
 
-  auto& secret_manager =
-      context.server_factory_context_.cluster_manager_.cluster_manager_factory_.secretManager();
+  NiceMock<Secret::MockSecretManager> secret_manager;
+  ON_CALL(context.server_factory_context_, secretManager())
+      .WillByDefault(ReturnRef(secret_manager));
   ON_CALL(secret_manager,
           findStaticGenericSecretProvider(failed_secret_name == "token" ? "hmac" : "token"))
       .WillByDefault(Return(std::make_shared<Secret::GenericSecretConfigProviderImpl>(
@@ -410,8 +411,9 @@ config:
   NiceMock<Server::Configuration::MockFactoryContext> context;
   context.server_factory_context_.cluster_manager_.initializeClusters({"foo"}, {});
 
-  auto& secret_manager =
-      context.server_factory_context_.cluster_manager_.cluster_manager_factory_.secretManager();
+  NiceMock<Secret::MockSecretManager> secret_manager;
+  ON_CALL(context.server_factory_context_, secretManager())
+      .WillByDefault(ReturnRef(secret_manager));
   ON_CALL(secret_manager, findStaticGenericSecretProvider(_))
       .WillByDefault(Return(std::make_shared<Secret::GenericSecretConfigProviderImpl>(
           envoy::extensions::transport_sockets::tls::v3::GenericSecret())));

--- a/test/extensions/filters/http/oauth2/filter_test.cc
+++ b/test/extensions/filters/http/oauth2/filter_test.cc
@@ -313,11 +313,11 @@ TEST_F(OAuth2Test, SdsDynamicGenericSecret) {
       }));
 
   auto client_secret_provider = secret_manager.findOrCreateGenericSecretProvider(
-      config_source, "client", secret_context, init_manager);
+      config_source, "client", secret_context.server_context_, init_manager);
   auto client_callback =
       secret_context.server_context_.cluster_manager_.subscription_factory_.callbacks_;
   auto token_secret_provider = secret_manager.findOrCreateGenericSecretProvider(
-      config_source, "token", secret_context, init_manager);
+      config_source, "token", secret_context.server_context_, init_manager);
   auto token_callback =
       secret_context.server_context_.cluster_manager_.subscription_factory_.callbacks_;
 

--- a/test/extensions/http/credential_injector/oauth2/config_test.cc
+++ b/test/extensions/http/credential_injector/oauth2/config_test.cc
@@ -40,11 +40,7 @@ TEST(Config, NullClientSecret) {
   TestUtility::loadFromYaml(yaml_string, proto_config);
   OAuth2CredentialInjectorFactory factory;
   NiceMock<Server::Configuration::MockServerFactoryContext> server_factory_context;
-  NiceMock<Server::Configuration::MockTransportSocketFactoryContext>
-      transport_socket_factory_context;
   NiceMock<Init::MockManager> init_manager;
-  ON_CALL(server_factory_context, getTransportSocketFactoryContext())
-      .WillByDefault(ReturnRef(transport_socket_factory_context));
 
   EXPECT_THROW_WITH_REGEX(factory.createOauth2ClientCredentialInjector(
                               proto_config, "stats", server_factory_context, init_manager),

--- a/test/extensions/quic/connection_id_generator/quic_lb/quic_lb_test.cc
+++ b/test/extensions/quic/connection_id_generator/quic_lb/quic_lb_test.cc
@@ -62,8 +62,8 @@ TEST(QuicLbTest, InvalidConfig) {
   envoy::extensions::transport_sockets::tls::v3::Secret encryption_parameters;
   encryption_parameters.set_name(kSecretName);
   encryption_parameters.mutable_generic_secret();
-  auto status = factory_context.transport_socket_factory_context_.server_context_.secretManager()
-                    .addStaticSecret(encryption_parameters);
+  auto status = factory_context.server_factory_context_.secretManager().addStaticSecret(
+      encryption_parameters);
   EXPECT_TRUE(status.ok());
   factory_or_status = Factory::create(cfg, factory_context);
   EXPECT_EQ(factory_or_status.status().message(), "Missing 'encryption_key'");
@@ -73,9 +73,9 @@ TEST(QuicLbTest, InvalidConfig) {
   envoy::config::core::v3::DataSource key;
   key.set_inline_string("bad");
   secrets["encryption_key"] = key;
-  factory_context.transport_socket_factory_context_.server_context_.resetSecretManager();
-  status = factory_context.transport_socket_factory_context_.server_context_.secretManager()
-               .addStaticSecret(encryption_parameters);
+  factory_context.server_factory_context_.resetSecretManager();
+  status = factory_context.server_factory_context_.secretManager().addStaticSecret(
+      encryption_parameters);
   EXPECT_TRUE(status.ok());
   factory_or_status = Factory::create(cfg, factory_context);
   EXPECT_EQ(factory_or_status.status().message(),
@@ -84,9 +84,9 @@ TEST(QuicLbTest, InvalidConfig) {
   // Missing version.
   key.set_inline_string("0123456789abcdef");
   secrets["encryption_key"] = key;
-  factory_context.transport_socket_factory_context_.server_context_.resetSecretManager();
-  status = factory_context.transport_socket_factory_context_.server_context_.secretManager()
-               .addStaticSecret(encryption_parameters);
+  factory_context.server_factory_context_.resetSecretManager();
+  status = factory_context.server_factory_context_.secretManager().addStaticSecret(
+      encryption_parameters);
   EXPECT_TRUE(status.ok());
   factory_or_status = Factory::create(cfg, factory_context);
   EXPECT_EQ(factory_or_status.status().message(), "Missing 'configuration_version'");
@@ -97,9 +97,9 @@ TEST(QuicLbTest, InvalidConfig) {
   version_bytes.resize(2);
   version.set_inline_bytes(version_bytes);
   secrets["configuration_version"] = version;
-  factory_context.transport_socket_factory_context_.server_context_.resetSecretManager();
-  status = factory_context.transport_socket_factory_context_.server_context_.secretManager()
-               .addStaticSecret(encryption_parameters);
+  factory_context.server_factory_context_.resetSecretManager();
+  status = factory_context.server_factory_context_.secretManager().addStaticSecret(
+      encryption_parameters);
   EXPECT_TRUE(status.ok());
   factory_or_status = Factory::create(cfg, factory_context);
   EXPECT_EQ(factory_or_status.status().message(),
@@ -110,9 +110,9 @@ TEST(QuicLbTest, InvalidConfig) {
   version_bytes.data()[0] = 7;
   version.set_inline_bytes(version_bytes);
   secrets["configuration_version"] = version;
-  factory_context.transport_socket_factory_context_.server_context_.resetSecretManager();
-  status = factory_context.transport_socket_factory_context_.server_context_.secretManager()
-               .addStaticSecret(encryption_parameters);
+  factory_context.server_factory_context_.resetSecretManager();
+  status = factory_context.server_factory_context_.secretManager().addStaticSecret(
+      encryption_parameters);
   EXPECT_TRUE(status.ok());
   factory_or_status = Factory::create(cfg, factory_context);
   EXPECT_EQ(factory_or_status.status().message(),
@@ -122,9 +122,9 @@ TEST(QuicLbTest, InvalidConfig) {
   version_bytes.data()[0] = 6;
   version.set_inline_bytes(version_bytes);
   secrets["configuration_version"] = version;
-  factory_context.transport_socket_factory_context_.server_context_.resetSecretManager();
-  status = factory_context.transport_socket_factory_context_.server_context_.secretManager()
-               .addStaticSecret(encryption_parameters);
+  factory_context.server_factory_context_.resetSecretManager();
+  status = factory_context.server_factory_context_.secretManager().addStaticSecret(
+      encryption_parameters);
   EXPECT_TRUE(status.ok());
   factory_or_status = Factory::create(cfg, factory_context);
   EXPECT_TRUE(factory_or_status.ok());
@@ -171,8 +171,8 @@ TEST(QuicLbTest, Unencrypted) {
 
   testing::NiceMock<Server::Configuration::MockFactoryContext> factory_context;
 
-  auto status = factory_context.transport_socket_factory_context_.server_context_.secretManager()
-                    .addStaticSecret(encryptionParamaters(0));
+  auto status = factory_context.server_factory_context_.secretManager().addStaticSecret(
+      encryptionParamaters(0));
   absl::StatusOr<std::unique_ptr<Factory>> factory_or_status =
       Factory::create(cfg, factory_context);
   auto generator = createTypedIdGenerator(*factory_or_status.value());
@@ -198,8 +198,8 @@ TEST(QuicLbTest, TooLong) {
 
   testing::NiceMock<Server::Configuration::MockFactoryContext> factory_context;
 
-  auto status = factory_context.transport_socket_factory_context_.server_context_.secretManager()
-                    .addStaticSecret(encryptionParamaters(0));
+  auto status = factory_context.server_factory_context_.secretManager().addStaticSecret(
+      encryptionParamaters(0));
   absl::StatusOr<std::unique_ptr<Factory>> factory_or_status =
       Factory::create(cfg, factory_context);
   auto generator = createTypedIdGenerator(*factory_or_status.value());
@@ -217,8 +217,8 @@ TEST(QuicLbTest, WorkerSelector) {
 
   testing::NiceMock<Server::Configuration::MockFactoryContext> factory_context;
 
-  auto status = factory_context.transport_socket_factory_context_.server_context_.secretManager()
-                    .addStaticSecret(encryptionParamaters(0));
+  auto status = factory_context.server_factory_context_.secretManager().addStaticSecret(
+      encryptionParamaters(0));
   absl::StatusOr<std::unique_ptr<Factory>> factory_or_status =
       Factory::create(cfg, factory_context);
   constexpr uint32_t concurrency = 8;
@@ -291,8 +291,7 @@ TEST(QuicLbTest, EmptySecretCallback) {
   testing::NiceMock<Server::Configuration::MockFactoryContext> factory_context;
   auto secret_mgr_unique = std::make_unique<Secret::MockSecretManager>();
   Secret::MockSecretManager* secret_manager = secret_mgr_unique.get();
-  factory_context.transport_socket_factory_context_.server_context_.secret_manager_ =
-      std::move(secret_mgr_unique);
+  factory_context.server_factory_context_.secret_manager_ = std::move(secret_mgr_unique);
   auto secret_provider = std::make_shared<Secret::MockGenericSecretConfigProvider>();
 
   EXPECT_CALL(*secret_manager, findOrCreateGenericSecretProvider(_, _, _, _))

--- a/test/integration/sds_generic_secret_integration_test.cc
+++ b/test/integration/sds_generic_secret_integration_test.cc
@@ -72,13 +72,9 @@ public:
   createFilter(const std::string&,
                Server::Configuration::FactoryContext& factory_context) override {
     auto secret_provider =
-        factory_context.serverFactoryContext()
-            .clusterManager()
-            .clusterManagerFactory()
-            .secretManager()
-            .findOrCreateGenericSecretProvider(config_source_, "encryption_key",
-                                               factory_context.getTransportSocketFactoryContext(),
-                                               factory_context.initManager());
+        factory_context.serverFactoryContext().secretManager().findOrCreateGenericSecretProvider(
+            config_source_, "encryption_key", factory_context.serverFactoryContext(),
+            factory_context.initManager());
     return
         [&factory_context, secret_provider](Http::FilterChainFactoryCallbacks& callbacks) -> void {
           callbacks.addStreamDecoderFilter(std::make_shared<::Envoy::SdsGenericSecretTestFilter>(

--- a/test/mocks/secret/mocks.h
+++ b/test/mocks/secret/mocks.h
@@ -42,20 +42,20 @@ public:
               (const envoy::extensions::transport_sockets::tls::v3::GenericSecret& generic_secret));
   MOCK_METHOD(TlsCertificateConfigProviderSharedPtr, findOrCreateTlsCertificateProvider,
               (const envoy::config::core::v3::ConfigSource&, const std::string&,
-               Server::Configuration::TransportSocketFactoryContext&, Init::Manager& init_manager));
+               Server::Configuration::ServerFactoryContext&, Init::Manager& init_manager));
   MOCK_METHOD(CertificateValidationContextConfigProviderSharedPtr,
               findOrCreateCertificateValidationContextProvider,
               (const envoy::config::core::v3::ConfigSource& config_source,
                const std::string& config_name,
-               Server::Configuration::TransportSocketFactoryContext& secret_provider_context,
+               Server::Configuration::ServerFactoryContext& server_context,
                Init::Manager& init_manager));
   MOCK_METHOD(TlsSessionTicketKeysConfigProviderSharedPtr,
               findOrCreateTlsSessionTicketKeysContextProvider,
               (const envoy::config::core::v3::ConfigSource&, const std::string&,
-               Server::Configuration::TransportSocketFactoryContext&, Init::Manager& init_manager));
+               Server::Configuration::ServerFactoryContext&, Init::Manager& init_manager));
   MOCK_METHOD(GenericSecretConfigProviderSharedPtr, findOrCreateGenericSecretProvider,
               (const envoy::config::core::v3::ConfigSource&, const std::string&,
-               Server::Configuration::TransportSocketFactoryContext&, Init::Manager& init_manager));
+               Server::Configuration::ServerFactoryContext&, Init::Manager& init_manager));
 };
 
 class MockSecretCallbacks : public SecretCallbacks {


### PR DESCRIPTION
Commit Message: use server factory context as priority
Additional Description:

Part of #26476

This PR replace `TransportSocketFactoryContext` of secret provider to `ServerFactoryContext`. After this PR, we can clean up the `getTransportSocketFactoryContext()` of FactoryContext and ServerFactoryContext and clusterManagerFactory() of ClusterManager.

Risk Level: low.
Testing: n/a.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.