### PR TITLE
dns: adding support for edns0 size customisation via envoy filters

### DIFF
--- a/api/envoy/extensions/network/dns_resolver/cares/v3/cares_dns_resolver.proto
+++ b/api/envoy/extensions/network/dns_resolver/cares/v3/cares_dns_resolver.proto
@@ -80,9 +80,13 @@ message CaresDnsResolverConfig {
 
   // Maximum EDNS0 UDP payload size in bytes.
   // If set, c-ares will include EDNS0 in DNS queries and use this value as the maximum UDP response size.
+
   // Recommended values:
+  //
   //   - 1232: Safe default (avoids fragmentation)
   //   - 4096: Maximum allowed
+  //
   // If unset, c-ares uses its internal default (usually 1232).
-  google.protobuf.UInt32Value edns0_max_payload_size = 9 [(validate.rules).uint32 = {gte: 512, lte: 4096}];
+  google.protobuf.UInt32Value edns0_max_payload_size = 9
+      [(validate.rules).uint32 = {lte: 4096 gte: 512}];
 }

--- a/api/envoy/extensions/network/dns_resolver/cares/v3/cares_dns_resolver.proto
+++ b/api/envoy/extensions/network/dns_resolver/cares/v3/cares_dns_resolver.proto
@@ -20,7 +20,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // [#extension: envoy.network.dns_resolver.cares]
 
 // Configuration for c-ares DNS resolver.
