### PR TITLE
route: provide stream info to cluster specifier plugin and simplify the weighted route entry

### DIFF
--- a/contrib/golang/router/cluster_specifier/source/golang_cluster_specifier.cc
+++ b/contrib/golang/router/cluster_specifier/source/golang_cluster_specifier.cc
@@ -44,9 +44,9 @@ ClusterConfig::ClusterConfig(const GolangClusterProto& config)
   }
 }
 
-RouteConstSharedPtr
-GolangClusterSpecifierPlugin::route(RouteConstSharedPtr parent,
-                                    const Http::RequestHeaderMap& header) const {
+RouteConstSharedPtr GolangClusterSpecifierPlugin::route(RouteEntryAndRouteConstSharedPtr parent,
+                                                        const Http::RequestHeaderMap& header,
+                                                        const StreamInfo::StreamInfo&) const {
   ASSERT(dynamic_cast<const RouteEntryImplBase*>(parent.get()) != nullptr);
   int buffer_len = 256;
   std::string buffer;
@@ -78,8 +78,7 @@ GolangClusterSpecifierPlugin::route(RouteConstSharedPtr parent,
     }
   }
 
-  return std::make_shared<RouteEntryImplBase::DynamicRouteEntry>(
-      dynamic_cast<const RouteEntryImplBase*>(parent.get()), parent, cluster);
+  return std::make_shared<RouteEntryImplBase::DynamicRouteEntry>(parent, cluster);
 }
 
 void GolangClusterSpecifierPlugin::log(absl::string_view& msg) const {

--- a/contrib/golang/router/cluster_specifier/source/golang_cluster_specifier.h
+++ b/contrib/golang/router/cluster_specifier/source/golang_cluster_specifier.h
@@ -36,8 +36,10 @@ class GolangClusterSpecifierPlugin : public ClusterSpecifierPlugin,
 public:
   GolangClusterSpecifierPlugin(ClusterConfigSharedPtr config) : config_(config) {};
 
-  RouteConstSharedPtr route(RouteConstSharedPtr parent,
-                            const Http::RequestHeaderMap& header) const override;
+  RouteConstSharedPtr route(RouteEntryAndRouteConstSharedPtr parent,
+                            const Http::RequestHeaderMap& header,
+                            const StreamInfo::StreamInfo& stream_info) const override;
+
   void log(absl::string_view& msg) const;
 
 private:

--- a/envoy/router/cluster_specifier_plugin.h
+++ b/envoy/router/cluster_specifier_plugin.h
@@ -23,11 +23,13 @@ public:
    * Create route from related route entry and request headers.
    *
    * @param parent related route.
-   * @param header request headers.
+   * @param headers request headers.
+   * @param stream_info stream info of the downstream request.
    * @return RouteConstSharedPtr final route with specific cluster.
    */
-  virtual RouteConstSharedPtr route(RouteConstSharedPtr parent,
-                                    const Http::RequestHeaderMap& header) const PURE;
+  virtual RouteConstSharedPtr route(RouteEntryAndRouteConstSharedPtr parent,
+                                    const Http::RequestHeaderMap& headers,
+                                    const StreamInfo::StreamInfo& stream_info) const PURE;
 };
 
 using ClusterSpecifierPluginSharedPtr = std::shared_ptr<ClusterSpecifierPlugin>;

--- a/envoy/router/router.h
+++ b/envoy/router/router.h
@@ -1268,6 +1268,7 @@ public:
 using RouteConstSharedPtr = std::shared_ptr<const Route>;
 
 class RouteEntryAndRoute : public RouteEntry, public Route {};
+using RouteEntryAndRouteConstSharedPtr = std::shared_ptr<const RouteEntryAndRoute>;
 
 /**
  * RouteCallback, returns one of these enums to the route matcher to indicate

--- a/source/extensions/router/cluster_specifiers/lua/lua_cluster_specifier.cc
+++ b/source/extensions/router/cluster_specifiers/lua/lua_cluster_specifier.cc
@@ -121,11 +121,11 @@ std::string LuaClusterSpecifierPlugin::startLua(const Http::HeaderMap& headers) 
 }
 
 Envoy::Router::RouteConstSharedPtr
-LuaClusterSpecifierPlugin::route(Envoy::Router::RouteConstSharedPtr parent,
-                                 const Http::RequestHeaderMap& headers) const {
-  return std::make_shared<Envoy::Router::RouteEntryImplBase::DynamicRouteEntry>(
-      dynamic_cast<const Envoy::Router::RouteEntryImplBase*>(parent.get()), parent,
-      startLua(headers));
+LuaClusterSpecifierPlugin::route(Envoy::Router::RouteEntryAndRouteConstSharedPtr parent,
+                                 const Http::RequestHeaderMap& headers,
+                                 const StreamInfo::StreamInfo&) const {
+  return std::make_shared<Envoy::Router::RouteEntryImplBase::DynamicRouteEntry>(std::move(parent),
+                                                                                startLua(headers));
 }
 } // namespace Lua
 } // namespace Router

--- a/source/extensions/router/cluster_specifiers/lua/lua_cluster_specifier.h
+++ b/source/extensions/router/cluster_specifiers/lua/lua_cluster_specifier.h
@@ -134,8 +134,10 @@ class LuaClusterSpecifierPlugin : public Envoy::Router::ClusterSpecifierPlugin,
                                   Logger::Loggable<Logger::Id::lua> {
 public:
   LuaClusterSpecifierPlugin(LuaClusterSpecifierConfigSharedPtr config);
-  Envoy::Router::RouteConstSharedPtr route(Envoy::Router::RouteConstSharedPtr parent,
-                                           const Http::RequestHeaderMap& header) const override;
+  Envoy::Router::RouteConstSharedPtr
+  route(Envoy::Router::RouteEntryAndRouteConstSharedPtr parent,
+        const Http::RequestHeaderMap& header,
+        const StreamInfo::StreamInfo& stream_info) const override;
 
 private:
   std::string startLua(const Http::HeaderMap& headers) const;

--- a/test/common/router/config_impl_integration_test.cc
+++ b/test/common/router/config_impl_integration_test.cc
@@ -24,11 +24,10 @@ public:
   public:
     FakeClusterSpecifierPlugin(absl::string_view cluster) : cluster_name_(cluster) {}
 
-    RouteConstSharedPtr route(RouteConstSharedPtr parent,
-                              const Http::RequestHeaderMap&) const override {
-      ASSERT(dynamic_cast<const RouteEntryImplBase*>(parent.get()) != nullptr);
-      return std::make_shared<RouteEntryImplBase::DynamicRouteEntry>(
-          dynamic_cast<const RouteEntryImplBase*>(parent.get()), parent, cluster_name_);
+    RouteConstSharedPtr route(RouteEntryAndRouteConstSharedPtr parent,
+                              const Http::RequestHeaderMap&,
+                              const StreamInfo::StreamInfo&) const override {
+      return std::make_shared<RouteEntryImplBase::DynamicRouteEntry>(parent, cluster_name_);
     }
 
     const std::string cluster_name_;

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -3669,7 +3669,7 @@ virtual_hosts:
 
   auto mock_route = std::make_shared<NiceMock<MockRoute>>();
 
-  EXPECT_CALL(*mock_cluster_specifier_plugin, route(_, _)).WillOnce(Return(mock_route));
+  EXPECT_CALL(*mock_cluster_specifier_plugin, route(_, _, _)).WillOnce(Return(mock_route));
 
   EXPECT_EQ(mock_route.get(), config.route(genHeaders("some_cluster", "/foo", "GET"), 0).get());
 }
@@ -3799,10 +3799,10 @@ virtual_hosts:
 
   auto mock_route = std::make_shared<NiceMock<MockRoute>>();
 
-  EXPECT_CALL(*mock_cluster_specifier_plugin_2, route(_, _)).WillOnce(Return(mock_route));
+  EXPECT_CALL(*mock_cluster_specifier_plugin_2, route(_, _, _)).WillOnce(Return(mock_route));
   EXPECT_EQ(mock_route.get(), config.route(genHeaders("some_cluster", "/foo", "GET"), 0).get());
 
-  EXPECT_CALL(*mock_cluster_specifier_plugin_3, route(_, _)).WillOnce(Return(mock_route));
+  EXPECT_CALL(*mock_cluster_specifier_plugin_3, route(_, _, _)).WillOnce(Return(mock_route));
   EXPECT_EQ(mock_route.get(), config.route(genHeaders("some_cluster", "/bar", "GET"), 0).get());
 }
 
@@ -5025,7 +5025,8 @@ virtual_hosts:
 )EOF";
 
   factory_context_.cluster_manager_.initializeClusters({"backoff"}, {});
-  TestConfigImpl(parseRouteConfigurationFromYaml(yaml), factory_context_, true, creation_status_);
+  TestConfigImpl config(parseRouteConfigurationFromYaml(yaml), factory_context_, true,
+                        creation_status_);
   EXPECT_EQ(creation_status_.message(),
             "retry_policy.max_interval must greater than or equal to the base_interval");
 }
@@ -6843,9 +6844,10 @@ TEST_F(RouteMatcherTest, WeightedClusterInvalidConfigWithBothNameAndClusterHeade
                       weight: 40
       )EOF";
 
-  EXPECT_THROW_WITH_MESSAGE(TestConfigImpl(parseRouteConfigurationFromYaml(yaml), factory_context_,
-                                           true, creation_status_),
-                            EnvoyException, "Only one of name or cluster_header can be specified");
+  TestConfigImpl config(parseRouteConfigurationFromYaml(yaml), factory_context_, true,
+                        creation_status_);
+  EXPECT_FALSE(creation_status_.ok());
+  EXPECT_EQ(creation_status_.message(), "Only one of name or cluster_header can be specified");
 }
 
 TEST_F(RouteMatcherTest, WeightedClusterInvalidConfigWithNoClusterSpecifier) {
@@ -6862,10 +6864,11 @@ TEST_F(RouteMatcherTest, WeightedClusterInvalidConfigWithNoClusterSpecifier) {
                       30
       )EOF";
 
-  EXPECT_THROW_WITH_MESSAGE(TestConfigImpl(parseRouteConfigurationFromYaml(yaml), factory_context_,
-                                           true, creation_status_),
-                            EnvoyException,
-                            "At least one of name or cluster_header need to be specified");
+  TestConfigImpl config(parseRouteConfigurationFromYaml(yaml), factory_context_, true,
+                        creation_status_);
+  EXPECT_FALSE(creation_status_.ok());
+  EXPECT_EQ(creation_status_.message(),
+            "At least one of name or cluster_header need to be specified");
 }
 
 TEST_F(RouteMatcherTest, WeightedClusterInvalidConfigWithInvalidHttpHeader) {

--- a/test/mocks/router/mocks.cc
+++ b/test/mocks/router/mocks.cc
@@ -191,7 +191,7 @@ MockGenericConnectionPoolCallbacks::MockGenericConnectionPoolCallbacks() {
 }
 
 MockClusterSpecifierPlugin::MockClusterSpecifierPlugin() {
-  ON_CALL(*this, route(_, _)).WillByDefault(Return(nullptr));
+  ON_CALL(*this, route(_, _, _)).WillByDefault(Return(nullptr));
 }
 
 MockClusterSpecifierPluginFactoryConfig::MockClusterSpecifierPluginFactoryConfig() {

--- a/test/mocks/router/mocks.h
+++ b/test/mocks/router/mocks.h
@@ -685,7 +685,9 @@ public:
   MockClusterSpecifierPlugin();
 
   MOCK_METHOD(RouteConstSharedPtr, route,
-              (RouteConstSharedPtr parent, const Http::RequestHeaderMap& header), (const));
+              (RouteEntryAndRouteConstSharedPtr parent, const Http::RequestHeaderMap& headers,
+               const StreamInfo::StreamInfo& stream_info),
+              (const));
 };
 
 class MockClusterSpecifierPluginFactoryConfig : public ClusterSpecifierPluginFactoryConfig {


### PR DESCRIPTION
Commit Message: route: provide stream info to cluster specifier plugin and simplify the weighted route entry
Additional Description:

This PR did two things:

1. Add stream info as input parameter to the ClusterSpecifierPlugin.
2. Simplify the WeightedClusterEntry and DynamicRouteEntry. Note, in the previous, the WeightedClusterEntry will inherit from DynamicRouteEntry and the WeightedClusterEntry of every weighted cluster will be stored in the basic route directly. But to avoid cicular shared pointer, the WeightedClusterEntry will not take the ownership of the parent basic route. When a weighted cluster is selected, the WeightedClusterEntry and the parent basic route will be used to construct a new DynamicRouteEntry. In this PR, we split the weighted cluster config out from the WeightedClusterEntry and the basic route will only store the configuration rather than the WeightedClusterEntry. When a weighted cluster is selcted, we will construct a  WeightedClusterEntry dynamically based on the configuration and parent basic route.

This is also the pre PR to land https://github.com/envoyproxy/envoy/pull/39227


Risk Level: low.
Testing: n/a.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.