### PR TITLE
grpc_field_extraction: [refactor] remove unneeded data members from extractor

### DIFF
--- a/source/extensions/filters/http/grpc_field_extraction/BUILD
+++ b/source/extensions/filters/http/grpc_field_extraction/BUILD
@@ -27,6 +27,7 @@ envoy_cc_library(
     external_deps = ["grpc_transcoding"],
     deps = [
         "extractor",
+        "//envoy/common:exception_lib",
         "//source/common/common:minimal_logger_lib",
         "@com_google_absl//absl/status",
         "@com_google_protofieldextraction//:all_libs",


### PR DESCRIPTION
Commit Message: grpc_field_extraction: [refactor] remove unneeded data members from extractor
Additional Description:
Refactor the internal representation of the Extractor class, and remove some data-memebrs that are only needed during initialization.

Risk Level: low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A