### PR TITLE
ssl: add OID map properties for proxy-wasm

### DIFF
--- a/envoy/ssl/connection.h
+++ b/envoy/ssl/connection.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <map>
 #include <memory>
 #include <string>
 
@@ -190,6 +191,20 @@ public:
    *         Returns {} if there is no local certificate, or no extensions.
    **/
   virtual absl::Span<const std::string> oidsLocalCertificate() const PURE;
+
+  /**
+   * @return const std::map<std::string, std::string>& the map of OID entries to their values
+   *         from peer certificate extensions. Returns empty map if there is no peer certificate,
+   *         or no extensions.
+   **/
+  virtual const std::map<std::string, std::string>& oidMapPeerCertificate() const PURE;
+
+  /**
+   * @return const std::map<std::string, std::string>& the map of OID entries to their values
+   *         from local certificate extensions. Returns empty map if there is no local certificate,
+   *         or no extensions.
+   **/
+  virtual const std::map<std::string, std::string>& oidMapLocalCertificate() const PURE;
 
   /**
    * @return absl::optional<SystemTime> the time that the peer certificate was issued and should be

--- a/source/common/tls/connection_info_impl_base.cc
+++ b/source/common/tls/connection_info_impl_base.cc
@@ -457,6 +457,28 @@ const std::string& ConnectionInfoImplBase::sessionId() const {
   });
 }
 
+const std::map<std::string, std::string>& ConnectionInfoImplBase::oidMapPeerCertificate() const {
+  return getCachedValueOrCreate<std::map<std::string, std::string>>(
+      CachedValueTag::OidMapPeerCertificate, [](SSL* ssl) {
+        bssl::UniquePtr<X509> cert(SSL_get_peer_certificate(ssl));
+        if (!cert) {
+          return std::map<std::string, std::string>{};
+        }
+        return Utility::getCertificateOidMap(*cert);
+      });
+}
+
+const std::map<std::string, std::string>& ConnectionInfoImplBase::oidMapLocalCertificate() const {
+  return getCachedValueOrCreate<std::map<std::string, std::string>>(
+      CachedValueTag::OidMapLocalCertificate, [](SSL* ssl) {
+        X509* cert = SSL_get_certificate(ssl);
+        if (!cert) {
+          return std::map<std::string, std::string>{};
+        }
+        return Utility::getCertificateOidMap(*cert);
+      });
+}
+
 } // namespace Tls
 } // namespace TransportSockets
 } // namespace Extensions

--- a/source/common/tls/connection_info_impl_base.h
+++ b/source/common/tls/connection_info_impl_base.h
@@ -45,6 +45,8 @@ public:
   absl::Span<const std::string> othernameSansLocalCertificate() const override;
   absl::Span<const std::string> oidsPeerCertificate() const override;
   absl::Span<const std::string> oidsLocalCertificate() const override;
+  const std::map<std::string, std::string>& oidMapPeerCertificate() const override;
+  const std::map<std::string, std::string>& oidMapLocalCertificate() const override;
   absl::optional<SystemTime> validFromPeerCertificate() const override;
   absl::optional<SystemTime> expirationPeerCertificate() const override;
   const std::string& sessionId() const override;
@@ -88,6 +90,8 @@ private:
     IpSansPeerCertificate,
     OidsPeerCertificate,
     OidsLocalCertificate,
+    OidMapPeerCertificate,
+    OidMapLocalCertificate,
   };
 
   // Retrieve the given tag from the set of cached values, or create the value via the supplied
@@ -101,7 +105,7 @@ private:
   // table of cached values that are created on demand. Use a node_hash_map so that returned
   // references are not invalidated when additional items are added.
   using CachedValue = absl::variant<std::string, std::vector<std::string>, Ssl::ParsedX509NamePtr,
-                                    bssl::UniquePtr<GENERAL_NAMES>>;
+                                    bssl::UniquePtr<GENERAL_NAMES>, std::map<std::string, std::string>>;
   mutable absl::node_hash_map<CachedValueTag, CachedValue> cached_values_;
 };
 

--- a/source/common/tls/utility.h
+++ b/source/common/tls/utility.h
@@ -117,6 +117,13 @@ std::vector<std::string> getCertificateExtensionOids(X509& cert);
 absl::string_view getCertificateExtensionValue(X509& cert, absl::string_view extension_name);
 
 /**
+ * Retrieves all OIDs and their values from a certificate's extensions as a map.
+ * @param cert the certificate.
+ * @return std::map<std::string, std::string> a map of OID strings to their extension values.
+ */
+std::map<std::string, std::string> getCertificateOidMap(X509& cert);
+
+/**
  * Returns the seconds since unix epoch of the expiration time of this certificate.
  * @param cert the certificate
  * @return the seconds since unix epoch as a duration, or max duration if cert is null.

--- a/source/extensions/filters/common/expr/context.h
+++ b/source/extensions/filters/common/expr/context.h
@@ -71,6 +71,8 @@ constexpr absl::string_view DNSSanLocalCertificate = "dns_san_local_certificate"
 constexpr absl::string_view DNSSanPeerCertificate = "dns_san_peer_certificate";
 constexpr absl::string_view SHA256PeerCertificateDigest = "sha256_peer_certificate_digest";
 constexpr absl::string_view DownstreamTransportFailureReason = "transport_failure_reason";
+constexpr absl::string_view OidMapLocalCertificate = "oid_map_local_certificate";
+constexpr absl::string_view OidMapPeerCertificate = "oid_map_peer_certificate";
 
 // Source properties
 constexpr absl::string_view Source = "source";

--- a/test/mocks/ssl/mocks.h
+++ b/test/mocks/ssl/mocks.h
@@ -71,6 +71,8 @@ public:
   MOCK_METHOD(absl::Span<const std::string>, othernameSansLocalCertificate, (), (const));
   MOCK_METHOD(absl::Span<const std::string>, oidsPeerCertificate, (), (const));
   MOCK_METHOD(absl::Span<const std::string>, oidsLocalCertificate, (), (const));
+  MOCK_METHOD((const std::map<std::string, std::string>&), oidMapPeerCertificate, (), (const));
+  MOCK_METHOD((const std::map<std::string, std::string>&), oidMapLocalCertificate, (), (const));
   MOCK_METHOD(absl::optional<SystemTime>, validFromPeerCertificate, (), (const));
   MOCK_METHOD(absl::optional<SystemTime>, expirationPeerCertificate, (), (const));
   MOCK_METHOD(const std::string&, sessionId, (), (const));


### PR DESCRIPTION
This implements the proposal from proxy-wasm/spec#89.

This change adds new methods to the SSL ConnectionInfo interface to expose certificate extension OID maps, which allow proxy-wasm filters to access certificate extension data. 

The new properties are:
- `connection.oid_map_local_certificate` (map)
- `connection.oid_map_peer_certificate` (map)
- `upstream.oid_map_local_certificate` (map)
- `upstream.oid_map_peer_certificate` (map)

Each property provides a map of OID strings to their values extracted from certificate extensions.