### PR TITLE
docs: clean up ExtProc docs and make it consistent

### DIFF
--- a/api/envoy/extensions/filters/http/ext_proc/v3/ext_proc.proto
+++ b/api/envoy/extensions/filters/http/ext_proc/v3/ext_proc.proto
@@ -34,10 +34,10 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // The filter communicates with an external gRPC service called an "external processor"
 // that can do a variety of things with the request and response:
 //
-// * Access and modify the HTTP headers on the request, response, or both
-// * Access and modify the HTTP request and response bodies
-// * Access and modify the dynamic stream metadata
-// * Immediately send an HTTP response downstream and terminate other processing
+// * Access and modify the HTTP headers on the request, response, or both.
+// * Access and modify the HTTP request and response bodies.
+// * Access and modify the dynamic stream metadata.
+// * Immediately send an HTTP response downstream and terminate other processing.
 //
 // The filter communicates with the server using a gRPC bidirectional stream. After the initial
 // request, the external server is in control over what additional data is sent to it
@@ -45,11 +45,11 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 //
 // By implementing the protocol specified by the stream, the external server can choose:
 //
-// * Whether it receives the response message at all
-// * Whether it receives the message body at all, in separate chunks, or as a single buffer
+// * Whether it receives the response message at all.
+// * Whether it receives the message body at all, in separate chunks, or as a single buffer.
 // * Whether subsequent HTTP requests are transmitted synchronously or whether they are
 //   sent asynchronously.
-// * To modify request or response trailers if they already exist
+// * To modify request or response trailers if they already exist.
 //
 // The filter supports up to six different processing steps. Each is represented by
 // a gRPC stream message that is sent to the external processor. For each message, the
@@ -57,10 +57,10 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 //
 // * Request headers: Contains the headers from the original HTTP request.
 // * Request body: Delivered if they are present and sent in a single message if
-//   the BUFFERED or BUFFERED_PARTIAL mode is chosen, in multiple messages if the
-//   STREAMED mode is chosen, and not at all otherwise.
+//   the ``BUFFERED`` or ``BUFFERED_PARTIAL`` mode is chosen, in multiple messages if the
+//   ``STREAMED`` mode is chosen, and not at all otherwise.
 // * Request trailers: Delivered if they are present and if the trailer mode is set
-//   to SEND.
+//   to ``SEND``.
 // * Response headers: Contains the headers from the HTTP response. Keep in mind
 //   that if the upstream system sends them before processing the request body that
 //   this message may arrive before the complete body.
@@ -69,9 +69,9 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 //   request trailers.
 //
 // By default, the processor sends only the request and response headers messages.
-// This may be changed to include any of the six steps by changing the processing_mode
-// setting of the filter configuration, or by setting the mode_override of any response
-// from the external processor. The latter is only enabled if allow_mode_override is
+// This may be changed to include any of the six steps by changing the ``processing_mode``
+// setting of the filter configuration, or by setting the ``mode_override`` of any response
+// from the external processor. The latter is only enabled if ``allow_mode_override`` is
 // set to true. This way, a processor may, for example, use information
 // in the request header to determine whether the message body must be examined, or whether
 // the proxy should simply stream it straight through.
