### PR TITLE
quic: make the FIPS build macros consistent

### DIFF
--- a/source/common/http/http3/BUILD
+++ b/source/common/http/http3/BUILD
@@ -2,6 +2,7 @@ load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_library",
     "envoy_package",
+    "envoy_select_enable_http3",
 )
 
 licenses(["notice"])  # Apache 2
@@ -10,26 +11,17 @@ envoy_package()
 
 envoy_cc_library(
     name = "conn_pool_lib",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["conn_pool.cc"],
-    }),
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["conn_pool.h"],
-    }),
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//envoy/event:dispatcher_interface",
-            "//envoy/http:persistent_quic_info_interface",
-            "//envoy/upstream:upstream_interface",
-            "//source/common/http:codec_client_lib",
-            "//source/common/http:conn_pool_base_lib",
-            "//source/common/quic:client_connection_factory_lib",
-            "@com_github_google_quiche//:quic_core_deterministic_connection_id_generator_lib",
-        ],
-    }),
+    srcs = envoy_select_enable_http3(["conn_pool.cc"]),
+    hdrs = envoy_select_enable_http3(["conn_pool.h"]),
+    deps = envoy_select_enable_http3([
+        "//envoy/event:dispatcher_interface",
+        "//envoy/http:persistent_quic_info_interface",
+        "//envoy/upstream:upstream_interface",
+        "//source/common/http:codec_client_lib",
+        "//source/common/http:conn_pool_base_lib",
+        "//source/common/quic:client_connection_factory_lib",
+        "@com_github_google_quiche//:quic_core_deterministic_connection_id_generator_lib",
+    ]),
 )
 
 envoy_cc_library(

--- a/source/common/quic/BUILD
+++ b/source/common/quic/BUILD
@@ -29,102 +29,63 @@ envoy_package()
 
 envoy_cc_library(
     name = "envoy_quic_alarm_lib",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_alarm.cc"],
-    }),
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_alarm.h"],
-    }),
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//envoy/event:dispatcher_interface",
-            "//envoy/event:timer_interface",
-            "@com_github_google_quiche//:quic_core_alarm_lib",
-            "@com_github_google_quiche//:quic_core_clock_lib",
-            "@com_github_google_quiche//:quic_platform",
-        ],
-    }),
+    srcs = envoy_select_enable_http3(["envoy_quic_alarm.cc"]),
+    hdrs = envoy_select_enable_http3(["envoy_quic_alarm.h"]),
+    deps = envoy_select_enable_http3([
+        "//envoy/event:dispatcher_interface",
+        "//envoy/event:timer_interface",
+        "@com_github_google_quiche//:quic_core_alarm_lib",
+        "@com_github_google_quiche//:quic_core_clock_lib",
+        "@com_github_google_quiche//:quic_platform",
+    ]),
 )
 
 envoy_cc_library(
     name = "envoy_quic_alarm_factory_lib",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_alarm_factory.cc"],
-    }),
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_alarm_factory.h"],
-    }),
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":envoy_quic_alarm_lib",
-            "@com_github_google_quiche//:quic_core_alarm_factory_lib",
-            "@com_github_google_quiche//:quic_core_arena_scoped_ptr_lib",
-            "@com_github_google_quiche//:quic_core_one_block_arena_lib",
-            "@com_github_google_quiche//:quic_platform",
-        ],
-    }),
+    srcs = envoy_select_enable_http3(["envoy_quic_alarm_factory.cc"]),
+    hdrs = envoy_select_enable_http3(["envoy_quic_alarm_factory.h"]),
+    deps = envoy_select_enable_http3([
+        ":envoy_quic_alarm_lib",
+        "@com_github_google_quiche//:quic_core_alarm_factory_lib",
+        "@com_github_google_quiche//:quic_core_arena_scoped_ptr_lib",
+        "@com_github_google_quiche//:quic_core_one_block_arena_lib",
+        "@com_github_google_quiche//:quic_platform",
+    ]),
 )
 
 envoy_cc_library(
     name = "envoy_quic_clock_lib",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_clock.cc"],
-    }),
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_clock.h"],
-    }),
+    srcs = envoy_select_enable_http3(["envoy_quic_clock.cc"]),
+    hdrs = envoy_select_enable_http3(["envoy_quic_clock.h"]),
     visibility = ["//visibility:public"],
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//envoy/event:dispatcher_interface",
-            "@com_github_google_quiche//:quic_core_clock_lib",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        "//envoy/event:dispatcher_interface",
+        "@com_github_google_quiche//:quic_core_clock_lib",
+    ]),
 )
 
 envoy_cc_library(
     name = "envoy_quic_connection_debug_visitor_factory_interface",
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_connection_debug_visitor_factory_interface.h"],
-    }),
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//envoy/common:optref_lib",
-            "//envoy/common:pure_lib",
-            "//envoy/config:typed_config_interface",
-            "//envoy/server:factory_context_interface",
-            "//envoy/stream_info:stream_info_interface",
-            "@com_github_google_quiche//:quic_core_connection_lib",
-            "@com_github_google_quiche//:quic_core_session_lib",
-        ],
-    }),
+    hdrs = envoy_select_enable_http3(["envoy_quic_connection_debug_visitor_factory_interface.h"]),
+    deps = envoy_select_enable_http3([
+        "//envoy/common:optref_lib",
+        "//envoy/common:pure_lib",
+        "//envoy/config:typed_config_interface",
+        "//envoy/server:factory_context_interface",
+        "//envoy/stream_info:stream_info_interface",
+        "@com_github_google_quiche//:quic_core_connection_lib",
+        "@com_github_google_quiche//:quic_core_session_lib",
+    ]),
 )
 
 envoy_cc_library(
     name = "envoy_quic_connection_helper_lib",
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_connection_helper.h"],
-    }),
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":envoy_quic_clock_lib",
-            "@com_github_google_quiche//:quic_core_connection_lib",
-            "@com_github_google_quiche//:quiche_common_random_lib",
-        ],
-    }),
+    hdrs = envoy_select_enable_http3(["envoy_quic_connection_helper.h"]),
+    deps = envoy_select_enable_http3([
+        ":envoy_quic_clock_lib",
+        "@com_github_google_quiche//:quic_core_connection_lib",
+        "@com_github_google_quiche//:quiche_common_random_lib",
+    ]),
 )
 
 envoy_cc_library(
@@ -147,338 +108,233 @@ envoy_cc_library(
 
 envoy_cc_library(
     name = "envoy_quic_proof_source_base_lib",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_proof_source_base.cc"],
-    }),
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_proof_source_base.h"],
-    }),
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":envoy_quic_utils_lib",
-            "@com_github_google_quiche//:quic_core_crypto_certificate_view_lib",
-            "@com_github_google_quiche//:quic_core_crypto_crypto_handshake_lib",
-            "@com_github_google_quiche//:quic_core_crypto_proof_source_lib",
-            "@com_github_google_quiche//:quic_core_data_lib",
-            "@com_github_google_quiche//:quic_core_versions_lib",
-            "@com_github_google_quiche//:quic_platform",
-        ],
-    }),
+    srcs = envoy_select_enable_http3(["envoy_quic_proof_source_base.cc"]),
+    hdrs = envoy_select_enable_http3(["envoy_quic_proof_source_base.h"]),
+    deps = envoy_select_enable_http3([
+        ":envoy_quic_utils_lib",
+        "@com_github_google_quiche//:quic_core_crypto_certificate_view_lib",
+        "@com_github_google_quiche//:quic_core_crypto_crypto_handshake_lib",
+        "@com_github_google_quiche//:quic_core_crypto_proof_source_lib",
+        "@com_github_google_quiche//:quic_core_data_lib",
+        "@com_github_google_quiche//:quic_core_versions_lib",
+        "@com_github_google_quiche//:quic_platform",
+    ]),
 )
 
 envoy_cc_library(
     name = "envoy_quic_proof_source_lib",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_proof_source.cc"],
-    }),
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_proof_source.h"],
-    }),
+    srcs = envoy_select_enable_http3(["envoy_quic_proof_source.cc"]),
+    hdrs = envoy_select_enable_http3(["envoy_quic_proof_source.h"]),
     external_deps = ["ssl"],
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":envoy_quic_proof_source_base_lib",
-            ":envoy_quic_utils_lib",
-            ":quic_io_handle_wrapper_lib",
-            ":quic_transport_socket_factory_lib",
-            "//envoy/ssl:tls_certificate_config_interface",
-            "//source/common/quic:cert_compression_lib",
-            "//source/common/quic:quic_server_transport_socket_factory_lib",
-            "//source/common/stream_info:stream_info_lib",
-            "//source/server:listener_stats",
-            "@com_github_google_quiche//:quic_core_crypto_certificate_view_lib",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        ":envoy_quic_proof_source_base_lib",
+        ":envoy_quic_utils_lib",
+        ":quic_io_handle_wrapper_lib",
+        ":quic_transport_socket_factory_lib",
+        "//envoy/ssl:tls_certificate_config_interface",
+        "//source/common/quic:cert_compression_lib",
+        "//source/common/quic:quic_server_transport_socket_factory_lib",
+        "//source/common/stream_info:stream_info_lib",
+        "//source/server:listener_stats",
+        "@com_github_google_quiche//:quic_core_crypto_certificate_view_lib",
+    ]),
 )
 
 envoy_cc_library(
     name = "envoy_quic_proof_verifier_base_lib",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_proof_verifier_base.cc"],
-    }),
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_proof_verifier_base.h"],
-    }),
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":envoy_quic_utils_lib",
-            "@com_github_google_quiche//:quic_core_crypto_certificate_view_lib",
-            "@com_github_google_quiche//:quic_core_crypto_crypto_handshake_lib",
-            "@com_github_google_quiche//:quic_core_versions_lib",
-            "@com_github_google_quiche//:quic_platform",
-        ],
-    }),
+    srcs = envoy_select_enable_http3(["envoy_quic_proof_verifier_base.cc"]),
+    hdrs = envoy_select_enable_http3(["envoy_quic_proof_verifier_base.h"]),
+    deps = envoy_select_enable_http3([
+        ":envoy_quic_utils_lib",
+        "@com_github_google_quiche//:quic_core_crypto_certificate_view_lib",
+        "@com_github_google_quiche//:quic_core_crypto_crypto_handshake_lib",
+        "@com_github_google_quiche//:quic_core_versions_lib",
+        "@com_github_google_quiche//:quic_platform",
+    ]),
 )
 
 envoy_cc_library(
     name = "envoy_quic_proof_verifier_lib",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_proof_verifier.cc"],
-    }),
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_proof_verifier.h"],
-    }),
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":envoy_quic_proof_verifier_base_lib",
-            ":envoy_quic_utils_lib",
-            ":quic_ssl_connection_info_lib",
-            "//source/common/tls:context_lib",
-            "@com_github_google_quiche//:quic_platform",
-        ],
-    }),
+    srcs = envoy_select_enable_http3(["envoy_quic_proof_verifier.cc"]),
+    hdrs = envoy_select_enable_http3(["envoy_quic_proof_verifier.h"]),
+    deps = envoy_select_enable_http3([
+        ":envoy_quic_proof_verifier_base_lib",
+        ":envoy_quic_utils_lib",
+        ":quic_ssl_connection_info_lib",
+        "//source/common/tls:context_lib",
+        "@com_github_google_quiche//:quic_platform",
+    ]),
 )
 
 envoy_cc_library(
     name = "envoy_quic_stream_lib",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_stream.cc"],
-    }),
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_stream.h"],
-    }),
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":envoy_quic_simulated_watermark_buffer_lib",
-            ":envoy_quic_utils_lib",
-            ":quic_filter_manager_connection_lib",
-            ":quic_stats_gatherer",
-            ":send_buffer_monitor_lib",
-            "//envoy/event:dispatcher_interface",
-            "//envoy/http:codec_interface",
-            "//source/common/http:codec_helper_lib",
-            "@com_github_google_quiche//:http2_adapter",
-            "@com_github_google_quiche//:quic_core_http_client_lib",
-            "@com_github_google_quiche//:quic_core_http_http_encoder_lib",
-            "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
-        ],
-    }) + envoy_select_enable_http_datagrams([
+    srcs = envoy_select_enable_http3(["envoy_quic_stream.cc"]),
+    hdrs = envoy_select_enable_http3(["envoy_quic_stream.h"]),
+    deps = envoy_select_enable_http3([
+        ":envoy_quic_simulated_watermark_buffer_lib",
+        ":envoy_quic_utils_lib",
+        ":quic_filter_manager_connection_lib",
+        ":quic_stats_gatherer",
+        ":send_buffer_monitor_lib",
+        "//envoy/event:dispatcher_interface",
+        "//envoy/http:codec_interface",
+        "//source/common/http:codec_helper_lib",
+        "@com_github_google_quiche//:http2_adapter",
+        "@com_github_google_quiche//:quic_core_http_client_lib",
+        "@com_github_google_quiche//:quic_core_http_http_encoder_lib",
+        "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
+    ]) + envoy_select_enable_http_datagrams([
         ":http_datagram_handler",
     ]),
 )
 
 envoy_cc_library(
     name = "client_connection_factory_lib",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["client_connection_factory_impl.cc"],
-    }),
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["client_connection_factory_impl.h"],
-    }),
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":envoy_quic_alarm_factory_lib",
-            ":envoy_quic_client_session_lib",
-            ":envoy_quic_connection_helper_lib",
-            ":envoy_quic_proof_verifier_lib",
-            ":envoy_quic_utils_lib",
-            "//envoy/http:codec_interface",
-            "//envoy/http:persistent_quic_info_interface",
-            "//envoy/registry",
-            "//source/common/runtime:runtime_lib",
-            "//source/common/tls:client_ssl_socket_lib",
-            "//source/extensions/quic/crypto_stream:envoy_quic_crypto_client_stream_lib",
-            "@com_github_google_quiche//:quic_core_http_spdy_session_lib",
-        ],
-    }),
+    srcs = envoy_select_enable_http3(["client_connection_factory_impl.cc"]),
+    hdrs = envoy_select_enable_http3(["client_connection_factory_impl.h"]),
+    deps = envoy_select_enable_http3([
+        ":envoy_quic_alarm_factory_lib",
+        ":envoy_quic_client_session_lib",
+        ":envoy_quic_connection_helper_lib",
+        ":envoy_quic_proof_verifier_lib",
+        ":envoy_quic_utils_lib",
+        "//envoy/http:codec_interface",
+        "//envoy/http:persistent_quic_info_interface",
+        "//envoy/registry",
+        "//source/common/runtime:runtime_lib",
+        "//source/common/tls:client_ssl_socket_lib",
+        "//source/extensions/quic/crypto_stream:envoy_quic_crypto_client_stream_lib",
+        "@com_github_google_quiche//:quic_core_http_spdy_session_lib",
+    ]),
 )
 
 envoy_cc_library(
     name = "client_codec_lib",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["client_codec_impl.cc"],
-    }),
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "client_codec_impl.h",
-            "codec_impl.h",
-        ],
-    }),
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":envoy_quic_client_session_lib",
-            ":envoy_quic_utils_lib",
-            "//envoy/http:codec_interface",
-            "//envoy/registry",
-            "@com_github_google_quiche//:quic_core_http_spdy_session_lib",
-        ],
-    }),
+    srcs = envoy_select_enable_http3(["client_codec_impl.cc"]),
+    hdrs = envoy_select_enable_http3([
+        "client_codec_impl.h",
+        "codec_impl.h",
+    ]),
+    deps = envoy_select_enable_http3([
+        ":envoy_quic_client_session_lib",
+        ":envoy_quic_utils_lib",
+        "//envoy/http:codec_interface",
+        "//envoy/registry",
+        "@com_github_google_quiche//:quic_core_http_spdy_session_lib",
+    ]),
 )
 
 envoy_cc_library(
     name = "server_codec_lib",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["server_codec_impl.cc"],
-    }),
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "codec_impl.h",
-            "server_codec_impl.h",
-        ],
-    }),
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":envoy_quic_server_session_lib",
-            ":envoy_quic_utils_lib",
-            ":quic_server_factory_stub_lib",
-            "//envoy/http:codec_interface",
-            "//envoy/registry",
-            "@com_github_google_quiche//:quic_core_http_spdy_session_lib",
-        ],
-    }),
+    srcs = envoy_select_enable_http3(["server_codec_impl.cc"]),
+    hdrs = envoy_select_enable_http3([
+        "codec_impl.h",
+        "server_codec_impl.h",
+    ]),
+    deps = envoy_select_enable_http3([
+        ":envoy_quic_server_session_lib",
+        ":envoy_quic_utils_lib",
+        ":quic_server_factory_stub_lib",
+        "//envoy/http:codec_interface",
+        "//envoy/registry",
+        "@com_github_google_quiche//:quic_core_http_spdy_session_lib",
+    ]),
     alwayslink = LEGACY_ALWAYSLINK,
 )
 
 envoy_cc_library(
     name = "quic_ssl_connection_info_lib",
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["quic_ssl_connection_info.h"],
-    }),
+    hdrs = envoy_select_enable_http3(["quic_ssl_connection_info.h"]),
     external_deps = ["ssl"],
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//source/common/tls:connection_info_impl_base_lib",
-            "@com_github_google_quiche//:quic_core_session_lib",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        "//source/common/tls:connection_info_impl_base_lib",
+        "@com_github_google_quiche//:quic_core_session_lib",
+    ]),
 )
 
 envoy_cc_library(
     name = "quic_filter_manager_connection_lib",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["quic_filter_manager_connection_impl.cc"],
-    }),
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["quic_filter_manager_connection_impl.h"],
-    }),
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":envoy_quic_simulated_watermark_buffer_lib",
-            ":quic_network_connection_lib",
-            ":quic_ssl_connection_info_lib",
-            ":quic_stat_names_lib",
-            ":send_buffer_monitor_lib",
-            "//envoy/event:dispatcher_interface",
-            "//envoy/network:connection_interface",
-            "//source/common/buffer:buffer_lib",
-            "//source/common/common:assert_lib",
-            "//source/common/common:empty_string",
-            "//source/common/http:header_map_lib",
-            "//source/common/http/http3:codec_stats_lib",
-            "//source/common/network:connection_base_lib",
-            "//source/common/stream_info:stream_info_lib",
-            "@com_github_google_quiche//:quic_core_connection_lib",
-        ],
-    }),
+    srcs = envoy_select_enable_http3(["quic_filter_manager_connection_impl.cc"]),
+    hdrs = envoy_select_enable_http3(["quic_filter_manager_connection_impl.h"]),
+    deps = envoy_select_enable_http3([
+        ":envoy_quic_simulated_watermark_buffer_lib",
+        ":quic_network_connection_lib",
+        ":quic_ssl_connection_info_lib",
+        ":quic_stat_names_lib",
+        ":send_buffer_monitor_lib",
+        "//envoy/event:dispatcher_interface",
+        "//envoy/network:connection_interface",
+        "//source/common/buffer:buffer_lib",
+        "//source/common/common:assert_lib",
+        "//source/common/common:empty_string",
+        "//source/common/http:header_map_lib",
+        "//source/common/http/http3:codec_stats_lib",
+        "//source/common/network:connection_base_lib",
+        "//source/common/stream_info:stream_info_lib",
+        "@com_github_google_quiche//:quic_core_connection_lib",
+    ]),
 )
 
 envoy_cc_library(
     name = "envoy_quic_server_session_lib",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "envoy_quic_server_session.cc",
-            "envoy_quic_server_stream.cc",
-        ],
-    }),
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "envoy_quic_server_session.h",
-            "envoy_quic_server_stream.h",
-        ],
-    }),
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":envoy_quic_connection_debug_visitor_factory_interface",
-            ":envoy_quic_proof_source_lib",
-            ":envoy_quic_server_connection_lib",
-            ":envoy_quic_server_crypto_stream_factory_lib",
-            ":envoy_quic_stream_lib",
-            ":envoy_quic_utils_lib",
-            ":quic_filter_manager_connection_lib",
-            ":quic_stat_names_lib",
-            ":quic_stats_gatherer",
-            "//source/common/buffer:buffer_lib",
-            "//source/common/common:assert_lib",
-            "//source/common/http:header_map_lib",
-            "@com_github_google_quiche//:quic_server_http_spdy_session_lib",
-            "@com_google_absl//absl/types:optional",
-        ],
-    }) + envoy_select_enable_http_datagrams([
+    srcs = envoy_select_enable_http3([
+        "envoy_quic_server_session.cc",
+        "envoy_quic_server_stream.cc",
+    ]),
+    hdrs = envoy_select_enable_http3([
+        "envoy_quic_server_session.h",
+        "envoy_quic_server_stream.h",
+    ]),
+    deps = envoy_select_enable_http3([
+        ":envoy_quic_connection_debug_visitor_factory_interface",
+        ":envoy_quic_proof_source_lib",
+        ":envoy_quic_server_connection_lib",
+        ":envoy_quic_server_crypto_stream_factory_lib",
+        ":envoy_quic_stream_lib",
+        ":envoy_quic_utils_lib",
+        ":quic_filter_manager_connection_lib",
+        ":quic_stat_names_lib",
+        ":quic_stats_gatherer",
+        "//source/common/buffer:buffer_lib",
+        "//source/common/common:assert_lib",
+        "//source/common/http:header_map_lib",
+        "@com_github_google_quiche//:quic_server_http_spdy_session_lib",
+        "@com_google_absl//absl/types:optional",
+    ]) + envoy_select_enable_http_datagrams([
         ":http_datagram_handler",
     ]),
 )
 
 envoy_cc_library(
     name = "envoy_quic_client_session_lib",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "envoy_quic_client_session.cc",
-            "envoy_quic_client_stream.cc",
-            "quic_network_connectivity_observer.cc",
-        ],
-    }),
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "envoy_quic_client_session.h",
-            "envoy_quic_client_stream.h",
-            "envoy_quic_network_observer_registry_factory.h",
-            "quic_network_connectivity_observer.h",
-        ],
-    }),
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":envoy_quic_client_connection_lib",
-            ":envoy_quic_client_crypto_stream_factory_lib",
-            ":envoy_quic_proof_verifier_lib",
-            ":envoy_quic_stream_lib",
-            ":envoy_quic_utils_lib",
-            ":quic_filter_manager_connection_lib",
-            ":quic_stat_names_lib",
-            ":quic_transport_socket_factory_lib",
-            "//envoy/http:http_server_properties_cache_interface",
-            "//source/common/buffer:buffer_lib",
-            "//source/common/common:assert_lib",
-            "//source/common/http:codes_lib",
-            "//source/common/http:header_map_lib",
-            "//source/common/http:header_utility_lib",
-            "@com_github_google_quiche//:quic_core_http_client_lib",
-        ],
-    }) + envoy_select_enable_http_datagrams([
+    srcs = envoy_select_enable_http3([
+        "envoy_quic_client_session.cc",
+        "envoy_quic_client_stream.cc",
+        "quic_network_connectivity_observer.cc",
+    ]),
+    hdrs = envoy_select_enable_http3([
+        "envoy_quic_client_session.h",
+        "envoy_quic_client_stream.h",
+        "envoy_quic_network_observer_registry_factory.h",
+        "quic_network_connectivity_observer.h",
+    ]),
+    deps = envoy_select_enable_http3([
+        ":envoy_quic_client_connection_lib",
+        ":envoy_quic_client_crypto_stream_factory_lib",
+        ":envoy_quic_proof_verifier_lib",
+        ":envoy_quic_stream_lib",
+        ":envoy_quic_utils_lib",
+        ":quic_filter_manager_connection_lib",
+        ":quic_stat_names_lib",
+        ":quic_transport_socket_factory_lib",
+        "//envoy/http:http_server_properties_cache_interface",
+        "//source/common/buffer:buffer_lib",
+        "//source/common/common:assert_lib",
+        "//source/common/http:codes_lib",
+        "//source/common/http:header_map_lib",
+        "//source/common/http:header_utility_lib",
+        "@com_github_google_quiche//:quic_core_http_client_lib",
+    ]) + envoy_select_enable_http_datagrams([
         ":http_datagram_handler",
     ]),
 )
@@ -495,237 +351,174 @@ envoy_cc_library(
 
 envoy_cc_library(
     name = "quic_io_handle_wrapper_lib",
-    hdrs = ["quic_io_handle_wrapper.h"],
-    deps = [
+    hdrs = envoy_select_enable_http3(["quic_io_handle_wrapper.h"]),
+    deps = envoy_select_enable_http3([
         "//envoy/network:io_handle_interface",
         "//source/common/network:io_socket_error_lib",
-    ],
+    ]),
 )
 
 envoy_cc_library(
     name = "quic_network_connection_lib",
-    srcs = ["quic_network_connection.cc"],
-    hdrs = ["quic_network_connection.h"],
-    deps = [
+    srcs = envoy_select_enable_http3(["quic_network_connection.cc"]),
+    hdrs = envoy_select_enable_http3(["quic_network_connection.h"]),
+    deps = envoy_select_enable_http3([
         "//envoy/network:connection_interface",
-    ],
+    ]),
 )
 
 envoy_cc_library(
     name = "envoy_quic_server_connection_lib",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_server_connection.cc"],
-    }),
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_server_connection.h"],
-    }),
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":quic_io_handle_wrapper_lib",
-            ":quic_network_connection_lib",
-            "//source/common/network:generic_listener_filter_impl_base_lib",
-            "//source/common/network:listen_socket_lib",
-            "//source/common/quic:envoy_quic_utils_lib",
-            "@com_github_google_quiche//:quic_core_connection_lib",
-            "@com_github_google_quiche//:quic_core_packet_writer_lib",
-            "@com_github_google_quiche//:quic_core_packets_lib",
-        ],
-    }),
+    srcs = envoy_select_enable_http3(["envoy_quic_server_connection.cc"]),
+    hdrs = envoy_select_enable_http3(["envoy_quic_server_connection.h"]),
+    deps = envoy_select_enable_http3([
+        ":quic_io_handle_wrapper_lib",
+        ":quic_network_connection_lib",
+        "//source/common/network:generic_listener_filter_impl_base_lib",
+        "//source/common/network:listen_socket_lib",
+        "//source/common/quic:envoy_quic_utils_lib",
+        "@com_github_google_quiche//:quic_core_connection_lib",
+        "@com_github_google_quiche//:quic_core_packet_writer_lib",
+        "@com_github_google_quiche//:quic_core_packets_lib",
+    ]),
 )
 
 envoy_cc_library(
     name = "envoy_quic_client_connection_lib",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_client_connection.cc"],
-    }),
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_client_connection.h"],
-    }),
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":envoy_quic_packet_writer_lib",
-            ":quic_network_connection_lib",
-            "//envoy/event:dispatcher_interface",
-            "//source/common/network:socket_option_factory_lib",
-            "//source/common/network:udp_packet_writer_handler_lib",
-            "//source/common/runtime:runtime_lib",
-            "@com_github_google_quiche//:quic_core_connection_lib",
-            "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
-        ],
-    }),
+    srcs = envoy_select_enable_http3(["envoy_quic_client_connection.cc"]),
+    hdrs = envoy_select_enable_http3(["envoy_quic_client_connection.h"]),
+    deps = envoy_select_enable_http3([
+        ":envoy_quic_packet_writer_lib",
+        ":quic_network_connection_lib",
+        "//envoy/event:dispatcher_interface",
+        "//source/common/network:socket_option_factory_lib",
+        "//source/common/network:udp_packet_writer_handler_lib",
+        "//source/common/runtime:runtime_lib",
+        "@com_github_google_quiche//:quic_core_connection_lib",
+        "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
+    ]),
 )
 
 envoy_cc_library(
     name = "envoy_quic_dispatcher_lib",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_dispatcher.cc"],
-    }),
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_dispatcher.h"],
-    }),
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":envoy_quic_connection_debug_visitor_factory_interface",
-            ":envoy_quic_proof_source_lib",
-            ":envoy_quic_server_connection_lib",
-            ":envoy_quic_server_crypto_stream_factory_lib",
-            ":envoy_quic_server_session_lib",
-            ":quic_stat_names_lib",
-            "//envoy/network:listener_interface",
-            "@com_github_google_quiche//:quic_core_server_lib",
-            "@com_github_google_quiche//:quic_core_utils_lib",
-        ],
-    }),
+    srcs = envoy_select_enable_http3(["envoy_quic_dispatcher.cc"]),
+    hdrs = envoy_select_enable_http3(["envoy_quic_dispatcher.h"]),
+    deps = envoy_select_enable_http3([
+        ":envoy_quic_connection_debug_visitor_factory_interface",
+        ":envoy_quic_proof_source_lib",
+        ":envoy_quic_server_connection_lib",
+        ":envoy_quic_server_crypto_stream_factory_lib",
+        ":envoy_quic_server_session_lib",
+        ":quic_stat_names_lib",
+        "//envoy/network:listener_interface",
+        "@com_github_google_quiche//:quic_core_server_lib",
+        "@com_github_google_quiche//:quic_core_utils_lib",
+    ]),
 )
 
 envoy_cc_library(
     name = "envoy_quic_simulated_watermark_buffer_lib",
-    hdrs = ["envoy_quic_simulated_watermark_buffer.h"],
-    deps = ["//source/common/common:assert_lib"],
+    hdrs = envoy_select_enable_http3(["envoy_quic_simulated_watermark_buffer.h"]),
+    deps = envoy_select_enable_http3(["//source/common/common:assert_lib"]),
 )
 
 envoy_cc_library(
     name = "active_quic_listener_lib",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["active_quic_listener.cc"],
-    }),
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["active_quic_listener.h"],
-    }),
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":envoy_quic_alarm_factory_lib",
-            ":envoy_quic_connection_debug_visitor_factory_interface",
-            ":envoy_quic_connection_helper_lib",
-            ":envoy_quic_dispatcher_lib",
-            ":envoy_quic_packet_writer_lib",
-            ":envoy_quic_proof_source_factory_interface",
-            ":envoy_quic_proof_source_lib",
-            ":envoy_quic_server_preferred_address_config_factory_interface",
-            ":envoy_quic_utils_lib",
-            "//envoy/network:listener_interface",
-            "//source/common/network:listener_lib",
-            "//source/common/protobuf:utility_lib",
-            "//source/common/runtime:runtime_lib",
-            "//source/extensions/quic/connection_id_generator/deterministic:envoy_deterministic_connection_id_generator_config",
-            "//source/server:active_udp_listener",
-            "@envoy_api//envoy/config/listener/v3:pkg_cc_proto",
-            "@envoy_api//envoy/extensions/quic/connection_id_generator/v3:pkg_cc_proto",
-            "@envoy_api//envoy/extensions/quic/crypto_stream/v3:pkg_cc_proto",
-            "@envoy_api//envoy/extensions/quic/proof_source/v3:pkg_cc_proto",
-        ],
-    }),
+    srcs = envoy_select_enable_http3(["active_quic_listener.cc"]),
+    hdrs = envoy_select_enable_http3(["active_quic_listener.h"]),
+    deps = envoy_select_enable_http3([
+        ":envoy_quic_alarm_factory_lib",
+        ":envoy_quic_connection_debug_visitor_factory_interface",
+        ":envoy_quic_connection_helper_lib",
+        ":envoy_quic_dispatcher_lib",
+        ":envoy_quic_packet_writer_lib",
+        ":envoy_quic_proof_source_factory_interface",
+        ":envoy_quic_proof_source_lib",
+        ":envoy_quic_server_preferred_address_config_factory_interface",
+        ":envoy_quic_utils_lib",
+        "//envoy/network:listener_interface",
+        "//source/common/network:listener_lib",
+        "//source/common/protobuf:utility_lib",
+        "//source/common/runtime:runtime_lib",
+        "//source/extensions/quic/connection_id_generator/deterministic:envoy_deterministic_connection_id_generator_config",
+        "//source/server:active_udp_listener",
+        "@envoy_api//envoy/config/listener/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/quic/connection_id_generator/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/quic/crypto_stream/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/quic/proof_source/v3:pkg_cc_proto",
+    ]),
 )
 
 envoy_cc_library(
     name = "envoy_quic_utils_lib",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_utils.cc"],
-    }),
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_utils.h"],
-    }),
+    srcs = envoy_select_enable_http3(["envoy_quic_utils.cc"]),
+    hdrs = envoy_select_enable_http3(["envoy_quic_utils.h"]),
     external_deps = ["ssl"],
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//envoy/http:codec_interface",
-            "//source/common/http:header_map_lib",
-            "//source/common/http:header_utility_lib",
-            "//source/common/network:address_lib",
-            "//source/common/network:connection_socket_lib",
-            "//source/common/network:socket_option_factory_lib",
-            "//source/common/protobuf:utility_lib",
-            "//source/common/quic:quic_io_handle_wrapper_lib",
-            "@com_github_google_quiche//:quic_core_config_lib",
-            "@com_github_google_quiche//:quic_core_http_header_list_lib",
-            "@com_github_google_quiche//:quic_platform",
-            "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
-            "@envoy_api//envoy/config/listener/v3:pkg_cc_proto",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        "//envoy/http:codec_interface",
+        "//source/common/http:header_map_lib",
+        "//source/common/http:header_utility_lib",
+        "//source/common/network:address_lib",
+        "//source/common/network:connection_socket_lib",
+        "//source/common/network:socket_option_factory_lib",
+        "//source/common/protobuf:utility_lib",
+        "//source/common/quic:quic_io_handle_wrapper_lib",
+        "@com_github_google_quiche//:quic_core_config_lib",
+        "@com_github_google_quiche//:quic_core_http_header_list_lib",
+        "@com_github_google_quiche//:quic_platform",
+        "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
+        "@envoy_api//envoy/config/listener/v3:pkg_cc_proto",
+    ]),
 )
 
 envoy_cc_library(
     name = "quic_transport_socket_factory_lib",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "quic_client_transport_socket_factory.cc",
-            "quic_transport_socket_factory.cc",
-        ],
-    }),
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "quic_client_transport_socket_factory.h",
-            "quic_transport_socket_factory.h",
-        ],
-    }),
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":envoy_quic_proof_verifier_lib",
-            "//envoy/network:transport_socket_interface",
-            "//envoy/server:transport_socket_config_interface",
-            "//envoy/ssl:context_config_interface",
-            "//source/common/common:assert_lib",
-            "//source/common/network:transport_socket_options_lib",
-            "//source/common/quic:cert_compression_lib",
-            "//source/common/tls:client_ssl_socket_lib",
-            "//source/common/tls:context_config_lib",
-            "@com_github_google_quiche//:quic_core_crypto_crypto_handshake_lib",
-            "@envoy_api//envoy/extensions/transport_sockets/quic/v3:pkg_cc_proto",
-        ],
-    }),
+    srcs = envoy_select_enable_http3([
+        "quic_client_transport_socket_factory.cc",
+        "quic_transport_socket_factory.cc",
+    ]),
+    hdrs = envoy_select_enable_http3([
+        "quic_client_transport_socket_factory.h",
+        "quic_transport_socket_factory.h",
+    ]),
+    deps = envoy_select_enable_http3([
+        ":envoy_quic_proof_verifier_lib",
+        "//envoy/network:transport_socket_interface",
+        "//envoy/server:transport_socket_config_interface",
+        "//envoy/ssl:context_config_interface",
+        "//source/common/common:assert_lib",
+        "//source/common/network:transport_socket_options_lib",
+        "//source/common/quic:cert_compression_lib",
+        "//source/common/tls:client_ssl_socket_lib",
+        "//source/common/tls:context_config_lib",
+        "@com_github_google_quiche//:quic_core_crypto_crypto_handshake_lib",
+        "@envoy_api//envoy/extensions/transport_sockets/quic/v3:pkg_cc_proto",
+    ]),
     alwayslink = LEGACY_ALWAYSLINK,
 )
 
 envoy_cc_library(
     name = "quic_server_transport_socket_factory_lib",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "quic_server_transport_socket_factory.cc",
-        ],
-    }),
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "quic_server_transport_socket_factory.h",
-        ],
-    }),
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":envoy_quic_proof_verifier_lib",
-            ":quic_transport_socket_factory_lib",
-            "//envoy/network:transport_socket_interface",
-            "//envoy/server:transport_socket_config_interface",
-            "//envoy/ssl:context_config_interface",
-            "//source/common/common:assert_lib",
-            "//source/common/network:transport_socket_options_lib",
-            "//source/common/tls:server_context_config_lib",
-            "//source/common/tls:server_context_lib",
-            "//source/common/tls:server_ssl_socket_lib",
-            "@com_github_google_quiche//:quic_core_crypto_crypto_handshake_lib",
-            "@envoy_api//envoy/extensions/transport_sockets/quic/v3:pkg_cc_proto",
-        ],
-    }),
+    srcs = envoy_select_enable_http3([
+        "quic_server_transport_socket_factory.cc",
+    ]),
+    hdrs = envoy_select_enable_http3([
+        "quic_server_transport_socket_factory.h",
+    ]),
+    deps = envoy_select_enable_http3([
+        ":envoy_quic_proof_verifier_lib",
+        ":quic_transport_socket_factory_lib",
+        "//envoy/network:transport_socket_interface",
+        "//envoy/server:transport_socket_config_interface",
+        "//envoy/ssl:context_config_interface",
+        "//source/common/common:assert_lib",
+        "//source/common/network:transport_socket_options_lib",
+        "//source/common/tls:server_context_config_lib",
+        "//source/common/tls:server_context_lib",
+        "//source/common/tls:server_ssl_socket_lib",
+        "@com_github_google_quiche//:quic_core_crypto_crypto_handshake_lib",
+        "@envoy_api//envoy/extensions/transport_sockets/quic/v3:pkg_cc_proto",
+    ]),
     alwayslink = LEGACY_ALWAYSLINK,
 )
 
