### PR TITLE
quic(backport): re-enable FIPS build and related tests

### DIFF
--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -298,7 +298,6 @@ selects.config_setting_group(
     name = "disable_http3",
     match_any = [
         ":disable_http3_setting",
-        ":boringssl_fips",
     ],
 )
 

--- a/bazel/external/quiche.BUILD
+++ b/bazel/external/quiche.BUILD
@@ -1511,7 +1511,6 @@ envoy_cc_library(
 envoy_cc_library(
     name = "quic_platform",
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quic_core_time_lib",
@@ -1526,7 +1525,6 @@ envoy_cc_library(
         "quiche/quic/platform/api/quic_hostname_utils.h",
     ],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_platform_hostname_utils",
@@ -1539,7 +1537,6 @@ envoy_cc_library(
         "quiche/quic/platform/api/quic_stack_trace.h",
     ],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_platform_stack_trace",
@@ -1552,7 +1549,6 @@ envoy_cc_library(
         "quiche/quic/platform/api/quic_server_stats.h",
     ],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_platform_server_stats",
@@ -1594,7 +1590,6 @@ envoy_cc_library(
         "quiche/quic/platform/api/quic_bug_tracker.h",
     ],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_platform_bug_tracker",
@@ -1605,7 +1600,6 @@ envoy_cc_library(
     name = "quic_platform_export",
     hdrs = ["quiche/quic/platform/api/quic_export.h"],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_platform_export",
@@ -1616,7 +1610,6 @@ envoy_cc_test_library(
     name = "quic_platform_expect_bug",
     hdrs = ["quiche/quic/platform/api/quic_expect_bug.h"],
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [":quiche_common_platform_expect_bug"],
 )
 
@@ -1624,7 +1617,6 @@ envoy_cc_library(
     name = "quic_platform_ip_address_family",
     hdrs = ["quiche/quic/platform/api/quic_ip_address_family.h"],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quic_platform_bug_tracker",
@@ -1637,7 +1629,6 @@ envoy_cc_library(
     srcs = ["quiche/common/quiche_ip_address_family.cc"],
     hdrs = ["quiche/common/quiche_ip_address_family.h"],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quic_platform_bug_tracker",
@@ -1663,7 +1654,6 @@ envoy_cc_library(
     hdrs = ["quiche/common/quiche_ip_address.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quic_platform_base",
@@ -1679,7 +1669,6 @@ envoy_cc_library(
         "//conditions:default": [],
     }),
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [":quiche_common_platform_udp_socket_platform"],
 )
 
@@ -1713,7 +1702,6 @@ envoy_cc_test_library(
     name = "quic_platform_test",
     hdrs = ["quiche/quic/platform/api/quic_test.h"],
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quic_platform_base",
         ":quiche_common_platform_test",
@@ -1725,7 +1713,6 @@ envoy_cc_test_library(
     name = "quic_platform_test_output",
     hdrs = ["quiche/quic/platform/api/quic_test_output.h"],
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [":quiche_common_platform_test_output"],
 )
 
@@ -1733,7 +1720,6 @@ envoy_cc_test_library(
     name = "quic_platform_thread",
     hdrs = ["quiche/quic/platform/api/quic_thread.h"],
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [":quiche_common_platform_thread"],
 )
 
@@ -1752,7 +1738,6 @@ envoy_cc_library(
     name = "quic_core_proto_cached_network_parameters_proto_header",
     hdrs = ["quiche/quic/core/proto/cached_network_parameters_proto.h"],
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [":quic_core_proto_cached_network_parameters_proto_cc"],
 )
 
@@ -1771,7 +1756,6 @@ envoy_cc_library(
     name = "quic_core_proto_source_address_token_proto_header",
     hdrs = ["quiche/quic/core/proto/source_address_token_proto.h"],
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [":quic_core_proto_source_address_token_proto_cc"],
 )
 
@@ -1789,7 +1773,6 @@ envoy_cc_library(
     name = "quic_core_proto_crypto_server_config_proto_header",
     hdrs = ["quiche/quic/core/proto/crypto_server_config_proto.h"],
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [":quic_core_proto_crypto_server_config_proto_cc"],
 )
 
@@ -1799,7 +1782,6 @@ envoy_cc_library(
     hdrs = ["quiche/quic/core/quic_ack_listener_interface.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quic_core_time_lib",
@@ -1834,7 +1816,6 @@ envoy_cc_library(
     hdrs = ["quiche/quic/core/quic_bandwidth.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quic_core_constants_lib",
@@ -1860,7 +1841,6 @@ envoy_cc_library(
     }),
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quic_core_linux_socket_utils_lib",
@@ -1886,7 +1866,6 @@ envoy_cc_library(
     }),
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quic_core_batch_writer_batch_writer_buffer_lib",
@@ -1906,7 +1885,6 @@ envoy_cc_test_library(
     }),
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quic_core_batch_writer_batch_writer_base_lib",
         ":quic_core_udp_socket_lib",
@@ -1930,7 +1908,6 @@ envoy_cc_library(
     }),
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":flow_label_lib",
@@ -1956,7 +1933,6 @@ envoy_cc_library(
     }),
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quic_core_batch_writer_batch_writer_base_lib",
@@ -1967,7 +1943,6 @@ envoy_cc_library(
 envoy_quic_cc_library(
     name = "quic_core_blocked_writer_interface_lib",
     hdrs = ["quiche/quic/core/quic_blocked_writer_interface.h"],
-    tags = ["nofips"],
     deps = [":quic_platform_export"],
 )
 
@@ -1988,7 +1963,6 @@ envoy_cc_test(
     srcs = ["quiche/quic/core/quic_blocked_writer_list_test.cc"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quic_core_blocked_writer_interface_lib",
         ":quic_core_blocked_writer_list_lib",
@@ -2413,7 +2387,6 @@ envoy_cc_library(
     hdrs = ["quiche/quic/core/quic_constants.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quic_core_types_lib",
@@ -2432,7 +2405,6 @@ envoy_cc_library(
     copts = quiche_copts,
     external_deps = ["ssl"],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_platform_logging",
@@ -2699,7 +2671,6 @@ envoy_cc_library(
     copts = quiche_copts,
     external_deps = ["ssl"],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [":quiche_common_random_lib"],
 )
@@ -2762,7 +2733,6 @@ envoy_cc_library(
         "quiche/common/simple_buffer_allocator.h",
     ],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_platform_export",
@@ -2776,7 +2746,6 @@ envoy_cc_library(
     hdrs = ["quiche/common/quiche_circular_deque.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quiche_common_platform",
         ":quiche_common_platform_export",
@@ -2790,7 +2759,6 @@ envoy_cc_library(
     copts = quiche_copts,
     external_deps = ["ssl"],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [":quiche_common_platform_logging"],
 )
@@ -2800,7 +2768,6 @@ envoy_cc_library(
     hdrs = ["quiche/common/quiche_status_utils.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/status",
@@ -2813,7 +2780,6 @@ envoy_cc_library(
     hdrs = ["quiche/common/wire_serialization.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quiche_common_buffer_allocator_lib",
         ":quiche_common_lib",
@@ -2828,7 +2794,6 @@ envoy_cc_library(
     hdrs = ["quiche/common/quiche_callbacks.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_platform_export",
@@ -2863,7 +2828,6 @@ envoy_cc_library(
     copts = quiche_copts,
     external_deps = ["ssl"],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quic_platform_base",
@@ -2876,7 +2840,6 @@ envoy_cc_library(
     hdrs = ["quiche/common/quiche_feature_flags_list.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
 )
 
@@ -2885,7 +2848,6 @@ envoy_cc_library(
     hdrs = ["quiche/common/quiche_protocol_flags_list.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
 )
 
@@ -2979,7 +2941,6 @@ envoy_cc_library(
         "//conditions:default": [],
     }),
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quic_core_constants_lib",
@@ -3283,7 +3244,6 @@ envoy_cc_library(
     hdrs = ["quiche/quic/core/quic_interval.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quic_platform_export",
@@ -3306,7 +3266,6 @@ envoy_cc_library(
     hdrs = ["quiche/quic/core/quic_interval_set.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quic_core_interval_lib",
@@ -3324,7 +3283,6 @@ envoy_cc_library(
     }),
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     deps = select({
         "@envoy//bazel:windows_x86_64": [],
         "@envoy//bazel:disable_http3": [],
@@ -3350,7 +3308,6 @@ envoy_cc_library(
     ],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quic_core_types_lib",
@@ -3387,7 +3344,6 @@ envoy_cc_library(
     }),
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     deps = select({
         "@envoy//bazel:windows_x86_64": [],
         "@envoy//bazel:disable_http3": [],
@@ -3447,7 +3403,6 @@ envoy_cc_library(
     }),
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quic_platform_export",
     ],
@@ -3465,7 +3420,6 @@ envoy_cc_library(
     }),
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quic_core_packet_writer_lib",
         ":quic_core_syscall_wrapper_lib",
@@ -3529,7 +3483,6 @@ envoy_cc_library(
     ],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quic_core_packets_lib",
@@ -3550,7 +3503,6 @@ envoy_cc_library(
     ],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":http2_core_priority_write_scheduler_lib",
@@ -3963,7 +3915,6 @@ envoy_cc_library(
     copts = quiche_copts,
     external_deps = ["ssl"],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quic_core_types_lib",
@@ -4155,7 +4106,6 @@ envoy_cc_library(
     hdrs = ["quiche/quic/core/quic_tag.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quic_platform_base",
@@ -4168,7 +4118,6 @@ envoy_cc_library(
     srcs = ["quiche/quic/core/quic_time.cc"],
     hdrs = ["quiche/quic/core/quic_time.h"],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [":quic_platform_base"],
 )
@@ -4224,7 +4173,6 @@ envoy_cc_library(
     copts = quiche_copts,
     external_deps = ["ssl"],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quic_core_crypto_random_lib",
@@ -4273,7 +4221,6 @@ envoy_cc_library(
         "//conditions:default": [],
     }),
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":flow_label_lib",
         ":quic_core_io_socket_lib",
@@ -4305,7 +4252,6 @@ envoy_cc_library(
     hdrs = ["quiche/quic/core/quic_utils.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quic_core_constants_lib",
@@ -4337,7 +4283,6 @@ envoy_cc_library(
     hdrs = ["quiche/quic/core/quic_versions.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quic_core_crypto_random_lib",
@@ -4644,7 +4589,6 @@ envoy_cc_library(
     name = "quiche_common_endian_lib",
     hdrs = ["quiche/common/quiche_endian.h"],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps =
         [
@@ -4658,7 +4602,6 @@ envoy_cc_library(
         "quiche/common/platform/api/quiche_client_stats.h",
     ],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [":quiche_common_platform_default_quiche_platform_impl_client_stats_impl_lib"],
 )
@@ -4676,7 +4619,6 @@ envoy_cc_test_library(
         "quiche/common/platform/api/quiche_system_event_loop.h",
     ],
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [":quiche_common_platform_default_quiche_platform_impl_system_event_loop_impl_lib"],
 )
 
@@ -4691,7 +4633,6 @@ envoy_cc_library(
     name = "quiche_common_platform_googleurl",
     hdrs = ["quiche/common/platform/api/quiche_googleurl.h"],
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [":quiche_common_platform_default_quiche_platform_impl_googleurl_impl_lib"],
 )
 
@@ -4700,7 +4641,6 @@ envoy_cc_library(
     srcs = ["quiche/common/platform/api/quiche_mem_slice.cc"],
     hdrs = ["quiche/common/platform/api/quiche_mem_slice.h"],
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quiche_common_buffer_allocator_lib",
         ":quiche_common_callbacks",
@@ -4725,7 +4665,6 @@ envoy_cc_library(
         "quiche/common/platform/api/quiche_iovec.h",
     ],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_platform_bug_tracker",
@@ -4740,7 +4679,6 @@ envoy_cc_library(
         "quiche/common/platform/api/quiche_bug_tracker.h",
     ],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_platform_export",
@@ -4761,7 +4699,6 @@ envoy_cc_library(
         "quiche/common/platform/api/quiche_logging.h",
     ],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_platform_export",
@@ -4801,7 +4738,6 @@ envoy_cc_library(
         "quiche/common/platform/api/quiche_hostname_utils.h",
     ],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_platform_export",
@@ -4816,7 +4752,6 @@ envoy_cc_test_library(
         "quiche/common/platform/api/quiche_thread.h",
     ],
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quiche_common_platform_export",
         "@envoy//test/common/quic/platform:quiche_thread_impl_lib",
@@ -4829,7 +4764,6 @@ envoy_cc_test_library(
         "quiche/common/platform/api/quiche_test_output.h",
     ],
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quiche_common_platform_export",
         "@envoy//test/common/quic/platform:quiche_test_output_impl_lib",
@@ -4842,7 +4776,6 @@ envoy_cc_test_library(
         "quiche/common/platform/api/quiche_expect_bug.h",
     ],
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quiche_common_platform_export",
         "@envoy//test/common/quic/platform:quiche_expect_bug_impl_lib",
@@ -4856,7 +4789,6 @@ envoy_cc_library(
         "//conditions:default": [],
     }),
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quic_core_types_lib",
@@ -4870,7 +4802,6 @@ envoy_cc_library(
     name = "quiche_common_platform_server_stats",
     hdrs = ["quiche/common/platform/api/quiche_server_stats.h"],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_platform_default_quiche_platform_impl_server_stats_impl_lib",
@@ -4890,7 +4821,6 @@ envoy_cc_library(
         "quiche/common/platform/api/quiche_stack_trace.h",
     ],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_platform_export",
@@ -4904,7 +4834,6 @@ envoy_cc_library(
         "quiche/common/platform/api/quiche_containers.h",
     ],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_platform_default_quiche_platform_impl_containers_impl_lib",
@@ -4938,7 +4867,6 @@ envoy_cc_library(
         "quiche/common/platform/api/quiche_testvalue.h",
     ],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_platform_export",
@@ -4956,7 +4884,6 @@ envoy_cc_library(
         "quiche/common/platform/api/quiche_time_utils.h",
     ],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_platform_bug_tracker",
@@ -5029,7 +4956,6 @@ envoy_cc_library(
         "quiche/common/platform/api/quiche_export.h",
     ],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         "@envoy//source/common/quic/platform:quiche_export_impl_lib",
@@ -5040,7 +4966,6 @@ envoy_cc_test_library(
     name = "quiche_common_platform_test",
     hdrs = ["quiche/common/platform/api/quiche_test.h"],
     repository = "@envoy",
-    tags = ["nofips"],
     deps = ["@envoy//test/common/quic/platform:quiche_test_impl_lib"],
 )
 
@@ -5049,7 +4974,6 @@ envoy_cc_test(
     srcs = ["quiche/common/platform/api/quiche_mem_slice_test.cc"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quiche_common_buffer_allocator_lib",
         ":quiche_common_platform",
@@ -5063,7 +4987,6 @@ envoy_cc_test(
     srcs = ["quiche/common/platform/api/quiche_time_utils_test.cc"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quiche_common_platform",
         ":quiche_common_platform_test",
@@ -5074,7 +4997,6 @@ envoy_cc_library(
     name = "quiche_common_print_elements_lib",
     hdrs = ["quiche/common/print_elements.h"],
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quiche_common_platform_export",
         "@com_google_absl//absl/container:inlined_vector",
@@ -5088,7 +5010,6 @@ envoy_cc_test_library(
         "quiche/common/test_tools/quiche_test_utils.h",
     ],
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quiche_common_platform",
         ":quiche_common_platform_googleurl",
@@ -5104,7 +5025,6 @@ envoy_cc_library(
     srcs = ["quiche/common/quiche_text_utils.cc"],
     hdrs = ["quiche/common/quiche_text_utils.h"],
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quiche_common_platform_export",
         "@com_google_absl//absl/hash",
@@ -5124,7 +5044,6 @@ envoy_cc_library(
         "quiche/common/quiche_linked_hash_map.h",
     ],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_endian_lib",
@@ -5137,7 +5056,6 @@ envoy_cc_library(
     srcs = ["quiche/common/quiche_simple_arena.cc"],
     hdrs = ["quiche/common/quiche_simple_arena.h"],
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quiche_common_platform_export",
         ":quiche_common_platform_logging",
@@ -5149,7 +5067,6 @@ envoy_cc_library(
     srcs = ["quiche/common/http/http_header_storage.cc"],
     hdrs = ["quiche/common/http/http_header_storage.h"],
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quiche_common_platform_export",
         ":quiche_common_platform_logging",
@@ -5162,7 +5079,6 @@ envoy_cc_library(
     srcs = ["quiche/common/http/http_header_block.cc"],
     hdrs = ["quiche/common/http/http_header_block.h"],
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quiche_common_lib",
         ":quiche_common_platform_export",
@@ -5176,7 +5092,6 @@ envoy_cc_test(
     name = "quiche_http_header_block_test",
     srcs = ["quiche/common/http/http_header_block_test.cc"],
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":http2_test_tools_test_utils_lib",
         ":quiche_common_platform_test",
@@ -5189,7 +5104,6 @@ envoy_cc_library(
     srcs = ["quiche/common/structured_headers.cc"],
     hdrs = ["quiche/common/structured_headers.h"],
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_platform",
@@ -5213,7 +5127,6 @@ envoy_cc_test(
     ],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quiche_common_lib",
         ":quiche_common_mem_slice_storage",
@@ -5227,7 +5140,6 @@ envoy_cc_test(
         "quiche/http2/test_tools/http2_random_test.cc",
     ],
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":http2_test_tools_random",
         ":quiche_common_platform",
@@ -5257,7 +5169,6 @@ envoy_cc_test(
     }),
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quic_core_batch_writer_batch_writer_test_lib",
         ":quic_core_batch_writer_gso_batch_writer_lib",
@@ -5272,7 +5183,6 @@ envoy_cc_library(
     hdrs = ["quiche/quic/load_balancer/load_balancer_server_id.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quic_core_types_lib",
@@ -5315,7 +5225,6 @@ envoy_cc_library(
     name = "quiche_common_platform_lower_case_string",
     hdrs = ["quiche/common/platform/api/quiche_lower_case_string.h"],
     repository = "@envoy",
-    tags = ["nofips"],
     deps = ["@envoy//source/common/quic/platform:quiche_lower_case_string_impl_lib"],
 )
 
@@ -5323,7 +5232,6 @@ envoy_cc_library(
     name = "quiche_common_platform_header_policy",
     hdrs = ["quiche/common/platform/api/quiche_header_policy.h"],
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [":quiche_common_platform_default_quiche_platform_impl_header_policy_impl_lib"],
 )
 
@@ -5338,7 +5246,6 @@ envoy_cc_library(
     hdrs = ["quiche/balsa/balsa_enums.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [":quiche_common_platform_export"],
 )
@@ -5348,7 +5255,6 @@ envoy_cc_library(
     hdrs = ["quiche/balsa/balsa_visitor_interface.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quiche_balsa_balsa_enums_lib",
@@ -5361,7 +5267,6 @@ envoy_cc_library(
     hdrs = ["quiche/balsa/noop_balsa_visitor.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quiche_balsa_balsa_visitor_interface_lib",
@@ -5375,7 +5280,6 @@ envoy_cc_library(
     hdrs = ["quiche/balsa/standard_header_map.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quiche_common_text_utils_lib",
         "@com_google_absl//absl/container:flat_hash_set",
@@ -5388,7 +5292,6 @@ envoy_cc_library(
     hdrs = ["quiche/balsa/framer_interface.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [":quiche_common_platform_export"],
 )
 
@@ -5397,7 +5300,6 @@ envoy_cc_library(
     hdrs = ["quiche/balsa/http_validation_policy.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quiche_common_platform_export",
         ":quiche_common_platform_logging",
@@ -5409,7 +5311,6 @@ envoy_cc_library(
     hdrs = ["quiche/balsa/header_api.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quiche_common_callbacks",
         ":quiche_common_platform_export",
@@ -5424,7 +5325,6 @@ envoy_cc_library(
     hdrs = ["quiche/balsa/simple_buffer.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quiche_common_platform",
         ":quiche_common_platform_bug_tracker",
@@ -5439,7 +5339,6 @@ envoy_cc_test(
     srcs = ["quiche/balsa/simple_buffer_test.cc"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quiche_balsa_simple_buffer_lib",
         ":quiche_common_platform_expect_bug",
@@ -5454,7 +5353,6 @@ envoy_cc_library(
     hdrs = ["quiche/balsa/header_properties.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quiche_common_platform",
         ":quiche_common_platform_export",
@@ -5469,7 +5367,6 @@ envoy_cc_test(
     srcs = ["quiche/balsa/header_properties_test.cc"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":quiche_balsa_header_properties_lib",
         ":quiche_common_platform_test",
@@ -5482,7 +5379,6 @@ envoy_cc_library(
     hdrs = ["quiche/balsa/balsa_headers.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quiche_balsa_balsa_enums_lib",
@@ -5528,7 +5424,6 @@ envoy_cc_library(
     hdrs = ["quiche/balsa/balsa_frame.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
         ":quiche_balsa_balsa_enums_lib",
@@ -5573,7 +5468,6 @@ envoy_cc_library(
     hdrs = ["quiche/web_transport/web_transport.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    tags = ["nofips"],
     deps = [
         ":common_http_http_header_block_lib",
         ":quiche_common_callbacks",

--- a/bazel/external/quiche.bzl
+++ b/bazel/external/quiche.bzl
@@ -32,7 +32,6 @@ def envoy_quiche_platform_impl_cc_library(
         deps = deps,
         repository = "@envoy",
         strip_include_prefix = "quiche/common/platform/default/",
-        tags = ["nofips"],
         visibility = ["//visibility:public"],
     )
 
@@ -48,7 +47,6 @@ def envoy_quiche_platform_impl_cc_test_library(
         deps = deps,
         repository = "@envoy",
         strip_include_prefix = "quiche/common/platform/default/",
-        tags = ["nofips"],
     )
 
 # Used for QUIC libraries
@@ -66,7 +64,7 @@ def envoy_quic_cc_library(
         hdrs = envoy_select_enable_http3(hdrs, "@envoy"),
         repository = "@envoy",
         copts = quiche_copts,
-        tags = ["nofips"] + tags,
+        tags = tags,
         visibility = ["//visibility:public"],
         defines = defines,
         external_deps = external_deps,
@@ -86,7 +84,7 @@ def envoy_quic_cc_test_library(
         hdrs = envoy_select_enable_http3(hdrs, "@envoy"),
         copts = quiche_copts,
         repository = "@envoy",
-        tags = ["nofips"] + tags,
+        tags = tags,
         external_deps = external_deps,
         deps = envoy_select_enable_http3(deps, "@envoy"),
     )

--- a/source/common/http/http3/BUILD
+++ b/source/common/http/http3/BUILD
@@ -2,6 +2,7 @@ load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_library",
     "envoy_package",
+    "envoy_select_enable_http3",
 )
 
 licenses(["notice"])  # Apache 2
@@ -10,26 +11,17 @@ envoy_package()
 
 envoy_cc_library(
     name = "conn_pool_lib",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["conn_pool.cc"],
-    }),
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["conn_pool.h"],
-    }),
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//envoy/event:dispatcher_interface",
-            "//envoy/http:persistent_quic_info_interface",
-            "//envoy/upstream:upstream_interface",
-            "//source/common/http:codec_client_lib",
-            "//source/common/http:conn_pool_base_lib",
-            "//source/common/quic:client_connection_factory_lib",
-            "@com_github_google_quiche//:quic_core_deterministic_connection_id_generator_lib",
-        ],
-    }),
+    srcs = envoy_select_enable_http3(["conn_pool.cc"]),
+    hdrs = envoy_select_enable_http3(["conn_pool.h"]),
+    deps = envoy_select_enable_http3([
+        "//envoy/event:dispatcher_interface",
+        "//envoy/http:persistent_quic_info_interface",
+        "//envoy/upstream:upstream_interface",
+        "//source/common/http:codec_client_lib",
+        "//source/common/http:conn_pool_base_lib",
+        "//source/common/quic:client_connection_factory_lib",
+        "@com_github_google_quiche//:quic_core_deterministic_connection_id_generator_lib",
+    ]),
 )
 
 envoy_cc_library(

--- a/source/common/http/http3/BUILD
+++ b/source/common/http/http3/BUILD
@@ -10,17 +10,26 @@ envoy_package()
 
 envoy_cc_library(
     name = "conn_pool_lib",
-    srcs = ["conn_pool.cc"],
-    hdrs = ["conn_pool.h"],
-    deps = [
-        "//envoy/event:dispatcher_interface",
-        "//envoy/http:persistent_quic_info_interface",
-        "//envoy/upstream:upstream_interface",
-        "//source/common/http:codec_client_lib",
-        "//source/common/http:conn_pool_base_lib",
-        "//source/common/quic:client_connection_factory_lib",
-        "@com_github_google_quiche//:quic_core_deterministic_connection_id_generator_lib",
-    ],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["conn_pool.cc"],
+    }),
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["conn_pool.h"],
+    }),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//envoy/event:dispatcher_interface",
+            "//envoy/http:persistent_quic_info_interface",
+            "//envoy/upstream:upstream_interface",
+            "//source/common/http:codec_client_lib",
+            "//source/common/http:conn_pool_base_lib",
+            "//source/common/quic:client_connection_factory_lib",
+            "@com_github_google_quiche//:quic_core_deterministic_connection_id_generator_lib",
+        ],
+    }),
 )
 
 envoy_cc_library(

--- a/source/common/quic/BUILD
+++ b/source/common/quic/BUILD
@@ -1,3 +1,4 @@
+load("@bazel_skylib//lib:selects.bzl", "selects")
 load(
     "@envoy_build_config//:extensions_build_config.bzl",
     "LEGACY_ALWAYSLINK",
@@ -12,6 +13,15 @@ load(
 
 licenses(["notice"])  # Apache 2
 
+# Create a condition for HTTP3 enabled AND Linux
+selects.config_setting_group(
+    name = "http3_enabled_and_linux",
+    match_all = [
+        "//bazel:linux",
+        "//bazel:enable_http3",
+    ],
+)
+
 # TODO(mattklein123): Default visibility for this package should not be public. We should have
 # default by private to within this package and package tests, and then only expose the libraries
 # that are required to be selected into the build for http3 to work.
@@ -19,324 +29,456 @@ envoy_package()
 
 envoy_cc_library(
     name = "envoy_quic_alarm_lib",
-    srcs = ["envoy_quic_alarm.cc"],
-    hdrs = ["envoy_quic_alarm.h"],
-    tags = ["nofips"],
-    deps = [
-        "//envoy/event:dispatcher_interface",
-        "//envoy/event:timer_interface",
-        "@com_github_google_quiche//:quic_core_alarm_lib",
-        "@com_github_google_quiche//:quic_core_clock_lib",
-        "@com_github_google_quiche//:quic_platform",
-    ],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_alarm.cc"],
+    }),
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_alarm.h"],
+    }),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//envoy/event:dispatcher_interface",
+            "//envoy/event:timer_interface",
+            "@com_github_google_quiche//:quic_core_alarm_lib",
+            "@com_github_google_quiche//:quic_core_clock_lib",
+            "@com_github_google_quiche//:quic_platform",
+        ],
+    }),
 )
 
 envoy_cc_library(
     name = "envoy_quic_alarm_factory_lib",
-    srcs = ["envoy_quic_alarm_factory.cc"],
-    hdrs = ["envoy_quic_alarm_factory.h"],
-    tags = ["nofips"],
-    deps = [
-        ":envoy_quic_alarm_lib",
-        "@com_github_google_quiche//:quic_core_alarm_factory_lib",
-        "@com_github_google_quiche//:quic_core_arena_scoped_ptr_lib",
-        "@com_github_google_quiche//:quic_core_one_block_arena_lib",
-        "@com_github_google_quiche//:quic_platform",
-    ],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_alarm_factory.cc"],
+    }),
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_alarm_factory.h"],
+    }),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":envoy_quic_alarm_lib",
+            "@com_github_google_quiche//:quic_core_alarm_factory_lib",
+            "@com_github_google_quiche//:quic_core_arena_scoped_ptr_lib",
+            "@com_github_google_quiche//:quic_core_one_block_arena_lib",
+            "@com_github_google_quiche//:quic_platform",
+        ],
+    }),
 )
 
 envoy_cc_library(
     name = "envoy_quic_clock_lib",
-    srcs = ["envoy_quic_clock.cc"],
-    hdrs = ["envoy_quic_clock.h"],
-    tags = ["nofips"],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_clock.cc"],
+    }),
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_clock.h"],
+    }),
     visibility = ["//visibility:public"],
-    deps = [
-        "//envoy/event:dispatcher_interface",
-        "@com_github_google_quiche//:quic_core_clock_lib",
-    ],
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//envoy/event:dispatcher_interface",
+            "@com_github_google_quiche//:quic_core_clock_lib",
+        ],
+    }),
 )
 
 envoy_cc_library(
     name = "envoy_quic_connection_debug_visitor_factory_interface",
-    hdrs = ["envoy_quic_connection_debug_visitor_factory_interface.h"],
-    tags = ["nofips"],
-    deps = [
-        "//envoy/common:optref_lib",
-        "//envoy/common:pure_lib",
-        "//envoy/config:typed_config_interface",
-        "//envoy/server:factory_context_interface",
-        "//envoy/stream_info:stream_info_interface",
-        "@com_github_google_quiche//:quic_core_connection_lib",
-        "@com_github_google_quiche//:quic_core_session_lib",
-    ],
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_connection_debug_visitor_factory_interface.h"],
+    }),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//envoy/common:optref_lib",
+            "//envoy/common:pure_lib",
+            "//envoy/config:typed_config_interface",
+            "//envoy/server:factory_context_interface",
+            "//envoy/stream_info:stream_info_interface",
+            "@com_github_google_quiche//:quic_core_connection_lib",
+            "@com_github_google_quiche//:quic_core_session_lib",
+        ],
+    }),
 )
 
 envoy_cc_library(
     name = "envoy_quic_connection_helper_lib",
-    hdrs = ["envoy_quic_connection_helper.h"],
-    tags = ["nofips"],
-    deps = [
-        ":envoy_quic_clock_lib",
-        "@com_github_google_quiche//:quic_core_connection_lib",
-        "@com_github_google_quiche//:quiche_common_random_lib",
-    ],
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_connection_helper.h"],
+    }),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":envoy_quic_clock_lib",
+            "@com_github_google_quiche//:quic_core_connection_lib",
+            "@com_github_google_quiche//:quiche_common_random_lib",
+        ],
+    }),
 )
 
 envoy_cc_library(
     name = "quic_stat_names_lib",
     srcs = ["quic_stat_names.cc"],
     hdrs = ["quic_stat_names.h"],
-    tags = ["nofips"],
-    deps = [
-        "//envoy/stats:stats_interface",
-        "//source/common/stats:symbol_table_lib",
-        "@com_github_google_quiche//:quic_core_error_codes_lib",
-        "@com_github_google_quiche//:quic_core_types_lib",
-    ],
+    deps = select({
+        "//bazel:disable_http3": [
+            "//envoy/stats:stats_interface",
+            "//source/common/stats:symbol_table_lib",
+        ],
+        "//conditions:default": [
+            "//envoy/stats:stats_interface",
+            "//source/common/stats:symbol_table_lib",
+            "@com_github_google_quiche//:quic_core_error_codes_lib",
+            "@com_github_google_quiche//:quic_core_types_lib",
+        ],
+    }),
 )
 
 envoy_cc_library(
     name = "envoy_quic_proof_source_base_lib",
-    srcs = ["envoy_quic_proof_source_base.cc"],
-    hdrs = ["envoy_quic_proof_source_base.h"],
-    tags = ["nofips"],
-    deps = [
-        ":envoy_quic_utils_lib",
-        "@com_github_google_quiche//:quic_core_crypto_certificate_view_lib",
-        "@com_github_google_quiche//:quic_core_crypto_crypto_handshake_lib",
-        "@com_github_google_quiche//:quic_core_crypto_proof_source_lib",
-        "@com_github_google_quiche//:quic_core_data_lib",
-        "@com_github_google_quiche//:quic_core_versions_lib",
-        "@com_github_google_quiche//:quic_platform",
-    ],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_proof_source_base.cc"],
+    }),
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_proof_source_base.h"],
+    }),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":envoy_quic_utils_lib",
+            "@com_github_google_quiche//:quic_core_crypto_certificate_view_lib",
+            "@com_github_google_quiche//:quic_core_crypto_crypto_handshake_lib",
+            "@com_github_google_quiche//:quic_core_crypto_proof_source_lib",
+            "@com_github_google_quiche//:quic_core_data_lib",
+            "@com_github_google_quiche//:quic_core_versions_lib",
+            "@com_github_google_quiche//:quic_platform",
+        ],
+    }),
 )
 
 envoy_cc_library(
     name = "envoy_quic_proof_source_lib",
-    srcs = ["envoy_quic_proof_source.cc"],
-    hdrs = ["envoy_quic_proof_source.h"],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_proof_source.cc"],
+    }),
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_proof_source.h"],
+    }),
     external_deps = ["ssl"],
-    tags = ["nofips"],
-    deps = [
-        ":envoy_quic_proof_source_base_lib",
-        ":envoy_quic_utils_lib",
-        ":quic_io_handle_wrapper_lib",
-        ":quic_transport_socket_factory_lib",
-        "//envoy/ssl:tls_certificate_config_interface",
-        "//source/common/quic:cert_compression_lib",
-        "//source/common/quic:quic_server_transport_socket_factory_lib",
-        "//source/common/stream_info:stream_info_lib",
-        "//source/server:listener_stats",
-        "@com_github_google_quiche//:quic_core_crypto_certificate_view_lib",
-    ],
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":envoy_quic_proof_source_base_lib",
+            ":envoy_quic_utils_lib",
+            ":quic_io_handle_wrapper_lib",
+            ":quic_transport_socket_factory_lib",
+            "//envoy/ssl:tls_certificate_config_interface",
+            "//source/common/quic:cert_compression_lib",
+            "//source/common/quic:quic_server_transport_socket_factory_lib",
+            "//source/common/stream_info:stream_info_lib",
+            "//source/server:listener_stats",
+            "@com_github_google_quiche//:quic_core_crypto_certificate_view_lib",
+        ],
+    }),
 )
 
 envoy_cc_library(
     name = "envoy_quic_proof_verifier_base_lib",
-    srcs = ["envoy_quic_proof_verifier_base.cc"],
-    hdrs = ["envoy_quic_proof_verifier_base.h"],
-    tags = ["nofips"],
-    deps = [
-        ":envoy_quic_utils_lib",
-        "@com_github_google_quiche//:quic_core_crypto_certificate_view_lib",
-        "@com_github_google_quiche//:quic_core_crypto_crypto_handshake_lib",
-        "@com_github_google_quiche//:quic_core_versions_lib",
-        "@com_github_google_quiche//:quic_platform",
-    ],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_proof_verifier_base.cc"],
+    }),
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_proof_verifier_base.h"],
+    }),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":envoy_quic_utils_lib",
+            "@com_github_google_quiche//:quic_core_crypto_certificate_view_lib",
+            "@com_github_google_quiche//:quic_core_crypto_crypto_handshake_lib",
+            "@com_github_google_quiche//:quic_core_versions_lib",
+            "@com_github_google_quiche//:quic_platform",
+        ],
+    }),
 )
 
 envoy_cc_library(
     name = "envoy_quic_proof_verifier_lib",
-    srcs = ["envoy_quic_proof_verifier.cc"],
-    hdrs = ["envoy_quic_proof_verifier.h"],
-    tags = ["nofips"],
-    deps = [
-        ":envoy_quic_proof_verifier_base_lib",
-        ":envoy_quic_utils_lib",
-        ":quic_ssl_connection_info_lib",
-        "//source/common/tls:context_lib",
-        "@com_github_google_quiche//:quic_platform",
-    ],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_proof_verifier.cc"],
+    }),
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_proof_verifier.h"],
+    }),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":envoy_quic_proof_verifier_base_lib",
+            ":envoy_quic_utils_lib",
+            ":quic_ssl_connection_info_lib",
+            "//source/common/tls:context_lib",
+            "@com_github_google_quiche//:quic_platform",
+        ],
+    }),
 )
 
 envoy_cc_library(
     name = "envoy_quic_stream_lib",
-    srcs = ["envoy_quic_stream.cc"],
-    hdrs = ["envoy_quic_stream.h"],
-    tags = ["nofips"],
-    deps = [
-        ":envoy_quic_simulated_watermark_buffer_lib",
-        ":envoy_quic_utils_lib",
-        ":quic_filter_manager_connection_lib",
-        ":quic_stats_gatherer",
-        ":send_buffer_monitor_lib",
-        "//envoy/event:dispatcher_interface",
-        "//envoy/http:codec_interface",
-        "//source/common/http:codec_helper_lib",
-        "@com_github_google_quiche//:http2_adapter",
-        "@com_github_google_quiche//:quic_core_http_client_lib",
-        "@com_github_google_quiche//:quic_core_http_http_encoder_lib",
-        "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
-    ] + envoy_select_enable_http_datagrams([
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_stream.cc"],
+    }),
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_stream.h"],
+    }),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":envoy_quic_simulated_watermark_buffer_lib",
+            ":envoy_quic_utils_lib",
+            ":quic_filter_manager_connection_lib",
+            ":quic_stats_gatherer",
+            ":send_buffer_monitor_lib",
+            "//envoy/event:dispatcher_interface",
+            "//envoy/http:codec_interface",
+            "//source/common/http:codec_helper_lib",
+            "@com_github_google_quiche//:http2_adapter",
+            "@com_github_google_quiche//:quic_core_http_client_lib",
+            "@com_github_google_quiche//:quic_core_http_http_encoder_lib",
+            "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
+        ],
+    }) + envoy_select_enable_http_datagrams([
         ":http_datagram_handler",
     ]),
 )
 
 envoy_cc_library(
     name = "client_connection_factory_lib",
-    srcs = ["client_connection_factory_impl.cc"],
-    hdrs = ["client_connection_factory_impl.h"],
-    tags = ["nofips"],
-    deps = [
-        ":envoy_quic_alarm_factory_lib",
-        ":envoy_quic_client_session_lib",
-        ":envoy_quic_connection_helper_lib",
-        ":envoy_quic_proof_verifier_lib",
-        ":envoy_quic_utils_lib",
-        "//envoy/http:codec_interface",
-        "//envoy/http:persistent_quic_info_interface",
-        "//envoy/registry",
-        "//source/common/runtime:runtime_lib",
-        "//source/common/tls:client_ssl_socket_lib",
-        "//source/extensions/quic/crypto_stream:envoy_quic_crypto_client_stream_lib",
-        "@com_github_google_quiche//:quic_core_http_spdy_session_lib",
-    ],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["client_connection_factory_impl.cc"],
+    }),
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["client_connection_factory_impl.h"],
+    }),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":envoy_quic_alarm_factory_lib",
+            ":envoy_quic_client_session_lib",
+            ":envoy_quic_connection_helper_lib",
+            ":envoy_quic_proof_verifier_lib",
+            ":envoy_quic_utils_lib",
+            "//envoy/http:codec_interface",
+            "//envoy/http:persistent_quic_info_interface",
+            "//envoy/registry",
+            "//source/common/runtime:runtime_lib",
+            "//source/common/tls:client_ssl_socket_lib",
+            "//source/extensions/quic/crypto_stream:envoy_quic_crypto_client_stream_lib",
+            "@com_github_google_quiche//:quic_core_http_spdy_session_lib",
+        ],
+    }),
 )
 
 envoy_cc_library(
     name = "client_codec_lib",
-    srcs = ["client_codec_impl.cc"],
-    hdrs = [
-        "client_codec_impl.h",
-        "codec_impl.h",
-    ],
-    tags = ["nofips"],
-    deps = [
-        ":envoy_quic_client_session_lib",
-        ":envoy_quic_utils_lib",
-        "//envoy/http:codec_interface",
-        "//envoy/registry",
-        "@com_github_google_quiche//:quic_core_http_spdy_session_lib",
-    ],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["client_codec_impl.cc"],
+    }),
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "client_codec_impl.h",
+            "codec_impl.h",
+        ],
+    }),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":envoy_quic_client_session_lib",
+            ":envoy_quic_utils_lib",
+            "//envoy/http:codec_interface",
+            "//envoy/registry",
+            "@com_github_google_quiche//:quic_core_http_spdy_session_lib",
+        ],
+    }),
 )
 
 envoy_cc_library(
     name = "server_codec_lib",
-    srcs = ["server_codec_impl.cc"],
-    hdrs = [
-        "codec_impl.h",
-        "server_codec_impl.h",
-    ],
-    tags = ["nofips"],
-    deps = [
-        ":envoy_quic_server_session_lib",
-        ":envoy_quic_utils_lib",
-        ":quic_server_factory_stub_lib",
-        "//envoy/http:codec_interface",
-        "//envoy/registry",
-        "@com_github_google_quiche//:quic_core_http_spdy_session_lib",
-    ],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["server_codec_impl.cc"],
+    }),
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "codec_impl.h",
+            "server_codec_impl.h",
+        ],
+    }),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":envoy_quic_server_session_lib",
+            ":envoy_quic_utils_lib",
+            ":quic_server_factory_stub_lib",
+            "//envoy/http:codec_interface",
+            "//envoy/registry",
+            "@com_github_google_quiche//:quic_core_http_spdy_session_lib",
+        ],
+    }),
     alwayslink = LEGACY_ALWAYSLINK,
 )
 
 envoy_cc_library(
     name = "quic_ssl_connection_info_lib",
-    hdrs = ["quic_ssl_connection_info.h"],
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["quic_ssl_connection_info.h"],
+    }),
     external_deps = ["ssl"],
