### PR TITLE
dynamic_modules: support additional attributes about ssl connection info

### DIFF
--- a/source/extensions/dynamic_modules/abi.h
+++ b/source/extensions/dynamic_modules/abi.h
@@ -353,7 +353,7 @@ typedef enum {
   // connection.uri_san_peer_certificate
   envoy_dynamic_module_type_attribute_id_ConnectionUriSanPeerCertificate,
   // connection.sha256_peer_certificate_digest
-  envoy_dynamic_module_type_attribute_id_ConnectionSha256PeerCertificate,
+  envoy_dynamic_module_type_attribute_id_ConnectionSha256PeerCertificateDigest,
   // connection.transport_failure_reason
   envoy_dynamic_module_type_attribute_id_ConnectionTransportFailureReason,
   // connection.termination_details

--- a/source/extensions/dynamic_modules/abi.h
+++ b/source/extensions/dynamic_modules/abi.h
@@ -341,21 +341,21 @@ typedef enum {
   // connection.tls_version
   envoy_dynamic_module_type_attribute_id_ConnectionTlsVersion,
   // connection.subject_local_certificate
-  envoy_dynamic_module_type_attribute_id_ConnectionSubjectLocalCertifica,
+  envoy_dynamic_module_type_attribute_id_ConnectionSubjectLocalCertificate,
   // connection.subject_peer_certificate
-  envoy_dynamic_module_type_attribute_id_ConnectionSubjectPeerCertificat,
+  envoy_dynamic_module_type_attribute_id_ConnectionSubjectPeerCertificate,
   // connection.dns_san_local_certificate
-  envoy_dynamic_module_type_attribute_id_ConnectionDnsSanLocalCertifica,
+  envoy_dynamic_module_type_attribute_id_ConnectionDnsSanLocalCertificate,
   // connection.dns_san_peer_certificate
-  envoy_dynamic_module_type_attribute_id_ConnectionDnsSanPeerCertificat,
+  envoy_dynamic_module_type_attribute_id_ConnectionDnsSanPeerCertificate,
   // connection.uri_san_local_certificate
-  envoy_dynamic_module_type_attribute_id_ConnectionUriSanLocalCertifica,
+  envoy_dynamic_module_type_attribute_id_ConnectionUriSanLocalCertificate,
   // connection.uri_san_peer_certificate
-  envoy_dynamic_module_type_attribute_id_ConnectionUriSanPeerCertificat,
+  envoy_dynamic_module_type_attribute_id_ConnectionUriSanPeerCertificate,
   // connection.sha256_peer_certificate_digest
   envoy_dynamic_module_type_attribute_id_ConnectionSha256PeerCertificate,
   // connection.transport_failure_reason
-  envoy_dynamic_module_type_attribute_id_ConnectionTransportFailureReaso,
+  envoy_dynamic_module_type_attribute_id_ConnectionTransportFailureReason,
   // connection.termination_details
   envoy_dynamic_module_type_attribute_id_ConnectionTerminationDetails,
   // upstream.address
@@ -377,7 +377,7 @@ typedef enum {
   // upstream.uri_san_peer_certificate
   envoy_dynamic_module_type_attribute_id_UpstreamUriSanPeerCertificate,
   // upstream.sha256_peer_certificate_digest
-  envoy_dynamic_module_type_attribute_id_UpstreamSha256PeerCertificateD,
+  envoy_dynamic_module_type_attribute_id_UpstreamSha256PeerCertificateDigest,
   // upstream.local_address
   envoy_dynamic_module_type_attribute_id_UpstreamLocalAddress,
   // upstream.transport_failure_reason

--- a/source/extensions/dynamic_modules/abi_version.h
+++ b/source/extensions/dynamic_modules/abi_version.h
@@ -6,7 +6,7 @@ namespace DynamicModules {
 #endif
 // This is the ABI version calculated as a sha256 hash of the ABI header files. When the ABI
 // changes, this value must change, and the correctness of this value is checked by the test.
-const char* kAbiVersion = "cb17cd829c177bc6b75a920283a3347b90d5aaa4d5e723eaa33bad31c8c5b9a9";
+const char* kAbiVersion = "0ca64cbfdbe768cdb37d02185fe36ad3c3103c8bc258110e0dedf824ce2b9174";
 
 #ifdef __cplusplus
 } // namespace DynamicModules

--- a/source/extensions/filters/http/dynamic_modules/abi_impl.cc
+++ b/source/extensions/filters/http/dynamic_modules/abi_impl.cc
@@ -1,10 +1,11 @@
+#include <functional>
+
 #include "source/common/http/header_map_impl.h"
 #include "source/common/http/message_impl.h"
 #include "source/common/http/utility.h"
 #include "source/common/router/string_accessor_impl.h"
 #include "source/extensions/dynamic_modules/abi.h"
 #include "source/extensions/filters/http/dynamic_modules/filter.h"
-#include <functional>
 
 namespace Envoy {
 namespace Extensions {
@@ -51,10 +52,12 @@ bool headerAsAttribute(HeadersMapOptConstRef map, const Envoy::Http::LowerCaseSt
   return size > 0;
 }
 
-bool getFirstSanEntry(OptRef<const Network::Connection> connection,
-                      std::function<absl::Span<const std::string>(const Ssl::ConnectionInfoConstSharedPtr)> get_san_func,
-                      envoy_dynamic_module_type_buffer_envoy_ptr* result_buffer_ptr,
-                      size_t* result_buffer_length_ptr) {
+bool getFirstSanEntry(
+    OptRef<const Network::Connection> connection,
+    std::function<absl::Span<const std::string>(const Ssl::ConnectionInfoConstSharedPtr)>
+        get_san_func,
+    envoy_dynamic_module_type_buffer_envoy_ptr* result_buffer_ptr,
+    size_t* result_buffer_length_ptr) {
   if (!connection.has_value() || !connection->ssl()) {
     return false;
   }
@@ -66,7 +69,7 @@ bool getFirstSanEntry(OptRef<const Network::Connection> connection,
   const auto& first_entry = sans[0];
   *result_buffer_ptr = const_cast<char*>(first_entry.data());
   *result_buffer_length_ptr = first_entry.size();
-  return true;  
+  return true;
 }
 
 size_t envoy_dynamic_module_callback_http_get_request_header(
@@ -880,32 +883,36 @@ bool envoy_dynamic_module_callback_http_filter_get_attribute_string(
     break;
   }
   case envoy_dynamic_module_type_attribute_id_ConnectionDnsSanLocalCertificate: {
-    return getFirstSanEntry(filter->connection(), 
-                [](const Ssl::ConnectionInfoConstSharedPtr ssl) -> absl::Span<const std::string> {
-                  return ssl->dnsSansLocalCertificate();
-                },
-                result, result_length);    
+    return getFirstSanEntry(
+        filter->connection(),
+        [](const Ssl::ConnectionInfoConstSharedPtr ssl) -> absl::Span<const std::string> {
+          return ssl->dnsSansLocalCertificate();
+        },
+        result, result_length);
   }
   case envoy_dynamic_module_type_attribute_id_ConnectionDnsSanPeerCertificate: {
-    return getFirstSanEntry(filter->connection(), 
-                [](const Ssl::ConnectionInfoConstSharedPtr ssl) -> absl::Span<const std::string> {
-                  return ssl->dnsSansPeerCertificate();
-                },
-                result, result_length);
+    return getFirstSanEntry(
+        filter->connection(),
+        [](const Ssl::ConnectionInfoConstSharedPtr ssl) -> absl::Span<const std::string> {
+          return ssl->dnsSansPeerCertificate();
+        },
+        result, result_length);
   }
   case envoy_dynamic_module_type_attribute_id_ConnectionUriSanLocalCertificate: {
-    return getFirstSanEntry(filter->connection(), 
-                [](const Ssl::ConnectionInfoConstSharedPtr ssl) -> absl::Span<const std::string> {
-                  return ssl->uriSanLocalCertificate();
-                },
-                result, result_length);
+    return getFirstSanEntry(
+        filter->connection(),
+        [](const Ssl::ConnectionInfoConstSharedPtr ssl) -> absl::Span<const std::string> {
+          return ssl->uriSanLocalCertificate();
+        },
+        result, result_length);
   }
   case envoy_dynamic_module_type_attribute_id_ConnectionUriSanPeerCertificate: {
-    return getFirstSanEntry(filter->connection(), 
-                [](const Ssl::ConnectionInfoConstSharedPtr ssl) -> absl::Span<const std::string> {
-                  return ssl->uriSanPeerCertificate();
-                },
-                result, result_length);
+    return getFirstSanEntry(
+        filter->connection(),
+        [](const Ssl::ConnectionInfoConstSharedPtr ssl) -> absl::Span<const std::string> {
+          return ssl->uriSanPeerCertificate();
+        },
+        result, result_length);
   }
   case envoy_dynamic_module_type_attribute_id_ConnectionSha256PeerCertificate: {
     const auto connection = filter->connection();
@@ -989,7 +996,7 @@ bool envoy_dynamic_module_callback_http_filter_get_attribute_int(
       ok = true;
     }
     break;
-  }  
+  }
   default:
     ENVOY_LOG_TO_LOGGER(Envoy::Logger::Registry::getLog(Envoy::Logger::Id::dynamic_modules), error,
                         "Unsupported attribute ID {} as int", static_cast<int64_t>(attribute_id));

--- a/source/extensions/filters/http/dynamic_modules/abi_impl.cc
+++ b/source/extensions/filters/http/dynamic_modules/abi_impl.cc
@@ -882,38 +882,6 @@ bool envoy_dynamic_module_callback_http_filter_get_attribute_string(
     }
     break;
   }
-  case envoy_dynamic_module_type_attribute_id_ConnectionDnsSanLocalCertificate: {
-    return getFirstSanEntry(
-        filter->connection(),
-        [](const Ssl::ConnectionInfoConstSharedPtr ssl) -> absl::Span<const std::string> {
-          return ssl->dnsSansLocalCertificate();
-        },
-        result, result_length);
-  }
-  case envoy_dynamic_module_type_attribute_id_ConnectionDnsSanPeerCertificate: {
-    return getFirstSanEntry(
-        filter->connection(),
-        [](const Ssl::ConnectionInfoConstSharedPtr ssl) -> absl::Span<const std::string> {
-          return ssl->dnsSansPeerCertificate();
-        },
-        result, result_length);
-  }
-  case envoy_dynamic_module_type_attribute_id_ConnectionUriSanLocalCertificate: {
-    return getFirstSanEntry(
-        filter->connection(),
-        [](const Ssl::ConnectionInfoConstSharedPtr ssl) -> absl::Span<const std::string> {
-          return ssl->uriSanLocalCertificate();
-        },
-        result, result_length);
-  }
-  case envoy_dynamic_module_type_attribute_id_ConnectionUriSanPeerCertificate: {
-    return getFirstSanEntry(
-        filter->connection(),
-        [](const Ssl::ConnectionInfoConstSharedPtr ssl) -> absl::Span<const std::string> {
-          return ssl->uriSanPeerCertificate();
-        },
-        result, result_length);
-  }
   case envoy_dynamic_module_type_attribute_id_ConnectionSha256PeerCertificateDigest: {
     const auto connection = filter->connection();
     if (connection) {
@@ -927,6 +895,34 @@ bool envoy_dynamic_module_callback_http_filter_get_attribute_string(
     }
     break;
   }
+  case envoy_dynamic_module_type_attribute_id_ConnectionDnsSanLocalCertificate:
+    return getFirstSanEntry(
+        filter->connection(),
+        [](const Ssl::ConnectionInfoConstSharedPtr ssl) -> absl::Span<const std::string> {
+          return ssl->dnsSansLocalCertificate();
+        },
+        result, result_length);
+  case envoy_dynamic_module_type_attribute_id_ConnectionDnsSanPeerCertificate:
+    return getFirstSanEntry(
+        filter->connection(),
+        [](const Ssl::ConnectionInfoConstSharedPtr ssl) -> absl::Span<const std::string> {
+          return ssl->dnsSansPeerCertificate();
+        },
+        result, result_length);
+  case envoy_dynamic_module_type_attribute_id_ConnectionUriSanLocalCertificate:
+    return getFirstSanEntry(
+        filter->connection(),
+        [](const Ssl::ConnectionInfoConstSharedPtr ssl) -> absl::Span<const std::string> {
+          return ssl->uriSanLocalCertificate();
+        },
+        result, result_length);
+  case envoy_dynamic_module_type_attribute_id_ConnectionUriSanPeerCertificate:
+    return getFirstSanEntry(
+        filter->connection(),
+        [](const Ssl::ConnectionInfoConstSharedPtr ssl) -> absl::Span<const std::string> {
+          return ssl->uriSanPeerCertificate();
+        },
+        result, result_length);
   default:
     ENVOY_LOG_TO_LOGGER(Envoy::Logger::Registry::getLog(Envoy::Logger::Id::dynamic_modules), error,
                         "Unsupported attribute ID {} as string",

--- a/source/extensions/filters/http/dynamic_modules/abi_impl.cc
+++ b/source/extensions/filters/http/dynamic_modules/abi_impl.cc
@@ -914,7 +914,7 @@ bool envoy_dynamic_module_callback_http_filter_get_attribute_string(
         },
         result, result_length);
   }
-  case envoy_dynamic_module_type_attribute_id_ConnectionSha256PeerCertificate: {
+  case envoy_dynamic_module_type_attribute_id_ConnectionSha256PeerCertificateDigest: {
     const auto connection = filter->connection();
     if (connection) {
       const auto ssl = connection->ssl();

--- a/source/extensions/filters/http/dynamic_modules/filter.h
+++ b/source/extensions/filters/http/dynamic_modules/filter.h
@@ -1,10 +1,11 @@
 #pragma once
 
+#include <cstddef>
+#include <optional>
+
 #include "source/extensions/dynamic_modules/dynamic_modules.h"
 #include "source/extensions/filters/http/common/pass_through_filter.h"
 #include "source/extensions/filters/http/dynamic_modules/filter_config.h"
-#include <cstddef>
-#include <optional>
 
 namespace Envoy {
 namespace Extensions {
@@ -132,8 +133,8 @@ public:
   }
 
   /**
-  * Helper to get the connection information
-  */
+   * Helper to get the connection information
+   */
   OptRef<const Network::Connection> connection() {
     auto cb = callbacks();
     if (cb == nullptr) {

--- a/source/extensions/filters/http/dynamic_modules/filter.h
+++ b/source/extensions/filters/http/dynamic_modules/filter.h
@@ -1,8 +1,5 @@
 #pragma once
 
-#include <cstddef>
-#include <optional>
-
 #include "source/extensions/dynamic_modules/dynamic_modules.h"
 #include "source/extensions/filters/http/common/pass_through_filter.h"
 #include "source/extensions/filters/http/dynamic_modules/filter_config.h"

--- a/source/extensions/filters/http/dynamic_modules/filter.h
+++ b/source/extensions/filters/http/dynamic_modules/filter.h
@@ -3,6 +3,8 @@
 #include "source/extensions/dynamic_modules/dynamic_modules.h"
 #include "source/extensions/filters/http/common/pass_through_filter.h"
 #include "source/extensions/filters/http/dynamic_modules/filter_config.h"
+#include <cstddef>
+#include <optional>
 
 namespace Envoy {
 namespace Extensions {
@@ -127,6 +129,17 @@ public:
       return stream_info->upstreamInfo().get();
     }
     return nullptr;
+  }
+
+  /**
+  * Helper to get the connection information
+  */
+  OptRef<const Network::Connection> connection() {
+    auto cb = callbacks();
+    if (cb == nullptr) {
+      return {};
+    }
+    return cb->connection();
   }
 
   /**

--- a/test/extensions/dynamic_modules/http/BUILD
+++ b/test/extensions/dynamic_modules/http/BUILD
@@ -68,6 +68,8 @@ envoy_cc_test(
     deps = [
         "//source/extensions/filters/http/dynamic_modules:abi_impl",
         "//test/mocks/http:http_mocks",
+        "//test/mocks/network:network_mocks",
+        "//test/mocks/ssl:ssl_mocks",
     ],
 )
 

--- a/test/extensions/dynamic_modules/http/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/http/abi_impl_test.cc
@@ -910,10 +910,15 @@ TEST(ABIImpl, GetAttributes) {
   EXPECT_EQ(std::string(result_str_ptr, result_str_length), "/api/v1/action");
 
   // empty connection, should return false
+  DynamicModuleHttpFilter filter_without_callbacks{nullptr};
+  EXPECT_FALSE(envoy_dynamic_module_callback_http_filter_get_attribute_string(
+      &filter_without_callbacks, envoy_dynamic_module_type_attribute_id_ConnectionTlsVersion,
+      &result_str_ptr, &result_str_length));
+
   EXPECT_CALL(callbacks, connection()).WillRepeatedly(testing::Return(absl::nullopt));
   EXPECT_FALSE(envoy_dynamic_module_callback_http_filter_get_attribute_string(
-      &filter, envoy_dynamic_module_type_attribute_id_ConnectionTlsVersion, &result_str_ptr,
-      &result_str_length));
+      &filter, envoy_dynamic_module_type_attribute_id_ConnectionUriSanPeerCertificate,
+      &result_str_ptr, &result_str_length));
 
   // tests for TLS connection attributes
   const Network::MockConnection connection;

--- a/test/extensions/dynamic_modules/http/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/http/abi_impl_test.cc
@@ -1,7 +1,3 @@
-#include <cstddef>
-#include <memory>
-#include <string>
-
 #include "source/extensions/filters/http/dynamic_modules/filter.h"
 
 #include "test/mocks/http/mocks.h"
@@ -9,8 +5,6 @@
 #include "test/mocks/ssl/mocks.h"
 #include "test/mocks/stream_info/mocks.h"
 #include "test/test_common/utility.h"
-
-#include "gmock/gmock.h"
 
 namespace Envoy {
 namespace Extensions {

--- a/test/extensions/dynamic_modules/http/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/http/abi_impl_test.cc
@@ -744,6 +744,7 @@ TEST(ABIImpl, ClearRouteCache) {
 }
 
 TEST(ABIImpl, GetAttributes) {
+  DynamicModuleHttpFilter filter_without_callbacks{nullptr};
   DynamicModuleHttpFilter filter{nullptr};
   Http::MockStreamDecoderFilterCallbacks callbacks;
   StreamInfo::MockStreamInfo stream_info;
@@ -910,7 +911,6 @@ TEST(ABIImpl, GetAttributes) {
   EXPECT_EQ(std::string(result_str_ptr, result_str_length), "/api/v1/action");
 
   // empty connection, should return false
-  DynamicModuleHttpFilter filter_without_callbacks{nullptr};
   EXPECT_FALSE(envoy_dynamic_module_callback_http_filter_get_attribute_string(
       &filter_without_callbacks, envoy_dynamic_module_type_attribute_id_ConnectionTlsVersion,
       &result_str_ptr, &result_str_length));
@@ -1004,6 +1004,9 @@ TEST(ABIImpl, GetAttributes) {
   EXPECT_EQ(std::string(result_str_ptr, result_str_length), sans[0]);
 
   // envoy_dynamic_module_type_attribute_id_ResponseCode
+  EXPECT_FALSE(envoy_dynamic_module_callback_http_filter_get_attribute_int(
+      &filter_without_callbacks, envoy_dynamic_module_type_attribute_id_ResponseCode,
+      &result_number));
   EXPECT_TRUE(envoy_dynamic_module_callback_http_filter_get_attribute_int(
       &filter, envoy_dynamic_module_type_attribute_id_ResponseCode, &result_number));
   EXPECT_EQ(result_number, 200);

--- a/test/extensions/dynamic_modules/http/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/http/abi_impl_test.cc
@@ -1,12 +1,13 @@
+#include <memory>
+#include <string>
+
 #include "source/extensions/filters/http/dynamic_modules/filter.h"
 
 #include "test/mocks/http/mocks.h"
-#include "test/mocks/stream_info/mocks.h"
 #include "test/mocks/network/mocks.h"
 #include "test/mocks/ssl/mocks.h"
+#include "test/mocks/stream_info/mocks.h"
 #include "test/test_common/utility.h"
-#include <memory>
-#include <string>
 
 namespace Envoy {
 namespace Extensions {
@@ -907,19 +908,21 @@ TEST(ABIImpl, GetAttributes) {
 
   // test TLS connection attributes
   const Network::MockConnection connection;
-  EXPECT_CALL(callbacks, connection()).WillRepeatedly(testing::Return(makeOptRef(dynamic_cast<const Network::Connection&>(connection))));
+  EXPECT_CALL(callbacks, connection())
+      .WillRepeatedly(
+          testing::Return(makeOptRef(dynamic_cast<const Network::Connection&>(connection))));
   EXPECT_CALL(connection, ssl()).WillRepeatedly(testing::Return(nullptr));
   EXPECT_FALSE(envoy_dynamic_module_callback_http_filter_get_attribute_string(
-  &filter, envoy_dynamic_module_type_attribute_id_ConnectionTlsVersion,
-  &result_str_ptr, &result_str_length));
+      &filter, envoy_dynamic_module_type_attribute_id_ConnectionTlsVersion, &result_str_ptr,
+      &result_str_length));
 
   auto ssl = std::make_shared<Ssl::MockConnectionInfo>();
   EXPECT_CALL(connection, ssl()).WillRepeatedly(testing::Return(ssl));
   const std::string tls_version = "TLSv1.2";
   EXPECT_CALL(*ssl, tlsVersion()).WillRepeatedly(testing::ReturnRef(tls_version));
   EXPECT_TRUE(envoy_dynamic_module_callback_http_filter_get_attribute_string(
-  &filter, envoy_dynamic_module_type_attribute_id_ConnectionTlsVersion,
-  &result_str_ptr, &result_str_length));
+      &filter, envoy_dynamic_module_type_attribute_id_ConnectionTlsVersion, &result_str_ptr,
+      &result_str_length));
   EXPECT_EQ(result_str_length, tls_version.size());
   EXPECT_EQ(std::string(result_str_ptr, result_str_length), tls_version);
 


### PR DESCRIPTION
Commit Message: support additional attributes about ssl connection info
Additional Description: new attributes supported: 
  - connection.id
  - connection.tls_version
  - connection.subject_local_certificate
  - connection.subject_peer_certificate
  - connection.dns_san_local_certificate
  - connection.dns_san_peer_certificate
  - connection.uri_san_local_certificate
  - connection.uri_san_peer_certificate
  - connection.sha256_peer_certificate_digest

Risk Level: Low
Testing: Unit tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A

Signed-off-by: Hieu Do <hieusydo@gmail.com>