### PR TITLE
Fixes grpc-web filter content length handling

### DIFF
--- a/source/extensions/filters/http/grpc_web/grpc_web_filter.cc
+++ b/source/extensions/filters/http/grpc_web/grpc_web_filter.cc
@@ -251,6 +251,10 @@ Http::FilterHeadersStatus GrpcWebFilter::encodeHeaders(Http::ResponseHeaderMap& 
   needs_transformation_for_non_proto_encoded_response_ =
       needsTransformationForNonProtoEncodedResponse(headers, end_stream);
 
+  // If upstream sets a content length, we must remove it because we're going to change the
+  // length of the body
+  headers.removeContentLength();
+
   if (is_text_response_) {
     headers.setReferenceContentType(Http::Headers::get().ContentTypeValues.GrpcWebTextProto);
   } else {

--- a/test/extensions/filters/http/grpc_web/grpc_web_filter_test.cc
+++ b/test/extensions/filters/http/grpc_web/grpc_web_filter_test.cc
@@ -502,6 +502,17 @@ TEST_P(GrpcWebFilterTest, MediaTypeWithParameter) {
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_.encodeData(data, false));
 }
 
+TEST_P(GrpcWebFilterTest, RemoveResponseContentLength) {
+  Http::TestRequestHeaderMapImpl request_headers{
+      {"content-type", Http::Headers::get().ContentTypeValues.GrpcWeb}, {":path", "/"}};
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.decodeHeaders(request_headers, false));
+
+  Http::TestResponseHeaderMapImpl response_headers{
+      {":status", "200"}, {"content-type", "application/grpc"}, {"content-length", "123"}};
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.encodeHeaders(response_headers, false));
+  EXPECT_EQ(nullptr, response_headers.ContentLength());
+}
+
 TEST_P(GrpcWebFilterTest, Unary) {
   // Tests request headers.
   request_headers_.addCopy(Http::Headers::get().ContentType, requestContentType());


### PR DESCRIPTION
Fixes #40097

This fixes a bug in the grpc web filter where if an upstream grpc server sends a response with the content length, the grpc web filter modifies the body without updating or removing the content length. The result is that some clients truncate the body, other clients throw a protocol error, and if the downstream protocol is HTTP/1.1, there's a potential for HTTP response splitting.

I have attempted to run the tests, but multiple attempts to run the tests in docker have caused my machine to go to 100% CPU for multiple hours before the machine crashes. Running the tests outside of docker seem to have dependency issues.