### PR TITLE
add a new field to use host weight in zone aware lb

### DIFF
--- a/api/envoy/extensions/load_balancing_policies/common/v3/common.proto
+++ b/api/envoy/extensions/load_balancing_policies/common/v3/common.proto
@@ -23,7 +23,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 message LocalityLbConfig {
   // Configuration for :ref:`zone aware routing
   // <arch_overview_load_balancing_zone_aware_routing>`.
-  // [#next-free-field: 6]
+  // [#next-free-field: 7]
   message ZoneAwareLbConfig {
     // Configures Envoy to always route requests to the local zone regardless of the
     // upstream zone structure. In Envoy's default configuration, traffic is distributed proportionally
@@ -66,6 +66,8 @@ message LocalityLbConfig {
         [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
 
     ForceLocalZone force_local_zone = 5;
+
+    bool use_host_weight = 6;
   }
 
   // Configuration for :ref:`locality weighted load balancing

--- a/source/extensions/load_balancing_policies/common/load_balancer_impl.h
+++ b/source/extensions/load_balancing_policies/common/load_balancer_impl.h
@@ -371,6 +371,10 @@ private:
   calculateLocalityPercentages(const HostsPerLocality& local_hosts_per_locality,
                                const HostsPerLocality& upstream_hosts_per_locality);
 
+  absl::FixedArray<LocalityPercentages>
+  calculateLocalityPercentagesWithWeight(const HostsPerLocality& local_hosts_per_locality,
+                              const HostsPerLocality& upstream_hosts_per_locality);
+
   /**
    * Regenerate locality aware routing structures for fast decisions on upstream locality selection.
    */
@@ -429,6 +433,7 @@ private:
   // Keep small members (bools and enums) at the end of class, to reduce alignment overhead.
   const uint32_t routing_enabled_;
   const bool fail_traffic_on_panic_ : 1;
+  const bool use_host_weight_: 1;
 
   // If locality weight aware routing is enabled.
   const bool locality_weighted_balancing_ : 1;


### PR DESCRIPTION
Commit Message: add a new field **use_host_weight** in **ZoneAwareLbConfig** to use weight of each host for calculating the locality percentages instead of the number of hosts.
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
