### PR TITLE
aws: assumerole missing protobuf validations

### DIFF
--- a/source/extensions/common/aws/credential_providers/assume_role_credentials_provider.cc
+++ b/source/extensions/common/aws/credential_providers/assume_role_credentials_provider.cc
@@ -31,6 +31,7 @@ AssumeRoleCredentialsProvider::AssumeRoleCredentialsProvider(
                                       initialization_timer),
       role_arn_(assume_role_config.role_arn()),
       role_session_name_(assume_role_config.role_session_name()), region_(region),
+      external_id_(assume_role_config.external_id()),
       assume_role_signer_(std::move(assume_role_signer)) {
 
   if (assume_role_config.has_session_duration()) {
@@ -78,6 +79,11 @@ void AssumeRoleCredentialsProvider::continueRefresh() {
   if (session_duration_) {
     path += fmt::format("&DurationSeconds={}", session_duration_.value());
   }
+
+  if (!external_id_.empty()) {
+    path += fmt::format("&ExternalId={}", external_id_);
+  }
+
   message.headers().setPath(path);
   // Use the Accept header to ensure that AssumeRoleResponse is returned as JSON.
   message.headers().setReference(Http::CustomHeaders::get().Accept,

--- a/source/extensions/common/aws/credential_providers/assume_role_credentials_provider.cc
+++ b/source/extensions/common/aws/credential_providers/assume_role_credentials_provider.cc
@@ -71,10 +71,14 @@ void AssumeRoleCredentialsProvider::continueRefresh() {
   message.headers().setScheme(Http::Headers::get().SchemeValues.Https);
   message.headers().setMethod(Http::Headers::get().MethodValues.Get);
   message.headers().setHost(Http::Utility::parseAuthority(uri.value()).host_);
-  message.headers().setPath(
+  std::string path =
       fmt::format("/?Version=2011-06-15&Action=AssumeRole&RoleArn={}&RoleSessionName={}",
                   Envoy::Http::Utility::PercentEncoding::encode(role_arn_),
-                  Envoy::Http::Utility::PercentEncoding::encode(role_session_name_)));
+                  Envoy::Http::Utility::PercentEncoding::encode(role_session_name_));
+  if (session_duration_) {
+    path += fmt::format("&DurationSeconds={}", session_duration_.value());
+  }
+  message.headers().setPath(path);
   // Use the Accept header to ensure that AssumeRoleResponse is returned as JSON.
   message.headers().setReference(Http::CustomHeaders::get().Accept,
                                  Http::Headers::get().ContentTypeValues.Json);

--- a/source/extensions/common/aws/credential_providers/assume_role_credentials_provider.h
+++ b/source/extensions/common/aws/credential_providers/assume_role_credentials_provider.h
@@ -44,6 +44,7 @@ private:
   const std::string role_arn_;
   const std::string role_session_name_;
   const std::string region_;
+  const std::string external_id_;
   absl::optional<uint16_t> session_duration_;
   std::unique_ptr<Extensions::Common::Aws::SigV4SignerImpl> assume_role_signer_;
 };

--- a/test/extensions/common/aws/credential_provider_chains_test.cc
+++ b/test/extensions/common/aws/credential_provider_chains_test.cc
@@ -427,6 +427,33 @@ TEST_F(CustomCredentialsProviderChainTest, AssumeRoleWithEnvironment) {
   EXPECT_EQ(2, chain.value()->getNumProviders());
 }
 
+TEST_F(CustomCredentialsProviderChainTest, AssumeRoleWithoutSessionName) {
+  envoy::extensions::common::aws::v3::AwsCredentialProvider credential_provider_config = {};
+  credential_provider_config.set_custom_credential_provider_chain(true);
+  credential_provider_config.mutable_assume_role_credential_provider()->set_role_arn(
+      "test-role-arn");
+  // Intentionally not setting role_session_name to test auto-generation
+
+  std::string role_session_name;
+  time_system_.setSystemTime(std::chrono::milliseconds(1234567890));
+
+  EXPECT_CALL(factories_, createAssumeRoleCredentialsProvider(Ref(context_), _, _, _))
+      .WillOnce(Invoke(WithArg<3>(
+          [&role_session_name](
+              const envoy::extensions::common::aws::v3::AssumeRoleCredentialProvider& provider)
+              -> CredentialsProviderSharedPtr {
+            role_session_name = provider.role_session_name();
+            return std::make_shared<MockCredentialsProvider>();
+          })));
+
+  CommonCredentialsProviderChain chain(context_, "us-east-1", credential_provider_config,
+                                       factories_);
+
+  // Verify that a session name was auto-generated based on the timestamp
+  EXPECT_FALSE(role_session_name.empty());
+  EXPECT_EQ(role_session_name, "1234567890000000");
+}
+
 } // namespace Aws
 } // namespace Common
 } // namespace Extensions

