### PR TITLE
tls: fix incorrectly cached empty peer certificate values

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -125,6 +125,13 @@ bug_fixes:
   change: |
     Fixed an bug where the config validation server will crash when the configuration contains
     ``%CEL%`` or ``%METADATA%`` substitution formatter.
+- area: tls
+  change: |
+    Fixed an issue with incorrectly cached connection properties on TLS connections.
+    If TLS connection data was queried before it was available, an empty value was being incorrectly cached, preventing later calls from
+    getting the correct value. This could be triggered with a ``tcp_proxy`` access log configured to emit a log upon connection
+    establishment if the log contains fields of the the TLS peer certificate. Then a later use of the data, such as the network RBAC
+    filter validating a peer certificate SAN, may incorrectly fail due to the emtpy cached value.
 - area: quic
   change: |
     Fixes a bug in Envoy's HTTP/3-to-HTTP/1 proxying when a ``transfer-encoding`` header is incorrectly appended.

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -131,7 +131,7 @@ bug_fixes:
     If TLS connection data was queried before it was available, an empty value was being incorrectly cached, preventing later calls from
     getting the correct value. This could be triggered with a ``tcp_proxy`` access log configured to emit a log upon connection
     establishment if the log contains fields of the the TLS peer certificate. Then a later use of the data, such as the network RBAC
-    filter validating a peer certificate SAN, may incorrectly fail due to the emtpy cached value.
+    filter validating a peer certificate SAN, may incorrectly fail due to the empty cached value.
 - area: quic
   change: |
     Fixes a bug in Envoy's HTTP/3-to-HTTP/1 proxying when a ``transfer-encoding`` header is incorrectly appended.

--- a/test/integration/tcp_proxy_integration_test.cc
+++ b/test/integration/tcp_proxy_integration_test.cc
@@ -1521,6 +1521,50 @@ TEST_P(TcpProxySslIntegrationTest, LargeBidirectionalTlsWrites) {
   sendAndReceiveTlsData(large_data, large_data);
 }
 
+// Test that if SSL connection data, such as peer certificate data, is read before it is
+// available, it is not cached when it is read again later when available.
+TEST_P(TcpProxySslIntegrationTest, SslConnectionDataEarlyReadNotCached) {
+  std::string access_log_path = TestEnvironment::temporaryPath(
+      fmt::format("access_log{}{}.txt", version_ == Network::Address::IpVersion::v4 ? "v4" : "v6",
+                  TestUtility::uniqueFilename()));
+  config_helper_.addConfigModifier([&](envoy::config::bootstrap::v3::Bootstrap& bootstrap) -> void {
+    auto* listener = bootstrap.mutable_static_resources()->mutable_listeners(0);
+    auto* filter_chain = listener->mutable_filter_chains(0);
+    auto* config_blob = filter_chain->mutable_filters(0)->mutable_typed_config();
+
+    ASSERT_TRUE(config_blob->Is<envoy::extensions::filters::network::tcp_proxy::v3::TcpProxy>());
+    auto tcp_proxy_config =
+        MessageUtil::anyConvert<envoy::extensions::filters::network::tcp_proxy::v3::TcpProxy>(
+            *config_blob);
+
+    auto* access_log = tcp_proxy_config.add_access_log();
+    access_log->set_name("accesslog");
+    envoy::extensions::access_loggers::file::v3::FileAccessLog access_log_config;
+    access_log_config.set_path(access_log_path);
+    access_log_config.mutable_log_format()->mutable_text_format_source()->set_inline_string(
+        "san=%DOWNSTREAM_PEER_URI_SAN% fingerprint=%DOWNSTREAM_PEER_FINGERPRINT_256%\n");
+    access_log->mutable_typed_config()->PackFrom(access_log_config);
+    tcp_proxy_config.mutable_access_log_options()->set_flush_access_log_on_connected(true);
+    config_blob->PackFrom(tcp_proxy_config);
+  });
+
+  setupConnections();
+  std::string large_data(1024 * 8, 'a');
+  sendAndReceiveTlsData(large_data, large_data);
+
+  // The test set `flush_access_log_on_connected`, so the first access log is emitted before the
+  // handshake has completed.
+  auto log_result = waitForAccessLog(access_log_path, 0, true);
+  EXPECT_EQ(log_result, "san=- fingerprint=-");
+
+  // The second accesss log is when the connection closes, so the handshake is complete and
+  // a valid peer cert is now available.
+  log_result = waitForAccessLog(access_log_path, 1, false);
+  EXPECT_EQ(log_result,
+            "san=spiffe://lyft.com/frontend-team,http://frontend.lyft.com "
+            "fingerprint=7346b3836cfc41385351191b5e6163f1a69704cfdf0a03634ed2019128e6fdc4");
+}
+
 // Test that a half-close on the downstream side is proxied correctly.
 TEST_P(TcpProxySslIntegrationTest, DownstreamHalfClose) {
   setupConnections();

--- a/test/integration/tcp_proxy_integration_test.cc
+++ b/test/integration/tcp_proxy_integration_test.cc
@@ -1557,7 +1557,7 @@ TEST_P(TcpProxySslIntegrationTest, SslConnectionDataEarlyReadNotCached) {
   auto log_result = waitForAccessLog(access_log_path, 0, true);
   EXPECT_EQ(log_result, "san=- fingerprint=-");
 
-  // The second accesss log is when the connection closes, so the handshake is complete and
+  // The second access log is when the connection closes, so the handshake is complete and
   // a valid peer cert is now available.
   log_result = waitForAccessLog(access_log_path, 1, false);
   EXPECT_EQ(log_result,


### PR DESCRIPTION
If tls connection data was queried before it was available, and empty value was being incorrectly cached, preventing later calls from getting the correct value.

One way this could be triggered was with an access log entry being emitted before the TLS peer certificate was received during the TLS handshake, which can be configured with tcp_proxy.

Fixes #40137

Risk Level: Low
Testing: New test added
Docs Changes: none
Release Notes: added