### PR TITLE
Tap/Transport tap Enhance buffer trace to send tapped messages based on configured size

### DIFF
--- a/api/envoy/config/tap/v3/common.proto
+++ b/api/envoy/config/tap/v3/common.proto
@@ -154,6 +154,7 @@ message HttpGenericBodyMatch {
 }
 
 // Tap output configuration.
+// [#next-free-field: 6]
 message OutputConfig {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.service.tap.v2alpha.OutputConfig";
@@ -181,6 +182,14 @@ message OutputConfig {
   // match can be determined. See the HTTP tap filter :ref:`streaming
   // <config_http_filters_tap_streaming>` documentation for more information.
   bool streaming = 4;
+
+  // For streamed tapping, tapped messages are sent on each read/write event,
+  // even for small payloads (e.g., 9 bytes, the minimum HTTP/2 frame size).
+  // To improve performance under high traffic, use min_streamed_sent_bytes
+  // to control when tapped messages are sent based on a configured size threshold.
+  // If specified, the minimum allowed value for min_streamed_sent_bytes is 9 bytes.
+  // This setting is only applicable when stream tracing is enabled.
+  google.protobuf.UInt32Value min_streamed_sent_bytes = 5;
 }
 
 // Tap output sink configuration.

--- a/api/envoy/config/tap/v3/common.proto
+++ b/api/envoy/config/tap/v3/common.proto
@@ -183,12 +183,10 @@ message OutputConfig {
   // <config_http_filters_tap_streaming>` documentation for more information.
   bool streaming = 4;
 
-  // For streamed tapping, tapped messages are sent on each read/write event,
-  // even for small payloads (e.g., 9 bytes, the minimum HTTP/2 frame size).
-  // To improve performance under high traffic, use min_streamed_sent_bytes
-  // to control when tapped messages are sent based on a configured size threshold.
-  // If specified, the minimum allowed value for min_streamed_sent_bytes is 9 bytes.
-  // This setting is only applicable when stream tracing is enabled.
+  // Tapped messages will be sent on each read/write event for streamed tapping by default.
+  // But this behavior could be controlled by setting this field.
+  // If set then the tapped messages will be send once the threshold is reached.
+  // This could be used to avoid high frequent sending.
   google.protobuf.UInt32Value min_streamed_sent_bytes = 5;
 }
 

--- a/api/envoy/data/tap/v3/transport.proto
+++ b/api/envoy/data/tap/v3/transport.proto
@@ -112,4 +112,7 @@ message SocketStreamedTraceSegment {
     // Socket event.
     SocketEvent event = 3;
   }
+
+  // Sequence of observed events.
+  repeated SocketEvent events = 4;
 }

--- a/api/envoy/data/tap/v3/transport.proto
+++ b/api/envoy/data/tap/v3/transport.proto
@@ -96,6 +96,11 @@ message SocketBufferedTrace {
   bool write_truncated = 5;
 }
 
+// A message for the sequence of observed events
+message SocketEvents {
+  repeated SocketEvent events = 1;
+}
+
 // A streamed socket trace segment. Multiple segments make up a full trace.
 message SocketStreamedTraceSegment {
   option (udpa.annotations.versioning).previous_message_type =
@@ -111,8 +116,8 @@ message SocketStreamedTraceSegment {
 
     // Socket event.
     SocketEvent event = 3;
-  }
 
-  // Sequence of observed events.
-  repeated SocketEvent events = 4;
+    // Sequence of observed events.
+    SocketEvents events = 4;
+  }
 }

--- a/api/envoy/extensions/transport_sockets/tap/v3/tap.proto
+++ b/api/envoy/extensions/transport_sockets/tap/v3/tap.proto
@@ -38,28 +38,18 @@ message Tap {
 }
 
 // Additional configurations for the transport socket tap
-// [#next-free-field: 6]
 message SocketTapConfig {
   // Indicates to whether output the connection information per event
   // This is only applicable if the streamed trace is enabled
   bool set_connection_per_event = 1;
 
-  // Indicates whether pegging the tap counter is required.
-  bool pegging_counter = 2;
-
   // The contents of the transport tap's statistics prefix.
-  string stats_prefix = 3;
-
-  // Indicates whether sending the tapped messages for the buffer trace
-  // which is conditioned on the configured min_buffered_bytes bytes value.
-  // This is only applicable if the buffer trace is enabled.
-  bool sending_tapped_msg_on_configured_size = 4;
+  string stats_prefix = 2;
 
   // For buffer tracing, tapped messages are sent only on connection closure by default.
   // This is suitable for HTTP/1 but not for HTTP/2.
   // Tapped messages are sent based on the min_buffered_bytes threshold
-  // when sending_tapped_msg_on_configured_size is true.
-  // If the min_buffered_bytes is unspecified, the default is 9 bytes (min HTTP/2 frame size).
+  // If the min_buffered_bytes is specified, the min value is 9 bytes (min HTTP/2 frame size).
   // This is only applicable if the buffer trace is enabled.
-  google.protobuf.UInt32Value min_buffered_bytes = 5;
+  google.protobuf.UInt32Value min_buffered_bytes = 3;
 }

--- a/api/envoy/extensions/transport_sockets/tap/v3/tap.proto
+++ b/api/envoy/extensions/transport_sockets/tap/v3/tap.proto
@@ -5,6 +5,8 @@ package envoy.extensions.transport_sockets.tap.v3;
 import "envoy/config/core/v3/base.proto";
 import "envoy/extensions/common/tap/v3/common.proto";
 
+import "google/protobuf/wrappers.proto";
+
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
@@ -36,8 +38,28 @@ message Tap {
 }
 
 // Additional configurations for the transport socket tap
+// [#next-free-field: 6]
 message SocketTapConfig {
   // Indicates to whether output the connection information per event
   // This is only applicable if the streamed trace is enabled
   bool set_connection_per_event = 1;
+
+  // Indicates whether pegging the tap counter is required.
+  bool pegging_counter = 2;
+
+  // The contents of the transport tap's statistics prefix.
+  string stats_prefix = 3;
+
+  // Indicates whether sending the tapped messages for the buffer trace
+  // which is conditioned on the configured min_buffered_bytes bytes value.
+  // This is only applicable if the buffer trace is enabled.
+  bool sending_tapped_msg_on_configured_size = 4;
+
+  // For buffer tracing, tapped messages are sent only on connection closure by default.
+  // This is suitable for HTTP/1 but not for HTTP/2.
+  // Tapped messages are sent based on the min_buffered_bytes threshold
+  // when sending_tapped_msg_on_configured_size is true.
+  // If the min_buffered_bytes is unspecified, the default is 9 bytes (min HTTP/2 frame size).
+  // This is only applicable if the buffer trace is enabled.
+  google.protobuf.UInt32Value min_buffered_bytes = 5;
 }

--- a/api/envoy/extensions/transport_sockets/tap/v3/tap.proto
+++ b/api/envoy/extensions/transport_sockets/tap/v3/tap.proto
@@ -5,8 +5,6 @@ package envoy.extensions.transport_sockets.tap.v3;
 import "envoy/config/core/v3/base.proto";
 import "envoy/extensions/common/tap/v3/common.proto";
 
-import "google/protobuf/wrappers.proto";
-
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
@@ -45,11 +43,4 @@ message SocketTapConfig {
 
   // The contents of the transport tap's statistics prefix.
   string stats_prefix = 2;
-
-  // For buffer tracing, tapped messages are sent only on connection closure by default.
-  // This is suitable for HTTP/1 but not for HTTP/2.
-  // Tapped messages are sent based on the min_buffered_bytes threshold
-  // If the min_buffered_bytes is specified, the min value is 9 bytes (min HTTP/2 frame size).
-  // This is only applicable if the buffer trace is enabled.
-  google.protobuf.UInt32Value min_buffered_bytes = 3;
 }

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -109,6 +109,11 @@ new_features:
     from upstream server. See :ref:`mode
     <envoy_v3_api_msg_extensions.http.stateful_session.envelope.v3.EnvelopeSessionState>`
     for more details.
