### PR TITLE
Make BackwardsTrace::addrMapping a string_view type

### DIFF
--- a/source/server/backtrace.cc
+++ b/source/server/backtrace.cc
@@ -8,8 +8,8 @@ namespace Envoy {
 
 bool BackwardsTrace::log_to_stderr_ = false;
 
-const std::string& BackwardsTrace::addrMapping(bool setup) {
-  CONSTRUCT_ON_FIRST_USE(std::string, [setup]() -> std::string {
+absl::string_view BackwardsTrace::addrMapping(bool setup) {
+  CONSTRUCT_ON_FIRST_USE(absl::string_view, [setup]() -> absl::string_view {
     if (!setup) {
       return "";
     }
@@ -23,7 +23,8 @@ const std::string& BackwardsTrace::addrMapping(bool setup) {
     while (std::getline(maps, line)) {
       std::vector<absl::string_view> parts = absl::StrSplit(line, ' ');
       if (parts[1] == "r-xp") {
-        return absl::StrCat(parts[0], " ", parts.back());
+        static std::string result = absl::StrCat(parts[0], " ", parts.back());
+        return result;
       }
     }
 #endif

--- a/source/server/backtrace.h
+++ b/source/server/backtrace.h
@@ -58,7 +58,7 @@ public:
    * e.g.
    *   `7d34c0e28000-7d34c1e0d000 /build/foo/bar/source/exe/envoy-static`
    */
-  static const std::string& addrMapping(bool setup = false);
+  static absl::string_view addrMapping(bool setup = false);
 
   /**
    * Directs the output of logTrace() to directly stderr rather than the


### PR DESCRIPTION
Commit Message: Make BackwardsTrace::addrMapping a string_view type
Additional Description: This makes it so in the event of it being triggered in a tsan context without having been initialized, it still doesn't malloc anything - it is a tsan error to malloc during a signal.
Risk Level: Only crash-related so pretty safe.
