### PR TITLE
ext_proc: refactor client code to remove dynamic_cast

### DIFF
--- a/source/extensions/filters/common/ext_proc/client_base.h
+++ b/source/extensions/filters/common/ext_proc/client_base.h
@@ -12,9 +12,15 @@ namespace ExternalProcessing {
 /**
  * Stream base class used during external processing.
  */
-class StreamBase {
+template <typename RequestType, typename ResponseType> class StreamBase {
 public:
   virtual ~StreamBase() = default;
+  virtual void send(RequestType&& request, bool end_stream) PURE;
+  virtual bool close() PURE;
+  virtual bool halfCloseAndDeleteOnRemoteClose() PURE;
+  virtual const StreamInfo::StreamInfo& streamInfo() const PURE;
+  virtual StreamInfo::StreamInfo& streamInfo() PURE;
+  virtual void notifyFilterDestroy() PURE;
 };
 
 /**
@@ -34,7 +40,8 @@ template <typename RequestType, typename ResponseType> class ClientBase {
 public:
   virtual ~ClientBase() = default;
   virtual void sendRequest(RequestType&& request, bool end_stream, const uint64_t stream_id,
-                           RequestCallbacks<ResponseType>* callbacks, StreamBase* stream) PURE;
+                           RequestCallbacks<ResponseType>* callbacks,
+                           StreamBase<RequestType, ResponseType>* stream) PURE;
   virtual void cancel() PURE;
   virtual const Envoy::StreamInfo::StreamInfo* getStreamInfo() const PURE;
 };

--- a/source/extensions/filters/common/ext_proc/grpc_client.h
+++ b/source/extensions/filters/common/ext_proc/grpc_client.h
@@ -27,16 +27,10 @@ public:
  * A stream to an external processing server. This uses a bidirectional gRPC stream to send
  * requests and receive responses.
  */
-template <typename RequestType, typename ResponseType> class ProcessorStream : public StreamBase {
+template <typename RequestType, typename ResponseType>
+class ProcessorStream : public StreamBase<RequestType, ResponseType> {
 public:
   ~ProcessorStream() override = default;
-  virtual void send(RequestType&& request, bool end_stream) PURE;
-  // Idempotent close. Return true if it actually closed.
-  virtual bool close() PURE;
-  virtual bool halfCloseAndDeleteOnRemoteClose() PURE;
-  virtual const StreamInfo::StreamInfo& streamInfo() const PURE;
-  virtual StreamInfo::StreamInfo& streamInfo() PURE;
-  virtual void notifyFilterDestroy() PURE;
 };
 
 template <typename RequestType, typename ResponseType>

--- a/source/extensions/filters/common/ext_proc/grpc_client_impl.h
+++ b/source/extensions/filters/common/ext_proc/grpc_client_impl.h
@@ -235,10 +235,10 @@ public:
   }
 
   void sendRequest(RequestType&& request, bool end_stream, const uint64_t,
-                   RequestCallbacks<ResponseType>*, StreamBase* stream) override {
-    auto* grpc_stream = dynamic_cast<ProcessorStream<RequestType, ResponseType>*>(stream);
-    if (grpc_stream != nullptr) {
-      grpc_stream->send(std::move(request), end_stream);
+                   RequestCallbacks<ResponseType>*,
+                   StreamBase<RequestType, ResponseType>* stream) override {
+    if (stream != nullptr) {
+      stream->send(std::move(request), end_stream);
     }
   };
 

--- a/source/extensions/filters/http/ext_proc/ext_proc.cc
+++ b/source/extensions/filters/http/ext_proc/ext_proc.cc
@@ -409,7 +409,7 @@ Filter::StreamOpenState Filter::openStream() {
     return StreamOpenState::IgnoreError;
   }
 
-  if (!config().grpcService().has_value()) {
+  if (!grpc_service_.has_envoy_grpc() && !grpc_service_.has_google_grpc()) {
     return StreamOpenState::Ok;
   }
 
@@ -425,7 +425,7 @@ Filter::StreamOpenState Filter::openStream() {
                        .setSampled(absl::nullopt)
                        .setRemoteCloseTimeout(config_->remoteCloseTimeout());
 
-    ExternalProcessorClient* grpc_client = dynamic_cast<ExternalProcessorClient*>(client_.get());
+    ExternalProcessorClient* grpc_client = static_cast<ExternalProcessorClient*>(client_.get());
     ExternalProcessorStreamPtr stream_object =
         grpc_client->start(*this, config_with_hash_key_, options, watermark_callbacks_);
 
@@ -442,7 +442,7 @@ Filter::StreamOpenState Filter::openStream() {
 }
 
 void Filter::closeStream() {
-  if (!config_->grpcService().has_value()) {
+  if (!grpc_service_.has_envoy_grpc() && !grpc_service_.has_google_grpc()) {
     return;
   }
 
@@ -459,7 +459,7 @@ void Filter::closeStream() {
 }
 
 void Filter::halfCloseAndWaitForRemoteClose() {
-  if (!config_->grpcService().has_value()) {
+  if (!grpc_service_.has_envoy_grpc() && !grpc_service_.has_google_grpc()) {
     return;
   }
 
@@ -488,7 +488,7 @@ void Filter::onDestroy() {
   decoding_state_.stopMessageTimer();
   encoding_state_.stopMessageTimer();
 
-  if (!config_->grpcService().has_value()) {
+  if (!grpc_service_.has_envoy_grpc() && !grpc_service_.has_google_grpc()) {
     client_->cancel();
     return;
   }

--- a/source/extensions/filters/http/ext_proc/http_client/http_client_impl.cc
+++ b/source/extensions/filters/http/ext_proc/http_client/http_client_impl.cc
@@ -10,7 +10,9 @@ namespace Extensions {
 namespace HttpFilters {
 namespace ExternalProcessing {
 
-using StreamBase = Envoy::Extensions::Common::ExternalProcessing::StreamBase;
+using StreamBase = Envoy::Extensions::Common::ExternalProcessing::StreamBase<
+    envoy::service::ext_proc::v3::ProcessingRequest,
+    envoy::service::ext_proc::v3::ProcessingResponse>;
 using RequestCallbacks = Envoy::Extensions::Common::ExternalProcessing::RequestCallbacks<
     envoy::service::ext_proc::v3::ProcessingResponse>;
 

--- a/source/extensions/filters/http/ext_proc/http_client/http_client_impl.h
+++ b/source/extensions/filters/http/ext_proc/http_client/http_client_impl.h
@@ -3,11 +3,12 @@
 #include <memory>
 
 #include "envoy/extensions/filters/http/ext_proc/v3/ext_proc.pb.h"
+#include "envoy/grpc/async_client_manager.h"
 #include "envoy/http/async_client.h"
 #include "envoy/service/ext_proc/v3/external_processor.pb.h"
 
 #include "source/common/common/logger.h"
-#include "source/extensions/filters/common/ext_proc/client_base.h"
+#include "source/extensions/filters/common/ext_proc/grpc_client.h"
 #include "source/extensions/filters/http/ext_proc/client_impl.h"
 
 namespace Envoy {
@@ -15,8 +16,8 @@ namespace Extensions {
 namespace HttpFilters {
 namespace ExternalProcessing {
 
-// Now use the templated base class with the HTTP-specific types
-class ExtProcHttpClient : public Envoy::Extensions::Common::ExternalProcessing::ClientBase<
+// Now use the ProcessorClient interface with HTTP-specific types.
+class ExtProcHttpClient : public Envoy::Extensions::Common::ExternalProcessing::ProcessorClient<
                               envoy::service::ext_proc::v3::ProcessingRequest,
                               envoy::service::ext_proc::v3::ProcessingResponse>,
                           public Http::AsyncClient::Callbacks,
@@ -32,7 +33,9 @@ public:
                    const uint64_t stream_id,
                    Envoy::Extensions::Common::ExternalProcessing::RequestCallbacks<
                        envoy::service::ext_proc::v3::ProcessingResponse>* callbacks,
-                   Envoy::Extensions::Common::ExternalProcessing::StreamBase* stream) override;
+                   Envoy::Extensions::Common::ExternalProcessing::StreamBase<
+                       envoy::service::ext_proc::v3::ProcessingRequest,
+                       envoy::service::ext_proc::v3::ProcessingResponse>* stream) override;
   void cancel() override;
   void onBeforeFinalizeUpstreamSpan(Tracing::Span&, const Http::ResponseHeaderMap*) override {}
 
@@ -43,6 +46,22 @@ public:
                  Http::AsyncClient::FailureReason reason) override;
 
   const Envoy::StreamInfo::StreamInfo* getStreamInfo() const override;
+
+  // ProcessorClient interface implementation for HTTP clients. HTTP ext_proc uses
+  // request-response pattern with individual HTTP calls.
+  //
+  // The start() method is designed for gRPC clients to create a persistent stream.
+  // HTTP clients don't need persistent streams, so we return nullptr to indicate
+  // "no stream created". All communication happens via sendRequest() instead.
+  std::unique_ptr<Envoy::Extensions::Common::ExternalProcessing::ProcessorStream<
+      envoy::service::ext_proc::v3::ProcessingRequest,
+      envoy::service::ext_proc::v3::ProcessingResponse>>
+  start(Envoy::Extensions::Common::ExternalProcessing::ProcessorCallbacks<
+            envoy::service::ext_proc::v3::ProcessingResponse>&,
+        const Grpc::GrpcServiceConfigWithHashKey&, Http::AsyncClient::StreamOptions&,
+        Http::StreamFilterSidestreamWatermarkCallbacks&) override {
+    return nullptr; // HTTP clients use sendRequest() directly, no persistent stream needed.
+  }
 
   Server::Configuration::ServerFactoryContext& context() const { return context_; }
 

--- a/test/coverage.yaml
+++ b/test/coverage.yaml
@@ -41,7 +41,7 @@ directories:
   source/extensions/filters/http/cache: 95.9
   source/extensions/filters/http/dynamic_forward_proxy: 94.3
   source/extensions/filters/http/decompressor: 95.9
-  source/extensions/filters/http/ext_proc: 96.5
+  source/extensions/filters/http/ext_proc: 96.4
   source/extensions/filters/http/grpc_json_reverse_transcoder: 94.8
   source/extensions/filters/http/grpc_json_transcoder: 94.0  # TODO(#28232)
   source/extensions/filters/http/ip_tagging: 95.9

--- a/test/extensions/filters/http/ext_proc/mock_server.cc
+++ b/test/extensions/filters/http/ext_proc/mock_server.cc
@@ -14,10 +14,10 @@ MockClient::MockClient() {
           [](envoy::service::ext_proc::v3::ProcessingRequest&& request, bool end_stream,
              const uint64_t,
              CommonExtProc::RequestCallbacks<envoy::service::ext_proc::v3::ProcessingResponse>*,
-             CommonExtProc::StreamBase* stream) {
+             CommonExtProc::StreamBase<envoy::service::ext_proc::v3::ProcessingRequest,
+                                       envoy::service::ext_proc::v3::ProcessingResponse>* stream) {
             if (stream != nullptr) {
-              ExternalProcessorStream* grpc_stream = dynamic_cast<ExternalProcessorStream*>(stream);
-              grpc_stream->send(std::move(request), end_stream);
+              stream->send(std::move(request), end_stream);
             }
           }));
 }

--- a/test/extensions/filters/http/ext_proc/mock_server.h
+++ b/test/extensions/filters/http/ext_proc/mock_server.h
@@ -24,11 +24,12 @@ public:
   MOCK_METHOD(void, sendRequest,
               (envoy::service::ext_proc::v3::ProcessingRequest&&, bool, const uint64_t,
                CommonExtProc::RequestCallbacks<envoy::service::ext_proc::v3::ProcessingResponse>*,
-               CommonExtProc::StreamBase*),
+               (CommonExtProc::StreamBase<envoy::service::ext_proc::v3::ProcessingRequest,
+                                          envoy::service::ext_proc::v3::ProcessingResponse>*)),
               (override));
-  MOCK_METHOD(void, cancel, ());
+  MOCK_METHOD(void, cancel, (), (override));
 
-  MOCK_METHOD(const Envoy::StreamInfo::StreamInfo*, getStreamInfo, (), (const));
+  MOCK_METHOD(const Envoy::StreamInfo::StreamInfo*, getStreamInfo, (), (const, override));
 };
 
 class MockStream : public ExternalProcessorStream {

--- a/test/extensions/filters/network/ext_proc/ext_proc_test.cc
+++ b/test/extensions/filters/network/ext_proc/ext_proc_test.cc
@@ -54,9 +54,11 @@ public:
        const uint64_t stream_id,
        CommonExtProc::RequestCallbacks<envoy::service::network_ext_proc::v3::ProcessingResponse>*
            callbacks,
-       CommonExtProc::StreamBase* stream));
-  MOCK_METHOD(void, cancel, ());
-  MOCK_METHOD(const Envoy::StreamInfo::StreamInfo*, getStreamInfo, (), (const));
+       (CommonExtProc::StreamBase<envoy::service::network_ext_proc::v3::ProcessingRequest,
+                                  envoy::service::network_ext_proc::v3::ProcessingResponse> *
+        stream)));
+  MOCK_METHOD(void, cancel, (), (override));
+  MOCK_METHOD(const Envoy::StreamInfo::StreamInfo*, getStreamInfo, (), (const, override));
 };
 
 class NetworkExtProcFilterTest : public testing::Test {


### PR DESCRIPTION
## Description

This PR updates the ExtProc's base interfaces to remove `dynamic_cast`. 

Fix https://github.com/envoyproxy/envoy/issues/37904

There is a follow up PR for implementing HTTP stream support for `ext_proc` to add proper stream lifecycle management and to complete the HTTP client architecture.

---

**Commit Message:** ext_proc: refactor client code to remove dynamic_cast
**Additional Description:** Refactor ExtProc's base interfaces to remove `dynamic_cast`. 
**Risk Level:** Low
**Testing:** CI
**Docs Changes:** N/A
**Release Notes:** N/A