+- area: transport tap
+  change: |
+    Add counter in transport tap for streaming and buffer trace.
+    Buffer trace can sent tapped message based on configured size.
+    Both are controlled by flag.
 - area: load_balancing
   change: |
     Added Override Host Load Balancing policy. See

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -113,7 +113,6 @@ new_features:
   change: |
     Add counter in transport tap for streaming and buffer trace.
     Buffer trace can sent tapped message based on configured size.
-    Both are controlled by flag.
 - area: load_balancing
   change: |
     Added Override Host Load Balancing policy. See

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -112,7 +112,7 @@ new_features:
 - area: transport tap
   change: |
     Add counter in transport tap for streaming and buffer trace.
-    Buffer trace can sent tapped message based on configured size.
+    streamed trace can sent tapped message based on configured size.
 - area: load_balancing
   change: |
     Added Override Host Load Balancing policy. See

--- a/contrib/tap_sinks/udp_sink/test/udp_sink_test.cc
+++ b/contrib/tap_sinks/udp_sink/test/udp_sink_test.cc
@@ -93,9 +93,7 @@ TEST_F(UdpTapSinkTest, TestSubmitTraceForNotSUpportedFormat) {
 
   Extensions::Common::Tap::TraceWrapperPtr local_buffered_trace =
       Extensions::Common::Tap::makeTraceWrapper();
-  // case1 format PROTO_BINARY
-  local_handle->submitTrace(std::move(local_buffered_trace),
-                            envoy::config::tap::v3::OutputSink::PROTO_BINARY);
+
   // case2 format PROTO_BINARY_LENGTH_DELIMITED
   local_handle->submitTrace(std::move(local_buffered_trace),
                             envoy::config::tap::v3::OutputSink::PROTO_BINARY_LENGTH_DELIMITED);
@@ -211,6 +209,32 @@ TEST_F(UdpTapSinkTest, TestSubmitTraceSendOkforProtoText) {
       Extensions::Common::Tap::makeTraceWrapper();
   local_handle->submitTrace(std::move(local_buffered_trace),
                             envoy::config::tap::v3::OutputSink::PROTO_TEXT);
+}
+
+TEST_F(UdpTapSinkTest, TestSubmitTraceSendOkforProtoBinary) {
+  // Construct UdpTapSink object.
+  envoy::extensions::tap_sinks::udp_sink::v3alpha::UdpSink loc_udp_sink;
+  auto* socket_address = loc_udp_sink.mutable_udp_address();
+  socket_address->set_protocol(envoy::config::core::v3::SocketAddress::UDP);
+  socket_address->set_port_value(8080);
+  socket_address->set_address("127.0.0.1");
+  UtSpecialUdpTapSink loc_udp_tap_sink(loc_udp_sink);
+
+  std::unique_ptr<MockUdpPacketWriterNew> local_UdpPacketWriter =
+      std::make_unique<MockUdpPacketWriterNew>(true);
+  loc_udp_tap_sink.replaceOrigUdpPacketWriter(std::move(local_UdpPacketWriter));
+
+  // Create UdpTapSinkHandle.
+  TapCommon::PerTapSinkHandlePtr local_handle =
+      loc_udp_tap_sink.createPerTapSinkHandle(99, ProtoOutputSink::OutputSinkTypeCase::kCustomSink);
+  // Case 1: the return of SerializeToArray() is true.
+  Extensions::Common::Tap::TraceWrapperPtr local_buffered_trace =
+      Extensions::Common::Tap::makeTraceWrapper();
+  local_handle->submitTrace(std::move(local_buffered_trace),
+                            envoy::config::tap::v3::OutputSink::PROTO_BINARY);
+
+  // Case 2 the return of SerializeToArray() is false.
+  // Google Test doesn't support mocking this kind of case with its current capabilities.
 }
 
 } // namespace UDP

--- a/contrib/tap_sinks/udp_sink/test/udp_sink_test.cc
+++ b/contrib/tap_sinks/udp_sink/test/udp_sink_test.cc
@@ -94,7 +94,7 @@ TEST_F(UdpTapSinkTest, TestSubmitTraceForNotSUpportedFormat) {
   Extensions::Common::Tap::TraceWrapperPtr local_buffered_trace =
       Extensions::Common::Tap::makeTraceWrapper();
 
-  // case2 format PROTO_BINARY_LENGTH_DELIMITED
+  // case for format PROTO_BINARY_LENGTH_DELIMITED
   local_handle->submitTrace(std::move(local_buffered_trace),
                             envoy::config::tap::v3::OutputSink::PROTO_BINARY_LENGTH_DELIMITED);
 }

--- a/docs/root/operations/traffic_tapping.rst
+++ b/docs/root/operations/traffic_tapping.rst
@@ -91,11 +91,8 @@ To customize the prefix used in these statistics, configure the :ref:`stats_pref
   :header: Name, Type, Description
   :widths: 1, 1, 2
 
-  streamed_init_submit, Counter, The total count of submissions triggered by streamed init events
-  streamed_read_submit, Counter, The total count of submissions triggered by streamed read events
-  streamed_write_submit, Counter, The total count of submissions triggered by streamed write events
-  streamed_close_submit, Counter, The total count of submissions triggered by streamed close events
-  buffered_close_submit, Counter, The total count of submissions triggered by buffered close events
+  streamed_submit, Counter, The total count of submissions triggered by streamed trace events
+  buffered_submit, Counter, The total count of submissions triggered by buffered trace events
 
 PCAP generation
 ---------------

--- a/docs/root/operations/traffic_tapping.rst
+++ b/docs/root/operations/traffic_tapping.rst
@@ -86,8 +86,6 @@ Statistics
 The tap filter emits statistics within the ``transport.tap.<stat_prefix>`` namespace.
 To customize the prefix used in these statistics, configure the :ref:`stats_prefix
 <envoy_v3_api_field_extensions.transport_sockets.tap.v3.SocketTapConfig.stats_prefix>` field accordingly.
-As an optional enhancement, the emission of tap statistics is governed by the :ref:`pegging_counter
-<envoy_v3_api_field_extensions.transport_sockets.tap.v3.SocketTapConfig.pegging_counter>` flag.
 
 .. csv-table::
   :header: Name, Type, Description

--- a/docs/root/operations/traffic_tapping.rst
+++ b/docs/root/operations/traffic_tapping.rst
@@ -80,6 +80,26 @@ emitted. When streaming, a series of :ref:`SocketStreamedTraceSegment
 See the :ref:`HTTP tap filter streaming <config_http_filters_tap_streaming>` documentation for more
 information. Most of the concepts overlap between the HTTP filter and the transport socket.
 
+Statistics
+----------
+
+The tap filter emits statistics within the ``transport.tap.<stat_prefix>`` namespace.
+To customize the prefix used in these statistics, configure the :ref:`stats_prefix
+<envoy_v3_api_field_extensions.transport_sockets.tap.v3.SocketTapConfig.stats_prefix>` field accordingly.
+As an optional enhancement, the emission of tap statistics is governed by the :ref:`pegging_counter
+<envoy_v3_api_field_extensions.transport_sockets.tap.v3.SocketTapConfig.pegging_counter>` flag.
+
+.. csv-table::
+  :header: Name, Type, Description
+  :widths: 1, 1, 2
+
+  streamed_read_submit, Counter, The total count of submissions triggered by streamed read events
+  streamed_write_submit, Counter, The total count of submissions triggered by streamed write events
+  streamed_close_submit, Counter, The total count of submissions triggered by streamed close events
+  buffered_read_submit, Counter, The total count of submissions triggered by buffered read events
+  buffered_write_submit, Counter, The total count of submissions triggered by buffered write events
+  buffered_close_submit, Counter, The total count of submissions triggered by buffered close events
+
 PCAP generation
 ---------------
 

