### PR TITLE
owners: add an entry in CODEOWNERS for domain_matcher

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -126,6 +126,7 @@ extensions/filters/common/original_src @klarose @mattklein123
 /*/extensions/wasm_runtime/ @mpwarres @kyessenov @lizan
 # common matcher
 /*/extensions/common/matcher @mattklein123 @yangminzhu
+/*/extensions/common/matcher/domain_matcher @agrawroh @kyessenov
 /*/extensions/common/proxy_protocol @ggreenway @wez470
 /*/extensions/filters/http/grpc_http1_bridge @jose @mattklein123
 /*/extensions/filters/http/fault @rshriram @kbaichoo


### PR DESCRIPTION
## Description

This PR adds a new entry in the CODEOWNERS file for the new `domain_matcher` extension.

---

**Commit Message:** owners: add an entry in CODEOWNERS for domain_matcher
**Additional Description:** Adds a new entry in the CODEOWNERS file for the new `domain_matcher` extension.
**Risk Level:** Low
**Testing:** CI
**Docs Changes:** N/A
**Release Notes:** N/A