### PR TITLE
Remove QUIC idle_network_timeout upper bound.

### DIFF
--- a/api/envoy/config/core/v3/protocol.proto
+++ b/api/envoy/config/core/v3/protocol.proto
@@ -111,9 +111,8 @@ message QuicProtocolOptions {
   // default 600s will be applied.
   // For internal corporate network, a long timeout is often fine.
   // But for client facing network, 30s is usually a good choice.
-  google.protobuf.Duration idle_network_timeout = 8 [(validate.rules).duration = {
-    gte {seconds: 1}
-  }];
+  google.protobuf.Duration idle_network_timeout = 8
+      [(validate.rules).duration = {gte {seconds: 1}}];
 
   // Maximum packet length for QUIC connections. It refers to the largest size of a QUIC packet that can be transmitted over the connection.
   // If not specified, one of the `default values in QUICHE <https://github.com/google/quiche/blob/main/quiche/quic/core/quic_constants.h>`_ is used.

--- a/api/envoy/config/core/v3/protocol.proto
+++ b/api/envoy/config/core/v3/protocol.proto
@@ -111,6 +111,7 @@ message QuicProtocolOptions {
   // default 600s will be applied.
   // For internal corporate network, a long timeout is often fine.
   // But for client facing network, 30s is usually a good choice.
+  // Do not add an upper bound here. A long idle timeout is useful for maintaining warm connections at non-front-line proxy for low QPS services."
   google.protobuf.Duration idle_network_timeout = 8
       [(validate.rules).duration = {gte {seconds: 1}}];
 

--- a/api/envoy/config/core/v3/protocol.proto
+++ b/api/envoy/config/core/v3/protocol.proto
@@ -112,7 +112,6 @@ message QuicProtocolOptions {
   // For internal corporate network, a long timeout is often fine.
   // But for client facing network, 30s is usually a good choice.
   google.protobuf.Duration idle_network_timeout = 8 [(validate.rules).duration = {
-    lte {seconds: 600}
     gte {seconds: 1}
   }];
 


### PR DESCRIPTION
Commit Message: Remove QUIC idle_network_timeout upper bound. For a non-front-line proxy, a longer value can be useful.
Risk Level: None