### PR TITLE
ext-proc: remove unused data-member

### DIFF
--- a/source/extensions/filters/common/ext_proc/grpc_client_impl.h
+++ b/source/extensions/filters/common/ext_proc/grpc_client_impl.h
@@ -84,7 +84,6 @@ private:
   OptRef<ProcessorCallbacks<ResponseType>> callbacks_;
   Grpc::AsyncClient<RequestType, ResponseType> client_;
   Grpc::AsyncStream<RequestType> stream_;
-  Http::AsyncClient::ParentContext grpc_context_;
   bool stream_closed_ = false;
   // Service method name
   const std::string service_method_;
@@ -120,7 +119,6 @@ bool ProcessorStreamImpl<RequestType, ResponseType>::startStream(
     const Http::AsyncClient::StreamOptions& options) {
   client_ = std::move(client);
   auto descriptor = Protobuf::DescriptorPool::generated_pool()->FindMethodByName(service_method_);
-  grpc_context_ = options.parent_context;
   stream_ = client_.start(*descriptor, *this, options);
   // Returns true if the start succeeded and returns false on start failure.
   return stream_ != nullptr;


### PR DESCRIPTION
Commit Message: ext-proc: remove unused data-member
Additional Description:
Removing the unused `grpc_context_` data member.

Risk Level: low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A