### PR TITLE
mutation_rules: replace proto data member with only required flags

### DIFF
--- a/source/extensions/filters/common/mutation_rules/mutation_rules.h
+++ b/source/extensions/filters/common/mutation_rules/mutation_rules.h
@@ -46,9 +46,13 @@ private:
   bool isValidValue(const Http::LowerCaseString& header_name, absl::string_view header_value) const;
   static const ExtraRoutingHeaders& extraRoutingHeaders();
 
-  envoy::config::common::mutation_rules::v3::HeaderMutationRules rules_;
   Regex::CompiledMatcherPtr allow_expression_;
   Regex::CompiledMatcherPtr disallow_expression_;
+  const bool allow_all_routing_ : 1;
+  const bool allow_envoy_ : 1;
+  const bool disallow_system_ : 1;
+  const bool disallow_all_ : 1;
+  const bool disallow_is_error_ : 1;
 };
 
 } // namespace MutationRules


### PR DESCRIPTION
Commit Message: mutation_rules: replace proto data member with only required flags
Additional Description:
The mutation-rules Checker class keeps the entire Rules proto as a data member, but only a few boolean flags may be accessed later. This PR removes the data-member and introduces the flags as data members.
This will reduce any memory needed for the the regex fields in that proto.

Risk Level: low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A