@@ -733,61 +526,46 @@ envoy_cc_library(
 # All of these are needed for this extension to function.
 envoy_cc_library(
     name = "quic_client_factory_lib",
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":client_codec_lib",
-            ":quic_transport_socket_factory_lib",
-            "//source/extensions/quic/proof_source:envoy_quic_proof_source_factory_impl_lib",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        ":client_codec_lib",
+        ":quic_transport_socket_factory_lib",
+        "//source/extensions/quic/proof_source:envoy_quic_proof_source_factory_impl_lib",
+    ]),
 )
 
 # The factory for server connection creation.
 envoy_cc_library(
     name = "quic_server_factory_stub_lib",
-    hdrs = ["server_connection_factory.h"],
-    deps = [
+    hdrs = envoy_select_enable_http3(["server_connection_factory.h"]),
+    deps = envoy_select_enable_http3([
         "//envoy/http:codec_interface",
         "//envoy/network:connection_interface",
         "//source/common/http/http3:codec_stats_lib",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
-    ],
+    ]),
 )
 
 # Create a single target that contains all the libraries that register factories.
 # All of these are needed for this extension to function.
 envoy_cc_library(
     name = "quic_server_factory_lib",
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":quic_transport_socket_factory_lib",
-            ":server_codec_lib",
-            "//source/extensions/quic/crypto_stream:envoy_quic_crypto_server_stream_lib",
-            "//source/extensions/quic/proof_source:envoy_quic_proof_source_factory_impl_lib",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        ":quic_transport_socket_factory_lib",
+        ":server_codec_lib",
+        "//source/extensions/quic/crypto_stream:envoy_quic_crypto_server_stream_lib",
+        "//source/extensions/quic/proof_source:envoy_quic_proof_source_factory_impl_lib",
+    ]),
 )
 
 envoy_cc_library(
     name = "envoy_quic_packet_writer_lib",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_packet_writer.cc"],
-    }),
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_packet_writer.h"],
-    }),
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":envoy_quic_utils_lib",
-            "@com_github_google_quiche//:quic_core_packet_writer_lib",
-            "@com_github_google_quiche//:quic_platform",
-        ],
-    }),
+    srcs = envoy_select_enable_http3(["envoy_quic_packet_writer.cc"]),
+    hdrs = envoy_select_enable_http3(["envoy_quic_packet_writer.h"]),
+    deps = envoy_select_enable_http3([
+        ":envoy_quic_utils_lib",
+        "@com_github_google_quiche//:quic_core_packet_writer_lib",
+        "@com_github_google_quiche//:quic_platform",
+    ]),
 )
 
 envoy_cc_library(
@@ -796,21 +574,15 @@ envoy_cc_library(
         ":http3_enabled_and_linux": ["udp_gso_batch_writer.cc"],
         "//conditions:default": [],
     }),
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["udp_gso_batch_writer.h"],
-    }),
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":envoy_quic_utils_lib",
-            "//envoy/network:udp_packet_writer_handler_interface",
-            "//source/common/network:io_socket_error_lib",
-            "//source/common/protobuf:utility_lib",
-            "//source/common/runtime:runtime_lib",
-            "@com_github_google_quiche//:quic_platform",
-        ],
-    }) + select({
+    hdrs = envoy_select_enable_http3(["udp_gso_batch_writer.h"]),
+    deps = envoy_select_enable_http3([
+        ":envoy_quic_utils_lib",
+        "//envoy/network:udp_packet_writer_handler_interface",
+        "//source/common/network:io_socket_error_lib",
+        "//source/common/protobuf:utility_lib",
+        "//source/common/runtime:runtime_lib",
+        "@com_github_google_quiche//:quic_platform",
+    ]) + select({
         ":http3_enabled_and_linux": ["@com_github_google_quiche//:quic_core_batch_writer_gso_batch_writer_lib"],
         "//conditions:default": [],
     }),
@@ -818,189 +590,114 @@ envoy_cc_library(
 
 envoy_cc_library(
     name = "send_buffer_monitor_lib",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["send_buffer_monitor.cc"],
-    }),
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["send_buffer_monitor.h"],
-    }),
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//source/common/common:assert_lib",
-            "@com_github_google_quiche//:quic_core_session_lib",
-        ],
-    }),
+    srcs = envoy_select_enable_http3(["send_buffer_monitor.cc"]),
+    hdrs = envoy_select_enable_http3(["send_buffer_monitor.h"]),
+    deps = envoy_select_enable_http3([
+        "//source/common/common:assert_lib",
+        "@com_github_google_quiche//:quic_core_session_lib",
+    ]),
 )
 
 envoy_cc_library(
     name = "envoy_quic_client_crypto_stream_factory_lib",
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_client_crypto_stream_factory.h"],
-    }),
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//envoy/common:optref_lib",
-            "//envoy/config:typed_config_interface",
-            "//envoy/network:transport_socket_interface",
-            "@com_github_google_quiche//:quic_client_session_lib",
-            "@com_github_google_quiche//:quic_core_http_spdy_session_lib",
-        ],
-    }),
+    hdrs = envoy_select_enable_http3(["envoy_quic_client_crypto_stream_factory.h"]),
+    deps = envoy_select_enable_http3([
+        "//envoy/common:optref_lib",
+        "//envoy/config:typed_config_interface",
+        "//envoy/network:transport_socket_interface",
+        "@com_github_google_quiche//:quic_client_session_lib",
+        "@com_github_google_quiche//:quic_core_http_spdy_session_lib",
+    ]),
 )
 
 envoy_cc_library(
     name = "envoy_quic_server_crypto_stream_factory_lib",
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_server_crypto_stream_factory.h"],
-    }),
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//envoy/config:typed_config_interface",
-            "@com_github_google_quiche//:quic_core_http_spdy_session_lib",
-            "@com_github_google_quiche//:quic_server_session_lib",
-        ],
-    }),
+    hdrs = envoy_select_enable_http3(["envoy_quic_server_crypto_stream_factory.h"]),
+    deps = envoy_select_enable_http3([
+        "//envoy/config:typed_config_interface",
+        "@com_github_google_quiche//:quic_core_http_spdy_session_lib",
+        "@com_github_google_quiche//:quic_server_session_lib",
+    ]),
 )
 
 envoy_cc_library(
     name = "envoy_quic_proof_source_factory_interface",
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_proof_source_factory_interface.h"],
-    }),
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//envoy/config:typed_config_interface",
-            "@com_github_google_quiche//:quic_core_crypto_proof_source_lib",
-        ],
-    }),
+    hdrs = envoy_select_enable_http3(["envoy_quic_proof_source_factory_interface.h"]),
+    deps = envoy_select_enable_http3([
+        "//envoy/config:typed_config_interface",
+        "@com_github_google_quiche//:quic_core_crypto_proof_source_lib",
+    ]),
 )
 
 envoy_cc_library(
     name = "envoy_quic_connection_id_generator_factory_interface",
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_connection_id_generator_factory.h"],
-    }),
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//envoy/config:typed_config_interface",
-            "@com_github_google_quiche//:quic_core_connection_id_generator_interface_lib",
-            "@com_github_google_quiche//:quic_load_balancer_encoder_lib",
-        ],
-    }),
+    hdrs = envoy_select_enable_http3(["envoy_quic_connection_id_generator_factory.h"]),
+    deps = envoy_select_enable_http3([
+        "//envoy/config:typed_config_interface",
+        "@com_github_google_quiche//:quic_core_connection_id_generator_interface_lib",
+        "@com_github_google_quiche//:quic_load_balancer_encoder_lib",
+    ]),
 )
 
 envoy_cc_library(
     name = "envoy_deterministic_connection_id_generator_lib",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_deterministic_connection_id_generator.cc"],
-    }),
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_deterministic_connection_id_generator.h"],
-    }),
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":envoy_quic_connection_id_generator_factory_interface",
-            ":envoy_quic_utils_lib",
-            "@com_github_google_quiche//:quic_core_deterministic_connection_id_generator_lib",
-        ],
-    }),
+    srcs = envoy_select_enable_http3(["envoy_deterministic_connection_id_generator.cc"]),
+    hdrs = envoy_select_enable_http3(["envoy_deterministic_connection_id_generator.h"]),
+    deps = envoy_select_enable_http3([
+        ":envoy_quic_connection_id_generator_factory_interface",
+        ":envoy_quic_utils_lib",
+        "@com_github_google_quiche//:quic_core_deterministic_connection_id_generator_lib",
+    ]),
 )
 
 envoy_cc_library(
     name = "envoy_quic_server_preferred_address_config_factory_interface",
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_server_preferred_address_config_factory.h"],
-    }),
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//envoy/config:typed_config_interface",
-            "//envoy/network:address_interface",
-            "//envoy/server:factory_context_interface",
-            "@com_github_google_quiche//:quic_platform_socket_address",
-        ],
-    }),
+    hdrs = envoy_select_enable_http3(["envoy_quic_server_preferred_address_config_factory.h"]),
+    deps = envoy_select_enable_http3([
+        "//envoy/config:typed_config_interface",
+        "//envoy/network:address_interface",
+        "//envoy/server:factory_context_interface",
+        "@com_github_google_quiche//:quic_platform_socket_address",
+    ]),
 )
 
 envoy_cc_library(
     name = "quic_stats_gatherer",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["quic_stats_gatherer.cc"],
-    }),
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["quic_stats_gatherer.h"],
-    }),
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//envoy/access_log:access_log_interface",
-            "//envoy/formatter:http_formatter_context_interface",
-            "//envoy/http:codec_interface",
-            "//source/common/formatter:substitution_formatter_lib",
-            "//source/common/http:header_map_lib",
-            "@com_github_google_quiche//:quic_core_ack_listener_interface_lib",
-        ],
-    }),
+    srcs = envoy_select_enable_http3(["quic_stats_gatherer.cc"]),
+    hdrs = envoy_select_enable_http3(["quic_stats_gatherer.h"]),
+    deps = envoy_select_enable_http3([
+        "//envoy/access_log:access_log_interface",
+        "//envoy/formatter:http_formatter_context_interface",
+        "//envoy/http:codec_interface",
+        "//source/common/formatter:substitution_formatter_lib",
+        "//source/common/http:header_map_lib",
+        "@com_github_google_quiche//:quic_core_ack_listener_interface_lib",
+    ]),
 )
 
 envoy_cc_library(
     name = "http_datagram_handler",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["http_datagram_handler.cc"],
-    }),
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["http_datagram_handler.h"],
-    }),
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//envoy/http:codec_interface",
-            "//source/common/buffer:buffer_lib",
-            "//source/common/common:logger_lib",
-            "//source/common/http:header_map_lib",
-            "@com_github_google_quiche//:quic_core_http_spdy_session_lib",
-            "@com_github_google_quiche//:quic_core_types_lib",
-        ],
-    }),
+    srcs = envoy_select_enable_http3(["http_datagram_handler.cc"]),
+    hdrs = envoy_select_enable_http3(["http_datagram_handler.h"]),
+    deps = envoy_select_enable_http3([
+        "//envoy/http:codec_interface",
+        "//source/common/buffer:buffer_lib",
+        "//source/common/common:logger_lib",
+        "//source/common/http:header_map_lib",
+        "@com_github_google_quiche//:quic_core_http_spdy_session_lib",
+        "@com_github_google_quiche//:quic_core_types_lib",
+    ]),
 )
 
 envoy_cc_library(
     name = "cert_compression_lib",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["cert_compression.cc"],
-    }),
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["cert_compression.h"],
-    }),
+    srcs = envoy_select_enable_http3(["cert_compression.cc"]),
+    hdrs = envoy_select_enable_http3(["cert_compression.h"]),
     external_deps = ["ssl"],
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//bazel/foreign_cc:zlib",
-            "//source/common/common:assert_lib",
-            "//source/common/common:logger_lib",
-            "//source/common/runtime:runtime_lib",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        "//bazel/foreign_cc:zlib",
+        "//source/common/common:assert_lib",
+        "//source/common/common:logger_lib",
+        "//source/common/runtime:runtime_lib",
+    ]),
 )

