### PR TITLE
xDS: add proto to get aggregate cluster config from a separate resource

### DIFF
--- a/api/envoy/extensions/clusters/aggregate/v3/BUILD
+++ b/api/envoy/extensions/clusters/aggregate/v3/BUILD
@@ -5,5 +5,8 @@ load("@envoy_api//bazel:api_build_system.bzl", "api_proto_package")
 licenses(["notice"])  # Apache 2
 
 api_proto_package(
-    deps = ["@com_github_cncf_xds//udpa/annotations:pkg"],
+    deps = [
+        "//envoy/config/core/v3:pkg",
+        "@com_github_cncf_xds//udpa/annotations:pkg",
+    ],
 )

--- a/api/envoy/extensions/clusters/aggregate/v3/cluster.proto
+++ b/api/envoy/extensions/clusters/aggregate/v3/cluster.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package envoy.extensions.clusters.aggregate.v3;
 
-import "config/core/v3/config_source.proto";
+import "envoy/config/core/v3/config_source.proto";
 
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";

--- a/api/envoy/extensions/clusters/aggregate/v3/cluster.proto
+++ b/api/envoy/extensions/clusters/aggregate/v3/cluster.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package envoy.extensions.clusters.aggregate.v3;
 
+import "config/core/v3/config_source.proto";
+
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
@@ -24,4 +26,19 @@ message ClusterConfig {
   // Load balancing clusters in aggregate cluster. Clusters are prioritized based on the order they
   // appear in this list.
   repeated string clusters = 1 [(validate.rules).repeated = {min_items: 1}];
+}
+
+// Configures an aggregate cluster whose
+// :ref:`ClusterConfig <envoy_v3_api_msg_extensions.clusters.aggregate.v3.ClusterConfig>`
+// is to be fetched from a separate xDS resource.
+// [#extension: envoy.clusters.aggregate_resource]
+// [#not-implemented-hide:]
+message AggregateClusterResource {
+  // Configuration source specifier for the ClusterConfig resource.
+  // Only the aggregated protocol variants are supported; if configured
+  // otherwise, the cluster resource will be NACKed.
+  config.core.v3.ConfigSource config_source = 1 [(validate.rules).message = {required: true}];
+
+  // The name of the ClusterConfig resource to subscribe to.
+  string resource_name = 2 [(validate.rules).string = {min_len: 1}];
 }


### PR DESCRIPTION
Commit Message: xDS: add proto to get aggregate cluster config from a separate resource
Additional Description: This allows the actual list of underlying clusters to be updated dynamically from a separate resource, rather than being inlined in the CDS resource.  The idea is that instead of the CDS resource directly including the `ClusterConfig` proto, it will contain the `AggregateClusterResource` proto, which will configure the data plane to fetch the `ClusterConfig` proto via ADS.
Risk Level: None
Testing: N/A
Docs Changes: Included in PR
Release Notes: N/A
Platform Specific Features: N/A

CC @adisuissa @fuqianggao