### PR TITLE
utility: use inlinevector to avoid heap allocations for splitToken

### DIFF
--- a/source/common/common/utility.cc
+++ b/source/common/common/utility.cc
@@ -459,11 +459,11 @@ absl::string_view StringUtil::cropLeft(absl::string_view source, absl::string_vi
   return source;
 }
 
-std::vector<absl::string_view> StringUtil::splitToken(absl::string_view source,
-                                                      absl::string_view delimiters,
-                                                      bool keep_empty_string,
-                                                      bool trim_whitespace) {
-  std::vector<absl::string_view> result;
+absl::InlinedVector<absl::string_view, 8> StringUtil::splitToken(absl::string_view source,
+                                                                 absl::string_view delimiters,
+                                                                 bool keep_empty_string,
+                                                                 bool trim_whitespace) {
+  absl::InlinedVector<absl::string_view, 8> result;
 
   if (keep_empty_string) {
     result = absl::StrSplit(source, absl::ByAnyChar(delimiters));

--- a/source/common/common/utility.h
+++ b/source/common/common/utility.h
@@ -439,10 +439,10 @@ public:
    * string views; default = false.
    * @return vector containing views of the split strings
    */
-  static std::vector<absl::string_view> splitToken(absl::string_view source,
-                                                   absl::string_view delimiters,
-                                                   bool keep_empty_string = false,
-                                                   bool trim_whitespace = false);
+  static absl::InlinedVector<absl::string_view, 8> splitToken(absl::string_view source,
+                                                              absl::string_view delimiters,
+                                                              bool keep_empty_string = false,
+                                                              bool trim_whitespace = false);
 
   /**
    * Remove tokens from a delimiter-separated string view. The tokens are trimmed before

--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -652,8 +652,7 @@ bool Utility::isWebSocketUpgradeRequest(const RequestHeaderMap& headers) {
 void Utility::removeUpgrade(RequestOrResponseHeaderMap& headers,
                             const std::vector<Matchers::StringMatcherPtr>& matchers) {
   if (headers.Upgrade()) {
-    std::vector<absl::string_view> tokens =
-        Envoy::StringUtil::splitToken(headers.getUpgradeValue(), ",", false, true);
+    auto tokens = Envoy::StringUtil::splitToken(headers.getUpgradeValue(), ",", false, true);
 
     auto end = std::remove_if(tokens.begin(), tokens.end(), [&](absl::string_view token) {
       return std::any_of(
@@ -900,7 +899,7 @@ bool Utility::sanitizeConnectionHeader(Http::RequestHeaderMap& headers) {
   const auto& connection_header_value = headers.Connection()->value();
 
   StringUtil::CaseUnorderedSet headers_to_remove{};
-  std::vector<absl::string_view> connection_header_tokens =
+  const auto connection_header_tokens =
       StringUtil::splitToken(connection_header_value.getStringView(), ",", false);
 
   // If we have 10 or more nominated headers, fail this request

--- a/source/common/tls/context_impl.cc
+++ b/source/common/tls/context_impl.cc
@@ -126,8 +126,7 @@ ContextImpl::ContextImpl(Stats::Scope& scope, const Envoy::Ssl::ContextConfig& c
       // cipher), and the common separator in names (ECDHE-ECDSA-AES128-GCM-SHA256). Don't split on
       // it because it will separate pieces of the same cipher. When it is a leading character, it
       // is removed below.
-      std::vector<absl::string_view> ciphers =
-          StringUtil::splitToken(config.cipherSuites(), ":+![|]", false);
+      const auto ciphers = StringUtil::splitToken(config.cipherSuites(), ":+![|]", false);
       std::vector<std::string> bad_ciphers;
       for (const auto& cipher : ciphers) {
         std::string cipher_str(cipher);

--- a/source/extensions/common/aws/utility.cc
+++ b/source/extensions/common/aws/utility.cc
@@ -149,7 +149,7 @@ Utility::createCanonicalRequest(absl::string_view method, absl::string_view path
  */
 std::string Utility::normalizePath(absl::string_view original_path) {
 
-  const auto path_segments = StringUtil::splitToken(original_path, std::string{PATH_SPLITTER});
+  const auto path_segments = StringUtil::splitToken(original_path, PATH_SPLITTER);
   std::vector<std::string> path_list;
   path_list.reserve(path_segments.size());
 

--- a/source/extensions/filters/common/ext_authz/ext_authz_http_impl.cc
+++ b/source/extensions/filters/common/ext_authz/ext_authz_http_impl.cc
@@ -333,7 +333,7 @@ ResponsePtr RawHttpClientImpl::toResponse(Http::ResponseMessagePtr message) {
       const Http::HeaderEntry* entry = get_result[i];
       if (entry != nullptr) {
         absl::string_view storage_header_value = entry->value().getStringView();
-        std::vector<absl::string_view> header_names = StringUtil::splitToken(
+        const auto header_names = StringUtil::splitToken(
             storage_header_value, ",", /*keep_empty_string=*/false, /*trim_whitespace=*/true);
         headers_to_remove.reserve(headers_to_remove.size() + header_names.size());
         for (const auto& header_name : header_names) {

--- a/source/extensions/filters/network/common/redis/client_impl.cc
+++ b/source/extensions/filters/network/common/redis/client_impl.cc
@@ -233,7 +233,7 @@ void ClientImpl::onRespValue(RespValuePtr&& value) {
     host_->cluster().trafficStats()->upstream_rq_cancelled_.inc();
   } else if (config_->enableRedirection() && !is_transaction_client_ &&
              (value->type() == Common::Redis::RespType::Error)) {
-    std::vector<absl::string_view> err = StringUtil::splitToken(value->asString(), " ", false);
+    const auto err = StringUtil::splitToken(value->asString(), " ", false);
     if (err.size() == 3 &&
         (err[0] == RedirectionResponse::get().MOVED || err[0] == RedirectionResponse::get().ASK)) {
       // MOVED and ASK redirection errors have the following substrings: MOVED or ASK (err[0]), hash

--- a/test/common/common/utility_test.cc
+++ b/test/common/common/utility_test.cc
@@ -30,6 +30,8 @@ using testing::Not;
 
 namespace Envoy {
 
+using TokensVector = absl::InlinedVector<absl::string_view, 8>;
+
 TEST(TimeSpecToChrono, convertsCorrectly) {
   struct timespec t;
   t.tv_nsec = 456789;
@@ -514,25 +516,25 @@ TEST(StringUtil, StringViewSplit) {
     EXPECT_TRUE(std::find(tokens.begin(), tokens.end(), "five ") != tokens.end());
   }
   {
-    EXPECT_EQ(std::vector<absl::string_view>{"hello"}, StringUtil::splitToken(",hello", ","));
-    EXPECT_EQ(std::vector<absl::string_view>{}, StringUtil::splitToken("", ","));
-    EXPECT_EQ(std::vector<absl::string_view>{"a"}, StringUtil::splitToken("a", ","));
-    EXPECT_EQ(std::vector<absl::string_view>{"hello"}, StringUtil::splitToken("hello,", ","));
-    EXPECT_EQ(std::vector<absl::string_view>{"hello"}, StringUtil::splitToken(",hello", ","));
-    EXPECT_EQ(std::vector<absl::string_view>{"hello"}, StringUtil::splitToken("hello, ", ", "));
-    EXPECT_EQ(std::vector<absl::string_view>{}, StringUtil::splitToken(",,", ","));
+    EXPECT_EQ(TokensVector{"hello"}, StringUtil::splitToken(",hello", ","));
+    EXPECT_EQ(TokensVector{}, StringUtil::splitToken("", ","));
+    EXPECT_EQ(TokensVector{"a"}, StringUtil::splitToken("a", ","));
+    EXPECT_EQ(TokensVector{"hello"}, StringUtil::splitToken("hello,", ","));
+    EXPECT_EQ(TokensVector{"hello"}, StringUtil::splitToken(",hello", ","));
+    EXPECT_EQ(TokensVector{"hello"}, StringUtil::splitToken("hello, ", ", "));
+    EXPECT_EQ(TokensVector{}, StringUtil::splitToken(",,", ","));
 
-    EXPECT_THAT(std::vector<absl::string_view>({"h", "e", "l", "l", "o"}),
+    EXPECT_THAT(TokensVector({"h", "e", "l", "l", "o"}),
                 ContainerEq(StringUtil::splitToken("hello", "")));
-    EXPECT_THAT(std::vector<absl::string_view>({"hello", "world"}),
+    EXPECT_THAT(TokensVector({"hello", "world"}),
                 ContainerEq(StringUtil::splitToken("hello world", " ")));
-    EXPECT_THAT(std::vector<absl::string_view>({"hello", "world"}),
+    EXPECT_THAT(TokensVector({"hello", "world"}),
                 ContainerEq(StringUtil::splitToken("hello   world", " ")));
-    EXPECT_THAT(std::vector<absl::string_view>({"", "", "hello", "world"}),
+    EXPECT_THAT(TokensVector({"", "", "hello", "world"}),
                 ContainerEq(StringUtil::splitToken("  hello world", " ", true)));
-    EXPECT_THAT(std::vector<absl::string_view>({"hello", "world", ""}),
+    EXPECT_THAT(TokensVector({"hello", "world", ""}),
                 ContainerEq(StringUtil::splitToken("hello world ", " ", true)));
-    EXPECT_THAT(std::vector<absl::string_view>({"hello", "world"}),
+    EXPECT_THAT(TokensVector({"hello", "world"}),
                 ContainerEq(StringUtil::splitToken("hello world", " ", true)));
   }
   {

--- a/test/extensions/filters/listener/proxy_protocol/proxy_proto_integration_test.cc
+++ b/test/extensions/filters/listener/proxy_protocol/proxy_proto_integration_test.cc
@@ -168,7 +168,7 @@ TEST_P(ProxyProtoIntegrationTest, AccessLog) {
 
   testRouterRequestAndResponseWithBody(1024, 512, false, false, &creator);
   const std::string log_line = waitForAccessLog(access_log_name_);
-  const std::vector<absl::string_view> tokens = StringUtil::splitToken(log_line, " ", false, true);
+  const auto tokens = StringUtil::splitToken(log_line, " ", false, true);
 
   ASSERT_EQ(2, tokens.size());
   EXPECT_EQ(tokens[0], Network::Test::getLoopbackAddressString(GetParam()));


### PR DESCRIPTION
Commit Message: utility: use inlinevector to avoid heap allocations for splitToken
Additional Description:

splitToken is used very widely but it will always will create a std::vector even there are only very limited tokens. This PR changed the return type to inlined vector. Then in most cases, these allocations could be eliminated.

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
