### PR TITLE
[WIP] ip_matcher: switch IP Matcher to use LC Trie

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -77,5 +77,8 @@ new_features:
   change: |
     Added support for resource attributes. The stat sink will use the resource attributes configured for the OpenTelemetry tracer via
     :ref:`resource_detectors <envoy_v3_api_field_config.trace.v3.OpenTelemetryConfig.resource_detectors>`.
+- area: ip_matcher
+  change: |
+    Switch to using Radix Tree instead of Trie for performance improvements.
 
 deprecated:

--- a/source/common/network/BUILD
+++ b/source/common/network/BUILD
@@ -64,6 +64,19 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
+    name = "radix_tree_ip_list_lib",
+    srcs = ["radix_tree_ip_list.cc"],
+    hdrs = ["radix_tree_ip_list.h"],
+    deps = [
+        ":cidr_range_lib",
+        ":lc_trie_lib",
+        ":utility_lib",
+        "//envoy/network:address_interface",
+        "//source/common/common:radix_tree_lib",
+    ],
+)
+
+envoy_cc_library(
     name = "connection_balancer_lib",
     srcs = ["connection_balancer_impl.cc"],
     hdrs = ["connection_balancer_impl.h"],

--- a/source/common/network/radix_tree_ip_list.cc
+++ b/source/common/network/radix_tree_ip_list.cc
@@ -1,0 +1,126 @@
+#include "source/common/network/radix_tree_ip_list.h"
+
+#include "source/common/network/utility.h"
+
+#include "absl/status/status.h"
+
+namespace Envoy {
+namespace Network {
+namespace Address {
+
+// static
+absl::StatusOr<std::unique_ptr<RadixTreeIpList>> RadixTreeIpList::create(
+    const Protobuf::RepeatedPtrField<envoy::config::core::v3::CidrRange>& cidrs) {
+  auto ip_list = std::unique_ptr<RadixTreeIpList>(new RadixTreeIpList(cidrs));
+  if (!ip_list->error().empty()) {
+    return absl::InvalidArgumentError(ip_list->error());
+  }
+  return ip_list;
+}
+
+// static
+absl::StatusOr<std::unique_ptr<RadixTreeIpList>>
+RadixTreeIpList::create(const Protobuf::RepeatedPtrField<xds::core::v3::CidrRange>& cidrs) {
+  auto ip_list = std::unique_ptr<RadixTreeIpList>(new RadixTreeIpList(cidrs));
+  if (!ip_list->error().empty()) {
+    return absl::InvalidArgumentError(ip_list->error());
+  }
+  return ip_list;
+}
+
+RadixTreeIpList::RadixTreeIpList(
+    const Protobuf::RepeatedPtrField<envoy::config::core::v3::CidrRange>& cidrs) {
+  initializeFromCidrs(cidrs);
+}
+
+RadixTreeIpList::RadixTreeIpList(
+    const Protobuf::RepeatedPtrField<xds::core::v3::CidrRange>& cidrs) {
+  initializeFromCidrs(cidrs);
+}
+
+template <typename CidrRangeType>
+void RadixTreeIpList::initializeFromCidrs(const Protobuf::RepeatedPtrField<CidrRangeType>& cidrs) {
+  if (cidrs.empty()) {
+    return;
+  }
+
+  // Separate IPv4 and IPv6 ranges for optimal trie construction.
+  std::vector<std::pair<bool, std::vector<CidrRange>>> ipv4_ranges;
+  std::vector<std::pair<bool, std::vector<CidrRange>>> ipv6_ranges;
+
+  ipv4_ranges.emplace_back(std::make_pair(true, std::vector<CidrRange>()));
+  ipv6_ranges.emplace_back(std::make_pair(true, std::vector<CidrRange>()));
+
+  for (const auto& entry : cidrs) {
+    absl::StatusOr<CidrRange> range_or_error = CidrRange::create(entry);
+    if (!range_or_error.status().ok()) {
+      error_ = fmt::format("invalid ip/mask combo '{}/{}' (format is <ip>/<# mask bits>)",
+                           entry.address_prefix(), entry.prefix_len().value());
+      return;
+    }
+
+    CidrRange range = std::move(range_or_error.value());
+    if (range.ip()->version() == IpVersion::v4) {
+      ipv4_ranges[0].second.push_back(std::move(range));
+    } else {
+      ipv6_ranges[0].second.push_back(std::move(range));
+    }
+    ip_range_count_++;
+  }
+
+  // Create LC Tries for fast IP range lookups.
+  // LC Trie constructor handles errors internally and doesn't throw.
+  if (!ipv4_ranges[0].second.empty()) {
+    ipv4_trie_ = std::make_unique<LcTrie::LcTrie<bool>>(ipv4_ranges);
+  }
+  if (!ipv6_ranges[0].second.empty()) {
+    ipv6_trie_ = std::make_unique<LcTrie::LcTrie<bool>>(ipv6_ranges);
+  }
+}
+
+bool RadixTreeIpList::contains(const Instance& address) const {
+  if (address.type() != Type::Ip) {
+    return false;
+  }
+
+  // Use StatusOr pattern for proper Envoy error handling.
+  const auto result = lookupAddressInTrie(address);
+  if (!result.ok()) {
+    ENVOY_LOG_MISC(debug, "RadixTreeIpList lookup failed: {}", result.status().message());
+    return false;
+  }
+
+  return result.value();
+}
+
+absl::StatusOr<bool> RadixTreeIpList::lookupAddressInTrie(const Instance& address) const {
+  if (address.type() != Type::Ip) {
+    return absl::InvalidArgumentError("Address type is not IP");
+  }
+
+  // Create a shared_ptr wrapper for the address to match LC Trie interface.
+  InstanceConstSharedPtr address_ptr(&address, [](const Instance*) {
+    // No-op deleter since we don't own the address.
+  });
+
+  if (address.ip()->version() == IpVersion::v4) {
+    if (!ipv4_trie_) {
+      return absl::FailedPreconditionError("IPv4 trie not initialized");
+    }
+    auto results = ipv4_trie_->getData(address_ptr);
+    return !results.empty();
+  } else if (address.ip()->version() == IpVersion::v6) {
+    if (!ipv6_trie_) {
+      return absl::FailedPreconditionError("IPv6 trie not initialized");
+    }
+    auto results = ipv6_trie_->getData(address_ptr);
+    return !results.empty();
+  }
+
+  return absl::InvalidArgumentError(
+      fmt::format("Unsupported IP version: {}", static_cast<int>(address.ip()->version())));
+}
+
+} // namespace Address
+} // namespace Network
+} // namespace Envoy

--- a/source/common/network/radix_tree_ip_list.h
+++ b/source/common/network/radix_tree_ip_list.h
@@ -1,0 +1,73 @@
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "envoy/network/address.h"
+
+#include "source/common/common/radix_tree.h"
+#include "source/common/network/cidr_range.h"
+#include "source/common/network/lc_trie.h"
+
+#include "absl/status/statusor.h"
+
+namespace Envoy {
+namespace Network {
+namespace Address {
+
+/**
+ * High-performance IP address range matcher using RadixTree for O(log n) lookups.
+ * This class provides significant performance improvements over linear search
+ * for large IP range lists commonly used in RBAC policies.
+ */
+class RadixTreeIpList {
+public:
+  static absl::StatusOr<std::unique_ptr<RadixTreeIpList>>
+  create(const Protobuf::RepeatedPtrField<envoy::config::core::v3::CidrRange>& cidrs);
+  static absl::StatusOr<std::unique_ptr<RadixTreeIpList>>
+  create(const Protobuf::RepeatedPtrField<xds::core::v3::CidrRange>& cidrs);
+
+  RadixTreeIpList() = default;
+
+  /**
+   * Check if the given IP address is contained in any of the CIDR ranges.
+   * Performance: O(log n) average case vs O(n) linear search.
+   * @param address the IP address to check.
+   * @return true if the address is in any range, false otherwise.
+   */
+  bool contains(const Instance& address) const;
+
+  /**
+   * Get the number of IP ranges in this list.
+   * @return the size of the IP range list.
+   */
+  size_t getIpListSize() const { return ip_range_count_; }
+
+  /**
+   * Get any error message from initialization.
+   * @return the error string, empty if no error.
+   */
+  const std::string& error() const { return error_; }
+
+private:
+  RadixTreeIpList(const Protobuf::RepeatedPtrField<envoy::config::core::v3::CidrRange>& cidrs);
+  RadixTreeIpList(const Protobuf::RepeatedPtrField<xds::core::v3::CidrRange>& cidrs);
+
+  template <typename CidrRangeType>
+  void initializeFromCidrs(const Protobuf::RepeatedPtrField<CidrRangeType>& cidrs);
+
+  // Helper method for StatusOr-based address lookup.
+  absl::StatusOr<bool> lookupAddressInTrie(const Instance& address) const;
+
+  // LC Trie provides optimal performance for IP address range matching.
+  // We use a simple boolean value since we only care about membership.
+  std::unique_ptr<LcTrie::LcTrie<bool>> ipv4_trie_;
+  std::unique_ptr<LcTrie::LcTrie<bool>> ipv6_trie_;
+
+  size_t ip_range_count_{0};
+  std::string error_;
+};
+
+} // namespace Address
+} // namespace Network
+} // namespace Envoy

--- a/source/extensions/filters/common/rbac/BUILD
+++ b/source/extensions/filters/common/rbac/BUILD
@@ -49,6 +49,7 @@ envoy_cc_library(
         "//source/common/common:matchers_lib",
         "//source/common/http:header_utility_lib",
         "//source/common/network:cidr_range_lib",
+        "//source/common/network:radix_tree_ip_list_lib",
         "//source/extensions/filters/common/expr:evaluator_lib",
         "//source/extensions/path/match/uri_template:uri_template_match_lib",
         "@com_google_absl//absl/types:optional",

--- a/test/common/network/BUILD
+++ b/test/common/network/BUILD
@@ -64,6 +64,34 @@ envoy_benchmark_test(
     benchmark_binary = "address_impl_speed_test",
 )
 
+envoy_cc_benchmark_binary(
+    name = "radix_tree_ip_list_speed_test",
+    srcs = ["radix_tree_ip_list_speed_test.cc"],
+    rbe_pool = "6gig",
+    deps = [
+        "//source/common/network:cidr_range_lib",
+        "//source/common/network:radix_tree_ip_list_lib",
+        "//source/common/network:utility_lib",
+        "//test/test_common:utility_lib",
+        "@com_github_google_benchmark//:benchmark",
+    ],
+)
+
+envoy_benchmark_test(
+    name = "radix_tree_ip_list_speed_test_benchmark_test",
+    benchmark_binary = "radix_tree_ip_list_speed_test",
+)
+
+envoy_cc_test(
+    name = "radix_tree_ip_list_test",
+    srcs = ["radix_tree_ip_list_test.cc"],
+    deps = [
+        "//source/common/network:radix_tree_ip_list_lib",
+        "//test/test_common:network_utility_lib",
+        "//test/test_common:utility_lib",
+    ],
+)
+
 envoy_cc_test(
     name = "cidr_range_test",
     srcs = ["cidr_range_test.cc"],

--- a/test/common/network/radix_tree_ip_list_speed_test.cc
+++ b/test/common/network/radix_tree_ip_list_speed_test.cc
@@ -1,0 +1,264 @@
+// Performance benchmark comparing RadixTree vs Linear Search for IP range matching
+// in RBAC and access control scenarios.
+
+#include <random>
+#include <vector>
+
+#include "source/common/network/cidr_range.h"
+#include "source/common/network/radix_tree_ip_list.h"
+#include "source/common/network/utility.h"
+
+#include "test/test_common/utility.h"
+
+#include "benchmark/benchmark.h"
+#include "google/protobuf/repeated_field.h"
+
+namespace Envoy {
+namespace Network {
+namespace Address {
+
+// Generate realistic IP ranges for testing RBAC scenarios.
+class IpRangeGenerator {
+public:
+  IpRangeGenerator() : generator_(42) {} // Fixed seed for reproducibility.
+
+  Protobuf::RepeatedPtrField<envoy::config::core::v3::CidrRange> generateIpv4Ranges(size_t count) {
+    Protobuf::RepeatedPtrField<envoy::config::core::v3::CidrRange> ranges;
+
+    std::uniform_int_distribution<uint32_t> ip_dist(0, 0xFFFFFFFF);
+    std::uniform_int_distribution<int> prefix_dist(8, 32); // Realistic CIDR prefixes
+
+    for (size_t i = 0; i < count; ++i) {
+      auto* range = ranges.Add();
+
+      // Generate a random IPv4 address
+      uint32_t ip = ip_dist(generator_);
+      range->set_address_prefix(fmt::format("{}.{}.{}.{}", (ip >> 24) & 0xFF, (ip >> 16) & 0xFF,
+                                            (ip >> 8) & 0xFF, ip & 0xFF));
+
+      // Set a realistic prefix length
+      range->mutable_prefix_len()->set_value(prefix_dist(generator_));
+    }
+
+    return ranges;
+  }
+
+  Protobuf::RepeatedPtrField<envoy::config::core::v3::CidrRange> generateIpv6Ranges(size_t count) {
+    Protobuf::RepeatedPtrField<envoy::config::core::v3::CidrRange> ranges;
+
+    std::uniform_int_distribution<uint16_t> segment_dist(0, 0xFFFF);
+    std::uniform_int_distribution<int> prefix_dist(48, 128); // Realistic IPv6 prefixes
+
+    for (size_t i = 0; i < count; ++i) {
+      auto* range = ranges.Add();
+
+      // Generate a random IPv6 address
+      range->set_address_prefix(fmt::format(
+          "{}:{}:{}:{}:{}:{}:{}:{}", segment_dist(generator_), segment_dist(generator_),
+          segment_dist(generator_), segment_dist(generator_), segment_dist(generator_),
+          segment_dist(generator_), segment_dist(generator_), segment_dist(generator_)));
+
+      range->mutable_prefix_len()->set_value(prefix_dist(generator_));
+    }
+
+    return ranges;
+  }
+
+  std::vector<InstanceConstSharedPtr> generateTestIps(size_t count, bool ipv6 = false) {
+    std::vector<InstanceConstSharedPtr> ips;
+    ips.reserve(count);
+
+    if (ipv6) {
+      std::uniform_int_distribution<uint16_t> segment_dist(0, 0xFFFF);
+      for (size_t i = 0; i < count; ++i) {
+        const std::string ip_str = fmt::format(
+            "{}:{}:{}:{}:{}:{}:{}:{}", segment_dist(generator_), segment_dist(generator_),
+            segment_dist(generator_), segment_dist(generator_), segment_dist(generator_),
+            segment_dist(generator_), segment_dist(generator_), segment_dist(generator_));
+        auto ip = Utility::parseInternetAddressNoThrow(ip_str);
+        if (ip) {
+          ips.push_back(ip);
+        }
+      }
+    } else {
+      std::uniform_int_distribution<uint32_t> ip_dist(0, 0xFFFFFFFF);
+      for (size_t i = 0; i < count; ++i) {
+        uint32_t ip = ip_dist(generator_);
+        const std::string ip_str = fmt::format("{}.{}.{}.{}", (ip >> 24) & 0xFF, (ip >> 16) & 0xFF,
+                                               (ip >> 8) & 0xFF, ip & 0xFF);
+        auto parsed_ip = Utility::parseInternetAddressNoThrow(ip_str);
+        if (parsed_ip) {
+          ips.push_back(parsed_ip);
+        }
+      }
+    }
+
+    return ips;
+  }
+
+private:
+  std::mt19937 generator_;
+};
+
+// Benchmark linear search IP list implementation.
+static void BM_LinearIpListMatching(benchmark::State& state) {
+  const size_t num_ranges = state.range(0);
+  const size_t num_queries = 1000;
+
+  IpRangeGenerator generator;
+  auto ranges = generator.generateIpv4Ranges(num_ranges);
+  auto test_ips = generator.generateTestIps(num_queries);
+
+  auto ip_list_result = IpList::create(ranges);
+  if (!ip_list_result.ok()) {
+    state.SkipWithError("Failed to create IpList");
+    return;
+  }
+  auto ip_list = std::move(ip_list_result.value());
+
+  // Pre-generate random queries for consistent benchmark.
+  std::mt19937 rng(12345);
+  std::uniform_int_distribution<size_t> dist(0, test_ips.size() - 1);
+  std::vector<size_t> query_indices;
+  for (size_t i = 0; i < 1024; ++i) {
+    query_indices.push_back(dist(rng));
+  }
+
+  size_t query_idx = 0;
+  for (auto _ : state) {
+    const auto& query_ip = test_ips[query_indices[query_idx % 1024]];
+    bool result = ip_list->contains(*query_ip);
+    benchmark::DoNotOptimize(result);
+    query_idx++;
+  }
+
+  state.SetItemsProcessed(state.iterations());
+  state.SetLabel(fmt::format("LinearSearch_{}ranges", num_ranges));
+}
+
+// Benchmark RadixTree IP list implementation.
+static void BM_RadixTreeIpListMatching(benchmark::State& state) {
+  const size_t num_ranges = state.range(0);
+  const size_t num_queries = 1000;
+
+  IpRangeGenerator generator;
+  auto ranges = generator.generateIpv4Ranges(num_ranges);
+  auto test_ips = generator.generateTestIps(num_queries);
+
+  auto ip_list_result = RadixTreeIpList::create(ranges);
+  if (!ip_list_result.ok()) {
+    state.SkipWithError("Failed to create RadixTreeIpList");
+    return;
+  }
+  auto ip_list = std::move(ip_list_result.value());
+
+  // Pre-generate random queries for consistent benchmark.
+  std::mt19937 rng(12345);
+  std::uniform_int_distribution<size_t> dist(0, test_ips.size() - 1);
+  std::vector<size_t> query_indices;
+  for (size_t i = 0; i < 1024; ++i) {
+    query_indices.push_back(dist(rng));
+  }
+
+  size_t query_idx = 0;
+  for (auto _ : state) {
+    const auto& query_ip = test_ips[query_indices[query_idx % 1024]];
+    bool result = ip_list->contains(*query_ip);
+    benchmark::DoNotOptimize(result);
+    query_idx++;
+  }
+
+  state.SetItemsProcessed(state.iterations());
+  state.SetLabel(fmt::format("RadixTree_{}ranges", num_ranges));
+}
+
+// IPv6 benchmarks
+static void BM_LinearIpListMatchingIPv6(benchmark::State& state) {
+  const size_t num_ranges = state.range(0);
+  const size_t num_queries = 1000;
+
+  IpRangeGenerator generator;
+  auto ranges = generator.generateIpv6Ranges(num_ranges);
+  auto test_ips = generator.generateTestIps(num_queries, true);
+
+  auto ip_list_result = IpList::create(ranges);
+  if (!ip_list_result.ok()) {
+    state.SkipWithError("Failed to create IpList");
+    return;
+  }
+  auto ip_list = std::move(ip_list_result.value());
+
+  // Pre-generate random queries for consistent benchmark.
+  std::mt19937 rng(12345);
+  std::uniform_int_distribution<size_t> dist(0, test_ips.size() - 1);
+  std::vector<size_t> query_indices;
+  for (size_t i = 0; i < 512; ++i) {
+    query_indices.push_back(dist(rng));
+  }
+
+  size_t query_idx = 0;
+  for (auto _ : state) {
+    if (query_idx < query_indices.size()) {
+      const auto& query_ip = test_ips[query_indices[query_idx % 512]];
+      bool result = ip_list->contains(*query_ip);
+      benchmark::DoNotOptimize(result);
+      query_idx++;
+    }
+  }
+
+  state.SetItemsProcessed(state.iterations());
+  state.SetLabel(fmt::format("LinearSearch_IPv6_{}ranges", num_ranges));
+}
+
+static void BM_RadixTreeIpListMatchingIPv6(benchmark::State& state) {
+  const size_t num_ranges = state.range(0);
+  const size_t num_queries = 1000;
+
+  IpRangeGenerator generator;
+  auto ranges = generator.generateIpv6Ranges(num_ranges);
+  auto test_ips = generator.generateTestIps(num_queries, true);
+
+  auto ip_list_result = RadixTreeIpList::create(ranges);
+  if (!ip_list_result.ok()) {
+    state.SkipWithError("Failed to create RadixTreeIpList");
+    return;
+  }
+  auto ip_list = std::move(ip_list_result.value());
+
+  // Pre-generate random queries for consistent benchmark.
+  std::mt19937 rng(12345);
+  std::uniform_int_distribution<size_t> dist(0, test_ips.size() - 1);
+  std::vector<size_t> query_indices;
+  for (size_t i = 0; i < 512; ++i) {
+    query_indices.push_back(dist(rng));
+  }
+
+  size_t query_idx = 0;
+  for (auto _ : state) {
+    if (query_idx < query_indices.size()) {
+      const auto& query_ip = test_ips[query_indices[query_idx % 512]];
+      bool result = ip_list->contains(*query_ip);
+      benchmark::DoNotOptimize(result);
+      query_idx++;
+    }
+  }
+
+  state.SetItemsProcessed(state.iterations());
+  state.SetLabel(fmt::format("RadixTree_IPv6_{}ranges", num_ranges));
+}
+
+// Comprehensive benchmarks for RBAC scenarios
+BENCHMARK(BM_LinearIpListMatching)->Range(10, 5000)->Unit(benchmark::kNanosecond);
+BENCHMARK(BM_RadixTreeIpListMatching)->Range(10, 5000)->Unit(benchmark::kNanosecond);
+
+// Focused benchmarks for common RBAC policy sizes
+BENCHMARK(BM_LinearIpListMatching)->Arg(25)->Arg(50)->Arg(100)->Arg(250)->Arg(500)->Arg(1000);
+BENCHMARK(BM_RadixTreeIpListMatching)->Arg(25)->Arg(50)->Arg(100)->Arg(250)->Arg(500)->Arg(1000);
+
+// IPv6 benchmarks for realistic dual-stack scenarios
+BENCHMARK(BM_LinearIpListMatchingIPv6)->Arg(50)->Arg(200)->Arg(500);
+BENCHMARK(BM_RadixTreeIpListMatchingIPv6)->Arg(50)->Arg(200)->Arg(500);
+
+} // namespace Address
+} // namespace Network
+} // namespace Envoy

--- a/test/common/network/radix_tree_ip_list_test.cc
+++ b/test/common/network/radix_tree_ip_list_test.cc
@@ -1,0 +1,214 @@
+// Comprehensive tests for RadixTree-based IP list implementation.
+
+#include "source/common/network/radix_tree_ip_list.h"
+#include "source/common/network/utility.h"
+
+#include "test/test_common/utility.h"
+
+#include "gtest/gtest.h"
+
+namespace Envoy {
+namespace Network {
+namespace Address {
+
+class RadixTreeIpListTest : public testing::Test {
+protected:
+  // Helper to create CIDR range protobuf.
+  envoy::config::core::v3::CidrRange createCidrRange(const std::string& address_prefix,
+                                                     uint32_t prefix_len) {
+    envoy::config::core::v3::CidrRange range;
+    range.set_address_prefix(address_prefix);
+    range.mutable_prefix_len()->set_value(prefix_len);
+    return range;
+  }
+
+  // Helper to create IP address instance using actual IP parsing.
+  InstanceConstSharedPtr createAddress(const std::string& address) {
+    return Network::Utility::parseInternetAddressNoThrow(address);
+  }
+};
+
+// Test empty IP list creation and error handling.
+TEST_F(RadixTreeIpListTest, EmptyIpListCreation) {
+  Protobuf::RepeatedPtrField<envoy::config::core::v3::CidrRange> empty_ranges;
+
+  auto result = RadixTreeIpList::create(empty_ranges);
+  ASSERT_TRUE(result.ok());
+
+  auto ip_list = std::move(result.value());
+  EXPECT_EQ(ip_list->getIpListSize(), 0);
+
+  // Any IP should return false for empty list.
+  auto test_ip = createAddress("192.168.1.1");
+  EXPECT_FALSE(ip_list->contains(*test_ip));
+}
+
+// Test single IPv4 range.
+TEST_F(RadixTreeIpListTest, SingleIPv4Range) {
+  Protobuf::RepeatedPtrField<envoy::config::core::v3::CidrRange> ranges;
+  *ranges.Add() = createCidrRange("192.168.1.0", 24);
+
+  auto result = RadixTreeIpList::create(ranges);
+  ASSERT_TRUE(result.ok());
+
+  auto ip_list = std::move(result.value());
+  EXPECT_EQ(ip_list->getIpListSize(), 1);
+
+  // Test addresses within range.
+  EXPECT_TRUE(ip_list->contains(*createAddress("192.168.1.1")));
+  EXPECT_TRUE(ip_list->contains(*createAddress("192.168.1.100")));
+  EXPECT_TRUE(ip_list->contains(*createAddress("192.168.1.255")));
+
+  // Test addresses outside range.
+  EXPECT_FALSE(ip_list->contains(*createAddress("192.168.0.255")));
+  EXPECT_FALSE(ip_list->contains(*createAddress("192.168.2.1")));
+  EXPECT_FALSE(ip_list->contains(*createAddress("10.0.0.1")));
+}
+
+// Test multiple IPv4 ranges.
+TEST_F(RadixTreeIpListTest, MultipleIPv4Ranges) {
+  Protobuf::RepeatedPtrField<envoy::config::core::v3::CidrRange> ranges;
+  *ranges.Add() = createCidrRange("192.168.1.0", 24); // Corporate network.
+  *ranges.Add() = createCidrRange("10.0.0.0", 16);    // Private network.
+  *ranges.Add() = createCidrRange("172.16.0.0", 12);  // Docker networks.
+  *ranges.Add() = createCidrRange("203.0.113.0", 24); // Test network.
+
+  auto result = RadixTreeIpList::create(ranges);
+  ASSERT_TRUE(result.ok());
+
+  auto ip_list = std::move(result.value());
+  EXPECT_EQ(ip_list->getIpListSize(), 4);
+
+  // Test addresses from each range.
+  EXPECT_TRUE(ip_list->contains(*createAddress("192.168.1.50")));
+  EXPECT_TRUE(ip_list->contains(*createAddress("10.0.5.100")));
+  EXPECT_TRUE(ip_list->contains(*createAddress("172.16.10.5")));
+  EXPECT_TRUE(ip_list->contains(*createAddress("203.0.113.200")));
+
+  // Test addresses outside all ranges.
+  EXPECT_FALSE(ip_list->contains(*createAddress("8.8.8.8")));
+  EXPECT_FALSE(ip_list->contains(*createAddress("1.1.1.1")));
+  EXPECT_FALSE(ip_list->contains(*createAddress("192.168.2.1")));
+}
+
+// Test invalid CIDR ranges.
+TEST_F(RadixTreeIpListTest, InvalidCidrRanges) {
+  Protobuf::RepeatedPtrField<envoy::config::core::v3::CidrRange> ranges;
+
+  // Invalid IP address.
+  *ranges.Add() = createCidrRange("invalid-ip", 24);
+
+  auto result = RadixTreeIpList::create(ranges);
+  EXPECT_FALSE(result.ok());
+  EXPECT_THAT(result.status().message(), testing::HasSubstr("invalid ip/mask combo"));
+}
+
+// Test single IPv6 range.
+TEST_F(RadixTreeIpListTest, SingleIPv6Range) {
+  Protobuf::RepeatedPtrField<envoy::config::core::v3::CidrRange> ranges;
+  *ranges.Add() = createCidrRange("2001:db8::", 32);
+
+  auto result = RadixTreeIpList::create(ranges);
+  ASSERT_TRUE(result.ok());
+
+  auto ip_list = std::move(result.value());
+  EXPECT_EQ(ip_list->getIpListSize(), 1);
+
+  // Test addresses within range.
+  auto ipv6_addr1 = createAddress("2001:db8::1");
+  auto ipv6_addr2 = createAddress("2001:db8:ffff::1");
+  ASSERT_NE(ipv6_addr1, nullptr);
+  ASSERT_NE(ipv6_addr2, nullptr);
+  EXPECT_TRUE(ip_list->contains(*ipv6_addr1));
+  EXPECT_TRUE(ip_list->contains(*ipv6_addr2));
+
+  // Test addresses outside range.
+  auto ipv6_outside1 = createAddress("2001:db9::1");
+  auto ipv6_outside2 = createAddress("fe80::1");
+  ASSERT_NE(ipv6_outside1, nullptr);
+  ASSERT_NE(ipv6_outside2, nullptr);
+  EXPECT_FALSE(ip_list->contains(*ipv6_outside1));
+  EXPECT_FALSE(ip_list->contains(*ipv6_outside2));
+}
+
+// Test mixed IPv4 and IPv6 ranges.
+TEST_F(RadixTreeIpListTest, MixedIPv4IPv6Ranges) {
+  Protobuf::RepeatedPtrField<envoy::config::core::v3::CidrRange> ranges;
+  *ranges.Add() = createCidrRange("192.168.1.0", 24);
+  *ranges.Add() = createCidrRange("2001:db8::", 32);
+  *ranges.Add() = createCidrRange("10.0.0.0", 8);
+  *ranges.Add() = createCidrRange("fe80::", 10);
+
+  auto result = RadixTreeIpList::create(ranges);
+  ASSERT_TRUE(result.ok());
+
+  auto ip_list = std::move(result.value());
+  EXPECT_EQ(ip_list->getIpListSize(), 4);
+
+  // Test IPv4 addresses.
+  auto ipv4_addr1 = createAddress("192.168.1.100");
+  auto ipv4_addr2 = createAddress("10.255.255.255");
+  auto ipv4_outside = createAddress("172.16.1.1");
+  ASSERT_NE(ipv4_addr1, nullptr);
+  ASSERT_NE(ipv4_addr2, nullptr);
+  ASSERT_NE(ipv4_outside, nullptr);
+  EXPECT_TRUE(ip_list->contains(*ipv4_addr1));
+  EXPECT_TRUE(ip_list->contains(*ipv4_addr2));
+  EXPECT_FALSE(ip_list->contains(*ipv4_outside));
+
+  // Test IPv6 addresses.
+  auto ipv6_addr1 = createAddress("2001:db8::1");
+  auto ipv6_addr2 = createAddress("fe80::1");
+  auto ipv6_outside = createAddress("2600::1");
+  ASSERT_NE(ipv6_addr1, nullptr);
+  ASSERT_NE(ipv6_addr2, nullptr);
+  ASSERT_NE(ipv6_outside, nullptr);
+  EXPECT_TRUE(ip_list->contains(*ipv6_addr1));
+  EXPECT_TRUE(ip_list->contains(*ipv6_addr2));
+  EXPECT_FALSE(ip_list->contains(*ipv6_outside));
+}
+
+// Test large number of ranges for performance characteristics.
+TEST_F(RadixTreeIpListTest, LargeNumberOfRanges) {
+  Protobuf::RepeatedPtrField<envoy::config::core::v3::CidrRange> ranges;
+
+  // Create 1000 ranges to test RadixTree performance.
+  for (int i = 0; i < 1000; ++i) {
+    *ranges.Add() = createCidrRange(fmt::format("10.{}.0.0", i % 256), 24);
+  }
+
+  auto result = RadixTreeIpList::create(ranges);
+  ASSERT_TRUE(result.ok());
+
+  auto ip_list = std::move(result.value());
+  EXPECT_EQ(ip_list->getIpListSize(), 1000);
+
+  // Test that matching still works correctly.
+  auto addr1 = createAddress("10.50.0.100");
+  auto addr2 = createAddress("192.168.1.1");
+  ASSERT_NE(addr1, nullptr);
+  ASSERT_NE(addr2, nullptr);
+  EXPECT_TRUE(ip_list->contains(*addr1));
+  EXPECT_FALSE(ip_list->contains(*addr2));
+}
+
+// Test non-IP address types (should return false).
+TEST_F(RadixTreeIpListTest, NonIpAddressTypes) {
+  Protobuf::RepeatedPtrField<envoy::config::core::v3::CidrRange> ranges;
+  *ranges.Add() = createCidrRange("192.168.1.0", 24);
+
+  auto result = RadixTreeIpList::create(ranges);
+  ASSERT_TRUE(result.ok());
+
+  auto ip_list = std::move(result.value());
+
+  // Create a pipe address (non-IP type).
+  auto pipe_result = Network::Address::PipeInstance::create("/tmp/test.sock");
+  ASSERT_TRUE(pipe_result.ok());
+  auto pipe_address = std::move(pipe_result.value());
+  EXPECT_FALSE(ip_list->contains(*pipe_address));
+}
+
+} // namespace Address
+} // namespace Network
+} // namespace Envoy

--- a/test/common/router/BUILD
+++ b/test/common/router/BUILD
@@ -82,6 +82,19 @@ envoy_cc_benchmark_binary(
     ],
 )
 
+envoy_cc_benchmark_binary(
+    name = "radix_tree_route_matching_speed_test",
+    srcs = ["radix_tree_route_matching_speed_test.cc"],
+    rbe_pool = "6gig",
+    deps = [
+        "//source/common/common:radix_tree_lib",
+        "//source/common/router:config_lib",
+        "//test/test_common:printers_lib",
+        "//test/test_common:utility_lib",
+        "@com_github_google_benchmark//:benchmark",
+    ],
+)
+
 envoy_proto_library(
     name = "header_parser_fuzz_proto",
     srcs = ["header_parser_fuzz.proto"],

--- a/test/common/router/radix_tree_route_matching_speed_test.cc
+++ b/test/common/router/radix_tree_route_matching_speed_test.cc
@@ -1,0 +1,258 @@
+// Performance benchmark comparing RadixTree vs traditional linear search
+// for HTTP route matching in virtual host wildcard scenarios.
+
+#include <random>
+#include <vector>
+
+#include "source/common/common/radix_tree.h"
+#include "source/common/router/config_impl.h"
+
+#include "test/test_common/printers.h"
+#include "test/test_common/utility.h"
+
+#include "benchmark/benchmark.h"
+
+namespace Envoy {
+namespace Router {
+
+// Generate realistic domain names for testing.
+class DomainGenerator {
+public:
+  DomainGenerator() : generator_(42) {} // Fixed seed for reproducibility.
+
+  std::vector<std::string> generateDomains(size_t count) {
+    std::vector<std::string> domains;
+    domains.reserve(count);
+
+    const std::vector<std::string> tlds = {".com", ".org", ".net", ".io", ".co"};
+    const std::vector<std::string> base_names = {"api",    "service", "app",  "web",   "admin",
+                                                 "user",   "auth",    "data", "cache", "cdn",
+                                                 "static", "media",   "blog", "shop",  "mail"};
+
+    std::uniform_int_distribution<size_t> tld_dist(0, tlds.size() - 1);
+    std::uniform_int_distribution<size_t> name_dist(0, base_names.size() - 1);
+    std::uniform_int_distribution<size_t> num_dist(1, 9999);
+
+    for (size_t i = 0; i < count; ++i) {
+      const std::string base = base_names[name_dist(generator_)];
+      const std::string tld = tlds[tld_dist(generator_)];
+      const size_t num = num_dist(generator_);
+
+      domains.push_back(base + std::to_string(num) + tld);
+    }
+
+    return domains;
+  }
+
+  std::vector<std::string> generateWildcardPatterns(const std::vector<std::string>& domains,
+                                                    double wildcard_ratio = 0.3) {
+    std::vector<std::string> patterns;
+    patterns.reserve(domains.size());
+
+    std::uniform_real_distribution<double> wildcard_dist(0.0, 1.0);
+    std::uniform_int_distribution<int> type_dist(0, 1); // 0 = prefix, 1 = suffix
+
+    for (const auto& domain : domains) {
+      if (wildcard_dist(generator_) < wildcard_ratio) {
+        if (type_dist(generator_) == 0) {
+          // Prefix wildcard: *.example.com
+          size_t dot_pos = domain.find('.');
+          if (dot_pos != std::string::npos) {
+            patterns.push_back("*" + domain.substr(dot_pos));
+          } else {
+            patterns.push_back(domain);
+          }
+        } else {
+          // Suffix wildcard: api.*
+          size_t dot_pos = domain.find('.');
+          if (dot_pos != std::string::npos) {
+            patterns.push_back(domain.substr(0, dot_pos) + "*");
+          } else {
+            patterns.push_back(domain);
+          }
+        }
+      } else {
+        patterns.push_back(domain);
+      }
+    }
+
+    return patterns;
+  }
+
+private:
+  std::mt19937 generator_;
+};
+
+// Traditional linear search implementation for comparison.
+class LinearWildcardMatcher {
+public:
+  void addPattern(const std::string& pattern, int value) { patterns_.emplace_back(pattern, value); }
+
+  int findMatch(absl::string_view host) const {
+    for (const auto& [pattern, value] : patterns_) {
+      if (matches(host, pattern)) {
+        return value;
+      }
+    }
+    return -1; // No match found.
+  }
+
+private:
+  bool matches(absl::string_view host, const std::string& pattern) const {
+    if (pattern.empty())
+      return false;
+
+    if (pattern[0] == '*') {
+      // Suffix wildcard: *.example.com
+      const std::string suffix = pattern.substr(1);
+      return host.size() >= suffix.size() && host.substr(host.size() - suffix.size()) == suffix;
+    } else if (pattern.back() == '*') {
+      // Prefix wildcard: api.*
+      const std::string prefix = pattern.substr(0, pattern.size() - 1);
+      return host.size() >= prefix.size() && host.substr(0, prefix.size()) == prefix;
+    } else {
+      // Exact match.
+      return host == pattern;
+    }
+  }
+
+  std::vector<std::pair<std::string, int>> patterns_;
+};
+
+// RadixTree-based matcher implementation.
+class RadixTreeWildcardMatcher {
+public:
+  RadixTreeWildcardMatcher()
+      : prefix_tree_(std::make_unique<RadixTree<int>>()),
+        suffix_tree_(std::make_unique<RadixTree<int>>()),
+        exact_tree_(std::make_unique<RadixTree<int>>()) {}
+
+  void addPattern(const std::string& pattern, int value) {
+    if (pattern.empty())
+      return;
+
+    if (pattern[0] == '*') {
+      // Suffix wildcard: *.example.com -> reverse for prefix matching.
+      std::string suffix = pattern.substr(1);
+      std::reverse(suffix.begin(), suffix.end());
+      suffix_tree_->add(suffix, value);
+    } else if (pattern.back() == '*') {
+      // Prefix wildcard: api.*
+      const std::string prefix = pattern.substr(0, pattern.size() - 1);
+      prefix_tree_->add(prefix, value);
+    } else {
+      // Exact match.
+      exact_tree_->add(pattern, value);
+    }
+  }
+
+  int findMatch(absl::string_view host) const {
+    // Try exact match first.
+    int exact_match = exact_tree_->find(host);
+    if (exact_match != 0) {
+      return exact_match;
+    }
+
+    // Try prefix match.
+    int prefix_match = prefix_tree_->findLongestPrefix(host);
+    if (prefix_match != 0) {
+      return prefix_match;
+    }
+
+    // Try suffix match.
+    std::string reversed_host(host);
+    std::reverse(reversed_host.begin(), reversed_host.end());
+    int suffix_match = suffix_tree_->findLongestPrefix(reversed_host);
+    if (suffix_match != 0) {
+      return suffix_match;
+    }
+
+    return -1; // No match found.
+  }
+
+private:
+  std::unique_ptr<RadixTree<int>> prefix_tree_;
+  std::unique_ptr<RadixTree<int>> suffix_tree_;
+  std::unique_ptr<RadixTree<int>> exact_tree_;
+};
+
+// Benchmark linear search implementation.
+static void BM_LinearWildcardMatching(benchmark::State& state) {
+  const size_t num_patterns = state.range(0);
+  const size_t num_queries = 1000;
+
+  DomainGenerator generator;
+  auto domains = generator.generateDomains(num_patterns);
+  auto patterns = generator.generateWildcardPatterns(domains, 0.4); // 40% wildcards
+  auto query_domains = generator.generateDomains(num_queries);
+
+  LinearWildcardMatcher matcher;
+  for (size_t i = 0; i < patterns.size(); ++i) {
+    matcher.addPattern(patterns[i], static_cast<int>(i));
+  }
+
+  // Pre-generate random queries for consistent benchmark.
+  std::mt19937 rng(12345);
+  std::uniform_int_distribution<size_t> dist(0, query_domains.size() - 1);
+  std::vector<size_t> query_indices;
+  for (size_t i = 0; i < 1024; ++i) {
+    query_indices.push_back(dist(rng));
+  }
+
+  size_t query_idx = 0;
+  for (auto _ : state) {
+    const auto& query = query_domains[query_indices[query_idx % 1024]];
+    int result = matcher.findMatch(query);
+    benchmark::DoNotOptimize(result);
+    query_idx++;
+  }
+
+  state.SetItemsProcessed(state.iterations());
+  state.SetLabel(fmt::format("LinearSearch_{}patterns", num_patterns));
+}
+
+// Benchmark RadixTree implementation.
+static void BM_RadixTreeWildcardMatching(benchmark::State& state) {
+  const size_t num_patterns = state.range(0);
+  const size_t num_queries = 1000;
+
+  DomainGenerator generator;
+  auto domains = generator.generateDomains(num_patterns);
+  auto patterns = generator.generateWildcardPatterns(domains, 0.4); // 40% wildcards
+  auto query_domains = generator.generateDomains(num_queries);
+
+  RadixTreeWildcardMatcher matcher;
+  for (size_t i = 0; i < patterns.size(); ++i) {
+    matcher.addPattern(patterns[i], static_cast<int>(i));
+  }
+
+  // Pre-generate random queries for consistent benchmark.
+  std::mt19937 rng(12345);
+  std::uniform_int_distribution<size_t> dist(0, query_domains.size() - 1);
+  std::vector<size_t> query_indices;
+  for (size_t i = 0; i < 1024; ++i) {
+    query_indices.push_back(dist(rng));
+  }
+
+  size_t query_idx = 0;
+  for (auto _ : state) {
+    const auto& query = query_domains[query_indices[query_idx % 1024]];
+    int result = matcher.findMatch(query);
+    benchmark::DoNotOptimize(result);
+    query_idx++;
+  }
+
+  state.SetItemsProcessed(state.iterations());
+  state.SetLabel(fmt::format("RadixTree_{}patterns", num_patterns));
+}
+
+// Comprehensive benchmark with varying pattern counts.
+BENCHMARK(BM_LinearWildcardMatching)->Range(10, 10000)->Unit(benchmark::kNanosecond);
+BENCHMARK(BM_RadixTreeWildcardMatching)->Range(10, 10000)->Unit(benchmark::kNanosecond);
+
+// Focused benchmarks for specific scenarios.
+BENCHMARK(BM_LinearWildcardMatching)->Arg(100)->Arg(500)->Arg(1000)->Arg(5000);
+BENCHMARK(BM_RadixTreeWildcardMatching)->Arg(100)->Arg(500)->Arg(1000)->Arg(5000);
+
+} // namespace Router
+} // namespace Envoy

--- a/test/extensions/filters/common/rbac/BUILD
+++ b/test/extensions/filters/common/rbac/BUILD
@@ -35,6 +35,21 @@ envoy_extension_cc_test(
 )
 
 envoy_extension_cc_test(
+    name = "radix_tree_ip_matcher_test",
+    srcs = ["radix_tree_ip_matcher_test.cc"],
+    extension_names = ["envoy.filters.http.rbac"],
+    rbe_pool = "6gig",
+    tags = ["skip_on_windows"],
+    deps = [
+        "//source/extensions/filters/common/rbac:matchers_lib",
+        "//test/mocks/network:network_mocks",
+        "//test/mocks/stream_info:stream_info_mocks",
+        "//test/test_common:network_utility_lib",
+        "//test/test_common:utility_lib",
+    ],
+)
+
+envoy_extension_cc_test(
     name = "engine_impl_test",
     srcs = ["engine_impl_test.cc"],
     extension_names = ["envoy.filters.http.rbac"],

--- a/test/extensions/filters/common/rbac/radix_tree_ip_matcher_test.cc
+++ b/test/extensions/filters/common/rbac/radix_tree_ip_matcher_test.cc
@@ -1,0 +1,291 @@
+// Comprehensive tests for RadixTree-enhanced IPMatcher in RBAC.
+
+#include "source/common/network/utility.h"
+#include "source/extensions/filters/common/rbac/matchers.h"
+
+#include "test/mocks/network/mocks.h"
+#include "test/mocks/stream_info/mocks.h"
+#include "test/test_common/utility.h"
+
+#include "gtest/gtest.h"
+
+using testing::NiceMock;
+using testing::Return;
+using testing::ReturnRef;
+
+namespace Envoy {
+namespace Extensions {
+namespace Filters {
+namespace Common {
+namespace RBAC {
+
+class RadixTreeIPMatcherTest : public testing::Test {
+protected:
+  // Helper to create CIDR range protobuf.
+  envoy::config::core::v3::CidrRange createCidrRange(const std::string& address_prefix,
+                                                     uint32_t prefix_len) {
+    envoy::config::core::v3::CidrRange range;
+    range.set_address_prefix(address_prefix);
+    range.mutable_prefix_len()->set_value(prefix_len);
+    return range;
+  }
+
+  // Helper to check matcher with mock connection setup.
+  void checkIPMatcher(const IPMatcher& matcher, bool expected_match, const std::string& test_ip,
+                      IPMatcher::Type type) {
+    NiceMock<Network::MockConnection> conn;
+    Envoy::Http::TestRequestHeaderMapImpl headers;
+    NiceMock<StreamInfo::MockStreamInfo> info;
+
+    auto addr = Network::Utility::parseInternetAddressNoThrow(test_ip);
+    ASSERT_NE(addr, nullptr) << "Failed to parse IP: " << test_ip;
+
+    // Setup connection and stream info based on matcher type.
+    switch (type) {
+    case IPMatcher::ConnectionRemote:
+      conn.stream_info_.downstream_connection_info_provider_->setRemoteAddress(addr);
+      break;
+    case IPMatcher::DownstreamLocal:
+      info.downstream_connection_info_provider_->setLocalAddress(addr);
+      break;
+    case IPMatcher::DownstreamDirectRemote:
+      info.downstream_connection_info_provider_->setDirectRemoteAddressForTest(addr);
+      break;
+    case IPMatcher::DownstreamRemote:
+      info.downstream_connection_info_provider_->setRemoteAddress(addr);
+      break;
+    }
+
+    EXPECT_EQ(expected_match, matcher.matches(conn, headers, info))
+        << "IP: " << test_ip << " Type: " << static_cast<int>(type);
+  }
+};
+
+// Test single range constructor with actual IP matching.
+TEST_F(RadixTreeIPMatcherTest, SingleRangeConstructorConnectionRemote) {
+  auto range = createCidrRange("192.168.1.0", 24);
+  IPMatcher matcher(range, IPMatcher::ConnectionRemote);
+
+  // Test matching addresses within range.
+  checkIPMatcher(matcher, true, "192.168.1.1", IPMatcher::ConnectionRemote);
+  checkIPMatcher(matcher, true, "192.168.1.100", IPMatcher::ConnectionRemote);
+  checkIPMatcher(matcher, true, "192.168.1.255", IPMatcher::ConnectionRemote);
+
+  // Test non-matching addresses.
+  checkIPMatcher(matcher, false, "192.168.2.1", IPMatcher::ConnectionRemote);
+  checkIPMatcher(matcher, false, "10.0.0.1", IPMatcher::ConnectionRemote);
+}
+
+// Test single range constructor with IPv6.
+TEST_F(RadixTreeIPMatcherTest, SingleRangeConstructorIPv6) {
+  auto range = createCidrRange("2001:db8::", 32);
+  IPMatcher matcher(range, IPMatcher::ConnectionRemote);
+
+  // Test matching IPv6 addresses.
+  checkIPMatcher(matcher, true, "2001:db8::1", IPMatcher::ConnectionRemote);
+  checkIPMatcher(matcher, true, "2001:db8:ffff::1", IPMatcher::ConnectionRemote);
+
+  // Test non-matching IPv6 addresses.
+  checkIPMatcher(matcher, false, "2001:db9::1", IPMatcher::ConnectionRemote);
+  checkIPMatcher(matcher, false, "fe80::1", IPMatcher::ConnectionRemote);
+}
+
+// Test multiple ranges with create() factory method and actual matching.
+TEST_F(RadixTreeIPMatcherTest, MultipleRangesCreate) {
+  Protobuf::RepeatedPtrField<envoy::config::core::v3::CidrRange> ranges;
+  *ranges.Add() = createCidrRange("192.168.1.0", 24); // Corporate network.
+  *ranges.Add() = createCidrRange("10.0.0.0", 16);    // Private network.
+  *ranges.Add() = createCidrRange("172.16.0.0", 12);  // Docker networks.
+  *ranges.Add() = createCidrRange("203.0.113.0", 24); // Test network.
+
+  auto result = IPMatcher::create(ranges, IPMatcher::ConnectionRemote);
+  ASSERT_TRUE(result.ok());
+  auto matcher = std::move(result.value());
+
+  // Test addresses from each range.
+  checkIPMatcher(*matcher, true, "192.168.1.50", IPMatcher::ConnectionRemote);
+  checkIPMatcher(*matcher, true, "10.0.5.100", IPMatcher::ConnectionRemote);
+  checkIPMatcher(*matcher, true, "172.16.10.5", IPMatcher::ConnectionRemote);
+  checkIPMatcher(*matcher, true, "203.0.113.200", IPMatcher::ConnectionRemote);
+
+  // Test addresses outside all ranges.
+  checkIPMatcher(*matcher, false, "8.8.8.8", IPMatcher::ConnectionRemote);
+  checkIPMatcher(*matcher, false, "1.1.1.1", IPMatcher::ConnectionRemote);
+  checkIPMatcher(*matcher, false, "192.168.2.1", IPMatcher::ConnectionRemote);
+}
+
+// Test all matcher types with actual IP matching.
+TEST_F(RadixTreeIPMatcherTest, AllMatcherTypesMatching) {
+  auto range = createCidrRange("192.168.1.0", 24);
+
+  // Test ConnectionRemote type.
+  IPMatcher matcher1(range, IPMatcher::ConnectionRemote);
+  checkIPMatcher(matcher1, true, "192.168.1.100", IPMatcher::ConnectionRemote);
+  checkIPMatcher(matcher1, false, "10.0.0.1", IPMatcher::ConnectionRemote);
+
+  // Test DownstreamLocal type.
+  IPMatcher matcher2(range, IPMatcher::DownstreamLocal);
+  checkIPMatcher(matcher2, true, "192.168.1.100", IPMatcher::DownstreamLocal);
+  checkIPMatcher(matcher2, false, "10.0.0.1", IPMatcher::DownstreamLocal);
+
+  // Test DownstreamDirectRemote type.
+  IPMatcher matcher3(range, IPMatcher::DownstreamDirectRemote);
+  checkIPMatcher(matcher3, true, "192.168.1.100", IPMatcher::DownstreamDirectRemote);
+  checkIPMatcher(matcher3, false, "10.0.0.1", IPMatcher::DownstreamDirectRemote);
+
+  // Test DownstreamRemote type.
+  IPMatcher matcher4(range, IPMatcher::DownstreamRemote);
+  checkIPMatcher(matcher4, true, "192.168.1.100", IPMatcher::DownstreamRemote);
+  checkIPMatcher(matcher4, false, "10.0.0.1", IPMatcher::DownstreamRemote);
+}
+
+// Test error handling for empty range list.
+TEST_F(RadixTreeIPMatcherTest, EmptyRangeListError) {
+  Protobuf::RepeatedPtrField<envoy::config::core::v3::CidrRange> empty_ranges;
+
+  auto result = IPMatcher::create(empty_ranges, IPMatcher::ConnectionRemote);
+  EXPECT_FALSE(result.ok());
+  EXPECT_THAT(result.status().message(), testing::HasSubstr("Empty IP range list provided"));
+}
+
+// Test error handling for invalid CIDR range in single constructor.
+TEST_F(RadixTreeIPMatcherTest, InvalidSingleRangeError) {
+  auto invalid_range = createCidrRange("invalid-ip", 24);
+
+  EXPECT_THROW(IPMatcher(invalid_range, IPMatcher::ConnectionRemote), EnvoyException);
+}
+
+// Test error handling for invalid CIDR range in create method.
+TEST_F(RadixTreeIPMatcherTest, InvalidMultipleRangesError) {
+  Protobuf::RepeatedPtrField<envoy::config::core::v3::CidrRange> ranges;
+  *ranges.Add() = createCidrRange("192.168.1.0", 24); // Valid range.
+  *ranges.Add() = createCidrRange("invalid-ip", 24);  // Invalid range.
+
+  auto result = IPMatcher::create(ranges, IPMatcher::ConnectionRemote);
+  EXPECT_FALSE(result.ok());
+  EXPECT_THAT(result.status().message(), testing::HasSubstr("invalid ip/mask combo"));
+}
+
+// Test successful creation with various valid prefix lengths.
+TEST_F(RadixTreeIPMatcherTest, ValidPrefixLengths) {
+  Protobuf::RepeatedPtrField<envoy::config::core::v3::CidrRange> ranges;
+  *ranges.Add() = createCidrRange("192.168.1.0", 24); // Standard /24 network.
+  *ranges.Add() = createCidrRange("10.0.0.0", 8);     // Large /8 network.
+  *ranges.Add() = createCidrRange("172.16.0.0", 16);  // Medium /16 network.
+
+  auto result = IPMatcher::create(ranges, IPMatcher::ConnectionRemote);
+  EXPECT_TRUE(result.ok());
+  EXPECT_NE(result.value(), nullptr);
+}
+
+// Test single /32 host range.
+TEST_F(RadixTreeIPMatcherTest, SingleHostRange) {
+  auto range = createCidrRange("192.168.1.100", 32);
+  IPMatcher matcher(range, IPMatcher::ConnectionRemote);
+
+  // Test exact host match.
+  checkIPMatcher(matcher, true, "192.168.1.100", IPMatcher::ConnectionRemote);
+
+  // Test non-matching hosts.
+  checkIPMatcher(matcher, false, "192.168.1.101", IPMatcher::ConnectionRemote);
+  checkIPMatcher(matcher, false, "192.168.1.99", IPMatcher::ConnectionRemote);
+}
+
+// Test single /128 IPv6 host range.
+TEST_F(RadixTreeIPMatcherTest, SingleIPv6HostRange) {
+  auto range = createCidrRange("2001:db8::1", 128);
+  IPMatcher matcher(range, IPMatcher::ConnectionRemote);
+
+  // Test exact IPv6 host match.
+  checkIPMatcher(matcher, true, "2001:db8::1", IPMatcher::ConnectionRemote);
+
+  // Test non-matching IPv6 hosts.
+  checkIPMatcher(matcher, false, "2001:db8::2", IPMatcher::ConnectionRemote);
+}
+
+// Test large number of ranges for performance characteristics.
+TEST_F(RadixTreeIPMatcherTest, LargeNumberOfRanges) {
+  Protobuf::RepeatedPtrField<envoy::config::core::v3::CidrRange> ranges;
+
+  // Create 100 ranges to test RadixTree performance.
+  for (int i = 0; i < 100; ++i) {
+    *ranges.Add() = createCidrRange(fmt::format("10.{}.0.0", i), 24);
+  }
+
+  auto result = IPMatcher::create(ranges, IPMatcher::ConnectionRemote);
+  ASSERT_TRUE(result.ok());
+  auto matcher = std::move(result.value());
+
+  // Test that matching still works correctly.
+  checkIPMatcher(*matcher, true, "10.50.0.100", IPMatcher::ConnectionRemote);
+  checkIPMatcher(*matcher, true, "10.99.0.50", IPMatcher::ConnectionRemote);
+
+  // Test non-matching address.
+  checkIPMatcher(*matcher, false, "192.168.1.1", IPMatcher::ConnectionRemote);
+}
+
+// Test overlapping ranges.
+TEST_F(RadixTreeIPMatcherTest, OverlappingRanges) {
+  Protobuf::RepeatedPtrField<envoy::config::core::v3::CidrRange> ranges;
+  *ranges.Add() = createCidrRange("192.168.0.0", 16);   // Large range.
+  *ranges.Add() = createCidrRange("192.168.1.0", 24);   // Subset of above.
+  *ranges.Add() = createCidrRange("192.168.1.100", 32); // Single host in subset.
+
+  auto result = IPMatcher::create(ranges, IPMatcher::ConnectionRemote);
+  ASSERT_TRUE(result.ok());
+  auto matcher = std::move(result.value());
+
+  // Validates overlapping ranges RadixTree creation.
+  EXPECT_NE(matcher, nullptr);
+}
+
+// Test mixed IPv4 and IPv6 ranges.
+TEST_F(RadixTreeIPMatcherTest, MixedIPv4IPv6Ranges) {
+  Protobuf::RepeatedPtrField<envoy::config::core::v3::CidrRange> ranges;
+  *ranges.Add() = createCidrRange("192.168.1.0", 24);
+  *ranges.Add() = createCidrRange("2001:db8::", 32);
+  *ranges.Add() = createCidrRange("10.0.0.0", 8);
+  *ranges.Add() = createCidrRange("fe80::", 10);
+
+  auto result = IPMatcher::create(ranges, IPMatcher::ConnectionRemote);
+  ASSERT_TRUE(result.ok());
+  auto matcher = std::move(result.value());
+
+  // Validates mixed IPv4/IPv6 RadixTree creation.
+  EXPECT_NE(matcher, nullptr);
+}
+
+// Test boundary conditions.
+TEST_F(RadixTreeIPMatcherTest, BoundaryConditions) {
+  auto range = createCidrRange("192.168.1.0", 24); // 192.168.1.0-192.168.1.255
+  IPMatcher matcher(range, IPMatcher::ConnectionRemote);
+
+  // Test exact boundaries.
+  checkIPMatcher(matcher, true, "192.168.1.0", IPMatcher::ConnectionRemote);   // Network address.
+  checkIPMatcher(matcher, true, "192.168.1.255", IPMatcher::ConnectionRemote); // Broadcast address.
+
+  // Test one outside each boundary.
+  checkIPMatcher(matcher, false, "192.168.0.255", IPMatcher::ConnectionRemote);
+  checkIPMatcher(matcher, false, "192.168.2.0", IPMatcher::ConnectionRemote);
+}
+
+// Test extractIpAddress coverage with nullptr handling.
+TEST_F(RadixTreeIPMatcherTest, ExtractIpAddressNull) {
+  auto range = createCidrRange("192.168.1.0", 24);
+  IPMatcher matcher(range, IPMatcher::ConnectionRemote);
+
+  NiceMock<Network::MockConnection> conn;
+  Envoy::Http::TestRequestHeaderMapImpl headers;
+  NiceMock<StreamInfo::MockStreamInfo> info;
+
+  // Setup connection with no remote address (nullptr).
+  conn.stream_info_.downstream_connection_info_provider_->setRemoteAddress(nullptr);
+
+  EXPECT_FALSE(matcher.matches(conn, headers, info));
+}
+
+} // namespace RBAC
+} // namespace Common
+} // namespace Filters
+} // namespace Extensions
+} // namespace Envoy


### PR DESCRIPTION
## Description

This PR switches IP Matcher to use LC Trie.

### Benchmarks

#### Command

```
bazel run -c opt test/common/network:lc_trie_ip_list_speed_test-- --benchmark_repetitions=10
```
#### Machine Config

```
Run on (12 X 24 MHz CPU s)
CPU Caches:
  L1 Data 64 KiB
  L1 Instruction 128 KiB
  L2 Unified 4096 KiB (x12)
Load Average: 7.51, 6.88, 6.74
```

#### Results

| Benchmark | Trie Mean | LCTrie Mean | Speedup (×) |
| --- | --- | --- | --- |
| BM_LinearIpListMatching/10_mean | 98.8 ns | 28.3 ns | 3.49× |
| BM_LinearIpListMatching/25_mean | 239.0 ns | 31.6 ns | 7.56× |
| BM_LinearIpListMatching/50_mean | 469.0 ns | 29.0 ns | 16.17× |
| BM_LinearIpListMatching/64_mean | 598.0 ns | 29.7 ns | 20.13× |
| BM_LinearIpListMatching/100_mean | 933.0 ns | 30.3 ns | 30.79× |
| BM_LinearIpListMatching/250_mean | 2231.0 ns | 32.6 ns | 68.44× |
| BM_LinearIpListMatching/500_mean | 4265.0 ns | 35.7 ns | 119.47× |
| BM_LinearIpListMatching/512_mean | 4405.0 ns | 35.1 ns | 125.50× |
| BM_LinearIpListMatching/1000_mean | 7913.0 ns | 39.7 ns | 199.32× |
| BM_LinearIpListMatching/4096_mean | 20492.0 ns | 48.5 ns | 422.52× |
| BM_LinearIpListMatching/5000_mean | 23793.0 ns | 50.0 ns | 475.86× |

<img width="1750" height="1103" alt="Linear vs Radix Time Analysis" src="https://github.com/user-attachments/assets/9f41d964-5451-482b-9978-6ff7f4f4925f" />

---

**Commit Message:** ip_matcher: switch IP Matcher to use LC Trie
**Additional Description:** Switch IP Matcher to use LC Trie.
**Risk Level:** Low
**Testing:** Added Unit Tests
**Docs Changes:** N/A
**Release Notes:** 