### PR TITLE
network_direct_response: allow keeping connection open

### DIFF
--- a/api/envoy/extensions/filters/network/direct_response/v3/config.proto
+++ b/api/envoy/extensions/filters/network/direct_response/v3/config.proto
@@ -23,4 +23,7 @@ message Config {
 
   // Response data as a data source.
   config.core.v3.DataSource response = 1;
+
+  // If true, the filter will not actively close the connection after sending the response.
+  bool keep_open_after_response = 2;
 }

--- a/source/extensions/filters/network/direct_response/BUILD
+++ b/source/extensions/filters/network/direct_response/BUILD
@@ -28,6 +28,10 @@ envoy_cc_library(
 envoy_cc_extension(
     name = "config",
     srcs = ["config.cc"],
+    # The direct response filter can be used in integration tests which don't need an upstream.
+    extra_visibility = [
+        "//test/integration:__subpackages__",
+    ],
     deps = [
         ":filter",
         "//envoy/registry",

--- a/source/extensions/filters/network/direct_response/config.cc
+++ b/source/extensions/filters/network/direct_response/config.cc
@@ -27,13 +27,15 @@ private:
   absl::StatusOr<Network::FilterFactoryCb> createFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::network::direct_response::v3::Config& config,
       Server::Configuration::FactoryContext& context) override {
+    bool keep_open_after_response = config.keep_open_after_response();
     absl::StatusOr<std::string> content_or =
         Config::DataSource::read(config.response(), true, context.serverFactoryContext().api());
     RETURN_IF_NOT_OK_REF(content_or.status());
-    return
-        [content = std::move(content_or.value())](Network::FilterManager& filter_manager) -> void {
-          filter_manager.addReadFilter(std::make_shared<DirectResponseFilter>(content));
-        };
+    return [keep_open_after_response, content = std::move(content_or.value())](
+               Network::FilterManager& filter_manager) -> void {
+      filter_manager.addReadFilter(
+          std::make_shared<DirectResponseFilter>(content, keep_open_after_response));
+    };
   }
 
   bool isTerminalFilterByProtoTyped(

--- a/source/extensions/filters/network/direct_response/filter.cc
+++ b/source/extensions/filters/network/direct_response/filter.cc
@@ -11,14 +11,17 @@ namespace DirectResponse {
 Network::FilterStatus DirectResponseFilter::onNewConnection() {
   auto& connection = read_callbacks_->connection();
   ENVOY_CONN_LOG(trace, "direct_response: new connection", connection);
+  bool close_after_response = !keep_open_after_response_;
   if (!response_.empty()) {
     Buffer::OwnedImpl data(response_);
-    connection.write(data, true);
+    connection.write(data, close_after_response);
     ASSERT(0 == data.length());
   }
   connection.streamInfo().setResponseCodeDetails(
       StreamInfo::ResponseCodeDetails::get().DirectResponse);
-  connection.close(Network::ConnectionCloseType::FlushWrite);
+  if (close_after_response) {
+    connection.close(Network::ConnectionCloseType::FlushWrite);
+  }
   return Network::FilterStatus::StopIteration;
 }
 

--- a/source/extensions/filters/network/direct_response/filter.h
+++ b/source/extensions/filters/network/direct_response/filter.h
@@ -15,10 +15,12 @@ namespace DirectResponse {
  */
 class DirectResponseFilter : public Network::ReadFilter, Logger::Loggable<Logger::Id::filter> {
 public:
-  DirectResponseFilter(const std::string& response) : response_(response) {}
+  DirectResponseFilter(const std::string& response, bool keep_open_after_response)
+      : response_(response), keep_open_after_response_(keep_open_after_response) {}
 
   // Network::ReadFilter
-  Network::FilterStatus onData(Buffer::Instance&, bool) override {
+  Network::FilterStatus onData(Buffer::Instance& data, bool) override {
+    data.drain(data.length());
     return Network::FilterStatus::Continue;
   }
   Network::FilterStatus onNewConnection() override;
@@ -29,6 +31,7 @@ public:
 
 private:
   const std::string response_;
+  const bool keep_open_after_response_;
   Network::ReadFilterCallbacks* read_callbacks_{};
 };
 

--- a/test/extensions/filters/network/direct_response/direct_response_integration_test.cc
+++ b/test/extensions/filters/network/direct_response/direct_response_integration_test.cc
@@ -1,3 +1,5 @@
+#include "envoy/extensions/filters/network/direct_response/v3/config.pb.h"
+
 #include "test/integration/integration.h"
 #include "test/integration/utility.h"
 #include "test/test_common/utility.h"
@@ -7,22 +9,29 @@ namespace Envoy {
 class DirectResponseIntegrationTest : public testing::TestWithParam<Network::Address::IpVersion>,
                                       public BaseIntegrationTest {
 public:
-  DirectResponseIntegrationTest() : BaseIntegrationTest(GetParam(), directResponseConfig()) {}
+  DirectResponseIntegrationTest() : BaseIntegrationTest(GetParam(), ConfigHelper::baseConfig()) {}
 
-  static std::string directResponseConfig() {
-    return absl::StrCat(ConfigHelper::baseConfig(), R"EOF(
-    filter_chains:
-      filters:
-      - name: direct_response
-        typed_config:
-          "@type": type.googleapis.com/envoy.extensions.filters.network.direct_response.v3.Config
-          response:
-            inline_string: "hello, world!\n"
-      )EOF");
-  }
-
-  void SetUp() override {
+  void init(bool keep_open_after_response = false) {
     useListenerAccessLog("%RESPONSE_CODE_DETAILS%");
+
+    const std::string yaml_config = fmt::format(R"EOF(
+        response:
+          inline_string: "hello, world!\n"
+        keep_open_after_response: {0}
+    )EOF",
+                                                keep_open_after_response ? "true" : "false");
+
+    config_helper_.addConfigModifier([&](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
+      envoy::extensions::filters::network::direct_response::v3::Config config;
+      TestUtility::loadFromYaml(yaml_config, config);
+
+      auto* listener = bootstrap.mutable_static_resources()->mutable_listeners(0);
+      auto* filter_chain = listener->add_filter_chains();
+      auto* filter = filter_chain->add_filters();
+      filter->set_name("direct_response");
+      filter->mutable_typed_config()->PackFrom(config);
+    });
+
     BaseIntegrationTest::initialize();
   }
 };
@@ -32,6 +41,8 @@ INSTANTIATE_TEST_SUITE_P(IpVersions, DirectResponseIntegrationTest,
                          TestUtility::ipTestParamsToString);
 
 TEST_P(DirectResponseIntegrationTest, DirectResponseOnConnection) {
+  init();
+
   std::string response;
   // This test becomes flaky (especially on Windows) if the connection is closed by the server
   // before the client finishes transmitting the data it writes (resulting in a connection aborted
@@ -47,6 +58,20 @@ TEST_P(DirectResponseIntegrationTest, DirectResponseOnConnection) {
   EXPECT_EQ("hello, world!\n", response);
   EXPECT_THAT(waitForAccessLog(listener_access_log_name_),
               testing::HasSubstr(StreamInfo::ResponseCodeDetails::get().DirectResponse));
+}
+
+TEST_P(DirectResponseIntegrationTest, DirectResponseKeepOpenOnConnection) {
+  init(true);
+  std::string expected_response = "hello, world!\n";
+
+  IntegrationTcpClientPtr tcp_client = makeTcpConnection(lookupPort("listener_0"));
+  EXPECT_TRUE(tcp_client->write("ping", false));
+  EXPECT_TRUE(tcp_client->waitForData(expected_response.length()));
+  EXPECT_EQ(expected_response, tcp_client->data());
+
+  EXPECT_TRUE(tcp_client->connected());
+  EXPECT_TRUE(tcp_client->write("ping2", false));
+  tcp_client->close();
 }
 
 } // namespace Envoy

--- a/test/extensions/filters/network/direct_response/direct_response_test.cc
+++ b/test/extensions/filters/network/direct_response/direct_response_test.cc
@@ -18,9 +18,9 @@ namespace DirectResponse {
 
 class DirectResponseFilterTest : public testing::Test {
 public:
-  void initialize(const std::string& response) {
+  void initialize(const std::string& response, bool keep_open_after_response = false) {
     EXPECT_CALL(read_filter_callbacks_.connection_, enableHalfClose(true));
-    filter_ = std::make_shared<DirectResponseFilter>(response);
+    filter_ = std::make_shared<DirectResponseFilter>(response, keep_open_after_response);
     filter_->initializeReadFilterCallbacks(read_filter_callbacks_);
   }
   std::shared_ptr<DirectResponseFilter> filter_;
@@ -48,12 +48,40 @@ TEST_F(DirectResponseFilterTest, OnNewConnectionEmptyResponse) {
   EXPECT_EQ(Network::FilterStatus::StopIteration, filter_->onNewConnection());
 }
 
+TEST_F(DirectResponseFilterTest, OnNewConnectionKeepOpen) {
+  initialize("hello", true);
+  Buffer::OwnedImpl response("hello");
+  EXPECT_CALL(read_filter_callbacks_.connection_, write(BufferEqual(&response), false));
+  EXPECT_CALL(read_filter_callbacks_.connection_, close(_)).Times(0);
+  EXPECT_CALL(read_filter_callbacks_.connection_.stream_info_,
+              setResponseCodeDetails(StreamInfo::ResponseCodeDetails::get().DirectResponse));
+  EXPECT_EQ(Network::FilterStatus::StopIteration, filter_->onNewConnection());
+}
+
+TEST_F(DirectResponseFilterTest, OnNewConnectionKeepOpenEmptyResponse) {
+  initialize("", true);
+  EXPECT_CALL(read_filter_callbacks_.connection_, write(_, _)).Times(0);
+  EXPECT_CALL(read_filter_callbacks_.connection_, close(_)).Times(0);
+  EXPECT_CALL(read_filter_callbacks_.connection_.stream_info_,
+              setResponseCodeDetails(StreamInfo::ResponseCodeDetails::get().DirectResponse));
+  EXPECT_EQ(Network::FilterStatus::StopIteration, filter_->onNewConnection());
+}
+
 // Test the filter's onData()
 TEST_F(DirectResponseFilterTest, OnData) {
   initialize("hello");
   Buffer::OwnedImpl data("data");
   EXPECT_CALL(read_filter_callbacks_.connection_, write(_, _)).Times(0);
   EXPECT_EQ(Network::FilterStatus::Continue, filter_->onData(data, false));
+}
+
+TEST_F(DirectResponseFilterTest, OnDataKeepOpen) {
+  initialize("hello", true);
+  Buffer::OwnedImpl data("incoming data");
+
+  // Data should still be drained even when keeping connection open
+  EXPECT_EQ(Network::FilterStatus::Continue, filter_->onData(data, false));
+  EXPECT_EQ(0, data.length());
 }
 
 } // namespace DirectResponse


### PR DESCRIPTION
Additional Description: adding an option to keep connections open after sending direct response from the network direct response filter. Also, allowing this filter to be used in integration tests files as I intend to use it in next PR's integration tests
Risk Level: low
Testing: unit, integration tests
Docs Changes: none
Release Notes: none
Platform Specific Features: none