### PR TITLE
http: deprecate flag allow_alt_svc_for_ips and remove legacy code paths

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -49,6 +49,9 @@ removed_config_or_runtime:
     Removed runtime guard ``envoy.reloadable_features.enable_udp_proxy_outlier_detection`` and legacy code paths.
 - area: http
   change: |
+    Removed runtime guard ``envoy.reloadable_features.allow_alt_svc_for_ips`` and legacy code paths.
+- area: http
+  change: |
     Removed runtime guard ``envoy.reloadable_features.filter_chain_aborted_can_not_continue`` and legacy code paths.
 - area: dns_resolver
   change: |

--- a/source/common/http/conn_pool_grid.cc
+++ b/source/common/http/conn_pool_grid.cc
@@ -33,8 +33,7 @@ std::string getTargetHostname(const Network::TransportSocketOptionsConstSharedPt
   }
   std::string default_sni =
       std::string(host->transportSocketFactory().defaultServerNameIndication());
-  if (!default_sni.empty() ||
-      !Runtime::runtimeFeatureEnabled("envoy.reloadable_features.allow_alt_svc_for_ips")) {
+  if (!default_sni.empty()) {
     return default_sni;
   }
   // If there's no configured SNI the hostname is probably an IP address. Return it here.

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -34,7 +34,6 @@
 // If issues are found that require a runtime feature to be disabled, it should be reported
 // ASAP by filing a bug on github. Overriding non-buggy code is strongly discouraged to avoid the
 // problem of the bugs being found after the old code path has been removed.
-RUNTIME_GUARD(envoy_reloadable_features_allow_alt_svc_for_ips);
 RUNTIME_GUARD(envoy_reloadable_features_async_host_selection);
 RUNTIME_GUARD(envoy_reloadable_features_dfp_cluster_resolves_hosts);
 RUNTIME_GUARD(envoy_reloadable_features_disallow_quic_client_udp_mmsg);


### PR DESCRIPTION
## Description

This PR removes the deprecated reloadable flag `allow_alt_svc_for_ips` and cleans up the legacy paths.

Fix https://github.com/envoyproxy/envoy/issues/39111

---

**Commit Message:** router: deprecate flag allow_alt_svc_for_ips and remove legacy code paths
**Additional Description:** Remove the deprecated reloadable flag `allow_alt_svc_for_ips` and cleans up the legacy paths.
**Risk Level:** Low
**Testing:** CI
**Docs Changes:** N/A
**Release Notes:** Added