### PR TITLE
Fix namespaces for various protobuf types

### DIFF
--- a/contrib/golang/filters/http/source/golang_filter.cc
+++ b/contrib/golang/filters/http/source/golang_filter.cc
@@ -1394,7 +1394,7 @@ CAPIStatus Filter::getStringPropertyInternal(absl::string_view path, std::string
         return CAPIStatus::CAPIValueNotFound;
       }
       const Protobuf::Descriptor* desc = msg->GetDescriptor();
-      const Protobuf::FieldDescriptor* field_desc = desc->FindFieldByName(std::string(part));
+      const ProtobufWkt::FieldDescriptor* field_desc = desc->FindFieldByName(std::string(part));
       if (field_desc == nullptr) {
         return CAPIStatus::CAPIValueNotFound;
       }

--- a/source/common/formatter/substitution_format_string.h
+++ b/source/common/formatter/substitution_format_string.h
@@ -24,7 +24,7 @@ namespace Formatter {
 class SubstitutionFormatStringUtils {
 public:
   using FormattersConfig =
-      ProtobufWkt::RepeatedPtrField<envoy::config::core::v3::TypedExtensionConfig>;
+      Protobuf::RepeatedPtrField<envoy::config::core::v3::TypedExtensionConfig>;
 
   /**
    * Parse list of formatter configurations to commands.

--- a/source/common/protobuf/deterministic_hash.cc
+++ b/source/common/protobuf/deterministic_hash.cc
@@ -14,47 +14,47 @@ namespace {
 // template.
 template <typename T>
 T reflectionGet(const Protobuf::Reflection& reflection, const Protobuf::Message& message,
-                const Protobuf::FieldDescriptor& field);
+                const ProtobufWkt::FieldDescriptor& field);
 
 template <>
 uint32_t reflectionGet(const Protobuf::Reflection& reflection, const Protobuf::Message& message,
-                       const Protobuf::FieldDescriptor& field) {
+                       const ProtobufWkt::FieldDescriptor& field) {
   return reflection.GetUInt32(message, &field);
 }
 
 template <>
 int32_t reflectionGet(const Protobuf::Reflection& reflection, const Protobuf::Message& message,
-                      const Protobuf::FieldDescriptor& field) {
+                      const ProtobufWkt::FieldDescriptor& field) {
   return reflection.GetInt32(message, &field);
 }
 
 template <>
 uint64_t reflectionGet(const Protobuf::Reflection& reflection, const Protobuf::Message& message,
-                       const Protobuf::FieldDescriptor& field) {
+                       const ProtobufWkt::FieldDescriptor& field) {
   return reflection.GetUInt64(message, &field);
 }
 
 template <>
 int64_t reflectionGet(const Protobuf::Reflection& reflection, const Protobuf::Message& message,
-                      const Protobuf::FieldDescriptor& field) {
+                      const ProtobufWkt::FieldDescriptor& field) {
   return reflection.GetInt64(message, &field);
 }
 
 template <>
 float reflectionGet(const Protobuf::Reflection& reflection, const Protobuf::Message& message,
-                    const Protobuf::FieldDescriptor& field) {
+                    const ProtobufWkt::FieldDescriptor& field) {
   return reflection.GetFloat(message, &field);
 }
 
 template <>
 double reflectionGet(const Protobuf::Reflection& reflection, const Protobuf::Message& message,
-                     const Protobuf::FieldDescriptor& field) {
+                     const ProtobufWkt::FieldDescriptor& field) {
   return reflection.GetDouble(message, &field);
 }
 
 template <>
 bool reflectionGet(const Protobuf::Reflection& reflection, const Protobuf::Message& message,
-                   const Protobuf::FieldDescriptor& field) {
+                   const ProtobufWkt::FieldDescriptor& field) {
   return reflection.GetBool(message, &field);
 }
 
@@ -62,7 +62,7 @@ bool reflectionGet(const Protobuf::Reflection& reflection, const Protobuf::Messa
 // the function hashes each of its elements.
 template <typename T, std::enable_if_t<std::is_scalar_v<T>, bool> = true>
 uint64_t hashScalarField(const Protobuf::Reflection& reflection, const Protobuf::Message& message,
-                         const Protobuf::FieldDescriptor& field, uint64_t seed) {
+                         const ProtobufWkt::FieldDescriptor& field, uint64_t seed) {
   if (field.is_repeated()) {
     for (const T& scalar : reflection.GetRepeatedFieldRef<T>(message, &field)) {
       seed = HashUtil::xxHash64Value(scalar, seed);
@@ -75,21 +75,21 @@ uint64_t hashScalarField(const Protobuf::Reflection& reflection, const Protobuf:
 
 uint64_t reflectionHashMessage(const Protobuf::Message& message, uint64_t seed = 0);
 uint64_t reflectionHashField(const Protobuf::Message& message,
-                             const Protobuf::FieldDescriptor& field, uint64_t seed);
+                             const ProtobufWkt::FieldDescriptor& field, uint64_t seed);
 
 // To make a map serialize deterministically we need to ignore the order of
 // the map fields. To do that, we simply combine the hashes of each entry
 // using an unordered operator (addition), and then apply that combined hash to
 // the seed.
 uint64_t reflectionHashMapField(const Protobuf::Message& message,
-                                const Protobuf::FieldDescriptor& field, uint64_t seed) {
+                                const ProtobufWkt::FieldDescriptor& field, uint64_t seed) {
   const Protobuf::Reflection& reflection = *message.GetReflection();
   ASSERT(field.is_map());
   const auto& entries = reflection.GetRepeatedFieldRef<Protobuf::Message>(message, &field);
   ASSERT(!entries.empty());
   const Protobuf::Descriptor& map_descriptor = *entries.begin()->GetDescriptor();
-  const Protobuf::FieldDescriptor& key_field = *map_descriptor.map_key();
-  const Protobuf::FieldDescriptor& value_field = *map_descriptor.map_value();
+  const ProtobufWkt::FieldDescriptor& key_field = *map_descriptor.map_key();
+  const ProtobufWkt::FieldDescriptor& value_field = *map_descriptor.map_value();
   uint64_t combined_hash = 0;
   for (const Protobuf::Message& entry : entries) {
     uint64_t entry_hash = reflectionHashField(entry, key_field, 0);
@@ -100,8 +100,8 @@ uint64_t reflectionHashMapField(const Protobuf::Message& message,
 }
 
 uint64_t reflectionHashField(const Protobuf::Message& message,
-                             const Protobuf::FieldDescriptor& field, uint64_t seed) {
-  using Protobuf::FieldDescriptor;
+                             const ProtobufWkt::FieldDescriptor& field, uint64_t seed) {
+  using ProtobufWkt::FieldDescriptor;
   const Protobuf::Reflection& reflection = *message.GetReflection();
   seed = HashUtil::xxHash64Value(field.number(), seed);
   switch (field.cpp_type()) {
@@ -197,7 +197,7 @@ std::unique_ptr<Protobuf::Message> unpackAnyForReflection(const ProtobufWkt::Any
 
 // This is intentionally ignoring unknown fields.
 uint64_t reflectionHashMessage(const Protobuf::Message& message, uint64_t seed) {
-  using Protobuf::FieldDescriptor;
+  using ProtobufWkt::FieldDescriptor;
   const Protobuf::Reflection* reflection = message.GetReflection();
   const Protobuf::Descriptor* descriptor = message.GetDescriptor();
   seed = HashUtil::xxHash64(descriptor->full_name(), seed);

--- a/source/common/protobuf/utility.h
+++ b/source/common/protobuf/utility.h
@@ -483,7 +483,7 @@ public:
                                            const std::string& field_name) {
     Protobuf::ReflectableMessage reflectable_message = createReflectableMessage(message);
     const Protobuf::Descriptor* descriptor = reflectable_message->GetDescriptor();
-    const Protobuf::FieldDescriptor* name_field = descriptor->FindFieldByName(field_name);
+    const ProtobufWkt::FieldDescriptor* name_field = descriptor->FindFieldByName(field_name);
     const Protobuf::Reflection* reflection = reflectable_message->GetReflection();
     return reflection->GetString(*reflectable_message, name_field);
   }

--- a/source/common/protobuf/visitor.cc
+++ b/source/common/protobuf/visitor.cc
@@ -52,11 +52,11 @@ absl::Status traverseMessageWorker(ConstProtoVisitor& visitor, const Protobuf::M
   const Protobuf::Descriptor* descriptor = reflectable_message->GetDescriptor();
   const Protobuf::Reflection* reflection = reflectable_message->GetReflection();
   for (int i = 0; i < descriptor->field_count(); ++i) {
-    const Protobuf::FieldDescriptor* field = descriptor->field(i);
+    const ProtobufWkt::FieldDescriptor* field = descriptor->field(i);
     visitor.onField(message, *field);
 
     // If this is a message, recurse in to the sub-message.
-    if (field->cpp_type() == Protobuf::FieldDescriptor::CPPTYPE_MESSAGE) {
+    if (field->cpp_type() == ProtobufWkt::FieldDescriptor::CPPTYPE_MESSAGE) {
       Helper::ScopedMessageParents scoped_parents(parents, message);
 
       if (field->is_repeated()) {

--- a/source/common/protobuf/visitor.h
+++ b/source/common/protobuf/visitor.h
@@ -14,7 +14,7 @@ public:
   virtual ~ConstProtoVisitor() = default;
 
   // Invoked when a field is visited, with the message, and field descriptor.
-  virtual void onField(const Protobuf::Message&, const Protobuf::FieldDescriptor&) PURE;
+  virtual void onField(const Protobuf::Message&, const ProtobufWkt::FieldDescriptor&) PURE;
 
   // Invoked when a message is visited, with the message and visited parents.
   // @param was_any_or_top_level supplies whether the message was either the top level message or an

--- a/source/common/rds/util.cc
+++ b/source/common/rds/util.cc
@@ -11,8 +11,9 @@ ProtobufTypes::MessagePtr cloneProto(ProtoTraits& proto_traits, const Protobuf::
 
 std::string resourceName(ProtoTraits& proto_traits, const Protobuf::Message& rc) {
   Protobuf::ReflectableMessage reflectable_message = createReflectableMessage(rc);
-  const Protobuf::FieldDescriptor* field = reflectable_message->GetDescriptor()->FindFieldByNumber(
-      proto_traits.resourceNameFieldNumber());
+  const ProtobufWkt::FieldDescriptor* field =
+      reflectable_message->GetDescriptor()->FindFieldByNumber(
+          proto_traits.resourceNameFieldNumber());
   if (!field) {
     return {};
   }

--- a/source/extensions/access_loggers/filters/cel/cel.cc
+++ b/source/extensions/access_loggers/filters/cel/cel.cc
@@ -19,7 +19,7 @@ CELAccessLogExtensionFilter::CELAccessLogExtensionFilter(
 
 bool CELAccessLogExtensionFilter::evaluate(const Formatter::HttpFormatterContext& log_context,
                                            const StreamInfo::StreamInfo& stream_info) const {
-  ProtobufWkt::Arena arena;
+  Protobuf::Arena arena;
   const auto result = Extensions::Filters::Common::Expr::evaluate(
       *compiled_expr_.get(), arena, &local_info_, stream_info, &log_context.requestHeaders(),
       &log_context.responseHeaders(), &log_context.responseTrailers());

--- a/source/extensions/common/wasm/context.cc
+++ b/source/extensions/common/wasm/context.cc
@@ -580,7 +580,7 @@ WasmResult Context::getProperty(std::string_view path, std::string* result) {
         return WasmResult::NotFound;
       }
       const Protobuf::Descriptor* desc = msg->GetDescriptor();
-      const Protobuf::FieldDescriptor* field_desc = desc->FindFieldByName(std::string(part));
+      const ProtobufWkt::FieldDescriptor* field_desc = desc->FindFieldByName(std::string(part));
       if (field_desc == nullptr) {
         return WasmResult::NotFound;
       }

--- a/source/extensions/config_subscription/filesystem/filesystem_subscription_impl.cc
+++ b/source/extensions/config_subscription/filesystem/filesystem_subscription_impl.cc
@@ -137,7 +137,7 @@ FilesystemCollectionSubscriptionImpl::refreshInternal(ProtobufTypes::MessagePtr*
   const auto* collection_entries_field_descriptor = collection_descriptor->field(0);
   // Verify collection message type structure.
   if (collection_entries_field_descriptor == nullptr ||
-      collection_entries_field_descriptor->type() != Protobuf::FieldDescriptor::TYPE_MESSAGE ||
+      collection_entries_field_descriptor->type() != ProtobufWkt::FieldDescriptor::TYPE_MESSAGE ||
       collection_entries_field_descriptor->message_type()->full_name() !=
           "xds.core.v3.CollectionEntry" ||
       !collection_entries_field_descriptor->is_repeated()) {

--- a/source/extensions/filters/common/expr/context.cc
+++ b/source/extensions/filters/common/expr/context.cc
@@ -682,11 +682,11 @@ absl::optional<CelValue> FilterStateWrapper::operator[](CelValue key) const {
       // field support, but callers only want to access the whole object.
       if (object->hasFieldSupport()) {
         return CelValue::CreateMap(
-            ProtobufWkt::Arena::Create<FilterStateObjectWrapper>(&arena_, object));
+            Protobuf::Arena::Create<FilterStateObjectWrapper>(&arena_, object));
       }
       absl::optional<std::string> serialized = object->serializeAsString();
       if (serialized.has_value()) {
-        std::string* out = ProtobufWkt::Arena::Create<std::string>(&arena_, serialized.value());
+        std::string* out = Protobuf::Arena::Create<std::string>(&arena_, serialized.value());
         return CelValue::CreateBytes(out);
       }
     }

--- a/source/extensions/filters/common/expr/context.h
+++ b/source/extensions/filters/common/expr/context.h
@@ -228,7 +228,7 @@ public:
   }
 
 protected:
-  ProtobufWkt::Arena& arena_;
+  Protobuf::Arena& arena_;
 };
 
 class RequestWrapper : public BaseWrapper {

--- a/source/extensions/filters/common/lua/protobuf_converter.cc
+++ b/source/extensions/filters/common/lua/protobuf_converter.cc
@@ -21,25 +21,25 @@ inline void pushLuaString(lua_State* state, absl::string_view str) {
 
 // Helper function to push numeric value based on protobuf field type
 void pushLuaNumericValue(lua_State* state, const Protobuf::ReflectableMessage& message,
-                         const Protobuf::FieldDescriptor* field,
+                         const ProtobufWkt::FieldDescriptor* field,
                          const Protobuf::Reflection* reflection) {
   switch (field->cpp_type()) {
-  case Protobuf::FieldDescriptor::CPPTYPE_INT32:
+  case ProtobufWkt::FieldDescriptor::CPPTYPE_INT32:
     lua_pushnumber(state, reflection->GetInt32(*message, field));
     break;
-  case Protobuf::FieldDescriptor::CPPTYPE_INT64:
+  case ProtobufWkt::FieldDescriptor::CPPTYPE_INT64:
     lua_pushnumber(state, reflection->GetInt64(*message, field));
     break;
-  case Protobuf::FieldDescriptor::CPPTYPE_UINT32:
+  case ProtobufWkt::FieldDescriptor::CPPTYPE_UINT32:
     lua_pushnumber(state, reflection->GetUInt32(*message, field));
     break;
-  case Protobuf::FieldDescriptor::CPPTYPE_UINT64:
+  case ProtobufWkt::FieldDescriptor::CPPTYPE_UINT64:
     lua_pushnumber(state, reflection->GetUInt64(*message, field));
     break;
-  case Protobuf::FieldDescriptor::CPPTYPE_DOUBLE:
+  case ProtobufWkt::FieldDescriptor::CPPTYPE_DOUBLE:
     lua_pushnumber(state, reflection->GetDouble(*message, field));
     break;
-  case Protobuf::FieldDescriptor::CPPTYPE_FLOAT:
+  case ProtobufWkt::FieldDescriptor::CPPTYPE_FLOAT:
     lua_pushnumber(state, reflection->GetFloat(*message, field));
     break;
   default:
@@ -65,7 +65,7 @@ void ProtobufConverterUtils::pushLuaTableFromMessage(
 
   // Process all fields
   for (int i = 0; i < descriptor->field_count(); ++i) {
-    const Protobuf::FieldDescriptor* field = descriptor->field(i);
+    const ProtobufWkt::FieldDescriptor* field = descriptor->field(i);
 
     // Skip fields that aren't set
     if (field->is_repeated()) {
@@ -85,7 +85,7 @@ void ProtobufConverterUtils::pushLuaTableFromMessage(
 
 void ProtobufConverterUtils::pushLuaValueFromField(lua_State* state,
                                                    const Protobuf::ReflectableMessage& message,
-                                                   const Protobuf::FieldDescriptor* field) {
+                                                   const ProtobufWkt::FieldDescriptor* field) {
   const Protobuf::Reflection* reflection = message->GetReflection();
 
   // Check for map fields first, before checking for repeated fields
@@ -100,32 +100,32 @@ void ProtobufConverterUtils::pushLuaValueFromField(lua_State* state,
   }
 
   switch (field->cpp_type()) {
-  case Protobuf::FieldDescriptor::CPPTYPE_INT32:
-  case Protobuf::FieldDescriptor::CPPTYPE_INT64:
-  case Protobuf::FieldDescriptor::CPPTYPE_UINT32:
-  case Protobuf::FieldDescriptor::CPPTYPE_UINT64:
-  case Protobuf::FieldDescriptor::CPPTYPE_DOUBLE:
-  case Protobuf::FieldDescriptor::CPPTYPE_FLOAT:
+  case ProtobufWkt::FieldDescriptor::CPPTYPE_INT32:
+  case ProtobufWkt::FieldDescriptor::CPPTYPE_INT64:
+  case ProtobufWkt::FieldDescriptor::CPPTYPE_UINT32:
+  case ProtobufWkt::FieldDescriptor::CPPTYPE_UINT64:
+  case ProtobufWkt::FieldDescriptor::CPPTYPE_DOUBLE:
+  case ProtobufWkt::FieldDescriptor::CPPTYPE_FLOAT:
     pushLuaNumericValue(state, message, field, reflection);
     break;
 
-  case Protobuf::FieldDescriptor::CPPTYPE_BOOL:
+  case ProtobufWkt::FieldDescriptor::CPPTYPE_BOOL:
     lua_pushboolean(state, reflection->GetBool(*message, field));
     break;
 
-  case Protobuf::FieldDescriptor::CPPTYPE_STRING: {
+  case ProtobufWkt::FieldDescriptor::CPPTYPE_STRING: {
     const std::string& value = reflection->GetString(*message, field);
     pushLuaString(state, value);
     break;
   }
 
-  case Protobuf::FieldDescriptor::CPPTYPE_MESSAGE: {
+  case ProtobufWkt::FieldDescriptor::CPPTYPE_MESSAGE: {
     const auto& msg = reflection->GetMessage(*message, field);
     pushLuaTableFromMessage(state, msg);
     break;
   }
 
-  case Protobuf::FieldDescriptor::CPPTYPE_ENUM:
+  case ProtobufWkt::FieldDescriptor::CPPTYPE_ENUM:
     lua_pushnumber(state, reflection->GetEnumValue(*message, field));
     break;
 
@@ -136,7 +136,7 @@ void ProtobufConverterUtils::pushLuaValueFromField(lua_State* state,
 
 void ProtobufConverterUtils::pushLuaTableFromMapField(lua_State* state,
                                                       const Protobuf::ReflectableMessage& message,
-                                                      const Protobuf::FieldDescriptor* field) {
+                                                      const ProtobufWkt::FieldDescriptor* field) {
   const Protobuf::Reflection* reflection = message->GetReflection();
   const int size = reflection->FieldSize(*message, field);
 
@@ -161,24 +161,24 @@ void ProtobufConverterUtils::pushLuaTableFromMapField(lua_State* state,
 
     // Push the key
     switch (key_field->cpp_type()) {
-    case Protobuf::FieldDescriptor::CPPTYPE_STRING: {
+    case ProtobufWkt::FieldDescriptor::CPPTYPE_STRING: {
       const std::string& key = entry_reflection->GetString(*entry, key_field);
       pushLuaString(state, key);
       break;
     }
-    case Protobuf::FieldDescriptor::CPPTYPE_INT32:
+    case ProtobufWkt::FieldDescriptor::CPPTYPE_INT32:
       lua_pushnumber(state, entry_reflection->GetInt32(*entry, key_field));
       break;
-    case Protobuf::FieldDescriptor::CPPTYPE_INT64:
+    case ProtobufWkt::FieldDescriptor::CPPTYPE_INT64:
       lua_pushnumber(state, entry_reflection->GetInt64(*entry, key_field));
       break;
-    case Protobuf::FieldDescriptor::CPPTYPE_UINT32:
+    case ProtobufWkt::FieldDescriptor::CPPTYPE_UINT32:
       lua_pushnumber(state, entry_reflection->GetUInt32(*entry, key_field));
       break;
-    case Protobuf::FieldDescriptor::CPPTYPE_UINT64:
+    case ProtobufWkt::FieldDescriptor::CPPTYPE_UINT64:
       lua_pushnumber(state, entry_reflection->GetUInt64(*entry, key_field));
       break;
-    case Protobuf::FieldDescriptor::CPPTYPE_BOOL:
+    case ProtobufWkt::FieldDescriptor::CPPTYPE_BOOL:
       lua_pushboolean(state, entry_reflection->GetBool(*entry, key_field));
       break;
     default:
@@ -194,7 +194,7 @@ void ProtobufConverterUtils::pushLuaTableFromMapField(lua_State* state,
 
 void ProtobufConverterUtils::pushLuaArrayFromRepeatedField(
     lua_State* state, const Protobuf::ReflectableMessage& message,
-    const Protobuf::FieldDescriptor* field) {
+    const ProtobufWkt::FieldDescriptor* field) {
   const Protobuf::Reflection* reflection = message->GetReflection();
   const int size = reflection->FieldSize(*message, field);
 
@@ -205,36 +205,36 @@ void ProtobufConverterUtils::pushLuaArrayFromRepeatedField(
     lua_pushnumber(state, i + 1);
 
     switch (field->cpp_type()) {
-    case Protobuf::FieldDescriptor::CPPTYPE_INT32:
+    case ProtobufWkt::FieldDescriptor::CPPTYPE_INT32:
       lua_pushnumber(state, reflection->GetRepeatedInt32(*message, field, i));
       break;
-    case Protobuf::FieldDescriptor::CPPTYPE_INT64:
+    case ProtobufWkt::FieldDescriptor::CPPTYPE_INT64:
       lua_pushnumber(state, reflection->GetRepeatedInt64(*message, field, i));
       break;
-    case Protobuf::FieldDescriptor::CPPTYPE_UINT32:
+    case ProtobufWkt::FieldDescriptor::CPPTYPE_UINT32:
       lua_pushnumber(state, reflection->GetRepeatedUInt32(*message, field, i));
       break;
-    case Protobuf::FieldDescriptor::CPPTYPE_UINT64:
+    case ProtobufWkt::FieldDescriptor::CPPTYPE_UINT64:
       lua_pushnumber(state, reflection->GetRepeatedUInt64(*message, field, i));
       break;
-    case Protobuf::FieldDescriptor::CPPTYPE_DOUBLE:
+    case ProtobufWkt::FieldDescriptor::CPPTYPE_DOUBLE:
       lua_pushnumber(state, reflection->GetRepeatedDouble(*message, field, i));
       break;
-    case Protobuf::FieldDescriptor::CPPTYPE_FLOAT:
+    case ProtobufWkt::FieldDescriptor::CPPTYPE_FLOAT:
       lua_pushnumber(state, reflection->GetRepeatedFloat(*message, field, i));
       break;
-    case Protobuf::FieldDescriptor::CPPTYPE_BOOL:
+    case ProtobufWkt::FieldDescriptor::CPPTYPE_BOOL:
       lua_pushboolean(state, reflection->GetRepeatedBool(*message, field, i));
       break;
-    case Protobuf::FieldDescriptor::CPPTYPE_STRING: {
+    case ProtobufWkt::FieldDescriptor::CPPTYPE_STRING: {
       const std::string& value = reflection->GetRepeatedString(*message, field, i);
       pushLuaString(state, value);
       break;
     }
-    case Protobuf::FieldDescriptor::CPPTYPE_MESSAGE:
+    case ProtobufWkt::FieldDescriptor::CPPTYPE_MESSAGE:
       pushLuaTableFromMessage(state, reflection->GetRepeatedMessage(*message, field, i));
       break;
-    case Protobuf::FieldDescriptor::CPPTYPE_ENUM:
+    case ProtobufWkt::FieldDescriptor::CPPTYPE_ENUM:
       lua_pushnumber(state, reflection->GetRepeatedEnumValue(*message, field, i));
       break;
     default:

--- a/source/extensions/filters/common/lua/protobuf_converter.h
+++ b/source/extensions/filters/common/lua/protobuf_converter.h
@@ -79,7 +79,7 @@ public:
    * then pushes that value onto the Lua stack.
    */
   static void pushLuaValueFromField(lua_State* state, const Protobuf::ReflectableMessage& message,
-                                    const Protobuf::FieldDescriptor* field);
+                                    const ProtobufWkt::FieldDescriptor* field);
 
   /**
    * Push a Lua table onto the stack that represents a protobuf map field
@@ -92,7 +92,7 @@ public:
    */
   static void pushLuaTableFromMapField(lua_State* state,
                                        const Protobuf::ReflectableMessage& message,
-                                       const Protobuf::FieldDescriptor* field);
+                                       const ProtobufWkt::FieldDescriptor* field);
 
   /**
    * Push a Lua array onto the stack that represents a repeated field
@@ -105,7 +105,7 @@ public:
    */
   static void pushLuaArrayFromRepeatedField(lua_State* state,
                                             const Protobuf::ReflectableMessage& message,
-                                            const Protobuf::FieldDescriptor* field);
+                                            const ProtobufWkt::FieldDescriptor* field);
 };
 
 } // namespace Lua

