### PR TITLE
Don't build API with libstdc++ by default

### DIFF
--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -188,9 +188,6 @@ function bazel_contrib_binary_build() {
 }
 
 function bazel_envoy_api_build() {
-    # Use libstdc++ because the API booster links to prebuilt libclang*/libLLVM* installed in /opt/llvm/lib,
-    # which is built with libstdc++. Using libstdc++ for whole of the API CI job to avoid unnecessary rebuild.
-    ENVOY_STDLIB="libstdc++"
     setup_clang_toolchain
     export CLANG_TOOLCHAIN_SETUP=1
     export LLVM_CONFIG="${LLVM_ROOT}"/bin/llvm-config


### PR DESCRIPTION
Commit Message:

It seems that in the past there was a reason for that because we linked some pre-built artifacts (api booster) that were built using libstdc++, but it does not seem like we do that anymore.

As we are moving to managing toolchains and standard library via Bazel it would be useful to limit the number of combinations of toolchain and standard library we need to support to simplify things.

If we could eliminate this, we can stick to just two combinations:

1. gcc + libstdc++
2. llvm + libc++

libstdc++ is native to gcc and libc++ is native to llvm, so these combinations make sense. And if we only need to support those two it simplifies things a bit because we can get away and bundle toolchain together with the standard library.

Additional Description: n/a
Risk Level: low
Testing: CI tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a

+cc @phlax 
