### PR TITLE
conn pool load shed: added a new lsp to connection pool when creating new connections to upstream

### DIFF
--- a/envoy/server/overload/load_shed_point.h
+++ b/envoy/server/overload/load_shed_point.h
@@ -33,6 +33,13 @@ public:
 
   const std::string HttpDownstreamFilterCheck =
       "envoy.load_shed_points.http_downstream_filter_check";
+
+  // Envoy will reject creating new connections in the connection pool when
+  // under pressure (typically memory pressure). If a new connection is
+  // rejected by this load shed point and there is no available capacity
+  // to serve the downstream request, the downstream request will fail.
+  const std::string ConnectionPoolNewConnection =
+      "envoy.load_shed_points.connection_pool_new_connection";
 };
 
 using LoadShedPointName = ConstSingleton<LoadShedPointNameValues>;

--- a/source/common/conn_pool/conn_pool_base.cc
+++ b/source/common/conn_pool/conn_pool_base.cc
@@ -1,5 +1,7 @@
 #include "source/common/conn_pool/conn_pool_base.h"
 
+#include "envoy/server/overload/load_shed_point.h"
+
 #include "source/common/common/assert.h"
 #include "source/common/common/debug_recursion_checker.h"
 #include "source/common/network/transport_socket_options_impl.h"
@@ -52,10 +54,16 @@ ConnPoolImplBase::ConnPoolImplBase(
     Upstream::HostConstSharedPtr host, Upstream::ResourcePriority priority,
     Event::Dispatcher& dispatcher, const Network::ConnectionSocket::OptionsSharedPtr& options,
     const Network::TransportSocketOptionsConstSharedPtr& transport_socket_options,
-    Upstream::ClusterConnectivityState& state)
+    Upstream::ClusterConnectivityState& state, Server::OverloadManager& overload_manager)
     : host_(host), priority_(priority), dispatcher_(dispatcher), socket_options_(options),
       transport_socket_options_(transport_socket_options), cluster_connectivity_state_(state),
-      upstream_ready_cb_(dispatcher_.createSchedulableCallback([this]() { onUpstreamReady(); })) {}
+      upstream_ready_cb_(dispatcher_.createSchedulableCallback([this]() { onUpstreamReady(); })),
+      create_new_connection_load_shed_(overload_manager.getLoadShedPoint(
+          Server::LoadShedPointName::get().ConnectionPoolNewConnection)) {
+  ENVOY_LOG_ONCE_IF(trace, create_new_connection_load_shed_ == nullptr,
+                    "LoadShedPoint envoy.load_shed_points.connection_pool_new_connection is not "
+                    "found. Is it configured?");
+}
 
 ConnPoolImplBase::~ConnPoolImplBase() {
   ENVOY_BUG(isIdleImpl(), dumpState());
@@ -179,6 +187,14 @@ ConnPoolImplBase::tryCreateNewConnection(float global_preconnect_ratio) {
     return ConnectionResult::ShouldNotConnect;
   }
   ENVOY_LOG(trace, "creating new preconnect connection");
+
+  // Drop new connection attempts if the load shed point indicates overload.
+  if (create_new_connection_load_shed_) {
+    if (create_new_connection_load_shed_->shouldShedLoad()) {
+      ENVOY_LOG(debug, "pool load shedding active, not creating new connection");
+      return ConnectionResult::LoadShed;
+    }
+  }
 
   const bool can_create_connection = host_->canCreateConnection(priority_);
 
@@ -346,11 +362,13 @@ ConnectionPool::Cancellable* ConnPoolImplBase::newStreamImpl(AttachContext& cont
   // length of pending_streams_ to determine if a new connection is needed.
   const ConnectionResult result = tryCreateNewConnections();
   // If there is not enough connecting capacity, the only reason to not
-  // increase capacity is if the connection limits are exceeded.
+  // increase capacity is if the connection limits are exceeded or load shed is
+  // triggered.
   ENVOY_BUG(pending_streams_.size() <= connecting_stream_capacity_ ||
                 connecting_stream_capacity_ > old_capacity ||
                 (result == ConnectionResult::NoConnectionRateLimited ||
-                 result == ConnectionResult::FailedToCreateConnection),
+                 result == ConnectionResult::FailedToCreateConnection ||
+                 result == ConnectionResult::LoadShed),
             fmt::format("Failed to create expected connection: {}", *this));
   if (result == ConnectionResult::FailedToCreateConnection) {
     // This currently only happens for HTTP/3 if secrets aren't yet loaded.
@@ -358,6 +376,12 @@ ConnectionPool::Cancellable* ConnPoolImplBase::newStreamImpl(AttachContext& cont
     pending->cancel(Envoy::ConnectionPool::CancelPolicy::CloseExcess);
     onPoolFailure(nullptr, absl::string_view(),
                   ConnectionPool::PoolFailureReason::LocalConnectionFailure, context);
+    return nullptr;
+  } else if (result == ConnectionResult::LoadShed) {
+    ENVOY_LOG(debug, "result == ConnectionResult:LoadShed");
+    pending->cancel(Envoy::ConnectionPool::CancelPolicy::CloseExcess);
+    onPoolFailure(nullptr, absl::string_view(), ConnectionPool::PoolFailureReason::Overflow,
+                  context);
     return nullptr;
   }
   return pending;

--- a/source/common/conn_pool/conn_pool_base.h
+++ b/source/common/conn_pool/conn_pool_base.h
@@ -3,6 +3,7 @@
 #include "envoy/common/conn_pool.h"
 #include "envoy/event/dispatcher.h"
 #include "envoy/network/connection.h"
+#include "envoy/server/overload/overload_manager.h"
 #include "envoy/stats/timespan.h"
 #include "envoy/upstream/cluster_manager.h"
 
@@ -183,7 +184,8 @@ public:
                    Event::Dispatcher& dispatcher,
                    const Network::ConnectionSocket::OptionsSharedPtr& options,
                    const Network::TransportSocketOptionsConstSharedPtr& transport_socket_options,
-                   Upstream::ClusterConnectivityState& state);
+                   Upstream::ClusterConnectivityState& state,
+                   Server::OverloadManager& overload_manager);
   virtual ~ConnPoolImplBase();
 
   void deleteIsPendingImpl();
