### PR TITLE
proto-hash: validate that Any unpacking is successful

### DIFF
--- a/source/common/protobuf/deterministic_hash.cc
+++ b/source/common/protobuf/deterministic_hash.cc
@@ -189,7 +189,9 @@ std::unique_ptr<Protobuf::Message> unpackAnyForReflection(const ProtobufWkt::Any
       Protobuf::MessageFactory::generated_factory()->GetPrototype(descriptor);
   ASSERT(prototype != nullptr, "should be impossible since the descriptor is known");
   std::unique_ptr<Protobuf::Message> msg(prototype->New());
-  any.UnpackTo(msg.get());
+  if (!any.UnpackTo(msg.get())) {
+    return nullptr;
+  }
   return msg;
 }
 

--- a/test/common/protobuf/deterministic_hash_test.cc
+++ b/test/common/protobuf/deterministic_hash_test.cc
@@ -499,5 +499,20 @@ TEST(HashTest, AnyWithKnownTypeMismatch) {
   EXPECT_NE(hash(a1), hash(a2));
 }
 
+TEST(HashTest, ValidateRepeatedAnyMismatchingType) {
+  deterministichashtest::AnyContainer a1, a2;
+  deterministichashtest::Recursion value;
+  value.set_index(1);
+  a1.mutable_any()->PackFrom(value);
+  a2.mutable_any()->PackFrom(value);
+  // Set a2 Any to a mismatching invalid type.
+  a2.mutable_any()->set_type_url("RawMessage");
+  EXPECT_NE(hash(a1), hash(a2));
+
+  // Set a2 Any to a mismatching valid type.
+  a2.mutable_any()->set_type_url("google.protobuf.Struct");
+  EXPECT_NE(hash(a1), hash(a2));
+}
+
 } // namespace DeterministicProtoHash
 } // namespace Envoy

--- a/test/common/protobuf/deterministic_hash_test.proto
+++ b/test/common/protobuf/deterministic_hash_test.proto
@@ -36,6 +36,7 @@ message RepeatedFields {
   repeated float floats = 9;
   repeated FooEnum enums = 10;
   repeated Recursion messages = 11;
+  repeated AnyContainer anys = 12;
 };
 
 message SingleFields {


### PR DESCRIPTION
Commit Message: proto-hash: validate that Any unpacking is successful
Additional Description:
This PR adds a protobuf Any unpacking validation for the deteriminstic-hash for protos function.

Risk Level: low
Testing: Added unit tests.
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A