### PR TITLE
Ext/Filter/http/Tap: Record the upstream connection information in the HTTP buffer trace output

### DIFF
--- a/api/envoy/data/tap/v3/http.proto
+++ b/api/envoy/data/tap/v3/http.proto
@@ -49,6 +49,9 @@ message HttpBufferedTrace {
 
   // downstream connection
   Connection downstream_connection = 3;
+
+  // upstream connection
+  Connection upstream_connection = 4;
 }
 
 // A streamed HTTP trace segment. Multiple segments make up a full trace.

--- a/api/envoy/extensions/filters/http/tap/v3/tap.proto
+++ b/api/envoy/extensions/filters/http/tap/v3/tap.proto
@@ -34,4 +34,7 @@ message Tap {
 
   // Indicates whether report downstream connection info
   bool record_downstream_connection = 3;
+
+  // Indicates whether report upstream connection info
+  bool record_upstream_connection = 4;
 }

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -181,6 +181,9 @@ new_features:
     support evictable metrics. This is done :ref:`periodically
     <envoy_v3_api_field_config.bootstrap.v3.Bootstrap.stats_eviction_interval>`
     during the metric flush.
+- area: tap
+  change: |
+    Record the upstream connection information in the HTTP buffer trace output.
 - area: quic
   change: |
     Added new option to support :ref:`base64 encoded server ID

--- a/source/extensions/filters/http/tap/tap_config.h
+++ b/source/extensions/filters/http/tap/tap_config.h
@@ -66,12 +66,11 @@ class HttpTapConfig : public virtual Extensions::Common::Tap::TapConfig {
 public:
   /**
    * @return a new per-request HTTP tapper which is used to handle tapping of a discrete request.
-   * @param tap_config provides http tap config
-   * @param stream_id supplies the owning HTTP stream ID.
+   * @param decoder_callbacks supplies all needed information for HTTP tap
    */
   virtual HttpPerRequestTapperPtr
   createPerRequestTapper(const envoy::extensions::filters::http::tap::v3::Tap& tap_config,
-                         uint64_t stream_id, OptRef<const Network::Connection> connection) PURE;
+                         Http::StreamDecoderFilterCallbacks& decoder_callbacks) PURE;
 
   /**
    * @return time source to use for timestamp

--- a/source/extensions/filters/http/tap/tap_filter.h
+++ b/source/extensions/filters/http/tap/tap_filter.h
@@ -100,9 +100,7 @@ public:
   void setDecoderFilterCallbacks(Http::StreamDecoderFilterCallbacks& callbacks) override {
     HttpTapConfigSharedPtr config = config_->currentConfig();
     if (config != nullptr) {
-      auto streamId = callbacks.streamId();
-      auto connection = callbacks.connection();
-      tapper_ = config->createPerRequestTapper(config_->getTapConfig(), streamId, connection);
+      tapper_ = config->createPerRequestTapper(config_->getTapConfig(), callbacks);
     } else {
       tapper_ = nullptr;
     }

--- a/test/extensions/filters/http/tap/BUILD
+++ b/test/extensions/filters/http/tap/BUILD
@@ -47,6 +47,7 @@ envoy_extension_cc_test(
         "//source/extensions/filters/http/tap:tap_config_impl",
         "//test/extensions/common/tap:common",
         "//test/mocks:common_lib",
+        "//test/mocks/http:http_mocks",
         "//test/mocks/network:network_mocks",
         "//test/test_common:simulated_time_system_lib",
         "//test/test_common:utility_lib",

--- a/test/extensions/filters/http/tap/common.h
+++ b/test/extensions/filters/http/tap/common.h
@@ -13,9 +13,8 @@ class MockHttpTapConfig : public HttpTapConfig {
 public:
   HttpPerRequestTapperPtr
   createPerRequestTapper(const envoy::extensions::filters::http::tap::v3::Tap& tap_config,
-                         uint64_t stream_id,
-                         OptRef<const Network::Connection> connection) override {
-    return HttpPerRequestTapperPtr{createPerRequestTapper_(tap_config, stream_id, connection)};
+                         Http::StreamDecoderFilterCallbacks& decoder_callbacks) override {
+    return HttpPerRequestTapperPtr{createPerRequestTapper_(tap_config, decoder_callbacks)};
   }
 
   Extensions::Common::Tap::PerTapSinkHandleManagerPtr
@@ -25,8 +24,8 @@ public:
   }
 
   MOCK_METHOD(HttpPerRequestTapper*, createPerRequestTapper_,
-              (const envoy::extensions::filters::http::tap::v3::Tap& tap_config, uint64_t stream_id,
-               OptRef<const Network::Connection>));
+              (const envoy::extensions::filters::http::tap::v3::Tap& tap_config,
+               Http::StreamDecoderFilterCallbacks& decoder_callbacks));
   MOCK_METHOD(Extensions::Common::Tap::PerTapSinkHandleManager*, createPerTapSinkHandleManager_,
               (uint64_t trace_id));
   MOCK_METHOD(uint32_t, maxBufferedRxBytes, (), (const));

--- a/test/extensions/filters/http/tap/tap_filter_integration_test.cc
+++ b/test/extensions/filters/http/tap/tap_filter_integration_test.cc
@@ -1206,6 +1206,48 @@ typed_config:
   EXPECT_EQ(1UL, test_server_->counter("http.config_test.tap.rq_tapped")->value());
 }
 
+// Verify option record_upstream_connection
+// when a request header is matched in a static configuration.
+TEST_P(TapIntegrationTest, StaticFilePerHttpBufferTraceTapUpstreamConnection) {
+  constexpr absl::string_view filter_config =
+      R"EOF(
+name: tap
+typed_config:
+  "@type": type.googleapis.com/envoy.extensions.filters.http.tap.v3.Tap
+  common_config:
+    static_config:
+      match:
+        http_request_headers_match:
+          headers:
+            - name: foo
+              string_match:
+                exact: bar
+      output_config:
+        sinks:
+          - format: PROTO_BINARY_LENGTH_DELIMITED
+            file_per_tap:
+              path_prefix: {}
+  record_upstream_connection: true
+)EOF";
+
+  const std::string path_prefix = getTempPathPrefix();
+  initializeFilter(fmt::format(filter_config, path_prefix));
+
+  // Initial request/response with tap.
+  codec_client_ = makeHttpConnection(makeClientConnection(lookupPort("http")));
+  makeRequest(request_headers_tap_, {"hello"}, &request_trailers_, response_headers_no_tap_,
+              {"world"}, &response_trailers_);
+  codec_client_->close();
+  test_server_->waitForCounterGe("http.config_test.downstream_cx_destroy", 1);
+
+  std::vector<envoy::data::tap::v3::TraceWrapper> traces =
+      Extensions::Common::Tap::readTracesFromPath(path_prefix);
+  ASSERT_EQ(1, traces.size());
+  EXPECT_TRUE(traces[0].has_http_buffered_trace());
+
+  EXPECT_EQ(1UL, test_server_->counter("http.config_test.tap.rq_tapped")->value());
+}
+
 // Verify that body matching works.
 TEST_P(TapIntegrationTest, AdminBodyMatching) {
   initializeFilter(admin_filter_config_);

--- a/test/extensions/filters/http/tap/tap_filter_test.cc
+++ b/test/extensions/filters/http/tap/tap_filter_test.cc
@@ -54,10 +54,8 @@ public:
     filter_ = std::make_unique<Filter>(filter_config_);
 
     if (has_config) {
-      EXPECT_CALL(callbacks_, streamId());
-      EXPECT_CALL(callbacks_, connection());
       http_per_request_tapper_ = new MockHttpPerRequestTapper();
-      EXPECT_CALL(*http_tap_config_, createPerRequestTapper_(_, _, _))
+      EXPECT_CALL(*http_tap_config_, createPerRequestTapper_(_, _))
           .WillOnce(Return(http_per_request_tapper_));
     }
 


### PR DESCRIPTION


<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Record the upstream connection information in the HTTP buffer trace output
Additional Description:
**Motivation:**
The HTTP tap filter currently records "downstream" connection information by [PR29240](https://github.com/envoyproxy/envoy/pull/29420), 
which is useful for tracing **ingress** traffic. 
As adoption of this filter grows, users increasingly rely on it for diagnosing complex traffic flows.

**Problem:**
Today, the filter does not provide human-readable "upstream" connection details. 
This gap is especially problematic for TLS **egress** traffic, where upstream endpoints cannot be easily inferred. 
As a result, debugging issues often becomes slow and cumbersome.

Proposed one solution:
Upon closely reviewing Envoy’s code, 
the upstream connection information is available in StreamInfo when an HTTP/2 request is sent out via CDS connection pool. 
This enhancement adds the upstream connection details into the HTTP tap filter output, 
enabling retrieval of the upstream IP and port even when :authority contains an FQDN.

Risk Level: lowest
Testing: done UT/FT
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
