### PR TITLE
set_filter_state: create IP address object factory

### DIFF
--- a/docs/root/configuration/advanced/well_known_filter_state.rst
+++ b/docs/root/configuration/advanced/well_known_filter_state.rst
@@ -19,8 +19,8 @@ The following lists the filter state object keys used by the Envoy extensions:
   names as a constructor.
 
 ``envoy.network.ip``
-  Shared Filter State object that can be used to create an IP address.
-  Accepts an `IP` string as a constructor.
+  Shared Filter State object used to create an IP address.
+  Accepts both `IPv4`` and `IPv6` string as a constructor.
 
 ``envoy.tcp_proxy.cluster``
   :ref:`TCP proxy <config_network_filters_tcp_proxy>` dynamic cluster name selection on a per-connection basis. Accepts

--- a/docs/root/configuration/advanced/well_known_filter_state.rst
+++ b/docs/root/configuration/advanced/well_known_filter_state.rst
@@ -18,6 +18,10 @@ The following lists the filter state object keys used by the Envoy extensions:
   Enables additional verification of the upstream peer certificate SAN names. Accepts a comma-separated list of SAN
   names as a constructor.
 
+``envoy.network.ip``
+  Shared Filter State object that can be used to create an IP address.
+  Accepts an `IP` string as a constructor.
+
 ``envoy.tcp_proxy.cluster``
   :ref:`TCP proxy <config_network_filters_tcp_proxy>` dynamic cluster name selection on a per-connection basis. Accepts
   a cluster name as a constructor.

--- a/source/common/network/BUILD
+++ b/source/common/network/BUILD
@@ -205,6 +205,18 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
+    name = "ip_address_lib",
+    srcs = ["ip_address.cc"],
+    hdrs = ["ip_address.h"],
+    deps = [
+        ":utility_lib",
+        "//envoy/network:address_interface",
+        "//envoy/registry",
+        "//envoy/stream_info:filter_state_interface",
+    ],
+)
+
+envoy_cc_library(
     name = "io_socket_error_lib",
     srcs = ["io_socket_error_impl.cc"],
     hdrs = ["io_socket_error_impl.h"],

--- a/source/common/network/ip_address.cc
+++ b/source/common/network/ip_address.cc
@@ -1,0 +1,31 @@
+#include "source/common/network/ip_address.h"
+
+#include "envoy/registry/registry.h"
+#include "envoy/stream_info/filter_state.h"
+
+#include "source/common/network/utility.h"
+
+namespace Envoy {
+namespace Network {
+
+const std::string& IPAddressObject::key() {
+  CONSTRUCT_ON_FIRST_USE(std::string, "envoy.network.ip");
+}
+
+/**
+ * Registers the filter state object for the dynamic extension support.
+ */
+class BaseIPAddressObjectFactory : public StreamInfo::FilterState::ObjectFactory {
+public:
+  std::string name() const override { return IPAddressObject::key(); }
+
+  std::unique_ptr<StreamInfo::FilterState::Object>
+  createFromBytes(absl::string_view data) const override {
+    const auto address = Utility::parseInternetAddressNoThrow(std::string(data));
+    return address ? std::make_unique<IPAddressObject>(address) : nullptr;
+  };
+};
+
+REGISTER_FACTORY(BaseIPAddressObjectFactory, StreamInfo::FilterState::ObjectFactory);
+} // namespace Network
+} // namespace Envoy

--- a/source/common/network/ip_address.h
+++ b/source/common/network/ip_address.h
@@ -14,7 +14,8 @@ public:
       : Address::InstanceAccessor(address) {}
 
   absl::optional<std::string> serializeAsString() const override {
-    return getIp() ? absl::make_optional(getIp()->asString()) : absl::nullopt;
+    const auto ip = getIp();
+    return ip ? absl::make_optional(ip->asString()) : absl::nullopt;
   }
   static const std::string& key();
 };

--- a/source/common/network/ip_address.h
+++ b/source/common/network/ip_address.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "envoy/network/address.h"
+
+namespace Envoy {
+namespace Network {
+
+/**
+ * IP Address Object that can be used to store the IP address in the filter state
+ */
+class IPAddressObject : public Address::InstanceAccessor {
+public:
+  IPAddressObject(Network::Address::InstanceConstSharedPtr address)
+      : Address::InstanceAccessor(address) {}
+
+  absl::optional<std::string> serializeAsString() const override {
+    return getIp() ? absl::make_optional(getIp()->asString()) : absl::nullopt;
+  }
+  static const std::string& key();
+};
+
+} // namespace Network
+} // namespace Envoy

--- a/source/extensions/filters/common/set_filter_state/BUILD
+++ b/source/extensions/filters/common/set_filter_state/BUILD
@@ -17,6 +17,7 @@ envoy_cc_library(
         "//envoy/registry",
         "//envoy/stream_info:filter_state_interface",
         "//source/common/formatter:substitution_format_string_lib",
+        "//source/common/network:ip_address_lib",
         "//source/common/protobuf",
         "//source/common/router:string_accessor_lib",
         "@envoy_api//envoy/extensions/filters/common/set_filter_state/v3:pkg_cc_proto",


### PR DESCRIPTION
The filter state factory that can be used in the `set-filter-state` HTTP filter are documented in https://www.envoyproxy.io/docs/envoy/latest/configuration/advanced/well_known_filter_state#well-known-filter-state

Unfortunately there is not factory that allows us to filter only on client-IP which means we need two case to parse an IP:
- one for IPv4 `IP:PORT`
- one for IPV6`[IP]:PORT`

This solves it by adding a factory key: `envoy.network.ip` that accept an IP where ever it is v4 or v6

Commit Message: create IP address object factory
Additional Description:
Risk Level: Low
Testing: Unit test and locally with custom build
Docs Changes: Yes
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
