### PR TITLE
Clean up Matcher::MatchResult's unnecessary templates

### DIFF
--- a/envoy/matcher/matcher.h
+++ b/envoy/matcher/matcher.h
@@ -127,9 +127,10 @@ public:
 };
 
 // The result of a match. There are three possible results:
-// - The match could not be completed due to lack of data (InsufficientData)
-// - The match was completed, no match found (NoMatch)
-// - The match was completed, match found (onMatch() will return the OnMatch).
+// - The match could not be completed due to lack of data (isInsufficientData() will return true.)
+// - The match was completed, no match found (isNoMatch() will return true.)
+// - The match was completed, match found (isMatch() will return true, action() will return the
+//   ActionFactoryCb.)
 struct MatchResult {
 private:
   struct InsufficientData {};

--- a/envoy/matcher/matcher.h
+++ b/envoy/matcher/matcher.h
@@ -132,14 +132,6 @@ public:
 // - The match was completed, match found (isMatch() will return true, action() will return the
 //   ActionFactoryCb.)
 struct MatchResult {
-private:
-  struct InsufficientData {};
-  struct NoMatch {};
-  using Result = absl::variant<ActionFactoryCb, NoMatch, InsufficientData>;
-  Result result_;
-  MatchResult(NoMatch) : result_(NoMatch{}) {}
-  MatchResult(InsufficientData) : result_(InsufficientData{}) {}
-
 public:
   MatchResult(ActionFactoryCb cb) : result_(std::move(cb)) {}
   static MatchResult noMatch() { return MatchResult(NoMatch{}); }
@@ -150,6 +142,14 @@ public:
   bool isMatch() const { return absl::holds_alternative<ActionFactoryCb>(result_); }
   ActionFactoryCb actionFactory() const { return absl::get<ActionFactoryCb>(result_); }
   ActionPtr action() const { return actionFactory()(); }
+
+private:
+  struct InsufficientData {};
+  struct NoMatch {};
+  using Result = absl::variant<ActionFactoryCb, NoMatch, InsufficientData>;
+  Result result_;
+  MatchResult(NoMatch) : result_(NoMatch{}) {}
+  MatchResult(InsufficientData) : result_(InsufficientData{}) {}
 };
 
 // Callback to execute against skipped matches' actions.

--- a/envoy/matcher/matcher.h
+++ b/envoy/matcher/matcher.h
@@ -13,6 +13,7 @@
 #include "absl/container/flat_hash_set.h"
 #include "absl/strings/string_view.h"
 #include "absl/types/optional.h"
+#include "absl/types/variant.h"
 #include "xds/type/matcher/v3/matcher.pb.h"
 
 namespace Envoy {
@@ -125,22 +126,33 @@ public:
   createOnMatch(const envoy::config::common::matcher::v3::Matcher::OnMatch&) PURE;
 };
 
-/**
- * State enum for the result of an attempted match.
- */
-enum class MatchState {
-  /**
-   * The match could not be completed, e.g. due to the required data not being available.
-   */
-  UnableToMatch,
-  /**
-   * The match was completed.
-   */
-  MatchComplete,
+// The result of a match. There are three possible results:
+// - The match could not be completed due to lack of data (InsufficientData)
+// - The match was completed, no match found (NoMatch)
+// - The match was completed, match found (onMatch() will return the OnMatch).
+struct MatchResult {
+private:
+  struct InsufficientData {};
+  struct NoMatch {};
+  using Result = absl::variant<ActionFactoryCb, NoMatch, InsufficientData>;
+  Result result_;
+  MatchResult(NoMatch) : result_(NoMatch{}) {}
+  MatchResult(InsufficientData) : result_(InsufficientData{}) {}
+
+public:
+  MatchResult(ActionFactoryCb cb) : result_(std::move(cb)) {}
+  static MatchResult noMatch() { return MatchResult(NoMatch{}); }
+  static MatchResult insufficientData() { return MatchResult(InsufficientData{}); }
+  bool isInsufficientData() const { return absl::holds_alternative<InsufficientData>(result_); }
+  bool isComplete() const { return !isInsufficientData(); }
+  bool isNoMatch() const { return absl::holds_alternative<NoMatch>(result_); }
+  bool isMatch() const { return absl::holds_alternative<ActionFactoryCb>(result_); }
+  ActionFactoryCb actionFactory() const { return absl::get<ActionFactoryCb>(result_); }
+  ActionPtr action() const { return actionFactory()(); }
 };
 
 // Callback to execute against skipped matches' actions.
-template <class DataType> using SkippedMatchCb = std::function<void(const OnMatch<DataType>&)>;
+using SkippedMatchCb = std::function<void(ActionFactoryCb)>;
 /**
  * MatchTree provides the interface for performing matches against the data provided by DataType.
  */
@@ -148,52 +160,45 @@ template <class DataType> class MatchTree {
 public:
   virtual ~MatchTree() = default;
 
-  // The result of a match. There are three possible results:
-  // - The match could not be completed (match_state_ == MatchState::UnableToMatch)
-  // - The match was completed, no match found (match_state_ == MatchState::MatchComplete, on_match_
-  // = {})
-  // - The match was complete, match found (match_state_ == MatchState::MatchComplete, on_match_ =
-  // something).
-  struct MatchResult {
-    const MatchState match_state_;
-    const absl::optional<OnMatch<DataType>> on_match_;
-  };
-
   // Attempts to match against the matching data (which should contain all the data requested via
-  // matching requirements). If the match couldn't be completed, {false, {}} will be returned.
-  // If a match result was determined, {true, action} will be returned. If a match result was
-  // determined to be no match, {true, {}} will be returned.
+  // matching requirements).
+  // If the match couldn't be completed, MatchResult::insufficientData() will be returned.
+  // If a match result was determined, an action callback factory will be returned.
+  // If it was determined to be no match, MatchResult::noMatch() will be returned.
+  //
+  // Implementors should call handleRecursionAndSkips() to transform OnMatch values
+  // into MatchResult values, and handle noMatch and insufficientData results as appropriate
+  // for the specific matcher type.
   virtual MatchResult match(const DataType& matching_data,
-                            SkippedMatchCb<DataType> skipped_match_cb = nullptr) PURE;
+                            SkippedMatchCb skipped_match_cb = nullptr) PURE;
 
 protected:
   // Internally handle recursion & keep_matching logic in matcher implementations.
   // This should be called against initial matching & on-no-match results.
   static inline MatchResult
   handleRecursionAndSkips(const absl::optional<OnMatch<DataType>>& on_match, const DataType& data,
-                          SkippedMatchCb<DataType> skipped_match_cb) {
+                          SkippedMatchCb skipped_match_cb) {
     if (!on_match.has_value()) {
-      return {MatchState::MatchComplete, absl::nullopt};
+      return MatchResult::noMatch();
     }
     if (on_match->matcher_) {
-      auto nested_result = on_match->matcher_->match(data, skipped_match_cb);
+      MatchResult nested_result = on_match->matcher_->match(data, skipped_match_cb);
       // Parent result's keep_matching skips the nested result.
-      if (on_match->keep_matching_ && nested_result.match_state_ == MatchState::MatchComplete &&
-          nested_result.on_match_.has_value()) {
+      if (on_match->keep_matching_ && nested_result.isMatch()) {
         if (skipped_match_cb) {
-          skipped_match_cb(*nested_result.on_match_);
+          skipped_match_cb(nested_result.actionFactory());
         }
-        return {MatchState::MatchComplete, absl::nullopt};
+        return MatchResult::noMatch();
       }
       return nested_result;
     }
     if (on_match->action_cb_ && on_match->keep_matching_) {
       if (skipped_match_cb) {
-        skipped_match_cb(*on_match);
+        skipped_match_cb(on_match->action_cb_);
       }
-      return {MatchState::MatchComplete, absl::nullopt};
+      return MatchResult::noMatch();
     }
-    return {MatchState::MatchComplete, on_match};
+    return MatchResult{on_match->action_cb_};
   }
 };
 

--- a/source/common/listener_manager/filter_chain_manager_impl.cc
+++ b/source/common/listener_manager/filter_chain_manager_impl.cc
@@ -542,12 +542,12 @@ const Network::FilterChain*
 FilterChainManagerImpl::findFilterChainUsingMatcher(const Network::ConnectionSocket& socket,
                                                     const StreamInfo::StreamInfo& info) const {
   Network::Matching::MatchingDataImpl data(socket, info.filterState(), info.dynamicMetadata());
-  const auto& match_result = Matcher::evaluateMatch<Network::MatchingData>(*matcher_, data);
-  ASSERT(match_result.match_state_ == Matcher::MatchState::MatchComplete,
-         "Matching must complete for network streams.");
-  if (match_result.result_) {
-    const auto result = match_result.result_();
-    return result->getTyped<Configuration::FilterChainBaseAction>().get(filter_chains_by_name_,
+  const Matcher::MatchResult match_result =
+      Matcher::evaluateMatch<Network::MatchingData>(*matcher_, data);
+  ASSERT(match_result.isComplete(), "Matching must complete for network streams.");
+  if (match_result.isMatch()) {
+    const Matcher::ActionPtr action = match_result.action();
+    return action->getTyped<Configuration::FilterChainBaseAction>().get(filter_chains_by_name_,
                                                                         info);
   }
   return default_filter_chain_.get();

--- a/source/common/matcher/exact_map_matcher.h
+++ b/source/common/matcher/exact_map_matcher.h
@@ -32,14 +32,17 @@ protected:
                   absl::optional<OnMatch<DataType>> on_no_match, absl::Status& creation_status)
       : MapMatcher<DataType>(std::move(data_input), std::move(on_no_match), creation_status) {}
 
-  typename MatchTree<DataType>::MatchResult doMatch(const DataType&, absl::string_view key,
-                                                    SkippedMatchCb<DataType>) override {
+  MatchResult doMatch(const DataType& data, absl::string_view key,
+                      SkippedMatchCb skipped_match_cb) override {
     const auto itr = children_.find(key);
     if (itr != children_.end()) {
-      return {MatchState::MatchComplete, itr->second};
+      MatchResult result =
+          MatchTree<DataType>::handleRecursionAndSkips(itr->second, data, skipped_match_cb);
+      if (!result.isNoMatch()) {
+        return result;
+      }
     }
-
-    return {MatchState::MatchComplete, absl::nullopt};
+    return this->doNoMatch(data, skipped_match_cb);
   }
 
 private:

--- a/source/common/matcher/list_matcher.h
+++ b/source/common/matcher/list_matcher.h
@@ -15,29 +15,26 @@ template <class DataType> class ListMatcher : public MatchTree<DataType> {
 public:
   explicit ListMatcher(absl::optional<OnMatch<DataType>> on_no_match) : on_no_match_(on_no_match) {}
 
-  using MatchResult = typename MatchTree<DataType>::MatchResult;
-
-  typename MatchTree<DataType>::MatchResult
-  match(const DataType& matching_data,
-        SkippedMatchCb<DataType> skipped_match_cb = nullptr) override {
+  MatchResult match(const DataType& matching_data,
+                    SkippedMatchCb skipped_match_cb = nullptr) override {
     for (const auto& matcher : matchers_) {
       FieldMatchResult result = matcher.first->match(matching_data);
 
       // One of the matchers don't have enough information, bail on evaluating the match.
-      if (result.match_state_ == MatchState::UnableToMatch) {
-        return {MatchState::UnableToMatch, absl::nullopt};
+      if (result.isInsufficientData()) {
+        return MatchResult::insufficientData();
       }
-      if (!result.result()) {
+      if (result.isNoMatch()) {
         continue;
       }
 
       MatchResult processed_result = MatchTree<DataType>::handleRecursionAndSkips(
           matcher.second, matching_data, skipped_match_cb);
       // Continue to next matcher if the result is a no-match or is skipped.
-      if (processed_result.match_state_ != MatchState::MatchComplete ||
-          processed_result.on_match_.has_value()) {
-        return processed_result;
+      if (processed_result.isNoMatch()) {
+        continue;
       }
+      return processed_result;
     }
 
     // Return on-no-match, after keep_matching and/or recursion handling.

--- a/source/common/matcher/map_matcher.h
+++ b/source/common/matcher/map_matcher.h
@@ -19,12 +19,19 @@ public:
   // Adds a child to the map.
   virtual void addChild(std::string value, OnMatch<DataType>&& on_match) PURE;
 
-  typename MatchTree<DataType>::MatchResult
-  match(const DataType& data, SkippedMatchCb<DataType> skipped_match_cb = nullptr) override {
+  MatchResult doNoMatch(const DataType& data, SkippedMatchCb skipped_match_cb) {
+    if (data_input_->get(data).data_availability_ ==
+        DataInputGetResult::DataAvailability::MoreDataMightBeAvailable) {
+      return MatchResult::insufficientData();
+    }
+    return MatchTree<DataType>::handleRecursionAndSkips(on_no_match_, data, skipped_match_cb);
+  }
+
+  MatchResult match(const DataType& data, SkippedMatchCb skipped_match_cb = nullptr) override {
     const auto input = data_input_->get(data);
     ENVOY_LOG(trace, "Attempting to match {}", input);
     if (input.data_availability_ == DataInputGetResult::DataAvailability::NotAvailable) {
-      return {MatchState::UnableToMatch, absl::nullopt};
+      return MatchResult::insufficientData();
     }
 
     // Returns `on_no_match` when input data is empty. (i.e., is absl::monostate).
@@ -32,32 +39,7 @@ public:
       return MatchTree<DataType>::handleRecursionAndSkips(on_no_match_, data, skipped_match_cb);
     }
 
-    const typename MatchTree<DataType>::MatchResult result =
-        doMatch(data, absl::get<std::string>(input.data_), skipped_match_cb);
-    if (result.match_state_ != MatchState::MatchComplete) {
-      return result;
-    }
-    // No match.
-    if (!result.on_match_.has_value()) {
-      // Match failed.
-      if (input.data_availability_ ==
-          DataInputGetResult::DataAvailability::MoreDataMightBeAvailable) {
-        return {MatchState::UnableToMatch, absl::nullopt};
-      }
-      // No-match, return on_no_match after keep_matching and/or recursion handling.
-      return MatchTree<DataType>::handleRecursionAndSkips(on_no_match_, data, skipped_match_cb);
-    }
-
-    // Handle recursion and keep_matching.
-    auto processed_result =
-        MatchTree<DataType>::handleRecursionAndSkips(result.on_match_, data, skipped_match_cb);
-    // Matched or failed nested matching.
-    if (processed_result.match_state_ != MatchState::MatchComplete ||
-        processed_result.on_match_.has_value()) {
-      return processed_result;
-    }
-    // No-match, return on_no_match after keep_matching and/or recursion handling.
-    return MatchTree<DataType>::handleRecursionAndSkips(on_no_match_, data, skipped_match_cb);
+    return doMatch(data, absl::get<std::string>(input.data_), skipped_match_cb);
   }
 
   template <class DataType2, class ActionFactoryContext> friend class MatchTreeFactory;
@@ -75,12 +57,11 @@ public:
   const DataInputPtr<DataType> data_input_;
   const absl::optional<OnMatch<DataType>> on_no_match_;
 
-  // The inner match method. Attempts to match against the resulting data string. If the match
-  // result was determined, the OnMatch will be returned. If a match result was determined to be no
-  // match, {} will be returned.
-  virtual typename MatchTree<DataType>::MatchResult
-  doMatch(const DataType& data, absl::string_view key,
-          SkippedMatchCb<DataType> skipped_match_cb) PURE;
+  // The inner match method. Attempts to match against the resulting data string.
+  // If a match is found, handleRecursionAndSkips must be called on it.
+  // Otherwise MatchResult::noMatch() or MatchResult::insufficientData() should be returned.
+  virtual MatchResult doMatch(const DataType& data, absl::string_view key,
+                              SkippedMatchCb skipped_match_cb) PURE;
 };
 
 } // namespace Matcher

--- a/source/common/matcher/map_matcher.h
+++ b/source/common/matcher/map_matcher.h
@@ -9,9 +9,6 @@ namespace Matcher {
 
 /**
  * Implementation of a map matcher which performs matches against the data provided by DataType.
- * If the match could not be completed, {MatchState::UnableToMatch, {}} will be returned. If the
- * match result was determined, {MatchState::MatchComplete, OnMatch} will be returned. If a match
- * result was determined to be no match, {MatchState::MatchComplete, {}} will be returned.
  */
 template <class DataType>
 class MapMatcher : public MatchTree<DataType>, Logger::Loggable<Logger::Id::matcher> {

--- a/source/extensions/common/matcher/trie_matcher.h
+++ b/source/extensions/common/matcher/trie_matcher.h
@@ -71,19 +71,18 @@ public:
     }
   }
 
-  typename MatchTree<DataType>::MatchResult
-  match(const DataType& data, SkippedMatchCb<DataType> skipped_match_cb = nullptr) override {
+  MatchResult match(const DataType& data, SkippedMatchCb skipped_match_cb = nullptr) override {
     const auto input = data_input_->get(data);
     if (input.data_availability_ != DataInputGetResult::DataAvailability::AllDataAvailable) {
-      return {MatchState::UnableToMatch, absl::nullopt};
+      return MatchResult::insufficientData();
     }
     if (absl::holds_alternative<absl::monostate>(input.data_)) {
-      return {MatchState::MatchComplete, on_no_match_};
+      return handleRecursionAndSkips(on_no_match_, data, skipped_match_cb);
     }
     const Network::Address::InstanceConstSharedPtr addr =
         Network::Utility::parseInternetAddressNoThrow(absl::get<std::string>(input.data_));
     if (!addr) {
-      return {MatchState::MatchComplete, on_no_match_};
+      return handleRecursionAndSkips(on_no_match_, data, skipped_match_cb);
     }
     auto values = trie_->getData(addr);
     // The candidates returned by the LC trie are not in any specific order, so we
@@ -95,11 +94,10 @@ public:
         continue;
       }
       // handleRecursionAndSkips should only return match-failure, no-match, or an action cb.
-      typename MatchTree<DataType>::MatchResult processed_match =
+      MatchResult processed_match =
           MatchTree<DataType>::handleRecursionAndSkips(*node.on_match_, data, skipped_match_cb);
 
-      if (processed_match.match_state_ != MatchState::MatchComplete ||
-          processed_match.on_match_.has_value()) {
+      if (processed_match.isMatch() || processed_match.isInsufficientData()) {
         return processed_match;
       }
       // No-match isn't definitive, so continue checking nodes.

--- a/source/extensions/common/matcher/trie_matcher.h
+++ b/source/extensions/common/matcher/trie_matcher.h
@@ -19,7 +19,7 @@ namespace Matcher {
 using ::Envoy::Matcher::DataInputFactoryCb;
 using ::Envoy::Matcher::DataInputGetResult;
 using ::Envoy::Matcher::DataInputPtr;
-using ::Envoy::Matcher::MatchState;
+using ::Envoy::Matcher::MatchResult;
 using ::Envoy::Matcher::MatchTree;
 using ::Envoy::Matcher::OnMatch;
 using ::Envoy::Matcher::OnMatchFactory;
@@ -77,12 +77,12 @@ public:
       return MatchResult::insufficientData();
     }
     if (absl::holds_alternative<absl::monostate>(input.data_)) {
-      return handleRecursionAndSkips(on_no_match_, data, skipped_match_cb);
+      return MatchTree<DataType>::handleRecursionAndSkips(on_no_match_, data, skipped_match_cb);
     }
     const Network::Address::InstanceConstSharedPtr addr =
         Network::Utility::parseInternetAddressNoThrow(absl::get<std::string>(input.data_));
     if (!addr) {
-      return handleRecursionAndSkips(on_no_match_, data, skipped_match_cb);
+      return MatchTree<DataType>::handleRecursionAndSkips(on_no_match_, data, skipped_match_cb);
     }
     auto values = trie_->getData(addr);
     // The candidates returned by the LC trie are not in any specific order, so we

--- a/source/extensions/filters/common/rbac/engine_impl.cc
+++ b/source/extensions/filters/common/rbac/engine_impl.cc
@@ -134,7 +134,7 @@ bool RoleBasedAccessControlMatcherEngineImpl::handleAction(
     StreamInfo::StreamInfo& info, std::string* effective_policy_id) const {
   Http::Matching::HttpMatchingDataImpl data(info);
   data.onRequestHeaders(headers);
-  const Matcher::MatchResult result =
+  const ::Envoy::Matcher::MatchResult result =
       Envoy::Matcher::evaluateMatch<Http::HttpMatchingData>(*matcher_, data);
   ASSERT(result.isComplete());
   if (result.isMatch()) {

--- a/source/extensions/filters/common/rbac/engine_impl.cc
+++ b/source/extensions/filters/common/rbac/engine_impl.cc
@@ -134,10 +134,11 @@ bool RoleBasedAccessControlMatcherEngineImpl::handleAction(
     StreamInfo::StreamInfo& info, std::string* effective_policy_id) const {
   Http::Matching::HttpMatchingDataImpl data(info);
   data.onRequestHeaders(headers);
-  const auto& result = Envoy::Matcher::evaluateMatch<Http::HttpMatchingData>(*matcher_, data);
-  ASSERT(result.match_state_ == Envoy::Matcher::MatchState::MatchComplete);
-  if (result.result_) {
-    auto action = result.result_()->getTyped<Action>();
+  const Matcher::MatchResult result =
+      Envoy::Matcher::evaluateMatch<Http::HttpMatchingData>(*matcher_, data);
+  ASSERT(result.isComplete());
+  if (result.isMatch()) {
+    auto action = result.action()->getTyped<Action>();
     if (effective_policy_id != nullptr) {
       *effective_policy_id = action.name();
     }

--- a/source/extensions/filters/http/custom_response/config.cc
+++ b/source/extensions/filters/http/custom_response/config.cc
@@ -57,11 +57,11 @@ PolicySharedPtr FilterConfig::getPolicy(const ::Envoy::Http::ResponseHeaderMap& 
 
   ::Envoy::Http::Matching::HttpMatchingDataImpl data(stream_info);
   data.onResponseHeaders(headers);
-  auto match = Matcher::evaluateMatch<::Envoy::Http::HttpMatchingData>(*matcher_, data);
-  if (!match.result_) {
+  auto match_result = Matcher::evaluateMatch<::Envoy::Http::HttpMatchingData>(*matcher_, data);
+  if (!match_result.isMatch()) {
     return PolicySharedPtr{};
   }
-  return match.result_()->getTyped<CustomResponseMatchAction>().policy_;
+  return match_result.action()->getTyped<CustomResponseMatchAction>().policy_;
 }
 
 } // namespace CustomResponse

--- a/source/extensions/filters/http/match_delegate/config.cc
+++ b/source/extensions/filters/http/match_delegate/config.cc
@@ -114,13 +114,13 @@ void DelegatingStreamFilter::FilterMatchState::evaluateMatchTree(
   ASSERT(matching_data_ != nullptr);
   data_update_func(*matching_data_);
 
-  const auto match_result =
+  const Matcher::MatchResult match_result =
       Matcher::evaluateMatch<Envoy::Http::HttpMatchingData>(*match_tree_, *matching_data_);
 
-  match_tree_evaluated_ = match_result.match_state_ == Matcher::MatchState::MatchComplete;
+  match_tree_evaluated_ = match_result.isComplete();
 
-  if (match_tree_evaluated_ && match_result.result_) {
-    const auto result = match_result.result_();
+  if (match_tree_evaluated_ && match_result.isMatch()) {
+    const Matcher::ActionPtr result = match_result.action();
     if ((result == nullptr) || (SkipAction().typeUrl() == result->typeUrl())) {
       skip_filter_ = true;
     } else {

--- a/source/extensions/filters/network/generic_proxy/route_impl.cc
+++ b/source/extensions/filters/network/generic_proxy/route_impl.cc
@@ -89,10 +89,10 @@ VirtualHostImpl::VirtualHostImpl(const ProtoVirtualHost& virtual_host_config,
 }
 
 RouteEntryConstSharedPtr VirtualHostImpl::routeEntry(const MatchInput& request) const {
-  auto match = Matcher::evaluateMatch<MatchInput>(*matcher_, request);
+  Matcher::MatchResult match_result = Matcher::evaluateMatch<MatchInput>(*matcher_, request);
 
-  if (match.result_) {
-    auto action = match.result_();
+  if (match_result.isMatch()) {
+    Matcher::ActionPtr action = match_result.action();
 
     // The only possible action that can be used within the route matching context
     // is the RouteMatchAction, so this must be true.

--- a/source/extensions/filters/network/generic_proxy/route_impl.cc
+++ b/source/extensions/filters/network/generic_proxy/route_impl.cc
@@ -104,7 +104,7 @@ RouteEntryConstSharedPtr VirtualHostImpl::routeEntry(const MatchInput& request) 
   }
 
   ENVOY_LOG(debug, "failed to match incoming request: {}",
-            static_cast<uint32_t>(match.match_state_));
+            match.isNoMatch() ? "no match" : "insufficient data");
   return nullptr;
 }
 

--- a/source/extensions/filters/network/generic_proxy/route_impl.cc
+++ b/source/extensions/filters/network/generic_proxy/route_impl.cc
@@ -104,7 +104,7 @@ RouteEntryConstSharedPtr VirtualHostImpl::routeEntry(const MatchInput& request) 
   }
 
   ENVOY_LOG(debug, "failed to match incoming request: {}",
-            match.isNoMatch() ? "no match" : "insufficient data");
+            match_result.isNoMatch() ? "no match" : "insufficient data");
   return nullptr;
 }
 

--- a/source/extensions/filters/network/match_delegate/config.cc
+++ b/source/extensions/filters/network/match_delegate/config.cc
@@ -101,13 +101,13 @@ void DelegatingNetworkFilter::FilterMatchState::evaluateMatchTree() {
   }
 
   ASSERT(matching_data_ != nullptr);
-  const auto match_result =
+  const Matcher::MatchResult match_result =
       Matcher::evaluateMatch<Envoy::Network::MatchingData>(*match_tree_, *matching_data_);
 
-  match_tree_evaluated_ = match_result.match_state_ == Matcher::MatchState::MatchComplete;
+  match_tree_evaluated_ = match_result.isComplete();
 
-  if (match_tree_evaluated_ && match_result.result_) {
-    const auto result = match_result.result_();
+  if (match_tree_evaluated_ && match_result.isMatch()) {
+    const Matcher::ActionPtr result = match_result.action();
     if ((result == nullptr) || (SkipAction().typeUrl() == result->typeUrl())) {
       skip_filter_ = true;
     } else {

--- a/source/extensions/filters/udp/udp_proxy/router/router_impl.cc
+++ b/source/extensions/filters/udp/udp_proxy/router/router_impl.cc
@@ -66,10 +66,11 @@ RouterImpl::RouterImpl(const envoy::extensions::filters::udp::udp_proxy::v3::Udp
 const std::string RouterImpl::route(const Network::Address::Instance& destination_address,
                                     const Network::Address::Instance& source_address) const {
   Network::Matching::UdpMatchingDataImpl data(destination_address, source_address);
-  const auto& result = Matcher::evaluateMatch<Network::UdpMatchingData>(*matcher_, data);
-  ASSERT(result.match_state_ == Matcher::MatchState::MatchComplete);
-  if (result.result_) {
-    return result.result_()->getTyped<RouteMatchAction>().cluster();
+  const Matcher::MatchResult result =
+      Matcher::evaluateMatch<Network::UdpMatchingData>(*matcher_, data);
+  ASSERT(result.isComplete());
+  if (result.isMatch()) {
+    return result.action()->getTyped<RouteMatchAction>().cluster();
   }
 
   return EMPTY_STRING;

--- a/test/common/matcher/exact_map_matcher_test.cc
+++ b/test/common/matcher/exact_map_matcher_test.cc
@@ -69,7 +69,7 @@ TEST(ExactMapMatcherTest, DataNotAvailable) {
 
   TestData data;
   const auto result = matcher->match(data);
-  EXPECT_THAT(result, HasNotEnoughData());
+  EXPECT_THAT(result, HasInsufficientData());
 }
 
 TEST(ExactMapMatcherTest, MoreDataMightBeAvailableNoMatch) {
@@ -82,7 +82,7 @@ TEST(ExactMapMatcherTest, MoreDataMightBeAvailableNoMatch) {
 
   TestData data;
   const auto result = matcher->match(data);
-  EXPECT_THAT(result, HasNotEnoughData());
+  EXPECT_THAT(result, HasInsufficientData());
 }
 
 TEST(ExactMapMatcherTest, MoreDataMightBeAvailableMatch) {
@@ -163,8 +163,8 @@ TEST(ExactMapMatcherTest, RecursiveMatchingWithKeepMatching) {
                                                /*.keep_matching=*/true});
 
   std::vector<ActionFactoryCb> skipped_results{};
-  SkippedMatchCb<TestData> skipped_match_cb = [&skipped_results](const OnMatch<TestData>& match) {
-    skipped_results.push_back(match.action_cb_);
+  SkippedMatchCb skipped_match_cb = [&skipped_results](ActionFactoryCb cb) {
+    skipped_results.push_back(cb);
   };
   TestData data;
   const auto result = matcher->match(data, skipped_match_cb);

--- a/test/common/matcher/field_matcher_test.cc
+++ b/test/common/matcher/field_matcher_test.cc
@@ -41,76 +41,71 @@ public:
 };
 
 TEST_F(FieldMatcherTest, SingleFieldMatcher) {
-  EXPECT_EQ(
-      createSingleMatcher("foo", [](auto v) { return v == "foo"; })->match(TestData()).match_state_,
-      MatchState::MatchComplete);
+  EXPECT_EQ(createSingleMatcher("foo", [](auto v) { return v == "foo"; })->match(TestData()),
+            FieldMatchResult::matched());
+  EXPECT_EQ(createSingleMatcher("foo", [](auto v) { return v != "foo"; })->match(TestData()),
+            FieldMatchResult::noMatch());
   EXPECT_EQ(createSingleMatcher(
                 absl::nullopt, [](auto v) { return v == "foo"; },
                 DataInputGetResult::DataAvailability::NotAvailable)
-                ->match(TestData())
-                .match_state_,
-            MatchState::UnableToMatch);
+                ->match(TestData()),
+            FieldMatchResult::insufficientData());
   EXPECT_EQ(createSingleMatcher(
                 "fo", [](auto v) { return v == "foo"; },
                 DataInputGetResult::DataAvailability::MoreDataMightBeAvailable)
-                ->match(TestData())
-                .match_state_,
-            MatchState::UnableToMatch);
-  EXPECT_TRUE(
-      createSingleMatcher("foo", [](auto v) { return v == "foo"; })->match(TestData()).result());
-  EXPECT_FALSE(
-      createSingleMatcher("foo", [](auto v) { return v != "foo"; })->match(TestData()).result());
-
-  EXPECT_FALSE(createSingleMatcher(absl::nullopt, [](auto v) { return v == "foo"; })
-                   ->match(TestData())
-                   .result());
+                ->match(TestData()),
+            FieldMatchResult::insufficientData());
+  EXPECT_EQ(
+      createSingleMatcher(absl::nullopt, [](auto v) { return v == "foo"; })->match(TestData()),
+      FieldMatchResult::noMatch());
 }
 
 TEST_F(FieldMatcherTest, AnyMatcher) {
-  EXPECT_TRUE(AnyFieldMatcher<TestData>(createMatchers({true, false})).match(TestData()).result());
-  EXPECT_TRUE(AnyFieldMatcher<TestData>(createMatchers({true, true})).match(TestData()).result());
-  EXPECT_FALSE(
-      AnyFieldMatcher<TestData>(createMatchers({false, false})).match(TestData()).result());
+  EXPECT_EQ(AnyFieldMatcher<TestData>(createMatchers({true, false})).match(TestData()),
+            FieldMatchResult::matched());
+  EXPECT_EQ(AnyFieldMatcher<TestData>(createMatchers({true, true})).match(TestData()),
+            FieldMatchResult::matched());
+  EXPECT_EQ(AnyFieldMatcher<TestData>(createMatchers({false, false})).match(TestData()),
+            FieldMatchResult::noMatch());
   EXPECT_EQ(AnyFieldMatcher<TestData>(
                 createMatchers(
                     {std::make_pair(false,
                                     DataInputGetResult::DataAvailability::MoreDataMightBeAvailable),
                      std::make_pair(true, DataInputGetResult::DataAvailability::AllDataAvailable)}))
-                .match(TestData())
-                .match_state_,
-            MatchState::MatchComplete);
+                .match(TestData()),
+            FieldMatchResult::matched());
   EXPECT_EQ(
       AnyFieldMatcher<TestData>(
           createMatchers(
               {std::make_pair(false,
                               DataInputGetResult::DataAvailability::MoreDataMightBeAvailable),
                std::make_pair(false, DataInputGetResult::DataAvailability::AllDataAvailable)}))
-          .match(TestData())
-          .match_state_,
-      MatchState::UnableToMatch);
+          .match(TestData()),
+      FieldMatchResult::insufficientData());
 }
 
 TEST_F(FieldMatcherTest, AllMatcher) {
-  EXPECT_FALSE(AllFieldMatcher<TestData>(createMatchers({true, false})).match(TestData()).result());
-  EXPECT_TRUE(AllFieldMatcher<TestData>(createMatchers({true, true})).match(TestData()).result());
-  EXPECT_FALSE(
-      AllFieldMatcher<TestData>(createMatchers({false, false})).match(TestData()).result());
+  EXPECT_EQ(AllFieldMatcher<TestData>(createMatchers({true, false})).match(TestData()),
+            FieldMatchResult::noMatch());
+  EXPECT_EQ(AllFieldMatcher<TestData>(createMatchers({true, true})).match(TestData()),
+            FieldMatchResult::matched());
+  EXPECT_EQ(AllFieldMatcher<TestData>(createMatchers({false, false})).match(TestData()),
+            FieldMatchResult::noMatch());
   EXPECT_EQ(
       AllFieldMatcher<TestData>(
           createMatchers(
               {std::make_pair(false,
                               DataInputGetResult::DataAvailability::MoreDataMightBeAvailable),
                std::make_pair(false, DataInputGetResult::DataAvailability::AllDataAvailable)}))
-          .match(TestData())
-          .match_state_,
-      MatchState::UnableToMatch);
+          .match(TestData()),
+      FieldMatchResult::insufficientData());
 }
 
 TEST_F(FieldMatcherTest, NotMatcher) {
-  EXPECT_TRUE(NotFieldMatcher<TestData>(
-                  std::make_unique<AllFieldMatcher<TestData>>(createMatchers({true, false})))
-                  .match(TestData())
-                  .result());
+  EXPECT_EQ(NotFieldMatcher<TestData>(
+                std::make_unique<AllFieldMatcher<TestData>>(createMatchers({true, false})))
+                .match(TestData()),
+            FieldMatchResult::matched());
 
   EXPECT_EQ(
       NotFieldMatcher<TestData>(
@@ -118,9 +113,8 @@ TEST_F(FieldMatcherTest, NotMatcher) {
               {std::make_pair(false,
                               DataInputGetResult::DataAvailability::MoreDataMightBeAvailable),
                std::make_pair(false, DataInputGetResult::DataAvailability::AllDataAvailable)})))
-          .match(TestData())
-          .match_state_,
-      MatchState::UnableToMatch);
+          .match(TestData()),
+      FieldMatchResult::insufficientData());
 }
 
 } // namespace Matcher

--- a/test/common/matcher/prefix_map_matcher_test.cc
+++ b/test/common/matcher/prefix_map_matcher_test.cc
@@ -95,7 +95,7 @@ TEST(PrefixMapMatcherTest, DataNotAvailable) {
 
   TestData data;
   const auto result = matcher->match(data);
-  EXPECT_THAT(result, HasNotEnoughData());
+  EXPECT_THAT(result, HasInsufficientData());
 }
 
 TEST(PrefixMapMatcherTest, MoreDataMightBeAvailableNoMatch) {
@@ -108,7 +108,7 @@ TEST(PrefixMapMatcherTest, MoreDataMightBeAvailableNoMatch) {
 
   TestData data;
   const auto result = matcher->match(data);
-  EXPECT_THAT(result, HasNotEnoughData());
+  EXPECT_THAT(result, HasInsufficientData());
 }
 
 TEST(PrefixMapMatcherTest, MoreDataMightBeAvailableMatch) {
@@ -139,7 +139,7 @@ TEST(PrefixMapMatcherTest, MoreDataMightBeAvailableNoMatchThenMatchDoesNotPerfor
 
   TestData data;
   const auto result = matcher->match(data);
-  EXPECT_THAT(result, HasNotEnoughData());
+  EXPECT_THAT(result, HasInsufficientData());
 }
 
 } // namespace Matcher

--- a/test/common/matcher/test_utility.h
+++ b/test/common/matcher/test_utility.h
@@ -338,6 +338,16 @@ MATCHER(HasInsufficientData, "") {
   return arg.isInsufficientData();
 }
 
+MATCHER_P(IsActionWithType, matcher, "") {
+  // Takes an ActionFactoryCb argument, and compares its action type against matcher.
+  if (arg == nullptr) {
+    return false;
+  }
+  ActionPtr action = arg();
+  return ::testing::ExplainMatchResult(testing::Matcher<absl::string_view>(matcher),
+                                       action->typeUrl(), result_listener);
+}
+
 MATCHER_P(IsStringAction, matcher, "") {
   // Takes an ActionFactoryCb argument, and compares its StringAction's string against matcher.
   if (arg == nullptr) {
@@ -359,6 +369,16 @@ MATCHER_P(HasStringAction, matcher, "") {
     return false;
   }
   return ::testing::ExplainMatchResult(IsStringAction(matcher), arg.actionFactory(),
+                                       result_listener);
+}
+
+MATCHER_P(HasActionWithType, matcher, "") {
+  // Takes a MatchResult& and validates that it
+  // has an action whose type matches matcher.
+  if (!arg.isMatch()) {
+    return false;
+  }
+  return ::testing::ExplainMatchResult(IsActionWithType(matcher), arg.actionFactory(),
                                        result_listener);
 }
 

--- a/test/common/matcher/test_utility.h
+++ b/test/common/matcher/test_utility.h
@@ -261,6 +261,18 @@ createSingleMatcher(absl::optional<absl::string_view> input,
       .value();
 }
 
+void PrintTo(const FieldMatchResult& result, std::ostream* os) {
+  if (result.isInsufficientData()) {
+    *os << "InsufficientData";
+  } else if (result.isNoMatch()) {
+    *os << "NoMatch";
+  } else if (result.isMatched()) {
+    *os << "Matched";
+  } else {
+    *os << "UnknownState";
+  }
+}
+
 // Creates a StringAction from a provided string.
 std::unique_ptr<StringAction> stringValue(absl::string_view value) {
   return std::make_unique<StringAction>(std::string(value));
@@ -288,14 +300,17 @@ inline void PrintTo(const ActionFactoryCb& action_cb, std::ostream* os) {
   PrintTo(*action, os);
 }
 
-inline void PrintTo(const MatchState state, std::ostream* os) {
-  switch (state) {
-  case MatchState::UnableToMatch:
-    *os << "UnableToMatch";
-    break;
-  case MatchState::MatchComplete:
-    *os << "MatchComplete";
-    break;
+inline void PrintTo(const MatchResult& result, std::ostream* os) {
+  if (result.isInsufficientData()) {
+    *os << "InsufficientData";
+  } else if (result.isNoMatch()) {
+    *os << "NoMatch";
+  } else if (result.isMatch()) {
+    *os << "Match{ActionFactoryCb=";
+    PrintTo(result.actionFactory(), os);
+    *os << "}";
+  } else {
+    *os << "UnknownState";
   }
 }
 
@@ -317,22 +332,10 @@ inline void PrintTo(const OnMatch<TestData>& on_match, std::ostream* os) {
   }
 }
 
-inline void PrintTo(const MatchTree<TestData>::MatchResult& result, std::ostream* os) {
-  *os << "{match_state_=";
-  PrintTo(result.match_state_, os);
-  *os << ", on_match_=";
-  if (result.on_match_.has_value()) {
-    PrintTo(result.on_match_.value(), os);
-  } else {
-    *os << "nullopt";
-  }
-  *os << "}";
-}
-
-MATCHER(HasNotEnoughData, "") {
-  // Takes a MatchTree<TestData>::MatchResult& and validates that it
-  // is in the UnableToMatch state.
-  return arg.match_state_ == MatchState::UnableToMatch && !arg.on_match_.has_value();
+MATCHER(HasInsufficientData, "") {
+  // Takes a MatchResult& and validates that it
+  // is in the InsufficientData state.
+  return arg.isInsufficientData();
 }
 
 MATCHER_P(IsStringAction, matcher, "") {
@@ -350,66 +353,18 @@ MATCHER_P(IsStringAction, matcher, "") {
 }
 
 MATCHER_P(HasStringAction, matcher, "") {
-  // Takes a MatchTree<TestData>::MatchResult& and validates that it
-  // is a StringAction with contents matching matcher.
-  if (arg.match_state_ != MatchState::MatchComplete || !arg.on_match_.has_value() ||
-      arg.on_match_->matcher_ != nullptr) {
+  // Takes a MatchResult& and validates that it
+  // has a StringAction with contents matching matcher.
+  if (!arg.isMatch()) {
     return false;
   }
-  return ::testing::ExplainMatchResult(IsStringAction(matcher), arg.on_match_->action_cb_,
+  return ::testing::ExplainMatchResult(IsStringAction(matcher), arg.actionFactory(),
                                        result_listener);
 }
 
 MATCHER(HasNoMatch, "") {
-  // Takes a MatchTree<TestData>::MatchResult& and validates that it
-  // is MatchComplete with no on_match_.
-  return arg.match_state_ == MatchState::MatchComplete && !arg.on_match_.has_value();
-}
-
-MATCHER(HasSubMatcher, "") {
-  // Takes a MatchTree<TestData>::MatchResult& and validates that it
-  // has a matcher_ value in on_match_.
-  return arg.match_state_ == MatchState::MatchComplete && arg.on_match_.has_value() &&
-         arg.on_match_->matcher_ != nullptr;
-}
-
-MATCHER_P(HasResult, m, "") {
-  // Accepts a MaybeMatchResult argument.
-  if (arg.match_state_ != MatchState::MatchComplete) {
-    *result_listener << "match_state_ is not MatchComplete";
-    return false;
-  }
-  if (arg.result_ == nullptr) {
-    *result_listener << "result_ is null";
-    return false;
-  }
-  return ExplainMatchResult(m, arg.result_, result_listener);
-}
-
-MATCHER(HasNoMatchResult, "") {
-  // Accepts a MaybeMatchResult argument.
-  if (arg.match_state_ != MatchState::MatchComplete) {
-    *result_listener << "match_state_ is not MatchComplete";
-    return false;
-  }
-  if (arg.result_ != nullptr) {
-    *result_listener << "result_ is not null";
-    return false;
-  }
-  return true;
-}
-
-MATCHER(HasFailureResult, "") {
-  // Accepts a MaybeMatchResult argument.
-  if (arg.match_state_ != MatchState::UnableToMatch) {
-    *result_listener << "match_state_ is not UnableToMatch";
-    return false;
-  }
-  if (arg.result_ != nullptr) {
-    *result_listener << "result_ is not null";
-    return false;
-  }
-  return true;
+  // Takes a MatchResult& and validates that it is NoMatch.
+  return arg.isNoMatch();
 }
 
 } // namespace Matcher

--- a/test/common/ssl/matching/inputs_integration_test.cc
+++ b/test/common/ssl/matching/inputs_integration_test.cc
@@ -16,6 +16,7 @@ namespace Envoy {
 namespace Ssl {
 namespace Matching {
 
+using ::Envoy::Matcher::HasStringAction;
 using ::testing::Return;
 
 constexpr absl::string_view yaml = R"EOF(
@@ -76,9 +77,7 @@ TEST_F(NetworkInputsIntegrationTest, UriSanInput) {
   envoy::config::core::v3::Metadata metadata;
   Network::Matching::MatchingDataImpl data(socket, filter_state, metadata);
 
-  const auto result = match_tree_()->match(data);
-  EXPECT_EQ(result.match_state_, Matcher::MatchState::MatchComplete);
-  EXPECT_TRUE(result.on_match_.has_value());
+  EXPECT_THAT(match_tree_()->match(data), HasStringAction("foo"));
 }
 
 TEST_F(NetworkInputsIntegrationTest, DnsSanInput) {
@@ -95,9 +94,7 @@ TEST_F(NetworkInputsIntegrationTest, DnsSanInput) {
   envoy::config::core::v3::Metadata metadata;
   Network::Matching::MatchingDataImpl data(socket, filter_state, metadata);
 
-  const auto result = match_tree_()->match(data);
-  EXPECT_EQ(result.match_state_, Matcher::MatchState::MatchComplete);
-  EXPECT_TRUE(result.on_match_.has_value());
+  EXPECT_THAT(match_tree_()->match(data), HasStringAction("foo"));
 }
 
 TEST_F(NetworkInputsIntegrationTest, SubjectInput) {
@@ -113,9 +110,7 @@ TEST_F(NetworkInputsIntegrationTest, SubjectInput) {
   envoy::config::core::v3::Metadata metadata;
   Network::Matching::MatchingDataImpl data(socket, filter_state, metadata);
 
-  const auto result = match_tree_()->match(data);
-  EXPECT_EQ(result.match_state_, Matcher::MatchState::MatchComplete);
-  EXPECT_TRUE(result.on_match_.has_value());
+  EXPECT_THAT(match_tree_()->match(data), HasStringAction("foo"));
 }
 
 using HttpInputsIntegrationTest = InputsIntegrationTest<Http::HttpMatchingData>;
@@ -132,9 +127,7 @@ TEST_F(HttpInputsIntegrationTest, UriSanInput) {
   EXPECT_CALL(*ssl, uriSanPeerCertificate()).WillOnce(Return(uri_sans));
   Http::Matching::HttpMatchingDataImpl data(stream_info);
 
-  const auto result = match_tree_()->match(data);
-  EXPECT_EQ(result.match_state_, Matcher::MatchState::MatchComplete);
-  EXPECT_TRUE(result.on_match_.has_value());
+  EXPECT_THAT(match_tree_()->match(data), HasStringAction("foo"));
 }
 
 TEST_F(HttpInputsIntegrationTest, DnsSanInput) {
@@ -149,9 +142,7 @@ TEST_F(HttpInputsIntegrationTest, DnsSanInput) {
   EXPECT_CALL(*ssl, dnsSansPeerCertificate()).WillOnce(Return(dns_sans));
   Http::Matching::HttpMatchingDataImpl data(stream_info);
 
-  const auto result = match_tree_()->match(data);
-  EXPECT_EQ(result.match_state_, Matcher::MatchState::MatchComplete);
-  EXPECT_TRUE(result.on_match_.has_value());
+  EXPECT_THAT(match_tree_()->match(data), HasStringAction("foo"));
 }
 
 TEST_F(HttpInputsIntegrationTest, SubjectInput) {
@@ -165,9 +156,7 @@ TEST_F(HttpInputsIntegrationTest, SubjectInput) {
   EXPECT_CALL(*ssl, subjectPeerCertificate()).WillOnce(testing::ReturnRef(host));
   Http::Matching::HttpMatchingDataImpl data(stream_info);
 
-  const auto result = match_tree_()->match(data);
-  EXPECT_EQ(result.match_state_, Matcher::MatchState::MatchComplete);
-  EXPECT_TRUE(result.on_match_.has_value());
+  EXPECT_THAT(match_tree_()->match(data), HasStringAction("foo"));
 }
 
 } // namespace Matching

--- a/test/extensions/common/matcher/trie_matcher_test.cc
+++ b/test/extensions/common/matcher/trie_matcher_test.cc
@@ -30,12 +30,10 @@ namespace {
 using ::Envoy::Matcher::ActionFactory;
 using ::Envoy::Matcher::CustomMatcherFactory;
 using ::Envoy::Matcher::DataInputGetResult;
-using ::Envoy::Matcher::evaluateMatch;
 using ::Envoy::Matcher::MatchTree;
 using ::Envoy::Matcher::MatchTreeFactory;
 using ::Envoy::Matcher::MatchTreePtr;
 using ::Envoy::Matcher::MatchTreeSharedPtr;
-using ::Envoy::Matcher::MaybeMatchResult;
 using ::Envoy::Matcher::MockMatchTreeValidationVisitor;
 using ::Envoy::Matcher::StringAction;
 using ::Envoy::Matcher::StringActionFactory;
@@ -102,7 +100,7 @@ public:
   MatchTreeFactory<TestData, absl::string_view> factory_;
   xds::type::matcher::v3::Matcher matcher_;
   // If expecting keep_matching matchers, set this cb & mark its support in the validation_visitor_.
-  SkippedMatchCb<TestData> skipped_match_cb_ = nullptr;
+  SkippedMatchCb skipped_match_cb_ = nullptr;
 };
 
 TEST_F(TrieMatcherTest, TestMatcher) {

--- a/test/extensions/common/matcher/trie_matcher_test.cc
+++ b/test/extensions/common/matcher/trie_matcher_test.cc
@@ -28,8 +28,14 @@ namespace Matcher {
 namespace {
 
 using ::Envoy::Matcher::ActionFactory;
+using ::Envoy::Matcher::ActionFactoryCb;
 using ::Envoy::Matcher::CustomMatcherFactory;
 using ::Envoy::Matcher::DataInputGetResult;
+using ::Envoy::Matcher::HasInsufficientData;
+using ::Envoy::Matcher::HasNoMatch;
+using ::Envoy::Matcher::HasStringAction;
+using ::Envoy::Matcher::IsStringAction;
+using ::Envoy::Matcher::MatchResult;
 using ::Envoy::Matcher::MatchTree;
 using ::Envoy::Matcher::MatchTreeFactory;
 using ::Envoy::Matcher::MatchTreePtr;
@@ -40,6 +46,7 @@ using ::Envoy::Matcher::StringActionFactory;
 using ::Envoy::Matcher::TestData;
 using ::Envoy::Matcher::TestDataInputBoolFactory;
 using ::Envoy::Matcher::TestDataInputStringFactory;
+using ::testing::ElementsAre;
 
 class TrieMatcherTest : public ::testing::Test {
 public:
@@ -54,39 +61,9 @@ public:
     TestUtility::validate(matcher_);
   }
 
-  void validateOnMatch(const OnMatch<TestData>& on_match, const std::string& output) {
-    ASSERT_NE(on_match.action_cb_, nullptr);
-    auto action = on_match.action_cb_();
-    ASSERT_NE(action, nullptr);
-    const auto value = action->getTyped<StringAction>();
-    EXPECT_EQ(value.string_, output);
-  }
-  void validateMatch(MatchTree<TestData>* match_tree, const std::string& output) {
-    auto result = match_tree->match(TestData());
-    ASSERT_TRUE(result.on_match_.has_value());
-    validateOnMatch(*result.on_match_, output);
-  }
-  void validateMatch(const std::string& output) {
+  MatchResult doMatch() {
     MatchTreePtr<TestData> match_tree = factory_.create(matcher_)();
-    validateMatch(match_tree.get(), output);
-  }
-  void validateNoMatch(MatchTree<TestData>* match_tree) {
-    auto result = match_tree->match(TestData());
-    EXPECT_EQ(result.match_state_, MatchState::MatchComplete);
-    EXPECT_FALSE(result.on_match_.has_value());
-  }
-  void validateNoMatch() {
-    MatchTreePtr<TestData> match_tree = factory_.create(matcher_)();
-    validateNoMatch(match_tree.get());
-  }
-  void validateUnableToMatch(MatchTree<TestData>* match_tree) {
-    auto result = match_tree->match(TestData());
-    EXPECT_EQ(result.match_state_, MatchState::UnableToMatch);
-  }
-  void validateUnableToMatch() {
-    MatchTreePtr<TestData> match_tree = factory_.create(matcher_)();
-
-    validateUnableToMatch(match_tree.get());
+    return match_tree->match(TestData(), skipped_match_cb_);
   }
 
   StringActionFactory action_factory_;
@@ -138,19 +115,19 @@ matcher_tree:
 
   {
     auto input = TestDataInputStringFactory("192.0.100.1");
-    validateMatch("foo");
+    EXPECT_THAT(doMatch(), HasStringAction("foo"));
   }
   {
     auto input = TestDataInputStringFactory("192.101.0.1");
-    validateMatch("bar");
+    EXPECT_THAT(doMatch(), HasStringAction("bar"));
   }
   {
     auto input = TestDataInputStringFactory("128.0.0.1");
-    validateNoMatch();
+    EXPECT_THAT(doMatch(), HasNoMatch());
   }
   {
     auto input = TestDataInputStringFactory("xxx");
-    validateNoMatch();
+    EXPECT_THAT(doMatch(), HasNoMatch());
   }
 }
 
@@ -225,23 +202,23 @@ on_no_match:
 
   {
     auto input = TestDataInputStringFactory("192.0.100.1");
-    validateMatch("foo");
+    EXPECT_THAT(doMatch(), HasStringAction("foo"));
   }
   {
     // No range matches.
     auto input = TestDataInputStringFactory("128.0.0.1");
-    validateMatch("bar");
+    EXPECT_THAT(doMatch(), HasStringAction("bar"));
   }
   {
     // Input is not a valid IP.
     auto input = TestDataInputStringFactory("xxx");
-    validateMatch("bar");
+    EXPECT_THAT(doMatch(), HasStringAction("bar"));
   }
   {
     // Input is nullopt.
     auto input = TestDataInputStringFactory(
         {DataInputGetResult::DataAvailability::AllDataAvailable, absl::monostate()});
-    validateMatch("bar");
+    EXPECT_THAT(doMatch(), HasStringAction("bar"));
   }
 }
 
@@ -288,15 +265,15 @@ matcher_tree:
 
   {
     auto input = TestDataInputStringFactory("192.0.100.1");
-    validateMatch("foo");
+    EXPECT_THAT(doMatch(), HasStringAction("foo"));
   }
   {
     auto input = TestDataInputStringFactory("192.0.0.1");
-    validateMatch("bar");
+    EXPECT_THAT(doMatch(), HasStringAction("bar"));
   }
   {
     auto input = TestDataInputStringFactory("255.0.0.1");
-    validateMatch("bar");
+    EXPECT_THAT(doMatch(), HasStringAction("bar"));
   }
 }
 
@@ -344,17 +321,17 @@ matcher_tree:
   {
     auto input = TestDataInputStringFactory("192.0.100.1");
     auto nested = TestDataInputBoolFactory("baz");
-    validateMatch("bar");
+    EXPECT_THAT(doMatch(), HasStringAction("bar"));
   }
   {
     auto input = TestDataInputStringFactory("192.0.100.1");
     auto nested = TestDataInputBoolFactory("");
-    validateMatch("foo");
+    EXPECT_THAT(doMatch(), HasStringAction("foo"));
   }
   {
     auto input = TestDataInputStringFactory("128.0.0.1");
     auto nested = TestDataInputBoolFactory("");
-    validateMatch("foo");
+    EXPECT_THAT(doMatch(), HasStringAction("foo"));
   }
 }
 
@@ -404,17 +381,17 @@ matcher_tree:
   {
     auto input = TestDataInputStringFactory("192.0.100.1");
     auto nested = TestDataInputBoolFactory("baz");
-    validateMatch("bar");
+    EXPECT_THAT(doMatch(), HasStringAction("bar"));
   }
   {
     auto input = TestDataInputStringFactory("192.0.100.1");
     auto nested = TestDataInputBoolFactory("");
-    validateNoMatch();
+    EXPECT_THAT(doMatch(), HasNoMatch());
   }
   {
     auto input = TestDataInputStringFactory("128.0.0.1");
     auto nested = TestDataInputBoolFactory("");
-    validateMatch("foo");
+    EXPECT_THAT(doMatch(), HasStringAction("foo"));
   }
 }
 
@@ -477,17 +454,17 @@ matcher_tree:
   {
     auto input = TestDataInputStringFactory("192.0.100.1");
     auto nested = TestDataInputBoolFactory("baz");
-    validateMatch("baz");
+    EXPECT_THAT(doMatch(), HasStringAction("baz"));
   }
   {
     auto input = TestDataInputStringFactory("192.0.100.1");
     auto nested = TestDataInputBoolFactory("bar");
-    validateMatch("bar");
+    EXPECT_THAT(doMatch(), HasStringAction("bar"));
   }
   {
     auto input = TestDataInputStringFactory("128.0.0.1");
     auto nested = TestDataInputBoolFactory("");
-    validateMatch("foo");
+    EXPECT_THAT(doMatch(), HasStringAction("foo"));
   }
 }
 
@@ -533,25 +510,25 @@ matcher_tree:
     auto input = TestDataInputStringFactory(
         {DataInputGetResult::DataAvailability::AllDataAvailable, absl::monostate()});
     auto nested = TestDataInputBoolFactory("");
-    validateNoMatch();
+    EXPECT_THAT(doMatch(), HasNoMatch());
   }
   {
     auto input = TestDataInputStringFactory("127.0.0.1");
     auto nested = TestDataInputBoolFactory(
         {DataInputGetResult::DataAvailability::AllDataAvailable, absl::monostate()});
-    validateNoMatch();
+    EXPECT_THAT(doMatch(), HasNoMatch());
   }
   {
     auto input = TestDataInputStringFactory(
         {DataInputGetResult::DataAvailability::NotAvailable, absl::monostate()});
     auto nested = TestDataInputBoolFactory("");
-    validateUnableToMatch();
+    EXPECT_THAT(doMatch(), HasInsufficientData());
   }
   {
     auto input = TestDataInputStringFactory("127.0.0.1");
     auto nested = TestDataInputBoolFactory(
         {DataInputGetResult::DataAvailability::NotAvailable, absl::monostate()});
-    validateUnableToMatch();
+    EXPECT_THAT(doMatch(), HasInsufficientData());
   }
 }
 
@@ -627,23 +604,15 @@ on_no_match:
   // Skip baz because the nested matcher is set with keep_matching.
   // Skip bag because the nested matcher returns on_no_match, but the top-level matcher is set to
   // keep_matching.
-  int skip_count = 0;
-  skipped_match_cb_ = [&](const OnMatch<TestData>& on_match) {
-    if (skip_count == 0) {
-      validateOnMatch(on_match, "foo");
-    } else if (skip_count == 1) {
-      validateOnMatch(on_match, "baz");
-    } else if (skip_count == 2) {
-      validateOnMatch(on_match, "bag");
-    } else {
-      FAIL() << "Unexpected skip count: " << skip_count;
-    }
-    skip_count++;
-  };
+  std::vector<ActionFactoryCb> skipped_results{};
+  skipped_match_cb_ = [&skipped_results](ActionFactoryCb cb) { skipped_results.push_back(cb); };
+
   auto input = TestDataInputStringFactory("192.101.0.1");
   auto nested = TestDataInputBoolFactory("baz");
   // Matches 192.101.0.0, 192.0.0.0, and 0.0.0.0.
-  validateMatch("bar");
+  EXPECT_THAT(doMatch(), HasStringAction("bar"));
+  EXPECT_THAT(skipped_results,
+              ElementsAre(IsStringAction("foo"), IsStringAction("baz"), IsStringAction("bag")));
 }
 
 TEST(TrieMatcherIntegrationTest, NetworkMatchingData) {
@@ -688,9 +657,8 @@ matcher_tree:
   envoy::config::core::v3::Metadata metadata;
   Network::Matching::MatchingDataImpl data(socket, filter_state, metadata);
 
-  const auto result = match_tree()->match(data);
-  EXPECT_EQ(result.match_state_, MatchState::MatchComplete);
-  EXPECT_EQ(result.on_match_->action_cb_()->getTyped<StringAction>().string_, "foo");
+  const MatchResult result = match_tree()->match(data);
+  EXPECT_THAT(result, HasStringAction("foo"));
 }
 
 TEST(TrieMatcherIntegrationTest, UdpNetworkMatchingData) {
@@ -732,9 +700,8 @@ matcher_tree:
   const Network::Address::Ipv4Instance address("192.168.0.1", 8080);
   Network::Matching::UdpMatchingDataImpl data(address, address);
 
-  const auto result = match_tree()->match(data);
-  EXPECT_EQ(result.match_state_, MatchState::MatchComplete);
-  EXPECT_EQ(result.on_match_->action_cb_()->getTyped<StringAction>().string_, "foo");
+  const MatchResult result = match_tree()->match(data);
+  EXPECT_THAT(result, HasStringAction("foo"));
 }
 
 TEST(TrieMatcherIntegrationTest, HttpMatchingData) {
@@ -780,9 +747,8 @@ matcher_tree:
 
   Http::Matching::HttpMatchingDataImpl data(stream_info);
 
-  const auto result = match_tree()->match(data);
-  EXPECT_EQ(result.match_state_, MatchState::MatchComplete);
-  EXPECT_EQ(result.on_match_->action_cb_()->getTyped<StringAction>().string_, "foo");
+  const MatchResult result = match_tree()->match(data);
+  EXPECT_THAT(result, HasStringAction("foo"));
 }
 
 } // namespace

--- a/test/extensions/filters/http/proto_api_scrubber/BUILD
+++ b/test/extensions/filters/http/proto_api_scrubber/BUILD
@@ -22,6 +22,7 @@ envoy_cc_test(
         "//source/extensions/filters/http/proto_api_scrubber:filter_config",
         "//source/extensions/matching/http/cel_input:cel_input_lib",
         "//source/extensions/matching/input_matchers/cel_matcher:config",
+        "//test/common/matcher:test_utility_lib",
         "//test/mocks/http:http_mocks",
         "//test/mocks/runtime:runtime_mocks",
         "//test/mocks/server:factory_context_mocks",

--- a/test/extensions/matching/input_matchers/cel_matcher/cel_matcher_test.cc
+++ b/test/extensions/matching/input_matchers/cel_matcher/cel_matcher_test.cc
@@ -34,6 +34,8 @@ using ::Envoy::Http::LowerCaseString;
 using ::Envoy::Http::TestRequestHeaderMapImpl;
 using ::Envoy::Http::TestResponseHeaderMapImpl;
 using ::Envoy::Http::TestResponseTrailerMapImpl;
+using ::Envoy::Matcher::HasNoMatch;
+using ::Envoy::Matcher::HasStringAction;
 
 enum class ExpressionType {
   CheckedExpression = 0,
@@ -177,11 +179,8 @@ TEST_F(CelMatcherTest, CelMatcherRequestHeaderMatched) {
   buildCustomHeader({{"authenticated_user", "staging"}}, request_headers);
   data_.onRequestHeaders(request_headers);
 
-  const auto result = matcher_tree->match(data_);
   // The match was complete, match found.
-  EXPECT_EQ(result.match_state_, Matcher::MatchState::MatchComplete);
-  EXPECT_TRUE(result.on_match_.has_value());
-  EXPECT_NE(result.on_match_->action_cb_, nullptr);
+  EXPECT_THAT(matcher_tree->match(data_), HasStringAction("match!!"));
 }
 
 TEST_F(CelMatcherTest, CelMatcherRequestHeaderNotMatched) {
@@ -192,10 +191,7 @@ TEST_F(CelMatcherTest, CelMatcherRequestHeaderNotMatched) {
   buildCustomHeader({{"authenticated_user", "NOT_MATCHED"}}, request_headers);
   data_.onRequestHeaders(request_headers);
 
-  const auto result = matcher_tree->match(data_);
-  // The match was completed, no match found.
-  EXPECT_EQ(result.match_state_, Matcher::MatchState::MatchComplete);
-  EXPECT_EQ(result.on_match_, absl::nullopt);
+  EXPECT_THAT(matcher_tree->match(data_), HasNoMatch());
 
   // Build header with request header key field mismatched case.
   TestRequestHeaderMapImpl request_headers_2 = default_headers_;
@@ -203,10 +199,7 @@ TEST_F(CelMatcherTest, CelMatcherRequestHeaderNotMatched) {
   Envoy::Http::Matching::HttpMatchingDataImpl data_2 =
       Envoy::Http::Matching::HttpMatchingDataImpl(stream_info_);
   data_2.onRequestHeaders(request_headers_2);
-  const auto result_2 = matcher_tree->match(data_2);
-  // The match was completed, no match found.
-  EXPECT_EQ(result_2.match_state_, Matcher::MatchState::MatchComplete);
-  EXPECT_EQ(result_2.on_match_, absl::nullopt);
+  EXPECT_THAT(matcher_tree->match(data_2), HasNoMatch());
 }
 
 TEST_F(CelMatcherTest, CelMatcherClusterMetadataMatched) {
@@ -216,11 +209,7 @@ TEST_F(CelMatcherTest, CelMatcherClusterMetadataMatched) {
       Envoy::Http::Matching::HttpMatchingDataImpl(stream_info_);
   auto matcher_tree = buildMatcherTree(absl::StrFormat(
       UpstreamClusterMetadataCelString, kFilterNamespace, kMetadataKey, kMetadataValue));
-  const auto result = matcher_tree->match(data_);
-  // The match was complete, match found.
-  EXPECT_EQ(result.match_state_, Matcher::MatchState::MatchComplete);
-  EXPECT_TRUE(result.on_match_.has_value());
-  EXPECT_NE(result.on_match_->action_cb_, nullptr);
+  EXPECT_THAT(matcher_tree->match(data_), HasStringAction("match!!"));
 }
 
 TEST_F(CelMatcherTest, CelMatcherClusterMetadataNotMatched) {
@@ -231,10 +220,7 @@ TEST_F(CelMatcherTest, CelMatcherClusterMetadataNotMatched) {
   auto matcher_tree = buildMatcherTree(absl::StrFormat(
       UpstreamClusterMetadataCelString, kFilterNamespace, kMetadataKey, kMetadataValue));
 
-  const auto result = matcher_tree->match(data_);
-  // The match was completed, no match found.
-  EXPECT_EQ(result.match_state_, Matcher::MatchState::MatchComplete);
-  EXPECT_EQ(result.on_match_, absl::nullopt);
+  EXPECT_THAT(matcher_tree->match(data_), HasNoMatch());
 }
 
 TEST_F(CelMatcherTest, CelMatcherRouteMetadataMatched) {
@@ -244,11 +230,7 @@ TEST_F(CelMatcherTest, CelMatcherRouteMetadataMatched) {
       Envoy::Http::Matching::HttpMatchingDataImpl(stream_info_);
   auto matcher_tree = buildMatcherTree(absl::StrFormat(
       UpstreamRouteMetadataCelString, kFilterNamespace, kMetadataKey, kMetadataValue));
-  const auto result = matcher_tree->match(data_);
-  // The match was complete, match found.
-  EXPECT_EQ(result.match_state_, Matcher::MatchState::MatchComplete);
-  EXPECT_TRUE(result.on_match_.has_value());
-  EXPECT_NE(result.on_match_->action_cb_, nullptr);
+  EXPECT_THAT(matcher_tree->match(data_), HasStringAction("match!!"));
 }
 
 TEST_F(CelMatcherTest, CelMatcherRouteMetadataNotMatched) {
@@ -259,10 +241,7 @@ TEST_F(CelMatcherTest, CelMatcherRouteMetadataNotMatched) {
   auto matcher_tree = buildMatcherTree(absl::StrFormat(
       UpstreamClusterMetadataCelString, kFilterNamespace, kMetadataKey, kMetadataValue));
 
-  const auto result = matcher_tree->match(data_);
-  // The match was completed, no match found.
-  EXPECT_EQ(result.match_state_, Matcher::MatchState::MatchComplete);
-  EXPECT_EQ(result.on_match_, absl::nullopt);
+  EXPECT_THAT(matcher_tree->match(data_), HasNoMatch());
 }
 
 TEST_F(CelMatcherTest, CelMatcherDynamicMetadataMatched) {
@@ -272,11 +251,7 @@ TEST_F(CelMatcherTest, CelMatcherDynamicMetadataMatched) {
       Envoy::Http::Matching::HttpMatchingDataImpl(stream_info_);
   auto matcher_tree = buildMatcherTree(
       absl::StrFormat(DynamicMetadataCelString, kFilterNamespace, kMetadataKey, kMetadataValue));
-  const auto result = matcher_tree->match(data_);
-  // The match was complete, match found.
-  EXPECT_EQ(result.match_state_, Matcher::MatchState::MatchComplete);
-  EXPECT_TRUE(result.on_match_.has_value());
-  EXPECT_NE(result.on_match_->action_cb_, nullptr);
+  EXPECT_THAT(matcher_tree->match(data_), HasStringAction("match!!"));
 }
 
 TEST_F(CelMatcherTest, CelMatcherDynamicMetadataNotMatched) {
@@ -286,10 +261,7 @@ TEST_F(CelMatcherTest, CelMatcherDynamicMetadataNotMatched) {
   auto matcher_tree = buildMatcherTree(
       absl::StrFormat(DynamicMetadataCelString, kFilterNamespace, kMetadataKey, kMetadataValue));
 
-  const auto result = matcher_tree->match(data_);
-  // The match was completed, no match found.
-  EXPECT_EQ(result.match_state_, Matcher::MatchState::MatchComplete);
-  EXPECT_EQ(result.on_match_, absl::nullopt);
+  EXPECT_THAT(matcher_tree->match(data_), HasNoMatch());
 }
 
 TEST_F(CelMatcherTest, CelMatcherTypedDynamicMetadataMatched) {
@@ -303,11 +275,7 @@ TEST_F(CelMatcherTest, CelMatcherTypedDynamicMetadataMatched) {
       Envoy::Http::Matching::HttpMatchingDataImpl(stream_info_);
   auto matcher_tree = buildMatcherTree(absl::StrFormat(
       TypedDynamicMetadataCelString, kFilterNamespace, "path", "/foo/bar/baz.fads"));
-  const auto result = matcher_tree->match(data_);
-  // The match was complete, match found.
-  EXPECT_EQ(result.match_state_, Matcher::MatchState::MatchComplete);
-  EXPECT_TRUE(result.on_match_.has_value());
-  EXPECT_NE(result.on_match_->action_cb_, nullptr);
+  EXPECT_THAT(matcher_tree->match(data_), HasStringAction("match!!"));
 }
 
 TEST_F(CelMatcherTest, CelMatcherRequestHeaderPathMatched) {
@@ -317,11 +285,7 @@ TEST_F(CelMatcherTest, CelMatcherRequestHeaderPathMatched) {
   buildCustomHeader({{":path", "/foo"}}, request_headers);
   data_.onRequestHeaders(request_headers);
 
-  const auto result = matcher_tree->match(data_);
-  // The match was complete, match found.
-  EXPECT_EQ(result.match_state_, Matcher::MatchState::MatchComplete);
-  EXPECT_TRUE(result.on_match_.has_value());
-  EXPECT_NE(result.on_match_->action_cb_, nullptr);
+  EXPECT_THAT(matcher_tree->match(data_), HasStringAction("match!!"));
 }
 
 TEST_F(CelMatcherTest, CelMatcherRequestHeaderPathMatchedUseCelExpr) {
@@ -332,11 +296,7 @@ TEST_F(CelMatcherTest, CelMatcherRequestHeaderPathMatchedUseCelExpr) {
   buildCustomHeader({{":path", "/foo"}}, request_headers);
   data_.onRequestHeaders(request_headers);
 
-  const auto result = matcher_tree->match(data_);
-  // The match was complete, match found.
-  EXPECT_EQ(result.match_state_, Matcher::MatchState::MatchComplete);
-  EXPECT_TRUE(result.on_match_.has_value());
-  EXPECT_NE(result.on_match_->action_cb_, nullptr);
+  EXPECT_THAT(matcher_tree->match(data_), HasStringAction("match!!"));
 }
 
 TEST_F(CelMatcherTest, CelMatcherRequestHeaderPathNotMatched) {
@@ -347,10 +307,7 @@ TEST_F(CelMatcherTest, CelMatcherRequestHeaderPathNotMatched) {
   buildCustomHeader({{":path", "/bar"}}, request_headers);
   data_.onRequestHeaders(request_headers);
 
-  const auto result = matcher_tree->match(data_);
-  // The match was completed, no match found.
-  EXPECT_EQ(result.match_state_, Matcher::MatchState::MatchComplete);
-  EXPECT_EQ(result.on_match_, absl::nullopt);
+  EXPECT_THAT(matcher_tree->match(data_), HasNoMatch());
 }
 
 TEST_F(CelMatcherTest, CelMatcherResponseHeaderMatched) {
@@ -362,11 +319,7 @@ TEST_F(CelMatcherTest, CelMatcherResponseHeaderMatched) {
   response_headers.addCopy(LowerCaseString("content-length"), "3");
   data_.onResponseHeaders(response_headers);
 
-  const auto result = matcher_tree->match(data_);
-  // The match was complete, match found.
-  EXPECT_EQ(result.match_state_, Matcher::MatchState::MatchComplete);
-  EXPECT_TRUE(result.on_match_.has_value());
-  EXPECT_NE(result.on_match_->action_cb_, nullptr);
+  EXPECT_THAT(matcher_tree->match(data_), HasStringAction("match!!"));
 }
 
 TEST_F(CelMatcherTest, CelMatcherResponseHeaderNotMatched) {
@@ -375,10 +328,7 @@ TEST_F(CelMatcherTest, CelMatcherResponseHeaderNotMatched) {
   TestResponseHeaderMapImpl response_headers = {{"content-type", "text/html"}};
   data_.onResponseHeaders(response_headers);
 
-  const auto result = matcher_tree->match(data_);
-  // The match was completed, no match found.
-  EXPECT_EQ(result.match_state_, Matcher::MatchState::MatchComplete);
-  EXPECT_EQ(result.on_match_, absl::nullopt);
+  EXPECT_THAT(matcher_tree->match(data_), HasNoMatch());
 }
 
 TEST_F(CelMatcherTest, CelMatcherResponseTrailerMatched) {
@@ -387,11 +337,7 @@ TEST_F(CelMatcherTest, CelMatcherResponseTrailerMatched) {
   TestResponseTrailerMapImpl response_trailers = {{"transfer-encoding", "chunked"}};
   data_.onResponseTrailers(response_trailers);
 
-  const auto result = matcher_tree->match(data_);
-  // The match was complete, match found.
-  EXPECT_EQ(result.match_state_, Matcher::MatchState::MatchComplete);
-  EXPECT_TRUE(result.on_match_.has_value());
-  EXPECT_NE(result.on_match_->action_cb_, nullptr);
+  EXPECT_THAT(matcher_tree->match(data_), HasStringAction("match!!"));
 }
 
 TEST_F(CelMatcherTest, CelMatcherResponseTrailerNotMatched) {
@@ -400,10 +346,7 @@ TEST_F(CelMatcherTest, CelMatcherResponseTrailerNotMatched) {
   TestResponseTrailerMapImpl response_trailers = {{"transfer-encoding", "chunked_not_matched"}};
   data_.onResponseTrailers(response_trailers);
 
-  const auto result = matcher_tree->match(data_);
-  // The match was completed, no match found.
-  EXPECT_EQ(result.match_state_, Matcher::MatchState::MatchComplete);
-  EXPECT_EQ(result.on_match_, absl::nullopt);
+  EXPECT_THAT(matcher_tree->match(data_), HasNoMatch());
 }
 
 TEST_F(CelMatcherTest, CelMatcherRequestHeaderAndPathMatched) {
@@ -413,11 +356,7 @@ TEST_F(CelMatcherTest, CelMatcherRequestHeaderAndPathMatched) {
   buildCustomHeader({{"user", "staging"}, {":path", "/foo"}}, request_headers);
   data_.onRequestHeaders(request_headers);
 
-  const auto result = matcher_tree->match(data_);
-  // The match was complete, match found.
-  EXPECT_EQ(result.match_state_, Matcher::MatchState::MatchComplete);
-  EXPECT_TRUE(result.on_match_.has_value());
-  EXPECT_NE(result.on_match_->action_cb_, nullptr);
+  EXPECT_THAT(matcher_tree->match(data_), HasStringAction("match!!"));
 }
 
 TEST_F(CelMatcherTest, CelMatcherRequestHeaderAndPathNotMatched) {
@@ -427,10 +366,7 @@ TEST_F(CelMatcherTest, CelMatcherRequestHeaderAndPathNotMatched) {
   buildCustomHeader({{"user", "prod"}, {":path", "/foo"}}, request_headers);
   data_.onRequestHeaders(request_headers);
 
-  const auto result = matcher_tree->match(data_);
-  // The match was completed, no match found.
-  EXPECT_EQ(result.match_state_, Matcher::MatchState::MatchComplete);
-  EXPECT_EQ(result.on_match_, absl::nullopt);
+  EXPECT_THAT(matcher_tree->match(data_), HasNoMatch());
 }
 
 TEST_F(CelMatcherTest, CelMatcherRequestHeaderOrPathMatched) {
@@ -440,11 +376,7 @@ TEST_F(CelMatcherTest, CelMatcherRequestHeaderOrPathMatched) {
   buildCustomHeader({{"user", "prod"}, {":path", "/foo"}}, request_headers);
   data_.onRequestHeaders(request_headers);
 
-  const auto result = matcher_tree->match(data_);
-  // The match was complete, match found.
-  EXPECT_EQ(result.match_state_, Matcher::MatchState::MatchComplete);
-  EXPECT_TRUE(result.on_match_.has_value());
-  EXPECT_NE(result.on_match_->action_cb_, nullptr);
+  EXPECT_THAT(matcher_tree->match(data_), HasStringAction("match!!"));
 }
 
 TEST_F(CelMatcherTest, CelMatcherRequestHeaderOrPathNotMatched) {
@@ -454,10 +386,7 @@ TEST_F(CelMatcherTest, CelMatcherRequestHeaderOrPathNotMatched) {
   buildCustomHeader({{"user", "prod"}, {":path", "/bar"}}, request_headers);
   data_.onRequestHeaders(request_headers);
 
-  const auto result = matcher_tree->match(data_);
-  // The match was completed, no match found.
-  EXPECT_EQ(result.match_state_, Matcher::MatchState::MatchComplete);
-  EXPECT_EQ(result.on_match_, absl::nullopt);
+  EXPECT_THAT(matcher_tree->match(data_), HasNoMatch());
 }
 
 TEST_F(CelMatcherTest, CelMatcherRequestResponseMatched) {
@@ -473,11 +402,7 @@ TEST_F(CelMatcherTest, CelMatcherRequestResponseMatched) {
   TestResponseTrailerMapImpl response_trailers = {{"transfer-encoding", "chunked"}};
   data_.onResponseTrailers(response_trailers);
 
-  const auto result = matcher_tree->match(data_);
-  // The match was complete, match found.
-  EXPECT_EQ(result.match_state_, Matcher::MatchState::MatchComplete);
-  EXPECT_TRUE(result.on_match_.has_value());
-  EXPECT_NE(result.on_match_->action_cb_, nullptr);
+  EXPECT_THAT(matcher_tree->match(data_), HasStringAction("match!!"));
 }
 
 TEST_F(CelMatcherTest, CelMatcherRequestResponseNotMatched) {
@@ -493,10 +418,7 @@ TEST_F(CelMatcherTest, CelMatcherRequestResponseNotMatched) {
   TestResponseTrailerMapImpl response_trailers = {{"transfer-encoding", "chunked"}};
   data_.onResponseTrailers(response_trailers);
 
-  const auto result = matcher_tree->match(data_);
-  // The match was completed, no match found.
-  EXPECT_EQ(result.match_state_, Matcher::MatchState::MatchComplete);
-  EXPECT_EQ(result.on_match_, absl::nullopt);
+  EXPECT_THAT(matcher_tree->match(data_), HasNoMatch());
 }
 
 TEST_F(CelMatcherTest, CelMatcherRequestResponseMatchedWithParsedExpr) {
@@ -513,11 +435,7 @@ TEST_F(CelMatcherTest, CelMatcherRequestResponseMatchedWithParsedExpr) {
   TestResponseTrailerMapImpl response_trailers = {{"transfer-encoding", "chunked"}};
   data_.onResponseTrailers(response_trailers);
 
-  const auto result = matcher_tree->match(data_);
-  // The match was complete, match found.
-  EXPECT_EQ(result.match_state_, Matcher::MatchState::MatchComplete);
-  EXPECT_TRUE(result.on_match_.has_value());
-  EXPECT_NE(result.on_match_->action_cb_, nullptr);
+  EXPECT_THAT(matcher_tree->match(data_), HasStringAction("match!!"));
 }
 
 TEST_F(CelMatcherTest, CelMatcherRequestResponseNotMatchedWithParsedExpr) {
@@ -534,10 +452,7 @@ TEST_F(CelMatcherTest, CelMatcherRequestResponseNotMatchedWithParsedExpr) {
   TestResponseTrailerMapImpl response_trailers = {{"transfer-encoding", "chunked"}};
   data_.onResponseTrailers(response_trailers);
 
-  const auto result = matcher_tree->match(data_);
-  // The match was completed, no match found.
-  EXPECT_EQ(result.match_state_, Matcher::MatchState::MatchComplete);
-  EXPECT_EQ(result.on_match_, absl::nullopt);
+  EXPECT_THAT(matcher_tree->match(data_), HasNoMatch());
 }
 
 TEST_F(CelMatcherTest, CelMatcherRequestResponseNotMatchedWithParsedExprUseCel) {
@@ -554,10 +469,7 @@ TEST_F(CelMatcherTest, CelMatcherRequestResponseNotMatchedWithParsedExprUseCel) 
   TestResponseTrailerMapImpl response_trailers = {{"transfer-encoding", "chunked"}};
   data_.onResponseTrailers(response_trailers);
 
-  const auto result = matcher_tree->match(data_);
-  // The match was completed, no match found.
-  EXPECT_EQ(result.match_state_, Matcher::MatchState::MatchComplete);
-  EXPECT_EQ(result.on_match_, absl::nullopt);
+  EXPECT_THAT(matcher_tree->match(data_), HasNoMatch());
 }
 
 TEST_F(CelMatcherTest, NoCelExpression) {

--- a/test/extensions/matching/input_matchers/metadata/dyn_meta_matcher_test.cc
+++ b/test/extensions/matching/input_matchers/metadata/dyn_meta_matcher_test.cc
@@ -31,6 +31,9 @@ constexpr absl::string_view kFilterNamespace = "meta_matcher";
 constexpr absl::string_view kMetadataKey = "service_name";
 constexpr absl::string_view kMetadataValue = "test_service";
 
+using ::Envoy::Matcher::HasNoMatch;
+using ::Envoy::Matcher::HasStringAction;
+
 class MetadataMatcherTest : public ::testing::Test {
 public:
   MetadataMatcherTest()
@@ -107,11 +110,8 @@ TEST_F(MetadataMatcherTest, DynamicMetadataMatched) {
   Envoy::Http::Matching::HttpMatchingDataImpl data =
       Envoy::Http::Matching::HttpMatchingDataImpl(stream_info_);
   auto matcher_tree = buildMatcherTree();
-  const auto result = matcher_tree->match(data_);
-  // The match was complete, match found.
-  EXPECT_EQ(result.match_state_, ::Envoy::Matcher::MatchState::MatchComplete);
-  EXPECT_TRUE(result.on_match_.has_value());
-  EXPECT_NE(result.on_match_->action_cb_, nullptr);
+
+  EXPECT_THAT(matcher_tree->match(data_), HasStringAction("match!!"));
 }
 
 TEST_F(MetadataMatcherTest, DynamicMetadataNotMatched) {
@@ -120,10 +120,7 @@ TEST_F(MetadataMatcherTest, DynamicMetadataNotMatched) {
       Envoy::Http::Matching::HttpMatchingDataImpl(stream_info_);
   auto matcher_tree = buildMatcherTree();
 
-  const auto result = matcher_tree->match(data_);
-  // The match was completed, no match found.
-  EXPECT_EQ(result.match_state_, ::Envoy::Matcher::MatchState::MatchComplete);
-  EXPECT_EQ(result.on_match_, absl::nullopt);
+  EXPECT_THAT(matcher_tree->match(data_), HasNoMatch());
 }
 
 TEST_F(MetadataMatcherTest, DynamicMetadataNotMatchedWithInvert) {
@@ -132,11 +129,8 @@ TEST_F(MetadataMatcherTest, DynamicMetadataNotMatchedWithInvert) {
       Envoy::Http::Matching::HttpMatchingDataImpl(stream_info_);
   auto matcher_tree = buildMatcherTree(true);
 
-  const auto result = matcher_tree->match(data_);
   // The match was completed, no match found but the invert flag was set.
-  EXPECT_EQ(result.match_state_, ::Envoy::Matcher::MatchState::MatchComplete);
-  EXPECT_TRUE(result.on_match_.has_value());
-  EXPECT_NE(result.on_match_->action_cb_, nullptr);
+  EXPECT_THAT(matcher_tree->match(data_), HasStringAction("match!!"));
 }
 
 TEST_F(MetadataMatcherTest, BadData) {

--- a/test/extensions/matching/network/common/inputs_integration_test.cc
+++ b/test/extensions/matching/network/common/inputs_integration_test.cc
@@ -16,6 +16,9 @@ namespace Envoy {
 namespace Network {
 namespace Matching {
 
+using Matcher::HasNoMatch;
+using Matcher::HasStringAction;
+
 constexpr absl::string_view yaml = R"EOF(
 matcher_tree:
   input:
@@ -93,9 +96,7 @@ TEST_F(InputsIntegrationTest, DestinationIPInput) {
   socket.connection_info_provider_->setLocalAddress(
       std::make_shared<Network::Address::Ipv4Instance>("127.0.0.1", 8080));
 
-  const auto result = match_tree_()->match(data);
-  EXPECT_EQ(result.match_state_, Matcher::MatchState::MatchComplete);
-  EXPECT_TRUE(result.on_match_.has_value());
+  EXPECT_THAT(match_tree_()->match(data), HasStringAction("foo"));
 }
 
 TEST_F(InputsIntegrationTest, DestinationPortInput) {
@@ -108,9 +109,7 @@ TEST_F(InputsIntegrationTest, DestinationPortInput) {
   socket.connection_info_provider_->setLocalAddress(
       std::make_shared<Network::Address::Ipv4Instance>("127.0.0.1", 8080));
 
-  const auto result = match_tree_()->match(data);
-  EXPECT_EQ(result.match_state_, Matcher::MatchState::MatchComplete);
-  EXPECT_TRUE(result.on_match_.has_value());
+  EXPECT_THAT(match_tree_()->match(data), HasStringAction("foo"));
 }
 
 TEST_F(InputsIntegrationTest, SourceIPInput) {
@@ -123,9 +122,7 @@ TEST_F(InputsIntegrationTest, SourceIPInput) {
   socket.connection_info_provider_->setRemoteAddress(
       std::make_shared<Network::Address::Ipv4Instance>("127.0.0.1", 8080));
 
-  const auto result = match_tree_()->match(data);
-  EXPECT_EQ(result.match_state_, Matcher::MatchState::MatchComplete);
-  EXPECT_TRUE(result.on_match_.has_value());
+  EXPECT_THAT(match_tree_()->match(data), HasStringAction("foo"));
 }
 
 TEST_F(InputsIntegrationTest, SourcePortInput) {
@@ -138,9 +135,7 @@ TEST_F(InputsIntegrationTest, SourcePortInput) {
   socket.connection_info_provider_->setRemoteAddress(
       std::make_shared<Network::Address::Ipv4Instance>("127.0.0.1", 8080));
 
-  const auto result = match_tree_()->match(data);
-  EXPECT_EQ(result.match_state_, Matcher::MatchState::MatchComplete);
-  EXPECT_TRUE(result.on_match_.has_value());
+  EXPECT_THAT(match_tree_()->match(data), HasStringAction("foo"));
 }
 
 TEST_F(InputsIntegrationTest, DirectSourceIPInput) {
@@ -153,9 +148,7 @@ TEST_F(InputsIntegrationTest, DirectSourceIPInput) {
   socket.connection_info_provider_->setDirectRemoteAddressForTest(
       std::make_shared<Network::Address::Ipv4Instance>("127.0.0.1", 8080));
 
-  const auto result = match_tree_()->match(data);
-  EXPECT_EQ(result.match_state_, Matcher::MatchState::MatchComplete);
-  EXPECT_TRUE(result.on_match_.has_value());
+  EXPECT_THAT(match_tree_()->match(data), HasStringAction("foo"));
 }
 
 TEST_F(InputsIntegrationTest, SourceTypeInput) {
@@ -168,9 +161,7 @@ TEST_F(InputsIntegrationTest, SourceTypeInput) {
   socket.connection_info_provider_->setRemoteAddress(
       std::make_shared<Network::Address::Ipv4Instance>("127.0.0.1", 8080));
 
-  const auto result = match_tree_()->match(data);
-  EXPECT_EQ(result.match_state_, Matcher::MatchState::MatchComplete);
-  EXPECT_TRUE(result.on_match_.has_value());
+  EXPECT_THAT(match_tree_()->match(data), HasStringAction("foo"));
 }
 
 TEST_F(InputsIntegrationTest, ServerNameInput) {
@@ -183,9 +174,7 @@ TEST_F(InputsIntegrationTest, ServerNameInput) {
   MatchingDataImpl data(socket, filter_state, metadata);
   socket.connection_info_provider_->setRequestedServerName(host);
 
-  const auto result = match_tree_()->match(data);
-  EXPECT_EQ(result.match_state_, Matcher::MatchState::MatchComplete);
-  EXPECT_TRUE(result.on_match_.has_value());
+  EXPECT_THAT(match_tree_()->match(data), HasStringAction("foo"));
 }
 
 TEST_F(InputsIntegrationTest, TransportProtocolInput) {
@@ -197,9 +186,7 @@ TEST_F(InputsIntegrationTest, TransportProtocolInput) {
   MatchingDataImpl data(socket, filter_state, metadata);
   EXPECT_CALL(socket, detectedTransportProtocol).WillOnce(testing::Return("tls"));
 
-  const auto result = match_tree_()->match(data);
-  EXPECT_EQ(result.match_state_, Matcher::MatchState::MatchComplete);
-  EXPECT_TRUE(result.on_match_.has_value());
+  EXPECT_THAT(match_tree_()->match(data), HasStringAction("foo"));
 }
 
 TEST_F(InputsIntegrationTest, ApplicationProtocolInput) {
@@ -212,9 +199,7 @@ TEST_F(InputsIntegrationTest, ApplicationProtocolInput) {
   std::vector<std::string> protocols = {"http/1.1"};
   EXPECT_CALL(socket, requestedApplicationProtocols).WillOnce(testing::ReturnRef(protocols));
 
-  const auto result = match_tree_()->match(data);
-  EXPECT_EQ(result.match_state_, Matcher::MatchState::MatchComplete);
-  EXPECT_TRUE(result.on_match_.has_value());
+  EXPECT_THAT(match_tree_()->match(data), HasStringAction("foo"));
 }
 
 TEST_F(InputsIntegrationTest, FilterStateInput) {
@@ -231,9 +216,7 @@ TEST_F(InputsIntegrationTest, FilterStateInput) {
   envoy::config::core::v3::Metadata metadata;
   MatchingDataImpl data(socket, filter_state, metadata);
 
-  const auto result = match_tree_()->match(data);
-  EXPECT_EQ(result.match_state_, Matcher::MatchState::MatchComplete);
-  EXPECT_TRUE(result.on_match_.has_value());
+  EXPECT_THAT(match_tree_()->match(data), HasStringAction("foo"));
 }
 
 TEST_F(InputsIntegrationTest, DynamicMetadataInput) {
@@ -265,27 +248,21 @@ TEST_F(InputsIntegrationTest, FilterStateInputFailure) {
   MatchingDataImpl data(socket, filter_state, metadata);
 
   // No filter state object - no match
-  const auto result_no_fs = match_tree_()->match(data);
-  EXPECT_EQ(result_no_fs.match_state_, Matcher::MatchState::MatchComplete);
-  EXPECT_FALSE(result_no_fs.on_match_.has_value());
+  EXPECT_THAT(match_tree_()->match(data), HasNoMatch());
 
   filter_state.setData("unknown_key", std::make_shared<Router::StringAccessorImpl>(value),
                        StreamInfo::FilterState::StateType::Mutable,
                        StreamInfo::FilterState::LifeSpan::Connection);
 
   // Unknown key in filter state - no match
-  const auto result_no_key = match_tree_()->match(data);
-  EXPECT_EQ(result_no_key.match_state_, Matcher::MatchState::MatchComplete);
-  EXPECT_FALSE(result_no_key.on_match_.has_value());
+  EXPECT_THAT(match_tree_()->match(data), HasNoMatch());
 
   filter_state.setData(key, std::make_shared<Router::StringAccessorImpl>("unknown_value"),
                        StreamInfo::FilterState::StateType::Mutable,
                        StreamInfo::FilterState::LifeSpan::Connection);
 
   // Known key in filter state but unknown value - no match
-  const auto result_no_value = match_tree_()->match(data);
-  EXPECT_EQ(result_no_value.match_state_, Matcher::MatchState::MatchComplete);
-  EXPECT_FALSE(result_no_value.on_match_.has_value());
+  EXPECT_THAT(match_tree_()->match(data), HasNoMatch());
 }
 
 class UdpInputsIntegrationTest : public ::testing::Test {
@@ -320,9 +297,7 @@ TEST_F(UdpInputsIntegrationTest, DestinationIPInput) {
   const Address::Ipv4Instance ip("127.0.0.1", 8080);
   UdpMatchingDataImpl data(ip, ip);
 
-  const auto result = match_tree_()->match(data);
-  EXPECT_EQ(result.match_state_, Matcher::MatchState::MatchComplete);
-  EXPECT_TRUE(result.on_match_.has_value());
+  EXPECT_THAT(match_tree_()->match(data), HasStringAction("foo"));
 }
 
 TEST_F(UdpInputsIntegrationTest, DestinationPortInput) {
@@ -331,9 +306,7 @@ TEST_F(UdpInputsIntegrationTest, DestinationPortInput) {
   const Address::Ipv4Instance ip("127.0.0.1", 8080);
   UdpMatchingDataImpl data(ip, ip);
 
-  const auto result = match_tree_()->match(data);
-  EXPECT_EQ(result.match_state_, Matcher::MatchState::MatchComplete);
-  EXPECT_TRUE(result.on_match_.has_value());
+  EXPECT_THAT(match_tree_()->match(data), HasStringAction("foo"));
 }
 
 TEST_F(UdpInputsIntegrationTest, SourceIPInput) {
@@ -342,9 +315,7 @@ TEST_F(UdpInputsIntegrationTest, SourceIPInput) {
   const Address::Ipv4Instance ip("127.0.0.1", 8080);
   UdpMatchingDataImpl data(ip, ip);
 
-  const auto result = match_tree_()->match(data);
-  EXPECT_EQ(result.match_state_, Matcher::MatchState::MatchComplete);
-  EXPECT_TRUE(result.on_match_.has_value());
+  EXPECT_THAT(match_tree_()->match(data), HasStringAction("foo"));
 }
 
 TEST_F(UdpInputsIntegrationTest, SourcePortInput) {
@@ -353,9 +324,7 @@ TEST_F(UdpInputsIntegrationTest, SourcePortInput) {
   const Address::Ipv4Instance ip("127.0.0.1", 8080);
   UdpMatchingDataImpl data(ip, ip);
 
-  const auto result = match_tree_()->match(data);
-  EXPECT_EQ(result.match_state_, Matcher::MatchState::MatchComplete);
-  EXPECT_TRUE(result.on_match_.has_value());
+  EXPECT_THAT(match_tree_()->match(data), HasStringAction("foo"));
 }
 
 } // namespace Matching


### PR DESCRIPTION
Commit Message: Clean up Matcher::MatchResult's unnecessary templates
Additional Description: Since #38726 refactored Matcher impls to recurse inside the match function, there is no longer any need for MatchResults to have the capacity to return sub-match-trees, which means they also don't need to be templates. Cleaning this up makes the code much easier to follow. This may have also caught a few locations where the internal recursion wasn't fully updated correctly (minor negative, it does make one `doMatch()` implementation slightly more complicated, but the corresponding `match()` implementation is made much simpler, so still an improvement).
Risk Level: Small, existing tests should be ensuring that behaviors were unchanged.
Testing: Covered by existing tests, which are also cleaner.
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