-    tags = ["nofips"],
-    deps = [
-        "//source/common/tls:connection_info_impl_base_lib",
-        "@com_github_google_quiche//:quic_core_session_lib",
-    ],
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//source/common/tls:connection_info_impl_base_lib",
+            "@com_github_google_quiche//:quic_core_session_lib",
+        ],
+    }),
 )
 
 envoy_cc_library(
     name = "quic_filter_manager_connection_lib",
-    srcs = ["quic_filter_manager_connection_impl.cc"],
-    hdrs = ["quic_filter_manager_connection_impl.h"],
-    tags = ["nofips"],
-    deps = [
-        ":envoy_quic_simulated_watermark_buffer_lib",
-        ":quic_network_connection_lib",
-        ":quic_ssl_connection_info_lib",
-        ":quic_stat_names_lib",
-        ":send_buffer_monitor_lib",
-        "//envoy/event:dispatcher_interface",
-        "//envoy/network:connection_interface",
-        "//source/common/buffer:buffer_lib",
-        "//source/common/common:assert_lib",
-        "//source/common/common:empty_string",
-        "//source/common/http:header_map_lib",
-        "//source/common/http/http3:codec_stats_lib",
-        "//source/common/network:connection_base_lib",
-        "//source/common/stream_info:stream_info_lib",
-        "@com_github_google_quiche//:quic_core_connection_lib",
-    ],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["quic_filter_manager_connection_impl.cc"],
+    }),
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["quic_filter_manager_connection_impl.h"],
+    }),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":envoy_quic_simulated_watermark_buffer_lib",
+            ":quic_network_connection_lib",
+            ":quic_ssl_connection_info_lib",
+            ":quic_stat_names_lib",
+            ":send_buffer_monitor_lib",
+            "//envoy/event:dispatcher_interface",
+            "//envoy/network:connection_interface",
+            "//source/common/buffer:buffer_lib",
+            "//source/common/common:assert_lib",
+            "//source/common/common:empty_string",
+            "//source/common/http:header_map_lib",
+            "//source/common/http/http3:codec_stats_lib",
+            "//source/common/network:connection_base_lib",
+            "//source/common/stream_info:stream_info_lib",
+            "@com_github_google_quiche//:quic_core_connection_lib",
+        ],
+    }),
 )
 
 envoy_cc_library(
     name = "envoy_quic_server_session_lib",
-    srcs = [
-        "envoy_quic_server_session.cc",
-        "envoy_quic_server_stream.cc",
-    ],
-    hdrs = [
-        "envoy_quic_server_session.h",
-        "envoy_quic_server_stream.h",
-    ],
-    tags = ["nofips"],
-    deps = [
-        ":envoy_quic_connection_debug_visitor_factory_interface",
-        ":envoy_quic_proof_source_lib",
-        ":envoy_quic_server_connection_lib",
-        ":envoy_quic_server_crypto_stream_factory_lib",
-        ":envoy_quic_stream_lib",
-        ":envoy_quic_utils_lib",
-        ":quic_filter_manager_connection_lib",
-        ":quic_stat_names_lib",
-        ":quic_stats_gatherer",
-        "//source/common/buffer:buffer_lib",
-        "//source/common/common:assert_lib",
-        "//source/common/http:header_map_lib",
-        "@com_github_google_quiche//:quic_server_http_spdy_session_lib",
-        "@com_google_absl//absl/types:optional",
-    ] + envoy_select_enable_http_datagrams([
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "envoy_quic_server_session.cc",
+            "envoy_quic_server_stream.cc",
+        ],
+    }),
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "envoy_quic_server_session.h",
+            "envoy_quic_server_stream.h",
+        ],
+    }),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":envoy_quic_connection_debug_visitor_factory_interface",
+            ":envoy_quic_proof_source_lib",
+            ":envoy_quic_server_connection_lib",
+            ":envoy_quic_server_crypto_stream_factory_lib",
+            ":envoy_quic_stream_lib",
+            ":envoy_quic_utils_lib",
+            ":quic_filter_manager_connection_lib",
+            ":quic_stat_names_lib",
+            ":quic_stats_gatherer",
+            "//source/common/buffer:buffer_lib",
+            "//source/common/common:assert_lib",
+            "//source/common/http:header_map_lib",
+            "@com_github_google_quiche//:quic_server_http_spdy_session_lib",
+            "@com_google_absl//absl/types:optional",
+        ],
+    }) + envoy_select_enable_http_datagrams([
         ":http_datagram_handler",
     ]),
 )
 
 envoy_cc_library(
     name = "envoy_quic_client_session_lib",
-    srcs = [
-        "envoy_quic_client_session.cc",
-        "envoy_quic_client_stream.cc",
-        "quic_network_connectivity_observer.cc",
-    ],
-    hdrs = [
-        "envoy_quic_client_session.h",
-        "envoy_quic_client_stream.h",
-        "envoy_quic_network_observer_registry_factory.h",
-        "quic_network_connectivity_observer.h",
-    ],
-    tags = ["nofips"],
-    deps = [
-        ":envoy_quic_client_connection_lib",
-        ":envoy_quic_client_crypto_stream_factory_lib",
-        ":envoy_quic_proof_verifier_lib",
-        ":envoy_quic_stream_lib",
-        ":envoy_quic_utils_lib",
-        ":quic_filter_manager_connection_lib",
-        ":quic_stat_names_lib",
-        ":quic_transport_socket_factory_lib",
-        "//envoy/http:http_server_properties_cache_interface",
-        "//source/common/buffer:buffer_lib",
-        "//source/common/common:assert_lib",
-        "//source/common/http:codes_lib",
-        "//source/common/http:header_map_lib",
-        "//source/common/http:header_utility_lib",
-        "@com_github_google_quiche//:quic_core_http_client_lib",
-    ] + envoy_select_enable_http_datagrams([
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "envoy_quic_client_session.cc",
+            "envoy_quic_client_stream.cc",
+            "quic_network_connectivity_observer.cc",
+        ],
+    }),
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "envoy_quic_client_session.h",
+            "envoy_quic_client_stream.h",
+            "envoy_quic_network_observer_registry_factory.h",
+            "quic_network_connectivity_observer.h",
+        ],
+    }),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":envoy_quic_client_connection_lib",
+            ":envoy_quic_client_crypto_stream_factory_lib",
+            ":envoy_quic_proof_verifier_lib",
+            ":envoy_quic_stream_lib",
+            ":envoy_quic_utils_lib",
+            ":quic_filter_manager_connection_lib",
+            ":quic_stat_names_lib",
+            ":quic_transport_socket_factory_lib",
+            "//envoy/http:http_server_properties_cache_interface",
+            "//source/common/buffer:buffer_lib",
+            "//source/common/common:assert_lib",
+            "//source/common/http:codes_lib",
+            "//source/common/http:header_map_lib",
+            "//source/common/http:header_utility_lib",
+            "@com_github_google_quiche//:quic_core_http_client_lib",
+        ],
+    }) + envoy_select_enable_http_datagrams([
         ":http_datagram_handler",
     ]),
 )
@@ -346,7 +488,6 @@ envoy_cc_library(
     hdrs = [
         "envoy_quic_network_observer_registry_factory.h",
     ],
-    tags = ["nofips"],
     deps = envoy_select_enable_http3([
         ":envoy_quic_client_session_lib",
     ]),
@@ -365,7 +506,6 @@ envoy_cc_library(
     name = "quic_network_connection_lib",
     srcs = ["quic_network_connection.cc"],
     hdrs = ["quic_network_connection.h"],
-    tags = ["nofips"],
     deps = [
         "//envoy/network:connection_interface",
     ],
@@ -373,54 +513,78 @@ envoy_cc_library(
 
 envoy_cc_library(
     name = "envoy_quic_server_connection_lib",
-    srcs = ["envoy_quic_server_connection.cc"],
-    hdrs = ["envoy_quic_server_connection.h"],
-    tags = ["nofips"],
-    deps = [
-        ":quic_io_handle_wrapper_lib",
-        ":quic_network_connection_lib",
-        "//source/common/network:generic_listener_filter_impl_base_lib",
-        "//source/common/network:listen_socket_lib",
-        "//source/common/quic:envoy_quic_utils_lib",
-        "@com_github_google_quiche//:quic_core_connection_lib",
-        "@com_github_google_quiche//:quic_core_packet_writer_lib",
-        "@com_github_google_quiche//:quic_core_packets_lib",
-    ],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_server_connection.cc"],
+    }),
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_server_connection.h"],
+    }),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":quic_io_handle_wrapper_lib",
+            ":quic_network_connection_lib",
+            "//source/common/network:generic_listener_filter_impl_base_lib",
+            "//source/common/network:listen_socket_lib",
+            "//source/common/quic:envoy_quic_utils_lib",
+            "@com_github_google_quiche//:quic_core_connection_lib",
+            "@com_github_google_quiche//:quic_core_packet_writer_lib",
+            "@com_github_google_quiche//:quic_core_packets_lib",
+        ],
+    }),
 )
 
 envoy_cc_library(
     name = "envoy_quic_client_connection_lib",
-    srcs = ["envoy_quic_client_connection.cc"],
-    hdrs = ["envoy_quic_client_connection.h"],
-    tags = ["nofips"],
-    deps = [
-        ":envoy_quic_packet_writer_lib",
-        ":quic_network_connection_lib",
-        "//envoy/event:dispatcher_interface",
-        "//source/common/network:socket_option_factory_lib",
-        "//source/common/network:udp_packet_writer_handler_lib",
-        "//source/common/runtime:runtime_lib",
-        "@com_github_google_quiche//:quic_core_connection_lib",
-        "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
-    ],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_client_connection.cc"],
+    }),
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_client_connection.h"],
+    }),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":envoy_quic_packet_writer_lib",
+            ":quic_network_connection_lib",
+            "//envoy/event:dispatcher_interface",
+            "//source/common/network:socket_option_factory_lib",
+            "//source/common/network:udp_packet_writer_handler_lib",
+            "//source/common/runtime:runtime_lib",
+            "@com_github_google_quiche//:quic_core_connection_lib",
+            "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
+        ],
+    }),
 )
 
 envoy_cc_library(
     name = "envoy_quic_dispatcher_lib",
-    srcs = ["envoy_quic_dispatcher.cc"],
-    hdrs = ["envoy_quic_dispatcher.h"],
-    tags = ["nofips"],
-    deps = [
-        ":envoy_quic_connection_debug_visitor_factory_interface",
-        ":envoy_quic_proof_source_lib",
-        ":envoy_quic_server_connection_lib",
-        ":envoy_quic_server_crypto_stream_factory_lib",
-        ":envoy_quic_server_session_lib",
-        ":quic_stat_names_lib",
-        "//envoy/network:listener_interface",
-        "@com_github_google_quiche//:quic_core_server_lib",
-        "@com_github_google_quiche//:quic_core_utils_lib",
-    ],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_dispatcher.cc"],
+    }),
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_dispatcher.h"],
+    }),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":envoy_quic_connection_debug_visitor_factory_interface",
+            ":envoy_quic_proof_source_lib",
+            ":envoy_quic_server_connection_lib",
+            ":envoy_quic_server_crypto_stream_factory_lib",
+            ":envoy_quic_server_session_lib",
+            ":quic_stat_names_lib",
+            "//envoy/network:listener_interface",
+            "@com_github_google_quiche//:quic_core_server_lib",
+            "@com_github_google_quiche//:quic_core_utils_lib",
+        ],
+    }),
 )
 
 envoy_cc_library(
@@ -431,105 +595,137 @@ envoy_cc_library(
 
 envoy_cc_library(
     name = "active_quic_listener_lib",
-    srcs = ["active_quic_listener.cc"],
-    hdrs = ["active_quic_listener.h"],
-    tags = ["nofips"],
-    deps = [
-        ":envoy_quic_alarm_factory_lib",
-        ":envoy_quic_connection_debug_visitor_factory_interface",
-        ":envoy_quic_connection_helper_lib",
-        ":envoy_quic_dispatcher_lib",
-        ":envoy_quic_packet_writer_lib",
-        ":envoy_quic_proof_source_factory_interface",
-        ":envoy_quic_proof_source_lib",
-        ":envoy_quic_server_preferred_address_config_factory_interface",
-        ":envoy_quic_utils_lib",
-        "//envoy/network:listener_interface",
-        "//source/common/network:listener_lib",
-        "//source/common/protobuf:utility_lib",
-        "//source/common/runtime:runtime_lib",
-        "//source/extensions/quic/connection_id_generator/deterministic:envoy_deterministic_connection_id_generator_config",
-        "//source/server:active_udp_listener",
-        "@envoy_api//envoy/config/listener/v3:pkg_cc_proto",
-        "@envoy_api//envoy/extensions/quic/connection_id_generator/v3:pkg_cc_proto",
-        "@envoy_api//envoy/extensions/quic/crypto_stream/v3:pkg_cc_proto",
-        "@envoy_api//envoy/extensions/quic/proof_source/v3:pkg_cc_proto",
-    ],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["active_quic_listener.cc"],
+    }),
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["active_quic_listener.h"],
+    }),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":envoy_quic_alarm_factory_lib",
+            ":envoy_quic_connection_debug_visitor_factory_interface",
+            ":envoy_quic_connection_helper_lib",
+            ":envoy_quic_dispatcher_lib",
+            ":envoy_quic_packet_writer_lib",
+            ":envoy_quic_proof_source_factory_interface",
+            ":envoy_quic_proof_source_lib",
+            ":envoy_quic_server_preferred_address_config_factory_interface",
+            ":envoy_quic_utils_lib",
+            "//envoy/network:listener_interface",
+            "//source/common/network:listener_lib",
+            "//source/common/protobuf:utility_lib",
+            "//source/common/runtime:runtime_lib",
+            "//source/extensions/quic/connection_id_generator/deterministic:envoy_deterministic_connection_id_generator_config",
+            "//source/server:active_udp_listener",
+            "@envoy_api//envoy/config/listener/v3:pkg_cc_proto",
+            "@envoy_api//envoy/extensions/quic/connection_id_generator/v3:pkg_cc_proto",
+            "@envoy_api//envoy/extensions/quic/crypto_stream/v3:pkg_cc_proto",
+            "@envoy_api//envoy/extensions/quic/proof_source/v3:pkg_cc_proto",
+        ],
+    }),
 )
 
 envoy_cc_library(
     name = "envoy_quic_utils_lib",
-    srcs = ["envoy_quic_utils.cc"],
-    hdrs = ["envoy_quic_utils.h"],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_utils.cc"],
+    }),
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_utils.h"],
+    }),
     external_deps = ["ssl"],
-    tags = ["nofips"],
-    deps = [
-        "//envoy/http:codec_interface",
-        "//source/common/http:header_map_lib",
-        "//source/common/http:header_utility_lib",
-        "//source/common/network:address_lib",
-        "//source/common/network:connection_socket_lib",
-        "//source/common/network:socket_option_factory_lib",
-        "//source/common/protobuf:utility_lib",
-        "//source/common/quic:quic_io_handle_wrapper_lib",
-        "@com_github_google_quiche//:quic_core_config_lib",
-        "@com_github_google_quiche//:quic_core_http_header_list_lib",
-        "@com_github_google_quiche//:quic_platform",
-        "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
-        "@envoy_api//envoy/config/listener/v3:pkg_cc_proto",
-    ],
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//envoy/http:codec_interface",
+            "//source/common/http:header_map_lib",
+            "//source/common/http:header_utility_lib",
+            "//source/common/network:address_lib",
+            "//source/common/network:connection_socket_lib",
+            "//source/common/network:socket_option_factory_lib",
+            "//source/common/protobuf:utility_lib",
+            "//source/common/quic:quic_io_handle_wrapper_lib",
+            "@com_github_google_quiche//:quic_core_config_lib",
+            "@com_github_google_quiche//:quic_core_http_header_list_lib",
+            "@com_github_google_quiche//:quic_platform",
+            "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
+            "@envoy_api//envoy/config/listener/v3:pkg_cc_proto",
+        ],
+    }),
 )
 
 envoy_cc_library(
     name = "quic_transport_socket_factory_lib",
-    srcs = [
-        "quic_client_transport_socket_factory.cc",
-        "quic_transport_socket_factory.cc",
-    ],
-    hdrs = [
-        "quic_client_transport_socket_factory.h",
-        "quic_transport_socket_factory.h",
-    ],
-    tags = ["nofips"],
-    deps = [
-        ":envoy_quic_proof_verifier_lib",
-        "//envoy/network:transport_socket_interface",
-        "//envoy/server:transport_socket_config_interface",
-        "//envoy/ssl:context_config_interface",
-        "//source/common/common:assert_lib",
-        "//source/common/network:transport_socket_options_lib",
-        "//source/common/quic:cert_compression_lib",
-        "//source/common/tls:client_ssl_socket_lib",
-        "//source/common/tls:context_config_lib",
-        "@com_github_google_quiche//:quic_core_crypto_crypto_handshake_lib",
-        "@envoy_api//envoy/extensions/transport_sockets/quic/v3:pkg_cc_proto",
-    ],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "quic_client_transport_socket_factory.cc",
+            "quic_transport_socket_factory.cc",
+        ],
+    }),
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "quic_client_transport_socket_factory.h",
+            "quic_transport_socket_factory.h",
+        ],
+    }),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":envoy_quic_proof_verifier_lib",
+            "//envoy/network:transport_socket_interface",
+            "//envoy/server:transport_socket_config_interface",
+            "//envoy/ssl:context_config_interface",
+            "//source/common/common:assert_lib",
+            "//source/common/network:transport_socket_options_lib",
+            "//source/common/quic:cert_compression_lib",
+            "//source/common/tls:client_ssl_socket_lib",
+            "//source/common/tls:context_config_lib",
+            "@com_github_google_quiche//:quic_core_crypto_crypto_handshake_lib",
+            "@envoy_api//envoy/extensions/transport_sockets/quic/v3:pkg_cc_proto",
+        ],
+    }),
     alwayslink = LEGACY_ALWAYSLINK,
 )
 
 envoy_cc_library(
     name = "quic_server_transport_socket_factory_lib",
-    srcs = [
-        "quic_server_transport_socket_factory.cc",
-    ],
-    hdrs = [
-        "quic_server_transport_socket_factory.h",
-    ],
-    tags = ["nofips"],
-    deps = [
-        ":envoy_quic_proof_verifier_lib",
-        ":quic_transport_socket_factory_lib",
-        "//envoy/network:transport_socket_interface",
-        "//envoy/server:transport_socket_config_interface",
-        "//envoy/ssl:context_config_interface",
-        "//source/common/common:assert_lib",
-        "//source/common/network:transport_socket_options_lib",
-        "//source/common/tls:server_context_config_lib",
-        "//source/common/tls:server_context_lib",
-        "//source/common/tls:server_ssl_socket_lib",
-        "@com_github_google_quiche//:quic_core_crypto_crypto_handshake_lib",
-        "@envoy_api//envoy/extensions/transport_sockets/quic/v3:pkg_cc_proto",
-    ],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "quic_server_transport_socket_factory.cc",
+        ],
+    }),
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "quic_server_transport_socket_factory.h",
+        ],
+    }),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":envoy_quic_proof_verifier_lib",
+            ":quic_transport_socket_factory_lib",
+            "//envoy/network:transport_socket_interface",
+            "//envoy/server:transport_socket_config_interface",
+            "//envoy/ssl:context_config_interface",
+            "//source/common/common:assert_lib",
+            "//source/common/network:transport_socket_options_lib",
+            "//source/common/tls:server_context_config_lib",
+            "//source/common/tls:server_context_lib",
+            "//source/common/tls:server_ssl_socket_lib",
+            "@com_github_google_quiche//:quic_core_crypto_crypto_handshake_lib",
+            "@envoy_api//envoy/extensions/transport_sockets/quic/v3:pkg_cc_proto",
+        ],
+    }),
     alwayslink = LEGACY_ALWAYSLINK,
 )
 
@@ -537,13 +733,8 @@ envoy_cc_library(
 # All of these are needed for this extension to function.
 envoy_cc_library(
     name = "quic_client_factory_lib",
-    tags = ["nofips"],
-    # QUICHE can't build against FIPS BoringSSL until the FIPS build
-    # is on a new enough version to have QUIC support. Remove it from
-    # the build until then. Re-enable as part of #7433.
     deps = select({
-        "//bazel:boringssl_fips": [],
-        "//bazel:boringssl_disabled": [],
+        "//bazel:disable_http3": [],
         "//conditions:default": [
             ":client_codec_lib",
             ":quic_transport_socket_factory_lib",
@@ -568,13 +759,8 @@ envoy_cc_library(
 # All of these are needed for this extension to function.
 envoy_cc_library(
     name = "quic_server_factory_lib",
-    tags = ["nofips"],
-    # QUICHE can't build against FIPS BoringSSL until the FIPS build
-    # is on a new enough version to have QUIC support. Remove it from
-    # the build until then. Re-enable as part of #7433.
     deps = select({
-        "//bazel:boringssl_fips": [],
-        "//bazel:boringssl_disabled": [],
+        "//bazel:disable_http3": [],
         "//conditions:default": [
             ":quic_transport_socket_factory_lib",
             ":server_codec_lib",
@@ -586,155 +772,235 @@ envoy_cc_library(
 
 envoy_cc_library(
     name = "envoy_quic_packet_writer_lib",
-    srcs = ["envoy_quic_packet_writer.cc"],
-    hdrs = ["envoy_quic_packet_writer.h"],
-    tags = ["nofips"],
-    deps = [
-        ":envoy_quic_utils_lib",
-        "@com_github_google_quiche//:quic_core_packet_writer_lib",
-        "@com_github_google_quiche//:quic_platform",
-    ],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_packet_writer.cc"],
+    }),
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_packet_writer.h"],
+    }),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":envoy_quic_utils_lib",
+            "@com_github_google_quiche//:quic_core_packet_writer_lib",
+            "@com_github_google_quiche//:quic_platform",
+        ],
+    }),
 )
 
 envoy_cc_library(
     name = "udp_gso_batch_writer_lib",
     srcs = select({
-        "//bazel:linux": ["udp_gso_batch_writer.cc"],
+        ":http3_enabled_and_linux": ["udp_gso_batch_writer.cc"],
         "//conditions:default": [],
     }),
-    hdrs = ["udp_gso_batch_writer.h"],
-    tags = ["nofips"],
-    deps = [
-        ":envoy_quic_utils_lib",
-        "//envoy/network:udp_packet_writer_handler_interface",
-        "//source/common/network:io_socket_error_lib",
-        "//source/common/protobuf:utility_lib",
-        "//source/common/runtime:runtime_lib",
-        "@com_github_google_quiche//:quic_platform",
-    ] + select({
-        "//bazel:linux": ["@com_github_google_quiche//:quic_core_batch_writer_gso_batch_writer_lib"],
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["udp_gso_batch_writer.h"],
+    }),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":envoy_quic_utils_lib",
+            "//envoy/network:udp_packet_writer_handler_interface",
+            "//source/common/network:io_socket_error_lib",
+            "//source/common/protobuf:utility_lib",
+            "//source/common/runtime:runtime_lib",
+            "@com_github_google_quiche//:quic_platform",
+        ],
+    }) + select({
+        ":http3_enabled_and_linux": ["@com_github_google_quiche//:quic_core_batch_writer_gso_batch_writer_lib"],
         "//conditions:default": [],
     }),
 )
 
 envoy_cc_library(
     name = "send_buffer_monitor_lib",
-    srcs = ["send_buffer_monitor.cc"],
-    hdrs = ["send_buffer_monitor.h"],
-    tags = ["nofips"],
-    deps = [
-        "//source/common/common:assert_lib",
-        "@com_github_google_quiche//:quic_core_session_lib",
-    ],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["send_buffer_monitor.cc"],
+    }),
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["send_buffer_monitor.h"],
+    }),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//source/common/common:assert_lib",
+            "@com_github_google_quiche//:quic_core_session_lib",
+        ],
+    }),
 )
 
 envoy_cc_library(
     name = "envoy_quic_client_crypto_stream_factory_lib",
-    hdrs = ["envoy_quic_client_crypto_stream_factory.h"],
-    tags = ["nofips"],
-    deps = [
-        "//envoy/common:optref_lib",
-        "//envoy/config:typed_config_interface",
-        "//envoy/network:transport_socket_interface",
-        "@com_github_google_quiche//:quic_client_session_lib",
-        "@com_github_google_quiche//:quic_core_http_spdy_session_lib",
-    ],
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_client_crypto_stream_factory.h"],
+    }),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//envoy/common:optref_lib",
+            "//envoy/config:typed_config_interface",
+            "//envoy/network:transport_socket_interface",
+            "@com_github_google_quiche//:quic_client_session_lib",
+            "@com_github_google_quiche//:quic_core_http_spdy_session_lib",
+        ],
+    }),
 )
 
 envoy_cc_library(
     name = "envoy_quic_server_crypto_stream_factory_lib",
-    hdrs = ["envoy_quic_server_crypto_stream_factory.h"],
-    tags = ["nofips"],
-    deps = [
-        "//envoy/config:typed_config_interface",
-        "@com_github_google_quiche//:quic_core_http_spdy_session_lib",
-        "@com_github_google_quiche//:quic_server_session_lib",
-    ],
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_server_crypto_stream_factory.h"],
+    }),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//envoy/config:typed_config_interface",
+            "@com_github_google_quiche//:quic_core_http_spdy_session_lib",
+            "@com_github_google_quiche//:quic_server_session_lib",
+        ],
+    }),
 )
 
 envoy_cc_library(
     name = "envoy_quic_proof_source_factory_interface",
-    hdrs = ["envoy_quic_proof_source_factory_interface.h"],
-    tags = ["nofips"],
-    deps = [
-        "//envoy/config:typed_config_interface",
-        "@com_github_google_quiche//:quic_core_crypto_proof_source_lib",
-    ],
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_proof_source_factory_interface.h"],
+    }),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//envoy/config:typed_config_interface",
+            "@com_github_google_quiche//:quic_core_crypto_proof_source_lib",
+        ],
+    }),
 )
 
 envoy_cc_library(
     name = "envoy_quic_connection_id_generator_factory_interface",
-    hdrs = ["envoy_quic_connection_id_generator_factory.h"],
-    tags = ["nofips"],
-    deps = [
-        "//envoy/config:typed_config_interface",
-        "@com_github_google_quiche//:quic_core_connection_id_generator_interface_lib",
-        "@com_github_google_quiche//:quic_load_balancer_encoder_lib",
-    ],
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_connection_id_generator_factory.h"],
+    }),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//envoy/config:typed_config_interface",
+            "@com_github_google_quiche//:quic_core_connection_id_generator_interface_lib",
+            "@com_github_google_quiche//:quic_load_balancer_encoder_lib",
+        ],
+    }),
 )
 
 envoy_cc_library(
     name = "envoy_deterministic_connection_id_generator_lib",
-    srcs = ["envoy_deterministic_connection_id_generator.cc"],
-    hdrs = ["envoy_deterministic_connection_id_generator.h"],
-    tags = ["nofips"],
-    deps = [
-        ":envoy_quic_connection_id_generator_factory_interface",
-        ":envoy_quic_utils_lib",
-        "@com_github_google_quiche//:quic_core_deterministic_connection_id_generator_lib",
-    ],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_deterministic_connection_id_generator.cc"],
+    }),
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_deterministic_connection_id_generator.h"],
+    }),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":envoy_quic_connection_id_generator_factory_interface",
+            ":envoy_quic_utils_lib",
+            "@com_github_google_quiche//:quic_core_deterministic_connection_id_generator_lib",
+        ],
+    }),
 )
 
 envoy_cc_library(
     name = "envoy_quic_server_preferred_address_config_factory_interface",
-    hdrs = ["envoy_quic_server_preferred_address_config_factory.h"],
-    tags = ["nofips"],
-    deps = [
-        "//envoy/config:typed_config_interface",
-        "//envoy/network:address_interface",
-        "//envoy/server:factory_context_interface",
-        "@com_github_google_quiche//:quic_platform_socket_address",
-    ],
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_server_preferred_address_config_factory.h"],
+    }),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//envoy/config:typed_config_interface",
+            "//envoy/network:address_interface",
+            "//envoy/server:factory_context_interface",
+            "@com_github_google_quiche//:quic_platform_socket_address",
+        ],
+    }),
 )
 
 envoy_cc_library(
     name = "quic_stats_gatherer",
-    srcs = ["quic_stats_gatherer.cc"],
-    hdrs = ["quic_stats_gatherer.h"],
-    tags = ["nofips"],
-    deps = [
-        "//envoy/access_log:access_log_interface",
-        "//envoy/formatter:http_formatter_context_interface",
-        "//envoy/http:codec_interface",
-        "//source/common/formatter:substitution_formatter_lib",
-        "//source/common/http:header_map_lib",
-        "@com_github_google_quiche//:quic_core_ack_listener_interface_lib",
-    ],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["quic_stats_gatherer.cc"],
+    }),
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["quic_stats_gatherer.h"],
+    }),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//envoy/access_log:access_log_interface",
+            "//envoy/formatter:http_formatter_context_interface",
+            "//envoy/http:codec_interface",
+            "//source/common/formatter:substitution_formatter_lib",
+            "//source/common/http:header_map_lib",
+            "@com_github_google_quiche//:quic_core_ack_listener_interface_lib",
+        ],
+    }),
 )
 
 envoy_cc_library(
     name = "http_datagram_handler",
-    srcs = ["http_datagram_handler.cc"],
-    hdrs = ["http_datagram_handler.h"],
-    deps = [
-        "//envoy/http:codec_interface",
-        "//source/common/buffer:buffer_lib",
-        "//source/common/common:logger_lib",
-        "//source/common/http:header_map_lib",
-        "@com_github_google_quiche//:quic_core_http_spdy_session_lib",
-        "@com_github_google_quiche//:quic_core_types_lib",
-    ],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["http_datagram_handler.cc"],
+    }),
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["http_datagram_handler.h"],
+    }),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//envoy/http:codec_interface",
+            "//source/common/buffer:buffer_lib",
+            "//source/common/common:logger_lib",
+            "//source/common/http:header_map_lib",
+            "@com_github_google_quiche//:quic_core_http_spdy_session_lib",
+            "@com_github_google_quiche//:quic_core_types_lib",
+        ],
+    }),
 )
 
 envoy_cc_library(
     name = "cert_compression_lib",
-    srcs = ["cert_compression.cc"],
-    hdrs = ["cert_compression.h"],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["cert_compression.cc"],
+    }),
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["cert_compression.h"],
+    }),
     external_deps = ["ssl"],
-    deps = [
-        "//bazel/foreign_cc:zlib",
-        "//source/common/common:assert_lib",
-        "//source/common/common:logger_lib",
-        "//source/common/runtime:runtime_lib",
-    ],
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//bazel/foreign_cc:zlib",
+            "//source/common/common:assert_lib",
+            "//source/common/common:logger_lib",
+            "//source/common/runtime:runtime_lib",
+        ],
+    }),
 )

--- a/source/common/quic/BUILD
+++ b/source/common/quic/BUILD
@@ -29,102 +29,63 @@ envoy_package()
 
 envoy_cc_library(
     name = "envoy_quic_alarm_lib",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_alarm.cc"],
-    }),
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_alarm.h"],
-    }),
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//envoy/event:dispatcher_interface",
-            "//envoy/event:timer_interface",
-            "@com_github_google_quiche//:quic_core_alarm_lib",
-            "@com_github_google_quiche//:quic_core_clock_lib",
-            "@com_github_google_quiche//:quic_platform",
-        ],
-    }),
+    srcs = envoy_select_enable_http3(["envoy_quic_alarm.cc"]),
+    hdrs = envoy_select_enable_http3(["envoy_quic_alarm.h"]),
+    deps = envoy_select_enable_http3([
+        "//envoy/event:dispatcher_interface",
+        "//envoy/event:timer_interface",
+        "@com_github_google_quiche//:quic_core_alarm_lib",
+        "@com_github_google_quiche//:quic_core_clock_lib",
+        "@com_github_google_quiche//:quic_platform",
+    ]),
 )
 
 envoy_cc_library(
     name = "envoy_quic_alarm_factory_lib",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_alarm_factory.cc"],
-    }),
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_alarm_factory.h"],
-    }),
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":envoy_quic_alarm_lib",
-            "@com_github_google_quiche//:quic_core_alarm_factory_lib",
-            "@com_github_google_quiche//:quic_core_arena_scoped_ptr_lib",
-            "@com_github_google_quiche//:quic_core_one_block_arena_lib",
-            "@com_github_google_quiche//:quic_platform",
-        ],
-    }),
+    srcs = envoy_select_enable_http3(["envoy_quic_alarm_factory.cc"]),
+    hdrs = envoy_select_enable_http3(["envoy_quic_alarm_factory.h"]),
+    deps = envoy_select_enable_http3([
+        ":envoy_quic_alarm_lib",
+        "@com_github_google_quiche//:quic_core_alarm_factory_lib",
+        "@com_github_google_quiche//:quic_core_arena_scoped_ptr_lib",
+        "@com_github_google_quiche//:quic_core_one_block_arena_lib",
+        "@com_github_google_quiche//:quic_platform",
+    ]),
 )
 
 envoy_cc_library(
     name = "envoy_quic_clock_lib",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_clock.cc"],
-    }),
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_clock.h"],
-    }),
+    srcs = envoy_select_enable_http3(["envoy_quic_clock.cc"]),
+    hdrs = envoy_select_enable_http3(["envoy_quic_clock.h"]),
     visibility = ["//visibility:public"],
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//envoy/event:dispatcher_interface",
-            "@com_github_google_quiche//:quic_core_clock_lib",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        "//envoy/event:dispatcher_interface",
+        "@com_github_google_quiche//:quic_core_clock_lib",
+    ]),
 )
 
 envoy_cc_library(
     name = "envoy_quic_connection_debug_visitor_factory_interface",
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_connection_debug_visitor_factory_interface.h"],
-    }),
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//envoy/common:optref_lib",
-            "//envoy/common:pure_lib",
-            "//envoy/config:typed_config_interface",
-            "//envoy/server:factory_context_interface",
-            "//envoy/stream_info:stream_info_interface",
-            "@com_github_google_quiche//:quic_core_connection_lib",
-            "@com_github_google_quiche//:quic_core_session_lib",
-        ],
-    }),
+    hdrs = envoy_select_enable_http3(["envoy_quic_connection_debug_visitor_factory_interface.h"]),
+    deps = envoy_select_enable_http3([
+        "//envoy/common:optref_lib",
+        "//envoy/common:pure_lib",
+        "//envoy/config:typed_config_interface",
+        "//envoy/server:factory_context_interface",
+        "//envoy/stream_info:stream_info_interface",
+        "@com_github_google_quiche//:quic_core_connection_lib",
+        "@com_github_google_quiche//:quic_core_session_lib",
+    ]),
 )
 
 envoy_cc_library(
     name = "envoy_quic_connection_helper_lib",
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_connection_helper.h"],
-    }),
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":envoy_quic_clock_lib",
-            "@com_github_google_quiche//:quic_core_connection_lib",
-            "@com_github_google_quiche//:quiche_common_random_lib",
-        ],
-    }),
+    hdrs = envoy_select_enable_http3(["envoy_quic_connection_helper.h"]),
+    deps = envoy_select_enable_http3([
+        ":envoy_quic_clock_lib",
+        "@com_github_google_quiche//:quic_core_connection_lib",
+        "@com_github_google_quiche//:quiche_common_random_lib",
+    ]),
 )
 
 envoy_cc_library(
@@ -147,338 +108,233 @@ envoy_cc_library(
 
 envoy_cc_library(
     name = "envoy_quic_proof_source_base_lib",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_proof_source_base.cc"],
-    }),
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_proof_source_base.h"],
-    }),
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":envoy_quic_utils_lib",
-            "@com_github_google_quiche//:quic_core_crypto_certificate_view_lib",
-            "@com_github_google_quiche//:quic_core_crypto_crypto_handshake_lib",
-            "@com_github_google_quiche//:quic_core_crypto_proof_source_lib",
-            "@com_github_google_quiche//:quic_core_data_lib",
-            "@com_github_google_quiche//:quic_core_versions_lib",
-            "@com_github_google_quiche//:quic_platform",
-        ],
-    }),
+    srcs = envoy_select_enable_http3(["envoy_quic_proof_source_base.cc"]),
+    hdrs = envoy_select_enable_http3(["envoy_quic_proof_source_base.h"]),
+    deps = envoy_select_enable_http3([
+        ":envoy_quic_utils_lib",
+        "@com_github_google_quiche//:quic_core_crypto_certificate_view_lib",
+        "@com_github_google_quiche//:quic_core_crypto_crypto_handshake_lib",
+        "@com_github_google_quiche//:quic_core_crypto_proof_source_lib",
+        "@com_github_google_quiche//:quic_core_data_lib",
+        "@com_github_google_quiche//:quic_core_versions_lib",
+        "@com_github_google_quiche//:quic_platform",
+    ]),
 )
 
 envoy_cc_library(
     name = "envoy_quic_proof_source_lib",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_proof_source.cc"],
-    }),
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_proof_source.h"],
-    }),
+    srcs = envoy_select_enable_http3(["envoy_quic_proof_source.cc"]),
+    hdrs = envoy_select_enable_http3(["envoy_quic_proof_source.h"]),
     external_deps = ["ssl"],
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":envoy_quic_proof_source_base_lib",
-            ":envoy_quic_utils_lib",
-            ":quic_io_handle_wrapper_lib",
-            ":quic_transport_socket_factory_lib",
-            "//envoy/ssl:tls_certificate_config_interface",
-            "//source/common/quic:cert_compression_lib",
-            "//source/common/quic:quic_server_transport_socket_factory_lib",
-            "//source/common/stream_info:stream_info_lib",
-            "//source/server:listener_stats",
-            "@com_github_google_quiche//:quic_core_crypto_certificate_view_lib",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        ":envoy_quic_proof_source_base_lib",
+        ":envoy_quic_utils_lib",
+        ":quic_io_handle_wrapper_lib",
+        ":quic_transport_socket_factory_lib",
+        "//envoy/ssl:tls_certificate_config_interface",
+        "//source/common/quic:cert_compression_lib",
+        "//source/common/quic:quic_server_transport_socket_factory_lib",
+        "//source/common/stream_info:stream_info_lib",
+        "//source/server:listener_stats",
+        "@com_github_google_quiche//:quic_core_crypto_certificate_view_lib",
+    ]),
 )
 
 envoy_cc_library(
     name = "envoy_quic_proof_verifier_base_lib",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_proof_verifier_base.cc"],
-    }),
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_proof_verifier_base.h"],
-    }),
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":envoy_quic_utils_lib",
-            "@com_github_google_quiche//:quic_core_crypto_certificate_view_lib",
-            "@com_github_google_quiche//:quic_core_crypto_crypto_handshake_lib",
-            "@com_github_google_quiche//:quic_core_versions_lib",
-            "@com_github_google_quiche//:quic_platform",
-        ],
-    }),
+    srcs = envoy_select_enable_http3(["envoy_quic_proof_verifier_base.cc"]),
+    hdrs = envoy_select_enable_http3(["envoy_quic_proof_verifier_base.h"]),
+    deps = envoy_select_enable_http3([
+        ":envoy_quic_utils_lib",
+        "@com_github_google_quiche//:quic_core_crypto_certificate_view_lib",
+        "@com_github_google_quiche//:quic_core_crypto_crypto_handshake_lib",
+        "@com_github_google_quiche//:quic_core_versions_lib",
+        "@com_github_google_quiche//:quic_platform",
+    ]),
 )
 
 envoy_cc_library(
     name = "envoy_quic_proof_verifier_lib",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_proof_verifier.cc"],
-    }),
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_proof_verifier.h"],
-    }),
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":envoy_quic_proof_verifier_base_lib",
-            ":envoy_quic_utils_lib",
-            ":quic_ssl_connection_info_lib",
-            "//source/common/tls:context_lib",
-            "@com_github_google_quiche//:quic_platform",
-        ],
-    }),
+    srcs = envoy_select_enable_http3(["envoy_quic_proof_verifier.cc"]),
+    hdrs = envoy_select_enable_http3(["envoy_quic_proof_verifier.h"]),
+    deps = envoy_select_enable_http3([
+        ":envoy_quic_proof_verifier_base_lib",
+        ":envoy_quic_utils_lib",
+        ":quic_ssl_connection_info_lib",
+        "//source/common/tls:context_lib",
+        "@com_github_google_quiche//:quic_platform",
+    ]),
 )
 
 envoy_cc_library(
     name = "envoy_quic_stream_lib",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_stream.cc"],
-    }),
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_stream.h"],
-    }),
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":envoy_quic_simulated_watermark_buffer_lib",
-            ":envoy_quic_utils_lib",
-            ":quic_filter_manager_connection_lib",
-            ":quic_stats_gatherer",
-            ":send_buffer_monitor_lib",
-            "//envoy/event:dispatcher_interface",
-            "//envoy/http:codec_interface",
-            "//source/common/http:codec_helper_lib",
-            "@com_github_google_quiche//:http2_adapter",
-            "@com_github_google_quiche//:quic_core_http_client_lib",
-            "@com_github_google_quiche//:quic_core_http_http_encoder_lib",
-            "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
-        ],
-    }) + envoy_select_enable_http_datagrams([
+    srcs = envoy_select_enable_http3(["envoy_quic_stream.cc"]),
+    hdrs = envoy_select_enable_http3(["envoy_quic_stream.h"]),
+    deps = envoy_select_enable_http3([
+        ":envoy_quic_simulated_watermark_buffer_lib",
+        ":envoy_quic_utils_lib",
+        ":quic_filter_manager_connection_lib",
+        ":quic_stats_gatherer",
+        ":send_buffer_monitor_lib",
+        "//envoy/event:dispatcher_interface",
+        "//envoy/http:codec_interface",
+        "//source/common/http:codec_helper_lib",
+        "@com_github_google_quiche//:http2_adapter",
+        "@com_github_google_quiche//:quic_core_http_client_lib",
+        "@com_github_google_quiche//:quic_core_http_http_encoder_lib",
+        "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
+    ]) + envoy_select_enable_http_datagrams([
         ":http_datagram_handler",
     ]),
 )
 
 envoy_cc_library(
     name = "client_connection_factory_lib",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["client_connection_factory_impl.cc"],
-    }),
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["client_connection_factory_impl.h"],
-    }),
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":envoy_quic_alarm_factory_lib",
-            ":envoy_quic_client_session_lib",
-            ":envoy_quic_connection_helper_lib",
-            ":envoy_quic_proof_verifier_lib",
-            ":envoy_quic_utils_lib",
-            "//envoy/http:codec_interface",
-            "//envoy/http:persistent_quic_info_interface",
-            "//envoy/registry",
-            "//source/common/runtime:runtime_lib",
-            "//source/common/tls:client_ssl_socket_lib",
-            "//source/extensions/quic/crypto_stream:envoy_quic_crypto_client_stream_lib",
-            "@com_github_google_quiche//:quic_core_http_spdy_session_lib",
-        ],
-    }),
+    srcs = envoy_select_enable_http3(["client_connection_factory_impl.cc"]),
+    hdrs = envoy_select_enable_http3(["client_connection_factory_impl.h"]),
+    deps = envoy_select_enable_http3([
+        ":envoy_quic_alarm_factory_lib",
+        ":envoy_quic_client_session_lib",
+        ":envoy_quic_connection_helper_lib",
+        ":envoy_quic_proof_verifier_lib",
+        ":envoy_quic_utils_lib",
+        "//envoy/http:codec_interface",
+        "//envoy/http:persistent_quic_info_interface",
+        "//envoy/registry",
+        "//source/common/runtime:runtime_lib",
+        "//source/common/tls:client_ssl_socket_lib",
+        "//source/extensions/quic/crypto_stream:envoy_quic_crypto_client_stream_lib",
+        "@com_github_google_quiche//:quic_core_http_spdy_session_lib",
+    ]),
 )
 
 envoy_cc_library(
     name = "client_codec_lib",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["client_codec_impl.cc"],
-    }),
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "client_codec_impl.h",
-            "codec_impl.h",
-        ],
-    }),
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":envoy_quic_client_session_lib",
-            ":envoy_quic_utils_lib",
-            "//envoy/http:codec_interface",
-            "//envoy/registry",
-            "@com_github_google_quiche//:quic_core_http_spdy_session_lib",
-        ],
-    }),
+    srcs = envoy_select_enable_http3(["client_codec_impl.cc"]),
+    hdrs = envoy_select_enable_http3([
+        "client_codec_impl.h",
+        "codec_impl.h",
+    ]),
+    deps = envoy_select_enable_http3([
+        ":envoy_quic_client_session_lib",
+        ":envoy_quic_utils_lib",
+        "//envoy/http:codec_interface",
+        "//envoy/registry",
+        "@com_github_google_quiche//:quic_core_http_spdy_session_lib",
+    ]),
 )
 
 envoy_cc_library(
     name = "server_codec_lib",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["server_codec_impl.cc"],
-    }),
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "codec_impl.h",
-            "server_codec_impl.h",
-        ],
-    }),
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":envoy_quic_server_session_lib",
-            ":envoy_quic_utils_lib",
-            ":quic_server_factory_stub_lib",
-            "//envoy/http:codec_interface",
-            "//envoy/registry",
-            "@com_github_google_quiche//:quic_core_http_spdy_session_lib",
-        ],
-    }),
+    srcs = envoy_select_enable_http3(["server_codec_impl.cc"]),
+    hdrs = envoy_select_enable_http3([
+        "codec_impl.h",
+        "server_codec_impl.h",
+    ]),
+    deps = envoy_select_enable_http3([
+        ":envoy_quic_server_session_lib",
+        ":envoy_quic_utils_lib",
+        ":quic_server_factory_stub_lib",
+        "//envoy/http:codec_interface",
+        "//envoy/registry",
+        "@com_github_google_quiche//:quic_core_http_spdy_session_lib",
+    ]),
     alwayslink = LEGACY_ALWAYSLINK,
 )
 
 envoy_cc_library(
     name = "quic_ssl_connection_info_lib",
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["quic_ssl_connection_info.h"],
-    }),
+    hdrs = envoy_select_enable_http3(["quic_ssl_connection_info.h"]),
     external_deps = ["ssl"],
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//source/common/tls:connection_info_impl_base_lib",
-            "@com_github_google_quiche//:quic_core_session_lib",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        "//source/common/tls:connection_info_impl_base_lib",
+        "@com_github_google_quiche//:quic_core_session_lib",
+    ]),
 )
 
 envoy_cc_library(
     name = "quic_filter_manager_connection_lib",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["quic_filter_manager_connection_impl.cc"],
-    }),
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["quic_filter_manager_connection_impl.h"],
-    }),
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":envoy_quic_simulated_watermark_buffer_lib",
-            ":quic_network_connection_lib",
-            ":quic_ssl_connection_info_lib",
-            ":quic_stat_names_lib",
-            ":send_buffer_monitor_lib",
-            "//envoy/event:dispatcher_interface",
-            "//envoy/network:connection_interface",
-            "//source/common/buffer:buffer_lib",
-            "//source/common/common:assert_lib",
-            "//source/common/common:empty_string",
-            "//source/common/http:header_map_lib",
-            "//source/common/http/http3:codec_stats_lib",
-            "//source/common/network:connection_base_lib",
-            "//source/common/stream_info:stream_info_lib",
-            "@com_github_google_quiche//:quic_core_connection_lib",
-        ],
-    }),
+    srcs = envoy_select_enable_http3(["quic_filter_manager_connection_impl.cc"]),
+    hdrs = envoy_select_enable_http3(["quic_filter_manager_connection_impl.h"]),
+    deps = envoy_select_enable_http3([
+        ":envoy_quic_simulated_watermark_buffer_lib",
+        ":quic_network_connection_lib",
+        ":quic_ssl_connection_info_lib",
+        ":quic_stat_names_lib",
+        ":send_buffer_monitor_lib",
+        "//envoy/event:dispatcher_interface",
+        "//envoy/network:connection_interface",
+        "//source/common/buffer:buffer_lib",
+        "//source/common/common:assert_lib",
+        "//source/common/common:empty_string",
+        "//source/common/http:header_map_lib",
+        "//source/common/http/http3:codec_stats_lib",
+        "//source/common/network:connection_base_lib",
+        "//source/common/stream_info:stream_info_lib",
+        "@com_github_google_quiche//:quic_core_connection_lib",
+    ]),
 )
 
 envoy_cc_library(
     name = "envoy_quic_server_session_lib",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "envoy_quic_server_session.cc",
-            "envoy_quic_server_stream.cc",
-        ],
-    }),
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "envoy_quic_server_session.h",
-            "envoy_quic_server_stream.h",
-        ],
-    }),
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":envoy_quic_connection_debug_visitor_factory_interface",
-            ":envoy_quic_proof_source_lib",
-            ":envoy_quic_server_connection_lib",
-            ":envoy_quic_server_crypto_stream_factory_lib",
-            ":envoy_quic_stream_lib",
-            ":envoy_quic_utils_lib",
-            ":quic_filter_manager_connection_lib",
-            ":quic_stat_names_lib",
-            ":quic_stats_gatherer",
-            "//source/common/buffer:buffer_lib",
-            "//source/common/common:assert_lib",
-            "//source/common/http:header_map_lib",
-            "@com_github_google_quiche//:quic_server_http_spdy_session_lib",
-            "@com_google_absl//absl/types:optional",
-        ],
-    }) + envoy_select_enable_http_datagrams([
+    srcs = envoy_select_enable_http3([
+        "envoy_quic_server_session.cc",
+        "envoy_quic_server_stream.cc",
+    ]),
+    hdrs = envoy_select_enable_http3([
+        "envoy_quic_server_session.h",
+        "envoy_quic_server_stream.h",
+    ]),
+    deps = envoy_select_enable_http3([
+        ":envoy_quic_connection_debug_visitor_factory_interface",
+        ":envoy_quic_proof_source_lib",
+        ":envoy_quic_server_connection_lib",
+        ":envoy_quic_server_crypto_stream_factory_lib",
+        ":envoy_quic_stream_lib",
+        ":envoy_quic_utils_lib",
+        ":quic_filter_manager_connection_lib",
+        ":quic_stat_names_lib",
+        ":quic_stats_gatherer",
+        "//source/common/buffer:buffer_lib",
+        "//source/common/common:assert_lib",
+        "//source/common/http:header_map_lib",
+        "@com_github_google_quiche//:quic_server_http_spdy_session_lib",
+        "@com_google_absl//absl/types:optional",
+    ]) + envoy_select_enable_http_datagrams([
         ":http_datagram_handler",
     ]),
 )
 
 envoy_cc_library(
     name = "envoy_quic_client_session_lib",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "envoy_quic_client_session.cc",
-            "envoy_quic_client_stream.cc",
-            "quic_network_connectivity_observer.cc",
-        ],
-    }),
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "envoy_quic_client_session.h",
-            "envoy_quic_client_stream.h",
-            "envoy_quic_network_observer_registry_factory.h",
-            "quic_network_connectivity_observer.h",
-        ],
-    }),
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":envoy_quic_client_connection_lib",
-            ":envoy_quic_client_crypto_stream_factory_lib",
-            ":envoy_quic_proof_verifier_lib",
-            ":envoy_quic_stream_lib",
-            ":envoy_quic_utils_lib",
-            ":quic_filter_manager_connection_lib",
-            ":quic_stat_names_lib",
-            ":quic_transport_socket_factory_lib",
-            "//envoy/http:http_server_properties_cache_interface",
-            "//source/common/buffer:buffer_lib",
-            "//source/common/common:assert_lib",
-            "//source/common/http:codes_lib",
-            "//source/common/http:header_map_lib",
-            "//source/common/http:header_utility_lib",
-            "@com_github_google_quiche//:quic_core_http_client_lib",
-        ],
-    }) + envoy_select_enable_http_datagrams([
+    srcs = envoy_select_enable_http3([
+        "envoy_quic_client_session.cc",
+        "envoy_quic_client_stream.cc",
+        "quic_network_connectivity_observer.cc",
+    ]),
+    hdrs = envoy_select_enable_http3([
+        "envoy_quic_client_session.h",
+        "envoy_quic_client_stream.h",
+        "envoy_quic_network_observer_registry_factory.h",
+        "quic_network_connectivity_observer.h",
+    ]),
+    deps = envoy_select_enable_http3([
+        ":envoy_quic_client_connection_lib",
+        ":envoy_quic_client_crypto_stream_factory_lib",
+        ":envoy_quic_proof_verifier_lib",
+        ":envoy_quic_stream_lib",
+        ":envoy_quic_utils_lib",
+        ":quic_filter_manager_connection_lib",
+        ":quic_stat_names_lib",
+        ":quic_transport_socket_factory_lib",
+        "//envoy/http:http_server_properties_cache_interface",
+        "//source/common/buffer:buffer_lib",
+        "//source/common/common:assert_lib",
+        "//source/common/http:codes_lib",
+        "//source/common/http:header_map_lib",
+        "//source/common/http:header_utility_lib",
+        "@com_github_google_quiche//:quic_core_http_client_lib",
+    ]) + envoy_select_enable_http_datagrams([
         ":http_datagram_handler",
     ]),
 )
@@ -495,237 +351,174 @@ envoy_cc_library(
 
 envoy_cc_library(
     name = "quic_io_handle_wrapper_lib",
-    hdrs = ["quic_io_handle_wrapper.h"],
-    deps = [
+    hdrs = envoy_select_enable_http3(["quic_io_handle_wrapper.h"]),
+    deps = envoy_select_enable_http3([
         "//envoy/network:io_handle_interface",
         "//source/common/network:io_socket_error_lib",
-    ],
+    ]),
 )
 
 envoy_cc_library(
     name = "quic_network_connection_lib",
-    srcs = ["quic_network_connection.cc"],
-    hdrs = ["quic_network_connection.h"],
-    deps = [
+    srcs = envoy_select_enable_http3(["quic_network_connection.cc"]),
+    hdrs = envoy_select_enable_http3(["quic_network_connection.h"]),
+    deps = envoy_select_enable_http3([
         "//envoy/network:connection_interface",
-    ],
+    ]),
 )
 
 envoy_cc_library(
     name = "envoy_quic_server_connection_lib",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_server_connection.cc"],
-    }),
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_server_connection.h"],
-    }),
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":quic_io_handle_wrapper_lib",
-            ":quic_network_connection_lib",
-            "//source/common/network:generic_listener_filter_impl_base_lib",
-            "//source/common/network:listen_socket_lib",
-            "//source/common/quic:envoy_quic_utils_lib",
-            "@com_github_google_quiche//:quic_core_connection_lib",
-            "@com_github_google_quiche//:quic_core_packet_writer_lib",
-            "@com_github_google_quiche//:quic_core_packets_lib",
-        ],
-    }),
+    srcs = envoy_select_enable_http3(["envoy_quic_server_connection.cc"]),
+    hdrs = envoy_select_enable_http3(["envoy_quic_server_connection.h"]),
+    deps = envoy_select_enable_http3([
+        ":quic_io_handle_wrapper_lib",
+        ":quic_network_connection_lib",
+        "//source/common/network:generic_listener_filter_impl_base_lib",
+        "//source/common/network:listen_socket_lib",
+        "//source/common/quic:envoy_quic_utils_lib",
+        "@com_github_google_quiche//:quic_core_connection_lib",
+        "@com_github_google_quiche//:quic_core_packet_writer_lib",
+        "@com_github_google_quiche//:quic_core_packets_lib",
+    ]),
 )
 
 envoy_cc_library(
     name = "envoy_quic_client_connection_lib",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_client_connection.cc"],
-    }),
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_client_connection.h"],
-    }),
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":envoy_quic_packet_writer_lib",
-            ":quic_network_connection_lib",
-            "//envoy/event:dispatcher_interface",
-            "//source/common/network:socket_option_factory_lib",
-            "//source/common/network:udp_packet_writer_handler_lib",
-            "//source/common/runtime:runtime_lib",
-            "@com_github_google_quiche//:quic_core_connection_lib",
-            "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
-        ],
-    }),
+    srcs = envoy_select_enable_http3(["envoy_quic_client_connection.cc"]),
+    hdrs = envoy_select_enable_http3(["envoy_quic_client_connection.h"]),
+    deps = envoy_select_enable_http3([
+        ":envoy_quic_packet_writer_lib",
+        ":quic_network_connection_lib",
+        "//envoy/event:dispatcher_interface",
+        "//source/common/network:socket_option_factory_lib",
+        "//source/common/network:udp_packet_writer_handler_lib",
+        "//source/common/runtime:runtime_lib",
+        "@com_github_google_quiche//:quic_core_connection_lib",
+        "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
+    ]),
 )
 
 envoy_cc_library(
     name = "envoy_quic_dispatcher_lib",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_dispatcher.cc"],
-    }),
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_dispatcher.h"],
-    }),
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":envoy_quic_connection_debug_visitor_factory_interface",
-            ":envoy_quic_proof_source_lib",
-            ":envoy_quic_server_connection_lib",
-            ":envoy_quic_server_crypto_stream_factory_lib",
-            ":envoy_quic_server_session_lib",
-            ":quic_stat_names_lib",
-            "//envoy/network:listener_interface",
-            "@com_github_google_quiche//:quic_core_server_lib",
-            "@com_github_google_quiche//:quic_core_utils_lib",
-        ],
-    }),
+    srcs = envoy_select_enable_http3(["envoy_quic_dispatcher.cc"]),
+    hdrs = envoy_select_enable_http3(["envoy_quic_dispatcher.h"]),
+    deps = envoy_select_enable_http3([
+        ":envoy_quic_connection_debug_visitor_factory_interface",
+        ":envoy_quic_proof_source_lib",
+        ":envoy_quic_server_connection_lib",
+        ":envoy_quic_server_crypto_stream_factory_lib",
+        ":envoy_quic_server_session_lib",
+        ":quic_stat_names_lib",
+        "//envoy/network:listener_interface",
+        "@com_github_google_quiche//:quic_core_server_lib",
+        "@com_github_google_quiche//:quic_core_utils_lib",
+    ]),
 )
 
 envoy_cc_library(
     name = "envoy_quic_simulated_watermark_buffer_lib",
-    hdrs = ["envoy_quic_simulated_watermark_buffer.h"],
-    deps = ["//source/common/common:assert_lib"],
+    hdrs = envoy_select_enable_http3(["envoy_quic_simulated_watermark_buffer.h"]),
+    deps = envoy_select_enable_http3(["//source/common/common:assert_lib"]),
 )
 
 envoy_cc_library(
     name = "active_quic_listener_lib",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["active_quic_listener.cc"],
-    }),
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["active_quic_listener.h"],
-    }),
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":envoy_quic_alarm_factory_lib",
-            ":envoy_quic_connection_debug_visitor_factory_interface",
-            ":envoy_quic_connection_helper_lib",
-            ":envoy_quic_dispatcher_lib",
-            ":envoy_quic_packet_writer_lib",
-            ":envoy_quic_proof_source_factory_interface",
-            ":envoy_quic_proof_source_lib",
-            ":envoy_quic_server_preferred_address_config_factory_interface",
-            ":envoy_quic_utils_lib",
-            "//envoy/network:listener_interface",
-            "//source/common/network:listener_lib",
-            "//source/common/protobuf:utility_lib",
-            "//source/common/runtime:runtime_lib",
-            "//source/extensions/quic/connection_id_generator/deterministic:envoy_deterministic_connection_id_generator_config",
-            "//source/server:active_udp_listener",
-            "@envoy_api//envoy/config/listener/v3:pkg_cc_proto",
-            "@envoy_api//envoy/extensions/quic/connection_id_generator/v3:pkg_cc_proto",
-            "@envoy_api//envoy/extensions/quic/crypto_stream/v3:pkg_cc_proto",
-            "@envoy_api//envoy/extensions/quic/proof_source/v3:pkg_cc_proto",
-        ],
-    }),
+    srcs = envoy_select_enable_http3(["active_quic_listener.cc"]),
+    hdrs = envoy_select_enable_http3(["active_quic_listener.h"]),
+    deps = envoy_select_enable_http3([
+        ":envoy_quic_alarm_factory_lib",
+        ":envoy_quic_connection_debug_visitor_factory_interface",
+        ":envoy_quic_connection_helper_lib",
+        ":envoy_quic_dispatcher_lib",
+        ":envoy_quic_packet_writer_lib",
+        ":envoy_quic_proof_source_factory_interface",
+        ":envoy_quic_proof_source_lib",
+        ":envoy_quic_server_preferred_address_config_factory_interface",
+        ":envoy_quic_utils_lib",
+        "//envoy/network:listener_interface",
+        "//source/common/network:listener_lib",
+        "//source/common/protobuf:utility_lib",
+        "//source/common/runtime:runtime_lib",
+        "//source/extensions/quic/connection_id_generator/deterministic:envoy_deterministic_connection_id_generator_config",
+        "//source/server:active_udp_listener",
+        "@envoy_api//envoy/config/listener/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/quic/connection_id_generator/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/quic/crypto_stream/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/quic/proof_source/v3:pkg_cc_proto",
+    ]),
 )
 
 envoy_cc_library(
     name = "envoy_quic_utils_lib",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_utils.cc"],
-    }),
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_utils.h"],
-    }),
+    srcs = envoy_select_enable_http3(["envoy_quic_utils.cc"]),
+    hdrs = envoy_select_enable_http3(["envoy_quic_utils.h"]),
     external_deps = ["ssl"],
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//envoy/http:codec_interface",
-            "//source/common/http:header_map_lib",
-            "//source/common/http:header_utility_lib",
-            "//source/common/network:address_lib",
-            "//source/common/network:connection_socket_lib",
-            "//source/common/network:socket_option_factory_lib",
-            "//source/common/protobuf:utility_lib",
-            "//source/common/quic:quic_io_handle_wrapper_lib",
-            "@com_github_google_quiche//:quic_core_config_lib",
-            "@com_github_google_quiche//:quic_core_http_header_list_lib",
-            "@com_github_google_quiche//:quic_platform",
-            "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
-            "@envoy_api//envoy/config/listener/v3:pkg_cc_proto",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        "//envoy/http:codec_interface",
+        "//source/common/http:header_map_lib",
+        "//source/common/http:header_utility_lib",
+        "//source/common/network:address_lib",
+        "//source/common/network:connection_socket_lib",
+        "//source/common/network:socket_option_factory_lib",
+        "//source/common/protobuf:utility_lib",
+        "//source/common/quic:quic_io_handle_wrapper_lib",
+        "@com_github_google_quiche//:quic_core_config_lib",
+        "@com_github_google_quiche//:quic_core_http_header_list_lib",
+        "@com_github_google_quiche//:quic_platform",
+        "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
+        "@envoy_api//envoy/config/listener/v3:pkg_cc_proto",
+    ]),
 )
 
 envoy_cc_library(
     name = "quic_transport_socket_factory_lib",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "quic_client_transport_socket_factory.cc",
-            "quic_transport_socket_factory.cc",
-        ],
-    }),
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "quic_client_transport_socket_factory.h",
-            "quic_transport_socket_factory.h",
-        ],
-    }),
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":envoy_quic_proof_verifier_lib",
-            "//envoy/network:transport_socket_interface",
-            "//envoy/server:transport_socket_config_interface",
-            "//envoy/ssl:context_config_interface",
-            "//source/common/common:assert_lib",
-            "//source/common/network:transport_socket_options_lib",
-            "//source/common/quic:cert_compression_lib",
-            "//source/common/tls:client_ssl_socket_lib",
-            "//source/common/tls:context_config_lib",
-            "@com_github_google_quiche//:quic_core_crypto_crypto_handshake_lib",
-            "@envoy_api//envoy/extensions/transport_sockets/quic/v3:pkg_cc_proto",
-        ],
-    }),
+    srcs = envoy_select_enable_http3([
+        "quic_client_transport_socket_factory.cc",
+        "quic_transport_socket_factory.cc",
+    ]),
+    hdrs = envoy_select_enable_http3([
+        "quic_client_transport_socket_factory.h",
+        "quic_transport_socket_factory.h",
+    ]),
+    deps = envoy_select_enable_http3([
+        ":envoy_quic_proof_verifier_lib",
+        "//envoy/network:transport_socket_interface",
+        "//envoy/server:transport_socket_config_interface",
+        "//envoy/ssl:context_config_interface",
+        "//source/common/common:assert_lib",
+        "//source/common/network:transport_socket_options_lib",
+        "//source/common/quic:cert_compression_lib",
+        "//source/common/tls:client_ssl_socket_lib",
+        "//source/common/tls:context_config_lib",
+        "@com_github_google_quiche//:quic_core_crypto_crypto_handshake_lib",
+        "@envoy_api//envoy/extensions/transport_sockets/quic/v3:pkg_cc_proto",
+    ]),
     alwayslink = LEGACY_ALWAYSLINK,
 )
 
 envoy_cc_library(
     name = "quic_server_transport_socket_factory_lib",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "quic_server_transport_socket_factory.cc",
-        ],
-    }),
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "quic_server_transport_socket_factory.h",
-        ],
-    }),
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":envoy_quic_proof_verifier_lib",
-            ":quic_transport_socket_factory_lib",
-            "//envoy/network:transport_socket_interface",
-            "//envoy/server:transport_socket_config_interface",
-            "//envoy/ssl:context_config_interface",
-            "//source/common/common:assert_lib",
-            "//source/common/network:transport_socket_options_lib",
-            "//source/common/tls:server_context_config_lib",
-            "//source/common/tls:server_context_lib",
-            "//source/common/tls:server_ssl_socket_lib",
-            "@com_github_google_quiche//:quic_core_crypto_crypto_handshake_lib",
-            "@envoy_api//envoy/extensions/transport_sockets/quic/v3:pkg_cc_proto",
-        ],
-    }),
+    srcs = envoy_select_enable_http3([
+        "quic_server_transport_socket_factory.cc",
+    ]),
+    hdrs = envoy_select_enable_http3([
+        "quic_server_transport_socket_factory.h",
+    ]),
+    deps = envoy_select_enable_http3([
+        ":envoy_quic_proof_verifier_lib",
+        ":quic_transport_socket_factory_lib",
+        "//envoy/network:transport_socket_interface",
+        "//envoy/server:transport_socket_config_interface",
+        "//envoy/ssl:context_config_interface",
+        "//source/common/common:assert_lib",
+        "//source/common/network:transport_socket_options_lib",
+        "//source/common/tls:server_context_config_lib",
+        "//source/common/tls:server_context_lib",
+        "//source/common/tls:server_ssl_socket_lib",
+        "@com_github_google_quiche//:quic_core_crypto_crypto_handshake_lib",
+        "@envoy_api//envoy/extensions/transport_sockets/quic/v3:pkg_cc_proto",
+    ]),
     alwayslink = LEGACY_ALWAYSLINK,
 )
 
