### PR TITLE
init_target: dispose callback if no watcher

### DIFF
--- a/source/common/init/target_impl.cc
+++ b/source/common/init/target_impl.cc
@@ -51,6 +51,8 @@ bool TargetImpl::ready() {
     auto local_watcher_handle = std::move(watcher_handle_);
     return local_watcher_handle->ready();
   }
+
+  fn_.reset();
   return false;
 }
 

--- a/source/common/init/target_impl.cc
+++ b/source/common/init/target_impl.cc
@@ -52,6 +52,9 @@ bool TargetImpl::ready() {
     return local_watcher_handle->ready();
   }
 
+  // If the watcher handle is not initialized, it means that the manager did not initialize its
+  // targets yet. Disposing the callback here so when the manager initializes it will not hang
+  // waiting for this target since it is already marked as ready.
   fn_.reset();
   return false;
 }

--- a/source/common/init/target_impl.h
+++ b/source/common/init/target_impl.h
@@ -86,7 +86,7 @@ private:
   WatcherHandlePtr watcher_handle_;
 
   // The callback function, called via TargetHandleImpl by the manager
-  const std::shared_ptr<InternalInitializeFn> fn_;
+  std::shared_ptr<InternalInitializeFn> fn_;
 };
 
 /**

--- a/test/common/init/manager_impl_test.cc
+++ b/test/common/init/manager_impl_test.cc
@@ -188,6 +188,43 @@ TEST(InitManagerImplTest, UnavailableWatcher) {
   t.ready();
 }
 
+TEST(InitManagerImplTest, TargetReadyBeforeInitialization) {
+  InSequence s;
+
+  ManagerImpl m("test");
+  expectUninitialized(m);
+
+  ExpectableTargetImpl t("t");
+  t.ready();
+  m.add(t);
+
+  ExpectableWatcherImpl w;
+  w.expectReady();
+  m.initialize(w);
+  expectInitialized(m);
+}
+
+TEST(InitManagerImplTest, OneTargetReadyBeforeInitialization) {
+  InSequence s;
+
+  ManagerImpl m("test");
+  expectUninitialized(m);
+
+  ExpectableTargetImpl t1("t1");
+  ExpectableTargetImpl t2("t2");
+  t1.ready();
+  m.add(t1);
+  m.add(t2);
+
+  ExpectableWatcherImpl w;
+  t2.expectInitialize();
+  w.expectReady();
+  m.initialize(w);
+  expectInitializing(m);
+  t2.ready();
+  expectInitialized(m);
+}
+
 } // namespace
 } // namespace Init
 } // namespace Envoy


### PR DESCRIPTION
Additional Description: in case an init target is marked ready before the init manager initialized its targets, the manager will hang forever waiting for the target, but it is already in initialized state. Fixing this by resetting the callback member. When the init manager initializes the targets, if there's no callback, it considers the target as ready.
Risk Level: low
Testing: unit tests
Docs Changes: none
Release Notes: none
Platform Specific Features: none