### PR TITLE
network: Adds methods to IP address to check if they are in reserved ranges

### DIFF
--- a/envoy/network/address.h
+++ b/envoy/network/address.h
@@ -101,6 +101,9 @@ public:
   virtual bool isUnicastAddress() const PURE;
 
   /**
+   * Determines whether the address is a link-local address, see
+   * https://datatracker.ietf.org/doc/html/rfc3513#section-2.4 for details.
+   *
    * @return true if the address is a link-local address, false otherwise.
    */
   virtual bool isLinkLocalAddress() const PURE;
@@ -112,6 +115,22 @@ public:
    * @return true if the address is a Teredo address, false otherwise.
    */
   virtual bool isTeredoAddress() const PURE;
+
+  /**
+   * Determines whether the address is a Unique Local Address, see
+   * https://datatracker.ietf.org/doc/html/rfc4193 for details.
+   *
+   * @return true if the address is a Unique Local Address, false otherwise.
+   */
+  virtual bool isUniqueLocalAddress() const PURE;
+
+  /**
+   * Determines whether the address is a Site-Local Address, see
+   * https://datatracker.ietf.org/doc/html/rfc3513#section-2.4 for details.
+   *
+   * @return true if the address is a Site-Local Address, false otherwise.
+   */
+  virtual bool isSiteLocalAddress() const PURE;
 
   /**
    * @return Ipv4 address data IFF version() == IpVersion::v4, otherwise nullptr.

--- a/envoy/network/address.h
+++ b/envoy/network/address.h
@@ -101,32 +101,40 @@ public:
   virtual bool isUnicastAddress() const PURE;
 
   /**
-   * Determines whether the address is a link-local address, see
-   * https://datatracker.ietf.org/doc/html/rfc3513#section-2.4 for details.
+   * Determines whether the address is a link-local address. For IPv6, the prefix is fe80::/10. For
+   * IPv4, the prefix is 169.254.0.0/16.
+   *
+   * See https://datatracker.ietf.org/doc/html/rfc3513#section-2.4 for details.
    *
    * @return true if the address is a link-local address, false otherwise.
    */
   virtual bool isLinkLocalAddress() const PURE;
 
   /**
-   * Determines whether the address is a Teredo address, see
-   * https://datatracker.ietf.org/doc/html/rfc4380 for details.
+   * Determines whether the address is a Teredo address. Applies to IPv6 addresses only, where the
+   * prefix is 2001:0000::/32.
+   *
+   * See https://datatracker.ietf.org/doc/html/rfc4380 for details.
    *
    * @return true if the address is a Teredo address, false otherwise.
    */
   virtual bool isTeredoAddress() const PURE;
 
   /**
-   * Determines whether the address is a Unique Local Address, see
-   * https://datatracker.ietf.org/doc/html/rfc4193 for details.
+   * Determines whether the address is a Unique Local Address. Applies to IPv6 addresses only, where the
+   * prefix is fc00::/7.
+   *
+   * See https://datatracker.ietf.org/doc/html/rfc4193 for details.
    *
    * @return true if the address is a Unique Local Address, false otherwise.
    */
   virtual bool isUniqueLocalAddress() const PURE;
 
   /**
-   * Determines whether the address is a Site-Local Address, see
-   * https://datatracker.ietf.org/doc/html/rfc3513#section-2.4 for details.
+   * Determines whether the address is a Site-Local Address. Applies to IPv6 addresses only, where the
+   * prefix is fec0::/10.
+   *
+   * See https://datatracker.ietf.org/doc/html/rfc3513#section-2.4 for details.
    *
    * @return true if the address is a Site-Local Address, false otherwise.
    */

--- a/envoy/network/address.h
+++ b/envoy/network/address.h
@@ -101,6 +101,19 @@ public:
   virtual bool isUnicastAddress() const PURE;
 
   /**
+   * @return true if the address is a link-local address, false otherwise.
+   */
+  virtual bool isLinkLocalAddress() const PURE;
+
+  /**
+   * Determines whether the address is a Teredo address, see
+   * https://datatracker.ietf.org/doc/html/rfc4380 for details.
+   *
+   * @return true if the address is a Teredo address, false otherwise.
+   */
+  virtual bool isTeredoAddress() const PURE;
+
+  /**
    * @return Ipv4 address data IFF version() == IpVersion::v4, otherwise nullptr.
    */
   virtual const Ipv4* ipv4() const PURE;

