### PR TITLE
Replace c-ares with getaddrinfo DNS resolver in RBAC filter integration test

### DIFF
--- a/test/extensions/filters/http/rbac/BUILD
+++ b/test/extensions/filters/http/rbac/BUILD
@@ -78,6 +78,7 @@ envoy_extension_cc_test(
         "//source/extensions/matching/input_matchers/cel_matcher:config",
         "//source/extensions/matching/input_matchers/ip:config",
         "//source/extensions/matching/network/common:inputs_lib",
+        "//source/extensions/network/dns_resolver/getaddrinfo:config",
         "//test/config:utility_lib",
         "//test/integration:http_protocol_integration_lib",
         "@envoy_api//envoy/extensions/filters/http/rbac/v3:pkg_cc_proto",

--- a/test/extensions/filters/http/rbac/rbac_filter_integration_test.cc
+++ b/test/extensions/filters/http/rbac/rbac_filter_integration_test.cc
@@ -2,6 +2,7 @@
 #include "envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.pb.h"
 
 #include "source/common/protobuf/utility.h"
+#include "source/extensions/network/dns_resolver/getaddrinfo/getaddrinfo.h"
 
 #include "test/integration/http_protocol_integration.h"
 
@@ -1594,6 +1595,10 @@ typed_config:
   dns_cache_config:
     name: foo
     dns_lookup_family: {}
+    typed_dns_resolver_config:
+      name: envoy.network.dns_resolver.getaddrinfo
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.network.dns_resolver.getaddrinfo.v3.GetAddrInfoDnsResolverConfig
 )EOF",
                     save_upstream_config, Network::Test::ipVersionToDnsFamily(GetParam()));
 
@@ -1636,6 +1641,10 @@ typed_config:
   dns_cache_config:
     name: foo
     dns_lookup_family: {}
+    typed_dns_resolver_config:
+      name: envoy.network.dns_resolver.getaddrinfo
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.network.dns_resolver.getaddrinfo.v3.GetAddrInfoDnsResolverConfig
 )EOF",
         Network::Test::ipVersionToDnsFamily(GetParam()));
 


### PR DESCRIPTION
This is a follow up of https://github.com/envoyproxy/envoy/pull/40895
It's the 3rd step to address: https://github.com/envoyproxy/envoy/issues/39900
