### PR TITLE
dfp: deprecate flag avoid_dfp_cluster_removal_on_cds_update and remove legacy code paths

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -10,7 +10,9 @@ bug_fixes:
 # *Changes expected to improve the state of the world and are unlikely to have negative effects*
 
 removed_config_or_runtime:
-# *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`
+- area: dynamic_forward_proxy
+  change: |
+    Removed runtime guard ``envoy.reloadable_features.avoid_dfp_cluster_removal_on_cds_update`` and legacy code paths.
 
 new_features:
 

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -33,7 +33,6 @@
 // problem of the bugs being found after the old code path has been removed.
 RUNTIME_GUARD(envoy_reloadable_features_allow_alt_svc_for_ips);
 RUNTIME_GUARD(envoy_reloadable_features_async_host_selection);
-RUNTIME_GUARD(envoy_reloadable_features_avoid_dfp_cluster_removal_on_cds_update);
 RUNTIME_GUARD(envoy_reloadable_features_dfp_cluster_resolves_hosts);
 RUNTIME_GUARD(envoy_reloadable_features_dfp_fail_on_empty_host_header);
 RUNTIME_GUARD(envoy_reloadable_features_disallow_quic_client_udp_mmsg);

--- a/source/extensions/clusters/dynamic_forward_proxy/cluster.cc
+++ b/source/extensions/clusters/dynamic_forward_proxy/cluster.cc
@@ -105,9 +105,7 @@ Cluster::~Cluster() {
     auto cluster_name = it->first;
     ENVOY_LOG(debug, "cluster='{}' removing from cluster_map & cluster manager", cluster_name);
     cluster_map_.erase(it++);
-    cm_.removeCluster(cluster_name,
-                      Runtime::runtimeFeatureEnabled(
-                          "envoy.reloadable_features.avoid_dfp_cluster_removal_on_cds_update"));
+    cm_.removeCluster(cluster_name, true);
   }
 }
 
@@ -148,9 +146,7 @@ void Cluster::checkIdleSubCluster() {
         auto cluster_name = it->first;
         ENVOY_LOG(debug, "cluster='{}' removing from cluster_map & cluster manager", cluster_name);
         cluster_map_.erase(it++);
-        cm_.removeCluster(cluster_name,
-                          Runtime::runtimeFeatureEnabled(
-                              "envoy.reloadable_features.avoid_dfp_cluster_removal_on_cds_update"));
+        cm_.removeCluster(cluster_name, true);
       } else {
         ++it;
       }

--- a/source/extensions/filters/http/dynamic_forward_proxy/proxy_filter.cc
+++ b/source/extensions/filters/http/dynamic_forward_proxy/proxy_filter.cc
@@ -122,12 +122,7 @@ LoadClusterEntryHandlePtr ProxyFilterConfig::addDynamicCluster(
       // update. As this cluster lifecycle is managed by DFP cluster, it should not be removed by
       // CDS. https://github.com/envoyproxy/envoy/issues/35171
       absl::Status status =
-          cluster_manager_
-              .addOrUpdateCluster(
-                  cluster, version_info,
-                  Runtime::runtimeFeatureEnabled(
-                      "envoy.reloadable_features.avoid_dfp_cluster_removal_on_cds_update"))
-              .status();
+          cluster_manager_.addOrUpdateCluster(cluster, version_info, true).status();
       ENVOY_BUG(status.ok(),
                 absl::StrCat("Failed to update DFP cluster due to ", status.message()));
     });

--- a/test/extensions/filters/http/dynamic_forward_proxy/proxy_filter_integration_test.cc
+++ b/test/extensions/filters/http/dynamic_forward_proxy/proxy_filter_integration_test.cc
@@ -1515,68 +1515,6 @@ TEST_P(ProxyFilterIntegrationTest, SubClusterReloadCluster) {
   test_server_->waitForGaugeEq("cluster_manager.warming_clusters", 0);
 }
 
