### PR TITLE
load-stats-report: performance improvement by fetching only relevant clusters

### DIFF
--- a/envoy/upstream/cluster_manager.h
+++ b/envoy/upstream/cluster_manager.h
@@ -333,6 +333,15 @@ public:
    */
   virtual ClusterInfoMaps clusters() const PURE;
 
+  /**
+   * Receives a cluster name and returns an active cluster (if found).
+   * @param cluster_name the name of the cluster.
+   * @return OptRef<const Cluster> A reference to the cluster if found, and nullopt otherwise.
+   *
+   * NOTE: This method is only thread safe on the main thread. It should not be called elsewhere.
+   */
+  virtual OptRef<const Cluster> getActiveCluster(absl::string_view cluster_name) const PURE;
+
   using ClusterSet = absl::flat_hash_set<std::string>;
 
   /**

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -280,6 +280,15 @@ public:
     return clusters_maps;
   }
 
+  OptRef<const Cluster> getActiveCluster(absl::string_view cluster_name) const override {
+    ASSERT_IS_MAIN_OR_TEST_THREAD();
+    if (const auto& it = active_clusters_.find(std::string(cluster_name));
+        it != active_clusters_.end()) {
+      return OptRef<const Cluster>(*it->second->cluster_);
+    }
+    return absl::nullopt;
+  }
+
   const ClusterSet& primaryClusters() override { return primary_clusters_; }
   ThreadLocalCluster* getThreadLocalCluster(absl::string_view cluster) override;
 

--- a/source/common/upstream/load_stats_reporter.cc
+++ b/source/common/upstream/load_stats_reporter.cc
@@ -65,12 +65,12 @@ void LoadStatsReporter::sendLoadStatsRequest() {
   auto all_clusters = cm_.clusters();
   for (const auto& cluster_name_and_timestamp : clusters_) {
     const std::string& cluster_name = cluster_name_and_timestamp.first;
-    auto it = all_clusters.active_clusters_.find(cluster_name);
-    if (it == all_clusters.active_clusters_.end()) {
+    OptRef<const Upstream::Cluster> active_cluster = cm_.getActiveCluster(cluster_name);
+    if (!active_cluster.has_value()) {
       ENVOY_LOG(debug, "Cluster {} does not exist", cluster_name);
       continue;
     }
-    auto& cluster = it->second.get();
+    const Upstream::Cluster& cluster = active_cluster.value();
     auto* cluster_stats = request_.add_cluster_stats();
     cluster_stats->set_cluster_name(cluster_name);
     if (const auto& name = cluster.info()->edsServiceName(); !name.empty()) {

--- a/test/common/upstream/load_stats_reporter_test.cc
+++ b/test/common/upstream/load_stats_reporter_test.cc
@@ -133,9 +133,10 @@ TEST_F(LoadStatsReporterTest, ExistingClusters) {
   foo_cluster.info_->load_report_stats_.upstream_rq_dropped_.add(2);
   foo_cluster.info_->eds_service_name_ = "bar";
   NiceMock<MockClusterMockPrioritySet> bar_cluster;
-  MockClusterManager::ClusterInfoMaps cluster_info{
-      {{"foo", foo_cluster}, {"bar", bar_cluster}}, {}, {}};
-  ON_CALL(cm_, clusters()).WillByDefault(Return(cluster_info));
+  ON_CALL(cm_, getActiveCluster("foo"))
+      .WillByDefault(Return(OptRef<const Upstream::Cluster>(foo_cluster)));
+  ON_CALL(cm_, getActiveCluster("bar"))
+      .WillByDefault(Return(OptRef<const Upstream::Cluster>(bar_cluster)));
   deliverLoadStatsResponse({"foo"});
   // Initial stats report for foo on timer tick.
   foo_cluster.info_->load_report_stats_.upstream_rq_dropped_.add(5);
@@ -145,7 +146,7 @@ TEST_F(LoadStatsReporterTest, ExistingClusters) {
     envoy::config::endpoint::v3::ClusterStats foo_cluster_stats;
     foo_cluster_stats.set_cluster_name("foo");
     foo_cluster_stats.set_cluster_service_name("bar");
-    foo_cluster_stats.set_total_dropped_requests(5);
+    foo_cluster_stats.set_total_dropped_requests(7);
     setDropOverload(foo_cluster_stats, 7);
     foo_cluster_stats.mutable_load_report_interval()->MergeFrom(
         Protobuf::util::TimeUtil::MicrosecondsToDuration(1));
@@ -176,8 +177,8 @@ TEST_F(LoadStatsReporterTest, ExistingClusters) {
         Protobuf::util::TimeUtil::MicrosecondsToDuration(24));
     envoy::config::endpoint::v3::ClusterStats bar_cluster_stats;
     bar_cluster_stats.set_cluster_name("bar");
-    bar_cluster_stats.set_total_dropped_requests(1);
-    setDropOverload(bar_cluster_stats, 3);
+    bar_cluster_stats.set_total_dropped_requests(2);
+    setDropOverload(bar_cluster_stats, 8);
     bar_cluster_stats.mutable_load_report_interval()->MergeFrom(
         Protobuf::util::TimeUtil::MicrosecondsToDuration(22));
     expectSendMessage({bar_cluster_stats, foo_cluster_stats});
@@ -228,8 +229,8 @@ TEST_F(LoadStatsReporterTest, ExistingClusters) {
     envoy::config::endpoint::v3::ClusterStats foo_cluster_stats;
     foo_cluster_stats.set_cluster_name("foo");
     foo_cluster_stats.set_cluster_service_name("bar");
-    foo_cluster_stats.set_total_dropped_requests(1);
-    setDropOverload(foo_cluster_stats, 9);
+    foo_cluster_stats.set_total_dropped_requests(8);
+    setDropOverload(foo_cluster_stats, 17);
     foo_cluster_stats.mutable_load_report_interval()->MergeFrom(
         Protobuf::util::TimeUtil::MicrosecondsToDuration(4));
     envoy::config::endpoint::v3::ClusterStats bar_cluster_stats;
@@ -316,8 +317,8 @@ TEST_P(LoadStatsReporterTestWithRqTotal, UpstreamLocalityStats) {
   addStats(host2, 10.01, 0, 20.02, 30.03);
 
   cluster.info_->eds_service_name_ = "bar";
-  MockClusterManager::ClusterInfoMaps cluster_info{{{"foo", cluster}}, {}, {}};
-  ON_CALL(cm_, clusters()).WillByDefault(Return(cluster_info));
+  ON_CALL(cm_, getActiveCluster("foo"))
+      .WillByDefault(Return(OptRef<const Upstream::Cluster>(cluster)));
   deliverLoadStatsResponse({"foo"});
   // First stats report on timer tick.
   time_system_.setMonotonicTime(std::chrono::microseconds(4));

--- a/test/mocks/upstream/cluster_manager.cc
+++ b/test/mocks/upstream/cluster_manager.cc
@@ -50,6 +50,13 @@ void MockClusterManager::initializeClusters(const std::vector<std::string>& acti
   // TODO(mattklein123): Add support for warming clusters when needed.
 
   ON_CALL(*this, clusters()).WillByDefault(Return(info_map));
+  ON_CALL(*this, getActiveCluster(_))
+      .WillByDefault(Invoke([this](absl::string_view cluster_name) -> OptRef<const Cluster> {
+        if (const auto& it = active_clusters_.find(cluster_name); it != active_clusters_.end()) {
+          return *it->second;
+        }
+        return absl::nullopt;
+      }));
 }
 
 void MockClusterManager::initializeThreadLocalClusters(

--- a/test/mocks/upstream/cluster_manager.h
+++ b/test/mocks/upstream/cluster_manager.h
@@ -43,6 +43,7 @@ public:
   MOCK_METHOD(absl::Status, initializeSecondaryClusters,
               (const envoy::config::bootstrap::v3::Bootstrap& bootstrap));
   MOCK_METHOD(ClusterInfoMaps, clusters, (), (const));
+  MOCK_METHOD(OptRef<const Cluster>, getActiveCluster, (absl::string_view cluster_name), (const));
 
   MOCK_METHOD(const ClusterSet&, primaryClusters, ());
   MOCK_METHOD(ThreadLocalCluster*, getThreadLocalCluster, (absl::string_view cluster));


### PR DESCRIPTION
Commit Message: load-stats-report: performance improvement by fetching only relevant clusters
Additional Description:
When issuing a load-report, Envoy creates a map of clusters (active and warming) from the cluster-manager, and then looks for the relevant clusters that need their load-report emitted.
This PR changes this flow, so the intermediate map is not created, and only the relevant active clusters are fetched on-demand.

Risk Level: low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
