### PR TITLE
aws: mark lambda and request signing extensions as stable

### DIFF
--- a/source/extensions/extensions_metadata.yaml
+++ b/source/extensions/extensions_metadata.yaml
@@ -219,7 +219,7 @@ envoy.filters.http.aws_lambda:
   - envoy.filters.http
   - envoy.filters.http.upstream
   security_posture: requires_trusted_downstream_and_upstream
-  status: alpha
+  status: stable
   status_upstream: alpha
   type_urls:
   - envoy.extensions.filters.http.aws_lambda.v3.Config
@@ -229,7 +229,7 @@ envoy.filters.http.aws_request_signing:
   - envoy.filters.http
   - envoy.filters.http.upstream
   security_posture: requires_trusted_downstream_and_upstream
-  status: alpha
+  status: stable
   status_upstream: alpha
   type_urls:
   - envoy.extensions.filters.http.aws_request_signing.v3.AwsRequestSigning


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: aws: mark lambda and request signing extensions as stable
Additional Description: These extensions are in heavy customer use, so alpha tag is not suitable any more.
Risk Level: N/A
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
