### PR TITLE
xds-federation: adding RDS using on xds-TP based configs

### DIFF
--- a/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
+++ b/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
@@ -1036,7 +1036,7 @@ message Rds {
       "envoy.config.filter.network.http_connection_manager.v2.Rds";
 
   // Configuration source specifier for RDS.
-  config.core.v3.ConfigSource config_source = 1 [(validate.rules).message = {required: true}];
+  config.core.v3.ConfigSource config_source = 1;
 
   // The name of the route configuration. This name will be passed to the RDS
   // API. This allows an Envoy configuration with multiple HTTP listeners (and

--- a/source/extensions/filters/network/http_connection_manager/BUILD
+++ b/source/extensions/filters/network/http_connection_manager/BUILD
@@ -38,6 +38,7 @@ envoy_cc_extension(
         "//source/common/access_log:access_log_lib",
         "//source/common/common:minimal_logger_lib",
         "//source/common/config:utility_lib",
+        "//source/common/config:xds_resource_lib",
         "//source/common/filter:config_discovery_lib",
         "//source/common/http:conn_manager_lib",
         "//source/common/http:default_server_string_lib",

--- a/source/extensions/filters/network/http_connection_manager/config.cc
+++ b/source/extensions/filters/network/http_connection_manager/config.cc
@@ -22,6 +22,7 @@
 #include "source/common/access_log/access_log_impl.h"
 #include "source/common/common/fmt.h"
 #include "source/common/config/utility.h"
+#include "source/common/config/xds_resource.h"
 #include "source/common/http/conn_manager_config.h"
 #include "source/common/http/conn_manager_utility.h"
 #include "source/common/http/default_server_string.h"
@@ -213,6 +214,20 @@ createHeaderValidatorFactory([[maybe_unused]] const envoy::extensions::filters::
   }
 #endif
   return header_validator_factory;
+}
+
+// Validates that an RDS config either has a config_source or an xdstp
+// route_config_name defined.
+absl::Status
+validateRds(const envoy::extensions::filters::network::http_connection_manager::v3::Rds& rds) {
+  if (!rds.has_config_source() &&
+      !Config::XdsResourceIdentifier::hasXdsTpScheme(rds.route_config_name())) {
+    return absl::InvalidArgumentError(
+        fmt::format("An RDS config must have either a 'config_source' or an xDS-TP based "
+                    "'route_config_name'. Error while parsing RDS config:\n{}",
+                    rds.DebugString()));
+  }
+  return absl::OkStatus();
 }
 
 } // namespace
@@ -554,6 +569,7 @@ HttpConnectionManagerConfig::HttpConnectionManagerConfig(
   switch (config.route_specifier_case()) {
   case envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager::
       RouteSpecifierCase::kRds:
+    SET_AND_RETURN_IF_NOT_OK(validateRds(config.rds()), creation_status);
     route_config_provider_ = route_config_provider_manager.createRdsRouteConfigProvider(
         // At the creation of a RDS route config provider, the factory_context's initManager is
         // always valid, though the init manager may go away later when the listener goes away.

--- a/test/extensions/filters/network/http_connection_manager/config_test.cc
+++ b/test/extensions/filters/network/http_connection_manager/config_test.cc
@@ -154,6 +154,21 @@ http_filters:
                             "chain.");
 }
 
+TEST_F(HttpConnectionManagerConfigTest, NonXdsTpRouteWithoutConfigSource) {
+  const std::string yaml_string = R"EOF(
+codec_type: http1
+stat_prefix: router
+rds:
+  route_config_name: route1
+http_filters:
+- name: foo
+  )EOF";
+
+  EXPECT_THROW_WITH_REGEX(
+      createHttpConnectionManagerConfig(yaml_string), EnvoyException,
+      "An RDS config must have either a 'config_source' or an xDS-TP based 'route_config_name'");
+}
+
 TEST_F(HttpConnectionManagerConfigTest, MiscConfig) {
   const std::string yaml_string = R"EOF(
 codec_type: http1

--- a/test/integration/xdstp_config_sources_integration_test.cc
+++ b/test/integration/xdstp_config_sources_integration_test.cc
@@ -67,7 +67,9 @@ public:
     // upstream for a backend (H/1).
     authority1_upstream_ = createAdsUpstream();
     default_authority_upstream_ = createAdsUpstream();
-    addFakeUpstream(Http::CodecType::HTTP1);
+    if (test_requires_additional_upstream_) {
+      addFakeUpstream(Http::CodecType::HTTP1);
+    }
   }
 
   bool isSotw() const {
@@ -154,6 +156,8 @@ public:
         name, Network::Test::getLoopbackAddressString(ipVersion()),
         fake_upstreams_.back().get()->localAddress()->ip()->port());
   }
