### PR TITLE
[bp/1.31] dynatracesampler: avoid div by zero (#40220) 

### DIFF
--- a/source/extensions/tracers/opentelemetry/samplers/dynatrace/sampling_controller.cc
+++ b/source/extensions/tracers/opentelemetry/samplers/dynatrace/sampling_controller.cc
@@ -123,12 +123,9 @@ void SamplingController::calculateSamplingExponents(
     return;
   }
 
-  // number of requests which are allowed for every entry
-  const uint32_t allowed_per_entry = total_wanted / top_k_size;
-
   for (auto& counter : top_k) {
     // allowed multiplicity for this entry
-    auto wanted_multiplicity = counter.getValue() / allowed_per_entry;
+    auto wanted_multiplicity = counter.getValue() * top_k_size / total_wanted;
     auto sampling_state = new_sampling_exponents.find(counter.getItem());
     // sampling exponent has to be a power of 2. Find the exponent to have multiplicity near to
     // wanted_multiplicity

--- a/test/extensions/tracers/opentelemetry/samplers/dynatrace/sampling_controller_test.cc
+++ b/test/extensions/tracers/opentelemetry/samplers/dynatrace/sampling_controller_test.cc
@@ -89,6 +89,24 @@ TEST(SamplingControllerTest, TestWithOneAllowedSpan) {
   EXPECT_EQ(sc.getSamplingState("1").getMultiplicity(), 1);
 }
 
+// Test with 1 root span per minute and more offered entries
+TEST(SamplingControllerTest, TestWithOneAllowedSpanMoreEntries) {
+  auto scf = std::make_unique<TestSamplerConfigProvider>(1);
+  SamplingController sc(std::move(scf));
+  sc.update();
+  EXPECT_EQ(sc.getSamplingState("1").getExponent(), SamplingController::MAX_SAMPLING_EXPONENT);
+  offerEntry(sc, "1", 1);
+  offerEntry(sc, "2", 1);
+  offerEntry(sc, "3", 1);
+  EXPECT_EQ(sc.getSamplingState("1").getExponent(), SamplingController::MAX_SAMPLING_EXPONENT);
+  EXPECT_EQ(sc.getSamplingState("2").getExponent(), SamplingController::MAX_SAMPLING_EXPONENT);
+  EXPECT_EQ(sc.getSamplingState("3").getExponent(), SamplingController::MAX_SAMPLING_EXPONENT);
+  sc.update();
+  EXPECT_EQ(sc.getSamplingState("1").getMultiplicity(), 2);
+  EXPECT_EQ(sc.getSamplingState("2").getMultiplicity(), 2);
+  EXPECT_EQ(sc.getSamplingState("3").getMultiplicity(), 1);
+}
+
 // Test with StreamSummary size not exceeded
 TEST(SamplingControllerTest, TestStreamSummarySizeNotExceeded) {
   auto scf = std::make_unique<TestSamplerConfigProvider>();


### PR DESCRIPTION
Backport #40220

