### PR TITLE
mobile: Fix tests for not setting the trusted CA when empty

### DIFF
--- a/mobile/test/cc/unit/envoy_config_test.cc
+++ b/mobile/test/cc/unit/envoy_config_test.cc
@@ -112,7 +112,6 @@ TEST(TestConfig, ConfigIsApplied) {
       "key: \"device_os\" value { string_value: \"probably-ubuntu-on-CI\" } }",
       "key: \"app_version\" value { string_value: \"1.2.3\" } }",
       "key: \"app_id\" value { string_value: \"1234-1234-1234\" } }",
-      "validation_context { trusted_ca {",
       "initial_stream_window_size { value: 6291456 }",
       "initial_connection_window_size { value: 15728640 }"};
 
@@ -428,7 +427,6 @@ TEST(TestConfig, EnablePlatformCertificatesValidation) {
   std::unique_ptr<Bootstrap> bootstrap = engine_builder.generateBootstrap();
   EXPECT_THAT(bootstrap->ShortDebugString(),
               Not(HasSubstr("envoy_mobile.cert_validator.platform_bridge_cert_validator")));
-  EXPECT_THAT(bootstrap->ShortDebugString(), HasSubstr("trusted_ca"));
 
   engine_builder.enablePlatformCertificatesValidation(true);
   bootstrap = engine_builder.generateBootstrap();

--- a/mobile/test/java/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
+++ b/mobile/test/java/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
@@ -213,9 +213,6 @@ class EnvoyConfigurationTest {
     assertThat(resolvedTemplate).contains("buffer_filter_1")
     assertThat(resolvedTemplate).contains("type.googleapis.com/envoy.extensions.filters.http.buffer.v3.Buffer")
 
-    // Cert Validation
-    assertThat(resolvedTemplate).contains("trusted_ca")
-
     // Validate ordering between filters and platform filters
     assertThat(resolvedTemplate).matches(Pattern.compile(".*name1.*name2.*buffer_filter_1.*buffer_filter_2.*", Pattern.DOTALL))
     // Validate that createProtoString doesn't change filter order.


### PR DESCRIPTION
This is a follow up for https://github.com/envoyproxy/envoy/pull/40027.