--- a/envoy/network/address.h
+++ b/envoy/network/address.h
@@ -111,18 +111,8 @@ public:
   virtual bool isLinkLocalAddress() const PURE;
 
   /**
-   * Determines whether the address is a Teredo address. Applies to IPv6 addresses only, where the
-   * prefix is 2001:0000::/32.
-   *
-   * See https://datatracker.ietf.org/doc/html/rfc4380 for details.
-   *
-   * @return true if the address is a Teredo address, false otherwise.
-   */
-  virtual bool isTeredoAddress() const PURE;
-
-  /**
-   * Determines whether the address is a Unique Local Address. Applies to IPv6 addresses only, where the
-   * prefix is fc00::/7.
+   * Determines whether the address is a Unique Local Address. Applies to IPv6 addresses only, where
+   * the prefix is fc00::/7.
    *
    * See https://datatracker.ietf.org/doc/html/rfc4193 for details.
    *
@@ -131,14 +121,24 @@ public:
   virtual bool isUniqueLocalAddress() const PURE;
 
   /**
-   * Determines whether the address is a Site-Local Address. Applies to IPv6 addresses only, where the
-   * prefix is fec0::/10.
+   * Determines whether the address is a Site-Local Address. Applies to IPv6 addresses only, where
+   * the prefix is fec0::/10.
    *
    * See https://datatracker.ietf.org/doc/html/rfc3513#section-2.4 for details.
    *
    * @return true if the address is a Site-Local Address, false otherwise.
    */
   virtual bool isSiteLocalAddress() const PURE;
