### PR TITLE
Transport Tap/Buffered trace - Submit captured transport streamed trace data as smoothly as possible with the configured chunk size

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -49,6 +49,9 @@ new_features:
 - area: socket
   change: |
     Added ``network_namespace_filepath`` to ``SocketAddress``.
+- area: tap
+  change: |
+    Submit captured transport streamed strace data as smoothly as possible with the configured chunk size.
 - area: ratelimit
   change: |
     Add the :ref:`rate_limits

--- a/source/extensions/transport_sockets/tap/tap_config_impl.h
+++ b/source/extensions/transport_sockets/tap/tap_config_impl.h
@@ -24,6 +24,10 @@ public:
   void closeSocket(Network::ConnectionEvent event) override;
   void onRead(const Buffer::Instance& data, uint32_t bytes_read) override;
   void onWrite(const Buffer::Instance& data, uint32_t bytes_written, bool end_stream) override;
+  void setStreamedBufferAgedDuration(uint32_t duration) {
+    streamed_buffer_aged_duration_ = duration;
+  }
+  uint32_t getStreamedBufferAgedDuration() const { return streamed_buffer_aged_duration_; }
 
 private:
   void initEvent(envoy::data::tap::v3::SocketEvent&);
@@ -48,6 +52,11 @@ private:
   }
   void pegSubmitCounter(const bool is_streaming);
   bool shouldSendStreamedMsgByConfiguredSize() const;
+  bool shouldSubmitStreamedDataPerConfiguredSizeByAgedDuration() const;
+  void submitStreamedDataPerConfiguredSize();
+  void setStreamedDataPerConfiguredSize(const Buffer::Instance& data, const uint32_t buffer_offset,
+                                        const uint32_t total_bytes, const bool is_read,
+                                        const bool is_end_stream);
   void handleSendingStreamTappedMsgPerConfigSize(const Buffer::Instance& data,
                                                  const uint32_t total_bytes, const bool is_read,
                                                  const bool is_end_stream);
@@ -55,6 +64,10 @@ private:
   // (This means that per transport socket buffer trace, the minimum amount
   // which triggering to send the tapped messages size is 9 bytes).
   static constexpr uint32_t DefaultMinBufferedBytes = 9;
+  // It isn't easy to meet data submit threshold when the configured byte size is too large
+  // and the tapped data volume is low, therefore, set below buffer aged duration (seconds)
+  // to make sure that the tapped data is submitted in time.
+  static constexpr uint32_t DefaultBufferedAgedDuration = 15;
   SocketTapConfigSharedPtr config_;
   Extensions::Common::Tap::PerTapSinkHandleManagerPtr sink_handle_;
   const Network::Connection& connection_;
@@ -65,6 +78,7 @@ private:
   uint32_t tx_bytes_buffered_{};
   const bool should_output_conn_info_per_event_{false};
   uint32_t current_streamed_rx_tx_bytes_{0};
+  uint32_t streamed_buffer_aged_duration_{0};
   Extensions::Common::Tap::TraceWrapperPtr streamed_trace_{nullptr};
   const TransportTapStats stats_;
 };

--- a/test/extensions/transport_sockets/tap/tap_config_impl_test.cc
+++ b/test/extensions/transport_sockets/tap/tap_config_impl_test.cc
@@ -371,7 +371,7 @@ socket_streamed_trace_segment:
   pegging_counter_ = local_pegging_counter;
 }
 
-// Verify the full streaming flow for submiting tapped message on all cases
+// Verify the full streaming flow for submiting tapped message on all cases.
 // When send_streamed_msg_on_configured_size_ is True.
 TEST_F(PerSocketTapperImplTest, StreamingFlowWhenSendStreamedMsgIsTrue) {
   // Keep the original value.
@@ -382,7 +382,6 @@ TEST_F(PerSocketTapperImplTest, StreamingFlowWhenSendStreamedMsgIsTrue) {
   bool local_send_streamed_msg_on_configured_size_ = send_streamed_msg_on_configured_size_;
   send_streamed_msg_on_configured_size_ = true;
   bool local_default_min_buffered_bytes = default_min_buffered_bytes_;
-  default_min_buffered_bytes_ = 15;
 
   // Submit when the transport socket is created.
   EXPECT_CALL(*sink_manager_, submitTrace_(TraceEqual(
@@ -403,7 +402,10 @@ socket_streamed_trace_segment:
 
   InSequence s;
 
-  // Submit when the transport socket is gotten read event
+  // Store the data and will submitted in next write event because 53+54 > 54.
+  default_min_buffered_bytes_ = 54;
+  EXPECT_CALL(*config_, minStreamedSentBytes()).WillRepeatedly(Return(default_min_buffered_bytes_));
+
   EXPECT_CALL(*sink_manager_, submitTrace_(TraceEqual(
                                   R"EOF(
 socket_streamed_trace_segment:
@@ -426,7 +428,9 @@ socket_streamed_trace_segment:
 )EOF")));
   tapper_->onRead(Buffer::OwnedImpl("Test transport socket tap buffered data onRead submit"), 53);
 
-  // Submit when the transport socket is gotten write event
+  // Submit when the transport socket is gotten write event because 54=54.
+  default_min_buffered_bytes_ = 54;
+  EXPECT_CALL(*config_, minStreamedSentBytes()).WillRepeatedly(Return(default_min_buffered_bytes_));
   EXPECT_CALL(*sink_manager_, submitTrace_(TraceEqual(
                                   R"EOF(
 socket_streamed_trace_segment:
@@ -452,7 +456,7 @@ socket_streamed_trace_segment:
   tapper_->onWrite(Buffer::OwnedImpl("Test transport socket tap buffered data onWrite submit"), 54,
                    true);
 
-  // Submit when the transport socket is gotten close event
+  // Submit when the transport socket is gotten close event.
   EXPECT_CALL(*sink_manager_, submitTrace_(TraceEqual(
                                   R"EOF(
 socket_streamed_trace_segment:
@@ -474,15 +478,16 @@ socket_streamed_trace_segment:
   time_system_.setSystemTime(std::chrono::seconds(2));
   tapper_->closeSocket(Network::ConnectionEvent::RemoteClose);
 
-  // Restore the value
+  // Restore the value.
   output_conn_info_per_event_ = local_output_conn_info_per_event;
   pegging_counter_ = local_pegging_counter;
   send_streamed_msg_on_configured_size_ = local_send_streamed_msg_on_configured_size_;
   default_min_buffered_bytes_ = local_default_min_buffered_bytes;
 }
 
-// Verify the full streaming flow for submiting tapped message on all cases
-// When send_streamed_msg_on_configured_size_ is True and two read events
+// Verify the full streaming flow for submiting tapped message on all cases.
+// When send_streamed_msg_on_configured_size_ is True and two read events.
+// and submitted because aged duration is reached threshold.
 TEST_F(PerSocketTapperImplTest, StreamingFlowWhenSendStreamedMsgIsTrueTwoReadEvents) {
   // Keep the original value.
   bool local_output_conn_info_per_event = output_conn_info_per_event_;
@@ -492,9 +497,9 @@ TEST_F(PerSocketTapperImplTest, StreamingFlowWhenSendStreamedMsgIsTrueTwoReadEve
   bool local_send_streamed_msg_on_configured_size_ = send_streamed_msg_on_configured_size_;
   send_streamed_msg_on_configured_size_ = true;
   bool local_default_min_buffered_bytes = default_min_buffered_bytes_;
-  default_min_buffered_bytes_ = 100;
+  default_min_buffered_bytes_ = 120;
 
-  // Submit when the transport socket is created
+  // Submit when the transport socket is created.
   EXPECT_CALL(*sink_manager_, submitTrace_(TraceEqual(
                                   R"EOF(
 socket_streamed_trace_segment:
@@ -513,7 +518,7 @@ socket_streamed_trace_segment:
 
   InSequence s;
 
-  // Submit when the transport socket is gotten read event
+  // Store the read event.
   EXPECT_CALL(*sink_manager_, submitTrace_(TraceEqual(
                                   R"EOF(
 socket_streamed_trace_segment:
@@ -533,7 +538,7 @@ socket_streamed_trace_segment:
           socket_address:
             address: 10.0.0.3
             port_value: 50000
-    - timestamp: 1970-01-01T00:00:01Z
+    - timestamp: 1970-01-01T00:00:15Z
       read:
         data:
           as_bytes: VGVzdCB0cmFuc3BvcnQgc29ja2V0IHRhcCBidWZmZXJlZCBkYXRhIG9uUmVhZCBzdWJtaXQ=
@@ -548,10 +553,10 @@ socket_streamed_trace_segment:
             port_value: 50000
 )EOF")));
   tapper_->onRead(Buffer::OwnedImpl("Test transport socket tap buffered data onRead submit"), 53);
-  time_system_.setSystemTime(std::chrono::seconds(1));
+  time_system_.setSystemTime(std::chrono::seconds(15));
   tapper_->onRead(Buffer::OwnedImpl("Test transport socket tap buffered data onRead submit"), 53);
 
-  // Submit when the transport socket is gotten close event
+  // Submit when the transport socket is gotten close event.
   EXPECT_CALL(*sink_manager_, submitTrace_(TraceEqual(
                                   R"EOF(
 socket_streamed_trace_segment:
@@ -573,7 +578,125 @@ socket_streamed_trace_segment:
   time_system_.setSystemTime(std::chrono::seconds(2));
   tapper_->closeSocket(Network::ConnectionEvent::RemoteClose);
 
-  // Restore the value
+  // Restore the value.
+  output_conn_info_per_event_ = local_output_conn_info_per_event;
+  pegging_counter_ = local_pegging_counter;
+  send_streamed_msg_on_configured_size_ = local_send_streamed_msg_on_configured_size_;
+  default_min_buffered_bytes_ = local_default_min_buffered_bytes;
+}
+
+TEST_F(PerSocketTapperImplTest, StreamingFlowWhenSendStreamedMsgIsTrueOneReadSlice2) {
+  // Keep the original value.
+  bool local_output_conn_info_per_event = output_conn_info_per_event_;
+  output_conn_info_per_event_ = true;
+  bool local_pegging_counter = pegging_counter_;
+  pegging_counter_ = true;
+  bool local_send_streamed_msg_on_configured_size_ = send_streamed_msg_on_configured_size_;
+  send_streamed_msg_on_configured_size_ = true;
+  bool local_default_min_buffered_bytes = default_min_buffered_bytes_;
+  default_min_buffered_bytes_ = 16;
+
+  // Submit when the transport socket is created.
+  EXPECT_CALL(*sink_manager_, submitTrace_(TraceEqual(
+                                  R"EOF(
+socket_streamed_trace_segment:
+  trace_id: 1
+  connection:
+    local_address:
+      socket_address:
+        address: 127.0.0.1
+        port_value: 1000
+    remote_address:
+      socket_address:
+        address: 10.0.0.3
+        port_value: 50000
+)EOF")));
+  setup(true);
+
+  InSequence s;
+
+  // Store the read event.
+  EXPECT_CALL(*sink_manager_, submitTrace_(TraceEqual(
+                                  R"EOF(
+socket_streamed_trace_segment:
+  trace_id: 1
+  events:
+    events:
+    - timestamp: 1970-01-01T00:00:01Z
+      read:
+        data:
+          as_bytes: VGVzdFRyYW5zcG9ydFNvYw==
+      connection:
+        local_address:
+          socket_address:
+            address: 127.0.0.1
+            port_value: 1000
+        remote_address:
+          socket_address:
+            address: 10.0.0.3
+            port_value: 50000
+)EOF")));
+
+  EXPECT_CALL(*sink_manager_, submitTrace_(TraceEqual(
+                                  R"EOF(
+socket_streamed_trace_segment:
+  trace_id: 1
+  events:
+    events:
+    - timestamp: 1970-01-01T00:00:01Z
+      read:
+        data:
+          as_bytes: a2V0VGFwQnVmZmVyZWREYQ==
+      connection:
+        local_address:
+          socket_address:
+            address: 127.0.0.1
+            port_value: 1000
+        remote_address:
+          socket_address:
+            address: 10.0.0.3
+            port_value: 50000
+)EOF")));
+
+  time_system_.setSystemTime(std::chrono::seconds(1));
+  tapper_->onRead(Buffer::OwnedImpl("TestTransportSocketTapBufferedDataonReadSubmit"), 46);
+
+  // Submit when the transport socket is gotten close event.
+  EXPECT_CALL(*sink_manager_, submitTrace_(TraceEqual(
+                                  R"EOF(
+socket_streamed_trace_segment:
+  trace_id: 1
+  events:
+    events:
+    - timestamp: 1970-01-01T00:00:01Z
+      read:
+        data:
+          as_bytes: dGFvblJlYWRTdWJtaXQ=
+      connection:
+        local_address:
+          socket_address:
+            address: 127.0.0.1
+            port_value: 1000
+        remote_address:
+          socket_address:
+            address: 10.0.0.3
+            port_value: 50000
+    - timestamp: 1970-01-01T00:00:02Z
+      closed: {}
+      connection:
+        local_address:
+          socket_address:
+            address: 127.0.0.1
+            port_value: 1000
+        remote_address:
+          socket_address:
+            address: 10.0.0.3
+            port_value: 50000
+)EOF")));
+  time_system_.setSystemTime(std::chrono::seconds(2));
+  tapper_->closeSocket(Network::ConnectionEvent::RemoteClose);
+
+  // Restore the value.
   output_conn_info_per_event_ = local_output_conn_info_per_event;
   pegging_counter_ = local_pegging_counter;
   send_streamed_msg_on_configured_size_ = local_send_streamed_msg_on_configured_size_;
@@ -591,9 +714,9 @@ TEST_F(PerSocketTapperImplTest, StreamingFlowWhenSendStreamedMsgIsTruetwoWriteEv
   bool local_send_streamed_msg_on_configured_size_ = send_streamed_msg_on_configured_size_;
   send_streamed_msg_on_configured_size_ = true;
   bool local_default_min_buffered_bytes = default_min_buffered_bytes_;
-  default_min_buffered_bytes_ = 100;
+  default_min_buffered_bytes_ = 120;
 
-  // Submit when the transport socket is created
+  // Submit when the transport socket is created.
   EXPECT_CALL(*sink_manager_, submitTrace_(TraceEqual(
                                   R"EOF(
 socket_streamed_trace_segment:
@@ -612,7 +735,7 @@ socket_streamed_trace_segment:
 
   InSequence s;
 
-  // Submit when the transport socket is gotten write event
+  // Submit when the aged duration is equal 12.
   EXPECT_CALL(*sink_manager_, submitTrace_(TraceEqual(
                                   R"EOF(
 socket_streamed_trace_segment:
@@ -633,7 +756,7 @@ socket_streamed_trace_segment:
           socket_address:
             address: 10.0.0.3
             port_value: 50000
-    - timestamp: 1970-01-01T00:00:01Z
+    - timestamp: 1970-01-01T00:00:12Z
       write:
         data:
           as_bytes: VGVzdCB0cmFuc3BvcnQgc29ja2V0IHRhcCBidWZmZXJlZCBkYXRhIG9uV3JpdGUgc3VibWl0
@@ -650,11 +773,12 @@ socket_streamed_trace_segment:
 )EOF")));
   tapper_->onWrite(Buffer::OwnedImpl("Test transport socket tap buffered data onWrite submit"), 54,
                    true);
-  time_system_.setSystemTime(std::chrono::seconds(1));
+  time_system_.setSystemTime(std::chrono::seconds(12));
+  tapper_->setStreamedBufferAgedDuration(12);
   tapper_->onWrite(Buffer::OwnedImpl("Test transport socket tap buffered data onWrite submit"), 54,
                    true);
 
-  // Submit when the transport socket is gotten close event
+  // Submit when the transport socket is gotten close event.
   EXPECT_CALL(*sink_manager_, submitTrace_(TraceEqual(
                                   R"EOF(
 socket_streamed_trace_segment:
@@ -676,7 +800,242 @@ socket_streamed_trace_segment:
   time_system_.setSystemTime(std::chrono::seconds(2));
   tapper_->closeSocket(Network::ConnectionEvent::RemoteClose);
 
-  // Restore the value
+  // Restore the value.
+  output_conn_info_per_event_ = local_output_conn_info_per_event;
+  pegging_counter_ = local_pegging_counter;
+  send_streamed_msg_on_configured_size_ = local_send_streamed_msg_on_configured_size_;
+  default_min_buffered_bytes_ = local_default_min_buffered_bytes;
+}
+
+TEST_F(PerSocketTapperImplTest, StreamingFlowWhenSendStreamedMsgIsTrueOneWriteSlice3) {
+  // Keep the original value.
+  bool local_output_conn_info_per_event = output_conn_info_per_event_;
+  output_conn_info_per_event_ = true;
+  bool local_pegging_counter = pegging_counter_;
+  pegging_counter_ = true;
+  bool local_send_streamed_msg_on_configured_size_ = send_streamed_msg_on_configured_size_;
+  send_streamed_msg_on_configured_size_ = true;
+  bool local_default_min_buffered_bytes = default_min_buffered_bytes_;
+  default_min_buffered_bytes_ = 13;
+
+  // Submit when the transport socket is created.
+  EXPECT_CALL(*sink_manager_, submitTrace_(TraceEqual(
+                                  R"EOF(
+socket_streamed_trace_segment:
+  trace_id: 1
+  connection:
+    local_address:
+      socket_address:
+        address: 127.0.0.1
+        port_value: 1000
+    remote_address:
+      socket_address:
+        address: 10.0.0.3
+        port_value: 50000
+)EOF")));
+  setup(true);
+
+  InSequence s;
+  // Store the write event.
+  EXPECT_CALL(*sink_manager_, submitTrace_(TraceEqual(
+                                  R"EOF(
+socket_streamed_trace_segment:
+  trace_id: 1
+  events:
+    events:
+    - timestamp: 1970-01-01T00:00:01Z
+      write:
+        data:
+          as_bytes: VGVzdFRyYW5zcG9ydA==
+        end_stream: true
+      connection:
+        local_address:
+          socket_address:
+            address: 127.0.0.1
+            port_value: 1000
+        remote_address:
+          socket_address:
+            address: 10.0.0.3
+            port_value: 50000
+)EOF")));
+
+  EXPECT_CALL(*sink_manager_, submitTrace_(TraceEqual(
+                                  R"EOF(
+socket_streamed_trace_segment:
+  trace_id: 1
+  events:
+    events:
+    - timestamp: 1970-01-01T00:00:01Z
+      write:
+        data:
+          as_bytes: U29ja2V0VGFwQnVmZg==
+        end_stream: true
+      connection:
+        local_address:
+          socket_address:
+            address: 127.0.0.1
+            port_value: 1000
+        remote_address:
+          socket_address:
+            address: 10.0.0.3
+            port_value: 50000
+)EOF")));
+
+  EXPECT_CALL(*sink_manager_, submitTrace_(TraceEqual(
+                                  R"EOF(
+socket_streamed_trace_segment:
+  trace_id: 1
+  events:
+    events:
+    - timestamp: 1970-01-01T00:00:01Z
+      write:
+        data:
+          as_bytes: ZXJlZERhdGFvbldyaQ==
+        end_stream: true
+      connection:
+        local_address:
+          socket_address:
+            address: 127.0.0.1
+            port_value: 1000
+        remote_address:
+          socket_address:
+            address: 10.0.0.3
+            port_value: 50000
+)EOF")));
+
+  time_system_.setSystemTime(std::chrono::seconds(1));
+  tapper_->onWrite(Buffer::OwnedImpl("TestTransportSocketTapBufferedDataonWriteSubmit"), 47, true);
+  // Submit when the transport socket is gotten close event
+  EXPECT_CALL(*sink_manager_, submitTrace_(TraceEqual(
+                                  R"EOF(
+socket_streamed_trace_segment:
+  trace_id: 1
+  events:
+    events:
+    - timestamp: 1970-01-01T00:00:01Z
+      write:
+        data:
+          as_bytes: dGVTdWJtaXQ=
+        end_stream: true
+      connection:
+        local_address:
+          socket_address:
+            address: 127.0.0.1
+            port_value: 1000
+        remote_address:
+          socket_address:
+            address: 10.0.0.3
+            port_value: 50000
+    - timestamp: 1970-01-01T00:00:02Z
+      closed: {}
+      connection:
+        local_address:
+          socket_address:
+            address: 127.0.0.1
+            port_value: 1000
+        remote_address:
+          socket_address:
+            address: 10.0.0.3
+            port_value: 50000
+)EOF")));
+  time_system_.setSystemTime(std::chrono::seconds(2));
+  tapper_->closeSocket(Network::ConnectionEvent::RemoteClose);
+
+  // Restore the value.
+  output_conn_info_per_event_ = local_output_conn_info_per_event;
+  pegging_counter_ = local_pegging_counter;
+  send_streamed_msg_on_configured_size_ = local_send_streamed_msg_on_configured_size_;
+  default_min_buffered_bytes_ = local_default_min_buffered_bytes;
+}
+
+// All data are submitted in close event
+TEST_F(PerSocketTapperImplTest, StreamingFlowWhenSendStreamedMsgIsTrueInCloseEvents) {
+  // Keep the original value.
+  bool local_output_conn_info_per_event = output_conn_info_per_event_;
+  output_conn_info_per_event_ = true;
+  bool local_pegging_counter = pegging_counter_;
+  pegging_counter_ = true;
+  bool local_send_streamed_msg_on_configured_size_ = send_streamed_msg_on_configured_size_;
+  send_streamed_msg_on_configured_size_ = true;
+  bool local_default_min_buffered_bytes = default_min_buffered_bytes_;
+  default_min_buffered_bytes_ = 128;
+
+  // Submit when the transport socket is created.
+  EXPECT_CALL(*sink_manager_, submitTrace_(TraceEqual(
+                                  R"EOF(
+socket_streamed_trace_segment:
+  trace_id: 1
+  connection:
+    local_address:
+      socket_address:
+        address: 127.0.0.1
+        port_value: 1000
+    remote_address:
+      socket_address:
+        address: 10.0.0.3
+        port_value: 50000
+)EOF")));
+  setup(true);
+
+  InSequence s;
+
+  time_system_.setSystemTime(std::chrono::seconds(1));
+  EXPECT_CALL(*sink_manager_, submitTrace_(TraceEqual(
+                                  R"EOF(
+socket_streamed_trace_segment:
+  trace_id: 1
+  events:
+    events:
+    - timestamp: 1970-01-01T00:00:01Z
+      read:
+        data:
+          as_bytes: VGVzdCB0cmFuc3BvcnQgc29ja2V0IHRhcCBidWZmZXJlZCBkYXRhIG9uUmVhZCBzdWJtaXQ=
+
+      connection:
+        local_address:
+          socket_address:
+            address: 127.0.0.1
+            port_value: 1000
+        remote_address:
+          socket_address:
+            address: 10.0.0.3
+            port_value: 50000
+    - timestamp: 1970-01-01T00:00:02Z
+      write:
+        data:
+          as_bytes: VGVzdCB0cmFuc3BvcnQgc29ja2V0IHRhcCBidWZmZXJlZCBkYXRhIG9uV3JpdGUgc3VibWl0
+
+        end_stream: true
+      connection:
+        local_address:
+          socket_address:
+            address: 127.0.0.1
+            port_value: 1000
+        remote_address:
+          socket_address:
+            address: 10.0.0.3
+            port_value: 50000
+    - timestamp: 1970-01-01T00:00:03Z
+      closed: {}
+      connection:
+        local_address:
+          socket_address:
+            address: 127.0.0.1
+            port_value: 1000
+        remote_address:
+          socket_address:
+            address: 10.0.0.3
+            port_value: 50000
+)EOF")));
+  tapper_->onRead(Buffer::OwnedImpl("Test transport socket tap buffered data onRead submit"), 53);
+  time_system_.setSystemTime(std::chrono::seconds(2));
+  tapper_->onWrite(Buffer::OwnedImpl("Test transport socket tap buffered data onWrite submit"), 54,
+                   true);
+
+  time_system_.setSystemTime(std::chrono::seconds(3));
+  tapper_->closeSocket(Network::ConnectionEvent::RemoteClose);
+
+  // Restore the value.
   output_conn_info_per_event_ = local_output_conn_info_per_event;
   pegging_counter_ = local_pegging_counter;
   send_streamed_msg_on_configured_size_ = local_send_streamed_msg_on_configured_size_;


### PR DESCRIPTION

Commit Message:Submit captured transport streamed trace data as smoothly as possible with the configured chunk size
Additional Description:
After PR [35940](https://github.com/envoyproxy/envoy/pull/39540), found:
1) Tapped data isn't even, tapped packet like, 5K, 4K, 40K, 5K, in fact, the configured size is 4K
2) Configured size is 4K, the sent out packet is far bigger than 4K
3) if traffic is low, before closing TCP connection, the less thank 4K data isn't sent in time
Therefore, in this PR, enhance all above and let traced data submitted as smoothly as possible with the configured chunk size
Risk Level: low
Testing: done load and UT test
Docs Changes: done
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
