### PR TITLE
Bump compiler requirements for C++20

### DIFF
--- a/source/common/common/compiler_requirements.h
+++ b/source/common/common/compiler_requirements.h
@@ -3,7 +3,7 @@
 namespace Envoy {
 
 #if __cplusplus < 202002L
-#error "Your compiler does not support C++20. GCC 13+, Clang, or MSVC 2019+ is required."
+#error "Your compiler does not support C++20. GCC 12+, Clang, or MSVC 2019+ is required."
 #endif
 
 // See:

--- a/source/common/common/compiler_requirements.h
+++ b/source/common/common/compiler_requirements.h
@@ -2,8 +2,8 @@
 
 namespace Envoy {
 
-#if __cplusplus < 201402L
-#error "Your compiler does not support C++14. GCC 5+, Clang, or MSVC 2017+ is required."
+#if __cplusplus < 202002L
+#error "Your compiler does not support C++20. GCC 13+, Clang, or MSVC 2019+ is required."
 #endif
 
 // See:


### PR DESCRIPTION

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Bump compiler requirements for C++20
Additional Description: Compiler require C++20 to fail with a nicer error message if using an older compiler. Used https://en.cppreference.com/w/cpp/compiler_support.html#:~:text=Apple%20Clang*-,C%2B%2B20%20features,-C%2B%2B20%20core for reference
Risk Level: low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a

