### PR TITLE
Downgrade HTTP cache filter security posture

### DIFF
--- a/source/extensions/extensions_metadata.yaml
+++ b/source/extensions/extensions_metadata.yaml
@@ -270,7 +270,7 @@ envoy.filters.http.buffer:
 envoy.filters.http.cache:
   categories:
   - envoy.filters.http
-  security_posture: robust_to_untrusted_downstream_and_upstream
+  security_posture: unknown
   status: wip
   type_urls:
   - envoy.extensions.filters.http.cache.v3.CacheConfig


### PR DESCRIPTION
Commit Message:
Per notification in the envoy-announce@googlegroups.com the HTTP cache filter security posture is downgraded to unknown to match its work-in-progress status. This removes the filter from the security release process.

Risk Level: low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
