### PR TITLE
Revert "Ext_proc: do not support fail_open+FULL_DUPLEX_STREAMED configuraton combination (#39740)"

### DIFF
--- a/api/envoy/extensions/filters/http/ext_proc/v3/ext_proc.proto
+++ b/api/envoy/extensions/filters/http/ext_proc/v3/ext_proc.proto
@@ -168,11 +168,7 @@ message ExternalProcessor {
     (xds.annotations.v3.field_status).work_in_progress = true
   ];
 
-  // If the ``BodySendMode`` in the
-  // :ref:`processing_mode <envoy_v3_api_field_extensions.filters.http.ext_proc.v3.ExternalProcessor.processing_mode>`
-  // is set to ``FULL_DUPLEX_STREAMED``, ``failure_mode_allow`` can not be set to true.
-  //
-  // Otherwise, by default, if in the following cases:
+  // By default, if in the following cases:
   //
   // 1. The gRPC stream cannot be established.
   //

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -1,7 +1,9 @@
 date: Pending
 
 behavior_changes:
-# *Changes that are expected to cause an incompatibility if applicable; deployment changes are likely required*
+- area: ext_proc
+  change: |
+    Reverted https://github.com/envoyproxy/envoy/pull/39740 to re-enable fail_open+FULL_DUPLEX_STREAMED configuraton combination.
 
 minor_behavior_changes:
 # *Changes that may cause incompatibilities for some users, but should not for most*

--- a/source/extensions/filters/http/ext_proc/config.cc
+++ b/source/extensions/filters/http/ext_proc/config.cc
@@ -50,17 +50,6 @@ absl::Status verifyProcessingModeConfig(
         "then the response_trailer_mode has to be set to SEND");
   }
 
-  // Do not support fail open for FULL_DUPLEX_STREAMED body mode.
-  if (((processing_mode.request_body_mode() ==
-        envoy::extensions::filters::http::ext_proc::v3::ProcessingMode::FULL_DUPLEX_STREAMED) ||
-       (processing_mode.response_body_mode() ==
-        envoy::extensions::filters::http::ext_proc::v3::ProcessingMode::FULL_DUPLEX_STREAMED)) &&
-      config.failure_mode_allow()) {
-    return absl::InvalidArgumentError(
-        "If the ext_proc filter has either the request_body_mode or the response_body_mode set "
-        "to FULL_DUPLEX_STREAMED, then the failure_mode_allow has to be left as false");
-  }
-
   return absl::OkStatus();
 }
 

--- a/test/extensions/filters/http/ext_proc/config_test.cc
+++ b/test/extensions/filters/http/ext_proc/config_test.cc
@@ -256,54 +256,6 @@ TEST(HttpExtProcConfigTest, InvalidFullDuplexStreamedConfig) {
             "then the request_trailer_mode has to be set to SEND");
 }
 
-TEST(HttpExtProcConfigTest, InvalidRequestFullDuplexStreamedFailureModeAllowConfig) {
-  std::string yaml = R"EOF(
-  grpc_service:
-    envoy_grpc:
-      cluster_name: ext_proc_server
-  failure_mode_allow: true
-  processing_mode:
-    request_body_mode: FULL_DUPLEX_STREAMED
-    request_trailer_mode: SEND
-  )EOF";
-
-  ExternalProcessingFilterConfig factory;
-  ProtobufTypes::MessagePtr proto_config = factory.createEmptyConfigProto();
-  TestUtility::loadFromYaml(yaml, *proto_config);
-
-  testing::NiceMock<Server::Configuration::MockFactoryContext> context;
-  auto result = factory.createFilterFactoryFromProto(*proto_config, "stats", context);
-  EXPECT_FALSE(result.ok());
-  EXPECT_EQ(result.status().code(), absl::StatusCode::kInvalidArgument);
-  EXPECT_EQ(result.status().message(),
-            "If the ext_proc filter has either the request_body_mode or the response_body_mode set "
-            "to FULL_DUPLEX_STREAMED, then the failure_mode_allow has to be left as false");
-}
-
-TEST(HttpExtProcConfigTest, InvalidResponseFullDuplexStreamedFailureModeAllowConfig) {
-  std::string yaml = R"EOF(
-  grpc_service:
-    envoy_grpc:
-      cluster_name: ext_proc_server
-  failure_mode_allow: true
-  processing_mode:
-    response_body_mode: FULL_DUPLEX_STREAMED
-    response_trailer_mode: SEND
-  )EOF";
-
-  ExternalProcessingFilterConfig factory;
-  ProtobufTypes::MessagePtr proto_config = factory.createEmptyConfigProto();
-  TestUtility::loadFromYaml(yaml, *proto_config);
-
-  testing::NiceMock<Server::Configuration::MockFactoryContext> context;
-  auto result = factory.createFilterFactoryFromProto(*proto_config, "stats", context);
-  EXPECT_FALSE(result.ok());
-  EXPECT_EQ(result.status().code(), absl::StatusCode::kInvalidArgument);
-  EXPECT_EQ(result.status().message(),
-            "If the ext_proc filter has either the request_body_mode or the response_body_mode set "
-            "to FULL_DUPLEX_STREAMED, then the failure_mode_allow has to be left as false");
-}
-
 TEST(HttpExtProcConfigTest, GrpcServiceHttpServiceBothSet) {
   std::string yaml = R"EOF(
   grpc_service:


### PR DESCRIPTION
There is a request that to have ext_proc FULL_DUPLEX_STREAMED mode support fail_open to certain stage, like before the 1st chunk of data is shipped to the ext_proc server.   This is doable. 

This PR reverts "Ext_proc: do not support fail_open+FULL_DUPLEX_STREAMED configuraton combination (#39740)", i.e, commit 4861b2057afbc67290da0ec77ae1f1af60f152d0.

A follow up PR will implement the above fail-open behavior.
