### PR TITLE
Docs: Clang 18 should be the suggested used version.

### DIFF
--- a/bazel/README.md
+++ b/bazel/README.md
@@ -98,7 +98,7 @@ for how to update or override dependencies.
     ```
 
     ### Linux
-    On Linux, we recommend using the prebuilt Clang+LLVM package from [LLVM official site](http://releases.llvm.org/download.html) for Clang 14.
+    On Linux, we recommend using the prebuilt Clang+LLVM package from [LLVM official site](http://releases.llvm.org/download.html) for Clang 18.
 
     Extract the tar.xz and run the following:
     ```console
@@ -365,7 +365,7 @@ for more details.
 ## Supported compiler versions
 
 We now require Clang >= 18 due to C++20 support (for Clang >= 14, your mileage may vary) and tcmalloc requirement. GCC >= 13 is also known to work for C++20.
-Currently the CI is running with Clang 14.
+Currently the CI is running with Clang 18.
 
 ## Clang STL debug symbols
 


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Docs: Clang 18 should be the suggested used version.
Additional Description: 
Risk Level: n/a
Testing: n/a
Docs Changes: yes
Release Notes: n/a
Platform Specific Features: n/a

