### PR TITLE
xDS: add XdsCreds and InsecureCreds support to GoogleGrpc

### DIFF
--- a/api/envoy/config/core/v3/grpc_service.proto
+++ b/api/envoy/config/core/v3/grpc_service.proto
@@ -91,6 +91,12 @@ message GrpcService {
           "envoy.api.v2.core.GrpcService.GoogleGrpc.GoogleLocalCredentials";
     }
 
+    // xDS credentials.
+    // [#not-implemented-hide:]
+    message XdsCredentials {
+      ChannelCredentials fallback_credentials = 1;
+    }
+
     // See https://grpc.io/docs/guides/auth.html#credential-types to understand Channel and Call
     // credential types.
     message ChannelCredentials {
@@ -106,6 +112,9 @@ message GrpcService {
         google.protobuf.Empty google_default = 2;
 
         GoogleLocalCredentials local_credentials = 3;
+
+        // [#not-implemented-hide:]
+        XdsCredentials xds_credentials = 4;
       }
     }
 

--- a/api/envoy/config/core/v3/grpc_service.proto
+++ b/api/envoy/config/core/v3/grpc_service.proto
@@ -115,6 +115,9 @@ message GrpcService {
 
         // [#not-implemented-hide:]
         XdsCredentials xds_credentials = 4;
+
+        // [#not-implemented-hide:]
+        google.protobuf.Empty insecure_credentials = 5;
       }
     }
 

--- a/api/envoy/config/core/v3/grpc_service.proto
+++ b/api/envoy/config/core/v3/grpc_service.proto
@@ -97,8 +97,14 @@ message GrpcService {
       ChannelCredentials fallback_credentials = 1;
     }
 
+    // Insecure credentials.
+    // [#not-implemented-hide:]
+    message InsecureCredentials {
+    }
+
     // See https://grpc.io/docs/guides/auth.html#credential-types to understand Channel and Call
     // credential types.
+    // [#next-free-field: 6]
     message ChannelCredentials {
       option (udpa.annotations.versioning).previous_message_type =
           "envoy.api.v2.core.GrpcService.GoogleGrpc.ChannelCredentials";
@@ -117,7 +123,7 @@ message GrpcService {
         XdsCredentials xds_credentials = 4;
 
         // [#not-implemented-hide:]
-        google.protobuf.Empty insecure_credentials = 5;
+        InsecureCredentials insecure_credentials = 5;
       }
     }
 


### PR DESCRIPTION
Commit Message: xDS: add XdsCreds and InsecureCreds support to GoogleGrpc
Additional Description: Adds fields to xDS.  Not currently implemented in Envoy, but should be trivial to add when someone needs it.
Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
