### PR TITLE
Support original IP detection with use_remote_address

### DIFF
--- a/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
+++ b/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
@@ -678,9 +678,7 @@ message HttpConnectionManager {
   // If all extensions fail without rejection, Envoy defaults to using the directly connected remote address.
   //
   // .. warning::
-  //    These extensions cannot be configured simultaneously with :ref:`use_remote_address
-  //    <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.use_remote_address>`
-  //    or :ref:`xff_num_trusted_hops
+  //    These extensions cannot be configured simultaneously with :ref:`xff_num_trusted_hops
   //    <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.xff_num_trusted_hops>`.
   //
   // [#extension-category: envoy.http.original_ip_detection]

--- a/envoy/http/original_ip_detection.h
+++ b/envoy/http/original_ip_detection.h
@@ -22,6 +22,8 @@ struct OriginalIPDetectionParams {
   Http::RequestHeaderMap& request_headers;
   // The downstream directly connected address.
   const Network::Address::InstanceConstSharedPtr& downstream_remote_address;
+  // Whether use_remote_address is enabled in the configuration.
+  bool use_remote_address = false;
 };
 
 // Parameters to be used for sending a local reply when detection fails.

--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -871,11 +871,17 @@ Utility::GetLastAddressFromXffInfo Utility::getLastNonTrustedAddressFromXFF(
 }
 
 Utility::GetLastAddressFromXffInfo
-Utility::getLastAddressFromXFF(const Http::RequestHeaderMap& request_headers,
-                               uint32_t num_to_skip) {
+Utility::getLastAddressFromXFF(const Http::RequestHeaderMap& request_headers, uint32_t num_to_skip,
+                               bool use_remote_address) {
   const auto xff_header = request_headers.ForwardedFor();
   if (xff_header == nullptr) {
     return {nullptr, false};
+  }
+
+  // When use_remote_address=true, reduce num_to_skip by 1 to account for
+  // the current connection being appended to XFF
+  if (use_remote_address && num_to_skip > 0) {
+    num_to_skip = num_to_skip - 1;
   }
 
   absl::string_view xff_string(xff_header->value().getStringView());

--- a/source/common/http/utility.h
+++ b/source/common/http/utility.h
@@ -439,11 +439,14 @@ getLastNonTrustedAddressFromXFF(const Http::RequestHeaderMap& request_headers,
  * @param request_headers supplies the request headers.
  * @param num_to_skip specifies the number of addresses at the end of the XFF header
  *        to ignore when identifying the "last" address.
+ * @param use_remote_address when true and num_to_skip > 0, reduces num_to_skip by 1
+ *        to account for the current connection being appended to XFF.
  * @return GetLastAddressFromXffInfo information about the last address in the XFF header.
  *         @see GetLastAddressFromXffInfo for more information.
  */
 GetLastAddressFromXffInfo getLastAddressFromXFF(const Http::RequestHeaderMap& request_headers,
-                                                uint32_t num_to_skip = 0);
+                                                uint32_t num_to_skip = 0,
+                                                bool use_remote_address = false);
 
 /**
  * Remove any headers nominated by the Connection header

--- a/source/extensions/filters/network/http_connection_manager/config.cc
+++ b/source/extensions/filters/network/http_connection_manager/config.cc
@@ -494,12 +494,6 @@ HttpConnectionManagerConfig::HttpConnectionManagerConfig(
     extension->set_name("envoy.http.original_ip_detection.xff");
     extension->mutable_typed_config()->PackFrom(xff_config);
   } else {
-    if (use_remote_address_) {
-      creation_status = absl::InvalidArgumentError(
-          "Original IP detection extensions and use_remote_address may not be mixed");
-      return;
-    }
-
     if (xff_num_trusted_hops_ > 0) {
       creation_status = absl::InvalidArgumentError(
           "Original IP detection extensions and xff_num_trusted_hops may not be mixed");

--- a/source/extensions/http/original_ip_detection/xff/xff.cc
+++ b/source/extensions/http/original_ip_detection/xff/xff.cc
@@ -55,8 +55,8 @@ XffIPDetection::detect(Envoy::Http::OriginalIPDetectionParams& params) {
     return {ret.address_, ret.allow_trusted_address_checks_, absl::nullopt, skip_xff_append_};
   }
 
-  auto ret =
-      Envoy::Http::Utility::getLastAddressFromXFF(params.request_headers, xff_num_trusted_hops_);
+  auto ret = Envoy::Http::Utility::getLastAddressFromXFF(
+      params.request_headers, xff_num_trusted_hops_, params.use_remote_address);
   return {ret.address_, ret.allow_trusted_address_checks_, absl::nullopt, skip_xff_append_};
 }
 

--- a/test/common/http/conn_manager_utility_test.cc
+++ b/test/common/http/conn_manager_utility_test.cc
@@ -233,6 +233,9 @@ TEST_F(ConnectionManagerUtilityTest, DetermineNextProtocol) {
 // Verify external request and XFF is set when we are using remote address and the address is
 // external.
 TEST_F(ConnectionManagerUtilityTest, UseRemoteAddressWhenNotLocalHostRemoteAddress) {
+  std::vector<Http::OriginalIPDetectionSharedPtr> extensions; // No extensions
+  ON_CALL(config_, originalIpDetectionExtensions()).WillByDefault(ReturnRef(extensions));
+
   connection_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(
       std::make_shared<Network::Address::Ipv4Instance>("12.12.12.12"));
   ON_CALL(config_, useRemoteAddress()).WillByDefault(Return(true));
@@ -247,6 +250,9 @@ TEST_F(ConnectionManagerUtilityTest, UseRemoteAddressWhenNotLocalHostRemoteAddre
 }
 
 TEST_F(ConnectionManagerUtilityTest, RemoveRefererIfUrlInvalid) {
+  std::vector<Http::OriginalIPDetectionSharedPtr> extensions; // No extensions
+  ON_CALL(config_, originalIpDetectionExtensions()).WillByDefault(ReturnRef(extensions));
+
   connection_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(
       std::make_shared<Network::Address::Ipv4Instance>("10.0.0.1"));
   ON_CALL(config_, useRemoteAddress()).WillByDefault(Return(true));
@@ -257,6 +263,9 @@ TEST_F(ConnectionManagerUtilityTest, RemoveRefererIfUrlInvalid) {
 }
 
 TEST_F(ConnectionManagerUtilityTest, RemoveRefererIfMultipleEntriesAreFound) {
+  std::vector<Http::OriginalIPDetectionSharedPtr> extensions; // No extensions
+  ON_CALL(config_, originalIpDetectionExtensions()).WillByDefault(ReturnRef(extensions));
+
   connection_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(
       std::make_shared<Network::Address::Ipv4Instance>("10.0.0.1"));
   ON_CALL(config_, useRemoteAddress()).WillByDefault(Return(true));
@@ -273,6 +282,9 @@ TEST_F(ConnectionManagerUtilityTest, RemoveRefererIfMultipleEntriesAreFound) {
 }
 
 TEST_F(ConnectionManagerUtilityTest, RemoveRefererIfFragmentIsFound) {
+  std::vector<Http::OriginalIPDetectionSharedPtr> extensions; // No extensions
+  ON_CALL(config_, originalIpDetectionExtensions()).WillByDefault(ReturnRef(extensions));
+
   connection_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(
       std::make_shared<Network::Address::Ipv4Instance>("10.0.0.1"));
   ON_CALL(config_, useRemoteAddress()).WillByDefault(Return(true));
@@ -283,6 +295,9 @@ TEST_F(ConnectionManagerUtilityTest, RemoveRefererIfFragmentIsFound) {
 }
 
 TEST_F(ConnectionManagerUtilityTest, RemoveRefererIfMalformedPath) {
+  std::vector<Http::OriginalIPDetectionSharedPtr> extensions; // No extensions
+  ON_CALL(config_, originalIpDetectionExtensions()).WillByDefault(ReturnRef(extensions));
+
   connection_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(
       std::make_shared<Network::Address::Ipv4Instance>("10.0.0.1"));
   ON_CALL(config_, useRemoteAddress()).WillByDefault(Return(true));
@@ -293,6 +308,9 @@ TEST_F(ConnectionManagerUtilityTest, RemoveRefererIfMalformedPath) {
 }
 
 TEST_F(ConnectionManagerUtilityTest, RemoveRefererIfUserinfoIncluded) {
+  std::vector<Http::OriginalIPDetectionSharedPtr> extensions; // No extensions
+  ON_CALL(config_, originalIpDetectionExtensions()).WillByDefault(ReturnRef(extensions));
+
   connection_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(
       std::make_shared<Network::Address::Ipv4Instance>("10.0.0.1"));
   ON_CALL(config_, useRemoteAddress()).WillByDefault(Return(true));
@@ -303,6 +321,9 @@ TEST_F(ConnectionManagerUtilityTest, RemoveRefererIfUserinfoIncluded) {
 }
 
 TEST_F(ConnectionManagerUtilityTest, ValidRefererPassesSanitization) {
+  std::vector<Http::OriginalIPDetectionSharedPtr> extensions; // No extensions
+  ON_CALL(config_, originalIpDetectionExtensions()).WillByDefault(ReturnRef(extensions));
+
   connection_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(
       std::make_shared<Network::Address::Ipv4Instance>("10.0.0.1"));
   ON_CALL(config_, useRemoteAddress()).WillByDefault(Return(true));
@@ -314,6 +335,9 @@ TEST_F(ConnectionManagerUtilityTest, ValidRefererPassesSanitization) {
 }
 
 TEST_F(ConnectionManagerUtilityTest, AlphaNumCharRefererPassesSanitization) {
+  std::vector<Http::OriginalIPDetectionSharedPtr> extensions; // No extensions
+  ON_CALL(config_, originalIpDetectionExtensions()).WillByDefault(ReturnRef(extensions));
+
   connection_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(
       std::make_shared<Network::Address::Ipv4Instance>("10.0.0.1"));
   ON_CALL(config_, useRemoteAddress()).WillByDefault(Return(true));
@@ -325,6 +349,9 @@ TEST_F(ConnectionManagerUtilityTest, AlphaNumCharRefererPassesSanitization) {
 }
 
 TEST_F(ConnectionManagerUtilityTest, ValidPathOnlyRefererPassesSanitization) {
+  std::vector<Http::OriginalIPDetectionSharedPtr> extensions; // No extensions
+  ON_CALL(config_, originalIpDetectionExtensions()).WillByDefault(ReturnRef(extensions));
+
   connection_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(
       std::make_shared<Network::Address::Ipv4Instance>("10.0.0.1"));
   ON_CALL(config_, useRemoteAddress()).WillByDefault(Return(true));
@@ -336,6 +363,9 @@ TEST_F(ConnectionManagerUtilityTest, ValidPathOnlyRefererPassesSanitization) {
 }
 
 TEST_F(ConnectionManagerUtilityTest, ValidFileOnlyRefererPassesSanitization) {
+  std::vector<Http::OriginalIPDetectionSharedPtr> extensions; // No extensions
+  ON_CALL(config_, originalIpDetectionExtensions()).WillByDefault(ReturnRef(extensions));
+
   connection_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(
       std::make_shared<Network::Address::Ipv4Instance>("10.0.0.1"));
   ON_CALL(config_, useRemoteAddress()).WillByDefault(Return(true));
@@ -349,6 +379,9 @@ TEST_F(ConnectionManagerUtilityTest, ValidFileOnlyRefererPassesSanitization) {
 // Verify that we don't append XFF when skipXffAppend(), even if using remote
 // address and where the address is external.
 TEST_F(ConnectionManagerUtilityTest, SkipXffAppendUseRemoteAddress) {
+  std::vector<Http::OriginalIPDetectionSharedPtr> extensions; // No extensions
+  ON_CALL(config_, originalIpDetectionExtensions()).WillByDefault(ReturnRef(extensions));
+
   EXPECT_CALL(config_, skipXffAppend()).WillOnce(Return(true));
   connection_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(
       std::make_shared<Network::Address::Ipv4Instance>("12.12.12.12"));
@@ -363,6 +396,9 @@ TEST_F(ConnectionManagerUtilityTest, SkipXffAppendUseRemoteAddress) {
 // Verify that we pass-thru XFF when skipXffAppend(), even if using remote
 // address and where the address is external.
 TEST_F(ConnectionManagerUtilityTest, SkipXffAppendPassThruUseRemoteAddress) {
+  std::vector<Http::OriginalIPDetectionSharedPtr> extensions; // No extensions
+  ON_CALL(config_, originalIpDetectionExtensions()).WillByDefault(ReturnRef(extensions));
+
   EXPECT_CALL(config_, skipXffAppend()).WillOnce(Return(true));
   connection_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(
       std::make_shared<Network::Address::Ipv4Instance>("12.12.12.12"));
@@ -375,6 +411,9 @@ TEST_F(ConnectionManagerUtilityTest, SkipXffAppendPassThruUseRemoteAddress) {
 }
 
 TEST_F(ConnectionManagerUtilityTest, PreserveForwardedProtoWhenInternal) {
+  std::vector<Http::OriginalIPDetectionSharedPtr> extensions; // No extensions
+  ON_CALL(config_, originalIpDetectionExtensions()).WillByDefault(ReturnRef(extensions));
+
   TestScopedRuntime scoped_runtime;
 
   ON_CALL(config_, useRemoteAddress()).WillByDefault(Return(true));
@@ -396,6 +435,9 @@ TEST_F(ConnectionManagerUtilityTest, PreserveForwardedProtoWhenInternal) {
 }
 
 TEST_F(ConnectionManagerUtilityTest, OverwriteForwardedProtoWhenExternal) {
+  std::vector<Http::OriginalIPDetectionSharedPtr> extensions; // No extensions
+  ON_CALL(config_, originalIpDetectionExtensions()).WillByDefault(ReturnRef(extensions));
+
   ON_CALL(config_, useRemoteAddress()).WillByDefault(Return(true));
   ON_CALL(config_, xffNumTrustedHops()).WillByDefault(Return(0));
   connection_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(
@@ -411,6 +453,9 @@ TEST_F(ConnectionManagerUtilityTest, OverwriteForwardedProtoWhenExternal) {
 }
 
 TEST_F(ConnectionManagerUtilityTest, PreserveForwardedProtoWhenInternalButSetScheme) {
+  std::vector<Http::OriginalIPDetectionSharedPtr> extensions; // No extensions
+  ON_CALL(config_, originalIpDetectionExtensions()).WillByDefault(ReturnRef(extensions));
+
   TestScopedRuntime scoped_runtime;
 
   ON_CALL(config_, useRemoteAddress()).WillByDefault(Return(true));
@@ -429,6 +474,9 @@ TEST_F(ConnectionManagerUtilityTest, PreserveForwardedProtoWhenInternalButSetSch
 }
 
 TEST_F(ConnectionManagerUtilityTest, SchemeIsRespected) {
+  std::vector<Http::OriginalIPDetectionSharedPtr> extensions; // No extensions
+  ON_CALL(config_, originalIpDetectionExtensions()).WillByDefault(ReturnRef(extensions));
+
   ON_CALL(config_, useRemoteAddress()).WillByDefault(Return(true));
   ON_CALL(config_, xffNumTrustedHops()).WillByDefault(Return(0));
   connection_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(
@@ -463,6 +511,9 @@ TEST_F(ConnectionManagerUtilityTest, SchemeOverwrite) {
 // Verify internal request and XFF is set when we are using remote address and the address is
 // internal according to user configuration.
 TEST_F(ConnectionManagerUtilityTest, UseRemoteAddressWhenUserConfiguredRemoteAddress) {
+  std::vector<Http::OriginalIPDetectionSharedPtr> extensions; // No extensions
+  ON_CALL(config_, originalIpDetectionExtensions()).WillByDefault(ReturnRef(extensions));
+
   auto config = std::make_unique<NiceMock<MockInternalAddressConfig>>();
   ON_CALL(*config, isInternalAddress).WillByDefault(Return(true));
   config_.internal_address_config_ = std::move(config);
@@ -482,6 +533,9 @@ TEST_F(ConnectionManagerUtilityTest, UseRemoteAddressWhenUserConfiguredRemoteAdd
 
 // Verify internal request and XFF is set when we are using remote address the address is internal.
 TEST_F(ConnectionManagerUtilityTest, UseRemoteAddressWhenLocalHostRemoteAddress) {
+  std::vector<Http::OriginalIPDetectionSharedPtr> extensions; // No extensions
+  ON_CALL(config_, originalIpDetectionExtensions()).WillByDefault(ReturnRef(extensions));
+
   connection_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(
       std::make_shared<Network::Address::Ipv4Instance>("127.0.0.1"));
   Network::Address::Ipv4Instance local_address("10.3.2.1");
@@ -496,6 +550,9 @@ TEST_F(ConnectionManagerUtilityTest, UseRemoteAddressWhenLocalHostRemoteAddress)
 
 // Verify that we trust Nth address from XFF when using remote address with xff_num_trusted_hops.
 TEST_F(ConnectionManagerUtilityTest, UseRemoteAddressWithXFFTrustedHops) {
+  std::vector<Http::OriginalIPDetectionSharedPtr> extensions; // No extensions
+  ON_CALL(config_, originalIpDetectionExtensions()).WillByDefault(ReturnRef(extensions));
+
   connection_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(
       std::make_shared<Network::Address::Ipv4Instance>("203.0.113.128"));
   ON_CALL(config_, useRemoteAddress()).WillByDefault(Return(true));
@@ -639,11 +696,11 @@ TEST_F(ConnectionManagerUtilityTest, DocumentationExample1) {
   const auto modifiedXFFHeader = "203.0.113.128,203.0.113.10,203.0.113.1,192.0.2.5";
   const auto envoyInternal = false;
 
-  detection_extensions_.clear();
-  detection_extensions_.push_back(getXFFExtension(xffNumTrustedHops, false));
+  std::vector<Http::OriginalIPDetectionSharedPtr>
+      extensions; // No extensions for useRemoteAddress=true
+  ON_CALL(config_, originalIpDetectionExtensions()).WillByDefault(ReturnRef(extensions));
 
   ON_CALL(config_, xffNumTrustedHops()).WillByDefault(Return(xffNumTrustedHops));
-  ON_CALL(config_, originalIpDetectionExtensions()).WillByDefault(ReturnRef(detection_extensions_));
 
   connection_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(
       std::make_shared<Network::Address::Ipv4Instance>(downstreamIPAddress));
@@ -928,6 +985,9 @@ TEST_F(ConnectionManagerUtilityTest, PreserveHopByHop) {
 
 // Verify that we don't set the via header on requests/responses when empty.
 TEST_F(ConnectionManagerUtilityTest, ViaEmpty) {
+  std::vector<Http::OriginalIPDetectionSharedPtr> extensions; // No extensions
+  ON_CALL(config_, originalIpDetectionExtensions()).WillByDefault(ReturnRef(extensions));
+
   connection_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(
       std::make_shared<Network::Address::Ipv4Instance>("10.0.0.1"));
   ON_CALL(config_, useRemoteAddress()).WillByDefault(Return(true));
@@ -945,6 +1005,9 @@ TEST_F(ConnectionManagerUtilityTest, ViaEmpty) {
 
 // Verify that we append a non-empty via header on requests/responses.
 TEST_F(ConnectionManagerUtilityTest, ViaAppend) {
+  std::vector<Http::OriginalIPDetectionSharedPtr> extensions; // No extensions
+  ON_CALL(config_, originalIpDetectionExtensions()).WillByDefault(ReturnRef(extensions));
+
   via_ = "foo";
   connection_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(
       std::make_shared<Network::Address::Ipv4Instance>("10.0.0.1"));
@@ -967,6 +1030,9 @@ TEST_F(ConnectionManagerUtilityTest, ViaAppend) {
 
 // Verify that we don't set user agent when it is already set.
 TEST_F(ConnectionManagerUtilityTest, UserAgentDontSet) {
+  std::vector<Http::OriginalIPDetectionSharedPtr> extensions; // No extensions
+  ON_CALL(config_, originalIpDetectionExtensions()).WillByDefault(ReturnRef(extensions));
+
   connection_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(
       std::make_shared<Network::Address::Ipv4Instance>("10.0.0.1"));
   ON_CALL(config_, useRemoteAddress()).WillByDefault(Return(true));
@@ -981,6 +1047,9 @@ TEST_F(ConnectionManagerUtilityTest, UserAgentDontSet) {
 
 // Verify that we do set user agent when it is empty.
 TEST_F(ConnectionManagerUtilityTest, UserAgentSetWhenIncomingEmpty) {
+  std::vector<Http::OriginalIPDetectionSharedPtr> extensions; // No extensions
+  ON_CALL(config_, originalIpDetectionExtensions()).WillByDefault(ReturnRef(extensions));
+
   connection_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(
       std::make_shared<Network::Address::Ipv4Instance>("10.0.0.1"));
   ON_CALL(config_, useRemoteAddress()).WillByDefault(Return(true));
@@ -1113,6 +1182,9 @@ TEST_F(ConnectionManagerUtilityTest, ExternalRequestPreserveRequestIdAndDownstre
 // Verify that we don't overwrite user agent, but do set x-envoy-downstream-service-cluster
 // correctly.
 TEST_F(ConnectionManagerUtilityTest, UserAgentSetIncomingUserAgent) {
+  std::vector<Http::OriginalIPDetectionSharedPtr> extensions; // No extensions
+  ON_CALL(config_, originalIpDetectionExtensions()).WillByDefault(ReturnRef(extensions));
+
   connection_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(
       std::make_shared<Network::Address::Ipv4Instance>("10.0.0.1"));
   ON_CALL(config_, useRemoteAddress()).WillByDefault(Return(true));
@@ -1131,6 +1203,9 @@ TEST_F(ConnectionManagerUtilityTest, UserAgentSetIncomingUserAgent) {
 
 // Verify that we set both user agent and x-envoy-downstream-service-cluster.
 TEST_F(ConnectionManagerUtilityTest, UserAgentSetNoIncomingUserAgent) {
+  std::vector<Http::OriginalIPDetectionSharedPtr> extensions; // No extensions
+  ON_CALL(config_, originalIpDetectionExtensions()).WillByDefault(ReturnRef(extensions));
+
   connection_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(
       std::make_shared<Network::Address::Ipv4Instance>("10.0.0.1"));
   ON_CALL(config_, useRemoteAddress()).WillByDefault(Return(true));
@@ -1169,6 +1244,9 @@ TEST_F(ConnectionManagerUtilityTest, RequestIdGeneratedWhenItsNotPresent) {
 
 // Make sure we do not overwrite x-request-id if the request is internal.
 TEST_F(ConnectionManagerUtilityTest, DoNotOverrideRequestIdIfPresentWhenInternalRequest) {
+  std::vector<Http::OriginalIPDetectionSharedPtr> extensions; // No extensions
+  ON_CALL(config_, originalIpDetectionExtensions()).WillByDefault(ReturnRef(extensions));
+
   connection_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(
       std::make_shared<Network::Address::Ipv4Instance>("10.0.0.1"));
   ON_CALL(config_, useRemoteAddress()).WillByDefault(Return(true));
@@ -1182,6 +1260,9 @@ TEST_F(ConnectionManagerUtilityTest, DoNotOverrideRequestIdIfPresentWhenInternal
 
 // Make sure that we do overwrite x-request-id for "edge" external requests.
 TEST_F(ConnectionManagerUtilityTest, OverrideRequestIdForExternalRequests) {
+  std::vector<Http::OriginalIPDetectionSharedPtr> extensions; // No extensions
+  ON_CALL(config_, originalIpDetectionExtensions()).WillByDefault(ReturnRef(extensions));
+
   connection_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(
       std::make_shared<Network::Address::Ipv4Instance>("134.2.2.11"));
   ON_CALL(config_, useRemoteAddress()).WillByDefault(Return(true));
@@ -1196,6 +1277,9 @@ TEST_F(ConnectionManagerUtilityTest, OverrideRequestIdForExternalRequests) {
 // A request that uses remote address and is from an external address should be treated as an
 // external request with all internal only headers cleaned.
 TEST_F(ConnectionManagerUtilityTest, ExternalAddressExternalRequestUseRemote) {
+  std::vector<Http::OriginalIPDetectionSharedPtr> extensions; // No extensions
+  ON_CALL(config_, originalIpDetectionExtensions()).WillByDefault(ReturnRef(extensions));
+
   connection_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(
       std::make_shared<Network::Address::Ipv4Instance>("50.0.0.1"));
   EXPECT_CALL(config_, useRemoteAddress()).WillRepeatedly(Return(true));
@@ -1300,6 +1384,9 @@ TEST_F(ConnectionManagerUtilityTest, PipeAddressInvalidXFFtDontUseRemote) {
 // includes only internal addresses. Note that this is legacy behavior. See the comments
 // in mutateRequestHeaders() for more info.
 TEST_F(ConnectionManagerUtilityTest, AppendInternalAddressXffNotInternalRequest) {
+  std::vector<Http::OriginalIPDetectionSharedPtr> extensions; // No extensions
+  ON_CALL(config_, originalIpDetectionExtensions()).WillByDefault(ReturnRef(extensions));
+
   connection_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(
       std::make_shared<Network::Address::Ipv4Instance>("10.0.0.1"));
   ON_CALL(config_, useRemoteAddress()).WillByDefault(Return(true));
@@ -1313,6 +1400,9 @@ TEST_F(ConnectionManagerUtilityTest, AppendInternalAddressXffNotInternalRequest)
 // A request that is from an internal address and uses remote address should be an internal request.
 // It should also preserve x-envoy-external-address.
 TEST_F(ConnectionManagerUtilityTest, ExternalAddressInternalRequestUseRemote) {
+  std::vector<Http::OriginalIPDetectionSharedPtr> extensions; // No extensions
+  ON_CALL(config_, originalIpDetectionExtensions()).WillByDefault(ReturnRef(extensions));
+
   connection_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(
       std::make_shared<Network::Address::Ipv4Instance>("10.0.0.1"));
   ON_CALL(config_, useRemoteAddress()).WillByDefault(Return(true));
@@ -2309,6 +2399,9 @@ TEST_F(ConnectionManagerUtilityTest, RedirectAfterAllOtherNormalizations) {
 
 // test preserve_external_request_id true does not reset the passed requestId if passed
 TEST_F(ConnectionManagerUtilityTest, PreserveExternalRequestId) {
+  std::vector<Http::OriginalIPDetectionSharedPtr> extensions; // No extensions
+  ON_CALL(config_, originalIpDetectionExtensions()).WillByDefault(ReturnRef(extensions));
+
   connection_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(
       std::make_shared<Network::Address::Ipv4Instance>("134.2.2.11"));
   ON_CALL(config_, useRemoteAddress()).WillByDefault(Return(true));
@@ -2324,6 +2417,9 @@ TEST_F(ConnectionManagerUtilityTest, PreserveExternalRequestId) {
 
 // test preserve_external_request_id true but generates new request id when not passed
 TEST_F(ConnectionManagerUtilityTest, PreseverExternalRequestIdNoReqId) {
+  std::vector<Http::OriginalIPDetectionSharedPtr> extensions; // No extensions
+  ON_CALL(config_, originalIpDetectionExtensions()).WillByDefault(ReturnRef(extensions));
+
   connection_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(
       std::make_shared<Network::Address::Ipv4Instance>("134.2.2.11"));
   ON_CALL(config_, useRemoteAddress()).WillByDefault(Return(true));
@@ -2357,6 +2453,9 @@ TEST_F(ConnectionManagerUtilityTest, PreserveExternalRequestIdNoEdgeRequestGener
 
 // Test preserve_external_request_id false and edge_request true.
 TEST_F(ConnectionManagerUtilityTest, NoPreserveExternalRequestIdEdgeRequestGenerateRequestId) {
+  std::vector<Http::OriginalIPDetectionSharedPtr> extensions; // No extensions
+  ON_CALL(config_, originalIpDetectionExtensions()).WillByDefault(ReturnRef(extensions));
+
   ON_CALL(config_, preserveExternalRequestId()).WillByDefault(Return(false));
   connection_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(
       std::make_shared<Network::Address::Ipv4Instance>("134.2.2.11"));
@@ -2523,6 +2622,9 @@ TEST_F(ConnectionManagerUtilityTest, IgnoreAppendingXForwardedPortIfHasBeenSet) 
 // Verify when append_x_forwarded_port is turned on, the x-forwarded-port header from trusted hop
 // will be preserved.
 TEST_F(ConnectionManagerUtilityTest, PreserveXForwardedPortFromTrustedHop) {
+  std::vector<Http::OriginalIPDetectionSharedPtr> extensions; // No extensions
+  ON_CALL(config_, originalIpDetectionExtensions()).WillByDefault(ReturnRef(extensions));
+
   ON_CALL(config_, useRemoteAddress()).WillByDefault(Return(true));
   ON_CALL(config_, xffNumTrustedHops()).WillByDefault(Return(1));
   ON_CALL(config_, appendXForwardedPort()).WillByDefault(Return(true));
@@ -2537,6 +2639,9 @@ TEST_F(ConnectionManagerUtilityTest, PreserveXForwardedPortFromTrustedHop) {
 // Verify when append_x_forwarded_port is turned on, the x-forwarded-port header from untrusted hop
 // will be overwritten.
 TEST_F(ConnectionManagerUtilityTest, OverwriteXForwardedPortFromUntrustedHop) {
+  std::vector<Http::OriginalIPDetectionSharedPtr> extensions; // No extensions
+  ON_CALL(config_, originalIpDetectionExtensions()).WillByDefault(ReturnRef(extensions));
+
   ON_CALL(config_, useRemoteAddress()).WillByDefault(Return(true));
   ON_CALL(config_, xffNumTrustedHops()).WillByDefault(Return(0));
   ON_CALL(config_, appendXForwardedPort()).WillByDefault(Return(true));
@@ -2551,6 +2656,9 @@ TEST_F(ConnectionManagerUtilityTest, OverwriteXForwardedPortFromUntrustedHop) {
 // Verify when append_x_forwarded_port is not turned on, the x-forwarded-port header from untrusted
 // hop will not be overwritten.
 TEST_F(ConnectionManagerUtilityTest, DoNotOverwriteXForwardedPortFromUntrustedHop) {
+  std::vector<Http::OriginalIPDetectionSharedPtr> extensions; // No extensions
+  ON_CALL(config_, originalIpDetectionExtensions()).WillByDefault(ReturnRef(extensions));
+
   ON_CALL(config_, useRemoteAddress()).WillByDefault(Return(true));
   ON_CALL(config_, xffNumTrustedHops()).WillByDefault(Return(0));
   ON_CALL(config_, appendXForwardedPort()).WillByDefault(Return(false));
@@ -2585,6 +2693,57 @@ TEST_F(ConnectionManagerUtilityTest, DiscardTEHeaderWithoutTrailers) {
   callMutateRequestHeaders(headers, Protocol::Http2);
 
   EXPECT_EQ("", headers.getTEValue());
+}
+
+// Test the combination of useRemoteAddress=true with extensions configured
+TEST_F(ConnectionManagerUtilityTest, UseRemoteAddressTrueWithExtensions) {
+  std::vector<Http::OriginalIPDetectionSharedPtr> extensions;
+  extensions.push_back(getXFFExtension(2, false));
+  ON_CALL(config_, originalIpDetectionExtensions()).WillByDefault(ReturnRef(extensions));
+
+  connection_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(
+      std::make_shared<Network::Address::Ipv4Instance>("10.0.0.1"));
+  ON_CALL(config_, useRemoteAddress()).WillByDefault(Return(true));
+  ON_CALL(config_, xffNumTrustedHops()).WillByDefault(Return(0));
+  TestRequestHeaderMapImpl headers{{"x-forwarded-for", "203.0.113.1,203.0.113.2"}};
+
+  EXPECT_EQ((MutateRequestRet{"203.0.113.1:0", false, Tracing::Reason::NotTraceable}),
+            callMutateRequestHeaders(headers, Protocol::Http2));
+  EXPECT_EQ("203.0.113.1,203.0.113.2,10.0.0.1", headers.get_(Headers::get().ForwardedFor));
+}
+
+// Test useRemoteAddress=true with extensions, extensions should detect IP
+TEST_F(ConnectionManagerUtilityTest, UseRemoteAddressTrueWithExtensionsDetectsIP) {
+  std::vector<Http::OriginalIPDetectionSharedPtr> extensions;
+  extensions.push_back(getXFFExtension(0, false));
+  ON_CALL(config_, originalIpDetectionExtensions()).WillByDefault(ReturnRef(extensions));
+
+  connection_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(
+      std::make_shared<Network::Address::Ipv4Instance>("192.168.1.1"));
+  ON_CALL(config_, useRemoteAddress()).WillByDefault(Return(true));
+  ON_CALL(config_, xffNumTrustedHops()).WillByDefault(Return(0));
+  TestRequestHeaderMapImpl headers{{"x-forwarded-for", "203.0.113.5"}};
+
+  EXPECT_EQ((MutateRequestRet{"203.0.113.5:0", false, Tracing::Reason::NotTraceable}),
+            callMutateRequestHeaders(headers, Protocol::Http2));
+  EXPECT_EQ("203.0.113.5,192.168.1.1", headers.get_(Headers::get().ForwardedFor));
+  EXPECT_EQ("203.0.113.5", headers.get_("x-envoy-external-address"));
+}
+
+// Test useRemoteAddress=false with NO extensions (should get downstream address)
+TEST_F(ConnectionManagerUtilityTest, UseRemoteAddressFalseNoExtensions) {
+  std::vector<Http::OriginalIPDetectionSharedPtr> extensions; // Empty extensions
+  ON_CALL(config_, originalIpDetectionExtensions()).WillByDefault(ReturnRef(extensions));
+
+  connection_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(
+      std::make_shared<Network::Address::Ipv4Instance>("192.168.1.1"));
+  ON_CALL(config_, useRemoteAddress()).WillByDefault(Return(false));
+  ON_CALL(config_, xffNumTrustedHops()).WillByDefault(Return(0));
+  TestRequestHeaderMapImpl headers{{"x-forwarded-for", "203.0.113.5"}};
+
+  EXPECT_EQ((MutateRequestRet{"192.168.1.1:0", false, Tracing::Reason::NotTraceable}),
+            callMutateRequestHeaders(headers, Protocol::Http2));
+  EXPECT_EQ("203.0.113.5", headers.get_(Headers::get().ForwardedFor));
 }
 
 } // namespace Http


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: support original IP detection with use_remote_address
Additional Description: Need to support original IP detection extensions in edge proxy mode
Risk Level: Backward compatible (existing usecases are not breaking)
Testing: Unit tests
Docs Changes: Removed restriction around setting extensions when use_remote_address=true
Release Notes: TBD
Platform Specific Features: N/A
Fixes #40119 

Note that there are changes to existing tests with `use_remote_address=true` to ensure extensions are empty. This is because they were written assuming `use_remote_address=true` and extensions are mutually exclusive which is not the case anymore.