### PR TITLE
router_check: add support for dynamic_metadata in router_check tool tests

### DIFF
--- a/test/tools/router_check/BUILD
+++ b/test/tools/router_check/BUILD
@@ -58,6 +58,7 @@ envoy_cc_test_library(
         "@com_github_mirror_tclap//:tclap",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
         "@envoy_api//envoy/config/route/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/filters/http/set_metadata/v3:pkg_cc_proto",
         "@envoy_api//envoy/type/v3:pkg_cc_proto",
     ],
 )
@@ -68,5 +69,6 @@ envoy_proto_library(
     deps = [
         "@envoy_api//envoy/config/core/v3:pkg",
         "@envoy_api//envoy/config/route/v3:pkg",
+        "@envoy_api//envoy/extensions/filters/http/set_metadata/v3:pkg",
     ],
 )

--- a/test/tools/router_check/router.cc
+++ b/test/tools/router_check/router.cc
@@ -7,6 +7,7 @@
 
 #include "envoy/config/core/v3/base.pb.h"
 #include "envoy/config/route/v3/route.pb.h"
+#include "envoy/extensions/filters/http/set_metadata/v3/set_metadata.pb.h"
 #include "envoy/type/v3/percent.pb.h"
 
 #include "source/common/common/enum_to_int.h"
@@ -234,6 +235,47 @@ Json::ObjectSharedPtr loadFromFile(const std::string& file_path, Api::Api& api) 
   return Json::Factory::loadFromString(contents).value();
 }
 
+void RouterCheckTool::applyDynamicMetadata(
+    Envoy::StreamInfo::StreamInfoImpl& stream_info,
+    const google::protobuf::RepeatedPtrField<envoy::extensions::filters::http::set_metadata::v3::Metadata>&
+        dynamic_metadata) {
+  if (dynamic_metadata.empty()) {
+    return;
+  }
+
+  for (const auto& metadata : dynamic_metadata) {
+    if (metadata.has_value()) {
+      auto& mut_untyped_metadata = *stream_info.dynamicMetadata().mutable_filter_metadata();
+      const std::string& metadata_namespace = metadata.metadata_namespace();
+      
+      if (!mut_untyped_metadata.contains(metadata_namespace)) {
+        // Insert the new entry.
+        mut_untyped_metadata[metadata_namespace] = metadata.value();
+      } else if (metadata.allow_overwrite()) {
+        // Get the existing metadata at this key for merging.
+        ProtobufWkt::Struct& orig_fields = mut_untyped_metadata[metadata_namespace];
+        const auto& to_merge = metadata.value();
+
+        // Merge the new metadata into the existing metadata.
+        StructUtil::update(orig_fields, to_merge);
+      }
+      // If allow_overwrite is false and entry exists, we skip it
+    } else if (metadata.has_typed_value()) {
+      auto& mut_typed_metadata = *stream_info.dynamicMetadata().mutable_typed_filter_metadata();
+      const std::string& metadata_namespace = metadata.metadata_namespace();
+      
+      if (!mut_typed_metadata.contains(metadata_namespace)) {
+        // Insert the new entry.
+        mut_typed_metadata[metadata_namespace] = metadata.typed_value();
+      } else if (metadata.allow_overwrite()) {
+        // Overwrite the existing typed metadata at this key.
+        mut_typed_metadata[metadata_namespace] = metadata.typed_value();
+      }
+      // If allow_overwrite is false and entry exists, we skip it
+    }
+  }
+}
+
 std::vector<envoy::RouterCheckToolSchema::ValidationItemResult>
 RouterCheckTool::compareEntries(const std::string& expected_routes) {
   envoy::RouterCheckToolSchema::Validation validation_config;
@@ -254,6 +296,10 @@ RouterCheckTool::compareEntries(const std::string& expected_routes) {
         Envoy::Http::Protocol::Http11, factory_context_->mainThreadDispatcher().timeSource(),
         connection_info_provider, StreamInfo::FilterState::LifeSpan::FilterChain);
     ToolConfig tool_config = ToolConfig::create(check_config);
+    
+    // Apply dynamic metadata to stream_info before routing
+    applyDynamicMetadata(stream_info, check_config.input().dynamic_metadata());
+    
     tool_config.route_ =
         config_->route(*tool_config.request_headers_, stream_info, tool_config.random_value_);
 

--- a/test/tools/router_check/router.h
+++ b/test/tools/router_check/router.h
@@ -123,6 +123,13 @@ private:
    */
   void sendLocalReply(ToolConfig& tool_config, const Router::DirectResponseEntry& entry);
 
+  /**
+   * Apply dynamic metadata to stream_info, similar to how the set_metadata filter works.
+   */
+  void applyDynamicMetadata(Envoy::StreamInfo::StreamInfoImpl& stream_info,
+                           const google::protobuf::RepeatedPtrField<envoy::extensions::filters::http::set_metadata::v3::Metadata>&
+                               dynamic_metadata);
+
   bool compareCluster(ToolConfig& tool_config,
                       const envoy::RouterCheckToolSchema::ValidationAssert& expected,
                       envoy::RouterCheckToolSchema::ValidationFailure& failure);

--- a/test/tools/router_check/test/config/DynamicMetadata.golden.proto.json
+++ b/test/tools/router_check/test/config/DynamicMetadata.golden.proto.json
@@ -1,0 +1,218 @@
+{
+  "tests": [
+    {
+      "test_name": "dynamic_metadata_basic_match",
+      "input": {
+        "authority": "edge.example.net",
+        "path": "/example",
+        "method": "GET",
+        "dynamic_metadata": [
+          {
+            "metadata_namespace": "example.meta",
+            "value": {
+              "foo": "bar"
+            }
+          }
+        ]
+      },
+      "validate": {
+        "cluster_name": "cluster2",
+        "virtual_host_name": "default"
+      }
+    },
+    {
+      "test_name": "dynamic_metadata_fallback_no_metadata",
+      "input": {
+        "authority": "edge.example.net",
+        "path": "/example",
+        "method": "GET"
+      },
+      "validate": {
+        "cluster_name": "cluster1",
+        "virtual_host_name": "default"
+      }
+    },
+    {
+      "test_name": "dynamic_metadata_different_value",
+      "input": {
+        "authority": "edge.example.net",
+        "path": "/example",
+        "method": "GET",
+        "dynamic_metadata": [
+          {
+            "metadata_namespace": "example.meta",
+            "value": {
+              "foo": "baz"
+            }
+          }
+        ]
+      },
+      "validate": {
+        "cluster_name": "cluster3",
+        "virtual_host_name": "default"
+      }
+    },
+    {
+      "test_name": "dynamic_metadata_nested_structure",
+      "input": {
+        "authority": "edge.example.net",
+        "path": "/nested",
+        "method": "GET",
+        "dynamic_metadata": [
+          {
+            "metadata_namespace": "nested.meta",
+            "value": {
+              "level1": {
+                "level2": "value"
+              }
+            }
+          }
+        ]
+      },
+      "validate": {
+        "cluster_name": "cluster4",
+        "virtual_host_name": "default"
+      }
+    },
+    {
+      "test_name": "dynamic_metadata_inverted_match",
+      "input": {
+        "authority": "edge.example.net",
+        "path": "/inverted",
+        "method": "GET",
+        "dynamic_metadata": [
+          {
+            "metadata_namespace": "example.meta",
+            "value": {
+              "foo": "different"
+            }
+          }
+        ]
+      },
+      "validate": {
+        "cluster_name": "cluster5",
+        "virtual_host_name": "default"
+      }
+    },
+    {
+      "test_name": "dynamic_metadata_inverted_no_match",
+      "input": {
+        "authority": "edge.example.net",
+        "path": "/inverted",
+        "method": "GET",
+        "dynamic_metadata": [
+          {
+            "metadata_namespace": "example.meta",
+            "value": {
+              "foo": "bar"
+            }
+          }
+        ]
+      },
+      "validate": {
+        "cluster_name": "cluster1",
+        "virtual_host_name": "default"
+      }
+    },
+    {
+      "test_name": "dynamic_metadata_multiple_matchers_match",
+      "input": {
+        "authority": "edge.example.net",
+        "path": "/multiple",
+        "method": "GET",
+        "dynamic_metadata": [
+          {
+            "metadata_namespace": "example.meta",
+            "value": {
+              "foo": "bar"
+            }
+          },
+          {
+            "metadata_namespace": "other.meta",
+            "value": {
+              "status": "active"
+            }
+          }
+        ]
+      },
+      "validate": {
+        "cluster_name": "cluster6",
+        "virtual_host_name": "default"
+      }
+    },
+    {
+      "test_name": "dynamic_metadata_multiple_matchers_partial_match",
+      "input": {
+        "authority": "edge.example.net",
+        "path": "/multiple",
+        "method": "GET",
+        "dynamic_metadata": [
+          {
+            "metadata_namespace": "example.meta",
+            "value": {
+              "foo": "bar"
+            }
+          }
+        ]
+      },
+      "validate": {
+        "cluster_name": "cluster1",
+        "virtual_host_name": "default"
+      }
+    },
+    {
+      "test_name": "dynamic_metadata_allow_overwrite",
+      "input": {
+        "authority": "edge.example.net",
+        "path": "/example",
+        "method": "GET",
+        "dynamic_metadata": [
+          {
+            "metadata_namespace": "example.meta",
+            "value": {
+              "foo": "initial"
+            }
+          },
+          {
+            "metadata_namespace": "example.meta",
+            "value": {
+              "foo": "bar"
+            },
+            "allow_overwrite": true
+          }
+        ]
+      },
+      "validate": {
+        "cluster_name": "cluster2",
+        "virtual_host_name": "default"
+      }
+    },
+    {
+      "test_name": "dynamic_metadata_no_overwrite",
+      "input": {
+        "authority": "edge.example.net",
+        "path": "/example",
+        "method": "GET",
+        "dynamic_metadata": [
+          {
+            "metadata_namespace": "example.meta",
+            "value": {
+              "foo": "bar"
+            }
+          },
+          {
+            "metadata_namespace": "example.meta",
+            "value": {
+              "foo": "different"
+            },
+            "allow_overwrite": false
+          }
+        ]
+      },
+      "validate": {
+        "cluster_name": "cluster2",
+        "virtual_host_name": "default"
+      }
+    }
+  ]
+} 

--- a/test/tools/router_check/test/config/DynamicMetadata.yaml
+++ b/test/tools/router_check/test/config/DynamicMetadata.yaml
@@ -1,0 +1,88 @@
+virtual_hosts:
+- name: default
+  domains:
+  - 'edge.example.net'
+  routes:
+  # Route with different dynamic metadata value - more specific path
+  - route:
+      cluster: cluster3
+    match:
+      path: /example
+      dynamic_metadata:
+        - filter: example.meta
+          path: 
+           - key: foo
+          value:
+            string_match:
+              exact: baz
+  # More specific route with dynamic metadata - should match first for foo=bar
+  - route:
+      cluster: cluster2
+    match:
+      path: /example
+      dynamic_metadata:
+        - filter: example.meta
+          path: 
+           - key: foo
+          value:
+            string_match:
+              exact: bar
+  # Route with nested metadata structure
+  - route:
+      cluster: cluster4
+    match:
+      path: /nested
+      dynamic_metadata:
+        - filter: nested.meta
+          path: 
+           - key: level1
+           - key: level2
+          value:
+            string_match:
+              exact: value
+  # Route with inverted dynamic metadata matcher - more specific path
+  - route:
+      cluster: cluster5
+    match:
+      path: /inverted
+      dynamic_metadata:
+        - filter: example.meta
+          path: 
+           - key: foo
+          value:
+            string_match:
+              exact: bar
+          invert: true
+  # Fallback route for /inverted path
+  - route:
+      cluster: cluster1
+    match:
+      path: /inverted
+  # Route with multiple dynamic metadata matchers - more specific path
+  - route:
+      cluster: cluster6
+    match:
+      path: /multiple
+      dynamic_metadata:
+        - filter: example.meta
+          path: 
+           - key: foo
+          value:
+            string_match:
+              exact: bar
+        - filter: other.meta
+          path: 
+           - key: status
+          value:
+            string_match:
+              exact: active
+  # Fallback route for /multiple path
+  - route:
+      cluster: cluster1
+    match:
+      path: /multiple
+  # Fallback route without dynamic metadata - should be last
+  - route:
+      cluster: cluster1
+    match:
+      path: /example 

--- a/test/tools/router_check/test/router_test.cc
+++ b/test/tools/router_check/test/router_test.cc
@@ -117,5 +117,20 @@ TEST(RouterCheckTest, RouterCheckTestRoutesFailuresTest) {
   EXPECT_TRUE(TestUtility::protoEqual(expected_result_proto, test_result, true));
 }
 
+TEST(RouterCheckTest, DynamicMetadataTest) {
+  const std::string config_filename_ =
+      TestEnvironment::runfilesPath(absl::StrCat(kDir, "DynamicMetadata.yaml"));
+  const std::string tests_filename_ =
+      TestEnvironment::runfilesPath(absl::StrCat(kDir, "DynamicMetadata.golden.proto.json"));
+  RouterCheckTool checktool = RouterCheckTool::create(config_filename_, false);
+  const std::vector<envoy::RouterCheckToolSchema::ValidationItemResult> test_results =
+      checktool.compareEntries(tests_filename_);
+  EXPECT_EQ(test_results.size(), 10);
+  for (const auto& test_result : test_results) {
+    EXPECT_TRUE(test_result.test_passed()) << "Test " << test_result.test_name() << " failed";
+    EXPECT_FALSE(test_result.has_failure()) << "Test " << test_result.test_name() << " has failure";
+  }
+}
+
 } // namespace
 } // namespace Envoy

