### PR TITLE
router: convert InlinedVector to an array

### DIFF
--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -127,11 +127,11 @@ namespace {
 
 constexpr uint32_t DEFAULT_MAX_DIRECT_RESPONSE_BODY_SIZE_BYTES = 4096;
 
-// Returns a vector of header parsers, sorted by specificity. The `specificity_ascend` parameter
+// Returns an array of header parsers, sorted by specificity. The `specificity_ascend` parameter
 // specifies whether the returned parsers will be sorted from least specific to most specific
 // (global connection manager level header parser, virtual host level header parser and finally
 // route-level parser.) or the reverse.
-absl::InlinedVector<const HeaderParser*, 3>
+std::array<const HeaderParser*, 3>
 getHeaderParsers(const HeaderParser* global_route_config_header_parser,
                  const HeaderParser* vhost_header_parser, const HeaderParser* route_header_parser,
                  bool specificity_ascend) {
@@ -977,14 +977,14 @@ RouteEntryImplBase::requestHeaderTransforms(const StreamInfo::StreamInfo& stream
   return transforms;
 }
 
-absl::InlinedVector<const HeaderParser*, 3>
+std::array<const HeaderParser*, 3>
 RouteEntryImplBase::getRequestHeaderParsers(bool specificity_ascend) const {
   return getHeaderParsers(&vhost_->globalRouteConfig().requestHeaderParser(),
                           &vhost_->requestHeaderParser(), &requestHeaderParser(),
                           specificity_ascend);
 }
 
-absl::InlinedVector<const HeaderParser*, 3>
+std::array<const HeaderParser*, 3>
 RouteEntryImplBase::getResponseHeaderParsers(bool specificity_ascend) const {
   return getHeaderParsers(&vhost_->globalRouteConfig().responseHeaderParser(),
                           &vhost_->responseHeaderParser(), &responseHeaderParser(),

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -846,26 +846,24 @@ private:
   };
 
   /**
-   * Returns a vector of request header parsers which applied or will apply header transformations
+   * Returns an array of request header parsers which applied or will apply header transformations
    * to the request in this route.
    * @param specificity_ascend specifies whether the returned parsers will be sorted from least
    *        specific to most specific (global connection manager level header parser, virtual host
    *        level header parser and finally route-level parser.) or the reverse.
-   * @return a vector of request header parsers.
+   * @return an array of request header parsers.
    */
-  absl::InlinedVector<const HeaderParser*, 3>
-  getRequestHeaderParsers(bool specificity_ascend) const;
+  std::array<const HeaderParser*, 3> getRequestHeaderParsers(bool specificity_ascend) const;
 
   /**
-   * Returns a vector of response header parsers which applied or will apply header transformations
+   * Returns an array of response header parsers which applied or will apply header transformations
    * to the response in this route.
    * @param specificity_ascend specifies whether the returned parsers will be sorted from least
    *        specific to most specific (global connection manager level header parser, virtual host
    *        level header parser and finally route-level parser.) or the reverse.
-   * @return a vector of request header parsers.
+   * @return an array of request header parsers.
    */
-  absl::InlinedVector<const HeaderParser*, 3>
-  getResponseHeaderParsers(bool specificity_ascend) const;
+  std::array<const HeaderParser*, 3> getResponseHeaderParsers(bool specificity_ascend) const;
 
   std::unique_ptr<const RuntimeData>
   loadRuntimeData(const envoy::config::route::v3::RouteMatch& route);


### PR DESCRIPTION
Commit Message: router: convert InlinedVector to an array
Additional Description:
Minor internal refactor - using an array instead of a dynamic vector. Fits better with the data-structure intent and uses a bit less memory.

Risk Level: low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A