### PR TITLE
docker/release: Fix distroless hash to use nonroot

### DIFF
--- a/distribution/docker/Dockerfile-envoy
+++ b/distribution/docker/Dockerfile-envoy
@@ -59,7 +59,7 @@ COPY --chown=0:0 --chmod=755 \
 
 
 # STAGE: envoy-distroless
-FROM gcr.io/distroless/base-nossl-debian12:nonroot@sha256:6fe9fd551fab9d442b7ee7096b8fcf286047ff91bac31bc577270bb77afa0184 AS envoy-distroless
+FROM gcr.io/distroless/base-nossl-debian12:nonroot@sha256:8981b63f968e829d21351ea9d28cc21127e5f034707f1d8483d2993d9577be0b AS envoy-distroless
 EXPOSE 10000
 ENTRYPOINT ["/usr/local/bin/envoy"]
 CMD ["-c", "/etc/envoy/envoy.yaml"]


### PR DESCRIPTION
Fix #40954 