### PR TITLE
rbac: only allocate CEL condition if used in policy matcher

### DIFF
--- a/source/extensions/filters/common/rbac/matchers.cc
+++ b/source/extensions/filters/common/rbac/matchers.cc
@@ -284,7 +284,7 @@ bool PolicyMatcher::matches(const Network::Connection& connection,
                             const StreamInfo::StreamInfo& info) const {
   return permissions_.matches(connection, headers, info) &&
          principals_.matches(connection, headers, info) &&
-         (expr_ == nullptr ? true : Expr::matches(*expr_, info, headers));
+         (expr_wrapper_ == nullptr ? true : expr_wrapper_->matches(headers, info));
 }
 
 bool RequestedServerNameMatcher::matches(const Network::Connection& connection,


### PR DESCRIPTION
Commit Message: rbac: only allocate CEL condition if used in policy matcher
Additional Description:
Prior to this PR an RBAC policy will always allocate a CEL Expression proto object even if it was not used.
This PR introduces a wrapper that couples the Expression proto with the Expression pointer that are only allocated if CEL is configured.

Risk Level: low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A