### PR TITLE
Use static linking for fuzz coverage CI targets

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -260,15 +260,14 @@ build:coverage --define=no_debug_info=1
 # `--no-relax` is required for coverage to not err with `relocation R_X86_64_REX_GOTPCRELX`
 build:coverage --linkopt=-Wl,-s,--no-relax
 build:coverage --test_env=ENVOY_IP_TEST_VERSIONS=v4only
+build:coverage --define=dynamic_link_tests=false
 
 build:test-coverage --test_arg="-l trace"
 build:test-coverage --test_arg="--log-path /dev/null"
 build:test-coverage --test_tag_filters=-nocoverage,-fuzz_target
-build:test-coverage --define=dynamic_link_tests=false
 build:fuzz-coverage --config=plain-fuzzer
 build:fuzz-coverage --run_under=@envoy//bazel/coverage:fuzz_coverage_wrapper.sh
 build:fuzz-coverage --test_tag_filters=-nocoverage
-build:fuzz-coverage --define=dynamic_link_tests=true
 # Existing fuzz tests don't need a full WASM runtime and in generally we don't really want to
 # fuzz dependencies anyways. On the other hand, disabling WASM reduces the build time and
 # resources required to build and run the tests.


### PR DESCRIPTION
Commit Message:

Static linking helps to work around the issue with LLVM/Clang source-based coverage (see llvm/llvm-project#32849). On the flip side, the coverage build and test run will take a bit longer with this change.

We already did this change for the regular test coverage, but we delayed the switch for the fuzz coverage because fuzz coverage hit RBE backend resource constraints and was OOMing during linking.

Since then we did a few things to mitigate the issue with resources:

1. We switched coverage runs from Google RBE backend to EngFlow which allows for somewhat larger workers
2. We started building fuzz targets without WASM - there are not fuzz targets that actually need a full WASM runtime and elimnating it speeds things up and reduces the footprint noticably.

With the above two changes I think we are ready to completely switch to static linking for all coverage tests. It also has a benefit of better cache re-use since we will be linking both coverage and fuzz coverage targets statically.

Additional Description:

https://github.com/envoyproxy/envoy/pull/39030 provides some context for EngFlow migration and https://github.com/envoyproxy/envoy/issues/39248 is a tracking bug.

Risk Level: low
Testing: regular CI tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a