### PR TITLE
Replace c-ares with getAddrInfo DNS resolver in DFP integration tests

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -46,6 +46,12 @@ minor_behavior_changes:
   change: |
     Allow ``getaddrinfo`` to be configured to run by a thread pool, controlled by :ref:`num_resolver_threads
     <envoy_v3_api_field_extensions.network.dns_resolver.getaddrinfo.v3.GetAddrInfoDnsResolverConfig.num_resolver_threads>`.
+- area: dns
+  change: |
+    Honor the default DNS resolver configuration in bootstrap
+    :ref:`typed_dns_resolver_config <envoy_v3_api_field_config.bootstrap.v3.Bootstrap.typed_dns_resolver_config>`
+    if the DNS cache configuration in the dynamic forward proxy filter is empty
+    :ref:`dns_cache_config <envoy_v3_api_field_extensions.filters.http.dynamic_forward_proxy.v3.FilterConfig.dns_cache_config>`
 - area: grpc-json-transcoding
   change: |
     Add SSE style message framing for streamed responses in :ref:`gRPC JSON transcoder filter <config_http_filters_grpc_json_transcoder>`.

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -48,10 +48,10 @@ minor_behavior_changes:
     <envoy_v3_api_field_extensions.network.dns_resolver.getaddrinfo.v3.GetAddrInfoDnsResolverConfig.num_resolver_threads>`.
 - area: dns
   change: |
-    Honor the default DNS resolver configuration in bootstrap
+    Honor the default DNS resolver configuration in the bootstrap config
     :ref:`typed_dns_resolver_config <envoy_v3_api_field_config.bootstrap.v3.Bootstrap.typed_dns_resolver_config>`
     if the DNS cache configuration in the dynamic forward proxy filter is empty
-    :ref:`dns_cache_config <envoy_v3_api_field_extensions.filters.http.dynamic_forward_proxy.v3.FilterConfig.dns_cache_config>`
+    :ref:`dns_cache_config <envoy_v3_api_field_extensions.filters.http.dynamic_forward_proxy.v3.FilterConfig.dns_cache_config>`.
 - area: grpc-json-transcoding
   change: |
     Add SSE style message framing for streamed responses in :ref:`gRPC JSON transcoder filter <config_http_filters_grpc_json_transcoder>`.

--- a/source/extensions/common/dynamic_forward_proxy/dns_cache_impl.cc
+++ b/source/extensions/common/dynamic_forward_proxy/dns_cache_impl.cc
@@ -93,7 +93,8 @@ absl::StatusOr<Network::DnsResolverSharedPtr> DnsCacheImpl::selectDnsResolver(
   Network::DnsResolverFactory* dns_resolver_factory;
 
   if (!config.use_tcp_for_dns_lookups() && !config.has_typed_dns_resolver_config() &&
-      !config.has_dns_resolution_config()) {
+      !config.has_dns_resolution_config() &&
+      context.api().bootstrap().has_typed_dns_resolver_config()) {
     typed_dns_resolver_config = context.api().bootstrap().typed_dns_resolver_config();
     dns_resolver_factory =
         &Network::createDnsResolverFactoryFromTypedConfig(typed_dns_resolver_config);

--- a/source/extensions/common/dynamic_forward_proxy/dns_cache_impl.cc
+++ b/source/extensions/common/dynamic_forward_proxy/dns_cache_impl.cc
@@ -93,10 +93,11 @@ absl::StatusOr<Network::DnsResolverSharedPtr> DnsCacheImpl::selectDnsResolver(
   Network::DnsResolverFactory* dns_resolver_factory;
 
   // If DnsCacheConfig doesn't have any DNS related configuration, and the
-  // the default DNS resolver, i.e, the typed_dns_resolver_config in bootstrap
-  // configuration, is not empty, use it.
+  // default DNS resolver, i.e, the typed_dns_resolver_config in the bootstrap
+  // configuration, is not empty, then creates the default DNS resolver.
   if (!config.has_typed_dns_resolver_config() && !config.has_dns_resolution_config() &&
-      context.api().bootstrap().has_typed_dns_resolver_config()) {
+      context.api().bootstrap().has_typed_dns_resolver_config() &&
+      !(context.api().bootstrap().typed_dns_resolver_config().typed_config().type_url().empty())) {
     typed_dns_resolver_config = context.api().bootstrap().typed_dns_resolver_config();
     dns_resolver_factory =
         &Network::createDnsResolverFactoryFromTypedConfig(typed_dns_resolver_config);

--- a/source/extensions/common/dynamic_forward_proxy/dns_cache_impl.cc
+++ b/source/extensions/common/dynamic_forward_proxy/dns_cache_impl.cc
@@ -92,8 +92,10 @@ absl::StatusOr<Network::DnsResolverSharedPtr> DnsCacheImpl::selectDnsResolver(
   envoy::config::core::v3::TypedExtensionConfig typed_dns_resolver_config;
   Network::DnsResolverFactory* dns_resolver_factory;
 
-  if (!config.use_tcp_for_dns_lookups() && !config.has_typed_dns_resolver_config() &&
-      !config.has_dns_resolution_config() &&
+  // If DnsCacheConfig doesn't have any DNS related configuration, and the
+  // the default DNS resolver, i.e, the typed_dns_resolver_config in bootstrap
+  // configuration, is not empty, use it.
+  if (!config.has_typed_dns_resolver_config() && !config.has_dns_resolution_config() &&
       context.api().bootstrap().has_typed_dns_resolver_config()) {
     typed_dns_resolver_config = context.api().bootstrap().typed_dns_resolver_config();
     dns_resolver_factory =


### PR DESCRIPTION
Replace c-ares with getAddrInfo DNS resolver in DFP integration tests.

It's the 1st step to address: https://github.com/envoyproxy/envoy/issues/39900

This PR also changed DFP cluster DNS resolver creating behavior to honor default DNS resolver configuration in bootstrap. Such behavior exists for strict and logical DNS clusters as here: https://github.com/envoyproxy/envoy/blob/83b36ea36575d09740cf7b1de909bdc603423212/source/common/upstream/cluster_factory_impl.cc#L106.    
The other issue is that currently: DFP sub_cluster_config feature does not support customized DNS resolver configuration as described in https://github.com/envoyproxy/envoy/issues/39694.  By honoring bootstrap default DNS resolver here, it also solved that problem.  Otherwise, when DFP sub_cluster_config is configured, Envoy always creates c-ares DNS resolver as described in this issue. 