### PR TITLE
http3: deprecate flag http3_happy_eyeballs and remove legacy code paths

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -50,6 +50,9 @@ removed_config_or_runtime:
 - area: http
   change: |
     Removed runtime guard ``envoy.reloadable_features.filter_chain_aborted_can_not_continue`` and legacy code paths.
+- area: http3
+  change: |
+    Removed runtime guard ``envoy.reloadable_features.http3_happy_eyeballs`` and legacy code paths.
 - area: dns_resolver
   change: |
     Removed runtime guard ``envoy.reloadable_features.getaddrinfo_num_retries`` and legacy code paths.

--- a/source/common/http/conn_pool_grid.cc
+++ b/source/common/http/conn_pool_grid.cc
@@ -106,10 +106,7 @@ bool ConnectivityGrid::WrapperCallbacks::shouldAttemptSecondHttp3Connection() {
   if (has_tried_http3_alternate_address_) {
     return false;
   }
-  // Branch on reloadable flags.
-  if (!Runtime::runtimeFeatureEnabled("envoy.reloadable_features.http3_happy_eyeballs")) {
-    return false;
-  }
+
   // QUIC "happy eyeballs" currently only handles one v4 and one v6 address. If
   // there's not multiple families don't bother.
   return hasBothAddressFamilies(grid_.host_);

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -50,7 +50,6 @@ RUNTIME_GUARD(envoy_reloadable_features_http1_balsa_disallow_lone_cr_in_chunk_ex
 RUNTIME_GUARD(envoy_reloadable_features_http2_discard_host_header);
 RUNTIME_GUARD(envoy_reloadable_features_http2_propagate_reset_events);
 RUNTIME_GUARD(envoy_reloadable_features_http2_use_oghttp2);
-RUNTIME_GUARD(envoy_reloadable_features_http3_happy_eyeballs);
 RUNTIME_GUARD(envoy_reloadable_features_http3_remove_empty_cookie);
 RUNTIME_GUARD(envoy_reloadable_features_http3_remove_empty_trailers);
 // Delay deprecation and decommission until UHV is enabled.


### PR DESCRIPTION
## Description

This PR removes the deprecated reloadable flag `http3_happy_eyeballs` and cleans up the legacy paths.

Fix https://github.com/envoyproxy/envoy/issues/38044

---

**Commit Message:** router: deprecate flag http3_happy_eyeballs and remove legacy code paths
**Additional Description:** Remove the deprecated reloadable flag `http3_happy_eyeballs` and cleans up the legacy paths.
**Risk Level:** Low
**Testing:** CI
**Docs Changes:** N/A
**Release Notes:** Added