### PR TITLE
http: refactor async_client_impl to remove a data-member

### DIFF
--- a/source/common/http/async_client_impl.cc
+++ b/source/common/http/async_client_impl.cc
@@ -33,8 +33,7 @@ AsyncClientImpl::AsyncClientImpl(Upstream::ClusterInfoConstSharedPtr cluster,
           factory_context.api().randomGenerator(), std::move(shadow_writer), true, false, false,
           false, false, false, Protobuf::RepeatedPtrField<std::string>{}, dispatcher.timeSource(),
           http_context, router_context)),
-      dispatcher_(dispatcher), runtime_(factory_context.runtime()),
-      local_reply_(LocalReply::Factory::createDefault()) {}
+      dispatcher_(dispatcher), local_reply_(LocalReply::Factory::createDefault()) {}
 
 AsyncClientImpl::~AsyncClientImpl() {
   while (!active_streams_.empty()) {
@@ -375,7 +374,7 @@ AsyncRequestSharedImpl::AsyncRequestSharedImpl(AsyncClientImpl& parent,
                                                const AsyncClient::RequestOptions& options,
                                                absl::Status& creation_status)
     : AsyncStreamImpl(parent, *this, options, creation_status), callbacks_(callbacks),
-      response_buffer_limit_(parent.runtime_.snapshot().getInteger(
+      response_buffer_limit_(parent.config_->runtime_.snapshot().getInteger(
           AsyncClientImpl::ResponseBufferLimit, kBufferLimitForResponse)) {
   if (!creation_status.ok()) {
     return;

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -84,7 +84,6 @@ private:
   const Router::FilterConfigSharedPtr config_;
   Event::Dispatcher& dispatcher_;
   std::list<std::unique_ptr<AsyncStreamImpl>> active_streams_;
-  Runtime::Loader& runtime_;
   const LocalReply::LocalReplyPtr local_reply_;
 
   friend class AsyncStreamImpl;


### PR DESCRIPTION
Commit Message: http: refactor async_client_impl to remove a data-member
Additional Description:
Minor refactor to remove the `runtime_` data member, and use the (same) one already stored by the shared-config.

Risk Level: low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A