### PR TITLE
wasm: add config setting to control StopIteration behavior

### DIFF
--- a/api/envoy/extensions/wasm/v3/wasm.proto
+++ b/api/envoy/extensions/wasm/v3/wasm.proto
@@ -148,7 +148,7 @@ message EnvironmentVariables {
 }
 
 // Base Configuration for Wasm Plugins e.g. filters and services.
-// [#next-free-field: 9]
+// [#next-free-field: 10]
 message PluginConfig {
   // A unique name for a filters/services in a VM for use in identifying the filter/service if
   // multiple filters/services are handled by the same ``vm_id`` and ``root_id`` and for
@@ -192,6 +192,10 @@ message PluginConfig {
 
   // Configuration for restricting Proxy-Wasm capabilities available to modules.
   CapabilityRestrictionConfig capability_restriction_config = 6;
+
+  // Whether or not to allow plugin onRequestHeaders and onResponseHeaders callbacks to return
+  // FilterHeadersStatus::StopIteration.
+  bool allow_on_headers_stop_iteration = 9;
 }
 
 // WasmService is configured as a built-in ``envoy.wasm_service`` :ref:`WasmService

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -1403,11 +1403,11 @@ REPOSITORY_LOCATIONS_SPEC = dict(
     proxy_wasm_cpp_host = dict(
         project_name = "WebAssembly for Proxies (C++ host implementation)",
         project_desc = "WebAssembly for Proxies (C++ host implementation)",
-        project_url = "https://github.com/proxy-wasm/proxy-wasm-cpp-host",
-        version = "c4d7bb0fda912e24c64daf2aa749ec54cec99412",
-        sha256 = "3ea005e85d2b37685149c794c6876fd6de7f632f0ad49dc2b3cd580e7e7a5525",
+        project_url = "https://github.com/mpwarres/proxy-wasm-cpp-host",
+        version = "769b7bd1e501eb45c8ee1da53e85c29a207f5602",
+        sha256 = "0f476b2c362079415e640f6fcd3e62d7c1c4197be5af3b9902a039f42f13dc28",
         strip_prefix = "proxy-wasm-cpp-host-{version}",
-        urls = ["https://github.com/proxy-wasm/proxy-wasm-cpp-host/archive/{version}.tar.gz"],
+        urls = ["https://github.com/mpwarres/proxy-wasm-cpp-host/archive/{version}.tar.gz"],
         use_category = ["dataplane_ext"],
         extensions = [
             "envoy.access_loggers.wasm",

--- a/source/extensions/common/wasm/context.cc
+++ b/source/extensions/common/wasm/context.cc
@@ -162,13 +162,17 @@ Context::Context(Wasm* wasm, const PluginSharedPtr& plugin) : ContextBase(wasm, 
   if (wasm != nullptr) {
     abi_version_ = wasm->abi_version_;
   }
-  root_local_info_ = &std::static_pointer_cast<Plugin>(plugin)->localInfo();
+  root_local_info_ = &this->plugin()->localInfo();
+  allow_on_headers_stop_iteration_ =
+    this->plugin()->wasmConfig().config().allow_on_headers_stop_iteration();
 }
 Context::Context(Wasm* wasm, uint32_t root_context_id, PluginHandleSharedPtr plugin_handle)
     : ContextBase(wasm, root_context_id, plugin_handle), plugin_handle_(plugin_handle) {
   if (wasm != nullptr) {
     abi_version_ = wasm->abi_version_;
   }
+  allow_on_headers_stop_iteration_ =
+    plugin()->wasmConfig().config().allow_on_headers_stop_iteration();
 }
 
 Wasm* Context::wasm() const { return static_cast<Wasm*>(wasm_); }

--- a/test/test_common/wasm_base.h
+++ b/test/test_common/wasm_base.h
@@ -65,6 +65,8 @@ public:
     *plugin_config.mutable_root_id() = root_id_;
     *plugin_config.mutable_name() = "plugin_name";
     plugin_config.set_fail_open(fail_open_);
+    plugin_config.set_allow_on_headers_stop_iteration(
+      allow_on_headers_stop_iteration_);
     plugin_config.mutable_configuration()->set_value(plugin_configuration_);
     *plugin_config.mutable_vm_config()->mutable_environment_variables() = envs_;
 
@@ -122,6 +124,9 @@ public:
     plugin_configuration_ = plugin_configuration;
   }
   void setFailOpen(bool fail_open) { fail_open_ = fail_open; }
+  void setAllowOnHeadersStopIteration(bool allow) {
+    allow_on_headers_stop_iteration_ = allow;
+  }
   void setAllowedCapabilities(proxy_wasm::AllowedCapabilitiesMap allowed_capabilities) {
     allowed_capabilities_ = allowed_capabilities;
   }
@@ -131,6 +136,7 @@ private:
   std::string root_id_ = "";
   std::string vm_configuration_ = "";
   bool fail_open_ = false;
+  bool allow_on_headers_stop_iteration_ = false;
   std::string plugin_configuration_ = "";
   proxy_wasm::AllowedCapabilitiesMap allowed_capabilities_ = {};
   envoy::extensions::wasm::v3::EnvironmentVariables envs_ = {};


### PR DESCRIPTION
Commit Message:

Add PluginConfig.allow_on_headers_stop_iteration config field to control the behavior of WasmFilter when plugin onRequestHeaders and onResponseHeaders callbacks return a value of FilterHeadersStatus::StopIteration.

If allow_on_headers_stop_iteration is false (the default), then in cases where a Wasm plugin onRequestHeaders or onResponseHeaders callback returns FilterHeadersStatus::StopIteration, WasmFilter will maintain its current behavior of translating that response code to FilterHeadersStatus::StopAllIterationAndWatermark.

If allow_on_headers_stop_iteration is true, then WasmFilter will avoid any translation of FilterHeadersStatus::StopIteration, and will pass it through to HCM unmodified, which allows Wasm plugins to inspect request or response body data before deciding how to handle/transform request or response headers.

For details, see [Envoy Wasm / Proxy-Wasm support for FilterHeadersStatus::StopIteration](https://docs.google.com/document/d/1Whd1C0k-H2NHrPOmlAqqauFz6ObSTP017juJIYyciB0/edit?usp=sharing). This PR implements [Option B: WasmFilter config knob](https://docs.google.com/document/d/1Whd1C0k-H2NHrPOmlAqqauFz6ObSTP017juJIYyciB0/edit?tab=t.0#bookmark=id.5wxldlapsp54), building on https://github.com/proxy-wasm/proxy-wasm-cpp-host/pull/434.

Additional Description:

This change is effectively stacked on top of https://github.com/proxy-wasm/proxy-wasm-cpp-host/pull/434, so temporarily modifies bazel/repository_locations.bzl to reference a non-main proxy-wasm-cpp-host branch. Once that parent PR is merged, this PR will be adjusted to reference the latest main branch version of proxy-wasm-cpp-host.

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
