### PR TITLE
override host: support multiple addresses parsing and cache parsing result

### DIFF
--- a/api/envoy/extensions/load_balancing_policies/override_host/v3/override_host.proto
+++ b/api/envoy/extensions/load_balancing_policies/override_host/v3/override_host.proto
@@ -19,19 +19,19 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // Configuration for the Override Host Load Balancing policy.
 //
-// This policy allows endpoint picking to be implemented in an external to Envoy
-// component. For example an ext_proc RPC to a service that implements k8s proposal for AI gateway inferences extensions
+// This policy allows endpoint picking to be implemented in downstream HTTP filters. For example an ext_proc RPC to a service
+// that implements k8s proposal for AI gateway inferences extensions
 // https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals/004-endpoint-picker-protocol
 // can provide hosts for serving a request using Override Host load balancing policy.
 //
-// This policy uses selected endpoints from either request headers or request metadata.
+// This policy extracts selected override hosts from a list of ``OverrideHostSource`` (request headers, metadata, etc.).
 //
-// The primary host override source must specify a single ``IP:port`` value in either the header or the
-// metadata. For example ``10.0.0.5:8080`` or ``[2600:4040:5204::1574:24ae]:80``. The IPv6 address is enclosed in square brackets.
+// The override host source must specify at least one host in ``IP:Port`` format or multiple hosts in ``IP:Port,IP:Port,...``
+// format. For example ``10.0.0.5:8080`` or ``[2600:4040:5204::1574:24ae]:80``. The IPv6 address is enclosed in square brackets.
 //
-// For example, to support k8s gateway inference extensions, which uses the ``x-gateway-destination-endpoint`` header or metadata
-// value under the "envoy.lb" key for the primary endpoint, the Override Host load balancing policy should be configured in the
-// following way:
+// For specific example, to support k8s gateway inference extensions, which uses the ``x-gateway-destination-endpoint``
+// header or metadata value under the "envoy.lb" key for selected hosts, the Override Host load balancing policy should be
+// configured in the following way:
 //
 // .. code-block:: yaml
 //
@@ -41,9 +41,8 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 //          key: "envoy.lb"
 //          path:
 //          - key: "x-gateway-destination-endpoint"
-//      - header: "x-gateway-fallback-endpoints"
 //
-// If neither header nor metadata is present, then the specified fallback load balancing policy is used. This allows load
+// If no valid host in the override host list, then the specified fallback load balancing policy is used. This allows load
 // balancing to degrade to a a built in policy (i.e. Round Robin) in case external endpoint picker fails.
 //
 // See the :ref:`load balancing architecture
