### PR TITLE
Unify scattered header matchers into ContainsHeader

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -71,7 +71,7 @@ CheckOptions:
     |^value_or$|
     |^Ip6(ntohl|htonl)$|
     |^get_$|
-    |^HeaderHasValue(Ref)?$|
+    |^(Pointee)?ContainsHeader$|
     |^HeaderValueOf$|
     |^Is(Superset|Subset)OfHeaders$|
     |^LLVMFuzzerInitialize$|

--- a/test/README.md
+++ b/test/README.md
@@ -17,7 +17,7 @@ downstream-Envoy-upstream communication.
 Envoy includes some custom Google Mock matchers to make test expectation
 statements simpler to write and easier to understand.
 
-### HeaderValueOf
+### ContainsHeader
 
 Tests that a HeaderMap argument contains exactly one header with the given key,
 whose value satisfies the given expectation. The expectation can be a matcher,
@@ -26,13 +26,13 @@ or a string that the value should equal.
 Examples:
 
 ```cpp
-EXPECT_THAT(response->headers(), HeaderValueOf(Headers::get().Server, "envoy"));
+EXPECT_THAT(response->headers(), ContainsHeader(Headers::get().Server, "envoy"));
 ```
 
 ```cpp
 using testing::HasSubstr;
 EXPECT_THAT(request->headers(),
-            HeaderValueOf(Headers::get().AcceptEncoding, HasSubstr("gzip")));
+            ContainsHeader(Headers::get().AcceptEncoding, HasSubstr("gzip")));
 ```
 
 ### HttpStatusIs

--- a/test/common/http/filter_manager_test.cc
+++ b/test/common/http/filter_manager_test.cc
@@ -180,7 +180,7 @@ TEST_F(FilterManagerTest, SendLocalReplyDuringDecodingGrpcClassiciation) {
   EXPECT_CALL(filter_manager_callbacks_, setResponseHeaders_(_))
       .WillOnce(Invoke([](auto& response_headers) {
         EXPECT_THAT(response_headers,
-                    HeaderHasValueRef(Http::Headers::get().ContentType, "application/grpc"));
+                    ContainsHeader(Http::Headers::get().ContentType, "application/grpc"));
       }));
   EXPECT_CALL(filter_manager_callbacks_, resetIdleTimer());
   EXPECT_CALL(filter_manager_callbacks_, encodeHeaders(_, _));
