### PR TITLE
docs: clean up the protocol options docs

### DIFF
--- a/api/envoy/config/core/v3/protocol.proto
+++ b/api/envoy/config/core/v3/protocol.proto
@@ -64,8 +64,11 @@ message QuicProtocolOptions {
   // <https://tools.ietf.org/html/draft-ietf-quic-transport-34#section-4.1>`_ size. Valid values range from
   // 1 to 16777216 (2^24, maximum supported by QUICHE) and defaults to 16777216 (16 * 1024 * 1024).
   //
-  // NOTE: 16384 (2^14) is the minimum window size supported in Google QUIC. If configured smaller than it, we will use 16384 instead.
-  // QUICHE IETF Quic implementation supports 1 bytes window. We only support increasing the default window size now, so it's also the minimum.
+  // .. note::
+  //
+  //   16384 (2^14) is the minimum window size supported in Google QUIC. If configured smaller than it, we will use
+  //   16384 instead. QUICHE IETF Quic implementation supports 1 bytes window. We only support increasing the default
+  //   window size now, so it's also the minimum.
   //
   // This field also acts as a soft limit on the number of bytes Envoy will buffer per-stream in the
   // QUIC stream send and receive buffers. Once the buffer reaches this pointer, watermark callbacks will fire to
@@ -77,8 +80,11 @@ message QuicProtocolOptions {
   // flow-control. Valid values rage from 1 to 25165824 (24MB, maximum supported by QUICHE) and defaults
   // to 25165824 (24 * 1024 * 1024).
   //
-  // NOTE: 16384 (2^14) is the minimum window size supported in Google QUIC. We only support increasing the default
-  // window size now, so it's also the minimum.
+  // .. note::
+  //
+  //   16384 (2^14) is the minimum window size supported in Google QUIC. We only support increasing the default
+  //   window size now, so it's also the minimum.
+  //
   google.protobuf.UInt32Value initial_connection_window_size = 3
       [(validate.rules).uint32 = {lte: 25165824 gte: 1}];
 
@@ -282,9 +288,13 @@ message HttpProtocolOptions {
   // :ref:`HTTP Connection Manager
   // <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.common_http_protocol_options>`.
   //
-  // Note: currently some protocol codecs impose limits on the maximum size of a single header:
-  //   HTTP/2 (when using nghttp2) limits a single header to around 100kb.
-  //   HTTP/3 limits a single header to around 1024kb.
+  // .. note::
+  //
+  //   Currently some protocol codecs impose limits on the maximum size of a single header.
+  //
+  //   * HTTP/2 (when using nghttp2) limits a single header to around 100kb.
+  //   * HTTP/3 limits a single header to around 1024kb.
+  //
   google.protobuf.UInt32Value max_response_headers_kb = 7
       [(validate.rules).uint32 = {lte: 8192 gt: 0}];
 
@@ -294,9 +304,15 @@ message HttpProtocolOptions {
 
   // Action to take when a client request with a header name containing underscore characters is received.
   // If this setting is not specified, the value defaults to ALLOW.
-  // Note: upstream responses are not affected by this setting.
-  // Note: this only affects client headers. It does not affect headers added
-  // by Envoy filters and does not have any impact if added to cluster config.
+  //
+  // .. note::
+  //
+  //   Upstream responses are not affected by this setting.
+  //
+  // .. note::
+  //
+  //   This only affects client headers. It does not affect headers added by Envoy filters and does not have any
+  //   impact if added to cluster config.
   HeadersWithUnderscoresAction headers_with_underscores_action = 5;
 
   // Optional maximum requests for both upstream and downstream connections.
@@ -504,8 +520,10 @@ message Http2ProtocolOptions {
   // (2^16 - 1, HTTP/2 default) to 2147483647 (2^31 - 1, HTTP/2 maximum) and defaults to 268435456
   // (256 * 1024 * 1024).
   //
-  // NOTE: 65535 is the initial window size from HTTP/2 spec. We only support increasing the default
-  // window size now, so it's also the minimum.
+  // .. note::
+  //
+  //   65535 is the initial window size from HTTP/2 spec. We only support increasing the default window size now,
+  //   so it's also the minimum.
   //
   // This field also acts as a soft limit on the number of bytes Envoy will buffer per-stream in the
   // HTTP/2 codec buffers. Once the buffer reaches this pointer, watermark callbacks will fire to


### PR DESCRIPTION
## Description

This PR cleans up the protocol option docs to use the proper note annotations.

---

**Commit Message:** docs: clean up the protocol options docs
**Additional Description:** Clean up the protocol options docs.
**Risk Level:** N/A
**Testing:** N/A
**Docs Changes:** N/A
**Release Notes:** N/A