### PR TITLE
tcp_proxy: account upstream bytes meter for tunneling flows

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -210,6 +210,10 @@ new_features:
     If configured, the OAuth2 filter will redirect users to this endpoint when they access the
     :ref:`signout_path <envoy_v3_api_field_extensions.filters.http.oauth2.v3.OAuth2Config.signout_path>`. This allows users to
     be logged out of the Authorization server.
+- area: tcp_access_logs
+  change: |
+    Added support for %BYTES_RECEIVED%, %BYTES_SENT%, %UPSTREAM_HEADER_BYTES_SENT%, %UPSTREAM_HEADER_BYTES_RECEIVED%,
+    %UPSTREAM_WIRE_BYTES_SENT%, %UPSTREAM_WIRE_BYTES_RECEIVED% access log substitution strings for TCP tunneling flows.
 - area: load shed point
   change: |
     Added load shed point ``envoy.load_shed_points.connection_pool_new_connection`` in the connection pool, and it will not

--- a/docs/root/configuration/observability/access_log/usage.rst
+++ b/docs/root/configuration/observability/access_log/usage.rst
@@ -346,7 +346,7 @@ The following command operators are supported:
     Number of header bytes sent to the upstream by the http stream.
 
   TCP
-    Not implemented (0).
+    Total number of HTTP header bytes sent to the upstream stream, For TCP tunneling flows. Not supported for non-tunneling.
 
   UDP
     Total number of HTTP header bytes sent to the upstream stream, For UDP tunneling flows. Not supported for non-tunneling.
@@ -356,7 +356,7 @@ The following command operators are supported:
     Number of header bytes received from the upstream by the http stream.
 
   TCP
-    Not implemented (0).
+    Total number of HTTP header bytes received from the upstream stream, For TCP tunneling flows. Not supported for non-tunneling.
 
   UDP
     Total number of HTTP header bytes received from the upstream stream, For UDP tunneling flows. Not supported for non-tunneling.

--- a/source/common/tcp_proxy/upstream.cc
+++ b/source/common/tcp_proxy/upstream.cc
@@ -385,6 +385,7 @@ void HttpConnPool::onPoolReady(Http::RequestEncoder& request_encoder,
   }
 
   upstream_handle_ = nullptr;
+  downstream_info_.setUpstreamBytesMeter(request_encoder.getStream().bytesMeter());
   upstream_->setRequestEncoder(request_encoder,
                                host->transportSocketFactory().implementsSecureTransport());
   upstream_->setConnPoolCallbacks(std::make_unique<HttpConnPool::Callbacks>(


### PR DESCRIPTION
Additional Description: allows the usage of access log commands such as %UPSTREAM_HEADER_WIRE_BYTES% in TCP tunneling flows
Risk Level: loe
Testing: integration tests
Docs Changes: changelog, access log usage
Release Notes: none
Platform Specific Features: none