--- a/source/extensions/filters/network/http_connection_manager/config.cc
+++ b/source/extensions/filters/network/http_connection_manager/config.cc
@@ -32,7 +32,10 @@
 #include "source/common/http/utility.h"
 #include "source/common/local_reply/local_reply.h"
 #include "source/common/protobuf/utility.h"
+
+#ifdef ENVOY_ENABLE_QUIC
 #include "source/common/quic/server_connection_factory.h"
+#endif
 #include "source/common/router/route_provider_manager.h"
 #include "source/common/runtime/runtime_impl.h"
 #include "source/common/tracing/custom_tag_impl.h"
@@ -772,6 +775,7 @@ Http::ServerConnectionPtr HttpConnectionManagerConfig::createCodec(
         maxRequestHeadersKb(), maxRequestHeadersCount(), headersWithUnderscoresAction(),
         overload_manager);
   case CodecType::HTTP3:
+#ifdef ENVOY_ENABLE_QUIC
     return Config::Utility::getAndCheckFactoryByName<QuicHttpServerConnectionFactory>(
                "quic.http_server_connection.default")
         .createQuicHttpServerConnectionImpl(
@@ -779,6 +783,11 @@ Http::ServerConnectionPtr HttpConnectionManagerConfig::createCodec(
             Http::Http3::CodecStats::atomicGet(http3_codec_stats_, context_.scope()),
             http3_options_, maxRequestHeadersKb(), maxRequestHeadersCount(),
             headersWithUnderscoresAction());
+#else
+    // Should be blocked by configuration checking at an earlier point.
+    PANIC("unexpected");
+#endif
+    break;
   case CodecType::AUTO:
     return Http::ConnectionManagerUtility::autoCreateCodec(
         connection, data, callbacks, context_.scope(),

--- a/source/extensions/quic/connection_debug_visitor/basic/BUILD
+++ b/source/extensions/quic/connection_debug_visitor/basic/BUILD
@@ -7,6 +7,7 @@ load(
     "envoy_cc_extension",
     "envoy_cc_library",
     "envoy_extension_package",
+    "envoy_select_enable_http3",
 )
 
 licenses(["notice"])  # Apache 2
@@ -17,32 +18,23 @@ envoy_extension_package()
 
 envoy_cc_library(
     name = "envoy_quic_connection_debug_visitor_basic_lib",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_connection_debug_visitor_basic.cc"],
-    }),
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_connection_debug_visitor_basic.h"],
-    }),
+    srcs = envoy_select_enable_http3(["envoy_quic_connection_debug_visitor_basic.cc"]),
+    hdrs = envoy_select_enable_http3(["envoy_quic_connection_debug_visitor_basic.h"]),
     visibility = [
         "//source/common/quic:__subpackages__",
     ],
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//envoy/registry",
-            "//envoy/stream_info:stream_info_interface",
-            "//source/common/common:minimal_logger_lib",
-            "//source/common/protobuf:utility_lib",
-            "//source/common/quic:envoy_quic_connection_debug_visitor_factory_interface",
-            "@com_github_google_quiche//:quic_core_connection_lib",
-            "@com_github_google_quiche//:quic_core_frames_frames_lib",
-            "@com_github_google_quiche//:quic_core_session_lib",
-            "@com_github_google_quiche//:quic_core_types_lib",
-            "@envoy_api//envoy/extensions/quic/connection_debug_visitor/v3:pkg_cc_proto",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        "//envoy/registry",
+        "//envoy/stream_info:stream_info_interface",
+        "//source/common/common:minimal_logger_lib",
+        "//source/common/protobuf:utility_lib",
+        "//source/common/quic:envoy_quic_connection_debug_visitor_factory_interface",
+        "@com_github_google_quiche//:quic_core_connection_lib",
+        "@com_github_google_quiche//:quic_core_frames_frames_lib",
+        "@com_github_google_quiche//:quic_core_session_lib",
+        "@com_github_google_quiche//:quic_core_types_lib",
+        "@envoy_api//envoy/extensions/quic/connection_debug_visitor/v3:pkg_cc_proto",
+    ]),
     alwayslink = LEGACY_ALWAYSLINK,
 )
 
