### PR TITLE
async_client: hook up sidestream watermark callbacks in Envoy::Http::AsyncSteamImpl

### DIFF
--- a/source/common/http/async_client_impl.cc
+++ b/source/common/http/async_client_impl.cc
@@ -159,6 +159,10 @@ AsyncStreamImpl::AsyncStreamImpl(AsyncClientImpl& parent, AsyncClient::StreamCal
     buffered_body_ = std::make_unique<Buffer::OwnedImpl>(account_);
   }
 
+  if (options.sidestream_watermark_callbacks != nullptr) {
+    setWatermarkCallbacks(*options.sidestream_watermark_callbacks);
+  }
+
   router_.setDecoderFilterCallbacks(*this);
   // TODO(mattklein123): Correctly set protocol in stream info when we support access logging.
 }


### PR DESCRIPTION
Commit Message: Saves sidestream watermark callbacks passed into the constructor of Envoy::Http::AsyncStreamImpl via options.sidestream_watermark_callbacks. Previously they were ignored and could only be set by calling setWatermarkCallbacks after construction. Passes downstream watermark callbacks to sidestream watermark callbacks so that the sidestream can apply downstream flow control. Previously [add|remove]DownstreamWatermarkCallbacks was a no-op.
Additional Description: n/a
Risk Level: low
Testing: Added unit tests.
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
