### PR TITLE
coverage: adjusting coverage for common/network

### DIFF
--- a/test/coverage.yaml
+++ b/test/coverage.yaml
@@ -15,7 +15,7 @@ directories:
   source/common/json: 95.2
   source/common/matcher: 94.7
   source/common/memory: 74.5  # tcmalloc code path is not enabled in coverage build, only gperf tcmalloc, see PR#32589
-  source/common/network: 94.4  # Flaky, `activateFileEvents`, `startSecureTransport` and `ioctl`, listener_socket do not always report LCOV
+  source/common/network: 94.3  # Flaky, `activateFileEvents`, `startSecureTransport` and `ioctl`, listener_socket do not always report LCOV
   source/common/network/dns_resolver: 91.4   # A few lines of MacOS code not tested in linux scripts. Tested in MacOS scripts
   source/common/quic: 93.0
   source/common/signal: 87.2  # Death tests don't report LCOV


### PR DESCRIPTION
## Description

Adjust the coverage numbers for `source/common/network` as it seems to be flaky and failing a few triggers. [See This](https://github.com/envoyproxy/envoy/pull/39829)

---

**Commit Message:** coverage: adjusting coverage for common/network
**Additional Description:** Adjusting the coverage numbers for `source/common/network`
**Risk Level:** Very Low
**Testing:** CI
**Docs Changes:** N/A
**Release Notes:** N/A