### PR TITLE
cluster specifier: add stream info as input parameter of cluster specifier plugin

### DIFF
--- a/contrib/golang/router/cluster_specifier/source/golang_cluster_specifier.cc
+++ b/contrib/golang/router/cluster_specifier/source/golang_cluster_specifier.cc
@@ -47,7 +47,6 @@ ClusterConfig::ClusterConfig(const GolangClusterProto& config)
 RouteConstSharedPtr GolangClusterSpecifierPlugin::route(RouteEntryAndRouteConstSharedPtr parent,
                                                         const Http::RequestHeaderMap& header,
                                                         const StreamInfo::StreamInfo&) const {
-  ASSERT(dynamic_cast<const RouteEntryImplBase*>(parent.get()) != nullptr);
   int buffer_len = 256;
   std::string buffer;
   std::string cluster;
@@ -78,8 +77,7 @@ RouteConstSharedPtr GolangClusterSpecifierPlugin::route(RouteEntryAndRouteConstS
     }
   }
 
-  return std::make_shared<RouteEntryImplBase::DynamicRouteEntry>(
-      dynamic_cast<const RouteEntryImplBase*>(parent.get()), parent, cluster);
+  return std::make_shared<RouteEntryImplBase::DynamicRouteEntry>(std::move(parent), cluster);
 }
 
 void GolangClusterSpecifierPlugin::log(absl::string_view& msg) const {

--- a/contrib/golang/router/cluster_specifier/source/golang_cluster_specifier.cc
+++ b/contrib/golang/router/cluster_specifier/source/golang_cluster_specifier.cc
@@ -44,9 +44,9 @@ ClusterConfig::ClusterConfig(const GolangClusterProto& config)
   }
 }
 
