### PR TITLE
docs: Clarify hot restart behaviour in documentation

### DIFF
--- a/docs/root/intro/arch_overview/operations/hot_restart.rst
+++ b/docs/root/intro/arch_overview/operations/hot_restart.rst
@@ -21,13 +21,13 @@ The hot restart functionality has the following general architecture:
   draining.
 * During the draining phase, the old process attempts to gracefully close existing connections. How
   this is done depends on the configured filters. The drain time is configurable via the
-  :option:`--drain-time-s` option and as more time passes draining becomes more aggressive. 
-  Once the drain time completes, any remaining connections to the old envoy process will be closed. 
-  They are not transferred to the new process.
-* Later, usually after the drain sequence, the new Envoy process tells the old Envoy process to shut 
+  :option:`--drain-time-s` option and as more time passes draining becomes more aggressive.
+* Later, usually after the drain sequence, the new Envoy process tells the old Envoy process to shut
   itself down. This time is configurable via the :option:`--parent-shutdown-time-s` option. Note
   that the `--parent-shutdown-time-s` option is independent of the `--drain-time-s` value, and so
   the parent shutdown time should be set to a larger value.
+* Any remaining connections to the old envoy process are closed. The hot restart functionality
+  does not transfer existing connections to the new process.
 * Envoy’s hot restart support was designed so that it will work correctly even if the new Envoy
   process and the old Envoy process are running inside different containers. Communication between
   the processes takes place only using unix domain sockets.


### PR DESCRIPTION
Commit Message: docs: Clarify hot restart behaviour
Additional Description:
From my testing and also from https://groups.google.com/g/envoy-users/c/KmVo_Md9xiE, I learnt that hot restart does *not* transfer existing connections to the new process. The way the documentation reads implies that it does. In fact, it only gives an overlapping drain period.

This documentation update hopefully clarifies this so that no-one else has to work this out for themselves.

Risk Level: N/A
Testing: N/A
Docs Changes: yes
Release Notes: N/A
Platform Specific Features: N/A