### PR TITLE
test: cleanup of unused var in stream_info/utility_test

### DIFF
--- a/test/common/stream_info/BUILD
+++ b/test/common/stream_info/BUILD
@@ -69,7 +69,6 @@ envoy_cc_test(
     deps = [
         "//source/common/stream_info:utility_lib",
         "//test/mocks/stream_info:stream_info_mocks",
-        "//test/test_common:test_runtime_lib",
         "@envoy_api//envoy/extensions/filters/network/http_connection_manager/v3:pkg_cc_proto",
     ],
 )

--- a/test/common/stream_info/utility_test.cc
+++ b/test/common/stream_info/utility_test.cc
@@ -4,7 +4,6 @@
 #include "source/common/stream_info/utility.h"
 
 #include "test/mocks/stream_info/mocks.h"
-#include "test/test_common/test_runtime.h"
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -365,7 +364,6 @@ TEST(ProxyStatusErrorToString, TestAll) {
 }
 
 TEST(ProxyStatusFromStreamInfo, TestAllWithExpandedResponseFlags) {
-  TestScopedRuntime scoped_runtime;
   for (const auto& [response_flag, proxy_status_error] :
        std::vector<std::pair<ResponseFlag, ProxyStatusError>>{
            {CoreResponseFlag::FailedLocalHealthCheck, ProxyStatusError::DestinationUnavailable},


### PR DESCRIPTION
Commit Message: test: cleanup of unused var in stream_info/utility_test
Additional Description:
minor cleanup - removing unused variable in a test.

Risk Level: low - tests only
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
