### PR TITLE
Fix a bug on Geoip maxmind apple_private_relay to check if apple_private_relay is set instead of isp header.

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -113,6 +113,9 @@ minor_behavior_changes:
 
 bug_fixes:
 # *Changes expected to improve the state of the world and are unlikely to have negative effects*
+- area: geoip
+  change: |
+    Fixed a bug where the ``apple_private_relay`` header was not populated correctly when isp header wasn't set.
 - area: conn_pool
   change: |
     Fixed an issue that could lead to too many connections when using

--- a/source/extensions/geoip_providers/maxmind/geoip_provider.cc
+++ b/source/extensions/geoip_providers/maxmind/geoip_provider.cc
@@ -72,7 +72,7 @@ GeoipProviderConfig::GeoipProviderConfig(
                            : absl::nullopt;
   isp_header_ = !geo_headers_to_add.isp().empty() ? absl::make_optional(geo_headers_to_add.isp())
                                                   : absl::nullopt;
-  apple_private_relay_header_ = !geo_headers_to_add.isp().empty()
+  apple_private_relay_header_ = !geo_headers_to_add.apple_private_relay().empty()
                                     ? absl::make_optional(geo_headers_to_add.apple_private_relay())
                                     : absl::nullopt;
   if (!city_db_path_ && !anon_db_path_ && !asn_db_path_ && !isp_db_path_) {

--- a/test/extensions/filters/http/geoip/geoip_filter_integration_test.cc
+++ b/test/extensions/filters/http/geoip/geoip_filter_integration_test.cc
@@ -99,6 +99,22 @@ const std::string ConfigIspAndCity = R"EOF(
           isp_db_path: "{{ test_rundir }}/test/extensions/geoip_providers/maxmind/test_data/GeoIP2-ISP-Test.mmdb"
   )EOF";
 
+const std::string ConfigIsApplePrivateRelayOnly = R"EOF(
+    name: envoy.filters.http.geoip
+    typed_config:
+      "@type": type.googleapis.com/envoy.extensions.filters.http.geoip.v3.Geoip
+      xff_config:
+        xff_num_trusted_hops: 1
+      provider:
+        name: envoy.geoip_providers.maxmind
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.geoip_providers.maxmind.v3.MaxMindConfig
+          common_provider_config:
+            geo_headers_to_add:
+              apple_private_relay: "x-geo-apple-private-relay"
+          isp_db_path: "{{ test_rundir }}/test/extensions/geoip_providers/maxmind/test_data/GeoIP2-ISP-Test.mmdb"
+    )EOF";
+
 class GeoipFilterIntegrationTest : public testing::TestWithParam<Network::Address::IpVersion>,
                                    public HttpIntegrationTest {
 public:
@@ -293,6 +309,27 @@ TEST_P(GeoipFilterIntegrationTest, GeoipFilterNoCrashOnLdsUpdate) {
   test_server_->waitForCounterEq("http.config_test.geoip.total", 2);
   EXPECT_EQ(2, test_server_->counter("http.config_test.maxmind.city_db.total")->value());
   EXPECT_EQ(2, test_server_->counter("http.config_test.maxmind.city_db.hit")->value());
+}
+
+TEST_P(GeoipFilterIntegrationTest, OnlyApplePrivateRelayHeaderIsPopulated) {
+  config_helper_.prependFilter(TestEnvironment::substitute(ConfigIsApplePrivateRelayOnly));
+  initialize();
+  codec_client_ = makeHttpConnection(makeClientConnection(lookupPort("http")));
+  Http::TestRequestHeaderMapImpl request_headers{{":method", "GET"},
+                                                 {":path", "/"},
+                                                 {":scheme", "http"},
+                                                 {":authority", "host"},
+                                                 {"x-forwarded-for", "81.2.69.142,9.10.11.12"},
+                                                 {"x-geo-city", "Berlin"},
+                                                 {"x-geo-country", "Germany"}};
+  auto response = sendRequestAndWaitForResponse(request_headers, 0, default_response_headers_, 0);
+
+  EXPECT_EQ("false", headerValue("x-geo-apple-private-relay"));
+  ASSERT_TRUE(response->complete());
+  EXPECT_EQ("200", response->headers().getStatusValue());
+  test_server_->waitForCounterEq("http.config_test.geoip.total", 1);
+  EXPECT_EQ(1, test_server_->counter("http.config_test.maxmind.isp_db.total")->value());
+  EXPECT_EQ(1, test_server_->counter("http.config_test.maxmind.isp_db.hit")->value());
 }
 
 } // namespace


### PR DESCRIPTION
The geoip filter should check for the correct field when setting the header, the apple_private_relay is a special header that sets true or false when the isp is iCloud Private Relay, but we were checking the wrong field with a potential bug when using the filter with only apple_private_relay header set.