--- a/source/extensions/filters/http/compressor/compressor_filter.cc
+++ b/source/extensions/filters/http/compressor/compressor_filter.cc
@@ -155,8 +155,8 @@ CompressorFilterConfig::ResponseDirectionConfig::commonConfig(
     config.set_allocated_min_content_length(
         // According to
         // https://developers.google.com/protocol-buffers/docs/reference/cpp-generated#embeddedmessage
-        // the message Compressor takes ownership of the allocated Protobuf::Uint32Value object.
-        new Protobuf::UInt32Value(proto_config.content_length()));
+        // the message Compressor takes ownership of the allocated ProtobufWkt::Uint32Value object.
+        new ProtobufWkt::UInt32Value(proto_config.content_length()));
   }
   // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
   for (const std::string& ctype : proto_config.content_type()) {

--- a/source/extensions/filters/http/ext_proc/matching_utils.cc
+++ b/source/extensions/filters/http/ext_proc/matching_utils.cc
@@ -53,7 +53,7 @@ ExpressionManager::evaluateAttributes(const Filters::Common::Expr::Activation& a
   }
 
   for (const auto& hash_entry : expr) {
-    ProtobufWkt::Arena arena;
+    Protobuf::Arena arena;
     const auto result = hash_entry.second.compiled_expr_->Evaluate(activation, &arena);
     if (!result.ok()) {
       // TODO: Stats?

--- a/source/extensions/filters/http/grpc_field_extraction/extractor.h
+++ b/source/extensions/filters/http/grpc_field_extraction/extractor.h
@@ -19,7 +19,7 @@ namespace Extensions {
 namespace HttpFilters {
 namespace GrpcFieldExtraction {
 
-using TypeFinder = std::function<const Protobuf::Type*(const std::string&)>;
+using TypeFinder = std::function<const ProtobufWkt::Type*(const std::string&)>;
 struct RequestField {
   // The request field path.
   absl::string_view path;
@@ -36,7 +36,7 @@ public:
 
   // Process a request message to extract targeted fields.
   virtual absl::StatusOr<ExtractionResult>
-  processRequest(Protobuf::field_extraction::MessageData& message) const = 0;
+  processRequest(ProtobufWkt::field_extraction::MessageData& message) const = 0;
 };
 
 using ExtractorPtr = std::unique_ptr<Extractor>;

--- a/source/extensions/filters/http/grpc_field_extraction/extractor_impl.cc
+++ b/source/extensions/filters/http/grpc_field_extraction/extractor_impl.cc
@@ -16,7 +16,7 @@ namespace HttpFilters {
 namespace GrpcFieldExtraction {
 namespace {
 
-using Protobuf::field_extraction::FieldValueExtractorFactory;
+using ProtobufWkt::field_extraction::FieldValueExtractorFactory;
 
 } // namespace
 
@@ -44,7 +44,7 @@ absl::Status ExtractorImpl::init(
 }
 
 absl::StatusOr<ExtractionResult>
-ExtractorImpl::processRequest(Protobuf::field_extraction::MessageData& message) const {
+ExtractorImpl::processRequest(ProtobufWkt::field_extraction::MessageData& message) const {
 
   ExtractionResult result;
   for (const auto& it : per_field_extractors_) {

--- a/source/extensions/filters/http/grpc_field_extraction/extractor_impl.h
+++ b/source/extensions/filters/http/grpc_field_extraction/extractor_impl.h
@@ -19,7 +19,7 @@ namespace HttpFilters {
 namespace GrpcFieldExtraction {
 
 using FieldValueExtractorPtr =
-    std::unique_ptr<Protobuf::field_extraction::FieldValueExtractorInterface>;
+    std::unique_ptr<ProtobufWkt::field_extraction::FieldValueExtractorInterface>;
 class ExtractorImpl : public Extractor {
 public:
   static absl::StatusOr<ExtractorImpl>
@@ -28,7 +28,7 @@ public:
              field_extractions);
 
   absl::StatusOr<ExtractionResult>
-  processRequest(Protobuf::field_extraction::MessageData& message) const override;
+  processRequest(ProtobufWkt::field_extraction::MessageData& message) const override;
 
 private:
   ExtractorImpl() = default;

--- a/source/extensions/filters/http/grpc_field_extraction/filter.cc
+++ b/source/extensions/filters/http/grpc_field_extraction/filter.cc
@@ -110,7 +110,7 @@ Envoy::Http::FilterHeadersStatus Filter::decodeHeaders(Envoy::Http::RequestHeade
 
   extractor_ = extractor;
   auto cord_message_data_factory = std::make_unique<CreateMessageDataFunc>(
-      []() { return std::make_unique<Protobuf::field_extraction::CordMessageData>(); });
+      []() { return std::make_unique<ProtobufWkt::field_extraction::CordMessageData>(); });
   request_msg_converter_ = std::make_unique<MessageConverter>(
       std::move(cord_message_data_factory), decoder_callbacks_->decoderBufferLimit());
 

--- a/source/extensions/filters/http/grpc_field_extraction/filter_config.cc
+++ b/source/extensions/filters/http/grpc_field_extraction/filter_config.cc
@@ -22,7 +22,7 @@ FilterConfig::FilterConfig(const GrpcFieldExtractionConfig& proto_config,
       std::make_unique<const TypeHelper>(Protobuf::util::NewTypeResolverForDescriptorPool(
           Grpc::Common::typeUrlPrefix(), descriptor_pool_.get()));
   type_finder_ = std::make_unique<const TypeFinder>(
-      [this](absl::string_view type_url) -> const Protobuf::Type* {
+      [this](absl::string_view type_url) -> const ProtobufWkt::Type* {
         return type_helper_->Info()->GetTypeByTypeUrl(type_url);
       });
 

--- a/source/extensions/filters/http/grpc_field_extraction/message_converter/message_converter_utility.h
+++ b/source/extensions/filters/http/grpc_field_extraction/message_converter/message_converter_utility.h
@@ -18,7 +18,7 @@ namespace HttpFilters {
 namespace GrpcFieldExtraction {
 
 using CreateMessageDataFunc =
-    std::function<std::unique_ptr<Protobuf::field_extraction::MessageData>()>;
+    std::function<std::unique_ptr<ProtobufWkt::field_extraction::MessageData>()>;
 
 // The output for the parseGrpcMessage function.
 struct ParsedGrpcMessage {
@@ -32,7 +32,7 @@ struct ParsedGrpcMessage {
 
   // The parsed `RawMessage`. Message does not own any of the underlying data.
   // Data is stored in the `owned_bytes` buffer instead.
-  std::unique_ptr<Protobuf::field_extraction::MessageData> message;
+  std::unique_ptr<ProtobufWkt::field_extraction::MessageData> message;
 
   // Envoy buffer that owns the underlying data.
   // Remember, data can NOT be moved out of this buffer anytime.

--- a/source/extensions/filters/http/grpc_field_extraction/message_converter/stream_message.h
+++ b/source/extensions/filters/http/grpc_field_extraction/message_converter/stream_message.h
@@ -14,7 +14,7 @@ namespace GrpcFieldExtraction {
 // It is neither copyable nor movable.
 class StreamMessage {
 public:
-  StreamMessage(std::unique_ptr<Protobuf::field_extraction::MessageData> message,
+  StreamMessage(std::unique_ptr<ProtobufWkt::field_extraction::MessageData> message,
                 Buffer::InstancePtr owned_bytes, std::shared_ptr<uint64_t> ref_to_bytes_usage)
       : message_(std::move(message)), owned_bytes_(std::move(owned_bytes)),
         ref_to_bytes_usage_(ref_to_bytes_usage) {
@@ -50,16 +50,16 @@ public:
   bool is_first_message_ = false;
   bool is_final_message_ = false;
 
-  Protobuf::field_extraction::MessageData* message() {
+  ProtobufWkt::field_extraction::MessageData* message() {
     return message_ != nullptr ? message_.get() : nullptr;
   }
 
-  void set(std::unique_ptr<Protobuf::field_extraction::MessageData> message) {
+  void set(std::unique_ptr<ProtobufWkt::field_extraction::MessageData> message) {
     message_ = std::move(message);
   }
 
 private:
-  std::unique_ptr<Protobuf::field_extraction::MessageData> message_;
+  std::unique_ptr<ProtobufWkt::field_extraction::MessageData> message_;
 
   // Envoy buffer that owns the underlying data.
   // This data can NOT be mutated during the lifetime of this message.

--- a/source/extensions/filters/http/proto_api_scrubber/filter.cc
+++ b/source/extensions/filters/http/proto_api_scrubber/filter.cc
@@ -47,7 +47,7 @@ ProtoApiScrubberFilter::decodeHeaders(Envoy::Http::RequestHeaderMap& headers, bo
   is_valid_grpc_request_ = true;
 
   auto cord_message_data_factory = std::make_unique<CreateMessageDataFunc>(
-      []() { return std::make_unique<Protobuf::field_extraction::CordMessageData>(); });
+      []() { return std::make_unique<ProtobufWkt::field_extraction::CordMessageData>(); });
 
   request_msg_converter_ = std::make_unique<MessageConverter>(
       std::move(cord_message_data_factory), decoder_callbacks_->decoderBufferLimit());

--- a/source/extensions/filters/http/proto_message_extraction/extraction_util/extraction_util.h
+++ b/source/extensions/filters/http/proto_message_extraction/extraction_util/extraction_util.h
@@ -70,17 +70,17 @@ void GetMonitoredResourceLabels(absl::string_view label_extractor,
 // In case of error or nullptr/empty field_mask, it returns a negative value and
 // logs the error.
 int64_t
-ExtractRepeatedFieldSize(const Protobuf::Type& type,
-                         std::function<const Protobuf::Type*(const std::string&)> type_finder,
-                         const Protobuf::FieldMask* field_mask,
-                         const Protobuf::field_extraction::MessageData& message);
+ExtractRepeatedFieldSize(const ProtobufWkt::Type& type,
+                         std::function<const ProtobufWkt::Type*(const std::string&)> type_finder,
+                         const ProtobufWkt::FieldMask* field_mask,
+                         const ProtobufWkt::field_extraction::MessageData& message);
 
 // Extract the size of the repeated field represented by given field mask
 // path from given proto message. `path` must represent a repeated field.
 absl::StatusOr<int64_t>
-ExtractRepeatedFieldSizeHelper(const Protobuf::field_extraction::FieldExtractor& field_extractor,
+ExtractRepeatedFieldSizeHelper(const ProtobufWkt::field_extraction::FieldExtractor& field_extractor,
                                const std::string& path,
-                               const Protobuf::field_extraction::MessageData& message);
+                               const ProtobufWkt::field_extraction::MessageData& message);
 
 absl::string_view ExtractLocationIdFromResourceName(absl::string_view resource_name);
 
@@ -95,7 +95,7 @@ void RedactPaths(absl::Span<const std::string> paths_to_redact, ProtobufWkt::Str
 // value. Returns an empty string if there is only one string field. Returns
 // an error if the resource is malformed in case that the search goes forever.
 absl::StatusOr<std::string>
-FindSingularLastValue(const Protobuf::Field* field,
+FindSingularLastValue(const ProtobufWkt::Field* field,
                       Envoy::Protobuf::io::CodedInputStream* input_stream);
 
 // Non-repeated fields can be repeat in a wire-format, in that case use the
@@ -105,14 +105,14 @@ FindSingularLastValue(const Protobuf::Field* field,
 // non-repeated field. However, parsers are expected to handle the case in
 // which they do."
 absl::StatusOr<std::string>
-SingularFieldUseLastValue(const std::string first_value, const Protobuf::Field* field,
+SingularFieldUseLastValue(const std::string first_value, const ProtobufWkt::Field* field,
                           Envoy::Protobuf::io::CodedInputStream* input_stream);
 
 absl::StatusOr<std::string>
-ExtractStringFieldValue(const Protobuf::Type& type,
-                        std::function<const Protobuf::Type*(const std::string&)> type_finder,
+ExtractStringFieldValue(const ProtobufWkt::Type& type,
+                        std::function<const ProtobufWkt::Type*(const std::string&)> type_finder,
                         const std::string& path,
-                        const Protobuf::field_extraction::MessageData& message);
+                        const ProtobufWkt::field_extraction::MessageData& message);
 
 absl::Status RedactStructRecursively(std::vector<std::string>::const_iterator path_pieces_begin,
                                      std::vector<std::string>::const_iterator path_pieces_end,
@@ -121,7 +121,7 @@ absl::Status RedactStructRecursively(std::vector<std::string>::const_iterator pa
 // Converts given proto message to Struct. It also adds
 // a "@type" property with proto type url to the generated Struct. Expects the
 // TypeResolver to handle types prefixed with "type.googleapis.com/".
-absl::Status ConvertToStruct(const Protobuf::field_extraction::MessageData& message,
+absl::Status ConvertToStruct(const ProtobufWkt::field_extraction::MessageData& message,
                              const Envoy::ProtobufWkt::Type& type,
                              ::Envoy::Protobuf::util::TypeResolver* type_resolver,
                              ::Envoy::ProtobufWkt::Struct* message_struct);
@@ -135,7 +135,7 @@ absl::Status ConvertToStruct(const Protobuf::field_extraction::MessageData& mess
 bool ScrubToStruct(const proto_processing_lib::proto_scrubber::ProtoScrubber* scrubber,
                    const Envoy::ProtobufWkt::Type& type,
                    const ::google::grpc::transcoding::TypeHelper& type_helper,
-                   Protobuf::field_extraction::MessageData* message,
+                   ProtobufWkt::field_extraction::MessageData* message,
                    Envoy::ProtobufWkt::Struct* message_struct);
 
 } // namespace ProtoMessageExtraction

--- a/source/extensions/filters/http/proto_message_extraction/extraction_util/proto_extractor.h
+++ b/source/extensions/filters/http/proto_message_extraction/extraction_util/proto_extractor.h
@@ -32,7 +32,7 @@ public:
 
   // Input message must be a message data.
   ExtractedMessageMetadata
-  ExtractMessage(const Protobuf::field_extraction::MessageData& message) const override;
+  ExtractMessage(const ProtobufWkt::field_extraction::MessageData& message) const override;
 
 private:
   // Initializes an instance of ProtoExtractor using FieldPolicies.
@@ -44,8 +44,9 @@ private:
   // Populate the target resource or the target resource callback in the extracted message
   // metadata.
   void GetTargetResourceOrTargetResourceCallback(
-      const Protobuf::FieldMask& field_mask, const Protobuf::field_extraction::MessageData& message,
-      bool callback, ExtractedMessageMetadata* extracted_message_metadata) const;
+      const ProtobufWkt::FieldMask& field_mask,
+      const ProtobufWkt::field_extraction::MessageData& message, bool callback,
+      ExtractedMessageMetadata* extracted_message_metadata) const;
 
   // Function to get the value associated with a key
   const ProtobufWkt::FieldMask& FindWithDefault(ExtractedMessageDirective directive);

--- a/source/extensions/filters/http/proto_message_extraction/extraction_util/proto_extractor_interface.h
+++ b/source/extensions/filters/http/proto_message_extraction/extraction_util/proto_extractor_interface.h
@@ -40,7 +40,7 @@ public:
   // that contains the extracted message and other extracted message metadata obtained during
   // extraction.
   virtual ExtractedMessageMetadata
-  ExtractMessage(const Protobuf::field_extraction::MessageData& message) const = 0;
+  ExtractMessage(const ProtobufWkt::field_extraction::MessageData& message) const = 0;
 
   virtual ~ProtoExtractorInterface() = default;
 };

--- a/source/extensions/filters/http/proto_message_extraction/extractor.h
+++ b/source/extensions/filters/http/proto_message_extraction/extractor.h
@@ -22,7 +22,7 @@ namespace Extensions {
 namespace HttpFilters {
 namespace ProtoMessageExtraction {
 
-using ::Envoy::Protobuf::Type;
+using ::Envoy::ProtobufWkt::Type;
 
 using TypeFinder = std::function<const Envoy::ProtobufWkt::Type*(const std::string&)>;
 
@@ -48,14 +48,14 @@ public:
   // for a client streaming call.
   // It can be called on every message too if callers don't know which one
   // is the last message. It only keeps the result from the first and the last.
-  virtual void processRequest(Protobuf::field_extraction::MessageData& message) = 0;
+  virtual void processRequest(ProtobufWkt::field_extraction::MessageData& message) = 0;
 
   // Extract EXTRACT fields on a response message.
   // It only needs to be called for the first response message and the last
   // for a server streaming call.
   // It can be called on every message too if callers don't know which one
   // is the last message. It only keeps the result from the first one the last.
-  virtual void processResponse(Protobuf::field_extraction::MessageData& message) = 0;
+  virtual void processResponse(ProtobufWkt::field_extraction::MessageData& message) = 0;
 
   virtual const ExtractedMessageResult& GetResult() const = 0;
 

--- a/source/extensions/filters/http/proto_message_extraction/extractor_impl.cc
+++ b/source/extensions/filters/http/proto_message_extraction/extractor_impl.cc
@@ -32,14 +32,15 @@ using ::envoy::extensions::filters::http::proto_message_extraction::v3::MethodEx
 using ::Envoy::Extensions::HttpFilters::ProtoMessageExtraction::ExtractedMessageDirective;
 using ::Envoy::Extensions::HttpFilters::ProtoMessageExtraction::ExtractedMessageMetadata;
 using ::proto_processing_lib::proto_scrubber::ScrubberContext;
-using Protobuf::field_extraction::FieldValueExtractorFactory;
+using ProtobufWkt::field_extraction::FieldValueExtractorFactory;
 
 // The type property value that will be included into the converted Struct.
 constexpr char kTypeProperty[] = "@type";
 
 ABSL_CONST_INIT const char* const kTypeServiceBaseUrl = "type.googleapis.com";
 
-void extract(ProtoExtractorInterface& extractor, Protobuf::field_extraction::MessageData& message,
+void extract(ProtoExtractorInterface& extractor,
+             ProtobufWkt::field_extraction::MessageData& message,
              std::vector<ExtractedMessageMetadata>& vect) {
   ExtractedMessageMetadata data = extractor.ExtractMessage(message);
   ENVOY_LOG_MISC(debug, "Extracted fields: {}", data.extracted_message.DebugString());
@@ -111,11 +112,11 @@ absl::Status ExtractorImpl::init() {
   return absl::OkStatus();
 }
 
-void ExtractorImpl::processRequest(Protobuf::field_extraction::MessageData& message) {
+void ExtractorImpl::processRequest(ProtobufWkt::field_extraction::MessageData& message) {
   extract(*request_extractor_, message, result_.request_data);
 }
 
-void ExtractorImpl::processResponse(Protobuf::field_extraction::MessageData& message) {
+void ExtractorImpl::processResponse(ProtobufWkt::field_extraction::MessageData& message) {
   extract(*response_extractor_, message, result_.response_data);
 }
 } // namespace ProtoMessageExtraction

--- a/source/extensions/filters/http/proto_message_extraction/extractor_impl.h
+++ b/source/extensions/filters/http/proto_message_extraction/extractor_impl.h
@@ -36,9 +36,9 @@ public:
   //  called.
   absl::Status init();
 
-  void processRequest(Protobuf::field_extraction::MessageData& message) override;
+  void processRequest(ProtobufWkt::field_extraction::MessageData& message) override;
 
-  void processResponse(Protobuf::field_extraction::MessageData& message) override;
+  void processResponse(ProtobufWkt::field_extraction::MessageData& message) override;
 
   const ExtractedMessageResult& GetResult() const override { return result_; }
 

--- a/source/extensions/filters/http/proto_message_extraction/filter.cc
+++ b/source/extensions/filters/http/proto_message_extraction/filter.cc
@@ -152,7 +152,7 @@ Envoy::Http::FilterHeadersStatus Filter::decodeHeaders(Envoy::Http::RequestHeade
   extractor_->ClearResult();
 
   auto cord_message_data_factory = std::make_unique<CreateMessageDataFunc>(
-      []() { return std::make_unique<Protobuf::field_extraction::CordMessageData>(); });
+      []() { return std::make_unique<ProtobufWkt::field_extraction::CordMessageData>(); });
 
   request_msg_converter_ = std::make_unique<MessageConverter>(
       std::move(cord_message_data_factory), decoder_callbacks_->decoderBufferLimit());
@@ -269,7 +269,7 @@ Envoy::Http::FilterHeadersStatus Filter::encodeHeaders(Envoy::Http::ResponseHead
 
   // Create response_msg_converter to convert response body.
   auto cord_message_data_factory = std::make_unique<CreateMessageDataFunc>(
-      []() { return std::make_unique<Protobuf::field_extraction::CordMessageData>(); });
+      []() { return std::make_unique<ProtobufWkt::field_extraction::CordMessageData>(); });
 
   response_msg_converter_ = std::make_unique<MessageConverter>(
       std::move(cord_message_data_factory), encoder_callbacks_->encoderBufferLimit());

--- a/source/extensions/load_balancing_policies/subset/subset_lb.h
+++ b/source/extensions/load_balancing_policies/subset/subset_lb.h
@@ -149,7 +149,7 @@ private:
   using ValueSubsetMap = absl::node_hash_map<HashedValue, LbSubsetEntryPtr>;
   using LbSubsetMap = absl::node_hash_map<std::string, ValueSubsetMap>;
   using SubsetSelectorFallbackParamsRef = std::reference_wrapper<SubsetSelectorFallbackParams>;
-  using MetadataFallbacks = ProtobufWkt::RepeatedPtrField<ProtobufWkt::Value>;
+  using MetadataFallbacks = Protobuf::RepeatedPtrField<ProtobufWkt::Value>;
 
 public:
   class LoadBalancerContextWrapper : public LoadBalancerContext {

--- a/source/extensions/rate_limit_descriptors/expr/config.cc
+++ b/source/extensions/rate_limit_descriptors/expr/config.cc
@@ -35,7 +35,7 @@ public:
   bool populateDescriptor(RateLimit::DescriptorEntry& descriptor_entry, const std::string&,
                           const Http::RequestHeaderMap& headers,
                           const StreamInfo::StreamInfo& info) const override {
-    ProtobufWkt::Arena arena;
+    Protobuf::Arena arena;
     const auto result = Filters::Common::Expr::evaluate(*compiled_expr_.get(), arena, nullptr, info,
                                                         &headers, nullptr, nullptr);
     if (!result.has_value() || result.value().IsError()) {

--- a/test/extensions/filters/common/expr/context_test.cc
+++ b/test/extensions/filters/common/expr/context_test.cc
@@ -841,7 +841,7 @@ TEST(Context, ConnectionAttributes) {
 
 TEST(Context, FilterStateAttributes) {
   StreamInfo::FilterStateImpl filter_state(StreamInfo::FilterState::LifeSpan::FilterChain);
-  ProtobufWkt::Arena arena;
+  Protobuf::Arena arena;
   FilterStateWrapper wrapper(arena, filter_state);
   auto status_or = wrapper.ListKeys(&arena);
   EXPECT_EQ(status_or.status().message(), "ListKeys() is not implemented");

--- a/test/extensions/filters/common/expr/evaluator_test.cc
+++ b/test/extensions/filters/common/expr/evaluator_test.cc
@@ -27,7 +27,7 @@ TEST(Evaluator, Print) {
   EXPECT_EQ(print(CelValue::CreateString(&test)), "test");
   EXPECT_EQ(print(CelValue::CreateBytes(&test)), "test");
 
-  ProtobufWkt::Arena arena;
+  Protobuf::Arena arena;
   envoy::config::core::v3::Node node;
   std::string node_yaml = "id: test";
   TestUtility::loadFromYaml(node_yaml, node);
@@ -48,7 +48,7 @@ TEST(Evaluator, Activation) {
   auto filter_state =
       std::make_shared<StreamInfo::FilterStateImpl>(StreamInfo::FilterState::LifeSpan::FilterChain);
   info.upstreamInfo()->setUpstreamFilterState(filter_state);
-  ProtobufWkt::Arena arena;
+  Protobuf::Arena arena;
   const auto activation = createActivation(nullptr, info, nullptr, nullptr, nullptr);
   EXPECT_TRUE(activation->FindValue("filter_state", &arena).has_value());
   EXPECT_TRUE(activation->FindValue("upstream_filter_state", &arena).has_value());

--- a/test/extensions/filters/http/grpc_field_extraction/message_converter/message_converter_test.cc
+++ b/test/extensions/filters/http/grpc_field_extraction/message_converter/message_converter_test.cc
@@ -248,7 +248,7 @@ void batchMutateStreamMessages(const std::vector<StreamMessagePtr>& message_data
 
 std::unique_ptr<CreateMessageDataFunc> factory() {
   return std::make_unique<CreateMessageDataFunc>(
-      []() { return std::make_unique<Protobuf::field_extraction::CordMessageData>(); });
+      []() { return std::make_unique<ProtobufWkt::field_extraction::CordMessageData>(); });
 }
 
 // Base class that all tests in this file inherit from.

--- a/test/extensions/filters/http/grpc_field_extraction/message_converter/message_converter_test_lib.h
+++ b/test/extensions/filters/http/grpc_field_extraction/message_converter/message_converter_test_lib.h
@@ -39,7 +39,7 @@ void checkSerializedData(Envoy::Buffer::Instance& data,
 
 apikeys::CreateApiKeyRequest parseFromStreamMessage(StreamMessage& msg) {
   apikeys::CreateApiKeyRequest parsed_request;
-  auto* c = dynamic_cast<Protobuf::field_extraction::CordMessageData*>(msg.message());
+  auto* c = dynamic_cast<ProtobufWkt::field_extraction::CordMessageData*>(msg.message());
   parsed_request.ParseFromCord(c->Cord());
   return parsed_request;
 }
@@ -48,7 +48,7 @@ apikeys::CreateApiKeyRequest parseFromStreamMessage(StreamMessage& msg) {
 // Serialization overwrites pre-existing date in the buffer.
 void serializeToStreamMessage(StreamMessage& msg, apikeys::CreateApiKeyRequest& request) {
   apikeys::CreateApiKeyRequest parsed_request;
-  auto* c = dynamic_cast<Protobuf::field_extraction::CordMessageData*>(msg.message());
+  auto* c = dynamic_cast<ProtobufWkt::field_extraction::CordMessageData*>(msg.message());
   request.SerializeToCord(&(c->Cord()));
 }
 } // namespace GrpcFieldExtraction

--- a/test/extensions/filters/http/grpc_field_extraction/message_converter/message_converter_utility_test.cc
+++ b/test/extensions/filters/http/grpc_field_extraction/message_converter/message_converter_utility_test.cc
@@ -36,7 +36,7 @@ TEST(ParseGrpcMessage, ParseSingleMessageSingleFrame) {
   // Setup request data.
   CreateApiKeyRequest request = getCreateApiKeyRequest();
   CreateMessageDataFunc factory = []() {
-    return std::make_unique<Protobuf::field_extraction::CordMessageData>();
+    return std::make_unique<ProtobufWkt::field_extraction::CordMessageData>();
   };
   Buffer::InstancePtr request_data = Grpc::Common::serializeToGrpcFrame(request);
 
@@ -63,7 +63,7 @@ TEST(ParseGrpcMessage, ParseSingleMessageSplitFrames) {
   CreateApiKeyRequest request = getCreateApiKeyRequest();
   Buffer::InstancePtr request_data = Grpc::Common::serializeToGrpcFrame(request);
   CreateMessageDataFunc factory = []() {
-    return std::make_unique<Protobuf::field_extraction::CordMessageData>();
+    return std::make_unique<ProtobufWkt::field_extraction::CordMessageData>();
   };
 
   // Split into multiple buffers.
@@ -105,7 +105,7 @@ TEST(ParseGrpcMessage, ParseMultipleMessagesSplitFrames) {
   // Setup request data.
   CreateApiKeyRequest request = getCreateApiKeyRequest();
   CreateMessageDataFunc factory = []() {
-    return std::make_unique<Protobuf::field_extraction::CordMessageData>();
+    return std::make_unique<ProtobufWkt::field_extraction::CordMessageData>();
   };
   Buffer::InstancePtr request_data1 = Grpc::Common::serializeToGrpcFrame(request);
   Buffer::InstancePtr request_data2 = Grpc::Common::serializeToGrpcFrame(request);
@@ -140,7 +140,7 @@ TEST(ParseGrpcMessage, ParseNeedsMoreData) {
 
   // No data to parse.
   CreateMessageDataFunc factory = []() {
-    return std::make_unique<Protobuf::field_extraction::CordMessageData>();
+    return std::make_unique<ProtobufWkt::field_extraction::CordMessageData>();
   };
   ASSERT_OK_AND_ASSIGN(auto parsed_output, parseGrpcMessage(factory, request_in));
   EXPECT_TRUE(parsed_output.needs_more_data);
@@ -153,7 +153,7 @@ TEST(SizeToDelimiter, VerifyDelimiterIsPreserved) {
   CreateApiKeyRequest request = getCreateApiKeyRequest();
   Buffer::InstancePtr request_data = Grpc::Common::serializeToGrpcFrame(request);
   CreateMessageDataFunc factory = []() {
-    return std::make_unique<Protobuf::field_extraction::CordMessageData>();
+    return std::make_unique<ProtobufWkt::field_extraction::CordMessageData>();
   };
 
   // Single message is parsed, but `request_out` not provided.
@@ -181,7 +181,7 @@ TEST(ParseGrpcMessage, ParseZeroLengthMessage) {
   EXPECT_EQ(delimiter->length(), kGrpcDelimiterByteSize);
   request_in.add(*delimiter);
   CreateMessageDataFunc factory = []() {
-    return std::make_unique<Protobuf::field_extraction::CordMessageData>();
+    return std::make_unique<ProtobufWkt::field_extraction::CordMessageData>();
   };
 
   // Single message (of length 0) to be parsed.

--- a/test/extensions/filters/http/grpc_field_extraction/message_converter/stream_message_test.cc
+++ b/test/extensions/filters/http/grpc_field_extraction/message_converter/stream_message_test.cc
@@ -12,7 +12,7 @@ namespace GrpcFieldExtraction {
 namespace {
 
 TEST(StreamMessage, SetterGetter) {
-  auto msg = std::make_unique<Protobuf::field_extraction::CordMessageData>(absl::Cord("aa"));
+  auto msg = std::make_unique<ProtobufWkt::field_extraction::CordMessageData>(absl::Cord("aa"));
   auto* msg_addr = msg.get();
   StreamMessage stream_message(nullptr, nullptr, nullptr);
 

--- a/test/extensions/filters/http/proto_message_extraction/extraction_util/extraction_util_test.cc
+++ b/test/extensions/filters/http/proto_message_extraction/extraction_util/extraction_util_test.cc
@@ -35,12 +35,12 @@ namespace HttpFilters {
 namespace ProtoMessageExtraction {
 namespace {
 
-using ::Envoy::Protobuf::Field;
-using ::Envoy::Protobuf::FieldMask;
 using Envoy::Protobuf::FileDescriptorSet;
-using ::Envoy::Protobuf::Type;
-using ::Envoy::Protobuf::field_extraction::CordMessageData;
+using ::Envoy::ProtobufWkt::Field;
+using ::Envoy::ProtobufWkt::FieldMask;
 using ::Envoy::ProtobufWkt::Struct;
+using ::Envoy::ProtobufWkt::Type;
+using ::Envoy::ProtobufWkt::field_extraction::CordMessageData;
 using ::Envoy::StatusHelpers::IsOkAndHolds;
 using ::Envoy::StatusHelpers::StatusIs;
 using ::extraction::TestRequest;
@@ -127,8 +127,9 @@ const char kTestResponse[] = R"pb(
 class ExtractionUtilTest : public ::testing::Test {
 protected:
   ExtractionUtilTest() = default;
-  const Protobuf::Type* findType(const std::string& type_url) {
-    absl::StatusOr<const Protobuf::Type*> result = type_helper_->Info()->ResolveTypeUrl(type_url);
+  const ProtobufWkt::Type* findType(const std::string& type_url) {
+    absl::StatusOr<const ProtobufWkt::Type*> result =
+        type_helper_->Info()->ResolveTypeUrl(type_url);
     if (!result.ok()) {
       return nullptr;
     }
@@ -211,11 +212,11 @@ protected:
   std::function<const Type*(const std::string&)> type_finder_;
 
   TestRequest test_request_proto_;
-  Protobuf::field_extraction::CordMessageData test_request_raw_proto_;
+  ProtobufWkt::field_extraction::CordMessageData test_request_raw_proto_;
   const Type* request_type_;
 
   TestResponse test_response_proto_;
-  Protobuf::field_extraction::CordMessageData test_response_raw_proto_;
+  ProtobufWkt::field_extraction::CordMessageData test_response_raw_proto_;
   const Type* response_type_;
 
   FieldMask field_mask_;

--- a/test/extensions/filters/http/rate_limit_quota/integration_test.cc
+++ b/test/extensions/filters/http/rate_limit_quota/integration_test.cc
@@ -565,7 +565,7 @@ TEST_P(RateLimitQuotaIntegrationTest, BasicFlowMultiDifferentRequest) {
   RateLimitQuotaUsageReports reports;
   ASSERT_TRUE(rlqs_stream_->waitForGrpcMessage(*dispatcher_, reports));
 
-  const Protobuf::FieldDescriptor* time_elapsed_desc =
+  const ProtobufWkt::FieldDescriptor* time_elapsed_desc =
       RateLimitQuotaUsageReports::BucketQuotaUsage::GetDescriptor()->FindFieldByName(
           "time_elapsed");
   ASSERT_THAT(reports, ProtoEqIgnoringFieldAndOrdering(expected_reports, time_elapsed_desc));
@@ -791,7 +791,7 @@ TEST_P(RateLimitQuotaIntegrationTest, MultiDifferentRequestNoAssignementAllowAll
   RateLimitQuotaUsageReports reports;
   ASSERT_TRUE(rlqs_stream_->waitForGrpcMessage(*dispatcher_, reports));
 
-  const Protobuf::FieldDescriptor* time_elapsed_desc =
+  const ProtobufWkt::FieldDescriptor* time_elapsed_desc =
       RateLimitQuotaUsageReports::BucketQuotaUsage::GetDescriptor()->FindFieldByName(
           "time_elapsed");
   ASSERT_THAT(reports, ProtoEqIgnoringFieldAndOrdering(expected_reports, time_elapsed_desc));
@@ -858,7 +858,7 @@ TEST_P(RateLimitQuotaIntegrationTest, MultiDifferentRequestNoAssignementDenyAll)
   RateLimitQuotaUsageReports reports;
   ASSERT_TRUE(rlqs_stream_->waitForGrpcMessage(*dispatcher_, reports));
 
-  const Protobuf::FieldDescriptor* time_elapsed_desc =
+  const ProtobufWkt::FieldDescriptor* time_elapsed_desc =
       RateLimitQuotaUsageReports::BucketQuotaUsage::GetDescriptor()->FindFieldByName(
           "time_elapsed");
   ASSERT_THAT(reports, ProtoEqIgnoringFieldAndOrdering(expected_reports, time_elapsed_desc));

--- a/test/fuzz/mutable_visitor.cc
+++ b/test/fuzz/mutable_visitor.cc
@@ -56,11 +56,11 @@ void traverseMessageWorkerExt(ProtoVisitor& visitor, Protobuf::Message& message,
   const Protobuf::Descriptor* descriptor = message.GetDescriptor();
   const Protobuf::Reflection* reflection = message.GetReflection();
   for (int i = 0; i < descriptor->field_count(); ++i) {
-    const Protobuf::FieldDescriptor* field = descriptor->field(i);
+    const ProtobufWkt::FieldDescriptor* field = descriptor->field(i);
     visitor.onField(message, *field, parents);
 
     // If this is a message, recurse in to the sub-message.
-    if (field->cpp_type() == Protobuf::FieldDescriptor::CPPTYPE_MESSAGE) {
+    if (field->cpp_type() == ProtobufWkt::FieldDescriptor::CPPTYPE_MESSAGE) {
       Helper::ScopedMessageParents scoped_parents(parents, message);
 
       if (field->is_repeated()) {

--- a/test/fuzz/mutable_visitor.h
+++ b/test/fuzz/mutable_visitor.h
@@ -14,7 +14,7 @@ public:
   virtual ~ProtoVisitor() = default;
 
   // Invoked when a field is visited, with the message, and field descriptor.
-  virtual void onField(Protobuf::Message&, const Protobuf::FieldDescriptor&,
+  virtual void onField(Protobuf::Message&, const ProtobufWkt::FieldDescriptor&,
                        const absl::Span<const Protobuf::Message* const>) PURE;
 
   // Invoked when a message is visited, with the message and visited parents.

--- a/test/fuzz/validated_input_generator.cc
+++ b/test/fuzz/validated_input_generator.cc
@@ -204,7 +204,7 @@ void ValidatedInputGenerator::handleAnyRules(
 }
 
 void ValidatedInputGenerator::handleMessageTypedField(
-    Protobuf::Message& msg, const Protobuf::FieldDescriptor& field,
+    Protobuf::Message& msg, const ProtobufWkt::FieldDescriptor& field,
     const Protobuf::Reflection* reflection, const validate::FieldRules& rules,
     const absl::Span<const Protobuf::Message* const>& parents, bool force_create, bool cut_off) {
 
@@ -264,7 +264,7 @@ void ValidatedInputGenerator::handleMessageTypedField(
 template <typename T, auto FIELDGETTER, auto FIELDSETTER, auto REPGETTER, auto REPSETTER,
           auto FIELDADDER, auto RULEGETTER, auto TYPEHANDLER>
 void ValidatedInputGenerator::handleIntrinsicTypedField(Protobuf::Message& msg,
-                                                        const Protobuf::FieldDescriptor& field,
+                                                        const ProtobufWkt::FieldDescriptor& field,
                                                         const Protobuf::Reflection* reflection,
                                                         const validate::FieldRules& rules,
                                                         bool force) {
@@ -315,13 +315,13 @@ void ValidatedInputGenerator::handleIntrinsicTypedField(Protobuf::Message& msg,
 }
 
 void ValidatedInputGenerator::onField(Protobuf::Message& msg,
-                                      const Protobuf::FieldDescriptor& field,
+                                      const ProtobufWkt::FieldDescriptor& field,
                                       const absl::Span<const Protobuf::Message* const> parents) {
   onField(msg, field, parents, false, false);
 }
 
 void ValidatedInputGenerator::onField(Protobuf::Message& msg,
-                                      const Protobuf::FieldDescriptor& field,
+                                      const ProtobufWkt::FieldDescriptor& field,
                                       const absl::Span<const Protobuf::Message* const> parents,
                                       bool force_create, bool cut_off) {
   const Protobuf::Reflection* reflection = msg.GetReflection();
@@ -335,7 +335,7 @@ void ValidatedInputGenerator::onField(Protobuf::Message& msg,
   }
 
   switch (field.cpp_type()) {
-  case Protobuf::FieldDescriptor::CPPTYPE_INT32: {
+  case ProtobufWkt::FieldDescriptor::CPPTYPE_INT32: {
     handleIntrinsicTypedField<
         std::int32_t, &Protobuf::Reflection::GetInt32, &Protobuf::Reflection::SetInt32,
         &Protobuf::Reflection::GetRepeatedInt32, &Protobuf::Reflection::SetRepeatedInt32,
@@ -343,7 +343,7 @@ void ValidatedInputGenerator::onField(Protobuf::Message& msg,
                                                                        rules, force_create);
     break;
   }
-  case Protobuf::FieldDescriptor::CPPTYPE_INT64: {
+  case ProtobufWkt::FieldDescriptor::CPPTYPE_INT64: {
     handleIntrinsicTypedField<
         std::int64_t, &Protobuf::Reflection::GetInt64, &Protobuf::Reflection::SetInt64,
         &Protobuf::Reflection::GetRepeatedInt64, &Protobuf::Reflection::SetRepeatedInt64,
@@ -351,7 +351,7 @@ void ValidatedInputGenerator::onField(Protobuf::Message& msg,
                                                                        rules, force_create);
     break;
   }
-  case Protobuf::FieldDescriptor::CPPTYPE_UINT32: {
+  case ProtobufWkt::FieldDescriptor::CPPTYPE_UINT32: {
     handleIntrinsicTypedField<
         std::uint32_t, &Protobuf::Reflection::GetUInt32, &Protobuf::Reflection::SetUInt32,
         &Protobuf::Reflection::GetRepeatedUInt32, &Protobuf::Reflection::SetRepeatedUInt32,
@@ -359,7 +359,7 @@ void ValidatedInputGenerator::onField(Protobuf::Message& msg,
                                                                          rules, force_create);
     break;
   }
-  case Protobuf::FieldDescriptor::CPPTYPE_UINT64: {
+  case ProtobufWkt::FieldDescriptor::CPPTYPE_UINT64: {
     handleIntrinsicTypedField<
         std::uint64_t, &Protobuf::Reflection::GetUInt64, &Protobuf::Reflection::SetUInt64,
         &Protobuf::Reflection::GetRepeatedUInt64, &Protobuf::Reflection::SetRepeatedUInt64,
@@ -367,7 +367,7 @@ void ValidatedInputGenerator::onField(Protobuf::Message& msg,
                                                                          rules, force_create);
     break;
   }
-  case Protobuf::FieldDescriptor::CPPTYPE_DOUBLE: {
+  case ProtobufWkt::FieldDescriptor::CPPTYPE_DOUBLE: {
     handleIntrinsicTypedField<
         double, &Protobuf::Reflection::GetDouble, &Protobuf::Reflection::SetDouble,
         &Protobuf::Reflection::GetRepeatedDouble, &Protobuf::Reflection::SetRepeatedDouble,
@@ -375,7 +375,7 @@ void ValidatedInputGenerator::onField(Protobuf::Message& msg,
                                                                           rules, force_create);
     break;
   }
-  case Protobuf::FieldDescriptor::CPPTYPE_FLOAT: {
+  case ProtobufWkt::FieldDescriptor::CPPTYPE_FLOAT: {
     handleIntrinsicTypedField<
         float, &Protobuf::Reflection::GetFloat, &Protobuf::Reflection::SetFloat,
         &Protobuf::Reflection::GetRepeatedFloat, &Protobuf::Reflection::SetRepeatedFloat,
@@ -383,22 +383,22 @@ void ValidatedInputGenerator::onField(Protobuf::Message& msg,
                                                                         rules, force_create);
     break;
   }
-  case Protobuf::FieldDescriptor::CPPTYPE_BOOL:
+  case ProtobufWkt::FieldDescriptor::CPPTYPE_BOOL:
     break;
-  case Protobuf::FieldDescriptor::CPPTYPE_ENUM:
+  case ProtobufWkt::FieldDescriptor::CPPTYPE_ENUM:
     break;
-  case Protobuf::FieldDescriptor::CPPTYPE_STRING: {
+  case ProtobufWkt::FieldDescriptor::CPPTYPE_STRING: {
     handleIntrinsicTypedField<
         std::string, &Protobuf::Reflection::GetString,
         static_cast<void (Protobuf::Reflection::*)(
-            Protobuf::Message*, const Protobuf::FieldDescriptor*, std::string) const>(
+            Protobuf::Message*, const ProtobufWkt::FieldDescriptor*, std::string) const>(
             &Protobuf::Reflection::SetString),
         &Protobuf::Reflection::GetRepeatedString, &Protobuf::Reflection::SetRepeatedString,
         &Protobuf::Reflection::AddString, &validate::FieldRules::string, &handleStringRules>(
         msg, field, reflection, rules, force_create);
     break;
   }
-  case Protobuf::FieldDescriptor::CPPTYPE_MESSAGE: {
+  case ProtobufWkt::FieldDescriptor::CPPTYPE_MESSAGE: {
     handleMessageTypedField(msg, field, reflection, rules, parents, force_create, cut_off);
     break;
   }

--- a/test/fuzz/validated_input_generator.h
+++ b/test/fuzz/validated_input_generator.h
@@ -38,7 +38,7 @@ public:
   void handleAnyRules(Protobuf::Message* msg, const validate::AnyRules& any_rules,
                       const absl::Span<const Protobuf::Message* const>& parents);
 
-  void handleMessageTypedField(Protobuf::Message& msg, const Protobuf::FieldDescriptor& field,
+  void handleMessageTypedField(Protobuf::Message& msg, const ProtobufWkt::FieldDescriptor& field,
                                const Protobuf::Reflection* reflection,
                                const validate::FieldRules& rules,
                                const absl::Span<const Protobuf::Message* const>& parents,
@@ -50,14 +50,14 @@ public:
             auto FIELDADDER, auto RULEGETTER,
             auto TYPEHANDLER = &handleNumericRules<
                 T, typename std::invoke_result<decltype(RULEGETTER), validate::FieldRules>::type>>
-  void handleIntrinsicTypedField(Protobuf::Message& msg, const Protobuf::FieldDescriptor& field,
+  void handleIntrinsicTypedField(Protobuf::Message& msg, const ProtobufWkt::FieldDescriptor& field,
                                  const Protobuf::Reflection* reflection,
                                  const validate::FieldRules& rules, bool force);
 
-  void onField(Protobuf::Message& msg, const Protobuf::FieldDescriptor& field,
+  void onField(Protobuf::Message& msg, const ProtobufWkt::FieldDescriptor& field,
                const absl::Span<const Protobuf::Message* const> parents) override;
 
-  void onField(Protobuf::Message& msg, const Protobuf::FieldDescriptor& field,
+  void onField(Protobuf::Message& msg, const ProtobufWkt::FieldDescriptor& field,
                const absl::Span<const Protobuf::Message* const> parents, bool force_create,
                bool cut_off);
 

--- a/test/server/admin/config_dump_handler_test.cc
+++ b/test/server/admin/config_dump_handler_test.cc
@@ -763,7 +763,7 @@ TEST_P(AdminInstanceTest, InvalidFieldMaskWithResourceDoesNotCrash) {
                 "/config_dump?resource=static_clusters&mask=cluster.transport_socket_matches.name",
                 header_map, response));
   std::string expected_mask_text = R"pb(paths: "cluster.transport_socket_matches.name")pb";
-  Protobuf::FieldMask expected_mask_proto;
+  ProtobufWkt::FieldMask expected_mask_proto;
   Protobuf::TextFormat::ParseFromString(expected_mask_text, &expected_mask_proto);
   EXPECT_EQ(fmt::format("FieldMask {} could not be successfully used.",
                         expected_mask_proto.DebugString()),

--- a/test/test_common/utility.h
+++ b/test/test_common/utility.h
@@ -413,7 +413,7 @@ public:
   static bool protoEqualIgnoringField(const Protobuf::Message& lhs, const Protobuf::Message& rhs,
                                       const std::string& field_to_ignore) {
     Protobuf::util::MessageDifferencer differencer;
-    const Protobuf::FieldDescriptor* ignored_field =
+    const ProtobufWkt::FieldDescriptor* ignored_field =
         lhs.GetDescriptor()->FindFieldByName(field_to_ignore);
     ASSERT(ignored_field != nullptr, "Field name to ignore not found.");
     differencer.IgnoreField(ignored_field);


### PR DESCRIPTION
Commit Message:
Large but trivial PR.
Fix namespaces for various protobuf types. Protobuf and ProtobufWkt are the same alias however they have different purposes. ProtobufWkt was intended to just reference the "well known" protobuf types https://protobuf.dev/reference/protobuf/google.protobuf/ and the Protobuf namespace reference everything else from the google:protobuf namespace.

Also instead of aliasing the Protobuf and ProtobufWkt to google::protobuf just pull in the names that are going to be used through these namespaces. This will prevent future misuse of these two namespaces.

Noop with the open source version of protobuf, bu saves me a lot of effort when compiling this internally.


Risk Level: none
Testing: unit tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
