### PR TITLE
[1.30] tls: Add support for building envoy against newer releases of BoringCrypto FIPS via override_repository

### DIFF
--- a/source/common/tls/context_impl.cc
+++ b/source/common/tls/context_impl.cc
@@ -576,10 +576,6 @@ void ContextImpl::logHandshake(SSL* ssl) const {
     stats_.no_certificate_.inc();
   }
 
-#if defined(BORINGSSL_FIPS) && BORINGSSL_API_VERSION >= 18
-#error "Delete preprocessor check below; no longer needed"
-#endif
-
 #if BORINGSSL_API_VERSION >= 18
   // Increment the `was_key_usage_invalid_` stats to indicate the given cert would have triggered an
   // error but is allowed because the enforcement that rsa key usage and tls usage need to be


### PR DESCRIPTION
Commit Message: tls: Add support for building envoy against newer releases of BoringCrypto FIPS via override_repository

Additional Description:
If one uses `build --override_repository=boringssl_fips=/usr/lib/boringssl-fips-static` to compile v1.30 envoy against BoringCrypto FIPS 2023042800 [#4953](https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4953) or the BoringCrypto update stream, the build will fail on an error assertion.

Remove this `#error` assertion, as it is meant to be a reminder to the developers in the development tip, but shouldn't prevent users of stable branches to build envoy against newly certified BoringCrypto FIPS or the BoringCrypto FIPS update stream.

Note the project is compiled against c++20 standard, and thus `#warning` from c++23 is not available.

Note! This change does not upgrade BoringCrypto FIPS version, and it remains the same, but compile time incompatibility with newer BoringCrypto FIPS is resolved.

Risk Level: Low
Testing: Compiled with override_repository pointing at BoringCrypto FIPS 2023042800
Fixes: https://github.com/envoyproxy/envoy/issues/39822