### PR TITLE
Clean up FieldMatchResult

### DIFF
--- a/source/common/matcher/field_matcher.h
+++ b/source/common/matcher/field_matcher.h
@@ -3,6 +3,7 @@
 #include "envoy/matcher/matcher.h"
 
 #include "absl/strings/str_join.h"
+#include "absl/types/variant.h"
 
 namespace Envoy {
 namespace Matcher {
@@ -10,19 +11,29 @@ namespace Matcher {
 /**
  * The result of a field match.
  */
-struct FieldMatchResult {
-  // Encodes whether we were able to perform the match.
-  MatchState match_state_;
+class FieldMatchResult {
+private:
+  // The match could not be completed, e.g. due to the required data
+  // not being available.
+  struct UnableToMatch {};
+  // The match comparison was completed, and there was no match.
+  struct NoMatch {};
+  // The match comparison was completed, and there was a match.
+  struct Matched {};
+  using ResultType = absl::variant<UnableToMatch, NoMatch, Matched>;
+  ResultType result_;
+  explicit FieldMatchResult(ResultType r) : result_(r) {}
 
-  // The result, if matching was completed.
-  absl::optional<bool> result_;
-
-  // The unwrapped result. Should only be called if match_state_ == MatchComplete.
-  bool result() const {
-    ASSERT(match_state_ == MatchState::MatchComplete);
-    ASSERT(result_.has_value());
-    return *result_;
+public:
+  inline bool operator==(const FieldMatchResult& other) const {
+    return result_.index() == other.result_.index();
   }
+  static FieldMatchResult unableToMatch() { return FieldMatchResult{UnableToMatch{}}; }
+  static FieldMatchResult matched() { return FieldMatchResult{Matched{}}; }
+  static FieldMatchResult noMatch() { return FieldMatchResult{NoMatch{}}; }
+  bool isUnableToMatch() const { return absl::holds_alternative<UnableToMatch>(result_); }
+  bool isMatched() const { return absl::holds_alternative<Matched>(result_); }
+  bool isNoMatch() const { return absl::holds_alternative<NoMatch>(result_); }
 };
 
 /**
@@ -34,8 +45,6 @@ public:
 
   /**
    * Attempts to match against the provided data.
-   * @returns absl::optional<bool> if matching was possible, the result of the match. Otherwise
-   * absl::nullopt if the data is not available.
    */
   virtual FieldMatchResult match(const DataType& data) PURE;
 };
@@ -54,20 +63,20 @@ public:
 
   FieldMatchResult match(const DataType& data) override {
     for (const auto& matcher : matchers_) {
-      const auto result = matcher->match(data);
+      const FieldMatchResult result = matcher->match(data);
 
       // If we are unable to decide on a match at this point, propagate this up to defer
       // the match result until we have the requisite data.
-      if (result.match_state_ == MatchState::UnableToMatch) {
+      if (result.isUnableToMatch()) {
         return result;
       }
 
-      if (!result.result()) {
+      if (result.isNoMatch()) {
         return result;
       }
     }
 
-    return {MatchState::MatchComplete, true};
+    return FieldMatchResult::matched();
   }
 
 private:
@@ -89,25 +98,25 @@ public:
   FieldMatchResult match(const DataType& data) override {
     bool unable_to_match_some_matchers = false;
     for (const auto& matcher : matchers_) {
-      const auto result = matcher->match(data);
+      const FieldMatchResult result = matcher->match(data);
 
-      if (result.match_state_ == MatchState::UnableToMatch) {
+      if (result.isUnableToMatch()) {
         unable_to_match_some_matchers = true;
         continue;
       }
 
-      if (result.result()) {
-        return {MatchState::MatchComplete, true};
+      if (result.isMatched()) {
+        return result;
       }
     }
 
     // If we didn't find a successful match but not all matchers could be evaluated,
     // return UnableToMatch to defer the match result.
     if (unable_to_match_some_matchers) {
-      return {MatchState::UnableToMatch, absl::nullopt};
+      return FieldMatchResult::unableToMatch();
     }
 
-    return {MatchState::MatchComplete, false};
+    return FieldMatchResult::noMatch();
   }
 
 private:
@@ -122,12 +131,11 @@ public:
   explicit NotFieldMatcher(FieldMatcherPtr<DataType> matcher) : matcher_(std::move(matcher)) {}
 
   FieldMatchResult match(const DataType& data) override {
-    const auto result = matcher_->match(data);
-    if (result.match_state_ == MatchState::UnableToMatch) {
+    const FieldMatchResult result = matcher_->match(data);
+    if (result.isUnableToMatch()) {
       return result;
     }
-
-    return {MatchState::MatchComplete, !result.result()};
+    return result.isMatched() ? FieldMatchResult::noMatch() : FieldMatchResult::matched();
   }
 
 private:
@@ -136,8 +144,8 @@ private:
 
 /**
  * Implementation of a FieldMatcher that extracts an input value from the provided data and attempts
- * to match using an InputMatcher. absl::nullopt is returned whenever the data is not available or
- * if we failed to match and there is more data available.
+ * to match using an InputMatcher. UnableToMatch is returned whenever the data is not available or
+ * if we failed to match and there may be more data available later.
  * A consequence of this is that if a match result is desired, care should be taken so that matching
  * is done with all the data available at some point.
  */
@@ -164,19 +172,18 @@ public:
 
     ENVOY_LOG(trace, "Attempting to match {}", input);
     if (input.data_availability_ == DataInputGetResult::DataAvailability::NotAvailable) {
-      return {MatchState::UnableToMatch, absl::nullopt};
+      return FieldMatchResult::unableToMatch();
     }
 
     bool current_match = input_matcher_->match(input.data_);
     if (!current_match && input.data_availability_ ==
                               DataInputGetResult::DataAvailability::MoreDataMightBeAvailable) {
       ENVOY_LOG(trace, "No match yet; delaying result as more data might be available.");
-      return {MatchState::UnableToMatch, absl::nullopt};
+      return FieldMatchResult::unableToMatch();
     }
 
     ENVOY_LOG(trace, "Match result: {}", current_match);
-
-    return {MatchState::MatchComplete, current_match};
+    return current_match ? FieldMatchResult::matched() : FieldMatchResult::noMatch();
   }
 
 private:

--- a/source/common/matcher/list_matcher.h
+++ b/source/common/matcher/list_matcher.h
@@ -24,10 +24,10 @@ public:
       FieldMatchResult result = matcher.first->match(matching_data);
 
       // One of the matchers don't have enough information, bail on evaluating the match.
-      if (result.match_state_ == MatchState::UnableToMatch) {
+      if (result.isUnableToMatch()) {
         return {MatchState::UnableToMatch, absl::nullopt};
       }
-      if (!result.result()) {
+      if (result.isNoMatch()) {
         continue;
       }
 

--- a/test/common/matcher/field_matcher_test.cc
+++ b/test/common/matcher/field_matcher_test.cc
@@ -41,76 +41,71 @@ public:
 };
 
 TEST_F(FieldMatcherTest, SingleFieldMatcher) {
-  EXPECT_EQ(
-      createSingleMatcher("foo", [](auto v) { return v == "foo"; })->match(TestData()).match_state_,
-      MatchState::MatchComplete);
+  EXPECT_EQ(createSingleMatcher("foo", [](auto v) { return v == "foo"; })->match(TestData()),
+            FieldMatchResult::matched());
+  EXPECT_EQ(createSingleMatcher("foo", [](auto v) { return v != "foo"; })->match(TestData()),
+            FieldMatchResult::noMatch());
   EXPECT_EQ(createSingleMatcher(
                 absl::nullopt, [](auto v) { return v == "foo"; },
                 DataInputGetResult::DataAvailability::NotAvailable)
-                ->match(TestData())
-                .match_state_,
-            MatchState::UnableToMatch);
+                ->match(TestData()),
+            FieldMatchResult::unableToMatch());
   EXPECT_EQ(createSingleMatcher(
                 "fo", [](auto v) { return v == "foo"; },
                 DataInputGetResult::DataAvailability::MoreDataMightBeAvailable)
-                ->match(TestData())
-                .match_state_,
-            MatchState::UnableToMatch);
-  EXPECT_TRUE(
-      createSingleMatcher("foo", [](auto v) { return v == "foo"; })->match(TestData()).result());
-  EXPECT_FALSE(
-      createSingleMatcher("foo", [](auto v) { return v != "foo"; })->match(TestData()).result());
-
-  EXPECT_FALSE(createSingleMatcher(absl::nullopt, [](auto v) { return v == "foo"; })
-                   ->match(TestData())
-                   .result());
+                ->match(TestData()),
+            FieldMatchResult::unableToMatch());
+  EXPECT_EQ(
+      createSingleMatcher(absl::nullopt, [](auto v) { return v == "foo"; })->match(TestData()),
+      FieldMatchResult::noMatch());
 }
 
 TEST_F(FieldMatcherTest, AnyMatcher) {
-  EXPECT_TRUE(AnyFieldMatcher<TestData>(createMatchers({true, false})).match(TestData()).result());
-  EXPECT_TRUE(AnyFieldMatcher<TestData>(createMatchers({true, true})).match(TestData()).result());
-  EXPECT_FALSE(
-      AnyFieldMatcher<TestData>(createMatchers({false, false})).match(TestData()).result());
+  EXPECT_EQ(AnyFieldMatcher<TestData>(createMatchers({true, false})).match(TestData()),
+            FieldMatchResult::matched());
+  EXPECT_EQ(AnyFieldMatcher<TestData>(createMatchers({true, true})).match(TestData()),
+            FieldMatchResult::matched());
+  EXPECT_EQ(AnyFieldMatcher<TestData>(createMatchers({false, false})).match(TestData()),
+            FieldMatchResult::noMatch());
   EXPECT_EQ(AnyFieldMatcher<TestData>(
                 createMatchers(
                     {std::make_pair(false,
                                     DataInputGetResult::DataAvailability::MoreDataMightBeAvailable),
                      std::make_pair(true, DataInputGetResult::DataAvailability::AllDataAvailable)}))
-                .match(TestData())
-                .match_state_,
-            MatchState::MatchComplete);
+                .match(TestData()),
+            FieldMatchResult::matched());
   EXPECT_EQ(
       AnyFieldMatcher<TestData>(
           createMatchers(
               {std::make_pair(false,
                               DataInputGetResult::DataAvailability::MoreDataMightBeAvailable),
                std::make_pair(false, DataInputGetResult::DataAvailability::AllDataAvailable)}))
-          .match(TestData())
-          .match_state_,
-      MatchState::UnableToMatch);
+          .match(TestData()),
+      FieldMatchResult::unableToMatch());
 }
 
 TEST_F(FieldMatcherTest, AllMatcher) {
-  EXPECT_FALSE(AllFieldMatcher<TestData>(createMatchers({true, false})).match(TestData()).result());
-  EXPECT_TRUE(AllFieldMatcher<TestData>(createMatchers({true, true})).match(TestData()).result());
-  EXPECT_FALSE(
-      AllFieldMatcher<TestData>(createMatchers({false, false})).match(TestData()).result());
+  EXPECT_EQ(AllFieldMatcher<TestData>(createMatchers({true, false})).match(TestData()),
+            FieldMatchResult::noMatch());
+  EXPECT_EQ(AllFieldMatcher<TestData>(createMatchers({true, true})).match(TestData()),
+            FieldMatchResult::matched());
+  EXPECT_EQ(AllFieldMatcher<TestData>(createMatchers({false, false})).match(TestData()),
+            FieldMatchResult::noMatch());
   EXPECT_EQ(
       AllFieldMatcher<TestData>(
           createMatchers(
               {std::make_pair(false,
                               DataInputGetResult::DataAvailability::MoreDataMightBeAvailable),
                std::make_pair(false, DataInputGetResult::DataAvailability::AllDataAvailable)}))
-          .match(TestData())
-          .match_state_,
-      MatchState::UnableToMatch);
+          .match(TestData()),
+      FieldMatchResult::unableToMatch());
 }
 
 TEST_F(FieldMatcherTest, NotMatcher) {
-  EXPECT_TRUE(NotFieldMatcher<TestData>(
-                  std::make_unique<AllFieldMatcher<TestData>>(createMatchers({true, false})))
-                  .match(TestData())
-                  .result());
+  EXPECT_EQ(NotFieldMatcher<TestData>(
+                std::make_unique<AllFieldMatcher<TestData>>(createMatchers({true, false})))
+                .match(TestData()),
+            FieldMatchResult::matched());
 
   EXPECT_EQ(
       NotFieldMatcher<TestData>(
@@ -118,9 +113,8 @@ TEST_F(FieldMatcherTest, NotMatcher) {
               {std::make_pair(false,
                               DataInputGetResult::DataAvailability::MoreDataMightBeAvailable),
                std::make_pair(false, DataInputGetResult::DataAvailability::AllDataAvailable)})))
-          .match(TestData())
-          .match_state_,
-      MatchState::UnableToMatch);
+          .match(TestData()),
+      FieldMatchResult::unableToMatch());
 }
 
 } // namespace Matcher

--- a/test/common/matcher/test_utility.h
+++ b/test/common/matcher/test_utility.h
@@ -261,6 +261,18 @@ createSingleMatcher(absl::optional<absl::string_view> input,
       .value();
 }
 
+void PrintTo(const FieldMatchResult& result, std::ostream* os) {
+  if (result.isUnableToMatch()) {
+    *os << "UnableToMatch";
+  } else if (result.isNoMatch()) {
+    *os << "NoMatch";
+  } else if (result.isMatched()) {
+    *os << "Matched";
+  } else {
+    *os << "UnknownState";
+  }
+}
+
 // Creates a StringAction from a provided string.
 std::unique_ptr<StringAction> stringValue(absl::string_view value) {
   return std::make_unique<StringAction>(std::string(value));


### PR DESCRIPTION
Commit Message: Clean up FieldMatchResult
Additional Description: The previous structure supported being in an invalid state (UnableToMatch+true), and making invalid inquiries of it (asking for result when state is UnableToMatch), and was storing two values to signify one thing. This is a first step to a larger cleanup in this area. I'm starting with this one because it's small and simple.
Risk Level: Negligible, no behavior change.
Testing: Existing tests.
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
