### PR TITLE
docs: address the stale docs for network_namespace_filepath

### DIFF
--- a/api/envoy/config/core/v3/address.proto
+++ b/api/envoy/config/core/v3/address.proto
@@ -105,9 +105,6 @@ message SocketAddress {
   // .. note::
   //    Setting this parameter requires Envoy to run with the ``CAP_NET_ADMIN`` capability.
   //
-  // .. note::
-  //    Currently only used for Listener sockets.
-  //
   // .. attention::
   //     Network namespaces are only configurable on Linux. Otherwise, this field has no effect.
   string network_namespace_filepath = 7;


### PR DESCRIPTION
## Description

This PR address the stale docs on `network_namespace_filepath` which says that it could only be done on the listener socket which is no longer true as we have merged the change to have the same for upstream as well.

---

**Commit Message:** docs: address the stale docs for network_namespace_filepath
**Additional Description:** Fix the SocketAddress docs around network_namespace_filepath.
**Risk Level:** Low
**Testing:** CI
**Docs Changes:** N/A
**Release Notes:** N/A