### PR TITLE
mobile/ci: Temporarily disable running the iOS simulator

### DIFF
--- a/.github/workflows/mobile-ios_build.yml
+++ b/.github/workflows/mobile-ios_build.yml
@@ -73,51 +73,51 @@ jobs:
           target: ios
           timeout-minutes: 120
 
-  hello-world:
-    permissions:
-      contents: read
-      packages: read
-    uses: ./.github/workflows/_run.yml
-    if: ${{ needs.load.outputs.request && fromJSON(needs.load.outputs.request).run.mobile-ios }}
-    needs:
-    - load
-    - build
-    name: ios-hello-world
-    with:
-      args: >-
-        build
-        ${{ matrix.args || '--config=mobile-remote-ci-macos-ios' }}
-        ${{ matrix.app }}
-      command: ./bazelw
-      container-command:
-      docker-ipv6: false
-      request: ${{ needs.load.outputs.request }}
-      runs-on: macos-15
-      source: |
-        source ./ci/mac_ci_setup.sh
-        ./bazelw shutdown
-      steps-post: |
-        - uses: envoyproxy/toolshed/gh-actions/envoy/ios/post@actions-v0.3.24
-          with:
-            app: ${{ matrix.app }}
-            args: ${{ matrix.args || '--config=mobile-remote-ci-macos-ios' }}
-            expected: received headers with status ${{ matrix.expected-status }}
-          env:
-            ANDROID_NDK_HOME:
-            ANDROID_HOME:
-      target: ${{ matrix.target }}
-      timeout-minutes: ${{ matrix.timeout-minutes }}
-      trusted: ${{ needs.load.outputs.trusted && fromJSON(needs.load.outputs.trusted) || false }}
-      working-directory: mobile
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-        - name: Build swift hello world
-          app: //examples/swift/hello_world:app
-          expected-status: 200
-          target: swift-hello-world
-          timeout-minutes: 90
+  # hello-world:
+  #   permissions:
+  #     contents: read
+  #     packages: read
+  #   uses: ./.github/workflows/_run.yml
+  #   if: ${{ needs.load.outputs.request && fromJSON(needs.load.outputs.request).run.mobile-ios }}
+  #   needs:
+  #   - load
+  #   - build
+  #   name: ios-hello-world
+  #   with:
+  #     args: >-
+  #       build
+  #       ${{ matrix.args || '--config=mobile-remote-ci-macos-ios' }}
+  #       ${{ matrix.app }}
+  #     command: ./bazelw
+  #     container-command:
+  #     docker-ipv6: false
+  #     request: ${{ needs.load.outputs.request }}
+  #     runs-on: macos-15
+  #     source: |
+  #       source ./ci/mac_ci_setup.sh
+  #       ./bazelw shutdown
+  #     steps-post: |
+  #       - uses: envoyproxy/toolshed/gh-actions/envoy/ios/post@actions-v0.3.24
+  #         with:
+  #           app: ${{ matrix.app }}
+  #           args: ${{ matrix.args || '--config=mobile-remote-ci-macos-ios' }}
+  #           expected: received headers with status ${{ matrix.expected-status }}
+  #         env:
+  #           ANDROID_NDK_HOME:
+  #           ANDROID_HOME:
+  #     target: ${{ matrix.target }}
+  #     timeout-minutes: ${{ matrix.timeout-minutes }}
+  #     trusted: ${{ needs.load.outputs.trusted && fromJSON(needs.load.outputs.trusted) || false }}
+  #     working-directory: mobile
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       include:
+  #       - name: Build swift hello world
+  #         app: //examples/swift/hello_world:app
+  #         expected-status: 200
+  #         target: swift-hello-world
+  #         timeout-minutes: 90
 
   apps:
     permissions:
@@ -186,7 +186,7 @@ jobs:
     needs:
     - load
     - build
-    - hello-world
+    # - hello-world
     - apps
     uses: ./.github/workflows/_finish.yml
     with:

--- a/.github/workflows/mobile-release_validation.yml
+++ b/.github/workflows/mobile-release_validation.yml
@@ -38,47 +38,47 @@ jobs:
     with:
       check-name: mobile-release-validation
 
