### PR TITLE
stats: fix a bug where the prometheus name of ssl certificate stats are wrong (#40891)

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -16,6 +16,12 @@ bug_fixes:
   change: |
     Fixed an UAF in DNS cache that can occur when the Host header is modified between the Dynamic Forwarding and Router
     filters.
+- area: stats
+  change: |
+    Fixed a bug where the metric name ``expiration_unix_time_seconds`` of
+    ``cluster.<cluster_name>.ssl.certificate.<cert_name>.<metric_name>``
+    and ``listener.<address>.ssl.certificate.<cert_name>.<metric_name>``
+    was not being properly extracted in the final prometheus stat name.
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/source/common/config/well_known_names.cc
+++ b/source/common/config/well_known_names.cc
@@ -242,7 +242,7 @@ TagNameValues::TagNameValues() {
   // listener.[<address>.]ssl.certificate.(<cert_name>).<metric_name> or
   // cluster.[<cluster_name>.]ssl.certificate.(<cert_name>).<metric_name>
   addRe2(TLS_CERTIFICATE,
-         R"(^<LISTENER_OR_CLUSTER_WITH_NAME>\.ssl\.certificate(\.(<TAG_VALUE>)\..*)$)",
+         R"(^<LISTENER_OR_CLUSTER_WITH_NAME>\.ssl\.certificate\.((<TAG_VALUE>)\.).*$)",
          ".ssl.certificate");
 }
 

--- a/test/common/stats/tag_extractor_impl_test.cc
+++ b/test/common/stats/tag_extractor_impl_test.cc
@@ -526,7 +526,8 @@ TEST(TagExtractorTest, DefaultTagExtractors) {
   listener_address.value_ = "0.0.0.0_0";
   regex_tester.testRegex(
       "listener.0.0.0.0_0.ssl.certificate.server_cert.expiration_unix_time_seconds",
-      "listener.ssl.certificate", {listener_address, certificate_name});
+      "listener.ssl.certificate.expiration_unix_time_seconds",
+      {listener_address, certificate_name});
 
   // Cluster test
   Tag test_cluster;
@@ -534,7 +535,7 @@ TEST(TagExtractorTest, DefaultTagExtractors) {
   test_cluster.value_ = "test_cluster";
   regex_tester.testRegex(
       "cluster.test_cluster.ssl.certificate.server_cert.expiration_unix_time_seconds",
-      "cluster.ssl.certificate", {test_cluster, certificate_name});
+      "cluster.ssl.certificate.expiration_unix_time_seconds", {test_cluster, certificate_name});
 }
 
 TEST(TagExtractorTest, ExtAuthzTagExtractors) {


### PR DESCRIPTION
Commit Message: stats: fix a bug where the prometheus name of ssl certificate stats are wrong 
Additional Description:

See #40891

Risk Level: low.
Testing: unit.
Docs Changes: n/a.
Release Notes: added.
Platform Specific Features: n/a.