### PR TITLE
Avoid trace span buffer becoming too large

### DIFF
--- a/api/envoy/config/trace/v3/opentelemetry.proto
+++ b/api/envoy/config/trace/v3/opentelemetry.proto
@@ -6,9 +6,10 @@ import "envoy/config/core/v3/extension.proto";
 import "envoy/config/core/v3/grpc_service.proto";
 import "envoy/config/core/v3/http_service.proto";
 
+import "google/protobuf/wrappers.proto";
+
 import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
-import "google/protobuf/wrappers.proto";
 
 option java_package = "io.envoyproxy.envoy.config.trace.v3";
 option java_outer_classname = "OpentelemetryProto";
@@ -20,7 +21,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // Configuration for the OpenTelemetry tracer.
 //  [#extension: envoy.tracers.opentelemetry]
-// [#next-free-field: 6]
+// [#next-free-field: 7]
 message OpenTelemetryConfig {
   // The upstream gRPC cluster that will receive OTLP traces.
   // Note that the tracer drops traces if the server does not read data fast enough.

--- a/api/envoy/config/trace/v3/opentelemetry.proto
+++ b/api/envoy/config/trace/v3/opentelemetry.proto
@@ -8,6 +8,7 @@ import "envoy/config/core/v3/http_service.proto";
 
 import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
+import "google/protobuf/wrappers.proto";
 
 option java_package = "io.envoyproxy.envoy.config.trace.v3";
 option java_outer_classname = "OpentelemetryProto";
@@ -57,4 +58,9 @@ message OpenTelemetryConfig {
   // See: `OpenTelemetry sampler specification <https://opentelemetry.io/docs/specs/otel/trace/sdk/#sampler>`_
   // [#extension-category: envoy.tracers.opentelemetry.samplers]
   core.v3.TypedExtensionConfig sampler = 5;
+
+  // Envoy caches the span in memory when the OpenTelemetry backend service is temporarily unavailable.
+  // This field specifies the maximum number of spans that can be cached. If not specified, the
+  // default is 1024.
+  google.protobuf.UInt32Value max_cache_size = 6;
 }

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -61,17 +61,12 @@ minor_behavior_changes:
    will also be applied to the local responses from the ``envoy.filters.http.router`` filter.
 - area: tracing
   change: |
-<<<<<<< HEAD
-    Add :ref:`max_buffer_size <envoy_v3_api_field_tracing.opentelemetry.v3.OpenTelemetryTracerConfig.max_buffer_size>`
-    to the OpenTelemetry tracer config. This limits the number of spans that can be buffered before flushing.
+    Add :ref:`max_cache_size <envoy_v3_api_field_config.trace.v3.OpenTelemetryConfig.max_cache_size>`
+    to the OpenTelemetry tracer config. This limits the number of spans that can be cached before flushing.
 - area: aws
   change: |
     :ref:`AwsCredentialProvider <envoy_v3_api_msg_extensions.common.aws.v3.AwsCredentialProvider>` now supports all defined credential
     providers, allowing complete customisation of the credential provider chain when using AWS request signing extension.
-=======
-    Add :ref:`max_cache_size <envoy_v3_api_field_config.trace.v3.OpenTelemetryConfig.max_cache_size>`
-    to the OpenTelemetry tracer config. This limits the number of spans that can be cached before flushing.
->>>>>>> 1744d0b07d (fix(tracing): resolve OpenTelemetry max_cache_size field inconsistencies - Fix field name mismatch from max_buffer_size() to max_cache_size(), add proper wrapper type handling with default value of 1024, update constructor signature, correct changelog field name, and remove incorrect runtime mock call in test)
 
 bug_fixes:
 # *Changes expected to improve the state of the world and are unlikely to have negative effects*

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -59,6 +59,10 @@ minor_behavior_changes:
    :ref:`response_headers_to_add <envoy_v3_api_field_config.route.v3.Route.response_headers_to_add>` and
    :ref:`response_headers_to_remove <envoy_v3_api_field_config.route.v3.Route.response_headers_to_remove>`
    will also be applied to the local responses from the ``envoy.filters.http.router`` filter.
+- area: tracing
+  change: |
+    Add :ref:`max_buffer_size <envoy_v3_api_field_tracing.opentelemetry.v3.OpenTelemetryTracerConfig.max_buffer_size>`
+    to the OpenTelemetry tracer config. This limits the number of spans that can be buffered before flushing.
 - area: aws
   change: |
     :ref:`AwsCredentialProvider <envoy_v3_api_msg_extensions.common.aws.v3.AwsCredentialProvider>` now supports all defined credential

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -61,12 +61,17 @@ minor_behavior_changes:
    will also be applied to the local responses from the ``envoy.filters.http.router`` filter.
 - area: tracing
   change: |
+<<<<<<< HEAD
     Add :ref:`max_buffer_size <envoy_v3_api_field_tracing.opentelemetry.v3.OpenTelemetryTracerConfig.max_buffer_size>`
     to the OpenTelemetry tracer config. This limits the number of spans that can be buffered before flushing.
 - area: aws
   change: |
     :ref:`AwsCredentialProvider <envoy_v3_api_msg_extensions.common.aws.v3.AwsCredentialProvider>` now supports all defined credential
     providers, allowing complete customisation of the credential provider chain when using AWS request signing extension.
+=======
+    Add :ref:`max_cache_size <envoy_v3_api_field_config.trace.v3.OpenTelemetryConfig.max_cache_size>`
+    to the OpenTelemetry tracer config. This limits the number of spans that can be cached before flushing.
+>>>>>>> 1744d0b07d (fix(tracing): resolve OpenTelemetry max_cache_size field inconsistencies - Fix field name mismatch from max_buffer_size() to max_cache_size(), add proper wrapper type handling with default value of 1024, update constructor signature, correct changelog field name, and remove incorrect runtime mock call in test)
 
 bug_fixes:
 # *Changes expected to improve the state of the world and are unlikely to have negative effects*

--- a/source/extensions/tracers/opentelemetry/opentelemetry_tracer_impl.cc
+++ b/source/extensions/tracers/opentelemetry/opentelemetry_tracer_impl.cc
@@ -105,11 +105,12 @@ Driver::Driver(const envoy::config::trace::v3::OpenTelemetryConfig& opentelemetr
           factory_context.clusterManager(), opentelemetry_config.http_service());
     }
     // Get the max cache size from config
-    uint64_t max_cache_size = PROTOBUF_GET_WRAPPED_OR_DEFAULT(opentelemetry_config.max_cache_size(), value, DEFAULT_MAX_CACHE_SIZE);
-    TracerPtr tracer = std::make_unique<Tracer>(
-        std::move(exporter), factory_context.timeSource(), factory_context.api().randomGenerator(),
-        factory_context.runtime(), dispatcher, tracing_stats_, resource_ptr, sampler,
-        max_cache_size);
+    uint64_t max_cache_size = PROTOBUF_GET_WRAPPED_OR_DEFAULT(opentelemetry_config.max_cache_size(),
+                                                              value, DEFAULT_MAX_CACHE_SIZE);
+    TracerPtr tracer =
+        std::make_unique<Tracer>(std::move(exporter), factory_context.timeSource(),
+                                 factory_context.api().randomGenerator(), factory_context.runtime(),
+                                 dispatcher, tracing_stats_, resource_ptr, sampler, max_cache_size);
     return std::make_shared<TlsTracer>(std::move(tracer));
   });
 }

--- a/source/extensions/tracers/opentelemetry/opentelemetry_tracer_impl.cc
+++ b/source/extensions/tracers/opentelemetry/opentelemetry_tracer_impl.cc
@@ -101,10 +101,14 @@ Driver::Driver(const envoy::config::trace::v3::OpenTelemetryConfig& opentelemetr
       exporter = std::make_unique<OpenTelemetryHttpTraceExporter>(
           factory_context.clusterManager(), opentelemetry_config.http_service());
     }
+    // Get the max cache size from config, with default value of 1024 if not specified
+    uint64_t max_cache_size = opentelemetry_config.has_max_cache_size() 
+        ? opentelemetry_config.max_cache_size().value() 
+        : 1024;
     TracerPtr tracer = std::make_unique<Tracer>(
         std::move(exporter), factory_context.timeSource(), factory_context.api().randomGenerator(),
         factory_context.runtime(), dispatcher, tracing_stats_, resource_ptr, sampler,
-        opentelemetry_config.max_cache_size());
+        max_cache_size);
     return std::make_shared<TlsTracer>(std::move(tracer));
   });
 }

