### PR TITLE
quic: re-enable tests for FIPS build

### DIFF
--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -298,7 +298,6 @@ selects.config_setting_group(
     name = "disable_http3",
     match_any = [
         ":disable_http3_setting",
-        ":boringssl_fips",
     ],
 )
 

--- a/bazel/external/quiche.BUILD
+++ b/bazel/external/quiche.BUILD
@@ -1511,7 +1511,6 @@ envoy_cc_library(
 envoy_cc_library(
     name = "quic_platform",
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quic_core_time_lib",
@@ -1526,7 +1525,6 @@ envoy_cc_library(
         "quiche/quic/platform/api/quic_hostname_utils.h",
     ],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_platform_hostname_utils",
@@ -1539,7 +1537,6 @@ envoy_cc_library(
         "quiche/quic/platform/api/quic_stack_trace.h",
     ],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_platform_stack_trace",
@@ -1552,7 +1549,6 @@ envoy_cc_library(
         "quiche/quic/platform/api/quic_server_stats.h",
     ],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_platform_server_stats",
@@ -1594,7 +1590,6 @@ envoy_cc_library(
         "quiche/quic/platform/api/quic_bug_tracker.h",
     ],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_platform_bug_tracker",
@@ -1605,7 +1600,6 @@ envoy_cc_library(
     name = "quic_platform_export",
     hdrs = ["quiche/quic/platform/api/quic_export.h"],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_platform_export",
@@ -1616,7 +1610,6 @@ envoy_cc_test_library(
     name = "quic_platform_expect_bug",
     hdrs = ["quiche/quic/platform/api/quic_expect_bug.h"],
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [":quiche_common_platform_expect_bug"],
 )
 
@@ -1624,7 +1617,6 @@ envoy_cc_library(
     name = "quic_platform_ip_address_family",
     hdrs = ["quiche/quic/platform/api/quic_ip_address_family.h"],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quic_platform_bug_tracker",
@@ -1637,7 +1629,6 @@ envoy_cc_library(
     srcs = ["quiche/common/quiche_ip_address_family.cc"],
     hdrs = ["quiche/common/quiche_ip_address_family.h"],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quic_platform_bug_tracker",
@@ -1663,7 +1654,6 @@ envoy_cc_library(
     hdrs = ["quiche/common/quiche_ip_address.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quic_platform_base",
@@ -1679,7 +1669,6 @@ envoy_cc_library(
         "//conditions:default": [],
     }),
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [":quiche_common_platform_udp_socket_platform"],
 )
 
@@ -1713,7 +1702,6 @@ envoy_cc_test_library(
     name = "quic_platform_test",
     hdrs = ["quiche/quic/platform/api/quic_test.h"],
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quic_platform_base",
         ":quiche_common_platform_test",
@@ -1725,7 +1713,6 @@ envoy_cc_test_library(
     name = "quic_platform_test_output",
     hdrs = ["quiche/quic/platform/api/quic_test_output.h"],
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [":quiche_common_platform_test_output"],
 )
 
@@ -1733,7 +1720,6 @@ envoy_cc_test_library(
     name = "quic_platform_thread",
     hdrs = ["quiche/quic/platform/api/quic_thread.h"],
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [":quiche_common_platform_thread"],
 )
 
@@ -1752,7 +1738,6 @@ envoy_cc_library(
     name = "quic_core_proto_cached_network_parameters_proto_header",
     hdrs = ["quiche/quic/core/proto/cached_network_parameters_proto.h"],
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [":quic_core_proto_cached_network_parameters_proto_cc"],
 )
 
@@ -1771,7 +1756,6 @@ envoy_cc_library(
     name = "quic_core_proto_source_address_token_proto_header",
     hdrs = ["quiche/quic/core/proto/source_address_token_proto.h"],
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [":quic_core_proto_source_address_token_proto_cc"],
 )
 
@@ -1789,7 +1773,6 @@ envoy_cc_library(
     name = "quic_core_proto_crypto_server_config_proto_header",
     hdrs = ["quiche/quic/core/proto/crypto_server_config_proto.h"],
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [":quic_core_proto_crypto_server_config_proto_cc"],
 )
 
@@ -1799,7 +1782,6 @@ envoy_cc_library(
     hdrs = ["quiche/quic/core/quic_ack_listener_interface.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quic_core_time_lib",
@@ -1834,7 +1816,6 @@ envoy_cc_library(
     hdrs = ["quiche/quic/core/quic_bandwidth.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quic_core_constants_lib",
@@ -1860,7 +1841,6 @@ envoy_cc_library(
     }),
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quic_core_linux_socket_utils_lib",
@@ -1886,7 +1866,6 @@ envoy_cc_library(
     }),
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quic_core_batch_writer_batch_writer_buffer_lib",
@@ -1906,7 +1885,6 @@ envoy_cc_test_library(
     }),
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quic_core_batch_writer_batch_writer_base_lib",
         ":quic_core_udp_socket_lib",
@@ -1930,7 +1908,6 @@ envoy_cc_library(
     }),
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":flow_label_lib",
@@ -1956,7 +1933,6 @@ envoy_cc_library(
     }),
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quic_core_batch_writer_batch_writer_base_lib",
@@ -1967,7 +1943,6 @@ envoy_cc_library(
 envoy_quic_cc_library(
     name = "quic_core_blocked_writer_interface_lib",
     hdrs = ["quiche/quic/core/quic_blocked_writer_interface.h"],
-    tags = ["nofips"],
     deps = [":quic_platform_export"],
 )
 
@@ -1988,7 +1963,6 @@ envoy_cc_test(
     srcs = ["quiche/quic/core/quic_blocked_writer_list_test.cc"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quic_core_blocked_writer_interface_lib",
         ":quic_core_blocked_writer_list_lib",
@@ -2413,7 +2387,6 @@ envoy_cc_library(
     hdrs = ["quiche/quic/core/quic_constants.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quic_core_types_lib",
@@ -2432,7 +2405,6 @@ envoy_cc_library(
     copts = quiche_copts,
     external_deps = ["ssl"],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_platform_logging",
@@ -2700,7 +2672,6 @@ envoy_cc_library(
     copts = quiche_copts,
     external_deps = ["ssl"],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [":quiche_common_random_lib"],
 )
@@ -2763,7 +2734,6 @@ envoy_cc_library(
         "quiche/common/simple_buffer_allocator.h",
     ],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_platform_export",
@@ -2777,7 +2747,6 @@ envoy_cc_library(
     hdrs = ["quiche/common/quiche_circular_deque.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quiche_common_platform",
         ":quiche_common_platform_export",
@@ -2791,7 +2760,6 @@ envoy_cc_library(
     copts = quiche_copts,
     external_deps = ["ssl"],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [":quiche_common_platform_logging"],
 )
@@ -2801,7 +2769,6 @@ envoy_cc_library(
     hdrs = ["quiche/common/quiche_status_utils.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/status",
@@ -2814,7 +2781,6 @@ envoy_cc_library(
     hdrs = ["quiche/common/wire_serialization.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quiche_common_buffer_allocator_lib",
         ":quiche_common_lib",
@@ -2829,7 +2795,6 @@ envoy_cc_library(
     hdrs = ["quiche/common/quiche_callbacks.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_platform_export",
@@ -2864,7 +2829,6 @@ envoy_cc_library(
     copts = quiche_copts,
     external_deps = ["ssl"],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quic_platform_base",
@@ -2877,7 +2841,6 @@ envoy_cc_library(
     hdrs = ["quiche/common/quiche_feature_flags_list.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
 )
 
@@ -2886,7 +2849,6 @@ envoy_cc_library(
     hdrs = ["quiche/common/quiche_protocol_flags_list.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
 )
 
@@ -2980,7 +2942,6 @@ envoy_cc_library(
         "//conditions:default": [],
     }),
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quic_core_constants_lib",
@@ -3285,7 +3246,6 @@ envoy_cc_library(
     hdrs = ["quiche/quic/core/quic_interval.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quic_platform_export",
@@ -3308,7 +3268,6 @@ envoy_cc_library(
     hdrs = ["quiche/quic/core/quic_interval_set.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quic_core_interval_lib",
@@ -3326,7 +3285,6 @@ envoy_cc_library(
     }),
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     deps = select({
         "@envoy//bazel:windows_x86_64": [],
         "@envoy//bazel:disable_http3": [],
@@ -3352,7 +3310,6 @@ envoy_cc_library(
     ],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quic_core_types_lib",
@@ -3389,7 +3346,6 @@ envoy_cc_library(
     }),
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     deps = select({
         "@envoy//bazel:windows_x86_64": [],
         "@envoy//bazel:disable_http3": [],
@@ -3449,7 +3405,6 @@ envoy_cc_library(
     }),
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quic_platform_export",
     ],
@@ -3467,7 +3422,6 @@ envoy_cc_library(
     }),
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quic_core_packet_writer_lib",
         ":quic_core_syscall_wrapper_lib",
@@ -3531,7 +3485,6 @@ envoy_cc_library(
     ],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quic_core_packets_lib",
@@ -3552,7 +3505,6 @@ envoy_cc_library(
     ],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":http2_core_priority_write_scheduler_lib",
@@ -3965,7 +3917,6 @@ envoy_cc_library(
     copts = quiche_copts,
     external_deps = ["ssl"],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quic_core_types_lib",
@@ -4157,7 +4108,6 @@ envoy_cc_library(
     hdrs = ["quiche/quic/core/quic_tag.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quic_platform_base",
@@ -4170,7 +4120,6 @@ envoy_cc_library(
     srcs = ["quiche/quic/core/quic_time.cc"],
     hdrs = ["quiche/quic/core/quic_time.h"],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [":quic_platform_base"],
 )
@@ -4226,7 +4175,6 @@ envoy_cc_library(
     copts = quiche_copts,
     external_deps = ["ssl"],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quic_core_crypto_random_lib",
@@ -4275,7 +4223,6 @@ envoy_cc_library(
         "//conditions:default": [],
     }),
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":flow_label_lib",
         ":quic_core_io_socket_lib",
@@ -4307,7 +4254,6 @@ envoy_cc_library(
     hdrs = ["quiche/quic/core/quic_utils.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quic_core_constants_lib",
@@ -4339,7 +4285,6 @@ envoy_cc_library(
     hdrs = ["quiche/quic/core/quic_versions.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quic_core_crypto_random_lib",
@@ -4646,7 +4591,6 @@ envoy_cc_library(
     name = "quiche_common_endian_lib",
     hdrs = ["quiche/common/quiche_endian.h"],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps =
         [
@@ -4660,7 +4604,6 @@ envoy_cc_library(
         "quiche/common/platform/api/quiche_client_stats.h",
     ],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [":quiche_common_platform_default_quiche_platform_impl_client_stats_impl_lib"],
 )
@@ -4678,7 +4621,6 @@ envoy_cc_test_library(
         "quiche/common/platform/api/quiche_system_event_loop.h",
     ],
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [":quiche_common_platform_default_quiche_platform_impl_system_event_loop_impl_lib"],
 )
 
@@ -4693,7 +4635,6 @@ envoy_cc_library(
     name = "quiche_common_platform_googleurl",
     hdrs = ["quiche/common/platform/api/quiche_googleurl.h"],
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [":quiche_common_platform_default_quiche_platform_impl_googleurl_impl_lib"],
 )
 
@@ -4702,7 +4643,6 @@ envoy_cc_library(
     srcs = ["quiche/common/platform/api/quiche_mem_slice.cc"],
     hdrs = ["quiche/common/platform/api/quiche_mem_slice.h"],
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quiche_common_buffer_allocator_lib",
         ":quiche_common_callbacks",
@@ -4727,7 +4667,6 @@ envoy_cc_library(
         "quiche/common/platform/api/quiche_iovec.h",
     ],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_platform_bug_tracker",
@@ -4742,7 +4681,6 @@ envoy_cc_library(
         "quiche/common/platform/api/quiche_bug_tracker.h",
     ],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_platform_export",
@@ -4763,7 +4701,6 @@ envoy_cc_library(
         "quiche/common/platform/api/quiche_logging.h",
     ],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_platform_export",
@@ -4803,7 +4740,6 @@ envoy_cc_library(
         "quiche/common/platform/api/quiche_hostname_utils.h",
     ],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_platform_export",
@@ -4818,7 +4754,6 @@ envoy_cc_test_library(
         "quiche/common/platform/api/quiche_thread.h",
     ],
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quiche_common_platform_export",
         "@envoy//test/common/quic/platform:quiche_thread_impl_lib",
@@ -4831,7 +4766,6 @@ envoy_cc_test_library(
         "quiche/common/platform/api/quiche_test_output.h",
     ],
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quiche_common_platform_export",
         "@envoy//test/common/quic/platform:quiche_test_output_impl_lib",
@@ -4844,7 +4778,6 @@ envoy_cc_test_library(
         "quiche/common/platform/api/quiche_expect_bug.h",
     ],
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quiche_common_platform_export",
         "@envoy//test/common/quic/platform:quiche_expect_bug_impl_lib",
@@ -4858,7 +4791,6 @@ envoy_cc_library(
         "//conditions:default": [],
     }),
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quic_core_types_lib",
@@ -4872,7 +4804,6 @@ envoy_cc_library(
     name = "quiche_common_platform_server_stats",
     hdrs = ["quiche/common/platform/api/quiche_server_stats.h"],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_platform_default_quiche_platform_impl_server_stats_impl_lib",
@@ -4892,7 +4823,6 @@ envoy_cc_library(
         "quiche/common/platform/api/quiche_stack_trace.h",
     ],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_platform_export",
@@ -4906,7 +4836,6 @@ envoy_cc_library(
         "quiche/common/platform/api/quiche_containers.h",
     ],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_platform_default_quiche_platform_impl_containers_impl_lib",
@@ -4940,7 +4869,6 @@ envoy_cc_library(
         "quiche/common/platform/api/quiche_testvalue.h",
     ],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_platform_export",
@@ -4958,7 +4886,6 @@ envoy_cc_library(
         "quiche/common/platform/api/quiche_time_utils.h",
     ],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_platform_bug_tracker",
@@ -5031,7 +4958,6 @@ envoy_cc_library(
         "quiche/common/platform/api/quiche_export.h",
     ],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         "@envoy//source/common/quic/platform:quiche_export_impl_lib",
@@ -5042,7 +4968,6 @@ envoy_cc_test_library(
     name = "quiche_common_platform_test",
     hdrs = ["quiche/common/platform/api/quiche_test.h"],
     repository = "@envoy",
-    tags = ["nofips"],
     deps = ["@envoy//test/common/quic/platform:quiche_test_impl_lib"],
 )
 
@@ -5051,7 +4976,6 @@ envoy_cc_test(
     srcs = ["quiche/common/platform/api/quiche_mem_slice_test.cc"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quiche_common_buffer_allocator_lib",
         ":quiche_common_platform",
@@ -5065,7 +4989,6 @@ envoy_cc_test(
     srcs = ["quiche/common/platform/api/quiche_time_utils_test.cc"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quiche_common_platform",
         ":quiche_common_platform_test",
@@ -5076,7 +4999,6 @@ envoy_cc_library(
     name = "quiche_common_print_elements_lib",
     hdrs = ["quiche/common/print_elements.h"],
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quiche_common_platform_export",
         "@com_google_absl//absl/container:inlined_vector",
@@ -5090,7 +5012,6 @@ envoy_cc_test_library(
         "quiche/common/test_tools/quiche_test_utils.h",
     ],
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quiche_common_platform",
         ":quiche_common_platform_googleurl",
@@ -5106,7 +5027,6 @@ envoy_cc_library(
     srcs = ["quiche/common/quiche_text_utils.cc"],
     hdrs = ["quiche/common/quiche_text_utils.h"],
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quiche_common_platform_export",
         "@com_google_absl//absl/hash",
@@ -5126,7 +5046,6 @@ envoy_cc_library(
         "quiche/common/quiche_linked_hash_map.h",
     ],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_endian_lib",
@@ -5139,7 +5058,6 @@ envoy_cc_library(
     srcs = ["quiche/common/quiche_simple_arena.cc"],
     hdrs = ["quiche/common/quiche_simple_arena.h"],
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quiche_common_platform_export",
         ":quiche_common_platform_logging",
@@ -5151,7 +5069,6 @@ envoy_cc_library(
     srcs = ["quiche/common/http/http_header_storage.cc"],
     hdrs = ["quiche/common/http/http_header_storage.h"],
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quiche_common_platform_export",
         ":quiche_common_platform_logging",
@@ -5164,7 +5081,6 @@ envoy_cc_library(
     srcs = ["quiche/common/http/http_header_block.cc"],
     hdrs = ["quiche/common/http/http_header_block.h"],
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quiche_common_lib",
         ":quiche_common_platform_export",
@@ -5178,7 +5094,6 @@ envoy_cc_test(
     name = "quiche_http_header_block_test",
     srcs = ["quiche/common/http/http_header_block_test.cc"],
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":http2_test_tools_test_utils_lib",
         ":quiche_common_platform_test",
@@ -5191,7 +5106,6 @@ envoy_cc_library(
     srcs = ["quiche/common/structured_headers.cc"],
     hdrs = ["quiche/common/structured_headers.h"],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_platform",
@@ -5215,7 +5129,6 @@ envoy_cc_test(
     ],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quiche_common_lib",
         ":quiche_common_mem_slice_storage",
@@ -5229,7 +5142,6 @@ envoy_cc_test(
         "quiche/http2/test_tools/http2_random_test.cc",
     ],
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":http2_test_tools_random",
         ":quiche_common_platform",
@@ -5259,7 +5171,6 @@ envoy_cc_test(
     }),
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quic_core_batch_writer_batch_writer_test_lib",
         ":quic_core_batch_writer_gso_batch_writer_lib",
@@ -5274,7 +5185,6 @@ envoy_cc_library(
     hdrs = ["quiche/quic/load_balancer/load_balancer_server_id.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quic_core_types_lib",
@@ -5317,7 +5227,6 @@ envoy_cc_library(
     name = "quiche_common_platform_lower_case_string",
     hdrs = ["quiche/common/platform/api/quiche_lower_case_string.h"],
     repository = "@envoy",
-    tags = ["nofips"],
     deps = ["@envoy//source/common/quic/platform:quiche_lower_case_string_impl_lib"],
 )
 
@@ -5325,7 +5234,6 @@ envoy_cc_library(
     name = "quiche_common_platform_header_policy",
     hdrs = ["quiche/common/platform/api/quiche_header_policy.h"],
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [":quiche_common_platform_default_quiche_platform_impl_header_policy_impl_lib"],
 )
 
@@ -5340,7 +5248,6 @@ envoy_cc_library(
     hdrs = ["quiche/balsa/balsa_enums.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [":quiche_common_platform_export"],
 )
@@ -5350,7 +5257,6 @@ envoy_cc_library(
     hdrs = ["quiche/balsa/balsa_visitor_interface.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quiche_balsa_balsa_enums_lib",
@@ -5363,7 +5269,6 @@ envoy_cc_library(
     hdrs = ["quiche/balsa/noop_balsa_visitor.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quiche_balsa_balsa_visitor_interface_lib",
@@ -5377,7 +5282,6 @@ envoy_cc_library(
     hdrs = ["quiche/balsa/standard_header_map.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quiche_common_text_utils_lib",
         "@com_google_absl//absl/container:flat_hash_set",
@@ -5390,7 +5294,6 @@ envoy_cc_library(
     hdrs = ["quiche/balsa/framer_interface.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [":quiche_common_platform_export"],
 )
 
@@ -5399,7 +5302,6 @@ envoy_cc_library(
     hdrs = ["quiche/balsa/http_validation_policy.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quiche_common_platform_export",
         ":quiche_common_platform_logging",
@@ -5411,7 +5313,6 @@ envoy_cc_library(
     hdrs = ["quiche/balsa/header_api.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quiche_common_callbacks",
         ":quiche_common_platform_export",
@@ -5426,7 +5327,6 @@ envoy_cc_library(
     hdrs = ["quiche/balsa/simple_buffer.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quiche_common_platform",
         ":quiche_common_platform_bug_tracker",
@@ -5441,7 +5341,6 @@ envoy_cc_test(
     srcs = ["quiche/balsa/simple_buffer_test.cc"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quiche_balsa_simple_buffer_lib",
         ":quiche_common_platform_expect_bug",
@@ -5456,7 +5355,6 @@ envoy_cc_library(
     hdrs = ["quiche/balsa/header_properties.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quiche_common_platform",
         ":quiche_common_platform_export",
@@ -5471,7 +5369,6 @@ envoy_cc_test(
     srcs = ["quiche/balsa/header_properties_test.cc"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quiche_balsa_header_properties_lib",
         ":quiche_common_platform_test",
@@ -5484,7 +5381,6 @@ envoy_cc_library(
     hdrs = ["quiche/balsa/balsa_headers.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quiche_balsa_balsa_enums_lib",
@@ -5530,7 +5426,6 @@ envoy_cc_library(
     hdrs = ["quiche/balsa/balsa_frame.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quiche_balsa_balsa_enums_lib",
@@ -5579,7 +5474,6 @@ envoy_cc_library(
     ],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":common_http_http_header_block_lib",
         ":quiche_common_callbacks",

--- a/bazel/external/quiche.bzl
+++ b/bazel/external/quiche.bzl
@@ -32,7 +32,6 @@ def envoy_quiche_platform_impl_cc_library(
         deps = deps,
         repository = "@envoy",
         strip_include_prefix = "quiche/common/platform/default/",
-        tags = ["nofips"],
         visibility = ["//visibility:public"],
     )
 
@@ -48,7 +47,6 @@ def envoy_quiche_platform_impl_cc_test_library(
         deps = deps,
         repository = "@envoy",
         strip_include_prefix = "quiche/common/platform/default/",
-        tags = ["nofips"],
     )
 
 # Used for QUIC libraries
@@ -66,7 +64,7 @@ def envoy_quic_cc_library(
         hdrs = envoy_select_enable_http3(hdrs, "@envoy"),
         repository = "@envoy",
         copts = quiche_copts,
-        tags = ["nofips"] + tags,
+        tags = tags,
         visibility = ["//visibility:public"],
         defines = defines,
         external_deps = external_deps,
@@ -86,7 +84,7 @@ def envoy_quic_cc_test_library(
         hdrs = envoy_select_enable_http3(hdrs, "@envoy"),
         copts = quiche_copts,
         repository = "@envoy",
-        tags = ["nofips"] + tags,
+        tags = tags,
         external_deps = external_deps,
         deps = envoy_select_enable_http3(deps, "@envoy"),
     )

--- a/source/common/http/http3/BUILD
+++ b/source/common/http/http3/BUILD
@@ -10,17 +10,26 @@ envoy_package()
 
 envoy_cc_library(
     name = "conn_pool_lib",
-    srcs = ["conn_pool.cc"],
-    hdrs = ["conn_pool.h"],
-    deps = [
-        "//envoy/event:dispatcher_interface",
-        "//envoy/http:persistent_quic_info_interface",
-        "//envoy/upstream:upstream_interface",
-        "//source/common/http:codec_client_lib",
-        "//source/common/http:conn_pool_base_lib",
-        "//source/common/quic:client_connection_factory_lib",
-        "@com_github_google_quiche//:quic_core_deterministic_connection_id_generator_lib",
-    ],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["conn_pool.cc"],
+    }),
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["conn_pool.h"],
+    }),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//envoy/event:dispatcher_interface",
+            "//envoy/http:persistent_quic_info_interface",
+            "//envoy/upstream:upstream_interface",
+            "//source/common/http:codec_client_lib",
+            "//source/common/http:conn_pool_base_lib",
+            "//source/common/quic:client_connection_factory_lib",
+            "@com_github_google_quiche//:quic_core_deterministic_connection_id_generator_lib",
+        ],
+    }),
 )
 
 envoy_cc_library(

--- a/source/common/quic/BUILD
+++ b/source/common/quic/BUILD
@@ -1,3 +1,4 @@
+load("@bazel_skylib//lib:selects.bzl", "selects")
 load(
     "@envoy_build_config//:extensions_build_config.bzl",
     "LEGACY_ALWAYSLINK",
@@ -12,6 +13,15 @@ load(
 
 licenses(["notice"])  # Apache 2
 
+# Create a condition for HTTP3 enabled AND Linux
+selects.config_setting_group(
+    name = "http3_enabled_and_linux",
+    match_all = [
+        "//bazel:linux",
+        "//bazel:enable_http3",
+    ],
+)
+
 # TODO(mattklein123): Default visibility for this package should not be public. We should have
 # default by private to within this package and package tests, and then only expose the libraries
 # that are required to be selected into the build for http3 to work.
@@ -19,324 +29,456 @@ envoy_package()
 
 envoy_cc_library(
     name = "envoy_quic_alarm_lib",
-    srcs = ["envoy_quic_alarm.cc"],
-    hdrs = ["envoy_quic_alarm.h"],
-    tags = ["nofips"],
-    deps = [
-        "//envoy/event:dispatcher_interface",
-        "//envoy/event:timer_interface",
-        "@com_github_google_quiche//:quic_core_alarm_lib",
-        "@com_github_google_quiche//:quic_core_clock_lib",
-        "@com_github_google_quiche//:quic_platform",
-    ],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_alarm.cc"],
+    }),
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_alarm.h"],
+    }),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//envoy/event:dispatcher_interface",
+            "//envoy/event:timer_interface",
+            "@com_github_google_quiche//:quic_core_alarm_lib",
+            "@com_github_google_quiche//:quic_core_clock_lib",
+            "@com_github_google_quiche//:quic_platform",
+        ],
+    }),
 )
 
 envoy_cc_library(
     name = "envoy_quic_alarm_factory_lib",
-    srcs = ["envoy_quic_alarm_factory.cc"],
-    hdrs = ["envoy_quic_alarm_factory.h"],
-    tags = ["nofips"],
-    deps = [
-        ":envoy_quic_alarm_lib",
-        "@com_github_google_quiche//:quic_core_alarm_factory_lib",
-        "@com_github_google_quiche//:quic_core_arena_scoped_ptr_lib",
-        "@com_github_google_quiche//:quic_core_one_block_arena_lib",
-        "@com_github_google_quiche//:quic_platform",
-    ],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_alarm_factory.cc"],
+    }),
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_alarm_factory.h"],
+    }),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":envoy_quic_alarm_lib",
+            "@com_github_google_quiche//:quic_core_alarm_factory_lib",
+            "@com_github_google_quiche//:quic_core_arena_scoped_ptr_lib",
+            "@com_github_google_quiche//:quic_core_one_block_arena_lib",
+            "@com_github_google_quiche//:quic_platform",
+        ],
+    }),
 )
 
 envoy_cc_library(
     name = "envoy_quic_clock_lib",
-    srcs = ["envoy_quic_clock.cc"],
-    hdrs = ["envoy_quic_clock.h"],
-    tags = ["nofips"],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_clock.cc"],
+    }),
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_clock.h"],
+    }),
     visibility = ["//visibility:public"],
-    deps = [
-        "//envoy/event:dispatcher_interface",
-        "@com_github_google_quiche//:quic_core_clock_lib",
-    ],
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//envoy/event:dispatcher_interface",
+            "@com_github_google_quiche//:quic_core_clock_lib",
+        ],
+    }),
 )
 
 envoy_cc_library(
     name = "envoy_quic_connection_debug_visitor_factory_interface",
-    hdrs = ["envoy_quic_connection_debug_visitor_factory_interface.h"],
-    tags = ["nofips"],
-    deps = [
-        "//envoy/common:optref_lib",
-        "//envoy/common:pure_lib",
-        "//envoy/config:typed_config_interface",
-        "//envoy/server:factory_context_interface",
-        "//envoy/stream_info:stream_info_interface",
-        "@com_github_google_quiche//:quic_core_connection_lib",
-        "@com_github_google_quiche//:quic_core_session_lib",
-    ],
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_connection_debug_visitor_factory_interface.h"],
+    }),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//envoy/common:optref_lib",
+            "//envoy/common:pure_lib",
+            "//envoy/config:typed_config_interface",
+            "//envoy/server:factory_context_interface",
+            "//envoy/stream_info:stream_info_interface",
+            "@com_github_google_quiche//:quic_core_connection_lib",
+            "@com_github_google_quiche//:quic_core_session_lib",
+        ],
+    }),
 )
 
 envoy_cc_library(
     name = "envoy_quic_connection_helper_lib",
-    hdrs = ["envoy_quic_connection_helper.h"],
-    tags = ["nofips"],
-    deps = [
-        ":envoy_quic_clock_lib",
-        "@com_github_google_quiche//:quic_core_connection_lib",
-        "@com_github_google_quiche//:quiche_common_random_lib",
-    ],
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_connection_helper.h"],
+    }),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":envoy_quic_clock_lib",
+            "@com_github_google_quiche//:quic_core_connection_lib",
+            "@com_github_google_quiche//:quiche_common_random_lib",
+        ],
+    }),
 )
 
 envoy_cc_library(
     name = "quic_stat_names_lib",
     srcs = ["quic_stat_names.cc"],
     hdrs = ["quic_stat_names.h"],
-    tags = ["nofips"],
-    deps = [
-        "//envoy/stats:stats_interface",
-        "//source/common/stats:symbol_table_lib",
-        "@com_github_google_quiche//:quic_core_error_codes_lib",
-        "@com_github_google_quiche//:quic_core_types_lib",
-    ],
+    deps = select({
+        "//bazel:disable_http3": [
+            "//envoy/stats:stats_interface",
+            "//source/common/stats:symbol_table_lib",
+        ],
+        "//conditions:default": [
+            "//envoy/stats:stats_interface",
+            "//source/common/stats:symbol_table_lib",
+            "@com_github_google_quiche//:quic_core_error_codes_lib",
+            "@com_github_google_quiche//:quic_core_types_lib",
+        ],
+    }),
 )
 
 envoy_cc_library(
     name = "envoy_quic_proof_source_base_lib",
-    srcs = ["envoy_quic_proof_source_base.cc"],
-    hdrs = ["envoy_quic_proof_source_base.h"],
-    tags = ["nofips"],
-    deps = [
-        ":envoy_quic_utils_lib",
-        "@com_github_google_quiche//:quic_core_crypto_certificate_view_lib",
-        "@com_github_google_quiche//:quic_core_crypto_crypto_handshake_lib",
-        "@com_github_google_quiche//:quic_core_crypto_proof_source_lib",
-        "@com_github_google_quiche//:quic_core_data_lib",
-        "@com_github_google_quiche//:quic_core_versions_lib",
-        "@com_github_google_quiche//:quic_platform",
-    ],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_proof_source_base.cc"],
+    }),
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_proof_source_base.h"],
+    }),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":envoy_quic_utils_lib",
+            "@com_github_google_quiche//:quic_core_crypto_certificate_view_lib",
+            "@com_github_google_quiche//:quic_core_crypto_crypto_handshake_lib",
+            "@com_github_google_quiche//:quic_core_crypto_proof_source_lib",
+            "@com_github_google_quiche//:quic_core_data_lib",
+            "@com_github_google_quiche//:quic_core_versions_lib",
+            "@com_github_google_quiche//:quic_platform",
+        ],
+    }),
 )
 
 envoy_cc_library(
     name = "envoy_quic_proof_source_lib",
-    srcs = ["envoy_quic_proof_source.cc"],
-    hdrs = ["envoy_quic_proof_source.h"],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_proof_source.cc"],
+    }),
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_proof_source.h"],
+    }),
     external_deps = ["ssl"],
-    tags = ["nofips"],
-    deps = [
-        ":envoy_quic_proof_source_base_lib",
-        ":envoy_quic_utils_lib",
-        ":quic_io_handle_wrapper_lib",
-        ":quic_transport_socket_factory_lib",
-        "//envoy/ssl:tls_certificate_config_interface",
-        "//source/common/quic:cert_compression_lib",
-        "//source/common/quic:quic_server_transport_socket_factory_lib",
-        "//source/common/stream_info:stream_info_lib",
-        "//source/server:listener_stats",
-        "@com_github_google_quiche//:quic_core_crypto_certificate_view_lib",
-    ],
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":envoy_quic_proof_source_base_lib",
+            ":envoy_quic_utils_lib",
+            ":quic_io_handle_wrapper_lib",
+            ":quic_transport_socket_factory_lib",
+            "//envoy/ssl:tls_certificate_config_interface",
+            "//source/common/quic:cert_compression_lib",
+            "//source/common/quic:quic_server_transport_socket_factory_lib",
+            "//source/common/stream_info:stream_info_lib",
+            "//source/server:listener_stats",
+            "@com_github_google_quiche//:quic_core_crypto_certificate_view_lib",
+        ],
+    }),
 )
 
 envoy_cc_library(
     name = "envoy_quic_proof_verifier_base_lib",
-    srcs = ["envoy_quic_proof_verifier_base.cc"],
-    hdrs = ["envoy_quic_proof_verifier_base.h"],
-    tags = ["nofips"],
-    deps = [
-        ":envoy_quic_utils_lib",
-        "@com_github_google_quiche//:quic_core_crypto_certificate_view_lib",
-        "@com_github_google_quiche//:quic_core_crypto_crypto_handshake_lib",
-        "@com_github_google_quiche//:quic_core_versions_lib",
-        "@com_github_google_quiche//:quic_platform",
-    ],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_proof_verifier_base.cc"],
+    }),
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_proof_verifier_base.h"],
+    }),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":envoy_quic_utils_lib",
+            "@com_github_google_quiche//:quic_core_crypto_certificate_view_lib",
+            "@com_github_google_quiche//:quic_core_crypto_crypto_handshake_lib",
+            "@com_github_google_quiche//:quic_core_versions_lib",
+            "@com_github_google_quiche//:quic_platform",
+        ],
+    }),
 )
 
 envoy_cc_library(
     name = "envoy_quic_proof_verifier_lib",
-    srcs = ["envoy_quic_proof_verifier.cc"],
-    hdrs = ["envoy_quic_proof_verifier.h"],
-    tags = ["nofips"],
-    deps = [
-        ":envoy_quic_proof_verifier_base_lib",
-        ":envoy_quic_utils_lib",
-        ":quic_ssl_connection_info_lib",
-        "//source/common/tls:context_lib",
-        "@com_github_google_quiche//:quic_platform",
-    ],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_proof_verifier.cc"],
+    }),
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_proof_verifier.h"],
+    }),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":envoy_quic_proof_verifier_base_lib",
+            ":envoy_quic_utils_lib",
+            ":quic_ssl_connection_info_lib",
+            "//source/common/tls:context_lib",
+            "@com_github_google_quiche//:quic_platform",
+        ],
+    }),
 )
 
 envoy_cc_library(
     name = "envoy_quic_stream_lib",
-    srcs = ["envoy_quic_stream.cc"],
-    hdrs = ["envoy_quic_stream.h"],
-    tags = ["nofips"],
-    deps = [
-        ":envoy_quic_simulated_watermark_buffer_lib",
-        ":envoy_quic_utils_lib",
-        ":quic_filter_manager_connection_lib",
-        ":quic_stats_gatherer",
-        ":send_buffer_monitor_lib",
-        "//envoy/event:dispatcher_interface",
-        "//envoy/http:codec_interface",
-        "//source/common/http:codec_helper_lib",
-        "@com_github_google_quiche//:http2_adapter",
-        "@com_github_google_quiche//:quic_core_http_client_lib",
-        "@com_github_google_quiche//:quic_core_http_http_encoder_lib",
-        "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
-    ] + envoy_select_enable_http_datagrams([
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_stream.cc"],
+    }),
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_stream.h"],
+    }),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":envoy_quic_simulated_watermark_buffer_lib",
+            ":envoy_quic_utils_lib",
+            ":quic_filter_manager_connection_lib",
+            ":quic_stats_gatherer",
+            ":send_buffer_monitor_lib",
+            "//envoy/event:dispatcher_interface",
+            "//envoy/http:codec_interface",
+            "//source/common/http:codec_helper_lib",
+            "@com_github_google_quiche//:http2_adapter",
+            "@com_github_google_quiche//:quic_core_http_client_lib",
+            "@com_github_google_quiche//:quic_core_http_http_encoder_lib",
+            "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
+        ],
+    }) + envoy_select_enable_http_datagrams([
         ":http_datagram_handler",
     ]),
 )
 
 envoy_cc_library(
     name = "client_connection_factory_lib",
-    srcs = ["client_connection_factory_impl.cc"],
-    hdrs = ["client_connection_factory_impl.h"],
-    tags = ["nofips"],
-    deps = [
-        ":envoy_quic_alarm_factory_lib",
-        ":envoy_quic_client_session_lib",
-        ":envoy_quic_connection_helper_lib",
-        ":envoy_quic_proof_verifier_lib",
-        ":envoy_quic_utils_lib",
-        "//envoy/http:codec_interface",
-        "//envoy/http:persistent_quic_info_interface",
-        "//envoy/registry",
-        "//source/common/runtime:runtime_lib",
-        "//source/common/tls:client_ssl_socket_lib",
-        "//source/extensions/quic/crypto_stream:envoy_quic_crypto_client_stream_lib",
-        "@com_github_google_quiche//:quic_core_http_spdy_session_lib",
-    ],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["client_connection_factory_impl.cc"],
+    }),
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["client_connection_factory_impl.h"],
+    }),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":envoy_quic_alarm_factory_lib",
+            ":envoy_quic_client_session_lib",
+            ":envoy_quic_connection_helper_lib",
+            ":envoy_quic_proof_verifier_lib",
+            ":envoy_quic_utils_lib",
+            "//envoy/http:codec_interface",
+            "//envoy/http:persistent_quic_info_interface",
+            "//envoy/registry",
+            "//source/common/runtime:runtime_lib",
+            "//source/common/tls:client_ssl_socket_lib",
+            "//source/extensions/quic/crypto_stream:envoy_quic_crypto_client_stream_lib",
+            "@com_github_google_quiche//:quic_core_http_spdy_session_lib",
+        ],
+    }),
 )
 
 envoy_cc_library(
     name = "client_codec_lib",
-    srcs = ["client_codec_impl.cc"],
-    hdrs = [
-        "client_codec_impl.h",
-        "codec_impl.h",
-    ],
-    tags = ["nofips"],
-    deps = [
-        ":envoy_quic_client_session_lib",
-        ":envoy_quic_utils_lib",
-        "//envoy/http:codec_interface",
-        "//envoy/registry",
-        "@com_github_google_quiche//:quic_core_http_spdy_session_lib",
-    ],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["client_codec_impl.cc"],
+    }),
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "client_codec_impl.h",
+            "codec_impl.h",
+        ],
+    }),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":envoy_quic_client_session_lib",
+            ":envoy_quic_utils_lib",
+            "//envoy/http:codec_interface",
+            "//envoy/registry",
+            "@com_github_google_quiche//:quic_core_http_spdy_session_lib",
+        ],
+    }),
 )
 
 envoy_cc_library(
     name = "server_codec_lib",
-    srcs = ["server_codec_impl.cc"],
-    hdrs = [
-        "codec_impl.h",
-        "server_codec_impl.h",
-    ],
-    tags = ["nofips"],
-    deps = [
-        ":envoy_quic_server_session_lib",
-        ":envoy_quic_utils_lib",
-        ":quic_server_factory_stub_lib",
-        "//envoy/http:codec_interface",
-        "//envoy/registry",
-        "@com_github_google_quiche//:quic_core_http_spdy_session_lib",
-    ],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["server_codec_impl.cc"],
+    }),
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "codec_impl.h",
+            "server_codec_impl.h",
+        ],
+    }),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":envoy_quic_server_session_lib",
+            ":envoy_quic_utils_lib",
+            ":quic_server_factory_stub_lib",
+            "//envoy/http:codec_interface",
+            "//envoy/registry",
+            "@com_github_google_quiche//:quic_core_http_spdy_session_lib",
+        ],
+    }),
     alwayslink = LEGACY_ALWAYSLINK,
 )
 
 envoy_cc_library(
     name = "quic_ssl_connection_info_lib",
-    hdrs = ["quic_ssl_connection_info.h"],
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["quic_ssl_connection_info.h"],
+    }),
     external_deps = ["ssl"],
