### PR TITLE
wasm: enable Wasm plugins to add bodies to bodyless requests and responses

### DIFF
--- a/source/extensions/common/wasm/context.h
+++ b/source/extensions/common/wasm/context.h
@@ -414,6 +414,8 @@ protected:
   Http::ResponseHeaderMap* response_headers_{};
   ::Envoy::Buffer::Instance* request_body_buffer_{};
   ::Envoy::Buffer::Instance* response_body_buffer_{};
+  ::Envoy::Buffer::InstancePtr added_request_body_buffer_{};
+  ::Envoy::Buffer::InstancePtr added_response_body_buffer_{};
   Http::RequestTrailerMap* request_trailers_{};
   Http::ResponseTrailerMap* response_trailers_{};
   Http::MetadataMap* request_metadata_{};

--- a/test/extensions/filters/http/wasm/test_data/body_rust.rs
+++ b/test/extensions/filters/http/wasm/test_data/body_rust.rs
@@ -30,6 +30,10 @@ impl HttpContext for TestStream {
     fn on_http_request_headers(&mut self, _: usize, _: bool) -> Action {
         self.test = self.get_http_request_header("x-test-operation");
         self.body_chunks = 0;
+        if self.test.as_deref() == Some("SetBodyDuringHeaders") {
+            self.set_http_request_body(0, 0xffffffff, b"set.during.headers");
+            self.log_body(self.get_http_request_body(0, 0xffffffff));
+        }
         Action::Continue
     }
 
@@ -136,6 +140,10 @@ impl HttpContext for TestStream {
 
     fn on_http_response_headers(&mut self, _: usize, _: bool) -> Action {
         self.test = self.get_http_response_header("x-test-operation");
+        if self.test.as_deref() == Some("SetBodyDuringHeaders") {
+            self.set_http_response_body(0, 0xffffffff, b"set.during.headers");
+            self.log_body(self.get_http_response_body(0, 0xffffffff));
+        }
         Action::Continue
     }
 

--- a/test/extensions/filters/http/wasm/wasm_filter_test.cc
+++ b/test/extensions/filters/http/wasm/wasm_filter_test.cc
@@ -740,6 +740,32 @@ TEST_P(WasmHttpFilterTest, BodyResponseBufferThenStreamBody) {
   filter().onDestroy();
 }
 
+// Script that adds a request body.
+TEST_P(WasmHttpFilterTest, BodyRequestSetBodyDuringHeaders) {
+  setupTest("body");
+  setupFilter();
+  EXPECT_CALL(filter(), log_(spdlog::level::err, Eq(absl::string_view("onBody set.during.headers"))));
+  Http::TestRequestHeaderMapImpl request_headers{{":path", "/"},
+                                                 {"x-test-operation", "SetBodyDuringHeaders"}};
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter().decodeHeaders(request_headers, true));
+  filter().onDestroy();
+}
+
+// Script that adds a response body.
+TEST_P(WasmHttpFilterTest, BodyResponseSetBodyDuringHeaders) {
+  setupTest("body");
+  setupFilter();
+  EXPECT_CALL(filter(), log_(spdlog::level::err, Eq(absl::string_view("onBody set.during.headers"))));
+
+  Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter().decodeHeaders(request_headers, true));
+
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "200"},
+                                                   {"x-test-operation", "SetBodyDuringHeaders"}};
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter().encodeHeaders(response_headers, true));
+  filter().onDestroy();
+}
+
 // Script testing AccessLog::Instance::log.
 TEST_P(WasmHttpFilterTest, AccessLog) {
   setupTest("", "headers");


### PR DESCRIPTION
Additional Description: Give Wasm plugins the ability to add bodies to HTTP requests or responses that were previously header-only, by translating getBuffer operations into addEncodedData() / addDecodedData() calls.

Risk Level: low
Testing: unit tests, integration test
Docs Changes: none
Release Notes:
Platform Specific Features:

