### PR TITLE
init_manager: add option for updating watcher

### DIFF
--- a/envoy/init/manager.h
+++ b/envoy/init/manager.h
@@ -78,6 +78,14 @@ struct Manager {
   virtual void initialize(const Watcher& watcher) PURE;
 
   /**
+   * Update the manager to notify a new watcher when initialization is complete. The previous
+   * watcher will be discarded from the manager. It is an error to call this method on a manager
+   * that is in initialized state.
+   * @param watcher the watcher to notify when initialization is complete.
+   */
+  virtual void updateWatcher(const Watcher& watcher) PURE;
+
+  /**
    * Add unready targets information into the config dump.
    */
   virtual void dumpUnreadyTargets(envoy::admin::v3::UnreadyTargetsDumps& dumps) PURE;

--- a/source/common/init/manager_impl.cc
+++ b/source/common/init/manager_impl.cc
@@ -63,6 +63,11 @@ void ManagerImpl::initialize(const Watcher& watcher) {
   }
 }
 
+void ManagerImpl::updateWatcher(const Watcher& watcher) {
+  ASSERT(state_ != State::Initialized, "attempted to update watcher on initialized manager");
+  watcher_handle_ = watcher.createHandle(name_);
+};
+
 void ManagerImpl::dumpUnreadyTargets(envoy::admin::v3::UnreadyTargetsDumps& unready_targets_dumps) {
   auto& message = *unready_targets_dumps.mutable_unready_targets_dumps()->Add();
   message.set_name(name_);

--- a/source/common/init/manager_impl.h
+++ b/source/common/init/manager_impl.h
@@ -36,6 +36,7 @@ public:
   State state() const override;
   void add(const Target& target) override;
   void initialize(const Watcher& watcher) override;
+  void updateWatcher(const Watcher& watcher) override;
   void dumpUnreadyTargets(envoy::admin::v3::UnreadyTargetsDumps& dumps) override;
 
 private:

--- a/test/common/init/manager_impl_test.cc
+++ b/test/common/init/manager_impl_test.cc
@@ -225,6 +225,30 @@ TEST(InitManagerImplTest, OneTargetReadyBeforeInitialization) {
   expectInitialized(m);
 }
 
+TEST(InitManagerImplTest, UpdateWatcherWhenInitializing) {
+  InSequence s;
+
+  ManagerImpl m("test");
+  expectUninitialized(m);
+
+  ExpectableTargetImpl t1("t1");
+  m.add(t1);
+
+  ExpectableWatcherImpl w1;
+  ExpectableWatcherImpl w2;
+
+  // first watcher should not be called
+  w1.expectReady().Times(0);
+
+  // initialization should complete immediately
+  t1.expectInitialize();
+  w2.expectReady();
+  m.initialize(w1);
+  m.updateWatcher(w2);
+  t1.ready();
+  expectInitialized(m);
+}
+
 } // namespace
 } // namespace Init
 } // namespace Envoy

--- a/test/mocks/init/mocks.h
+++ b/test/mocks/init/mocks.h
@@ -73,6 +73,7 @@ struct MockManager : Manager {
   MOCK_METHOD(Manager::State, state, (), (const));
   MOCK_METHOD(void, add, (const Target&));
   MOCK_METHOD(void, initialize, (const Watcher&));
+  MOCK_METHOD(void, updateWatcher, (const Watcher&));
   MOCK_METHOD((const absl::flat_hash_map<std::string, uint32_t>&), unreadyTargets, (), (const));
   MOCK_METHOD(void, dumpUnreadyTargets, (envoy::admin::v3::UnreadyTargetsDumps&));
 };


### PR DESCRIPTION
Additional Description: adding an option to update the watcher that the init manager notifies when it is done initializing. This will be used for #39141 in next PR. This is needed for cases where the original watcher is being discarded but the init targets are still initializing and are part of an initialization process. Specifically for FCDS - this is required in case an FCDS update is received while a previous listener is warming. In that case, we don't want to allow the new listener to warm up until all targets of the previous listener have also finished warming up, because the FCDS updates are incremental
Risk Level: low
Testing: unit test
Docs Changes: none
Release Notes: none
Platform Specific Features: none