### PR TITLE
Support attributes in stateful session cookies

### DIFF
--- a/api/envoy/type/http/v3/cookie.proto
+++ b/api/envoy/type/http/v3/cookie.proto
@@ -28,4 +28,20 @@ message Cookie {
   // Path of cookie. This will be used to set the path of a new cookie when it is generated.
   // If no path is specified here, no path will be set for the cookie.
   string path = 3;
+
+  // Additional attributes for the cookie. They will be used when generating a new cookie.
+  repeated CookieAttribute attributes = 4;
+}
+
+// CookieAttribute defines an API for adding additional attributes for a HTTP cookie.
+message CookieAttribute {
+  // The name of the cookie attribute.
+  string name = 1
+      [(validate.rules).string =
+           {min_len: 1 max_bytes: 16384 well_known_regex: HTTP_HEADER_NAME strict: false}];
+
+  // The optional value of the cookie attribute.
+  string value = 2 [
+    (validate.rules).string = {max_bytes: 16384 well_known_regex: HTTP_HEADER_VALUE strict: false}
+  ];
 }

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -300,5 +300,8 @@ new_features:
 - area: matcher
   change: |
     added support for :ref:`ServerNameMatcher <envoy_v3_api_msg_.xds.type.matcher.v3.ServerNameMatcher>` trie-based matching.
+- area: stateful_session
+  change: |
+    Added support for cookie attributes to stateful session cookie.
 
 deprecated:

--- a/source/extensions/http/stateful_session/cookie/cookie.cc
+++ b/source/extensions/http/stateful_session/cookie/cookie.cc
@@ -38,6 +38,11 @@ CookieBasedSessionStateFactory::CookieBasedSessionStateFactory(
     throw EnvoyException("Cookie key cannot be empty for cookie based stateful sessions");
   }
 
+  // Extract attributes from proto config
+  for (const auto& proto_attr : config.cookie().attributes()) {
+    attributes_.push_back({proto_attr.name(), proto_attr.value()});
+  }
+
   // If no cookie path is specified or root cookie path is specified then this session state will
   // be enabled for any request.
   if (path_.empty() || path_ == "/") {

--- a/source/extensions/http/stateful_session/cookie/cookie.h
+++ b/source/extensions/http/stateful_session/cookie/cookie.h
@@ -92,13 +92,19 @@ private:
   }
 
   std::string makeSetCookie(const std::string& address) const {
-    return Envoy::Http::Utility::makeSetCookieValue(name_, address, path_, ttl_, true, attributes_);
+    Envoy::Http::CookieAttributeRefVector ref_attributes;
+    ref_attributes.reserve(attributes_.size());
+    for (const auto& attribute : attributes_) {
+      ref_attributes.push_back(attribute);
+    }
+    return Envoy::Http::Utility::makeSetCookieValue(name_, address, path_, ttl_, true,
+                                                    ref_attributes);
   }
 
   const std::string name_;
   const std::chrono::seconds ttl_;
   const std::string path_;
-  const Envoy::Http::CookieAttributeRefVector attributes_;
+  std::vector<Envoy::Http::CookieAttribute> attributes_;
   TimeSource& time_source_;
 
   std::function<bool(absl::string_view)> path_matcher_;


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: support attributes in stateful session cookies
Additional Description: Today setting attributes in stateful session cookies is not supported natively. A follow up filter modifies the cookie to add attributes, e.g. a Lua script. This improves UX for this usecase.
Risk Level: Minor
Testing: Unit testing
Docs Changes: TBD
Release Notes: TBD
Platform Specific Features: N/A
Fixes #36846 