### PR TITLE
composite: allow filters to be added on encode path

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -246,6 +246,9 @@ new_features:
     extract trace information from W3C trace headers when B3 headers are not present (downstream),
     and inject both B3 and W3C trace headers for upstream requests to maximize compatibility.
     The default value ``USE_B3`` maintains backward compatibility with B3-only behavior.
+- area: composite
+  change: |
+    Allow composite filter to be configured to insert a filter into filter chain outside of the decode headers lifecycle phase.
 - area: rbac
   change: |
     Switch the IP matcher to use LC-Trie for performance improvements.

--- a/docs/root/configuration/http/http_filters/composite_filter.rst
+++ b/docs/root/configuration/http/http_filters/composite_filter.rst
@@ -9,10 +9,10 @@ or filter configurations to be selected based on the incoming request, allowing 
 configuration that could become prohibitive when making use of per route configurations (e.g.
 because the cardinality would cause a route table explosion).
 
-The filter does not do any kind of buffering, and as a result it must be able to instantiate the
-filter it will delegate to before it receives any callbacks that it needs to delegate. Because of
-this, in order to delegate all the data to the specified filter, the decision must be made based
-on just the request headers.
+The filter does not do any kind of buffering, and as a result it will only
+delegate callbacks received during or after the phase which instantiates the
+delegated filter. In order to delegate all the data to the specified filter,
+the decision must be made based on just the request headers.
 
 Delegation can fail if the filter factory attempted to use a callback not supported by the
 composite filter. In either case, the ``<stat_prefix>.composite.delegation_error`` stat will be

