### PR TITLE
Add missing include to ssl_socket_extended_info_interface.h

### DIFF
--- a/envoy/ssl/BUILD
+++ b/envoy/ssl/BUILD
@@ -76,6 +76,7 @@ envoy_cc_library(
 envoy_cc_library(
     name = "ssl_socket_extended_info_interface",
     hdrs = ["ssl_socket_extended_info.h"],
+    deps = [":handshaker_interface"],
 )
 
 envoy_cc_library(

--- a/envoy/ssl/ssl_socket_extended_info.h
+++ b/envoy/ssl/ssl_socket_extended_info.h
@@ -7,6 +7,7 @@
 
 #include "envoy/common/pure.h"
 #include "envoy/event/dispatcher.h"
+#include "envoy/ssl/handshaker.h"
 
 namespace Envoy {
 namespace Ssl {

--- a/test/common/tls/cert_validator/BUILD
+++ b/test/common/tls/cert_validator/BUILD
@@ -19,9 +19,9 @@ envoy_cc_test(
     ],
     rbe_pool = "6gig",
     deps = [
+        ":test_common",
         "//source/common/tls/cert_validator:cert_validator_lib",
         "//test/common/tls:ssl_test_utils",
-        "//test/common/tls/cert_validator:test_common",
         "//test/mocks/server:server_factory_context_mocks",
         "//test/test_common:environment_lib",
         "//test/test_common:test_runtime_lib",
@@ -35,8 +35,8 @@ envoy_cc_test(
     ],
     rbe_pool = "6gig",
     deps = [
+        ":test_common",
         "//source/common/tls/cert_validator:cert_validator_lib",
-        "//test/common/tls/cert_validator:test_common",
     ],
 )
 


### PR DESCRIPTION
Commit Message:
For `CertificateSelectionCallbackPtr` type. 

Risk Level: low
Testing: unit test
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