@@ -733,61 +526,46 @@ envoy_cc_library(
 # All of these are needed for this extension to function.
 envoy_cc_library(
     name = "quic_client_factory_lib",
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":client_codec_lib",
-            ":quic_transport_socket_factory_lib",
-            "//source/extensions/quic/proof_source:envoy_quic_proof_source_factory_impl_lib",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        ":client_codec_lib",
+        ":quic_transport_socket_factory_lib",
+        "//source/extensions/quic/proof_source:envoy_quic_proof_source_factory_impl_lib",
+    ]),
 )
 
 # The factory for server connection creation.
 envoy_cc_library(
     name = "quic_server_factory_stub_lib",
-    hdrs = ["server_connection_factory.h"],
-    deps = [
+    hdrs = envoy_select_enable_http3(["server_connection_factory.h"]),
+    deps = envoy_select_enable_http3([
         "//envoy/http:codec_interface",
         "//envoy/network:connection_interface",
         "//source/common/http/http3:codec_stats_lib",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
-    ],
+    ]),
 )
 
 # Create a single target that contains all the libraries that register factories.
 # All of these are needed for this extension to function.
 envoy_cc_library(
     name = "quic_server_factory_lib",
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":quic_transport_socket_factory_lib",
-            ":server_codec_lib",
-            "//source/extensions/quic/crypto_stream:envoy_quic_crypto_server_stream_lib",
-            "//source/extensions/quic/proof_source:envoy_quic_proof_source_factory_impl_lib",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        ":quic_transport_socket_factory_lib",
+        ":server_codec_lib",
+        "//source/extensions/quic/crypto_stream:envoy_quic_crypto_server_stream_lib",
+        "//source/extensions/quic/proof_source:envoy_quic_proof_source_factory_impl_lib",
+    ]),
 )
 
 envoy_cc_library(
     name = "envoy_quic_packet_writer_lib",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_packet_writer.cc"],
-    }),
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_packet_writer.h"],
-    }),
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":envoy_quic_utils_lib",
-            "@com_github_google_quiche//:quic_core_packet_writer_lib",
-            "@com_github_google_quiche//:quic_platform",
-        ],
-    }),
+    srcs = envoy_select_enable_http3(["envoy_quic_packet_writer.cc"]),
+    hdrs = envoy_select_enable_http3(["envoy_quic_packet_writer.h"]),
+    deps = envoy_select_enable_http3([
+        ":envoy_quic_utils_lib",
+        "@com_github_google_quiche//:quic_core_packet_writer_lib",
+        "@com_github_google_quiche//:quic_platform",
+    ]),
 )
 
 envoy_cc_library(
@@ -796,21 +574,15 @@ envoy_cc_library(
         ":http3_enabled_and_linux": ["udp_gso_batch_writer.cc"],
         "//conditions:default": [],
     }),
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["udp_gso_batch_writer.h"],
-    }),
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":envoy_quic_utils_lib",
-            "//envoy/network:udp_packet_writer_handler_interface",
-            "//source/common/network:io_socket_error_lib",
-            "//source/common/protobuf:utility_lib",
-            "//source/common/runtime:runtime_lib",
-            "@com_github_google_quiche//:quic_platform",
-        ],
-    }) + select({
+    hdrs = envoy_select_enable_http3(["udp_gso_batch_writer.h"]),
+    deps = envoy_select_enable_http3([
+        ":envoy_quic_utils_lib",
+        "//envoy/network:udp_packet_writer_handler_interface",
+        "//source/common/network:io_socket_error_lib",
+        "//source/common/protobuf:utility_lib",
+        "//source/common/runtime:runtime_lib",
+        "@com_github_google_quiche//:quic_platform",
+    ]) + select({
         ":http3_enabled_and_linux": ["@com_github_google_quiche//:quic_core_batch_writer_gso_batch_writer_lib"],
         "//conditions:default": [],
     }),
@@ -818,189 +590,114 @@ envoy_cc_library(
 
 envoy_cc_library(
     name = "send_buffer_monitor_lib",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["send_buffer_monitor.cc"],
-    }),
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["send_buffer_monitor.h"],
-    }),
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//source/common/common:assert_lib",
-            "@com_github_google_quiche//:quic_core_session_lib",
-        ],
-    }),
+    srcs = envoy_select_enable_http3(["send_buffer_monitor.cc"]),
+    hdrs = envoy_select_enable_http3(["send_buffer_monitor.h"]),
+    deps = envoy_select_enable_http3([
+        "//source/common/common:assert_lib",
+        "@com_github_google_quiche//:quic_core_session_lib",
+    ]),
 )
 
 envoy_cc_library(
     name = "envoy_quic_client_crypto_stream_factory_lib",
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_client_crypto_stream_factory.h"],
-    }),
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//envoy/common:optref_lib",
-            "//envoy/config:typed_config_interface",
-            "//envoy/network:transport_socket_interface",
-            "@com_github_google_quiche//:quic_client_session_lib",
-            "@com_github_google_quiche//:quic_core_http_spdy_session_lib",
-        ],
-    }),
+    hdrs = envoy_select_enable_http3(["envoy_quic_client_crypto_stream_factory.h"]),
+    deps = envoy_select_enable_http3([
+        "//envoy/common:optref_lib",
+        "//envoy/config:typed_config_interface",
+        "//envoy/network:transport_socket_interface",
+        "@com_github_google_quiche//:quic_client_session_lib",
+        "@com_github_google_quiche//:quic_core_http_spdy_session_lib",
+    ]),
 )
 
 envoy_cc_library(
     name = "envoy_quic_server_crypto_stream_factory_lib",
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_server_crypto_stream_factory.h"],
-    }),
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//envoy/config:typed_config_interface",
-            "@com_github_google_quiche//:quic_core_http_spdy_session_lib",
-            "@com_github_google_quiche//:quic_server_session_lib",
-        ],
-    }),
+    hdrs = envoy_select_enable_http3(["envoy_quic_server_crypto_stream_factory.h"]),
+    deps = envoy_select_enable_http3([
+        "//envoy/config:typed_config_interface",
+        "@com_github_google_quiche//:quic_core_http_spdy_session_lib",
+        "@com_github_google_quiche//:quic_server_session_lib",
+    ]),
 )
 
 envoy_cc_library(
     name = "envoy_quic_proof_source_factory_interface",
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_proof_source_factory_interface.h"],
-    }),
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//envoy/config:typed_config_interface",
-            "@com_github_google_quiche//:quic_core_crypto_proof_source_lib",
-        ],
-    }),
+    hdrs = envoy_select_enable_http3(["envoy_quic_proof_source_factory_interface.h"]),
+    deps = envoy_select_enable_http3([
+        "//envoy/config:typed_config_interface",
+        "@com_github_google_quiche//:quic_core_crypto_proof_source_lib",
+    ]),
 )
 
 envoy_cc_library(
     name = "envoy_quic_connection_id_generator_factory_interface",
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_connection_id_generator_factory.h"],
-    }),
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//envoy/config:typed_config_interface",
-            "@com_github_google_quiche//:quic_core_connection_id_generator_interface_lib",
-            "@com_github_google_quiche//:quic_load_balancer_encoder_lib",
-        ],
-    }),
+    hdrs = envoy_select_enable_http3(["envoy_quic_connection_id_generator_factory.h"]),
+    deps = envoy_select_enable_http3([
+        "//envoy/config:typed_config_interface",
+        "@com_github_google_quiche//:quic_core_connection_id_generator_interface_lib",
+        "@com_github_google_quiche//:quic_load_balancer_encoder_lib",
+    ]),
 )
 
 envoy_cc_library(
     name = "envoy_deterministic_connection_id_generator_lib",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_deterministic_connection_id_generator.cc"],
-    }),
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_deterministic_connection_id_generator.h"],
-    }),
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":envoy_quic_connection_id_generator_factory_interface",
-            ":envoy_quic_utils_lib",
-            "@com_github_google_quiche//:quic_core_deterministic_connection_id_generator_lib",
-        ],
-    }),
+    srcs = envoy_select_enable_http3(["envoy_deterministic_connection_id_generator.cc"]),
+    hdrs = envoy_select_enable_http3(["envoy_deterministic_connection_id_generator.h"]),
+    deps = envoy_select_enable_http3([
+        ":envoy_quic_connection_id_generator_factory_interface",
+        ":envoy_quic_utils_lib",
+        "@com_github_google_quiche//:quic_core_deterministic_connection_id_generator_lib",
+    ]),
 )
 
 envoy_cc_library(
     name = "envoy_quic_server_preferred_address_config_factory_interface",
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_server_preferred_address_config_factory.h"],
-    }),
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//envoy/config:typed_config_interface",
-            "//envoy/network:address_interface",
-            "//envoy/server:factory_context_interface",
-            "@com_github_google_quiche//:quic_platform_socket_address",
-        ],
-    }),
+    hdrs = envoy_select_enable_http3(["envoy_quic_server_preferred_address_config_factory.h"]),
+    deps = envoy_select_enable_http3([
+        "//envoy/config:typed_config_interface",
+        "//envoy/network:address_interface",
+        "//envoy/server:factory_context_interface",
+        "@com_github_google_quiche//:quic_platform_socket_address",
+    ]),
 )
 
 envoy_cc_library(
     name = "quic_stats_gatherer",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["quic_stats_gatherer.cc"],
-    }),
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["quic_stats_gatherer.h"],
-    }),
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//envoy/access_log:access_log_interface",
-            "//envoy/formatter:http_formatter_context_interface",
-            "//envoy/http:codec_interface",
-            "//source/common/formatter:substitution_formatter_lib",
-            "//source/common/http:header_map_lib",
-            "@com_github_google_quiche//:quic_core_ack_listener_interface_lib",
-        ],
-    }),
+    srcs = envoy_select_enable_http3(["quic_stats_gatherer.cc"]),
+    hdrs = envoy_select_enable_http3(["quic_stats_gatherer.h"]),
+    deps = envoy_select_enable_http3([
+        "//envoy/access_log:access_log_interface",
+        "//envoy/formatter:http_formatter_context_interface",
+        "//envoy/http:codec_interface",
+        "//source/common/formatter:substitution_formatter_lib",
+        "//source/common/http:header_map_lib",
+        "@com_github_google_quiche//:quic_core_ack_listener_interface_lib",
+    ]),
 )
 
 envoy_cc_library(
     name = "http_datagram_handler",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["http_datagram_handler.cc"],
-    }),
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["http_datagram_handler.h"],
-    }),
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//envoy/http:codec_interface",
-            "//source/common/buffer:buffer_lib",
-            "//source/common/common:logger_lib",
-            "//source/common/http:header_map_lib",
-            "@com_github_google_quiche//:quic_core_http_spdy_session_lib",
-            "@com_github_google_quiche//:quic_core_types_lib",
-        ],
-    }),
+    srcs = envoy_select_enable_http3(["http_datagram_handler.cc"]),
+    hdrs = envoy_select_enable_http3(["http_datagram_handler.h"]),
+    deps = envoy_select_enable_http3([
+        "//envoy/http:codec_interface",
+        "//source/common/buffer:buffer_lib",
+        "//source/common/common:logger_lib",
+        "//source/common/http:header_map_lib",
+        "@com_github_google_quiche//:quic_core_http_spdy_session_lib",
+        "@com_github_google_quiche//:quic_core_types_lib",
+    ]),
 )
 
 envoy_cc_library(
     name = "cert_compression_lib",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["cert_compression.cc"],
-    }),
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["cert_compression.h"],
-    }),
+    srcs = envoy_select_enable_http3(["cert_compression.cc"]),
+    hdrs = envoy_select_enable_http3(["cert_compression.h"]),
     external_deps = ["ssl"],
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//bazel/foreign_cc:zlib",
-            "//source/common/common:assert_lib",
-            "//source/common/common:logger_lib",
-            "//source/common/runtime:runtime_lib",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        "//bazel/foreign_cc:zlib",
+        "//source/common/common:assert_lib",
+        "//source/common/common:logger_lib",
+        "//source/common/runtime:runtime_lib",
+    ]),
 )

--- a/source/common/quic/platform/BUILD
+++ b/source/common/quic/platform/BUILD
@@ -82,7 +82,6 @@ envoy_quiche_platform_impl_cc_library(
         "quiche_bug_tracker_impl.h",
         "quiche_logging_impl.h",
     ],
-    tags = ["nofips"],
     deps = [
         "//source/common/common:assert_lib",
         "//source/common/common:utility_lib",
@@ -91,7 +90,6 @@ envoy_quiche_platform_impl_cc_library(
 
 envoy_quiche_platform_impl_cc_library(
     name = "quic_base_impl_lib",
-    tags = ["nofips"],
     deps = [
         ":quiche_flags_impl_lib",
         "//source/common/common:assert_lib",
@@ -111,7 +109,6 @@ envoy_quiche_platform_impl_cc_library(
     hdrs = [
         "quiche_iovec_impl.h",
     ],
-    tags = ["nofips"],
     deps = [
         "//envoy/common:base_includes",
     ],
@@ -122,7 +119,6 @@ envoy_quiche_platform_impl_cc_library(
     hdrs = [
         "quiche_stack_trace_impl.h",
     ],
-    tags = ["nofips"],
     deps = [
         "//source/server:backtrace_lib",
         "@com_github_google_quiche//:quiche_common_platform_export",
@@ -151,13 +147,11 @@ envoy_quiche_platform_impl_cc_library(
 envoy_quiche_platform_impl_cc_library(
     name = "quiche_lower_case_string_impl_lib",
     hdrs = ["quiche_lower_case_string_impl.h"],
-    tags = ["nofips"],
     deps = ["//envoy/http:header_map_interface"],
 )
 
 envoy_quiche_platform_impl_cc_library(
     name = "quiche_export_impl_lib",
     hdrs = ["quiche_export_impl.h"],
-    tags = ["nofips"],
     deps = ["@com_google_absl//absl/base"],
 )

--- a/source/common/quic/platform/mobile_impl/BUILD
+++ b/source/common/quic/platform/mobile_impl/BUILD
@@ -16,7 +16,6 @@ envoy_quiche_platform_impl_cc_library(
     hdrs = [
         "quiche_bug_tracker_impl.h",
     ],
-    tags = ["nofips"],
     deps = [
         "@com_github_google_quiche//:quiche_common_platform_logging",
     ],

--- a/source/extensions/filters/network/http_connection_manager/config.cc
+++ b/source/extensions/filters/network/http_connection_manager/config.cc
@@ -32,7 +32,10 @@
 #include "source/common/http/utility.h"
 #include "source/common/local_reply/local_reply.h"
 #include "source/common/protobuf/utility.h"
+
+#ifdef ENVOY_ENABLE_QUIC
 #include "source/common/quic/server_connection_factory.h"
+#endif
 #include "source/common/router/route_provider_manager.h"
 #include "source/common/runtime/runtime_impl.h"
 #include "source/common/tracing/custom_tag_impl.h"
@@ -772,6 +775,7 @@ Http::ServerConnectionPtr HttpConnectionManagerConfig::createCodec(
         maxRequestHeadersKb(), maxRequestHeadersCount(), headersWithUnderscoresAction(),
         overload_manager);
   case CodecType::HTTP3:
+#ifdef ENVOY_ENABLE_QUIC
     return Config::Utility::getAndCheckFactoryByName<QuicHttpServerConnectionFactory>(
                "quic.http_server_connection.default")
         .createQuicHttpServerConnectionImpl(
@@ -779,6 +783,11 @@ Http::ServerConnectionPtr HttpConnectionManagerConfig::createCodec(
             Http::Http3::CodecStats::atomicGet(http3_codec_stats_, context_.scope()),
             http3_options_, maxRequestHeadersKb(), maxRequestHeadersCount(),
             headersWithUnderscoresAction());
+#else
+    // Should be blocked by configuration checking at an earlier point.
+    PANIC("unexpected");
+#endif
+    break;
   case CodecType::AUTO:
     return Http::ConnectionManagerUtility::autoCreateCodec(
         connection, data, callbacks, context_.scope(),

--- a/source/extensions/quic/connection_debug_visitor/basic/BUILD
+++ b/source/extensions/quic/connection_debug_visitor/basic/BUILD
@@ -7,6 +7,7 @@ load(
     "envoy_cc_extension",
     "envoy_cc_library",
     "envoy_extension_package",
+    "envoy_select_enable_http3",
 )
 
 licenses(["notice"])  # Apache 2
@@ -17,32 +18,23 @@ envoy_extension_package()
 
 envoy_cc_library(
     name = "envoy_quic_connection_debug_visitor_basic_lib",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_connection_debug_visitor_basic.cc"],
-    }),
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_connection_debug_visitor_basic.h"],
-    }),
+    srcs = envoy_select_enable_http3(["envoy_quic_connection_debug_visitor_basic.cc"]),
+    hdrs = envoy_select_enable_http3(["envoy_quic_connection_debug_visitor_basic.h"]),
     visibility = [
         "//source/common/quic:__subpackages__",
     ],
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//envoy/registry",
-            "//envoy/stream_info:stream_info_interface",
-            "//source/common/common:minimal_logger_lib",
-            "//source/common/protobuf:utility_lib",
-            "//source/common/quic:envoy_quic_connection_debug_visitor_factory_interface",
-            "@com_github_google_quiche//:quic_core_connection_lib",
-            "@com_github_google_quiche//:quic_core_frames_frames_lib",
-            "@com_github_google_quiche//:quic_core_session_lib",
-            "@com_github_google_quiche//:quic_core_types_lib",
-            "@envoy_api//envoy/extensions/quic/connection_debug_visitor/v3:pkg_cc_proto",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        "//envoy/registry",
+        "//envoy/stream_info:stream_info_interface",
+        "//source/common/common:minimal_logger_lib",
+        "//source/common/protobuf:utility_lib",
+        "//source/common/quic:envoy_quic_connection_debug_visitor_factory_interface",
+        "@com_github_google_quiche//:quic_core_connection_lib",
+        "@com_github_google_quiche//:quic_core_frames_frames_lib",
+        "@com_github_google_quiche//:quic_core_session_lib",
+        "@com_github_google_quiche//:quic_core_types_lib",
+        "@envoy_api//envoy/extensions/quic/connection_debug_visitor/v3:pkg_cc_proto",
+    ]),
     alwayslink = LEGACY_ALWAYSLINK,
 )
 
@@ -52,10 +44,7 @@ envoy_cc_extension(
         "//source/common/quic:__subpackages__",
         "//test:__subpackages__",
     ],
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":envoy_quic_connection_debug_visitor_basic_lib",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        ":envoy_quic_connection_debug_visitor_basic_lib",
+    ]),
 )

--- a/source/extensions/quic/connection_debug_visitor/basic/BUILD
+++ b/source/extensions/quic/connection_debug_visitor/basic/BUILD
@@ -17,24 +17,32 @@ envoy_extension_package()
 
 envoy_cc_library(
     name = "envoy_quic_connection_debug_visitor_basic_lib",
-    srcs = ["envoy_quic_connection_debug_visitor_basic.cc"],
-    hdrs = ["envoy_quic_connection_debug_visitor_basic.h"],
-    tags = ["nofips"],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_connection_debug_visitor_basic.cc"],
+    }),
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_connection_debug_visitor_basic.h"],
+    }),
     visibility = [
         "//source/common/quic:__subpackages__",
     ],
