### PR TITLE
dynamic_modules: pass filter config on destroy entrypoint

### DIFF
--- a/source/extensions/dynamic_modules/abi.h
+++ b/source/extensions/dynamic_modules/abi.h
@@ -510,10 +510,13 @@ envoy_dynamic_module_on_http_filter_config_new(
  * envoy_dynamic_module_on_http_filter_config_destroy is called when the HTTP filter configuration
  * is destroyed in Envoy. The module should release any resources associated with the corresponding
  * in-module HTTP filter configuration.
+ * @param filter_config_envoy_ptr is the pointer to the DynamicModuleHttpFilterConfig object for the
+ * corresponding config.
  * @param filter_config_ptr is a pointer to the in-module HTTP filter configuration whose
  * corresponding Envoy HTTP filter configuration is being destroyed.
  */
 void envoy_dynamic_module_on_http_filter_config_destroy(
+    envoy_dynamic_module_type_http_filter_config_envoy_ptr filter_config_envoy_ptr,
     envoy_dynamic_module_type_http_filter_config_module_ptr filter_config_ptr);
 
 /**

--- a/source/extensions/dynamic_modules/abi_version.h
+++ b/source/extensions/dynamic_modules/abi_version.h
@@ -6,7 +6,7 @@ namespace DynamicModules {
 #endif
 // This is the ABI version calculated as a sha256 hash of the ABI header files. When the ABI
 // changes, this value must change, and the correctness of this value is checked by the test.
-const char* kAbiVersion = "c07c1d909f0fa183d9c454377242978585ca4569d2e7e9aa27002ccebf34a00d";
+const char* kAbiVersion = "1e973528f6ecb2073e69719d6eb0e202e88237ae3589e69b0a130d5b93479867";
 
 #ifdef __cplusplus
 } // namespace DynamicModules

--- a/source/extensions/dynamic_modules/sdk/rust/src/lib_test.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/lib_test.rs
@@ -35,7 +35,7 @@ fn test_envoy_dynamic_module_on_http_filter_config_new_impl() {
   assert!(!result.is_null());
 
   unsafe {
-    envoy_dynamic_module_on_http_filter_config_destroy(result);
+    envoy_dynamic_module_on_http_filter_config_destroy(envoy_filter_config.raw_ptr, result);
   }
 
   // None should result in null pointer.
@@ -65,20 +65,22 @@ fn test_envoy_dynamic_module_on_http_filter_config_destroy() {
     }
   }
 
+  let mut envoy_filter_config = EnvoyHttpFilterConfigImpl {
+    raw_ptr: std::ptr::null_mut(),
+  };
+
   // This is a sort of round-trip to ensure the same control flow as the actual usage.
   let new_fn: NewHttpFilterConfigFunction<EnvoyHttpFilterConfigImpl, EnvoyHttpFilterImpl> =
     |_, _, _| Some(Box::new(TestHttpFilterConfig));
   let config_ptr = envoy_dynamic_module_on_http_filter_config_new_impl(
-    &mut EnvoyHttpFilterConfigImpl {
-      raw_ptr: std::ptr::null_mut(),
-    },
+    &mut envoy_filter_config,
     "test_name",
     b"test_config",
     &new_fn,
   );
 
   unsafe {
-    envoy_dynamic_module_on_http_filter_config_destroy(config_ptr);
+    envoy_dynamic_module_on_http_filter_config_destroy(envoy_filter_config.raw_ptr, config_ptr);
   }
   // Now that the drop is called, DROPPED must be set to true.
   assert!(DROPPED.load(std::sync::atomic::Ordering::SeqCst));

--- a/source/extensions/filters/http/dynamic_modules/filter_config.cc
+++ b/source/extensions/filters/http/dynamic_modules/filter_config.cc
@@ -16,7 +16,9 @@ DynamicModuleHttpFilterConfig::~DynamicModuleHttpFilterConfig() {
   // When the initialization of the dynamic module fails, the in_module_config_ is nullptr,
   // and there's nothing to destroy from the module's point of view.
   if (on_http_filter_config_destroy_) {
-    (*on_http_filter_config_destroy_)(in_module_config_);
+    // Passing this is safe as there are no cleaned up virtual functions which is guaranteed
+    // by the class type being final
+    (*on_http_filter_config_destroy_)(this, in_module_config_);
   }
 }
 

--- a/source/extensions/filters/http/dynamic_modules/filter_config.h
+++ b/source/extensions/filters/http/dynamic_modules/filter_config.h
@@ -38,7 +38,7 @@ using OnHttpFilterScheduled = decltype(&envoy_dynamic_module_on_http_filter_sche
  * filter instances. This resolves and holds the symbols used for the HTTP filters.
  * Each filter instance and the factory callback holds a shared pointer to this config.
  */
-class DynamicModuleHttpFilterConfig {
+class DynamicModuleHttpFilterConfig final {
 public:
   /**
    * Constructor for the config.

--- a/test/extensions/dynamic_modules/test_data/c/no_http_filter_destroy.c
+++ b/test/extensions/dynamic_modules/test_data/c/no_http_filter_destroy.c
@@ -15,6 +15,7 @@ envoy_dynamic_module_on_http_filter_config_new(
 }
 
 void envoy_dynamic_module_on_http_filter_config_destroy(
+    envoy_dynamic_module_type_http_filter_config_envoy_ptr filter_config_envoy_ptr,
     envoy_dynamic_module_type_http_filter_config_module_ptr filter_config_ptr) {}
 
 envoy_dynamic_module_type_http_filter_module_ptr envoy_dynamic_module_on_http_filter_new(

--- a/test/extensions/dynamic_modules/test_data/c/no_http_filter_new.c
+++ b/test/extensions/dynamic_modules/test_data/c/no_http_filter_new.c
@@ -15,4 +15,5 @@ envoy_dynamic_module_on_http_filter_config_new(
 }
 
 void envoy_dynamic_module_on_http_filter_config_destroy(
+    envoy_dynamic_module_type_http_filter_config_envoy_ptr filter_config_envoy_ptr,
     envoy_dynamic_module_type_http_filter_config_module_ptr filter_config_ptr) {}

--- a/test/extensions/dynamic_modules/test_data/c/no_http_filter_request_body.c
+++ b/test/extensions/dynamic_modules/test_data/c/no_http_filter_request_body.c
@@ -15,6 +15,7 @@ envoy_dynamic_module_on_http_filter_config_new(
 }
 
 void envoy_dynamic_module_on_http_filter_config_destroy(
+    envoy_dynamic_module_type_http_filter_config_envoy_ptr filter_config_envoy_ptr,
     envoy_dynamic_module_type_http_filter_config_module_ptr filter_config_ptr) {}
 
 envoy_dynamic_module_type_http_filter_module_ptr envoy_dynamic_module_on_http_filter_new(

--- a/test/extensions/dynamic_modules/test_data/c/no_http_filter_request_headers.c
+++ b/test/extensions/dynamic_modules/test_data/c/no_http_filter_request_headers.c
@@ -15,6 +15,7 @@ envoy_dynamic_module_on_http_filter_config_new(
 }
 
 void envoy_dynamic_module_on_http_filter_config_destroy(
+    envoy_dynamic_module_type_http_filter_config_envoy_ptr filter_config_envoy_ptr,
     envoy_dynamic_module_type_http_filter_config_module_ptr filter_config_ptr) {}
 
 envoy_dynamic_module_type_http_filter_module_ptr envoy_dynamic_module_on_http_filter_new(

--- a/test/extensions/dynamic_modules/test_data/c/no_http_filter_request_trailers.c
+++ b/test/extensions/dynamic_modules/test_data/c/no_http_filter_request_trailers.c
@@ -15,6 +15,7 @@ envoy_dynamic_module_on_http_filter_config_new(
 }
 
 void envoy_dynamic_module_on_http_filter_config_destroy(
+    envoy_dynamic_module_type_http_filter_config_envoy_ptr filter_config_envoy_ptr,
     envoy_dynamic_module_type_http_filter_config_module_ptr filter_config_ptr) {}
 
 envoy_dynamic_module_type_http_filter_module_ptr envoy_dynamic_module_on_http_filter_new(

--- a/test/extensions/dynamic_modules/test_data/c/no_http_filter_response_body.c
+++ b/test/extensions/dynamic_modules/test_data/c/no_http_filter_response_body.c
@@ -15,6 +15,7 @@ envoy_dynamic_module_on_http_filter_config_new(
 }
 
 void envoy_dynamic_module_on_http_filter_config_destroy(
+    envoy_dynamic_module_type_http_filter_config_envoy_ptr filter_config_envoy_ptr,
     envoy_dynamic_module_type_http_filter_config_module_ptr filter_config_ptr) {}
 
 envoy_dynamic_module_type_http_filter_module_ptr envoy_dynamic_module_on_http_filter_new(

--- a/test/extensions/dynamic_modules/test_data/c/no_http_filter_response_headers.c
+++ b/test/extensions/dynamic_modules/test_data/c/no_http_filter_response_headers.c
@@ -15,6 +15,7 @@ envoy_dynamic_module_on_http_filter_config_new(
 }
 
 void envoy_dynamic_module_on_http_filter_config_destroy(
+    envoy_dynamic_module_type_http_filter_config_envoy_ptr filter_config_envoy_ptr,
     envoy_dynamic_module_type_http_filter_config_module_ptr filter_config_ptr) {}
 
 envoy_dynamic_module_type_http_filter_module_ptr envoy_dynamic_module_on_http_filter_new(

--- a/test/extensions/dynamic_modules/test_data/c/no_http_filter_response_trailers.c
+++ b/test/extensions/dynamic_modules/test_data/c/no_http_filter_response_trailers.c
@@ -15,6 +15,7 @@ envoy_dynamic_module_on_http_filter_config_new(
 }
 
 void envoy_dynamic_module_on_http_filter_config_destroy(
+    envoy_dynamic_module_type_http_filter_config_envoy_ptr filter_config_envoy_ptr,
     envoy_dynamic_module_type_http_filter_config_module_ptr filter_config_ptr) {}
 
 envoy_dynamic_module_type_http_filter_module_ptr envoy_dynamic_module_on_http_filter_new(

--- a/test/extensions/dynamic_modules/test_data/c/no_http_filter_stream_complete.c
+++ b/test/extensions/dynamic_modules/test_data/c/no_http_filter_stream_complete.c
@@ -15,6 +15,7 @@ envoy_dynamic_module_on_http_filter_config_new(
 }
 
 void envoy_dynamic_module_on_http_filter_config_destroy(
+    envoy_dynamic_module_type_http_filter_config_envoy_ptr filter_config_envoy_ptr,
     envoy_dynamic_module_type_http_filter_config_module_ptr filter_config_ptr) {}
 
 envoy_dynamic_module_type_http_filter_module_ptr envoy_dynamic_module_on_http_filter_new(

--- a/test/extensions/dynamic_modules/test_data/c/no_op.c
+++ b/test/extensions/dynamic_modules/test_data/c/no_op.c
@@ -14,15 +14,20 @@ envoy_dynamic_module_type_abi_version_envoy_ptr envoy_dynamic_module_on_program_
   return kAbiVersion;
 }
 
+static envoy_dynamic_module_type_http_filter_config_envoy_ptr cached_filter_config_envoy_ptr;
+
 envoy_dynamic_module_type_http_filter_config_module_ptr
 envoy_dynamic_module_on_http_filter_config_new(
     envoy_dynamic_module_type_http_filter_config_envoy_ptr filter_config_envoy_ptr,
     const char* name_ptr, size_t name_size, const char* config_ptr, size_t config_size) {
+  cached_filter_config_envoy_ptr = filter_config_envoy_ptr;
   return &some_variable;
 }
 
 void envoy_dynamic_module_on_http_filter_config_destroy(
+     envoy_dynamic_module_type_http_filter_config_envoy_ptr filter_config_envoy_ptr,
     envoy_dynamic_module_type_http_filter_config_module_ptr filter_config_ptr) {
+  assert(filter_config_envoy_ptr == cached_filter_config_envoy_ptr);
   assert(filter_config_ptr == &some_variable);
 }
 

--- a/test/extensions/dynamic_modules/test_data/rust/no_op.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/no_op.rs
@@ -39,7 +39,6 @@ fn destroy_nop_http_filter_config_fn<EC: EnvoyHttpFilterConfig>(_envoy_filter_co
 /// A no-op HTTP filter configuration that implements
 /// [`envoy_proxy_dynamic_modules_rust_sdk::HttpFilterConfig`] as well as the [`Drop`] to test the
 /// cleanup of the configuration.
-#[derive(Debug, PartialEq, Eq, Clone)]
 struct NopHttpFilterConfig {
   name: String,
   config: String,

--- a/test/extensions/dynamic_modules/test_data/rust/no_op.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/no_op.rs
@@ -1,7 +1,12 @@
 use envoy_proxy_dynamic_modules_rust_sdk::*;
 use std::sync::atomic::{AtomicI32, Ordering};
 
-declare_init_functions!(init, new_nop_http_filter_config_fn);
+declare_init_functions!(InitFunctions {
+  init_fn: init,
+  new_http_filter_config_fn: new_nop_http_filter_config_fn,
+  destroy_http_filter_config_fn: Some(destroy_nop_http_filter_config_fn),
+  new_http_filter_per_route_config_fn: None,
+});
 
 /// This implements the [`envoy_proxy_dynamic_modules_rust_sdk::ProgramInitFunction`] signature.
 fn init() -> bool {
@@ -27,9 +32,14 @@ fn new_nop_http_filter_config_fn<EC: EnvoyHttpFilterConfig, EHF: EnvoyHttpFilter
   Some(Box::new(NopHttpFilterConfig { name, config }))
 }
 
+/// This implements the [`envoy_proxy_dynamic_modules_rust_sdk::DestroyHttpFilterConfigFunction`]
+/// signature
+fn destroy_nop_http_filter_config_fn<EC: EnvoyHttpFilterConfig>(_envoy_filter_config: &mut EC) {}
+
 /// A no-op HTTP filter configuration that implements
 /// [`envoy_proxy_dynamic_modules_rust_sdk::HttpFilterConfig`] as well as the [`Drop`] to test the
 /// cleanup of the configuration.
+#[derive(Debug, PartialEq, Eq, Clone)]
 struct NopHttpFilterConfig {
   name: String,
   config: String,


### PR DESCRIPTION
Commit Message: dynamic_modules: pass filter config on destroy entrypoint
Additional Description: Pass the filter config on the destroy callback. This is a preparation step for once metrics are supported, where a user may want to update a metric on filter config cleanup. Since Rust code may want to access this argument, expose an init function for filter config cleanup (not really an init function anymore ATP).
Risk Level: Low
Testing: unit tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
