### PR TITLE
mobile: Filter reserved IP address ranges in IPv6 probing

### DIFF
--- a/mobile/library/common/internal_engine.cc
+++ b/mobile/library/common/internal_engine.cc
@@ -27,6 +27,8 @@ MobileProcessWide& initOnceMobileProcessWide(const OptionsImplBase& options) {
 
 Network::Address::InstanceConstSharedPtr ipv6ProbeAddr() {
   // Use Google DNS IPv6 address for IPv6 probes.
+  // Same as Chromium:
+  // https://source.chromium.org/chromium/chromium/src/+/main:net/dns/host_resolver_manager.cc;l=155;drc=7b232da0f22e8cdf555d43c52b6491baeb87f729.
   CONSTRUCT_ON_FIRST_USE(Network::Address::InstanceConstSharedPtr,
                          new Network::Address::Ipv6Instance("2001:4860:4860::8888", 53));
 }
@@ -545,9 +547,6 @@ void InternalEngine::logInterfaces(absl::string_view event,
 
 Network::Address::InstanceConstSharedPtr InternalEngine::probeAndGetLocalAddr(int domain) {
   // This probing logic is borrowed from Chromium.
-  // -
-  // https://source.chromium.org/chromium/chromium/src/+/main:net/dns/host_resolver_manager.cc;l=154-157;drc=7b232da0f22e8cdf555d43c52b6491baeb87f729
-  // -
   // https://source.chromium.org/chromium/chromium/src/+/main:net/dns/host_resolver_manager.cc;l=1467-1488;drc=7b232da0f22e8cdf555d43c52b6491baeb87f729
   ENVOY_LOG(trace, "Checking for {} connectivity.", domain == AF_INET6 ? "IPv6" : "IPv4");
   const Api::SysCallSocketResult socket_result =
@@ -560,18 +559,40 @@ Network::Address::InstanceConstSharedPtr InternalEngine::probeAndGetLocalAddr(in
                                             /* socket_v6only= */ domain == AF_INET6, {domain});
   Api::SysCallIntResult connect_result =
       socket_handle.connect(domain == AF_INET6 ? ipv6ProbeAddr() : ipv4ProbeAddr());
-  if (connect_result.return_value_ == 0) {
-    auto address_or_error = socket_handle.localAddress();
-    if (!address_or_error.status().ok()) {
-      ENVOY_LOG(trace, "Local address error: {}", address_or_error.status().message());
-      return nullptr;
-    }
-    ENVOY_LOG(trace, "Found {} connectivity.", domain == AF_INET6 ? "IPv6" : "IPv4");
-    return *address_or_error;
+  if (connect_result.return_value_ != 0) {
+    ENVOY_LOG(trace, "No {} connectivity found with errno: {}.",
+              domain == AF_INET6 ? "IPv6" : "IPv4", connect_result.errno_);
+    return nullptr;
   }
-  ENVOY_LOG(trace, "No {} connectivity found with errno: {}.", domain == AF_INET6 ? "IPv6" : "IPv4",
-            connect_result.errno_);
-  return nullptr;
+
+  auto address = socket_handle.localAddress();
+  if (!address.status().ok()) {
+    ENVOY_LOG(trace, "Local address error: {}", address.status().message());
+    return nullptr;
+  }
+  if (address->ip() == nullptr) {
+    ENVOY_LOG(trace, "Local address is not an IP address: {}.", address->asString());
+    return nullptr;
+  }
+  if (address->ip()->isLinkLocalAddress()) {
+    ENVOY_LOG(trace, "Ignoring link-local address: {}.", address->asString());
+    return nullptr;
+  }
+  if (address->ip()->isUniqueLocalAddress()) {
+    ENVOY_LOG(trace, "Ignoring unique-local address: {}.", address->asString());
+    return nullptr;
+  }
+  if (address->ip()->isSiteLocalAddress()) {
+    ENVOY_LOG(trace, "Ignoring site-local address: {}.", address->asString());
+    return nullptr;
+  }
+  if (address->ip()->isTeredoAddress()) {
+    ENVOY_LOG(trace, "Ignoring teredo address: {}.", address->asString());
+    return nullptr;
+  }
+
+  ENVOY_LOG(trace, "Found {} connectivity.", domain == AF_INET6 ? "IPv6" : "IPv4");
+  return *address;
 }
 
 } // namespace Envoy

--- a/mobile/library/common/internal_engine.cc
+++ b/mobile/library/common/internal_engine.cc
@@ -570,23 +570,23 @@ Network::Address::InstanceConstSharedPtr InternalEngine::probeAndGetLocalAddr(in
     ENVOY_LOG(trace, "Local address error: {}", address.status().message());
     return nullptr;
   }
-  if (address->ip() == nullptr) {
+  if ((*address)->ip() == nullptr) {
     ENVOY_LOG(trace, "Local address is not an IP address: {}.", address->asString());
     return nullptr;
   }
-  if (address->ip()->isLinkLocalAddress()) {
+  if ((*address)->ip()->isLinkLocalAddress()) {
     ENVOY_LOG(trace, "Ignoring link-local address: {}.", address->asString());
     return nullptr;
   }
-  if (address->ip()->isUniqueLocalAddress()) {
+  if ((*address)->ip()->isUniqueLocalAddress()) {
     ENVOY_LOG(trace, "Ignoring unique-local address: {}.", address->asString());
     return nullptr;
   }
-  if (address->ip()->isSiteLocalAddress()) {
+  if ((*address)->ip()->isSiteLocalAddress()) {
     ENVOY_LOG(trace, "Ignoring site-local address: {}.", address->asString());
     return nullptr;
   }
-  if (address->ip()->isTeredoAddress()) {
+  if ((*address)->ip()->isTeredoAddress()) {
     ENVOY_LOG(trace, "Ignoring teredo address: {}.", address->asString());
     return nullptr;
   }

--- a/mobile/library/common/internal_engine.cc
+++ b/mobile/library/common/internal_engine.cc
@@ -565,29 +565,30 @@ Network::Address::InstanceConstSharedPtr InternalEngine::probeAndGetLocalAddr(in
     return nullptr;
   }
 
-  auto address = socket_handle.localAddress();
+  absl::StatusOr<Network::Address::InstanceConstSharedPtr> address = socket_handle.localAddress();
   if (!address.status().ok()) {
     ENVOY_LOG(trace, "Local address error: {}", address.status().message());
     return nullptr;
   }
+
   if ((*address)->ip() == nullptr) {
-    ENVOY_LOG(trace, "Local address is not an IP address: {}.", address->asString());
+    ENVOY_LOG(trace, "Local address is not an IP address: {}.", (*address)->asString());
     return nullptr;
   }
   if ((*address)->ip()->isLinkLocalAddress()) {
-    ENVOY_LOG(trace, "Ignoring link-local address: {}.", address->asString());
+    ENVOY_LOG(trace, "Ignoring link-local address: {}.", (*address)->asString());
     return nullptr;
   }
   if ((*address)->ip()->isUniqueLocalAddress()) {
-    ENVOY_LOG(trace, "Ignoring unique-local address: {}.", address->asString());
+    ENVOY_LOG(trace, "Ignoring unique-local address: {}.", (*address)->asString());
     return nullptr;
   }
   if ((*address)->ip()->isSiteLocalAddress()) {
-    ENVOY_LOG(trace, "Ignoring site-local address: {}.", address->asString());
+    ENVOY_LOG(trace, "Ignoring site-local address: {}.", (*address)->asString());
     return nullptr;
   }
   if ((*address)->ip()->isTeredoAddress()) {
-    ENVOY_LOG(trace, "Ignoring teredo address: {}.", address->asString());
+    ENVOY_LOG(trace, "Ignoring teredo address: {}.", (*address)->asString());
     return nullptr;
   }
 


### PR DESCRIPTION
IPv6 probing will now filter out:
  * Link-local IP addresses
  * Site-local IPv6 addresses
  * Unique Local IPv6 addresses
  * Teredo addresses

This is the same as Chromium's logic for IPv6 connectivity probing: https://source.chromium.org/chromium/chromium/src/+/main:net/dns/host_resolver_manager.cc;l=1572-1581;drc=d0260a368e65b2be56d179d21fab90976fd494b8.

Though it doesn't seem like Chromium filters out site-local addresses, local testing has shown that the IPv6 probe socket will successfully connect but the local address will be site-local on non-IPv6 networks/machines.