@@ -245,7 +245,7 @@ TEST_F(FilterManagerTest, SendLocalReplyDuringEncodingGrpcClassiciation) {
       .WillOnce(Invoke([](auto&) {}))
       .WillOnce(Invoke([](auto& response_headers) {
         EXPECT_THAT(response_headers,
-                    HeaderHasValueRef(Http::Headers::get().ContentType, "application/grpc"));
+                    ContainsHeader(Http::Headers::get().ContentType, "application/grpc"));
       }));
   EXPECT_CALL(filter_manager_callbacks_, encodeHeaders(_, _));
   EXPECT_CALL(filter_manager_callbacks_, endStream());

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -2694,7 +2694,7 @@ TEST_F(RouterTest, RetryRequestBeforeBody) {
 
   NiceMock<Http::MockRequestEncoder> encoder2;
   expectNewStreamWithImmediateEncoder(encoder2, &response_decoder, Http::Protocol::Http10);
-  EXPECT_CALL(encoder2, encodeHeaders(HeaderHasValueRef("myheader", "present"), false));
+  EXPECT_CALL(encoder2, encodeHeaders(ContainsHeader("myheader", "present"), false));
   router_->retry_state_->callback_();
   EXPECT_EQ(2U,
             callbacks_.route_->virtual_host_->virtual_cluster_.stats().upstream_rq_total_.value());
@@ -2747,7 +2747,7 @@ TEST_F(RouterTest, RetryRequestDuringBody) {
   NiceMock<Http::MockRequestEncoder> encoder2;
   expectNewStreamWithImmediateEncoder(encoder2, &response_decoder, Http::Protocol::Http10);
 
-  EXPECT_CALL(encoder2, encodeHeaders(HeaderHasValueRef("myheader", "present"), false));
+  EXPECT_CALL(encoder2, encodeHeaders(ContainsHeader("myheader", "present"), false));
   EXPECT_CALL(encoder2, encodeData(BufferStringEqual(body1), false));
   router_->retry_state_->callback_();
   EXPECT_EQ(2U,
@@ -2805,7 +2805,7 @@ TEST_F(RouterTest, RetryRequestDuringBodyDataBetweenAttemptsNotEndStream) {
   NiceMock<Http::MockRequestEncoder> encoder2;
   expectNewStreamWithImmediateEncoder(encoder2, &response_decoder, Http::Protocol::Http10);
 
-  EXPECT_CALL(encoder2, encodeHeaders(HeaderHasValueRef("myheader", "present"), false));
+  EXPECT_CALL(encoder2, encodeHeaders(ContainsHeader("myheader", "present"), false));
   EXPECT_CALL(encoder2, encodeData(BufferStringEqual(body1 + body2), false));
   router_->retry_state_->callback_();
   EXPECT_EQ(2U,
@@ -2888,7 +2888,7 @@ TEST_F(RouterTest, RetryRequestDuringBodyCompleteBetweenAttempts) {
   NiceMock<Http::MockRequestEncoder> encoder2;
   expectNewStreamWithImmediateEncoder(encoder2, &response_decoder, Http::Protocol::Http10);
 
-  EXPECT_CALL(encoder2, encodeHeaders(HeaderHasValueRef("myheader", "present"), false));
+  EXPECT_CALL(encoder2, encodeHeaders(ContainsHeader("myheader", "present"), false));
   EXPECT_CALL(encoder2, encodeData(BufferStringEqual(body1 + body2), true));
   router_->retry_state_->callback_();
   EXPECT_EQ(2U,
@@ -2938,7 +2938,7 @@ TEST_F(RouterTest, RetryRequestDuringBodyTrailerBetweenAttempts) {
   NiceMock<Http::MockRequestEncoder> encoder2;
   expectNewStreamWithImmediateEncoder(encoder2, &response_decoder, Http::Protocol::Http10);
 
-  EXPECT_CALL(encoder2, encodeHeaders(HeaderHasValueRef("myheader", "present"), false));
+  EXPECT_CALL(encoder2, encodeHeaders(ContainsHeader("myheader", "present"), false));
   EXPECT_CALL(encoder2, encodeData(BufferStringEqual(body1), false));
   EXPECT_CALL(encoder2, encodeTrailers(HeaderMapEqualRef(&trailers)));
   router_->retry_state_->callback_();
@@ -4930,8 +4930,8 @@ TEST_P(RouterShadowingTest, StreamingShadow) {
 
   Http::TestRequestTrailerMapImpl trailers{{"some", "trailer"}};
   EXPECT_CALL(callbacks_, decodingBuffer()).Times(0);
-  EXPECT_CALL(foo_request, captureAndSendTrailers_(Http::HeaderValueOf("some", "trailer")));
-  EXPECT_CALL(fizz_request, captureAndSendTrailers_(Http::HeaderValueOf("some", "trailer")));
+  EXPECT_CALL(foo_request, captureAndSendTrailers_(ContainsHeader("some", "trailer")));
+  EXPECT_CALL(fizz_request, captureAndSendTrailers_(ContainsHeader("some", "trailer")));
   router_->decodeTrailers(trailers);
   EXPECT_EQ(1U,
             callbacks_.route_->virtual_host_->virtual_cluster_.stats().upstream_rq_total_.value());

--- a/test/extensions/filters/http/cache/cache_filter_integration_test.cc
+++ b/test/extensions/filters/http/cache/cache_filter_integration_test.cc
@@ -150,8 +150,7 @@ TEST_P(CacheIntegrationTest, MissInsertHit) {
         sendHeaderOnlyRequestAwaitResponse(request_headers, serveFromCache());
     EXPECT_THAT(response_decoder->headers(), IsSupersetOfHeaders(response_headers));
     EXPECT_EQ(response_decoder->body(), response_body);
-    EXPECT_THAT(response_decoder->headers(),
-                HeaderHasValueRef(Http::CustomHeaders::get().Age, "10"));
+    EXPECT_THAT(response_decoder->headers(), ContainsHeader(Http::CustomHeaders::get().Age, "10"));
     // Advance time to force a log flush.
     simTime().advanceTimeWait(Seconds(1));
     EXPECT_THAT(waitForAccessLog(access_log_name_, 1),
@@ -222,8 +221,7 @@ TEST_P(CacheIntegrationTest, ExpiredValidated) {
   {
     IntegrationStreamDecoderPtr response_decoder =
         sendHeaderOnlyRequestAwaitResponse(request_headers, serveFromCache());
-    EXPECT_THAT(response_decoder->headers(),
-                HeaderHasValueRef(Http::CustomHeaders::get().Age, "1"));
+    EXPECT_THAT(response_decoder->headers(), ContainsHeader(Http::CustomHeaders::get().Age, "1"));
 
     // Advance time to force a log flush.
     simTime().advanceTimeWait(Seconds(1));
@@ -355,8 +353,7 @@ TEST_P(CacheIntegrationTest, GetRequestWithResponseTrailers) {
     IntegrationStreamDecoderPtr response_decoder =
         sendHeaderOnlyRequestAwaitResponse(request_headers, serveFromCache());
     EXPECT_THAT(response_decoder->headers(), IsSupersetOfHeaders(response_headers));
-    EXPECT_THAT(response_decoder->headers(),
-                HeaderHasValueRef(Http::CustomHeaders::get().Age, "10"));
+    EXPECT_THAT(response_decoder->headers(), ContainsHeader(Http::CustomHeaders::get().Age, "10"));
     EXPECT_EQ(response_decoder->body(), response_body);
     ASSERT_TRUE(response_decoder->trailers() != nullptr);
     simTime().advanceTimeWait(Seconds(1));
@@ -434,8 +431,7 @@ TEST_P(CacheIntegrationTest, ServeHeadFromCacheAfterGetRequest) {
         sendHeaderOnlyRequestAwaitResponse(request_headers, serveFromCache());
     EXPECT_THAT(response_decoder->headers(), IsSupersetOfHeaders(response_headers));
     EXPECT_EQ(response_decoder->body().size(), 0);
-    EXPECT_THAT(response_decoder->headers(),
-                HeaderHasValueRef(Http::CustomHeaders::get().Age, "10"));
+    EXPECT_THAT(response_decoder->headers(), ContainsHeader(Http::CustomHeaders::get().Age, "10"));
     // Advance time to force a log flush.
     simTime().advanceTimeWait(Seconds(1));
     EXPECT_THAT(waitForAccessLog(access_log_name_, 1),

--- a/test/extensions/filters/http/cache/cache_filter_test.cc
+++ b/test/extensions/filters/http/cache/cache_filter_test.cc
@@ -223,11 +223,10 @@ protected:
 
   void testDecodeRequestHitNoBody(CacheFilterSharedPtr filter) {
     // The filter should encode cached headers.
-    EXPECT_CALL(
-        decoder_callbacks_,
-        encodeHeaders_(testing::AllOf(IsSupersetOfHeaders(response_headers_),
-                                      HeaderHasValueRef(Http::CustomHeaders::get().Age, age)),
-                       true));
+    EXPECT_CALL(decoder_callbacks_,
+                encodeHeaders_(testing::AllOf(IsSupersetOfHeaders(response_headers_),
+                                              ContainsHeader(Http::CustomHeaders::get().Age, age)),
+                               true));
 
     // The filter should not encode any data as the response has no body.
     EXPECT_CALL(decoder_callbacks_, encodeData).Times(0);
@@ -250,11 +249,10 @@ protected:
 
   void testDecodeRequestHitWithBody(CacheFilterSharedPtr filter, std::string body) {
     // The filter should encode cached headers.
-    EXPECT_CALL(
-        decoder_callbacks_,
-        encodeHeaders_(testing::AllOf(IsSupersetOfHeaders(response_headers_),
-                                      HeaderHasValueRef(Http::CustomHeaders::get().Age, age)),
-                       false));
+    EXPECT_CALL(decoder_callbacks_,
+                encodeHeaders_(testing::AllOf(IsSupersetOfHeaders(response_headers_),
+                                              ContainsHeader(Http::CustomHeaders::get().Age, age)),
+                               false));
 
     // The filter should encode cached data.
     EXPECT_CALL(
@@ -1101,7 +1099,7 @@ TEST_F(CacheFilterTest, UnsuccessfulValidation) {
     receiveUpstreamBody(1, new_body, true);
 
     // The response headers should have the new status.
-    EXPECT_THAT(response_headers_, HeaderHasValueRef(Http::Headers::get().Status, "204"));
+    EXPECT_THAT(response_headers_, ContainsHeader(Http::Headers::get().Status, "204"));
 
     // The filter should not encode any data.
     EXPECT_CALL(encoder_callbacks_, addEncodedData).Times(0);
@@ -1136,11 +1134,10 @@ TEST_F(CacheFilterTest, SingleSatisfiableRange) {
     CacheFilterSharedPtr filter = makeFilter(simple_cache_);
 
     // Decode request 2 header
-    EXPECT_CALL(
-        decoder_callbacks_,
-        encodeHeaders_(testing::AllOf(IsSupersetOfHeaders(response_headers_),
-                                      HeaderHasValueRef(Http::CustomHeaders::get().Age, age)),
-                       false));
+    EXPECT_CALL(decoder_callbacks_,
+                encodeHeaders_(testing::AllOf(IsSupersetOfHeaders(response_headers_),
+                                              ContainsHeader(Http::CustomHeaders::get().Age, age)),
+                               false));
 
     EXPECT_CALL(
         decoder_callbacks_,
@@ -1177,11 +1174,10 @@ TEST_F(CacheFilterTest, MultipleSatisfiableRanges) {
     CacheFilterSharedPtr filter = makeFilter(simple_cache_);
 
     // Decode request 2 header
-    EXPECT_CALL(
-        decoder_callbacks_,
-        encodeHeaders_(testing::AllOf(IsSupersetOfHeaders(response_headers_),
-                                      HeaderHasValueRef(Http::CustomHeaders::get().Age, age)),
-                       false));
+    EXPECT_CALL(decoder_callbacks_,
+                encodeHeaders_(testing::AllOf(IsSupersetOfHeaders(response_headers_),
+                                              ContainsHeader(Http::CustomHeaders::get().Age, age)),
+                               false));
 
     EXPECT_CALL(
         decoder_callbacks_,
@@ -1220,11 +1216,10 @@ TEST_F(CacheFilterTest, NotSatisfiableRange) {
     CacheFilterSharedPtr filter = makeFilter(simple_cache_);
 
     // Decode request 2 header
-    EXPECT_CALL(
-        decoder_callbacks_,
-        encodeHeaders_(testing::AllOf(IsSupersetOfHeaders(response_headers_),
-                                      HeaderHasValueRef(Http::CustomHeaders::get().Age, age)),
-                       true));
+    EXPECT_CALL(decoder_callbacks_,
+                encodeHeaders_(testing::AllOf(IsSupersetOfHeaders(response_headers_),
+                                              ContainsHeader(Http::CustomHeaders::get().Age, age)),
+                               true));
 
     // 416 response should not have a body, so we don't expect a call to encodeData
     EXPECT_CALL(decoder_callbacks_,

--- a/test/extensions/filters/http/cache/http_cache_test.cc
+++ b/test/extensions/filters/http/cache/http_cache_test.cc
@@ -199,7 +199,7 @@ TEST_P(LookupRequestTest, ResultWithoutBodyMatchesExpectation) {
   ASSERT_TRUE(lookup_response.headers_);
   EXPECT_THAT(*lookup_response.headers_, Http::IsSupersetOfHeaders(response_headers));
   EXPECT_THAT(*lookup_response.headers_,
-              HeaderHasValueRef(Http::CustomHeaders::get().Age, GetParam().expected_age));
+              ContainsHeader(Http::CustomHeaders::get().Age, GetParam().expected_age));
   EXPECT_EQ(lookup_response.content_length_, 0);
 }
 
@@ -217,7 +217,7 @@ TEST_P(LookupRequestTest, ResultWithUnknownContentLengthMatchesExpectation) {
   ASSERT_TRUE(lookup_response.headers_);
   EXPECT_THAT(*lookup_response.headers_, Http::IsSupersetOfHeaders(response_headers));
   EXPECT_THAT(*lookup_response.headers_,
-              HeaderHasValueRef(Http::CustomHeaders::get().Age, GetParam().expected_age));
+              ContainsHeader(Http::CustomHeaders::get().Age, GetParam().expected_age));
   EXPECT_FALSE(lookup_response.content_length_.has_value());
 }
 
@@ -237,7 +237,7 @@ TEST_P(LookupRequestTest, ResultWithBodyMatchesExpectation) {
   ASSERT_TRUE(lookup_response.headers_);
   EXPECT_THAT(*lookup_response.headers_, Http::IsSupersetOfHeaders(response_headers));
   EXPECT_THAT(*lookup_response.headers_,
-              HeaderHasValueRef(Http::CustomHeaders::get().Age, GetParam().expected_age));
+              ContainsHeader(Http::CustomHeaders::get().Age, GetParam().expected_age));
   EXPECT_EQ(lookup_response.content_length_, content_length);
 }
 
@@ -357,7 +357,7 @@ TEST_P(LookupRequestTest, ResultWithBodyAndTrailersMatchesExpectation) {
   EXPECT_THAT(*lookup_response.headers_, Http::IsSupersetOfHeaders(response_headers));
   // Age is populated in LookupRequest::makeLookupResult, which is called in makeLookupResult.
   EXPECT_THAT(*lookup_response.headers_,
-              HeaderHasValueRef(Http::CustomHeaders::get().Age, GetParam().expected_age));
+              ContainsHeader(Http::CustomHeaders::get().Age, GetParam().expected_age));
   EXPECT_EQ(lookup_response.content_length_, content_length);
 }
 

--- a/test/extensions/filters/http/common/jwks_fetcher_test.cc
+++ b/test/extensions/filters/http/common/jwks_fetcher_test.cc
@@ -330,8 +330,7 @@ TEST_F(JwksFetcherTest, TestSchemeHeaderHttps) {
       .WillOnce(testing::Invoke(
           [](Http::RequestMessagePtr& message, Http::AsyncClient::Callbacks&,
              const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
-            EXPECT_THAT(message->headers(),
-                        HeaderHasValueRef(Http::Headers::get().Scheme, "https"));
+            EXPECT_THAT(message->headers(), ContainsHeader(Http::Headers::get().Scheme, "https"));
             return nullptr;
           }));
 
@@ -356,7 +355,7 @@ TEST_F(JwksFetcherTest, TestSchemeHeaderHttp) {
       .WillOnce(testing::Invoke(
           [](Http::RequestMessagePtr& message, Http::AsyncClient::Callbacks&,
              const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
-            EXPECT_THAT(message->headers(), HeaderHasValueRef(Http::Headers::get().Scheme, "http"));
+            EXPECT_THAT(message->headers(), ContainsHeader(Http::Headers::get().Scheme, "http"));
             return nullptr;
           }));
 

--- a/test/extensions/filters/http/connect_grpc_bridge/connect_grpc_bridge_integration_test.cc
+++ b/test/extensions/filters/http/connect_grpc_bridge/connect_grpc_bridge_integration_test.cc
@@ -100,11 +100,11 @@ TEST_P(ConnectIntegrationTest, ConnectFilterUnaryRequestE2E) {
   EXPECT_THAT(grpc_request, ProtoEq(connect_request));
 
   EXPECT_THAT(upstream_request_->headers(),
-              HeaderHasValueRef(Http::Headers::get().ContentType, "application/grpc+proto"));
+              ContainsHeader(Http::Headers::get().ContentType, "application/grpc+proto"));
   EXPECT_THAT(upstream_request_->headers(),
-              HeaderHasValueRef(Http::Headers::get().Path, "/Service/Method"));
+              ContainsHeader(Http::Headers::get().Path, "/Service/Method"));
   EXPECT_THAT(upstream_request_->headers(),
-              HeaderHasValueRef(Http::CustomHeaders::get().GrpcTimeout, "10000m"));
+              ContainsHeader(Http::CustomHeaders::get().GrpcTimeout, "10000m"));
 
   helloworld::HelloReply grpc_response;
   grpc_response.set_message("success");
@@ -119,7 +119,7 @@ TEST_P(ConnectIntegrationTest, ConnectFilterUnaryRequestE2E) {
   EXPECT_TRUE(response->complete());
   EXPECT_THAT(response->headers(), Http::HttpStatusIs("200"));
   EXPECT_THAT(response->headers(),
-              HeaderHasValueRef(Http::Headers::get().ContentType, "application/proto"));
+              ContainsHeader(Http::Headers::get().ContentType, "application/proto"));
 
   helloworld::HelloReply connect_response;
   ASSERT_TRUE(connect_response.ParseFromString(response->body()));
@@ -150,11 +150,11 @@ TEST_P(ConnectIntegrationTest, ConnectFilterStreamingRequestE2E) {
   EXPECT_THAT(grpc_request, ProtoEq(connect_request));
 
   EXPECT_THAT(upstream_request_->headers(),
-              HeaderHasValueRef(Http::Headers::get().ContentType, "application/grpc+proto"));
+              ContainsHeader(Http::Headers::get().ContentType, "application/grpc+proto"));
   EXPECT_THAT(upstream_request_->headers(),
-              HeaderHasValueRef(Http::Headers::get().Path, "/Service/Method"));
+              ContainsHeader(Http::Headers::get().Path, "/Service/Method"));
   EXPECT_THAT(upstream_request_->headers(),
-              HeaderHasValueRef(Http::CustomHeaders::get().GrpcTimeout, "10000m"));
+              ContainsHeader(Http::CustomHeaders::get().GrpcTimeout, "10000m"));
 
   helloworld::HelloReply grpc_response;
   grpc_response.set_message("success");
@@ -170,7 +170,7 @@ TEST_P(ConnectIntegrationTest, ConnectFilterStreamingRequestE2E) {
   EXPECT_TRUE(response->complete());
   EXPECT_THAT(response->headers(), Http::HttpStatusIs("200"));
   EXPECT_THAT(response->headers(),
-              HeaderHasValueRef(Http::Headers::get().ContentType, "application/connect+proto"));
+              ContainsHeader(Http::Headers::get().ContentType, "application/connect+proto"));
 
   Buffer::OwnedImpl response_body{response->body()};
   ASSERT_THAT(response_body.length(), testing::Gt(5));

--- a/test/extensions/filters/http/ext_authz/ext_authz_integration_test.cc
+++ b/test/extensions/filters/http/ext_authz/ext_authz_integration_test.cc
@@ -380,17 +380,17 @@ public:
 
     if (opts.failure_mode_allowed_header) {
       EXPECT_THAT(upstream_request_->headers(),
-                  Http::HeaderValueOf("x-envoy-auth-failure-mode-allowed", "true"));
+                  ContainsHeader("x-envoy-auth-failure-mode-allowed", "true"));
     }
     // Check that ext_authz didn't remove this downstream header which should be immune to
     // mutations.
     EXPECT_THAT(upstream_request_->headers(),
-                Http::HeaderValueOf("disallow-mutation-downstream-req",
-                                    "authz resp cannot set or append to this header"));
+                ContainsHeader("disallow-mutation-downstream-req",
+                               "authz resp cannot set or append to this header"));
 
     for (const auto& header_to_add : opts.headers_to_add) {
       EXPECT_THAT(upstream_request_->headers(),
-                  Http::HeaderValueOf(header_to_add.first, header_to_add.second));
+                  ContainsHeader(header_to_add.first, header_to_add.second));
       // For headers_to_add (with append = false), the original request headers have no "-replaced"
       // suffix, but the ones from the authorization server have it.
       EXPECT_TRUE(absl::EndsWith(header_to_add.second, "-replaced"));
@@ -403,7 +403,7 @@ public:
       // header is existed in the original request headers).
       EXPECT_THAT(
           upstream_request_->headers(),
-          Http::HeaderValueOf(
+          ContainsHeader(
               header_to_append.first,
               // In this test, the keys and values of the original request headers have the same
               // string value. Hence for "header2" key, the value is "header2,header2-appended".
@@ -430,7 +430,7 @@ public:
       // headers_to_append_multiple has append = false for the first entry of multiple entries, and
       // append = true for the rest entries.
       EXPECT_THAT(upstream_request_->headers(),
-                  Http::HeaderValueOf("multiple", "multiple-first,multiple-second"));
+                  ContainsHeader("multiple", "multiple-first,multiple-second"));
     }
 
     for (const auto& header_to_remove : opts.headers_to_remove) {
@@ -746,11 +746,11 @@ public:
     result = ext_authz_request_->waitForEndStream(*dispatcher_);
     RELEASE_ASSERT(result, result.message());
 
-    EXPECT_THAT(ext_authz_request_->headers(), Http::HeaderValueOf("allowed-prefix-one", "one"));
-    EXPECT_THAT(ext_authz_request_->headers(), Http::HeaderValueOf("allowed-prefix-two", "two"));
-    EXPECT_THAT(ext_authz_request_->headers(), Http::HeaderValueOf("authorization", "legit"));
-    EXPECT_THAT(ext_authz_request_->headers(), Http::HeaderValueOf("regex-food", "food"));
-    EXPECT_THAT(ext_authz_request_->headers(), Http::HeaderValueOf("regex-fool", "fool"));
+    EXPECT_THAT(ext_authz_request_->headers(), ContainsHeader("allowed-prefix-one", "one"));
+    EXPECT_THAT(ext_authz_request_->headers(), ContainsHeader("allowed-prefix-two", "two"));
+    EXPECT_THAT(ext_authz_request_->headers(), ContainsHeader("authorization", "legit"));
+    EXPECT_THAT(ext_authz_request_->headers(), ContainsHeader("regex-food", "food"));
+    EXPECT_THAT(ext_authz_request_->headers(), ContainsHeader("regex-fool", "fool"));
 
     EXPECT_TRUE(ext_authz_request_->headers()
                     .get(Http::LowerCaseString(std::string("not-allowed")))
@@ -859,7 +859,7 @@ public:
     // The original client request header value of "baz" is "foo". Since we configure to "override"
     // the value of "baz", we expect the request headers to be sent to upstream contain only one
     // "baz" with value "baz" (set by the authorization server).
-    EXPECT_THAT(upstream_request_->headers(), Http::HeaderValueOf("baz", "baz"));
+    EXPECT_THAT(upstream_request_->headers(), ContainsHeader("baz", "baz"));
 
     // The original client request header value of "bat" is "foo". Since we configure to "append"
     // the value of "bat", we expect the request headers to be sent to upstream contain two "bat"s,
@@ -1428,7 +1428,7 @@ TEST_P(ExtAuthzHttpIntegrationTest, DefaultCaseSensitiveStringMatcher) {
 // Verifies that "X-Forwarded-For" header is unmodified.
 TEST_P(ExtAuthzHttpIntegrationTest, UnmodifiedForwardedForHeader) {
   setup(false);
-  EXPECT_THAT(ext_authz_request_->headers(), Http::HeaderValueOf("x-forwarded-for", "1.2.3.4"));
+  EXPECT_THAT(ext_authz_request_->headers(), ContainsHeader("x-forwarded-for", "1.2.3.4"));
 }
 
 // Verifies that by default HTTP service uses the case-sensitive string matcher
@@ -1548,7 +1548,7 @@ TEST_P(ExtAuthzHttpIntegrationTest, TimeoutFailOpen) {
   RELEASE_ASSERT(result, result.message());
 
   EXPECT_THAT(upstream_request_->headers(),
-              Http::HeaderValueOf("x-envoy-auth-failure-mode-allowed", "true"));
+              ContainsHeader("x-envoy-auth-failure-mode-allowed", "true"));
 
   upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, true);
   ASSERT_TRUE(response_->waitForEndStream());

--- a/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
+++ b/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
@@ -360,8 +360,8 @@ protected:
 
   void verifyChunkedEncoding(const Http::RequestOrResponseHeaderMap& headers) {
     EXPECT_EQ(headers.ContentLength(), nullptr);
-    EXPECT_THAT(headers, HeaderValueOf(Http::Headers::get().TransferEncoding,
-                                       Http::Headers::get().TransferEncodingValues.Chunked));
+    EXPECT_THAT(headers, ContainsHeader(Http::Headers::get().TransferEncoding,
+                                        Http::Headers::get().TransferEncodingValues.Chunked));
   }
 
   void handleUpstreamRequestWithTrailer() {

--- a/test/extensions/filters/http/ext_proc/utils.h
+++ b/test/extensions/filters/http/ext_proc/utils.h
@@ -33,23 +33,6 @@ MATCHER_P(HeaderProtosEqual, expected, "HTTP header protos match") {
   return ExtProcTestUtility::headerProtosEqualIgnoreOrder(expected, arg);
 }
 
-MATCHER_P(HasNoHeader, key, absl::StrFormat("Headers have no value for \"%s\"", key)) {
-  return arg.get(::Envoy::Http::LowerCaseString(std::string(key))).empty();
-}
-
-MATCHER_P(HasHeader, key, absl::StrFormat("There exists a header for \"%s\"", key)) {
-  return !arg.get(::Envoy::Http::LowerCaseString(std::string(key))).empty();
-}
-
-MATCHER_P2(SingleHeaderValueIs, key, value,
-           absl::StrFormat("Header \"%s\" equals \"%s\"", key, value)) {
-  const auto hdr = arg.get(::Envoy::Http::LowerCaseString(std::string(key)));
-  if (hdr.size() != 1) {
-    return false;
-  }
-  return hdr[0]->value() == value;
-}
-
 template <typename... Args>
 inline void verifyMultipleHeaderValues(const Envoy::Http::HeaderMap& headers,
                                        Envoy::Http::LowerCaseString const& key, Args... values) {

--- a/test/extensions/filters/http/fault/fault_filter_integration_test.cc
+++ b/test/extensions/filters/http/fault/fault_filter_integration_test.cc
@@ -329,10 +329,10 @@ TEST_P(FaultIntegrationTestAllProtocols, HeaderFaultAbortGrpcConfig) {
   EXPECT_TRUE(response->complete());
   EXPECT_THAT(response->headers(), Envoy::Http::HttpStatusIs("200"));
   EXPECT_THAT(response->headers(),
-              HeaderValueOf(Http::Headers::get().ContentType, "application/grpc"));
-  EXPECT_THAT(response->headers(), HeaderValueOf(Http::Headers::get().GrpcStatus, "5"));
+              ContainsHeader(Http::Headers::get().ContentType, "application/grpc"));
+  EXPECT_THAT(response->headers(), ContainsHeader(Http::Headers::get().GrpcStatus, "5"));
   EXPECT_THAT(response->headers(),
-              HeaderValueOf(Http::Headers::get().GrpcMessage, "fault filter abort"));
+              ContainsHeader(Http::Headers::get().GrpcMessage, "fault filter abort"));
   EXPECT_EQ(nullptr, response->trailers());
 
   EXPECT_EQ(1UL, test_server_->counter("http.config_test.fault.aborts_injected")->value());
@@ -380,10 +380,10 @@ TEST_P(FaultIntegrationTestAllProtocols, FaultAbortGrpcConfig) {
   EXPECT_TRUE(response->complete());
   EXPECT_THAT(response->headers(), Envoy::Http::HttpStatusIs("200"));
   EXPECT_THAT(response->headers(),
-              HeaderValueOf(Http::Headers::get().ContentType, "application/grpc"));
-  EXPECT_THAT(response->headers(), HeaderValueOf(Http::Headers::get().GrpcStatus, "5"));
+              ContainsHeader(Http::Headers::get().ContentType, "application/grpc"));
+  EXPECT_THAT(response->headers(), ContainsHeader(Http::Headers::get().GrpcStatus, "5"));
   EXPECT_THAT(response->headers(),
-              HeaderValueOf(Http::Headers::get().GrpcMessage, "fault filter abort"));
+              ContainsHeader(Http::Headers::get().GrpcMessage, "fault filter abort"));
   EXPECT_EQ(nullptr, response->trailers());
 
   EXPECT_EQ(1UL, test_server_->counter("http.config_test.fault.aborts_injected")->value());

--- a/test/extensions/filters/http/grpc_http1_bridge/grpc_http1_bridge_integration_test.cc
+++ b/test/extensions/filters/http/grpc_http1_bridge/grpc_http1_bridge_integration_test.cc
@@ -42,7 +42,7 @@ TEST_P(GrpcIntegrationTest, HittingGrpcFilterLimitBufferingHeaders) {
   EXPECT_TRUE(response->complete());
   EXPECT_THAT(response->headers(), Http::HttpStatusIs("200"));
   EXPECT_THAT(response->headers(),
-              HeaderValueOf(Http::Headers::get().GrpcStatus, "2")); // Unknown gRPC error
+              ContainsHeader(Http::Headers::get().GrpcStatus, "2")); // Unknown gRPC error
 }
 
 INSTANTIATE_TEST_SUITE_P(IpVersions, GrpcIntegrationTest,

--- a/test/extensions/filters/http/grpc_http1_reverse_bridge/reverse_bridge_integration_test.cc
+++ b/test/extensions/filters/http/grpc_http1_reverse_bridge/reverse_bridge_integration_test.cc
@@ -12,8 +12,6 @@
 #include "fmt/printf.h"
 #include "gtest/gtest.h"
 
-using Envoy::Http::HeaderValueOf;
-
 // for ::operator""s (which Windows compiler does not support):
 using namespace std::string_literals;
 
@@ -87,7 +85,7 @@ TEST_P(ReverseBridgeIntegrationTest, DisabledRoute) {
   // Ensure that we don't do anything
   EXPECT_EQ("abcdef", upstream_request_->body().toString());
   EXPECT_THAT(upstream_request_->headers(),
-              HeaderValueOf(Http::Headers::get().ContentType, "application/grpc"));
+              ContainsHeader(Http::Headers::get().ContentType, "application/grpc"));
 
   // Respond to the request.
   Http::TestResponseHeaderMapImpl response_headers;
@@ -107,8 +105,8 @@ TEST_P(ReverseBridgeIntegrationTest, DisabledRoute) {
 
   EXPECT_EQ(response->body(), response_data.toString());
   EXPECT_THAT(response->headers(),
-              HeaderValueOf(Http::Headers::get().ContentType, "application/grpc"));
-  EXPECT_THAT(*response->trailers(), HeaderValueOf(Http::Headers::get().GrpcStatus, "0"));
+              ContainsHeader(Http::Headers::get().ContentType, "application/grpc"));
+  EXPECT_THAT(*response->trailers(), ContainsHeader(Http::Headers::get().GrpcStatus, "0"));
 
   codec_client_->close();
   ASSERT_TRUE(fake_upstream_connection_->close());
@@ -138,9 +136,9 @@ TEST_P(ReverseBridgeIntegrationTest, EnabledRoute) {
   EXPECT_EQ("f", upstream_request_->body().toString());
 
   EXPECT_THAT(upstream_request_->headers(),
-              HeaderValueOf(Http::Headers::get().ContentType, "application/x-protobuf"));
+              ContainsHeader(Http::Headers::get().ContentType, "application/x-protobuf"));
   EXPECT_THAT(upstream_request_->headers(),
-              HeaderValueOf(Http::CustomHeaders::get().Accept, "application/x-protobuf"));
+              ContainsHeader(Http::CustomHeaders::get().Accept, "application/x-protobuf"));
 
   // Respond to the request.
   Http::TestResponseHeaderMapImpl response_headers;
@@ -165,8 +163,8 @@ TEST_P(ReverseBridgeIntegrationTest, EnabledRoute) {
   EXPECT_TRUE(
       std::equal(response->body().begin(), response->body().begin() + 5, expected_prefix.begin()));
   EXPECT_THAT(response->headers(),
-              HeaderValueOf(Http::Headers::get().ContentType, "application/grpc"));
-  EXPECT_THAT(*response->trailers(), HeaderValueOf(Http::Headers::get().GrpcStatus, "0"));
+              ContainsHeader(Http::Headers::get().ContentType, "application/grpc"));
+  EXPECT_THAT(*response->trailers(), ContainsHeader(Http::Headers::get().GrpcStatus, "0"));
 
   codec_client_->close();
   ASSERT_TRUE(fake_upstream_connection_->close());
@@ -195,8 +193,8 @@ TEST_P(ReverseBridgeIntegrationTest, EnabledRouteBadContentType) {
 
   // The response should indicate an error.
   EXPECT_THAT(response->headers(),
-              HeaderValueOf(Http::Headers::get().ContentType, "application/grpc"));
-  EXPECT_THAT(response->headers(), HeaderValueOf(Http::Headers::get().GrpcStatus, "2"));
+              ContainsHeader(Http::Headers::get().ContentType, "application/grpc"));
+  EXPECT_THAT(response->headers(), ContainsHeader(Http::Headers::get().GrpcStatus, "2"));
 
   codec_client_->close();
   ASSERT_TRUE(fake_upstream_connection_->close());
@@ -229,9 +227,9 @@ TEST_P(ReverseBridgeIntegrationTest, EnabledRouteStreamResponse) {
   EXPECT_EQ("f", upstream_request_->body().toString());
 
   EXPECT_THAT(upstream_request_->headers(),
-              HeaderValueOf(Http::Headers::get().ContentType, "application/x-protobuf"));
+              ContainsHeader(Http::Headers::get().ContentType, "application/x-protobuf"));
   EXPECT_THAT(upstream_request_->headers(),
-              HeaderValueOf(Http::CustomHeaders::get().Accept, "application/x-protobuf"));
+              ContainsHeader(Http::CustomHeaders::get().Accept, "application/x-protobuf"));
 
   // Respond to the request.
   Http::TestResponseHeaderMapImpl response_headers;
@@ -265,8 +263,8 @@ TEST_P(ReverseBridgeIntegrationTest, EnabledRouteStreamResponse) {
   EXPECT_TRUE(
       std::equal(response->body().begin(), response->body().begin() + 5, expected_prefix.begin()));
   EXPECT_THAT(response->headers(),
-              HeaderValueOf(Http::Headers::get().ContentType, "application/grpc"));
-  EXPECT_THAT(*response->trailers(), HeaderValueOf(Http::Headers::get().GrpcStatus, "0"));
+              ContainsHeader(Http::Headers::get().ContentType, "application/grpc"));
+  EXPECT_THAT(*response->trailers(), ContainsHeader(Http::Headers::get().GrpcStatus, "0"));
 
   codec_client_->close();
   ASSERT_TRUE(fake_upstream_connection_->close());
@@ -298,9 +296,9 @@ TEST_P(ReverseBridgeIntegrationTest, EnabledRouteStreamWithholdResponse) {
   EXPECT_EQ("f", upstream_request_->body().toString());
 
   EXPECT_THAT(upstream_request_->headers(),
-              HeaderValueOf(Http::Headers::get().ContentType, "application/x-protobuf"));
+              ContainsHeader(Http::Headers::get().ContentType, "application/x-protobuf"));
   EXPECT_THAT(upstream_request_->headers(),
-              HeaderValueOf(Http::CustomHeaders::get().Accept, "application/x-protobuf"));
+              ContainsHeader(Http::CustomHeaders::get().Accept, "application/x-protobuf"));
 
   // Respond to the request.
   Http::TestResponseHeaderMapImpl response_headers;

--- a/test/extensions/filters/http/grpc_json_reverse_transcoder/grpc_json_reverse_transcoder_integration_test.cc
+++ b/test/extensions/filters/http/grpc_json_reverse_transcoder/grpc_json_reverse_transcoder_integration_test.cc
@@ -99,14 +99,14 @@ TEST_P(GrpcJsonReverseTranscoderIntegrationTest, SimpleRequest) {
   ASSERT_TRUE(upstream_request_->waitForEndStream(*dispatcher_));
 
   std::string expected_request = "{\"author\":\"John Doe\",\"id\":\"123\",\"title\":\"Kids book\"}";
+  EXPECT_THAT(upstream_request_->headers(),
+              ContainsHeader(Http::Headers::get().ContentType,
+                             Http::Headers::get().ContentTypeValues.Json));
   EXPECT_THAT(
       upstream_request_->headers(),
-      HeaderValueOf(Http::Headers::get().ContentType, Http::Headers::get().ContentTypeValues.Json));
+      ContainsHeader(Http::Headers::get().ContentLength, std::to_string(expected_request.size())));
   EXPECT_THAT(upstream_request_->headers(),
-              Http::HeaderValueOf(Http::Headers::get().ContentLength,
-                                  std::to_string(expected_request.size())));
-  EXPECT_THAT(upstream_request_->headers(),
-              Http::HeaderValueOf(Http::Headers::get().Path, "/shelves/12345/books/123"));
+              ContainsHeader(Http::Headers::get().Path, "/shelves/12345/books/123"));
   EXPECT_EQ(upstream_request_->body().toString(), expected_request);
 
   Http::TestResponseHeaderMapImpl response_headers;
@@ -124,8 +124,8 @@ TEST_P(GrpcJsonReverseTranscoderIntegrationTest, SimpleRequest) {
   ASSERT_TRUE(response->waitForEndStream());
   EXPECT_TRUE(response->complete());
 
-  EXPECT_THAT(response->headers(), HeaderValueOf(Http::Headers::get().ContentType,
-                                                 Http::Headers::get().ContentTypeValues.Grpc));
+  EXPECT_THAT(response->headers(), ContainsHeader(Http::Headers::get().ContentType,
+                                                  Http::Headers::get().ContentTypeValues.Grpc));
 
   bookstore::Book expected_book;
   expected_book.set_id(123);
@@ -143,7 +143,7 @@ TEST_P(GrpcJsonReverseTranscoderIntegrationTest, SimpleRequest) {
 
   EXPECT_TRUE(MessageDifferencer::Equals(expected_book, book));
 
-  EXPECT_THAT(*response->trailers(), HeaderValueOf(Http::Headers::get().GrpcStatus, "0"));
+  EXPECT_THAT(*response->trailers(), ContainsHeader(Http::Headers::get().GrpcStatus, "0"));
 
   codec_client_->close();
   ASSERT_TRUE(fake_upstream_connection_->close());
@@ -176,14 +176,13 @@ TEST_P(GrpcJsonReverseTranscoderIntegrationTest, HttpBodyRequestResponse) {
   ASSERT_TRUE(fake_upstream_connection_->waitForNewStream(*dispatcher_, upstream_request_));
   ASSERT_TRUE(upstream_request_->waitForEndStream(*dispatcher_));
 
-  EXPECT_THAT(
-      upstream_request_->headers(),
-      HeaderValueOf(Http::Headers::get().ContentType, Http::Headers::get().ContentTypeValues.Text));
-  EXPECT_THAT(
-      upstream_request_->headers(),
-      Http::HeaderValueOf(Http::Headers::get().ContentLength, std::to_string(request_str.size())));
   EXPECT_THAT(upstream_request_->headers(),
-              Http::HeaderValueOf(Http::Headers::get().Path, "/echoRawBody"));
+              ContainsHeader(Http::Headers::get().ContentType,
+                             Http::Headers::get().ContentTypeValues.Text));
+  EXPECT_THAT(upstream_request_->headers(), ContainsHeader(Http::Headers::get().ContentLength,
+                                                           std::to_string(request_str.size())));
+  EXPECT_THAT(upstream_request_->headers(),
+              ContainsHeader(Http::Headers::get().Path, "/echoRawBody"));
   EXPECT_EQ(upstream_request_->body().toString(), request_str);
 
   Http::TestResponseHeaderMapImpl response_headers;
@@ -202,8 +201,8 @@ TEST_P(GrpcJsonReverseTranscoderIntegrationTest, HttpBodyRequestResponse) {
   ASSERT_TRUE(response->waitForEndStream());
   EXPECT_TRUE(response->complete());
 
-  EXPECT_THAT(response->headers(), HeaderValueOf(Http::Headers::get().ContentType,
-                                                 Http::Headers::get().ContentTypeValues.Grpc));
+  EXPECT_THAT(response->headers(), ContainsHeader(Http::Headers::get().ContentType,
+                                                  Http::Headers::get().ContentTypeValues.Grpc));
 
   google::api::HttpBody expected_res;
   expected_res.set_content_type(Http::Headers::get().ContentTypeValues.Html);
@@ -219,7 +218,7 @@ TEST_P(GrpcJsonReverseTranscoderIntegrationTest, HttpBodyRequestResponse) {
 
   EXPECT_TRUE(MessageDifferencer::Equals(expected_res, transcoded_res));
 
-  EXPECT_THAT(*response->trailers(), HeaderValueOf(Http::Headers::get().GrpcStatus, "0"));
+  EXPECT_THAT(*response->trailers(), ContainsHeader(Http::Headers::get().GrpcStatus, "0"));
 
   codec_client_->close();
   ASSERT_TRUE(fake_upstream_connection_->close());
@@ -261,13 +260,13 @@ TEST_P(GrpcJsonReverseTranscoderIntegrationTest, NestedHttpBodyRequest) {
   ASSERT_TRUE(fake_upstream_connection_->waitForNewStream(*dispatcher_, upstream_request_));
   ASSERT_TRUE(upstream_request_->waitForEndStream(*dispatcher_));
 
-  EXPECT_THAT(
-      upstream_request_->headers(),
-      HeaderValueOf(Http::Headers::get().ContentType, Http::Headers::get().ContentTypeValues.Json));
-  EXPECT_THAT(upstream_request_->headers(), Http::HeaderValueOf(Http::Headers::get().ContentLength,
-                                                                std::to_string(book_str.size())));
   EXPECT_THAT(upstream_request_->headers(),
-              Http::HeaderValueOf(Http::Headers::get().Path, "/v2/shelves/12345/books"));
+              ContainsHeader(Http::Headers::get().ContentType,
+                             Http::Headers::get().ContentTypeValues.Json));
+  EXPECT_THAT(upstream_request_->headers(),
+              ContainsHeader(Http::Headers::get().ContentLength, std::to_string(book_str.size())));
+  EXPECT_THAT(upstream_request_->headers(),
+              ContainsHeader(Http::Headers::get().Path, "/v2/shelves/12345/books"));
   EXPECT_EQ(upstream_request_->body().toString(), book_str);
 
   Http::TestResponseHeaderMapImpl response_headers;
@@ -286,8 +285,8 @@ TEST_P(GrpcJsonReverseTranscoderIntegrationTest, NestedHttpBodyRequest) {
   ASSERT_TRUE(response->waitForEndStream());
   EXPECT_TRUE(response->complete());
 
-  EXPECT_THAT(response->headers(), HeaderValueOf(Http::Headers::get().ContentType,
-                                                 Http::Headers::get().ContentTypeValues.Grpc));
+  EXPECT_THAT(response->headers(), ContainsHeader(Http::Headers::get().ContentType,
+                                                  Http::Headers::get().ContentTypeValues.Grpc));
 
   google::api::HttpBody expected_res;
   expected_res.set_content_type(Http::Headers::get().ContentTypeValues.Html);
@@ -303,7 +302,7 @@ TEST_P(GrpcJsonReverseTranscoderIntegrationTest, NestedHttpBodyRequest) {
 
   EXPECT_TRUE(MessageDifferencer::Equals(expected_res, transcoded_res));
 
-  EXPECT_THAT(*response->trailers(), HeaderValueOf(Http::Headers::get().GrpcStatus, "0"));
+  EXPECT_THAT(*response->trailers(), ContainsHeader(Http::Headers::get().GrpcStatus, "0"));
 
   codec_client_->close();
   ASSERT_TRUE(fake_upstream_connection_->close());
@@ -337,10 +336,10 @@ TEST_P(GrpcJsonReverseTranscoderIntegrationTest, RequestWithQueryParams) {
   ASSERT_TRUE(upstream_request_->waitForEndStream(*dispatcher_));
 
   EXPECT_THAT(upstream_request_->headers(),
-              HeaderValueOf(Http::Headers::get().Method, Http::Headers::get().MethodValues.Get));
+              ContainsHeader(Http::Headers::get().Method, Http::Headers::get().MethodValues.Get));
   EXPECT_THAT(upstream_request_->headers(),
-              Http::HeaderValueOf(Http::Headers::get().Path,
-                                  "/shelves/12345/books:unary?author=567&theme=Science%20Fiction"));
+              ContainsHeader(Http::Headers::get().Path,
+                             "/shelves/12345/books:unary?author=567&theme=Science%20Fiction"));
 
   Http::TestResponseHeaderMapImpl response_headers;
   response_headers.setStatus(200);
@@ -359,8 +358,8 @@ TEST_P(GrpcJsonReverseTranscoderIntegrationTest, RequestWithQueryParams) {
   ASSERT_TRUE(response->waitForEndStream());
   EXPECT_TRUE(response->complete());
 
-  EXPECT_THAT(response->headers(), HeaderValueOf(Http::Headers::get().ContentType,
-                                                 Http::Headers::get().ContentTypeValues.Grpc));
+  EXPECT_THAT(response->headers(), ContainsHeader(Http::Headers::get().ContentType,
+                                                  Http::Headers::get().ContentTypeValues.Grpc));
 
   bookstore::ListBooksResponse expected_res;
   auto* book = expected_res.add_books();
@@ -378,7 +377,7 @@ TEST_P(GrpcJsonReverseTranscoderIntegrationTest, RequestWithQueryParams) {
 
   EXPECT_TRUE(MessageDifferencer::Equals(expected_res, transcoded_res));
 
-  EXPECT_THAT(*response->trailers(), HeaderValueOf(Http::Headers::get().GrpcStatus, "0"));
+  EXPECT_THAT(*response->trailers(), ContainsHeader(Http::Headers::get().GrpcStatus, "0"));
 
   codec_client_->close();
   ASSERT_TRUE(fake_upstream_connection_->close());
@@ -410,9 +409,9 @@ TEST_P(GrpcJsonReverseTranscoderIntegrationTest, ErrorFromBackend) {
   ASSERT_TRUE(upstream_request_->waitForEndStream(*dispatcher_));
 
   EXPECT_THAT(upstream_request_->headers(),
-              HeaderValueOf(Http::Headers::get().Method, Http::Headers::get().MethodValues.Put));
+              ContainsHeader(Http::Headers::get().Method, Http::Headers::get().MethodValues.Put));
   EXPECT_THAT(upstream_request_->headers(),
-              Http::HeaderValueOf(Http::Headers::get().Path, "/shelves/12345/books"));
+              ContainsHeader(Http::Headers::get().Path, "/shelves/12345/books"));
 
   Http::TestResponseHeaderMapImpl response_headers;
   response_headers.setStatus(400);
@@ -431,10 +430,10 @@ TEST_P(GrpcJsonReverseTranscoderIntegrationTest, ErrorFromBackend) {
 
   ASSERT_TRUE(response->trailers());
   EXPECT_THAT(*response->trailers(),
-              Http::HeaderValueOf(Http::Headers::get().GrpcStatus,
-                                  std::to_string(Grpc::Status::WellKnownGrpcStatus::Internal)));
+              ContainsHeader(Http::Headers::get().GrpcStatus,
+                             std::to_string(Grpc::Status::WellKnownGrpcStatus::Internal)));
   EXPECT_THAT(*response->trailers(),
-              Http::HeaderValueOf(Http::Headers::get().GrpcMessage, response_str));
+              ContainsHeader(Http::Headers::get().GrpcMessage, response_str));
 
   codec_client_->close();
   ASSERT_TRUE(fake_upstream_connection_->close());

--- a/test/extensions/filters/http/local_ratelimit/local_ratelimit_integration_test.cc
+++ b/test/extensions/filters/http/local_ratelimit/local_ratelimit_integration_test.cc
@@ -171,17 +171,16 @@ protected:
     EXPECT_EQ(expected_body_size, response->body().size());
     EXPECT_THAT(
         response->headers(),
-        Http::HeaderValueOf(
+        ContainsHeader(
             Extensions::HttpFilters::Common::RateLimit::XRateLimitHeaders::get().XRateLimitLimit,
             expected_limit));
+    EXPECT_THAT(response->headers(),
+                ContainsHeader(Extensions::HttpFilters::Common::RateLimit::XRateLimitHeaders::get()
+                                   .XRateLimitRemaining,
+                               expected_remaining));
     EXPECT_THAT(
         response->headers(),
-        Http::HeaderValueOf(Extensions::HttpFilters::Common::RateLimit::XRateLimitHeaders::get()
-                                .XRateLimitRemaining,
-                            expected_remaining));
-    EXPECT_THAT(
-        response->headers(),
-        Http::HeaderValueOf(
+        ContainsHeader(
             Extensions::HttpFilters::Common::RateLimit::XRateLimitHeaders::get().XRateLimitReset,
             expected_reset));
   }

--- a/test/extensions/filters/http/lua/lua_integration_test.cc
+++ b/test/extensions/filters/http/lua/lua_integration_test.cc
@@ -11,8 +11,6 @@
 
 #include "gtest/gtest.h"
 
-using Envoy::Http::HeaderValueOf;
-
 namespace Envoy {
 namespace {
 
@@ -748,8 +746,8 @@ typed_config:
   ASSERT_TRUE(fake_lua_connection_->waitForNewStream(*dispatcher_, lua_request_));
   ASSERT_TRUE(lua_request_->waitForEndStream(*dispatcher_));
   // Sanity checking that we sent the expected data.
-  EXPECT_THAT(lua_request_->headers(), HeaderValueOf(Http::Headers::get().Method, "POST"));
-  EXPECT_THAT(lua_request_->headers(), HeaderValueOf(Http::Headers::get().Path, "/"));
+  EXPECT_THAT(lua_request_->headers(), ContainsHeader(Http::Headers::get().Method, "POST"));
+  EXPECT_THAT(lua_request_->headers(), ContainsHeader(Http::Headers::get().Path, "/"));
 
   waitForNextUpstreamRequest();
 

--- a/test/extensions/filters/http/ratelimit/ratelimit_integration_test.cc
+++ b/test/extensions/filters/http/ratelimit/ratelimit_integration_test.cc
@@ -286,8 +286,8 @@ TEST_P(RatelimitIntegrationTest, OverLimit) {
   waitForFailedUpstreamResponse(429, 0);
 
   EXPECT_THAT(responses_[0].get()->headers(),
-              Http::HeaderValueOf(Http::Headers::get().EnvoyRateLimited,
-                                  Http::Headers::get().EnvoyRateLimitedValues.True));
+              ContainsHeader(Http::Headers::get().EnvoyRateLimited,
+                             Http::Headers::get().EnvoyRateLimitedValues.True));
 
   cleanup();
 
@@ -313,8 +313,8 @@ TEST_P(RatelimitIntegrationTest, OverLimitWithHeaders) {
       });
 
   EXPECT_THAT(responses_[0].get()->headers(),
-              Http::HeaderValueOf(Http::Headers::get().EnvoyRateLimited,
-                                  Http::Headers::get().EnvoyRateLimitedValues.True));
+              ContainsHeader(Http::Headers::get().EnvoyRateLimited,
+                             Http::Headers::get().EnvoyRateLimitedValues.True));
 
   cleanup();
 
@@ -412,17 +412,17 @@ TEST_P(RatelimitFilterHeadersEnabledIntegrationTest, OkWithFilterHeaders) {
 
   EXPECT_THAT(
       responses_[0].get()->headers(),
-      Http::HeaderValueOf(
+      ContainsHeader(
           Extensions::HttpFilters::Common::RateLimit::XRateLimitHeaders::get().XRateLimitLimit,
           "1, 1;w=60;name=\"first\", 4;w=3600;name=\"second\""));
   EXPECT_THAT(
       responses_[0].get()->headers(),
-      Http::HeaderValueOf(
+      ContainsHeader(
           Extensions::HttpFilters::Common::RateLimit::XRateLimitHeaders::get().XRateLimitRemaining,
           "2"));
   EXPECT_THAT(
       responses_[0].get()->headers(),
-      Http::HeaderValueOf(
+      ContainsHeader(
           Extensions::HttpFilters::Common::RateLimit::XRateLimitHeaders::get().XRateLimitReset,
           "3"));
 
@@ -449,17 +449,17 @@ TEST_P(RatelimitFilterHeadersEnabledIntegrationTest, OverLimitWithFilterHeaders)
 
   EXPECT_THAT(
       responses_[0].get()->headers(),
-      Http::HeaderValueOf(
+      ContainsHeader(
           Extensions::HttpFilters::Common::RateLimit::XRateLimitHeaders::get().XRateLimitLimit,
           "1, 1;w=60;name=\"first\", 4;w=3600;name=\"second\""));
   EXPECT_THAT(
       responses_[0].get()->headers(),
-      Http::HeaderValueOf(
+      ContainsHeader(
           Extensions::HttpFilters::Common::RateLimit::XRateLimitHeaders::get().XRateLimitRemaining,
           "2"));
   EXPECT_THAT(
       responses_[0].get()->headers(),
-      Http::HeaderValueOf(
+      ContainsHeader(
           Extensions::HttpFilters::Common::RateLimit::XRateLimitHeaders::get().XRateLimitReset,
           "3"));
 
@@ -479,7 +479,7 @@ TEST_P(RatelimitFilterEnvoyRatelimitedHeaderDisabledIntegrationTest,
   waitForFailedUpstreamResponse(429, 0);
 
   EXPECT_THAT(responses_[0].get()->headers(),
-              ::testing::Not(Http::HeaderValueOf(Http::Headers::get().EnvoyRateLimited, _)));
+              ::testing::Not(ContainsHeader(Http::Headers::get().EnvoyRateLimited, _)));
 
   cleanup();
 
@@ -526,10 +526,10 @@ TEST_P(RatelimitIntegrationTest, OverLimitResponseHeadersToAdd) {
   waitForFailedUpstreamResponse(429, 0);
 
   EXPECT_THAT(responses_[0].get()->headers(),
-              Http::HeaderValueOf(Http::Headers::get().EnvoyRateLimited,
-                                  Http::Headers::get().EnvoyRateLimitedValues.True));
+              ContainsHeader(Http::Headers::get().EnvoyRateLimited,
+                             Http::Headers::get().EnvoyRateLimitedValues.True));
   EXPECT_THAT(responses_[0].get()->headers(),
-              Http::HeaderValueOf("x-global-ratelimit-service", "rate_limit_service"));
+              ContainsHeader("x-global-ratelimit-service", "rate_limit_service"));
   cleanup();
 
   EXPECT_EQ(nullptr, test_server_->counter("cluster.cluster_0.ratelimit.ok"));

--- a/test/extensions/tracers/opentelemetry/resource_detectors/static/static_config_resource_detector_integration_test.cc
+++ b/test/extensions/tracers/opentelemetry/resource_detectors/static/static_config_resource_detector_integration_test.cc
@@ -114,9 +114,9 @@ TEST_P(StaticConfigResourceDetectorIntegrationTest, TestResourceAttributeSet) {
   ASSERT_TRUE(backend_request_->waitForEndStream(*dispatcher_));
 
   // Sanity checking that we sent the expected data.
-  EXPECT_THAT(backend_request_->headers(), HeaderValueOf(Http::Headers::get().Method, "POST"));
+  EXPECT_THAT(backend_request_->headers(), ContainsHeader(Http::Headers::get().Method, "POST"));
   EXPECT_THAT(backend_request_->headers(),
-              HeaderValueOf(Http::Headers::get().Path, "/api/v2/traces"));
+              ContainsHeader(Http::Headers::get().Path, "/api/v2/traces"));
 
   backend_request_->encodeHeaders(default_response_headers_, true /*end_stream*/);
 

--- a/test/integration/integration_admin_test.cc
+++ b/test/integration/integration_admin_test.cc
@@ -53,13 +53,13 @@ TEST_P(IntegrationAdminTest, AdminLogging) {
   EXPECT_EQ("200", request("admin", "POST", "/logging", response));
   EXPECT_EQ("text/plain; charset=UTF-8", contentType(response));
   EXPECT_THAT(response->headers(),
-              HeaderValueOf(Http::Headers::get().XContentTypeOptions, "nosniff"));
+              ContainsHeader(Http::Headers::get().XContentTypeOptions, "nosniff"));
 
   // Bad level
   EXPECT_EQ("400", request("admin", "POST", "/logging?level=blah", response));
   EXPECT_EQ("text/plain; charset=UTF-8", contentType(response));
   EXPECT_THAT(response->headers(),
-              HeaderValueOf(Http::Headers::get().XContentTypeOptions, "nosniff"));
+              ContainsHeader(Http::Headers::get().XContentTypeOptions, "nosniff"));
   EXPECT_THAT(response->body(), HasSubstr("error: unknown logger level\n"));
 
   // Bad logger

--- a/test/integration/multiplexed_upstream_integration_test.cc
+++ b/test/integration/multiplexed_upstream_integration_test.cc
@@ -701,7 +701,7 @@ TEST_P(MultiplexedUpstreamIntegrationTest, AutoRetrySafeRequestUponTooEarlyRespo
   waitForNextUpstreamRequest(0);
   // If the request already has Early-Data header, no additional Early-Data header should be added
   // and the header should be forwarded as is.
-  EXPECT_THAT(upstream_request_->headers(), HeaderValueOf(Http::Headers::get().EarlyData, "1"));
+  EXPECT_THAT(upstream_request_->headers(), ContainsHeader(Http::Headers::get().EarlyData, "1"));
   upstream_request_->encodeHeaders(too_early_response_headers, true);
   ASSERT_TRUE(response2->waitForEndStream());
   // 425 response should be forwarded back to the client.

--- a/test/integration/protocol_integration_test.cc
+++ b/test/integration/protocol_integration_test.cc
@@ -1878,9 +1878,9 @@ TEST_P(ProtocolIntegrationTest, HeadersWithUnderscoresDropped) {
       Http::TestRequestTrailerMapImpl{{"trailer1", "value1"}, {"trailer_2", "value2"}});
   waitForNextUpstreamRequest();
 
-  EXPECT_THAT(upstream_request_->headers(), Not(HeaderHasValueRef("foo_bar", "baz")));
+  EXPECT_THAT(upstream_request_->headers(), Not(ContainsHeader("foo_bar", "baz")));
   // Headers with underscores should be dropped from request headers and trailers.
-  EXPECT_THAT(*upstream_request_->trailers(), Not(HeaderHasValueRef("trailer_2", "value2")));
+  EXPECT_THAT(*upstream_request_->trailers(), Not(ContainsHeader("trailer_2", "value2")));
   upstream_request_->encodeHeaders(
       Http::TestResponseHeaderMapImpl{{":status", "200"}, {"bar_baz", "fooz"}}, false);
   upstream_request_->encodeData("b", false);
@@ -1890,8 +1890,8 @@ TEST_P(ProtocolIntegrationTest, HeadersWithUnderscoresDropped) {
   EXPECT_TRUE(response->complete());
   EXPECT_EQ("200", response->headers().getStatusValue());
   // Both response headers and trailers must retain headers with underscores.
-  EXPECT_THAT(response->headers(), HeaderHasValueRef("bar_baz", "fooz"));
-  EXPECT_THAT(*response->trailers(), HeaderHasValueRef("response_trailer", "ok"));
+  EXPECT_THAT(response->headers(), ContainsHeader("bar_baz", "fooz"));
+  EXPECT_THAT(*response->trailers(), ContainsHeader("response_trailer", "ok"));
   Stats::Store& stats = test_server_->server().stats();
   std::string stat_name;
   switch (downstreamProtocol()) {
@@ -1924,13 +1924,13 @@ TEST_P(ProtocolIntegrationTest, HeadersWithUnderscoresRemainByDefault) {
                                      {"foo_bar", "baz"}});
   waitForNextUpstreamRequest();
 
-  EXPECT_THAT(upstream_request_->headers(), HeaderHasValueRef("foo_bar", "baz"));
+  EXPECT_THAT(upstream_request_->headers(), ContainsHeader("foo_bar", "baz"));
   upstream_request_->encodeHeaders(
       Http::TestResponseHeaderMapImpl{{":status", "200"}, {"bar_baz", "fooz"}}, true);
   ASSERT_TRUE(response->waitForEndStream());
   EXPECT_TRUE(response->complete());
   EXPECT_EQ("200", response->headers().getStatusValue());
-  EXPECT_THAT(response->headers(), HeaderHasValueRef("bar_baz", "fooz"));
+  EXPECT_THAT(response->headers(), ContainsHeader("bar_baz", "fooz"));
 }
 
 // Verify that request with headers containing underscores is rejected when configured.
@@ -2036,8 +2036,8 @@ TEST_P(ProtocolIntegrationTest, HeadersWithUnderscoresInResponseAllowRequest) {
   EXPECT_TRUE(response->complete());
   EXPECT_EQ("200", response->headers().getStatusValue());
   // Both response headers and trailers must retain headers with underscores.
-  EXPECT_THAT(response->headers(), HeaderHasValueRef("bar_baz", "fooz"));
-  EXPECT_THAT(*response->trailers(), HeaderHasValueRef("response_trailer", "ok"));
+  EXPECT_THAT(response->headers(), ContainsHeader("bar_baz", "fooz"));
+  EXPECT_THAT(*response->trailers(), ContainsHeader("response_trailer", "ok"));
 }
 
 TEST_P(DownstreamProtocolIntegrationTest, ValidZeroLengthContent) {
@@ -5537,7 +5537,7 @@ TEST_P(DownstreamProtocolIntegrationTest, InvalidSchemeHeaderWithWhitespace) {
     // The scheme header is not conveyed in HTTP/1.
     EXPECT_EQ(nullptr, upstream_request_->headers().Scheme());
   } else {
-    EXPECT_THAT(upstream_request_->headers(), HeaderValueOf(Http::Headers::get().Scheme, "http"));
+    EXPECT_THAT(upstream_request_->headers(), ContainsHeader(Http::Headers::get().Scheme, "http"));
   }
   upstream_request_->encodeHeaders(default_response_headers_, true);
   ASSERT_TRUE(response->waitForEndStream());

--- a/test/integration/quic_http_integration_test.cc
+++ b/test/integration/quic_http_integration_test.cc
@@ -126,7 +126,7 @@ TEST_P(QuicHttpIntegrationTest, ZeroRtt) {
   // Send a complete request on the second connection.
   auto response2 = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
   waitForNextUpstreamRequest(0);
-  EXPECT_THAT(upstream_request_->headers(), HeaderValueOf(Http::Headers::get().EarlyData, "1"));
+  EXPECT_THAT(upstream_request_->headers(), ContainsHeader(Http::Headers::get().EarlyData, "1"));
   upstream_request_->encodeHeaders(default_response_headers_, true);
   ASSERT_TRUE(response2->waitForEndStream());
   // Ensure 0-RTT was used by second connection.
@@ -157,7 +157,7 @@ TEST_P(QuicHttpIntegrationTest, ZeroRtt) {
                                          /*wait_for_1rtt_key*/ false);
   auto response3 = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
   waitForNextUpstreamRequest(0);
-  EXPECT_THAT(upstream_request_->headers(), HeaderValueOf(Http::Headers::get().EarlyData, "1"));
+  EXPECT_THAT(upstream_request_->headers(), ContainsHeader(Http::Headers::get().EarlyData, "1"));
   upstream_request_->encodeHeaders(too_early_response_headers, true);
   ASSERT_TRUE(response3->waitForEndStream());
   // This is downstream sending early data, so the 425 response should be forwarded back to the
@@ -177,7 +177,7 @@ TEST_P(QuicHttpIntegrationTest, ZeroRtt) {
   waitForNextUpstreamRequest(0);
   // If the request already has Early-Data header, no additional Early-Data header should be added
   // and the header should be forwarded as is.
-  EXPECT_THAT(upstream_request_->headers(), HeaderValueOf(Http::Headers::get().EarlyData, "2"));
+  EXPECT_THAT(upstream_request_->headers(), ContainsHeader(Http::Headers::get().EarlyData, "2"));
   upstream_request_->encodeHeaders(too_early_response_headers, true);
   ASSERT_TRUE(response4->waitForEndStream());
   // 425 response should be forwarded back to the client.
@@ -1211,7 +1211,7 @@ TEST_P(QuicHttpIntegrationTest, DisableQpack) {
   auto response = codec_client_->makeHeaderOnlyRequest(headers);
   waitForNextUpstreamRequest(0);
   // Cookie crumbling is disabled along with QPACK.
-  EXPECT_THAT(upstream_request_->headers(), HeaderHasValueRef("cookie", "x;y"));
+  EXPECT_THAT(upstream_request_->headers(), ContainsHeader("cookie", "x;y"));
   upstream_request_->encodeHeaders(default_response_headers_, true);
   ASSERT_TRUE(response->waitForEndStream());
   codec_client_->close();

--- a/test/integration/redirect_integration_test.cc
+++ b/test/integration/redirect_integration_test.cc
@@ -267,8 +267,7 @@ TEST_P(RedirectIntegrationTest, ConnectionCloseHeaderHonoredInInternalRedirect) 
   ASSERT_TRUE(response->complete());
   EXPECT_EQ("200", response->headers().getStatusValue());
   // "Connection: close" should be sent back in response.
-  EXPECT_THAT(response->headers(),
-              Envoy::Http::HeaderValueOf(Envoy::Http::Headers::get().Connection, "close"));
+  EXPECT_THAT(response->headers(), ContainsHeader(Envoy::Http::Headers::get().Connection, "close"));
 
   // Envoy should close the connection immediately.
   ASSERT_TRUE(codec_client_->waitForDisconnect(std::chrono::milliseconds(2000)));

--- a/test/integration/upstream_http_filter_integration_test.cc
+++ b/test/integration/upstream_http_filter_integration_test.cc
@@ -31,7 +31,6 @@ constexpr absl::string_view expected_types[] = {
 
 using HttpFilterProto =
     envoy::extensions::filters::network::http_connection_manager::v3::HttpFilter;
-using Http::HeaderValueOf;
 using testing::Not;
 
 class UpstreamHttpFilterIntegrationTestBase : public HttpIntegrationTest {
@@ -174,8 +173,8 @@ TEST_P(StaticRouterOrClusterFiltersIntegrationTest,
   initialize();
 
   auto headers = sendRequestAndGetHeaders();
-  EXPECT_THAT(*headers, Not(HeaderValueOf("x-test-router", "aa")));
-  EXPECT_THAT(*headers, HeaderValueOf("x-test-cluster", "bb"));
+  EXPECT_THAT(*headers, Not(ContainsHeader("x-test-router", "aa")));
+  EXPECT_THAT(*headers, ContainsHeader("x-test-cluster", "bb"));
 }
 
 TEST_P(StaticRouterOrClusterFiltersIntegrationTest, ClusterUpstreamFiltersDisabled) {
@@ -185,7 +184,7 @@ TEST_P(StaticRouterOrClusterFiltersIntegrationTest, ClusterUpstreamFiltersDisabl
   initialize();
 
   auto headers = sendRequestAndGetHeaders();
-  EXPECT_THAT(*headers, Not(HeaderValueOf("x-test-router", "aa")));
+  EXPECT_THAT(*headers, Not(ContainsHeader("x-test-router", "aa")));
 }
 
 TEST_P(StaticRouterOrClusterFiltersIntegrationTest, RouterUpstreamFiltersDisabled) {
@@ -195,7 +194,7 @@ TEST_P(StaticRouterOrClusterFiltersIntegrationTest, RouterUpstreamFiltersDisable
   initialize();
 
   auto headers = sendRequestAndGetHeaders();
-  EXPECT_THAT(*headers, Not(HeaderValueOf("x-test-cluster", "bb")));
+  EXPECT_THAT(*headers, Not(ContainsHeader("x-test-cluster", "bb")));
 }
 
 TEST_P(StaticRouterOrClusterFiltersIntegrationTest,
@@ -213,9 +212,9 @@ TEST_P(StaticRouterOrClusterFiltersIntegrationTest,
 
   auto headers = sendRequestAndGetHeaders();
   if (useRouterFilters()) {
-    EXPECT_THAT(*headers, Not(HeaderValueOf(default_header_key_, default_header_value_)));
+    EXPECT_THAT(*headers, Not(ContainsHeader(default_header_key_, default_header_value_)));
   } else {
-    EXPECT_THAT(*headers, HeaderValueOf(default_header_key_, default_header_value_));
+    EXPECT_THAT(*headers, ContainsHeader(default_header_key_, default_header_value_));
   }
 }
 

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -800,14 +800,6 @@ private:
   const testing::Matcher<absl::string_view> matcher_;
 };
 
-// Test that a HeaderMap argument contains exactly one header with the given
-// key, whose value satisfies the given expectation. The expectation can be a
-// matcher, or a string that the value should equal.
-template <typename T, typename K> HeaderValueOfMatcher HeaderValueOf(K key, const T& matcher) {
-  return HeaderValueOfMatcher(LowerCaseString(key),
-                              testing::SafeMatcherCast<absl::string_view>(matcher));
-}
-
 // Tests the provided Envoy HeaderMap for the provided HTTP status code.
 MATCHER_P(HttpStatusIs, expected_code, "") {
   const HeaderEntry* status = arg.Status();
@@ -987,16 +979,20 @@ MATCHER_P(HeaderMapEqualRef, rhs, "") {
   return equal;
 }
 
-// Test that a HeaderMapPtr argument includes a given key-value pair, e.g.,
-//  HeaderHasValue("Upgrade", "WebSocket")
-template <typename K, typename V>
-testing::Matcher<const Http::HeaderMap*> HeaderHasValue(K key, V value) {
-  return testing::Pointee(Http::HeaderValueOf(key, value));
+// Test that a HeaderMap& argument includes a given key-value pair, e.g.,
+// ContainsHeader("Upgrade", "WebSocket"). Key is case-insensitive.
+// Value can be a matcher, e.g.
+// ContainsHeader("Upgrade", HasSubstr("Socket"))
+template <typename K, typename V> Http::HeaderValueOfMatcher ContainsHeader(K key, V value) {
+  return Http::HeaderValueOfMatcher(Http::LowerCaseString(key),
+                                    testing::SafeMatcherCast<absl::string_view>(value));
 }
 
-// Like HeaderHasValue, but matches against a HeaderMap& argument.
-template <typename K, typename V> Http::HeaderValueOfMatcher HeaderHasValueRef(K key, V value) {
-  return Http::HeaderValueOf(key, value);
+// Test that a HeaderMapPtr argument includes a given key-value pair.
+// See ContainsHeader above for details.
+template <typename K, typename V>
+testing::Matcher<const Http::HeaderMap*> PointeeContainsHeader(K key, V value) {
+  return testing::Pointee(ContainsHeader(key, value));
 }
 
 } // namespace Envoy

--- a/test/mocks/http/mocks_test.cc
+++ b/test/mocks/http/mocks_test.cc
@@ -8,48 +8,6 @@ using ::testing::_;
 using ::testing::Not;
 
 namespace Http {
-TEST(HeaderValueOfTest, ConstHeaderMap) {
-  const TestRequestHeaderMapImpl header_map{{"key", "expected value"}};
-
-  // Positive checks.
-  EXPECT_THAT(header_map, HeaderValueOf("key", "expected value"));
-  EXPECT_THAT(header_map, HeaderValueOf("key", _));
-
-  // Negative checks.
-  EXPECT_THAT(header_map, Not(HeaderValueOf("key", "other value")));
-  EXPECT_THAT(header_map, Not(HeaderValueOf("other key", _)));
-}
-
-TEST(HeaderValueOfTest, MutableHeaderMap) {
-  TestRequestHeaderMapImpl header_map;
-
-  // Negative checks.
-  EXPECT_THAT(header_map, Not(HeaderValueOf("key", "other value")));
-  EXPECT_THAT(header_map, Not(HeaderValueOf("other key", _)));
-
-  header_map.addCopy("key", "expected value");
-
-  // Positive checks.
-  EXPECT_THAT(header_map, HeaderValueOf("key", "expected value"));
-  EXPECT_THAT(header_map, HeaderValueOf("key", _));
-}
-
-TEST(HeaderValueOfTest, LowerCaseString) {
-  TestRequestHeaderMapImpl header_map;
-  LowerCaseString key("key");
-  LowerCaseString other_key("other_key");
-
-  // Negative checks.
-  EXPECT_THAT(header_map, Not(HeaderValueOf(key, "other value")));
-  EXPECT_THAT(header_map, Not(HeaderValueOf(other_key, _)));
-
-  header_map.addCopy(key, "expected value");
-  header_map.addCopy(other_key, "ValUe");
-
-  // Positive checks.
-  EXPECT_THAT(header_map, HeaderValueOf(key, "expected value"));
-  EXPECT_THAT(header_map, HeaderValueOf(other_key, _));
-}
 
 TEST(HttpStatusIsTest, CheckStatus) {
   TestResponseHeaderMapImpl header_map;
@@ -106,36 +64,47 @@ TEST(IsSupersetOfHeadersTest, MutableHeaderMap) {
 }
 } // namespace Http
 
-TEST(HeaderHasValueRefTest, MutableValueRef) {
-  Http::TestRequestHeaderMapImpl header_map;
-
-  EXPECT_THAT(header_map, Not(HeaderHasValueRef("key", "value")));
-  EXPECT_THAT(header_map, Not(HeaderHasValueRef("other key", "value")));
-
-  header_map.addCopy("key", "value");
-
-  EXPECT_THAT(header_map, HeaderHasValueRef("key", "value"));
-  EXPECT_THAT(header_map, Not(HeaderHasValueRef("key", "wrong value")));
-}
-
-TEST(HeaderHasValueRefTest, ConstValueRef) {
+TEST(ContainsHeaderTest, ConstHeaderMap) {
   const Http::TestRequestHeaderMapImpl header_map{{"key", "expected value"}};
 
-  EXPECT_THAT(header_map, Not(HeaderHasValueRef("key", "other value")));
-  EXPECT_THAT(header_map, HeaderHasValueRef("key", "expected value"));
+  // Positive checks.
+  EXPECT_THAT(header_map, ContainsHeader("key", "expected value"));
+  EXPECT_THAT(header_map, ContainsHeader("key", _));
+
+  // Negative checks.
+  EXPECT_THAT(header_map, Not(ContainsHeader("key", "other value")));
+  EXPECT_THAT(header_map, Not(ContainsHeader("other key", _)));
 }
 
-TEST(HeaderHasValueRefTest, LowerCaseStringArguments) {
-  Http::LowerCaseString key("key"), other_key("other key");
+TEST(ContainsHeaderTest, MutableHeaderMap) {
   Http::TestRequestHeaderMapImpl header_map;
 
-  EXPECT_THAT(header_map, Not(HeaderHasValueRef(key, "value")));
-  EXPECT_THAT(header_map, Not(HeaderHasValueRef(other_key, "value")));
+  // Negative checks.
+  EXPECT_THAT(header_map, Not(ContainsHeader("key", "other value")));
+  EXPECT_THAT(header_map, Not(ContainsHeader("other key", _)));
 
-  header_map.addCopy(key, "value");
+  header_map.addCopy("key", "expected value");
 
-  EXPECT_THAT(header_map, HeaderHasValueRef(key, "value"));
-  EXPECT_THAT(header_map, Not(HeaderHasValueRef(other_key, "wrong value")));
+  // Positive checks.
+  EXPECT_THAT(header_map, ContainsHeader("key", "expected value"));
+  EXPECT_THAT(header_map, ContainsHeader("key", _));
+}
+
+TEST(ContainsHeaderTest, LowerCaseStringArguments) {
+  Http::TestRequestHeaderMapImpl header_map;
+  Http::LowerCaseString key("key");
+  Http::LowerCaseString other_key("other_key");
+
+  // Negative checks.
+  EXPECT_THAT(header_map, Not(ContainsHeader(key, "other value")));
+  EXPECT_THAT(header_map, Not(ContainsHeader(other_key, _)));
+
+  header_map.addCopy(key, "expected value");
+  header_map.addCopy(other_key, "ValUe");
+
+  // Positive checks.
+  EXPECT_THAT(header_map, ContainsHeader(key, "expected value"));
+  EXPECT_THAT(header_map, ContainsHeader(other_key, _));
 }
 
 TEST(HeaderMatcherTest, OutputsActualHeadersOnMatchFailure) {


### PR DESCRIPTION
Commit Message: Unify scattered header matchers into ContainsHeader
Additional Description: Across envoy there's `Http::HeaderValueOf`, `HeaderHasValue`, `HeaderHasValueRef` and `HasHeader` all performing the same task. The only well-named one of these is `HasHeader`, which is the smallest scoped and worst-implemented one.

`HeaderHasValueRef` sounds like it's a matcher for a header, checking that it has a ValueRef, when it is in fact a matcher for a reference to a HeaderMap, checking that it has a specified key-value pair.
`HeaderValueOf` *almost* makes sense, but Value is kind of meaningless, and you have to read it like `HeaderValueOf(x, y)` means `HeaderValueOf(x) is (y)` which is not a very natural reading.
`HeaderHasValue` again sounds like it's a matcher for a header, checking that it has a value, when it is in fact a matcher for a HeaderMap pointer, checking that it has a specified key-value pair.
`HasHeader` is doing what it says on the tin but has unhelpful output on failure and lives in a limited namespace.

Replacing all of these is `ContainsHeader`, which is intuitively checking that a HeaderMap *contains* the header described by a key-value pair. Initially I also replaced `HeaderHasValue` with `PointeeContainsHeader()` but it turns out there were in fact zero uses of `HeaderHasValue`, and `Pointee(ContainsHeader())` can achieve the same thing so it's not necessary.
Risk Level: May require external extensions to update their matchers.
Testing: It's test-only and used in existing tests.
Docs Changes: Yes, HeaderValueOf documentation has been replaced.
Release Notes: Pending.
Platform Specific Features: n/a
