### PR TITLE
test: set rbe_pool to 4 cores for lua_integration_test

### DIFF
--- a/test/extensions/filters/http/lua/BUILD
+++ b/test/extensions/filters/http/lua/BUILD
@@ -55,7 +55,7 @@ envoy_extension_cc_test(
     size = "large",
     srcs = ["lua_integration_test.cc"],
     extension_names = ["envoy.filters.http.lua"],
-    rbe_pool = "6gig",
+    rbe_pool = "4core",
     deps = [
         "//source/common/protobuf:utility_lib",
         "//source/extensions/filters/http/lua:config",


### PR DESCRIPTION
## Description

This PR increases assigns the `lua_integration_test` to a 4-core pool as it's failing sporadically due to the timeout.

[See This](https://github.com/envoyproxy/envoy/actions/runs/15826855740/job/44609261078#step:17:17408)

---

**Commit Message:** test: set rbe_pool to 4 cores for lua_integration_test
**Additional Description:** Set the rbe_pool value to 4 cores for `lua_integration_test` as it's failing sporadically
**Risk Level:** Low
**Testing:** CI
**Docs Changes:** N/A
**Release Notes:** N/A