-    tags = ["nofips"],
-    deps = [
-        "//source/common/tls:connection_info_impl_base_lib",
-        "@com_github_google_quiche//:quic_core_session_lib",
-    ],
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//source/common/tls:connection_info_impl_base_lib",
+            "@com_github_google_quiche//:quic_core_session_lib",
+        ],
+    }),
 )
 
 envoy_cc_library(
     name = "quic_filter_manager_connection_lib",
-    srcs = ["quic_filter_manager_connection_impl.cc"],
-    hdrs = ["quic_filter_manager_connection_impl.h"],
-    tags = ["nofips"],
-    deps = [
-        ":envoy_quic_simulated_watermark_buffer_lib",
-        ":quic_network_connection_lib",
-        ":quic_ssl_connection_info_lib",
-        ":quic_stat_names_lib",
-        ":send_buffer_monitor_lib",
-        "//envoy/event:dispatcher_interface",
-        "//envoy/network:connection_interface",
-        "//source/common/buffer:buffer_lib",
-        "//source/common/common:assert_lib",
-        "//source/common/common:empty_string",
-        "//source/common/http:header_map_lib",
-        "//source/common/http/http3:codec_stats_lib",
-        "//source/common/network:connection_base_lib",
-        "//source/common/stream_info:stream_info_lib",
-        "@com_github_google_quiche//:quic_core_connection_lib",
-    ],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["quic_filter_manager_connection_impl.cc"],
+    }),
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["quic_filter_manager_connection_impl.h"],
+    }),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":envoy_quic_simulated_watermark_buffer_lib",
+            ":quic_network_connection_lib",
+            ":quic_ssl_connection_info_lib",
+            ":quic_stat_names_lib",
+            ":send_buffer_monitor_lib",
+            "//envoy/event:dispatcher_interface",
+            "//envoy/network:connection_interface",
+            "//source/common/buffer:buffer_lib",
+            "//source/common/common:assert_lib",
+            "//source/common/common:empty_string",
+            "//source/common/http:header_map_lib",
+            "//source/common/http/http3:codec_stats_lib",
+            "//source/common/network:connection_base_lib",
+            "//source/common/stream_info:stream_info_lib",
+            "@com_github_google_quiche//:quic_core_connection_lib",
+        ],
+    }),
 )
 
 envoy_cc_library(
     name = "envoy_quic_server_session_lib",
-    srcs = [
-        "envoy_quic_server_session.cc",
-        "envoy_quic_server_stream.cc",
-    ],
-    hdrs = [
-        "envoy_quic_server_session.h",
-        "envoy_quic_server_stream.h",
-    ],
-    tags = ["nofips"],
-    deps = [
-        ":envoy_quic_connection_debug_visitor_factory_interface",
-        ":envoy_quic_proof_source_lib",
-        ":envoy_quic_server_connection_lib",
-        ":envoy_quic_server_crypto_stream_factory_lib",
-        ":envoy_quic_stream_lib",
-        ":envoy_quic_utils_lib",
-        ":quic_filter_manager_connection_lib",
-        ":quic_stat_names_lib",
-        ":quic_stats_gatherer",
-        "//source/common/buffer:buffer_lib",
-        "//source/common/common:assert_lib",
-        "//source/common/http:header_map_lib",
-        "@com_github_google_quiche//:quic_server_http_spdy_session_lib",
-        "@com_google_absl//absl/types:optional",
-    ] + envoy_select_enable_http_datagrams([
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "envoy_quic_server_session.cc",
+            "envoy_quic_server_stream.cc",
+        ],
+    }),
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "envoy_quic_server_session.h",
+            "envoy_quic_server_stream.h",
+        ],
+    }),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":envoy_quic_connection_debug_visitor_factory_interface",
+            ":envoy_quic_proof_source_lib",
+            ":envoy_quic_server_connection_lib",
+            ":envoy_quic_server_crypto_stream_factory_lib",
+            ":envoy_quic_stream_lib",
+            ":envoy_quic_utils_lib",
+            ":quic_filter_manager_connection_lib",
+            ":quic_stat_names_lib",
+            ":quic_stats_gatherer",
+            "//source/common/buffer:buffer_lib",
+            "//source/common/common:assert_lib",
+            "//source/common/http:header_map_lib",
+            "@com_github_google_quiche//:quic_server_http_spdy_session_lib",
+            "@com_google_absl//absl/types:optional",
+        ],
+    }) + envoy_select_enable_http_datagrams([
         ":http_datagram_handler",
     ]),
 )
 
 envoy_cc_library(
     name = "envoy_quic_client_session_lib",
-    srcs = [
-        "envoy_quic_client_session.cc",
-        "envoy_quic_client_stream.cc",
-        "quic_network_connectivity_observer.cc",
-    ],
-    hdrs = [
-        "envoy_quic_client_session.h",
-        "envoy_quic_client_stream.h",
-        "envoy_quic_network_observer_registry_factory.h",
-        "quic_network_connectivity_observer.h",
-    ],
-    tags = ["nofips"],
-    deps = [
-        ":envoy_quic_client_connection_lib",
-        ":envoy_quic_client_crypto_stream_factory_lib",
-        ":envoy_quic_proof_verifier_lib",
-        ":envoy_quic_stream_lib",
-        ":envoy_quic_utils_lib",
-        ":quic_filter_manager_connection_lib",
-        ":quic_stat_names_lib",
-        ":quic_transport_socket_factory_lib",
-        "//envoy/http:http_server_properties_cache_interface",
-        "//source/common/buffer:buffer_lib",
-        "//source/common/common:assert_lib",
-        "//source/common/http:codes_lib",
-        "//source/common/http:header_map_lib",
-        "//source/common/http:header_utility_lib",
-        "@com_github_google_quiche//:quic_core_http_client_lib",
-    ] + envoy_select_enable_http_datagrams([
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "envoy_quic_client_session.cc",
+            "envoy_quic_client_stream.cc",
+            "quic_network_connectivity_observer.cc",
+        ],
+    }),
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "envoy_quic_client_session.h",
+            "envoy_quic_client_stream.h",
+            "envoy_quic_network_observer_registry_factory.h",
+            "quic_network_connectivity_observer.h",
+        ],
+    }),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":envoy_quic_client_connection_lib",
+            ":envoy_quic_client_crypto_stream_factory_lib",
+            ":envoy_quic_proof_verifier_lib",
+            ":envoy_quic_stream_lib",
+            ":envoy_quic_utils_lib",
+            ":quic_filter_manager_connection_lib",
+            ":quic_stat_names_lib",
+            ":quic_transport_socket_factory_lib",
+            "//envoy/http:http_server_properties_cache_interface",
+            "//source/common/buffer:buffer_lib",
+            "//source/common/common:assert_lib",
+            "//source/common/http:codes_lib",
+            "//source/common/http:header_map_lib",
+            "//source/common/http:header_utility_lib",
+            "@com_github_google_quiche//:quic_core_http_client_lib",
+        ],
+    }) + envoy_select_enable_http_datagrams([
         ":http_datagram_handler",
     ]),
 )
