### PR TITLE
Allow sharing of xDS client connections for ADS and LRS

### DIFF
--- a/source/common/config/xds_manager_impl.cc
+++ b/source/common/config/xds_manager_impl.cc
@@ -44,12 +44,12 @@
 namespace Envoy {
 namespace Config {
 namespace {
-absl::Status createGrpcClients(Grpc::AsyncClientManager& async_client_manager,
-                               const envoy::config::core::v3::ApiConfigSource& config_source,
-                               Stats::Scope& stats_scope, bool skip_cluster_check,
-                               bool xdstp_config_source,
-                               Grpc::RawAsyncClientSharedPtr& primary_client,
-                               Grpc::RawAsyncClientSharedPtr& failover_client) {
+absl::Status createUniqueClients(Grpc::AsyncClientManager& async_client_manager,
+                                 const envoy::config::core::v3::ApiConfigSource& config_source,
+                                 Stats::Scope& stats_scope, bool skip_cluster_check,
+                                 bool xdstp_config_source,
+                                 Grpc::RawAsyncClientSharedPtr& primary_client,
+                                 Grpc::RawAsyncClientSharedPtr& failover_client) {
   auto factory_primary_or_error = Config::Utility::factoryForGrpcApiConfigSource(
       async_client_manager, config_source, stats_scope, skip_cluster_check, 0 /*grpc_service_idx*/,
       xdstp_config_source);
@@ -70,6 +70,60 @@ absl::Status createGrpcClients(Grpc::AsyncClientManager& async_client_manager,
     success = factory_failover->createUncachedRawAsyncClient();
     RETURN_IF_NOT_OK_REF(success.status());
     failover_client = std::move(*success);
+  }
+  return absl::OkStatus();
+}
+
+absl::Status createSharedClients(Grpc::AsyncClientManager& async_client_manager,
+                                 const envoy::config::core::v3::ApiConfigSource& api_config_source,
+                                 Stats::Scope& stats_scope, bool skip_cluster_check,
+                                 bool xdstp_config_source,
+                                 Grpc::RawAsyncClientSharedPtr& primary_client,
+                                 Grpc::RawAsyncClientSharedPtr& failover_client) {
+  absl::StatusOr<Envoy::OptRef<const envoy::config::core::v3::GrpcService>> maybe_grpc_service =
+      Utility::getGrpcConfigFromApiConfigSource(api_config_source, /*grpc_service_idx*/ 0,
+                                                xdstp_config_source);
+  RETURN_IF_NOT_OK_REF(maybe_grpc_service.status());
+  if (maybe_grpc_service.value().has_value()) {
+    absl::StatusOr<Grpc::RawAsyncClientSharedPtr> success =
+        async_client_manager.getOrCreateRawAsyncClientWithHashKey(
+            Grpc::GrpcServiceConfigWithHashKey(*maybe_grpc_service.value()), stats_scope,
+            skip_cluster_check);
+    RETURN_IF_NOT_OK_REF(success.status());
+    primary_client = std::move(*success);
+  }
+  if (Runtime::runtimeFeatureEnabled("envoy.restart_features.xds_failover_support")) {
+    absl::StatusOr<Envoy::OptRef<const envoy::config::core::v3::GrpcService>> maybe_grpc_service =
+        Utility::getGrpcConfigFromApiConfigSource(api_config_source, /*grpc_service_idx*/ 1,
+                                                  xdstp_config_source);
+    RETURN_IF_NOT_OK_REF(maybe_grpc_service.status());
+    if (maybe_grpc_service.value().has_value()) {
+      absl::StatusOr<Grpc::RawAsyncClientSharedPtr> success =
+          async_client_manager.getOrCreateRawAsyncClientWithHashKey(
+              Grpc::GrpcServiceConfigWithHashKey(*maybe_grpc_service.value()), stats_scope,
+              skip_cluster_check);
+      RETURN_IF_NOT_OK_REF(success.status());
+      failover_client = std::move(*success);
+    }
+  }
+  return absl::OkStatus();
+}
+
+absl::Status createGrpcClients(Grpc::AsyncClientManager& async_client_manager,
+                               const envoy::config::core::v3::ApiConfigSource& api_config_source,
+                               Stats::Scope& stats_scope, bool skip_cluster_check,
+                               bool xdstp_config_source,
+                               Grpc::RawAsyncClientSharedPtr& primary_client,
+                               Grpc::RawAsyncClientSharedPtr& failover_client) {
+
+  if (Runtime::runtimeFeatureEnabled("envoy.restart_features.use_cached_grpc_client_for_xds")) {
+    RETURN_IF_NOT_OK(createSharedClients(async_client_manager, api_config_source, stats_scope,
+                                         skip_cluster_check, xdstp_config_source, primary_client,
+                                         failover_client));
+  } else {
+    RETURN_IF_NOT_OK(createUniqueClients(async_client_manager, api_config_source, stats_scope,
+                                         skip_cluster_check, xdstp_config_source, primary_client,
+                                         failover_client));
   }
   return absl::OkStatus();
 }

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -87,6 +87,7 @@ RUNTIME_GUARD(envoy_restart_features_raise_file_limits);
 RUNTIME_GUARD(envoy_restart_features_skip_backing_cluster_check_for_sds);
 RUNTIME_GUARD(envoy_restart_features_use_eds_cache_for_ads);
 RUNTIME_GUARD(envoy_restart_features_validate_http3_pseudo_headers);
+RUNTIME_GUARD(envoy_restart_features_use_cached_grpc_client_for_xds);
 
 // Begin false flags. Most of them should come with a TODO to flip true.
 

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -500,11 +500,26 @@ absl::Status ClusterManagerImpl::initializeSecondaryClusters(
 
     absl::Status status = Config::Utility::checkTransportVersion(load_stats_config);
     RETURN_IF_NOT_OK(status);
-    auto factory_or_error = Config::Utility::factoryForGrpcApiConfigSource(
-        *async_client_manager_, load_stats_config, *stats_.rootScope(), false, 0, false);
-    RETURN_IF_NOT_OK_REF(factory_or_error.status());
-    absl::StatusOr<Grpc::RawAsyncClientSharedPtr> client_or_error =
-        factory_or_error.value()->createUncachedRawAsyncClient();
+    absl::StatusOr<Grpc::RawAsyncClientSharedPtr> client_or_error;
+    if (Runtime::runtimeFeatureEnabled("envoy.restart_features.use_cached_grpc_client_for_xds")) {
+      absl::StatusOr<Envoy::OptRef<const envoy::config::core::v3::GrpcService>> maybe_grpc_service =
+          Envoy::Config::Utility::getGrpcConfigFromApiConfigSource(load_stats_config,
+                                                                   /*grpc_service_idx*/ 0,
+                                                                   /*xdstp_config_source*/ false);
+      RETURN_IF_NOT_OK_REF(maybe_grpc_service.status());
+      if (maybe_grpc_service.value().has_value()) {
+        client_or_error = async_client_manager_->getOrCreateRawAsyncClientWithHashKey(
+            Grpc::GrpcServiceConfigWithHashKey(*maybe_grpc_service.value()), *stats_.rootScope(),
+            /*skip_cluster_check*/ false);
+      } else {
+        return absl::InvalidArgumentError("Invalid grpc service.");
+      }
+    } else {
+      auto factory_or_error = Config::Utility::factoryForGrpcApiConfigSource(
+          *async_client_manager_, load_stats_config, *stats_.rootScope(), false, 0, false);
+      RETURN_IF_NOT_OK_REF(factory_or_error.status());
+      client_or_error = factory_or_error.value()->createUncachedRawAsyncClient();
+    }
     RETURN_IF_NOT_OK_REF(client_or_error.status());
     load_stats_reporter_ = std::make_unique<LoadStatsReporter>(
         local_info_, *this, *stats_.rootScope(), std::move(client_or_error.value()), dispatcher_);

--- a/test/common/config/xds_manager_impl_test.cc
+++ b/test/common/config/xds_manager_impl_test.cc
@@ -90,12 +90,19 @@ public:
   MOCK_METHOD(Config::SubscriptionPtr, create, (SubscriptionData & data), (override));
 };
 
-class XdsManagerImplTest : public testing::Test {
+class XdsManagerImplTest : public testing::TestWithParam<bool> {
 public:
   XdsManagerImplTest()
       : xds_manager_impl_(dispatcher_, api_, stats_, local_info_, validation_context_, server_) {
     ON_CALL(validation_context_, staticValidationVisitor())
         .WillByDefault(ReturnRef(validation_visitor_));
+    if (GetParam()) {
+      scoped_runtime_.mergeValues(
+          {{"envoy.restart_features.use_cached_grpc_client_for_xds", "true"}});
+    } else {
+      scoped_runtime_.mergeValues(
+          {{"envoy.restart_features.use_cached_grpc_client_for_xds", "false"}});
+    }
   }
 
   void initialize(const std::string& bootstrap_yaml = "") {
@@ -115,16 +122,20 @@ public:
   NiceMock<ProtobufMessage::MockValidationVisitor> validation_visitor_;
   NiceMock<ProtobufMessage::MockValidationContext> validation_context_;
   XdsManagerImpl xds_manager_impl_;
+  TestScopedRuntime scoped_runtime_;
 };
 
+INSTANTIATE_TEST_SUITE_P(XdsManagerImplTest, XdsManagerImplTest,
+                         ::testing::ValuesIn({false, true}));
+
 // Validates that a call to shutdown succeeds.
-TEST_F(XdsManagerImplTest, ShutdownSuccessful) {
+TEST_P(XdsManagerImplTest, ShutdownSuccessful) {
   initialize();
   xds_manager_impl_.shutdown();
 }
 
 // Validates that ADS replacement fails when ADS isn't configured.
-TEST_F(XdsManagerImplTest, AdsReplacementNoPriorAdsRejection) {
+TEST_P(XdsManagerImplTest, AdsReplacementNoPriorAdsRejection) {
   // Make the server return a bootstrap that returns a non-ADS config.
   initialize(R"EOF(
   static_resources:
@@ -162,9 +173,8 @@ TEST_F(XdsManagerImplTest, AdsReplacementNoPriorAdsRejection) {
 }
 
 // Validates that ADS replacement with primary source only works.
-TEST_F(XdsManagerImplTest, AdsReplacementPrimaryOnly) {
-  TestScopedRuntime scoped_runtime;
-  scoped_runtime.mergeValues({{"envoy.restart_features.xds_failover_support", "true"}});
+TEST_P(XdsManagerImplTest, AdsReplacementPrimaryOnly) {
+  scoped_runtime_.mergeValues({{"envoy.restart_features.xds_failover_support", "true"}});
   testing::InSequence s;
   NiceMock<MockGrpcMuxFactory> factory;
   Registry::InjectFactory<Config::MuxFactory> registry(factory);
@@ -252,9 +262,8 @@ TEST_F(XdsManagerImplTest, AdsReplacementPrimaryOnly) {
 }
 
 // Validates that ADS replacement with primary and failover sources works.
-TEST_F(XdsManagerImplTest, AdsReplacementPrimaryAndFailover) {
-  TestScopedRuntime scoped_runtime;
-  scoped_runtime.mergeValues({{"envoy.restart_features.xds_failover_support", "true"}});
+TEST_P(XdsManagerImplTest, AdsReplacementPrimaryAndFailover) {
+  scoped_runtime_.mergeValues({{"envoy.restart_features.xds_failover_support", "true"}});
   testing::InSequence s;
   NiceMock<MockGrpcMuxFactory> factory;
   Registry::InjectFactory<Config::MuxFactory> registry(factory);
@@ -347,7 +356,7 @@ TEST_F(XdsManagerImplTest, AdsReplacementPrimaryAndFailover) {
 }
 
 // Validates that setAdsConfigSource validation failure is detected.
-TEST_F(XdsManagerImplTest, AdsReplacementInvalidConfig) {
+TEST_P(XdsManagerImplTest, AdsReplacementInvalidConfig) {
   testing::InSequence s;
   NiceMock<MockGrpcMuxFactory> factory;
   Registry::InjectFactory<MuxFactory> registry(factory);
@@ -390,7 +399,7 @@ TEST_F(XdsManagerImplTest, AdsReplacementInvalidConfig) {
 }
 
 // Validates that ADS replacement with unknown cluster fails.
-TEST_F(XdsManagerImplTest, AdsReplacementUnknownCluster) {
+TEST_P(XdsManagerImplTest, AdsReplacementUnknownCluster) {
   testing::InSequence s;
   NiceMock<MockGrpcMuxFactory> factory;
   Registry::InjectFactory<MuxFactory> registry(factory);
@@ -433,19 +442,25 @@ TEST_F(XdsManagerImplTest, AdsReplacementUnknownCluster) {
   )EOF",
                             new_ads_config);
 
-  // Emulates an error for gRPC-cluster not found.
-  EXPECT_CALL(cm_.async_client_manager_, factoryForGrpcService(_, _, _))
-      .WillOnce(
-          Return(ByMove(absl::InvalidArgumentError("Unknown gRPC client cluster 'ads_cluster2'"))));
+  if (GetParam()) {
+    // Emulates an error for gRPC-cluster not found.
+    EXPECT_CALL(cm_.async_client_manager_, getOrCreateRawAsyncClientWithHashKey(_, _, _))
+        .WillOnce(Return(
+            ByMove(absl::InvalidArgumentError("Unknown gRPC client cluster 'ads_cluster2'"))));
+  } else {
+    // Emulates an error for gRPC-cluster not found.
+    EXPECT_CALL(cm_.async_client_manager_, factoryForGrpcService(_, _, _))
+        .WillOnce(Return(
+            ByMove(absl::InvalidArgumentError("Unknown gRPC client cluster 'ads_cluster2'"))));
+  }
   const auto res = xds_manager_impl_.setAdsConfigSource(new_ads_config);
   EXPECT_THAT(res, StatusCodeIs(absl::StatusCode::kInvalidArgument));
   EXPECT_EQ(res.message(), "Unknown gRPC client cluster 'ads_cluster2'");
 }
 
 // Validates that ADS replacement with unknown failover cluster fails.
-TEST_F(XdsManagerImplTest, AdsReplacementUnknownFailoverCluster) {
-  TestScopedRuntime scoped_runtime;
-  scoped_runtime.mergeValues({{"envoy.restart_features.xds_failover_support", "true"}});
+TEST_P(XdsManagerImplTest, AdsReplacementUnknownFailoverCluster) {
+  scoped_runtime_.mergeValues({{"envoy.restart_features.xds_failover_support", "true"}});
   testing::InSequence s;
   NiceMock<MockGrpcMuxFactory> factory;
   Registry::InjectFactory<MuxFactory> registry(factory);
@@ -509,24 +524,36 @@ TEST_F(XdsManagerImplTest, AdsReplacementUnknownFailoverCluster) {
   // Emulates a successful finding of the primary_ads_cluster.
   envoy::config::core::v3::GrpcService expected_primary_grpc_service;
   expected_primary_grpc_service.mutable_envoy_grpc()->set_cluster_name("primary_ads_cluster");
-  EXPECT_CALL(cm_.async_client_manager_,
-              factoryForGrpcService(ProtoEq(expected_primary_grpc_service), _, _))
-      .WillOnce(Return(ByMove(std::make_unique<Grpc::MockAsyncClientFactory>())));
+  if (GetParam()) {
+    EXPECT_CALL(cm_.async_client_manager_, getOrCreateRawAsyncClientWithHashKey(_, _, _))
+        .WillOnce(Return(ByMove(std::make_shared<Grpc::MockAsyncClient>())));
+  } else {
+    EXPECT_CALL(cm_.async_client_manager_,
+                factoryForGrpcService(ProtoEq(expected_primary_grpc_service), _, _))
+        .WillOnce(Return(ByMove(std::make_unique<Grpc::MockAsyncClientFactory>())));
+  }
   // Emulates an error for non_existent_failover_ads_cluster not found.
   envoy::config::core::v3::GrpcService expected_failover_grpc_service;
   expected_failover_grpc_service.mutable_envoy_grpc()->set_cluster_name(
       "non_existent_failover_ads_cluster");
-  EXPECT_CALL(cm_.async_client_manager_,
-              factoryForGrpcService(ProtoEq(expected_failover_grpc_service), _, _))
-      .WillOnce(Return(ByMove(absl::InvalidArgumentError(
-          "Unknown gRPC client cluster 'non_existent_failover_ads_cluster'"))));
+  if (GetParam()) {
+    // Emulates an error for gRPC-cluster not found.
+    EXPECT_CALL(cm_.async_client_manager_, getOrCreateRawAsyncClientWithHashKey(_, _, _))
+        .WillOnce(Return(ByMove(absl::InvalidArgumentError(
+            "Unknown gRPC client cluster 'non_existent_failover_ads_cluster'"))));
+  } else {
+    EXPECT_CALL(cm_.async_client_manager_,
+                factoryForGrpcService(ProtoEq(expected_failover_grpc_service), _, _))
+        .WillOnce(Return(ByMove(absl::InvalidArgumentError(
+            "Unknown gRPC client cluster 'non_existent_failover_ads_cluster'"))));
+  }
   const auto res = xds_manager_impl_.setAdsConfigSource(new_ads_config);
   EXPECT_THAT(res, StatusCodeIs(absl::StatusCode::kInvalidArgument));
   EXPECT_EQ(res.message(), "Unknown gRPC client cluster 'non_existent_failover_ads_cluster'");
 }
 
 // Validates that ADS replacement fails when ADS type is different (SotW <-> Delta).
-TEST_F(XdsManagerImplTest, AdsReplacementDifferentAdsTypeRejection) {
+TEST_P(XdsManagerImplTest, AdsReplacementDifferentAdsTypeRejection) {
   NiceMock<MockGrpcMuxFactory> factory;
   Registry::InjectFactory<MuxFactory> registry(factory);
 
@@ -574,7 +601,7 @@ TEST_F(XdsManagerImplTest, AdsReplacementDifferentAdsTypeRejection) {
 }
 
 // Validates that ADS replacement fails when a wrong backoff strategy is used.
-TEST_F(XdsManagerImplTest, AdsReplacementInvalidBackoffRejection) {
+TEST_P(XdsManagerImplTest, AdsReplacementInvalidBackoffRejection) {
   NiceMock<MockGrpcMuxFactory> factory;
   Registry::InjectFactory<Config::MuxFactory> registry(factory);
 
@@ -624,7 +651,7 @@ TEST_F(XdsManagerImplTest, AdsReplacementInvalidBackoffRejection) {
 }
 
 // Validates that ADS replacement of unsupported API type is rejected.
-TEST_F(XdsManagerImplTest, AdsReplacementUnsupportedTypeRejection) {
+TEST_P(XdsManagerImplTest, AdsReplacementUnsupportedTypeRejection) {
   NiceMock<MockGrpcMuxFactory> factory;
   Registry::InjectFactory<Config::MuxFactory> registry(factory);
 
@@ -675,7 +702,7 @@ TEST_F(XdsManagerImplTest, AdsReplacementUnsupportedTypeRejection) {
 
 // Validates that ADS replacement fails when there are a different number of custom validators
 // defined between the original ADS config and the replacement.
-TEST_F(XdsManagerImplTest, AdsReplacementNumberOfCustomValidatorsRejection) {
+TEST_P(XdsManagerImplTest, AdsReplacementNumberOfCustomValidatorsRejection) {
   NiceMock<MockGrpcMuxFactory> factory;
   Registry::InjectFactory<MuxFactory> registry(factory);
   FakeConfigValidatorFactory fake_config_validator_factory;
@@ -729,7 +756,7 @@ TEST_F(XdsManagerImplTest, AdsReplacementNumberOfCustomValidatorsRejection) {
 
 // Validates that ADS replacement fails when a custom validators with some
 // different contents is used compared to the original ADS config.
-TEST_F(XdsManagerImplTest, AdsReplacementContentsOfCustomValidatorsRejection) {
+TEST_P(XdsManagerImplTest, AdsReplacementContentsOfCustomValidatorsRejection) {
   NiceMock<MockGrpcMuxFactory> factory;
   Registry::InjectFactory<Config::MuxFactory> registry(factory);
   FakeConfigValidatorFactory fake_config_validator_factory;


### PR DESCRIPTION
Commit Message:
Additional Description:
Added the ability to use a cached grpc client for xDS grpc streams. This allows for sharing of the grpc connection for ADS and LRS xDS streams if they have identical grpc service configurations.
This change is guarded by envoy.restart_features.use_cached_grpc_client_for_xds.
Risk Level: Low
Testing: Added tests, tested //test/...
Docs Changes: N/A
Release Notes:
Platform Specific Features: N/A
[Optional Runtime guard:] Guarded by envoy.restart_features.use_cached_grpc_client_for_xds