@@ -52,10 +44,7 @@ envoy_cc_extension(
         "//source/common/quic:__subpackages__",
         "//test:__subpackages__",
     ],
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":envoy_quic_connection_debug_visitor_basic_lib",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        ":envoy_quic_connection_debug_visitor_basic_lib",
+    ]),
 )

--- a/source/extensions/quic/connection_debug_visitor/quic_stats/BUILD
+++ b/source/extensions/quic/connection_debug_visitor/quic_stats/BUILD
@@ -7,6 +7,7 @@ load(
     "envoy_cc_extension",
     "envoy_cc_library",
     "envoy_extension_package",
+    "envoy_select_enable_http3",
 )
 
 licenses(["notice"])  # Apache 2
@@ -15,26 +16,17 @@ envoy_extension_package()
 
 envoy_cc_library(
     name = "quic_stats_lib",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["quic_stats.cc"],
-    }),
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["quic_stats.h"],
-    }),
+    srcs = envoy_select_enable_http3(["quic_stats.cc"]),
+    hdrs = envoy_select_enable_http3(["quic_stats.h"]),
     visibility = [
         "//test:__subpackages__",
     ],
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//envoy/registry",
-            "//source/common/protobuf:utility_lib",
-            "//source/common/quic:envoy_quic_connection_debug_visitor_factory_interface",
-            "@envoy_api//envoy/extensions/quic/connection_debug_visitor/quic_stats/v3:pkg_cc_proto",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        "//envoy/registry",
+        "//source/common/protobuf:utility_lib",
+        "//source/common/quic:envoy_quic_connection_debug_visitor_factory_interface",
+        "@envoy_api//envoy/extensions/quic/connection_debug_visitor/quic_stats/v3:pkg_cc_proto",
+    ]),
     alwayslink = LEGACY_ALWAYSLINK,
 )
 
