### PR TITLE
route: avoid copying the route config when creating a new route

### DIFF
--- a/source/common/http/header_utility.h
+++ b/source/common/http/header_utility.h
@@ -271,6 +271,7 @@ public:
       const Protobuf::RepeatedPtrField<envoy::config::route::v3::HeaderMatcher>& header_matchers,
       Server::Configuration::CommonFactoryContext& context) {
     std::vector<HeaderUtility::HeaderDataPtr> ret;
+    ret.reserve(header_matchers.size());
     for (const auto& header_matcher : header_matchers) {
       ret.emplace_back(HeaderUtility::createHeaderData(header_matcher, context));
     }
@@ -284,6 +285,7 @@ public:
       const Protobuf::RepeatedPtrField<envoy::config::route::v3::HeaderMatcher>& header_matchers,
       Server::Configuration::CommonFactoryContext& context) {
     std::vector<Http::HeaderMatcherSharedPtr> ret;
+    ret.reserve(header_matchers.size());
     for (const auto& header_matcher : header_matchers) {
       ret.emplace_back(HeaderUtility::createHeaderData(header_matcher, context));
     }

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -1310,7 +1310,7 @@ RouteEntryImplBase::OptionalTimeouts RouteEntryImplBase::buildOptionalTimeouts(
 }
 
 absl::StatusOr<PathRewriterSharedPtr>
-RouteEntryImplBase::buildPathRewriter(envoy::config::route::v3::Route route,
+RouteEntryImplBase::buildPathRewriter(const envoy::config::route::v3::Route& route,
                                       ProtobufMessage::ValidationVisitor& validator) const {
   if (!route.route().has_path_rewrite_policy()) {
     return nullptr;
@@ -1329,7 +1329,7 @@ RouteEntryImplBase::buildPathRewriter(envoy::config::route::v3::Route route,
 }
 
 absl::StatusOr<PathMatcherSharedPtr>
-RouteEntryImplBase::buildPathMatcher(envoy::config::route::v3::Route route,
+RouteEntryImplBase::buildPathMatcher(const envoy::config::route::v3::Route& route,
                                      ProtobufMessage::ValidationVisitor& validator) const {
   if (!route.match().has_path_match_policy()) {
     return nullptr;

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -1183,11 +1183,11 @@ private:
   }
 
   absl::StatusOr<PathMatcherSharedPtr>
-  buildPathMatcher(envoy::config::route::v3::Route route,
+  buildPathMatcher(const envoy::config::route::v3::Route& route,
                    ProtobufMessage::ValidationVisitor& validator) const;
 
   absl::StatusOr<PathRewriterSharedPtr>
-  buildPathRewriter(envoy::config::route::v3::Route route,
+  buildPathRewriter(const envoy::config::route::v3::Route& route,
                     ProtobufMessage::ValidationVisitor& validator) const;
 
   RouteConstSharedPtr


### PR DESCRIPTION
Commit Message: route: avoid copying the route config when creating a new route
Additional Description:
Minor optimization to avoid copying the Route protobuf structure, and to reserve some vectors memory upfront.

Risk Level: low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A