### PR TITLE
http ratelimit: Add rate_limits to filter config

### DIFF
--- a/api/envoy/extensions/filters/http/ratelimit/v3/rate_limit.proto
+++ b/api/envoy/extensions/filters/http/ratelimit/v3/rate_limit.proto
@@ -173,7 +173,8 @@ message RateLimit {
   // If this is set, then
   // :ref:`VirtualHost.rate_limits<envoy_v3_api_field_config.route.v3.VirtualHost.rate_limits>` or
   // :ref:`RouteAction.rate_limits<envoy_v3_api_field_config.route.v3.RouteAction.rate_limits>` fields
-  // will be ignored.
+  // will be ignored. However, :ref:`RateLimitPerRoute.rate_limits<envoy_v3_api_field_extensions.filters.http.ratelimit.v3.RateLimitPerRoute.rate_limits>`
+  // will take precedence over this field.
   //
   // .. note::
   //   Not all configuration fields of
@@ -230,8 +231,9 @@ message RateLimitPerRoute {
   // the request context. The generated entries will be used to find one or multiple matched rate
   // limit rule from the ``descriptors``.
   // If this is set, then
-  // :ref:`VirtualHost.rate_limits<envoy_v3_api_field_config.route.v3.VirtualHost.rate_limits>` or
-  // :ref:`RouteAction.rate_limits<envoy_v3_api_field_config.route.v3.RouteAction.rate_limits>` fields
+  // :ref:`VirtualHost.rate_limits<envoy_v3_api_field_config.route.v3.VirtualHost.rate_limits>`,
+  // :ref:`RouteAction.rate_limits<envoy_v3_api_field_config.route.v3.RouteAction.rate_limits>` and
+  // :ref:`RateLimit.rate_limits<envoy_v3_api_field_extensions.filters.http.ratelimit.v3.RateLimit.rate_limits>` fields
   // will be ignored.
   //
   // .. note::

--- a/api/envoy/extensions/filters/http/ratelimit/v3/rate_limit.proto
+++ b/api/envoy/extensions/filters/http/ratelimit/v3/rate_limit.proto
@@ -23,7 +23,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // Rate limit :ref:`configuration overview <config_http_filters_rate_limit>`.
 // [#extension: envoy.filters.http.ratelimit]
 
-// [#next-free-field: 17]
+// [#next-free-field: 18]
 message RateLimit {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.http.rate_limit.v2.RateLimit";
@@ -167,6 +167,26 @@ message RateLimit {
   // This means that when the rate limit service is unavailable, 50% of requests will be denied
   // (fail closed) and 50% will be allowed (fail open).
   config.core.v3.RuntimeFractionalPercent failure_mode_deny_percent = 16;
+
+  // Rate limit configuration that is used to generate a list of descriptor entries based on
+  // the request context. The generated entries will be sent to the rate limit service.
+  // If this is set, then
+  // :ref:`VirtualHost.rate_limits<envoy_v3_api_field_config.route.v3.VirtualHost.rate_limits>` or
+  // :ref:`RouteAction.rate_limits<envoy_v3_api_field_config.route.v3.RouteAction.rate_limits>` fields
+  // will be ignored.
+  //
+  // .. note::
+  //   Not all configuration fields of
+  //   :ref:`rate limit config <envoy_v3_api_msg_config.route.v3.RateLimit>` is supported at here.
+  //   Following fields are not supported:
+  //
+  //   1. :ref:`rate limit stage <envoy_v3_api_field_config.route.v3.RateLimit.stage>`.
+  //   2. :ref:`dynamic metadata <envoy_v3_api_field_config.route.v3.RateLimit.Action.dynamic_metadata>`.
+  //   3. :ref:`disable_key <envoy_v3_api_field_config.route.v3.RateLimit.disable_key>`.
+  //   4. :ref:`override limit <envoy_v3_api_field_config.route.v3.RateLimit.limit>`.
+  //   5. :ref:`hits_addend <envoy_v3_api_field_config.route.v3.RateLimit.hits_addend>`.
+  //   6. :ref:`apply_on_stream_done <envoy_v3_api_field_config.route.v3.RateLimit.apply_on_stream_done>`.
+  repeated config.route.v3.RateLimit rate_limits = 17;
 }
 
 message RateLimitPerRoute {

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -30,5 +30,14 @@ new_features:
     This allows Lua scripts to retrieve string, boolean, and numeric values stored by various filters for use in routing decisions,
     header modifications, and other processing logic. See :ref:`Filter State API <config_http_filters_lua_stream_info_filter_state_wrapper>`
     for more details.
+- area: ratelimit
+  change: |
+    Add the :ref:`rate_limits
+    <envoy_v3_api_field_extensions.filters.http.ratelimit.v3.RateLimit.rate_limits>`
+    field to generate rate limit descriptors. If this field is set, the
+    :ref:`VirtualHost.rate_limits<envoy_v3_api_field_config.route.v3.VirtualHost.rate_limits>` or
+    :ref:`RouteAction.rate_limits<envoy_v3_api_field_config.route.v3.RouteAction.rate_limits>` fields will be ignored. However,
+    :ref:`RateLimitPerRoute.rate_limits<envoy_v3_api_field_extensions.filters.http.ratelimit.v3.RateLimitPerRoute.rate_limits>`
+    will take precedence over this field.
 
 deprecated:

--- a/source/extensions/filters/http/ratelimit/config.cc
+++ b/source/extensions/filters/http/ratelimit/config.cc
@@ -26,7 +26,7 @@ absl::StatusOr<Http::FilterFactoryCb> RateLimitFilterConfig::createFilterFactory
   absl::Status status = absl::OkStatus();
   FilterConfigSharedPtr filter_config(new FilterConfig(proto_config, server_context.localInfo(),
                                                        context.scope(), server_context.runtime(),
-                                                       server_context.httpContext(), status));
+                                                       server_context, status));
   RETURN_IF_NOT_OK_REF(status);
   const std::chrono::milliseconds timeout =
       std::chrono::milliseconds(PROTOBUF_GET_MS_OR_DEFAULT(proto_config, timeout, 20));

--- a/source/extensions/filters/http/ratelimit/ratelimit.cc
+++ b/source/extensions/filters/http/ratelimit/ratelimit.cc
@@ -56,7 +56,12 @@ void Filter::initiateCall(const Http::RequestHeaderMap& headers) {
   }
 
   std::vector<Envoy::RateLimit::Descriptor> descriptors;
-  populateRateLimitDescriptors(descriptors, headers, false);
+  if (config_.get()->hasRateLimitConfigs()) {
+    cluster_ = callbacks_->clusterInfo();
+    config_.get()->populateDescriptors(headers, callbacks_->streamInfo(), descriptors);
+  } else {
+    populateRateLimitDescriptors(descriptors, headers, false);
+  }
   if (!descriptors.empty()) {
     state_ = State::Calling;
     initiating_call_ = true;

--- a/test/extensions/filters/http/ratelimit/ratelimit_test.cc
+++ b/test/extensions/filters/http/ratelimit/ratelimit_test.cc
@@ -62,7 +62,7 @@ public:
     auto status = absl::OkStatus();
     config_ = std::make_shared<FilterConfig>(
         proto_config, factory_context_.local_info_, *factory_context_.store_.rootScope(),
-        factory_context_.runtime_loader_, factory_context_.http_context_, status);
+        factory_context_.runtime_loader_, factory_context_, status);
     EXPECT_TRUE(status.ok());
 
     client_ = new Filters::Common::RateLimit::MockClient();
@@ -82,9 +82,13 @@ public:
       route_config_ =
           std::make_shared<FilterConfigPerRoute>(factory_context_, settings, creation_status);
       EXPECT_TRUE(creation_status.ok());
-
-      EXPECT_CALL(filter_callbacks_, mostSpecificPerFilterConfig())
-          .WillOnce(Return(route_config_.get()));
+      // rate_limits in filter config takes precedence over route config.
+      if (proto_config.rate_limits_size() > 0) {
+        EXPECT_CALL(filter_callbacks_, mostSpecificPerFilterConfig()).Times(0);
+      } else {
+        EXPECT_CALL(filter_callbacks_, mostSpecificPerFilterConfig())
+            .WillOnce(Return(route_config_.get()));
+      }
     }
   }
 