-// Verify that we expire sub clusters and not remove on CDS.
-TEST_P(ProxyFilterWithSimtimeIntegrationTest, RemoveViaTTLAndDFPUpdateWithoutAvoidCDSRemoval) {
-  const std::string cluster_yaml = R"EOF(
-    name: fake_cluster
-    connect_timeout: 0.250s
-    type: STATIC
-    lb_policy: ROUND_ROBIN
-    load_assignment:
-      cluster_name: fake_cluster
-      endpoints:
-      - lb_endpoints:
-        - endpoint:
-            address:
-              socket_address:
-                address: 127.0.0.1
-                port_value: 11001
-  )EOF";
-  auto cluster = Upstream::parseClusterFromV3Yaml(cluster_yaml);
-  // make runtime guard false
-  config_helper_.addRuntimeOverride(
-      "envoy.reloadable_features.avoid_dfp_cluster_removal_on_cds_update", "false");
-  initializeWithArgs(1024, 1024, "", typed_dns_resolver_config_, true);
-  codec_client_ = makeHttpConnection(lookupPort("http"));
-  const Http::TestRequestHeaderMapImpl request_headers{
-      {":method", "POST"},
-      {":path", "/test/long/url"},
-      {":scheme", "http"},
-      {":authority",
-       fmt::format("localhost:{}", fake_upstreams_[0]->localAddress()->ip()->port())}};
-
-  auto response =
-      sendRequestAndWaitForResponse(request_headers, 1024, default_response_headers_, 1024);
-  checkSimpleRequestSuccess(1024, 1024, response.get());
-  // one more cluster
-  test_server_->waitForCounterEq("cluster_manager.cluster_added", 2);
-  test_server_->waitForCounterEq("cluster_manager.cluster_removed", 0);
-  cleanupUpstreamAndDownstream();
-
-  // Sub cluster expected to be removed after ttl
-  // > 5m
-  simTime().advanceTimeWait(std::chrono::milliseconds(300001));
-  test_server_->waitForCounterEq("cluster_manager.cluster_added", 2);
-  test_server_->waitForCounterEq("cluster_manager.cluster_removed", 1);
-
-  codec_client_ = makeHttpConnection(lookupPort("http"));
-  response = sendRequestAndWaitForResponse(request_headers, 1024, default_response_headers_, 1024);
-  checkSimpleRequestSuccess(1024, 1024, response.get());
-
-  // sub cluster added again
-  test_server_->waitForCounterEq("cluster_manager.cluster_added", 3);
-  test_server_->waitForCounterEq("cluster_manager.cluster_removed", 1);
-  cleanupUpstreamAndDownstream();
-
-  // Make update to DFP cluster
-  cluster_.mutable_circuit_breakers()->add_thresholds()->mutable_max_connections()->set_value(100);
-  cds_helper_.setCds({cluster_});
-
-  // sub cluster removed due to dfp cluster update
-  test_server_->waitForCounterEq("cluster_manager.cluster_added", 3);
-  test_server_->waitForCounterEq("cluster_manager.cluster_removed", 2);
-}
-
 // Verify that we expire sub clusters.
 TEST_P(ProxyFilterWithSimtimeIntegrationTest, RemoveSubClusterViaTTL) {
   initializeWithArgs(1024, 1024, "", typed_dns_resolver_config_, true);
@@ -1655,8 +1593,6 @@ TEST_P(ProxyFilterIntegrationTest, SubClusterWithIpHost) {
 
 // Verify that no DFP clusters are removed when CDS Reload is triggered.
 TEST_P(ProxyFilterIntegrationTest, CDSReloadNotRemoveDFPCluster) {
-  config_helper_.addRuntimeOverride(
-      "envoy.reloadable_features.avoid_dfp_cluster_removal_on_cds_update", "true");
   const std::string cluster_yaml = R"EOF(
     name: fake_cluster
     connect_timeout: 0.250s


### PR DESCRIPTION
## Description

This PR removes the deprecated reloadable flag `avoid_dfp_cluster_removal_on_cds_update` and cleans up the legacy paths.

Fix https://github.com/envoyproxy/envoy/issues/40370

---

**Commit Message:** dfp: deprecate flag avoid_dfp_cluster_removal_on_cds_update and remove legacy code paths
**Additional Description:** Remove the deprecated reloadable flag `avoid_dfp_cluster_removal_on_cds_update` and cleans up the legacy paths.
**Risk Level:** Low
**Testing:** CI
**Docs Changes:** N/A
**Release Notes:** Added