### PR TITLE
add force_trace_header configuration

### DIFF
--- a/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
+++ b/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
@@ -217,6 +217,11 @@ message HttpConnectionManager {
     //
     // The default value is false for now for backward compatibility.
     google.protobuf.BoolValue spawn_upstream_span = 10;
+
+    // The name of the header to use for forcing tracing. If not specified, defaults to
+    // ``x-envoy-force-trace``. This header allows clients to force tracing for specific requests.
+    // The header value is not used; only the presence of the header is checked.
+    string force_trace_header = 11 [(validate.rules).string = {well_known_regex: HTTP_HEADER_NAME strict: false}];
   }
 
   message InternalAddressConfig {

--- a/envoy/tracing/trace_config.h
+++ b/envoy/tracing/trace_config.h
@@ -100,6 +100,11 @@ public:
    * for HTTP protocol tracing.
    */
   virtual uint32_t maxPathTagLength() const PURE;
+
+  /**
+   * @return the name of the header used to force tracing. If empty, defaults to "x-envoy-force-trace".
+   */
+  virtual const std::string& forceTraceHeader() const PURE;
 };
 
 using ConnectionManagerTracingConfigPtr = std::unique_ptr<ConnectionManagerTracingConfig>;

--- a/source/common/http/conn_manager_utility.h
+++ b/source/common/http/conn_manager_utility.h
@@ -145,7 +145,8 @@ private:
                                       ConnectionManagerConfig& config);
   static void sanitizeTEHeader(RequestHeaderMap& request_headers);
   static void cleanInternalHeaders(RequestHeaderMap& request_headers, bool edge_request,
-                                   const std::vector<Http::LowerCaseString>& internal_only_headers);
+                                   const std::vector<Http::LowerCaseString>& internal_only_headers,
+                                   const ConnectionManagerConfig& config);
 };
 
 } // namespace Http

--- a/source/common/tracing/tracer_config_impl.h
+++ b/source/common/tracing/tracer_config_impl.h
@@ -75,6 +75,7 @@ public:
     verbose_ = tracing_config.verbose();
     max_path_tag_length_ = PROTOBUF_GET_WRAPPED_OR_DEFAULT(tracing_config, max_path_tag_length,
                                                            Tracing::DefaultMaxPathTagLength);
+    force_trace_header_ = tracing_config.force_trace_header();
   }
 
   ConnectionManagerTracingConfigImpl(Tracing::OperationName operation_name,
@@ -82,11 +83,12 @@ public:
                                      envoy::type::v3::FractionalPercent client_sampling,
                                      envoy::type::v3::FractionalPercent random_sampling,
                                      envoy::type::v3::FractionalPercent overall_sampling,
-                                     bool verbose, uint32_t max_path_tag_length)
+                                     bool verbose, uint32_t max_path_tag_length,
+                                     const std::string& force_trace_header = "")
       : operation_name_(operation_name), custom_tags_(custom_tags),
         client_sampling_(client_sampling), random_sampling_(random_sampling),
         overall_sampling_(overall_sampling), verbose_(verbose),
-        max_path_tag_length_(max_path_tag_length) {}
+        max_path_tag_length_(max_path_tag_length), force_trace_header_(force_trace_header) {}
 
   ConnectionManagerTracingConfigImpl() = default;
 
@@ -105,6 +107,7 @@ public:
   bool verbose() const override { return verbose_; }
   uint32_t maxPathTagLength() const override { return max_path_tag_length_; }
   bool spawnUpstreamSpan() const override { return spawn_upstream_span_; }
+  const std::string& forceTraceHeader() const override { return force_trace_header_; }
 
   // TODO(wbpcode): keep this field be public for compatibility. Then the HCM needn't change much
   // code to use this config.
@@ -116,6 +119,7 @@ public:
   bool verbose_{};
   uint32_t max_path_tag_length_{};
   bool spawn_upstream_span_{};
+  std::string force_trace_header_{};
 };
 
 } // namespace Tracing


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Allow customization of the force trace header (x-envoy-force-trace by default)
Additional Description: We would like to use x-envoy-force-trace but we already have a different header we use for the same purpose. I thought I'd try proposing this here to see if there is interest before adding x-envoy-force-trace support to our services.
Risk Level: Low (small optional feature)
Testing: Unit tests
Docs Changes: TBD
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
