### PR TITLE
Add an option to disable connection flow control for HTTP/3 stream

### DIFF
--- a/api/envoy/config/core/v3/protocol.proto
+++ b/api/envoy/config/core/v3/protocol.proto
@@ -674,7 +674,7 @@ message GrpcProtocolOptions {
 }
 
 // A message which allows using HTTP/3.
-// [#next-free-field: 8]
+// [#next-free-field: 9]
 message Http3ProtocolOptions {
   QuicProtocolOptions quic_protocol_options = 1;
 
@@ -709,6 +709,10 @@ message Http3ProtocolOptions {
   // No huffman encoding, zero dynamic table capacity and no cookie crumbing.
   // This can be useful for trading off CPU vs bandwidth when an upstream HTTP/3 connection multiplexes multiple downstream connections.
   bool disable_qpack = 7;
+
+  // Disables connection level flow control for HTTP/3 streams. This is useful such that streams share the same connection but originated
+  // from different end-clients can make progress independently at non-frontline proxies.
+  bool disable_connection_flow_control_for_streams = 8;
 }
 
 // A message to control transformations to the :scheme header

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -329,5 +329,10 @@ new_features:
 - area: stateful_session
   change: |
     Added support for cookie attributes to stateful session cookie.
+- area: http3
+  change: |
+    Added envoy_v3_api_field_extensions.upstreams.http.v3.Http3ProtocolOptions.disable_connection_flow_control_for_streams, an experimental
+    support for disabling connection level flow control for streams. This can be useful for decoupling flow control among streams on the
+    same connection at a non-frontline proxy.  
 
 deprecated:

--- a/source/common/quic/envoy_quic_stream.h
+++ b/source/common/quic/envoy_quic_stream.h
@@ -46,7 +46,11 @@ public:
         filter_manager_connection_(filter_manager_connection),
         async_stream_blockage_change_(
             filter_manager_connection.dispatcher().createSchedulableCallback(
-                [this]() { switchStreamBlockState(); })) {}
+                [this]() { switchStreamBlockState(); })) {
+    if (http3_options_.disable_connection_flow_control_for_streams()) {
+      quic_stream_.DisableConnectionFlowControlForThisStream();
+    }
+  }
 
   ~EnvoyQuicStream() override = default;
 

--- a/test/common/quic/envoy_quic_server_session_test.cc
+++ b/test/common/quic/envoy_quic_server_session_test.cc
@@ -1179,6 +1179,42 @@ TEST_F(EnvoyQuicServerSessionTest, DisableQpack) {
   installReadFilter();
 }
 
+TEST_F(EnvoyQuicServerSessionTest, ConnectionFlowControlForStreamsEnabledByDefault) {
+  installReadFilter();
+  Http::MockRequestDecoder request_decoder;
+  Http::MockStreamCallbacks stream_callbacks;
+  EXPECT_CALL(request_decoder, accessLogHandlers());
+  setupRequestDecoderMock(request_decoder);
+  auto* stream =
+      dynamic_cast<EnvoyQuicServerStream*>(createNewStream(request_decoder, stream_callbacks));
+
+  EXPECT_TRUE(quic::test::QuicStreamPeer::StreamContributesToConnectionFlowControl(stream));
+
+  EXPECT_CALL(stream_callbacks, onResetStream(Http::StreamResetReason::LocalReset, _));
+  EXPECT_CALL(*quic_connection_, SendControlFrame(_));
+  stream->resetStream(Http::StreamResetReason::LocalReset);
+}
+
+TEST_F(EnvoyQuicServerSessionTest, DisableConnectionFlowControlForStreams) {
+  installReadFilter();
+  envoy::config::core::v3::Http3ProtocolOptions http3_options;
+  http3_options.set_disable_connection_flow_control_for_streams(true);
+  envoy_quic_session_.setHttp3Options(http3_options);
+
+  Http::MockRequestDecoder request_decoder;
+  Http::MockStreamCallbacks stream_callbacks;
+  EXPECT_CALL(request_decoder, accessLogHandlers());
+  setupRequestDecoderMock(request_decoder);
+  auto* stream =
+      dynamic_cast<EnvoyQuicServerStream*>(createNewStream(request_decoder, stream_callbacks));
+
+  EXPECT_FALSE(quic::test::QuicStreamPeer::StreamContributesToConnectionFlowControl(stream));
+
+  EXPECT_CALL(stream_callbacks, onResetStream(Http::StreamResetReason::LocalReset, _));
+  EXPECT_CALL(*quic_connection_, SendControlFrame(_));
+  stream->resetStream(Http::StreamResetReason::LocalReset);
+}
+
 TEST_F(EnvoyQuicServerSessionTest, Http3OptionsTest) {
   envoy::config::core::v3::Http3ProtocolOptions http3_options;
   auto* quic_options = http3_options.mutable_quic_protocol_options();


### PR DESCRIPTION
Commit Message: Add an option to disable connection level flow control for HTTP/3 stream

Additional Description: Streams in the same connection at a non-frontline proxy can originate from different end clients. This feature allows these streams's flow control be decoupled.

Risk Level: none. Not enabled by default
Testing: unit-tested.