### PR TITLE
runtime: fix errors when using legacy header limit settings

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -129,6 +129,11 @@ bug_fixes:
   change: |
     Fixes a bug in Envoy's HTTP/3-to-HTTP/1 proxying when a ``transfer-encoding`` header is incorrectly appended.
     Protected by runtime guard ``envoy.reloadable_features.quic_signal_headers_only_to_http1_backend``.
+- area: runtime
+  change: |
+    Fixed a bug which resulted in an ENVOY_BUG being incorrectly triggered when runtime settings ``envoy.reloadable_features.max_request_headers_count``,
+    ``envoy.reloadable_features.max_response_headers_count``, ``envoy.reloadable_features.max_request_headers_size_kb``, or
+    ``envoy.reloadable_features.max_response_headers_size_kb`` were set.
 - area: tls
   change: |
     Fixes a bug where empty trusted CA file or inline string is accepted and causes Envoy to successfully validate any certificate

--- a/envoy/http/codec.h
+++ b/envoy/http/codec.h
@@ -42,13 +42,13 @@ static constexpr uint32_t DEFAULT_MAX_REQUEST_HEADERS_KB = 60;
 // Default maximum number of headers.
 static constexpr uint32_t DEFAULT_MAX_HEADERS_COUNT = 100;
 
-const char MaxRequestHeadersCountOverrideKey[] =
+constexpr absl::string_view MaxRequestHeadersCountOverrideKey =
     "envoy.reloadable_features.max_request_headers_count";
-const char MaxResponseHeadersCountOverrideKey[] =
+constexpr absl::string_view MaxResponseHeadersCountOverrideKey =
     "envoy.reloadable_features.max_response_headers_count";
-const char MaxRequestHeadersSizeOverrideKey[] =
+constexpr absl::string_view MaxRequestHeadersSizeOverrideKey =
     "envoy.reloadable_features.max_request_headers_size_kb";
-const char MaxResponseHeadersSizeOverrideKey[] =
+constexpr absl::string_view MaxResponseHeadersSizeOverrideKey =
     "envoy.reloadable_features.max_response_headers_size_kb";
 
 class Stream;

--- a/source/common/runtime/BUILD
+++ b/source/common/runtime/BUILD
@@ -48,6 +48,7 @@ envoy_cc_library(
         # the harder it is to runtime-guard without dependency loops.
         "@com_google_absl//absl/flags:commandlineflag",
         "@com_google_absl//absl/flags:flag",
+        "//envoy/http:codec_interface",
         "//envoy/runtime:runtime_interface",
         "//source/common/common:hash_lib",
         "//source/common/singleton:const_singleton",

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -1,5 +1,7 @@
 #include "source/common/runtime/runtime_features.h"
 
+#include "envoy/http/codec.h"
+
 #include "absl/flags/commandlineflag.h"
 #include "absl/flags/flag.h"
 #include "absl/strings/match.h"
@@ -233,6 +235,13 @@ bool hasRuntimePrefix(absl::string_view feature) {
 
 bool isRuntimeFeature(absl::string_view feature) {
   return RuntimeFeaturesDefaults::get().getFlag(feature) != nullptr;
+}
+
+bool isLegacyRuntimeFeature(absl::string_view feature) {
+  return feature == Http::MaxRequestHeadersCountOverrideKey ||
+         feature == Http::MaxResponseHeadersCountOverrideKey ||
+         feature == Http::MaxRequestHeadersSizeOverrideKey ||
+         feature == Http::MaxResponseHeadersSizeOverrideKey;
 }
 
 bool runtimeFeatureEnabled(absl::string_view feature) {

--- a/source/common/runtime/runtime_features.h
+++ b/source/common/runtime/runtime_features.h
@@ -15,6 +15,12 @@ namespace Runtime {
 
 bool hasRuntimePrefix(absl::string_view feature);
 bool isRuntimeFeature(absl::string_view feature);
+
+// Returns true if the feature is one of the legacy runtime features that uses the
+// `envoy.reloadable_features` prefix but is not implemented like all other runtime
+// feature flags.
+bool isLegacyRuntimeFeature(absl::string_view feature);
+
 bool runtimeFeatureEnabled(absl::string_view feature);
 uint64_t getInteger(absl::string_view feature, uint64_t default_value);
 

--- a/source/common/runtime/runtime_impl.cc
+++ b/source/common/runtime/runtime_impl.cc
@@ -445,7 +445,7 @@ absl::Status ProtoLayer::walkProtoValue(const ProtobufWkt::Value& v, const std::
     break;
   case ProtobufWkt::Value::kNumberValue:
   case ProtobufWkt::Value::kBoolValue:
-    if (hasRuntimePrefix(prefix) && !isRuntimeFeature(prefix)) {
+    if (hasRuntimePrefix(prefix) && !isRuntimeFeature(prefix) && !isLegacyRuntimeFeature(prefix)) {
       IS_ENVOY_BUG(absl::StrCat(
           "Using a removed guard ", prefix,
           ". In future version of Envoy this will be treated as invalid configuration"));

--- a/test/common/runtime/runtime_impl_test.cc
+++ b/test/common/runtime/runtime_impl_test.cc
@@ -760,6 +760,35 @@ TEST_F(StaticLoaderImplTest, ProtoParsing) {
       .createEntry(empty_value, "");
 }
 
+// Test that an ENVOY_BUG is emitted for a value with `envoy.reloadable_features` as a prefix which
+// isn't an actual feature flag.
+TEST_F(StaticLoaderImplTest, ProtoParsingRuntimeFeaturePrefix) {
+  // Validate proto parsing sanity.
+  base_ = TestUtility::parseYaml<ProtobufWkt::Struct>(R"EOF(
+    envoy.reloadable_features.not_a_feature: true
+  )EOF");
+  EXPECT_ENVOY_BUG(setup(),
+                   "Using a removed guard envoy.reloadable_features.not_a_feature. In future "
+                   "version of Envoy this will be treated as invalid configuration");
+}
+
+// Test that legacy names do not result in an ENVOY_BUG and the values can be fetched correctly.
+TEST_F(StaticLoaderImplTest, ProtoParsingRuntimeFeaturePrefixLegacy) {
+  // Validate proto parsing sanity.
+  base_ = TestUtility::parseYaml<ProtobufWkt::Struct>(R"EOF(
+    envoy.reloadable_features.max_request_headers_count: 2
+    envoy.reloadable_features.max_response_headers_count: 3
+    envoy.reloadable_features.max_request_headers_size_kb: 4
+    envoy.reloadable_features.max_response_headers_size_kb: 5
+  )EOF");
+  setup();
+
+  EXPECT_EQ(2, loader_->snapshot().getInteger(Http::MaxRequestHeadersCountOverrideKey, 0));
+  EXPECT_EQ(3, loader_->snapshot().getInteger(Http::MaxResponseHeadersCountOverrideKey, 0));
+  EXPECT_EQ(4, loader_->snapshot().getInteger(Http::MaxRequestHeadersSizeOverrideKey, 0));
+  EXPECT_EQ(5, loader_->snapshot().getInteger(Http::MaxResponseHeadersSizeOverrideKey, 0));
+}
+
 TEST_F(StaticLoaderImplTest, InvalidNumerator) {
   base_ = TestUtility::parseYaml<ProtobufWkt::Struct>(R"EOF(
     invalid_numerator:


### PR DESCRIPTION
When the runtime settings for
`envoy.reloadable_features.max_request_headers_count` and similar were used, and ENVOY_BUG was incorrectly generated.

Fixes #40093
Risk Level: Low
Testing: new tests added
Release Notes: added
