### PR TITLE
Replace @krajshiva with @tgschwen on security team

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -87,7 +87,7 @@ without further review.
 * Boteng Yao ([botengyao](https://github.com/botengyao)) (boteng@google.com)
 * Kevin Baichoo ([KBaichoo](https://github.com/KBaichoo)) (envoy@kevinbaichoo.com)
 * Tianyu Xia ([tyxia](https://github.com/tyxia)) (tyxia@google.com)
-* Kirtimaan Rajshiva ([krajshiva](https://github.com/krajshiva))
+* Thomas Gschwendtner ([tgschwen](https://github.com/tgschwen)) (tgschwen@google.com)
 * Yanjun Xiang ([yanjunxiang-google](https://github.com/yanjunxiang-google)) (yanjunxiang@google.com)
 * Raven Black ([ravenblackx](https://github.com/ravenblackx)) (ravenblack@dropbox.com)
 


### PR DESCRIPTION
Additional Description:
Due to Google internal team changes, Thomas will be taking over Kirti's duties on the security team.

Risk Level: none
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
