### PR TITLE
fix: make HTTP RBAC filter to set the metadata when enforced engine allows access

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -56,6 +56,10 @@ bug_fixes:
   change: |
     Fixes a bug where the lifetime of the HttpConnectionManager's ActiveStream can be out of sync
     with the lifetime of the codec stream.
+- area: rbac filter
+  change: |
+    Fixed an issue where metadata wasn't being set when the RBAC HTTP filter's enforced engine allowed access
+    (returned ``Continue``) and there was no shadow engine configured.
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/source/extensions/filters/http/rbac/rbac_filter.h
+++ b/source/extensions/filters/http/rbac/rbac_filter.h
@@ -126,7 +126,8 @@ public:
 
 private:
   // Handles shadow engine evaluation and updates metrics
-  bool evaluateShadowEngine(Http::RequestHeaderMap& headers, ProtobufWkt::Struct& metrics);
+  bool evaluateShadowEngine(const Http::RequestHeaderMap& headers,
+                            ProtobufWkt::Struct& metrics) const;
 
   // Handles enforced engine evaluation and updates metrics
   Http::FilterHeadersStatus evaluateEnforcedEngine(Http::RequestHeaderMap& headers,


### PR DESCRIPTION
## Description

This PR fixes an issue in the RBAC HTTP filter where dynamic metadata was not being set when:
1. Only an enforced engine exists (no shadow engine)
2. The enforced engine allows access (returns `FilterHeadersStatus::Continue`)

The bug was introduced in PR #39465 which refactored the RBAC filter code but didn't properly account for this case. It was reported in issue #39479.

## Changes

1. Modified the RBAC filter to check if an enforced engine exists, not just if it denied access
2. Added a new test case that specifically verifies this scenario
3. Improved code clarity with better variable names and comments

## Testing

Added a new test `EnforcedEngineOnlyAllowsAccessMetadataTest` which creates a config with only an enforced engine (no shadow engine) and verifies that metadata is correctly set when the enforced engine allows access. This test fails without the fix and passes with it, confirming that the fix addresses the issue.

**Fixes:** #39479

---

**Commit Message:** fix: make HTTP RBAC filter to set the metadata when enforced engine allows access
**Additional Description:** Fixed an issue in the RBAC HTTP filter where dynamic metadata was not being set.
**Risk Level:** Low
**Testing:** Added Unit Tests
**Docs Changes:** N/A
**Release Notes:** Added