@@ -51,13 +50,16 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 //
 message OverrideHost {
   message OverrideHostSource {
-    // The header to get the override host addresses. Only one of the header or metadata field must be set.
+    // The header to get the override host addresses.
+    //
+    // Only one of the header or metadata field could be set.
     string header = 1
         [(validate.rules).string = {well_known_regex: HTTP_HEADER_VALUE strict: false}];
 
     // The metadata key to get the override host addresses from the request dynamic metadata. If
     // set this field then it will take precedence over the header field.
-    // Only one of the header or metadata field must be set.
+    //
+    // Only one of the header or metadata field could be set.
     type.metadata.v3.MetadataKey metadata = 2;
   }
 

--- a/source/extensions/load_balancing_policies/override_host/load_balancer.cc
+++ b/source/extensions/load_balancing_policies/override_host/load_balancer.cc
@@ -20,7 +20,6 @@
 #include "source/common/common/thread.h"
 #include "source/common/config/metadata.h"
 #include "source/common/config/utility.h"
-#include "source/extensions/load_balancing_policies/override_host/override_host_filter_state.h"
 
 #include "absl/container/inlined_vector.h"
 #include "absl/log/check.h"
@@ -153,21 +152,28 @@ OverrideHostLoadBalancer::LoadBalancerImpl::chooseHost(LoadBalancerContext* cont
     return fallback_picker_lb_->chooseHost(context);
   }
 
-  // First check if headers or request metadata contains the list of endpoints
-  // that should be used for serving.
-  // TODO(yanavlasov): Store parsed SelectedHosts in the filter state to avoid
-  // parsing it again during retries.
-  std::vector<std::string> selected_hosts = getSelectedHosts(context);
-  if (selected_hosts.empty()) {
+  OverrideHostFilterState* override_host_state = nullptr;
+  if (override_host_state =
+          context->requestStreamInfo()->filterState()->getDataMutable<OverrideHostFilterState>(
+              OverrideHostFilterState::kFilterStateKey);
+      override_host_state == nullptr) {
+    auto state_ptr = std::make_shared<OverrideHostFilterState>(getSelectedHosts(context));
+    override_host_state = state_ptr.get();
+
+    context->requestStreamInfo()->filterState()->setData(
+        OverrideHostFilterState::kFilterStateKey, std::move(state_ptr),
+        StreamInfo::FilterState::StateType::Mutable);
+  }
+
+  if (override_host_state->selectedHosts().empty()) {
     ENVOY_LOG(trace, "No overriden hosts were found. Using fallback LB policy.");
     return fallback_picker_lb_->chooseHost(context);
   }
 
-  HostConstSharedPtr host =
-      getEndpoint(selected_hosts, *context->requestStreamInfo()->filterState());
-  if (host) {
+  if (HostConstSharedPtr host = getEndpoint(*override_host_state); host != nullptr) {
     return {host};
   }
+
   // If some endpoints were found, but none of them are available in
   // the cluster endpoint set, or the number of retries in the retry policy
   // exceeds the number of fallback endpoints, then use to the fallback LB
@@ -184,7 +190,7 @@ OverrideHostLoadBalancer::LoadBalancerImpl::getSelectedHostsFromMetadata(
       Config::Metadata::metadataValue(&metadata, metadata_key);
   // TODO(yanavlasov): make it distinguish between not-present and invalid metadata.
   if (metadata_value.has_string_value()) {
-    return metadata_value.string_value();
+    return absl::string_view{metadata_value.string_value()};
   }
   return absl::nullopt;
 }
@@ -204,33 +210,41 @@ OverrideHostLoadBalancer::LoadBalancerImpl::getSelectedHostsFromHeader(
   return result[0]->value().getStringView();
 }
 
-std::vector<std::string>
+std::string
 OverrideHostLoadBalancer::LoadBalancerImpl::getSelectedHosts(LoadBalancerContext* context) {
   // This is checked by config validation.
   ASSERT(!config_.overrideHostSources().empty());
 
-  std::vector<std::string> selected_hosts;
+  std::string selected_hosts;
+  selected_hosts.reserve(256);
+
   for (const auto& override_source : config_.overrideHostSources()) {
     // This is checked by config validation
     ASSERT(override_source.header_name.has_value() != override_source.metadata_key.has_value());
+
     if (override_source.header_name.has_value()) {
       absl::optional<absl::string_view> host = getSelectedHostsFromHeader(
           context->downstreamHeaders(), override_source.header_name.value());
-      if (host.has_value() && !host.value().empty()) {
-        selected_hosts.push_back(std::string(host.value()));
+      if (host.has_value()) {
+        selected_hosts.append(host.value());
+        selected_hosts.push_back(',');
       }
     }
 
     // Lookup selected endpoints in the request metadata if the header based
-    // selection is not enabled or header was not present.
+    // selection is not enabled.
     if (override_source.metadata_key.has_value()) {
       absl::optional<absl::string_view> host = getSelectedHostsFromMetadata(
           context->requestStreamInfo()->dynamicMetadata(), override_source.metadata_key.value());
-      if (host.has_value() && !host.value().empty()) {
-        selected_hosts.push_back(std::string(host.value()));
+      if (host.has_value()) {
+        selected_hosts.append(host.value());
+        selected_hosts.push_back(',');
       }
     }
   }
+
+  std::cout << selected_hosts << std::endl;
+  ENVOY_LOG(trace, "Selected endpoints: {}", selected_hosts);
   return selected_hosts;
 }
 
@@ -255,49 +269,27 @@ OverrideHostLoadBalancer::LoadBalancerImpl::findHost(absl::string_view endpoint)
 }
 
 HostConstSharedPtr OverrideHostLoadBalancer::LoadBalancerImpl::getEndpoint(
-    const std::vector<std::string>& selected_hosts, StreamInfo::FilterState& filter_state) {
-  uint32_t fallback_index = 1;
-  OverrideHostFilterState* override_host_state =
-      filter_state.getDataMutable<OverrideHostFilterState>(
-          OverrideHostFilterState::kFilterStateKey);
-  if (!override_host_state && selected_hosts.size()) {
-    // Use the primary endpoint.
-    ENVOY_LOG(trace, "Selecting primary endpoint {}", selected_hosts[0]);
-    auto new_override_host_state = std::make_shared<OverrideHostFilterState>();
-    filter_state.setData(OverrideHostFilterState::kFilterStateKey, new_override_host_state,
-                         StreamInfo::FilterState::StateType::Mutable);
-    override_host_state = new_override_host_state.get();
+    OverrideHostFilterState& override_host_state) {
+  uint64_t host_index = override_host_state.hostIndex();
+  const auto selected_hosts = override_host_state.selectedHosts();
 
-    // Endpoint extracted from the header does not have locality.
-    HostConstSharedPtr host = findHost(selected_hosts[0]);
-    // If the primary endpoint was found in the current host set, use it.
-    // Otherwise try to see if one of the failover endpoints is available. This
-    // is possible when the cluster received EDS update while the request to the
-    // endpoint picker was in flight.
-    if (host) {
+  for (; host_index < selected_hosts.size(); host_index++) {
+    if (HostConstSharedPtr host = findHost(selected_hosts[host_index]); host != nullptr) {
+      ENVOY_LOG(trace, "Selected endpoint {}: {}", host_index, selected_hosts[host_index]);
+      // Update the host index in the filter state to the next host. We will start from that
+      // index in the next call to getEndpoint.
+      override_host_state.setHostIndex(host_index + 1);
       return host;
     }
-  } else {
-    fallback_index = override_host_state->fallbackHostIndex();
   }
 
-  // Loop through fallback hosts until we find one that is available.
-  HostConstSharedPtr host;
-  for (; fallback_index < selected_hosts.size() && !host; ++fallback_index) {
-    ENVOY_LOG(trace, "Selecting failover endpoint {}: {}", fallback_index,
-              selected_hosts[fallback_index]);
-    host = findHost(selected_hosts[fallback_index]);
-  }
+  // If we reach here, it means that all the selected hosts are not available or have used.
+  ASSERT(host_index == selected_hosts.size());
+  override_host_state.setHostIndex(host_index);
+  ENVOY_LOG(trace, "Number of retry attempts has exceeded the number of failover endpoints {}",
+            selected_hosts.size());
 
-  // Update the fallback index in the metadata.
-  override_host_state->setFallbackHostIndex(fallback_index);
-  if (!host) {
-    ENVOY_LOG(trace,
-              "Number of retry attempts {} has exceeded the number of failover "
-              "endpoints {}",
-              fallback_index + 1, selected_hosts.size());
-  }
-  return host;
+  return nullptr;
 }
 
 LoadBalancerPtr

--- a/source/extensions/load_balancing_policies/override_host/load_balancer.cc
+++ b/source/extensions/load_balancing_policies/override_host/load_balancer.cc
@@ -215,6 +215,7 @@ OverrideHostLoadBalancer::LoadBalancerImpl::getSelectedHosts(LoadBalancerContext
   // This is checked by config validation.
   ASSERT(!config_.overrideHostSources().empty());
 
+  // Use single string to store all selected hosts to avoid multiple heap allocations.
   std::string selected_hosts;
   selected_hosts.reserve(256);
 
@@ -243,7 +244,6 @@ OverrideHostLoadBalancer::LoadBalancerImpl::getSelectedHosts(LoadBalancerContext
     }
   }
 
-  std::cout << selected_hosts << std::endl;
   ENVOY_LOG(trace, "Selected endpoints: {}", selected_hosts);
   return selected_hosts;
 }

--- a/source/extensions/load_balancing_policies/override_host/load_balancer.h
+++ b/source/extensions/load_balancing_policies/override_host/load_balancer.h
@@ -19,7 +19,7 @@
 
 #include "source/common/common/logger.h"
 #include "source/common/config/metadata.h"
-#include "source/common/protobuf/protobuf.h"
+#include "source/extensions/load_balancing_policies/override_host/override_host_filter_state.h"
 
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
@@ -145,15 +145,12 @@ private:
     }
 
   private:
-    HostConstSharedPtr getEndpoint(const std::vector<std::string>& selected_hosts,
-                                   StreamInfo::FilterState& filter_state);
+    HostConstSharedPtr getEndpoint(OverrideHostFilterState& override_host_state);
     HostConstSharedPtr findHost(absl::string_view endpoint);
 
     // Lookup the list of endpoints selected by the LbTrafficExtension in the
-    // header (if configured) or in the request metadata.
-    // nullptr if neither host nor metadata is present.
-    // Error if the metadata is present but cannot be parsed.
-    std::vector<std::string> getSelectedHosts(LoadBalancerContext* context);
+    // header or in the request metadata.
+    std::string getSelectedHosts(LoadBalancerContext* context);
 
     // Return a list of endpoints selected by the LbTrafficExtension.
     // nullopt if the metadata is not present.

--- a/source/extensions/load_balancing_policies/override_host/load_balancer.h
+++ b/source/extensions/load_balancing_policies/override_host/load_balancer.h
@@ -150,7 +150,8 @@ private:
 
     // Lookup the list of endpoints selected by the LbTrafficExtension in the
     // header or in the request metadata.
-    std::string getSelectedHosts(LoadBalancerContext* context);
+    // TODO(wbpcode): will absl::InlinedVector be used here be better?
+    std::vector<std::string> getSelectedHosts(LoadBalancerContext* context);
 
     // Return a list of endpoints selected by the LbTrafficExtension.
     // nullopt if the metadata is not present.

--- a/source/extensions/load_balancing_policies/override_host/override_host_filter_state.h
+++ b/source/extensions/load_balancing_policies/override_host/override_host_filter_state.h
@@ -18,11 +18,8 @@ public:
   static constexpr absl::string_view kFilterStateKey =
       "envoy.extensions.load_balancing_policies.override_host.filter_state";
 
-  OverrideHostFilterState(std::string&& host_list) : host_list_(std::move(host_list)) {
-    for (absl::string_view host : absl::StrSplit(host_list_, ',', absl::SkipWhitespace())) {
-      selected_hosts_.push_back(absl::StripAsciiWhitespace(host));
-    }
-  }
+  OverrideHostFilterState(std::string&& host_list)
+      : host_list_(std::move(host_list)), selected_hosts_(parseList(host_list_)) {}
 
   uint64_t hostIndex() const { return host_index_; }
   void setHostIndex(uint64_t host_index) { host_index_ = host_index; }
@@ -30,8 +27,16 @@ public:
   absl::Span<const absl::string_view> selectedHosts() const { return selected_hosts_; }
 
 private:
+  static absl::InlinedVector<absl::string_view, 8> parseList(absl::string_view list) {
+    absl::InlinedVector<absl::string_view, 8> result;
+    for (absl::string_view host : absl::StrSplit(list, ',', absl::SkipWhitespace())) {
+      result.push_back(absl::StripAsciiWhitespace(host));
+    }
+    return result;
+  }
+
   const std::string host_list_;
-  absl::InlinedVector<absl::string_view, 8> selected_hosts_;
+  const absl::InlinedVector<absl::string_view, 8> selected_hosts_;
   uint64_t host_index_ = 0;
 };
 

--- a/source/extensions/load_balancing_policies/override_host/override_host_filter_state.h
+++ b/source/extensions/load_balancing_policies/override_host/override_host_filter_state.h
@@ -31,7 +31,7 @@ public:
 
 private:
   const std::string host_list_;
-  absl::InlinedVector<const absl::string_view, 8> selected_hosts_;
+  absl::InlinedVector<absl::string_view, 8> selected_hosts_;
   uint64_t host_index_ = 0;
 };
 

--- a/source/extensions/load_balancing_policies/override_host/override_host_filter_state.h
+++ b/source/extensions/load_balancing_policies/override_host/override_host_filter_state.h
@@ -2,6 +2,7 @@
 
 #include "envoy/stream_info/filter_state.h"
 
+#include "absl/strings/str_split.h"
 #include "absl/strings/string_view.h"
 
 namespace Envoy {
@@ -16,15 +17,22 @@ class OverrideHostFilterState : public StreamInfo::FilterState::Object {
 public:
   static constexpr absl::string_view kFilterStateKey =
       "envoy.extensions.load_balancing_policies.override_host.filter_state";
-  OverrideHostFilterState() = default;
 
-  uint64_t fallbackHostIndex() const { return fallback_host_index_; }
-  void setFallbackHostIndex(uint64_t fallback_host_index) {
-    fallback_host_index_ = fallback_host_index;
+  OverrideHostFilterState(std::string&& host_list) : host_list_(std::move(host_list)) {
+    for (absl::string_view host : absl::StrSplit(host_list_, ',', absl::SkipWhitespace())) {
+      selected_hosts_.push_back(absl::StripAsciiWhitespace(host));
+    }
   }
 
+  uint64_t hostIndex() const { return host_index_; }
+  void setHostIndex(uint64_t host_index) { host_index_ = host_index; }
+
+  absl::Span<const absl::string_view> selectedHosts() const { return selected_hosts_; }
+
 private:
-  uint64_t fallback_host_index_ = 1;
+  const std::string host_list_;
+  absl::InlinedVector<const absl::string_view, 8> selected_hosts_;
+  uint64_t host_index_ = 0;
 };
 
 } // namespace OverrideHost

--- a/source/extensions/load_balancing_policies/override_host/override_host_filter_state.h
+++ b/source/extensions/load_balancing_policies/override_host/override_host_filter_state.h
@@ -18,7 +18,8 @@ public:
   static constexpr absl::string_view kFilterStateKey =
       "envoy.extensions.load_balancing_policies.override_host.filter_state";
 
-  OverrideHostFilterState(std::string&& host_list) : host_list_(std::move(host_list)) {}
+  OverrideHostFilterState(std::vector<std::string>&& host_list)
+      : host_list_(std::move(host_list)) {}
   bool empty() const { return host_list_.empty(); }
 
   /**
@@ -26,22 +27,14 @@ public:
    * Empty string view is returned if there are no more hosts.
    */
   absl::string_view consumeNextHost() {
-    for (; host_index_ < host_list_.size();) {
-      auto host = absl::string_view(host_list_).substr(host_index_);
-      host = host.substr(0, host.find(','));
-
-      host_index_ += host.size() + 1; // +1 for the delimiter
-
-      // Skip senseless host.
-      if (host = absl::StripAsciiWhitespace(host); !host.empty()) {
-        return host;
-      }
+    if (host_index_ >= host_list_.size()) {
+      return {};
     }
-    return {};
+    return host_list_[host_index_++];
   }
 
 private:
-  const std::string host_list_;
+  const std::vector<std::string> host_list_;
   uint64_t host_index_ = 0;
 };
 

--- a/source/extensions/load_balancing_policies/override_host/override_host_filter_state.h
+++ b/source/extensions/load_balancing_policies/override_host/override_host_filter_state.h
@@ -20,6 +20,11 @@ public:
 
   OverrideHostFilterState(std::string&& host_list) : host_list_(std::move(host_list)) {}
   bool empty() const { return host_list_.empty(); }
+
+  /**
+   * @return consume next valid host from the list of selected hosts.
+   * Empty string view is returned if there are no more hosts.
+   */
   absl::string_view consumeNextHost() {
     for (; host_index_ < host_list_.size();) {
       auto host = absl::string_view(host_list_).substr(host_index_);


### PR DESCRIPTION
Commit Message: override host: support multiple addresses parsing and cache parsing result
Additional Description:

1. The override host lb could parse multiple hosts from single header or single metadata entry. **It's completely compatible with previous implementation.**
2. The initial parsing result will be cached.

Risk Level: n/a.
Testing: unit.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.