### PR TITLE
ci/macos: macOS 14 -> macOS 15

### DIFF
--- a/.github/workflows/envoy-macos.yml
+++ b/.github/workflows/envoy-macos.yml
@@ -49,7 +49,7 @@ jobs:
       container-command:
       docker-ipv6: false
       request: ${{ needs.load.outputs.request }}
-      runs-on: macos-14-xlarge
+      runs-on: macos-15-xlarge
       source: ${{ matrix.source }}
       steps-post:
       steps-pre: ${{ matrix.steps-pre }}


### PR DESCRIPTION
This change switches the macOS CI job from MacOS 14 to MacOS 15.

macOS 14 (sonoma) came out in Sept '23 and hit github actions in Jan 2024: https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/

macOS 15 (sequoia) came out in Sept '24 and hit github actions in April 2025: https://github.blog/changelog/2025-04-10-github-actions-macos-15-and-windows-2025-images-are-now-generally-available/

It would be great to run CI on the more recent macOS as many developers have now updated to the latest OS version.