--- a/source/extensions/tracers/opentelemetry/opentelemetry_tracer_impl.cc
+++ b/source/extensions/tracers/opentelemetry/opentelemetry_tracer_impl.cc
@@ -103,7 +103,8 @@ Driver::Driver(const envoy::config::trace::v3::OpenTelemetryConfig& opentelemetr
     }
     TracerPtr tracer = std::make_unique<Tracer>(
         std::move(exporter), factory_context.timeSource(), factory_context.api().randomGenerator(),
-        factory_context.runtime(), dispatcher, tracing_stats_, resource_ptr, sampler);
+        factory_context.runtime(), dispatcher, tracing_stats_, resource_ptr, sampler,
+        opentelemetry_config.max_cache_size());
     return std::make_shared<TlsTracer>(std::move(tracer));
   });
 }

--- a/source/extensions/tracers/opentelemetry/opentelemetry_tracer_impl.cc
+++ b/source/extensions/tracers/opentelemetry/opentelemetry_tracer_impl.cc
@@ -29,6 +29,9 @@ namespace OpenTelemetry {
 
 namespace {
 
+// Default max cache size for OpenTelemetry tracer
+static constexpr uint64_t DEFAULT_MAX_CACHE_SIZE = 1024;
+
 SamplerSharedPtr
 tryCreateSamper(const envoy::config::trace::v3::OpenTelemetryConfig& opentelemetry_config,
                 Server::Configuration::TracerFactoryContext& context) {
@@ -101,10 +104,8 @@ Driver::Driver(const envoy::config::trace::v3::OpenTelemetryConfig& opentelemetr
       exporter = std::make_unique<OpenTelemetryHttpTraceExporter>(
           factory_context.clusterManager(), opentelemetry_config.http_service());
     }
-    // Get the max cache size from config, with default value of 1024 if not specified
-    uint64_t max_cache_size = opentelemetry_config.has_max_cache_size() 
-        ? opentelemetry_config.max_cache_size().value() 
-        : 1024;
+    // Get the max cache size from config
+    uint64_t max_cache_size = PROTOBUF_GET_WRAPPED_OR_DEFAULT(opentelemetry_config.max_cache_size(), value, DEFAULT_MAX_CACHE_SIZE);
     TracerPtr tracer = std::make_unique<Tracer>(
         std::move(exporter), factory_context.timeSource(), factory_context.api().randomGenerator(),
         factory_context.runtime(), dispatcher, tracing_stats_, resource_ptr, sampler,

--- a/source/extensions/tracers/opentelemetry/opentelemetry_tracer_impl.cc
+++ b/source/extensions/tracers/opentelemetry/opentelemetry_tracer_impl.cc
@@ -105,8 +105,8 @@ Driver::Driver(const envoy::config::trace::v3::OpenTelemetryConfig& opentelemetr
           factory_context.clusterManager(), opentelemetry_config.http_service());
     }
     // Get the max cache size from config
-    uint64_t max_cache_size = PROTOBUF_GET_WRAPPED_OR_DEFAULT(opentelemetry_config.max_cache_size(),
-                                                              value, DEFAULT_MAX_CACHE_SIZE);
+    uint64_t max_cache_size = PROTOBUF_GET_WRAPPED_OR_DEFAULT(opentelemetry_config, max_cache_size,
+                                                              DEFAULT_MAX_CACHE_SIZE);
     TracerPtr tracer =
         std::make_unique<Tracer>(std::move(exporter), factory_context.timeSource(),
                                  factory_context.api().randomGenerator(), factory_context.runtime(),

--- a/source/extensions/tracers/opentelemetry/tracer.cc
+++ b/source/extensions/tracers/opentelemetry/tracer.cc
@@ -245,9 +245,7 @@ void Tracer::flushSpans() {
 }
 
 void Tracer::sendSpan(::opentelemetry::proto::trace::v1::Span& span) {
-  const uint64_t max_buffer_size =
-    runtime_.snapshot().getInteger("tracing.opentelemetry.max_buffer_size", 1000U);
-  if (span_buffer_.size() > max_buffer_size) {
+  if (span_buffer_.size() > max_cache_size_) {
     ENVOY_LOG(warn, "Span buffer size exceeded maximum limit. Discarding span.");
     return;
   }

--- a/source/extensions/tracers/opentelemetry/tracer.cc
+++ b/source/extensions/tracers/opentelemetry/tracer.cc
@@ -184,9 +184,11 @@ void Span::setTag(absl::string_view name, absl::string_view value) {
 Tracer::Tracer(OpenTelemetryTraceExporterPtr exporter, Envoy::TimeSource& time_source,
                Random::RandomGenerator& random, Runtime::Loader& runtime,
                Event::Dispatcher& dispatcher, OpenTelemetryTracerStats tracing_stats,
-               const ResourceConstSharedPtr resource, SamplerSharedPtr sampler)
+               const ResourceConstSharedPtr resource, SamplerSharedPtr sampler,
+               uint64_t max_cache_size)
     : exporter_(std::move(exporter)), time_source_(time_source), random_(random), runtime_(runtime),
-      tracing_stats_(tracing_stats), resource_(resource), sampler_(sampler) {
+      tracing_stats_(tracing_stats), resource_(resource), sampler_(sampler),
+      max_cache_size_(max_cache_size) {
   flush_timer_ = dispatcher.createTimer([this]() -> void {
     tracing_stats_.timer_flushed_.inc();
     flushSpans();

--- a/source/extensions/tracers/opentelemetry/tracer.cc
+++ b/source/extensions/tracers/opentelemetry/tracer.cc
@@ -245,6 +245,12 @@ void Tracer::flushSpans() {
 }
 
 void Tracer::sendSpan(::opentelemetry::proto::trace::v1::Span& span) {
+  const uint64_t max_buffer_size =
+    runtime_.snapshot().getInteger("tracing.opentelemetry.max_buffer_size", 1000U);
+  if (span_buffer_.size() > max_buffer_size) {
+    ENVOY_LOG(warn, "Span buffer size exceeded maximum limit. Discarding span.");
+    return;
+  }
   span_buffer_.push_back(span);
   const uint64_t min_flush_spans =
       runtime_.snapshot().getInteger("tracing.opentelemetry.min_flush_spans", 5U);

--- a/source/extensions/tracers/opentelemetry/tracer.cc
+++ b/source/extensions/tracers/opentelemetry/tracer.cc
@@ -248,7 +248,8 @@ void Tracer::flushSpans() {
 
 void Tracer::sendSpan(::opentelemetry::proto::trace::v1::Span& span) {
   if (span_buffer_.size() >= max_cache_size_) {
-    ENVOY_LOG(warn, "Span buffer size exceeded maximum limit. Discarding span.");
+    ENVOY_LOG(warn, "Span buffer size exceeded maximum limit. Discarding span. Current size: {}, Max size: {}", span_buffer_.size(), max_cache_size_);
+    flushSpans();
     return;
   }
   span_buffer_.push_back(span);

--- a/source/extensions/tracers/opentelemetry/tracer.cc
+++ b/source/extensions/tracers/opentelemetry/tracer.cc
@@ -248,7 +248,10 @@ void Tracer::flushSpans() {
 
 void Tracer::sendSpan(::opentelemetry::proto::trace::v1::Span& span) {
   if (span_buffer_.size() >= max_cache_size_) {
-    ENVOY_LOG(warn, "Span buffer size exceeded maximum limit. Discarding span. Current size: {}, Max size: {}", span_buffer_.size(), max_cache_size_);
+    ENVOY_LOG(
+        warn,
+        "Span buffer size exceeded maximum limit. Discarding span. Current size: {}, Max size: {}",
+        span_buffer_.size(), max_cache_size_);
     flushSpans();
     return;
   }

--- a/source/extensions/tracers/opentelemetry/tracer.cc
+++ b/source/extensions/tracers/opentelemetry/tracer.cc
@@ -247,7 +247,7 @@ void Tracer::flushSpans() {
 }
 
 void Tracer::sendSpan(::opentelemetry::proto::trace::v1::Span& span) {
-  if (span_buffer_.size() > max_cache_size_) {
+  if (span_buffer_.size() >= max_cache_size_) {
     ENVOY_LOG(warn, "Span buffer size exceeded maximum limit. Discarding span.");
     return;
   }

--- a/source/extensions/tracers/opentelemetry/tracer.cc
+++ b/source/extensions/tracers/opentelemetry/tracer.cc
@@ -247,18 +247,18 @@ void Tracer::flushSpans() {
 }
 
 void Tracer::sendSpan(::opentelemetry::proto::trace::v1::Span& span) {
-  if (span_buffer_.size() >= max_cache_size_) {
-    ENVOY_LOG(
+  span_buffer_.push_back(span);
+  if (span_buffer_.size() > max_cache_size_) {
+    ENVOY_LOG_EVERY_POW_2(
         warn,
         "Span buffer size exceeded maximum limit. Discarding span. Current size: {}, Max size: {}",
         span_buffer_.size(), max_cache_size_);
-    flushSpans();
-    return;
+    tracing_stats_.spans_dropped_.inc();
+    span_buffer_.pop_front();
   }
-  span_buffer_.push_back(span);
   const uint64_t min_flush_spans =
       runtime_.snapshot().getInteger("tracing.opentelemetry.min_flush_spans", 5U);
-  if (span_buffer_.size() >= min_flush_spans) {
+  if (span_buffer_.size() >= min_flush_spans || span_buffer_.size() >= max_cache_size_) {
     flushSpans();
   }
 }

--- a/source/extensions/tracers/opentelemetry/tracer.cc
+++ b/source/extensions/tracers/opentelemetry/tracer.cc
@@ -247,7 +247,7 @@ void Tracer::flushSpans() {
 }
 
 void Tracer::sendSpan(::opentelemetry::proto::trace::v1::Span& span) {
-  if (span_buffer_.size() > max_cache_size_) {
+  if (span_buffer_.size() >= max_cache_size_) {
     ENVOY_LOG_EVERY_POW_2(
         warn,
         "Span buffer size exceeded maximum limit. Discarding span. Current size: {}, Max size: {}",

--- a/source/extensions/tracers/opentelemetry/tracer.h
+++ b/source/extensions/tracers/opentelemetry/tracer.h
@@ -25,7 +25,8 @@ namespace OpenTelemetry {
 
 #define OPENTELEMETRY_TRACER_STATS(COUNTER)                                                        \
   COUNTER(spans_sent)                                                                              \
-  COUNTER(timer_flushed)
+  COUNTER(timer_flushed)                                                                           \
+  COUNTER(spans_dropped)                                                                           \
 
 struct OpenTelemetryTracerStats {
   OPENTELEMETRY_TRACER_STATS(GENERATE_COUNTER_STRUCT)

--- a/source/extensions/tracers/opentelemetry/tracer.h
+++ b/source/extensions/tracers/opentelemetry/tracer.h
@@ -26,7 +26,7 @@ namespace OpenTelemetry {
 #define OPENTELEMETRY_TRACER_STATS(COUNTER)                                                        \
   COUNTER(spans_sent)                                                                              \
   COUNTER(timer_flushed)                                                                           \
-  COUNTER(spans_dropped)                                                                           \
+  COUNTER(spans_dropped)
 
 struct OpenTelemetryTracerStats {
   OPENTELEMETRY_TRACER_STATS(GENERATE_COUNTER_STRUCT)

--- a/source/extensions/tracers/opentelemetry/tracer.h
+++ b/source/extensions/tracers/opentelemetry/tracer.h
@@ -39,7 +39,7 @@ public:
   Tracer(OpenTelemetryTraceExporterPtr exporter, Envoy::TimeSource& time_source,
          Random::RandomGenerator& random, Runtime::Loader& runtime, Event::Dispatcher& dispatcher,
          OpenTelemetryTracerStats tracing_stats, const ResourceConstSharedPtr resource,
-         SamplerSharedPtr sampler);
+         SamplerSharedPtr sampler, uint64_t max_cache_size);
 
   void sendSpan(::opentelemetry::proto::trace::v1::Span& span);
 
@@ -74,6 +74,7 @@ private:
   OpenTelemetryTracerStats tracing_stats_;
   const ResourceConstSharedPtr resource_;
   SamplerSharedPtr sampler_;
+  uint64_t max_cache_size_;
 };
 
 /**

--- a/test/extensions/tracers/opentelemetry/opentelemetry_tracer_impl_test.cc
+++ b/test/extensions/tracers/opentelemetry/opentelemetry_tracer_impl_test.cc
@@ -928,10 +928,7 @@ TEST_F(OpenTelemetryDriverTest, ExportOTLPSpanHTTP) {
                                              operation_name_, {Tracing::Reason::Sampling, true});
   EXPECT_NE(span.get(), nullptr);
 
-  // Check that the max buffer size.
-  EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.opentelemetry.max_cache_size", 1000U))
-      .Times(1)
-      .WillRepeatedly(Return(1));
+  // Check that spans are buffered and flushed properly with max cache size.
   // Flush after a single span.
   EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.opentelemetry.min_flush_spans", 5U))
       .Times(1)

--- a/test/extensions/tracers/opentelemetry/opentelemetry_tracer_impl_test.cc
+++ b/test/extensions/tracers/opentelemetry/opentelemetry_tracer_impl_test.cc
@@ -398,6 +398,8 @@ TEST_F(OpenTelemetryDriverTest, ExportOTLPSpanWithMaxCacheSize) {
 
   // Verify only 2 spans were sent (not 3), confirming the third was discarded
   EXPECT_EQ(2U, stats_.counter("tracing.opentelemetry.spans_sent").value());
+  // Verify the third span was discarded
+  EXPECT_EQ(1U, stats_.counter("tracing.opentelemetry.spans_dropped").value());
 }
 
 // Verifies the export happens after a timeout

--- a/test/extensions/tracers/opentelemetry/opentelemetry_tracer_impl_test.cc
+++ b/test/extensions/tracers/opentelemetry/opentelemetry_tracer_impl_test.cc
@@ -373,13 +373,13 @@ TEST_F(OpenTelemetryDriverTest, ExportOTLPSpanWithMaxCacheSize) {
   EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.opentelemetry.min_flush_spans", 5U))
       .WillRepeatedly(Return(10));
 
-  // Create first span - should be cached
+  // Create first span - should be cached (1/2)
   Tracing::SpanPtr span1 = driver_->startSpan(mock_tracing_config_, request_headers, stream_info_,
                                               operation_name_, {Tracing::Reason::Sampling, true});
   EXPECT_NE(span1.get(), nullptr);
   span1->finishSpan();
 
-  // Create second span - should be cached (max_cache_size = 2)
+  // Create second span - should be cached (2/2, at max capacity)
   Tracing::SpanPtr span2 = driver_->startSpan(mock_tracing_config_, request_headers, stream_info_,
                                               operation_name_, {Tracing::Reason::Sampling, true});
   EXPECT_NE(span2.get(), nullptr);

--- a/test/extensions/tracers/opentelemetry/opentelemetry_tracer_impl_test.cc
+++ b/test/extensions/tracers/opentelemetry/opentelemetry_tracer_impl_test.cc
@@ -386,12 +386,6 @@ TEST_F(OpenTelemetryDriverTest, ExportOTLPSpanWithMaxCacheSize) {
   EXPECT_NE(span2.get(), nullptr);
   span2->finishSpan();
 
-  // Create third span - should be discarded due to max_cache_size limit
-  Tracing::SpanPtr span3 = driver_->startSpan(mock_tracing_config_, request_headers, stream_info_,
-                                              operation_name_, {Tracing::Reason::Sampling, true});
-  EXPECT_NE(span3.get(), nullptr);
-  span3->finishSpan();
-
   // Create another span to trigger flush
   Tracing::SpanPtr trigger_span =
       driver_->startSpan(mock_tracing_config_, request_headers, stream_info_, operation_name_,

--- a/test/extensions/tracers/opentelemetry/opentelemetry_tracer_impl_test.cc
+++ b/test/extensions/tracers/opentelemetry/opentelemetry_tracer_impl_test.cc
@@ -928,6 +928,10 @@ TEST_F(OpenTelemetryDriverTest, ExportOTLPSpanHTTP) {
                                              operation_name_, {Tracing::Reason::Sampling, true});
   EXPECT_NE(span.get(), nullptr);
 
+  // Check that the max buffer size.
+  EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.opentelemetry.max_buffer_size", 1000U))
+      .Times(1)
+      .WillRepeatedly(Return(1));
   // Flush after a single span.
   EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.opentelemetry.min_flush_spans", 5U))
       .Times(1)

--- a/test/extensions/tracers/opentelemetry/opentelemetry_tracer_impl_test.cc
+++ b/test/extensions/tracers/opentelemetry/opentelemetry_tracer_impl_test.cc
@@ -369,10 +369,6 @@ TEST_F(OpenTelemetryDriverTest, ExportOTLPSpanWithMaxCacheSize) {
   Tracing::TestTraceContextImpl request_headers{
       {":authority", "test.com"}, {":path", "/"}, {":method", "GET"}};
 
-  // Set min_flush_spans to a large value to prevent automatic flushing
-  EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.opentelemetry.min_flush_spans", 5U))
-      .WillRepeatedly(Return(10));
-
   // Create first span - should be cached (1/2)
   Tracing::SpanPtr span1 = driver_->startSpan(mock_tracing_config_, request_headers, stream_info_,
                                               operation_name_, {Tracing::Reason::Sampling, true});

--- a/test/extensions/tracers/opentelemetry/opentelemetry_tracer_impl_test.cc
+++ b/test/extensions/tracers/opentelemetry/opentelemetry_tracer_impl_test.cc
@@ -389,7 +389,8 @@ TEST_F(OpenTelemetryDriverTest, ExportOTLPSpanWithMaxCacheSize) {
 
   // Now force flush by setting min_flush_spans to 1
   EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.opentelemetry.min_flush_spans", 5U))
-      .WillOnce(Return(1));
+      .Times(1)
+      .WillRepeatedly(Return(1));
 
   // Create another span to trigger flush
   Tracing::SpanPtr trigger_span =

--- a/test/extensions/tracers/opentelemetry/opentelemetry_tracer_impl_test.cc
+++ b/test/extensions/tracers/opentelemetry/opentelemetry_tracer_impl_test.cc
@@ -929,7 +929,7 @@ TEST_F(OpenTelemetryDriverTest, ExportOTLPSpanHTTP) {
   EXPECT_NE(span.get(), nullptr);
 
   // Check that the max buffer size.
-  EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.opentelemetry.max_buffer_size", 1000U))
+  EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.opentelemetry.max_cache_size", 1000U))
       .Times(1)
       .WillRepeatedly(Return(1));
   // Flush after a single span.

--- a/test/extensions/tracers/opentelemetry/opentelemetry_tracer_impl_test.cc
+++ b/test/extensions/tracers/opentelemetry/opentelemetry_tracer_impl_test.cc
@@ -396,8 +396,9 @@ TEST_F(OpenTelemetryDriverTest, ExportOTLPSpanWithMaxCacheSize) {
       .WillOnce(Return(1));
 
   // Create another span to trigger flush
-  Tracing::SpanPtr trigger_span = driver_->startSpan(mock_tracing_config_, request_headers, stream_info_,
-                                                     operation_name_, {Tracing::Reason::Sampling, true});
+  Tracing::SpanPtr trigger_span =
+      driver_->startSpan(mock_tracing_config_, request_headers, stream_info_, operation_name_,
+                         {Tracing::Reason::Sampling, true});
   EXPECT_NE(trigger_span.get(), nullptr);
 
   // Should only see 2 spans exported (third span was discarded)

--- a/test/extensions/tracers/opentelemetry/opentelemetry_tracer_impl_test.cc
+++ b/test/extensions/tracers/opentelemetry/opentelemetry_tracer_impl_test.cc
@@ -371,8 +371,8 @@ TEST_F(OpenTelemetryDriverTest, ExportOTLPSpanWithMaxCacheSize) {
 
   // set min_flush_spans to 10 avoid automatic flushing.
   EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.opentelemetry.min_flush_spans", 5U))
-      .Times(10)
-      .WillRepeatedly(Return(10))
+      .Times(2)
+      .WillRepeatedly(Return(10));
 
   // Create first span - should be cached (1/2)
   Tracing::SpanPtr span1 = driver_->startSpan(mock_tracing_config_, request_headers, stream_info_,


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Avoid trace span buffer becoming too large
Additional Description:
See https://github.com/istio/istio/issues/55439#issuecomment-2883638106 , the sidecar space-inuse flame graph shows sometimes span serialize message grow too large, maybe it's caused by sending span to remote server is too slow. We should avoid this memory growing.
![image](https://github.com/user-attachments/assets/b258c474-0a04-47d5-8752-39086d618ffc)

Risk Level: 
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:

