### PR TITLE
Replace c-ares with getaddrinfo DNS resolver in connect_integration_test

### DIFF
--- a/test/extensions/transport_sockets/http_11_proxy/BUILD
+++ b/test/extensions/transport_sockets/http_11_proxy/BUILD
@@ -38,6 +38,7 @@ envoy_extension_cc_test(
         "//source/extensions/filters/http/dynamic_forward_proxy:config",
         "//source/extensions/filters/network/tcp_proxy:config",
         "//source/extensions/key_value/file_based:config_lib",
+        "//source/extensions/network/dns_resolver/getaddrinfo:config",
         "//source/extensions/transport_sockets/http_11_proxy:upstream_config",
         "//test/integration:http_integration_lib",
         "//test/integration:integration_lib",

--- a/test/extensions/transport_sockets/http_11_proxy/connect_integration_test.cc
+++ b/test/extensions/transport_sockets/http_11_proxy/connect_integration_test.cc
@@ -30,6 +30,10 @@ typed_config:
   "@type": type.googleapis.com/envoy.extensions.filters.http.dynamic_forward_proxy.v3.FilterConfig
   dns_cache_config:
     name: foo
+    typed_dns_resolver_config:
+      name: envoy.network.dns_resolver.getaddrinfo
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.network.dns_resolver.getaddrinfo.v3.GetAddrInfoDnsResolverConfig
 )EOF";
     config_helper_.prependFilter(filter);
 
@@ -42,6 +46,10 @@ typed_config:
   "@type": type.googleapis.com/envoy.extensions.clusters.dynamic_forward_proxy.v3.ClusterConfig
   dns_cache_config:
     name: foo
+    typed_dns_resolver_config:
+      name: envoy.network.dns_resolver.getaddrinfo
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.network.dns_resolver.getaddrinfo.v3.GetAddrInfoDnsResolverConfig
 )EOF";
       TestUtility::loadFromYaml(cluster_type_config, *cluster->mutable_cluster_type());
       cluster->clear_load_assignment();


### PR DESCRIPTION
This is a follow up of https://github.com/envoyproxy/envoy/pull/40896
It's the 5th step to address: https://github.com/envoyproxy/envoy/issues/39900
