### PR TITLE
happy-eye-balls: minor refactor to reduce proto copy

### DIFF
--- a/source/common/network/happy_eyeballs_connection_impl.cc
+++ b/source/common/network/happy_eyeballs_connection_impl.cc
@@ -15,7 +15,7 @@ HappyEyeballsConnectionProvider::HappyEyeballsConnectionProvider(
     TransportSocketOptionsConstSharedPtr transport_socket_options,
     const Upstream::HostDescriptionConstSharedPtr& host,
     const ConnectionSocket::OptionsSharedPtr options,
-    const absl::optional<envoy::config::cluster::v3::UpstreamConnectionOptions::HappyEyeballsConfig>
+    OptRef<const envoy::config::cluster::v3::UpstreamConnectionOptions::HappyEyeballsConfig>
         happy_eyeballs_config)
     : dispatcher_(dispatcher),
       address_list_(sortAddressesWithConfig(address_list, happy_eyeballs_config)),
@@ -97,7 +97,7 @@ std::vector<Address::InstanceConstSharedPtr> HappyEyeballsConnectionProvider::so
 std::vector<Address::InstanceConstSharedPtr>
 HappyEyeballsConnectionProvider::sortAddressesWithConfig(
     const std::vector<Address::InstanceConstSharedPtr>& in,
-    const absl::optional<envoy::config::cluster::v3::UpstreamConnectionOptions::HappyEyeballsConfig>
+    OptRef<const envoy::config::cluster::v3::UpstreamConnectionOptions::HappyEyeballsConfig>
         happy_eyeballs_config) {
   if (!happy_eyeballs_config.has_value()) {
     return sortAddresses(in);
@@ -121,8 +121,8 @@ HappyEyeballsConnectionProvider::sortAddressesWithConfig(
   Address::IpVersion first_family_ip_version = in[0].get()->ip()->version();
 
   const auto first_address_family_count =
-      PROTOBUF_GET_WRAPPED_OR_DEFAULT(happy_eyeballs_config.value(), first_address_family_count, 1);
-  switch (happy_eyeballs_config.value().first_address_family_version()) {
+      PROTOBUF_GET_WRAPPED_OR_DEFAULT(*happy_eyeballs_config, first_address_family_count, 1);
+  switch (happy_eyeballs_config->first_address_family_version()) {
   case envoy::config::cluster::v3::UpstreamConnectionOptions::DEFAULT:
     break;
   case envoy::config::cluster::v3::UpstreamConnectionOptions::V4:

--- a/source/common/network/happy_eyeballs_connection_impl.h
+++ b/source/common/network/happy_eyeballs_connection_impl.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "envoy/common/optref.h"
 #include "envoy/config/cluster/v3/cluster.pb.h"
 #include "envoy/upstream/upstream.h"
 
@@ -25,8 +26,7 @@ public:
       TransportSocketOptionsConstSharedPtr transport_socket_options,
       const Upstream::HostDescriptionConstSharedPtr& host,
       const ConnectionSocket::OptionsSharedPtr options,
-      const absl::optional<
-          envoy::config::cluster::v3::UpstreamConnectionOptions::HappyEyeballsConfig>
+      OptRef<const envoy::config::cluster::v3::UpstreamConnectionOptions::HappyEyeballsConfig>
           happy_eyeballs_config);
   bool hasNextConnection() override;
   ClientConnectionPtr createNextConnection(const uint64_t id) override;
@@ -41,8 +41,7 @@ public:
   sortAddresses(const std::vector<Address::InstanceConstSharedPtr>& address_list);
   static std::vector<Address::InstanceConstSharedPtr> sortAddressesWithConfig(
       const std::vector<Address::InstanceConstSharedPtr>& address_list,
-      const absl::optional<
-          envoy::config::cluster::v3::UpstreamConnectionOptions::HappyEyeballsConfig>
+      OptRef<const envoy::config::cluster::v3::UpstreamConnectionOptions::HappyEyeballsConfig>
           happy_eyeballs_config);
 
 private:
@@ -87,8 +86,7 @@ public:
       TransportSocketOptionsConstSharedPtr transport_socket_options,
       const Upstream::HostDescriptionConstSharedPtr& host,
       const ConnectionSocket::OptionsSharedPtr options,
-      const absl::optional<
-          envoy::config::cluster::v3::UpstreamConnectionOptions::HappyEyeballsConfig>
+      OptRef<const envoy::config::cluster::v3::UpstreamConnectionOptions::HappyEyeballsConfig>
           happy_eyeballs_config)
       : MultiConnectionBaseImpl(dispatcher,
                                 std::make_unique<Network::HappyEyeballsConnectionProvider>(

--- a/test/common/network/happy_eyeballs_connection_provider_test.cc
+++ b/test/common/network/happy_eyeballs_connection_provider_test.cc
@@ -62,7 +62,8 @@ TEST_F(HappyEyeballsConnectionProviderTest, SortAddressesWithHappyEyeballsConfig
   he_config.set_first_address_family_version(
       envoy::config::cluster::v3::UpstreamConnectionOptions::V4);
   he_config.mutable_first_address_family_count()->set_value(2);
-  auto config = absl::make_optional(he_config);
+  OptRef<const envoy::config::cluster::v3::UpstreamConnectionOptions::HappyEyeballsConfig> config =
+      he_config;
 
   // All v4 address so unchanged.
   std::vector<Address::InstanceConstSharedPtr> v4_list = {ip_v4_1, ip_v4_2, ip_v4_3, ip_v4_4};
@@ -95,7 +96,8 @@ TEST_F(HappyEyeballsConnectionProviderTest, SortAddressesWithHappyEyeballsConfig
   // missing first_address_family_version
   envoy::config::cluster::v3::UpstreamConnectionOptions::HappyEyeballsConfig he_config_no_version;
   he_config_no_version.mutable_first_address_family_count()->set_value(2);
-  auto config_no_version = absl::make_optional(he_config_no_version);
+  OptRef<const envoy::config::cluster::v3::UpstreamConnectionOptions::HappyEyeballsConfig>
+      config_no_version = he_config_no_version;
   // first_address_family_version should default to DEFAULT when absent.
   // v6 then v4, return interleaved list.
   std::vector<Address::InstanceConstSharedPtr> interleaved4 = {ip_v6_1, ip_v6_2, ip_v4_1, ip_v4_2};
@@ -106,7 +108,8 @@ TEST_F(HappyEyeballsConnectionProviderTest, SortAddressesWithHappyEyeballsConfig
   envoy::config::cluster::v3::UpstreamConnectionOptions::HappyEyeballsConfig he_config_no_count;
   he_config_no_count.set_first_address_family_version(
       envoy::config::cluster::v3::UpstreamConnectionOptions::V4);
-  auto config_no_count = absl::make_optional(he_config_no_count);
+  OptRef<const envoy::config::cluster::v3::UpstreamConnectionOptions::HappyEyeballsConfig>
+      config_no_count = he_config_no_count;
   // first_address_family_count should default to 1 when absent.
   // v6 then v4, return interleaved list.
   std::vector<Address::InstanceConstSharedPtr> interleaved5 = {ip_v4_1, ip_v6_1, ip_v4_2, ip_v6_2};


### PR DESCRIPTION
Commit Message: happy-eye-balls: minor refactor to reduce proto copy
Additional Description:
A minor refactor that avoids proto copy by using an OptRef type.
Risk Level: low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A