### PR TITLE
Update udp_tunneling_integration_test.cc's unknown capsule type

### DIFF
--- a/test/integration/udp_tunneling_integration_test.cc
+++ b/test/integration/udp_tunneling_integration_test.cc
@@ -225,7 +225,7 @@ TEST_P(ConnectUdpTerminationIntegrationTest, DropUnknownCapsules) {
   setUpConnection();
   Network::UdpRecvData request_datagram;
   const std::string unknown_capsule_fragment =
-      absl::HexStringToBytes("01"             // DATAGRAM Capsule Type
+      absl::HexStringToBytes("17"             // Reserved UNKNOWN Capsule Type
                              "08"             // Capsule Length
                              "00"             // Context ID
                              "a1a2a3a4a5a6a7" // UDP Proxying Payload


### PR DESCRIPTION
When this test was written, capsule type 0x01 was unknown to Envoy and Google QUICHE, but it had already been assigned to the connect-ip draft, later RFC 9484. RFC 9297, which defines capsules in general, defines capsule types of the form 0x29 * N + 0x17, for integer values of N, as reserved for testing behavior with unknown capsule types. Setting N=0, we can just use 0x17 instead of 0x01 and per the RFC we should never collide with a real capsule assignment again.

https://www.rfc-editor.org/rfc/rfc9484.html#section-12.4
https://www.rfc-editor.org/rfc/rfc9297.html#section-5.4-3

Risk Level: low
Testing: test-only change
