### PR TITLE
docs: clean up lua docs and make it consistent

### DIFF
--- a/docs/root/configuration/http/http_filters/lua_filter.rst
+++ b/docs/root/configuration/http/http_filters/lua_filter.rst
@@ -23,7 +23,7 @@ The design of the filter and Lua support at a high level is as follows:
 * **Do not perform blocking operations from scripts.** It is critical for performance that
   Envoy APIs are used for all IO.
 
-Currently supported high level features
+Currently supported high-level features
 ---------------------------------------
 
 .. note::
@@ -49,8 +49,8 @@ Configuration
 * This filter should be configured with the type URL ``type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua``.
 * :ref:`v3 API reference <envoy_v3_api_msg_extensions.filters.http.lua.v3.Lua>`
 
-A simple example of configuring Lua HTTP filter that contains only :ref:`default source code
-<envoy_v3_api_field_extensions.filters.http.lua.v3.Lua.default_source_code>` is as follow:
+A simple example of configuring the Lua HTTP filter that contains only :ref:`default source code
+<envoy_v3_api_field_extensions.filters.http.lua.v3.Lua.default_source_code>` is as follows:
 
 .. literalinclude:: _include/lua-filter.yaml
     :language: yaml
@@ -59,7 +59,7 @@ A simple example of configuring Lua HTTP filter that contains only :ref:`default
     :linenos:
     :caption: :download:`lua-filter.yaml <_include/lua-filter.yaml>`
 
-By default, Lua script defined in ``default_source_code`` will be treated as a ``default`` script. Envoy will
+By default, the Lua script defined in ``default_source_code`` will be treated as a ``default`` script. Envoy will
 execute it for every HTTP request. This ``default`` script is optional.
 
 Per-Route Configuration
@@ -74,7 +74,7 @@ LuaPerRoute provides two ways of overriding the ``default`` Lua script:
 * By providing a name reference to the defined :ref:`named Lua source codes map
   <envoy_v3_api_field_extensions.filters.http.lua.v3.Lua.source_codes>`.
 * By providing inline :ref:`source code
-  <envoy_v3_api_field_extensions.filters.http.lua.v3.LuaPerRoute.source_code>` (This allows the
+  <envoy_v3_api_field_extensions.filters.http.lua.v3.LuaPerRoute.source_code>` (this allows the
   code to be sent through RDS).
 
 As a concrete example, given the following Lua filter configuration:
@@ -88,7 +88,7 @@ As a concrete example, given the following Lua filter configuration:
 
 The HTTP Lua filter can be disabled on some virtual host, route, or weighted cluster by the
 :ref:`LuaPerRoute <envoy_v3_api_msg_extensions.filters.http.lua.v3.LuaPerRoute>` configuration as
-follow:
+follows:
 
 .. literalinclude:: _include/lua-filter-override.yaml
     :language: yaml
@@ -120,16 +120,16 @@ Lua script as follows:
 Upstream Filter
 ---------------
 
-The lua filter can be used as an upstream filter. Upstream filters cannot clear the route cache (as
-routing decision has already been made). Clearing the route cache will be a no-op in this case.
+The Lua filter can be used as an upstream filter. Upstream filters cannot clear the route cache (as
+the routing decision has already been made). Clearing the route cache will be a no-op in this case.
 
 Statistics
 ----------
 .. _config_http_filters_lua_stats:
 
-The lua filter outputs statistics in the ``.lua.`` namespace by default. When
-there are multiple lua filters configured in a filter chain, stats from
-individual filter instance/script can be tracked by providing a per filter
+The Lua filter outputs statistics in the ``.lua.`` namespace by default. When
+there are multiple Lua filters configured in a filter chain, stats from
+individual filter instance/script can be tracked by providing a per-filter
 :ref:`stat prefix
 <envoy_v3_api_field_extensions.filters.http.lua.v3.Lua.stat_prefix>`.
 
@@ -142,7 +142,7 @@ individual filter instance/script can be tracked by providing a per filter
 Script examples
 ---------------
 