@@ -44,10 +36,7 @@ envoy_cc_extension(
         "//source/common/quic:__subpackages__",
         "//test:__subpackages__",
     ],
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":quic_stats_lib",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        ":quic_stats_lib",
+    ]),
 )

--- a/source/extensions/quic/connection_id_generator/deterministic/BUILD
+++ b/source/extensions/quic/connection_id_generator/deterministic/BUILD
@@ -7,6 +7,7 @@ load(
     "envoy_cc_extension",
     "envoy_cc_library",
     "envoy_extension_package",
+    "envoy_select_enable_http3",
 )
 
 licenses(["notice"])  # Apache 2
@@ -17,23 +18,14 @@ envoy_extension_package()
 
 envoy_cc_library(
     name = "envoy_deterministic_connection_id_generator_config_lib",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_deterministic_connection_id_generator_config.cc"],
-    }),
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_deterministic_connection_id_generator_config.h"],
-    }),
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//envoy/registry",
-            "//source/common/quic:envoy_deterministic_connection_id_generator_lib",
-            "//source/common/quic:envoy_quic_connection_id_generator_factory_interface",
-            "@envoy_api//envoy/extensions/quic/connection_id_generator/v3:pkg_cc_proto",
-        ],
-    }),
+    srcs = envoy_select_enable_http3(["envoy_deterministic_connection_id_generator_config.cc"]),
+    hdrs = envoy_select_enable_http3(["envoy_deterministic_connection_id_generator_config.h"]),
+    deps = envoy_select_enable_http3([
+        "//envoy/registry",
+        "//source/common/quic:envoy_deterministic_connection_id_generator_lib",
+        "//source/common/quic:envoy_quic_connection_id_generator_factory_interface",
+        "@envoy_api//envoy/extensions/quic/connection_id_generator/v3:pkg_cc_proto",
+    ]),
     alwayslink = LEGACY_ALWAYSLINK,
 )
 
@@ -42,10 +34,7 @@ envoy_cc_extension(
     extra_visibility = [
         "//source/common/quic:__subpackages__",
     ],
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":envoy_deterministic_connection_id_generator_config_lib",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        ":envoy_deterministic_connection_id_generator_config_lib",
+    ]),
 )

--- a/source/extensions/quic/connection_id_generator/quic_lb/BUILD
+++ b/source/extensions/quic/connection_id_generator/quic_lb/BUILD
@@ -7,6 +7,7 @@ load(
     "envoy_cc_extension",
     "envoy_cc_library",
     "envoy_extension_package",
+    "envoy_select_enable_http3",
 )
 
 licenses(["notice"])  # Apache 2
@@ -15,56 +16,35 @@ envoy_extension_package()
 
 envoy_cc_library(
     name = "quic_lb_lib",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["quic_lb.cc"],
-    }),
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["quic_lb.h"],
-    }),
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//source/common/config:datasource_lib",
-            "//source/common/quic:envoy_quic_connection_id_generator_factory_interface",
-            "//source/common/quic:envoy_quic_utils_lib",
-            "@com_github_google_quiche//:quic_load_balancer_config_lib",
-            "@com_github_google_quiche//:quic_load_balancer_encoder_lib",
-            "@com_github_google_quiche//:quic_load_balancer_server_id_lib",
-            "@envoy_api//envoy/extensions/quic/connection_id_generator/quic_lb/v3:pkg_cc_proto",
-        ],
-    }),
+    srcs = envoy_select_enable_http3(["quic_lb.cc"]),
+    hdrs = envoy_select_enable_http3(["quic_lb.h"]),
+    deps = envoy_select_enable_http3([
+        "//source/common/config:datasource_lib",
+        "//source/common/quic:envoy_quic_connection_id_generator_factory_interface",
+        "//source/common/quic:envoy_quic_utils_lib",
+        "@com_github_google_quiche//:quic_load_balancer_config_lib",
+        "@com_github_google_quiche//:quic_load_balancer_encoder_lib",
+        "@com_github_google_quiche//:quic_load_balancer_server_id_lib",
+        "@envoy_api//envoy/extensions/quic/connection_id_generator/quic_lb/v3:pkg_cc_proto",
+    ]),
 )
 
 envoy_cc_library(
     name = "config_lib",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["config.cc"],
-    }),
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["config.h"],
-    }),
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":quic_lb_lib",
-            "//envoy/registry",
-            "//source/common/quic:envoy_quic_connection_id_generator_factory_interface",
-            "@envoy_api//envoy/extensions/quic/connection_id_generator/quic_lb/v3:pkg_cc_proto",
-        ],
-    }),
+    srcs = envoy_select_enable_http3(["config.cc"]),
+    hdrs = envoy_select_enable_http3(["config.h"]),
+    deps = envoy_select_enable_http3([
+        ":quic_lb_lib",
+        "//envoy/registry",
+        "//source/common/quic:envoy_quic_connection_id_generator_factory_interface",
+        "@envoy_api//envoy/extensions/quic/connection_id_generator/quic_lb/v3:pkg_cc_proto",
+    ]),
     alwayslink = LEGACY_ALWAYSLINK,
 )
 
 envoy_cc_extension(
     name = "quic_lb_config",
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":config_lib",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        ":config_lib",
+    ]),
 )

--- a/source/extensions/quic/crypto_stream/BUILD
+++ b/source/extensions/quic/crypto_stream/BUILD
@@ -7,6 +7,7 @@ load(
     "envoy_cc_extension",
     "envoy_cc_library",
     "envoy_extension_package",
+    "envoy_select_enable_http3",
 )
 
 licenses(["notice"])  # Apache 2
@@ -17,26 +18,17 @@ envoy_extension_package()
 
 envoy_cc_library(
     name = "envoy_quic_crypto_server_stream_lib",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_crypto_server_stream.cc"],
-    }),
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_crypto_server_stream.h"],
-    }),
+    srcs = envoy_select_enable_http3(["envoy_quic_crypto_server_stream.cc"]),
+    hdrs = envoy_select_enable_http3(["envoy_quic_crypto_server_stream.h"]),
     visibility = [
         "//source/common/quic:__subpackages__",
         "//test:__subpackages__",
     ],
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//envoy/registry",
-            "//source/common/quic:envoy_quic_server_crypto_stream_factory_lib",
-            "@envoy_api//envoy/extensions/quic/crypto_stream/v3:pkg_cc_proto",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        "//envoy/registry",
+        "//source/common/quic:envoy_quic_server_crypto_stream_factory_lib",
+        "@envoy_api//envoy/extensions/quic/crypto_stream/v3:pkg_cc_proto",
+    ]),
     alwayslink = LEGACY_ALWAYSLINK,
 )
 
@@ -46,33 +38,21 @@ envoy_cc_extension(
         "//source/common/quic:__subpackages__",
         "//test:__subpackages__",
     ],
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":envoy_quic_crypto_server_stream_lib",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        ":envoy_quic_crypto_server_stream_lib",
+    ]),
 )
 
 envoy_cc_library(
     name = "envoy_quic_crypto_client_stream_lib",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_crypto_client_stream.cc"],
-    }),
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_crypto_client_stream.h"],
-    }),
+    srcs = envoy_select_enable_http3(["envoy_quic_crypto_client_stream.cc"]),
+    hdrs = envoy_select_enable_http3(["envoy_quic_crypto_client_stream.h"]),
     visibility = [
         "//source/common/quic:__subpackages__",
         "//test:__subpackages__",
     ],
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//source/common/quic:envoy_quic_client_crypto_stream_factory_lib",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        "//source/common/quic:envoy_quic_client_crypto_stream_factory_lib",
+    ]),
     alwayslink = LEGACY_ALWAYSLINK,
 )

--- a/source/extensions/quic/proof_source/BUILD
+++ b/source/extensions/quic/proof_source/BUILD
@@ -7,6 +7,7 @@ load(
     "envoy_cc_extension",
     "envoy_cc_library",
     "envoy_extension_package",
+    "envoy_select_enable_http3",
 )
 
 licenses(["notice"])  # Apache 2
@@ -17,26 +18,17 @@ envoy_extension_package()
 
 envoy_cc_library(
     name = "envoy_quic_proof_source_factory_impl_lib",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_proof_source_factory_impl.cc"],
-    }),
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_proof_source_factory_impl.h"],
-    }),
+    srcs = envoy_select_enable_http3(["envoy_quic_proof_source_factory_impl.cc"]),
+    hdrs = envoy_select_enable_http3(["envoy_quic_proof_source_factory_impl.h"]),
     visibility = [
         "//source/common/quic:__subpackages__",
         "//test:__subpackages__",
     ],
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//source/common/quic:envoy_quic_proof_source_factory_interface",
-            "//source/common/quic:envoy_quic_proof_source_lib",
-            "@envoy_api//envoy/extensions/quic/proof_source/v3:pkg_cc_proto",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        "//source/common/quic:envoy_quic_proof_source_factory_interface",
+        "//source/common/quic:envoy_quic_proof_source_lib",
+        "@envoy_api//envoy/extensions/quic/proof_source/v3:pkg_cc_proto",
+    ]),
     alwayslink = LEGACY_ALWAYSLINK,
 )
 
@@ -46,10 +38,7 @@ envoy_cc_extension(
         "//source/common/quic:__subpackages__",
         "//test:__subpackages__",
     ],
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":envoy_quic_proof_source_factory_impl_lib",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        ":envoy_quic_proof_source_factory_impl_lib",
+    ]),
 )

--- a/source/extensions/quic/server_preferred_address/BUILD
+++ b/source/extensions/quic/server_preferred_address/BUILD
@@ -7,6 +7,7 @@ load(
     "envoy_cc_extension",
     "envoy_cc_library",
     "envoy_extension_package",
+    "envoy_select_enable_http3",
 )
 
 licenses(["notice"])  # Apache 2
@@ -17,42 +18,24 @@ envoy_extension_package()
 
 envoy_cc_library(
     name = "server_preferred_address_lib",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["server_preferred_address.cc"],
-    }),
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["server_preferred_address.h"],
-    }),
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//source/common/quic:envoy_quic_server_preferred_address_config_factory_interface",
-        ],
-    }),
+    srcs = envoy_select_enable_http3(["server_preferred_address.cc"]),
+    hdrs = envoy_select_enable_http3(["server_preferred_address.h"]),
+    deps = envoy_select_enable_http3([
+        "//source/common/quic:envoy_quic_server_preferred_address_config_factory_interface",
+    ]),
 )
 
 envoy_cc_library(
     name = "fixed_server_preferred_address_config_lib",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["fixed_server_preferred_address_config.cc"],
-    }),
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["fixed_server_preferred_address_config.h"],
-    }),
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":server_preferred_address_lib",
-            "//envoy/registry",
-            "//source/common/quic:envoy_quic_server_preferred_address_config_factory_interface",
-            "//source/common/quic:envoy_quic_utils_lib",
-            "@envoy_api//envoy/extensions/quic/server_preferred_address/v3:pkg_cc_proto",
-        ],
-    }),
+    srcs = envoy_select_enable_http3(["fixed_server_preferred_address_config.cc"]),
+    hdrs = envoy_select_enable_http3(["fixed_server_preferred_address_config.h"]),
+    deps = envoy_select_enable_http3([
+        ":server_preferred_address_lib",
+        "//envoy/registry",
+        "//source/common/quic:envoy_quic_server_preferred_address_config_factory_interface",
+        "//source/common/quic:envoy_quic_utils_lib",
+        "@envoy_api//envoy/extensions/quic/server_preferred_address/v3:pkg_cc_proto",
+    ]),
     alwayslink = LEGACY_ALWAYSLINK,
 )
 
@@ -61,44 +44,29 @@ envoy_cc_extension(
     extra_visibility = [
         "//test:__subpackages__",
     ],
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":fixed_server_preferred_address_config_lib",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        ":fixed_server_preferred_address_config_lib",
+    ]),
 )
 
 envoy_cc_library(
     name = "datasource_server_preferred_address_config_lib",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["datasource_server_preferred_address_config.cc"],
-    }),
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["datasource_server_preferred_address_config.h"],
-    }),
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":server_preferred_address_lib",
-            "//envoy/registry",
-            "//source/common/config:datasource_lib",
-            "//source/common/quic:envoy_quic_server_preferred_address_config_factory_interface",
-            "//source/common/quic:envoy_quic_utils_lib",
-            "@envoy_api//envoy/extensions/quic/server_preferred_address/v3:pkg_cc_proto",
-        ],
-    }),
+    srcs = envoy_select_enable_http3(["datasource_server_preferred_address_config.cc"]),
+    hdrs = envoy_select_enable_http3(["datasource_server_preferred_address_config.h"]),
+    deps = envoy_select_enable_http3([
+        ":server_preferred_address_lib",
+        "//envoy/registry",
+        "//source/common/config:datasource_lib",
+        "//source/common/quic:envoy_quic_server_preferred_address_config_factory_interface",
+        "//source/common/quic:envoy_quic_utils_lib",
+        "@envoy_api//envoy/extensions/quic/server_preferred_address/v3:pkg_cc_proto",
+    ]),
     alwayslink = LEGACY_ALWAYSLINK,
 )
 
 envoy_cc_extension(
     name = "datasource_server_preferred_address_config_factory_config",
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":datasource_server_preferred_address_config_lib",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        ":datasource_server_preferred_address_config_lib",
+    ]),
 )

--- a/test/common/listener_manager/BUILD
+++ b/test/common/listener_manager/BUILD
@@ -6,6 +6,7 @@ load(
     "envoy_cc_test_library",
     "envoy_package",
     "envoy_proto_library",
+    "envoy_select_enable_http3",
 )
 
 licenses(["notice"])  # Apache 2
