### PR TITLE
rbac: avoid unnecessary string copying

### DIFF
--- a/source/extensions/filters/http/rbac/rbac_filter.cc
+++ b/source/extensions/filters/http/rbac/rbac_filter.cc
@@ -85,12 +85,12 @@ RoleBasedAccessControlFilterConfig::RoleBasedAccessControlFilterConfig(
       const Http::StreamFilterCallbacks* callbacks) const {                                        \
     const auto* route_local = Http::Utility::resolveMostSpecificPerFilterConfig<                   \
         RoleBasedAccessControlRouteSpecificFilterConfig>(callbacks);                               \
-    std::string prefix = PREFIX;                                                                   \
+    absl::string_view prefix = PREFIX;                                                             \
     if (route_local && !route_local->ROUTE_LOCAL_PREFIX_OVERRIDE().empty()) {                      \
       prefix = route_local->ROUTE_LOCAL_PREFIX_OVERRIDE();                                         \
     }                                                                                              \
-    return prefix +                                                                                \
-           Filters::Common::RBAC::DynamicMetadataKeysSingleton::get().DYNAMIC_METADATA_KEY;        \
+    return absl::StrCat(                                                                           \
+        prefix, Filters::Common::RBAC::DynamicMetadataKeysSingleton::get().DYNAMIC_METADATA_KEY);  \
   }
 
 DEFINE_DYNAMIC_METADATA_STAT_KEY_GETTER(shadowEffectivePolicyIdField, shadow_rules_stat_prefix_,

--- a/source/extensions/filters/http/rbac/rbac_filter.h
+++ b/source/extensions/filters/http/rbac/rbac_filter.h
@@ -37,9 +37,9 @@ public:
     return mode == Filters::Common::RBAC::EnforcementMode::Enforced ? engine_.get()
                                                                     : shadow_engine_.get();
   }
-  std::string rulesStatPrefix() const { return rules_stat_prefix_; }
+  absl::string_view rulesStatPrefix() const { return rules_stat_prefix_; }
 
-  std::string shadowRulesStatPrefix() const { return shadow_rules_stat_prefix_; }
+  absl::string_view shadowRulesStatPrefix() const { return shadow_rules_stat_prefix_; }
 
   bool perRuleStatsEnabled() const { return per_rule_stats_; }
 


### PR DESCRIPTION
Commit Message: rbac: avoid unnecessary string copying
Additional Description:
Minor refactor of the http RBAC filter to avoid unnecessary string copy for the getters.

Risk Level: low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A