### PR TITLE
docs: add warning on misaligned HTTP DFP host resolution behavior

### DIFF
--- a/docs/root/configuration/http/http_filters/dynamic_forward_proxy_filter.rst
+++ b/docs/root/configuration/http/http_filters/dynamic_forward_proxy_filter.rst
@@ -34,6 +34,14 @@ host when forwarding. See the example below within the configured routes.
   understanding that any address reachable from the proxy is potentially accessible by untrusted
   clients.
 
+.. warning::
+
+  If a custom preceding filter sets the ``envoy.upstream.dynamic_host``` and ``envoy.upstream.dynamic_port``` filter
+  state, the HTTP Dynamic Forward Proxy filter might not function correctly unless the filter state values match the
+  host used for DNS lookups by the filter. The Dynamic Forward Proxy cluster prioritizes cache lookups using the filter
+  state values first, so mismatched hosts between the filter's resolution logic and the cluster's cache lookup can
+  result in request failures.
+
 .. note::
 
   Configuring a :ref:`transport_socket with name envoy.transport_sockets.tls <envoy_v3_api_field_config.cluster.v3.Cluster.transport_socket>` on the cluster with


### PR DESCRIPTION
## Description

This PR adds a warning on the public docs for the misaligned HTTP DFP host resolution behavior per [this discussion](https://github.com/envoyproxy/envoy/issues/39579#issuecomment-2935569023).

---

**Commit Message:** docs: add warning on misaligned HTTP DFP host resolution behavior
**Additional Description:** Adds a warning on the misaligned HTTP DFP host resolution behavior
**Risk Level:** N/A
**Testing:** CI
**Docs Changes**: N/A
**Release Notes:** N/A