### PR TITLE
zipkin: add custom headers support for collector requests

### DIFF
--- a/api/envoy/config/trace/v3/zipkin.proto
+++ b/api/envoy/config/trace/v3/zipkin.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package envoy.config.trace.v3;
 
+import "envoy/config/core/v3/base.proto";
+
 import "google/protobuf/wrappers.proto";
 
 import "envoy/annotations/deprecation.proto";
@@ -21,7 +23,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // Configuration for the Zipkin tracer.
 // [#extension: envoy.tracers.zipkin]
-// [#next-free-field: 9]
+// [#next-free-field: 10]
 message ZipkinConfig {
   option (udpa.annotations.versioning).previous_message_type = "envoy.config.trace.v2.ZipkinConfig";
 
@@ -106,4 +108,10 @@ message ZipkinConfig {
   // Here is the spec for W3C trace headers: https://www.w3.org/TR/trace-context/
   // The default value is USE_B3 to maintain backward compatibility.
   TraceContextOption trace_context_option = 8;
+
+  // Additional HTTP headers to include in requests sent to the Zipkin collector.
+  // These headers will be added to all HTTP requests sent to the collector endpoint.
+  // This can be useful for authentication, authorization, or collector-specific routing.
+  // Note: This is different from custom tags which add metadata to individual spans.
+  repeated core.v3.HeaderValue collector_request_headers = 9;
 }

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -275,6 +275,12 @@ new_features:
     extract trace information from W3C trace headers when B3 headers are not present (downstream),
     and inject both B3 and W3C trace headers for upstream requests to maximize compatibility.
     The default value ``USE_B3`` maintains backward compatibility with B3-only behavior.
+- area: tracing
+  change: |
+    Added support for custom HTTP headers in Zipkin collector requests via the
+    :ref:`collector_request_headers <envoy_v3_api_field_config.trace.v3.ZipkinConfig.collector_request_headers>`
+    configuration option. This enables authentication, authorization, and collector-specific routing
+    for requests sent to the Zipkin tracing backend.
 - area: rbac
   change: |
     Switch the IP matcher to use LC-Trie for performance improvements.

--- a/docs/root/faq/configuration/tracing.rst
+++ b/docs/root/faq/configuration/tracing.rst
@@ -5,3 +5,29 @@ How do I configure tracing?
 
 See the :ref:`architecture overview <arch_overview_tracing>`. In the addition there are
 :ref:`sandboxes <start_sandboxes>` that demonstrate several different tracing providers.
+
+How do I add custom headers to Zipkin collector requests?
+==========================================================
+
+The Zipkin tracer supports adding custom HTTP headers to requests sent to the Zipkin collector
+using the ``collector_request_headers`` configuration option. This is useful for authentication,
+authorization, or collector-specific routing.
+
+.. code-block:: yaml
+
+  tracing:
+    provider:
+      name: envoy.tracers.zipkin
+      typed_config:
+        "@type": type.googleapis.com/envoy.config.trace.v3.ZipkinConfig
+        collector_cluster: zipkin
+        collector_endpoint: "/api/v2/spans"
+        collector_endpoint_version: HTTP_JSON
+        collector_request_headers:
+          - key: "Authorization"
+            value: "Bearer your-auth-token"
+          - key: "X-API-Key"
+            value: "your-api-key"
+
+This feature is different from custom tags, which add metadata to individual spans within the trace data.
+Custom headers are added to the HTTP requests sent to the Zipkin backend for purposes like authentication.

--- a/docs/root/intro/arch_overview/observability/tracing.rst
+++ b/docs/root/intro/arch_overview/observability/tracing.rst
@@ -110,6 +110,13 @@ Alternatively the trace context can be manually propagated by the service:
     :ref:`tracestate <config_http_conn_man_headers_tracestate>`) when B3 headers are not present.
   - For upstream requests: Inject both B3 and W3C trace headers to maximize compatibility.
 
+  The Zipkin tracer also supports adding custom HTTP headers to requests sent to the Zipkin collector.
+  This is configured using the
+  :ref:`collector_request_headers <envoy_v3_api_field_config.trace.v3.ZipkinConfig.collector_request_headers>` option,
+  which allows adding headers for authentication, authorization, or collector-specific routing.
+  For example, API keys or bearer tokens can be included in collector requests for authentication.
+  This is different from custom tags, which add metadata to individual spans within the trace data.
+
   This option is disabled by default (``USE_B3``) to maintain backward compatibility, where only
   B3 headers are used for both extraction and injection.
 

