### PR TITLE
ext_proc Adding detail gRPC error message in the logging for debugging

### DIFF
--- a/source/extensions/filters/http/ext_proc/ext_proc.cc
+++ b/source/extensions/filters/http/ext_proc/ext_proc.cc
@@ -1646,7 +1646,8 @@ void Filter::onReceiveMessage(std::unique_ptr<ProcessingResponse>&& r) {
 }
 
 void Filter::onGrpcError(Grpc::Status::GrpcStatus status, const std::string& message) {
-  ENVOY_STREAM_LOG(debug, "Received gRPC error on stream: {}", *decoder_callbacks_, status);
+  ENVOY_STREAM_LOG(warn, "Received gRPC error on stream: {}, message {}",
+                   *decoder_callbacks_, status, message);
   stats_.streams_failed_.inc();
 
   if (processing_complete_) {


### PR DESCRIPTION
Two minor changes in onGrpcError():
1) Adding the detail message in the logging for debugging.
2) changing the logging level to warn so it's visible by default
