### PR TITLE
http rate limit filter v3: add support for failure_mode_deny runtime overrides

### DIFF
--- a/api/envoy/extensions/filters/http/ratelimit/v3/rate_limit.proto
+++ b/api/envoy/extensions/filters/http/ratelimit/v3/rate_limit.proto
@@ -158,7 +158,7 @@ message RateLimit {
   // .. code-block:: yaml
   //
   //   failure_mode_deny: true
-  //   failure_mode_deny_runtime:
+  //   failure_mode_deny_percent:
   //     default_value:
   //       numerator: 50
   //       denominator: HUNDRED
@@ -166,7 +166,7 @@ message RateLimit {
   //
   // This means that when the rate limit service is unavailable, 50% of requests will be denied
   // (fail closed) and 50% will be allowed (fail open).
-  config.core.v3.RuntimeFractionalPercent failure_mode_deny_runtime = 16;
+  config.core.v3.RuntimeFractionalPercent failure_mode_deny_percent = 16;
 }
 
 message RateLimitPerRoute {

--- a/api/envoy/extensions/filters/http/ratelimit/v3/rate_limit.proto
+++ b/api/envoy/extensions/filters/http/ratelimit/v3/rate_limit.proto
@@ -23,7 +23,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // Rate limit :ref:`configuration overview <config_http_filters_rate_limit>`.
 // [#extension: envoy.filters.http.ratelimit]
 
-// [#next-free-field: 16]
+// [#next-free-field: 17]
 message RateLimit {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.http.rate_limit.v2.RateLimit";
@@ -149,6 +149,24 @@ message RateLimit {
   // the fraction of requests to enforce rate limits on. And the default percentage of the
   // runtime key is 100% for backwards compatibility.
   config.core.v3.RuntimeFractionalPercent filter_enforced = 15;
+
+  // If set, this will override the failure_mode_deny parameter with a runtime fraction.
+  // If the runtime key is not specified, the value of failure_mode_deny will be used.
+  //
+  // Example:
+  //
+  // .. code-block:: yaml
+  //
+  //   failure_mode_deny: true
+  //   failure_mode_deny_runtime:
+  //     default_value:
+  //       numerator: 50
+  //       denominator: HUNDRED
+  //     runtime_key: ratelimit.failure_mode_deny_percent
+  //
+  // This means that when the rate limit service is unavailable, 50% of requests will be denied
+  // (fail closed) and 50% will be allowed (fail open).
+  config.core.v3.RuntimeFractionalPercent failure_mode_deny_runtime = 16;
 }
 
 message RateLimitPerRoute {

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -241,5 +241,10 @@ new_features:
   change: |
     Added a new ``dynamicTypedMetadata()`` on ``streamInfo()`` which could be used to access the typed metadata from
     HTTP filters, such as the Set Metadata filter, etc.
+- area: ratelimit
+  change: |
+    Added a new ``failure_mode_deny_runtime`` field of type ``Envoy::Runtime::FractionalPercent`` attached to the rate limit filter
+    to configure the failure mode for rate limit service errors in runtime.
+    It acts as an override for the existing ``failure_mode_deny`` field in the filter config.
 
 deprecated:

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -243,7 +243,7 @@ new_features:
     HTTP filters, such as the Set Metadata filter, etc.
 - area: ratelimit
   change: |
-    Added a new ``failure_mode_deny_runtime`` field of type ``Envoy::Runtime::FractionalPercent`` attached to the rate limit filter
+    Added a new ``failure_mode_deny_percent`` field of type ``Envoy::Runtime::FractionalPercent`` attached to the rate limit filter
     to configure the failure mode for rate limit service errors in runtime.
     It acts as an override for the existing ``failure_mode_deny`` field in the filter config.
 

--- a/source/extensions/filters/http/ratelimit/ratelimit.h
+++ b/source/extensions/filters/http/ratelimit/ratelimit.h
@@ -71,11 +71,11 @@ public:
                 ? absl::optional<Envoy::Runtime::FractionalPercent>(
                       Envoy::Runtime::FractionalPercent(config.filter_enforced(), runtime_))
                 : absl::nullopt),
-        failure_mode_deny_runtime_(
-            config.has_failure_mode_deny_runtime()
-                ? absl::optional<Envoy::Runtime::FractionalPercent>(
-                      Envoy::Runtime::FractionalPercent(config.failure_mode_deny_runtime(), runtime_))
-                : absl::nullopt) {
+        failure_mode_deny_runtime_(config.has_failure_mode_deny_runtime()
+                                       ? absl::optional<Envoy::Runtime::FractionalPercent>(
+                                             Envoy::Runtime::FractionalPercent(
+                                                 config.failure_mode_deny_runtime(), runtime_))
+                                       : absl::nullopt) {
     absl::StatusOr<Router::HeaderParserPtr> response_headers_parser_or_ =
         Envoy::Router::HeaderParser::configure(config.response_headers_to_add());
     SET_AND_RETURN_IF_NOT_OK(response_headers_parser_or_.status(), creation_status);

--- a/source/extensions/filters/http/ratelimit/ratelimit.h
+++ b/source/extensions/filters/http/ratelimit/ratelimit.h
@@ -71,10 +71,10 @@ public:
                 ? absl::optional<Envoy::Runtime::FractionalPercent>(
                       Envoy::Runtime::FractionalPercent(config.filter_enforced(), runtime_))
                 : absl::nullopt),
-        failure_mode_deny_runtime_(config.has_failure_mode_deny_runtime()
+        failure_mode_deny_percent_(config.has_failure_mode_deny_percent()
                                        ? absl::optional<Envoy::Runtime::FractionalPercent>(
                                              Envoy::Runtime::FractionalPercent(
-                                                 config.failure_mode_deny_runtime(), runtime_))
+                                                 config.failure_mode_deny_percent(), runtime_))
                                        : absl::nullopt) {
     absl::StatusOr<Router::HeaderParserPtr> response_headers_parser_or_ =
         Envoy::Router::HeaderParser::configure(config.response_headers_to_add());
@@ -89,8 +89,8 @@ public:
   Stats::Scope& scope() { return scope_; }
   FilterRequestType requestType() const { return request_type_; }
   bool failureModeAllow() const {
-    if (failure_mode_deny_runtime_.has_value()) {
-      return !failure_mode_deny_runtime_->enabled();
+    if (failure_mode_deny_percent_.has_value()) {
+      return !failure_mode_deny_percent_->enabled();
     }
     return !failure_mode_deny_;
   }
@@ -152,7 +152,7 @@ private:
   const Http::Code status_on_error_;
   const absl::optional<Envoy::Runtime::FractionalPercent> filter_enabled_;
   const absl::optional<Envoy::Runtime::FractionalPercent> filter_enforced_;
-  const absl::optional<Envoy::Runtime::FractionalPercent> failure_mode_deny_runtime_;
+  const absl::optional<Envoy::Runtime::FractionalPercent> failure_mode_deny_percent_;
 };
 
 using FilterConfigSharedPtr = std::shared_ptr<FilterConfig>;

--- a/test/extensions/filters/http/ratelimit/ratelimit_test.cc
+++ b/test/extensions/filters/http/ratelimit/ratelimit_test.cc
@@ -2034,16 +2034,17 @@ TEST_F(HttpRateLimitFilterTest, FailureModeRuntimeZeroPercentFailsOpen) {
       featureEnabled(absl::string_view("test.ratelimit.failure_mode_deny_percent"),
                      testing::Matcher<const envoy::type::v3::FractionalPercent&>(Percent(0))))
       .WillOnce(testing::Return(false));
-  
+
   setUpTest(failure_mode_runtime_zero_percent_config_);
   InSequence s;
 
   EXPECT_CALL(route_rate_limit_, populateDescriptors(_, _, _, _))
       .WillOnce(SetArgReferee<0>(descriptor_));
   EXPECT_CALL(*client_, limit(_, _, _, _, _, 0))
-      .WillOnce(WithArgs<0>(Invoke([&](Filters::Common::RateLimit::RequestCallbacks& callbacks) -> void {
-        request_callbacks_ = &callbacks;
-      })));
+      .WillOnce(
+          WithArgs<0>(Invoke([&](Filters::Common::RateLimit::RequestCallbacks& callbacks) -> void {
+            request_callbacks_ = &callbacks;
+          })));
 
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
             filter_->decodeHeaders(request_headers_, false));
@@ -2051,12 +2052,11 @@ TEST_F(HttpRateLimitFilterTest, FailureModeRuntimeZeroPercentFailsOpen) {
   EXPECT_CALL(filter_callbacks_, continueDecoding());
 
   request_callbacks_->complete(Filters::Common::RateLimit::LimitStatus::Error, nullptr, nullptr,
-                              nullptr, "", nullptr);
+                               nullptr, "", nullptr);
 
-  EXPECT_EQ(1U, filter_callbacks_.clusterInfo()
-                    ->statsScope()
-                    .counterFromStatName(ratelimit_error_)
-                    .value());
+  EXPECT_EQ(
+      1U,
+      filter_callbacks_.clusterInfo()->statsScope().counterFromStatName(ratelimit_error_).value());
   EXPECT_EQ(1U, filter_callbacks_.clusterInfo()
                     ->statsScope()
                     .counterFromStatName(ratelimit_failure_mode_allowed_)
@@ -2070,16 +2070,17 @@ TEST_F(HttpRateLimitFilterTest, FailureModeRuntimeHundredPercentFailsClose) {
       featureEnabled(absl::string_view("test.ratelimit.failure_mode_deny_percent"),
                      testing::Matcher<const envoy::type::v3::FractionalPercent&>(Percent(100))))
       .WillOnce(testing::Return(true));
-  
+
   setUpTest(failure_mode_runtime_hundred_percent_config_);
   InSequence s;
 
   EXPECT_CALL(route_rate_limit_, populateDescriptors(_, _, _, _))
       .WillOnce(SetArgReferee<0>(descriptor_));
   EXPECT_CALL(*client_, limit(_, _, _, _, _, 0))
-      .WillOnce(WithArgs<0>(Invoke([&](Filters::Common::RateLimit::RequestCallbacks& callbacks) -> void {
-        request_callbacks_ = &callbacks;
-      })));
+      .WillOnce(
+          WithArgs<0>(Invoke([&](Filters::Common::RateLimit::RequestCallbacks& callbacks) -> void {
+            request_callbacks_ = &callbacks;
+          })));
 
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
             filter_->decodeHeaders(request_headers_, false));
@@ -2094,12 +2095,11 @@ TEST_F(HttpRateLimitFilterTest, FailureModeRuntimeHundredPercentFailsClose) {
       }));
 
   request_callbacks_->complete(Filters::Common::RateLimit::LimitStatus::Error, nullptr, nullptr,
-                              nullptr, "", nullptr);
+                               nullptr, "", nullptr);
 
