### PR TITLE
(chore): trivial proto format spacing fixup

### DIFF
--- a/api/envoy/config/core/v3/address.proto
+++ b/api/envoy/config/core/v3/address.proto
@@ -99,7 +99,7 @@ message SocketAddress {
   bool ipv4_compat = 6;
 
   // Filepath that specifies the Linux network namespace this socket will be created in (see ``man 7
-  // network_namespaces``).  If this field is set, Envoy will create the socket in the specified
+  // network_namespaces``). If this field is set, Envoy will create the socket in the specified
   // network namespace.
   //
   // .. note::


### PR DESCRIPTION
Commit Message: (chore): trivial proto format spacing fixup
Additional Description:
https://github.com/envoyproxy/envoy/pull/39517 introduced spacing issue that is rejected by pre-commit hooks.

```
INFO: Running command line: bazel-bin/tools/code_format/check_format '--path=/workspaces/envoy' '--clang_format_path=tools/clang-format/clang-format' '--buildifier_path=external/com_github_bazelbuild_buildtools/buildifier/buildifier_/buildifier' '--buildozer_path=external/com_github_bazelbuild_buildtools/buildozer/buildozer_/buildozer' check api/envoy/config/core/v3/address.proto
ERROR: From ./api/envoy/config/core/v3/address.proto
ERROR: ./api/envoy/config/core/v3/address.proto:102: over-enthusiastic spaces
ERROR: check format failed. run 'bazel run //tools/code_format:check_format -- fix'
```

Risk Level: Low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
