### PR TITLE
[bp/1.34] tls inspector time out fix

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -8,6 +8,12 @@ minor_behavior_changes:
 
 bug_fixes:
 # *Changes expected to improve the state of the world and are unlikely to have negative effects*
+- area: listeners
+  change: |
+    Fixed issue where :ref:`TLS inspector listener filter <config_listener_filters_tls_inspector>` timed out
+    when used with other listener filters. The bug was triggered when a previous listener filter processed more data
+    than the TLS inspector had requested, causing the TLS inspector to incorrectly calculate its buffer growth strategy.
+    The fix ensures that buffer growth is now based on actual bytes available rather than the previously requested amount.
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/source/extensions/filters/listener/tls_inspector/tls_inspector.cc
+++ b/source/extensions/filters/listener/tls_inspector/tls_inspector.cc
@@ -188,15 +188,15 @@ ParseState Filter::parseClientHello(const void* data, size_t len,
   ParseState state = [this, ret]() {
     switch (SSL_get_error(ssl_.get(), ret)) {
     case SSL_ERROR_WANT_READ:
-      if (read_ == maxConfigReadBytes()) {
+      if (read_ >= maxConfigReadBytes()) {
         // We've hit the specified size limit. This is an unreasonably large ClientHello;
         // indicate failure.
         config_->stats().client_hello_too_large_.inc();
         return ParseState::Error;
       }
-      if (read_ == requested_read_bytes_) {
+      if (read_ >= requested_read_bytes_) {
         // Double requested bytes up to the maximum configured.
-        requested_read_bytes_ = std::min<uint32_t>(2 * requested_read_bytes_, maxConfigReadBytes());
+        requested_read_bytes_ = std::min<uint32_t>(2 * read_, maxConfigReadBytes());
       }
       return ParseState::Continue;
     case SSL_ERROR_SSL:

--- a/test/extensions/filters/listener/tls_inspector/tls_inspector_integration_test.cc
+++ b/test/extensions/filters/listener/tls_inspector/tls_inspector_integration_test.cc
@@ -22,6 +22,53 @@
 namespace Envoy {
 namespace {
 
+class LargeBufferListenerFilter : public Network::ListenerFilter {
+public:
+  static constexpr int BUFFER_SIZE = 512;
+  // Network::ListenerFilter
+  Network::FilterStatus onAccept(Network::ListenerFilterCallbacks&) override {
+    ENVOY_LOG_MISC(debug, "LargeBufferListenerFilter::onAccept");
+    return Network::FilterStatus::StopIteration;
+  }
+
+  // this needs to be smaller than the client hello, but larger than tls inspector's initial read
+  // buffer size.
+  size_t maxReadBytes() const override { return BUFFER_SIZE; }
+
+  Network::FilterStatus onData(Network::ListenerFilterBuffer& buffer) override {
+    auto raw_slice = buffer.rawSlice();
+    ENVOY_LOG_MISC(debug, "LargeBufferListenerFilter::onData: recv: {}", raw_slice.len_);
+    return Network::FilterStatus::Continue;
+  }
+};
+
+class LargeBufferListenerFilterConfigFactory
+    : public Server::Configuration::NamedListenerFilterConfigFactory {
+public:
+  // NamedListenerFilterConfigFactory
+  Network::ListenerFilterFactoryCb createListenerFilterFactoryFromProto(
+      const Protobuf::Message&,
+      const Network::ListenerFilterMatcherSharedPtr& listener_filter_matcher,
+      Server::Configuration::ListenerFactoryContext&) override {
+    return [listener_filter_matcher](Network::ListenerFilterManager& filter_manager) -> void {
+      filter_manager.addAcceptFilter(listener_filter_matcher,
+                                     std::make_unique<LargeBufferListenerFilter>());
+    };
+  }
+
+  ProtobufTypes::MessagePtr createEmptyConfigProto() override {
+    return ProtobufTypes::MessagePtr{new Envoy::ProtobufWkt::Struct()};
+  }
+
+  std::string name() const override {
+    // This fake original_dest should be used only in integration test!
+    return "envoy.filters.listener.large_buffer";
+  }
+};
+static Registry::RegisterFactory<LargeBufferListenerFilterConfigFactory,
+                                 Server::Configuration::NamedListenerFilterConfigFactory>
+    register_;
+
 class TlsInspectorIntegrationTest : public testing::TestWithParam<Network::Address::IpVersion>,
                                     public BaseIntegrationTest {
 public:
@@ -88,6 +135,38 @@ filter_disabled:
     }
 
     useListenerAccessLog(log_format);
+    BaseIntegrationTest::initialize();
+
+    context_manager_ = std::make_unique<Extensions::TransportSockets::Tls::ContextManagerImpl>(
+        server_factory_context_);
+  }
+
+  void initializeWithTlsInspectorWithLargeBufferFilter() {
+    config_helper_.renameListener("echo");
+    // note that initial_read_buffer_size should be smaller than the
+    // LargeBufferListenerFilter::BUFFER_SIZE for the test scenario to be effective.
+    config_helper_.addListenerFilter(R"EOF(
+name: "envoy.filters.listener.tls_inspector"
+typed_config:
+  "@type": type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+  initial_read_buffer_size: 256
+)EOF");
+    // filters are prepended, so this filter will be the first one.
+    config_helper_.addListenerFilter(R"EOF(
+name: "envoy.filters.listener.large_buffer"
+typed_config:
+  "@type": type.googleapis.com/google.protobuf.Struct
+)EOF");
+
+    config_helper_.addConfigModifier([](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
+      auto* timeout = bootstrap.mutable_static_resources()
+                          ->mutable_listeners(0)
+                          ->mutable_listener_filters_timeout();
+      timeout->MergeFrom(ProtobufUtil::TimeUtil::MillisecondsToDuration(1000));
+      bootstrap.mutable_static_resources()
+          ->mutable_listeners(0)
+          ->set_continue_on_listener_filters_timeout(true);
+    });
     BaseIntegrationTest::initialize();
 
     context_manager_ = std::make_unique<Extensions::TransportSockets::Tls::ContextManagerImpl>(
@@ -253,6 +332,47 @@ TEST_P(TlsInspectorIntegrationTest, RequestedBufferSizeCanGrow) {
   EXPECT_EQ(static_cast<int>(TestUtility::readSampleSum(test_server_->server().dispatcher(),
                                                         *bytes_processed_histogram)),
             515);
+}
+
+TEST_P(TlsInspectorIntegrationTest, RequestedBufferSizeCanStartBig) {
+  initializeWithTlsInspectorWithLargeBufferFilter();
+
+  Network::Address::InstanceConstSharedPtr address =
+      Ssl::getSslAddress(version_, lookupPort("echo"));
+
+  Ssl::ClientSslTransportOptions ssl_options;
+  ssl_options.setCipherSuites({"ECDHE-RSA-AES128-GCM-SHA256"});
+  ssl_options.setTlsVersion(envoy::extensions::transport_sockets::tls::v3::TlsParameters::TLSv1_2);
+  const std::string really_long_sni(absl::StrCat(std::string(240, 'a'), ".foo.com"));
+  ssl_options.setSni(really_long_sni);
+  context_ = Ssl::createClientSslTransportSocketFactory(ssl_options, *context_manager_, *api_);
+  Network::TransportSocketPtr transport_socket = context_->createTransportSocket(
+      std::make_shared<Network::TransportSocketOptionsImpl>(
+          absl::string_view(""), std::vector<std::string>(), std::vector<std::string>{}),
+      nullptr);
+
+  client_ = dispatcher_->createClientConnection(address, Network::Address::InstanceConstSharedPtr(),
+                                                std::move(transport_socket), nullptr, nullptr);
+  client_->addConnectionCallbacks(connect_callbacks_);
+  client_->connect();
+
+  while (!connect_callbacks_.connected() && !connect_callbacks_.closed()) {
+    dispatcher_->run(Event::Dispatcher::RunType::NonBlock);
+  }
+
+  client_->close(Network::ConnectionCloseType::NoFlush);
+
+  test_server_->waitUntilHistogramHasSamples("tls_inspector.bytes_processed");
+  auto bytes_processed_histogram = test_server_->histogram("tls_inspector.bytes_processed");
+  EXPECT_EQ(
+      TestUtility::readSampleCount(test_server_->server().dispatcher(), *bytes_processed_histogram),
+      1);
+  auto bytes_processed = static_cast<int>(
+      TestUtility::readSampleSum(test_server_->server().dispatcher(), *bytes_processed_histogram));
+  EXPECT_EQ(bytes_processed, 515);
+  // Double check that the test is effective by ensuring that the
+  // LargeBufferListenerFilter::BUFFER_SIZE is smaller than the client hello.
+  EXPECT_GT(bytes_processed, LargeBufferListenerFilter::BUFFER_SIZE);
 }
 
 INSTANTIATE_TEST_SUITE_P(IpVersions, TlsInspectorIntegrationTest,


### PR DESCRIPTION
https://github.com/envoyproxy/envoy/pull/40544

Fix a bug where the `tls_inspector` times out when used with the `http_inspector` and it gets a large client hello.

Envoy was set up with both `http_inspector` and `tls_inspector` present. We noticed `tls_inspector` timing out when receiving a large client hello (>8 KB).

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
