### PR TITLE
Revert "build(deps): bump envoyproxy/toolshed from actions-v0.3.18 to…

### DIFF
--- a/.github/workflows/_check_coverage.yml
+++ b/.github/workflows/_check_coverage.yml
@@ -53,7 +53,7 @@ jobs:
       request: ${{ inputs.request }}
       runs-on: ${{ fromJSON(inputs.request).config.ci.agent-ubuntu }}
       steps-post: |
-        - uses: envoyproxy/toolshed/gh-actions/gcs/artefact/sync@actions-v0.3.19
+        - uses: envoyproxy/toolshed/gh-actions/gcs/artefact/sync@actions-v0.3.18
           with:
             bucket: ${{ inputs.trusted && vars.GCS_ARTIFACT_BUCKET_POST || vars.GCS_ARTIFACT_BUCKET_PRE }}
             path: generated/${{ matrix.target }}/html

--- a/.github/workflows/_finish.yml
+++ b/.github/workflows/_finish.yml
@@ -36,7 +36,7 @@ jobs:
       actions: read
       contents: read
     steps:
-    - uses: envoyproxy/toolshed/gh-actions/jq@actions-v0.3.19
+    - uses: envoyproxy/toolshed/gh-actions/jq@actions-v0.3.18
       name: Incoming data
       id: needs
       with:
@@ -87,7 +87,7 @@ jobs:
                    summary: "Check has finished",
                    text: $text}}}}
 
-    - uses: envoyproxy/toolshed/gh-actions/jq@actions-v0.3.19
+    - uses: envoyproxy/toolshed/gh-actions/jq@actions-v0.3.18
       name: Print summary
       with:
         input: ${{ toJSON(steps.needs.outputs.value).summary-title }}
@@ -95,13 +95,13 @@ jobs:
           "## \(.)"
         options: -Rr
         output-path: GITHUB_STEP_SUMMARY
-    - uses: envoyproxy/toolshed/gh-actions/appauth@actions-v0.3.19
+    - uses: envoyproxy/toolshed/gh-actions/appauth@actions-v0.3.18
       name: Appauth
       id: appauth
       with:
         app_id: ${{ secrets.app-id }}
         key: ${{ secrets.app-key }}
-    - uses: envoyproxy/toolshed/gh-actions/github/checks@actions-v0.3.19
+    - uses: envoyproxy/toolshed/gh-actions/github/checks@actions-v0.3.18
       name: Update check
       with:
         action: update

--- a/.github/workflows/_load.yml
+++ b/.github/workflows/_load.yml
@@ -100,7 +100,7 @@ jobs:
     # Handle any failure in triggering job
     # Remove any `checks` we dont care about
     # Prepare a check request
-    - uses: envoyproxy/toolshed/gh-actions/github/env/load@actions-v0.3.19
+    - uses: envoyproxy/toolshed/gh-actions/github/env/load@actions-v0.3.18
       name: Load env
       id: data
       with:
@@ -111,13 +111,13 @@ jobs:
         GH_TOKEN: ${{ github.token }}
 
     #  Update the check
-    - uses: envoyproxy/toolshed/gh-actions/appauth@actions-v0.3.19
+    - uses: envoyproxy/toolshed/gh-actions/appauth@actions-v0.3.18
       name: Appauth
       id: appauth
       with:
         app_id: ${{ secrets.app-id }}
         key: ${{ secrets.app-key }}
-    - uses: envoyproxy/toolshed/gh-actions/github/checks@actions-v0.3.19
+    - uses: envoyproxy/toolshed/gh-actions/github/checks@actions-v0.3.18
       name: Update check
       if: ${{ fromJSON(steps.data.outputs.data).data.check.action == 'RUN' }}
       with:
@@ -125,7 +125,7 @@ jobs:
         checks: ${{ toJSON(fromJSON(steps.data.outputs.data).checks) }}
         token: ${{ steps.appauth.outputs.token }}
 
-    - uses: envoyproxy/toolshed/gh-actions/jq@actions-v0.3.19
+    - uses: envoyproxy/toolshed/gh-actions/jq@actions-v0.3.18
       name: Print request summary
       with:
         input: |
@@ -145,7 +145,7 @@ jobs:
           | $summary.summary as $summary
           | "${{ inputs.template-request-summary }}"
 
-    - uses: envoyproxy/toolshed/gh-actions/jq@actions-v0.3.19
+    - uses: envoyproxy/toolshed/gh-actions/jq@actions-v0.3.18
       id: request-output
       name: Load request
       with:

--- a/.github/workflows/_load_env.yml
+++ b/.github/workflows/_load_env.yml
@@ -63,18 +63,18 @@ jobs:
       request: ${{ steps.env.outputs.data }}
       trusted: true
     steps:
-    - uses: envoyproxy/toolshed/gh-actions/jq@actions-v0.3.19
+    - uses: envoyproxy/toolshed/gh-actions/jq@actions-v0.3.18
       id: started
       name: Create timestamp
       with:
         options: -r
         filter: |
           now
-    - uses: envoyproxy/toolshed/gh-actions/github/checkout@actions-v0.3.19
+    - uses: envoyproxy/toolshed/gh-actions/github/checkout@actions-v0.3.18
       id: checkout
       name: Checkout Envoy repository
     - name: Generate environment variables
