### PR TITLE
set_fitler_state: code cleanup for IP address object factory

### DIFF
--- a/source/common/network/ip_address.cc
+++ b/source/common/network/ip_address.cc
@@ -8,16 +8,16 @@
 namespace Envoy {
 namespace Network {
 
-const std::string& IPAddressObject::key() {
-  CONSTRUCT_ON_FIRST_USE(std::string, "envoy.network.ip");
-}
+namespace {
+const std::string& key() { CONSTRUCT_ON_FIRST_USE(std::string, "envoy.network.ip"); }
+} // namespace
 
 /**
  * Registers the filter state object for the dynamic extension support.
  */
 class BaseIPAddressObjectFactory : public StreamInfo::FilterState::ObjectFactory {
 public:
-  std::string name() const override { return IPAddressObject::key(); }
+  std::string name() const override { return key(); }
 
   std::unique_ptr<StreamInfo::FilterState::Object>
   createFromBytes(absl::string_view data) const override {

--- a/source/common/network/ip_address.h
+++ b/source/common/network/ip_address.h
@@ -17,7 +17,6 @@ public:
     const auto ip = getIp();
     return ip ? absl::make_optional(ip->asString()) : absl::nullopt;
   }
-  static const std::string& key();
 };
 
 } // namespace Network


### PR DESCRIPTION
Commit Message: set_fitler_state: code cleanup for IP address object factory
Additional Description:
Followup to #39873 - minor refactor - moving the `key()` method to an internal namespace.

Risk Level: low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
