### PR TITLE
aggregated-cluster: replace data-members with getters

### DIFF
--- a/source/extensions/clusters/aggregate/cluster.cc
+++ b/source/extensions/clusters/aggregate/cluster.cc
@@ -17,8 +17,6 @@ Cluster::Cluster(const envoy::config::cluster::v3::Cluster& cluster,
                  Upstream::ClusterFactoryContext& context, absl::Status& creation_status)
     : Upstream::ClusterImplBase(cluster, context, creation_status),
       cluster_manager_(context.serverFactoryContext().clusterManager()),
-      runtime_(context.serverFactoryContext().runtime()),
-      random_(context.serverFactoryContext().api().randomGenerator()),
       clusters_(std::make_shared<ClusterSet>(config.clusters().begin(), config.clusters().end())) {}
 
 AggregateClusterLoadBalancer::AggregateClusterLoadBalancer(

--- a/source/extensions/clusters/aggregate/cluster.h
+++ b/source/extensions/clusters/aggregate/cluster.h
@@ -44,9 +44,11 @@ public:
     return Upstream::Cluster::InitializePhase::Secondary;
   }
 
+  // Getters that return the values from ClusterImplBase.
+  Runtime::Loader& runtime() const { return runtime_; }
+  Random::RandomGenerator& random() const { return random_; }
+
   Upstream::ClusterManager& cluster_manager_;
-  Runtime::Loader& runtime_;
-  Random::RandomGenerator& random_;
   const ClusterSetConstSharedPtr clusters_;
 
 protected:
@@ -148,7 +150,7 @@ public:
   // Upstream::LoadBalancerFactory
   Upstream::LoadBalancerPtr create(Upstream::LoadBalancerParams) override {
     return std::make_unique<AggregateClusterLoadBalancer>(
-        cluster_.info(), cluster_.cluster_manager_, cluster_.runtime_, cluster_.random_,
+        cluster_.info(), cluster_.cluster_manager_, cluster_.runtime(), cluster_.random(),
         cluster_.clusters_);
   }
 


### PR DESCRIPTION
Commit Message: aggregated-cluster: replace data-members with getters
Additional Description:
This PR removes the `runtime_` and `random_` data-members and adds a getter to the members that are in the base class (`ClusterImplBase`).
Note that the getters are const, but return a non-const reference, which is keeping the "spirit" of the previous implementation - a const Cluster data member was accessed for non-const operations.

Risk Level: low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A