### PR TITLE
deps: upgrading GO to v1.24.6 in dependency_imports.bzl

### DIFF
--- a/bazel/dependency_imports.bzl
+++ b/bazel/dependency_imports.bzl
@@ -24,7 +24,7 @@ load("@rules_rust//rust:defs.bzl", "rust_common")
 load("@rules_rust//rust:repositories.bzl", "rules_rust_dependencies", "rust_register_toolchains", "rust_repository_set")
 
 # go version for rules_go
-GO_VERSION = "1.23.1"
+GO_VERSION = "1.24.6"
 
 JQ_VERSION = "1.7"
 YQ_VERSION = "4.24.4"


### PR DESCRIPTION
Commit Message: deps: upgrading GO to v1.24.6 in dependency_imports.bzl
Additional Description:
Attempt to solve the issue that has been seen today in some PRs:
```
compilepkg: missing strict dependencies:
	/mnt/engflow/worker/work/3/exec/external/org_golang_google_grpc/internal/status/status.go: import of "google.golang.org/genproto/googleapis/rpc/status"
```
([example](https://github.com/envoyproxy/envoy/actions/runs/17246350777/job/48936907349#step:17:601))

Risk Level: low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A