### PR TITLE
http2: Add header validation to prevent assertion failures in fuzz tests

### DIFF
--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -1780,6 +1780,15 @@ bool ConnectionImpl::Http2Visitor::OnBeginHeadersForStream(Http2StreamId stream_
 OnHeaderResult ConnectionImpl::Http2Visitor::OnHeaderForStream(Http2StreamId stream_id,
                                                                absl::string_view name_view,
                                                                absl::string_view value_view) {
+  // Validate the header name and value before setting them
+  const bool valid_name = HeaderUtility::headerNameIsValid(name_view);
+  const bool valid_value = HeaderUtility::headerValueIsValid(value_view);
+
+  if (!valid_name || !valid_value) {
+    ENVOY_LOG(debug, "Invalid header name or value received: [{}:{}]", name_view, value_view);
+    return OnHeaderResult::HEADER_CONNECTION_ERROR;
+  }
+
   // TODO PERF: Can reference count here to avoid copies.
   HeaderString name;
   name.setCopy(name_view.data(), name_view.size());


### PR DESCRIPTION
## Description

The fuzz test for the HTTP/2 codec i.e. `http2_codec_impl_fuzz_test` triggers an assertion failure in `valid()` in `UnionStringBase` when it tries to process malformed inputs from the fuzzer (like the corrupted `:scheme` header with value "h+tpN").

Root Cause seems to be that while processing header frames in the HTTP/2 codec, `OnHeaderForStream` calls `setCopy()` on the header name and value without validating that they contain only valid characters. This leads to an assertion failure in `UnionStringBase::valid()` when testing with malformed input from the fuzzer.

This PR adds validation checks before attempting to copy header data which solves the issue.

**Repro:**
```
./ci/do_ci.sh compile_time_options test/common/http/http2_codec_impl_fuzz_test
```

---

**Commit Message:** http2: Add header validation to prevent assertion failures in fuzz tests
**Additional Description:** Added header validation in the HTTP codec to prevent assertion failures.
**Risk Level:** Low
**Testing:** Existing Fuzz Test
**Docs Changes:** N/A
**Release Notes:** N/A