### PR TITLE
Use GitHub mirror for V8 sources

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -1165,12 +1165,13 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         # NOTE: Update together with com_googlesource_chromium_base_trace_event_common.
         # Patch contains workaround for https://github.com/bazelbuild/rules_python/issues/1221
         version = "10.7.193.13",
-        # Static snapshot created using https://storage.googleapis.com/envoyproxy-wee8/wee8-fetch-deps.sh.
-        sha256 = "2170df76ce5d7ecd7fb8d131370d210152f200273cba126f06d8b88fb53c9fbc",
-        urls = ["https://storage.googleapis.com/envoyproxy-wee8/v8-{version}.tar.gz"],
+        # Follow thi sguide to pick next stable release: https://v8.dev/docs/version-numbers#which-v8-version-should-i-use%3F
+        strip_prefix = "v8-{version}",
+        sha256 = "6fb91b839e9c36ca4c151268f772e7a6a888a75bcb947f37be9758e49f485db7",
+        urls = ["https://github.com/v8/v8/archive/refs/tags/{version}.tar.gz"],
         use_category = ["dataplane_ext"],
         extensions = ["envoy.wasm.runtime.v8"],
-        release_date = "2022-10-12",
+        release_date = "2022-09-28",
         cpe = "cpe:2.3:a:google:v8:*",
     ),
     com_googlesource_chromium_base_trace_event_common = dict(

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -1165,7 +1165,7 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         # NOTE: Update together with com_googlesource_chromium_base_trace_event_common.
         # Patch contains workaround for https://github.com/bazelbuild/rules_python/issues/1221
         version = "10.7.193.13",
-        # Follow thi sguide to pick next stable release: https://v8.dev/docs/version-numbers#which-v8-version-should-i-use%3F
+        # Follow this guide to pick next stable release: https://v8.dev/docs/version-numbers#which-v8-version-should-i-use%3F
         strip_prefix = "v8-{version}",
         sha256 = "6fb91b839e9c36ca4c151268f772e7a6a888a75bcb947f37be9758e49f485db7",
         urls = ["https://github.com/v8/v8/archive/refs/tags/{version}.tar.gz"],


### PR DESCRIPTION
Additional Description:
This just updates V8 repository leaving currently used tag the same to create baseline. V8 tag update in the followup PR.

Risk Level: Low
Testing: Unit Tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
