### PR TITLE
nit: rename Sockopts => SockOpts for cluster & listener tests

### DIFF
--- a/test/common/listener_manager/listener_manager_impl_test.cc
+++ b/test/common/listener_manager/listener_manager_impl_test.cc
@@ -6325,7 +6325,7 @@ TEST_P(ListenerManagerImplWithRealFiltersTest, UdpListenerWithDynamicFilterConfi
 
 TEST_P(ListenerManagerImplWithRealFiltersTest, LiteralSockoptListenerEnabled) {
   const envoy::config::listener::v3::Listener listener = parseListenerFromV3Yaml(R"EOF(
-    name: SockoptsListener
+    name: SockOptsListener
     address:
       socket_address: { address: 127.0.0.1, port_value: 1111 }
     enable_reuse_port: false
@@ -6359,7 +6359,7 @@ TEST_P(ListenerManagerImplWithRealFiltersTest, LiteralSockoptListenerEnabled) {
 TEST_P(ListenerManagerImplWithRealFiltersTest,
        LiteralSockoptListenerEnabledWithMultiAddressesNoOverrideOpts) {
   const envoy::config::listener::v3::Listener listener = parseListenerFromV3Yaml(R"EOF(
-    name: SockoptsListener
+    name: SockOptsListener
     address:
       socket_address: { address: 127.0.0.1, port_value: 1111 }
     additional_addresses:
@@ -6405,7 +6405,7 @@ TEST_P(ListenerManagerImplWithRealFiltersTest,
 TEST_P(ListenerManagerImplWithRealFiltersTest,
        LiteralSockoptListenerEnabledWithMultiAddressesOverrideOpts) {
   const envoy::config::listener::v3::Listener listener = parseListenerFromV3Yaml(R"EOF(
-    name: SockoptsListener
+    name: SockOptsListener
     address:
       socket_address: { address: 127.0.0.1, port_value: 1111 }
     additional_addresses:
@@ -6468,7 +6468,7 @@ TEST_P(ListenerManagerImplWithRealFiltersTest,
 TEST_P(ListenerManagerImplWithRealFiltersTest,
        LiteralSockoptListenerEnabledWithMultiAddressesEmptyOverrideOpts) {
   const envoy::config::listener::v3::Listener listener = parseListenerFromV3Yaml(R"EOF(
-    name: SockoptsListener
+    name: SockOptsListener
     address:
       socket_address: { address: 127.0.0.1, port_value: 1111 }
     additional_addresses:
@@ -6516,7 +6516,7 @@ TEST_P(ListenerManagerImplWithRealFiltersTest,
 TEST_P(ListenerManagerImplWithRealFiltersTest,
        LiteralSockoptListenerEnabledWithSocketOptOnAdditionalAddressOnly) {
   const envoy::config::listener::v3::Listener listener = parseListenerFromV3Yaml(R"EOF(
-    name: SockoptsListener
+    name: SockOptsListener
     address:
       socket_address: { address: 127.0.0.1, port_value: 1111 }
     additional_addresses:

--- a/test/common/upstream/cluster_manager_misc_test.cc
+++ b/test/common/upstream/cluster_manager_misc_test.cc
@@ -277,7 +277,7 @@ using NameVals = std::vector<std::pair<Network::SocketOptionName, int>>;
 // due to the complexity of creating an integration test involving the network stack. We only test
 // the IPv4 case here, as the logic around IPv4/IPv6 handling is tested generically in
 // socket_option_impl_test.cc.
-class SockoptsTest : public ClusterManagerImplTest {
+class SockOptsTest : public ClusterManagerImplTest {
 public:
   void initialize(const std::string& yaml) { create(parseBootstrapFromV3Yaml(yaml)); }
 
@@ -323,7 +323,7 @@ public:
           }
           return connection_;
         }));
-    cluster_manager_->getThreadLocalCluster("SockoptsCluster")->tcpConn(nullptr);
+    cluster_manager_->getThreadLocalCluster("SockOptsCluster")->tcpConn(nullptr);
   }
 
   void expectSetsockoptFreebind() {
@@ -349,23 +349,23 @@ public:
               EXPECT_TRUE(options != nullptr && options->empty());
               return connection_;
             }));
-    auto conn_data = cluster_manager_->getThreadLocalCluster("SockoptsCluster")->tcpConn(nullptr);
+    auto conn_data = cluster_manager_->getThreadLocalCluster("SockOptsCluster")->tcpConn(nullptr);
     EXPECT_EQ(connection_, conn_data.connection_.get());
   }
 
   Network::MockClientConnection* connection_ = new NiceMock<Network::MockClientConnection>();
 };
 
-TEST_F(SockoptsTest, SockoptsUnset) {
+TEST_F(SockOptsTest, SockOptsUnset) {
   const std::string yaml = R"EOF(
   static_resources:
     clusters:
-    - name: SockoptsCluster
+    - name: SockOptsCluster
       connect_timeout: 0.250s
       lb_policy: ROUND_ROBIN
       type: STATIC
       load_assignment:
-        cluster_name: SockoptsCluster
+        cluster_name: SockOptsCluster
         endpoints:
           - lb_endpoints:
             - endpoint:
@@ -382,16 +382,16 @@ TEST_F(SockoptsTest, SockoptsUnset) {
   }
 }
 
-TEST_F(SockoptsTest, FreebindClusterOnly) {
+TEST_F(SockOptsTest, FreebindClusterOnly) {
   const std::string yaml = R"EOF(
   static_resources:
     clusters:
-    - name: SockoptsCluster
+    - name: SockOptsCluster
       connect_timeout: 0.250s
       lb_policy: ROUND_ROBIN
       type: STATIC
       load_assignment:
-        cluster_name: SockoptsCluster
+        cluster_name: SockOptsCluster
         endpoints:
           - lb_endpoints:
             - endpoint:
@@ -406,16 +406,16 @@ TEST_F(SockoptsTest, FreebindClusterOnly) {
   expectSetsockoptFreebind();
 }
 
-TEST_F(SockoptsTest, FreebindClusterManagerOnly) {
+TEST_F(SockOptsTest, FreebindClusterManagerOnly) {
   const std::string yaml = R"EOF(
   static_resources:
     clusters:
-    - name: SockoptsCluster
+    - name: SockOptsCluster
       connect_timeout: 0.250s
       lb_policy: ROUND_ROBIN
       type: STATIC
       load_assignment:
-        cluster_name: SockoptsCluster
+        cluster_name: SockOptsCluster
         endpoints:
           - lb_endpoints:
             - endpoint:
@@ -431,16 +431,16 @@ TEST_F(SockoptsTest, FreebindClusterManagerOnly) {
   expectSetsockoptFreebind();
 }
 
-TEST_F(SockoptsTest, FreebindClusterOverride) {
+TEST_F(SockOptsTest, FreebindClusterOverride) {
   const std::string yaml = R"EOF(
   static_resources:
     clusters:
-    - name: SockoptsCluster
+    - name: SockOptsCluster
       connect_timeout: 0.250s
       lb_policy: ROUND_ROBIN
       type: STATIC
       load_assignment:
-        cluster_name: SockoptsCluster
+        cluster_name: SockOptsCluster
         endpoints:
           - lb_endpoints:
             - endpoint:
@@ -458,16 +458,16 @@ TEST_F(SockoptsTest, FreebindClusterOverride) {
   expectSetsockoptFreebind();
 }
 
-TEST_F(SockoptsTest, SockoptsClusterOnly) {
+TEST_F(SockOptsTest, SockOptsClusterOnly) {
   const std::string yaml = R"EOF(
   static_resources:
     clusters:
-    - name: SockoptsCluster
+    - name: SockOptsCluster
       connect_timeout: 0.250s
       lb_policy: ROUND_ROBIN
       type: STATIC
       load_assignment:
-        cluster_name: SockoptsCluster
+        cluster_name: SockOptsCluster
         endpoints:
           - lb_endpoints:
             - endpoint:
@@ -490,16 +490,16 @@ TEST_F(SockoptsTest, SockoptsClusterOnly) {
   expectSetsockopts(names_vals);
 }
 
-TEST_F(SockoptsTest, SockoptsClusterManagerOnly) {
+TEST_F(SockOptsTest, SockOptsClusterManagerOnly) {
   const std::string yaml = R"EOF(
   static_resources:
     clusters:
-    - name: SockoptsCluster
+    - name: SockOptsCluster
       connect_timeout: 0.250s
       lb_policy: ROUND_ROBIN
       type: STATIC
       load_assignment:
-        cluster_name: SockoptsCluster
+        cluster_name: SockOptsCluster
         endpoints:
           - lb_endpoints:
             - endpoint:
@@ -523,16 +523,16 @@ TEST_F(SockoptsTest, SockoptsClusterManagerOnly) {
 }
 
 // The cluster options should override/replace the cluster manager options when both are specified.
-TEST_F(SockoptsTest, SockoptsClusterAndClusterManagerNoAddress) {
+TEST_F(SockOptsTest, SockOptsClusterAndClusterManagerNoAddress) {
   const std::string yaml = R"EOF(
   static_resources:
     clusters:
-    - name: SockoptsCluster
+    - name: SockOptsCluster
       connect_timeout: 0.250s
       lb_policy: ROUND_ROBIN
       type: STATIC
       load_assignment:
-        cluster_name: SockoptsCluster
+        cluster_name: SockOptsCluster
         endpoints:
           - lb_endpoints:
             - endpoint:
@@ -558,16 +558,16 @@ TEST_F(SockoptsTest, SockoptsClusterAndClusterManagerNoAddress) {
 
 // The cluster options should override/replace the cluster manager options when both are specified
 // when a source_address is only specified on the cluster manager bind config.
-TEST_F(SockoptsTest, SockoptsClusterAndClusterManagerAddress) {
+TEST_F(SockOptsTest, SockOptsClusterAndClusterManagerAddress) {
   const std::string yaml = R"EOF(
   static_resources:
     clusters:
-    - name: SockoptsCluster
+    - name: SockOptsCluster
       connect_timeout: 0.250s
       lb_policy: ROUND_ROBIN
       type: STATIC
       load_assignment:
-        cluster_name: SockoptsCluster
+        cluster_name: SockOptsCluster
         endpoints:
           - lb_endpoints:
             - endpoint:
@@ -594,16 +594,16 @@ TEST_F(SockoptsTest, SockoptsClusterAndClusterManagerAddress) {
   expectSetsockopts(names_vals);
 }
 
-TEST_F(SockoptsTest, SockoptsWithExtraSourceAddressAndOpts) {
+TEST_F(SockOptsTest, SockOptsWithExtraSourceAddressAndOpts) {
   const std::string yaml = R"EOF(
   static_resources:
     clusters:
-    - name: SockoptsCluster
+    - name: SockOptsCluster
       connect_timeout: 0.250s
       lb_policy: ROUND_ROBIN
       type: STATIC
       load_assignment:
-        cluster_name: SockoptsCluster
+        cluster_name: SockOptsCluster
         endpoints:
           - lb_endpoints:
             - endpoint:
@@ -639,16 +639,16 @@ TEST_F(SockoptsTest, SockoptsWithExtraSourceAddressAndOpts) {
   expectSetsockopts(names_vals);
 }
 
-TEST_F(SockoptsTest, SockoptsWithExtraSourceAddressAndEmptyOpts) {
+TEST_F(SockOptsTest, SockOptsWithExtraSourceAddressAndEmptyOpts) {
   const std::string yaml = R"EOF(
   static_resources:
     clusters:
-    - name: SockoptsCluster
+    - name: SockOptsCluster
       connect_timeout: 0.250s
       lb_policy: ROUND_ROBIN
       type: STATIC
       load_assignment:
-        cluster_name: SockoptsCluster
+        cluster_name: SockOptsCluster
         endpoints:
           - lb_endpoints:
             - endpoint:
@@ -681,16 +681,16 @@ TEST_F(SockoptsTest, SockoptsWithExtraSourceAddressAndEmptyOpts) {
   }
 }
 
-TEST_F(SockoptsTest, SockoptsWithExtraSourceAddressAndClusterOpts) {
+TEST_F(SockOptsTest, SockOptsWithExtraSourceAddressAndClusterOpts) {
   const std::string yaml = R"EOF(
   static_resources:
     clusters:
-    - name: SockoptsCluster
+    - name: SockOptsCluster
       connect_timeout: 0.250s
       lb_policy: ROUND_ROBIN
       type: STATIC
       load_assignment:
-        cluster_name: SockoptsCluster
+        cluster_name: SockOptsCluster
         endpoints:
           - lb_endpoints:
             - endpoint:
@@ -722,16 +722,16 @@ TEST_F(SockoptsTest, SockoptsWithExtraSourceAddressAndClusterOpts) {
   expectSetsockopts(names_vals);
 }
 
-TEST_F(SockoptsTest, SockoptsWithExtraSourceAddressAndClusterManagerOpts) {
+TEST_F(SockOptsTest, SockOptsWithExtraSourceAddressAndClusterManagerOpts) {
   const std::string yaml = R"EOF(
   static_resources:
     clusters:
-    - name: SockoptsCluster
+    - name: SockOptsCluster
       connect_timeout: 0.250s
       lb_policy: ROUND_ROBIN
       type: STATIC
       load_assignment:
-        cluster_name: SockoptsCluster
+        cluster_name: SockOptsCluster
         endpoints:
           - lb_endpoints:
             - endpoint:


### PR DESCRIPTION
## Description

It's a follow up for [this PR](https://github.com/envoyproxy/envoy/pull/39687) where we are making a change to rename `Sockopts` => `SockOpts` as technically they are two different words and the latter makes more sense.

---

**Commit Message:** nit: rename Sockopts => SockOpts for cluster & listener tests
**Additional Description:** Renaming Sockopts => SockOpts for clarity
**Risk Level:** N/A
**Testing:** CI
**Docs Changes:** N/A
**Release Notes:** N/A