### PR TITLE
OPTIMIZATION: add fast return for featureEnabled when fractional percent is >= 100

### DIFF
--- a/source/common/runtime/runtime_impl.cc
+++ b/source/common/runtime/runtime_impl.cc
@@ -181,6 +181,7 @@ bool SnapshotImpl::featureEnabled(absl::string_view key,
               "WARNING runtime key '{}': numerator ({}) > denominator ({}), condition always "
               "evaluates to true",
               key, percent.numerator(), denominator_value);
+    return true;
   }
 
   return ProtobufPercentHelper::evaluateFractionalPercent(percent, random_value);


### PR DESCRIPTION
added simple test

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: In sampling, when the numerator >= denominator the result always evaluates to true. This behaviour is logged, however, we still call `ProtobufPercentHelper ::evaluateFractionalPercent` which needlessly jumps into a function and computes a modulo operation. 
Risk Level: Low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
