### PR TITLE
dynamic modules: support metrics with labels by defining metric vector counterparts

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -350,5 +350,8 @@ new_features:
     Added a new metric ``db_build_epoch`` to track the build timestamp of the Maxmind geolocation database files.
     This can be used to monitor the freshness of the databases currently in use by the filter.
     See https://maxmind.github.io/MaxMind-DB/#build_epoch for more details.
+- area: dynamic_modules
+  change: |
+    Added support for counters, gauges, histograms, and their vector variants to the dynamic modules API.
 
 deprecated:

--- a/source/extensions/dynamic_modules/abi.h
+++ b/source/extensions/dynamic_modules/abi.h
@@ -165,6 +165,14 @@ typedef struct {
 } envoy_dynamic_module_type_envoy_buffer;
 
 /**
+ * envoy_dynamic_module_type_module_str represents a string owned by the module.
+ */
+typedef struct {
+  char* ptr;
+  size_t length;
+} envoy_dynamic_module_type_module_str;
+
+/**
  * envoy_dynamic_module_type_module_http_header represents a key-value pair of an HTTP header owned
  * by the module.
  */
@@ -786,6 +794,26 @@ size_t envoy_dynamic_module_callback_http_filter_config_define_counter(
     envoy_dynamic_module_type_buffer_module_ptr name, size_t name_length);
 
 /**
+ * envoy_dynamic_module_callback_http_filter_config_define_counter_vec is called by the module
+ * during initialization to create a template for generating Stats::Counters with the given name and
+ * labels during the lifecycle of the module.
+ *
+ * @param filter_config_envoy_ptr is the pointer to the DynamicModuleHttpFilterConfig in which the
+ * counter will be defined.
+ * @param name is the name of the counter to be defined.
+ * @param name_length is the length of the name.
+ * @param label_names is the labels of the counter to be defined.
+ * @param label_names_length is the length of the label_names.
+ * @return an opaque ID that represents a unique metric. This can be passed to
+ * envoy_dynamic_module_callback_http_filter_increment_counter together with filter_envoy_ptr
+ * created from filter_config_envoy_ptr.
+ */
+size_t envoy_dynamic_module_callback_http_filter_config_define_counter_vec(
+    envoy_dynamic_module_type_http_filter_config_envoy_ptr filter_config_envoy_ptr,
+    envoy_dynamic_module_type_buffer_module_ptr name, size_t name_length,
+    envoy_dynamic_module_type_module_str* label_names, size_t label_names_length);
+
+/**
  * envoy_dynamic_module_callback_http_filter_increment_counter is called by the module to increment
  * a previously defined counter.
  *
@@ -796,6 +824,21 @@ size_t envoy_dynamic_module_callback_http_filter_config_define_counter(
  */
 void envoy_dynamic_module_callback_http_filter_increment_counter(
     envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr, size_t id, uint64_t value);
+
+/**
+ * envoy_dynamic_module_callback_http_filter_increment_counter_vec is called by the module to
+ * increment a previously defined counter vec.
+ *
+ * @param filter_envoy_ptr is the pointer to the DynamicModuleHttpFilter object.
+ * @param id is the ID of the counter previously defined using the config that created
+ * filter_envoy_ptr
+ * @param label_values is the values of the labels to be incremented.
+ * @param label_values_length is the length of the label_values.
+ * @param value is the value to increment the counter by.
+ */
+void envoy_dynamic_module_callback_http_filter_increment_counter_vec(
+    envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr, size_t id,
+    envoy_dynamic_module_type_module_str* label_values, size_t label_values_length, uint64_t value);
 
 /**
  * envoy_dynamic_module_callback_http_filter_config_define_gauge is called by the module during
@@ -814,6 +857,26 @@ size_t envoy_dynamic_module_callback_http_filter_config_define_gauge(
     envoy_dynamic_module_type_buffer_module_ptr name, size_t name_length);
 
 /**
+ * envoy_dynamic_module_callback_http_filter_config_define_gauge_vec is called by the module during
+ * initialization to create a template for generating Stats::Gauges with the given name and labels
+ * during the lifecycle of the module.
+ *
+ * @param filter_config_envoy_ptr is the pointer to the DynamicModuleHttpFilterConfig in which the
+ * gauge will be defined.
+ * @param name is the name of the gauge to be defined.
+ * @param name_length is the length of the name.
+ * @param label_names is the labels of the gauge to be defined.
+ * @param label_names_length is the length of the label_names.
+ * @return an opaque ID that represents a unique metric. This can be passed to
+ * envoy_dynamic_module_callback_http_filter_increment_gauge together with filter_envoy_ptr created
+ * from filter_config_envoy_ptr.
+ */
+size_t envoy_dynamic_module_callback_http_filter_config_define_gauge_vec(
+    envoy_dynamic_module_type_http_filter_config_envoy_ptr filter_config_envoy_ptr,
+    envoy_dynamic_module_type_buffer_module_ptr name, size_t name_length,
+    envoy_dynamic_module_type_module_str* label_names, size_t label_names_length);
+
+/**
  * envoy_dynamic_module_callback_http_filter_increase_gauge is called by the module to increase the
  * value of a previously defined gauge.
  *
@@ -824,6 +887,21 @@ size_t envoy_dynamic_module_callback_http_filter_config_define_gauge(
  */
 void envoy_dynamic_module_callback_http_filter_increase_gauge(
     envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr, size_t id, uint64_t value);
+
+/**
+ * envoy_dynamic_module_callback_http_filter_increase_gauge_vec is called by the module to increase
+ * the value of a previously defined gauge vec.
+ *
+ * @param filter_envoy_ptr is the pointer to the DynamicModuleHttpFilter object.
+ * @param id is the ID of the gauge previously defined using the config that created
+ * filter_envoy_ptr
+ * @param label_values is the values of the labels to be increased.
+ * @param label_values_length is the length of the label_values.
+ * @param value is the value to increase the gauge by.
+ */
+void envoy_dynamic_module_callback_http_filter_increase_gauge_vec(
+    envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr, size_t id,
+    envoy_dynamic_module_type_module_str* label_values, size_t label_values_length, uint64_t value);
 
 /**
  * envoy_dynamic_module_callback_http_filter_decrease_gauge is called by the module to decrease the
@@ -838,6 +916,21 @@ void envoy_dynamic_module_callback_http_filter_decrease_gauge(
     envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr, size_t id, uint64_t value);
 
 /**
+ * envoy_dynamic_module_callback_http_filter_decrease_gauge_vec is called by the module to decrease
+ * the value of a previously defined gauge vec.
+ *
+ * @param filter_envoy_ptr is the pointer to the DynamicModuleHttpFilter object.
+ * @param id is the ID of the gauge previously defined using the config that created
+ * filter_envoy_ptr
+ * @param label_values is the values of the labels to be decreased.
+ * @param label_values_length is the length of the label_values.
+ * @param value is the value to decrease the gauge by.
+ */
+void envoy_dynamic_module_callback_http_filter_decrease_gauge_vec(
+    envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr, size_t id,
+    envoy_dynamic_module_type_module_str* label_values, size_t label_values_length, uint64_t value);
+
+/**
  * envoy_dynamic_module_callback_http_filter_set_gauge is called by the module to set the value
  * of a previously defined gauge.
  *
@@ -848,6 +941,21 @@ void envoy_dynamic_module_callback_http_filter_decrease_gauge(
  */
 void envoy_dynamic_module_callback_http_filter_set_gauge(
     envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr, size_t id, uint64_t value);
+
+/**
+ * envoy_dynamic_module_callback_http_filter_set_gauge_vec is called by the module to set the value
+ * of a previously defined gauge vec.
+ *
+ * @param filter_envoy_ptr is the pointer to the DynamicModuleHttpFilter object.
+ * @param id is the ID of the gauge previously defined using the config that created
+ * filter_envoy_ptr
+ * @param label_values is the values of the labels to be set.
+ * @param label_values_length is the length of the label_values.
+ * @param value is the value to set the gauge to.
+ */
+void envoy_dynamic_module_callback_http_filter_set_gauge_vec(
+    envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr, size_t id,
+    envoy_dynamic_module_type_module_str* label_values, size_t label_values_length, uint64_t value);
 
 /**
  * envoy_dynamic_module_callback_http_filter_config_define_histogram is called by the module during
@@ -866,6 +974,26 @@ size_t envoy_dynamic_module_callback_http_filter_config_define_histogram(
     envoy_dynamic_module_type_buffer_module_ptr name, size_t name_length);
 
 /**
+ * envoy_dynamic_module_callback_http_filter_config_define_histogram is called by the module during
+ * initialization to create a template for generating Stats::Histograms with the given name and
+ * labels during the lifecycle of the module.
+ *
+ * @param filter_config_envoy_ptr is the pointer to the DynamicModuleHttpFilterConfig in which the
+ * histogram will be defined.
+ * @param name is the name of the histogram to be defined.
+ * @param name_length is the length of the name.
+ * @param label_names is the labels of the histogram to be defined.
+ * @param label_names_length is the length of the label_names.
+ * @return an opaque ID that represents a unique metric. This can be passed to
+ * envoy_dynamic_module_callback_http_filter_increment_gauge together with filter_envoy_ptr created
+ * from filter_config_envoy_ptr.
+ */
+size_t envoy_dynamic_module_callback_http_filter_config_define_histogram_vec(
+    envoy_dynamic_module_type_http_filter_config_envoy_ptr filter_config_envoy_ptr,
+    envoy_dynamic_module_type_buffer_module_ptr name, size_t name_length,
+    envoy_dynamic_module_type_module_str* label_names, size_t label_names_length);
+
+/**
  * envoy_dynamic_module_callback_http_filter_record_histogram_value is called by the module to
  * record a value in a previously defined histogram.
  *
@@ -877,6 +1005,22 @@ size_t envoy_dynamic_module_callback_http_filter_config_define_histogram(
  */
 void envoy_dynamic_module_callback_http_filter_record_histogram_value(
     envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr, size_t id, uint64_t value);
