### PR TITLE
Variable names in comments are not spelling errors

### DIFF
--- a/tools/spelling/check_spelling_pedantic.py
+++ b/tools/spelling/check_spelling_pedantic.py
@@ -88,6 +88,10 @@ QUOTED_WORD = re.compile(r'((["\'])[A-Za-z0-9.:-]+(\2))|(\*[A-Za-z0-9.:-]+\*)')
 # Backtick-quoted words that look like code. Note the overlap with RST_LINK.
 QUOTED_EXPR = re.compile(r'`[A-Za-z0-9:()<>_.,/{}\[\]&*-]+`')
 
+# Words with underscores are likely variable names and as such
+# should not be spell checked.
+UNDERSCORE_EXPR = re.compile(r'_[A-Za-z0-9_]*|[A-Za-z][A-Za-z0-9]*_[A-Za-z0-9_]*')
+
 # Tuple expressions like (abc, def).
 TUPLE_EXPR = re.compile(r'\([A-Za-z0-9]+(?:, *[A-Za-z0-9]+){1,}\)')
 
@@ -418,6 +422,8 @@ def check_comment(checker, offset, comment):
     comment, found = mask_with_regex(comment, RST_LINK, 0)
     if not found:
         comment, _ = mask_with_regex(comment, QUOTED_EXPR, 0)
+
+    comment, _ = mask_with_regex(comment, UNDERSCORE_EXPR, 0)
 
     comment, _ = mask_with_regex(comment, TUPLE_EXPR, 0)
 

--- a/tools/testdata/spelling/valid
+++ b/tools/testdata/spelling/valid
@@ -9,3 +9,6 @@ Heer too.
 /**
  * As well as this.
  */
+
+// An underscore should negate spell checking as it
+// implies a variable name, e.g. ai_flags should be fine.


### PR DESCRIPTION
Commit Message: Variable names in comments are not spelling errors
Additional Description: Having the spellchecker complain about a comment mentioning ai_flags is annoying.
Risk Level: None.
Testing: Yes.
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
