### PR TITLE
userspace socket: allow providing an existing PassthroughState when creating IoHandle pair

### DIFF
--- a/source/extensions/io_socket/user_space/io_handle.h
+++ b/source/extensions/io_socket/user_space/io_handle.h
@@ -32,6 +32,7 @@ public:
 };
 
 using PassthroughStateSharedPtr = std::shared_ptr<PassthroughState>;
+using PassthroughStatePtr = std::unique_ptr<PassthroughState>;
 
 /**
  * The interface for the peer as a writer and supplied read status query.

--- a/test/extensions/io_socket/user_space/io_handle_impl_test.cc
+++ b/test/extensions/io_socket/user_space/io_handle_impl_test.cc
@@ -1293,6 +1293,28 @@ TEST_F(IoHandleImplNotImplementedTest, ErrorOnGetOption) {
 TEST_F(IoHandleImplNotImplementedTest, ErrorOnIoctl) {
   EXPECT_THAT(io_handle_->ioctl(0, nullptr, 0, nullptr, 0, nullptr), IsNotSupportedResult());
 }
+
+class TestPassthroughState : public PassthroughStateImpl {};
+
+TEST(IoHandleFactoryTest, UseExistingPassthroughState) {
+  {
+    auto [io_handle, io_handle_peer] =
+        IoHandleFactory::createIoHandlePair(std::make_unique<TestPassthroughState>());
+    EXPECT_NE(std::dynamic_pointer_cast<TestPassthroughState>(io_handle->passthroughState()),
+              nullptr);
+    EXPECT_NE(std::dynamic_pointer_cast<TestPassthroughState>(io_handle_peer->passthroughState()),
+              nullptr);
+  }
+  {
+    auto [io_handle, io_handle_peer] = IoHandleFactory::createBufferLimitedIoHandlePair(
+        1024, std::make_unique<TestPassthroughState>());
+    EXPECT_NE(std::dynamic_pointer_cast<TestPassthroughState>(io_handle->passthroughState()),
+              nullptr);
+    EXPECT_NE(std::dynamic_pointer_cast<TestPassthroughState>(io_handle_peer->passthroughState()),
+              nullptr);
+  }
+}
+
 } // namespace
 } // namespace UserSpace
 } // namespace IoSocket


### PR DESCRIPTION
Commit Message: userspace socket: allow providing an existing PassthroughState when creating IoHandle pair
Additional Description:
This change is to allow extensions to provide their own implementation of PassthroughState and/or derive from the default PassthroughStateImpl when creating userspace IoHandle pairs with the IoHandleFactory. 

Risk Level: Low; changes are backwards compatible
Testing: Unit tests added
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
