### PR TITLE
docs: clarify Circuit Breakers docs for Dynamic Forward Proxy

### DIFF
--- a/docs/root/configuration/http/http_filters/_include/dns-cache-circuit-breaker.yaml
+++ b/docs/root/configuration/http/http_filters/_include/dns-cache-circuit-breaker.yaml
@@ -45,7 +45,7 @@ static_resources:
                 dns_lookup_family: V4_ONLY
                 # DNS Cache Circuit Breaker Configuration
                 dns_cache_circuit_breaker:
-                  max_pending_requests: 1024 # Maximum DNS resolution requests pending
+                  max_pending_requests: 1024
                 typed_dns_resolver_config:
                   name: envoy.network.dns_resolver.cares
                   typed_config:

--- a/docs/root/configuration/http/http_filters/_include/dns-cache-circuit-breaker.yaml
+++ b/docs/root/configuration/http/http_filters/_include/dns-cache-circuit-breaker.yaml
@@ -43,6 +43,9 @@ static_resources:
               dns_cache_config:
                 name: dynamic_forward_proxy_cache_config
                 dns_lookup_family: V4_ONLY
+                # DNS Cache Circuit Breaker Configuration
+                dns_cache_circuit_breaker:
+                  max_pending_requests: 1024 # Maximum DNS resolution requests pending
                 typed_dns_resolver_config:
                   name: envoy.network.dns_resolver.cares
                   typed_config:
@@ -60,6 +63,14 @@ static_resources:
   clusters:
   - name: dynamic_forward_proxy_cluster
     lb_policy: CLUSTER_PROVIDED
+    # Standard Cluster Circuit Breaker Configuration
+    circuit_breakers:
+      thresholds:
+      - priority: DEFAULT
+        max_connections: 1024
+        max_pending_requests: 1024
+        max_requests: 1024
+        max_retries: 3
     cluster_type:
       name: envoy.clusters.dynamic_forward_proxy
       typed_config:
@@ -67,6 +78,9 @@ static_resources:
         dns_cache_config:
           name: dynamic_forward_proxy_cache_config
           dns_lookup_family: V4_ONLY
+          # DNS Cache Circuit Breaker Configuration (same as above)
+          dns_cache_circuit_breaker:
+            max_pending_requests: 1024
           typed_dns_resolver_config:
             name: envoy.network.dns_resolver.cares
             typed_config:

--- a/docs/root/configuration/http/http_filters/dynamic_forward_proxy_filter.rst
+++ b/docs/root/configuration/http/http_filters/dynamic_forward_proxy_filter.rst
@@ -43,8 +43,20 @@ host when forwarding. See the example below within the configured routes.
 
 .. _dns_cache_circuit_breakers:
 
-  Dynamic forward proxy uses circuit breakers built in to the DNS cache with the configuration
-  of :ref:`DNS cache circuit breakers <envoy_v3_api_field_extensions.common.dynamic_forward_proxy.v3.DnsCacheConfig.dns_cache_circuit_breaker>`.
+Circuit Breakers
+----------------
+
+Dynamic Forward Proxy cluster has two types of circuit breakers:
+
+1. **DNS Cache Circuit Breakers**: These are specific to the DNS resolution process. They limit the number of
+   pending DNS requests and prevent overwhelming the resolver. These circuit breakers are configured through
+   the :ref:`dns_cache_circuit_breaker <envoy_v3_api_field_extensions.common.dynamic_forward_proxy.v3.DnsCacheConfig.dns_cache_circuit_breaker>`
+   field in the DNS cache configuration.
+
+2. **Cluster Circuit Breakers**: In addition to the DNS-specific circuit breakers, the standard
+   :ref:`cluster circuit breakers <config_cluster_manager_cluster_circuit_breakers>` also apply to the Dynamic
+   Forward Proxy cluster. These limit connections, requests, retries, etc. to the upstream hosts and are configured
+   like any other Envoy cluster.
 
 .. literalinclude:: _include/dns-cache-circuit-breaker.yaml
     :language: yaml


### PR DESCRIPTION
## Description

This PR clarifies the documentation for circuit breakers in Dynamic Forward Proxy to address the confusion raised in #39497.

**Fixes:** #39497

### Preview

<img width="927" alt="Screenshot 2025-05-21 at 13 58 08" src="https://github.com/user-attachments/assets/be9b03d2-05d5-4a28-b1ce-6c0137dcef21" />

https://storage.googleapis.com/envoy-pr/6d45f12/docs/configuration/http/http_filters/dynamic_forward_proxy_filter.html#circuit-breakers

---

**Commit Message:** docs: clarify Circuit Breakers docs for Dynamic Forward Proxy
**Additional Description:** Add clarification to the documentation for circuit breakers in Dynamic Forward Proxy
**Risk Level:** N/A
**Testing:** N/A
**Docs Changes:** Added
**Release Notes:** N/A