### PR TITLE
docs: add docs for SNI DFP mentioning the stats emission

### DIFF
--- a/docs/root/configuration/http/http_filters/dynamic_forward_proxy_filter.rst
+++ b/docs/root/configuration/http/http_filters/dynamic_forward_proxy_filter.rst
@@ -155,5 +155,5 @@ namespace.
   :header: Name, Type, Description
   :widths: 1, 1, 2
 
-  rq_pending_open, Gauge, Whether the requests circuit breaker is closed (0) or open (1)
-  rq_pending_remaining, Gauge, Number of remaining requests until the circuit breaker opens
+  rq_pending_open, Gauge, Whether the requests circuit breaker is closed (0) or open (1).
+  rq_pending_remaining, Gauge, Number of remaining requests until the circuit breaker opens.

--- a/docs/root/configuration/listeners/network_filters/sni_dynamic_forward_proxy_filter.rst
+++ b/docs/root/configuration/listeners/network_filters/sni_dynamic_forward_proxy_filter.rst
@@ -39,3 +39,33 @@ by setting a per-connection state object under the key ``envoy.upstream.dynamic_
 objects are set, they take precedence over the SNI value and default port. In case that the overridden
 port is out of the valid port range, the overriding value will be ignored and the default port
 configured will be used. See the implementation for the details.
+
+Statistics
+----------
+
+The SNI dynamic forward proxy DNS cache outputs statistics in the ``dns_cache.<dns_cache_name>.``
+namespace.
+
+.. csv-table::
+  :header: Name, Type, Description
+  :widths: 1, 1, 2
+
+  dns_query_attempt, Counter, Number of DNS query attempts.
+  dns_query_success, Counter, Number of DNS query successes.
+  dns_query_failure, Counter, Number of DNS query failures.
+  dns_query_timeout, Counter, Number of DNS query :ref:`timeouts <envoy_v3_api_field_extensions.common.dynamic_forward_proxy.v3.DnsCacheConfig.dns_query_timeout>`.
+  host_address_changed, Counter, Number of DNS queries that resulted in a host address change.
+  host_added, Counter, Number of hosts that have been added to the cache.
+  host_removed, Counter, Number of hosts that have been removed from the cache.
+  num_hosts, Gauge, Number of hosts that are currently in the cache.
+  dns_rq_pending_overflow, Counter, Number of DNS pending request overflow.
+
+The dynamic forward proxy DNS cache circuit breakers output statistics in the ``dns_cache.<dns_cache_name>.circuit_breakers``
+namespace.
+
+.. csv-table::
+  :header: Name, Type, Description
+  :widths: 1, 1, 2
+
+  rq_pending_open, Gauge, Whether the requests circuit breaker is closed (0) or open (1).
+  rq_pending_remaining, Gauge, Number of remaining requests until the circuit breaker opens.


### PR DESCRIPTION
## Description

This PR adds docs for the SNI DFP mentioning the stats emission from DNS Cache. 

---

**Commit Message:** docs: add docs for SNI DFP mentioning the stats emission
**Additional Description:** Added docs for the SNI DFP mentioning the stats emission for DNS Cache.
**Risk Level:** Low
**Testing:** CI
**Docs Changes:** Added
**Release Notes:** N/A