### PR TITLE
docs: clarify http cache filter architecture and document filesystem storage backend configuration

### DIFF
--- a/docs/root/configuration/http/http_filters/_include/http-cache-configuration-fs.yaml
+++ b/docs/root/configuration/http/http_filters/_include/http-cache-configuration-fs.yaml
@@ -1,0 +1,8 @@
+http_filters:
+- name: envoy.filters.http.cache
+  typed_config:
+    "@type": type.googleapis.com/envoy.extensions.filters.http.cache.v3.CacheConfig
+    typed_config:
+      "@type": type.googleapis.com/envoy.extensions.http.cache.file_system_http_cache.v3.FileSystemHttpCacheConfig
+      cache_path: /var/cache/envoy
+      max_cache_size_bytes: 1073741824  # 1 GiB

--- a/docs/root/configuration/http/http_filters/cache_filter.rst
+++ b/docs/root/configuration/http/http_filters/cache_filter.rst
@@ -36,7 +36,15 @@ For HTTP Responses:
 HTTP Cache delegates the actual storage of HTTP responses to implementations of the ``HttpCache`` interface. These implementations can
 cover all points on the spectrum of persistence, performance, and distribution, from local RAM caches to globally distributed
 persistent caches. They can be fully custom caches, or wrappers/adapters around local or remote open-source or proprietary caches.
-Currently the only available cache storage implementation is :ref:`SimpleHTTPCache <envoy_v3_api_msg_extensions.http.cache.simple_http_cache.v3.SimpleHttpCacheConfig>`.
+Built-in cache storage backends include :ref:`SimpleHttpCacheConfig <envoy_v3_api_msg_extensions.http.cache.simple_http_cache.v3.SimpleHttpCacheConfig>` (in-memory) and :ref:`FileSystemHttpCacheConfig <envoy_v3_api_msg_extensions.http.cache.file_system_http_cache.v3.FileSystemHttpCacheConfig>` (persistent; LRU).
+
+Architecture and extension points
+---------------------------------
+
+Envoy’s HTTP caching is split into:
+
+* **HTTP Cache filter** (extension name ``envoy.filters.http.cache``, category ``envoy.filters.http``) — configured via ``CacheConfig`` to apply HTTP caching semantics.
+* **Cache storage backends** (extension category ``envoy.http.cache``) — the filter delegates object storage/retrieval to a backend, selected via a nested ``typed_config`` in ``CacheConfig``.
 
 Example configuration
 ---------------------
@@ -50,7 +58,23 @@ Example filter configuration with a ``SimpleHttpCache`` cache implementation:
    :lineno-start: 29
    :caption: :download:`http-cache-configuration.yaml <_include/http-cache-configuration.yaml>`
 
+Example filter configuration with a ``FileSystemHttpCache`` cache implementation:
+
+.. literalinclude:: _include/http-cache-configuration-fs.yaml
+   :language: yaml
+   :linenos:
+   :caption: :download:`http-cache-configuration-fs.yaml <_include/http-cache-configuration-fs.yaml>`
+
 .. seealso::
 
    :ref:`Envoy Cache Sandbox <install_sandboxes_cache_filter>`
       Learn more about the Envoy Cache filter in the step by step sandbox.
+
+   :ref:`HTTP Cache filter (proto file) <envoy_v3_api_file_envoy/extensions/filters/http/cache/v3/cache.proto>`
+      ``CacheConfig`` API reference.
+
+   :ref:`In-memory storage backend <envoy_v3_api_file_envoy/extensions/http/cache/simple_http_cache/v3/config.proto>`
+      ``SimpleHttpCacheConfig`` API reference.
+
+   :ref:`Persistent on-disk storage backend <config_http_caches_file_system_http_cache>`
+      Docs page for File System Http Cache; links to ``FileSystemHttpCacheConfig`` API reference.


### PR DESCRIPTION
Commit Message:
docs: clarify http cache filter architecture; document filesystem storage backend config

Additional Description:
- Clarify the architecture and extension points (HTTP Cache filter vs. storage
  backends) and how a storage backend is selected
- Add a filesystem storage backend configuration example and reference it from
  the Cache filter docs
- Add links to related API/docs in the "See also" section

Partially addresses #16246.

Risk Level:
None (docs-only)

Testing:
- CI will build the docs (Sphinx) and validate cross-refs
- After CI finishes, verify in the preview artifact:
  * the filesystem backend snippet renders
  * both example blocks appear under "Example configuration"
  * the "See also" links resolve

Docs Changes:
Yes
- docs/root/configuration/http/http_filters/cache_filter.rst
- docs/root/configuration/http/http_filters/_include/http-cache-configuration-fs.yaml (new)

Release Notes:
N/A

Platform Specific Features:
N/A