### PR TITLE
tcp_proxy: minor refactor using makeOptRefFromPtr

### DIFF
--- a/source/common/tcp_proxy/tcp_proxy.h
+++ b/source/common/tcp_proxy/tcp_proxy.h
@@ -240,18 +240,10 @@ public:
       return access_log_flush_interval_;
     }
     TunnelingConfigHelperOptConstRef tunnelingConfigHelper() {
-      if (tunneling_config_helper_) {
-        return {*tunneling_config_helper_};
-      } else {
-        return {};
-      }
+      return makeOptRefFromPtr<const TunnelingConfigHelper>(tunneling_config_helper_.get());
     }
     OnDemandConfigOptConstRef onDemandConfig() {
-      if (on_demand_config_) {
-        return {*on_demand_config_};
-      } else {
-        return {};
-      }
+      return makeOptRefFromPtr<const OnDemandConfig>(on_demand_config_.get());
     }
     const BackOffStrategyPtr& backoffStrategy() const { return backoff_strategy_; };
     const Network::ProxyProtocolTLVVector& proxyProtocolTLVs() const {


### PR DESCRIPTION
Commit Message: tcp_proxy: minor refactor using makeOptRefFromPtr
Additional Description:
clean up the code by using makeOptRefFromPtr to convert a pointer to opt-ref.

Risk Level: low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
