### PR TITLE
set_metadata: add substitution format string support for dynamic placeholder expansion

### DIFF
--- a/api/envoy/extensions/filters/http/set_metadata/v3/BUILD
+++ b/api/envoy/extensions/filters/http/set_metadata/v3/BUILD
@@ -7,6 +7,7 @@ licenses(["notice"])  # Apache 2
 api_proto_package(
     deps = [
         "//envoy/annotations:pkg",
+        "//envoy/config/core/v3:pkg",
         "@com_github_cncf_xds//udpa/annotations:pkg",
     ],
 )

--- a/api/envoy/extensions/filters/http/set_metadata/v3/set_metadata.proto
+++ b/api/envoy/extensions/filters/http/set_metadata/v3/set_metadata.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package envoy.extensions.filters.http.set_metadata.v3;
 
+import "envoy/config/core/v3/substitution_format_string.proto";
+
 import "google/protobuf/any.proto";
 import "google/protobuf/struct.proto";
 
@@ -21,6 +23,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 //
 // [#extension: envoy.filters.http.set_metadata]
 
+// [#next-free-field: 6]
 message Metadata {
   // The metadata namespace.
   string metadata_namespace = 1 [(validate.rules).string = {min_len: 1}];
@@ -28,18 +31,32 @@ message Metadata {
   // Allow the filter to overwrite or merge with an existing value in the namespace.
   bool allow_overwrite = 2;
 
-  // The value to place at the namespace. If ``allow_overwrite``, this will
-  // overwrite or merge with any existing values in that namespace. See
-  // :ref:`the filter documentation <config_http_filters_set_metadata>` for
-  // more information on how this value is merged with potentially existing
-  // ones if ``allow_overwrite`` is configured. Only one of ``value`` and
-  // ``typed_value`` may be set.
-  google.protobuf.Struct value = 3;
+  oneof kind {
+    // The value to place at the namespace. If ``allow_overwrite``, this will
+    // overwrite or merge with any existing values in that namespace. See
+    // :ref:`the filter documentation <config_http_filters_set_metadata>` for
+    // more information on how this value is merged with potentially existing
+    // ones if ``allow_overwrite`` is configured.
+    //
+    // Only one of ``value``, ``typed_value``, or ``format_string`` may be set.
+    google.protobuf.Struct value = 3;
 
-  // The value to place at the namespace. If ``allow_overwrite``, this will
-  // overwrite any existing values in that namespace. Only one of ``value`` and
-  // ``typed_value`` may be set.
-  google.protobuf.Any typed_value = 4;
+    // The value to place at the namespace. If ``allow_overwrite``, this will
+    // overwrite any existing values in that namespace.
+    //
+    // Only one of ``value``, ``typed_value``, or ``format_string`` may be set.
+    google.protobuf.Any typed_value = 4;
+
+    // The value to place at the namespace. It uses the :ref:`format string
+    // <config_access_log_format_strings>` to dynamically set the metadata value.
+    //
+    // It supports placeholder expansion such as ``%VIRTUAL_CLUSTER_NAME%``,
+    // ``%REQ(header-name)%``, etc. The result will be set as a string value in
+    // the metadata.
+    //
+    // Only one of ``value``, ``typed_value``, or ``format_string`` may be set.
+    config.core.v3.SubstitutionFormatString format_string = 5;
+  }
 }
 
 message Config {

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -22,5 +22,10 @@ new_features:
     are validated and will throw an error if combined with payloads. The implementation is optimized to process the
     payload once during configuration and reuse it for all health check requests. See :ref:`HttpHealthCheck
     <envoy_v3_api_msg_config.core.v3.HealthCheck.HttpHealthCheck>` for configuration details.
+- area: set_metadata
+  change: |
+    Added ``format_string`` support to the set_metadata filter. This allows dynamic placeholder expansion using Envoy's
+    substitution formatter, enabling values like ``%VIRTUAL_CLUSTER_NAME%``, ``%REQ(header-name)%``, and other
+    :ref:`format strings <config_access_log_format_strings>` to be expanded when setting metadata.
 
 deprecated:

--- a/source/extensions/filters/http/set_metadata/BUILD
+++ b/source/extensions/filters/http/set_metadata/BUILD
@@ -14,8 +14,10 @@ envoy_cc_library(
     srcs = ["set_metadata_filter.cc"],
     hdrs = ["set_metadata_filter.h"],
     deps = [
+        "//envoy/formatter:substitution_formatter_interface",
         "//envoy/server:filter_config_interface",
         "//source/common/config:well_known_names",
+        "//source/common/formatter:substitution_format_string_lib",
         "//source/common/http:utility_lib",
         "//source/common/protobuf:utility_lib",
         "//source/extensions/filters/http/common:pass_through_filter_lib",
@@ -32,6 +34,7 @@ envoy_cc_extension(
         "//source/common/protobuf:utility_lib",
         "//source/extensions/filters/http/common:factory_base_lib",
         "//source/extensions/filters/http/set_metadata:set_metadata_filter_lib",
+        "//source/server:generic_factory_context_lib",
         "@envoy_api//envoy/extensions/filters/http/set_metadata/v3:pkg_cc_proto",
     ],
 )

--- a/source/extensions/filters/http/set_metadata/config.h
+++ b/source/extensions/filters/http/set_metadata/config.h
@@ -3,6 +3,7 @@
 #include "envoy/extensions/filters/http/set_metadata/v3/set_metadata.pb.h"
 #include "envoy/extensions/filters/http/set_metadata/v3/set_metadata.pb.validate.h"
 
+#include "source/common/protobuf/utility.h"
 #include "source/extensions/filters/http/common/factory_base.h"
 
 namespace Envoy {
@@ -11,22 +12,29 @@ namespace HttpFilters {
 namespace SetMetadataFilter {
 
 /**
- * Config registration for the header-to-metadata filter. @see NamedHttpFilterConfigFactory.
+ * Config registration for the set-metadata filter. @see NamedHttpFilterConfigFactory.
  */
 class SetMetadataConfig
-    : public Common::FactoryBase<envoy::extensions::filters::http::set_metadata::v3::Config> {
+    : public Common::CommonFactoryBase<envoy::extensions::filters::http::set_metadata::v3::Config>,
+      public Server::Configuration::NamedHttpFilterConfigFactory {
 public:
-  SetMetadataConfig() : FactoryBase("envoy.filters.http.set_metadata") {}
+  SetMetadataConfig() : CommonFactoryBase("envoy.filters.http.set_metadata") {}
+
+  absl::StatusOr<Http::FilterFactoryCb>
+  createFilterFactoryFromProto(const Protobuf::Message& proto_config,
+                               const std::string& stats_prefix,
+                               Server::Configuration::FactoryContext& context) override {
+    return createFilterFactoryFromProtoTyped(
+        MessageUtil::downcastAndValidate<
+            const envoy::extensions::filters::http::set_metadata::v3::Config&>(
+            proto_config, context.messageValidationVisitor()),
+        stats_prefix, context);
+  }
 
 private:
-  Http::FilterFactoryCb createFilterFactoryFromProtoTyped(
+  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::set_metadata::v3::Config& proto_config,
-      const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
-
-  Http::FilterFactoryCb createFilterFactoryFromProtoWithServerContextTyped(
-      const envoy::extensions::filters::http::set_metadata::v3::Config& proto_config,
-      const std::string& stats_prefix,
-      Server::Configuration::ServerFactoryContext& server_context) override;
+      const std::string& stats_prefix, Server::Configuration::FactoryContext& context);
 };
 
 } // namespace SetMetadataFilter

--- a/source/extensions/filters/http/set_metadata/set_metadata_filter.cc
+++ b/source/extensions/filters/http/set_metadata/set_metadata_filter.cc
@@ -3,9 +3,13 @@
 #include "envoy/extensions/filters/http/set_metadata/v3/set_metadata.pb.h"
 
 #include "source/common/config/well_known_names.h"
+#include "source/common/formatter/substitution_format_string.h"
 #include "source/common/http/utility.h"
 #include "source/common/protobuf/protobuf.h"
+#include "source/server/generic_factory_context.h"
 
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
 #include "absl/strings/str_format.h"
 
 namespace Envoy {
@@ -13,9 +17,38 @@ namespace Extensions {
 namespace HttpFilters {
 namespace SetMetadataFilter {
 
+absl::StatusOr<std::shared_ptr<Config>>
+Config::create(const envoy::extensions::filters::http::set_metadata::v3::Config& proto_config,
+               Stats::Scope& scope, const std::string& stats_prefix,
+               Server::Configuration::FactoryContext& factory_context) {
+  // Create a GenericFactoryContext from FactoryContext.
+  Server::GenericFactoryContextImpl generic_context(factory_context.serverFactoryContext(),
+                                                    factory_context.messageValidationVisitor());
+  return create(proto_config, scope, stats_prefix, generic_context);
+}
+
+absl::StatusOr<std::shared_ptr<Config>>
+Config::create(const envoy::extensions::filters::http::set_metadata::v3::Config& proto_config,
+               Stats::Scope& scope, const std::string& stats_prefix,
+               Server::Configuration::GenericFactoryContext& factory_context) {
+  absl::Status creation_status = absl::OkStatus();
+  auto cfg = std::shared_ptr<Config>(
+      new Config(proto_config, scope, stats_prefix, factory_context, creation_status));
+  RETURN_IF_NOT_OK_REF(creation_status);
+  return cfg;
+}
+
 Config::Config(const envoy::extensions::filters::http::set_metadata::v3::Config& proto_config,
-               Stats::Scope& scope, const std::string& stats_prefix)
+               Stats::Scope& scope, const std::string& stats_prefix,
+               Server::Configuration::GenericFactoryContext& factory_context,
+               absl::Status& creation_status)
     : stats_(generateStats(stats_prefix, scope)) {
+  parseConfig(proto_config, factory_context, creation_status);
+}
+
+void Config::parseConfig(
+    const envoy::extensions::filters::http::set_metadata::v3::Config& proto_config,
+    Server::Configuration::GenericFactoryContext& factory_context, absl::Status& creation_status) {
   if (proto_config.has_value() && !proto_config.metadata_namespace().empty()) {
     UntypedMetadataEntry deprecated_api_val{true, proto_config.metadata_namespace(),
                                             proto_config.value()};
@@ -31,9 +64,22 @@ Config::Config(const envoy::extensions::filters::http::set_metadata::v3::Config&
       TypedMetadataEntry typed_entry{metadata.allow_overwrite(), metadata.metadata_namespace(),
                                      metadata.typed_value()};
       typed_.emplace_back(typed_entry);
+    } else if (metadata.has_format_string()) {
+      auto formatter_or_error = Formatter::SubstitutionFormatStringUtils::fromProtoConfig(
+          metadata.format_string(), factory_context);
+      if (!formatter_or_error.ok()) {
+        creation_status = absl::InvalidArgumentError(
+            fmt::format("Failed to create formatter for metadata namespace '{}': {}",
+                        metadata.metadata_namespace(), formatter_or_error.status().message()));
+        return;
+      }
+      FormattedMetadataEntry formatted_entry{metadata.allow_overwrite(),
+                                             metadata.metadata_namespace(),
+                                             std::move(formatter_or_error.value())};
+      formatted_.emplace_back(std::move(formatted_entry));
     } else {
-      ENVOY_LOG(warn, "set_metadata filter configuration contains metadata entries without value "
-                      "or typed_value");
+      ENVOY_LOG(warn, "set_metadata filter configuration contains metadata entries without value, "
+                      "typed_value, or format_string.");
     }
   }
 }
@@ -47,7 +93,7 @@ SetMetadataFilter::SetMetadataFilter(const ConfigSharedPtr config) : config_(con
 
 SetMetadataFilter::~SetMetadataFilter() = default;
 
-Http::FilterHeadersStatus SetMetadataFilter::decodeHeaders(Http::RequestHeaderMap&, bool) {
+Http::FilterHeadersStatus SetMetadataFilter::decodeHeaders(Http::RequestHeaderMap& headers, bool) {
 
   // Add configured untyped metadata.
   if (!config_->untyped().empty()) {
@@ -86,6 +132,37 @@ Http::FilterHeadersStatus SetMetadataFilter::decodeHeaders(Http::RequestHeaderMa
         mut_typed_metadata[entry.metadata_namespace] = entry.value;
       } else {
         // The entry exists, and we are not allowed to overwrite -- emit a stat.
+        config_->stats().overwrite_denied_.inc();
+      }
+    }
+  }
+
+  // Add configured formatted metadata.
+  if (!config_->formatted().empty()) {
+    auto& mut_untyped_metadata =
+        *decoder_callbacks_->streamInfo().dynamicMetadata().mutable_filter_metadata();
+
+    for (const auto& entry : config_->formatted()) {
+      // Format the value using substitution formatter to expand placeholders like
+      // %VIRTUAL_CLUSTER_NAME%.
+      const std::string formatted_value = entry.formatter->formatWithContext(
+          Formatter::HttpFormatterContext(&headers), decoder_callbacks_->streamInfo());
+
+      // Create a Struct with the formatted string value.
+      ProtobufWkt::Struct formatted_struct;
+      (*formatted_struct.mutable_fields())["value"].set_string_value(formatted_value);
+
+      if (!mut_untyped_metadata.contains(entry.metadata_namespace)) {
+        // Insert the new entry.
+        mut_untyped_metadata[entry.metadata_namespace] = formatted_struct;
+      } else if (entry.allow_overwrite) {
+        // Get the existing metadata at this key for merging.
+        ProtobufWkt::Struct& orig_fields = mut_untyped_metadata[entry.metadata_namespace];
+
+        // Merge the new formatted metadata into the existing metadata.
+        StructUtil::update(orig_fields, formatted_struct);
+      } else {
+        // The entry exists, and we are not allowed to overwrite, we emit a stat.
         config_->stats().overwrite_denied_.inc();
       }
     }

--- a/test/extensions/filters/http/set_metadata/BUILD
+++ b/test/extensions/filters/http/set_metadata/BUILD
@@ -20,8 +20,12 @@ envoy_extension_cc_test(
     rbe_pool = "6gig",
     deps = [
         "//source/extensions/filters/http/set_metadata:config",
-        "//test/integration:http_integration_lib",
-        "//test/mocks/api:api_mocks",
+        "//source/extensions/filters/http/set_metadata:set_metadata_filter_lib",
+        "//source/server:generic_factory_context_lib",
+        "//test/mocks/http:http_mocks",
+        "//test/mocks/server:factory_context_mocks",
+        "//test/mocks/stats:stats_mocks",
+        "//test/mocks/stream_info:stream_info_mocks",
         "//test/test_common:utility_lib",
     ],
 )

--- a/test/extensions/filters/http/set_metadata/config_test.cc
+++ b/test/extensions/filters/http/set_metadata/config_test.cc
@@ -77,11 +77,10 @@ metadata:
   testing::NiceMock<Server::Configuration::MockServerFactoryContext> context;
   SetMetadataConfig factory;
 
-  Http::FilterFactoryCb cb =
-      factory.createFilterFactoryFromProtoWithServerContext(proto_config, "stats", context);
-  Http::MockFilterChainFactoryCallbacks filter_callbacks;
-  EXPECT_CALL(filter_callbacks, addStreamDecoderFilter(_));
-  cb(filter_callbacks);
+  // The set_metadata filter doesn't support server context creation, so it should throw.
+  EXPECT_THROW_WITH_MESSAGE(
+      factory.createFilterFactoryFromProtoWithServerContext(proto_config, "stats", context),
+      EnvoyException, "Creating filter factory from server factory context is not supported");
 }
 
 } // namespace SetMetadataFilter

--- a/test/extensions/filters/http/set_metadata/set_metadata_filter_test.cc
+++ b/test/extensions/filters/http/set_metadata/set_metadata_filter_test.cc
@@ -2,14 +2,17 @@
 
 #include "source/common/protobuf/protobuf.h"
 #include "source/extensions/filters/http/set_metadata/set_metadata_filter.h"
+#include "source/server/generic_factory_context.h"
 
 #include "test/mocks/http/mocks.h"
+#include "test/mocks/server/factory_context.h"
 #include "test/mocks/stream_info/mocks.h"
 #include "test/test_common/utility.h"
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
+using testing::HasSubstr;
 using testing::NiceMock;
 using testing::ReturnRef;
 
@@ -28,10 +31,75 @@ public:
   void runFilter(envoy::config::core::v3::Metadata& metadata, const std::string& yaml_config) {
     envoy::extensions::filters::http::set_metadata::v3::Config proto_config;
     TestUtility::loadFromYaml(yaml_config, proto_config);
-    config_ = std::make_shared<Config>(proto_config, *stats_store_.rootScope(), "");
+
+    // Create GenericFactoryContext from mock FactoryContext.
+    Server::GenericFactoryContextImpl generic_context(factory_context_);
+    auto config_or_error =
+        Config::create(proto_config, *stats_store_.rootScope(), "", generic_context);
+    ASSERT_TRUE(config_or_error.ok());
+    config_ = config_or_error.value();
     filter_ = std::make_shared<SetMetadataFilter>(config_);
 
     Http::TestRequestHeaderMapImpl headers;
+
+    NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks;
+    NiceMock<Envoy::StreamInfo::MockStreamInfo> req_info;
+    filter_->setDecoderFilterCallbacks(decoder_callbacks);
+
+    EXPECT_CALL(decoder_callbacks, streamInfo()).WillRepeatedly(ReturnRef(req_info));
+    EXPECT_CALL(req_info, dynamicMetadata()).WillRepeatedly(ReturnRef(metadata));
+    EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(headers, true));
+    Buffer::OwnedImpl buffer;
+    EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(buffer, true));
+    filter_->onDestroy();
+  }
+
+  void runFilterWithVirtualCluster(envoy::config::core::v3::Metadata& metadata,
+                                   const std::string& yaml_config,
+                                   const std::string& virtual_cluster_name) {
+    envoy::extensions::filters::http::set_metadata::v3::Config proto_config;
+    TestUtility::loadFromYaml(yaml_config, proto_config);
+
+    // Create GenericFactoryContext from mock FactoryContext.
+    Server::GenericFactoryContextImpl generic_context(factory_context_);
+    auto config_or_error =
+        Config::create(proto_config, *stats_store_.rootScope(), "", generic_context);
+    ASSERT_TRUE(config_or_error.ok());
+    config_ = config_or_error.value();
+    filter_ = std::make_shared<SetMetadataFilter>(config_);
+
+    Http::TestRequestHeaderMapImpl headers;
+
+    NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks;
+    NiceMock<Envoy::StreamInfo::MockStreamInfo> req_info;
+    filter_->setDecoderFilterCallbacks(decoder_callbacks);
+
+    // Mock virtual cluster name.
+    virtual_cluster_name_ = absl::optional<std::string>(virtual_cluster_name);
+    EXPECT_CALL(req_info, virtualClusterName())
+        .WillRepeatedly(testing::ReturnRef(virtual_cluster_name_));
+
+    EXPECT_CALL(decoder_callbacks, streamInfo()).WillRepeatedly(ReturnRef(req_info));
+    EXPECT_CALL(req_info, dynamicMetadata()).WillRepeatedly(ReturnRef(metadata));
+    EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(headers, true));
+    Buffer::OwnedImpl buffer;
+    EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(buffer, true));
+    filter_->onDestroy();
+  }
+
+  void runFilterWithHeaders(envoy::config::core::v3::Metadata& metadata,
+                            const std::string& yaml_config,
+                            Http::TestRequestHeaderMapImpl& headers) {
+    envoy::extensions::filters::http::set_metadata::v3::Config proto_config;
+    TestUtility::loadFromYaml(yaml_config, proto_config);
+
+    // Create GenericFactoryContext from mock FactoryContext.
+    Server::GenericFactoryContextImpl generic_context(factory_context_);
+    auto config_or_error =
+        Config::create(proto_config, *stats_store_.rootScope(), "", generic_context);
+    ASSERT_TRUE(config_or_error.ok());
+    config_ = config_or_error.value();
+    filter_ = std::make_shared<SetMetadataFilter>(config_);
 
     NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks;
     NiceMock<Envoy::StreamInfo::MockStreamInfo> req_info;
@@ -54,11 +122,35 @@ public:
     EXPECT_EQ(pbval.number_value(), val);
   }
 
+  void checkKeyString(const ProtobufWkt::Struct& s, std::string key, const std::string& val) {
+    const auto& fields = s.fields();
+    const auto it = fields.find(key);
+    ASSERT_NE(it, fields.end());
+    const auto& pbval = it->second;
+    ASSERT_EQ(pbval.kind_case(), ProtobufWkt::Value::kStringValue);
+    EXPECT_EQ(pbval.string_value(), val);
+  }
+
+  void expectConfigThrow(const std::string& yaml_config, const std::string& expected_error) {
+    envoy::extensions::filters::http::set_metadata::v3::Config proto_config;
+    TestUtility::loadFromYaml(yaml_config, proto_config);
+
+    Server::GenericFactoryContextImpl generic_context(factory_context_);
+    auto config_or_error =
+        Config::create(proto_config, *stats_store_.rootScope(), "", generic_context);
+    EXPECT_FALSE(config_or_error.ok());
+    EXPECT_THAT(std::string(config_or_error.status().message()), HasSubstr(expected_error));
+  }
+
   ConfigSharedPtr config_;
   FilterSharedPtr filter_;
 
-private:
+protected:
   NiceMock<Stats::MockIsolatedStatsStore> stats_store_;
+
+private:
+  NiceMock<Server::Configuration::MockFactoryContext> factory_context_;
+  absl::optional<std::string> virtual_cluster_name_;
 };
 
 TEST_F(SetMetadataFilterTest, DeprecatedSimple) {
@@ -443,10 +535,131 @@ TEST_F(SetMetadataFilterTest, LogsErrorWhenNoValueConfigured) {
     - metadata_namespace: thenamespace
   )EOF";
   envoy::config::core::v3::Metadata metadata;
-  EXPECT_LOG_CONTAINS(
-      "warn",
-      "set_metadata filter configuration contains metadata entries without value or typed_value",
-      runFilter(metadata, yaml_config));
+  EXPECT_LOG_CONTAINS("warn",
+                      "set_metadata filter configuration contains metadata entries without value, "
+                      "typed_value, or format_string",
+                      runFilter(metadata, yaml_config));
+}
+
+TEST_F(SetMetadataFilterTest, FormatStringWithStaticText) {
+  const std::string yaml_config = R"EOF(
+    metadata:
+      - metadata_namespace: test_namespace
+        allow_overwrite: true
+        format_string:
+          text_format: "static_value"
+  )EOF";
+
+  envoy::config::core::v3::Metadata metadata;
+  runFilter(metadata, yaml_config);
+
+  // Verify the static text was set correctly
+  const auto& filter_metadata = metadata.filter_metadata();
+  const auto it_namespace = filter_metadata.find("test_namespace");
+  ASSERT_NE(it_namespace, filter_metadata.end());
+
+  // Check that the "value" field contains the formatted string.
+  checkKeyString(it_namespace->second, "value", "static_value");
+}
+
+TEST_F(SetMetadataFilterTest, InvalidFormatString) {
+  const std::string yaml_config = R"EOF(
+    metadata:
+      - metadata_namespace: test_namespace
+        allow_overwrite: true
+        format_string:
+          text_format: "invalid: %INVALID_PLACEHOLDER%"
+  )EOF";
+
+  expectConfigThrow(yaml_config,
+                    "Failed to create formatter for metadata namespace 'test_namespace': Not "
+                    "supported field in StreamInfo: INVALID_PLACEHOLDER");
+}
+
+TEST_F(SetMetadataFilterTest, FormatStringMergeWithExistingMetadata) {
+  const std::string yaml_config = R"EOF(
+    metadata:
+      - metadata_namespace: test_namespace
+        allow_overwrite: true
+        format_string:
+          text_format: "dynamic_value"
+  )EOF";
+
+  // Pre-populate metadata.
+  envoy::config::core::v3::Metadata metadata;
+  auto& existing_metadata = *metadata.mutable_filter_metadata();
+  ProtobufWkt::Struct existing_struct;
+  (*existing_struct.mutable_fields())["static_field"].set_string_value("static_value");
+  existing_metadata["test_namespace"] = existing_struct;
+
+  runFilter(metadata, yaml_config);
+
+  // Verify that both static and dynamic values exist after merge.
+  const auto& filter_metadata = metadata.filter_metadata();
+  const auto it_namespace = filter_metadata.find("test_namespace");
+  ASSERT_NE(it_namespace, filter_metadata.end());
+
+  checkKeyString(it_namespace->second, "static_field", "static_value");
+  checkKeyString(it_namespace->second, "value", "dynamic_value");
+}
+
+TEST_F(SetMetadataFilterTest, FormatStringOverwriteBlocked) {
+  const std::string yaml_config = R"EOF(
+    metadata:
+      - metadata_namespace: test_namespace
+        allow_overwrite: false
+        format_string:
+          text_format: "new_value"
+  )EOF";
+
+  // Pre-populate metadata.
+  envoy::config::core::v3::Metadata metadata;
+  auto& existing_metadata = *metadata.mutable_filter_metadata();
+  ProtobufWkt::Struct existing_struct;
+  (*existing_struct.mutable_fields())["value"].set_string_value("existing_value");
+  existing_metadata["test_namespace"] = existing_struct;
+
+  runFilter(metadata, yaml_config);
+
+  // Verify that the existing value is preserved and stats incremented.
+  const auto& filter_metadata = metadata.filter_metadata();
+  const auto it_namespace = filter_metadata.find("test_namespace");
+  ASSERT_NE(it_namespace, filter_metadata.end());
+
+  checkKeyString(it_namespace->second, "value", "existing_value");
+
+  // Verify stats were incremented.
+  EXPECT_EQ(1UL, config_->stats().overwrite_denied_.value());
+}
+
+TEST_F(SetMetadataFilterTest, MixedMetadataTypes) {
+  const std::string yaml_config = R"EOF(
+    metadata:
+      - metadata_namespace: untyped_namespace
+        allow_overwrite: true
+        value:
+          static_field: "static_value"
+      - metadata_namespace: formatted_namespace
+        allow_overwrite: true
+        format_string:
+          text_format: "simple_text"
+  )EOF";
+
+  envoy::config::core::v3::Metadata metadata;
+  runFilter(metadata, yaml_config);
+
+  // Verify both types of metadata are set correctly.
+  const auto& filter_metadata = metadata.filter_metadata();
+
+  // Check untyped metadata.
+  const auto it_untyped = filter_metadata.find("untyped_namespace");
+  ASSERT_NE(it_untyped, filter_metadata.end());
+  checkKeyString(it_untyped->second, "static_field", "static_value");
+
+  // Check formatted metadata.
+  const auto it_formatted = filter_metadata.find("formatted_namespace");
+  ASSERT_NE(it_formatted, filter_metadata.end());
+  checkKeyString(it_formatted->second, "value", "simple_text");
 }
 
 } // namespace SetMetadataFilter


### PR DESCRIPTION
## Description

Today, [Set-Metadata filter](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/http/set_metadata/v3/set_metadata.proto#envoy-v3-api-msg-extensions-filters-http-set-metadata-v3-metadata) does not provide ability to use substitution formatter while writing the metadata. For example, if I want to write the metadata with the value of `%VIRTUAL_CLUSTER_NAME%`, it's not possible as this would not get expanded and the metadata would just get populated as a string "%VIRTUAL_CLUSTER_NAME%".

This PR adds a new `format_string` to the filter which make these dynamic substitutions possible.

Fix https://github.com/envoyproxy/envoy/issues/40399

---

**Commit Message:** set_metadata: add substitution format string support for dynamic placeholder expansion
**Additional Description:** Added a new `format_string` to the Set-Metadata filter which make dynamic substitutions like `%ROUTE_NAME%` possible.
**Risk Level:** Low
**Testing:** Added Tests
**Docs Changes:** Added
**Release Notes:** Added