@@ -323,6 +325,7 @@ protected:
     ShouldNotConnect,
     NoConnectionRateLimited,
     CreatedButRateLimited,
+    LoadShed,
   };
   // Creates up to 3 connections, based on the preconnect ratio.
   // Returns the ConnectionResult of the last attempt.
@@ -415,6 +418,7 @@ private:
 
   Event::SchedulableCallbackPtr upstream_ready_cb_;
   Common::DebugRecursionChecker recursion_checker_;
+  Server::LoadShedPoint* create_new_connection_load_shed_{nullptr};
 };
 
 } // namespace ConnectionPool

--- a/source/common/http/conn_pool_base.cc
+++ b/source/common/http/conn_pool_base.cc
@@ -46,10 +46,10 @@ HttpConnPoolImplBase::HttpConnPoolImplBase(
     Event::Dispatcher& dispatcher, const Network::ConnectionSocket::OptionsSharedPtr& options,
     const Network::TransportSocketOptionsConstSharedPtr& transport_socket_options,
     Random::RandomGenerator& random_generator, Upstream::ClusterConnectivityState& state,
-    std::vector<Http::Protocol> protocols)
+    std::vector<Http::Protocol> protocols, Server::OverloadManager& overload_manager)
     : Envoy::ConnectionPool::ConnPoolImplBase(
           host, priority, dispatcher, options,
-          wrapTransportSocketOptions(transport_socket_options, protocols), state),
+          wrapTransportSocketOptions(transport_socket_options, protocols), state, overload_manager),
       random_generator_(random_generator) {
   ASSERT(!protocols.empty());
 }

--- a/source/common/http/conn_pool_base.h
+++ b/source/common/http/conn_pool_base.h
@@ -54,7 +54,7 @@ public:
       Event::Dispatcher& dispatcher, const Network::ConnectionSocket::OptionsSharedPtr& options,
       const Network::TransportSocketOptionsConstSharedPtr& transport_socket_options,
       Random::RandomGenerator& random_generator, Upstream::ClusterConnectivityState& state,
-      std::vector<Http::Protocol> protocols);
+      std::vector<Http::Protocol> protocols, Server::OverloadManager& overload_manager);
   ~HttpConnPoolImplBase() override;
 
   // Event::DeferredDeletable
@@ -164,10 +164,11 @@ public:
       const Network::TransportSocketOptionsConstSharedPtr& transport_socket_options,
       Random::RandomGenerator& random_generator, Upstream::ClusterConnectivityState& state,
       CreateClientFn client_fn, CreateCodecFn codec_fn, std::vector<Http::Protocol> protocols,
+      Server::OverloadManager& overload_manager,
       absl::optional<Http::HttpServerPropertiesCache::Origin> origin = absl::nullopt,
       Http::HttpServerPropertiesCacheSharedPtr cache = nullptr)
       : HttpConnPoolImplBase(host, priority, dispatcher, options, transport_socket_options,
-                             random_generator, state, protocols),
+                             random_generator, state, protocols, overload_manager),
         codec_fn_(codec_fn), client_fn_(client_fn), protocol_(protocols[0]), cache_(cache) {
     setOrigin(origin);
     ASSERT(protocols.size() == 1);

--- a/source/common/http/conn_pool_grid.h
+++ b/source/common/http/conn_pool_grid.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "envoy/server/overload/overload_manager.h"
+
 #include "source/common/http/conn_pool_base.h"
 #include "source/common/http/http3/conn_pool.h"
 #include "source/common/http/http_server_properties_cache_impl.h"
@@ -185,7 +187,8 @@ public:
                    HttpServerPropertiesCacheSharedPtr alternate_protocols,
                    ConnectivityOptions connectivity_options, Quic::QuicStatNames& quic_stat_names,
                    Stats::Scope& scope, Http::PersistentQuicInfo& quic_info,
-                   OptRef<Quic::EnvoyQuicNetworkObserverRegistry> network_observer_registry);
+                   OptRef<Quic::EnvoyQuicNetworkObserverRegistry> network_observer_registry,
+                   Server::OverloadManager& overload_manager);
   ~ConnectivityGrid() override;
 
   // Event::DeferredDeletable
@@ -288,6 +291,7 @@ private:
 
   Http::PersistentQuicInfo& quic_info_;
   Upstream::ResourcePriority priority_;
+  Server::OverloadManager& overload_manager_;
 
   // True iff this pool is draining. No new streams or connections should be created
   // in this state.

--- a/source/common/http/http1/conn_pool.cc
+++ b/source/common/http/http1/conn_pool.cc
@@ -9,6 +9,7 @@
 #include "envoy/event/timer.h"
 #include "envoy/http/codec.h"
 #include "envoy/http/header_map.h"
+#include "envoy/server/overload/overload_manager.h"
 #include "envoy/upstream/upstream.h"
 
 #include "source/common/http/codec_client.h"
@@ -96,7 +97,8 @@ allocateConnPool(Event::Dispatcher& dispatcher, Random::RandomGenerator& random_
                  Upstream::HostConstSharedPtr host, Upstream::ResourcePriority priority,
                  const Network::ConnectionSocket::OptionsSharedPtr& options,
                  const Network::TransportSocketOptionsConstSharedPtr& transport_socket_options,
-                 Upstream::ClusterConnectivityState& state) {
+                 Upstream::ClusterConnectivityState& state,
+                 Server::OverloadManager& overload_manager) {
   return std::make_unique<FixedHttpConnPoolImpl>(
       std::move(host), std::move(priority), dispatcher, options, transport_socket_options,
       random_generator, state,
@@ -109,7 +111,7 @@ allocateConnPool(Event::Dispatcher& dispatcher, Random::RandomGenerator& random_
             pool->dispatcher(), pool->randomGenerator(), pool->transportSocketOptions())};
         return codec;
       },
-      std::vector<Protocol>{Protocol::Http11}, absl::nullopt, nullptr);
+      std::vector<Protocol>{Protocol::Http11}, overload_manager, absl::nullopt, nullptr);
 }
 
 } // namespace Http1

--- a/source/common/http/http1/conn_pool.h
+++ b/source/common/http/http1/conn_pool.h
@@ -2,6 +2,7 @@
 
 #include "envoy/event/timer.h"
 #include "envoy/http/codec.h"
+#include "envoy/server/overload/overload_manager.h"
 #include "envoy/upstream/upstream.h"
 
 #include "source/common/http/codec_wrappers.h"
