### PR TITLE
xds-federation: introduce OD-CDS xds-federation support

### DIFF
--- a/api/envoy/extensions/filters/http/on_demand/v3/on_demand.proto
+++ b/api/envoy/extensions/filters/http/on_demand/v3/on_demand.proto
@@ -29,7 +29,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 message OnDemandCds {
   // A configuration source for the service that will be used for
   // on-demand cluster discovery.
-  config.core.v3.ConfigSource source = 1 [(validate.rules).message = {required: true}];
+  config.core.v3.ConfigSource source = 1;
 
   // xdstp:// resource locator for on-demand cluster collection.
   string resources_locator = 2;

--- a/envoy/upstream/cluster_manager.h
+++ b/envoy/upstream/cluster_manager.h
@@ -525,7 +525,8 @@ public:
       const envoy::config::core::v3::ConfigSource& odcds_config,
       OptRef<xds::core::v3::ResourceLocator> odcds_resources_locator,
       Config::XdsManager& xds_manager, ClusterManager& cm, MissingClusterNotifier& notifier,
-      Stats::Scope& scope, ProtobufMessage::ValidationVisitor& validation_visitor)>;
+      Stats::Scope& scope, ProtobufMessage::ValidationVisitor& validation_visitor,
+      Server::Configuration::ServerFactoryContext& server_factory_context)>;
 
   virtual absl::StatusOr<OdCdsApiHandlePtr>
   allocateOdCdsApi(OdCdsCreationFunction creation_function,

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -1536,8 +1536,9 @@ ClusterManagerImpl::allocateOdCdsApi(OdCdsCreationFunction creation_function,
   // TODO(krnowak): Instead of creating a new handle every time, store the handles internally and
   // return an already existing one if the config or locator matches. Note that this may need a
   // way to clean up the unused handles, so we can close the unnecessary connections.
-  auto odcds_or_error = creation_function(odcds_config, odcds_resources_locator, xds_manager_,
-                                          *this, *this, *stats_.rootScope(), validation_visitor);
+  auto odcds_or_error =
+      creation_function(odcds_config, odcds_resources_locator, xds_manager_, *this, *this,
+                        *stats_.rootScope(), validation_visitor, context_);
   RETURN_IF_NOT_OK_REF(odcds_or_error.status());
   return OdCdsApiHandleImpl::create(*this, std::move(*odcds_or_error));
 }

--- a/source/common/upstream/od_cds_api_impl.cc
+++ b/source/common/upstream/od_cds_api_impl.cc
@@ -13,7 +13,8 @@ OdCdsApiImpl::create(const envoy::config::core::v3::ConfigSource& odcds_config,
                      OptRef<xds::core::v3::ResourceLocator> odcds_resources_locator,
                      Config::XdsManager& xds_manager, ClusterManager& cm,
                      MissingClusterNotifier& notifier, Stats::Scope& scope,
-                     ProtobufMessage::ValidationVisitor& validation_visitor) {
+                     ProtobufMessage::ValidationVisitor& validation_visitor,
+                     Server::Configuration::ServerFactoryContext&) {
   absl::Status creation_status = absl::OkStatus();
   auto ret =
       OdCdsApiSharedPtr(new OdCdsApiImpl(odcds_config, odcds_resources_locator, xds_manager, cm,
@@ -118,5 +119,215 @@ void OdCdsApiImpl::updateOnDemand(std::string cluster_name) {
   }
 }
 
+// A class that maintains all the od-cds xDS-TP based singleton subscriptions,
+// and update the cluster-manager when the resources are updated.
+// The object will only be accessed by the main thread. It should also be a
+// singleton object that is used by all the filters that need to access od-cds
+// over xdstp-based config sources, and will only be allocated for the first
+// occurrence of the filter.
+class XdstpOdCdsApiImpl::XdstpOdcdsSubscriptionsManager : public Singleton::Instance,
+                                                          Logger::Loggable<Logger::Id::upstream> {
+public:
+  XdstpOdcdsSubscriptionsManager(Config::XdsManager& xds_manager, ClusterManager& cm,
+                                 MissingClusterNotifier& notifier, Stats::Scope& scope,
+                                 ProtobufMessage::ValidationVisitor& validation_visitor)
+      : xds_manager_(xds_manager), helper_(cm, xds_manager, "odcds-xdstp"), notifier_(notifier),
+        scope_(scope.createScope("cluster_manager.odcds.")),
+        validation_visitor_(validation_visitor) {}
+
+  absl::Status onResourceUpdate(absl::string_view resource_name,
+                                const Config::DecodedResourceRef& resource,
+                                const std::string& system_version_info) {
+    auto [_, exception_msgs] = helper_.onConfigUpdate({resource}, {}, system_version_info);
+    if (!exception_msgs.empty()) {
+      return absl::InvalidArgumentError(fmt::format("Error adding/updating cluster {} - {}",
+                                                    resource_name,
+                                                    absl::StrJoin(exception_msgs, ", ")));
+    }
+    return absl::OkStatus();
+  }
+
+  absl::Status onResourceRemoved(absl::string_view resource_name,
+                                 const std::string& system_version_info) {
+    // TODO(adisuissa): add direct `onResourceRemove(resource_name)` to `helper_`.
+    Protobuf::RepeatedPtrField<std::string> removed_resource_list;
+    removed_resource_list.Add(std::string(resource_name));
+    auto [_, exception_msgs] =
+        helper_.onConfigUpdate({}, removed_resource_list, system_version_info);
+    // Removal of a cluster should not result in an error.
+    ASSERT(exception_msgs.empty());
+    notifier_.notifyMissingCluster(resource_name);
+    return absl::OkStatus();
+  }
+
+  void onFailure(absl::string_view resource_name) {
+    ENVOY_LOG(trace, "ODCDS-manager: failure for resource: {}", resource_name);
+    // This function will only be invoked if the resource wasn't previously updated or removed.
+    // Remove the resource, so if there are other resources waiting for it,
+    // their initialization can proceed.
+    notifier_.notifyMissingCluster(resource_name);
+  }
+
+  absl::Status addSubscription(absl::string_view resource_name) {
+    if (subscriptions_.contains(resource_name)) {
+      ENVOY_LOG(debug, "ODCDS-manager: resource {} is already subscribed to, skipping",
+                resource_name);
+      return absl::OkStatus();
+    }
+    ENVOY_LOG(trace, "ODCDS-manager: adding a subscription for resource {}", resource_name);
+    // Subscribe using the xds-manager.
+    auto subscription =
+        std::make_unique<PerSubscriptionData>(*this, resource_name, validation_visitor_);
+    absl::Status status = subscription->initializeSubscription();
+    if (status.ok()) {
+      subscriptions_.emplace(std::string(resource_name), std::move(subscription));
+    }
+    return status;
+  }
+
+private:
+  // A singleton subscription handler.
+  class PerSubscriptionData : Envoy::Config::SubscriptionBase<envoy::config::cluster::v3::Cluster> {
+  public:
+    PerSubscriptionData(XdstpOdcdsSubscriptionsManager& parent, absl::string_view resource_name,
+                        ProtobufMessage::ValidationVisitor& validation_visitor)
+        : Envoy::Config::SubscriptionBase<envoy::config::cluster::v3::Cluster>(validation_visitor,
+                                                                               "name"),
+          parent_(parent), resource_name_(resource_name) {}
+
+    absl::Status initializeSubscription() {
+      const auto resource_type = getResourceName();
+      absl::StatusOr<Config::SubscriptionPtr> subscription_or_error =
+          parent_.xds_manager_.subscribeToSingletonResource(
+              resource_name_, absl::nullopt, Grpc::Common::typeUrl(resource_type), *parent_.scope_,
+              *this, resource_decoder_, {});
+      RETURN_IF_NOT_OK_REF(subscription_or_error.status());
+      subscription_ = std::move(subscription_or_error.value());
+      subscription_->start({resource_name_});
+      return absl::OkStatus();
+    }
+
+  private:
+    // Config::SubscriptionCallbacks
+    absl::Status onConfigUpdate(const std::vector<Config::DecodedResourceRef>& resources,
+                                const std::string& version_info) override {
+      // As this is a singleton subscription, the response can either contain 1
+      // resource that should be updated or 0 (implying the resource should be
+      // removed).
+      ASSERT(resources.empty() || (resources.size() == 1));
+      resource_was_updated_ = true;
+      if (resources.empty()) {
+        ENVOY_LOG(trace, "ODCDS-manager: removing a single resource: {}", resource_name_);
+        return parent_.onResourceRemoved(resource_name_, version_info);
+      }
+      // A single cluster update.
+      ENVOY_LOG(trace, "ODCDS-manager: updating a single resource: {}", resource_name_);
+      return parent_.onResourceUpdate(resource_name_, resources[0], version_info);
+    }
+    absl::Status onConfigUpdate(const std::vector<Config::DecodedResourceRef>& added_resources,
+                                const Protobuf::RepeatedPtrField<std::string>& removed_resources,
+                                const std::string& system_version_info) override {
+      // As this is a singleton subscription, the update can either contain 1
+      // added resource, or remove the resource.
+      ASSERT(added_resources.size() + removed_resources.size() == 1);
+      resource_was_updated_ = true;
+      if (!removed_resources.empty()) {
+        ENVOY_LOG(trace, "ODCDS-manager: removing a single resource: {}", resource_name_);
+        return parent_.onResourceRemoved(resource_name_, system_version_info);
+      }
+      // A single cluster update.
+      ENVOY_LOG(trace, "ODCDS-manager: updating a single resource: {}", resource_name_);
+      return parent_.onResourceUpdate(resource_name_, added_resources[0], system_version_info);
+    }
+    void onConfigUpdateFailed(Envoy::Config::ConfigUpdateFailureReason reason,
+                              const EnvoyException* e) override {
+      ASSERT(reason != Envoy::Config::ConfigUpdateFailureReason::ConnectionFailure);
+      ENVOY_LOG(trace, "ODCDS-manager: error while fetching a single resource {}: {}",
+                resource_name_, e->what());
+      // If the resource wasn't previously updated, this sends a notification that it was removed,
+      // so if there are any resources waiting for this one, they can proceed.
+      if (!resource_was_updated_) {
+        resource_was_updated_ = true;
+        parent_.onFailure(resource_name_);
+      }
+    }
+
+    XdstpOdcdsSubscriptionsManager& parent_;
+    // TODO(adisuissa): this can be converted to an absl::string_view and point to the
+    // subscriptions_ map key.
+    const std::string resource_name_;
+    Config::SubscriptionPtr subscription_;
+    bool resource_was_updated_{false};
+  };
+  using PerSubscriptionDataPtr = std::unique_ptr<PerSubscriptionData>;
+
+  Config::XdsManager& xds_manager_;
+  CdsApiHelper helper_;
+  MissingClusterNotifier& notifier_;
+  Stats::ScopeSharedPtr scope_;
+  ProtobufMessage::ValidationVisitor& validation_visitor_;
+  // Maps a resource name to its subscription data.
+  absl::flat_hash_map<std::string, PerSubscriptionDataPtr> subscriptions_;
+};
+
+// Register the XdstpOdcdsSubscriptionsManager singleton.
+SINGLETON_MANAGER_REGISTRATION(xdstp_odcds_subscriptions_manager);
+
+absl::StatusOr<OdCdsApiSharedPtr>
+XdstpOdCdsApiImpl::create(const envoy::config::core::v3::ConfigSource&,
+                          OptRef<xds::core::v3::ResourceLocator>, Config::XdsManager& xds_manager,
+                          ClusterManager& cm, MissingClusterNotifier& notifier, Stats::Scope& scope,
+                          ProtobufMessage::ValidationVisitor& validation_visitor,
+                          Server::Configuration::ServerFactoryContext& server_factory_context) {
+  absl::Status creation_status = absl::OkStatus();
+  auto ret = OdCdsApiSharedPtr(new XdstpOdCdsApiImpl(xds_manager, cm, notifier, scope,
+                                                     server_factory_context, validation_visitor,
+                                                     creation_status));
+  RETURN_IF_NOT_OK(creation_status);
+  return ret;
+}
+
+XdstpOdCdsApiImpl::XdstpOdCdsApiImpl(Config::XdsManager& xds_manager, ClusterManager& cm,
+                                     MissingClusterNotifier& notifier, Stats::Scope& scope,
+                                     Server::Configuration::ServerFactoryContext& server_context,
+                                     ProtobufMessage::ValidationVisitor& validation_visitor,
+                                     absl::Status& creation_status) {
+  // Create a singleton xdstp-based od-cds handler. This will be accessed by
+  // the main thread and used by all the filters that need to access od-cds
+  // over xdstp-based config sources.
+  // The singleton object will handle all the subscriptions to OD-CDS
+  // resources, and will apply the updates to the cluster-manager.
+  subscriptions_manager_ =
+      subscriptionsManager(server_context, xds_manager, cm, notifier, scope, validation_visitor);
+  // This will always succeed as the xDS-TP config-source matching the resource name
+  // will only be known when that resource is subscribed to.
+  creation_status = absl::OkStatus();
+}
+
+XdstpOdCdsApiImpl::XdstpOdcdsSubscriptionsManagerSharedPtr
+XdstpOdCdsApiImpl::subscriptionsManager(Server::Configuration::ServerFactoryContext& server_context,
+                                        Config::XdsManager& xds_manager, ClusterManager& cm,
+                                        MissingClusterNotifier& notifier, Stats::Scope& scope,
+                                        ProtobufMessage::ValidationVisitor& validation_visitor) {
+  return server_context.singletonManager().getTyped<XdstpOdcdsSubscriptionsManager>(
+      SINGLETON_MANAGER_REGISTERED_NAME(xdstp_odcds_subscriptions_manager),
+      [&xds_manager, &cm, &notifier, &scope, &validation_visitor] {
+        return std::make_shared<XdstpOdcdsSubscriptionsManager>(xds_manager, cm, notifier, scope,
+                                                                validation_visitor);
+      });
+}
+
+void XdstpOdCdsApiImpl::updateOnDemand(std::string cluster_name) {
+  absl::Status status = subscriptions_manager_->addSubscription(cluster_name);
+  if (!status.ok()) {
+    // There was an error while subscribing. This could be, for example, when
+    // the cluster_name isn't a valid xdstp resource, or its config-source was
+    // not added to the bootstrap's config_sources.
+    ENVOY_LOG_MISC(
+        info, "odcds: xDS-TP resource {} could not be registered: {}. Treating as missing cluster",
+        cluster_name, status.message());
+    subscriptions_manager_->onFailure(cluster_name);
+  }
+}
 } // namespace Upstream
 } // namespace Envoy

--- a/test/common/upstream/BUILD
+++ b/test/common/upstream/BUILD
@@ -23,8 +23,28 @@ envoy_cc_test(
         "//source/common/upstream:od_cds_api_lib",
         "//test/mocks/config:xds_manager_mocks",
         "//test/mocks/protobuf:protobuf_mocks",
+        "//test/mocks/server:server_mocks",
         "//test/mocks/upstream:cluster_manager_mocks",
         "//test/mocks/upstream:missing_cluster_notifier_mocks",
+        "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
+    ],
+)
+
+envoy_cc_test(
+    name = "xdstp_od_cds_api_impl_test",
+    srcs = ["xdstp_od_cds_api_impl_test.cc"],
+    rbe_pool = "6gig",
+    deps = [
+        "//envoy/config:subscription_interface",
+        "//source/common/stats:isolated_store_lib",
+        "//source/common/upstream:od_cds_api_lib",
+        "//test/mocks/config:xds_manager_mocks",
+        "//test/mocks/protobuf:protobuf_mocks",
+        "//test/mocks/server:server_mocks",
+        "//test/mocks/upstream:cluster_manager_mocks",
+        "//test/mocks/upstream:missing_cluster_notifier_mocks",
+        "//test/test_common:test_runtime_lib",
+        "@envoy_api//envoy/config/cluster/v3:pkg_cc_proto",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
     ],
 )

