### PR TITLE
Make SanMatcher::match consistent

### DIFF
--- a/source/common/tls/cert_validator/san_matcher.cc
+++ b/source/common/tls/cert_validator/san_matcher.cc
@@ -27,7 +27,7 @@ bool StringSanMatcher::typeCompatible(const GENERAL_NAME* general_name) const {
   return true;
 }
 
-bool StringSanMatcher::match(const GENERAL_NAME* general_name) const {
+bool StringSanMatcher::match(GENERAL_NAME const* general_name) const {
   if (!typeCompatible(general_name)) {
     return false;
   }
@@ -35,7 +35,7 @@ bool StringSanMatcher::match(const GENERAL_NAME* general_name) const {
   return matcher_.match(Utility::generalNameAsString(general_name));
 }
 
-bool StringSanMatcher::match(const GENERAL_NAME* general_name,
+bool StringSanMatcher::match(GENERAL_NAME const* general_name,
                              const StreamInfo::StreamInfo& stream_info) const {
   if (!typeCompatible(general_name)) {
     return false;
@@ -45,7 +45,7 @@ bool StringSanMatcher::match(const GENERAL_NAME* general_name,
   return matcher_.match(Utility::generalNameAsString(general_name), context);
 }
 
-bool DnsExactStringSanMatcher::match(const GENERAL_NAME* general_name) const {
+bool DnsExactStringSanMatcher::match(GENERAL_NAME const* general_name) const {
   if (general_name->type != GEN_DNS) {
     return false;
   }

--- a/source/common/tls/cert_validator/san_matcher.h
+++ b/source/common/tls/cert_validator/san_matcher.h
@@ -42,8 +42,8 @@ using Ssl::SanMatcherPtr;
 
 class StringSanMatcher : public SanMatcher {
 public:
-  bool match(const GENERAL_NAME* general_name) const override;
-  bool match(const GENERAL_NAME* general_name,
+  bool match(GENERAL_NAME const* general_name) const override;
+  bool match(GENERAL_NAME const* general_name,
              const StreamInfo::StreamInfo& stream_info) const override;
   ~StringSanMatcher() override = default;
 
@@ -72,7 +72,7 @@ private:
 // and the DNS matching semantics must be followed.
 class DnsExactStringSanMatcher : public SanMatcher {
 public:
-  bool match(const GENERAL_NAME* general_name) const override;
+  bool match(GENERAL_NAME const* general_name) const override;
   ~DnsExactStringSanMatcher() override = default;
 
   DnsExactStringSanMatcher(absl::string_view dns_exact_match) : dns_exact_match_(dns_exact_match) {}


### PR DESCRIPTION
Commit Message: Make SanMatcher::match consistent
Additional Description: Function was implemented with a mix of `const GENERAL_NAME*` and `GENERAL_NAME const*`. I expect the latter was the intention, a pointer to an immutable struct, not an immutable pointer to a mutable struct. (Arguably the intention is *both* kinds of const, but there is no meaningful value in the pointer being immutable.)
The current implementation also leads to many warnings in the gcc build of the form
```
./source/common/tls/cert_validator/san_matcher.h:27:16: warning: ‘virtual bool Envoy::Ssl::SanMatcher::match(const GENERAL_NAME*, const Envoy::StreamInfo::StreamInfo&) const’ was hidden [-Woverloaded-virtual]
    27 |   virtual bool match(GENERAL_NAME const* general_name, const StreamInfo::StreamInfo&) const {
```
Risk Level: No behavior change.
Testing: If it builds it's good.
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