@@ -346,7 +488,6 @@ envoy_cc_library(
     hdrs = [
         "envoy_quic_network_observer_registry_factory.h",
     ],
-    tags = ["nofips"],
     deps = envoy_select_enable_http3([
         ":envoy_quic_client_session_lib",
     ]),
@@ -365,7 +506,6 @@ envoy_cc_library(
     name = "quic_network_connection_lib",
     srcs = ["quic_network_connection.cc"],
     hdrs = ["quic_network_connection.h"],
-    tags = ["nofips"],
     deps = [
         "//envoy/network:connection_interface",
     ],
@@ -373,54 +513,78 @@ envoy_cc_library(
 
 envoy_cc_library(
     name = "envoy_quic_server_connection_lib",
-    srcs = ["envoy_quic_server_connection.cc"],
-    hdrs = ["envoy_quic_server_connection.h"],
-    tags = ["nofips"],
-    deps = [
-        ":quic_io_handle_wrapper_lib",
-        ":quic_network_connection_lib",
-        "//source/common/network:generic_listener_filter_impl_base_lib",
-        "//source/common/network:listen_socket_lib",
-        "//source/common/quic:envoy_quic_utils_lib",
-        "@com_github_google_quiche//:quic_core_connection_lib",
-        "@com_github_google_quiche//:quic_core_packet_writer_lib",
-        "@com_github_google_quiche//:quic_core_packets_lib",
-    ],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_server_connection.cc"],
+    }),
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_server_connection.h"],
+    }),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":quic_io_handle_wrapper_lib",
+            ":quic_network_connection_lib",
+            "//source/common/network:generic_listener_filter_impl_base_lib",
+            "//source/common/network:listen_socket_lib",
+            "//source/common/quic:envoy_quic_utils_lib",
+            "@com_github_google_quiche//:quic_core_connection_lib",
+            "@com_github_google_quiche//:quic_core_packet_writer_lib",
+            "@com_github_google_quiche//:quic_core_packets_lib",
+        ],
+    }),
 )
 
 envoy_cc_library(
     name = "envoy_quic_client_connection_lib",
-    srcs = ["envoy_quic_client_connection.cc"],
-    hdrs = ["envoy_quic_client_connection.h"],
-    tags = ["nofips"],
-    deps = [
-        ":envoy_quic_packet_writer_lib",
-        ":quic_network_connection_lib",
-        "//envoy/event:dispatcher_interface",
-        "//source/common/network:socket_option_factory_lib",
-        "//source/common/network:udp_packet_writer_handler_lib",
-        "//source/common/runtime:runtime_lib",
-        "@com_github_google_quiche//:quic_core_connection_lib",
-        "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
-    ],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_client_connection.cc"],
+    }),
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_client_connection.h"],
+    }),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":envoy_quic_packet_writer_lib",
+            ":quic_network_connection_lib",
+            "//envoy/event:dispatcher_interface",
+            "//source/common/network:socket_option_factory_lib",
+            "//source/common/network:udp_packet_writer_handler_lib",
+            "//source/common/runtime:runtime_lib",
+            "@com_github_google_quiche//:quic_core_connection_lib",
+            "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
+        ],
+    }),
 )
 
 envoy_cc_library(
     name = "envoy_quic_dispatcher_lib",
-    srcs = ["envoy_quic_dispatcher.cc"],
-    hdrs = ["envoy_quic_dispatcher.h"],
-    tags = ["nofips"],
-    deps = [
-        ":envoy_quic_connection_debug_visitor_factory_interface",
-        ":envoy_quic_proof_source_lib",
-        ":envoy_quic_server_connection_lib",
-        ":envoy_quic_server_crypto_stream_factory_lib",
-        ":envoy_quic_server_session_lib",
-        ":quic_stat_names_lib",
-        "//envoy/network:listener_interface",
-        "@com_github_google_quiche//:quic_core_server_lib",
-        "@com_github_google_quiche//:quic_core_utils_lib",
-    ],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_dispatcher.cc"],
+    }),
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_dispatcher.h"],
+    }),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":envoy_quic_connection_debug_visitor_factory_interface",
+            ":envoy_quic_proof_source_lib",
+            ":envoy_quic_server_connection_lib",
+            ":envoy_quic_server_crypto_stream_factory_lib",
+            ":envoy_quic_server_session_lib",
+            ":quic_stat_names_lib",
+            "//envoy/network:listener_interface",
+            "@com_github_google_quiche//:quic_core_server_lib",
+            "@com_github_google_quiche//:quic_core_utils_lib",
+        ],
+    }),
 )
 
 envoy_cc_library(
@@ -431,105 +595,137 @@ envoy_cc_library(
 
 envoy_cc_library(
     name = "active_quic_listener_lib",
-    srcs = ["active_quic_listener.cc"],
-    hdrs = ["active_quic_listener.h"],
-    tags = ["nofips"],
-    deps = [
-        ":envoy_quic_alarm_factory_lib",
-        ":envoy_quic_connection_debug_visitor_factory_interface",
-        ":envoy_quic_connection_helper_lib",
-        ":envoy_quic_dispatcher_lib",
-        ":envoy_quic_packet_writer_lib",
-        ":envoy_quic_proof_source_factory_interface",
-        ":envoy_quic_proof_source_lib",
-        ":envoy_quic_server_preferred_address_config_factory_interface",
-        ":envoy_quic_utils_lib",
-        "//envoy/network:listener_interface",
-        "//source/common/network:listener_lib",
-        "//source/common/protobuf:utility_lib",
-        "//source/common/runtime:runtime_lib",
-        "//source/extensions/quic/connection_id_generator/deterministic:envoy_deterministic_connection_id_generator_config",
-        "//source/server:active_udp_listener",
-        "@envoy_api//envoy/config/listener/v3:pkg_cc_proto",
-        "@envoy_api//envoy/extensions/quic/connection_id_generator/v3:pkg_cc_proto",
-        "@envoy_api//envoy/extensions/quic/crypto_stream/v3:pkg_cc_proto",
-        "@envoy_api//envoy/extensions/quic/proof_source/v3:pkg_cc_proto",
-    ],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["active_quic_listener.cc"],
+    }),
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["active_quic_listener.h"],
+    }),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":envoy_quic_alarm_factory_lib",
+            ":envoy_quic_connection_debug_visitor_factory_interface",
+            ":envoy_quic_connection_helper_lib",
+            ":envoy_quic_dispatcher_lib",
+            ":envoy_quic_packet_writer_lib",
+            ":envoy_quic_proof_source_factory_interface",
+            ":envoy_quic_proof_source_lib",
+            ":envoy_quic_server_preferred_address_config_factory_interface",
+            ":envoy_quic_utils_lib",
+            "//envoy/network:listener_interface",
+            "//source/common/network:listener_lib",
+            "//source/common/protobuf:utility_lib",
+            "//source/common/runtime:runtime_lib",
+            "//source/extensions/quic/connection_id_generator/deterministic:envoy_deterministic_connection_id_generator_config",
+            "//source/server:active_udp_listener",
+            "@envoy_api//envoy/config/listener/v3:pkg_cc_proto",
+            "@envoy_api//envoy/extensions/quic/connection_id_generator/v3:pkg_cc_proto",
+            "@envoy_api//envoy/extensions/quic/crypto_stream/v3:pkg_cc_proto",
+            "@envoy_api//envoy/extensions/quic/proof_source/v3:pkg_cc_proto",
+        ],
+    }),
 )
 
 envoy_cc_library(
     name = "envoy_quic_utils_lib",
-    srcs = ["envoy_quic_utils.cc"],
-    hdrs = ["envoy_quic_utils.h"],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_utils.cc"],
+    }),
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_utils.h"],
+    }),
     external_deps = ["ssl"],
