### PR TITLE
[1.33] Restore `ENVOY_STDLIB` variable

### DIFF
--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -53,6 +53,7 @@ x-envoy-build-base: &envoy-build-base
   - ENVOY_REPO
   - ENVOY_BUILD_ARCH
   - ENVOY_GEN_COMPDB_OPTIONS
+  - ENVOY_STDLIB
 
   # Publishing and artifacts
   - DOCKERHUB_USERNAME


### PR DESCRIPTION
It was silently removed after https://github.com/envoyproxy/envoy/pull/40541

While it was removed in main and in 1.35, it's still used by CI in 1.33.
