### PR TITLE
rbac: fix upstream connection open before RBAC bug

### DIFF
--- a/source/extensions/filters/network/rbac/BUILD
+++ b/source/extensions/filters/network/rbac/BUILD
@@ -33,6 +33,8 @@ envoy_cc_library(
         "//envoy/network:connection_interface",
         "//envoy/network:filter_interface",
         "//source/common/common:minimal_logger_lib",
+        "//source/common/stream_info:bool_accessor_lib",
+        "//source/common/tcp_proxy:tcp_proxy",
         "//source/extensions/filters/common/rbac:engine_lib",
         "//source/extensions/filters/common/rbac:utility_lib",
         "//source/extensions/filters/network:well_known_names",

--- a/source/extensions/filters/network/rbac/BUILD
+++ b/source/extensions/filters/network/rbac/BUILD
@@ -34,7 +34,7 @@ envoy_cc_library(
         "//envoy/network:filter_interface",
         "//source/common/common:minimal_logger_lib",
         "//source/common/stream_info:bool_accessor_lib",
-        "//source/common/tcp_proxy:tcp_proxy",
+        "//source/common/tcp_proxy",
         "//source/extensions/filters/common/rbac:engine_lib",
         "//source/extensions/filters/common/rbac:utility_lib",
         "//source/extensions/filters/network:well_known_names",

--- a/source/extensions/filters/network/rbac/rbac_filter.h
+++ b/source/extensions/filters/network/rbac/rbac_filter.h
@@ -106,6 +106,7 @@ private:
   EngineResult engine_result_{Unknown};
   EngineResult shadow_engine_result_{Unknown};
 
+  bool runAuthorization();
   Result checkEngine(Filters::Common::RBAC::EnforcementMode mode) const;
   void closeConnection() const;
   void resetTimerState();

--- a/source/extensions/filters/network/rbac/rbac_filter.h
+++ b/source/extensions/filters/network/rbac/rbac_filter.h
@@ -89,11 +89,8 @@ public:
 
   // Network::ReadFilter
   Network::FilterStatus onData(Buffer::Instance& data, bool end_stream) override;
-  Network::FilterStatus onNewConnection() override { return Network::FilterStatus::Continue; };
-  void initializeReadFilterCallbacks(Network::ReadFilterCallbacks& callbacks) override {
-    callbacks_ = &callbacks;
-    callbacks_->connection().addConnectionCallbacks(*this);
-  }
+  Network::FilterStatus onNewConnection() override;
+  void initializeReadFilterCallbacks(Network::ReadFilterCallbacks& callbacks) override;
 
   // Network::ConnectionCallbacks
   void onEvent(Network::ConnectionEvent event) override;

--- a/test/extensions/access_loggers/grpc/tcp_grpc_access_log_integration_test.cc
+++ b/test/extensions/access_loggers/grpc/tcp_grpc_access_log_integration_test.cc
@@ -440,20 +440,8 @@ typed_config:
   initialize();
 
   IntegrationTcpClientPtr tcp_client = makeTcpConnection(lookupPort("tcp_proxy"));
-  FakeRawConnectionPtr fake_upstream_connection;
-  ASSERT_TRUE(fake_upstreams_[0]->waitForRawConnection(fake_upstream_connection));
-
-  ASSERT_TRUE(fake_upstream_connection->write("hello"));
-  tcp_client->waitForData("hello");
   ASSERT_TRUE(tcp_client->write("bar", false));
-
-  ASSERT_TRUE(fake_upstream_connection->write("", true));
-  tcp_client->waitForHalfClose();
-  ASSERT_TRUE(tcp_client->write("", true));
-
-  // Connection blocked. Do not wait for data, but directly wait for disconnect.
-  ASSERT_TRUE(fake_upstream_connection->waitForDisconnect());
-
+  tcp_client->waitForDisconnect();
   ASSERT_TRUE(waitForAccessLogConnection());
   ASSERT_TRUE(waitForAccessLogStream());
   ASSERT_TRUE(
@@ -475,27 +463,12 @@ tcp_logs:
       downstream_local_address:
         socket_address:
           address: {}
-      upstream_remote_address:
-        socket_address:
-          address: {}
-      upstream_local_address:
-        socket_address:
-          address: {}
-      upstream_cluster: cluster_0
-      upstream_request_attempt_count: 1
-      downstream_wire_bytes_sent: 5
-      upstream_wire_bytes_received: 5
       connection_termination_details: rbac_access_denied_matched_policy[none]
       downstream_direct_remote_address:
         socket_address:
           address: {}
       access_log_type: NotSet
-    connection_properties:
-      received_bytes: 3
-      sent_bytes: 5
 )EOF",
-                                          Network::Test::getLoopbackAddressString(ipVersion()),
-                                          Network::Test::getLoopbackAddressString(ipVersion()),
                                           Network::Test::getLoopbackAddressString(ipVersion()),
                                           Network::Test::getLoopbackAddressString(ipVersion()),
                                           Network::Test::getLoopbackAddressString(ipVersion()))));