@@ -73,7 +74,8 @@ allocateConnPool(Event::Dispatcher& dispatcher, Random::RandomGenerator& random_
                  Upstream::HostConstSharedPtr host, Upstream::ResourcePriority priority,
                  const Network::ConnectionSocket::OptionsSharedPtr& options,
                  const Network::TransportSocketOptionsConstSharedPtr& transport_socket_options,
-                 Upstream::ClusterConnectivityState& state);
+                 Upstream::ClusterConnectivityState& state,
+                 Server::OverloadManager& overload_manager);
 
 } // namespace Http1
 } // namespace Http

--- a/source/common/http/http2/conn_pool.cc
+++ b/source/common/http/http2/conn_pool.cc
@@ -3,6 +3,7 @@
 #include <cstdint>
 
 #include "envoy/event/dispatcher.h"
+#include "envoy/server/overload/overload_manager.h"
 #include "envoy/upstream/upstream.h"
 
 #include "source/common/http/http2/codec_impl.h"
@@ -49,6 +50,7 @@ allocateConnPool(Event::Dispatcher& dispatcher, Random::RandomGenerator& random_
                  const Network::ConnectionSocket::OptionsSharedPtr& options,
                  const Network::TransportSocketOptionsConstSharedPtr& transport_socket_options,
                  Upstream::ClusterConnectivityState& state,
+                 Server::OverloadManager& overload_manager,
                  absl::optional<HttpServerPropertiesCache::Origin> origin,
                  Http::HttpServerPropertiesCacheSharedPtr cache) {
   return std::make_unique<FixedHttpConnPoolImpl>(
@@ -62,7 +64,7 @@ allocateConnPool(Event::Dispatcher& dispatcher, Random::RandomGenerator& random_
             pool->dispatcher(), pool->randomGenerator(), pool->transportSocketOptions())};
         return codec;
       },
-      std::vector<Protocol>{Protocol::Http2}, origin, cache);
+      std::vector<Protocol>{Protocol::Http2}, overload_manager, origin, cache);
 }
 
 } // namespace Http2

--- a/source/common/http/http2/conn_pool.h
+++ b/source/common/http/http2/conn_pool.h
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 
+#include "envoy/server/overload/overload_manager.h"
 #include "envoy/upstream/upstream.h"
 
 #include "source/common/http/codec_client.h"
@@ -34,6 +35,7 @@ allocateConnPool(Event::Dispatcher& dispatcher, Random::RandomGenerator& random_
                  const Network::ConnectionSocket::OptionsSharedPtr& options,
                  const Network::TransportSocketOptionsConstSharedPtr& transport_socket_options,
                  Upstream::ClusterConnectivityState& state,
+                 Server::OverloadManager& overload_manager,
                  absl::optional<HttpServerPropertiesCache::Origin> origin = absl::nullopt,
                  Http::HttpServerPropertiesCacheSharedPtr http_server_properties_cache = nullptr);
 

--- a/source/common/http/http3/conn_pool.h
+++ b/source/common/http/http3/conn_pool.h
@@ -5,6 +5,7 @@
 
 #include "envoy/common/optref.h"
 #include "envoy/http/persistent_quic_info.h"
+#include "envoy/server/overload/overload_manager.h"
 #include "envoy/upstream/upstream.h"
 
 #include "source/common/http/codec_client.h"
@@ -150,7 +151,7 @@ public:
                     OptRef<PoolConnectResultCallback> connect_callback,
                     Http::PersistentQuicInfo& quic_info,
                     OptRef<Quic::EnvoyQuicNetworkObserverRegistry> network_observer_registry,
-                    bool attempt_happy_eyeballs = false);
+                    Server::OverloadManager& overload_manager, bool attempt_happy_eyeballs = false);
 
   ~Http3ConnPoolImpl() override;
   ConnectionPool::Cancellable* newStream(Http::ResponseDecoder& response_decoder,
@@ -200,7 +201,7 @@ allocateConnPool(Event::Dispatcher& dispatcher, Random::RandomGenerator& random_
                  OptRef<PoolConnectResultCallback> connect_callback,
                  Http::PersistentQuicInfo& quic_info,
                  OptRef<Quic::EnvoyQuicNetworkObserverRegistry> network_observer_registry,
-                 bool attempt_happy_eyeballs = false);
+                 Server::OverloadManager& overload_manager, bool attempt_happy_eyeballs = false);
 
 } // namespace Http3
 } // namespace Http

--- a/source/common/http/mixed_conn_pool.h
+++ b/source/common/http/mixed_conn_pool.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "envoy/http/http_server_properties_cache.h"
+#include "envoy/server/overload/overload_manager.h"
 
 #include "source/common/http/conn_pool_base.h"
 
@@ -17,10 +18,11 @@ public:
       const Network::TransportSocketOptionsConstSharedPtr& transport_socket_options,
       Upstream::ClusterConnectivityState& state,
       absl::optional<HttpServerPropertiesCache::Origin> origin,
-      Http::HttpServerPropertiesCacheSharedPtr http_server_properties_cache)
+      Http::HttpServerPropertiesCacheSharedPtr http_server_properties_cache,
+      Server::OverloadManager& overload_manager)
       : HttpConnPoolImplBase(std::move(host), std::move(priority), dispatcher, options,
                              transport_socket_options, random_generator, state,
-                             {Protocol::Http2, Protocol::Http11}),
+                             {Protocol::Http2, Protocol::Http11}, overload_manager),
         http_server_properties_cache_(http_server_properties_cache), origin_(origin) {}
 
   Envoy::ConnectionPool::ActiveClientPtr instantiateActiveClient() override;

--- a/source/common/tcp/conn_pool.h
+++ b/source/common/tcp/conn_pool.h
@@ -7,6 +7,7 @@
 #include "envoy/event/timer.h"
 #include "envoy/network/connection.h"
 #include "envoy/network/filter.h"
+#include "envoy/server/overload/overload_manager.h"
 #include "envoy/stats/timespan.h"
 #include "envoy/tcp/conn_pool.h"
 #include "envoy/upstream/upstream.h"
@@ -140,9 +141,10 @@ public:
                const Network::ConnectionSocket::OptionsSharedPtr& options,
                Network::TransportSocketOptionsConstSharedPtr transport_socket_options,
                Upstream::ClusterConnectivityState& state,
