### PR TITLE
generic proxy: add onDownstreamConnected() callback to ServerCodec

### DIFF
--- a/source/extensions/filters/network/generic_proxy/interface/codec.h
+++ b/source/extensions/filters/network/generic_proxy/interface/codec.h
@@ -22,11 +22,19 @@ public:
   virtual ~ServerCodec() = default;
 
   /**
-   * Set callbacks of server codec.
+   * Set callbacks of server codec. Called before onConnected().
    * @param callbacks callbacks of server codec. This callback will have same or longer
    * lifetime as the server codec.
    */
   virtual void setCodecCallbacks(ServerCodecCallbacks& callbacks) PURE;
+
+  /**
+   * Called when the downstream connection is established.
+   *
+   * The connection obtained from ServerCodecCallbacks::connection() will be valid when this
+   * callback is invoked. It should not be relied upon to be valid until this point.
+   */
+  virtual void onConnected() {}
 
   /**
    * Decode request frame from downstream connection.

--- a/source/extensions/filters/network/generic_proxy/proxy.h
+++ b/source/extensions/filters/network/generic_proxy/proxy.h
@@ -370,6 +370,7 @@ public:
   // Envoy::Network::ReadFilter
   Envoy::Network::FilterStatus onData(Envoy::Buffer::Instance& data, bool end_stream) override;
   Envoy::Network::FilterStatus onNewConnection() override {
+    server_codec_->onConnected();
     return Envoy::Network::FilterStatus::Continue;
   }
   void initializeReadFilterCallbacks(Envoy::Network::ReadFilterCallbacks& callbacks) override {

--- a/test/extensions/filters/network/generic_proxy/fake_codec.h
+++ b/test/extensions/filters/network/generic_proxy/fake_codec.h
@@ -163,6 +163,11 @@ public:
     }
 
     void setCodecCallbacks(ServerCodecCallbacks& callback) override { callback_ = &callback; }
+    void onConnected() override {
+      ASSERT(callback_->connection().has_value());
+      ASSERT(callback_->connection()->state() == Network::Connection::State::Open);
+      ASSERT(!callback_->connection()->connecting());
+    }
     void decode(Buffer::Instance& buffer, bool) override {
       ENVOY_LOG(debug, "FakeServerCodec::decode: {}", buffer.toString());
 

--- a/test/extensions/filters/network/generic_proxy/mocks/codec.h
+++ b/test/extensions/filters/network/generic_proxy/mocks/codec.h
@@ -55,6 +55,7 @@ public:
   }
 
   MOCK_METHOD(void, setCodecCallbacks, (ServerCodecCallbacks & callbacks));
+  MOCK_METHOD(void, onConnected, ());
   MOCK_METHOD(void, decode, (Buffer::Instance & buffer, bool end_stream));
   MOCK_METHOD(EncodingResult, encode, (const StreamFrame&, EncodingContext& ctx));
   MOCK_METHOD(ResponseHeaderFramePtr, respond,

--- a/test/extensions/filters/network/generic_proxy/proxy_test.cc
+++ b/test/extensions/filters/network/generic_proxy/proxy_test.cc
@@ -232,6 +232,12 @@ public:
 
 TEST_F(FilterTest, SimpleOnNewConnection) {
   initializeFilter();
+
+  EXPECT_CALL(*server_codec_, onConnected()).WillOnce(Invoke([this] {
+    ASSERT_NE(server_codec_callbacks_, nullptr);
+    ASSERT_EQ(&filter_callbacks_.connection_, server_codec_callbacks_->connection().ptr());
+  }));
+
   EXPECT_EQ(Network::FilterStatus::Continue, filter_->onNewConnection());
 }
 


### PR DESCRIPTION
Commit Message: generic proxy: add onDownstreamConnected() callback to ServerCodec
Additional Description:
This adds a new method ServerCodec::onDownstreamConnected() that is called when the downstream connection is established. This can be used for initialization steps that require the connection returned by ServerCodecCallbacks::connection() to have a value and be in a connected state.

Risk Level: Low; the new method has an empty default implementation, as to not break existing ServerCodec implementations.
Testing: Updated unit tests and mocks
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
