### PR TITLE
router: remove redundant local_info member that can be accessed through the factory

### DIFF
--- a/source/common/http/async_client_impl.cc
+++ b/source/common/http/async_client_impl.cc
@@ -28,11 +28,11 @@ AsyncClientImpl::AsyncClientImpl(Upstream::ClusterInfoConstSharedPtr cluster,
                                  Http::Context& http_context, Router::Context& router_context)
     : factory_context_(factory_context), cluster_(cluster),
       config_(std::make_shared<Router::FilterConfig>(
-          factory_context, http_context.asyncClientStatPrefix(), factory_context.localInfo(),
-          *stats_store.rootScope(), cm, factory_context.runtime(),
-          factory_context.api().randomGenerator(), std::move(shadow_writer), true, false, false,
-          false, false, false, Protobuf::RepeatedPtrField<std::string>{}, dispatcher.timeSource(),
-          http_context, router_context)),
+          factory_context, http_context.asyncClientStatPrefix(), *stats_store.rootScope(), cm,
+          factory_context.runtime(), factory_context.api().randomGenerator(),
+          std::move(shadow_writer), true, false, false, false, false, false,
+          Protobuf::RepeatedPtrField<std::string>{}, dispatcher.timeSource(), http_context,
+          router_context)),
       dispatcher_(dispatcher), local_reply_(LocalReply::Factory::createDefault()) {}
 
 AsyncClientImpl::~AsyncClientImpl() {
@@ -246,7 +246,7 @@ void AsyncStreamImpl::sendHeaders(RequestHeaderMap& headers, bool end_stream) {
   }
 
   if (send_xff_) {
-    Utility::appendXff(headers, *parent_.config_->local_info_.address());
+    Utility::appendXff(headers, *parent_.config_->factory_context_.localInfo().address());
   }
 
   router_.decodeHeaders(headers, end_stream);

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -83,9 +83,8 @@ FilterConfig::FilterConfig(Stats::StatName stat_prefix,
                            const envoy::extensions::filters::http::router::v3::Router& config,
                            absl::Status& creation_status)
     : FilterConfig(
-          context.serverFactoryContext(), stat_prefix, context.serverFactoryContext().localInfo(),
-          context.scope(), context.serverFactoryContext().clusterManager(),
-          context.serverFactoryContext().runtime(),
+          context.serverFactoryContext(), stat_prefix, context.scope(),
+          context.serverFactoryContext().clusterManager(), context.serverFactoryContext().runtime(),
           context.serverFactoryContext().api().randomGenerator(), std::move(shadow_writer),
           PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, dynamic_stats, true), config.start_child_span(),
           config.suppress_envoy_headers(), config.respect_expected_rq_timeout(),

--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -202,25 +202,24 @@ public:
 class FilterConfig : public Http::FilterChainFactory {
 public:
   FilterConfig(Server::Configuration::CommonFactoryContext& factory_context,
-               Stats::StatName stat_prefix, const LocalInfo::LocalInfo& local_info,
-               Stats::Scope& scope, Upstream::ClusterManager& cm, Runtime::Loader& runtime,
-               Random::RandomGenerator& random, ShadowWriterPtr&& shadow_writer,
-               bool emit_dynamic_stats, bool start_child_span, bool suppress_envoy_headers,
-               bool respect_expected_rq_timeout, bool suppress_grpc_request_failure_code_stats,
+               Stats::StatName stat_prefix, Stats::Scope& scope, Upstream::ClusterManager& cm,
+               Runtime::Loader& runtime, Random::RandomGenerator& random,
+               ShadowWriterPtr&& shadow_writer, bool emit_dynamic_stats, bool start_child_span,
+               bool suppress_envoy_headers, bool respect_expected_rq_timeout,
+               bool suppress_grpc_request_failure_code_stats,
                bool flush_upstream_log_on_upstream_stream,
                const Protobuf::RepeatedPtrField<std::string>& strict_check_headers,
                TimeSource& time_source, Http::Context& http_context,
                Router::Context& router_context)
-      : factory_context_(factory_context), router_context_(router_context), scope_(scope),
-        local_info_(local_info), cm_(cm), runtime_(runtime),
-        default_stats_(router_context_.statNames(), scope_, stat_prefix),
+      : factory_context_(factory_context), router_context_(router_context), scope_(scope), cm_(cm),
+        runtime_(runtime), default_stats_(router_context_.statNames(), scope_, stat_prefix),
         async_stats_(router_context_.statNames(), scope, http_context.asyncClientStatPrefix()),
         random_(random), emit_dynamic_stats_(emit_dynamic_stats),
         start_child_span_(start_child_span), suppress_envoy_headers_(suppress_envoy_headers),
         respect_expected_rq_timeout_(respect_expected_rq_timeout),
         suppress_grpc_request_failure_code_stats_(suppress_grpc_request_failure_code_stats),
         flush_upstream_log_on_upstream_stream_(flush_upstream_log_on_upstream_stream),
-        http_context_(http_context), zone_name_(local_info_.zoneStatName()),
+        http_context_(http_context), zone_name_(factory_context.localInfo().zoneStatName()),
         shadow_writer_(std::move(shadow_writer)), time_source_(time_source) {
     if (!strict_check_headers.empty()) {
       strict_check_headers_ = std::make_unique<HeaderVector>();
@@ -270,7 +269,6 @@ public:
   Server::Configuration::CommonFactoryContext& factory_context_;
   Router::Context& router_context_;
   Stats::Scope& scope_;
-  const LocalInfo::LocalInfo& local_info_;
   Upstream::ClusterManager& cm_;
   Runtime::Loader& runtime_;
   FilterStats default_stats_;

--- a/source/common/tcp_proxy/tcp_proxy.cc
+++ b/source/common/tcp_proxy/tcp_proxy.cc
@@ -761,8 +761,7 @@ TunnelingConfigHelperImpl::TunnelingConfigHelperImpl(
       // TODO(vikaschoudhary16): figure out which of the following router_config_ members are
       // not required by tcp_proxy and move them to a different class
       router_config_(context.serverFactoryContext(), route_stat_name_storage_.statName(),
-                     context.serverFactoryContext().localInfo(), stats_scope,
-                     context.serverFactoryContext().clusterManager(),
+                     stats_scope, context.serverFactoryContext().clusterManager(),
                      context.serverFactoryContext().runtime(),
                      context.serverFactoryContext().api().randomGenerator(),
                      std::make_unique<Router::ShadowWriterImpl>(

--- a/test/common/router/router_test_base.cc
+++ b/test/common/router/router_test_base.cc
@@ -17,11 +17,11 @@ RouterTestBase::RouterTestBase(bool start_child_span, bool suppress_envoy_header
     : pool_(stats_store_.symbolTable()), http_context_(stats_store_.symbolTable()),
       router_context_(stats_store_.symbolTable()), shadow_writer_(new MockShadowWriter()),
       config_(std::make_shared<FilterConfig>(
-          factory_context_, pool_.add("test"), factory_context_.local_info_,
-          *stats_store_.rootScope(), cm_, runtime_, random_, ShadowWriterPtr{shadow_writer_}, true,
-          start_child_span, suppress_envoy_headers, false, suppress_grpc_request_failure_code_stats,
-          flush_upstream_log_on_upstream_stream, std::move(strict_headers_to_check),
-          test_time_.timeSystem(), http_context_, router_context_)),
+          factory_context_, pool_.add("test"), *stats_store_.rootScope(), cm_, runtime_, random_,
+          ShadowWriterPtr{shadow_writer_}, true, start_child_span, suppress_envoy_headers, false,
+          suppress_grpc_request_failure_code_stats, flush_upstream_log_on_upstream_stream,
+          std::move(strict_headers_to_check), test_time_.timeSystem(), http_context_,
+          router_context_)),
       router_(std::make_unique<RouterTestFilter>(config_, config_->default_stats_)) {
   router_->setDecoderFilterCallbacks(callbacks_);
   upstream_locality_.set_zone("to_az");


### PR DESCRIPTION
Commit Message: router: remove redundant local_info member that can be accessed through the factory
Additional Description:
Minor refactor of the router filter config.

Risk Level: low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A