-This section provides some concrete examples of Lua scripts as a more gentle introduction and quick
+This section provides some concrete examples of Lua scripts as a gentler introduction and quick
 start. Please refer to the :ref:`stream handle API <config_http_filters_lua_stream_handle_api>` for
 more details on the supported API.
 
@@ -219,8 +219,8 @@ more details on the supported API.
     response_handle:logInfo("Status: "..response_handle:headers():get(":status"))
   end
 
-A common use-case is to rewrite upstream response body, for example: an upstream sends non-2xx
-response with JSON data, but the application requires HTML page to be sent to browsers.
+A common use case is to rewrite the upstream response body. For example: an upstream sends a non-2xx
+response with JSON data, but the application requires an HTML page to be sent to browsers.
 
 There are two ways of doing this, the first one is via the ``body()`` API.
 
@@ -232,7 +232,7 @@ There are two ways of doing this, the first one is via the ``body()`` API.
     end
 
 
-Or, through ``bodyChunks()`` API, which let Envoy to skip buffering the upstream response data.
+Or, through the ``bodyChunks()`` API, which lets Envoy skip buffering the upstream response data.
 
 .. code-block:: lua
 
@@ -261,8 +261,8 @@ A complete example using Docker is available in `here <https://github.com/envoyp
 Stream handle API
 -----------------
 
-When Envoy loads the script in the configuration, it looks for two global functions that the
-script defines:
+When Envoy loads the script in the configuration, it looks for two global functions defined by the
+script:
 
 .. code-block:: lua
 
@@ -293,8 +293,8 @@ The following methods on the stream handle are supported:
   local headers = handle:headers()
 
 Returns the stream's headers. The headers can be modified as long as they have not been sent to
-the next filter in the header chain. For example, they can be modified after an *httpCall()* or
-after a *body()* call returns. The script will fail if the headers are modified in any other
+the next filter in the filter chain. For example, they can be modified after an ``httpCall()`` or
+after a ``body()`` call returns. The script will fail if the headers are modified in any other
 situation.
 
 Returns a :ref:`header object <config_http_filters_lua_header_wrapper>`.
@@ -311,8 +311,8 @@ the entire body has been received in a buffer. Note that all buffering must adhe
 flow-control policies in place. Envoy will not buffer more data than is allowed by the connection
 manager.
 
-An optional boolean argument ``always_wrap_body`` can be used to require Envoy always returns a
-``body`` object even if the body is empty. Therefore we can modify the body regardless of whether the
+An optional boolean argument ``always_wrap_body`` can be used to require that Envoy always returns a
+``body`` object even if the body is empty. Therefore, we can modify the body regardless of whether the
 original body exists or not.
 
 Returns a :ref:`buffer object <config_http_filters_lua_buffer_wrapper>`.
@@ -344,7 +344,7 @@ Each chunk the iterator returns is a :ref:`buffer object <config_http_filters_lu
   local trailers = handle:trailers()
 
 Returns the stream's trailers. Before calling this method, the caller should call ``body()`` or
-``bodyChunks()`` to consume the body, otherwise the trailers will not be available.
+``bodyChunks()`` to consume the body; otherwise, the trailers will not be available.
 May return nil if there are no trailers. The trailers may be modified before they are sent
 to the next filter.
 
@@ -362,32 +362,32 @@ Returns a :ref:`header object <config_http_filters_lua_header_wrapper>`.
   -- Alternative function signature.
   local headers, body = handle:httpCall(cluster, headers, body, options)
 
-Makes an HTTP call to an upstream host. *cluster* is a string which maps to a configured cluster manager cluster. *headers*
+Makes an HTTP call to an upstream host. ``cluster`` is a string which maps to a configured cluster. ``headers``
 is a table of key/value pairs to send (the value can be a string or table of strings). Note that
-the *:method*, *:path*, and *:authority* headers must be set. *body* is an optional string of body
-data to send. *timeout_ms* is an integer that specifies the call timeout in milliseconds.
+the ``:method``, ``:path``, and ``:authority`` headers must be set. ``body`` is an optional string of body
+data to send. ``timeout_ms`` is an integer that specifies the call timeout in milliseconds.
 
