### PR TITLE
match_delegate: remove redundant bool data member

### DIFF
--- a/source/extensions/filters/http/match_delegate/config.cc
+++ b/source/extensions/filters/http/match_delegate/config.cc
@@ -105,7 +105,7 @@ void DelegatingStreamFilter::FilterMatchState::evaluateMatchTree(
   }
 
   // If no match tree is set, interpret as a skip.
-  if (!has_match_tree_) {
+  if (match_tree_ == nullptr) {
     skip_filter_ = true;
     match_tree_evaluated_ = true;
     return;

--- a/source/extensions/filters/http/match_delegate/config.h
+++ b/source/extensions/filters/http/match_delegate/config.h
@@ -27,7 +27,7 @@ public:
   class FilterMatchState {
   public:
     FilterMatchState(Matcher::MatchTreeSharedPtr<Envoy::Http::HttpMatchingData> match_tree)
-        : match_tree_(std::move(match_tree)), has_match_tree_(match_tree_ != nullptr) {}
+        : match_tree_(std::move(match_tree)) {}
 
     void evaluateMatchTree(MatchDataUpdateFunc data_update_func);
     bool skipFilter() const { return skip_filter_; }
@@ -41,14 +41,12 @@ public:
     // filter config.
     void setMatchTree(Matcher::MatchTreeSharedPtr<Envoy::Http::HttpMatchingData> match_tree) {
       match_tree_ = std::move(match_tree);
-      has_match_tree_ = match_tree_ != nullptr;
     }
 
     void setBaseFilter(Envoy::Http::StreamFilterBase* base_filter) { base_filter_ = base_filter; }
 
   private:
     Matcher::MatchTreeSharedPtr<Envoy::Http::HttpMatchingData> match_tree_;
-    bool has_match_tree_{};
     Envoy::Http::StreamFilterBase* base_filter_{};
 
     Envoy::Http::Matching::HttpMatchingDataImplSharedPtr matching_data_;


### PR DESCRIPTION
Commit Message: match_delegate: remove redundant bool data member
Additional Description:
Removes the `has_match_tree_` data member, and checking directly if `match_tree_` has a value or not.

Risk Level: low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A