-  validate-swiftpm-example:
-    permissions:
-      contents: read
-      packages: read
-    if: ${{ needs.load.outputs.request && fromJSON(needs.load.outputs.request).run.mobile-release-validation }}
-    needs: load
-    uses: ./.github/workflows/_run.yml
-    name: Build xframework
-    with:
-      args: >-
-        build
-        --config=mobile-remote-ci-macos-ios
-        //:ios_xcframework
-      command: ./bazelw
-      container-command:
-      docker-ipv6: false
-      request: ${{ needs.load.outputs.request }}
-      # revert this to non-large once updated
-      runs-on: macos-15
-      source: |
-        source ./ci/mac_ci_setup.sh
-      # Ignore errors: Bad CRC when unzipping large files: https://bbs.archlinux.org/viewtopic.php?id=153011
-      steps-post: |
-        - run: |
-            unzip mobile/bazel-bin/library/swift/Envoy.xcframework.zip \
-                  -d mobile/examples/swift/swiftpm/Packages \
-                || :
-          shell: bash
-          name: Unzip xcframework
-        - run: |
-            xcodebuild -project mobile/examples/swift/swiftpm/EnvoySwiftPMExample.xcodeproj \
-                       -scheme EnvoySwiftPMExample \
-                       -destination platform="iOS Simulator,name=iPhone 16 Pro Max,OS=18.1" \
-                       -allowProvisioningUpdates
-          shell: bash
-          name: Build app
-        # TODO(jpsim): Run app and inspect logs to validate
-      target: validate-swiftpm-example
-      timeout-minutes: 120
-      trusted: ${{ needs.load.outputs.trusted && fromJSON(needs.load.outputs.trusted) || false }}
-      working-directory: mobile
+  # validate-swiftpm-example:
+  #   permissions:
+  #     contents: read
+  #     packages: read
+  #   if: ${{ needs.load.outputs.request && fromJSON(needs.load.outputs.request).run.mobile-release-validation }}
+  #   needs: load
+  #   uses: ./.github/workflows/_run.yml
+  #   name: Build xframework
+  #   with:
+  #     args: >-
+  #       build
+  #       --config=mobile-remote-ci-macos-ios
+  #       //:ios_xcframework
+  #     command: ./bazelw
+  #     container-command:
+  #     docker-ipv6: false
+  #     request: ${{ needs.load.outputs.request }}
+  #     # revert this to non-large once updated
+  #     runs-on: macos-15
+  #     source: |
+  #       source ./ci/mac_ci_setup.sh
+  #     # Ignore errors: Bad CRC when unzipping large files: https://bbs.archlinux.org/viewtopic.php?id=153011
+  #     steps-post: |
+  #       - run: |
+  #           unzip mobile/bazel-bin/library/swift/Envoy.xcframework.zip \
+  #                 -d mobile/examples/swift/swiftpm/Packages \
+  #               || :
+  #         shell: bash
+  #         name: Unzip xcframework
+  #       - run: |
+  #           xcodebuild -project mobile/examples/swift/swiftpm/EnvoySwiftPMExample.xcodeproj \
+  #                      -scheme EnvoySwiftPMExample \
+  #                      -destination platform="iOS Simulator,name=iPhone 16 Pro Max,OS=18.1" \
+  #                      -allowProvisioningUpdates
+  #         shell: bash
+  #         name: Build app
+  #       # TODO(jpsim): Run app and inspect logs to validate
+  #     target: validate-swiftpm-example
+  #     timeout-minutes: 120
+  #     trusted: ${{ needs.load.outputs.trusted && fromJSON(needs.load.outputs.trusted) || false }}
+  #     working-directory: mobile
 
   request:
     secrets:
@@ -97,7 +97,7 @@ jobs:
       && fromJSON(needs.load.outputs.request).run.mobile-release-validation
     needs:
     - load
-    - validate-swiftpm-example
+    # - validate-swiftpm-example
     uses: ./.github/workflows/_finish.yml
     with:
       needs: ${{ toJSON(needs) }}


### PR DESCRIPTION
CI is currently broken, as the `Mobile/iOS` and `Mobile/Release Validation` jobs are failing while trying to start the iOS Simulator 18.1:
```
INFO: Streaming build results to: https://envoy.cluster.engflow.com/invocation/e45b583d-15a6-431a-83f9-32b8b2e73dbb
2025-08-13 21:16:13.962 INFO Creating simulator, device=iPhone 16 Pro Max, version=18.1
Invalid runtime: com.apple.CoreSimulator.SimRuntime.iOS-18-1
2025-08-13 21:16:21.214 ERROR ['/Applications/Xcode_16.1.app/Contents/Developer/usr/bin/simctl', 'create', 'TestDevice', 'iPhone 16 Pro Max', 'com.apple.CoreSimulator.SimRuntime.iOS-18-1'] exited with error code 145
```

CI is still building the iOS binary so we aren't losing too much build coverage.