--- a/test/extensions/common/aws/credential_providers/assume_role_credentials_provider_test.cc
+++ b/test/extensions/common/aws/credential_providers/assume_role_credentials_provider_test.cc
@@ -883,6 +883,90 @@ TEST_F(AssumeRoleCredentialsProviderTest, CredentialsPendingReturn) {
   delete (raw_metadata_fetcher_);
 }
 
+TEST_F(AssumeRoleCredentialsProviderTest, WithExternalId) {
+  timer_ = new NiceMock<Event::MockTimer>(&context_.dispatcher_);
+
+  // Custom matcher for request with external ID parameter
+  Http::TestRequestHeaderMapImpl headers_with_external_id{
+      {":path", "/?Version=2011-06-15&Action=AssumeRole&RoleArn=aws:iam::123456789012:role/"
+                "arn&RoleSessionName=role-session-name&ExternalId=test-external-id"},
+      {":authority", "sts.region.amazonaws.com"},
+      {":scheme", "https"},
+      {":method", "GET"},
+      {"Accept", "application/json"},
+      {"x-amz-content-sha256", "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"},
+      {"x-amz-security-token", "token"},
+      {"x-amz-date", "20180102T030405Z"},
+      {"authorization",
+       "AWS4-HMAC-SHA256 Credential=akid/20180102/region/sts/aws4_request, "
+       "SignedHeaders=accept;host;x-amz-content-sha256;x-amz-date;x-amz-security-token, "
+       "Signature=cc05851f97c3e6c1d8c28c205a1dcbb6248a944375f3e7b349800c2b3744fc48"}};
+
+  EXPECT_CALL(*raw_metadata_fetcher_, fetch(messageMatches(headers_with_external_id), _, _))
+      .WillRepeatedly(Invoke(
+          [](Http::RequestMessage&, Tracing::Span&, MetadataFetcher::MetadataReceiver& receiver) {
+            receiver.onMetadataSuccess(std::move(R"EOF(
+{
+  "AssumeRoleResponse": {
+    "AssumeRoleResult": {
+      "Credentials": {
+        "AccessKeyId": "test-access-key",
+        "SecretAccessKey": "test-secret-key",
+        "SessionToken": "test-session-token"
+      }
+    }
+  }
+}
+)EOF"));
+          }));
+
+  // Setup provider with external ID
+  ON_CALL(context_, clusterManager()).WillByDefault(ReturnRef(cluster_manager_));
+  envoy::extensions::common::aws::v3::AssumeRoleCredentialProvider cred_provider = {};
+  cred_provider.set_role_arn("aws:iam::123456789012:role/arn");
+  cred_provider.set_role_session_name("role-session-name");
+  cred_provider.set_external_id("test-external-id");
+
+  mock_manager_ = std::make_shared<MockAwsClusterManager>();
+  EXPECT_CALL(*mock_manager_, getUriFromClusterName(_))
+      .WillRepeatedly(Return("sts.region.amazonaws.com:443"));
+
+  auto cluster_name = "credentials_provider_cluster";
+  envoy::extensions::common::aws::v3::AwsCredentialProvider defaults;
+  envoy::extensions::common::aws::v3::EnvironmentCredentialProvider env_provider;
+  TestEnvironment::setEnvVar("AWS_ACCESS_KEY_ID", "akid", 1);
+  TestEnvironment::setEnvVar("AWS_SECRET_ACCESS_KEY", "secret", 1);
+  TestEnvironment::setEnvVar("AWS_SESSION_TOKEN", "token", 1);
+
+  defaults.mutable_environment_credential_provider()->CopyFrom(env_provider);
+  auto credentials_provider_chain =
+      std::make_shared<Extensions::Common::Aws::CommonCredentialsProviderChain>(context_, "region",
+                                                                                defaults);
+  auto signer = std::make_unique<SigV4SignerImpl>(
+      STS_SERVICE_NAME, "region", credentials_provider_chain, context_,
+      Extensions::Common::Aws::AwsSigningHeaderExclusionVector{});
+
+  provider_ = std::make_shared<AssumeRoleCredentialsProvider>(
+      context_, mock_manager_, cluster_name,
+      [this](Upstream::ClusterManager&, absl::string_view) {
+        metadata_fetcher_.reset(raw_metadata_fetcher_);
+        return std::move(metadata_fetcher_);
+      },
+      "region", MetadataFetcher::MetadataReceiver::RefreshState::Ready, std::chrono::seconds(2),
+      std::move(signer), cred_provider);
+
+  timer_->enableTimer(std::chrono::milliseconds(1), nullptr);
+  EXPECT_CALL(*timer_, enableTimer(_, nullptr));
+
+  auto provider_friend = MetadataCredentialsProviderBaseFriend(provider_);
+  provider_friend.onClusterAddOrUpdate();
+  timer_->invokeCallback();
+
+  const auto credentials = provider_->getCredentials();
+  EXPECT_TRUE(credentials.accessKeyId().has_value());
+  EXPECT_EQ("test-access-key", credentials.accessKeyId().value());
+}
+
 } // namespace Aws
 } // namespace Common
 } // namespace Extensions

