### PR TITLE
Resolve Python Datetime warnings

### DIFF
--- a/test/integration/python/hotrestart_handoff_test.py
+++ b/test/integration/python/hotrestart_handoff_test.py
@@ -19,7 +19,7 @@ import sys
 import tempfile
 from typing import Awaitable
 import unittest
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from aiohttp import client_exceptions, web, ClientSession
 
 
@@ -507,7 +507,7 @@ def generate_server_cert(
     alt_names.append(x509.IPAddress(ip_address(ENVOY_HOST)))
     san = x509.SubjectAlternativeName(alt_names)
     basic_constraints = x509.BasicConstraints(ca=True, path_length=0)
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
     cert = (
         x509.CertificateBuilder()  # Comment to keep linter from uglifying!
         .subject_name(name).issuer_name(ca_cert.subject).public_key(key.public_key()).serial_number(


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Resolve Python Datetime warnings
Additional Description: This small PR resolves the `datetime` library warnings:
```python
DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC). or datetime.datetime.utcnow()
```
Note that `.replace(tzinfo=None)` allows to keep the original behavior where the time appears as a naive UTC timestamp (i.e., without any timezone offset).
Risk Level: low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
