### PR TITLE
docs: fix ext_proc stream_msgs_received and stream_msgs_sent metrics name

### DIFF
--- a/docs/root/configuration/http/http_filters/ext_proc_filter.rst
+++ b/docs/root/configuration/http/http_filters/ext_proc_filter.rst
@@ -41,8 +41,8 @@ The following statistics are supported:
   :widths: auto
 
   streams_started, Counter, The number of gRPC streams that have been started to send to the external processing service
-  streams_msgs_sent, Counter, The number of messages sent on those streams
-  streams_msgs_received, Counter, The number of messages received on those streams
+  stream_msgs_sent, Counter, The number of messages sent on those streams
+  stream_msgs_received, Counter, The number of messages received on those streams
   spurious_msgs_received, Counter, The number of unexpected messages received that violated the protocol
   streams_closed, Counter, The number of streams successfully closed on either end
   streams_failed, Counter, The number of times a stream produced a gRPC error


### PR DESCRIPTION
Signed-off-by: Vincenzo Vicaretti <vvicaretti@zendesk.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

This PR only updates the documentation without modifying the metrics themselves. I'll leave it to the maintainers to provide guidance on whether renaming the metrics is more appropriate.

Updating the metric name would make it consistent with the other `streams_*` metrics. However, such a change would be more disruptive.


Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes: Update the documentation to reflect the real metrics name
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
