### PR TITLE
Fix error message check to accommodate newer protobuf library

### DIFF
--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -1642,9 +1642,9 @@ TEST_F(StrictDnsClusterImplTest, NegativeDnsJitter) {
   envoy::config::cluster::v3::Cluster cluster_config = parseClusterFromV3Yaml(yaml);
   Envoy::Upstream::ClusterFactoryContextImpl factory_context(server_context_, nullptr, nullptr,
                                                              false);
-  EXPECT_THROW_WITH_MESSAGE(
+  EXPECT_THROW_WITH_REGEX(
       auto x = *createStrictDnsCluster(cluster_config, factory_context, dns_resolver_),
-      EnvoyException, "Invalid duration: Expected positive duration: seconds: -1\n");
+      EnvoyException, "(?s)Invalid duration: Expected positive duration:.*seconds: -1\n");
 }
 TEST_F(StrictDnsClusterImplTest, TtlAsDnsRefreshRateYesJitter) {
   ResolverData resolver(*dns_resolver_, server_context_.dispatcher_);

--- a/test/extensions/clusters/logical_dns/logical_dns_cluster_test.cc
+++ b/test/extensions/clusters/logical_dns/logical_dns_cluster_test.cc
@@ -909,8 +909,8 @@ TEST_F(LogicalDnsClusterTest, NegativeDnsJitter) {
                     address: foo.bar.com
                     port_value: 443
   )EOF";
-  EXPECT_THROW_WITH_MESSAGE(setupFromV3Yaml(yaml, false), EnvoyException,
-                            "Invalid duration: Expected positive duration: seconds: -1\n");
+  EXPECT_THROW_WITH_REGEX(setupFromV3Yaml(yaml, false), EnvoyException,
+                          "(?s)Invalid duration: Expected positive duration:.*seconds: -1\n");
 }
 
 TEST_F(LogicalDnsClusterTest, ExtremeJitter) {


### PR DESCRIPTION
Newer protobuf formats the output differently.

Risk Level: low
Testing: unit tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
