### PR TITLE
tcp_proxy: remove internal use_post bool which is redundant

### DIFF
--- a/source/common/tcp_proxy/tcp_proxy.cc
+++ b/source/common/tcp_proxy/tcp_proxy.cc
@@ -751,8 +751,7 @@ TunnelingConfigHelperImpl::TunnelingConfigHelperImpl(
     Stats::Scope& stats_scope,
     const envoy::extensions::filters::network::tcp_proxy::v3::TcpProxy& config_message,
     Server::Configuration::FactoryContext& context)
-    : use_post_(config_message.tunneling_config().use_post()),
-      header_parser_(THROW_OR_RETURN_VALUE(Envoy::Router::HeaderParser::configure(
+    : header_parser_(THROW_OR_RETURN_VALUE(Envoy::Router::HeaderParser::configure(
                                                config_message.tunneling_config().headers_to_add()),
                                            Router::HeaderParserPtr)),
       propagate_response_headers_(config_message.tunneling_config().propagate_response_headers()),
@@ -773,10 +772,12 @@ TunnelingConfigHelperImpl::TunnelingConfigHelperImpl(
                      context.serverFactoryContext().httpContext(),
                      context.serverFactoryContext().routerContext()),
       server_factory_context_(context.serverFactoryContext()) {
-  if (!post_path_.empty() && !use_post_) {
+  if (!post_path_.empty() && !config_message.tunneling_config().use_post()) {
     throw EnvoyException("Can't set a post path when POST method isn't used");
   }
-  post_path_ = post_path_.empty() ? "/" : post_path_;
+  if (config_message.tunneling_config().use_post()) {
+    post_path_ = post_path_.empty() ? "/" : post_path_;
+  }
 
   envoy::config::core::v3::SubstitutionFormatString substitution_format_config;
   substitution_format_config.mutable_text_format_source()->set_inline_string(

--- a/source/common/tcp_proxy/tcp_proxy.h
+++ b/source/common/tcp_proxy/tcp_proxy.h
@@ -166,7 +166,7 @@ public:
       const envoy::extensions::filters::network::tcp_proxy::v3::TcpProxy& config_message,
       Server::Configuration::FactoryContext& context);
   std::string host(const StreamInfo::StreamInfo& stream_info) const override;
-  bool usePost() const override { return use_post_; }
+  bool usePost() const override { return !post_path_.empty(); }
   const std::string& postPath() const override { return post_path_; }
   Envoy::Http::HeaderEvaluator& headerEvaluator() const override { return *header_parser_; }
 
@@ -182,7 +182,6 @@ public:
   }
 
 private:
-  const bool use_post_;
   std::unique_ptr<Envoy::Router::HeaderParser> header_parser_;
   Formatter::FormatterPtr hostname_fmt_;
   const bool propagate_response_headers_;


### PR DESCRIPTION
Commit Message: tcp_proxy: remove internal use_post bool which is redundant
Additional Description:
The use_post boolean data-member is coupled with the value of post_path.
Refactored the code to make that coupling explicit, following ODR.

Risk Level: low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A