### PR TITLE
upstream lb context: add method to set headers modifier

### DIFF
--- a/envoy/upstream/load_balancer.h
+++ b/envoy/upstream/load_balancer.h
@@ -166,6 +166,15 @@ public:
    * @param details gives optional details about the resolution success/failure.
    */
   virtual void onAsyncHostSelection(HostConstSharedPtr&& host, std::string&& details) PURE;
+
+  /**
+   * Called by the load balancer to set the headers modifier that will be used to modify the
+   * response headers before sending them downstream.
+   * NOTE: this should be called only once per request, no matter how many times the retrying
+   * happens.
+   * @param modifier supplies the function that will modify the response headers.
+   */
+  virtual void setHeadersModifier(std::function<void(Http::ResponseHeaderMap&)> modifier) PURE;
 };
 
 /**

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -452,6 +452,10 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers,
       return;
     }
 
+    if (modify_headers_from_upstream_lb_) {
+      modify_headers_from_upstream_lb_(headers);
+    }
+
     route_entry_->finalizeResponseHeaders(headers, callbacks_->streamInfo());
 
     if (attempt_count_ == 0 || !route_entry_->includeAttemptCountInResponse()) {

--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -449,6 +449,9 @@ public:
     }
     return callbacks_->upstreamOverrideHost();
   }
+  void setHeadersModifier(std::function<void(Http::ResponseHeaderMap&)> modifier) override {
+    modify_headers_from_upstream_lb_ = std::move(modifier);
+  }
 
   void onAsyncHostSelection(Upstream::HostConstSharedPtr&& host, std::string&& details) override;
 
@@ -621,7 +624,8 @@ private:
   MonotonicTime downstream_request_complete_time_;
   MetadataMatchCriteriaConstPtr metadata_match_;
   std::function<void(Http::ResponseHeaderMap&)> modify_headers_;
-  std::vector<std::reference_wrapper<const ShadowPolicy>> active_shadow_policies_{};
+  std::function<void(Http::ResponseHeaderMap&)> modify_headers_from_upstream_lb_;
+  std::vector<std::reference_wrapper<const ShadowPolicy>> active_shadow_policies_;
   std::unique_ptr<Http::RequestHeaderMap> shadow_headers_;
   std::unique_ptr<Http::RequestTrailerMap> shadow_trailers_;
   // The stream lifetime configured by request header.

--- a/source/common/upstream/load_balancer_context_base.h
+++ b/source/common/upstream/load_balancer_context_base.h
@@ -36,6 +36,8 @@ public:
   absl::optional<OverrideHost> overrideHostToSelect() const override { return {}; }
 
   void onAsyncHostSelection(HostConstSharedPtr&&, std::string&&) override {}
+
+  void setHeadersModifier(std::function<void(Http::ResponseHeaderMap&)>) override {}
 };
 
 } // namespace Upstream

--- a/source/extensions/clusters/aggregate/lb_context.h
+++ b/source/extensions/clusters/aggregate/lb_context.h
@@ -65,6 +65,9 @@ public:
   Network::TransportSocketOptionsConstSharedPtr upstreamTransportSocketOptions() const override {
     return context_->upstreamTransportSocketOptions();
   }
+  void setHeadersModifier(std::function<void(Http::ResponseHeaderMap&)> modifier) override {
+    context_->setHeadersModifier(std::move(modifier));
+  }
 
 private:
   Upstream::HealthyAndDegradedLoad priority_load_;

--- a/source/extensions/load_balancing_policies/subset/subset_lb.h
+++ b/source/extensions/load_balancing_policies/subset/subset_lb.h
@@ -200,6 +200,9 @@ public:
       return wrapped_->overrideHostToSelect();
     }
     void onAsyncHostSelection(Upstream::HostConstSharedPtr&&, std::string&&) override {}
+    void setHeadersModifier(std::function<void(Http::ResponseHeaderMap&)> modifier) override {
+      wrapped_->setHeadersModifier(std::move(modifier));
+    }
 
   private:
     LoadBalancerContext* wrapped_;

--- a/test/common/upstream/load_balancer_context_base_test.cc
+++ b/test/common/upstream/load_balancer_context_base_test.cc
@@ -31,6 +31,7 @@ TEST(LoadBalancerContextBaseTest, LoadBalancerContextBaseTest) {
     EXPECT_EQ(nullptr, context.upstreamSocketOptions());
     EXPECT_EQ(nullptr, context.upstreamTransportSocketOptions());
     EXPECT_EQ(absl::nullopt, context.overrideHostToSelect());
+    context.setHeadersModifier(nullptr);
   }
 }
 

--- a/test/extensions/clusters/aggregate/cluster_test.cc
+++ b/test/extensions/clusters/aggregate/cluster_test.cc
@@ -386,6 +386,7 @@ TEST_F(AggregateClusterTest, LBContextTest) {
   EXPECT_EQ(context.downstreamHeaders(), nullptr);
   EXPECT_EQ(context.upstreamSocketOptions(), nullptr);
   EXPECT_EQ(context.upstreamTransportSocketOptions(), nullptr);
+  context.setHeadersModifier(nullptr);
 }
 
 TEST_F(AggregateClusterTest, ContextDeterminePriorityLoad) {

--- a/test/extensions/load_balancing_policies/subset/subset_test.cc
+++ b/test/extensions/load_balancing_policies/subset/subset_test.cc
@@ -3337,6 +3337,9 @@ TEST(LoadBalancerContextWrapperTest, LoadBalancingContextWrapperTest) {
 
   EXPECT_CALL(mock_context, overrideHostToSelect());
   wrapper.overrideHostToSelect();
+
+  EXPECT_CALL(mock_context, setHeadersModifier(_));
+  wrapper.setHeadersModifier(nullptr);
 }
 
 } // namespace

--- a/test/mocks/upstream/load_balancer_context.h
+++ b/test/mocks/upstream/load_balancer_context.h
@@ -27,6 +27,7 @@ public:
               (const));
   MOCK_METHOD(absl::optional<OverrideHost>, overrideHostToSelect, (), (const));
   MOCK_METHOD(void, onAsyncHostSelection, (HostConstSharedPtr && host, std::string&& details));
+  MOCK_METHOD(void, setHeadersModifier, (std::function<void(Http::ResponseHeaderMap&)>));
 
 private:
   HealthyAndDegradedLoad priority_load_;


### PR DESCRIPTION
Commit Message: upstream lb context: add method to set headers modifier
Additional Description:

First PR to support hash policy in upstream lb. This PR make it possible that the upstream lb could modify the response headers after the response headers is received from upstream server.

This make it's possible to support hash policy in upstream lb (for generated mode of cookie based hash policy), and this may also could be used to support session management in the upstream lb in the future.

Risk Level: low.
Testing: unit.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.