### PR TITLE
tcp_stats: fix a flaky test fixture

### DIFF
--- a/test/extensions/transport_sockets/tcp_stats/tcp_stats_test.cc
+++ b/test/extensions/transport_sockets/tcp_stats/tcp_stats_test.cc
@@ -30,6 +30,8 @@ namespace {
 class TcpStatsTest : public testing::Test {
 public:
   void initialize(bool enable_periodic) {
+    // Reset the C struct tcp_info_ members.
+    memset(&tcp_info_, 0, sizeof(tcp_info_));
     envoy::extensions::transport_sockets::tcp_stats::v3::Config proto_config;
     if (enable_periodic) {
       proto_config.mutable_update_period()->MergeFrom(


### PR DESCRIPTION
Commit Message: tcp_stats: fix a flaky test fixture
Additional Description:
Our internal system caught a tcp_stats case that assumed initialization of all the fields of the tcp_info C struct in one of the test fixtures.
This change introduces an explicit initialization of this data-member.

Risk Level: low - tests only.
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
