### PR TITLE
ratelimits: to support apply on stream done at filter config

### DIFF
--- a/api/envoy/extensions/filters/http/ratelimit/v3/rate_limit.proto
+++ b/api/envoy/extensions/filters/http/ratelimit/v3/rate_limit.proto
@@ -185,8 +185,6 @@ message RateLimit {
   //   2. :ref:`dynamic metadata <envoy_v3_api_field_config.route.v3.RateLimit.Action.dynamic_metadata>`.
   //   3. :ref:`disable_key <envoy_v3_api_field_config.route.v3.RateLimit.disable_key>`.
   //   4. :ref:`override limit <envoy_v3_api_field_config.route.v3.RateLimit.limit>`.
-  //   5. :ref:`hits_addend <envoy_v3_api_field_config.route.v3.RateLimit.hits_addend>`.
-  //   6. :ref:`apply_on_stream_done <envoy_v3_api_field_config.route.v3.RateLimit.apply_on_stream_done>`.
   repeated config.route.v3.RateLimit rate_limits = 17;
 }
 

--- a/source/extensions/filters/http/ratelimit/ratelimit.cc
+++ b/source/extensions/filters/http/ratelimit/ratelimit.cc
@@ -97,8 +97,8 @@ void Filter::populateRateLimitDescriptors(std::vector<Envoy::RateLimit::Descript
   }
 
   // Rate Limit config in typed_per_filter_config takes precedence over route's rate limit.
-  if (config_.get()->hasRateLimitConfigs()) {
-    config_.get()->populateDescriptors(headers, callbacks_->streamInfo(), descriptors);
+  if (config_->hasRateLimitConfigs()) {
+    config_->populateDescriptors(headers, callbacks_->streamInfo(), descriptors, on_stream_done);
     return;
   }
 

--- a/source/extensions/filters/http/ratelimit/ratelimit.h
+++ b/source/extensions/filters/http/ratelimit/ratelimit.h
@@ -37,6 +37,8 @@ enum class FilterRequestType { Internal, External, Both };
  */
 enum class VhRateLimitOptions { Override, Include, Ignore };
 
+using RateLimitConfig = Extensions::Filters::Common::RateLimit::RateLimitConfig;
+
 /**
  * Global configuration for the HTTP rate limit filter.
  */
@@ -116,9 +118,11 @@ public:
   }
   void populateDescriptors(const Http::RequestHeaderMap& headers,
                            const StreamInfo::StreamInfo& info,
-                           Filters::Common::RateLimit::RateLimitDescriptors& descriptors) const {
+                           Filters::Common::RateLimit::RateLimitDescriptors& descriptors,
+                           bool on_stream_done) const {
     ASSERT(rate_limit_config_ != nullptr);
-    rate_limit_config_->populateDescriptors(headers, info, local_info_.clusterName(), descriptors);
+    rate_limit_config_->populateDescriptors(headers, info, local_info_.clusterName(), descriptors,
+                                            on_stream_done);
   }
 
 private:
@@ -167,7 +171,7 @@ private:
   const absl::optional<Envoy::Runtime::FractionalPercent> filter_enabled_;
   const absl::optional<Envoy::Runtime::FractionalPercent> filter_enforced_;
   const absl::optional<Envoy::Runtime::FractionalPercent> failure_mode_deny_percent_;
-  std::unique_ptr<Extensions::Filters::Common::RateLimit::RateLimitConfig> rate_limit_config_;
+  std::unique_ptr<RateLimitConfig> rate_limit_config_;
 };
 
 using FilterConfigSharedPtr = std::shared_ptr<FilterConfig>;
@@ -210,7 +214,7 @@ private:
   const envoy::extensions::filters::http::ratelimit::v3::RateLimitPerRoute::VhRateLimitsOptions
       vh_rate_limits_;
   const std::string domain_;
-  std::unique_ptr<Extensions::Filters::Common::RateLimit::RateLimitConfig> rate_limit_config_;
+  std::unique_ptr<RateLimitConfig> rate_limit_config_;
 };
 
 using FilterConfigPerRouteSharedPtr = std::shared_ptr<FilterConfigPerRoute>;


### PR DESCRIPTION
Commit Message: ratelimits: to support apply on stream done at filter config
Additional Description:

At #40118, we added the `rate_limits` in the filter config of rate limit filter. But the apply on stream done is disabled. This PR removed related restrictions and make the `rate_limits` at the filter config has similar ability with the one in the route level filter config.

**Change log is not added because this should could be treat as supplement to the #40118 and could reuse its change log.**

Risk Level: low.
Testing: unit.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.