### PR TITLE
router: refactor the cluster validation step

### DIFF
--- a/envoy/upstream/cluster_manager.h
+++ b/envoy/upstream/cluster_manager.h
@@ -342,6 +342,16 @@ public:
    */
   virtual OptRef<const Cluster> getActiveCluster(absl::string_view cluster_name) const PURE;
 
+  /**
+   * Returns true iff the given cluster name is known in the cluster-manager
+   * (either as active or as warming).
+   * @param cluster_name the name of the cluster.
+   * @return bool true if the cluster name is known, and false otherwise.
+   *
+   * NOTE: This method is only thread safe on the main thread. It should not be called elsewhere.
+   */
+  virtual bool hasCluster(const std::string& cluster_name) const PURE;
+
   using ClusterSet = absl::flat_hash_set<std::string>;
 
   /**

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -391,13 +391,11 @@ private:
  */
 class VirtualHostImpl : Logger::Loggable<Logger::Id::router> {
 public:
-  VirtualHostImpl(
-      const envoy::config::route::v3::VirtualHost& virtual_host,
-      const CommonConfigSharedPtr& global_route_config,
-      Server::Configuration::ServerFactoryContext& factory_context, Stats::Scope& scope,
-      ProtobufMessage::ValidationVisitor& validator,
-      const absl::optional<Upstream::ClusterManager::ClusterInfoMaps>& validation_clusters,
-      absl::Status& creation_status);
+  VirtualHostImpl(const envoy::config::route::v3::VirtualHost& virtual_host,
+                  const CommonConfigSharedPtr& global_route_config,
+                  Server::Configuration::ServerFactoryContext& factory_context, Stats::Scope& scope,
+                  ProtobufMessage::ValidationVisitor& validator, bool validate_clusters,
+                  absl::Status& creation_status);
 
   RouteConstSharedPtr getRouteFromEntries(const RouteCallback& cb,
                                           const Http::RequestHeaderMap& headers,
@@ -669,8 +667,7 @@ public:
 
   bool matchRoute(const Http::RequestHeaderMap& headers, const StreamInfo::StreamInfo& stream_info,
                   uint64_t random_value) const;
-  absl::Status
-  validateClusters(const Upstream::ClusterManager::ClusterInfoMaps& cluster_info_maps) const;
+  absl::Status validateClusters(const Upstream::ClusterManager& cluster_manager) const;
 
   // Router::RouteEntry
   const std::string& clusterName() const override;

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -291,8 +291,7 @@ public:
 
   bool hasCluster(const std::string& cluster_name) const override {
     ASSERT_IS_MAIN_OR_TEST_THREAD();
-    return (active_clusters_.find(cluster_name) != active_clusters_.end()) ||
-           (warming_clusters_.find(cluster_name) != warming_clusters_.end());
+    return active_clusters_.contains(cluster_name) || warming_clusters_.contains(cluster_name);
   }
 
   const ClusterSet& primaryClusters() override { return primary_clusters_; }

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -289,6 +289,12 @@ public:
     return absl::nullopt;
   }
 
+  bool hasCluster(const std::string& cluster_name) const override {
+    ASSERT_IS_MAIN_OR_TEST_THREAD();
+    return (active_clusters_.find(cluster_name) != active_clusters_.end()) ||
+           (warming_clusters_.find(cluster_name) != warming_clusters_.end());
+  }
+
   const ClusterSet& primaryClusters() override { return primary_clusters_; }
   ThreadLocalCluster* getThreadLocalCluster(absl::string_view cluster) override;
 

--- a/test/mocks/upstream/cluster_manager.cc
+++ b/test/mocks/upstream/cluster_manager.cc
@@ -57,6 +57,10 @@ void MockClusterManager::initializeClusters(const std::vector<std::string>& acti
         }
         return absl::nullopt;
       }));
+  ON_CALL(*this, hasCluster(_))
+      .WillByDefault(Invoke([this](const std::string& cluster_name) -> bool {
+        return active_clusters_.find(cluster_name) != active_clusters_.end();
+      }));
 }
 
 void MockClusterManager::initializeThreadLocalClusters(

--- a/test/mocks/upstream/cluster_manager.h
+++ b/test/mocks/upstream/cluster_manager.h
@@ -44,6 +44,7 @@ public:
               (const envoy::config::bootstrap::v3::Bootstrap& bootstrap));
   MOCK_METHOD(ClusterInfoMaps, clusters, (), (const));
   MOCK_METHOD(OptRef<const Cluster>, getActiveCluster, (absl::string_view cluster_name), (const));
+  MOCK_METHOD(bool, hasCluster, (const std::string& cluster_name), (const));
 
   MOCK_METHOD(const ClusterSet&, primaryClusters, ());
   MOCK_METHOD(ThreadLocalCluster*, getThreadLocalCluster, (absl::string_view cluster));


### PR DESCRIPTION
Commit Message: router: refactor the cluster validation step
Additional Description:
Prior to this PR, for every route the cluster-manager will create a temporary map of the known clusters, and that will be used in the validation step. This will incur a temporary memory and time complexity of O(|clusters|).
This change removes the need for the temporary object, by directly querying the cluster-manager if the cluster name is known or not.

Risk Level: low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
