### PR TITLE
docs: rewording server_preferred_address docs for clarity

### DIFF
--- a/api/envoy/extensions/quic/server_preferred_address/v3/fixed_server_preferred_address_config.proto
+++ b/api/envoy/extensions/quic/server_preferred_address/v3/fixed_server_preferred_address_config.proto
@@ -21,19 +21,24 @@ message FixedServerPreferredAddressConfig {
   message AddressFamilyConfig {
     // The server preferred address sent to clients.
     //
-    // Note: Envoy currently must receive all packets for a QUIC connection on the same port, so unless
-    // :ref:`dnat_address <envoy_v3_api_field_extensions.quic.server_preferred_address.v3.FixedServerPreferredAddressConfig.AddressFamilyConfig.dnat_address>`
-    // is configured, the port for this address must be zero, and the listener's
-    // port will be used instead.
+    // .. note::
+    //
+    //   Envoy currently requires all packets for a QUIC connection to arrive on the same port. Therefore, unless a
+    //   :ref:`dnat_address <envoy_v3_api_field_extensions.quic.server_preferred_address.v3.FixedServerPreferredAddressConfig.AddressFamilyConfig.dnat_address>`
+    //   is explicitly configured, the port specified here must be set to zero. In such cases, Envoy will automatically
+    //   use the listener's port.
+    //
     config.core.v3.SocketAddress address = 1;
 
-    // If there is a DNAT between the client and Envoy, the address that Envoy will observe
-    // server preferred address packets being sent to. If this is not specified, it is assumed
-    // there is no DNAT and the server preferred address packets will be sent to the address advertised
-    // to clients for server preferred address.
+    // If a DNAT exists between the client and Envoy, this is the address where Envoy will observe incoming server
+    // preferred address packets. If unspecified, Envoy assumes there is no DNAT, and packets will be sent directly
+    // to the address advertised to clients as the server preferred address.
     //
-    // Note: Envoy currently must receive all packets for a QUIC connection on the same port, so the
-    // port for this address must be zero, and the listener's port will be used instead.
+    // .. note::
+    //
+    //   Envoy currently requires all packets for a QUIC connection to arrive on the same port. Consequently, the
+    //   port for this address must be set to zero, with Envoy defaulting to the listener's port instead.
+    //
     config.core.v3.SocketAddress dnat_address = 2;
   }
 


### PR DESCRIPTION
## Description

This PR rewords server preferred address docs and addresses some nits for clarity.

---

**Commit Message:** docs: rewording server_preferred_address docs for clarity
**Additional Description:** Reworded Server Preferred Address docs for clarity.
**Risk Level:** N/A
**Testing:** N/A
**Docs Changes:** N/A
**Release Notes:** N/A