### PR TITLE
tls-inspector: Use max tls client hello size from boring ssl

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -96,6 +96,11 @@ bug_fixes:
     Fixes a bug where empty trusted CA file or inline string is accepted and causes Envoy to successfully validate any certificate
     chain. This fix addresses this issue by rejecting such configuration with empty value. This behavior can be reverted by setting
     the runtime guard ``envoy.reloadable_features.reject_empty_trusted_ca_file`` to ``false``.
+- area: tls_inspector
+  change: |
+    Fixes a bug where the TLS inspector filter would not correctly report client_hello_too_large_ stat for too big client hello messages
+    i.e bigger than 16kb.
+
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -98,7 +98,7 @@ bug_fixes:
     the runtime guard ``envoy.reloadable_features.reject_empty_trusted_ca_file`` to ``false``.
 - area: tls_inspector
   change: |
-    Fixes a bug where the TLS inspector filter would not correctly report client_hello_too_large_ stat for too big client hello messages
+    Fixes a bug where the TLS inspector filter would not correctly report ``client_hello_too_large`` stat for too big client hello messages
     i.e bigger than 16kb.
 
 

--- a/source/extensions/filters/listener/tls_inspector/tls_inspector.cc
+++ b/source/extensions/filters/listener/tls_inspector/tls_inspector.cc
@@ -214,7 +214,7 @@ ParseState Filter::parseClientHello(const void* data, size_t len,
         }
         cb_->socket().setDetectedTransportProtocol("tls");
       } else {
-        if (read_ == maxConfigReadBytes()) {
+        if (read_ >= maxConfigReadBytes()) {
           // We've hit the specified size limit. This is an unreasonably large ClientHello;
           // indicate failure.
           config_->stats().client_hello_too_large_.inc();

--- a/source/extensions/filters/listener/tls_inspector/tls_inspector.cc
+++ b/source/extensions/filters/listener/tls_inspector/tls_inspector.cc
@@ -23,7 +23,6 @@
 #include "absl/strings/str_join.h"
 #include "openssl/md5.h"
 #include "openssl/ssl.h"
-#include "openssl/ssl3.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -64,9 +63,9 @@ Config::Config(
           std::min(PROTOBUF_GET_WRAPPED_OR_DEFAULT(proto_config, initial_read_buffer_size,
                                                    max_client_hello_size),
                    max_client_hello_size)) {
-  if (max_client_hello_size_ > SSL3_RT_MAX_PLAIN_LENGTH) {
+  if (max_client_hello_size_ > TLS_MAX_CLIENT_HELLO) {
     throw EnvoyException(fmt::format("max_client_hello_size of {} is greater than maximum of {}.",
-                                     max_client_hello_size_, size_t(SSL3_RT_MAX_PLAIN_LENGTH)));
+                                     max_client_hello_size_, size_t(TLS_MAX_CLIENT_HELLO)));
   }
 
   SSL_CTX_set_min_proto_version(ssl_ctx_.get(), TLS_MIN_SUPPORTED_VERSION);

--- a/source/extensions/filters/listener/tls_inspector/tls_inspector.h
+++ b/source/extensions/filters/listener/tls_inspector/tls_inspector.h
@@ -63,6 +63,9 @@ public:
   uint32_t maxClientHelloSize() const { return max_client_hello_size_; }
   uint32_t initialReadBufferSize() const { return initial_read_buffer_size_; }
 
+  // This is the maximum size of a ClientHello that boring ssl will accept.
+  // Here is the check in boring ssl:
+  // https://github.com/google/boringssl/blob/56383dabf472100181226cd14249f04c69a0c10b/ssl/tls_record.cc#L133
   static constexpr size_t TLS_MAX_CLIENT_HELLO = SSL3_RT_MAX_PLAIN_LENGTH;
   static const unsigned TLS_MIN_SUPPORTED_VERSION;
   static const unsigned TLS_MAX_SUPPORTED_VERSION;

--- a/source/extensions/filters/listener/tls_inspector/tls_inspector.h
+++ b/source/extensions/filters/listener/tls_inspector/tls_inspector.h
@@ -54,7 +54,7 @@ class Config {
 public:
   Config(Stats::Scope& scope,
          const envoy::extensions::filters::listener::tls_inspector::v3::TlsInspector& proto_config,
-         uint32_t max_client_hello_size = SSL3_RT_MAX_PLAIN_LENGTH);
+         uint32_t max_client_hello_size = TLS_MAX_CLIENT_HELLO);
 
   const TlsInspectorStats& stats() const { return stats_; }
   bssl::UniquePtr<SSL> newSsl();
@@ -63,7 +63,7 @@ public:
   uint32_t maxClientHelloSize() const { return max_client_hello_size_; }
   uint32_t initialReadBufferSize() const { return initial_read_buffer_size_; }
 
-  static constexpr size_t TLS_MAX_CLIENT_HELLO = 64 * 1024;
+  static constexpr size_t TLS_MAX_CLIENT_HELLO = SSL3_RT_MAX_PLAIN_LENGTH;
   static const unsigned TLS_MIN_SUPPORTED_VERSION;
   static const unsigned TLS_MAX_SUPPORTED_VERSION;
 

--- a/source/extensions/filters/listener/tls_inspector/tls_inspector.h
+++ b/source/extensions/filters/listener/tls_inspector/tls_inspector.h
@@ -12,6 +12,7 @@
 #include "source/extensions/filters/listener/tls_inspector/ja4_fingerprint.h"
 
 #include "openssl/ssl.h"
+#include "openssl/ssl3.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -53,7 +54,7 @@ class Config {
 public:
   Config(Stats::Scope& scope,
          const envoy::extensions::filters::listener::tls_inspector::v3::TlsInspector& proto_config,
-         uint32_t max_client_hello_size = TLS_MAX_CLIENT_HELLO);
+         uint32_t max_client_hello_size = SSL3_RT_MAX_PLAIN_LENGTH);
 
   const TlsInspectorStats& stats() const { return stats_; }
   bssl::UniquePtr<SSL> newSsl();

--- a/test/extensions/filters/listener/tls_inspector/tls_inspector_test.cc
+++ b/test/extensions/filters/listener/tls_inspector/tls_inspector_test.cc
@@ -122,9 +122,9 @@ INSTANTIATE_TEST_SUITE_P(TlsProtocolVersions, TlsInspectorTest,
 // Test that an exception is thrown for an invalid value for max_client_hello_size
 TEST_P(TlsInspectorTest, MaxClientHelloSize) {
   envoy::extensions::filters::listener::tls_inspector::v3::TlsInspector proto_config;
-  EXPECT_THROW_WITH_MESSAGE(Config(*store_.rootScope(), proto_config, SSL3_RT_MAX_PLAIN_LENGTH + 1),
-                            EnvoyException,
-                            "max_client_hello_size of 16385 is greater than maximum of 16384.");
+  EXPECT_THROW_WITH_MESSAGE(
+      Config(*store_.rootScope(), proto_config, Config::TLS_MAX_CLIENT_HELLO + 1), EnvoyException,
+      "max_client_hello_size of 16385 is greater than maximum of 16384.");
 }
 
 // Test that a ClientHello with an SNI value causes the correct name notification.
@@ -262,7 +262,7 @@ TEST_P(TlsInspectorTest, ClientHelloTooBig) {
   cfg_ = std::make_shared<Config>(*store_.rootScope(), proto_config);
   std::vector<uint8_t> client_hello = Tls::Test::generateClientHelloFromJA3Fingerprint(
       "769,47-53-5-10-49161-49162-49171-49172-50-56-19-4,0-10-11,23-24-25,0", 17000);
-  ASSERT(client_hello.size() > SSL3_RT_MAX_PLAIN_LENGTH);
+  ASSERT(client_hello.size() > Config::TLS_MAX_CLIENT_HELLO);
 
   filter_ = std::make_unique<Filter>(cfg_);
   EXPECT_CALL(socket_, detectedTransportProtocol()).Times(::testing::AnyNumber());

--- a/test/extensions/filters/listener/tls_inspector/tls_inspector_test.cc
+++ b/test/extensions/filters/listener/tls_inspector/tls_inspector_test.cc
@@ -122,9 +122,9 @@ INSTANTIATE_TEST_SUITE_P(TlsProtocolVersions, TlsInspectorTest,
 // Test that an exception is thrown for an invalid value for max_client_hello_size
 TEST_P(TlsInspectorTest, MaxClientHelloSize) {
   envoy::extensions::filters::listener::tls_inspector::v3::TlsInspector proto_config;
-  EXPECT_THROW_WITH_MESSAGE(
-      Config(*store_.rootScope(), proto_config, Config::TLS_MAX_CLIENT_HELLO + 1), EnvoyException,
-      "max_client_hello_size of 65537 is greater than maximum of 65536.");
+  EXPECT_THROW_WITH_MESSAGE(Config(*store_.rootScope(), proto_config, SSL3_RT_MAX_PLAIN_LENGTH + 1),
+                            EnvoyException,
+                            "max_client_hello_size of 16385 is greater than maximum of 16384.");
 }
 
 // Test that a ClientHello with an SNI value causes the correct name notification.
@@ -259,15 +259,13 @@ TEST_P(TlsInspectorTest, NoExtensions) {
 // maximum allowed size.
 TEST_P(TlsInspectorTest, ClientHelloTooBig) {
   envoy::extensions::filters::listener::tls_inspector::v3::TlsInspector proto_config;
-  const size_t max_size = 50;
-  cfg_ =
-      std::make_shared<Config>(*store_.rootScope(), proto_config, static_cast<uint32_t>(max_size));
-  std::vector<uint8_t> client_hello = Tls::Test::generateClientHello(
-      std::get<0>(GetParam()), std::get<1>(GetParam()), "example.com", "");
-  ASSERT(client_hello.size() > max_size);
+  cfg_ = std::make_shared<Config>(*store_.rootScope(), proto_config);
+  std::vector<uint8_t> client_hello = Tls::Test::generateClientHelloFromJA3Fingerprint(
+      "769,47-53-5-10-49161-49162-49171-49172-50-56-19-4,0-10-11,23-24-25,0", 17000);
+  ASSERT(client_hello.size() > SSL3_RT_MAX_PLAIN_LENGTH);
 
   filter_ = std::make_unique<Filter>(cfg_);
-
+  EXPECT_CALL(socket_, detectedTransportProtocol()).Times(::testing::AnyNumber());
   EXPECT_CALL(cb_, socket()).WillRepeatedly(ReturnRef(socket_));
   EXPECT_CALL(socket_, ioHandle()).WillRepeatedly(ReturnRef(*io_handle_));
   EXPECT_CALL(dispatcher_,
@@ -289,7 +287,6 @@ TEST_P(TlsInspectorTest, ClientHelloTooBig) {
   const std::vector<uint64_t> bytes_processed =
       store_.histogramValues("tls_inspector.bytes_processed", false);
   ASSERT_EQ(1, bytes_processed.size());
-  EXPECT_EQ(max_size, bytes_processed[0]);
 }
 
 // Test that the filter sets the `JA3` hash

--- a/test/extensions/filters/listener/tls_inspector/tls_inspector_test.cc
+++ b/test/extensions/filters/listener/tls_inspector/tls_inspector_test.cc
@@ -265,7 +265,7 @@ TEST_P(TlsInspectorTest, ClientHelloTooBig) {
   ASSERT(client_hello.size() > Config::TLS_MAX_CLIENT_HELLO);
 
   filter_ = std::make_unique<Filter>(cfg_);
-  EXPECT_CALL(socket_, detectedTransportProtocol()).Times(::testing::AnyNumber());
+  EXPECT_CALL(socket_, detectedTransportProtocol()).Times(0);
   EXPECT_CALL(cb_, socket()).WillRepeatedly(ReturnRef(socket_));
   EXPECT_CALL(socket_, ioHandle()).WillRepeatedly(ReturnRef(*io_handle_));
   EXPECT_CALL(dispatcher_,

--- a/test/extensions/filters/listener/tls_inspector/tls_utility.cc
+++ b/test/extensions/filters/listener/tls_inspector/tls_utility.cc
@@ -226,7 +226,7 @@ std::vector<uint8_t> generateClientHelloFromJA3Fingerprint(const std::string& ja
     }
   }
 
-  // Build initial clienthello message
+  // Build initial client hello message
   std::vector<uint8_t> clienthello_message =
       buildClientHelloMessage(ciphers, extensions, tls_version);
 
@@ -249,7 +249,7 @@ std::vector<uint8_t> generateClientHelloFromJA3Fingerprint(const std::string& ja
   return clienthello_message;
 }
 
-// Helper function to build the clienthello message
+// Helper function to build the client hello message
 std::vector<uint8_t> buildClientHelloMessage(const std::vector<uint8_t>& ciphers,
                                              const std::vector<uint8_t>& extensions,
                                              uint16_t tls_version) {

--- a/test/extensions/filters/listener/tls_inspector/tls_utility.cc
+++ b/test/extensions/filters/listener/tls_inspector/tls_utility.cc
@@ -94,10 +94,51 @@ std::vector<uint8_t> generateClientHelloWithoutExtensions(uint16_t tls_max_versi
   return client_hello;
 }
 
-// Forward declaration for helper
+// Helper function to build the client hello message
 std::vector<uint8_t> buildClientHelloMessage(const std::vector<uint8_t>& ciphers,
                                              const std::vector<uint8_t>& extensions,
-                                             uint16_t tls_version);
+                                             uint16_t tls_version) {
+  std::vector<uint8_t> clienthello = {static_cast<uint8_t>((tls_version & 0xff00) >> 8),
+                                      static_cast<uint8_t>(tls_version & 0xff),
+                                      // client random (32 bytes)
+                                      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                      // session id
+                                      0};
+  // cipher suite length and ciphers
+  uint16_t ciphers_length = ciphers.size();
+  clienthello.push_back((ciphers_length & 0xff00) >> 8);
+  clienthello.push_back(ciphers_length & 0xff);
+  clienthello.insert(std::end(clienthello), std::begin(ciphers), std::end(ciphers));
+  // compression methods
+  clienthello.push_back(0x01);
+  clienthello.push_back(0x00);
+  // extension length and extensions
+  uint16_t extensions_length = extensions.size();
+  clienthello.push_back((extensions_length & 0xff00) >> 8);
+  clienthello.push_back(extensions_length & 0xff);
+  clienthello.insert(std::end(clienthello), std::begin(extensions), std::end(extensions));
+
+  // headers
+  uint32_t clienthello_bytes = clienthello.size();
+  uint16_t handshake_bytes = clienthello.size() + 4;
+  std::vector<uint8_t> clienthello_message = {
+      // record header
+      0x16, 0x03, 0x01,
+      // handshake bytes
+      static_cast<uint8_t>((handshake_bytes & 0xff00) >> 8),
+      static_cast<uint8_t>(handshake_bytes & 0xff),
+      // handshake header
+      0x01,
+      // client hello bytes
+      static_cast<uint8_t>((clienthello_bytes & 0xff0000) >> 16),
+      static_cast<uint8_t>((clienthello_bytes & 0xff00) >> 8),
+      static_cast<uint8_t>(clienthello_bytes & 0xff)};
+  clienthello_message.insert(std::end(clienthello_message), std::begin(clienthello),
+                             std::end(clienthello));
+
+  return clienthello_message;
+}
 
 std::vector<uint8_t> generateClientHelloFromJA3Fingerprint(const std::string& ja3_fingerprint,
                                                            size_t target_size) {
@@ -233,7 +274,14 @@ std::vector<uint8_t> generateClientHelloFromJA3Fingerprint(const std::string& ja
   // Add dummy extension if needed
   size_t dummy_payload_size = 0;
   if (clienthello_message.size() < target_size) {
+    // 4 bytes are for the dummy extension header, so we need to subtract that
+    // from the target size to calculate the dummy payload size.
     dummy_payload_size = target_size - clienthello_message.size() - 4;
+    // Ensure the dummy payload size does not exceed 0xFFFF
+    // (the maximum size for a TLS extension payload).
+    // The limit is 0xFFFF (65535) because, in the TLS protocol, the length field for each extension
+    // is encoded as a 16-bit unsigned integer (2 bytes). This means the maximum value that can be
+    // represented for an extension's payload length is 65535 bytes.
     if (dummy_payload_size > 0xFFFF) {
       dummy_payload_size = 0xFFFF;
     }
@@ -245,52 +293,6 @@ std::vector<uint8_t> generateClientHelloFromJA3Fingerprint(const std::string& ja
     extensions.insert(extensions.end(), dummy_payload_size, 0x00);
     clienthello_message = buildClientHelloMessage(ciphers, extensions, tls_version);
   }
-
-  return clienthello_message;
-}
-
-// Helper function to build the client hello message
-std::vector<uint8_t> buildClientHelloMessage(const std::vector<uint8_t>& ciphers,
-                                             const std::vector<uint8_t>& extensions,
-                                             uint16_t tls_version) {
-  std::vector<uint8_t> clienthello = {static_cast<uint8_t>((tls_version & 0xff00) >> 8),
-                                      static_cast<uint8_t>(tls_version & 0xff),
-                                      // client random (32 bytes)
-                                      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                                      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                                      // session id
-                                      0};
-  // cipher suite length and ciphers
-  uint16_t ciphers_length = ciphers.size();
-  clienthello.push_back((ciphers_length & 0xff00) >> 8);
-  clienthello.push_back(ciphers_length & 0xff);
-  clienthello.insert(std::end(clienthello), std::begin(ciphers), std::end(ciphers));
-  // compression methods
-  clienthello.push_back(0x01);
-  clienthello.push_back(0x00);
-  // extension length and extensions
-  uint16_t extensions_length = extensions.size();
-  clienthello.push_back((extensions_length & 0xff00) >> 8);
-  clienthello.push_back(extensions_length & 0xff);
-  clienthello.insert(std::end(clienthello), std::begin(extensions), std::end(extensions));
-
-  // headers
-  uint32_t clienthello_bytes = clienthello.size();
-  uint16_t handshake_bytes = clienthello.size() + 4;
-  std::vector<uint8_t> clienthello_message = {
-      // record header
-      0x16, 0x03, 0x01,
-      // handshake bytes
-      static_cast<uint8_t>((handshake_bytes & 0xff00) >> 8),
-      static_cast<uint8_t>(handshake_bytes & 0xff),
-      // handshake header
-      0x01,
-      // client hello bytes
-      static_cast<uint8_t>((clienthello_bytes & 0xff0000) >> 16),
-      static_cast<uint8_t>((clienthello_bytes & 0xff00) >> 8),
-      static_cast<uint8_t>(clienthello_bytes & 0xff)};
-  clienthello_message.insert(std::end(clienthello_message), std::begin(clienthello),
-                             std::end(clienthello));
 
   return clienthello_message;
 }

--- a/test/extensions/filters/listener/tls_inspector/tls_utility.h
+++ b/test/extensions/filters/listener/tls_inspector/tls_utility.h
@@ -24,7 +24,8 @@ std::vector<uint8_t> generateClientHello(uint16_t tls_min_version, uint16_t tls_
  * Generate a TLS ClientHello in wire-format from a `JA3` fingerprint.
  * @param ja3_fingerprint The `JA3` fingerprint to use when creating the ClientHello message.
  */
-std::vector<uint8_t> generateClientHelloFromJA3Fingerprint(const std::string& ja3_fingerprint);
+std::vector<uint8_t> generateClientHelloFromJA3Fingerprint(const std::string& ja3_fingerprint, 
+                                                           size_t target_size = 0);
 
 /**
  * Generate a TLS ClientHello in wire-format without any extensions.

--- a/test/extensions/filters/listener/tls_inspector/tls_utility.h
+++ b/test/extensions/filters/listener/tls_inspector/tls_utility.h
@@ -24,7 +24,7 @@ std::vector<uint8_t> generateClientHello(uint16_t tls_min_version, uint16_t tls_
  * Generate a TLS ClientHello in wire-format from a `JA3` fingerprint.
  * @param ja3_fingerprint The `JA3` fingerprint to use when creating the ClientHello message.
  */
-std::vector<uint8_t> generateClientHelloFromJA3Fingerprint(const std::string& ja3_fingerprint, 
+std::vector<uint8_t> generateClientHelloFromJA3Fingerprint(const std::string& ja3_fingerprint,
                                                            size_t target_size = 0);
 
 /**


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Use max tls client hello size from boring ssl
Additional Description:
Before this change, tls inspector is using 64kb as the max size for tls client hello message but boring ssl library allows only 16kb. Here is the [check in boring ssl library](https://github.com/google/boringssl/blob/main/ssl/tls_record.cc#L133). Because of this mismatch, for any tls client hello with size above 16kb, there are no appropriate stats/warnings reported by envoy. It becomes harder to figure out the issue.

This PR is making envoy's max size for tls client hello same as the boring ssl's max size.


Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
