### PR TITLE
config-dump: refactor to use hasActiveCluster that has constant time complexity

### DIFF
--- a/envoy/upstream/cluster_manager.h
+++ b/envoy/upstream/cluster_manager.h
@@ -352,6 +352,14 @@ public:
    */
   virtual bool hasCluster(const std::string& cluster_name) const PURE;
 
+  /**
+   * Returns true iff there's an active cluster in the cluster-manager.
+   * @return bool true if there is an active cluster, and false otherwise.
+   *
+   * NOTE: This method is only thread safe on the main thread. It should not be called elsewhere.
+   */
+  virtual bool hasActiveClusters() const PURE;
+
   using ClusterSet = absl::flat_hash_set<std::string>;
 
   /**

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -294,6 +294,11 @@ public:
     return active_clusters_.contains(cluster_name) || warming_clusters_.contains(cluster_name);
   }
 
+  bool hasActiveClusters() const override {
+    ASSERT_IS_MAIN_OR_TEST_THREAD();
+    return !active_clusters_.empty();
+  }
+
   const ClusterSet& primaryClusters() override { return primary_clusters_; }
   ThreadLocalCluster* getThreadLocalCluster(absl::string_view cluster) override;
 

--- a/source/server/admin/config_dump_handler.cc
+++ b/source/server/admin/config_dump_handler.cc
@@ -194,8 +194,7 @@ absl::optional<std::pair<Http::Code, std::string>> ConfigDumpHandler::addResourc
   Envoy::Server::ConfigTracker::CbsMap callbacks_map = config_tracker_.getCallbacksMap();
   if (include_eds) {
     // TODO(mattklein123): Add ability to see warming clusters in admin output.
-    auto all_clusters = server_.clusterManager().clusters();
-    if (!all_clusters.active_clusters_.empty()) {
+    if (server_.clusterManager().hasActiveClusters()) {
       callbacks_map.emplace("endpoint", [this](const Matchers::StringMatcher& name_matcher) {
         return dumpEndpointConfigs(name_matcher);
       });
@@ -248,8 +247,7 @@ absl::optional<std::pair<Http::Code, std::string>> ConfigDumpHandler::addAllConf
   Envoy::Server::ConfigTracker::CbsMap callbacks_map = config_tracker_.getCallbacksMap();
   if (include_eds) {
     // TODO(mattklein123): Add ability to see warming clusters in admin output.
-    auto all_clusters = server_.clusterManager().clusters();
-    if (!all_clusters.active_clusters_.empty()) {
+    if (server_.clusterManager().hasActiveClusters()) {
       callbacks_map.emplace("endpoint", [this](const Matchers::StringMatcher& name_matcher) {
         return dumpEndpointConfigs(name_matcher);
       });

--- a/test/mocks/upstream/cluster_manager.cc
+++ b/test/mocks/upstream/cluster_manager.cc
@@ -32,6 +32,7 @@ MockClusterManager::MockClusterManager()
                     OptRef<xds::core::v3::ResourceLocator>,
                     ProtobufMessage::ValidationVisitor&) { return MockOdCdsApiHandle::create(); }));
   ON_CALL(*this, addOrUpdateCluster(_, _, _)).WillByDefault(Return(false));
+  ON_CALL(*this, hasActiveClusters()).WillByDefault(Return(false));
 }
 
 MockClusterManager::~MockClusterManager() = default;
@@ -61,6 +62,7 @@ void MockClusterManager::initializeClusters(const std::vector<std::string>& acti
       .WillByDefault(Invoke([this](const std::string& cluster_name) -> bool {
         return active_clusters_.find(cluster_name) != active_clusters_.end();
       }));
+  ON_CALL(*this, hasActiveClusters()).WillByDefault(Return(!active_cluster_names.empty()));
 }
 
 void MockClusterManager::initializeThreadLocalClusters(

--- a/test/mocks/upstream/cluster_manager.h
+++ b/test/mocks/upstream/cluster_manager.h
@@ -45,6 +45,7 @@ public:
   MOCK_METHOD(ClusterInfoMaps, clusters, (), (const));
   MOCK_METHOD(OptRef<const Cluster>, getActiveCluster, (absl::string_view cluster_name), (const));
   MOCK_METHOD(bool, hasCluster, (const std::string& cluster_name), (const));
+  MOCK_METHOD(bool, hasActiveClusters, (), (const));
 
   MOCK_METHOD(const ClusterSet&, primaryClusters, ());
   MOCK_METHOD(ThreadLocalCluster*, getThreadLocalCluster, (absl::string_view cluster));

--- a/test/server/admin/config_dump_handler_test.cc
+++ b/test/server/admin/config_dump_handler_test.cc
@@ -136,6 +136,8 @@ TEST_P(AdminInstanceTest, ConfigDumpWithEndpoint) {
 
   NiceMock<Upstream::MockClusterMockPrioritySet> cluster;
   cluster_maps.active_clusters_.emplace(cluster.info_->name_, cluster);
+  // Emulate an addition of a cluster to the cluster-manager.
+  ON_CALL(server_.cluster_manager_, hasActiveClusters()).WillByDefault(Return(true));
 
   ON_CALL(*cluster.info_, addedViaApi()).WillByDefault(Return(false));
 
@@ -232,6 +234,8 @@ TEST_P(AdminInstanceTest, ConfigDumpWithLocalityEndpoint) {
 
   NiceMock<Upstream::MockClusterMockPrioritySet> cluster;
   cluster_maps.active_clusters_.emplace(cluster.info_->name_, cluster);
+  // Emulate an addition of a cluster to the cluster-manager.
+  ON_CALL(server_.cluster_manager_, hasActiveClusters()).WillByDefault(Return(true));
 
   ON_CALL(*cluster.info_, addedViaApi()).WillByDefault(Return(false));
 
@@ -445,6 +449,8 @@ TEST_P(AdminInstanceTest, ConfigDumpWithEndpointFiltersByResourceAndName) {
 
   NiceMock<Upstream::MockClusterMockPrioritySet> cluster_1;
   cluster_maps.active_clusters_.emplace(cluster_1.info_->name_, cluster_1);
+  // Emulate an addition of a cluster to the cluster-manager.
+  ON_CALL(server_.cluster_manager_, hasActiveClusters()).WillByDefault(Return(true));
 
   ON_CALL(*cluster_1.info_, addedViaApi()).WillByDefault(Return(true));
 


### PR DESCRIPTION
Commit Message: config-dump: refactor to use hasActiveCluster that has constant time complexity
Additional Description:
Refactor the config-dump code to use an O(1) call (introduced `hasActiveCluster()`) instead of invoking `clusters()` that is O(n).
Note that the config-dump will later invoke `clusters()` to produce the entire info, but at the places where the code was changed the entire clusters list isn't needed.

Risk Level: low
Testing: Updated.
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