-    tags = ["nofips"],
-    deps = [
-        "//envoy/http:codec_interface",
-        "//source/common/http:header_map_lib",
-        "//source/common/http:header_utility_lib",
-        "//source/common/network:address_lib",
-        "//source/common/network:connection_socket_lib",
-        "//source/common/network:socket_option_factory_lib",
-        "//source/common/protobuf:utility_lib",
-        "//source/common/quic:quic_io_handle_wrapper_lib",
-        "@com_github_google_quiche//:quic_core_config_lib",
-        "@com_github_google_quiche//:quic_core_http_header_list_lib",
-        "@com_github_google_quiche//:quic_platform",
-        "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
-        "@envoy_api//envoy/config/listener/v3:pkg_cc_proto",
-    ],
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//envoy/http:codec_interface",
+            "//source/common/http:header_map_lib",
+            "//source/common/http:header_utility_lib",
+            "//source/common/network:address_lib",
+            "//source/common/network:connection_socket_lib",
+            "//source/common/network:socket_option_factory_lib",
+            "//source/common/protobuf:utility_lib",
+            "//source/common/quic:quic_io_handle_wrapper_lib",
+            "@com_github_google_quiche//:quic_core_config_lib",
+            "@com_github_google_quiche//:quic_core_http_header_list_lib",
+            "@com_github_google_quiche//:quic_platform",
+            "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
+            "@envoy_api//envoy/config/listener/v3:pkg_cc_proto",
+        ],
+    }),
 )
 
 envoy_cc_library(
     name = "quic_transport_socket_factory_lib",
-    srcs = [
-        "quic_client_transport_socket_factory.cc",
-        "quic_transport_socket_factory.cc",
-    ],
-    hdrs = [
-        "quic_client_transport_socket_factory.h",
-        "quic_transport_socket_factory.h",
-    ],
-    tags = ["nofips"],
-    deps = [
-        ":envoy_quic_proof_verifier_lib",
-        "//envoy/network:transport_socket_interface",
-        "//envoy/server:transport_socket_config_interface",
-        "//envoy/ssl:context_config_interface",
-        "//source/common/common:assert_lib",
-        "//source/common/network:transport_socket_options_lib",
-        "//source/common/quic:cert_compression_lib",
-        "//source/common/tls:client_ssl_socket_lib",
-        "//source/common/tls:context_config_lib",
-        "@com_github_google_quiche//:quic_core_crypto_crypto_handshake_lib",
-        "@envoy_api//envoy/extensions/transport_sockets/quic/v3:pkg_cc_proto",
-    ],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "quic_client_transport_socket_factory.cc",
+            "quic_transport_socket_factory.cc",
+        ],
+    }),
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "quic_client_transport_socket_factory.h",
+            "quic_transport_socket_factory.h",
+        ],
+    }),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":envoy_quic_proof_verifier_lib",
+            "//envoy/network:transport_socket_interface",
+            "//envoy/server:transport_socket_config_interface",
+            "//envoy/ssl:context_config_interface",
+            "//source/common/common:assert_lib",
+            "//source/common/network:transport_socket_options_lib",
+            "//source/common/quic:cert_compression_lib",
+            "//source/common/tls:client_ssl_socket_lib",
+            "//source/common/tls:context_config_lib",
+            "@com_github_google_quiche//:quic_core_crypto_crypto_handshake_lib",
+            "@envoy_api//envoy/extensions/transport_sockets/quic/v3:pkg_cc_proto",
+        ],
+    }),
     alwayslink = LEGACY_ALWAYSLINK,
 )
 
 envoy_cc_library(
     name = "quic_server_transport_socket_factory_lib",
-    srcs = [
-        "quic_server_transport_socket_factory.cc",
-    ],
-    hdrs = [
-        "quic_server_transport_socket_factory.h",
-    ],
-    tags = ["nofips"],
-    deps = [
-        ":envoy_quic_proof_verifier_lib",
-        ":quic_transport_socket_factory_lib",
-        "//envoy/network:transport_socket_interface",
-        "//envoy/server:transport_socket_config_interface",
-        "//envoy/ssl:context_config_interface",
-        "//source/common/common:assert_lib",
-        "//source/common/network:transport_socket_options_lib",
-        "//source/common/tls:server_context_config_lib",
-        "//source/common/tls:server_context_lib",
-        "//source/common/tls:server_ssl_socket_lib",
-        "@com_github_google_quiche//:quic_core_crypto_crypto_handshake_lib",
-        "@envoy_api//envoy/extensions/transport_sockets/quic/v3:pkg_cc_proto",
-    ],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "quic_server_transport_socket_factory.cc",
+        ],
+    }),
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "quic_server_transport_socket_factory.h",
+        ],
+    }),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":envoy_quic_proof_verifier_lib",
+            ":quic_transport_socket_factory_lib",
+            "//envoy/network:transport_socket_interface",
+            "//envoy/server:transport_socket_config_interface",
+            "//envoy/ssl:context_config_interface",
+            "//source/common/common:assert_lib",
+            "//source/common/network:transport_socket_options_lib",
+            "//source/common/tls:server_context_config_lib",
+            "//source/common/tls:server_context_lib",
+            "//source/common/tls:server_ssl_socket_lib",
+            "@com_github_google_quiche//:quic_core_crypto_crypto_handshake_lib",
+            "@envoy_api//envoy/extensions/transport_sockets/quic/v3:pkg_cc_proto",
+        ],
+    }),
     alwayslink = LEGACY_ALWAYSLINK,
 )
 
@@ -537,13 +733,8 @@ envoy_cc_library(
 # All of these are needed for this extension to function.
 envoy_cc_library(
     name = "quic_client_factory_lib",
-    tags = ["nofips"],
-    # QUICHE can't build against FIPS BoringSSL until the FIPS build
-    # is on a new enough version to have QUIC support. Remove it from
-    # the build until then. Re-enable as part of #7433.
     deps = select({
-        "//bazel:boringssl_fips": [],
-        "//bazel:boringssl_disabled": [],
+        "//bazel:disable_http3": [],
         "//conditions:default": [
             ":client_codec_lib",
             ":quic_transport_socket_factory_lib",
@@ -568,13 +759,8 @@ envoy_cc_library(
 # All of these are needed for this extension to function.
 envoy_cc_library(
     name = "quic_server_factory_lib",
-    tags = ["nofips"],
-    # QUICHE can't build against FIPS BoringSSL until the FIPS build
-    # is on a new enough version to have QUIC support. Remove it from
-    # the build until then. Re-enable as part of #7433.
     deps = select({
-        "//bazel:boringssl_fips": [],
-        "//bazel:boringssl_disabled": [],
+        "//bazel:disable_http3": [],
         "//conditions:default": [
             ":quic_transport_socket_factory_lib",
             ":server_codec_lib",
@@ -586,155 +772,235 @@ envoy_cc_library(
 
 envoy_cc_library(
     name = "envoy_quic_packet_writer_lib",
-    srcs = ["envoy_quic_packet_writer.cc"],
-    hdrs = ["envoy_quic_packet_writer.h"],
-    tags = ["nofips"],
-    deps = [
-        ":envoy_quic_utils_lib",
-        "@com_github_google_quiche//:quic_core_packet_writer_lib",
-        "@com_github_google_quiche//:quic_platform",
-    ],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_packet_writer.cc"],
+    }),
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_packet_writer.h"],
+    }),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":envoy_quic_utils_lib",
+            "@com_github_google_quiche//:quic_core_packet_writer_lib",
+            "@com_github_google_quiche//:quic_platform",
+        ],
+    }),
 )
 
 envoy_cc_library(
     name = "udp_gso_batch_writer_lib",
     srcs = select({
-        "//bazel:linux": ["udp_gso_batch_writer.cc"],
+        ":http3_enabled_and_linux": ["udp_gso_batch_writer.cc"],
         "//conditions:default": [],
     }),
-    hdrs = ["udp_gso_batch_writer.h"],
-    tags = ["nofips"],
-    deps = [
-        ":envoy_quic_utils_lib",
-        "//envoy/network:udp_packet_writer_handler_interface",
-        "//source/common/network:io_socket_error_lib",
-        "//source/common/protobuf:utility_lib",
-        "//source/common/runtime:runtime_lib",
-        "@com_github_google_quiche//:quic_platform",
-    ] + select({
-        "//bazel:linux": ["@com_github_google_quiche//:quic_core_batch_writer_gso_batch_writer_lib"],
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["udp_gso_batch_writer.h"],
+    }),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":envoy_quic_utils_lib",
+            "//envoy/network:udp_packet_writer_handler_interface",
+            "//source/common/network:io_socket_error_lib",
+            "//source/common/protobuf:utility_lib",
+            "//source/common/runtime:runtime_lib",
+            "@com_github_google_quiche//:quic_platform",
+        ],
+    }) + select({
+        ":http3_enabled_and_linux": ["@com_github_google_quiche//:quic_core_batch_writer_gso_batch_writer_lib"],
         "//conditions:default": [],
     }),
 )
 
 envoy_cc_library(
     name = "send_buffer_monitor_lib",
-    srcs = ["send_buffer_monitor.cc"],
-    hdrs = ["send_buffer_monitor.h"],
-    tags = ["nofips"],
-    deps = [
-        "//source/common/common:assert_lib",
-        "@com_github_google_quiche//:quic_core_session_lib",
-    ],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["send_buffer_monitor.cc"],
+    }),
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["send_buffer_monitor.h"],
+    }),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//source/common/common:assert_lib",
+            "@com_github_google_quiche//:quic_core_session_lib",
+        ],
+    }),
 )
 
 envoy_cc_library(
     name = "envoy_quic_client_crypto_stream_factory_lib",
-    hdrs = ["envoy_quic_client_crypto_stream_factory.h"],
-    tags = ["nofips"],
-    deps = [
-        "//envoy/common:optref_lib",
-        "//envoy/config:typed_config_interface",
-        "//envoy/network:transport_socket_interface",
-        "@com_github_google_quiche//:quic_client_session_lib",
-        "@com_github_google_quiche//:quic_core_http_spdy_session_lib",
-    ],
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_client_crypto_stream_factory.h"],
+    }),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//envoy/common:optref_lib",
+            "//envoy/config:typed_config_interface",
+            "//envoy/network:transport_socket_interface",
+            "@com_github_google_quiche//:quic_client_session_lib",
+            "@com_github_google_quiche//:quic_core_http_spdy_session_lib",
+        ],
+    }),
 )
 
 envoy_cc_library(
     name = "envoy_quic_server_crypto_stream_factory_lib",
-    hdrs = ["envoy_quic_server_crypto_stream_factory.h"],
-    tags = ["nofips"],
-    deps = [
-        "//envoy/config:typed_config_interface",
-        "@com_github_google_quiche//:quic_core_http_spdy_session_lib",
-        "@com_github_google_quiche//:quic_server_session_lib",
-    ],
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_server_crypto_stream_factory.h"],
+    }),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//envoy/config:typed_config_interface",
+            "@com_github_google_quiche//:quic_core_http_spdy_session_lib",
+            "@com_github_google_quiche//:quic_server_session_lib",
+        ],
+    }),
 )
 
 envoy_cc_library(
     name = "envoy_quic_proof_source_factory_interface",
-    hdrs = ["envoy_quic_proof_source_factory_interface.h"],
-    tags = ["nofips"],
-    deps = [
-        "//envoy/config:typed_config_interface",
-        "@com_github_google_quiche//:quic_core_crypto_proof_source_lib",
-    ],
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_proof_source_factory_interface.h"],
+    }),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//envoy/config:typed_config_interface",
+            "@com_github_google_quiche//:quic_core_crypto_proof_source_lib",
+        ],
+    }),
 )
 
 envoy_cc_library(
     name = "envoy_quic_connection_id_generator_factory_interface",
-    hdrs = ["envoy_quic_connection_id_generator_factory.h"],
-    tags = ["nofips"],
-    deps = [
-        "//envoy/config:typed_config_interface",
-        "@com_github_google_quiche//:quic_core_connection_id_generator_interface_lib",
-        "@com_github_google_quiche//:quic_load_balancer_encoder_lib",
-    ],
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_connection_id_generator_factory.h"],
+    }),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//envoy/config:typed_config_interface",
+            "@com_github_google_quiche//:quic_core_connection_id_generator_interface_lib",
+            "@com_github_google_quiche//:quic_load_balancer_encoder_lib",
+        ],
+    }),
 )
 
 envoy_cc_library(
     name = "envoy_deterministic_connection_id_generator_lib",
-    srcs = ["envoy_deterministic_connection_id_generator.cc"],
-    hdrs = ["envoy_deterministic_connection_id_generator.h"],
-    tags = ["nofips"],
-    deps = [
-        ":envoy_quic_connection_id_generator_factory_interface",
-        ":envoy_quic_utils_lib",
-        "@com_github_google_quiche//:quic_core_deterministic_connection_id_generator_lib",
-    ],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_deterministic_connection_id_generator.cc"],
+    }),
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_deterministic_connection_id_generator.h"],
+    }),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":envoy_quic_connection_id_generator_factory_interface",
+            ":envoy_quic_utils_lib",
+            "@com_github_google_quiche//:quic_core_deterministic_connection_id_generator_lib",
+        ],
+    }),
 )
 
 envoy_cc_library(
     name = "envoy_quic_server_preferred_address_config_factory_interface",
-    hdrs = ["envoy_quic_server_preferred_address_config_factory.h"],
-    tags = ["nofips"],
-    deps = [
-        "//envoy/config:typed_config_interface",
-        "//envoy/network:address_interface",
-        "//envoy/server:factory_context_interface",
-        "@com_github_google_quiche//:quic_platform_socket_address",
-    ],
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_server_preferred_address_config_factory.h"],
+    }),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//envoy/config:typed_config_interface",
+            "//envoy/network:address_interface",
+            "//envoy/server:factory_context_interface",
+            "@com_github_google_quiche//:quic_platform_socket_address",
+        ],
+    }),
 )
 
 envoy_cc_library(
     name = "quic_stats_gatherer",
-    srcs = ["quic_stats_gatherer.cc"],
-    hdrs = ["quic_stats_gatherer.h"],
-    tags = ["nofips"],
-    deps = [
-        "//envoy/access_log:access_log_interface",
-        "//envoy/formatter:http_formatter_context_interface",
-        "//envoy/http:codec_interface",
-        "//source/common/formatter:substitution_formatter_lib",
-        "//source/common/http:header_map_lib",
-        "@com_github_google_quiche//:quic_core_ack_listener_interface_lib",
-    ],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["quic_stats_gatherer.cc"],
+    }),
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["quic_stats_gatherer.h"],
+    }),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//envoy/access_log:access_log_interface",
+            "//envoy/formatter:http_formatter_context_interface",
+            "//envoy/http:codec_interface",
+            "//source/common/formatter:substitution_formatter_lib",
+            "//source/common/http:header_map_lib",
+            "@com_github_google_quiche//:quic_core_ack_listener_interface_lib",
+        ],
+    }),
 )
 
 envoy_cc_library(
     name = "http_datagram_handler",
-    srcs = ["http_datagram_handler.cc"],
-    hdrs = ["http_datagram_handler.h"],
-    deps = [
-        "//envoy/http:codec_interface",
-        "//source/common/buffer:buffer_lib",
-        "//source/common/common:logger_lib",
-        "//source/common/http:header_map_lib",
-        "@com_github_google_quiche//:quic_core_http_spdy_session_lib",
-        "@com_github_google_quiche//:quic_core_types_lib",
-    ],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["http_datagram_handler.cc"],
+    }),
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["http_datagram_handler.h"],
+    }),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//envoy/http:codec_interface",
+            "//source/common/buffer:buffer_lib",
+            "//source/common/common:logger_lib",
+            "//source/common/http:header_map_lib",
+            "@com_github_google_quiche//:quic_core_http_spdy_session_lib",
+            "@com_github_google_quiche//:quic_core_types_lib",
+        ],
+    }),
 )
 
 envoy_cc_library(
     name = "cert_compression_lib",
-    srcs = ["cert_compression.cc"],
-    hdrs = ["cert_compression.h"],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["cert_compression.cc"],
+    }),
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["cert_compression.h"],
+    }),
     external_deps = ["ssl"],
