### PR TITLE
docs: fix typo in the protocol docs (rage => range)

### DIFF
--- a/api/envoy/config/core/v3/protocol.proto
+++ b/api/envoy/config/core/v3/protocol.proto
@@ -77,7 +77,7 @@ message QuicProtocolOptions {
       [(validate.rules).uint32 = {lte: 16777216 gte: 1}];
 
   // Similar to ``initial_stream_window_size``, but for connection-level
-  // flow-control. Valid values rage from 1 to 25165824 (24MB, maximum supported by QUICHE) and defaults
+  // flow-control. Valid values range from 1 to 25165824 (24MB, maximum supported by QUICHE) and defaults
   // to 25165824 (24 * 1024 * 1024).
   //
   // .. note::


### PR DESCRIPTION
## Description

This PR fixes a typo in the protocol docs. We misspelled range as "rage".

---

**Commit Message:** docs: fix typo in the protocol docs (rage => range)
**Additional Description:** Fixes a typo in the protocol docs. We misspelled range as "rage.
**Risk Level:** N/A
**Testing:** CI
**Docs Changes:** N/A
**Release Notes:** N/A