+
+  /**
+   * Determines whether the address is a Teredo address. Applies to IPv6 addresses only, where the
+   * prefix is 2001:0000::/32.
+   *
+   * See https://datatracker.ietf.org/doc/html/rfc4380 for details.
+   *
+   * @return true if the address is a Teredo address, false otherwise.
+   */
+  virtual bool isTeredoAddress() const PURE;
 
   /**
    * @return Ipv4 address data IFF version() == IpVersion::v4, otherwise nullptr.

--- a/source/common/network/address_impl.h
+++ b/source/common/network/address_impl.h
@@ -316,7 +316,7 @@ private:
                ipv6_.address_.sin6_addr.s6_addr[13] == 0xfe));
     }
     bool isTeredoAddress() const override {
-      // Teredo addresses have the prefix 2001::/32.
+      // Teredo addresses have the prefix 2001:0000::/32.
       return ipv6_.address_.sin6_addr.s6_addr[0] == 0x20 &&
              ipv6_.address_.sin6_addr.s6_addr[1] == 0x01 &&
              ipv6_.address_.sin6_addr.s6_addr[2] == 0x00 &&

--- a/source/common/network/address_impl.h
+++ b/source/common/network/address_impl.h
@@ -184,7 +184,15 @@ private:
       return (ipv4_.address_.sin_addr.s_addr & htonl(0xffff0000)) == htonl(0xa9fe0000);
     }
     bool isTeredoAddress() const override {
-      // Only applies to IPv6 addresses.
+      // Teredo addresses are not applicable to IPv4.
+      return false;
+    }
+    bool isUniqueLocalAddress() const override {
+      // Unique Local Addresses (ULA) are not applicable to IPv4.
+      return false;
+    }
+    bool isSiteLocalAddress() const override {
+      // Site-Local Addresses are not applicable to IPv4.
       return false;
     }
     const Ipv4* ipv4() const override { return &ipv4_; }
@@ -306,13 +314,21 @@ private:
              (IN6_IS_ADDR_V4MAPPED(&ipv6_.address_.sin6_addr) &&
               (ipv6_.address_.sin6_addr.s6_addr[12] == 0xa9 &&
                ipv6_.address_.sin6_addr.s6_addr[13] == 0xfe));
-    };
+    }
     bool isTeredoAddress() const override {
       // Teredo addresses have the prefix 2001::/32.
       return ipv6_.address_.sin6_addr.s6_addr[0] == 0x20 &&
              ipv6_.address_.sin6_addr.s6_addr[1] == 0x01 &&
              ipv6_.address_.sin6_addr.s6_addr[2] == 0x00 &&
              ipv6_.address_.sin6_addr.s6_addr[3] == 0x00;
+    }
+    bool isUniqueLocalAddress() const override {
+      // Unique Local Addresses (ULA) are in the range fc00::/7.
+      return (ipv6_.address_.sin6_addr.s6_addr[0] & 0xfe) == 0xfc;
+    }
+    bool isSiteLocalAddress() const override {
+      // Site-Local Addresses are in the range fec0::/10.
+      return IN6_IS_ADDR_SITELOCAL(&ipv6_.address_.sin6_addr);
     }
     const Ipv4* ipv4() const override { return nullptr; }
     const Ipv6* ipv6() const override { return &ipv6_; }

--- a/source/common/network/address_impl.h
+++ b/source/common/network/address_impl.h
@@ -179,6 +179,14 @@ private:
              // inlined IN_MULTICAST() to avoid byte swapping
              !((ipv4_.address_.sin_addr.s_addr & htonl(0xf0000000)) == htonl(0xe0000000));
     }
+    bool isLinkLocalAddress() const override {
+      // Check if the address is in the link-local range: 169.254.0.0/16.
+      return (ipv4_.address_.sin_addr.s_addr & htonl(0xffff0000)) == htonl(0xa9fe0000);
+    }
+    bool isTeredoAddress() const override {
+      // Only applies to IPv6 addresses.
+      return false;
+    }
     const Ipv4* ipv4() const override { return &ipv4_; }
     const Ipv6* ipv6() const override { return nullptr; }
     uint32_t port() const override { return ntohs(ipv4_.address_.sin_port); }
@@ -290,6 +298,21 @@ private:
     }
     bool isUnicastAddress() const override {
       return !isAnyAddress() && !IN6_IS_ADDR_MULTICAST(&ipv6_.address_.sin6_addr);
+    }
+    bool isLinkLocalAddress() const override {
+      // Check if the address is in the link-local range: fe80::/10 or in the v4 mapped link-local
+      // range: [::ffff:169.254.0.0].
+      return IN6_IS_ADDR_LINKLOCAL(&ipv6_.address_.sin6_addr) ||
+             (IN6_IS_ADDR_V4MAPPED(&ipv6_.address_.sin6_addr) &&
+              (ipv6_.address_.sin6_addr.s6_addr[12] == 0xa9 &&
+               ipv6_.address_.sin6_addr.s6_addr[13] == 0xfe));
+    };
+    bool isTeredoAddress() const override {
+      // Teredo addresses have the prefix 2001::/32.
+      return ipv6_.address_.sin6_addr.s6_addr[0] == 0x20 &&
+             ipv6_.address_.sin6_addr.s6_addr[1] == 0x01 &&
+             ipv6_.address_.sin6_addr.s6_addr[2] == 0x00 &&
+             ipv6_.address_.sin6_addr.s6_addr[3] == 0x00;
     }
     const Ipv4* ipv4() const override { return nullptr; }
     const Ipv6* ipv6() const override { return &ipv6_; }

--- a/source/common/network/address_impl.h
+++ b/source/common/network/address_impl.h
@@ -183,16 +183,16 @@ private:
       // Check if the address is in the link-local range: 169.254.0.0/16.
       return (ipv4_.address_.sin_addr.s_addr & htonl(0xffff0000)) == htonl(0xa9fe0000);
     }
-    bool isTeredoAddress() const override {
-      // Teredo addresses are not applicable to IPv4.
-      return false;
-    }
     bool isUniqueLocalAddress() const override {
       // Unique Local Addresses (ULA) are not applicable to IPv4.
       return false;
     }
     bool isSiteLocalAddress() const override {
       // Site-Local Addresses are not applicable to IPv4.
+      return false;
+    }
+    bool isTeredoAddress() const override {
+      // Teredo addresses are not applicable to IPv4.
       return false;
     }
     const Ipv4* ipv4() const override { return &ipv4_; }
@@ -315,13 +315,6 @@ private:
               (ipv6_.address_.sin6_addr.s6_addr[12] == 0xa9 &&
                ipv6_.address_.sin6_addr.s6_addr[13] == 0xfe));
     }
-    bool isTeredoAddress() const override {
-      // Teredo addresses have the prefix 2001:0000::/32.
-      return ipv6_.address_.sin6_addr.s6_addr[0] == 0x20 &&
-             ipv6_.address_.sin6_addr.s6_addr[1] == 0x01 &&
-             ipv6_.address_.sin6_addr.s6_addr[2] == 0x00 &&
-             ipv6_.address_.sin6_addr.s6_addr[3] == 0x00;
-    }
     bool isUniqueLocalAddress() const override {
       // Unique Local Addresses (ULA) are in the range fc00::/7.
       return (ipv6_.address_.sin6_addr.s6_addr[0] & 0xfe) == 0xfc;
@@ -329,6 +322,13 @@ private:
     bool isSiteLocalAddress() const override {
       // Site-Local Addresses are in the range fec0::/10.
       return IN6_IS_ADDR_SITELOCAL(&ipv6_.address_.sin6_addr);
+    }
+    bool isTeredoAddress() const override {
+      // Teredo addresses have the prefix 2001:0000::/32.
+      return ipv6_.address_.sin6_addr.s6_addr[0] == 0x20 &&
+             ipv6_.address_.sin6_addr.s6_addr[1] == 0x01 &&
+             ipv6_.address_.sin6_addr.s6_addr[2] == 0x00 &&
+             ipv6_.address_.sin6_addr.s6_addr[3] == 0x00;
     }
     const Ipv4* ipv4() const override { return nullptr; }
     const Ipv6* ipv6() const override { return &ipv6_; }

--- a/test/common/network/address_impl_test.cc
+++ b/test/common/network/address_impl_test.cc
@@ -250,6 +250,18 @@ TEST(Ipv4InstanceTest, Teredo) {
   EXPECT_FALSE(Ipv4Instance("200.1.1.1").ip()->isTeredoAddress());
 }
 
+TEST(Ipv4InstanceTest, SiteLocal) {
+  // Site-local addresses are not applicable to IPv4.
+  EXPECT_FALSE(Ipv4Instance("1.2.3.4").ip()->isSiteLocalAddress());
+  EXPECT_FALSE(Ipv4Instance("200.1.1.1").ip()->isSiteLocalAddress());
+}
+
+TEST(Ipv4InstanceTest, UniqueLocal) {
+  // Unique Local Addresses (ULA) are not applicable to IPv4.
+  EXPECT_FALSE(Ipv4Instance("1.2.3.4").ip()->isUniqueLocalAddress());
+  EXPECT_FALSE(Ipv4Instance("200.1.1.1").ip()->isUniqueLocalAddress());
+}
+
 TEST(Ipv4InstanceTest, BadAddress) {
   EXPECT_THROW(Ipv4Instance("foo"), EnvoyException);
   EXPECT_THROW(Ipv4Instance("bar", 1), EnvoyException);
@@ -409,6 +421,36 @@ TEST(Ipv6InstanceTest, Teredo) {
   EXPECT_FALSE(Ipv6Instance("2002::0").ip()->isTeredoAddress());
   EXPECT_FALSE(Ipv6Instance("2002::1").ip()->isTeredoAddress());
   EXPECT_FALSE(Ipv6Instance("3001::1").ip()->isTeredoAddress());
+}
+
+TEST(Ipv6InstanceTest, UniqueLocal) {
+  // Unique Local Addresses (ULA) are in the range fc00::/7.
+  EXPECT_TRUE(Ipv6Instance("fc00:0:0:0:0:0:0:0").ip()->isUniqueLocalAddress());
+  EXPECT_TRUE(Ipv6Instance("fc00::1").ip()->isUniqueLocalAddress());
+  EXPECT_TRUE(Ipv6Instance("fc00::42:43").ip()->isUniqueLocalAddress());
+  EXPECT_TRUE(Ipv6Instance("fdff::ffff:ffff:ffff:ffff:ffff:ffff").ip()->isUniqueLocalAddress());
+
+  // Not ULA addresses.
+  EXPECT_FALSE(Ipv6Instance("fec0:0:0:0:0:0:0:0").ip()->isSiteLocalAddress());
+  EXPECT_FALSE(Ipv6Instance("feff::ffff:ffff:ffff:ffff:ffff:ffff:ffff").ip()->isSiteLocalAddress());
+  EXPECT_FALSE(Ipv6Instance("fe00::0").ip()->isUniqueLocalAddress());
+  EXPECT_FALSE(Ipv6Instance("fe80::0").ip()->isUniqueLocalAddress());
+  EXPECT_FALSE(Ipv6Instance("ff00::0").ip()->isUniqueLocalAddress());
+}
+
+TEST(Ipv6InstanceTest, SiteLocal) {
+  // Site-local addresses are in the range fec0::/10.
+  EXPECT_TRUE(Ipv6Instance("fec0:0:0:0:0:0:0:0").ip()->isSiteLocalAddress());
+  EXPECT_TRUE(Ipv6Instance("fec0::1").ip()->isSiteLocalAddress());
+  EXPECT_TRUE(Ipv6Instance("fec0::42:43").ip()->isSiteLocalAddress());
+  EXPECT_TRUE(Ipv6Instance("feff::ffff:ffff:ffff:ffff:ffff:ffff:ffff").ip()->isSiteLocalAddress());
+
+  // Not site-local addresses.
+  EXPECT_FALSE(Ipv6Instance("fc00:0:0:0:0:0:0:0").ip()->isUniqueLocalAddress());
+  EXPECT_FALSE(Ipv6Instance("fdff::ffff:ffff:ffff:ffff:ffff:ffff").ip()->isUniqueLocalAddress());
+  EXPECT_FALSE(Ipv6Instance("ff00::0").ip()->isSiteLocalAddress());
+  EXPECT_FALSE(Ipv6Instance("2002::1").ip()->isSiteLocalAddress());
+  EXPECT_FALSE(Ipv6Instance("3001::1").ip()->isSiteLocalAddress());
 }
 
 TEST(Ipv6InstanceTest, BadAddress) {

--- a/test/common/network/address_impl_test.cc
+++ b/test/common/network/address_impl_test.cc
@@ -364,7 +364,7 @@ TEST(Ipv6InstanceTest, Broadcast) {
 }
 
 TEST(Ipv6InstanceTest, LinkLocal) {
-  // Link-local addresses are in the range fe80::0 to febf:ffff:ffff:ffff:ffff:ffff:ffff:ffff.
+  // Link-local addresses are in the range "fe80::0" to "febf:ffff:ffff:ffff:ffff:ffff:ffff:ffff".
   EXPECT_TRUE(Ipv6Instance("fe80:0:0:0:0:0:0:0").ip()->isLinkLocalAddress());
   EXPECT_TRUE(Ipv6Instance("fe80::0").ip()->isLinkLocalAddress());
   EXPECT_TRUE(Ipv6Instance("fe80::1").ip()->isLinkLocalAddress());

--- a/test/common/network/address_impl_test.cc
+++ b/test/common/network/address_impl_test.cc
@@ -431,8 +431,9 @@ TEST(Ipv6InstanceTest, UniqueLocal) {
   EXPECT_TRUE(Ipv6Instance("fdff::ffff:ffff:ffff:ffff:ffff:ffff").ip()->isUniqueLocalAddress());
 
   // Not ULA addresses.
-  EXPECT_FALSE(Ipv6Instance("fec0:0:0:0:0:0:0:0").ip()->isSiteLocalAddress());
-  EXPECT_FALSE(Ipv6Instance("feff::ffff:ffff:ffff:ffff:ffff:ffff:ffff").ip()->isSiteLocalAddress());
+  EXPECT_FALSE(Ipv6Instance("fec0:0:0:0:0:0:0:0").ip()->isUniqueLocalAddress());
+  EXPECT_FALSE(
+      Ipv6Instance("feff:ffff:ffff:ffff:ffff:ffff:ffff:ffff").ip()->isUniqueLocalAddress());
   EXPECT_FALSE(Ipv6Instance("fe00::0").ip()->isUniqueLocalAddress());
   EXPECT_FALSE(Ipv6Instance("fe80::0").ip()->isUniqueLocalAddress());
   EXPECT_FALSE(Ipv6Instance("ff00::0").ip()->isUniqueLocalAddress());
@@ -443,11 +444,11 @@ TEST(Ipv6InstanceTest, SiteLocal) {
   EXPECT_TRUE(Ipv6Instance("fec0:0:0:0:0:0:0:0").ip()->isSiteLocalAddress());
   EXPECT_TRUE(Ipv6Instance("fec0::1").ip()->isSiteLocalAddress());
   EXPECT_TRUE(Ipv6Instance("fec0::42:43").ip()->isSiteLocalAddress());
-  EXPECT_TRUE(Ipv6Instance("feff::ffff:ffff:ffff:ffff:ffff:ffff:ffff").ip()->isSiteLocalAddress());
+  EXPECT_TRUE(Ipv6Instance("feff:ffff:ffff:ffff:ffff:ffff:ffff:ffff").ip()->isSiteLocalAddress());
 
   // Not site-local addresses.
-  EXPECT_FALSE(Ipv6Instance("fc00:0:0:0:0:0:0:0").ip()->isUniqueLocalAddress());
-  EXPECT_FALSE(Ipv6Instance("fdff::ffff:ffff:ffff:ffff:ffff:ffff").ip()->isUniqueLocalAddress());
+  EXPECT_FALSE(Ipv6Instance("fc00:0:0:0:0:0:0:0").ip()->isSiteLocalAddress());
+  EXPECT_FALSE(Ipv6Instance("fdff::ffff:ffff:ffff:ffff:ffff:ffff").ip()->isSiteLocalAddress());
   EXPECT_FALSE(Ipv6Instance("ff00::0").ip()->isSiteLocalAddress());
   EXPECT_FALSE(Ipv6Instance("2002::1").ip()->isSiteLocalAddress());
   EXPECT_FALSE(Ipv6Instance("3001::1").ip()->isSiteLocalAddress());

--- a/test/common/network/address_impl_test.cc
+++ b/test/common/network/address_impl_test.cc
@@ -29,6 +29,10 @@ namespace Network {
 namespace Address {
 namespace {
 
+Ipv6Instance v4MappedV6Instance(const std::string& address) {
+  return Ipv6Instance(address, /*port=*/0, /*sock_interface=*/nullptr, /*v6only=*/false);
+}
+
 bool addressesEqual(const InstanceConstSharedPtr& a, const Instance& b) {
   if (a == nullptr || a->type() != Type::Ip || b.type() != Type::Ip) {
     return false;
@@ -228,6 +232,24 @@ TEST(Ipv4InstanceTest, Broadcast) {
   EXPECT_FALSE(address.ip()->isUnicastAddress());
 }
 
+TEST(Ipv4InstanceTest, LinkLocal) {
+  // Link-local addresses.
+  EXPECT_TRUE(Ipv4Instance("169.254.0.0").ip()->isLinkLocalAddress());
+  EXPECT_TRUE(Ipv4Instance("169.254.42.43").ip()->isLinkLocalAddress());
+  EXPECT_TRUE(Ipv4Instance("169.254.255.255").ip()->isLinkLocalAddress());
+
+  // Not link-local addresses.
+  EXPECT_FALSE(Ipv4Instance("169.255.0.0").ip()->isLinkLocalAddress());
+  EXPECT_FALSE(Ipv4Instance("169.255.255.255").ip()->isLinkLocalAddress());
+  EXPECT_FALSE(Ipv4Instance("170.254.0.0").ip()->isLinkLocalAddress());
+}
+
+TEST(Ipv4InstanceTest, Teredo) {
+  // Teredo addresses are not applicable to IPv4.
+  EXPECT_FALSE(Ipv4Instance("20.1.1.1").ip()->isTeredoAddress());
+  EXPECT_FALSE(Ipv4Instance("200.1.1.1").ip()->isTeredoAddress());
+}
+
 TEST(Ipv4InstanceTest, BadAddress) {
   EXPECT_THROW(Ipv4Instance("foo"), EnvoyException);
   EXPECT_THROW(Ipv4Instance("bar", 1), EnvoyException);
@@ -339,6 +361,54 @@ TEST(Ipv6InstanceTest, Broadcast) {
       Network::Utility::parseInternetAddressNoThrow("FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF"),
       address));
   EXPECT_FALSE(address.ip()->isUnicastAddress());
+}
+
+TEST(Ipv6InstanceTest, LinkLocal) {
+  // Link-local addresses are in the range fe80::0 to febf:ffff:ffff:ffff:ffff:ffff:ffff:ffff.
+  EXPECT_TRUE(Ipv6Instance("fe80:0:0:0:0:0:0:0").ip()->isLinkLocalAddress());
+  EXPECT_TRUE(Ipv6Instance("fe80::0").ip()->isLinkLocalAddress());
+  EXPECT_TRUE(Ipv6Instance("fe80::1").ip()->isLinkLocalAddress());
+  EXPECT_TRUE(Ipv6Instance("fe80::42:43").ip()->isLinkLocalAddress());
+  EXPECT_TRUE(Ipv6Instance("fe80::ffff:ffff:ffff:ffff").ip()->isLinkLocalAddress());
+  EXPECT_TRUE(Ipv6Instance("fe81::1").ip()->isLinkLocalAddress());
+  EXPECT_TRUE(Ipv6Instance("fe90::1").ip()->isLinkLocalAddress());
+  EXPECT_TRUE(Ipv6Instance("febf::0").ip()->isLinkLocalAddress());
+  EXPECT_TRUE(Ipv6Instance("febf:ffff:ffff:ffff:ffff:ffff:ffff:ffff").ip()->isLinkLocalAddress());
+
+  // Not link-local addresses.
+  EXPECT_FALSE(Ipv6Instance("::fe80").ip()->isLinkLocalAddress());
+  EXPECT_FALSE(Ipv6Instance("fec0::0").ip()->isLinkLocalAddress());
+  EXPECT_FALSE(Ipv6Instance("ff00::0").ip()->isLinkLocalAddress());
+  EXPECT_FALSE(Ipv6Instance("ab80::0").ip()->isLinkLocalAddress());
+  EXPECT_FALSE(Ipv6Instance("abcd::0").ip()->isLinkLocalAddress());
+  EXPECT_FALSE(Ipv6Instance("::ffff").ip()->isLinkLocalAddress());
+}
+
+TEST(Ipv6InstanceTest, V4MappedLinkLocal) {
+  // Link-local addresses in the range ::ffff:169.254.0.0/16.
+  EXPECT_TRUE(v4MappedV6Instance("::ffff:169.254.0.0").ip()->isLinkLocalAddress());
+  EXPECT_TRUE(v4MappedV6Instance("::ffff:169.254.42.42").ip()->isLinkLocalAddress());
+  EXPECT_TRUE(v4MappedV6Instance("::ffff:169.254.255.255").ip()->isLinkLocalAddress());
+
+  // Not link-local addresses.
+  EXPECT_FALSE(v4MappedV6Instance("::ffff:169.255.0.0").ip()->isLinkLocalAddress());
+  EXPECT_FALSE(v4MappedV6Instance("::ffff:170.254.0.0").ip()->isLinkLocalAddress());
+  EXPECT_FALSE(v4MappedV6Instance("::ffff:0.0.0.0").ip()->isLinkLocalAddress());
+  EXPECT_FALSE(v4MappedV6Instance("::ffff:192.168.1.1").ip()->isLinkLocalAddress());
+  EXPECT_FALSE(v4MappedV6Instance("::ffff:10.54.1.1").ip()->isLinkLocalAddress());
+}
+
+TEST(Ipv6InstanceTest, Teredo) {
+  // Teredo addresses are in the range 2001::/32.
+  EXPECT_TRUE(Ipv6Instance("2001:0:0:0:0:0:0:0").ip()->isTeredoAddress());
+  EXPECT_TRUE(Ipv6Instance("2001::1").ip()->isTeredoAddress());
+  EXPECT_TRUE(Ipv6Instance("2001::42:43").ip()->isTeredoAddress());
+  EXPECT_TRUE(Ipv6Instance("2001::ffff:ffff:ffff:ffff").ip()->isTeredoAddress());
+
+  // Not Teredo addresses.
+  EXPECT_FALSE(Ipv6Instance("2002::0").ip()->isTeredoAddress());
+  EXPECT_FALSE(Ipv6Instance("2002::1").ip()->isTeredoAddress());
+  EXPECT_FALSE(Ipv6Instance("3001::1").ip()->isTeredoAddress());
 }
 
 TEST(Ipv6InstanceTest, BadAddress) {

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -587,8 +587,8 @@ public:
   MOCK_METHOD(const std::string&, addressAsString, (), (const));
   MOCK_METHOD(bool, isAnyAddress, (), (const));
   MOCK_METHOD(bool, isUnicastAddress, (), (const));
-  MOCK_METHOD(bool, isLinkLocalAddress(), (), (const));
-  MOCK_METHOD(bool, isTeredoAddress(), (), (const));
+  MOCK_METHOD(bool, isLinkLocalAddress, (), (const));
+  MOCK_METHOD(bool, isTeredoAddress, (), (const));
   MOCK_METHOD(const Address::Ipv4*, ipv4, (), (const));
   MOCK_METHOD(const Address::Ipv6*, ipv6, (), (const));
   MOCK_METHOD(uint32_t, port, (), (const));

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -588,6 +588,8 @@ public:
   MOCK_METHOD(bool, isAnyAddress, (), (const));
   MOCK_METHOD(bool, isUnicastAddress, (), (const));
   MOCK_METHOD(bool, isLinkLocalAddress, (), (const));
+  MOCK_METHOD(bool, isUniqueLocalAddress, (), (const));
+  MOCK_METHOD(bool, isSiteLocalAddress, (), (const));
   MOCK_METHOD(bool, isTeredoAddress, (), (const));
   MOCK_METHOD(const Address::Ipv4*, ipv4, (), (const));
   MOCK_METHOD(const Address::Ipv6*, ipv6, (), (const));

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -587,6 +587,8 @@ public:
   MOCK_METHOD(const std::string&, addressAsString, (), (const));
   MOCK_METHOD(bool, isAnyAddress, (), (const));
   MOCK_METHOD(bool, isUnicastAddress, (), (const));
+  MOCK_METHOD(bool, isLinkLocalAddress(), (), (const));
+  MOCK_METHOD(bool, isTeredoAddress(), (), (const));
   MOCK_METHOD(const Address::Ipv4*, ipv4, (), (const));
   MOCK_METHOD(const Address::Ipv6*, ipv6, (), (const));
   MOCK_METHOD(uint32_t, port, (), (const));

--- a/tools/spelling/spelling_dictionary.txt
+++ b/tools/spelling/spelling_dictionary.txt
@@ -113,6 +113,7 @@ STX
 SkyWalking
 TIDs
 Timedout
+ULA
 WRSQ
 WASI
 ceil

--- a/tools/spelling/spelling_dictionary.txt
+++ b/tools/spelling/spelling_dictionary.txt
@@ -1414,6 +1414,7 @@ templating
 templatize
 templatized
 templatizing
+teredo
 testability
 testcase
 testcases


### PR DESCRIPTION
This commit adds the following two methods to the `Ip` interface:
  * `isLinkLocalAddress()`
  * `isTeredoAddress()`
  * `isUniqueLocalAddress()`
  * `isSiteLocalAddress()`

These methods will be used by Envoy Mobile to determine IPv6 connectivity on the current network.