### PR TITLE
python: Bump min version and set glibc

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -16,6 +16,8 @@ common --noenable_bzlmod
 fetch --color=yes
 run --color=yes
 
+common --@rules_python//python/config_settings:pip_whl_glibc_version=2.28
+
 build --color=yes
 build --jobs=HOST_CPUS-1
 build --workspace_status_command="bash bazel/get_workspace_status"

--- a/bazel/python_dependencies.bzl
+++ b/bazel/python_dependencies.bzl
@@ -9,6 +9,7 @@ def envoy_python_dependencies():
         name = "base_pip3",
         python_interpreter_target = "@python3_12_host//:python",
         requirements_lock = "@envoy//tools/base:requirements.txt",
+        experimental_index_url = "https://pypi.org/simple",
         extra_pip_args = ["--require-hashes"],
     )
 
@@ -16,6 +17,7 @@ def envoy_python_dependencies():
         name = "dev_pip3",
         python_interpreter_target = "@python3_12_host//:python",
         requirements_lock = "@envoy//tools/dev:requirements.txt",
+        experimental_index_url = "https://pypi.org/simple",
         extra_pip_args = ["--require-hashes"],
     )
 
@@ -23,10 +25,11 @@ def envoy_python_dependencies():
         name = "fuzzing_pip3",
         python_interpreter_target = "@python3_12_host//:python",
         requirements_lock = "@rules_fuzzing//fuzzing:requirements.txt",
+        experimental_index_url = "https://pypi.org/simple",
         extra_pip_args = ["--require-hashes"],
     )
 
     system_python(
         name = "system_python",
-        minimum_python_version = "3.7",
+        minimum_python_version = "3.9",
     )


### PR DESCRIPTION
i think this is the right way to resolve

also bumps python, conservatively - our current version is 3.12 and i have a feeling that most of our tooling at least requires 3.11
