### PR TITLE
ext_proc: reference the service-method to avoid copying it

### DIFF
--- a/source/extensions/filters/http/ext_proc/client_impl.cc
+++ b/source/extensions/filters/http/ext_proc/client_impl.cc
@@ -9,7 +9,8 @@ namespace ExternalProcessing {
 
 ExternalProcessorClientPtr createExternalProcessorClient(Grpc::AsyncClientManager& client_manager,
                                                          Stats::Scope& scope) {
-  static constexpr char kExternalMethod[] = "envoy.service.ext_proc.v3.ExternalProcessor.Process";
+  static constexpr absl::string_view kExternalMethod =
+      "envoy.service.ext_proc.v3.ExternalProcessor.Process";
   return std::make_unique<
       CommonExtProc::ProcessorClientImpl<ProcessingRequest, ProcessingResponse>>(
       client_manager, scope, kExternalMethod);

--- a/source/extensions/filters/network/ext_proc/client_impl.cc
+++ b/source/extensions/filters/network/ext_proc/client_impl.cc
@@ -9,7 +9,7 @@ namespace ExtProc {
 
 ExternalProcessorClientPtr createExternalProcessorClient(Grpc::AsyncClientManager& client_manager,
                                                          Stats::Scope& scope) {
-  static constexpr char kExternalMethod[] =
+  static constexpr absl::string_view kExternalMethod[] =
       "envoy.service.network_ext_proc.v3.NetworkExternalProcessor.Process";
   return std::make_unique<
       CommonExtProc::ProcessorClientImpl<ProcessingRequest, ProcessingResponse>>(

--- a/source/extensions/filters/network/ext_proc/client_impl.cc
+++ b/source/extensions/filters/network/ext_proc/client_impl.cc
@@ -9,7 +9,7 @@ namespace ExtProc {
 
 ExternalProcessorClientPtr createExternalProcessorClient(Grpc::AsyncClientManager& client_manager,
                                                          Stats::Scope& scope) {
-  static constexpr absl::string_view kExternalMethod[] =
+  static constexpr absl::string_view kExternalMethod =
       "envoy.service.network_ext_proc.v3.NetworkExternalProcessor.Process";
   return std::make_unique<
       CommonExtProc::ProcessorClientImpl<ProcessingRequest, ProcessingResponse>>(


### PR DESCRIPTION
Commit Message: ext_proc: reference the service-method to avoid copying it
Additional Description:
ext-proc's service-method are statically defined in Envoy's code base.
Instead of copying it over to different objects, this PR now uses a string_view to reference the service-method.

Risk Level: low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A