### PR TITLE
rbac: guard LC-Trie matcher against non-IP addresses

### DIFF
--- a/source/extensions/filters/common/rbac/matchers.cc
+++ b/source/extensions/filters/common/rbac/matchers.cc
@@ -267,7 +267,15 @@ bool IPMatcher::matches(const Network::Connection& connection, const Envoy::Http
                         const StreamInfo::StreamInfo& info) const {
   // Extract IP address using reference to avoid shared_ptr copies.
   const auto& address = extractIpAddress(connection, info);
-  return address && !trie_->getData(address).empty();
+  // Guard against non-IP addresses (e.g., pipe) or missing address.
+  if (!address) {
+    return false;
+  }
+  const auto* ip = address->ip();
+  if (ip == nullptr) {
+    return false;
+  }
+  return !trie_->getData(address).empty();
 }
 
 bool PortMatcher::matches(const Network::Connection&, const Envoy::Http::RequestHeaderMap&,


### PR DESCRIPTION
## Description

This PR has a small fix to guard the RBAC LC-Trie based matcher against the non-IP addresses to avoid any crashes. 

---

**Commit Message:** rbac: guard LC-Trie matcher against non-IP addresses
**Additional Description:** A small fix to guard the RBAC LC-Trie based matcher against the non-IP addresses to avoid any crashes.
**Risk Level:** Low
**Testing:** Added Unit Tests
**Docs Changes:** N/A
**Release Notes:** N/A