### PR TITLE
Mark oauth2 extension as stable

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -101,6 +101,9 @@ minor_behavior_changes:
   change: |
     Now the ``METADATA`` and ``CEL`` substitution formatters could access or log the metadata of
     virtual host in case the route is not matched but the virtual host is found.
+- area: oauth2
+  change: |
+    Extension status changed from ``alpha`` to ``stable``.
 
 bug_fixes:
 # *Changes expected to improve the state of the world and are unlikely to have negative effects*

--- a/source/extensions/extensions_metadata.yaml
+++ b/source/extensions/extensions_metadata.yaml
@@ -512,7 +512,7 @@ envoy.filters.http.oauth2:
   categories:
   - envoy.filters.http
   security_posture: robust_to_untrusted_downstream
-  status: alpha
+  status: stable
   type_urls:
   - envoy.extensions.filters.http.oauth2.v3.OAuth2
 envoy.filters.http.on_demand:


### PR DESCRIPTION
Commit Message:
oauth2 extension is widely used and has been stable for some time.

Risk Level: Low
Testing: n/a
Docs Changes: n/a
Release Notes: Yes
Platform Specific Features: n/a
