### PR TITLE
Use gmock mock functions for testing callbacks

### DIFF
--- a/test/common/upstream/BUILD
+++ b/test/common/upstream/BUILD
@@ -542,7 +542,6 @@ envoy_cc_test(
         "//source/extensions/upstreams/tcp:config",
         "//source/server:transport_socket_config_lib",
         "//test/common/stats:stat_test_utility_lib",
-        "//test/mocks:common_lib",
         "//test/mocks/local_info:local_info_mocks",
         "//test/mocks/network:network_mocks",
         "//test/mocks/protobuf:protobuf_mocks",

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -36,7 +36,6 @@
 #include "test/common/stats/stat_test_utility.h"
 #include "test/common/upstream/test_local_address_selector.h"
 #include "test/common/upstream/utility.h"
-#include "test/mocks/common.h"
 #include "test/mocks/http/mocks.h"
 #include "test/mocks/network/mocks.h"
 #include "test/mocks/protobuf/mocks.h"


### PR DESCRIPTION
Commit Message: Use gmock mock functions for testing callbacks
Additional Description: This is a testing-the-waters PR, is this change desirable? If so I'll do the same to the rest of the file. The main hope is that a good example existing would propagate next time someone cargo-cults "how do I test this kind of thing".
(This change also slightly improves the test behavior in that now it only passes if the initialize callback is called during `initialize`, where before the test would also have passed if the initialize callback was called during `dns_callback_`. This distinction seems like it might be important based on the name of the test case and the comment `Initialized without completing DNS resolution.`.)
Risk Level: test-only
Testing: test-only
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
