### PR TITLE
aws: remove cancel from destructor

### DIFF
--- a/source/extensions/common/aws/metadata_credentials_provider_base.h
+++ b/source/extensions/common/aws/metadata_credentials_provider_base.h
@@ -41,6 +41,13 @@ public:
                                   MetadataFetcher::MetadataReceiver::RefreshState refresh_state,
                                   std::chrono::seconds initialization_timer);
 
+  ~MetadataCredentialsProviderBase() override {
+    if (metadata_fetcher_) {
+      metadata_fetcher_->cancel();
+      metadata_fetcher_.reset();
+    }
+  }
+
   Credentials getCredentials() override;
   bool credentialsPending() override;
 

--- a/source/extensions/common/aws/metadata_fetcher.cc
+++ b/source/extensions/common/aws/metadata_fetcher.cc
@@ -19,8 +19,7 @@ public:
   MetadataFetcherImpl(Upstream::ClusterManager& cm, absl::string_view cluster_name)
       : cm_(cm), cluster_name_(std::string(cluster_name)) {}
 
-  // TODO(suniltheta): Verify that bypassing virtual dispatch here was intentional
-  ~MetadataFetcherImpl() override { MetadataFetcherImpl::cancel(); }
+  ~MetadataFetcherImpl() override { reset(); }
 
   void cancel() override {
     if (request_ && !complete_) {


### PR DESCRIPTION
Commit Message: aws: remove cancel from destructor
Additional Description: Addresses customer reported exception during cleanup of metadata provider. Provider was calling cancel from a non main thread inside the destructor.
Risk Level: Low
Testing: Unit
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