-*asynchronous* is a boolean flag. If async is set to true, Envoy will make the HTTP request and continue,
+``asynchronous`` is a boolean flag. If async is set to true, Envoy will make the HTTP request and continue,
 regardless of the response success or failure. If this is set to false, or not set, Envoy will suspend executing the script
 until the call completes or has an error.
 
-Returns *headers* which is a table of response headers. Returns *body* which is the string response
+Returns ``headers``, which is a table of response headers. Returns ``body``, which is the string response
 body. May be nil if there is no body.
 
 
-The alternative function signature allows caller to specify *options* as a table. Currently,
+The alternative function signature allows the caller to specify ``options`` as a table. Currently,
 the supported keys are:
 
-- *asynchronous* is a boolean flag that controls the asynchronicity of the HTTP call.
-  It refers to the same *asynchronous* flag as the first function signature.
-- *timeout_ms* is an integer that specifies the call timeout in milliseconds.
-  It refers to the same *timeout_ms* argument as the first function signature.
-- *trace_sampled* is a boolean flag that decides whether the produced trace span will be sampled or not. If not provided, the sampling decision of the parent span is used.
-- *return_duplicate_headers* is boolean flag that decides whether the repeated headers are allowed in response headers.
-  If the *return_duplicate_headers* is set to false (default), the returned *headers* is table with value type of string.
-  If the *return_duplicate_headers* is set to true, the returned *headers* is table with value type of string or value type
+* ``asynchronous`` is a boolean flag that controls the asynchronicity of the HTTP call.
+  It refers to the same ``asynchronous`` flag as the first function signature.
+* ``timeout_ms`` is an integer that specifies the call timeout in milliseconds.
+  It refers to the same ``timeout_ms`` argument as the first function signature.
+* ``trace_sampled`` is a boolean flag that decides whether the produced trace span will be sampled or not. If not provided, the sampling decision of the parent span is used.
+* ``return_duplicate_headers`` is a boolean flag that decides whether the repeated headers are allowed in response headers.
+  If ``return_duplicate_headers`` is set to false (default), the returned ``headers`` is a table with value type of string.
+  If ``return_duplicate_headers`` is set to true, the returned ``headers`` is a table with value type of string or value type
   of table.
-- *send_xff* is a boolean flag that decides whether the *x-forwarded-for* header is sent to target server.
+* ``send_xff`` is a boolean flag that decides whether the ``x-forwarded-for`` header is sent to the target server.
   The default value is true.
 
   For example, the following upstream response headers have repeated headers.
@@ -402,7 +402,7 @@ the supported keys are:
       { "key", "value_2" },
     }
 
-  Then if *return_duplicate_headers* is set to false, the returned headers will be:
+  Then if ``return_duplicate_headers`` is set to false, the returned headers will be:
 
   .. code-block:: lua
 
@@ -412,7 +412,7 @@ the supported keys are:
       ["key"] = "value_2",
     }
 
-  If *return_duplicate_headers* is set to true, the returned *headers* will be:
+  If ``return_duplicate_headers`` is set to true, the returned ``headers`` will be:
 
   .. code-block:: lua
 
@@ -423,7 +423,7 @@ the supported keys are:
     }
 
 
-Some examples of specifying *options* are shown below:
+Some examples of specifying ``options`` are shown below:
 
 .. code-block:: lua
 
@@ -450,8 +450,8 @@ Some examples of specifying *options* are shown below:
 
   handle:respond(headers, body)
 
-Respond immediately and do not continue further filter iteration. This call is *only valid in
-the request flow*. Additionally, a response is only possible if the request headers have not yet been
+Respond immediately and do not continue with further filter iteration. This call is **only valid in
+the request flow**. Additionally, a response is only possible if the request headers have not yet been
 passed to subsequent filters. Meaning, the following Lua code is invalid:
 
 .. code-block:: lua
@@ -464,8 +464,8 @@ passed to subsequent filters. Meaning, the following Lua code is invalid:
     end
   end
 
