### PR TITLE
apple: Upgrade the XCode version to 16.1

### DIFF
--- a/mobile/.bazelrc
+++ b/mobile/.bazelrc
@@ -20,12 +20,12 @@ build --features=debug_prefix_map_pwd_is_dot
 build --features=swift.cacheable_swiftmodules
 build --features=swift.debug_prefix_map
 build --host_force_python=PY3
-build --macos_minimum_os=13.3
-build --ios_minimum_os=16.3
-build --ios_simulator_version=17.4
+build --macos_minimum_os=15.1
+build --ios_minimum_os=18.1
+build --ios_simulator_version=18.1
 build --verbose_failures
 build --workspace_status_command=../bazel/get_workspace_status
-build --xcode_version=15.3
+build --xcode_version=16.1
 build --use_top_level_targets_for_symlinks
 build --experimental_repository_downloader_retries=2
 build --define=google_grpc=disabled
@@ -41,8 +41,7 @@ build --swiftcopt=-wmo
 # https://github.com/bazelbuild/rules_jvm_external/issues/445
 build --repo_env=JAVA_HOME=../bazel_tools/jdk
 build --define disable_known_issue_asserts=true
-# Temporarily set to C++17 because Android NDK does not fully support C++20 yet.
-build --cxxopt=-std=c++17 --host_cxxopt=-std=c++17
+build --cxxopt=-std=c++20 --host_cxxopt=-std=c++20
 # Unset per_object_debug_info. Causes failures on Android Linux release builds.
 build --features=-per_object_debug_info
 # Suppress deprecated declaration warnings due to extensive transitive noise from protobuf.

--- a/mobile/bazel/apple.bzl
+++ b/mobile/bazel/apple.bzl
@@ -8,7 +8,7 @@ def envoy_objc_library(name, hdrs = [], visibility = [], data = [], deps = [], m
         name = name,
         srcs = srcs,
         hdrs = hdrs,
-        copts = ["-ObjC++", "-std=c++17", "-Wno-shorten-64-to-32"],
+        copts = ["-ObjC++", "-std=c++20", "-Wno-shorten-64-to-32"],
         defines = envoy_mobile_defines("@envoy"),
         module_name = module_name,
         sdk_frameworks = sdk_frameworks,

--- a/mobile/ci/BUILD
+++ b/mobile/ci/BUILD
@@ -1,27 +1,27 @@
 licenses(["notice"])  # Apache 2
 
 xcode_version(
-    name = "xcode_15_3_0",
-    default_ios_sdk_version = "17.4",
-    default_macos_sdk_version = "14.4",
-    default_tvos_sdk_version = "17.4",
-    default_watchos_sdk_version = "10.4",
-    version = "15.3",
+    name = "xcode_16_1_0",
+    default_ios_sdk_version = "18.1",
+    default_macos_sdk_version = "15.1",
+    default_tvos_sdk_version = "18.1",
+    default_watchos_sdk_version = "11.1",
+    version = "16.1",
 )
 
 available_xcodes(
     name = "local_xcodes",
-    default = ":xcode_15_3_0",
+    default = ":xcode_16_1_0",
     versions = [
-        ":xcode_15_3_0",
+        ":xcode_16_1_0",
     ],
 )
 
 available_xcodes(
     name = "remote_xcodes",
-    default = ":xcode_15_3_0",
+    default = ":xcode_16_1_0",
     versions = [
-        ":xcode_15_3_0",
+        ":xcode_16_1_0",
     ],
 )
 

--- a/mobile/ci/mac_ci_setup.sh
+++ b/mobile/ci/mac_ci_setup.sh
@@ -12,7 +12,8 @@ set -e
 export HOMEBREW_NO_AUTO_UPDATE=1
 RETRY_ATTEMPTS=10
 RETRY_INTERVAL=3
-XCODE_VERSION=15.3
+# https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md#xcode
+XCODE_VERSION=16.1
 
 function retry () {
     local returns=1 i=1
@@ -54,7 +55,6 @@ do
     install "${DEP}"
 done
 
-# https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md#xcode
 sudo xcode-select --switch "/Applications/Xcode_${XCODE_VERSION}.app"
 
 retry ./bazelw version

--- a/mobile/docs/root/start/building/building.rst
+++ b/mobile/docs/root/start/building/building.rst
@@ -58,7 +58,7 @@ See `ci/mac_ci_setup.sh` or `ci/linux_ci_setup.sh` for the specific NDK version 
 iOS requirements
 ----------------
 
-- Xcode 14.1
+- Xcode 16.0 or later
 - iOS 13.0 or later
 - Note: Requirements are listed in the :repo:`.bazelrc file <.bazelrc>` and CI scripts
 

--- a/mobile/library/common/internal_engine.cc
+++ b/mobile/library/common/internal_engine.cc
@@ -19,8 +19,13 @@ namespace Envoy {
 namespace {
 constexpr absl::Duration ENGINE_RUNNING_TIMEOUT = absl::Seconds(30);
 
+consteval int GetInt(int x){
+  return x;
+}
+
 // There is only one shared MobileProcessWide instance for all Envoy Mobile engines.
 MobileProcessWide& initOnceMobileProcessWide(const OptionsImplBase& options) {
+  std::cerr << "Testing a C++ 20 feature: " << GetInt(123) << std::endl;
   MUTABLE_CONSTRUCT_ON_FIRST_USE(MobileProcessWide, options);
 }
 


### PR DESCRIPTION
This will allow us to build mobile with C++20
and therefore allow C++ 20 features in the Envoy code base.