-  EXPECT_EQ(1U, filter_callbacks_.clusterInfo()
-                    ->statsScope()
-                    .counterFromStatName(ratelimit_error_)
-                    .value());
+  EXPECT_EQ(
+      1U,
+      filter_callbacks_.clusterInfo()->statsScope().counterFromStatName(ratelimit_error_).value());
   EXPECT_EQ(0U, filter_callbacks_.clusterInfo()
                     ->statsScope()
                     .counterFromStatName(ratelimit_failure_mode_allowed_)

--- a/test/extensions/filters/http/ratelimit/ratelimit_test.cc
+++ b/test/extensions/filters/http/ratelimit/ratelimit_test.cc
@@ -156,7 +156,7 @@ public:
       envoy_grpc:
         cluster_name: ratelimit
       timeout: 0.25s
-  failure_mode_deny_runtime:
+  failure_mode_deny_percent:
     runtime_key: test.ratelimit.failure_mode_deny_percent
     default_value:
       numerator: 0
@@ -170,7 +170,7 @@ public:
       envoy_grpc:
         cluster_name: ratelimit
       timeout: 0.25s
-  failure_mode_deny_runtime:
+  failure_mode_deny_percent:
     runtime_key: test.ratelimit.failure_mode_deny_percent
     default_value:
       numerator: 100
@@ -2027,7 +2027,7 @@ TEST_F(HttpRateLimitFilterTest, PerRouteRateLimitsAndOnStreamDone) {
                                nullptr);
 }
 
