### PR TITLE
[getaddrinfo]add a flag to disable setting ai_flags in getaddrinfo

### DIFF
--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -164,6 +164,8 @@ FALSE_RUNTIME_GUARD(envoy_reloadable_features_allow_multiplexed_upstream_half_cl
 
 FALSE_RUNTIME_GUARD(envoy_reloadable_features_ext_proc_graceful_grpc_close);
 
+FALSE_RUNTIME_GUARD(envoy_reloadable_features_getaddrinfo_no_ai_flags);
+
 // Block of non-boolean flags. Use of int flags is deprecated. Do not add more.
 ABSL_FLAG(uint64_t, re2_max_program_size_error_level, 100, ""); // NOLINT
 ABSL_FLAG(uint64_t, re2_max_program_size_warn_level,            // NOLINT

--- a/source/extensions/network/dns_resolver/getaddrinfo/getaddrinfo.cc
+++ b/source/extensions/network/dns_resolver/getaddrinfo/getaddrinfo.cc
@@ -173,7 +173,9 @@ void GetAddrInfoDnsResolver::resolveThreadRoutine() {
       next_query->addTrace(static_cast<uint8_t>(GetAddrInfoTrace::Starting));
       addrinfo hints;
       memset(&hints, 0, sizeof(hints));
-      hints.ai_flags = AI_ADDRCONFIG;
+      if (!Runtime::runtimeFeatureEnabled("envoy.reloadable_features.getaddrinfo_no_ai_flags")) {
+        hints.ai_flags = AI_ADDRCONFIG;
+      }
       hints.ai_family = AF_UNSPEC;
       // If we don't specify a socket type, every address will appear twice, once
       // for SOCK_STREAM and one for SOCK_DGRAM. Since we do not return the family


### PR DESCRIPTION
Commit Message: Add a runtime flag to disable setting ai_flags in getaddrinfo's hints.
Additional Description: The goal is to experiment with this on Android and hopefully get more flexible dns results.
Risk Level: low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
Runtime guard: envoy_reloadable_features_getaddrinfo_no_ai_flags
