### PR TITLE
tracing: support get all to avoid full interation

### DIFF
--- a/source/common/tracing/trace_context_impl.h
+++ b/source/common/tracing/trace_context_impl.h
@@ -43,6 +43,16 @@ public:
    */
   absl::optional<absl::string_view> get(const TraceContext& trace_context) const;
 
+  using GetAllResult = absl::InlinedVector<absl::string_view, 1>;
+
+  /**
+   * Get all values from the trace context by the key. If the underlying trace context is HTTP
+   * header map, then there may be multiple values for the same key and the get() method will
+   * return the first value only. This method will return all values for the key.
+   * @param trace_context the trace context to get the values.
+   */
+  GetAllResult getAll(const TraceContext& trace_context) const;
+
   /*
    * Set the key/value pair in the trace context.
    * @param trace_context the trace context to set the key/value pair.

--- a/source/extensions/tracers/datadog/dict_util.cc
+++ b/source/extensions/tracers/datadog/dict_util.cc
@@ -70,8 +70,7 @@ void TraceContextReader::visit(
         visitor) const {
   context_.forEach([&](absl::string_view key, absl::string_view value) {
     visitor(key, value);
-    const bool continue_iterating = true;
-    return continue_iterating;
+    return true;
   });
 }
 

--- a/source/extensions/tracers/opentelemetry/span_context.h
+++ b/source/extensions/tracers/opentelemetry/span_context.h
@@ -55,11 +55,11 @@ public:
   const std::string& tracestate() const { return tracestate_; }
 
 private:
-  const std::string version_;
-  const std::string trace_id_;
-  const std::string span_id_;
-  const bool sampled_{false};
-  const std::string tracestate_;
+  std::string version_;
+  std::string trace_id_;
+  std::string span_id_;
+  bool sampled_{false};
+  std::string tracestate_;
 };
 
 } // namespace OpenTelemetry

--- a/source/extensions/tracers/opentelemetry/span_context_extractor.cc
+++ b/source/extensions/tracers/opentelemetry/span_context_extractor.cc
@@ -89,20 +89,10 @@ absl::StatusOr<SpanContext> SpanContextExtractor::extractSpanContext() {
   // it is invalid and MUST be discarded. Because we're already checking for the
   // traceparent header above, we don't need to check here.
   // See https://www.w3.org/TR/trace-context/#processing-model-for-working-with-trace-context
-  absl::string_view tracestate_key = OpenTelemetryConstants::get().TRACE_STATE.key();
-  std::vector<std::string> tracestate_values;
-  // Multiple tracestate header fields MUST be handled as specified by RFC7230 Section 3.2.2 Field
-  // Order.
-  trace_context_.forEach(
-      [&tracestate_key, &tracestate_values](absl::string_view key, absl::string_view value) {
-        if (key == tracestate_key) {
-          tracestate_values.push_back(std::string{value});
-        }
-        return true;
-      });
-  std::string tracestate = absl::StrJoin(tracestate_values, ",");
+  const auto tracestate_values = OpenTelemetryConstants::get().TRACE_STATE.getAll(trace_context_);
 
-  SpanContext parent_context(version, trace_id, span_id, sampled, std::move(tracestate));
+  SpanContext parent_context(version, trace_id, span_id, sampled,
+                             absl::StrJoin(tracestate_values, ","));
   return parent_context;
 }
 


### PR DESCRIPTION
Commit Message: tracing: support get all to avoid full interation
Additional Description:

Added `getAll()` method to the `TraceContextHandler`. Then the opentelemtry/fluentd needn't to iterate the whole header map to find all `tracestate` headers/values.

Risk Level: low.
Testing: n/a.
Docs Changes: n/a.
Release Notes: n/a.