### PR TITLE
mobile: flag guard the IP-reserved range filtering in the IPv6 check

### DIFF
--- a/mobile/library/common/internal_engine.cc
+++ b/mobile/library/common/internal_engine.cc
@@ -594,25 +594,31 @@ Network::Address::InstanceConstSharedPtr InternalEngine::probeAndGetLocalAddr(in
     return nullptr;
   }
 
-  if ((*address)->ip() == nullptr) {
-    ENVOY_LOG(trace, "Local address is not an IP address: {}.", (*address)->asString());
-    return nullptr;
-  }
-  if ((*address)->ip()->isLinkLocalAddress()) {
-    ENVOY_LOG(trace, "Ignoring link-local address: {}.", (*address)->asString());
-    return nullptr;
-  }
-  if ((*address)->ip()->isUniqueLocalAddress()) {
-    ENVOY_LOG(trace, "Ignoring unique-local address: {}.", (*address)->asString());
-    return nullptr;
-  }
-  if ((*address)->ip()->isSiteLocalAddress()) {
-    ENVOY_LOG(trace, "Ignoring site-local address: {}.", (*address)->asString());
-    return nullptr;
-  }
-  if ((*address)->ip()->isTeredoAddress()) {
-    ENVOY_LOG(trace, "Ignoring teredo address: {}.", (*address)->asString());
-    return nullptr;
+  if (Runtime::runtimeFeatureEnabled(
+          "envoy.reloadable_features.mobile_ipv6_probe_simple_filtering")) {
+    if ((*address)->ip() == nullptr) {
+      ENVOY_LOG(trace, "Local address is not an IP address: {}.", (*address)->asString());
+      return nullptr;
+    }
+    if ((*address)->ip()->isLinkLocalAddress()) {
+      ENVOY_LOG(trace, "Ignoring link-local address: {}.", (*address)->asString());
+      return nullptr;
+    }
+    if (Runtime::runtimeFeatureEnabled(
+            "envoy.reloadable_features.mobile_ipv6_probe_advanced_filtering")) {
+      if ((*address)->ip()->isUniqueLocalAddress()) {
+        ENVOY_LOG(trace, "Ignoring unique-local address: {}.", (*address)->asString());
+        return nullptr;
+      }
+      if ((*address)->ip()->isSiteLocalAddress()) {
+        ENVOY_LOG(trace, "Ignoring site-local address: {}.", (*address)->asString());
+        return nullptr;
+      }
+      if ((*address)->ip()->isTeredoAddress()) {
+        ENVOY_LOG(trace, "Ignoring teredo address: {}.", (*address)->asString());
+        return nullptr;
+      }
+    }
   }
 
   ENVOY_LOG(trace, "Found {} connectivity.", domain == AF_INET6 ? "IPv6" : "IPv4");

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -136,6 +136,12 @@ FALSE_RUNTIME_GUARD(envoy_reloadable_features_use_canonical_suffix_for_quic_brok
 FALSE_RUNTIME_GUARD(envoy_reloadable_features_use_canonical_suffix_for_srtt);
 // TODO(fredyw): Remove after done with debugging.
 FALSE_RUNTIME_GUARD(envoy_reloadable_features_log_ip_families_on_network_error);
+// TODO(abeyad): Flip to true after prod testing. Simple filtering applies to link-local addresses
+// only.
+FALSE_RUNTIME_GUARD(envoy_reloadable_features_mobile_ipv6_probe_simple_filtering);
+// TODO(abeyad): Flip to true after prod testing. Advanced filtering applies to all IP reserved
+// range addresses.
+FALSE_RUNTIME_GUARD(envoy_reloadable_features_mobile_ipv6_probe_advanced_filtering);
 // TODO(botengyao): flip to true after canarying the feature internally without problems.
 FALSE_RUNTIME_GUARD(envoy_reloadable_features_connection_close_through_filter_manager);
 // TODO(adisuissa): flip to true after all xDS types use the new subscription


### PR DESCRIPTION
Adds two runtime guards to experiment with filtering reserved IP ranges in the IPv6 probing check that were introduced in https://github.com/envoyproxy/envoy/pull/40345:

  1. `envoy_reloadable_features_mobile_ipv6_probe_simple_filtering`
  2. `envoy_reloadable_features_mobile_ipv6_probe_advanced_filtering`