### PR TITLE
opentelemetry: clean up the code to avoid unnecessary copy/constructing

### DIFF
--- a/source/extensions/tracers/opentelemetry/span_context.h
+++ b/source/extensions/tracers/opentelemetry/span_context.h
@@ -24,10 +24,10 @@ public:
   /*
    * Constructor that creates a context object from the supplied attributes.
    */
-  SpanContext(const absl::string_view& version, const absl::string_view& trace_id,
-              const absl::string_view& parent_id, bool sampled, const absl::string_view& tracestate)
-      : version_(version), trace_id_(trace_id), parent_id_(parent_id), sampled_(sampled),
-        tracestate_(tracestate) {}
+  SpanContext(absl::string_view version, absl::string_view trace_id, absl::string_view span_id,
+              bool sampled, std::string tracestate)
+      : version_(version), trace_id_(trace_id), span_id_(span_id), sampled_(sampled),
+        tracestate_(std::move(tracestate)) {}
 
   /**
    * @return the span's version as a hex string.
@@ -35,9 +35,9 @@ public:
   const std::string& version() const { return version_; }
 
   /**
-   * @return the span's parent id as a hex string.
+   * @return the span's id as a hex string.
    */
-  const std::string& parentId() const { return parent_id_; }
+  const std::string& spanId() const { return span_id_; }
 
   /**
    * @return the trace id as an integer.
@@ -57,7 +57,7 @@ public:
 private:
   const std::string version_;
   const std::string trace_id_;
-  const std::string parent_id_;
+  const std::string span_id_;
   const bool sampled_{false};
   const std::string tracestate_;
 };

--- a/source/extensions/tracers/opentelemetry/span_context_extractor.cc
+++ b/source/extensions/tracers/opentelemetry/span_context_extractor.cc
@@ -61,13 +61,13 @@ absl::StatusOr<SpanContext> SpanContextExtractor::extractSpanContext() {
   }
   absl::string_view version = propagation_header_components[0];
   absl::string_view trace_id = propagation_header_components[1];
-  absl::string_view parent_id = propagation_header_components[2];
+  absl::string_view span_id = propagation_header_components[2];
   absl::string_view trace_flags = propagation_header_components[3];
   if (version.size() != kVersionHexSize || trace_id.size() != kTraceIdHexSize ||
-      parent_id.size() != kParentIdHexSize || trace_flags.size() != kTraceFlagsHexSize) {
+      span_id.size() != kParentIdHexSize || trace_flags.size() != kTraceFlagsHexSize) {
     return absl::InvalidArgumentError("Invalid traceparent field sizes");
   }
-  if (!isValidHex(version) || !isValidHex(trace_id) || !isValidHex(parent_id) ||
+  if (!isValidHex(version) || !isValidHex(trace_id) || !isValidHex(span_id) ||
       !isValidHex(trace_flags)) {
     return absl::InvalidArgumentError("Invalid header hex");
   }
@@ -76,7 +76,7 @@ absl::StatusOr<SpanContext> SpanContextExtractor::extractSpanContext() {
   if (isAllZeros(trace_id)) {
     return absl::InvalidArgumentError("Invalid trace id");
   }
-  if (isAllZeros(parent_id)) {
+  if (isAllZeros(span_id)) {
     return absl::InvalidArgumentError("Invalid parent id");
   }
 
@@ -102,8 +102,8 @@ absl::StatusOr<SpanContext> SpanContextExtractor::extractSpanContext() {
       });
   std::string tracestate = absl::StrJoin(tracestate_values, ",");
 
-  SpanContext span_context(version, trace_id, parent_id, sampled, tracestate);
-  return span_context;
+  SpanContext parent_context(version, trace_id, span_id, sampled, std::move(tracestate));
+  return parent_context;
 }
 
 } // namespace OpenTelemetry

--- a/source/extensions/tracers/opentelemetry/tracer.cc
+++ b/source/extensions/tracers/opentelemetry/tracer.cc
@@ -73,7 +73,8 @@ Span::Span(const std::string& name, const StreamInfo::StreamInfo& stream_info,
 Tracing::SpanPtr Span::spawnChild(const Tracing::Config&, const std::string& name,
                                   SystemTime start_time) {
   // Build span_context from the current span, then generate the child span from that context.
-  SpanContext span_context(kDefaultVersion, getTraceId(), spanId(), sampled(), tracestate());
+  SpanContext span_context(kDefaultVersion, getTraceId(), spanId(), sampled(),
+                           std::string(tracestate()));
   return parent_tracer_.startSpan(name, stream_info_, start_time, span_context, {},
                                   ::opentelemetry::proto::trace::v1::Span::SPAN_KIND_CLIENT);
 }
@@ -287,28 +288,27 @@ Tracing::SpanPtr Tracer::startSpan(const std::string& operation_name,
 
 Tracing::SpanPtr Tracer::startSpan(const std::string& operation_name,
                                    const StreamInfo::StreamInfo& stream_info, SystemTime start_time,
-                                   const SpanContext& previous_span_context,
+                                   const SpanContext& parent_context,
                                    OptRef<const Tracing::TraceContext> trace_context,
                                    OTelSpanKind span_kind) {
   // Create a new span and populate details from the span context.
   auto new_span = std::make_unique<Span>(operation_name, stream_info, start_time, time_source_,
                                          *this, span_kind);
-  new_span->setTraceId(previous_span_context.traceId());
-  if (!previous_span_context.parentId().empty()) {
-    new_span->setParentId(previous_span_context.parentId());
+  new_span->setTraceId(parent_context.traceId());
+  if (!parent_context.spanId().empty()) {
+    new_span->setParentId(parent_context.spanId());
   }
   // Generate a new identifier for the span id.
   uint64_t span_id = random_.random();
   new_span->setId(Hex::uint64ToHex(span_id));
   if (sampler_) {
     // Sampler should make a sampling decision and set tracestate
-    callSampler(sampler_, stream_info, previous_span_context, *new_span, operation_name,
-                trace_context);
+    callSampler(sampler_, stream_info, parent_context, *new_span, operation_name, trace_context);
   } else {
     // Respect the previous span's sampled flag.
-    new_span->setSampled(previous_span_context.sampled());
-    if (!previous_span_context.tracestate().empty()) {
-      new_span->setTracestate(std::string{previous_span_context.tracestate()});
+    new_span->setSampled(parent_context.sampled());
+    if (!parent_context.tracestate().empty()) {
+      new_span->setTracestate(parent_context.tracestate());
     }
   }
   return new_span;

--- a/source/extensions/tracers/opentelemetry/tracer.h
+++ b/source/extensions/tracers/opentelemetry/tracer.h
@@ -116,7 +116,7 @@ public:
   /**
    * Sets the span's trace id attribute.
    */
