### PR TITLE
dynamic_modules: adds support for LocalityLbEndpoints metadata

### DIFF
--- a/source/extensions/dynamic_modules/abi.h
+++ b/source/extensions/dynamic_modules/abi.h
@@ -262,13 +262,15 @@ typedef enum {
  */
 typedef enum {
   // stream's dynamic metadata.
-  envoy_dynamic_module_type_metadata_source_dynamic,
+  envoy_dynamic_module_type_metadata_source_Dynamic,
   // route metadata
-  envoy_dynamic_module_type_metadata_source_route,
+  envoy_dynamic_module_type_metadata_source_Route,
   // cluster metadata
-  envoy_dynamic_module_type_metadata_source_cluster,
+  envoy_dynamic_module_type_metadata_source_Cluster,
   // host (LbEndpoint in xDS) metadata
-  envoy_dynamic_module_type_metadata_source_host,
+  envoy_dynamic_module_type_metadata_source_Host,
+  // host locality (LocalityLbEndpoints in xDS) metadata
+  envoy_dynamic_module_type_metadata_source_HostLocality,
 } envoy_dynamic_module_type_metadata_source;
 
 /**

--- a/source/extensions/dynamic_modules/abi_version.h
+++ b/source/extensions/dynamic_modules/abi_version.h
@@ -6,7 +6,7 @@ namespace DynamicModules {
 #endif
 // This is the ABI version calculated as a sha256 hash of the ABI header files. When the ABI
 // changes, this value must change, and the correctness of this value is checked by the test.
-const char* kAbiVersion = "0ca64cbfdbe768cdb37d02185fe36ad3c3103c8bc258110e0dedf824ce2b9174";
+const char* kAbiVersion = "c32cc7696650a6a54653327e6609734a8b32aeb5c80a6a664687636a0d671666";
 
 #ifdef __cplusplus
 } // namespace DynamicModules

--- a/source/extensions/filters/http/dynamic_modules/abi_impl.cc
+++ b/source/extensions/filters/http/dynamic_modules/abi_impl.cc
@@ -273,6 +273,31 @@ void envoy_dynamic_module_callback_http_send_response(
 }
 
 /**
+ * Helper to get the metadata namespace from the metadata.
+ * @param metadata is the metadata to search in.
+ * @param namespace_ptr is the namespace of the metadata.
+ * @param namespace_length is the length of the namespace.
+ * @return the metadata namespace if it exists, nullptr otherwise.
+ *
+ * This will be reused by all envoy_dynamic_module_type_metadata_source where
+ * each differes in the returned type of the matadata. For example, route metadata will return
+ * OptRef vs upstream host metadata will return a shared pointer.
+ */
+const ProtobufWkt::Struct*
+getMetadataNamespaceImpl(const envoy::config::core::v3::Metadata& metadata,
+                         envoy_dynamic_module_type_buffer_module_ptr namespace_ptr,
+                         size_t namespace_length) {
+  absl::string_view namespace_view(static_cast<const char*>(namespace_ptr), namespace_length);
+  auto metadata_namespace = metadata.filter_metadata().find(namespace_view);
+  if (metadata_namespace == metadata.filter_metadata().end()) {
+    ENVOY_LOG_TO_LOGGER(Envoy::Logger::Registry::getLog(Envoy::Logger::Id::dynamic_modules), debug,
+                        fmt::format("namespace {} not found in metadata", namespace_view));
+    return nullptr;
+  }
+  return &metadata_namespace->second;
+}
+
+/**
  * Helper to get the metadata namespace from the stream info.
  * @param filter_envoy_ptr is the pointer to the DynamicModuleHttpFilter object of the
  * corresponding HTTP filter.
@@ -294,55 +319,55 @@ getMetadataNamespace(envoy_dynamic_module_type_http_filter_envoy_ptr filter_envo
     return nullptr;
   }
   auto& stream_info = callbacks->streamInfo();
-  const envoy::config::core::v3::Metadata* metadata = nullptr;
 
   switch (metadata_source) {
-  case envoy_dynamic_module_type_metadata_source_dynamic: {
-    metadata = &stream_info.dynamicMetadata();
-    break;
+  case envoy_dynamic_module_type_metadata_source_Dynamic: {
+    return getMetadataNamespaceImpl(stream_info.dynamicMetadata(), namespace_ptr, namespace_length);
   }
-  case envoy_dynamic_module_type_metadata_source_route: {
+  case envoy_dynamic_module_type_metadata_source_Route: {
     auto route = stream_info.route();
     if (route) {
-      metadata = &route->metadata();
+      return getMetadataNamespaceImpl(route->metadata(), namespace_ptr, namespace_length);
     }
     break;
   }
-  case envoy_dynamic_module_type_metadata_source_cluster: {
+  case envoy_dynamic_module_type_metadata_source_Cluster: {
     auto clusterInfo = callbacks->clusterInfo();
     if (clusterInfo) {
-      metadata = &clusterInfo->metadata();
+      return getMetadataNamespaceImpl(clusterInfo->metadata(), namespace_ptr, namespace_length);
     }
     break;
   }
-  case envoy_dynamic_module_type_metadata_source_host: {
-    auto upstreamInfo = stream_info.upstreamInfo();
+  case envoy_dynamic_module_type_metadata_source_Host: {
+    std::shared_ptr<StreamInfo::UpstreamInfo> upstreamInfo = stream_info.upstreamInfo();
     if (upstreamInfo) {
-      auto hostInfo = upstreamInfo->upstreamHost();
+      Upstream::HostDescriptionConstSharedPtr hostInfo = upstreamInfo->upstreamHost();
       if (hostInfo) {
-        auto md = hostInfo->metadata();
+        Upstream::MetadataConstSharedPtr md = hostInfo->metadata();
         if (md) {
-          metadata = md.get();
+          return getMetadataNamespaceImpl(*md, namespace_ptr, namespace_length);
+        }
+      }
+    }
+    break;
+  }
+  case envoy_dynamic_module_type_metadata_source_HostLocality: {
+    std::shared_ptr<StreamInfo::UpstreamInfo> upstreamInfo = stream_info.upstreamInfo();
+    if (upstreamInfo) {
+      Upstream::HostDescriptionConstSharedPtr hostInfo = upstreamInfo->upstreamHost();
+      if (hostInfo) {
+        Upstream::MetadataConstSharedPtr md = hostInfo->localityMetadata();
+        if (md) {
+          return getMetadataNamespaceImpl(*md, namespace_ptr, namespace_length);
         }
       }
     }
     break;
   }
   }
-  if (!metadata) {
-    ENVOY_LOG_TO_LOGGER(Envoy::Logger::Registry::getLog(Envoy::Logger::Id::dynamic_modules), debug,
-                        "metadata is not available");
-    return nullptr;
-  }
-  const auto& filter_metdata = metadata->filter_metadata();
-  absl::string_view namespace_view(static_cast<const char*>(namespace_ptr), namespace_length);
-  auto metadata_namespace = filter_metdata.find(namespace_view);
-  if (metadata_namespace == filter_metdata.end()) {
-    ENVOY_LOG_TO_LOGGER(Envoy::Logger::Registry::getLog(Envoy::Logger::Id::dynamic_modules), debug,
-                        fmt::format("namespace {} not found in metadata", namespace_view));
-    return nullptr;
-  }
-  return &metadata_namespace->second;
+  ENVOY_LOG_TO_LOGGER(Envoy::Logger::Registry::getLog(Envoy::Logger::Id::dynamic_modules), debug,
+                      "metadata is not available");
+  return nullptr;
 }
 
 /**

--- a/test/extensions/dynamic_modules/test_data/rust/http.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/http.rs
@@ -309,7 +309,7 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for DynamicMetadataCallbacksFilter {
   ) -> abi::envoy_dynamic_module_type_on_http_filter_request_headers_status {
     // No namespace.
     let no_namespace = envoy_filter.get_metadata_number(
-      abi::envoy_dynamic_module_type_metadata_source::dynamic,
+      abi::envoy_dynamic_module_type_metadata_source::Dynamic,
       "no_namespace",
       "key",
     );
@@ -317,14 +317,14 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for DynamicMetadataCallbacksFilter {
     // Set a number.
     envoy_filter.set_dynamic_metadata_number("ns_req_header", "key", 123f64);
     let ns_req_header = envoy_filter.get_metadata_number(
-      abi::envoy_dynamic_module_type_metadata_source::dynamic,
+      abi::envoy_dynamic_module_type_metadata_source::Dynamic,
       "ns_req_header",
       "key",
     );
     assert_eq!(ns_req_header, Some(123f64));
     // Try getting a number as string.
     let ns_req_header = envoy_filter.get_metadata_string(
-      abi::envoy_dynamic_module_type_metadata_source::dynamic,
+      abi::envoy_dynamic_module_type_metadata_source::Dynamic,
       "ns_req_header",
       "key",
     );
@@ -332,19 +332,19 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for DynamicMetadataCallbacksFilter {
 
     // Try getting metadata from rotuer cluster and host.
     let metadata = envoy_filter.get_metadata_string(
-      abi::envoy_dynamic_module_type_metadata_source::route,
+      abi::envoy_dynamic_module_type_metadata_source::Route,
       "metadata",
       "route_key",
     );
     assert_eq!(metadata.unwrap().as_slice(), b"route");
     let metadata = envoy_filter.get_metadata_string(
-      abi::envoy_dynamic_module_type_metadata_source::cluster,
+      abi::envoy_dynamic_module_type_metadata_source::Cluster,
       "metadata",
       "cluster_key",
     );
     assert_eq!(metadata.unwrap().as_slice(), b"cluster");
     let metadata = envoy_filter.get_metadata_string(
-      abi::envoy_dynamic_module_type_metadata_source::host,
+      abi::envoy_dynamic_module_type_metadata_source::Host,
       "metadata",
       "host_key",
     );
@@ -360,7 +360,7 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for DynamicMetadataCallbacksFilter {
   ) -> abi::envoy_dynamic_module_type_on_http_filter_request_body_status {
     // No namespace.
     let no_namespace = envoy_filter.get_metadata_string(
-      abi::envoy_dynamic_module_type_metadata_source::dynamic,
+      abi::envoy_dynamic_module_type_metadata_source::Dynamic,
       "no_namespace",
       "key",
     );
@@ -368,7 +368,7 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for DynamicMetadataCallbacksFilter {
     // Set a string.
     envoy_filter.set_dynamic_metadata_string("ns_req_body", "key", "value");
     let ns_req_body = envoy_filter.get_metadata_string(
-      abi::envoy_dynamic_module_type_metadata_source::dynamic,
+      abi::envoy_dynamic_module_type_metadata_source::Dynamic,
       "ns_req_body",
       "key",
     );
@@ -376,7 +376,7 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for DynamicMetadataCallbacksFilter {
     assert_eq!(ns_req_body.unwrap().as_slice(), b"value");
     // Try getting a string as number.
     let ns_req_body = envoy_filter.get_metadata_number(
-      abi::envoy_dynamic_module_type_metadata_source::dynamic,
+      abi::envoy_dynamic_module_type_metadata_source::Dynamic,
       "ns_req_body",
       "key",
     );
@@ -391,7 +391,7 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for DynamicMetadataCallbacksFilter {
   ) -> abi::envoy_dynamic_module_type_on_http_filter_response_headers_status {
     // No namespace.
     let no_namespace = envoy_filter.get_metadata_string(
-      abi::envoy_dynamic_module_type_metadata_source::dynamic,
+      abi::envoy_dynamic_module_type_metadata_source::Dynamic,
       "no_namespace",
       "key",
     );
@@ -399,14 +399,14 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for DynamicMetadataCallbacksFilter {
     // Set a number.
     envoy_filter.set_dynamic_metadata_number("ns_res_header", "key", 123f64);
     let ns_res_header = envoy_filter.get_metadata_number(
-      abi::envoy_dynamic_module_type_metadata_source::dynamic,
+      abi::envoy_dynamic_module_type_metadata_source::Dynamic,
       "ns_res_header",
       "key",
     );
     assert_eq!(ns_res_header, Some(123f64));
     // Try getting a number as string.
     let ns_res_header = envoy_filter.get_metadata_string(
-      abi::envoy_dynamic_module_type_metadata_source::dynamic,
+      abi::envoy_dynamic_module_type_metadata_source::Dynamic,
       "ns_res_header",
       "key",
     );
@@ -421,7 +421,7 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for DynamicMetadataCallbacksFilter {
   ) -> abi::envoy_dynamic_module_type_on_http_filter_response_body_status {
     // No namespace.
     let no_namespace = envoy_filter.get_metadata_string(
-      abi::envoy_dynamic_module_type_metadata_source::dynamic,
+      abi::envoy_dynamic_module_type_metadata_source::Dynamic,
       "no_namespace",
       "key",
     );
@@ -429,14 +429,14 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for DynamicMetadataCallbacksFilter {
     // Set a string.
     envoy_filter.set_dynamic_metadata_string("ns_res_body", "key", "value");
     let ns_res_body = envoy_filter.get_metadata_string(
-      abi::envoy_dynamic_module_type_metadata_source::dynamic,
+      abi::envoy_dynamic_module_type_metadata_source::Dynamic,
       "ns_res_body",
       "key",
     );
     assert!(ns_res_body.is_some());
     // Try getting a string as number.
     let ns_res_body = envoy_filter.get_metadata_number(
-      abi::envoy_dynamic_module_type_metadata_source::dynamic,
+      abi::envoy_dynamic_module_type_metadata_source::Dynamic,
       "ns_res_body",
       "key",
     );


### PR DESCRIPTION
Commit Message: dynamic_modules: adds support for LocalityLbEndpoints metadata
Additional Description:

This as a new enum variant to envoy_dynamic_module_type_metadata_source to get LocalityLbEndpoints. This also fixes the naming style of the enum so that the variants are in pascal case. This is a followup on #39805.

Risk Level: low (new code path)
Testing: done
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
