### PR TITLE
Feature: support SetUpstreamOverrideHost in golang filter

### DIFF
--- a/contrib/golang/common/go/api/api.h
+++ b/contrib/golang/common/go/api/api.h
@@ -70,6 +70,7 @@ typedef enum { // NOLINT(modernize-use-using)
   CAPIInternalFailure = -7,
   CAPISerializationFailure = -8,
   CAPIInvalidScene = -9,
+  CAPIInvalidIPAddress = -10,
 } CAPIStatus;
 
 /* These APIs are related to the decode/encode phase, use the pointer of processState. */
@@ -120,6 +121,8 @@ CAPIStatus envoyGoFilterHttpGetStringProperty(void* r, void* key_data, int key_l
                                               uint64_t* value_data, int* value_len, int* rc);
 CAPIStatus envoyGoFilterHttpGetStringSecret(void* r, void* key_data, int key_len,
                                             uint64_t* value_data, int* value_len);
+
+CAPIStatus envoyGoFilterHttpSetUpstreamOverrideHost(void* s, void* host_data, int host_len, bool strict);
 
 /* These APIs have nothing to do with request */
 void envoyGoFilterLog(uint32_t level, void* message_data, int message_len);

--- a/contrib/golang/common/go/api/api.h
+++ b/contrib/golang/common/go/api/api.h
@@ -99,6 +99,8 @@ CAPIStatus envoyGoFilterHttpCopyTrailers(void* s, void* strs, void* buf);
 CAPIStatus envoyGoFilterHttpSetTrailer(void* s, void* key_data, int key_len, void* value,
                                        int value_len, headerAction action);
 CAPIStatus envoyGoFilterHttpRemoveTrailer(void* s, void* key_data, int key_len);
+CAPIStatus envoyGoFilterHttpSetUpstreamOverrideHost(void* s, void* host_data, int host_len,
+                                                    bool strict);
 
 /* These APIs have nothing to do with the decode/encode phase, use the pointer of httpRequest. */
 CAPIStatus envoyGoFilterHttpClearRouteCache(void* r, bool refresh);
@@ -121,9 +123,6 @@ CAPIStatus envoyGoFilterHttpGetStringProperty(void* r, void* key_data, int key_l
                                               uint64_t* value_data, int* value_len, int* rc);
 CAPIStatus envoyGoFilterHttpGetStringSecret(void* r, void* key_data, int key_len,
                                             uint64_t* value_data, int* value_len);
-
-CAPIStatus envoyGoFilterHttpSetUpstreamOverrideHost(void* s, void* host_data, int host_len,
-                                                    bool strict);
 
 /* These APIs have nothing to do with request */
 void envoyGoFilterLog(uint32_t level, void* message_data, int message_len);