-      uses: envoyproxy/toolshed/gh-actions/envoy/ci/env@actions-v0.3.19
+      uses: envoyproxy/toolshed/gh-actions/envoy/ci/env@actions-v0.3.18
       id: env
       with:
         branch-name: ${{ inputs.branch-name }}
@@ -86,7 +86,7 @@ jobs:
 
     - name: Request summary
       id: summary
-      uses: envoyproxy/toolshed/gh-actions/github/env/summary@actions-v0.3.19
+      uses: envoyproxy/toolshed/gh-actions/github/env/summary@actions-v0.3.18
       with:
         actor: ${{ toJSON(fromJSON(steps.env.outputs.data).request.actor) }}
         base-sha: ${{ fromJSON(steps.env.outputs.data).request.base-sha }}

--- a/.github/workflows/_precheck_publish.yml
+++ b/.github/workflows/_precheck_publish.yml
@@ -78,7 +78,7 @@ jobs:
             --config=docs-ci
           rbe: true
           steps-post: |
-            - uses: envoyproxy/toolshed/gh-actions/gcs/artefact/sync@actions-v0.3.19
+            - uses: envoyproxy/toolshed/gh-actions/gcs/artefact/sync@actions-v0.3.18
               with:
                 bucket: ${{ inputs.trusted && vars.GCS_ARTIFACT_BUCKET_POST || vars.GCS_ARTIFACT_BUCKET_PRE }}
                 path: generated/docs

--- a/.github/workflows/_publish_publish.yml
+++ b/.github/workflows/_publish_publish.yml
@@ -78,12 +78,12 @@ jobs:
     needs:
     - publish
     steps:
-    - uses: envoyproxy/toolshed/gh-actions/appauth@actions-v0.3.19
+    - uses: envoyproxy/toolshed/gh-actions/appauth@actions-v0.3.18
       id: appauth
       with:
         app_id: ${{ secrets.ENVOY_CI_SYNC_APP_ID }}
         key: ${{ secrets.ENVOY_CI_SYNC_APP_KEY }}
-    - uses: envoyproxy/toolshed/gh-actions/dispatch@actions-v0.3.19
+    - uses: envoyproxy/toolshed/gh-actions/dispatch@actions-v0.3.18
       with:
         ref: main
         repository: ${{ fromJSON(inputs.request).request.version.dev && 'envoyproxy/envoy-website' || 'envoyproxy/archive' }}

--- a/.github/workflows/_request.yml
+++ b/.github/workflows/_request.yml
@@ -56,14 +56,14 @@ jobs:
       caches: ${{ steps.caches.outputs.value }}
       config: ${{ steps.config.outputs.config }}
     steps:
-    - uses: envoyproxy/toolshed/gh-actions/jq@actions-v0.3.19
+    - uses: envoyproxy/toolshed/gh-actions/jq@actions-v0.3.18
       id: started
       name: Create timestamp
       with:
         options: -r
         filter: |
           now
-    - uses: envoyproxy/toolshed/gh-actions/github/checkout@actions-v0.3.19
+    - uses: envoyproxy/toolshed/gh-actions/github/checkout@actions-v0.3.18
       id: checkout
       name: Checkout Envoy repository (requested)
       with:
@@ -77,7 +77,7 @@ jobs:
     # *ALL* variables collected should be treated as untrusted and should be sanitized before
     # use
     - name: Generate environment variables from commit
-      uses: envoyproxy/toolshed/gh-actions/envoy/ci/request@actions-v0.3.19
+      uses: envoyproxy/toolshed/gh-actions/envoy/ci/request@actions-v0.3.18
       id: env
       with:
         branch-name: ${{ steps.checkout.outputs.branch-name }}
@@ -88,7 +88,7 @@ jobs:
         vars: ${{ toJSON(vars) }}
         working-directory: requested
 
-    - uses: envoyproxy/toolshed/gh-actions/github/checkout@actions-v0.3.19
+    - uses: envoyproxy/toolshed/gh-actions/github/checkout@actions-v0.3.18
       id: checkout-target
       name: Checkout Envoy repository (target branch)
       with:
@@ -96,7 +96,7 @@ jobs:
         config: |
           fetch-depth: 1
           path: target
-    - uses: envoyproxy/toolshed/gh-actions/hashfiles@actions-v0.3.19
+    - uses: envoyproxy/toolshed/gh-actions/hashfiles@actions-v0.3.18
       id: bazel-cache-hash
       name: Bazel cache hash
       with:
@@ -105,7 +105,7 @@ jobs:
 
     - name: Request summary
       id: summary
-      uses: envoyproxy/toolshed/gh-actions/github/env/summary@actions-v0.3.19
+      uses: envoyproxy/toolshed/gh-actions/github/env/summary@actions-v0.3.18
       with:
         actor: ${{ toJSON(fromJSON(steps.env.outputs.data).request.actor) }}
         base-sha: ${{ fromJSON(steps.env.outputs.data).request.base-sha }}
@@ -121,7 +121,7 @@ jobs:
         target-branch: ${{ fromJSON(steps.env.outputs.data).request.target-branch }}
 
     - name: Environment data
-      uses: envoyproxy/toolshed/gh-actions/jq@actions-v0.3.19
+      uses: envoyproxy/toolshed/gh-actions/jq@actions-v0.3.18
       id: data
       with:
         input: |
@@ -164,18 +164,18 @@ jobs:
         path: /tmp/cache
         key: ${{ fromJSON(steps.data.outputs.value).request.build-image.default }}-arm64
 
-    - uses: envoyproxy/toolshed/gh-actions/gcp/setup@actions-v0.3.19
+    - uses: envoyproxy/toolshed/gh-actions/gcp/setup@actions-v0.3.18
       name: Setup GCP
       with:
         key: ${{ secrets.gcs-cache-key }}
 
-    - uses: envoyproxy/toolshed/gh-actions/gcs/cache/exists@actions-v0.3.19
+    - uses: envoyproxy/toolshed/gh-actions/gcs/cache/exists@actions-v0.3.18
       name: Check GCS bucket cache (x64)
       id: cache-exists-bazel-x64
       with:
         bucket: ${{ inputs.gcs-cache-bucket }}
         key: ${{ fromJSON(steps.data.outputs.value).config.ci.cache.bazel }}-x64
-    - uses: envoyproxy/toolshed/gh-actions/gcs/cache/exists@actions-v0.3.19
+    - uses: envoyproxy/toolshed/gh-actions/gcs/cache/exists@actions-v0.3.18
       name: Check GCS bucket cache (arm64)
       id: cache-exists-bazel-arm64
       with:
@@ -183,7 +183,7 @@ jobs:
         key: ${{ fromJSON(steps.data.outputs.value).config.ci.cache.bazel }}-arm64
 
     - name: Caches
-      uses: envoyproxy/toolshed/gh-actions/jq@actions-v0.3.19
+      uses: envoyproxy/toolshed/gh-actions/jq@actions-v0.3.18
       id: caches
       with:
         input-format: yaml

--- a/.github/workflows/_request_cache_bazel.yml
+++ b/.github/workflows/_request_cache_bazel.yml
@@ -51,7 +51,7 @@ jobs:
     name: "[${{ inputs.arch }}] Prime Bazel cache"
     if: ${{ ! fromJSON(inputs.caches).bazel[inputs.arch] }}
     steps:
-    - uses: envoyproxy/toolshed/gh-actions/github/checkout@actions-v0.3.19
+    - uses: envoyproxy/toolshed/gh-actions/github/checkout@actions-v0.3.18
       id: checkout-target
       name: Checkout Envoy repository (target branch)
       with:
@@ -59,14 +59,14 @@ jobs:
         config: |
           fetch-depth: 1
 
-    - uses: envoyproxy/toolshed/gh-actions/appauth@actions-v0.3.19
+    - uses: envoyproxy/toolshed/gh-actions/appauth@actions-v0.3.18
       id: appauth
       name: Appauth (mutex lock)
       with:
         app_id: ${{ secrets.app-id }}
         key: ${{ secrets.app-key }}
 
-    - uses: envoyproxy/toolshed/gh-actions/gcp/setup@actions-v0.3.19
+    - uses: envoyproxy/toolshed/gh-actions/gcp/setup@actions-v0.3.18
       name: Setup GCP
       with:
         key: ${{ secrets.gcs-cache-key }}
@@ -76,7 +76,7 @@ jobs:
         sudo mkdir /build
         sudo chown runner:docker /build
         echo "GITHUB_TOKEN=${{ github.token }}" >> $GITHUB_ENV
-    - uses: envoyproxy/toolshed/gh-actions/cache/prime@actions-v0.3.19
+    - uses: envoyproxy/toolshed/gh-actions/cache/prime@actions-v0.3.18
       id: bazel-cache
       name: Prime Bazel cache
       with:

--- a/.github/workflows/_request_cache_docker.yml
+++ b/.github/workflows/_request_cache_docker.yml
@@ -39,7 +39,7 @@ on:
 # For a job that does, you can restore with something like:
 #
 #    steps:
-#    - uses: envoyproxy/toolshed/gh-actions/docker/cache/restore@actions-v0.3.19
+#    - uses: envoyproxy/toolshed/gh-actions/docker/cache/restore@actions-v0.3.18
 #      with:
 #        key: "${{ needs.env.outputs.build-image }}"
 #
@@ -51,13 +51,13 @@ jobs:
     name: "[${{ inputs.arch }}] Prime Docker cache"
     if: ${{ ! fromJSON(inputs.caches).docker[inputs.arch] }}
     steps:
-    - uses: envoyproxy/toolshed/gh-actions/appauth@actions-v0.3.19
+    - uses: envoyproxy/toolshed/gh-actions/appauth@actions-v0.3.18
       id: appauth
       name: Appauth (mutex lock)
       with:
         app_id: ${{ secrets.app-id }}
         key: ${{ secrets.app-key }}
-    - uses: envoyproxy/toolshed/gh-actions/docker/cache/prime@actions-v0.3.19
+    - uses: envoyproxy/toolshed/gh-actions/docker/cache/prime@actions-v0.3.18
       id: docker
       name: Prime Docker cache (${{ inputs.image-tag }}${{ inputs.cache-suffix }})
       with:
@@ -65,7 +65,7 @@ jobs:
         key-suffix: ${{ inputs.cache-suffix }}
         lock-token: ${{ steps.appauth.outputs.token }}
         lock-repository: ${{ inputs.lock-repository }}
-    - uses: envoyproxy/toolshed/gh-actions/jq@actions-v0.3.19
+    - uses: envoyproxy/toolshed/gh-actions/jq@actions-v0.3.18
       id: data
       name: Cache data
       with:
@@ -73,7 +73,7 @@ jobs:
         input: |
           cached: ${{ steps.docker.outputs.cached }}
           key: ${{ inputs.image-tag }}${{ inputs.cache-suffix }}
-    - uses: envoyproxy/toolshed/gh-actions/json/table@actions-v0.3.19
+    - uses: envoyproxy/toolshed/gh-actions/json/table@actions-v0.3.18
       name: Summary
       with:
         json: ${{ steps.data.outputs.value }}

--- a/.github/workflows/_request_checks.yml
+++ b/.github/workflows/_request_checks.yml
@@ -55,7 +55,7 @@ jobs:
     runs-on: ${{ fromJSON(inputs.env).config.ci.agent-ubuntu }}
     name: Start checks
     steps:
-    - uses: envoyproxy/toolshed/gh-actions/jq@actions-v0.3.19
+    - uses: envoyproxy/toolshed/gh-actions/jq@actions-v0.3.18
       id: check-config
       name: Prepare check data
       with:
@@ -78,13 +78,13 @@ jobs:
           | .skipped.output.summary = "${{ inputs.skipped-summary }}"
           | .skipped.output.text = ""
 
-    - uses: envoyproxy/toolshed/gh-actions/appauth@actions-v0.3.19
+    - uses: envoyproxy/toolshed/gh-actions/appauth@actions-v0.3.18
       name: Appauth
       id: appauth
       with:
         app_id: ${{ secrets.app-id }}
         key: ${{ secrets.app-key }}
-    - uses: envoyproxy/toolshed/gh-actions/github/checks@actions-v0.3.19
+    - uses: envoyproxy/toolshed/gh-actions/github/checks@actions-v0.3.18
       name: Start checks
       id: checks
       with:
@@ -95,7 +95,7 @@ jobs:
 
           ${{ fromJSON(inputs.env).summary.summary }}
         token: ${{ steps.appauth.outputs.token }}
-    - uses: envoyproxy/toolshed/gh-actions/json/table@actions-v0.3.19
+    - uses: envoyproxy/toolshed/gh-actions/json/table@actions-v0.3.18
       name: Summary
       with:
         collapse-open: true
@@ -119,7 +119,7 @@ jobs:
         output-path: GITHUB_STEP_SUMMARY
         title: Checks started/skipped
 
-    - uses: envoyproxy/toolshed/gh-actions/github/env/save@actions-v0.3.19
+    - uses: envoyproxy/toolshed/gh-actions/github/env/save@actions-v0.3.18
       name: Save env
       id: data
       with:

--- a/.github/workflows/_run.yml
+++ b/.github/workflows/_run.yml
@@ -155,7 +155,7 @@ on:
       summary-post:
         type: string
         default: |
-          - uses: envoyproxy/toolshed/gh-actions/envoy/run/summary@actions-v0.3.19
+          - uses: envoyproxy/toolshed/gh-actions/envoy/run/summary@actions-v0.3.18
             with:
               context: %{{ inputs.context }}
       steps-pre:
@@ -217,7 +217,7 @@ jobs:
     name: ${{ inputs.target-suffix && format('[{0}] ', inputs.target-suffix) || '' }}${{ inputs.command }} ${{ inputs.target }}
     timeout-minutes: ${{ inputs.timeout-minutes }}
     steps:
-    - uses: envoyproxy/toolshed/gh-actions/jq@actions-v0.3.19
+    - uses: envoyproxy/toolshed/gh-actions/jq@actions-v0.3.18
       id: started
       name: Create timestamp
       with:
@@ -225,7 +225,7 @@ jobs:
         filter: |
           now
     # This controls which input vars are exposed to the run action (and related steps)
-    - uses: envoyproxy/toolshed/gh-actions/jq@actions-v0.3.19
+    - uses: envoyproxy/toolshed/gh-actions/jq@actions-v0.3.18
       name: Context
       id: context
       with:
@@ -257,13 +257,13 @@ jobs:
       if: ${{ inputs.docker-ipv6 }}
 
     # Caches
-    - uses: envoyproxy/toolshed/gh-actions/gcp/setup@actions-v0.3.19
+    - uses: envoyproxy/toolshed/gh-actions/gcp/setup@actions-v0.3.18
       name: Setup GCP (cache)
       if: ${{ inputs.gcs-cache-bucket }}
       with:
         key: ${{ secrets.gcs-cache-key }}
         force-install: ${{ contains(fromJSON('["envoy-arm64-medium", "github-arm64-2c-8gb"]'), inputs.runs-on) }}
