### PR TITLE
Avoid an unnecessary string copy in ProxyFilter

### DIFF
--- a/source/extensions/filters/http/dynamic_forward_proxy/proxy_filter.cc
+++ b/source/extensions/filters/http/dynamic_forward_proxy/proxy_filter.cc
@@ -319,11 +319,11 @@ Http::FilterHeadersStatus ProxyFilter::decodeHeaders(Http::RequestHeaderMap& hea
   // For any other address type just use the existing unmodified host string.
   std::string host_str;
   absl::string_view host;
-  if (!host_attributes.is_ip_address_ || !absl::StrContains(host_attributes.host_, ":")) {
-    host = host_attributes.host_;
-  } else {
+  if (host_attributes.is_ip_address_ && absl::StrContains(host_attributes.host_, ":")) {
     host_str = absl::StrCat("[", host_attributes.host_, "]");
     host = host_str;
+  } else {
+    host = host_attributes.host_;
   }
   uint16_t port = host_attributes.port_.value_or(default_port);
 

--- a/source/extensions/filters/http/dynamic_forward_proxy/proxy_filter.cc
+++ b/source/extensions/filters/http/dynamic_forward_proxy/proxy_filter.cc
@@ -315,11 +315,16 @@ Http::FilterHeadersStatus ProxyFilter::decodeHeaders(Http::RequestHeaderMap& hea
   // Get host value from the request headers.
   const auto host_attributes =
       Http::Utility::parseAuthority(headers.Host()->value().getStringView());
-  std::string host_str(!host_attributes.is_ip_address_ ||
-                               !absl::StrContains(host_attributes.host_, ":")
-                           ? host_attributes.host_
-                           : absl::StrCat("[", host_attributes.host_, "]"));
-  absl::string_view host = host_str;
+  // For IPv6 numeric addresses, use a copy with square brackets added around the host.
+  // For any other address type just use the existing unmodified host string.
+  std::string host_str;
+  absl::string_view host;
+  if (!host_attributes.is_ip_address_ || !absl::StrContains(host_attributes.host_, ":")) {
+    host = host_attributes.host_;
+  } else {
+    host_str = absl::StrCat("[", host_attributes.host_, "]");
+    host = host_str;
+  }
   uint16_t port = host_attributes.port_.value_or(default_port);
 
   // Apply filter state overrides for host and port.


### PR DESCRIPTION
Commit Message: Avoid an unnecessary string copy in ProxyFilter
Additional Description: This code was changed recently to fix an issue, but it gained a string-copy that's avoidable for any addresses that are not numeric IPv6 addresses.
Risk Level: Negligible.
Testing: Existing tests cover it.
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