--- a/contrib/golang/common/go/api/api.h
+++ b/contrib/golang/common/go/api/api.h
@@ -122,7 +122,8 @@ CAPIStatus envoyGoFilterHttpGetStringProperty(void* r, void* key_data, int key_l
 CAPIStatus envoyGoFilterHttpGetStringSecret(void* r, void* key_data, int key_len,
                                             uint64_t* value_data, int* value_len);
 
-CAPIStatus envoyGoFilterHttpSetUpstreamOverrideHost(void* s, void* host_data, int host_len, bool strict);
+CAPIStatus envoyGoFilterHttpSetUpstreamOverrideHost(void* s, void* host_data, int host_len,
+                                                    bool strict);
 
 /* These APIs have nothing to do with request */
 void envoyGoFilterLog(uint32_t level, void* message_data, int message_len);

--- a/contrib/golang/common/go/api/capi.go
+++ b/contrib/golang/common/go/api/capi.go
@@ -61,6 +61,8 @@ type HttpCAPI interface {
 	HttpFinalize(r unsafe.Pointer, reason int)
 	HttpGetStringSecret(c unsafe.Pointer, key string) (string, bool)
 
+	HttpSetUpstreamOverrideHost(s unsafe.Pointer, host string, strict bool) error
+
 	/* These APIs are related to config, use the pointer of config. */
 	HttpDefineMetric(c unsafe.Pointer, metricType MetricType, name string) uint32
 	HttpIncrementMetric(c unsafe.Pointer, metricId uint32, offset int64)

--- a/contrib/golang/common/go/api/capi.go
+++ b/contrib/golang/common/go/api/capi.go
@@ -43,6 +43,7 @@ type HttpCAPI interface {
 	HttpCopyTrailers(s unsafe.Pointer, num uint64, bytes uint64) map[string][]string
 	HttpSetTrailer(s unsafe.Pointer, key string, value string, add bool)
 	HttpRemoveTrailer(s unsafe.Pointer, key string)
+	HttpSetUpstreamOverrideHost(s unsafe.Pointer, host string, strict bool) error
 
 	/* These APIs have nothing to do with the decode/encode phase, use the pointer of httpRequest. */
 	ClearRouteCache(r unsafe.Pointer, refresh bool)
@@ -60,8 +61,6 @@ type HttpCAPI interface {
 
 	HttpFinalize(r unsafe.Pointer, reason int)
 	HttpGetStringSecret(c unsafe.Pointer, key string) (string, bool)
-
-	HttpSetUpstreamOverrideHost(s unsafe.Pointer, host string, strict bool) error
 
 	/* These APIs are related to config, use the pointer of config. */
 	HttpDefineMetric(c unsafe.Pointer, metricType MetricType, name string) uint32

--- a/contrib/golang/common/go/api/filter.go
+++ b/contrib/golang/common/go/api/filter.go
@@ -213,11 +213,13 @@ type DecoderFilterCallbacks interface {
 	// Sets an upstream address override for the request. When the overridden host exists in the host list of the routed cluster
 	// and can be selected directly, the load balancer bypasses its algorithm and routes traffic directly to the specified host.
 	//
-	// The strict flag determines whether the HTTP request must strictly use the overridden destination.
-	// When the destination is unavailable/not-found, if strict is set to true, Envoy responds with a 503 Service Unavailable error;
-	// if strict is set to false, Envoy will fall back to its load balancing mechanism.
+	// host (string): The upstream host address to use for the request. This must be a valid IP address(with port); otherwise, the
+	// C++ side will throw an error.
 	//
-	// Notice: host must be a valid IP address(with port).
+	// strict (boolean): Determines whether the HTTP request must be strictly routed to the requested
+	// destination. When set to ``true``, if the requested destination is unavailable/not-found, Envoy will return a 503 status code.
+	// The default value is ``false``, which allows Envoy to fall back to its load balancing mechanism. In this case, if the
+	// requested destination is not found, the request will be routed according to the load balancing algorithm.
 	SetUpstreamOverrideHost(host string, strict bool) error
 }
 

--- a/contrib/golang/common/go/api/filter.go
+++ b/contrib/golang/common/go/api/filter.go
@@ -213,13 +213,19 @@ type DecoderFilterCallbacks interface {
 	// Sets an upstream address override for the request. When the overridden host exists in the host list of the routed cluster
 	// and can be selected directly, the load balancer bypasses its algorithm and routes traffic directly to the specified host.
 	//
+	// Here are some cases for invalid host:
+	// 1. When set invalid host, non strict mode, envoy will fall back to its load balancing mechanism.
+	// 2. When set invalid host, strict mode, Envoy responds with a 503 Service Unavailable error.
+	// 3. When set invalid host, strict mode with retry, when first request with invalid host failed 503, the second request will retry with the valid host, then the second request will succeed and finally return 200.
+	//
+	// The function takes two arguments:
 	// host (string): The upstream host address to use for the request. This must be a valid IP address(with port); otherwise, the
 	// C++ side will throw an error.
 	//
 	// strict (boolean): Determines whether the HTTP request must be strictly routed to the requested
-	// destination. When set to ``true``, if the requested destination is unavailable/not-found, Envoy will return a 503 status code.
+	// host. When set to ``true``, if the requested host is invalid (can not connect to the host, or the host not found in the cluster), Envoy will return a 503 status code.
 	// The default value is ``false``, which allows Envoy to fall back to its load balancing mechanism. In this case, if the
-	// requested destination is not found, the request will be routed according to the load balancing algorithm.
+	// requested host is invalid, the request will be routed according to the load balancing algorithm.
 	SetUpstreamOverrideHost(host string, strict bool) error
 }
 

--- a/contrib/golang/common/go/api/filter.go
+++ b/contrib/golang/common/go/api/filter.go
@@ -210,6 +210,15 @@ type FilterProcessCallbacks interface {
 
 type DecoderFilterCallbacks interface {
 	FilterProcessCallbacks
+	// Sets an upstream address override for the request. When the overridden host exists in the host list of the routed cluster
+	// and can be selected directly, the load balancer bypasses its algorithm and routes traffic directly to the specified host.
+	//
+	// The strict flag determines whether the HTTP request must strictly use the overridden destination.
+	// When the destination is unavailable/not-found, if strict is set to true, Envoy responds with a 503 Service Unavailable error;
+	// if strict is set to false, Envoy will fall back to its load balancing mechanism.
+	//
+	// Notice: host must be a valid IP address(with port).
+	SetUpstreamOverrideHost(host string, strict bool) error
 }
 
 type EncoderFilterCallbacks interface {

--- a/contrib/golang/common/go/api/filter.go
+++ b/contrib/golang/common/go/api/filter.go
@@ -213,10 +213,16 @@ type DecoderFilterCallbacks interface {
 	// Sets an upstream address override for the request. When the overridden host exists in the host list of the routed cluster
 	// and can be selected directly, the load balancer bypasses its algorithm and routes traffic directly to the specified host.
 	//
-	// Here are some cases for invalid host:
-	// 1. When set invalid host, non strict mode, envoy will fall back to its load balancing mechanism.
-	// 2. When set invalid host, strict mode, Envoy responds with a 503 Service Unavailable error.
-	// 3. When set invalid host, strict mode with retry, when first request with invalid host failed 503, the second request will retry with the valid host, then the second request will succeed and finally return 200.
+	// Here are some cases:
+	// 1. Set a valid host(no matter in or not in the cluster), will route to the specified host directly and return 200.
+	// 2. Set a non-IP host, C++ side will return error and not route to cluster.
+	// 3. Set a unavaiable host, and the host is not in the cluster, will req the valid host in the cluster and rerurn 200.
+	// 4. Set a unavaiable host, and the host is in the cluster, but not available(can not connect to the host), will req the unavaiable hoat and rerurn 503.
+	// 5. Set a unavaiable host, and the host is in the cluster, but not available(can not connect to the host), and with retry. when first request with unavaiable host failed 503, the second request will retry with the valid host, then the second request will succeed and finally return 200.
+	// 6. Set a unavaiable host with strict mode, and the host is in the cluster, will req the unavaiable host and rerurn 503.
+	// 7. Set a unavaiable host with strict mode, and the host is not in the cluster, will req the unavaiable host and rerurn 503.
+	// 8. Set a unavaiable host with strict mode and retry. when first request with unavaiable host failed 503, the second request will retry with the valid host, then the second request will succeed and finally return 200.
+	// 9. Set a unavaiable host with strict mode and retry, and the host is not in the cluster, will req the unavaiable host and rerurn 503.
 	//
 	// The function takes two arguments:
 	//
@@ -224,9 +230,9 @@ type DecoderFilterCallbacks interface {
 	// C++ side will throw an error.
 	//
 	// strict (boolean): Determines whether the HTTP request must be strictly routed to the requested
-	// host. When set to ``true``, if the requested host is invalid (can not connect to the host, or the host not found in the cluster), Envoy will return a 503 status code.
+	// host. When set to ``true``, if the requested host is invalid, Envoy will return a 503 status code.
 	// The default value is ``false``, which allows Envoy to fall back to its load balancing mechanism. In this case, if the
-	// requested host is invalid, the request will be routed according to the load balancing algorithm.
+	// requested host is invalid, the request will be routed according to the load balancing algorithm and choose other hosts.
 	SetUpstreamOverrideHost(host string, strict bool) error
 }
 

--- a/contrib/golang/common/go/api/filter.go
+++ b/contrib/golang/common/go/api/filter.go
@@ -219,6 +219,7 @@ type DecoderFilterCallbacks interface {
 	// 3. When set invalid host, strict mode with retry, when first request with invalid host failed 503, the second request will retry with the valid host, then the second request will succeed and finally return 200.
 	//
 	// The function takes two arguments:
+	//
 	// host (string): The upstream host address to use for the request. This must be a valid IP address(with port); otherwise, the
 	// C++ side will throw an error.
 	//

--- a/contrib/golang/common/go/api/type.go
+++ b/contrib/golang/common/go/api/type.go
@@ -447,6 +447,7 @@ var (
 	ErrValueNotFound   = errors.New("value not found")
 	// Failed to serialize the value when we fetch the value as string
 	ErrSerializationFailure = errors.New("serialization failure")
+	ErrInvalidIPAddress     = errors.New("invalid IP address")
 )
 
 // *************** errors end **************//

--- a/contrib/golang/filters/http/source/cgo.cc
+++ b/contrib/golang/filters/http/source/cgo.cc
@@ -402,11 +402,12 @@ CAPIStatus envoyGoFilterHttpRecordMetric(void* c, uint32_t metric_id, uint64_t v
       });
 }
 
-CAPIStatus envoyGoFilterHttpSetUpstreamOverrideHost(void* s, void* host_data, int host_len, bool strict) {
+CAPIStatus envoyGoFilterHttpSetUpstreamOverrideHost(void* s, void* host_data, int host_len,
+                                                    bool strict) {
   return envoyGoFilterProcessStateHandlerWrapper(
       s,
       [host_data, host_len, strict](std::shared_ptr<Filter>& filter,
-                                                      ProcessorState& state) -> CAPIStatus {
+                                    ProcessorState& state) -> CAPIStatus {
         auto host_str = stringViewFromGoPointer(host_data, host_len);
         return filter->setUpstreamOverrideHost(state, host_str, strict);
       });

--- a/contrib/golang/filters/http/source/cgo.cc
+++ b/contrib/golang/filters/http/source/cgo.cc
@@ -402,6 +402,16 @@ CAPIStatus envoyGoFilterHttpRecordMetric(void* c, uint32_t metric_id, uint64_t v
       });
 }
 
+CAPIStatus envoyGoFilterHttpSetUpstreamOverrideHost(void* s, void* host_data, int host_len, bool strict) {
+  return envoyGoFilterProcessStateHandlerWrapper(
+      s,
+      [host_data, host_len, strict](std::shared_ptr<Filter>& filter,
+                                                      ProcessorState& state) -> CAPIStatus {
+        auto host_str = stringViewFromGoPointer(host_data, host_len);
+        return filter->setUpstreamOverrideHost(state, host_str, strict);
+      });
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/contrib/golang/filters/http/source/go/pkg/http/capi_impl.go
+++ b/contrib/golang/filters/http/source/go/pkg/http/capi_impl.go
@@ -108,6 +108,8 @@ func capiStatusToErr(status C.CAPIStatus) error {
 		return api.ErrInternalFailure
 	case C.CAPISerializationFailure:
 		return api.ErrSerializationFailure
+	case C.CAPIInvalidIPAddress:
+		return api.ErrInvalidIPAddress
 	}
 
 	return errors.New("unknown status")
@@ -475,6 +477,17 @@ func (c *httpCApiImpl) HttpGetStringSecret(r unsafe.Pointer, key string) (string
 		return "", false
 	}
 	return strings.Clone(unsafe.String((*byte)(unsafe.Pointer(uintptr(valueData))), int(valueLen))), true
+}
+
+func (c *httpCApiImpl) HttpSetUpstreamOverrideHost(s unsafe.Pointer, host string, strict bool) error {
+	state := (*processState)(s)
+	res := C.envoyGoFilterHttpSetUpstreamOverrideHost(unsafe.Pointer(state.processState), unsafe.Pointer(unsafe.StringData(host)), C.int(len(host)), C.bool(strict))
+	handleCApiStatus(res)
+	if res != C.CAPIOK {
+		return capiStatusToErr(res)
+	}
+
+	return nil
 }
 
 func (c *httpCApiImpl) HttpLog(level api.LogType, message string) {

--- a/contrib/golang/filters/http/source/go/pkg/http/capi_impl.go
+++ b/contrib/golang/filters/http/source/go/pkg/http/capi_impl.go
@@ -323,6 +323,17 @@ func (c *httpCApiImpl) HttpRemoveTrailer(s unsafe.Pointer, key string) {
 	handleCApiStatus(res)
 }
 
+func (c *httpCApiImpl) HttpSetUpstreamOverrideHost(s unsafe.Pointer, host string, strict bool) error {
+	state := (*processState)(s)
+	res := C.envoyGoFilterHttpSetUpstreamOverrideHost(unsafe.Pointer(state.processState), unsafe.Pointer(unsafe.StringData(host)), C.int(len(host)), C.bool(strict))
+	handleCApiStatus(res)
+	if res != C.CAPIOK {
+		return capiStatusToErr(res)
+	}
+
+	return nil
+}
+
 func (c *httpCApiImpl) ClearRouteCache(r unsafe.Pointer, refresh bool) {
 	req := (*httpRequest)(r)
 	res := C.envoyGoFilterHttpClearRouteCache(unsafe.Pointer(req.req), C.bool(refresh))
@@ -477,17 +488,6 @@ func (c *httpCApiImpl) HttpGetStringSecret(r unsafe.Pointer, key string) (string
 		return "", false
 	}
 	return strings.Clone(unsafe.String((*byte)(unsafe.Pointer(uintptr(valueData))), int(valueLen))), true
-}
-
-func (c *httpCApiImpl) HttpSetUpstreamOverrideHost(s unsafe.Pointer, host string, strict bool) error {
-	state := (*processState)(s)
-	res := C.envoyGoFilterHttpSetUpstreamOverrideHost(unsafe.Pointer(state.processState), unsafe.Pointer(unsafe.StringData(host)), C.int(len(host)), C.bool(strict))
-	handleCApiStatus(res)
-	if res != C.CAPIOK {
-		return capiStatusToErr(res)
-	}
-
-	return nil
 }
 
 func (c *httpCApiImpl) HttpLog(level api.LogType, message string) {

--- a/contrib/golang/filters/http/source/go/pkg/http/filter.go
+++ b/contrib/golang/filters/http/source/go/pkg/http/filter.go
@@ -80,7 +80,7 @@ type httpRequest struct {
 
 	// decodingState and encodingState are part of httpRequest, not another GC object.
 	// So, no cycle reference, GC finalizer could work well.
-	decodingState processState
+	decodingState decodingProcessState
 	encodingState processState
 	streamInfo    streamInfo
 }
@@ -89,6 +89,11 @@ type httpRequest struct {
 type processState struct {
 	request      *httpRequest
 	processState *C.processState
+}
+
+// processState implements the DecoderFilterCallbacks interface.
+type decodingProcessState struct {
+	processState
 }
 
 const (
@@ -173,6 +178,10 @@ func (s *processState) AddData(data []byte, isStreaming bool) {
 
 func (s *processState) InjectData(data []byte) {
 	cAPI.HttpInjectData(unsafe.Pointer(s), data)
+}
+
+func (s *decodingProcessState) SetUpstreamOverrideHost(host string, strict bool) error {
+	return cAPI.HttpSetUpstreamOverrideHost(unsafe.Pointer(&s.processState), host, strict)
 }
 
 func (r *httpRequest) StreamInfo() api.StreamInfo {

--- a/contrib/golang/filters/http/source/go/pkg/http/shim.go
+++ b/contrib/golang/filters/http/source/go/pkg/http/shim.go
@@ -112,10 +112,10 @@ func getOrCreateState(s *C.processState) *processState {
 		req = createRequest(r)
 	}
 	if s.is_encoding == 0 {
-		if req.decodingState.processState == nil {
-			req.decodingState.processState = s
+		if req.decodingState.processState.processState == nil {
+			req.decodingState.processState.processState = s
 		}
-		return &req.decodingState
+		return &req.decodingState.processState
 	}
 
 	// s.is_encoding == 1
@@ -158,7 +158,7 @@ func getState(s *C.processState) *processState {
 	r := s.req
 	req := getRequest(r)
 	if s.is_encoding == 0 {
-		return &req.decodingState
+		return &req.decodingState.processState
 	}
 	// s.is_encoding == 1
 	return &req.encodingState

--- a/contrib/golang/filters/http/source/golang_filter.cc
+++ b/contrib/golang/filters/http/source/golang_filter.cc
@@ -970,6 +970,55 @@ CAPIStatus Filter::removeTrailer(ProcessorState& state, absl::string_view key) {
   return CAPIStatus::CAPIOK;
 }
 
+CAPIStatus Filter::setUpstreamOverrideHost(ProcessorState& state, absl::string_view host,
+                                           bool strict) {
+  Thread::LockGuard lock(mutex_);
+  if (has_destroyed_) {
+    ENVOY_LOG(debug, "golang filter has been destroyed");
+    return CAPIStatus::CAPIFilterIsDestroy;
+  }
+
+  if (!state.isProcessingInGo()) {
+    ENVOY_LOG(debug, "golang filter is not processing Go");
+    return CAPIStatus::CAPINotInGo;
+  }
+  auto* s = dynamic_cast<DecodingProcessorState*>(&state);
+  if (s == nullptr) {
+    ENVOY_LOG(debug,
+              "golang filter invoking cgo api setUpstreamOverrideHost at invalid state: {}, "
+              "which must be DecodingProcessorState",
+              __func__);
+    return CAPIStatus::CAPIInvalidPhase;
+  }
+
+  if (!Http::Utility::parseAuthority(host).is_ip_address_) {
+    ENVOY_LOG(debug, "host is not a valid IP address");
+    return CAPIStatus::CAPIInvalidIPAddress;
+  }
+
+  if (state.isThreadSafe()) {
+    // it's safe to write header in the safe thread.
+    s->setUpstreamOverrideHost(std::make_pair(std::string(host), strict));
+  } else {
+    // should deep copy the string_view before post to dispatcher callback.
+    auto host_str = std::string(host);
+
+    auto weak_ptr = weak_from_this();
+    // dispatch a callback to write header in the envoy safe thread, to make the write operation
+    // safety. otherwise, there might be race between reading in the envoy worker thread and writing
+    // in the Go thread.
+    state.getDispatcher().post([this, s, weak_ptr, host_str] {
+      if (!weak_ptr.expired() && !hasDestroyed()) {
+        s->setUpstreamOverrideHost(std::make_pair(std::string(host_str), false));
+      } else {
+        ENVOY_LOG(debug, "golang filter has gone or destroyed in setUpstreamOverrideHost");
+      }
+    });
+  }
+
+  return CAPIStatus::CAPIOK;
+}
+
 CAPIStatus Filter::clearRouteCache(bool refresh) {
   Thread::LockGuard lock(mutex_);
   if (has_destroyed_) {
@@ -1496,55 +1545,6 @@ CAPIStatus Filter::getSecret(const absl::string_view name, uint64_t* value_data,
         });
     return CAPIStatus::CAPIYield;
   }
-}
-
-CAPIStatus Filter::setUpstreamOverrideHost(ProcessorState& state, absl::string_view host,
-                                           bool strict) {
-  Thread::LockGuard lock(mutex_);
-  if (has_destroyed_) {
-    ENVOY_LOG(debug, "golang filter has been destroyed");
-    return CAPIStatus::CAPIFilterIsDestroy;
-  }
-
-  if (!state.isProcessingInGo()) {
-    ENVOY_LOG(debug, "golang filter is not processing Go");
-    return CAPIStatus::CAPINotInGo;
-  }
-  auto* s = dynamic_cast<DecodingProcessorState*>(&state);
-  if (s == nullptr) {
-    ENVOY_LOG(debug,
-              "golang filter invoking cgo api setUpstreamOverrideHost at invalid state: {}, "
-              "which must be DecodingProcessorState",
-              __func__);
-    return CAPIStatus::CAPIInvalidPhase;
-  }
-
-  if (!Http::Utility::parseAuthority(host).is_ip_address_) {
-    ENVOY_LOG(debug, "host is not a valid IP address");
-    return CAPIStatus::CAPIInvalidIPAddress;
-  }
-
-  if (state.isThreadSafe()) {
-    // it's safe to write header in the safe thread.
-    s->setUpstreamOverrideHost(std::make_pair(std::string(host), strict));
-  } else {
-    // should deep copy the string_view before post to dispatcher callback.
-    auto host_str = std::string(host);
-
-    auto weak_ptr = weak_from_this();
-    // dispatch a callback to write header in the envoy safe thread, to make the write operation
-    // safety. otherwise, there might be race between reading in the envoy worker thread and writing
-    // in the Go thread.
-    state.getDispatcher().post([this, s, weak_ptr, host_str] {
-      if (!weak_ptr.expired() && !hasDestroyed()) {
-        s->setUpstreamOverrideHost(std::make_pair(std::string(host_str), false));
-      } else {
-        ENVOY_LOG(debug, "golang filter has gone or destroyed in setUpstreamOverrideHost");
-      }
-    });
-  }
-
-  return CAPIStatus::CAPIOK;
 }
 
 /* ConfigId */

--- a/contrib/golang/filters/http/source/golang_filter.cc
+++ b/contrib/golang/filters/http/source/golang_filter.cc
@@ -1498,13 +1498,14 @@ CAPIStatus Filter::getSecret(const absl::string_view name, uint64_t* value_data,
   }
 }
 
-CAPIStatus Filter::setUpstreamOverrideHost(ProcessorState& state, absl::string_view host, bool strict) {
+CAPIStatus Filter::setUpstreamOverrideHost(ProcessorState& state, absl::string_view host,
+                                           bool strict) {
   Thread::LockGuard lock(mutex_);
   if (has_destroyed_) {
     ENVOY_LOG(debug, "golang filter has been destroyed");
     return CAPIStatus::CAPIFilterIsDestroy;
   }
-  
+
   if (!state.isProcessingInGo()) {
     ENVOY_LOG(debug, "golang filter is not processing Go");
     return CAPIStatus::CAPINotInGo;

--- a/contrib/golang/filters/http/source/golang_filter.cc
+++ b/contrib/golang/filters/http/source/golang_filter.cc
@@ -1498,6 +1498,54 @@ CAPIStatus Filter::getSecret(const absl::string_view name, uint64_t* value_data,
   }
 }
 
+CAPIStatus Filter::setUpstreamOverrideHost(ProcessorState& state, absl::string_view host, bool strict) {
+  Thread::LockGuard lock(mutex_);
+  if (has_destroyed_) {
+    ENVOY_LOG(debug, "golang filter has been destroyed");
+    return CAPIStatus::CAPIFilterIsDestroy;
+  }
+  
+  if (!state.isProcessingInGo()) {
+    ENVOY_LOG(debug, "golang filter is not processing Go");
+    return CAPIStatus::CAPINotInGo;
+  }
+  auto* s = dynamic_cast<DecodingProcessorState*>(&state);
+  if (s == nullptr) {
+    ENVOY_LOG(debug,
+              "golang filter invoking cgo api setUpstreamOverrideHost at invalid state: {}, "
+              "which must be DecodingProcessorState",
+              __func__);
+    return CAPIStatus::CAPIInvalidPhase;
+  }
+
+  if (!Http::Utility::parseAuthority(host).is_ip_address_) {
+    ENVOY_LOG(debug, "host is not a valid IP address");
+    return CAPIStatus::CAPIInvalidIPAddress;
+  }
+
+  if (state.isThreadSafe()) {
+    // it's safe to write header in the safe thread.
+    s->setUpstreamOverrideHost(std::make_pair(std::string(host), strict));
+  } else {
+    // should deep copy the string_view before post to dispatcher callback.
+    auto host_str = std::string(host);
+
+    auto weak_ptr = weak_from_this();
+    // dispatch a callback to write header in the envoy safe thread, to make the write operation
+    // safety. otherwise, there might be race between reading in the envoy worker thread and writing
+    // in the Go thread.
+    state.getDispatcher().post([this, s, weak_ptr, host_str] {
+      if (!weak_ptr.expired() && !hasDestroyed()) {
+        s->setUpstreamOverrideHost(std::make_pair(std::string(host_str), false));
+      } else {
+        ENVOY_LOG(debug, "golang filter has gone or destroyed in setUpstreamOverrideHost");
+      }
+    });
+  }
+
+  return CAPIStatus::CAPIOK;
+}
+
 /* ConfigId */
 
 uint64_t Filter::getMergedConfigId() {

--- a/contrib/golang/filters/http/source/golang_filter.h
+++ b/contrib/golang/filters/http/source/golang_filter.h
@@ -301,6 +301,7 @@ public:
   CAPIStatus setTrailer(ProcessorState& state, absl::string_view key, absl::string_view value,
                         headerAction act);
   CAPIStatus removeTrailer(ProcessorState& state, absl::string_view key);
+  CAPIStatus setUpstreamOverrideHost(ProcessorState& state, absl::string_view host, bool strict);
 
   CAPIStatus getStringValue(int id, uint64_t* value_data, int* value_len);
   CAPIStatus getIntegerValue(int id, uint64_t* value);
@@ -313,8 +314,6 @@ public:
   CAPIStatus getStringProperty(absl::string_view path, uint64_t* value_data, int* value_len,
                                GoInt32* rc);
   CAPIStatus getSecret(absl::string_view key, uint64_t* value_data, int* value_len);
-
-  CAPIStatus setUpstreamOverrideHost(ProcessorState& state, absl::string_view host, bool strict);
 
   bool isProcessingInGo() {
     return decoding_state_.isProcessingInGo() || encoding_state_.isProcessingInGo();

--- a/contrib/golang/filters/http/source/golang_filter.h
+++ b/contrib/golang/filters/http/source/golang_filter.h
@@ -314,6 +314,8 @@ public:
                                GoInt32* rc);
   CAPIStatus getSecret(absl::string_view key, uint64_t* value_data, int* value_len);
 
+  CAPIStatus setUpstreamOverrideHost(ProcessorState& state, absl::string_view host, bool strict);
+
   bool isProcessingInGo() {
     return decoding_state_.isProcessingInGo() || encoding_state_.isProcessingInGo();
   }

--- a/contrib/golang/filters/http/source/processor_state.h
+++ b/contrib/golang/filters/http/source/processor_state.h
@@ -219,6 +219,10 @@ public:
     decoder_callbacks_->addDecodedData(data, is_streaming);
   }
 
+  void setUpstreamOverrideHost(std::pair<std::string, bool> host_and_strict) {
+    decoder_callbacks_->setUpstreamOverrideHost(host_and_strict);
+  }
+
 private:
   Http::StreamDecoderFilterCallbacks* decoder_callbacks_{nullptr};
 };

--- a/contrib/golang/filters/http/test/golang_integration_test.cc
+++ b/contrib/golang/filters/http/test/golang_integration_test.cc
@@ -864,7 +864,9 @@ typed_config:
     cleanup();
   }
 
-  void testUpstreamOverrideHost(const std::string expected_status_code, const std::string expected_upstream_host, std::string path, bool strict, bool bad_host, bool invalid_host) {
+  void testUpstreamOverrideHost(const std::string expected_status_code,
+                                const std::string expected_upstream_host, std::string path,
+                                bool strict, bool bad_host, bool invalid_host) {
     initializeBasicFilter(BASIC);
 
     codec_client_ = makeHttpConnection(makeClientConnection(lookupPort("http")));
@@ -874,7 +876,7 @@ typed_config:
     auto encoder_decoder = codec_client_->startRequest(request_headers);
     Http::RequestEncoder& request_encoder = encoder_decoder.first;
     auto response = std::move(encoder_decoder.second);
-    
+
     if (!bad_host) {
       codec_client_->sendData(request_encoder, "helloworld", true);
       if (!(invalid_host && strict)) {
@@ -886,14 +888,14 @@ typed_config:
 
     ASSERT_TRUE(response->waitForEndStream());
 
-
     EXPECT_EQ(expected_status_code, response->headers().getStatusValue());
     if (expected_upstream_host != "") {
-      EXPECT_TRUE(absl::StrContains(getHeader(response->headers(), "rsp-upstream-host"), expected_upstream_host));
+      EXPECT_TRUE(absl::StrContains(getHeader(response->headers(), "rsp-upstream-host"),
+                                    expected_upstream_host));
     }
 
     cleanup();
-}
+  }
 
   const std::string ECHO{"echo"};
   const std::string BASIC{"basic"};
@@ -1801,30 +1803,29 @@ TEST_P(GolangIntegrationTest, MissingSecretGoRoutine) {
   testSecrets("missing_secret", "", "404", "/async");
 }
 
-// Set a valid IP address 
+// Set a valid IP address
 TEST_P(GolangIntegrationTest, SetUpstreamOverrideHost) {
-  const std::string host = GetParam() == Network::Address::IpVersion::v4 
-                         ? "127.0.0.1" 
-                         : "[::1]";
+  const std::string host = GetParam() == Network::Address::IpVersion::v4 ? "127.0.0.1" : "[::1]";
   testUpstreamOverrideHost("200", host, "/test?upstreamOverrideHost=" + host, false, false, false);
 }
 
-// Set a non-IP address, 
+// Set a non-IP address,
 TEST_P(GolangIntegrationTest, SetUpstreamOverrideHost_BadHost) {
   testUpstreamOverrideHost("403", "", "/test?upstreamOverrideHost=badhost", false, true, false);
 }
 
 // Set a invalid IP address
 TEST_P(GolangIntegrationTest, SetUpstreamOverrideHost_InvalidHost) {
-  const std::string host = GetParam() == Network::Address::IpVersion::v4 
-                        ? "127.0.0.1" 
-                        : "[::1]";
-  testUpstreamOverrideHost("200", host, "/test?upstreamOverrideHost=200.0.0.1:8080", false, false, true);
+  const std::string host = GetParam() == Network::Address::IpVersion::v4 ? "127.0.0.1" : "[::1]";
+  testUpstreamOverrideHost("200", host, "/test?upstreamOverrideHost=200.0.0.1:8080", false, false,
+                           true);
 }
 
 // Set a invalid IP address with strict mode
 TEST_P(GolangIntegrationTest, SetUpstreamOverrideHost_InvalidHost_Strict) {
-  testUpstreamOverrideHost("503", "", "/test?upstreamOverrideHost=200.0.0.1:8080&upstreamOverrideHostStrict=true", true, false, true);
+  testUpstreamOverrideHost(
+      "503", "", "/test?upstreamOverrideHost=200.0.0.1:8080&upstreamOverrideHostStrict=true", true,
+      false, true);
 }
 
 } // namespace Envoy

--- a/contrib/golang/filters/http/test/golang_integration_test.cc
+++ b/contrib/golang/filters/http/test/golang_integration_test.cc
@@ -1872,9 +1872,9 @@ TEST_P(GolangIntegrationTest, SetUpstreamOverrideHost_InvalidHost_Strict) {
       true, false, add_endpoint);
 }
 
-// Set a invalid IP address with strict mode and retry. when first request with invalid host failed,
-// the second request will retry with the valid host 503, then the second request will succeed and
-// finally return 200.
+// Set a invalid IP address with strict mode and retry.
+// when first request with invalid host failed 503, the second request will retry with the valid
+// host, then the second request will succeed and finally return 200.
 TEST_P(GolangIntegrationTest, SetUpstreamOverrideHost_InvalidHost_Strict_Retry) {
   const std::string expected_host =
       GetParam() == Network::Address::IpVersion::v4 ? "127.0.0.1" : "[::1]";

--- a/contrib/golang/filters/http/test/golang_integration_test.cc
+++ b/contrib/golang/filters/http/test/golang_integration_test.cc
@@ -869,16 +869,18 @@ typed_config:
                                 bool strict, bool bad_host, bool invalid_host, bool retry = false) {
     if (retry) {
       config_helper_.addConfigModifier(
-      [](
-          envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
-              hcm) {
-
-        auto* retry_policy = hcm.mutable_route_config()->mutable_virtual_hosts(0)->mutable_routes(0)->mutable_route()->mutable_retry_policy();
-        retry_policy->set_retry_on("5xx");
-        retry_policy->mutable_num_retries()->set_value(2);
-      });   
+          [](envoy::extensions::filters::network::http_connection_manager::v3::
+                 HttpConnectionManager& hcm) {
+            auto* retry_policy = hcm.mutable_route_config()
+                                     ->mutable_virtual_hosts(0)
+                                     ->mutable_routes(0)
+                                     ->mutable_route()
+                                     ->mutable_retry_policy();
+            retry_policy->set_retry_on("5xx");
+            retry_policy->mutable_num_retries()->set_value(2);
+          });
     }
-    
+
     initializeBasicFilter(BASIC);
 
     codec_client_ = makeHttpConnection(makeClientConnection(lookupPort("http")));

--- a/contrib/golang/filters/http/test/golang_integration_test.cc
+++ b/contrib/golang/filters/http/test/golang_integration_test.cc
@@ -1188,10 +1188,10 @@ TEST_P(GolangIntegrationTest, Async_DataBuffer_DecodeHeader) {
 // buffer all data in decode data phase with sync mode.
 TEST_P(GolangIntegrationTest, DataBuffer_DecodeData) { testBasic("/test?databuffer=decode-data"); }
 
-// // buffer all data in decode data phase with async mode.
-// TEST_P(GolangIntegrationTest, Async_DataBuffer_DecodeData) {
-//   testBasic("/test?async=1&databuffer=decode-data");
-// }
+// buffer all data in decode data phase with async mode.
+TEST_P(GolangIntegrationTest, Async_DataBuffer_DecodeData) {
+  testBasic("/test?async=1&databuffer=decode-data");
+}
 
 // Go send local reply in decode header phase.
 TEST_P(GolangIntegrationTest, LocalReply_DecodeHeader) {


### PR DESCRIPTION
Support set upstream override host  in golang filter, developer can call SetUpstreamOverrideHost in DecoderFilterCallbacks, here is the description for SetUpstreamOverrideHost: 

Sets an upstream address override for the request. When the overridden host exists in the host list of the routed cluster
and can be selected directly, the load balancer bypasses its algorithm and routes traffic directly to the specified host.

The strict flag determines whether the HTTP request must strictly use the overridden destination.
When the destination is unavailable/not-found, if strict is set to true, Envoy responds with a 503 Service Unavailable error;
if strict is set to false, Envoy will fall back to its load balancing mechanism.

Notice: host must be a valid IP address(with port).

Here is the function:
SetUpstreamOverrideHost(host string, strict bool) error


Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