@@ -175,6 +179,15 @@ public:
     default_value:
       numerator: 100
       denominator: HUNDRED
+  )EOF";
+
+  const std::string inlined_rate_limit_actions_config_ = R"EOF(
+  domain: "bar"
+  rate_limits:
+  - actions:
+    - request_headers:
+        header_name: "x-header-name"
+        descriptor_key: "header-name"
   )EOF";
 
   Filters::Common::RateLimit::MockClient* client_;
@@ -2108,6 +2121,60 @@ TEST_F(HttpRateLimitFilterTest, FailureModeHundredPercentFailsClose) {
                     ->statsScope()
                     .counterFromStatName(ratelimit_failure_mode_allowed_)
                     .value());
+}
+
+TEST_F(HttpRateLimitFilterTest, InlinedRateLimitOverridesRoute) {
+  const std::string route_config_yaml = R"EOF(
+  domain: "foo"
+  rate_limits:
+  - actions:
+    - request_headers:
+        header_name: "x-header-name-route"
+        descriptor_key: "header-name-route"
+    )EOF";
+  setUpTest(inlined_rate_limit_actions_config_, route_config_yaml);
+  request_headers_.addCopy("x-header-name", "header-value");
+
+  EXPECT_CALL(*client_, limit(_, _, _, _, _, 0))
+      .WillOnce(Invoke(
+          [this](Filters::Common::RateLimit::RequestCallbacks& callbacks, const std::string& domain,
+                 const std::vector<Envoy::RateLimit::Descriptor>& descriptors, Tracing::Span&,
+                 OptRef<const StreamInfo::StreamInfo>, uint32_t) -> void {
+            request_callbacks_ = &callbacks;
+            EXPECT_EQ("bar", domain);
+            EXPECT_EQ(1, descriptors.size());
+            EXPECT_EQ("header-name", descriptors[0].entries_[0].key_);
+            EXPECT_EQ("header-value", descriptors[0].entries_[0].value_);
+          }));
+
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
+            filter_->decodeHeaders(request_headers_, false));
+
+  EXPECT_CALL(filter_callbacks_.stream_info_,
+              setResponseFlag(StreamInfo::CoreResponseFlag::RateLimited));
+
+  Http::TestResponseHeaderMapImpl response_headers{
+      {":status", "429"},
+      {"x-envoy-ratelimited", Http::Headers::get().EnvoyRateLimitedValues.True}};
+  EXPECT_CALL(filter_callbacks_, encodeHeaders_(HeaderMapEqualRef(&response_headers), true));
+  EXPECT_CALL(filter_callbacks_, continueDecoding()).Times(0);
+
+  request_callbacks_->complete(Filters::Common::RateLimit::LimitStatus::OverLimit, nullptr,
+                               std::make_unique<Http::TestResponseHeaderMapImpl>(), nullptr, "",
+                               nullptr);
+
+  EXPECT_EQ(1U, filter_callbacks_.clusterInfo()
+                    ->statsScope()
+                    .counterFromStatName(ratelimit_over_limit_)
+                    .value());
+
+  EXPECT_EQ(
+      1U,
+      filter_callbacks_.clusterInfo()->statsScope().counterFromStatName(upstream_rq_4xx_).value());
+  EXPECT_EQ(
+      1U,
+      filter_callbacks_.clusterInfo()->statsScope().counterFromStatName(upstream_rq_429_).value());
+  EXPECT_EQ("request_rate_limited", filter_callbacks_.details());
 }
 
 } // namespace

