### PR TITLE
Remove dependency from runtime to codec

### DIFF
--- a/envoy/http/BUILD
+++ b/envoy/http/BUILD
@@ -41,9 +41,16 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
+    name = "codec_runtime_overrides",
+    hdrs = ["codec_runtime_overrides.h"],
+    deps = ["@com_google_absl//absl/strings"],
+)
+
+envoy_cc_library(
     name = "codec_interface",
     hdrs = ["codec.h"],
     deps = [
+        ":codec_runtime_overrides",
         ":header_map_interface",
         ":metadata_interface",
         ":protocol_interface",

--- a/envoy/http/codec.h
+++ b/envoy/http/codec.h
@@ -10,6 +10,7 @@
 #include "envoy/common/optref.h"
 #include "envoy/common/pure.h"
 #include "envoy/grpc/status.h"
+#include "envoy/http/codec_runtime_overrides.h"
 #include "envoy/http/header_formatter.h"
 #include "envoy/http/header_map.h"
 #include "envoy/http/metadata_interface.h"
@@ -36,20 +37,6 @@ struct CodecStats;
 namespace Http3 {
 struct CodecStats;
 }
-
-// Legacy default value of 60K is safely under both codec default limits.
-static constexpr uint32_t DEFAULT_MAX_REQUEST_HEADERS_KB = 60;
-// Default maximum number of headers.
-static constexpr uint32_t DEFAULT_MAX_HEADERS_COUNT = 100;
-
-constexpr absl::string_view MaxRequestHeadersCountOverrideKey =
-    "envoy.reloadable_features.max_request_headers_count";
-constexpr absl::string_view MaxResponseHeadersCountOverrideKey =
-    "envoy.reloadable_features.max_response_headers_count";
-constexpr absl::string_view MaxRequestHeadersSizeOverrideKey =
-    "envoy.reloadable_features.max_request_headers_size_kb";
-constexpr absl::string_view MaxResponseHeadersSizeOverrideKey =
-    "envoy.reloadable_features.max_response_headers_size_kb";
 
 class Stream;
 class RequestDecoder;

--- a/envoy/http/codec_runtime_overrides.h
+++ b/envoy/http/codec_runtime_overrides.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "absl/strings/string_view.h"
+
+namespace Envoy {
+namespace Http {
+
+// Legacy default value of 60K is safely under both codec default limits.
+static constexpr uint32_t DEFAULT_MAX_REQUEST_HEADERS_KB = 60;
+// Default maximum number of headers.
+static constexpr uint32_t DEFAULT_MAX_HEADERS_COUNT = 100;
+
+constexpr absl::string_view MaxRequestHeadersCountOverrideKey =
+    "envoy.reloadable_features.max_request_headers_count";
+constexpr absl::string_view MaxResponseHeadersCountOverrideKey =
+    "envoy.reloadable_features.max_response_headers_count";
+constexpr absl::string_view MaxRequestHeadersSizeOverrideKey =
+    "envoy.reloadable_features.max_request_headers_size_kb";
+constexpr absl::string_view MaxResponseHeadersSizeOverrideKey =
+    "envoy.reloadable_features.max_response_headers_size_kb";
+
+} // namespace Http
+} // namespace Envoy

--- a/source/common/runtime/BUILD
+++ b/source/common/runtime/BUILD
@@ -48,9 +48,8 @@ envoy_cc_library(
         # the harder it is to runtime-guard without dependency loops.
         "@com_google_absl//absl/flags:commandlineflag",
         "@com_google_absl//absl/flags:flag",
-        "//envoy/http:codec_interface",
+        "//envoy/http:codec_runtime_overrides",
         "//envoy/runtime:runtime_interface",
-        "//source/common/common:hash_lib",
         "//source/common/singleton:const_singleton",
     ],
 )

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -1,9 +1,12 @@
 #include "source/common/runtime/runtime_features.h"
 
-#include "envoy/http/codec.h"
+#include "envoy/http/codec_runtime_overrides.h"
+
+#include "source/common/singleton/const_singleton.h"
 
 #include "absl/flags/commandlineflag.h"
 #include "absl/flags/flag.h"
+#include "absl/flags/reflection.h"
 #include "absl/strings/match.h"
 #include "absl/strings/str_replace.h"
 

--- a/source/common/runtime/runtime_features.h
+++ b/source/common/runtime/runtime_features.h
@@ -1,14 +1,10 @@
 #pragma once
 
-#include <string>
+#include <cstdint>
 
 #include "envoy/runtime/runtime.h"
 
-#include "source/common/singleton/const_singleton.h"
-
-#include "absl/container/flat_hash_set.h"
-#include "absl/flags/flag.h"
-#include "absl/flags/reflection.h"
+#include "absl/strings/string_view.h"
 
 namespace Envoy {
 namespace Runtime {


### PR DESCRIPTION
Commit Message:
codec_interface dependency is very heavy and brings in libevent. This prevents WASM modules that need to use runtime facility from compiling with v8 runtime.

Risk Level: none
Testing: unit tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