--- a/source/extensions/tracers/zipkin/zipkin_tracer_impl.h
+++ b/source/extensions/tracers/zipkin/zipkin_tracer_impl.h
@@ -107,6 +107,9 @@ struct CollectorInfo {
   envoy::config::trace::v3::ZipkinConfig::CollectorEndpointVersion version_;
 
   bool shared_span_context_{DEFAULT_SHARED_SPAN_CONTEXT};
+
+  // Additional custom headers to include in requests to the Zipkin collector.
+  std::vector<std::pair<std::string, std::string>> request_headers_;
 };
 
 /**

--- a/test/extensions/tracers/zipkin/BUILD
+++ b/test/extensions/tracers/zipkin/BUILD
@@ -14,6 +14,7 @@ envoy_package()
 envoy_extension_cc_test(
     name = "zipkin_test",
     srcs = [
+        "collector_info_test.cc",
         "span_buffer_test.cc",
         "span_context_extractor_test.cc",
         "tracer_test.cc",

--- a/test/extensions/tracers/zipkin/collector_info_test.cc
+++ b/test/extensions/tracers/zipkin/collector_info_test.cc
@@ -1,0 +1,100 @@
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "source/extensions/tracers/zipkin/zipkin_tracer_impl.h"
+
+#include "gtest/gtest.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace Tracers {
+namespace Zipkin {
+namespace {
+
+TEST(CollectorInfoTest, DefaultConstruction) {
+  CollectorInfo collector_info;
+  
+  // Default values should be set correctly
+  EXPECT_TRUE(collector_info.endpoint_.empty());
+  EXPECT_EQ(collector_info.version_, envoy::config::trace::v3::ZipkinConfig::HTTP_JSON);
+  EXPECT_TRUE(collector_info.shared_span_context_);
+  EXPECT_TRUE(collector_info.request_headers_.empty());
+}
+
+TEST(CollectorInfoTest, CustomHeadersAssignment) {
+  CollectorInfo collector_info;
+  
+  // Add custom headers
+  collector_info.request_headers_ = {
+      {"Authorization", "Bearer token123"},
+      {"X-Custom-Header", "custom-value"},
+      {"X-API-Key", "api-key-123"}
+  };
+  
+  // Verify headers were set correctly
+  EXPECT_EQ(collector_info.request_headers_.size(), 3);
+  EXPECT_EQ(collector_info.request_headers_[0].first, "Authorization");
+  EXPECT_EQ(collector_info.request_headers_[0].second, "Bearer token123");
+  EXPECT_EQ(collector_info.request_headers_[1].first, "X-Custom-Header");
+  EXPECT_EQ(collector_info.request_headers_[1].second, "custom-value");
+  EXPECT_EQ(collector_info.request_headers_[2].first, "X-API-Key");
+  EXPECT_EQ(collector_info.request_headers_[2].second, "api-key-123");
+}
+
+TEST(CollectorInfoTest, EmptyCustomHeaders) {
+  CollectorInfo collector_info;
+  
+  // Explicitly set empty headers
+  collector_info.request_headers_ = {};
+  
+  // Verify headers are empty
+  EXPECT_TRUE(collector_info.request_headers_.empty());
+  EXPECT_EQ(collector_info.request_headers_.size(), 0);
+}
+
+TEST(CollectorInfoTest, CustomHeadersWithCompleteConfiguration) {
+  CollectorInfo collector_info;
+  
+  // Set all fields including custom headers
+  collector_info.endpoint_ = "/api/v2/spans";
+  collector_info.version_ = envoy::config::trace::v3::ZipkinConfig::HTTP_PROTO;
+  collector_info.shared_span_context_ = false;
+  collector_info.request_headers_ = {
+      {"Content-Type", "application/x-protobuf"},
+      {"Authorization", "Bearer secret-token"},
+      {"X-Zipkin-Trace", "enabled"}
+  };
+  
+  // Verify all fields are set correctly
+  EXPECT_EQ(collector_info.endpoint_, "/api/v2/spans");
+  EXPECT_EQ(collector_info.version_, envoy::config::trace::v3::ZipkinConfig::HTTP_PROTO);
+  EXPECT_FALSE(collector_info.shared_span_context_);
+  EXPECT_EQ(collector_info.request_headers_.size(), 3);
+  
+  // Verify specific headers
+  EXPECT_EQ(collector_info.request_headers_[0].first, "Content-Type");
+  EXPECT_EQ(collector_info.request_headers_[0].second, "application/x-protobuf");
+  EXPECT_EQ(collector_info.request_headers_[1].first, "Authorization");
+  EXPECT_EQ(collector_info.request_headers_[1].second, "Bearer secret-token");
+  EXPECT_EQ(collector_info.request_headers_[2].first, "X-Zipkin-Trace");
+  EXPECT_EQ(collector_info.request_headers_[2].second, "enabled");
+}
+
+TEST(CollectorInfoTest, SingleCustomHeader) {
+  CollectorInfo collector_info;
+  
+  // Add single custom header
+  collector_info.request_headers_ = {{"X-Single-Header", "single-value"}};
+  
+  // Verify single header was set correctly
+  EXPECT_EQ(collector_info.request_headers_.size(), 1);
+  EXPECT_EQ(collector_info.request_headers_[0].first, "X-Single-Header");
+  EXPECT_EQ(collector_info.request_headers_[0].second, "single-value");
+}
+
+} // namespace
+} // namespace Zipkin
+} // namespace Tracers
+} // namespace Extensions
+} // namespace Envoy

--- a/test/extensions/tracers/zipkin/collector_info_test.cc
+++ b/test/extensions/tracers/zipkin/collector_info_test.cc
@@ -14,7 +14,7 @@ namespace {
 
 TEST(CollectorInfoTest, DefaultConstruction) {
   CollectorInfo collector_info;
-  
+
   // Default values should be set correctly
   EXPECT_TRUE(collector_info.endpoint_.empty());
   EXPECT_EQ(collector_info.version_, envoy::config::trace::v3::ZipkinConfig::HTTP_JSON);
@@ -24,14 +24,12 @@ TEST(CollectorInfoTest, DefaultConstruction) {
 
 TEST(CollectorInfoTest, CustomHeadersAssignment) {
   CollectorInfo collector_info;
-  
+
   // Add custom headers
-  collector_info.request_headers_ = {
-      {"Authorization", "Bearer token123"},
-      {"X-Custom-Header", "custom-value"},
-      {"X-API-Key", "api-key-123"}
-  };
-  
+  collector_info.request_headers_ = {{"Authorization", "Bearer token123"},
+                                     {"X-Custom-Header", "custom-value"},
+                                     {"X-API-Key", "api-key-123"}};
+
   // Verify headers were set correctly
   EXPECT_EQ(collector_info.request_headers_.size(), 3);
   EXPECT_EQ(collector_info.request_headers_[0].first, "Authorization");
@@ -44,10 +42,10 @@ TEST(CollectorInfoTest, CustomHeadersAssignment) {
 
 TEST(CollectorInfoTest, EmptyCustomHeaders) {
   CollectorInfo collector_info;
-  
+
   // Explicitly set empty headers
   collector_info.request_headers_ = {};
-  
+
   // Verify headers are empty
   EXPECT_TRUE(collector_info.request_headers_.empty());
   EXPECT_EQ(collector_info.request_headers_.size(), 0);
@@ -55,23 +53,21 @@ TEST(CollectorInfoTest, EmptyCustomHeaders) {
 
 TEST(CollectorInfoTest, CustomHeadersWithCompleteConfiguration) {
   CollectorInfo collector_info;
-  
+
   // Set all fields including custom headers
   collector_info.endpoint_ = "/api/v2/spans";
   collector_info.version_ = envoy::config::trace::v3::ZipkinConfig::HTTP_PROTO;
   collector_info.shared_span_context_ = false;
-  collector_info.request_headers_ = {
-      {"Content-Type", "application/x-protobuf"},
-      {"Authorization", "Bearer secret-token"},
-      {"X-Zipkin-Trace", "enabled"}
-  };
-  
+  collector_info.request_headers_ = {{"Content-Type", "application/x-protobuf"},
+                                     {"Authorization", "Bearer secret-token"},
+                                     {"X-Zipkin-Trace", "enabled"}};
+
   // Verify all fields are set correctly
   EXPECT_EQ(collector_info.endpoint_, "/api/v2/spans");
   EXPECT_EQ(collector_info.version_, envoy::config::trace::v3::ZipkinConfig::HTTP_PROTO);
   EXPECT_FALSE(collector_info.shared_span_context_);
   EXPECT_EQ(collector_info.request_headers_.size(), 3);
-  
+
   // Verify specific headers
   EXPECT_EQ(collector_info.request_headers_[0].first, "Content-Type");
   EXPECT_EQ(collector_info.request_headers_[0].second, "application/x-protobuf");
@@ -83,10 +79,10 @@ TEST(CollectorInfoTest, CustomHeadersWithCompleteConfiguration) {
 
 TEST(CollectorInfoTest, SingleCustomHeader) {
   CollectorInfo collector_info;
-  
+
   // Add single custom header
   collector_info.request_headers_ = {{"X-Single-Header", "single-value"}};
-  
+
   // Verify single header was set correctly
   EXPECT_EQ(collector_info.request_headers_.size(), 1);
   EXPECT_EQ(collector_info.request_headers_[0].first, "X-Single-Header");

--- a/test/extensions/tracers/zipkin/config_test.cc
+++ b/test/extensions/tracers/zipkin/config_test.cc
@@ -1,12 +1,9 @@
 #include "envoy/config/trace/v3/http_tracer.pb.h"
-#include "envoy/config/trace/v3/zipkin.pb.h"
-#include "envoy/config/trace/v3/zipkin.pb.validate.h"
-#include "envoy/registry/registry.h"
 
 #include "source/extensions/tracers/zipkin/config.h"
 
-#include "test/mocks/server/tracer_factory.h"
 #include "test/mocks/server/tracer_factory_context.h"
+#include "test/test_common/utility.h"
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -53,6 +50,62 @@ TEST(ZipkinTracerConfigTest, ZipkinHttpTracerWithTypedConfig) {
       collector_cluster: fake_cluster
       collector_endpoint: /api/v2/spans
       collector_endpoint_version: HTTP_PROTO
+  )EOF";
+
+  envoy::config::trace::v3::Tracing configuration;
+  TestUtility::loadFromYaml(yaml_string, configuration);
+
+  ZipkinTracerFactory factory;
+  auto message = Config::Utility::translateToFactoryConfig(
+      configuration.http(), ProtobufMessage::getStrictValidationVisitor(), factory);
+  auto zipkin_tracer = factory.createTracerDriver(*message, context);
+  EXPECT_NE(nullptr, zipkin_tracer);
+}
+
+TEST(ZipkinTracerConfigTest, ZipkinHttpTracerWithCustomHeaders) {
+  NiceMock<Server::Configuration::MockTracerFactoryContext> context;
+  context.server_factory_context_.cluster_manager_.initializeClusters({"fake_cluster"}, {});
+
+  const std::string yaml_string = R"EOF(
+  http:
+    name: zipkin
+    typed_config:
+      "@type": type.googleapis.com/envoy.config.trace.v3.ZipkinConfig
+      collector_cluster: fake_cluster
+      collector_endpoint: /api/v2/spans
+      collector_endpoint_version: HTTP_JSON
+      collector_request_headers:
+        - key: "Authorization"
+          value: "Bearer token123"
+        - key: "X-Custom-Header"
+          value: "custom-value"
+        - key: "X-API-Key"
+          value: "api-key-123"
+  )EOF";
+
+  envoy::config::trace::v3::Tracing configuration;
+  TestUtility::loadFromYaml(yaml_string, configuration);
+
+  ZipkinTracerFactory factory;
+  auto message = Config::Utility::translateToFactoryConfig(
+      configuration.http(), ProtobufMessage::getStrictValidationVisitor(), factory);
+  auto zipkin_tracer = factory.createTracerDriver(*message, context);
+  EXPECT_NE(nullptr, zipkin_tracer);
+}
+
+TEST(ZipkinTracerConfigTest, ZipkinHttpTracerWithEmptyCustomHeaders) {
+  NiceMock<Server::Configuration::MockTracerFactoryContext> context;
+  context.server_factory_context_.cluster_manager_.initializeClusters({"fake_cluster"}, {});
+
+  const std::string yaml_string = R"EOF(
+  http:
+    name: zipkin
+    typed_config:
+      "@type": type.googleapis.com/envoy.config.trace.v3.ZipkinConfig
+      collector_cluster: fake_cluster
+      collector_endpoint: /api/v2/spans
+      collector_endpoint_version: HTTP_JSON
+      collector_request_headers: []
   )EOF";
 
   envoy::config::trace::v3::Tracing configuration;

--- a/test/extensions/tracers/zipkin/zipkin_tracer_impl_test.cc
+++ b/test/extensions/tracers/zipkin/zipkin_tracer_impl_test.cc
@@ -1080,7 +1080,7 @@ TEST_F(ZipkinDriverTest, DriverWithCustomHeaders) {
       value: "Bearer token123"
     - key: "X-Custom-Header"
       value: "custom-value"
-    - key: "X-API-Key" 
+    - key: "X-API-Key"
       value: "api-key-123"
   )EOF";
 
@@ -1151,8 +1151,10 @@ TEST_F(ZipkinDriverTest, ReporterFlushWithCustomHeaders) {
                                              operation_name_, {Tracing::Reason::Sampling, true});
   span->finishSpan();
 
-  Http::ResponseHeaderMapPtr response_headers{new Http::TestResponseHeaderMapImpl{{":status", "202"}}};
-  callback->onSuccess(request, std::make_unique<Http::ResponseMessageImpl>(std::move(response_headers)));
+  Http::ResponseHeaderMapPtr response_headers{
+      new Http::TestResponseHeaderMapImpl{{":status", "202"}}};
+  callback->onSuccess(request,
+                      std::make_unique<Http::ResponseMessageImpl>(std::move(response_headers)));
 }
 
 TEST_F(ZipkinDriverTest, ReporterFlushWithCustomHeadersVerifyHeaders) {
@@ -1212,8 +1214,10 @@ TEST_F(ZipkinDriverTest, ReporterFlushWithCustomHeadersVerifyHeaders) {
                                              operation_name_, {Tracing::Reason::Sampling, true});
   span->finishSpan();
 
-  Http::ResponseHeaderMapPtr response_headers{new Http::TestResponseHeaderMapImpl{{":status", "202"}}};
-  callback->onSuccess(request, std::make_unique<Http::ResponseMessageImpl>(std::move(response_headers)));
+  Http::ResponseHeaderMapPtr response_headers{
+      new Http::TestResponseHeaderMapImpl{{":status", "202"}}};
+  callback->onSuccess(request,
+                      std::make_unique<Http::ResponseMessageImpl>(std::move(response_headers)));
 }
 
 TEST_F(ZipkinDriverTest, ReporterFlushWithCustomHeadersProtobuf) {
@@ -1256,7 +1260,8 @@ TEST_F(ZipkinDriverTest, ReporterFlushWithCustomHeadersProtobuf) {
             ASSERT_FALSE(auth_header.empty());
             EXPECT_EQ("Bearer token123", auth_header[0]->value().getStringView());
 
-            auto encoding_header = message->headers().get(Http::LowerCaseString("content-encoding"));
+            auto encoding_header =
+                message->headers().get(Http::LowerCaseString("content-encoding"));
             ASSERT_FALSE(encoding_header.empty());
             EXPECT_EQ("gzip", encoding_header[0]->value().getStringView());
 
@@ -1267,8 +1272,10 @@ TEST_F(ZipkinDriverTest, ReporterFlushWithCustomHeadersProtobuf) {
                                              operation_name_, {Tracing::Reason::Sampling, true});
   span->finishSpan();
 
-  Http::ResponseHeaderMapPtr response_headers{new Http::TestResponseHeaderMapImpl{{":status", "202"}}};
-  callback->onSuccess(request, std::make_unique<Http::ResponseMessageImpl>(std::move(response_headers)));
+  Http::ResponseHeaderMapPtr response_headers{
+      new Http::TestResponseHeaderMapImpl{{":status", "202"}}};
+  callback->onSuccess(request,
+                      std::make_unique<Http::ResponseMessageImpl>(std::move(response_headers)));
 }
 
 } // namespace


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Add support for custom HTTP headers in Zipkin collector requests

This change introduces the collector_request_headers field to ZipkinConfig,
allowing users to add custom headers to HTTP requests sent to the Zipkin
collector. This enables authentication, authorization, and collector-specific 
routing capabilities.

The feature includes:
- New collector_request_headers field in ZipkinConfig proto
- CollectorInfo struct updated to store header key-value pairs  
- ReporterImpl modified to include headers in HTTP requests
- Comprehensive test coverage for all components
- Documentation updates in tracing overview and FAQ

This is different from custom tags which add metadata to spans;
this feature adds HTTP headers to collector API requests.

Additional Description:
Risk Level: Medium
Testing: Unit tests, integration tests, configuration tests
Docs Changes: Updated tracing architecture docs and FAQ
Release Notes: Yes - added to current.yaml