@@ -110,31 +111,25 @@ envoy_cc_test(
 # Stand-alone quic test because of FIPS.
 envoy_cc_test(
     name = "listener_manager_impl_quic_only_test",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["listener_manager_impl_quic_only_test.cc"],
-    }),
+    srcs = envoy_select_enable_http3(["listener_manager_impl_quic_only_test.cc"]),
     rbe_pool = "6gig",
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":listener_manager_impl_test_lib",
-            "//source/common/formatter:formatter_extension_lib",
-            "//source/extensions/filters/http/router:config",
-            "//source/extensions/filters/network/http_connection_manager:config",
-            "//source/extensions/matching/network/common:inputs_lib",
-            "//source/extensions/quic/server_preferred_address:fixed_server_preferred_address_config_factory_config",
-            "//source/extensions/request_id/uuid:config",
-            "//source/extensions/transport_sockets/raw_buffer:config",
-            "//source/extensions/transport_sockets/tls:config",
-            "//test/integration/filters:test_listener_filter_lib",
-            "//test/integration/filters:test_network_filter_lib",
-            "//test/server:utility_lib",
-            "//test/test_common:threadsafe_singleton_injector_lib",
-            "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
-            "@envoy_api//envoy/config/listener/v3:pkg_cc_proto",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        ":listener_manager_impl_test_lib",
+        "//source/common/formatter:formatter_extension_lib",
+        "//source/extensions/filters/http/router:config",
+        "//source/extensions/filters/network/http_connection_manager:config",
+        "//source/extensions/matching/network/common:inputs_lib",
+        "//source/extensions/quic/server_preferred_address:fixed_server_preferred_address_config_factory_config",
+        "//source/extensions/request_id/uuid:config",
+        "//source/extensions/transport_sockets/raw_buffer:config",
+        "//source/extensions/transport_sockets/tls:config",
+        "//test/integration/filters:test_listener_filter_lib",
+        "//test/integration/filters:test_network_filter_lib",
+        "//test/server:utility_lib",
+        "//test/test_common:threadsafe_singleton_injector_lib",
+        "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
+        "@envoy_api//envoy/config/listener/v3:pkg_cc_proto",
+    ]),
 )
 
 envoy_cc_test(

--- a/test/common/network/BUILD
+++ b/test/common/network/BUILD
@@ -7,6 +7,7 @@ load(
     "envoy_cc_test_library",
     "envoy_package",
     "envoy_proto_library",
+    "envoy_select_enable_http3",
 )
 
 licenses(["notice"])  # Apache 2
@@ -273,37 +274,31 @@ envoy_cc_test(
 
 envoy_cc_test(
     name = "udp_listener_impl_batch_writer_test",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["udp_listener_impl_batch_writer_test.cc"],
-    }),
+    srcs = envoy_select_enable_http3(["udp_listener_impl_batch_writer_test.cc"]),
     rbe_pool = "6gig",
     # Skipping as quiche quic_gso_batch_writer.h does not exist on Windows
     tags = [
         "skip_on_windows",
     ],
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":udp_listener_impl_test_base_lib",
-            "//source/common/event:dispatcher_lib",
-            "//source/common/network:address_lib",
-            "//source/common/network:listener_lib",
-            "//source/common/network:socket_option_lib",
-            "//source/common/network:udp_packet_writer_handler_lib",
-            "//source/common/network:utility_lib",
-            "//source/common/quic:udp_gso_batch_writer_lib",
-            "//source/common/stats:stats_lib",
-            "//test/common/network:listener_impl_test_base_lib",
-            "//test/mocks/network:network_mocks",
-            "//test/test_common:environment_lib",
-            "//test/test_common:network_utility_lib",
-            "//test/test_common:threadsafe_singleton_injector_lib",
-            "//test/test_common:utility_lib",
-            "@com_github_google_quiche//:quic_test_tools_mock_syscall_wrapper_lib",
-            "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        ":udp_listener_impl_test_base_lib",
+        "//source/common/event:dispatcher_lib",
+        "//source/common/network:address_lib",
+        "//source/common/network:listener_lib",
+        "//source/common/network:socket_option_lib",
+        "//source/common/network:udp_packet_writer_handler_lib",
+        "//source/common/network:utility_lib",
+        "//source/common/quic:udp_gso_batch_writer_lib",
+        "//source/common/stats:stats_lib",
+        "//test/common/network:listener_impl_test_base_lib",
+        "//test/mocks/network:network_mocks",
+        "//test/test_common:environment_lib",
+        "//test/test_common:network_utility_lib",
+        "//test/test_common:threadsafe_singleton_injector_lib",
+        "//test/test_common:utility_lib",
+        "@com_github_google_quiche//:quic_test_tools_mock_syscall_wrapper_lib",
+        "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
+    ]),
 )
 
 envoy_cc_test(

--- a/test/common/quic/BUILD
+++ b/test/common/quic/BUILD
@@ -14,353 +14,269 @@ envoy_package()
 
 envoy_cc_test(
     name = "envoy_quic_alarm_test",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_alarm_test.cc"],
-    }),
+    srcs = envoy_select_enable_http3(["envoy_quic_alarm_test.cc"]),
     rbe_pool = "6gig",
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//source/common/quic:envoy_quic_alarm_factory_lib",
-            "//source/common/quic:envoy_quic_alarm_lib",
-            "//source/common/quic:envoy_quic_clock_lib",
-            "//test/test_common:simulated_time_system_lib",
-            "//test/test_common:utility_lib",
-            "@com_github_google_quiche//:quic_platform",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        "//source/common/quic:envoy_quic_alarm_factory_lib",
+        "//source/common/quic:envoy_quic_alarm_lib",
+        "//source/common/quic:envoy_quic_clock_lib",
+        "//test/test_common:simulated_time_system_lib",
+        "//test/test_common:utility_lib",
+        "@com_github_google_quiche//:quic_platform",
+    ]),
 )
 
 envoy_cc_test(
     name = "envoy_quic_clock_test",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_clock_test.cc"],
-    }),
+    srcs = envoy_select_enable_http3(["envoy_quic_clock_test.cc"]),
     rbe_pool = "6gig",
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//source/common/quic:envoy_quic_clock_lib",
-            "//test/test_common:simulated_time_system_lib",
-            "//test/test_common:test_time_lib",
-            "//test/test_common:utility_lib",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        "//source/common/quic:envoy_quic_clock_lib",
+        "//test/test_common:simulated_time_system_lib",
+        "//test/test_common:test_time_lib",
+        "//test/test_common:utility_lib",
+    ]),
 )
 
 envoy_cc_test(
     name = "envoy_quic_writer_test",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_writer_test.cc"],
-    }),
+    srcs = envoy_select_enable_http3(["envoy_quic_writer_test.cc"]),
     rbe_pool = "6gig",
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//source/common/network:io_socket_error_lib",
-            "//source/common/network:udp_packet_writer_handler_lib",
-            "//source/common/quic:envoy_quic_packet_writer_lib",
-            "//test/mocks/api:api_mocks",
-            "//test/mocks/network:network_mocks",
-            "//test/test_common:threadsafe_singleton_injector_lib",
-            "@com_github_google_quiche//:quic_platform",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        "//source/common/network:io_socket_error_lib",
+        "//source/common/network:udp_packet_writer_handler_lib",
+        "//source/common/quic:envoy_quic_packet_writer_lib",
+        "//test/mocks/api:api_mocks",
+        "//test/mocks/network:network_mocks",
+        "//test/test_common:threadsafe_singleton_injector_lib",
+        "@com_github_google_quiche//:quic_platform",
+    ]),
 )
 
 envoy_cc_test(
     name = "envoy_quic_proof_source_test",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_proof_source_test.cc"],
-    }),
+    srcs = envoy_select_enable_http3(["envoy_quic_proof_source_test.cc"]),
     rbe_pool = "6gig",
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":test_utils_lib",
-            "//source/common/quic:envoy_quic_proof_source_lib",
-            "//source/common/quic:envoy_quic_proof_verifier_lib",
-            "//source/common/tls:context_config_lib",
-            "//source/common/tls:server_context_lib",
-            "//test/mocks/network:network_mocks",
-            "//test/mocks/server:server_factory_context_mocks",
-            "//test/mocks/ssl:ssl_mocks",
-            "//test/test_common:test_runtime_lib",
-            "@com_github_google_quiche//:quic_core_versions_lib",
-            "@com_github_google_quiche//:quic_platform",
-            "@com_github_google_quiche//:quic_test_tools_test_certificates_lib",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        ":test_utils_lib",
+        "//source/common/quic:envoy_quic_proof_source_lib",
+        "//source/common/quic:envoy_quic_proof_verifier_lib",
+        "//source/common/tls:context_config_lib",
+        "//source/common/tls:server_context_lib",
+        "//test/mocks/network:network_mocks",
+        "//test/mocks/server:server_factory_context_mocks",
+        "//test/mocks/ssl:ssl_mocks",
+        "//test/test_common:test_runtime_lib",
+        "@com_github_google_quiche//:quic_core_versions_lib",
+        "@com_github_google_quiche//:quic_platform",
+        "@com_github_google_quiche//:quic_test_tools_test_certificates_lib",
+    ]),
 )
 
 envoy_cc_test(
     name = "quic_filter_manager_connection_impl_test",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["quic_filter_manager_connection_impl_test.cc"],
-    }),
+    srcs = envoy_select_enable_http3(["quic_filter_manager_connection_impl_test.cc"]),
     rbe_pool = "6gig",
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//source/common/quic:quic_filter_manager_connection_lib",
-            "//test/mocks/event:event_mocks",
-            "//test/mocks/network:network_mocks",
-            "//test/test_common:utility_lib",
-            "@com_github_google_quiche//:quic_test_tools_test_utils_lib",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        "//source/common/quic:quic_filter_manager_connection_lib",
+        "//test/mocks/event:event_mocks",
+        "//test/mocks/network:network_mocks",
+        "//test/test_common:utility_lib",
+        "@com_github_google_quiche//:quic_test_tools_test_utils_lib",
+    ]),
 )
 
 envoy_cc_test(
     name = "quic_stat_names_test",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["quic_stat_names_test.cc"],
-    }),
+    srcs = envoy_select_enable_http3(["quic_stat_names_test.cc"]),
     rbe_pool = "6gig",
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//source/common/quic:quic_stat_names_lib",
-            "//source/common/stats:stats_lib",
-            "//test/mocks/stats:stats_mocks",
-            "//test/test_common:utility_lib",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        "//source/common/quic:quic_stat_names_lib",
+        "//source/common/stats:stats_lib",
+        "//test/mocks/stats:stats_mocks",
+        "//test/test_common:utility_lib",
+    ]),
 )
 
 envoy_cc_test(
     name = "envoy_quic_proof_verifier_test",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_proof_verifier_test.cc"],
-    }),
+    srcs = envoy_select_enable_http3(["envoy_quic_proof_verifier_test.cc"]),
     rbe_pool = "6gig",
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":test_utils_lib",
-            "//source/common/quic:envoy_quic_proof_verifier_lib",
-            "//source/common/tls:context_config_lib",
-            "//test/common/config:dummy_config_proto_cc_proto",
-            "//test/common/tls/cert_validator:timed_cert_validator",
-            "//test/mocks/event:event_mocks",
-            "//test/mocks/server:server_factory_context_mocks",
-            "//test/mocks/ssl:ssl_mocks",
-            "@com_github_google_quiche//:quic_platform",
-            "@com_github_google_quiche//:quic_test_tools_test_certificates_lib",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        ":test_utils_lib",
+        "//source/common/quic:envoy_quic_proof_verifier_lib",
+        "//source/common/tls:context_config_lib",
+        "//test/common/config:dummy_config_proto_cc_proto",
+        "//test/common/tls/cert_validator:timed_cert_validator",
+        "//test/mocks/event:event_mocks",
+        "//test/mocks/server:server_factory_context_mocks",
+        "//test/mocks/ssl:ssl_mocks",
+        "@com_github_google_quiche//:quic_platform",
+        "@com_github_google_quiche//:quic_test_tools_test_certificates_lib",
+    ]),
 )
 
 envoy_cc_test(
     name = "envoy_quic_server_stream_test",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_server_stream_test.cc"],
-    }),
+    srcs = envoy_select_enable_http3(["envoy_quic_server_stream_test.cc"]),
     rbe_pool = "6gig",
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":test_utils_lib",
-            "//source/common/http:headers_lib",
-            "//source/common/quic:envoy_quic_alarm_factory_lib",
-            "//source/common/quic:envoy_quic_connection_helper_lib",
-            "//source/common/quic:envoy_quic_server_connection_lib",
-            "//source/common/quic:envoy_quic_server_session_lib",
-            "//source/server:active_listener_base",
-            "//test/mocks/http:http_mocks",
-            "//test/mocks/http:stream_decoder_mock",
-            "//test/mocks/network:network_mocks",
-            "//test/test_common:utility_lib",
-            "@com_github_google_quiche//:quic_core_http_spdy_session_lib",
-            "@com_github_google_quiche//:quic_test_tools_qpack_qpack_test_utils_lib",
-            "@com_github_google_quiche//:quic_test_tools_session_peer_lib",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        ":test_utils_lib",
+        "//source/common/http:headers_lib",
+        "//source/common/quic:envoy_quic_alarm_factory_lib",
+        "//source/common/quic:envoy_quic_connection_helper_lib",
+        "//source/common/quic:envoy_quic_server_connection_lib",
+        "//source/common/quic:envoy_quic_server_session_lib",
+        "//source/server:active_listener_base",
+        "//test/mocks/http:http_mocks",
+        "//test/mocks/http:stream_decoder_mock",
+        "//test/mocks/network:network_mocks",
+        "//test/test_common:utility_lib",
+        "@com_github_google_quiche//:quic_core_http_spdy_session_lib",
+        "@com_github_google_quiche//:quic_test_tools_qpack_qpack_test_utils_lib",
+        "@com_github_google_quiche//:quic_test_tools_session_peer_lib",
+    ]),
 )
 
 envoy_cc_test(
     name = "envoy_quic_client_stream_test",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_client_stream_test.cc"],
-    }),
+    srcs = envoy_select_enable_http3(["envoy_quic_client_stream_test.cc"]),
     rbe_pool = "6gig",
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":test_utils_lib",
-            "//source/common/http:headers_lib",
-            "//source/common/quic:envoy_quic_alarm_factory_lib",
-            "//source/common/quic:envoy_quic_client_connection_lib",
-            "//source/common/quic:envoy_quic_client_session_lib",
-            "//source/common/quic:envoy_quic_connection_helper_lib",
-            "//test/mocks/http:http_mocks",
-            "//test/mocks/http:stream_decoder_mock",
-            "//test/mocks/network:network_mocks",
-            "//test/test_common:utility_lib",
-            "@com_github_google_quiche//:quic_core_http_spdy_session_lib",
-            "@com_github_google_quiche//:quic_test_tools_qpack_qpack_test_utils_lib",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        ":test_utils_lib",
+        "//source/common/http:headers_lib",
+        "//source/common/quic:envoy_quic_alarm_factory_lib",
+        "//source/common/quic:envoy_quic_client_connection_lib",
+        "//source/common/quic:envoy_quic_client_session_lib",
+        "//source/common/quic:envoy_quic_connection_helper_lib",
+        "//test/mocks/http:http_mocks",
+        "//test/mocks/http:stream_decoder_mock",
+        "//test/mocks/network:network_mocks",
+        "//test/test_common:utility_lib",
+        "@com_github_google_quiche//:quic_core_http_spdy_session_lib",
+        "@com_github_google_quiche//:quic_test_tools_qpack_qpack_test_utils_lib",
+    ]),
 )
 
 envoy_cc_test(
     name = "envoy_quic_server_session_test",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_server_session_test.cc"],
-    }),
+    srcs = envoy_select_enable_http3(["envoy_quic_server_session_test.cc"]),
     rbe_pool = "6gig",
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":test_proof_source_lib",
-            ":test_utils_lib",
-            "//envoy/stats:stats_macros",
-            "//source/common/quic:envoy_quic_alarm_factory_lib",
-            "//source/common/quic:envoy_quic_connection_helper_lib",
-            "//source/common/quic:envoy_quic_server_connection_lib",
-            "//source/common/quic:envoy_quic_server_session_lib",
-            "//source/common/quic:server_codec_lib",
-            "//source/server:configuration_lib",
-            "//test/mocks/event:event_mocks",
-            "//test/mocks/http:http_mocks",
-            "//test/mocks/http:stream_decoder_mock",
-            "//test/mocks/network:network_mocks",
-            "//test/mocks/stats:stats_mocks",
-            "//test/test_common:global_lib",
-            "//test/test_common:logging_lib",
-            "//test/test_common:simulated_time_system_lib",
-            "@com_github_google_quiche//:quic_test_tools_config_peer_lib",
-            "@com_github_google_quiche//:quic_test_tools_server_session_base_peer",
-            "@com_github_google_quiche//:quic_test_tools_test_utils_lib",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        ":test_proof_source_lib",
+        ":test_utils_lib",
+        "//envoy/stats:stats_macros",
+        "//source/common/quic:envoy_quic_alarm_factory_lib",
+        "//source/common/quic:envoy_quic_connection_helper_lib",
+        "//source/common/quic:envoy_quic_server_connection_lib",
+        "//source/common/quic:envoy_quic_server_session_lib",
+        "//source/common/quic:server_codec_lib",
+        "//source/server:configuration_lib",
+        "//test/mocks/event:event_mocks",
+        "//test/mocks/http:http_mocks",
+        "//test/mocks/http:stream_decoder_mock",
+        "//test/mocks/network:network_mocks",
+        "//test/mocks/stats:stats_mocks",
+        "//test/test_common:global_lib",
+        "//test/test_common:logging_lib",
+        "//test/test_common:simulated_time_system_lib",
+        "@com_github_google_quiche//:quic_test_tools_config_peer_lib",
+        "@com_github_google_quiche//:quic_test_tools_server_session_base_peer",
+        "@com_github_google_quiche//:quic_test_tools_test_utils_lib",
+    ]),
 )
 
 envoy_cc_test(
     name = "envoy_quic_client_session_test",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_client_session_test.cc"],
-    }),
+    srcs = envoy_select_enable_http3(["envoy_quic_client_session_test.cc"]),
     rbe_pool = "6gig",
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":test_utils_lib",
-            "//envoy/stats:stats_macros",
-            "//source/common/api:os_sys_calls_lib",
-            "//source/common/quic:client_codec_lib",
-            "//source/common/quic:envoy_quic_alarm_factory_lib",
-            "//source/common/quic:envoy_quic_client_connection_lib",
-            "//source/common/quic:envoy_quic_client_session_lib",
-            "//source/common/quic:envoy_quic_connection_helper_lib",
-            "//source/extensions/quic/crypto_stream:envoy_quic_crypto_client_stream_lib",
-            "//test/mocks/api:api_mocks",
-            "//test/mocks/http:http_mocks",
-            "//test/mocks/http:stream_decoder_mock",
-            "//test/mocks/network:network_mocks",
-            "//test/mocks/stats:stats_mocks",
-            "//test/test_common:logging_lib",
-            "//test/test_common:simulated_time_system_lib",
-            "//test/test_common:test_runtime_lib",
-            "//test/test_common:threadsafe_singleton_injector_lib",
-            "@com_github_google_quiche//:quic_test_tools_session_peer_lib",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        ":test_utils_lib",
+        "//envoy/stats:stats_macros",
+        "//source/common/api:os_sys_calls_lib",
+        "//source/common/quic:client_codec_lib",
+        "//source/common/quic:envoy_quic_alarm_factory_lib",
+        "//source/common/quic:envoy_quic_client_connection_lib",
+        "//source/common/quic:envoy_quic_client_session_lib",
+        "//source/common/quic:envoy_quic_connection_helper_lib",
+        "//source/extensions/quic/crypto_stream:envoy_quic_crypto_client_stream_lib",
+        "//test/mocks/api:api_mocks",
+        "//test/mocks/http:http_mocks",
+        "//test/mocks/http:stream_decoder_mock",
+        "//test/mocks/network:network_mocks",
+        "//test/mocks/stats:stats_mocks",
+        "//test/test_common:logging_lib",
+        "//test/test_common:simulated_time_system_lib",
+        "//test/test_common:test_runtime_lib",
+        "//test/test_common:threadsafe_singleton_injector_lib",
+        "@com_github_google_quiche//:quic_test_tools_session_peer_lib",
+    ]),
 )
 
 envoy_cc_test(
     name = "active_quic_listener_test",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["active_quic_listener_test.cc"],
-    }),
+    srcs = envoy_select_enable_http3(["active_quic_listener_test.cc"]),
     rbe_pool = "6gig",
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":test_proof_source_lib",
-            ":test_utils_lib",
-            "//source/common/http:utility_lib",
-            "//source/common/listener_manager:connection_handler_lib",
-            "//source/common/network:udp_packet_writer_handler_lib",
-            "//source/common/quic:active_quic_listener_lib",
-            "//source/common/quic:envoy_quic_utils_lib",
-            "//source/common/quic:udp_gso_batch_writer_lib",
-            "//source/extensions/quic/crypto_stream:envoy_quic_crypto_server_stream_lib",
-            "//source/extensions/quic/proof_source:envoy_quic_proof_source_factory_impl_lib",
-            "//source/server:configuration_lib",
-            "//source/server:process_context_lib",
-            "//test/mocks/network:network_mocks",
-            "//test/mocks/server:instance_mocks",
-            "//test/mocks/server:listener_factory_context_mocks",
-            "//test/test_common:network_utility_lib",
-            "//test/test_common:simulated_time_system_lib",
-            "//test/test_common:test_runtime_lib",
-            "@com_github_google_quiche//:quic_test_tools_crypto_server_config_peer_lib",
-            "@envoy_api//envoy/config/listener/v3:pkg_cc_proto",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        ":test_proof_source_lib",
+        ":test_utils_lib",
+        "//source/common/http:utility_lib",
+        "//source/common/listener_manager:connection_handler_lib",
+        "//source/common/network:udp_packet_writer_handler_lib",
+        "//source/common/quic:active_quic_listener_lib",
+        "//source/common/quic:envoy_quic_utils_lib",
+        "//source/common/quic:udp_gso_batch_writer_lib",
+        "//source/extensions/quic/crypto_stream:envoy_quic_crypto_server_stream_lib",
+        "//source/extensions/quic/proof_source:envoy_quic_proof_source_factory_impl_lib",
+        "//source/server:configuration_lib",
+        "//source/server:process_context_lib",
+        "//test/mocks/network:network_mocks",
+        "//test/mocks/server:instance_mocks",
+        "//test/mocks/server:listener_factory_context_mocks",
+        "//test/test_common:network_utility_lib",
+        "//test/test_common:simulated_time_system_lib",
+        "//test/test_common:test_runtime_lib",
+        "@com_github_google_quiche//:quic_test_tools_crypto_server_config_peer_lib",
+        "@envoy_api//envoy/config/listener/v3:pkg_cc_proto",
+    ]),
 )
 
 envoy_cc_test(
     name = "envoy_quic_dispatcher_test",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_dispatcher_test.cc"],
-    }),
+    srcs = envoy_select_enable_http3(["envoy_quic_dispatcher_test.cc"]),
     rbe_pool = "6gig",
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":test_proof_source_lib",
-            ":test_utils_lib",
-            "//envoy/stats:stats_macros",
-            "//source/common/listener_manager:connection_handler_lib",
-            "//source/common/quic:envoy_quic_alarm_factory_lib",
-            "//source/common/quic:envoy_quic_connection_helper_lib",
-            "//source/common/quic:envoy_quic_dispatcher_lib",
-            "//source/common/quic:envoy_quic_proof_source_lib",
-            "//source/common/quic:envoy_quic_server_session_lib",
-            "//source/common/quic:quic_server_transport_socket_factory_lib",
-            "//source/extensions/quic/crypto_stream:envoy_quic_crypto_server_stream_lib",
-            "//source/server:configuration_lib",
-            "//test/mocks/event:event_mocks",
-            "//test/mocks/http:http_mocks",
-            "//test/mocks/network:network_mocks",
-            "//test/mocks/ssl:ssl_mocks",
-            "//test/mocks/stats:stats_mocks",
-            "//test/test_common:global_lib",
-            "//test/test_common:simulated_time_system_lib",
-            "//test/test_common:test_runtime_lib",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        ":test_proof_source_lib",
+        ":test_utils_lib",
+        "//envoy/stats:stats_macros",
+        "//source/common/listener_manager:connection_handler_lib",
+        "//source/common/quic:envoy_quic_alarm_factory_lib",
+        "//source/common/quic:envoy_quic_connection_helper_lib",
+        "//source/common/quic:envoy_quic_dispatcher_lib",
+        "//source/common/quic:envoy_quic_proof_source_lib",
+        "//source/common/quic:envoy_quic_server_session_lib",
+        "//source/common/quic:quic_server_transport_socket_factory_lib",
+        "//source/extensions/quic/crypto_stream:envoy_quic_crypto_server_stream_lib",
+        "//source/server:configuration_lib",
+        "//test/mocks/event:event_mocks",
+        "//test/mocks/http:http_mocks",
+        "//test/mocks/network:network_mocks",
+        "//test/mocks/ssl:ssl_mocks",
+        "//test/mocks/stats:stats_mocks",
+        "//test/test_common:global_lib",
+        "//test/test_common:simulated_time_system_lib",
+        "//test/test_common:test_runtime_lib",
+    ]),
 )
 
 envoy_cc_test_library(
     name = "test_proof_source_lib",
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["test_proof_source.h"],
-    }),
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//source/common/quic:envoy_quic_proof_source_base_lib",
-            "//test/mocks/network:network_mocks",
-            "@com_github_google_quiche//:quic_test_tools_test_certificates_lib",
-        ],
-    }),
+    hdrs = envoy_select_enable_http3(["test_proof_source.h"]),
+    deps = envoy_select_enable_http3([
+        "//source/common/quic:envoy_quic_proof_source_base_lib",
+        "//test/mocks/network:network_mocks",
+        "@com_github_google_quiche//:quic_test_tools_test_certificates_lib",
+    ]),
 )
 
 envoy_cc_test_library(
@@ -373,83 +289,59 @@ envoy_cc_test_library(
 
 envoy_cc_test(
     name = "client_connection_factory_impl_test",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["client_connection_factory_impl_test.cc"],
-    }),
+    srcs = envoy_select_enable_http3(["client_connection_factory_impl_test.cc"]),
     rbe_pool = "6gig",
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//source/common/event:dispatcher_lib",
-            "//source/common/http/http3:conn_pool_lib",
-            "//source/common/network:utility_lib",
-            "//source/common/upstream:upstream_includes",
-            "//source/common/upstream:upstream_lib",
-            "//test/common/http:common_lib",
-            "//test/common/upstream:utility_lib",
-            "//test/mocks/event:event_mocks",
-            "//test/mocks/http:http_mocks",
-            "//test/mocks/http:http_server_properties_cache_mocks",
-            "//test/mocks/network:network_mocks",
-            "//test/mocks/runtime:runtime_mocks",
-            "//test/mocks/server:factory_context_mocks",
-            "//test/mocks/upstream:cluster_info_mocks",
-            "//test/mocks/upstream:transport_socket_match_mocks",
-            "//test/test_common:test_runtime_lib",
-            "//test/test_common:threadsafe_singleton_injector_lib",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        "//source/common/event:dispatcher_lib",
+        "//source/common/http/http3:conn_pool_lib",
+        "//source/common/network:utility_lib",
+        "//source/common/upstream:upstream_includes",
+        "//source/common/upstream:upstream_lib",
+        "//test/common/http:common_lib",
+        "//test/common/upstream:utility_lib",
+        "//test/mocks/event:event_mocks",
+        "//test/mocks/http:http_mocks",
+        "//test/mocks/http:http_server_properties_cache_mocks",
+        "//test/mocks/network:network_mocks",
+        "//test/mocks/runtime:runtime_mocks",
+        "//test/mocks/server:factory_context_mocks",
+        "//test/mocks/upstream:cluster_info_mocks",
+        "//test/mocks/upstream:transport_socket_match_mocks",
+        "//test/test_common:test_runtime_lib",
+        "//test/test_common:threadsafe_singleton_injector_lib",
+    ]),
 )
 
 envoy_cc_test(
     name = "quic_io_handle_wrapper_test",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["quic_io_handle_wrapper_test.cc"],
-    }),
+    srcs = envoy_select_enable_http3(["quic_io_handle_wrapper_test.cc"]),
     rbe_pool = "6gig",
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//source/common/quic:quic_io_handle_wrapper_lib",
-            "//test/mocks/api:api_mocks",
-            "//test/mocks/network:io_handle_mocks",
-            "//test/mocks/network:network_mocks",
-            "//test/test_common:threadsafe_singleton_injector_lib",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        "//source/common/quic:quic_io_handle_wrapper_lib",
+        "//test/mocks/api:api_mocks",
+        "//test/mocks/network:io_handle_mocks",
+        "//test/mocks/network:network_mocks",
+        "//test/test_common:threadsafe_singleton_injector_lib",
+    ]),
 )
 
 envoy_cc_test(
     name = "envoy_quic_utils_test",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_utils_test.cc"],
-    }),
+    srcs = envoy_select_enable_http3(["envoy_quic_utils_test.cc"]),
     rbe_pool = "6gig",
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//source/common/quic:envoy_quic_utils_lib",
-            "//test/mocks/api:api_mocks",
-            "//test/test_common:threadsafe_singleton_injector_lib",
-            "@com_github_google_quiche//:quic_test_tools_test_utils_lib",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        "//source/common/quic:envoy_quic_utils_lib",
+        "//test/mocks/api:api_mocks",
+        "//test/test_common:threadsafe_singleton_injector_lib",
+        "@com_github_google_quiche//:quic_test_tools_test_utils_lib",
+    ]),
 )
 
 envoy_cc_test(
     name = "envoy_quic_simulated_watermark_buffer_test",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_simulated_watermark_buffer_test.cc"],
-    }),
+    srcs = envoy_select_enable_http3(["envoy_quic_simulated_watermark_buffer_test.cc"]),
     rbe_pool = "6gig",
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["//source/common/quic:envoy_quic_simulated_watermark_buffer_lib"],
-    }),
+    deps = envoy_select_enable_http3(["//source/common/quic:envoy_quic_simulated_watermark_buffer_lib"]),
 )
 
 envoy_cc_test_library(
@@ -475,59 +367,41 @@ envoy_cc_test_library(
 
 envoy_cc_test(
     name = "quic_transport_socket_factory_test",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["quic_transport_socket_factory_test.cc"],
-    }),
+    srcs = envoy_select_enable_http3(["quic_transport_socket_factory_test.cc"]),
     data = [
         "//test/common/tls/test_data:certs",
     ],
     rbe_pool = "6gig",
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//source/common/quic:quic_server_transport_socket_factory_lib",
-            "//source/common/quic:quic_transport_socket_factory_lib",
-            "//source/common/tls:context_config_lib",
-            "//test/mocks/server:factory_context_mocks",
-            "//test/mocks/ssl:ssl_mocks",
-            "//test/test_common:environment_lib",
-            "//test/test_common:utility_lib",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        "//source/common/quic:quic_server_transport_socket_factory_lib",
+        "//source/common/quic:quic_transport_socket_factory_lib",
+        "//source/common/tls:context_config_lib",
+        "//test/mocks/server:factory_context_mocks",
+        "//test/mocks/ssl:ssl_mocks",
+        "//test/test_common:environment_lib",
+        "//test/test_common:utility_lib",
+    ]),
 )
 
 envoy_cc_test(
     name = "http_datagram_handler_test",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["http_datagram_handler_test.cc"],
-    }),
+    srcs = envoy_select_enable_http3(["http_datagram_handler_test.cc"]),
     rbe_pool = "6gig",
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//source/common/quic:http_datagram_handler",
-            "//test/mocks/buffer:buffer_mocks",
-            "//test/test_common:utility_lib",
-            "@com_github_google_quiche//:quic_test_tools_test_utils_lib",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        "//source/common/quic:http_datagram_handler",
+        "//test/mocks/buffer:buffer_mocks",
+        "//test/test_common:utility_lib",
+        "@com_github_google_quiche//:quic_test_tools_test_utils_lib",
+    ]),
 )
 
 envoy_cc_test(
     name = "cert_compression_test",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["cert_compression_test.cc"],
-    }),
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//source/common/quic:cert_compression_lib",
-            "//test/test_common:logging_lib",
-        ],
-    }),
+    srcs = envoy_select_enable_http3(["cert_compression_test.cc"]),
+    deps = envoy_select_enable_http3([
+        "//source/common/quic:cert_compression_lib",
+        "//test/test_common:logging_lib",
+    ]),
 )
 
 envoy_cc_test_library(
@@ -538,19 +412,13 @@ envoy_cc_test_library(
 
 envoy_cc_test(
     name = "envoy_deterministic_connection_id_generator_test",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_deterministic_connection_id_generator_test.cc"],
-    }),
+    srcs = envoy_select_enable_http3(["envoy_deterministic_connection_id_generator_test.cc"]),
     rbe_pool = "6gig",
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":connection_id_matchers",
-            "//source/common/quic:envoy_deterministic_connection_id_generator_lib",
-            "@com_github_google_quiche//:quic_test_tools_test_utils_lib",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        ":connection_id_matchers",
+        "//source/common/quic:envoy_deterministic_connection_id_generator_lib",
+        "@com_github_google_quiche//:quic_test_tools_test_utils_lib",
+    ]),
 )
 
 envoy_proto_library(

--- a/test/extensions/quic/connection_debug_visitor/quic_stats/BUILD
+++ b/test/extensions/quic/connection_debug_visitor/quic_stats/BUILD
@@ -1,6 +1,7 @@
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_package",
+    "envoy_select_enable_http3",
 )
 load(
     "//test/extensions:extensions_build_system.bzl",
@@ -13,36 +14,24 @@ envoy_package()
 
 envoy_extension_cc_test(
     name = "quic_stats_test",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["quic_stats_test.cc"],
-    }),
+    srcs = envoy_select_enable_http3(["quic_stats_test.cc"]),
     extension_names = ["envoy.quic.connection_debug_visitor.quic_stats"],
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//source/extensions/quic/connection_debug_visitor/quic_stats:quic_stats_lib",
-            "//test/mocks/event:event_mocks",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        "//source/extensions/quic/connection_debug_visitor/quic_stats:quic_stats_lib",
+        "//test/mocks/event:event_mocks",
+    ]),
 )
 
 envoy_extension_cc_test(
     name = "integration_test",
     size = "large",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["integration_test.cc"],
-    }),
+    srcs = envoy_select_enable_http3(["integration_test.cc"]),
     extension_names = ["envoy.quic.connection_debug_visitor.quic_stats"],
     rbe_pool = "2core",
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//source/extensions/quic/connection_debug_visitor/quic_stats:config",
-            "//test/integration:http_integration_lib",
-            "@envoy_api//envoy/extensions/quic/connection_debug_visitor/quic_stats/v3:pkg_cc_proto",
-            "@envoy_api//envoy/extensions/transport_sockets/quic/v3:pkg_cc_proto",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        "//source/extensions/quic/connection_debug_visitor/quic_stats:config",
+        "//test/integration:http_integration_lib",
+        "@envoy_api//envoy/extensions/quic/connection_debug_visitor/quic_stats/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/transport_sockets/quic/v3:pkg_cc_proto",
+    ]),
 )

