### PR TITLE
ci: Add a workflow to test Xcode-16.1 for macos/iOS builds

### DIFF
--- a/.github/workflows/mobile-ios_build_xcode16.yml
+++ b/.github/workflows/mobile-ios_build_xcode16.yml
@@ -1,0 +1,134 @@
+name: Mobile/iOS build Xcode 16
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+
+
+concurrency:
+  group: >-
+    ${{ ((github.event.workflow_run.head_branch == 'main'
+          || startsWith(github.event.workflow_run.head_branch, 'release/v'))
+          && github.event.repository.full_name == github.repository)
+        && github.run_id
+        || github.event.workflow_run.head_branch }}-${{ github.event.repository.full_name }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+
+jobs:
+  load:
+    secrets:
+      app-key: ${{ secrets.ENVOY_CI_APP_KEY }}
+      app-id: ${{ secrets.ENVOY_CI_APP_ID }}
+    permissions:
+      actions: read
+      contents: read
+      packages: read
+      pull-requests: read
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    uses: ./.github/workflows/_load.yml
+    with:
+      check-name: mobile-ios
+
+  build:
+    permissions:
+      contents: read
+      packages: read
+    uses: ./.github/workflows/_run.yml
+    if: ${{ fromJSON(needs.load.outputs.request).run.mobile-ios }}
+    needs: load
+    name: ios-build
+    with:
+      args: ${{ matrix.args }}
+      command: ./bazelw
+      container-command:
+      docker-ipv6: false
+      request: ${{ needs.load.outputs.request }}
+      runs-on: macos-14
+      source: |
+        source ./ci/mac_ci_setup_xcode16.sh
+        ./bazelw shutdown
+      steps-post: ${{ matrix.steps-post }}
+      target: ${{ matrix.target }}
+      timeout-minutes: ${{ matrix.timeout-minutes }}
+      trusted: ${{ fromJSON(needs.load.outputs.trusted) }}
+      working-directory: mobile
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - name: Build Envoy.framework distributable
+          args: >-
+            build
+            --config=mobile-remote-ci-macos-ios-xcode16
+            //library/swift:ios_framework
+          target: ios
+          timeout-minutes: 120
+
+  hello-world:
+    permissions:
+      contents: read
+      packages: read
+    uses: ./.github/workflows/_run.yml
+    if: ${{ fromJSON(needs.load.outputs.request).run.mobile-ios }}
+    needs:
+    - load
+    - build
+    name: ios-hello-world
+    with:
+      args: >-
+        build
+        ${{ matrix.args || '--config=mobile-remote-ci-macos-ios-xcode16' }}
+        ${{ matrix.app }}
+      command: ./bazelw
+      container-command:
+      docker-ipv6: false
+      request: ${{ needs.load.outputs.request }}
+      runs-on: macos-14-xlarge
+      source: |
+        source ./ci/mac_ci_setup_xcode16.sh
+        ./bazelw shutdown
+      steps-post: |
+        - uses: envoyproxy/toolshed/gh-actions/envoy/ios/post@actions-v0.3.16
+          with:
+            app: ${{ matrix.app }}
+            args: ${{ matrix.args || '--config=mobile-remote-ci-macos-ios-xcode16' }}
+            expected: received headers with status ${{ matrix.expected-status }}
+          env:
+            ANDROID_NDK_HOME:
+            ANDROID_HOME:
+      target: ${{ matrix.target }}
+      timeout-minutes: ${{ matrix.timeout-minutes }}
+      trusted: ${{ fromJSON(needs.load.outputs.trusted) }}
+      working-directory: mobile
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - name: Build swift hello world
+          app: //examples/swift/hello_world:app
+          expected-status: 200
+          target: swift-hello-world
+          timeout-minutes: 90
+
+  request:
+    secrets:
+      app-id: ${{ secrets.ENVOY_CI_APP_ID }}
+      app-key: ${{ secrets.ENVOY_CI_APP_KEY }}
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: read
+    if: >-
+      ${{ always()
+          && github.event.workflow_run.conclusion == 'success'
+          && fromJSON(needs.load.outputs.request).run.mobile-ios }}
+    needs:
+    - load
+    - build
+    - hello-world
+    uses: ./.github/workflows/_finish.yml
+    with:
+      needs: ${{ toJSON(needs) }}

--- a/mobile/.bazelrc
+++ b/mobile/.bazelrc
@@ -266,3 +266,8 @@ test:mobile-remote-ci-macos-ios-swift --build_tests_only
 
 build:mobile-remote-ci-macos-ios-obj-c --config=mobile-remote-ci-macos-ios
 test:mobile-remote-ci-macos-ios-obj-c --build_tests_only
+
+build:mobile-remote-ci-macos-ios-xcode16 --config=mobile-remote-ci-macos
+build:mobile-remote-ci-macos-ios-xcode16 --config=mobile-test-ios
+build:mobile-remote-ci-macos-ios-xcode16 --xcode_version=16.1
+build:mobile-remote-ci-macos-ios-xcode16 --macos_minimum_os=14.5

--- a/mobile/ci/mac_ci_setup_xcode16.sh
+++ b/mobile/ci/mac_ci_setup_xcode16.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Copied from Envoy upstream's setup scripts with homebrew update disabled.
+# Installs the dependencies required for a macOS build via homebrew.
+# Tools are not upgraded to new versions.
+# See:
+# https://github.com/actions/virtual-environments/blob/main/images/macos/macos-12-Readme.md for
+# a list of pre-installed tools in the macOS image.
+
+export HOMEBREW_NO_AUTO_UPDATE=1
+RETRY_ATTEMPTS=10
+RETRY_INTERVAL=3
+# https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md#xcode
+XCODE_VERSION=16.1
+
+function retry () {
+    local returns=1 i=1
+    while ((i<=RETRY_ATTEMPTS)); do
+        if "$@"; then
+            returns=0
+            break
+        else
+            sleep "$RETRY_INTERVAL";
+            ((i++))
+        fi
+    done
+    return "$returns"
+}
+
+function install {
+    echo "Installing brew package $1"
+    if ! retry brew install --quiet "$1"; then
+        echo "Failed to install brew package $1"
+        exit 1
+    fi
+}
+
+if ! retry brew update; then
+  # Do not exit early if update fails.
+  echo "Failed to update homebrew"
+fi
+
+# This is to save some disk space.
+# https://mac.install.guide/homebrew/8
+brew autoremove
+brew cleanup --prune=all
+# Remove broken symlinks.
+brew cleanup --prune-prefix
+
+DEPS="automake cmake coreutils libtool ninja"
+for DEP in ${DEPS}
+do
+    install "${DEP}"
+done
+
+sudo xcode-select --switch "/Applications/Xcode_${XCODE_VERSION}.app"
+
+retry ./bazelw version
+
+# Unset default variables so we don't have to install Android SDK/NDK.
+unset ANDROID_HOME
+unset ANDROID_NDK_HOME


### PR DESCRIPTION
The CI workflow is not part of the jobs run on PR merging but rather it can only be manually triggered.

Once Xcode 16.1 is working, it will become the default and we can get rid of this job.