### PR TITLE
tcp_proxy: Add max_downstream_connection_duration_jitter_percentage

### DIFF
--- a/api/envoy/extensions/filters/network/tcp_proxy/v3/tcp_proxy.proto
+++ b/api/envoy/extensions/filters/network/tcp_proxy/v3/tcp_proxy.proto
@@ -8,6 +8,7 @@ import "envoy/config/core/v3/base.proto";
 import "envoy/config/core/v3/config_source.proto";
 import "envoy/config/core/v3/proxy_protocol.proto";
 import "envoy/type/v3/hash_policy.proto";
+import "envoy/type/v3/percent.proto";
 
 import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
@@ -27,7 +28,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // TCP Proxy :ref:`configuration overview <config_network_filters_tcp_proxy>`.
 // [#extension: envoy.filters.network.tcp_proxy]
 
-// [#next-free-field: 20]
+// [#next-free-field: 21]
 message TcpProxy {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.network.tcp_proxy.v2.TcpProxy";
@@ -232,6 +233,11 @@ message TcpProxy {
   // is reached the connection will be closed. Duration must be at least 1ms.
   google.protobuf.Duration max_downstream_connection_duration = 13
       [(validate.rules).duration = {gte {nanos: 1000000}}];
+
+  // Percentage-based jitter for max_downstream_connection_duration. The jitter will be added
+  // randomly to the max_downstream_connection_duration.
+  // This field is ignored if max_downstream_connection_duration is not set.
+  type.v3.Percent max_downstream_connection_duration_jitter_percentage = 20;
 
   // Note that if both this field and :ref:`access_log_flush_interval
   // <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.TcpAccessLogOptions.access_log_flush_interval>`

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -272,6 +272,9 @@ new_features:
 - area: http
   change: |
     Added ``upstream_rq_per_cx`` histogram to track requests per connection for monitoring connection reuse efficiency.
-
+- area: tcp_proxy
+  change: |
+    Added ``max_downstream_connection_duration_jitter_percentage`` to allow adding a jitter to the max downstream connection duration.
+    This can be used to avoid thundering herd problems with many clients being disconnected and possibly reconnecting at the same time.
 
 deprecated:

--- a/source/common/tcp_proxy/tcp_proxy.cc
+++ b/source/common/tcp_proxy/tcp_proxy.cc
@@ -264,6 +264,31 @@ RouteConstSharedPtr Config::getRouteFromEntries(Network::Connection& connection)
                                           random_generator_.random(), false);
 }
 
+const absl::optional<std::chrono::milliseconds>
+Config::calculateMaxDownstreamConnectionDurationWithJitter() {
+  const auto& max_downstream_connection_duration = maxDownstreamConnectionDuration();
+  if (!max_downstream_connection_duration) {
+    return max_downstream_connection_duration;
+  }
+
+  const auto& jitter_percentage = maxDownstreamConnectionDurationJitterPercentage();
+  if (!jitter_percentage) {
+    return max_downstream_connection_duration;
+  }
+
+  // Apply jitter: base_duration * (1 + random(0, jitter_factor));
+  const uint64_t max_jitter_ms = std::ceil(max_downstream_connection_duration.value().count() *
+                                           (jitter_percentage.value() / 100.0));
+
+  if (max_jitter_ms == 0) {
+    return max_downstream_connection_duration;
+  }
+
+  const uint64_t jitter_ms = randomGenerator().random() % max_jitter_ms;
+  return std::chrono::milliseconds(
+      static_cast<uint64_t>(max_downstream_connection_duration.value().count() + jitter_ms));
+}
+
 UpstreamDrainManager& Config::drainManager() {
   return upstream_drain_manager_slot_->getTyped<UpstreamDrainManager>();
 }