@@ -107,12 +107,12 @@ message ExternalProcessor {
     // field is set in an external processor response.
     DEFAULT = 0;
 
-    // Always clear the route cache irrespective of the clear_route_cache bit in
+    // Always clear the route cache irrespective of the ``clear_route_cache`` bit in
     // the external processor response.
     CLEAR = 1;
 
-    // Do not clear the route cache irrespective of the clear_route_cache bit in
-    // the external processor response. Setting to RETAIN is equivalent to set the
+    // Do not clear the route cache irrespective of the ``clear_route_cache`` bit in
+    // the external processor response. Setting to ``RETAIN`` is equivalent to setting the
     // :ref:`disable_clear_route_cache <envoy_v3_api_field_extensions.filters.http.ext_proc.v3.ExternalProcessor.disable_clear_route_cache>`
     // to true.
     RETAIN = 2;
@@ -131,12 +131,12 @@ message ExternalProcessor {
 
   // Configuration for the HTTP service that the filter will communicate with.
   // Only one of ``http_service`` or
-  // :ref:`grpc_service <envoy_v3_api_field_extensions.filters.http.ext_proc.v3.ExternalProcessor.grpc_service>`.
+  // :ref:`grpc_service <envoy_v3_api_field_extensions.filters.http.ext_proc.v3.ExternalProcessor.grpc_service>`
   // can be set. It is required that one of them must be set.
   //
   // If ``http_service`` is set, the
   // :ref:`processing_mode <envoy_v3_api_field_extensions.filters.http.ext_proc.v3.ExternalProcessor.processing_mode>`
-  // can not be configured to send any body or trailers. i.e, http_service only supports
+  // cannot be configured to send any body or trailers. i.e., ``http_service`` only supports
   // sending request or response headers to the side stream server.
   //
   // With this configuration, Envoy behavior:
@@ -146,7 +146,7 @@ message ExternalProcessor {
   //
   // 2. This proto message is then transcoded into a JSON text.
   //
-  // 3. Envoy then sends a HTTP POST message with content-type as "application/json",
+  // 3. Envoy then sends an HTTP POST message with content-type as "application/json",
   // and this JSON text as body to the side stream server.
   //
   // After the side-stream receives this HTTP request message, it is expected to do as follows:
@@ -157,10 +157,10 @@ message ExternalProcessor {
   // 2. It then sets the mutated headers into a new proto message
   // :ref:`ProcessingResponse <envoy_v3_api_msg_service.ext_proc.v3.ProcessingResponse>`.
   //
-  // 3. It converts ``ProcessingResponse`` proto message into a JSON text.
+  // 3. It converts the ``ProcessingResponse`` proto message into a JSON text.
   //
-  // 4. It then sends a HTTP response back to Envoy with status code as "200",
-  // content-type as "application/json" and sets the JSON text as the body.
+  // 4. It then sends an HTTP response back to Envoy with status code as ``"200"``,
+  // ``content-type`` as ``"application/json"`` and sets the JSON text as the body.
   //
   ExtProcHttpService http_service = 20 [
     (udpa.annotations.field_migrate).oneof_promotion = "ext_proc_service_type",
@@ -177,19 +177,19 @@ message ExternalProcessor {
   bool failure_mode_allow = 2;
 
   // Specifies default options for how HTTP headers, trailers, and bodies are
-  // sent. See ProcessingMode for details.
+  // sent. See ``ProcessingMode`` for details.
   ProcessingMode processing_mode = 3;
 
   // Envoy provides a number of :ref:`attributes <arch_overview_attributes>`
   // for expressive policies. Each attribute name provided in this field will be
-  // matched against that list and populated in the request_headers message.
+  // matched against that list and populated in the ``request_headers`` message.
   // See the :ref:`attribute documentation <arch_overview_request_attributes>`
   // for the list of supported attributes and their types.
   repeated string request_attributes = 5;
 
   // Envoy provides a number of :ref:`attributes <arch_overview_attributes>`
   // for expressive policies. Each attribute name provided in this field will be
-  // matched against that list and populated in the response_headers message.
+  // matched against that list and populated in the ``response_headers`` message.
   // See the :ref:`attribute documentation <arch_overview_attributes>`
   // for the list of supported attributes and their types.
   repeated string response_attributes = 6;
@@ -208,7 +208,7 @@ message ExternalProcessor {
   }];
 
   // Optional additional prefix to use when emitting statistics. This allows to distinguish
-  // emitted statistics between configured *ext_proc* filters in an HTTP filter chain.
+  // emitted statistics between configured ``ext_proc`` filters in an HTTP filter chain.
   string stat_prefix = 8;
 
   // Rules that determine what modifications an external processing server may
@@ -258,12 +258,12 @@ message ExternalProcessor {
   // Options related to the sending and receiving of dynamic metadata.
   MetadataOptions metadata_options = 16;
 
-  // If true, send each part of the HTTP request or response specified by ProcessingMode
+  // If true, send each part of the HTTP request or response specified by ``ProcessingMode``
   // without pausing on filter chain iteration. It is "Send and Go" mode that can be used
   // by external processor to observe Envoy data and status. In this mode:
   //
-  // 1. Only STREAMED body processing mode is supported and any other body processing modes will be
-  // ignored. NONE mode(i.e., skip body processing) will still work as expected.
+  // 1. Only ``STREAMED`` body processing mode is supported and any other body processing modes will be
+  // ignored. ``NONE`` mode (i.e., skip body processing) will still work as expected.
   //
   // 2. External processor should not send back processing response, as any responses will be ignored.
   // This also means that
@@ -274,7 +274,7 @@ message ExternalProcessor {
   //
   // .. warning::
   //
-  //    Flow control is necessary mechanism to prevent the fast sender (either downstream client or upstream server)
+  //    Flow control is a necessary mechanism to prevent the fast sender (either downstream client or upstream server)
   //    from overwhelming the external processor when its processing speed is slower.
   //    This protective measure is being explored and developed but has not been ready yet, so please use your own
   //    discretion when enabling this feature.
@@ -291,7 +291,7 @@ message ExternalProcessor {
       [(udpa.annotations.field_migrate).oneof_promotion = "clear_route_cache_type"];
 
   // Specifies the action to be taken when an external processor response is
-  // received in response to request headers. It is recommended to set this field than set
+  // received in response to request headers. It is recommended to set this field rather than set
   // :ref:`disable_clear_route_cache <envoy_v3_api_field_extensions.filters.http.ext_proc.v3.ExternalProcessor.disable_clear_route_cache>`.
   // Only one of ``disable_clear_route_cache`` or ``route_cache_action`` can be set.
   RouteCacheAction route_cache_action = 18
@@ -305,7 +305,7 @@ message ExternalProcessor {
   google.protobuf.Duration deferred_close_timeout = 19;
 
   // Send body to the side stream server once it arrives without waiting for the header response from that server.
-  // It only works for STREAMED body processing mode. For any other body processing modes, it is ignored.
+  // It only works for ``STREAMED`` body processing mode. For any other body processing modes, it is ignored.
   // The server has two options upon receiving a header request:
   //
   // 1. Instant Response: send the header response as soon as the header request is received.
@@ -327,7 +327,7 @@ message ExternalProcessor {
   // can only be overridden by the response message from the external processing server iff the
   // :ref:`mode_override <envoy_v3_api_field_service.ext_proc.v3.ProcessingResponse.mode_override>` is allowed by
   // the ``allowed_override_modes`` allow-list below.
-  // Since request_header_mode is not applicable in any way, it's ignored in comparison.
+  // Since ``request_header_mode`` is not applicable in any way, it's ignored in comparison.
   repeated ProcessingMode allowed_override_modes = 22;
 
   // Decorator to introduce custom logic that runs after a message received from
@@ -353,11 +353,11 @@ message ExtProcHttpService {
 message MetadataOptions {
   message MetadataNamespaces {
     // Specifies a list of metadata namespaces whose values, if present,
-    // will be passed to the ext_proc service as an opaque *protobuf::Struct*.
+    // will be passed to the ``ext_proc`` service as an opaque ``protobuf::Struct``.
     repeated string untyped = 1;
 
     // Specifies a list of metadata namespaces whose values, if present,
-    // will be passed to the ext_proc service as a *protobuf::Any*. This allows
+    // will be passed to the ``ext_proc`` service as a ``protobuf::Any``. This allows
     // envoy and the external processing server to share the protobuf message
     // definition for safe parsing.
     repeated string typed = 2;
@@ -442,7 +442,7 @@ message ExtProcOverrides {
   // most-specific config contains the correct final overrides.
   MetadataOptions metadata_options = 6;
 
-  // Additional metadata to include into streams initiated to the ext_proc gRPC
+  // Additional metadata to include into streams initiated to the ``ext_proc`` gRPC
   // service. This can be used for scenarios in which additional ad hoc
   // authorization headers (e.g. ``x-foo-bar: baz-key``) are to be injected or
   // when a route needs to partially override inherited metadata.


### PR DESCRIPTION
## Description

This PR have some cleanup in ExtProc docs for consistency. We are using the backticks inconsistently throughout right now.

---

**Commit Message:** docs: clean up ExtProc docs and make it consistent
**Additional Description:** Minor clean up for added clarity on the ExtProc docs.
**Risk Level:** N/A
**Testing:** N/A
**Docs Changes:** N/A
**Release Notes:** N/A