### PR TITLE
tls: future-proof UnsupportedCurveEcdsaCert's test expectation

### DIFF
--- a/test/common/tls/context_impl_test.cc
+++ b/test/common/tls/context_impl_test.cc
@@ -1618,12 +1618,13 @@ TEST_F(ClientContextConfigImplTest, UnsupportedCurveEcdsaCert) {
                             *tls_context.mutable_common_tls_context()->add_tls_certificates());
   auto client_context_config = *ClientContextConfigImpl::create(tls_context, factory_context_);
   Stats::IsolatedStoreImpl store;
+  // Envoy has logic to reject P-224, but newer versions of BoringSSL reject it in `SSL_CTX`
+  // before Envoy's logic runs. This test expectation is written to accept both paths.
   EXPECT_THAT(manager_.createSslClientContext(*store.rootScope(), *client_context_config)
                   .status()
                   .message(),
               testing::ContainsRegex(
-                  "Failed to load certificate chain from .*selfsigned_secp224r1_cert.pem, "
-                  "only P-256, P-384 or P-521 ECDSA certificates are supported"));
+                  "Failed to load certificate chain from .*selfsigned_secp224r1_cert.pem"));
 }
 
 // Multiple TLS certificates are not yet supported.


### PR DESCRIPTION
Commit Message:
Envoy has logic to reject P-224, but newer versions of BoringSSL reject it in `SSL_CTX` before Envoy's logic runs. Fix the test expectation to accept both paths.

(It was already not possible to use a P-224 TLS key in BoringSSL because we didn't recognize the P-224 NamedCurve codepoint in TLS 1.2, and there is no P-224 SignatureScheme codepoint in TLS 1.3. BoringSSL just didn't notice in SSL_CTX_use_certificate before.)

Additional Description:
Risk Level: none, this is a test-only change
Testing: run the test changed in this test-only change
Docs Changes: no, this is a test only change
Release Notes: no, this is a test only change
Platform Specific Features: no, this is a test only change
[Optional Runtime guard:] no, this is a test only change
[Optional Fixes #Issue] no, this is a test only change
[Optional Fixes commit #PR or SHA] no, this is a test only change
[Optional Deprecated:] no, this is a test only change
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):] no, this is a test only change