-TEST_F(HttpRateLimitFilterTest, FailureModeRuntimeZeroPercentFailsOpen) {
+TEST_F(HttpRateLimitFilterTest, FailureModeZeroPercentFailsOpen) {
 
   EXPECT_CALL(
       factory_context_.runtime_loader_.snapshot_,
@@ -2063,7 +2063,7 @@ TEST_F(HttpRateLimitFilterTest, FailureModeRuntimeZeroPercentFailsOpen) {
                     .value());
 }
 
-TEST_F(HttpRateLimitFilterTest, FailureModeRuntimeHundredPercentFailsClose) {
+TEST_F(HttpRateLimitFilterTest, FailureModeHundredPercentFailsClose) {
 
   EXPECT_CALL(
       factory_context_.runtime_loader_.snapshot_,

--- a/test/extensions/filters/http/ratelimit/ratelimit_test.cc
+++ b/test/extensions/filters/http/ratelimit/ratelimit_test.cc
@@ -149,6 +149,34 @@ public:
         denominator: HUNDRED
     )EOF";
 
+  const std::string failure_mode_runtime_zero_percent_config_ = R"EOF(
+  domain: foo
+  rate_limit_service:
+    grpc_service:
+      envoy_grpc:
+        cluster_name: ratelimit
+      timeout: 0.25s
+  failure_mode_deny_runtime:
+    runtime_key: test.ratelimit.failure_mode_deny_percent
+    default_value:
+      numerator: 0
+      denominator: HUNDRED
+  )EOF";
+
+  const std::string failure_mode_runtime_hundred_percent_config_ = R"EOF(
+  domain: foo
+  rate_limit_service:
+    grpc_service:
+      envoy_grpc:
+        cluster_name: ratelimit
+      timeout: 0.25s
+  failure_mode_deny_runtime:
+    runtime_key: test.ratelimit.failure_mode_deny_percent
+    default_value:
+      numerator: 100
+      denominator: HUNDRED
+  )EOF";
+
   Filters::Common::RateLimit::MockClient* client_;
   NiceMock<Http::MockStreamDecoderFilterCallbacks> filter_callbacks_;
   Stats::StatNamePool pool_{filter_callbacks_.clusterInfo()->statsScope().symbolTable()};
@@ -1997,6 +2025,85 @@ TEST_F(HttpRateLimitFilterTest, PerRouteRateLimitsAndOnStreamDone) {
   request_callbacks_->complete(Filters::Common::RateLimit::LimitStatus::OK, nullptr,
                                std::make_unique<Http::TestResponseHeaderMapImpl>(), nullptr, "",
                                nullptr);
+}
+
+TEST_F(HttpRateLimitFilterTest, FailureModeRuntimeZeroPercentFailsOpen) {
+
+  EXPECT_CALL(
+      factory_context_.runtime_loader_.snapshot_,
+      featureEnabled(absl::string_view("test.ratelimit.failure_mode_deny_percent"),
+                     testing::Matcher<const envoy::type::v3::FractionalPercent&>(Percent(0))))
+      .WillOnce(testing::Return(false));
+  
+  setUpTest(failure_mode_runtime_zero_percent_config_);
+  InSequence s;
+
+  EXPECT_CALL(route_rate_limit_, populateDescriptors(_, _, _, _))
+      .WillOnce(SetArgReferee<0>(descriptor_));
+  EXPECT_CALL(*client_, limit(_, _, _, _, _, 0))
+      .WillOnce(WithArgs<0>(Invoke([&](Filters::Common::RateLimit::RequestCallbacks& callbacks) -> void {
+        request_callbacks_ = &callbacks;
+      })));
+
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
+            filter_->decodeHeaders(request_headers_, false));
+
+  EXPECT_CALL(filter_callbacks_, continueDecoding());
+
+  request_callbacks_->complete(Filters::Common::RateLimit::LimitStatus::Error, nullptr, nullptr,
+                              nullptr, "", nullptr);
+
+  EXPECT_EQ(1U, filter_callbacks_.clusterInfo()
+                    ->statsScope()
+                    .counterFromStatName(ratelimit_error_)
+                    .value());
+  EXPECT_EQ(1U, filter_callbacks_.clusterInfo()
+                    ->statsScope()
+                    .counterFromStatName(ratelimit_failure_mode_allowed_)
+                    .value());
+}
+
+TEST_F(HttpRateLimitFilterTest, FailureModeRuntimeHundredPercentFailsClose) {
+
+  EXPECT_CALL(
+      factory_context_.runtime_loader_.snapshot_,
+      featureEnabled(absl::string_view("test.ratelimit.failure_mode_deny_percent"),
+                     testing::Matcher<const envoy::type::v3::FractionalPercent&>(Percent(100))))
+      .WillOnce(testing::Return(true));
+  
+  setUpTest(failure_mode_runtime_hundred_percent_config_);
+  InSequence s;
+
+  EXPECT_CALL(route_rate_limit_, populateDescriptors(_, _, _, _))
+      .WillOnce(SetArgReferee<0>(descriptor_));
+  EXPECT_CALL(*client_, limit(_, _, _, _, _, 0))
+      .WillOnce(WithArgs<0>(Invoke([&](Filters::Common::RateLimit::RequestCallbacks& callbacks) -> void {
+        request_callbacks_ = &callbacks;
+      })));
+
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
+            filter_->decodeHeaders(request_headers_, false));
+
+  EXPECT_CALL(filter_callbacks_.stream_info_,
+              setResponseFlag(StreamInfo::CoreResponseFlag::RateLimitServiceError));
+
+  EXPECT_CALL(filter_callbacks_, encodeHeaders_(_, true))
+      .WillOnce(Invoke([&](const Http::ResponseHeaderMap& headers, bool) -> void {
+        EXPECT_EQ(headers.getStatusValue(),
+                  std::to_string(enumToInt(Http::Code::InternalServerError)));
+      }));
+
+  request_callbacks_->complete(Filters::Common::RateLimit::LimitStatus::Error, nullptr, nullptr,
+                              nullptr, "", nullptr);
+
+  EXPECT_EQ(1U, filter_callbacks_.clusterInfo()
+                    ->statsScope()
+                    .counterFromStatName(ratelimit_error_)
+                    .value());
+  EXPECT_EQ(0U, filter_callbacks_.clusterInfo()
+                    ->statsScope()
+                    .counterFromStatName(ratelimit_failure_mode_allowed_)
+                    .value());
 }
 
 } // namespace


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: add new `failure_mode_deny_percent` optional RuntimeFractionalPercent field to the `type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimit `filter, so that if specified, its runtime value overrides the default failure_mode_deny value
Additional Description: the change does not consider deprecating the existing `failure_mode_deny` parameter
Risk Level: Low
Testing: adds unit tests, and manually tested behaviour with the following Envoy config
```yaml
admin:
  profile_path: /tmp/envoy.prof
  access_log:
  - name: envoy.access_loggers.file
    typed_config:
      "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
      path: /dev/null
  address:
    socket_address:
      address: 0.0.0.0
      port_value: 8001

layered_runtime:
  layers:
    - name: admin
      admin_layer: {}

static_resources:
  listeners:
  - name: web
    address:
      socket_address:
        protocol: TCP
        address: 0.0.0.0
        port_value: 8100
    per_connection_buffer_limit_bytes: 32768
    filter_chains:
    - filters:
      - name: envoy.filters.network.http_connection_manager
        typed_config:
          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
          codec_type: AUTO
          stat_prefix: web_ratelimit
          http_filters:
          - name: envoy.filters.http.ratelimit
            typed_config:
              "@type": type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimit
              domain: test_domain
              stat_prefix: test_ratelimit
              stage: 0
              failure_mode_deny_percent:
                runtime_key: ratelimit.failure_mode_deny_percent
                default_value:
                  numerator: 100
                  denominator: HUNDRED
              rate_limit_service:
                transport_api_version: V3
                grpc_service:
                  envoy_grpc:
                    cluster_name: ratelimit_service
          - name: envoy.filters.http.router
            typed_config:
              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
          route_config:
            name: local_route
            virtual_hosts:
            - name: local_service
              domains: ["*"]
              routes:
              - match:
                  prefix: "/"
                route:
                  host_rewrite_literal: www.envoyproxy.io
                  cluster: service_envoyproxy_io
              rate_limits:
                - actions:
                  - source_cluster: {}
                  - destination_cluster: {}

  clusters:
  - name: service_envoyproxy_io
    type: LOGICAL_DNS
    dns_lookup_family: V4_ONLY
    load_assignment:
      cluster_name: service_envoyproxy_io
      endpoints:
      - lb_endpoints:
        - endpoint:
            address:
              socket_address:
                address: www.envoyproxy.io
                port_value: 443
    transport_socket:
      name: envoy.transport_sockets.tls
      typed_config:
        "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
        sni: www.envoyproxy.io

  - name: ratelimit_service
    connect_timeout: 1s
    type: STRICT_DNS
    protocol_selection: USE_CONFIGURED_PROTOCOL
    lb_policy: ROUND_ROBIN
    http2_protocol_options: {}
    load_assignment:
      cluster_name: ratelimit_service
      endpoints:
      - lb_endpoints:
        - endpoint:
            address:
              socket_address:
                address: 127.0.0.1
                port_value: 8080 
```
Docs Changes: yes, inline with protos
Release Notes: yes
Platform Specific Features: no
Fixes #39928 