-    deps = [
-        "//bazel/foreign_cc:zlib",
-        "//source/common/common:assert_lib",
-        "//source/common/common:logger_lib",
-        "//source/common/runtime:runtime_lib",
-    ],
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//bazel/foreign_cc:zlib",
+            "//source/common/common:assert_lib",
+            "//source/common/common:logger_lib",
+            "//source/common/runtime:runtime_lib",
+        ],
+    }),
 )

--- a/source/common/quic/platform/BUILD
+++ b/source/common/quic/platform/BUILD
@@ -82,7 +82,6 @@ envoy_quiche_platform_impl_cc_library(
         "quiche_bug_tracker_impl.h",
         "quiche_logging_impl.h",
     ],
-    tags = ["nofips"],
     deps = [
         "//source/common/common:assert_lib",
         "//source/common/common:utility_lib",
@@ -91,7 +90,6 @@ envoy_quiche_platform_impl_cc_library(
 
 envoy_quiche_platform_impl_cc_library(
     name = "quic_base_impl_lib",
-    tags = ["nofips"],
     deps = [
         ":quiche_flags_impl_lib",
         "//source/common/common:assert_lib",
@@ -111,7 +109,6 @@ envoy_quiche_platform_impl_cc_library(
     hdrs = [
         "quiche_iovec_impl.h",
     ],
-    tags = ["nofips"],
     deps = [
         "//envoy/common:base_includes",
     ],
@@ -122,7 +119,6 @@ envoy_quiche_platform_impl_cc_library(
     hdrs = [
         "quiche_stack_trace_impl.h",
     ],
-    tags = ["nofips"],
     deps = [
         "//source/server:backtrace_lib",
         "@com_github_google_quiche//:quiche_common_platform_export",
@@ -151,13 +147,11 @@ envoy_quiche_platform_impl_cc_library(
 envoy_quiche_platform_impl_cc_library(
     name = "quiche_lower_case_string_impl_lib",
     hdrs = ["quiche_lower_case_string_impl.h"],
-    tags = ["nofips"],
     deps = ["//envoy/http:header_map_interface"],
 )
 
 envoy_quiche_platform_impl_cc_library(
     name = "quiche_export_impl_lib",
     hdrs = ["quiche_export_impl.h"],
-    tags = ["nofips"],
     deps = ["@com_google_absl//absl/base"],
 )

--- a/source/common/quic/platform/mobile_impl/BUILD
+++ b/source/common/quic/platform/mobile_impl/BUILD
@@ -16,7 +16,6 @@ envoy_quiche_platform_impl_cc_library(
     hdrs = [
         "quiche_bug_tracker_impl.h",
     ],
-    tags = ["nofips"],
     deps = [
         "@com_github_google_quiche//:quiche_common_platform_logging",
     ],

--- a/source/extensions/quic/connection_debug_visitor/basic/BUILD
+++ b/source/extensions/quic/connection_debug_visitor/basic/BUILD
@@ -17,24 +17,32 @@ envoy_extension_package()
 
 envoy_cc_library(
     name = "envoy_quic_connection_debug_visitor_basic_lib",
-    srcs = ["envoy_quic_connection_debug_visitor_basic.cc"],
-    hdrs = ["envoy_quic_connection_debug_visitor_basic.h"],
-    tags = ["nofips"],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_connection_debug_visitor_basic.cc"],
+    }),
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_connection_debug_visitor_basic.h"],
+    }),
     visibility = [
         "//source/common/quic:__subpackages__",
     ],
-    deps = [
-        "//envoy/registry",
-        "//envoy/stream_info:stream_info_interface",
-        "//source/common/common:minimal_logger_lib",
-        "//source/common/protobuf:utility_lib",
-        "//source/common/quic:envoy_quic_connection_debug_visitor_factory_interface",
-        "@com_github_google_quiche//:quic_core_connection_lib",
-        "@com_github_google_quiche//:quic_core_frames_frames_lib",
-        "@com_github_google_quiche//:quic_core_session_lib",
-        "@com_github_google_quiche//:quic_core_types_lib",
-        "@envoy_api//envoy/extensions/quic/connection_debug_visitor/v3:pkg_cc_proto",
-    ],
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//envoy/registry",
+            "//envoy/stream_info:stream_info_interface",
+            "//source/common/common:minimal_logger_lib",
+            "//source/common/protobuf:utility_lib",
+            "//source/common/quic:envoy_quic_connection_debug_visitor_factory_interface",
+            "@com_github_google_quiche//:quic_core_connection_lib",
+            "@com_github_google_quiche//:quic_core_frames_frames_lib",
+            "@com_github_google_quiche//:quic_core_session_lib",
+            "@com_github_google_quiche//:quic_core_types_lib",
+            "@envoy_api//envoy/extensions/quic/connection_debug_visitor/v3:pkg_cc_proto",
+        ],
+    }),
     alwayslink = LEGACY_ALWAYSLINK,
 )
 
@@ -44,14 +52,10 @@ envoy_cc_extension(
         "//source/common/quic:__subpackages__",
         "//test:__subpackages__",
     ],
-    tags = ["nofips"],
-    deps = select(
-        {
-            "//bazel:boringssl_fips": [],
-            "//bazel:boringssl_disabled": [],
-            "//conditions:default": [
-                ":envoy_quic_connection_debug_visitor_basic_lib",
-            ],
-        },
-    ),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":envoy_quic_connection_debug_visitor_basic_lib",
+        ],
+    }),
 )

--- a/source/extensions/quic/connection_debug_visitor/quic_stats/BUILD
+++ b/source/extensions/quic/connection_debug_visitor/quic_stats/BUILD
@@ -15,18 +15,26 @@ envoy_extension_package()
 
 envoy_cc_library(
     name = "quic_stats_lib",
-    srcs = ["quic_stats.cc"],
-    hdrs = ["quic_stats.h"],
-    tags = ["nofips"],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["quic_stats.cc"],
+    }),
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["quic_stats.h"],
+    }),
     visibility = [
         "//test:__subpackages__",
     ],
-    deps = [
-        "//envoy/registry",
-        "//source/common/protobuf:utility_lib",
-        "//source/common/quic:envoy_quic_connection_debug_visitor_factory_interface",
-        "@envoy_api//envoy/extensions/quic/connection_debug_visitor/quic_stats/v3:pkg_cc_proto",
-    ],
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//envoy/registry",
+            "//source/common/protobuf:utility_lib",
+            "//source/common/quic:envoy_quic_connection_debug_visitor_factory_interface",
+            "@envoy_api//envoy/extensions/quic/connection_debug_visitor/quic_stats/v3:pkg_cc_proto",
+        ],
+    }),
     alwayslink = LEGACY_ALWAYSLINK,
 )
 
@@ -36,14 +44,10 @@ envoy_cc_extension(
         "//source/common/quic:__subpackages__",
         "//test:__subpackages__",
     ],
-    tags = ["nofips"],
-    deps = select(
-        {
-            "//bazel:boringssl_fips": [],
-            "//bazel:boringssl_disabled": [],
-            "//conditions:default": [
-                ":quic_stats_lib",
-            ],
-        },
-    ),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":quic_stats_lib",
+        ],
+    }),
 )

--- a/source/extensions/quic/connection_id_generator/deterministic/BUILD
+++ b/source/extensions/quic/connection_id_generator/deterministic/BUILD
@@ -17,15 +17,23 @@ envoy_extension_package()
 
 envoy_cc_library(
     name = "envoy_deterministic_connection_id_generator_config_lib",
-    srcs = ["envoy_deterministic_connection_id_generator_config.cc"],
-    hdrs = ["envoy_deterministic_connection_id_generator_config.h"],
-    tags = ["nofips"],
-    deps = [
-        "//envoy/registry",
-        "//source/common/quic:envoy_deterministic_connection_id_generator_lib",
-        "//source/common/quic:envoy_quic_connection_id_generator_factory_interface",
-        "@envoy_api//envoy/extensions/quic/connection_id_generator/v3:pkg_cc_proto",
-    ],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_deterministic_connection_id_generator_config.cc"],
+    }),
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_deterministic_connection_id_generator_config.h"],
+    }),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//envoy/registry",
+            "//source/common/quic:envoy_deterministic_connection_id_generator_lib",
+            "//source/common/quic:envoy_quic_connection_id_generator_factory_interface",
+            "@envoy_api//envoy/extensions/quic/connection_id_generator/v3:pkg_cc_proto",
+        ],
+    }),
     alwayslink = LEGACY_ALWAYSLINK,
 )
 
@@ -34,14 +42,10 @@ envoy_cc_extension(
     extra_visibility = [
         "//source/common/quic:__subpackages__",
     ],
-    tags = ["nofips"],
-    deps = select(
-        {
-            "//bazel:boringssl_fips": [],
-            "//bazel:boringssl_disabled": [],
-            "//conditions:default": [
-                ":envoy_deterministic_connection_id_generator_config_lib",
-            ],
-        },
-    ),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":envoy_deterministic_connection_id_generator_config_lib",
+        ],
+    }),
 )

--- a/source/extensions/quic/connection_id_generator/quic_lb/BUILD
+++ b/source/extensions/quic/connection_id_generator/quic_lb/BUILD
@@ -15,44 +15,56 @@ envoy_extension_package()
 
 envoy_cc_library(
     name = "quic_lb_lib",
-    srcs = ["quic_lb.cc"],
-    hdrs = ["quic_lb.h"],
-    tags = ["nofips"],
-    deps = [
-        "//source/common/config:datasource_lib",
-        "//source/common/quic:envoy_quic_connection_id_generator_factory_interface",
-        "//source/common/quic:envoy_quic_utils_lib",
-        "@com_github_google_quiche//:quic_load_balancer_config_lib",
-        "@com_github_google_quiche//:quic_load_balancer_encoder_lib",
-        "@com_github_google_quiche//:quic_load_balancer_server_id_lib",
-        "@envoy_api//envoy/extensions/quic/connection_id_generator/quic_lb/v3:pkg_cc_proto",
-    ],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["quic_lb.cc"],
+    }),
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["quic_lb.h"],
+    }),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//source/common/config:datasource_lib",
+            "//source/common/quic:envoy_quic_connection_id_generator_factory_interface",
+            "//source/common/quic:envoy_quic_utils_lib",
+            "@com_github_google_quiche//:quic_load_balancer_config_lib",
+            "@com_github_google_quiche//:quic_load_balancer_encoder_lib",
+            "@com_github_google_quiche//:quic_load_balancer_server_id_lib",
+            "@envoy_api//envoy/extensions/quic/connection_id_generator/quic_lb/v3:pkg_cc_proto",
+        ],
+    }),
 )
 
 envoy_cc_library(
     name = "config_lib",
-    srcs = ["config.cc"],
-    hdrs = ["config.h"],
-    tags = ["nofips"],
-    deps = [
-        ":quic_lb_lib",
-        "//envoy/registry",
-        "//source/common/quic:envoy_quic_connection_id_generator_factory_interface",
-        "@envoy_api//envoy/extensions/quic/connection_id_generator/quic_lb/v3:pkg_cc_proto",
-    ],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["config.cc"],
+    }),
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["config.h"],
+    }),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":quic_lb_lib",
+            "//envoy/registry",
+            "//source/common/quic:envoy_quic_connection_id_generator_factory_interface",
+            "@envoy_api//envoy/extensions/quic/connection_id_generator/quic_lb/v3:pkg_cc_proto",
+        ],
+    }),
     alwayslink = LEGACY_ALWAYSLINK,
 )
 
 envoy_cc_extension(
     name = "quic_lb_config",
-    tags = ["nofips"],
-    deps = select(
-        {
-            "//bazel:boringssl_fips": [],
-            "//bazel:boringssl_disabled": [],
-            "//conditions:default": [
-                ":config_lib",
-            ],
-        },
-    ),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":config_lib",
+        ],
+    }),
 )

--- a/source/extensions/quic/crypto_stream/BUILD
+++ b/source/extensions/quic/crypto_stream/BUILD
@@ -17,18 +17,26 @@ envoy_extension_package()
 
 envoy_cc_library(
     name = "envoy_quic_crypto_server_stream_lib",
-    srcs = ["envoy_quic_crypto_server_stream.cc"],
-    hdrs = ["envoy_quic_crypto_server_stream.h"],
-    tags = ["nofips"],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_crypto_server_stream.cc"],
+    }),
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_crypto_server_stream.h"],
+    }),
     visibility = [
         "//source/common/quic:__subpackages__",
         "//test:__subpackages__",
     ],
-    deps = [
-        "//envoy/registry",
-        "//source/common/quic:envoy_quic_server_crypto_stream_factory_lib",
-        "@envoy_api//envoy/extensions/quic/crypto_stream/v3:pkg_cc_proto",
-    ],
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//envoy/registry",
+            "//source/common/quic:envoy_quic_server_crypto_stream_factory_lib",
+            "@envoy_api//envoy/extensions/quic/crypto_stream/v3:pkg_cc_proto",
+        ],
+    }),
     alwayslink = LEGACY_ALWAYSLINK,
 )
 
@@ -38,29 +46,33 @@ envoy_cc_extension(
         "//source/common/quic:__subpackages__",
         "//test:__subpackages__",
     ],
-    tags = ["nofips"],
-    deps = select(
-        {
-            "//bazel:boringssl_fips": [],
-            "//bazel:boringssl_disabled": [],
-            "//conditions:default": [
-                ":envoy_quic_crypto_server_stream_lib",
-            ],
-        },
-    ),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":envoy_quic_crypto_server_stream_lib",
+        ],
+    }),
 )
 
 envoy_cc_library(
     name = "envoy_quic_crypto_client_stream_lib",
-    srcs = ["envoy_quic_crypto_client_stream.cc"],
-    hdrs = ["envoy_quic_crypto_client_stream.h"],
-    tags = ["nofips"],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_crypto_client_stream.cc"],
+    }),
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_crypto_client_stream.h"],
+    }),
     visibility = [
         "//source/common/quic:__subpackages__",
         "//test:__subpackages__",
     ],
-    deps = [
-        "//source/common/quic:envoy_quic_client_crypto_stream_factory_lib",
-    ],
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//source/common/quic:envoy_quic_client_crypto_stream_factory_lib",
+        ],
+    }),
     alwayslink = LEGACY_ALWAYSLINK,
 )

--- a/source/extensions/quic/proof_source/BUILD
+++ b/source/extensions/quic/proof_source/BUILD
@@ -17,18 +17,26 @@ envoy_extension_package()
 
 envoy_cc_library(
     name = "envoy_quic_proof_source_factory_impl_lib",
-    srcs = ["envoy_quic_proof_source_factory_impl.cc"],
-    hdrs = ["envoy_quic_proof_source_factory_impl.h"],
-    tags = ["nofips"],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_proof_source_factory_impl.cc"],
+    }),
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_proof_source_factory_impl.h"],
+    }),
     visibility = [
         "//source/common/quic:__subpackages__",
         "//test:__subpackages__",
     ],
-    deps = [
-        "//source/common/quic:envoy_quic_proof_source_factory_interface",
-        "//source/common/quic:envoy_quic_proof_source_lib",
-        "@envoy_api//envoy/extensions/quic/proof_source/v3:pkg_cc_proto",
-    ],
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//source/common/quic:envoy_quic_proof_source_factory_interface",
+            "//source/common/quic:envoy_quic_proof_source_lib",
+            "@envoy_api//envoy/extensions/quic/proof_source/v3:pkg_cc_proto",
+        ],
+    }),
     alwayslink = LEGACY_ALWAYSLINK,
 )
 
@@ -38,14 +46,10 @@ envoy_cc_extension(
         "//source/common/quic:__subpackages__",
         "//test:__subpackages__",
     ],
-    tags = ["nofips"],
-    deps = select(
-        {
-            "//bazel:boringssl_fips": [],
-            "//bazel:boringssl_disabled": [],
-            "//conditions:default": [
-                ":envoy_quic_proof_source_factory_impl_lib",
-            ],
-        },
-    ),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":envoy_quic_proof_source_factory_impl_lib",
+        ],
+    }),
 )