-*headers* is a table of key/value pairs to send (the value can be a string or table of strings).
-Note that the *:status* header must be set. *body* is a string and supplies the optional response
+``headers`` is a table of key/value pairs to send (the value can be a string or table of strings).
+Note that the ``:status`` header must be set. ``body`` is a string and supplies an optional response
 body. May be nil.
 
 ``metadata()``
@@ -478,8 +478,8 @@ body. May be nil.
 Returns the current route entry metadata. Note that the metadata should be specified
 under the :ref:`filter config name
 <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpFilter.name>`.
-If no entry could be find by the filter config name, then filter canonical name
-i.e. ``envoy.filters.http.lua`` will be used as alternative. But note this downgrade will be
+If no entry could be found by the filter config name, then the filter canonical name
+i.e. ``envoy.filters.http.lua`` will be used as an alternative. Note that this downgrade will be
 deprecated in the future.
 
 Below is an example of a ``metadata`` in a :ref:`route entry <envoy_v3_api_msg_config.route.v3.Route>`.
@@ -568,10 +568,10 @@ Example:
 
   handle:clearRouteCache()
 
-To clear the route cache for the current request. This will force the route to be recomputed. If you
+Clears the route cache for the current request. This will force the route to be recomputed. If you
 updated the request headers, metadata, or other information that affects the route and expect the route
 to be recomputed, you can call this function to clear the route cache. Then the route will be recomputed
-when the route is accessed next time.
+when the route is accessed the next time.
 
 Example:
 
@@ -591,7 +591,7 @@ Example:
 
   local filter_context = handle:filterContext()
 
-Returns the filter context that configured in the the
+Returns the filter context that is configured in the
 :ref:`filter_context <envoy_v3_api_field_extensions.filters.http.lua.v3.LuaPerRoute.filter_context>`.
 
 For example, given the following filter context in the route entry:
@@ -623,7 +623,7 @@ The filter context can be accessed in the related Lua script as follows:
 
   local pubkey = handle:importPublicKey(keyder, keyderLength)
 
-Returns public key which is used by :ref:`verifySignature <verify_signature>` to verify digital signature.
+Returns a public key which is used by :ref:`verifySignature <verify_signature>` to verify a digital signature.
 
 .. _verify_signature:
 
@@ -634,18 +634,19 @@ Returns public key which is used by :ref:`verifySignature <verify_signature>` to
 
   local ok, error = handle:verifySignature(hashFunction, pubkey, signature, signatureLength, data, dataLength)
 
-Verify signature using provided parameters. *hashFunction* is the variable for the hash function which be used
-for verifying signature. *SHA1*, *SHA224*, *SHA256*, *SHA384* and *SHA512* are supported.
-*pubkey* is the public key. *signature* is the signature to be verified. *signatureLength* is
-the length of the signature. *data* is the content which will be hashed. *dataLength* is the length of data.
+Verifies a signature using the provided parameters. ``hashFunction`` is the variable for the hash function which will be used
+for verifying the signature. ``SHA1``, ``SHA224``, ``SHA256``, ``SHA384`` and ``SHA512`` are supported.
+``pubkey`` is the public key. ``signature`` is the signature to be verified. ``signatureLength`` is
+the length of the signature. ``data`` is the content which will be hashed. ``dataLength`` is the length of the data.
 
-The function returns a pair. If the first element is *true*, the second element will be empty
-which means signature is verified; otherwise, the second element will store the error message.
+The function returns a pair. If the first element is ``true``, the second element will be empty,
+which means the signature is verified; otherwise, the second element will store the error message.
 
 .. _config_http_filters_lua_stream_handle_api_base64_escape:
 
 ``base64Escape()``
 ^^^^^^^^^^^^^^^^^^
+
 .. code-block:: lua
 
   local base64_encoded = handle:base64Escape("input string")
@@ -659,9 +660,9 @@ Encodes the input string as base64. This can be useful for escaping binary data.
 
   timestamp = handle:timestamp(format)
 