--- a/test/common/upstream/od_cds_api_impl_test.cc
+++ b/test/common/upstream/od_cds_api_impl_test.cc
@@ -6,6 +6,7 @@
 
 #include "test/mocks/config/xds_manager.h"
 #include "test/mocks/protobuf/mocks.h"
+#include "test/mocks/server/mocks.h"
 #include "test/mocks/upstream/cluster_manager.h"
 #include "test/mocks/upstream/missing_cluster_notifier.h"
 
@@ -25,8 +26,9 @@ public:
   void SetUp() override {
     envoy::config::core::v3::ConfigSource odcds_config;
     OptRef<xds::core::v3::ResourceLocator> null_locator;
-    odcds_ = *OdCdsApiImpl::create(odcds_config, null_locator, xds_manager_, cm_, notifier_,
-                                   *store_.rootScope(), validation_visitor_);
+    odcds_ =
+        *OdCdsApiImpl::create(odcds_config, null_locator, xds_manager_, cm_, notifier_,
+                              *store_.rootScope(), validation_visitor_, server_factory_context_);
     odcds_callbacks_ = cm_.subscription_factory_.callbacks_;
   }
 
@@ -34,6 +36,7 @@ public:
   NiceMock<MockClusterManager> cm_;
   Stats::IsolatedStoreImpl store_;
   MockMissingClusterNotifier notifier_;
