### PR TITLE
Replace c-ares with getaddrinfo DNS resolver in ext_authz filter integration test

### DIFF
--- a/test/extensions/filters/http/ext_authz/BUILD
+++ b/test/extensions/filters/http/ext_authz/BUILD
@@ -82,6 +82,7 @@ envoy_extension_cc_test(
         "//source/extensions/clusters/dns:dns_cluster_lib",
         "//source/extensions/filters/http/ext_authz:config",
         "//source/extensions/listener_managers/validation_listener_manager:validation_listener_manager_lib",
+        "//source/extensions/network/dns_resolver/getaddrinfo:config",
         "//source/server/config_validation:server_lib",
         "//test/integration:http_integration_lib",
         "//test/mocks/server:options_mocks",

--- a/test/extensions/filters/http/ext_authz/ext_authz.yaml
+++ b/test/extensions/filters/http/ext_authz/ext_authz.yaml
@@ -43,6 +43,10 @@ static_resources:
   - name: local_service
     connect_timeout: 30s
     type: STRICT_DNS
+    typed_dns_resolver_config:
+      name: envoy.network.dns_resolver.getaddrinfo
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.network.dns_resolver.getaddrinfo.v3.GetAddrInfoDnsResolverConfig
     lb_policy: ROUND_ROBIN
     load_assignment:
       cluster_name: local_service
@@ -55,6 +59,10 @@ static_resources:
                 port_value: 8080
   - name: ext_authz-service
     type: STRICT_DNS
+    typed_dns_resolver_config:
+      name: envoy.network.dns_resolver.getaddrinfo
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.network.dns_resolver.getaddrinfo.v3.GetAddrInfoDnsResolverConfig
     lb_policy: ROUND_ROBIN
     typed_extension_protocol_options:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:

--- a/test/extensions/filters/http/ext_authz/ext_authz_integration_test.cc
+++ b/test/extensions/filters/http/ext_authz/ext_authz_integration_test.cc
@@ -6,6 +6,7 @@
 #include "source/common/common/macros.h"
 #include "source/extensions/filters/common/ext_authz/ext_authz.h"
 #include "source/extensions/filters/http/ext_authz/ext_authz.h"
+#include "source/extensions/network/dns_resolver/getaddrinfo/getaddrinfo.h"
 #include "source/server/config_validation/server.h"
 
 #include "test/common/grpc/grpc_client_integration.h"


### PR DESCRIPTION
This is a follow up of https://github.com/envoyproxy/envoy/pull/40894
It's the 3rd step to address: https://github.com/envoyproxy/envoy/issues/39900
