### PR TITLE
Fix wrong comment in GolangIntegrationTest

### DIFF
--- a/contrib/golang/filters/http/test/golang_integration_test.cc
+++ b/contrib/golang/filters/http/test/golang_integration_test.cc
@@ -1222,10 +1222,10 @@ TEST_P(GolangIntegrationTest, Async_DataBuffer_DecodeHeader) {
 // buffer all data in decode data phase with sync mode.
 TEST_P(GolangIntegrationTest, DataBuffer_DecodeData) { testBasic("/test?databuffer=decode-data"); }
 
-// // buffer all data in decode data phase with async mode.
-// TEST_P(GolangIntegrationTest, Async_DataBuffer_DecodeData) {
-//   testBasic("/test?async=1&databuffer=decode-data");
-// }
+// buffer all data in decode data phase with async mode.
+TEST_P(GolangIntegrationTest, Async_DataBuffer_DecodeData) {
+  testBasic("/test?async=1&databuffer=decode-data");
+}
 
 // Go send local reply in decode header phase.
 TEST_P(GolangIntegrationTest, LocalReply_DecodeHeader) {


### PR DESCRIPTION
in the previous PR(https://github.com/envoyproxy/envoy/pull/39754), contrib/golang/filters/http/test/golang_integration_test.cc，line1225-line1228, have wrong comment, so this PR is to Fix the wrong comment .

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
