### PR TITLE
server: enhance skip_deprecated_logs for deprecated runtime key warning

### DIFF
--- a/source/server/options_impl.cc
+++ b/source/server/options_impl.cc
@@ -276,8 +276,10 @@ OptionsImpl::OptionsImpl(std::vector<std::string> args,
   config_path_ = config_path.getValue();
   config_yaml_ = config_yaml.getValue();
   if (allow_unknown_fields.getValue()) {
-    ENVOY_LOG(warn,
-              "--allow-unknown-fields is deprecated, use --allow-unknown-static-fields instead.");
+    if (!skip_deprecated_logs.getValue()) {
+      ENVOY_LOG(warn,
+                "--allow-unknown-fields is deprecated, use --allow-unknown-static-fields instead.");
+    }
   }
   allow_unknown_static_fields_ =
       allow_unknown_static_fields.getValue() || allow_unknown_fields.getValue();

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -907,11 +907,13 @@ void InstanceBase::onRuntimeReady() {
 
   // TODO (nezdolik): Fully deprecate this runtime key in the next release.
   if (runtime().snapshot().get(Runtime::Keys::GlobalMaxCxRuntimeKey)) {
-    ENVOY_LOG(warn,
-              "Usage of the deprecated runtime key {}, consider switching to "
-              "`envoy.resource_monitors.global_downstream_max_connections` instead."
-              "This runtime key will be removed in future.",
-              Runtime::Keys::GlobalMaxCxRuntimeKey);
+    if (!options_.skipDeprecatedLogs()) {
+      ENVOY_LOG(warn,
+                "Usage of the deprecated runtime key {}, consider switching to "
+                "`envoy.resource_monitors.global_downstream_max_connections` instead."
+                "This runtime key will be removed in future.",
+                Runtime::Keys::GlobalMaxCxRuntimeKey);
+    }
   }
 }
 

--- a/test/server/options_impl_test.cc
+++ b/test/server/options_impl_test.cc
@@ -684,5 +684,20 @@ public:
   }
 };
 
+// Test that deprecated --allow-unknown-fields warning is logged when skip_deprecated_logs is false
+TEST_F(OptionsImplTest, DeprecatedAllowUnknownFieldsWarningWhenNotSkipped) {
+  EXPECT_LOG_CONTAINS(
+      "warn", "--allow-unknown-fields is deprecated, use --allow-unknown-static-fields instead.",
+      createOptionsImpl("envoy --allow-unknown-fields"));
+}
+
+// Test that deprecated --allow-unknown-fields warning is suppressed when skip_deprecated_logs is
+// true
+TEST_F(OptionsImplTest, DeprecatedAllowUnknownFieldsWarningWhenSkipped) {
+  EXPECT_LOG_NOT_CONTAINS(
+      "warn", "--allow-unknown-fields is deprecated, use --allow-unknown-static-fields instead.",
+      createOptionsImpl("envoy --allow-unknown-fields --skip-deprecated-logs"));
+}
+
 } // namespace
 } // namespace Envoy

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -1856,6 +1856,34 @@ TEST_P(ServerInstanceImplTest, TextApplicationLog) {
   ENVOY_LOG_MISC(info, "hello");
 }
 
+// Test that deprecated runtime key warning is logged when skip_deprecated_logs is false
+TEST_P(ServerInstanceImplTest, DeprecatedRuntimeKeyWarningWhenNotSkipped) {
+  // Set skip_deprecated_logs to false (default)
+  ON_CALL(options_, skipDeprecatedLogs()).WillByDefault(Return(false));
+
+  EXPECT_LOG_CONTAINS(
+      "warn",
+      "Usage of the deprecated runtime key overload.global_downstream_max_connections, consider "
+      "switching to "
+      "`envoy.resource_monitors.global_downstream_max_connections` instead."
+      "This runtime key will be removed in future.",
+      { initialize("test/server/test_data/server/deprecated_runtime_key_bootstrap.yaml"); });
+}
+
+// Test that deprecated runtime key warning is suppressed when skip_deprecated_logs is true
+TEST_P(ServerInstanceImplTest, DeprecatedRuntimeKeyWarningWhenSkipped) {
+  // Set skip_deprecated_logs to true
+  ON_CALL(options_, skipDeprecatedLogs()).WillByDefault(Return(true));
+
+  EXPECT_LOG_NOT_CONTAINS(
+      "warn",
+      "Usage of the deprecated runtime key overload.global_downstream_max_connections, consider "
+      "switching to "
+      "`envoy.resource_monitors.global_downstream_max_connections` instead."
+      "This runtime key will be removed in future.",
+      { initialize("test/server/test_data/server/deprecated_runtime_key_bootstrap.yaml"); });
+}
+
 } // namespace
 } // namespace Server
 } // namespace Envoy

--- a/test/server/test_data/server/deprecated_runtime_key_bootstrap.yaml
+++ b/test/server/test_data/server/deprecated_runtime_key_bootstrap.yaml
@@ -1,0 +1,34 @@
+node:
+  id: bootstrap_id
+  cluster: bootstrap_cluster
+  locality:
+    zone: bootstrap_zone
+    sub_zone: bootstrap_sub_zone
+
+layered_runtime:
+  layers:
+  - name: static_layer
+    static_layer:
+      overload.global_downstream_max_connections: "100"
+
+admin:
+  address:
+    socket_address:
+      protocol: TCP
+      address: 127.0.0.1
+      port_value: 0
+
+static_resources:
+  clusters:
+  - name: service_google
+    type: LOGICAL_DNS
+    lb_policy: ROUND_ROBIN
+    load_assignment:
+      cluster_name: service_google
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: 127.0.0.1
+                port_value: 0


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: enhance `skip_deprecated_logs` for deprecated runtime key warning 

Additional Description: Enhances the existing skip_deprecated_logs functionality to conditionally log the deprecated runtime key warning in server.cc, following the same pattern as message_validator_impl.cc.
Also extends skip_deprecated_logs support to options_impl.cc for consistent deprecated warning suppression across the codebase. 

Risk Level: Low
Testing: Added unit tests for skip_deprecated_logs functionality covering both server runtime key warnings and options_impl command-line flag warnings. Tests verify both positive (warning logged) and negative (warning suppressed) scenarios. All tests pass successfully.
Docs Changes: N/A
Release Notes: N/A

Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
