### PR TITLE
deps: update cncf/xds to 2025-05-01 version

### DIFF
--- a/api/bazel/repository_locations.bzl
+++ b/api/bazel/repository_locations.bzl
@@ -52,9 +52,9 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         project_desc = "xDS API Working Group (xDS-WG)",
         project_url = "https://github.com/cncf/xds",
         # During the UDPA -> xDS migration, we aren't working with releases.
-        version = "b4127c9b8d78b77423fd25169f05b7476b6ea932",
-        sha256 = "aa5f1596bbef3f277dcf4700e4c1097b34301ae66f3b79cd731e3adfbaff2f8f",
-        release_date = "2024-09-05",
+        version = "2ac532fd44436293585084f8d94c6bdb17835af0",
+        sha256 = "790c4c83b6950bb602fec221f6a529d9f368cdc8852aae7d2592d0d04b015f37",
+        release_date = "2025-05-01",
         strip_prefix = "xds-{version}",
         urls = ["https://github.com/cncf/xds/archive/{version}.tar.gz"],
         use_category = ["api"],


### PR DESCRIPTION
Commit Message: deps: update cncf/xds to 2025-05-01 version
Additional Description:
Periodic upgrade of the xds repo.

Risk Level: low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
