### PR TITLE
xds: transform recursive call by returning iterator

### DIFF
--- a/source/extensions/config_subscription/grpc/new_grpc_mux_impl.h
+++ b/source/extensions/config_subscription/grpc/new_grpc_mux_impl.h
@@ -154,6 +154,8 @@ private:
     const SubscriptionOptions options_;
   };
 
+  using SubscriptionsMap = absl::flat_hash_map<std::string, SubscriptionStuffPtr>;
+
   // Helper function to create the grpc_stream_ object.
   std::unique_ptr<GrpcStreamInterface<envoy::service::discovery::v3::DeltaDiscoveryRequest,
                                       envoy::service::discovery::v3::DeltaDiscoveryResponse>>
@@ -173,7 +175,8 @@ private:
                    const SubscriptionOptions& options);
 
   // Adds a subscription for the type_url to the subscriptions map and order list.
-  void addSubscription(const std::string& type_url, bool use_namespace_matching);
+  SubscriptionsMap::iterator addSubscription(const std::string& type_url,
+                                             bool use_namespace_matching);
 
   void trySendDiscoveryRequests();
 
@@ -198,7 +201,7 @@ private:
   PausableAckQueue pausable_ack_queue_;
 
   // Map key is type_url.
-  absl::flat_hash_map<std::string, SubscriptionStuffPtr> subscriptions_;
+  SubscriptionsMap subscriptions_;
 
   // Determines the order of initial discovery requests. (Assumes that subscriptions are added in
   // the order of Envoy's dependency ordering).


### PR DESCRIPTION
Commit Message: xds: transform recursive call by returning iterator
Additional Description:
Minor refactor that changes a recursive call that is done after an entry is not found in the map, to changing the iterator that is returned after adding the resource.

Risk Level: low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
