### PR TITLE
host/cluster: remove unused data-members creation_time_ and time_source_

### DIFF
--- a/contrib/rocketmq_proxy/filters/network/test/conn_manager_test.cc
+++ b/contrib/rocketmq_proxy/filters/network/test/conn_manager_test.cc
@@ -98,7 +98,7 @@ public:
   std::shared_ptr<Upstream::MockClusterInfo> cluster_info_{
       new NiceMock<Upstream::MockClusterInfo>()};
   Upstream::HostSharedPtr host_{
-      Upstream::makeTestHost(cluster_info_, "tcp://127.0.0.1:80", simTime())};
+      Upstream::makeTestHost(cluster_info_, "tcp://127.0.0.1:80")};
   Upstream::PrioritySetImpl priority_set_;
 };
 

--- a/contrib/rocketmq_proxy/filters/network/test/conn_manager_test.cc
+++ b/contrib/rocketmq_proxy/filters/network/test/conn_manager_test.cc
@@ -97,8 +97,7 @@ public:
 
   std::shared_ptr<Upstream::MockClusterInfo> cluster_info_{
       new NiceMock<Upstream::MockClusterInfo>()};
-  Upstream::HostSharedPtr host_{
-      Upstream::makeTestHost(cluster_info_, "tcp://127.0.0.1:80")};
+  Upstream::HostSharedPtr host_{Upstream::makeTestHost(cluster_info_, "tcp://127.0.0.1:80")};
   Upstream::PrioritySetImpl priority_set_;
 };
 

--- a/source/common/upstream/health_discovery_service.cc
+++ b/source/common/upstream/health_discovery_service.cc
@@ -347,7 +347,7 @@ HdsCluster::HdsCluster(Server::Configuration::ServerFactoryContext& server_conte
                        ClusterInfoFactory& info_factory, ThreadLocal::SlotAllocator& tls)
     : server_context_(server_context), cluster_(std::move(cluster)), stats_(stats),
       ssl_context_manager_(ssl_context_manager), added_via_api_(added_via_api),
-      hosts_(new HostVector()), time_source_(server_context_.mainThreadDispatcher().timeSource()) {
+      hosts_(new HostVector()) {
   ENVOY_LOG(debug, "Creating an HdsCluster");
   priority_set_.getOrCreateHostSet(0);
   // Set initial hashes for possible delta updates.
@@ -376,7 +376,7 @@ HdsCluster::HdsCluster(Server::Configuration::ServerFactoryContext& server_conte
       HostSharedPtr endpoint = std::shared_ptr<HostImpl>(THROW_OR_RETURN_VALUE(
           HostImpl::create(info_, "", std::move(address_or_error.value()), nullptr, nullptr, 1,
                            locality_endpoints.locality(), host.endpoint().health_check_config(), 0,
-                           envoy::config::core::v3::UNKNOWN, time_source_),
+                           envoy::config::core::v3::UNKNOWN),
           std::unique_ptr<HostImpl>));
       // Add this host/endpoint pointer to our flat list of endpoints for health checking.
       hosts_->push_back(endpoint);
@@ -492,7 +492,7 @@ void HdsCluster::updateHosts(
         host = std::shared_ptr<HostImpl>(THROW_OR_RETURN_VALUE(
             HostImpl::create(info_, "", std::move(address_or_error.value()), nullptr, nullptr, 1,
                              endpoints.locality(), endpoint.endpoint().health_check_config(), 0,
-                             envoy::config::core::v3::UNKNOWN, time_source_),
+                             envoy::config::core::v3::UNKNOWN),
             std::unique_ptr<HostImpl>));
 
         // Set the initial health status as in HdsCluster::initialize.

--- a/source/common/upstream/health_discovery_service.h
+++ b/source/common/upstream/health_discovery_service.h
@@ -97,7 +97,6 @@ private:
   ClusterInfoConstSharedPtr info_;
   std::vector<Upstream::HealthCheckerSharedPtr> health_checkers_;
   HealthCheckerMap health_checkers_map_;
-  TimeSource& time_source_;
   UnitFloat drop_overload_{0};
   const std::string drop_category_;
 

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -430,11 +430,11 @@ absl::StatusOr<std::unique_ptr<HostDescriptionImpl>> HostDescriptionImpl::create
     Network::Address::InstanceConstSharedPtr dest_address, MetadataConstSharedPtr endpoint_metadata,
     MetadataConstSharedPtr locality_metadata, const envoy::config::core::v3::Locality& locality,
     const envoy::config::endpoint::v3::Endpoint::HealthCheckConfig& health_check_config,
-    uint32_t priority, TimeSource& time_source, const AddressVector& address_list) {
+    uint32_t priority, const AddressVector& address_list) {
   absl::Status creation_status = absl::OkStatus();
   auto ret = std::unique_ptr<HostDescriptionImpl>(new HostDescriptionImpl(
       creation_status, cluster, hostname, dest_address, endpoint_metadata, locality_metadata,
-      locality, health_check_config, priority, time_source, address_list));
+      locality, health_check_config, priority, address_list));
   RETURN_IF_NOT_OK(creation_status);
   return ret;
 }
@@ -444,10 +444,9 @@ HostDescriptionImpl::HostDescriptionImpl(
     Network::Address::InstanceConstSharedPtr dest_address, MetadataConstSharedPtr endpoint_metadata,
     MetadataConstSharedPtr locality_metadata, const envoy::config::core::v3::Locality& locality,
     const envoy::config::endpoint::v3::Endpoint::HealthCheckConfig& health_check_config,
-    uint32_t priority, TimeSource& time_source, const AddressVector& address_list)
+    uint32_t priority, const AddressVector& address_list)
     : HostDescriptionImplBase(cluster, hostname, dest_address, endpoint_metadata, locality_metadata,
-                              locality, health_check_config, priority, time_source,
-                              creation_status),
+                              locality, health_check_config, priority, creation_status),
       address_(dest_address),
       address_list_or_null_(makeAddressListOrNull(dest_address, address_list)),
       health_check_address_(resolveHealthCheckAddress(health_check_config, dest_address)) {}
@@ -457,7 +456,7 @@ HostDescriptionImplBase::HostDescriptionImplBase(
     Network::Address::InstanceConstSharedPtr dest_address, MetadataConstSharedPtr endpoint_metadata,
     MetadataConstSharedPtr locality_metadata, const envoy::config::core::v3::Locality& locality,
     const envoy::config::endpoint::v3::Endpoint::HealthCheckConfig& health_check_config,
-    uint32_t priority, TimeSource& time_source, absl::Status& creation_status)
+    uint32_t priority, absl::Status& creation_status)
     : cluster_(cluster), hostname_(hostname),
       health_checks_hostname_(health_check_config.hostname()),
       canary_(Config::Metadata::metadataValue(endpoint_metadata.get(),
@@ -468,8 +467,7 @@ HostDescriptionImplBase::HostDescriptionImplBase(
       locality_(locality),
       locality_zone_stat_name_(locality.zone(), cluster->statsScope().symbolTable()),
       priority_(priority),
-      socket_factory_(resolveTransportSocketFactory(dest_address, endpoint_metadata_.get())),
-      creation_time_(time_source.monotonicTime()) {
+      socket_factory_(resolveTransportSocketFactory(dest_address, endpoint_metadata_.get())) {
   if (health_check_config.port_value() != 0 && dest_address->type() != Network::Address::Type::Ip) {
     // Setting the health check port to non-0 only works for IP-type addresses. Setting the port
     // for a pipe address is a misconfiguration.
@@ -661,12 +659,11 @@ absl::StatusOr<std::unique_ptr<HostImpl>> HostImpl::create(
     const envoy::config::core::v3::Locality& locality,
     const envoy::config::endpoint::v3::Endpoint::HealthCheckConfig& health_check_config,
     uint32_t priority, const envoy::config::core::v3::HealthStatus health_status,
-    TimeSource& time_source, const AddressVector& address_list) {
+    const AddressVector& address_list) {
   absl::Status creation_status = absl::OkStatus();
-  auto ret = std::unique_ptr<HostImpl>(
-      new HostImpl(creation_status, cluster, hostname, address, endpoint_metadata,
-                   locality_metadata, initial_weight, locality, health_check_config, priority,
-                   health_status, time_source, address_list));
+  auto ret = std::unique_ptr<HostImpl>(new HostImpl(
+      creation_status, cluster, hostname, address, endpoint_metadata, locality_metadata,
+      initial_weight, locality, health_check_config, priority, health_status, address_list));
   RETURN_IF_NOT_OK(creation_status);
   return ret;
 }
@@ -1597,7 +1594,6 @@ ClusterImplBase::ClusterImplBase(const envoy::config::cluster::v3::Cluster& clus
       runtime_(cluster_context.serverFactoryContext().runtime()),
       wait_for_warm_on_init_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(cluster, wait_for_warm_on_init, true)),
       random_(cluster_context.serverFactoryContext().api().randomGenerator()),
-      time_source_(cluster_context.serverFactoryContext().timeSource()),
       local_cluster_(cluster_context.clusterManager().localClusterName().value_or("") ==
                      cluster.name()),
       const_metadata_shared_pool_(Config::Metadata::getConstMetadataSharedPool(
@@ -2182,7 +2178,7 @@ void PriorityStateManager::registerHostForPriority(
     const std::string& hostname, Network::Address::InstanceConstSharedPtr address,
     const std::vector<Network::Address::InstanceConstSharedPtr>& address_list,
     const envoy::config::endpoint::v3::LocalityLbEndpoints& locality_lb_endpoint,
-    const envoy::config::endpoint::v3::LbEndpoint& lb_endpoint, TimeSource& time_source) {
+    const envoy::config::endpoint::v3::LbEndpoint& lb_endpoint) {
   auto endpoint_metadata =
       lb_endpoint.has_metadata()
           ? parent_.constMetadataSharedPool()->getObject(lb_endpoint.metadata())
@@ -2195,8 +2191,7 @@ void PriorityStateManager::registerHostForPriority(
       HostImpl::create(parent_.info(), hostname, address, endpoint_metadata, locality_metadata,
                        lb_endpoint.load_balancing_weight().value(), locality_lb_endpoint.locality(),
                        lb_endpoint.endpoint().health_check_config(),
-                       locality_lb_endpoint.priority(), lb_endpoint.health_status(), time_source,
-                       address_list),
+                       locality_lb_endpoint.priority(), lb_endpoint.health_status(), address_list),
       std::unique_ptr<HostImpl>));
   registerHostForPriority(host, locality_lb_endpoint);
 }

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -251,7 +251,7 @@ protected:
       MetadataConstSharedPtr endpoint_metadata, MetadataConstSharedPtr locality_metadata,
       const envoy::config::core::v3::Locality& locality,
       const envoy::config::endpoint::v3::Endpoint::HealthCheckConfig& health_check_config,
-      uint32_t priority, TimeSource& time_source, absl::Status& creation_status);
+      uint32_t priority, absl::Status& creation_status);
 
   /**
    * @return nullptr if address_list is empty, otherwise a shared_ptr copy of address_list.
@@ -277,7 +277,6 @@ private:
   std::atomic<uint32_t> priority_;
   std::reference_wrapper<Network::UpstreamTransportSocketFactory>
       socket_factory_ ABSL_GUARDED_BY(metadata_mutex_);
-  const MonotonicTime creation_time_;
   absl::optional<MonotonicTime> last_hc_pass_time_;
   HostLbPolicyDataPtr lb_policy_data_;
 };
@@ -298,7 +297,7 @@ public:
          MetadataConstSharedPtr endpoint_metadata, MetadataConstSharedPtr locality_metadata,
          const envoy::config::core::v3::Locality& locality,
          const envoy::config::endpoint::v3::Endpoint::HealthCheckConfig& health_check_config,
-         uint32_t priority, TimeSource& time_source, const AddressVector& address_list = {});
+         uint32_t priority, const AddressVector& address_list = {});
 
   // HostDescription
   Network::Address::InstanceConstSharedPtr address() const override { return address_; }
@@ -314,7 +313,7 @@ protected:
       MetadataConstSharedPtr endpoint_metadata, MetadataConstSharedPtr locality_metadata,
       const envoy::config::core::v3::Locality& locality,
       const envoy::config::endpoint::v3::Endpoint::HealthCheckConfig& health_check_config,
-      uint32_t priority, TimeSource& time_source, const AddressVector& address_list = {});
+      uint32_t priority, const AddressVector& address_list = {});
 
 private:
   // No locks are required in this implementation: all address-related member
@@ -482,7 +481,7 @@ public:
          const envoy::config::core::v3::Locality& locality,
          const envoy::config::endpoint::v3::Endpoint::HealthCheckConfig& health_check_config,
          uint32_t priority, const envoy::config::core::v3::HealthStatus health_status,
-         TimeSource& time_source, const AddressVector& address_list = {});
+         const AddressVector& address_list = {});
 
 protected:
   HostImpl(absl::Status& creation_status, ClusterInfoConstSharedPtr cluster,
@@ -491,10 +490,10 @@ protected:
            uint32_t initial_weight, const envoy::config::core::v3::Locality& locality,
            const envoy::config::endpoint::v3::Endpoint::HealthCheckConfig& health_check_config,
            uint32_t priority, const envoy::config::core::v3::HealthStatus health_status,
-           TimeSource& time_source, const AddressVector& address_list = {})
+           const AddressVector& address_list = {})
       : HostImplBase(initial_weight, health_check_config, health_status),
         HostDescriptionImpl(creation_status, cluster, hostname, address, endpoint_metadata,
-                            locality_metadata, locality, health_check_config, priority, time_source,
+                            locality_metadata, locality, health_check_config, priority,
                             address_list) {}
 };
 
@@ -1286,7 +1285,6 @@ protected:
 
 protected:
   Random::RandomGenerator& random_;
-  TimeSource& time_source_;
   MainPrioritySetImpl priority_set_;
 
   absl::Status validateEndpointsForZoneAwareRouting(
@@ -1335,7 +1333,7 @@ public:
       const std::string& hostname, Network::Address::InstanceConstSharedPtr address,
       const HostDescription::AddressVector& address_list,
       const envoy::config::endpoint::v3::LocalityLbEndpoints& locality_lb_endpoint,
-      const envoy::config::endpoint::v3::LbEndpoint& lb_endpoint, TimeSource& time_source);
+      const envoy::config::endpoint::v3::LbEndpoint& lb_endpoint);
 
   void registerHostForPriority(
       const HostSharedPtr& host,

--- a/source/extensions/clusters/common/logical_host.cc
+++ b/source/extensions/clusters/common/logical_host.cc
@@ -8,12 +8,11 @@ absl::StatusOr<std::unique_ptr<LogicalHost>> LogicalHost::create(
     const Network::Address::InstanceConstSharedPtr& address, const AddressVector& address_list,
     const envoy::config::endpoint::v3::LocalityLbEndpoints& locality_lb_endpoint,
     const envoy::config::endpoint::v3::LbEndpoint& lb_endpoint,
-    const Network::TransportSocketOptionsConstSharedPtr& override_transport_socket_options,
-    TimeSource& time_source) {
+    const Network::TransportSocketOptionsConstSharedPtr& override_transport_socket_options) {
   absl::Status creation_status = absl::OkStatus();
   auto ret = std::unique_ptr<LogicalHost>(
       new LogicalHost(cluster, hostname, address, address_list, locality_lb_endpoint, lb_endpoint,
-                      override_transport_socket_options, time_source, creation_status));
+                      override_transport_socket_options, creation_status));
   RETURN_IF_NOT_OK(creation_status);
   return ret;
 }
@@ -24,7 +23,7 @@ LogicalHost::LogicalHost(
     const envoy::config::endpoint::v3::LocalityLbEndpoints& locality_lb_endpoint,
     const envoy::config::endpoint::v3::LbEndpoint& lb_endpoint,
     const Network::TransportSocketOptionsConstSharedPtr& override_transport_socket_options,
-    TimeSource& time_source, absl::Status& creation_status)
+    absl::Status& creation_status)
     : HostImplBase(lb_endpoint.load_balancing_weight().value(),
                    lb_endpoint.endpoint().health_check_config(), lb_endpoint.health_status()),
       HostDescriptionImplBase(
@@ -34,7 +33,7 @@ LogicalHost::LogicalHost(
           std::make_shared<const envoy::config::core::v3::Metadata>(
               locality_lb_endpoint.metadata()),
           locality_lb_endpoint.locality(), lb_endpoint.endpoint().health_check_config(),
-          locality_lb_endpoint.priority(), time_source, creation_status),
+          locality_lb_endpoint.priority(), creation_status),
       override_transport_socket_options_(override_transport_socket_options), address_(address),
       address_list_or_null_(makeAddressListOrNull(address, address_list)) {
   health_check_address_ =

--- a/source/extensions/clusters/common/logical_host.h
+++ b/source/extensions/clusters/common/logical_host.h
@@ -22,8 +22,7 @@ public:
          const Network::Address::InstanceConstSharedPtr& address, const AddressVector& address_list,
          const envoy::config::endpoint::v3::LocalityLbEndpoints& locality_lb_endpoint,
          const envoy::config::endpoint::v3::LbEndpoint& lb_endpoint,
-         const Network::TransportSocketOptionsConstSharedPtr& override_transport_socket_options,
-         TimeSource& time_source);
+         const Network::TransportSocketOptionsConstSharedPtr& override_transport_socket_options);
 
   /**
    * Sets new addresses. This can be called dynamically during operation, and
@@ -60,7 +59,7 @@ protected:
       const envoy::config::endpoint::v3::LocalityLbEndpoints& locality_lb_endpoint,
       const envoy::config::endpoint::v3::LbEndpoint& lb_endpoint,
       const Network::TransportSocketOptionsConstSharedPtr& override_transport_socket_options,
-      TimeSource& time_source, absl::Status& creation_status);
+      absl::Status& creation_status);
 
 private:
   const Network::TransportSocketOptionsConstSharedPtr override_transport_socket_options_;

--- a/source/extensions/clusters/dynamic_forward_proxy/cluster.cc
+++ b/source/extensions/clusters/dynamic_forward_proxy/cluster.cc
@@ -75,8 +75,9 @@ Cluster::Cluster(
       main_thread_dispatcher_(context.serverFactoryContext().mainThreadDispatcher()),
       orig_cluster_config_(cluster),
       allow_coalesced_connections_(config.allow_coalesced_connections()),
-      cm_(context.clusterManager()), max_sub_clusters_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(
-                                         config.sub_clusters_config(), max_sub_clusters, 1024)),
+      time_source_(context.serverFactoryContext().timeSource()), cm_(context.clusterManager()),
+      max_sub_clusters_(
+          PROTOBUF_GET_WRAPPED_OR_DEFAULT(config.sub_clusters_config(), max_sub_clusters, 1024)),
       sub_cluster_ttl_(
           PROTOBUF_GET_MS_OR_DEFAULT(config.sub_clusters_config(), sub_cluster_ttl, 300000)),
       sub_cluster_lb_policy_(config.sub_clusters_config().lb_policy()),
@@ -297,7 +298,7 @@ absl::Status Cluster::addOrUpdateHost(
     ENVOY_LOG(debug, "adding new dfproxy cluster host '{}'", host);
     auto host_or_error = Upstream::LogicalHost::create(
         info(), std::string{host}, host_info->address(), host_info->addressList(/*filtered=*/true),
-        dummy_locality_lb_endpoint_, dummy_lb_endpoint_, nullptr, time_source_);
+        dummy_locality_lb_endpoint_, dummy_lb_endpoint_, nullptr);
     RETURN_IF_NOT_OK_REF(host_or_error.status());
 
     emplaced_host =

--- a/source/extensions/clusters/dynamic_forward_proxy/cluster.h
+++ b/source/extensions/clusters/dynamic_forward_proxy/cluster.h
@@ -237,6 +237,7 @@ private:
   mutable absl::Mutex cluster_map_lock_;
   ClusterInfoMap cluster_map_ ABSL_GUARDED_BY(cluster_map_lock_);
 
+  TimeSource& time_source_;
   Upstream::ClusterManager& cm_;
   const size_t max_sub_clusters_;
   const std::chrono::milliseconds sub_cluster_ttl_;

--- a/source/extensions/clusters/eds/eds.cc
+++ b/source/extensions/clusters/eds/eds.cc
@@ -180,8 +180,7 @@ void EdsClusterImpl::BatchUpdateHelper::updateLocalityEndpoints(
   }
 
   priority_state_manager.registerHostForPriority(lb_endpoint.endpoint().hostname(), address,
-                                                 address_list, locality_lb_endpoint, lb_endpoint,
-                                                 parent_.time_source_);
+                                                 address_list, locality_lb_endpoint, lb_endpoint);
   all_new_hosts.emplace(address_as_string);
 }
 

--- a/source/extensions/clusters/logical_dns/logical_dns_cluster.cc
+++ b/source/extensions/clusters/logical_dns/logical_dns_cluster.cc
@@ -157,7 +157,7 @@ void LogicalDnsCluster::startResolve() {
           if (!logical_host_) {
             logical_host_ = THROW_OR_RETURN_VALUE(
                 LogicalHost::create(info_, hostname_, new_address, address_list,
-                                    localityLbEndpoint(), lbEndpoint(), nullptr, time_source_),
+                                    localityLbEndpoint(), lbEndpoint(), nullptr),
                 std::unique_ptr<LogicalHost>);
 
             const auto& locality_lb_endpoint = localityLbEndpoint();

--- a/source/extensions/clusters/original_dst/original_dst_cluster.cc
+++ b/source/extensions/clusters/original_dst/original_dst_cluster.cc
@@ -78,7 +78,7 @@ HostSelectionResponse OriginalDstCluster::LoadBalancer::chooseHost(LoadBalancerC
                 info, info->name() + dst_addr.asString(), std::move(host_ip_port), nullptr, nullptr,
                 1, envoy::config::core::v3::Locality().default_instance(),
                 envoy::config::endpoint::v3::Endpoint::HealthCheckConfig().default_instance(), 0,
-                envoy::config::core::v3::UNKNOWN, parent_->cluster_->time_source_),
+                envoy::config::core::v3::UNKNOWN),
             std::unique_ptr<HostImpl>)));
         ENVOY_LOG(debug, "Created host {} {}.", *host, host->address()->asString());
 

--- a/source/extensions/clusters/redis/redis_cluster.h
+++ b/source/extensions/clusters/redis/redis_cluster.h
@@ -114,7 +114,7 @@ public:
 
   InitializePhase initializePhase() const override { return InitializePhase::Primary; }
 
-  TimeSource& timeSource() const { return time_source_; }
+  /// TimeSource& timeSource() const { return time_source_; }
 
 protected:
   RedisCluster(const envoy::config::cluster::v3::Cluster& cluster,
@@ -152,13 +152,12 @@ private:
   public:
     static absl::StatusOr<std::unique_ptr<RedisHost>>
     create(Upstream::ClusterInfoConstSharedPtr cluster, const std::string& hostname,
-           Network::Address::InstanceConstSharedPtr address, RedisCluster& parent, bool primary,
-           TimeSource& time_source);
+           Network::Address::InstanceConstSharedPtr address, RedisCluster& parent, bool primary);
 
   protected:
     RedisHost(Upstream::ClusterInfoConstSharedPtr cluster, const std::string& hostname,
               Network::Address::InstanceConstSharedPtr address, RedisCluster& parent, bool primary,
-              TimeSource& time_source, absl::Status& creation_status)
+              absl::Status& creation_status)
         : Upstream::HostImpl(
               creation_status, cluster, hostname, address,
               // TODO(zyfjeff): Created through metadata shared pool
@@ -168,8 +167,7 @@ private:
               parent.lbEndpoint().load_balancing_weight().value(),
               parent.localityLbEndpoint().locality(),
               parent.lbEndpoint().endpoint().health_check_config(),
-              parent.localityLbEndpoint().priority(), parent.lbEndpoint().health_status(),
-              time_source),
+              parent.localityLbEndpoint().priority(), parent.lbEndpoint().health_status()),
           primary_(primary) {}
 
     bool isPrimary() const { return primary_; }

--- a/source/extensions/clusters/static/static_cluster.cc
+++ b/source/extensions/clusters/static/static_cluster.cc
@@ -19,8 +19,6 @@ StaticClusterImpl::StaticClusterImpl(const envoy::config::cluster::v3::Cluster& 
       cluster_load_assignment.policy(), overprovisioning_factor, kDefaultOverProvisioningFactor);
   weighted_priority_health_ = cluster_load_assignment.policy().weighted_priority_health();
 
-  Event::Dispatcher& dispatcher = context.serverFactoryContext().mainThreadDispatcher();
-
   for (const auto& locality_lb_endpoint : cluster_load_assignment.endpoints()) {
     THROW_IF_NOT_OK(validateEndpointsForZoneAwareRouting(locality_lb_endpoint));
     priority_state_manager_->initializePriorityFor(locality_lb_endpoint);
@@ -46,7 +44,7 @@ StaticClusterImpl::StaticClusterImpl(const envoy::config::cluster::v3::Cluster& 
           lb_endpoint.endpoint().hostname(),
           THROW_OR_RETURN_VALUE(resolveProtoAddress(lb_endpoint.endpoint().address()),
                                 const Network::Address::InstanceConstSharedPtr),
-          address_list, locality_lb_endpoint, lb_endpoint, dispatcher.timeSource());
+          address_list, locality_lb_endpoint, lb_endpoint);
     }
   }
 }

--- a/source/extensions/clusters/strict_dns/strict_dns_cluster.cc
+++ b/source/extensions/clusters/strict_dns/strict_dns_cluster.cc
@@ -165,8 +165,7 @@ void StrictDnsClusterImpl::ResolveTarget::startResolve() {
                                  lb_endpoint_.load_balancing_weight().value(),
                                  locality_lb_endpoints_.locality(),
                                  lb_endpoint_.endpoint().health_check_config(),
-                                 locality_lb_endpoints_.priority(), lb_endpoint_.health_status(),
-                                 parent_.time_source_),
+                                 locality_lb_endpoints_.priority(), lb_endpoint_.health_status()),
                 std::unique_ptr<HostImpl>));
             all_new_hosts.emplace(address->asString());
             ttl_refresh_rate = min(ttl_refresh_rate, addrinfo.ttl_);

--- a/source/extensions/filters/network/redis_proxy/conn_pool_impl.cc
+++ b/source/extensions/filters/network/redis_proxy/conn_pool_impl.cc
@@ -424,7 +424,7 @@ Common::Redis::Client::PoolRequest* InstanceImpl::ThreadLocalPool::makeRequestTo
             cluster_->info(), "", address_ptr, nullptr, nullptr, 1,
             envoy::config::core::v3::Locality(),
             envoy::config::endpoint::v3::Endpoint::HealthCheckConfig::default_instance(), 0,
-            envoy::config::core::v3::UNKNOWN, dispatcher_.timeSource()),
+            envoy::config::core::v3::UNKNOWN),
         std::unique_ptr<Upstream::HostImpl>)};
     host_address_map_[host_address_map_key] = new_host;
     created_via_redirect_hosts_.push_back(new_host);

--- a/test/common/access_log/access_log_impl_test.cc
+++ b/test/common/access_log/access_log_impl_test.cc
@@ -114,7 +114,7 @@ typed_config:
 
   auto cluster = std::make_shared<NiceMock<Upstream::MockClusterInfo>>();
   stream_info_.upstreamInfo()->setUpstreamHost(
-      Upstream::makeTestHostDescription(cluster, "tcp://10.0.0.5:1234", simTime()));
+      Upstream::makeTestHostDescription(cluster, "tcp://10.0.0.5:1234"));
   stream_info_.setResponseFlag(StreamInfo::CoreResponseFlag::DownstreamConnectionTermination);
 
   log->log({&request_headers_, &response_headers_, &response_trailers_}, stream_info_);
@@ -255,7 +255,7 @@ typed_config:
 TEST_F(AccessLogImplTest, UpstreamHost) {
   auto cluster = std::make_shared<NiceMock<Upstream::MockClusterInfo>>();
   stream_info_.upstreamInfo()->setUpstreamHost(
-      Upstream::makeTestHostDescription(cluster, "tcp://10.0.0.5:1234", simTime()));
+      Upstream::makeTestHostDescription(cluster, "tcp://10.0.0.5:1234"));
 
   const std::string yaml = R"EOF(
 name: accesslog

--- a/test/common/conn_pool/conn_pool_base_test.cc
+++ b/test/common/conn_pool/conn_pool_base_test.cc
@@ -131,8 +131,7 @@ public:
   NiceMock<Event::MockDispatcher> dispatcher_;
   NiceMock<Event::MockSchedulableCallback>* upstream_ready_cb_;
   NiceMock<Server::MockOverloadManager> overload_manager_;
-  Upstream::HostSharedPtr host_{
-      Upstream::makeTestHost(cluster_, "tcp://127.0.0.1:80", dispatcher_.timeSource())};
+  Upstream::HostSharedPtr host_{Upstream::makeTestHost(cluster_, "tcp://127.0.0.1:80")};
   TestConnPoolImplBase pool_;
   AttachContext context_;
   std::vector<TestActiveClient*> clients_;
@@ -241,8 +240,7 @@ public:
   std::shared_ptr<NiceMock<Upstream::MockHostDescription>> descr_{
       new NiceMock<Upstream::MockHostDescription>()};
   std::shared_ptr<Upstream::MockClusterInfo> cluster_{new NiceMock<Upstream::MockClusterInfo>()};
-  Upstream::HostSharedPtr host_{
-      Upstream::makeTestHost(cluster_, "tcp://127.0.0.1:80", dispatcher_->timeSource())};
+  Upstream::HostSharedPtr host_{Upstream::makeTestHost(cluster_, "tcp://127.0.0.1:80")};
   TestConnPoolImplBase pool_;
   AttachContext context_;
   std::vector<TestActiveClient*> clients_;

--- a/test/common/http/codec_client_test.cc
+++ b/test/common/http/codec_client_test.cc
@@ -92,7 +92,7 @@ public:
   std::shared_ptr<Upstream::MockIdleTimeEnabledClusterInfo> cluster_{
       new NiceMock<Upstream::MockIdleTimeEnabledClusterInfo>()};
   Upstream::HostDescriptionConstSharedPtr host_{
-      Upstream::makeTestHostDescription(cluster_, "tcp://127.0.0.1:80", simTime())};
+      Upstream::makeTestHostDescription(cluster_, "tcp://127.0.0.1:80")};
   NiceMock<StreamInfo::MockStreamInfo> stream_info_;
 #ifdef ENVOY_ENABLE_UHV
   NiceMock<MockClientHeaderValidator>* header_validator_{new NiceMock<MockClientHeaderValidator>};
@@ -572,7 +572,7 @@ protected:
   std::unique_ptr<CodecClientForTest> client_;
   std::shared_ptr<Upstream::MockClusterInfo> cluster_{new NiceMock<Upstream::MockClusterInfo>()};
   Upstream::HostDescriptionConstSharedPtr host_{
-      Upstream::makeTestHostDescription(cluster_, "tcp://127.0.0.1:80", simTime())};
+      Upstream::makeTestHostDescription(cluster_, "tcp://127.0.0.1:80")};
   Network::ConnectionPtr upstream_connection_;
   NiceMock<Network::MockConnectionCallbacks> upstream_callbacks_;
   Network::ClientConnection* client_connection_{};

--- a/test/common/http/conn_pool_grid_test.cc
+++ b/test/common/http/conn_pool_grid_test.cc
@@ -190,7 +190,7 @@ public:
         cluster_, host_impl_hostname_, *Network::Utility::resolveUrl("tcp://127.0.0.1:9000"),
         nullptr, nullptr, 1, envoy::config::core::v3::Locality(),
         envoy::config::endpoint::v3::Endpoint::HealthCheckConfig::default_instance(), 0,
-        envoy::config::core::v3::UNKNOWN, simTime(), address_list_));
+        envoy::config::core::v3::UNKNOWN, address_list_));
 
     grid_ = std::make_unique<ConnectivityGridForTest>(
         dispatcher_, random_, host_, Upstream::ResourcePriority::Default, socket_options_,
@@ -1693,7 +1693,7 @@ TEST_F(ConnectivityGridTest, RealGrid) {
           Return(Upstream::TransportSocketMatcher::MatchData(*factory, matcher.stats_, "test")));
 
   ConnectivityGrid grid(
-      dispatcher_, random_, Upstream::makeTestHost(cluster_, "tcp://127.0.0.1:9000", simTime()),
+      dispatcher_, random_, Upstream::makeTestHost(cluster_, "tcp://127.0.0.1:9000"),
       Upstream::ResourcePriority::Default, socket_options_, transport_socket_options_, state_,
       simTime(), alternate_protocols_, options_, quic_stat_names_, *store_.rootScope(),
       *quic_connection_persistent_info_, {}, overload_manager_);
@@ -1733,7 +1733,7 @@ TEST_F(ConnectivityGridTest, ConnectionCloseDuringAysnConnect) {
           Return(Upstream::TransportSocketMatcher::MatchData(*factory, matcher.stats_, "test")));
 
   ConnectivityGrid grid(
-      dispatcher_, random_, Upstream::makeTestHost(cluster_, "tcp://127.0.0.1:9000", simTime()),
+      dispatcher_, random_, Upstream::makeTestHost(cluster_, "tcp://127.0.0.1:9000"),
       Upstream::ResourcePriority::Default, socket_options_, transport_socket_options_, state_,
       simTime(), alternate_protocols_, options_, quic_stat_names_, *store_.rootScope(),
       *quic_connection_persistent_info_, {}, overload_manager_);

--- a/test/common/http/http1/conn_pool_test.cc
+++ b/test/common/http/http1/conn_pool_test.cc
@@ -64,7 +64,7 @@ public:
                       Event::MockSchedulableCallback* upstream_ready_cb,
                       Server::OverloadManager& overload_manager)
       : FixedHttpConnPoolImpl(
-            Upstream::makeTestHost(cluster, "tcp://127.0.0.1:9000", dispatcher.timeSource()),
+            Upstream::makeTestHost(cluster, "tcp://127.0.0.1:9000"),
             Upstream::ResourcePriority::Default, dispatcher, nullptr, nullptr, random_generator,
             state_,
             [](HttpConnPoolImplBase* pool) {
@@ -121,8 +121,7 @@ public:
             }
           }
         },
-        Upstream::makeTestHost(cluster, "tcp://127.0.0.1:9000", simTime()),
-        *test_client.client_dispatcher_);
+        Upstream::makeTestHost(cluster, "tcp://127.0.0.1:9000"), *test_client.client_dispatcher_);
     EXPECT_CALL(*test_client.connect_timer_, enableTimer(_, _));
     EXPECT_CALL(mock_dispatcher_, createClientConnection_(_, _, _, _))
         .WillOnce(Return(test_client.connection_));

--- a/test/common/http/http2/conn_pool_test.cc
+++ b/test/common/http/http2/conn_pool_test.cc
@@ -140,8 +140,7 @@ public:
       test_client.codec_client_ = new CodecClientForTest(
           CodecType::HTTP1, std::move(connection), test_client.codec_,
           [this](CodecClient*) -> void { onClientDestroy(); },
-          Upstream::makeTestHost(cluster, "tcp://127.0.0.1:9000", simTime()),
-          *test_client.client_dispatcher_);
+          Upstream::makeTestHost(cluster, "tcp://127.0.0.1:9000"), *test_client.client_dispatcher_);
       if (buffer_limits) {
         EXPECT_CALL(*cluster_, perConnectionBufferLimitBytes())
             .Times(num_clients)
@@ -219,7 +218,7 @@ public:
   Api::ApiPtr api_;
   NiceMock<Event::MockDispatcher> dispatcher_;
   std::shared_ptr<Upstream::MockClusterInfo> cluster_{new NiceMock<Upstream::MockClusterInfo>()};
-  Upstream::HostSharedPtr host_{Upstream::makeTestHost(cluster_, "tcp://127.0.0.1:80", simTime())};
+  Upstream::HostSharedPtr host_{Upstream::makeTestHost(cluster_, "tcp://127.0.0.1:80")};
   NiceMock<Event::MockSchedulableCallback>* upstream_ready_cb_;
   NiceMock<Server::MockOverloadManager> overload_manager_;
   std::unique_ptr<TestConnPoolImpl> pool_;
@@ -348,7 +347,7 @@ TEST_F(Http2ConnPoolImplTest, VerifyAlpnFallback) {
 
   // Recreate the conn pool so that the host re-evaluates the transport socket match, arriving at
   // our test transport socket factory.
-  host_ = Upstream::makeTestHost(cluster_, "tcp://127.0.0.1:80", simTime());
+  host_ = Upstream::makeTestHost(cluster_, "tcp://127.0.0.1:80");
   new NiceMock<Event::MockSchedulableCallback>(&dispatcher_);
   pool_ = std::make_unique<TestConnPoolImpl>(dispatcher_, random_, host_,
                                              Upstream::ResourcePriority::Default, nullptr, nullptr,

--- a/test/common/http/mixed_conn_pool_test.cc
+++ b/test/common/http/mixed_conn_pool_test.cc
@@ -34,7 +34,7 @@ public:
                       HttpServerPropertiesCacheSharedPtr cache,
                       Server::OverloadManager& overload_manager)
       : HttpConnPoolImplMixed(dispatcher, random,
-                              Upstream::makeTestHost(cluster, "tcp://127.0.0.1:9000", simTime()),
+                              Upstream::makeTestHost(cluster, "tcp://127.0.0.1:9000"),
                               Upstream::ResourcePriority::Default, nullptr, nullptr, state, origin,
                               cache, overload_manager) {}
 };

--- a/test/common/tcp/async_tcp_client_impl_test.cc
+++ b/test/common/tcp/async_tcp_client_impl_test.cc
@@ -47,7 +47,7 @@ public:
     conn_info.connection_ = connection_;
 
     conn_info.host_description_ = Upstream::makeTestHost(
-        std::make_unique<NiceMock<Upstream::MockClusterInfo>>(), "tcp://127.0.0.1:80", simTime());
+        std::make_unique<NiceMock<Upstream::MockClusterInfo>>(), "tcp://127.0.0.1:80");
 
     EXPECT_CALL(cluster_manager_.thread_local_cluster_, tcpConn_(_)).WillOnce(Return(conn_info));
     EXPECT_CALL(*connection_, connect());

--- a/test/common/tcp/conn_pool_test.cc
+++ b/test/common/tcp/conn_pool_test.cc
@@ -236,7 +236,7 @@ class TcpConnPoolImplTest : public Event::TestUsingSimulatedTime, public testing
 public:
   TcpConnPoolImplTest()
       : upstream_ready_cb_(new NiceMock<Event::MockSchedulableCallback>(&dispatcher_)),
-        host_(Upstream::makeTestHost(cluster_, "tcp://127.0.0.1:9000", simTime())) {}
+        host_(Upstream::makeTestHost(cluster_, "tcp://127.0.0.1:9000")) {}
 
   ~TcpConnPoolImplTest() override {
     EXPECT_TRUE(TestUtility::gaugesZeroed(cluster_->stats_store_.gauges()))
@@ -268,7 +268,7 @@ class TcpConnPoolImplDestructorTest : public Event::TestUsingSimulatedTime, publ
 public:
   TcpConnPoolImplDestructorTest()
       : upstream_ready_cb_(new NiceMock<Event::MockSchedulableCallback>(&dispatcher_)) {
-    host_ = Upstream::makeTestHost(cluster_, "tcp://127.0.0.1:9000", simTime());
+    host_ = Upstream::makeTestHost(cluster_, "tcp://127.0.0.1:9000");
     conn_pool_ =
         std::make_unique<ConnPoolImpl>(dispatcher_, host_, Upstream::ResourcePriority::Default,
                                        nullptr, nullptr, state_, absl::nullopt, overload_manager_);

--- a/test/common/upstream/cluster_manager_lifecycle_test.cc
+++ b/test/common/upstream/cluster_manager_lifecycle_test.cc
@@ -77,7 +77,6 @@ TEST_P(ClusterManagerLifecycleTest, ShutdownOrder) {
 
 TEST_P(ClusterManagerLifecycleTest, InitializeOrder) {
   time_system_.setSystemTime(std::chrono::milliseconds(1234567891234));
-
   const std::string json = fmt::sprintf(
       R"EOF(
   {
@@ -345,8 +344,7 @@ TEST_P(ClusterManagerLifecycleTest, DynamicRemoveWithLocalCluster) {
 
   // Fire a member callback on the local cluster, which should not call any update callbacks on
   // the deleted cluster.
-  foo->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(foo->info_, "tcp://127.0.0.1:80", time_system_)};
+  foo->prioritySet().getMockHostSet(0)->hosts_ = {makeTestHost(foo->info_, "tcp://127.0.0.1:80")};
   EXPECT_CALL(membership_updated, ready());
   foo->prioritySet().getMockHostSet(0)->runCallbacks(foo->prioritySet().getMockHostSet(0)->hosts_,
                                                      {});
@@ -727,7 +725,7 @@ TEST_P(ClusterManagerLifecycleTest, DynamicAddRemove) {
 
   std::shared_ptr<MockClusterMockPrioritySet> cluster2(new NiceMock<MockClusterMockPrioritySet>());
   cluster2->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster2->info_, "tcp://127.0.0.1:80", time_system_)};
+      makeTestHost(cluster2->info_, "tcp://127.0.0.1:80")};
   EXPECT_CALL(factory_, clusterFromProto_(_, _, _, _))
       .WillOnce(Return(std::make_pair(cluster2, nullptr)));
   EXPECT_CALL(*cluster2, initializePhase()).Times(0);
@@ -836,7 +834,7 @@ TEST_P(ClusterManagerLifecycleTest, ClusterAddOrUpdateCallbackRemovalDuringItera
 
   std::shared_ptr<MockClusterMockPrioritySet> cluster2(new NiceMock<MockClusterMockPrioritySet>());
   cluster2->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster2->info_, "tcp://127.0.0.1:80", time_system_)};
+      makeTestHost(cluster2->info_, "tcp://127.0.0.1:80")};
   EXPECT_CALL(factory_, clusterFromProto_(_, _, _, _))
       .WillOnce(Return(std::make_pair(cluster2, nullptr)));
   EXPECT_CALL(*cluster2, initializePhase()).Times(0);
@@ -905,11 +903,11 @@ TEST_P(ClusterManagerLifecycleTest, HostsPostedToTlsCluster) {
   cluster1->initialize_callback_();
 
   // Set up the HostSet with 1 healthy, 1 degraded and 1 unhealthy.
-  HostSharedPtr host1 = makeTestHost(cluster1->info_, "tcp://127.0.0.1:80", time_system_);
+  HostSharedPtr host1 = makeTestHost(cluster1->info_, "tcp://127.0.0.1:80");
   host1->healthFlagSet(HostImpl::HealthFlag::DEGRADED_ACTIVE_HC);
-  HostSharedPtr host2 = makeTestHost(cluster1->info_, "tcp://127.0.0.1:80", time_system_);
+  HostSharedPtr host2 = makeTestHost(cluster1->info_, "tcp://127.0.0.1:80");
   host2->healthFlagSet(HostImpl::HealthFlag::FAILED_ACTIVE_HC);
-  HostSharedPtr host3 = makeTestHost(cluster1->info_, "tcp://127.0.0.1:80", time_system_);
+  HostSharedPtr host3 = makeTestHost(cluster1->info_, "tcp://127.0.0.1:80");
 
   HostVector hosts{host1, host2, host3};
   auto hosts_ptr = std::make_shared<HostVector>(hosts);
@@ -940,7 +938,7 @@ TEST_P(ClusterManagerLifecycleTest, CloseHttpConnectionsOnHealthFailure) {
                                         clustersJson({defaultStaticClusterJson("some_cluster")}));
   std::shared_ptr<MockClusterMockPrioritySet> cluster1(new NiceMock<MockClusterMockPrioritySet>());
   cluster1->info_->name_ = "some_cluster";
-  HostSharedPtr test_host = makeTestHost(cluster1->info_, "tcp://127.0.0.1:80", time_system_);
+  HostSharedPtr test_host = makeTestHost(cluster1->info_, "tcp://127.0.0.1:80");
   cluster1->prioritySet().getMockHostSet(0)->hosts_ = {test_host};
   ON_CALL(*cluster1, initializePhase()).WillByDefault(Return(Cluster::InitializePhase::Primary));
 
@@ -1016,7 +1014,7 @@ TEST_P(ClusterManagerLifecycleTest,
   EXPECT_CALL(*cluster1->info_, features())
       .WillRepeatedly(Return(ClusterInfo::Features::CLOSE_CONNECTIONS_ON_HOST_HEALTH_FAILURE));
   cluster1->info_->name_ = "some_cluster";
-  HostSharedPtr test_host = makeTestHost(cluster1->info_, "tcp://127.0.0.1:80", time_system_);
+  HostSharedPtr test_host = makeTestHost(cluster1->info_, "tcp://127.0.0.1:80");
   cluster1->prioritySet().getMockHostSet(0)->hosts_ = {test_host};
   ON_CALL(*cluster1, initializePhase()).WillByDefault(Return(Cluster::InitializePhase::Primary));
 
@@ -1069,7 +1067,7 @@ TEST_P(ClusterManagerLifecycleTest, CloseHttpConnectionsAndDeletePoolOnHealthFai
                                         clustersJson({defaultStaticClusterJson("some_cluster")}));
   std::shared_ptr<MockClusterMockPrioritySet> cluster1(new NiceMock<MockClusterMockPrioritySet>());
   cluster1->info_->name_ = "some_cluster";
-  HostSharedPtr test_host = makeTestHost(cluster1->info_, "tcp://127.0.0.1:80", time_system_);
+  HostSharedPtr test_host = makeTestHost(cluster1->info_, "tcp://127.0.0.1:80");
   cluster1->prioritySet().getMockHostSet(0)->hosts_ = {test_host};
   ON_CALL(*cluster1, initializePhase()).WillByDefault(Return(Cluster::InitializePhase::Primary));
 
@@ -1116,7 +1114,7 @@ TEST_P(ClusterManagerLifecycleTest, CloseTcpConnectionPoolsOnHealthFailure) {
                                         clustersJson({defaultStaticClusterJson("some_cluster")}));
   std::shared_ptr<MockClusterMockPrioritySet> cluster1(new NiceMock<MockClusterMockPrioritySet>());
   cluster1->info_->name_ = "some_cluster";
-  HostSharedPtr test_host = makeTestHost(cluster1->info_, "tcp://127.0.0.1:80", time_system_);
+  HostSharedPtr test_host = makeTestHost(cluster1->info_, "tcp://127.0.0.1:80");
   cluster1->prioritySet().getMockHostSet(0)->hosts_ = {test_host};
   ON_CALL(*cluster1, initializePhase()).WillByDefault(Return(Cluster::InitializePhase::Primary));
 
@@ -1191,7 +1189,7 @@ TEST_P(ClusterManagerLifecycleTest, CloseTcpConnectionsOnHealthFailure) {
   EXPECT_CALL(*cluster1->info_, features())
       .WillRepeatedly(Return(ClusterInfo::Features::CLOSE_CONNECTIONS_ON_HOST_HEALTH_FAILURE));
   cluster1->info_->name_ = "some_cluster";
-  HostSharedPtr test_host = makeTestHost(cluster1->info_, "tcp://127.0.0.1:80", time_system_);
+  HostSharedPtr test_host = makeTestHost(cluster1->info_, "tcp://127.0.0.1:80");
   cluster1->prioritySet().getMockHostSet(0)->hosts_ = {test_host};
   ON_CALL(*cluster1, initializePhase()).WillByDefault(Return(Cluster::InitializePhase::Primary));
 
@@ -1268,7 +1266,7 @@ TEST_P(ClusterManagerLifecycleTest, DoNotCloseTcpConnectionsOnHealthFailure) {
   std::shared_ptr<MockClusterMockPrioritySet> cluster1(new NiceMock<MockClusterMockPrioritySet>());
   EXPECT_CALL(*cluster1->info_, features()).WillRepeatedly(Return(0));
   cluster1->info_->name_ = "some_cluster";
-  HostSharedPtr test_host = makeTestHost(cluster1->info_, "tcp://127.0.0.1:80", time_system_);
+  HostSharedPtr test_host = makeTestHost(cluster1->info_, "tcp://127.0.0.1:80");
   cluster1->prioritySet().getMockHostSet(0)->hosts_ = {test_host};
   ON_CALL(*cluster1, initializePhase()).WillByDefault(Return(Cluster::InitializePhase::Primary));
 
@@ -2475,8 +2473,8 @@ TEST_P(ClusterManagerLifecycleTest, DrainConnectionsPredicate) {
 
   // Set up the HostSet.
   Cluster& cluster = cluster_manager_->activeClusters().begin()->second;
-  HostSharedPtr host1 = makeTestHost(cluster.info(), "tcp://127.0.0.1:80", time_system_);
-  HostSharedPtr host2 = makeTestHost(cluster.info(), "tcp://127.0.0.1:81", time_system_);
+  HostSharedPtr host1 = makeTestHost(cluster.info(), "tcp://127.0.0.1:80");
+  HostSharedPtr host2 = makeTestHost(cluster.info(), "tcp://127.0.0.1:81");
 
   HostVector hosts{host1, host2};
   auto hosts_ptr = std::make_shared<HostVector>(hosts);
@@ -2553,8 +2551,8 @@ TEST_P(ClusterManagerLifecycleTest, ConnPoolsDrainedOnHostSetChange) {
   Cluster& cluster = cluster_manager_->activeClusters().begin()->second;
 
   // Set up the HostSet.
-  HostSharedPtr host1 = makeTestHost(cluster.info(), "tcp://127.0.0.1:80", time_system_);
-  HostSharedPtr host2 = makeTestHost(cluster.info(), "tcp://127.0.0.1:81", time_system_);
+  HostSharedPtr host1 = makeTestHost(cluster.info(), "tcp://127.0.0.1:80");
+  HostSharedPtr host2 = makeTestHost(cluster.info(), "tcp://127.0.0.1:81");
 
   HostVector hosts{host1, host2};
   auto hosts_ptr = std::make_shared<HostVector>(hosts);
@@ -2639,7 +2637,7 @@ TEST_P(ClusterManagerLifecycleTest, ConnPoolsDrainedOnHostSetChange) {
   tcp1 = TcpPoolDataPeer::getPool(cluster_manager_->getThreadLocalCluster("cluster_1")
                                       ->tcpConnPool(ResourcePriority::Default, nullptr));
 
-  HostSharedPtr host3 = makeTestHost(cluster.info(), "tcp://127.0.0.1:82", time_system_);
+  HostSharedPtr host3 = makeTestHost(cluster.info(), "tcp://127.0.0.1:82");
 
   HostVector hosts_added;
   hosts_added.push_back(host3);
@@ -2685,7 +2683,7 @@ TEST_P(ClusterManagerLifecycleTest, ConnPoolsNotDrainedOnHostSetChange) {
   Cluster& cluster = cluster_manager_->activeClusters().begin()->second;
 
   // Set up the HostSet.
-  HostSharedPtr host1 = makeTestHost(cluster.info(), "tcp://127.0.0.1:80", time_system_);
+  HostSharedPtr host1 = makeTestHost(cluster.info(), "tcp://127.0.0.1:80");
 
   HostVector hosts{host1};
   auto hosts_ptr = std::make_shared<HostVector>(hosts);
@@ -2714,7 +2712,7 @@ TEST_P(ClusterManagerLifecycleTest, ConnPoolsNotDrainedOnHostSetChange) {
       TcpPoolDataPeer::getPool(cluster_manager_->getThreadLocalCluster("cluster_1")
                                    ->tcpConnPool(ResourcePriority::Default, nullptr));
 
-  HostSharedPtr host2 = makeTestHost(cluster.info(), "tcp://127.0.0.1:82", time_system_);
+  HostSharedPtr host2 = makeTestHost(cluster.info(), "tcp://127.0.0.1:82");
   HostVector hosts_added;
   hosts_added.push_back(host2);
 
@@ -2758,7 +2756,7 @@ TEST_P(ClusterManagerLifecycleTest, ConnPoolsIdleDeleted) {
   Cluster& cluster = cluster_manager_->activeClusters().begin()->second;
 
   // Set up the HostSet.
-  HostSharedPtr host1 = makeTestHost(cluster.info(), "tcp://127.0.0.1:80", time_system_);
+  HostSharedPtr host1 = makeTestHost(cluster.info(), "tcp://127.0.0.1:80");
 
   HostVector hosts{host1};
   auto hosts_ptr = std::make_shared<HostVector>(hosts);

--- a/test/common/upstream/cluster_manager_misc_test.cc
+++ b/test/common/upstream/cluster_manager_misc_test.cc
@@ -143,7 +143,7 @@ public:
     EXPECT_EQ(nullptr, cluster_manager_->getThreadLocalCluster("cluster_0"));
 
     cluster1->prioritySet().getMockHostSet(0)->hosts_ = {
-        makeTestHost(cluster1->info_, "tcp://127.0.0.1:80", time_system_)};
+        makeTestHost(cluster1->info_, "tcp://127.0.0.1:80")};
     cluster1->prioritySet().getMockHostSet(0)->runCallbacks(
         cluster1->prioritySet().getMockHostSet(0)->hosts_, {});
     cluster1->initialize_callback_();
@@ -259,7 +259,7 @@ TEST_F(ClusterManagerImplThreadAwareLbTest, LoadBalancerCanUpdateMetadata) {
   EXPECT_EQ(nullptr, cluster_manager_->getThreadLocalCluster("cluster_0"));
 
   cluster1->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster1->info_, "tcp://127.0.0.1:80", time_system_)};
+      makeTestHost(cluster1->info_, "tcp://127.0.0.1:80")};
   cluster1->prioritySet().getMockHostSet(0)->runCallbacks(
       cluster1->prioritySet().getMockHostSet(0)->hosts_, {});
   cluster1->initialize_callback_();
@@ -1029,10 +1029,10 @@ public:
     cluster_ = &cluster_manager_->activeClusters().begin()->second.get();
 
     // Set up the HostSet.
-    host1_ = makeTestHost(cluster_->info(), "tcp://127.0.0.1:80", time_system_);
-    host2_ = makeTestHost(cluster_->info(), "tcp://127.0.0.1:80", time_system_);
-    host3_ = makeTestHost(cluster_->info(), "tcp://127.0.0.1:80", time_system_);
-    host4_ = makeTestHost(cluster_->info(), "tcp://127.0.0.1:80", time_system_);
+    host1_ = makeTestHost(cluster_->info(), "tcp://127.0.0.1:80");
+    host2_ = makeTestHost(cluster_->info(), "tcp://127.0.0.1:80");
+    host3_ = makeTestHost(cluster_->info(), "tcp://127.0.0.1:80");
+    host4_ = makeTestHost(cluster_->info(), "tcp://127.0.0.1:80");
 
     HostVector hosts{host1_, host2_, host3_, host4_};
     auto hosts_ptr = std::make_shared<HostVector>(hosts);

--- a/test/common/upstream/health_check_fuzz.cc
+++ b/test/common/upstream/health_check_fuzz.cc
@@ -101,9 +101,8 @@ void HttpHealthCheckFuzz::initialize(test::common::upstream::HealthCheckTestCase
   allocHttpHealthCheckerFromProto(input.health_check_config());
   ON_CALL(context_.runtime_.snapshot_, featureEnabled("health_check.verify_cluster", 100))
       .WillByDefault(testing::Return(input.http_verify_cluster()));
-  auto time_source = std::make_unique<NiceMock<MockTimeSystem>>();
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", *time_source)};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   if (input.upstream_cx_success()) {
     cluster_->info_->trafficStats()->upstream_cx_total_.inc();
   }
@@ -216,9 +215,8 @@ void TcpHealthCheckFuzz::allocTcpHealthCheckerFromProto(
 
 void TcpHealthCheckFuzz::initialize(test::common::upstream::HealthCheckTestCase input) {
   allocTcpHealthCheckerFromProto(input.health_check_config());
-  auto time_source = std::make_unique<NiceMock<MockTimeSystem>>();
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", *time_source)};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   if (input.upstream_cx_success()) {
     cluster_->info_->trafficStats()->upstream_cx_total_.inc();
   }
@@ -334,9 +332,8 @@ void GrpcHealthCheckFuzz::allocGrpcHealthCheckerFromProto(
 void GrpcHealthCheckFuzz::initialize(test::common::upstream::HealthCheckTestCase input) {
   test_session_ = std::make_unique<TestSession>();
   allocGrpcHealthCheckerFromProto(input.health_check_config());
-  auto time_source = std::make_unique<NiceMock<MockTimeSystem>>();
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", *time_source)};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   if (input.upstream_cx_success()) {
     cluster_->info_->trafficStats()->upstream_cx_total_.inc();
   }
@@ -352,11 +349,9 @@ void GrpcHealthCheckFuzz::initialize(test::common::upstream::HealthCheckTestCase
             std::shared_ptr<Upstream::MockClusterInfo> cluster{
                 new NiceMock<Upstream::MockClusterInfo>()};
             Event::MockDispatcher dispatcher_;
-            auto time_source = std::make_unique<NiceMock<MockTimeSystem>>();
             test_session.codec_client_ = new CodecClientForTest(
                 Http::CodecType::HTTP1, std::move(conn_data.connection_), test_session.codec_,
-                nullptr, Upstream::makeTestHost(cluster, "tcp://127.0.0.1:9000", *time_source),
-                dispatcher_);
+                nullptr, Upstream::makeTestHost(cluster, "tcp://127.0.0.1:9000"), dispatcher_);
             return test_session.codec_client_;
           }));
   expectStreamCreate();

--- a/test/common/upstream/health_check_fuzz_test_utils.cc
+++ b/test/common/upstream/health_check_fuzz_test_utils.cc
@@ -53,9 +53,7 @@ void HttpHealthCheckerImplTestBase::expectClientCreate(
             Event::MockDispatcher dispatcher_;
             test_session.codec_client_ = new CodecClientForTest(
                 Http::CodecType::HTTP1, std::move(conn_data.connection_), test_session.codec_,
-                nullptr,
-                Upstream::makeTestHost(cluster, "tcp://127.0.0.1:9000", dispatcher_.timeSource()),
-                dispatcher_);
+                nullptr, Upstream::makeTestHost(cluster, "tcp://127.0.0.1:9000"), dispatcher_);
             return test_session.codec_client_;
           }));
 }
@@ -130,9 +128,7 @@ void GrpcHealthCheckerImplTestBaseUtils::expectClientCreate(size_t index) {
 
             test_session.codec_client_ = new CodecClientForTest(
                 Http::CodecType::HTTP1, std::move(conn_data.connection_), test_session.codec_,
-                nullptr,
-                Upstream::makeTestHost(cluster, "tcp://127.0.0.1:9000", dispatcher_.timeSource()),
-                dispatcher_);
+                nullptr, Upstream::makeTestHost(cluster, "tcp://127.0.0.1:9000"), dispatcher_);
             return test_session.codec_client_;
           }));
 }

--- a/test/common/upstream/health_checker_impl_test.cc
+++ b/test/common/upstream/health_checker_impl_test.cc
@@ -599,8 +599,8 @@ public:
                        const HostWithHealthCheckMap& hosts, const std::string& protocol = "tcp://",
                        const uint32_t priority = 0) {
     for (const auto& host : hosts) {
-      cluster->prioritySet().getMockHostSet(priority)->hosts_.emplace_back(makeTestHost(
-          cluster->info_, fmt::format("{}{}", protocol, host.first), host.second, simTime()));
+      cluster->prioritySet().getMockHostSet(priority)->hosts_.emplace_back(
+          makeTestHost(cluster->info_, fmt::format("{}{}", protocol, host.first), host.second));
     }
   }
 
@@ -720,8 +720,7 @@ public:
               Event::MockDispatcher dispatcher_;
               test_session.codec_client_ = new CodecClientForTest(
                   Http::CodecType::HTTP1, std::move(conn_data.connection_), test_session.codec_,
-                  nullptr, Upstream::makeTestHost(cluster, "tcp://127.0.0.1:9000", simTime()),
-                  dispatcher_);
+                  nullptr, Upstream::makeTestHost(cluster, "tcp://127.0.0.1:9000"), dispatcher_);
               return test_session.codec_client_;
             }));
   }
@@ -794,7 +793,7 @@ public:
   void expectSuccessStartFailedFailFirst(
       const absl::optional<std::string>& health_checked_cluster = absl::optional<std::string>()) {
     cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-        makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+        makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
     cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthFlagSet(
         Host::HealthFlag::FAILED_ACTIVE_HC);
     expectSessionCreate();
@@ -882,7 +881,7 @@ TEST_F(HttpHealthCheckerImplTest, Success) {
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
 
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   cluster_->info_->trafficStats()->upstream_cx_total_.inc();
   expectSessionCreate();
   expectStreamCreate(0);
@@ -905,7 +904,7 @@ TEST_F(HttpHealthCheckerImplTest, Degraded) {
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Changed)).Times(2);
 
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   cluster_->info_->trafficStats()->upstream_cx_total_.inc();
   expectSessionCreate();
   expectStreamCreate(0);
@@ -943,7 +942,7 @@ TEST_F(HttpHealthCheckerImplTest, SuccessIntervalJitter) {
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged)).Times(testing::AnyNumber());
 
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   expectSessionCreate();
   expectStreamCreate(0);
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_, _));
@@ -973,7 +972,7 @@ TEST_F(HttpHealthCheckerImplTest, InitialJitterNoTraffic) {
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged)).Times(testing::AnyNumber());
 
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   expectSessionCreate();
   expectStreamCreate(0);
   EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(_, _));
@@ -1005,7 +1004,7 @@ TEST_F(HttpHealthCheckerImplTest, SuccessIntervalJitterPercentNoTraffic) {
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged)).Times(testing::AnyNumber());
 
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   expectSessionCreate();
   expectStreamCreate(0);
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_, _));
@@ -1035,7 +1034,7 @@ TEST_F(HttpHealthCheckerImplTest, SuccessIntervalJitterPercent) {
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged)).Times(testing::AnyNumber());
 
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   cluster_->info_->trafficStats()->upstream_cx_total_.inc();
   expectSessionCreate();
   expectStreamCreate(0);
@@ -1066,7 +1065,7 @@ TEST_F(HttpHealthCheckerImplTest, SuccessWithSpurious1xx) {
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
 
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   cluster_->info_->trafficStats()->upstream_cx_total_.inc();
   expectSessionCreate();
   expectStreamCreate(0);
@@ -1094,7 +1093,7 @@ TEST_F(HttpHealthCheckerImplTest, SuccessWithSpuriousMetadata) {
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
 
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   cluster_->info_->trafficStats()->upstream_cx_total_.inc();
   expectSessionCreate();
   expectStreamCreate(0);
@@ -1123,8 +1122,8 @@ TEST_F(HttpHealthCheckerImplTest, SuccessWithMultipleHosts) {
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged)).Times(2);
 
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime()),
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:81", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80"),
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:81")};
   cluster_->info_->trafficStats()->upstream_cx_total_.inc();
   cluster_->info_->trafficStats()->upstream_cx_total_.inc();
   expectSessionCreate();
@@ -1159,9 +1158,9 @@ TEST_F(HttpHealthCheckerImplTest, SuccessWithMultipleHostSets) {
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged)).Times(2);
 
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   cluster_->prioritySet().getMockHostSet(1)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:81", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:81")};
   cluster_->info_->trafficStats()->upstream_cx_total_.inc();
   cluster_->info_->trafficStats()->upstream_cx_total_.inc();
   expectSessionCreate();
@@ -1195,7 +1194,7 @@ TEST_F(HttpHealthCheckerImplTest, SuccessExpectedResponseCheck) {
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
 
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   cluster_->info_->trafficStats()->upstream_cx_total_.inc();
   expectSessionCreate();
   expectStreamCreate(0);
@@ -1218,7 +1217,7 @@ TEST_F(HttpHealthCheckerImplTest, SuccessExpectedResponseStringContainsCheck) {
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
 
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   cluster_->info_->trafficStats()->upstream_cx_total_.inc();
   expectSessionCreate();
   expectStreamCreate(0);
@@ -1242,7 +1241,7 @@ TEST_F(HttpHealthCheckerImplTest, SuccessExpectedResponseHexStringContainsCheck)
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
 
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   cluster_->info_->trafficStats()->upstream_cx_total_.inc();
   expectSessionCreate();
   expectStreamCreate(0);
@@ -1265,7 +1264,7 @@ TEST_F(HttpHealthCheckerImplTest, SuccessExpectedResponseCheckBuffer) {
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
 
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   cluster_->info_->trafficStats()->upstream_cx_total_.inc();
   expectSessionCreate();
   expectStreamCreate(0);
@@ -1290,7 +1289,7 @@ TEST_F(HttpHealthCheckerImplTest, SuccessExpectedResponseCheckMaxBuffer) {
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
 
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   cluster_->info_->trafficStats()->upstream_cx_total_.inc();
   expectSessionCreate();
   expectStreamCreate(0);
@@ -1330,7 +1329,7 @@ TEST_F(HttpHealthCheckerImplTest, SuccessExpectedResponseCheckHttp2) {
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
 
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   cluster_->info_->trafficStats()->upstream_cx_total_.inc();
   expectSessionCreate();
   expectStreamCreate(0);
@@ -1355,7 +1354,7 @@ TEST_F(HttpHealthCheckerImplTest, FailExpectedResponseCheck) {
   EXPECT_CALL(event_logger_, logUnhealthy(_, _, _, true));
 
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   cluster_->info_->trafficStats()->upstream_cx_total_.inc();
   expectSessionCreate();
   expectStreamCreate(0);
@@ -1381,7 +1380,7 @@ TEST_F(HttpHealthCheckerImplTest, FailStatusCheckWithExpectedResponseCheck) {
   EXPECT_CALL(event_logger_, logUnhealthy(_, _, _, true));
 
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   cluster_->info_->trafficStats()->upstream_cx_total_.inc();
   expectSessionCreate();
   expectStreamCreate(0);
@@ -1406,7 +1405,7 @@ TEST_F(HttpHealthCheckerImplTest, ImmediateFailExpectedResponseCheck) {
   EXPECT_CALL(event_logger_, logUnhealthy(_, _, _, true));
 
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   cluster_->info_->trafficStats()->upstream_cx_total_.inc();
   expectSessionCreate();
   expectStreamCreate(0);
@@ -1453,7 +1452,7 @@ TEST_F(HttpHealthCheckerImplTest, ZeroRetryInterval) {
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
 
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   cluster_->info_->trafficStats()->upstream_cx_total_.inc();
   expectSessionCreate();
   expectStreamCreate(0);
@@ -1512,7 +1511,7 @@ TEST_F(HttpHealthCheckerImplTest, TlsOptions) {
 
   allocHealthChecker(yaml);
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   cluster_->info_->trafficStats()->upstream_cx_total_.inc();
   expectSessionCreate();
   expectStreamCreate(0);
@@ -1530,7 +1529,7 @@ TEST_F(HttpHealthCheckerImplTest, SuccessServiceCheckSetsCorrectLastHcPassTime) 
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
   simTime().advanceTimeWait(std::chrono::seconds(1));
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   cluster_->info_->trafficStats()->upstream_cx_total_.inc();
   expectSessionCreate();
   expectStreamCreate(0);
@@ -1613,7 +1612,7 @@ TEST_F(HttpHealthCheckerImplTest, SuccessServicePrefixPatternCheck) {
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
 
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   cluster_->info_->trafficStats()->upstream_cx_total_.inc();
   expectSessionCreate();
   expectStreamCreate(0);
@@ -1649,7 +1648,7 @@ TEST_F(HttpHealthCheckerImplTest, SuccessServiceExactPatternCheck) {
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
 
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   cluster_->info_->trafficStats()->upstream_cx_total_.inc();
   expectSessionCreate();
   expectStreamCreate(0);
@@ -1685,7 +1684,7 @@ TEST_F(HttpHealthCheckerImplTest, SuccessServiceRegexPatternCheck) {
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
 
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   cluster_->info_->trafficStats()->upstream_cx_total_.inc();
   expectSessionCreate();
   expectStreamCreate(0);
@@ -1720,7 +1719,7 @@ TEST_F(HttpHealthCheckerImplTest, SuccessServiceCheckWithCustomHostValueOnTheHos
   auto test_host = std::shared_ptr<Upstream::HostImpl>(
       *HostImpl::create(cluster_->info_, "", *Network::Utility::resolveUrl("tcp://127.0.0.1:80"),
                         nullptr, nullptr, 1, envoy::config::core::v3::Locality(),
-                        health_check_config, 0, envoy::config::core::v3::UNKNOWN, simTime()));
+                        health_check_config, 0, envoy::config::core::v3::UNKNOWN));
   const std::string path = "/healthcheck";
   setupServiceValidationHC();
   // Requires non-empty `service_name` in config.
@@ -1765,7 +1764,7 @@ TEST_F(HttpHealthCheckerImplTest,
   auto test_host = std::shared_ptr<Upstream::HostImpl>(
       *HostImpl::create(cluster_->info_, "", *Network::Utility::resolveUrl("tcp://127.0.0.1:80"),
                         nullptr, nullptr, 1, envoy::config::core::v3::Locality(),
-                        health_check_config, 0, envoy::config::core::v3::UNKNOWN, simTime()));
+                        health_check_config, 0, envoy::config::core::v3::UNKNOWN));
   const std::string path = "/healthcheck";
   // Setup health check config with a different host, to check that we still get the host configured
   // on the endpoint.
@@ -1812,7 +1811,7 @@ TEST_F(HttpHealthCheckerImplTest, SuccessServiceCheckWithCustomHostValue) {
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
 
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   cluster_->info_->trafficStats()->upstream_cx_total_.inc();
   expectSessionCreate();
   expectStreamCreate(0);
@@ -1877,7 +1876,7 @@ TEST_F(HttpHealthCheckerImplTest, SuccessServiceCheckWithAdditionalHeaders) {
       )EOF");
 
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", metadata, simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", metadata)};
   cluster_->info_->trafficStats()->upstream_cx_total_.inc();
   expectSessionCreate();
   expectStreamCreate(0);
@@ -1942,7 +1941,7 @@ TEST_F(HttpHealthCheckerImplTest, SuccessServiceCheckWithoutUserAgent) {
 
   std::string current_start_time;
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", metadata, simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", metadata)};
   cluster_->info_->trafficStats()->upstream_cx_total_.inc();
   expectSessionCreate();
   expectStreamCreate(0);
@@ -1980,7 +1979,7 @@ TEST_F(HttpHealthCheckerImplTest, ServiceDoesNotMatchFail) {
   EXPECT_CALL(event_logger_, logEjectUnhealthy(_, _, _));
 
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   cluster_->info_->trafficStats()->upstream_cx_total_.inc();
   expectSessionCreate();
   expectStreamCreate(0);
@@ -2012,7 +2011,7 @@ TEST_F(HttpHealthCheckerImplTest, ServicePatternDoesNotMatchFail) {
   EXPECT_CALL(event_logger_, logEjectUnhealthy(_, _, _));
 
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   cluster_->info_->trafficStats()->upstream_cx_total_.inc();
   expectSessionCreate();
   expectStreamCreate(0);
@@ -2043,7 +2042,7 @@ TEST_F(HttpHealthCheckerImplTest, ServiceNotPresentInResponseFail) {
   EXPECT_CALL(event_logger_, logEjectUnhealthy(_, _, _));
 
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   cluster_->info_->trafficStats()->upstream_cx_total_.inc();
   expectSessionCreate();
   expectStreamCreate(0);
@@ -2071,7 +2070,7 @@ TEST_F(HttpHealthCheckerImplTest, ServiceCheckRuntimeOff) {
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
 
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   cluster_->info_->trafficStats()->upstream_cx_total_.inc();
   expectSessionCreate();
   expectStreamCreate(0);
@@ -2098,7 +2097,7 @@ TEST_F(HttpHealthCheckerImplTest, ServiceCheckRuntimeOffWithStringPattern) {
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
 
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   cluster_->info_->trafficStats()->upstream_cx_total_.inc();
   expectSessionCreate();
   expectStreamCreate(0);
@@ -2130,7 +2129,7 @@ TEST_F(HttpHealthCheckerImplTest, SuccessNoTraffic) {
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
 
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   expectSessionCreate();
   expectStreamCreate(0);
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_, _));
@@ -2148,7 +2147,7 @@ TEST_F(HttpHealthCheckerImplTest, SuccessNoTraffic) {
 TEST_F(HttpHealthCheckerImplTest, UnhealthyTransitionNoTrafficHealthy) {
   setupNoTrafficHealthyValidationHC();
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthFlagSet(
       Host::HealthFlag::FAILED_ACTIVE_HC);
   expectSessionCreate();
@@ -2170,7 +2169,7 @@ TEST_F(HttpHealthCheckerImplTest, UnhealthyTransitionNoTrafficHealthy) {
 TEST_F(HttpHealthCheckerImplTest, SuccessStartFailedSuccessFirst) {
   setupNoServiceValidationHC();
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthFlagSet(
       Host::HealthFlag::FAILED_ACTIVE_HC);
   expectSessionCreate();
@@ -2204,7 +2203,7 @@ TEST_F(HttpHealthCheckerImplTest, SuccessStartFailedFailFirstLogError) {
 TEST_F(HttpHealthCheckerImplTest, HttpFailRemoveHostInCallbackNoClose) {
   setupNoServiceValidationHC();
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   expectSessionCreate();
   expectStreamCreate(0);
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_, _));
@@ -2226,7 +2225,7 @@ TEST_F(HttpHealthCheckerImplTest, HttpFailRemoveHostInCallbackNoClose) {
 TEST_F(HttpHealthCheckerImplTest, HttpFailRemoveHostInCallbackClose) {
   setupNoServiceValidationHC();
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   expectSessionCreate();
   expectStreamCreate(0);
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_, _));
@@ -2247,7 +2246,7 @@ TEST_F(HttpHealthCheckerImplTest, HttpFailRemoveHostInCallbackClose) {
 TEST_F(HttpHealthCheckerImplTest, HttpFail) {
   setupNoServiceValidationHC();
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   expectSessionCreate();
   expectStreamCreate(0);
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_, _));
@@ -2295,7 +2294,7 @@ TEST_F(HttpHealthCheckerImplTest, HttpFail) {
 TEST_F(HttpHealthCheckerImplTest, ImmediateFailure) {
   setupNoServiceValidationHC();
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   expectSessionCreate();
   expectStreamCreate(0);
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_, _));
@@ -2318,7 +2317,7 @@ TEST_F(HttpHealthCheckerImplTest, ImmediateFailure) {
 TEST_F(HttpHealthCheckerImplTest, HttpFailLogError) {
   setupNoServiceValidationHCAlwaysLogFailure();
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   expectSessionCreate();
   expectStreamCreate(0);
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_, _));
@@ -2379,7 +2378,7 @@ TEST_F(HttpHealthCheckerImplTest, HttpFailLogError) {
 TEST_F(HttpHealthCheckerImplTest, HttpAlwaysLogSuccess) {
   setupNoServiceValidationHCAlwaysLogSuccess();
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthFlagSet(
       Host::HealthFlag::FAILED_ACTIVE_HC);
   cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthFlagSet(
@@ -2418,7 +2417,7 @@ TEST_F(HttpHealthCheckerImplTest, Disconnect) {
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::ChangePending));
 
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   expectSessionCreate();
   expectStreamCreate(0);
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_, _));
@@ -2450,7 +2449,7 @@ TEST_F(HttpHealthCheckerImplTest, Disconnect) {
 TEST_F(HttpHealthCheckerImplTest, Timeout) {
   setupNoServiceValidationHCOneUnhealthy();
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   expectSessionCreate();
   expectStreamCreate(0);
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_, _));
@@ -2474,7 +2473,7 @@ TEST_F(HttpHealthCheckerImplTest, TimeoutThenSuccess) {
   setupNoServiceValidationHC();
 
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   expectSessionCreate();
   expectStreamCreate(0);
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_, _));
@@ -2511,7 +2510,7 @@ TEST_F(HttpHealthCheckerImplTest, TimeoutThenRemoteClose) {
   setupNoServiceValidationHC();
   EXPECT_CALL(event_logger_, logUnhealthy(_, _, _, true));
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   expectSessionCreate();
   expectStreamCreate(0);
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_, _));
@@ -2546,7 +2545,7 @@ TEST_F(HttpHealthCheckerImplTest, TimeoutThenRemoteClose) {
 TEST_F(HttpHealthCheckerImplTest, TimeoutAfterDisconnect) {
   setupNoServiceValidationHC();
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   expectSessionCreate();
   expectStreamCreate(0);
   EXPECT_CALL(event_logger_, logUnhealthy(_, _, _, true));
@@ -2577,7 +2576,7 @@ TEST_F(HttpHealthCheckerImplTest, DynamicAddAndRemove) {
   expectSessionCreate();
   expectStreamCreate(0);
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_, _));
   cluster_->prioritySet().getMockHostSet(0)->runCallbacks(
       {cluster_->prioritySet().getMockHostSet(0)->hosts_.back()}, {});
@@ -2602,7 +2601,7 @@ TEST_F(HttpHealthCheckerImplTest, DynamicRemoveDisableHC) {
   auto enable_host = std::shared_ptr<Upstream::HostImpl>(*HostImpl::create(
       cluster_->info_, "test_host", *Network::Utility::resolveUrl("tcp://127.0.0.1:80"), nullptr,
       nullptr, 1, envoy::config::core::v3::Locality(), health_check_config, 0,
-      envoy::config::core::v3::UNKNOWN, simTime()));
+      envoy::config::core::v3::UNKNOWN));
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {enable_host};
   health_checker_->start();
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
@@ -2611,7 +2610,7 @@ TEST_F(HttpHealthCheckerImplTest, DynamicRemoveDisableHC) {
   auto disable_host = std::shared_ptr<Upstream::HostImpl>(*HostImpl::create(
       cluster_->info_, "test_host", *Network::Utility::resolveUrl("tcp://127.0.0.1:80"), nullptr,
       nullptr, 1, envoy::config::core::v3::Locality(), health_check_config, 0,
-      envoy::config::core::v3::UNKNOWN, simTime()));
+      envoy::config::core::v3::UNKNOWN));
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {disable_host};
   EXPECT_CALL(*test_sessions_[0]->client_connection_, close(Network::ConnectionCloseType::Abort));
   cluster_->prioritySet().runUpdateCallbacks(0, {disable_host}, {enable_host});
@@ -2631,7 +2630,7 @@ TEST_F(HttpHealthCheckerImplTest, AddDisableHC) {
   auto disable_host = std::shared_ptr<Upstream::HostImpl>(*HostImpl::create(
       cluster_->info_, "test_host", *Network::Utility::resolveUrl("tcp://127.0.0.1:80"), nullptr,
       nullptr, 1, envoy::config::core::v3::Locality(), health_check_config, 0,
-      envoy::config::core::v3::UNKNOWN, simTime()));
+      envoy::config::core::v3::UNKNOWN));
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {disable_host};
   health_checker_->start();
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged)).Times(0);
@@ -2642,7 +2641,7 @@ TEST_F(HttpHealthCheckerImplTest, ConnectionClose) {
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
 
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   expectSessionCreate();
   expectStreamCreate(0);
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_, _));
@@ -2665,7 +2664,7 @@ TEST_F(HttpHealthCheckerImplTest, ProxyConnectionClose) {
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
 
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   expectSessionCreate();
   expectStreamCreate(0);
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_, _));
@@ -2686,7 +2685,7 @@ TEST_F(HttpHealthCheckerImplTest, ProxyConnectionClose) {
 TEST_F(HttpHealthCheckerImplTest, HealthCheckIntervals) {
   setupHealthCheckIntervalOverridesHC();
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://128.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://128.0.0.1:80")};
   expectSessionCreate();
   expectStreamCreate(0);
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_, _));
@@ -2921,7 +2920,7 @@ TEST_F(HttpHealthCheckerImplTest, RemoteCloseBetweenChecks) {
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged)).Times(2);
 
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   expectSessionCreate();
   expectStreamCreate(0);
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_, _));
@@ -2953,7 +2952,7 @@ TEST_F(HttpHealthCheckerImplTest, DontReuseConnectionBetweenChecks) {
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged)).Times(2);
 
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   expectSessionCreate();
   expectStreamCreate(0);
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_, _));
@@ -2985,7 +2984,7 @@ TEST_F(HttpHealthCheckerImplTest, StreamReachesWatermarkDuringCheck) {
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
 
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   expectSessionCreate();
   expectStreamCreate(0);
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_, _));
@@ -3007,7 +3006,7 @@ TEST_F(HttpHealthCheckerImplTest, ConnectionReachesWatermarkDuringCheck) {
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
 
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   expectSessionCreate();
   expectStreamCreate(0);
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_, _));
@@ -3240,7 +3239,7 @@ TEST_F(HttpHealthCheckerImplTest, TransportSocketMatchCriteria) {
   allocHealthChecker(yaml);
 
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   cluster_->info_->trafficStats()->upstream_cx_total_.inc();
   expectSessionCreate();
   expectStreamCreate(0);
@@ -3281,7 +3280,7 @@ TEST_F(HttpHealthCheckerImplTest, NoTransportSocketMatchCriteria) {
   allocHealthChecker(yaml);
 
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   cluster_->info_->trafficStats()->upstream_cx_total_.inc();
   expectSessionCreate();
   expectStreamCreate(0);
@@ -3298,7 +3297,7 @@ TEST_F(HttpHealthCheckerImplTest, GoAwayErrorProbeInProgress) {
       .WillRepeatedly(Return(false));
 
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   cluster_->info_->trafficStats()->upstream_cx_total_.inc();
   expectSessionCreate();
   expectStreamCreate(0);
@@ -3346,7 +3345,7 @@ TEST_F(HttpHealthCheckerImplTest, GoAwayProbeInProgress) {
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("health_check.verify_cluster", 100))
       .WillRepeatedly(Return(false));
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   cluster_->info_->trafficStats()->upstream_cx_total_.inc();
 
   expectSessionCreate();
@@ -3379,7 +3378,7 @@ TEST_F(HttpHealthCheckerImplTest, GoAwayProbeInProgress) {
 TEST_F(HttpHealthCheckerImplTest, GoAwayProbeInProgressTimeout) {
   setupHCHttp2();
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("health_check.verify_cluster", 100))
       .WillRepeatedly(Return(false));
 
@@ -3415,7 +3414,7 @@ TEST_F(HttpHealthCheckerImplTest, GoAwayProbeInProgressTimeout) {
 TEST_F(HttpHealthCheckerImplTest, GoAwayProbeInProgressStreamReset) {
   setupHCHttp2();
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("health_check.verify_cluster", 100))
       .WillRepeatedly(Return(false));
 
@@ -3451,7 +3450,7 @@ TEST_F(HttpHealthCheckerImplTest, GoAwayProbeInProgressStreamReset) {
 TEST_F(HttpHealthCheckerImplTest, GoAwayProbeInProgressConnectionClose) {
   setupHCHttp2();
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("health_check.verify_cluster", 100))
       .WillRepeatedly(Return(false));
 
@@ -3487,7 +3486,7 @@ TEST_F(HttpHealthCheckerImplTest, GoAwayProbeInProgressConnectionClose) {
 TEST_F(HttpHealthCheckerImplTest, GoAwayBetweenChecks) {
   setupHCHttp2();
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("health_check.verify_cluster", 100))
       .WillRepeatedly(Return(false));
 
@@ -3645,7 +3644,7 @@ TEST_F(HttpHealthCheckerImplTest, ServiceNameMatch) {
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
 
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   cluster_->info_->trafficStats()->upstream_cx_total_.inc();
   expectSessionCreate();
   expectStreamCreate(0);
@@ -3681,7 +3680,7 @@ TEST_F(HttpHealthCheckerImplTest, ServiceNameMismatch) {
   EXPECT_CALL(event_logger_, logEjectUnhealthy(_, _, _));
 
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   cluster_->info_->trafficStats()->upstream_cx_total_.inc();
   expectSessionCreate();
   expectStreamCreate(0);
@@ -3707,7 +3706,7 @@ TEST_F(HttpHealthCheckerImplTest, DefaultMethodGet) {
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
 
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   cluster_->info_->trafficStats()->upstream_cx_total_.inc();
   expectSessionCreate();
   expectStreamCreate(0);
@@ -3736,7 +3735,7 @@ TEST_F(HttpHealthCheckerImplTest, MethodHead) {
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
 
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   cluster_->info_->trafficStats()->upstream_cx_total_.inc();
   expectSessionCreate();
   expectStreamCreate(0);
@@ -4319,7 +4318,7 @@ TEST_F(TcpHealthCheckerImplTest, Success) {
 
   setupData();
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   expectSessionCreate();
   expectClientCreate();
   EXPECT_CALL(*connection_, write(_, _));
@@ -4343,7 +4342,7 @@ TEST_F(TcpHealthCheckerImplTest, DataWithoutReusingConnection) {
 
   setupDataDontReuseConnection();
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   expectSessionCreate();
   expectClientCreate();
   EXPECT_CALL(*connection_, write(_, _));
@@ -4372,7 +4371,7 @@ TEST_F(TcpHealthCheckerImplTest, WrongData) {
 
   setupDataDontReuseConnection();
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   expectSessionCreate();
   expectClientCreate();
   EXPECT_CALL(*connection_, write(_, _));
@@ -4403,7 +4402,7 @@ TEST_F(TcpHealthCheckerImplTest, TimeoutThenRemoteClose) {
   expectSessionCreate();
   expectClientCreate();
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   EXPECT_CALL(*connection_, write(_, _));
   EXPECT_CALL(*timeout_timer_, enableTimer(_, _));
 
@@ -4462,7 +4461,7 @@ TEST_F(TcpHealthCheckerImplTest, Timeout) {
   expectSessionCreate();
   expectClientCreate();
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   EXPECT_CALL(*connection_, write(_, _));
   EXPECT_CALL(*timeout_timer_, enableTimer(_, _));
 
@@ -4496,7 +4495,7 @@ TEST_F(TcpHealthCheckerImplTest, DoubleTimeout) {
   expectSessionCreate();
   expectClientCreate();
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   EXPECT_CALL(*connection_, write(_, _));
   EXPECT_CALL(*timeout_timer_, enableTimer(_, _));
 
@@ -4555,7 +4554,7 @@ TEST_F(TcpHealthCheckerImplTest, TimeoutWithoutReusingConnection) {
 
   setupDataDontReuseConnection();
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   expectSessionCreate();
   expectClientCreate();
   EXPECT_CALL(*connection_, write(_, _));
@@ -4626,7 +4625,7 @@ TEST_F(TcpHealthCheckerImplTest, NoData) {
 
   setupNoData();
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   expectSessionCreate();
   expectClientCreate();
   EXPECT_CALL(*connection_, write(_, _)).Times(0);
@@ -4649,7 +4648,7 @@ TEST_F(TcpHealthCheckerImplTest, PassiveFailure) {
 
   setupNoData();
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   expectSessionCreate();
   expectClientCreate();
   EXPECT_CALL(*connection_, write(_, _)).Times(0);
@@ -4710,7 +4709,7 @@ TEST_F(TcpHealthCheckerImplTest, PassiveFailureCrossThreadRemoveHostRace) {
 
   setupNoData();
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   expectSessionCreate();
   expectClientCreate();
   EXPECT_CALL(*connection_, write(_, _)).Times(0);
@@ -4742,7 +4741,7 @@ TEST_F(TcpHealthCheckerImplTest, PassiveFailureCrossThreadRemoveClusterRace) {
 
   setupNoData();
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   expectSessionCreate();
   expectClientCreate();
   EXPECT_CALL(*connection_, write(_, _)).Times(0);
@@ -4773,7 +4772,7 @@ TEST_F(TcpHealthCheckerImplTest, ConnectionLocalFailure) {
 
   setupData();
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   expectSessionCreate();
   expectClientCreate();
   EXPECT_CALL(*connection_, write(_, _));
@@ -4800,7 +4799,7 @@ TEST_F(TcpHealthCheckerImplTest, SuccessProxyProtocol) {
 
   setupDataProxyProtocol();
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   expectSessionCreate();
   expectClientCreate();
   EXPECT_CALL(*connection_, write(_, _));
@@ -5040,8 +5039,7 @@ public:
 
               test_session.codec_client_ = new CodecClientForTest(
                   Http::CodecType::HTTP1, std::move(conn_data.connection_), test_session.codec_,
-                  nullptr, Upstream::makeTestHost(cluster, "tcp://127.0.0.1:9000", simTime()),
-                  dispatcher_);
+                  nullptr, Upstream::makeTestHost(cluster, "tcp://127.0.0.1:9000"), dispatcher_);
               return test_session.codec_client_;
             }));
   }
@@ -5077,7 +5075,7 @@ public:
 
   void expectSingleHealthcheck(HealthTransition host_changed_state) {
     cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-        makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+        makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
     expectHealthchecks(host_changed_state, 1);
   }
 
@@ -5155,7 +5153,7 @@ public:
     setupServiceNameHC(authority);
 
     cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-        makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+        makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
     runHealthCheck(expected_host);
   }
 
@@ -5241,7 +5239,7 @@ TEST_F(GrpcHealthCheckerImplTest, SuccessWithHostname) {
   auto test_host = std::shared_ptr<Upstream::HostImpl>(
       *HostImpl::create(cluster_->info_, "", *Network::Utility::resolveUrl("tcp://127.0.0.1:80"),
                         nullptr, nullptr, 1, envoy::config::core::v3::Locality(),
-                        health_check_config, 0, envoy::config::core::v3::UNKNOWN, simTime()));
+                        health_check_config, 0, envoy::config::core::v3::UNKNOWN));
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {test_host};
   runHealthCheck(expected_host);
 }
@@ -5256,7 +5254,7 @@ TEST_F(GrpcHealthCheckerImplTest, SuccessWithHostnameOverridesConfig) {
   auto test_host = std::shared_ptr<Upstream::HostImpl>(
       *HostImpl::create(cluster_->info_, "", *Network::Utility::resolveUrl("tcp://127.0.0.1:80"),
                         nullptr, nullptr, 1, envoy::config::core::v3::Locality(),
-                        health_check_config, 0, envoy::config::core::v3::UNKNOWN, simTime()));
+                        health_check_config, 0, envoy::config::core::v3::UNKNOWN));
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {test_host};
   runHealthCheck(expected_host);
 }
@@ -5309,7 +5307,7 @@ TEST_F(GrpcHealthCheckerImplTest, SuccessWithAdditionalHeaders) {
       )EOF");
 
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", metadata, simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", metadata)};
 
   cluster_->info_->trafficStats()->upstream_cx_total_.inc();
 
@@ -5424,8 +5422,8 @@ TEST_F(GrpcHealthCheckerImplTest, SuccessWithMultipleHosts) {
   setupHC();
 
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime()),
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:81", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80"),
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:81")};
 
   expectHealthchecks(HealthTransition::Unchanged, 2);
 
@@ -5442,9 +5440,9 @@ TEST_F(GrpcHealthCheckerImplTest, SuccessWithMultipleHostSets) {
   setupHC();
 
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   cluster_->prioritySet().getMockHostSet(1)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:81", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:81")};
 
   expectHealthchecks(HealthTransition::Unchanged, 2);
 
@@ -5484,7 +5482,7 @@ TEST_F(GrpcHealthCheckerImplTest, ConnectionReachesWatermarkDuringCheck) {
 TEST_F(GrpcHealthCheckerImplTest, SuccessNoTraffic) {
   setupHC();
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
 
   expectSessionCreate();
   expectHealthcheckStart(0);
@@ -5502,7 +5500,7 @@ TEST_F(GrpcHealthCheckerImplTest, SuccessNoTraffic) {
 TEST_F(GrpcHealthCheckerImplTest, SuccessStartFailedSuccessFirst) {
   setupHC();
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthFlagSet(
       Host::HealthFlag::FAILED_ACTIVE_HC);
   cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthFlagSet(
@@ -5528,7 +5526,7 @@ TEST_F(GrpcHealthCheckerImplTest, SuccessStartFailedSuccessFirst) {
 TEST_F(GrpcHealthCheckerImplTest, SuccessStartFailedFailFirst) {
   setupHC();
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthFlagSet(
       Host::HealthFlag::FAILED_ACTIVE_HC);
   cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthFlagSet(
@@ -5576,7 +5574,7 @@ TEST_F(GrpcHealthCheckerImplTest, SuccessStartFailedFailFirst) {
 TEST_F(GrpcHealthCheckerImplTest, GrpcHealthFailViaRpcRemoveHostInCallback) {
   setupHC();
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
 
   expectSessionCreate();
   expectHealthcheckStart(0);
@@ -5597,7 +5595,7 @@ TEST_F(GrpcHealthCheckerImplTest, GrpcHealthFailViaRpcRemoveHostInCallback) {
 TEST_F(GrpcHealthCheckerImplTest, GrpcHealthFailViaGoawayRemoveHostInCallback) {
   setupHCWithUnhealthyThreshold(/*threshold=*/1);
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
 
   expectSessionCreate();
   expectHealthcheckStart(0);
@@ -5617,7 +5615,7 @@ TEST_F(GrpcHealthCheckerImplTest, GrpcHealthFailViaGoawayRemoveHostInCallback) {
 TEST_F(GrpcHealthCheckerImplTest, GrpcHealthFailViaBadResponseRemoveHostInCallback) {
   setupHCWithUnhealthyThreshold(/*threshold=*/1);
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
 
   expectSessionCreate();
   expectHealthcheckStart(0);
@@ -5639,7 +5637,7 @@ TEST_F(GrpcHealthCheckerImplTest, GrpcHealthFailViaBadResponseRemoveHostInCallba
 TEST_F(GrpcHealthCheckerImplTest, GrpcHealthFail) {
   setupHC();
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
 
   expectSessionCreate();
   expectHealthcheckStart(0);
@@ -5678,7 +5676,7 @@ TEST_F(GrpcHealthCheckerImplTest, GrpcHealthFail) {
 TEST_F(GrpcHealthCheckerImplTest, Disconnect) {
   setupHC();
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
 
   expectSessionCreate();
   expectHealthcheckStart(0);
@@ -5706,7 +5704,7 @@ TEST_F(GrpcHealthCheckerImplTest, Disconnect) {
 TEST_F(GrpcHealthCheckerImplTest, Timeout) {
   setupHCWithUnhealthyThreshold(1);
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   expectSessionCreate();
 
   expectHealthcheckStart(0);
@@ -5725,7 +5723,7 @@ TEST_F(GrpcHealthCheckerImplTest, Timeout) {
 TEST_F(GrpcHealthCheckerImplTest, DoubleTimeout) {
   setupHC();
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   expectSessionCreate();
 
   expectHealthcheckStart(0);
@@ -5757,7 +5755,7 @@ TEST_F(GrpcHealthCheckerImplTest, DynamicAddAndRemove) {
   expectSessionCreate();
   expectStreamCreate(0);
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_, _));
   cluster_->prioritySet().getMockHostSet(0)->runCallbacks(
       {cluster_->prioritySet().getMockHostSet(0)->hosts_.back()}, {});
@@ -5772,7 +5770,7 @@ TEST_F(GrpcHealthCheckerImplTest, DynamicAddAndRemove) {
 TEST_F(GrpcHealthCheckerImplTest, HealthCheckIntervals) {
   setupHealthCheckIntervalOverridesHC();
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://128.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://128.0.0.1:80")};
   expectSessionCreate();
   expectStreamCreate(0);
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_, _));
@@ -5986,7 +5984,7 @@ TEST_F(GrpcHealthCheckerImplTest, HealthCheckIntervals) {
 TEST_F(GrpcHealthCheckerImplTest, RemoteCloseBetweenChecks) {
   setupHC();
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
 
   expectSessionCreate();
   expectHealthcheckStart(0);
@@ -6015,7 +6013,7 @@ TEST_F(GrpcHealthCheckerImplTest, RemoteCloseBetweenChecks) {
 TEST_F(GrpcHealthCheckerImplTest, DontReuseConnectionBetweenChecks) {
   setupNoReuseConnectionHC();
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
 
   expectSessionCreate();
   expectHealthcheckStart(0);
@@ -6044,7 +6042,7 @@ TEST_F(GrpcHealthCheckerImplTest, DontReuseConnectionBetweenChecks) {
 TEST_F(GrpcHealthCheckerImplTest, DontReuseConnectionTimeout) {
   setupNoReuseConnectionHC();
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
 
   expectSessionCreate();
   expectHealthcheckStart(0);
@@ -6074,7 +6072,7 @@ TEST_F(GrpcHealthCheckerImplTest, DontReuseConnectionTimeout) {
 TEST_F(GrpcHealthCheckerImplTest, DontReuseConnectionStreamReset) {
   setupNoReuseConnectionHC();
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
 
   expectSessionCreate();
   expectHealthcheckStart(0);
@@ -6196,7 +6194,7 @@ TEST_F(GrpcHealthCheckerImplTest, GoAwayErrorProbeInProgress) {
 TEST_F(GrpcHealthCheckerImplTest, GoAwayProbeInProgress) {
   setupHCWithUnhealthyThreshold(/*threshold=*/1);
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
 
   expectSessionCreate();
   expectHealthcheckStart(0);
@@ -6226,7 +6224,7 @@ TEST_F(GrpcHealthCheckerImplTest, GoAwayProbeInProgress) {
 TEST_F(GrpcHealthCheckerImplTest, GoAwayProbeInProgressTimeout) {
   setupHCWithUnhealthyThreshold(/*threshold=*/1);
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
 
   expectSessionCreate();
   expectHealthcheckStart(0);
@@ -6261,7 +6259,7 @@ TEST_F(GrpcHealthCheckerImplTest, GoAwayProbeInProgressTimeout) {
 TEST_F(GrpcHealthCheckerImplTest, GoAwayProbeInProgressStreamReset) {
   setupHCWithUnhealthyThreshold(/*threshold=*/1);
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
 
   expectSessionCreate();
   expectHealthcheckStart(0);
@@ -6296,7 +6294,7 @@ TEST_F(GrpcHealthCheckerImplTest, GoAwayProbeInProgressStreamReset) {
 TEST_F(GrpcHealthCheckerImplTest, GoAwayProbeInProgressBadResponse) {
   setupHCWithUnhealthyThreshold(/*threshold=*/1);
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
 
   expectSessionCreate();
   expectHealthcheckStart(0);
@@ -6333,7 +6331,7 @@ TEST_F(GrpcHealthCheckerImplTest, GoAwayProbeInProgressBadResponse) {
 TEST_F(GrpcHealthCheckerImplTest, GoAwayProbeInProgressConnectionClose) {
   setupHCWithUnhealthyThreshold(/*threshold=*/1);
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
 
   expectSessionCreate();
   expectHealthcheckStart(0);
@@ -6368,7 +6366,7 @@ TEST_F(GrpcHealthCheckerImplTest, GoAwayProbeInProgressConnectionClose) {
 TEST_F(GrpcHealthCheckerImplTest, GoAwayBetweenChecks) {
   setupHC();
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
 
   expectSessionCreate();
   expectHealthcheckStart(0);

--- a/test/common/upstream/host_utility_test.cc
+++ b/test/common/upstream/host_utility_test.cc
@@ -36,8 +36,7 @@ static constexpr HostUtility::HostStatusSet DegradedStatus =
 
 TEST(HostUtilityTest, All) {
   auto cluster = std::make_shared<NiceMock<MockClusterInfo>>();
-  auto time_source = std::make_unique<NiceMock<MockTimeSystem>>();
-  HostSharedPtr host = makeTestHost(cluster, "tcp://127.0.0.1:80", *time_source);
+  HostSharedPtr host = makeTestHost(cluster, "tcp://127.0.0.1:80");
   EXPECT_EQ("healthy", HostUtility::healthFlagsToString(*host));
 
   host->healthFlagSet(Host::HealthFlag::FAILED_ACTIVE_HC);
@@ -67,15 +66,12 @@ TEST(HostUtilityTest, All) {
 
 TEST(HostLogging, FmtUtils) {
   auto cluster = std::make_shared<NiceMock<MockClusterInfo>>();
-  auto time_source = std::make_unique<NiceMock<MockTimeSystem>>();
-  auto time_ms = std::chrono::milliseconds(5);
-  ON_CALL(*time_source, monotonicTime()).WillByDefault(Return(MonotonicTime(time_ms)));
   EXPECT_LOG_CONTAINS("warn", "Logging host info 127.0.0.1:80 end", {
-    HostSharedPtr host = makeTestHost(cluster, "tcp://127.0.0.1:80", *time_source);
+    HostSharedPtr host = makeTestHost(cluster, "tcp://127.0.0.1:80");
     ENVOY_LOG_MISC(warn, "Logging host info {} end", *host);
   });
   EXPECT_LOG_CONTAINS("warn", "Logging host info hostname end", {
-    HostSharedPtr host = makeTestHost(cluster, "hostname", "tcp://127.0.0.1:80", *time_source);
+    HostSharedPtr host = makeTestHost(cluster, "hostname", "tcp://127.0.0.1:80");
     ENVOY_LOG_MISC(warn, "Logging host info {} end", *host);
   });
 }

--- a/test/common/upstream/outlier_detection_impl_test.cc
+++ b/test/common/upstream/outlier_detection_impl_test.cc
@@ -91,7 +91,7 @@ public:
   void addHosts(std::vector<std::string> urls, bool primary = true) {
     HostVector& hosts = primary ? hosts_ : failover_hosts_;
     for (auto& url : urls) {
-      hosts.emplace_back(makeTestHost(cluster_.info_, url, simTime()));
+      hosts.emplace_back(makeTestHost(cluster_.info_, url));
     }
   }
 

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -1815,7 +1815,7 @@ protected:
 
 TEST_F(HostImplTest, HostCluster) {
   MockClusterMockPrioritySet cluster;
-  HostSharedPtr host = makeTestHost(cluster.info_, "tcp://10.0.0.1:1234", simTime(), 1);
+  HostSharedPtr host = makeTestHost(cluster.info_, "tcp://10.0.0.1:1234", 1);
   EXPECT_EQ(cluster.info_.get(), &host->cluster());
   EXPECT_EQ("", host->hostname());
   EXPECT_FALSE(host->canary());
@@ -1825,14 +1825,13 @@ TEST_F(HostImplTest, HostCluster) {
 TEST_F(HostImplTest, Weight) {
   MockClusterMockPrioritySet cluster;
 
-  EXPECT_EQ(1U, makeTestHost(cluster.info_, "tcp://10.0.0.1:1234", simTime(), 0)->weight());
-  EXPECT_EQ(128U, makeTestHost(cluster.info_, "tcp://10.0.0.1:1234", simTime(), 128)->weight());
+  EXPECT_EQ(1U, makeTestHost(cluster.info_, "tcp://10.0.0.1:1234", 0)->weight());
+  EXPECT_EQ(128U, makeTestHost(cluster.info_, "tcp://10.0.0.1:1234", 128)->weight());
   EXPECT_EQ(std::numeric_limits<uint32_t>::max(),
-            makeTestHost(cluster.info_, "tcp://10.0.0.1:1234", simTime(),
-                         std::numeric_limits<uint32_t>::max())
+            makeTestHost(cluster.info_, "tcp://10.0.0.1:1234", std::numeric_limits<uint32_t>::max())
                 ->weight());
 
-  HostSharedPtr host = makeTestHost(cluster.info_, "tcp://10.0.0.1:1234", simTime(), 50);
+  HostSharedPtr host = makeTestHost(cluster.info_, "tcp://10.0.0.1:1234", 50);
   EXPECT_EQ(50U, host->weight());
   host->weight(51);
   EXPECT_EQ(51U, host->weight());
@@ -1844,7 +1843,7 @@ TEST_F(HostImplTest, Weight) {
 
 TEST_F(HostImplTest, HostLbPolicyData) {
   MockClusterMockPrioritySet cluster;
-  HostSharedPtr host = makeTestHost(cluster.info_, "tcp://10.0.0.1:1234", simTime(), 1);
+  HostSharedPtr host = makeTestHost(cluster.info_, "tcp://10.0.0.1:1234", 1);
   EXPECT_TRUE(!host->lbPolicyData().has_value());
 
   class TestLbPolicyData : public Upstream::HostLbPolicyData {
@@ -1873,7 +1872,7 @@ TEST_F(HostImplTest, HostnameCanaryAndLocality) {
       cluster.info_, "lyft.com", *Network::Utility::resolveUrl("tcp://10.0.0.1:1234"),
       std::make_shared<const envoy::config::core::v3::Metadata>(metadata), nullptr, 1, locality,
       envoy::config::endpoint::v3::Endpoint::HealthCheckConfig::default_instance(), 1,
-      envoy::config::core::v3::UNKNOWN, simTime());
+      envoy::config::core::v3::UNKNOWN);
   EXPECT_EQ(cluster.info_.get(), &host->cluster());
   EXPECT_EQ("lyft.com", host->hostname());
   EXPECT_TRUE(host->canary());
@@ -1899,7 +1898,7 @@ TEST_F(HostImplTest, CreateConnection) {
       cluster.info_, "lyft.com", address,
       std::make_shared<const envoy::config::core::v3::Metadata>(metadata), nullptr, 1, locality,
       envoy::config::endpoint::v3::Endpoint::HealthCheckConfig::default_instance(), 1,
-      envoy::config::core::v3::UNKNOWN, simTime()));
+      envoy::config::core::v3::UNKNOWN));
 
   testing::StrictMock<Event::MockDispatcher> dispatcher;
   Network::TransportSocketOptionsConstSharedPtr transport_socket_options;
@@ -1937,7 +1936,7 @@ TEST_F(HostImplTest, CreateConnectionHappyEyeballs) {
       cluster.info_, "lyft.com", address,
       std::make_shared<const envoy::config::core::v3::Metadata>(metadata), nullptr, 1, locality,
       envoy::config::endpoint::v3::Endpoint::HealthCheckConfig::default_instance(), 1,
-      envoy::config::core::v3::UNKNOWN, simTime(), address_list));
+      envoy::config::core::v3::UNKNOWN, address_list));
 
   testing::StrictMock<Event::MockDispatcher> dispatcher;
   Network::TransportSocketOptionsConstSharedPtr transport_socket_options;
@@ -1984,7 +1983,7 @@ TEST_F(HostImplTest, ProxyOverridesHappyEyeballs) {
       cluster.info_, "lyft.com", address,
       std::make_shared<const envoy::config::core::v3::Metadata>(metadata), nullptr, 1, locality,
       envoy::config::endpoint::v3::Endpoint::HealthCheckConfig::default_instance(), 1,
-      envoy::config::core::v3::UNKNOWN, simTime(), address_list));
+      envoy::config::core::v3::UNKNOWN, address_list));
 
   testing::StrictMock<Event::MockDispatcher> dispatcher;
   auto proxy_info = std::make_unique<Network::TransportSocketOptions::Http11ProxyInfo>(
@@ -2042,7 +2041,7 @@ TEST_F(HostImplTest, CreateConnectionHappyEyeballsWithConfig) {
       cluster.info_, "lyft.com", address,
       std::make_shared<const envoy::config::core::v3::Metadata>(metadata), nullptr, 1, locality,
       envoy::config::endpoint::v3::Endpoint::HealthCheckConfig::default_instance(), 1,
-      envoy::config::core::v3::UNKNOWN, simTime(), address_list));
+      envoy::config::core::v3::UNKNOWN, address_list));
 
   testing::StrictMock<Event::MockDispatcher> dispatcher;
   Network::TransportSocketOptionsConstSharedPtr transport_socket_options;
@@ -2095,7 +2094,7 @@ TEST_F(HostImplTest, CreateConnectionHappyEyeballsWithEmptyConfig) {
       cluster.info_, "lyft.com", address,
       std::make_shared<const envoy::config::core::v3::Metadata>(metadata), nullptr, 1, locality,
       envoy::config::endpoint::v3::Endpoint::HealthCheckConfig::default_instance(), 1,
-      envoy::config::core::v3::UNKNOWN, simTime(), address_list));
+      envoy::config::core::v3::UNKNOWN, address_list));
 
   testing::StrictMock<Event::MockDispatcher> dispatcher;
   Network::TransportSocketOptionsConstSharedPtr transport_socket_options;
@@ -2124,7 +2123,7 @@ TEST_F(HostImplTest, CreateConnectionHappyEyeballsWithEmptyConfig) {
 
 TEST_F(HostImplTest, HealthFlags) {
   MockClusterMockPrioritySet cluster;
-  HostSharedPtr host = makeTestHost(cluster.info_, "tcp://10.0.0.1:1234", simTime(), 1);
+  HostSharedPtr host = makeTestHost(cluster.info_, "tcp://10.0.0.1:1234", 1);
 
   // To begin with, no flags are set so we're healthy.
   EXPECT_EQ(Host::Health::Healthy, host->coarseHealth());
@@ -2156,8 +2155,8 @@ TEST_F(HostImplTest, HealthFlags) {
 
 TEST_F(HostImplTest, HealthStatus) {
   MockClusterMockPrioritySet cluster;
-  HostSharedPtr host = makeTestHost(cluster.info_, "tcp://10.0.0.1:1234", simTime(), 1, 0,
-                                    Host::HealthStatus::DEGRADED);
+  HostSharedPtr host =
+      makeTestHost(cluster.info_, "tcp://10.0.0.1:1234", 1, 0, Host::HealthStatus::DEGRADED);
 
   // To begin with, no active flags are set so EDS status is used.
   EXPECT_EQ(Host::HealthStatus::DEGRADED, host->healthStatus());
@@ -2221,7 +2220,7 @@ TEST_F(HostImplTest, HealthStatus) {
 
 TEST_F(HostImplTest, SkipActiveHealthCheckFlag) {
   MockClusterMockPrioritySet cluster;
-  HostSharedPtr host = makeTestHost(cluster.info_, "tcp://10.0.0.1:1234", simTime(), 1);
+  HostSharedPtr host = makeTestHost(cluster.info_, "tcp://10.0.0.1:1234", 1);
 
   // To begin with, the default setting is false.
   EXPECT_EQ(false, host->disableActiveHealthCheck());
@@ -2239,7 +2238,7 @@ TEST_F(HostImplTest, HealthPipeAddress) {
   config.set_port_value(8000);
   EXPECT_EQ(HostDescriptionImpl::create(
                 info, "", *Network::Utility::resolveUrl("unix://foo"), nullptr, nullptr,
-                envoy::config::core::v3::Locality().default_instance(), config, 1, simTime())
+                envoy::config::core::v3::Locality().default_instance(), config, 1)
                 .status()
                 .message(),
             "Invalid host configuration: non-zero port for non-IP address");
@@ -2247,7 +2246,7 @@ TEST_F(HostImplTest, HealthPipeAddress) {
 
 TEST_F(HostImplTest, HostAddressList) {
   MockClusterMockPrioritySet cluster;
-  HostSharedPtr host = makeTestHost(cluster.info_, "tcp://10.0.0.1:1234", simTime(), 1);
+  HostSharedPtr host = makeTestHost(cluster.info_, "tcp://10.0.0.1:1234", 1);
   const AddressVector address_list = {};
   EXPECT_TRUE(host->addressListOrNull() == nullptr);
 }
@@ -2259,7 +2258,7 @@ TEST_F(HostImplTest, HealthcheckHostname) {
   config.set_hostname("foo");
   std::unique_ptr<HostDescriptionImpl> descr = *HostDescriptionImpl::create(
       info, "", *Network::Utility::resolveUrl("tcp://1.2.3.4:80"), nullptr, nullptr,
-      envoy::config::core::v3::Locality().default_instance(), config, 1, simTime());
+      envoy::config::core::v3::Locality().default_instance(), config, 1);
   EXPECT_EQ("foo", descr->hostnameForHealthChecks());
 }
 
@@ -4100,8 +4099,7 @@ TEST(PrioritySet, Extend) {
   // Now add hosts for priority 1, and ensure they're added and subscribers are notified.
   std::shared_ptr<MockClusterInfo> info{new NiceMock<MockClusterInfo>()};
   auto time_source = std::make_unique<NiceMock<MockTimeSystem>>();
-  HostVectorSharedPtr hosts(
-      new HostVector({makeTestHost(info, "tcp://127.0.0.1:80", *time_source)}));
+  HostVectorSharedPtr hosts(new HostVector({makeTestHost(info, "tcp://127.0.0.1:80")}));
   HostsPerLocalitySharedPtr hosts_per_locality = std::make_shared<HostsPerLocalityImpl>();
   HostMapConstSharedPtr fake_cross_priority_host_map = std::make_shared<HostMap>();
   {
@@ -4163,8 +4161,7 @@ TEST(PrioritySet, MainPrioritySetTest) {
 
   std::shared_ptr<MockClusterInfo> info{new NiceMock<MockClusterInfo>()};
   auto time_source = std::make_unique<NiceMock<MockTimeSystem>>();
-  HostVectorSharedPtr hosts(
-      new HostVector({makeTestHost(info, "tcp://127.0.0.1:80", *time_source)}));
+  HostVectorSharedPtr hosts(new HostVector({makeTestHost(info, "tcp://127.0.0.1:80")}));
   HostsPerLocalitySharedPtr hosts_per_locality = std::make_shared<HostsPerLocalityImpl>();
 
   // The host map is initially empty or null.
@@ -5915,8 +5912,8 @@ TEST_F(HostsWithLocalityImpl, Cons) {
   zone_a.set_zone("A");
   envoy::config::core::v3::Locality zone_b;
   zone_b.set_zone("B");
-  HostSharedPtr host_0 = makeTestHost(cluster.info_, "tcp://10.0.0.1:1234", simTime(), zone_a, 1);
-  HostSharedPtr host_1 = makeTestHost(cluster.info_, "tcp://10.0.0.1:1234", simTime(), zone_b, 1);
+  HostSharedPtr host_0 = makeTestHost(cluster.info_, "tcp://10.0.0.1:1234", zone_a, 1);
+  HostSharedPtr host_1 = makeTestHost(cluster.info_, "tcp://10.0.0.1:1234", zone_b, 1);
 
   {
     std::vector<HostVector> locality_hosts = {{host_0}, {host_1}};
@@ -5941,8 +5938,8 @@ TEST_F(HostsWithLocalityImpl, Filter) {
   zone_a.set_zone("A");
   envoy::config::core::v3::Locality zone_b;
   zone_b.set_zone("B");
-  HostSharedPtr host_0 = makeTestHost(cluster.info_, "tcp://10.0.0.1:1234", simTime(), zone_a, 1);
-  HostSharedPtr host_1 = makeTestHost(cluster.info_, "tcp://10.0.0.1:1234", simTime(), zone_b, 1);
+  HostSharedPtr host_0 = makeTestHost(cluster.info_, "tcp://10.0.0.1:1234", zone_a, 1);
+  HostSharedPtr host_1 = makeTestHost(cluster.info_, "tcp://10.0.0.1:1234", zone_b, 1);
 
   {
     std::vector<HostVector> locality_hosts = {{host_0}, {host_1}};
@@ -5988,9 +5985,9 @@ TEST_F(HostSetImplLocalityTest, AllUnhealthy) {
   zone_b.set_zone("B");
   envoy::config::core::v3::Locality zone_c;
   zone_c.set_zone("C");
-  HostVector hosts{makeTestHost(info_, "tcp://127.0.0.1:80", simTime(), zone_a),
-                   makeTestHost(info_, "tcp://127.0.0.1:81", simTime(), zone_b),
-                   makeTestHost(info_, "tcp://127.0.0.1:82", simTime(), zone_c)};
+  HostVector hosts{makeTestHost(info_, "tcp://127.0.0.1:80", zone_a),
+                   makeTestHost(info_, "tcp://127.0.0.1:81", zone_b),
+                   makeTestHost(info_, "tcp://127.0.0.1:82", zone_c)};
 
   HostsPerLocalitySharedPtr hosts_per_locality =
       makeHostsPerLocality({{hosts[0]}, {hosts[1]}, {hosts[2]}});
@@ -6008,11 +6005,11 @@ TEST_F(HostSetImplLocalityTest, NotWarmedHostsLocality) {
   zone_a.set_zone("A");
   envoy::config::core::v3::Locality zone_b;
   zone_b.set_zone("B");
-  HostVector hosts{makeTestHost(info_, "tcp://127.0.0.1:80", simTime(), zone_a),
-                   makeTestHost(info_, "tcp://127.0.0.1:81", simTime(), zone_a),
-                   makeTestHost(info_, "tcp://127.0.0.1:82", simTime(), zone_a),
-                   makeTestHost(info_, "tcp://127.0.0.1:83", simTime(), zone_b),
-                   makeTestHost(info_, "tcp://127.0.0.1:84", simTime(), zone_b)};
+  HostVector hosts{makeTestHost(info_, "tcp://127.0.0.1:80", zone_a),
+                   makeTestHost(info_, "tcp://127.0.0.1:81", zone_a),
+                   makeTestHost(info_, "tcp://127.0.0.1:82", zone_a),
+                   makeTestHost(info_, "tcp://127.0.0.1:83", zone_b),
+                   makeTestHost(info_, "tcp://127.0.0.1:84", zone_b)};
 
   // We have two localities with 3 hosts in A, 2 hosts in B. Two of the hosts in A are not
   // warmed yet, so even though they are unhealthy we should not adjust the locality weight.
@@ -6045,9 +6042,9 @@ TEST_F(HostSetImplLocalityTest, NotWarmedHostsLocality) {
 TEST_F(HostSetImplLocalityTest, EmptyLocality) {
   envoy::config::core::v3::Locality zone_a;
   zone_a.set_zone("A");
-  HostVector hosts{makeTestHost(info_, "tcp://127.0.0.1:80", simTime(), zone_a),
-                   makeTestHost(info_, "tcp://127.0.0.1:81", simTime(), zone_a),
-                   makeTestHost(info_, "tcp://127.0.0.1:82", simTime(), zone_a)};
+  HostVector hosts{makeTestHost(info_, "tcp://127.0.0.1:80", zone_a),
+                   makeTestHost(info_, "tcp://127.0.0.1:81", zone_a),
+                   makeTestHost(info_, "tcp://127.0.0.1:82", zone_a)};
 
   HostsPerLocalitySharedPtr hosts_per_locality =
       makeHostsPerLocality({{hosts[0], hosts[1], hosts[2]}, {}});
@@ -6068,8 +6065,8 @@ TEST_F(HostSetImplLocalityTest, AllZeroWeights) {
   zone_a.set_zone("A");
   envoy::config::core::v3::Locality zone_b;
   zone_b.set_zone("B");
-  HostVector hosts{makeTestHost(info_, "tcp://127.0.0.1:80", simTime(), zone_a),
-                   makeTestHost(info_, "tcp://127.0.0.1:81", simTime(), zone_b)};
+  HostVector hosts{makeTestHost(info_, "tcp://127.0.0.1:80", zone_a),
+                   makeTestHost(info_, "tcp://127.0.0.1:81", zone_b)};
 
   HostsPerLocalitySharedPtr hosts_per_locality = makeHostsPerLocality({{hosts[0]}, {hosts[1]}});
   LocalityWeightsConstSharedPtr locality_weights{new LocalityWeights{0, 0}};
@@ -6089,9 +6086,9 @@ TEST_F(HostSetImplLocalityTest, Unweighted) {
   zone_b.set_zone("B");
   envoy::config::core::v3::Locality zone_c;
   zone_c.set_zone("C");
-  HostVector hosts{makeTestHost(info_, "tcp://127.0.0.1:80", simTime(), zone_a),
-                   makeTestHost(info_, "tcp://127.0.0.1:81", simTime(), zone_b),
-                   makeTestHost(info_, "tcp://127.0.0.1:82", simTime(), zone_c)};
+  HostVector hosts{makeTestHost(info_, "tcp://127.0.0.1:80", zone_a),
+                   makeTestHost(info_, "tcp://127.0.0.1:81", zone_b),
+                   makeTestHost(info_, "tcp://127.0.0.1:82", zone_c)};
 
   HostsPerLocalitySharedPtr hosts_per_locality =
       makeHostsPerLocality({{hosts[0]}, {hosts[1]}, {hosts[2]}});
@@ -6115,8 +6112,8 @@ TEST_F(HostSetImplLocalityTest, Weighted) {
   zone_a.set_zone("A");
   envoy::config::core::v3::Locality zone_b;
   zone_b.set_zone("B");
-  HostVector hosts{makeTestHost(info_, "tcp://127.0.0.1:80", simTime(), zone_a),
-                   makeTestHost(info_, "tcp://127.0.0.1:81", simTime(), zone_b)};
+  HostVector hosts{makeTestHost(info_, "tcp://127.0.0.1:80", zone_a),
+                   makeTestHost(info_, "tcp://127.0.0.1:81", zone_b)};
 
   HostsPerLocalitySharedPtr hosts_per_locality = makeHostsPerLocality({{hosts[0]}, {hosts[1]}});
   LocalityWeightsConstSharedPtr locality_weights{new LocalityWeights{1, 2}};
@@ -6141,9 +6138,9 @@ TEST_F(HostSetImplLocalityTest, MissingWeight) {
   zone_b.set_zone("B");
   envoy::config::core::v3::Locality zone_c;
   zone_c.set_zone("C");
-  HostVector hosts{makeTestHost(info_, "tcp://127.0.0.1:80", simTime(), zone_a),
-                   makeTestHost(info_, "tcp://127.0.0.1:81", simTime(), zone_b),
-                   makeTestHost(info_, "tcp://127.0.0.1:82", simTime(), zone_c)};
+  HostVector hosts{makeTestHost(info_, "tcp://127.0.0.1:80", zone_a),
+                   makeTestHost(info_, "tcp://127.0.0.1:81", zone_b),
+                   makeTestHost(info_, "tcp://127.0.0.1:82", zone_c)};
 
   HostsPerLocalitySharedPtr hosts_per_locality =
       makeHostsPerLocality({{hosts[0]}, {hosts[1]}, {hosts[2]}});
@@ -6170,9 +6167,9 @@ TEST_F(HostSetImplLocalityTest, WeightedAllChosen) {
   zone_b.set_zone("B");
   envoy::config::core::v3::Locality zone_c;
   zone_b.set_zone("C");
-  HostVector hosts{makeTestHost(info_, "tcp://127.0.0.1:80", simTime(), zone_a),
-                   makeTestHost(info_, "tcp://127.0.0.1:81", simTime(), zone_b),
-                   makeTestHost(info_, "tcp://127.0.0.1:82", simTime(), zone_c)};
+  HostVector hosts{makeTestHost(info_, "tcp://127.0.0.1:80", zone_a),
+                   makeTestHost(info_, "tcp://127.0.0.1:81", zone_b),
+                   makeTestHost(info_, "tcp://127.0.0.1:82", zone_c)};
 
   HostsPerLocalitySharedPtr hosts_per_locality =
       makeHostsPerLocality({{hosts[0]}, {hosts[1]}, {hosts[2]}});
@@ -6204,12 +6201,12 @@ TEST_F(HostSetImplLocalityTest, UnhealthyFailover) {
   zone_a.set_zone("A");
   envoy::config::core::v3::Locality zone_b;
   zone_b.set_zone("B");
-  HostVector hosts{makeTestHost(info_, "tcp://127.0.0.1:80", simTime(), zone_a),
-                   makeTestHost(info_, "tcp://127.0.0.1:81", simTime(), zone_a),
-                   makeTestHost(info_, "tcp://127.0.0.1:82", simTime(), zone_a),
-                   makeTestHost(info_, "tcp://127.0.0.1:83", simTime(), zone_a),
-                   makeTestHost(info_, "tcp://127.0.0.1:84", simTime(), zone_a),
-                   makeTestHost(info_, "tcp://127.0.0.1:85", simTime(), zone_b)};
+  HostVector hosts{makeTestHost(info_, "tcp://127.0.0.1:80", zone_a),
+                   makeTestHost(info_, "tcp://127.0.0.1:81", zone_a),
+                   makeTestHost(info_, "tcp://127.0.0.1:82", zone_a),
+                   makeTestHost(info_, "tcp://127.0.0.1:83", zone_a),
+                   makeTestHost(info_, "tcp://127.0.0.1:84", zone_a),
+                   makeTestHost(info_, "tcp://127.0.0.1:85", zone_b)};
 
   const auto setHealthyHostCount = [this, hosts](uint32_t host_count) {
     LocalityWeightsConstSharedPtr locality_weights{new LocalityWeights{1, 2}};
@@ -6266,9 +6263,9 @@ TEST(OverProvisioningFactorTest, LocalityPickChanges) {
     zone_a.set_zone("A");
     envoy::config::core::v3::Locality zone_b;
     zone_b.set_zone("B");
-    HostVector hosts{makeTestHost(cluster_info, "tcp://127.0.0.1:80", *time_source, zone_a),
-                     makeTestHost(cluster_info, "tcp://127.0.0.1:81", *time_source, zone_a),
-                     makeTestHost(cluster_info, "tcp://127.0.0.1:82", *time_source, zone_b)};
+    HostVector hosts{makeTestHost(cluster_info, "tcp://127.0.0.1:80", zone_a),
+                     makeTestHost(cluster_info, "tcp://127.0.0.1:81", zone_a),
+                     makeTestHost(cluster_info, "tcp://127.0.0.1:82", zone_b)};
     LocalityWeightsConstSharedPtr locality_weights{new LocalityWeights{1, 1}};
     HostsPerLocalitySharedPtr hosts_per_locality =
         makeHostsPerLocality({{hosts[0], hosts[1]}, {hosts[2]}});
@@ -6312,12 +6309,12 @@ TEST(HostPartitionTest, PartitionHosts) {
   zone_a.set_zone("A");
   envoy::config::core::v3::Locality zone_b;
   zone_b.set_zone("B");
-  HostVector hosts{makeTestHost(info, "tcp://127.0.0.1:80", *time_source, zone_a),
-                   makeTestHost(info, "tcp://127.0.0.1:81", *time_source, zone_a),
-                   makeTestHost(info, "tcp://127.0.0.1:82", *time_source, zone_b),
-                   makeTestHost(info, "tcp://127.0.0.1:83", *time_source, zone_b),
-                   makeTestHost(info, "tcp://127.0.0.1:84", *time_source, zone_b),
-                   makeTestHost(info, "tcp://127.0.0.1:84", *time_source, zone_b)};
+  HostVector hosts{makeTestHost(info, "tcp://127.0.0.1:80", zone_a),
+                   makeTestHost(info, "tcp://127.0.0.1:81", zone_a),
+                   makeTestHost(info, "tcp://127.0.0.1:82", zone_b),
+                   makeTestHost(info, "tcp://127.0.0.1:83", zone_b),
+                   makeTestHost(info, "tcp://127.0.0.1:84", zone_b),
+                   makeTestHost(info, "tcp://127.0.0.1:84", zone_b)};
 
   hosts[0]->healthFlagSet(Host::HealthFlag::FAILED_ACTIVE_HC);
   hosts[1]->healthFlagSet(Host::HealthFlag::DEGRADED_ACTIVE_HC);
@@ -6488,8 +6485,8 @@ TEST_F(PriorityStateManagerTest, LocalityClusterUpdate) {
                                               random);
 
   auto current_hosts = cluster->prioritySet().hostSetsPerPriority()[0]->hosts();
-  HostVector hosts_added{makeTestHost(cluster->info(), "tcp://127.0.0.1:81", simTime(), zone_b),
-                         makeTestHost(cluster->info(), "tcp://127.0.0.1:82", simTime(), zone_a)};
+  HostVector hosts_added{makeTestHost(cluster->info(), "tcp://127.0.0.1:81", zone_b),
+                         makeTestHost(cluster->info(), "tcp://127.0.0.1:82", zone_a)};
 
   envoy::config::endpoint::v3::LocalityLbEndpoints zone_a_endpoints;
   zone_a_endpoints.mutable_locality()->CopyFrom(zone_a);

--- a/test/common/upstream/utility.h
+++ b/test/common/upstream/utility.h
@@ -95,72 +95,68 @@ inline envoy::config::cluster::v3::Cluster defaultStaticCluster(const std::strin
 }
 
 inline HostSharedPtr makeTestHost(ClusterInfoConstSharedPtr cluster, const std::string& hostname,
-                                  const std::string& url, TimeSource& time_source,
-                                  uint32_t weight = 1) {
+                                  const std::string& url, uint32_t weight = 1) {
   return std::shared_ptr<Upstream::HostImpl>(*HostImpl::create(
       cluster, hostname, *Network::Utility::resolveUrl(url), nullptr, nullptr, weight,
       envoy::config::core::v3::Locality(),
       envoy::config::endpoint::v3::Endpoint::HealthCheckConfig::default_instance(), 0,
-      envoy::config::core::v3::UNKNOWN, time_source));
+      envoy::config::core::v3::UNKNOWN));
 }
 
 inline HostSharedPtr makeTestHost(ClusterInfoConstSharedPtr cluster, const std::string& url,
-                                  TimeSource& time_source, uint32_t weight = 1,
-                                  uint32_t priority = 0,
+                                  uint32_t weight = 1, uint32_t priority = 0,
                                   Host::HealthStatus status = Host::HealthStatus::UNKNOWN) {
   return std::shared_ptr<Upstream::HostImpl>(*HostImpl::create(
       cluster, "", *Network::Utility::resolveUrl(url), nullptr, nullptr, weight,
       envoy::config::core::v3::Locality(),
       envoy::config::endpoint::v3::Endpoint::HealthCheckConfig::default_instance(), priority,
-      status, time_source));
+      status));
 }
 
 inline HostSharedPtr makeTestHost(ClusterInfoConstSharedPtr cluster, const std::string& url,
-                                  TimeSource& time_source,
                                   envoy::config::core::v3::Locality locality, uint32_t weight = 1,
                                   uint32_t priority = 0,
                                   Host::HealthStatus status = Host::HealthStatus::UNKNOWN) {
   return std::shared_ptr<Upstream::HostImpl>(*HostImpl::create(
       cluster, "", *Network::Utility::resolveUrl(url), nullptr, nullptr, weight, locality,
       envoy::config::endpoint::v3::Endpoint::HealthCheckConfig::default_instance(), priority,
-      status, time_source));
+      status));
 }
 
 inline HostSharedPtr makeTestHost(ClusterInfoConstSharedPtr cluster, const std::string& url,
                                   const envoy::config::core::v3::Metadata& metadata,
-                                  TimeSource& time_source, uint32_t weight = 1) {
+                                  uint32_t weight = 1) {
   return std::shared_ptr<Upstream::HostImpl>(*HostImpl::create(
       cluster, "", *Network::Utility::resolveUrl(url),
       std::make_shared<const envoy::config::core::v3::Metadata>(metadata), nullptr, weight,
       envoy::config::core::v3::Locality(),
       envoy::config::endpoint::v3::Endpoint::HealthCheckConfig::default_instance(), 0,
-      envoy::config::core::v3::UNKNOWN, time_source));
+      envoy::config::core::v3::UNKNOWN));
 }
 
 inline HostSharedPtr makeTestHost(ClusterInfoConstSharedPtr cluster, const std::string& url,
                                   const envoy::config::core::v3::Metadata& metadata,
-                                  envoy::config::core::v3::Locality locality,
-                                  TimeSource& time_source, uint32_t weight = 1) {
+                                  envoy::config::core::v3::Locality locality, uint32_t weight = 1) {
   return std::shared_ptr<Upstream::HostImpl>(*HostImpl::create(
       cluster, "", *Network::Utility::resolveUrl(url),
       std::make_shared<const envoy::config::core::v3::Metadata>(metadata), nullptr, weight,
       locality, envoy::config::endpoint::v3::Endpoint::HealthCheckConfig::default_instance(), 0,
-      envoy::config::core::v3::UNKNOWN, time_source));
+      envoy::config::core::v3::UNKNOWN));
 }
 
 inline HostSharedPtr
 makeTestHost(ClusterInfoConstSharedPtr cluster, const std::string& url,
              const envoy::config::endpoint::v3::Endpoint::HealthCheckConfig& health_check_config,
-             TimeSource& time_source, uint32_t weight = 1) {
+             uint32_t weight = 1) {
   return std::shared_ptr<Upstream::HostImpl>(
       *HostImpl::create(cluster, "", *Network::Utility::resolveUrl(url), nullptr, nullptr, weight,
                         envoy::config::core::v3::Locality(), health_check_config, 0,
-                        envoy::config::core::v3::UNKNOWN, time_source));
+                        envoy::config::core::v3::UNKNOWN));
 }
 
 inline HostSharedPtr makeTestHostWithHashKey(ClusterInfoConstSharedPtr cluster,
                                              const std::string& hash_key, const std::string& url,
-                                             TimeSource& time_source, uint32_t weight = 1) {
+                                             uint32_t weight = 1) {
   envoy::config::core::v3::Metadata metadata;
   Config::Metadata::mutableMetadataValue(metadata, Config::MetadataFilters::get().ENVOY_LB,
                                          Config::MetadataEnvoyLbKeys::get().HASH_KEY)
@@ -170,28 +166,25 @@ inline HostSharedPtr makeTestHostWithHashKey(ClusterInfoConstSharedPtr cluster,
       std::make_shared<const envoy::config::core::v3::Metadata>(metadata), nullptr, weight,
       envoy::config::core::v3::Locality(),
       envoy::config::endpoint::v3::Endpoint::HealthCheckConfig::default_instance(), 0,
-      envoy::config::core::v3::UNKNOWN, time_source));
+      envoy::config::core::v3::UNKNOWN));
 }
 
 inline HostSharedPtr makeTestHostWithMetadata(ClusterInfoConstSharedPtr cluster,
                                               MetadataConstSharedPtr metadata,
-                                              const std::string& url, TimeSource& time_source,
-                                              uint32_t weight = 1) {
+                                              const std::string& url, uint32_t weight = 1) {
   return std::shared_ptr<Upstream::HostImpl>(*HostImpl::create(
       cluster, "", *Network::Utility::resolveUrl(url), metadata, nullptr, weight,
       envoy::config::core::v3::Locality(),
       envoy::config::endpoint::v3::Endpoint::HealthCheckConfig::default_instance(), 0,
-      envoy::config::core::v3::UNKNOWN, time_source));
+      envoy::config::core::v3::UNKNOWN));
 }
 
 inline HostDescriptionConstSharedPtr makeTestHostDescription(ClusterInfoConstSharedPtr cluster,
-                                                             const std::string& url,
-                                                             TimeSource& time_source) {
+                                                             const std::string& url) {
   return std::shared_ptr<HostDescriptionImpl>(*HostDescriptionImpl::create(
       cluster, "", *Network::Utility::resolveUrl(url), nullptr, nullptr,
       envoy::config::core::v3::Locality().default_instance(),
-      envoy::config::endpoint::v3::Endpoint::HealthCheckConfig::default_instance(), 0,
-      time_source));
+      envoy::config::endpoint::v3::Endpoint::HealthCheckConfig::default_instance(), 0));
 }
 
 inline HostsPerLocalitySharedPtr makeHostsPerLocality(std::vector<HostVector>&& locality_hosts,

--- a/test/extensions/clusters/aggregate/cluster_test.cc
+++ b/test/extensions/clusters/aggregate/cluster_test.cc
@@ -46,20 +46,19 @@ public:
                                     int degraded_hosts, int unhealthy_hosts, uint32_t priority) {
     Upstream::HostVector hosts;
     for (int i = 0; i < healthy_hosts; ++i) {
-      hosts.emplace_back(
-          Upstream::makeTestHost(cluster, "tcp://127.0.0.1:80", simTime(), 1, priority));
+      hosts.emplace_back(Upstream::makeTestHost(cluster, "tcp://127.0.0.1:80", 1, priority));
     }
 
     for (int i = 0; i < degraded_hosts; ++i) {
       Upstream::HostSharedPtr host =
-          Upstream::makeTestHost(cluster, "tcp://127.0.0.2:80", simTime(), 1, priority);
+          Upstream::makeTestHost(cluster, "tcp://127.0.0.2:80", 1, priority);
       host->healthFlagSet(Upstream::HostImpl::HealthFlag::DEGRADED_ACTIVE_HC);
       hosts.emplace_back(host);
     }
 
     for (int i = 0; i < unhealthy_hosts; ++i) {
       Upstream::HostSharedPtr host =
-          Upstream::makeTestHost(cluster, "tcp://127.0.0.3:80", simTime(), 1, priority);
+          Upstream::makeTestHost(cluster, "tcp://127.0.0.3:80", 1, priority);
       host->healthFlagSet(Upstream::HostImpl::HealthFlag::FAILED_ACTIVE_HC);
       hosts.emplace_back(host);
     }
@@ -178,8 +177,7 @@ TEST_F(AggregateClusterTest, LoadBalancerTest) {
   // Cluster 2:
   //     Priority 0: 33.3%
   //     Priority 1: 33.3%
-  Upstream::HostSharedPtr host =
-      Upstream::makeTestHost(primary_info_, "tcp://127.0.0.1:80", simTime());
+  Upstream::HostSharedPtr host = Upstream::makeTestHost(primary_info_, "tcp://127.0.0.1:80");
   EXPECT_CALL(primary_load_balancer_, chooseHost(_)).WillRepeatedly(Invoke([host] {
     return Upstream::HostSelectionResponse{host};
   }));
@@ -251,8 +249,7 @@ TEST_F(AggregateClusterTest, LoadBalancerTest) {
 
 TEST_F(AggregateClusterTest, AllHostAreUnhealthyTest) {
   initialize(default_yaml_config_);
-  Upstream::HostSharedPtr host =
-      Upstream::makeTestHost(primary_info_, "tcp://127.0.0.1:80", simTime());
+  Upstream::HostSharedPtr host = Upstream::makeTestHost(primary_info_, "tcp://127.0.0.1:80");
   // Set up the HostSet with 0 healthy, 0 degraded and 2 unhealthy.
   setupPrimary(0, 0, 0, 2);
   setupPrimary(1, 0, 0, 2);
@@ -298,8 +295,7 @@ TEST_F(AggregateClusterTest, AllHostAreUnhealthyTest) {
 
 TEST_F(AggregateClusterTest, ClusterInPanicTest) {
   initialize(default_yaml_config_);
-  Upstream::HostSharedPtr host =
-      Upstream::makeTestHost(primary_info_, "tcp://127.0.0.1:80", simTime());
+  Upstream::HostSharedPtr host = Upstream::makeTestHost(primary_info_, "tcp://127.0.0.1:80");
   setupPrimary(0, 1, 0, 4);
   setupPrimary(1, 1, 0, 4);
   setupSecondary(0, 1, 0, 4);
@@ -399,7 +395,7 @@ TEST_F(AggregateClusterTest, ContextDeterminePriorityLoad) {
 
   const uint32_t invalid_priority = 42;
   Upstream::HostSharedPtr host =
-      Upstream::makeTestHost(primary_info_, "tcp://127.0.0.1:80", simTime(), 1, invalid_priority);
+      Upstream::makeTestHost(primary_info_, "tcp://127.0.0.1:80", 1, invalid_priority);
 
   // The linearized priorities are [P0, P1, S0, S1].
   Upstream::HealthyAndDegradedLoad secondary_priority_1{Upstream::HealthyLoad({0, 0, 0, 100}),

--- a/test/extensions/clusters/aggregate/cluster_update_test.cc
+++ b/test/extensions/clusters/aggregate/cluster_update_test.cc
@@ -154,14 +154,11 @@ TEST_P(AggregateClusterUpdateTest, LoadBalancingTest) {
   EXPECT_NE(nullptr, secondary);
 
   // Set up the HostSet with 1 healthy, 1 degraded and 1 unhealthy.
-  Upstream::HostSharedPtr host1 =
-      Upstream::makeTestHost(primary->info(), "tcp://127.0.0.1:80", simTime());
+  Upstream::HostSharedPtr host1 = Upstream::makeTestHost(primary->info(), "tcp://127.0.0.1:80");
   host1->healthFlagSet(Upstream::HostImpl::HealthFlag::DEGRADED_ACTIVE_HC);
-  Upstream::HostSharedPtr host2 =
-      Upstream::makeTestHost(primary->info(), "tcp://127.0.0.2:80", simTime());
+  Upstream::HostSharedPtr host2 = Upstream::makeTestHost(primary->info(), "tcp://127.0.0.2:80");
   host2->healthFlagSet(Upstream::HostImpl::HealthFlag::FAILED_ACTIVE_HC);
-  Upstream::HostSharedPtr host3 =
-      Upstream::makeTestHost(primary->info(), "tcp://127.0.0.3:80", simTime());
+  Upstream::HostSharedPtr host3 = Upstream::makeTestHost(primary->info(), "tcp://127.0.0.3:80");
   Upstream::Cluster& cluster = cluster_manager_->activeClusters().find("primary")->second;
   cluster.prioritySet().updateHosts(
       0,
@@ -171,14 +168,11 @@ TEST_P(AggregateClusterUpdateTest, LoadBalancingTest) {
       nullptr, {host1, host2, host3}, {}, 0, absl::nullopt, 100);
 
   // Set up the HostSet with 1 healthy, 1 degraded and 1 unhealthy.
-  Upstream::HostSharedPtr host4 =
-      Upstream::makeTestHost(secondary->info(), "tcp://127.0.0.4:80", simTime());
+  Upstream::HostSharedPtr host4 = Upstream::makeTestHost(secondary->info(), "tcp://127.0.0.4:80");
   host4->healthFlagSet(Upstream::HostImpl::HealthFlag::DEGRADED_ACTIVE_HC);
-  Upstream::HostSharedPtr host5 =
-      Upstream::makeTestHost(secondary->info(), "tcp://127.0.0.5:80", simTime());
+  Upstream::HostSharedPtr host5 = Upstream::makeTestHost(secondary->info(), "tcp://127.0.0.5:80");
   host5->healthFlagSet(Upstream::HostImpl::HealthFlag::FAILED_ACTIVE_HC);
-  Upstream::HostSharedPtr host6 =
-      Upstream::makeTestHost(secondary->info(), "tcp://127.0.0.6:80", simTime());
+  Upstream::HostSharedPtr host6 = Upstream::makeTestHost(secondary->info(), "tcp://127.0.0.6:80");
   Upstream::Cluster& cluster1 = cluster_manager_->activeClusters().find("secondary")->second;
   cluster1.prioritySet().updateHosts(
       0,
@@ -212,14 +206,11 @@ TEST_P(AggregateClusterUpdateTest, LoadBalancingTest) {
   EXPECT_EQ(nullptr, cluster_manager_->getThreadLocalCluster("primary"));
 
   // Set up the HostSet with 1 healthy, 1 degraded and 1 unhealthy.
-  Upstream::HostSharedPtr host7 =
-      Upstream::makeTestHost(secondary->info(), "tcp://127.0.0.7:80", simTime());
+  Upstream::HostSharedPtr host7 = Upstream::makeTestHost(secondary->info(), "tcp://127.0.0.7:80");
   host7->healthFlagSet(Upstream::HostImpl::HealthFlag::DEGRADED_ACTIVE_HC);
-  Upstream::HostSharedPtr host8 =
-      Upstream::makeTestHost(secondary->info(), "tcp://127.0.0.8:80", simTime());
+  Upstream::HostSharedPtr host8 = Upstream::makeTestHost(secondary->info(), "tcp://127.0.0.8:80");
   host8->healthFlagSet(Upstream::HostImpl::HealthFlag::FAILED_ACTIVE_HC);
-  Upstream::HostSharedPtr host9 =
-      Upstream::makeTestHost(secondary->info(), "tcp://127.0.0.9:80", simTime());
+  Upstream::HostSharedPtr host9 = Upstream::makeTestHost(secondary->info(), "tcp://127.0.0.9:80");
   cluster1.prioritySet().updateHosts(
       1,
       Upstream::HostSetImpl::partitionHosts(
@@ -301,14 +292,11 @@ TEST_P(AggregateClusterUpdateTest, InitializeAggregateClusterAfterOtherClusters)
   EXPECT_EQ("127.0.0.1:80", host->address()->asString());
 
   // Set up the HostSet with 1 healthy, 1 degraded and 1 unhealthy.
-  Upstream::HostSharedPtr host1 =
-      Upstream::makeTestHost(primary->info(), "tcp://127.0.0.1:80", simTime());
+  Upstream::HostSharedPtr host1 = Upstream::makeTestHost(primary->info(), "tcp://127.0.0.1:80");
   host1->healthFlagSet(Upstream::HostImpl::HealthFlag::DEGRADED_ACTIVE_HC);
-  Upstream::HostSharedPtr host2 =
-      Upstream::makeTestHost(primary->info(), "tcp://127.0.0.2:80", simTime());
+  Upstream::HostSharedPtr host2 = Upstream::makeTestHost(primary->info(), "tcp://127.0.0.2:80");
   host2->healthFlagSet(Upstream::HostImpl::HealthFlag::FAILED_ACTIVE_HC);
-  Upstream::HostSharedPtr host3 =
-      Upstream::makeTestHost(primary->info(), "tcp://127.0.0.3:80", simTime());
+  Upstream::HostSharedPtr host3 = Upstream::makeTestHost(primary->info(), "tcp://127.0.0.3:80");
   Upstream::Cluster& cluster = cluster_manager_->activeClusters().find("primary")->second;
   cluster.prioritySet().updateHosts(
       0,

--- a/test/extensions/clusters/redis/redis_cluster_lb_test.cc
+++ b/test/extensions/clusters/redis/redis_cluster_lb_test.cc
@@ -107,9 +107,9 @@ TEST_F(RedisClusterLoadBalancerTest, NoHost) {
 
 // Works correctly with empty context
 TEST_F(RedisClusterLoadBalancerTest, NoHash) {
-  Upstream::HostVector hosts{Upstream::makeTestHost(info_, "tcp://127.0.0.1:90", simTime()),
-                             Upstream::makeTestHost(info_, "tcp://127.0.0.1:91", simTime()),
-                             Upstream::makeTestHost(info_, "tcp://127.0.0.1:92", simTime())};
+  Upstream::HostVector hosts{Upstream::makeTestHost(info_, "tcp://127.0.0.1:90"),
+                             Upstream::makeTestHost(info_, "tcp://127.0.0.1:91"),
+                             Upstream::makeTestHost(info_, "tcp://127.0.0.1:92")};
 
   ClusterSlotsPtr slots = std::make_unique<std::vector<ClusterSlot>>(std::vector<ClusterSlot>{
       ClusterSlot(0, 1000, hosts[0]->address()),
@@ -128,9 +128,9 @@ TEST_F(RedisClusterLoadBalancerTest, NoHash) {
 };
 
 TEST_F(RedisClusterLoadBalancerTest, Basic) {
-  Upstream::HostVector hosts{Upstream::makeTestHost(info_, "tcp://127.0.0.1:90", simTime()),
-                             Upstream::makeTestHost(info_, "tcp://127.0.0.1:91", simTime()),
-                             Upstream::makeTestHost(info_, "tcp://127.0.0.1:92", simTime())};
+  Upstream::HostVector hosts{Upstream::makeTestHost(info_, "tcp://127.0.0.1:90"),
+                             Upstream::makeTestHost(info_, "tcp://127.0.0.1:91"),
+                             Upstream::makeTestHost(info_, "tcp://127.0.0.1:92")};
 
   ClusterSlotsPtr slots = std::make_unique<std::vector<ClusterSlot>>(std::vector<ClusterSlot>{
       ClusterSlot(0, 1000, hosts[0]->address()),
@@ -153,9 +153,9 @@ TEST_F(RedisClusterLoadBalancerTest, Basic) {
 }
 
 TEST_F(RedisClusterLoadBalancerTest, Shard) {
-  Upstream::HostVector hosts{Upstream::makeTestHost(info_, "tcp://127.0.0.1:90", simTime()),
-                             Upstream::makeTestHost(info_, "tcp://127.0.0.1:91", simTime()),
-                             Upstream::makeTestHost(info_, "tcp://127.0.0.1:92", simTime())};
+  Upstream::HostVector hosts{Upstream::makeTestHost(info_, "tcp://127.0.0.1:90"),
+                             Upstream::makeTestHost(info_, "tcp://127.0.0.1:91"),
+                             Upstream::makeTestHost(info_, "tcp://127.0.0.1:92")};
 
   ClusterSlotsPtr slots = std::make_unique<std::vector<ClusterSlot>>(std::vector<ClusterSlot>{
       ClusterSlot(0, 1000, hosts[0]->address()),
@@ -197,10 +197,10 @@ TEST_F(RedisClusterLoadBalancerTest, Shard) {
 
 TEST_F(RedisClusterLoadBalancerTest, ReadStrategiesHealthy) {
   Upstream::HostVector hosts{
-      Upstream::makeTestHost(info_, "tcp://127.0.0.1:90", simTime()),
-      Upstream::makeTestHost(info_, "tcp://127.0.0.1:91", simTime()),
-      Upstream::makeTestHost(info_, "tcp://127.0.0.2:90", simTime()),
-      Upstream::makeTestHost(info_, "tcp://127.0.0.2:91", simTime()),
+      Upstream::makeTestHost(info_, "tcp://127.0.0.1:90"),
+      Upstream::makeTestHost(info_, "tcp://127.0.0.1:91"),
+      Upstream::makeTestHost(info_, "tcp://127.0.0.2:90"),
+      Upstream::makeTestHost(info_, "tcp://127.0.0.2:91"),
   };
 
   ClusterSlotsPtr slots = std::make_unique<std::vector<ClusterSlot>>(std::vector<ClusterSlot>{
@@ -239,10 +239,10 @@ TEST_F(RedisClusterLoadBalancerTest, ReadStrategiesHealthy) {
 
 TEST_F(RedisClusterLoadBalancerTest, ReadStrategiesUnhealthyPrimary) {
   Upstream::HostVector hosts{
-      Upstream::makeTestHost(info_, "tcp://127.0.0.1:90", simTime()),
-      Upstream::makeTestHost(info_, "tcp://127.0.0.1:91", simTime()),
-      Upstream::makeTestHost(info_, "tcp://127.0.0.2:90", simTime()),
-      Upstream::makeTestHost(info_, "tcp://127.0.0.2:91", simTime()),
+      Upstream::makeTestHost(info_, "tcp://127.0.0.1:90"),
+      Upstream::makeTestHost(info_, "tcp://127.0.0.1:91"),
+      Upstream::makeTestHost(info_, "tcp://127.0.0.2:90"),
+      Upstream::makeTestHost(info_, "tcp://127.0.0.2:91"),
   };
 
   ClusterSlotsPtr slots = std::make_unique<std::vector<ClusterSlot>>(std::vector<ClusterSlot>{
@@ -286,10 +286,10 @@ TEST_F(RedisClusterLoadBalancerTest, ReadStrategiesUnhealthyPrimary) {
 
 TEST_F(RedisClusterLoadBalancerTest, ReadStrategiesUnhealthyReplica) {
   Upstream::HostVector hosts{
-      Upstream::makeTestHost(info_, "tcp://127.0.0.1:90", simTime()),
-      Upstream::makeTestHost(info_, "tcp://127.0.0.1:91", simTime()),
-      Upstream::makeTestHost(info_, "tcp://127.0.0.2:90", simTime()),
-      Upstream::makeTestHost(info_, "tcp://127.0.0.2:91", simTime()),
+      Upstream::makeTestHost(info_, "tcp://127.0.0.1:90"),
+      Upstream::makeTestHost(info_, "tcp://127.0.0.1:91"),
+      Upstream::makeTestHost(info_, "tcp://127.0.0.2:90"),
+      Upstream::makeTestHost(info_, "tcp://127.0.0.2:91"),
   };
 
   ClusterSlotsPtr slots = std::make_unique<std::vector<ClusterSlot>>(std::vector<ClusterSlot>{
@@ -332,8 +332,8 @@ TEST_F(RedisClusterLoadBalancerTest, ReadStrategiesUnhealthyReplica) {
 }
 
 TEST_F(RedisClusterLoadBalancerTest, ReadStrategiesNoReplica) {
-  Upstream::HostVector hosts{Upstream::makeTestHost(info_, "tcp://127.0.0.1:90", simTime()),
-                             Upstream::makeTestHost(info_, "tcp://127.0.0.1:91", simTime())};
+  Upstream::HostVector hosts{Upstream::makeTestHost(info_, "tcp://127.0.0.1:90"),
+                             Upstream::makeTestHost(info_, "tcp://127.0.0.1:91")};
 
   ClusterSlotsPtr slots = std::make_unique<std::vector<ClusterSlot>>(std::vector<ClusterSlot>{
       ClusterSlot(0, 2000, hosts[0]->address()),
@@ -364,8 +364,8 @@ TEST_F(RedisClusterLoadBalancerTest, ReadStrategiesNoReplica) {
 }
 
 TEST_F(RedisClusterLoadBalancerTest, ClusterSlotUpdate) {
-  Upstream::HostVector hosts{Upstream::makeTestHost(info_, "tcp://127.0.0.1:90", simTime()),
-                             Upstream::makeTestHost(info_, "tcp://127.0.0.1:91", simTime())};
+  Upstream::HostVector hosts{Upstream::makeTestHost(info_, "tcp://127.0.0.1:90"),
+                             Upstream::makeTestHost(info_, "tcp://127.0.0.1:91")};
   ClusterSlotsPtr slots = std::make_unique<std::vector<ClusterSlot>>(std::vector<ClusterSlot>{
       ClusterSlot(0, 1000, hosts[0]->address()), ClusterSlot(1001, 16383, hosts[1]->address())});
   Upstream::HostMap all_hosts{{hosts[0]->address()->asString(), hosts[0]},
@@ -395,16 +395,16 @@ TEST_F(RedisClusterLoadBalancerTest, ClusterSlotUpdate) {
 }
 
 TEST_F(RedisClusterLoadBalancerTest, ClusterSlotNoUpdate) {
-  Upstream::HostVector hosts{Upstream::makeTestHost(info_, "tcp://127.0.0.1:90", simTime()),
-                             Upstream::makeTestHost(info_, "tcp://127.0.0.1:91", simTime()),
-                             Upstream::makeTestHost(info_, "tcp://127.0.0.1:92", simTime()),
-                             Upstream::makeTestHost(info_, "tcp://127.0.0.1:90", simTime()),
-                             Upstream::makeTestHost(info_, "tcp://127.0.0.1:91", simTime()),
-                             Upstream::makeTestHost(info_, "tcp://127.0.0.1:92", simTime())};
-  Upstream::HostVector replicas{Upstream::makeTestHost(info_, "tcp://127.0.0.2:90", simTime()),
-                                Upstream::makeTestHost(info_, "tcp://127.0.0.2:91", simTime()),
-                                Upstream::makeTestHost(info_, "tcp://127.0.0.2:90", simTime()),
-                                Upstream::makeTestHost(info_, "tcp://127.0.0.2:91", simTime())};
+  Upstream::HostVector hosts{Upstream::makeTestHost(info_, "tcp://127.0.0.1:90"),
+                             Upstream::makeTestHost(info_, "tcp://127.0.0.1:91"),
+                             Upstream::makeTestHost(info_, "tcp://127.0.0.1:92"),
+                             Upstream::makeTestHost(info_, "tcp://127.0.0.1:90"),
+                             Upstream::makeTestHost(info_, "tcp://127.0.0.1:91"),
+                             Upstream::makeTestHost(info_, "tcp://127.0.0.1:92")};
+  Upstream::HostVector replicas{Upstream::makeTestHost(info_, "tcp://127.0.0.2:90"),
+                                Upstream::makeTestHost(info_, "tcp://127.0.0.2:91"),
+                                Upstream::makeTestHost(info_, "tcp://127.0.0.2:90"),
+                                Upstream::makeTestHost(info_, "tcp://127.0.0.2:91")};
 
   ClusterSlotsPtr slots = std::make_unique<std::vector<ClusterSlot>>(std::vector<ClusterSlot>{
       ClusterSlot(0, 1000, hosts[0]->address()),

--- a/test/extensions/health_checkers/redis/redis_test.cc
+++ b/test/extensions/health_checkers/redis/redis_test.cc
@@ -258,8 +258,7 @@ public:
   }
 
   void exerciseStubs() {
-    Upstream::HostSharedPtr host =
-        Upstream::makeTestHost(cluster_->info_, "tcp://127.0.0.1:100", simTime());
+    Upstream::HostSharedPtr host = Upstream::makeTestHost(cluster_->info_, "tcp://127.0.0.1:100");
     RedisHealthChecker::RedisActiveHealthCheckSessionPtr session =
         std::make_unique<RedisHealthChecker::RedisActiveHealthCheckSession>(*health_checker_, host);
 
@@ -299,7 +298,7 @@ TEST_F(RedisHealthCheckerTest, PingWithAuth) {
   setupWithAuth();
 
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      Upstream::makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      Upstream::makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
 
   expectSessionCreate();
   expectClientCreate();
@@ -347,7 +346,7 @@ TEST_F(RedisHealthCheckerTest, ExistsWithAuth) {
   setupExistsHealthcheckWithAuth();
 
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      Upstream::makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      Upstream::makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
 
   expectSessionCreate();
   expectClientCreate();
@@ -393,7 +392,7 @@ TEST_F(RedisHealthCheckerTest, PingAndVariousFailures) {
   exerciseStubs();
 
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      Upstream::makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      Upstream::makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
 
   expectSessionCreate();
   expectClientCreate();
@@ -461,7 +460,7 @@ TEST_F(RedisHealthCheckerTest, FailuresLogging) {
   setupAlwaysLogHealthCheckFailures();
 
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      Upstream::makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      Upstream::makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
 
   expectSessionCreate();
   expectClientCreate();
@@ -519,7 +518,7 @@ TEST_F(RedisHealthCheckerTest, LogInitialFailure) {
   setup();
 
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      Upstream::makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      Upstream::makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
 
   expectSessionCreate();
   expectClientCreate();
@@ -569,7 +568,7 @@ TEST_F(RedisHealthCheckerTest, Exists) {
   setupExistsHealthcheck();
 
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      Upstream::makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      Upstream::makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
 
   expectSessionCreate();
   expectClientCreate();
@@ -623,7 +622,7 @@ TEST_F(RedisHealthCheckerTest, ExistsRedirected) {
   setupExistsHealthcheck();
 
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      Upstream::makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      Upstream::makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
 
   expectSessionCreate();
   expectClientCreate();
@@ -667,7 +666,7 @@ TEST_F(RedisHealthCheckerTest, NoConnectionReuse) {
   setupDontReuseConnection();
 
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      Upstream::makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+      Upstream::makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
 
   expectSessionCreate();
   expectClientCreate();
@@ -746,9 +745,8 @@ TEST(RedisHealthCheckerIamAuthTest, CheckTokenIsRetrieved) {
   Api::ApiPtr api = Api::createApiForTest();
   Envoy::Extensions::Common::Aws::CredentialsPendingCallback capture;
 
-  Event::SimulatedTimeSystem sim;
   cluster->prioritySet().getMockHostSet(0)->hosts_ = {
-      Upstream::makeTestHost(cluster->info_, "tcp://127.0.0.1:80", sim)};
+      Upstream::makeTestHost(cluster->info_, "tcp://127.0.0.1:80")};
 
   auto mock_connection = std::make_unique<NiceMock<Network::MockClientConnection>>();
 

--- a/test/extensions/health_checkers/thrift/thrift_test.cc
+++ b/test/extensions/health_checkers/thrift/thrift_test.cc
@@ -40,7 +40,7 @@ public:
         health_check_config, ProtobufMessage::getStrictValidationVisitor());
 
     cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-        Upstream::makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+        Upstream::makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
 
     health_checker_ = std::make_shared<ThriftHealthChecker>(
         *cluster_, health_check_config, thrift_config, dispatcher_, runtime_,

--- a/test/extensions/load_balancing_policies/client_side_weighted_round_robin/client_side_weighted_round_robin_lb_test.cc
+++ b/test/extensions/load_balancing_policies/client_side_weighted_round_robin/client_side_weighted_round_robin_lb_test.cc
@@ -162,9 +162,9 @@ TEST_P(ClientSideWeightedRoundRobinLoadBalancerTest,
        UpdateWeightsOnHostsAllHostsHaveClientSideWeights) {
   init(false);
   HostVector hosts = {
-      makeTestHost(info_, "tcp://127.0.0.1:80", simTime()),
-      makeTestHost(info_, "tcp://127.0.0.1:81", simTime()),
-      makeTestHost(info_, "tcp://127.0.0.1:82", simTime()),
+      makeTestHost(info_, "tcp://127.0.0.1:80"),
+      makeTestHost(info_, "tcp://127.0.0.1:81"),
+      makeTestHost(info_, "tcp://127.0.0.1:82"),
   };
   simTime().setMonotonicTime(MonotonicTime(std::chrono::seconds(30)));
   lb_->setHostClientSideWeight(hosts[0], 40, 5, 10);
@@ -185,9 +185,9 @@ TEST_P(ClientSideWeightedRoundRobinLoadBalancerTest,
 TEST_P(ClientSideWeightedRoundRobinLoadBalancerTest, UpdateWeightsOneHostHasClientSideWeight) {
   init(false);
   HostVector hosts = {
-      makeTestHost(info_, "tcp://127.0.0.1:80", simTime()),
-      makeTestHost(info_, "tcp://127.0.0.1:81", simTime()),
-      makeTestHost(info_, "tcp://127.0.0.1:82", simTime()),
+      makeTestHost(info_, "tcp://127.0.0.1:80"),
+      makeTestHost(info_, "tcp://127.0.0.1:81"),
+      makeTestHost(info_, "tcp://127.0.0.1:82"),
   };
   simTime().setMonotonicTime(MonotonicTime(std::chrono::seconds(30)));
   // Set client side weight for one host.
@@ -207,11 +207,9 @@ TEST_P(ClientSideWeightedRoundRobinLoadBalancerTest, UpdateWeightsOneHostHasClie
 TEST_P(ClientSideWeightedRoundRobinLoadBalancerTest, UpdateWeightsDefaultIsOddMedianWeight) {
   init(false);
   HostVector hosts = {
-      makeTestHost(info_, "tcp://127.0.0.1:80", simTime()),
-      makeTestHost(info_, "tcp://127.0.0.1:81", simTime()),
-      makeTestHost(info_, "tcp://127.0.0.1:82", simTime()),
-      makeTestHost(info_, "tcp://127.0.0.1:83", simTime()),
-      makeTestHost(info_, "tcp://127.0.0.1:84", simTime()),
+      makeTestHost(info_, "tcp://127.0.0.1:80"), makeTestHost(info_, "tcp://127.0.0.1:81"),
+      makeTestHost(info_, "tcp://127.0.0.1:82"), makeTestHost(info_, "tcp://127.0.0.1:83"),
+      makeTestHost(info_, "tcp://127.0.0.1:84"),
   };
   simTime().setMonotonicTime(MonotonicTime(std::chrono::seconds(30)));
   // Set client side weight for first three hosts.
@@ -238,11 +236,9 @@ TEST_P(ClientSideWeightedRoundRobinLoadBalancerTest, UpdateWeightsDefaultIsOddMe
 TEST_P(ClientSideWeightedRoundRobinLoadBalancerTest, UpdateWeightsDefaultIsEvenMedianWeight) {
   init(false);
   HostVector hosts = {
-      makeTestHost(info_, "tcp://127.0.0.1:80", simTime()),
-      makeTestHost(info_, "tcp://127.0.0.1:81", simTime()),
-      makeTestHost(info_, "tcp://127.0.0.1:82", simTime()),
-      makeTestHost(info_, "tcp://127.0.0.1:83", simTime()),
-      makeTestHost(info_, "tcp://127.0.0.1:84", simTime()),
+      makeTestHost(info_, "tcp://127.0.0.1:80"), makeTestHost(info_, "tcp://127.0.0.1:81"),
+      makeTestHost(info_, "tcp://127.0.0.1:82"), makeTestHost(info_, "tcp://127.0.0.1:83"),
+      makeTestHost(info_, "tcp://127.0.0.1:84"),
   };
   simTime().setMonotonicTime(MonotonicTime(std::chrono::seconds(30)));
   // Set client side weight for first two hosts.
@@ -270,9 +266,9 @@ TEST_P(ClientSideWeightedRoundRobinLoadBalancerTest, ChooseHostWithClientSideWei
     return;
   }
   hostSet().healthy_hosts_ = {
-      makeTestHost(info_, "tcp://127.0.0.1:80", simTime()),
-      makeTestHost(info_, "tcp://127.0.0.1:81", simTime()),
-      makeTestHost(info_, "tcp://127.0.0.1:82", simTime()),
+      makeTestHost(info_, "tcp://127.0.0.1:80"),
+      makeTestHost(info_, "tcp://127.0.0.1:81"),
+      makeTestHost(info_, "tcp://127.0.0.1:82"),
   };
   hostSet().hosts_ = hostSet().healthy_hosts_;
   init(false);

--- a/test/extensions/load_balancing_policies/common/benchmark_base_tester.cc
+++ b/test/extensions/load_balancing_policies/common/benchmark_base_tester.cc
@@ -19,9 +19,9 @@ BaseTester::BaseTester(uint64_t num_hosts, uint32_t weighted_subset_percent, uin
           (*metadata.mutable_filter_metadata())[Config::MetadataFilters::get().ENVOY_LB];
       (*map.mutable_fields())[std::string(metadata_key)] = value;
 
-      hosts.push_back(Upstream::makeTestHost(info_, url, metadata, simTime(), effective_weight));
+      hosts.push_back(Upstream::makeTestHost(info_, url, metadata, effective_weight));
     } else {
-      hosts.push_back(Upstream::makeTestHost(info_, url, simTime(), effective_weight));
+      hosts.push_back(Upstream::makeTestHost(info_, url, effective_weight));
     }
   }
 

--- a/test/extensions/load_balancing_policies/common/bounded_load_hlb_test.cc
+++ b/test/extensions/load_balancing_policies/common/bounded_load_hlb_test.cc
@@ -70,7 +70,7 @@ public:
     const double equal_weight = static_cast<double>(1.0 / num_hosts);
     for (uint32_t i = 0; i < num_hosts; i++) {
       normalized_host_weights.push_back(
-          {makeTestHost(info_, fmt::format("tcp://127.0.0.1{}:90", i), simTime()), equal_weight});
+          {makeTestHost(info_, fmt::format("tcp://127.0.0.1{}:90", i)), equal_weight});
     }
   }
 
@@ -79,7 +79,7 @@ public:
                    NormalizedHostWeightVector& ring) {
     const double equal_weight = static_cast<double>(1.0 / num_hosts);
     for (uint32_t i = 0; i < num_hosts; i++) {
-      HostConstSharedPtr h = makeTestHost(info_, fmt::format("tcp://127.0.0.1{}:90", i), simTime());
+      HostConstSharedPtr h = makeTestHost(info_, fmt::format("tcp://127.0.0.1{}:90", i));
       ring.push_back({h, equal_weight});
       ring.push_back({h, equal_weight});
       hosts.push_back({h, equal_weight});
@@ -104,7 +104,7 @@ TEST_F(HashingLoadBalancerTest, HashKey) {
   NormalizedHostWeightVector normalized_host_weights;
   hlb_ = std::make_shared<TestHashingLoadBalancer>(normalized_host_weights);
 
-  HostSharedPtr host = makeTestHost(info_, "hostname", "tcp://127.0.0.1:90", simTime());
+  HostSharedPtr host = makeTestHost(info_, "hostname", "tcp://127.0.0.1:90");
   // don't use hostname
   EXPECT_EQ(hlb_->hashKey(host, false), "127.0.0.1:90");
   // use hostname
@@ -117,7 +117,7 @@ TEST_F(HashingLoadBalancerTest, HashKey) {
       .set_string_value("hash_key");
   host = makeTestHostWithMetadata(
       info_, std::make_shared<const envoy::config::core::v3::Metadata>(string_metadata),
-      "tcp://127.0.0.1:90", simTime());
+      "tcp://127.0.0.1:90");
   EXPECT_EQ(hlb_->hashKey(host, false), "hash_key");
 
   // other type(int) metadata
@@ -127,7 +127,7 @@ TEST_F(HashingLoadBalancerTest, HashKey) {
       .set_number_value(1337);
   host = makeTestHostWithMetadata(
       info_, std::make_shared<const envoy::config::core::v3::Metadata>(int_metadata),
-      "tcp://127.0.0.1:90", simTime());
+      "tcp://127.0.0.1:90");
   EXPECT_EQ(hlb_->hashKey(host, false), "127.0.0.1:90");
 };
 

--- a/test/extensions/load_balancing_policies/common/load_balancer_fuzz_base.cc
+++ b/test/extensions/load_balancing_policies/common/load_balancer_fuzz_base.cc
@@ -22,9 +22,8 @@ constructByteVectorForRandom(const Protobuf::RepeatedField<Protobuf::uint32>& ra
 HostVector
 LoadBalancerFuzzBase::initializeHostsForUseInFuzzing(std::shared_ptr<MockClusterInfo> info) {
   HostVector hosts;
-  auto time_source = std::make_unique<NiceMock<MockTimeSystem>>();
   for (uint32_t i = 1; i <= 60000; ++i) {
-    hosts.push_back(makeTestHost(info, "tcp://127.0.0.1:" + std::to_string(i), *time_source));
+    hosts.push_back(makeTestHost(info, "tcp://127.0.0.1:" + std::to_string(i)));
   }
   return hosts;
 }

--- a/test/extensions/load_balancing_policies/common/load_balancer_impl_base_test.cc
+++ b/test/extensions/load_balancing_policies/common/load_balancer_impl_base_test.cc
@@ -40,7 +40,7 @@ public:
     host_set.degraded_hosts_.clear();
     host_set.excluded_hosts_.clear();
     for (uint32_t i = 0; i < num_hosts; ++i) {
-      host_set.hosts_.push_back(makeTestHost(info_, "tcp://127.0.0.1:80", simTime()));
+      host_set.hosts_.push_back(makeTestHost(info_, "tcp://127.0.0.1:80"));
     }
     uint32_t i = 0;
     for (; i < num_healthy_hosts; ++i) {

--- a/test/extensions/load_balancing_policies/least_request/least_request_lb_simulation_test.cc
+++ b/test/extensions/load_balancing_policies/least_request/least_request_lb_simulation_test.cc
@@ -52,14 +52,13 @@ void leastRequestLBWeightTest(LRLBTestParams params) {
   ASSERT_LT(tolerance_pct, 100);
   ASSERT_GE(tolerance_pct, 0);
 
-  NiceMock<MockTimeSystem> time_source_;
   HostVector hosts;
   absl::node_hash_map<HostConstSharedPtr, uint64_t> host_hits;
   std::shared_ptr<MockClusterInfo> info{new NiceMock<MockClusterInfo>()};
   for (uint64_t i = 0; i < params.num_hosts; i++) {
     const bool should_weight = i < params.num_subset_hosts;
     auto hostPtr = makeTestHost(info, fmt::format("tcp://10.0.{}.{}:6379", i / 256, i % 256),
-                                time_source_, should_weight ? params.weight : 1);
+                                should_weight ? params.weight : 1);
     host_hits[hostPtr] = 0;
     hosts.push_back(hostPtr);
     if (should_weight) {

--- a/test/extensions/load_balancing_policies/least_request/least_request_lb_test.cc
+++ b/test/extensions/load_balancing_policies/least_request/least_request_lb_test.cc
@@ -23,7 +23,7 @@ public:
 TEST_P(LeastRequestLoadBalancerTest, NoHosts) { EXPECT_EQ(nullptr, lb_.chooseHost(nullptr).host); }
 
 TEST_P(LeastRequestLoadBalancerTest, SingleHostAndPeek) {
-  hostSet().healthy_hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:80", simTime())};
+  hostSet().healthy_hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:80")};
   hostSet().hosts_ = hostSet().healthy_hosts_;
   hostSet().runCallbacks({}, {}); // Trigger callbacks. The added/removed lists are not relevant.
 
@@ -35,7 +35,7 @@ TEST_P(LeastRequestLoadBalancerTest, SingleHostAndPeek) {
 }
 
 TEST_P(LeastRequestLoadBalancerTest, SingleHost) {
-  hostSet().healthy_hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:80", simTime())};
+  hostSet().healthy_hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:80")};
   hostSet().hosts_ = hostSet().healthy_hosts_;
   hostSet().runCallbacks({}, {}); // Trigger callbacks. The added/removed lists are not relevant.
 
@@ -70,8 +70,8 @@ TEST_P(LeastRequestLoadBalancerTest, SingleHost) {
 }
 
 TEST_P(LeastRequestLoadBalancerTest, Normal) {
-  hostSet().healthy_hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:80", simTime()),
-                              makeTestHost(info_, "tcp://127.0.0.1:81", simTime())};
+  hostSet().healthy_hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:80"),
+                              makeTestHost(info_, "tcp://127.0.0.1:81")};
   hostSet().hosts_ = hostSet().healthy_hosts_;
   hostSet().runCallbacks({}, {}); // Trigger callbacks. The added/removed lists are not relevant.
 
@@ -87,10 +87,9 @@ TEST_P(LeastRequestLoadBalancerTest, Normal) {
 }
 
 TEST_P(LeastRequestLoadBalancerTest, PNC) {
-  hostSet().healthy_hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:80", simTime()),
-                              makeTestHost(info_, "tcp://127.0.0.1:81", simTime()),
-                              makeTestHost(info_, "tcp://127.0.0.1:82", simTime()),
-                              makeTestHost(info_, "tcp://127.0.0.1:83", simTime())};
+  hostSet().healthy_hosts_ = {
+      makeTestHost(info_, "tcp://127.0.0.1:80"), makeTestHost(info_, "tcp://127.0.0.1:81"),
+      makeTestHost(info_, "tcp://127.0.0.1:82"), makeTestHost(info_, "tcp://127.0.0.1:83")};
   hostSet().hosts_ = hostSet().healthy_hosts_;
   hostSet().runCallbacks({}, {}); // Trigger callbacks. The added/removed lists are not relevant.
 
@@ -141,11 +140,10 @@ TEST_P(LeastRequestLoadBalancerTest, DefaultSelectionMethod) {
 }
 
 TEST_P(LeastRequestLoadBalancerTest, FullScanOneHostWithLeastRequests) {
-  hostSet().healthy_hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:80", simTime()),
-                              makeTestHost(info_, "tcp://127.0.0.1:81", simTime()),
-                              makeTestHost(info_, "tcp://127.0.0.1:82", simTime()),
-                              makeTestHost(info_, "tcp://127.0.0.1:83", simTime()),
-                              makeTestHost(info_, "tcp://127.0.0.1:84", simTime())};
+  hostSet().healthy_hosts_ = {
+      makeTestHost(info_, "tcp://127.0.0.1:80"), makeTestHost(info_, "tcp://127.0.0.1:81"),
+      makeTestHost(info_, "tcp://127.0.0.1:82"), makeTestHost(info_, "tcp://127.0.0.1:83"),
+      makeTestHost(info_, "tcp://127.0.0.1:84")};
   hostSet().hosts_ = hostSet().healthy_hosts_;
   hostSet().runCallbacks({}, {}); // Trigger callbacks. The added/removed lists are not relevant.
 
@@ -169,11 +167,10 @@ TEST_P(LeastRequestLoadBalancerTest, FullScanOneHostWithLeastRequests) {
 }
 
 TEST_P(LeastRequestLoadBalancerTest, FullScanMultipleHostsWithLeastRequests) {
-  hostSet().healthy_hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:80", simTime()),
-                              makeTestHost(info_, "tcp://127.0.0.1:81", simTime()),
-                              makeTestHost(info_, "tcp://127.0.0.1:82", simTime()),
-                              makeTestHost(info_, "tcp://127.0.0.1:83", simTime()),
-                              makeTestHost(info_, "tcp://127.0.0.1:84", simTime())};
+  hostSet().healthy_hosts_ = {
+      makeTestHost(info_, "tcp://127.0.0.1:80"), makeTestHost(info_, "tcp://127.0.0.1:81"),
+      makeTestHost(info_, "tcp://127.0.0.1:82"), makeTestHost(info_, "tcp://127.0.0.1:83"),
+      makeTestHost(info_, "tcp://127.0.0.1:84")};
   hostSet().hosts_ = hostSet().healthy_hosts_;
   hostSet().runCallbacks({}, {}); // Trigger callbacks. The added/removed lists are not relevant.
 
@@ -225,8 +222,8 @@ TEST_P(LeastRequestLoadBalancerTest, FullScanMultipleHostsWithLeastRequests) {
 }
 
 TEST_P(LeastRequestLoadBalancerTest, WeightImbalance) {
-  hostSet().healthy_hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:80", simTime(), 1),
-                              makeTestHost(info_, "tcp://127.0.0.1:81", simTime(), 2)};
+  hostSet().healthy_hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:80", 1),
+                              makeTestHost(info_, "tcp://127.0.0.1:81", 2)};
 
   hostSet().hosts_ = hostSet().healthy_hosts_;
   hostSet().runCallbacks({}, {}); // Trigger callbacks. The added/removed lists are not relevant.
@@ -276,8 +273,8 @@ TEST_P(LeastRequestLoadBalancerTest, WeightImbalanceWithInvalidActiveRequestBias
 
   EXPECT_CALL(runtime_.snapshot_, getDouble("ar_bias", 1.0)).WillRepeatedly(Return(-1.0));
 
-  hostSet().healthy_hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:80", simTime(), 1),
-                              makeTestHost(info_, "tcp://127.0.0.1:81", simTime(), 2)};
+  hostSet().healthy_hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:80", 1),
+                              makeTestHost(info_, "tcp://127.0.0.1:81", 2)};
 
   hostSet().hosts_ = hostSet().healthy_hosts_;
 
@@ -330,8 +327,8 @@ TEST_P(LeastRequestLoadBalancerTest, WeightImbalanceWithCustomActiveRequestBias)
 
   EXPECT_CALL(runtime_.snapshot_, getDouble("ar_bias", 1.0)).WillRepeatedly(Return(0.0));
 
-  hostSet().healthy_hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:80", simTime(), 1),
-                              makeTestHost(info_, "tcp://127.0.0.1:81", simTime(), 2)};
+  hostSet().healthy_hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:80", 1),
+                              makeTestHost(info_, "tcp://127.0.0.1:81", 2)};
 
   hostSet().hosts_ = hostSet().healthy_hosts_;
   hostSet().runCallbacks({}, {}); // Trigger callbacks. The added/removed lists are not relevant.
@@ -349,8 +346,8 @@ TEST_P(LeastRequestLoadBalancerTest, WeightImbalanceWithCustomActiveRequestBias)
 }
 
 TEST_P(LeastRequestLoadBalancerTest, WeightImbalanceCallbacks) {
-  hostSet().healthy_hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:80", simTime(), 1),
-                              makeTestHost(info_, "tcp://127.0.0.1:81", simTime(), 2)};
+  hostSet().healthy_hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:80", 1),
+                              makeTestHost(info_, "tcp://127.0.0.1:81", 2)};
 
   hostSet().hosts_ = hostSet().healthy_hosts_;
   hostSet().runCallbacks({}, {}); // Trigger callbacks. The added/removed lists are not relevant.
@@ -395,7 +392,7 @@ TEST_P(LeastRequestLoadBalancerTest, SlowStartNoWait) {
   simTime().advanceTimeWait(std::chrono::seconds(1));
 
   // As no healthcheck is configured, hosts would enter slow start immediately.
-  hostSet().healthy_hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:80", simTime())};
+  hostSet().healthy_hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:80")};
   hostSet().hosts_ = hostSet().healthy_hosts_;
   hostSet().runCallbacks({}, {});
   // Host1 is 5 secs in slow start, its weight is scaled with max((5/60)^1, 0.1)=0.1 factor.
@@ -408,7 +405,7 @@ TEST_P(LeastRequestLoadBalancerTest, SlowStartNoWait) {
   // Advance time, so that host is no longer in slow start.
   simTime().advanceTimeWait(std::chrono::seconds(56));
 
-  auto host2 = makeTestHost(info_, "tcp://127.0.0.1:90", simTime());
+  auto host2 = makeTestHost(info_, "tcp://127.0.0.1:90");
   hostSet().healthy_hosts_.push_back(host2);
   hostSet().hosts_ = hostSet().healthy_hosts_;
   HostVector hosts_added;
@@ -463,7 +460,7 @@ TEST_P(LeastRequestLoadBalancerTest, SlowStartWithActiveHC) {
                                 random_,       50,      lr_lb_config, simTime()};
 
   simTime().advanceTimeWait(std::chrono::seconds(1));
-  auto host1 = makeTestHost(info_, "tcp://127.0.0.1:80", simTime());
+  auto host1 = makeTestHost(info_, "tcp://127.0.0.1:80");
   host1->healthFlagSet(Host::HealthFlag::FAILED_ACTIVE_HC);
   host_set_.hosts_ = {host1};
   HostVector hosts_added;
@@ -476,7 +473,7 @@ TEST_P(LeastRequestLoadBalancerTest, SlowStartWithActiveHC) {
   simTime().advanceTimeWait(std::chrono::seconds(5));
 
   hosts_added.clear();
-  auto host2 = makeTestHost(info_, "tcp://127.0.0.1:90", simTime());
+  auto host2 = makeTestHost(info_, "tcp://127.0.0.1:90");
   hosts_added.push_back(host2);
 
   hostSet().healthy_hosts_ = {host1, host2};

--- a/test/extensions/load_balancing_policies/maglev/maglev_lb_test.cc
+++ b/test/extensions/load_balancing_policies/maglev/maglev_lb_test.cc
@@ -141,12 +141,10 @@ TEST_F(MaglevLoadBalancerTest, DefaultMaglevTableSize) {
 
 // Basic sanity tests.
 TEST_F(MaglevLoadBalancerTest, Basic) {
-  host_set_.hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:90", simTime()),
-                      makeTestHost(info_, "tcp://127.0.0.1:91", simTime()),
-                      makeTestHost(info_, "tcp://127.0.0.1:92", simTime()),
-                      makeTestHost(info_, "tcp://127.0.0.1:93", simTime()),
-                      makeTestHost(info_, "tcp://127.0.0.1:94", simTime()),
-                      makeTestHost(info_, "tcp://127.0.0.1:95", simTime())};
+  host_set_.hosts_ = {
+      makeTestHost(info_, "tcp://127.0.0.1:90"), makeTestHost(info_, "tcp://127.0.0.1:91"),
+      makeTestHost(info_, "tcp://127.0.0.1:92"), makeTestHost(info_, "tcp://127.0.0.1:93"),
+      makeTestHost(info_, "tcp://127.0.0.1:94"), makeTestHost(info_, "tcp://127.0.0.1:95")};
   host_set_.healthy_hosts_ = host_set_.hosts_;
   host_set_.runCallbacks({}, {});
   init(7);
@@ -175,12 +173,12 @@ TEST_F(MaglevLoadBalancerTest, Basic) {
 // Test bounded load. This test only ensures that the
 // hash balancer factory won't break the normal load balancer process.
 TEST_F(MaglevLoadBalancerTest, BasicWithBoundedLoad) {
-  host_set_.hosts_ = {makeTestHost(info_, "90", "tcp://127.0.0.1:90", simTime()),
-                      makeTestHost(info_, "91", "tcp://127.0.0.1:91", simTime()),
-                      makeTestHost(info_, "92", "tcp://127.0.0.1:92", simTime()),
-                      makeTestHost(info_, "93", "tcp://127.0.0.1:93", simTime()),
-                      makeTestHost(info_, "94", "tcp://127.0.0.1:94", simTime()),
-                      makeTestHost(info_, "95", "tcp://127.0.0.1:95", simTime())};
+  host_set_.hosts_ = {makeTestHost(info_, "90", "tcp://127.0.0.1:90"),
+                      makeTestHost(info_, "91", "tcp://127.0.0.1:91"),
+                      makeTestHost(info_, "92", "tcp://127.0.0.1:92"),
+                      makeTestHost(info_, "93", "tcp://127.0.0.1:93"),
+                      makeTestHost(info_, "94", "tcp://127.0.0.1:94"),
+                      makeTestHost(info_, "95", "tcp://127.0.0.1:95")};
   host_set_.healthy_hosts_ = host_set_.hosts_;
   host_set_.runCallbacks({}, {});
   config_.mutable_consistent_hashing_lb_config()->set_use_hostname_for_hashing(true);
@@ -210,12 +208,12 @@ TEST_F(MaglevLoadBalancerTest, BasicWithBoundedLoad) {
 
 // Basic with hostname.
 TEST_F(MaglevLoadBalancerTest, BasicWithHostName) {
-  host_set_.hosts_ = {makeTestHost(info_, "90", "tcp://127.0.0.1:90", simTime()),
-                      makeTestHost(info_, "91", "tcp://127.0.0.1:91", simTime()),
-                      makeTestHost(info_, "92", "tcp://127.0.0.1:92", simTime()),
-                      makeTestHost(info_, "93", "tcp://127.0.0.1:93", simTime()),
-                      makeTestHost(info_, "94", "tcp://127.0.0.1:94", simTime()),
-                      makeTestHost(info_, "95", "tcp://127.0.0.1:95", simTime())};
+  host_set_.hosts_ = {makeTestHost(info_, "90", "tcp://127.0.0.1:90"),
+                      makeTestHost(info_, "91", "tcp://127.0.0.1:91"),
+                      makeTestHost(info_, "92", "tcp://127.0.0.1:92"),
+                      makeTestHost(info_, "93", "tcp://127.0.0.1:93"),
+                      makeTestHost(info_, "94", "tcp://127.0.0.1:94"),
+                      makeTestHost(info_, "95", "tcp://127.0.0.1:95")};
   host_set_.healthy_hosts_ = host_set_.hosts_;
   host_set_.runCallbacks({}, {});
   config_.mutable_consistent_hashing_lb_config()->set_use_hostname_for_hashing(true);
@@ -244,12 +242,12 @@ TEST_F(MaglevLoadBalancerTest, BasicWithHostName) {
 
 // Basic with metadata hash_key.
 TEST_F(MaglevLoadBalancerTest, BasicWithMetadataHashKey) {
-  host_set_.hosts_ = {makeTestHostWithHashKey(info_, "90", "tcp://127.0.0.1:90", simTime()),
-                      makeTestHostWithHashKey(info_, "91", "tcp://127.0.0.1:91", simTime()),
-                      makeTestHostWithHashKey(info_, "92", "tcp://127.0.0.1:92", simTime()),
-                      makeTestHostWithHashKey(info_, "93", "tcp://127.0.0.1:93", simTime()),
-                      makeTestHostWithHashKey(info_, "94", "tcp://127.0.0.1:94", simTime()),
-                      makeTestHostWithHashKey(info_, "95", "tcp://127.0.0.1:95", simTime())};
+  host_set_.hosts_ = {makeTestHostWithHashKey(info_, "90", "tcp://127.0.0.1:90"),
+                      makeTestHostWithHashKey(info_, "91", "tcp://127.0.0.1:91"),
+                      makeTestHostWithHashKey(info_, "92", "tcp://127.0.0.1:92"),
+                      makeTestHostWithHashKey(info_, "93", "tcp://127.0.0.1:93"),
+                      makeTestHostWithHashKey(info_, "94", "tcp://127.0.0.1:94"),
+                      makeTestHostWithHashKey(info_, "95", "tcp://127.0.0.1:95")};
   host_set_.healthy_hosts_ = host_set_.hosts_;
   host_set_.runCallbacks({}, {});
   config_.mutable_consistent_hashing_lb_config()->set_use_hostname_for_hashing(true);
@@ -278,12 +276,10 @@ TEST_F(MaglevLoadBalancerTest, BasicWithMetadataHashKey) {
 
 // Same ring as the Basic test, but exercise retry host predicate behavior.
 TEST_F(MaglevLoadBalancerTest, BasicWithRetryHostPredicate) {
-  host_set_.hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:90", simTime()),
-                      makeTestHost(info_, "tcp://127.0.0.1:91", simTime()),
-                      makeTestHost(info_, "tcp://127.0.0.1:92", simTime()),
-                      makeTestHost(info_, "tcp://127.0.0.1:93", simTime()),
-                      makeTestHost(info_, "tcp://127.0.0.1:94", simTime()),
-                      makeTestHost(info_, "tcp://127.0.0.1:95", simTime())};
+  host_set_.hosts_ = {
+      makeTestHost(info_, "tcp://127.0.0.1:90"), makeTestHost(info_, "tcp://127.0.0.1:91"),
+      makeTestHost(info_, "tcp://127.0.0.1:92"), makeTestHost(info_, "tcp://127.0.0.1:93"),
+      makeTestHost(info_, "tcp://127.0.0.1:94"), makeTestHost(info_, "tcp://127.0.0.1:95")};
   host_set_.healthy_hosts_ = host_set_.hosts_;
   host_set_.runCallbacks({}, {});
   init(7);
@@ -326,12 +322,10 @@ TEST_F(MaglevLoadBalancerTest, BasicWithRetryHostPredicate) {
 
 // Basic stability test.
 TEST_F(MaglevLoadBalancerTest, BasicStability) {
-  host_set_.hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:90", simTime()),
-                      makeTestHost(info_, "tcp://127.0.0.1:91", simTime()),
-                      makeTestHost(info_, "tcp://127.0.0.1:92", simTime()),
-                      makeTestHost(info_, "tcp://127.0.0.1:93", simTime()),
-                      makeTestHost(info_, "tcp://127.0.0.1:94", simTime()),
-                      makeTestHost(info_, "tcp://127.0.0.1:95", simTime())};
+  host_set_.hosts_ = {
+      makeTestHost(info_, "tcp://127.0.0.1:90"), makeTestHost(info_, "tcp://127.0.0.1:91"),
+      makeTestHost(info_, "tcp://127.0.0.1:92"), makeTestHost(info_, "tcp://127.0.0.1:93"),
+      makeTestHost(info_, "tcp://127.0.0.1:94"), makeTestHost(info_, "tcp://127.0.0.1:95")};
   host_set_.healthy_hosts_ = host_set_.hosts_;
   host_set_.runCallbacks({}, {});
   init(7);
@@ -371,8 +365,8 @@ TEST_F(MaglevLoadBalancerTest, BasicStability) {
 
 // Weighted sanity test.
 TEST_F(MaglevLoadBalancerTest, Weighted) {
-  host_set_.hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:90", simTime(), 1),
-                      makeTestHost(info_, "tcp://127.0.0.1:91", simTime(), 2)};
+  host_set_.hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:90", 1),
+                      makeTestHost(info_, "tcp://127.0.0.1:91", 2)};
   host_set_.healthy_hosts_ = host_set_.hosts_;
   host_set_.runCallbacks({}, {});
   init(17);
@@ -414,8 +408,8 @@ TEST_F(MaglevLoadBalancerTest, LocalityWeightedSameLocalityWeights) {
   envoy::config::core::v3::Locality zone_b;
   zone_b.set_zone("B");
 
-  host_set_.hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:90", simTime(), zone_a, 1),
-                      makeTestHost(info_, "tcp://127.0.0.1:91", simTime(), zone_b, 2)};
+  host_set_.hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:90", zone_a, 1),
+                      makeTestHost(info_, "tcp://127.0.0.1:91", zone_b, 2)};
   host_set_.healthy_hosts_ = host_set_.hosts_;
   host_set_.hosts_per_locality_ =
       makeHostsPerLocality({{host_set_.hosts_[0]}, {host_set_.hosts_[1]}});
@@ -464,9 +458,9 @@ TEST_F(MaglevLoadBalancerTest, LocalityWeightedDifferentLocalityWeights) {
   envoy::config::core::v3::Locality zone_c;
   zone_c.set_zone("C");
 
-  host_set_.hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:90", simTime(), zone_a, 1),
-                      makeTestHost(info_, "tcp://127.0.0.1:91", simTime(), zone_c, 2),
-                      makeTestHost(info_, "tcp://127.0.0.1:92", simTime(), zone_b, 3)};
+  host_set_.hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:90", zone_a, 1),
+                      makeTestHost(info_, "tcp://127.0.0.1:91", zone_c, 2),
+                      makeTestHost(info_, "tcp://127.0.0.1:92", zone_b, 3)};
   host_set_.healthy_hosts_ = host_set_.hosts_;
   host_set_.hosts_per_locality_ =
       makeHostsPerLocality({{host_set_.hosts_[0]}, {host_set_.hosts_[2]}, {host_set_.hosts_[1]}});
@@ -507,7 +501,7 @@ TEST_F(MaglevLoadBalancerTest, LocalityWeightedDifferentLocalityWeights) {
 
 // Locality weighted with all localities zero weighted.
 TEST_F(MaglevLoadBalancerTest, LocalityWeightedAllZeroLocalityWeights) {
-  host_set_.hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:90", simTime(), 1)};
+  host_set_.hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:90", 1)};
   host_set_.healthy_hosts_ = host_set_.hosts_;
   host_set_.hosts_per_locality_ = makeHostsPerLocality({{host_set_.hosts_[0]}});
   host_set_.healthy_hosts_per_locality_ = host_set_.hosts_per_locality_;
@@ -528,8 +522,8 @@ TEST_F(MaglevLoadBalancerTest, LocalityWeightedGlobalPanic) {
   envoy::config::core::v3::Locality zone_b;
   zone_b.set_zone("B");
 
-  host_set_.hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:90", simTime(), zone_a, 1),
-                      makeTestHost(info_, "tcp://127.0.0.1:91", simTime(), zone_b, 2)};
+  host_set_.hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:90", zone_a, 1),
+                      makeTestHost(info_, "tcp://127.0.0.1:91", zone_b, 2)};
   host_set_.healthy_hosts_ = {};
   host_set_.hosts_per_locality_ =
       makeHostsPerLocality({{host_set_.hosts_[0]}, {host_set_.hosts_[1]}});
@@ -580,7 +574,7 @@ TEST_F(MaglevLoadBalancerTest, LocalityWeightedLopsided) {
   HostVector heavy_but_sparse, light_but_dense;
   for (uint32_t i = 0; i < 1024; ++i) {
     auto host_locality = i == 0 ? zone_a : zone_b;
-    auto host(makeTestHost(info_, fmt::format("tcp://127.0.0.1:{}", i), simTime(), host_locality));
+    auto host(makeTestHost(info_, fmt::format("tcp://127.0.0.1:{}", i), host_locality));
     host_set_.hosts_.push_back(host);
     (i == 0 ? heavy_but_sparse : light_but_dense).push_back(host);
   }

--- a/test/extensions/load_balancing_policies/override_host/config_test.cc
+++ b/test/extensions/load_balancing_policies/override_host/config_test.cc
@@ -214,8 +214,7 @@ TEST(OverrideHostLbonfigTest, FallbackLbCalledToChooseHost) {
   EXPECT_NE(thread_local_lb_factory, nullptr);
 
   MockHostSet* host_set = thread_local_priority_set.getMockHostSet(0);
-  host_set->hosts_ = {
-      Envoy::Upstream::makeTestHost(cluster_info, "tcp://127.0.0.1:80", context.time_system_)};
+  host_set->hosts_ = {Envoy::Upstream::makeTestHost(cluster_info, "tcp://127.0.0.1:80")};
   host_set->runCallbacks(host_set->hosts_, {});
   auto thread_local_lb = thread_local_lb_factory->create({thread_local_priority_set, nullptr});
   EXPECT_NE(thread_local_lb, nullptr);

--- a/test/extensions/load_balancing_policies/override_host/load_balancer_test.cc
+++ b/test/extensions/load_balancing_policies/override_host/load_balancer_test.cc
@@ -176,8 +176,7 @@ TEST_F(OverrideHostLoadBalancerTest, NoMetadatOrHeaders) {
 
   MockHostSet* host_set = thread_local_priority_set_.getMockHostSet(0);
   host_set->hosts_ = {Envoy::Upstream::makeTestHost(
-      cluster_info_, "tcp://127.0.0.1:80", server_factory_context_.time_system_, us_central1_a, 1,
-      0, Host::HealthStatus::HEALTHY)};
+      cluster_info_, "tcp://127.0.0.1:80", us_central1_a, 1, 0, Host::HealthStatus::HEALTHY)};
   host_set->hosts_per_locality_ = ::Envoy::Upstream::makeHostsPerLocality({{host_set->hosts_[0]}});
   makeCrossPriorityHostMap();
 
@@ -200,8 +199,7 @@ TEST_F(OverrideHostLoadBalancerTest, NullptrHeaders) {
 
   MockHostSet* host_set = thread_local_priority_set_.getMockHostSet(0);
   host_set->hosts_ = {Envoy::Upstream::makeTestHost(
-      cluster_info_, "tcp://127.0.0.1:80", server_factory_context_.time_system_, us_central1_a, 1,
-      0, Host::HealthStatus::HEALTHY)};
+      cluster_info_, "tcp://127.0.0.1:80", us_central1_a, 1, 0, Host::HealthStatus::HEALTHY)};
   host_set->hosts_per_locality_ = ::Envoy::Upstream::makeHostsPerLocality({{host_set->hosts_[0]}});
   makeCrossPriorityHostMap();
 
@@ -239,14 +237,11 @@ TEST_F(OverrideHostLoadBalancerTest, PrimaryAddressDoesNotExist) {
   MockHostSet* host_set = thread_local_priority_set_.getMockHostSet(0);
   host_set->hosts_ = {
       Envoy::Upstream::makeTestHost(cluster_info_, "tcp://[fda3:e722:ac3:cc00:172:b9fb:a00:2]:80",
-                                    server_factory_context_.time_system_, us_central1_a, 1, 0,
-                                    Host::HealthStatus::HEALTHY),
-      Envoy::Upstream::makeTestHost(cluster_info_, "tcp://[2002:a17:93c:a62::1]:80",
-                                    server_factory_context_.time_system_, us_central1_b, 1, 0,
-                                    Host::HealthStatus::UNHEALTHY),
+                                    us_central1_a, 1, 0, Host::HealthStatus::HEALTHY),
+      Envoy::Upstream::makeTestHost(cluster_info_, "tcp://[2002:a17:93c:a62::1]:80", us_central1_b,
+                                    1, 0, Host::HealthStatus::UNHEALTHY),
       Envoy::Upstream::makeTestHost(cluster_info_, "tcp://[fda3:e722:ac3:cc00:172:b9fb:a00:4]:80",
-                                    server_factory_context_.time_system_, us_west3_c, 1, 0,
-                                    Host::HealthStatus::DEGRADED)};
+                                    us_west3_c, 1, 0, Host::HealthStatus::DEGRADED)};
   host_set->hosts_per_locality_ = ::Envoy::Upstream::makeHostsPerLocality(
       {{host_set->hosts_[0]}, {host_set->hosts_[1]}, {host_set->hosts_[2]}});
   makeCrossPriorityHostMap();
@@ -280,14 +275,11 @@ TEST_F(OverrideHostLoadBalancerTest, HeaderIsPreferredOverMetadata) {
   MockHostSet* host_set = thread_local_priority_set_.getMockHostSet(0);
   host_set->hosts_ = {
       Envoy::Upstream::makeTestHost(cluster_info_, "tcp://[2600:2d00:1:cc00:172:b9fb:a00:2]:80",
-                                    server_factory_context_.time_system_, us_central1_a, 1, 0,
-                                    Host::HealthStatus::HEALTHY),
+                                    us_central1_a, 1, 0, Host::HealthStatus::HEALTHY),
       Envoy::Upstream::makeTestHost(cluster_info_, "tcp://[2600:2d00:1:cc00:172:b9fb:a00:3]:80",
-                                    server_factory_context_.time_system_, us_central1_b, 1, 0,
-                                    Host::HealthStatus::UNHEALTHY),
+                                    us_central1_b, 1, 0, Host::HealthStatus::UNHEALTHY),
       Envoy::Upstream::makeTestHost(cluster_info_, "tcp://[2600:2d00:1:cc00:172:b9fb:a00:4]:80",
-                                    server_factory_context_.time_system_, us_west3_c, 1, 0,
-                                    Host::HealthStatus::DEGRADED)};
+                                    us_west3_c, 1, 0, Host::HealthStatus::DEGRADED)};
   host_set->hosts_per_locality_ = ::Envoy::Upstream::makeHostsPerLocality(
       {{host_set->hosts_[0]}, {host_set->hosts_[1]}, {host_set->hosts_[2]}});
   makeCrossPriorityHostMap();
@@ -328,14 +320,11 @@ TEST_F(OverrideHostLoadBalancerTest, HeaderWithMultipleValueIsPreferredOverMetad
   MockHostSet* host_set = thread_local_priority_set_.getMockHostSet(0);
   host_set->hosts_ = {
       Envoy::Upstream::makeTestHost(cluster_info_, "tcp://[2600:2d00:1:cc00:172:b9fb:a00:2]:80",
-                                    server_factory_context_.time_system_, us_central1_a, 1, 0,
-                                    Host::HealthStatus::HEALTHY),
+                                    us_central1_a, 1, 0, Host::HealthStatus::HEALTHY),
       Envoy::Upstream::makeTestHost(cluster_info_, "tcp://[2600:2d00:1:cc00:172:b9fb:a00:3]:80",
-                                    server_factory_context_.time_system_, us_central1_b, 1, 0,
-                                    Host::HealthStatus::UNHEALTHY),
+                                    us_central1_b, 1, 0, Host::HealthStatus::UNHEALTHY),
       Envoy::Upstream::makeTestHost(cluster_info_, "tcp://[2600:2d00:1:cc00:172:b9fb:a00:4]:80",
-                                    server_factory_context_.time_system_, us_west3_c, 1, 0,
-                                    Host::HealthStatus::DEGRADED)};
+                                    us_west3_c, 1, 0, Host::HealthStatus::DEGRADED)};
   host_set->hosts_per_locality_ = ::Envoy::Upstream::makeHostsPerLocality(
       {{host_set->hosts_[0]}, {host_set->hosts_[1]}, {host_set->hosts_[2]}});
   makeCrossPriorityHostMap();
@@ -380,14 +369,11 @@ TEST_F(OverrideHostLoadBalancerTest, MetadataIsPreferredOverHeaders) {
   MockHostSet* host_set = thread_local_priority_set_.getMockHostSet(0);
   host_set->hosts_ = {
       Envoy::Upstream::makeTestHost(cluster_info_, "tcp://[2600:2d00:1:cc00:172:b9fb:a00:2]:80",
-                                    server_factory_context_.time_system_, us_central1_a, 1, 0,
-                                    Host::HealthStatus::HEALTHY),
+                                    us_central1_a, 1, 0, Host::HealthStatus::HEALTHY),
       Envoy::Upstream::makeTestHost(cluster_info_, "tcp://[2600:2d00:1:cc00:172:b9fb:a00:3]:80",
-                                    server_factory_context_.time_system_, us_central1_b, 1, 0,
-                                    Host::HealthStatus::UNHEALTHY),
+                                    us_central1_b, 1, 0, Host::HealthStatus::UNHEALTHY),
       Envoy::Upstream::makeTestHost(cluster_info_, "tcp://[2600:2d00:1:cc00:172:b9fb:a00:4]:80",
-                                    server_factory_context_.time_system_, us_west3_c, 1, 0,
-                                    Host::HealthStatus::DEGRADED)};
+                                    us_west3_c, 1, 0, Host::HealthStatus::DEGRADED)};
   host_set->hosts_per_locality_ = ::Envoy::Upstream::makeHostsPerLocality(
       {{host_set->hosts_[0]}, {host_set->hosts_[1]}, {host_set->hosts_[2]}});
   makeCrossPriorityHostMap();
@@ -428,14 +414,11 @@ TEST_F(OverrideHostLoadBalancerTest, UnparseableHeaderValueUsesFallback) {
   MockHostSet* host_set = thread_local_priority_set_.getMockHostSet(0);
   host_set->hosts_ = {
       Envoy::Upstream::makeTestHost(cluster_info_, "tcp://[2600:2d00:1:cc00:172:b9fb:a00:2]:80",
-                                    server_factory_context_.time_system_, us_central1_a, 1, 0,
-                                    Host::HealthStatus::HEALTHY),
+                                    us_central1_a, 1, 0, Host::HealthStatus::HEALTHY),
       Envoy::Upstream::makeTestHost(cluster_info_, "tcp://[2600:2d00:1:cc00:172:b9fb:a00:3]:80",
-                                    server_factory_context_.time_system_, us_central1_b, 1, 0,
-                                    Host::HealthStatus::UNHEALTHY),
+                                    us_central1_b, 1, 0, Host::HealthStatus::UNHEALTHY),
       Envoy::Upstream::makeTestHost(cluster_info_, "tcp://[2600:2d00:1:cc00:172:b9fb:a00:4]:80",
-                                    server_factory_context_.time_system_, us_west3_c, 1, 0,
-                                    Host::HealthStatus::DEGRADED)};
+                                    us_west3_c, 1, 0, Host::HealthStatus::DEGRADED)};
   host_set->hosts_per_locality_ = ::Envoy::Upstream::makeHostsPerLocality(
       {{host_set->hosts_[0]}, {host_set->hosts_[1]}, {host_set->hosts_[2]}});
   makeCrossPriorityHostMap();
@@ -469,12 +452,11 @@ TEST_F(OverrideHostLoadBalancerTest, SelectIpv4EndpointWithHeader) {
   Locality us_central1_a = makeLocality("us-central1", "us-central1-a");
 
   MockHostSet* host_set = thread_local_priority_set_.getMockHostSet(0);
-  host_set->hosts_ = {Envoy::Upstream::makeTestHost(
-                          cluster_info_, "tcp://1.2.3.4:80", server_factory_context_.time_system_,
-                          us_central1_a, 1, 0, Host::HealthStatus::HEALTHY),
-                      Envoy::Upstream::makeTestHost(
-                          cluster_info_, "tcp://5.6.7.8:80", server_factory_context_.time_system_,
-                          us_central1_a, 1, 0, Host::HealthStatus::HEALTHY)};
+  host_set->hosts_ = {
+      Envoy::Upstream::makeTestHost(cluster_info_, "tcp://1.2.3.4:80", us_central1_a, 1, 0,
+                                    Host::HealthStatus::HEALTHY),
+      Envoy::Upstream::makeTestHost(cluster_info_, "tcp://5.6.7.8:80", us_central1_a, 1, 0,
+                                    Host::HealthStatus::HEALTHY)};
   host_set->hosts_per_locality_ =
       ::Envoy::Upstream::makeHostsPerLocality({{host_set->hosts_[0], host_set->hosts_[1]}});
   makeCrossPriorityHostMap();
@@ -493,12 +475,10 @@ TEST_F(OverrideHostLoadBalancerTest, SelectIpv6EndpointWithHeader) {
   Locality us_central1_a = makeLocality("us-central1", "us-central1-a");
 
   MockHostSet* host_set = thread_local_priority_set_.getMockHostSet(0);
-  host_set->hosts_ = {Envoy::Upstream::makeTestHost(
-                          cluster_info_, "tcp://[::1]:80", server_factory_context_.time_system_,
-                          us_central1_a, 1, 0, Host::HealthStatus::HEALTHY),
-                      Envoy::Upstream::makeTestHost(
-                          cluster_info_, "tcp://[::2]:80", server_factory_context_.time_system_,
-                          us_central1_a, 1, 0, Host::HealthStatus::HEALTHY)};
+  host_set->hosts_ = {Envoy::Upstream::makeTestHost(cluster_info_, "tcp://[::1]:80", us_central1_a,
+                                                    1, 0, Host::HealthStatus::HEALTHY),
+                      Envoy::Upstream::makeTestHost(cluster_info_, "tcp://[::2]:80", us_central1_a,
+                                                    1, 0, Host::HealthStatus::HEALTHY)};
   host_set->hosts_per_locality_ =
       ::Envoy::Upstream::makeHostsPerLocality({{host_set->hosts_[0], host_set->hosts_[1]}});
   makeCrossPriorityHostMap();
@@ -517,12 +497,10 @@ TEST_F(OverrideHostLoadBalancerTest, WrongHeaderName) {
   Locality us_central1_a = makeLocality("us-central1", "us-central1-a");
 
   MockHostSet* host_set = thread_local_priority_set_.getMockHostSet(0);
-  host_set->hosts_ = {Envoy::Upstream::makeTestHost(
-                          cluster_info_, "tcp://[::1]:80", server_factory_context_.time_system_,
-                          us_central1_a, 1, 0, Host::HealthStatus::HEALTHY),
-                      Envoy::Upstream::makeTestHost(
-                          cluster_info_, "tcp://[::2]:80", server_factory_context_.time_system_,
-                          us_central1_a, 1, 0, Host::HealthStatus::HEALTHY)};
+  host_set->hosts_ = {Envoy::Upstream::makeTestHost(cluster_info_, "tcp://[::1]:80", us_central1_a,
+                                                    1, 0, Host::HealthStatus::HEALTHY),
+                      Envoy::Upstream::makeTestHost(cluster_info_, "tcp://[::2]:80", us_central1_a,
+                                                    1, 0, Host::HealthStatus::HEALTHY)};
   host_set->hosts_per_locality_ =
       ::Envoy::Upstream::makeHostsPerLocality({{host_set->hosts_[0], host_set->hosts_[1]}});
   makeCrossPriorityHostMap();
@@ -562,8 +540,7 @@ TEST_F(OverrideHostLoadBalancerTest, SelectIpv4EndpointUsingMetadata) {
 
   MockHostSet* host_set = thread_local_priority_set_.getMockHostSet(0);
   host_set->hosts_ = {Envoy::Upstream::makeTestHost(
-      cluster_info_, "tcp://127.0.0.1:80", server_factory_context_.time_system_, us_central1_a, 1,
-      0, Host::HealthStatus::HEALTHY)};
+      cluster_info_, "tcp://127.0.0.1:80", us_central1_a, 1, 0, Host::HealthStatus::HEALTHY)};
   host_set->hosts_per_locality_ = ::Envoy::Upstream::makeHostsPerLocality({{host_set->hosts_[0]}});
   makeCrossPriorityHostMap();
 
@@ -585,8 +562,7 @@ TEST_F(OverrideHostLoadBalancerTest, SelectEndpointUsingMetadataMissingEndpoint)
 
   MockHostSet* host_set = thread_local_priority_set_.getMockHostSet(0);
   host_set->hosts_ = {Envoy::Upstream::makeTestHost(
-      cluster_info_, "tcp://127.0.0.1:80", server_factory_context_.time_system_, us_central1_a, 1,
-      0, Host::HealthStatus::HEALTHY)};
+      cluster_info_, "tcp://127.0.0.1:80", us_central1_a, 1, 0, Host::HealthStatus::HEALTHY)};
   host_set->hosts_per_locality_ = ::Envoy::Upstream::makeHostsPerLocality({{host_set->hosts_[0]}});
   makeCrossPriorityHostMap();
 
@@ -611,14 +587,11 @@ TEST_F(OverrideHostLoadBalancerTest, SelectIPv6UsingMetadata) {
   MockHostSet* host_set = thread_local_priority_set_.getMockHostSet(0);
   host_set->hosts_ = {
       Envoy::Upstream::makeTestHost(cluster_info_, "tcp://[fda3:e722:ac3:cc00:172:b9fb:a00:2]:80",
-                                    server_factory_context_.time_system_, us_central1_a, 1, 0,
-                                    Host::HealthStatus::HEALTHY),
+                                    us_central1_a, 1, 0, Host::HealthStatus::HEALTHY),
       Envoy::Upstream::makeTestHost(cluster_info_, "tcp://[fda3:e722:ac3:cc00:172:b9fb:a00:3]:80",
-                                    server_factory_context_.time_system_, us_central1_b, 1, 0,
-                                    Host::HealthStatus::UNHEALTHY),
+                                    us_central1_b, 1, 0, Host::HealthStatus::UNHEALTHY),
       Envoy::Upstream::makeTestHost(cluster_info_, "tcp://[fda3:e722:ac3:cc00:172:b9fb:a00:4]:80",
-                                    server_factory_context_.time_system_, us_west3_c, 1, 0,
-                                    Host::HealthStatus::DEGRADED)};
+                                    us_west3_c, 1, 0, Host::HealthStatus::DEGRADED)};
   host_set->hosts_per_locality_ = ::Envoy::Upstream::makeHostsPerLocality(
       {{host_set->hosts_[0]}, {host_set->hosts_[1]}, {host_set->hosts_[2]}});
   makeCrossPriorityHostMap();
@@ -643,8 +616,7 @@ TEST_F(OverrideHostLoadBalancerTest, SelectEndpointBadMetadata) {
 
   MockHostSet* host_set = thread_local_priority_set_.getMockHostSet(0);
   host_set->hosts_ = {Envoy::Upstream::makeTestHost(
-      cluster_info_, "tcp://127.0.0.1:80", server_factory_context_.time_system_, us_central1_a, 1,
-      0, Host::HealthStatus::HEALTHY)};
+      cluster_info_, "tcp://127.0.0.1:80", us_central1_a, 1, 0, Host::HealthStatus::HEALTHY)};
   host_set->hosts_per_locality_ = ::Envoy::Upstream::makeHostsPerLocality({{host_set->hosts_[0]}});
   makeCrossPriorityHostMap();
 
@@ -667,8 +639,7 @@ TEST_F(OverrideHostLoadBalancerTest, SelectEndpointBadMetadataType) {
 
   MockHostSet* host_set = thread_local_priority_set_.getMockHostSet(0);
   host_set->hosts_ = {Envoy::Upstream::makeTestHost(
-      cluster_info_, "tcp://127.0.0.1:80", server_factory_context_.time_system_, us_central1_a, 1,
-      0, Host::HealthStatus::HEALTHY)};
+      cluster_info_, "tcp://127.0.0.1:80", us_central1_a, 1, 0, Host::HealthStatus::HEALTHY)};
   host_set->hosts_per_locality_ = ::Envoy::Upstream::makeHostsPerLocality({{host_set->hosts_[0]}});
   makeCrossPriorityHostMap();
 
@@ -690,12 +661,11 @@ TEST_F(OverrideHostLoadBalancerTest, HeaderOnlySourceWithNoHeader) {
   Locality us_central1_a = makeLocality("us-central1", "us-central1-a");
 
   MockHostSet* host_set = thread_local_priority_set_.getMockHostSet(0);
-  host_set->hosts_ = {Envoy::Upstream::makeTestHost(
-                          cluster_info_, "tcp://1.2.3.4:80", server_factory_context_.time_system_,
-                          us_central1_a, 1, 0, Host::HealthStatus::HEALTHY),
-                      Envoy::Upstream::makeTestHost(
-                          cluster_info_, "tcp://5.6.7.8:80", server_factory_context_.time_system_,
-                          us_central1_a, 1, 0, Host::HealthStatus::HEALTHY)};
+  host_set->hosts_ = {
+      Envoy::Upstream::makeTestHost(cluster_info_, "tcp://1.2.3.4:80", us_central1_a, 1, 0,
+                                    Host::HealthStatus::HEALTHY),
+      Envoy::Upstream::makeTestHost(cluster_info_, "tcp://5.6.7.8:80", us_central1_a, 1, 0,
+                                    Host::HealthStatus::HEALTHY)};
   host_set->hosts_per_locality_ =
       ::Envoy::Upstream::makeHostsPerLocality({{host_set->hosts_[0], host_set->hosts_[1]}});
   makeCrossPriorityHostMap();
@@ -722,8 +692,7 @@ TEST_F(OverrideHostLoadBalancerTest, NullDownstreamHeaders) {
 
   MockHostSet* host_set = thread_local_priority_set_.getMockHostSet(0);
   host_set->hosts_ = {Envoy::Upstream::makeTestHost(
-      cluster_info_, "tcp://127.0.0.1:80", server_factory_context_.time_system_, us_central1_a, 1,
-      0, Host::HealthStatus::HEALTHY)};
+      cluster_info_, "tcp://127.0.0.1:80", us_central1_a, 1, 0, Host::HealthStatus::HEALTHY)};
   host_set->hosts_per_locality_ = ::Envoy::Upstream::makeHostsPerLocality({{host_set->hosts_[0]}});
   makeCrossPriorityHostMap();
 

--- a/test/extensions/load_balancing_policies/random/random_lb_simulation_test.cc
+++ b/test/extensions/load_balancing_policies/random/random_lb_simulation_test.cc
@@ -19,14 +19,14 @@ namespace Upstream {
 namespace {
 
 static HostSharedPtr newTestHost(Upstream::ClusterInfoConstSharedPtr cluster,
-                                 const std::string& url, TimeSource& time_source,
-                                 uint32_t weight = 1, const std::string& zone = "") {
+                                 const std::string& url, uint32_t weight = 1,
+                                 const std::string& zone = "") {
   envoy::config::core::v3::Locality locality;
   locality.set_zone(zone);
   return HostSharedPtr{*HostImpl::create(
       cluster, "", *Network::Utility::resolveUrl(url), nullptr, nullptr, weight, locality,
       envoy::config::endpoint::v3::Endpoint::HealthCheckConfig::default_instance(), 0,
-      envoy::config::core::v3::UNKNOWN, time_source)};
+      envoy::config::core::v3::UNKNOWN)};
 }
 
 /**
@@ -137,7 +137,7 @@ public:
       const std::string zone = std::to_string(i);
       for (uint32_t j = 0; j < hosts[i]; ++j) {
         const std::string url = fmt::format("tcp://host.{}.{}:80", i, j);
-        ret->push_back(newTestHost(info_, url, time_source_, 1, zone));
+        ret->push_back(newTestHost(info_, url, 1, zone));
       }
     }
 
@@ -156,7 +156,7 @@ public:
 
       for (uint32_t j = 0; j < hosts[i]; ++j) {
         const std::string url = fmt::format("tcp://host.{}.{}:80", i, j);
-        zone_hosts.push_back(newTestHost(info_, url, time_source_, 1, zone));
+        zone_hosts.push_back(newTestHost(info_, url, 1, zone));
       }
 
       ret.push_back(std::move(zone_hosts));
@@ -173,7 +173,6 @@ public:
   MockHostSet& host_set_ = *priority_set_.getMockHostSet(0);
   std::shared_ptr<MockClusterInfo> info_{new NiceMock<MockClusterInfo>()};
   NiceMock<Runtime::MockLoader> runtime_;
-  NiceMock<MockTimeSystem> time_source_;
   Random::RandomGeneratorImpl random_;
   Stats::IsolatedStoreImpl stats_store_;
   ClusterLbStatNames stat_names_;

--- a/test/extensions/load_balancing_policies/random/random_lb_test.cc
+++ b/test/extensions/load_balancing_policies/random/random_lb_test.cc
@@ -32,8 +32,8 @@ TEST_P(RandomLoadBalancerTest, NoHosts) {
 
 TEST_P(RandomLoadBalancerTest, Normal) {
   init();
-  hostSet().healthy_hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:80", simTime()),
-                              makeTestHost(info_, "tcp://127.0.0.1:81", simTime())};
+  hostSet().healthy_hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:80"),
+                              makeTestHost(info_, "tcp://127.0.0.1:81")};
   hostSet().hosts_ = hostSet().healthy_hosts_;
   hostSet().runCallbacks({}, {}); // Trigger callbacks. The added/removed lists are not relevant.
 
@@ -54,8 +54,8 @@ TEST_P(RandomLoadBalancerTest, FailClusterOnPanic) {
   init();
 
   hostSet().healthy_hosts_ = {};
-  hostSet().hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:80", simTime()),
-                      makeTestHost(info_, "tcp://127.0.0.1:81", simTime())};
+  hostSet().hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:80"),
+                      makeTestHost(info_, "tcp://127.0.0.1:81")};
   hostSet().runCallbacks({}, {}); // Trigger callbacks. The added/removed lists are not relevant.
   EXPECT_EQ(nullptr, lb_->chooseHost(nullptr).host);
 }

--- a/test/extensions/load_balancing_policies/ring_hash/ring_hash_lb_test.cc
+++ b/test/extensions/load_balancing_policies/ring_hash/ring_hash_lb_test.cc
@@ -153,12 +153,10 @@ TEST_P(RingHashLoadBalancerTest, BadRingSizeBounds) {
 }
 
 TEST_P(RingHashLoadBalancerTest, Basic) {
-  hostSet().hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:90", simTime()),
-                      makeTestHost(info_, "tcp://127.0.0.1:91", simTime()),
-                      makeTestHost(info_, "tcp://127.0.0.1:92", simTime()),
-                      makeTestHost(info_, "tcp://127.0.0.1:93", simTime()),
-                      makeTestHost(info_, "tcp://127.0.0.1:94", simTime()),
-                      makeTestHost(info_, "tcp://127.0.0.1:95", simTime())};
+  hostSet().hosts_ = {
+      makeTestHost(info_, "tcp://127.0.0.1:90"), makeTestHost(info_, "tcp://127.0.0.1:91"),
+      makeTestHost(info_, "tcp://127.0.0.1:92"), makeTestHost(info_, "tcp://127.0.0.1:93"),
+      makeTestHost(info_, "tcp://127.0.0.1:94"), makeTestHost(info_, "tcp://127.0.0.1:95")};
   hostSet().healthy_hosts_ = hostSet().hosts_;
   hostSet().runCallbacks({}, {});
 
@@ -223,8 +221,8 @@ TEST_P(RingHashLoadBalancerTest, Basic) {
 
 // Ensure if all the hosts with priority 0 unhealthy, the next priority hosts are used.
 TEST_P(RingHashFailoverTest, BasicFailover) {
-  host_set_.hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:80", simTime())};
-  failover_host_set_.healthy_hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:82", simTime())};
+  host_set_.hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:80")};
+  failover_host_set_.healthy_hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:82")};
   failover_host_set_.hosts_ = failover_host_set_.healthy_hosts_;
 
   config_.mutable_minimum_ring_size()->set_value(12);
@@ -249,8 +247,8 @@ TEST_P(RingHashFailoverTest, BasicFailover) {
   EXPECT_EQ(failover_host_set_.healthy_hosts_[0], lb->chooseHost(nullptr).host);
 
   // Set up so P=0 gets 70% of the load, and P=1 gets 30%.
-  host_set_.hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:80", simTime()),
-                      makeTestHost(info_, "tcp://127.0.0.1:81", simTime())};
+  host_set_.hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:80"),
+                      makeTestHost(info_, "tcp://127.0.0.1:81")};
   host_set_.healthy_hosts_ = {host_set_.hosts_[0]};
   host_set_.runCallbacks({}, {});
   lb = lb_->factory()->create(lb_params_);
@@ -262,12 +260,10 @@ TEST_P(RingHashFailoverTest, BasicFailover) {
 
 // Expect reasonable results with Murmur2 hash.
 TEST_P(RingHashLoadBalancerTest, BasicWithMurmur2) {
-  hostSet().hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:80", simTime()),
-                      makeTestHost(info_, "tcp://127.0.0.1:81", simTime()),
-                      makeTestHost(info_, "tcp://127.0.0.1:82", simTime()),
-                      makeTestHost(info_, "tcp://127.0.0.1:83", simTime()),
-                      makeTestHost(info_, "tcp://127.0.0.1:84", simTime()),
-                      makeTestHost(info_, "tcp://127.0.0.1:85", simTime())};
+  hostSet().hosts_ = {
+      makeTestHost(info_, "tcp://127.0.0.1:80"), makeTestHost(info_, "tcp://127.0.0.1:81"),
+      makeTestHost(info_, "tcp://127.0.0.1:82"), makeTestHost(info_, "tcp://127.0.0.1:83"),
+      makeTestHost(info_, "tcp://127.0.0.1:84"), makeTestHost(info_, "tcp://127.0.0.1:85")};
   hostSet().healthy_hosts_ = hostSet().hosts_;
   hostSet().runCallbacks({}, {});
 
@@ -319,12 +315,12 @@ TEST_P(RingHashLoadBalancerTest, BasicWithMurmur2) {
 // Test bounded load. This test only ensures that the
 // hash balancer factory won't break the normal load balancer process.
 TEST_P(RingHashLoadBalancerTest, BasicWithDoundedLoad) {
-  hostSet().hosts_ = {makeTestHost(info_, "90", "tcp://127.0.0.1:90", simTime()),
-                      makeTestHost(info_, "91", "tcp://127.0.0.1:91", simTime()),
-                      makeTestHost(info_, "92", "tcp://127.0.0.1:92", simTime()),
-                      makeTestHost(info_, "93", "tcp://127.0.0.1:93", simTime()),
-                      makeTestHost(info_, "94", "tcp://127.0.0.1:94", simTime()),
-                      makeTestHost(info_, "95", "tcp://127.0.0.1:95", simTime())};
+  hostSet().hosts_ = {makeTestHost(info_, "90", "tcp://127.0.0.1:90"),
+                      makeTestHost(info_, "91", "tcp://127.0.0.1:91"),
+                      makeTestHost(info_, "92", "tcp://127.0.0.1:92"),
+                      makeTestHost(info_, "93", "tcp://127.0.0.1:93"),
+                      makeTestHost(info_, "94", "tcp://127.0.0.1:94"),
+                      makeTestHost(info_, "95", "tcp://127.0.0.1:95")};
   hostSet().healthy_hosts_ = hostSet().hosts_;
   hostSet().runCallbacks({}, {});
 
@@ -389,12 +385,12 @@ TEST_P(RingHashLoadBalancerTest, BasicWithDoundedLoad) {
 
 // Expect reasonable results with hostname.
 TEST_P(RingHashLoadBalancerTest, BasicWithHostname) {
-  hostSet().hosts_ = {makeTestHost(info_, "90", "tcp://127.0.0.1:90", simTime()),
-                      makeTestHost(info_, "91", "tcp://127.0.0.1:91", simTime()),
-                      makeTestHost(info_, "92", "tcp://127.0.0.1:92", simTime()),
-                      makeTestHost(info_, "93", "tcp://127.0.0.1:93", simTime()),
-                      makeTestHost(info_, "94", "tcp://127.0.0.1:94", simTime()),
-                      makeTestHost(info_, "95", "tcp://127.0.0.1:95", simTime())};
+  hostSet().hosts_ = {makeTestHost(info_, "90", "tcp://127.0.0.1:90"),
+                      makeTestHost(info_, "91", "tcp://127.0.0.1:91"),
+                      makeTestHost(info_, "92", "tcp://127.0.0.1:92"),
+                      makeTestHost(info_, "93", "tcp://127.0.0.1:93"),
+                      makeTestHost(info_, "94", "tcp://127.0.0.1:94"),
+                      makeTestHost(info_, "95", "tcp://127.0.0.1:95")};
   hostSet().healthy_hosts_ = hostSet().hosts_;
   hostSet().runCallbacks({}, {});
 
@@ -458,12 +454,12 @@ TEST_P(RingHashLoadBalancerTest, BasicWithHostname) {
 
 // Expect reasonable results with metadata hash_key.
 TEST_P(RingHashLoadBalancerTest, BasicWithMetadataHashKey) {
-  hostSet().hosts_ = {makeTestHostWithHashKey(info_, "90", "tcp://127.0.0.1:90", simTime()),
-                      makeTestHostWithHashKey(info_, "91", "tcp://127.0.0.1:91", simTime()),
-                      makeTestHostWithHashKey(info_, "92", "tcp://127.0.0.1:92", simTime()),
-                      makeTestHostWithHashKey(info_, "93", "tcp://127.0.0.1:93", simTime()),
-                      makeTestHostWithHashKey(info_, "94", "tcp://127.0.0.1:94", simTime()),
-                      makeTestHostWithHashKey(info_, "95", "tcp://127.0.0.1:95", simTime())};
+  hostSet().hosts_ = {makeTestHostWithHashKey(info_, "90", "tcp://127.0.0.1:90"),
+                      makeTestHostWithHashKey(info_, "91", "tcp://127.0.0.1:91"),
+                      makeTestHostWithHashKey(info_, "92", "tcp://127.0.0.1:92"),
+                      makeTestHostWithHashKey(info_, "93", "tcp://127.0.0.1:93"),
+                      makeTestHostWithHashKey(info_, "94", "tcp://127.0.0.1:94"),
+                      makeTestHostWithHashKey(info_, "95", "tcp://127.0.0.1:95")};
   hostSet().healthy_hosts_ = hostSet().hosts_;
   hostSet().runCallbacks({}, {});
 
@@ -527,12 +523,10 @@ TEST_P(RingHashLoadBalancerTest, BasicWithMetadataHashKey) {
 
 // Test the same ring as Basic but exercise retry host predicate behavior.
 TEST_P(RingHashLoadBalancerTest, BasicWithRetryHostPredicate) {
-  hostSet().hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:90", simTime()),
-                      makeTestHost(info_, "tcp://127.0.0.1:91", simTime()),
-                      makeTestHost(info_, "tcp://127.0.0.1:92", simTime()),
-                      makeTestHost(info_, "tcp://127.0.0.1:93", simTime()),
-                      makeTestHost(info_, "tcp://127.0.0.1:94", simTime()),
-                      makeTestHost(info_, "tcp://127.0.0.1:95", simTime())};
+  hostSet().hosts_ = {
+      makeTestHost(info_, "tcp://127.0.0.1:90"), makeTestHost(info_, "tcp://127.0.0.1:91"),
+      makeTestHost(info_, "tcp://127.0.0.1:92"), makeTestHost(info_, "tcp://127.0.0.1:93"),
+      makeTestHost(info_, "tcp://127.0.0.1:94"), makeTestHost(info_, "tcp://127.0.0.1:95")};
   hostSet().healthy_hosts_ = hostSet().hosts_;
   hostSet().runCallbacks({}, {});
 
@@ -593,8 +587,8 @@ TEST_P(RingHashLoadBalancerTest, BasicWithRetryHostPredicate) {
 
 // Given 2 hosts and a minimum ring size of 3, expect 2 hashes per host and a ring size of 4.
 TEST_P(RingHashLoadBalancerTest, UnevenHosts) {
-  hostSet().hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:80", simTime()),
-                      makeTestHost(info_, "tcp://127.0.0.1:81", simTime())};
+  hostSet().hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:80"),
+                      makeTestHost(info_, "tcp://127.0.0.1:81")};
   hostSet().healthy_hosts_ = hostSet().hosts_;
   hostSet().runCallbacks({}, {});
 
@@ -618,8 +612,8 @@ TEST_P(RingHashLoadBalancerTest, UnevenHosts) {
     EXPECT_EQ(hostSet().hosts_[0], lb->chooseHost(&context).host);
   }
 
-  hostSet().hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:81", simTime()),
-                      makeTestHost(info_, "tcp://127.0.0.1:82", simTime())};
+  hostSet().hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:81"),
+                      makeTestHost(info_, "tcp://127.0.0.1:82")};
   hostSet().healthy_hosts_ = hostSet().hosts_;
   hostSet().runCallbacks({}, {});
 
@@ -641,9 +635,9 @@ TEST_P(RingHashLoadBalancerTest, UnevenHosts) {
 // Given hosts with weights 1, 2 and 3, and a ring size of exactly 6, expect the correct number of
 // hashes for each host.
 TEST_P(RingHashLoadBalancerTest, HostWeightedTinyRing) {
-  hostSet().hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:90", simTime(), 1),
-                      makeTestHost(info_, "tcp://127.0.0.1:91", simTime(), 2),
-                      makeTestHost(info_, "tcp://127.0.0.1:92", simTime(), 3)};
+  hostSet().hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:90", 1),
+                      makeTestHost(info_, "tcp://127.0.0.1:91", 2),
+                      makeTestHost(info_, "tcp://127.0.0.1:92", 3)};
   hostSet().healthy_hosts_ = hostSet().hosts_;
   hostSet().runCallbacks({}, {});
 
@@ -670,9 +664,9 @@ TEST_P(RingHashLoadBalancerTest, HostWeightedTinyRing) {
 // Given hosts with weights 1, 2 and 3, and a sufficiently large ring, expect that requests will
 // distribute to the hosts with approximately the right proportion.
 TEST_P(RingHashLoadBalancerTest, HostWeightedLargeRing) {
-  hostSet().hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:90", simTime(), 1),
-                      makeTestHost(info_, "tcp://127.0.0.1:91", simTime(), 2),
-                      makeTestHost(info_, "tcp://127.0.0.1:92", simTime(), 3)};
+  hostSet().hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:90", 1),
+                      makeTestHost(info_, "tcp://127.0.0.1:91", 2),
+                      makeTestHost(info_, "tcp://127.0.0.1:92", 3)};
   hostSet().healthy_hosts_ = hostSet().hosts_;
   hostSet().runCallbacks({}, {});
 
@@ -703,8 +697,8 @@ TEST_P(RingHashLoadBalancerTest, ZeroLocalityWeights) {
   envoy::config::core::v3::Locality zone_b;
   zone_b.set_zone("B");
 
-  hostSet().hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:90", simTime(), zone_a),
-                      makeTestHost(info_, "tcp://127.0.0.1:91", simTime(), zone_b)};
+  hostSet().hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:90", zone_a),
+                      makeTestHost(info_, "tcp://127.0.0.1:91", zone_b)};
   hostSet().healthy_hosts_ = hostSet().hosts_;
   hostSet().hosts_per_locality_ =
       makeHostsPerLocality({{hostSet().hosts_[0]}, {hostSet().hosts_[1]}});
@@ -728,10 +722,10 @@ TEST_P(RingHashLoadBalancerTest, LocalityWeightedTinyRing) {
   envoy::config::core::v3::Locality zone_d;
   zone_d.set_zone("D");
 
-  hostSet().hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:90", simTime(), zone_a),
-                      makeTestHost(info_, "tcp://127.0.0.1:91", simTime(), zone_b),
-                      makeTestHost(info_, "tcp://127.0.0.1:92", simTime(), zone_c),
-                      makeTestHost(info_, "tcp://127.0.0.1:93", simTime(), zone_d)};
+  hostSet().hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:90", zone_a),
+                      makeTestHost(info_, "tcp://127.0.0.1:91", zone_b),
+                      makeTestHost(info_, "tcp://127.0.0.1:92", zone_c),
+                      makeTestHost(info_, "tcp://127.0.0.1:93", zone_d)};
   hostSet().healthy_hosts_ = hostSet().hosts_;
   hostSet().hosts_per_locality_ = makeHostsPerLocality(
       {{hostSet().hosts_[0]}, {hostSet().hosts_[1]}, {hostSet().hosts_[2]}, {hostSet().hosts_[3]}});
@@ -772,10 +766,10 @@ TEST_P(RingHashLoadBalancerTest, LocalityWeightedLargeRing) {
   envoy::config::core::v3::Locality zone_d;
   zone_d.set_zone("D");
 
-  hostSet().hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:90", simTime(), zone_a),
-                      makeTestHost(info_, "tcp://127.0.0.1:91", simTime(), zone_b),
-                      makeTestHost(info_, "tcp://127.0.0.1:92", simTime(), zone_c),
-                      makeTestHost(info_, "tcp://127.0.0.1:93", simTime(), zone_d)};
+  hostSet().hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:90", zone_a),
+                      makeTestHost(info_, "tcp://127.0.0.1:91", zone_b),
+                      makeTestHost(info_, "tcp://127.0.0.1:92", zone_c),
+                      makeTestHost(info_, "tcp://127.0.0.1:93", zone_d)};
   hostSet().healthy_hosts_ = hostSet().hosts_;
   hostSet().hosts_per_locality_ = makeHostsPerLocality(
       {{hostSet().hosts_[0]}, {hostSet().hosts_[1]}, {hostSet().hosts_[2]}, {hostSet().hosts_[3]}});
@@ -813,10 +807,10 @@ TEST_P(RingHashLoadBalancerTest, HostAndLocalityWeightedTinyRing) {
 
   // :90 and :91 have a 1:2 ratio within the first locality, :92 and :93 have a 1:2 ratio within the
   // second locality, and the two localities have a 1:2 ratio overall.
-  hostSet().hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:90", simTime(), zone_a, 1),
-                      makeTestHost(info_, "tcp://127.0.0.1:91", simTime(), zone_a, 2),
-                      makeTestHost(info_, "tcp://127.0.0.1:92", simTime(), zone_b, 1),
-                      makeTestHost(info_, "tcp://127.0.0.1:93", simTime(), zone_b, 2)};
+  hostSet().hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:90", zone_a, 1),
+                      makeTestHost(info_, "tcp://127.0.0.1:91", zone_a, 2),
+                      makeTestHost(info_, "tcp://127.0.0.1:92", zone_b, 1),
+                      makeTestHost(info_, "tcp://127.0.0.1:93", zone_b, 2)};
   hostSet().healthy_hosts_ = hostSet().hosts_;
   hostSet().hosts_per_locality_ = makeHostsPerLocality(
       {{hostSet().hosts_[0], hostSet().hosts_[1]}, {hostSet().hosts_[2], hostSet().hosts_[3]}});
@@ -856,10 +850,10 @@ TEST_P(RingHashLoadBalancerTest, HostAndLocalityWeightedLargeRing) {
 
   // :90 and :91 have a 1:2 ratio within the first locality, :92 and :93 have a 1:2 ratio within the
   // second locality, and the two localities have a 1:2 ratio overall.
-  hostSet().hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:90", simTime(), zone_a, 1),
-                      makeTestHost(info_, "tcp://127.0.0.1:91", simTime(), zone_a, 2),
-                      makeTestHost(info_, "tcp://127.0.0.1:92", simTime(), zone_b, 1),
-                      makeTestHost(info_, "tcp://127.0.0.1:93", simTime(), zone_b, 2)};
+  hostSet().hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:90", zone_a, 1),
+                      makeTestHost(info_, "tcp://127.0.0.1:91", zone_a, 2),
+                      makeTestHost(info_, "tcp://127.0.0.1:92", zone_b, 1),
+                      makeTestHost(info_, "tcp://127.0.0.1:93", zone_b, 2)};
   hostSet().healthy_hosts_ = hostSet().hosts_;
   hostSet().hosts_per_locality_ = makeHostsPerLocality(
       {{hostSet().hosts_[0], hostSet().hosts_[1]}, {hostSet().hosts_[2], hostSet().hosts_[3]}});
@@ -891,10 +885,9 @@ TEST_P(RingHashLoadBalancerTest, HostAndLocalityWeightedLargeRing) {
 // Given 4 hosts and a ring size of exactly 2, expect that 2 hosts will be present in the ring and
 // the other 2 hosts will be absent.
 TEST_P(RingHashLoadBalancerTest, SmallFractionalScale) {
-  hostSet().hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:90", simTime()),
-                      makeTestHost(info_, "tcp://127.0.0.1:91", simTime()),
-                      makeTestHost(info_, "tcp://127.0.0.1:92", simTime()),
-                      makeTestHost(info_, "tcp://127.0.0.1:93", simTime())};
+  hostSet().hosts_ = {
+      makeTestHost(info_, "tcp://127.0.0.1:90"), makeTestHost(info_, "tcp://127.0.0.1:91"),
+      makeTestHost(info_, "tcp://127.0.0.1:92"), makeTestHost(info_, "tcp://127.0.0.1:93")};
   hostSet().healthy_hosts_ = hostSet().hosts_;
   hostSet().runCallbacks({}, {});
 
@@ -932,8 +925,8 @@ TEST_P(RingHashLoadBalancerTest, SmallFractionalScale) {
 // Given 2 hosts and a ring size of exactly 1023, expect that one host will have 511 entries and the
 // other will have 512.
 TEST_P(RingHashLoadBalancerTest, LargeFractionalScale) {
-  hostSet().hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:90", simTime()),
-                      makeTestHost(info_, "tcp://127.0.0.1:91", simTime())};
+  hostSet().hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:90"),
+                      makeTestHost(info_, "tcp://127.0.0.1:91")};
   hostSet().healthy_hosts_ = hostSet().hosts_;
   hostSet().runCallbacks({}, {});
 
@@ -969,7 +962,7 @@ TEST_P(RingHashLoadBalancerTest, LopsidedWeightSmallScale) {
   HostVector heavy_but_sparse, light_but_dense;
   for (uint32_t i = 0; i < 1024; ++i) {
     auto host_locality = i == 0 ? zone_a : zone_b;
-    auto host(makeTestHost(info_, fmt::format("tcp://127.0.0.1:{}", i), simTime(), host_locality));
+    auto host(makeTestHost(info_, fmt::format("tcp://127.0.0.1:{}", i), host_locality));
     hostSet().hosts_.push_back(host);
     (i == 0 ? heavy_but_sparse : light_but_dense).push_back(host);
   }

--- a/test/extensions/load_balancing_policies/round_robin/round_robin_lb_test.cc
+++ b/test/extensions/load_balancing_policies/round_robin/round_robin_lb_test.cc
@@ -63,8 +63,8 @@ using FailoverTest = RoundRobinLoadBalancerTest;
 
 // Ensure if all the hosts with priority 0 unhealthy, the next priority hosts are used.
 TEST_P(FailoverTest, BasicFailover) {
-  host_set_.hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:80", simTime())};
-  failover_host_set_.healthy_hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:82", simTime())};
+  host_set_.hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:80")};
+  failover_host_set_.healthy_hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:82")};
   failover_host_set_.hosts_ = failover_host_set_.healthy_hosts_;
   init(false);
   EXPECT_EQ(failover_host_set_.healthy_hosts_[0], lb_->peekAnotherHost(nullptr));
@@ -73,7 +73,7 @@ TEST_P(FailoverTest, BasicFailover) {
 
 // Ensure if all the hosts with priority 0 degraded, the first priority degraded hosts are used.
 TEST_P(FailoverTest, BasicDegradedHosts) {
-  host_set_.hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:80", simTime())};
+  host_set_.hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:80")};
   host_set_.degraded_hosts_ = host_set_.hosts_;
   failover_host_set_.hosts_ = failover_host_set_.healthy_hosts_;
   init(false);
@@ -85,9 +85,9 @@ TEST_P(FailoverTest, BasicDegradedHosts) {
 // Ensure if all the hosts with priority 0 degraded, but healthy hosts in the failover, the healthy
 // hosts in the second priority are used.
 TEST_P(FailoverTest, BasicFailoverDegradedHosts) {
-  host_set_.hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:80", simTime())};
+  host_set_.hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:80")};
   host_set_.degraded_hosts_ = host_set_.hosts_;
-  failover_host_set_.healthy_hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:82", simTime())};
+  failover_host_set_.healthy_hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:82")};
   failover_host_set_.hosts_ = failover_host_set_.healthy_hosts_;
   init(false);
   EXPECT_EQ(failover_host_set_.healthy_hosts_[0], lb_->chooseHost(nullptr).host);
@@ -95,8 +95,8 @@ TEST_P(FailoverTest, BasicFailoverDegradedHosts) {
 
 // Test that extending the priority set with an existing LB causes the correct updates.
 TEST_P(FailoverTest, PriorityUpdatesWithLocalHostSet) {
-  host_set_.hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:80", simTime())};
-  failover_host_set_.hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:81", simTime())};
+  host_set_.hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:80")};
+  failover_host_set_.hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:81")};
   init(false);
   // With both the primary and failover hosts unhealthy, we should select an
   // unhealthy primary host.
@@ -105,7 +105,7 @@ TEST_P(FailoverTest, PriorityUpdatesWithLocalHostSet) {
   // Update the priority set with a new priority level P=2 and ensure the host
   // is chosen
   MockHostSet& tertiary_host_set_ = *priority_set_.getMockHostSet(2);
-  HostVectorSharedPtr hosts(new HostVector({makeTestHost(info_, "tcp://127.0.0.1:82", simTime())}));
+  HostVectorSharedPtr hosts(new HostVector({makeTestHost(info_, "tcp://127.0.0.1:82")}));
   tertiary_host_set_.hosts_ = *hosts;
   tertiary_host_set_.healthy_hosts_ = tertiary_host_set_.hosts_;
   HostVector add_hosts;
@@ -127,8 +127,8 @@ TEST_P(FailoverTest, PriorityUpdatesWithLocalHostSet) {
 // Test that extending the priority set with an existing LB causes the correct updates when the
 // cluster is configured to disable on panic.
 TEST_P(FailoverTest, PriorityUpdatesWithLocalHostSetDisableOnPanic) {
-  host_set_.hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:80", simTime())};
-  failover_host_set_.hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:81", simTime())};
+  host_set_.hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:80")};
+  failover_host_set_.hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:81")};
   round_robin_lb_config_.mutable_locality_lb_config()
       ->mutable_zone_aware_lb_config()
       ->set_fail_traffic_on_panic(true);
@@ -140,7 +140,7 @@ TEST_P(FailoverTest, PriorityUpdatesWithLocalHostSetDisableOnPanic) {
   // Update the priority set with a new priority level P=2 and ensure the host
   // is chosen
   MockHostSet& tertiary_host_set_ = *priority_set_.getMockHostSet(2);
-  HostVectorSharedPtr hosts(new HostVector({makeTestHost(info_, "tcp://127.0.0.1:82", simTime())}));
+  HostVectorSharedPtr hosts(new HostVector({makeTestHost(info_, "tcp://127.0.0.1:82")}));
   tertiary_host_set_.hosts_ = *hosts;
   tertiary_host_set_.healthy_hosts_ = tertiary_host_set_.hosts_;
   HostVector add_hosts;
@@ -161,8 +161,8 @@ TEST_P(FailoverTest, PriorityUpdatesWithLocalHostSetDisableOnPanic) {
 
 // Test extending the priority set.
 TEST_P(FailoverTest, ExtendPrioritiesUpdatingPrioritySet) {
-  host_set_.hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:80", simTime())};
-  failover_host_set_.hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:81", simTime())};
+  host_set_.hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:80")};
+  failover_host_set_.hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:81")};
   init(true);
   // With both the primary and failover hosts unhealthy, we should select an
   // unhealthy primary host.
@@ -171,7 +171,7 @@ TEST_P(FailoverTest, ExtendPrioritiesUpdatingPrioritySet) {
   // Update the priority set with a new priority level P=2
   // As it has healthy hosts, it should be selected.
   MockHostSet& tertiary_host_set_ = *priority_set_.getMockHostSet(2);
-  HostVectorSharedPtr hosts(new HostVector({makeTestHost(info_, "tcp://127.0.0.1:82", simTime())}));
+  HostVectorSharedPtr hosts(new HostVector({makeTestHost(info_, "tcp://127.0.0.1:82")}));
   tertiary_host_set_.hosts_ = *hosts;
   tertiary_host_set_.healthy_hosts_ = tertiary_host_set_.hosts_;
   HostVector add_hosts;
@@ -186,8 +186,8 @@ TEST_P(FailoverTest, ExtendPrioritiesUpdatingPrioritySet) {
 }
 
 TEST_P(FailoverTest, ExtendPrioritiesWithLocalPrioritySet) {
-  host_set_.hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:80", simTime())};
-  failover_host_set_.hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:81", simTime())};
+  host_set_.hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:80")};
+  failover_host_set_.hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:81")};
   init(true);
   // With both the primary and failover hosts unhealthy, we should select an
   // unhealthy primary host.
@@ -196,8 +196,7 @@ TEST_P(FailoverTest, ExtendPrioritiesWithLocalPrioritySet) {
   // Update the host set with a new priority level. We should start selecting
   // hosts from that level as it has viable hosts.
   MockHostSet& tertiary_host_set_ = *priority_set_.getMockHostSet(2);
-  HostVectorSharedPtr hosts2(
-      new HostVector({makeTestHost(info_, "tcp://127.0.0.1:84", simTime())}));
+  HostVectorSharedPtr hosts2(new HostVector({makeTestHost(info_, "tcp://127.0.0.1:84")}));
   tertiary_host_set_.hosts_ = *hosts2;
   tertiary_host_set_.healthy_hosts_ = tertiary_host_set_.hosts_;
   HostVector add_hosts;
@@ -207,7 +206,7 @@ TEST_P(FailoverTest, ExtendPrioritiesWithLocalPrioritySet) {
 
   // Update the local hosts. We're not doing locality based routing in this
   // test, but it should at least do no harm.
-  HostVectorSharedPtr hosts(new HostVector({makeTestHost(info_, "tcp://127.0.0.1:82", simTime())}));
+  HostVectorSharedPtr hosts(new HostVector({makeTestHost(info_, "tcp://127.0.0.1:82")}));
   updateHosts(hosts, HostsPerLocalityImpl::empty());
   EXPECT_EQ(tertiary_host_set_.hosts_[0], lb_->chooseHost(nullptr).host);
 }
@@ -218,10 +217,10 @@ TEST_P(FailoverTest, PrioritiesWithNotAllWarmedHosts) {
   // P0: 1 healthy, 1 unhealthy, 1 warmed.
   // P1: 1 healthy.
   // We then expect no spillover, since P0 is still overprovisioned.
-  host_set_.hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:80", simTime()),
-                      makeTestHost(info_, "tcp://127.0.0.1:81", simTime())};
+  host_set_.hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:80"),
+                      makeTestHost(info_, "tcp://127.0.0.1:81")};
   host_set_.healthy_hosts_ = {host_set_.hosts_[0]};
-  failover_host_set_.hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:82", simTime())};
+  failover_host_set_.hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:82")};
   failover_host_set_.healthy_hosts_ = failover_host_set_.hosts_;
   init(true);
 
@@ -236,9 +235,9 @@ TEST_P(FailoverTest, PrioritiesWithZeroWarmedHosts) {
   // P0: 2 unhealthy, 0 warmed.
   // P1: 1 healthy.
   // We then expect all the traffic to spill over to P1 since P0 has an effective load of zero.
-  host_set_.hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:80", simTime()),
-                      makeTestHost(info_, "tcp://127.0.0.1:81", simTime())};
-  failover_host_set_.hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:82", simTime())};
+  host_set_.hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:80"),
+                      makeTestHost(info_, "tcp://127.0.0.1:81")};
+  failover_host_set_.hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:82")};
   failover_host_set_.healthy_hosts_ = failover_host_set_.hosts_;
 
   init(true);
@@ -258,15 +257,15 @@ TEST_P(RoundRobinLoadBalancerTest, NoHosts) {
 }
 
 TEST_P(RoundRobinLoadBalancerTest, SingleHost) {
-  hostSet().healthy_hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:80", simTime())};
+  hostSet().healthy_hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:80")};
   hostSet().hosts_ = hostSet().healthy_hosts_;
   init(false);
   EXPECT_EQ(hostSet().healthy_hosts_[0], lb_->chooseHost(nullptr).host);
 }
 
 TEST_P(RoundRobinLoadBalancerTest, Normal) {
-  hostSet().healthy_hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:80", simTime()),
-                              makeTestHost(info_, "tcp://127.0.0.1:81", simTime())};
+  hostSet().healthy_hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:80"),
+                              makeTestHost(info_, "tcp://127.0.0.1:81")};
   hostSet().hosts_ = hostSet().healthy_hosts_;
   init(false);
 
@@ -285,7 +284,7 @@ TEST_P(RoundRobinLoadBalancerTest, Normal) {
   EXPECT_EQ(hostSet().healthy_hosts_[0], lb_->chooseHost(nullptr).host);
 
   // Change host set with no peeks in progress
-  hostSet().healthy_hosts_.push_back(makeTestHost(info_, "tcp://127.0.0.1:82", simTime()));
+  hostSet().healthy_hosts_.push_back(makeTestHost(info_, "tcp://127.0.0.1:82"));
   hostSet().hosts_.push_back(hostSet().healthy_hosts_.back());
   hostSet().runCallbacks({hostSet().healthy_hosts_.back()}, {});
   peekThenPick({2, 0, 1});
@@ -296,7 +295,7 @@ TEST_P(RoundRobinLoadBalancerTest, Normal) {
   EXPECT_EQ(hostSet().healthy_hosts_[0], lb_->peekAnotherHost(nullptr));
   EXPECT_EQ(hostSet().healthy_hosts_[1], lb_->peekAnotherHost(nullptr));
 
-  hostSet().healthy_hosts_.push_back(makeTestHost(info_, "tcp://127.0.0.1:83", simTime()));
+  hostSet().healthy_hosts_.push_back(makeTestHost(info_, "tcp://127.0.0.1:83"));
   hostSet().hosts_.push_back(hostSet().healthy_hosts_.back());
   hostSet().runCallbacks({hostSet().healthy_hosts_.back()}, {hostSet().healthy_hosts_.front()});
   EXPECT_EQ(hostSet().healthy_hosts_[1], lb_->chooseHost(nullptr).host);
@@ -306,9 +305,9 @@ TEST_P(RoundRobinLoadBalancerTest, Normal) {
 // Validate that the RNG seed influences pick order.
 TEST_P(RoundRobinLoadBalancerTest, Seed) {
   hostSet().healthy_hosts_ = {
-      makeTestHost(info_, "tcp://127.0.0.1:80", simTime()),
-      makeTestHost(info_, "tcp://127.0.0.1:81", simTime()),
-      makeTestHost(info_, "tcp://127.0.0.1:82", simTime()),
+      makeTestHost(info_, "tcp://127.0.0.1:80"),
+      makeTestHost(info_, "tcp://127.0.0.1:81"),
+      makeTestHost(info_, "tcp://127.0.0.1:82"),
   };
   hostSet().hosts_ = hostSet().healthy_hosts_;
   EXPECT_CALL(random_, random()).WillRepeatedly(Return(1));
@@ -327,10 +326,9 @@ TEST_P(RoundRobinLoadBalancerTest, Locality) {
   envoy::config::core::v3::Locality zone_c;
   zone_c.set_zone("C");
 
-  HostVectorSharedPtr hosts(
-      new HostVector({makeTestHost(info_, "tcp://127.0.0.1:80", simTime(), zone_a),
-                      makeTestHost(info_, "tcp://127.0.0.1:81", simTime(), zone_b),
-                      makeTestHost(info_, "tcp://127.0.0.1:82", simTime(), zone_c)}));
+  HostVectorSharedPtr hosts(new HostVector({makeTestHost(info_, "tcp://127.0.0.1:80", zone_a),
+                                            makeTestHost(info_, "tcp://127.0.0.1:81", zone_b),
+                                            makeTestHost(info_, "tcp://127.0.0.1:82", zone_c)}));
   HostsPerLocalitySharedPtr hosts_per_locality =
       makeHostsPerLocality({{(*hosts)[1]}, {(*hosts)[0]}, {(*hosts)[2]}});
   hostSet().hosts_ = *hosts;
@@ -363,10 +361,9 @@ TEST_P(RoundRobinLoadBalancerTest, DegradedLocality) {
   envoy::config::core::v3::Locality zone_b;
   zone_b.set_zone("B");
 
-  HostVectorSharedPtr hosts(
-      new HostVector({makeTestHost(info_, "tcp://127.0.0.1:80", simTime(), zone_a),
-                      makeTestHost(info_, "tcp://127.0.0.1:81", simTime(), zone_b),
-                      makeTestHost(info_, "tcp://127.0.0.1:84", simTime(), zone_b)}));
+  HostVectorSharedPtr hosts(new HostVector({makeTestHost(info_, "tcp://127.0.0.1:80", zone_a),
+                                            makeTestHost(info_, "tcp://127.0.0.1:81", zone_b),
+                                            makeTestHost(info_, "tcp://127.0.0.1:84", zone_b)}));
   HostVectorSharedPtr healthy_hosts(new HostVector({(*hosts)[0]}));
   HostVectorSharedPtr degraded_hosts(new HostVector({(*hosts)[1], (*hosts)[2]}));
   HostsPerLocalitySharedPtr hosts_per_locality =
@@ -393,8 +390,8 @@ TEST_P(RoundRobinLoadBalancerTest, DegradedLocality) {
 }
 
 TEST_P(RoundRobinLoadBalancerTest, Weighted) {
-  hostSet().healthy_hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:80", simTime(), 1),
-                              makeTestHost(info_, "tcp://127.0.0.1:81", simTime(), 2)};
+  hostSet().healthy_hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:80", 1),
+                              makeTestHost(info_, "tcp://127.0.0.1:81", 2)};
   hostSet().hosts_ = hostSet().healthy_hosts_;
   init(false);
   // Initial weights respected.
@@ -416,7 +413,7 @@ TEST_P(RoundRobinLoadBalancerTest, Weighted) {
   EXPECT_EQ(hostSet().healthy_hosts_[1], lb_->chooseHost(nullptr).host);
   EXPECT_EQ(hostSet().healthy_hosts_[0], lb_->chooseHost(nullptr).host);
   // Add a host, it should participate in next round of scheduling.
-  hostSet().healthy_hosts_.push_back(makeTestHost(info_, "tcp://127.0.0.1:82", simTime(), 3));
+  hostSet().healthy_hosts_.push_back(makeTestHost(info_, "tcp://127.0.0.1:82", 3));
   hostSet().hosts_.push_back(hostSet().healthy_hosts_.back());
   hostSet().runCallbacks({hostSet().healthy_hosts_.back()}, {});
   EXPECT_EQ(hostSet().healthy_hosts_[2], lb_->chooseHost(nullptr).host);
@@ -437,7 +434,7 @@ TEST_P(RoundRobinLoadBalancerTest, Weighted) {
   hostSet().healthy_hosts_.pop_back();
   hostSet().hosts_.pop_back();
   hostSet().hosts_.pop_back();
-  hostSet().healthy_hosts_.push_back(makeTestHost(info_, "tcp://127.0.0.1:83", simTime(), 4));
+  hostSet().healthy_hosts_.push_back(makeTestHost(info_, "tcp://127.0.0.1:83", 4));
   hostSet().hosts_.push_back(hostSet().healthy_hosts_.back());
   hostSet().healthy_hosts_[0]->weight(1);
   hostSet().runCallbacks({hostSet().healthy_hosts_.back()}, removed_hosts);
@@ -455,8 +452,8 @@ TEST_P(RoundRobinLoadBalancerTest, Weighted) {
 
 // Validate that the RNG seed influences pick order when weighted RR.
 TEST_P(RoundRobinLoadBalancerTest, WeightedSeed) {
-  hostSet().healthy_hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:80", simTime(), 1),
-                              makeTestHost(info_, "tcp://127.0.0.1:81", simTime(), 2)};
+  hostSet().healthy_hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:80", 1),
+                              makeTestHost(info_, "tcp://127.0.0.1:81", 2)};
   hostSet().hosts_ = hostSet().healthy_hosts_;
   EXPECT_CALL(random_, random()).WillRepeatedly(Return(1));
   init(false);
@@ -476,9 +473,9 @@ TEST_P(RoundRobinLoadBalancerTest, WeightedInitializationPicksAllHosts) {
   // random value, 6 times the first host will be chosen, 3 times the second
   // host will be chosen, and 1 time the third host will be chosen.
   hostSet().healthy_hosts_ = {
-      makeTestHost(info_, "tcp://127.0.0.1:80", simTime(), 6),
-      makeTestHost(info_, "tcp://127.0.0.1:81", simTime(), 3),
-      makeTestHost(info_, "tcp://127.0.0.1:82", simTime(), 1),
+      makeTestHost(info_, "tcp://127.0.0.1:80", 6),
+      makeTestHost(info_, "tcp://127.0.0.1:81", 3),
+      makeTestHost(info_, "tcp://127.0.0.1:82", 1),
   };
   hostSet().hosts_ = hostSet().healthy_hosts_;
   absl::flat_hash_map<HostConstSharedPtr, uint32_t> host_picked_count_map;
@@ -504,14 +501,12 @@ TEST_P(RoundRobinLoadBalancerTest, WeightedInitializationPicksAllHosts) {
 }
 
 TEST_P(RoundRobinLoadBalancerTest, MaxUnhealthyPanic) {
-  hostSet().healthy_hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:80", simTime()),
-                              makeTestHost(info_, "tcp://127.0.0.1:81", simTime())};
-  hostSet().hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:80", simTime()),
-                      makeTestHost(info_, "tcp://127.0.0.1:81", simTime()),
-                      makeTestHost(info_, "tcp://127.0.0.1:82", simTime()),
-                      makeTestHost(info_, "tcp://127.0.0.1:83", simTime()),
-                      makeTestHost(info_, "tcp://127.0.0.1:84", simTime()),
-                      makeTestHost(info_, "tcp://127.0.0.1:85", simTime())};
+  hostSet().healthy_hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:80"),
+                              makeTestHost(info_, "tcp://127.0.0.1:81")};
+  hostSet().hosts_ = {
+      makeTestHost(info_, "tcp://127.0.0.1:80"), makeTestHost(info_, "tcp://127.0.0.1:81"),
+      makeTestHost(info_, "tcp://127.0.0.1:82"), makeTestHost(info_, "tcp://127.0.0.1:83"),
+      makeTestHost(info_, "tcp://127.0.0.1:84"), makeTestHost(info_, "tcp://127.0.0.1:85")};
 
   init(false);
   EXPECT_EQ(hostSet().hosts_[0], lb_->chooseHost(nullptr).host);
@@ -519,10 +514,9 @@ TEST_P(RoundRobinLoadBalancerTest, MaxUnhealthyPanic) {
   EXPECT_EQ(hostSet().hosts_[2], lb_->chooseHost(nullptr).host);
 
   // Take the threshold back above the panic threshold.
-  hostSet().healthy_hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:80", simTime()),
-                              makeTestHost(info_, "tcp://127.0.0.1:81", simTime()),
-                              makeTestHost(info_, "tcp://127.0.0.1:82", simTime()),
-                              makeTestHost(info_, "tcp://127.0.0.1:83", simTime())};
+  hostSet().healthy_hosts_ = {
+      makeTestHost(info_, "tcp://127.0.0.1:80"), makeTestHost(info_, "tcp://127.0.0.1:81"),
+      makeTestHost(info_, "tcp://127.0.0.1:82"), makeTestHost(info_, "tcp://127.0.0.1:83")};
   hostSet().runCallbacks({}, {});
 
   EXPECT_EQ(hostSet().healthy_hosts_[0], lb_->chooseHost(nullptr).host);
@@ -533,14 +527,12 @@ TEST_P(RoundRobinLoadBalancerTest, MaxUnhealthyPanic) {
 
 // Test that no hosts are selected when fail_traffic_on_panic is enabled.
 TEST_P(RoundRobinLoadBalancerTest, MaxUnhealthyPanicDisableOnPanic) {
-  hostSet().healthy_hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:80", simTime()),
-                              makeTestHost(info_, "tcp://127.0.0.1:81", simTime())};
-  hostSet().hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:80", simTime()),
-                      makeTestHost(info_, "tcp://127.0.0.1:81", simTime()),
-                      makeTestHost(info_, "tcp://127.0.0.1:82", simTime()),
-                      makeTestHost(info_, "tcp://127.0.0.1:83", simTime()),
-                      makeTestHost(info_, "tcp://127.0.0.1:84", simTime()),
-                      makeTestHost(info_, "tcp://127.0.0.1:85", simTime())};
+  hostSet().healthy_hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:80"),
+                              makeTestHost(info_, "tcp://127.0.0.1:81")};
+  hostSet().hosts_ = {
+      makeTestHost(info_, "tcp://127.0.0.1:80"), makeTestHost(info_, "tcp://127.0.0.1:81"),
+      makeTestHost(info_, "tcp://127.0.0.1:82"), makeTestHost(info_, "tcp://127.0.0.1:83"),
+      makeTestHost(info_, "tcp://127.0.0.1:84"), makeTestHost(info_, "tcp://127.0.0.1:85")};
 
   round_robin_lb_config_.mutable_locality_lb_config()
       ->mutable_zone_aware_lb_config()
@@ -549,10 +541,9 @@ TEST_P(RoundRobinLoadBalancerTest, MaxUnhealthyPanicDisableOnPanic) {
   EXPECT_EQ(nullptr, lb_->chooseHost(nullptr).host);
 
   // Take the threshold back above the panic threshold.
-  hostSet().healthy_hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:80", simTime()),
-                              makeTestHost(info_, "tcp://127.0.0.1:81", simTime()),
-                              makeTestHost(info_, "tcp://127.0.0.1:82", simTime()),
-                              makeTestHost(info_, "tcp://127.0.0.1:83", simTime())};
+  hostSet().healthy_hosts_ = {
+      makeTestHost(info_, "tcp://127.0.0.1:80"), makeTestHost(info_, "tcp://127.0.0.1:81"),
+      makeTestHost(info_, "tcp://127.0.0.1:82"), makeTestHost(info_, "tcp://127.0.0.1:83")};
   hostSet().runCallbacks({}, {});
 
   EXPECT_EQ(hostSet().healthy_hosts_[0], lb_->chooseHost(nullptr).host);
@@ -564,7 +555,7 @@ TEST_P(RoundRobinLoadBalancerTest, MaxUnhealthyPanicDisableOnPanic) {
 // Ensure if the panic threshold is 0%, panic mode is disabled.
 TEST_P(RoundRobinLoadBalancerTest, DisablePanicMode) {
   hostSet().healthy_hosts_ = {};
-  hostSet().hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:80", simTime())};
+  hostSet().hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:80")};
 
   common_config_.mutable_healthy_panic_threshold()->set_value(0);
 
@@ -584,12 +575,11 @@ TEST_P(RoundRobinLoadBalancerTest, HostSelectionWithFilter) {
   envoy::config::core::v3::Locality zone_b;
   zone_b.set_zone("B");
 
-  HostVectorSharedPtr hosts(
-      new HostVector({makeTestHost(info_, "tcp://127.0.0.1:80", simTime(), zone_a),
-                      makeTestHost(info_, "tcp://127.0.0.1:81", simTime(), zone_b)}));
+  HostVectorSharedPtr hosts(new HostVector({makeTestHost(info_, "tcp://127.0.0.1:80", zone_a),
+                                            makeTestHost(info_, "tcp://127.0.0.1:81", zone_b)}));
   HostsPerLocalitySharedPtr hosts_per_locality =
-      makeHostsPerLocality({{makeTestHost(info_, "tcp://127.0.0.1:80", simTime(), zone_a)},
-                            {makeTestHost(info_, "tcp://127.0.0.1:81", simTime(), zone_b)}});
+      makeHostsPerLocality({{makeTestHost(info_, "tcp://127.0.0.1:80", zone_a)},
+                            {makeTestHost(info_, "tcp://127.0.0.1:81", zone_b)}});
 
   hostSet().hosts_ = *hosts;
   hostSet().healthy_hosts_ = *hosts;
@@ -635,14 +625,13 @@ TEST_P(RoundRobinLoadBalancerTest, ZoneAwareSmallCluster) {
   envoy::config::core::v3::Locality zone_c;
   zone_c.set_zone("C");
 
-  HostVectorSharedPtr hosts(
-      new HostVector({makeTestHost(info_, "tcp://127.0.0.1:80", simTime(), zone_a),
-                      makeTestHost(info_, "tcp://127.0.0.1:81", simTime(), zone_b),
-                      makeTestHost(info_, "tcp://127.0.0.1:82", simTime(), zone_c)}));
+  HostVectorSharedPtr hosts(new HostVector({makeTestHost(info_, "tcp://127.0.0.1:80", zone_a),
+                                            makeTestHost(info_, "tcp://127.0.0.1:81", zone_b),
+                                            makeTestHost(info_, "tcp://127.0.0.1:82", zone_c)}));
   HostsPerLocalitySharedPtr hosts_per_locality =
-      makeHostsPerLocality({{makeTestHost(info_, "tcp://127.0.0.1:81", simTime(), zone_b)},
-                            {makeTestHost(info_, "tcp://127.0.0.1:80", simTime(), zone_a)},
-                            {makeTestHost(info_, "tcp://127.0.0.1:82", simTime(), zone_c)}});
+      makeHostsPerLocality({{makeTestHost(info_, "tcp://127.0.0.1:81", zone_b)},
+                            {makeTestHost(info_, "tcp://127.0.0.1:80", zone_a)},
+                            {makeTestHost(info_, "tcp://127.0.0.1:82", zone_c)}});
 
   hostSet().hosts_ = *hosts;
   hostSet().healthy_hosts_ = *hosts;
@@ -706,16 +695,15 @@ TEST_P(RoundRobinLoadBalancerTest, ZoneAwareZonesMismatched) {
   envoy::config::core::v3::Locality zone_c;
   zone_c.set_zone("C");
 
-  HostVectorSharedPtr hosts(
-      new HostVector({makeTestHost(info_, "tcp://127.0.0.1:80", simTime(), zone_a),
-                      makeTestHost(info_, "tcp://127.0.0.1:82", simTime(), zone_c)}));
+  HostVectorSharedPtr hosts(new HostVector({makeTestHost(info_, "tcp://127.0.0.1:80", zone_a),
+                                            makeTestHost(info_, "tcp://127.0.0.1:82", zone_c)}));
   // Upstream and local hosts when in zone A
   HostsPerLocalitySharedPtr upstream_hosts_per_locality_a =
-      makeHostsPerLocality({{makeTestHost(info_, "tcp://127.0.0.1:80", simTime(), zone_a)},
-                            {makeTestHost(info_, "tcp://127.0.0.1:82", simTime(), zone_c)}});
+      makeHostsPerLocality({{makeTestHost(info_, "tcp://127.0.0.1:80", zone_a)},
+                            {makeTestHost(info_, "tcp://127.0.0.1:82", zone_c)}});
   HostsPerLocalitySharedPtr local_hosts_per_locality_a =
-      makeHostsPerLocality({{makeTestHost(info_, "tcp://127.0.0.1:80", simTime(), zone_a)},
-                            {makeTestHost(info_, "tcp://127.0.0.1:81", simTime(), zone_b)}});
+      makeHostsPerLocality({{makeTestHost(info_, "tcp://127.0.0.1:80", zone_a)},
+                            {makeTestHost(info_, "tcp://127.0.0.1:81", zone_b)}});
 
   hostSet().healthy_hosts_ = *hosts;
   hostSet().hosts_ = *hosts;
@@ -749,12 +737,12 @@ TEST_P(RoundRobinLoadBalancerTest, ZoneAwareZonesMismatched) {
 
   // Upstream and local hosts when in zone B (no local upstream in B)
   HostsPerLocalitySharedPtr upstream_hosts_per_locality_b =
-      makeHostsPerLocality({{makeTestHost(info_, "tcp://127.0.0.1:80", simTime(), zone_a)},
-                            {makeTestHost(info_, "tcp://127.0.0.1:82", simTime(), zone_c)}},
+      makeHostsPerLocality({{makeTestHost(info_, "tcp://127.0.0.1:80", zone_a)},
+                            {makeTestHost(info_, "tcp://127.0.0.1:82", zone_c)}},
                            true);
   HostsPerLocalitySharedPtr local_hosts_per_locality_b =
-      makeHostsPerLocality({{makeTestHost(info_, "tcp://127.0.0.1:81", simTime(), zone_b)},
-                            {makeTestHost(info_, "tcp://127.0.0.1:80", simTime(), zone_a)}});
+      makeHostsPerLocality({{makeTestHost(info_, "tcp://127.0.0.1:81", zone_b)},
+                            {makeTestHost(info_, "tcp://127.0.0.1:80", zone_a)}});
 
   hostSet().healthy_hosts_per_locality_ = upstream_hosts_per_locality_b;
   updateHosts(hosts, local_hosts_per_locality_b);
@@ -807,49 +795,48 @@ TEST_P(RoundRobinLoadBalancerTest, ZoneAwareResidualsMismatched) {
   envoy::config::core::v3::Locality zone_e;
   zone_e.set_zone("E");
 
-  HostVectorSharedPtr hosts(
-      new HostVector({makeTestHost(info_, "tcp://127.0.0.1:80", simTime(), zone_a),
-                      makeTestHost(info_, "tcp://127.0.0.1:81", simTime(), zone_c),
-                      makeTestHost(info_, "tcp://127.0.0.1:82", simTime(), zone_c),
-                      makeTestHost(info_, "tcp://127.0.0.1:83", simTime(), zone_c),
-                      makeTestHost(info_, "tcp://127.0.0.1:84", simTime(), zone_d),
-                      makeTestHost(info_, "tcp://127.0.0.1:85", simTime(), zone_d),
-                      makeTestHost(info_, "tcp://127.0.0.1:86", simTime(), zone_d),
-                      makeTestHost(info_, "tcp://127.0.0.1:87", simTime(), zone_e)}));
+  HostVectorSharedPtr hosts(new HostVector({makeTestHost(info_, "tcp://127.0.0.1:80", zone_a),
+                                            makeTestHost(info_, "tcp://127.0.0.1:81", zone_c),
+                                            makeTestHost(info_, "tcp://127.0.0.1:82", zone_c),
+                                            makeTestHost(info_, "tcp://127.0.0.1:83", zone_c),
+                                            makeTestHost(info_, "tcp://127.0.0.1:84", zone_d),
+                                            makeTestHost(info_, "tcp://127.0.0.1:85", zone_d),
+                                            makeTestHost(info_, "tcp://127.0.0.1:86", zone_d),
+                                            makeTestHost(info_, "tcp://127.0.0.1:87", zone_e)}));
   HostVectorSharedPtr local_hosts(
-      new HostVector({makeTestHost(info_, "tcp://127.0.0.1:0", simTime(), zone_a),
-                      makeTestHost(info_, "tcp://127.0.0.1:1", simTime(), zone_a),
-                      makeTestHost(info_, "tcp://127.0.0.1:2", simTime(), zone_b),
-                      makeTestHost(info_, "tcp://127.0.0.1:3", simTime(), zone_b),
-                      makeTestHost(info_, "tcp://127.0.0.1:4", simTime(), zone_c),
-                      makeTestHost(info_, "tcp://127.0.0.1:5", simTime(), zone_d)}));
+      new HostVector({makeTestHost(info_, "tcp://127.0.0.1:0", zone_a),
+                      makeTestHost(info_, "tcp://127.0.0.1:1", zone_a),
+                      makeTestHost(info_, "tcp://127.0.0.1:2", zone_b),
+                      makeTestHost(info_, "tcp://127.0.0.1:3", zone_b),
+                      makeTestHost(info_, "tcp://127.0.0.1:4", zone_c),
+                      makeTestHost(info_, "tcp://127.0.0.1:5", zone_d)}));
 
   // Local zone is zone A
   HostsPerLocalitySharedPtr upstream_hosts_per_locality =
       makeHostsPerLocality({{// Zone A
-                             makeTestHost(info_, "tcp://127.0.0.1:80", simTime(), zone_a)},
+                             makeTestHost(info_, "tcp://127.0.0.1:80", zone_a)},
                             {// Zone C
-                             makeTestHost(info_, "tcp://127.0.0.1:81", simTime(), zone_c),
-                             makeTestHost(info_, "tcp://127.0.0.1:82", simTime(), zone_c),
-                             makeTestHost(info_, "tcp://127.0.0.1:83", simTime(), zone_c)},
+                             makeTestHost(info_, "tcp://127.0.0.1:81", zone_c),
+                             makeTestHost(info_, "tcp://127.0.0.1:82", zone_c),
+                             makeTestHost(info_, "tcp://127.0.0.1:83", zone_c)},
                             {// Zone D
-                             makeTestHost(info_, "tcp://127.0.0.1:84", simTime(), zone_d),
-                             makeTestHost(info_, "tcp://127.0.0.1:85", simTime(), zone_d),
-                             makeTestHost(info_, "tcp://127.0.0.1:86", simTime(), zone_d)},
+                             makeTestHost(info_, "tcp://127.0.0.1:84", zone_d),
+                             makeTestHost(info_, "tcp://127.0.0.1:85", zone_d),
+                             makeTestHost(info_, "tcp://127.0.0.1:86", zone_d)},
                             {// Zone E
-                             makeTestHost(info_, "tcp://127.0.0.1:87", simTime(), zone_e)}});
+                             makeTestHost(info_, "tcp://127.0.0.1:87", zone_e)}});
 
   HostsPerLocalitySharedPtr local_hosts_per_locality =
       makeHostsPerLocality({{// Zone A
-                             makeTestHost(info_, "tcp://127.0.0.1:0", simTime(), zone_a),
-                             makeTestHost(info_, "tcp://127.0.0.1:1", simTime(), zone_a)},
+                             makeTestHost(info_, "tcp://127.0.0.1:0", zone_a),
+                             makeTestHost(info_, "tcp://127.0.0.1:1", zone_a)},
                             {// Zone B
-                             makeTestHost(info_, "tcp://127.0.0.1:2", simTime(), zone_b),
-                             makeTestHost(info_, "tcp://127.0.0.1:3", simTime(), zone_b)},
+                             makeTestHost(info_, "tcp://127.0.0.1:2", zone_b),
+                             makeTestHost(info_, "tcp://127.0.0.1:3", zone_b)},
                             {// Zone C
-                             makeTestHost(info_, "tcp://127.0.0.1:4", simTime(), zone_c)},
+                             makeTestHost(info_, "tcp://127.0.0.1:4", zone_c)},
                             {// Zone D
-                             makeTestHost(info_, "tcp://127.0.0.1:5", simTime(), zone_d)}});
+                             makeTestHost(info_, "tcp://127.0.0.1:5", zone_d)}});
 
   hostSet().healthy_hosts_ = *hosts;
   hostSet().hosts_ = *hosts;
@@ -923,19 +910,19 @@ TEST_P(RoundRobinLoadBalancerTest, ZoneAwareDifferentZoneSize) {
   zone_c.set_zone("C");
 
   HostVectorSharedPtr upstream_hosts(
-      new HostVector({makeTestHost(info_, "tcp://127.0.0.1:80", simTime(), zone_a),
-                      makeTestHost(info_, "tcp://127.0.0.1:81", simTime(), zone_b),
-                      makeTestHost(info_, "tcp://127.0.0.1:82", simTime(), zone_c)}));
+      new HostVector({makeTestHost(info_, "tcp://127.0.0.1:80", zone_a),
+                      makeTestHost(info_, "tcp://127.0.0.1:81", zone_b),
+                      makeTestHost(info_, "tcp://127.0.0.1:82", zone_c)}));
   HostVectorSharedPtr local_hosts(
-      new HostVector({makeTestHost(info_, "tcp://127.0.0.1:0", simTime(), zone_a),
-                      makeTestHost(info_, "tcp://127.0.0.1:1", simTime(), zone_b)}));
+      new HostVector({makeTestHost(info_, "tcp://127.0.0.1:0", zone_a),
+                      makeTestHost(info_, "tcp://127.0.0.1:1", zone_b)}));
   HostsPerLocalitySharedPtr upstream_hosts_per_locality =
-      makeHostsPerLocality({{makeTestHost(info_, "tcp://127.0.0.1:81", simTime(), zone_b)},
-                            {makeTestHost(info_, "tcp://127.0.0.1:80", simTime(), zone_a)},
-                            {makeTestHost(info_, "tcp://127.0.0.1:82", simTime(), zone_c)}});
+      makeHostsPerLocality({{makeTestHost(info_, "tcp://127.0.0.1:81", zone_b)},
+                            {makeTestHost(info_, "tcp://127.0.0.1:80", zone_a)},
+                            {makeTestHost(info_, "tcp://127.0.0.1:82", zone_c)}});
   HostsPerLocalitySharedPtr local_hosts_per_locality =
-      makeHostsPerLocality({{makeTestHost(info_, "tcp://127.0.0.1:1", simTime(), zone_b)},
-                            {makeTestHost(info_, "tcp://127.0.0.1:0", simTime(), zone_a)}});
+      makeHostsPerLocality({{makeTestHost(info_, "tcp://127.0.0.1:1", zone_b)},
+                            {makeTestHost(info_, "tcp://127.0.0.1:0", zone_a)}});
 
   hostSet().healthy_hosts_ = *upstream_hosts;
   hostSet().hosts_ = *upstream_hosts;
@@ -989,14 +976,13 @@ TEST_P(RoundRobinLoadBalancerTest, ZoneAwareRoutingLargeZoneSwitchOnOff) {
   zone_b.set_zone("B");
   envoy::config::core::v3::Locality zone_c;
   zone_c.set_zone("C");
-  HostVectorSharedPtr hosts(
-      new HostVector({makeTestHost(info_, "tcp://127.0.0.1:80", simTime(), zone_a),
-                      makeTestHost(info_, "tcp://127.0.0.1:81", simTime(), zone_b),
-                      makeTestHost(info_, "tcp://127.0.0.1:82", simTime(), zone_c)}));
+  HostVectorSharedPtr hosts(new HostVector({makeTestHost(info_, "tcp://127.0.0.1:80", zone_a),
+                                            makeTestHost(info_, "tcp://127.0.0.1:81", zone_b),
+                                            makeTestHost(info_, "tcp://127.0.0.1:82", zone_c)}));
   HostsPerLocalitySharedPtr hosts_per_locality =
-      makeHostsPerLocality({{makeTestHost(info_, "tcp://127.0.0.1:81", simTime(), zone_b)},
-                            {makeTestHost(info_, "tcp://127.0.0.1:80", simTime(), zone_a)},
-                            {makeTestHost(info_, "tcp://127.0.0.1:82", simTime(), zone_c)}});
+      makeHostsPerLocality({{makeTestHost(info_, "tcp://127.0.0.1:81", zone_b)},
+                            {makeTestHost(info_, "tcp://127.0.0.1:80", zone_a)},
+                            {makeTestHost(info_, "tcp://127.0.0.1:82", zone_c)}});
 
   EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.healthy_panic_threshold", 50))
       .WillRepeatedly(Return(50));
@@ -1036,27 +1022,27 @@ TEST_P(RoundRobinLoadBalancerTest, ZoneAwareRoutingSmallZone) {
   envoy::config::core::v3::Locality zone_c;
   zone_c.set_zone("C");
   HostVectorSharedPtr upstream_hosts(
-      new HostVector({makeTestHost(info_, "tcp://127.0.0.1:80", simTime(), zone_b),
-                      makeTestHost(info_, "tcp://127.0.0.1:81", simTime(), zone_a),
-                      makeTestHost(info_, "tcp://127.0.0.1:82", simTime(), zone_b),
-                      makeTestHost(info_, "tcp://127.0.0.1:83", simTime(), zone_c),
-                      makeTestHost(info_, "tcp://127.0.0.1:84", simTime(), zone_c)}));
+      new HostVector({makeTestHost(info_, "tcp://127.0.0.1:80", zone_b),
+                      makeTestHost(info_, "tcp://127.0.0.1:81", zone_a),
+                      makeTestHost(info_, "tcp://127.0.0.1:82", zone_b),
+                      makeTestHost(info_, "tcp://127.0.0.1:83", zone_c),
+                      makeTestHost(info_, "tcp://127.0.0.1:84", zone_c)}));
   HostVectorSharedPtr local_hosts(
-      new HostVector({makeTestHost(info_, "tcp://127.0.0.1:0", simTime(), zone_a),
-                      makeTestHost(info_, "tcp://127.0.0.1:1", simTime(), zone_b),
-                      makeTestHost(info_, "tcp://127.0.0.1:2", simTime(), zone_c)}));
+      new HostVector({makeTestHost(info_, "tcp://127.0.0.1:0", zone_a),
+                      makeTestHost(info_, "tcp://127.0.0.1:1", zone_b),
+                      makeTestHost(info_, "tcp://127.0.0.1:2", zone_c)}));
 
   HostsPerLocalitySharedPtr upstream_hosts_per_locality =
-      makeHostsPerLocality({{makeTestHost(info_, "tcp://127.0.0.1:81", simTime(), zone_a)},
-                            {makeTestHost(info_, "tcp://127.0.0.1:80", simTime(), zone_b),
-                             makeTestHost(info_, "tcp://127.0.0.1:82", simTime(), zone_b)},
-                            {makeTestHost(info_, "tcp://127.0.0.1:83", simTime(), zone_c),
-                             makeTestHost(info_, "tcp://127.0.0.1:84", simTime(), zone_c)}});
+      makeHostsPerLocality({{makeTestHost(info_, "tcp://127.0.0.1:81", zone_a)},
+                            {makeTestHost(info_, "tcp://127.0.0.1:80", zone_b),
+                             makeTestHost(info_, "tcp://127.0.0.1:82", zone_b)},
+                            {makeTestHost(info_, "tcp://127.0.0.1:83", zone_c),
+                             makeTestHost(info_, "tcp://127.0.0.1:84", zone_c)}});
 
   HostsPerLocalitySharedPtr local_hosts_per_locality =
-      makeHostsPerLocality({{makeTestHost(info_, "tcp://127.0.0.1:0", simTime(), zone_a)},
-                            {makeTestHost(info_, "tcp://127.0.0.1:1", simTime(), zone_b)},
-                            {makeTestHost(info_, "tcp://127.0.0.1:2", simTime(), zone_c)}});
+      makeHostsPerLocality({{makeTestHost(info_, "tcp://127.0.0.1:0", zone_a)},
+                            {makeTestHost(info_, "tcp://127.0.0.1:1", zone_b)},
+                            {makeTestHost(info_, "tcp://127.0.0.1:2", zone_c)}});
 
   EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.healthy_panic_threshold", 50))
       .WillRepeatedly(Return(50));
@@ -1101,24 +1087,24 @@ TEST_P(RoundRobinLoadBalancerTest, ZoneAwareNoMatchingZones) {
   envoy::config::core::v3::Locality zone_f;
   zone_f.set_zone("F");
   HostVectorSharedPtr upstream_hosts(
-      new HostVector({makeTestHost(info_, "tcp://127.0.0.1:80", simTime(), zone_d),
-                      makeTestHost(info_, "tcp://127.0.0.1:81", simTime(), zone_e),
-                      makeTestHost(info_, "tcp://127.0.0.1:82", simTime(), zone_f)}));
+      new HostVector({makeTestHost(info_, "tcp://127.0.0.1:80", zone_d),
+                      makeTestHost(info_, "tcp://127.0.0.1:81", zone_e),
+                      makeTestHost(info_, "tcp://127.0.0.1:82", zone_f)}));
   HostVectorSharedPtr local_hosts(
-      new HostVector({makeTestHost(info_, "tcp://127.0.0.1:0", simTime(), zone_a),
-                      makeTestHost(info_, "tcp://127.0.0.1:1", simTime(), zone_b),
-                      makeTestHost(info_, "tcp://127.0.0.1:2", simTime(), zone_c)}));
+      new HostVector({makeTestHost(info_, "tcp://127.0.0.1:0", zone_a),
+                      makeTestHost(info_, "tcp://127.0.0.1:1", zone_b),
+                      makeTestHost(info_, "tcp://127.0.0.1:2", zone_c)}));
 
   HostsPerLocalitySharedPtr upstream_hosts_per_locality =
-      makeHostsPerLocality({{makeTestHost(info_, "tcp://127.0.0.1:80", simTime(), zone_d)},
-                            {makeTestHost(info_, "tcp://127.0.0.1:81", simTime(), zone_e)},
-                            {makeTestHost(info_, "tcp://127.0.0.1:82", simTime(), zone_f)}},
+      makeHostsPerLocality({{makeTestHost(info_, "tcp://127.0.0.1:80", zone_d)},
+                            {makeTestHost(info_, "tcp://127.0.0.1:81", zone_e)},
+                            {makeTestHost(info_, "tcp://127.0.0.1:82", zone_f)}},
                            true);
 
   HostsPerLocalitySharedPtr local_hosts_per_locality =
-      makeHostsPerLocality({{makeTestHost(info_, "tcp://127.0.0.1:0", simTime(), zone_a)},
-                            {makeTestHost(info_, "tcp://127.0.0.1:1", simTime(), zone_b)},
-                            {makeTestHost(info_, "tcp://127.0.0.1:2", simTime(), zone_c)}});
+      makeHostsPerLocality({{makeTestHost(info_, "tcp://127.0.0.1:0", zone_a)},
+                            {makeTestHost(info_, "tcp://127.0.0.1:1", zone_b)},
+                            {makeTestHost(info_, "tcp://127.0.0.1:2", zone_c)}});
 
   EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.healthy_panic_threshold", 50))
       .WillRepeatedly(Return(50));
@@ -1165,17 +1151,17 @@ TEST_P(RoundRobinLoadBalancerTest, NoZoneAwareNotEnoughLocalZones) {
   zone_b.set_zone("B");
 
   HostVectorSharedPtr upstream_hosts(
-      new HostVector({makeTestHost(info_, "tcp://127.0.0.1:80", simTime(), zone_a),
-                      makeTestHost(info_, "tcp://127.0.0.1:81", simTime(), zone_b)}));
+      new HostVector({makeTestHost(info_, "tcp://127.0.0.1:80", zone_a),
+                      makeTestHost(info_, "tcp://127.0.0.1:81", zone_b)}));
   HostVectorSharedPtr local_hosts(
-      new HostVector({makeTestHost(info_, "tcp://127.0.0.1:0", simTime(), zone_a)}));
+      new HostVector({makeTestHost(info_, "tcp://127.0.0.1:0", zone_a)}));
 
   HostsPerLocalitySharedPtr upstream_hosts_per_locality =
-      makeHostsPerLocality({{makeTestHost(info_, "tcp://127.0.0.1:80", simTime(), zone_a)},
-                            {makeTestHost(info_, "tcp://127.0.0.1:81", simTime(), zone_b)}});
+      makeHostsPerLocality({{makeTestHost(info_, "tcp://127.0.0.1:80", zone_a)},
+                            {makeTestHost(info_, "tcp://127.0.0.1:81", zone_b)}});
 
   HostsPerLocalitySharedPtr local_hosts_per_locality =
-      makeHostsPerLocality({{makeTestHost(info_, "tcp://127.0.0.1:0", simTime(), zone_a)}});
+      makeHostsPerLocality({{makeTestHost(info_, "tcp://127.0.0.1:0", zone_a)}});
 
   EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.healthy_panic_threshold", 50))
       .WillRepeatedly(Return(50));
@@ -1211,17 +1197,17 @@ TEST_P(RoundRobinLoadBalancerTest, NoZoneAwareNotEnoughUpstreamZones) {
   zone_b.set_zone("B");
 
   HostVectorSharedPtr upstream_hosts(
-      new HostVector({makeTestHost(info_, "tcp://127.0.0.1:80", simTime(), zone_a)}));
+      new HostVector({makeTestHost(info_, "tcp://127.0.0.1:80", zone_a)}));
   HostVectorSharedPtr local_hosts(
-      new HostVector({makeTestHost(info_, "tcp://127.0.0.1:0", simTime(), zone_a),
-                      makeTestHost(info_, "tcp://127.0.0.1:1", simTime(), zone_b)}));
+      new HostVector({makeTestHost(info_, "tcp://127.0.0.1:0", zone_a),
+                      makeTestHost(info_, "tcp://127.0.0.1:1", zone_b)}));
 
   HostsPerLocalitySharedPtr upstream_hosts_per_locality =
-      makeHostsPerLocality({{makeTestHost(info_, "tcp://127.0.0.1:80", simTime(), zone_a)}});
+      makeHostsPerLocality({{makeTestHost(info_, "tcp://127.0.0.1:80", zone_a)}});
 
   HostsPerLocalitySharedPtr local_hosts_per_locality =
-      makeHostsPerLocality({{makeTestHost(info_, "tcp://127.0.0.1:0", simTime(), zone_a)},
-                            {makeTestHost(info_, "tcp://127.0.0.1:1", simTime(), zone_b)}});
+      makeHostsPerLocality({{makeTestHost(info_, "tcp://127.0.0.1:0", zone_a)},
+                            {makeTestHost(info_, "tcp://127.0.0.1:1", zone_b)}});
 
   EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.healthy_panic_threshold", 50))
       .WillRepeatedly(Return(50));
@@ -1267,17 +1253,16 @@ TEST_P(RoundRobinLoadBalancerTest, ZoneAwareForceLocalityDirect) {
   envoy::config::core::v3::Locality zone_c;
   zone_c.set_zone("C");
 
-  HostVectorSharedPtr hosts(
-      new HostVector({makeTestHost(info_, "tcp://127.0.0.1:80", simTime(), zone_a),
-                      makeTestHost(info_, "tcp://127.0.0.1:81", simTime(), zone_b),
-                      makeTestHost(info_, "tcp://127.0.0.1:82", simTime(), zone_c)}));
+  HostVectorSharedPtr hosts(new HostVector({makeTestHost(info_, "tcp://127.0.0.1:80", zone_a),
+                                            makeTestHost(info_, "tcp://127.0.0.1:81", zone_b),
+                                            makeTestHost(info_, "tcp://127.0.0.1:82", zone_c)}));
   HostsPerLocalitySharedPtr upstream_hosts_per_locality =
-      makeHostsPerLocality({{makeTestHost(info_, "tcp://127.0.0.1:80", simTime(), zone_a)},
-                            {makeTestHost(info_, "tcp://127.0.0.1:81", simTime(), zone_b)},
-                            {makeTestHost(info_, "tcp://127.0.0.1:82", simTime(), zone_c)}});
+      makeHostsPerLocality({{makeTestHost(info_, "tcp://127.0.0.1:80", zone_a)},
+                            {makeTestHost(info_, "tcp://127.0.0.1:81", zone_b)},
+                            {makeTestHost(info_, "tcp://127.0.0.1:82", zone_c)}});
   HostsPerLocalitySharedPtr local_hosts_per_locality =
-      makeHostsPerLocality({{makeTestHost(info_, "tcp://127.0.0.1:1", simTime(), zone_a)},
-                            {makeTestHost(info_, "tcp://127.0.0.1:2", simTime(), zone_b)}});
+      makeHostsPerLocality({{makeTestHost(info_, "tcp://127.0.0.1:1", zone_a)},
+                            {makeTestHost(info_, "tcp://127.0.0.1:2", zone_b)}});
 
   hostSet().healthy_hosts_ = *hosts;
   hostSet().hosts_ = *hosts;
@@ -1379,36 +1364,36 @@ TEST_P(RoundRobinLoadBalancerTest, ZoneAwareEmptyLocalities) {
   zone_h.set_zone("H");
 
   HostVectorSharedPtr upstream_hosts(
-      new HostVector({makeTestHost(info_, "tcp://127.0.0.1:80", simTime(), zone_c),
-                      makeTestHost(info_, "tcp://127.0.0.1:81", simTime(), zone_c),
-                      makeTestHost(info_, "tcp://127.0.0.1:82", simTime(), zone_e),
-                      makeTestHost(info_, "tcp://127.0.0.1:83", simTime(), zone_f),
-                      makeTestHost(info_, "tcp://127.0.0.1:84", simTime(), zone_f),
-                      makeTestHost(info_, "tcp://127.0.0.1:85", simTime(), zone_h)}));
+      new HostVector({makeTestHost(info_, "tcp://127.0.0.1:80", zone_c),
+                      makeTestHost(info_, "tcp://127.0.0.1:81", zone_c),
+                      makeTestHost(info_, "tcp://127.0.0.1:82", zone_e),
+                      makeTestHost(info_, "tcp://127.0.0.1:83", zone_f),
+                      makeTestHost(info_, "tcp://127.0.0.1:84", zone_f),
+                      makeTestHost(info_, "tcp://127.0.0.1:85", zone_h)}));
   HostVectorSharedPtr local_hosts(
-      new HostVector({makeTestHost(info_, "tcp://127.0.0.1:0", simTime(), zone_a),
-                      makeTestHost(info_, "tcp://127.0.0.1:1", simTime(), zone_c),
-                      makeTestHost(info_, "tcp://127.0.0.1:2", simTime(), zone_d),
-                      makeTestHost(info_, "tcp://127.0.0.1:2", simTime(), zone_f)}));
+      new HostVector({makeTestHost(info_, "tcp://127.0.0.1:0", zone_a),
+                      makeTestHost(info_, "tcp://127.0.0.1:1", zone_c),
+                      makeTestHost(info_, "tcp://127.0.0.1:2", zone_d),
+                      makeTestHost(info_, "tcp://127.0.0.1:2", zone_f)}));
 
   HostsPerLocalitySharedPtr upstream_hosts_per_locality =
       makeHostsPerLocality({{},
                             {},
-                            {makeTestHost(info_, "tcp://127.0.0.1:80", simTime(), zone_c),
-                             makeTestHost(info_, "tcp://127.0.0.1:81", simTime(), zone_c)},
-                            {makeTestHost(info_, "tcp://127.0.0.1:82", simTime(), zone_e)},
-                            {makeTestHost(info_, "tcp://127.0.0.1:83", simTime(), zone_f),
-                             makeTestHost(info_, "tcp://127.0.0.1:84", simTime(), zone_f)},
+                            {makeTestHost(info_, "tcp://127.0.0.1:80", zone_c),
+                             makeTestHost(info_, "tcp://127.0.0.1:81", zone_c)},
+                            {makeTestHost(info_, "tcp://127.0.0.1:82", zone_e)},
+                            {makeTestHost(info_, "tcp://127.0.0.1:83", zone_f),
+                             makeTestHost(info_, "tcp://127.0.0.1:84", zone_f)},
                             {},
-                            {makeTestHost(info_, "tcp://127.0.0.1:85", simTime(), zone_h)},
+                            {makeTestHost(info_, "tcp://127.0.0.1:85", zone_h)},
                             {}});
 
   HostsPerLocalitySharedPtr local_hosts_per_locality =
-      makeHostsPerLocality({{makeTestHost(info_, "tcp://127.0.0.1:0", simTime(), zone_a)},
-                            {makeTestHost(info_, "tcp://127.0.0.1:0", simTime(), zone_c)},
-                            {makeTestHost(info_, "tcp://127.0.0.1:1", simTime(), zone_d)},
+      makeHostsPerLocality({{makeTestHost(info_, "tcp://127.0.0.1:0", zone_a)},
+                            {makeTestHost(info_, "tcp://127.0.0.1:0", zone_c)},
+                            {makeTestHost(info_, "tcp://127.0.0.1:1", zone_d)},
                             {},
-                            {makeTestHost(info_, "tcp://127.0.0.1:2", simTime(), zone_f)}});
+                            {makeTestHost(info_, "tcp://127.0.0.1:2", zone_f)}});
 
   EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.healthy_panic_threshold", 50))
       .WillRepeatedly(Return(50));
@@ -1476,12 +1461,10 @@ TEST_P(RoundRobinLoadBalancerTest, LowPrecisionForDistribution) {
   envoy::config::core::v3::Locality zone_b;
   zone_b.set_zone("B");
   // upstream_hosts and local_hosts do not matter, zone aware routing is based on per zone hosts.
-  HostVectorSharedPtr upstream_hosts(
-      new HostVector({makeTestHost(info_, "tcp://127.0.0.1:80", simTime())}));
+  HostVectorSharedPtr upstream_hosts(new HostVector({makeTestHost(info_, "tcp://127.0.0.1:80")}));
   hostSet().healthy_hosts_ = *upstream_hosts;
   hostSet().hosts_ = *upstream_hosts;
-  HostVectorSharedPtr local_hosts(
-      new HostVector({makeTestHost(info_, "tcp://127.0.0.1:0", simTime())}));
+  HostVectorSharedPtr local_hosts(new HostVector({makeTestHost(info_, "tcp://127.0.0.1:0")}));
 
   std::vector<HostVector> upstream_hosts_per_locality;
   std::vector<HostVector> local_hosts_per_locality;
@@ -1499,8 +1482,8 @@ TEST_P(RoundRobinLoadBalancerTest, LowPrecisionForDistribution) {
   // situation.
   // Reuse the same host for each zone in all of the structures below to reduce time test takes and
   // this does not impact load balancing logic.
-  HostSharedPtr host_a = makeTestHost(info_, "tcp://127.0.0.1:80", simTime(), zone_a);
-  HostSharedPtr host_b = makeTestHost(info_, "tcp://127.0.0.1:80", simTime(), zone_b);
+  HostSharedPtr host_a = makeTestHost(info_, "tcp://127.0.0.1:80", zone_a);
+  HostSharedPtr host_b = makeTestHost(info_, "tcp://127.0.0.1:80", zone_b);
   HostVector current(45000);
 
   for (int i = 0; i < 45000; ++i) {
@@ -1544,9 +1527,9 @@ TEST_P(RoundRobinLoadBalancerTest, NoZoneAwareRoutingOneZone) {
   if (&hostSet() == &failover_host_set_) { // P = 1 does not support zone-aware routing.
     return;
   }
-  HostVectorSharedPtr hosts(new HostVector({makeTestHost(info_, "tcp://127.0.0.1:80", simTime())}));
+  HostVectorSharedPtr hosts(new HostVector({makeTestHost(info_, "tcp://127.0.0.1:80")}));
   HostsPerLocalitySharedPtr hosts_per_locality =
-      makeHostsPerLocality({{makeTestHost(info_, "tcp://127.0.0.1:81", simTime())}});
+      makeHostsPerLocality({{makeTestHost(info_, "tcp://127.0.0.1:81")}});
 
   hostSet().healthy_hosts_ = *hosts;
   hostSet().hosts_ = *hosts;
@@ -1561,12 +1544,11 @@ TEST_P(RoundRobinLoadBalancerTest, NoZoneAwareRoutingNotHealthy) {
   zone_a.set_zone("A");
   envoy::config::core::v3::Locality zone_b;
   zone_b.set_zone("B");
-  HostVectorSharedPtr hosts(
-      new HostVector({makeTestHost(info_, "tcp://127.0.0.1:80", simTime(), zone_a),
-                      makeTestHost(info_, "tcp://127.0.0.2:80", simTime(), zone_a)}));
+  HostVectorSharedPtr hosts(new HostVector({makeTestHost(info_, "tcp://127.0.0.1:80", zone_a),
+                                            makeTestHost(info_, "tcp://127.0.0.2:80", zone_a)}));
   HostsPerLocalitySharedPtr hosts_per_locality =
-      makeHostsPerLocality({{makeTestHost(info_, "tcp://127.0.0.1:80", simTime(), zone_a),
-                             makeTestHost(info_, "tcp://127.0.0.2:80", simTime(), zone_a)}},
+      makeHostsPerLocality({{makeTestHost(info_, "tcp://127.0.0.1:80", zone_a),
+                             makeTestHost(info_, "tcp://127.0.0.2:80", zone_a)}},
                            true);
 
   hostSet().healthy_hosts_ = *hosts;
@@ -1589,16 +1571,16 @@ TEST_P(RoundRobinLoadBalancerTest, NoZoneAwareRoutingLocalEmpty) {
   envoy::config::core::v3::Locality zone_b;
   zone_b.set_zone("B");
   HostVectorSharedPtr upstream_hosts(
-      new HostVector({makeTestHost(info_, "tcp://127.0.0.1:80", simTime(), zone_a),
-                      makeTestHost(info_, "tcp://127.0.0.1:81", simTime(), zone_b)}));
+      new HostVector({makeTestHost(info_, "tcp://127.0.0.1:80", zone_a),
+                      makeTestHost(info_, "tcp://127.0.0.1:81", zone_b)}));
   HostVectorSharedPtr local_hosts(new HostVector({}, {}));
 
   HostsPerLocalitySharedPtr upstream_hosts_per_locality =
-      makeHostsPerLocality({{makeTestHost(info_, "tcp://127.0.0.1:80", simTime(), zone_a)},
-                            {makeTestHost(info_, "tcp://127.0.0.1:81", simTime(), zone_b)}});
+      makeHostsPerLocality({{makeTestHost(info_, "tcp://127.0.0.1:80", zone_a)},
+                            {makeTestHost(info_, "tcp://127.0.0.1:81", zone_b)}});
   HostsPerLocalitySharedPtr local_hosts_per_locality =
-      makeHostsPerLocality({{makeTestHost(info_, "tcp://127.0.0.1:0", simTime(), zone_a)},
-                            {makeTestHost(info_, "tcp://127.0.0.1:1", simTime(), zone_b)}});
+      makeHostsPerLocality({{makeTestHost(info_, "tcp://127.0.0.1:0", zone_a)},
+                            {makeTestHost(info_, "tcp://127.0.0.1:1", zone_b)}});
 
   EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.healthy_panic_threshold", 50))
       .WillOnce(Return(50))
@@ -1637,16 +1619,16 @@ TEST_P(RoundRobinLoadBalancerTest, NoZoneAwareRoutingLocalEmptyFailTrafficOnPani
   zone_b.set_zone("B");
 
   HostVectorSharedPtr upstream_hosts(
-      new HostVector({makeTestHost(info_, "tcp://127.0.0.1:80", simTime(), zone_a),
-                      makeTestHost(info_, "tcp://127.0.0.1:81", simTime(), zone_b)}));
+      new HostVector({makeTestHost(info_, "tcp://127.0.0.1:80", zone_a),
+                      makeTestHost(info_, "tcp://127.0.0.1:81", zone_b)}));
   HostVectorSharedPtr local_hosts(new HostVector({}, {}));
 
   HostsPerLocalitySharedPtr upstream_hosts_per_locality =
-      makeHostsPerLocality({{makeTestHost(info_, "tcp://127.0.0.1:80", simTime(), zone_a)},
-                            {makeTestHost(info_, "tcp://127.0.0.1:81", simTime(), zone_b)}});
+      makeHostsPerLocality({{makeTestHost(info_, "tcp://127.0.0.1:80", zone_a)},
+                            {makeTestHost(info_, "tcp://127.0.0.1:81", zone_b)}});
   HostsPerLocalitySharedPtr local_hosts_per_locality =
-      makeHostsPerLocality({{makeTestHost(info_, "tcp://127.0.0.1:0", simTime(), zone_a)},
-                            {makeTestHost(info_, "tcp://127.0.0.1:1", simTime(), zone_b)}});
+      makeHostsPerLocality({{makeTestHost(info_, "tcp://127.0.0.1:0", zone_a)},
+                            {makeTestHost(info_, "tcp://127.0.0.1:1", zone_b)}});
 
   EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.healthy_panic_threshold", 50))
       .WillOnce(Return(50))
@@ -1682,13 +1664,13 @@ TEST_P(RoundRobinLoadBalancerTest, NoZoneAwareRoutingNoLocalLocality) {
   envoy::config::core::v3::Locality zone_b;
   zone_b.set_zone("B");
   HostVectorSharedPtr upstream_hosts(
-      new HostVector({makeTestHost(info_, "tcp://127.0.0.1:80", simTime(), zone_a),
-                      makeTestHost(info_, "tcp://127.0.0.1:81", simTime(), zone_b)}));
+      new HostVector({makeTestHost(info_, "tcp://127.0.0.1:80", zone_a),
+                      makeTestHost(info_, "tcp://127.0.0.1:81", zone_b)}));
   HostVectorSharedPtr local_hosts(new HostVector());
 
   HostsPerLocalitySharedPtr upstream_hosts_per_locality =
-      makeHostsPerLocality({{makeTestHost(info_, "tcp://127.0.0.1:80", simTime(), zone_a)},
-                            {makeTestHost(info_, "tcp://127.0.0.1:81", simTime(), zone_b)}},
+      makeHostsPerLocality({{makeTestHost(info_, "tcp://127.0.0.1:80", zone_a)},
+                            {makeTestHost(info_, "tcp://127.0.0.1:81", zone_b)}},
                            true);
   const HostsPerLocalitySharedPtr& local_hosts_per_locality = upstream_hosts_per_locality;
 
@@ -1738,7 +1720,7 @@ TEST_P(RoundRobinLoadBalancerTest, SlowStartWithMinWeightPercent) {
 TEST_P(RoundRobinLoadBalancerTest, SlowStartNoWait) {
   round_robin_lb_config_.mutable_slow_start_config()->mutable_slow_start_window()->set_seconds(60);
   simTime().advanceTimeWait(std::chrono::seconds(1));
-  auto host1 = makeTestHost(info_, "tcp://127.0.0.1:80", simTime());
+  auto host1 = makeTestHost(info_, "tcp://127.0.0.1:80");
   host_set_.hosts_ = {host1};
 
   init(true);
@@ -1757,7 +1739,7 @@ TEST_P(RoundRobinLoadBalancerTest, SlowStartNoWait) {
   simTime().advanceTimeWait(std::chrono::seconds(56));
 
   hosts_added.clear();
-  auto host2 = makeTestHost(info_, "tcp://127.0.0.1:90", simTime());
+  auto host2 = makeTestHost(info_, "tcp://127.0.0.1:90");
 
   hosts_added.push_back(host2);
 
@@ -1811,7 +1793,7 @@ TEST_P(RoundRobinLoadBalancerTest, SlowStartNoWait) {
 TEST_P(RoundRobinLoadBalancerTest, SlowStartWithActiveHC) {
   round_robin_lb_config_.mutable_slow_start_config()->mutable_slow_start_window()->set_seconds(10);
   simTime().advanceTimeWait(std::chrono::seconds(1));
-  auto host1 = makeTestHost(info_, "tcp://127.0.0.1:80", simTime());
+  auto host1 = makeTestHost(info_, "tcp://127.0.0.1:80");
   host1->healthFlagSet(Host::HealthFlag::FAILED_ACTIVE_HC);
   host_set_.hosts_ = {host1};
   init(true);
@@ -1825,7 +1807,7 @@ TEST_P(RoundRobinLoadBalancerTest, SlowStartWithActiveHC) {
   EXPECT_EQ(std::chrono::milliseconds(1000), latest_host_added_time_ms);
   simTime().advanceTimeWait(std::chrono::seconds(5));
   hosts_added.clear();
-  auto host2 = makeTestHost(info_, "tcp://127.0.0.1:90", simTime());
+  auto host2 = makeTestHost(info_, "tcp://127.0.0.1:90");
   simTime().advanceTimeWait(std::chrono::seconds(1));
   host2->setLastHcPassTime(simTime().monotonicTime());
   hosts_added.push_back(host2);
@@ -1894,9 +1876,9 @@ TEST_P(RoundRobinLoadBalancerTest, SlowStartWithRuntimeAggression) {
 
   simTime().advanceTimeWait(std::chrono::seconds(1));
 
-  hostSet().healthy_hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:80", simTime(), 1),
-                              makeTestHost(info_, "tcp://127.0.0.1:90", simTime(), 1),
-                              makeTestHost(info_, "tcp://127.0.0.1:100", simTime(), 1)};
+  hostSet().healthy_hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:80", 1),
+                              makeTestHost(info_, "tcp://127.0.0.1:90", 1),
+                              makeTestHost(info_, "tcp://127.0.0.1:100", 1)};
 
   hostSet().hosts_ = hostSet().healthy_hosts_;
   hostSet().runCallbacks({}, {});
@@ -1919,7 +1901,7 @@ TEST_P(RoundRobinLoadBalancerTest, SlowStartWithRuntimeAggression) {
 
   simTime().advanceTimeWait(std::chrono::seconds(4));
   HostVector hosts_added;
-  auto host4 = makeTestHost(info_, "tcp://127.0.0.1:110", simTime());
+  auto host4 = makeTestHost(info_, "tcp://127.0.0.1:110");
   hostSet().hosts_.push_back(host4);
   hostSet().healthy_hosts_.push_back(host4);
   EXPECT_CALL(runtime_.snapshot_, getDouble("aggression", 1.0)).WillRepeatedly(Return(1.5));
@@ -1962,7 +1944,7 @@ TEST_P(RoundRobinLoadBalancerTest, SlowStartNoWaitNonLinearAggression) {
   init(true);
 
   // As no healthcheck is configured, hosts would enter slow start immediately.
-  hostSet().healthy_hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:80", simTime())};
+  hostSet().healthy_hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:80")};
   hostSet().hosts_ = hostSet().healthy_hosts_;
   simTime().advanceTimeWait(std::chrono::seconds(5));
   // Host1 is 5 secs in slow start, its weight is scaled with max((5/60)^(1/2), 0.1)=0.28 factor.
@@ -1972,7 +1954,7 @@ TEST_P(RoundRobinLoadBalancerTest, SlowStartNoWaitNonLinearAggression) {
   simTime().advanceTimeWait(std::chrono::seconds(56));
 
   HostVector hosts_added;
-  auto host2 = makeTestHost(info_, "tcp://127.0.0.1:90", simTime());
+  auto host2 = makeTestHost(info_, "tcp://127.0.0.1:90");
 
   hosts_added.push_back(host2);
 
@@ -2028,7 +2010,7 @@ TEST_P(RoundRobinLoadBalancerTest, SlowStartNoWaitMinWeightPercent35) {
   round_robin_lb_config_.mutable_slow_start_config()->mutable_slow_start_window()->set_seconds(60);
   round_robin_lb_config_.mutable_slow_start_config()->mutable_min_weight_percent()->set_value(35);
   simTime().advanceTimeWait(std::chrono::seconds(1));
-  auto host1 = makeTestHost(info_, "tcp://127.0.0.1:80", simTime());
+  auto host1 = makeTestHost(info_, "tcp://127.0.0.1:80");
   host_set_.hosts_ = {host1};
 
   init(true);
@@ -2047,7 +2029,7 @@ TEST_P(RoundRobinLoadBalancerTest, SlowStartNoWaitMinWeightPercent35) {
   simTime().advanceTimeWait(std::chrono::seconds(56));
 
   hosts_added.clear();
-  auto host2 = makeTestHost(info_, "tcp://127.0.0.1:90", simTime());
+  auto host2 = makeTestHost(info_, "tcp://127.0.0.1:90");
 
   hosts_added.push_back(host2);
 

--- a/test/extensions/load_balancing_policies/subset/subset_test.cc
+++ b/test/extensions/load_balancing_policies/subset/subset_test.cc
@@ -487,7 +487,7 @@ public:
           .set_string_value(m_it.second);
     }
 
-    return makeTestHost(info_, url, m, simTime());
+    return makeTestHost(info_, url, m);
   }
 
   HostSharedPtr makeHost(const std::string& url, const HostMetadata& metadata,
@@ -498,7 +498,7 @@ public:
           .set_string_value(m_it.second);
     }
 
-    return makeTestHost(info_, url, m, locality, simTime());
+    return makeTestHost(info_, url, m, locality);
   }
 
   HostSharedPtr makeHost(const std::string& url, const HostListMetadata& metadata) {
@@ -511,7 +511,7 @@ public:
       }
     }
 
-    return makeTestHost(info_, url, m, simTime());
+    return makeTestHost(info_, url, m);
   }
 
   ProtobufWkt::Struct makeDefaultSubset(HostMetadata metadata) {
@@ -1682,7 +1682,7 @@ TEST_F(SubsetLoadBalancerTest, IgnoresHostsWithoutMetadata) {
   EXPECT_CALL(subset_info_, subsetSelectors()).WillRepeatedly(ReturnRef(subset_selectors));
 
   HostVector hosts;
-  hosts.emplace_back(makeTestHost(info_, "tcp://127.0.0.1:80", simTime()));
+  hosts.emplace_back(makeTestHost(info_, "tcp://127.0.0.1:80"));
   hosts.emplace_back(makeHost("tcp://127.0.0.1:81", {{"version", "1.0"}}));
 
   host_set_.hosts_ = hosts;

--- a/test/extensions/stats_sinks/common/statsd/statsd_test.cc
+++ b/test/extensions/stats_sinks/common/statsd/statsd_test.cc
@@ -49,7 +49,7 @@ public:
     Upstream::MockHost::MockCreateConnectionData conn_info;
     conn_info.connection_ = connection_;
     conn_info.host_description_ = Upstream::makeTestHost(
-        std::make_unique<NiceMock<Upstream::MockClusterInfo>>(), "tcp://127.0.0.1:80", simTime());
+        std::make_unique<NiceMock<Upstream::MockClusterInfo>>(), "tcp://127.0.0.1:80");
 
     EXPECT_CALL(cluster_manager_.thread_local_cluster_, tcpConn_(_)).WillOnce(Return(conn_info));
     EXPECT_CALL(*connection_, setConnectionStats(_));

--- a/test/integration/clusters/custom_static_cluster.cc
+++ b/test/integration/clusters/custom_static_cluster.cc
@@ -29,7 +29,7 @@ Upstream::HostSharedPtr CustomStaticCluster::makeHost() {
       std::make_shared<const envoy::config::core::v3::Metadata>(info()->metadata()), nullptr, 1,
       envoy::config::core::v3::Locality::default_instance(),
       envoy::config::endpoint::v3::Endpoint::HealthCheckConfig::default_instance(), priority_,
-      envoy::config::core::v3::UNKNOWN, time_source_)};
+      envoy::config::core::v3::UNKNOWN)};
 }
 
 Upstream::ThreadAwareLoadBalancerPtr CustomStaticCluster::threadAwareLb() {

--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -297,8 +297,7 @@ IntegrationCodecClientPtr HttpIntegrationTest::makeRawHttpConnection(
   }
 
   Upstream::HostDescriptionConstSharedPtr host_description{Upstream::makeTestHostDescription(
-      cluster, fmt::format("tcp://{}:80", Network::Test::getLoopbackAddressUrlString(version_)),
-      timeSystem())};
+      cluster, fmt::format("tcp://{}:80", Network::Test::getLoopbackAddressUrlString(version_)))};
   // This call may fail in QUICHE because of INVALID_VERSION. QUIC connection doesn't support
   // in-connection version negotiation.
   auto codec = std::make_unique<IntegrationCodecClient>(*dispatcher_, random_, std::move(conn),

--- a/test/integration/listener_extension_discovery_integration_test.cc
+++ b/test/integration/listener_extension_discovery_integration_test.cc
@@ -910,8 +910,7 @@ TEST_P(QuicListenerExtensionDiscoveryIntegrationTest, BadEcdsUpdateWithoutDefaul
   Network::ClientConnectionPtr conn = makeClientConnection(lookupPort(port_name_));
   std::shared_ptr<Upstream::MockClusterInfo> cluster{new NiceMock<Upstream::MockClusterInfo>()};
   Upstream::HostDescriptionConstSharedPtr host_description{Upstream::makeTestHostDescription(
-      cluster, fmt::format("tcp://{}:80", Network::Test::getLoopbackAddressUrlString(version_)),
-      timeSystem())};
+      cluster, fmt::format("tcp://{}:80", Network::Test::getLoopbackAddressUrlString(version_)))};
   auto codec = std::make_unique<IntegrationCodecClient>(
       *dispatcher_, random_, std::move(conn), host_description, downstream_protocol_, true);
   EXPECT_TRUE(codec->disconnected());

--- a/test/integration/quic_http_integration_test.h
+++ b/test/integration/quic_http_integration_test.h
@@ -288,8 +288,7 @@ public:
       cluster->http3_options_.set_disable_qpack(*disable_qpack);
     }
     Upstream::HostDescriptionConstSharedPtr host_description{Upstream::makeTestHostDescription(
-        cluster, fmt::format("tcp://{}:80", Network::Test::getLoopbackAddressUrlString(version_)),
-        timeSystem())};
+        cluster, fmt::format("tcp://{}:80", Network::Test::getLoopbackAddressUrlString(version_)))};
     // This call may fail in QUICHE because of INVALID_VERSION. QUIC connection doesn't support
     // in-connection version negotiation.
     auto codec = std::make_unique<IntegrationCodecClient>(*dispatcher_, random_, std::move(conn),

--- a/test/integration/utility.cc
+++ b/test/integration/utility.cc
@@ -227,8 +227,7 @@ IntegrationUtil::makeSingleRequest(const Network::Address::InstanceConstSharedPt
           *Network::Utility::resolveUrl(
               fmt::format("{}://127.0.0.1:80", (type == Http::CodecType::HTTP3 ? "udp" : "tcp"))),
           nullptr, nullptr, envoy::config::core::v3::Locality().default_instance(),
-          envoy::config::endpoint::v3::Endpoint::HealthCheckConfig::default_instance(), 0,
-          time_system));
+          envoy::config::endpoint::v3::Endpoint::HealthCheckConfig::default_instance(), 0));
 
   if (type <= Http::CodecType::HTTP2) {
     Http::CodecClientProd client(type,

--- a/test/server/admin/clusters_handler_test.cc
+++ b/test/server/admin/clusters_handler_test.cc
@@ -248,7 +248,7 @@ fake_cluster::1.2.3.4:80::local_origin_success_rate::93.2
 TEST_P(AdminInstanceTest, TestSetHealthFlag) {
   std::shared_ptr<Upstream::MockClusterInfo> cluster{new NiceMock<Upstream::MockClusterInfo>()};
   Event::MockDispatcher dispatcher;
-  auto host = Upstream::makeTestHost(cluster, "tcp://127.0.0.1:9000", dispatcher.timeSource());
+  auto host = Upstream::makeTestHost(cluster, "tcp://127.0.0.1:9000");
   envoy::admin::v3::HostHealthStatus health_status;
 
   // FAILED_ACTIVE_HC


### PR DESCRIPTION
Commit Message: host/cluster: remove unused data-members creation_time_ and time_source_
Additional Description:
Explanation for the large PR motivation:
This PR removes [HostDescriptionImplBase::creation_time_](https://github.com/envoyproxy/envoy/blob/a0a45b72e5161f42002f9c17feb542ad8b7c6da5/source/common/upstream/upstream_impl.h#L280), which makes [ClusterImplBase::time_source_](https://github.com/envoyproxy/envoy/blob/a0a45b72e5161f42002f9c17feb542ad8b7c6da5/source/common/upstream/upstream_impl.h#L1289) redundant for many cases.
The types of clusters that do need the time-source (e.g., Redis, dynamic_forward_proxy) now have theid own time_source_ data member.

Apologies for the large PR, this change touches many tests.

Risk Level: low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A