### PR TITLE
Add Runtime Enabled Flag to FilterConfig struct

### DIFF
--- a/api/envoy/config/route/v3/route_components.proto
+++ b/api/envoy/config/route/v3/route_components.proto
@@ -2438,4 +2438,14 @@ message FilterConfig {
   //
   //   This field only make sense for the downstream HTTP filters for now.
   bool disabled = 3;
+
+  // Specifies the % of requests for which the filter is enabled.
+  //
+  // If neither `filter_enabled` nor `disabled` are specified, the filter will be enabled for 100% of requests.
+  //
+  // If the `disabled` field is true, this field has no effect and the filter will always be disabled.
+  //
+  // If :ref:`runtime_key <envoy_v3_api_field_config.core.v3.RuntimeFractionalPercent.runtime_key>` is
+  // specified, Envoy will look up the runtime key to determine the percentage of requests for which the filter is enabled.
+  core.v3.RuntimeFractionalPercent filter_enabled = 4;
 }

--- a/source/common/router/BUILD
+++ b/source/common/router/BUILD
@@ -70,6 +70,7 @@ envoy_cc_library(
         "//source/common/http/matching:data_impl_lib",
         "//source/common/matcher:matcher_lib",
         "//source/common/protobuf:utility_lib",
+        "//source/common/runtime:runtime_protos_lib",
         "//source/common/tracing:custom_tag_lib",
         "//source/common/tracing:http_tracer_lib",
         "//source/common/upstream:retry_factory_lib",

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -34,6 +34,7 @@
 #include "source/common/router/metadatamatchcriteria_impl.h"
 #include "source/common/router/router_ratelimit.h"
 #include "source/common/router/tls_context_match_criteria_impl.h"
+#include "source/common/runtime/runtime_protos.h"
 #include "source/common/stats/symbol_table.h"
 
 #include "absl/container/node_hash_map.h"
@@ -90,7 +91,15 @@ public:
 
   struct FilterConfig {
     RouteSpecificFilterConfigConstSharedPtr config_;
-    bool disabled_{};
+
+    FilterConfig(RouteSpecificFilterConfigConstSharedPtr route_specific_config,
+                 const envoy::config::route::v3::FilterConfig& filter_config,
+                 Runtime::Loader& runtime);
+    bool isEnabled() const;
+
+  private:
+    const absl::optional<Runtime::FractionalPercent> filter_enabled_;
+    bool disabled_;
   };
 
   const RouteSpecificFilterConfig* get(const std::string& name) const;
@@ -113,6 +122,7 @@ private:
                                   Server::Configuration::ServerFactoryContext& factory_context,
                                   ProtobufMessage::ValidationVisitor& validator);
   absl::flat_hash_map<std::string, FilterConfig> configs_;
+  Runtime::Loader& runtime_;
 };
 
 class RouteEntryImplBase;


### PR DESCRIPTION
Commit Message:
Add filter_enabled flag to FilterConfig struct to support conditional filter activation at runtime.

Additional Description:
This change introduces a filter_enabled flag within the FilterConfig structure. The flag allows filters to be dynamically enabled or disabled via runtime configuration, improving flexibility and control over filter behavior without requiring binary changes.

Risk Level:
Low – the change is additive and gated by a new optional configuration flag.

Testing:
Unit tests added for the new runtime flag behavior. Existing filter configuration tests pass verifying backwards compatibility.

Docs Changes:
Pending – will update documentation to include the new runtime_enabled field and usage examples.

Release Notes:
Added filter_enabled flag to FilterConfig to support runtime-controlled filter activation.

Platform Specific Features:
None

[Optional Runtime guard:]
The feature is controlled by the presence of the runtime_enabled field in the config.

[Optional Fixes #Issue]
https://github.com/envoyproxy/envoy/issues/38435

[Optional Fixes commit #PR or SHA]
N/A

[Optional Deprecated:]
None

[Optional API Considerations:]
Field is optional; no API breakage expected.