+
+/**
+ * envoy_dynamic_module_callback_http_filter_record_histogram_value is called by the module to
+ * record a value in a previously defined histogram vec.
+ *
+ * @param histogram_envoy_ptr is a pointer to a histogram previously defined using
+ * envoy_dynamic_module_callback_http_define_histogram.
+ * @param id is the ID of the histogram previously defined using the config that created
+ * filter_envoy_ptr
+ * @param label_values is the values of the labels to be recorded.
+ * @param label_values_length is the length of the label_values.
+ * @param value is the value to record in the histogram.
+ */
+void envoy_dynamic_module_callback_http_filter_record_histogram_value_vec(
+    envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr, size_t id,
+    envoy_dynamic_module_type_module_str* label_values, size_t label_values_length, uint64_t value);
 
 // ---------------------- HTTP Header/Trailer callbacks ------------------------
 

--- a/source/extensions/dynamic_modules/abi_version.h
+++ b/source/extensions/dynamic_modules/abi_version.h
@@ -6,7 +6,7 @@ namespace DynamicModules {
 #endif
 // This is the ABI version calculated as a sha256 hash of the ABI header files. When the ABI
 // changes, this value must change, and the correctness of this value is checked by the test.
-const char* kAbiVersion = "56b4589b9f99ce76622a82bf3972f007679c197ed5b21be1f6c723a2dd0c8237";
+const char* kAbiVersion = "8c4ac684117a2a72ccba702e9cd22bfe5ae892e217b6f772f6c067e0c796c3c0";
 
 #ifdef __cplusplus
 } // namespace DynamicModules

