### PR TITLE
lua: extend StreamHandle API with route() to access matched route metadata

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -160,5 +160,10 @@ new_features:
 - area: rbac
   change: |
     Switch the IP matcher to use LC-Trie for performance improvements.
+- area: lua
+  change: |
+    Added ``route()`` to the Stream handle API, allowing Lua scripts to retrieve route information. So far, the only method
+    implemented is ``metadata()``, allowing Lua scripts to access route metadata scoped to the specific filter name. See
+    :ref:`Route object API <config_http_filters_lua_route_wrapper>` for more details.
 
 deprecated:

--- a/docs/root/configuration/http/http_filters/lua_filter.rst
+++ b/docs/root/configuration/http/http_filters/lua_filter.rst
@@ -482,6 +482,14 @@ If no entry could be found by the filter config name, then the filter canonical 
 i.e. ``envoy.filters.http.lua`` will be used as an alternative. Note that this downgrade will be
 deprecated in the future.
 
+.. note::
+
+  This method will be deprecated in the future. In order to access route configuration,
+  consider using :ref:`route object's metadata() <config_http_filters_lua_route_wrapper_metadata>` instead,
+  which provides more consistent behavior. **Important**: route object's ``metadata()`` requires
+  metadata to be configured under the exact filter name and does not fall back to the
+  canonical name ``envoy.filters.http.lua``.
+
 Below is an example of a ``metadata`` in a :ref:`route entry <envoy_v3_api_msg_config.route.v3.Route>`.
 
 .. literalinclude:: _include/lua-filter.yaml
@@ -693,6 +701,22 @@ matches, calling methods on the returned object will return ``nil`` or, in the c
 an empty metadata object.
 
 Returns a :ref:`virtual host object <config_http_filters_lua_virtual_host_wrapper>`.
+
+.. _config_http_filters_lua_stream_handle_api_route:
+
+``route()``
+^^^^^^^^^^^
+
+.. code-block:: lua
+
+  local route = handle:route()
+
+Returns a route object that provides access to the route configuration. This method always returns
+a valid object, even when the request does not match any configured route. However, if no route
+matches, calling methods on the returned object will return ``nil`` or, in the case of the ``metadata()`` method,
+an empty metadata object.
+
+Returns a :ref:`route object <config_http_filters_lua_route_wrapper>`.
 
 .. _config_http_filters_lua_header_wrapper:
 
@@ -1617,6 +1641,37 @@ Below is an example of a ``metadata`` in a :ref:`route entry <envoy_v3_api_msg_c
     :language: yaml
     :lines: 20-26
     :lineno-start: 20
+    :linenos:
+    :caption: :download:`lua-filter.yaml <_include/lua-filter.yaml>`
+
+Returns a :ref:`metadata object <config_http_filters_lua_metadata_wrapper>`.
+
+.. _config_http_filters_lua_route_wrapper:
+
+Route object API
+----------------
+
+.. include:: ../../../_include/lua_common.rst
+
+.. _config_http_filters_lua_route_wrapper_metadata:
+
+``metadata()``
+^^^^^^^^^^^^^^
+
+.. code-block:: lua
+
+  local metadata = route:metadata()
+
+Returns the route metadata. Note that the metadata should be specified
+under the :ref:`filter config name
+<envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpFilter.name>`.
+
+Below is an example of a ``metadata`` in a :ref:`route entry <envoy_v3_api_msg_config.route.v3.Route>`.
+
+.. literalinclude:: _include/lua-filter.yaml
+    :language: yaml
+    :lines: 33-39
+    :lineno-start: 33
     :linenos:
     :caption: :download:`lua-filter.yaml <_include/lua-filter.yaml>`
 

--- a/source/extensions/filters/http/lua/lua_filter.cc
+++ b/source/extensions/filters/http/lua/lua_filter.cc
@@ -213,6 +213,7 @@ PerLuaCodeSetup::PerLuaCodeSetup(const std::string& lua_code, ThreadLocal::SlotA
   lua_state_.registerType<ConnectionDynamicMetadataMapWrapper>();
   lua_state_.registerType<ConnectionDynamicMetadataMapIterator>();
   lua_state_.registerType<VirtualHostWrapper>();
+  lua_state_.registerType<RouteWrapper>();
 
   const Filters::Common::Lua::InitializerList initializers(
       // EnvoyTimestampResolution "enum".
@@ -637,6 +638,17 @@ int StreamHandleWrapper::luaVirtualHost(lua_State* state) {
     virtual_host_wrapper_.reset(
         VirtualHostWrapper::create(state, callbacks_.streamInfo(), callbacks_.filterConfigName()),
         true);
+  }
+  return 1;
+}
+
+int StreamHandleWrapper::luaRoute(lua_State* state) {
+  ASSERT(state_ == State::Running);
+  if (route_wrapper_.get() != nullptr) {
+    route_wrapper_.pushStack();
+  } else {
+    route_wrapper_.reset(
+        RouteWrapper::create(state, callbacks_.streamInfo(), callbacks_.filterConfigName()), true);
   }
   return 1;
 }

--- a/source/extensions/filters/http/lua/lua_filter.h
+++ b/source/extensions/filters/http/lua/lua_filter.h
@@ -208,7 +208,8 @@ public:
             {"setUpstreamOverrideHost", static_luaSetUpstreamOverrideHost},
             {"clearRouteCache", static_luaClearRouteCache},
             {"filterContext", static_luaFilterContext},
-            {"virtualHost", static_luaVirtualHost}};
+            {"virtualHost", static_luaVirtualHost},
+            {"route", static_luaRoute}};
   }
 
 private:
@@ -350,6 +351,11 @@ private:
    */
   DECLARE_LUA_FUNCTION(StreamHandleWrapper, luaVirtualHost);
 
+  /**
+   * @return a handle to the route.
+   */
+  DECLARE_LUA_FUNCTION(StreamHandleWrapper, luaRoute);
+
   enum Timestamp::Resolution getTimestampResolution(absl::string_view unit_parameter);
 
   int doHttpCall(lua_State* state, const HttpCallOptions& options);
@@ -375,6 +381,7 @@ private:
     public_key_wrapper_.reset();
     connection_stream_info_wrapper_.reset();
     virtual_host_wrapper_.reset();
+    route_wrapper_.reset();
   }
 
   // Http::AsyncClient::Callbacks
@@ -405,6 +412,7 @@ private:
   Filters::Common::Lua::LuaDeathRef<Filters::Common::Lua::ConnectionWrapper> connection_wrapper_;
   Filters::Common::Lua::LuaDeathRef<PublicKeyWrapper> public_key_wrapper_;
   Filters::Common::Lua::LuaDeathRef<VirtualHostWrapper> virtual_host_wrapper_;
+  Filters::Common::Lua::LuaDeathRef<RouteWrapper> route_wrapper_;
   State state_{State::Running};
   std::function<void()> yield_callback_;
   Http::AsyncClient::Request* http_request_{};

--- a/source/extensions/filters/http/lua/wrappers.cc
+++ b/source/extensions/filters/http/lua/wrappers.cc
@@ -471,6 +471,32 @@ int VirtualHostWrapper::luaMetadata(lua_State* state) {
   return 1;
 }
 
+const ProtobufWkt::Struct& RouteWrapper::getMetadata() const {
+  const auto& route = stream_info_.route();
+  if (route == nullptr) {
+    return ProtobufWkt::Struct::default_instance();
+  }
+
+  const auto& metadata = route->metadata();
+  auto filter_it = metadata.filter_metadata().find(filter_config_name_);
+
+  if (filter_it != metadata.filter_metadata().end()) {
+    return filter_it->second;
+  }
+
+  return ProtobufWkt::Struct::default_instance();
+}
+
+int RouteWrapper::luaMetadata(lua_State* state) {
+  if (metadata_wrapper_.get() != nullptr) {
+    metadata_wrapper_.pushStack();
+  } else {
+    metadata_wrapper_.reset(Filters::Common::Lua::MetadataMapWrapper::create(state, getMetadata()),
+                            true);
+  }
+  return 1;
+}
+
 } // namespace Lua
 } // namespace HttpFilters
 } // namespace Extensions

--- a/source/extensions/filters/http/lua/wrappers.h
+++ b/source/extensions/filters/http/lua/wrappers.h
@@ -478,6 +478,30 @@ private:
   Filters::Common::Lua::LuaDeathRef<Filters::Common::Lua::MetadataMapWrapper> metadata_wrapper_;
 };
 
+class RouteWrapper : public Filters::Common::Lua::BaseLuaObject<RouteWrapper> {
+public:
+  RouteWrapper(const StreamInfo::StreamInfo& stream_info,
+               const absl::string_view filter_config_name)
+      : stream_info_{stream_info}, filter_config_name_{filter_config_name} {}
+
+  static ExportedFunctions exportedFunctions() { return {{"metadata", static_luaMetadata}}; }
+
+private:
+  /**
+   * @return a handle to the metadata.
+   */
+  DECLARE_LUA_FUNCTION(RouteWrapper, luaMetadata);
+
+  const ProtobufWkt::Struct& getMetadata() const;
+
+  // Filters::Common::Lua::BaseLuaObject
+  void onMarkDead() override { metadata_wrapper_.reset(); }
+
+  const StreamInfo::StreamInfo& stream_info_;
+  const absl::string_view filter_config_name_;
+  Filters::Common::Lua::LuaDeathRef<Filters::Common::Lua::MetadataMapWrapper> metadata_wrapper_;
+};
+
 } // namespace Lua
 } // namespace HttpFilters
 } // namespace Extensions

--- a/test/extensions/filters/http/lua/lua_filter_test.cc
+++ b/test/extensions/filters/http/lua/lua_filter_test.cc
@@ -137,6 +137,22 @@ public:
     EXPECT_EQ(0, stats_store_.counter("test.lua.errors").value());
   }
 
+  void setupRouteMetadata(const std::string& yaml) {
+    auto route = std::make_shared<NiceMock<Router::MockRoute>>();
+    TestUtility::loadFromYaml(yaml, route->metadata_);
+
+    ON_CALL(stream_info_, route()).WillByDefault(Return(route));
+
+    EXPECT_CALL(decoder_callbacks_, streamInfo()).WillOnce(ReturnRef(stream_info_));
+    EXPECT_CALL(encoder_callbacks_, streamInfo()).WillOnce(ReturnRef(stream_info_));
+
+    const std::string filter_name = "lua-filter-config-name";
+    ON_CALL(decoder_callbacks_, filterConfigName()).WillByDefault(Return(filter_name));
+    ON_CALL(encoder_callbacks_, filterConfigName()).WillByDefault(Return(filter_name));
+
+    EXPECT_EQ(0, stats_store_.counter("test.lua.errors").value());
+  }
+
   NiceMock<Server::Configuration::MockServerFactoryContext> server_factory_context_;
   NiceMock<ThreadLocal::MockInstance> tls_;
   NiceMock<Api::MockApi> api_;
@@ -4116,6 +4132,148 @@ TEST_F(LuaHttpFilterTest, GetVirtualHostMetadataFromHandleNoRoute) {
                                EXPECT_EQ(Http::FilterHeadersStatus::Continue,
                                          filter_->encodeHeaders(response_headers, true));
                              });
+}
+
+// Test that handle:route():metadata() returns metadata when route matches the request.
+// This verifies that when a route is found for the request, the route() function returns
+// a valid object and metadata can be successfully accessed from both request and response handles.
+TEST_F(LuaHttpFilterTest, GetRouteMetadataFromHandle) {
+  const std::string SCRIPT{R"EOF(
+    function envoy_on_request(request_handle)
+      local metadata = request_handle:route():metadata()
+      request_handle:logTrace(metadata:get("foo.bar")["name"])
+      request_handle:logTrace(metadata:get("foo.bar")["prop"])
+    end
+    function envoy_on_response(response_handle)
+      local metadata = response_handle:route():metadata()
+      response_handle:logTrace(metadata:get("baz.bat")["name"])
+      response_handle:logTrace(metadata:get("baz.bat")["prop"])
+    end
+  )EOF"};
+
+  const std::string METADATA{R"EOF(
+    filter_metadata:
+      lua-filter-config-name:
+        foo.bar:
+          name: foo
+          prop: bar
+        baz.bat:
+          name: baz
+          prop: bat
+  )EOF"};
+
+  InSequence s;
+  setup(SCRIPT);
+  setupRouteMetadata(METADATA);
+
+  // Request path
+  Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
+  EXPECT_LOG_CONTAINS_ALL_OF(Envoy::ExpectedLogMessages({
+                                 {"trace", "foo"},
+                                 {"trace", "bar"},
+                             }),
+                             {
+                               EXPECT_EQ(Http::FilterHeadersStatus::Continue,
+                                         filter_->decodeHeaders(request_headers, true));
+                             });
+
+  // Response path
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}};
+  EXPECT_LOG_CONTAINS_ALL_OF(Envoy::ExpectedLogMessages({
+                                 {"trace", "baz"},
+                                 {"trace", "bat"},
+                             }),
+                             {
+                               EXPECT_EQ(Http::FilterHeadersStatus::Continue,
+                                         filter_->encodeHeaders(response_headers, true));
+                             });
+}
+
+// Test that handle:route():metadata() returns empty metadata when no filter-specific metadata
+// exists. This verifies that when a route has metadata for other filters but not for the
+// current one, the metadata object is empty.
+TEST_F(LuaHttpFilterTest, GetRouteMetadataFromHandleNoLuaMetadata) {
+  const std::string SCRIPT{R"EOF(
+    function is_metadata_empty(metadata)
+      for _, _ in pairs(metadata) do
+        return false
+      end
+      return true
+    end
+    function envoy_on_request(request_handle)
+      if is_metadata_empty(request_handle:route():metadata()) then
+        request_handle:logTrace("No metadata found during request handling")
+      end
+    end
+    function envoy_on_response(response_handle)
+      if is_metadata_empty(response_handle:route():metadata()) then
+        response_handle:logTrace("No metadata found during response handling")
+      end
+    end
+  )EOF"};
+
+  const std::string METADATA{R"EOF(
+    filter_metadata:
+      envoy.some_filter:
+        foo.bar:
+          name: foo
+          prop: bar
+  )EOF"};
+
+  InSequence s;
+  setup(SCRIPT);
+  setupRouteMetadata(METADATA);
+
+  // Request path
+  Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
+  EXPECT_LOG_CONTAINS("trace", "No metadata found during request handling", {
+    EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, true));
+  });
+
+  // Response path
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}};
+  EXPECT_LOG_CONTAINS("trace", "No metadata found during response handling", {
+    EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->encodeHeaders(response_headers, true));
+  });
+}
+
+// Test that handle:route() returns a valid route wrapper object that can be
+// safely accessed when no route matches the request.
+// This verifies that calling metadata() returns an empty metadata object.
+TEST_F(LuaHttpFilterTest, GetRouteFromHandleNoRoute) {
+  const std::string SCRIPT{R"EOF(
+    function envoy_on_request(request_handle)
+      local route = request_handle:route()
+      for _, _ in pairs(route:metadata()) do
+        return
+      end
+      request_handle:logTrace("No metadata found during request handling")
+    end
+    function envoy_on_response(response_handle)
+      local route = response_handle:route()
+      for _, _ in pairs(route:metadata()) do
+        return
+      end
+      response_handle:logTrace("No metadata found during response handling")
+    end
+  )EOF"};
+
+  InSequence s;
+  setup(SCRIPT);
+
+  // Request path
+  Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
+  EXPECT_LOG_CONTAINS("trace", "No metadata found during request handling", {
+    EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, true));
+  });
+
+  // Response path
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}};
+  EXPECT_LOG_CONTAINS("trace", "No metadata found during response handling", {
+    EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->encodeHeaders(response_headers, true));
+  });
+
+  EXPECT_EQ(0, stats_store_.counter("test.lua.errors").value());
 }
 
 } // namespace

--- a/test/extensions/filters/http/lua/lua_integration_test.cc
+++ b/test/extensions/filters/http/lua/lua_integration_test.cc
@@ -74,12 +74,11 @@ public:
           response_header->set_value("fake_value");
 
           // Metadata variables for the virtual host and route.
-          std::string key;
+          const std::string key = "lua";
           ProtobufWkt::Struct value;
           std::string yaml;
 
           // Sets the virtual host's metadata.
-          key = "lua";
           yaml =
               R"EOF(
             foo.bar:
@@ -94,7 +93,6 @@ public:
               ->insert(Protobuf::MapPair<std::string, ProtobufWkt::Struct>(key, value));
 
           // Sets the route's metadata.
-          key = "envoy.filters.http.lua";
           yaml =
               R"EOF(
             foo.bar:
@@ -344,6 +342,88 @@ typed_config:
   EXPECT_TRUE(response.find("HTTP/1.1 400 Bad Request\r\n") == 0);
 }
 
+// Test that handle:metadata() falls back to metadata under the filter canonical name
+// (envoy.filters.http.lua) when no metadata is present under the filter configured name.
+TEST_P(LuaIntegrationTest, MetadataFallbackToCanonicalName) {
+  const std::string filter_config =
+      R"EOF(
+name: lua-filter-custom-name
+typed_config:
+  "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
+  default_source_code:
+    inline_string: |
+      function envoy_on_request(request_handle)
+        local foo_bar = request_handle:metadata():get("foo.bar")
+        request_handle:logTrace(foo_bar["name"])
+        request_handle:logTrace(foo_bar["prop"])
+      end
+      function envoy_on_response(response_handle)
+        local baz_bat = response_handle:metadata():get("baz.bat")
+        response_handle:logTrace(baz_bat["name"])
+        response_handle:logTrace(baz_bat["prop"])
+      end
+)EOF";
+
+  const std::string route_config =
+      R"EOF(
+name: test_routes
+virtual_hosts:
+- name: test_vhost
+  domains: ["foo.lyft.com"]
+  routes:
+  - match:
+      path: "/test/long/url"
+    metadata:
+      filter_metadata:
+        envoy.filters.http.lua:
+          foo.bar:
+            name: foo
+            prop: bar
+          baz.bat:
+            name: baz
+            prop: bat
+    route:
+      cluster: cluster_0
+)EOF";
+
+  initializeWithYaml(filter_config, route_config);
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+  IntegrationStreamDecoderPtr response;
+
+  // Request path
+  Http::TestRequestHeaderMapImpl request_headers{{":method", "GET"},
+                                                 {":path", "/test/long/url"},
+                                                 {":scheme", "http"},
+                                                 {":authority", "foo.lyft.com"},
+                                                 {"x-forwarded-for", "10.0.0.1"}};
+  EXPECT_LOG_CONTAINS_ALL_OF(Envoy::ExpectedLogMessages({
+                                 {"trace", "foo"},
+                                 {"trace", "bar"},
+                             }),
+                             {
+                               response = codec_client_->makeHeaderOnlyRequest(request_headers);
+
+                               waitForNextUpstreamRequest();
+                             });
+
+  // Response path
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}};
+  EXPECT_LOG_CONTAINS_ALL_OF(Envoy::ExpectedLogMessages({
+                                 {"trace", "baz"},
+                                 {"trace", "bat"},
+                             }),
+                             {
+                               upstream_request_->encodeHeaders(response_headers, true);
+
+                               ASSERT_TRUE(response->waitForEndStream());
+                             });
+
+  EXPECT_TRUE(response->complete());
+  EXPECT_EQ("200", response->headers().getStatusValue());
+
+  cleanup();
+}
+
 // Basic request and response.
 TEST_P(LuaIntegrationTest, RequestAndResponse) {
   const std::string FILTER_AND_CODE =
@@ -362,6 +442,7 @@ typed_config:
         request_handle:logCritical("log test")
 
         local vhost_metadata = request_handle:virtualHost():metadata():get("foo.bar")
+        local route_metadata = request_handle:route():metadata():get("foo.bar")
         local metadata = request_handle:metadata():get("foo.bar")
         local body_length = request_handle:body():length()
 
@@ -385,6 +466,8 @@ typed_config:
         request_handle:headers():add("request_body_size", body_length)
         request_handle:headers():add("request_vhost_metadata_foo", vhost_metadata["foo"])
         request_handle:headers():add("request_vhost_metadata_baz", vhost_metadata["baz"])
+        request_handle:headers():add("request_route_metadata_foo", route_metadata["foo"])
+        request_handle:headers():add("request_route_metadata_baz", route_metadata["baz"])
         request_handle:headers():add("request_metadata_foo", metadata["foo"])
         request_handle:headers():add("request_metadata_baz", metadata["baz"])
         if request_handle:connection():ssl() == nil then
@@ -408,10 +491,13 @@ typed_config:
 
       function envoy_on_response(response_handle)
         local vhost_metadata = response_handle:virtualHost():metadata():get("foo.bar")
+        local route_metadata = response_handle:route():metadata():get("foo.bar")
         local metadata = response_handle:metadata():get("foo.bar")
         local body_length = response_handle:body():length()
         response_handle:headers():add("response_vhost_metadata_foo", vhost_metadata["foo"])
         response_handle:headers():add("response_vhost_metadata_baz", vhost_metadata["baz"])
+        response_handle:headers():add("response_route_metadata_foo", route_metadata["foo"])
+        response_handle:headers():add("response_route_metadata_baz", route_metadata["baz"])
         response_handle:headers():add("response_metadata_foo", metadata["foo"])
         response_handle:headers():add("response_metadata_baz", metadata["baz"])
         response_handle:headers():add("response_body_size", body_length)
@@ -501,6 +587,16 @@ typed_config:
                              .getStringView());
 
   EXPECT_EQ("bar", upstream_request_->headers()
+                       .get(Http::LowerCaseString("request_route_metadata_foo"))[0]
+                       ->value()
+                       .getStringView());
+
+  EXPECT_EQ("bat", upstream_request_->headers()
+                       .get(Http::LowerCaseString("request_route_metadata_baz"))[0]
+                       ->value()
+                       .getStringView());
+
+  EXPECT_EQ("bar", upstream_request_->headers()
                        .get(Http::LowerCaseString("request_metadata_foo"))[0]
                        ->value()
                        .getStringView());
@@ -582,6 +678,14 @@ typed_config:
                              .get(Http::LowerCaseString("response_vhost_metadata_baz"))[0]
                              ->value()
                              .getStringView());
+  EXPECT_EQ("bar", response->headers()
+                       .get(Http::LowerCaseString("response_route_metadata_foo"))[0]
+                       ->value()
+                       .getStringView());
+  EXPECT_EQ("bat", response->headers()
+                       .get(Http::LowerCaseString("response_route_metadata_baz"))[0]
+                       ->value()
+                       .getStringView());
   EXPECT_EQ("bar", response->headers()
                        .get(Http::LowerCaseString("response_metadata_foo"))[0]
                        ->value()
@@ -2253,6 +2357,86 @@ typed_config:
 
   EXPECT_TRUE(response->complete());
   EXPECT_EQ("404", response->headers().getStatusValue());
+  cleanup();
+}
+
+// Test that handle:route() returns a valid object when no route matches the request.
+// This verifies that metadata() returns an empty metadata object that can be safely
+// iterated.
+TEST_P(LuaIntegrationTest, RouteValidWhenNoRouteMatch) {
+  if (!testing_downstream_filter_) {
+    GTEST_SKIP() << "This is a local reply test that does not go upstream";
+  }
+
+  const std::string filter_config =
+      R"EOF(
+name: lua
+typed_config:
+  "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
+  default_source_code:
+    inline_string: |
+      function envoy_on_request(request_handle)
+        local route = request_handle:route()
+        for _, _ in pairs(route:metadata()) do
+          return
+        end
+        request_handle:logTrace("No metadata found during request handling")
+      end
+      function envoy_on_response(response_handle)
+        local route = response_handle:route()
+        for _, _ in pairs(route:metadata()) do
+          return
+        end
+        response_handle:logTrace("No metadata found during response handling")
+      end
+)EOF";
+
+  const std::string route_config =
+      R"EOF(
+name: test_routes
+virtual_hosts:
+- name: test_vhost
+  domains: ["foo.lyft.com"]
+  routes:
+  - match:
+      path: "/existing/route"
+    metadata:
+      filter_metadata:
+        lua:
+          foo.bar:
+            name: foo
+            prop: bar
+          baz.bat:
+            name: baz
+            prop: bat
+    route:
+      cluster: cluster_0
+)EOF";
+
+  initializeWithYaml(filter_config, route_config);
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+
+  Http::TestRequestHeaderMapImpl request_headers{{":method", "GET"},
+                                                 {":path", "/non/existing/path"},
+                                                 {":scheme", "http"},
+                                                 {":authority", "foo.lyft.com"},
+                                                 {"x-forwarded-for", "10.0.0.1"}};
+
+  IntegrationStreamDecoderPtr response;
+  EXPECT_LOG_CONTAINS_ALL_OF(Envoy::ExpectedLogMessages({
+                                 {"trace", "No metadata found during request handling"},
+                                 {"trace", "No metadata found during response handling"},
+                             }),
+                             {
+                               auto encoder_decoder = codec_client_->startRequest(request_headers);
+                               response = std::move(encoder_decoder.second);
+
+                               ASSERT_TRUE(response->waitForEndStream());
+                             });
+
+  EXPECT_TRUE(response->complete());
+  EXPECT_EQ("404", response->headers().getStatusValue());
+
   cleanup();
 }
 


### PR DESCRIPTION


### Description

This PR extends the Envoy HTTP Lua filter StreamHandle API by introducing a new `route()` method. This method returns a Route object representing the matched route for the current request.

Initially, the Route object exposes a single method: `metadata()`, which retrieves route metadata scoped to a specific filter name. This enhancement allows Lua scripts to access per-filter route metadata through a dedicated Route object, improving API consistency and paving the way for future extensions.

Currently, route metadata can be accessed via `StreamHandle:metadata()`. However, with the introduction of the Route object, the preferred access pattern becomes `StreamHandle:route():metadata()`. In the long term, the goal is to migrate usage towards this new interface and deprecate the direct `StreamHandle:metadata()` method for clarity and modularity.

---

**Commit Message:** lua: extend StreamHandle API with route() to access matched route metadata
**Risk Level:** Low
**Testing:** Unit, integration and wrapper tests added
**Docs Changes:** Added
**Release Notes:** Added
**Platform Specific Features:** N/A