### PR TITLE
Use uint64_t for buffer watermark values

### DIFF
--- a/contrib/postgres_proxy/filters/network/test/postgres_decoder_test.cc
+++ b/contrib/postgres_proxy/filters/network/test/postgres_decoder_test.cc
@@ -728,8 +728,8 @@ public:
   MOCK_METHOD(ssize_t, search, (const void*, uint64_t, size_t, size_t), (const, override));
   MOCK_METHOD(bool, startsWith, (absl::string_view), (const, override));
   MOCK_METHOD(std::string, toString, (), (const, override));
-  MOCK_METHOD(void, setWatermarks, (uint32_t, uint32_t), (override));
-  MOCK_METHOD(uint32_t, highWatermark, (), (const, override));
+  MOCK_METHOD(void, setWatermarks, (uint64_t, uint32_t), (override));
+  MOCK_METHOD(uint64_t, highWatermark, (), (const, override));
   MOCK_METHOD(bool, highWatermarkTriggered, (), (const, override));
   MOCK_METHOD(size_t, addFragments, (absl::Span<const absl::string_view>));
 };

--- a/envoy/buffer/buffer.h
+++ b/envoy/buffer/buffer.h
@@ -506,13 +506,13 @@ public:
    *        If set to non-zero, overflow callbacks will be called if the
    *        buffered data exceeds watermark * overflow_multiplier.
    */
-  virtual void setWatermarks(uint32_t watermark, uint32_t overflow_multiplier = 0) PURE;
+  virtual void setWatermarks(uint64_t watermark, uint32_t overflow_multiplier = 0) PURE;
 
   /**
    * Returns the configured high watermark. A return value of 0 indicates that watermark
    * functionality is disabled.
    */
-  virtual uint32_t highWatermark() const PURE;
+  virtual uint64_t highWatermark() const PURE;
   /**
    * Determine if the buffer watermark trigger condition is currently set. The watermark trigger is
    * set when the buffer size exceeds the configured high watermark and is cleared once the buffer

--- a/envoy/http/filter.h
+++ b/envoy/http/filter.h
@@ -766,7 +766,7 @@ public:
    *
    * @param limit supplies the desired buffer limit.
    */
-  virtual void setDecoderBufferLimit(uint32_t limit) PURE;
+  virtual void setDecoderBufferLimit(uint64_t limit) PURE;
 
   /**
    * This routine returns the current buffer limit for decoder filters. Filters should abide by
@@ -775,7 +775,7 @@ public:
    *
    * @return the buffer limit the filter should apply.
    */
