### PR TITLE
Change `ClientSideWeightedRoundRobinLoadBalancer::WorkerLocalLbFactory::applyWeightsToAllWorkers()` to iterate over priorities on the thread local worker's priority set.

### DIFF
--- a/source/extensions/load_balancing_policies/client_side_weighted_round_robin/client_side_weighted_round_robin_lb.cc
+++ b/source/extensions/load_balancing_policies/client_side_weighted_round_robin/client_side_weighted_round_robin_lb.cc
@@ -63,8 +63,14 @@ ClientSideWeightedRoundRobinLoadBalancer::WorkerLocalLb::WorkerLocalLb(
                                  common_config, healthy_panic_threshold, 100, 50),
                              getRoundRobinConfig(common_config), time_source) {
   if (tls_shim.has_value()) {
-    apply_weights_cb_handle_ = tls_shim->apply_weights_cb_helper_.add([this](uint32_t priority) {
-      refresh(priority);
+    apply_weights_cb_handle_ = tls_shim->apply_weights_cb_helper_.add([this]() {
+      // Refresh the EDF scheduler on the hosts in priority set of the
+      // worker-local load balancer on the worker thread.
+      for (const HostSetPtr& host_set : priority_set_.hostSetsPerPriority()) {
+        if (host_set != nullptr) {
+          refresh(host_set->priority());
+        }
+      }
       return absl::OkStatus();
     });
   }
@@ -84,11 +90,14 @@ void ClientSideWeightedRoundRobinLoadBalancer::initFromConfig(
 
 void ClientSideWeightedRoundRobinLoadBalancer::updateWeightsOnMainThread() {
   ENVOY_LOG(trace, "updateWeightsOnMainThread");
+  bool updated = false;
+  // Update weights on hosts in priority set of the thread aware load balancer
+  // on the main thread.
   for (const HostSetPtr& host_set : priority_set_.hostSetsPerPriority()) {
-    if (updateWeightsOnHosts(host_set->hosts())) {
-      // If weights have changed, then apply them to all workers.
-      factory_->applyWeightsToAllWorkers(host_set->priority());
-    }
+    updated = updateWeightsOnHosts(host_set->hosts()) || updated;
+  }
+  if (updated) {
+    factory_->applyWeightsToAllWorkers();
   }
 }
 
@@ -254,11 +263,10 @@ Upstream::LoadBalancerPtr ClientSideWeightedRoundRobinLoadBalancer::WorkerLocalL
       cluster_info_.lbConfig(), time_source_, tls_->get());
 }
 
-void ClientSideWeightedRoundRobinLoadBalancer::WorkerLocalLbFactory::applyWeightsToAllWorkers(
-    uint32_t priority) {
-  tls_->runOnAllThreads([priority](OptRef<ThreadLocalShim> tls_shim) -> void {
+void ClientSideWeightedRoundRobinLoadBalancer::WorkerLocalLbFactory::applyWeightsToAllWorkers() {
+  tls_->runOnAllThreads([](OptRef<ThreadLocalShim> tls_shim) -> void {
     if (tls_shim.has_value()) {
-      auto status = tls_shim->apply_weights_cb_helper_.runCallbacks(priority);
+      auto status = tls_shim->apply_weights_cb_helper_.runCallbacks();
     }
   });
 }

--- a/source/extensions/load_balancing_policies/client_side_weighted_round_robin/client_side_weighted_round_robin_lb.h
+++ b/source/extensions/load_balancing_policies/client_side_weighted_round_robin/client_side_weighted_round_robin_lb.h
@@ -138,7 +138,7 @@ public:
   // Thread local shim to store callbacks for weight updates of worker local lb.
   class ThreadLocalShim : public Envoy::ThreadLocal::ThreadLocalObject {
   public:
-    Common::CallbackManager<uint32_t> apply_weights_cb_helper_;
+    Common::CallbackManager<> apply_weights_cb_helper_;
   };
 
   // This class is used to handle the load balancing on the worker thread.
@@ -171,7 +171,7 @@ public:
 
     bool recreateOnHostChange() const override { return false; }
 
-    void applyWeightsToAllWorkers(uint32_t priority);
+    void applyWeightsToAllWorkers();
 
     std::unique_ptr<Envoy::ThreadLocal::TypedSlot<ThreadLocalShim>> tls_;
 


### PR DESCRIPTION
- If the passed `priority` is >= the number of priorities in `EdfLoadBalancerBase::priority_set_`, the code tries to access an element out of bounds in `EdfLoadBalancerBase::refresh(uint32_t priority)`.
- The issue is that thread aware load balancer and thread local worker load balancers reference different instances of `PrioritySet` which are updated asynchronously after receiving EDS updates, so thread aware load balancer's priority set might have more priorities than the worker's.
- Added `ClientSideWeightedRoundRobinEdsIntegrationTest` reproduces the issue and verifies the fix.

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
