### PR TITLE
Simplify the protobuf::BytesValue::set_value call

### DIFF
--- a/source/extensions/filters/listener/proxy_protocol/proxy_protocol.cc
+++ b/source/extensions/filters/listener/proxy_protocol/proxy_protocol.cc
@@ -573,7 +573,7 @@ bool Filter::parseTlvs(const uint8_t* buf, size_t len) {
                              tlv_type);
         } else {
           Protobuf::BytesValue tlv_byte_value;
-          tlv_byte_value.set_value(tlv_value.data(), tlv_value.size());
+          tlv_byte_value.set_value(tlv_value);
           tlvs_metadata.mutable_typed_metadata()->insert(
               {key_value_pair->key(), tlv_byte_value.value()});
           ProtobufWkt::Any typed_metadata;


### PR DESCRIPTION
Risk Level: none
Testing: unit tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