-High resolution timestamp function. *format* is an optional enum parameter to indicate the format of the timestamp.
-*EnvoyTimestampResolution.MILLISECOND* is supported
-The function returns timestamp in milliseconds since epoch by default if format is not set.
+High-resolution timestamp function. ``format`` is an optional enum parameter to indicate the format of the timestamp.
+``EnvoyTimestampResolution.MILLISECOND`` is supported.
+The function returns a timestamp in milliseconds since epoch by default if format is not set.
 
 .. _config_http_filters_lua_stream_handle_api_timestamp_string:
 
@@ -672,10 +673,10 @@ The function returns timestamp in milliseconds since epoch by default if format 
 
   timestamp = handle:timestampString(resolution)
 
-Timestamp function. Timestamp is returned as a string. It represents the integer value of the selected resolution
-since epoch. *resolution* is an optional enum parameter to indicate the resolution of the timestamp.
-Supported resolutions are *EnvoyTimestampResolution.MILLISECOND* and *EnvoyTimestampResolution.MICROSECOND*.
-Default resolution is millisecond if *resolution* is not set.
+Timestamp function. The timestamp is returned as a string. It represents the integer value of the selected resolution
+since epoch. ``resolution`` is an optional enum parameter to indicate the resolution of the timestamp.
+Supported resolutions are ``EnvoyTimestampResolution.MILLISECOND`` and ``EnvoyTimestampResolution.MICROSECOND``.
+The default resolution is millisecond if ``resolution`` is not set.
 
 .. _config_http_filters_lua_header_wrapper:
 
@@ -691,7 +692,7 @@ Header object API
 
   headers:add(key, value)
 
-Adds a header. *key* is a string that supplies the header key. *value* is a string that supplies
+Adds a header. ``key`` is a string that supplies the header key. ``value`` is a string that supplies
 the header value.
 
 ``get()``
@@ -701,9 +702,9 @@ the header value.
 
   headers:get(key)
 
-Gets a header. *key* is a string that supplies the header key. Returns a string that is the header
+Gets a header. ``key`` is a string that supplies the header key. Returns a string that is the header
 value or nil if there is no such header. If there are multiple headers in the same case-insensitive
-key, their values will be combined with a *,* separator and returned as a string.
+key, their values will be combined with a ``,`` separator and returned as a string.
 
 ``getAtIndex()``
 ^^^^^^^^^^^^^^^^
@@ -713,7 +714,7 @@ key, their values will be combined with a *,* separator and returned as a string
   headers:getAtIndex(key, index)
 
 Gets the header value at the given index. It can be used to fetch a specific value in case the
-given header has multiple values. *key* is a string that supplies the header key and index is
+given header has multiple values. ``key`` is a string that supplies the header key and index is
 an integer that supplies the position. It returns a string that is the header value or nil if
 there is no such header or if there is no value at the specified index.
 
@@ -725,8 +726,8 @@ there is no such header or if there is no value at the specified index.
   headers:getNumValues(key)
 
 Gets the number of values of a given header. It can be used to fetch the total number of values in case
-the given header has multiple values. *key* is a string that supplies the header key. It returns
-an integer with the value size for the given header or *0* if there is no such header.
+the given header has multiple values. ``key`` is a string that supplies the header key. It returns
+an integer with the value size for the given header or ``0`` if there is no such header.
 
 ``__pairs()``
 ^^^^^^^^^^^^^
@@ -736,7 +737,7 @@ an integer with the value size for the given header or *0* if there is no such h
   for key, value in pairs(headers) do
   end
 
-Iterates through every header. *key* is a string that supplies the header key. *value* is a string
+Iterates through every header. ``key`` is a string that supplies the header key. ``value`` is a string
 that supplies the header value.
 
 .. attention::
@@ -752,7 +753,7 @@ that supplies the header value.
 
   headers:remove(key)
 
-Removes a header. *key* supplies the header key to remove.
+Removes a header. ``key`` supplies the header key to remove.
 
 ``replace()``
 ^^^^^^^^^^^^^
@@ -761,8 +762,8 @@ Removes a header. *key* supplies the header key to remove.
 
   headers:replace(key, value)
 
