### PR TITLE
dynamic_modules: enables accessing headers from generic events

### DIFF
--- a/source/extensions/filters/http/dynamic_modules/abi_impl.cc
+++ b/source/extensions/filters/http/dynamic_modules/abi_impl.cc
@@ -781,38 +781,32 @@ bool envoy_dynamic_module_callback_http_filter_get_attribute_string(
   case envoy_dynamic_module_type_attribute_id_RequestUrlPath: {
     RequestHeaderMapOptRef headers = filter->requestHeaders();
     if (headers.has_value()) {
-      const auto values = headers->get(Envoy::Http::Headers::get().Path);
-      if (!values.empty()) {
-        const absl::string_view path = headers->getPathValue();
-        size_t query_offset = path.find('?');
-        if (query_offset == absl::string_view::npos) {
-          *result = const_cast<char*>(path.data());
-          *result_length = path.size();
-        } else {
-          const auto url_path = path.substr(0, query_offset);
-          *result = const_cast<char*>(url_path.data());
-          *result_length = url_path.length();
-        }
-        ok = true;
+      const absl::string_view path = headers->getPathValue();
+      size_t query_offset = path.find('?');
+      if (query_offset == absl::string_view::npos) {
+        *result = const_cast<char*>(path.data());
+        *result_length = path.size();
+      } else {
+        const auto url_path = path.substr(0, query_offset);
+        *result = const_cast<char*>(url_path.data());
+        *result_length = url_path.length();
       }
+      ok = true;
     }
     break;
   }
   case envoy_dynamic_module_type_attribute_id_RequestQuery: {
     RequestHeaderMapOptRef headers = filter->requestHeaders();
     if (headers.has_value()) {
-      const auto values = headers->get(Envoy::Http::Headers::get().Path);
-      if (!values.empty()) {
-        const absl::string_view path = headers->getPathValue();
-        size_t query_offset = path.find('?');
-        if (query_offset != absl::string_view::npos) {
-          auto query = path.substr(query_offset + 1);
-          const auto fragment_offset = query.find('#');
-          query = query.substr(0, fragment_offset);
-          *result = const_cast<char*>(query.data());
-          *result_length = query.length();
-          ok = true;
-        }
+      const absl::string_view path = headers->getPathValue();
+      size_t query_offset = path.find('?');
+      if (query_offset != absl::string_view::npos) {
+        auto query = path.substr(query_offset + 1);
+        const auto fragment_offset = query.find('#');
+        query = query.substr(0, fragment_offset);
+        *result = const_cast<char*>(query.data());
+        *result_length = query.length();
+        ok = true;
       }
     }
     break;

--- a/source/extensions/filters/http/dynamic_modules/abi_impl.cc
+++ b/source/extensions/filters/http/dynamic_modules/abi_impl.cc
@@ -11,11 +11,14 @@ namespace DynamicModules {
 namespace HttpFilters {
 extern "C" {
 
-size_t getHeaderValueImpl(const Http::HeaderMap* map,
+using HeadersMapOptConstRef = OptRef<const Http::HeaderMap>;
+using HeadersMapOptRef = OptRef<Http::HeaderMap>;
+
+size_t getHeaderValueImpl(HeadersMapOptConstRef map,
                           envoy_dynamic_module_type_buffer_module_ptr key, size_t key_length,
                           envoy_dynamic_module_type_buffer_envoy_ptr* result_buffer_ptr,
                           size_t* result_buffer_length_ptr, size_t index) {
-  if (!map) {
+  if (!map.has_value()) {
     *result_buffer_ptr = nullptr;
     *result_buffer_length_ptr = 0;
     return 0;
@@ -34,10 +37,10 @@ size_t getHeaderValueImpl(const Http::HeaderMap* map,
   return values.size();
 }
 
-bool headerAsAttribute(const Http::HeaderMap* map, const Envoy::Http::LowerCaseString& header,
+bool headerAsAttribute(HeadersMapOptConstRef map, const Envoy::Http::LowerCaseString& header,
                        envoy_dynamic_module_type_buffer_envoy_ptr* result_buffer_ptr,
                        size_t* result_buffer_length_ptr) {
-  if (!map) {
+  if (!map.has_value()) {
     return false;
   }
   auto lower_header = header.get();
@@ -53,7 +56,7 @@ size_t envoy_dynamic_module_callback_http_get_request_header(
     envoy_dynamic_module_type_buffer_envoy_ptr* result_buffer_ptr, size_t* result_buffer_length_ptr,
     size_t index) {
   DynamicModuleHttpFilter* filter = static_cast<DynamicModuleHttpFilter*>(filter_envoy_ptr);
-  return getHeaderValueImpl(filter->request_headers_, key, key_length, result_buffer_ptr,
+  return getHeaderValueImpl(filter->requestHeaders(), key, key_length, result_buffer_ptr,
                             result_buffer_length_ptr, index);
 }
 
@@ -63,7 +66,7 @@ size_t envoy_dynamic_module_callback_http_get_request_trailer(
     envoy_dynamic_module_type_buffer_envoy_ptr* result_buffer_ptr, size_t* result_buffer_length_ptr,
     size_t index) {
   DynamicModuleHttpFilter* filter = static_cast<DynamicModuleHttpFilter*>(filter_envoy_ptr);
-  return getHeaderValueImpl(filter->request_trailers_, key, key_length, result_buffer_ptr,
+  return getHeaderValueImpl(filter->requestTrailers(), key, key_length, result_buffer_ptr,
                             result_buffer_length_ptr, index);
 }
 
@@ -73,7 +76,7 @@ size_t envoy_dynamic_module_callback_http_get_response_header(
     envoy_dynamic_module_type_buffer_envoy_ptr* result_buffer_ptr, size_t* result_buffer_length_ptr,
     size_t index) {
   DynamicModuleHttpFilter* filter = static_cast<DynamicModuleHttpFilter*>(filter_envoy_ptr);
-  return getHeaderValueImpl(filter->response_headers_, key, key_length, result_buffer_ptr,
+  return getHeaderValueImpl(filter->responseHeaders(), key, key_length, result_buffer_ptr,
                             result_buffer_length_ptr, index);
 }
 
@@ -83,14 +86,14 @@ size_t envoy_dynamic_module_callback_http_get_response_trailer(
     envoy_dynamic_module_type_buffer_envoy_ptr* result_buffer_ptr, size_t* result_buffer_length_ptr,
     size_t index) {
   DynamicModuleHttpFilter* filter = static_cast<DynamicModuleHttpFilter*>(filter_envoy_ptr);
-  return getHeaderValueImpl(filter->response_trailers_, key, key_length, result_buffer_ptr,
+  return getHeaderValueImpl(filter->responseTrailers(), key, key_length, result_buffer_ptr,
                             result_buffer_length_ptr, index);
 }
 
-bool setHeaderValueImpl(Http::HeaderMap* map, envoy_dynamic_module_type_buffer_module_ptr key,
+bool setHeaderValueImpl(HeadersMapOptRef map, envoy_dynamic_module_type_buffer_module_ptr key,
                         size_t key_length, envoy_dynamic_module_type_buffer_module_ptr value,
                         size_t value_length) {
-  if (!map) {
+  if (!map.has_value()) {
     return false;
   }
   absl::string_view key_view(key, key_length);
@@ -109,7 +112,7 @@ bool envoy_dynamic_module_callback_http_set_request_header(
     envoy_dynamic_module_type_buffer_module_ptr key, size_t key_length,
     envoy_dynamic_module_type_buffer_module_ptr value, size_t value_length) {
   DynamicModuleHttpFilter* filter = static_cast<DynamicModuleHttpFilter*>(filter_envoy_ptr);
-  return setHeaderValueImpl(filter->request_headers_, key, key_length, value, value_length);
+  return setHeaderValueImpl(filter->requestHeaders(), key, key_length, value, value_length);
 }
 
 bool envoy_dynamic_module_callback_http_set_request_trailer(
@@ -117,7 +120,7 @@ bool envoy_dynamic_module_callback_http_set_request_trailer(
     envoy_dynamic_module_type_buffer_module_ptr key, size_t key_length,
     envoy_dynamic_module_type_buffer_module_ptr value, size_t value_length) {
   DynamicModuleHttpFilter* filter = static_cast<DynamicModuleHttpFilter*>(filter_envoy_ptr);
-  return setHeaderValueImpl(filter->request_trailers_, key, key_length, value, value_length);
+  return setHeaderValueImpl(filter->requestTrailers(), key, key_length, value, value_length);
 }
 
 bool envoy_dynamic_module_callback_http_set_response_header(
@@ -125,7 +128,7 @@ bool envoy_dynamic_module_callback_http_set_response_header(
     envoy_dynamic_module_type_buffer_module_ptr key, size_t key_length,
     envoy_dynamic_module_type_buffer_module_ptr value, size_t value_length) {
   DynamicModuleHttpFilter* filter = static_cast<DynamicModuleHttpFilter*>(filter_envoy_ptr);
-  return setHeaderValueImpl(filter->response_headers_, key, key_length, value, value_length);
+  return setHeaderValueImpl(filter->responseHeaders(), key, key_length, value, value_length);
 }
 
 bool envoy_dynamic_module_callback_http_set_response_trailer(
@@ -133,46 +136,50 @@ bool envoy_dynamic_module_callback_http_set_response_trailer(
     envoy_dynamic_module_type_buffer_module_ptr key, size_t key_length,
     envoy_dynamic_module_type_buffer_module_ptr value, size_t value_length) {
   DynamicModuleHttpFilter* filter = static_cast<DynamicModuleHttpFilter*>(filter_envoy_ptr);
-  return setHeaderValueImpl(filter->response_trailers_, key, key_length, value, value_length);
+  return setHeaderValueImpl(filter->responseTrailers(), key, key_length, value, value_length);
 }
 
 size_t envoy_dynamic_module_callback_http_get_request_headers_count(
     envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr) {
   DynamicModuleHttpFilter* filter = static_cast<DynamicModuleHttpFilter*>(filter_envoy_ptr);
-  if (!filter->request_headers_) {
+  RequestHeaderMapOptRef request_headers = filter->requestHeaders();
+  if (!request_headers.has_value()) {
     return 0;
   }
-  return filter->request_headers_->size();
+  return request_headers->size();
 }
 
 size_t envoy_dynamic_module_callback_http_get_request_trailers_count(
     envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr) {
   DynamicModuleHttpFilter* filter = static_cast<DynamicModuleHttpFilter*>(filter_envoy_ptr);
-  if (!filter->request_trailers_) {
+  RequestTrailerMapOptRef request_trailers = filter->requestTrailers();
+  if (!request_trailers.has_value()) {
     return 0;
   }
-  return filter->request_trailers_->size();
+  return request_trailers->size();
 }
 
 size_t envoy_dynamic_module_callback_http_get_response_headers_count(
     envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr) {
   DynamicModuleHttpFilter* filter = static_cast<DynamicModuleHttpFilter*>(filter_envoy_ptr);
-  if (!filter->response_headers_) {
+  ResponseHeaderMapOptRef response_headers = filter->responseHeaders();
+  if (!response_headers.has_value()) {
     return 0;
   }
-  return filter->response_headers_->size();
+  return response_headers->size();
 }
 
 size_t envoy_dynamic_module_callback_http_get_response_trailers_count(
     envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr) {
   DynamicModuleHttpFilter* filter = static_cast<DynamicModuleHttpFilter*>(filter_envoy_ptr);
-  if (!filter->response_trailers_) {
+  ResponseTrailerMapOptRef response_trailers = filter->responseTrailers();
+  if (!response_trailers.has_value()) {
     return 0;
   }
-  return filter->response_trailers_->size();
+  return response_trailers->size();
 }
 
-bool getHeadersImpl(const Http::HeaderMap* map,
+bool getHeadersImpl(HeadersMapOptConstRef map,
                     envoy_dynamic_module_type_http_header* result_headers) {
   if (!map) {
     return false;
@@ -195,28 +202,28 @@ bool envoy_dynamic_module_callback_http_get_request_headers(
     envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr,
     envoy_dynamic_module_type_http_header* result_headers) {
   DynamicModuleHttpFilter* filter = static_cast<DynamicModuleHttpFilter*>(filter_envoy_ptr);
-  return getHeadersImpl(filter->request_headers_, result_headers);
+  return getHeadersImpl(filter->requestHeaders(), result_headers);
 }
 
 bool envoy_dynamic_module_callback_http_get_request_trailers(
     envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr,
     envoy_dynamic_module_type_http_header* result_headers) {
   DynamicModuleHttpFilter* filter = static_cast<DynamicModuleHttpFilter*>(filter_envoy_ptr);
-  return getHeadersImpl(filter->request_trailers_, result_headers);
+  return getHeadersImpl(filter->requestTrailers(), result_headers);
 }
 
 bool envoy_dynamic_module_callback_http_get_response_headers(
     envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr,
     envoy_dynamic_module_type_http_header* result_headers) {
   DynamicModuleHttpFilter* filter = static_cast<DynamicModuleHttpFilter*>(filter_envoy_ptr);
-  return getHeadersImpl(filter->response_headers_, result_headers);
+  return getHeadersImpl(filter->responseHeaders(), result_headers);
 }
 
 bool envoy_dynamic_module_callback_http_get_response_trailers(
     envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr,
     envoy_dynamic_module_type_http_header* result_headers) {
   DynamicModuleHttpFilter* filter = static_cast<DynamicModuleHttpFilter*>(filter_envoy_ptr);
-  return getHeadersImpl(filter->response_trailers_, result_headers);
+  return getHeadersImpl(filter->responseTrailers(), result_headers);
 }
 
 void envoy_dynamic_module_callback_http_send_response(
@@ -742,64 +749,70 @@ bool envoy_dynamic_module_callback_http_filter_get_attribute_string(
     break;
   }
   case envoy_dynamic_module_type_attribute_id_RequestPath: {
-    ok = headerAsAttribute(filter->request_headers_, Envoy::Http::Headers::get().Path, result,
+    ok = headerAsAttribute(filter->requestHeaders(), Envoy::Http::Headers::get().Path, result,
                            result_length);
     break;
   }
   case envoy_dynamic_module_type_attribute_id_RequestHost: {
-    ok = headerAsAttribute(filter->request_headers_, Envoy::Http::Headers::get().Host, result,
+    ok = headerAsAttribute(filter->requestHeaders(), Envoy::Http::Headers::get().Host, result,
                            result_length);
     break;
   }
   case envoy_dynamic_module_type_attribute_id_RequestMethod: {
-    ok = headerAsAttribute(filter->request_headers_, Envoy::Http::Headers::get().Method, result,
+    ok = headerAsAttribute(filter->requestHeaders(), Envoy::Http::Headers::get().Method, result,
                            result_length);
     break;
   }
   case envoy_dynamic_module_type_attribute_id_RequestScheme: {
-    ok = headerAsAttribute(filter->request_headers_, Envoy::Http::Headers::get().Scheme, result,
+    ok = headerAsAttribute(filter->requestHeaders(), Envoy::Http::Headers::get().Scheme, result,
                            result_length);
     break;
   }
   case envoy_dynamic_module_type_attribute_id_RequestReferer: {
-    ok = headerAsAttribute(filter->request_headers_, Envoy::Http::CustomHeaders::get().Referer,
+    ok = headerAsAttribute(filter->requestHeaders(), Envoy::Http::CustomHeaders::get().Referer,
                            result, result_length);
     break;
   }
   case envoy_dynamic_module_type_attribute_id_RequestUserAgent: {
-    ok = headerAsAttribute(filter->request_headers_, Envoy::Http::Headers::get().UserAgent, result,
+    ok = headerAsAttribute(filter->requestHeaders(), Envoy::Http::Headers::get().UserAgent, result,
                            result_length);
     break;
   }
   case envoy_dynamic_module_type_attribute_id_RequestUrlPath: {
-    const auto values = filter->request_headers_->get(Envoy::Http::Headers::get().Path);
-    if (!values.empty()) {
-      const auto& path = values[0]->value().getStringView();
-      size_t query_offset = path.find('?');
-      if (query_offset == absl::string_view::npos) {
-        *result = const_cast<char*>(path.data());
-        *result_length = path.size();
-      } else {
-        const auto url_path = path.substr(0, query_offset);
-        *result = const_cast<char*>(url_path.data());
-        *result_length = url_path.length();
+    RequestHeaderMapOptRef headers = filter->requestHeaders();
+    if (headers.has_value()) {
+      const auto values = headers->get(Envoy::Http::Headers::get().Path);
+      if (!values.empty()) {
+        const auto& path = values[0]->value().getStringView();
+        size_t query_offset = path.find('?');
+        if (query_offset == absl::string_view::npos) {
+          *result = const_cast<char*>(path.data());
+          *result_length = path.size();
+        } else {
+          const auto url_path = path.substr(0, query_offset);
+          *result = const_cast<char*>(url_path.data());
+          *result_length = url_path.length();
+        }
+        ok = true;
       }
-      ok = true;
     }
     break;
   }
   case envoy_dynamic_module_type_attribute_id_RequestQuery: {
-    const auto values = filter->request_headers_->get(Envoy::Http::Headers::get().Path);
-    if (!values.empty()) {
-      const auto& path = values[0]->value().getStringView();
-      size_t query_offset = path.find('?');
-      if (query_offset != absl::string_view::npos) {
-        auto query = path.substr(query_offset + 1);
-        const auto fragment_offset = query.find('#');
-        query = query.substr(0, fragment_offset);
-        *result = const_cast<char*>(query.data());
-        *result_length = query.length();
-        ok = true;
+    RequestHeaderMapOptRef headers = filter->requestHeaders();
+    if (headers.has_value()) {
+      const auto values = headers->get(Envoy::Http::Headers::get().Path);
+      if (!values.empty()) {
+        const auto& path = values[0]->value().getStringView();
+        size_t query_offset = path.find('?');
+        if (query_offset != absl::string_view::npos) {
+          auto query = path.substr(query_offset + 1);
+          const auto fragment_offset = query.find('#');
+          query = query.substr(0, fragment_offset);
+          *result = const_cast<char*>(query.data());
+          *result_length = query.length();
+          ok = true;
+        }
       }
     }
     break;

--- a/source/extensions/filters/http/dynamic_modules/abi_impl.cc
+++ b/source/extensions/filters/http/dynamic_modules/abi_impl.cc
@@ -783,7 +783,7 @@ bool envoy_dynamic_module_callback_http_filter_get_attribute_string(
     if (headers.has_value()) {
       const auto values = headers->get(Envoy::Http::Headers::get().Path);
       if (!values.empty()) {
-        const auto& path = values[0]->value().getStringView();
+        const absl::string_view path = headers->getPathValue();
         size_t query_offset = path.find('?');
         if (query_offset == absl::string_view::npos) {
           *result = const_cast<char*>(path.data());
@@ -803,7 +803,7 @@ bool envoy_dynamic_module_callback_http_filter_get_attribute_string(
     if (headers.has_value()) {
       const auto values = headers->get(Envoy::Http::Headers::get().Path);
       if (!values.empty()) {
-        const auto& path = values[0]->value().getStringView();
+        const absl::string_view path = headers->getPathValue();
         size_t query_offset = path.find('?');
         if (query_offset != absl::string_view::npos) {
           auto query = path.substr(query_offset + 1);

--- a/source/extensions/filters/http/dynamic_modules/filter.cc
+++ b/source/extensions/filters/http/dynamic_modules/filter.cc
@@ -37,13 +37,10 @@ void DynamicModuleHttpFilter::destroy() {
   http_callouts_.clear();
 }
 
-FilterHeadersStatus DynamicModuleHttpFilter::decodeHeaders(RequestHeaderMap& headers,
-                                                           bool end_of_stream) {
-  request_headers_ = &headers;
+FilterHeadersStatus DynamicModuleHttpFilter::decodeHeaders(RequestHeaderMap&, bool end_of_stream) {
   const envoy_dynamic_module_type_on_http_filter_request_headers_status status =
       config_->on_http_filter_request_headers_(thisAsVoidPtr(), in_module_filter_, end_of_stream);
   in_continue_ = status == envoy_dynamic_module_type_on_http_filter_request_headers_status_Continue;
-  request_headers_ = nullptr;
   return static_cast<FilterHeadersStatus>(status);
 };
 
@@ -61,13 +58,11 @@ FilterDataStatus DynamicModuleHttpFilter::decodeData(Buffer::Instance& chunk, bo
   return static_cast<FilterDataStatus>(status);
 };
 
-FilterTrailersStatus DynamicModuleHttpFilter::decodeTrailers(RequestTrailerMap& trailers) {
-  request_trailers_ = &trailers;
+FilterTrailersStatus DynamicModuleHttpFilter::decodeTrailers(RequestTrailerMap&) {
   const envoy_dynamic_module_type_on_http_filter_request_trailers_status status =
       config_->on_http_filter_request_trailers_(thisAsVoidPtr(), in_module_filter_);
   in_continue_ =
       status == envoy_dynamic_module_type_on_http_filter_request_trailers_status_Continue;
-  request_trailers_ = nullptr;
   return static_cast<FilterTrailersStatus>(status);
 }
 
@@ -83,17 +78,14 @@ Filter1xxHeadersStatus DynamicModuleHttpFilter::encode1xxHeaders(ResponseHeaderM
   return Filter1xxHeadersStatus::Continue;
 }
 
-FilterHeadersStatus DynamicModuleHttpFilter::encodeHeaders(ResponseHeaderMap& headers,
-                                                           bool end_of_stream) {
+FilterHeadersStatus DynamicModuleHttpFilter::encodeHeaders(ResponseHeaderMap&, bool end_of_stream) {
   if (sent_local_reply_) { // See the comment on the flag.
     return FilterHeadersStatus::Continue;
   }
-  response_headers_ = &headers;
   const envoy_dynamic_module_type_on_http_filter_response_headers_status status =
       config_->on_http_filter_response_headers_(thisAsVoidPtr(), in_module_filter_, end_of_stream);
   in_continue_ =
       status == envoy_dynamic_module_type_on_http_filter_response_headers_status_Continue;
-  response_headers_ = nullptr;
   return static_cast<FilterHeadersStatus>(status);
 };
 
@@ -114,16 +106,14 @@ FilterDataStatus DynamicModuleHttpFilter::encodeData(Buffer::Instance& chunk, bo
   return static_cast<FilterDataStatus>(status);
 };
 
-FilterTrailersStatus DynamicModuleHttpFilter::encodeTrailers(ResponseTrailerMap& trailers) {
+FilterTrailersStatus DynamicModuleHttpFilter::encodeTrailers(ResponseTrailerMap&) {
   if (sent_local_reply_) { // See the comment on the flag.
     return FilterTrailersStatus::Continue;
   }
-  response_trailers_ = &trailers;
   const envoy_dynamic_module_type_on_http_filter_response_trailers_status status =
       config_->on_http_filter_response_trailers_(thisAsVoidPtr(), in_module_filter_);
   in_continue_ =
       status == envoy_dynamic_module_type_on_http_filter_response_trailers_status_Continue;
-  response_trailers_ = nullptr;
   return static_cast<FilterTrailersStatus>(status);
 };
 

--- a/source/extensions/filters/http/dynamic_modules/filter.cc
+++ b/source/extensions/filters/http/dynamic_modules/filter.cc
@@ -43,6 +43,7 @@ FilterHeadersStatus DynamicModuleHttpFilter::decodeHeaders(RequestHeaderMap& hea
   const envoy_dynamic_module_type_on_http_filter_request_headers_status status =
       config_->on_http_filter_request_headers_(thisAsVoidPtr(), in_module_filter_, end_of_stream);
   in_continue_ = status == envoy_dynamic_module_type_on_http_filter_request_headers_status_Continue;
+  request_headers_ = nullptr;
   return static_cast<FilterHeadersStatus>(status);
 };
 
@@ -66,6 +67,7 @@ FilterTrailersStatus DynamicModuleHttpFilter::decodeTrailers(RequestTrailerMap& 
       config_->on_http_filter_request_trailers_(thisAsVoidPtr(), in_module_filter_);
   in_continue_ =
       status == envoy_dynamic_module_type_on_http_filter_request_trailers_status_Continue;
+  request_trailers_ = nullptr;
   return static_cast<FilterTrailersStatus>(status);
 }
 
@@ -91,6 +93,7 @@ FilterHeadersStatus DynamicModuleHttpFilter::encodeHeaders(ResponseHeaderMap& he
       config_->on_http_filter_response_headers_(thisAsVoidPtr(), in_module_filter_, end_of_stream);
   in_continue_ =
       status == envoy_dynamic_module_type_on_http_filter_response_headers_status_Continue;
+  response_headers_ = nullptr;
   return static_cast<FilterHeadersStatus>(status);
 };
 
@@ -120,6 +123,7 @@ FilterTrailersStatus DynamicModuleHttpFilter::encodeTrailers(ResponseTrailerMap&
       config_->on_http_filter_response_trailers_(thisAsVoidPtr(), in_module_filter_);
   in_continue_ =
       status == envoy_dynamic_module_type_on_http_filter_response_trailers_status_Continue;
+  response_trailers_ = nullptr;
   return static_cast<FilterTrailersStatus>(status);
 };
 

--- a/source/extensions/filters/http/dynamic_modules/filter.h
+++ b/source/extensions/filters/http/dynamic_modules/filter.h
@@ -60,15 +60,6 @@ public:
   StreamDecoderFilterCallbacks* decoder_callbacks_ = nullptr;
   StreamEncoderFilterCallbacks* encoder_callbacks_ = nullptr;
 
-  // They are only valid during the decodeHeaders/decodeTrailers/encodeHeaders/encodeTrailers
-  // callbacks. Usually, requestHeaders(), requestTrailers(), responseHeaders(), and
-  // responseTrailers() should be used instead. They are public only for testing purpose at the ABI
-  // level.
-  RequestHeaderMap* request_headers_ = nullptr;
-  RequestTrailerMap* request_trailers_ = nullptr;
-  ResponseHeaderMap* response_headers_ = nullptr;
-  ResponseTrailerMap* response_trailers_ = nullptr;
-
   // These are used to hold the current chunk of the request/response body during the decodeData and
   // encodeData callbacks. It is only valid during the call and should not be used outside of the
   // call.
@@ -89,53 +80,29 @@ public:
   }
 
   RequestHeaderMapOptRef requestHeaders() {
-    if (request_headers_) {
-      return *request_headers_;
-    }
     if (decoder_callbacks_) {
-      auto header = decoder_callbacks_->requestHeaders();
-      if (header.has_value()) {
-        return header;
-      }
+      return decoder_callbacks_->requestHeaders();
     }
     return absl::nullopt;
   }
 
   RequestTrailerMapOptRef requestTrailers() {
-    if (request_trailers_) {
-      return *request_trailers_;
-    }
     if (decoder_callbacks_) {
-      auto trailers = decoder_callbacks_->requestTrailers();
-      if (trailers.has_value()) {
-        return trailers;
-      }
+      return decoder_callbacks_->requestTrailers();
     }
     return absl::nullopt;
   }
 
   ResponseHeaderMapOptRef responseHeaders() {
-    if (response_headers_) {
-      return *response_headers_;
-    }
     if (encoder_callbacks_) {
-      auto headers = encoder_callbacks_->responseHeaders();
-      if (headers.has_value()) {
-        return headers;
-      }
+      return encoder_callbacks_->responseHeaders();
     }
     return absl::nullopt;
   }
 
   ResponseTrailerMapOptRef responseTrailers() {
-    if (response_trailers_) {
-      return *response_trailers_;
-    }
     if (encoder_callbacks_) {
-      auto trailers = encoder_callbacks_->responseTrailers();
-      if (trailers.has_value()) {
-        return trailers;
-      }
+      return encoder_callbacks_->responseTrailers();
     }
     return absl::nullopt;
   }

--- a/test/extensions/dynamic_modules/http/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/http/abi_impl_test.cc
@@ -52,13 +52,17 @@ TEST_P(DynamicModuleHttpFilterGetHeaderValueTest, GetHeaderValue) {
   std::initializer_list<std::pair<std::string, std::string>> headers = {
       {"single", "value"}, {"multi", "value1"}, {"multi", "value2"}};
   Http::TestRequestHeaderMapImpl request_headers{headers};
-  filter_->request_headers_ = &request_headers;
   Http::TestRequestTrailerMapImpl request_trailers{headers};
-  filter_->request_trailers_ = &request_trailers;
   Http::TestResponseHeaderMapImpl response_headers{headers};
-  filter_->response_headers_ = &response_headers;
   Http::TestResponseTrailerMapImpl response_trailers{headers};
-  filter_->response_trailers_ = &response_trailers;
+  EXPECT_CALL(decoder_callbacks_, requestHeaders())
+      .WillRepeatedly(testing::Return(makeOptRef<RequestHeaderMap>(request_headers)));
+  EXPECT_CALL(decoder_callbacks_, requestTrailers())
+      .WillRepeatedly(testing::Return(makeOptRef<RequestTrailerMap>(request_trailers)));
+  EXPECT_CALL(encoder_callbacks_, responseHeaders())
+      .WillRepeatedly(testing::Return(makeOptRef<ResponseHeaderMap>(response_headers)));
+  EXPECT_CALL(encoder_callbacks_, responseTrailers())
+      .WillRepeatedly(testing::Return(makeOptRef<ResponseTrailerMap>(response_trailers)));
 
   // The key is not found.
   std::string key = "nonexistent";
@@ -165,13 +169,17 @@ TEST_P(DynamicModuleHttpFilterSetHeaderValueTest, SetHeaderValue) {
   std::initializer_list<std::pair<std::string, std::string>> headers = {
       {"single", "value"}, {"multi", "value1"}, {"multi", "value2"}};
   Http::TestRequestHeaderMapImpl request_headers{headers};
-  filter_->request_headers_ = &request_headers;
   Http::TestRequestTrailerMapImpl request_trailers{headers};
-  filter_->request_trailers_ = &request_trailers;
   Http::TestResponseHeaderMapImpl response_headers{headers};
-  filter_->response_headers_ = &response_headers;
   Http::TestResponseTrailerMapImpl response_trailers{headers};
-  filter_->response_trailers_ = &response_trailers;
+  EXPECT_CALL(decoder_callbacks_, requestHeaders())
+      .WillRepeatedly(testing::Return(makeOptRef<RequestHeaderMap>(request_headers)));
+  EXPECT_CALL(decoder_callbacks_, requestTrailers())
+      .WillRepeatedly(testing::Return(makeOptRef<RequestTrailerMap>(request_trailers)));
+  EXPECT_CALL(encoder_callbacks_, responseHeaders())
+      .WillRepeatedly(testing::Return(makeOptRef<ResponseHeaderMap>(response_headers)));
+  EXPECT_CALL(encoder_callbacks_, responseTrailers())
+      .WillRepeatedly(testing::Return(makeOptRef<ResponseTrailerMap>(response_trailers)));
 
   Http::HeaderMap* header_map = nullptr;
   if (callback == &envoy_dynamic_module_callback_http_set_request_header) {
@@ -258,14 +266,17 @@ TEST_P(DynamicModuleHttpFilterGetHeadersCountTest, GetHeadersCount) {
   std::initializer_list<std::pair<std::string, std::string>> headers = {
       {"single", "value"}, {"multi", "value1"}, {"multi", "value2"}};
   Http::TestRequestHeaderMapImpl request_headers{headers};
-  filter_->request_headers_ = &request_headers;
   Http::TestRequestTrailerMapImpl request_trailers{headers};
-  filter_->request_trailers_ = &request_trailers;
   Http::TestResponseHeaderMapImpl response_headers{headers};
-  filter_->response_headers_ = &response_headers;
   Http::TestResponseTrailerMapImpl response_trailers{headers};
-  filter_->response_trailers_ = &response_trailers;
-
+  EXPECT_CALL(decoder_callbacks_, requestHeaders())
+      .WillRepeatedly(testing::Return(makeOptRef<RequestHeaderMap>(request_headers)));
+  EXPECT_CALL(decoder_callbacks_, requestTrailers())
+      .WillRepeatedly(testing::Return(makeOptRef<RequestTrailerMap>(request_trailers)));
+  EXPECT_CALL(encoder_callbacks_, responseHeaders())
+      .WillRepeatedly(testing::Return(makeOptRef<ResponseHeaderMap>(response_headers)));
+  EXPECT_CALL(encoder_callbacks_, responseTrailers())
+      .WillRepeatedly(testing::Return(makeOptRef<ResponseTrailerMap>(response_trailers)));
   EXPECT_EQ(callback(filter_.get()), 3);
 }
 
@@ -294,13 +305,17 @@ TEST_P(DynamicModuleHttpFilterGetHeadersTest, GetHeaders) {
   std::initializer_list<std::pair<std::string, std::string>> headers = {
       {"single", "value"}, {"multi", "value1"}, {"multi", "value2"}};
   Http::TestRequestHeaderMapImpl request_headers{headers};
-  filter_->request_headers_ = &request_headers;
+  EXPECT_CALL(decoder_callbacks_, requestHeaders())
+      .WillRepeatedly(testing::Return(makeOptRef<RequestHeaderMap>(request_headers)));
   Http::TestRequestTrailerMapImpl request_trailers{headers};
-  filter_->request_trailers_ = &request_trailers;
+  EXPECT_CALL(decoder_callbacks_, requestTrailers())
+      .WillRepeatedly(testing::Return(makeOptRef<RequestTrailerMap>(request_trailers)));
   Http::TestResponseHeaderMapImpl response_headers{headers};
-  filter_->response_headers_ = &response_headers;
+  EXPECT_CALL(encoder_callbacks_, responseHeaders())
+      .WillRepeatedly(testing::Return(makeOptRef<ResponseHeaderMap>(response_headers)));
   Http::TestResponseTrailerMapImpl response_trailers{headers};
-  filter_->response_trailers_ = &response_trailers;
+  EXPECT_CALL(encoder_callbacks_, responseTrailers())
+      .WillRepeatedly(testing::Return(makeOptRef<ResponseTrailerMap>(response_trailers)));
 
   EXPECT_TRUE(callback(filter_.get(), result_headers));
 
@@ -335,7 +350,8 @@ TEST_F(DynamicModuleHttpFilterTest, SendResponseNullptr) {
 
 TEST_F(DynamicModuleHttpFilterTest, SendResponseEmptyResponse) {
   Http::TestResponseHeaderMapImpl response_headers;
-  filter_->response_headers_ = &response_headers;
+  EXPECT_CALL(encoder_callbacks_, responseHeaders())
+      .WillRepeatedly(testing::Return(makeOptRef<ResponseHeaderMap>(response_headers)));
 
   // Test with empty response.
   EXPECT_CALL(decoder_callbacks_, sendLocalReply(Envoy::Http::Code::OK, testing::Eq(""), _,
@@ -762,7 +778,8 @@ TEST(ABIImpl, GetAttributes) {
       {"referer", "envoyproxy.io"},
       {"user-agent", "curl/7.54.1"}};
   Http::TestRequestHeaderMapImpl request_headers{headers};
-  filter.request_headers_ = &request_headers;
+  EXPECT_CALL(callbacks, requestHeaders())
+      .WillRepeatedly(testing::Return(makeOptRef<RequestHeaderMap>(request_headers)));
 
   // Unsupported attributes.
   EXPECT_FALSE(envoy_dynamic_module_callback_http_filter_get_attribute_int(

--- a/test/extensions/dynamic_modules/http/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/http/abi_impl_test.cc
@@ -749,6 +749,7 @@ TEST(ABIImpl, GetAttributes) {
   uint64_t result_number = 0;
 
   // envoy_dynamic_module_type_attribute_id_RequestPath with null headers map, should return false.
+  EXPECT_CALL(callbacks, requestHeaders()).WillOnce(testing::Return(absl::nullopt));
   EXPECT_FALSE(envoy_dynamic_module_callback_http_filter_get_attribute_string(
       &filter, envoy_dynamic_module_type_attribute_id_RequestPath, &result_str_ptr,
       &result_str_length));

--- a/test/extensions/dynamic_modules/http/filter_test.cc
+++ b/test/extensions/dynamic_modules/http/filter_test.cc
@@ -90,14 +90,17 @@ TEST(DynamicModulesTest, HeaderCallbacks) {
   auto filter = std::make_shared<DynamicModuleHttpFilter>(filter_config_or_status.value());
   filter->initializeInModuleFilter();
 
-  Http::MockStreamDecoderFilterCallbacks callbacks;
+  Http::MockStreamDecoderFilterCallbacks decoder_callbacks;
   StreamInfo::MockStreamInfo stream_info;
-  EXPECT_CALL(callbacks, streamInfo()).WillRepeatedly(testing::ReturnRef(stream_info));
+  EXPECT_CALL(decoder_callbacks, streamInfo()).WillRepeatedly(testing::ReturnRef(stream_info));
   Http::MockDownstreamStreamFilterCallbacks downstream_callbacks;
   EXPECT_CALL(downstream_callbacks, clearRouteCache());
-  EXPECT_CALL(callbacks, downstreamCallbacks())
+  EXPECT_CALL(decoder_callbacks, downstreamCallbacks())
       .WillOnce(testing::Return(OptRef(downstream_callbacks)));
-  filter->setDecoderFilterCallbacks(callbacks);
+  filter->setDecoderFilterCallbacks(decoder_callbacks);
+
+  Http::MockStreamEncoderFilterCallbacks encoder_callbacks;
+  filter->setEncoderFilterCallbacks(encoder_callbacks);
 
   NiceMock<StreamInfo::MockStreamInfo> info;
   EXPECT_CALL(stream_info, downstreamAddressProvider())
@@ -111,6 +114,14 @@ TEST(DynamicModulesTest, HeaderCallbacks) {
   Http::TestRequestTrailerMapImpl request_trailers{headers};
   Http::TestResponseHeaderMapImpl response_headers{headers};
   Http::TestResponseTrailerMapImpl response_trailers{headers};
+  EXPECT_CALL(decoder_callbacks, requestHeaders())
+      .WillRepeatedly(testing::Return(makeOptRef<RequestHeaderMap>(request_headers)));
+  EXPECT_CALL(decoder_callbacks, requestTrailers())
+      .WillRepeatedly(testing::Return(makeOptRef<RequestTrailerMap>(request_trailers)));
+  EXPECT_CALL(encoder_callbacks, responseHeaders())
+      .WillRepeatedly(testing::Return(makeOptRef<ResponseHeaderMap>(response_headers)));
+  EXPECT_CALL(encoder_callbacks, responseTrailers())
+      .WillRepeatedly(testing::Return(makeOptRef<ResponseTrailerMap>(response_trailers)));
   EXPECT_EQ(FilterHeadersStatus::Continue, filter->decodeHeaders(request_headers, false));
   EXPECT_EQ(FilterTrailersStatus::Continue, filter->decodeTrailers(request_trailers));
   EXPECT_EQ(FilterHeadersStatus::Continue, filter->encodeHeaders(response_headers, false));
@@ -573,8 +584,10 @@ TEST(DynamicModulesTest, HttpFilterPerFilterConfigLifetimes) {
   auto filter = std::make_shared<DynamicModuleHttpFilter>(filter_config_or_status.value());
 
   NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks;
+  NiceMock<Http::MockStreamEncoderFilterCallbacks> encoder_callbacks;
 
   filter->setDecoderFilterCallbacks(decoder_callbacks);
+  filter->setEncoderFilterCallbacks(encoder_callbacks);
   filter->initializeInModuleFilter();
 
   // Now simulate a per-route config that is very short lived, and verify that the filter doesn't
@@ -600,6 +613,8 @@ TEST(DynamicModulesTest, HttpFilterPerFilterConfigLifetimes) {
   }
 
   TestResponseHeaderMapImpl response_headers{{}};
+  EXPECT_CALL(encoder_callbacks, responseHeaders())
+      .WillRepeatedly(testing::Return(makeOptRef<ResponseHeaderMap>(response_headers)));
   EXPECT_EQ(FilterHeadersStatus::Continue, filter->encodeHeaders(response_headers, true));
 
   // Assert response header is what we expect

--- a/test/extensions/dynamic_modules/http/integration_test.cc
+++ b/test/extensions/dynamic_modules/http/integration_test.cc
@@ -379,9 +379,17 @@ TEST_P(DynamicModulesIntegrationTest, FakeExternalCache) {
     auto response = std::move(encoder_decoder.second);
     waitForNextUpstreamRequest();
     upstream_request_->encodeHeaders(default_response_headers_, true);
+    EXPECT_EQ("req", upstream_request_->headers()
+                         .get(Http::LowerCaseString("on-scheduled"))[0]
+                         ->value()
+                         .getStringView());
+    // Check that the cache key is set in the request trailers.
     ASSERT_TRUE(response->waitForEndStream());
     EXPECT_TRUE(response->complete());
     EXPECT_EQ("200", response->headers().Status()->value().getStringView());
+    EXPECT_EQ(
+        "res",
+        response->headers().get(Http::LowerCaseString("on-scheduled"))[0]->value().getStringView());
     EXPECT_TRUE(response->body().empty());
   }
   // Existing cache key should return 200 OK with body and shouldn't reach the upstream.

--- a/test/extensions/dynamic_modules/http/integration_test.cc
+++ b/test/extensions/dynamic_modules/http/integration_test.cc
@@ -383,7 +383,6 @@ TEST_P(DynamicModulesIntegrationTest, FakeExternalCache) {
                          .get(Http::LowerCaseString("on-scheduled"))[0]
                          ->value()
                          .getStringView());
-    // Check that the cache key is set in the request trailers.
     ASSERT_TRUE(response->waitForEndStream());
     EXPECT_TRUE(response->complete());
     EXPECT_EQ("200", response->headers().Status()->value().getStringView());

--- a/test/extensions/dynamic_modules/test_data/rust/http_integration_test.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/http_integration_test.rs
@@ -647,12 +647,10 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for FakeExternalCachingFilter {
       0 => {
         // Ensure that it is possible to set response headers on the generic scheduled event.
         envoy_filter.set_request_header("on-scheduled", b"req");
-        // This means the cache key was not found, so we continue decoding.
         envoy_filter.continue_decoding();
       },
       // Event from the on_scheduled when the cache key was found.
       1 => {
-        // This means the cache key was found, so we continue encoding.
         let result = self.rx.take().unwrap().recv().unwrap();
         envoy_filter.send_response(200, vec![("cached", b"yes")], Some(result.as_bytes()));
       },
@@ -660,7 +658,6 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for FakeExternalCachingFilter {
       2 => {
         // Ensure that it is possible to set response headers on the generic scheduled event.
         envoy_filter.set_response_header("on-scheduled", b"res");
-        // This means the cache key was not found, so we continue encoding.
         envoy_filter.continue_encoding();
       },
       _ => unreachable!(),

--- a/test/extensions/dynamic_modules/test_data/rust/http_integration_test.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/http_integration_test.rs
@@ -642,13 +642,43 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for FakeExternalCachingFilter {
   }
 
   fn on_scheduled(&mut self, envoy_filter: &mut EHF, event_id: u64) {
-    // We use event_id to determine if the cache key was found.
-    if event_id == 0 {
-      // This means the cache key was not found, so we continue decoding.
-      envoy_filter.continue_decoding();
-    } else {
-      let result = self.rx.take().unwrap().recv().unwrap();
-      envoy_filter.send_response(200, vec![("cached", b"yes")], Some(result.as_bytes()));
+    match event_id {
+      // Event from the on_request_headers when the cache key was not found.
+      0 => {
+        // Ensure that it is possible to set response headers on the generic scheduled event.
+        envoy_filter.set_request_header("on-scheduled", b"req");
+        // This means the cache key was not found, so we continue decoding.
+        envoy_filter.continue_decoding();
+      },
+      // Event from the on_scheduled when the cache key was found.
+      1 => {
+        // This means the cache key was found, so we continue encoding.
+        let result = self.rx.take().unwrap().recv().unwrap();
+        envoy_filter.send_response(200, vec![("cached", b"yes")], Some(result.as_bytes()));
+      },
+      // Event from the on_response_headers.
+      2 => {
+        // Ensure that it is possible to set response headers on the generic scheduled event.
+        envoy_filter.set_response_header("on-scheduled", b"res");
+        // This means the cache key was not found, so we continue encoding.
+        envoy_filter.continue_encoding();
+      },
+      _ => unreachable!(),
     }
+  }
+
+  fn on_response_headers(
+    &mut self,
+    envoy_filter: &mut EHF,
+    _end_of_stream: bool,
+  ) -> abi::envoy_dynamic_module_type_on_http_filter_response_headers_status {
+    let scheduler = envoy_filter.new_scheduler();
+    _ = std::thread::spawn(move || {
+      scheduler.commit(2);
+    });
+
+    // Return StopIteration to indicate that we will continue the processing
+    // once the scheduled event is completed.
+    envoy_dynamic_module_type_on_http_filter_response_headers_status::StopIteration
   }
 }


### PR DESCRIPTION
Commit Message: dynamic_modules: enables accessing headers from generic events
Additional Description:

Previously, the header access was done through the header maps passed to decode/encodeHeaders callbacks, and it didn't utilize the headers via decoder/encode callbacks. This changes the code slightly so that it will fallback to it. As a result, now a module can modify/access headers during generic event hook as well as the callout event hook.

Risk Level:
Testing:
Docs Changes: 
Release Notes: n/a
Platform Specific Features: n/a