--- a/source/extensions/quic/server_preferred_address/BUILD
+++ b/source/extensions/quic/server_preferred_address/BUILD
@@ -17,26 +17,42 @@ envoy_extension_package()
 
 envoy_cc_library(
     name = "server_preferred_address_lib",
-    srcs = ["server_preferred_address.cc"],
-    hdrs = ["server_preferred_address.h"],
-    tags = ["nofips"],
-    deps = [
-        "//source/common/quic:envoy_quic_server_preferred_address_config_factory_interface",
-    ],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["server_preferred_address.cc"],
+    }),
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["server_preferred_address.h"],
+    }),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//source/common/quic:envoy_quic_server_preferred_address_config_factory_interface",
+        ],
+    }),
 )
 
 envoy_cc_library(
     name = "fixed_server_preferred_address_config_lib",
-    srcs = ["fixed_server_preferred_address_config.cc"],
-    hdrs = ["fixed_server_preferred_address_config.h"],
-    tags = ["nofips"],
-    deps = [
-        ":server_preferred_address_lib",
-        "//envoy/registry",
-        "//source/common/quic:envoy_quic_server_preferred_address_config_factory_interface",
-        "//source/common/quic:envoy_quic_utils_lib",
-        "@envoy_api//envoy/extensions/quic/server_preferred_address/v3:pkg_cc_proto",
-    ],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["fixed_server_preferred_address_config.cc"],
+    }),
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["fixed_server_preferred_address_config.h"],
+    }),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":server_preferred_address_lib",
+            "//envoy/registry",
+            "//source/common/quic:envoy_quic_server_preferred_address_config_factory_interface",
+            "//source/common/quic:envoy_quic_utils_lib",
+            "@envoy_api//envoy/extensions/quic/server_preferred_address/v3:pkg_cc_proto",
+        ],
+    }),
     alwayslink = LEGACY_ALWAYSLINK,
 )
 
@@ -45,44 +61,44 @@ envoy_cc_extension(
     extra_visibility = [
         "//test:__subpackages__",
     ],
-    tags = ["nofips"],
-    deps = select(
-        {
-            "//bazel:boringssl_fips": [],
-            "//bazel:boringssl_disabled": [],
-            "//conditions:default": [
-                ":fixed_server_preferred_address_config_lib",
-            ],
-        },
-    ),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":fixed_server_preferred_address_config_lib",
+        ],
+    }),
 )
 
 envoy_cc_library(
     name = "datasource_server_preferred_address_config_lib",
-    srcs = ["datasource_server_preferred_address_config.cc"],
-    hdrs = ["datasource_server_preferred_address_config.h"],
-    tags = ["nofips"],
-    deps = [
-        ":server_preferred_address_lib",
-        "//envoy/registry",
-        "//source/common/config:datasource_lib",
-        "//source/common/quic:envoy_quic_server_preferred_address_config_factory_interface",
-        "//source/common/quic:envoy_quic_utils_lib",
-        "@envoy_api//envoy/extensions/quic/server_preferred_address/v3:pkg_cc_proto",
-    ],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["datasource_server_preferred_address_config.cc"],
+    }),
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["datasource_server_preferred_address_config.h"],
+    }),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":server_preferred_address_lib",
+            "//envoy/registry",
+            "//source/common/config:datasource_lib",
+            "//source/common/quic:envoy_quic_server_preferred_address_config_factory_interface",
+            "//source/common/quic:envoy_quic_utils_lib",
+            "@envoy_api//envoy/extensions/quic/server_preferred_address/v3:pkg_cc_proto",
+        ],
+    }),
     alwayslink = LEGACY_ALWAYSLINK,
 )
 
 envoy_cc_extension(
     name = "datasource_server_preferred_address_config_factory_config",
-    tags = ["nofips"],
-    deps = select(
-        {
-            "//bazel:boringssl_fips": [],
-            "//bazel:boringssl_disabled": [],
-            "//conditions:default": [
-                ":datasource_server_preferred_address_config_lib",
-            ],
-        },
-    ),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":datasource_server_preferred_address_config_lib",
+        ],
+    }),
 )

--- a/source/extensions/udp_packet_writer/gso/BUILD
+++ b/source/extensions/udp_packet_writer/gso/BUILD
@@ -21,7 +21,6 @@ envoy_cc_extension(
         "//source/server:__subpackages__",
         "//source/common/listener_manager:__subpackages__",
     ],
-    tags = ["nofips"],
     deps = [
         "//envoy/config:typed_config_interface",
         "//envoy/network:udp_packet_writer_handler_interface",

--- a/test/common/http/http3/BUILD
+++ b/test/common/http/http3/BUILD
@@ -13,7 +13,6 @@ envoy_cc_test(
     name = "conn_pool_test",
     srcs = envoy_select_enable_http3(["conn_pool_test.cc"]),
     rbe_pool = "6gig",
-    tags = ["nofips"],
     deps = envoy_select_enable_http3([
         "//source/common/event:dispatcher_lib",
         "//source/common/http/http3:conn_pool_lib",

--- a/test/common/listener_manager/BUILD
+++ b/test/common/listener_manager/BUILD
@@ -110,26 +110,31 @@ envoy_cc_test(
 # Stand-alone quic test because of FIPS.
 envoy_cc_test(
     name = "listener_manager_impl_quic_only_test",
-    srcs = ["listener_manager_impl_quic_only_test.cc"],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["listener_manager_impl_quic_only_test.cc"],
+    }),
     rbe_pool = "6gig",
-    tags = ["nofips"],
-    deps = [
-        ":listener_manager_impl_test_lib",
-        "//source/common/formatter:formatter_extension_lib",
-        "//source/extensions/filters/http/router:config",
-        "//source/extensions/filters/network/http_connection_manager:config",
-        "//source/extensions/matching/network/common:inputs_lib",
-        "//source/extensions/quic/server_preferred_address:fixed_server_preferred_address_config_factory_config",
-        "//source/extensions/request_id/uuid:config",
-        "//source/extensions/transport_sockets/raw_buffer:config",
-        "//source/extensions/transport_sockets/tls:config",
-        "//test/integration/filters:test_listener_filter_lib",
-        "//test/integration/filters:test_network_filter_lib",
-        "//test/server:utility_lib",
-        "//test/test_common:threadsafe_singleton_injector_lib",
-        "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
-        "@envoy_api//envoy/config/listener/v3:pkg_cc_proto",
-    ],
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":listener_manager_impl_test_lib",
+            "//source/common/formatter:formatter_extension_lib",
+            "//source/extensions/filters/http/router:config",
+            "//source/extensions/filters/network/http_connection_manager:config",
+            "//source/extensions/matching/network/common:inputs_lib",
+            "//source/extensions/quic/server_preferred_address:fixed_server_preferred_address_config_factory_config",
+            "//source/extensions/request_id/uuid:config",
+            "//source/extensions/transport_sockets/raw_buffer:config",
+            "//source/extensions/transport_sockets/tls:config",
+            "//test/integration/filters:test_listener_filter_lib",
+            "//test/integration/filters:test_network_filter_lib",
+            "//test/server:utility_lib",
+            "//test/test_common:threadsafe_singleton_injector_lib",
+            "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
+            "@envoy_api//envoy/config/listener/v3:pkg_cc_proto",
+        ],
+    }),
 )
 
 envoy_cc_test(

--- a/test/common/network/BUILD
+++ b/test/common/network/BUILD
@@ -273,32 +273,37 @@ envoy_cc_test(
 
 envoy_cc_test(
     name = "udp_listener_impl_batch_writer_test",
-    srcs = ["udp_listener_impl_batch_writer_test.cc"],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["udp_listener_impl_batch_writer_test.cc"],
+    }),
     rbe_pool = "6gig",
     # Skipping as quiche quic_gso_batch_writer.h does not exist on Windows
     tags = [
-        "nofips",
         "skip_on_windows",
     ],
-    deps = [
-        ":udp_listener_impl_test_base_lib",
-        "//source/common/event:dispatcher_lib",
-        "//source/common/network:address_lib",
-        "//source/common/network:listener_lib",
-        "//source/common/network:socket_option_lib",
-        "//source/common/network:udp_packet_writer_handler_lib",
-        "//source/common/network:utility_lib",
-        "//source/common/quic:udp_gso_batch_writer_lib",
-        "//source/common/stats:stats_lib",
-        "//test/common/network:listener_impl_test_base_lib",
-        "//test/mocks/network:network_mocks",
-        "//test/test_common:environment_lib",
-        "//test/test_common:network_utility_lib",
-        "//test/test_common:threadsafe_singleton_injector_lib",
-        "//test/test_common:utility_lib",
-        "@com_github_google_quiche//:quic_test_tools_mock_syscall_wrapper_lib",
-        "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
-    ],
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":udp_listener_impl_test_base_lib",
+            "//source/common/event:dispatcher_lib",
+            "//source/common/network:address_lib",
+            "//source/common/network:listener_lib",
+            "//source/common/network:socket_option_lib",
+            "//source/common/network:udp_packet_writer_handler_lib",
+            "//source/common/network:utility_lib",
+            "//source/common/quic:udp_gso_batch_writer_lib",
+            "//source/common/stats:stats_lib",
+            "//test/common/network:listener_impl_test_base_lib",
+            "//test/mocks/network:network_mocks",
+            "//test/test_common:environment_lib",
+            "//test/test_common:network_utility_lib",
+            "//test/test_common:threadsafe_singleton_injector_lib",
+            "//test/test_common:utility_lib",
+            "@com_github_google_quiche//:quic_test_tools_mock_syscall_wrapper_lib",
+            "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
+        ],
+    }),
 )
 
 envoy_cc_test(

--- a/test/common/quic/BUILD
+++ b/test/common/quic/BUILD
@@ -5,7 +5,7 @@ load(
     "envoy_cc_test_library",
     "envoy_package",
     "envoy_proto_library",
-    "envoy_select_enable_http_datagrams",
+    "envoy_select_enable_http3",
 )
 
 licenses(["notice"])  # Apache 2
@@ -14,289 +14,358 @@ envoy_package()
 
 envoy_cc_test(
     name = "envoy_quic_alarm_test",
-    srcs = ["envoy_quic_alarm_test.cc"],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_alarm_test.cc"],
+    }),
     rbe_pool = "6gig",
-    tags = ["nofips"],
-    deps = [
-        "//source/common/quic:envoy_quic_alarm_factory_lib",
-        "//source/common/quic:envoy_quic_alarm_lib",
-        "//source/common/quic:envoy_quic_clock_lib",
-        "//test/test_common:simulated_time_system_lib",
-        "//test/test_common:utility_lib",
-        "@com_github_google_quiche//:quic_platform",
-    ],
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//source/common/quic:envoy_quic_alarm_factory_lib",
+            "//source/common/quic:envoy_quic_alarm_lib",
+            "//source/common/quic:envoy_quic_clock_lib",
+            "//test/test_common:simulated_time_system_lib",
+            "//test/test_common:utility_lib",
+            "@com_github_google_quiche//:quic_platform",
+        ],
+    }),
 )
 
 envoy_cc_test(
     name = "envoy_quic_clock_test",
-    srcs = ["envoy_quic_clock_test.cc"],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_clock_test.cc"],
+    }),
     rbe_pool = "6gig",
-    tags = ["nofips"],
-    deps = [
-        "//source/common/quic:envoy_quic_clock_lib",
-        "//test/test_common:simulated_time_system_lib",
-        "//test/test_common:test_time_lib",
-        "//test/test_common:utility_lib",
-    ],
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//source/common/quic:envoy_quic_clock_lib",
+            "//test/test_common:simulated_time_system_lib",
+            "//test/test_common:test_time_lib",
+            "//test/test_common:utility_lib",
+        ],
+    }),
 )
 
 envoy_cc_test(
     name = "envoy_quic_writer_test",
-    srcs = ["envoy_quic_writer_test.cc"],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_writer_test.cc"],
+    }),
     rbe_pool = "6gig",
-    tags = ["nofips"],
-    deps = [
-        "//source/common/network:io_socket_error_lib",
-        "//source/common/network:udp_packet_writer_handler_lib",
-        "//source/common/quic:envoy_quic_packet_writer_lib",
-        "//test/mocks/api:api_mocks",
-        "//test/mocks/network:network_mocks",
-        "//test/test_common:threadsafe_singleton_injector_lib",
-        "@com_github_google_quiche//:quic_platform",
-    ],
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//source/common/network:io_socket_error_lib",
+            "//source/common/network:udp_packet_writer_handler_lib",
+            "//source/common/quic:envoy_quic_packet_writer_lib",
+            "//test/mocks/api:api_mocks",
+            "//test/mocks/network:network_mocks",
+            "//test/test_common:threadsafe_singleton_injector_lib",
+            "@com_github_google_quiche//:quic_platform",
+        ],
+    }),
 )
 
 envoy_cc_test(
     name = "envoy_quic_proof_source_test",
-    srcs = ["envoy_quic_proof_source_test.cc"],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_proof_source_test.cc"],
+    }),
     rbe_pool = "6gig",
-    tags = ["nofips"],
-    deps = [
-        ":test_utils_lib",
-        "//source/common/quic:envoy_quic_proof_source_lib",
-        "//source/common/quic:envoy_quic_proof_verifier_lib",
-        "//source/common/tls:context_config_lib",
-        "//source/common/tls:server_context_lib",
-        "//test/mocks/network:network_mocks",
-        "//test/mocks/server:server_factory_context_mocks",
-        "//test/mocks/ssl:ssl_mocks",
-        "//test/test_common:test_runtime_lib",
-        "@com_github_google_quiche//:quic_core_versions_lib",
-        "@com_github_google_quiche//:quic_platform",
-        "@com_github_google_quiche//:quic_test_tools_test_certificates_lib",
-    ],
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":test_utils_lib",
+            "//source/common/quic:envoy_quic_proof_source_lib",
+            "//source/common/quic:envoy_quic_proof_verifier_lib",
+            "//source/common/tls:context_config_lib",
+            "//source/common/tls:server_context_lib",
+            "//test/mocks/network:network_mocks",
+            "//test/mocks/server:server_factory_context_mocks",
+            "//test/mocks/ssl:ssl_mocks",
+            "//test/test_common:test_runtime_lib",
+            "@com_github_google_quiche//:quic_core_versions_lib",
+            "@com_github_google_quiche//:quic_platform",
+            "@com_github_google_quiche//:quic_test_tools_test_certificates_lib",
+        ],
+    }),
 )
 
 envoy_cc_test(
     name = "quic_filter_manager_connection_impl_test",
-    srcs = ["quic_filter_manager_connection_impl_test.cc"],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["quic_filter_manager_connection_impl_test.cc"],
+    }),
     rbe_pool = "6gig",
-    tags = ["nofips"],
-    deps = [
-        "//source/common/quic:quic_filter_manager_connection_lib",
-        "//test/mocks/event:event_mocks",
-        "//test/mocks/network:network_mocks",
-        "//test/test_common:utility_lib",
-        "@com_github_google_quiche//:quic_test_tools_test_utils_lib",
-    ],
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//source/common/quic:quic_filter_manager_connection_lib",
+            "//test/mocks/event:event_mocks",
+            "//test/mocks/network:network_mocks",
+            "//test/test_common:utility_lib",
+            "@com_github_google_quiche//:quic_test_tools_test_utils_lib",
+        ],
+    }),
 )
 
 envoy_cc_test(
     name = "quic_stat_names_test",
-    srcs = ["quic_stat_names_test.cc"],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["quic_stat_names_test.cc"],
+    }),
     rbe_pool = "6gig",
-    tags = ["nofips"],
-    deps = [
-        "//source/common/quic:quic_stat_names_lib",
-        "//source/common/stats:stats_lib",
-        "//test/mocks/stats:stats_mocks",
-        "//test/test_common:utility_lib",
-    ],
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//source/common/quic:quic_stat_names_lib",
+            "//source/common/stats:stats_lib",
+            "//test/mocks/stats:stats_mocks",
+            "//test/test_common:utility_lib",
+        ],
+    }),
 )
 
 envoy_cc_test(
     name = "envoy_quic_proof_verifier_test",
-    srcs = ["envoy_quic_proof_verifier_test.cc"],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_proof_verifier_test.cc"],
+    }),
     rbe_pool = "6gig",
-    tags = ["nofips"],
-    deps = [
-        ":test_utils_lib",
-        "//source/common/quic:envoy_quic_proof_verifier_lib",
-        "//source/common/tls:context_config_lib",
-        "//test/common/config:dummy_config_proto_cc_proto",
-        "//test/common/tls/cert_validator:timed_cert_validator",
-        "//test/mocks/event:event_mocks",
-        "//test/mocks/server:server_factory_context_mocks",
-        "//test/mocks/ssl:ssl_mocks",
-        "@com_github_google_quiche//:quic_platform",
-        "@com_github_google_quiche//:quic_test_tools_test_certificates_lib",
-    ],
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":test_utils_lib",
+            "//source/common/quic:envoy_quic_proof_verifier_lib",
+            "//source/common/tls:context_config_lib",
+            "//test/common/config:dummy_config_proto_cc_proto",
+            "//test/common/tls/cert_validator:timed_cert_validator",
+            "//test/mocks/event:event_mocks",
+            "//test/mocks/server:server_factory_context_mocks",
+            "//test/mocks/ssl:ssl_mocks",
+            "@com_github_google_quiche//:quic_platform",
+            "@com_github_google_quiche//:quic_test_tools_test_certificates_lib",
+        ],
+    }),
 )
 
 envoy_cc_test(
     name = "envoy_quic_server_stream_test",
-    srcs = ["envoy_quic_server_stream_test.cc"],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_server_stream_test.cc"],
+    }),
     rbe_pool = "6gig",
