### PR TITLE
upstream: introduce new drain behavior DrainExistingNonMigratableConnections

### DIFF
--- a/bazel/external/quiche.BUILD
+++ b/bazel/external/quiche.BUILD
@@ -3029,13 +3029,17 @@ envoy_cc_library(
 envoy_quic_cc_library(
     name = "quic_core_http_client_lib",
     srcs = [
+        "quiche/quic/core/http/quic_connection_migration_manager.cc",
         "quiche/quic/core/http/quic_spdy_client_session.cc",
         "quiche/quic/core/http/quic_spdy_client_session_base.cc",
+        "quiche/quic/core/http/quic_spdy_client_session_with_migration.cc",
         "quiche/quic/core/http/quic_spdy_client_stream.cc",
     ],
     hdrs = [
+        "quiche/quic/core/http/quic_connection_migration_manager.h",
         "quiche/quic/core/http/quic_spdy_client_session.h",
         "quiche/quic/core/http/quic_spdy_client_session_base.h",
+        "quiche/quic/core/http/quic_spdy_client_session_with_migration.h",
         "quiche/quic/core/http/quic_spdy_client_stream.h",
     ],
     deps = [
@@ -3047,10 +3051,12 @@ envoy_quic_cc_library(
         ":quic_core_http_server_initiated_spdy_stream_lib",
         ":quic_core_http_spdy_session_lib",
         ":quic_core_packets_lib",
+        ":quic_core_path_context_factory_interface_lib",
         ":quic_core_qpack_qpack_streams_lib",
         ":quic_core_server_id_lib",
         ":quic_core_types_lib",
         ":quic_core_utils_lib",
+        ":quic_force_blockable_packet_writer_lib",
         ":quic_platform_base",
     ],
 )
@@ -3202,6 +3208,12 @@ envoy_quic_cc_library(
         ":quic_core_http_spdy_session_lib",
         ":quic_server_session_lib",
     ],
+)
+
+envoy_quic_cc_library(
+    name = "quic_force_blockable_packet_writer_lib",
+    hdrs = ["quiche/quic/core/quic_force_blockable_packet_writer.h"],
+    deps = [":quic_core_packet_writer_lib"],
 )
 
 envoy_quic_cc_library(
@@ -3391,6 +3403,16 @@ envoy_quic_cc_library(
         ":quic_core_arena_scoped_ptr_lib",
         ":quic_core_types_lib",
         ":quic_platform_base",
+    ],
+)
+
+envoy_quic_cc_library(
+    name = "quic_core_path_context_factory_interface_lib",
+    hdrs = ["quiche/quic/core/quic_path_context_factory.h"],
+    deps = [
+        ":quic_core_path_validator_lib",
+        ":quic_platform_export",
+        ":quic_platform_socket_address",
     ],
 )
 

--- a/envoy/common/conn_pool.h
+++ b/envoy/common/conn_pool.h
@@ -49,6 +49,9 @@ enum class DrainBehavior {
   // all new streams take place on a new connection. For example, when a health check failure
   // occurs.
   DrainExistingConnections,
+  // Same as DrainExistingConnections, but only drains connections unable to migrate to a different
+  // network on mobile.
+  DrainExistingNonMigratableConnections,
 };
 
 /**

--- a/envoy/upstream/cluster_manager.h
+++ b/envoy/upstream/cluster_manager.h
@@ -503,7 +503,8 @@ public:
    * @param predicate supplies the optional drain connections host predicate. If not supplied, all
    *                  hosts are drained.
    */
-  virtual void drainConnections(DrainConnectionsHostPredicate predicate) PURE;
+  virtual void drainConnections(DrainConnectionsHostPredicate predicate,
+                                ConnectionPool::DrainBehavior drain_behavior) PURE;
 
   /**
    * Check if the cluster is active and statically configured, and if not, return an error

--- a/mobile/library/common/internal_engine.cc
+++ b/mobile/library/common/internal_engine.cc
@@ -462,8 +462,7 @@ void InternalEngine::resetHttpPropertiesAndDrainHosts(bool has_ipv6_connectivity
       ENVOY_LOG_EVENT(debug, "netconf_immediate_drain", "DrainAllHosts");
       getClusterManager().drainConnections(
           [](const Upstream::Host&) { return true; },
-          Envoy::ConnectionPool::DrainBehavior::
-              DrainExistingNonMigratableConnections);
+          Envoy::ConnectionPool::DrainBehavior::DrainExistingNonMigratableConnections);
     }
   }
 }

--- a/mobile/library/common/internal_engine.cc
+++ b/mobile/library/common/internal_engine.cc
@@ -458,9 +458,12 @@ void InternalEngine::resetHttpPropertiesAndDrainHosts(bool has_ipv6_connectivity
 
   if (disable_dns_refresh_on_network_change_) {
     if (Runtime::runtimeFeatureEnabled("envoy.reloadable_features.drain_pools_on_network_change")) {
-      // Since DNS refreshing is disabled, explicitly drain all connections.
+      // Since DNS refreshing is disabled, explicitly drain all non-migratable connections.
       ENVOY_LOG_EVENT(debug, "netconf_immediate_drain", "DrainAllHosts");
-      getClusterManager().drainConnections([](const Upstream::Host&) { return true; });
+      getClusterManager().drainConnections(
+          [](const Upstream::Host&) { return true; },
+          Envoy::ConnectionPool::DrainBehavior::
+              DrainExistingNonMigratableConnections);
     }
   }
 }

--- a/mobile/library/common/network/connectivity_manager.cc
+++ b/mobile/library/common/network/connectivity_manager.cc
@@ -248,7 +248,8 @@ void RefreshDnsWithPostDrainHandler::onDnsResolutionComplete(
 
   // Pass predicate to only drain connections to the resolved host (for any cluster).
   cluster_manager_.drainConnections(
-      [resolved_host](const Upstream::Host& host) { return host.hostname() == resolved_host; });
+      [resolved_host](const Upstream::Host& host) { return host.hostname() == resolved_host; },
+      ConnectionPool::DrainBehavior::DrainExistingConnections);
 }
 
 void ConnectivityManagerImpl::setDrainPostDnsRefreshEnabled(bool enabled) {

--- a/mobile/test/common/network/connectivity_manager_test.cc
+++ b/mobile/test/common/network/connectivity_manager_test.cc
@@ -111,7 +111,7 @@ TEST_F(ConnectivityManagerTest, WhenDrainPostDnsRefreshEnabledDrainsPostDnsRefre
   envoy_netconf_t configuration_key = connectivity_manager_->getConfigurationKey();
   connectivity_manager_->refreshDns(configuration_key, true);
 
-  EXPECT_CALL(cm_, drainConnections(_));
+  EXPECT_CALL(cm_, drainConnections(_, ConnectionPool::DrainBehavior::DrainExistingConnections));
   dns_completion_callback->onDnsResolutionComplete(
       "cached.example.com",
       std::make_shared<Extensions::Common::DynamicForwardProxy::MockDnsHostInfo>(),

--- a/source/common/http/http3/conn_pool.h
+++ b/source/common/http/http3/conn_pool.h
@@ -158,6 +158,18 @@ public:
                                          ConnectionPool::Callbacks& callbacks,
                                          const Instance::StreamOptions& options) override;
 
+  void drainConnections(Envoy::ConnectionPool::DrainBehavior drain_behavior) override {
+    if (drain_behavior ==
+            Envoy::ConnectionPool::DrainBehavior::DrainExistingNonMigratableConnections &&
+        quic_info_.migration_config_.migrate_session_on_network_change) {
+      // If connection migration is enabled, don't drain existing connections.
+      // Each connection will observe network change signals and decide whether
+      // to migrate or drain.
+      return;
+    }
+    FixedHttpConnPoolImpl::drainConnections(drain_behavior);
+  }
+
   // For HTTP/3 the base connection pool does not track stream capacity, rather
   // the HTTP3 active client does.
   bool trackStreamCapacity() override { return false; }

--- a/source/common/quic/client_connection_factory_impl.cc
+++ b/source/common/quic/client_connection_factory_impl.cc
@@ -10,6 +10,7 @@ PersistentQuicInfoImpl::PersistentQuicInfoImpl(Event::Dispatcher& dispatcher, ui
     : conn_helper_(dispatcher), alarm_factory_(dispatcher, *conn_helper_.GetClock()),
       buffer_limit_(buffer_limit), max_packet_length_(max_packet_length) {
   quiche::FlagRegistry::getInstance();
+  migration_config_.migrate_session_on_network_change = false;
 }
 
 std::unique_ptr<PersistentQuicInfoImpl>

--- a/source/common/quic/client_connection_factory_impl.h
+++ b/source/common/quic/client_connection_factory_impl.h
@@ -12,6 +12,7 @@
 #include "source/common/tls/client_ssl_socket.h"
 #include "source/extensions/quic/crypto_stream/envoy_quic_crypto_client_stream.h"
 
+#include "quiche/quic/core/http/quic_connection_migration_manager.h"
 #include "quiche/quic/core/quic_utils.h"
 
 namespace Envoy {
@@ -34,6 +35,9 @@ struct PersistentQuicInfoImpl : public Http::PersistentQuicInfo {
   // Override the maximum packet length of connections for tunneling. Use the default length in
   // QUICHE if this is set to 0.
   quic::QuicByteCount max_packet_length_;
+  // Whether connection migration is enabled for this cluster.
+  // TODO(danzh): Add a config knob to configure connection migration.
+  quic::QuicConnectionMigrationConfig migration_config_{.migrate_session_on_network_change = false};
 };
 
 std::unique_ptr<PersistentQuicInfoImpl>

--- a/source/common/quic/client_connection_factory_impl.h
+++ b/source/common/quic/client_connection_factory_impl.h
@@ -35,9 +35,8 @@ struct PersistentQuicInfoImpl : public Http::PersistentQuicInfo {
   // Override the maximum packet length of connections for tunneling. Use the default length in
   // QUICHE if this is set to 0.
   quic::QuicByteCount max_packet_length_;
-  // Whether connection migration is enabled for this cluster.
   // TODO(danzh): Add a config knob to configure connection migration.
-  quic::QuicConnectionMigrationConfig migration_config_{.migrate_session_on_network_change = false};
+  quic::QuicConnectionMigrationConfig migration_config_;
 };
 
 std::unique_ptr<PersistentQuicInfoImpl>

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -1077,11 +1077,12 @@ void ClusterManagerImpl::drainConnections(DrainConnectionsHostPredicate predicat
                                           ConnectionPool::DrainBehavior drain_behavior) {
   ENVOY_LOG_EVENT(debug, "drain_connections_call_for_all_clusters",
                   "drainConnections called for all clusters");
-  tls_.runOnAllThreads([predicate](OptRef<ThreadLocalClusterManagerImpl> cluster_manager) {
-    for (const auto& cluster_entry : cluster_manager->thread_local_clusters_) {
-      cluster_entry.second->drainConnPools(predicate, drain_behavior);
-    }
-  });
+  tls_.runOnAllThreads(
+      [predicate, drain_behavior](OptRef<ThreadLocalClusterManagerImpl> cluster_manager) {
+        for (const auto& cluster_entry : cluster_manager->thread_local_clusters_) {
+          cluster_entry.second->drainConnPools(predicate, drain_behavior);
+        }
+      });
 }
 
 absl::Status ClusterManagerImpl::checkActiveStaticCluster(const std::string& cluster) {

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -1073,13 +1073,13 @@ void ClusterManagerImpl::drainConnections(const std::string& cluster,
   });
 }
 
-void ClusterManagerImpl::drainConnections(DrainConnectionsHostPredicate predicate) {
+void ClusterManagerImpl::drainConnections(DrainConnectionsHostPredicate predicate,
+                                          ConnectionPool::DrainBehavior drain_behavior) {
   ENVOY_LOG_EVENT(debug, "drain_connections_call_for_all_clusters",
                   "drainConnections called for all clusters");
   tls_.runOnAllThreads([predicate](OptRef<ThreadLocalClusterManagerImpl> cluster_manager) {
     for (const auto& cluster_entry : cluster_manager->thread_local_clusters_) {
-      cluster_entry.second->drainConnPools(predicate,
-                                           ConnectionPool::DrainBehavior::DrainExistingConnections);
+      cluster_entry.second->drainConnPools(predicate, drain_behavior);
     }
   });
 }

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -361,7 +361,8 @@ public:
   void drainConnections(const std::string& cluster,
                         DrainConnectionsHostPredicate predicate) override;
 
-  void drainConnections(DrainConnectionsHostPredicate predicate) override;
+  void drainConnections(DrainConnectionsHostPredicate predicate,
+                        ConnectionPool::DrainBehavior drain_behavior) override;
 
   absl::Status checkActiveStaticCluster(const std::string& cluster) override;
 

--- a/test/common/http/http3/conn_pool_test.cc
+++ b/test/common/http/http3/conn_pool_test.cc
@@ -87,7 +87,7 @@ public:
   Upstream::ClusterConnectivityState state_;
   NiceMock<Server::MockOverloadManager> overload_manager_;
   Network::Address::InstanceConstSharedPtr test_address_ =
-      *Network::Utility::resolveUrl("tcp://[::]:3000");
+      *Network::Utility::resolveUrl("tcp://127.0.0.1:3000");
   std::shared_ptr<Upstream::HostDescription::AddressVector> address_list_{
       new Upstream::HostDescription::AddressVector{
           *Network::Utility::resolveUrl("tcp://127.0.0.1:3000"),

--- a/test/integration/http_conn_pool_integration_test.cc
+++ b/test/integration/http_conn_pool_integration_test.cc
@@ -211,7 +211,8 @@ TEST_P(HttpConnPoolIntegrationTest, PoolDrainAfterDrainApiAllClusters) {
 
   // Drain connection pools via API. Need to post this to the server thread.
   test_server_->server().dispatcher().post(
-      [this] { test_server_->server().clusterManager().drainConnections(nullptr); });
+      [this] { test_server_->server().clusterManager().drainConnections(nullptr,
+      ConnectionPool::DrainBehavior::DrainExistingConnections); });
 
   ASSERT_TRUE(first_connection->waitForDisconnect());
   ASSERT_TRUE(fake_upstream_connection_->waitForDisconnect());

--- a/test/integration/http_conn_pool_integration_test.cc
+++ b/test/integration/http_conn_pool_integration_test.cc
@@ -210,9 +210,10 @@ TEST_P(HttpConnPoolIntegrationTest, PoolDrainAfterDrainApiAllClusters) {
   EXPECT_TRUE(response->complete());
 
   // Drain connection pools via API. Need to post this to the server thread.
-  test_server_->server().dispatcher().post(
-      [this] { test_server_->server().clusterManager().drainConnections(nullptr,
-      ConnectionPool::DrainBehavior::DrainExistingConnections); });
+  test_server_->server().dispatcher().post([this] {
+    test_server_->server().clusterManager().drainConnections(
+        nullptr, ConnectionPool::DrainBehavior::DrainExistingConnections);
+  });
 
   ASSERT_TRUE(first_connection->waitForDisconnect());
   ASSERT_TRUE(fake_upstream_connection_->waitForDisconnect());

--- a/test/mocks/upstream/cluster_manager.h
+++ b/test/mocks/upstream/cluster_manager.h
@@ -84,7 +84,9 @@ public:
   }
   MOCK_METHOD(void, drainConnections,
               (const std::string& cluster, DrainConnectionsHostPredicate predicate));
-  MOCK_METHOD(void, drainConnections, (DrainConnectionsHostPredicate predicate));
+  MOCK_METHOD(void, drainConnections,
+              (DrainConnectionsHostPredicate predicate,
+               ConnectionPool::DrainBehavior drain_behavior));
   MOCK_METHOD(absl::Status, checkActiveStaticCluster, (const std::string& cluster));
   MOCK_METHOD(absl::StatusOr<OdCdsApiHandlePtr>, allocateOdCdsApi,
               (OdCdsCreationFunction creation_function,

--- a/tools/spelling/spelling_dictionary.txt
+++ b/tools/spelling/spelling_dictionary.txt
@@ -1007,6 +1007,7 @@ metaprogramming
 metatable
 microbenchmarks
 midp
+migratable
 milli
 mimics
 misconfiguration


### PR DESCRIPTION
Commit Message: Introduces new enum value `ConnectionPool::DrainBehavior::DrainExistingNonMigratableConnections`. When this behavior is used, HTTP/3 connection pools will only drain existing connections if QUIC connection migration is not enabled. 

The mobile engine is updated to use this new drain behavior when DNS refreshing is disabled on network changes, allowing migratable QUIC connections to persist across network transitions.

Additional Description: also add QUICHE migration code into build target
Risk Level: low, the new behavior is disabled
Testing: new unit test pass
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
