### PR TITLE
xds: Add metrics around discovery requests and responses 

### DIFF
--- a/envoy/config/grpc_mux.h
+++ b/envoy/config/grpc_mux.h
@@ -21,10 +21,16 @@ using ScopedResume = std::unique_ptr<Cleanup>;
 /**
  * All control plane related stats. @see stats_macros.h
  */
-#define ALL_CONTROL_PLANE_STATS(COUNTER, GAUGE, TEXT_READOUT)                                      \
+#define ALL_CONTROL_PLANE_STATS(COUNTER, GAUGE, TEXT_READOUT, HISTOGRAM)                           \
   COUNTER(rate_limit_enforced)                                                                     \
   GAUGE(connected_state, NeverImport)                                                              \
   GAUGE(pending_requests, Accumulate)                                                              \
+  COUNTER(discovery_requests)                                                                      \
+  HISTOGRAM(discovery_request_resource_count, Unspecified)                                         \
+  COUNTER(discovery_responses)                                                                     \
+  HISTOGRAM(discovery_response_resource_count, Unspecified)                                        \
+  HISTOGRAM(discovery_response_size, Bytes)                                                        \
+  HISTOGRAM(discovery_request_size, Bytes)                                                         \
   TEXT_READOUT(identifier)
 
 /**
@@ -32,7 +38,7 @@ using ScopedResume = std::unique_ptr<Cleanup>;
  */
 struct ControlPlaneStats {
   ALL_CONTROL_PLANE_STATS(GENERATE_COUNTER_STRUCT, GENERATE_GAUGE_STRUCT,
-                          GENERATE_TEXT_READOUT_STRUCT)
+                          GENERATE_TEXT_READOUT_STRUCT, GENERATE_HISTOGRAM_STRUCT)
 };
 
 /**

--- a/source/common/config/utility.h
+++ b/source/common/config/utility.h
@@ -187,7 +187,8 @@ public:
     const std::string control_plane_prefix = "control_plane.";
     return {ALL_CONTROL_PLANE_STATS(POOL_COUNTER_PREFIX(scope, control_plane_prefix),
                                     POOL_GAUGE_PREFIX(scope, control_plane_prefix),
-                                    POOL_TEXT_READOUT_PREFIX(scope, control_plane_prefix))};
+                                    POOL_TEXT_READOUT_PREFIX(scope, control_plane_prefix),
+                                    POOL_HISTOGRAM_PREFIX(scope, control_plane_prefix))};
   }
 
   /**

--- a/source/extensions/config_subscription/grpc/grpc_mux_failover.h
+++ b/source/extensions/config_subscription/grpc/grpc_mux_failover.h
@@ -160,6 +160,15 @@ public:
     primary_grpc_stream_->sendMessage(request);
   }
 
+  void maybeRecordRequestStats(uint64_t payload_size, uint64_t resource_count) override {
+    if (connectingToOrConnectedToFailover()) {
+      failover_grpc_stream_->maybeRecordRequestStats(payload_size, resource_count);
+      return;
+    }
+    // Either connecting/connected to the primary, or no connection was attempted.
+    primary_grpc_stream_->maybeRecordRequestStats(payload_size, resource_count);
+  }
+
   // Updates the queue size of the underlying stream.
   void maybeUpdateQueueSizeStat(uint64_t size) override {
     if (connectingToOrConnectedToFailover()) {

--- a/source/extensions/config_subscription/grpc/grpc_stream_interface.h
+++ b/source/extensions/config_subscription/grpc/grpc_stream_interface.h
@@ -29,6 +29,8 @@ public:
   // meaningful value is given.
   virtual void maybeUpdateQueueSizeStat(uint64_t size) PURE;
 
+  virtual void maybeRecordRequestStats(uint64_t payload_size, uint64_t resource_count) PURE;
+
   // Returns true if a message can be sent from the rate-limiting perspective.
   // The rate-limiting counters may be updated by this method.
   virtual bool checkRateLimitAllowsDrain() PURE;

--- a/source/extensions/config_subscription/grpc/new_grpc_mux_impl.cc
+++ b/source/extensions/config_subscription/grpc/new_grpc_mux_impl.cc
@@ -166,6 +166,9 @@ void NewGrpcMuxImpl::onDiscoveryResponse(
     return;
   }
 
+  control_plane_stats.discovery_response_size_.recordValue(message->ByteSizeLong());
+  control_plane_stats.discovery_response_resource_count_.recordValue(message->resources_size());
+
   if (message->has_control_plane()) {
     control_plane_stats.identifier_.set(message->control_plane().identifier());
 
@@ -401,6 +404,7 @@ void NewGrpcMuxImpl::trySendDiscoveryRequests() {
       request = sub->second->sub_state_.getNextRequestAckless();
     }
     grpc_stream_->sendMessage(request);
+    grpc_stream_->maybeRecordRequestStats(request.ByteSizeLong(), 0);
   }
   grpc_stream_->maybeUpdateQueueSizeStat(pausable_ack_queue_.size());
 }


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

# Description

This PR is an attempt at fixing https://github.com/envoyproxy/envoy/issues/21911, new to envoy, so looking for early feedback , if I should take a different approach and which tests, docs need updating. 

---

Commit Message: Add metrics around control plane gRPC requests and responses

    This is fixing issue #21911. New metrics are added to the
    ControlPlaneStats struct and the grpc_stream class modified to
    increment counters at appropriate places of sending a request and
    receiving a response.


Additional Description:
Risk Level: Low
Testing: Manual testing by running `curl localhost:19000/stats` on envoy built from this PR to verify the new metrics showing up.

Docs Changes: Need help in figuring out which docs to update. 
Release Notes: 
Platform Specific Features: None
Runtime guard: New metrics, likely not needed.
Fixes #21911