### PR TITLE
coverage: adjusting coverage numbers for ExtProc

### DIFF
--- a/test/coverage.yaml
+++ b/test/coverage.yaml
@@ -41,7 +41,7 @@ directories:
   source/extensions/filters/http/cache: 95.9
   source/extensions/filters/http/dynamic_forward_proxy: 94.8
   source/extensions/filters/http/decompressor: 95.9
-  source/extensions/filters/http/ext_proc: 96.5
+  source/extensions/filters/http/ext_proc: 96.4 # might be flaky: be careful adjusting
   source/extensions/filters/http/grpc_json_reverse_transcoder: 94.8
   source/extensions/filters/http/grpc_json_transcoder: 94.0  # TODO(#28232)
   source/extensions/filters/http/ip_tagging: 95.9

--- a/test/coverage.yaml
+++ b/test/coverage.yaml
@@ -41,7 +41,7 @@ directories:
   source/extensions/filters/http/cache: 95.9
   source/extensions/filters/http/dynamic_forward_proxy: 94.8
   source/extensions/filters/http/decompressor: 95.9
-  source/extensions/filters/http/ext_proc: 96.4 # might be flaky: be careful adjusting
+  source/extensions/filters/http/ext_proc: 96.4  # might be flaky: be careful adjusting
   source/extensions/filters/http/grpc_json_reverse_transcoder: 94.8
   source/extensions/filters/http/grpc_json_transcoder: 94.0  # TODO(#28232)
   source/extensions/filters/http/ip_tagging: 95.9


### PR DESCRIPTION
## Description

This PR fixes the coverage numbers for ExtProc. Two previous PRs https://github.com/envoyproxy/envoy/pull/40503 and https://github.com/envoyproxy/envoy/pull/40568 had a race to landing made coverage to fail in CI.

---

Commit Message: coverage: adjusting coverage numbers for ExtProc
Additional Description: Fixes the coverage numbers for ExtProc.
Risk Level: N/A
Testing: CI
Docs Changes: N/A
Release Notes: N/A