### PR TITLE
mobile: AndroidNetworkMonitorV2 support Android API versions below 26 

### DIFF
--- a/mobile/bazel/android_artifacts.bzl
+++ b/mobile/bazel/android_artifacts.bzl
@@ -308,7 +308,7 @@ def _manifest(package_name):
     package="{}" >
 
     <uses-sdk
-            android:minSdkVersion="26"
+            android:minSdkVersion="23"
             android:targetSdkVersion="29"/>
 </manifest>
 """.format(package_name)

--- a/mobile/bazel/test_manifest.xml
+++ b/mobile/bazel/test_manifest.xml
@@ -7,6 +7,6 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
 
     <uses-sdk
-            android:minSdkVersion="26"
+            android:minSdkVersion="23"
             android:targetSdkVersion="27"/>
 </manifest>

--- a/mobile/examples/java/hello_world/AndroidManifest.xml
+++ b/mobile/examples/java/hello_world/AndroidManifest.xml
@@ -8,7 +8,7 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
 
     <uses-sdk
-            android:minSdkVersion="26"
+            android:minSdkVersion="23"
             android:targetSdkVersion="27"/>
 
     <application

--- a/mobile/examples/kotlin/hello_world/AndroidManifest.xml
+++ b/mobile/examples/kotlin/hello_world/AndroidManifest.xml
@@ -6,7 +6,7 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
 
     <uses-sdk
-            android:minSdkVersion="26"
+            android:minSdkVersion="23"
             android:targetSdkVersion="27"/>
 
     <application

--- a/mobile/examples/kotlin/shared/AndroidManifest.xml
+++ b/mobile/examples/kotlin/shared/AndroidManifest.xml
@@ -4,6 +4,6 @@
           android:versionName="0.1">
 
     <uses-sdk
-            android:minSdkVersion="26"
+            android:minSdkVersion="23"
             android:targetSdkVersion="27"/>
 </manifest>

--- a/mobile/library/java/io/envoyproxy/envoymobile/engine/AndroidEngineManifest.xml
+++ b/mobile/library/java/io/envoyproxy/envoymobile/engine/AndroidEngineManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="io.envoyproxy.envoymobile.engine">
     <uses-sdk
-            android:minSdkVersion="26"
+            android:minSdkVersion="23"
             android:targetSdkVersion="29"/>
 
 </manifest>

--- a/mobile/library/java/io/envoyproxy/envoymobile/engine/AndroidNetworkMonitor.java
+++ b/mobile/library/java/io/envoyproxy/envoymobile/engine/AndroidNetworkMonitor.java
@@ -11,6 +11,7 @@ import android.net.ConnectivityManager.NetworkCallback;
 import android.net.Network;
 import android.net.NetworkCapabilities;
 import android.net.NetworkInfo;
+import android.os.Build;
 import android.telephony.TelephonyManager;
 
 import androidx.annotation.NonNull;

--- a/mobile/library/java/io/envoyproxy/envoymobile/engine/AndroidNetworkMonitor.java
+++ b/mobile/library/java/io/envoyproxy/envoymobile/engine/AndroidNetworkMonitor.java
@@ -198,8 +198,10 @@ public class AndroidNetworkMonitor {
 
     connectivityManager =
         (ConnectivityManager)context.getSystemService(Context.CONNECTIVITY_SERVICE);
-    connectivityManager.registerDefaultNetworkCallback(
-        new DefaultNetworkCallback(envoyEngine, connectivityManager, useNetworkChangeEvent));
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+      connectivityManager.registerDefaultNetworkCallback(
+          new DefaultNetworkCallback(envoyEngine, connectivityManager, useNetworkChangeEvent));
+    }
   }
 
   /** @returns The singleton instance of {@link AndroidNetworkMonitor}. */

--- a/mobile/library/java/io/envoyproxy/envoymobile/engine/AndroidNetworkMonitorV2.java
+++ b/mobile/library/java/io/envoyproxy/envoymobile/engine/AndroidNetworkMonitorV2.java
@@ -9,7 +9,10 @@ import static android.net.NetworkCapabilities.TRANSPORT_VPN;
 
 import android.Manifest;
 import android.annotation.SuppressLint;
+import android.content.BroadcastReceiver;
 import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
 import android.content.pm.PackageManager;
 import android.net.ConnectivityManager;
 import android.net.ConnectivityManager.NetworkCallback;
@@ -172,6 +175,10 @@ public class AndroidNetworkMonitorV2 {
   private NetworkRequest mNetworkRequest;
   private NetworkState mNetworkState;
   private boolean mRegistered = false;
+  private IntentFilter mIntentFilter;
+  private Context mApplicationContext;
+  private BroadcastReceiver mBroadcastReceiver;
+  private boolean mIgnoreNextBroadcast = false;
 
   public static void load(Context context, EnvoyEngine envoyEngine) {
     if (mInstance != null) {
@@ -292,8 +299,7 @@ public class AndroidNetworkMonitorV2 {
 
   /** Returns the current default {@link Network}, or {@code null} if disconnected. */
   private Network getDefaultNetwork() {
-    Network defaultNetwork = null;
-    defaultNetwork = mConnectivityManager.getActiveNetwork();
+    Network defaultNetwork = mConnectivityManager.getActiveNetwork();
     if (defaultNetwork != null) {
       return defaultNetwork;
     }
@@ -698,6 +704,23 @@ public class AndroidNetworkMonitorV2 {
     }
   }
 
+  private class ConnectivityBroadcastReceiver extends BroadcastReceiver {
+    @Override
+    public void onReceive(Context context, Intent intent) {
+      runOnThread(
+          new Runnable() {
+            @Override
+            public void run() {
+              if (mIgnoreNextBroadcast) {
+                mIgnoreNextBroadcast = false;
+                return;
+              }
+              onNetworkStateChangedTo(getDefaultNetworkState(), getDefaultNetId());
+            }
+          });
+    }
+  }
+
   private void onNetworkStateChangedTo(NetworkState networkState, long netId) {
     assert mNetworkState != null;
     if (networkState.getEnvoyConnectionType() != mNetworkState.getEnvoyConnectionType() ||
@@ -710,6 +733,7 @@ public class AndroidNetworkMonitorV2 {
   }
 
   private AndroidNetworkMonitorV2(Context context, EnvoyEngine envoyEngine) {
+    mApplicationContext = context.getApplicationContext();
     int permission =
         ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_NETWORK_STATE);
     if (permission == PackageManager.PERMISSION_DENIED) {
@@ -726,7 +750,9 @@ public class AndroidNetworkMonitorV2 {
         (ConnectivityManager)context.getSystemService(Context.CONNECTIVITY_SERVICE);
     mLooper = Looper.myLooper();
     mHandler = new Handler(mLooper);
-    mDefaultNetworkCallback = new DefaultNetworkCallback();
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+      mDefaultNetworkCallback = new DefaultNetworkCallback();
+    }
     mAllNetworksCallback = new AllNetworksCallback();
     mNetworkRequest = new NetworkRequest.Builder()
                           .addCapability(NET_CAPABILITY_INTERNET)
@@ -734,6 +760,9 @@ public class AndroidNetworkMonitorV2 {
                           .removeCapability(NET_CAPABILITY_NOT_VPN)
                           .build();
     mNetworkState = getDefaultNetworkState();
+    mIntentFilter = new IntentFilter(ConnectivityManager.CONNECTIVITY_ACTION);
+    // Used when mDefaultNetworkCallback is null.
+    mBroadcastReceiver = new ConnectivityBroadcastReceiver();
     registerNetworkCallbacks(false);
   }
 
@@ -746,10 +775,24 @@ public class AndroidNetworkMonitorV2 {
     }
 
     if (mDefaultNetworkCallback != null) {
-      try {
-        mConnectivityManager.registerDefaultNetworkCallback(mDefaultNetworkCallback);
-      } catch (RuntimeException e) {
-        mDefaultNetworkCallback = null;
+      // This is only reachable for Android O+.
+      maybeRegisterDefaultNetworkCallback();
+    }
+    if (mDefaultNetworkCallback == null) {
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+        // When registering for a sticky broadcast, like CONNECTIVITY_ACTION, if
+        // registerReceiver returns non-null, it means the broadcast was previously issued
+        // and onReceive() will be immediately called with this previous Intent. Since this
+        // initial callback doesn't actually indicate a network change, we can ignore it.
+        mIgnoreNextBroadcast =
+            (mApplicationContext.registerReceiver(
+                    mBroadcastReceiver, mIntentFilter, /*permission*/ null, mHandler, /*flags*/ 0)
+                != null);
+      } else {
+        mIgnoreNextBroadcast =
+            (mApplicationContext.registerReceiver(
+                    mBroadcastReceiver, mIntentFilter, /*permission*/ null, mHandler)
+                != null);
       }
     }
     mRegistered = true;
@@ -757,8 +800,12 @@ public class AndroidNetworkMonitorV2 {
     if (mAllNetworksCallback != null) {
       mAllNetworksCallback.initializeVpnInPlace();
       try {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
         mConnectivityManager.registerNetworkCallback(mNetworkRequest, mAllNetworksCallback,
                                                      mHandler);
+        } else {
+          mConnectivityManager.registerNetworkCallback(mNetworkRequest, mAllNetworksCallback);
+        }
       } catch (RuntimeException e) {
         // If Android thinks this app has used up all available NetworkRequests, don't
         // bother trying to register any more callbacks as Android will still think
@@ -784,6 +831,16 @@ public class AndroidNetworkMonitorV2 {
     }
   }
 
+  // This is guaranteed to be called only for Android O+.
+  @SuppressLint("NewApi")
+  private void maybeRegisterDefaultNetworkCallback() {
+    try {
+      mConnectivityManager.registerDefaultNetworkCallback(mDefaultNetworkCallback);
+    } catch (RuntimeException e) {
+      mDefaultNetworkCallback = null;
+    }
+  }
+
   public void unregisterNetworkCallbacks() {
     assert onThread();
     if (!mRegistered)
@@ -794,6 +851,8 @@ public class AndroidNetworkMonitorV2 {
     }
     if (mDefaultNetworkCallback != null) {
       mConnectivityManager.unregisterNetworkCallback(mDefaultNetworkCallback);
+    } else {
+      mApplicationContext.unregisterReceiver(mBroadcastReceiver);
     }
   }
 }

--- a/mobile/library/java/io/envoyproxy/envoymobile/engine/AndroidNetworkMonitorV2.java
+++ b/mobile/library/java/io/envoyproxy/envoymobile/engine/AndroidNetworkMonitorV2.java
@@ -707,17 +707,16 @@ public class AndroidNetworkMonitorV2 {
   private class ConnectivityBroadcastReceiver extends BroadcastReceiver {
     @Override
     public void onReceive(Context context, Intent intent) {
-      runOnThread(
-          new Runnable() {
-            @Override
-            public void run() {
-              if (mIgnoreNextBroadcast) {
-                mIgnoreNextBroadcast = false;
-                return;
-              }
-              onNetworkStateChangedTo(getDefaultNetworkState(), getDefaultNetId());
-            }
-          });
+      runOnThread(new Runnable() {
+        @Override
+        public void run() {
+          if (mIgnoreNextBroadcast) {
+            mIgnoreNextBroadcast = false;
+            return;
+          }
+          onNetworkStateChangedTo(getDefaultNetworkState(), getDefaultNetId());
+        }
+      });
     }
   }
 
@@ -776,6 +775,7 @@ public class AndroidNetworkMonitorV2 {
 
     if (mDefaultNetworkCallback != null) {
       // This is only reachable for Android O+.
+      // If registration fails, mDefaultNetworkCallback will be reset.
       maybeRegisterDefaultNetworkCallback();
     }
     if (mDefaultNetworkCallback == null) {
@@ -784,15 +784,13 @@ public class AndroidNetworkMonitorV2 {
         // registerReceiver returns non-null, it means the broadcast was previously issued
         // and onReceive() will be immediately called with this previous Intent. Since this
         // initial callback doesn't actually indicate a network change, we can ignore it.
-        mIgnoreNextBroadcast =
-            (mApplicationContext.registerReceiver(
-                    mBroadcastReceiver, mIntentFilter, /*permission*/ null, mHandler, /*flags*/ 0)
-                != null);
+        mIgnoreNextBroadcast = (mApplicationContext.registerReceiver(
+                                    mBroadcastReceiver, mIntentFilter, /*permission*/ null,
+                                    mHandler, /*flags*/ 0) != null);
       } else {
         mIgnoreNextBroadcast =
-            (mApplicationContext.registerReceiver(
-                    mBroadcastReceiver, mIntentFilter, /*permission*/ null, mHandler)
-                != null);
+            (mApplicationContext.registerReceiver(mBroadcastReceiver, mIntentFilter,
+                                                  /*permission*/ null, mHandler) != null);
       }
     }
     mRegistered = true;
@@ -801,8 +799,8 @@ public class AndroidNetworkMonitorV2 {
       mAllNetworksCallback.initializeVpnInPlace();
       try {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-        mConnectivityManager.registerNetworkCallback(mNetworkRequest, mAllNetworksCallback,
-                                                     mHandler);
+          mConnectivityManager.registerNetworkCallback(mNetworkRequest, mAllNetworksCallback,
+                                                       mHandler);
         } else {
           mConnectivityManager.registerNetworkCallback(mNetworkRequest, mAllNetworksCallback);
         }

--- a/mobile/library/java/io/envoyproxy/envoymobile/utilities/UtilitiesManifest.xml
+++ b/mobile/library/java/io/envoyproxy/envoymobile/utilities/UtilitiesManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="io.envoyproxy.envoymobile.utilities">
     <uses-sdk
-            android:minSdkVersion="26"
+            android:minSdkVersion="23"
             android:targetSdkVersion="29"/>
 
 </manifest>

--- a/mobile/library/java/org/chromium/net/ChromiumNetManifest.xml
+++ b/mobile/library/java/org/chromium/net/ChromiumNetManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="org.chromium.net">
     <uses-sdk
-            android:minSdkVersion="26"
+            android:minSdkVersion="23"
             android:targetSdkVersion="27" />
 
 </manifest>

--- a/mobile/library/java/org/chromium/net/impl/CronvoyManifest.xml
+++ b/mobile/library/java/org/chromium/net/impl/CronvoyManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="org.cronvoy">
     <uses-sdk
-            android:minSdkVersion="26"
+            android:minSdkVersion="23"
             android:targetSdkVersion="27" />
 
 </manifest>

--- a/mobile/library/java/org/chromium/net/urlconnection/URLConnectionManifest.xml
+++ b/mobile/library/java/org/chromium/net/urlconnection/URLConnectionManifest.xml
@@ -2,6 +2,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="org.urlconnection">
   <uses-sdk
-      android:minSdkVersion="26"
+      android:minSdkVersion="23"
       android:targetSdkVersion="29" />
 </manifest>

--- a/mobile/library/kotlin/io/envoyproxy/envoymobile/EnvoyManifest.xml
+++ b/mobile/library/kotlin/io/envoyproxy/envoymobile/EnvoyManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="io.envoyproxy.envoymobile">
     <uses-sdk
-            android:minSdkVersion="26"
+            android:minSdkVersion="23"
             android:targetSdkVersion="29"/>
 
 </manifest>

--- a/mobile/test/java/io/envoyproxy/envoymobile/engine/AndroidNetworkMonitorV2Test.java
+++ b/mobile/test/java/io/envoyproxy/envoymobile/engine/AndroidNetworkMonitorV2Test.java
@@ -11,6 +11,7 @@ import static org.mockito.AdditionalMatchers.aryEq;
 import static org.robolectric.Shadows.shadowOf;
 
 import android.content.Context;
+import android.content.Intent;
 import android.Manifest;
 import android.net.ConnectivityManager;
 import android.net.NetworkCapabilities;
@@ -22,6 +23,7 @@ import androidx.test.platform.app.InstrumentationRegistry;
 import androidx.test.rule.GrantPermissionRule;
 import static androidx.test.core.app.ApplicationProvider.getApplicationContext;
 import android.os.Build;
+import android.os.Looper;
 
 import org.junit.After;
 import org.junit.Before;
@@ -44,6 +46,8 @@ import android.os.Handler;
  * Tests functionality of AndroidNetworkMonitorV2
  */
 @RunWith(RobolectricTestRunner.class)
+// Individual tests may override this to test different Android SDK versions.
+@Config(sdk = Build.VERSION_CODES.O)
 public class AndroidNetworkMonitorV2Test {
   @Rule
   public GrantPermissionRule mRuntimePermissionRule =
@@ -62,7 +66,12 @@ public class AndroidNetworkMonitorV2Test {
     connectivityManager = androidNetworkMonitor.getConnectivityManager();
     networkCapabilities =
         connectivityManager.getNetworkCapabilities(connectivityManager.getActiveNetwork());
-    assertThat(shadowOf(connectivityManager).getNetworkCallbacks()).hasSize(2);
+    int expectedNetworkCallbackSize = 2;
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+      expectedNetworkCallbackSize = 1;
+    }
+    assertThat(shadowOf(connectivityManager).getNetworkCallbacks())
+        .hasSize(expectedNetworkCallbackSize);
   }
 
   @After
@@ -245,5 +254,23 @@ public class AndroidNetworkMonitorV2Test {
     verify(mockEnvoyEngine, times(2))
         .onDefaultNetworkChangedV2(EnvoyConnectionType.CONNECTION_WIFI,
                                    activeNetwork.getNetworkHandle());
+  }
+
+  // Tests that the broadcast receiver is triggered when the default network changes from cell to
+  // WIFI on Android M.
+  @Test
+  @Config(sdk = Build.VERSION_CODES.M)
+  public void testBroadcastReceiver() {
+    Network activeNetwork =
+        triggerDefaultNetworkChange(
+            NetworkCapabilities.TRANSPORT_WIFI, ConnectivityManager.TYPE_WIFI, 0);
+    Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
+    Intent intent = new Intent(ConnectivityManager.CONNECTIVITY_ACTION);
+    context.sendBroadcast(intent);
+    // Robolectric doesn't seem to run the receiver in the main looper, so we need to idle it.
+    shadowOf(Looper.getMainLooper()).idle();
+    verify(mockEnvoyEngine)
+        .onDefaultNetworkChangedV2(
+            EnvoyConnectionType.CONNECTION_WIFI, activeNetwork.getNetworkHandle());
   }
 }

--- a/mobile/test/java/io/envoyproxy/envoymobile/engine/AndroidNetworkMonitorV2Test.java
+++ b/mobile/test/java/io/envoyproxy/envoymobile/engine/AndroidNetworkMonitorV2Test.java
@@ -261,16 +261,15 @@ public class AndroidNetworkMonitorV2Test {
   @Test
   @Config(sdk = Build.VERSION_CODES.M)
   public void testBroadcastReceiver() {
-    Network activeNetwork =
-        triggerDefaultNetworkChange(
-            NetworkCapabilities.TRANSPORT_WIFI, ConnectivityManager.TYPE_WIFI, 0);
+    Network activeNetwork = triggerDefaultNetworkChange(NetworkCapabilities.TRANSPORT_WIFI,
+                                                        ConnectivityManager.TYPE_WIFI, 0);
     Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
     Intent intent = new Intent(ConnectivityManager.CONNECTIVITY_ACTION);
     context.sendBroadcast(intent);
     // Robolectric doesn't seem to run the receiver in the main looper, so we need to idle it.
     shadowOf(Looper.getMainLooper()).idle();
     verify(mockEnvoyEngine)
-        .onDefaultNetworkChangedV2(
-            EnvoyConnectionType.CONNECTION_WIFI, activeNetwork.getNetworkHandle());
+        .onDefaultNetworkChangedV2(EnvoyConnectionType.CONNECTION_WIFI,
+                                   activeNetwork.getNetworkHandle());
   }
 }

--- a/mobile/test/kotlin/apps/baseline/AndroidManifest.xml
+++ b/mobile/test/kotlin/apps/baseline/AndroidManifest.xml
@@ -6,7 +6,7 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
 
     <uses-sdk
-            android:minSdkVersion="26"
+            android:minSdkVersion="23"
             android:targetSdkVersion="27"/>
 
     <application

--- a/mobile/test/kotlin/apps/experimental/AndroidManifest.xml
+++ b/mobile/test/kotlin/apps/experimental/AndroidManifest.xml
@@ -6,7 +6,7 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
 
     <uses-sdk
-            android:minSdkVersion="26"
+            android:minSdkVersion="23"
             android:targetSdkVersion="27"/>
 
     <application


### PR DESCRIPTION
Commit Message: added a BroadcastReceiver callback in AndroidNetworkMonitorV2 to listen for default network changes on Android SDK versions below Oreo (API level 26).

Also lower min SDK version from 26 to 23.

Additional Description: AndroidNetworkMonitor also calls `registerDefaultNetworkCallback()` which is only supported on version 24 (N) and above. So this PR has to add version guard around the call. Unfortunately AndroidNetworkMonitor will not handle network change event on devices below version N, but we will replace it with AndroidNetworkMonitorV2 soon.

Risk Level: low
Testing: new unit test pass
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