--- a/source/extensions/dynamic_modules/sdk/rust/src/abi_str.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/abi_str.rs
@@ -1,0 +1,151 @@
+use std::borrow::Borrow;
+use std::convert::Infallible;
+use std::fmt::Display;
+use std::hash::{Hash, Hasher};
+use std::str::FromStr;
+
+/// A str struct that represents a string slice owned by the dynamic module.
+///
+/// This is used to pass strings between the dynamic module and Envoy.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, Eq)]
+pub struct ModuleStr<'a> {
+  ptr: *const u8,
+  len: usize,
+  _marker: std::marker::PhantomData<&'a ()>,
+}
+
+impl Default for ModuleStr<'_> {
+  fn default() -> Self {
+    Self::new("")
+  }
+}
+
+impl ModuleStr<'_> {
+  pub fn new(s: &str) -> Self {
+    Self {
+      ptr: s.as_ptr(),
+      len: s.len(),
+      _marker: std::marker::PhantomData,
+    }
+  }
+}
+
+impl PartialEq for ModuleStr<'_> {
+  fn eq(&self, other: &Self) -> bool {
+    Into::<&str>::into(*self) == Into::<&str>::into(*other)
+  }
+}
+
+impl Ord for ModuleStr<'_> {
+  fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+    Into::<&str>::into(*self).cmp(Into::<&str>::into(*other))
+  }
+}
+
+impl PartialOrd for ModuleStr<'_> {
+  fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+    Some(self.cmp(other))
+  }
+}
+
+impl Hash for ModuleStr<'_> {
+  fn hash<H: Hasher>(&self, state: &mut H) {
+    Into::<&str>::into(*self).hash(state)
+  }
+}
+
+impl From<&str> for ModuleStr<'_> {
+  fn from(s: &str) -> Self {
+    Self::new(s)
+  }
+}
+
+impl From<ModuleStr<'_>> for &'_ str {
+  fn from(s: ModuleStr<'_>) -> Self {
+    if s.ptr.is_null() {
+      ""
+    } else {
+      unsafe { std::str::from_utf8_unchecked(std::slice::from_raw_parts(s.ptr, s.len)) }
+    }
+  }
+}
+
+impl Borrow<str> for ModuleStr<'_> {
+  fn borrow(&self) -> &str {
+    (*self).into()
+  }
+}
+
+impl AsRef<str> for ModuleStr<'_> {
+  fn as_ref(&self) -> &str {
+    (*self).into()
+  }
+}
+
+impl Display for ModuleStr<'_> {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    Into::<&str>::into(*self).fmt(f)
+  }
+}
+
+impl FromStr for ModuleStr<'_> {
+  type Err = Infallible;
+
+  fn from_str(s: &str) -> Result<Self, Self::Err> {
+    Ok(Self::new(s))
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::abi;
+  use std::collections::HashMap;
+  use std::mem::offset_of;
+
+  #[test]
+  fn test_module_str_conversion() {
+    let s = ModuleStr::new("test");
+    assert_eq!(s.to_string(), "test");
+
+    let s = ModuleStr::default();
+    assert_eq!(s.to_string(), "");
+
+    let s = ModuleStr::from("");
+    assert_eq!(s.to_string(), "");
+    assert_eq!(ModuleStr::default(), ModuleStr::from(""));
+
+    // Test hash map
+    let mut str_map = HashMap::new();
+    str_map.insert(ModuleStr::new("test"), "value");
+    assert_eq!(str_map.get(&ModuleStr::new("test")), Some(&"value"));
+    assert_eq!(str_map.get("test"), Some(&"value"));
+
+    // Test ordering
+    let a = ModuleStr::new("a");
+    let b = ModuleStr::new("b");
+    assert!(a < b);
+    assert!(a <= b);
+    assert!(a <= a);
+    assert!(b > a);
+    assert!(b >= a);
+    assert!(b >= b);
+  }
+
+  #[test]
+  fn test_module_str_equivalent_layout() {
+    // TODO: Create/find a proc macro to do this automatically.
+    assert!(
+      offset_of!(ModuleStr<'_>, ptr) == offset_of!(abi::envoy_dynamic_module_type_module_str, ptr)
+    );
+    assert!(
+      offset_of!(ModuleStr<'_>, len)
+        == offset_of!(abi::envoy_dynamic_module_type_module_str, length)
+    );
+    assert!(
+      std::mem::size_of::<ModuleStr<'_>>()
+        == std::mem::size_of::<abi::envoy_dynamic_module_type_module_str>()
+    );
+  }
+}

--- a/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
@@ -3,6 +3,8 @@
 #![allow(non_snake_case)]
 #![allow(dead_code)]
 
+pub mod abi_str;
+pub use abi_str::ModuleStr;
 pub mod buffer;
 pub use buffer::{EnvoyBuffer, EnvoyMutBuffer};
 use mockall::predicate::*;
@@ -372,11 +374,20 @@ pub trait EnvoyHttpFilterConfig {
   /// Define a new counter scoped to this filter config with the given name.
   fn define_counter(&mut self, name: &str) -> EnvoyCounterId;
 
+  // Define a new counter vec scoped to this filter config with the given name.
+  fn define_counter_vec(&mut self, name: &str, labels: &[ModuleStr<'_>]) -> EnvoyCounterId;
+
   /// Define a new gauge scoped to this filter config with the given name.
   fn define_gauge(&mut self, name: &str) -> EnvoyGaugeId;
 
+  /// Define a new gauge vec scoped to this filter config with the given name.
+  fn define_gauge_vec(&mut self, name: &str, labels: &[ModuleStr<'_>]) -> EnvoyGaugeId;
+
   /// Define a new histogram scoped to this filter config with the given name.
   fn define_histogram(&mut self, name: &str) -> EnvoyHistogramId;
+
+  /// Define a new histogram vec scoped to this filter config with the given name.
+  fn define_histogram_vec(&mut self, name: &str, labels: &[ModuleStr<'_>]) -> EnvoyHistogramId;
 }
 
 pub struct EnvoyHttpFilterConfigImpl {
@@ -397,6 +408,23 @@ impl EnvoyHttpFilterConfig for EnvoyHttpFilterConfigImpl {
     EnvoyCounterId(id)
   }
 
+  fn define_counter_vec(&mut self, name: &str, labels: &[ModuleStr<'_>]) -> EnvoyCounterId {
+    let name_ptr = name.as_ptr();
+    let name_size = name.len();
+    let labels_ptr = labels.as_ptr();
+    let labels_size = labels.len();
+    let id = unsafe {
+      abi::envoy_dynamic_module_callback_http_filter_config_define_counter_vec(
+        self.raw_ptr,
+        name_ptr as *const _ as *mut _,
+        name_size,
+        labels_ptr as *const _ as *mut _,
+        labels_size,
+      )
+    };
+    EnvoyCounterId(id)
+  }
+
   fn define_gauge(&mut self, name: &str) -> EnvoyGaugeId {
     let name_ptr = name.as_ptr();
     let name_size = name.len();
@@ -410,6 +438,23 @@ impl EnvoyHttpFilterConfig for EnvoyHttpFilterConfigImpl {
     EnvoyGaugeId(id)
   }
 
+  fn define_gauge_vec(&mut self, name: &str, labels: &[ModuleStr<'_>]) -> EnvoyGaugeId {
+    let name_ptr = name.as_ptr();
+    let name_size = name.len();
+    let labels_ptr = labels.as_ptr();
+    let labels_size = labels.len();
+    let id = unsafe {
+      abi::envoy_dynamic_module_callback_http_filter_config_define_gauge_vec(
+        self.raw_ptr,
+        name_ptr as *const _ as *mut _,
+        name_size,
+        labels_ptr as *const _ as *mut _,
+        labels_size,
+      )
+    };
+    EnvoyGaugeId(id)
+  }
+
   fn define_histogram(&mut self, name: &str) -> EnvoyHistogramId {
     let name_ptr = name.as_ptr();
     let name_size = name.len();
@@ -418,6 +463,23 @@ impl EnvoyHttpFilterConfig for EnvoyHttpFilterConfigImpl {
         self.raw_ptr,
         name_ptr as *const _ as *mut _,
         name_size,
+      )
+    };
+    EnvoyHistogramId(id)
+  }
+
+  fn define_histogram_vec(&mut self, name: &str, labels: &[ModuleStr<'_>]) -> EnvoyHistogramId {
+    let name_ptr = name.as_ptr();
+    let name_size = name.len();
+    let labels_ptr = labels.as_ptr();
+    let labels_size = labels.len();
+    let id = unsafe {
+      abi::envoy_dynamic_module_callback_http_filter_config_define_histogram_vec(
+        self.raw_ptr,
+        name_ptr as *const _ as *mut _,
+        name_size,
+        labels_ptr as *const _ as *mut _,
+        labels_size,
       )
     };
     EnvoyHistogramId(id)
@@ -841,17 +903,37 @@ pub trait EnvoyHttpFilter {
   /// Increment the counter with the given id.
   fn increment_counter(&self, id: EnvoyCounterId, value: u64);
 
+  /// Increment the counter vec with the given id.
+  fn increment_counter_vec<'a>(&self, id: EnvoyCounterId, labels: &[ModuleStr<'a>], value: u64);
+
   /// Increase the gauge with the given id.
   fn increase_gauge(&self, id: EnvoyGaugeId, value: u64);
+
+  /// Increase the gauge vec with the given id.
+  fn increase_gauge_vec<'a>(&self, id: EnvoyGaugeId, labels: &[ModuleStr<'a>], value: u64);
 
   /// Decrease the gauge with the given id.
   fn decrease_gauge(&self, id: EnvoyGaugeId, value: u64);
 
+  /// Decrease the gauge vec with the given id.
+  fn decrease_gauge_vec<'a>(&self, id: EnvoyGaugeId, labels: &[ModuleStr<'a>], value: u64);
+
   /// Set the value of the gauge with the given id.
   fn set_gauge(&self, id: EnvoyGaugeId, value: u64);
 
+  /// Set the value of the gauge vec with the given id.
+  fn set_gauge_vec<'a>(&self, id: EnvoyGaugeId, labels: &[ModuleStr<'a>], value: u64);
+
   /// Record a value in the histogram with the given id.
   fn record_histogram_value(&self, id: EnvoyHistogramId, value: u64);
+
+  /// Record a value in the histogram vec with the given id.
+  fn record_histogram_value_vec<'a>(
+    &self,
+    id: EnvoyHistogramId,
+    labels: &[ModuleStr<'a>],
+    value: u64,
+  );
 }
 
 /// This implements the [`EnvoyHttpFilter`] trait with the given raw pointer to the Envoy HTTP
@@ -1413,10 +1495,36 @@ impl EnvoyHttpFilter for EnvoyHttpFilterImpl {
     }
   }
 
+  fn increment_counter_vec(&self, id: EnvoyCounterId, labels: &[ModuleStr<'_>], value: u64) {
+    let EnvoyCounterId(id) = id;
+    unsafe {
+      abi::envoy_dynamic_module_callback_http_filter_increment_counter_vec(
+        self.raw_ptr,
+        id,
+        labels.as_ptr() as *const _ as *mut _,
+        labels.len(),
+        value,
+      );
+    }
+  }
+
   fn increase_gauge(&self, id: EnvoyGaugeId, value: u64) {
     let EnvoyGaugeId(id) = id;
     unsafe {
       abi::envoy_dynamic_module_callback_http_filter_increase_gauge(self.raw_ptr, id, value);
+    }
+  }
+
+  fn increase_gauge_vec(&self, id: EnvoyGaugeId, labels: &[ModuleStr<'_>], value: u64) {
+    let EnvoyGaugeId(id) = id;
+    unsafe {
+      abi::envoy_dynamic_module_callback_http_filter_increase_gauge_vec(
+        self.raw_ptr,
+        id,
+        labels.as_ptr() as *const _ as *mut _,
+        labels.len(),
+        value,
+      );
     }
   }
 
@@ -1427,10 +1535,36 @@ impl EnvoyHttpFilter for EnvoyHttpFilterImpl {
     }
   }
 
+  fn decrease_gauge_vec(&self, id: EnvoyGaugeId, labels: &[ModuleStr<'_>], value: u64) {
+    let EnvoyGaugeId(id) = id;
+    unsafe {
+      abi::envoy_dynamic_module_callback_http_filter_decrease_gauge_vec(
+        self.raw_ptr,
+        id,
+        labels.as_ptr() as *const _ as *mut _,
+        labels.len(),
+        value,
+      );
+    }
+  }
+
   fn set_gauge(&self, id: EnvoyGaugeId, value: u64) {
     let EnvoyGaugeId(id) = id;
     unsafe {
       abi::envoy_dynamic_module_callback_http_filter_set_gauge(self.raw_ptr, id, value);
+    }
+  }
+
+  fn set_gauge_vec(&self, id: EnvoyGaugeId, labels: &[ModuleStr<'_>], value: u64) {
+    let EnvoyGaugeId(id) = id;
+    unsafe {
+      abi::envoy_dynamic_module_callback_http_filter_set_gauge_vec(
+        self.raw_ptr,
+        id,
+        labels.as_ptr() as *const _ as *mut _,
+        labels.len(),
+        value,
+      );
     }
   }
 
@@ -1440,6 +1574,19 @@ impl EnvoyHttpFilter for EnvoyHttpFilterImpl {
       abi::envoy_dynamic_module_callback_http_filter_record_histogram_value(
         self.raw_ptr,
         id,
+        value,
+      );
+    }
+  }
+
+  fn record_histogram_value_vec(&self, id: EnvoyHistogramId, labels: &[ModuleStr<'_>], value: u64) {
+    let EnvoyHistogramId(id) = id;
+    unsafe {
+      abi::envoy_dynamic_module_callback_http_filter_record_histogram_value_vec(
+        self.raw_ptr,
+        id,
+        labels.as_ptr() as *const _ as *mut _,
+        labels.len(),
         value,
       );
     }

--- a/source/extensions/filters/http/dynamic_modules/BUILD
+++ b/source/extensions/filters/http/dynamic_modules/BUILD
@@ -53,6 +53,7 @@ envoy_cc_extension(
 envoy_cc_library(
     name = "abi_impl",
     srcs = ["abi_impl.cc"],
+    hdrs = ["abi_impl.h"],
     deps = [
         ":filter_lib",
         "//source/common/http:utility_lib",

--- a/source/extensions/filters/http/dynamic_modules/abi_impl.h
+++ b/source/extensions/filters/http/dynamic_modules/abi_impl.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "source/extensions/dynamic_modules/abi.h"
+#include "source/extensions/filters/http/dynamic_modules/filter.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace DynamicModules {
+namespace HttpFilters {
+
+static absl::optional<Stats::StatNameTagVector>
+buildTagsForModuleMetric(DynamicModuleHttpFilter& filter,
+                         const DynamicModuleHttpFilterConfig::ModuleMetricHandle& metric,
+                         envoy_dynamic_module_type_module_str* label_values,
+                         size_t label_values_length) {
+
+  auto label_names = metric.getLabelNames();
+  if (label_values_length == 0) {
+    ASSERT(!label_names.has_value());
+    return absl::nullopt;
+  }
+
+  ASSERT(label_names.has_value());
+  ASSERT(label_values_length == label_names.value().get().size());
+  Stats::StatNameTagVector tags;
+  tags.reserve(label_values_length);
+  for (size_t i = 0; i < label_values_length; i++) {
+    absl::string_view label_value_view(label_values[i].ptr, label_values[i].length);
+    auto label_value = filter.getStatNamePool().add(label_value_view);
+    tags.push_back(Stats::StatNameTag(label_names.value().get()[i], label_value));
+  }
+  return tags;
+}
+
+} // namespace HttpFilters
+} // namespace DynamicModules
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/http/dynamic_modules/factory.cc
+++ b/source/extensions/filters/http/dynamic_modules/factory.cc
@@ -43,7 +43,7 @@ absl::StatusOr<Http::FilterFactoryCb> DynamicModuleConfigFactory::createFilterFa
   return [config = filter_config.value()](Http::FilterChainFactoryCallbacks& callbacks) -> void {
     auto filter =
         std::make_shared<Envoy::Extensions::DynamicModules::HttpFilters::DynamicModuleHttpFilter>(
-            config);
+            config, config->stats_scope_->symbolTable());
     filter->initializeInModuleFilter();
     callbacks.addStreamFilter(filter);
   };

--- a/source/extensions/filters/http/dynamic_modules/filter.h
+++ b/source/extensions/filters/http/dynamic_modules/filter.h
@@ -18,7 +18,9 @@ class DynamicModuleHttpFilter : public Http::StreamFilter,
                                 public std::enable_shared_from_this<DynamicModuleHttpFilter>,
                                 public Logger::Loggable<Logger::Id::dynamic_modules> {
 public:
-  DynamicModuleHttpFilter(DynamicModuleHttpFilterConfigSharedPtr config) : config_(config) {}
+  DynamicModuleHttpFilter(DynamicModuleHttpFilterConfigSharedPtr config,
+                          Stats::SymbolTable& symbol_table)
+      : config_(config), stat_name_pool_(symbol_table) {}
   ~DynamicModuleHttpFilter() override;
 
   /**
@@ -165,6 +167,7 @@ public:
                   Http::RequestMessagePtr&& message, uint64_t timeout_milliseconds);
 
   const DynamicModuleHttpFilterConfig& getFilterConfig() const { return *config_; }
+  Stats::StatNameDynamicPool& getStatNamePool() { return stat_name_pool_; }
 
 private:
   /**
@@ -193,6 +196,7 @@ private:
 
   const DynamicModuleHttpFilterConfigSharedPtr config_ = nullptr;
   envoy_dynamic_module_type_http_filter_module_ptr in_module_filter_ = nullptr;
+  Stats::StatNameDynamicPool stat_name_pool_;
 
   /**
    * This implementation of the AsyncClient::Callbacks is used to handle the response from the HTTP

--- a/source/extensions/filters/http/dynamic_modules/filter_config.cc
+++ b/source/extensions/filters/http/dynamic_modules/filter_config.cc
@@ -9,9 +9,9 @@ DynamicModuleHttpFilterConfig::DynamicModuleHttpFilterConfig(
     const absl::string_view filter_name, const absl::string_view filter_config,
     Extensions::DynamicModules::DynamicModulePtr dynamic_module, Stats::Scope& stats_scope,
     Server::Configuration::ServerFactoryContext& context)
-    : cluster_manager_(context.clusterManager()), stats_scope_(stats_scope.createScope("")),
-      stat_name_pool_(stats_scope_->symbolTable()),
-      custom_stat_namespace_(stat_name_pool_.add(CustomStatNamespace)), filter_name_(filter_name),
+    : cluster_manager_(context.clusterManager()),
+      stats_scope_(stats_scope.createScope(std::string(CustomStatNamespace) + ".")),
+      stat_name_pool_(stats_scope_->symbolTable()), filter_name_(filter_name),
       filter_config_(filter_config), dynamic_module_(std::move(dynamic_module)) {};
 
 DynamicModuleHttpFilterConfig::~DynamicModuleHttpFilterConfig() {

--- a/source/extensions/filters/http/dynamic_modules/filter_config.h
+++ b/source/extensions/filters/http/dynamic_modules/filter_config.h
@@ -80,43 +80,215 @@ public:
   Envoy::Upstream::ClusterManager& cluster_manager_;
   const Stats::ScopeSharedPtr stats_scope_;
   Stats::StatNamePool stat_name_pool_;
-  const Stats::StatName custom_stat_namespace_;
   // We only allow the module to create stats during envoy_dynamic_module_on_http_filter_config_new,
   // and not later during request handling, so that we don't have to wrap the stat storage in a
   // lock.
   bool stat_creation_frozen_ = false;
 
-  size_t addCounter(Stats::Counter& counter) {
+  using StatNameVecConstOptRef = OptRef<const Stats::StatNameVec>;
+
+  class ModuleMetricHandle {
+  public:
+    virtual ~ModuleMetricHandle() = default;
+
+    virtual StatNameVecConstOptRef getLabelNames() const { return StatNameVecConstOptRef(); };
+  };
+
+  class ModuleCounterHandle : public ModuleMetricHandle {
+  public:
+    virtual ~ModuleCounterHandle() = default;
+
+    // Increment the counter by the given amount.
+    virtual void add(Stats::Scope& scope, Stats::StatNameTagVectorOptConstRef tags,
+                     uint64_t amount) const PURE;
+  };
+  using ModuleCounterHandlePtr = std::unique_ptr<ModuleCounterHandle>;
+
+  class ModuleCounterHandleImpl : public ModuleCounterHandle {
+  public:
+    ModuleCounterHandleImpl(Stats::Counter& counter) : counter_(counter) {}
+    void add(Stats::Scope&, Stats::StatNameTagVectorOptConstRef tags,
+             uint64_t amount) const override {
+      ASSERT(!tags.has_value());
+      counter_.add(amount);
+    }
+
+  private:
+    Stats::Counter& counter_;
+  };
+
+  class ModuleCounterVecHandleImpl : public ModuleCounterHandle {
+  public:
+    ModuleCounterVecHandleImpl(Stats::StatName name, Stats::StatNameVec label_names)
+        : name_(name), label_names_(label_names) {}
+
+    // ModuleMetricHandle
+    virtual StatNameVecConstOptRef getLabelNames() const override {
+      return StatNameVecConstOptRef(label_names_);
+    }
+
+    virtual void add(Stats::Scope& scope, Stats::StatNameTagVectorOptConstRef tags,
+                     uint64_t amount) const override {
+      ASSERT(tags.has_value());
+      Stats::Utility::counterFromElements(scope, {name_}, tags).add(amount);
+    }
+
+  private:
+    Stats::StatName name_;
+    Stats::StatNameVec label_names_;
+  };
+
+  class ModuleGaugeHandle : public ModuleMetricHandle {
+  public:
+    virtual ~ModuleGaugeHandle() = default;
+
+    // Increase the gauge by the given amount.
+    virtual void increase(Stats::Scope& scope, Stats::StatNameTagVectorOptConstRef tags,
+                          uint64_t amount) const PURE;
+
+    // Decrease the gauge by the given amount.
+    virtual void decrease(Stats::Scope& scope, Stats::StatNameTagVectorOptConstRef tags,
+                          uint64_t amount) const PURE;
+
+    // Set the value of the gauge to the given amount.
+    virtual void set(Stats::Scope& scope, Stats::StatNameTagVectorOptConstRef tags,
+                     uint64_t amount) const PURE;
+  };
+  using ModuleGaugeHandlePtr = std::unique_ptr<ModuleGaugeHandle>;
+
+  class ModuleGaugeHandleImpl : public ModuleGaugeHandle {
+  public:
+    ModuleGaugeHandleImpl(Stats::Gauge& gauge) : gauge_(gauge) {}
+    virtual void increase(Stats::Scope&, Stats::StatNameTagVectorOptConstRef tags,
+                          uint64_t amount) const override {
+      ASSERT(!tags.has_value());
+      gauge_.add(amount);
+    }
+    virtual void decrease(Stats::Scope&, Stats::StatNameTagVectorOptConstRef tags,
+                          uint64_t amount) const override {
+      ASSERT(!tags.has_value());
+      gauge_.sub(amount);
+    }
+    virtual void set(Stats::Scope&, Stats::StatNameTagVectorOptConstRef tags,
+                     uint64_t amount) const override {
+      ASSERT(!tags.has_value());
+      gauge_.set(amount);
+    }
+
+  private:
+    Stats::Gauge& gauge_;
+  };
+
+  class ModuleGaugeVecHandleImpl : public ModuleGaugeHandle {
+  public:
+    ModuleGaugeVecHandleImpl(Stats::StatName name, Stats::StatNameVec label_names,
+                             Stats::Gauge::ImportMode import_mode)
+        : name_(name), label_names_(label_names), import_mode_(import_mode) {}
+
+    // ModuleMetricHandle
+    virtual StatNameVecConstOptRef getLabelNames() const override {
+      return StatNameVecConstOptRef(label_names_);
+    }
+
+    virtual void increase(Stats::Scope& scope, Stats::StatNameTagVectorOptConstRef tags,
+                          uint64_t amount) const override {
+      ASSERT(tags.has_value());
+      Stats::Utility::gaugeFromElements(scope, {name_}, import_mode_, tags).add(amount);
+    }
+    virtual void decrease(Stats::Scope& scope, Stats::StatNameTagVectorOptConstRef tags,
+                          uint64_t amount) const override {
+      ASSERT(tags.has_value());
+      Stats::Utility::gaugeFromElements(scope, {name_}, import_mode_, tags).sub(amount);
+    }
+    virtual void set(Stats::Scope& scope, Stats::StatNameTagVectorOptConstRef tags,
+                     uint64_t amount) const override {
+      ASSERT(tags.has_value());
+      Stats::Utility::gaugeFromElements(scope, {name_}, import_mode_, tags).set(amount);
+    }
+
+  private:
+    Stats::StatName name_;
+    Stats::StatNameVec label_names_;
+    Stats::Gauge::ImportMode import_mode_;
+  };
+
+  class ModuleHistogramHandle : public ModuleMetricHandle {
+  public:
+    virtual ~ModuleHistogramHandle() = default;
+
+    // Record the given value.
+    virtual void recordValue(Stats::Scope& scope, Stats::StatNameTagVectorOptConstRef tags,
+                             uint64_t value) const PURE;
+  };
+  using ModuleHistogramHandlePtr = std::unique_ptr<ModuleHistogramHandle>;
+
+  class ModuleHistogramHandleImpl : public ModuleHistogramHandle {
+  public:
+    ModuleHistogramHandleImpl(Stats::Histogram& histogram) : histogram_(histogram) {}
+    virtual void recordValue(Stats::Scope&, Stats::StatNameTagVectorOptConstRef tags,
+                             uint64_t value) const override {
+      ASSERT(!tags.has_value());
+      histogram_.recordValue(value);
+    }
+
+  private:
+    Stats::Histogram& histogram_;
+  };
+
+  class ModuleHistogramVecHandleImpl : public ModuleHistogramHandle {
+  public:
+    ModuleHistogramVecHandleImpl(Stats::StatName name, Stats::StatNameVec label_names,
+                                 Stats::Histogram::Unit unit)
+        : name_(name), label_names_(label_names), unit_(unit) {}
+
+    // ModuleMetricHandle
+    virtual StatNameVecConstOptRef getLabelNames() const override {
+      return StatNameVecConstOptRef(label_names_);
+    }
+
+    virtual void recordValue(Stats::Scope& scope, Stats::StatNameTagVectorOptConstRef tags,
+                             uint64_t value) const override {
+      ASSERT(tags.has_value());
+      Stats::Utility::histogramFromElements(scope, {name_}, unit_, tags).recordValue(value);
+    }
+
+  private:
+    Stats::StatName name_;
+    Stats::StatNameVec label_names_;
+    Stats::Histogram::Unit unit_;
+  };
+
+  size_t addCounter(ModuleCounterHandlePtr&& counter) {
     size_t id = counters_.size();
-    counters_.push_back(counter);
+    counters_.push_back(std::move(counter));
     return id;
   }
 
-  Stats::Counter& getCounterById(size_t id) const {
+  const ModuleCounterHandle& getCounterById(size_t id) const {
     ASSERT(id < counters_.size());
-    return counters_[id];
+    return *counters_[id];
   }
 
-  size_t addGauge(Stats::Gauge& gauge) {
+  size_t addGauge(ModuleGaugeHandlePtr&& gauge) {
     size_t id = gauges_.size();
-    gauges_.push_back(gauge);
+    gauges_.push_back(std::move(gauge));
     return id;
   }
 
-  Stats::Gauge& getGaugeById(size_t id) const {
+  const ModuleGaugeHandle& getGaugeById(size_t id) const {
     ASSERT(id < gauges_.size());
-    return gauges_[id];
+    return *gauges_[id];
   }
 
-  size_t addHistogram(Stats::Histogram& hist) {
+  size_t addHistogram(ModuleHistogramHandlePtr&& hist) {
     size_t id = hists_.size();
-    hists_.push_back(hist);
+    hists_.push_back(std::move(hist));
     return id;
   }
 
-  Stats::Histogram& getHistogramById(size_t id) const {
+  const ModuleHistogramHandle& getHistogramById(size_t id) const {
     ASSERT(id < hists_.size());
-    return hists_[id];
+    return *hists_[id];
   }
 
 private:
@@ -127,9 +299,9 @@ private:
   const std::string filter_config_;
 
   // The cached references to stats and their metadata.
-  std::vector<std::reference_wrapper<Stats::Counter>> counters_;
-  std::vector<std::reference_wrapper<Stats::Gauge>> gauges_;
-  std::vector<std::reference_wrapper<Stats::Histogram>> hists_;
+  std::vector<ModuleCounterHandlePtr> counters_;
+  std::vector<ModuleGaugeHandlePtr> gauges_;
+  std::vector<ModuleHistogramHandlePtr> hists_;
 
   // The handle for the module.
   Extensions::DynamicModules::DynamicModulePtr dynamic_module_;

--- a/test/extensions/dynamic_modules/http/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/http/abi_impl_test.cc
@@ -1,3 +1,6 @@
+#include <iterator>
+#include <memory>
+
 #include "source/extensions/filters/http/dynamic_modules/filter.h"
 
 #include "test/common/stats/stat_test_utility.h"
@@ -16,11 +19,12 @@ namespace HttpFilters {
 class DynamicModuleHttpFilterTest : public testing::Test {
 public:
   void SetUp() override {
-    filter_ = std::make_unique<DynamicModuleHttpFilter>(nullptr);
+    filter_ = std::make_unique<DynamicModuleHttpFilter>(nullptr, symbol_table_);
     filter_->setDecoderFilterCallbacks(decoder_callbacks_);
     filter_->setEncoderFilterCallbacks(encoder_callbacks_);
   }
 
+  Stats::SymbolTableImpl symbol_table_;
   NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks_;
   NiceMock<Http::MockStreamEncoderFilterCallbacks> encoder_callbacks_;
   Http::TestRequestHeaderMapImpl request_headers_;
@@ -423,7 +427,8 @@ TEST_F(DynamicModuleHttpFilterTest, SendResponseWithBody) {
 }
 
 TEST(ABIImpl, metadata) {
-  DynamicModuleHttpFilter filter{nullptr};
+  Stats::SymbolTableImpl symbol_table;
+  DynamicModuleHttpFilter filter{nullptr, symbol_table};
   const std::string namespace_str = "foo";
   const std::string key_str = "key";
   envoy_dynamic_module_type_buffer_module_ptr namespace_ptr =
@@ -546,7 +551,8 @@ TEST(ABIImpl, metadata) {
 }
 
 TEST(ABIImpl, filter_state) {
-  DynamicModuleHttpFilter filter{nullptr};
+  Stats::SymbolTableImpl symbol_table;
+  DynamicModuleHttpFilter filter{nullptr, symbol_table};
   const std::string key_str = "key";
   envoy_dynamic_module_type_buffer_module_ptr key_ptr = const_cast<char*>(key_str.data());
   size_t key_length = key_str.size();
@@ -595,7 +601,8 @@ bufferVectorToString(const std::vector<envoy_dynamic_module_type_envoy_buffer>& 
 }
 
 TEST(ABIImpl, RequestBody) {
-  DynamicModuleHttpFilter filter{nullptr};
+  Stats::SymbolTableImpl symbol_table;
+  DynamicModuleHttpFilter filter{nullptr, symbol_table};
   Http::MockStreamDecoderFilterCallbacks callbacks;
   StreamInfo::MockStreamInfo stream_info;
   EXPECT_CALL(callbacks, streamInfo()).WillRepeatedly(testing::ReturnRef(stream_info));
@@ -668,7 +675,8 @@ TEST(ABIImpl, RequestBody) {
 }
 
 TEST(ABIImpl, ResponseBody) {
-  DynamicModuleHttpFilter filter{nullptr};
+  Stats::SymbolTableImpl symbol_table;
+  DynamicModuleHttpFilter filter{nullptr, symbol_table};
   Http::MockStreamEncoderFilterCallbacks callbacks;
   StreamInfo::MockStreamInfo stream_info;
   EXPECT_CALL(callbacks, streamInfo()).WillRepeatedly(testing::ReturnRef(stream_info));
@@ -751,7 +759,8 @@ TEST(ABIImpl, ResponseBody) {
 }
 
 TEST(ABIImpl, ClearRouteCache) {
-  DynamicModuleHttpFilter filter{nullptr};
+  Stats::SymbolTableImpl symbol_table;
+  DynamicModuleHttpFilter filter{nullptr, symbol_table};
   Http::MockStreamDecoderFilterCallbacks callbacks;
   StreamInfo::MockStreamInfo stream_info;
   EXPECT_CALL(callbacks, streamInfo()).WillRepeatedly(testing::ReturnRef(stream_info));
@@ -764,8 +773,9 @@ TEST(ABIImpl, ClearRouteCache) {
 }
 
 TEST(ABIImpl, GetAttributes) {
-  DynamicModuleHttpFilter filter_without_callbacks{nullptr};
-  DynamicModuleHttpFilter filter{nullptr};
+  Stats::SymbolTableImpl symbol_table;
+  DynamicModuleHttpFilter filter_without_callbacks{nullptr, symbol_table};
+  DynamicModuleHttpFilter filter{nullptr, symbol_table};
   Http::MockStreamDecoderFilterCallbacks callbacks;
   StreamInfo::MockStreamInfo stream_info;
   EXPECT_CALL(callbacks, streamInfo()).WillRepeatedly(testing::ReturnRef(stream_info));
@@ -1054,7 +1064,8 @@ TEST(ABIImpl, GetAttributes) {
 }
 
 TEST(ABIImpl, HttpCallout) {
-  DynamicModuleHttpFilter filter{nullptr};
+  Stats::SymbolTableImpl symbol_table;
+  DynamicModuleHttpFilter filter{nullptr, symbol_table};
   const std::string cluster{"some_cluster"};
   EXPECT_EQ(envoy_dynamic_module_callback_http_filter_http_callout(
                 &filter, 1, const_cast<char*>(cluster.data()), cluster.size(), nullptr, 0, nullptr,
@@ -1093,7 +1104,7 @@ TEST(ABIImpl, Stats) {
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   auto filter_config = std::make_shared<DynamicModuleHttpFilterConfig>(
       "some_name", "some_config", nullptr, stats_scope, context);
-  DynamicModuleHttpFilter filter{filter_config};
+  DynamicModuleHttpFilter filter{filter_config, stats_scope.symbolTable()};
 
   const std::string counter_name{"some_counter"};
   size_t counter_id = envoy_dynamic_module_callback_http_filter_config_define_counter(
@@ -1106,6 +1117,35 @@ TEST(ABIImpl, Stats) {
   EXPECT_EQ(counter->get().value(), 10);
   envoy_dynamic_module_callback_http_filter_increment_counter(&filter, counter_id, 42);
   EXPECT_EQ(counter->get().value(), 52);
+
+  const std::string counter_vec_name{"some_counter_vec"};
+  const std::string counter_vec_label_name{"some_label"};
+  std::vector<envoy_dynamic_module_type_module_str> counter_vec_labels = {
+      {const_cast<char*>(counter_vec_label_name.data()), counter_vec_label_name.size()},
+  };
+  size_t counter_vec_id = envoy_dynamic_module_callback_http_filter_config_define_counter_vec(
+      filter_config.get(), const_cast<char*>(counter_vec_name.data()), counter_vec_name.size(),
+      counter_vec_labels.data(), counter_vec_labels.size());
+
+  const std::string counter_vec_label_value{"some_value"};
+  std::vector<envoy_dynamic_module_type_module_str> counter_vec_labels_values = {
+      {const_cast<char*>(counter_vec_label_value.data()), counter_vec_label_value.size()},
+  };
+  envoy_dynamic_module_callback_http_filter_increment_counter_vec(
+      &filter, counter_vec_id, counter_vec_labels_values.data(), counter_vec_labels_values.size(),
+      10);
+  Stats::CounterOptConstRef counter_vec = stats_store.findCounterByString(
+      "dynamicmodulescustom.some_counter_vec.some_label.some_value");
+  EXPECT_TRUE(counter_vec.has_value());
+  EXPECT_EQ(counter_vec->get().value(), 10);
+  envoy_dynamic_module_callback_http_filter_increment_counter_vec(
+      &filter, counter_vec_id, counter_vec_labels_values.data(), counter_vec_labels_values.size(),
+      10);
+  EXPECT_EQ(counter_vec->get().value(), 20);
+  envoy_dynamic_module_callback_http_filter_increment_counter_vec(
+      &filter, counter_vec_id, counter_vec_labels_values.data(), counter_vec_labels_values.size(),
+      42);
+  EXPECT_EQ(counter_vec->get().value(), 62);
 
   const std::string gauge_name{"some_gauge"};
   size_t gauge_id = envoy_dynamic_module_callback_http_filter_config_define_gauge(
@@ -1122,6 +1162,35 @@ TEST(ABIImpl, Stats) {
   envoy_dynamic_module_callback_http_filter_set_gauge(&filter, gauge_id, 9001);
   EXPECT_EQ(gauge->get().value(), 9001);
 
+  const std::string gauge_vec_name{"some_gauge_vec"};
+  const std::string gauge_vec_label_name{"some_label"};
+  std::vector<envoy_dynamic_module_type_module_str> gauge_vec_labels = {
+      {const_cast<char*>(gauge_vec_label_name.data()), gauge_vec_label_name.size()},
+  };
+  size_t gauge_vec_id = envoy_dynamic_module_callback_http_filter_config_define_gauge_vec(
+      filter_config.get(), const_cast<char*>(gauge_vec_name.data()), gauge_vec_name.size(),
+      gauge_vec_labels.data(), gauge_vec_labels.size());
+
+  const std::string gauge_vec_label_value{"some_value"};
+  std::vector<envoy_dynamic_module_type_module_str> gauge_vec_labels_values = {
+      {const_cast<char*>(gauge_vec_label_value.data()), gauge_vec_label_value.size()},
+  };
+  envoy_dynamic_module_callback_http_filter_increase_gauge_vec(
+      &filter, gauge_vec_id, gauge_vec_labels_values.data(), gauge_vec_labels_values.size(), 10);
+  Stats::GaugeOptConstRef gauge_vec =
+      stats_store.findGaugeByString("dynamicmodulescustom.some_gauge_vec.some_label.some_value");
+  EXPECT_TRUE(gauge_vec.has_value());
+  EXPECT_EQ(gauge_vec->get().value(), 10);
+  envoy_dynamic_module_callback_http_filter_increase_gauge_vec(
+      &filter, gauge_vec_id, gauge_vec_labels_values.data(), gauge_vec_labels_values.size(), 10);
+  EXPECT_EQ(gauge_vec->get().value(), 20);
+  envoy_dynamic_module_callback_http_filter_decrease_gauge_vec(
+      &filter, gauge_vec_id, gauge_vec_labels_values.data(), gauge_vec_labels_values.size(), 12);
+  EXPECT_EQ(gauge_vec->get().value(), 8);
+  envoy_dynamic_module_callback_http_filter_set_gauge_vec(
+      &filter, gauge_vec_id, gauge_vec_labels_values.data(), gauge_vec_labels_values.size(), 9001);
+  EXPECT_EQ(gauge_vec->get().value(), 9001);
+
   const std::string histogram_name{"some_histogram"};
   size_t histogram_id = envoy_dynamic_module_callback_http_filter_config_define_histogram(
       filter_config.get(), const_cast<char*>(histogram_name.data()), histogram_name.size());
@@ -1134,6 +1203,35 @@ TEST(ABIImpl, Stats) {
             (std::vector<uint64_t>{10}));
   envoy_dynamic_module_callback_http_filter_record_histogram_value(&filter, histogram_id, 42);
   EXPECT_EQ(stats_store.histogramValues("dynamicmodulescustom.some_histogram", false),
+            (std::vector<uint64_t>{10, 42}));
+
+  const std::string histogram_vec_name{"some_histogram_vec"};
+  const std::string histogram_vec_label_name{"some_label"};
+  std::vector<envoy_dynamic_module_type_module_str> histogram_vec_labels = {
+      {const_cast<char*>(histogram_vec_label_name.data()), histogram_vec_label_name.size()},
+  };
+  size_t histogram_vec_id = envoy_dynamic_module_callback_http_filter_config_define_histogram_vec(
+      filter_config.get(), const_cast<char*>(histogram_vec_name.data()), histogram_vec_name.size(),
+      histogram_vec_labels.data(), histogram_vec_labels.size());
+
+  const std::string histogram_vec_label_value{"some_value"};
+  std::vector<envoy_dynamic_module_type_module_str> histogram_vec_labels_values = {
+      {const_cast<char*>(histogram_vec_label_value.data()), histogram_vec_label_value.size()},
+  };
+  envoy_dynamic_module_callback_http_filter_record_histogram_value_vec(
+      &filter, histogram_vec_id, histogram_vec_labels_values.data(),
+      histogram_vec_labels_values.size(), 10);
+  Stats::HistogramOptConstRef histogram_vec = stats_store.findHistogramByString(
+      "dynamicmodulescustom.some_histogram_vec.some_label.some_value");
+  EXPECT_TRUE(histogram_vec.has_value());
+  EXPECT_EQ(stats_store.histogramValues(
+                "dynamicmodulescustom.some_histogram_vec.some_label.some_value", false),
+            (std::vector<uint64_t>{10}));
+  envoy_dynamic_module_callback_http_filter_record_histogram_value_vec(
+      &filter, histogram_vec_id, histogram_vec_labels_values.data(),
+      histogram_vec_labels_values.size(), 42);
+  EXPECT_EQ(stats_store.histogramValues(
+                "dynamicmodulescustom.some_histogram_vec.some_label.some_value", false),
             (std::vector<uint64_t>{10, 42}));
 }
 

--- a/test/extensions/dynamic_modules/http/filter_test.cc
+++ b/test/extensions/dynamic_modules/http/filter_test.cc
@@ -34,7 +34,8 @@ TEST_P(DynamicModuleTestLanguages, Nop) {
           *stats_store.createScope(""), context);
   EXPECT_TRUE(filter_config_or_status.ok());
 
-  auto filter = std::make_shared<DynamicModuleHttpFilter>(filter_config_or_status.value());
+  auto filter = std::make_shared<DynamicModuleHttpFilter>(filter_config_or_status.value(),
+                                                          stats_store.symbolTable());
   filter->initializeInModuleFilter();
 
   // The followings are mostly for coverage at the moment.
@@ -94,7 +95,8 @@ TEST(DynamicModulesTest, StatsCallbacks) {
           filter_name, filter_config, std::move(dynamic_module.value()), stats_scope, context);
   EXPECT_TRUE(filter_config_or_status.ok());
 
-  auto filter = std::make_shared<DynamicModuleHttpFilter>(filter_config_or_status.value());
+  auto filter = std::make_shared<DynamicModuleHttpFilter>(filter_config_or_status.value(),
+                                                          stats_scope.symbolTable());
   filter->initializeInModuleFilter();
 
   Stats::CounterOptConstRef counter =
@@ -113,6 +115,29 @@ TEST(DynamicModulesTest, StatsCallbacks) {
       stats_store.findHistogramByString("dynamicmodulescustom.ones");
   EXPECT_TRUE(histogram.has_value());
   EXPECT_FALSE(stats_store.histogramRecordedValues("dynamicmodulescustom.ones"));
+
+  Stats::CounterOptConstRef counter_vec_increment =
+      stats_store.findCounterByString("dynamicmodulescustom.test_counter_vec.test_label.increment");
+  EXPECT_TRUE(counter_vec_increment.has_value());
+  EXPECT_EQ(counter_vec_increment->get().value(), 1);
+  Stats::GaugeOptConstRef gauge_vec_increase =
+      stats_store.findGaugeByString("dynamicmodulescustom.test_gauge_vec.test_label.increase");
+  EXPECT_TRUE(gauge_vec_increase.has_value());
+  EXPECT_EQ(gauge_vec_increase->get().value(), 1);
+  Stats::GaugeOptConstRef gauge_vec_decrease =
+      stats_store.findGaugeByString("dynamicmodulescustom.test_gauge_vec.test_label.decrease");
+  EXPECT_TRUE(gauge_vec_decrease.has_value());
+  EXPECT_EQ(gauge_vec_decrease->get().value(), 2);
+  Stats::GaugeOptConstRef gauge_vec_set =
+      stats_store.findGaugeByString("dynamicmodulescustom.test_gauge_vec.test_label.set");
+  EXPECT_TRUE(gauge_vec_set.has_value());
+  EXPECT_EQ(gauge_vec_set->get().value(), 9001);
+  Stats::HistogramOptConstRef histogram_vec_record = stats_store.findHistogramByString(
+      "dynamicmodulescustom.test_histogram_vec.test_label.record");
+  EXPECT_TRUE(histogram_vec_record.has_value());
+  EXPECT_EQ(stats_store.histogramValues("dynamicmodulescustom.test_histogram_vec.test_label.record",
+                                        false),
+            (std::vector<uint64_t>{1}));
 
   Http::MockStreamDecoderFilterCallbacks decoder_callbacks;
   StreamInfo::MockStreamInfo stream_info;
@@ -163,7 +188,8 @@ TEST(DynamicModulesTest, HeaderCallbacks) {
           *stats_store.createScope(""), context);
   EXPECT_TRUE(filter_config_or_status.ok());
 
-  auto filter = std::make_shared<DynamicModuleHttpFilter>(filter_config_or_status.value());
+  auto filter = std::make_shared<DynamicModuleHttpFilter>(filter_config_or_status.value(),
+                                                          stats_store.symbolTable());
   filter->initializeInModuleFilter();
 
   Http::MockStreamDecoderFilterCallbacks decoder_callbacks;
@@ -218,13 +244,14 @@ TEST(DynamicModulesTest, DynamicMetadataCallbacks) {
 
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   Stats::IsolatedStoreImpl stats_store;
+  auto stats_scope = stats_store.createScope("");
   auto filter_config_or_status =
       Envoy::Extensions::DynamicModules::HttpFilters::newDynamicModuleHttpFilterConfig(
-          filter_name, filter_config, std::move(dynamic_module.value()),
-          *stats_store.createScope(""), context);
+          filter_name, filter_config, std::move(dynamic_module.value()), *stats_scope, context);
   EXPECT_TRUE(filter_config_or_status.ok());
 
-  auto filter = std::make_shared<DynamicModuleHttpFilter>(filter_config_or_status.value());
+  auto filter = std::make_shared<DynamicModuleHttpFilter>(filter_config_or_status.value(),
+                                                          stats_scope->symbolTable());
   filter->initializeInModuleFilter();
 
   auto route = std::make_shared<NiceMock<Router::MockRoute>>();
@@ -300,13 +327,14 @@ TEST(DynamicModulesTest, FilterStateCallbacks) {
 
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   Stats::IsolatedStoreImpl stats_store;
+  auto stats_scope = stats_store.createScope("");
   auto filter_config_or_status =
       Envoy::Extensions::DynamicModules::HttpFilters::newDynamicModuleHttpFilterConfig(
-          filter_name, filter_config, std::move(dynamic_module.value()),
-          *stats_store.createScope(""), context);
+          filter_name, filter_config, std::move(dynamic_module.value()), *stats_scope, context);
   EXPECT_TRUE(filter_config_or_status.ok());
 
-  auto filter = std::make_shared<DynamicModuleHttpFilter>(filter_config_or_status.value());
+  auto filter = std::make_shared<DynamicModuleHttpFilter>(filter_config_or_status.value(),
+                                                          stats_scope->symbolTable());
   filter->initializeInModuleFilter();
 
   Http::MockStreamDecoderFilterCallbacks callbacks;
@@ -376,13 +404,14 @@ TEST(DynamicModulesTest, BodyCallbacks) {
 
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   Stats::IsolatedStoreImpl stats_store;
+  auto stats_scope = stats_store.createScope("");
   auto filter_config_or_status =
       Envoy::Extensions::DynamicModules::HttpFilters::newDynamicModuleHttpFilterConfig(
-          filter_name, filter_config, std::move(dynamic_module.value()),
-          *stats_store.createScope(""), context);
+          filter_name, filter_config, std::move(dynamic_module.value()), *stats_scope, context);
   EXPECT_TRUE(filter_config_or_status.ok());
 
-  auto filter = std::make_shared<DynamicModuleHttpFilter>(filter_config_or_status.value());
+  auto filter = std::make_shared<DynamicModuleHttpFilter>(filter_config_or_status.value(),
+                                                          stats_scope->symbolTable());
   filter->initializeInModuleFilter();
 
   Http::MockStreamDecoderFilterCallbacks decoder_callbacks;
@@ -443,6 +472,7 @@ TEST(DynamicModulesTest, HttpFilterHttpCallout_non_existing_cluster) {
 
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   Stats::IsolatedStoreImpl stats_store;
+  auto stats_scope = stats_store.createScope("");
   Upstream::MockClusterManager cluster_manager;
   NiceMock<Upstream::MockThreadLocalCluster> thread_local_cluster;
   EXPECT_CALL(cluster_manager, getThreadLocalCluster(_))
@@ -454,12 +484,12 @@ TEST(DynamicModulesTest, HttpFilterHttpCallout_non_existing_cluster) {
       .WillOnce(testing::Return(nullptr));
   auto filter_config_or_status =
       Envoy::Extensions::DynamicModules::HttpFilters::newDynamicModuleHttpFilterConfig(
-          filter_name, filter_config, std::move(dynamic_module.value()),
-          *stats_store.createScope(""), context);
+          filter_name, filter_config, std::move(dynamic_module.value()), *stats_scope, context);
   EXPECT_TRUE(filter_config_or_status.ok());
 
   Http::MockStreamDecoderFilterCallbacks callbacks;
-  auto filter = std::make_shared<DynamicModuleHttpFilter>(filter_config_or_status.value());
+  auto filter = std::make_shared<DynamicModuleHttpFilter>(filter_config_or_status.value(),
+                                                          stats_scope->symbolTable());
   filter->initializeInModuleFilter();
   filter->setDecoderFilterCallbacks(callbacks);
   EXPECT_CALL(callbacks, sendLocalReply(Http::Code::InternalServerError, _, _, _, _));
@@ -481,6 +511,7 @@ TEST(DynamicModulesTest, HttpFilterHttpCallout_immediate_failing_cluster) {
 
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   Stats::IsolatedStoreImpl stats_store;
+  auto stats_scope = stats_store.createScope("");
   Upstream::MockClusterManager cluster_manager;
   NiceMock<Upstream::MockThreadLocalCluster> thread_local_cluster;
   EXPECT_CALL(cluster_manager, getThreadLocalCluster(_))
@@ -490,8 +521,7 @@ TEST(DynamicModulesTest, HttpFilterHttpCallout_immediate_failing_cluster) {
   const std::string filter_config = "immediate_failing_cluster";
   auto filter_config_or_status =
       Envoy::Extensions::DynamicModules::HttpFilters::newDynamicModuleHttpFilterConfig(
-          filter_name, filter_config, std::move(dynamic_module.value()),
-          *stats_store.createScope(""), context);
+          filter_name, filter_config, std::move(dynamic_module.value()), *stats_scope, context);
   EXPECT_TRUE(filter_config_or_status.ok());
 
   std::shared_ptr<Upstream::MockThreadLocalCluster> cluster =
@@ -511,7 +541,8 @@ TEST(DynamicModulesTest, HttpFilterHttpCallout_immediate_failing_cluster) {
           }));
 
   Http::MockStreamDecoderFilterCallbacks callbacks;
-  auto filter = std::make_shared<DynamicModuleHttpFilter>(filter_config_or_status.value());
+  auto filter = std::make_shared<DynamicModuleHttpFilter>(filter_config_or_status.value(),
+                                                          stats_scope->symbolTable());
   filter->initializeInModuleFilter();
   filter->setDecoderFilterCallbacks(callbacks);
   EXPECT_CALL(callbacks, sendLocalReply(Http::Code::InternalServerError, _, _, _, _));
@@ -533,6 +564,7 @@ TEST(DynamicModulesTest, HttpFilterHttpCallout_success) {
 
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   Stats::IsolatedStoreImpl stats_store;
+  auto stats_scope = stats_store.createScope("");
   Upstream::MockClusterManager cluster_manager;
   NiceMock<Upstream::MockThreadLocalCluster> thread_local_cluster;
   EXPECT_CALL(cluster_manager, getThreadLocalCluster(_))
@@ -542,8 +574,7 @@ TEST(DynamicModulesTest, HttpFilterHttpCallout_success) {
   const std::string filter_config = "success_cluster";
   auto filter_config_or_status =
       Envoy::Extensions::DynamicModules::HttpFilters::newDynamicModuleHttpFilterConfig(
-          filter_name, filter_config, std::move(dynamic_module.value()),
-          *stats_store.createScope(""), context);
+          filter_name, filter_config, std::move(dynamic_module.value()), *stats_scope, context);
   EXPECT_TRUE(filter_config_or_status.ok());
 
   std::shared_ptr<Upstream::MockThreadLocalCluster> cluster =
@@ -567,7 +598,8 @@ TEST(DynamicModulesTest, HttpFilterHttpCallout_success) {
           }));
 
   Http::MockStreamDecoderFilterCallbacks callbacks;
-  auto filter = std::make_shared<DynamicModuleHttpFilter>(filter_config_or_status.value());
+  auto filter = std::make_shared<DynamicModuleHttpFilter>(filter_config_or_status.value(),
+                                                          stats_scope->symbolTable());
   filter->initializeInModuleFilter();
   filter->setDecoderFilterCallbacks(callbacks);
   EXPECT_CALL(callbacks, sendLocalReply(Http::Code::OK, _, _, _, _));
@@ -601,6 +633,7 @@ TEST(DynamicModulesTest, HttpFilterHttpCallout_resetting) {
 
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   Stats::IsolatedStoreImpl stats_store;
+  auto stats_scope = stats_store.createScope("");
   Upstream::MockClusterManager cluster_manager;
   NiceMock<Upstream::MockThreadLocalCluster> thread_local_cluster;
   EXPECT_CALL(cluster_manager, getThreadLocalCluster(_))
@@ -610,8 +643,7 @@ TEST(DynamicModulesTest, HttpFilterHttpCallout_resetting) {
   const std::string filter_config = "resetting_cluster";
   auto filter_config_or_status =
       Envoy::Extensions::DynamicModules::HttpFilters::newDynamicModuleHttpFilterConfig(
-          filter_name, filter_config, std::move(dynamic_module.value()),
-          *stats_store.createScope(""), context);
+          filter_name, filter_config, std::move(dynamic_module.value()), *stats_scope, context);
   EXPECT_TRUE(filter_config_or_status.ok());
 
   std::shared_ptr<Upstream::MockThreadLocalCluster> cluster =
@@ -629,7 +661,8 @@ TEST(DynamicModulesTest, HttpFilterHttpCallout_resetting) {
             return &request;
           }));
 
-  auto filter = std::make_shared<DynamicModuleHttpFilter>(filter_config_or_status.value());
+  auto filter = std::make_shared<DynamicModuleHttpFilter>(filter_config_or_status.value(),
+                                                          stats_scope->symbolTable());
   filter->initializeInModuleFilter();
 
   TestRequestHeaderMapImpl headers{{}};
@@ -653,6 +686,7 @@ TEST(DynamicModulesTest, HttpFilterPerFilterConfigLifetimes) {
 
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   Stats::IsolatedStoreImpl stats_store;
+  auto stats_scope = stats_store.createScope("");
   Upstream::MockClusterManager cluster_manager;
   NiceMock<Upstream::MockThreadLocalCluster> thread_local_cluster;
   EXPECT_CALL(cluster_manager, getThreadLocalCluster(_))
@@ -662,8 +696,7 @@ TEST(DynamicModulesTest, HttpFilterPerFilterConfigLifetimes) {
   const std::string filter_config = "listener config";
   auto filter_config_or_status =
       Envoy::Extensions::DynamicModules::HttpFilters::newDynamicModuleHttpFilterConfig(
-          filter_name, filter_config, std::move(dynamic_module.value()),
-          *stats_store.createScope(""), context);
+          filter_name, filter_config, std::move(dynamic_module.value()), *stats_scope, context);
   EXPECT_TRUE(filter_config_or_status.ok());
 
   auto dynamic_module_for_route =
@@ -673,7 +706,8 @@ TEST(DynamicModulesTest, HttpFilterPerFilterConfigLifetimes) {
   }
   EXPECT_TRUE(dynamic_module_for_route.ok());
 
-  auto filter = std::make_shared<DynamicModuleHttpFilter>(filter_config_or_status.value());
+  auto filter = std::make_shared<DynamicModuleHttpFilter>(filter_config_or_status.value(),
+                                                          stats_scope->symbolTable());
 
   NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks;
   NiceMock<Http::MockStreamEncoderFilterCallbacks> encoder_callbacks;
@@ -685,8 +719,8 @@ TEST(DynamicModulesTest, HttpFilterPerFilterConfigLifetimes) {
   // Now simulate a per-route config that is very short lived, and verify that the filter doesn't
   // segfaults if it uses it after after it discarded.
   {
-    // do all per-route config in an inner scope to make sure the is destroyed before the filter
-    // response headers is called.
+    // do all per-route config in an inner scope to make sure the per-route config is destroyed
+    // before the filter response headers is called.
     const std::string route_filter_config_str = "router config";
     auto route_filter_config_or_status =
         Envoy::Extensions::DynamicModules::HttpFilters::newDynamicModuleHttpPerRouteConfig(
@@ -717,7 +751,8 @@ TEST(DynamicModulesTest, HttpFilterPerFilterConfigLifetimes) {
 }
 
 TEST(HttpFilter, HeaderMapGetter) {
-  DynamicModuleHttpFilter filter(nullptr);
+  Stats::SymbolTableImpl symbol_table;
+  DynamicModuleHttpFilter filter(nullptr, symbol_table);
 
   EXPECT_EQ(absl::nullopt, filter.requestHeaders());
   EXPECT_EQ(absl::nullopt, filter.requestTrailers());

--- a/test/extensions/dynamic_modules/test_data/rust/http.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/http.rs
@@ -24,6 +24,12 @@ fn new_http_filter_config_fn<EC: EnvoyHttpFilterConfig, EHF: EnvoyHttpFilter>(
       concurrent_streams: envoy_filter_config.define_gauge("concurrent_streams"),
       ones: envoy_filter_config.define_histogram("ones"),
       magic_number: envoy_filter_config.define_gauge("magic_number"),
+      test_counter_vec: envoy_filter_config
+        .define_counter_vec("test_counter_vec", &["test_label".into()]),
+      test_gauge_vec: envoy_filter_config
+        .define_gauge_vec("test_gauge_vec", &["test_label".into()]),
+      test_histogram_vec: envoy_filter_config
+        .define_histogram_vec("test_histogram_vec", &["test_label".into()]),
     })),
     "header_callbacks" => Some(Box::new(HeaderCallbacksFilterConfig {})),
     "send_response" => Some(Box::new(SendResponseFilterConfig {})),
@@ -44,6 +50,9 @@ struct StatsCallbacksFilterConfig {
   magic_number: EnvoyGaugeId,
   // It's full of 1s.
   ones: EnvoyHistogramId,
+  test_counter_vec: EnvoyCounterId,
+  test_gauge_vec: EnvoyGaugeId,
+  test_histogram_vec: EnvoyHistogramId,
 }
 
 impl<EHF: EnvoyHttpFilter> HttpFilterConfig<EHF> for StatsCallbacksFilterConfig {
@@ -51,6 +60,12 @@ impl<EHF: EnvoyHttpFilter> HttpFilterConfig<EHF> for StatsCallbacksFilterConfig 
     envoy_filter.increment_counter(self.streams_total, 1);
     envoy_filter.increase_gauge(self.concurrent_streams, 1);
     envoy_filter.set_gauge(self.magic_number, 42);
+    envoy_filter.increment_counter_vec(self.test_counter_vec, &["increment".into()], 1);
+    envoy_filter.increase_gauge_vec(self.test_gauge_vec, &["increase".into()], 1);
+    envoy_filter.increase_gauge_vec(self.test_gauge_vec, &["decrease".into()], 10);
+    envoy_filter.decrease_gauge_vec(self.test_gauge_vec, &["decrease".into()], 8);
+    envoy_filter.set_gauge_vec(self.test_gauge_vec, &["set".into()], 9001);
+    envoy_filter.record_histogram_value_vec(self.test_histogram_vec, &["record".into()], 1);
     // Copy the stats handles onto the filter so that we can observe stats while
     // handling requests.
     Box::new(StatsCallbacksFilter {


### PR DESCRIPTION
Commit Message: dynamic modules: support metrics with labels by defining metric vector counterparts
Additional Description: Here, we define CounterVec, GaugeVec, and HistogramVec, which behave similar to how prometheus metrics are defined in [golang](https://pkg.go.dev/github.com/prometheus/client_golang/prometheus#NewCounterVec) and other languages. Label names are fixed and set on filter config initialization whereas label values are dynamically provisioned for each new Filter instance. 
Risk Level: Low (still in active development, feature itself would be high)
Testing: Unit and Integration tests
Docs Changes: N/A
Release Notes: Added in changelogs
Platform Specific Features: N/A
Closes https://github.com/envoyproxy/envoy/issues/41002