### PR TITLE
minor renaming and test utility refactor

### DIFF
--- a/source/common/listener_manager/listener_manager_impl.cc
+++ b/source/common/listener_manager/listener_manager_impl.cc
@@ -392,7 +392,7 @@ ListenerManagerImpl::ListenerManagerImpl(Instance& server,
     factory_ = std::make_unique<ProdListenerComponentFactory>(server);
   }
   if (server.admin().has_value()) {
-    config_tracker_entry_ = server.admin()->getConfigTracker().add(
+    listeners_config_tracker_entry_ = server.admin()->getConfigTracker().add(
         "listeners", [this](const Matchers::StringMatcher& name_matcher) {
           return dumpListenerConfigs(name_matcher);
         });
@@ -461,7 +461,7 @@ ListenerManagerImpl::dumpListenerConfigs(const Matchers::StringMatcher& name_mat
     fillState(*dump_listener, *listener);
   }
 
-  for (const auto& [error_name, error_state] : error_state_tracker_) {
+  for (const auto& [error_name, error_state] : lds_error_state_tracker_) {
     DynamicListener* dynamic_listener =
         getOrCreateDynamicListener(error_name, *config_dump, listener_map);
 
@@ -527,7 +527,7 @@ ListenerManagerImpl::addOrUpdateListener(const envoy::config::listener::v3::List
         fmt::format("error adding listener named '{}': address is necessary", name));
   }
 
-  auto it = error_state_tracker_.find(name);
+  auto it = lds_error_state_tracker_.find(name);
   absl::StatusOr<bool> add_or_update_status;
   TRY_ASSERT_MAIN_THREAD {
     add_or_update_status = addOrUpdateListenerInternal(config, version_info, added_via_api, name);
@@ -535,8 +535,8 @@ ListenerManagerImpl::addOrUpdateListener(const envoy::config::listener::v3::List
   END_TRY
   CATCH(const EnvoyException& e, { add_or_update_status = absl::InvalidArgumentError(e.what()); })
   if (!add_or_update_status.status().ok()) {
-    if (it == error_state_tracker_.end()) {
-      it = error_state_tracker_.emplace(name, std::make_unique<UpdateFailureState>()).first;
+    if (it == lds_error_state_tracker_.end()) {
+      it = lds_error_state_tracker_.emplace(name, std::make_unique<UpdateFailureState>()).first;
     }
     TimestampUtil::systemClockToTimestamp(server_.api().timeSource().systemTime(),
                                           *(it->second->mutable_last_update_attempt()));

--- a/source/common/listener_manager/listener_manager_impl.h
+++ b/source/common/listener_manager/listener_manager_impl.h
@@ -236,7 +236,7 @@ public:
   void stopListeners(StopListenersType stop_listeners_type,
                      const Network::ExtraShutdownListenerOptions& options) override;
   void stopWorkers() override;
-  void beginListenerUpdate() override { error_state_tracker_.clear(); }
+  void beginListenerUpdate() override { lds_error_state_tracker_.clear(); }
   void endListenerUpdate(FailureStates&& failure_state) override;
   bool isWorkerStarted() override { return workers_started_; }
   Http::Context& httpContext() { return server_.httpContext(); }
@@ -360,11 +360,11 @@ private:
   absl::optional<StopListenersType> stop_listeners_type_;
   Stats::ScopeSharedPtr scope_;
   ListenerManagerStats stats_;
-  ConfigTracker::EntryOwnerPtr config_tracker_entry_;
+  ConfigTracker::EntryOwnerPtr listeners_config_tracker_entry_;
   LdsApiPtr lds_api_;
   const bool enable_dispatcher_stats_{};
   using UpdateFailureState = envoy::admin::v3::UpdateFailureState;
-  absl::flat_hash_map<std::string, std::unique_ptr<UpdateFailureState>> error_state_tracker_;
+  absl::flat_hash_map<std::string, std::unique_ptr<UpdateFailureState>> lds_error_state_tracker_;
   FailureStates overall_error_state_;
   Quic::QuicStatNames& quic_stat_names_;
   absl::flat_hash_set<uint64_t> stopped_listener_tags_;

--- a/test/integration/ads_integration.cc
+++ b/test/integration/ads_integration.cc
@@ -22,13 +22,14 @@ using testing::AssertionResult;
 namespace Envoy {
 
 AdsIntegrationTest::AdsIntegrationTest()
-    : HttpIntegrationTest(
-          Http::CodecType::HTTP2, ipVersion(),
+    : AdsIntegrationTest(
           ConfigHelper::adsBootstrap((sotwOrDelta() == Grpc::SotwOrDelta::Sotw) ||
                                              (sotwOrDelta() == Grpc::SotwOrDelta::UnifiedSotw)
                                          ? "GRPC"
-                                         : "DELTA_GRPC")) {
+                                         : "DELTA_GRPC")) {}
 
+AdsIntegrationTest::AdsIntegrationTest(const std::string& config)
+    : HttpIntegrationTest(Http::CodecType::HTTP2, ipVersion(), config) {
   config_helper_.addRuntimeOverride("envoy.reloadable_features.unified_mux",
                                     (sotwOrDelta() == Grpc::SotwOrDelta::UnifiedSotw ||
                                      sotwOrDelta() == Grpc::SotwOrDelta::UnifiedDelta)

--- a/test/integration/ads_integration.h
+++ b/test/integration/ads_integration.h
@@ -41,6 +41,7 @@ class AdsIntegrationTest : public AdsDeltaSotwIntegrationSubStateParamTest,
                            public HttpIntegrationTest {
 public:
   AdsIntegrationTest();
+  AdsIntegrationTest(const std::string& config);
 
   void TearDown() override;
 


### PR DESCRIPTION
Additional Description: renaming variables in listener manager to distinct from listener and filter chain error states and adding an overload to AdsItegration to allow setting the config
Risk Level: low
Testing: none
Docs Changes: none
Release Notes: none
Platform Specific Features: none