### PR TITLE
Fix racily added SingleHeaderValueIs->ContainsHeader

### DIFF
--- a/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
+++ b/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
@@ -5553,7 +5553,7 @@ TEST_P(ExtProcIntegrationTest, LargeBodyTestDuplexStreamed) {
                                      /*response*/ false, body_response);
 
     handleUpstreamRequest();
-    EXPECT_THAT(upstream_request_->headers(), SingleHeaderValueIs("x-new-header", "new"));
+    EXPECT_THAT(upstream_request_->headers(), ContainsHeader("x-new-header", "new"));
     EXPECT_EQ(upstream_request_->body().toString(), body_upstream);
     verifyDownstreamResponse(*response, 200);
     TearDown();


### PR DESCRIPTION
Commit Message: Fix racily added SingleHeaderValueIs->ContainsHeader
Additional Description: CI broke because ContainsHeader cleanup raced with another PR adding one of the old matcher.
