### PR TITLE
Adds note in the docs for ORCA Header Propagation

### DIFF
--- a/api/envoy/extensions/load_balancing_policies/client_side_weighted_round_robin/v3/client_side_weighted_round_robin.proto
+++ b/api/envoy/extensions/load_balancing_policies/client_side_weighted_round_robin/v3/client_side_weighted_round_robin.proto
@@ -32,7 +32,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // weights using eps and qps. The weight of a given endpoint is computed as:
 // ``qps / (utilization + eps/qps * error_utilization_penalty)``.
 //
-// Note that Envoy will forward the ORCA reponse headers/trailers from the upstream
+// Note that Envoy will forward the ORCA response headers/trailers from the upstream
 // cluster to the downstream client. This means that if the downstream client is also
 // configured to use `client_side_weighted_round_robin` it will load balance against
 // Envoy based on upstream weights. This can happen when Envoy is used as a reverse proxy.

--- a/api/envoy/extensions/load_balancing_policies/client_side_weighted_round_robin/v3/client_side_weighted_round_robin.proto
+++ b/api/envoy/extensions/load_balancing_policies/client_side_weighted_round_robin/v3/client_side_weighted_round_robin.proto
@@ -32,10 +32,10 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // weights using eps and qps. The weight of a given endpoint is computed as:
 // ``qps / (utilization + eps/qps * error_utilization_penalty)``.
 //
-// Note that Envoy will forward the ORCA reponse headers/trailers from the upsteream
-// cluster to the downstream client. This means that if the client is also configured
-// to use `client_side_weighted_round_robin` it will load balance against Envoy based
-/// on upstream weights. This can happen when Envoy is used as a reverse proxy.
+// Note that Envoy will forward the ORCA reponse headers/trailers from the upstream
+// cluster to the downstream client. This means that if the downstream client is also
+// configured to use `client_side_weighted_round_robin` it will load balance against
+// Envoy based on upstream weights. This can happen when Envoy is used as a reverse proxy.
 // To avoid this issue you can configure the :ref:`header_mutation filter  <envoy_v3_api_msg_extensions.filters.http.header_mutation.v3.HeaderMutation>` to remove
 // the ORCA payload from the response headers/trailers.
 //

--- a/api/envoy/extensions/load_balancing_policies/client_side_weighted_round_robin/v3/client_side_weighted_round_robin.proto
+++ b/api/envoy/extensions/load_balancing_policies/client_side_weighted_round_robin/v3/client_side_weighted_round_robin.proto
@@ -32,6 +32,13 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // weights using eps and qps. The weight of a given endpoint is computed as:
 // ``qps / (utilization + eps/qps * error_utilization_penalty)``.
 //
+// Note that Envoy will forward the ORCA reponse headers/trailers from the upsteream
+// cluster to the downstream client. This means that if the client is also configured
+// to use `client_side_weighted_round_robin` it will load balance against Envoy based
+/// on upstream weights. This can happen when Envoy is used as a reverse proxy.
+// To avoid this issue you can configure the :ref:`header_mutation filter  <envoy_v3_api_msg_extensions.filters.http.header_mutation.v3.HeaderMutation>` to remove
+// the ORCA payload from the response headers/trailers.
+//
 // See the :ref:`load balancing architecture
 // overview<arch_overview_load_balancing_types>` for more information.
 //

--- a/api/envoy/extensions/load_balancing_policies/client_side_weighted_round_robin/v3/client_side_weighted_round_robin.proto
+++ b/api/envoy/extensions/load_balancing_policies/client_side_weighted_round_robin/v3/client_side_weighted_round_robin.proto
@@ -34,7 +34,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 //
 // Note that Envoy will forward the ORCA response headers/trailers from the upstream
 // cluster to the downstream client. This means that if the downstream client is also
-// configured to use `client_side_weighted_round_robin` it will load balance against
+// configured to use ``client_side_weighted_round_robin`` it will load balance against
 // Envoy based on upstream weights. This can happen when Envoy is used as a reverse proxy.
 // To avoid this issue you can configure the :ref:`header_mutation filter  <envoy_v3_api_msg_extensions.filters.http.header_mutation.v3.HeaderMutation>` to remove
 // the ORCA payload from the response headers/trailers.


### PR DESCRIPTION
Commit Message:
As discussed in #39382 this is something operators should be aware of when using the ORCA LB policy.

So I added a note in the proto file for the ORCA LB policy to show up in the docs.

Additional Description: N/A
Risk Level: N/A
Testing: N/A
Docs Changes: only docs
Release Notes: N/A
Platform Specific Features: N/A