+
+  bool test_requires_additional_upstream_{true};
 
   // Data members that emulate the authority1 server.
   FakeUpstream* authority1_upstream_;
@@ -399,4 +403,49 @@ TEST_P(XdsTpConfigsIntegrationTest, EdsOnlyConfigDefaultSource) {
 
 // TODO(adisuissa): add a test that validates that two clusters with the same
 // config source multiplex the request on the same stream.
+
+// Validate that a bootstrap cluster that has an xds-tp based config RDS source
+// works.
+TEST_P(XdsTpConfigsIntegrationTest, RdsOnlyConfigAuthority1) {
+  test_requires_additional_upstream_ = false;
+  const std::string route_config_name =
+      "xdstp://authority1.com/envoy.config.route.v3.RouteConfiguration/my_routes/route1";
+  // Set up the listener to point to an RDS resource (that will route to the
+  // the default cluster_0).
+  // Update the route to the xdstp-based cluster.
+  config_helper_.addConfigModifier(
+      [&route_config_name](
+          envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
+              hcm) { hcm.mutable_rds()->set_route_config_name(route_config_name); });
+
+  // Envoy will request the routes of the listener in the bootstrap during the
+  // initialization phase. This will make sure the xDS server answers with the
+  // correct assignment.
+  on_server_init_function_ = [this, &route_config_name]() {
+    connectAuthority1();
+    connectDefaultAuthority();
+
+    // Authority1 should receive the RDS request.
+    EXPECT_TRUE(compareDiscoveryRequest(
+        Config::TypeUrl::get().RouteConfiguration, "", {route_config_name}, {route_config_name}, {},
+        true, Grpc::Status::WellKnownGrpcStatus::Ok, "", authority1_xds_stream_.get()));
+    sendDiscoveryResponse<envoy::config::route::v3::RouteConfiguration>(
+        Config::TypeUrl::get().RouteConfiguration,
+        {ConfigHelper::buildRouteConfig(route_config_name, "cluster_0")},
+        {ConfigHelper::buildRouteConfig(route_config_name, "cluster_0")}, {}, "1", {},
+        authority1_xds_stream_.get());
+
+    // Expect an RDS ACK.
+    EXPECT_TRUE(compareDiscoveryRequest(
+        Config::TypeUrl::get().RouteConfiguration, "1", {route_config_name}, {}, {}, false,
+        Grpc::Status::WellKnownGrpcStatus::Ok, "", authority1_xds_stream_.get()));
+  };
+  initialize();
+
+  test_server_->waitForCounterGe("listener_manager.listener_create_success", 1);
+  // Try to send a request and see that it reaches the backend (backend 0).
+  testRouterHeaderOnlyRequestAndResponse(nullptr);
+  cleanupUpstreamAndDownstream();
+}
+
 } // namespace Envoy


### PR DESCRIPTION
Commit Message: xds-federation: adding RDS using on xds-TP based configs
Additional Description:
This PR makes RDS the second xDS-resource-type to support xds-tp based configs, which enables it to be used in a federated-xDS scenario.
This feature is under a runtime flag `envoy.reloadable_features.xdstp_based_config_singleton_subscriptions` which is disabled by default. Once we get to test it end-to-end, and add a few more xDS-resource types to the support, it could be enabled by default.
We removed having the `config_source` constraint in an `RDS` config, and added a validation to check that the resource is an xDS-TP resource.

Risk Level: low - disabled by default
Testing: Added both unit and integration tests.
Docs Changes: not yet
Release Notes: not yet
Platform Specific Features: N/A