### PR TITLE
listener: add generic socket interface selection and filter cleanup

### DIFF
--- a/envoy/network/filter.h
+++ b/envoy/network/filter.h
@@ -441,6 +441,12 @@ public:
   virtual FilterStatus onData(Network::ListenerFilterBuffer& buffer) PURE;
 
   /**
+   * Called when the connection is closed. Only the current filter that has stopped filter
+   * chain iteration will get the callback.
+   */
+  virtual void onClose() {};
+
+  /**
    * Return the size of data the filter want to inspect from the connection.
    * The size can be increased after filter need to inspect more data.
    * @return maximum number of bytes of the data consumed by the filter. 0 means filter does not

--- a/source/common/listener_manager/active_tcp_socket.cc
+++ b/source/common/listener_manager/active_tcp_socket.cc
@@ -74,6 +74,7 @@ void ActiveTcpSocket::createListenerFilterBuffer() {
   listener_filter_buffer_ = std::make_unique<Network::ListenerFilterBufferImpl>(
       socket_->ioHandle(), listener_.dispatcher(),
       [this](bool error) {
+        (*iter_)->onClose();
         socket_->ioHandle().close();
         if (error) {
           listener_.stats_.downstream_listener_filter_error_.inc();

--- a/source/common/listener_manager/active_tcp_socket.h
+++ b/source/common/listener_manager/active_tcp_socket.h
@@ -53,6 +53,8 @@ public:
     }
 
     size_t maxReadBytes() const override { return listener_filter_->maxReadBytes(); }
+
+    void onClose() override { return listener_filter_->onClose(); }
   };
   using ListenerFilterWrapperPtr = std::unique_ptr<GenericListenerFilter>;
 

--- a/source/common/listener_manager/listener_manager_impl.cc
+++ b/source/common/listener_manager/listener_manager_impl.cc
@@ -21,6 +21,7 @@
 #include "source/common/network/filter_matcher.h"
 #include "source/common/network/io_socket_handle_impl.h"
 #include "source/common/network/listen_socket_impl.h"
+#include "source/common/network/socket_interface.h"
 #include "source/common/network/socket_option_factory.h"
 #include "source/common/network/utility.h"
 #include "source/common/protobuf/utility.h"
@@ -316,6 +317,22 @@ absl::StatusOr<Network::SocketSharedPtr> ProdListenerComponentFactory::createLis
   ASSERT(socket_type == Network::Socket::Type::Stream ||
          socket_type == Network::Socket::Type::Datagram);
 
+  // Use the address's socket interface for socket creation.
+  const Network::SocketInterface& socket_interface = address->socketInterface();
+  const Network::SocketInterface& default_interface = Network::SocketInterfaceSingleton::get();
+
+  // Check if this address specifies a custom socket interface.
+  if (&socket_interface != &default_interface) {
+    ENVOY_LOG(debug, "creating socket using custom interface for address: {}",
+              address->logicalName());
+    auto io_handle = socket_interface.socket(socket_type, address, creation_options);
+    if (!io_handle) {
+      return absl::InvalidArgumentError("failed to create socket using custom interface");
+    }
+    return std::make_shared<Network::TcpListenSocket>(std::move(io_handle), address, options);
+  }
+
+  // Continue with standard socket creation for addresses using the default interface.
   // First we try to get the socket from our parent if applicable in each case below.
   if (address->type() == Network::Address::Type::Pipe) {
     if (socket_type != Network::Socket::Type::Stream) {
@@ -401,6 +418,7 @@ ListenerManagerImpl::ListenerManagerImpl(Instance& server,
   for (uint32_t i = 0; i < server.options().concurrency(); i++) {
     workers_.emplace_back(worker_factory.createWorker(
         i, server.overloadManager(), server.nullOverloadManager(), absl::StrCat("worker_", i)));
+    ENVOY_LOG(debug, "starting worker: {}", i);
   }
 }
 

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -273,6 +273,7 @@ public:
   MOCK_METHOD(void, destroy_, ());
   MOCK_METHOD(Network::FilterStatus, onAccept, (ListenerFilterCallbacks&));
   MOCK_METHOD(Network::FilterStatus, onData, (Network::ListenerFilterBuffer&));
+  MOCK_METHOD(void, onClose, ());
 
   size_t listener_filter_max_read_bytes_{0};
 };


### PR DESCRIPTION
## Description

This PR introduces a mechanism for custom address types to specify their preferred socket interface. It also adds cleanup capabilities for listener filters. We need this change for custom connection types (like reverse tunnels) to integrate cleanly without requiring any hardcoded logic in any of the core components.
---

**Commit Message:** listener: add generic socket interface selection and filter cleanup
**Additional Description:** Adds a mechanism for custom address types to specify their preferred socket interface and cleanup capabilities for listener filters.
**Risk Level:** Low
**Testing:** Added Unit Tests
**Docs Changes:** N/A
**Release Notes:** N/A