-    deps = [
-        "//envoy/registry",
-        "//envoy/stream_info:stream_info_interface",
-        "//source/common/common:minimal_logger_lib",
-        "//source/common/protobuf:utility_lib",
-        "//source/common/quic:envoy_quic_connection_debug_visitor_factory_interface",
-        "@com_github_google_quiche//:quic_core_connection_lib",
-        "@com_github_google_quiche//:quic_core_frames_frames_lib",
-        "@com_github_google_quiche//:quic_core_session_lib",
-        "@com_github_google_quiche//:quic_core_types_lib",
-        "@envoy_api//envoy/extensions/quic/connection_debug_visitor/v3:pkg_cc_proto",
-    ],
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//envoy/registry",
+            "//envoy/stream_info:stream_info_interface",
+            "//source/common/common:minimal_logger_lib",
+            "//source/common/protobuf:utility_lib",
+            "//source/common/quic:envoy_quic_connection_debug_visitor_factory_interface",
+            "@com_github_google_quiche//:quic_core_connection_lib",
+            "@com_github_google_quiche//:quic_core_frames_frames_lib",
+            "@com_github_google_quiche//:quic_core_session_lib",
+            "@com_github_google_quiche//:quic_core_types_lib",
+            "@envoy_api//envoy/extensions/quic/connection_debug_visitor/v3:pkg_cc_proto",
+        ],
+    }),
     alwayslink = LEGACY_ALWAYSLINK,
 )
 
@@ -44,14 +52,10 @@ envoy_cc_extension(
         "//source/common/quic:__subpackages__",
         "//test:__subpackages__",
     ],
-    tags = ["nofips"],
-    deps = select(
-        {
-            "//bazel:boringssl_fips": [],
-            "//bazel:boringssl_disabled": [],
-            "//conditions:default": [
-                ":envoy_quic_connection_debug_visitor_basic_lib",
-            ],
-        },
-    ),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":envoy_quic_connection_debug_visitor_basic_lib",
+        ],
+    }),
 )

--- a/source/extensions/quic/connection_debug_visitor/quic_stats/BUILD
+++ b/source/extensions/quic/connection_debug_visitor/quic_stats/BUILD
@@ -15,18 +15,26 @@ envoy_extension_package()
 
 envoy_cc_library(
     name = "quic_stats_lib",
-    srcs = ["quic_stats.cc"],
-    hdrs = ["quic_stats.h"],
-    tags = ["nofips"],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["quic_stats.cc"],
+    }),
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["quic_stats.h"],
+    }),
     visibility = [
         "//test:__subpackages__",
     ],
-    deps = [
-        "//envoy/registry",
-        "//source/common/protobuf:utility_lib",
-        "//source/common/quic:envoy_quic_connection_debug_visitor_factory_interface",
-        "@envoy_api//envoy/extensions/quic/connection_debug_visitor/quic_stats/v3:pkg_cc_proto",
-    ],
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//envoy/registry",
+            "//source/common/protobuf:utility_lib",
+            "//source/common/quic:envoy_quic_connection_debug_visitor_factory_interface",
+            "@envoy_api//envoy/extensions/quic/connection_debug_visitor/quic_stats/v3:pkg_cc_proto",
+        ],
+    }),
     alwayslink = LEGACY_ALWAYSLINK,
 )
 
@@ -36,14 +44,10 @@ envoy_cc_extension(
         "//source/common/quic:__subpackages__",
         "//test:__subpackages__",
     ],
-    tags = ["nofips"],
-    deps = select(
-        {
-            "//bazel:boringssl_fips": [],
-            "//bazel:boringssl_disabled": [],
-            "//conditions:default": [
-                ":quic_stats_lib",
-            ],
-        },
-    ),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":quic_stats_lib",
+        ],
+    }),
 )

--- a/source/extensions/quic/connection_debug_visitor/quic_stats/BUILD
+++ b/source/extensions/quic/connection_debug_visitor/quic_stats/BUILD
@@ -7,6 +7,7 @@ load(
     "envoy_cc_extension",
     "envoy_cc_library",
     "envoy_extension_package",
+    "envoy_select_enable_http3",
 )
 
 licenses(["notice"])  # Apache 2
@@ -15,26 +16,17 @@ envoy_extension_package()
 
 envoy_cc_library(
     name = "quic_stats_lib",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["quic_stats.cc"],
-    }),
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["quic_stats.h"],
-    }),
+    srcs = envoy_select_enable_http3(["quic_stats.cc"]),
+    hdrs = envoy_select_enable_http3(["quic_stats.h"]),
     visibility = [
         "//test:__subpackages__",
     ],
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//envoy/registry",
-            "//source/common/protobuf:utility_lib",
-            "//source/common/quic:envoy_quic_connection_debug_visitor_factory_interface",
-            "@envoy_api//envoy/extensions/quic/connection_debug_visitor/quic_stats/v3:pkg_cc_proto",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        "//envoy/registry",
+        "//source/common/protobuf:utility_lib",
+        "//source/common/quic:envoy_quic_connection_debug_visitor_factory_interface",
+        "@envoy_api//envoy/extensions/quic/connection_debug_visitor/quic_stats/v3:pkg_cc_proto",
+    ]),
     alwayslink = LEGACY_ALWAYSLINK,
 )
 
@@ -44,10 +36,7 @@ envoy_cc_extension(
         "//source/common/quic:__subpackages__",
         "//test:__subpackages__",
     ],
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":quic_stats_lib",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        ":quic_stats_lib",
+    ]),
 )

--- a/source/extensions/quic/connection_id_generator/deterministic/BUILD
+++ b/source/extensions/quic/connection_id_generator/deterministic/BUILD
@@ -7,6 +7,7 @@ load(
     "envoy_cc_extension",
     "envoy_cc_library",
     "envoy_extension_package",
+    "envoy_select_enable_http3",
 )
 
 licenses(["notice"])  # Apache 2
@@ -17,23 +18,14 @@ envoy_extension_package()
 
 envoy_cc_library(
     name = "envoy_deterministic_connection_id_generator_config_lib",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_deterministic_connection_id_generator_config.cc"],
-    }),
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_deterministic_connection_id_generator_config.h"],
-    }),
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//envoy/registry",
-            "//source/common/quic:envoy_deterministic_connection_id_generator_lib",
-            "//source/common/quic:envoy_quic_connection_id_generator_factory_interface",
-            "@envoy_api//envoy/extensions/quic/connection_id_generator/v3:pkg_cc_proto",
-        ],
-    }),
+    srcs = envoy_select_enable_http3(["envoy_deterministic_connection_id_generator_config.cc"]),
+    hdrs = envoy_select_enable_http3(["envoy_deterministic_connection_id_generator_config.h"]),
+    deps = envoy_select_enable_http3([
+        "//envoy/registry",
+        "//source/common/quic:envoy_deterministic_connection_id_generator_lib",
+        "//source/common/quic:envoy_quic_connection_id_generator_factory_interface",
+        "@envoy_api//envoy/extensions/quic/connection_id_generator/v3:pkg_cc_proto",
+    ]),
     alwayslink = LEGACY_ALWAYSLINK,
 )
 
@@ -42,10 +34,7 @@ envoy_cc_extension(
     extra_visibility = [
         "//source/common/quic:__subpackages__",
     ],
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":envoy_deterministic_connection_id_generator_config_lib",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        ":envoy_deterministic_connection_id_generator_config_lib",
+    ]),
 )

--- a/source/extensions/quic/connection_id_generator/deterministic/BUILD
+++ b/source/extensions/quic/connection_id_generator/deterministic/BUILD
@@ -17,15 +17,23 @@ envoy_extension_package()
 
 envoy_cc_library(
     name = "envoy_deterministic_connection_id_generator_config_lib",
-    srcs = ["envoy_deterministic_connection_id_generator_config.cc"],
-    hdrs = ["envoy_deterministic_connection_id_generator_config.h"],
-    tags = ["nofips"],
-    deps = [
-        "//envoy/registry",
-        "//source/common/quic:envoy_deterministic_connection_id_generator_lib",
-        "//source/common/quic:envoy_quic_connection_id_generator_factory_interface",
-        "@envoy_api//envoy/extensions/quic/connection_id_generator/v3:pkg_cc_proto",
-    ],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_deterministic_connection_id_generator_config.cc"],
+    }),
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_deterministic_connection_id_generator_config.h"],
+    }),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//envoy/registry",
+            "//source/common/quic:envoy_deterministic_connection_id_generator_lib",
+            "//source/common/quic:envoy_quic_connection_id_generator_factory_interface",
+            "@envoy_api//envoy/extensions/quic/connection_id_generator/v3:pkg_cc_proto",
+        ],
+    }),
     alwayslink = LEGACY_ALWAYSLINK,
 )
 
@@ -34,14 +42,10 @@ envoy_cc_extension(
     extra_visibility = [
         "//source/common/quic:__subpackages__",
     ],
-    tags = ["nofips"],
-    deps = select(
-        {
-            "//bazel:boringssl_fips": [],
-            "//bazel:boringssl_disabled": [],
-            "//conditions:default": [
-                ":envoy_deterministic_connection_id_generator_config_lib",
-            ],
-        },
-    ),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":envoy_deterministic_connection_id_generator_config_lib",
+        ],
+    }),
 )

--- a/source/extensions/quic/connection_id_generator/quic_lb/BUILD
+++ b/source/extensions/quic/connection_id_generator/quic_lb/BUILD
@@ -15,44 +15,56 @@ envoy_extension_package()
 
 envoy_cc_library(
     name = "quic_lb_lib",
-    srcs = ["quic_lb.cc"],
-    hdrs = ["quic_lb.h"],
-    tags = ["nofips"],
-    deps = [
-        "//source/common/config:datasource_lib",
-        "//source/common/quic:envoy_quic_connection_id_generator_factory_interface",
-        "//source/common/quic:envoy_quic_utils_lib",
-        "@com_github_google_quiche//:quic_load_balancer_config_lib",
-        "@com_github_google_quiche//:quic_load_balancer_encoder_lib",
-        "@com_github_google_quiche//:quic_load_balancer_server_id_lib",
-        "@envoy_api//envoy/extensions/quic/connection_id_generator/quic_lb/v3:pkg_cc_proto",
-    ],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["quic_lb.cc"],
+    }),
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["quic_lb.h"],
+    }),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//source/common/config:datasource_lib",
+            "//source/common/quic:envoy_quic_connection_id_generator_factory_interface",
+            "//source/common/quic:envoy_quic_utils_lib",
+            "@com_github_google_quiche//:quic_load_balancer_config_lib",
+            "@com_github_google_quiche//:quic_load_balancer_encoder_lib",
+            "@com_github_google_quiche//:quic_load_balancer_server_id_lib",
+            "@envoy_api//envoy/extensions/quic/connection_id_generator/quic_lb/v3:pkg_cc_proto",
+        ],
+    }),
 )
 
 envoy_cc_library(
     name = "config_lib",
-    srcs = ["config.cc"],
-    hdrs = ["config.h"],
-    tags = ["nofips"],
-    deps = [
-        ":quic_lb_lib",
-        "//envoy/registry",
-        "//source/common/quic:envoy_quic_connection_id_generator_factory_interface",
-        "@envoy_api//envoy/extensions/quic/connection_id_generator/quic_lb/v3:pkg_cc_proto",
-    ],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["config.cc"],
+    }),
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["config.h"],
+    }),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":quic_lb_lib",
+            "//envoy/registry",
+            "//source/common/quic:envoy_quic_connection_id_generator_factory_interface",
+            "@envoy_api//envoy/extensions/quic/connection_id_generator/quic_lb/v3:pkg_cc_proto",
+        ],
+    }),
     alwayslink = LEGACY_ALWAYSLINK,
 )
 
 envoy_cc_extension(
     name = "quic_lb_config",
-    tags = ["nofips"],
-    deps = select(
-        {
-            "//bazel:boringssl_fips": [],
-            "//bazel:boringssl_disabled": [],
-            "//conditions:default": [
-                ":config_lib",
-            ],
-        },
-    ),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":config_lib",
+        ],
+    }),
 )

--- a/source/extensions/quic/connection_id_generator/quic_lb/BUILD
+++ b/source/extensions/quic/connection_id_generator/quic_lb/BUILD
@@ -7,6 +7,7 @@ load(
     "envoy_cc_extension",
     "envoy_cc_library",
     "envoy_extension_package",
+    "envoy_select_enable_http3",
 )
 
 licenses(["notice"])  # Apache 2
@@ -15,56 +16,35 @@ envoy_extension_package()
 
 envoy_cc_library(
     name = "quic_lb_lib",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["quic_lb.cc"],
-    }),
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["quic_lb.h"],
-    }),
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//source/common/config:datasource_lib",
-            "//source/common/quic:envoy_quic_connection_id_generator_factory_interface",
-            "//source/common/quic:envoy_quic_utils_lib",
-            "@com_github_google_quiche//:quic_load_balancer_config_lib",
-            "@com_github_google_quiche//:quic_load_balancer_encoder_lib",
-            "@com_github_google_quiche//:quic_load_balancer_server_id_lib",
-            "@envoy_api//envoy/extensions/quic/connection_id_generator/quic_lb/v3:pkg_cc_proto",
-        ],
-    }),
+    srcs = envoy_select_enable_http3(["quic_lb.cc"]),
+    hdrs = envoy_select_enable_http3(["quic_lb.h"]),
+    deps = envoy_select_enable_http3([
+        "//source/common/config:datasource_lib",
+        "//source/common/quic:envoy_quic_connection_id_generator_factory_interface",
+        "//source/common/quic:envoy_quic_utils_lib",
+        "@com_github_google_quiche//:quic_load_balancer_config_lib",
+        "@com_github_google_quiche//:quic_load_balancer_encoder_lib",
+        "@com_github_google_quiche//:quic_load_balancer_server_id_lib",
+        "@envoy_api//envoy/extensions/quic/connection_id_generator/quic_lb/v3:pkg_cc_proto",
+    ]),
 )
 
 envoy_cc_library(
     name = "config_lib",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["config.cc"],
-    }),
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["config.h"],
-    }),
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":quic_lb_lib",
-            "//envoy/registry",
-            "//source/common/quic:envoy_quic_connection_id_generator_factory_interface",
-            "@envoy_api//envoy/extensions/quic/connection_id_generator/quic_lb/v3:pkg_cc_proto",
-        ],
-    }),
+    srcs = envoy_select_enable_http3(["config.cc"]),
+    hdrs = envoy_select_enable_http3(["config.h"]),
+    deps = envoy_select_enable_http3([
+        ":quic_lb_lib",
+        "//envoy/registry",
+        "//source/common/quic:envoy_quic_connection_id_generator_factory_interface",
+        "@envoy_api//envoy/extensions/quic/connection_id_generator/quic_lb/v3:pkg_cc_proto",
+    ]),
     alwayslink = LEGACY_ALWAYSLINK,
 )
 
 envoy_cc_extension(
     name = "quic_lb_config",
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":config_lib",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        ":config_lib",
+    ]),
 )

--- a/source/extensions/quic/crypto_stream/BUILD
+++ b/source/extensions/quic/crypto_stream/BUILD
@@ -17,18 +17,26 @@ envoy_extension_package()
 
 envoy_cc_library(
     name = "envoy_quic_crypto_server_stream_lib",
-    srcs = ["envoy_quic_crypto_server_stream.cc"],
-    hdrs = ["envoy_quic_crypto_server_stream.h"],
-    tags = ["nofips"],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_crypto_server_stream.cc"],
+    }),
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_crypto_server_stream.h"],
+    }),
     visibility = [
         "//source/common/quic:__subpackages__",
         "//test:__subpackages__",
     ],
-    deps = [
-        "//envoy/registry",
-        "//source/common/quic:envoy_quic_server_crypto_stream_factory_lib",
-        "@envoy_api//envoy/extensions/quic/crypto_stream/v3:pkg_cc_proto",
-    ],
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//envoy/registry",
+            "//source/common/quic:envoy_quic_server_crypto_stream_factory_lib",
+            "@envoy_api//envoy/extensions/quic/crypto_stream/v3:pkg_cc_proto",
+        ],
+    }),
     alwayslink = LEGACY_ALWAYSLINK,
 )
 
@@ -38,29 +46,33 @@ envoy_cc_extension(
         "//source/common/quic:__subpackages__",
         "//test:__subpackages__",
     ],
-    tags = ["nofips"],
-    deps = select(
-        {
-            "//bazel:boringssl_fips": [],
-            "//bazel:boringssl_disabled": [],
-            "//conditions:default": [
-                ":envoy_quic_crypto_server_stream_lib",
-            ],
-        },
-    ),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":envoy_quic_crypto_server_stream_lib",
+        ],
+    }),
 )
 
 envoy_cc_library(
     name = "envoy_quic_crypto_client_stream_lib",
-    srcs = ["envoy_quic_crypto_client_stream.cc"],
-    hdrs = ["envoy_quic_crypto_client_stream.h"],
-    tags = ["nofips"],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_crypto_client_stream.cc"],
+    }),
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_crypto_client_stream.h"],
+    }),
     visibility = [
         "//source/common/quic:__subpackages__",
         "//test:__subpackages__",
     ],
-    deps = [
-        "//source/common/quic:envoy_quic_client_crypto_stream_factory_lib",
-    ],
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//source/common/quic:envoy_quic_client_crypto_stream_factory_lib",
+        ],
+    }),
     alwayslink = LEGACY_ALWAYSLINK,
 )

--- a/source/extensions/quic/crypto_stream/BUILD
+++ b/source/extensions/quic/crypto_stream/BUILD
@@ -7,6 +7,7 @@ load(
     "envoy_cc_extension",
     "envoy_cc_library",
     "envoy_extension_package",
+    "envoy_select_enable_http3",
 )
 
 licenses(["notice"])  # Apache 2
@@ -17,26 +18,17 @@ envoy_extension_package()
 
 envoy_cc_library(
     name = "envoy_quic_crypto_server_stream_lib",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_crypto_server_stream.cc"],
-    }),
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_crypto_server_stream.h"],
-    }),
+    srcs = envoy_select_enable_http3(["envoy_quic_crypto_server_stream.cc"]),
+    hdrs = envoy_select_enable_http3(["envoy_quic_crypto_server_stream.h"]),
     visibility = [
         "//source/common/quic:__subpackages__",
         "//test:__subpackages__",
     ],
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//envoy/registry",
-            "//source/common/quic:envoy_quic_server_crypto_stream_factory_lib",
-            "@envoy_api//envoy/extensions/quic/crypto_stream/v3:pkg_cc_proto",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        "//envoy/registry",
+        "//source/common/quic:envoy_quic_server_crypto_stream_factory_lib",
+        "@envoy_api//envoy/extensions/quic/crypto_stream/v3:pkg_cc_proto",
+    ]),
     alwayslink = LEGACY_ALWAYSLINK,
 )
 
@@ -46,33 +38,21 @@ envoy_cc_extension(
         "//source/common/quic:__subpackages__",
         "//test:__subpackages__",
     ],
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":envoy_quic_crypto_server_stream_lib",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        ":envoy_quic_crypto_server_stream_lib",
+    ]),
 )
 
 envoy_cc_library(
     name = "envoy_quic_crypto_client_stream_lib",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_crypto_client_stream.cc"],
-    }),
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_crypto_client_stream.h"],
-    }),
+    srcs = envoy_select_enable_http3(["envoy_quic_crypto_client_stream.cc"]),
+    hdrs = envoy_select_enable_http3(["envoy_quic_crypto_client_stream.h"]),
     visibility = [
         "//source/common/quic:__subpackages__",
         "//test:__subpackages__",
     ],
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//source/common/quic:envoy_quic_client_crypto_stream_factory_lib",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        "//source/common/quic:envoy_quic_client_crypto_stream_factory_lib",
+    ]),
     alwayslink = LEGACY_ALWAYSLINK,
 )

--- a/source/extensions/quic/proof_source/BUILD
+++ b/source/extensions/quic/proof_source/BUILD
@@ -17,18 +17,26 @@ envoy_extension_package()
 
 envoy_cc_library(
     name = "envoy_quic_proof_source_factory_impl_lib",
-    srcs = ["envoy_quic_proof_source_factory_impl.cc"],
-    hdrs = ["envoy_quic_proof_source_factory_impl.h"],
-    tags = ["nofips"],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_proof_source_factory_impl.cc"],
+    }),
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_proof_source_factory_impl.h"],
+    }),
     visibility = [
         "//source/common/quic:__subpackages__",
         "//test:__subpackages__",
     ],
-    deps = [
-        "//source/common/quic:envoy_quic_proof_source_factory_interface",
-        "//source/common/quic:envoy_quic_proof_source_lib",
-        "@envoy_api//envoy/extensions/quic/proof_source/v3:pkg_cc_proto",
-    ],
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//source/common/quic:envoy_quic_proof_source_factory_interface",
+            "//source/common/quic:envoy_quic_proof_source_lib",
+            "@envoy_api//envoy/extensions/quic/proof_source/v3:pkg_cc_proto",
+        ],
+    }),
     alwayslink = LEGACY_ALWAYSLINK,
 )
 
@@ -38,14 +46,10 @@ envoy_cc_extension(
         "//source/common/quic:__subpackages__",
         "//test:__subpackages__",
     ],
-    tags = ["nofips"],
-    deps = select(
-        {
-            "//bazel:boringssl_fips": [],
-            "//bazel:boringssl_disabled": [],
-            "//conditions:default": [
-                ":envoy_quic_proof_source_factory_impl_lib",
-            ],
-        },
-    ),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":envoy_quic_proof_source_factory_impl_lib",
+        ],
+    }),
 )

--- a/source/extensions/quic/proof_source/BUILD
+++ b/source/extensions/quic/proof_source/BUILD
@@ -7,6 +7,7 @@ load(
     "envoy_cc_extension",
     "envoy_cc_library",
     "envoy_extension_package",
+    "envoy_select_enable_http3",
 )
 
 licenses(["notice"])  # Apache 2
@@ -17,26 +18,17 @@ envoy_extension_package()
 
 envoy_cc_library(
     name = "envoy_quic_proof_source_factory_impl_lib",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_proof_source_factory_impl.cc"],
-    }),
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_proof_source_factory_impl.h"],
-    }),
+    srcs = envoy_select_enable_http3(["envoy_quic_proof_source_factory_impl.cc"]),
+    hdrs = envoy_select_enable_http3(["envoy_quic_proof_source_factory_impl.h"]),
     visibility = [
         "//source/common/quic:__subpackages__",
         "//test:__subpackages__",
     ],
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//source/common/quic:envoy_quic_proof_source_factory_interface",
-            "//source/common/quic:envoy_quic_proof_source_lib",
-            "@envoy_api//envoy/extensions/quic/proof_source/v3:pkg_cc_proto",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        "//source/common/quic:envoy_quic_proof_source_factory_interface",
+        "//source/common/quic:envoy_quic_proof_source_lib",
+        "@envoy_api//envoy/extensions/quic/proof_source/v3:pkg_cc_proto",
+    ]),
     alwayslink = LEGACY_ALWAYSLINK,
 )
 
@@ -46,10 +38,7 @@ envoy_cc_extension(
         "//source/common/quic:__subpackages__",
         "//test:__subpackages__",
     ],
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":envoy_quic_proof_source_factory_impl_lib",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        ":envoy_quic_proof_source_factory_impl_lib",
+    ]),
 )

--- a/source/extensions/quic/server_preferred_address/BUILD
+++ b/source/extensions/quic/server_preferred_address/BUILD
@@ -7,6 +7,7 @@ load(
     "envoy_cc_extension",
     "envoy_cc_library",
     "envoy_extension_package",
+    "envoy_select_enable_http3",
 )
 
 licenses(["notice"])  # Apache 2
@@ -17,42 +18,24 @@ envoy_extension_package()
 
 envoy_cc_library(
     name = "server_preferred_address_lib",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["server_preferred_address.cc"],
-    }),
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["server_preferred_address.h"],
-    }),
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//source/common/quic:envoy_quic_server_preferred_address_config_factory_interface",
-        ],
-    }),
+    srcs = envoy_select_enable_http3(["server_preferred_address.cc"]),
+    hdrs = envoy_select_enable_http3(["server_preferred_address.h"]),
+    deps = envoy_select_enable_http3([
+        "//source/common/quic:envoy_quic_server_preferred_address_config_factory_interface",
+    ]),
 )
 
 envoy_cc_library(
     name = "fixed_server_preferred_address_config_lib",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["fixed_server_preferred_address_config.cc"],
-    }),
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["fixed_server_preferred_address_config.h"],
-    }),
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":server_preferred_address_lib",
-            "//envoy/registry",
-            "//source/common/quic:envoy_quic_server_preferred_address_config_factory_interface",
-            "//source/common/quic:envoy_quic_utils_lib",
-            "@envoy_api//envoy/extensions/quic/server_preferred_address/v3:pkg_cc_proto",
-        ],
-    }),
+    srcs = envoy_select_enable_http3(["fixed_server_preferred_address_config.cc"]),
+    hdrs = envoy_select_enable_http3(["fixed_server_preferred_address_config.h"]),
+    deps = envoy_select_enable_http3([
+        ":server_preferred_address_lib",
+        "//envoy/registry",
+        "//source/common/quic:envoy_quic_server_preferred_address_config_factory_interface",
+        "//source/common/quic:envoy_quic_utils_lib",
+        "@envoy_api//envoy/extensions/quic/server_preferred_address/v3:pkg_cc_proto",
+    ]),
     alwayslink = LEGACY_ALWAYSLINK,
 )
 
@@ -61,44 +44,29 @@ envoy_cc_extension(
     extra_visibility = [
         "//test:__subpackages__",
     ],
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":fixed_server_preferred_address_config_lib",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        ":fixed_server_preferred_address_config_lib",
+    ]),
 )
 
 envoy_cc_library(
     name = "datasource_server_preferred_address_config_lib",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["datasource_server_preferred_address_config.cc"],
-    }),
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["datasource_server_preferred_address_config.h"],
-    }),
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":server_preferred_address_lib",
-            "//envoy/registry",
-            "//source/common/config:datasource_lib",
-            "//source/common/quic:envoy_quic_server_preferred_address_config_factory_interface",
-            "//source/common/quic:envoy_quic_utils_lib",
-            "@envoy_api//envoy/extensions/quic/server_preferred_address/v3:pkg_cc_proto",
-        ],
-    }),
+    srcs = envoy_select_enable_http3(["datasource_server_preferred_address_config.cc"]),
+    hdrs = envoy_select_enable_http3(["datasource_server_preferred_address_config.h"]),
+    deps = envoy_select_enable_http3([
+        ":server_preferred_address_lib",
+        "//envoy/registry",
+        "//source/common/config:datasource_lib",
+        "//source/common/quic:envoy_quic_server_preferred_address_config_factory_interface",
+        "//source/common/quic:envoy_quic_utils_lib",
+        "@envoy_api//envoy/extensions/quic/server_preferred_address/v3:pkg_cc_proto",
+    ]),
     alwayslink = LEGACY_ALWAYSLINK,
 )
 
 envoy_cc_extension(
     name = "datasource_server_preferred_address_config_factory_config",
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":datasource_server_preferred_address_config_lib",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        ":datasource_server_preferred_address_config_lib",
+    ]),
 )

--- a/source/extensions/quic/server_preferred_address/BUILD
+++ b/source/extensions/quic/server_preferred_address/BUILD
@@ -17,26 +17,42 @@ envoy_extension_package()
 
 envoy_cc_library(
     name = "server_preferred_address_lib",
-    srcs = ["server_preferred_address.cc"],
-    hdrs = ["server_preferred_address.h"],
-    tags = ["nofips"],
-    deps = [
-        "//source/common/quic:envoy_quic_server_preferred_address_config_factory_interface",
-    ],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["server_preferred_address.cc"],
+    }),
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["server_preferred_address.h"],
+    }),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//source/common/quic:envoy_quic_server_preferred_address_config_factory_interface",
+        ],
+    }),
 )
 
 envoy_cc_library(
     name = "fixed_server_preferred_address_config_lib",
-    srcs = ["fixed_server_preferred_address_config.cc"],
-    hdrs = ["fixed_server_preferred_address_config.h"],
-    tags = ["nofips"],
-    deps = [
-        ":server_preferred_address_lib",
-        "//envoy/registry",
-        "//source/common/quic:envoy_quic_server_preferred_address_config_factory_interface",
-        "//source/common/quic:envoy_quic_utils_lib",
-        "@envoy_api//envoy/extensions/quic/server_preferred_address/v3:pkg_cc_proto",
-    ],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["fixed_server_preferred_address_config.cc"],
+    }),
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["fixed_server_preferred_address_config.h"],
+    }),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":server_preferred_address_lib",
+            "//envoy/registry",
+            "//source/common/quic:envoy_quic_server_preferred_address_config_factory_interface",
+            "//source/common/quic:envoy_quic_utils_lib",
+            "@envoy_api//envoy/extensions/quic/server_preferred_address/v3:pkg_cc_proto",
+        ],
+    }),
     alwayslink = LEGACY_ALWAYSLINK,
 )
 
