### PR TITLE
fix(on_demand): support VHDS requests with request body

### DIFF
--- a/source/extensions/filters/http/on_demand/on_demand_update.cc
+++ b/source/extensions/filters/http/on_demand/on_demand_update.cc
@@ -210,9 +210,8 @@ void OnDemandRouteUpdate::onRouteConfigUpdateCompletion(bool route_exists) {
     return;
   }
 
-  if (route_exists &&                  // route can be resolved after an on-demand
-                                       // VHDS update
-      !callbacks_->decodingBuffer() && // Redirects with body not yet supported.
+  if (route_exists && // route can be resolved after an on-demand
+                      // VHDS update
       callbacks_->recreateStream(/*headers=*/nullptr)) {
     return;
   }
@@ -226,8 +225,7 @@ void OnDemandRouteUpdate::onClusterDiscoveryCompletion(
     Upstream::ClusterDiscoveryStatus cluster_status) {
   filter_iteration_state_ = Http::FilterHeadersStatus::Continue;
   cluster_discovery_handle_.reset();
-  if (cluster_status == Upstream::ClusterDiscoveryStatus::Available &&
-      !callbacks_->decodingBuffer()) { // Redirects with body not yet supported.
+  if (cluster_status == Upstream::ClusterDiscoveryStatus::Available) {
     const Http::ResponseHeaderMap* headers = nullptr;
     if (callbacks_->recreateStream(headers)) {
       callbacks_->downstreamCallbacks()->clearRouteCache();

--- a/test/extensions/filters/http/on_demand/on_demand_filter_test.cc
+++ b/test/extensions/filters/http/on_demand/on_demand_filter_test.cc
@@ -131,10 +131,10 @@ TEST_F(OnDemandFilterTest,
 }
 
 // tests onRouteConfigUpdateCompletion() when redirect contains a body
-TEST_F(OnDemandFilterTest, TestOnRouteConfigUpdateCompletionContinuesDecodingWithRedirectWithBody) {
+// With the fix, requests with bodies should now properly recreate the stream
+TEST_F(OnDemandFilterTest, TestOnRouteConfigUpdateCompletionRestartsStreamWithRedirectWithBody) {
   Buffer::OwnedImpl buffer;
-  EXPECT_CALL(decoder_callbacks_, continueDecoding());
-  EXPECT_CALL(decoder_callbacks_, decodingBuffer()).WillOnce(Return(&buffer));
+  EXPECT_CALL(decoder_callbacks_, recreateStream(_)).WillOnce(Return(true));
   filter_->onRouteConfigUpdateCompletion(true);
 }
 
@@ -185,13 +185,40 @@ TEST_F(OnDemandFilterTest, OnClusterDiscoveryCompletionClusterFoundRecreateStrea
   filter_->onClusterDiscoveryCompletion(Upstream::ClusterDiscoveryStatus::Available);
 }
 
-// tests onClusterDiscoveryCompletion when a cluster is available, but redirect contains a body
+// tests onClusterDiscoveryCompletion when a cluster is available and redirect contains a body
+// With the fix, requests with bodies should now properly recreate the stream
 TEST_F(OnDemandFilterTest, OnClusterDiscoveryCompletionClusterFoundRedirectWithBody) {
   Buffer::OwnedImpl buffer;
-  EXPECT_CALL(decoder_callbacks_, continueDecoding());
-  EXPECT_CALL(decoder_callbacks_.downstream_callbacks_, clearRouteCache()).Times(0);
-  EXPECT_CALL(decoder_callbacks_, decodingBuffer()).WillOnce(Return(&buffer));
+  EXPECT_CALL(decoder_callbacks_, continueDecoding()).Times(0);
+  EXPECT_CALL(decoder_callbacks_.downstream_callbacks_, clearRouteCache());
+  EXPECT_CALL(decoder_callbacks_, recreateStream(_)).WillOnce(Return(true));
   filter_->onClusterDiscoveryCompletion(Upstream::ClusterDiscoveryStatus::Available);
+}
+
+// Test case specifically for the GitHub issue fix: OnDemand VHDS with request body
+// This test verifies that requests with bodies now properly recreate streams
+// after route discovery, fixing the bug where they would get 404 NR responses
+TEST_F(OnDemandFilterTest, VhdsWithRequestBodyShouldRecreateStream) {
+  Http::TestRequestHeaderMapImpl headers;
+  Buffer::OwnedImpl request_body("test request body");
+
+  // Simulate the scenario: route not initially available
+  EXPECT_CALL(decoder_callbacks_, route()).WillRepeatedly(Return(nullptr));
+  EXPECT_CALL(decoder_callbacks_.downstream_callbacks_, requestRouteConfigUpdate(_));
+
+  // Headers processing should stop iteration to wait for route discovery
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration, filter_->decodeHeaders(headers, false));
+
+  // Body data should be buffered while waiting for route discovery
+  EXPECT_EQ(Http::FilterDataStatus::StopIterationAndWatermark,
+            filter_->decodeData(request_body, true));
+
+  // Now simulate route discovery completion with a body present
+  // The fix ensures this will recreate the stream even with a body
+  EXPECT_CALL(decoder_callbacks_, recreateStream(_)).WillOnce(Return(true));
+
+  // This should now succeed (previously would have called continueDecoding)
+  filter_->onRouteConfigUpdateCompletion(true);
 }
 
 TEST(OnDemandConfigTest, Basic) {


### PR DESCRIPTION
Remove outdated decodingBuffer() checks that prevented stream recreation for requests with bodies. The underlying infrastructure now supports internal redirects with request bodies.

Fixes #18741

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
