### PR TITLE
Revert "xDS: add proto to get aggregate cluster config from a separat…

### DIFF
--- a/api/envoy/extensions/clusters/aggregate/v3/BUILD
+++ b/api/envoy/extensions/clusters/aggregate/v3/BUILD
@@ -5,8 +5,5 @@ load("@envoy_api//bazel:api_build_system.bzl", "api_proto_package")
 licenses(["notice"])  # Apache 2
 
 api_proto_package(
-    deps = [
-        "//envoy/config/core/v3:pkg",
-        "@com_github_cncf_xds//udpa/annotations:pkg",
-    ],
+    deps = ["@com_github_cncf_xds//udpa/annotations:pkg"],
 )

--- a/api/envoy/extensions/clusters/aggregate/v3/cluster.proto
+++ b/api/envoy/extensions/clusters/aggregate/v3/cluster.proto
@@ -2,8 +2,6 @@ syntax = "proto3";
 
 package envoy.extensions.clusters.aggregate.v3;
 
-import "envoy/config/core/v3/config_source.proto";
-
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
@@ -26,19 +24,4 @@ message ClusterConfig {
   // Load balancing clusters in aggregate cluster. Clusters are prioritized based on the order they
   // appear in this list.
   repeated string clusters = 1 [(validate.rules).repeated = {min_items: 1}];
-}
-
-// Configures an aggregate cluster whose
-// :ref:`ClusterConfig <envoy_v3_api_msg_extensions.clusters.aggregate.v3.ClusterConfig>`
-// is to be fetched from a separate xDS resource.
-// [#extension: envoy.clusters.aggregate_resource]
-// [#not-implemented-hide:]
-message AggregateClusterResource {
-  // Configuration source specifier for the ClusterConfig resource.
-  // Only the aggregated protocol variants are supported; if configured
-  // otherwise, the cluster resource will be NACKed.
-  config.core.v3.ConfigSource config_source = 1 [(validate.rules).message = {required: true}];
-
-  // The name of the ClusterConfig resource to subscribe to.
-  string resource_name = 2 [(validate.rules).string = {min_len: 1}];
 }


### PR DESCRIPTION
…e resource (#39669)"

This reverts commit 6707aab4ca2a0dac0968126dc4628dcaa3065871.

This has broken coverage in `source/common/config`