### PR TITLE
coverage: adjusting coverage numbers to reflect current state

### DIFF
--- a/test/coverage.yaml
+++ b/test/coverage.yaml
@@ -7,36 +7,36 @@ directories:
   source/common/api: 95.3  # some syscalls require sandboxing
   source/common/api/posix: 94.9  # setns requires Linux CAP_NET_ADMIN privileges
   source/common/common/posix: 96.2  # flaky due to posix: be careful adjusting
-  source/common/config: 96.4
+  source/common/config: 96.5
   source/common/crypto: 95.5
-  source/common/event: 95.6  # Emulated edge events guards don't report LCOV
-  source/common/filesystem/posix: 96.3  # FileReadToEndNotReadable fails in some env; createPath can't test all failure branches.
-  source/common/http/http2: 96.1
+  source/common/event: 98.3  # Emulated edge events guards don't report LCOV
+  source/common/filesystem/posix: 96.4  # FileReadToEndNotReadable fails in some env; createPath can't test all failure branches.
+  source/common/http/http2: 96.6
   source/common/json: 95.2
-  source/common/matcher: 94.7
-  source/common/memory: 74.5  # tcmalloc code path is not enabled in coverage build, only gperf tcmalloc, see PR#32589
+  source/common/matcher: 95.0
+  source/common/memory: 98.1  # tcmalloc code path is not enabled in coverage build, only gperf tcmalloc, see PR#32589
   source/common/network: 94.3  # Flaky, `activateFileEvents`, `startSecureTransport` and `ioctl`, listener_socket do not always report LCOV
   source/common/network/dns_resolver: 91.4   # A few lines of MacOS code not tested in linux scripts. Tested in MacOS scripts
-  source/common/quic: 93.0
-  source/common/signal: 87.2  # Death tests don't report LCOV
+  source/common/quic: 93.4
+  source/common/signal: 87.4  # Death tests don't report LCOV
   source/common/thread: 0.0  # Death tests don't report LCOV
   source/common/tls: 94.4  # FIPS code paths impossible to trigger on non-FIPS builds and vice versa
-  source/common/tls/cert_validator: 94.7
+  source/common/tls/cert_validator: 95.0
   source/common/tls/private_key: 88.9
   source/common/tracing: 95.4
-  source/common/watchdog: 58.6  # Death tests don't report LCOV
-  source/exe: 94.2  # increased by #32346, need coverage for terminate_handler and hot restart failures
+  source/common/watchdog: 60.0  # Death tests don't report LCOV
+  source/exe: 94.4  # increased by #32346, need coverage for terminate_handler and hot restart failures
   source/extensions/api_listeners: 55.0  # Many IS_ENVOY_BUG are not covered.
   source/extensions/api_listeners/default_api_listener: 55.0  # Many IS_ENVOY_BUG are not covered.
-  source/extensions/common/aws: 96.3
-  source/extensions/common/aws/credential_providers: 94.4
-  source/extensions/common/proxy_protocol: 93.8  # Adjusted for security patch
-  source/extensions/common/tap: 94.6
+  source/extensions/common/aws: 98.5
+  source/extensions/common/aws/credential_providers: 100.0
+  source/extensions/common/proxy_protocol: 94.6  # Adjusted for security patch
+  source/extensions/common/tap: 95.0
   source/extensions/common/wasm: 95.3  # flaky: be careful adjusting
-  source/extensions/common/wasm/ext: 92.0
+  source/extensions/common/wasm/ext: 100.0
   source/extensions/filters/common: 97.1
   source/extensions/filters/common/fault: 94.5
-  source/extensions/filters/common/rbac: 92.6
+  source/extensions/filters/common/rbac: 93.2
   source/extensions/filters/common/lua: 95.7
   source/extensions/filters/http/cache: 95.9
   source/extensions/filters/http/dynamic_forward_proxy: 94.3
@@ -44,9 +44,9 @@ directories:
   source/extensions/filters/http/ext_proc: 96.5
   source/extensions/filters/http/grpc_json_reverse_transcoder: 94.8
   source/extensions/filters/http/grpc_json_transcoder: 94.0  # TODO(#28232)
-  source/extensions/filters/http/ip_tagging: 90.6
+  source/extensions/filters/http/ip_tagging: 95.9
   source/extensions/filters/http/kill_request: 91.7  # Death tests don't report LCOV
-  source/extensions/filters/http/oauth2: 96.4
+  source/extensions/filters/http/oauth2: 97.6
   source/extensions/filters/listener: 96.5
   source/extensions/filters/listener/original_src: 92.1
   source/extensions/filters/listener/tls_inspector: 94.0
@@ -54,28 +54,28 @@ directories:
   source/extensions/filters/network/mongo_proxy: 96.1
   source/extensions/filters/network/sni_cluster: 88.9
   source/extensions/internal_redirect: 86.2
-  source/extensions/internal_redirect/safe_cross_scheme: 81.2
+  source/extensions/internal_redirect/safe_cross_scheme: 81.3
   source/extensions/internal_redirect/allow_listed_routes: 85.7
   source/extensions/internal_redirect/previous_routes: 89.3
-  source/extensions/load_balancing_policies/maglev: 90.7
+  source/extensions/load_balancing_policies/maglev: 94.8
   source/extensions/load_balancing_policies/round_robin: 96.4
-  source/extensions/load_balancing_policies/ring_hash: 96.2
+  source/extensions/load_balancing_policies/ring_hash: 96.9
   source/extensions/rate_limit_descriptors: 95.0
-  source/extensions/rate_limit_descriptors/expr: 95.0
+  source/extensions/rate_limit_descriptors/expr: 95.2
   source/extensions/stat_sinks/graphite_statsd: 82.8  # Death tests don't report LCOV
   source/extensions/stat_sinks/statsd: 85.2  # Death tests don't report LCOV
-  source/extensions/tracers/zipkin: 95.8
+  source/extensions/tracers/zipkin: 95.9
   source/extensions/transport_sockets/proxy_protocol: 96.2
   source/extensions/wasm_runtime/wamr: 0.0  # Not enabled in coverage build
   source/extensions/wasm_runtime/wasmtime: 0.0  # Not enabled in coverage build
   source/extensions/watchdog: 83.3  # Death tests within extensions
   source/extensions/listener_managers: 77.3
   source/extensions/listener_managers/validation_listener_manager: 77.3
-  source/extensions/watchdog/profile_action: 83.3
+  source/extensions/watchdog/profile_action: 86.1
   source/server: 91.0  # flaky: be careful adjusting. See https://github.com/envoyproxy/envoy/issues/15239
   source/server/config_validation: 92.3
   source/extensions/health_checkers: 96.1
-  source/extensions/health_checkers/http: 93.9
-  source/extensions/health_checkers/grpc: 92.1
-  source/extensions/config_subscription/rest: 94.8
+  source/extensions/health_checkers/http: 94.2
+  source/extensions/health_checkers/grpc: 92.3
+  source/extensions/config_subscription/rest: 94.9
   source/extensions/matching/input_matchers/cel_matcher: 91.3  # Death tests don't report LCOV


### PR DESCRIPTION
## Description

This PR bumps up the coverage numbers for some existing directories to reflect the current state.

---

**Commit Message:** coverage: adjusting coverage numbers to reflect current state
**Additional Description:** Adjusting coverage numbers for some existing directories to reflect the current state.
**Risk Level:** N/A
**Testing:** CI
**Docs Changes:** N/A
**Release Notes:** N/A