### PR TITLE
add override knob for stream flush timeout

### DIFF
--- a/api/envoy/config/route/v3/route_components.proto
+++ b/api/envoy/config/route/v3/route_components.proto
@@ -793,7 +793,7 @@ message CorsPolicy {
   google.protobuf.BoolValue forward_not_matching_preflights = 13;
 }
 
-// [#next-free-field: 42]
+// [#next-free-field: 43]
 message RouteAction {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.route.RouteAction";
 
@@ -1318,7 +1318,27 @@ message RouteAction {
   // If the :ref:`overload action <config_overload_manager_overload_actions>` "envoy.overload_actions.reduce_timeouts"
   // is configured, this timeout is scaled according to the value for
   // :ref:`HTTP_DOWNSTREAM_STREAM_IDLE <envoy_v3_api_enum_value_config.overload.v3.ScaleTimersOverloadActionConfig.TimerType.HTTP_DOWNSTREAM_STREAM_IDLE>`.
+  //
+  // This timeout may also be used in place of ``flush_timeout`` in very specific cases. See the
+  // documentation for ``flush_timeout`` for more details.
   google.protobuf.Duration idle_timeout = 24;
+
+  // Specifies the codec stream flush timeout for the route.
+  //
+  // If not specified, the first preference is the global :ref:`stream_flush_timeout
+  // <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.stream_flush_timeout>`,
+  // but only if explicitly configured.
+  //
+  // If neither the explicit HCM-wide flush timeout nor this route-specific flush timeout is configured,
+  // the route's stream idle timeout is reused for this timeout. This is for
+  // backwards compatibility since both behaviors were historically controlled by the one timeout.
+  //
+  // If the route also does not have an idle timeout configured, the global :ref:`stream_idle_timeout
+  // <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.stream_idle_timeout>`. used, again
+  // for backwards compatibility. That timeout defaults to 5 minutes.
+  //
+  // A value of 0 via any of the above paths will completely disable the timeout for a given route.
+  google.protobuf.Duration flush_timeout = 42;
 
   // Specifies how to send request over TLS early data.
   // If absent, allows `safe HTTP requests <https://www.rfc-editor.org/rfc/rfc7231#section-4.2.1>`_ to be sent on early data.

--- a/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
+++ b/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
@@ -37,7 +37,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // HTTP connection manager :ref:`configuration overview <config_http_conn_man>`.
 // [#extension: envoy.filters.network.http_connection_manager]
 
-// [#next-free-field: 59]
+// [#next-free-field: 60]
 message HttpConnectionManager {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager";
@@ -527,16 +527,6 @@ message HttpConnectionManager {
   // is terminated with a 408 Request Timeout error code if no upstream response
   // header has been received, otherwise a stream reset occurs.
   //
-  // This timeout also specifies the amount of time that Envoy will wait for the peer to open enough
-  // window to write any remaining stream data once the entirety of stream data (local end stream is
-  // true) has been buffered pending available window. In other words, this timeout defends against
-  // a peer that does not release enough window to completely write the stream, even though all
-  // data has been proxied within available flow control windows. If the timeout is hit in this
-  // case, the :ref:`tx_flush_timeout <config_http_conn_man_stats_per_codec>` counter will be
-  // incremented. Note that :ref:`max_stream_duration
-  // <envoy_v3_api_field_config.core.v3.HttpProtocolOptions.max_stream_duration>` does not apply to
-  // this corner case.
-  //
   // If the :ref:`overload action <config_overload_manager_overload_actions>` "envoy.overload_actions.reduce_timeouts"
   // is configured, this timeout is scaled according to the value for
   // :ref:`HTTP_DOWNSTREAM_STREAM_IDLE <envoy_v3_api_enum_value_config.overload.v3.ScaleTimersOverloadActionConfig.TimerType.HTTP_DOWNSTREAM_STREAM_IDLE>`.
@@ -549,8 +539,28 @@ message HttpConnectionManager {
   //
   // A value of 0 will completely disable the connection manager stream idle
   // timeout, although per-route idle timeout overrides will continue to apply.
+  //
+  // This timeout is also used as the default value for :ref:`stream_flush_timeout
+  // <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.stream_flush_timeout>`.
   google.protobuf.Duration stream_idle_timeout = 24
       [(udpa.annotations.security).configure_for_untrusted_downstream = true];
+
+  // The stream flush timeout for connections managed by the connection manager.
+  //
+  // If not specified, the value of stream_idle_timeout is used. This is for backwards compatibility
+  // since this was the original behavior. In essence this timeout is an override for the
+  // stream_idle_timeout that applies specifically to the end of stream flush case.
+  //
+  // This timeout specifies the amount of time that Envoy will wait for the peer to open enough
+  // window to write any remaining stream data once the entirety of stream data (local end stream is
+  // true) has been buffered pending available window. In other words, this timeout defends against
+  // a peer that does not release enough window to completely write the stream, even though all
+  // data has been proxied within available flow control windows. If the timeout is hit in this
+  // case, the :ref:`tx_flush_timeout <config_http_conn_man_stats_per_codec>` counter will be
+  // incremented. Note that :ref:`max_stream_duration
+  // <envoy_v3_api_field_config.core.v3.HttpProtocolOptions.max_stream_duration>` does not apply to
+  // this corner case.
+  google.protobuf.Duration stream_flush_timeout = 59;
 
   // The amount of time that Envoy will wait for the entire request to be received.
   // The timer is activated when the request is initiated, and is disarmed when the last byte of the

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -272,6 +272,9 @@ new_features:
 - area: http
   change: |
     Added ``upstream_rq_per_cx`` histogram to track requests per connection for monitoring connection reuse efficiency.
-
+- area: http
+  change: |
+    Added :ref:`stream_flush_timeout <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.stream_flush_timeout>`
+    to allow for configuring a stream flush timeout independently from the stream idle timeout.
 
 deprecated:

--- a/envoy/router/router.h
+++ b/envoy/router/router.h
@@ -1034,6 +1034,12 @@ public:
   virtual absl::optional<std::chrono::milliseconds> idleTimeout() const PURE;
 
   /**
+   * @return optional<std::chrono::milliseconds> the route's flush timeout. Zero indicates a
+   *         disabled idle timeout, while nullopt indicates deference to the global timeout.
+   */
+  virtual absl::optional<std::chrono::milliseconds> flushTimeout() const PURE;
+
+  /**
    * @return true if new style max_stream_duration config should be used over the old style.
    */
   virtual bool usingNewTimeouts() const PURE;

--- a/source/common/http/codec_helper.h
+++ b/source/common/http/codec_helper.h
@@ -117,14 +117,14 @@ public:
 
 protected:
   void setFlushTimeout(std::chrono::milliseconds timeout) override {
-    stream_idle_timeout_ = timeout;
+    stream_flush_timeout_ = timeout;
   }
 
   void createPendingFlushTimer() {
     ASSERT(stream_idle_timer_ == nullptr);
-    if (stream_idle_timeout_.count() > 0) {
+    if (stream_flush_timeout_.count() > 0) {
       stream_idle_timer_ = dispatcher_.createTimer([this] { onPendingFlushTimer(); });
-      stream_idle_timer_->enableTimer(stream_idle_timeout_);
+      stream_idle_timer_->enableTimer(stream_flush_timeout_);
     }
   }
 
@@ -137,7 +137,7 @@ protected:
 private:
   Event::Dispatcher& dispatcher_;
   // See HttpConnectionManager.stream_idle_timeout.
-  std::chrono::milliseconds stream_idle_timeout_{};
+  std::chrono::milliseconds stream_flush_timeout_{};
   Event::TimerPtr stream_idle_timer_;
 };
 

--- a/source/common/http/conn_manager_config.h
+++ b/source/common/http/conn_manager_config.h
@@ -312,6 +312,12 @@ public:
   virtual std::chrono::milliseconds streamIdleTimeout() const PURE;
 
   /**
+   * @return per-stream flush timeout for incoming connection manager connections. Zero indicates a
+   *         disabled idle timeout.
+   */
+  virtual absl::optional<std::chrono::milliseconds> streamFlushTimeout() const PURE;
+
+  /**
    * @return request timeout for incoming connection manager connections. Zero indicates
    *         a disabled request timeout.
    */

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -334,6 +334,7 @@ private:
 
     void refreshDurationTimeout();
     void refreshIdleTimeout();
+    void refreshFlushTimeout();
     void refreshAccessLogFlushTimer();
     void refreshTracing();
 
@@ -473,6 +474,11 @@ private:
     Event::TimerPtr access_log_flush_timer_;
 
     std::chrono::milliseconds idle_timeout_ms_{};
+    // If an explicit global flush timeout is set, never override it with the route entry idle
+    // timeout. If there is no explicit global flush timeout, then override with the route entry
+    // idle timeout if it exists. This is to prevent breaking existing user expectations that the
+    // flush timeout is the same as the idle timeout.
+    const bool has_explicit_global_flush_timeout_{false};
     State state_;
 
     // Snapshot of the route configuration at the time of request is started. This is used to ensure

--- a/source/common/http/null_route_impl.h
+++ b/source/common/http/null_route_impl.h
@@ -174,6 +174,7 @@ protected:
   }
   bool usingNewTimeouts() const override { return false; }
   absl::optional<std::chrono::milliseconds> idleTimeout() const override { return absl::nullopt; }
+  absl::optional<std::chrono::milliseconds> flushTimeout() const override { return absl::nullopt; }
   absl::optional<std::chrono::milliseconds> maxStreamDuration() const override {
     return absl::nullopt;
   }

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -1188,6 +1188,7 @@ RouteEntryImplBase::OptionalTimeouts RouteEntryImplBase::buildOptionalTimeouts(
   // Calculate how many values are actually set, to initialize `OptionalTimeouts` packed_struct,
   // avoiding memory re-allocation on each set() call.
   int num_timeouts_set = route.has_idle_timeout() ? 1 : 0;
+  num_timeouts_set += route.has_flush_timeout() ? 1 : 0;
   num_timeouts_set += route.has_max_grpc_timeout() ? 1 : 0;
   num_timeouts_set += route.has_grpc_timeout_offset() ? 1 : 0;
   if (route.has_max_stream_duration()) {
@@ -1199,6 +1200,10 @@ RouteEntryImplBase::OptionalTimeouts RouteEntryImplBase::buildOptionalTimeouts(
   if (route.has_idle_timeout()) {
     timeouts.set<OptionalTimeoutNames::IdleTimeout>(
         std::chrono::milliseconds(PROTOBUF_GET_MS_REQUIRED(route, idle_timeout)));
+  }
+  if (route.has_flush_timeout()) {
+    timeouts.set<OptionalTimeoutNames::FlushTimeout>(
+        std::chrono::milliseconds(PROTOBUF_GET_MS_REQUIRED(route, flush_timeout)));
   }
   if (route.has_max_grpc_timeout()) {
     timeouts.set<OptionalTimeoutNames::MaxGrpcTimeout>(

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -747,12 +747,16 @@ public:
     GrpcTimeoutHeaderMax,
     GrpcTimeoutHeaderOffset,
     MaxGrpcTimeout,
-    GrpcTimeoutOffset
+    GrpcTimeoutOffset,
+    FlushTimeout,
   };
-  using OptionalTimeouts = PackedStruct<std::chrono::milliseconds, 6, OptionalTimeoutNames>;
+  using OptionalTimeouts = PackedStruct<std::chrono::milliseconds, 7, OptionalTimeoutNames>;
 
   absl::optional<std::chrono::milliseconds> idleTimeout() const override {
     return getOptionalTimeout<OptionalTimeoutNames::IdleTimeout>();
+  }
+  absl::optional<std::chrono::milliseconds> flushTimeout() const override {
+    return getOptionalTimeout<OptionalTimeoutNames::FlushTimeout>();
   }
   absl::optional<std::chrono::milliseconds> maxStreamDuration() const override {
     return getOptionalTimeout<OptionalTimeoutNames::MaxStreamDuration>();

--- a/source/common/router/delegating_route_impl.cc
+++ b/source/common/router/delegating_route_impl.cc
@@ -93,6 +93,10 @@ absl::optional<std::chrono::milliseconds> DelegatingRouteEntry::idleTimeout() co
   return base_route_entry_->idleTimeout();
 }
 
+absl::optional<std::chrono::milliseconds> DelegatingRouteEntry::flushTimeout() const {
+  return base_route_entry_->flushTimeout();
+}
+
 bool DelegatingRouteEntry::usingNewTimeouts() const {
   return base_route_entry_->usingNewTimeouts();
 }

--- a/source/common/router/delegating_route_impl.h
+++ b/source/common/router/delegating_route_impl.h
@@ -108,6 +108,7 @@ public:
   const std::vector<Router::ShadowPolicyPtr>& shadowPolicies() const override;
   std::chrono::milliseconds timeout() const override;
   absl::optional<std::chrono::milliseconds> idleTimeout() const override;
+  absl::optional<std::chrono::milliseconds> flushTimeout() const override;
   bool usingNewTimeouts() const override;
   absl::optional<std::chrono::milliseconds> maxStreamDuration() const override;
   absl::optional<std::chrono::milliseconds> grpcTimeoutHeaderMax() const override;

--- a/source/extensions/filters/network/http_connection_manager/config.cc
+++ b/source/extensions/filters/network/http_connection_manager/config.cc
@@ -395,6 +395,8 @@ HttpConnectionManagerConfig::HttpConnectionManagerConfig(
           PROTOBUF_GET_OPTIONAL_MS(config.common_http_protocol_options(), max_stream_duration)),
       stream_idle_timeout_(
           PROTOBUF_GET_MS_OR_DEFAULT(config, stream_idle_timeout, StreamIdleTimeoutMs)),
+      stream_flush_timeout_(
+          PROTOBUF_GET_MS_OR_DEFAULT(config, stream_flush_timeout, stream_idle_timeout_.count())),
       request_timeout_(PROTOBUF_GET_MS_OR_DEFAULT(config, request_timeout, RequestTimeoutMs)),
       request_headers_timeout_(
           PROTOBUF_GET_MS_OR_DEFAULT(config, request_headers_timeout, RequestHeaderTimeoutMs)),

--- a/source/extensions/filters/network/http_connection_manager/config.h
+++ b/source/extensions/filters/network/http_connection_manager/config.h
@@ -184,6 +184,9 @@ public:
     return http1_safe_max_connection_duration_;
   }
   std::chrono::milliseconds streamIdleTimeout() const override { return stream_idle_timeout_; }
+  absl::optional<std::chrono::milliseconds> streamFlushTimeout() const override {
+    return stream_flush_timeout_;
+  }
   std::chrono::milliseconds requestTimeout() const override { return request_timeout_; }
   std::chrono::milliseconds requestHeadersTimeout() const override {
     return request_headers_timeout_;
@@ -330,6 +333,7 @@ private:
   const bool http1_safe_max_connection_duration_;
   absl::optional<std::chrono::milliseconds> max_stream_duration_;
   std::chrono::milliseconds stream_idle_timeout_;
+  absl::optional<std::chrono::milliseconds> stream_flush_timeout_;
   std::chrono::milliseconds request_timeout_;
   std::chrono::milliseconds request_headers_timeout_;
   Router::RouteConfigProviderSharedPtr route_config_provider_;

--- a/source/server/admin/admin.h
+++ b/source/server/admin/admin.h
@@ -152,6 +152,9 @@ public:
   uint32_t maxRequestHeadersKb() const override { return max_request_headers_kb_; }
   uint32_t maxRequestHeadersCount() const override { return max_request_headers_count_; }
   std::chrono::milliseconds streamIdleTimeout() const override { return {}; }
+  absl::optional<std::chrono::milliseconds> streamFlushTimeout() const override {
+    return std::nullopt;
+  }
   std::chrono::milliseconds requestTimeout() const override { return {}; }
   std::chrono::milliseconds requestHeadersTimeout() const override { return {}; }
   std::chrono::milliseconds delayedCloseTimeout() const override { return {}; }

--- a/test/common/http/conn_manager_impl_fuzz_test.cc
+++ b/test/common/http/conn_manager_impl_fuzz_test.cc
@@ -160,6 +160,9 @@ public:
     return max_stream_duration_;
   }
   std::chrono::milliseconds streamIdleTimeout() const override { return stream_idle_timeout_; }
+  absl::optional<std::chrono::milliseconds> streamFlushTimeout() const override {
+    return stream_flush_timeout_;
+  }
   std::chrono::milliseconds requestTimeout() const override { return request_timeout_; }
   std::chrono::milliseconds requestHeadersTimeout() const override {
     return request_headers_timeout_;
@@ -282,6 +285,7 @@ public:
   bool http1_safe_max_connection_duration_{false};
   absl::optional<std::chrono::milliseconds> max_stream_duration_;
   std::chrono::milliseconds stream_idle_timeout_{};
+  std::chrono::milliseconds stream_flush_timeout_{};
   std::chrono::milliseconds request_timeout_{};
   std::chrono::milliseconds request_headers_timeout_{};
   std::chrono::milliseconds delayed_close_timeout_{};

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -3472,6 +3472,104 @@ TEST_F(HttpConnectionManagerImplTest, PerStreamIdleTimeoutRouteOverride) {
   filter_callbacks_.connection_.raiseEvent(Network::ConnectionEvent::RemoteClose);
 }
 
+// Per-stream flush and idle timeouts have a somewhat complex precedence order, so here we test
+// every combination of global and per-route flush and idle timeouts. Note that global idle timeout
+// not being set or unset doesn't affect the behavior of the flush timeout since it's the same as
+// the idle timeout being set explicitly to the default value. For this reason it's a constant in
+// the below tests.
+class IdleAndFlushTimeoutTestFixture : public HttpConnectionManagerImplMixin,
+                                       public testing::TestWithParam<std::tuple<bool, bool, bool>> {
+public:
+  IdleAndFlushTimeoutTestFixture()
+      : global_flush_timeout_set_(std::get<0>(GetParam())),
+        route_flush_timeout_set_(std::get<1>(GetParam())),
+        route_idle_timeout_set_(std::get<2>(GetParam())) {
+    if (route_flush_timeout_set_) {
+      route_flush_timeout_ = std::chrono::milliseconds(30);
+    }
+    if (route_idle_timeout_set_) {
+      route_idle_timeout_ = std::chrono::milliseconds(40);
+    }
+  }
+
+protected:
+  const bool global_flush_timeout_set_;
+  const bool route_flush_timeout_set_;
+  const bool route_idle_timeout_set_;
+  absl::optional<std::chrono::milliseconds> global_flush_timeout_{absl::nullopt};
+  absl::optional<std::chrono::milliseconds> route_flush_timeout_{absl::nullopt};
+  absl::optional<std::chrono::milliseconds> route_idle_timeout_{absl::nullopt};
+};
+
+INSTANTIATE_TEST_SUITE_P(IdleAndFlushTimeoutTestFixture, IdleAndFlushTimeoutTestFixture,
+                         testing::Combine(testing::Bool(), testing::Bool(), testing::Bool()),
+                         [](const testing::TestParamInfo<std::tuple<bool, bool, bool>>& info) {
+                           return absl::StrCat(std::get<0>(info.param) ? "GlobalFlushTimeoutSet"
+                                                                       : "NoGlobalFlushTimeout",
+                                               std::get<1>(info.param) ? "RouteFlushTimeoutSet"
+                                                                       : "NoRouteFlushTimeout",
+                                               std::get<2>(info.param) ? "RouteIdleTimeoutSet"
+                                                                       : "NoRouteIdleTimeout");
+                         });
+
+TEST_P(IdleAndFlushTimeoutTestFixture, TestAllCases) {
+  stream_idle_timeout_ = std::chrono::milliseconds(10); // Constant across all cases.
+  if (global_flush_timeout_set_) {
+    stream_flush_timeout_ = std::chrono::milliseconds(20);
+  }
+  setup();
+  ON_CALL(route_config_provider_.route_config_->route_->route_entry_, flushTimeout())
+      .WillByDefault(Return(route_flush_timeout_));
+  ON_CALL(route_config_provider_.route_config_->route_->route_entry_, idleTimeout())
+      .WillByDefault(Return(route_idle_timeout_));
+
+  EXPECT_CALL(*codec_, dispatch(_))
+      .WillRepeatedly(Invoke([&](Buffer::Instance& data) -> Http::Status {
+        // Both timers will get initialized in all cases here. The value of the flush timeout
+        // just depends on whether it was set explicitly or inherited from the idle timeout.
+        EXPECT_CALL(response_encoder_.stream_,
+                    setFlushTimeout(global_flush_timeout_set_ ? stream_flush_timeout_.value()
+                                                              : stream_idle_timeout_));
+        Event::MockTimer* idle_timer = setUpTimer();
+        EXPECT_CALL(*idle_timer, enableTimer(stream_idle_timeout_, _));
+        decoder_ = &conn_manager_->newStream(response_encoder_);
+
+        RequestHeaderMapPtr headers{new TestRequestHeaderMapImpl{
+            {":authority", "host"}, {":path", "/"}, {":method", "GET"}}};
+
+        if (route_flush_timeout_set_) {
+          // If a route flush timeout is set it will ALWAYS be used.
+          EXPECT_CALL(response_encoder_.stream_, setFlushTimeout(route_flush_timeout_.value()));
+        } else if (!global_flush_timeout_set_ && route_idle_timeout_set_) {
+          // If no route flush timeout is set and the global flush timeout was inherited from the
+          // idle timeout, adopt the route idle timeout. This is for backwards compatibility with
+          // existing Envoy behavior.
+          EXPECT_CALL(response_encoder_.stream_, setFlushTimeout(route_idle_timeout_.value()));
+        } else {
+          // One of the following is true:
+          // 1. No route flush or idle timeout is set, so there's nothing to do here.
+          // 2. The global flush timeout is set explicitly, so the route idle timeout is ignored.
+          EXPECT_CALL(response_encoder_.stream_, setFlushTimeout(_)).Times(0);
+        }
+
+        EXPECT_CALL(*idle_timer, disableTimer());
+        EXPECT_CALL(*idle_timer, enableTimer(route_idle_timeout_set_ ? route_idle_timeout_.value()
+                                                                     : stream_idle_timeout_,
+                                             _));
+
+        decoder_->decodeHeaders(std::move(headers), false);
+
+        data.drain(4);
+        return Http::okStatus();
+      }));
+
+  Buffer::OwnedImpl fake_input("1234");
+  conn_manager_->onData(fake_input, false);
+
+  EXPECT_EQ(0U, stats_.named_.downstream_rq_idle_timeout_.value());
+  filter_callbacks_.connection_.raiseEvent(Network::ConnectionEvent::RemoteClose);
+}
+
 // Per-route zero timeout overrides the global stream idle timeout.
 TEST_F(HttpConnectionManagerImplTest, PerStreamIdleTimeoutRouteZeroOverride) {
   stream_idle_timeout_ = std::chrono::milliseconds(10);

--- a/test/common/http/conn_manager_impl_test_base.cc
+++ b/test/common/http/conn_manager_impl_test_base.cc
@@ -61,6 +61,9 @@ public:
   std::chrono::milliseconds streamIdleTimeout() const override {
     return parent_.streamIdleTimeout();
   }
+  absl::optional<std::chrono::milliseconds> streamFlushTimeout() const override {
+    return parent_.streamFlushTimeout();
+  }
   std::chrono::milliseconds requestTimeout() const override { return parent_.requestTimeout(); }
   std::chrono::milliseconds requestHeadersTimeout() const override {
     return parent_.requestHeadersTimeout();

--- a/test/common/http/conn_manager_impl_test_base.h
+++ b/test/common/http/conn_manager_impl_test_base.h
@@ -122,6 +122,9 @@ public:
     return http1_safe_max_connection_duration_;
   }
   std::chrono::milliseconds streamIdleTimeout() const override { return stream_idle_timeout_; }
+  absl::optional<std::chrono::milliseconds> streamFlushTimeout() const override {
+    return stream_flush_timeout_;
+  }
   std::chrono::milliseconds requestTimeout() const override { return request_timeout_; }
   std::chrono::milliseconds requestHeadersTimeout() const override {
     return request_headers_timeout_;
@@ -285,6 +288,7 @@ public:
   absl::optional<std::chrono::milliseconds> max_connection_duration_;
   bool http1_safe_max_connection_duration_{false};
   std::chrono::milliseconds stream_idle_timeout_{};
+  absl::optional<std::chrono::milliseconds> stream_flush_timeout_{};
   std::chrono::milliseconds request_timeout_{};
   std::chrono::milliseconds request_headers_timeout_{};
   std::chrono::milliseconds delayed_close_timeout_{};

--- a/test/integration/multiplexed_integration_test.cc
+++ b/test/integration/multiplexed_integration_test.cc
@@ -254,6 +254,51 @@ TEST_P(MultiplexedIntegrationTest, CodecStreamIdleTimeout) {
   ASSERT_TRUE(response->waitForReset());
 }
 
+// Test that the codec stream flush timeout can be overridden independently from
+// the connection manager stream idle timeout.
+TEST_P(MultiplexedIntegrationTest, CodecStreamIdleTimeoutOverride) {
+  config_helper_.setBufferLimits(1024, 1024);
+  config_helper_.addConfigModifier(
+      [&](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
+              hcm) -> void {
+        // Disable the generic stream idle timeout. This will be overridden by the
+        // stream_flush_timeout and the test should work exactly the same as the
+        // CodecStreamIdleTimeout test.
+        hcm.mutable_stream_idle_timeout()->set_seconds(0);
+        hcm.mutable_stream_idle_timeout()->set_nanos(0);
+
+        hcm.mutable_stream_flush_timeout()->set_seconds(0);
+        constexpr uint64_t FlushTimeoutMs = 400;
+        hcm.mutable_stream_flush_timeout()->set_nanos(FlushTimeoutMs * 1000 * 1000);
+      });
+  initialize();
+  const size_t stream_flow_control_window =
+      downstream_protocol_ == Http::CodecType::HTTP3 ? 32 * 1024 : 65535;
+  envoy::config::core::v3::Http2ProtocolOptions http2_options =
+      ::Envoy::Http2::Utility::initializeAndValidateOptions(
+          envoy::config::core::v3::Http2ProtocolOptions())
+          .value();
+  http2_options.mutable_initial_stream_window_size()->set_value(stream_flow_control_window);
+#if 1 // changed through copybara ifdef ENVOY_ENABLE_QUIC
+  if (downstream_protocol_ == Http::CodecType::HTTP3) {
+    dynamic_cast<Quic::PersistentQuicInfoImpl&>(*quic_connection_persistent_info_)
+        .quic_config_.SetInitialStreamFlowControlWindowToSend(stream_flow_control_window);
+    dynamic_cast<Quic::PersistentQuicInfoImpl&>(*quic_connection_persistent_info_)
+        .quic_config_.SetInitialSessionFlowControlWindowToSend(stream_flow_control_window);
+  }
+#endif
+  codec_client_ = makeRawHttpConnection(makeClientConnection(lookupPort("http")), http2_options);
+  auto response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
+  waitForNextUpstreamRequest();
+  upstream_request_->encodeHeaders(default_response_headers_, false);
+  upstream_request_->encodeData(stream_flow_control_window + 2000, true);
+  std::string flush_timeout_counter(downstreamProtocol() == Http::CodecType::HTTP3
+                                        ? "http3.tx_flush_timeout"
+                                        : "http2.tx_flush_timeout");
+  test_server_->waitForCounterEq(flush_timeout_counter, 1);
+  ASSERT_TRUE(response->waitForReset());
+}
+
 TEST_P(MultiplexedIntegrationTest, Http2DownstreamKeepalive) {
   EXCLUDE_DOWNSTREAM_HTTP3; // Http3 keepalive doesn't timeout and close connection.
   constexpr uint64_t interval_ms = 1;

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -652,6 +652,7 @@ public:
   MOCK_METHOD(bool, http1SafeMaxConnectionDuration, (), (const));
   MOCK_METHOD(absl::optional<std::chrono::milliseconds>, maxStreamDuration, (), (const));
   MOCK_METHOD(std::chrono::milliseconds, streamIdleTimeout, (), (const));
+  MOCK_METHOD(absl::optional<std::chrono::milliseconds>, streamFlushTimeout, (), (const));
   MOCK_METHOD(std::chrono::milliseconds, requestTimeout, (), (const));
   MOCK_METHOD(std::chrono::milliseconds, requestHeadersTimeout, (), (const));
   MOCK_METHOD(std::chrono::milliseconds, delayedCloseTimeout, (), (const));

--- a/test/mocks/router/mocks.h
+++ b/test/mocks/router/mocks.h
@@ -436,6 +436,7 @@ public:
   MOCK_METHOD(const std::vector<ShadowPolicyPtr>&, shadowPolicies, (), (const));
   MOCK_METHOD(std::chrono::milliseconds, timeout, (), (const));
   MOCK_METHOD(absl::optional<std::chrono::milliseconds>, idleTimeout, (), (const));
+  MOCK_METHOD(absl::optional<std::chrono::milliseconds>, flushTimeout, (), (const));
   MOCK_METHOD(bool, usingNewTimeouts, (), (const));
   MOCK_METHOD(absl::optional<std::chrono::milliseconds>, maxStreamDuration, (), (const));
   MOCK_METHOD(absl::optional<std::chrono::milliseconds>, grpcTimeoutHeaderMax, (), (const));
@@ -556,6 +557,7 @@ public:
   MOCK_METHOD(const std::vector<ShadowPolicyPtr>&, shadowPolicies, (), (const));
   MOCK_METHOD(std::chrono::milliseconds, timeout, (), (const));
   MOCK_METHOD(absl::optional<std::chrono::milliseconds>, idleTimeout, (), (const));
+  MOCK_METHOD(absl::optional<std::chrono::milliseconds>, flushTimeout, (), (const));
   MOCK_METHOD(bool, usingNewTimeouts, (), (const));
   MOCK_METHOD(absl::optional<std::chrono::milliseconds>, maxStreamDuration, (), (const));
   MOCK_METHOD(absl::optional<std::chrono::milliseconds>, grpcTimeoutHeaderMax, (), (const));


### PR DESCRIPTION
Commit Message: add override knob for stream flush timeout
Additional Description:

Today it is not possible to configure the stream idle timeout and the stream flush timeout (i.e. the time envoy will wait for the downstream client to open enough window for its response) independently. This PR makes it possible to configure an explicit flush timeout. It also maintains the current behavior of allowing you to configure it just through the stream idle timeout knob for backwards compatibility.

Risk Level: low