### PR TITLE
AddressObject to inherit from Address::InstanceAccessor

### DIFF
--- a/source/common/network/filter_state_dst_address.h
+++ b/source/common/network/filter_state_dst_address.h
@@ -10,9 +10,10 @@ namespace Network {
 /**
  * Overrides the address selection for extensions, e.g. ORIGINAL_DST cluster.
  */
-class AddressObject : public StreamInfo::FilterState::Object, public Hashable {
+class AddressObject : public Address::InstanceAccessor, public Hashable {
 public:
-  AddressObject(Network::Address::InstanceConstSharedPtr address) : address_(address) {}
+  AddressObject(Network::Address::InstanceConstSharedPtr address)
+      : Address::InstanceAccessor(address), address_(address) {}
   Network::Address::InstanceConstSharedPtr address() const { return address_; }
   absl::optional<std::string> serializeAsString() const override {
     return address_ ? absl::make_optional(address_->asString()) : absl::nullopt;


### PR DESCRIPTION
Updated the AddressObject class to inherit from Address::InstanceAccessor instead of StreamInfo::FilterState::Object. This change enhances the address handling capabilities while maintaining the existing functionality. This will allow to do CIDR range matching on AddressObject

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: AddressObject to inherit from Address::InstanceAccessor
Additional Description: Updated the AddressObject class to inherit from Address::InstanceAccessor instead of StreamInfo::FilterState::Object. This change enhances the address handling capabilities while maintaining the existing functionality. This will allow to do CIDR range matching on AddressObject
Risk Level: Low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
