### PR TITLE
udp_proxy: Fix crash during ENVOY_SIGTERM

### DIFF
--- a/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.h
+++ b/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.h
@@ -293,7 +293,7 @@ public:
   void onDownstreamEvent(Network::ConnectionEvent event) override {
     if (event == Network::ConnectionEvent::LocalClose ||
         event == Network::ConnectionEvent::RemoteClose) {
-      resetEncoder(event, /*by_downstream=*/true);
+      resetEncoder(event, /*by_local_close=*/true);
     }
   };
 
@@ -360,7 +360,7 @@ private:
   };
 
   const std::string resolveTargetTunnelPath();
-  void resetEncoder(Network::ConnectionEvent event, bool by_downstream = false);
+  void resetEncoder(Network::ConnectionEvent event, bool by_local_close = false);
 
   ResponseDecoder response_decoder_;
   Http::RequestEncoder* request_encoder_{};

--- a/test/extensions/filters/udp/udp_proxy/udp_proxy_filter_test.cc
+++ b/test/extensions/filters/udp/udp_proxy/udp_proxy_filter_test.cc
@@ -1851,7 +1851,7 @@ tunneling_config:
 
   auto session = filter_->createTunnelingSession();
   EXPECT_NO_THROW(session->onAboveWriteBufferHighWatermark());
-  session->onSessionComplete();
+  filter_.reset();
 }
 
 TEST_F(UdpProxyFilterTest, TunnelingSessionUpstreamClosedDuringFlush) {


### PR DESCRIPTION
Commit Message: Fix crash in UDP proxy during ENVOY_SIGTERM with active tunneling sessions
Additional Description:
The UDP proxy crashes during ENVOY_SIGTERM if there are active tunneling sessions. This issue arises during the destruction of `UdpProxyFilter`, which attempts to clean up all active sessions. When a `TunnelingActionSession` is removed, it triggers `resetEncoder` in the `HttpUpstreamImpl` destructor. This, in turn, calls `upstream_callbacks_.onUpstreamEvent(event);`, which tries to remove the session again—leading to a double removal and ultimately a crash.

<img width="1533" height="777" alt="image" src="https://github.com/user-attachments/assets/74333e9c-3510-4c97-bd6f-2424c02b26eb" />

Risk Level: low
Testing: integration test
Docs Changes: N/A
Release Notes:
Platform Specific Features: N/A
