### PR TITLE
Replace c-ares with getaddrinfo DNS resolver in sni_dynamic_forward_proxy filter integration test

### DIFF
--- a/test/extensions/filters/network/sni_dynamic_forward_proxy/BUILD
+++ b/test/extensions/filters/network/sni_dynamic_forward_proxy/BUILD
@@ -46,6 +46,7 @@ envoy_extension_cc_test(
         "//source/extensions/filters/listener/tls_inspector:config",
         "//source/extensions/filters/network/sni_dynamic_forward_proxy:config",
         "//source/extensions/filters/network/tcp_proxy:config",
+        "//source/extensions/network/dns_resolver/getaddrinfo:config",
         "//test/integration:http_integration_lib",
         "@envoy_api//envoy/config/bootstrap/v3:pkg_cc_proto",
         "@envoy_api//envoy/config/cluster/v3:pkg_cc_proto",

--- a/test/extensions/filters/network/sni_dynamic_forward_proxy/proxy_filter_integration_test.cc
+++ b/test/extensions/filters/network/sni_dynamic_forward_proxy/proxy_filter_integration_test.cc
@@ -5,6 +5,7 @@
 
 #include "source/common/tls/client_ssl_socket.h"
 #include "source/common/tls/context_config_impl.h"
+#include "source/extensions/network/dns_resolver/getaddrinfo/getaddrinfo.h"
 
 #include "test/integration/http_integration.h"
 #include "test/integration/ssl_utility.h"
@@ -49,6 +50,10 @@ typed_config:
     max_hosts: {}
     dns_cache_circuit_breaker:
       max_pending_requests: {}
+    typed_dns_resolver_config:
+      name: envoy.network.dns_resolver.getaddrinfo
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.network.dns_resolver.getaddrinfo.v3.GetAddrInfoDnsResolverConfig
   port_value: {}
 )EOF",
                       Network::Test::ipVersionToDnsFamily(GetParam()), max_hosts,
@@ -73,6 +78,10 @@ typed_config:
     max_hosts: {}
     dns_cache_circuit_breaker:
       max_pending_requests: {}
+    typed_dns_resolver_config:
+      name: envoy.network.dns_resolver.getaddrinfo
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.network.dns_resolver.getaddrinfo.v3.GetAddrInfoDnsResolverConfig
 )EOF",
         Network::Test::ipVersionToDnsFamily(GetParam()), max_hosts, max_pending_requests);
 


### PR DESCRIPTION
This is a follow up of https://github.com/envoyproxy/envoy/pull/39901
It's the 2nd step to address: https://github.com/envoyproxy/envoy/issues/39900