### PR TITLE
rbac: only allocate protobuf arena if it CEL is used

### DIFF
--- a/source/extensions/filters/common/rbac/engine_impl.h
+++ b/source/extensions/filters/common/rbac/engine_impl.h
@@ -88,8 +88,13 @@ private:
 
   std::map<std::string, std::unique_ptr<PolicyMatcher>> policies_;
 
-  Protobuf::Arena constant_arena_;
-  Expr::BuilderPtr builder_;
+  // Encapsulated the CEL expression builder with the arena, that will only be
+  // allocated if CEL is configured.
+  struct ExprBuilderWithArena {
+    Protobuf::Arena constant_arena_;
+    Expr::BuilderPtr builder_;
+  };
+  std::unique_ptr<ExprBuilderWithArena> builder_with_arena_;
 };
 
 class RoleBasedAccessControlMatcherEngineImpl : public RoleBasedAccessControlEngine, NonCopyable {


### PR DESCRIPTION
Commit Message: rbac: only allocate protobuf arena if it CEL is used
Additional Description:
Prior to this PR, the protobuf arena would've been allocated for each RBAC configuration, even if CEL wasn't used.
Wrapped the arena and the builder around a single wrapper that will only be allocated if CEL is used.

Risk Level: low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A