@@ -45,44 +61,44 @@ envoy_cc_extension(
     extra_visibility = [
         "//test:__subpackages__",
     ],
-    tags = ["nofips"],
-    deps = select(
-        {
-            "//bazel:boringssl_fips": [],
-            "//bazel:boringssl_disabled": [],
-            "//conditions:default": [
-                ":fixed_server_preferred_address_config_lib",
-            ],
-        },
-    ),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":fixed_server_preferred_address_config_lib",
+        ],
+    }),
 )
 
 envoy_cc_library(
     name = "datasource_server_preferred_address_config_lib",
-    srcs = ["datasource_server_preferred_address_config.cc"],
-    hdrs = ["datasource_server_preferred_address_config.h"],
-    tags = ["nofips"],
-    deps = [
-        ":server_preferred_address_lib",
-        "//envoy/registry",
-        "//source/common/config:datasource_lib",
-        "//source/common/quic:envoy_quic_server_preferred_address_config_factory_interface",
-        "//source/common/quic:envoy_quic_utils_lib",
-        "@envoy_api//envoy/extensions/quic/server_preferred_address/v3:pkg_cc_proto",
-    ],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["datasource_server_preferred_address_config.cc"],
+    }),
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["datasource_server_preferred_address_config.h"],
+    }),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":server_preferred_address_lib",
+            "//envoy/registry",
+            "//source/common/config:datasource_lib",
+            "//source/common/quic:envoy_quic_server_preferred_address_config_factory_interface",
+            "//source/common/quic:envoy_quic_utils_lib",
+            "@envoy_api//envoy/extensions/quic/server_preferred_address/v3:pkg_cc_proto",
+        ],
+    }),
     alwayslink = LEGACY_ALWAYSLINK,
 )
 
 envoy_cc_extension(
     name = "datasource_server_preferred_address_config_factory_config",
-    tags = ["nofips"],
-    deps = select(
-        {
-            "//bazel:boringssl_fips": [],
-            "//bazel:boringssl_disabled": [],
-            "//conditions:default": [
-                ":datasource_server_preferred_address_config_lib",
-            ],
-        },
-    ),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":datasource_server_preferred_address_config_lib",
+        ],
+    }),
 )

--- a/source/extensions/udp_packet_writer/gso/BUILD
+++ b/source/extensions/udp_packet_writer/gso/BUILD
@@ -21,7 +21,6 @@ envoy_cc_extension(
         "//source/server:__subpackages__",
         "//source/common/listener_manager:__subpackages__",
     ],
-    tags = ["nofips"],
     deps = [
         "//envoy/config:typed_config_interface",
         "//envoy/network:udp_packet_writer_handler_interface",

--- a/test/common/http/http3/BUILD
+++ b/test/common/http/http3/BUILD
@@ -13,7 +13,6 @@ envoy_cc_test(
     name = "conn_pool_test",
     srcs = envoy_select_enable_http3(["conn_pool_test.cc"]),
     rbe_pool = "6gig",
-    tags = ["nofips"],
     deps = envoy_select_enable_http3([
         "//source/common/event:dispatcher_lib",
         "//source/common/http/http3:conn_pool_lib",

--- a/test/common/listener_manager/BUILD
+++ b/test/common/listener_manager/BUILD
@@ -109,25 +109,31 @@ envoy_cc_test(
 # Stand-alone quic test because of FIPS.
 envoy_cc_test(
     name = "listener_manager_impl_quic_only_test",
-    srcs = ["listener_manager_impl_quic_only_test.cc"],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["listener_manager_impl_quic_only_test.cc"],
+    }),
     rbe_pool = "6gig",
-    tags = ["nofips"],
-    deps = [
-        ":listener_manager_impl_test_lib",
-        "//source/common/formatter:formatter_extension_lib",
-        "//source/extensions/filters/http/router:config",
-        "//source/extensions/matching/network/common:inputs_lib",
-        "//source/extensions/quic/server_preferred_address:fixed_server_preferred_address_config_factory_config",
-        "//source/extensions/request_id/uuid:config",
-        "//source/extensions/transport_sockets/raw_buffer:config",
-        "//source/extensions/transport_sockets/tls:config",
-        "//test/integration/filters:test_listener_filter_lib",
-        "//test/integration/filters:test_network_filter_lib",
-        "//test/server:utility_lib",
-        "//test/test_common:threadsafe_singleton_injector_lib",
-        "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
-        "@envoy_api//envoy/config/listener/v3:pkg_cc_proto",
-    ],
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":listener_manager_impl_test_lib",
+            "//source/common/formatter:formatter_extension_lib",
+            "//source/extensions/filters/http/router:config",
+            "//source/extensions/filters/network/http_connection_manager:config",
+            "//source/extensions/matching/network/common:inputs_lib",
+            "//source/extensions/quic/server_preferred_address:fixed_server_preferred_address_config_factory_config",
+            "//source/extensions/request_id/uuid:config",
+            "//source/extensions/transport_sockets/raw_buffer:config",
+            "//source/extensions/transport_sockets/tls:config",
+            "//test/integration/filters:test_listener_filter_lib",
+            "//test/integration/filters:test_network_filter_lib",
+            "//test/server:utility_lib",
+            "//test/test_common:threadsafe_singleton_injector_lib",
+            "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
+            "@envoy_api//envoy/config/listener/v3:pkg_cc_proto",
+        ],
+    }),
 )
 
 envoy_cc_test(

--- a/test/common/listener_manager/BUILD
+++ b/test/common/listener_manager/BUILD
@@ -6,6 +6,7 @@ load(
     "envoy_cc_test_library",
     "envoy_package",
     "envoy_proto_library",
+    "envoy_select_enable_http3",
 )
 
 licenses(["notice"])  # Apache 2
@@ -109,31 +110,25 @@ envoy_cc_test(
 # Stand-alone quic test because of FIPS.
 envoy_cc_test(
     name = "listener_manager_impl_quic_only_test",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["listener_manager_impl_quic_only_test.cc"],
-    }),
+    srcs = envoy_select_enable_http3(["listener_manager_impl_quic_only_test.cc"]),
     rbe_pool = "6gig",
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":listener_manager_impl_test_lib",
-            "//source/common/formatter:formatter_extension_lib",
-            "//source/extensions/filters/http/router:config",
-            "//source/extensions/filters/network/http_connection_manager:config",
-            "//source/extensions/matching/network/common:inputs_lib",
-            "//source/extensions/quic/server_preferred_address:fixed_server_preferred_address_config_factory_config",
-            "//source/extensions/request_id/uuid:config",
-            "//source/extensions/transport_sockets/raw_buffer:config",
-            "//source/extensions/transport_sockets/tls:config",
-            "//test/integration/filters:test_listener_filter_lib",
-            "//test/integration/filters:test_network_filter_lib",
-            "//test/server:utility_lib",
-            "//test/test_common:threadsafe_singleton_injector_lib",
-            "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
-            "@envoy_api//envoy/config/listener/v3:pkg_cc_proto",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        ":listener_manager_impl_test_lib",
+        "//source/common/formatter:formatter_extension_lib",
+        "//source/extensions/filters/http/router:config",
+        "//source/extensions/filters/network/http_connection_manager:config",
+        "//source/extensions/matching/network/common:inputs_lib",
+        "//source/extensions/quic/server_preferred_address:fixed_server_preferred_address_config_factory_config",
+        "//source/extensions/request_id/uuid:config",
+        "//source/extensions/transport_sockets/raw_buffer:config",
+        "//source/extensions/transport_sockets/tls:config",
+        "//test/integration/filters:test_listener_filter_lib",
+        "//test/integration/filters:test_network_filter_lib",
+        "//test/server:utility_lib",
+        "//test/test_common:threadsafe_singleton_injector_lib",
+        "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
+        "@envoy_api//envoy/config/listener/v3:pkg_cc_proto",
+    ]),
 )
 
 envoy_cc_test(

--- a/test/common/network/BUILD
+++ b/test/common/network/BUILD
@@ -7,6 +7,7 @@ load(
     "envoy_cc_test_library",
     "envoy_package",
     "envoy_proto_library",
+    "envoy_select_enable_http3",
 )
 
 licenses(["notice"])  # Apache 2
@@ -273,37 +274,31 @@ envoy_cc_test(
 
 envoy_cc_test(
     name = "udp_listener_impl_batch_writer_test",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["udp_listener_impl_batch_writer_test.cc"],
-    }),
+    srcs = envoy_select_enable_http3(["udp_listener_impl_batch_writer_test.cc"]),
     rbe_pool = "6gig",
     # Skipping as quiche quic_gso_batch_writer.h does not exist on Windows
     tags = [
         "skip_on_windows",
     ],
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":udp_listener_impl_test_base_lib",
-            "//source/common/event:dispatcher_lib",
-            "//source/common/network:address_lib",
-            "//source/common/network:listener_lib",
-            "//source/common/network:socket_option_lib",
-            "//source/common/network:udp_packet_writer_handler_lib",
-            "//source/common/network:utility_lib",
-            "//source/common/quic:udp_gso_batch_writer_lib",
-            "//source/common/stats:stats_lib",
-            "//test/common/network:listener_impl_test_base_lib",
-            "//test/mocks/network:network_mocks",
-            "//test/test_common:environment_lib",
-            "//test/test_common:network_utility_lib",
-            "//test/test_common:threadsafe_singleton_injector_lib",
-            "//test/test_common:utility_lib",
-            "@com_github_google_quiche//:quic_test_tools_mock_syscall_wrapper_lib",
-            "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        ":udp_listener_impl_test_base_lib",
+        "//source/common/event:dispatcher_lib",
+        "//source/common/network:address_lib",
+        "//source/common/network:listener_lib",
+        "//source/common/network:socket_option_lib",
+        "//source/common/network:udp_packet_writer_handler_lib",
+        "//source/common/network:utility_lib",
+        "//source/common/quic:udp_gso_batch_writer_lib",
+        "//source/common/stats:stats_lib",
+        "//test/common/network:listener_impl_test_base_lib",
+        "//test/mocks/network:network_mocks",
+        "//test/test_common:environment_lib",
+        "//test/test_common:network_utility_lib",
+        "//test/test_common:threadsafe_singleton_injector_lib",
+        "//test/test_common:utility_lib",
+        "@com_github_google_quiche//:quic_test_tools_mock_syscall_wrapper_lib",
+        "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
+    ]),
 )
 
 envoy_cc_test(

--- a/test/common/network/BUILD
+++ b/test/common/network/BUILD
@@ -273,32 +273,37 @@ envoy_cc_test(
 
 envoy_cc_test(
     name = "udp_listener_impl_batch_writer_test",
-    srcs = ["udp_listener_impl_batch_writer_test.cc"],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["udp_listener_impl_batch_writer_test.cc"],
+    }),
     rbe_pool = "6gig",
     # Skipping as quiche quic_gso_batch_writer.h does not exist on Windows
     tags = [
-        "nofips",
         "skip_on_windows",
     ],
-    deps = [
-        ":udp_listener_impl_test_base_lib",
-        "//source/common/event:dispatcher_lib",
-        "//source/common/network:address_lib",
-        "//source/common/network:listener_lib",
-        "//source/common/network:socket_option_lib",
-        "//source/common/network:udp_packet_writer_handler_lib",
-        "//source/common/network:utility_lib",
-        "//source/common/quic:udp_gso_batch_writer_lib",
-        "//source/common/stats:stats_lib",
-        "//test/common/network:listener_impl_test_base_lib",
-        "//test/mocks/network:network_mocks",
-        "//test/test_common:environment_lib",
-        "//test/test_common:network_utility_lib",
-        "//test/test_common:threadsafe_singleton_injector_lib",
-        "//test/test_common:utility_lib",
-        "@com_github_google_quiche//:quic_test_tools_mock_syscall_wrapper_lib",
-        "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
-    ],
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":udp_listener_impl_test_base_lib",
+            "//source/common/event:dispatcher_lib",
+            "//source/common/network:address_lib",
+            "//source/common/network:listener_lib",
+            "//source/common/network:socket_option_lib",
+            "//source/common/network:udp_packet_writer_handler_lib",
+            "//source/common/network:utility_lib",
+            "//source/common/quic:udp_gso_batch_writer_lib",
+            "//source/common/stats:stats_lib",
+            "//test/common/network:listener_impl_test_base_lib",
+            "//test/mocks/network:network_mocks",
+            "//test/test_common:environment_lib",
+            "//test/test_common:network_utility_lib",
+            "//test/test_common:threadsafe_singleton_injector_lib",
+            "//test/test_common:utility_lib",
+            "@com_github_google_quiche//:quic_test_tools_mock_syscall_wrapper_lib",
+            "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
+        ],
+    }),
 )
 
 envoy_cc_test(

--- a/test/common/quic/BUILD
+++ b/test/common/quic/BUILD
@@ -5,7 +5,7 @@ load(
     "envoy_cc_test_library",
     "envoy_package",
     "envoy_proto_library",
-    "envoy_select_enable_http_datagrams",
+    "envoy_select_enable_http3",
 )
 
 licenses(["notice"])  # Apache 2
@@ -14,289 +14,358 @@ envoy_package()
 
 envoy_cc_test(
     name = "envoy_quic_alarm_test",
-    srcs = ["envoy_quic_alarm_test.cc"],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_alarm_test.cc"],
+    }),
     rbe_pool = "6gig",
-    tags = ["nofips"],
-    deps = [
-        "//source/common/quic:envoy_quic_alarm_factory_lib",
-        "//source/common/quic:envoy_quic_alarm_lib",
-        "//source/common/quic:envoy_quic_clock_lib",
-        "//test/test_common:simulated_time_system_lib",
-        "//test/test_common:utility_lib",
-        "@com_github_google_quiche//:quic_platform",
-    ],
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//source/common/quic:envoy_quic_alarm_factory_lib",
+            "//source/common/quic:envoy_quic_alarm_lib",
+            "//source/common/quic:envoy_quic_clock_lib",
+            "//test/test_common:simulated_time_system_lib",
+            "//test/test_common:utility_lib",
+            "@com_github_google_quiche//:quic_platform",
+        ],
+    }),
 )
 
 envoy_cc_test(
     name = "envoy_quic_clock_test",
-    srcs = ["envoy_quic_clock_test.cc"],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_clock_test.cc"],
+    }),
     rbe_pool = "6gig",
-    tags = ["nofips"],
-    deps = [
-        "//source/common/quic:envoy_quic_clock_lib",
-        "//test/test_common:simulated_time_system_lib",
-        "//test/test_common:test_time_lib",
-        "//test/test_common:utility_lib",
-    ],
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//source/common/quic:envoy_quic_clock_lib",
+            "//test/test_common:simulated_time_system_lib",
+            "//test/test_common:test_time_lib",
+            "//test/test_common:utility_lib",
+        ],
+    }),
 )
 
 envoy_cc_test(
     name = "envoy_quic_writer_test",
-    srcs = ["envoy_quic_writer_test.cc"],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_writer_test.cc"],
+    }),
     rbe_pool = "6gig",
-    tags = ["nofips"],
-    deps = [
-        "//source/common/network:io_socket_error_lib",
-        "//source/common/network:udp_packet_writer_handler_lib",
-        "//source/common/quic:envoy_quic_packet_writer_lib",
-        "//test/mocks/api:api_mocks",
-        "//test/mocks/network:network_mocks",
-        "//test/test_common:threadsafe_singleton_injector_lib",
-        "@com_github_google_quiche//:quic_platform",
-    ],
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//source/common/network:io_socket_error_lib",
+            "//source/common/network:udp_packet_writer_handler_lib",
+            "//source/common/quic:envoy_quic_packet_writer_lib",
+            "//test/mocks/api:api_mocks",
+            "//test/mocks/network:network_mocks",
+            "//test/test_common:threadsafe_singleton_injector_lib",
+            "@com_github_google_quiche//:quic_platform",
+        ],
+    }),
 )
 
 envoy_cc_test(
     name = "envoy_quic_proof_source_test",
-    srcs = ["envoy_quic_proof_source_test.cc"],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_proof_source_test.cc"],
+    }),
     rbe_pool = "6gig",
-    tags = ["nofips"],
-    deps = [
-        ":test_utils_lib",
-        "//source/common/quic:envoy_quic_proof_source_lib",
-        "//source/common/quic:envoy_quic_proof_verifier_lib",
-        "//source/common/tls:context_config_lib",
-        "//source/common/tls:server_context_lib",
-        "//test/mocks/network:network_mocks",
-        "//test/mocks/server:server_factory_context_mocks",
-        "//test/mocks/ssl:ssl_mocks",
-        "//test/test_common:test_runtime_lib",
-        "@com_github_google_quiche//:quic_core_versions_lib",
-        "@com_github_google_quiche//:quic_platform",
-        "@com_github_google_quiche//:quic_test_tools_test_certificates_lib",
-    ],
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":test_utils_lib",
+            "//source/common/quic:envoy_quic_proof_source_lib",
+            "//source/common/quic:envoy_quic_proof_verifier_lib",
+            "//source/common/tls:context_config_lib",
+            "//source/common/tls:server_context_lib",
+            "//test/mocks/network:network_mocks",
+            "//test/mocks/server:server_factory_context_mocks",
+            "//test/mocks/ssl:ssl_mocks",
+            "//test/test_common:test_runtime_lib",
+            "@com_github_google_quiche//:quic_core_versions_lib",
+            "@com_github_google_quiche//:quic_platform",
+            "@com_github_google_quiche//:quic_test_tools_test_certificates_lib",
+        ],
+    }),
 )
 
 envoy_cc_test(
     name = "quic_filter_manager_connection_impl_test",
-    srcs = ["quic_filter_manager_connection_impl_test.cc"],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["quic_filter_manager_connection_impl_test.cc"],
+    }),
     rbe_pool = "6gig",
-    tags = ["nofips"],
-    deps = [
-        "//source/common/quic:quic_filter_manager_connection_lib",
-        "//test/mocks/event:event_mocks",
-        "//test/mocks/network:network_mocks",
-        "//test/test_common:utility_lib",
-        "@com_github_google_quiche//:quic_test_tools_test_utils_lib",
-    ],
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//source/common/quic:quic_filter_manager_connection_lib",
+            "//test/mocks/event:event_mocks",
+            "//test/mocks/network:network_mocks",
+            "//test/test_common:utility_lib",
+            "@com_github_google_quiche//:quic_test_tools_test_utils_lib",
+        ],
+    }),
 )
 
 envoy_cc_test(
     name = "quic_stat_names_test",
-    srcs = ["quic_stat_names_test.cc"],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["quic_stat_names_test.cc"],
+    }),
     rbe_pool = "6gig",
-    tags = ["nofips"],
-    deps = [
-        "//source/common/quic:quic_stat_names_lib",
-        "//source/common/stats:stats_lib",
-        "//test/mocks/stats:stats_mocks",
-        "//test/test_common:utility_lib",
-    ],
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//source/common/quic:quic_stat_names_lib",
+            "//source/common/stats:stats_lib",
+            "//test/mocks/stats:stats_mocks",
+            "//test/test_common:utility_lib",
+        ],
+    }),
 )
 
 envoy_cc_test(
     name = "envoy_quic_proof_verifier_test",
-    srcs = ["envoy_quic_proof_verifier_test.cc"],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_proof_verifier_test.cc"],
+    }),
     rbe_pool = "6gig",
-    tags = ["nofips"],
-    deps = [
-        ":test_utils_lib",
-        "//source/common/quic:envoy_quic_proof_verifier_lib",
-        "//source/common/tls:context_config_lib",
-        "//test/common/config:dummy_config_proto_cc_proto",
-        "//test/common/tls/cert_validator:timed_cert_validator",
-        "//test/mocks/event:event_mocks",
-        "//test/mocks/server:server_factory_context_mocks",
-        "//test/mocks/ssl:ssl_mocks",
-        "@com_github_google_quiche//:quic_platform",
-        "@com_github_google_quiche//:quic_test_tools_test_certificates_lib",
-    ],
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":test_utils_lib",
+            "//source/common/quic:envoy_quic_proof_verifier_lib",
+            "//source/common/tls:context_config_lib",
+            "//test/common/config:dummy_config_proto_cc_proto",
+            "//test/common/tls/cert_validator:timed_cert_validator",
+            "//test/mocks/event:event_mocks",
+            "//test/mocks/server:server_factory_context_mocks",
+            "//test/mocks/ssl:ssl_mocks",
+            "@com_github_google_quiche//:quic_platform",
+            "@com_github_google_quiche//:quic_test_tools_test_certificates_lib",
+        ],
+    }),
 )
 
 envoy_cc_test(
     name = "envoy_quic_server_stream_test",
-    srcs = ["envoy_quic_server_stream_test.cc"],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_server_stream_test.cc"],
+    }),
     rbe_pool = "6gig",
-    tags = ["nofips"],
-    deps = [
-        ":test_utils_lib",
-        "//source/common/http:headers_lib",
-        "//source/common/quic:envoy_quic_alarm_factory_lib",
-        "//source/common/quic:envoy_quic_connection_helper_lib",
-        "//source/common/quic:envoy_quic_server_connection_lib",
-        "//source/common/quic:envoy_quic_server_session_lib",
-        "//source/server:active_listener_base",
-        "//test/mocks/http:http_mocks",
-        "//test/mocks/http:stream_decoder_mock",
-        "//test/mocks/network:network_mocks",
-        "//test/test_common:utility_lib",
-        "@com_github_google_quiche//:quic_core_http_spdy_session_lib",
-        "@com_github_google_quiche//:quic_test_tools_qpack_qpack_test_utils_lib",
-        "@com_github_google_quiche//:quic_test_tools_session_peer_lib",
-    ],
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":test_utils_lib",
+            "//source/common/http:headers_lib",
+            "//source/common/quic:envoy_quic_alarm_factory_lib",
+            "//source/common/quic:envoy_quic_connection_helper_lib",
+            "//source/common/quic:envoy_quic_server_connection_lib",
+            "//source/common/quic:envoy_quic_server_session_lib",
+            "//source/server:active_listener_base",
+            "//test/mocks/http:http_mocks",
+            "//test/mocks/http:stream_decoder_mock",
+            "//test/mocks/network:network_mocks",
+            "//test/test_common:utility_lib",
+            "@com_github_google_quiche//:quic_core_http_spdy_session_lib",
+            "@com_github_google_quiche//:quic_test_tools_qpack_qpack_test_utils_lib",
+            "@com_github_google_quiche//:quic_test_tools_session_peer_lib",
+        ],
+    }),
 )
 
 envoy_cc_test(
     name = "envoy_quic_client_stream_test",
-    srcs = ["envoy_quic_client_stream_test.cc"],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_client_stream_test.cc"],
+    }),
     rbe_pool = "6gig",
-    tags = ["nofips"],
-    deps = [
-        ":test_utils_lib",
-        "//source/common/http:headers_lib",
-        "//source/common/quic:envoy_quic_alarm_factory_lib",
-        "//source/common/quic:envoy_quic_client_connection_lib",
-        "//source/common/quic:envoy_quic_client_session_lib",
-        "//source/common/quic:envoy_quic_connection_helper_lib",
-        "//test/mocks/http:http_mocks",
-        "//test/mocks/http:stream_decoder_mock",
-        "//test/mocks/network:network_mocks",
-        "//test/test_common:utility_lib",
-        "@com_github_google_quiche//:quic_core_http_spdy_session_lib",
-        "@com_github_google_quiche//:quic_test_tools_qpack_qpack_test_utils_lib",
-    ],
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":test_utils_lib",
+            "//source/common/http:headers_lib",
+            "//source/common/quic:envoy_quic_alarm_factory_lib",
+            "//source/common/quic:envoy_quic_client_connection_lib",
+            "//source/common/quic:envoy_quic_client_session_lib",
+            "//source/common/quic:envoy_quic_connection_helper_lib",
+            "//test/mocks/http:http_mocks",
+            "//test/mocks/http:stream_decoder_mock",
+            "//test/mocks/network:network_mocks",
+            "//test/test_common:utility_lib",
+            "@com_github_google_quiche//:quic_core_http_spdy_session_lib",
+            "@com_github_google_quiche//:quic_test_tools_qpack_qpack_test_utils_lib",
+        ],
+    }),
 )
 
 envoy_cc_test(
     name = "envoy_quic_server_session_test",
-    srcs = ["envoy_quic_server_session_test.cc"],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_server_session_test.cc"],
+    }),
     rbe_pool = "6gig",
-    tags = ["nofips"],
-    deps = [
-        ":test_proof_source_lib",
-        ":test_utils_lib",
-        "//envoy/stats:stats_macros",
-        "//source/common/quic:envoy_quic_alarm_factory_lib",
-        "//source/common/quic:envoy_quic_connection_helper_lib",
-        "//source/common/quic:envoy_quic_server_connection_lib",
-        "//source/common/quic:envoy_quic_server_session_lib",
-        "//source/common/quic:server_codec_lib",
-        "//source/server:configuration_lib",
-        "//test/mocks/event:event_mocks",
-        "//test/mocks/http:http_mocks",
-        "//test/mocks/http:stream_decoder_mock",
-        "//test/mocks/network:network_mocks",
-        "//test/mocks/stats:stats_mocks",
-        "//test/test_common:global_lib",
-        "//test/test_common:logging_lib",
-        "//test/test_common:simulated_time_system_lib",
-        "@com_github_google_quiche//:quic_test_tools_config_peer_lib",
-        "@com_github_google_quiche//:quic_test_tools_server_session_base_peer",
-        "@com_github_google_quiche//:quic_test_tools_test_utils_lib",
-    ],
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":test_proof_source_lib",
+            ":test_utils_lib",
+            "//envoy/stats:stats_macros",
+            "//source/common/quic:envoy_quic_alarm_factory_lib",
+            "//source/common/quic:envoy_quic_connection_helper_lib",
+            "//source/common/quic:envoy_quic_server_connection_lib",
+            "//source/common/quic:envoy_quic_server_session_lib",
+            "//source/common/quic:server_codec_lib",
+            "//source/server:configuration_lib",
+            "//test/mocks/event:event_mocks",
+            "//test/mocks/http:http_mocks",
+            "//test/mocks/http:stream_decoder_mock",
+            "//test/mocks/network:network_mocks",
+            "//test/mocks/stats:stats_mocks",
+            "//test/test_common:global_lib",
+            "//test/test_common:logging_lib",
+            "//test/test_common:simulated_time_system_lib",
+            "@com_github_google_quiche//:quic_test_tools_config_peer_lib",
+            "@com_github_google_quiche//:quic_test_tools_server_session_base_peer",
+            "@com_github_google_quiche//:quic_test_tools_test_utils_lib",
+        ],
+    }),
 )
 
 envoy_cc_test(
     name = "envoy_quic_client_session_test",
-    srcs = ["envoy_quic_client_session_test.cc"],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_client_session_test.cc"],
+    }),
     rbe_pool = "6gig",
-    tags = ["nofips"],
-    deps = [
-        ":test_utils_lib",
-        "//envoy/stats:stats_macros",
-        "//source/common/api:os_sys_calls_lib",
-        "//source/common/quic:client_codec_lib",
-        "//source/common/quic:envoy_quic_alarm_factory_lib",
-        "//source/common/quic:envoy_quic_client_connection_lib",
-        "//source/common/quic:envoy_quic_client_session_lib",
-        "//source/common/quic:envoy_quic_connection_helper_lib",
-        "//source/extensions/quic/crypto_stream:envoy_quic_crypto_client_stream_lib",
-        "//test/mocks/api:api_mocks",
-        "//test/mocks/http:http_mocks",
-        "//test/mocks/http:stream_decoder_mock",
-        "//test/mocks/network:network_mocks",
-        "//test/mocks/stats:stats_mocks",
-        "//test/test_common:logging_lib",
-        "//test/test_common:simulated_time_system_lib",
-        "//test/test_common:test_runtime_lib",
-        "//test/test_common:threadsafe_singleton_injector_lib",
-        "@com_github_google_quiche//:quic_test_tools_session_peer_lib",
-    ],
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":test_utils_lib",
+            "//envoy/stats:stats_macros",
+            "//source/common/api:os_sys_calls_lib",
+            "//source/common/quic:client_codec_lib",
+            "//source/common/quic:envoy_quic_alarm_factory_lib",
+            "//source/common/quic:envoy_quic_client_connection_lib",
+            "//source/common/quic:envoy_quic_client_session_lib",
+            "//source/common/quic:envoy_quic_connection_helper_lib",
+            "//source/extensions/quic/crypto_stream:envoy_quic_crypto_client_stream_lib",
+            "//test/mocks/api:api_mocks",
+            "//test/mocks/http:http_mocks",
+            "//test/mocks/http:stream_decoder_mock",
+            "//test/mocks/network:network_mocks",
+            "//test/mocks/stats:stats_mocks",
+            "//test/test_common:logging_lib",
+            "//test/test_common:simulated_time_system_lib",
+            "//test/test_common:test_runtime_lib",
+            "//test/test_common:threadsafe_singleton_injector_lib",
+            "@com_github_google_quiche//:quic_test_tools_session_peer_lib",
+        ],
+    }),
 )
 
 envoy_cc_test(
     name = "active_quic_listener_test",
-    srcs = ["active_quic_listener_test.cc"],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["active_quic_listener_test.cc"],
+    }),
     rbe_pool = "6gig",
-    tags = ["nofips"],
-    deps = [
-        ":test_proof_source_lib",
-        ":test_utils_lib",
-        "//source/common/http:utility_lib",
-        "//source/common/listener_manager:connection_handler_lib",
-        "//source/common/network:udp_packet_writer_handler_lib",
-        "//source/common/quic:active_quic_listener_lib",
-        "//source/common/quic:envoy_quic_utils_lib",
-        "//source/common/quic:udp_gso_batch_writer_lib",
-        "//source/extensions/quic/crypto_stream:envoy_quic_crypto_server_stream_lib",
-        "//source/extensions/quic/proof_source:envoy_quic_proof_source_factory_impl_lib",
-        "//source/server:configuration_lib",
-        "//source/server:process_context_lib",
-        "//test/mocks/network:network_mocks",
-        "//test/mocks/server:instance_mocks",
-        "//test/mocks/server:listener_factory_context_mocks",
-        "//test/test_common:network_utility_lib",
-        "//test/test_common:simulated_time_system_lib",
-        "//test/test_common:test_runtime_lib",
-        "@com_github_google_quiche//:quic_test_tools_crypto_server_config_peer_lib",
-        "@envoy_api//envoy/config/listener/v3:pkg_cc_proto",
-    ],
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":test_proof_source_lib",
+            ":test_utils_lib",
+            "//source/common/http:utility_lib",
+            "//source/common/listener_manager:connection_handler_lib",
+            "//source/common/network:udp_packet_writer_handler_lib",
+            "//source/common/quic:active_quic_listener_lib",
+            "//source/common/quic:envoy_quic_utils_lib",
+            "//source/common/quic:udp_gso_batch_writer_lib",
+            "//source/extensions/quic/crypto_stream:envoy_quic_crypto_server_stream_lib",
+            "//source/extensions/quic/proof_source:envoy_quic_proof_source_factory_impl_lib",
+            "//source/server:configuration_lib",
+            "//source/server:process_context_lib",
+            "//test/mocks/network:network_mocks",
+            "//test/mocks/server:instance_mocks",
+            "//test/mocks/server:listener_factory_context_mocks",
+            "//test/test_common:network_utility_lib",
+            "//test/test_common:simulated_time_system_lib",
+            "//test/test_common:test_runtime_lib",
+            "@com_github_google_quiche//:quic_test_tools_crypto_server_config_peer_lib",
+            "@envoy_api//envoy/config/listener/v3:pkg_cc_proto",
+        ],
+    }),
 )
 
 envoy_cc_test(
     name = "envoy_quic_dispatcher_test",
-    srcs = ["envoy_quic_dispatcher_test.cc"],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_dispatcher_test.cc"],
+    }),
     rbe_pool = "6gig",
