### PR TITLE
cleanup: remove unused variable in load-stats reporter

### DIFF
--- a/source/common/upstream/load_stats_reporter.cc
+++ b/source/common/upstream/load_stats_reporter.cc
@@ -62,7 +62,6 @@ void LoadStatsReporter::sendLoadStatsRequest() {
   // added to the cluster manager. When we get the notification, we record the current time in
   // clusters_ as the start time for the load reporting window for that cluster.
   request_.mutable_cluster_stats()->Clear();
-  auto all_clusters = cm_.clusters();
   for (const auto& cluster_name_and_timestamp : clusters_) {
     const std::string& cluster_name = cluster_name_and_timestamp.first;
     OptRef<const Upstream::Cluster> active_cluster = cm_.getActiveCluster(cluster_name);


### PR DESCRIPTION
Commit Message: cleanup: remove unused variable in load-stats reporter
Additional Description:
Minor cleanup following #39601. I forgot to remove the unused variable that called `clusters()`.

Risk Level: low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A