### PR TITLE
update codeowner of oauth2

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -174,7 +174,7 @@ extensions/filters/common/original_src @klarose @mattklein123
 extensions/upstreams/http @yanavlasov @mattklein123
 extensions/upstreams/tcp @ggreenway @mattklein123
 # OAuth2
-/*/extensions/filters/http/oauth2 @bplotnick @derekargueta @mattklein123
+/*/extensions/filters/http/oauth2 @bplotnick @zhaohuabing @mattklein123 @wbpcode
 # HTTP Local Rate Limit
 /*/extensions/filters/http/local_ratelimit @mattklein123 @wbpcode
 /*/extensions/filters/common/local_ratelimit @mattklein123 @wbpcode

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -164,7 +164,7 @@ extensions/filters/common/original_src @klarose @mattklein123
 # support for on-demand VHDS requests
 /*/extensions/filters/http/on_demand @dmitri-d @yanavlasov @kyessenov
 /*/extensions/filters/network/connection_limit @mattklein123 @delong-coder
-/*/extensions/filters/http/aws_request_signing @derekargueta @mattklein123 @marcomagdy @nbaws @niax
+/*/extensions/filters/http/aws_request_signing @mattklein123 @marcomagdy @nbaws @niax
 /*/extensions/filters/http/aws_lambda @mattklein123 @marcomagdy @nbaws @niax
 /*/extensions/filters/http/buffer @adisuissa @mattklein123
 /*/extensions/transport_sockets/raw_buffer @botengyao @mattklein123

--- a/OWNERS.md
+++ b/OWNERS.md
@@ -125,3 +125,13 @@ matter expert reviews. Feel free to loop them in as needed.
   * External dependencies, Envoy's supply chain and documentation.
 * Cerek Hillen ([crockeo](https://github.com/crockeo)) (chillen@lyft.com)
   * Python and C++ platform bindings.
+
+
+# Emeritus code owners
+
+This section lists emeritus code owners who have contributed or maintained some extensions and
+now have left Envoy community. When we add this section, some of code owners have left for a
+while. So, feel free to ping the maintainers if you find any emeritus code owners missing and
+would like to be added to this list.
+
+* Derek Argueta ([derekargueta](https://github.com/derekargueta))

--- a/OWNERS.md
+++ b/OWNERS.md
@@ -22,7 +22,7 @@ routing PRs, questions, etc. to the right place.
   * Docs, tooling, CI, containers and sandbox examples
 * Ryan Hamilton ([RyanTheOptimist](https://github.com/ryantheoptimist)) (rch@google.com)
   * HTTP/3, upstream connection management, Envoy Mobile.
-* Baiping Wang ([wbpcode](https://github.com/wbpcode)) (wbphub@live.com)
+* Baiping Wang ([wbpcode](https://github.com/wbpcode)) (wbphub@gmail.com)
   * Upstream, LB, tracing, logging, performance, and generic/dubbo proxy.
 
 # Maintainers
@@ -125,7 +125,6 @@ matter expert reviews. Feel free to loop them in as needed.
   * External dependencies, Envoy's supply chain and documentation.
 * Cerek Hillen ([crockeo](https://github.com/crockeo)) (chillen@lyft.com)
   * Python and C++ platform bindings.
-
 
 # Emeritus code owners
 


### PR DESCRIPTION
Commit Message: update codeowner of oauth2
Additional Description:

This PR added me and @zhaohuabing as codeowner of oauth2 filter. Thanks for great contributions from @zhaohuabing.

This PR also moved @derekargueta to emeritus code owner list because @derekargueta has no activity for a long time. Thanks for all the great contribution @derekargueta has done. Hope we can meet @derekargueta at community one day again!

Risk Level: low.
Testing: n/a.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.