### PR TITLE
docs: removes 'experimental' from dynamic_modules.rst

### DIFF
--- a/docs/root/intro/arch_overview/advanced/dynamic_modules.rst
+++ b/docs/root/intro/arch_overview/advanced/dynamic_modules.rst
@@ -5,8 +5,7 @@ Dynamic modules
 
 .. attention::
 
-   The dynamic modules feature is experimental and is currently under active development.
-
+   The dynamic modules feature is currently under active development.
    Capabilities will be expanded over time and it still lacks some features that are available in other extension mechanisms.
    We are looking for feedback from the community to improve the feature.
 


### PR DESCRIPTION
Commit Message: docs: removes 'experimental' from dynamic_modules.rst
Additional Description:

The dynamic_modules feature is no longer "experimental" after two Envoy stable releases. It has started being used in production as well, so the word "experimental" is not appropriate. Otherwise, people might think that there might be a breaking change in API, etc as opposed to the fact that it won't happen.

Risk Level: n/a
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a