-Replaces a header. *key* is a string that supplies the header key. *value* is a string that supplies
-the header value. If the header does not exist, it is added as per the *add()* function.
+Replaces a header. ``key`` is a string that supplies the header key. ``value`` is a string that supplies
+the header value. If the header does not exist, it is added as per the ``add()`` function.
 
 ``setHttp1ReasonPhrase()``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -771,9 +772,9 @@ the header value. If the header does not exist, it is added as per the *add()* f
 
   headers:setHttp1ReasonPhrase(reasonPhrase)
 
-Sets a custom HTTP/1 response reason phrase. This call is *only valid in the response flow*.
-*reasonPhrase* is a string that supplies the reason phrase value. Additionally this call only
-effects HTTP/1 connections. It will have no effect if the client is HTTP/2 or HTTP/3.
+Sets a custom HTTP/1 response reason phrase. This call is **only valid in the response flow**.
+``reasonPhrase`` is a string that supplies the reason phrase value. Additionally this call only
+affects HTTP/1 connections. It will have no effect if the client is HTTP/2 or HTTP/3.
 
 .. _config_http_filters_lua_buffer_wrapper:
 
@@ -798,9 +799,9 @@ Gets the size of the buffer in bytes. Returns an integer.
 
   buffer:getBytes(index, length)
 
-Get bytes from the buffer. By default Envoy will not copy all buffer bytes to Lua. This will
-cause a buffer segment to be copied. *index* is an integer and supplies the buffer start index to
-copy. *length* is an integer and supplies the buffer length to copy. *index* + *length* must be
+Gets bytes from the buffer. By default Envoy will not copy all buffer bytes to Lua. This will
+cause a buffer segment to be copied. ``index`` is an integer and supplies the buffer start index to
+copy. ``length`` is an integer and supplies the buffer length to copy. ``index`` + ``length`` must be
 less than the buffer length.
 
 .. _config_http_filters_lua_buffer_wrapper_api_set_bytes:
@@ -828,9 +829,9 @@ Metadata object API
 
   metadata:get(key)
 
-Gets a metadata. *key* is a string that supplies the metadata key. Returns the corresponding
-value of the given metadata key. The type of the value can be: *nil*, *boolean*, *number*,
-*string* and *table*.
+Gets metadata. ``key`` is a string that supplies the metadata key. Returns the corresponding
+value of the given metadata key. The type of the value can be: ``nil``, ``boolean``, ``number``,
+``string`` and ``table``.
 
 ``__pairs()``
 ^^^^^^^^^^^^^
@@ -840,8 +841,8 @@ value of the given metadata key. The type of the value can be: *nil*, *boolean*,
   for key, value in pairs(metadata) do
   end
 
-Iterates through every *metadata* entry. *key* is a string that supplies a *metadata*
-key. *value* is a *metadata* entry value.
+Iterates through every ``metadata`` entry. ``key`` is a string that supplies a ``metadata``
+key. ``value`` is a ``metadata`` entry value.
 
 .. _config_http_filters_lua_stream_info_wrapper:
 
@@ -858,7 +859,7 @@ Stream info object API
   streamInfo:protocol()
 
 Returns the string representation of :repo:`HTTP protocol <envoy/http/protocol.h>`
-used by the current request. The possible values are: ``HTTP/1.0``, ``HTTP/1.1``, ``HTTP/2`` and ``HTTP/3*``.
+used by the current request. The possible values are: ``HTTP/1.0``, ``HTTP/1.1``, ``HTTP/2`` and ``HTTP/3``.
 
 .. _config_http_filters_lua_stream_info_route_name:
 
@@ -996,31 +997,33 @@ Connection stream info object API
 
 Returns dynamic metadata for a given filter name. Dynamic metadata provides type-safe access to metadata values that are stored as protocol buffer messages. This is particularly useful when working with filters that store structured data.
 
-*filterName* is a string that supplies the filter name, e.g. *envoy.lb*. Returns a Lua table containing the unpacked protocol buffer message. Returns nil if no dynamic metadata exists for the given filter name or if the metadata cannot be unpacked.
+``filterName`` is a string that supplies the filter name, e.g. ``envoy.lb``. Returns a Lua table containing the unpacked protocol buffer message. Returns nil if no dynamic metadata exists for the given filter name or if the metadata cannot be unpacked.
 
 **Type Conversion Details:**
