### PR TITLE
xds: start the xdstp-config-source muxes after initializing them

### DIFF
--- a/envoy/config/xds_manager.h
+++ b/envoy/config/xds_manager.h
@@ -47,6 +47,13 @@ public:
   initializeAdsConnections(const envoy::config::bootstrap::v3::Bootstrap& bootstrap) PURE;
 
   /**
+   * Start all xDS-TP config-based gRPC muxes (if any).
+   * This includes both the servers defined in the `config_sources`, and
+   * `default_config_source` in the bootstrap.
+   */
+  virtual void startXdstpAdsMuxes() PURE;
+
+  /**
    * Subscription to a singleton resource.
    * This will create a subscription to a singleton resource, based on the resource_name and the
    * config source. If an xDS-TP based resource name is given, then the config sources defined in

--- a/source/common/config/xds_manager_impl.cc
+++ b/source/common/config/xds_manager_impl.cc
@@ -185,7 +185,7 @@ XdsManagerImpl::initializeAdsConnections(const envoy::config::bootstrap::v3::Boo
 }
 
 void XdsManagerImpl::startXdstpAdsMuxes() {
-  // Start the ADS muxes that were defined in `config_sources`.
+  // Start the ADS mux objects that were defined in `config_sources`.
   for (AuthorityData& authority : authorities_) {
     authority.grpc_mux_->start();
   }

--- a/source/common/config/xds_manager_impl.cc
+++ b/source/common/config/xds_manager_impl.cc
@@ -184,6 +184,17 @@ XdsManagerImpl::initializeAdsConnections(const envoy::config::bootstrap::v3::Boo
   return absl::OkStatus();
 }
 
+void XdsManagerImpl::startXdstpAdsMuxes() {
+  // Start the ADS muxes that were defined in `config_sources`.
+  for (AuthorityData& authority : authorities_) {
+    authority.grpc_mux_->start();
+  }
+  // Start the ADS mux of the `default_config_source`, if defined.
+  if (default_authority_ != nullptr) {
+    default_authority_->grpc_mux_->start();
+  }
+}
+
 absl::StatusOr<SubscriptionPtr> XdsManagerImpl::subscribeToSingletonResource(
     absl::string_view resource_name, OptRef<const envoy::config::core::v3::ConfigSource> config,
     absl::string_view type_url, Stats::Scope& scope, SubscriptionCallbacks& callbacks,

--- a/source/common/config/xds_manager_impl.h
+++ b/source/common/config/xds_manager_impl.h
@@ -23,6 +23,7 @@ public:
                           Upstream::ClusterManager* cm) override;
   absl::Status
   initializeAdsConnections(const envoy::config::bootstrap::v3::Bootstrap& bootstrap) override;
+  void startXdstpAdsMuxes() override;
   absl::StatusOr<SubscriptionPtr> subscribeToSingletonResource(
       absl::string_view resource_name, OptRef<const envoy::config::core::v3::ConfigSource> config,
       absl::string_view type_url, Stats::Scope& scope, SubscriptionCallbacks& callbacks,

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -478,7 +478,7 @@ ClusterManagerImpl::initialize(const envoy::config::bootstrap::v3::Bootstrap& bo
   // clusters have already initialized. (E.g., if all static).
   init_helper_.onStaticLoadComplete();
 
-  // Initialize the ADS and xDS-TP config based cpnnections.
+  // Initialize the ADS and xDS-TP config based connections.
   if (!has_ads_cluster) {
     // There is no ADS cluster, so we won't be starting the ADS mux after a cluster has finished
     // initializing, so we must start ADS here.

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -478,11 +478,17 @@ ClusterManagerImpl::initialize(const envoy::config::bootstrap::v3::Bootstrap& bo
   // clusters have already initialized. (E.g., if all static).
   init_helper_.onStaticLoadComplete();
 
+  // Initialize the ADS and xDS-TP config based cpnnections.
   if (!has_ads_cluster) {
     // There is no ADS cluster, so we won't be starting the ADS mux after a cluster has finished
     // initializing, so we must start ADS here.
     xds_manager_.adsMux()->start();
   }
+  // TODO(adisuissa): to ensure parity with the non-xdstp-config-based ADS
+  // we need to change this to only be invoked for Envoy-based clusters when
+  // they are ready (this is needed to avoid early connection attempts in the
+  // DNS based clusters).
+  xds_manager_.startXdstpAdsMuxes();
   return absl::OkStatus();
 }
 

--- a/test/common/config/xds_manager_impl_test.cc
+++ b/test/common/config/xds_manager_impl_test.cc
@@ -1337,7 +1337,7 @@ TEST_F(XdsManagerImplXdstpConfigSourcesTest, NonDefaultConfigSourceRepeatedAutho
                         "than once in an xdstp-based config source."));
 }
 
-// Validate that both the non-default and default config source muxes are
+// Validate that both the non-default and default config source mux objects are
 // started.
 TEST_F(XdsManagerImplXdstpConfigSourcesTest, DefaultAndNonDefaultMuxesStarted) {
   testing::InSequence s;
@@ -1392,7 +1392,7 @@ TEST_F(XdsManagerImplXdstpConfigSourcesTest, DefaultAndNonDefaultMuxesStarted) {
   )EOF",
              true, false, true);
 
-  // Validate that start() is called on all muxes.
+  // Validate that start() is invoked on all mux objects.
   EXPECT_CALL(*authority_A_mux_, start());
   EXPECT_CALL(*default_mux_, start());
   xds_manager_impl_.startXdstpAdsMuxes();

--- a/test/common/config/xds_manager_impl_test.cc
+++ b/test/common/config/xds_manager_impl_test.cc
@@ -1337,6 +1337,67 @@ TEST_F(XdsManagerImplXdstpConfigSourcesTest, NonDefaultConfigSourceRepeatedAutho
                         "than once in an xdstp-based config source."));
 }
 
+// Validate that both the non-default and default config source muxes are
+// started.
+TEST_F(XdsManagerImplXdstpConfigSourcesTest, DefaultAndNonDefaultMuxesStarted) {
+  testing::InSequence s;
+  // Have a config-source and default_config_source.
+  initialize(R"EOF(
+  config_sources:
+  - authorities:
+    - name: authority_1.com
+    api_config_source:
+      api_type: AGGREGATED_GRPC
+      set_node_on_first_message_only: true
+      grpc_services:
+        envoy_grpc:
+          cluster_name: config_source1_cluster
+  default_config_source:
+    authorities:
+    - name: authority_2.com
+    api_config_source:
+      api_type: AGGREGATED_GRPC
+      set_node_on_first_message_only: true
+      grpc_services:
+        envoy_grpc:
+          cluster_name: default_config_source_cluster
+  static_resources:
+    clusters:
+    - name: config_source1_cluster
+      connect_timeout: 0.250s
+      type: static
+      lb_policy: round_robin
+      load_assignment:
+        cluster_name: config_source1_cluster
+        endpoints:
+        - lb_endpoints:
+          - endpoint:
+              address:
+                socket_address:
+                  address: 127.0.0.1
+                  port_value: 11001
+    - name: default_config_source_cluster
+      connect_timeout: 0.250s
+      type: static
+      lb_policy: round_robin
+      load_assignment:
+        cluster_name: default_config_source_cluster
+        endpoints:
+        - lb_endpoints:
+          - endpoint:
+              address:
+                socket_address:
+                  address: 127.0.0.1
+                  port_value: 11002
+  )EOF",
+             true, false, true);
+
+  // Validate that start() is called on all muxes.
+  EXPECT_CALL(*authority_A_mux_, start());
+  EXPECT_CALL(*default_mux_, start());
+  xds_manager_impl_.startXdstpAdsMuxes();
+}
+
 // Validates that when a single valid config source is defined, a subscription to a resource
 // under that authority uses the config source's gRPC mux.
 TEST_F(XdsManagerImplXdstpConfigSourcesTest, SubscribeSingleValidConfigSource) {

--- a/test/mocks/config/xds_manager.h
+++ b/test/mocks/config/xds_manager.h
@@ -17,6 +17,7 @@ public:
   MOCK_METHOD(absl::Status, initialize,
               (const envoy::config::bootstrap::v3::Bootstrap& bootstrap,
                Upstream::ClusterManager* cm));
+  MOCK_METHOD(void, startXdstpAdsMuxes, ());
   MOCK_METHOD(absl::StatusOr<SubscriptionPtr>, subscribeToSingletonResource,
               (absl::string_view resource_name,
                OptRef<const envoy::config::core::v3::ConfigSource> config,


### PR DESCRIPTION
Commit Message: xds: start the xdstp-config-source muxes after initializing them
Additional Description:
This PR invokes the `start()` method on the xdstp-config-source based muxes at the end of the cluster-manager initialization.

Note that to make it fully compatible with the ADS the `start()` method should be invoked by a callback as described in [this TODO](https://github.com/envoyproxy/envoy/blob/e78d4a515ece03f906939d1f9052278a1b9f3c0d/source/common/upstream/cluster_manager_impl.cc#L397-L399) that was introduced in #30215. I plan to refactor this later as part of this work.

Risk Level: low - not used yet
Testing: Added unit tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