-    tags = ["nofips"],
-    deps = [
-        ":test_proof_source_lib",
-        ":test_utils_lib",
-        "//envoy/stats:stats_macros",
-        "//source/common/listener_manager:connection_handler_lib",
-        "//source/common/quic:envoy_quic_alarm_factory_lib",
-        "//source/common/quic:envoy_quic_connection_helper_lib",
-        "//source/common/quic:envoy_quic_dispatcher_lib",
-        "//source/common/quic:envoy_quic_proof_source_lib",
-        "//source/common/quic:envoy_quic_server_session_lib",
-        "//source/common/quic:quic_server_transport_socket_factory_lib",
-        "//source/extensions/quic/crypto_stream:envoy_quic_crypto_server_stream_lib",
-        "//source/server:configuration_lib",
-        "//test/mocks/event:event_mocks",
-        "//test/mocks/http:http_mocks",
-        "//test/mocks/network:network_mocks",
-        "//test/mocks/ssl:ssl_mocks",
-        "//test/mocks/stats:stats_mocks",
-        "//test/test_common:global_lib",
-        "//test/test_common:simulated_time_system_lib",
-        "//test/test_common:test_runtime_lib",
-    ],
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":test_proof_source_lib",
+            ":test_utils_lib",
+            "//envoy/stats:stats_macros",
+            "//source/common/listener_manager:connection_handler_lib",
+            "//source/common/quic:envoy_quic_alarm_factory_lib",
+            "//source/common/quic:envoy_quic_connection_helper_lib",
+            "//source/common/quic:envoy_quic_dispatcher_lib",
+            "//source/common/quic:envoy_quic_proof_source_lib",
+            "//source/common/quic:envoy_quic_server_session_lib",
+            "//source/common/quic:quic_server_transport_socket_factory_lib",
+            "//source/extensions/quic/crypto_stream:envoy_quic_crypto_server_stream_lib",
+            "//source/server:configuration_lib",
+            "//test/mocks/event:event_mocks",
+            "//test/mocks/http:http_mocks",
+            "//test/mocks/network:network_mocks",
+            "//test/mocks/ssl:ssl_mocks",
+            "//test/mocks/stats:stats_mocks",
+            "//test/test_common:global_lib",
+            "//test/test_common:simulated_time_system_lib",
+            "//test/test_common:test_runtime_lib",
+        ],
+    }),
 )
 
 envoy_cc_test_library(
     name = "test_proof_source_lib",
-    hdrs = ["test_proof_source.h"],
-    tags = ["nofips"],
-    deps = [
-        "//source/common/quic:envoy_quic_proof_source_base_lib",
-        "//test/mocks/network:network_mocks",
-        "@com_github_google_quiche//:quic_test_tools_test_certificates_lib",
-    ],
+    hdrs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["test_proof_source.h"],
+    }),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//source/common/quic:envoy_quic_proof_source_base_lib",
+            "//test/mocks/network:network_mocks",
+            "@com_github_google_quiche//:quic_test_tools_test_certificates_lib",
+        ],
+    }),
 )
 
 envoy_cc_test_library(
     name = "test_proof_verifier_lib",
     hdrs = ["test_proof_verifier.h"],
-    tags = ["nofips"],
     deps = [
         "//source/common/quic:envoy_quic_proof_verifier_base_lib",
     ],
@@ -304,71 +373,90 @@ envoy_cc_test_library(
 
 envoy_cc_test(
     name = "client_connection_factory_impl_test",
-    srcs = ["client_connection_factory_impl_test.cc"],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["client_connection_factory_impl_test.cc"],
+    }),
     rbe_pool = "6gig",
-    tags = ["nofips"],
-    deps = [
-        "//source/common/event:dispatcher_lib",
-        "//source/common/http/http3:conn_pool_lib",
-        "//source/common/network:utility_lib",
-        "//source/common/upstream:upstream_includes",
-        "//source/common/upstream:upstream_lib",
-        "//test/common/http:common_lib",
-        "//test/common/upstream:utility_lib",
-        "//test/mocks/event:event_mocks",
-        "//test/mocks/http:http_mocks",
-        "//test/mocks/http:http_server_properties_cache_mocks",
-        "//test/mocks/network:network_mocks",
-        "//test/mocks/runtime:runtime_mocks",
-        "//test/mocks/server:factory_context_mocks",
-        "//test/mocks/upstream:cluster_info_mocks",
-        "//test/mocks/upstream:transport_socket_match_mocks",
-        "//test/test_common:test_runtime_lib",
-        "//test/test_common:threadsafe_singleton_injector_lib",
-    ],
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//source/common/event:dispatcher_lib",
+            "//source/common/http/http3:conn_pool_lib",
+            "//source/common/network:utility_lib",
+            "//source/common/upstream:upstream_includes",
+            "//source/common/upstream:upstream_lib",
+            "//test/common/http:common_lib",
+            "//test/common/upstream:utility_lib",
+            "//test/mocks/event:event_mocks",
+            "//test/mocks/http:http_mocks",
+            "//test/mocks/http:http_server_properties_cache_mocks",
+            "//test/mocks/network:network_mocks",
+            "//test/mocks/runtime:runtime_mocks",
+            "//test/mocks/server:factory_context_mocks",
+            "//test/mocks/upstream:cluster_info_mocks",
+            "//test/mocks/upstream:transport_socket_match_mocks",
+            "//test/test_common:test_runtime_lib",
+            "//test/test_common:threadsafe_singleton_injector_lib",
+        ],
+    }),
 )
 
 envoy_cc_test(
     name = "quic_io_handle_wrapper_test",
-    srcs = ["quic_io_handle_wrapper_test.cc"],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["quic_io_handle_wrapper_test.cc"],
+    }),
     rbe_pool = "6gig",
-    tags = ["nofips"],
-    deps = [
-        "//source/common/quic:quic_io_handle_wrapper_lib",
-        "//test/mocks/api:api_mocks",
-        "//test/mocks/network:io_handle_mocks",
-        "//test/mocks/network:network_mocks",
-        "//test/test_common:threadsafe_singleton_injector_lib",
-    ],
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//source/common/quic:quic_io_handle_wrapper_lib",
+            "//test/mocks/api:api_mocks",
+            "//test/mocks/network:io_handle_mocks",
+            "//test/mocks/network:network_mocks",
+            "//test/test_common:threadsafe_singleton_injector_lib",
+        ],
+    }),
 )
 
 envoy_cc_test(
     name = "envoy_quic_utils_test",
-    srcs = ["envoy_quic_utils_test.cc"],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_utils_test.cc"],
+    }),
     rbe_pool = "6gig",
-    tags = ["nofips"],
-    deps = [
-        "//source/common/quic:envoy_quic_utils_lib",
-        "//test/mocks/api:api_mocks",
-        "//test/test_common:threadsafe_singleton_injector_lib",
-        "@com_github_google_quiche//:quic_test_tools_test_utils_lib",
-    ],
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//source/common/quic:envoy_quic_utils_lib",
+            "//test/mocks/api:api_mocks",
+            "//test/test_common:threadsafe_singleton_injector_lib",
+            "@com_github_google_quiche//:quic_test_tools_test_utils_lib",
+        ],
+    }),
 )
 
 envoy_cc_test(
     name = "envoy_quic_simulated_watermark_buffer_test",
-    srcs = ["envoy_quic_simulated_watermark_buffer_test.cc"],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_quic_simulated_watermark_buffer_test.cc"],
+    }),
     rbe_pool = "6gig",
-    tags = ["nofips"],
-    deps = ["//source/common/quic:envoy_quic_simulated_watermark_buffer_lib"],
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["//source/common/quic:envoy_quic_simulated_watermark_buffer_lib"],
+    }),
 )
 
 envoy_cc_test_library(
     name = "test_utils_lib",
-    hdrs = ["test_utils.h"],
+    hdrs = envoy_select_enable_http3(["test_utils.h"]),
     external_deps = ["bazel_runfiles"],
-    tags = ["nofips"],
-    deps = [
+    deps = envoy_select_enable_http3([
         "//envoy/stream_info:stream_info_interface",
         "//source/common/quic:envoy_quic_client_connection_lib",
         "//source/common/quic:envoy_quic_client_session_lib",
@@ -382,48 +470,64 @@ envoy_cc_test_library(
         "@com_github_google_quiche//:quic_core_http_spdy_session_lib",
         "@com_github_google_quiche//:quic_test_tools_first_flight_lib",
         "@com_github_google_quiche//:quic_test_tools_qpack_qpack_test_utils_lib",
-    ],
-)
-
-envoy_cc_test(
-    name = "quic_transport_socket_factory_test",
-    srcs = ["quic_transport_socket_factory_test.cc"],
-    data = [
-        "//test/common/tls/test_data:certs",
-    ],
-    rbe_pool = "6gig",
-    tags = ["nofips"],
-    deps = [
-        "//source/common/quic:quic_server_transport_socket_factory_lib",
-        "//source/common/quic:quic_transport_socket_factory_lib",
-        "//source/common/tls:context_config_lib",
-        "//test/mocks/server:factory_context_mocks",
-        "//test/mocks/ssl:ssl_mocks",
-        "//test/test_common:environment_lib",
-        "//test/test_common:utility_lib",
-    ],
-)
-
-envoy_cc_test(
-    name = "http_datagram_handler_test",
-    srcs = envoy_select_enable_http_datagrams(["http_datagram_handler_test.cc"]),
-    rbe_pool = "6gig",
-    tags = ["nofips"],
-    deps = envoy_select_enable_http_datagrams([
-        "//source/common/quic:http_datagram_handler",
-        "//test/mocks/buffer:buffer_mocks",
-        "//test/test_common:utility_lib",
-        "@com_github_google_quiche//:quic_test_tools_test_utils_lib",
     ]),
 )
 
 envoy_cc_test(
-    name = "cert_compression_test",
-    srcs = ["cert_compression_test.cc"],
-    deps = [
-        "//source/common/quic:cert_compression_lib",
-        "//test/test_common:logging_lib",
+    name = "quic_transport_socket_factory_test",
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["quic_transport_socket_factory_test.cc"],
+    }),
+    data = [
+        "//test/common/tls/test_data:certs",
     ],
+    rbe_pool = "6gig",
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//source/common/quic:quic_server_transport_socket_factory_lib",
+            "//source/common/quic:quic_transport_socket_factory_lib",
+            "//source/common/tls:context_config_lib",
+            "//test/mocks/server:factory_context_mocks",
+            "//test/mocks/ssl:ssl_mocks",
+            "//test/test_common:environment_lib",
+            "//test/test_common:utility_lib",
+        ],
+    }),
+)
+
+envoy_cc_test(
+    name = "http_datagram_handler_test",
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["http_datagram_handler_test.cc"],
+    }),
+    rbe_pool = "6gig",
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//source/common/quic:http_datagram_handler",
+            "//test/mocks/buffer:buffer_mocks",
+            "//test/test_common:utility_lib",
+            "@com_github_google_quiche//:quic_test_tools_test_utils_lib",
+        ],
+    }),
+)
+
+envoy_cc_test(
+    name = "cert_compression_test",
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["cert_compression_test.cc"],
+    }),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//source/common/quic:cert_compression_lib",
+            "//test/test_common:logging_lib",
+        ],
+    }),
 )
 
 envoy_cc_test_library(
@@ -434,14 +538,19 @@ envoy_cc_test_library(
 
 envoy_cc_test(
     name = "envoy_deterministic_connection_id_generator_test",
-    srcs = ["envoy_deterministic_connection_id_generator_test.cc"],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["envoy_deterministic_connection_id_generator_test.cc"],
+    }),
     rbe_pool = "6gig",
-    tags = ["nofips"],
-    deps = [
-        ":connection_id_matchers",
-        "//source/common/quic:envoy_deterministic_connection_id_generator_lib",
-        "@com_github_google_quiche//:quic_test_tools_test_utils_lib",
-    ],
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            ":connection_id_matchers",
+            "//source/common/quic:envoy_deterministic_connection_id_generator_lib",
+            "@com_github_google_quiche//:quic_test_tools_test_utils_lib",
+        ],
+    }),
 )
 
 envoy_proto_library(
@@ -454,7 +563,6 @@ envoy_cc_test_library(
     name = "envoy_quic_h3_fuzz_helper_lib",
     srcs = ["envoy_quic_h3_fuzz_helper.cc"],
     hdrs = ["envoy_quic_h3_fuzz_helper.h"],
-    tags = ["nofips"],
     deps = [
         ":envoy_quic_h3_fuzz_proto_cc_proto",
         "//source/common/common:assert_lib",

--- a/test/common/quic/BUILD
+++ b/test/common/quic/BUILD
@@ -14,353 +14,269 @@ envoy_package()
 
 envoy_cc_test(
     name = "envoy_quic_alarm_test",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_alarm_test.cc"],
-    }),
+    srcs = envoy_select_enable_http3(["envoy_quic_alarm_test.cc"]),
     rbe_pool = "6gig",
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//source/common/quic:envoy_quic_alarm_factory_lib",
-            "//source/common/quic:envoy_quic_alarm_lib",
-            "//source/common/quic:envoy_quic_clock_lib",
-            "//test/test_common:simulated_time_system_lib",
-            "//test/test_common:utility_lib",
-            "@com_github_google_quiche//:quic_platform",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        "//source/common/quic:envoy_quic_alarm_factory_lib",
+        "//source/common/quic:envoy_quic_alarm_lib",
+        "//source/common/quic:envoy_quic_clock_lib",
+        "//test/test_common:simulated_time_system_lib",
+        "//test/test_common:utility_lib",
+        "@com_github_google_quiche//:quic_platform",
+    ]),
 )
 
 envoy_cc_test(
     name = "envoy_quic_clock_test",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_clock_test.cc"],
-    }),
+    srcs = envoy_select_enable_http3(["envoy_quic_clock_test.cc"]),
     rbe_pool = "6gig",
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//source/common/quic:envoy_quic_clock_lib",
-            "//test/test_common:simulated_time_system_lib",
-            "//test/test_common:test_time_lib",
-            "//test/test_common:utility_lib",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        "//source/common/quic:envoy_quic_clock_lib",
+        "//test/test_common:simulated_time_system_lib",
+        "//test/test_common:test_time_lib",
+        "//test/test_common:utility_lib",
+    ]),
 )
 
 envoy_cc_test(
     name = "envoy_quic_writer_test",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_writer_test.cc"],
-    }),
+    srcs = envoy_select_enable_http3(["envoy_quic_writer_test.cc"]),
     rbe_pool = "6gig",
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//source/common/network:io_socket_error_lib",
-            "//source/common/network:udp_packet_writer_handler_lib",
-            "//source/common/quic:envoy_quic_packet_writer_lib",
-            "//test/mocks/api:api_mocks",
-            "//test/mocks/network:network_mocks",
-            "//test/test_common:threadsafe_singleton_injector_lib",
-            "@com_github_google_quiche//:quic_platform",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        "//source/common/network:io_socket_error_lib",
+        "//source/common/network:udp_packet_writer_handler_lib",
+        "//source/common/quic:envoy_quic_packet_writer_lib",
+        "//test/mocks/api:api_mocks",
+        "//test/mocks/network:network_mocks",
+        "//test/test_common:threadsafe_singleton_injector_lib",
+        "@com_github_google_quiche//:quic_platform",
+    ]),
 )
 
 envoy_cc_test(
     name = "envoy_quic_proof_source_test",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_proof_source_test.cc"],
-    }),
+    srcs = envoy_select_enable_http3(["envoy_quic_proof_source_test.cc"]),
     rbe_pool = "6gig",
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":test_utils_lib",
-            "//source/common/quic:envoy_quic_proof_source_lib",
-            "//source/common/quic:envoy_quic_proof_verifier_lib",
-            "//source/common/tls:context_config_lib",
-            "//source/common/tls:server_context_lib",
-            "//test/mocks/network:network_mocks",
-            "//test/mocks/server:server_factory_context_mocks",
-            "//test/mocks/ssl:ssl_mocks",
-            "//test/test_common:test_runtime_lib",
-            "@com_github_google_quiche//:quic_core_versions_lib",
-            "@com_github_google_quiche//:quic_platform",
-            "@com_github_google_quiche//:quic_test_tools_test_certificates_lib",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        ":test_utils_lib",
+        "//source/common/quic:envoy_quic_proof_source_lib",
+        "//source/common/quic:envoy_quic_proof_verifier_lib",
+        "//source/common/tls:context_config_lib",
+        "//source/common/tls:server_context_lib",
+        "//test/mocks/network:network_mocks",
+        "//test/mocks/server:server_factory_context_mocks",
+        "//test/mocks/ssl:ssl_mocks",
+        "//test/test_common:test_runtime_lib",
+        "@com_github_google_quiche//:quic_core_versions_lib",
+        "@com_github_google_quiche//:quic_platform",
+        "@com_github_google_quiche//:quic_test_tools_test_certificates_lib",
+    ]),
 )
 
 envoy_cc_test(
     name = "quic_filter_manager_connection_impl_test",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["quic_filter_manager_connection_impl_test.cc"],
-    }),
+    srcs = envoy_select_enable_http3(["quic_filter_manager_connection_impl_test.cc"]),
     rbe_pool = "6gig",
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//source/common/quic:quic_filter_manager_connection_lib",
-            "//test/mocks/event:event_mocks",
-            "//test/mocks/network:network_mocks",
-            "//test/test_common:utility_lib",
-            "@com_github_google_quiche//:quic_test_tools_test_utils_lib",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        "//source/common/quic:quic_filter_manager_connection_lib",
+        "//test/mocks/event:event_mocks",
+        "//test/mocks/network:network_mocks",
+        "//test/test_common:utility_lib",
+        "@com_github_google_quiche//:quic_test_tools_test_utils_lib",
+    ]),
 )
 
 envoy_cc_test(
     name = "quic_stat_names_test",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["quic_stat_names_test.cc"],
-    }),
+    srcs = envoy_select_enable_http3(["quic_stat_names_test.cc"]),
     rbe_pool = "6gig",
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//source/common/quic:quic_stat_names_lib",
-            "//source/common/stats:stats_lib",
-            "//test/mocks/stats:stats_mocks",
-            "//test/test_common:utility_lib",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        "//source/common/quic:quic_stat_names_lib",
+        "//source/common/stats:stats_lib",
+        "//test/mocks/stats:stats_mocks",
+        "//test/test_common:utility_lib",
+    ]),
 )
 
 envoy_cc_test(
     name = "envoy_quic_proof_verifier_test",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_proof_verifier_test.cc"],
-    }),
+    srcs = envoy_select_enable_http3(["envoy_quic_proof_verifier_test.cc"]),
     rbe_pool = "6gig",
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":test_utils_lib",
-            "//source/common/quic:envoy_quic_proof_verifier_lib",
-            "//source/common/tls:context_config_lib",
-            "//test/common/config:dummy_config_proto_cc_proto",
-            "//test/common/tls/cert_validator:timed_cert_validator",
-            "//test/mocks/event:event_mocks",
-            "//test/mocks/server:server_factory_context_mocks",
-            "//test/mocks/ssl:ssl_mocks",
-            "@com_github_google_quiche//:quic_platform",
-            "@com_github_google_quiche//:quic_test_tools_test_certificates_lib",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        ":test_utils_lib",
+        "//source/common/quic:envoy_quic_proof_verifier_lib",
+        "//source/common/tls:context_config_lib",
+        "//test/common/config:dummy_config_proto_cc_proto",
+        "//test/common/tls/cert_validator:timed_cert_validator",
+        "//test/mocks/event:event_mocks",
+        "//test/mocks/server:server_factory_context_mocks",
+        "//test/mocks/ssl:ssl_mocks",
+        "@com_github_google_quiche//:quic_platform",
+        "@com_github_google_quiche//:quic_test_tools_test_certificates_lib",
+    ]),
 )
 
 envoy_cc_test(
     name = "envoy_quic_server_stream_test",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_server_stream_test.cc"],
-    }),
+    srcs = envoy_select_enable_http3(["envoy_quic_server_stream_test.cc"]),
     rbe_pool = "6gig",
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":test_utils_lib",
-            "//source/common/http:headers_lib",
-            "//source/common/quic:envoy_quic_alarm_factory_lib",
-            "//source/common/quic:envoy_quic_connection_helper_lib",
-            "//source/common/quic:envoy_quic_server_connection_lib",
-            "//source/common/quic:envoy_quic_server_session_lib",
-            "//source/server:active_listener_base",
-            "//test/mocks/http:http_mocks",
-            "//test/mocks/http:stream_decoder_mock",
-            "//test/mocks/network:network_mocks",
-            "//test/test_common:utility_lib",
-            "@com_github_google_quiche//:quic_core_http_spdy_session_lib",
-            "@com_github_google_quiche//:quic_test_tools_qpack_qpack_test_utils_lib",
-            "@com_github_google_quiche//:quic_test_tools_session_peer_lib",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        ":test_utils_lib",
+        "//source/common/http:headers_lib",
+        "//source/common/quic:envoy_quic_alarm_factory_lib",
+        "//source/common/quic:envoy_quic_connection_helper_lib",
+        "//source/common/quic:envoy_quic_server_connection_lib",
+        "//source/common/quic:envoy_quic_server_session_lib",
+        "//source/server:active_listener_base",
+        "//test/mocks/http:http_mocks",
+        "//test/mocks/http:stream_decoder_mock",
+        "//test/mocks/network:network_mocks",
+        "//test/test_common:utility_lib",
+        "@com_github_google_quiche//:quic_core_http_spdy_session_lib",
+        "@com_github_google_quiche//:quic_test_tools_qpack_qpack_test_utils_lib",
+        "@com_github_google_quiche//:quic_test_tools_session_peer_lib",
+    ]),
 )
 
 envoy_cc_test(
     name = "envoy_quic_client_stream_test",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_client_stream_test.cc"],
-    }),
+    srcs = envoy_select_enable_http3(["envoy_quic_client_stream_test.cc"]),
     rbe_pool = "6gig",
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":test_utils_lib",
-            "//source/common/http:headers_lib",
-            "//source/common/quic:envoy_quic_alarm_factory_lib",
-            "//source/common/quic:envoy_quic_client_connection_lib",
-            "//source/common/quic:envoy_quic_client_session_lib",
-            "//source/common/quic:envoy_quic_connection_helper_lib",
-            "//test/mocks/http:http_mocks",
-            "//test/mocks/http:stream_decoder_mock",
-            "//test/mocks/network:network_mocks",
-            "//test/test_common:utility_lib",
-            "@com_github_google_quiche//:quic_core_http_spdy_session_lib",
-            "@com_github_google_quiche//:quic_test_tools_qpack_qpack_test_utils_lib",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        ":test_utils_lib",
+        "//source/common/http:headers_lib",
+        "//source/common/quic:envoy_quic_alarm_factory_lib",
+        "//source/common/quic:envoy_quic_client_connection_lib",
+        "//source/common/quic:envoy_quic_client_session_lib",
+        "//source/common/quic:envoy_quic_connection_helper_lib",
+        "//test/mocks/http:http_mocks",
+        "//test/mocks/http:stream_decoder_mock",
+        "//test/mocks/network:network_mocks",
+        "//test/test_common:utility_lib",
+        "@com_github_google_quiche//:quic_core_http_spdy_session_lib",
+        "@com_github_google_quiche//:quic_test_tools_qpack_qpack_test_utils_lib",
+    ]),
 )
 
 envoy_cc_test(
     name = "envoy_quic_server_session_test",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_server_session_test.cc"],
-    }),
+    srcs = envoy_select_enable_http3(["envoy_quic_server_session_test.cc"]),
     rbe_pool = "6gig",
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":test_proof_source_lib",
-            ":test_utils_lib",
-            "//envoy/stats:stats_macros",
-            "//source/common/quic:envoy_quic_alarm_factory_lib",
-            "//source/common/quic:envoy_quic_connection_helper_lib",
-            "//source/common/quic:envoy_quic_server_connection_lib",
-            "//source/common/quic:envoy_quic_server_session_lib",
-            "//source/common/quic:server_codec_lib",
-            "//source/server:configuration_lib",
-            "//test/mocks/event:event_mocks",
-            "//test/mocks/http:http_mocks",
-            "//test/mocks/http:stream_decoder_mock",
-            "//test/mocks/network:network_mocks",
-            "//test/mocks/stats:stats_mocks",
-            "//test/test_common:global_lib",
-            "//test/test_common:logging_lib",
-            "//test/test_common:simulated_time_system_lib",
-            "@com_github_google_quiche//:quic_test_tools_config_peer_lib",
-            "@com_github_google_quiche//:quic_test_tools_server_session_base_peer",
-            "@com_github_google_quiche//:quic_test_tools_test_utils_lib",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        ":test_proof_source_lib",
+        ":test_utils_lib",
+        "//envoy/stats:stats_macros",
+        "//source/common/quic:envoy_quic_alarm_factory_lib",
+        "//source/common/quic:envoy_quic_connection_helper_lib",
+        "//source/common/quic:envoy_quic_server_connection_lib",
+        "//source/common/quic:envoy_quic_server_session_lib",
+        "//source/common/quic:server_codec_lib",
+        "//source/server:configuration_lib",
+        "//test/mocks/event:event_mocks",
+        "//test/mocks/http:http_mocks",
+        "//test/mocks/http:stream_decoder_mock",
+        "//test/mocks/network:network_mocks",
+        "//test/mocks/stats:stats_mocks",
+        "//test/test_common:global_lib",
+        "//test/test_common:logging_lib",
+        "//test/test_common:simulated_time_system_lib",
+        "@com_github_google_quiche//:quic_test_tools_config_peer_lib",
+        "@com_github_google_quiche//:quic_test_tools_server_session_base_peer",
+        "@com_github_google_quiche//:quic_test_tools_test_utils_lib",
+    ]),
 )
 
 envoy_cc_test(
     name = "envoy_quic_client_session_test",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_client_session_test.cc"],
-    }),
+    srcs = envoy_select_enable_http3(["envoy_quic_client_session_test.cc"]),
     rbe_pool = "6gig",
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":test_utils_lib",
-            "//envoy/stats:stats_macros",
-            "//source/common/api:os_sys_calls_lib",
-            "//source/common/quic:client_codec_lib",
-            "//source/common/quic:envoy_quic_alarm_factory_lib",
-            "//source/common/quic:envoy_quic_client_connection_lib",
-            "//source/common/quic:envoy_quic_client_session_lib",
-            "//source/common/quic:envoy_quic_connection_helper_lib",
-            "//source/extensions/quic/crypto_stream:envoy_quic_crypto_client_stream_lib",
-            "//test/mocks/api:api_mocks",
-            "//test/mocks/http:http_mocks",
-            "//test/mocks/http:stream_decoder_mock",
-            "//test/mocks/network:network_mocks",
-            "//test/mocks/stats:stats_mocks",
-            "//test/test_common:logging_lib",
-            "//test/test_common:simulated_time_system_lib",
-            "//test/test_common:test_runtime_lib",
-            "//test/test_common:threadsafe_singleton_injector_lib",
-            "@com_github_google_quiche//:quic_test_tools_session_peer_lib",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        ":test_utils_lib",
+        "//envoy/stats:stats_macros",
+        "//source/common/api:os_sys_calls_lib",
+        "//source/common/quic:client_codec_lib",
+        "//source/common/quic:envoy_quic_alarm_factory_lib",
+        "//source/common/quic:envoy_quic_client_connection_lib",
+        "//source/common/quic:envoy_quic_client_session_lib",
+        "//source/common/quic:envoy_quic_connection_helper_lib",
+        "//source/extensions/quic/crypto_stream:envoy_quic_crypto_client_stream_lib",
+        "//test/mocks/api:api_mocks",
+        "//test/mocks/http:http_mocks",
+        "//test/mocks/http:stream_decoder_mock",
+        "//test/mocks/network:network_mocks",
+        "//test/mocks/stats:stats_mocks",
+        "//test/test_common:logging_lib",
+        "//test/test_common:simulated_time_system_lib",
+        "//test/test_common:test_runtime_lib",
+        "//test/test_common:threadsafe_singleton_injector_lib",
+        "@com_github_google_quiche//:quic_test_tools_session_peer_lib",
+    ]),
 )
 
 envoy_cc_test(
     name = "active_quic_listener_test",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["active_quic_listener_test.cc"],
-    }),
+    srcs = envoy_select_enable_http3(["active_quic_listener_test.cc"]),
     rbe_pool = "6gig",
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":test_proof_source_lib",
-            ":test_utils_lib",
-            "//source/common/http:utility_lib",
-            "//source/common/listener_manager:connection_handler_lib",
-            "//source/common/network:udp_packet_writer_handler_lib",
-            "//source/common/quic:active_quic_listener_lib",
-            "//source/common/quic:envoy_quic_utils_lib",
-            "//source/common/quic:udp_gso_batch_writer_lib",
-            "//source/extensions/quic/crypto_stream:envoy_quic_crypto_server_stream_lib",
-            "//source/extensions/quic/proof_source:envoy_quic_proof_source_factory_impl_lib",
-            "//source/server:configuration_lib",
-            "//source/server:process_context_lib",
-            "//test/mocks/network:network_mocks",
-            "//test/mocks/server:instance_mocks",
-            "//test/mocks/server:listener_factory_context_mocks",
-            "//test/test_common:network_utility_lib",
-            "//test/test_common:simulated_time_system_lib",
-            "//test/test_common:test_runtime_lib",
-            "@com_github_google_quiche//:quic_test_tools_crypto_server_config_peer_lib",
-            "@envoy_api//envoy/config/listener/v3:pkg_cc_proto",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        ":test_proof_source_lib",
+        ":test_utils_lib",
+        "//source/common/http:utility_lib",
+        "//source/common/listener_manager:connection_handler_lib",
+        "//source/common/network:udp_packet_writer_handler_lib",
+        "//source/common/quic:active_quic_listener_lib",
+        "//source/common/quic:envoy_quic_utils_lib",
+        "//source/common/quic:udp_gso_batch_writer_lib",
+        "//source/extensions/quic/crypto_stream:envoy_quic_crypto_server_stream_lib",
+        "//source/extensions/quic/proof_source:envoy_quic_proof_source_factory_impl_lib",
+        "//source/server:configuration_lib",
+        "//source/server:process_context_lib",
+        "//test/mocks/network:network_mocks",
+        "//test/mocks/server:instance_mocks",
+        "//test/mocks/server:listener_factory_context_mocks",
+        "//test/test_common:network_utility_lib",
+        "//test/test_common:simulated_time_system_lib",
+        "//test/test_common:test_runtime_lib",
+        "@com_github_google_quiche//:quic_test_tools_crypto_server_config_peer_lib",
+        "@envoy_api//envoy/config/listener/v3:pkg_cc_proto",
+    ]),
 )
 
 envoy_cc_test(
     name = "envoy_quic_dispatcher_test",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_dispatcher_test.cc"],
-    }),
+    srcs = envoy_select_enable_http3(["envoy_quic_dispatcher_test.cc"]),
     rbe_pool = "6gig",
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":test_proof_source_lib",
-            ":test_utils_lib",
-            "//envoy/stats:stats_macros",
-            "//source/common/listener_manager:connection_handler_lib",
-            "//source/common/quic:envoy_quic_alarm_factory_lib",
-            "//source/common/quic:envoy_quic_connection_helper_lib",
-            "//source/common/quic:envoy_quic_dispatcher_lib",
-            "//source/common/quic:envoy_quic_proof_source_lib",
-            "//source/common/quic:envoy_quic_server_session_lib",
-            "//source/common/quic:quic_server_transport_socket_factory_lib",
-            "//source/extensions/quic/crypto_stream:envoy_quic_crypto_server_stream_lib",
-            "//source/server:configuration_lib",
-            "//test/mocks/event:event_mocks",
-            "//test/mocks/http:http_mocks",
-            "//test/mocks/network:network_mocks",
-            "//test/mocks/ssl:ssl_mocks",
-            "//test/mocks/stats:stats_mocks",
-            "//test/test_common:global_lib",
-            "//test/test_common:simulated_time_system_lib",
-            "//test/test_common:test_runtime_lib",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        ":test_proof_source_lib",
+        ":test_utils_lib",
+        "//envoy/stats:stats_macros",
+        "//source/common/listener_manager:connection_handler_lib",
+        "//source/common/quic:envoy_quic_alarm_factory_lib",
+        "//source/common/quic:envoy_quic_connection_helper_lib",
+        "//source/common/quic:envoy_quic_dispatcher_lib",
+        "//source/common/quic:envoy_quic_proof_source_lib",
+        "//source/common/quic:envoy_quic_server_session_lib",
+        "//source/common/quic:quic_server_transport_socket_factory_lib",
+        "//source/extensions/quic/crypto_stream:envoy_quic_crypto_server_stream_lib",
+        "//source/server:configuration_lib",
+        "//test/mocks/event:event_mocks",
+        "//test/mocks/http:http_mocks",
+        "//test/mocks/network:network_mocks",
+        "//test/mocks/ssl:ssl_mocks",
+        "//test/mocks/stats:stats_mocks",
+        "//test/test_common:global_lib",
+        "//test/test_common:simulated_time_system_lib",
+        "//test/test_common:test_runtime_lib",
+    ]),
 )
 
 envoy_cc_test_library(
     name = "test_proof_source_lib",
-    hdrs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["test_proof_source.h"],
-    }),
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//source/common/quic:envoy_quic_proof_source_base_lib",
-            "//test/mocks/network:network_mocks",
-            "@com_github_google_quiche//:quic_test_tools_test_certificates_lib",
-        ],
-    }),
+    hdrs = envoy_select_enable_http3(["test_proof_source.h"]),
+    deps = envoy_select_enable_http3([
+        "//source/common/quic:envoy_quic_proof_source_base_lib",
+        "//test/mocks/network:network_mocks",
+        "@com_github_google_quiche//:quic_test_tools_test_certificates_lib",
+    ]),
 )
 
 envoy_cc_test_library(
@@ -373,83 +289,59 @@ envoy_cc_test_library(
 
 envoy_cc_test(
     name = "client_connection_factory_impl_test",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["client_connection_factory_impl_test.cc"],
-    }),
+    srcs = envoy_select_enable_http3(["client_connection_factory_impl_test.cc"]),
     rbe_pool = "6gig",
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//source/common/event:dispatcher_lib",
-            "//source/common/http/http3:conn_pool_lib",
-            "//source/common/network:utility_lib",
-            "//source/common/upstream:upstream_includes",
-            "//source/common/upstream:upstream_lib",
-            "//test/common/http:common_lib",
-            "//test/common/upstream:utility_lib",
-            "//test/mocks/event:event_mocks",
-            "//test/mocks/http:http_mocks",
-            "//test/mocks/http:http_server_properties_cache_mocks",
-            "//test/mocks/network:network_mocks",
-            "//test/mocks/runtime:runtime_mocks",
-            "//test/mocks/server:factory_context_mocks",
-            "//test/mocks/upstream:cluster_info_mocks",
-            "//test/mocks/upstream:transport_socket_match_mocks",
-            "//test/test_common:test_runtime_lib",
-            "//test/test_common:threadsafe_singleton_injector_lib",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        "//source/common/event:dispatcher_lib",
+        "//source/common/http/http3:conn_pool_lib",
+        "//source/common/network:utility_lib",
+        "//source/common/upstream:upstream_includes",
+        "//source/common/upstream:upstream_lib",
+        "//test/common/http:common_lib",
+        "//test/common/upstream:utility_lib",
+        "//test/mocks/event:event_mocks",
+        "//test/mocks/http:http_mocks",
+        "//test/mocks/http:http_server_properties_cache_mocks",
+        "//test/mocks/network:network_mocks",
+        "//test/mocks/runtime:runtime_mocks",
+        "//test/mocks/server:factory_context_mocks",
+        "//test/mocks/upstream:cluster_info_mocks",
+        "//test/mocks/upstream:transport_socket_match_mocks",
+        "//test/test_common:test_runtime_lib",
+        "//test/test_common:threadsafe_singleton_injector_lib",
+    ]),
 )
 
 envoy_cc_test(
     name = "quic_io_handle_wrapper_test",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["quic_io_handle_wrapper_test.cc"],
-    }),
+    srcs = envoy_select_enable_http3(["quic_io_handle_wrapper_test.cc"]),
     rbe_pool = "6gig",
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//source/common/quic:quic_io_handle_wrapper_lib",
-            "//test/mocks/api:api_mocks",
-            "//test/mocks/network:io_handle_mocks",
-            "//test/mocks/network:network_mocks",
-            "//test/test_common:threadsafe_singleton_injector_lib",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        "//source/common/quic:quic_io_handle_wrapper_lib",
+        "//test/mocks/api:api_mocks",
+        "//test/mocks/network:io_handle_mocks",
+        "//test/mocks/network:network_mocks",
+        "//test/test_common:threadsafe_singleton_injector_lib",
+    ]),
 )
 
 envoy_cc_test(
     name = "envoy_quic_utils_test",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_utils_test.cc"],
-    }),
+    srcs = envoy_select_enable_http3(["envoy_quic_utils_test.cc"]),
     rbe_pool = "6gig",
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//source/common/quic:envoy_quic_utils_lib",
-            "//test/mocks/api:api_mocks",
-            "//test/test_common:threadsafe_singleton_injector_lib",
-            "@com_github_google_quiche//:quic_test_tools_test_utils_lib",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        "//source/common/quic:envoy_quic_utils_lib",
+        "//test/mocks/api:api_mocks",
+        "//test/test_common:threadsafe_singleton_injector_lib",
+        "@com_github_google_quiche//:quic_test_tools_test_utils_lib",
+    ]),
 )
 
 envoy_cc_test(
     name = "envoy_quic_simulated_watermark_buffer_test",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_quic_simulated_watermark_buffer_test.cc"],
-    }),
+    srcs = envoy_select_enable_http3(["envoy_quic_simulated_watermark_buffer_test.cc"]),
     rbe_pool = "6gig",
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["//source/common/quic:envoy_quic_simulated_watermark_buffer_lib"],
-    }),
+    deps = envoy_select_enable_http3(["//source/common/quic:envoy_quic_simulated_watermark_buffer_lib"]),
 )
 
 envoy_cc_test_library(
@@ -475,59 +367,41 @@ envoy_cc_test_library(
 
 envoy_cc_test(
     name = "quic_transport_socket_factory_test",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["quic_transport_socket_factory_test.cc"],
-    }),
+    srcs = envoy_select_enable_http3(["quic_transport_socket_factory_test.cc"]),
     data = [
         "//test/common/tls/test_data:certs",
     ],
     rbe_pool = "6gig",
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//source/common/quic:quic_server_transport_socket_factory_lib",
-            "//source/common/quic:quic_transport_socket_factory_lib",
-            "//source/common/tls:context_config_lib",
-            "//test/mocks/server:factory_context_mocks",
-            "//test/mocks/ssl:ssl_mocks",
-            "//test/test_common:environment_lib",
-            "//test/test_common:utility_lib",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        "//source/common/quic:quic_server_transport_socket_factory_lib",
+        "//source/common/quic:quic_transport_socket_factory_lib",
+        "//source/common/tls:context_config_lib",
+        "//test/mocks/server:factory_context_mocks",
+        "//test/mocks/ssl:ssl_mocks",
+        "//test/test_common:environment_lib",
+        "//test/test_common:utility_lib",
+    ]),
 )
 
 envoy_cc_test(
     name = "http_datagram_handler_test",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["http_datagram_handler_test.cc"],
-    }),
+    srcs = envoy_select_enable_http3(["http_datagram_handler_test.cc"]),
     rbe_pool = "6gig",
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//source/common/quic:http_datagram_handler",
-            "//test/mocks/buffer:buffer_mocks",
-            "//test/test_common:utility_lib",
-            "@com_github_google_quiche//:quic_test_tools_test_utils_lib",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        "//source/common/quic:http_datagram_handler",
+        "//test/mocks/buffer:buffer_mocks",
+        "//test/test_common:utility_lib",
+        "@com_github_google_quiche//:quic_test_tools_test_utils_lib",
+    ]),
 )
 
 envoy_cc_test(
     name = "cert_compression_test",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["cert_compression_test.cc"],
-    }),
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//source/common/quic:cert_compression_lib",
-            "//test/test_common:logging_lib",
-        ],
-    }),
+    srcs = envoy_select_enable_http3(["cert_compression_test.cc"]),
+    deps = envoy_select_enable_http3([
+        "//source/common/quic:cert_compression_lib",
+        "//test/test_common:logging_lib",
+    ]),
 )
 
 envoy_cc_test_library(
@@ -538,19 +412,13 @@ envoy_cc_test_library(
 
 envoy_cc_test(
     name = "envoy_deterministic_connection_id_generator_test",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["envoy_deterministic_connection_id_generator_test.cc"],
-    }),
+    srcs = envoy_select_enable_http3(["envoy_deterministic_connection_id_generator_test.cc"]),
     rbe_pool = "6gig",
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            ":connection_id_matchers",
-            "//source/common/quic:envoy_deterministic_connection_id_generator_lib",
-            "@com_github_google_quiche//:quic_test_tools_test_utils_lib",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        ":connection_id_matchers",
+        "//source/common/quic:envoy_deterministic_connection_id_generator_lib",
+        "@com_github_google_quiche//:quic_test_tools_test_utils_lib",
+    ]),
 )
 
 envoy_proto_library(

--- a/test/common/quic/platform/BUILD
+++ b/test/common/quic/platform/BUILD
@@ -24,7 +24,6 @@ envoy_cc_test(
     }),
     data = ["//test/common/tls/test_data:certs"],
     rbe_pool = "6gig",
