### PR TITLE
refactor: minor refactoring in RateLimit filter & some cleanup

### DIFF
--- a/source/extensions/filters/http/ratelimit/ratelimit.cc
+++ b/source/extensions/filters/http/ratelimit/ratelimit.cc
@@ -26,7 +26,7 @@ class HitsAddendObjectFactory : public StreamInfo::FilterState::ObjectFactory {
 public:
   std::string name() const override { return std::string(HitsAddendFilterStateKey); }
   std::unique_ptr<StreamInfo::FilterState::Object>
-  createFromBytes(const absl::string_view data) const override {
+  createFromBytes(absl::string_view data) const override {
     uint32_t hits_addend = 0;
     if (absl::SimpleAtoi(data, &hits_addend)) {
       return std::make_unique<StreamInfo::UInt32AccessorImpl>(hits_addend);
@@ -361,11 +361,11 @@ void Filter::initializeVirtualHostRateLimitOption(const Router::RouteEntry* rout
   }
 }
 
-std::string Filter::getDomain() const {
+const std::string& Filter::getDomain() const {
   if (route_config_ != nullptr && !route_config_->domain().empty()) {
-    return std::string(route_config_->domain());
+    return route_config_->domain();
   }
-  return std::string(config_->domain());
+  return config_->domain();
 }
 
 void OnStreamDoneCallBack::complete(Filters::Common::RateLimit::LimitStatus,

--- a/source/extensions/filters/http/ratelimit/ratelimit.h
+++ b/source/extensions/filters/http/ratelimit/ratelimit.h
@@ -78,7 +78,7 @@ public:
     response_headers_parser_ = std::move(response_headers_parser_or_.value());
   }
 
-  absl::string_view domain() const { return domain_; }
+  const std::string& domain() const { return domain_; }
   const LocalInfo::LocalInfo& localInfo() const { return local_info_; }
   uint64_t stage() const { return stage_; }
   Runtime::Loader& runtime() const { return runtime_; }
@@ -178,7 +178,7 @@ public:
                                             on_stream_done);
   }
 
-  absl::string_view domain() const { return domain_; }
+  const std::string& domain() const { return domain_; }
 
 private:
   const LocalInfo::LocalInfo& local_info_;
@@ -238,7 +238,7 @@ private:
   void appendRequestHeaders(Http::HeaderMapPtr& request_headers_to_add) const;
   double getHitAddend() const;
   void initializeVirtualHostRateLimitOption(const Router::RouteEntry* route_entry);
-  std::string getDomain() const;
+  const std::string& getDomain() const;
 
   Http::Context& httpContext() const { return config_->httpContext(); }
 


### PR DESCRIPTION
## Description

This PR have some minor refactoring and cleanup in the RateLimit filter. It uses some unused imports, switches to use `inlined_vector` and `string_views`.

---

**Commit Message:** refactor: minor refactoring in RateLimit filter & some cleanup
**Additional Description:** Addressed a few minor nits in the HTTP RateLimit filter's code.
**Risk Level:** Low
**Testing:** Existing Tests
**Docs Changes:** N/A
**Release Notes:** N/A