### PR TITLE
filter_chain: add indicator if added by discovery

### DIFF
--- a/envoy/network/filter.h
+++ b/envoy/network/filter.h
@@ -606,6 +606,11 @@ public:
    * @return the name of this filter chain.
    */
   virtual absl::string_view name() const PURE;
+
+  /**
+   * @return true if this filter chain configuration was discovered by FCDS.
+   */
+  virtual bool addedByDiscovery() const PURE;
 };
 
 using FilterChainSharedPtr = std::shared_ptr<FilterChain>;

--- a/source/common/listener_manager/filter_chain_manager_impl.cc
+++ b/source/common/listener_manager/filter_chain_manager_impl.cc
@@ -135,7 +135,7 @@ absl::Status FilterChainManagerImpl::addFilterChains(
     auto filter_chain_impl = findExistingFilterChain(*filter_chain);
     if (filter_chain_impl == nullptr) {
       auto filter_chain_or_error =
-          filter_chain_factory_builder.buildFilterChain(*filter_chain, context_creator);
+          filter_chain_factory_builder.buildFilterChain(*filter_chain, context_creator, false);
       RETURN_IF_NOT_OK(filter_chain_or_error.status());
       filter_chain_impl = filter_chain_or_error.value();
       ++new_filter_chain_size;
@@ -295,8 +295,8 @@ absl::Status FilterChainManagerImpl::copyOrRebuildDefaultFilterChain(
   // Origin filter chain manager could be empty if the current is the ancestor.
   const auto* origin = getOriginFilterChainManager();
   if (origin == nullptr) {
-    auto filter_chain_or_error =
-        filter_chain_factory_builder.buildFilterChain(*default_filter_chain, context_creator);
+    auto filter_chain_or_error = filter_chain_factory_builder.buildFilterChain(
+        *default_filter_chain, context_creator, false);
     RETURN_IF_NOT_OK(filter_chain_or_error.status());
     default_filter_chain_ = *filter_chain_or_error;
     return absl::OkStatus();
@@ -309,8 +309,8 @@ absl::Status FilterChainManagerImpl::copyOrRebuildDefaultFilterChain(
       eq(origin->default_filter_chain_message_.value(), *default_filter_chain)) {
     default_filter_chain_ = origin->default_filter_chain_;
   } else {
-    auto filter_chain_or_error =
-        filter_chain_factory_builder.buildFilterChain(*default_filter_chain, context_creator);
+    auto filter_chain_or_error = filter_chain_factory_builder.buildFilterChain(
+        *default_filter_chain, context_creator, false);
     RETURN_IF_NOT_OK(filter_chain_or_error.status());
     default_filter_chain_ = *filter_chain_or_error;
   }

--- a/source/common/listener_manager/filter_chain_manager_impl.h
+++ b/source/common/listener_manager/filter_chain_manager_impl.h
@@ -37,7 +37,8 @@ public:
    */
   virtual absl::StatusOr<Network::DrainableFilterChainSharedPtr>
   buildFilterChain(const envoy::config::listener::v3::FilterChain& filter_chain,
-                   FilterChainFactoryContextCreator& context_creator) const PURE;
+                   FilterChainFactoryContextCreator& context_creator,
+                   bool added_by_fcds) const PURE;
 };
 
 // PerFilterChainFactoryContextImpl is supposed to be used by network filter chain.
@@ -89,10 +90,11 @@ public:
   FilterChainImpl(Network::DownstreamTransportSocketFactoryPtr&& transport_socket_factory,
                   Filter::NetworkFilterFactoriesList&& filters_factory,
                   std::chrono::milliseconds transport_socket_connect_timeout,
-                  absl::string_view name)
+                  absl::string_view name, bool added_by_fcds)
       : transport_socket_factory_(std::move(transport_socket_factory)),
         filters_factory_(std::move(filters_factory)),
-        transport_socket_connect_timeout_(transport_socket_connect_timeout), name_(name) {}
+        transport_socket_connect_timeout_(transport_socket_connect_timeout), name_(name),
+        added_by_fcds_(added_by_fcds) {}
 
   // Network::FilterChain
   const Network::DownstreamTransportSocketFactory& transportSocketFactory() const override {
@@ -114,12 +116,15 @@ public:
 
   absl::string_view name() const override { return name_; }
 
+  bool addedByDiscovery() const override { return added_by_fcds_; }
+
 private:
   Configuration::FilterChainFactoryContextPtr factory_context_;
   const Network::DownstreamTransportSocketFactoryPtr transport_socket_factory_;
   const Filter::NetworkFilterFactoriesList filters_factory_;
   const std::chrono::milliseconds transport_socket_connect_timeout_;
   const std::string name_;
+  const bool added_by_fcds_;
 };
 
 /**

--- a/source/common/listener_manager/listener_manager_impl.cc
+++ b/source/common/listener_manager/listener_manager_impl.cc
@@ -1110,15 +1110,16 @@ ListenerFilterChainFactoryBuilder::ListenerFilterChainFactoryBuilder(
 absl::StatusOr<Network::DrainableFilterChainSharedPtr>
 ListenerFilterChainFactoryBuilder::buildFilterChain(
     const envoy::config::listener::v3::FilterChain& filter_chain,
-    FilterChainFactoryContextCreator& context_creator) const {
-  return buildFilterChainInternal(filter_chain,
-                                  context_creator.createFilterChainFactoryContext(&filter_chain));
+    FilterChainFactoryContextCreator& context_creator, bool added_by_fcds) const {
+  return buildFilterChainInternal(
+      filter_chain, context_creator.createFilterChainFactoryContext(&filter_chain), added_by_fcds);
 }
 
 absl::StatusOr<Network::DrainableFilterChainSharedPtr>
 ListenerFilterChainFactoryBuilder::buildFilterChainInternal(
     const envoy::config::listener::v3::FilterChain& filter_chain,
-    Configuration::FilterChainFactoryContextPtr&& filter_chain_factory_context) const {
+    Configuration::FilterChainFactoryContextPtr&& filter_chain_factory_context,
+    bool added_by_fcds) const {
   // If the cluster doesn't have transport socket configured, then use the default "raw_buffer"
   // transport socket or BoringSSL-based "tls" transport socket if TLS settings are configured.
   // We copy by value first then override if necessary.
@@ -1177,7 +1178,7 @@ ListenerFilterChainFactoryBuilder::buildFilterChainInternal(
       std::move(factory_or_error.value()), std::move(*factory_list_or_error),
       std::chrono::milliseconds(
           PROTOBUF_GET_MS_OR_DEFAULT(filter_chain, transport_socket_connect_timeout, 0)),
-      filter_chain.name());
+      filter_chain.name(), added_by_fcds);
 
   filter_chain_res->setFilterChainFactoryContext(std::move(filter_chain_factory_context));
   return filter_chain_res;

--- a/source/common/listener_manager/listener_manager_impl.h
+++ b/source/common/listener_manager/listener_manager_impl.h
@@ -377,12 +377,14 @@ public:
 
   absl::StatusOr<Network::DrainableFilterChainSharedPtr>
   buildFilterChain(const envoy::config::listener::v3::FilterChain& filter_chain,
-                   FilterChainFactoryContextCreator& context_creator) const override;
+                   FilterChainFactoryContextCreator& context_creator,
+                   bool added_by_fcds) const override;
 
 private:
   absl::StatusOr<Network::DrainableFilterChainSharedPtr> buildFilterChainInternal(
       const envoy::config::listener::v3::FilterChain& filter_chain,
-      Configuration::FilterChainFactoryContextPtr&& filter_chain_factory_context) const;
+      Configuration::FilterChainFactoryContextPtr&& filter_chain_factory_context,
+      bool added_by_fcds) const;
 
   ListenerImpl& listener_;
   ProtobufMessage::ValidationVisitor& validator_;

--- a/source/server/admin/admin.h
+++ b/source/server/admin/admin.h
@@ -441,6 +441,8 @@ private:
 
     absl::string_view name() const override { return "admin"; }
 
+    bool addedByDiscovery() const override { return false; }
+
   private:
     const Network::RawBufferSocketFactory transport_socket_factory_;
     const Filter::NetworkFilterFactoriesList empty_network_filter_factory_;

--- a/test/common/listener_manager/filter_chain_benchmark_test.cc
+++ b/test/common/listener_manager/filter_chain_benchmark_test.cc
@@ -31,7 +31,7 @@ namespace {
 class MockFilterChainFactoryBuilder : public FilterChainFactoryBuilder {
   absl::StatusOr<Network::DrainableFilterChainSharedPtr>
   buildFilterChain(const envoy::config::listener::v3::FilterChain&,
-                   FilterChainFactoryContextCreator&) const override {
+                   FilterChainFactoryContextCreator&, bool) const override {
     // A place holder to be found
     return std::make_shared<Network::MockFilterChain>();
   }

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -334,6 +334,7 @@ public:
   MOCK_METHOD(const NetworkFilterFactoriesList&, networkFilterFactories, (), (const));
   MOCK_METHOD(void, startDraining, ());
   MOCK_METHOD(absl::string_view, name, (), (const));
+  MOCK_METHOD(bool, addedByDiscovery, (), (const));
 };
 
 class MockFilterChainInfo : public FilterChainInfo {

--- a/test/test_common/network_utility.h
+++ b/test/test_common/network_utility.h
@@ -195,6 +195,8 @@ public:
 
   absl::string_view name() const override { return "EmptyFilterChain"; }
 
+  bool addedByDiscovery() const override { return false; }
+
 private:
   const DownstreamTransportSocketFactoryPtr transport_socket_factory_;
   const NetworkFilterFactoriesList empty_network_filter_factory_{};


### PR DESCRIPTION
Additional Description: adding a Boolean indicator to created filter chain objects whether it was created statically or by discovery. Currently all instances of ``FilterChainImpl`` will have this set to false. This will be used to support filter chain discovery service (#39141), to enforce that dynamic updates of filter chains will not be able to update or remove statically added filter chains
Risk Level: low
Testing: none
Docs Changes: none
Release Notes: none
Platform Specific Features: none