### PR TITLE
Revert "Switch coverage CI targets to EngFlow (#39436)"

### DIFF
--- a/.github/workflows/_check_coverage.yml
+++ b/.github/workflows/_check_coverage.yml
@@ -38,7 +38,7 @@ jobs:
     uses: ./.github/workflows/_run.yml
     name: ${{ matrix.name ||matrix.target }}
     with:
-      bazel-extra: '--config=remote-envoy-engflow'
+      # bazel-extra: '--config=remote-envoy-engflow'
       cache-build-image: ${{ fromJSON(inputs.request).request.build-image.default }}
       concurrency-suffix: -${{ matrix.target }}
       diskspace-hack: ${{ matrix.diskspace-hack && true || false }}
@@ -50,6 +50,7 @@ jobs:
         lower than limit
       gcs-cache-bucket: ${{ inputs.gcs-cache-bucket }}
       rbe: true
+      rbe-google: true
       request: ${{ inputs.request }}
       runs-on: ${{ fromJSON(inputs.request).config.ci.agent-ubuntu }}
       steps-post: |


### PR DESCRIPTION
Commit Message:

This reverts commit 1858f70e9b0d04a04f5a3eba99449d3998a3317e. It looks like EngFlow cluster is straggling a bit and even if at the moment backlog cleared, we should hold off the Eng Flow migration for coverage for now.

Additional Description: n/a
Risk Level: low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a

+cc @phlax 