### PR TITLE
Make StringMatcher::match consistent

### DIFF
--- a/envoy/common/matchers.h
+++ b/envoy/common/matchers.h
@@ -25,13 +25,13 @@ public:
   /**
    * Return whether a passed string value matches.
    */
-  virtual bool match(const absl::string_view value) const PURE;
+  virtual bool match(absl::string_view value) const PURE;
 
   /**
    * Return whether a passed string value matches with context.
    * Because most implementations don't use the context, provides a default implementation.
    */
-  virtual bool match(const absl::string_view value, const Context&) const { return match(value); }
+  virtual bool match(absl::string_view value, const Context&) const { return match(value); }
 };
 
 using StringMatcherPtr = std::unique_ptr<const StringMatcher>;

--- a/source/common/common/matchers.h
+++ b/source/common/common/matchers.h
@@ -98,7 +98,7 @@ public:
       : exact_(exact), ignore_case_(ignore_case) {}
 
   // StringMatcher
-  bool match(const absl::string_view value, OptRef<const StringMatcher::Context>) const {
+  bool match(absl::string_view value, OptRef<const StringMatcher::Context>) const {
     return ignore_case_ ? absl::EqualsIgnoreCase(value, exact_) : value == exact_;
   }
 
@@ -116,7 +116,7 @@ public:
       : prefix_(prefix), ignore_case_(ignore_case) {}
 
   // StringMatcher
-  bool match(const absl::string_view value, OptRef<const StringMatcher::Context>) const {
+  bool match(absl::string_view value, OptRef<const StringMatcher::Context>) const {
     return ignore_case_ ? absl::StartsWithIgnoreCase(value, prefix_)
                         : absl::StartsWith(value, prefix_);
   }
@@ -136,7 +136,7 @@ public:
       : suffix_(suffix), ignore_case_(ignore_case) {}
 
   // StringMatcher
-  bool match(const absl::string_view value, OptRef<const StringMatcher::Context>) const {
+  bool match(absl::string_view value, OptRef<const StringMatcher::Context>) const {
     return ignore_case_ ? absl::EndsWithIgnoreCase(value, suffix_) : absl::EndsWith(value, suffix_);
   }
 
@@ -161,7 +161,7 @@ public:
   RegexStringMatcher(RegexStringMatcher&& other) noexcept { regex_ = std::move(other.regex_); }
 
   // StringMatcher
-  bool match(const absl::string_view value, OptRef<const StringMatcher::Context>) const {
+  bool match(absl::string_view value, OptRef<const StringMatcher::Context>) const {
     return regex_->match(value);
   }
 
@@ -179,7 +179,7 @@ public:
         ignore_case_(ignore_case) {}
 
   // StringMatcher
-  bool match(const absl::string_view value, OptRef<const StringMatcher::Context>) const {
+  bool match(absl::string_view value, OptRef<const StringMatcher::Context>) const {
     return ignore_case_ ? absl::StrContains(absl::AsciiStrToLower(value), contents_)
                         : absl::StrContains(value, contents_);
   }
@@ -206,7 +206,7 @@ public:
       : custom_(getExtensionStringMatcher(custom, context)) {}
 
   // StringMatcher
-  bool match(const absl::string_view value, OptRef<const StringMatcher::Context> context) const {
+  bool match(absl::string_view value, OptRef<const StringMatcher::Context> context) const {
     if (context) {
       return custom_->match(value, context.ref());
     }
@@ -240,8 +240,8 @@ public:
   }
 
   // StringMatcher
-  bool match(const absl::string_view value) const override { return doMatch(value, absl::nullopt); }
-  bool match(const absl::string_view value, const StringMatcher::Context& context) const override {
+  bool match(absl::string_view value) const override { return doMatch(value, absl::nullopt); }
+  bool match(absl::string_view value, const StringMatcher::Context& context) const override {
     return doMatch(value, makeOptRef(context));
   }
 
@@ -317,7 +317,7 @@ private:
     }
   }
 
-  bool doMatch(const absl::string_view value, OptRef<const StringMatcher::Context> context) const {
+  bool doMatch(absl::string_view value, OptRef<const StringMatcher::Context> context) const {
     // Implementing polymorphism for match(absl::string_value) on the different
     // types that can be in the matcher_ variant.
     auto call_match = [value, context](const auto& obj) -> bool {
@@ -421,7 +421,7 @@ public:
   createSafeRegex(const envoy::type::matcher::v3::RegexMatcher& regex_matcher,
                   Server::Configuration::CommonFactoryContext& context);
 
-  bool match(const absl::string_view path) const override;
+  bool match(absl::string_view path) const override;
   const std::string& stringRepresentation() const { return matcher_.stringRepresentation(); }
 
 private:

--- a/source/extensions/filters/network/dubbo_proxy/router/route_matcher.h
+++ b/source/extensions/filters/network/dubbo_proxy/router/route_matcher.h
@@ -138,7 +138,7 @@ public:
   class InterfaceMatcher {
   public:
     InterfaceMatcher(const std::string& interface_name);
-    bool match(const absl::string_view interface) const { return impl_(interface); }
+    bool match(absl::string_view interface) const { return impl_(interface); }
 
   private:
     std::function<bool(const absl::string_view)> impl_;

--- a/source/extensions/string_matcher/lua/match.cc
+++ b/source/extensions/string_matcher/lua/match.cc
@@ -34,7 +34,7 @@ LuaStringMatcher::LuaStringMatcher(const std::string& code) : state_(luaL_newsta
   matcher_func_ref_ = luaL_ref(state_.get(), LUA_REGISTRYINDEX);
 }
 
-bool LuaStringMatcher::match(const absl::string_view value) const {
+bool LuaStringMatcher::match(absl::string_view value) const {
   const int initial_depth = lua_gettop(state_.get());
 
   bool ret = [&]() {
@@ -88,7 +88,7 @@ public:
     });
   }
 
-  bool match(const absl::string_view value) const override { return (*tls_slot_)->match(value); }
+  bool match(absl::string_view value) const override { return (*tls_slot_)->match(value); }
 
 private:
   ThreadLocal::TypedSlotPtr<LuaStringMatcher> tls_slot_;

--- a/source/extensions/string_matcher/lua/match.h
+++ b/source/extensions/string_matcher/lua/match.h
@@ -20,7 +20,7 @@ public:
   ~LuaStringMatcher() override = default;
 
   // Matchers::StringMatcher
-  bool match(const absl::string_view value) const override;
+  bool match(absl::string_view value) const override;
 
 private:
   CSmartPtr<lua_State, lua_close> state_;

--- a/test/common/tls/cert_validator/default_validator_integration_test.cc
+++ b/test/common/tls/cert_validator/default_validator_integration_test.cc
@@ -182,8 +182,8 @@ REGISTER_FACTORY(TestSanListenerFilterFactory,
 
 class CustomSanStringMatcher : public Matchers::StringMatcher {
 public:
-  bool match(const absl::string_view) const override { return false; }
-  bool match(const absl::string_view, const StringMatcher::Context& context) const override {
+  bool match(absl::string_view) const override { return false; }
+  bool match(absl::string_view, const StringMatcher::Context& context) const override {
     return context.stream_info_ &&
            context.stream_info_->filterState().hasDataWithName("test_san_filter_state");
   }


### PR DESCRIPTION
Commit Message: Make StringMatcher::match consistent
Additional Description: There were instances of `StringMatcher::match` that take `const absl::string_view` and instances that take `absl::string_view` (not const). Making a string_view const is about as meaningful as an argument being `const int`, in that there's little advantage, and for a virtual function significant disadvantage (in that an implementation may want to modify the value, and since it's passed by value there's no reason to not allow it), so my preferred direction of consistency is to remove the non-useful const rather than add it to the other overrides, but I'm happy to go the other way if reviewers have that preference.

My main reason to make it consistent is, the gcc build currently logs over 5000 instances of warnings like
```
./envoy/common/matchers.h:34:16: warning: ‘virtual bool Envoy::Matchers::StringMatcher::match(absl::lts_20250127::string_view, const Envoy::Matchers::StringMatcher::Context&) const’ was hidden [-Woverloaded-virtual]
    34 |   virtual bool match(const absl::string_view value, const Context&) const { return match(value); }
       |                ^~~~~
 In file included from ./source/common/stats/histogram_impl.h:11,
                  from ./test/mocks/stats/mocks.h:18,
                  from ./test/mocks/api/mocks.h:20,
                  from ./test/mocks/server/server_factory_context.h:13,
                  from ./test/mocks/server/instance.h:7,
                  from ./test/integration/fake_upstream.h:41,
                  from ./test/integration/autonomous_upstream.h:3,
                  from ./test/integration/base_integration_test.h:16,
                  from ./test/integration/integration.h:5,
                  from ./test/integration/http_integration.h:16,
                  from ./test/integration/http_protocol_integration.h:3,
                  from test/extensions/filters/http/lua/lua_integration_test.cc:5:
 ./source/common/common/matchers.h:88:8: note:   by ‘virtual bool Envoy::Matchers::UniversalStringMatcher::match(absl::lts_20250127::string_view) const’
    88 |   bool match(absl::string_view) const override { return true; }
       |        ^~~~~
 In file included from ./envoy/http/codec.h:9,
                  from ./source/common/http/codec_client.h:10,
                  from ./test/integration/http_integration.h:11,
                  from ./test/integration/http_protocol_integration.h:3,
                  from test/extensions/filters/http/lua/lua_integration_test.cc:5:
```
which makes those logs barely usable. But also it's just not very good virtual function practice!
Risk Level: No behavior change.
Testing: Does it still build?
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
