### PR TITLE
macos: fix build

### DIFF
--- a/bazel/grpc.patch
+++ b/bazel/grpc.patch
@@ -11,6 +11,34 @@ index 848e65dabb857..84aea6256b976 100644
      ],
  )
 
+diff --git a/bazel/grpc_build_system.bzl b/bazel/grpc_build_system.bzl
+index 0fc2e1d061..aab6e990a6 100644
+--- a/bazel/grpc_build_system.bzl
++++ b/bazel/grpc_build_system.bzl
+@@ -27,7 +27,6 @@
+ Contains macros used throughout the repo.
+ """
+ 
+-load("@build_bazel_apple_support//rules:universal_binary.bzl", "universal_binary")
+ load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
+ load("@build_bazel_rules_apple//apple/testing/default_runner:ios_test_runner.bzl", "ios_test_runner")
+ load("@com_google_protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
+@@ -194,14 +193,9 @@ def grpc_proto_plugin(name, srcs = [], deps = []):
+         srcs = srcs,
+         deps = deps,
+     )
+-    universal_binary(
+-        name = name + "_universal",
+-        binary = name + "_native",
+-    )
+     native.genrule(
+         name = name,
+         srcs = select({
+-            "@platforms//os:macos": [name + "_universal"],
+             "//conditions:default": [name + "_native"],
+         }),
+         outs = [name],
+
 diff --git a/src/core/BUILD b/src/core/BUILD
 index e8bf5e85629c4..442348ddf70ca 100644
 --- a/src/core/BUILD


### PR DESCRIPTION
In the Envoy grpc dependency update in #39450, grpc added support for univeral binaries (https://github.com/grpc/grpc/pull/38378). This was causing issues resolving toolchains, at least in some environments (but not in Envoy CI).

Patch out that support because we don't need it and it's causing issues.

Fixes #39639