--- a/test/extensions/filters/http/ratelimit/ratelimit_test.cc
+++ b/test/extensions/filters/http/ratelimit/ratelimit_test.cc
@@ -82,13 +82,9 @@ public:
       route_config_ =
           std::make_shared<FilterConfigPerRoute>(factory_context_, settings, creation_status);
       EXPECT_TRUE(creation_status.ok());
-      // rate_limits in filter config takes precedence over route config.
-      if (proto_config.rate_limits_size() > 0) {
-        EXPECT_CALL(filter_callbacks_, mostSpecificPerFilterConfig()).Times(0);
-      } else {
-        EXPECT_CALL(filter_callbacks_, mostSpecificPerFilterConfig())
-            .WillOnce(Return(route_config_.get()));
-      }
+
+      EXPECT_CALL(filter_callbacks_, mostSpecificPerFilterConfig())
+          .WillOnce(Return(route_config_.get()));
     }
   }
 
@@ -2123,16 +2119,8 @@ TEST_F(HttpRateLimitFilterTest, FailureModeHundredPercentFailsClose) {
                     .value());
 }
 
-TEST_F(HttpRateLimitFilterTest, InlinedRateLimitOverridesRoute) {
-  const std::string route_config_yaml = R"EOF(
-  domain: "foo"
-  rate_limits:
-  - actions:
-    - request_headers:
-        header_name: "x-header-name-route"
-        descriptor_key: "header-name-route"
-    )EOF";
-  setUpTest(inlined_rate_limit_actions_config_, route_config_yaml);
+TEST_F(HttpRateLimitFilterTest, InlinedRateLimitAction) {
+  setUpTest(inlined_rate_limit_actions_config_);
   request_headers_.addCopy("x-header-name", "header-value");
 
   EXPECT_CALL(*client_, limit(_, _, _, _, _, 0))
@@ -2144,6 +2132,60 @@ TEST_F(HttpRateLimitFilterTest, InlinedRateLimitOverridesRoute) {
             EXPECT_EQ("bar", domain);
             EXPECT_EQ(1, descriptors.size());
             EXPECT_EQ("header-name", descriptors[0].entries_[0].key_);
+            EXPECT_EQ("header-value", descriptors[0].entries_[0].value_);
+          }));
+
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
+            filter_->decodeHeaders(request_headers_, false));
+
+  EXPECT_CALL(filter_callbacks_.stream_info_,
+              setResponseFlag(StreamInfo::CoreResponseFlag::RateLimited));
+
+  Http::TestResponseHeaderMapImpl response_headers{
+      {":status", "429"},
+      {"x-envoy-ratelimited", Http::Headers::get().EnvoyRateLimitedValues.True}};
+  EXPECT_CALL(filter_callbacks_, encodeHeaders_(HeaderMapEqualRef(&response_headers), true));
+  EXPECT_CALL(filter_callbacks_, continueDecoding()).Times(0);
+
+  request_callbacks_->complete(Filters::Common::RateLimit::LimitStatus::OverLimit, nullptr,
+                               std::make_unique<Http::TestResponseHeaderMapImpl>(), nullptr, "",
+                               nullptr);
+
+  EXPECT_EQ(1U, filter_callbacks_.clusterInfo()
+                    ->statsScope()
+                    .counterFromStatName(ratelimit_over_limit_)
+                    .value());
+
+  EXPECT_EQ(
+      1U,
+      filter_callbacks_.clusterInfo()->statsScope().counterFromStatName(upstream_rq_4xx_).value());
+  EXPECT_EQ(
+      1U,
+      filter_callbacks_.clusterInfo()->statsScope().counterFromStatName(upstream_rq_429_).value());
+  EXPECT_EQ("request_rate_limited", filter_callbacks_.details());
+}
+
+TEST_F(HttpRateLimitFilterTest, PerRouteOverridesInlinedRateLimit) {
+  const std::string route_config_yaml = R"EOF(
+  domain: "foo"
+  rate_limits:
+  - actions:
+    - request_headers:
+        header_name: "x-header-name-route"
+        descriptor_key: "header-name-route"
+    )EOF";
+  setUpTest(inlined_rate_limit_actions_config_, route_config_yaml);
+  request_headers_.addCopy("x-header-name-route", "header-value");
+
+  EXPECT_CALL(*client_, limit(_, _, _, _, _, 0))
+      .WillOnce(Invoke(
+          [this](Filters::Common::RateLimit::RequestCallbacks& callbacks, const std::string& domain,
+                 const std::vector<Envoy::RateLimit::Descriptor>& descriptors, Tracing::Span&,
+                 OptRef<const StreamInfo::StreamInfo>, uint32_t) -> void {
+            request_callbacks_ = &callbacks;
+            EXPECT_EQ("foo", domain);
+            EXPECT_EQ(1, descriptors.size());
+            EXPECT_EQ("header-name-route", descriptors[0].entries_[0].key_);
             EXPECT_EQ("header-value", descriptors[0].entries_[0].value_);
           }));
 


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: http ratelimit: Add rate_limits to filter config

Additional Description:
This PR adds a new field `rate_limits` to the external rate limit filter which reduces the need of configuring this as part of route or vhost config. This is particularly useful when used in a service mesh (e.g. Istio) setting where users are expected to interact with mesh APIs and not Envoy APIs directly. With this change, we (service mesh providers) can limit user configurability (e.g. users now only need access to insert HTTP Filters rather than change Route or Virtual Host behaviour) to provide better support and safeguard against unintended data plane configurations. This PR is similar to what https://github.com/envoyproxy/envoy/pull/36099 does for local rate limit. I've also seen interest about moving this field to the filter config (e.g. https://github.com/envoyproxy/envoy/issues/14732#issuecomment-896350448 cc @kyessenov ) so this PR seems directionally aligned.

Risk Level: Low
Testing: Unit tests and manual testing
Docs Changes: Covered by comments in proto file
Release Notes: Added to `changelogs/current.yaml`
Platform Specific Features: N/A