--- a/test/extensions/common/aws/credential_providers/assume_role_credentials_provider_test.cc
+++ b/test/extensions/common/aws/credential_providers/assume_role_credentials_provider_test.cc
@@ -632,7 +632,27 @@ TEST_F(AssumeRoleCredentialsProviderTest, Coverage) {
 TEST_F(AssumeRoleCredentialsProviderTest, WithSessionDuration) {
   timer_ = new NiceMock<Event::MockTimer>(&context_.dispatcher_);
 
-  expectDocument(200, std::move(R"EOF(
+  // Custom matcher for request with session duration parameter
+  Http::TestRequestHeaderMapImpl headers_with_duration{
+      {":path", "/?Version=2011-06-15&Action=AssumeRole&RoleArn=aws:iam::123456789012:role/"
+                "arn&RoleSessionName=role-session-name&DurationSeconds=3600"},
+      {":authority", "sts.region.amazonaws.com"},
+      {":scheme", "https"},
+      {":method", "GET"},
+      {"Accept", "application/json"},
+      {"x-amz-content-sha256", "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"},
+      {"x-amz-security-token", "token"},
+      {"x-amz-date", "20180102T030405Z"},
+      {"authorization",
+       "AWS4-HMAC-SHA256 Credential=akid/20180102/region/sts/aws4_request, "
+       "SignedHeaders=accept;host;x-amz-content-sha256;x-amz-date;x-amz-security-token, "
+       "Signature=88533b93b82077848fa88b5d1fe69540a0916960fdd48a1df66b764dc73a6d9a"}};
+
+  // Use a custom expectation for this test to verify the DurationSeconds parameter
+  EXPECT_CALL(*raw_metadata_fetcher_, fetch(messageMatches(headers_with_duration), _, _))
+      .WillRepeatedly(Invoke(
+          [](Http::RequestMessage&, Tracing::Span&, MetadataFetcher::MetadataReceiver& receiver) {
+            receiver.onMetadataSuccess(std::move(R"EOF(
 {
   "AssumeRoleResponse": {
     "AssumeRoleResult": {
@@ -645,6 +665,7 @@ TEST_F(AssumeRoleCredentialsProviderTest, WithSessionDuration) {
   }
 }
 )EOF"));
+          }));
 
   // Setup provider with session duration
   ON_CALL(context_, clusterManager()).WillByDefault(ReturnRef(cluster_manager_));


### PR DESCRIPTION
Commit Message: aws: assumerole missing protobuf validations
Additional Description: Adds missing protobuf validations that were unintentionally skipped, plus test cases to match
Risk Level: Low
Testing: Unit
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