-  virtual uint32_t decoderBufferLimit() PURE;
+  virtual uint64_t decoderBufferLimit() PURE;
 
   /**
    * @return the account, if any, used by this stream.

--- a/source/common/buffer/buffer_impl.h
+++ b/source/common/buffer/buffer_impl.h
@@ -699,8 +699,8 @@ public:
   // Does not implement watermarking.
   // TODO(antoniovicente) Implement watermarks by merging the OwnedImpl and WatermarkBuffer
   // implementations. Also, make high-watermark config a constructor argument.
-  void setWatermarks(uint32_t, uint32_t) override { ASSERT(false, "watermarks not implemented."); }
-  uint32_t highWatermark() const override { return 0; }
+  void setWatermarks(uint64_t, uint32_t) override { ASSERT(false, "watermarks not implemented."); }
+  uint64_t highWatermark() const override { return 0; }
   bool highWatermarkTriggered() const override { return false; }
 
   /**

--- a/source/common/buffer/watermark_buffer.cc
+++ b/source/common/buffer/watermark_buffer.cc
@@ -116,11 +116,10 @@ size_t WatermarkBuffer::addFragments(absl::Span<const absl::string_view> fragmen
   return total_size_to_write;
 }
 
-void WatermarkBuffer::setWatermarks(uint32_t high_watermark,
+void WatermarkBuffer::setWatermarks(uint64_t high_watermark,
                                     uint32_t overflow_watermark_multiplier) {
   if (overflow_watermark_multiplier > 0 &&
-      (static_cast<uint64_t>(overflow_watermark_multiplier) * high_watermark) >
-          std::numeric_limits<uint32_t>::max()) {
+      (high_watermark > std::numeric_limits<uint64_t>::max() / overflow_watermark_multiplier)) {
     ENVOY_LOG_MISC(debug, "Error setting overflow threshold: overflow_watermark_multiplier * "
                           "high_watermark is overflowing. Disabling overflow watermark.");
     overflow_watermark_multiplier = 0;

--- a/source/common/buffer/watermark_buffer.h
+++ b/source/common/buffer/watermark_buffer.h
@@ -45,8 +45,8 @@ public:
   void appendSliceForTest(const void* data, uint64_t size) override;
   void appendSliceForTest(absl::string_view data) override;
 
-  void setWatermarks(uint32_t high_watermark, uint32_t overflow_watermark = 0) override;
-  uint32_t highWatermark() const override { return high_watermark_; }
+  void setWatermarks(uint64_t high_watermark, uint32_t overflow_watermark = 0) override;
+  uint64_t highWatermark() const override { return high_watermark_; }
   // Returns true if the high watermark callbacks have been called more recently
   // than the low watermark callbacks.
   bool highWatermarkTriggered() const override { return above_high_watermark_called_; }
@@ -54,6 +54,8 @@ public:
 protected:
   virtual void checkHighAndOverflowWatermarks();
   virtual void checkLowWatermark();
+
+  uint64_t overflowWatermarkForTestOnly() const { return overflow_watermark_; }
 
 private:
   void commit(uint64_t length, absl::Span<RawSlice> slices,
@@ -65,9 +67,9 @@ private:
 
   // Used for enforcing buffer limits (off by default). If these are set to non-zero by a call to
   // setWatermarks() the watermark callbacks will be called as described above.
-  uint32_t high_watermark_{0};
-  uint32_t low_watermark_{0};
-  uint32_t overflow_watermark_{0};
+  uint64_t high_watermark_{0};
+  uint64_t low_watermark_{0};
+  uint64_t overflow_watermark_{0};
   // Tracks the latest state of watermark callbacks.
   // True between the time above_high_watermark_ has been called until below_low_watermark_ has
   // been called.

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -230,10 +230,10 @@ private:
   void removeDownstreamWatermarkCallbacks(DownstreamWatermarkCallbacks&) override {}
   void sendGoAwayAndClose() override {}
 
-  void setDecoderBufferLimit(uint32_t) override {
+  void setDecoderBufferLimit(uint64_t) override {
     IS_ENVOY_BUG("decoder buffer limits should not be overridden on async streams.");
   }
-  uint32_t decoderBufferLimit() override { return buffer_limit_.value_or(0); }
+  uint64_t decoderBufferLimit() override { return buffer_limit_.value_or(0); }
   bool recreateStream(const ResponseHeaderMap*) override { return false; }
   const ScopeTrackedObject& scope() override { return *this; }
   void restoreContextOnContinue(ScopeTrackedObjectStack& tracked_object_stack) override {
@@ -285,7 +285,7 @@ private:
   bool remote_closed_{};
   Buffer::InstancePtr buffered_body_;
   Buffer::BufferMemoryAccountSharedPtr account_{nullptr};
-  absl::optional<uint32_t> buffer_limit_{absl::nullopt};
+  absl::optional<uint64_t> buffer_limit_{absl::nullopt};
   RequestHeaderMap* request_headers_{};
   RequestTrailerMap* request_trailers_{};
   bool encoded_response_headers_{};

--- a/source/common/http/filter_manager.cc
+++ b/source/common/http/filter_manager.cc
@@ -1633,7 +1633,7 @@ void FilterManager::callLowWatermarkCallbacks() {
   }
 }
 
-void FilterManager::setBufferLimit(uint32_t new_limit) {
+void FilterManager::setBufferLimit(uint64_t new_limit) {
   ENVOY_STREAM_LOG(debug, "setting buffer limit to {}", *this, new_limit);
   buffer_limit_ = new_limit;
   if (buffered_request_data_) {
@@ -1748,11 +1748,11 @@ void ActiveStreamDecoderFilter::removeDownstreamWatermarkCallbacks(
   parent_.watermark_callbacks_.remove(&watermark_callbacks);
 }
 
-void ActiveStreamDecoderFilter::setDecoderBufferLimit(uint32_t limit) {
+void ActiveStreamDecoderFilter::setDecoderBufferLimit(uint64_t limit) {
   parent_.setBufferLimit(limit);
 }
 
-uint32_t ActiveStreamDecoderFilter::decoderBufferLimit() { return parent_.buffer_limit_; }
+uint64_t ActiveStreamDecoderFilter::decoderBufferLimit() { return parent_.buffer_limit_; }
 
 bool ActiveStreamDecoderFilter::recreateStream(const ResponseHeaderMap* headers) {
   // Because the filter's and the HCM view of if the stream has a body and if

--- a/source/common/http/filter_manager.h
+++ b/source/common/http/filter_manager.h
@@ -289,8 +289,8 @@ struct ActiveStreamDecoderFilter : public ActiveStreamFilterBase,
   void addDownstreamWatermarkCallbacks(DownstreamWatermarkCallbacks& watermark_callbacks) override;
   void
   removeDownstreamWatermarkCallbacks(DownstreamWatermarkCallbacks& watermark_callbacks) override;
-  void setDecoderBufferLimit(uint32_t limit) override;
-  uint32_t decoderBufferLimit() override;
+  void setDecoderBufferLimit(uint64_t limit) override;
+  uint64_t decoderBufferLimit() override;
   bool recreateStream(const Http::ResponseHeaderMap* original_response_headers) override;
 
   void addUpstreamSocketOptions(const Network::Socket::OptionsSharedPtr& options) override;
@@ -682,7 +682,7 @@ public:
   FilterManager(FilterManagerCallbacks& filter_manager_callbacks, Event::Dispatcher& dispatcher,
                 OptRef<const Network::Connection> connection, uint64_t stream_id,
                 Buffer::BufferMemoryAccountSharedPtr account, bool proxy_100_continue,
-                uint32_t buffer_limit)
+                uint64_t buffer_limit)
       : filter_manager_callbacks_(filter_manager_callbacks), dispatcher_(dispatcher),
         connection_(connection), stream_id_(stream_id), account_(std::move(account)),
         proxy_100_continue_(proxy_100_continue), buffer_limit_(buffer_limit) {}
@@ -800,7 +800,7 @@ public:
   virtual void executeLocalReplyIfPrepared() PURE;
 
   // Possibly increases buffer_limit_ to the value of limit.
-  void setBufferLimit(uint32_t limit);
+  void setBufferLimit(uint64_t limit);
 
   /**
    * @return bool whether any above high watermark triggers are currently active
@@ -1114,7 +1114,7 @@ private:
   std::unique_ptr<MetadataMapVector> request_metadata_map_vector_;
   Buffer::InstancePtr buffered_response_data_;
   Buffer::InstancePtr buffered_request_data_;
-  uint32_t buffer_limit_{0};
+  uint64_t buffer_limit_{0};
   uint32_t high_watermark_count_{0};
   std::list<DownstreamWatermarkCallbacks*> watermark_callbacks_;
   Network::Socket::OptionsSharedPtr upstream_options_ =

--- a/source/common/tcp_proxy/tcp_proxy.h
+++ b/source/common/tcp_proxy/tcp_proxy.h
@@ -548,8 +548,8 @@ public:
     }
     void addDownstreamWatermarkCallbacks(Http::DownstreamWatermarkCallbacks&) override {}
     void removeDownstreamWatermarkCallbacks(Http::DownstreamWatermarkCallbacks&) override {}
-    void setDecoderBufferLimit(uint32_t) override {}
-    uint32_t decoderBufferLimit() override { return 0; }
+    void setDecoderBufferLimit(uint64_t) override {}
+    uint64_t decoderBufferLimit() override { return 0; }
     bool recreateStream(const Http::ResponseHeaderMap*) override { return false; }
     void addUpstreamSocketOptions(const Network::Socket::OptionsSharedPtr&) override {}
     Network::Socket::OptionsSharedPtr getUpstreamSocketOptions() const override { return nullptr; }

--- a/test/common/buffer/buffer_fuzz.cc
+++ b/test/common/buffer/buffer_fuzz.cc
@@ -216,14 +216,14 @@ public:
     return total_size_to_write;
   }
 
-  void setWatermarks(uint32_t, uint32_t) override {
+  void setWatermarks(uint64_t, uint32_t) override {
     // Not implemented.
     // TODO(antoniovicente) Implement and add fuzz coverage as we merge the Buffer::OwnedImpl and
     // WatermarkBuffer implementations.
     ASSERT(false);
   }
 
-  uint32_t highWatermark() const override { return 0; }
+  uint64_t highWatermark() const override { return 0; }
   bool highWatermarkTriggered() const override { return false; }
 
   absl::string_view asStringView() const { return {start(), size_}; }

--- a/test/integration/tracked_watermark_buffer.cc
+++ b/test/integration/tracked_watermark_buffer.cc
@@ -141,14 +141,14 @@ uint64_t TrackedWatermarkBufferFactory::sumMaxBufferSizes() const {
   return val;
 }
 
-std::pair<uint32_t, uint32_t> TrackedWatermarkBufferFactory::highWatermarkRange() const {
+std::pair<uint64_t, uint64_t> TrackedWatermarkBufferFactory::highWatermarkRange() const {
   absl::MutexLock lock(&mutex_);
-  uint32_t min_watermark = 0;
-  uint32_t max_watermark = 0;
+  uint64_t min_watermark = 0;
+  uint64_t max_watermark = 0;
   bool watermarks_set = false;
 
   for (auto& item : buffer_infos_) {
-    uint32_t watermark = item.second.watermark_;
+    uint64_t watermark = item.second.watermark_;
     if (watermark == 0) {
       max_watermark = 0;
       watermarks_set = true;

--- a/test/integration/tracked_watermark_buffer.h
+++ b/test/integration/tracked_watermark_buffer.h
@@ -20,7 +20,7 @@ class TrackedWatermarkBuffer : public Buffer::WatermarkBuffer {
 public:
   TrackedWatermarkBuffer(
       std::function<void(uint64_t current_size)> update_size,
-      std::function<void(uint32_t watermark)> update_high_watermark,
+      std::function<void(uint64_t watermark)> update_high_watermark,
       std::function<void(TrackedWatermarkBuffer*)> on_delete,
       std::function<void(BufferMemoryAccountSharedPtr&, TrackedWatermarkBuffer*)> on_bind,
       std::function<void()> below_low_watermark, std::function<void()> above_high_watermark,
@@ -30,7 +30,7 @@ public:
         on_delete_(on_delete), on_bind_(on_bind) {}
   ~TrackedWatermarkBuffer() override { on_delete_(this); }
 
-  void setWatermarks(uint32_t watermark, uint32_t overload) override {
+  void setWatermarks(uint64_t watermark, uint32_t overload) override {
     update_high_watermark_(watermark);
     WatermarkBuffer::setWatermarks(watermark, overload);
   }
@@ -53,7 +53,7 @@ protected:
 
 private:
   std::function<void(uint64_t current_size)> update_size_;
-  std::function<void(uint32_t)> update_high_watermark_;
+  std::function<void(uint64_t)> update_high_watermark_;
   std::function<void(TrackedWatermarkBuffer*)> on_delete_;
   std::function<void(BufferMemoryAccountSharedPtr&, TrackedWatermarkBuffer*)> on_bind_;
 };
@@ -85,7 +85,7 @@ public:
   uint64_t sumMaxBufferSizes() const;
   // Get lower and upper bound on buffer high watermarks. A watermark of 0 indicates that watermark
   // functionality is disabled.
-  std::pair<uint32_t, uint32_t> highWatermarkRange() const;
+  std::pair<uint64_t, uint64_t> highWatermarkRange() const;
 
   // Number of accounts created.
   uint64_t numAccountsCreated() const;
@@ -152,7 +152,7 @@ private:
   void checkIfExpectedBalancesMet() ABSL_EXCLUSIVE_LOCKS_REQUIRED(mutex_);
 
   struct BufferInfo {
-    uint32_t watermark_ = 0;
+    uint64_t watermark_ = 0;
     uint64_t current_size_ = 0;
     uint64_t max_size_ = 0;
   };

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -277,8 +277,8 @@ public:
   MOCK_METHOD(void, onDecoderFilterBelowWriteBufferLowWatermark, ());
   MOCK_METHOD(void, addDownstreamWatermarkCallbacks, (DownstreamWatermarkCallbacks&));
   MOCK_METHOD(void, removeDownstreamWatermarkCallbacks, (DownstreamWatermarkCallbacks&));
-  MOCK_METHOD(void, setDecoderBufferLimit, (uint32_t));
-  MOCK_METHOD(uint32_t, decoderBufferLimit, ());
+  MOCK_METHOD(void, setDecoderBufferLimit, (uint64_t));
+  MOCK_METHOD(uint64_t, decoderBufferLimit, ());
   MOCK_METHOD(bool, recreateStream, (const ResponseHeaderMap* headers));
   MOCK_METHOD(void, sendGoAwayAndClose, ());
   MOCK_METHOD(void, addUpstreamSocketOptions, (const Network::Socket::OptionsSharedPtr& options));


### PR DESCRIPTION
This is needed to support the new `request_body_buffer_limit` route configuration.

WatermarkBufferTest.OverflowWatermarkDisabledOnVeryHighValue had to be refactored to not used allocations as it is no longer practical with 64 bit limit and 32 bit multiplier.

Risk Level: none
Testing: unit tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