--- a/docs/root/operations/traffic_tapping.rst
+++ b/docs/root/operations/traffic_tapping.rst
@@ -91,11 +91,10 @@ To customize the prefix used in these statistics, configure the :ref:`stats_pref
   :header: Name, Type, Description
   :widths: 1, 1, 2
 
+  streamed_init_submit, Counter, The total count of submissions triggered by streamed init events
   streamed_read_submit, Counter, The total count of submissions triggered by streamed read events
   streamed_write_submit, Counter, The total count of submissions triggered by streamed write events
   streamed_close_submit, Counter, The total count of submissions triggered by streamed close events
-  buffered_read_submit, Counter, The total count of submissions triggered by buffered read events
-  buffered_write_submit, Counter, The total count of submissions triggered by buffered write events
   buffered_close_submit, Counter, The total count of submissions triggered by buffered close events
 
 PCAP generation

--- a/source/extensions/common/tap/tap.h
+++ b/source/extensions/common/tap/tap.h
@@ -153,6 +153,17 @@ public:
   virtual uint32_t maxBufferedTxBytes() const PURE;
 
   /**
+   * Return the minimum transmitted bytes that can be buffered in memory. Streaming taps are still
+   * subject to this limit depending on match status.
+   */
+  virtual uint32_t minStreamedSentBytes() const PURE;
+
+  /**
+   * Return whether streamed msg should be sent by configured size
+   */
+  virtual bool shouldSendStreamedMsgByConfiguredSize() const PURE;
+
+  /**
    * Return a new match status vector that is correctly sized for the number of matchers that are in
    * the configuration.
    */

--- a/source/extensions/common/tap/tap.h
+++ b/source/extensions/common/tap/tap.h
@@ -159,11 +159,6 @@ public:
   virtual uint32_t minStreamedSentBytes() const PURE;
 
   /**
-   * Return whether streamed msg should be sent by configured size
-   */
-  virtual bool shouldSendStreamedMsgByConfiguredSize() const PURE;
-
-  /**
    * Return a new match status vector that is correctly sized for the number of matchers that are in
    * the configuration.
    */

--- a/source/extensions/common/tap/tap_config_base.cc
+++ b/source/extensions/common/tap/tap_config_base.cc
@@ -63,6 +63,14 @@ TapConfigBaseImpl::TapConfigBaseImpl(const envoy::config::tap::v3::TapConfig& pr
   sink_format_ = sinks[0].format();
   sink_type_ = sinks[0].output_sink_type_case();
 
+  if (PROTOBUF_GET_OPTIONAL_WRAPPED(proto_config.output_config(), min_streamed_sent_bytes) !=
+      absl::nullopt) {
+    min_streamed_sent_bytes_ =
+        std::max(proto_config.output_config().min_streamed_sent_bytes().value(),
+                 DefaultMinStreamedSentBytes);
+    should_send_streamed_msg_by_configured_size_ = true;
+  }
+
   switch (sink_type_) {
   case ProtoOutputSink::OutputSinkTypeCase::kBufferedAdmin:
     if (admin_streamer == nullptr) {

--- a/source/extensions/common/tap/tap_config_base.cc
+++ b/source/extensions/common/tap/tap_config_base.cc
@@ -68,7 +68,6 @@ TapConfigBaseImpl::TapConfigBaseImpl(const envoy::config::tap::v3::TapConfig& pr
     min_streamed_sent_bytes_ =
         std::max(proto_config.output_config().min_streamed_sent_bytes().value(),
                  DefaultMinStreamedSentBytes);
-    should_send_streamed_msg_by_configured_size_ = true;
   }
 
   switch (sink_type_) {

--- a/source/extensions/common/tap/tap_config_base.h
+++ b/source/extensions/common/tap/tap_config_base.h
@@ -95,6 +95,10 @@ public:
   }
   uint32_t maxBufferedRxBytes() const override { return max_buffered_rx_bytes_; }
   uint32_t maxBufferedTxBytes() const override { return max_buffered_tx_bytes_; }
+  uint32_t minStreamedSentBytes() const override { return min_streamed_sent_bytes_; }
+  bool shouldSendStreamedMsgByConfiguredSize() const override {
+    return should_send_streamed_msg_by_configured_size_;
+  }
   Matcher::MatchStatusVector createMatchStatusVector() const override {
     return Matcher::MatchStatusVector(matchers_.size());
   }
@@ -119,6 +123,12 @@ private:
   envoy::config::tap::v3::OutputSink::Format sink_format_;
   envoy::config::tap::v3::OutputSink::OutputSinkTypeCase sink_type_;
   std::vector<MatcherPtr> matchers_;
+  // This is the default value for min streamed buffered bytes.
+  // (This means that per streamed trace, the minimum amount
+  // which triggering to send the tapped messages size is 9 bytes).
+  static constexpr uint32_t DefaultMinStreamedSentBytes = 9;
+  uint32_t min_streamed_sent_bytes_;
+  bool should_send_streamed_msg_by_configured_size_{false};
 };
 
 /**

--- a/source/extensions/common/tap/tap_config_base.h
+++ b/source/extensions/common/tap/tap_config_base.h
@@ -96,9 +96,6 @@ public:
   uint32_t maxBufferedRxBytes() const override { return max_buffered_rx_bytes_; }
   uint32_t maxBufferedTxBytes() const override { return max_buffered_tx_bytes_; }
   uint32_t minStreamedSentBytes() const override { return min_streamed_sent_bytes_; }
-  bool shouldSendStreamedMsgByConfiguredSize() const override {
-    return should_send_streamed_msg_by_configured_size_;
-  }
   Matcher::MatchStatusVector createMatchStatusVector() const override {
     return Matcher::MatchStatusVector(matchers_.size());
   }
@@ -127,8 +124,7 @@ private:
   // (This means that per streamed trace, the minimum amount
   // which triggering to send the tapped messages size is 9 bytes).
   static constexpr uint32_t DefaultMinStreamedSentBytes = 9;
-  uint32_t min_streamed_sent_bytes_;
-  bool should_send_streamed_msg_by_configured_size_{false};
+  uint32_t min_streamed_sent_bytes_{0};
 };
 
 /**

--- a/source/extensions/transport_sockets/tap/config.cc
+++ b/source/extensions/transport_sockets/tap/config.cc
@@ -55,7 +55,8 @@ UpstreamTapSocketConfigFactory::createTransportSocketFactory(
       std::make_unique<SocketTapConfigFactoryImpl>(
           server_context.mainThreadDispatcher().timeSource(), context),
       server_context.admin(), server_context.singletonManager(), server_context.threadLocal(),
-      server_context.mainThreadDispatcher(), std::move(factory_or_error.value()));
+      server_context.mainThreadDispatcher(), server_context.scope(),
+      std::move(factory_or_error.value()));
 }
 
 absl::StatusOr<Network::DownstreamTransportSocketFactoryPtr>
@@ -79,7 +80,8 @@ DownstreamTapSocketConfigFactory::createTransportSocketFactory(
       std::make_unique<SocketTapConfigFactoryImpl>(
           server_context.mainThreadDispatcher().timeSource(), context),
       server_context.admin(), server_context.singletonManager(), server_context.threadLocal(),
-      server_context.mainThreadDispatcher(), std::move(factory_or_error.value()));
+      server_context.mainThreadDispatcher(), server_context.scope(),
+      std::move(factory_or_error.value()));
 }
 
 ProtobufTypes::MessagePtr TapSocketConfigFactory::createEmptyConfigProto() {

--- a/source/extensions/transport_sockets/tap/tap.cc
+++ b/source/extensions/transport_sockets/tap/tap.cc
@@ -12,15 +12,28 @@ namespace Tap {
 TapSocket::TapSocket(
     SocketTapConfigSharedPtr config,
     const envoy::extensions::transport_sockets::tap::v3::SocketTapConfig& socket_tap_config,
-    Network::TransportSocketPtr&& transport_socket)
+    Stats::Scope& stats_scope, Network::TransportSocketPtr&& transport_socket)
     : PassthroughSocket(std::move(transport_socket)), config_(config),
-      socket_tap_config_(socket_tap_config) {}
+      socket_tap_config_(socket_tap_config),
+      stats_(generateStats(stats_scope, socket_tap_config.stats_prefix())) {}
+
+TransportTapStats TapSocket::generateStats(Stats::Scope& stats_scope, const std::string& prefix) {
+  std::string final_prefix;
+  if (prefix.empty()) {
+    final_prefix = fmt::format("transport.tap.");
+  } else {
+    final_prefix = fmt::format("transport.tap.{}.", prefix);
+  }
+  TransportTapStats stats{ALL_TRANSPORT_TAP_STATS(POOL_COUNTER_PREFIX(stats_scope, final_prefix))};
+  return stats;
+}
 
 void TapSocket::setTransportSocketCallbacks(Network::TransportSocketCallbacks& callbacks) {
   ASSERT(!tapper_);
   transport_socket_->setTransportSocketCallbacks(callbacks);
-  tapper_ = config_ ? config_->createPerSocketTapper(socket_tap_config_, callbacks.connection())
-                    : nullptr;
+  tapper_ = config_
+                ? config_->createPerSocketTapper(socket_tap_config_, stats_, callbacks.connection())
+                : nullptr;
 }
 
 void TapSocket::closeSocket(Network::ConnectionEvent event) {
@@ -54,18 +67,18 @@ TapSocketFactory::TapSocketFactory(
     const envoy::extensions::transport_sockets::tap::v3::Tap& proto_config,
     Common::Tap::TapConfigFactoryPtr&& config_factory, OptRef<Server::Admin> admin,
     Singleton::Manager& singleton_manager, ThreadLocal::SlotAllocator& tls,
-    Event::Dispatcher& main_thread_dispatcher,
+    Event::Dispatcher& main_thread_dispatcher, Stats::Scope& scope,
     Network::UpstreamTransportSocketFactoryPtr&& transport_socket_factory)
     : ExtensionConfigBase(proto_config.common_config(), std::move(config_factory), admin,
                           singleton_manager, tls, main_thread_dispatcher),
       PassthroughFactory(std::move(transport_socket_factory)),
-      ts_tap_config_(proto_config.socket_tap_config()) {}
+      ts_tap_config_(proto_config.socket_tap_config()), stats_scope_(scope) {}
 
 Network::TransportSocketPtr
 TapSocketFactory::createTransportSocket(Network::TransportSocketOptionsConstSharedPtr options,
                                         Upstream::HostDescriptionConstSharedPtr host) const {
   return std::make_unique<TapSocket>(
-      currentConfigHelper<SocketTapConfig>(), ts_tap_config_,
+      currentConfigHelper<SocketTapConfig>(), ts_tap_config_, stats_scope_,
       transport_socket_factory_->createTransportSocket(options, host));
 }
 
@@ -73,15 +86,16 @@ DownstreamTapSocketFactory::DownstreamTapSocketFactory(
     const envoy::extensions::transport_sockets::tap::v3::Tap& proto_config,
     Common::Tap::TapConfigFactoryPtr&& config_factory, OptRef<Server::Admin> admin,
     Singleton::Manager& singleton_manager, ThreadLocal::SlotAllocator& tls,
-    Event::Dispatcher& main_thread_dispatcher,
+    Event::Dispatcher& main_thread_dispatcher, Stats::Scope& scope,
     Network::DownstreamTransportSocketFactoryPtr&& transport_socket_factory)
     : ExtensionConfigBase(proto_config.common_config(), std::move(config_factory), admin,
                           singleton_manager, tls, main_thread_dispatcher),
       DownstreamPassthroughFactory(std::move(transport_socket_factory)),
-      ds_ts_tap_config_(proto_config.socket_tap_config()) {}
+      ds_ts_tap_config_(proto_config.socket_tap_config()), stats_scope_(scope) {}
 
 Network::TransportSocketPtr DownstreamTapSocketFactory::createDownstreamTransportSocket() const {
   return std::make_unique<TapSocket>(currentConfigHelper<SocketTapConfig>(), ds_ts_tap_config_,
+                                     stats_scope_,
                                      transport_socket_factory_->createDownstreamTransportSocket());
 }
 

--- a/source/extensions/transport_sockets/tap/tap.h
+++ b/source/extensions/transport_sockets/tap/tap.h
@@ -17,7 +17,7 @@ class TapSocket : public TransportSockets::PassthroughSocket {
 public:
   TapSocket(SocketTapConfigSharedPtr config,
             const envoy::extensions::transport_sockets::tap::v3::SocketTapConfig& socket_tap_config,
-            Network::TransportSocketPtr&& transport_socket);
+            Stats::Scope& stats_scope, Network::TransportSocketPtr&& transport_socket);
 
   // Network::TransportSocket
   void setTransportSocketCallbacks(Network::TransportSocketCallbacks& callbacks) override;
@@ -29,6 +29,8 @@ private:
   SocketTapConfigSharedPtr config_;
   PerSocketTapperPtr tapper_;
   const envoy::extensions::transport_sockets::tap::v3::SocketTapConfig socket_tap_config_;
+  TransportTapStats stats_;
+  static TransportTapStats generateStats(Stats::Scope& stats_scope, const std::string& prefix);
 };
 
 class TapSocketFactory : public Common::Tap::ExtensionConfigBase, public PassthroughFactory {
@@ -36,7 +38,7 @@ public:
   TapSocketFactory(const envoy::extensions::transport_sockets::tap::v3::Tap& proto_config,
                    Common::Tap::TapConfigFactoryPtr&& config_factory, OptRef<Server::Admin> admin,
                    Singleton::Manager& singleton_manager, ThreadLocal::SlotAllocator& tls,
-                   Event::Dispatcher& main_thread_dispatcher,
+                   Event::Dispatcher& main_thread_dispatcher, Stats::Scope& scope,
                    Network::UpstreamTransportSocketFactoryPtr&& transport_socket_factory);
 
   // Network::UpstreamTransportSocketFactory
@@ -46,6 +48,7 @@ public:
 
 private:
   const envoy::extensions::transport_sockets::tap::v3::SocketTapConfig ts_tap_config_;
+  Stats::Scope& stats_scope_;
 };
 
 class DownstreamTapSocketFactory : public Common::Tap::ExtensionConfigBase,
@@ -55,7 +58,7 @@ public:
       const envoy::extensions::transport_sockets::tap::v3::Tap& proto_config,
       Common::Tap::TapConfigFactoryPtr&& config_factory, OptRef<Server::Admin> admin,
       Singleton::Manager& singleton_manager, ThreadLocal::SlotAllocator& tls,
-      Event::Dispatcher& main_thread_dispatcher,
+      Event::Dispatcher& main_thread_dispatcher, Stats::Scope& scope,
       Network::DownstreamTransportSocketFactoryPtr&& transport_socket_factory);
 
   // Network::UpstreamTransportSocketFactory
@@ -63,6 +66,7 @@ public:
 
 private:
   const envoy::extensions::transport_sockets::tap::v3::SocketTapConfig ds_ts_tap_config_;
+  Stats::Scope& stats_scope_;
 };
 
 } // namespace Tap

--- a/source/extensions/transport_sockets/tap/tap_config.h
+++ b/source/extensions/transport_sockets/tap/tap_config.h
@@ -2,6 +2,8 @@
 
 #include "envoy/extensions/transport_sockets/tap/v3/tap.pb.h"
 #include "envoy/network/connection.h"
+#include "envoy/stats/scope.h"
+#include "envoy/stats/stats_macros.h"
 
 #include "source/extensions/common/tap/tap.h"
 
@@ -9,6 +11,24 @@ namespace Envoy {
 namespace Extensions {
 namespace TransportSockets {
 namespace Tap {
+
+/**
+ * All stats for the tap filter. @see stats_macros.h
+ */
+#define ALL_TRANSPORT_TAP_STATS(COUNTER)                                                           \
+  COUNTER(streamed_read_submit)                                                                    \
+  COUNTER(streamed_write_submit)                                                                   \
+  COUNTER(streamed_close_submit)                                                                   \
+  COUNTER(buffered_read_submit)                                                                    \
+  COUNTER(buffered_write_submit)                                                                   \
+  COUNTER(buffered_close_submit)
+
+/**
+ * Wrapper struct for tap filter stats. @see stats_macros.h
+ */
+struct TransportTapStats {
+  ALL_TRANSPORT_TAP_STATS(GENERATE_COUNTER_STRUCT)
+};
 
 /**
  * Per-socket tap implementation. Abstractly handles all socket lifecycle events in order to tap
@@ -54,7 +74,7 @@ public:
    */
   virtual PerSocketTapperPtr createPerSocketTapper(
       const envoy::extensions::transport_sockets::tap::v3::SocketTapConfig& tap_config,
-      const Network::Connection& connection) PURE;
+      const TransportTapStats& stats, const Network::Connection& connection) PURE;
 
   /**
    * @return time source to use for stamping events.

--- a/source/extensions/transport_sockets/tap/tap_config.h
+++ b/source/extensions/transport_sockets/tap/tap_config.h
@@ -16,11 +16,10 @@ namespace Tap {
  * All stats for the tap filter. @see stats_macros.h
  */
 #define ALL_TRANSPORT_TAP_STATS(COUNTER)                                                           \
+  COUNTER(streamed_init_submit)                                                                    \
   COUNTER(streamed_read_submit)                                                                    \
   COUNTER(streamed_write_submit)                                                                   \
   COUNTER(streamed_close_submit)                                                                   \
-  COUNTER(buffered_read_submit)                                                                    \
-  COUNTER(buffered_write_submit)                                                                   \
   COUNTER(buffered_close_submit)
 
 /**

--- a/source/extensions/transport_sockets/tap/tap_config.h
+++ b/source/extensions/transport_sockets/tap/tap_config.h
@@ -16,11 +16,8 @@ namespace Tap {
  * All stats for the tap filter. @see stats_macros.h
  */
 #define ALL_TRANSPORT_TAP_STATS(COUNTER)                                                           \
-  COUNTER(streamed_init_submit)                                                                    \
-  COUNTER(streamed_read_submit)                                                                    \
-  COUNTER(streamed_write_submit)                                                                   \
-  COUNTER(streamed_close_submit)                                                                   \
-  COUNTER(buffered_close_submit)
+  COUNTER(streamed_submit)                                                                         \
+  COUNTER(buffered_submit)
 
 /**
  * Wrapper struct for tap filter stats. @see stats_macros.h

--- a/source/extensions/transport_sockets/tap/tap_config_impl.cc
+++ b/source/extensions/transport_sockets/tap/tap_config_impl.cc
@@ -94,8 +94,8 @@ void PerSocketTapperImpl::initStreamingEvent(envoy::data::tap::v3::SocketEvent& 
   }
 }
 
-void PerSocketTapperImpl::pegSubmitCounter(const bool isStreaming) {
-  if (isStreaming) {
+void PerSocketTapperImpl::pegSubmitCounter(const bool is_streaming) {
+  if (is_streaming) {
     stats_.streamed_submit_.inc();
   } else {
     stats_.buffered_submit_.inc();
@@ -107,23 +107,23 @@ bool PerSocketTapperImpl::shouldSendStreamedMsgByConfiguredSize() const {
 }
 
 void PerSocketTapperImpl::handleSendingStreamTappedMsgPerConfigSize(const Buffer::Instance& data,
-                                                                    const uint32_t totalBytes,
-                                                                    const bool isRead,
-                                                                    const bool isEndStream) {
+                                                                    const uint32_t total_bytes,
+                                                                    const bool is_read,
+                                                                    const bool is_end_stream) {
   makeStreamedTraceIfNeeded();
   auto& event =
       *streamed_trace_->mutable_socket_streamed_trace_segment()->mutable_events()->add_events();
   initStreamingEvent(event);
   uint32_t buffer_start_offset = 0;
-  if (isRead) {
-    buffer_start_offset = data.length() - totalBytes;
-    TapCommon::Utility::addBufferToProtoBytes(*event.mutable_read()->mutable_data(), totalBytes,
-                                              data, buffer_start_offset, totalBytes);
+  if (is_read) {
+    buffer_start_offset = data.length() - total_bytes;
+    TapCommon::Utility::addBufferToProtoBytes(*event.mutable_read()->mutable_data(), total_bytes,
+                                              data, buffer_start_offset, total_bytes);
     current_streamed_rx_tx_bytes_ += event.read().data().as_bytes().size();
   } else {
-    event.mutable_write()->set_end_stream(isEndStream);
-    TapCommon::Utility::addBufferToProtoBytes(*event.mutable_write()->mutable_data(), totalBytes,
-                                              data, buffer_start_offset, totalBytes);
+    event.mutable_write()->set_end_stream(is_end_stream);
+    TapCommon::Utility::addBufferToProtoBytes(*event.mutable_write()->mutable_data(), total_bytes,
+                                              data, buffer_start_offset, total_bytes);
     current_streamed_rx_tx_bytes_ += event.write().data().as_bytes().size();
   }
 

--- a/source/extensions/transport_sockets/tap/tap_config_impl.h
+++ b/source/extensions/transport_sockets/tap/tap_config_impl.h
@@ -58,10 +58,9 @@ private:
   uint32_t rx_bytes_buffered_{};
   uint32_t tx_bytes_buffered_{};
   const bool should_output_conn_info_per_event_{false};
-  const bool should_peg_counter_{false};
-  const bool should_sending_tapped_msg_on_configured_size_{false};
-  const uint32_t min_sending_buffered_bytes_{};
-  uint32_t current_buffered_rx_tx_bytes_{};
+  bool should_sending_tapped_msg_on_configured_size_{false};
+  uint32_t min_sending_buffered_bytes_{0};
+  uint32_t current_buffered_rx_tx_bytes_{0};
   const TransportTapStats stats_;
 };
 

--- a/source/extensions/transport_sockets/tap/tap_config_impl.h
+++ b/source/extensions/transport_sockets/tap/tap_config_impl.h
@@ -46,8 +46,8 @@ private:
     trace->mutable_socket_streamed_trace_segment()->set_trace_id(connection_.id());
     return trace;
   }
-  void pegReadWriteSubmitCounter(const bool onStreaming, const bool isRead);
-  void pegCloseSubmitCounter(const bool isStreaming);
+  void pegSubmitCounter(const bool isStreaming);
+  bool shouldSendStreamedMsgByConfiguredSize() const;
   void handleSendingStreamTappedMsgPerConfigSize(const Buffer::Instance& data,
                                                  const uint32_t totalBytes, const bool isRead,
                                                  const bool isEndStream);

--- a/source/extensions/transport_sockets/tap/tap_config_impl.h
+++ b/source/extensions/transport_sockets/tap/tap_config_impl.h
@@ -46,11 +46,11 @@ private:
     trace->mutable_socket_streamed_trace_segment()->set_trace_id(connection_.id());
     return trace;
   }
-  void pegSubmitCounter(const bool isStreaming);
+  void pegSubmitCounter(const bool is_streaming);
   bool shouldSendStreamedMsgByConfiguredSize() const;
   void handleSendingStreamTappedMsgPerConfigSize(const Buffer::Instance& data,
-                                                 const uint32_t totalBytes, const bool isRead,
-                                                 const bool isEndStream);
+                                                 const uint32_t total_bytes, const bool is_read,
+                                                 const bool is_end_stream);
   // This is the default value for min buffered bytes.
   // (This means that per transport socket buffer trace, the minimum amount
   // which triggering to send the tapped messages size is 9 bytes).

--- a/source/extensions/transport_sockets/tap/tap_config_impl.h
+++ b/source/extensions/transport_sockets/tap/tap_config_impl.h
@@ -47,7 +47,7 @@ private:
                                            const bool isRead);
   // This is the default value for min buffered bytes.
   // (This means that per transport socket buffer trace, the minimum amount
-  // which triggering to send the tapped messages size is 9 byes).
+  // which triggering to send the tapped messages size is 9 bytes).
   static constexpr uint32_t DefaultMinBufferedBytes = 9;
   SocketTapConfigSharedPtr config_;
   Extensions::Common::Tap::PerTapSinkHandleManagerPtr sink_handle_;

--- a/test/extensions/filters/http/tap/common.h
+++ b/test/extensions/filters/http/tap/common.h
@@ -31,10 +31,12 @@ public:
               (uint64_t trace_id));
   MOCK_METHOD(uint32_t, maxBufferedRxBytes, (), (const));
   MOCK_METHOD(uint32_t, maxBufferedTxBytes, (), (const));
+  MOCK_METHOD(uint32_t, minStreamedSentBytes, (), (const));
   MOCK_METHOD(Extensions::Common::Tap::Matcher::MatchStatusVector, createMatchStatusVector, (),
               (const));
   MOCK_METHOD(const Extensions::Common::Tap::Matcher&, rootMatcher, (), (const));
   MOCK_METHOD(bool, streaming, (), (const));
+  MOCK_METHOD(bool, shouldSendStreamedMsgByConfiguredSize, (), (const));
   MOCK_METHOD(TimeSource&, timeSource, (), (const));
 };
 

--- a/test/extensions/filters/http/tap/common.h
+++ b/test/extensions/filters/http/tap/common.h
@@ -36,7 +36,6 @@ public:
               (const));
   MOCK_METHOD(const Extensions::Common::Tap::Matcher&, rootMatcher, (), (const));
   MOCK_METHOD(bool, streaming, (), (const));
-  MOCK_METHOD(bool, shouldSendStreamedMsgByConfiguredSize, (), (const));
   MOCK_METHOD(TimeSource&, timeSource, (), (const));
 };
 

--- a/test/extensions/transport_sockets/tap/ssl_tap_integration_test.cc
+++ b/test/extensions/transport_sockets/tap/ssl_tap_integration_test.cc
@@ -86,13 +86,11 @@ public:
 
     // stats for both streaming and buffered trace
     if (pegging_counter_) {
-      socket_tap_config->set_pegging_counter(true);
       socket_tap_config->set_stats_prefix("tranTapPrefix");
     }
 
     // Only for buffered trace
     if (sending_tapped_msg_on_configured_size_) {
-      socket_tap_config->set_sending_tapped_msg_on_configured_size(true);
       socket_tap_config->mutable_min_buffered_bytes()->set_value(min_buffered_bytes_);
     }
     tap_config.mutable_transport_socket()->MergeFrom(inner_transport);

--- a/test/extensions/transport_sockets/tap/ssl_tap_integration_test.cc
+++ b/test/extensions/transport_sockets/tap/ssl_tap_integration_test.cc
@@ -77,6 +77,10 @@ public:
     }
     output_config->set_streaming(streaming_tap_);
 
+    // Only for streamed trace
+    if (sending_streamed_msg_on_configured_size_) {
+      output_config->mutable_min_streamed_sent_bytes()->set_value(min_streamed_sent_bytes_);
+    }
     auto* output_sink = output_config->mutable_sinks()->Add();
     output_sink->set_format(format_);
     output_sink->mutable_file_per_tap()->set_path_prefix(path_prefix_);
@@ -89,10 +93,6 @@ public:
       socket_tap_config->set_stats_prefix("tranTapPrefix");
     }
 
-    // Only for buffered trace
-    if (sending_tapped_msg_on_configured_size_) {
-      socket_tap_config->mutable_min_buffered_bytes()->set_value(min_buffered_bytes_);
-    }
     tap_config.mutable_transport_socket()->MergeFrom(inner_transport);
     return tap_config;
   }
@@ -106,8 +106,8 @@ public:
   bool streaming_tap_{};
   bool set_connection_per_event_{false};
   bool pegging_counter_{false};
-  bool sending_tapped_msg_on_configured_size_{false};
-  unsigned int min_buffered_bytes_{2048};
+  bool sending_streamed_msg_on_configured_size_{false};
+  unsigned int min_streamed_sent_bytes_{9};
 };
 
 INSTANTIATE_TEST_SUITE_P(IpVersions, SslTapIntegrationTest,
@@ -342,7 +342,7 @@ TEST_P(SslTapIntegrationTest, RequestWithStreamingUpstreamTap) {
   EXPECT_TRUE(traces[2].socket_streamed_trace_segment().event().read().data().truncated());
 }
 
-TEST_P(SslTapIntegrationTest, RequestWithStreamingUpstreamTapPegCounter) {
+TEST_P(SslTapIntegrationTest, RequestWithStreamingDownstreamTapPegCounter) {
   bool local_upstream_tap = upstream_tap_;
   upstream_tap_ = false;
   bool local_streaming_tap_ = streaming_tap_;
@@ -364,9 +364,41 @@ TEST_P(SslTapIntegrationTest, RequestWithStreamingUpstreamTapPegCounter) {
   checkStats();
   codec_client_->close();
   test_server_->waitForCounterGe("http.config_test.downstream_cx_destroy", 1);
+  test_server_->waitForCounterGe("transport.tap.tranTapPrefix.streamed_init_submit", 1);
   test_server_->waitForCounterGe("transport.tap.tranTapPrefix.streamed_read_submit", 1);
   test_server_->waitForCounterGe("transport.tap.tranTapPrefix.streamed_write_submit", 1);
   test_server_->waitForCounterGe("transport.tap.tranTapPrefix.streamed_close_submit", 1);
+  test_server_.reset();
+
+  // restore the value
+  upstream_tap_ = local_upstream_tap;
+  streaming_tap_ = local_streaming_tap_;
+  pegging_counter_ = local_pegging_counter;
+}
+
+TEST_P(SslTapIntegrationTest, RequestWithBuffedDownstreamTapPegCounter) {
+  bool local_upstream_tap = upstream_tap_;
+  upstream_tap_ = false;
+  bool local_streaming_tap_ = streaming_tap_;
+  streaming_tap_ = false;
+  bool local_pegging_counter = pegging_counter_;
+  pegging_counter_ = true;
+
+  format_ = envoy::config::tap::v3::OutputSink::PROTO_BINARY_LENGTH_DELIMITED;
+  ConnectionCreationFunction creator = [&]() -> Network::ClientConnectionPtr {
+    return makeSslClientConnection({});
+  };
+
+  // Disable for this test because it uses connection IDs, which disrupts the accounting below
+  // leading to the wrong path for the `pb_text` being used.
+  skip_tag_extraction_rule_check_ = true;
+
+  // const uint64_t id = Network::ConnectionImpl::nextGlobalIdForTest() + 2;
+  testRouterRequestAndResponseWithBody(512, 1024, false, false, &creator);
+  checkStats();
+  codec_client_->close();
+  test_server_->waitForCounterGe("http.config_test.downstream_cx_destroy", 1);
+  test_server_->waitForCounterGe("transport.tap.tranTapPrefix.buffered_close_submit", 1);
   test_server_.reset();
 
   // restore the value

--- a/test/extensions/transport_sockets/tap/ssl_tap_integration_test.cc
+++ b/test/extensions/transport_sockets/tap/ssl_tap_integration_test.cc
@@ -80,6 +80,21 @@ public:
     auto* output_sink = output_config->mutable_sinks()->Add();
     output_sink->set_format(format_);
     output_sink->mutable_file_per_tap()->set_path_prefix(path_prefix_);
+    auto* socket_tap_config = tap_config.mutable_socket_tap_config();
+    // Only for streaming trace
+    socket_tap_config->set_set_connection_per_event(set_connection_per_event_);
+
+    // stats for both streaming and buffered trace
+    if (pegging_counter_) {
+      socket_tap_config->set_pegging_counter(true);
+      socket_tap_config->set_stats_prefix("tranTapPrefix");
+    }
+
+    // Only for buffered trace
+    if (sending_tapped_msg_on_configured_size_) {
+      socket_tap_config->set_sending_tapped_msg_on_configured_size(true);
+      socket_tap_config->mutable_min_buffered_bytes()->set_value(min_buffered_bytes_);
+    }
     tap_config.mutable_transport_socket()->MergeFrom(inner_transport);
     return tap_config;
   }
@@ -91,6 +106,10 @@ public:
   absl::optional<uint64_t> max_tx_bytes_;
   bool upstream_tap_{};
   bool streaming_tap_{};
+  bool set_connection_per_event_{false};
+  bool pegging_counter_{false};
+  bool sending_tapped_msg_on_configured_size_{false};
+  unsigned int min_buffered_bytes_{2048};
 };
 
 INSTANTIATE_TEST_SUITE_P(IpVersions, SslTapIntegrationTest,
@@ -323,6 +342,39 @@ TEST_P(SslTapIntegrationTest, RequestWithStreamingUpstreamTap) {
   EXPECT_TRUE(traces[1].socket_streamed_trace_segment().event().write().data().truncated());
   EXPECT_EQ(traces[2].socket_streamed_trace_segment().event().read().data().as_bytes(), "HTTP/");
   EXPECT_TRUE(traces[2].socket_streamed_trace_segment().event().read().data().truncated());
+}
+
+TEST_P(SslTapIntegrationTest, RequestWithStreamingUpstreamTapPegCounter) {
+  bool local_upstream_tap = upstream_tap_;
+  upstream_tap_ = false;
+  bool local_streaming_tap_ = streaming_tap_;
+  streaming_tap_ = true;
+  bool local_pegging_counter = pegging_counter_;
+  pegging_counter_ = true;
+
+  format_ = envoy::config::tap::v3::OutputSink::PROTO_BINARY_LENGTH_DELIMITED;
+  ConnectionCreationFunction creator = [&]() -> Network::ClientConnectionPtr {
+    return makeSslClientConnection({});
+  };
+
+  // Disable for this test because it uses connection IDs, which disrupts the accounting below
+  // leading to the wrong path for the `pb_text` being used.
+  skip_tag_extraction_rule_check_ = true;
+
+  // const uint64_t id = Network::ConnectionImpl::nextGlobalIdForTest() + 2;
+  testRouterRequestAndResponseWithBody(512, 1024, false, false, &creator);
+  checkStats();
+  codec_client_->close();
+  test_server_->waitForCounterGe("http.config_test.downstream_cx_destroy", 1);
+  test_server_->waitForCounterGe("transport.tap.tranTapPrefix.streamed_read_submit", 1);
+  test_server_->waitForCounterGe("transport.tap.tranTapPrefix.streamed_write_submit", 1);
+  test_server_->waitForCounterGe("transport.tap.tranTapPrefix.streamed_close_submit", 1);
+  test_server_.reset();
+
+  // restore the value
+  upstream_tap_ = local_upstream_tap;
+  streaming_tap_ = local_streaming_tap_;
+  pegging_counter_ = local_pegging_counter;
 }
 
 } // namespace Ssl

--- a/test/extensions/transport_sockets/tap/ssl_tap_integration_test.cc
+++ b/test/extensions/transport_sockets/tap/ssl_tap_integration_test.cc
@@ -364,13 +364,10 @@ TEST_P(SslTapIntegrationTest, RequestWithStreamingDownstreamTapPegCounter) {
   checkStats();
   codec_client_->close();
   test_server_->waitForCounterGe("http.config_test.downstream_cx_destroy", 1);
-  test_server_->waitForCounterGe("transport.tap.tranTapPrefix.streamed_init_submit", 1);
-  test_server_->waitForCounterGe("transport.tap.tranTapPrefix.streamed_read_submit", 1);
-  test_server_->waitForCounterGe("transport.tap.tranTapPrefix.streamed_write_submit", 1);
-  test_server_->waitForCounterGe("transport.tap.tranTapPrefix.streamed_close_submit", 1);
+  test_server_->waitForCounterGe("transport.tap.tranTapPrefix.streamed_submit", 1);
   test_server_.reset();
 
-  // restore the value
+  // Restore the value.
   upstream_tap_ = local_upstream_tap;
   streaming_tap_ = local_streaming_tap_;
   pegging_counter_ = local_pegging_counter;
@@ -398,10 +395,10 @@ TEST_P(SslTapIntegrationTest, RequestWithBuffedDownstreamTapPegCounter) {
   checkStats();
   codec_client_->close();
   test_server_->waitForCounterGe("http.config_test.downstream_cx_destroy", 1);
-  test_server_->waitForCounterGe("transport.tap.tranTapPrefix.buffered_close_submit", 1);
+  test_server_->waitForCounterGe("transport.tap.tranTapPrefix.buffered_submit", 1);
   test_server_.reset();
 
-  // restore the value
+  // Restore the value.
   upstream_tap_ = local_upstream_tap;
   streaming_tap_ = local_streaming_tap_;
   pegging_counter_ = local_pegging_counter;

--- a/test/extensions/transport_sockets/tap/tap_config_impl_test.cc
+++ b/test/extensions/transport_sockets/tap/tap_config_impl_test.cc
@@ -24,8 +24,8 @@ class MockSocketTapConfig : public SocketTapConfig {
 public:
   PerSocketTapperPtr createPerSocketTapper(
       const envoy::extensions::transport_sockets::tap::v3::SocketTapConfig& tap_config,
-      const Network::Connection& connection) override {
-    return PerSocketTapperPtr{createPerSocketTapper_(tap_config, connection)};
+      const TransportTapStats& stats, const Network::Connection& connection) override {
+    return PerSocketTapperPtr{createPerSocketTapper_(tap_config, stats, connection)};
   }
 
   Extensions::Common::Tap::PerTapSinkHandleManagerPtr
@@ -36,7 +36,7 @@ public:
 
   MOCK_METHOD(PerSocketTapper*, createPerSocketTapper_,
               (const envoy::extensions::transport_sockets::tap::v3::SocketTapConfig& tap_config,
-               const Network::Connection& connection));
+               const TransportTapStats& stats, const Network::Connection& connection));
   MOCK_METHOD(Extensions::Common::Tap::PerTapSinkHandleManager*, createPerTapSinkHandleManager_,
               (uint64_t trace_id));
   MOCK_METHOD(uint32_t, maxBufferedRxBytes, (), (const));
@@ -73,8 +73,26 @@ public:
     EXPECT_CALL(*config_, maxBufferedTxBytes()).WillRepeatedly(Return(1024));
     EXPECT_CALL(*config_, timeSource()).WillRepeatedly(ReturnRef(time_system_));
     time_system_.setSystemTime(std::chrono::seconds(0));
+
+    // Only for streaming trace
     tap_config_.set_set_connection_per_event(output_conn_info_per_event_);
-    tapper_ = std::make_unique<PerSocketTapperImpl>(config_, tap_config_, connection_);
+
+    // stats for both streaming and buffered trace
+    std::string final_prefix = fmt::format("transport.tap.");
+    TransportTapStats stats{
+        ALL_TRANSPORT_TAP_STATS(POOL_COUNTER_PREFIX(*stats_store_.rootScope(), final_prefix))};
+    if (pegging_counter_) {
+      tap_config_.set_pegging_counter(true);
+      tap_config_.set_stats_prefix("tranTapPrefix");
+    }
+
+    // Only for buffered trace
+    if (sending_tapped_msg_on_configured_size_) {
+      tap_config_.set_sending_tapped_msg_on_configured_size(true);
+      tap_config_.mutable_min_buffered_bytes()->set_value(default_min_buffered_bytes_);
+    }
+
+    tapper_ = std::make_unique<PerSocketTapperImpl>(config_, tap_config_, stats, connection_);
   }
 
   std::shared_ptr<MockSocketTapConfig> config_{std::make_shared<MockSocketTapConfig>()};
@@ -91,6 +109,10 @@ public:
   // Add transport configurations
   envoy::extensions::transport_sockets::tap::v3::SocketTapConfig tap_config_;
   bool output_conn_info_per_event_{false};
+  bool pegging_counter_{false};
+  Stats::IsolatedStoreImpl stats_store_;
+  bool sending_tapped_msg_on_configured_size_{false};
+  unsigned int default_min_buffered_bytes_ = 20;
 };
 
 // Verify the full streaming flow.
@@ -248,6 +270,232 @@ socket_streamed_trace_segment:
   tapper_->closeSocket(Network::ConnectionEvent::RemoteClose);
   // restore the value
   output_conn_info_per_event_ = local_output_conn_info_per_event;
+}
+
+// Verify the full streaming flow for peg counter.
+TEST_F(PerSocketTapperImplTest, StreamingFlowPegCounter) {
+  // keep the original value
+  bool local_output_conn_info_per_event = output_conn_info_per_event_;
+  output_conn_info_per_event_ = true;
+  bool local_pegging_counter = pegging_counter_;
+  pegging_counter_ = true;
+  EXPECT_CALL(*sink_manager_, submitTrace_(TraceEqual(
+                                  R"EOF(
+socket_streamed_trace_segment:
+  trace_id: 1
+  connection:
+    local_address:
+      socket_address:
+        address: 127.0.0.1
+        port_value: 1000
+    remote_address:
+      socket_address:
+        address: 10.0.0.3
+        port_value: 50000
+)EOF")));
+  setup(true);
+
+  InSequence s;
+
+  EXPECT_CALL(*sink_manager_, submitTrace_(TraceEqual(
+                                  R"EOF(
+socket_streamed_trace_segment:
+  trace_id: 1
+  event:
+    timestamp: 1970-01-01T00:00:00Z
+    read:
+      data:
+        as_bytes: aGVsbG8=
+    connection:
+      local_address:
+        socket_address:
+          address: 127.0.0.1
+          port_value: 1000
+      remote_address:
+        socket_address:
+          address: 10.0.0.3
+          port_value: 50000
+)EOF")));
+  tapper_->onRead(Buffer::OwnedImpl("hello"), 5);
+
+  EXPECT_CALL(*sink_manager_, submitTrace_(TraceEqual(
+                                  R"EOF(
+socket_streamed_trace_segment:
+  trace_id: 1
+  event:
+    timestamp: 1970-01-01T00:00:01Z
+    write:
+      data:
+        as_bytes: d29ybGQ=
+      end_stream: true
+    connection:
+      local_address:
+        socket_address:
+          address: 127.0.0.1
+          port_value: 1000
+      remote_address:
+        socket_address:
+          address: 10.0.0.3
+          port_value: 50000
+)EOF")));
+  time_system_.setSystemTime(std::chrono::seconds(1));
+  tapper_->onWrite(Buffer::OwnedImpl("world"), 5, true);
+
+  EXPECT_CALL(*sink_manager_, submitTrace_(TraceEqual(
+                                  R"EOF(
+socket_streamed_trace_segment:
+  trace_id: 1
+  event:
+    timestamp: 1970-01-01T00:00:02Z
+    closed: {}
+    connection:
+      local_address:
+        socket_address:
+          address: 127.0.0.1
+          port_value: 1000
+      remote_address:
+        socket_address:
+          address: 10.0.0.3
+          port_value: 50000
+)EOF")));
+  time_system_.setSystemTime(std::chrono::seconds(2));
+  tapper_->closeSocket(Network::ConnectionEvent::RemoteClose);
+
+  // restore the value
+  output_conn_info_per_event_ = local_output_conn_info_per_event;
+  pegging_counter_ = local_pegging_counter;
+}
+
+// Verify the full buffered flow for submit data in close event.
+TEST_F(PerSocketTapperImplTest, BufferedFlow) {
+  // keep the original value
+  bool local_pegging_counter = pegging_counter_;
+  pegging_counter_ = true;
+  bool local_sending_tapped_msg_on_configured_size = sending_tapped_msg_on_configured_size_;
+  sending_tapped_msg_on_configured_size_ = true;
+  bool local_default_min_buffered_bytes = default_min_buffered_bytes_;
+  default_min_buffered_bytes_ = 30;
+
+  setup(false);
+  // InSequence s;
+
+  EXPECT_CALL(*sink_manager_, submitTrace_(TraceEqual(
+                                  R"EOF(
+socket_buffered_trace:
+  trace_id: 1
+  connection:
+    local_address:
+      socket_address:
+        address: 127.0.0.1
+        port_value: 1000
+    remote_address:
+      socket_address:
+        address: 10.0.0.3
+        port_value: 50000
+  events:
+  - timestamp: 1970-01-01T00:00:00Z
+    read:
+      data:
+        as_bytes: aGVsbG8=
+  - timestamp: 1970-01-01T00:00:01Z
+    write:
+      data:
+        as_bytes: d29ybGQ=
+      end_stream: true
+)EOF")));
+  tapper_->onRead(Buffer::OwnedImpl("hello"), 5);
+
+  // Call onWrite after one seconds.
+  time_system_.setSystemTime(std::chrono::seconds(1));
+  tapper_->onWrite(Buffer::OwnedImpl("world"), 5, true);
+
+  // All buffered data is submitted.
+  time_system_.setSystemTime(std::chrono::seconds(2));
+  tapper_->closeSocket(Network::ConnectionEvent::RemoteClose);
+
+  // restore the value.
+  pegging_counter_ = local_pegging_counter;
+  sending_tapped_msg_on_configured_size_ = local_sending_tapped_msg_on_configured_size;
+  default_min_buffered_bytes_ = local_default_min_buffered_bytes;
+}
+
+// Verify the full buffered flow for submit data in Read/Write event.
+TEST_F(PerSocketTapperImplTest, BufferedFlowSubmitOnReadOnWrite) {
+  // keep the original value
+  bool local_pegging_counter = pegging_counter_;
+  pegging_counter_ = true;
+  bool local_sending_tapped_msg_on_configured_size = sending_tapped_msg_on_configured_size_;
+  sending_tapped_msg_on_configured_size_ = true;
+  bool local_default_min_buffered_bytes = default_min_buffered_bytes_;
+  default_min_buffered_bytes_ = 30;
+
+  setup(false);
+  EXPECT_CALL(*sink_manager_, submitTrace_(TraceEqual(
+                                  R"EOF(
+socket_buffered_trace:
+  trace_id: 1
+  connection:
+    local_address:
+      socket_address:
+        address: 127.0.0.1
+        port_value: 1000
+    remote_address:
+      socket_address:
+        address: 10.0.0.3
+        port_value: 50000
+  events:
+  - timestamp: 1970-01-01T00:00:00Z
+    read:
+      data:
+        as_bytes: VGVzdCB0cmFuc3BvcnQgc29ja2V0IHRhcCBidWZmZXJlZCBkYXRhIG9uUmVhZCBzdWJtaXQ=
+)EOF")));
+  tapper_->onRead(Buffer::OwnedImpl("Test transport socket tap buffered data onRead submit"), 53);
+
+  EXPECT_CALL(*sink_manager_, submitTrace_(TraceEqual(
+                                  R"EOF(
+socket_buffered_trace:
+  trace_id: 1
+  connection:
+    local_address:
+      socket_address:
+        address: 127.0.0.1
+        port_value: 1000
+    remote_address:
+      socket_address:
+        address: 10.0.0.3
+        port_value: 50000
+  events:
+  - timestamp: 1970-01-01T00:00:01Z
+    write:
+      data:
+        as_bytes: VGVzdCB0cmFuc3BvcnQgc29ja2V0IHRhcCBidWZmZXJlZCBkYXRhIG9uV3JpdGUgc3VibWl0
+      end_stream: true
+)EOF")));
+  // Call onWrite after one seconds
+  time_system_.setSystemTime(std::chrono::seconds(1));
+  tapper_->onWrite(Buffer::OwnedImpl("Test transport socket tap buffered data onWrite submit"), 54,
+                   true);
+
+  EXPECT_CALL(*sink_manager_, submitTrace_(TraceEqual(
+                                  R"EOF(
+socket_buffered_trace:
+  trace_id: 1
+  connection:
+    local_address:
+      socket_address:
+        address: 127.0.0.1
+        port_value: 1000
+    remote_address:
+      socket_address:
+        address: 10.0.0.3
+        port_value: 50000
+)EOF")));
+  time_system_.setSystemTime(std::chrono::seconds(2));
+  tapper_->closeSocket(Network::ConnectionEvent::RemoteClose);
+  // restore the value
+  pegging_counter_ = local_pegging_counter;
+  sending_tapped_msg_on_configured_size_ = local_sending_tapped_msg_on_configured_size;
+  default_min_buffered_bytes_ = local_default_min_buffered_bytes;
 }
 
 } // namespace

--- a/test/extensions/transport_sockets/tap/tap_config_impl_test.cc
+++ b/test/extensions/transport_sockets/tap/tap_config_impl_test.cc
@@ -82,13 +82,11 @@ public:
     TransportTapStats stats{
         ALL_TRANSPORT_TAP_STATS(POOL_COUNTER_PREFIX(*stats_store_.rootScope(), final_prefix))};
     if (pegging_counter_) {
-      tap_config_.set_pegging_counter(true);
       tap_config_.set_stats_prefix("tranTapPrefix");
     }
 
     // Only for buffered trace
     if (sending_tapped_msg_on_configured_size_) {
-      tap_config_.set_sending_tapped_msg_on_configured_size(true);
       tap_config_.mutable_min_buffered_bytes()->set_value(default_min_buffered_bytes_);
     }
 


### PR DESCRIPTION
Commit Message: Enhance transport tap buffer trace to send tapped messages based on configured size
Additional Description:
For buffer tracing, tapped messages are sent only on connection closure by default. This is suitable for HTTP/1 but not for HTTP/2.
Tapped messages are sent based on the configured size is needed for HTTP/2 and later.

Risk Level: Low
Testing: Done the test in local.
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
