### PR TITLE
ext_proc: increasing tracing integration test timeout to be 1s to avoid flaky

### DIFF
--- a/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
+++ b/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
@@ -950,6 +950,7 @@ TEST_P(ExtProcIntegrationTest, GetAndCloseStream) {
 }
 
 TEST_P(ExtProcIntegrationTest, GetAndCloseStreamWithTracing) {
+  proto_config_.mutable_message_timeout()->set_seconds(1);
   // Turn on debug to troubleshoot possible flaky test.
   // TODO(cainelli): Remove this and the debug logs in the tracer test filter after a test failure
   // occurs.


### PR DESCRIPTION

Fix https://github.com/envoyproxy/envoy/issues/36041