### PR TITLE
add x-envoy-original-host to keep original host

### DIFF
--- a/api/envoy/config/route/v3/route_components.proto
+++ b/api/envoy/config/route/v3/route_components.proto
@@ -1161,12 +1161,21 @@ message RouteAction {
   // [#extension-category: envoy.path.rewrite]
   core.v3.TypedExtensionConfig path_rewrite_policy = 41;
 
+  // If one of the host rewrite specifiers is set and the
+  // :ref:`suppress_envoy_headers
+  // <envoy_api_field_config.filter.http.router.v3.Router.suppress_envoy_headers>` flag is not
+  // set to true, the router filter will place the original host header value before
+  // rewriting into the :ref:`x-envoy-original-host
+  // <config_http_filters_router_x-envoy-original-host>` header.
+  //
+  // And if the
+  // :ref:`append_x_forwarded_host <envoy_v3_api_field_config.route.v3.RouteAction.append_x_forwarded_host>`
+  // is set to true, the original host value will also be appended to the
+  // :ref:`config_http_conn_man_headers_x-forwarded-host` header.
+  //
   oneof host_rewrite_specifier {
     // Indicates that during forwarding, the host header will be swapped with
-    // this value. Using this option will append the
-    // :ref:`config_http_conn_man_headers_x-forwarded-host` header if
-    // :ref:`append_x_forwarded_host <envoy_v3_api_field_config.route.v3.RouteAction.append_x_forwarded_host>`
-    // is set.
+    // this value.
     string host_rewrite_literal = 6
         [(validate.rules).string = {well_known_regex: HTTP_HEADER_VALUE strict: false}];
 
@@ -1176,18 +1185,12 @@ message RouteAction {
     // type ``strict_dns`` or ``logical_dns``,
     // or when :ref:`hostname <envoy_v3_api_field_config.endpoint.v3.Endpoint.hostname>`
     // field is not empty. Setting this to true with other cluster types
-    // has no effect. Using this option will append the
-    // :ref:`config_http_conn_man_headers_x-forwarded-host` header if
-    // :ref:`append_x_forwarded_host <envoy_v3_api_field_config.route.v3.RouteAction.append_x_forwarded_host>`
-    // is set.
+    // has no effect.
     google.protobuf.BoolValue auto_host_rewrite = 7;
 
     // Indicates that during forwarding, the host header will be swapped with the content of given
     // downstream or :ref:`custom <config_http_conn_man_headers_custom_request_headers>` header.
-    // If header value is empty, host header is left intact. Using this option will append the
-    // :ref:`config_http_conn_man_headers_x-forwarded-host` header if
-    // :ref:`append_x_forwarded_host <envoy_v3_api_field_config.route.v3.RouteAction.append_x_forwarded_host>`
-    // is set.
+    // If header value is empty, host header is left intact.
     //
     // .. attention::
     //
@@ -1203,10 +1206,6 @@ message RouteAction {
     // Indicates that during forwarding, the host header will be swapped with
     // the result of the regex substitution executed on path value with query and fragment removed.
     // This is useful for transitioning variable content between path segment and subdomain.
-    // Using this option will append the
-    // :ref:`config_http_conn_man_headers_x-forwarded-host` header if
-    // :ref:`append_x_forwarded_host <envoy_v3_api_field_config.route.v3.RouteAction.append_x_forwarded_host>`
-    // is set.
     //
     // For example with the following config:
     //

--- a/api/envoy/config/route/v3/route_components.proto
+++ b/api/envoy/config/route/v3/route_components.proto
@@ -1163,7 +1163,7 @@ message RouteAction {
 
   // If one of the host rewrite specifiers is set and the
   // :ref:`suppress_envoy_headers
-  // <envoy_api_field_config.filter.http.router.v3.Router.suppress_envoy_headers>` flag is not
+  // <envoy_v3_api_field_extensions.filters.http.router.v3.Router.suppress_envoy_headers>` flag is not
   // set to true, the router filter will place the original host header value before
   // rewriting into the :ref:`x-envoy-original-host
   // <config_http_filters_router_x-envoy-original-host>` header.

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -108,6 +108,10 @@ removed_config_or_runtime:
     Removed runtime guard ``envoy.reloadable_features.lua_flow_control_while_http_call`` and legacy code paths.
 
 new_features:
+- area: http
+  change: |
+    added :ref:`x-envoy-original-host <config_http_filters_router_x-envoy-original-host>` that
+    used to record the original host header value before it is mutated by the router filter.
 - area: stateful_session
   change: |
     Supports envelope stateful session extension to keep the exist session header value

--- a/docs/root/configuration/http/http_filters/router_filter.rst
+++ b/docs/root/configuration/http/http_filters/router_filter.rst
@@ -376,6 +376,19 @@ or :ref:`regex_rewrite <envoy_v3_api_field_config.route.v3.RouteAction.regex_rew
 Envoy will put the original path header in this header. This can be useful for logging and
 debugging.
 
+.. _config_http_filters_router_x-envoy-original-host:
+
+x-envoy-original-host
+^^^^^^^^^^^^^^^^^^^^^
+
+If the route utilizes
+:ref:`host_rewrite_literal <envoy_v3_api_field_config.route.v3.RouteAction.host_rewrite_literal>`,
+:ref:`auto_host_rewrite <envoy_v3_api_field_config.route.v3.RouteAction.auto_host_rewrite>`,
+:ref:`host_rewrite_header <envoy_v3_api_field_config.route.v3.RouteAction.host_rewrite_header>`,
+:ref:`host_rewrite_path_regex <envoy_v3_api_field_config.route.v3.RouteAction.host_rewrite_path_regex>`,
+Envoy will put the original host header in this header. This can be useful for logging and
+debugging.
+
 .. _config_http_filters_router_x-envoy-upstream-stream-duration-ms:
 
 x-envoy-upstream-stream-duration-ms

--- a/envoy/http/header_map.h
+++ b/envoy/http/header_map.h
@@ -191,6 +191,7 @@ private:
   HEADER_FUNC(EnvoyRetriableHeaderNames)                                                           \
   HEADER_FUNC(EnvoyIsTimeoutRetry)                                                                 \
   HEADER_FUNC(EnvoyOriginalPath)                                                                   \
+  HEADER_FUNC(EnvoyOriginalHost)                                                                   \
   HEADER_FUNC(EnvoyOriginalUrl)                                                                    \
   HEADER_FUNC(EnvoyUpstreamAltStatName)                                                            \
   HEADER_FUNC(EnvoyUpstreamRequestTimeoutAltResponse)                                              \

--- a/envoy/router/router.h
+++ b/envoy/router/router.h
@@ -902,23 +902,6 @@ public:
   virtual const std::string& clusterName() const PURE;
 
   /**
-   * Returns the final host value for the request, taking into account route-level mutations.
-   *
-   * The value returned is computed with the following logic in order:
-   *
-   * 1. If a host rewrite is configured for the route, it returns that value.
-   * 2. If a host rewrite header is specified, it attempts to use the value from that header.
-   * 3. If a host rewrite path regex is configured, it applies the regex to the request path and
-   *    returns the result.
-   * 4. If none of the above apply, it returns the original host value from the request headers.
-   *
-   * @param headers The constant reference to the request headers.
-   * @note This function will not attempt to restore the port in the host value. If port information
-   *       is required, it should be handled separately.
-   */
-  virtual const std::string getRequestHostValue(const Http::RequestHeaderMap& headers) const PURE;
-
-  /**
    * Returns the HTTP status code to use when configured cluster is not found.
    * @return Http::Code to use when configured cluster is not found.
    */
@@ -946,11 +929,12 @@ public:
    * immediately prior to forwarding. It is done this way vs. copying for performance reasons.
    * @param headers supplies the request headers, which may be modified during this call.
    * @param stream_info holds additional information about the request.
-   * @param insert_envoy_original_path insert x-envoy-original-path header if path rewritten?
+   * @param keep_original_host_or_path insert x-envoy-original-path header if path rewritten,
+   *        or x-envoy-original-host header if host rewritten.
    */
   virtual void finalizeRequestHeaders(Http::RequestHeaderMap& headers,
                                       const StreamInfo::StreamInfo& stream_info,
-                                      bool insert_envoy_original_path) const PURE;
+                                      bool keep_original_host_or_path) const PURE;
 
   /**
    * Returns the request header transforms that would be applied if finalizeRequestHeaders were

--- a/source/common/http/conn_manager_utility.cc
+++ b/source/common/http/conn_manager_utility.cc
@@ -325,7 +325,11 @@ void ConnectionManagerUtility::cleanInternalHeaders(
     request_headers.removeEnvoyDecoratorOperation();
     request_headers.removeEnvoyDownstreamServiceCluster();
     request_headers.removeEnvoyDownstreamServiceNode();
+
+    // TODO(wbpcode): Envoy may should always remove these headers from client because
+    // these headers are hop by hop headers and should not be sent to upstream.
     request_headers.removeEnvoyOriginalPath();
+    request_headers.removeEnvoyOriginalHost();
   }
 
   // Headers to be stripped from edge *and* intermediate-hop external requests.

--- a/source/common/http/headers.h
+++ b/source/common/http/headers.h
@@ -176,6 +176,7 @@ public:
   const LowerCaseString EnvoyOriginalDstHost{absl::StrCat(prefix(), "-original-dst-host")};
   const LowerCaseString EnvoyOriginalMethod{absl::StrCat(prefix(), "-original-method")};
   const LowerCaseString EnvoyOriginalPath{absl::StrCat(prefix(), "-original-path")};
+  const LowerCaseString EnvoyOriginalHost{absl::StrCat(prefix(), "-original-host")};
   const LowerCaseString EnvoyOverloaded{absl::StrCat(prefix(), "-overloaded")};
   const LowerCaseString EnvoyDropOverload{absl::StrCat(prefix(), "-drop-overload")};
   const LowerCaseString EnvoyUnconditionalDropOverload{

--- a/source/common/http/null_route_impl.h
+++ b/source/common/http/null_route_impl.h
@@ -123,9 +123,6 @@ protected:
 
   // Router::RouteEntry
   const std::string& clusterName() const override { return cluster_name_; }
-  const std::string getRequestHostValue(const Http::RequestHeaderMap& headers) const override {
-    return std::string(headers.getHostValue());
-  }
   const Router::RouteStatsContextOptRef routeStatsContext() const override {
     return Router::RouteStatsContextOptRef();
   }

--- a/source/common/http/utility.h
+++ b/source/common/http/utility.h
@@ -202,8 +202,10 @@ void appendVia(RequestOrResponseHeaderMap& headers, const std::string& via);
  * @param headers headers where authority should be updated.
  * @param hostname hostname that authority should be updated with.
  * @param append_xfh append the original authority to the x-forwarded-host header.
+ * @param keep_old insert the original authority in the x-envoy-original-host header.
  */
-void updateAuthority(RequestHeaderMap& headers, absl::string_view hostname, bool append_xfh);
+void updateAuthority(RequestHeaderMap& headers, absl::string_view hostname, bool append_xfh,
+                     bool keep_old);
 
 /**
  * Creates an SSL (https) redirect path based on the input host and path headers.

--- a/source/common/router/delegating_route_impl.cc
+++ b/source/common/router/delegating_route_impl.cc
@@ -32,11 +32,6 @@ const std::string& DelegatingRouteEntry::clusterName() const {
   return base_route_->routeEntry()->clusterName();
 }
 
-const std::string
-DelegatingRouteEntry::getRequestHostValue(const Http::RequestHeaderMap& headers) const {
-  return base_route_->routeEntry()->getRequestHostValue(headers);
-}
-
 Http::Code DelegatingRouteEntry::clusterNotFoundResponseCode() const {
   return base_route_->routeEntry()->clusterNotFoundResponseCode();
 }

--- a/source/common/router/delegating_route_impl.h
+++ b/source/common/router/delegating_route_impl.h
@@ -72,7 +72,6 @@ public:
 
   // Router::RouteEntry
   const std::string& clusterName() const override;
-  const std::string getRequestHostValue(const Http::RequestHeaderMap& headers) const override;
   Http::Code clusterNotFoundResponseCode() const override;
   const CorsPolicy* corsPolicy() const override;
   absl::optional<std::string>

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -591,13 +591,20 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers,
     return Http::FilterHeadersStatus::StopIteration;
   }
 
+  // Increment the attempt count from 0 to 1 at the first upstream request.
+  attempt_count_++;
+  callbacks_->streamInfo().setAttemptCount(attempt_count_);
+
+  // Finalize the request headers before the host selection.
+  route_entry_->finalizeRequestHeaders(headers, callbacks_->streamInfo(),
+                                       !config_->suppress_envoy_headers_);
+
   // Fetch a connection pool for the upstream cluster.
   const auto& upstream_http_protocol_options = cluster_->upstreamHttpProtocolOptions();
-
   if (upstream_http_protocol_options && (upstream_http_protocol_options->auto_sni() ||
                                          upstream_http_protocol_options->auto_san_validation())) {
     // Default the header to Host/Authority header.
-    std::string header_value = route_entry_->getRequestHostValue(headers);
+    absl::string_view header_value = headers.getHostValue();
 
     // Check whether `override_auto_sni_header` is specified.
     if (const auto& override_header = upstream_http_protocol_options->override_auto_sni_header();
@@ -609,7 +616,7 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers,
                          *callbacks_, override_header);
       }
       if (!override_header_value.empty() && !override_header_value[0]->value().empty()) {
-        header_value = std::string(override_header_value[0]->value().getStringView());
+        header_value = override_header_value[0]->value().getStringView();
       }
     }
 
@@ -658,15 +665,6 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers,
   callbacks_->streamInfo().downstreamTiming().setValue(
       "envoy.router.host_selection_start_ms",
       callbacks_->dispatcher().timeSource().monotonicTime());
-
-  // Increment the attempt count from 0 to 1 at the first upstream request.
-  attempt_count_++;
-  include_attempt_count_in_request_ = route_entry_->includeAttemptCountInRequest();
-  if (include_attempt_count_in_request_) {
-    headers.setEnvoyAttemptCount(attempt_count_);
-  }
-
-  callbacks_->streamInfo().setAttemptCount(attempt_count_);
 
   auto host_selection_response = cluster->chooseHost(this);
   if (!host_selection_response.cancelable ||
@@ -771,8 +769,11 @@ bool Filter::continueDecodeHeaders(Upstream::ThreadLocalCluster* cluster,
     headers.removeEnvoyUpstreamRequestTimeoutAltResponse();
   }
 
-  route_entry_->finalizeRequestHeaders(headers, callbacks_->streamInfo(),
-                                       !config_->suppress_envoy_headers_);
+  include_attempt_count_in_request_ = route_entry_->includeAttemptCountInRequest();
+  if (include_attempt_count_in_request_) {
+    headers.setEnvoyAttemptCount(attempt_count_);
+  }
+
   FilterUtility::setUpstreamScheme(
       headers, callbacks_->streamInfo().downstreamAddressProvider().sslConnection() != nullptr,
       host->transportSocketFactory().sslCtx() != nullptr,

--- a/source/common/router/upstream_request.cc
+++ b/source/common/router/upstream_request.cc
@@ -673,7 +673,8 @@ void UpstreamRequest::onPoolReady(std::unique_ptr<GenericUpstream>&& upstream,
   const auto* route_entry = route().routeEntry();
   if (route_entry->autoHostRewrite() && !host->hostname().empty()) {
     Http::Utility::updateAuthority(*parent_.downstreamHeaders(), host->hostname(),
-                                   route_entry->appendXfh());
+                                   route_entry->appendXfh(),
+                                   !parent_.config().suppress_envoy_headers_);
   }
 
   stream_info_.setRequestHeaders(*parent_.downstreamHeaders());

--- a/test/common/http/utility_test.cc
+++ b/test/common/http/utility_test.cc
@@ -587,7 +587,8 @@ TEST(HttpUtility, updateAuthority) {
             EXPECT_EQ(new_host, headers.getHostValue());
 
             if (old_host.empty() || !append_xfh_or_keep_old_hosdt) {
-              // No original host or the flag not allowing to append xfh or keep old host.
+              // No original host or the flag not allowing to append x-forwarded-host or keep
+              // original host.
               EXPECT_EQ(old_xfh, headers.getForwardedHostValue());
               EXPECT_EQ("", headers.getEnvoyOriginalHostValue());
               return;

--- a/test/common/http/utility_test.cc
+++ b/test/common/http/utility_test.cc
@@ -591,7 +591,7 @@ TEST(HttpUtility, updateAuthority) {
               // original host.
               EXPECT_EQ(old_xfh, headers.getForwardedHostValue());
               EXPECT_EQ("", headers.getEnvoyOriginalHostValue());
-              return;
+              continue;
             }
 
             EXPECT_EQ(old_xfh.empty() ? std::string(old_host)

--- a/test/common/http/utility_test.cc
+++ b/test/common/http/utility_test.cc
@@ -570,95 +570,44 @@ TEST(HttpUtility, appendVia) {
 
 TEST(HttpUtility, updateAuthority) {
   {
-    TestRequestHeaderMapImpl headers;
-    Utility::updateAuthority(headers, "dns.name", true);
-    EXPECT_EQ("dns.name", headers.get_(":authority"));
-    EXPECT_EQ("", headers.get_("x-forwarded-host"));
-  }
+    for (absl::string_view new_host : {"dns.name", ""}) {
+      for (absl::string_view old_host : {"host.com", ""}) {
+        for (absl::string_view old_xfh : {"old.xfh.com", ""}) {
+          for (bool append_xfh_or_keep_old_hosdt : {true, false}) {
+            TestRequestHeaderMapImpl headers;
+            if (!old_host.empty()) {
+              headers.setHost(old_host);
+            }
+            if (!old_xfh.empty()) {
+              headers.setForwardedHost(old_xfh);
+            }
 
-  {
-    TestRequestHeaderMapImpl headers;
-    Utility::updateAuthority(headers, "dns.name", false);
-    EXPECT_EQ("dns.name", headers.get_(":authority"));
-    EXPECT_EQ("", headers.get_("x-forwarded-host"));
-  }
+            Utility::updateAuthority(headers, new_host, append_xfh_or_keep_old_hosdt,
+                                     append_xfh_or_keep_old_hosdt);
+            EXPECT_EQ(new_host, headers.getHostValue());
 
-  {
-    TestRequestHeaderMapImpl headers;
-    Utility::updateAuthority(headers, "", true);
-    EXPECT_EQ("", headers.get_(":authority"));
-    EXPECT_EQ("", headers.get_("x-forwarded-host"));
-  }
+            if (old_host.empty() || !append_xfh_or_keep_old_hosdt) {
+              // No original host or the flag not allowing to append xfh or keep old host.
+              EXPECT_EQ(old_xfh, headers.getForwardedHostValue());
+              EXPECT_EQ("", headers.getEnvoyOriginalHostValue());
+              return;
+            }
 
-  {
-    TestRequestHeaderMapImpl headers;
-    Utility::updateAuthority(headers, "", false);
-    EXPECT_EQ("", headers.get_(":authority"));
-    EXPECT_EQ("", headers.get_("x-forwarded-host"));
-  }
-
-  {
-    TestRequestHeaderMapImpl headers{{":authority", "host.com"}};
-    Utility::updateAuthority(headers, "dns.name", true);
-    EXPECT_EQ("dns.name", headers.get_(":authority"));
-    EXPECT_EQ("host.com", headers.get_("x-forwarded-host"));
-  }
-
-  {
-    TestRequestHeaderMapImpl headers{{":authority", "host.com"}};
-    Utility::updateAuthority(headers, "dns.name", false);
-    EXPECT_EQ("dns.name", headers.get_(":authority"));
-    EXPECT_EQ("", headers.get_("x-forwarded-host"));
-  }
-
-  {
-    TestRequestHeaderMapImpl headers{{":authority", "host.com"}};
-    Utility::updateAuthority(headers, "", true);
-    EXPECT_EQ("", headers.get_(":authority"));
-    EXPECT_EQ("host.com", headers.get_("x-forwarded-host"));
-  }
-
-  {
-    TestRequestHeaderMapImpl headers{{":authority", "host.com"}};
-    Utility::updateAuthority(headers, "", false);
-    EXPECT_EQ("", headers.get_(":authority"));
-    EXPECT_EQ("", headers.get_("x-forwarded-host"));
-  }
-
-  {
-    TestRequestHeaderMapImpl headers{{":authority", "dns.name"}, {"x-forwarded-host", "host.com"}};
-    Utility::updateAuthority(headers, "newhost.com", true);
-    EXPECT_EQ("newhost.com", headers.get_(":authority"));
-    EXPECT_EQ("host.com,dns.name", headers.get_("x-forwarded-host"));
-  }
-
-  {
-    TestRequestHeaderMapImpl headers{{":authority", "dns.name"}, {"x-forwarded-host", "host.com"}};
-    Utility::updateAuthority(headers, "newhost.com", false);
-    EXPECT_EQ("newhost.com", headers.get_(":authority"));
-    EXPECT_EQ("host.com", headers.get_("x-forwarded-host"));
-  }
-
-  {
-    TestRequestHeaderMapImpl headers{{"x-forwarded-host", "host.com"}};
-    Utility::updateAuthority(headers, "dns.name", true);
-    EXPECT_EQ("dns.name", headers.get_(":authority"));
-    EXPECT_EQ("host.com", headers.get_("x-forwarded-host"));
-  }
-
-  {
-    TestRequestHeaderMapImpl headers{{"x-forwarded-host", "host.com"}};
-    Utility::updateAuthority(headers, "dns.name", false);
-    EXPECT_EQ("dns.name", headers.get_(":authority"));
-    EXPECT_EQ("host.com", headers.get_("x-forwarded-host"));
+            EXPECT_EQ(old_xfh.empty() ? std::string(old_host)
+                                      : fmt::format("{},{}", old_xfh, old_host),
+                      headers.getForwardedHostValue());
+            EXPECT_EQ(old_host, headers.getEnvoyOriginalHostValue());
+          }
+        }
+      }
+    }
   }
 
   // Test that we only append to x-forwarded-host if it is not already present.
   {
     TestRequestHeaderMapImpl headers{{":authority", "dns.name"},
                                      {"x-forwarded-host", "host.com,dns.name"}};
-    Utility::updateAuthority(headers, "newhost.com", true);
-    EXPECT_EQ("newhost.com", headers.get_(":authority"));
+    Utility::updateAuthority(headers, "newhost.com", true, true);
     EXPECT_EQ("host.com,dns.name", headers.get_("x-forwarded-host"));
   }
 }

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -984,9 +984,16 @@ virtual_hosts:
     EXPECT_FALSE(route_entry->currentUrlPathAfterRewrite(headers).has_value());
     route_entry->finalizeRequestHeaders(headers, stream_info, true);
     EXPECT_EQ("new_host", headers.get_(Http::Headers::get().Host));
+    EXPECT_EQ("api.lyft.com", headers.getEnvoyOriginalHostValue());
     // Config setting append_x_forwarded_host is false (by default). Expect empty x-forwarded-host
     // header value.
     EXPECT_EQ("", headers.get_(Http::Headers::get().ForwardedHost));
+
+    Http::TestRequestHeaderMapImpl headers2 = genHeaders("api.lyft.com", "/host/rewrite/me", "GET");
+    // Host rewrite testing with x-envoy-* headers suppressed.
+    route_entry->finalizeRequestHeaders(headers2, stream_info, false);
+    EXPECT_EQ("new_host", headers2.get_(Http::Headers::get().Host));
+    EXPECT_EQ("", headers2.getEnvoyOriginalHostValue());
   }
 
   // Rewrites host using supplied header.
@@ -997,6 +1004,7 @@ virtual_hosts:
     EXPECT_FALSE(route_entry->currentUrlPathAfterRewrite(headers).has_value());
     route_entry->finalizeRequestHeaders(headers, stream_info, true);
     EXPECT_EQ("rewrote", headers.get_(Http::Headers::get().Host));
+    EXPECT_EQ("api.lyft.com", headers.getEnvoyOriginalHostValue());
     EXPECT_EQ("api.lyft.com", headers.get_(Http::Headers::get().ForwardedHost));
   }
 
@@ -1008,6 +1016,7 @@ virtual_hosts:
     EXPECT_FALSE(route_entry->currentUrlPathAfterRewrite(headers).has_value());
     route_entry->finalizeRequestHeaders(headers, stream_info, true);
     EXPECT_EQ("api.lyft.com", headers.get_(Http::Headers::get().Host));
+    EXPECT_EQ("", headers.getEnvoyOriginalHostValue());
     EXPECT_EQ("", headers.get_(Http::Headers::get().ForwardedHost));
   }
 
@@ -1019,6 +1028,7 @@ virtual_hosts:
     EXPECT_FALSE(route_entry->currentUrlPathAfterRewrite(headers).has_value());
     route_entry->finalizeRequestHeaders(headers, stream_info, true);
     EXPECT_EQ("envoyproxy.io", headers.get_(Http::Headers::get().Host));
+    EXPECT_EQ("api.lyft.com", headers.getEnvoyOriginalHostValue());
     EXPECT_EQ("api.lyft.com", headers.get_(Http::Headers::get().ForwardedHost));
   }
 
@@ -1030,6 +1040,7 @@ virtual_hosts:
     EXPECT_FALSE(route_entry->currentUrlPathAfterRewrite(headers).has_value());
     route_entry->finalizeRequestHeaders(headers, stream_info, true);
     EXPECT_EQ("envoyproxy.io", headers.get_(Http::Headers::get().Host));
+    EXPECT_EQ("api.lyft.com", headers.getEnvoyOriginalHostValue());
     EXPECT_EQ("api.lyft.com", headers.get_(Http::Headers::get().ForwardedHost));
   }
 

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -6104,8 +6104,8 @@ TEST_F(RouterTest, AutoHostRewriteEnabled) {
   Http::TestRequestHeaderMapImpl outgoing_headers;
   HttpTestUtility::addDefaultHeaders(outgoing_headers);
   outgoing_headers.setHost(cm_.thread_local_cluster_.conn_pool_.host_->hostname_);
-  outgoing_headers.setForwardedHost(req_host);
   outgoing_headers.setEnvoyOriginalHost(req_host);
+  outgoing_headers.setForwardedHost(req_host);
 
   EXPECT_CALL(callbacks_.route_->route_entry_, timeout())
       .WillOnce(Return(std::chrono::milliseconds(0)));

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -6105,6 +6105,7 @@ TEST_F(RouterTest, AutoHostRewriteEnabled) {
   HttpTestUtility::addDefaultHeaders(outgoing_headers);
   outgoing_headers.setHost(cm_.thread_local_cluster_.conn_pool_.host_->hostname_);
   outgoing_headers.setForwardedHost(req_host);
+  outgoing_headers.setEnvoyOriginalHost(req_host);
 
   EXPECT_CALL(callbacks_.route_->route_entry_, timeout())
       .WillOnce(Return(std::chrono::milliseconds(0)));

--- a/test/mocks/router/mocks.cc
+++ b/test/mocks/router/mocks.cc
@@ -99,10 +99,6 @@ MockPathMatchCriterion::~MockPathMatchCriterion() = default;
 
 MockRouteEntry::MockRouteEntry() {
   ON_CALL(*this, clusterName()).WillByDefault(ReturnRef(cluster_name_));
-  ON_CALL(*this, getRequestHostValue(_))
-      .WillByDefault([](const Http::RequestHeaderMap& headers) -> std::string {
-        return std::string(headers.getHostValue());
-      });
   ON_CALL(*this, opaqueConfig()).WillByDefault(ReturnRef(opaque_config_));
   ON_CALL(*this, rateLimitPolicy()).WillByDefault(ReturnRef(rate_limit_policy_));
   ON_CALL(*this, retryPolicy()).WillByDefault(ReturnRef(retry_policy_));

--- a/test/mocks/router/mocks.h
+++ b/test/mocks/router/mocks.h
@@ -410,8 +410,6 @@ public:
 
   // Router::Config
   MOCK_METHOD(const std::string&, clusterName, (), (const));
-  MOCK_METHOD(const std::string, getRequestHostValue, (const Http::RequestHeaderMap& headers),
-              (const));
   MOCK_METHOD(Http::Code, clusterNotFoundResponseCode, (), (const));
   MOCK_METHOD(void, finalizeRequestHeaders,
               (Http::RequestHeaderMap & headers, const StreamInfo::StreamInfo& stream_info,


### PR DESCRIPTION
Commit Message: add x-envoy-original-host to keep original host
Additional Description:

This PR added a x-envoy-original-host to keep original host value if the host rewriting happens.

Risk Level: low.
Testing: n/a.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.