+
 The following rules apply when converting protocol buffer messages into Lua tables:
 
-- Repeated fields are converted to Lua arrays (1-based indexing).
-- Map fields become Lua tables with string keys.
-- Enums are represented as their numeric values.
-- Byte fields are translated to Lua strings.
-- Nested messages are converted to nested tables.
-- Optional fields that are not set are returned as nil.
+* Repeated fields are converted to Lua arrays (1-based indexing)
+* Map fields become Lua tables with string keys
+* Enums are represented as their numeric values
+* Byte fields are translated to Lua strings
+* Nested messages are converted to nested tables
+* Optional fields that are not set are returned as nil
 
 **Error Handling:**
+
 This method ensures type-safe access to metadata but returns nil in the following scenarios:
 
-- If the specified filter name does not exist. For example, trying to access
+* If the specified filter name does not exist. For example, trying to access
   ``dynamicTypedMetadata("envoy.filters.listener.proxy_protocol")`` when the proxy protocol filter isn't configured.
-- If the metadata exists but cannot be unpacked. It could happen if the filter state exists but is stored as a different
+* If the metadata exists but cannot be unpacked. It could happen if the filter state exists but is stored as a different
   type than ``ProtobufWkt::Struct``.
-- If the protocol buffer message is malformed. It could happen when the data in the filter state is corrupted or
+* If the protocol buffer message is malformed. It could happen when the data in the filter state is corrupted or
   partially written.
 
 **Common Use Cases:**
 
-1. Accessing Proxy Protocol Metadata:
+1. **Accessing Proxy Protocol Metadata:**
 
 .. code-block:: lua
 
@@ -1040,7 +1043,7 @@ This method ensures type-safe access to metadata but returns nil in the followin
     end
   end
 
-2. Working with Custom Filter Metadata:
+2. **Working with Custom Filter Metadata:**
 
 .. code-block:: lua
 
@@ -1104,8 +1107,8 @@ Dynamic metadata object API
   -- to get a value from a returned table.
   dynamicMetadata:get(filterName)[key]
 
-Gets an entry in dynamic metadata struct. *filterName* is a string that supplies the filter name, e.g. *envoy.lb*.
-Returns the corresponding *table* of a given *filterName*.
+Gets an entry in the dynamic metadata struct. ``filterName`` is a string that supplies the filter name, e.g. ``envoy.lb``.
+Returns the corresponding ``table`` of a given ``filterName``.
 
 ``set()``
 ^^^^^^^^^
@@ -1114,10 +1117,10 @@ Returns the corresponding *table* of a given *filterName*.
 
   dynamicMetadata:set(filterName, key, value)
 
-Sets key-value pair of a *filterName*'s metadata. *filterName* is a key specifying the target filter name,
-e.g. *envoy.lb*. The type of *key* is *string*. The type of *value* is any Lua type that can be mapped
-to a metadata value: *table*, *numeric*, *boolean*, *string* or *nil*. When using a *table* as an argument,
-its keys can only be *string* or *numeric*.
+Sets a key-value pair of a ``filterName``'s metadata. ``filterName`` is a key specifying the target filter name,
+e.g. ``envoy.lb``. The type of ``key`` is ``string``. The type of ``value`` is any Lua type that can be mapped
+to a metadata value: ``table``, ``numeric``, ``boolean``, ``string`` or ``nil``. When using a ``table`` as an argument,
+its keys can only be ``string`` or ``numeric``.
 
 .. code-block:: lua
 
@@ -1143,8 +1146,8 @@ its keys can only be *string* or *numeric*.
   for key, value in pairs(dynamicMetadata) do
   end
 
-Iterates through every *dynamicMetadata* entry. *key* is a string that supplies a *dynamicMetadata*
-key. *value* is a *dynamicMetadata* entry value.
+Iterates through every ``dynamicMetadata`` entry. ``key`` is a string that supplies a ``dynamicMetadata``
+key. ``value`` is a ``dynamicMetadata`` entry value.
 
 .. _config_http_filters_lua_connection_wrapper:
 
