### PR TITLE
tls_inspector: add debug log when parseClientHello fails

### DIFF
--- a/source/extensions/filters/listener/tls_inspector/BUILD
+++ b/source/extensions/filters/listener/tls_inspector/BUILD
@@ -39,6 +39,7 @@ envoy_cc_library(
         "//source/common/common:hex_lib",
         "//source/common/common:minimal_logger_lib",
         "//source/common/protobuf:utility_lib",
+        "//source/common/tls:utility_lib",
         "@envoy_api//envoy/extensions/filters/listener/tls_inspector/v3:pkg_cc_proto",
     ],
 )

--- a/source/extensions/filters/listener/tls_inspector/tls_inspector.cc
+++ b/source/extensions/filters/listener/tls_inspector/tls_inspector.cc
@@ -16,6 +16,7 @@
 #include "source/common/common/assert.h"
 #include "source/common/common/hex.h"
 #include "source/common/protobuf/utility.h"
+#include "source/common/tls/utility.h"
 #include "source/extensions/filters/listener/tls_inspector/ja4_fingerprint.h"
 
 #include "absl/strings/ascii.h"
@@ -215,6 +216,9 @@ ParseState Filter::parseClientHello(const void* data, size_t len,
         cb_->socket().setDetectedTransportProtocol("tls");
       } else {
         config_->stats().tls_not_found_.inc();
+        ENVOY_LOG(
+            debug, "tls inspector: parseClientHello failed: {}",
+            Extensions::TransportSockets::Tls::Utility::getLastCryptoError().value_or("unknown"));
       }
       return ParseState::Done;
     default:


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: tls_inspector: add debug log when parseClientHello fails
Additional Description: Had to debug some TLS issues down in BoringSSL and while the metric tls_not_found is incremented, an additional debug log (which might be applicable or not) will be useful for understanding the rejection of the ClientHello
Risk Level: Low
Testing: Compiled, Ran and replicated the issue:
```
tls inspector: parseClientHello failed: error:10000096:SSL routines:OPENSSL_internal:xxxx
```
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