+  NiceMock<Server::Configuration::MockServerFactoryContext> server_factory_context_;
   OdCdsApiSharedPtr odcds_;
   Config::SubscriptionCallbacks* odcds_callbacks_ = nullptr;
   NiceMock<ProtobufMessage::MockValidationVisitor> validation_visitor_;

--- a/test/common/upstream/xdstp_od_cds_api_impl_test.cc
+++ b/test/common/upstream/xdstp_od_cds_api_impl_test.cc
@@ -1,0 +1,329 @@
+#include "envoy/config/cluster/v3/cluster.pb.h"
+#include "envoy/config/core/v3/config_source.pb.h"
+#include "envoy/config/subscription.h"
+
+#include "source/common/config/decoded_resource_impl.h"
+#include "source/common/stats/isolated_store_impl.h"
+#include "source/common/upstream/od_cds_api_impl.h"
+
+#include "test/mocks/config/xds_manager.h"
+#include "test/mocks/protobuf/mocks.h"
+#include "test/mocks/server/mocks.h"
+#include "test/mocks/upstream/cluster_manager.h"
+#include "test/mocks/upstream/missing_cluster_notifier.h"
+#include "test/test_common/test_runtime.h"
+#include "test/test_common/utility.h"
+
+#include "fmt/core.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace Envoy {
+namespace Upstream {
+namespace {
+
+using ::testing::ElementsAre;
+using ::testing::InSequence;
+using ::testing::UnorderedElementsAre;
+
+class XdstpOdCdsApiImplTest : public testing::Test {
+public:
+  void SetUp() override {
+    scoped_runtime_.mergeValues(
+        {{"envoy.reloadable_features.xdstp_based_config_singleton_subscriptions", "true"}});
+    envoy::config::core::v3::ConfigSource odcds_config;
+    OptRef<xds::core::v3::ResourceLocator> null_locator;
+    odcds_ = *XdstpOdCdsApiImpl::create(odcds_config, null_locator, xds_manager_, cm_, notifier_,
+                                        *store_.rootScope(), validation_visitor_,
+                                        server_factory_context_);
+
+    ON_CALL(xds_manager_, subscriptionFactory())
+        .WillByDefault(ReturnRef(cm_.subscription_factory_));
+  }
+
+  void expectSingletonSubscription(absl::string_view resource_name) {
+    EXPECT_CALL(xds_manager_, subscribeToSingletonResource(resource_name, _, _, _, _, _, _))
+        .WillOnce(Invoke(
+            [this](absl::string_view, OptRef<const envoy::config::core::v3::ConfigSource>,
+                   absl::string_view, Stats::Scope&, Config::SubscriptionCallbacks& callbacks,
+                   Config::OpaqueResourceDecoderSharedPtr,
+                   const Config::SubscriptionOptions&) -> absl::StatusOr<Config::SubscriptionPtr> {
+              auto ret = std::make_unique<NiceMock<Config::MockSubscription>>();
+              subscription_ = ret.get();
+              odcds_callbacks_ = &callbacks;
+              return ret;
+            }));
+  }
+
+  TestScopedRuntime scoped_runtime_;
+  NiceMock<Config::MockXdsManager> xds_manager_;
+  NiceMock<MockClusterManager> cm_;
+  Stats::IsolatedStoreImpl store_;
+  MockMissingClusterNotifier notifier_;
+  NiceMock<Server::Configuration::MockServerFactoryContext> server_factory_context_;
+  OdCdsApiSharedPtr odcds_;
+  Config::SubscriptionCallbacks* odcds_callbacks_ = nullptr;
+  NiceMock<ProtobufMessage::MockValidationVisitor> validation_visitor_;
+  Config::MockSubscription* subscription_;
+};
+
+// Check that a subscription is created when the odcds is updated.
+TEST_F(XdstpOdCdsApiImplTest, SuccesfulSubscriptionToCluster) {
+  InSequence s;
+
+  expectSingletonSubscription("fake_cluster");
+  odcds_->updateOnDemand("fake_cluster");
+}
+
+// Check that a subscription is created when the odcds is updated,
+// and if the same cluster is requested again, another subscription will not be created.
+TEST_F(XdstpOdCdsApiImplTest, SingleSubscriptionToSomeCluster) {
+  InSequence s;
+
+  expectSingletonSubscription("fake_cluster");
+  odcds_->updateOnDemand("fake_cluster");
+
+  EXPECT_CALL(xds_manager_, subscribeToSingletonResource(_, _, _, _, _, _, _)).Times(0);
+  odcds_->updateOnDemand("fake_cluster");
+}
+
+// Check that a subscription is created when the odcds is updated,
+// and if a different cluster is requested, a new subscription will be created.
+TEST_F(XdstpOdCdsApiImplTest, TwoSubscriptionsToDifferectClusters) {
+  InSequence s;
+
+  expectSingletonSubscription("fake_cluster");
+  odcds_->updateOnDemand("fake_cluster");
+
+  expectSingletonSubscription("fake_cluster2");
+  odcds_->updateOnDemand("fake_cluster2");
+}
+
+// Tests a successful subscription and cluster addition.
+TEST_F(XdstpOdCdsApiImplTest, SuccessfulClusterAddition) {
+  InSequence s;
+
+  const std::string cluster_name = "fake_cluster";
+  expectSingletonSubscription(cluster_name);
+  odcds_->updateOnDemand(cluster_name);
+
+  ASSERT_NE(odcds_callbacks_, nullptr);
+
+  const auto cluster =
+      TestUtility::parseYaml<envoy::config::cluster::v3::Cluster>(fmt::format(R"EOF(
+    name: {}
+    connect_timeout: 1.250s
+    lb_policy: ROUND_ROBIN
+    type: STATIC
+  )EOF",
+                                                                              cluster_name));
+
+  const std::string version = "v1";
+  EXPECT_CALL(cm_, addOrUpdateCluster(ProtoEq(cluster), version, false));
+
+  Config::DecodedResourceImpl decoded_resource(
+      std::make_unique<envoy::config::cluster::v3::Cluster>(cluster), "fake_cluster", {}, version);
+  std::vector<Config::DecodedResourceRef> resources;
+  resources.emplace_back(decoded_resource);
+
+  EXPECT_TRUE(odcds_callbacks_->onConfigUpdate(resources, version).ok());
+}
+
+// Tests cluster removal.
+TEST_F(XdstpOdCdsApiImplTest, ClusterRemoval) {
+  InSequence s;
+
+  const std::string cluster_name = "fake_cluster";
+  expectSingletonSubscription(cluster_name);
+  odcds_->updateOnDemand(cluster_name);
+
+  ASSERT_NE(odcds_callbacks_, nullptr);
+
+  const auto cluster =
+      TestUtility::parseYaml<envoy::config::cluster::v3::Cluster>(fmt::format(R"EOF(
+    name: {}
+    connect_timeout: 1.250s
+    lb_policy: ROUND_ROBIN
+    type: STATIC
+  )EOF",
+                                                                              cluster_name));
+
+  const std::string version = "v1";
+  EXPECT_CALL(cm_, addOrUpdateCluster(ProtoEq(cluster), version, false));
+
+  Config::DecodedResourceImpl decoded_resource(
+      std::make_unique<envoy::config::cluster::v3::Cluster>(cluster), "fake_cluster", {}, version);
+  std::vector<Config::DecodedResourceRef> resources;
+  resources.emplace_back(decoded_resource);
+
+  EXPECT_TRUE(odcds_callbacks_->onConfigUpdate(resources, version).ok());
+
+  // Now remove the cluster.
+  const std::string version2 = "v2";
+  EXPECT_CALL(notifier_, notifyMissingCluster(cluster_name));
+  EXPECT_TRUE(odcds_callbacks_->onConfigUpdate({}, version2).ok());
+}
+
+// Tests that a config update failure is handled correctly.
+TEST_F(XdstpOdCdsApiImplTest, SubscriptionFailure) {
+  InSequence s;
+
+  const std::string cluster_name = "fake_cluster";
+  expectSingletonSubscription(cluster_name);
+  odcds_->updateOnDemand(cluster_name);
+
+  ASSERT_NE(odcds_callbacks_, nullptr);
+
+  EXPECT_CALL(cm_, addOrUpdateCluster(_, _, _)).Times(0);
+  EXPECT_CALL(notifier_, notifyMissingCluster(cluster_name));
+
+  EnvoyException e("rejecting update");
+  odcds_callbacks_->onConfigUpdateFailed(Envoy::Config::ConfigUpdateFailureReason::UpdateRejected,
+                                         &e);
+}
+
+// Tests that an existing cluster is updated.
+TEST_F(XdstpOdCdsApiImplTest, ClusterUpdate) {
+  InSequence s;
+
+  const std::string cluster_name = "fake_cluster";
+  expectSingletonSubscription(cluster_name);
+  odcds_->updateOnDemand(cluster_name);
+
+  ASSERT_NE(odcds_callbacks_, nullptr);
+
+  const auto cluster =
+      TestUtility::parseYaml<envoy::config::cluster::v3::Cluster>(fmt::format(R"EOF(
+    name: {}
+    connect_timeout: 1.250s
+    lb_policy: ROUND_ROBIN
+    type: STATIC
+  )EOF",
+                                                                              cluster_name));
+
+  const std::string version = "v1";
+  EXPECT_CALL(cm_, addOrUpdateCluster(ProtoEq(cluster), version, false));
+
+  Config::DecodedResourceImpl decoded_resource(
+      std::make_unique<envoy::config::cluster::v3::Cluster>(cluster), "fake_cluster", {}, version);
+  std::vector<Config::DecodedResourceRef> resources;
+  resources.emplace_back(decoded_resource);
+
+  EXPECT_TRUE(odcds_callbacks_->onConfigUpdate(resources, version).ok());
+
+  // Now update the cluster.
+  const auto updated_cluster =
+      TestUtility::parseYaml<envoy::config::cluster::v3::Cluster>(fmt::format(R"EOF(
+    name: {}
+    connect_timeout: 2.250s
+    lb_policy: ROUND_ROBIN
+    type: STATIC
+  )EOF",
+                                                                              cluster_name));
+  const std::string version2 = "v2";
+  EXPECT_CALL(cm_, addOrUpdateCluster(ProtoEq(updated_cluster), version2, false));
+
+  Config::DecodedResourceImpl decoded_resource2(
+      std::make_unique<envoy::config::cluster::v3::Cluster>(updated_cluster), "fake_cluster", {},
+      version2);
+  std::vector<Config::DecodedResourceRef> resources2;
+  resources2.emplace_back(decoded_resource2);
+
+  EXPECT_TRUE(odcds_callbacks_->onConfigUpdate(resources2, version2).ok());
+}
+
+// Tests that multiple subscriptions are handled independently.
+TEST_F(XdstpOdCdsApiImplTest, MultipleSubscriptions) {
+  InSequence s;
+
+  // Subscription for fake_cluster1 succeeds.
+  const std::string cluster_name1 = "fake_cluster1";
+  Config::SubscriptionCallbacks* callbacks1 = nullptr;
+  EXPECT_CALL(xds_manager_, subscribeToSingletonResource(cluster_name1, _, _, _, _, _, _))
+      .WillOnce(Invoke(
+          [&callbacks1](absl::string_view, OptRef<const envoy::config::core::v3::ConfigSource>,
+                        absl::string_view, Stats::Scope&, Config::SubscriptionCallbacks& callbacks,
+                        Config::OpaqueResourceDecoderSharedPtr, const Config::SubscriptionOptions&)
+              -> absl::StatusOr<Config::SubscriptionPtr> {
+            callbacks1 = &callbacks;
+            return std::make_unique<NiceMock<Config::MockSubscription>>();
+          }));
+  odcds_->updateOnDemand(cluster_name1);
+  ASSERT_NE(callbacks1, nullptr);
+
+  // Subscription for fake_cluster2 fails.
+  const std::string cluster_name2 = "fake_cluster2";
+  Config::SubscriptionCallbacks* callbacks2 = nullptr;
+  EXPECT_CALL(xds_manager_, subscribeToSingletonResource(cluster_name2, _, _, _, _, _, _))
+      .WillOnce(Invoke(
+          [&callbacks2](absl::string_view, OptRef<const envoy::config::core::v3::ConfigSource>,
+                        absl::string_view, Stats::Scope&, Config::SubscriptionCallbacks& callbacks,
+                        Config::OpaqueResourceDecoderSharedPtr, const Config::SubscriptionOptions&)
+              -> absl::StatusOr<Config::SubscriptionPtr> {
+            callbacks2 = &callbacks;
+            return std::make_unique<NiceMock<Config::MockSubscription>>();
+          }));
+  odcds_->updateOnDemand(cluster_name2);
+  ASSERT_NE(callbacks2, nullptr);
+
+  // Verify that the successful subscription works as expected.
+  const auto cluster =
+      TestUtility::parseYaml<envoy::config::cluster::v3::Cluster>(fmt::format(R"EOF(
+    name: {}
+    connect_timeout: 1.250s
+    lb_policy: ROUND_ROBIN
+    type: STATIC
+  )EOF",
+                                                                              cluster_name1));
+  const std::string version = "v1";
+  EXPECT_CALL(cm_, addOrUpdateCluster(ProtoEq(cluster), version, false));
+  Config::DecodedResourceImpl decoded_resource(
+      std::make_unique<envoy::config::cluster::v3::Cluster>(cluster), cluster_name1, {}, version);
+  std::vector<Config::DecodedResourceRef> resources;
+  resources.emplace_back(decoded_resource);
+  EXPECT_TRUE(callbacks1->onConfigUpdate(resources, version).ok());
+
+  // Verify that the failed subscription works as expected.
+  EXPECT_CALL(cm_, addOrUpdateCluster(_, _, _)).Times(0);
+  EXPECT_CALL(notifier_, notifyMissingCluster(cluster_name2));
+  EnvoyException e("rejecting update");
+  callbacks2->onConfigUpdateFailed(Envoy::Config::ConfigUpdateFailureReason::UpdateRejected, &e);
+}
+
+// Tests cluster removal via a delta update.
+TEST_F(XdstpOdCdsApiImplTest, ClusterRemovalViaDeltaUpdate) {
+  InSequence s;
+
+  const std::string cluster_name = "fake_cluster";
+  expectSingletonSubscription(cluster_name);
+  odcds_->updateOnDemand(cluster_name);
+
+  ASSERT_NE(odcds_callbacks_, nullptr);
+
+  // First, add the cluster.
+  const auto cluster =
+      TestUtility::parseYaml<envoy::config::cluster::v3::Cluster>(fmt::format(R"EOF(
+    name: {}
+    connect_timeout: 1.250s
+    lb_policy: ROUND_ROBIN
+    type: STATIC
+  )EOF",
+                                                                              cluster_name));
+  const std::string version = "v1";
+  EXPECT_CALL(cm_, addOrUpdateCluster(ProtoEq(cluster), version, false));
+  Config::DecodedResourceImpl decoded_resource(
+      std::make_unique<envoy::config::cluster::v3::Cluster>(cluster), cluster_name, {}, version);
+  std::vector<Config::DecodedResourceRef> resources;
+  resources.emplace_back(decoded_resource);
+  EXPECT_TRUE(odcds_callbacks_->onConfigUpdate(resources, version).ok());
+
+  // Now, remove the cluster using a delta update.
+  const std::string version2 = "v2";
+  Protobuf::RepeatedPtrField<std::string> removed_resources;
+  removed_resources.Add(std::string(cluster_name));
+  EXPECT_CALL(notifier_, notifyMissingCluster(cluster_name));
+  EXPECT_TRUE(odcds_callbacks_->onConfigUpdate({}, removed_resources, version2).ok());
+}
+} // namespace
+} // namespace Upstream
+} // namespace Envoy