-    - uses: envoyproxy/toolshed/gh-actions/cache/restore@actions-v0.3.19
+    - uses: envoyproxy/toolshed/gh-actions/cache/restore@actions-v0.3.18
       if: ${{ inputs.gcs-cache-bucket }}
       name: >-
         Restore Bazel cache
@@ -283,12 +283,12 @@ jobs:
         key: ${{ inputs.cache-build-image }}${{ inputs.cache-build-image-key-suffix }}
     - if: ${{ inputs.cache-build-image && steps.cache-lookup.outputs.cache-hit == 'true' }}
       name: Restore Docker cache ${{ inputs.cache-build-image && format('({0})', inputs.cache-build-image) || '' }}
-      uses: envoyproxy/toolshed/gh-actions/docker/cache/restore@actions-v0.3.19
+      uses: envoyproxy/toolshed/gh-actions/docker/cache/restore@actions-v0.3.18
       with:
         image-tag: ${{ inputs.cache-build-image }}
         key-suffix: ${{ inputs.cache-build-image-key-suffix }}
 
-    - uses: envoyproxy/toolshed/gh-actions/appauth@actions-v0.3.19
+    - uses: envoyproxy/toolshed/gh-actions/appauth@actions-v0.3.18
       id: appauth
       name: Appauth
       if: ${{ inputs.trusted }}
@@ -299,7 +299,7 @@ jobs:
         # - the workaround is to allow the token to be passed through.
         token: ${{ github.token }}
         token-ok: true
-    - uses: envoyproxy/toolshed/gh-actions/github/checkout@actions-v0.3.19
+    - uses: envoyproxy/toolshed/gh-actions/github/checkout@actions-v0.3.18
       id: checkout
       name: Checkout Envoy repository
       with:
@@ -316,7 +316,7 @@ jobs:
         token: ${{ inputs.trusted && steps.appauth.outputs.token || github.token }}
 
     # This is currently only use by mobile-docs and can be removed once they are updated to the newer website
-    - uses: envoyproxy/toolshed/gh-actions/github/checkout@actions-v0.3.19
+    - uses: envoyproxy/toolshed/gh-actions/github/checkout@actions-v0.3.18
       id: checkout-extra
       name: Checkout extra repository (for publishing)
       if: ${{ inputs.checkout-extra }}
@@ -325,7 +325,7 @@ jobs:
         ssh-key: ${{ inputs.trusted && inputs.ssh-key-extra || '' }}
 
     - name: Import GPG key
-      uses: envoyproxy/toolshed/gh-actions/gpg/import@actions-v0.3.19
+      uses: envoyproxy/toolshed/gh-actions/gpg/import@actions-v0.3.18
       if: ${{ inputs.import-gpg }}
       with:
         key: ${{ secrets.gpg-key }}
@@ -338,7 +338,7 @@ jobs:
       name: Configure PR Bazel settings
       if: >-
         ${{ fromJSON(inputs.request).request.pr != '' }}
-    - uses: envoyproxy/toolshed/gh-actions/gcp/setup@actions-v0.3.19
+    - uses: envoyproxy/toolshed/gh-actions/gcp/setup@actions-v0.3.18
       name: Setup GCP (artefacts/rbe)
       id: gcp
       with:
@@ -356,7 +356,7 @@ jobs:
       if: ${{ vars.ENVOY_CI_BAZELRC }}
       name: Configure repo Bazel settings
 
-    - uses: envoyproxy/toolshed/gh-actions/github/run@actions-v0.3.19
+    - uses: envoyproxy/toolshed/gh-actions/github/run@actions-v0.3.18
       name: Run CI ${{ inputs.command }} ${{ inputs.target }}
       with:
         args: ${{ inputs.args != '--' && inputs.args || inputs.target }}

--- a/.github/workflows/codeql-daily.yml
+++ b/.github/workflows/codeql-daily.yml
@@ -30,7 +30,7 @@ jobs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
     - name: Free disk space
-      uses: envoyproxy/toolshed/gh-actions/diskspace@actions-v0.3.19
+      uses: envoyproxy/toolshed/gh-actions/diskspace@actions-v0.3.18
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/codeql-push.yml
+++ b/.github/workflows/codeql-push.yml
@@ -63,7 +63,7 @@ jobs:
 
     - name: Free disk space
       if: ${{ env.BUILD_TARGETS != '' }}
-      uses: envoyproxy/toolshed/gh-actions/diskspace@actions-v0.3.19
+      uses: envoyproxy/toolshed/gh-actions/diskspace@actions-v0.3.18
 
     - name: Initialize CodeQL
       if: ${{ env.BUILD_TARGETS != '' }}

--- a/.github/workflows/command.yml
+++ b/.github/workflows/command.yml
@@ -28,7 +28,7 @@ jobs:
          && github.actor != 'dependabot[bot]'
       }}
     steps:
-    - uses: envoyproxy/toolshed/gh-actions/github/command@actions-v0.3.19
+    - uses: envoyproxy/toolshed/gh-actions/github/command@actions-v0.3.18
       name: Parse command from comment
       id: command
       with:
@@ -37,14 +37,14 @@ jobs:
           ^/(retest)
 
     # /retest