-// [#next-free-field: 9]
+// [#next-free-field: 10]
 message CaresDnsResolverConfig {
   // A list of DNS resolver addresses.
   // :ref:`use_resolvers_as_fallback <envoy_v3_api_field_extensions.network.dns_resolver.cares.v3.CaresDnsResolverConfig.use_resolvers_as_fallback>`
@@ -77,4 +77,12 @@ message CaresDnsResolverConfig {
   //   This setting overrides any system configuration for name server rotation.
   //
   bool rotate_nameservers = 8;
+
+  // Maximum EDNS0 UDP payload size in bytes.
+  // If set, c-ares will include EDNS0 in DNS queries and use this value as the maximum UDP response size.
+  // Recommended values:
+  //   - 1232: Safe default (avoids fragmentation)
+  //   - 4096: Maximum allowed
+  // If unset, c-ares uses its internal default (usually 1232).
+  google.protobuf.UInt32Value edns0_max_payload_size = 9 [(validate.rules).uint32 = {gte: 512, lte: 4096}];
 }

--- a/source/extensions/network/dns_resolver/cares/dns_impl.h
+++ b/source/extensions/network/dns_resolver/cares/dns_impl.h
@@ -201,6 +201,7 @@ private:
   const uint64_t query_timeout_seconds_;
   const uint32_t query_tries_;
   const bool rotate_nameservers_;
+  const uint32_t edns0_max_payload_size_;
   const absl::optional<std::string> resolvers_csv_;
   const bool filter_unroutable_families_;
   Stats::ScopeSharedPtr scope_;

--- a/test/extensions/network/dns_resolver/cares/dns_impl_test.cc
+++ b/test/extensions/network/dns_resolver/cares/dns_impl_test.cc
@@ -726,7 +726,7 @@ public:
     cares.set_filter_unroutable_families(filterUnroutableFamilies());
     cares.set_allocated_udp_max_queries(udpMaxQueries());
     cares.set_rotate_nameservers(setRotateNameservers());
-    
+
     // Set EDNS0 configuration if specified
     if (getEdns0MaxPayloadSize() > 0) {
       cares.mutable_edns0_max_payload_size()->set_value(getEdns0MaxPayloadSize());
@@ -2341,11 +2341,11 @@ TEST_P(DnsImplEdns0Test, Edns0ConfigurationApplied) {
   ares_options opts{};
   int optmask = 0;
   EXPECT_EQ(ARES_SUCCESS, ares_save_options(peer_->channel(), &opts, &optmask));
-  
+
   // Verify EDNS0 payload size flag is set and value is correct
   EXPECT_TRUE((optmask & ARES_OPT_EDNSPSZ) == ARES_OPT_EDNSPSZ);
   EXPECT_EQ(opts.ednspsz, 4096);
-  
+
   ares_destroy_options(&opts);
 }
 

--- a/test/extensions/network/dns_resolver/cares/dns_impl_test.cc
+++ b/test/extensions/network/dns_resolver/cares/dns_impl_test.cc
@@ -2324,6 +2324,7 @@ TEST_P(DnsImplAresFlagsForNoNameserverRotationTest, NameserverRotationDisabled) 
 
 class DnsImplEdns0Test : public DnsImplTest {
 protected:
+  bool tcpOnly() const override { return false; }
   uint32_t getEdns0MaxPayloadSize() const override { return 4096; }
 };
 
@@ -2332,6 +2333,10 @@ INSTANTIATE_TEST_SUITE_P(IpVersions, DnsImplEdns0Test,
                          TestUtility::ipTestParamsToString);
 
 // Test: Verify EDNS0 configuration is applied to c-ares options
+// Note: EDNS0 is only relevant for UDP DNS queries.
+// The DNS tests in this file use TCP-only mode to avoid instability and flakiness from UDP.
+// Therefore, this test only verifies that the EDNS0 configuration flag is set in c-ares,
+// not its functional behavior.
 TEST_P(DnsImplEdns0Test, Edns0ConfigurationApplied) {
   ares_options opts{};
   int optmask = 0;


### PR DESCRIPTION
Implementation for https://github.com/envoyproxy/envoy/issues/40696
 
Currently dns response size is 1232 on UDP support as per c-ares lib(https://github.com/c-ares/c-ares/blob/main/src/lib/ares_private.h#L133) on EDNS0. we can provide the option via envoy filters to customise the size as per end user needs like 4096, etc.
[optional Relevant Links:]

Any extra documentation required to understand the issue.
https://datatracker.ietf.org/doc/html/rfc6891

**Sample Service Entry for testing:**
```
apiVersion: networking.istio.io/v1beta1
kind: ServiceEntry
metadata:
  name: external-svc-https
spec:
  hosts:
  - example.com
  location: MESH_EXTERNAL
  ports:
  - number: 443
    name: https
    protocol: TLS
  resolution: DNS
```

**Sample Envoy filter tested with:**
```
apiVersion: networking.istio.io/v1alpha3
kind: EnvoyFilter
metadata:
  name: dns-edns0-config
  namespace: istio-system
spec:
  configPatches:
  - applyTo: CLUSTER
    patch:
      operation: MERGE
      value:
        typed_dns_resolver_config:
          name: envoy.network.dns_resolver.cares
          typed_config:
            "@type": type.googleapis.com/envoy.extensions.network.dns_resolver.cares.v3.CaresDnsResolverConfig
            edns0_max_payload_size: 4096
```

**Test Results:**
          ============Before applying the envoy filter (UDP truncate, TCP retry)==================
          
     

> Aug 19, 2025 11:41:01.806071736 UTC     1268    sll:ethertype:ip:udp:dns        17      192.168.1.101,192.168.1.102,192.168.1.103,192.168.1.104,192.168.1.105,192.168.1.106,192.168.1.107,192.168.1.108,192.168.1.109,192.168.1.110,192.168.1.111,192.168.1.112,192.168.1.113,192.168.1.114,192.168.2.195,192.168.2.196,192.168.2.197,192.168.2.198,192.168.2.199,192.168.2.200,192.168.2.201,192.168.2.202,192.168.3.101,192.168.3.102,192.168.3.103,192.168.3.104,192.168.3.105,192.168.3.106,192.168.3.107,192.168.3.108,192.168.3.109,192.168.3.110,192.168.3.111,192.168.3.112,192.168.3.113,192.168.3.114,192.168.3.195,192.168.3.196,192.168.3.197,192.168.3.198,192.168.3.199,192.168.3.200,192.168.4.101,192.168.4.102,192.168.4.103,192.168.4.104,192.168.4.105,192.168.4.106,192.168.4.107,192.168.4.108,192.168.4.109,192.168.4.110,192.168.4.111,192.168.4.112,192.168.4.113,192.168.4.114,192.168.4.195,192.168.5.101,192.168.5.102,192.168.5.103,192.168.5.104,192.168.5.105,192.168.5.106,192.168.5.107,192.168.5.108,192.168.5.109,192.168.5.110,192.168.5.111,192.168.5.112,192.168.5.113,192.168.5.114,192.168.5.195,192.168.6.101,192.168.6.102

>  Aug 19, 2025 11:41:01.806637942 UTC     2459    sll:ethertype:ip:tcp:dns        6       192.168.1.101,192.168.1.102,192.168.1.103,192.168.1.104,192.168.1.105,192.168.1.106,192.168.1.107,192.168.1.108,192.168.1.109,192.168.1.110,192.168.1.111,192.168.1.112,192.168.1.113,192.168.1.114,192.168.2.195,192.168.2.196,192.168.2.197,192.168.2.198,192.168.2.199,192.168.2.200,192.168.2.201,192.168.2.202,192.168.3.101,192.168.3.102,192.168.3.103,192.168.3.104,192.168.3.105,192.168.3.106,192.168.3.107,192.168.3.108,192.168.3.109,192.168.3.110,192.168.3.111,192.168.3.112,192.168.3.113,192.168.3.114,192.168.3.195,192.168.3.196,192.168.3.197,192.168.3.198,192.168.3.199,192.168.3.200,192.168.4.101,192.168.4.102,192.168.4.103,192.168.4.104,192.168.4.105,192.168.4.106,192.168.4.107,192.168.4.108,192.168.4.109,192.168.4.110,192.168.4.111,192.168.4.112,192.168.4.113,192.168.4.114,192.168.4.195,192.168.5.101,192.168.5.102,192.168.5.103,192.168.5.104,192.168.5.105,192.168.5.106,192.168.5.107,192.168.5.108,192.168.5.109,192.168.5.110,192.168.5.111,192.168.5.112,192.168.5.113,192.168.5.114,192.168.5.195,192.168.6.101,192.168.6.102,192.168.6.103,192.168.6.104,192.168.6.105,192.168.6.106,192.168.6.107,192.168.6.108,192.168.6.109,192.168.6.110,192.168.6.111,192.168.6.112,192.168.6.113,192.168.6.114,192.168.6.195

                   =============After applying the envoy filter(whole response in UDP)=============
                   
 

>  Aug 19, 2025 11:39:45.315502503 UTC     1476    sll:ethertype:ip:udp:dns        17      192.168.1.101,192.168.1.102,192.168.1.103,192.168.1.104,192.168.1.105,192.168.1.106,192.168.1.107,192.168.1.108,192.168.1.109,192.168.1.110,192.168.1.111,192.168.1.112,192.168.1.113,192.168.1.114,192.168.2.195,192.168.2.196,192.168.2.197,192.168.2.198,192.168.2.199,192.168.2.200,192.168.2.201,192.168.2.202,192.168.3.101,192.168.3.102,192.168.3.103,192.168.3.104,192.168.3.105,192.168.3.106,192.168.3.107,192.168.3.108,192.168.3.109,192.168.3.110,192.168.3.111,192.168.3.112,192.168.3.113,192.168.3.114,192.168.3.195,192.168.3.196,192.168.3.197,192.168.3.198,192.168.3.199,192.168.3.200,192.168.4.101,192.168.4.102,192.168.4.103,192.168.4.104,192.168.4.105,192.168.4.106,192.168.4.107,192.168.4.108,192.168.4.109,192.168.4.110,192.168.4.111,192.168.4.112,192.168.4.113,192.168.4.114,192.168.4.195,192.168.5.101,192.168.5.102,192.168.5.103,192.168.5.104,192.168.5.105,192.168.5.106,192.168.5.107,192.168.5.108,192.168.5.109,192.168.5.110,192.168.5.111,192.168.5.112,192.168.5.113,192.168.5.114,192.168.5.195,192.168.6.101,192.168.6.102,192.168.6.103,192.168.6.104,192.168.6.105,192.168.6.106,192.168.6.107,192.168.6.108,192.168.6.109,192.168.6.110,192.168.6.111,192.168.6.112,192.168.6.113,192.168.6.114,192.168.6.195
