### PR TITLE
generic proxy: ensure downstream connection callbacks removed if bound upstream is closed first

### DIFF
--- a/source/extensions/filters/network/generic_proxy/router/upstream.cc
+++ b/source/extensions/filters/network/generic_proxy/router/upstream.cc
@@ -222,6 +222,12 @@ void BoundGenericUpstream::onEvent(Network::ConnectionEvent event) {
       encoder_decoder_->onConnectionClose(event);
     }
 
+    // Remove the connection event watcher callbacks since the upstream is already closed.
+    // If the upstream connection closes shortly after a frame that ends the stream is sent by the
+    // client codec, the downstream connection may end up being closed after this object has already
+    // been destroyed.
+    downstream_conn_.removeConnectionCallbacks(connection_event_watcher_);
+
     // If the downstream connection is not closed, close it.
     downstream_conn_.close(Network::ConnectionCloseType::FlushWrite);
   }


### PR DESCRIPTION
Commit Message: generic proxy: ensure downstream connection callbacks removed if bound upstream is closed first
Additional Description:
This fixes an issue in the BoundGenericUpstream where the connection callbacks added to the downstream connection can be invoked after the upstream object has been deleted. Specifically, if the client codec sends a frame with FLAG_END_STREAM, then the upstream is disconnected before the frame triggers the downstream connection to be closed, the event that fires after the downstream connection is eventually closed may attempt to invoke callbacks on the BoundGenericUpstream instance after it has already been deleted.

Risk Level: 
Testing: Added an integration test that should cover this case.