-    - uses: envoyproxy/toolshed/gh-actions/appauth@actions-v0.3.19
+    - uses: envoyproxy/toolshed/gh-actions/appauth@actions-v0.3.18
       if: ${{ steps.command.outputs.command == 'retest' }}
       id: appauth-retest
       name: Appauth (retest)
       with:
         key: ${{ secrets.ENVOY_CI_APP_KEY }}
         app_id: ${{ secrets.ENVOY_CI_APP_ID }}
-    - uses: envoyproxy/toolshed/gh-actions/retest@actions-v0.3.19
+    - uses: envoyproxy/toolshed/gh-actions/retest@actions-v0.3.18
       if: ${{ steps.command.outputs.command == 'retest' }}
       name: Retest
       with:

--- a/.github/workflows/envoy-dependency.yml
+++ b/.github/workflows/envoy-dependency.yml
@@ -53,16 +53,16 @@ jobs:
     steps:
     - id: appauth
       name: Appauth
-      uses: envoyproxy/toolshed/gh-actions/appauth@actions-v0.3.19
+      uses: envoyproxy/toolshed/gh-actions/appauth@actions-v0.3.18
       with:
         app_id: ${{ secrets.ENVOY_CI_DEP_APP_ID }}
         key: ${{ secrets.ENVOY_CI_DEP_APP_KEY }}
     - id: checkout
       name: Checkout Envoy repository
-      uses: envoyproxy/toolshed/gh-actions/github/checkout@actions-v0.3.19
+      uses: envoyproxy/toolshed/gh-actions/github/checkout@actions-v0.3.18
       with:
         token: ${{ steps.appauth.outputs.token }}
-    - uses: envoyproxy/toolshed/gh-actions/bson@actions-v0.3.19
+    - uses: envoyproxy/toolshed/gh-actions/bson@actions-v0.3.18
       id: update
       name: Update dependency (${{ inputs.dependency }})
       with:
@@ -97,13 +97,13 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    - uses: envoyproxy/toolshed/gh-actions/upload/diff@actions-v0.3.19
+    - uses: envoyproxy/toolshed/gh-actions/upload/diff@actions-v0.3.18
       name: Upload diff
       with:
         name: ${{ inputs.dependency }}-${{ steps.update.outputs.output }}
     - name: Create a PR
       if: ${{ inputs.pr }}
-      uses: envoyproxy/toolshed/gh-actions/github/pr@actions-v0.3.19
+      uses: envoyproxy/toolshed/gh-actions/github/pr@actions-v0.3.18
       with:
         base: main
         body: |
@@ -134,11 +134,11 @@ jobs:
     steps:
     - id: appauth
       name: Appauth
-      uses: envoyproxy/toolshed/gh-actions/appauth@actions-v0.3.19
+      uses: envoyproxy/toolshed/gh-actions/appauth@actions-v0.3.18
       with:
         app_id: ${{ secrets.ENVOY_CI_DEP_APP_ID }}
         key: ${{ secrets.ENVOY_CI_DEP_APP_KEY }}
-    - uses: envoyproxy/toolshed/gh-actions/github/checkout@actions-v0.3.19
+    - uses: envoyproxy/toolshed/gh-actions/github/checkout@actions-v0.3.18
       id: checkout
       name: Checkout Envoy repository
       with:
@@ -180,7 +180,7 @@ jobs:
 
     - name: Check Docker SHAs
       id: build-images
-      uses: envoyproxy/toolshed/gh-actions/docker/shas@actions-v0.3.19
+      uses: envoyproxy/toolshed/gh-actions/docker/shas@actions-v0.3.18
       with:
         images: |
            sha: envoyproxy/envoy-build-ubuntu:${{ steps.build-tools.outputs.tag }}
@@ -209,7 +209,7 @@ jobs:
       name: Update SHAs
       working-directory: envoy
     - name: Create a PR
-      uses: envoyproxy/toolshed/gh-actions/github/pr@actions-v0.3.19
+      uses: envoyproxy/toolshed/gh-actions/github/pr@actions-v0.3.18
       with:
         base: main
         body: Created by Envoy dependency bot

--- a/.github/workflows/envoy-release.yml
+++ b/.github/workflows/envoy-release.yml
@@ -59,14 +59,14 @@ jobs:
     steps:
     - id: appauth
       name: App auth
-      uses: envoyproxy/toolshed/gh-actions/appauth@actions-v0.3.19
+      uses: envoyproxy/toolshed/gh-actions/appauth@actions-v0.3.18
       with:
         app_id: ${{ secrets.ENVOY_CI_PUBLISH_APP_ID }}
         key: ${{ secrets.ENVOY_CI_PUBLISH_APP_KEY }}
 
     - id: checkout
       name: Checkout Envoy repository
-      uses: envoyproxy/toolshed/gh-actions/github/checkout@actions-v0.3.19
+      uses: envoyproxy/toolshed/gh-actions/github/checkout@actions-v0.3.18
       with:
         committer-name: ${{ env.COMMITTER_NAME }}
         committer-email: ${{ env.COMMITTER_EMAIL }}
