### PR TITLE
Adding c-ares DNS resolving integration test under extension specific folder

### DIFF
--- a/test/extensions/network/dns_resolver/cares/BUILD
+++ b/test/extensions/network/dns_resolver/cares/BUILD
@@ -46,6 +46,7 @@ envoy_cc_test(
     tags = ["fails_on_clang_cl"],
     deps = [
         "//source/extensions/clusters/dns:dns_cluster_lib",
+        "//source/extensions/network/dns_resolver/cares:config",
         "//test/integration:http_integration_lib",
     ],
 )

--- a/test/extensions/network/dns_resolver/cares/BUILD
+++ b/test/extensions/network/dns_resolver/cares/BUILD
@@ -39,3 +39,13 @@ envoy_cc_test(
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
     ],
 )
+
+envoy_cc_test(
+    name = "dns_impl_integration_test",
+    srcs = ["dns_impl_integration_test.cc"],
+    tags = ["fails_on_clang_cl"],
+    deps = [
+        "//source/extensions/clusters/dns:dns_cluster_lib",
+        "//test/integration:http_integration_lib",
+    ],
+)

--- a/test/extensions/network/dns_resolver/cares/dns_impl_integration_test.cc
+++ b/test/extensions/network/dns_resolver/cares/dns_impl_integration_test.cc
@@ -1,0 +1,58 @@
+#include "test/integration/http_integration.h"
+
+namespace Envoy {
+namespace Network {
+namespace {
+
+class DnsImplIntegrationTest : public testing::TestWithParam<Network::Address::IpVersion>,
+                               public HttpIntegrationTest {
+ public:
+  DnsImplIntegrationTest() : HttpIntegrationTest(Http::CodecType::HTTP2, GetParam()) {}
+};
+
+INSTANTIATE_TEST_SUITE_P(IpVersions, DnsImplIntegrationTest,
+                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+                         TestUtility::ipTestParamsToString);
+
+
+TEST_P(DnsImplIntegrationTest, LogicalDns) {
+  config_helper_.addConfigModifier([&](envoy::config::bootstrap::v3::Bootstrap& bootstrap) -> void {
+    RELEASE_ASSERT(bootstrap.mutable_static_resources()->clusters_size() == 1, "");
+    auto& cluster = *bootstrap.mutable_static_resources()->mutable_clusters(0);
+    cluster.set_type(envoy::config::cluster::v3::Cluster::LOGICAL_DNS);
+    cluster.set_dns_lookup_family(envoy::config::cluster::v3::Cluster::ALL);
+  });
+  config_helper_.addConfigModifier(
+      [](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
+             hcm) {
+        auto* route = hcm.mutable_route_config()->mutable_virtual_hosts(0)->mutable_routes(0);
+        route->mutable_route()->mutable_auto_host_rewrite()->set_value(true);
+      });
+  initialize();
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+  auto response =
+      sendRequestAndWaitForResponse(default_request_headers_, 0, default_response_headers_, 0);
+
+  ASSERT_TRUE(response->complete());
+  EXPECT_EQ("200", response->headers().getStatusValue());
+}
+
+TEST_P(DnsImplIntegrationTest, StrictDns) {
+  config_helper_.addConfigModifier([&](envoy::config::bootstrap::v3::Bootstrap& bootstrap) -> void {
+    RELEASE_ASSERT(bootstrap.mutable_static_resources()->clusters_size() == 1, "");
+    auto& cluster = *bootstrap.mutable_static_resources()->mutable_clusters(0);
+    cluster.set_type(envoy::config::cluster::v3::Cluster::STRICT_DNS);
+    cluster.set_dns_lookup_family(envoy::config::cluster::v3::Cluster::ALL);
+  });
+  initialize();
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+  auto response =
+      sendRequestAndWaitForResponse(default_request_headers_, 0, default_response_headers_, 0);
+
+  ASSERT_TRUE(response->complete());
+  EXPECT_EQ("200", response->headers().getStatusValue());
+}
+
+} // namespace
+} // namespace network
+} // namespace Envoy

--- a/test/extensions/network/dns_resolver/cares/dns_impl_integration_test.cc
+++ b/test/extensions/network/dns_resolver/cares/dns_impl_integration_test.cc
@@ -6,7 +6,7 @@ namespace {
 
 class DnsImplIntegrationTest : public testing::TestWithParam<Network::Address::IpVersion>,
                                public HttpIntegrationTest {
- public:
+public:
   DnsImplIntegrationTest() : HttpIntegrationTest(Http::CodecType::HTTP2, GetParam()) {}
 };
 
@@ -14,8 +14,7 @@ INSTANTIATE_TEST_SUITE_P(IpVersions, DnsImplIntegrationTest,
                          testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                          TestUtility::ipTestParamsToString);
 
-
-TEST_P(DnsImplIntegrationTest, LogicalDns) {
+TEST_P(DnsImplIntegrationTest, LogicalDnsWithCaresResolver) {
   config_helper_.addConfigModifier([&](envoy::config::bootstrap::v3::Bootstrap& bootstrap) -> void {
     RELEASE_ASSERT(bootstrap.mutable_static_resources()->clusters_size() == 1, "");
     auto& cluster = *bootstrap.mutable_static_resources()->mutable_clusters(0);
@@ -37,7 +36,7 @@ TEST_P(DnsImplIntegrationTest, LogicalDns) {
   EXPECT_EQ("200", response->headers().getStatusValue());
 }
 
-TEST_P(DnsImplIntegrationTest, StrictDns) {
+TEST_P(DnsImplIntegrationTest, StrictDnsWithCaresResolver) {
   config_helper_.addConfigModifier([&](envoy::config::bootstrap::v3::Bootstrap& bootstrap) -> void {
     RELEASE_ASSERT(bootstrap.mutable_static_resources()->clusters_size() == 1, "");
     auto& cluster = *bootstrap.mutable_static_resources()->mutable_clusters(0);
@@ -54,5 +53,5 @@ TEST_P(DnsImplIntegrationTest, StrictDns) {
 }
 
 } // namespace
-} // namespace network
+} // namespace Network
 } // namespace Envoy


### PR DESCRIPTION
This is a follow up of https://github.com/envoyproxy/envoy/pull/40938
It's the 7th step to address: https://github.com/envoyproxy/envoy/issues/39900

While we are trying to remove c-ares from integration tests in different components, this PR adds back a couple c-ares integration test cases under c-ares extension to make sure c-ares DNS resolving is covered in integration test.