### PR TITLE
tls inspector test: change the test description for ContinueOnListenerTimeout

### DIFF
--- a/test/extensions/filters/listener/tls_inspector/tls_inspector_integration_test.cc
+++ b/test/extensions/filters/listener/tls_inspector/tls_inspector_integration_test.cc
@@ -250,9 +250,8 @@ TEST_P(TlsInspectorIntegrationTest, DisabledTlsInspectorFailsFilterChainFind) {
 TEST_P(TlsInspectorIntegrationTest, ContinueOnListenerTimeout) {
   setupConnections(/*listener_filter_disabled=*/false, /*expect_connection_open=*/true,
                    /*ssl_client=*/false);
-  // The length of tls hello message is defined as `TLS_MAX_CLIENT_HELLO = 64 * 1024`
-  // if tls inspect filter doesn't read the max length of hello message data, it
-  // will continue wait. Then the listener filter timeout timer will be triggered.
+  // The listener filter will not process the following data but will only wait for 1 second
+  // to timeout and then fall over to another listener filter chain.
   Buffer::OwnedImpl buffer("fake data");
   client_->write(buffer, false);
   // The timeout is set as one seconds, advance 2 seconds to trigger the timeout.


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

The comments on the ContinueOnListenerTimeout doesn't make sense.
1. the max length is changed to 16K.
2. the reason is also not correct.

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