-               absl::optional<std::chrono::milliseconds> idle_timeout)
+               absl::optional<std::chrono::milliseconds> idle_timeout,
+               Server::OverloadManager& overload_manager)
       : Envoy::ConnectionPool::ConnPoolImplBase(host, priority, dispatcher, options,
-                                                transport_socket_options, state),
+                                                transport_socket_options, state, overload_manager),
         idle_timeout_(idle_timeout) {}
   ~ConnPoolImpl() override { destructAllConnections(); }
 

--- a/test/common/grpc/grpc_client_integration_test_harness.h
+++ b/test/common/grpc/grpc_client_integration_test_harness.h
@@ -391,9 +391,9 @@ public:
     EXPECT_CALL(*mock_host_, cluster())
         .WillRepeatedly(ReturnRef(*cm_.thread_local_cluster_.cluster_.info_));
     EXPECT_CALL(*mock_host_description_, locality()).WillRepeatedly(ReturnRef(host_locality_));
-    http_conn_pool_ = Http::Http2::allocateConnPool(*dispatcher_, api_->randomGenerator(),
-                                                    host_ptr_, Upstream::ResourcePriority::Default,
-                                                    nullptr, nullptr, state_);
+    http_conn_pool_ = Http::Http2::allocateConnPool(
+        *dispatcher_, api_->randomGenerator(), host_ptr_, Upstream::ResourcePriority::Default,
+        nullptr, nullptr, state_, server_factory_context_.overloadManager());
     EXPECT_CALL(cm_.thread_local_cluster_, chooseHost(_)).WillRepeatedly(Invoke([this] {
       return Upstream::HostSelectionResponse{cm_.thread_local_cluster_.lb_.host_};
     }));

--- a/test/common/http/http1/conn_pool_test.cc
+++ b/test/common/http/http1/conn_pool_test.cc
@@ -20,6 +20,7 @@
 #include "test/mocks/http/mocks.h"
 #include "test/mocks/network/mocks.h"
 #include "test/mocks/runtime/mocks.h"
+#include "test/mocks/server/overload_manager.h"
 #include "test/mocks/upstream/cluster_info.h"
 #include "test/mocks/upstream/transport_socket_match.h"
 #include "test/test_common/printers.h"
@@ -60,7 +61,8 @@ public:
   ConnPoolImplForTest(Event::MockDispatcher& dispatcher,
                       Upstream::ClusterInfoConstSharedPtr cluster,
                       Random::RandomGenerator& random_generator,
-                      Event::MockSchedulableCallback* upstream_ready_cb)
+                      Event::MockSchedulableCallback* upstream_ready_cb,
+                      Server::MockOverloadManager& overload_manager)
       : FixedHttpConnPoolImpl(
             Upstream::makeTestHost(cluster, "tcp://127.0.0.1:9000", dispatcher.timeSource()),
             Upstream::ResourcePriority::Default, dispatcher, nullptr, nullptr, random_generator,
@@ -71,7 +73,7 @@ public:
             [](Upstream::Host::CreateConnectionData&, HttpConnPoolImplBase*) {
               return nullptr; // Not used: createCodecClient overloaded.
             },
-            std::vector<Protocol>{Protocol::Http11}),
+            std::vector<Protocol>{Protocol::Http11}, absl::nullopt, nullptr, overload_manager),
         api_(Api::createApiForTest()), mock_dispatcher_(dispatcher),
         mock_upstream_ready_cb_(upstream_ready_cb) {}
 
