### PR TITLE
oauth2: make CSRF and code verifier token expiration configurable

### DIFF
--- a/api/envoy/extensions/filters/http/oauth2/v3/oauth.proto
+++ b/api/envoy/extensions/filters/http/oauth2/v3/oauth.proto
@@ -126,7 +126,7 @@ message OAuth2Credentials {
 
 // OAuth config
 //
-// [#next-free-field: 24]
+// [#next-free-field: 25]
 message OAuth2Config {
   enum AuthType {
     // The ``client_id`` and ``client_secret`` will be sent in the URL encoded request body.
@@ -242,6 +242,12 @@ message OAuth2Config {
 
   // Optional additional prefix to use when emitting statistics.
   string stat_prefix = 22;
+
+  // Optional expiration time for the CSRF protection token cookie.
+  // The CSRF token prevents cross-site request forgery attacks during the OAuth2 flow.
+  // If not specified, defaults to ``600s`` (10 minutes), which should provide sufficient time
+  // for users to complete the OAuth2 authorization flow. 
+  google.protobuf.Duration default_csrf_token_expires_in = 24;
 }
 
 // Filter config.

--- a/api/envoy/extensions/filters/http/oauth2/v3/oauth.proto
+++ b/api/envoy/extensions/filters/http/oauth2/v3/oauth.proto
@@ -246,7 +246,7 @@ message OAuth2Config {
   // Optional expiration time for the CSRF protection token cookie.
   // The CSRF token prevents cross-site request forgery attacks during the OAuth2 flow.
   // If not specified, defaults to ``600s`` (10 minutes), which should provide sufficient time
-  // for users to complete the OAuth2 authorization flow. 
+  // for users to complete the OAuth2 authorization flow.
   google.protobuf.Duration csrf_token_expires_in = 24;
 
   // Optional expiration time for the code verifier cookie.

--- a/api/envoy/extensions/filters/http/oauth2/v3/oauth.proto
+++ b/api/envoy/extensions/filters/http/oauth2/v3/oauth.proto
@@ -126,7 +126,7 @@ message OAuth2Credentials {
 
 // OAuth config
 //
-// [#next-free-field: 25]
+// [#next-free-field: 26]
 message OAuth2Config {
   enum AuthType {
     // The ``client_id`` and ``client_secret`` will be sent in the URL encoded request body.
@@ -248,6 +248,12 @@ message OAuth2Config {
   // If not specified, defaults to ``600s`` (10 minutes), which should provide sufficient time
   // for users to complete the OAuth2 authorization flow. 
   google.protobuf.Duration default_csrf_token_expires_in = 24;
+
+  // Optional expiration time for the code verifier cookie.
+  // The code verifier is stored in a secure, HTTP-only cookie during the OAuth2 authorization process.
+  // If not specified, defaults to ``600s`` (10 minutes), which should provide sufficient time
+  // for users to complete the OAuth2 authorization flow.
+  google.protobuf.Duration default_code_verifier_token_expires_in = 25;
 }
 
 // Filter config.

--- a/api/envoy/extensions/filters/http/oauth2/v3/oauth.proto
+++ b/api/envoy/extensions/filters/http/oauth2/v3/oauth.proto
@@ -247,13 +247,13 @@ message OAuth2Config {
   // The CSRF token prevents cross-site request forgery attacks during the OAuth2 flow.
   // If not specified, defaults to ``600s`` (10 minutes), which should provide sufficient time
   // for users to complete the OAuth2 authorization flow. 
-  google.protobuf.Duration default_csrf_token_expires_in = 24;
+  google.protobuf.Duration csrf_token_expires_in = 24;
 
   // Optional expiration time for the code verifier cookie.
   // The code verifier is stored in a secure, HTTP-only cookie during the OAuth2 authorization process.
   // If not specified, defaults to ``600s`` (10 minutes), which should provide sufficient time
   // for users to complete the OAuth2 authorization flow.
-  google.protobuf.Duration default_code_verifier_token_expires_in = 25;
+  google.protobuf.Duration code_verifier_token_expires_in = 25;
 }
 
 // Filter config.

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -210,6 +210,11 @@ new_features:
     If configured, the OAuth2 filter will redirect users to this endpoint when they access the
     :ref:`signout_path <envoy_v3_api_field_extensions.filters.http.oauth2.v3.OAuth2Config.signout_path>`. This allows users to
     be logged out of the Authorization server.
+- area: oauth2
+  change: |
+    Added configurable :ref:`default_csrf_token_expires_in <envoy_v3_api_field_extensions.filters.http.oauth2.v3.OAuth2Config.default_csrf_token_expires_in>`
+    and :ref:`default_code_verifier_token_expires_in <envoy_v3_api_field_extensions.filters.http.oauth2.v3.OAuth2Config.default_code_verifier_token_expires_in>`
+    fields to the ``oauth2`` filter. Both default to ``600s`` (10 minutes) if not specified, keeping backward compatibility.
 - area: load shed point
   change: |
     Added load shed point ``envoy.load_shed_points.connection_pool_new_connection`` in the connection pool, and it will not

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -212,8 +212,8 @@ new_features:
     be logged out of the Authorization server.
 - area: oauth2
   change: |
-    Added configurable :ref:`default_csrf_token_expires_in <envoy_v3_api_field_extensions.filters.http.oauth2.v3.OAuth2Config.default_csrf_token_expires_in>`
-    and :ref:`default_code_verifier_token_expires_in <envoy_v3_api_field_extensions.filters.http.oauth2.v3.OAuth2Config.default_code_verifier_token_expires_in>`
+    Added configurable :ref:`csrf_token_expires_in <envoy_v3_api_field_extensions.filters.http.oauth2.v3.OAuth2Config.csrf_token_expires_in>`
+    and :ref:`code_verifier_token_expires_in <envoy_v3_api_field_extensions.filters.http.oauth2.v3.OAuth2Config.code_verifier_token_expires_in>`
     fields to the ``oauth2`` filter. Both default to ``600s`` (10 minutes) if not specified, keeping backward compatibility.
 - area: load shed point
   change: |

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -212,8 +212,10 @@ new_features:
     be logged out of the Authorization server.
 - area: oauth2
   change: |
-    Added configurable :ref:`csrf_token_expires_in <envoy_v3_api_field_extensions.filters.http.oauth2.v3.OAuth2Config.csrf_token_expires_in>`
-    and :ref:`code_verifier_token_expires_in <envoy_v3_api_field_extensions.filters.http.oauth2.v3.OAuth2Config.code_verifier_token_expires_in>`
+    Added configurable :ref:`csrf_token_expires_in
+    <envoy_v3_api_field_extensions.filters.http.oauth2.v3.OAuth2Config.csrf_token_expires_in>`
+    and :ref:`code_verifier_token_expires_in
+    <envoy_v3_api_field_extensions.filters.http.oauth2.v3.OAuth2Config.code_verifier_token_expires_in>`
     fields to the ``oauth2`` filter. Both default to ``600s`` (10 minutes) if not specified, keeping backward compatibility.
 - area: load shed point
   change: |

--- a/source/extensions/filters/http/oauth2/filter.cc
+++ b/source/extensions/filters/http/oauth2/filter.cc
@@ -423,14 +423,10 @@ FilterConfig::FilterConfig(
       default_expires_in_(PROTOBUF_GET_SECONDS_OR_DEFAULT(proto_config, default_expires_in, 0)),
       default_refresh_token_expires_in_(
           PROTOBUF_GET_SECONDS_OR_DEFAULT(proto_config, default_refresh_token_expires_in, 604800)),
-      csrf_token_expires_in_(
-          PROTOBUF_GET_SECONDS_OR_DEFAULT(proto_config,
-                                          csrf_token_expires_in,
-                                          DEFAULT_CSRF_TOKEN_EXPIRES_IN)),
-      code_verifier_token_expires_in_(
-          PROTOBUF_GET_SECONDS_OR_DEFAULT(proto_config,
-                                          code_verifier_token_expires_in,
-                                          DEFAULT_CODE_VERIFIER_TOKEN_EXPIRES_IN)),
+      csrf_token_expires_in_(PROTOBUF_GET_SECONDS_OR_DEFAULT(proto_config, csrf_token_expires_in,
+                                                             DEFAULT_CSRF_TOKEN_EXPIRES_IN)),
+      code_verifier_token_expires_in_(PROTOBUF_GET_SECONDS_OR_DEFAULT(
+          proto_config, code_verifier_token_expires_in, DEFAULT_CODE_VERIFIER_TOKEN_EXPIRES_IN)),
       forward_bearer_token_(proto_config.forward_bearer_token()),
       preserve_authorization_header_(proto_config.preserve_authorization_header()),
       use_refresh_token_(FilterConfig::shouldUseRefreshToken(proto_config)),
@@ -803,8 +799,7 @@ void OAuth2Filter::redirectToOAuthServer(Http::RequestHeaderMap& headers) {
     // Generate a CSRF token to prevent CSRF attacks.
     csrf_token = generateCsrfToken(config_->hmacSecret(), random_);
 
-    const std::chrono::seconds csrf_token_expires_in =
-        config_->getCsrfTokenExpiresIn();
+    const std::chrono::seconds csrf_token_expires_in = config_->getCsrfTokenExpiresIn();
     std::string csrf_expires = std::to_string(csrf_token_expires_in.count());
 
     std::string same_site = getSameSiteString(config_->nonceCookieSettings().same_site_);

--- a/source/extensions/filters/http/oauth2/filter.cc
+++ b/source/extensions/filters/http/oauth2/filter.cc
@@ -420,10 +420,10 @@ FilterConfig::FilterConfig(
       default_expires_in_(PROTOBUF_GET_SECONDS_OR_DEFAULT(proto_config, default_expires_in, 0)),
       default_refresh_token_expires_in_(
           PROTOBUF_GET_SECONDS_OR_DEFAULT(proto_config, default_refresh_token_expires_in, 604800)),
-      default_csrf_token_expires_in_(
-          PROTOBUF_GET_SECONDS_OR_DEFAULT(proto_config, default_csrf_token_expires_in, 600)),
-      default_code_verifier_token_expires_in_(
-          PROTOBUF_GET_SECONDS_OR_DEFAULT(proto_config, default_code_verifier_token_expires_in, 600)),
+      csrf_token_expires_in_(
+          PROTOBUF_GET_SECONDS_OR_DEFAULT(proto_config, csrf_token_expires_in, 600)),
+      code_verifier_token_expires_in_(
+          PROTOBUF_GET_SECONDS_OR_DEFAULT(proto_config, code_verifier_token_expires_in, 600)),
       forward_bearer_token_(proto_config.forward_bearer_token()),
       preserve_authorization_header_(proto_config.preserve_authorization_header()),
       use_refresh_token_(FilterConfig::shouldUseRefreshToken(proto_config)),
@@ -796,9 +796,9 @@ void OAuth2Filter::redirectToOAuthServer(Http::RequestHeaderMap& headers) {
     // Generate a CSRF token to prevent CSRF attacks.
     csrf_token = generateCsrfToken(config_->hmacSecret(), random_);
 
-    const std::chrono::seconds default_csrf_token_expires_in =
-        config_->defaultCsrfTokenExpiresIn();
-    std::string csrf_expires = std::to_string(default_csrf_token_expires_in.count());
+    const std::chrono::seconds csrf_token_expires_in =
+        config_->csrfTokenExpiresIn();
+    std::string csrf_expires = std::to_string(csrf_token_expires_in.count());
 
     std::string same_site = getSameSiteString(config_->nonceCookieSettings().same_site_);
     std::string cookie_tail_http_only =
@@ -829,9 +829,9 @@ void OAuth2Filter::redirectToOAuthServer(Http::RequestHeaderMap& headers) {
   const std::string encrypted_code_verifier =
       encrypt(code_verifier, config_->hmacSecret(), random_);
 
-  const std::chrono::seconds default_code_verifier_token_expires_in =
-      config_->defaultCodeVerifierTokenExpiresIn();
-  std::string expire_in = std::to_string(default_code_verifier_token_expires_in.count());
+  const std::chrono::seconds code_verifier_token_expires_in =
+      config_->codeVerifierTokenExpiresIn();
+  std::string expire_in = std::to_string(code_verifier_token_expires_in.count());
 
   std::string same_site = getSameSiteString(config_->codeVerifierCookieSettings().same_site_);
   std::string cookie_tail_http_only =

--- a/source/extensions/filters/http/oauth2/filter.cc
+++ b/source/extensions/filters/http/oauth2/filter.cc
@@ -797,7 +797,7 @@ void OAuth2Filter::redirectToOAuthServer(Http::RequestHeaderMap& headers) {
     csrf_token = generateCsrfToken(config_->hmacSecret(), random_);
 
     const std::chrono::seconds csrf_token_expires_in =
-        config_->csrfTokenExpiresIn();
+        config_->getCsrfTokenExpiresIn();
     std::string csrf_expires = std::to_string(csrf_token_expires_in.count());
 
     std::string same_site = getSameSiteString(config_->nonceCookieSettings().same_site_);
@@ -830,7 +830,7 @@ void OAuth2Filter::redirectToOAuthServer(Http::RequestHeaderMap& headers) {
       encrypt(code_verifier, config_->hmacSecret(), random_);
 
   const std::chrono::seconds code_verifier_token_expires_in =
-      config_->codeVerifierTokenExpiresIn();
+      config_->getCodeVerifierTokenExpiresIn();
   std::string expire_in = std::to_string(code_verifier_token_expires_in.count());
 
   std::string same_site = getSameSiteString(config_->codeVerifierCookieSettings().same_site_);

--- a/source/extensions/filters/http/oauth2/filter.cc
+++ b/source/extensions/filters/http/oauth2/filter.cc
@@ -72,6 +72,9 @@ constexpr absl::string_view SameSiteStrict = ";SameSite=Strict";
 constexpr absl::string_view SameSiteNone = ";SameSite=None";
 constexpr absl::string_view HmacPayloadSeparator = "\n";
 
+constexpr int DEFAULT_CSRF_TOKEN_EXPIRES_IN = 600;
+constexpr int DEFAULT_CODE_VERIFIER_TOKEN_EXPIRES_IN = 600;
+
 template <class T>
 std::vector<Http::HeaderUtility::HeaderDataPtr>
 headerMatchers(const T& matcher_protos, Server::Configuration::CommonFactoryContext& context) {
@@ -421,9 +424,13 @@ FilterConfig::FilterConfig(
       default_refresh_token_expires_in_(
           PROTOBUF_GET_SECONDS_OR_DEFAULT(proto_config, default_refresh_token_expires_in, 604800)),
       csrf_token_expires_in_(
-          PROTOBUF_GET_SECONDS_OR_DEFAULT(proto_config, csrf_token_expires_in, 600)),
+          PROTOBUF_GET_SECONDS_OR_DEFAULT(proto_config,
+                                          csrf_token_expires_in,
+                                          DEFAULT_CSRF_TOKEN_EXPIRES_IN)),
       code_verifier_token_expires_in_(
-          PROTOBUF_GET_SECONDS_OR_DEFAULT(proto_config, code_verifier_token_expires_in, 600)),
+          PROTOBUF_GET_SECONDS_OR_DEFAULT(proto_config,
+                                          code_verifier_token_expires_in,
+                                          DEFAULT_CODE_VERIFIER_TOKEN_EXPIRES_IN)),
       forward_bearer_token_(proto_config.forward_bearer_token()),
       preserve_authorization_header_(proto_config.preserve_authorization_header()),
       use_refresh_token_(FilterConfig::shouldUseRefreshToken(proto_config)),

--- a/source/extensions/filters/http/oauth2/filter.h
+++ b/source/extensions/filters/http/oauth2/filter.h
@@ -166,6 +166,9 @@ public:
   std::chrono::seconds defaultCsrfTokenExpiresIn() const {
     return default_csrf_token_expires_in_;
   }
+  std::chrono::seconds defaultCodeVerifierTokenExpiresIn() const {
+    return default_code_verifier_token_expires_in_;
+  }
   bool disableIdTokenSetCookie() const { return disable_id_token_set_cookie_; }
   bool disableAccessTokenSetCookie() const { return disable_access_token_set_cookie_; }
   bool disableRefreshTokenSetCookie() const { return disable_refresh_token_set_cookie_; }
@@ -227,6 +230,7 @@ private:
   const std::chrono::seconds default_expires_in_;
   const std::chrono::seconds default_refresh_token_expires_in_;
   const std::chrono::seconds default_csrf_token_expires_in_;
+  const std::chrono::seconds default_code_verifier_token_expires_in_;
   const bool forward_bearer_token_ : 1;
   const bool preserve_authorization_header_ : 1;
   const bool use_refresh_token_ : 1;

--- a/source/extensions/filters/http/oauth2/filter.h
+++ b/source/extensions/filters/http/oauth2/filter.h
@@ -163,9 +163,7 @@ public:
   std::chrono::seconds defaultRefreshTokenExpiresIn() const {
     return default_refresh_token_expires_in_;
   }
-  std::chrono::seconds getCsrfTokenExpiresIn() const {
-    return csrf_token_expires_in_;
-  }
+  std::chrono::seconds getCsrfTokenExpiresIn() const { return csrf_token_expires_in_; }
   std::chrono::seconds getCodeVerifierTokenExpiresIn() const {
     return code_verifier_token_expires_in_;
   }

--- a/source/extensions/filters/http/oauth2/filter.h
+++ b/source/extensions/filters/http/oauth2/filter.h
@@ -163,6 +163,9 @@ public:
   std::chrono::seconds defaultRefreshTokenExpiresIn() const {
     return default_refresh_token_expires_in_;
   }
+  std::chrono::seconds defaultCsrfTokenExpiresIn() const {
+    return default_csrf_token_expires_in_;
+  }
   bool disableIdTokenSetCookie() const { return disable_id_token_set_cookie_; }
   bool disableAccessTokenSetCookie() const { return disable_access_token_set_cookie_; }
   bool disableRefreshTokenSetCookie() const { return disable_refresh_token_set_cookie_; }
@@ -223,6 +226,7 @@ private:
   const AuthType auth_type_;
   const std::chrono::seconds default_expires_in_;
   const std::chrono::seconds default_refresh_token_expires_in_;
+  const std::chrono::seconds default_csrf_token_expires_in_;
   const bool forward_bearer_token_ : 1;
   const bool preserve_authorization_header_ : 1;
   const bool use_refresh_token_ : 1;

--- a/source/extensions/filters/http/oauth2/filter.h
+++ b/source/extensions/filters/http/oauth2/filter.h
@@ -163,10 +163,10 @@ public:
   std::chrono::seconds defaultRefreshTokenExpiresIn() const {
     return default_refresh_token_expires_in_;
   }
-  std::chrono::seconds csrfTokenExpiresIn() const {
+  std::chrono::seconds getCsrfTokenExpiresIn() const {
     return csrf_token_expires_in_;
   }
-  std::chrono::seconds codeVerifierTokenExpiresIn() const {
+  std::chrono::seconds getCodeVerifierTokenExpiresIn() const {
     return code_verifier_token_expires_in_;
   }
   bool disableIdTokenSetCookie() const { return disable_id_token_set_cookie_; }

--- a/source/extensions/filters/http/oauth2/filter.h
+++ b/source/extensions/filters/http/oauth2/filter.h
@@ -163,11 +163,11 @@ public:
   std::chrono::seconds defaultRefreshTokenExpiresIn() const {
     return default_refresh_token_expires_in_;
   }
-  std::chrono::seconds defaultCsrfTokenExpiresIn() const {
-    return default_csrf_token_expires_in_;
+  std::chrono::seconds csrfTokenExpiresIn() const {
+    return csrf_token_expires_in_;
   }
-  std::chrono::seconds defaultCodeVerifierTokenExpiresIn() const {
-    return default_code_verifier_token_expires_in_;
+  std::chrono::seconds codeVerifierTokenExpiresIn() const {
+    return code_verifier_token_expires_in_;
   }
   bool disableIdTokenSetCookie() const { return disable_id_token_set_cookie_; }
   bool disableAccessTokenSetCookie() const { return disable_access_token_set_cookie_; }
@@ -229,8 +229,8 @@ private:
   const AuthType auth_type_;
   const std::chrono::seconds default_expires_in_;
   const std::chrono::seconds default_refresh_token_expires_in_;
-  const std::chrono::seconds default_csrf_token_expires_in_;
-  const std::chrono::seconds default_code_verifier_token_expires_in_;
+  const std::chrono::seconds csrf_token_expires_in_;
+  const std::chrono::seconds code_verifier_token_expires_in_;
   const bool forward_bearer_token_ : 1;
   const bool preserve_authorization_header_ : 1;
   const bool use_refresh_token_ : 1;

--- a/test/extensions/filters/http/oauth2/filter_test.cc
+++ b/test/extensions/filters/http/oauth2/filter_test.cc
@@ -151,7 +151,7 @@ public:
       ::envoy::extensions::filters::http::oauth2::v3::CookieConfig_SameSite code_verifier_samesite =
           ::envoy::extensions::filters::http::oauth2::v3::CookieConfig_SameSite::
               CookieConfig_SameSite_DISABLED,
-      int default_csrf_token_expires_in = 0, int default_code_verifier_token_expires_in = 0) {
+      int csrf_token_expires_in = 0, int code_verifier_token_expires_in = 0) {
     envoy::extensions::filters::http::oauth2::v3::OAuth2Config p;
     auto* endpoint = p.mutable_token_endpoint();
     endpoint->set_cluster("auth.example.com");
@@ -176,14 +176,14 @@ public:
       refresh_token_expires_in->set_seconds(default_refresh_token_expires_in);
     }
 
-    if (default_csrf_token_expires_in != 0) {
-      auto* csrf_token_expires_in = p.mutable_default_csrf_token_expires_in();
-      csrf_token_expires_in->set_seconds(default_csrf_token_expires_in);
+    if (csrf_token_expires_in != 0) {
+      auto* expires_in = p.mutable_csrf_token_expires_in();
+      expires_in->set_seconds(csrf_token_expires_in);
     }
 
-    if (default_code_verifier_token_expires_in != 0) {
-      auto* code_verifier_token_expires_in = p.mutable_default_code_verifier_token_expires_in();
-      code_verifier_token_expires_in->set_seconds(default_code_verifier_token_expires_in);
+    if (code_verifier_token_expires_in != 0) {
+      auto* expires_in = p.mutable_code_verifier_token_expires_in();
+      expires_in->set_seconds(code_verifier_token_expires_in);
     }
 
     p.set_auth_type(auth_type);
@@ -487,7 +487,7 @@ TEST_F(OAuth2Test, DefaultAuthScope) {
 }
 
 // Verifies that the CSRF token cookie expiration (Max-Age) uses the custom
-// value from default_csrf_token_expires_in configuration.
+// value from csrf_token_expires_in configuration.
 TEST_F(OAuth2Test, CustomCsrfTokenExpiresIn) {
   // Create a filter config with a custom CSRF token expiration.
   envoy::extensions::filters::http::oauth2::v3::OAuth2Config p;
@@ -506,7 +506,7 @@ TEST_F(OAuth2Test, CustomCsrfTokenExpiresIn) {
 
   // Set custom CSRF token expiration
   const int custom_csrf_token_expires_in = 1234;
-  auto* csrf_token_expires_in = p.mutable_default_csrf_token_expires_in();
+  auto* csrf_token_expires_in = p.mutable_csrf_token_expires_in();
   csrf_token_expires_in->set_seconds(custom_csrf_token_expires_in);
 
   // Create the OAuth config.
@@ -554,7 +554,7 @@ TEST_F(OAuth2Test, CustomCsrfTokenExpiresIn) {
 }
 
 // Verifies that the code verifier token cookie expiration (Max-Age) uses the custom
-// value from default_code_verifier_token_expires_in configuration.
+// value from code_verifier_token_expires_in configuration.
 TEST_F(OAuth2Test, CustomCodeVerifierTokenExpiresIn) {
   // Create a filter config with a custom code verifier token expiration.
   envoy::extensions::filters::http::oauth2::v3::OAuth2Config p;
@@ -573,7 +573,7 @@ TEST_F(OAuth2Test, CustomCodeVerifierTokenExpiresIn) {
 
   // Set custom code verifier token expiration
   const int custom_code_verifier_token_expires_in = 1234;
-  auto* code_verifier_token_expires_in = p.mutable_default_code_verifier_token_expires_in();
+  auto* code_verifier_token_expires_in = p.mutable_code_verifier_token_expires_in();
   code_verifier_token_expires_in->set_seconds(custom_code_verifier_token_expires_in);
 
   // Create the OAuth config.

--- a/test/extensions/filters/http/oauth2/filter_test.cc
+++ b/test/extensions/filters/http/oauth2/filter_test.cc
@@ -49,6 +49,7 @@ static const std::string TEST_ENCRYPTED_CODE_VERIFIER =
     "Fc1bBwAAAAAVzVsHAAAAABjf6i_Hvf8T2dEuEhPhhDNMlp16az-0dxisL-TzJKaZjOMF8nov_pG377FHmpKcsA";
 static const std::string TEST_CODE_CHALLENGE = "YRQaBq_UpkWzfr6JvtNnh7LMfmPVcIKVYdV98ugwmLY";
 static const std::string TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN = "600";
+static const std::string TEST_DEFAULT_CODE_VERIFIER_TOKEN_EXPIRES_IN = "600";
 
 namespace {
 Http::RegisterCustomInlineHeader<Http::CustomInlineHeaderRegistry::Type::RequestHeaders>
@@ -149,7 +150,8 @@ public:
               CookieConfig_SameSite_DISABLED,
       ::envoy::extensions::filters::http::oauth2::v3::CookieConfig_SameSite code_verifier_samesite =
           ::envoy::extensions::filters::http::oauth2::v3::CookieConfig_SameSite::
-              CookieConfig_SameSite_DISABLED, int default_csrf_token_expires_in = 0) {
+              CookieConfig_SameSite_DISABLED,
+      int default_csrf_token_expires_in = 0, int default_code_verifier_token_expires_in = 0) {
     envoy::extensions::filters::http::oauth2::v3::OAuth2Config p;
     auto* endpoint = p.mutable_token_endpoint();
     endpoint->set_cluster("auth.example.com");
@@ -177,6 +179,11 @@ public:
     if (default_csrf_token_expires_in != 0) {
       auto* csrf_token_expires_in = p.mutable_default_csrf_token_expires_in();
       csrf_token_expires_in->set_seconds(default_csrf_token_expires_in);
+    }
+
+    if (default_code_verifier_token_expires_in != 0) {
+      auto* code_verifier_token_expires_in = p.mutable_default_code_verifier_token_expires_in();
+      code_verifier_token_expires_in->set_seconds(default_code_verifier_token_expires_in);
     }
 
     p.set_auth_type(auth_type);
@@ -454,7 +461,8 @@ TEST_F(OAuth2Test, DefaultAuthScope) {
        "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=" +
            TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
       {Http::Headers::get().SetCookie.get(),
-       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER + ";path=/;Max-Age=600;secure;HttpOnly"},
+       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER + ";path=/;Max-Age=" +
+           TEST_DEFAULT_CODE_VERIFIER_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
 
       {Http::Headers::get().Location.get(),
        "https://auth.example.com/oauth/"
@@ -527,7 +535,75 @@ TEST_F(OAuth2Test, CustomCsrfTokenExpiresIn) {
        "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=" +
            std::to_string(custom_csrf_token_expires_in) + ";secure;HttpOnly"},
       {Http::Headers::get().SetCookie.get(),
-       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER + ";path=/;Max-Age=600;secure;HttpOnly"},
+       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER + ";path=/;Max-Age=" +
+           TEST_DEFAULT_CODE_VERIFIER_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
+      {Http::Headers::get().Location.get(),
+       "https://auth.example.com/oauth/"
+       "authorize/?client_id=" +
+           TEST_CLIENT_ID + "&code_challenge=" + TEST_CODE_CHALLENGE +
+           "&code_challenge_method=S256" +
+           "&redirect_uri=https%3A%2F%2Ftraffic.example.com%2F_oauth"
+           "&response_type=code"
+           "&scope=" +
+           TEST_DEFAULT_SCOPE + "&state=" + TEST_ENCODED_STATE},
+  };
+  EXPECT_CALL(decoder_callbacks_, encodeHeaders_(HeaderMapEqualRef(&response_headers), true));
+
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
+            filter_->decodeHeaders(request_headers, false));
+}
+
+// Verifies that the code verifier token cookie expiration (Max-Age) uses the custom
+// value from default_code_verifier_token_expires_in configuration.
+TEST_F(OAuth2Test, CustomCodeVerifierTokenExpiresIn) {
+  // Create a filter config with a custom code verifier token expiration.
+  envoy::extensions::filters::http::oauth2::v3::OAuth2Config p;
+  auto* endpoint = p.mutable_token_endpoint();
+  endpoint->set_cluster("auth.example.com");
+  endpoint->set_uri("auth.example.com/_oauth");
+  endpoint->mutable_timeout()->set_seconds(1);
+  p.set_redirect_uri("%REQ(:scheme)%://%REQ(:authority)%" + TEST_CALLBACK);
+  p.mutable_redirect_path_matcher()->mutable_path()->set_exact(TEST_CALLBACK);
+  p.set_authorization_endpoint("https://auth.example.com/oauth/authorize/");
+  p.mutable_signout_path()->mutable_path()->set_exact("/_signout");
+  auto credentials = p.mutable_credentials();
+  credentials->set_client_id(TEST_CLIENT_ID);
+  credentials->mutable_token_secret()->set_name("secret");
+  credentials->mutable_hmac_secret()->set_name("hmac");
+
+  // Set custom code verifier token expiration
+  const int custom_code_verifier_token_expires_in = 1234;
+  auto* code_verifier_token_expires_in = p.mutable_default_code_verifier_token_expires_in();
+  code_verifier_token_expires_in->set_seconds(custom_code_verifier_token_expires_in);
+
+  // Create the OAuth config.
+  auto secret_reader = std::make_shared<MockSecretReader>();
+  FilterConfigSharedPtr test_config_;
+  test_config_ = std::make_shared<FilterConfig>(p, factory_context_.server_factory_context_,
+                                                secret_reader, scope_, "test.");
+
+  init(test_config_);
+  Http::TestRequestHeaderMapImpl request_headers{
+      {Http::Headers::get().Path.get(), "/original_path?var1=1&var2=2"},
+      {Http::Headers::get().Host.get(), "traffic.example.com"},
+      {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
+      {Http::Headers::get().Scheme.get(), "https"},
+  };
+
+  // Explicitly tell the validator to fail the validation.
+  EXPECT_CALL(*validator_, setParams(_, _));
+  EXPECT_CALL(*validator_, isValid()).WillOnce(Return(false));
+  EXPECT_CALL(*validator_, canUpdateTokenByRefreshToken()).WillOnce(Return(false));
+
+  // Verify that the CSRF token cookie (OauthNonce) expiration is set to the custom value.
+  Http::TestResponseHeaderMapImpl response_headers{
+      {Http::Headers::get().Status.get(), "302"},
+      {Http::Headers::get().SetCookie.get(),
+       "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=" +
+           TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
+      {Http::Headers::get().SetCookie.get(),
+       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER + ";path=/;Max-Age=" +
+           std::to_string(custom_code_verifier_token_expires_in) + ";secure;HttpOnly"},
       {Http::Headers::get().Location.get(),
        "https://auth.example.com/oauth/"
        "authorize/?client_id=" +
@@ -586,7 +662,8 @@ TEST_F(OAuth2Test, PreservesQueryParametersInAuthorizationEndpoint) {
        "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=" +
            TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
       {Http::Headers::get().SetCookie.get(),
-       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER + ";path=/;Max-Age=600;secure;HttpOnly"},
+       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER + ";path=/;Max-Age=" +
+           TEST_DEFAULT_CODE_VERIFIER_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
       {Http::Headers::get().Location.get(),
        "https://auth.example.com/oauth/"
        "authorize/?client_id=" +
@@ -645,7 +722,8 @@ TEST_F(OAuth2Test, PreservesQueryParametersInAuthorizationEndpointWithUrlEncodin
        "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=" +
            TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
       {Http::Headers::get().SetCookie.get(),
-       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER + ";path=/;Max-Age=600;secure;HttpOnly"},
+       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER + ";path=/;Max-Age=" +
+           TEST_DEFAULT_CODE_VERIFIER_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
       {Http::Headers::get().Location.get(),
        "https://auth.example.com/oauth/"
        "authorize/?client_id=" +
@@ -907,7 +985,8 @@ TEST_F(OAuth2Test, SetBearerToken) {
        "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=" +
            TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
       {Http::Headers::get().Cookie.get(),
-       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER + ";path=/;Max-Age=600;secure;HttpOnly"},
+       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER + ";path=/;Max-Age=" +
+           TEST_DEFAULT_CODE_VERIFIER_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
       {Http::Headers::get().Host.get(), "traffic.example.com"},
       {Http::Headers::get().Scheme.get(), "https"},
       {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
@@ -979,7 +1058,8 @@ TEST_F(OAuth2Test, OAuthErrorNonOAuthHttpCallback) {
        "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=" +
            TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
       {Http::Headers::get().SetCookie.get(),
-       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER + ";path=/;Max-Age=600;secure;HttpOnly"},
+       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER + ";path=/;Max-Age=" +
+           TEST_DEFAULT_CODE_VERIFIER_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
       {Http::Headers::get().Location.get(),
        "https://auth.example.com/oauth/"
        "authorize/?client_id=" +
@@ -1012,7 +1092,8 @@ TEST_F(OAuth2Test, OAuthErrorNonOAuthHttpCallback) {
        "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=" +
            TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
       {Http::Headers::get().Cookie.get(),
-       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER + ";path=/;Max-Age=600;secure;HttpOnly"},
+       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER + ";path=/;Max-Age=" +
+           TEST_DEFAULT_CODE_VERIFIER_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
       {Http::Headers::get().Host.get(), "traffic.example.com"},
       {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
       {Http::Headers::get().Scheme.get(), "https"},
@@ -1108,7 +1189,8 @@ TEST_F(OAuth2Test, OAuthCallbackStartsAuthentication) {
        "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=" +
            TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
       {Http::Headers::get().Cookie.get(),
-       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER + ";path=/;Max-Age=600;secure;HttpOnly"},
+       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER + ";path=/;Max-Age=" +
+           TEST_DEFAULT_CODE_VERIFIER_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
       {Http::Headers::get().Host.get(), "traffic.example.com"},
       {Http::Headers::get().Scheme.get(), "https"},
       {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
@@ -1140,7 +1222,8 @@ TEST_F(OAuth2Test, OAuthCallbackWithInvalidCodeVerifierCookie) {
        "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=" +
            TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
       {Http::Headers::get().Cookie.get(),
-       "CodeVerifier=" + invalid_encrypted_code_verifier + ";path=/;Max-Age=600;secure;HttpOnly"},
+       "CodeVerifier=" + invalid_encrypted_code_verifier + ";path=/;Max-Age=" +
+           TEST_DEFAULT_CODE_VERIFIER_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
       {Http::Headers::get().Host.get(), "traffic.example.com"},
       {Http::Headers::get().Scheme.get(), "https"},
       {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
@@ -1345,7 +1428,8 @@ TEST_F(OAuth2Test, RedirectToOAuthServerWithInvalidCSRFToken) {
        "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=" +
            TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
       {Http::Headers::get().SetCookie.get(),
-       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER + ";path=/;Max-Age=600;secure;HttpOnly"},
+       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER + ";path=/;Max-Age=" +
+           TEST_DEFAULT_CODE_VERIFIER_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
       {Http::Headers::get().Location.get(),
        "https://auth.example.com/oauth/"
        "authorize/?client_id=" +
@@ -1751,8 +1835,8 @@ TEST_F(OAuth2Test, OAuthTestFullFlowPostWithCookieDomain) {
        "OauthNonce=" + TEST_CSRF_TOKEN + ";domain=example.com;path=/;Max-Age=" +
            TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
       {Http::Headers::get().SetCookie.get(),
-       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER +
-           ";domain=example.com;path=/;Max-Age=600;secure;HttpOnly"},
+       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER + ";domain=example.com;path=/;Max-Age=" +
+           TEST_DEFAULT_CODE_VERIFIER_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
       {Http::Headers::get().Location.get(),
        "https://auth.example.com/oauth/"
        "authorize/?client_id=" +
@@ -1785,8 +1869,8 @@ TEST_F(OAuth2Test, OAuthTestFullFlowPostWithCookieDomain) {
        "OauthNonce=" + TEST_CSRF_TOKEN + ";domain=example.com;path=/;Max-Age=" +
            TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
       {Http::Headers::get().Cookie.get(),
-       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER +
-           ";domain=example.com;path=/;Max-Age=600;secure;HttpOnly"},
+       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER + ";domain=example.com;path=/;Max-Age=" +
+           TEST_DEFAULT_CODE_VERIFIER_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
       {Http::Headers::get().Path.get(), "/_oauth?code=123&state=" + TEST_ENCODED_STATE},
       {Http::Headers::get().Host.get(), "traffic.example.com"},
       {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
@@ -1866,7 +1950,8 @@ TEST_F(OAuth2Test, OAuthTestFullFlowPostWithSpecialCharactersForJson) {
        "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=" +
            TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
       {Http::Headers::get().SetCookie.get(),
-       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER + ";path=/;Max-Age=600;secure;HttpOnly"},
+       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER + ";path=/;Max-Age=" +
+           TEST_DEFAULT_CODE_VERIFIER_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
       {Http::Headers::get().Location.get(),
        "https://auth.example.com/oauth/"
        "authorize/?client_id=" +
@@ -1901,7 +1986,8 @@ TEST_F(OAuth2Test, OAuthTestFullFlowPostWithSpecialCharactersForJson) {
        "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=" +
            TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
       {Http::Headers::get().Cookie.get(),
-       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER + ";path=/;Max-Age=600;secure;HttpOnly"},
+       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER + ";path=/;Max-Age=" +
+           TEST_DEFAULT_CODE_VERIFIER_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
       {Http::Headers::get().Path.get(),
        "/_oauth?code=123&state=" + test_encoded_state_with_special_characters},
       {Http::Headers::get().Host.get(), "traffic.example.com"},
@@ -2648,7 +2734,8 @@ TEST_F(OAuth2Test, OAuthTestFullFlowWithUseRefreshToken) {
        "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=" +
            TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
       {Http::Headers::get().SetCookie.get(),
-       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER + ";path=/;Max-Age=600;secure;HttpOnly"},
+       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER + ";path=/;Max-Age=" +
+           TEST_DEFAULT_CODE_VERIFIER_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
       {Http::Headers::get().Location.get(),
        "https://auth.example.com/oauth/"
        "authorize/?client_id=" +
@@ -2682,8 +2769,8 @@ TEST_F(OAuth2Test, OAuthTestFullFlowWithUseRefreshToken) {
        "OauthNonce=" + TEST_CSRF_TOKEN + ";domain=example.com;path=/;Max-Age=" +
            TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
       {Http::Headers::get().Cookie.get(),
-       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER +
-           ";domain=example.com;path=/;Max-Age=600;secure;HttpOnly"},
+       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER + ";domain=example.com;path=/;Max-Age=" +
+           TEST_DEFAULT_CODE_VERIFIER_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
       {Http::Headers::get().Path.get(), "/_oauth?code=123&state=" + TEST_ENCODED_STATE},
       {Http::Headers::get().Host.get(), "traffic.example.com"},
       {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
@@ -2838,7 +2925,8 @@ TEST_F(OAuth2Test, OAuthTestRefreshAccessTokenFail) {
        "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=" +
            TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
       {Http::Headers::get().SetCookie.get(),
-       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER + ";path=/;Max-Age=600;secure;HttpOnly"},
+       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER + ";path=/;Max-Age=" +
+           TEST_DEFAULT_CODE_VERIFIER_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
       {Http::Headers::get().Location.get(),
        "https://auth.example.com/oauth/"
        "authorize/?client_id=" +
@@ -3339,8 +3427,8 @@ TEST_F(OAuth2Test, CSRFSameSiteWithCookieDomain) {
        "OauthNonce=" + TEST_CSRF_TOKEN + ";domain=example.com;path=/;Max-Age=" +
            TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN + ";secure;HttpOnly;SameSite=Strict"},
       {Http::Headers::get().SetCookie.get(),
-       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER +
-           ";domain=example.com;path=/;Max-Age=600;secure;HttpOnly;SameSite=Lax"},
+       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER + ";domain=example.com;path=/;Max-Age=" +
+           TEST_DEFAULT_CODE_VERIFIER_TOKEN_EXPIRES_IN + ";secure;HttpOnly;SameSite=Lax"},
       {Http::Headers::get().Location.get(),
        "https://auth.example.com/oauth/"
        "authorize/?client_id=" +

--- a/test/extensions/filters/http/oauth2/filter_test.cc
+++ b/test/extensions/filters/http/oauth2/filter_test.cc
@@ -48,8 +48,6 @@ static const std::string TEST_CODE_VERIFIER = "Fc1bBwAAAAAVzVsHAAAAABXNWwcAAAAAF
 static const std::string TEST_ENCRYPTED_CODE_VERIFIER =
     "Fc1bBwAAAAAVzVsHAAAAABjf6i_Hvf8T2dEuEhPhhDNMlp16az-0dxisL-TzJKaZjOMF8nov_pG377FHmpKcsA";
 static const std::string TEST_CODE_CHALLENGE = "YRQaBq_UpkWzfr6JvtNnh7LMfmPVcIKVYdV98ugwmLY";
-static const std::string TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN = "600";
-static const std::string TEST_DEFAULT_CODE_VERIFIER_TOKEN_EXPIRES_IN = "600";
 
 namespace {
 Http::RegisterCustomInlineHeader<Http::CustomInlineHeaderRegistry::Type::RequestHeaders>
@@ -458,11 +456,9 @@ TEST_F(OAuth2Test, DefaultAuthScope) {
   Http::TestResponseHeaderMapImpl response_headers{
       {Http::Headers::get().Status.get(), "302"},
       {Http::Headers::get().SetCookie.get(),
-       "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=" + TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN +
-           ";secure;HttpOnly"},
+       "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=600;secure;HttpOnly"},
       {Http::Headers::get().SetCookie.get(),
-       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER +
-           ";path=/;Max-Age=" + TEST_DEFAULT_CODE_VERIFIER_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
+       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER + ";path=/;Max-Age=600;secure;HttpOnly"},
 
       {Http::Headers::get().Location.get(),
        "https://auth.example.com/oauth/"
@@ -535,8 +531,7 @@ TEST_F(OAuth2Test, CustomCsrfTokenExpiresIn) {
        "OauthNonce=" + TEST_CSRF_TOKEN +
            ";path=/;Max-Age=" + std::to_string(custom_csrf_token_expires_in) + ";secure;HttpOnly"},
       {Http::Headers::get().SetCookie.get(),
-       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER +
-           ";path=/;Max-Age=" + TEST_DEFAULT_CODE_VERIFIER_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
+       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER + ";path=/;Max-Age=600;secure;HttpOnly"},
       {Http::Headers::get().Location.get(),
        "https://auth.example.com/oauth/"
        "authorize/?client_id=" +
@@ -599,8 +594,7 @@ TEST_F(OAuth2Test, CustomCodeVerifierTokenExpiresIn) {
   Http::TestResponseHeaderMapImpl response_headers{
       {Http::Headers::get().Status.get(), "302"},
       {Http::Headers::get().SetCookie.get(),
-       "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=" + TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN +
-           ";secure;HttpOnly"},
+       "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=600;secure;HttpOnly"},
       {Http::Headers::get().SetCookie.get(),
        "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER + ";path=/;Max-Age=" +
            std::to_string(custom_code_verifier_token_expires_in) + ";secure;HttpOnly"},
@@ -659,11 +653,9 @@ TEST_F(OAuth2Test, PreservesQueryParametersInAuthorizationEndpoint) {
   Http::TestResponseHeaderMapImpl response_headers{
       {Http::Headers::get().Status.get(), "302"},
       {Http::Headers::get().SetCookie.get(),
-       "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=" + TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN +
-           ";secure;HttpOnly"},
+       "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=600;secure;HttpOnly"},
       {Http::Headers::get().SetCookie.get(),
-       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER +
-           ";path=/;Max-Age=" + TEST_DEFAULT_CODE_VERIFIER_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
+       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER + ";path=/;Max-Age=600;secure;HttpOnly"},
       {Http::Headers::get().Location.get(),
        "https://auth.example.com/oauth/"
        "authorize/?client_id=" +
@@ -719,11 +711,9 @@ TEST_F(OAuth2Test, PreservesQueryParametersInAuthorizationEndpointWithUrlEncodin
   Http::TestResponseHeaderMapImpl response_headers{
       {Http::Headers::get().Status.get(), "302"},
       {Http::Headers::get().SetCookie.get(),
-       "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=" + TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN +
-           ";secure;HttpOnly"},
+       "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=600;secure;HttpOnly"},
       {Http::Headers::get().SetCookie.get(),
-       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER +
-           ";path=/;Max-Age=" + TEST_DEFAULT_CODE_VERIFIER_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
+       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER + ";path=/;Max-Age=600;secure;HttpOnly"},
       {Http::Headers::get().Location.get(),
        "https://auth.example.com/oauth/"
        "authorize/?client_id=" +
@@ -982,11 +972,9 @@ TEST_F(OAuth2Test, SetBearerToken) {
   Http::TestRequestHeaderMapImpl request_headers{
       {Http::Headers::get().Path.get(), "/_oauth?code=123&state=" + TEST_ENCODED_STATE},
       {Http::Headers::get().Cookie.get(),
-       "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=" + TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN +
-           ";secure;HttpOnly"},
+       "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=600;secure;HttpOnly"},
       {Http::Headers::get().Cookie.get(),
-       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER +
-           ";path=/;Max-Age=" + TEST_DEFAULT_CODE_VERIFIER_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
+       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER + ";path=/;Max-Age=600;secure;HttpOnly"},
       {Http::Headers::get().Host.get(), "traffic.example.com"},
       {Http::Headers::get().Scheme.get(), "https"},
       {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
@@ -1055,11 +1043,9 @@ TEST_F(OAuth2Test, OAuthErrorNonOAuthHttpCallback) {
   Http::TestResponseHeaderMapImpl first_response_headers{
       {Http::Headers::get().Status.get(), "302"},
       {Http::Headers::get().SetCookie.get(),
-       "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=" + TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN +
-           ";secure;HttpOnly"},
+       "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=600;secure;HttpOnly"},
       {Http::Headers::get().SetCookie.get(),
-       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER +
-           ";path=/;Max-Age=" + TEST_DEFAULT_CODE_VERIFIER_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
+       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER + ";path=/;Max-Age=600;secure;HttpOnly"},
       {Http::Headers::get().Location.get(),
        "https://auth.example.com/oauth/"
        "authorize/?client_id=" +
@@ -1089,11 +1075,9 @@ TEST_F(OAuth2Test, OAuthErrorNonOAuthHttpCallback) {
   Http::TestRequestHeaderMapImpl second_request_headers{
       {Http::Headers::get().Path.get(), "/_oauth?code=123&state=" + TEST_ENCODED_STATE},
       {Http::Headers::get().Cookie.get(),
-       "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=" + TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN +
-           ";secure;HttpOnly"},
+       "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=600;secure;HttpOnly"},
       {Http::Headers::get().Cookie.get(),
-       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER +
-           ";path=/;Max-Age=" + TEST_DEFAULT_CODE_VERIFIER_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
+       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER + ";path=/;Max-Age=600;secure;HttpOnly"},
       {Http::Headers::get().Host.get(), "traffic.example.com"},
       {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
       {Http::Headers::get().Scheme.get(), "https"},
@@ -1186,11 +1170,9 @@ TEST_F(OAuth2Test, OAuthCallbackStartsAuthentication) {
   Http::TestRequestHeaderMapImpl request_headers{
       {Http::Headers::get().Path.get(), "/_oauth?code=123&state=" + TEST_ENCODED_STATE},
       {Http::Headers::get().Cookie.get(),
-       "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=" + TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN +
-           ";secure;HttpOnly"},
+       "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=600;secure;HttpOnly"},
       {Http::Headers::get().Cookie.get(),
-       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER +
-           ";path=/;Max-Age=" + TEST_DEFAULT_CODE_VERIFIER_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
+       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER + ";path=/;Max-Age=600;secure;HttpOnly"},
       {Http::Headers::get().Host.get(), "traffic.example.com"},
       {Http::Headers::get().Scheme.get(), "https"},
       {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
@@ -1219,11 +1201,9 @@ TEST_F(OAuth2Test, OAuthCallbackWithInvalidCodeVerifierCookie) {
   Http::TestRequestHeaderMapImpl request_headers{
       {Http::Headers::get().Path.get(), "/_oauth?code=123&state=" + TEST_ENCODED_STATE},
       {Http::Headers::get().Cookie.get(),
-       "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=" + TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN +
-           ";secure;HttpOnly"},
+       "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=600;secure;HttpOnly"},
       {Http::Headers::get().Cookie.get(),
-       "CodeVerifier=" + invalid_encrypted_code_verifier +
-           ";path=/;Max-Age=" + TEST_DEFAULT_CODE_VERIFIER_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
+       "CodeVerifier=" + invalid_encrypted_code_verifier + ";path=/;Max-Age=600;secure;HttpOnly"},
       {Http::Headers::get().Host.get(), "traffic.example.com"},
       {Http::Headers::get().Scheme.get(), "https"},
       {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
@@ -1249,8 +1229,7 @@ TEST_F(OAuth2Test, OAuthCallbackWithoutCodeVerifierCookie) {
   Http::TestRequestHeaderMapImpl request_headers{
       {Http::Headers::get().Path.get(), "/_oauth?code=123&state=" + TEST_ENCODED_STATE},
       {Http::Headers::get().Cookie.get(),
-       "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=" + TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN +
-           ";secure;HttpOnly"},
+       "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=600;secure;HttpOnly"},
       {Http::Headers::get().Host.get(), "traffic.example.com"},
       {Http::Headers::get().Scheme.get(), "https"},
       {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
@@ -1280,8 +1259,7 @@ TEST_F(OAuth2Test, OAuthCallbackStartsAuthenticationNoCsrfToken) {
   Http::TestRequestHeaderMapImpl request_headers{
       {Http::Headers::get().Path.get(), "/_oauth?code=123&state=" + state_without_csrf_token},
       {Http::Headers::get().Cookie.get(),
-       "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=" + TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN +
-           ";secure;HttpOnly"},
+       "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=600;secure;HttpOnly"},
       {Http::Headers::get().Host.get(), "traffic.example.com"},
       {Http::Headers::get().Scheme.get(), "https"},
       {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
@@ -1314,8 +1292,7 @@ TEST_F(OAuth2Test, OAuthCallbackStartsAuthenticationInvalidCsrfTokenWithoutDot) 
   Http::TestRequestHeaderMapImpl request_headers{
       {Http::Headers::get().Path.get(), "/_oauth?code=123&state=" + state_with_invalid_csrf_token},
       {Http::Headers::get().Cookie.get(),
-       "OauthNonce=" + invalid_csrf_token_cookie +
-           ";path=/;Max-Age=" + TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
+       "OauthNonce=" + invalid_csrf_token_cookie + ";path=/;Max-Age=600;secure;HttpOnly"},
       {Http::Headers::get().Host.get(), "traffic.example.com"},
       {Http::Headers::get().Scheme.get(), "https"},
       {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
@@ -1348,8 +1325,7 @@ TEST_F(OAuth2Test, OAuthCallbackStartsAuthenticationInvalidCsrfTokenInvalidHmac)
   Http::TestRequestHeaderMapImpl request_headers{
       {Http::Headers::get().Path.get(), "/_oauth?code=123&state=" + state_with_invalid_csrf_token},
       {Http::Headers::get().Cookie.get(),
-       "OauthNonce=" + invalid_csrf_token_cookie +
-           ";path=/;Max-Age=" + TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
+       "OauthNonce=" + invalid_csrf_token_cookie + ";path=/;Max-Age=600;secure;HttpOnly"},
       {Http::Headers::get().Host.get(), "traffic.example.com"},
       {Http::Headers::get().Scheme.get(), "https"},
       {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
@@ -1385,8 +1361,7 @@ TEST_F(OAuth2Test, OAuthCallbackStartsAuthenticationMalformedState) {
       {Http::Headers::get().Path.get(),
        "/_oauth?code=123&state=" + state_with_invalid_csrf_token_json},
       {Http::Headers::get().Cookie.get(),
-       "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=" + TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN +
-           ";secure;HttpOnly"},
+       "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=600;secure;HttpOnly"},
       {Http::Headers::get().Host.get(), "traffic.example.com"},
       {Http::Headers::get().Scheme.get(), "https"},
       {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
@@ -1425,11 +1400,9 @@ TEST_F(OAuth2Test, RedirectToOAuthServerWithInvalidCSRFToken) {
   Http::TestResponseHeaderMapImpl response_headers{
       {Http::Headers::get().Status.get(), "302"},
       {Http::Headers::get().SetCookie.get(),
-       "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=" + TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN +
-           ";secure;HttpOnly"},
+       "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=600;secure;HttpOnly"},
       {Http::Headers::get().SetCookie.get(),
-       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER +
-           ";path=/;Max-Age=" + TEST_DEFAULT_CODE_VERIFIER_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
+       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER + ";path=/;Max-Age=600;secure;HttpOnly"},
       {Http::Headers::get().Location.get(),
        "https://auth.example.com/oauth/"
        "authorize/?client_id=" +
@@ -1832,11 +1805,10 @@ TEST_F(OAuth2Test, OAuthTestFullFlowPostWithCookieDomain) {
   Http::TestResponseHeaderMapImpl first_response_headers{
       {Http::Headers::get().Status.get(), "302"},
       {Http::Headers::get().SetCookie.get(),
-       "OauthNonce=" + TEST_CSRF_TOKEN + ";domain=example.com;path=/;Max-Age=" +
-           TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
+       "OauthNonce=" + TEST_CSRF_TOKEN + ";domain=example.com;path=/;Max-Age=600;secure;HttpOnly"},
       {Http::Headers::get().SetCookie.get(),
-       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER + ";domain=example.com;path=/;Max-Age=" +
-           TEST_DEFAULT_CODE_VERIFIER_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
+       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER +
+           ";domain=example.com;path=/;Max-Age=600;secure;HttpOnly"},
       {Http::Headers::get().Location.get(),
        "https://auth.example.com/oauth/"
        "authorize/?client_id=" +
@@ -1866,11 +1838,10 @@ TEST_F(OAuth2Test, OAuthTestFullFlowPostWithCookieDomain) {
   // This represents the callback request from the authorization server.
   Http::TestRequestHeaderMapImpl second_request_headers{
       {Http::Headers::get().Cookie.get(),
-       "OauthNonce=" + TEST_CSRF_TOKEN + ";domain=example.com;path=/;Max-Age=" +
-           TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
+       "OauthNonce=" + TEST_CSRF_TOKEN + ";domain=example.com;path=/;Max-Age=600;secure;HttpOnly"},
       {Http::Headers::get().Cookie.get(),
-       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER + ";domain=example.com;path=/;Max-Age=" +
-           TEST_DEFAULT_CODE_VERIFIER_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
+       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER +
+           ";domain=example.com;path=/;Max-Age=600;secure;HttpOnly"},
       {Http::Headers::get().Path.get(), "/_oauth?code=123&state=" + TEST_ENCODED_STATE},
       {Http::Headers::get().Host.get(), "traffic.example.com"},
       {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
@@ -1947,11 +1918,9 @@ TEST_F(OAuth2Test, OAuthTestFullFlowPostWithSpecialCharactersForJson) {
   Http::TestResponseHeaderMapImpl first_response_headers{
       {Http::Headers::get().Status.get(), "302"},
       {Http::Headers::get().SetCookie.get(),
-       "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=" + TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN +
-           ";secure;HttpOnly"},
+       "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=600;secure;HttpOnly"},
       {Http::Headers::get().SetCookie.get(),
-       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER +
-           ";path=/;Max-Age=" + TEST_DEFAULT_CODE_VERIFIER_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
+       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER + ";path=/;Max-Age=600;secure;HttpOnly"},
       {Http::Headers::get().Location.get(),
        "https://auth.example.com/oauth/"
        "authorize/?client_id=" +
@@ -1983,11 +1952,9 @@ TEST_F(OAuth2Test, OAuthTestFullFlowPostWithSpecialCharactersForJson) {
   // This represents the callback request from the authorization server.
   Http::TestRequestHeaderMapImpl second_request_headers{
       {Http::Headers::get().Cookie.get(),
-       "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=" + TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN +
-           ";secure;HttpOnly"},
+       "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=600;secure;HttpOnly"},
       {Http::Headers::get().Cookie.get(),
-       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER +
-           ";path=/;Max-Age=" + TEST_DEFAULT_CODE_VERIFIER_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
+       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER + ";path=/;Max-Age=600;secure;HttpOnly"},
       {Http::Headers::get().Path.get(),
        "/_oauth?code=123&state=" + test_encoded_state_with_special_characters},
       {Http::Headers::get().Host.get(), "traffic.example.com"},
@@ -2731,11 +2698,9 @@ TEST_F(OAuth2Test, OAuthTestFullFlowWithUseRefreshToken) {
   Http::TestResponseHeaderMapImpl first_response_headers{
       {Http::Headers::get().Status.get(), "302"},
       {Http::Headers::get().SetCookie.get(),
-       "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=" + TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN +
-           ";secure;HttpOnly"},
+       "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=600;secure;HttpOnly"},
       {Http::Headers::get().SetCookie.get(),
-       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER +
-           ";path=/;Max-Age=" + TEST_DEFAULT_CODE_VERIFIER_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
+       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER + ";path=/;Max-Age=600;secure;HttpOnly"},
       {Http::Headers::get().Location.get(),
        "https://auth.example.com/oauth/"
        "authorize/?client_id=" +
@@ -2766,11 +2731,10 @@ TEST_F(OAuth2Test, OAuthTestFullFlowWithUseRefreshToken) {
   // This represents the callback request from the authorization server.
   Http::TestRequestHeaderMapImpl second_request_headers{
       {Http::Headers::get().Cookie.get(),
-       "OauthNonce=" + TEST_CSRF_TOKEN + ";domain=example.com;path=/;Max-Age=" +
-           TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
+       "OauthNonce=" + TEST_CSRF_TOKEN + ";domain=example.com;path=/;Max-Age=600;secure;HttpOnly"},
       {Http::Headers::get().Cookie.get(),
-       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER + ";domain=example.com;path=/;Max-Age=" +
-           TEST_DEFAULT_CODE_VERIFIER_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
+       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER +
+           ";domain=example.com;path=/;Max-Age=600;secure;HttpOnly"},
       {Http::Headers::get().Path.get(), "/_oauth?code=123&state=" + TEST_ENCODED_STATE},
       {Http::Headers::get().Host.get(), "traffic.example.com"},
       {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
@@ -2922,11 +2886,9 @@ TEST_F(OAuth2Test, OAuthTestRefreshAccessTokenFail) {
   Http::TestResponseHeaderMapImpl redirect_response_headers{
       {Http::Headers::get().Status.get(), "302"},
       {Http::Headers::get().SetCookie.get(),
-       "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=" + TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN +
-           ";secure;HttpOnly"},
+       "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=600;secure;HttpOnly"},
       {Http::Headers::get().SetCookie.get(),
-       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER +
-           ";path=/;Max-Age=" + TEST_DEFAULT_CODE_VERIFIER_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
+       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER + ";path=/;Max-Age=600;secure;HttpOnly"},
       {Http::Headers::get().Location.get(),
        "https://auth.example.com/oauth/"
        "authorize/?client_id=" +
@@ -3424,11 +3386,11 @@ TEST_F(OAuth2Test, CSRFSameSiteWithCookieDomain) {
   Http::TestResponseHeaderMapImpl first_response_headers{
       {Http::Headers::get().Status.get(), "302"},
       {Http::Headers::get().SetCookie.get(),
-       "OauthNonce=" + TEST_CSRF_TOKEN + ";domain=example.com;path=/;Max-Age=" +
-           TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN + ";secure;HttpOnly;SameSite=Strict"},
+       "OauthNonce=" + TEST_CSRF_TOKEN +
+           ";domain=example.com;path=/;Max-Age=600;secure;HttpOnly;SameSite=Strict"},
       {Http::Headers::get().SetCookie.get(),
-       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER + ";domain=example.com;path=/;Max-Age=" +
-           TEST_DEFAULT_CODE_VERIFIER_TOKEN_EXPIRES_IN + ";secure;HttpOnly;SameSite=Lax"},
+       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER +
+           ";domain=example.com;path=/;Max-Age=600;secure;HttpOnly;SameSite=Lax"},
       {Http::Headers::get().Location.get(),
        "https://auth.example.com/oauth/"
        "authorize/?client_id=" +
@@ -3476,8 +3438,7 @@ TEST_F(OAuth2Test, CookiesDeletedWhenTokensCleared) {
       {Http::Headers::get().Cookie.get(),
        "RefreshToken=some-refresh-token;path=/;Max-Age=604800;secure;HttpOnly;SameSite=Lax"},
       {Http::Headers::get().Cookie.get(),
-       "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=" + TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN +
-           ";secure;HttpOnly;SameSite=Strict"},
+       "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=600;secure;HttpOnly;SameSite=Strict"},
   };
 
   EXPECT_CALL(*validator_, setParams(_, _));

--- a/test/extensions/filters/http/oauth2/filter_test.cc
+++ b/test/extensions/filters/http/oauth2/filter_test.cc
@@ -458,11 +458,11 @@ TEST_F(OAuth2Test, DefaultAuthScope) {
   Http::TestResponseHeaderMapImpl response_headers{
       {Http::Headers::get().Status.get(), "302"},
       {Http::Headers::get().SetCookie.get(),
-       "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=" +
-           TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
+       "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=" + TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN +
+           ";secure;HttpOnly"},
       {Http::Headers::get().SetCookie.get(),
-       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER + ";path=/;Max-Age=" +
-           TEST_DEFAULT_CODE_VERIFIER_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
+       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER +
+           ";path=/;Max-Age=" + TEST_DEFAULT_CODE_VERIFIER_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
 
       {Http::Headers::get().Location.get(),
        "https://auth.example.com/oauth/"
@@ -532,11 +532,11 @@ TEST_F(OAuth2Test, CustomCsrfTokenExpiresIn) {
   Http::TestResponseHeaderMapImpl response_headers{
       {Http::Headers::get().Status.get(), "302"},
       {Http::Headers::get().SetCookie.get(),
-       "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=" +
-           std::to_string(custom_csrf_token_expires_in) + ";secure;HttpOnly"},
+       "OauthNonce=" + TEST_CSRF_TOKEN +
+           ";path=/;Max-Age=" + std::to_string(custom_csrf_token_expires_in) + ";secure;HttpOnly"},
       {Http::Headers::get().SetCookie.get(),
-       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER + ";path=/;Max-Age=" +
-           TEST_DEFAULT_CODE_VERIFIER_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
+       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER +
+           ";path=/;Max-Age=" + TEST_DEFAULT_CODE_VERIFIER_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
       {Http::Headers::get().Location.get(),
        "https://auth.example.com/oauth/"
        "authorize/?client_id=" +
@@ -599,8 +599,8 @@ TEST_F(OAuth2Test, CustomCodeVerifierTokenExpiresIn) {
   Http::TestResponseHeaderMapImpl response_headers{
       {Http::Headers::get().Status.get(), "302"},
       {Http::Headers::get().SetCookie.get(),
-       "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=" +
-           TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
+       "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=" + TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN +
+           ";secure;HttpOnly"},
       {Http::Headers::get().SetCookie.get(),
        "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER + ";path=/;Max-Age=" +
            std::to_string(custom_code_verifier_token_expires_in) + ";secure;HttpOnly"},
@@ -659,11 +659,11 @@ TEST_F(OAuth2Test, PreservesQueryParametersInAuthorizationEndpoint) {
   Http::TestResponseHeaderMapImpl response_headers{
       {Http::Headers::get().Status.get(), "302"},
       {Http::Headers::get().SetCookie.get(),
-       "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=" +
-           TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
+       "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=" + TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN +
+           ";secure;HttpOnly"},
       {Http::Headers::get().SetCookie.get(),
-       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER + ";path=/;Max-Age=" +
-           TEST_DEFAULT_CODE_VERIFIER_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
+       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER +
+           ";path=/;Max-Age=" + TEST_DEFAULT_CODE_VERIFIER_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
       {Http::Headers::get().Location.get(),
        "https://auth.example.com/oauth/"
        "authorize/?client_id=" +
@@ -719,11 +719,11 @@ TEST_F(OAuth2Test, PreservesQueryParametersInAuthorizationEndpointWithUrlEncodin
   Http::TestResponseHeaderMapImpl response_headers{
       {Http::Headers::get().Status.get(), "302"},
       {Http::Headers::get().SetCookie.get(),
-       "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=" +
-           TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
+       "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=" + TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN +
+           ";secure;HttpOnly"},
       {Http::Headers::get().SetCookie.get(),
-       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER + ";path=/;Max-Age=" +
-           TEST_DEFAULT_CODE_VERIFIER_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
+       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER +
+           ";path=/;Max-Age=" + TEST_DEFAULT_CODE_VERIFIER_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
       {Http::Headers::get().Location.get(),
        "https://auth.example.com/oauth/"
        "authorize/?client_id=" +
@@ -982,11 +982,11 @@ TEST_F(OAuth2Test, SetBearerToken) {
   Http::TestRequestHeaderMapImpl request_headers{
       {Http::Headers::get().Path.get(), "/_oauth?code=123&state=" + TEST_ENCODED_STATE},
       {Http::Headers::get().Cookie.get(),
-       "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=" +
-           TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
+       "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=" + TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN +
+           ";secure;HttpOnly"},
       {Http::Headers::get().Cookie.get(),
-       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER + ";path=/;Max-Age=" +
-           TEST_DEFAULT_CODE_VERIFIER_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
+       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER +
+           ";path=/;Max-Age=" + TEST_DEFAULT_CODE_VERIFIER_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
       {Http::Headers::get().Host.get(), "traffic.example.com"},
       {Http::Headers::get().Scheme.get(), "https"},
       {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
@@ -1055,11 +1055,11 @@ TEST_F(OAuth2Test, OAuthErrorNonOAuthHttpCallback) {
   Http::TestResponseHeaderMapImpl first_response_headers{
       {Http::Headers::get().Status.get(), "302"},
       {Http::Headers::get().SetCookie.get(),
-       "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=" +
-           TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
+       "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=" + TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN +
+           ";secure;HttpOnly"},
       {Http::Headers::get().SetCookie.get(),
-       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER + ";path=/;Max-Age=" +
-           TEST_DEFAULT_CODE_VERIFIER_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
+       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER +
+           ";path=/;Max-Age=" + TEST_DEFAULT_CODE_VERIFIER_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
       {Http::Headers::get().Location.get(),
        "https://auth.example.com/oauth/"
        "authorize/?client_id=" +
@@ -1089,11 +1089,11 @@ TEST_F(OAuth2Test, OAuthErrorNonOAuthHttpCallback) {
   Http::TestRequestHeaderMapImpl second_request_headers{
       {Http::Headers::get().Path.get(), "/_oauth?code=123&state=" + TEST_ENCODED_STATE},
       {Http::Headers::get().Cookie.get(),
-       "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=" +
-           TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
+       "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=" + TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN +
+           ";secure;HttpOnly"},
       {Http::Headers::get().Cookie.get(),
-       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER + ";path=/;Max-Age=" +
-           TEST_DEFAULT_CODE_VERIFIER_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
+       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER +
+           ";path=/;Max-Age=" + TEST_DEFAULT_CODE_VERIFIER_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
       {Http::Headers::get().Host.get(), "traffic.example.com"},
       {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
       {Http::Headers::get().Scheme.get(), "https"},
@@ -1186,11 +1186,11 @@ TEST_F(OAuth2Test, OAuthCallbackStartsAuthentication) {
   Http::TestRequestHeaderMapImpl request_headers{
       {Http::Headers::get().Path.get(), "/_oauth?code=123&state=" + TEST_ENCODED_STATE},
       {Http::Headers::get().Cookie.get(),
-       "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=" +
-           TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
+       "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=" + TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN +
+           ";secure;HttpOnly"},
       {Http::Headers::get().Cookie.get(),
-       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER + ";path=/;Max-Age=" +
-           TEST_DEFAULT_CODE_VERIFIER_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
+       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER +
+           ";path=/;Max-Age=" + TEST_DEFAULT_CODE_VERIFIER_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
       {Http::Headers::get().Host.get(), "traffic.example.com"},
       {Http::Headers::get().Scheme.get(), "https"},
       {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
@@ -1219,11 +1219,11 @@ TEST_F(OAuth2Test, OAuthCallbackWithInvalidCodeVerifierCookie) {
   Http::TestRequestHeaderMapImpl request_headers{
       {Http::Headers::get().Path.get(), "/_oauth?code=123&state=" + TEST_ENCODED_STATE},
       {Http::Headers::get().Cookie.get(),
-       "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=" +
-           TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
+       "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=" + TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN +
+           ";secure;HttpOnly"},
       {Http::Headers::get().Cookie.get(),
-       "CodeVerifier=" + invalid_encrypted_code_verifier + ";path=/;Max-Age=" +
-           TEST_DEFAULT_CODE_VERIFIER_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
+       "CodeVerifier=" + invalid_encrypted_code_verifier +
+           ";path=/;Max-Age=" + TEST_DEFAULT_CODE_VERIFIER_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
       {Http::Headers::get().Host.get(), "traffic.example.com"},
       {Http::Headers::get().Scheme.get(), "https"},
       {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
@@ -1249,8 +1249,8 @@ TEST_F(OAuth2Test, OAuthCallbackWithoutCodeVerifierCookie) {
   Http::TestRequestHeaderMapImpl request_headers{
       {Http::Headers::get().Path.get(), "/_oauth?code=123&state=" + TEST_ENCODED_STATE},
       {Http::Headers::get().Cookie.get(),
-       "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=" +
-           TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
+       "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=" + TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN +
+           ";secure;HttpOnly"},
       {Http::Headers::get().Host.get(), "traffic.example.com"},
       {Http::Headers::get().Scheme.get(), "https"},
       {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
@@ -1280,8 +1280,8 @@ TEST_F(OAuth2Test, OAuthCallbackStartsAuthenticationNoCsrfToken) {
   Http::TestRequestHeaderMapImpl request_headers{
       {Http::Headers::get().Path.get(), "/_oauth?code=123&state=" + state_without_csrf_token},
       {Http::Headers::get().Cookie.get(),
-       "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=" +
-           TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
+       "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=" + TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN +
+           ";secure;HttpOnly"},
       {Http::Headers::get().Host.get(), "traffic.example.com"},
       {Http::Headers::get().Scheme.get(), "https"},
       {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
@@ -1314,8 +1314,8 @@ TEST_F(OAuth2Test, OAuthCallbackStartsAuthenticationInvalidCsrfTokenWithoutDot) 
   Http::TestRequestHeaderMapImpl request_headers{
       {Http::Headers::get().Path.get(), "/_oauth?code=123&state=" + state_with_invalid_csrf_token},
       {Http::Headers::get().Cookie.get(),
-       "OauthNonce=" + invalid_csrf_token_cookie + ";path=/;Max-Age=" +
-           TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
+       "OauthNonce=" + invalid_csrf_token_cookie +
+           ";path=/;Max-Age=" + TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
       {Http::Headers::get().Host.get(), "traffic.example.com"},
       {Http::Headers::get().Scheme.get(), "https"},
       {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
@@ -1348,8 +1348,8 @@ TEST_F(OAuth2Test, OAuthCallbackStartsAuthenticationInvalidCsrfTokenInvalidHmac)
   Http::TestRequestHeaderMapImpl request_headers{
       {Http::Headers::get().Path.get(), "/_oauth?code=123&state=" + state_with_invalid_csrf_token},
       {Http::Headers::get().Cookie.get(),
-       "OauthNonce=" + invalid_csrf_token_cookie + ";path=/;Max-Age=" +
-           TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
+       "OauthNonce=" + invalid_csrf_token_cookie +
+           ";path=/;Max-Age=" + TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
       {Http::Headers::get().Host.get(), "traffic.example.com"},
       {Http::Headers::get().Scheme.get(), "https"},
       {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
@@ -1385,8 +1385,8 @@ TEST_F(OAuth2Test, OAuthCallbackStartsAuthenticationMalformedState) {
       {Http::Headers::get().Path.get(),
        "/_oauth?code=123&state=" + state_with_invalid_csrf_token_json},
       {Http::Headers::get().Cookie.get(),
-       "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=" +
-           TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
+       "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=" + TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN +
+           ";secure;HttpOnly"},
       {Http::Headers::get().Host.get(), "traffic.example.com"},
       {Http::Headers::get().Scheme.get(), "https"},
       {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
@@ -1425,11 +1425,11 @@ TEST_F(OAuth2Test, RedirectToOAuthServerWithInvalidCSRFToken) {
   Http::TestResponseHeaderMapImpl response_headers{
       {Http::Headers::get().Status.get(), "302"},
       {Http::Headers::get().SetCookie.get(),
-       "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=" +
-           TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
+       "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=" + TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN +
+           ";secure;HttpOnly"},
       {Http::Headers::get().SetCookie.get(),
-       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER + ";path=/;Max-Age=" +
-           TEST_DEFAULT_CODE_VERIFIER_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
+       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER +
+           ";path=/;Max-Age=" + TEST_DEFAULT_CODE_VERIFIER_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
       {Http::Headers::get().Location.get(),
        "https://auth.example.com/oauth/"
        "authorize/?client_id=" +
@@ -1947,11 +1947,11 @@ TEST_F(OAuth2Test, OAuthTestFullFlowPostWithSpecialCharactersForJson) {
   Http::TestResponseHeaderMapImpl first_response_headers{
       {Http::Headers::get().Status.get(), "302"},
       {Http::Headers::get().SetCookie.get(),
-       "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=" +
-           TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
+       "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=" + TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN +
+           ";secure;HttpOnly"},
       {Http::Headers::get().SetCookie.get(),
-       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER + ";path=/;Max-Age=" +
-           TEST_DEFAULT_CODE_VERIFIER_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
+       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER +
+           ";path=/;Max-Age=" + TEST_DEFAULT_CODE_VERIFIER_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
       {Http::Headers::get().Location.get(),
        "https://auth.example.com/oauth/"
        "authorize/?client_id=" +
@@ -1983,11 +1983,11 @@ TEST_F(OAuth2Test, OAuthTestFullFlowPostWithSpecialCharactersForJson) {
   // This represents the callback request from the authorization server.
   Http::TestRequestHeaderMapImpl second_request_headers{
       {Http::Headers::get().Cookie.get(),
-       "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=" +
-           TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
+       "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=" + TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN +
+           ";secure;HttpOnly"},
       {Http::Headers::get().Cookie.get(),
-       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER + ";path=/;Max-Age=" +
-           TEST_DEFAULT_CODE_VERIFIER_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
+       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER +
+           ";path=/;Max-Age=" + TEST_DEFAULT_CODE_VERIFIER_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
       {Http::Headers::get().Path.get(),
        "/_oauth?code=123&state=" + test_encoded_state_with_special_characters},
       {Http::Headers::get().Host.get(), "traffic.example.com"},
@@ -2731,11 +2731,11 @@ TEST_F(OAuth2Test, OAuthTestFullFlowWithUseRefreshToken) {
   Http::TestResponseHeaderMapImpl first_response_headers{
       {Http::Headers::get().Status.get(), "302"},
       {Http::Headers::get().SetCookie.get(),
-       "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=" +
-           TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
+       "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=" + TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN +
+           ";secure;HttpOnly"},
       {Http::Headers::get().SetCookie.get(),
-       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER + ";path=/;Max-Age=" +
-           TEST_DEFAULT_CODE_VERIFIER_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
+       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER +
+           ";path=/;Max-Age=" + TEST_DEFAULT_CODE_VERIFIER_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
       {Http::Headers::get().Location.get(),
        "https://auth.example.com/oauth/"
        "authorize/?client_id=" +
@@ -2922,11 +2922,11 @@ TEST_F(OAuth2Test, OAuthTestRefreshAccessTokenFail) {
   Http::TestResponseHeaderMapImpl redirect_response_headers{
       {Http::Headers::get().Status.get(), "302"},
       {Http::Headers::get().SetCookie.get(),
-       "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=" +
-           TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
+       "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=" + TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN +
+           ";secure;HttpOnly"},
       {Http::Headers::get().SetCookie.get(),
-       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER + ";path=/;Max-Age=" +
-           TEST_DEFAULT_CODE_VERIFIER_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
+       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER +
+           ";path=/;Max-Age=" + TEST_DEFAULT_CODE_VERIFIER_TOKEN_EXPIRES_IN + ";secure;HttpOnly"},
       {Http::Headers::get().Location.get(),
        "https://auth.example.com/oauth/"
        "authorize/?client_id=" +
@@ -3476,8 +3476,8 @@ TEST_F(OAuth2Test, CookiesDeletedWhenTokensCleared) {
       {Http::Headers::get().Cookie.get(),
        "RefreshToken=some-refresh-token;path=/;Max-Age=604800;secure;HttpOnly;SameSite=Lax"},
       {Http::Headers::get().Cookie.get(),
-       "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=" +
-           TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN + ";secure;HttpOnly;SameSite=Strict"},
+       "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=" + TEST_DEFAULT_CSRF_TOKEN_EXPIRES_IN +
+           ";secure;HttpOnly;SameSite=Strict"},
   };
 
   EXPECT_CALL(*validator_, setParams(_, _));


### PR DESCRIPTION
Commit Message: oauth2: make CSRF and code verifier token expiration configurable

Additional Description: Currently, the OAuth2 filter hardcodes the values of the CSRF and code verifier tokens to `600s` (10 minutes) . This limits flexibility for use cases where:

- Users need shorter expiration (e.g., high-security scenarios).
- Users need longer expiration (e.g., backward-compatibility).

This PR makes both tokens configurable, adding `default_csrf_token_expires_in` and `default_code_verifier_token_expires_in` fields to the OAuth2 filter configuration. Both default to ``600s`` (10 minutes) if not specified, keeping backward compatibility.

Risk Level: Low
Testing: Added tests for cases where uses sets the values of the new fields in the configuration. The default values are already tested in almost all the tests.
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
