### PR TITLE
docs: clean up docs to make them consistent

### DIFF
--- a/api/envoy/config/cluster/v3/cluster.proto
+++ b/api/envoy/config/cluster/v3/cluster.proto
@@ -652,9 +652,10 @@ message Cluster {
     // If this is not set, we default to a merge window of 1000ms. To disable it, set the merge
     // window to 0.
     //
-    // Note: merging does not apply to cluster membership changes (e.g.: adds/removes); this is
-    // because merging those updates isn't currently safe. See
-    // https://github.com/envoyproxy/envoy/pull/3941.
+    // .. note::
+    //   Merging does not apply to cluster membership changes (e.g.: adds/removes); this is
+    //   because merging those updates isn't currently safe. See
+    //   https://github.com/envoyproxy/envoy/pull/3941.
     google.protobuf.Duration update_merge_window = 4;
 
     // If set to true, Envoy will :ref:`exclude <arch_overview_load_balancing_excluded>` new hosts
@@ -816,12 +817,14 @@ message Cluster {
   string name = 1 [(validate.rules).string = {min_len: 1}];
 
   // An optional alternative to the cluster name to be used for observability. This name is used
-  // emitting stats for the cluster and access logging the cluster name. This will appear as
+  // for emitting stats for the cluster and access logging the cluster name. This will appear as
   // additional information in configuration dumps of a cluster's current status as
   // :ref:`observability_name <envoy_v3_api_field_admin.v3.ClusterStatus.observability_name>`
-  // and as an additional tag "upstream_cluster.name" while tracing. Note: Any ``:`` in the name
-  // will be converted to ``_`` when emitting statistics. This should not be confused with
-  // :ref:`Router Filter Header <config_http_filters_router_x-envoy-upstream-alt-stat-name>`.
+  // and as an additional tag "upstream_cluster.name" while tracing.
+  //
+  // .. note::
+  //   Any ``:`` in the name will be converted to ``_`` when emitting statistics. This should not be confused with
+  //   :ref:`Router Filter Header <config_http_filters_router_x-envoy-upstream-alt-stat-name>`.
   string alt_stat_name = 28 [(udpa.annotations.field_migrate).rename = "observability_name"];
 
   oneof cluster_discovery_type {

--- a/api/envoy/config/endpoint/v3/endpoint.proto
+++ b/api/envoy/config/endpoint/v3/endpoint.proto
@@ -113,8 +113,9 @@ message ClusterLoadAssignment {
     // to determine the health of the priority level, or in other words assume each host has a weight of 1 for
     // this calculation.
     //
-    // Note: this is not currently implemented for
-    // :ref:`locality weighted load balancing <arch_overview_load_balancing_locality_weighted_lb>`.
+    // .. note::
+    //   This is not currently implemented for
+    //   :ref:`locality weighted load balancing <arch_overview_load_balancing_locality_weighted_lb>`.
     bool weighted_priority_health = 6;
   }
 

--- a/api/envoy/extensions/wasm/v3/wasm.proto
+++ b/api/envoy/extensions/wasm/v3/wasm.proto
@@ -19,12 +19,12 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // [#protodoc-title: Wasm]
 // [#extension: envoy.bootstrap.wasm]
 
-// If there is a fatal error on the VM (e.g. exception, abort()), then the policy will be applied.
+// If there is a fatal error on the VM (e.g. exception, ``abort()``), then the policy will be applied.
 enum FailurePolicy {
   // No policy is specified. The default policy will be used. The default policy is ``FAIL_CLOSED``.
   UNSPECIFIED = 0;
 
-  // New plugin instance will be created for the new request if the VM is failed. Note this only
+  // New plugin instance will be created for the new request if the VM is failed. Note this will only
   // be applied to the following failures:
   //
   // * ``proxy_wasm::FailState::RuntimeError``
@@ -64,7 +64,8 @@ message CapabilityRestrictionConfig {
 
 // Configuration for sanitization of inputs to an allowed capability.
 //
-// NOTE: This is currently unimplemented.
+// .. note::
+//   This is currently unimplemented.
 message SanitizationConfig {
 }
 
@@ -109,14 +110,16 @@ message VmConfig {
   config.core.v3.AsyncDataSource code = 3;
 
   // The Wasm configuration used in initialization of a new VM
-  // (proxy_on_start). ``google.protobuf.Struct`` is serialized as JSON before
+  // (``proxy_on_start``). ``google.protobuf.Struct`` is serialized as JSON before
   // passing it to the plugin. ``google.protobuf.BytesValue`` and
   // ``google.protobuf.StringValue`` are passed directly without the wrapper.
   google.protobuf.Any configuration = 4;
 
   // Allow the wasm file to include pre-compiled code on VMs which support it.
-  // Warning: this should only be enable for trusted sources as the precompiled code is not
-  // verified.
+  //
+  // .. warning::
+  //   This should only be enabled for trusted sources as the precompiled code is not
+  //   verified.
   bool allow_precompiled = 5;
 
   // If true and the code needs to be remotely fetched and it is not in the cache then NACK the configuration
@@ -129,7 +132,9 @@ message VmConfig {
   // are generally called implicitly by your language's standard library. Therefore, you do not
   // need to call them directly. You can access environment variables in the same way you would
   // on native platforms.
-  // Warning: Envoy rejects the configuration if there's conflict of key space.
+  //
+  // .. warning::
+  //   Envoy rejects the configuration if there's conflict of key space.
   EnvironmentVariables environment_variables = 7;
 }
 
@@ -168,11 +173,14 @@ message PluginConfig {
   // ``google.protobuf.StringValue`` are passed directly without the wrapper.
   google.protobuf.Any configuration = 4;
 
-  // If there is a fatal error on the VM (e.g. exception, abort(), on_start or on_configure return false),
+  // If there is a fatal error on the VM (e.g. exception, ``abort()``, ``on_start`` or ``on_configure`` return false),
   // then all plugins associated with the VM will either fail closed (by default), e.g. by returning an HTTP 503 error,
-  // or fail open (if 'fail_open' is set to true) by bypassing the filter. Note: when on_start or on_configure return false
-  // during xDS updates the xDS configuration will be rejected and when on_start or on_configuration return false on initial
-  // startup the proxy will not start.
+  // or fail open (if 'fail_open' is set to true) by bypassing the filter.
+  //
+  // .. note::
+  //   When ``on_start`` or ``on_configure`` return ``false`` during xDS updates the xDS configuration will be rejected and when ``on_start`` or ``on_configure`` return ``false`` on
+  //   initial startup the proxy will not start.
+  //
   // This field is deprecated in favor of the ``failure_policy`` field.
   bool fail_open = 5 [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
 


### PR DESCRIPTION
## Description

This PR have some cleanup in cluster, endpoint and WASM proto docs for consistency. We are using the new note and warning annotations and the backticks inconsistently throughout right now.

---

**Commit Message:** docs: clean up docs to make them consistent
**Additional Description:** Minor clean up for added clarity on the docs.
**Risk Level:** N/A
**Testing:** N/A
**Docs Changes:** N/A
**Release Notes:** N/A