### PR TITLE
Temporary revert for release "matcher: refactor the matcher to avoid unnecessary wrapper and heap allocation (envoyproxy#40249)

### DIFF
--- a/source/common/listener_manager/filter_chain_manager_impl.cc
+++ b/source/common/listener_manager/filter_chain_manager_impl.cc
@@ -49,11 +49,11 @@ class FilterChainNameActionFactory : public Matcher::ActionFactory<FilterChainAc
                                      Logger::Loggable<Logger::Id::config> {
 public:
   std::string name() const override { return "filter-chain-name"; }
-  Matcher::ActionConstSharedPtr createAction(const Protobuf::Message& config,
-                                             FilterChainActionFactoryContext&,
-                                             ProtobufMessage::ValidationVisitor&) override {
-    return std::make_shared<FilterChainNameAction>(
-        dynamic_cast<const ProtobufWkt::StringValue&>(config).value());
+  Matcher::ActionFactoryCb createActionFactoryCb(const Protobuf::Message& config,
+                                                 FilterChainActionFactoryContext&,
+                                                 ProtobufMessage::ValidationVisitor&) override {
+    const auto& name = dynamic_cast<const ProtobufWkt::StringValue&>(config);
+    return [value = name.value()]() { return std::make_unique<FilterChainNameAction>(value); };
   }
   ProtobufTypes::MessagePtr createEmptyConfigProto() override {
     return std::make_unique<ProtobufWkt::StringValue>();
@@ -573,8 +573,9 @@ FilterChainManagerImpl::findFilterChainUsingMatcher(const Network::ConnectionSoc
       Matcher::evaluateMatch<Network::MatchingData>(*matcher_, data);
   ASSERT(match_result.isComplete(), "Matching must complete for network streams.");
   if (match_result.isMatch()) {
-    return match_result.action()->getTyped<Configuration::FilterChainBaseAction>().get(
-        filter_chains_by_name_, info);
+    const Matcher::ActionPtr action = match_result.action();
+    return action->getTyped<Configuration::FilterChainBaseAction>().get(filter_chains_by_name_,
+                                                                        info);
   }
   return default_filter_chain_.get();
 }

--- a/source/common/matcher/matcher.h
+++ b/source/common/matcher/matcher.h
@@ -324,10 +324,10 @@ private:
           on_match.action().typed_config(), server_factory_context_.messageValidationVisitor(),
           factory);
 
-      auto action = factory.createAction(*message, action_factory_context_,
-                                         server_factory_context_.messageValidationVisitor());
-      return [action, keep_matching = on_match.keep_matching()] {
-        return OnMatch<DataType>{action, {}, keep_matching};
+      auto action_factory = factory.createActionFactoryCb(
+          *message, action_factory_context_, server_factory_context_.messageValidationVisitor());
+      return [action_factory, keep_matching = on_match.keep_matching()] {
+        return OnMatch<DataType>{action_factory, {}, keep_matching};
       };
     }
 

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -1825,13 +1825,14 @@ RouteConstSharedPtr VirtualHostImpl::getRouteFromEntries(const RouteCallback& cb
         Matcher::evaluateMatch<Http::HttpMatchingData>(*matcher_, data);
 
     if (match_result.isMatch()) {
-      const auto result = match_result.actionByMove();
+      const Matcher::ActionPtr result = match_result.action();
       if (result->typeUrl() == RouteMatchAction::staticTypeUrl()) {
-        return getRouteFromRoutes(
-            cb, headers, stream_info, random_value,
-            {std::dynamic_pointer_cast<const RouteEntryImplBase>(std::move(result))});
+        const RouteMatchAction& route_action = result->getTyped<RouteMatchAction>();
+
+        return getRouteFromRoutes(cb, headers, stream_info, random_value, {route_action.route()});
       } else if (result->typeUrl() == RouteListMatchAction::staticTypeUrl()) {
         const RouteListMatchAction& action = result->getTyped<RouteListMatchAction>();
+
         return getRouteFromRoutes(cb, headers, stream_info, random_value, action.routes());
       }
       PANIC("Action in router matcher should be Route or RouteList");
@@ -2139,9 +2140,9 @@ const Envoy::Config::TypedMetadata& NullConfigImpl::typedMetadata() const {
   return DefaultRouteMetadataPack::get().typed_metadata_;
 }
 
-Matcher::ActionConstSharedPtr
-RouteMatchActionFactory::createAction(const Protobuf::Message& config, RouteActionContext& context,
-                                      ProtobufMessage::ValidationVisitor& validation_visitor) {
+Matcher::ActionFactoryCb RouteMatchActionFactory::createActionFactoryCb(
+    const Protobuf::Message& config, RouteActionContext& context,
+    ProtobufMessage::ValidationVisitor& validation_visitor) {
   const auto& route_config =
       MessageUtil::downcastAndValidate<const envoy::config::route::v3::Route&>(config,
                                                                                validation_visitor);
@@ -2149,14 +2150,14 @@ RouteMatchActionFactory::createAction(const Protobuf::Message& config, RouteActi
       RouteCreator::createAndValidateRoute(route_config, context.vhost, context.factory_context,
                                            validation_visitor, false),
       RouteEntryImplBaseConstSharedPtr);
-  return route;
+
+  return [route]() { return std::make_unique<RouteMatchAction>(route); };
 }
 REGISTER_FACTORY(RouteMatchActionFactory, Matcher::ActionFactory<RouteActionContext>);
 
-Matcher::ActionConstSharedPtr
-RouteListMatchActionFactory::createAction(const Protobuf::Message& config,
-                                          RouteActionContext& context,
-                                          ProtobufMessage::ValidationVisitor& validation_visitor) {
+Matcher::ActionFactoryCb RouteListMatchActionFactory::createActionFactoryCb(
+    const Protobuf::Message& config, RouteActionContext& context,
+    ProtobufMessage::ValidationVisitor& validation_visitor) {
   const auto& route_config =
       MessageUtil::downcastAndValidate<const envoy::config::route::v3::RouteList&>(
           config, validation_visitor);
@@ -2168,7 +2169,7 @@ RouteListMatchActionFactory::createAction(const Protobuf::Message& config,
                                              validation_visitor, false),
         RouteEntryImplBaseConstSharedPtr));
   }
-  return std::make_shared<RouteListMatchAction>(std::move(routes));
+  return [routes]() { return std::make_unique<RouteListMatchAction>(routes); };
 }
 REGISTER_FACTORY(RouteListMatchActionFactory, Matcher::ActionFactory<RouteActionContext>);
 

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -619,7 +619,6 @@ class RouteEntryImplBase : public RouteEntryAndRoute,
                            public Matchable,
                            public DirectResponseEntry,
                            public PathMatchCriterion,
-                           public Matcher::ActionBase<envoy::config::route::v3::Route>,
                            public std::enable_shared_from_this<RouteEntryImplBase>,
                            Logger::Loggable<Logger::Id::router> {
 protected:
@@ -1192,9 +1191,9 @@ private:
 // Registered factory for RouteMatchAction.
 class RouteMatchActionFactory : public Matcher::ActionFactory<RouteActionContext> {
 public:
-  Matcher::ActionConstSharedPtr
-  createAction(const Protobuf::Message& config, RouteActionContext& context,
-               ProtobufMessage::ValidationVisitor& validation_visitor) override;
+  Matcher::ActionFactoryCb
+  createActionFactoryCb(const Protobuf::Message& config, RouteActionContext& context,
+                        ProtobufMessage::ValidationVisitor& validation_visitor) override;
   std::string name() const override { return "route"; }
   ProtobufTypes::MessagePtr createEmptyConfigProto() override {
     return std::make_unique<envoy::config::route::v3::Route>();
@@ -1218,9 +1217,9 @@ private:
 // Registered factory for RouteListMatchAction.
 class RouteListMatchActionFactory : public Matcher::ActionFactory<RouteActionContext> {
 public:
-  Matcher::ActionConstSharedPtr
-  createAction(const Protobuf::Message& config, RouteActionContext& context,
-               ProtobufMessage::ValidationVisitor& validation_visitor) override;
+  Matcher::ActionFactoryCb
+  createActionFactoryCb(const Protobuf::Message& config, RouteActionContext& context,
+                        ProtobufMessage::ValidationVisitor& validation_visitor) override;
   std::string name() const override { return "route_match_action"; }
   ProtobufTypes::MessagePtr createEmptyConfigProto() override {
     return std::make_unique<envoy::config::route::v3::RouteList>();

--- a/source/extensions/filters/common/rbac/engine_impl.cc
+++ b/source/extensions/filters/common/rbac/engine_impl.cc
@@ -11,9 +11,9 @@ namespace Filters {
 namespace Common {
 namespace RBAC {
 
-Envoy::Matcher::ActionConstSharedPtr
-ActionFactory::createAction(const Protobuf::Message& config, ActionContext& context,
-                            ProtobufMessage::ValidationVisitor& validation_visitor) {
+Envoy::Matcher::ActionFactoryCb
+ActionFactory::createActionFactoryCb(const Protobuf::Message& config, ActionContext& context,
+                                     ProtobufMessage::ValidationVisitor& validation_visitor) {
   const auto& action_config =
       MessageUtil::downcastAndValidate<const envoy::config::rbac::v3::Action&>(config,
                                                                                validation_visitor);
@@ -25,7 +25,7 @@ ActionFactory::createAction(const Protobuf::Message& config, ActionContext& cont
     context.has_log_ = true;
   }
 
-  return std::make_shared<Action>(name, action);
+  return [name, action]() { return std::make_unique<Action>(name, action); };
 }
 
 REGISTER_FACTORY(ActionFactory, Envoy::Matcher::ActionFactory<ActionContext>);
@@ -138,17 +138,18 @@ bool RoleBasedAccessControlMatcherEngineImpl::handleAction(
       Envoy::Matcher::evaluateMatch<Http::HttpMatchingData>(*matcher_, data);
   ASSERT(result.isComplete());
   if (result.isMatch()) {
-    const auto& action = result.action()->getTyped<Action>();
+    auto action = result.action()->getTyped<Action>();
     if (effective_policy_id != nullptr) {
       *effective_policy_id = action.name();
     }
 
     // If there is at least an LOG action in matchers, we have to turn on and off for shared log
     // metadata every time when there is a connection or request.
-    const auto rbac_action = action.action();
+    auto rbac_action = action.action();
     if (has_log_) {
       generateLog(info, mode_, rbac_action == envoy::config::rbac::v3::RBAC::LOG);
     }
+
     switch (rbac_action) {
       PANIC_ON_PROTO_ENUM_SENTINEL_VALUES;
     case envoy::config::rbac::v3::RBAC::ALLOW:

--- a/source/extensions/filters/common/rbac/engine_impl.h
+++ b/source/extensions/filters/common/rbac/engine_impl.h
@@ -50,9 +50,9 @@ private:
 
 class ActionFactory : public Envoy::Matcher::ActionFactory<ActionContext> {
 public:
-  Envoy::Matcher::ActionConstSharedPtr
-  createAction(const Protobuf::Message& config, ActionContext& context,
-               ProtobufMessage::ValidationVisitor& validation_visitor) override;
+  Envoy::Matcher::ActionFactoryCb
+  createActionFactoryCb(const Protobuf::Message& config, ActionContext& context,
+                        ProtobufMessage::ValidationVisitor& validation_visitor) override;
   std::string name() const override { return "envoy.filters.rbac.action"; }
   ProtobufTypes::MessagePtr createEmptyConfigProto() override {
     return std::make_unique<envoy::config::rbac::v3::Action>();

--- a/source/extensions/filters/http/composite/action.h
+++ b/source/extensions/filters/http/composite/action.h
@@ -18,26 +18,16 @@ class ExecuteFilterAction
     : public Matcher::ActionBase<
           envoy::extensions::filters::http::composite::v3::ExecuteFilterAction> {
 public:
-  using FilterConfigProvider = std::function<OptRef<Http::FilterFactoryCb>()>;
-
-  explicit ExecuteFilterAction(
-      FilterConfigProvider config_provider, const std::string& name,
-      const absl::optional<envoy::config::core::v3::RuntimeFractionalPercent>& sample,
-      Runtime::Loader& runtime)
-      : config_provider_(std::move(config_provider)), name_(name), sample_(sample),
-        runtime_(runtime) {}
+  explicit ExecuteFilterAction(Http::FilterFactoryCb cb, const std::string& name)
+      : cb_(std::move(cb)), name_(name) {}
 
   void createFilters(Http::FilterChainFactoryCallbacks& callbacks) const;
 
-  const std::string& actionName() const;
-
-  bool actionSkip() const;
+  const std::string& actionName() const { return name_; }
 
 private:
-  FilterConfigProvider config_provider_;
+  Http::FilterFactoryCb cb_;
   const std::string name_;
-  const absl::optional<envoy::config::core::v3::RuntimeFractionalPercent> sample_;
-  Runtime::Loader& runtime_;
 };
 
 class ExecuteFilterActionFactory
@@ -46,22 +36,29 @@ class ExecuteFilterActionFactory
 public:
   std::string name() const override { return "composite-action"; }
 
-  Matcher::ActionConstSharedPtr
-  createAction(const Protobuf::Message& config, Http::Matching::HttpFilterActionContext& context,
-               ProtobufMessage::ValidationVisitor& validation_visitor) override;
+  Matcher::ActionFactoryCb
+  createActionFactoryCb(const Protobuf::Message& config,
+                        Http::Matching::HttpFilterActionContext& context,
+                        ProtobufMessage::ValidationVisitor& validation_visitor) override;
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override {
     return std::make_unique<envoy::extensions::filters::http::composite::v3::ExecuteFilterAction>();
   }
 
+  // Rolling the dice to decide whether the action will be sampled.
+  // By default, if sample_percent is not specified, then it is sampled.
+  bool isSampled(
+      const envoy::extensions::filters::http::composite::v3::ExecuteFilterAction& composite_action,
+      Envoy::Runtime::Loader& runtime);
+
 private:
-  Matcher::ActionConstSharedPtr createActionCommon(
+  Matcher::ActionFactoryCb createActionFactoryCbCommon(
       const envoy::extensions::filters::http::composite::v3::ExecuteFilterAction& composite_action,
       Http::Matching::HttpFilterActionContext& context, Envoy::Http::FilterFactoryCb& callback,
       bool is_downstream);
 
   template <class FactoryCtx, class FilterCfgProviderMgr>
-  Matcher::ActionConstSharedPtr createDynamicActionTyped(
+  Matcher::ActionFactoryCb createDynamicActionFactoryCbTyped(
       const envoy::extensions::filters::http::composite::v3::ExecuteFilterAction& composite_action,
       Http::Matching::HttpFilterActionContext& context, const std::string& filter_chain_type,
       FactoryCtx& factory_context, std::shared_ptr<FilterCfgProviderMgr>& provider_manager) {
@@ -76,30 +73,35 @@ private:
             server_factory_context.clusterManager(), false, filter_chain_type, nullptr);
 
     Envoy::Runtime::Loader& runtime = context.server_factory_context_->runtime();
+    return
+        [provider = std::move(provider), n = std::move(name),
+         composite_action = std::move(composite_action), &runtime, this]() -> Matcher::ActionPtr {
+          if (!isSampled(composite_action, runtime)) {
+            return nullptr;
+          }
 
-    return std::make_shared<ExecuteFilterAction>(
-        [provider]() -> OptRef<Http::FilterFactoryCb> { return provider->config(); }, name,
-        composite_action.has_sample_percent()
-            ? absl::make_optional<envoy::config::core::v3::RuntimeFractionalPercent>(
-                  composite_action.sample_percent())
-            : absl::nullopt,
-        runtime);
+          if (auto config_value = provider->config(); config_value.has_value()) {
+            return std::make_unique<ExecuteFilterAction>(config_value.ref(), n);
+          }
+          // There is no dynamic config available. Apply missing config filter.
+          return std::make_unique<ExecuteFilterAction>(Envoy::Http::MissingConfigFilterFactory, n);
+        };
   }
 
-  Matcher::ActionConstSharedPtr createDynamicActionDownstream(
+  Matcher::ActionFactoryCb createDynamicActionFactoryCbDownstream(
       const envoy::extensions::filters::http::composite::v3::ExecuteFilterAction& composite_action,
       Http::Matching::HttpFilterActionContext& context);
 
-  Matcher::ActionConstSharedPtr createDynamicActionUpstream(
+  Matcher::ActionFactoryCb createDynamicActionFactoryCbUpstream(
       const envoy::extensions::filters::http::composite::v3::ExecuteFilterAction& composite_action,
       Http::Matching::HttpFilterActionContext& context);
 
-  Matcher::ActionConstSharedPtr createStaticActionDownstream(
+  Matcher::ActionFactoryCb createStaticActionFactoryCbDownstream(
       const envoy::extensions::filters::http::composite::v3::ExecuteFilterAction& composite_action,
       Http::Matching::HttpFilterActionContext& context,
       ProtobufMessage::ValidationVisitor& validation_visitor);
 
-  Matcher::ActionConstSharedPtr createStaticActionUpstream(
+  Matcher::ActionFactoryCb createStaticActionFactoryCbUpstream(
       const envoy::extensions::filters::http::composite::v3::ExecuteFilterAction& composite_action,
       Http::Matching::HttpFilterActionContext& context,
       ProtobufMessage::ValidationVisitor& validation_visitor);

--- a/source/extensions/filters/http/composite/filter.cc
+++ b/source/extensions/filters/http/composite/filter.cc
@@ -96,6 +96,7 @@ void Filter::encodeComplete() {
 
 void Filter::onMatchCallback(const Matcher::Action& action) {
   const auto& composite_action = action.getTyped<ExecuteFilterAction>();
+
   FactoryCallbacksWrapper wrapper(*this, dispatcher_);
   composite_action.createFilters(wrapper);
 
@@ -106,11 +107,10 @@ void Filter::onMatchCallback(const Matcher::Action& action) {
                   wrapper.errors_, [](const auto& status) { return status.ToString(); }));
     return;
   }
+  const std::string& action_name = composite_action.actionName();
 
   if (wrapper.filter_to_inject_.has_value()) {
     stats_.filter_delegation_success_.inc();
-
-    const std::string& action_name = composite_action.actionName();
 
     auto createDelegatedFilterFn = Overloaded{
         [this, action_name](Http::StreamDecoderFilterSharedPtr filter) {
@@ -137,6 +137,7 @@ void Filter::onMatchCallback(const Matcher::Action& action) {
     access_loggers_.insert(access_loggers_.end(), wrapper.access_loggers_.begin(),
                            wrapper.access_loggers_.end());
   }
+
   // TODO(snowp): Make it possible for onMatchCallback to fail the stream by issuing a local reply,
   // either directly or via some return status.
 }

--- a/source/extensions/filters/http/composite/filter.h
+++ b/source/extensions/filters/http/composite/filter.h
@@ -57,7 +57,8 @@ class Filter : public Http::StreamFilter,
                Logger::Loggable<Logger::Id::filter> {
 public:
   Filter(FilterStats& stats, Event::Dispatcher& dispatcher, bool is_upstream)
-      : dispatcher_(dispatcher), stats_(stats), is_upstream_(is_upstream) {}
+      : dispatcher_(dispatcher), decoded_headers_(false), stats_(stats), is_upstream_(is_upstream) {
+  }
 
   // Http::StreamDecoderFilter
   Http::FilterHeadersStatus decodeHeaders(Http::RequestHeaderMap& headers,
@@ -123,7 +124,7 @@ private:
   // time will result in various FM assertions firing.
   // We should be protected against this by the match tree validation that only allows request
   // headers, this just provides some additional sanity checking.
-  bool decoded_headers_{false};
+  bool decoded_headers_ : 1;
 
   // Wraps a stream encoder OR a stream decoder filter into a stream filter, making it easier to
   // delegate calls.

--- a/source/extensions/filters/http/custom_response/config.cc
+++ b/source/extensions/filters/http/custom_response/config.cc
@@ -61,7 +61,7 @@ PolicySharedPtr FilterConfig::getPolicy(const ::Envoy::Http::ResponseHeaderMap& 
   if (!match_result.isMatch()) {
     return PolicySharedPtr{};
   }
-  return std::dynamic_pointer_cast<const Policy>(match_result.actionByMove());
+  return match_result.action()->getTyped<CustomResponseMatchAction>().policy_;
 }
 
 } // namespace CustomResponse

--- a/source/extensions/filters/http/match_delegate/config.cc
+++ b/source/extensions/filters/http/match_delegate/config.cc
@@ -24,10 +24,10 @@ class SkipActionFactory
     : public Matcher::ActionFactory<Envoy::Http::Matching::HttpFilterActionContext> {
 public:
   std::string name() const override { return "skip"; }
-  Matcher::ActionConstSharedPtr createAction(const Protobuf::Message&,
-                                             Envoy::Http::Matching::HttpFilterActionContext&,
-                                             ProtobufMessage::ValidationVisitor&) override {
-    return std::make_shared<SkipAction>();
+  Matcher::ActionFactoryCb createActionFactoryCb(const Protobuf::Message&,
+                                                 Envoy::Http::Matching::HttpFilterActionContext&,
+                                                 ProtobufMessage::ValidationVisitor&) override {
+    return []() { return std::make_unique<SkipAction>(); };
   }
   ProtobufTypes::MessagePtr createEmptyConfigProto() override {
     return std::make_unique<envoy::extensions::filters::common::matcher::action::v3::SkipFilter>();
@@ -120,8 +120,8 @@ void DelegatingStreamFilter::FilterMatchState::evaluateMatchTree(
   match_tree_evaluated_ = match_result.isComplete();
 
   if (match_tree_evaluated_ && match_result.isMatch()) {
-    const auto& result = match_result.action();
-    if (result == nullptr || SkipAction().typeUrl() == result->typeUrl()) {
+    const Matcher::ActionPtr result = match_result.action();
+    if ((result == nullptr) || (SkipAction().typeUrl() == result->typeUrl())) {
       skip_filter_ = true;
     } else {
       ASSERT(base_filter_ != nullptr);

--- a/source/extensions/filters/http/proto_api_scrubber/filter_config.h
+++ b/source/extensions/filters/http/proto_api_scrubber/filter_config.h
@@ -118,10 +118,10 @@ class RemoveFieldAction : public Matcher::ActionBase<ProtoApiScrubberRemoveField
 // ActionFactory for the RemoveFieldAction.
 class RemoveFilterActionFactory : public Matcher::ActionFactory<ProtoApiScrubberRemoveFieldAction> {
 public:
-  Matcher::ActionConstSharedPtr createAction(const Protobuf::Message&,
-                                             ProtoApiScrubberRemoveFieldAction&,
-                                             ProtobufMessage::ValidationVisitor&) override {
-    return std::make_shared<RemoveFieldAction>();
+  Matcher::ActionFactoryCb createActionFactoryCb(const Protobuf::Message&,
+                                                 ProtoApiScrubberRemoveFieldAction&,
+                                                 ProtobufMessage::ValidationVisitor&) override {
+    return []() { return std::make_unique<RemoveFieldAction>(); };
   }
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override {

--- a/source/extensions/filters/http/rate_limit_quota/filter.cc
+++ b/source/extensions/filters/http/rate_limit_quota/filter.cc
@@ -56,9 +56,8 @@ inline Envoy::Http::Code getDenyResponseCode(const DenyResponseSettings& setting
 
 inline std::function<void(Http::ResponseHeaderMap&)>
 addDenyResponseHeadersCb(const DenyResponseSettings& settings) {
-  if (settings.response_headers_to_add().empty()) {
+  if (settings.response_headers_to_add().empty())
     return nullptr;
-  }
   // Headers copied from settings for thread-safety.
   return [headers_to_add = settings.response_headers_to_add()](Http::ResponseHeaderMap& headers) {
     for (const envoy::config::core::v3::HeaderValueOption& header : headers_to_add) {
@@ -80,7 +79,7 @@ Http::FilterHeadersStatus RateLimitQuotaFilter::decodeHeaders(Http::RequestHeade
                                                               bool end_stream) {
   ENVOY_LOG(trace, "decodeHeaders: end_stream = {}", end_stream);
   // First, perform the request matching.
-  absl::StatusOr<Matcher::ActionConstSharedPtr> match_result = requestMatching(headers);
+  absl::StatusOr<Matcher::ActionPtr> match_result = requestMatching(headers);
   if (!match_result.ok()) {
     // When the request is not matched by any matchers, it is ALLOWED by default
     // (i.e., fail-open) and its quota usage will not be reported to RLQS
@@ -185,7 +184,7 @@ Http::FilterHeadersStatus RateLimitQuotaFilter::decodeHeaders(Http::RequestHeade
 
 // TODO(tyxia) Currently request matching is only performed on the request
 // header.
-absl::StatusOr<Matcher::ActionConstSharedPtr>
+absl::StatusOr<Matcher::ActionPtr>
 RateLimitQuotaFilter::requestMatching(const Http::RequestHeaderMap& headers) {
   // Initialize the data pointer on first use and reuse it for subsequent
   // requests. This avoids creating the data object for every request, which
@@ -216,7 +215,7 @@ RateLimitQuotaFilter::requestMatching(const Http::RequestHeaderMap& headers) {
     return absl::NotFoundError("Matching completed but no match result was found.");
   }
   // Return the matched result for `on_match` case.
-  return match_result.actionByMove();
+  return match_result.action();
 }
 
 void RateLimitQuotaFilter::onDestroy() {

--- a/source/extensions/filters/http/rate_limit_quota/filter.h
+++ b/source/extensions/filters/http/rate_limit_quota/filter.h
@@ -65,8 +65,7 @@ public:
 
   // Perform request matching. It returns the generated bucket ids if the
   // matching succeeded, error status otherwise.
-  absl::StatusOr<Matcher::ActionConstSharedPtr>
-  requestMatching(const Http::RequestHeaderMap& headers);
+  absl::StatusOr<Matcher::ActionPtr> requestMatching(const Http::RequestHeaderMap& headers);
 
   Http::Matching::HttpMatchingDataImpl matchingData() {
     ASSERT(data_ptr_ != nullptr);

--- a/source/extensions/filters/network/match_delegate/config.cc
+++ b/source/extensions/filters/network/match_delegate/config.cc
@@ -18,9 +18,10 @@ namespace Factory {
 class SkipActionFactory : public Matcher::ActionFactory<NetworkFilterActionContext> {
 public:
   std::string name() const override { return "skip"; }
-  Matcher::ActionConstSharedPtr createAction(const Protobuf::Message&, NetworkFilterActionContext&,
-                                             ProtobufMessage::ValidationVisitor&) override {
-    return std::make_shared<SkipAction>();
+  Matcher::ActionFactoryCb createActionFactoryCb(const Protobuf::Message&,
+                                                 NetworkFilterActionContext&,
+                                                 ProtobufMessage::ValidationVisitor&) override {
+    return []() { return std::make_unique<SkipAction>(); };
   }
   ProtobufTypes::MessagePtr createEmptyConfigProto() override {
     return std::make_unique<envoy::extensions::filters::common::matcher::action::v3::SkipFilter>();
@@ -106,8 +107,8 @@ void DelegatingNetworkFilter::FilterMatchState::evaluateMatchTree() {
   match_tree_evaluated_ = match_result.isComplete();
 
   if (match_tree_evaluated_ && match_result.isMatch()) {
-    const auto& result = match_result.action();
-    if (result == nullptr || SkipAction().typeUrl() == result->typeUrl()) {
+    const Matcher::ActionPtr result = match_result.action();
+    if ((result == nullptr) || (SkipAction().typeUrl() == result->typeUrl())) {
       skip_filter_ = true;
     } else {
       // TODO(botengyao) this would be similar to `base_filter_->onMatchCallback(*result);`
@@ -191,7 +192,7 @@ Envoy::Network::FilterFactoryCb MatchDelegateConfig::createFilterFactory(
   auto message = Config::Utility::translateAnyToFactoryConfig(
       proto_config.extension_config().typed_config(), validation, factory);
   auto filter_factory_or_error = factory.createFilterFactoryFromProto(*message, context);
-  THROW_IF_NOT_OK_REF(filter_factory_or_error.status());
+  THROW_IF_NOT_OK(filter_factory_or_error.status());
   auto filter_factory = filter_factory_or_error.value();
 
   Factory::MatchTreeValidationVisitor validation_visitor(*factory.matchingRequirements());

--- a/source/extensions/filters/udp/udp_proxy/router/router_impl.cc
+++ b/source/extensions/filters/udp/udp_proxy/router/router_impl.cc
@@ -15,16 +15,17 @@ namespace UdpFilters {
 namespace UdpProxy {
 namespace Router {
 
-Matcher::ActionConstSharedPtr
-RouteMatchActionFactory::createAction(const Protobuf::Message& config, RouteActionContext& context,
-                                      ProtobufMessage::ValidationVisitor& validation_visitor) {
+Matcher::ActionFactoryCb RouteMatchActionFactory::createActionFactoryCb(
+    const Protobuf::Message& config, RouteActionContext& context,
+    ProtobufMessage::ValidationVisitor& validation_visitor) {
   const auto& route_config = MessageUtil::downcastAndValidate<
       const envoy::extensions::filters::udp::udp_proxy::v3::Route&>(config, validation_visitor);
   const auto& cluster = route_config.cluster();
 
   // Emplace cluster names to context to get all cluster names.
   context.cluster_name_.emplace(cluster);
-  return std::make_shared<RouteMatchAction>(cluster);
+
+  return [cluster]() { return std::make_unique<RouteMatchAction>(cluster); };
 }
 
 REGISTER_FACTORY(RouteMatchActionFactory, Matcher::ActionFactory<RouteActionContext>);

--- a/source/extensions/filters/udp/udp_proxy/router/router_impl.h
+++ b/source/extensions/filters/udp/udp_proxy/router/router_impl.h
@@ -32,9 +32,9 @@ private:
 
 class RouteMatchActionFactory : public Matcher::ActionFactory<RouteActionContext> {
 public:
-  Matcher::ActionConstSharedPtr
-  createAction(const Protobuf::Message& config, RouteActionContext& context,
-               ProtobufMessage::ValidationVisitor& validation_visitor) override;
+  Matcher::ActionFactoryCb
+  createActionFactoryCb(const Protobuf::Message& config, RouteActionContext& context,
+                        ProtobufMessage::ValidationVisitor& validation_visitor) override;
   std::string name() const override { return "route"; }
   ProtobufTypes::MessagePtr createEmptyConfigProto() override {
     return std::make_unique<envoy::extensions::filters::udp::udp_proxy::v3::Route>();

--- a/source/extensions/matching/actions/format_string/config.cc
+++ b/source/extensions/matching/actions/format_string/config.cc
@@ -23,10 +23,10 @@ ActionImpl::get(const Server::Configuration::FilterChainsByName& filter_chains_b
   return nullptr;
 }
 
-Matcher::ActionConstSharedPtr
-ActionFactory::createAction(const Protobuf::Message& proto_config,
-                            FilterChainActionFactoryContext& context,
-                            ProtobufMessage::ValidationVisitor& validator) {
+Matcher::ActionFactoryCb
+ActionFactory::createActionFactoryCb(const Protobuf::Message& proto_config,
+                                     FilterChainActionFactoryContext& context,
+                                     ProtobufMessage::ValidationVisitor& validator) {
   const auto& config =
       MessageUtil::downcastAndValidate<const envoy::config::core::v3::SubstitutionFormatString&>(
           proto_config, validator);
@@ -35,7 +35,7 @@ ActionFactory::createAction(const Protobuf::Message& proto_config,
   Formatter::FormatterConstSharedPtr formatter = THROW_OR_RETURN_VALUE(
       Formatter::SubstitutionFormatStringUtils::fromProtoConfig(config, generic_context),
       Formatter::FormatterPtr);
-  return std::make_shared<ActionImpl>(std::move(formatter));
+  return [formatter]() { return std::make_unique<ActionImpl>(formatter); };
 }
 
 REGISTER_FACTORY(ActionFactory, Matcher::ActionFactory<FilterChainActionFactoryContext>);

--- a/source/extensions/matching/actions/format_string/config.h
+++ b/source/extensions/matching/actions/format_string/config.h
@@ -17,7 +17,7 @@ namespace FormatString {
 class ActionImpl : public Matcher::ActionBase<envoy::config::core::v3::SubstitutionFormatString,
                                               Server::Configuration::FilterChainBaseAction> {
 public:
-  ActionImpl(Formatter::FormatterConstSharedPtr formatter) : formatter_(std::move(formatter)) {}
+  ActionImpl(const Formatter::FormatterConstSharedPtr& formatter) : formatter_(formatter) {}
   const Network::FilterChain*
   get(const Server::Configuration::FilterChainsByName& filter_chains_by_name,
       const StreamInfo::StreamInfo& info) const override;
@@ -30,9 +30,10 @@ using FilterChainActionFactoryContext = Server::Configuration::ServerFactoryCont
 class ActionFactory : public Matcher::ActionFactory<FilterChainActionFactoryContext> {
 public:
   std::string name() const override { return "envoy.matching.actions.format_string"; }
-  Matcher::ActionConstSharedPtr
-  createAction(const Protobuf::Message& proto_config, FilterChainActionFactoryContext& context,
-               ProtobufMessage::ValidationVisitor& validator) override;
+  Matcher::ActionFactoryCb
+  createActionFactoryCb(const Protobuf::Message& proto_config,
+                        FilterChainActionFactoryContext& context,
+                        ProtobufMessage::ValidationVisitor& validator) override;
   ProtobufTypes::MessagePtr createEmptyConfigProto() override {
     return std::make_unique<envoy::config::core::v3::SubstitutionFormatString>();
   }

--- a/source/extensions/router/cluster_specifiers/matcher/matcher_cluster_specifier.cc
+++ b/source/extensions/router/cluster_specifiers/matcher/matcher_cluster_specifier.cc
@@ -10,12 +10,14 @@ namespace Extensions {
 namespace Router {
 namespace Matcher {
 
-Envoy::Matcher::ActionConstSharedPtr
-ClusterActionFactory::createAction(const Protobuf::Message& config, ClusterActionContext&,
-                                   ProtobufMessage::ValidationVisitor& validation_visitor) {
+Envoy::Matcher::ActionFactoryCb ClusterActionFactory::createActionFactoryCb(
+    const Protobuf::Message& config, ClusterActionContext&,
+    ProtobufMessage::ValidationVisitor& validation_visitor) {
   const auto& proto_config =
       MessageUtil::downcastAndValidate<const ClusterActionProto&>(config, validation_visitor);
-  return std::make_shared<ClusterAction>(proto_config.cluster());
+  auto cluster = std::make_shared<std::string>(proto_config.cluster());
+
+  return [cluster]() { return std::make_unique<ClusterAction>(cluster); };
 }
 
 REGISTER_FACTORY(ClusterActionFactory, Envoy::Matcher::ActionFactory<ClusterActionContext>);
@@ -41,7 +43,9 @@ public:
     if (!match_result.isMatch()) {
       return;
     }
-    cluster_name_.emplace(match_result.action()->getTyped<ClusterAction>().cluster());
+
+    const Envoy::Matcher::ActionPtr result = match_result.action();
+    cluster_name_.emplace(result->getTyped<ClusterAction>().cluster());
   }
 
 private:

--- a/source/extensions/router/cluster_specifiers/matcher/matcher_cluster_specifier.h
+++ b/source/extensions/router/cluster_specifiers/matcher/matcher_cluster_specifier.h
@@ -26,21 +26,21 @@ struct ClusterActionContext {};
  */
 class ClusterAction : public Envoy::Matcher::ActionBase<ClusterActionProto> {
 public:
-  explicit ClusterAction(absl::string_view cluster) : cluster_(cluster) {}
+  explicit ClusterAction(std::shared_ptr<std::string> cluster) : cluster_(cluster) {}
 
-  const std::string& cluster() const { return cluster_; }
+  const std::string& cluster() const { return *cluster_; }
 
 private:
-  const std::string cluster_;
+  const std::shared_ptr<std::string> cluster_;
 };
 
 // Registered factory for ClusterAction. This factory will be used to load proto configuration
 // from opaque config.
 class ClusterActionFactory : public Envoy::Matcher::ActionFactory<ClusterActionContext> {
 public:
-  Envoy::Matcher::ActionConstSharedPtr
-  createAction(const Protobuf::Message& config, ClusterActionContext& context,
-               ProtobufMessage::ValidationVisitor& validation_visitor) override;
+  Envoy::Matcher::ActionFactoryCb
+  createActionFactoryCb(const Protobuf::Message& config, ClusterActionContext& context,
+                        ProtobufMessage::ValidationVisitor& validation_visitor) override;
   std::string name() const override { return "cluster"; }
   ProtobufTypes::MessagePtr createEmptyConfigProto() override {
     return std::make_unique<ClusterActionProto>();

--- a/test/common/matcher/exact_map_matcher_test.cc
+++ b/test/common/matcher/exact_map_matcher_test.cc
@@ -109,7 +109,7 @@ TEST(ExactMapMatcherTest, RecursiveMatching) {
       std::make_unique<TestInput>(
           DataInputGetResult{DataInputGetResult::DataAvailability::AllDataAvailable, "match"}),
       stringOnMatch<TestData>("no_match"));
-  matcher->addChild("match", OnMatch<TestData>{/*.action_=*/nullptr, /*.matcher=*/sub_matcher,
+  matcher->addChild("match", OnMatch<TestData>{/*.action_cb=*/nullptr, /*.matcher=*/sub_matcher,
                                                /*.keep_matching=*/false});
 
   TestData data;
@@ -127,7 +127,7 @@ TEST(ExactMapMatcherTest, RecursiveMatchingOnNoMatch) {
   std::unique_ptr<ExactMapMatcher<TestData>> matcher = *ExactMapMatcher<TestData>::create(
       std::make_unique<TestInput>(
           DataInputGetResult{DataInputGetResult::DataAvailability::AllDataAvailable, "blah"}),
-      OnMatch<TestData>{/*.action_=*/nullptr, /*.matcher=*/sub_matcher,
+      OnMatch<TestData>{/*.action_cb=*/nullptr, /*.matcher=*/sub_matcher,
                         /*.keep_matching=*/false});
   matcher->addChild("match", stringOnMatch<TestData>("match"));
 
@@ -156,14 +156,14 @@ TEST(ExactMapMatcherTest, RecursiveMatchingWithKeepMatching) {
   std::unique_ptr<ExactMapMatcher<TestData>> matcher = *ExactMapMatcher<TestData>::create(
       std::make_unique<TestInput>(
           DataInputGetResult{DataInputGetResult::DataAvailability::AllDataAvailable, "match"}),
-      OnMatch<TestData>{/*.action_=*/nullptr, /*.matcher=*/top_on_no_match_matcher,
+      OnMatch<TestData>{/*.action_cb=*/nullptr, /*.matcher=*/top_on_no_match_matcher,
                         /*.keep_matching=*/false});
-  matcher->addChild("match", OnMatch<TestData>{/*.action_=*/nullptr,
+  matcher->addChild("match", OnMatch<TestData>{/*.action_cb=*/nullptr,
                                                /*.matcher=*/sub_matcher_match_keeps_matching,
                                                /*.keep_matching=*/true});
 
-  std::vector<ActionConstSharedPtr> skipped_results{};
-  SkippedMatchCb skipped_match_cb = [&skipped_results](const ActionConstSharedPtr& cb) {
+  std::vector<ActionFactoryCb> skipped_results{};
+  SkippedMatchCb skipped_match_cb = [&skipped_results](ActionFactoryCb cb) {
     skipped_results.push_back(cb);
   };
   TestData data;

--- a/test/common/matcher/list_matcher_test.cc
+++ b/test/common/matcher/list_matcher_test.cc
@@ -40,8 +40,8 @@ TEST(ListMatcherTest, KeepMatching) {
   matcher.addMatcher(createSingleMatcher("string", [](auto) { return true; }),
                      stringOnMatch<TestData>("matched", /*keep_matching=*/false));
 
-  std::vector<ActionConstSharedPtr> skipped_results;
-  SkippedMatchCb skipped_match_cb = [&skipped_results](ActionConstSharedPtr cb) {
+  std::vector<ActionFactoryCb> skipped_results;
+  SkippedMatchCb skipped_match_cb = [&skipped_results](ActionFactoryCb cb) {
     skipped_results.push_back(cb);
   };
   auto result = matcher.match(TestData(), skipped_match_cb);
@@ -56,8 +56,8 @@ TEST(ListMatcherTest, KeepMatchingOnNoMatch) {
   matcher.addMatcher(createSingleMatcher("string", [](auto) { return true; }),
                      stringOnMatch<TestData>("keep matching 2", /*keep_matching=*/true));
 
-  std::vector<ActionConstSharedPtr> skipped_results;
-  SkippedMatchCb skipped_match_cb = [&skipped_results](const ActionConstSharedPtr cb) {
+  std::vector<ActionFactoryCb> skipped_results;
+  SkippedMatchCb skipped_match_cb = [&skipped_results](const ActionFactoryCb cb) {
     skipped_results.push_back(cb);
   };
   auto result = matcher.match(TestData(), skipped_match_cb);
@@ -84,17 +84,17 @@ TEST(ListMatcherTest, KeepMatchingWithRecursion) {
 
   Envoy::Matcher::ListMatcher<TestData> matcher(stringOnMatch<TestData>("top_level on_no_match"));
   matcher.addMatcher(createSingleMatcher("string", [](auto) { return true; }),
-                     OnMatch<TestData>{/*.action_=*/nullptr, /*.matcher=*/sub_matcher_1,
+                     OnMatch<TestData>{/*.action_cb=*/nullptr, /*.matcher=*/sub_matcher_1,
                                        /*.keep_matching=*/false});
   matcher.addMatcher(createSingleMatcher("string", [](auto) { return true; }),
-                     OnMatch<TestData>{/*.action_=*/nullptr, /*.matcher=*/sub_matcher_2,
+                     OnMatch<TestData>{/*.action_cb=*/nullptr, /*.matcher=*/sub_matcher_2,
                                        /*.keep_matching=*/true});
   matcher.addMatcher(createSingleMatcher("string", [](auto) { return true; }),
-                     OnMatch<TestData>{/*.action_=*/nullptr, /*.matcher=*/sub_matcher_3,
+                     OnMatch<TestData>{/*.action_cb=*/nullptr, /*.matcher=*/sub_matcher_3,
                                        /*.keep_matching=*/false});
 
-  std::vector<ActionConstSharedPtr> skipped_results;
-  SkippedMatchCb skipped_match_cb = [&skipped_results](ActionConstSharedPtr cb) {
+  std::vector<ActionFactoryCb> skipped_results;
+  SkippedMatchCb skipped_match_cb = [&skipped_results](ActionFactoryCb cb) {
     skipped_results.push_back(cb);
   };
   MatchResult result = matcher.match(TestData(), skipped_match_cb);
@@ -120,17 +120,17 @@ TEST(ListMatcherTest, KeepMatchingWithRecursiveOnNoMatch) {
       stringOnMatch<TestData>("on_no_match sub match", /*keep_matching=*/true));
 
   Envoy::Matcher::ListMatcher<TestData> matcher(
-      OnMatch<TestData>{/*action_=*/nullptr,
+      OnMatch<TestData>{/*action_cb=*/nullptr,
                         /*matcher=*/on_no_match_sub_matcher, /*keep_matching=*/false});
   matcher.addMatcher(
       createSingleMatcher("string", [](auto) { return true; }),
-      OnMatch<TestData>{/*action_=*/nullptr, /*matcher=*/sub_matcher_1, /*keep_matching=*/true});
+      OnMatch<TestData>{/*action_cb=*/nullptr, /*matcher=*/sub_matcher_1, /*keep_matching=*/true});
   matcher.addMatcher(
       createSingleMatcher("string", [](auto) { return true; }),
-      OnMatch<TestData>{/*action_=*/nullptr, /*matcher=*/sub_matcher_2, /*keep_matching=*/false});
+      OnMatch<TestData>{/*action_cb=*/nullptr, /*matcher=*/sub_matcher_2, /*keep_matching=*/false});
 
-  std::vector<ActionConstSharedPtr> skipped_results;
-  SkippedMatchCb skipped_match_cb = [&skipped_results](ActionConstSharedPtr cb) {
+  std::vector<ActionFactoryCb> skipped_results;
+  SkippedMatchCb skipped_match_cb = [&skipped_results](ActionFactoryCb cb) {
     skipped_results.push_back(cb);
   };
   MatchResult result = matcher.match(TestData(), skipped_match_cb);

--- a/test/common/matcher/matcher_test.cc
+++ b/test/common/matcher/matcher_test.cc
@@ -907,8 +907,8 @@ TEST_P(MatcherAmbiguousTest, KeepMatchingSupportInEvaluation) {
   validation_visitor_.setSupportKeepMatching(true);
   std::shared_ptr<MatchTree<TestData>> matcher = createMatcherFromYaml(yaml)();
 
-  std::vector<ActionConstSharedPtr> skipped_results;
-  SkippedMatchCb skipped_match_cb = [&skipped_results](ActionConstSharedPtr cb) {
+  std::vector<ActionFactoryCb> skipped_results;
+  SkippedMatchCb skipped_match_cb = [&skipped_results](ActionFactoryCb cb) {
     skipped_results.push_back(cb);
   };
   const auto result = evaluateMatch(*matcher, TestData(), skipped_match_cb);
@@ -1020,8 +1020,8 @@ TEST_P(MatcherAmbiguousTest, KeepMatchingWithRecursiveMatcher) {
 
   // Expect the nested matchers with keep_matching to be skipped and also the top-level
   // keep_matching setting to skip the result of the first sub-matcher.
-  std::vector<ActionConstSharedPtr> skipped_results;
-  SkippedMatchCb skipped_match_cb = [&skipped_results](ActionConstSharedPtr cb) {
+  std::vector<ActionFactoryCb> skipped_results;
+  SkippedMatchCb skipped_match_cb = [&skipped_results](ActionFactoryCb cb) {
     skipped_results.push_back(cb);
   };
   MatchResult result = evaluateMatch(*matcher, TestData(), skipped_match_cb);
@@ -1056,8 +1056,8 @@ TEST_P(MatcherAmbiguousTest, KeepMatchingWithUnsupportedReentry) {
   validation_visitor_.setSupportKeepMatching(true);
   std::shared_ptr<MatchTree<TestData>> matcher = createMatcherFromYaml(yaml)();
 
-  std::vector<ActionConstSharedPtr> skipped_results;
-  SkippedMatchCb skipped_match_cb = [&skipped_results](ActionConstSharedPtr cb) {
+  std::vector<ActionFactoryCb> skipped_results;
+  SkippedMatchCb skipped_match_cb = [&skipped_results](ActionFactoryCb cb) {
     skipped_results.push_back(cb);
   };
   MatchResult result = evaluateMatch(*matcher, TestData(), skipped_match_cb);
@@ -1130,12 +1130,12 @@ TEST_P(MatcherAmbiguousTest, KeepMatchingWithFailingNestedMatcher) {
       stringOnMatch<TestData>("fail"));
 
   matcher->addMatcher(createSingleMatcher("string", [](auto) { return true; }),
-                      OnMatch<TestData>{/*.action_=*/nullptr, /*.matcher=*/nested_matcher,
+                      OnMatch<TestData>{/*.action_cb=*/nullptr, /*.matcher=*/nested_matcher,
                                         /*.keep_matching=*/true});
 
   // Expect re-entry to fail due to the nested matcher.
-  std::vector<ActionConstSharedPtr> skipped_results;
-  SkippedMatchCb skipped_match_cb = [&skipped_results](ActionConstSharedPtr cb) {
+  std::vector<ActionFactoryCb> skipped_results;
+  SkippedMatchCb skipped_match_cb = [&skipped_results](ActionFactoryCb cb) {
     skipped_results.push_back(cb);
   };
   MatchResult result = evaluateMatch(*matcher, TestData(), skipped_match_cb);

--- a/test/common/matcher/test_utility.h
+++ b/test/common/matcher/test_utility.h
@@ -162,10 +162,10 @@ struct StringAction : public ActionBase<ProtobufWkt::StringValue> {
 // Factory for StringAction.
 class StringActionFactory : public ActionFactory<absl::string_view> {
 public:
-  ActionConstSharedPtr createAction(const Protobuf::Message& config, absl::string_view&,
-                                    ProtobufMessage::ValidationVisitor&) override {
+  ActionFactoryCb createActionFactoryCb(const Protobuf::Message& config, absl::string_view&,
+                                        ProtobufMessage::ValidationVisitor&) override {
     const auto& string = dynamic_cast<const ProtobufWkt::StringValue&>(config);
-    return std::make_shared<StringAction>(string.value());
+    return [string]() { return std::make_unique<StringAction>(string.value()); };
   }
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override {
@@ -273,9 +273,14 @@ void PrintTo(const FieldMatchResult& result, std::ostream* os) {
   }
 }
 
+// Creates a StringAction from a provided string.
+std::unique_ptr<StringAction> stringValue(absl::string_view value) {
+  return std::make_unique<StringAction>(std::string(value));
+}
+
 // Creates an OnMatch that evaluates to a StringValue with the provided value.
 template <class T> OnMatch<T> stringOnMatch(absl::string_view value, bool keep_matching = false) {
-  return OnMatch<T>{std::make_shared<StringAction>(std::string(value)), nullptr, keep_matching};
+  return OnMatch<T>{[s = std::string(value)]() { return stringValue(s); }, nullptr, keep_matching};
 }
 
 inline void PrintTo(const Action& action, std::ostream* os) {
@@ -286,14 +291,23 @@ inline void PrintTo(const Action& action, std::ostream* os) {
   *os << "{type=" << action.typeUrl() << "}";
 }
 
+inline void PrintTo(const ActionFactoryCb& action_cb, std::ostream* os) {
+  if (action_cb == nullptr) {
+    *os << "nullptr";
+    return;
+  }
+  ActionPtr action = action_cb();
+  PrintTo(*action, os);
+}
+
 inline void PrintTo(const MatchResult& result, std::ostream* os) {
   if (result.isInsufficientData()) {
     *os << "InsufficientData";
   } else if (result.isNoMatch()) {
     *os << "NoMatch";
   } else if (result.isMatch()) {
-    *os << "Match{Action=";
-    PrintTo(*result.action(), os);
+    *os << "Match{ActionFactoryCb=";
+    PrintTo(result.actionFactory(), os);
     *os << "}";
   } else {
     *os << "UnknownState";
@@ -305,9 +319,9 @@ inline void PrintTo(const MatchTree<TestData>& matcher, std::ostream* os) {
 }
 
 inline void PrintTo(const OnMatch<TestData>& on_match, std::ostream* os) {
-  if (on_match.action_) {
-    *os << "{action_=";
-    PrintTo(on_match.action_, os);
+  if (on_match.action_cb_) {
+    *os << "{action_cb_=";
+    PrintTo(on_match.action_cb_, os);
     *os << "}";
   } else if (on_match.matcher_) {
     *os << "{matcher_=";
@@ -325,25 +339,26 @@ MATCHER(HasInsufficientData, "") {
 }
 
 MATCHER_P(IsActionWithType, matcher, "") {
-  // Takes an ActionConstSharedPtr argument, and compares its action type against matcher.
+  // Takes an ActionFactoryCb argument, and compares its action type against matcher.
   if (arg == nullptr) {
     return false;
   }
-  return ::testing::ExplainMatchResult(testing::Matcher<absl::string_view>(matcher), arg->typeUrl(),
-                                       result_listener);
+  ActionPtr action = arg();
+  return ::testing::ExplainMatchResult(testing::Matcher<absl::string_view>(matcher),
+                                       action->typeUrl(), result_listener);
 }
 
 MATCHER_P(IsStringAction, matcher, "") {
-  // Takes an ActionConstSharedPtr argument, and compares its StringAction's string against matcher.
+  // Takes an ActionFactoryCb argument, and compares its StringAction's string against matcher.
   if (arg == nullptr) {
     return false;
   }
-
-  if (arg->typeUrl() != "google.protobuf.StringValue") {
+  ActionPtr action = arg();
+  if (action->typeUrl() != "google.protobuf.StringValue") {
     return false;
   }
   return ::testing::ExplainMatchResult(testing::Matcher<std::string>(matcher),
-                                       arg->template getTyped<StringAction>().string_,
+                                       action->template getTyped<StringAction>().string_,
                                        result_listener);
 }
 
@@ -353,7 +368,8 @@ MATCHER_P(HasStringAction, matcher, "") {
   if (!arg.isMatch()) {
     return false;
   }
-  return ::testing::ExplainMatchResult(IsStringAction(matcher), arg.action(), result_listener);
+  return ::testing::ExplainMatchResult(IsStringAction(matcher), arg.actionFactory(),
+                                       result_listener);
 }
 
 MATCHER_P(HasActionWithType, matcher, "") {
@@ -362,7 +378,8 @@ MATCHER_P(HasActionWithType, matcher, "") {
   if (!arg.isMatch()) {
     return false;
   }
-  return ::testing::ExplainMatchResult(IsActionWithType(matcher), arg.action(), result_listener);
+  return ::testing::ExplainMatchResult(IsActionWithType(matcher), arg.actionFactory(),
+                                       result_listener);
 }
 
 MATCHER(HasNoMatch, "") {

--- a/test/extensions/common/matcher/domain_matcher_test.cc
+++ b/test/extensions/common/matcher/domain_matcher_test.cc
@@ -38,6 +38,7 @@ using ::Envoy::Matcher::MatchResult;
 using ::Envoy::Matcher::MatchTreeFactory;
 using ::Envoy::Matcher::MockMatchTreeValidationVisitor;
 using ::Envoy::Matcher::SkippedMatchCb;
+using ::Envoy::Matcher::StringAction;
 using ::Envoy::Matcher::StringActionFactory;
 using ::Envoy::Matcher::TestData;
 using ::Envoy::Matcher::TestDataInputBoolFactory;
@@ -624,8 +625,8 @@ on_no_match:
   loadConfig(yaml);
 
   validation_visitor_.setSupportKeepMatching(true);
-  std::vector<Envoy::Matcher::ActionConstSharedPtr> skipped_results;
-  skipped_match_cb_ = [&skipped_results](const Envoy::Matcher::ActionConstSharedPtr& cb) {
+  std::vector<Envoy::Matcher::ActionFactoryCb> skipped_results;
+  skipped_match_cb_ = [&skipped_results](Envoy::Matcher::ActionFactoryCb cb) {
     skipped_results.push_back(cb);
   };
 

--- a/test/extensions/common/matcher/trie_matcher_test.cc
+++ b/test/extensions/common/matcher/trie_matcher_test.cc
@@ -27,8 +27,8 @@ namespace Common {
 namespace Matcher {
 namespace {
 
-using ::Envoy::Matcher::ActionConstSharedPtr;
 using ::Envoy::Matcher::ActionFactory;
+using ::Envoy::Matcher::ActionFactoryCb;
 using ::Envoy::Matcher::CustomMatcherFactory;
 using ::Envoy::Matcher::DataInputGetResult;
 using ::Envoy::Matcher::HasInsufficientData;
@@ -36,10 +36,12 @@ using ::Envoy::Matcher::HasNoMatch;
 using ::Envoy::Matcher::HasStringAction;
 using ::Envoy::Matcher::IsStringAction;
 using ::Envoy::Matcher::MatchResult;
+using ::Envoy::Matcher::MatchTree;
 using ::Envoy::Matcher::MatchTreeFactory;
 using ::Envoy::Matcher::MatchTreePtr;
 using ::Envoy::Matcher::MatchTreeSharedPtr;
 using ::Envoy::Matcher::MockMatchTreeValidationVisitor;
+using ::Envoy::Matcher::StringAction;
 using ::Envoy::Matcher::StringActionFactory;
 using ::Envoy::Matcher::TestData;
 using ::Envoy::Matcher::TestDataInputBoolFactory;
@@ -602,10 +604,8 @@ on_no_match:
   // Skip baz because the nested matcher is set with keep_matching.
   // Skip bag because the nested matcher returns on_no_match, but the top-level matcher is set to
   // keep_matching.
-  std::vector<ActionConstSharedPtr> skipped_results{};
-  skipped_match_cb_ = [&skipped_results](const ActionConstSharedPtr& cb) {
-    skipped_results.push_back(cb);
-  };
+  std::vector<ActionFactoryCb> skipped_results{};
+  skipped_match_cb_ = [&skipped_results](ActionFactoryCb cb) { skipped_results.push_back(cb); };
 
   auto input = TestDataInputStringFactory("192.101.0.1");
   auto nested = TestDataInputBoolFactory("baz");

--- a/test/extensions/filters/http/match_delegate/config_test.cc
+++ b/test/extensions/filters/http/match_delegate/config_test.cc
@@ -302,7 +302,7 @@ createMatchingTree(const std::string& name, const std::string& value) {
       std::make_unique<InputType>(name), absl::nullopt);
 
   tree->addChild(value, Matcher::OnMatch<Envoy::Http::HttpMatchingData>{
-                            std::make_shared<ActionType>(), nullptr, false});
+                            []() { return std::make_unique<ActionType>(); }, nullptr, false});
 
   return tree;
 }
@@ -315,7 +315,7 @@ Matcher::MatchTreeSharedPtr<Envoy::Http::HttpMatchingData> createRequestAndRespo
   tree->addChild(
       "match",
       Matcher::OnMatch<Envoy::Http::HttpMatchingData>{
-          std::make_shared<SkipAction>(),
+          []() { return std::make_unique<SkipAction>(); },
           createMatchingTree<Envoy::Http::Matching::HttpRequestHeadersDataInput, SkipAction>(
               "match-header", "match"),
           false});
@@ -369,11 +369,13 @@ template <class InputType, class ActionType>
 Matcher::MatchTreeSharedPtr<Envoy::Http::HttpMatchingData>
 createMatchTreeWithOnNoMatch(const std::string& name, const std::string& value) {
   auto tree = *Matcher::ExactMapMatcher<Envoy::Http::HttpMatchingData>::create(
-      std::make_unique<InputType>(name), Matcher::OnMatch<Envoy::Http::HttpMatchingData>{
-                                             std::make_shared<ActionType>(), nullptr, false});
+      std::make_unique<InputType>(name),
+      Matcher::OnMatch<Envoy::Http::HttpMatchingData>{
+          []() { return std::make_unique<ActionType>(); }, nullptr, false});
 
   // No action is set on match. i.e., nullptr action factory cb.
-  tree->addChild(value, Matcher::OnMatch<Envoy::Http::HttpMatchingData>{nullptr, nullptr, false});
+  tree->addChild(value, Matcher::OnMatch<Envoy::Http::HttpMatchingData>{[]() { return nullptr; },
+                                                                        nullptr, false});
   return tree;
 }
 

--- a/test/extensions/filters/http/rate_limit_quota/filter_test.cc
+++ b/test/extensions/filters/http/rate_limit_quota/filter_test.cc
@@ -150,7 +150,7 @@ public:
     ASSERT_TRUE(match_result.ok());
     // Retrieve the matched action.
     const RateLimitOnMatchAction* match_action =
-        dynamic_cast<const RateLimitOnMatchAction*>(match_result.value().get());
+        dynamic_cast<RateLimitOnMatchAction*>(match_result.value().get());
 
     RateLimitQuotaValidationVisitor visitor = {};
     // Generate the bucket ids.
@@ -277,7 +277,7 @@ TEST_F(FilterTest, RequestMatchingWithInvalidOnNoMatch) {
   ASSERT_TRUE(match_result.ok());
   // Retrieve the matched action.
   const RateLimitOnMatchAction* match_action =
-      dynamic_cast<const RateLimitOnMatchAction*>(match_result.value().get());
+      dynamic_cast<RateLimitOnMatchAction*>(match_result.value().get());
 
   RateLimitQuotaValidationVisitor visitor = {};
   // Generate the bucket ids.

--- a/test/extensions/filters/network/generic_proxy/route_test.cc
+++ b/test/extensions/filters/network/generic_proxy/route_test.cc
@@ -280,6 +280,16 @@ TEST_F(RouteEntryImplTest, NullRouteSpecificConfig) {
 };
 
 /**
+ * Test the simple route action wrapper.
+ */
+TEST(RouteMatchActionTest, SimpleRouteMatchActionTest) {
+  auto entry = std::make_shared<NiceMock<MockRouteEntry>>();
+  RouteMatchAction action(entry);
+
+  EXPECT_EQ(action.route().get(), entry.get());
+}
+
+/**
  * Test the simple data input validator.
  */
 TEST(RouteActionValidationVisitorTest, SimpleRouteActionValidationVisitorTest) {
@@ -311,11 +321,13 @@ TEST(RouteMatchActionFactoryTest, SimpleRouteMatchActionFactoryTest) {
   TestUtility::loadFromYaml(yaml_config, proto_config);
   RouteActionContext context{server_context};
 
-  auto action =
-      factory.createAction(proto_config, context, server_context.messageValidationVisitor());
+  auto factory_cb = factory.createActionFactoryCb(proto_config, context,
+                                                  server_context.messageValidationVisitor());
 
-  EXPECT_NE(action, nullptr);
-  EXPECT_EQ(action->getTyped<RouteEntryImpl>().clusterName(), "cluster_0");
+  EXPECT_EQ(factory_cb()->getTyped<RouteMatchAction>().route().get(),
+            factory_cb()->getTyped<RouteMatchAction>().route().get());
+
+  EXPECT_EQ(factory_cb()->getTyped<RouteMatchAction>().route()->clusterName(), "cluster_0");
 }
 
 class RouteMatcherImplTest : public testing::Test {

--- a/test/extensions/filters/network/match_delegate/config_test.cc
+++ b/test/extensions/filters/network/match_delegate/config_test.cc
@@ -243,7 +243,7 @@ createMatchingTree(const std::string& name, const std::string& value) {
       std::make_unique<InputType>(name), absl::nullopt);
 
   tree->addChild(value, Matcher::OnMatch<Envoy::Network::MatchingData>{
-                            std::make_shared<ActionType>(), nullptr, false});
+                            []() { return std::make_unique<ActionType>(); }, nullptr, false});
 
   return tree;
 }
@@ -394,7 +394,7 @@ createMatchingTreeWithTestAction(const std::string& name, const std::string& val
       std::make_unique<InputType>(name), absl::nullopt);
 
   tree->addChild(value, Matcher::OnMatch<Envoy::Network::MatchingData>{
-                            std::make_shared<TestAction>(), nullptr, false});
+                            []() { return std::make_unique<TestAction>(); }, nullptr, false});
   return tree;
 }
 

--- a/test/extensions/matching/actions/format_string/config_test.cc
+++ b/test/extensions/matching/actions/format_string/config_test.cc
@@ -23,8 +23,10 @@ TEST(ConfigTest, TestConfig) {
 
   testing::NiceMock<Server::Configuration::MockServerFactoryContext> factory_context;
   ActionFactory factory;
-  auto action =
-      factory.createAction(config, factory_context, ProtobufMessage::getStrictValidationVisitor());
+  auto action_cb = factory.createActionFactoryCb(config, factory_context,
+                                                 ProtobufMessage::getStrictValidationVisitor());
+  ASSERT_NE(nullptr, action_cb);
+  auto action = action_cb();
   ASSERT_NE(nullptr, action);
   const auto& typed_action = action->getTyped<Server::Configuration::FilterChainBaseAction>();
 

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -141,7 +141,7 @@ public:
 class MockCodecEventCallbacks : public CodecEventCallbacks {
 public:
   MockCodecEventCallbacks();
-  ~MockCodecEventCallbacks() override;
+  ~MockCodecEventCallbacks();
 
   MOCK_METHOD(void, onCodecEncodeComplete, ());
   MOCK_METHOD(void, onCodecLowLevelReset, ());
@@ -343,7 +343,7 @@ public:
   MOCK_METHOD(bool, shouldLoadShed, (), (const));
 
   Buffer::InstancePtr buffer_;
-  std::list<DownstreamWatermarkCallbacks*> callbacks_;
+  std::list<DownstreamWatermarkCallbacks*> callbacks_{};
   testing::NiceMock<MockDownstreamStreamFilterCallbacks> downstream_callbacks_;
   testing::NiceMock<Tracing::MockSpan> active_span_;
   testing::NiceMock<Tracing::MockConfig> tracing_config_;


### PR DESCRIPTION
This reverts commit c34a837e680f906962b66673c44cb1f4ba0568f1.