### PR TITLE
thrift_proxy: simply propagate exception while downstream connection is closing

### DIFF
--- a/source/extensions/filters/network/thrift_proxy/conn_manager.cc
+++ b/source/extensions/filters/network/thrift_proxy/conn_manager.cc
@@ -880,14 +880,22 @@ FilterStatus ConnectionManager::ActiveRpc::messageBegin(MessageMetadataSharedPtr
       metadata->hasFrameSize() ? static_cast<int32_t>(metadata->frameSize()) : -1;
 
   if (error.has_value()) {
-    parent_.stats_.request_internal_error_.inc();
-    std::ostringstream oss;
-    parent_.read_callbacks_->connection().dumpState(oss, 0);
-    ENVOY_STREAM_LOG(error,
-                     "Catch exception: {}. Request seq_id: {}, method: {}, frame size: {}, cluster "
-                     "name: {}, downstream connection state {}, headers:\n{}",
-                     *this, error.value(), metadata_->sequenceId(), method, frame_size,
-                     cluster_name, oss.str(), metadata->requestHeaders());
+    // If downstream connection is closing, we won't be able to proxy and expect this exception.
+    // In this case, just propagate the error and do *not* increase the internal error counter.
+    if (parent_.read_callbacks_->connection().state() == Network::Connection::State::Closing) {
+      ENVOY_CONN_LOG(debug, "thrift: downstream connection closing, not proxying",
+                     parent_.read_callbacks_->connection());
+    } else {
+      parent_.stats_.request_internal_error_.inc();
+      std::ostringstream oss;
+      parent_.read_callbacks_->connection().dumpState(oss, 0);
+      ENVOY_STREAM_LOG(
+          error,
+          "Catch exception: {}. Request seq_id: {}, method: {}, frame size: {}, cluster "
+          "name: {}, downstream connection state {}, headers:\n{}",
+          *this, error.value(), metadata_->sequenceId(), method, frame_size, cluster_name,
+          oss.str(), metadata->requestHeaders());
+    }
     throw EnvoyException(error.value());
   }
 

--- a/test/extensions/filters/network/thrift_proxy/conn_manager_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/conn_manager_test.cc
@@ -1433,6 +1433,37 @@ TEST_F(ThriftConnectionManagerTest, BadFunctionCallExceptionHandling) {
   EXPECT_EQ(access_log_data_, "");
 }
 
+TEST_F(ThriftConnectionManagerTest,
+       BadFunctionCallExceptionHandlingWithClosingDownstreamConnection) {
+  initializeFilter();
+
+  writeFramedBinaryMessage(buffer_, MessageType::Oneway, 0x0F);
+
+  ThriftFilters::DecoderFilterCallbacks* callbacks{};
+  EXPECT_CALL(*decoder_filter_, setDecoderFilterCallbacks(_))
+      .WillOnce(
+          Invoke([&](ThriftFilters::DecoderFilterCallbacks& cb) -> void { callbacks = &cb; }));
+  EXPECT_CALL(*decoder_filter_, messageBegin(_))
+      .WillOnce(Invoke([&](MessageMetadataSharedPtr) -> FilterStatus {
+        // mock that downstream connection is closing
+        filter_callbacks_.connection_.state_ = Network::Connection::State::Closing;
+
+        std::function<int()> func;
+        func(); // throw bad_function_call
+        return FilterStatus::Continue;
+      }));
+
+  // A local exception is sent by error handling.
+  EXPECT_CALL(*decoder_filter_, onLocalReply(_, _));
+  EXPECT_EQ(filter_->onData(buffer_, false), Network::FilterStatus::StopIteration);
+
+  EXPECT_EQ(1U, store_.counter("test.request_decoding_error").value());
+  // Won't increase this counter as it's expected.
+  EXPECT_EQ(0U, store_.counter("test.request_internal_error").value());
+
+  EXPECT_EQ(access_log_data_, "");
+}
+
 // Tests that a request is routed and a non-thrift response is handled.
 TEST_F(ThriftConnectionManagerTest, RequestAndGarbageResponse) {
   initializeFilter();


### PR DESCRIPTION
Commit Message:
After we merge https://github.com/envoyproxy/envoy/pull/26386, we've seen internal error from time to time.
For those observed internal error, downstream connection is always in closing state which makes us trying to avoid logging this known case. Moreover, while downstream connection is in closing state, we shouldn't expect we could successfully proxy this request.

Note that previous exception happens [here](https://github.com/envoyproxy/envoy/blob/6c702f45fadf4abd2f24605e3d9e81c748b13f85/source/extensions/filters/network/thrift_proxy/conn_manager.cc#L566) which is the end of function, which could be opt result which makes us hard to pinpoint.

Additional Description:
Risk Level: low
Testing: unit
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
