### PR TITLE
rbac: allowlist FilterStateInput for xDS matcher in HTTP RBAC

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -130,5 +130,8 @@ new_features:
     Included the asterisk ``*`` in the match pattern when using the * or ** operators in the URL template.
     This behavioral change can be temporarily reverted by setting runtime guard
     ``envoy.reloadable_features.uri_template_match_on_asterisk`` to ``false``.
+- area: rbac filter
+  change: |
+    allow listed ``FilterStateInput`` to be used with the xDS matcher in the HTTP RBAC filter.
 
 deprecated:

--- a/source/extensions/filters/http/rbac/rbac_filter.cc
+++ b/source/extensions/filters/http/rbac/rbac_filter.cc
@@ -52,7 +52,10 @@ absl::Status ActionValidationVisitor::performDataInputValidation(
                                                  v3::DynamicMetadataInput::descriptor()
                                                      ->full_name())},
       {TypeUtil::descriptorFullNameToTypeUrl(
-          xds::type::matcher::v3::HttpAttributesCelMatchInput::descriptor()->full_name())}};
+          xds::type::matcher::v3::HttpAttributesCelMatchInput::descriptor()->full_name())},
+      {TypeUtil::descriptorFullNameToTypeUrl(
+          envoy::extensions::matching::common_inputs::network::v3::FilterStateInput::descriptor()
+              ->full_name())}};
   if (allowed_inputs_set.contains(type_url)) {
     return absl::OkStatus();
   }

--- a/test/extensions/filters/http/rbac/BUILD
+++ b/test/extensions/filters/http/rbac/BUILD
@@ -72,6 +72,7 @@ envoy_extension_cc_test(
         "//source/extensions/filters/http/dynamic_forward_proxy:config",
         "//source/extensions/filters/http/header_to_metadata:config",
         "//source/extensions/filters/http/rbac:config",
+        "//source/extensions/filters/http/set_filter_state:config",
         "//source/extensions/key_value/file_based:config_lib",
         "//source/extensions/matching/http/cel_input:cel_input_lib",
         "//source/extensions/matching/input_matchers/cel_matcher:config",

--- a/test/extensions/filters/http/rbac/rbac_filter_integration_test.cc
+++ b/test/extensions/filters/http/rbac/rbac_filter_integration_test.cc
@@ -41,6 +41,18 @@ typed_config:
           - any: true
 )EOF";
 
+const std::string FILTER_STATE_SETTER_CONFIG = R"EOF(
+name: test-filter-state-setter
+typed_config:
+  "@type": type.googleapis.com/envoy.extensions.filters.http.set_filter_state.v3.Config
+  on_request_headers:
+    object_key: "test_key"
+    factory_key: "envoy.string"
+    format_string:
+      text_format: "deny_value"
+    read_only: false
+)EOF";
+
 const std::string SET_METADATA_FILTER_CONFIG = R"EOF(
 name: envoy.filters.http.header_to_metadata
 typed_config:
@@ -533,6 +545,35 @@ typed_config:
           action: ALLOW
 )EOF";
 
+const std::string RBAC_CONFIG_WITH_FILTER_STATE_INPUT_MATCH = R"EOF(
+name: rbac
+typed_config:
+  "@type": type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC
+  matcher:
+    matcher_tree:
+      input:
+        name: filter_state
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.matching.common_inputs.network.v3.FilterStateInput
+          key: test_key
+      exact_match_map:
+        map:
+          "deny_value":
+            action:
+              name: envoy.filters.rbac.action
+              typed_config:
+                "@type": type.googleapis.com/envoy.config.rbac.v3.Action
+                name: deny-request
+                action: DENY
+    on_no_match:
+      action:
+        name: action
+        typed_config:
+          "@type": type.googleapis.com/envoy.config.rbac.v3.Action
+          name: allow-request
+          action: ALLOW
+)EOF";
+
 using RBACIntegrationTest = HttpProtocolIntegrationTest;
 
 // TODO(#26236): Fix test suite for HTTP/3.
@@ -548,7 +589,7 @@ TEST_P(RBACIntegrationTest, WithHttpAttributesCelMatchInputDenied) {
 
   codec_client_ = makeHttpConnection(lookupPort("http"));
 
-  // The test request utilizing the path '/test-localhost-deny' is expected to be denied by the RBAC
+  // The test request uses the path '/test-localhost-deny' is expected to be denied by the RBAC
   // filter. This denial is based on the CEL expression that matches the request's path as
   // '/test-localhost-deny' and subsequently restricts all access based on the IP Address, in this
   // instance pointing to localhost.
@@ -564,6 +605,31 @@ TEST_P(RBACIntegrationTest, WithHttpAttributesCelMatchInputDenied) {
   ASSERT_TRUE(deny_response->waitForEndStream());
   ASSERT_TRUE(deny_response->complete());
   EXPECT_EQ("403", deny_response->headers().getStatusValue());
+  EXPECT_THAT(waitForAccessLog(access_log_name_),
+              testing::HasSubstr("rbac_access_denied_matched_policy[deny-request]"));
+}
+
+TEST_P(RBACIntegrationTest, FilterStateMatchDenied) {
+  useAccessLog("%RESPONSE_CODE_DETAILS%");
+  config_helper_.prependFilter(RBAC_CONFIG_WITH_FILTER_STATE_INPUT_MATCH);
+  config_helper_.prependFilter(FILTER_STATE_SETTER_CONFIG);
+  initialize();
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+
+  auto response = codec_client_->makeRequestWithBody(
+      Http::TestRequestHeaderMapImpl{
+          {":method", "GET"},
+          {":path", "/"},
+          {":scheme", "http"},
+          {":authority", "sni.lyft.com"},
+          {"x-forwarded-for", "10.0.0.1"},
+      },
+      1024);
+  ASSERT_TRUE(response->waitForEndStream());
+  ASSERT_TRUE(response->complete());
+  EXPECT_EQ("403", response->headers().getStatusValue());
+  // Note the whitespace in the policy id is replaced by '_'.
   EXPECT_THAT(waitForAccessLog(access_log_name_),
               testing::HasSubstr("rbac_access_denied_matched_policy[deny-request]"));
 }

--- a/test/extensions/filters/http/rbac/rbac_filter_integration_test.cc
+++ b/test/extensions/filters/http/rbac/rbac_filter_integration_test.cc
@@ -49,7 +49,8 @@ typed_config:
     object_key: "test_key"
     factory_key: "envoy.string"
     format_string:
-      text_format: "deny_value"
+      text_format_source:
+        inline_string: "deny_value"
     read_only: false
 )EOF";
 


### PR DESCRIPTION
### Background

This PR adds the support for `FilterStateInput` in the HTTP RBAC filter.

---

Commit Message:  allowlist `FilterStateInput` for xDS matcher in HTTP RBAC filter.
Additional Description: added support for `FilterStateInput` to be allowed in the xDS matcher inside the HTTP RBAC filter.
Risk Level: Low
Testing: Added Integration & Unit Tests.
Docs Changes: N/A
Release Notes: Yes
Platform Specific Features: No