-    tags = ["nofips"],
-    deps = [
-        ":test_utils_lib",
-        "//source/common/http:headers_lib",
-        "//source/common/quic:envoy_quic_alarm_factory_lib",
-        "//source/common/quic:envoy_quic_connection_helper_lib",
-        "//source/common/quic:envoy_quic_server_connection_lib",
-        "//source/common/quic:envoy_quic_server_session_lib",
-        "//source/server:active_listener_base",
-        "//test/mocks/http:http_mocks",
-        "//test/mocks/http:stream_decoder_mock",
-        "//test/mocks/network:network_mocks",
-        "//test/test_common:utility_lib",
-        "@com_github_google_quiche//:quic_core_http_spdy_session_lib",
-        "@com_github_google_quiche//:quic_test_tools_qpack_qpack_test_utils_lib",
-        "@com_github_google_quiche//:quic_test_tools_session_peer_lib",
-    ],
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":test_utils_lib",
+            "//source/common/http:headers_lib",
+            "//source/common/quic:envoy_quic_alarm_factory_lib",
+            "//source/common/quic:envoy_quic_connection_helper_lib",
+            "//source/common/quic:envoy_quic_server_connection_lib",
+            "//source/common/quic:envoy_quic_server_session_lib",
+            "//source/server:active_listener_base",
+            "//test/mocks/http:http_mocks",
+            "//test/mocks/http:stream_decoder_mock",
+            "//test/mocks/network:network_mocks",
+            "//test/test_common:utility_lib",
+            "@com_github_google_quiche//:quic_core_http_spdy_session_lib",
+            "@com_github_google_quiche//:quic_test_tools_qpack_qpack_test_utils_lib",
+            "@com_github_google_quiche//:quic_test_tools_session_peer_lib",
+        ],
+    }),
 )
 
 envoy_cc_test(
     name = "envoy_quic_client_stream_test",
-    srcs = ["envoy_quic_client_stream_test.cc"],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_client_stream_test.cc"],
+    }),
     rbe_pool = "6gig",
-    tags = ["nofips"],
-    deps = [
-        ":test_utils_lib",
-        "//source/common/http:headers_lib",
-        "//source/common/quic:envoy_quic_alarm_factory_lib",
-        "//source/common/quic:envoy_quic_client_connection_lib",
-        "//source/common/quic:envoy_quic_client_session_lib",
-        "//source/common/quic:envoy_quic_connection_helper_lib",
-        "//test/mocks/http:http_mocks",
-        "//test/mocks/http:stream_decoder_mock",
-        "//test/mocks/network:network_mocks",
-        "//test/test_common:utility_lib",
-        "@com_github_google_quiche//:quic_core_http_spdy_session_lib",
-        "@com_github_google_quiche//:quic_test_tools_qpack_qpack_test_utils_lib",
-    ],
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":test_utils_lib",
+            "//source/common/http:headers_lib",
+            "//source/common/quic:envoy_quic_alarm_factory_lib",
+            "//source/common/quic:envoy_quic_client_connection_lib",
+            "//source/common/quic:envoy_quic_client_session_lib",
+            "//source/common/quic:envoy_quic_connection_helper_lib",
+            "//test/mocks/http:http_mocks",
+            "//test/mocks/http:stream_decoder_mock",
+            "//test/mocks/network:network_mocks",
+            "//test/test_common:utility_lib",
+            "@com_github_google_quiche//:quic_core_http_spdy_session_lib",
+            "@com_github_google_quiche//:quic_test_tools_qpack_qpack_test_utils_lib",
+        ],
+    }),
 )
 
 envoy_cc_test(
     name = "envoy_quic_server_session_test",
-    srcs = ["envoy_quic_server_session_test.cc"],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_server_session_test.cc"],
+    }),
     rbe_pool = "6gig",
-    tags = ["nofips"],
-    deps = [
-        ":test_proof_source_lib",
-        ":test_utils_lib",
-        "//envoy/stats:stats_macros",
-        "//source/common/quic:envoy_quic_alarm_factory_lib",
-        "//source/common/quic:envoy_quic_connection_helper_lib",
-        "//source/common/quic:envoy_quic_server_connection_lib",
-        "//source/common/quic:envoy_quic_server_session_lib",
-        "//source/common/quic:server_codec_lib",
-        "//source/server:configuration_lib",
-        "//test/mocks/event:event_mocks",
-        "//test/mocks/http:http_mocks",
-        "//test/mocks/http:stream_decoder_mock",
-        "//test/mocks/network:network_mocks",
-        "//test/mocks/stats:stats_mocks",
-        "//test/test_common:global_lib",
-        "//test/test_common:logging_lib",
-        "//test/test_common:simulated_time_system_lib",
-        "@com_github_google_quiche//:quic_test_tools_config_peer_lib",
-        "@com_github_google_quiche//:quic_test_tools_server_session_base_peer",
-        "@com_github_google_quiche//:quic_test_tools_test_utils_lib",
-    ],
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":test_proof_source_lib",
+            ":test_utils_lib",
+            "//envoy/stats:stats_macros",
+            "//source/common/quic:envoy_quic_alarm_factory_lib",
+            "//source/common/quic:envoy_quic_connection_helper_lib",
+            "//source/common/quic:envoy_quic_server_connection_lib",
+            "//source/common/quic:envoy_quic_server_session_lib",
+            "//source/common/quic:server_codec_lib",
+            "//source/server:configuration_lib",
+            "//test/mocks/event:event_mocks",
+            "//test/mocks/http:http_mocks",
+            "//test/mocks/http:stream_decoder_mock",
+            "//test/mocks/network:network_mocks",
+            "//test/mocks/stats:stats_mocks",
+            "//test/test_common:global_lib",
+            "//test/test_common:logging_lib",
+            "//test/test_common:simulated_time_system_lib",
+            "@com_github_google_quiche//:quic_test_tools_config_peer_lib",
+            "@com_github_google_quiche//:quic_test_tools_server_session_base_peer",
+            "@com_github_google_quiche//:quic_test_tools_test_utils_lib",
+        ],
+    }),
 )
 
 envoy_cc_test(
     name = "envoy_quic_client_session_test",
-    srcs = ["envoy_quic_client_session_test.cc"],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_client_session_test.cc"],
+    }),
     rbe_pool = "6gig",
-    tags = ["nofips"],
-    deps = [
-        ":test_utils_lib",
-        "//envoy/stats:stats_macros",
-        "//source/common/api:os_sys_calls_lib",
-        "//source/common/quic:client_codec_lib",
-        "//source/common/quic:envoy_quic_alarm_factory_lib",
-        "//source/common/quic:envoy_quic_client_connection_lib",
-        "//source/common/quic:envoy_quic_client_session_lib",
-        "//source/common/quic:envoy_quic_connection_helper_lib",
-        "//source/extensions/quic/crypto_stream:envoy_quic_crypto_client_stream_lib",
-        "//test/mocks/api:api_mocks",
-        "//test/mocks/http:http_mocks",
-        "//test/mocks/http:stream_decoder_mock",
-        "//test/mocks/network:network_mocks",
-        "//test/mocks/stats:stats_mocks",
-        "//test/test_common:logging_lib",
-        "//test/test_common:simulated_time_system_lib",
-        "//test/test_common:test_runtime_lib",
-        "//test/test_common:threadsafe_singleton_injector_lib",
-        "@com_github_google_quiche//:quic_test_tools_session_peer_lib",
-    ],
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":test_utils_lib",
+            "//envoy/stats:stats_macros",
+            "//source/common/api:os_sys_calls_lib",
+            "//source/common/quic:client_codec_lib",
+            "//source/common/quic:envoy_quic_alarm_factory_lib",
+            "//source/common/quic:envoy_quic_client_connection_lib",
+            "//source/common/quic:envoy_quic_client_session_lib",
+            "//source/common/quic:envoy_quic_connection_helper_lib",
+            "//source/extensions/quic/crypto_stream:envoy_quic_crypto_client_stream_lib",
+            "//test/mocks/api:api_mocks",
+            "//test/mocks/http:http_mocks",
+            "//test/mocks/http:stream_decoder_mock",
+            "//test/mocks/network:network_mocks",
+            "//test/mocks/stats:stats_mocks",
+            "//test/test_common:logging_lib",
+            "//test/test_common:simulated_time_system_lib",
+            "//test/test_common:test_runtime_lib",
+            "//test/test_common:threadsafe_singleton_injector_lib",
+            "@com_github_google_quiche//:quic_test_tools_session_peer_lib",
+        ],
+    }),
 )
 
 envoy_cc_test(
     name = "active_quic_listener_test",
-    srcs = ["active_quic_listener_test.cc"],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["active_quic_listener_test.cc"],
+    }),
     rbe_pool = "6gig",
-    tags = ["nofips"],
-    deps = [
-        ":test_proof_source_lib",
-        ":test_utils_lib",
-        "//source/common/http:utility_lib",
-        "//source/common/listener_manager:connection_handler_lib",
-        "//source/common/network:udp_packet_writer_handler_lib",
-        "//source/common/quic:active_quic_listener_lib",
-        "//source/common/quic:envoy_quic_utils_lib",
-        "//source/common/quic:udp_gso_batch_writer_lib",
-        "//source/extensions/quic/crypto_stream:envoy_quic_crypto_server_stream_lib",
-        "//source/extensions/quic/proof_source:envoy_quic_proof_source_factory_impl_lib",
-        "//source/server:configuration_lib",
-        "//source/server:process_context_lib",
-        "//test/mocks/network:network_mocks",
-        "//test/mocks/server:instance_mocks",
-        "//test/mocks/server:listener_factory_context_mocks",
-        "//test/test_common:network_utility_lib",
-        "//test/test_common:simulated_time_system_lib",
-        "//test/test_common:test_runtime_lib",
-        "@com_github_google_quiche//:quic_test_tools_crypto_server_config_peer_lib",
-        "@envoy_api//envoy/config/listener/v3:pkg_cc_proto",
-    ],
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":test_proof_source_lib",
+            ":test_utils_lib",
+            "//source/common/http:utility_lib",
+            "//source/common/listener_manager:connection_handler_lib",
+            "//source/common/network:udp_packet_writer_handler_lib",
+            "//source/common/quic:active_quic_listener_lib",
+            "//source/common/quic:envoy_quic_utils_lib",
+            "//source/common/quic:udp_gso_batch_writer_lib",
+            "//source/extensions/quic/crypto_stream:envoy_quic_crypto_server_stream_lib",
+            "//source/extensions/quic/proof_source:envoy_quic_proof_source_factory_impl_lib",
+            "//source/server:configuration_lib",
+            "//source/server:process_context_lib",
+            "//test/mocks/network:network_mocks",
+            "//test/mocks/server:instance_mocks",
+            "//test/mocks/server:listener_factory_context_mocks",
+            "//test/test_common:network_utility_lib",
+            "//test/test_common:simulated_time_system_lib",
+            "//test/test_common:test_runtime_lib",
+            "@com_github_google_quiche//:quic_test_tools_crypto_server_config_peer_lib",
+            "@envoy_api//envoy/config/listener/v3:pkg_cc_proto",
+        ],
+    }),
 )
 
 envoy_cc_test(
     name = "envoy_quic_dispatcher_test",
-    srcs = ["envoy_quic_dispatcher_test.cc"],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_dispatcher_test.cc"],
+    }),
     rbe_pool = "6gig",
-    tags = ["nofips"],
-    deps = [
-        ":test_proof_source_lib",
-        ":test_utils_lib",
-        "//envoy/stats:stats_macros",
-        "//source/common/listener_manager:connection_handler_lib",
-        "//source/common/quic:envoy_quic_alarm_factory_lib",
-        "//source/common/quic:envoy_quic_connection_helper_lib",
-        "//source/common/quic:envoy_quic_dispatcher_lib",
-        "//source/common/quic:envoy_quic_proof_source_lib",
-        "//source/common/quic:envoy_quic_server_session_lib",
-        "//source/common/quic:quic_server_transport_socket_factory_lib",
-        "//source/extensions/quic/crypto_stream:envoy_quic_crypto_server_stream_lib",
-        "//source/server:configuration_lib",
-        "//test/mocks/event:event_mocks",
-        "//test/mocks/http:http_mocks",
-        "//test/mocks/network:network_mocks",
-        "//test/mocks/ssl:ssl_mocks",
-        "//test/mocks/stats:stats_mocks",
-        "//test/test_common:global_lib",
-        "//test/test_common:simulated_time_system_lib",
-        "//test/test_common:test_runtime_lib",
-    ],
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":test_proof_source_lib",
+            ":test_utils_lib",
+            "//envoy/stats:stats_macros",
+            "//source/common/listener_manager:connection_handler_lib",
+            "//source/common/quic:envoy_quic_alarm_factory_lib",
+            "//source/common/quic:envoy_quic_connection_helper_lib",
+            "//source/common/quic:envoy_quic_dispatcher_lib",
+            "//source/common/quic:envoy_quic_proof_source_lib",
+            "//source/common/quic:envoy_quic_server_session_lib",
+            "//source/common/quic:quic_server_transport_socket_factory_lib",
+            "//source/extensions/quic/crypto_stream:envoy_quic_crypto_server_stream_lib",
+            "//source/server:configuration_lib",
+            "//test/mocks/event:event_mocks",
+            "//test/mocks/http:http_mocks",
+            "//test/mocks/network:network_mocks",
+            "//test/mocks/ssl:ssl_mocks",
+            "//test/mocks/stats:stats_mocks",
+            "//test/test_common:global_lib",
+            "//test/test_common:simulated_time_system_lib",
+            "//test/test_common:test_runtime_lib",
+        ],
+    }),
 )
 
 envoy_cc_test_library(
     name = "test_proof_source_lib",
-    hdrs = ["test_proof_source.h"],
-    tags = ["nofips"],
-    deps = [
-        "//source/common/quic:envoy_quic_proof_source_base_lib",
-        "//test/mocks/network:network_mocks",
-        "@com_github_google_quiche//:quic_test_tools_test_certificates_lib",
-    ],
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["test_proof_source.h"],
+    }),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//source/common/quic:envoy_quic_proof_source_base_lib",
+            "//test/mocks/network:network_mocks",
+            "@com_github_google_quiche//:quic_test_tools_test_certificates_lib",
+        ],
+    }),
 )
 
 envoy_cc_test_library(
     name = "test_proof_verifier_lib",
     hdrs = ["test_proof_verifier.h"],
-    tags = ["nofips"],
     deps = [
         "//source/common/quic:envoy_quic_proof_verifier_base_lib",
     ],
@@ -304,71 +373,90 @@ envoy_cc_test_library(
 
 envoy_cc_test(
     name = "client_connection_factory_impl_test",
-    srcs = ["client_connection_factory_impl_test.cc"],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["client_connection_factory_impl_test.cc"],
+    }),
     rbe_pool = "6gig",
-    tags = ["nofips"],
-    deps = [
-        "//source/common/event:dispatcher_lib",
-        "//source/common/http/http3:conn_pool_lib",
-        "//source/common/network:utility_lib",
-        "//source/common/upstream:upstream_includes",
-        "//source/common/upstream:upstream_lib",
-        "//test/common/http:common_lib",
-        "//test/common/upstream:utility_lib",
-        "//test/mocks/event:event_mocks",
-        "//test/mocks/http:http_mocks",
-        "//test/mocks/http:http_server_properties_cache_mocks",
-        "//test/mocks/network:network_mocks",
-        "//test/mocks/runtime:runtime_mocks",
-        "//test/mocks/server:factory_context_mocks",
-        "//test/mocks/upstream:cluster_info_mocks",
-        "//test/mocks/upstream:transport_socket_match_mocks",
-        "//test/test_common:test_runtime_lib",
-        "//test/test_common:threadsafe_singleton_injector_lib",
-    ],
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//source/common/event:dispatcher_lib",
+            "//source/common/http/http3:conn_pool_lib",
+            "//source/common/network:utility_lib",
+            "//source/common/upstream:upstream_includes",
+            "//source/common/upstream:upstream_lib",
+            "//test/common/http:common_lib",
+            "//test/common/upstream:utility_lib",
+            "//test/mocks/event:event_mocks",
+            "//test/mocks/http:http_mocks",
+            "//test/mocks/http:http_server_properties_cache_mocks",
+            "//test/mocks/network:network_mocks",
+            "//test/mocks/runtime:runtime_mocks",
+            "//test/mocks/server:factory_context_mocks",
+            "//test/mocks/upstream:cluster_info_mocks",
+            "//test/mocks/upstream:transport_socket_match_mocks",
+            "//test/test_common:test_runtime_lib",
+            "//test/test_common:threadsafe_singleton_injector_lib",
+        ],
+    }),
 )
 
 envoy_cc_test(
     name = "quic_io_handle_wrapper_test",
-    srcs = ["quic_io_handle_wrapper_test.cc"],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["quic_io_handle_wrapper_test.cc"],
+    }),
     rbe_pool = "6gig",
-    tags = ["nofips"],
-    deps = [
-        "//source/common/quic:quic_io_handle_wrapper_lib",
-        "//test/mocks/api:api_mocks",
-        "//test/mocks/network:io_handle_mocks",
-        "//test/mocks/network:network_mocks",
-        "//test/test_common:threadsafe_singleton_injector_lib",
-    ],
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//source/common/quic:quic_io_handle_wrapper_lib",
+            "//test/mocks/api:api_mocks",
+            "//test/mocks/network:io_handle_mocks",
+            "//test/mocks/network:network_mocks",
+            "//test/test_common:threadsafe_singleton_injector_lib",
+        ],
+    }),
 )
 
 envoy_cc_test(
     name = "envoy_quic_utils_test",
-    srcs = ["envoy_quic_utils_test.cc"],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_utils_test.cc"],
+    }),
     rbe_pool = "6gig",
-    tags = ["nofips"],
-    deps = [
-        "//source/common/quic:envoy_quic_utils_lib",
-        "//test/mocks/api:api_mocks",
-        "//test/test_common:threadsafe_singleton_injector_lib",
-        "@com_github_google_quiche//:quic_test_tools_test_utils_lib",
-    ],
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//source/common/quic:envoy_quic_utils_lib",
+            "//test/mocks/api:api_mocks",
+            "//test/test_common:threadsafe_singleton_injector_lib",
+            "@com_github_google_quiche//:quic_test_tools_test_utils_lib",
+        ],
+    }),
 )
 
 envoy_cc_test(
     name = "envoy_quic_simulated_watermark_buffer_test",
-    srcs = ["envoy_quic_simulated_watermark_buffer_test.cc"],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_simulated_watermark_buffer_test.cc"],
+    }),
     rbe_pool = "6gig",
