### PR TITLE
fips: update test to use the whole build

### DIFF
--- a/bazel/grpc.patch
+++ b/bazel/grpc.patch
@@ -39,26 +39,47 @@ diff --git a/src/proto/grpc/health/v1/BUILD b/src/proto/grpc/health/v1/BUILD
 +    visibility = ["//visibility:public"],
 +)
 diff --git a/third_party/BUILD b/third_party/BUILD
+index 9cf5e50cb8..d15970783c 100644
 --- a/third_party/BUILD
 +++ b/third_party/BUILD
-@@ -49,7 +49,7 @@
-
+@@ -31,25 +31,19 @@ config_setting(
+ 
+ alias(
+     name = "libssl",
+-    actual = select({
+-        ":grpc_use_openssl_setting": "@openssl//:ssl",
+-        "//conditions:default": "@boringssl//:ssl",
+-    }),
++    actual = "@envoy//bazel:boringssl",
+     tags = ["manual"],
+ )
+ 
+ alias(
+     name = "libcrypto",
+-    actual = select({
+-        ":grpc_use_openssl_setting": "@openssl//:crypto",
+-        "//conditions:default": "@boringssl//:crypto",
+-    }),
++    actual = "@envoy//bazel:boringcrypto",
+     tags = ["manual"],
+ )
+ 
  alias(
      name = "madler_zlib",
 -    actual = "@zlib//:zlib",
 +    actual = "@envoy//bazel/foreign_cc:zlib",
      tags = ["manual"],
  )
-
-@@ -80,7 +80,7 @@
-
+ 
+@@ -80,7 +74,7 @@ alias(
+ 
  alias(
      name = "cares",
 -    actual = "@com_github_cares_cares//:ares",
 +    actual = "@envoy//bazel/foreign_cc:ares",
      tags = ["manual"],
  )
-
+ 
 diff --git a/src/core/lib/promise/detail/promise_factory.h b/src/core/lib/promise/detail/promise_factory.h
 --- a/src/core/lib/promise/detail/promise_factory.h
 +++ b/src/core/lib/promise/detail/promise_factory.h

--- a/test/exe/BUILD
+++ b/test/exe/BUILD
@@ -4,6 +4,7 @@ load(
     "envoy_cc_test_library",
     "envoy_package",
     "envoy_select_admin_functionality",
+    "envoy_select_boringssl",
     "envoy_sh_test",
 )
 
@@ -147,14 +148,17 @@ envoy_cc_test(
 )
 
 envoy_cc_test(
-    name = "check_extensions_against_registry_test",
+    name = "all_extensions_build_test",
     size = "large",
-    srcs = ["check_extensions_against_registry_test.cc"],
+    srcs = ["all_extensions_build_test.cc"],
+    copts = envoy_select_boringssl(["-DENVOY_SSL_FIPS"]),
     data = [
+        "fips_check.sh",
         "//source/extensions:extensions_metadata.yaml",
     ],
     rbe_pool = "6gig",
     deps = [
+        "//source/common/version:version_lib",
         "//test/test_common:environment_lib",
     ] + select({
         # gcc RBE build has trouble compiling target with all extensions

--- a/test/exe/all_extensions_build_test.cc
+++ b/test/exe/all_extensions_build_test.cc
@@ -1,5 +1,7 @@
 #include "envoy/registry/registry.h"
 
+#include "source/common/version/version.h"
+
 #include "test/test_common/environment.h"
 #include "test/test_common/utility.h"
 
@@ -73,6 +75,19 @@ TEST(CheckExtensionsAgainstRegistry, CorrectMetadata) {
       }
     }
   }
+}
+
+// Validate the the Envoy FIPS compilation flags are consistent with the FIPS
+// mode of the underlying BoringSSL build.
+// Note: this must be done on the "complete" build since transitive dependencies may override the
+// choice of the boringssl library.
+TEST(FIPS, ValidateFIPSModeConsistency) {
+#ifdef ENVOY_SSL_FIPS
+  EXPECT_TRUE(VersionInfo::sslFipsCompliant());
+  TestEnvironment::exec({TestEnvironment::runfilesPath("test/exe/fips_check.sh")});
+#else
+  EXPECT_FALSE(VersionInfo::sslFipsCompliant());
+#endif
 }
 
 } // namespace

--- a/test/exe/fips_check.sh
+++ b/test/exe/fips_check.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -e
+
+# FIPS requires a consistency self-test. In practice, the FIPS binary has
+# special markers for the start and the end of the crypto code which we can use
+# to validate that the binar was built in FIPS mode.
+ENVOY_BIN="${TEST_SRCDIR}"/envoy/test/exe/all_extensions_build_test
+objdump -t "${ENVOY_BIN}" | grep BORINGSSL_bcm_text_start

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -534,13 +534,6 @@ TEST_P(ServerInstanceImplTest, ValidateFIPSModeStat) {
   server_thread->join();
 }
 
-// Validate the the Envoy FIPS compilation flags are consistent with the FIPS
-// mode of the underlying BoringSSL build.
-TEST_P(ServerInstanceImplTest, ValidateFIPSModeConsistency) {
-  bool isFIPS = (FIPS_mode() != 0);
-  EXPECT_EQ(isFIPS, VersionInfo::sslFipsCompliant());
-}
-
 TEST_P(ServerInstanceImplTest, EmptyShutdownLifecycleNotifications) {
   auto server_thread = startTestServer("test/server/test_data/server/node_bootstrap.yaml", false);
   server_->dispatcher().post([&] { server_->shutdown(); });


### PR DESCRIPTION
Change-Id: I41f9b0725d5f2b3925b7702134eff41b1c0471bb

Commit Message: https://github.com/envoyproxy/envoy/pull/39450 accidentally broke the FIPS build by using "@boringssl" directly as a transitive dependency. The tests to validate FIPS missed this because they were not linking gRPC library. To ensure this does not happen again, I moved the test to the "all extensions" build and added a secondary check for the binary segment marker.

Additional Description:
Risk Level: low
Testing: modified
Docs Changes: none
Release Notes: none