### PR TITLE
Explain why not using inet_pton for IPv6 addresses

### DIFF
--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -120,6 +120,8 @@ StatusOr<sockaddr_in> parseV4Address(const std::string& ip_address, uint16_t por
 
 StatusOr<sockaddr_in6> parseV6Address(const std::string& ip_address, uint16_t port) {
   // Parse IPv6 with optional scope using getaddrinfo().
+  // While inet_pton() would be faster and simpler, it does not support IPv6
+  // addresses that specify a scope, e.g. `::%eth0` to listen on only one interface.
   struct addrinfo hints;
   memset(&hints, 0, sizeof(hints));
   struct addrinfo* res = nullptr;


### PR DESCRIPTION
Commit Message: Explain why not using inet_pton for IPv6 addresses
Additional Description: It took me a while to figure out why we're using the much more complicated and less performant `getaddrinfo()` for `parseV6Address`, rather than `inet_pton`, which google searches generally recommend using. Even the discussion history on the responsible commits didn't really clarify, and `scope` as an explanation was insufficient because the word is way too overloaded. This PR adds a couple of lines of comments that make the reason for this choice clear for the next confused person.
Risk Level: None, change is comment-only.
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