@@ -87,10 +87,10 @@ jobs:
       name: Check changelog summary
     - if: ${{ inputs.author }}
       name: Validate signoff email
-      uses: envoyproxy/toolshed/gh-actions/email/validate@actions-v0.3.19
+      uses: envoyproxy/toolshed/gh-actions/email/validate@actions-v0.3.18
       with:
         email: ${{ inputs.author }}
-    - uses: envoyproxy/toolshed/gh-actions/github/run@actions-v0.3.19
+    - uses: envoyproxy/toolshed/gh-actions/github/run@actions-v0.3.18
       name: Create release
       with:
         source: |
@@ -115,7 +115,7 @@ jobs:
       name: Release version
       id: release
     - name: Create a PR
-      uses: envoyproxy/toolshed/gh-actions/github/pr@actions-v0.3.19
+      uses: envoyproxy/toolshed/gh-actions/github/pr@actions-v0.3.18
       with:
         base: ${{ github.ref_name }}
         commit: false
@@ -140,20 +140,20 @@ jobs:
     steps:
     - id: appauth
       name: App auth
-      uses: envoyproxy/toolshed/gh-actions/appauth@actions-v0.3.19
+      uses: envoyproxy/toolshed/gh-actions/appauth@actions-v0.3.18
       with:
         app_id: ${{ secrets.ENVOY_CI_PUBLISH_APP_ID }}
         key: ${{ secrets.ENVOY_CI_PUBLISH_APP_KEY }}
 
     - id: checkout
       name: Checkout Envoy repository
-      uses: envoyproxy/toolshed/gh-actions/github/checkout@actions-v0.3.19
+      uses: envoyproxy/toolshed/gh-actions/github/checkout@actions-v0.3.18
       with:
         committer-name: ${{ env.COMMITTER_NAME }}
         committer-email: ${{ env.COMMITTER_EMAIL }}
         strip-prefix: release/
         token: ${{ steps.appauth.outputs.token }}
-    - uses: envoyproxy/toolshed/gh-actions/github/run@actions-v0.3.19
+    - uses: envoyproxy/toolshed/gh-actions/github/run@actions-v0.3.18
       name: Sync version histories
       with:
         command: >-
@@ -163,7 +163,7 @@ jobs:
           --
           --signoff="${{ env.COMMITTER_NAME }} <${{ env.COMMITTER_EMAIL }}>"
     - name: Create a PR
-      uses: envoyproxy/toolshed/gh-actions/github/pr@actions-v0.3.19
+      uses: envoyproxy/toolshed/gh-actions/github/pr@actions-v0.3.18
       with:
         append-commit-message: true
         base: ${{ github.ref_name }}
@@ -190,13 +190,13 @@ jobs:
     steps:
     - id: appauth
       name: App auth
-      uses: envoyproxy/toolshed/gh-actions/appauth@actions-v0.3.19
+      uses: envoyproxy/toolshed/gh-actions/appauth@actions-v0.3.18
       with:
         app_id: ${{ secrets.ENVOY_CI_PUBLISH_APP_ID }}
         key: ${{ secrets.ENVOY_CI_PUBLISH_APP_KEY }}
     - id: checkout
       name: Checkout Envoy repository
-      uses: envoyproxy/toolshed/gh-actions/github/checkout@actions-v0.3.19
+      uses: envoyproxy/toolshed/gh-actions/github/checkout@actions-v0.3.18
       with:
         config: |
           fetch-depth: 0
@@ -226,13 +226,13 @@ jobs:
     steps:
     - id: appauth
       name: App auth
-      uses: envoyproxy/toolshed/gh-actions/appauth@actions-v0.3.19
+      uses: envoyproxy/toolshed/gh-actions/appauth@actions-v0.3.18
       with:
         app_id: ${{ secrets.ENVOY_CI_PUBLISH_APP_ID }}
         key: ${{ secrets.ENVOY_CI_PUBLISH_APP_KEY }}
 
     - name: Checkout repository
-      uses: envoyproxy/toolshed/gh-actions/github/checkout@actions-v0.3.19
+      uses: envoyproxy/toolshed/gh-actions/github/checkout@actions-v0.3.18
       with:
         committer-name: ${{ env.COMMITTER_NAME }}
         committer-email: ${{ env.COMMITTER_EMAIL }}

--- a/.github/workflows/envoy-sync.yml
+++ b/.github/workflows/envoy-sync.yml
@@ -34,12 +34,12 @@ jobs:
         - data-plane-api
         - mobile-website
     steps:
-    - uses: envoyproxy/toolshed/gh-actions/appauth@actions-v0.3.19
+    - uses: envoyproxy/toolshed/gh-actions/appauth@actions-v0.3.18
       id: appauth
       with:
         app_id: ${{ secrets.ENVOY_CI_SYNC_APP_ID }}
         key: ${{ secrets.ENVOY_CI_SYNC_APP_KEY }}
-    - uses: envoyproxy/toolshed/gh-actions/dispatch@actions-v0.3.19
+    - uses: envoyproxy/toolshed/gh-actions/dispatch@actions-v0.3.18
       with:
         repository: "envoyproxy/${{ matrix.downstream }}"
         ref: main
