### PR TITLE
Don't hide virtual functions

### DIFF
--- a/envoy/common/regex.h
+++ b/envoy/common/regex.h
@@ -14,6 +14,9 @@ namespace Regex {
  */
 class CompiledMatcher : public Matchers::StringMatcher {
 public:
+  // To avoid hiding other implementations of match.
+  using Matchers::StringMatcher::match;
+
   /**
    * Replaces all non-overlapping occurrences of the pattern in "value" with
    * "substitution". The "substitution" string can make references to

--- a/source/common/common/matchers.h
+++ b/source/common/common/matchers.h
@@ -85,6 +85,9 @@ private:
 
 class UniversalStringMatcher : public StringMatcher {
 public:
+  // To avoid hiding other implementations of match.
+  using StringMatcher::match;
+
   bool match(absl::string_view) const override { return true; }
 };
 

--- a/source/common/common/matchers.h
+++ b/source/common/common/matchers.h
@@ -411,6 +411,9 @@ public:
               Server::Configuration::CommonFactoryContext& context)
       : matcher_(matcher, context) {}
 
+  // To avoid hiding other implementations of match.
+  using StringMatcher::match;
+
   static PathMatcherConstSharedPtr
   createExact(const std::string& exact, bool ignore_case,
               Server::Configuration::CommonFactoryContext& context);

--- a/source/common/common/regex.h
+++ b/source/common/common/regex.h
@@ -28,6 +28,9 @@ public:
   static absl::StatusOr<std::unique_ptr<CompiledGoogleReMatcher>>
   create(const xds::type::matcher::v3::RegexMatcher& config);
 
+  // To avoid hiding other implementations of match.
+  using CompiledMatcher::match;
+
   // CompiledMatcher
   bool match(absl::string_view value) const override { return re2::RE2::FullMatch(value, regex_); }
 

--- a/source/common/tls/cert_validator/san_matcher.h
+++ b/source/common/tls/cert_validator/san_matcher.h
@@ -72,6 +72,9 @@ private:
 // and the DNS matching semantics must be followed.
 class DnsExactStringSanMatcher : public SanMatcher {
 public:
+  // To avoid hiding other implementations of match.
+  using SanMatcher::match;
+
   bool match(GENERAL_NAME const* general_name) const override;
   ~DnsExactStringSanMatcher() override = default;
 

--- a/source/extensions/string_matcher/lua/match.cc
+++ b/source/extensions/string_matcher/lua/match.cc
@@ -88,6 +88,9 @@ public:
     });
   }
 
+  // To avoid hiding other implementations of match.
+  using Matchers::StringMatcher::match;
+
   bool match(absl::string_view value) const override { return (*tls_slot_)->match(value); }
 
 private:

--- a/source/extensions/string_matcher/lua/match.h
+++ b/source/extensions/string_matcher/lua/match.h
@@ -19,6 +19,9 @@ public:
   // ThreadLocal::ThreadLocalObject
   ~LuaStringMatcher() override = default;
 
+  // To avoid hiding other implementations of match.
+  using Matchers::StringMatcher::match;
+
   // Matchers::StringMatcher
   bool match(absl::string_view value) const override;
 

--- a/test/mocks/matcher/mocks.h
+++ b/test/mocks/matcher/mocks.h
@@ -24,6 +24,7 @@ namespace Matchers {
 class MockStringMatcher : public StringMatcher {
 public:
   MOCK_METHOD(bool, match, (absl::string_view), (const, override));
+  MOCK_METHOD(bool, match, (absl::string_view, const Context&), (const, override));
 };
 } // namespace Matchers
 } // namespace Envoy


### PR DESCRIPTION
Commit Message: Don't hide virtual functions
Additional Description: gcc has a lot of warnings when `match(absl::string_view)` "hides" virtual functions `match(absl::string_view, const Context&)`. For all practical purposes this is not important because the caller always has the base/dynamic type, and the virtual function table has access to both functions, it's just the explicit base-class that has the functions "hidden". However, the thousands of repeated warnings in the gcc build output are bothersome, and it's arguably more correct to not "hide" the functions.
Risk Level: No behavior change.
Testing: Checked gcc CI output - there are now 6 instances of "hidden" in the log, vs 5180 before.
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
