### PR TITLE
[bp/1.34] build(deps): bump distroless/base-nossl-debian12 from `fa7b50f` to `9…

### DIFF
--- a/distribution/docker/Dockerfile-envoy
+++ b/distribution/docker/Dockerfile-envoy
@@ -59,7 +59,7 @@ COPY --chown=0:0 --chmod=755 \
 
 
 # STAGE: envoy-distroless
-FROM gcr.io/distroless/base-nossl-debian12:nonroot@sha256:fa7b50f111719aaf5f7435383b6d05f12277f3ce9514bc0a62759374a04d6bae AS envoy-distroless
+FROM gcr.io/distroless/base-nossl-debian12:nonroot@sha256:9a1c8b2ff7412ea80ca8c531eb7542e0e7766c8cf79489a8f0f31f0aa341c0fe AS envoy-distroless
 EXPOSE 10000
 ENTRYPOINT ["/usr/local/bin/envoy"]
 CMD ["-c", "/etc/envoy/envoy.yaml"]


### PR DESCRIPTION
…a1c8b2` in /distribution/docker (#40587)

