### PR TITLE
bazel/ci: Add test for default toolchains

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -73,7 +73,7 @@ build:linux --conlyopt=-fexceptions
 build:linux --fission=dbg,opt
 build:linux --features=per_object_debug_info
 build:linux --action_env=BAZEL_LINKLIBS=-l%:libstdc++.a
-build:linux --action_env=BAZEL_LINKOPTS=-lm
+build:linux --action_env=BAZEL_LINKOPTS=-lm:-fuse-ld=gold
 
 # We already have absl in the build, define absl=1 to tell googletest to use absl for backtrace.
 build --define absl=1

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,12 @@ updates:
     interval: daily
     time: "06:00"
 
+- package-ecosystem: "docker"
+  directory: "/ci/matrix"
+  schedule:
+    interval: daily
+    time: "06:00"
+
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:

--- a/.github/workflows/toolchain-test.yml
+++ b/.github/workflows/toolchain-test.yml
@@ -1,0 +1,39 @@
+name: Toolchain default behavior test
+
+permissions:
+  contents: read
+on:
+  pull_request:
+    paths:
+    - .bazelrc
+    - .github/workflows/toolchain-test.yml
+    - ci/matrix/**
+    - tools/toolchain
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  toolchain-test:
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - name: "GCC only"
+          service: "gcc"
+        - name: "LLVM only"
+          service: "llvm"
+        - name: "Both GCC & LLVM"
+          service: "all"
+        - name: "No compilers"
+          service: "none"
+    name: "Test: ${{ matrix.name }}"
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+    - name: Run matrix test
+      run: |
+        cd ci/matrix
+        export UID
+        docker compose run --rm --build ${{ matrix.service }}

--- a/ci/matrix/Dockerfile
+++ b/ci/matrix/Dockerfile
@@ -1,0 +1,34 @@
+FROM ubuntu:22.04
+ENV DEBIAN_FRONTEND=noninteractive
+RUN --mount=type=tmpfs,target=/var/cache/apt \
+    --mount=type=tmpfs,target=/var/lib/apt/lists \
+    apt-get -qq update \
+    && apt-get -qq upgrade -y \
+    && apt-get -qq install --no-install-recommends -y \
+        curl \
+        git \
+        gosu \
+        libc6-dev \
+        software-properties-common \
+    && curl -fsSL -o /usr/local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/latest/download/bazelisk-linux-amd64 \
+    && chmod +x /usr/local/bin/bazel \
+    && groupadd -g 1001 envoybuild \
+    && useradd -m -u 1001 -g 1001 -s /bin/bash envoybuild
+ARG MATRIX_SETUP=""
+RUN --mount=type=tmpfs,target=/var/cache/apt \
+    --mount=type=tmpfs,target=/var/lib/apt/lists \
+    TMPFILE="$(mktemp)" \
+    && echo "$MATRIX_SETUP" > "$TMPFILE" \
+    && chmod +x "${TMPFILE}" \
+    && "${TMPFILE}"
+ARG MATRIX_SETUP_EXTRA=""
+RUN --mount=type=tmpfs,target=/var/cache/apt \
+    --mount=type=tmpfs,target=/var/lib/apt/lists \
+    TMPFILE="$(mktemp)" \
+    && echo "$MATRIX_SETUP_EXTRA" > "$TMPFILE" \
+    && chmod +x "${TMPFILE}" \
+    && "${TMPFILE}"
+COPY --chmod=755 ci/matrix/entrypoint.sh /entrypoint.sh
+COPY --chmod=755 ci/matrix/test.sh /usr/local/bin/test.sh
+WORKDIR /workspace
+ENTRYPOINT ["/entrypoint.sh"]

--- a/ci/matrix/README.md
+++ b/ci/matrix/README.md
@@ -1,0 +1,71 @@
+# CI Matrix Tests
+
+This directory contains tests that verify Envoy's toolchain detection and selection behavior across different compiler configurations. These tests ensure that Bazel correctly identifies and uses the appropriate compiler toolchains (GCC vs Clang) based on various configuration methods.
+
+> **NOTE**: If running these tests locally, please ensure that you do not have a `user.bazelrc` file as this may interfere with the tests. The tests rely on specific default behavior that can be altered by user-specific Bazel configurations.
+
+## What is Being Tested
+
+The test suite validates toolchain behavior in the following scenarios:
+
+- **Default build**: Testing what toolchain is selected with no explicit configuration
+- **Config-based selection**: Testing `--config=clang-libc++` and `--config=gcc` flags
+- **Environment-based selection**: Testing `CC`/`CXX` environment variable overrides
+- **Compiler availability**: Testing behavior when only specific compilers are available
+
+The tests run against different Docker environments:
+- `gcc`: Only GCC available
+- `llvm`: Only LLVM/Clang available
+- `all`: Both compilers available
+- `none`: No compilers available (tests hermetic toolchain fallback)
+
+## Running Tests Locally
+
+### Prerequisites
+
+- Docker and Docker Compose
+- Make sure your user has Docker permissions
+
+### Running Specific Test Configurations
+
+```bash
+
+# ensure correct permissions
+export UID
+export GID
+
+# Test only GCC configuration
+docker compose -f ci/matrix/docker-compose.yml run --build gcc
+
+# Test only LLVM configuration
+docker compose -f ci/matrix/docker-compose.yml run --build llvm
+
+# Test both compilers available
+docker compose -f ci/matrix/docker-compose.yml run --build all
+
+# Test no compilers (hermetic toolchains)
+docker compose -f ci/matrix/docker-compose.yml run --build none
+```
+
+## Test Output
+
+Successful tests will show output like:
+```
+✅ NO_ARGS passed as expected
+✅ GCC passed as expected
+✅ CLANG passed as expected
+✅ GCC_ENV passed as expected
+✅ CLANG_ENV passed as expected
+All test configs passed as expected
+```
+
+Failed tests will show which configuration didn't match expectations:
+```
+❌ CLANG: expected=clang-libc++, got=fail
+```
+
+### Troubleshooting
+
+- If you get permission errors, ensure `UID` and `GID` environment variables are set correctly
+- If tests fail unexpectedly, check that no local Bazel configuration files are interfering
+- The `none` configuration is expected to fail until hermetic toolchains are fully implemented

--- a/ci/matrix/docker-compose.yml
+++ b/ci/matrix/docker-compose.yml
@@ -1,0 +1,125 @@
+x-common: &common-base
+  build:
+    context: ../..
+    dockerfile: ci/matrix/Dockerfile
+  volumes:
+  - ../..:/workspace
+  environment: &common-env
+    ENVOY_UID: "${UID:?UID not set, **try** `export UID`}"
+    ENVOY_GID: ${GID}
+
+x-gcc-setup: &gcc-setup |
+  #!/usr/bin/env bash
+  set -eo pipefail
+  apt-get update --error-on=any
+  apt-get -qq install -y gnupg2 gpg-agent
+  add-apt-repository -y ppa:ubuntu-toolchain-r/test
+  apt-get update --error-on=any
+  apt-get -qq install -y --no-install-recommends gcc-13 g++-13 libstdc++-13-dev libc6-dev build-essential
+  update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 100
+  update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-13 100
+
+x-llvm-setup: &llvm-setup |
+  #!/usr/bin/env bash
+  set -eo pipefail
+  apt-get -qq update --error-on=any
+  apt-get -qq install -y gnupg2 gpg-agent
+  add-apt-repository -y ppa:ubuntu-toolchain-r/test
+  apt-get update --error-on=any
+  apt-get -qq install -y libtinfo5 wget xz-utils libgcc-s1 libgcc-13-dev
+  mkdir -p /opt/llvm
+  cd /opt/llvm
+  wget -q https://github.com/llvm/llvm-project/releases/download/llvmorg-18.1.8/clang+llvm-18.1.8-x86_64-linux-gnu-ubuntu-18.04.tar.xz
+  tar -xf clang+llvm-18.1.8-x86_64-linux-gnu-ubuntu-18.04.tar.xz --strip-components 1
+
+services:
+  gcc:
+    <<: *common-base
+    build:
+      context: ../..
+      dockerfile: ci/matrix/Dockerfile
+      args:
+        MATRIX_SETUP: *gcc-setup
+    environment:
+      <<: *common-env
+      EXPECTED_NO_ARGS: gcc-libstdc++
+      EXPECTED_GCC: gcc-libstdc++
+      EXPECTED_CLANG: fail
+      EXPECTED_GCC_ENV: gcc-libstdc++
+      EXPECTED_CLANG_ENV: fail
+    command:
+    - bash
+    - -c
+    - |
+      ! which clang || (echo "ERROR: clang found when it shouldn't be" && exit 1)
+      /usr/local/bin/test.sh
+
+  llvm:
+    <<: *common-base
+    build:
+      context: ../..
+      dockerfile: ci/matrix/Dockerfile
+      args:
+        MATRIX_SETUP: *llvm-setup
+    environment:
+      <<: *common-env
+      EXPECTED_NO_ARGS: fail
+      EXPECTED_GCC: fail
+      EXPECTED_CLANG: clang-libc++
+      EXPECTED_GCC_ENV: fail
+      EXPECTED_CLANG_ENV: fail
+    command:
+    - bash
+    - -c
+    - |
+      ! which gcc || (echo "ERROR: gcc found when it shouldn't be" && exit 1)
+      bazel/setup_clang.sh /opt/llvm
+      export PATH=/opt/llvm/bin:$PATH
+      clang --version
+      /usr/local/bin/test.sh
+
+  all:
+    <<: *common-base
+    build:
+      context: ../..
+      dockerfile: ci/matrix/Dockerfile
+      args:
+        MATRIX_SETUP: *llvm-setup
+        MATRIX_SETUP_EXTRA: *gcc-setup
+    environment:
+      <<: *common-env
+      EXPECTED_NO_ARGS: gcc-libstdc++
+      EXPECTED_GCC: gcc-libstdc++
+      EXPECTED_CLANG: clang-libc++
+      EXPECTED_GCC_ENV: gcc-libstdc++
+      EXPECTED_CLANG_ENV: clang-libstdc++
+    command:
+    - bash
+    - -c
+    - |
+      bazel/setup_clang.sh /opt/llvm
+      export PATH=/opt/llvm/bin:$PATH
+      gcc --version
+      clang --version
+      /usr/local/bin/test.sh
+
+  # this fails all now, but should start working with hermetic toolchains
+  none:
+    <<: *common-base
+    build:
+      context: ../..
+      dockerfile: ci/matrix/Dockerfile
+    environment:
+      <<: *common-env
+      EXPECTED_NO_ARGS: fail
+      EXPECTED_GCC: fail
+      EXPECTED_CLANG: fail
+      EXPECTED_GCC_ENV: fail
+      EXPECTED_CLANG_ENV: fail
+    command:
+    - bash
+    - -c
+    - |
+      ! which clang || (echo "ERROR: clang found when it shouldn't be" && exit 1)
+      ! which gcc || (echo "ERROR: gcc found when it shouldn't be" && exit 1)
+      /usr/local/bin/test.sh

--- a/ci/matrix/entrypoint.sh
+++ b/ci/matrix/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -eo pipefail
+
+if [[ -n "${ENVOY_GID:-}" ]]; then
+    groupmod -g "$ENVOY_GID" envoybuild
+fi
+if [[ -n "${ENVOY_UID:-}" ]]; then
+    usermod -u "$ENVOY_UID" envoybuild
+fi
+gosu envoybuild git config --global --add safe.directory /workspace
+exec gosu envoybuild "$@"

--- a/ci/matrix/test.sh
+++ b/ci/matrix/test.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+# This provides a test of what toolchains are used according to what environment is setup
+# and how bazel is invoked.
+
+
+echo "Testing toolchain detection"
+RESULT_NO_ARGS=fail
+RESULT_GCC=fail
+RESULT_CLANG=fail
+RESULT_GCC_ENV=fail
+RESULT_CLANG_ENV=fail
+
+echo "Testing default build"
+if OUTPUT_NO_ARGS=$(bazel run --verbose_failures -s //tools/toolchain:detect 2>&1); then
+    COMPILER=$(echo "$OUTPUT_NO_ARGS" | grep "Compiler:" | awk '{print $2}' | tr -d '\r\n')
+    LIBRARY=$(echo "$OUTPUT_NO_ARGS" | grep "Standard Library:" | awk '{print $3}' | tr -d '\r\n')
+    if [[ -n "$COMPILER" && -n "$LIBRARY" ]]; then
+        # shellcheck disable=SC2034
+        RESULT_NO_ARGS="$COMPILER-$LIBRARY"
+    fi
+fi
+
+echo "Testing --config=clang-libc++"
+if OUTPUT_CLANG=$(bazel run --verbose_failures -s  --config=clang-libc++ //tools/toolchain:detect 2>&1); then
+    COMPILER=$(echo "$OUTPUT_CLANG" | grep "Compiler:" | awk '{print $2}' | tr -d '\r\n')
+    LIBRARY=$(echo "$OUTPUT_CLANG" | grep "Standard Library:" | awk '{print $3}' | tr -d '\r\n')
+    if [[ -n "$COMPILER" && -n "$LIBRARY" ]]; then
+        # shellcheck disable=SC2034
+        RESULT_CLANG="$COMPILER-$LIBRARY"
+    fi
+fi
+
+echo "Testing --config=gcc"
+if OUTPUT_GCC=$(bazel run --verbose_failures -s  --config=gcc //tools/toolchain:detect 2>&1); then
+    COMPILER=$(echo "$OUTPUT_GCC" | grep "Compiler:" | awk '{print $2}' | tr -d '\r\n')
+    LIBRARY=$(echo "$OUTPUT_GCC" | grep "Standard Library:" | awk '{print $3}' | tr -d '\r\n')
+    if [[ -n "$COMPILER" && -n "$LIBRARY" ]]; then
+        # shellcheck disable=SC2034
+        RESULT_GCC="$COMPILER-$LIBRARY"
+    fi
+fi
+
+echo "Testing CC=gcc"
+CC=gcc
+CXX=g++
+export CC
+export CXX
+if OUTPUT_GCC_ENV=$(bazel run --verbose_failures -s //tools/toolchain:detect 2>&1); then
+    COMPILER=$(echo "$OUTPUT_GCC_ENV" | grep "Compiler:" | awk '{print $2}' | tr -d '\r\n')
+    LIBRARY=$(echo "$OUTPUT_GCC_ENV" | grep "Standard Library:" | awk '{print $3}' | tr -d '\r\n')
+    if [[ -n "$COMPILER" && -n "$LIBRARY" ]]; then
+        # shellcheck disable=SC2034
+        RESULT_GCC_ENV="$COMPILER-$LIBRARY"
+    fi
+fi
+
+echo "Testing CC=clang++"
+CC=clang
+CXX=clang++
+export CC
+export CXX
+if OUTPUT_CLANG_ENV=$(bazel run --verbose_failures -s //tools/toolchain:detect 2>&1); then
+    COMPILER=$(echo "$OUTPUT_CLANG_ENV" | grep "Compiler:" | awk '{print $2}' | tr -d '\r\n')
+    LIBRARY=$(echo "$OUTPUT_CLANG_ENV" | grep "Standard Library:" | awk '{print $3}' | tr -d '\r\n')
+    if [[ -n "$COMPILER" && -n "$LIBRARY" ]]; then
+        # shellcheck disable=SC2034
+        RESULT_CLANG_ENV="$COMPILER-$LIBRARY"
+    fi
+fi
+
+FAILED=0
+for key in NO_ARGS GCC CLANG GCC_ENV CLANG_ENV; do
+    actual_var="RESULT_${key}"
+    expected_var="EXPECTED_${key}"
+    output_var="OUTPUT_${key}"
+    actual="${!actual_var}"
+    expected="${!expected_var}"
+    output="${!output_var}"
+    if [[ "$actual" != "$expected" ]]; then
+        echo "❌ $key: expected=$expected, got=$actual"
+        echo "$output"
+        FAILED=1
+    elif [[ "$actual" == "fail" ]]; then
+        echo "✅ $key failed as expected"
+    else
+        echo "✅ $key passed as expected"
+    fi
+done
+if [[ "$FAILED" -ne 0 ]]; then
+    echo "Some test configs did not match expectations"
+    exit 1
+fi
+echo "All test configs passed as expected"

--- a/tools/toolchain/BUILD
+++ b/tools/toolchain/BUILD
@@ -1,0 +1,9 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary")
+
+licenses(["notice"])  # Apache 2
+
+cc_binary(
+    name = "detect",
+    srcs = ["detect.cc"],
+    visibility = ["//visibility:public"],
+)

--- a/tools/toolchain/detect.cc
+++ b/tools/toolchain/detect.cc
@@ -1,0 +1,22 @@
+#include <iostream>
+
+// NOLINT(namespace-envoy)
+int main() {
+#if defined(__clang__)
+  std::cout << "Compiler: clang\n";
+#elif defined(__GNUC__)
+  std::cout << "Compiler: gcc\n";
+#else
+  std::cout << "Compiler: unknown\n";
+#endif
+
+#if defined(_LIBCPP_VERSION)
+  std::cout << "Standard Library: libc++\n";
+#elif defined(__GLIBCXX__)
+  std::cout << "Standard Library: libstdc++\n";
+#else
+  std::cout << "Standard Library: unknown\n";
+#endif
+
+  return 0;
+}


### PR DESCRIPTION
This adds some ci/tests for which toolchains bazel uses given different flags/env

Essentially this is to track change/prevent breakage in .bazelrc - mostly for non-rbe/local setups, but its also quite useful for validating how our rbe/ci is working 