--- a/test/extensions/quic/connection_id_generator/quic_lb/BUILD
+++ b/test/extensions/quic/connection_id_generator/quic_lb/BUILD
@@ -1,6 +1,7 @@
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_package",
+    "envoy_select_enable_http3",
 )
 load(
     "//test/extensions:extensions_build_system.bzl",
@@ -13,39 +14,27 @@ envoy_package()
 
 envoy_extension_cc_test(
     name = "quic_lb_test",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["quic_lb_test.cc"],
-    }),
+    srcs = envoy_select_enable_http3(["quic_lb_test.cc"]),
     extension_names = ["envoy.quic.connection_id_generator.quic_lb"],
     rbe_pool = "6gig",
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//source/extensions/quic/connection_id_generator/quic_lb:quic_lb_lib",
-            "//test/mocks/server:factory_context_mocks",
-            "@com_github_google_quiche//:quic_test_tools_test_utils_lib",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        "//source/extensions/quic/connection_id_generator/quic_lb:quic_lb_lib",
+        "//test/mocks/server:factory_context_mocks",
+        "@com_github_google_quiche//:quic_test_tools_test_utils_lib",
+    ]),
 )
 
 envoy_extension_cc_test(
     name = "integration_test",
     size = "large",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["integration_test.cc"],
-    }),
+    srcs = envoy_select_enable_http3(["integration_test.cc"]),
     extension_names = ["envoy.quic.connection_id_generator.quic_lb"],
     rbe_pool = "4core",
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//source/extensions/quic/connection_id_generator/quic_lb:quic_lb_config",
-            "//test/integration:http_integration_lib",
-            "//test/integration:quic_http_integration_test_lib",
-            "@envoy_api//envoy/extensions/quic/connection_id_generator/quic_lb/v3:pkg_cc_proto",
-            "@envoy_api//envoy/extensions/transport_sockets/quic/v3:pkg_cc_proto",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        "//source/extensions/quic/connection_id_generator/quic_lb:quic_lb_config",
+        "//test/integration:http_integration_lib",
+        "//test/integration:quic_http_integration_test_lib",
+        "@envoy_api//envoy/extensions/quic/connection_id_generator/quic_lb/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/transport_sockets/quic/v3:pkg_cc_proto",
+    ]),
 )

