### PR TITLE
[bp/1.34] backport: fix: fix a bug where the validate mode may assert failure (#39761)

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -21,6 +21,10 @@ bug_fixes:
     draining. This can result in not enough connections being established for current pending requests. This is most problematic for
     long-lived requests (such as streaming gRPC requests or long-poll requests) because a connection could be in the draining state
     for a long time.
+- area: config_validation
+  change: |
+    Fixed an bug where the config validation server will crash when the configuration contains
+    ``%CEL%`` or ``%METADATA%`` substitution formatter.
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/source/server/config_validation/server.h
+++ b/source/server/config_validation/server.h
@@ -71,6 +71,8 @@ public:
                      Filesystem::Instance& file_system,
                      const ProcessContextOptRef& process_context = absl::nullopt);
 
+  ~ValidationInstance() override;
+
   // Server::Instance
   void run() override { PANIC("not implemented"); }
   OptRef<Admin> admin() override {

--- a/test/config/utility.cc
+++ b/test/config/utility.cc
@@ -672,7 +672,8 @@ envoy::config::listener::v3::Listener ConfigHelper::buildListener(const std::str
 }
 
 envoy::config::route::v3::RouteConfiguration
-ConfigHelper::buildRouteConfig(const std::string& name, const std::string& cluster) {
+ConfigHelper::buildRouteConfig(const std::string& name, const std::string& cluster,
+                               bool header_mutations) {
   API_NO_BOOST(envoy::config::route::v3::RouteConfiguration) route;
 #ifdef ENVOY_ENABLE_YAML
   TestUtility::loadFromYaml(fmt::format(R"EOF(
@@ -686,10 +687,31 @@ ConfigHelper::buildRouteConfig(const std::string& name, const std::string& clust
     )EOF",
                                         name, cluster),
                             route);
+
+  if (header_mutations) {
+    auto* route_entry = route.mutable_virtual_hosts(0)->mutable_routes(0);
+    auto* header1 = route_entry->add_request_headers_to_add();
+    *header1->mutable_header()->mutable_key() = "test-metadata";
+    *header1->mutable_header()->mutable_value() = "%METADATA(ROUTE:com.test.my_filter)%";
+
+    auto* header2 = route_entry->add_response_headers_to_add();
+    *header2->mutable_header()->mutable_key() = "test-cel";
+    *header2->mutable_header()->mutable_value() = "%CEL(request.headers['some-header'])%";
+
+    auto* header3 = route_entry->add_response_headers_to_add();
+    *header3->mutable_header()->mutable_key() = "test-other-command";
+    *header3->mutable_header()->mutable_value() = "%START_TIME%";
+
+    auto* header4 = route_entry->add_response_headers_to_add();
+    *header4->mutable_header()->mutable_key() = "test-plain";
+    *header4->mutable_header()->mutable_value() = "plain";
+  }
+
   return route;
 #else
   UNREFERENCED_PARAMETER(name);
   UNREFERENCED_PARAMETER(cluster);
+  UNREFERENCED_PARAMETER(header_mutations);
   PANIC("YAML support compiled out");
 #endif
 }

--- a/test/config/utility.h
+++ b/test/config/utility.h
@@ -164,8 +164,7 @@ public:
     bool keylog_multiple_ips_{false};
     std::string keylog_path_;
     Network::Address::IpVersion ip_version_{Network::Address::IpVersion::v4};
-    std::vector<envoy::extensions::transport_sockets::tls::v3::SubjectAltNameMatcher>
-        san_matchers_{};
+    std::vector<envoy::extensions::transport_sockets::tls::v3::SubjectAltNameMatcher> san_matchers_;
     std::string tls_cert_selector_yaml_{""};
     bool client_with_intermediate_cert_{false};
     bool trust_root_only_{false};
@@ -280,8 +279,9 @@ public:
                                                              const std::string& address,
                                                              const std::string& stat_prefix);
 
-  static envoy::config::route::v3::RouteConfiguration buildRouteConfig(const std::string& name,
-                                                                       const std::string& cluster);
+  static envoy::config::route::v3::RouteConfiguration
+  buildRouteConfig(const std::string& name, const std::string& cluster,
+                   bool header_mutations = false);
 
   // Builds a standard Endpoint suitable for population by finalize().
   static envoy::config::endpoint::v3::Endpoint buildEndpoint(const std::string& address);

--- a/test/server/config_validation/xds_verifier_test.cc
+++ b/test/server/config_validation/xds_verifier_test.cc
@@ -11,7 +11,7 @@ envoy::config::listener::v3::Listener buildListener(const std::string& listener_
 }
 
 envoy::config::route::v3::RouteConfiguration buildRoute(const std::string& route_name) {
-  return ConfigHelper::buildRouteConfig(route_name, "cluster_0");
+  return ConfigHelper::buildRouteConfig(route_name, "cluster_0", true);
 }
 
 // Add, warm, drain and remove a listener.


### PR DESCRIPTION
Commit Message: fix: fix a bug where the validate mode may assert failure
Additional Description:

This fixed the bug introduced at https://github.com/envoyproxy/envoy/pull/38740 . To close https://github.com/envoyproxy/envoy/issues/39653.

Risk Level: low, config validation code only.
Testing: unit.
Docs Changes: n/a.
Release Notes: added.
Platform Specific Features: n/a.
