### PR TITLE
dyanmic_modules: expose {route, cluster, host} metadata

### DIFF
--- a/source/extensions/dynamic_modules/abi.h
+++ b/source/extensions/dynamic_modules/abi.h
@@ -244,6 +244,21 @@ typedef enum {
 } envoy_dynamic_module_type_on_http_filter_response_trailers_status;
 
 /**
+ * envoy_dynamic_module_type_metadata_source represents the location of metadata to get when calling
+ * envoy_dynamic_module_callback_http_get_metadata_* functions.
+ */
+typedef enum {
+  // stream's dynamic metadata.
+  envoy_dynamic_module_type_metadata_source_dynamic,
+  // route metadata
+  envoy_dynamic_module_type_metadata_source_route,
+  // cluster metadata
+  envoy_dynamic_module_type_metadata_source_cluster,
+  // host (LbEndpoint in xDS) metadata
+  envoy_dynamic_module_type_metadata_source_host,
+} envoy_dynamic_module_type_metadata_source;
+
+/**
  * envoy_dynamic_module_type_attribute_id represents an attribute described in
  * https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
  */
@@ -1044,8 +1059,9 @@ bool envoy_dynamic_module_callback_http_set_dynamic_metadata_number(
  * be stored.
  * @return true if the operation is successful, false otherwise.
  */
-bool envoy_dynamic_module_callback_http_get_dynamic_metadata_number(
+bool envoy_dynamic_module_callback_http_get_metadata_number(
     envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr,
+    envoy_dynamic_module_type_metadata_source metadata_source,
     envoy_dynamic_module_type_buffer_module_ptr namespace_ptr, size_t namespace_length,
     envoy_dynamic_module_type_buffer_module_ptr key_ptr, size_t key_length, double* result);
 
@@ -1092,8 +1108,9 @@ bool envoy_dynamic_module_callback_http_set_dynamic_metadata_string(
  * they are guaranteed to be valid until the end of the current event hook unless the setter
  * callback is called.
  */
-bool envoy_dynamic_module_callback_http_get_dynamic_metadata_string(
+bool envoy_dynamic_module_callback_http_get_metadata_string(
     envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr,
+    envoy_dynamic_module_type_metadata_source metadata_source,
     envoy_dynamic_module_type_buffer_module_ptr namespace_ptr, size_t namespace_length,
     envoy_dynamic_module_type_buffer_module_ptr key_ptr, size_t key_length,
     envoy_dynamic_module_type_buffer_envoy_ptr* result, size_t* result_length);

--- a/source/extensions/dynamic_modules/abi_version.h
+++ b/source/extensions/dynamic_modules/abi_version.h
@@ -6,7 +6,7 @@ namespace DynamicModules {
 #endif
 // This is the ABI version calculated as a sha256 hash of the ABI header files. When the ABI
 // changes, this value must change, and the correctness of this value is checked by the test.
-const char* kAbiVersion = "35a11e0f7f0059b0a405dccebf233b19c69f8accb7ef6d7a748e301b463529d0";
+const char* kAbiVersion = "6880e51e622847350697658aa1390e04f8adde82adcab3d5ea6cfa1a5e604695";
 
 #ifdef __cplusplus
 } // namespace DynamicModules

--- a/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
@@ -417,7 +417,12 @@ pub trait EnvoyHttpFilter {
 
   /// Get the number-typed dynamic metadata value with the given key.
   /// If the metadata is not found or is the wrong type, this returns `None`.
-  fn get_dynamic_metadata_number(&self, namespace: &str, key: &str) -> Option<f64>;
+  fn get_metadata_number(
+    &self,
+    source: abi::envoy_dynamic_module_type_metadata_source,
+    namespace: &str,
+    key: &str,
+  ) -> Option<f64>;
 
   /// Set the number-typed dynamic metadata value with the given key.
   /// If the namespace is not found, this will create a new namespace.
@@ -427,8 +432,9 @@ pub trait EnvoyHttpFilter {
 
   /// Get the string-typed dynamic metadata value with the given key.
   /// If the metadata is not found or is the wrong type, this returns `None`.
-  fn get_dynamic_metadata_string<'a>(
+  fn get_metadata_string<'a>(
     &'a self,
+    source: abi::envoy_dynamic_module_type_metadata_source,
     namespace: &str,
     key: &str,
   ) -> Option<EnvoyBuffer<'a>>;
@@ -799,15 +805,21 @@ impl EnvoyHttpFilter for EnvoyHttpFilterImpl {
     }
   }
 
-  fn get_dynamic_metadata_number(&self, namespace: &str, key: &str) -> Option<f64> {
+  fn get_metadata_number(
+    &self,
+    source: abi::envoy_dynamic_module_type_metadata_source,
+    namespace: &str,
+    key: &str,
+  ) -> Option<f64> {
     let namespace_ptr = namespace.as_ptr();
     let namespace_size = namespace.len();
     let key_ptr = key.as_ptr();
     let key_size = key.len();
     let mut value: f64 = 0f64;
     let success = unsafe {
-      abi::envoy_dynamic_module_callback_http_get_dynamic_metadata_number(
+      abi::envoy_dynamic_module_callback_http_get_metadata_number(
         self.raw_ptr,
+        source,
         namespace_ptr as *const _ as *mut _,
         namespace_size,
         key_ptr as *const _ as *mut _,
@@ -839,7 +851,12 @@ impl EnvoyHttpFilter for EnvoyHttpFilterImpl {
     }
   }
 
-  fn get_dynamic_metadata_string(&self, namespace: &str, key: &str) -> Option<EnvoyBuffer> {
+  fn get_metadata_string(
+    &self,
+    source: abi::envoy_dynamic_module_type_metadata_source,
+    namespace: &str,
+    key: &str,
+  ) -> Option<EnvoyBuffer> {
     let namespace_ptr = namespace.as_ptr();
     let namespace_size = namespace.len();
     let key_ptr = key.as_ptr();
@@ -847,8 +864,9 @@ impl EnvoyHttpFilter for EnvoyHttpFilterImpl {
     let mut result_ptr: *const u8 = std::ptr::null();
     let mut result_size: usize = 0;
     let success = unsafe {
-      abi::envoy_dynamic_module_callback_http_get_dynamic_metadata_string(
+      abi::envoy_dynamic_module_callback_http_get_metadata_string(
         self.raw_ptr,
+        source,
         namespace_ptr as *const _ as *mut _,
         namespace_size,
         key_ptr as *const _ as *mut _,

--- a/source/extensions/filters/http/dynamic_modules/abi_impl.cc
+++ b/source/extensions/filters/http/dynamic_modules/abi_impl.cc
@@ -241,6 +241,69 @@ void envoy_dynamic_module_callback_http_send_response(
  * assuming stream info is available.
  * @return the metadata namespace if it exists, nullptr otherwise.
  */
+const ProtobufWkt::Struct*
+getMetadataNamespace(envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr,
+                     envoy_dynamic_module_type_metadata_source metadata_source,
+                     envoy_dynamic_module_type_buffer_module_ptr namespace_ptr,
+                     size_t namespace_length) {
+  auto filter = static_cast<const DynamicModuleHttpFilter*>(filter_envoy_ptr);
+  auto stream_info = filter->streamInfo();
+  if (!stream_info) {
+    ENVOY_LOG_TO_LOGGER(Envoy::Logger::Registry::getLog(Envoy::Logger::Id::dynamic_modules), debug,
+                        "stream info is not available");
+    return nullptr;
+  }
+  const envoy::config::core::v3::Metadata* metadata = nullptr;
+
+  switch (metadata_source) {
+  case envoy_dynamic_module_type_metadata_source_dynamic: {
+    metadata = &stream_info->dynamicMetadata();
+    break;
+  }
+  case envoy_dynamic_module_type_metadata_source_route: {
+    auto route = stream_info->route();
+    if (route) {
+      metadata = &route->metadata();
+    }
+    break;
+  }
+  case envoy_dynamic_module_type_metadata_source_cluster: {
+    auto clusterInfo = filter->clusterInfo();
+    if (clusterInfo) {
+      metadata = &clusterInfo->metadata();
+    }
+    break;
+  }
+  case envoy_dynamic_module_type_metadata_source_host: {
+    auto upstreamInfo = stream_info->upstreamInfo();
+    if (upstreamInfo) {
+      auto hostInfo = upstreamInfo->upstreamHost();
+      if (hostInfo) {
+        auto md = hostInfo->metadata();
+        if (md) {
+          metadata = md.get();
+        }
+      }
+    }
+    break;
+  }
+  }
+  if (!metadata) {
+    ENVOY_LOG_TO_LOGGER(Envoy::Logger::Registry::getLog(Envoy::Logger::Id::dynamic_modules), debug,
+                        "metadata is not available");
+    return nullptr;
+  }
+  const auto& filter_metdata = metadata->filter_metadata();
+  absl::string_view namespace_view(static_cast<const char*>(namespace_ptr), namespace_length);
+  auto metadata_namespace = filter_metdata.find(namespace_view);
+  if (metadata_namespace == filter_metdata.end()) {
+    ENVOY_LOG_TO_LOGGER(Envoy::Logger::Registry::getLog(Envoy::Logger::Id::dynamic_modules), debug,
+                        fmt::format("namespace {} not found in dynamic metadata", namespace_view));
+    return nullptr;
+  }
+  return &metadata_namespace->second;
+}
+
 ProtobufWkt::Struct*
 getDynamicMetadataNamespace(envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr,
                             envoy_dynamic_module_type_buffer_module_ptr namespace_ptr,
@@ -279,12 +342,12 @@ getDynamicMetadataNamespace(envoy_dynamic_module_type_http_filter_envoy_ptr filt
  * @return the metadata value if it exists, nullptr otherwise.
  */
 const ProtobufWkt::Value*
-getDynamicMetadataValue(envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr,
-                        envoy_dynamic_module_type_buffer_module_ptr namespace_ptr,
-                        size_t namespace_length,
-                        envoy_dynamic_module_type_buffer_module_ptr key_ptr, size_t key_length) {
+getMetadataValue(envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr,
+                 envoy_dynamic_module_type_metadata_source metadata_source,
+                 envoy_dynamic_module_type_buffer_module_ptr namespace_ptr, size_t namespace_length,
+                 envoy_dynamic_module_type_buffer_module_ptr key_ptr, size_t key_length) {
   auto metadata_namespace =
-      getDynamicMetadataNamespace(filter_envoy_ptr, namespace_ptr, namespace_length, false);
+      getMetadataNamespace(filter_envoy_ptr, metadata_source, namespace_ptr, namespace_length);
   if (!metadata_namespace) {
     return nullptr;
   }
@@ -315,12 +378,13 @@ bool envoy_dynamic_module_callback_http_set_dynamic_metadata_number(
   return true;
 }
 
-bool envoy_dynamic_module_callback_http_get_dynamic_metadata_number(
+bool envoy_dynamic_module_callback_http_get_metadata_number(
     envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr,
+    envoy_dynamic_module_type_metadata_source metadata_source,
     envoy_dynamic_module_type_buffer_module_ptr namespace_ptr, size_t namespace_length,
     envoy_dynamic_module_type_buffer_module_ptr key_ptr, size_t key_length, double* result) {
-  const auto key_metadata = getDynamicMetadataValue(filter_envoy_ptr, namespace_ptr,
-                                                    namespace_length, key_ptr, key_length);
+  const auto key_metadata = getMetadataValue(filter_envoy_ptr, metadata_source, namespace_ptr,
+                                             namespace_length, key_ptr, key_length);
   if (!key_metadata) {
     return false;
   }
@@ -354,13 +418,14 @@ bool envoy_dynamic_module_callback_http_set_dynamic_metadata_string(
   return true;
 }
 
-bool envoy_dynamic_module_callback_http_get_dynamic_metadata_string(
+bool envoy_dynamic_module_callback_http_get_metadata_string(
     envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr,
+    envoy_dynamic_module_type_metadata_source metadata_source,
     envoy_dynamic_module_type_buffer_module_ptr namespace_ptr, size_t namespace_length,
     envoy_dynamic_module_type_buffer_module_ptr key_ptr, size_t key_length,
     envoy_dynamic_module_type_buffer_envoy_ptr* result, size_t* result_length) {
-  const auto key_metadata = getDynamicMetadataValue(filter_envoy_ptr, namespace_ptr,
-                                                    namespace_length, key_ptr, key_length);
+  const auto key_metadata = getMetadataValue(filter_envoy_ptr, metadata_source, namespace_ptr,
+                                             namespace_length, key_ptr, key_length);
   if (!key_metadata) {
     return false;
   }

--- a/source/extensions/filters/http/dynamic_modules/filter.h
+++ b/source/extensions/filters/http/dynamic_modules/filter.h
@@ -84,6 +84,16 @@ public:
     }
   }
 
+  const StreamInfo::StreamInfo* streamInfo() const {
+    if (decoder_callbacks_) {
+      return &decoder_callbacks_->streamInfo();
+    } else if (encoder_callbacks_) {
+      return &encoder_callbacks_->streamInfo();
+    } else {
+      return nullptr;
+    }
+  }
+
   /**
    * Helper to get the upstream information of the stream.
    */
@@ -93,6 +103,19 @@ public:
       return stream_info->upstreamInfo().get();
     }
     return nullptr;
+  }
+
+  /**
+   * Helper to get the cluster information of the stream.
+   */
+  Upstream::ClusterInfoConstSharedPtr clusterInfo() const {
+    if (decoder_callbacks_) {
+      return decoder_callbacks_->clusterInfo();
+    } else if (encoder_callbacks_) {
+      return encoder_callbacks_->clusterInfo();
+    } else {
+      return nullptr;
+    }
   }
 
   /**

--- a/test/extensions/dynamic_modules/http/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/http/abi_impl_test.cc
@@ -424,11 +424,12 @@ TEST(ABIImpl, dynamic_metadata) {
       &filter, namespace_ptr, namespace_length, key_ptr, key_length, value));
   EXPECT_FALSE(envoy_dynamic_module_callback_http_set_dynamic_metadata_string(
       &filter, namespace_ptr, namespace_length, key_ptr, key_length, value_ptr, value_length));
-  EXPECT_FALSE(envoy_dynamic_module_callback_http_get_dynamic_metadata_number(
-      &filter, namespace_ptr, namespace_length, key_ptr, key_length, &result_number));
-  EXPECT_FALSE(envoy_dynamic_module_callback_http_get_dynamic_metadata_string(
-      &filter, namespace_ptr, namespace_length, key_ptr, key_length, &result_str_ptr,
-      &result_str_length));
+  EXPECT_FALSE(envoy_dynamic_module_callback_http_get_metadata_number(
+      &filter, envoy_dynamic_module_type_metadata_source_dynamic, namespace_ptr, namespace_length,
+      key_ptr, key_length, &result_number));
+  EXPECT_FALSE(envoy_dynamic_module_callback_http_get_metadata_string(
+      &filter, envoy_dynamic_module_type_metadata_source_dynamic, namespace_ptr, namespace_length,
+      key_ptr, key_length, &result_str_ptr, &result_str_length));
 
   // No namespace.
   Http::MockStreamDecoderFilterCallbacks callbacks;
@@ -436,13 +437,16 @@ TEST(ABIImpl, dynamic_metadata) {
   EXPECT_CALL(callbacks, streamInfo()).WillRepeatedly(testing::ReturnRef(stream_info));
   envoy::config::core::v3::Metadata metadata;
   EXPECT_CALL(stream_info, dynamicMetadata()).WillRepeatedly(testing::ReturnRef(metadata));
+  EXPECT_CALL(testing::Const(stream_info), dynamicMetadata())
+      .WillRepeatedly(testing::ReturnRef(metadata));
   filter.setDecoderFilterCallbacks(callbacks);
   // Only tests get methods as setters create the namespace.
-  EXPECT_FALSE(envoy_dynamic_module_callback_http_get_dynamic_metadata_number(
-      &filter, namespace_ptr, namespace_length, key_ptr, key_length, &result_number));
-  EXPECT_FALSE(envoy_dynamic_module_callback_http_get_dynamic_metadata_string(
-      &filter, namespace_ptr, namespace_length, key_ptr, key_length, &result_str_ptr,
-      &result_str_length));
+  EXPECT_FALSE(envoy_dynamic_module_callback_http_get_metadata_number(
+      &filter, envoy_dynamic_module_type_metadata_source_dynamic, namespace_ptr, namespace_length,
+      key_ptr, key_length, &result_number));
+  EXPECT_FALSE(envoy_dynamic_module_callback_http_get_metadata_string(
+      &filter, envoy_dynamic_module_type_metadata_source_dynamic, namespace_ptr, namespace_length,
+      key_ptr, key_length, &result_str_ptr, &result_str_length));
 
   // With namespace but non existing key.
   const char* non_existing_key = "non_existing";
@@ -452,34 +456,36 @@ TEST(ABIImpl, dynamic_metadata) {
   // This will create the namespace.
   EXPECT_TRUE(envoy_dynamic_module_callback_http_set_dynamic_metadata_number(
       &filter, namespace_ptr, namespace_length, key_ptr, key_length, value));
-  EXPECT_FALSE(envoy_dynamic_module_callback_http_get_dynamic_metadata_number(
-      &filter, namespace_ptr, namespace_length, non_existing_key_ptr, non_existing_key_length,
-      &result_number));
-  EXPECT_FALSE(envoy_dynamic_module_callback_http_get_dynamic_metadata_string(
-      &filter, namespace_ptr, namespace_length, non_existing_key_ptr, non_existing_key_length,
-      &result_str_ptr, &result_str_length));
+  EXPECT_FALSE(envoy_dynamic_module_callback_http_get_metadata_number(
+      &filter, envoy_dynamic_module_type_metadata_source_dynamic, namespace_ptr, namespace_length,
+      non_existing_key_ptr, non_existing_key_length, &result_number));
+  EXPECT_FALSE(envoy_dynamic_module_callback_http_get_metadata_string(
+      &filter, envoy_dynamic_module_type_metadata_source_dynamic, namespace_ptr, namespace_length,
+      non_existing_key_ptr, non_existing_key_length, &result_str_ptr, &result_str_length));
 
   // With namespace and key.
   EXPECT_TRUE(envoy_dynamic_module_callback_http_set_dynamic_metadata_number(
       &filter, namespace_ptr, namespace_length, key_ptr, key_length, value));
-  EXPECT_TRUE(envoy_dynamic_module_callback_http_get_dynamic_metadata_number(
-      &filter, namespace_ptr, namespace_length, key_ptr, key_length, &result_number));
+  EXPECT_TRUE(envoy_dynamic_module_callback_http_get_metadata_number(
+      &filter, envoy_dynamic_module_type_metadata_source_dynamic, namespace_ptr, namespace_length,
+      key_ptr, key_length, &result_number));
   EXPECT_EQ(result_number, value);
   // Wrong type.
-  EXPECT_FALSE(envoy_dynamic_module_callback_http_get_dynamic_metadata_string(
-      &filter, namespace_ptr, namespace_length, key_ptr, key_length, &result_str_ptr,
-      &result_str_length));
+  EXPECT_FALSE(envoy_dynamic_module_callback_http_get_metadata_string(
+      &filter, envoy_dynamic_module_type_metadata_source_dynamic, namespace_ptr, namespace_length,
+      key_ptr, key_length, &result_str_ptr, &result_str_length));
 
   EXPECT_TRUE(envoy_dynamic_module_callback_http_set_dynamic_metadata_string(
       &filter, namespace_ptr, namespace_length, key_ptr, key_length, value_ptr, value_length));
-  EXPECT_TRUE(envoy_dynamic_module_callback_http_get_dynamic_metadata_string(
-      &filter, namespace_ptr, namespace_length, key_ptr, key_length, &result_str_ptr,
-      &result_str_length));
+  EXPECT_TRUE(envoy_dynamic_module_callback_http_get_metadata_string(
+      &filter, envoy_dynamic_module_type_metadata_source_dynamic, namespace_ptr, namespace_length,
+      key_ptr, key_length, &result_str_ptr, &result_str_length));
   EXPECT_EQ(result_str_length, value_length);
   EXPECT_EQ(std::string(result_str_ptr, result_str_length), value_str);
   // Wrong type.
-  EXPECT_FALSE(envoy_dynamic_module_callback_http_get_dynamic_metadata_number(
-      &filter, namespace_ptr, namespace_length, key_ptr, key_length, &result_number));
+  EXPECT_FALSE(envoy_dynamic_module_callback_http_get_metadata_number(
+      &filter, envoy_dynamic_module_type_metadata_source_dynamic, namespace_ptr, namespace_length,
+      key_ptr, key_length, &result_number));
 }
 
 TEST(ABIImpl, filter_state) {

--- a/test/extensions/dynamic_modules/http/filter_test.cc
+++ b/test/extensions/dynamic_modules/http/filter_test.cc
@@ -138,11 +138,36 @@ TEST(DynamicModulesTest, DynamicMetadataCallbacks) {
   auto filter = std::make_shared<DynamicModuleHttpFilter>(filter_config_or_status.value());
   filter->initializeInModuleFilter();
 
+  auto route = std::make_shared<NiceMock<Router::MockRoute>>();
   Http::MockStreamDecoderFilterCallbacks callbacks;
   StreamInfo::MockStreamInfo stream_info;
   EXPECT_CALL(callbacks, streamInfo()).WillRepeatedly(testing::ReturnRef(stream_info));
+  EXPECT_CALL(callbacks, streamInfo()).WillRepeatedly(testing::ReturnRef(stream_info));
   envoy::config::core::v3::Metadata metadata;
   EXPECT_CALL(stream_info, dynamicMetadata()).WillRepeatedly(testing::ReturnRef(metadata));
+  EXPECT_CALL(testing::Const(stream_info), dynamicMetadata())
+      .WillRepeatedly(testing::ReturnRef(metadata));
+
+  EXPECT_CALL(stream_info, route()).WillRepeatedly(Return(route));
+  EXPECT_CALL(callbacks, clusterInfo()).WillRepeatedly(testing::Return(callbacks.cluster_info_));
+
+  Envoy::Config::Metadata::mutableMetadataValue(callbacks.cluster_info_->metadata_, "metadata",
+                                                "cluster_key")
+      .set_string_value("cluster");
+  Envoy::Config::Metadata::mutableMetadataValue(route->metadata_, "metadata", "route_key")
+      .set_string_value("route");
+
+  auto upstream_info = std::make_shared<NiceMock<StreamInfo::MockUpstreamInfo>>();
+  auto upstream_host = std::make_shared<NiceMock<Upstream::MockHostDescription>>();
+  auto host_metadata = std::make_shared<envoy::config::core::v3::Metadata>();
+  EXPECT_CALL(*upstream_host, metadata()).WillRepeatedly(testing::Return(host_metadata));
+  EXPECT_CALL(testing::Const(stream_info), upstreamInfo())
+      .WillRepeatedly(Invoke(
+          [upstream_info]() -> OptRef<const StreamInfo::UpstreamInfo> { return *upstream_info; }));
+
+  upstream_info->upstream_host_ = upstream_host;
+  Envoy::Config::Metadata::mutableMetadataValue(*host_metadata, "metadata", "host_key")
+      .set_string_value("host");
   filter->setDecoderFilterCallbacks(callbacks);
 
   Http::TestRequestHeaderMapImpl request_headers{};

--- a/test/extensions/dynamic_modules/test_data/rust/http.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/http.rs
@@ -308,15 +308,48 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for DynamicMetadataCallbacksFilter {
     _end_of_stream: bool,
   ) -> abi::envoy_dynamic_module_type_on_http_filter_request_headers_status {
     // No namespace.
-    let no_namespace = envoy_filter.get_dynamic_metadata_number("no_namespace", "key");
+    let no_namespace = envoy_filter.get_metadata_number(
+      abi::envoy_dynamic_module_type_metadata_source::dynamic,
+      "no_namespace",
+      "key",
+    );
     assert!(no_namespace.is_none());
     // Set a number.
     envoy_filter.set_dynamic_metadata_number("ns_req_header", "key", 123f64);
-    let ns_req_header = envoy_filter.get_dynamic_metadata_number("ns_req_header", "key");
+    let ns_req_header = envoy_filter.get_metadata_number(
+      abi::envoy_dynamic_module_type_metadata_source::dynamic,
+      "ns_req_header",
+      "key",
+    );
     assert_eq!(ns_req_header, Some(123f64));
     // Try getting a number as string.
-    let ns_req_header = envoy_filter.get_dynamic_metadata_string("ns_req_header", "key");
+    let ns_req_header = envoy_filter.get_metadata_string(
+      abi::envoy_dynamic_module_type_metadata_source::dynamic,
+      "ns_req_header",
+      "key",
+    );
     assert!(ns_req_header.is_none());
+
+    // Try getting metadata from rotuer cluster and host.
+    let metadata = envoy_filter.get_metadata_string(
+      abi::envoy_dynamic_module_type_metadata_source::route,
+      "metadata",
+      "route_key",
+    );
+    assert_eq!(metadata.unwrap().as_slice(), b"route");
+    let metadata = envoy_filter.get_metadata_string(
+      abi::envoy_dynamic_module_type_metadata_source::cluster,
+      "metadata",
+      "cluster_key",
+    );
+    assert_eq!(metadata.unwrap().as_slice(), b"cluster");
+    let metadata = envoy_filter.get_metadata_string(
+      abi::envoy_dynamic_module_type_metadata_source::host,
+      "metadata",
+      "host_key",
+    );
+    assert_eq!(metadata.unwrap().as_slice(), b"host");
+
     abi::envoy_dynamic_module_type_on_http_filter_request_headers_status::Continue
   }
 
@@ -326,15 +359,27 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for DynamicMetadataCallbacksFilter {
     _end_of_stream: bool,
   ) -> abi::envoy_dynamic_module_type_on_http_filter_request_body_status {
     // No namespace.
-    let no_namespace = envoy_filter.get_dynamic_metadata_string("no_namespace", "key");
+    let no_namespace = envoy_filter.get_metadata_string(
+      abi::envoy_dynamic_module_type_metadata_source::dynamic,
+      "no_namespace",
+      "key",
+    );
     assert!(no_namespace.is_none());
     // Set a string.
     envoy_filter.set_dynamic_metadata_string("ns_req_body", "key", "value");
-    let ns_req_body = envoy_filter.get_dynamic_metadata_string("ns_req_body", "key");
+    let ns_req_body = envoy_filter.get_metadata_string(
+      abi::envoy_dynamic_module_type_metadata_source::dynamic,
+      "ns_req_body",
+      "key",
+    );
     assert!(ns_req_body.is_some());
     assert_eq!(ns_req_body.unwrap().as_slice(), b"value");
     // Try getting a string as number.
-    let ns_req_body = envoy_filter.get_dynamic_metadata_number("ns_req_body", "key");
+    let ns_req_body = envoy_filter.get_metadata_number(
+      abi::envoy_dynamic_module_type_metadata_source::dynamic,
+      "ns_req_body",
+      "key",
+    );
     assert!(ns_req_body.is_none());
     abi::envoy_dynamic_module_type_on_http_filter_request_body_status::Continue
   }
@@ -345,14 +390,26 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for DynamicMetadataCallbacksFilter {
     _end_of_stream: bool,
   ) -> abi::envoy_dynamic_module_type_on_http_filter_response_headers_status {
     // No namespace.
-    let no_namespace = envoy_filter.get_dynamic_metadata_string("no_namespace", "key");
+    let no_namespace = envoy_filter.get_metadata_string(
+      abi::envoy_dynamic_module_type_metadata_source::dynamic,
+      "no_namespace",
+      "key",
+    );
     assert!(no_namespace.is_none());
     // Set a number.
     envoy_filter.set_dynamic_metadata_number("ns_res_header", "key", 123f64);
-    let ns_res_header = envoy_filter.get_dynamic_metadata_number("ns_res_header", "key");
+    let ns_res_header = envoy_filter.get_metadata_number(
+      abi::envoy_dynamic_module_type_metadata_source::dynamic,
+      "ns_res_header",
+      "key",
+    );
     assert_eq!(ns_res_header, Some(123f64));
     // Try getting a number as string.
-    let ns_res_header = envoy_filter.get_dynamic_metadata_string("ns_res_header", "key");
+    let ns_res_header = envoy_filter.get_metadata_string(
+      abi::envoy_dynamic_module_type_metadata_source::dynamic,
+      "ns_res_header",
+      "key",
+    );
     assert!(ns_res_header.is_none());
     abi::envoy_dynamic_module_type_on_http_filter_response_headers_status::Continue
   }
@@ -363,14 +420,26 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for DynamicMetadataCallbacksFilter {
     _end_of_stream: bool,
   ) -> abi::envoy_dynamic_module_type_on_http_filter_response_body_status {
     // No namespace.
-    let no_namespace = envoy_filter.get_dynamic_metadata_string("no_namespace", "key");
+    let no_namespace = envoy_filter.get_metadata_string(
+      abi::envoy_dynamic_module_type_metadata_source::dynamic,
+      "no_namespace",
+      "key",
+    );
     assert!(no_namespace.is_none());
     // Set a string.
     envoy_filter.set_dynamic_metadata_string("ns_res_body", "key", "value");
-    let ns_res_body = envoy_filter.get_dynamic_metadata_string("ns_res_body", "key");
+    let ns_res_body = envoy_filter.get_metadata_string(
+      abi::envoy_dynamic_module_type_metadata_source::dynamic,
+      "ns_res_body",
+      "key",
+    );
     assert!(ns_res_body.is_some());
     // Try getting a string as number.
-    let ns_res_body = envoy_filter.get_dynamic_metadata_number("ns_res_body", "key");
+    let ns_res_body = envoy_filter.get_metadata_number(
+      abi::envoy_dynamic_module_type_metadata_source::dynamic,
+      "ns_res_body",
+      "key",
+    );
     assert!(ns_res_body.is_none());
     abi::envoy_dynamic_module_type_on_http_filter_response_body_status::Continue
   }


### PR DESCRIPTION
Commit Message:
Modified the ABI to allow specifying metadata source (which can be dynamic, cluster, host or route) when getting metadata.

Risk Level: Low
Testing: Updated unit tests
Docs Changes: N/A

