### PR TITLE
Print error message before config dump

### DIFF
--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -441,9 +441,9 @@ void InstanceBase::initialize(Network::Address::InstanceConstSharedPtr local_add
   MULTI_CATCH(
       const EnvoyException& e,
       {
-        ENVOY_LOG(critical, "error initializing config '{} {} {}': {}",
+        ENVOY_LOG(critical, "error `{}` initializing config '{} {} {}'", e.what(),
                   options_.configProto().DebugString(), options_.configYaml(),
-                  options_.configPath(), e.what());
+                  options_.configPath());
         terminate();
         throw;
       },


### PR DESCRIPTION
Additional Description:
Some log storage systems can truncate very long lines. In this case the error is lost if the bootstrap is very large. Print the error first so it is available regardless of the bootstrap size.

Risk Level: Low
Testing: Unit tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
