### PR TITLE
Fixes reviewers.yaml for mathetake

### DIFF
--- a/reviewers.yaml
+++ b/reviewers.yaml
@@ -46,7 +46,7 @@ mattklein123:
   slack: U5CALEVSL
 mathetake:
   maintainer: true
-  opsgenie: Mathetake
+  opsgenie: mathetake
   slack: UG9TD2FSB
 nezdolik:
   maintainer: true


### PR DESCRIPTION
This applies the same fix as in #40470.