--- a/test/extensions/filters/http/on_demand/BUILD
+++ b/test/extensions/filters/http/on_demand/BUILD
@@ -67,6 +67,7 @@ envoy_extension_cc_test(
         "//test/integration:fake_upstream_lib",
         "//test/integration:http_integration_lib",
         "//test/integration:scoped_rds_lib",
+        "//test/integration:xdstp_config_sources_integration_lib",
         "//test/test_common:resources_lib",
         "//test/test_common:utility_lib",
         "@envoy_api//envoy/config/cluster/v3:pkg_cc_proto",

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -81,6 +81,31 @@ envoy_cc_test(
     ],
 )
 
+envoy_cc_test_library(
+    name = "xdstp_config_sources_integration_lib",
+    hdrs = [
+        "xdstp_config_sources_integration.h",
+    ],
+    rbe_pool = "2core",
+    deps = [
+        ":ads_integration_lib",
+        ":http_integration_lib",
+        "//source/common/config:protobuf_link_hacks",
+        "//source/common/protobuf:utility_lib",
+        "//source/common/version:version_lib",
+        "//test/common/grpc:grpc_client_integration_lib",
+        "//test/test_common:network_utility_lib",
+        "//test/test_common:resources_lib",
+        "//test/test_common:utility_lib",
+        "@envoy_api//envoy/config/bootstrap/v3:pkg_cc_proto",
+        "@envoy_api//envoy/config/cluster/v3:pkg_cc_proto",
+        "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
+        "@envoy_api//envoy/config/endpoint/v3:pkg_cc_proto",
+        "@envoy_api//envoy/config/listener/v3:pkg_cc_proto",
+        "@envoy_api//envoy/config/route/v3:pkg_cc_proto",
+    ],
+)
+
 envoy_cc_test(
     name = "xdstp_config_sources_integration_test",
     srcs = ["xdstp_config_sources_integration_test.cc"],
@@ -89,8 +114,8 @@ envoy_cc_test(
         "cpu:3",
     ],
     deps = [
-        ":ads_integration_lib",
         ":http_integration_lib",
+        ":xdstp_config_sources_integration_lib",
         "//source/common/config:protobuf_link_hacks",
         "//source/common/protobuf:utility_lib",
         "//test/common/grpc:grpc_client_integration_lib",

--- a/test/integration/xdstp_config_sources_integration.h
+++ b/test/integration/xdstp_config_sources_integration.h
@@ -1,0 +1,174 @@
+#pragma once
+
+#include "envoy/config/bootstrap/v3/bootstrap.pb.h"
+#include "envoy/config/cluster/v3/cluster.pb.h"
+#include "envoy/config/core/v3/base.pb.h"
+#include "envoy/config/endpoint/v3/endpoint.pb.h"
+#include "envoy/config/listener/v3/listener.pb.h"
+#include "envoy/config/route/v3/route.pb.h"
+#include "envoy/grpc/status.h"
+
+#include "source/common/config/protobuf_link_hacks.h"
+#include "source/common/protobuf/protobuf.h"
+#include "source/common/protobuf/utility.h"
+#include "source/common/tls/server_context_config_impl.h"
+#include "source/common/tls/server_ssl_socket.h"
+#include "source/common/version/version.h"
+
+#include "test/common/grpc/grpc_client_integration.h"
+#include "test/integration/ads_integration.h"
+#include "test/integration/http_integration.h"
+#include "test/integration/utility.h"
+#include "test/test_common/network_utility.h"
+#include "test/test_common/resources.h"
+#include "test/test_common/utility.h"
+
+#include "gtest/gtest.h"
+
+using testing::AssertionResult;
+
+namespace Envoy {
+
+// A base class for the xDS-TP based config sources (defined in the bootstrap) tests, without the
+// ads_config definition.
+class XdsTpConfigsIntegration : public AdsDeltaSotwIntegrationSubStateParamTest,
+                                public HttpIntegrationTest {
+public:
+  XdsTpConfigsIntegration()
+      : HttpIntegrationTest(Http::CodecType::HTTP2, ipVersion(),
+                            ConfigHelper::httpProxyConfig(false)) {
+    config_helper_.addRuntimeOverride("envoy.reloadable_features.unified_mux",
+                                      (sotwOrDelta() == Grpc::SotwOrDelta::UnifiedSotw ||
+                                       sotwOrDelta() == Grpc::SotwOrDelta::UnifiedDelta)
+                                          ? "true"
+                                          : "false");
+    config_helper_.addRuntimeOverride(
+        "envoy.reloadable_features.xdstp_based_config_singleton_subscriptions", "true");
+    // Not using the normal xds upstream, but the
+    // authority1_upstream_/default_upstream.
+    create_xds_upstream_ = false;
+    // Not testing TLS in this case.
+    tls_xds_upstream_ = false;
+    sotw_or_delta_ = sotwOrDelta();
+    setUpstreamProtocol(Http::CodecType::HTTP2);
+  }
+
+  FakeUpstream* createAdsUpstream() {
+    ASSERT(!tls_xds_upstream_);
+    addFakeUpstream(Http::CodecType::HTTP2);
+    return fake_upstreams_.back().get();
+  }
+
+  void TearDown() override {
+    cleanupXdsConnection(authority1_xds_connection_);
+    cleanupXdsConnection(default_authority_xds_connection_);
+  }
+
+  void createUpstreams() override {
+    HttpIntegrationTest::createUpstreams();
+    // An upstream for authority1 (H/2), an upstream for the default_authority (H/2), and an
+    // upstream for a backend (H/1).
+    authority1_upstream_ = createAdsUpstream();
+    default_authority_upstream_ = createAdsUpstream();
+    if (test_requires_additional_upstream_) {
+      addFakeUpstream(Http::CodecType::HTTP1);
+    }
+  }
+
+  bool isSotw() const {
+    return sotwOrDelta() == Grpc::SotwOrDelta::Sotw ||
+           sotwOrDelta() == Grpc::SotwOrDelta::UnifiedSotw;
+  }
+
+  // Adds config_source for authority1.com and a default_config_source for
+  // default_authority.com.
+  void initialize() override {
+    config_helper_.addConfigModifier([this](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
+      // Add the first config_source.
+      {
+        auto* config_source1 = bootstrap.mutable_config_sources()->Add();
+        config_source1->mutable_authorities()->Add()->set_name("authority1.com");
+        auto* api_config_source = config_source1->mutable_api_config_source();
+        api_config_source->set_api_type(
+            isSotw() ? envoy::config::core::v3::ApiConfigSource::AGGREGATED_GRPC
+                     : envoy::config::core::v3::ApiConfigSource::AGGREGATED_DELTA_GRPC);
+        api_config_source->set_transport_api_version(envoy::config::core::v3::V3);
+        api_config_source->set_set_node_on_first_message_only(true);
+        auto* grpc_service = api_config_source->add_grpc_services();
+        setGrpcService(*grpc_service, "authority1_cluster", authority1_upstream_->localAddress());
+        auto* xds_cluster = bootstrap.mutable_static_resources()->add_clusters();
+        xds_cluster->MergeFrom(bootstrap.static_resources().clusters()[0]);
+        xds_cluster->set_name("authority1_cluster");
+      }
+      // Add the default config source.
+      {
+        auto* default_config_source = bootstrap.mutable_default_config_source();
+        default_config_source->mutable_authorities()->Add()->set_name("default_authority.com");
+        auto* api_config_source = default_config_source->mutable_api_config_source();
+        api_config_source->set_api_type(
+            isSotw() ? envoy::config::core::v3::ApiConfigSource::AGGREGATED_GRPC
+                     : envoy::config::core::v3::ApiConfigSource::AGGREGATED_DELTA_GRPC);
+        api_config_source->set_transport_api_version(envoy::config::core::v3::V3);
+        api_config_source->set_set_node_on_first_message_only(true);
+        auto* grpc_service = api_config_source->add_grpc_services();
+        setGrpcService(*grpc_service, "default_authority_cluster",
+                       default_authority_upstream_->localAddress());
+        auto* xds_cluster = bootstrap.mutable_static_resources()->add_clusters();
+        xds_cluster->MergeFrom(bootstrap.static_resources().clusters()[0]);
+        xds_cluster->set_name("default_authority_cluster");
+      }
+    });
+    HttpIntegrationTest::initialize();
+  }
+
+  void connectAuthority1() {
+    AssertionResult result =
+        authority1_upstream_->waitForHttpConnection(*dispatcher_, authority1_xds_connection_);
+    RELEASE_ASSERT(result, result.message());
+    result = authority1_xds_connection_->waitForNewStream(*dispatcher_, authority1_xds_stream_);
+    RELEASE_ASSERT(result, result.message());
+    authority1_xds_stream_->startGrpcStream();
+  }
+
+  void connectDefaultAuthority() {
+    AssertionResult result = default_authority_upstream_->waitForHttpConnection(
+        *dispatcher_, default_authority_xds_connection_);
+    RELEASE_ASSERT(result, result.message());
+    result = default_authority_xds_connection_->waitForNewStream(*dispatcher_,
+                                                                 default_authority_xds_stream_);
+    RELEASE_ASSERT(result, result.message());
+    default_authority_xds_stream_->startGrpcStream();
+  }
+
+  void cleanupXdsConnection(FakeHttpConnectionPtr& connection) {
+    if (connection != nullptr) {
+      AssertionResult result = connection->close();
+      RELEASE_ASSERT(result, result.message());
+      result = connection->waitForDisconnect();
+      RELEASE_ASSERT(result, result.message());
+      connection.reset();
+    }
+  }
+
+  envoy::config::endpoint::v3::ClusterLoadAssignment
+  buildClusterLoadAssignment(const std::string& name) {
+    // The last fake upstream is the emulated server.
+    return ConfigHelper::buildClusterLoadAssignment(
+        name, Network::Test::getLoopbackAddressString(ipVersion()),
+        fake_upstreams_.back().get()->localAddress()->ip()->port());
+  }
+
+  bool test_requires_additional_upstream_{true};
+
+  // Data members that emulate the authority1 server.
+  FakeUpstream* authority1_upstream_;
+  FakeHttpConnectionPtr authority1_xds_connection_;
+  FakeStreamPtr authority1_xds_stream_;
+
+  // Data members that emulate the default_authority server.
+  FakeUpstream* default_authority_upstream_;
+  FakeHttpConnectionPtr default_authority_xds_connection_;
+  FakeStreamPtr default_authority_xds_stream_;
+};
+
+} // namespace Envoy

--- a/test/integration/xdstp_config_sources_integration_test.cc
+++ b/test/integration/xdstp_config_sources_integration_test.cc
@@ -14,10 +14,9 @@
 #include "source/common/version/version.h"
 
 #include "test/common/grpc/grpc_client_integration.h"
-#include "test/config/v2_link_hacks.h"
-#include "test/integration/ads_integration.h"
 #include "test/integration/http_integration.h"
 #include "test/integration/utility.h"
+#include "test/integration/xdstp_config_sources_integration.h"
 #include "test/test_common/network_utility.h"
 #include "test/test_common/resources.h"
 #include "test/test_common/utility.h"
@@ -30,144 +29,9 @@ namespace Envoy {
 
 // Tests for xDS-TP based config sources (defined in the bootstrap), without the
 // ads_config definition.
-class XdsTpConfigsIntegrationTest : public AdsDeltaSotwIntegrationSubStateParamTest,
-                                    public HttpIntegrationTest {
+class XdsTpConfigsIntegrationTest : public XdsTpConfigsIntegration {
 public:
-  XdsTpConfigsIntegrationTest()
-      : HttpIntegrationTest(Http::CodecType::HTTP2, ipVersion(),
-                            ConfigHelper::httpProxyConfig(false)) {
-    config_helper_.addRuntimeOverride("envoy.reloadable_features.unified_mux",
-                                      (sotwOrDelta() == Grpc::SotwOrDelta::UnifiedSotw ||
-                                       sotwOrDelta() == Grpc::SotwOrDelta::UnifiedDelta)
-                                          ? "true"
-                                          : "false");
-    // Not using the normal xds upstream, but the
-    // authority1_upstream_/default_upstream.
-    create_xds_upstream_ = false;
-    // Not testing TLS in this case.
-    tls_xds_upstream_ = false;
-    sotw_or_delta_ = sotwOrDelta();
-    setUpstreamProtocol(Http::CodecType::HTTP2);
-  }
-
-  FakeUpstream* createAdsUpstream() {
-    ASSERT(!tls_xds_upstream_);
-    addFakeUpstream(Http::CodecType::HTTP2);
-    return fake_upstreams_.back().get();
-  }
-
-  void TearDown() override {
-    cleanupXdsConnection(authority1_xds_connection_);
-    cleanupXdsConnection(default_authority_xds_connection_);
-  }
-
-  void createUpstreams() override {
-    HttpIntegrationTest::createUpstreams();
-    // An upstream for authority1 (H/2), an upstream for the default_authority (H/2), and an
-    // upstream for a backend (H/1).
-    authority1_upstream_ = createAdsUpstream();
-    default_authority_upstream_ = createAdsUpstream();
-    if (test_requires_additional_upstream_) {
-      addFakeUpstream(Http::CodecType::HTTP1);
-    }
-  }
-
-  bool isSotw() const {
-    return sotwOrDelta() == Grpc::SotwOrDelta::Sotw ||
-           sotwOrDelta() == Grpc::SotwOrDelta::UnifiedSotw;
-  }
-
-  // Adds config_source for authority1.com and a default_config_source for
-  // default_authority.com.
-  void initialize() override {
-    config_helper_.addRuntimeOverride(
-        "envoy.reloadable_features.xdstp_based_config_singleton_subscriptions", "true");
-    config_helper_.addConfigModifier([this](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
-      // Add the first config_source.
-      {
-        auto* config_source1 = bootstrap.mutable_config_sources()->Add();
-        config_source1->mutable_authorities()->Add()->set_name("authority1.com");
-        auto* api_config_source = config_source1->mutable_api_config_source();
-        api_config_source->set_api_type(
-            isSotw() ? envoy::config::core::v3::ApiConfigSource::AGGREGATED_GRPC
-                     : envoy::config::core::v3::ApiConfigSource::AGGREGATED_DELTA_GRPC);
-        api_config_source->set_transport_api_version(envoy::config::core::v3::V3);
-        api_config_source->set_set_node_on_first_message_only(true);
-        auto* grpc_service = api_config_source->add_grpc_services();
-        setGrpcService(*grpc_service, "authority1_cluster", authority1_upstream_->localAddress());
-        auto* xds_cluster = bootstrap.mutable_static_resources()->add_clusters();
-        xds_cluster->MergeFrom(bootstrap.static_resources().clusters()[0]);
-        xds_cluster->set_name("authority1_cluster");
-      }
-      // Add the default config source.
-      {
-        auto* default_config_source = bootstrap.mutable_default_config_source();
-        default_config_source->mutable_authorities()->Add()->set_name("default_authority.com");
-        auto* api_config_source = default_config_source->mutable_api_config_source();
-        api_config_source->set_api_type(
-            isSotw() ? envoy::config::core::v3::ApiConfigSource::AGGREGATED_GRPC
-                     : envoy::config::core::v3::ApiConfigSource::AGGREGATED_DELTA_GRPC);
-        api_config_source->set_transport_api_version(envoy::config::core::v3::V3);
-        api_config_source->set_set_node_on_first_message_only(true);
-        auto* grpc_service = api_config_source->add_grpc_services();
-        setGrpcService(*grpc_service, "default_authority_cluster",
-                       default_authority_upstream_->localAddress());
-        auto* xds_cluster = bootstrap.mutable_static_resources()->add_clusters();
-        xds_cluster->MergeFrom(bootstrap.static_resources().clusters()[0]);
-        xds_cluster->set_name("default_authority_cluster");
-      }
-    });
-    HttpIntegrationTest::initialize();
-  }
-
-  void connectAuthority1() {
-    AssertionResult result =
-        authority1_upstream_->waitForHttpConnection(*dispatcher_, authority1_xds_connection_);
-    RELEASE_ASSERT(result, result.message());
-    result = authority1_xds_connection_->waitForNewStream(*dispatcher_, authority1_xds_stream_);
-    RELEASE_ASSERT(result, result.message());
-    authority1_xds_stream_->startGrpcStream();
-  }
-
-  void connectDefaultAuthority() {
-    AssertionResult result = default_authority_upstream_->waitForHttpConnection(
-        *dispatcher_, default_authority_xds_connection_);
-    RELEASE_ASSERT(result, result.message());
-    result = default_authority_xds_connection_->waitForNewStream(*dispatcher_,
-                                                                 default_authority_xds_stream_);
-    RELEASE_ASSERT(result, result.message());
-    default_authority_xds_stream_->startGrpcStream();
-  }
-
-  void cleanupXdsConnection(FakeHttpConnectionPtr& connection) {
-    if (connection != nullptr) {
-      AssertionResult result = connection->close();
-      RELEASE_ASSERT(result, result.message());
-      result = connection->waitForDisconnect();
-      RELEASE_ASSERT(result, result.message());
-      connection.reset();
-    }
-  }
-
-  envoy::config::endpoint::v3::ClusterLoadAssignment
-  buildClusterLoadAssignment(const std::string& name) {
-    // The last fake upstream is the emulated server.
-    return ConfigHelper::buildClusterLoadAssignment(
-        name, Network::Test::getLoopbackAddressString(ipVersion()),
-        fake_upstreams_.back().get()->localAddress()->ip()->port());
-  }
-
-  bool test_requires_additional_upstream_{true};
-
-  // Data members that emulate the authority1 server.
-  FakeUpstream* authority1_upstream_;
-  FakeHttpConnectionPtr authority1_xds_connection_;
-  FakeStreamPtr authority1_xds_stream_;
-
-  // Data members that emulate the default_authority server.
-  FakeUpstream* default_authority_upstream_;
-  FakeHttpConnectionPtr default_authority_xds_connection_;
-  FakeStreamPtr default_authority_xds_stream_;
+  XdsTpConfigsIntegrationTest() = default;
 };
 
 INSTANTIATE_TEST_SUITE_P(IpVersionsClientTypeDeltaWildcard, XdsTpConfigsIntegrationTest,


### PR DESCRIPTION
Commit Message: xds-federation: introduce OD-CDS xds-federation support
Additional Description:

This PR introduces OD-CDS xds-Federation support. The implementation uses a new OD-CDS subscription management on the main thread, that is simpler than the former (issues subscriptions directly using the xDS-manager subscription function), and doesn't need to maintain the state of whether the first request was sent or not.
It does so by allowing each subscription be a singleton subscription on the component side (the gRPC-mux to the xds-Federation server will ensure that a single subscription message is sent to the server). This approach handles some bugs that were detected for the non-xDS-TP based OD-CDS implementation.
The plan is first to use this implementation for xDS-TP based resources, and when it is validated in production, move the ADS and the specific-config-source paths to use the new implementation/model.

Apologies for the large PR, but the number of tests that was needed here is quite large.

Risk Level: low - only for xDS-TP based config sources and it is guarded by the `envoy.reloadable_features.xdstp_based_config_singleton_subscriptions` runtime guard which is currently disabled.
Testing: Added both unit-tests and integration tests
Docs Changes: N/A (until the entire xDS-TP based config sources support is done).
Release Notes: N/A (until the entire xDS-TP based config sources support is done).
Platform Specific Features: N/A