-  void setTraceId(const absl::string_view& trace_id_hex) {
+  void setTraceId(absl::string_view trace_id_hex) {
     span_.set_trace_id(absl::HexStringToBytes(trace_id_hex));
   }
 
@@ -129,12 +129,12 @@ public:
   /**
    * @return the operation name set on the span
    */
-  std::string name() const { return span_.name(); }
+  absl::string_view name() const { return span_.name(); }
 
   /**
    * Sets the span's id.
    */
-  void setId(const absl::string_view& span_id_hex) {
+  void setId(absl::string_view span_id_hex) {
     span_.set_span_id(absl::HexStringToBytes(span_id_hex));
   }
 
@@ -143,16 +143,16 @@ public:
   /**
    * Sets the span's parent id.
    */
-  void setParentId(const absl::string_view& parent_span_id_hex) {
+  void setParentId(absl::string_view parent_span_id_hex) {
     span_.set_parent_span_id(absl::HexStringToBytes(parent_span_id_hex));
   }
 
-  std::string tracestate() const { return span_.trace_state(); }
+  absl::string_view tracestate() const { return span_.trace_state(); }
 
   /**
    * Sets the span's tracestate.
    */
-  void setTracestate(const absl::string_view& tracestate) {
+  void setTracestate(absl::string_view tracestate) {
     span_.set_trace_state(std::string{tracestate});
   }
 

--- a/test/extensions/tracers/opentelemetry/samplers/sampler_test.cc
+++ b/test/extensions/tracers/opentelemetry/samplers/sampler_test.cc
@@ -156,7 +156,7 @@ TEST_F(SamplerFactoryTest, TestWithSampler) {
   // So the dynamic_cast should be safe.
   std::unique_ptr<Span> span(dynamic_cast<Span*>(tracing_span.release()));
   EXPECT_TRUE(span->sampled());
-  EXPECT_STREQ(span->tracestate().c_str(), "this_is=tracesate");
+  EXPECT_EQ(span->tracestate(), "this_is=tracesate");
 
   // shouldSamples return a result containing additional attributes and Decision::Drop
   EXPECT_CALL(*test_sampler, shouldSample(_, _, _, _, _, _, _))
@@ -184,7 +184,7 @@ TEST_F(SamplerFactoryTest, TestWithSampler) {
                                    {Tracing::Reason::Sampling, true});
   std::unique_ptr<Span> unsampled_span(dynamic_cast<Span*>(tracing_span.release()));
   EXPECT_FALSE(unsampled_span->sampled());
-  EXPECT_STREQ(unsampled_span->tracestate().c_str(), "this_is=another_tracesate");
+  EXPECT_EQ(unsampled_span->tracestate(), "this_is=another_tracesate");
   auto proto_span = unsampled_span->spanForTest();
 
   auto get_attr_value =

--- a/test/extensions/tracers/opentelemetry/span_context_extractor_test.cc
+++ b/test/extensions/tracers/opentelemetry/span_context_extractor_test.cc
@@ -30,7 +30,7 @@ TEST(SpanContextExtractorTest, ExtractSpanContext) {
 
   EXPECT_OK(span_context);
   EXPECT_EQ(span_context->traceId(), trace_id);
-  EXPECT_EQ(span_context->parentId(), parent_id);
+  EXPECT_EQ(span_context->spanId(), parent_id);
   EXPECT_EQ(span_context->version(), version);
   EXPECT_TRUE(span_context->sampled());
 }
@@ -45,7 +45,7 @@ TEST(SpanContextExtractorTest, ExtractSpanContextNotSampled) {
 
   EXPECT_OK(span_context);
   EXPECT_EQ(span_context->traceId(), trace_id);
-  EXPECT_EQ(span_context->parentId(), parent_id);
+  EXPECT_EQ(span_context->spanId(), parent_id);
   EXPECT_EQ(span_context->version(), version);
   EXPECT_FALSE(span_context->sampled());
 }


### PR DESCRIPTION
Commit Message: opentelemetry: clean up the code to avoid unnecessary copy/constructing
Additional Description:

Minor optimization.

Risk Level: low.
Testing: n/a.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.