@@ -61,12 +61,12 @@ jobs:
         downstream:
         - envoy-openssl
     steps:
-    - uses: envoyproxy/toolshed/gh-actions/appauth@actions-v0.3.19
+    - uses: envoyproxy/toolshed/gh-actions/appauth@actions-v0.3.18
       id: appauth
       with:
         app_id: ${{ secrets.ENVOY_CI_SYNC_APP_ID }}
         key: ${{ secrets.ENVOY_CI_SYNC_APP_KEY }}
-    - uses: envoyproxy/toolshed/gh-actions/dispatch@actions-v0.3.19
+    - uses: envoyproxy/toolshed/gh-actions/dispatch@actions-v0.3.18
       with:
         repository: "envoyproxy/${{ matrix.downstream }}"
         ref: release/v1.28

--- a/.github/workflows/mobile-android_build.yml
+++ b/.github/workflows/mobile-android_build.yml
@@ -82,9 +82,9 @@ jobs:
       target: kotlin-hello-world
       runs-on: ubuntu-22.04
       steps-pre: |
-        - uses: envoyproxy/toolshed/gh-actions/envoy/android/pre@actions-v0.3.19
+        - uses: envoyproxy/toolshed/gh-actions/envoy/android/pre@actions-v0.3.18
       steps-post: |
-        - uses: envoyproxy/toolshed/gh-actions/envoy/android/post@actions-v0.3.19
+        - uses: envoyproxy/toolshed/gh-actions/envoy/android/post@actions-v0.3.18
           with:
             apk: bazel-bin/examples/kotlin/hello_world/hello_envoy_kt.apk
             app: io.envoyproxy.envoymobile.helloenvoykotlin/.MainActivity
@@ -111,7 +111,7 @@ jobs:
       target: ${{ matrix.target }}
       runs-on: ubuntu-22.04
       steps-pre: |
-        - uses: envoyproxy/toolshed/gh-actions/envoy/android/pre@actions-v0.3.19
+        - uses: envoyproxy/toolshed/gh-actions/envoy/android/pre@actions-v0.3.18
       steps-post: ${{ matrix.steps-post }}
       timeout-minutes: 50
       trusted: ${{ fromJSON(needs.load.outputs.trusted) }}
@@ -122,7 +122,7 @@ jobs:
         include:
         - name: java-hello-world
           steps-post: |
-            - uses: envoyproxy/toolshed/gh-actions/envoy/android/post@actions-v0.3.19
+            - uses: envoyproxy/toolshed/gh-actions/envoy/android/post@actions-v0.3.18
               with:
                 apk: bazel-bin/examples/java/hello_world/hello_envoy.apk
                 app: io.envoyproxy.envoymobile.helloenvoy/.MainActivity
@@ -141,7 +141,7 @@ jobs:
             --config=mobile-remote-release-clang-android
             //test/kotlin/apps/baseline:hello_envoy_kt
           steps-post: |
-            - uses: envoyproxy/toolshed/gh-actions/envoy/android/post@actions-v0.3.19
+            - uses: envoyproxy/toolshed/gh-actions/envoy/android/post@actions-v0.3.18
               with:
                 apk: bazel-bin/test/kotlin/apps/baseline/hello_envoy_kt.apk
                 app: io.envoyproxy.envoymobile.helloenvoybaselinetest/.MainActivity
@@ -156,7 +156,7 @@ jobs:
             --config=mobile-remote-release-clang-android
             //test/kotlin/apps/experimental:hello_envoy_kt
           steps-post: |
-            - uses: envoyproxy/toolshed/gh-actions/envoy/android/post@actions-v0.3.19
+            - uses: envoyproxy/toolshed/gh-actions/envoy/android/post@actions-v0.3.18
               with:
                 apk: bazel-bin/test/kotlin/apps/experimental/hello_envoy_kt.apk
                 app: io.envoyproxy.envoymobile.helloenvoyexperimentaltest/.MainActivity

--- a/.github/workflows/mobile-ios_build.yml
+++ b/.github/workflows/mobile-ios_build.yml
@@ -97,7 +97,7 @@ jobs:
         source ./ci/mac_ci_setup.sh
         ./bazelw shutdown
       steps-post: |
-        - uses: envoyproxy/toolshed/gh-actions/envoy/ios/post@actions-v0.3.19
+        - uses: envoyproxy/toolshed/gh-actions/envoy/ios/post@actions-v0.3.18
           with:
             app: ${{ matrix.app }}
             args: ${{ matrix.args || '--config=mobile-remote-ci-macos-ios' }}
@@ -142,7 +142,7 @@ jobs:
       source: |
         source ./ci/mac_ci_setup.sh
       steps-post: |
-        - uses: envoyproxy/toolshed/gh-actions/envoy/ios/post@actions-v0.3.19
+        - uses: envoyproxy/toolshed/gh-actions/envoy/ios/post@actions-v0.3.18
           with:
             app: ${{ matrix.app }}
             args: ${{ matrix.args || '--config=mobile-remote-ci-macos-ios' }}


### PR DESCRIPTION
… 0.3.19 (#40007)"

This reverts commit eb9502c683f5efc69e35b80f64c82f988a9f450e.

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