-    tags = ["nofips"],
     deps = [
         "//source/common/memory:stats_lib",
         "//source/common/quic/platform:quiche_flags_impl_lib",
@@ -50,7 +49,6 @@ envoy_cc_test(
 envoy_quiche_platform_impl_cc_test_library(
     name = "quiche_expect_bug_impl_lib",
     hdrs = ["quiche_expect_bug_impl.h"],
-    tags = ["nofips"],
     deps = [
         "@com_github_google_quiche//:quic_platform_base",
     ],
@@ -59,7 +57,6 @@ envoy_quiche_platform_impl_cc_test_library(
 envoy_quiche_platform_impl_cc_test_library(
     name = "quiche_thread_impl_lib",
     hdrs = ["quiche_thread_impl.h"],
-    tags = ["nofips"],
     deps = [
         "//envoy/thread:thread_interface",
         "//source/common/common:assert_lib",
@@ -71,7 +68,6 @@ envoy_quiche_platform_impl_cc_test_library(
     name = "quiche_test_output_impl_lib",
     srcs = ["quiche_test_output_impl.cc"],
     hdrs = ["quiche_test_output_impl.h"],
-    tags = ["nofips"],
     deps = [
         "//test/test_common:file_system_for_test_lib",
         "@com_github_google_quiche//:quic_platform_base",

--- a/test/extensions/quic/connection_debug_visitor/quic_stats/BUILD
+++ b/test/extensions/quic/connection_debug_visitor/quic_stats/BUILD
@@ -13,26 +13,36 @@ envoy_package()
 
 envoy_extension_cc_test(
     name = "quic_stats_test",
-    srcs = ["quic_stats_test.cc"],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["quic_stats_test.cc"],
+    }),
     extension_names = ["envoy.quic.connection_debug_visitor.quic_stats"],
-    tags = ["nofips"],
-    deps = [
-        "//source/extensions/quic/connection_debug_visitor/quic_stats:quic_stats_lib",
-        "//test/mocks/event:event_mocks",
-    ],
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//source/extensions/quic/connection_debug_visitor/quic_stats:quic_stats_lib",
+            "//test/mocks/event:event_mocks",
+        ],
+    }),
 )
 
 envoy_extension_cc_test(
     name = "integration_test",
     size = "large",
-    srcs = ["integration_test.cc"],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["integration_test.cc"],
+    }),
     extension_names = ["envoy.quic.connection_debug_visitor.quic_stats"],
     rbe_pool = "2core",
-    tags = ["nofips"],
-    deps = [
-        "//source/extensions/quic/connection_debug_visitor/quic_stats:config",
-        "//test/integration:http_integration_lib",
-        "@envoy_api//envoy/extensions/quic/connection_debug_visitor/quic_stats/v3:pkg_cc_proto",
-        "@envoy_api//envoy/extensions/transport_sockets/quic/v3:pkg_cc_proto",
-    ],
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//source/extensions/quic/connection_debug_visitor/quic_stats:config",
+            "//test/integration:http_integration_lib",
+            "@envoy_api//envoy/extensions/quic/connection_debug_visitor/quic_stats/v3:pkg_cc_proto",
+            "@envoy_api//envoy/extensions/transport_sockets/quic/v3:pkg_cc_proto",
+        ],
+    }),
 )

--- a/test/extensions/quic/connection_debug_visitor/quic_stats/BUILD
+++ b/test/extensions/quic/connection_debug_visitor/quic_stats/BUILD
@@ -1,6 +1,7 @@
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_package",
+    "envoy_select_enable_http3",
 )
 load(
     "//test/extensions:extensions_build_system.bzl",
@@ -13,36 +14,24 @@ envoy_package()
 
 envoy_extension_cc_test(
     name = "quic_stats_test",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["quic_stats_test.cc"],
-    }),
+    srcs = envoy_select_enable_http3(["quic_stats_test.cc"]),
     extension_names = ["envoy.quic.connection_debug_visitor.quic_stats"],
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//source/extensions/quic/connection_debug_visitor/quic_stats:quic_stats_lib",
-            "//test/mocks/event:event_mocks",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        "//source/extensions/quic/connection_debug_visitor/quic_stats:quic_stats_lib",
+        "//test/mocks/event:event_mocks",
+    ]),
 )
 
 envoy_extension_cc_test(
     name = "integration_test",
     size = "large",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["integration_test.cc"],
-    }),
+    srcs = envoy_select_enable_http3(["integration_test.cc"]),
     extension_names = ["envoy.quic.connection_debug_visitor.quic_stats"],
     rbe_pool = "2core",
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//source/extensions/quic/connection_debug_visitor/quic_stats:config",
-            "//test/integration:http_integration_lib",
-            "@envoy_api//envoy/extensions/quic/connection_debug_visitor/quic_stats/v3:pkg_cc_proto",
-            "@envoy_api//envoy/extensions/transport_sockets/quic/v3:pkg_cc_proto",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        "//source/extensions/quic/connection_debug_visitor/quic_stats:config",
+        "//test/integration:http_integration_lib",
+        "@envoy_api//envoy/extensions/quic/connection_debug_visitor/quic_stats/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/transport_sockets/quic/v3:pkg_cc_proto",
+    ]),
 )

--- a/test/extensions/quic/connection_id_generator/quic_lb/BUILD
+++ b/test/extensions/quic/connection_id_generator/quic_lb/BUILD
@@ -13,29 +13,39 @@ envoy_package()
 
 envoy_extension_cc_test(
     name = "quic_lb_test",
-    srcs = ["quic_lb_test.cc"],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["quic_lb_test.cc"],
+    }),
     extension_names = ["envoy.quic.connection_id_generator.quic_lb"],
     rbe_pool = "6gig",
-    tags = ["nofips"],
-    deps = [
-        "//source/extensions/quic/connection_id_generator/quic_lb:quic_lb_lib",
-        "//test/mocks/server:factory_context_mocks",
-        "@com_github_google_quiche//:quic_test_tools_test_utils_lib",
-    ],
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//source/extensions/quic/connection_id_generator/quic_lb:quic_lb_lib",
+            "//test/mocks/server:factory_context_mocks",
+            "@com_github_google_quiche//:quic_test_tools_test_utils_lib",
+        ],
+    }),
 )
 
 envoy_extension_cc_test(
     name = "integration_test",
     size = "large",
-    srcs = ["integration_test.cc"],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["integration_test.cc"],
+    }),
     extension_names = ["envoy.quic.connection_id_generator.quic_lb"],
     rbe_pool = "4core",
-    tags = ["nofips"],
-    deps = [
-        "//source/extensions/quic/connection_id_generator/quic_lb:quic_lb_config",
-        "//test/integration:http_integration_lib",
-        "//test/integration:quic_http_integration_test_lib",
-        "@envoy_api//envoy/extensions/quic/connection_id_generator/quic_lb/v3:pkg_cc_proto",
-        "@envoy_api//envoy/extensions/transport_sockets/quic/v3:pkg_cc_proto",
-    ],
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//source/extensions/quic/connection_id_generator/quic_lb:quic_lb_config",
+            "//test/integration:http_integration_lib",
+            "//test/integration:quic_http_integration_test_lib",
+            "@envoy_api//envoy/extensions/quic/connection_id_generator/quic_lb/v3:pkg_cc_proto",
+            "@envoy_api//envoy/extensions/transport_sockets/quic/v3:pkg_cc_proto",
+        ],
+    }),
 )

--- a/test/extensions/quic/connection_id_generator/quic_lb/BUILD
+++ b/test/extensions/quic/connection_id_generator/quic_lb/BUILD
@@ -1,6 +1,7 @@
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_package",
+    "envoy_select_enable_http3",
 )
 load(
     "//test/extensions:extensions_build_system.bzl",
@@ -13,39 +14,27 @@ envoy_package()
 
 envoy_extension_cc_test(
     name = "quic_lb_test",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["quic_lb_test.cc"],
-    }),
+    srcs = envoy_select_enable_http3(["quic_lb_test.cc"]),
     extension_names = ["envoy.quic.connection_id_generator.quic_lb"],
     rbe_pool = "6gig",
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//source/extensions/quic/connection_id_generator/quic_lb:quic_lb_lib",
-            "//test/mocks/server:factory_context_mocks",
-            "@com_github_google_quiche//:quic_test_tools_test_utils_lib",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        "//source/extensions/quic/connection_id_generator/quic_lb:quic_lb_lib",
+        "//test/mocks/server:factory_context_mocks",
+        "@com_github_google_quiche//:quic_test_tools_test_utils_lib",
+    ]),
 )
 
 envoy_extension_cc_test(
     name = "integration_test",
     size = "large",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["integration_test.cc"],
-    }),
+    srcs = envoy_select_enable_http3(["integration_test.cc"]),
     extension_names = ["envoy.quic.connection_id_generator.quic_lb"],
     rbe_pool = "4core",
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//source/extensions/quic/connection_id_generator/quic_lb:quic_lb_config",
-            "//test/integration:http_integration_lib",
-            "//test/integration:quic_http_integration_test_lib",
-            "@envoy_api//envoy/extensions/quic/connection_id_generator/quic_lb/v3:pkg_cc_proto",
-            "@envoy_api//envoy/extensions/transport_sockets/quic/v3:pkg_cc_proto",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        "//source/extensions/quic/connection_id_generator/quic_lb:quic_lb_config",
+        "//test/integration:http_integration_lib",
+        "//test/integration:quic_http_integration_test_lib",
+        "@envoy_api//envoy/extensions/quic/connection_id_generator/quic_lb/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/transport_sockets/quic/v3:pkg_cc_proto",
+    ]),
 )

--- a/test/extensions/quic/proof_source/BUILD
+++ b/test/extensions/quic/proof_source/BUILD
@@ -12,7 +12,6 @@ envoy_cc_test_library(
     name = "pending_proof_source_factory_impl_lib",
     srcs = ["pending_proof_source_factory_impl.cc"],
     hdrs = ["pending_proof_source_factory_impl.h"],
-    tags = ["nofips"],
     deps = [
         "//envoy/registry",
         "//source/common/quic:envoy_quic_proof_source_factory_interface",

--- a/test/extensions/quic/server_preferred_address/BUILD
+++ b/test/extensions/quic/server_preferred_address/BUILD
@@ -1,6 +1,7 @@
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_package",
+    "envoy_select_enable_http3",
 )
 load(
     "//test/extensions:extensions_build_system.bzl",
@@ -13,36 +14,24 @@ envoy_package()
 
 envoy_extension_cc_test(
     name = "datasource_server_preferred_address_test",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["datasource_server_preferred_address_test.cc"],
-    }),
+    srcs = envoy_select_enable_http3(["datasource_server_preferred_address_test.cc"]),
     extension_names = ["envoy.quic.server_preferred_address.datasource"],
     rbe_pool = "6gig",
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//source/extensions/quic/server_preferred_address:datasource_server_preferred_address_config_lib",
-            "//test/mocks/protobuf:protobuf_mocks",
-            "//test/mocks/server:server_factory_context_mocks",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        "//source/extensions/quic/server_preferred_address:datasource_server_preferred_address_config_lib",
+        "//test/mocks/protobuf:protobuf_mocks",
+        "//test/mocks/server:server_factory_context_mocks",
+    ]),
 )
 
 envoy_extension_cc_test(
     name = "fixed_server_preferred_address_test",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": ["fixed_server_preferred_address_test.cc"],
-    }),
+    srcs = envoy_select_enable_http3(["fixed_server_preferred_address_test.cc"]),
     extension_names = ["envoy.quic.server_preferred_address.fixed"],
     rbe_pool = "6gig",
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//source/extensions/quic/server_preferred_address:fixed_server_preferred_address_config_lib",
-            "//test/mocks/protobuf:protobuf_mocks",
-            "//test/mocks/server:server_factory_context_mocks",
-        ],
-    }),
+    deps = envoy_select_enable_http3([
+        "//source/extensions/quic/server_preferred_address:fixed_server_preferred_address_config_lib",
+        "//test/mocks/protobuf:protobuf_mocks",
+        "//test/mocks/server:server_factory_context_mocks",
+    ]),
 )

--- a/test/extensions/quic/server_preferred_address/BUILD
+++ b/test/extensions/quic/server_preferred_address/BUILD
@@ -13,26 +13,36 @@ envoy_package()
 
 envoy_extension_cc_test(
     name = "datasource_server_preferred_address_test",
-    srcs = ["datasource_server_preferred_address_test.cc"],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["datasource_server_preferred_address_test.cc"],
+    }),
     extension_names = ["envoy.quic.server_preferred_address.datasource"],
     rbe_pool = "6gig",
-    tags = ["nofips"],
-    deps = [
-        "//source/extensions/quic/server_preferred_address:datasource_server_preferred_address_config_lib",
-        "//test/mocks/protobuf:protobuf_mocks",
-        "//test/mocks/server:server_factory_context_mocks",
-    ],
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//source/extensions/quic/server_preferred_address:datasource_server_preferred_address_config_lib",
+            "//test/mocks/protobuf:protobuf_mocks",
+            "//test/mocks/server:server_factory_context_mocks",
+        ],
+    }),
 )
 
 envoy_extension_cc_test(
     name = "fixed_server_preferred_address_test",
-    srcs = ["fixed_server_preferred_address_test.cc"],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["fixed_server_preferred_address_test.cc"],
+    }),
     extension_names = ["envoy.quic.server_preferred_address.fixed"],
     rbe_pool = "6gig",
-    tags = ["nofips"],
-    deps = [
-        "//source/extensions/quic/server_preferred_address:fixed_server_preferred_address_config_lib",
-        "//test/mocks/protobuf:protobuf_mocks",
-        "//test/mocks/server:server_factory_context_mocks",
-    ],
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//source/extensions/quic/server_preferred_address:fixed_server_preferred_address_config_lib",
+            "//test/mocks/protobuf:protobuf_mocks",
+            "//test/mocks/server:server_factory_context_mocks",
+        ],
+    }),
 )

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -1492,12 +1492,9 @@ envoy_cc_test(
         "//test/test_common:utility_lib",
         "@envoy_api//envoy/config/route/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/filters/network/http_connection_manager/v3:pkg_cc_proto",
-    ] + select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//test/integration/filters:pause_filter_for_quic_lib",
-        ],
-    }),
+    ] + envoy_select_enable_http3([
+        "//test/integration/filters:pause_filter_for_quic_lib",
+    ]),
 )
 
 envoy_cc_test(

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -1485,16 +1485,19 @@ envoy_cc_test(
     shard_count = 2,
     tags = [
         "cpu:3",
-        "nofips",
     ],
     deps = [
         ":http_protocol_integration_lib",
         "//source/common/http:header_map_lib",
-        "//test/integration/filters:pause_filter_for_quic_lib",
         "//test/test_common:utility_lib",
         "@envoy_api//envoy/config/route/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/filters/network/http_connection_manager/v3:pkg_cc_proto",
-    ],
+    ] + select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//test/integration/filters:pause_filter_for_quic_lib",
+        ],
+    }),
 )
 
 envoy_cc_test(
@@ -2556,7 +2559,6 @@ envoy_cc_test(
     shard_count = 16,
     tags = [
         "cpu:4",
-        "nofips",
     ],
     deps = select({
         "//bazel:disable_http3": [],
@@ -2575,10 +2577,10 @@ envoy_cc_test(
 
 envoy_cc_test_library(
     name = "quic_http_integration_test_lib",
-    hdrs = [
+    hdrs = envoy_select_enable_http3([
         "quic_http_integration_test.h",
-    ],
-    deps = [
+    ]),
+    deps = envoy_select_enable_http3([
         ":http_integration_lib",
         ":socket_interface_swap_lib",
         "//source/common/quic:client_connection_factory_lib",
@@ -2604,7 +2606,7 @@ envoy_cc_test_library(
         "@envoy_api//envoy/extensions/quic/connection_debug_visitor/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/quic/server_preferred_address/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/transport_sockets/quic/v3:pkg_cc_proto",
-    ],
+    ]),
 )
 
 # TODO(mattklein123): Use target_compatible_with when we switch to Bazel 4.0 instead of multiple
@@ -2631,7 +2633,6 @@ envoy_cc_test(
         "cpu:3",
         "fails_on_clang_cl",
         "fails_on_windows",
-        "nofips",
     ],
     deps = envoy_select_enable_http3([
         ":quic_http_integration_test_lib",

--- a/test/integration/filters/BUILD
+++ b/test/integration/filters/BUILD
@@ -3,6 +3,7 @@ load(
     "envoy_cc_test_library",
     "envoy_package",
     "envoy_proto_library",
+    "envoy_select_enable_http3",
 )
 
 licenses(["notice"])  # Apache 2
@@ -469,22 +470,16 @@ envoy_cc_test_library(
 
 envoy_cc_test_library(
     name = "pause_filter_for_quic_lib",
-    srcs = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "pause_filter_for_quic.cc",
-        ],
-    }),
-    deps = select({
-        "//bazel:disable_http3": [],
-        "//conditions:default": [
-            "//envoy/http:filter_interface",
-            "//envoy/registry",
-            "//source/common/quic:quic_filter_manager_connection_lib",
-            "//source/extensions/filters/http/common:pass_through_filter_lib",
-            "//test/extensions/filters/http/common:empty_http_filter_config_lib",
-        ],
-    }),
+    srcs = envoy_select_enable_http3([
+        "pause_filter_for_quic.cc",
+    ]),
+    deps = envoy_select_enable_http3([
+        "//envoy/http:filter_interface",
+        "//envoy/registry",
+        "//source/common/quic:quic_filter_manager_connection_lib",
+        "//source/extensions/filters/http/common:pass_through_filter_lib",
+        "//test/extensions/filters/http/common:empty_http_filter_config_lib",
+    ]),
 )
 
 envoy_cc_test_library(

--- a/test/integration/filters/BUILD
+++ b/test/integration/filters/BUILD
@@ -469,17 +469,22 @@ envoy_cc_test_library(
 
 envoy_cc_test_library(
     name = "pause_filter_for_quic_lib",
-    srcs = [
-        "pause_filter_for_quic.cc",
-    ],
-    tags = ["nofips"],
-    deps = [
-        "//envoy/http:filter_interface",
-        "//envoy/registry",
-        "//source/common/quic:quic_filter_manager_connection_lib",
-        "//source/extensions/filters/http/common:pass_through_filter_lib",
-        "//test/extensions/filters/http/common:empty_http_filter_config_lib",
-    ],
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "pause_filter_for_quic.cc",
+        ],
+    }),
+    deps = select({
+        "//bazel:disable_http3": [],
+        "//conditions:default": [
+            "//envoy/http:filter_interface",
+            "//envoy/registry",
+            "//source/common/quic:quic_filter_manager_connection_lib",
+            "//source/extensions/filters/http/common:pass_through_filter_lib",
+            "//test/extensions/filters/http/common:empty_http_filter_config_lib",
+        ],
+    }),
 )
 
 envoy_cc_test_library(

--- a/test/per_file_coverage.sh
+++ b/test/per_file_coverage.sh
@@ -4,6 +4,7 @@
 # for existing directories with low coverage.
 declare -a KNOWN_LOW_COVERAGE=(
 "source/common:96.4"
+"source/common/common:96.5"
 "source/common/common/posix:96.2" # flaky due to posix: be careful adjusting
 "source/common/config:96.4"
 "source/common/crypto:95.5"
@@ -15,14 +16,14 @@ declare -a KNOWN_LOW_COVERAGE=(
 "source/common/memory:74.5" # tcmalloc code path is not enabled in coverage build, only gperf tcmalloc, see PR#32589
 "source/common/network:94.4" # Flaky, `activateFileEvents`, `startSecureTransport` and `ioctl`, listener_socket do not always report LCOV
 "source/common/network/dns_resolver:91.4"  # A few lines of MacOS code not tested in linux scripts. Tested in MacOS scripts
-"source/common/quic:93.2"
+"source/common/quic:92.9"
 "source/common/signal:87.2" # Death tests don't report LCOV
 "source/common/thread:0.0" # Death tests don't report LCOV
 "source/common/tls:95.5"
 "source/common/tls/cert_validator:94.7"
 "source/common/tls/private_key:88.9"
 "source/common/watchdog:58.6" # Death tests don't report LCOV
-"source/exe:94.2" # increased by #32346, need coverage for terminate_handler and hot restart failures
+"source/exe:87.9" # increased by #32346, need coverage for terminate_handler and hot restart failures
 "source/extensions/common/proxy_protocol:93.8" # Adjusted for security patch
 "source/extensions/common/tap:94.6"
 "source/extensions/common/wasm:95.3" # flaky: be careful adjusting
@@ -40,6 +41,7 @@ declare -a KNOWN_LOW_COVERAGE=(
 "source/extensions/filters/network/sni_cluster:88.9"
 "source/extensions/rate_limit_descriptors:95.0"
 "source/extensions/rate_limit_descriptors/expr:95.0"
+"source/extensions/resource_monitors/cpu_utilization:96.3"
 "source/extensions/stat_sinks/graphite_statsd:82.8" # Death tests don't report LCOV
 "source/extensions/stat_sinks/statsd:85.2" # Death tests don't report LCOV
 "source/extensions/tracers/zipkin:95.8"


### PR DESCRIPTION
## Description

This PR cherry-picks the two commits we checked in the main to enable QUIC for FIPS build and parameterize the classes using QUIC.

**Fixes:** https://github.com/envoyproxy/envoy/issues/39821

--- 

**Commit Message:** quic(backport): re-enable FIPS build and related tests
**Additional Description:** Cherry-pick the two FIPS related commits in v1.34
**Risk Level:** Low
**Testing:** CI
**Docs Changes:** N/A
**Release Notes:** N/A