@@ -151,7 +153,7 @@ public:
   Http1ConnPoolImplTest()
       : upstream_ready_cb_(new Event::MockSchedulableCallback(&dispatcher_)),
         conn_pool_(std::make_unique<ConnPoolImplForTest>(dispatcher_, cluster_, random_,
-                                                         upstream_ready_cb_)) {}
+                                                         upstream_ready_cb_, overload_manager_)) {}
 
   ~Http1ConnPoolImplTest() override {
     EXPECT_EQ("", TestUtility::nonZeroedGauges(cluster_->stats_store_.gauges()));
@@ -163,6 +165,7 @@ public:
   Event::MockSchedulableCallback* upstream_ready_cb_;
   std::unique_ptr<ConnPoolImplForTest> conn_pool_;
   NiceMock<Runtime::MockLoader> runtime_;
+  NiceMock<Server::MockOverloadManager> overload_manager_;
 };
 
 /**
@@ -316,8 +319,8 @@ TEST_F(Http1ConnPoolImplTest, VerifyAlpnFallback) {
   // our test transport socket factory.
   // Recreate this to refresh expectation that the callback is scheduled and saved.
   new Event::MockSchedulableCallback(&dispatcher_);
-  conn_pool_ =
-      std::make_unique<ConnPoolImplForTest>(dispatcher_, cluster_, random_, upstream_ready_cb_);
+  conn_pool_ = std::make_unique<ConnPoolImplForTest>(dispatcher_, cluster_, random_,
+                                                     upstream_ready_cb_, overload_manager_);
   NiceMock<MockResponseDecoder> outer_decoder;
   ConnPoolCallbacks callbacks;
   conn_pool_->expectClientCreate(Protocol::Http11);
@@ -1117,7 +1120,7 @@ public:
   Http1ConnPoolDestructImplTest()
       : upstream_ready_cb_(new MockDestructSchedulableCallback(&dispatcher_)),
         conn_pool_(std::make_unique<ConnPoolImplForTest>(dispatcher_, cluster_, random_,
-                                                         upstream_ready_cb_)) {}
+                                                         upstream_ready_cb_, overload_manager_)) {}
 
   ~Http1ConnPoolDestructImplTest() override {
     EXPECT_EQ("", TestUtility::nonZeroedGauges(cluster_->stats_store_.gauges()));
@@ -1129,6 +1132,7 @@ public:
   MockDestructSchedulableCallback* upstream_ready_cb_;
   std::unique_ptr<ConnPoolImplForTest> conn_pool_;
   NiceMock<Runtime::MockLoader> runtime_;
+  NiceMock<Server::MockOverloadManager> overload_manager_;
 };
 
 // Regression test for use after free when dispatcher executes onUpstreamReady after connection pool

--- a/test/common/http/http3/conn_pool_test.cc
+++ b/test/common/http/http3/conn_pool_test.cc
@@ -9,6 +9,7 @@
 #include "test/common/upstream/utility.h"
 #include "test/mocks/common.h"
 #include "test/mocks/event/mocks.h"
+#include "test/mocks/server/overload_manager.h"
 #include "test/mocks/server/server_factory_context.h"
 #include "test/mocks/ssl/mocks.h"
 #include "test/mocks/upstream/cluster_info.h"
@@ -70,7 +71,7 @@ public:
         allocateConnPool(dispatcher_, random_, host_, Upstream::ResourcePriority::Default, options,
                          transport_options, state_, quic_stat_names_, {}, *store_.rootScope(),
                          makeOptRef<PoolConnectResultCallback>(connect_result_callback_),
-                         quic_info_, {observers_}, happy_eyeballs_);
+                         quic_info_, {observers_}, happy_eyeballs_, overload_manager_);
     EXPECT_EQ(3000, Http3ConnPoolImplPeer::getServerId(*pool_).port());
   }
 
@@ -84,6 +85,7 @@ public:
   Upstream::HostSharedPtr host_{new NiceMock<Upstream::MockHost>};
   NiceMock<Random::MockRandomGenerator> random_;
   Upstream::ClusterConnectivityState state_;
+  NiceMock<Server::MockOverloadManager> overload_manager_;
   Network::Address::InstanceConstSharedPtr test_address_ =
       *Network::Utility::resolveUrl("tcp://127.0.0.1:3000");
   std::shared_ptr<Upstream::HostDescription::AddressVector> address_list_{

--- a/test/common/tcp/conn_pool_test.cc
+++ b/test/common/tcp/conn_pool_test.cc
@@ -12,6 +12,7 @@
 #include "test/mocks/event/mocks.h"
 #include "test/mocks/network/mocks.h"
 #include "test/mocks/runtime/mocks.h"
+#include "test/mocks/server/overload_manager.h"
 #include "test/mocks/ssl/mocks.h"
 #include "test/mocks/tcp/mocks.h"
 #include "test/mocks/upstream/cluster_info.h"
@@ -173,6 +174,7 @@ public:
   Network::ConnectionSocket::OptionsSharedPtr options_;
   Network::TransportSocketOptionsConstSharedPtr transport_socket_options_;
   bool has_idle_timers_{false};
+  NiceMock<Server::MockOverloadManager> overload_manager_;
 
 protected:
   class ConnPoolImplForTest : public ConnPoolImpl {
@@ -180,9 +182,9 @@ protected:
     ConnPoolImplForTest(Event::MockDispatcher& dispatcher, Upstream::HostSharedPtr host,
                         Network::ConnectionSocket::OptionsSharedPtr options,
                         Network::TransportSocketOptionsConstSharedPtr transport_socket_options,
-                        ConnPoolBase& parent)
+                        ConnPoolBase& parent, Server::MockOverloadManager& overload_manager)
         : ConnPoolImpl(dispatcher, host, Upstream::ResourcePriority::Default, options,
-                       transport_socket_options, state_, absl::nullopt),
+                       transport_socket_options, state_, absl::nullopt, overload_manager),
           parent_(parent) {}
 
     void onConnReleased(Envoy::ConnectionPool::ActiveClient& client) override {
@@ -213,8 +215,8 @@ ConnPoolBase::ConnPoolBase(Event::MockDispatcher& dispatcher, Upstream::HostShar
                            Network::TransportSocketOptionsConstSharedPtr transport_socket_options)
     : mock_dispatcher_(dispatcher), mock_upstream_ready_cb_(upstream_ready_cb), options_(options),
       transport_socket_options_(transport_socket_options) {
-  conn_pool_ = std::make_unique<ConnPoolImplForTest>(dispatcher, host, options,
-                                                     transport_socket_options, *this);
+  conn_pool_ = std::make_unique<ConnPoolImplForTest>(
+      dispatcher, host, options, transport_socket_options, *this, overload_manager_);
 }
 
 void ConnPoolBase::expectEnableUpstreamReady(bool run) {

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -2300,7 +2300,7 @@ TEST_P(ClusterManagerLifecycleTest, DynamicAddRemove) {
   EXPECT_EQ(1UL, cluster_manager_->clusters().active_clusters_.size());
   Http::ConnectionPool::MockInstance* cp = new Http::ConnectionPool::MockInstance();
   Http::ConnectionPool::Instance::IdleCb idle_cb;
-  EXPECT_CALL(factory_, allocateConnPool_(_, _, _, _, _, _)).WillOnce(Return(cp));
+  EXPECT_CALL(factory_, allocateConnPool_(_, _, _, _, _, _, _)).WillOnce(Return(cp));
   EXPECT_CALL(*cp, addIdleCallback(_)).WillOnce(SaveArg<0>(&idle_cb));
   EXPECT_EQ(
       cp,
@@ -2524,7 +2524,7 @@ TEST_P(ClusterManagerLifecycleTest, CloseHttpConnectionsOnHealthFailure) {
         }));
     create(parseBootstrapFromV3Json(json));
 
-    EXPECT_CALL(factory_, allocateConnPool_(_, _, _, _, _, _)).WillOnce(Return(cp1));
+    EXPECT_CALL(factory_, allocateConnPool_(_, _, _, _, _, _, _)).WillOnce(Return(cp1));
     cluster_manager_->getThreadLocalCluster("some_cluster")
         ->httpConnPool(
             cluster_manager_->getThreadLocalCluster("some_cluster")->chooseHost(nullptr).host,
@@ -2540,7 +2540,7 @@ TEST_P(ClusterManagerLifecycleTest, CloseHttpConnectionsOnHealthFailure) {
     test_host->healthFlagSet(Host::HealthFlag::FAILED_OUTLIER_CHECK);
     outlier_detector.runCallbacks(test_host);
 
-    EXPECT_CALL(factory_, allocateConnPool_(_, _, _, _, _, _)).WillOnce(Return(cp2));
+    EXPECT_CALL(factory_, allocateConnPool_(_, _, _, _, _, _, _)).WillOnce(Return(cp2));
     cluster_manager_->getThreadLocalCluster("some_cluster")
         ->httpConnPool(
             cluster_manager_->getThreadLocalCluster("some_cluster")->chooseHost(nullptr).host,
@@ -2599,7 +2599,7 @@ TEST_P(ClusterManagerLifecycleTest,
       }));
   create(parseBootstrapFromV3Json(json));
 
-  EXPECT_CALL(factory_, allocateConnPool_(_, _, _, _, _, _)).WillOnce(Return(cp1));
+  EXPECT_CALL(factory_, allocateConnPool_(_, _, _, _, _, _, _)).WillOnce(Return(cp1));
   cluster_manager_->getThreadLocalCluster("some_cluster")
       ->httpConnPool(test_host, ResourcePriority::Default, Http::Protocol::Http11, nullptr);
 
@@ -2651,7 +2651,7 @@ TEST_P(ClusterManagerLifecycleTest, CloseHttpConnectionsAndDeletePoolOnHealthFai
       }));
   create(parseBootstrapFromV3Json(json));
 
-  EXPECT_CALL(factory_, allocateConnPool_(_, _, _, _, _, _)).WillOnce(Return(cp1));
+  EXPECT_CALL(factory_, allocateConnPool_(_, _, _, _, _, _, _)).WillOnce(Return(cp1));
   cluster_manager_->getThreadLocalCluster("some_cluster")
       ->httpConnPool(test_host, ResourcePriority::Default, Http::Protocol::Http11, nullptr);
 
@@ -2915,7 +2915,7 @@ TEST_P(ClusterManagerLifecycleTest, DynamicHostRemove) {
   EXPECT_CALL(initialized, ready());
   cluster_manager_->setInitializedCb([&]() -> void { initialized.ready(); });
 
-  EXPECT_CALL(factory_, allocateConnPool_(_, _, _, _, _, _))
+  EXPECT_CALL(factory_, allocateConnPool_(_, _, _, _, _, _, _))
       .Times(4)
       .WillRepeatedly(ReturnNew<NiceMock<Http::ConnectionPool::MockInstance>>());
 
@@ -3083,7 +3083,7 @@ TEST_P(ClusterManagerLifecycleTest, DynamicHostRemoveWithTls) {
   EXPECT_CALL(initialized, ready());
   cluster_manager_->setInitializedCb([&]() -> void { initialized.ready(); });
 
-  EXPECT_CALL(factory_, allocateConnPool_(_, _, _, _, _, _))
+  EXPECT_CALL(factory_, allocateConnPool_(_, _, _, _, _, _, _))
       .Times(4)
       .WillRepeatedly(ReturnNew<NiceMock<Http::ConnectionPool::MockInstance>>());
 
@@ -4034,7 +4034,7 @@ TEST_P(ClusterManagerLifecycleTest, DynamicHostRemoveDefaultPriority) {
   dns_callback(Network::DnsResolver::ResolutionStatus::Completed, "",
                TestUtility::makeDnsResponse({"127.0.0.2"}));
 
-  EXPECT_CALL(factory_, allocateConnPool_(_, _, _, _, _, _))
+  EXPECT_CALL(factory_, allocateConnPool_(_, _, _, _, _, _, _))
       .WillOnce(ReturnNew<NiceMock<Http::ConnectionPool::MockInstance>>());
 
   EXPECT_CALL(factory_, allocateTcpConnPool_)
@@ -4132,7 +4132,7 @@ TEST_P(ClusterManagerLifecycleTest, ConnPoolDestroyWithDraining) {
 
   MockConnPoolWithDestroy* mock_cp = new MockConnPoolWithDestroy();
   Http::ConnectionPool::Instance::IdleCb drained_cb;
-  EXPECT_CALL(factory_, allocateConnPool_(_, _, _, _, _, _)).WillOnce(Return(mock_cp));
+  EXPECT_CALL(factory_, allocateConnPool_(_, _, _, _, _, _, _)).WillOnce(Return(mock_cp));
   EXPECT_CALL(*mock_cp, addIdleCallback(_)).WillOnce(SaveArg<0>(&drained_cb));
   EXPECT_CALL(*mock_cp, drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainAndDelete));
 
@@ -4738,7 +4738,7 @@ TEST_F(ClusterManagerImplTest, UpstreamSocketOptionsPassedToConnPool) {
       Network::SocketOptionFactory::buildIpTransparentOptions();
 
   EXPECT_CALL(context, upstreamSocketOptions()).WillOnce(Return(options_to_return));
-  EXPECT_CALL(factory_, allocateConnPool_(_, _, _, _, _, _)).WillOnce(Return(to_create));
+  EXPECT_CALL(factory_, allocateConnPool_(_, _, _, _, _, _, _)).WillOnce(Return(to_create));
 
   auto opt_cp =
       cluster_manager_->getThreadLocalCluster("cluster_1")
@@ -4770,7 +4770,7 @@ TEST_F(ClusterManagerImplTest, UpstreamSocketOptionsUsedInConnPoolHash) {
       new NiceMock<Http::ConnectionPool::MockInstance>();
 
   EXPECT_CALL(context1, upstreamSocketOptions()).WillOnce(Return(options1));
-  EXPECT_CALL(factory_, allocateConnPool_(_, _, _, _, _, _)).WillOnce(Return(to_create1));
+  EXPECT_CALL(factory_, allocateConnPool_(_, _, _, _, _, _, _)).WillOnce(Return(to_create1));
   Http::ConnectionPool::Instance* cp1 = HttpPoolDataPeer::getPool(
       cluster_manager_->getThreadLocalCluster("cluster_1")
           ->httpConnPool(
@@ -4779,7 +4779,7 @@ TEST_F(ClusterManagerImplTest, UpstreamSocketOptionsUsedInConnPoolHash) {
   EXPECT_NE(nullptr, cp1);
 
   EXPECT_CALL(context2, upstreamSocketOptions()).WillOnce(Return(options2));
-  EXPECT_CALL(factory_, allocateConnPool_(_, _, _, _, _, _)).WillOnce(Return(to_create2));
+  EXPECT_CALL(factory_, allocateConnPool_(_, _, _, _, _, _, _)).WillOnce(Return(to_create2));
   Http::ConnectionPool::Instance* cp2 = HttpPoolDataPeer::getPool(
       cluster_manager_->getThreadLocalCluster("cluster_1")
           ->httpConnPool(
@@ -4818,7 +4818,7 @@ TEST_F(ClusterManagerImplTest, UpstreamSocketOptionsNullIsOkay) {
   Network::Socket::OptionsSharedPtr options_to_return = nullptr;
 
   EXPECT_CALL(context, upstreamSocketOptions()).WillOnce(Return(options_to_return));
-  EXPECT_CALL(factory_, allocateConnPool_(_, _, _, _, _, _)).WillOnce(Return(to_create));
+  EXPECT_CALL(factory_, allocateConnPool_(_, _, _, _, _, _, _)).WillOnce(Return(to_create));
 
   auto opt_cp =
       cluster_manager_->getThreadLocalCluster("cluster_1")
@@ -4835,7 +4835,7 @@ TEST_F(ClusterManagerImplTest, HttpPoolDataForwardsCallsToConnectionPool) {
   Http::ConnectionPool::MockInstance* pool_mock = new Http::ConnectionPool::MockInstance();
   Network::Socket::OptionsSharedPtr options_to_return = nullptr;
 
-  EXPECT_CALL(factory_, allocateConnPool_(_, _, _, _, _, _)).WillOnce(Return(pool_mock));
+  EXPECT_CALL(factory_, allocateConnPool_(_, _, _, _, _, _, _)).WillOnce(Return(pool_mock));
   EXPECT_CALL(*pool_mock, addIdleCallback(_));
 
   auto opt_cp =
@@ -6017,7 +6017,7 @@ TEST_P(ClusterManagerLifecycleTest, DrainConnectionsPredicate) {
       123, absl::nullopt, 100);
 
   // Using RR LB get a pool for each host.
-  EXPECT_CALL(factory_, allocateConnPool_(_, _, _, _, _, _))
+  EXPECT_CALL(factory_, allocateConnPool_(_, _, _, _, _, _, _))
       .Times(2)
       .WillRepeatedly(ReturnNew<NiceMock<Http::ConnectionPool::MockInstance>>());
   Http::ConnectionPool::MockInstance* cp1 = HttpPoolDataPeer::getPool(
@@ -6098,7 +6098,7 @@ TEST_P(ClusterManagerLifecycleTest, ConnPoolsDrainedOnHostSetChange) {
   EXPECT_EQ(0, factory_.stats_.counter("cluster_manager.cluster_updated_via_merge").value());
   EXPECT_EQ(0, factory_.stats_.counter("cluster_manager.update_merge_cancelled").value());
 
-  EXPECT_CALL(factory_, allocateConnPool_(_, _, _, _, _, _))
+  EXPECT_CALL(factory_, allocateConnPool_(_, _, _, _, _, _, _))
       .Times(3)
       .WillRepeatedly(ReturnNew<NiceMock<Http::ConnectionPool::MockInstance>>());
 
@@ -6225,7 +6225,7 @@ TEST_P(ClusterManagerLifecycleTest, ConnPoolsNotDrainedOnHostSetChange) {
       0, HostSetImpl::partitionHosts(hosts_ptr, HostsPerLocalityImpl::empty()), nullptr, hosts, {},
       123, absl::nullopt, 100);
 
-  EXPECT_CALL(factory_, allocateConnPool_(_, _, _, _, _, _))
+  EXPECT_CALL(factory_, allocateConnPool_(_, _, _, _, _, _, _))
       .Times(1)
       .WillRepeatedly(ReturnNew<NiceMock<Http::ConnectionPool::MockInstance>>());
 
@@ -6300,7 +6300,7 @@ TEST_P(ClusterManagerLifecycleTest, ConnPoolsIdleDeleted) {
 
   {
     auto* cp1 = new NiceMock<Http::ConnectionPool::MockInstance>();
-    EXPECT_CALL(factory_, allocateConnPool_(_, _, _, _, _, _)).WillOnce(Return(cp1));
+    EXPECT_CALL(factory_, allocateConnPool_(_, _, _, _, _, _, _)).WillOnce(Return(cp1));
     std::function<void()> idle_callback;
     EXPECT_CALL(*cp1, addIdleCallback(_)).WillOnce(SaveArg<0>(&idle_callback));
 
@@ -6324,7 +6324,7 @@ TEST_P(ClusterManagerLifecycleTest, ConnPoolsIdleDeleted) {
     idle_callback();
 
     auto* cp2 = new NiceMock<Http::ConnectionPool::MockInstance>();
-    EXPECT_CALL(factory_, allocateConnPool_(_, _, _, _, _, _)).WillOnce(Return(cp2));
+    EXPECT_CALL(factory_, allocateConnPool_(_, _, _, _, _, _, _)).WillOnce(Return(cp2));
     EXPECT_CALL(*cp2, addIdleCallback(_));
 
     // This time we expect cp2 since cp1 will have been destroyed
@@ -6471,7 +6471,7 @@ TEST_F(ClusterManagerImplTest, ConnectionPoolPerDownstreamConnection) {
   for (size_t i = 0; i < 3; ++i) {
     conn_pool_vector.push_back(new Http::ConnectionPool::MockInstance());
     EXPECT_CALL(*conn_pool_vector.back(), addIdleCallback(_));
-    EXPECT_CALL(factory_, allocateConnPool_(_, _, _, _, _, _))
+    EXPECT_CALL(factory_, allocateConnPool_(_, _, _, _, _, _, _))
         .WillOnce(Return(conn_pool_vector.back()));
     EXPECT_CALL(downstream_connection, hashKey)
         .WillOnce(Invoke([i](std::vector<uint8_t>& hash_key) { hash_key.push_back(i); }));
@@ -6551,7 +6551,7 @@ TEST_F(ClusterManagerImplTest, PassDownNetworkObserverRegistryToConnectionPool) 
   auto* pool = new Http::ConnectionPool::MockInstance();
   Quic::EnvoyQuicNetworkObserverRegistry* created_registry = nullptr;
   EXPECT_CALL(*pool, addIdleCallback(_));
-  EXPECT_CALL(factory_, allocateConnPool_(_, _, _, _, _, _))
+  EXPECT_CALL(factory_, allocateConnPool_(_, _, _, _, _, _, _))
       .WillOnce(testing::WithArg<5>(
           Invoke([pool, created_registry_ptr = &created_registry](
                      OptRef<Quic::EnvoyQuicNetworkObserverRegistry> network_observer_registry) {
@@ -6569,7 +6569,7 @@ TEST_F(ClusterManagerImplTest, PassDownNetworkObserverRegistryToConnectionPool) 
 
   pool = new Http::ConnectionPool::MockInstance();
   EXPECT_CALL(*pool, addIdleCallback(_));
-  EXPECT_CALL(factory_, allocateConnPool_(_, _, _, _, _, _))
+  EXPECT_CALL(factory_, allocateConnPool_(_, _, _, _, _, _, _))
       .WillOnce(testing::WithArg<5>(
           Invoke([pool, created_registry](
                      OptRef<Quic::EnvoyQuicNetworkObserverRegistry> network_observer_registry) {
@@ -6928,7 +6928,7 @@ TEST_F(PreconnectTest, PreconnectOff) {
   // With preconnect set to 0, each request for a connection pool will only
   // allocate that conn pool.
   initialize(0);
-  EXPECT_CALL(factory_, allocateConnPool_(_, _, _, _, _, _))
+  EXPECT_CALL(factory_, allocateConnPool_(_, _, _, _, _, _, _))
       .Times(1)
       .WillRepeatedly(ReturnNew<NiceMock<Http::ConnectionPool::MockInstance>>());
   auto http_handle =
@@ -6952,7 +6952,7 @@ TEST_F(PreconnectTest, PreconnectOn) {
   // preconnecting, so create the pool for both the current connection and the
   // anticipated one.
   initialize(1.1);
-  EXPECT_CALL(factory_, allocateConnPool_(_, _, _, _, _, _))
+  EXPECT_CALL(factory_, allocateConnPool_(_, _, _, _, _, _, _))
       .Times(2)
       .WillRepeatedly(ReturnNew<NiceMock<Http::ConnectionPool::MockInstance>>());
   auto http_handle =
@@ -6995,7 +6995,7 @@ TEST_F(PreconnectTest, PreconnectHighHttp) {
   // With preconnect set to 3, the first request will kick off 3 preconnect attempts.
   initialize(3);
   int http_preconnect = 0;
-  EXPECT_CALL(factory_, allocateConnPool_(_, _, _, _, _, _))
+  EXPECT_CALL(factory_, allocateConnPool_(_, _, _, _, _, _, _))
       .Times(4)
       .WillRepeatedly(InvokeWithoutArgs([&]() -> Http::ConnectionPool::Instance* {
         auto* ret = new NiceMock<Http::ConnectionPool::MockInstance>();
@@ -7040,7 +7040,7 @@ TEST_F(PreconnectTest, PreconnectCappedAt3) {
   // With preconnect set to 20, no more than 3 connections will be preconnected.
   initialize(20);
   int http_preconnect = 0;
-  EXPECT_CALL(factory_, allocateConnPool_(_, _, _, _, _, _))
+  EXPECT_CALL(factory_, allocateConnPool_(_, _, _, _, _, _, _))
       .Times(4)
       .WillRepeatedly(InvokeWithoutArgs([&]() -> Http::ConnectionPool::Instance* {
         auto* ret = new NiceMock<Http::ConnectionPool::MockInstance>();
@@ -7079,7 +7079,7 @@ TEST_F(PreconnectTest, PreconnectCappedByMaybePreconnect) {
   // Set preconnect high, and verify preconnecting stops when maybePreconnect returns false.
   initialize(20);
   int http_preconnect_calls = 0;
-  EXPECT_CALL(factory_, allocateConnPool_(_, _, _, _, _, _))
+  EXPECT_CALL(factory_, allocateConnPool_(_, _, _, _, _, _, _))
       .Times(2)
       .WillRepeatedly(InvokeWithoutArgs([&]() -> Http::ConnectionPool::Instance* {
         auto* ret = new NiceMock<Http::ConnectionPool::MockInstance>();

--- a/test/integration/overload_integration_test.cc
+++ b/test/integration/overload_integration_test.cc
@@ -1159,6 +1159,51 @@ TEST_P(LoadShedPointIntegrationTest, HttpDownstreamFilterLoadShed) {
   EXPECT_EQ(response_that_is_proxied->headers().getStatusValue(), "200");
 }
 
+TEST_P(LoadShedPointIntegrationTest, ConnectionPoolNewConnectionLoadShed) {
+  initializeOverloadManager(
+      TestUtility::parseYaml<envoy::config::overload::v3::LoadShedPoint>(R"EOF(
+      name: "envoy.load_shed_points.connection_pool_new_connection"
+      triggers:
+        - name: "envoy.resource_monitors.testonly.fake_resource_monitor"
+          threshold:
+            value: 0.90
+    )EOF"));
+
+  updateResource(0.95);
+  test_server_->waitForGaugeEq(
+      "overload.envoy.load_shed_points.connection_pool_new_connection.scale_percent", 100);
+
+  codec_client_ = makeHttpConnection(makeClientConnection((lookupPort("http"))));
+  auto response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
+  ASSERT_TRUE(response->waitForEndStream());
+  EXPECT_EQ(response->headers().getStatusValue(), "503");
+  codec_client_->close();
+}
+
+TEST_P(LoadShedPointIntegrationTest, ConnectionPoolLoadShedWithExistingConnections) {
+  initializeOverloadManager(
+      TestUtility::parseYaml<envoy::config::overload::v3::LoadShedPoint>(R"EOF(
+      name: "envoy.load_shed_points.connection_pool_new_connection"
+      triggers:
+        - name: "envoy.resource_monitors.testonly.fake_resource_monitor"
+          threshold:
+            value: 0.90
+    )EOF"));
+
+  codec_client_ = makeHttpConnection(makeClientConnection((lookupPort("http"))));
+
+  updateResource(0.95);
+  test_server_->waitForGaugeEq(
+      "overload.envoy.load_shed_points.connection_pool_new_connection.scale_percent", 100);
+
+  auto response2 = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
+  waitForNextUpstreamRequest();
+  upstream_request_->encodeHeaders(default_response_headers_, true);
+  ASSERT_TRUE(response2->waitForEndStream());
+  EXPECT_EQ(response2->headers().getStatusValue(), "200");
+  codec_client_->close();
+}
+
 TEST_P(LoadShedPointIntegrationTest, HttpConnManagerDoesNotShedLoadWhenBypassed) {
   // QUIC uses UDP, not TCP.
   if (downstreamProtocol() == Http::CodecClient::Type::HTTP3) {


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