@@ -1165,7 +1168,7 @@ Connection object API
   end
 
 Returns :repo:`SSL connection <envoy/ssl/connection.h>` object when the connection is
-secured and *nil* when it is not.
+secured and ``nil`` when it is not.
 
 Returns an :ref:`SSL connection info object <config_http_filters_lua_ssl_socket_info>`.
 
@@ -1196,7 +1199,7 @@ Returns a bool representing whether the peer certificate is presented.
     print("peer certificate is validated")
   end
 
-Returns bool whether the peer certificate was validated.
+Returns a bool whether the peer certificate was validated.
 
 .. warning::
 
@@ -1259,7 +1262,7 @@ peer certificate, or no issuer.
 
   downstreamSslConnection:subjectPeerCertificate()
 
-Return the subject field of the peer certificate in RFC 2253 format. Returns ``""`` if there is no
+Returns the subject field of the peer certificate in RFC 2253 format. Returns ``""`` if there is no
 peer certificate, or no subject.
 
 ``parsedSubjectPeerCertificate()``
@@ -1273,7 +1276,7 @@ peer certificate, or no subject.
     print("O: " .. table.concat(parsedSubject:organizationName(), ","))
   end
 
-Returns :repo:`connection <envoy/ssl/parsed_x509_name.h>` parsed from subject field of the peer
+Returns :repo:`connection <envoy/ssl/parsed_x509_name.h>` parsed from the subject field of the peer
 certificate. Returns nil if there is no peer certificate.
 
 Returns a :ref:`parsed name object <config_http_filters_lua_parsed_name>`.
@@ -1370,7 +1373,7 @@ Returns an empty table if there is no local certificate or no OIDs.
 Returns the time (timestamp-since-epoch in seconds) that the peer certificate was issued and should
 be considered valid from. Returns ``0`` if there is no peer certificate.
 
-In Lua, we usually use ``os.time(os.date("!*t"))`` to get current timestamp-since-epoch in seconds.
+In Lua, we usually use ``os.time(os.date("!*t"))`` to get the current timestamp-since-epoch in seconds.
 
 ``expirationPeerCertificate()``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1382,7 +1385,7 @@ In Lua, we usually use ``os.time(os.date("!*t"))`` to get current timestamp-sinc
 Returns the time (timestamp-since-epoch in seconds) that the peer certificate expires and should not
 be considered valid after. Returns ``0`` if there is no peer certificate.
 
-In Lua, we usually use ``os.time(os.date("!*t"))`` to get current timestamp-since-epoch in seconds.
+In Lua, we usually use ``os.time(os.date("!*t"))`` to get the current timestamp-since-epoch in seconds.
 
 ``sessionId()``
 ^^^^^^^^^^^^^^^
@@ -1436,8 +1439,8 @@ Parsed name object API
 
   parsedSubject:commonName()
 
-Returns the string representation of CN field from the X.509 name. Returns ``""`` if there is no such
-field or if the field can't be converted to UTF8 string.
+Returns the string representation of the CN field from the X.509 name. Returns ``""`` if there is no such
+field or if the field can't be converted to a UTF8 string.
 
 ``organizationName()``
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -1447,4 +1450,4 @@ field or if the field can't be converted to UTF8 string.
   parsedSubject:organizationName()
 
 Returns the string representation of O fields (as a table) from the X.509 name. Returns an empty
-table if there is no such field or if the field can't be converted to UTF8 string.
+table if there is no such field or if the field can't be converted to a UTF8 string.


### PR DESCRIPTION
## Description

This PR have some cleanup in Lua docs for consistency. We are using the backticks inconsistently throughout right now.

---

**Commit Message:** docs: clean up Lua docs and make it consistent
**Additional Description:** Minor clean up for added clarity on the Lua docs.
**Risk Level:** N/A
**Testing:** N/A
**Docs Changes:** N/A
**Release Notes:** N/A