--- a/test/tools/router_check/validation.proto
+++ b/test/tools/router_check/validation.proto
@@ -4,6 +4,7 @@ package envoy.RouterCheckToolSchema;
 
 import "envoy/config/core/v3/base.proto";
 import "envoy/config/route/v3/route_components.proto";
+import "envoy/extensions/filters/http/set_metadata/v3/set_metadata.proto";
 import "google/protobuf/wrappers.proto";
 import "validate/validate.proto";
 
@@ -69,6 +70,9 @@ message ValidationInput {
   // specified by the other config options and should not be set here.
   repeated envoy.config.core.v3.HeaderValue additional_request_headers = 10;
   repeated envoy.config.core.v3.HeaderValue additional_response_headers = 11;
+
+  // Metadata to be added to the request as input for route determination.
+  repeated envoy.extensions.filters.http.set_metadata.v3.Metadata dynamic_metadata = 12;
 
   // Runtime setting key to enable for the test case.
   // If a route depends on the runtime, the route will be enabled based on the random_value defined


### PR DESCRIPTION
Commit Message: add support for dynamic_metadata in router_check tool tests
Additional Description:
Risk Level: low
Testing: unit test
Docs Changes: Updated router_check tool docs to reflect the updated ValidationInput message and included an example
Release Notes: N/A
Platform Specific Features: N/A