### PR TITLE
wasm: add wasm.<runtime>.crashed metric

### DIFF
--- a/source/extensions/common/wasm/stats_handler.cc
+++ b/source/extensions/common/wasm/stats_handler.cc
@@ -75,6 +75,9 @@ void LifecycleStatsHandler::onEvent(WasmEvent event) {
     lifecycle_stats_.active_.set(++active_wasms);
     lifecycle_stats_.created_.inc();
     break;
+  case WasmEvent::VmCrashed:
+    lifecycle_stats_.crashed_.inc();
+    break;
   default:
     break;
   }

--- a/source/extensions/common/wasm/stats_handler.h
+++ b/source/extensions/common/wasm/stats_handler.h
@@ -33,6 +33,7 @@ struct CreateWasmStats {
 
 #define LIFECYCLE_STATS(COUNTER, GAUGE)                                                            \
   COUNTER(created)                                                                                 \
+  COUNTER(crashed)                                                                                 \
   GAUGE(active, NeverImport)
 
 struct LifecycleStats {
@@ -57,6 +58,7 @@ enum class WasmEvent : int {
   RuntimeError,
   VmCreated,
   VmShutDown,
+  VmCrashed,
   VmReloadBackoff,
   VmReloadSuccess,
   VmReloadFailure,

--- a/source/extensions/common/wasm/wasm.cc
+++ b/source/extensions/common/wasm/wasm.cc
@@ -189,6 +189,11 @@ void Wasm::registerCallbacks() {
       &proxy_wasm::ConvertFunctionWordToUint32<decltype(_fn), _fn>::convertFunctionWordToUint32)
   _REGISTER(resolve_dns);
 #undef _REGISTER
+  wasm_vm_->addFailCallback([this](proxy_wasm::FailState fail_state) {
+    if (fail_state == proxy_wasm::FailState::RuntimeError) {
+      lifecycle_stats_handler_.onEvent(WasmEvent::VmCrashed);
+    }
+  });
 }
 
 void Wasm::getFunctions() {

--- a/test/extensions/common/wasm/wasm_test.cc
+++ b/test/extensions/common/wasm/wasm_test.cc
@@ -1589,6 +1589,13 @@ vm_config:
     // The wasm should be in runtime error state now.
     EXPECT_EQ(initial_wasm->fail_state(), proxy_wasm::FailState::RuntimeError);
 
+    // The crashed counter should have incremented exactly once.
+    const std::string crashed_stat_name =
+        absl::StrCat("wasm.envoy.wasm.runtime.", runtime_name, ".crashed");
+    auto crashed_counter = TestUtility::findCounter(server_.store_, crashed_stat_name);
+    ASSERT_NE(nullptr, crashed_counter);
+    EXPECT_EQ(crashed_counter->value(), 1);
+
     // Wait 2 seconds to avoid possible backoff.
     server_.dispatcher_.globalTimeSystem().advanceTimeWait(std::chrono::seconds(2));
 
@@ -1613,6 +1620,9 @@ vm_config:
 
     // The wasm should be in runtime error state again.
     EXPECT_EQ(context_wasm->fail_state(), proxy_wasm::FailState::RuntimeError);
+
+    // The crashed counter should have incremented again (second VM crash).
+    EXPECT_EQ(TestUtility::findCounter(server_.store_, crashed_stat_name)->value(), 2);
 
     // The wasm failed again and the PluginConfig::wasm() will try to reload again but will backoff.
     // The previous wasm will be returned.


### PR DESCRIPTION
Commit Message: A new metric to track crashed wasm VMs
Additional Description: When a runtime error happens (wasm oom or panic), the VM state transitions to failed. A metric is now incremented so that the user can configure an alert .
Risk Level: Low
Testing: Added
Docs Changes: todo
Release Notes: todo
Fixes #34881
