### PR TITLE
listener: Fix incorrect error status handling when failing to change netns

### DIFF
--- a/source/common/network/utility.h
+++ b/source/common/network/utility.h
@@ -410,6 +410,10 @@ public:
 
     // Restore the original network namespace before returning the function result.
     setns_result = Api::LinuxOsSysCallsSingleton().get().setns(og_netns_fd, CLONE_NEWNET);
+
+    // If we cannot jump back into the original network namespace, this is an unrecoverable error.
+    // It would leave the current thread in another network namespace indefinitely, so we cannot
+    // continue running in that state.
     RELEASE_ASSERT(
         setns_result.return_value_ == 0,
         fmt::format("failed to restore original netns (fd={}): {}", netns_fd, errorDetails(errno)));


### PR DESCRIPTION
When creating a listener socket in another network namespace, a nested `absl::StatusOr<>` is returned. The outer status shows the result of the attempt to switch network namespaces and the inner status is the result of the creation of a listener socket.

This patch fixes a bug where we checked the inner status when we should have been checking the outer status. This results in a segfault because the outer status is dereferenced without first checking if it was OK.

We now check the correct results and additional comments have been added to improve clarity of this code.

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Risk Level: Low
Testing: Existing UT
Docs Changes: n/a
Release Notes: Added
Platform Specific Features: Linux only
