### PR TITLE
Add empty check for ":path" header to fix fuzz err

### DIFF
--- a/source/extensions/filters/http/grpc_json_reverse_transcoder/filter.cc
+++ b/source/extensions/filters/http/grpc_json_reverse_transcoder/filter.cc
@@ -381,6 +381,18 @@ FilterHeadersStatus GrpcJsonReverseTranscoderFilter::decodeHeaders(RequestHeader
   InitPerRouteConfig();
 
   absl::string_view path = headers.getPathValue();
+  if (path.empty()) {
+    ENVOY_STREAM_LOG(error, "Request path is empty", *decoder_callbacks_);
+    decoder_callbacks_->sendLocalReply(
+        Code::BadRequest, "Request path is empty", nullptr,
+        Status::WellKnownGrpcStatus::InvalidArgument,
+        absl::StrCat(
+            RcDetails::get().grpc_transcode_failed_early, "{",
+            StringUtil::replaceAllEmptySpace(
+                MessageUtil::codeEnumToString(absl::StatusCode::kNotFound)),
+            "}"));
+    return FilterHeadersStatus::StopIteration;
+  }
   const auto* method_descriptor = per_route_config_->GetMethodDescriptor(path);
   if (method_descriptor == nullptr) {
     ENVOY_STREAM_LOG(error, "Couldn't find a gRPC method matching {}", *decoder_callbacks_, path);


### PR DESCRIPTION
Commit Message: Add empty check for ":path" header to fix fuzz err
Additional Description: Fuzz error was discovered, which was a timeout/crash error. It crashes if the :path header is empty. Envoy will reject such request.
Risk Level: Low
Testing: Using existing testing infra, /test/extensions/filters/http/common/fuzz:filter_fuzz_test
Docs Changes:
Release Notes:
Platform Specific Features:
