### PR TITLE
mobile: fix network change tests in CronetHttp3Test

### DIFF
--- a/mobile/library/common/network/connectivity_manager.cc
+++ b/mobile/library/common/network/connectivity_manager.cc
@@ -284,6 +284,7 @@ void ConnectivityManagerImpl::resetConnectivityState() {
   envoy_netconf_t configuration_key;
   {
     Thread::LockGuard lock{network_state_.mutex_};
+    network_state_.network_ = 0;
     network_state_.remaining_faults_ = 1;
     network_state_.socket_mode_ = SocketMode::DefaultPreferredNetworkMode;
     configuration_key = ++network_state_.configuration_key_;

--- a/mobile/library/java/io/envoyproxy/envoymobile/engine/AndroidEngineImpl.java
+++ b/mobile/library/java/io/envoyproxy/envoymobile/engine/AndroidEngineImpl.java
@@ -24,9 +24,11 @@ public class AndroidEngineImpl implements EnvoyEngine {
    */
   public AndroidEngineImpl(Context context, EnvoyOnEngineRunning runningCallback,
                            EnvoyLogger logger, EnvoyEventTracker eventTracker,
-                           Boolean enableProxying, Boolean useNetworkChangeEvent) {
+                           Boolean enableProxying, Boolean useNetworkChangeEvent,
+                           Boolean disableDnsRefreshOnNetworkChange) {
     this.context = context;
-    this.envoyEngine = new EnvoyEngineImpl(runningCallback, logger, eventTracker);
+    this.envoyEngine = new EnvoyEngineImpl(runningCallback, logger, eventTracker,
+                                           disableDnsRefreshOnNetworkChange);
     if (ContextUtils.getApplicationContext() == null) {
       ContextUtils.initApplicationContext(context.getApplicationContext());
     }

--- a/mobile/library/java/io/envoyproxy/envoymobile/engine/EnvoyEngineImpl.java
+++ b/mobile/library/java/io/envoyproxy/envoymobile/engine/EnvoyEngineImpl.java
@@ -23,9 +23,10 @@ public class EnvoyEngineImpl implements EnvoyEngine {
    * @param eventTracker    The event tracking interface.
    */
   public EnvoyEngineImpl(EnvoyOnEngineRunning runningCallback, EnvoyLogger logger,
-                         EnvoyEventTracker eventTracker) {
+                         EnvoyEventTracker eventTracker, Boolean disableDnsRefreshOnNetworkChange) {
     JniLibrary.load();
-    this.engineHandle = JniLibrary.initEngine(runningCallback, logger, eventTracker);
+    this.engineHandle = JniLibrary.initEngine(runningCallback, logger, eventTracker,
+                                              disableDnsRefreshOnNetworkChange.booleanValue());
   }
 
   /**

--- a/mobile/library/java/io/envoyproxy/envoymobile/engine/JniLibrary.java
+++ b/mobile/library/java/io/envoyproxy/envoymobile/engine/JniLibrary.java
@@ -152,10 +152,13 @@ public class JniLibrary {
    * @param runningCallback, called when the engine finishes its async startup and begins running.
    * @param logger,          the logging interface.
    * @param eventTracker     the event tracking interface.
+   * @param disableDnsRefreshOnNetworkChange whether disable dns refreshment or not after the
+   *     network has changed.
    * @return envoy_engine_t, handle to the underlying engine.
    */
   protected static native long initEngine(EnvoyOnEngineRunning runningCallback, EnvoyLogger logger,
-                                          EnvoyEventTracker eventTracker);
+                                          EnvoyEventTracker eventTracker,
+                                          boolean disableDnsRefreshOnNetworkChange);
 
   /**
    * External entry point for library.

--- a/mobile/library/java/org/chromium/net/impl/NativeCronvoyEngineBuilderImpl.java
+++ b/mobile/library/java/org/chromium/net/impl/NativeCronvoyEngineBuilderImpl.java
@@ -265,9 +265,9 @@ public class NativeCronvoyEngineBuilderImpl extends CronvoyEngineBuilderImpl {
 
   EnvoyEngine createEngine(EnvoyOnEngineRunning onEngineRunning, EnvoyLogger envoyLogger,
                            String logLevel) {
-    AndroidEngineImpl engine =
-        new AndroidEngineImpl(getContext(), onEngineRunning, envoyLogger, mEnvoyEventTracker,
-                              mEnableProxying, mUseNetworkChangeEvent);
+    AndroidEngineImpl engine = new AndroidEngineImpl(
+        getContext(), onEngineRunning, envoyLogger, mEnvoyEventTracker, mEnableProxying,
+        mUseNetworkChangeEvent, mDisableDnsRefreshOnNetworkChange);
     engine.runWithConfig(createEnvoyConfiguration(), logLevel);
     return engine;
   }

--- a/mobile/library/jni/jni_impl.cc
+++ b/mobile/library/jni/jni_impl.cc
@@ -36,7 +36,7 @@ Java_io_envoyproxy_envoymobile_engine_JniLibrary_setLogLevel(JNIEnv* /*env*/, jc
 
 extern "C" JNIEXPORT jlong JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibrary_initEngine(
     JNIEnv* env, jclass, jobject on_engine_running, jobject envoy_logger,
-    jobject envoy_event_tracker) {
+    jobject envoy_event_tracker, jboolean disable_dns_refresh_on_network_change) {
   //================================================================================================
   // EngineCallbacks
   //================================================================================================
@@ -108,7 +108,9 @@ extern "C" JNIEXPORT jlong JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibr
   }
 
   return reinterpret_cast<jlong>(
-      new Envoy::InternalEngine(std::move(callbacks), std::move(logger), std::move(event_tracker)));
+      new Envoy::InternalEngine(std::move(callbacks), std::move(logger), std::move(event_tracker),
+                                /*network_thread_priority*/ absl::nullopt,
+                                (disable_dns_refresh_on_network_change == JNI_TRUE)));
 }
 
 extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibrary_runEngine(

--- a/mobile/library/kotlin/io/envoyproxy/envoymobile/AndroidEngineBuilder.kt
+++ b/mobile/library/kotlin/io/envoyproxy/envoymobile/AndroidEngineBuilder.kt
@@ -13,7 +13,8 @@ class AndroidEngineBuilder(context: Context) : EngineBuilder() {
         { level, msg -> logger?.let { it(LogLevel.from(level), msg) } },
         eventTracker,
         enableProxying,
-        false
+        /*useNetworkChangeEvent*/ false,
+        /*disableDnsRefreshOnNetworkChange*/ false
       )
     }
   }

--- a/mobile/library/kotlin/io/envoyproxy/envoymobile/EngineBuilder.kt
+++ b/mobile/library/kotlin/io/envoyproxy/envoymobile/EngineBuilder.kt
@@ -21,7 +21,8 @@ open class EngineBuilder() {
     EnvoyEngineImpl(
       onEngineRunning,
       { level, msg -> logger?.let { it(LogLevel.from(level), msg) } },
-      eventTracker
+      eventTracker,
+      disableDnsRefreshOnNetworkChange
     )
   }
   private var logLevel = LogLevel.INFO

--- a/mobile/test/java/org/chromium/net/CronetHttp3Test.java
+++ b/mobile/test/java/org/chromium/net/CronetHttp3Test.java
@@ -2,6 +2,7 @@ package org.chromium.net;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 import android.Manifest;
 
@@ -61,6 +62,7 @@ public class CronetHttp3Test {
   // Optional reloadable flags to set.
   private boolean drainOnNetworkChange = false;
   private boolean resetBrokennessOnNetworkChange = false;
+  private boolean disableDnsRefreshOnNetworkChange = false;
 
   @BeforeClass
   public static void loadJniLibrary() {
@@ -100,6 +102,7 @@ public class CronetHttp3Test {
         new NativeCronvoyEngineBuilderImpl(ApplicationProvider.getApplicationContext());
     nativeCronetEngineBuilder.addRuntimeGuard("drain_pools_on_network_change",
                                               drainOnNetworkChange);
+    nativeCronetEngineBuilder.setDisableDnsRefreshOnNetworkChange(disableDnsRefreshOnNetworkChange);
 
     if (setUpLogging) {
       nativeCronetEngineBuilder.setLogger(logger);
@@ -108,6 +111,8 @@ public class CronetHttp3Test {
     // Make sure the handshake will work despite lack of real certs.
     nativeCronetEngineBuilder.setMockCertVerifierForTesting();
     cronvoyEngine = new CronvoyUrlRequestContext(nativeCronetEngineBuilder);
+    // Clear network states in ConnectivityManager.
+    cronvoyEngine.getEnvoyEngine().resetConnectivityState();
   }
 
   @After
@@ -277,6 +282,7 @@ public class CronetHttp3Test {
   @SmallTest
   @Feature({"Cronet"})
   public void testRetryPostHandshake() throws Exception {
+
     setUp(printEnvoyLogs);
 
     retryPostHandshake();
@@ -286,6 +292,9 @@ public class CronetHttp3Test {
   @SmallTest
   @Feature({"Cronet"})
   public void networkChangeNoDrains() throws Exception {
+    // Disable dns refreshment so that the engine will attempt immediate draining.
+    disableDnsRefreshOnNetworkChange = true;
+    drainOnNetworkChange = false;
     setUp(printEnvoyLogs);
 
     // Do the initial handshake dance
@@ -298,7 +307,7 @@ public class CronetHttp3Test {
 
     // There should be one HTTP/3 connection
     String postStats = cronvoyEngine.getEnvoyEngine().dumpStats();
-    assertTrue(postStats.contains("cluster.base.upstream_cx_http3_total: 1"));
+    assertTrue(postStats, postStats.contains("cluster.base.upstream_cx_http3_total: 1"));
 
     // Force a network change
     cronvoyEngine.getEnvoyEngine().onDefaultNetworkUnavailable();
@@ -310,15 +319,20 @@ public class CronetHttp3Test {
     assertEquals(200, get2Callback.mResponseInfo.getHttpStatusCode());
     assertEquals("h3", get2Callback.mResponseInfo.getNegotiatedProtocol());
 
-    // There should still only be one HTTP/3 connection.
+    // There should be 2 HTTP/3 connections because the 2nd request was hashed to a different
+    // connection pool. But the 1st HTTP/3 connection which is idle now shouldn't have been drained
+    // or closed.
     postStats = cronvoyEngine.getEnvoyEngine().dumpStats();
-    assertTrue(postStats.contains("cluster.base.upstream_cx_http3_total: 1"));
+    assertTrue(postStats, postStats.contains("cluster.base.upstream_cx_http3_total: 2"));
+    assertFalse(postStats, postStats.contains("cluster.base.upstream_cx_destroy"));
   }
 
   @Test
   @SmallTest
   @Feature({"Cronet"})
   public void networkChangeWithDrains() throws Exception {
+    // Disable dns refreshment so that the engine will attempt immediate draining.
+    disableDnsRefreshOnNetworkChange = true;
     drainOnNetworkChange = true;
     setUp(printEnvoyLogs);
 
@@ -344,9 +358,13 @@ public class CronetHttp3Test {
     assertEquals(200, get2Callback.mResponseInfo.getHttpStatusCode());
     assertEquals("h3", get2Callback.mResponseInfo.getNegotiatedProtocol());
 
-    // There should still only be one HTTP/3 connection.
+    // There should be 2 HTTP/3 connections because the 1st HTTP/3 connection which is idle now
+    // should have been drained and closed.
     postStats = cronvoyEngine.getEnvoyEngine().dumpStats();
-    assertTrue(postStats.contains("cluster.base.upstream_cx_http3_total: 1"));
+    assertTrue(postStats, postStats.contains("cluster.base.upstream_cx_http3_total: 2"));
+    // The 1st HTTP/3 connection and the TCP connection are both idle now, so they should have been
+    // closed during draining.
+    assertTrue(postStats, postStats.contains("cluster.base.upstream_cx_destroy: 2"));
   }
 
   @Test

--- a/mobile/test/java/org/chromium/net/CronetHttp3Test.java
+++ b/mobile/test/java/org/chromium/net/CronetHttp3Test.java
@@ -282,7 +282,6 @@ public class CronetHttp3Test {
   @SmallTest
   @Feature({"Cronet"})
   public void testRetryPostHandshake() throws Exception {
-
     setUp(printEnvoyLogs);
 
     retryPostHandshake();


### PR DESCRIPTION
Commit Message: these tests failed to verify the desired behavior that existing connections are drained upon network change events. And they failed when run individually. As the code evolved over time, EM no longer drains connections immediately upon network change events if it's configured to refresh DNS at that time. But rather DNS refreshment will drain each host upon resolution completion. `networkChangeWithDrains/networkChangeNoDrains` tests have been always skipping draining connections because of this. These tests should be run with DNS refreshment disabled upon network change to test the draining behavior. To disable DNS refreshment, this PR also fixes another issue that disableDnsRefreshOnNetworkChange knob in Java engines is not plumbed into native c++ engine.

And the existing tests expectations checking stats `cluster.base.upstream_cx_http3_total` can't really verify whether connections are drained or not. This stats is always incremented. A new connection is always created because changing network will rehash new requests to a different connection pool. This PR added another expectation to truly verify the draining behavior. The tests passes today when running in the context of the test suite because of a different issue stated below.

Additional Description: this PR changes resetConnectivityState() to also reset `ConnectivityManagerImpl::network_state_.network` and calling it to clear the static variable ConnectivityManagerImpl::network_state_ before each run as junit doesn't destruct static variables between different test runs.  And the cached network type in this static variable will affect the following test runs.  This is why the tests passes with current wrong test expectations.

resetConnectivityState() has  been resetting all other member variables in NetworkState. It should also reset `network`.

Risk Level: low
Testing: existing tests are fixed and passed
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A