--- a/test/extensions/filters/network/rbac/filter_test.cc
+++ b/test/extensions/filters/network/rbac/filter_test.cc
@@ -251,7 +251,7 @@ TEST_F(RoleBasedAccessControlNetworkFilterTest, AllowedWithOneTimeEnforcement) {
 
   setDestinationPort(123);
 
-  EXPECT_EQ(Network::FilterStatus::Continue, filter_->onNewConnection());
+  EXPECT_EQ(Network::FilterStatus::StopIteration, filter_->onNewConnection());
 
   // Call onData() twice, should only increase stats once.
   EXPECT_EQ(Network::FilterStatus::Continue, filter_->onData(data_, false));
@@ -272,7 +272,7 @@ TEST_F(RoleBasedAccessControlNetworkFilterTest, AllowedWithContinuousEnforcement
 
   setDestinationPort(123);
 
-  EXPECT_EQ(Network::FilterStatus::Continue, filter_->onNewConnection());
+  EXPECT_EQ(Network::FilterStatus::StopIteration, filter_->onNewConnection());
 
   // Call onData() twice, should increase stats twice.
   EXPECT_EQ(Network::FilterStatus::Continue, filter_->onData(data_, false));
@@ -294,7 +294,7 @@ TEST_F(RoleBasedAccessControlNetworkFilterTest, RequestedServerName) {
   setDestinationPort(999);
   setRequestedServerName("www.cncf.io");
 
-  EXPECT_EQ(Network::FilterStatus::Continue, filter_->onNewConnection());
+  EXPECT_EQ(Network::FilterStatus::StopIteration, filter_->onNewConnection());
 
   // Call onData() twice, should only increase stats once.
   EXPECT_EQ(Network::FilterStatus::Continue, filter_->onData(data_, false));
@@ -316,7 +316,7 @@ TEST_F(RoleBasedAccessControlNetworkFilterTest, AllowedWithNoPolicy) {
   setDestinationPort(0);
 
   // Allow access and no metric change when there is no policy.
-  EXPECT_EQ(Network::FilterStatus::Continue, filter_->onNewConnection());
+  EXPECT_EQ(Network::FilterStatus::StopIteration, filter_->onNewConnection());
   EXPECT_EQ(Network::FilterStatus::Continue, filter_->onData(data_, false));
   EXPECT_EQ(0U, config_->stats().allowed_.value());
   EXPECT_EQ(0U, config_->stats().denied_.value());
@@ -386,7 +386,7 @@ TEST_F(RoleBasedAccessControlNetworkFilterTest, MatcherAllowedWithOneTimeEnforce
 
   setDestinationPort(123);
 
-  EXPECT_EQ(Network::FilterStatus::Continue, filter_->onNewConnection());
+  EXPECT_EQ(Network::FilterStatus::StopIteration, filter_->onNewConnection());
 
   // Call onData() twice, should only increase stats once.
   EXPECT_EQ(Network::FilterStatus::Continue, filter_->onData(data_, false));
@@ -407,7 +407,7 @@ TEST_F(RoleBasedAccessControlNetworkFilterTest, MatcherAllowedWithContinuousEnfo
 
   setDestinationPort(123);
 
-  EXPECT_EQ(Network::FilterStatus::Continue, filter_->onNewConnection());
+  EXPECT_EQ(Network::FilterStatus::StopIteration, filter_->onNewConnection());
 
   // Call onData() twice, should increase stats twice.
   EXPECT_EQ(Network::FilterStatus::Continue, filter_->onData(data_, false));
@@ -429,7 +429,7 @@ TEST_F(RoleBasedAccessControlNetworkFilterTest, RequestedServerNameMatcher) {
   setDestinationPort(999);
   setRequestedServerName("www.cncf.io");
 
-  EXPECT_EQ(Network::FilterStatus::Continue, filter_->onNewConnection());
+  EXPECT_EQ(Network::FilterStatus::StopIteration, filter_->onNewConnection());
 
   // Call onData() twice, should only increase stats once.
   EXPECT_EQ(Network::FilterStatus::Continue, filter_->onData(data_, false));
@@ -451,7 +451,7 @@ TEST_F(RoleBasedAccessControlNetworkFilterTest, AllowedWithNoMatcher) {
   setDestinationPort(0);
 
   // Allow access and no metric change when there is no policy.
-  EXPECT_EQ(Network::FilterStatus::Continue, filter_->onNewConnection());
+  EXPECT_EQ(Network::FilterStatus::StopIteration, filter_->onNewConnection());
   EXPECT_EQ(Network::FilterStatus::Continue, filter_->onData(data_, false));
   EXPECT_EQ(0U, config_->stats().allowed_.value());
   EXPECT_EQ(0U, config_->stats().denied_.value());


### PR DESCRIPTION
Commit Message:
This change fixes https://github.com/envoyproxy/envoy/issues/9023 by delaying upstream connection setup until onData is called for the first time and an authorization data can be made.

Additional Description:
I believe this change as is will break (non-TLS'd?) server first protocols that rely on the RBAC filter, as the lack of data from upstream would prevent onData from firing.

I'm opening this PR as is to ask for guidance on how to deal with this. Potential options I see are:
1) Expose a flag in the API that disables this behavior for server-first protocols
2) Abandon this overall approach and rely on a restructuring of TLS setup to allow authorization data to be available before onData

Risk Level: Low
Testing: Modified unit tests to match new behavior, integration tests continue to pass.
Docs Changes: N/A
Release Notes: Unclear if necessary
Platform Specific Features: N/A
Fixes #9023
