### PR TITLE
nit: remove unused imports from Network RBAC filter & some cleanup

### DIFF
--- a/source/extensions/filters/network/rbac/rbac_filter.h
+++ b/source/extensions/filters/network/rbac/rbac_filter.h
@@ -100,7 +100,8 @@ public:
   void onAboveWriteBufferHighWatermark() override {}
   void onBelowWriteBufferLowWatermark() override {}
 
-  void setDynamicMetadata(std::string shadow_engine_result, std::string shadow_policy_id);
+  void setDynamicMetadata(const std::string& shadow_engine_result,
+                          const std::string& shadow_policy_id) const;
 
 private:
   RoleBasedAccessControlFilterConfigSharedPtr config_;
@@ -108,8 +109,8 @@ private:
   EngineResult engine_result_{Unknown};
   EngineResult shadow_engine_result_{Unknown};
 
-  Result checkEngine(Filters::Common::RBAC::EnforcementMode mode);
-  void closeConnection();
+  Result checkEngine(Filters::Common::RBAC::EnforcementMode mode) const;
+  void closeConnection() const;
   void resetTimerState();
   Event::TimerPtr delay_timer_{nullptr};
   bool is_delay_denied_{false};

--- a/test/extensions/filters/network/rbac/integration_test.cc
+++ b/test/extensions/filters/network/rbac/integration_test.cc
@@ -40,6 +40,9 @@ public:
       : BaseIntegrationTest(GetParam(), rbac_config) {}
 
   static void SetUpTestSuite() { // NOLINT(readability-identifier-naming)
+    // Enable debug logging for all loggers to ensure coverage of debug log statements
+    Envoy::Logger::Registry::setLogLevel(spdlog::level::debug);
+
     rbac_config = absl::StrCat(ConfigHelper::baseConfig(), R"EOF(
     filter_chains:
       filters:


### PR DESCRIPTION
## Description

This PR removes an unused import and do some other minor cleanup in the Network RBAC filter.

---

**Commit Message:** nit: remove unused imports from Network RBAC filter & some cleanup
**Additional Description:** Addressed a few minor nits in the Network RBAC filter's code
**Risk Level:** Low
**Testing:** Existing Tests
**Docs Changes:** N/A
**Release Notes:** N/A