### PR TITLE
Fix JsonTranscoderFilter assert

### DIFF
--- a/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
+++ b/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
@@ -667,6 +667,11 @@ void JsonTranscoderFilter::setDecoderFilterCallbacks(
 
 Http::FilterHeadersStatus JsonTranscoderFilter::encodeHeaders(Http::ResponseHeaderMap& headers,
                                                               bool end_stream) {
+  if (error_ || !transcoder_) {
+    ENVOY_STREAM_LOG(debug, "Response headers is passed through", *encoder_callbacks_);
+    return Http::FilterHeadersStatus::Continue;
+  }
+
   if (!Grpc::Common::isGrpcResponseHeaders(headers, end_stream)) {
     ENVOY_STREAM_LOG(
         debug,
@@ -674,10 +679,6 @@ Http::FilterHeadersStatus JsonTranscoderFilter::encodeHeaders(Http::ResponseHead
         "without transcoding.",
         *encoder_callbacks_);
     error_ = true;
-  }
-
-  if (error_ || !transcoder_) {
-    ENVOY_STREAM_LOG(debug, "Response headers is passed through", *encoder_callbacks_);
     return Http::FilterHeadersStatus::Continue;
   }
 


### PR DESCRIPTION
Commit Message: Fix JsonTranscoderFilter assert
Additional Description: If downstream sends more data after upstream sends non-grpc response headers, an assert was triggered in debug builds. This change makes it so if non-grpc response headers are expected (transcoding isn't happening) it's passed through without being tagged as an error. This is particularly an issue if a websocket connection shares a filter chain with a grpc_json_transcoder.
Risk Level: Very small, behavior change is `error_` not being incorrectly set when there is no error, which is only used in the case where downstream sends more data after upstream sends a non-grpc response header, and mostly only an issue for debug builds.
Testing:
Output of new test before fix:
```
[ RUN      ] GrpcJsonTranscoderFilterTest.NoTranscodingWithStreamedRequest
[2025-07-25 19:27:57.572][91049][critical][assert] [source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc:587] assert failure: !error_.
[2025-07-25 19:27:57.573][91049][error][envoy_bug] [./source/common/common/assert.h:38] stacktrace for envoy bug
[2025-07-25 19:27:57.583][91049][error][envoy_bug] [./source/common/common/assert.h:43] #0 Envoy::Extensions::HttpFilters::GrpcJsonTranscoder::JsonTranscoderFilter::decodeData() [0x58c08814f50c]
[...]
```
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