--- a/source/extensions/filters/http/composite/factory_wrapper.cc
+++ b/source/extensions/filters/http/composite/factory_wrapper.cc
@@ -7,7 +7,6 @@ namespace Extensions {
 namespace HttpFilters {
 namespace Composite {
 void FactoryCallbacksWrapper::addStreamDecoderFilter(Http::StreamDecoderFilterSharedPtr filter) {
-  ASSERT(!filter_.decoded_headers_);
   if (filter_to_inject_) {
     errors_.push_back(absl::InvalidArgumentError(
         "cannot delegate to decoder filter that instantiates multiple filters"));
@@ -18,7 +17,6 @@ void FactoryCallbacksWrapper::addStreamDecoderFilter(Http::StreamDecoderFilterSh
 }
 
 void FactoryCallbacksWrapper::addStreamEncoderFilter(Http::StreamEncoderFilterSharedPtr filter) {
-  ASSERT(!filter_.decoded_headers_);
   if (filter_to_inject_) {
     errors_.push_back(absl::InvalidArgumentError(
         "cannot delegate to encoder filter that instantiates multiple filters"));
@@ -29,7 +27,6 @@ void FactoryCallbacksWrapper::addStreamEncoderFilter(Http::StreamEncoderFilterSh
 }
 
 void FactoryCallbacksWrapper::addStreamFilter(Http::StreamFilterSharedPtr filter) {
-  ASSERT(!filter_.decoded_headers_);
   if (filter_to_inject_) {
     errors_.push_back(absl::InvalidArgumentError(
         "cannot delegate to stream filter that instantiates multiple filters"));

--- a/source/extensions/filters/http/composite/filter.cc
+++ b/source/extensions/filters/http/composite/filter.cc
@@ -40,8 +40,6 @@ std::unique_ptr<Protobuf::Struct> MatchedActionInfo::buildProtoStruct() const {
 }
 
 Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers, bool end_stream) {
-  decoded_headers_ = true;
-
   return delegateFilterActionOr(delegated_filter_, &StreamDecoderFilter::decodeHeaders,
                                 Http::FilterHeadersStatus::Continue, headers, end_stream);
 }

--- a/source/extensions/filters/http/composite/filter.h
+++ b/source/extensions/filters/http/composite/filter.h
@@ -118,12 +118,6 @@ private:
                          const std::string& action_name);
 
   Event::Dispatcher& dispatcher_;
-  // Use these to track whether we are allowed to insert a specific kind of filter. These mainly
-  // serve to surface an easier to understand error, as attempting to insert a filter at a later
-  // time will result in various FM assertions firing.
-  // We should be protected against this by the match tree validation that only allows request
-  // headers, this just provides some additional sanity checking.
-  bool decoded_headers_{false};
 
   // Wraps a stream encoder OR a stream decoder filter into a stream filter, making it easier to
   // delegate calls.

--- a/test/extensions/filters/http/composite/BUILD
+++ b/test/extensions/filters/http/composite/BUILD
@@ -36,6 +36,7 @@ envoy_extension_cc_test(
     srcs = ["composite_filter_integration_test.cc"],
     extension_names = ["envoy.filters.http.composite"],
     rbe_pool = "6gig",
+    shard_count = 6,
     deps = [
         "//source/common/http:header_map_lib",
         "//source/extensions/filters/http/composite:config",
@@ -44,6 +45,7 @@ envoy_extension_cc_test(
         "//test/common/grpc:grpc_client_integration_lib",
         "//test/common/http:common_lib",
         "//test/integration:http_integration_lib",
+        "//test/integration/filters:local_reply_during_encoding_filter_lib",
         "//test/integration/filters:server_factory_context_filter_config_proto_cc_proto",
         "//test/integration/filters:server_factory_context_filter_lib",
         "//test/integration/filters:set_response_code_filter_config_proto_cc_proto",

--- a/test/extensions/filters/http/composite/composite_filter_integration_test.cc
+++ b/test/extensions/filters/http/composite/composite_filter_integration_test.cc
@@ -177,6 +177,51 @@ public:
                                  downstream_filter_);
   }
 
+  void prependCompositeFilterResponseMatcher(const std::string& name = "composite") {
+    config_helper_.prependFilter(absl::StrFormat(R"EOF(
+      name: %s
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.common.matching.v3.ExtensionWithMatcher
+        extension_config:
+          name: composite
+          typed_config:
+            "@type": type.googleapis.com/envoy.extensions.filters.http.composite.v3.Composite
+        xds_matcher:
+          matcher_list:
+            matchers:
+              - predicate:
+                  and_matcher:
+                    predicate:
+                      - single_predicate:
+                          input:
+                            name: request-header-match
+                            typed_config:
+                              "@type": type.googleapis.com/envoy.type.matcher.v3.HttpRequestHeaderMatchInput
+                              header_name: match-header
+                          value_match:
+                            exact: match
+                      - single_predicate:
+                          input:
+                            name: response-header-match
+                            typed_config:
+                              "@type": type.googleapis.com/envoy.type.matcher.v3.HttpResponseHeaderMatchInput
+                              header_name: match-response
+                          value_match:
+                            exact: match
+                on_match:
+                  action:
+                    name: composite-action
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.composite.v3.ExecuteFilterAction
+                      typed_config:
+                        name: local-reply-during-encode
+                        typed_config:
+                          "@type": type.googleapis.com/google.protobuf.Struct
+    )EOF",
+                                                 name),
+                                 downstream_filter_);
+  }
+
   void prependCompositeDynamicFilter(const std::string& name = "composite",
                                      const std::string& path = "set_response_code.yaml",
                                      bool sampling = true) {
@@ -280,6 +325,9 @@ resources:
                                                                  {"match-header", "match"},
                                                                  {":authority", "blah"}};
 
+  const Http::TestResponseHeaderMapImpl match_response_headers_ = {{":status", "200"},
+                                                                   {"match-response", "match"}};
+
   void initialize() override {
     if (!downstream_filter_) {
       setUpstreamProtocol(Http::CodecType::HTTP2);
@@ -358,6 +406,31 @@ TEST_P(CompositeFilterIntegrationTest, TestBasic) {
     auto response = codec_client_->makeRequestWithBody(match_request_headers_, 1024);
     ASSERT_TRUE(response->waitForEndStream());
     EXPECT_THAT(response->headers(), Http::HttpStatusIs("403"));
+  }
+}
+
+TEST_P(CompositeFilterIntegrationTest, TestResponseHeaders) {
+  prependCompositeFilterResponseMatcher();
+  initialize();
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+
+  {
+    auto response = codec_client_->makeRequestWithBody(match_request_headers_, 1024);
+    waitForNextUpstreamRequest();
+
+    upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, true);
+    ASSERT_TRUE(response->waitForEndStream());
+    EXPECT_THAT(response->headers(), Http::HttpStatusIs("200"));
+  }
+
+  {
+    auto response = codec_client_->makeRequestWithBody(match_request_headers_, 1024);
+    waitForNextUpstreamRequest();
+
+    upstream_request_->encodeHeaders(match_response_headers_, true);
+    ASSERT_TRUE(response->waitForEndStream());
+    EXPECT_THAT(response->headers(),
+                Http::HttpStatusIs("500")); // local-reply-during-encode sets 500.
   }
 }
 


### PR DESCRIPTION
Commit Message: composite: allow filters to be added on encode path
Additional Description:
Removes assertion preventing matchers from inserting a filter on the response path.

It appears like this behavior used to cause a crash or be validated against, but it doesn't appear to still be the case.

This is very useful for end-users who would like to, for example, mutate the response body for a filter when a request header is specified and the content-type matches, which could be especially expensive if the executed filter is ext_proc.

Risk Level: medium (new feature in existing filter)
Testing: integration. Also tested locally with an end-to-end test with ext_proc.
Docs Changes: Removed stipulation that matching can only rely on request headers.
Release Notes: Added note that composite filter can be configured to match outside of request headers.
Platform Specific Features: None.
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