-RouteConstSharedPtr
-GolangClusterSpecifierPlugin::route(RouteConstSharedPtr parent,
-                                    const Http::RequestHeaderMap& header) const {
+RouteConstSharedPtr GolangClusterSpecifierPlugin::route(RouteEntryAndRouteConstSharedPtr parent,
+                                                        const Http::RequestHeaderMap& header,
+                                                        const StreamInfo::StreamInfo&) const {
   ASSERT(dynamic_cast<const RouteEntryImplBase*>(parent.get()) != nullptr);
   int buffer_len = 256;
   std::string buffer;

--- a/contrib/golang/router/cluster_specifier/source/golang_cluster_specifier.h
+++ b/contrib/golang/router/cluster_specifier/source/golang_cluster_specifier.h
@@ -36,8 +36,10 @@ class GolangClusterSpecifierPlugin : public ClusterSpecifierPlugin,
 public:
   GolangClusterSpecifierPlugin(ClusterConfigSharedPtr config) : config_(config) {};
 
-  RouteConstSharedPtr route(RouteConstSharedPtr parent,
-                            const Http::RequestHeaderMap& header) const override;
+  RouteConstSharedPtr route(RouteEntryAndRouteConstSharedPtr parent,
+                            const Http::RequestHeaderMap& header,
+                            const StreamInfo::StreamInfo& stream_info) const override;
+
   void log(absl::string_view& msg) const;
 
 private:

--- a/envoy/router/cluster_specifier_plugin.h
+++ b/envoy/router/cluster_specifier_plugin.h
@@ -23,11 +23,13 @@ public:
    * Create route from related route entry and request headers.
    *
    * @param parent related route.
-   * @param header request headers.
+   * @param headers request headers.
+   * @param stream_info stream info of the downstream request.
    * @return RouteConstSharedPtr final route with specific cluster.
    */
-  virtual RouteConstSharedPtr route(RouteConstSharedPtr parent,
-                                    const Http::RequestHeaderMap& header) const PURE;
+  virtual RouteConstSharedPtr route(RouteEntryAndRouteConstSharedPtr parent,
+                                    const Http::RequestHeaderMap& headers,
+                                    const StreamInfo::StreamInfo& stream_info) const PURE;
 };
 
 using ClusterSpecifierPluginSharedPtr = std::shared_ptr<ClusterSpecifierPlugin>;

--- a/envoy/router/router.h
+++ b/envoy/router/router.h
@@ -1268,6 +1268,7 @@ public:
 using RouteConstSharedPtr = std::shared_ptr<const Route>;
 
 class RouteEntryAndRoute : public RouteEntry, public Route {};
+using RouteEntryAndRouteConstSharedPtr = std::shared_ptr<const RouteEntryAndRoute>;
 
 /**
  * RouteCallback, returns one of these enums to the route matcher to indicate

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -1390,9 +1390,8 @@ RouteConstSharedPtr RouteEntryImplBase::pickClusterViaClusterHeader(
     final_cluster_name = std::string(entry[0]->value().getStringView());
   }
 
-  return std::make_shared<DynamicRouteEntry>(route_selector_override
-                                                 ? route_selector_override
-                                                 : static_cast<const RouteEntryAndRoute*>(this),
+  return std::make_shared<DynamicRouteEntry>(route_selector_override ? route_selector_override
+                                                                     : this,
                                              shared_from_this(), final_cluster_name);
 }
 

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -193,7 +193,8 @@ getHeaderParsers(const HeaderParser* global_route_config_header_parser,
 // plugin is set to optional, then this null plugin will be used as a placeholder.
 class NullClusterSpecifierPlugin : public ClusterSpecifierPlugin {
 public:
-  RouteConstSharedPtr route(RouteConstSharedPtr, const Http::RequestHeaderMap&) const override {
+  RouteConstSharedPtr route(RouteEntryAndRouteConstSharedPtr, const Http::RequestHeaderMap&,
+                            const StreamInfo::StreamInfo&) const override {
     return nullptr;
   }
 };
@@ -1396,6 +1397,7 @@ RouteConstSharedPtr RouteEntryImplBase::pickClusterViaClusterHeader(
 }
 
 RouteConstSharedPtr RouteEntryImplBase::clusterEntry(const Http::RequestHeaderMap& headers,
+                                                     const StreamInfo::StreamInfo& stream_info,
                                                      uint64_t random_value) const {
   // Gets the route object chosen from the list of weighted clusters
   // (if there is one) or returns self.
@@ -1409,7 +1411,7 @@ RouteConstSharedPtr RouteEntryImplBase::clusterEntry(const Http::RequestHeaderMa
       // TODO(wbpcode): make the cluster header or weighted clusters an implementation of the
       // cluster specifier plugin.
       ASSERT(cluster_specifier_plugin_ != nullptr);
-      return cluster_specifier_plugin_->route(shared_from_this(), headers);
+      return cluster_specifier_plugin_->route(shared_from_this(), headers, stream_info);
     }
   }
   return pickWeightedCluster(headers, random_value);
@@ -1685,7 +1687,7 @@ UriTemplateMatcherRouteEntryImpl::matches(const Http::RequestHeaderMap& headers,
                                           uint64_t random_value) const {
   if (RouteEntryImplBase::matchRoute(headers, stream_info, random_value) &&
       path_matcher_->match(headers.getPathValue())) {
-    return clusterEntry(headers, random_value);
+    return clusterEntry(headers, stream_info, random_value);
   }
   return nullptr;
 }
@@ -1716,7 +1718,7 @@ RouteConstSharedPtr PrefixRouteEntryImpl::matches(const Http::RequestHeaderMap& 
                                                   uint64_t random_value) const {
   if (RouteEntryImplBase::matchRoute(headers, stream_info, random_value) &&
       path_matcher_->match(sanitizePathBeforePathMatching(headers.getPathValue()))) {
-    return clusterEntry(headers, random_value);
+    return clusterEntry(headers, stream_info, random_value);
   }
   return nullptr;
 }
@@ -1748,7 +1750,7 @@ RouteConstSharedPtr PathRouteEntryImpl::matches(const Http::RequestHeaderMap& he
                                                 uint64_t random_value) const {
   if (RouteEntryImplBase::matchRoute(headers, stream_info, random_value) &&
       path_matcher_->match(sanitizePathBeforePathMatching(headers.getPathValue()))) {
-    return clusterEntry(headers, random_value);
+    return clusterEntry(headers, stream_info, random_value);
   }
 
   return nullptr;
@@ -1787,7 +1789,7 @@ RouteConstSharedPtr RegexRouteEntryImpl::matches(const Http::RequestHeaderMap& h
                                                  uint64_t random_value) const {
   if (RouteEntryImplBase::matchRoute(headers, stream_info, random_value)) {
     if (path_matcher_->match(sanitizePathBeforePathMatching(headers.getPathValue()))) {
-      return clusterEntry(headers, random_value);
+      return clusterEntry(headers, stream_info, random_value);
     }
   }
   return nullptr;
@@ -1817,7 +1819,7 @@ RouteConstSharedPtr ConnectRouteEntryImpl::matches(const Http::RequestHeaderMap&
   if ((Http::HeaderUtility::isConnect(headers) ||
        Http::HeaderUtility::isConnectUdpRequest(headers)) &&
       RouteEntryImplBase::matchRoute(headers, stream_info, random_value)) {
-    return clusterEntry(headers, random_value);
+    return clusterEntry(headers, stream_info, random_value);
   }
   return nullptr;
 }
@@ -1856,7 +1858,7 @@ PathSeparatedPrefixRouteEntryImpl::matches(const Http::RequestHeaderMap& headers
   const size_t matcher_size = matcher().size();
   if (sanitized_size >= matcher_size && path_matcher_->match(sanitized_path) &&
       (sanitized_size == matcher_size || sanitized_path[matcher_size] == '/')) {
-    return clusterEntry(headers, random_value);
+    return clusterEntry(headers, stream_info, random_value);
   }
   return nullptr;
 }

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -838,6 +838,8 @@ public:
     DynamicRouteEntry(const RouteEntryAndRoute* parent, RouteConstSharedPtr owner,
                       const std::string& name)
         : parent_(parent), owner_(std::move(owner)), cluster_name_(name) {}
+    DynamicRouteEntry(RouteEntryAndRouteConstSharedPtr parent, absl::string_view name)
+        : parent_(parent.get()), owner_(parent), cluster_name_(name) {}
 
     // Router::RouteEntry
     const std::string& clusterName() const override { return cluster_name_; }

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -1096,6 +1096,7 @@ protected:
 
   bool case_sensitive() const { return case_sensitive_; }
   RouteConstSharedPtr clusterEntry(const Http::RequestHeaderMap& headers,
+                                   const StreamInfo::StreamInfo& stream_info,
                                    uint64_t random_value) const;
 
   /**

--- a/source/extensions/router/cluster_specifiers/lua/lua_cluster_specifier.cc
+++ b/source/extensions/router/cluster_specifiers/lua/lua_cluster_specifier.cc
@@ -121,8 +121,9 @@ std::string LuaClusterSpecifierPlugin::startLua(const Http::HeaderMap& headers) 
 }
 
 Envoy::Router::RouteConstSharedPtr
-LuaClusterSpecifierPlugin::route(Envoy::Router::RouteConstSharedPtr parent,
-                                 const Http::RequestHeaderMap& headers) const {
+LuaClusterSpecifierPlugin::route(Envoy::Router::RouteEntryAndRouteConstSharedPtr parent,
+                                 const Http::RequestHeaderMap& headers,
+                                 const StreamInfo::StreamInfo&) const {
   return std::make_shared<Envoy::Router::RouteEntryImplBase::DynamicRouteEntry>(
       dynamic_cast<const Envoy::Router::RouteEntryImplBase*>(parent.get()), parent,
       startLua(headers));

--- a/source/extensions/router/cluster_specifiers/lua/lua_cluster_specifier.cc
+++ b/source/extensions/router/cluster_specifiers/lua/lua_cluster_specifier.cc
@@ -124,9 +124,8 @@ Envoy::Router::RouteConstSharedPtr
 LuaClusterSpecifierPlugin::route(Envoy::Router::RouteEntryAndRouteConstSharedPtr parent,
                                  const Http::RequestHeaderMap& headers,
                                  const StreamInfo::StreamInfo&) const {
-  return std::make_shared<Envoy::Router::RouteEntryImplBase::DynamicRouteEntry>(
-      dynamic_cast<const Envoy::Router::RouteEntryImplBase*>(parent.get()), parent,
-      startLua(headers));
+  return std::make_shared<Envoy::Router::RouteEntryImplBase::DynamicRouteEntry>(std::move(parent),
+                                                                                startLua(headers));
 }
 } // namespace Lua
 } // namespace Router

--- a/source/extensions/router/cluster_specifiers/lua/lua_cluster_specifier.h
+++ b/source/extensions/router/cluster_specifiers/lua/lua_cluster_specifier.h
@@ -134,8 +134,10 @@ class LuaClusterSpecifierPlugin : public Envoy::Router::ClusterSpecifierPlugin,
                                   Logger::Loggable<Logger::Id::lua> {
 public:
   LuaClusterSpecifierPlugin(LuaClusterSpecifierConfigSharedPtr config);
-  Envoy::Router::RouteConstSharedPtr route(Envoy::Router::RouteConstSharedPtr parent,
-                                           const Http::RequestHeaderMap& header) const override;
+  Envoy::Router::RouteConstSharedPtr
+  route(Envoy::Router::RouteEntryAndRouteConstSharedPtr parent,
+        const Http::RequestHeaderMap& header,
+        const StreamInfo::StreamInfo& stream_info) const override;
 
 private:
   std::string startLua(const Http::HeaderMap& headers) const;

--- a/test/common/router/config_impl_integration_test.cc
+++ b/test/common/router/config_impl_integration_test.cc
@@ -24,8 +24,9 @@ public:
   public:
     FakeClusterSpecifierPlugin(absl::string_view cluster) : cluster_name_(cluster) {}
 
-    RouteConstSharedPtr route(RouteConstSharedPtr parent,
-                              const Http::RequestHeaderMap&) const override {
+    RouteConstSharedPtr route(RouteEntryAndRouteConstSharedPtr parent,
+                              const Http::RequestHeaderMap&,
+                              const StreamInfo::StreamInfo&) const override {
       ASSERT(dynamic_cast<const RouteEntryImplBase*>(parent.get()) != nullptr);
       return std::make_shared<RouteEntryImplBase::DynamicRouteEntry>(
           dynamic_cast<const RouteEntryImplBase*>(parent.get()), parent, cluster_name_);

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -3669,7 +3669,7 @@ virtual_hosts:
 
   auto mock_route = std::make_shared<NiceMock<MockRoute>>();
 
-  EXPECT_CALL(*mock_cluster_specifier_plugin, route(_, _)).WillOnce(Return(mock_route));
+  EXPECT_CALL(*mock_cluster_specifier_plugin, route(_, _, _)).WillOnce(Return(mock_route));
 
   EXPECT_EQ(mock_route.get(), config.route(genHeaders("some_cluster", "/foo", "GET"), 0).get());
 }
@@ -3799,10 +3799,10 @@ virtual_hosts:
 
   auto mock_route = std::make_shared<NiceMock<MockRoute>>();
 
-  EXPECT_CALL(*mock_cluster_specifier_plugin_2, route(_, _)).WillOnce(Return(mock_route));
+  EXPECT_CALL(*mock_cluster_specifier_plugin_2, route(_, _, _)).WillOnce(Return(mock_route));
   EXPECT_EQ(mock_route.get(), config.route(genHeaders("some_cluster", "/foo", "GET"), 0).get());
 
-  EXPECT_CALL(*mock_cluster_specifier_plugin_3, route(_, _)).WillOnce(Return(mock_route));
+  EXPECT_CALL(*mock_cluster_specifier_plugin_3, route(_, _, _)).WillOnce(Return(mock_route));
   EXPECT_EQ(mock_route.get(), config.route(genHeaders("some_cluster", "/bar", "GET"), 0).get());
 }
 

--- a/test/mocks/router/mocks.cc
+++ b/test/mocks/router/mocks.cc
@@ -191,7 +191,7 @@ MockGenericConnectionPoolCallbacks::MockGenericConnectionPoolCallbacks() {
 }
 
 MockClusterSpecifierPlugin::MockClusterSpecifierPlugin() {
-  ON_CALL(*this, route(_, _)).WillByDefault(Return(nullptr));
+  ON_CALL(*this, route(_, _, _)).WillByDefault(Return(nullptr));
 }
 
 MockClusterSpecifierPluginFactoryConfig::MockClusterSpecifierPluginFactoryConfig() {

--- a/test/mocks/router/mocks.cc
+++ b/test/mocks/router/mocks.cc
@@ -97,7 +97,9 @@ MockPathMatchCriterion::MockPathMatchCriterion() {
 
 MockPathMatchCriterion::~MockPathMatchCriterion() = default;
 
-MockRouteEntry::MockRouteEntry() {
+MockRouteEntry::MockRouteEntry()
+    : path_matcher_(std::make_shared<testing::NiceMock<MockPathMatcher>>()),
+      path_rewriter_(std::make_shared<testing::NiceMock<MockPathRewriter>>()) {
   ON_CALL(*this, clusterName()).WillByDefault(ReturnRef(cluster_name_));
   ON_CALL(*this, opaqueConfig()).WillByDefault(ReturnRef(opaque_config_));
   ON_CALL(*this, rateLimitPolicy()).WillByDefault(ReturnRef(rate_limit_policy_));
@@ -115,9 +117,7 @@ MockRouteEntry::MockRouteEntry() {
     return connect_config_.has_value() ? makeOptRef(connect_config_.value()) : absl::nullopt;
   }));
   ON_CALL(*this, earlyDataPolicy()).WillByDefault(ReturnRef(early_data_policy_));
-  path_matcher_ = std::make_shared<testing::NiceMock<MockPathMatcher>>();
   ON_CALL(*this, pathMatcher()).WillByDefault(ReturnRef(path_matcher_));
-  path_rewriter_ = std::make_shared<testing::NiceMock<MockPathRewriter>>();
   ON_CALL(*this, pathRewriter()).WillByDefault(ReturnRef(path_rewriter_));
   ON_CALL(*this, routeStatsContext()).WillByDefault(Return(RouteStatsContextOptRef()));
 }
@@ -146,6 +146,7 @@ MockRouteTracing::MockRouteTracing() = default;
 MockRouteTracing::~MockRouteTracing() = default;
 
 MockRoute::MockRoute() {
+  // Route methods.
   ON_CALL(*this, routeEntry()).WillByDefault(Return(&route_entry_));
   ON_CALL(*this, decorator()).WillByDefault(Return(&decorator_));
   ON_CALL(*this, tracingConfig()).WillByDefault(Return(nullptr));
@@ -153,6 +154,31 @@ MockRoute::MockRoute() {
   ON_CALL(*this, typedMetadata()).WillByDefault(ReturnRef(typed_metadata_));
   ON_CALL(*this, routeName()).WillByDefault(ReturnRef(route_name_));
   ON_CALL(*this, virtualHost()).WillByDefault(ReturnRef(virtual_host_));
+
+  // Route entry methods.
+  ON_CALL(*this, clusterName()).WillByDefault(ReturnRef(route_entry_.cluster_name_));
+  ON_CALL(*this, opaqueConfig()).WillByDefault(ReturnRef(route_entry_.opaque_config_));
+  ON_CALL(*this, rateLimitPolicy()).WillByDefault(ReturnRef(route_entry_.rate_limit_policy_));
+  ON_CALL(*this, retryPolicy()).WillByDefault(ReturnRef(route_entry_.retry_policy_));
+  ON_CALL(*this, internalRedirectPolicy())
+      .WillByDefault(ReturnRef(route_entry_.internal_redirect_policy_));
+  ON_CALL(*this, retryShadowBufferLimit())
+      .WillByDefault(Return(std::numeric_limits<uint32_t>::max()));
+  ON_CALL(*this, shadowPolicies()).WillByDefault(ReturnRef(route_entry_.shadow_policies_));
+  ON_CALL(*this, timeout()).WillByDefault(Return(std::chrono::milliseconds(10)));
+  ON_CALL(*this, includeVirtualHostRateLimits()).WillByDefault(Return(true));
+  ON_CALL(*this, pathMatchCriterion()).WillByDefault(ReturnRef(route_entry_.path_match_criterion_));
+  ON_CALL(*this, upgradeMap()).WillByDefault(ReturnRef(route_entry_.upgrade_map_));
+  ON_CALL(*this, hedgePolicy()).WillByDefault(ReturnRef(route_entry_.hedge_policy_));
+  ON_CALL(*this, connectConfig()).WillByDefault(Invoke([this]() {
+    return route_entry_.connect_config_.has_value()
+               ? makeOptRef(route_entry_.connect_config_.value())
+               : absl::nullopt;
+  }));
+  ON_CALL(*this, earlyDataPolicy()).WillByDefault(ReturnRef(route_entry_.early_data_policy_));
+  ON_CALL(*this, pathMatcher()).WillByDefault(ReturnRef(route_entry_.path_matcher_));
+  ON_CALL(*this, pathRewriter()).WillByDefault(ReturnRef(route_entry_.path_rewriter_));
+  ON_CALL(*this, routeStatsContext()).WillByDefault(Return(RouteStatsContextOptRef()));
 }
 MockRoute::~MockRoute() = default;
 

--- a/test/mocks/router/mocks.h
+++ b/test/mocks/router/mocks.h
@@ -95,7 +95,7 @@ public:
   std::string allow_methods_;
   std::string allow_headers_;
   std::string expose_headers_;
-  std::string max_age_{};
+  std::string max_age_;
   absl::optional<bool> allow_credentials_;
   absl::optional<bool> allow_private_network_access_;
   bool enabled_{};
@@ -113,7 +113,7 @@ public:
   bool hedgeOnPerTryTimeout() const override { return hedge_on_per_try_timeout_; }
 
   uint32_t initial_requests_{};
-  envoy::type::v3::FractionalPercent additional_request_chance_{};
+  envoy::type::v3::FractionalPercent additional_request_chance_;
   bool hedge_on_per_try_timeout_{};
 };
 
@@ -159,9 +159,9 @@ public:
   std::vector<uint32_t> retriable_status_codes_;
   std::vector<Http::HeaderMatcherSharedPtr> retriable_headers_;
   std::vector<Http::HeaderMatcherSharedPtr> retriable_request_headers_;
-  absl::optional<std::chrono::milliseconds> base_interval_{};
-  absl::optional<std::chrono::milliseconds> max_interval_{};
-  std::vector<ResetHeaderParserSharedPtr> reset_headers_{};
+  absl::optional<std::chrono::milliseconds> base_interval_;
+  absl::optional<std::chrono::milliseconds> max_interval_;
+  std::vector<ResetHeaderParserSharedPtr> reset_headers_;
   std::chrono::milliseconds reset_max_interval_{300000};
   std::vector<Upstream::RetryOptionsPredicateConstSharedPtr> retry_options_predicates_;
 };
@@ -408,7 +408,7 @@ public:
   MockRouteEntry();
   ~MockRouteEntry() override;
 
-  // Router::Config
+  // Router::RouteEntry
   MOCK_METHOD(const std::string&, clusterName, (), (const));
   MOCK_METHOD(Http::Code, clusterNotFoundResponseCode, (), (const));
   MOCK_METHOD(void, finalizeRequestHeaders,
@@ -501,7 +501,7 @@ public:
   MOCK_METHOD(const Tracing::CustomTagMap&, getCustomTags, (), (const));
 };
 
-class MockRoute : public Route {
+class MockRoute : public RouteEntryAndRoute {
 public:
   MockRoute();
   ~MockRoute() override;
@@ -520,6 +520,55 @@ public:
   MOCK_METHOD(const Envoy::Config::TypedMetadata&, typedMetadata, (), (const));
   MOCK_METHOD(const std::string&, routeName, (), (const));
   MOCK_METHOD(const VirtualHost&, virtualHost, (), (const));
+
+  // Router::RouteEntry
+  MOCK_METHOD(const std::string&, clusterName, (), (const));
+  MOCK_METHOD(Http::Code, clusterNotFoundResponseCode, (), (const));
+  MOCK_METHOD(void, finalizeRequestHeaders,
+              (Http::RequestHeaderMap & headers, const StreamInfo::StreamInfo& stream_info,
+               bool insert_envoy_original_path),
+              (const));
+  MOCK_METHOD(Http::HeaderTransforms, requestHeaderTransforms,
+              (const StreamInfo::StreamInfo& stream_info, bool do_formatting), (const));
+  MOCK_METHOD(void, finalizeResponseHeaders,
+              (Http::ResponseHeaderMap & headers, const StreamInfo::StreamInfo& stream_info),
+              (const));
+  MOCK_METHOD(Http::HeaderTransforms, responseHeaderTransforms,
+              (const StreamInfo::StreamInfo& stream_info, bool do_formatting), (const));
+  MOCK_METHOD(const Http::HashPolicy*, hashPolicy, (), (const));
+  MOCK_METHOD(const HedgePolicy&, hedgePolicy, (), (const));
+  MOCK_METHOD(const Router::MetadataMatchCriteria*, metadataMatchCriteria, (), (const));
+  MOCK_METHOD(const Router::TlsContextMatchCriteria*, tlsContextMatchCriteria, (), (const));
+  MOCK_METHOD(Upstream::ResourcePriority, priority, (), (const));
+  MOCK_METHOD(const RateLimitPolicy&, rateLimitPolicy, (), (const));
+  MOCK_METHOD(const RetryPolicy&, retryPolicy, (), (const));
+  MOCK_METHOD(const InternalRedirectPolicy&, internalRedirectPolicy, (), (const));
+  MOCK_METHOD(const PathMatcherSharedPtr&, pathMatcher, (), (const));
+  MOCK_METHOD(const PathRewriterSharedPtr&, pathRewriter, (), (const));
+  MOCK_METHOD(uint32_t, retryShadowBufferLimit, (), (const));
+  MOCK_METHOD(const std::vector<ShadowPolicyPtr>&, shadowPolicies, (), (const));
+  MOCK_METHOD(std::chrono::milliseconds, timeout, (), (const));
+  MOCK_METHOD(absl::optional<std::chrono::milliseconds>, idleTimeout, (), (const));
+  MOCK_METHOD(bool, usingNewTimeouts, (), (const));
+  MOCK_METHOD(absl::optional<std::chrono::milliseconds>, maxStreamDuration, (), (const));
+  MOCK_METHOD(absl::optional<std::chrono::milliseconds>, grpcTimeoutHeaderMax, (), (const));
+  MOCK_METHOD(absl::optional<std::chrono::milliseconds>, grpcTimeoutHeaderOffset, (), (const));
+  MOCK_METHOD(absl::optional<std::chrono::milliseconds>, maxGrpcTimeout, (), (const));
+  MOCK_METHOD(absl::optional<std::chrono::milliseconds>, grpcTimeoutOffset, (), (const));
+  MOCK_METHOD(bool, autoHostRewrite, (), (const));
+  MOCK_METHOD(bool, appendXfh, (), (const));
+  MOCK_METHOD((const std::multimap<std::string, std::string>&), opaqueConfig, (), (const));
+  MOCK_METHOD(bool, includeVirtualHostRateLimits, (), (const));
+  MOCK_METHOD(const CorsPolicy*, corsPolicy, (), (const));
+  MOCK_METHOD(absl::optional<std::string>, currentUrlPathAfterRewrite,
+              (const Http::RequestHeaderMap&), (const));
+  MOCK_METHOD(const PathMatchCriterion&, pathMatchCriterion, (), (const));
+  MOCK_METHOD(bool, includeAttemptCountInRequest, (), (const));
+  MOCK_METHOD(bool, includeAttemptCountInResponse, (), (const));
+  MOCK_METHOD(const ConnectConfigOptRef, connectConfig, (), (const));
+  MOCK_METHOD(const UpgradeMap&, upgradeMap, (), (const));
+  MOCK_METHOD(const EarlyDataPolicy&, earlyDataPolicy, (), (const));
+  MOCK_METHOD(const RouteStatsContextOptRef, routeStatsContext, (), (const));
 
   testing::NiceMock<MockRouteEntry> route_entry_;
   testing::NiceMock<MockDecorator> decorator_;

--- a/test/mocks/router/mocks.h
+++ b/test/mocks/router/mocks.h
@@ -685,7 +685,9 @@ public:
   MockClusterSpecifierPlugin();
 
   MOCK_METHOD(RouteConstSharedPtr, route,
-              (RouteConstSharedPtr parent, const Http::RequestHeaderMap& header), (const));
+              (RouteEntryAndRouteConstSharedPtr parent, const Http::RequestHeaderMap& headers,
+               const StreamInfo::StreamInfo& stream_info),
+              (const));
 };
 
 class MockClusterSpecifierPluginFactoryConfig : public ClusterSpecifierPluginFactoryConfig {


### PR DESCRIPTION
Commit Message: cluster specifier: add stream info as input parameter of cluster specifier plugin
Additional Description:

Add stream info as input parameter to the ClusterSpecifierPlugin. This is pre PR to support https://github.com/envoyproxy/envoy/pull/39227.


Risk Level: low.
Testing: n/a.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.