### PR TITLE
Removed unused dependency from header map to runtime

### DIFF
--- a/source/common/http/BUILD
+++ b/source/common/http/BUILD
@@ -467,7 +467,6 @@ envoy_cc_library(
         "//source/common/common:empty_string",
         "//source/common/common:non_copyable",
         "//source/common/common:utility_lib",
-        "//source/common/runtime:runtime_features_lib",
         "//source/common/singleton:const_singleton",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
     ],

--- a/source/common/http/header_map_impl.cc
+++ b/source/common/http/header_map_impl.cc
@@ -10,7 +10,6 @@
 #include "source/common/common/assert.h"
 #include "source/common/common/dump_state_utils.h"
 #include "source/common/common/empty_string.h"
-#include "source/common/runtime/runtime_features.h"
 #include "source/common/singleton/const_singleton.h"
 
 #include "absl/strings/match.h"

--- a/source/common/http/header_map_impl.h
+++ b/source/common/http/header_map_impl.h
@@ -15,7 +15,6 @@
 #include "source/common/common/non_copyable.h"
 #include "source/common/common/utility.h"
 #include "source/common/http/headers.h"
-#include "source/common/runtime/runtime_features.h"
 
 namespace Envoy {
 namespace Http {

--- a/source/common/quic/BUILD
+++ b/source/common/quic/BUILD
@@ -463,6 +463,7 @@ envoy_cc_library(
         "//source/common/network:socket_option_factory_lib",
         "//source/common/protobuf:utility_lib",
         "//source/common/quic:quic_io_handle_wrapper_lib",
+        "//source/common/runtime:runtime_lib",
         "@com_github_google_quiche//:quic_core_config_lib",
         "@com_github_google_quiche//:quic_core_http_header_list_lib",
         "@com_github_google_quiche//:quic_platform",

--- a/source/common/quic/envoy_quic_client_connection.h
+++ b/source/common/quic/envoy_quic_client_connection.h
@@ -6,6 +6,7 @@
 #include "source/common/quic/envoy_quic_packet_writer.h"
 #include "source/common/quic/envoy_quic_utils.h"
 #include "source/common/quic/quic_network_connection.h"
+#include "source/common/runtime/runtime_features.h"
 
 #include "quiche/quic/core/quic_connection.h"
 

--- a/source/common/quic/envoy_quic_utils.cc
+++ b/source/common/quic/envoy_quic_utils.cc
@@ -10,6 +10,7 @@
 #include "source/common/network/socket_option_factory.h"
 #include "source/common/network/utility.h"
 #include "source/common/protobuf/utility.h"
+#include "source/common/runtime/runtime_features.h"
 
 #include "openssl/crypto.h"
 

--- a/source/extensions/filters/http/gcp_authn/BUILD
+++ b/source/extensions/filters/http/gcp_authn/BUILD
@@ -19,6 +19,7 @@ envoy_cc_library(
         "//source/common/http:headers_lib",
         "//source/common/http:message_lib",
         "//source/common/http:utility_lib",
+        "//source/common/runtime:runtime_features_lib",
         "//source/extensions/filters/http/common:factory_base_lib",
         "//source/extensions/filters/http/common:pass_through_filter_lib",
         "@envoy_api//envoy/extensions/filters/http/gcp_authn/v3:pkg_cc_proto",

--- a/source/extensions/filters/http/gcp_authn/gcp_authn_filter.cc
+++ b/source/extensions/filters/http/gcp_authn/gcp_authn_filter.cc
@@ -6,6 +6,7 @@
 #include "source/common/common/enum_to_int.h"
 #include "source/common/http/header_map_impl.h"
 #include "source/common/http/utility.h"
+#include "source/common/runtime/runtime_features.h"
 
 #include "absl/strings/str_replace.h"
 

--- a/test/common/quic/BUILD
+++ b/test/common/quic/BUILD
@@ -332,6 +332,7 @@ envoy_cc_test(
     rbe_pool = "6gig",
     deps = envoy_select_enable_http3([
         "//source/common/quic:envoy_quic_utils_lib",
+        "//source/common/runtime:runtime_lib",
         "//test/mocks/api:api_mocks",
         "//test/test_common:threadsafe_singleton_injector_lib",
         "@com_github_google_quiche//:quic_test_tools_test_utils_lib",

--- a/test/common/quic/envoy_quic_utils_test.cc
+++ b/test/common/quic/envoy_quic_utils_test.cc
@@ -1,4 +1,5 @@
 #include "source/common/quic/envoy_quic_utils.h"
+#include "source/common/runtime/runtime_features.h"
 
 #include "test/mocks/api/mocks.h"
 #include "test/test_common/threadsafe_singleton_injector.h"


### PR DESCRIPTION
Commit Message:
To prevent runtime headers to be pulled everywhere.

Risk Level: none
Testing: unit tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