@@ -867,10 +892,12 @@ Network::FilterStatus Filter::onData(Buffer::Instance& data, bool end_stream) {
 }
 
 Network::FilterStatus Filter::onNewConnection() {
-  if (config_->maxDownstreamConnectionDuration()) {
+  const auto& max_downstream_connection_duration =
+      config_->calculateMaxDownstreamConnectionDurationWithJitter();
+  if (max_downstream_connection_duration) {
     connection_duration_timer_ = read_callbacks_->connection().dispatcher().createTimer(
         [this]() -> void { onMaxDownstreamConnectionDuration(); });
-    connection_duration_timer_->enableTimer(config_->maxDownstreamConnectionDuration().value());
+    connection_duration_timer_->enableTimer(max_downstream_connection_duration.value());
   }
 
   if (config_->accessLogFlushInterval().has_value()) {

--- a/source/common/tcp_proxy/tcp_proxy.cc
+++ b/source/common/tcp_proxy/tcp_proxy.cc
@@ -132,6 +132,10 @@ Config::SharedConfig::SharedConfig(
         DurationUtil::durationToMilliseconds(config.max_downstream_connection_duration());
     max_downstream_connection_duration_ = std::chrono::milliseconds(connection_duration);
   }
+  if (config.has_max_downstream_connection_duration_jitter_percentage()) {
+    max_downstream_connection_duration_jitter_percentage_ =
+        config.max_downstream_connection_duration_jitter_percentage().value();
+  }
 
   if (config.has_access_log_options()) {
     if (config.flush_access_log_on_connected() /* deprecated */) {

--- a/source/common/tcp_proxy/tcp_proxy.h
+++ b/source/common/tcp_proxy/tcp_proxy.h
@@ -302,6 +302,8 @@ public:
   const absl::optional<double>& maxDownstreamConnectionDurationJitterPercentage() const {
     return shared_config_->maxDownstreamConnectionDurationJitterPercentage();
   }
+  const absl::optional<std::chrono::milliseconds>
+  calculateMaxDownstreamConnectionDurationWithJitter();
   const absl::optional<std::chrono::milliseconds>& accessLogFlushInterval() const {
     return shared_config_->accessLogFlushInterval();
   }

--- a/source/common/tcp_proxy/tcp_proxy.h
+++ b/source/common/tcp_proxy/tcp_proxy.h
@@ -235,6 +235,9 @@ public:
     const absl::optional<std::chrono::milliseconds>& maxDownstreamConnectionDuration() const {
       return max_downstream_connection_duration_;
     }
+    const absl::optional<double>& maxDownstreamConnectionDurationJitterPercentage() const {
+      return max_downstream_connection_duration_jitter_percentage_;
+    }
     const absl::optional<std::chrono::milliseconds>& accessLogFlushInterval() const {
       return access_log_flush_interval_;
     }
@@ -263,6 +266,7 @@ public:
     bool flush_access_log_on_connected_;
     absl::optional<std::chrono::milliseconds> idle_timeout_;
     absl::optional<std::chrono::milliseconds> max_downstream_connection_duration_;
+    absl::optional<double> max_downstream_connection_duration_jitter_percentage_;
     absl::optional<std::chrono::milliseconds> access_log_flush_interval_;
     std::unique_ptr<TunnelingConfigHelper> tunneling_config_helper_;
     std::unique_ptr<OnDemandConfig> on_demand_config_;
@@ -294,6 +298,9 @@ public:
   }
   const absl::optional<std::chrono::milliseconds>& maxDownstreamConnectionDuration() const {
     return shared_config_->maxDownstreamConnectionDuration();
+  }
+  const absl::optional<double>& maxDownstreamConnectionDurationJitterPercentage() const {
+    return shared_config_->maxDownstreamConnectionDurationJitterPercentage();
   }
   const absl::optional<std::chrono::milliseconds>& accessLogFlushInterval() const {
     return shared_config_->accessLogFlushInterval();

--- a/test/common/tcp_proxy/config_test.cc
+++ b/test/common/tcp_proxy/config_test.cc
@@ -1,3 +1,5 @@
+#include <chrono>
+
 #include "envoy/common/hashable.h"
 
 #include "test/common/tcp_proxy/tcp_proxy_test_base.h"
@@ -236,6 +238,83 @@ max_downstream_connection_duration_jitter_percentage:
   Config config_obj(constructConfigFromYaml(yaml, factory_context));
   EXPECT_EQ(std::chrono::seconds(10), config_obj.maxDownstreamConnectionDuration().value());
   EXPECT_EQ(50.0, config_obj.maxDownstreamConnectionDurationJitterPercentage().value());
+}
+
+TEST(ConfigTest, CalculateActualMaxDownstreamConnectionDuration) {
+  struct TestCase {
+    std::string name;
+    Protobuf::Duration* max_downstream_connection_duration;
+    envoy::type::v3::Percent* max_downstream_connection_duration_jitter_percentage;
+    uint64_t random_value;
+    absl::optional<std::chrono::milliseconds> expected_actual_max_downstream_connection_duration;
+  };
+
+  const auto seconds = [](uint64_t seconds) {
+    auto* d = new Protobuf::Duration();
+    d->set_seconds(seconds);
+    return d;
+  };
+
+  const auto percent = [](double value) {
+    auto* p = new envoy::type::v3::Percent();
+    p->set_value(value);
+    return p;
+  };
+
+  std::vector<TestCase> test_cases = {
+      {/* name */ "0% random value",
+       /* max_downstream_connection_duration */ seconds(10),
+       /* max_downstream_connection_duration_jitter_percentage */ percent(50.0),
+       /* random_value */ 0,
+       /* expected_actual_max_downstream_connection_duration */ std::chrono::milliseconds(10000)},
+      {/* name */ "50% random value",
+       /* max_downstream_connection_duration */ seconds(10),
+       /* max_downstream_connection_duration_jitter_percentage */ percent(50.0),
+       /* random_value */ 2500,
+       /* expected_actual_max_downstream_connection_duration */ std::chrono::milliseconds(12500)},
+      {/* name */ "99.99% random value",
+       /* max_downstream_connection_duration */ seconds(10),
+       /* max_downstream_connection_duration_jitter_percentage */ percent(50.0),
+       /* random_value */ 9999,
+       /* expected_actual_max_downstream_connection_duration */ std::chrono::milliseconds(14999)},
+      {/* name */ "0% jitter",
+       /* max_downstream_connection_duration */ seconds(10),
+       /* max_downstream_connection_duration_jitter_percentage */ percent(0),
+       /* random_value */ 5000,
+       /* expected_actual_max_downstream_connection_duration */ std::chrono::milliseconds(10000)},
+      {/* name */ "100% jitter",
+       /* max_downstream_connection_duration */ seconds(10),
+       /* max_downstream_connection_duration_jitter_percentage */ percent(100),
+       /* random_value */ 5000,
+       /* expected_actual_max_downstream_connection_duration */ std::chrono::milliseconds(15000)},
+      {/* name */ "no jitter",
+       /* max_downstream_connection_duration */ seconds(10),
+       /* max_downstream_connection_duration_jitter_percentage */ nullptr,
+       /* random_value */ 5000,
+       /* expected_actual_max_downstream_connection_duration */ std::chrono::milliseconds(10000)},
+      {/* name */ "no max duration",
+       /* max_downstream_connection_duration */ nullptr,
+       /* max_downstream_connection_duration_jitter_percentage */ percent(50),
+       /* random_value */ 5000,
+       /* expected_actual_max_downstream_connection_duration */ absl::nullopt},
+  };
+
+  for (const auto& test_case : test_cases) {
+    SCOPED_TRACE(test_case.name);
+    NiceMock<Server::Configuration::MockFactoryContext> factory_context;
+    ON_CALL(factory_context.server_factory_context_.api_.random_, random())
+        .WillByDefault(Return(test_case.random_value));
+
+    envoy::extensions::filters::network::tcp_proxy::v3::TcpProxy proto_config;
+    proto_config.set_allocated_max_downstream_connection_duration(
+        test_case.max_downstream_connection_duration);
+    proto_config.set_allocated_max_downstream_connection_duration_jitter_percentage(
+        test_case.max_downstream_connection_duration_jitter_percentage);
+    Config config_obj(proto_config, factory_context);
+
+    EXPECT_EQ(test_case.expected_actual_max_downstream_connection_duration,
+              config_obj.calculateMaxDownstreamConnectionDurationWithJitter());
+  }
 }
 
 TEST(ConfigTest, NoRouteConfig) {

--- a/test/common/tcp_proxy/config_test.cc
+++ b/test/common/tcp_proxy/config_test.cc
@@ -223,6 +223,21 @@ max_downstream_connection_duration: 10s
   EXPECT_EQ(std::chrono::seconds(10), config_obj.maxDownstreamConnectionDuration().value());
 }
 
+TEST(ConfigTest, MaxDownstreamConnectionDurationJitterPercentage) {
+  const std::string yaml = R"EOF(
+stat_prefix: name
+cluster: foo
+max_downstream_connection_duration: 10s
+max_downstream_connection_duration_jitter_percentage:
+  value: 50.0
+)EOF";
+
+  NiceMock<Server::Configuration::MockFactoryContext> factory_context;
+  Config config_obj(constructConfigFromYaml(yaml, factory_context));
+  EXPECT_EQ(std::chrono::seconds(10), config_obj.maxDownstreamConnectionDuration().value());
+  EXPECT_EQ(50.0, config_obj.maxDownstreamConnectionDurationJitterPercentage().value());
+}
+
 TEST(ConfigTest, NoRouteConfig) {
   const std::string yaml = R"EOF(
   stat_prefix: name

--- a/test/common/tcp_proxy/tcp_proxy_test.cc
+++ b/test/common/tcp_proxy/tcp_proxy_test.cc
@@ -2138,6 +2138,30 @@ TEST_P(TcpProxyTest, UpstreamStartSecureTransport) {
   filter_->startUpstreamSecureTransport();
 }
 
+// Verify the filter uses the value returned by
+// Config::calculateMaxDownstreamConnectionDurationWithJitter.
+TEST_P(TcpProxyTest, MaxDownstreamConnectionDurationWithJitterPercentage) {
+  envoy::extensions::filters::network::tcp_proxy::v3::TcpProxy config = defaultConfig();
+  config.mutable_max_downstream_connection_duration()->set_seconds(10);
+  config.mutable_max_downstream_connection_duration_jitter_percentage()->set_value(50.0);
+
+  EXPECT_CALL(factory_context_.server_factory_context_.api_.random_, random())
+      .WillRepeatedly(Return(2500));
+
+  setup(1, config);
+
+  // Calculation of expected value is verified in config test. Here we just verify that the filter
+  // uses the value returned by the config.
+  const auto expected = config_->calculateMaxDownstreamConnectionDurationWithJitter();
+  ASSERT_TRUE(expected.has_value());
+
+  Event::MockTimer* connection_duration_timer =
+      new Event::MockTimer(&filter_callbacks_.connection_.dispatcher_);
+
+  EXPECT_CALL(*connection_duration_timer, enableTimer(expected.value(), _));
+  EXPECT_EQ(Network::FilterStatus::StopIteration, filter_->onNewConnection());
+}
+
 // Test that the proxy protocol TLV is set.
 TEST_P(TcpProxyTest, SetTLV) {
   envoy::extensions::filters::network::tcp_proxy::v3::TcpProxy config = defaultConfig();


### PR DESCRIPTION
**Commit Message**: tcp_proxy: Add max_downstream_connection_duration_jitter_percentage
**Additional Description**: Adds proto for a new field that can be used to add a jitter to the max_downstream_connection_duration. This allows to prevent thundering herd problems.
**Risk Level**: Low (adds new feature not enabled by default)
**Testing**: Unit tests & Integration tests added, Functionality manually verified locally
**Docs Changes**: Added API docs
**Release Notes**: Added
**Platform Specific Features**: n/a
Fixes #40686
**Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md)*: Considered