### PR TITLE
mobile/ci: Temporarily disable jobs starting the iOS Simulator pt 2

### DIFF
--- a/.github/workflows/mobile-ios_build.yml
+++ b/.github/workflows/mobile-ios_build.yml
@@ -119,54 +119,54 @@ jobs:
   #         target: swift-hello-world
   #         timeout-minutes: 90
 
-  apps:
-    permissions:
-      contents: read
-      packages: read
-    uses: ./.github/workflows/_run.yml
-    if: ${{ needs.load.outputs.request && fromJSON(needs.load.outputs.request).run.mobile-ios-all }}
-    needs:
-    - load
-    - build
-    name: ios-apps
-    with:
-      args: >-
-        build
-        ${{ matrix.args || '--config=mobile-remote-ci-macos-ios' }}
-        ${{ matrix.app }}
-      command: ./bazelw
-      container-command:
-      docker-ipv6: false
-      request: ${{ needs.load.outputs.request }}
-      runs-on: macos-15
-      source: |
-        source ./ci/mac_ci_setup.sh
-      steps-post: |
-        - uses: envoyproxy/toolshed/gh-actions/envoy/ios/post@actions-v0.3.24
-          with:
-            app: ${{ matrix.app }}
-            args: ${{ matrix.args || '--config=mobile-remote-ci-macos-ios' }}
-            expected: >-
-              ${{ matrix.expected
-                  || format('received headers with status {0}', matrix.expected-status) }}
-            timeout: ${{ matrix.timeout || '5m' }}
-          env:
-            ANDROID_NDK_HOME:
-            ANDROID_HOME:
-      target: ${{ matrix.target }}
-      timeout-minutes: 90
-      trusted: ${{ needs.load.outputs.trusted && fromJSON(needs.load.outputs.trusted) || false }}
-      working-directory: mobile
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-        - name: Build swift experimental app
-          args: >-
-            --config=mobile-remote-ci-macos-ios
-          app: //test/swift/apps/experimental:app
-          expected-status: 200
-          target: swift-experimental-app
+  # apps:
+  #   permissions:
+  #     contents: read
+  #     packages: read
+  #   uses: ./.github/workflows/_run.yml
+  #   if: ${{ needs.load.outputs.request && fromJSON(needs.load.outputs.request).run.mobile-ios-all }}
+  #   needs:
+  #   - load
+  #   - build
+  #   name: ios-apps
+  #   with:
+  #     args: >-
+  #       build
+  #       ${{ matrix.args || '--config=mobile-remote-ci-macos-ios' }}
+  #       ${{ matrix.app }}
+  #     command: ./bazelw
+  #     container-command:
+  #     docker-ipv6: false
+  #     request: ${{ needs.load.outputs.request }}
+  #     runs-on: macos-15
+  #     source: |
+  #       source ./ci/mac_ci_setup.sh
+  #     steps-post: |
+  #       - uses: envoyproxy/toolshed/gh-actions/envoy/ios/post@actions-v0.3.24
+  #         with:
+  #           app: ${{ matrix.app }}
+  #           args: ${{ matrix.args || '--config=mobile-remote-ci-macos-ios' }}
+  #           expected: >-
+  #             ${{ matrix.expected
+  #                 || format('received headers with status {0}', matrix.expected-status) }}
+  #           timeout: ${{ matrix.timeout || '5m' }}
+  #         env:
+  #           ANDROID_NDK_HOME:
+  #           ANDROID_HOME:
+  #     target: ${{ matrix.target }}
+  #     timeout-minutes: 90
+  #     trusted: ${{ needs.load.outputs.trusted && fromJSON(needs.load.outputs.trusted) || false }}
+  #     working-directory: mobile
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       include:
+  #       - name: Build swift experimental app
+  #         args: >-
+  #           --config=mobile-remote-ci-macos-ios
+  #         app: //test/swift/apps/experimental:app
+  #         expected-status: 200
+  #         target: swift-experimental-app
 
   request:
     secrets:
@@ -187,7 +187,7 @@ jobs:
     - load
     - build
     # - hello-world
-    - apps
+    # - apps
     uses: ./.github/workflows/_finish.yml
     with:
       needs: ${{ toJSON(needs) }}


### PR DESCRIPTION
This is a follow-up to https://github.com/envoyproxy/envoy/pull/40715