### PR TITLE
tools: simplify the format api to remove unnecessary xfrom related logic

### DIFF
--- a/tools/proto_format/BUILD
+++ b/tools/proto_format/BUILD
@@ -1,7 +1,5 @@
 load("@aspect_bazel_lib//lib:jq.bzl", "jq")
 load("@envoy_repo//:path.bzl", "PATH")
-load("@rules_pkg//pkg:mappings.bzl", "pkg_files", "strip_prefix")
-load("@rules_pkg//pkg:pkg.bzl", "pkg_tar")
 load("@rules_python//python:defs.bzl", "py_binary")
 load("//tools/base:envoy_python.bzl", "envoy_genjson", "envoy_py_data", "envoy_pytool_binary")
 load("//tools/python:namespace.bzl", "envoy_py_namespace")

--- a/tools/proto_format/format_api.py
+++ b/tools/proto_format/format_api.py
@@ -3,7 +3,6 @@
 # Mangle protoxform and protoprint artifacts.
 
 import argparse
-from collections import defaultdict
 import os
 import pathlib
 import re
@@ -231,7 +230,7 @@ def find_pkgs(package_version_status, api_root):
     return set([os.path.dirname(p)[len(api_root) + 1:] for p in api_protos])
 
 
-def format_api(mode, outfile, xformed, printed, build_file):
+def format_api(mode, outfile, printed, build_file):
 
     with tempfile.TemporaryDirectory() as tmp:
         dst_dir = pathlib.Path(tmp)
@@ -242,10 +241,10 @@ def format_api(mode, outfile, xformed, printed, build_file):
 
         for label in data["proto_targets"]:
             _label = label[len('@@envoy_api//'):].replace(':', '/')
-                source = printed_dir.joinpath(f"{_label}.proto")
-                target = dst_dir.joinpath(_label)
-                target.parent.mkdir(exist_ok=True, parents=True)
-                shutil.copy(source, target)
+            source = printed_dir.joinpath(f"{_label}.proto")
+            target = dst_dir.joinpath(_label)
+            target.parent.mkdir(exist_ok=True, parents=True)
+            shutil.copy(source, target)
 
         sync_build_files(mode, dst_dir)
 
@@ -274,6 +273,5 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     format_api(
-        args.mode, str(pathlib.Path(args.outfile).absolute()),
-        str(pathlib.Path(args.xformed).absolute()), args.protoprinted,
+        args.mode, str(pathlib.Path(args.outfile).absolute()), args.protoprinted,
         pathlib.Path(args.build_file))


### PR DESCRIPTION
Commit Message: tools: simplify the format api to remove unnecessary xfrom related logic
Additional Description:

Now the `xformed` dep make no sense because its content is not used in the formatting. It's very helpful and make big help when we migrate from v2 -> v3. But now, it's time to clean up this unneessary logic.

This PR change updated some logic of format api script. And I will create a PR to clean up all other xformed things after this PR is merged.

Risk Level: low.
Testing: n/a.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.