-    tags = ["nofips"],
-    deps = ["//source/common/quic:envoy_quic_simulated_watermark_buffer_lib"],
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["//source/common/quic:envoy_quic_simulated_watermark_buffer_lib"],
+    }),
 )
 
 envoy_cc_test_library(
     name = "test_utils_lib",
-    hdrs = ["test_utils.h"],
+    hdrs = envoy_select_enable_http3(["test_utils.h"]),
     external_deps = ["bazel_runfiles"],
-    tags = ["nofips"],
-    deps = [
+    deps = envoy_select_enable_http3([
         "//envoy/stream_info:stream_info_interface",
         "//source/common/quic:envoy_quic_client_connection_lib",
         "//source/common/quic:envoy_quic_client_session_lib",
@@ -382,48 +470,64 @@ envoy_cc_test_library(
         "@com_github_google_quiche//:quic_core_http_spdy_session_lib",
         "@com_github_google_quiche//:quic_test_tools_first_flight_lib",
         "@com_github_google_quiche//:quic_test_tools_qpack_qpack_test_utils_lib",
-    ],
-)
-
-envoy_cc_test(
-    name = "quic_transport_socket_factory_test",
-    srcs = ["quic_transport_socket_factory_test.cc"],
-    data = [
-        "//test/common/tls/test_data:certs",
-    ],
-    rbe_pool = "6gig",
-    tags = ["nofips"],
-    deps = [
-        "//source/common/quic:quic_server_transport_socket_factory_lib",
-        "//source/common/quic:quic_transport_socket_factory_lib",
-        "//source/common/tls:context_config_lib",
-        "//test/mocks/server:factory_context_mocks",
-        "//test/mocks/ssl:ssl_mocks",
-        "//test/test_common:environment_lib",
-        "//test/test_common:utility_lib",
-    ],
-)
-
-envoy_cc_test(
-    name = "http_datagram_handler_test",
-    srcs = envoy_select_enable_http_datagrams(["http_datagram_handler_test.cc"]),
-    rbe_pool = "6gig",
-    tags = ["nofips"],
-    deps = envoy_select_enable_http_datagrams([
-        "//source/common/quic:http_datagram_handler",
-        "//test/mocks/buffer:buffer_mocks",
-        "//test/test_common:utility_lib",
-        "@com_github_google_quiche//:quic_test_tools_test_utils_lib",
     ]),
 )
 
 envoy_cc_test(
-    name = "cert_compression_test",
-    srcs = ["cert_compression_test.cc"],
-    deps = [
-        "//source/common/quic:cert_compression_lib",
-        "//test/test_common:logging_lib",
+    name = "quic_transport_socket_factory_test",
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["quic_transport_socket_factory_test.cc"],
+    }),
+    data = [
+        "//test/common/tls/test_data:certs",
     ],
+    rbe_pool = "6gig",
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//source/common/quic:quic_server_transport_socket_factory_lib",
+            "//source/common/quic:quic_transport_socket_factory_lib",
+            "//source/common/tls:context_config_lib",
+            "//test/mocks/server:factory_context_mocks",
+            "//test/mocks/ssl:ssl_mocks",
+            "//test/test_common:environment_lib",
+            "//test/test_common:utility_lib",
+        ],
+    }),
+)
+
+envoy_cc_test(
+    name = "http_datagram_handler_test",
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["http_datagram_handler_test.cc"],
+    }),
+    rbe_pool = "6gig",
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//source/common/quic:http_datagram_handler",
+            "//test/mocks/buffer:buffer_mocks",
+            "//test/test_common:utility_lib",
+            "@com_github_google_quiche//:quic_test_tools_test_utils_lib",
+        ],
+    }),
+)
+
+envoy_cc_test(
+    name = "cert_compression_test",
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["cert_compression_test.cc"],
+    }),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//source/common/quic:cert_compression_lib",
+            "//test/test_common:logging_lib",
+        ],
+    }),
 )
 
 envoy_cc_test_library(
@@ -434,14 +538,19 @@ envoy_cc_test_library(
 
 envoy_cc_test(
     name = "envoy_deterministic_connection_id_generator_test",
-    srcs = ["envoy_deterministic_connection_id_generator_test.cc"],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_deterministic_connection_id_generator_test.cc"],
+    }),
     rbe_pool = "6gig",
-    tags = ["nofips"],
-    deps = [
-        ":connection_id_matchers",
-        "//source/common/quic:envoy_deterministic_connection_id_generator_lib",
-        "@com_github_google_quiche//:quic_test_tools_test_utils_lib",
-    ],
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":connection_id_matchers",
+            "//source/common/quic:envoy_deterministic_connection_id_generator_lib",
+            "@com_github_google_quiche//:quic_test_tools_test_utils_lib",
+        ],
+    }),
 )
 
 envoy_proto_library(
@@ -454,7 +563,6 @@ envoy_cc_test_library(
     name = "envoy_quic_h3_fuzz_helper_lib",
     srcs = ["envoy_quic_h3_fuzz_helper.cc"],
     hdrs = ["envoy_quic_h3_fuzz_helper.h"],
-    tags = ["nofips"],
     deps = [
         ":envoy_quic_h3_fuzz_proto_cc_proto",
         "//source/common/common:assert_lib",

--- a/test/common/quic/platform/BUILD
+++ b/test/common/quic/platform/BUILD
@@ -24,7 +24,6 @@ envoy_cc_test(
     }),
     data = ["//test/common/tls/test_data:certs"],
     rbe_pool = "6gig",
-    tags = ["nofips"],
     deps = [
         "//source/common/memory:stats_lib",
         "//source/common/quic/platform:quiche_flags_impl_lib",
@@ -50,7 +49,6 @@ envoy_cc_test(
 envoy_quiche_platform_impl_cc_test_library(
     name = "quiche_expect_bug_impl_lib",
     hdrs = ["quiche_expect_bug_impl.h"],
-    tags = ["nofips"],
     deps = [
         "@com_github_google_quiche//:quic_platform_base",
     ],
@@ -59,7 +57,6 @@ envoy_quiche_platform_impl_cc_test_library(
 envoy_quiche_platform_impl_cc_test_library(
     name = "quiche_thread_impl_lib",
     hdrs = ["quiche_thread_impl.h"],
-    tags = ["nofips"],
     deps = [
         "//envoy/thread:thread_interface",
         "//source/common/common:assert_lib",
@@ -71,7 +68,6 @@ envoy_quiche_platform_impl_cc_test_library(
     name = "quiche_test_output_impl_lib",
     srcs = ["quiche_test_output_impl.cc"],
     hdrs = ["quiche_test_output_impl.h"],
-    tags = ["nofips"],
     deps = [
         "//test/test_common:file_system_for_test_lib",
         "@com_github_google_quiche//:quic_platform_base",

--- a/test/extensions/quic/connection_debug_visitor/quic_stats/BUILD
+++ b/test/extensions/quic/connection_debug_visitor/quic_stats/BUILD
@@ -13,26 +13,36 @@ envoy_package()
 
 envoy_extension_cc_test(
     name = "quic_stats_test",
-    srcs = ["quic_stats_test.cc"],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["quic_stats_test.cc"],
+    }),
     extension_names = ["envoy.quic.connection_debug_visitor.quic_stats"],
-    tags = ["nofips"],
-    deps = [
-        "//source/extensions/quic/connection_debug_visitor/quic_stats:quic_stats_lib",
-        "//test/mocks/event:event_mocks",
-    ],
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//source/extensions/quic/connection_debug_visitor/quic_stats:quic_stats_lib",
+            "//test/mocks/event:event_mocks",
+        ],
+    }),
 )
 
 envoy_extension_cc_test(
     name = "integration_test",
     size = "large",
-    srcs = ["integration_test.cc"],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["integration_test.cc"],
+    }),
     extension_names = ["envoy.quic.connection_debug_visitor.quic_stats"],
     rbe_pool = "2core",
-    tags = ["nofips"],
-    deps = [
-        "//source/extensions/quic/connection_debug_visitor/quic_stats:config",
-        "//test/integration:http_integration_lib",
-        "@envoy_api//envoy/extensions/quic/connection_debug_visitor/quic_stats/v3:pkg_cc_proto",
-        "@envoy_api//envoy/extensions/transport_sockets/quic/v3:pkg_cc_proto",
-    ],
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//source/extensions/quic/connection_debug_visitor/quic_stats:config",
+            "//test/integration:http_integration_lib",
+            "@envoy_api//envoy/extensions/quic/connection_debug_visitor/quic_stats/v3:pkg_cc_proto",
+            "@envoy_api//envoy/extensions/transport_sockets/quic/v3:pkg_cc_proto",
+        ],
+    }),
 )

--- a/test/extensions/quic/connection_id_generator/quic_lb/BUILD
+++ b/test/extensions/quic/connection_id_generator/quic_lb/BUILD
@@ -13,29 +13,39 @@ envoy_package()
 
 envoy_extension_cc_test(
     name = "quic_lb_test",
-    srcs = ["quic_lb_test.cc"],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["quic_lb_test.cc"],
+    }),
     extension_names = ["envoy.quic.connection_id_generator.quic_lb"],
     rbe_pool = "6gig",
-    tags = ["nofips"],
-    deps = [
-        "//source/extensions/quic/connection_id_generator/quic_lb:quic_lb_lib",
-        "//test/mocks/server:factory_context_mocks",
-        "@com_github_google_quiche//:quic_test_tools_test_utils_lib",
-    ],
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//source/extensions/quic/connection_id_generator/quic_lb:quic_lb_lib",
+            "//test/mocks/server:factory_context_mocks",
+            "@com_github_google_quiche//:quic_test_tools_test_utils_lib",
+        ],
+    }),
 )
 
 envoy_extension_cc_test(
     name = "integration_test",
     size = "large",
-    srcs = ["integration_test.cc"],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["integration_test.cc"],
+    }),
     extension_names = ["envoy.quic.connection_id_generator.quic_lb"],
     rbe_pool = "4core",
-    tags = ["nofips"],
-    deps = [
-        "//source/extensions/quic/connection_id_generator/quic_lb:quic_lb_config",
-        "//test/integration:http_integration_lib",
-        "//test/integration:quic_http_integration_test_lib",
-        "@envoy_api//envoy/extensions/quic/connection_id_generator/quic_lb/v3:pkg_cc_proto",
-        "@envoy_api//envoy/extensions/transport_sockets/quic/v3:pkg_cc_proto",
-    ],
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//source/extensions/quic/connection_id_generator/quic_lb:quic_lb_config",
+            "//test/integration:http_integration_lib",
+            "//test/integration:quic_http_integration_test_lib",
+            "@envoy_api//envoy/extensions/quic/connection_id_generator/quic_lb/v3:pkg_cc_proto",
+            "@envoy_api//envoy/extensions/transport_sockets/quic/v3:pkg_cc_proto",
+        ],
+    }),
 )

--- a/test/extensions/quic/proof_source/BUILD
+++ b/test/extensions/quic/proof_source/BUILD
@@ -12,7 +12,6 @@ envoy_cc_test_library(
     name = "pending_proof_source_factory_impl_lib",
     srcs = ["pending_proof_source_factory_impl.cc"],
     hdrs = ["pending_proof_source_factory_impl.h"],
-    tags = ["nofips"],
     deps = [
         "//envoy/registry",
         "//source/common/quic:envoy_quic_proof_source_factory_interface",

--- a/test/extensions/quic/server_preferred_address/BUILD
+++ b/test/extensions/quic/server_preferred_address/BUILD
@@ -13,26 +13,36 @@ envoy_package()
 
 envoy_extension_cc_test(
     name = "datasource_server_preferred_address_test",
-    srcs = ["datasource_server_preferred_address_test.cc"],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["datasource_server_preferred_address_test.cc"],
+    }),
     extension_names = ["envoy.quic.server_preferred_address.datasource"],
     rbe_pool = "6gig",
-    tags = ["nofips"],
-    deps = [
-        "//source/extensions/quic/server_preferred_address:datasource_server_preferred_address_config_lib",
-        "//test/mocks/protobuf:protobuf_mocks",
-        "//test/mocks/server:server_factory_context_mocks",
-    ],
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//source/extensions/quic/server_preferred_address:datasource_server_preferred_address_config_lib",
+            "//test/mocks/protobuf:protobuf_mocks",
+            "//test/mocks/server:server_factory_context_mocks",
+        ],
+    }),
 )
 
 envoy_extension_cc_test(
     name = "fixed_server_preferred_address_test",
-    srcs = ["fixed_server_preferred_address_test.cc"],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["fixed_server_preferred_address_test.cc"],
+    }),
     extension_names = ["envoy.quic.server_preferred_address.fixed"],
     rbe_pool = "6gig",
-    tags = ["nofips"],
-    deps = [
-        "//source/extensions/quic/server_preferred_address:fixed_server_preferred_address_config_lib",
-        "//test/mocks/protobuf:protobuf_mocks",
-        "//test/mocks/server:server_factory_context_mocks",
-    ],
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//source/extensions/quic/server_preferred_address:fixed_server_preferred_address_config_lib",
+            "//test/mocks/protobuf:protobuf_mocks",
+            "//test/mocks/server:server_factory_context_mocks",
+        ],
+    }),
 )

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -1488,16 +1488,19 @@ envoy_cc_test(
     shard_count = 2,
     tags = [
         "cpu:3",
-        "nofips",
     ],
     deps = [
         ":http_protocol_integration_lib",
         "//source/common/http:header_map_lib",
-        "//test/integration/filters:pause_filter_for_quic_lib",
         "//test/test_common:utility_lib",
         "@envoy_api//envoy/config/route/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/filters/network/http_connection_manager/v3:pkg_cc_proto",
-    ],
+    ] + select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//test/integration/filters:pause_filter_for_quic_lib",
+        ],
+    }),
 )
 
 envoy_cc_test(
@@ -2559,7 +2562,6 @@ envoy_cc_test(
     shard_count = 16,
     tags = [
         "cpu:4",
-        "nofips",
     ],
     deps = select({
         "//bazel:disable_http3": [],
@@ -2578,10 +2580,10 @@ envoy_cc_test(
 
 envoy_cc_test_library(
     name = "quic_http_integration_test_lib",
-    hdrs = [
+    hdrs = envoy_select_enable_http3([
         "quic_http_integration_test.h",
-    ],
-    deps = [
+    ]),
+    deps = envoy_select_enable_http3([
         ":http_integration_lib",
         ":socket_interface_swap_lib",
         "//source/common/quic:client_connection_factory_lib",
@@ -2607,7 +2609,7 @@ envoy_cc_test_library(
         "@envoy_api//envoy/extensions/quic/connection_debug_visitor/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/quic/server_preferred_address/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/transport_sockets/quic/v3:pkg_cc_proto",
-    ],
+    ]),
 )
 
 # TODO(mattklein123): Use target_compatible_with when we switch to Bazel 4.0 instead of multiple
@@ -2634,7 +2636,6 @@ envoy_cc_test(
         "cpu:3",
         "fails_on_clang_cl",
         "fails_on_windows",
-        "nofips",
     ],
     deps = envoy_select_enable_http3([
         ":quic_http_integration_test_lib",

--- a/test/integration/filters/BUILD
+++ b/test/integration/filters/BUILD
@@ -469,17 +469,22 @@ envoy_cc_test_library(
 
 envoy_cc_test_library(
     name = "pause_filter_for_quic_lib",
-    srcs = [
-        "pause_filter_for_quic.cc",
-    ],
-    tags = ["nofips"],
-    deps = [
-        "//envoy/http:filter_interface",
-        "//envoy/registry",
-        "//source/common/quic:quic_filter_manager_connection_lib",
-        "//source/extensions/filters/http/common:pass_through_filter_lib",
-        "//test/extensions/filters/http/common:empty_http_filter_config_lib",
-    ],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "pause_filter_for_quic.cc",
+        ],
+    }),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//envoy/http:filter_interface",
+            "//envoy/registry",
+            "//source/common/quic:quic_filter_manager_connection_lib",
+            "//source/extensions/filters/http/common:pass_through_filter_lib",
+            "//test/extensions/filters/http/common:empty_http_filter_config_lib",
+        ],
+    }),
 )
 
 envoy_cc_test_library(


### PR DESCRIPTION
## Description

This PR re-enables all the QUIC tests for the FIPS build as the FIPS version Envoy uses now ([fips-20220613](https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4735)) has the interface that QUIC supports.

After this, QUIC for FIPS builds are also supported.

I was able to build a FIPS binary with QUIC after this change:
<img width="1204" alt="Screenshot 2025-06-05 at 18 09 57" src="https://github.com/user-attachments/assets/92ee5efd-36dc-457c-93f4-19b4abea50d7" />

<img width="1160" alt="Screenshot 2025-06-05 at 18 11 40" src="https://github.com/user-attachments/assets/e00f8c29-4e83-4f8c-b26a-d2ea8ce7ceab" />

**Fixes:** [#7433](https://github.com/envoyproxy/envoy/issues/7433)

---

**Commit Message:** quic: re-enable QUICHE for FIPS build and all the related tests
**Additional Description:** Re-enable QUIC for FIPS build and un-gate all the related tests
**Risk Level:** Low
**Testing:** Existing Tests
**Docs Changes:** N/A
**Release Notes:** N/A