--- a/test/extensions/quic/server_preferred_address/BUILD
+++ b/test/extensions/quic/server_preferred_address/BUILD
@@ -1,6 +1,7 @@
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_package",
+    "envoy_select_enable_http3",
 )
 load(
     "//test/extensions:extensions_build_system.bzl",
@@ -13,36 +14,24 @@ envoy_package()
 
 envoy_extension_cc_test(
     name = "datasource_server_preferred_address_test",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["datasource_server_preferred_address_test.cc"],
-    }),
+    srcs = envoy_select_enable_http3(["datasource_server_preferred_address_test.cc"]),
     extension_names = ["envoy.quic.server_preferred_address.datasource"],
     rbe_pool = "6gig",
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//source/extensions/quic/server_preferred_address:datasource_server_preferred_address_config_lib",
-            "//test/mocks/protobuf:protobuf_mocks",
-            "//test/mocks/server:server_factory_context_mocks",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        "//source/extensions/quic/server_preferred_address:datasource_server_preferred_address_config_lib",
+        "//test/mocks/protobuf:protobuf_mocks",
+        "//test/mocks/server:server_factory_context_mocks",
+    ]),
 )
 
 envoy_extension_cc_test(
     name = "fixed_server_preferred_address_test",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["fixed_server_preferred_address_test.cc"],
-    }),
+    srcs = envoy_select_enable_http3(["fixed_server_preferred_address_test.cc"]),
     extension_names = ["envoy.quic.server_preferred_address.fixed"],
     rbe_pool = "6gig",
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//source/extensions/quic/server_preferred_address:fixed_server_preferred_address_config_lib",
-            "//test/mocks/protobuf:protobuf_mocks",
-            "//test/mocks/server:server_factory_context_mocks",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        "//source/extensions/quic/server_preferred_address:fixed_server_preferred_address_config_lib",
+        "//test/mocks/protobuf:protobuf_mocks",
+        "//test/mocks/server:server_factory_context_mocks",
+    ]),
 )

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -1496,12 +1496,9 @@ envoy_cc_test(
         "//test/test_common:utility_lib",
         "@envoy_api//envoy/config/route/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/filters/network/http_connection_manager/v3:pkg_cc_proto",
-    ] + select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//test/integration/filters:pause_filter_for_quic_lib",
-        ],
-    }),
+    ] + envoy_select_enable_http3([
+        "//test/integration/filters:pause_filter_for_quic_lib",
+    ]),
 )
 
 envoy_cc_test(

--- a/test/integration/filters/BUILD
+++ b/test/integration/filters/BUILD
@@ -3,6 +3,7 @@ load(
     "envoy_cc_test_library",
     "envoy_package",
     "envoy_proto_library",
+    "envoy_select_enable_http3",
 )
 
 licenses(["notice"])  # Apache 2
@@ -469,22 +470,16 @@ envoy_cc_test_library(
 
 envoy_cc_test_library(
     name = "pause_filter_for_quic_lib",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "pause_filter_for_quic.cc",
-        ],
-    }),
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//envoy/http:filter_interface",
-            "//envoy/registry",
-            "//source/common/quic:quic_filter_manager_connection_lib",
-            "//source/extensions/filters/http/common:pass_through_filter_lib",
-            "//test/extensions/filters/http/common:empty_http_filter_config_lib",
-        ],
-    }),
+    srcs = envoy_select_enable_http3([
+        "pause_filter_for_quic.cc",
+    ]),
+    deps = envoy_select_enable_http3([
+        "//envoy/http:filter_interface",
+        "//envoy/registry",
+        "//source/common/quic:quic_filter_manager_connection_lib",
+        "//source/extensions/filters/http/common:pass_through_filter_lib",
+        "//test/extensions/filters/http/common:empty_http_filter_config_lib",
+    ]),
 )
 
 envoy_cc_test_library(


### PR DESCRIPTION
## Description

This PR migrates everything to use the consistent `envoy_select_enable_http3` macro we have.

---

**Commit Message:** quic: make the FIPS build macros consistent
**Additional Description:** Make BUILD files consistent by using the recommended macro everywhere.
**Risk Level:** Low
**Testing:** CI
**Docs Changes:** N/A
**Release Notes:** N/A