### PR TITLE
async stream options: use shared pointer for pased retry policy

### DIFF
--- a/envoy/http/async_client.h
+++ b/envoy/http/async_client.h
@@ -343,8 +343,8 @@ public:
     // The retry policy can be set as either a proto or Router::RetryPolicy but
     // not both. If both formats of the options are set, the more recent call
     // will overwrite the older one.
-    StreamOptions& setRetryPolicy(const Router::RetryPolicy& p) {
-      parsed_retry_policy = &p;
+    StreamOptions& setRetryPolicy(Router::RetryPolicyConstSharedPtr p) {
+      parsed_retry_policy = std::move(p);
       retry_policy = absl::nullopt;
       return *this;
     }
@@ -432,7 +432,7 @@ public:
     absl::optional<uint32_t> buffer_limit_;
 
     absl::optional<envoy::config::route::v3::RetryPolicy> retry_policy;
-    const Router::RetryPolicy* parsed_retry_policy{nullptr};
+    Router::RetryPolicyConstSharedPtr parsed_retry_policy;
 
     Router::FilterConfigSharedPtr filter_config_;
 

--- a/envoy/router/router.h
+++ b/envoy/router/router.h
@@ -311,6 +311,8 @@ public:
   virtual std::chrono::milliseconds resetMaxInterval() const PURE;
 };
 
+using RetryPolicyConstSharedPtr = std::shared_ptr<const RetryPolicy>;
+
 /**
  * RetryStatus whether request should be retried or not.
  */

--- a/source/common/http/async_client_impl.cc
+++ b/source/common/http/async_client_impl.cc
@@ -18,6 +18,14 @@
 namespace Envoy {
 namespace Http {
 
+namespace {
+Router::RetryPolicyConstSharedPtr sharedEmptyRetryPolicy() {
+  static Router::RetryPolicyConstSharedPtr empty_policy =
+      std::make_shared<Router::RetryPolicyImpl>();
+  return empty_policy;
+}
+} // namespace
+
 const absl::string_view AsyncClientImpl::ResponseBufferLimit = "http.async_response_buffer_limit";
 
 AsyncClientImpl::AsyncClientImpl(Upstream::ClusterInfoConstSharedPtr cluster,
@@ -90,23 +98,19 @@ AsyncClient::Stream* AsyncClientImpl::start(AsyncClient::StreamCallbacks& callba
   return active_streams_.front().get();
 }
 
-std::unique_ptr<const Router::RetryPolicy>
-createRetryPolicy(AsyncClientImpl& parent, const AsyncClient::StreamOptions& options,
+Router::RetryPolicyConstSharedPtr
+createRetryPolicy(const AsyncClient::StreamOptions& options,
                   Server::Configuration::CommonFactoryContext& context,
                   absl::Status& creation_status) {
   if (options.retry_policy.has_value()) {
-    Upstream::RetryExtensionFactoryContextImpl factory_context(
-        parent.factory_context_.singletonManager());
     auto policy_or_error = Router::RetryPolicyImpl::create(
-        options.retry_policy.value(), ProtobufMessage::getNullValidationVisitor(), factory_context,
-        context);
+        options.retry_policy.value(), ProtobufMessage::getNullValidationVisitor(), context);
     creation_status = policy_or_error.status();
-    return policy_or_error.status().ok() ? std::move(policy_or_error.value()) : nullptr;
+    return policy_or_error.status().ok() ? std::move(policy_or_error.value())
+                                         : sharedEmptyRetryPolicy();
   }
-  if (options.parsed_retry_policy == nullptr) {
-    return std::make_unique<Router::RetryPolicyImpl>();
-  }
-  return nullptr;
+  return options.parsed_retry_policy != nullptr ? options.parsed_retry_policy
+                                                : sharedEmptyRetryPolicy();
 }
 
 AsyncStreamImpl::AsyncStreamImpl(AsyncClientImpl& parent, AsyncClient::StreamCallbacks& callbacks,
@@ -122,7 +126,7 @@ AsyncStreamImpl::AsyncStreamImpl(AsyncClientImpl& parent, AsyncClient::StreamCal
                        : std::make_shared<StreamInfo::FilterStateImpl>(
                              StreamInfo::FilterState::LifeSpan::FilterChain)),
       tracing_config_(Tracing::EgressConfig::get()), local_reply_(*parent.local_reply_),
-      retry_policy_(createRetryPolicy(parent, options, parent_.factory_context_, creation_status)),
+      retry_policy_(createRetryPolicy(options, parent.factory_context_, creation_status)),
       account_(options.account_), buffer_limit_(options.buffer_limit_), send_xff_(options.send_xff),
       send_internal_(options.send_internal) {
   // A field initialization may set the creation-status as unsuccessful.
@@ -144,10 +148,8 @@ AsyncStreamImpl::AsyncStreamImpl(AsyncClientImpl& parent, AsyncClient::StreamCal
   }
 
   auto route_or_error = NullRouteImpl::create(
-      parent_.cluster_->name(),
-      retry_policy_ != nullptr ? *retry_policy_ : *options.parsed_retry_policy,
-      parent_.factory_context_.regexEngine(), options.timeout, options.hash_policy,
-      metadata_matching_criteria);
+      parent_.cluster_->name(), *retry_policy_, parent_.factory_context_.regexEngine(),
+      options.timeout, options.hash_policy, metadata_matching_criteria);
   SET_AND_RETURN_IF_NOT_OK(route_or_error.status(), creation_status);
   route_ = std::move(*route_or_error);
   stream_info_.dynamicMetadata().MergeFrom(options.metadata);

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -278,7 +278,7 @@ private:
   Tracing::NullSpan active_span_;
   const Tracing::Config& tracing_config_;
   const LocalReply::LocalReply& local_reply_;
-  const std::unique_ptr<const Router::RetryPolicy> retry_policy_;
+  Router::RetryPolicyConstSharedPtr retry_policy_;
   std::shared_ptr<NullRouteImpl> route_;
   uint32_t high_watermark_calls_{};
   bool local_closed_{};

--- a/source/common/router/BUILD
+++ b/source/common/router/BUILD
@@ -43,7 +43,7 @@ envoy_cc_library(
         ":matcher_visitor_lib",
         ":metadatamatchcriteria_lib",
         ":per_filter_config_lib",
-        ":reset_header_parser_lib",
+        ":retry_policy_lib",
         ":retry_state_lib",
         ":router_ratelimit_lib",
         ":tls_context_match_criteria_lib",
@@ -539,5 +539,21 @@ envoy_cc_library(
     deps = [
         ":delegating_route_lib",
         "//envoy/router:cluster_specifier_plugin_interface",
+    ],
+)
+
+envoy_cc_library(
+    name = "retry_policy_lib",
+    srcs = ["retry_policy_impl.cc"],
+    hdrs = ["retry_policy_impl.h"],
+    deps = [
+        ":reset_header_parser_lib",
+        ":retry_state_lib",
+        "//envoy/router:router_interface",
+        "//envoy/server:factory_context_interface",
+        "//source/common/config:utility_lib",
+        "//source/common/upstream:retry_factory_lib",
+        "@com_google_absl//absl/types:optional",
+        "@envoy_api//envoy/config/route/v3:pkg_cc_proto",
     ],
 )

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -44,13 +44,10 @@
 #include "source/common/router/context_impl.h"
 #include "source/common/router/header_cluster_specifier.h"
 #include "source/common/router/matcher_visitor.h"
-#include "source/common/router/reset_header_parser.h"
-#include "source/common/router/retry_state_impl.h"
 #include "source/common/router/weighted_cluster_specifier.h"
 #include "source/common/runtime/runtime_features.h"
 #include "source/common/tracing/custom_tag_impl.h"
 #include "source/common/tracing/http_tracer_impl.h"
-#include "source/common/upstream/retry_factory.h"
 #include "source/extensions/early_data/default_early_data_policy.h"
 #include "source/extensions/matching/network/common/inputs.h"
 #include "source/extensions/path/match/uri_template/uri_template_match.h"
@@ -216,128 +213,6 @@ HedgePolicyImpl::HedgePolicyImpl(const envoy::config::route::v3::HedgePolicy& he
       hedge_on_per_try_timeout_(hedge_policy.hedge_on_per_try_timeout()) {}
 
 HedgePolicyImpl::HedgePolicyImpl() : initial_requests_(1), hedge_on_per_try_timeout_(false) {}
-
-absl::StatusOr<std::unique_ptr<RetryPolicyImpl>>
-RetryPolicyImpl::create(const envoy::config::route::v3::RetryPolicy& retry_policy,
-                        ProtobufMessage::ValidationVisitor& validation_visitor,
-                        Upstream::RetryExtensionFactoryContext& factory_context,
-                        Server::Configuration::CommonFactoryContext& common_context) {
-  absl::Status creation_status = absl::OkStatus();
-  auto ret = std::unique_ptr<RetryPolicyImpl>(new RetryPolicyImpl(
-      retry_policy, validation_visitor, factory_context, common_context, creation_status));
-  RETURN_IF_NOT_OK(creation_status);
-  return ret;
-}
-RetryPolicyImpl::RetryPolicyImpl(const envoy::config::route::v3::RetryPolicy& retry_policy,
-                                 ProtobufMessage::ValidationVisitor& validation_visitor,
-                                 Upstream::RetryExtensionFactoryContext& factory_context,
-                                 Server::Configuration::CommonFactoryContext& common_context,
-                                 absl::Status& creation_status)
-    : retriable_headers_(Http::HeaderUtility::buildHeaderMatcherVector(
-          retry_policy.retriable_headers(), common_context)),
-      retriable_request_headers_(Http::HeaderUtility::buildHeaderMatcherVector(
-          retry_policy.retriable_request_headers(), common_context)),
-      validation_visitor_(&validation_visitor) {
-  per_try_timeout_ =
-      std::chrono::milliseconds(PROTOBUF_GET_MS_OR_DEFAULT(retry_policy, per_try_timeout, 0));
-  per_try_idle_timeout_ =
-      std::chrono::milliseconds(PROTOBUF_GET_MS_OR_DEFAULT(retry_policy, per_try_idle_timeout, 0));
-  num_retries_ = PROTOBUF_GET_WRAPPED_OR_DEFAULT(retry_policy, num_retries, 1);
-  retry_on_ = RetryStateImpl::parseRetryOn(retry_policy.retry_on()).first;
-  retry_on_ |= RetryStateImpl::parseRetryGrpcOn(retry_policy.retry_on()).first;
-
-  for (const auto& host_predicate : retry_policy.retry_host_predicate()) {
-    auto& factory = Envoy::Config::Utility::getAndCheckFactory<Upstream::RetryHostPredicateFactory>(
-        host_predicate);
-    auto config = Envoy::Config::Utility::translateToFactoryConfig(host_predicate,
-                                                                   validation_visitor, factory);
-    retry_host_predicate_configs_.emplace_back(factory, std::move(config));
-  }
-
-  const auto& retry_priority = retry_policy.retry_priority();
-  if (!retry_priority.name().empty()) {
-    auto& factory =
-        Envoy::Config::Utility::getAndCheckFactory<Upstream::RetryPriorityFactory>(retry_priority);
-    retry_priority_config_ =
-        std::make_pair(&factory, Envoy::Config::Utility::translateToFactoryConfig(
-                                     retry_priority, validation_visitor, factory));
-  }
-
-  for (const auto& options_predicate : retry_policy.retry_options_predicates()) {
-    auto& factory =
-        Envoy::Config::Utility::getAndCheckFactory<Upstream::RetryOptionsPredicateFactory>(
-            options_predicate);
-    retry_options_predicates_.emplace_back(
-        factory.createOptionsPredicate(*Envoy::Config::Utility::translateToFactoryConfig(
-                                           options_predicate, validation_visitor, factory),
-                                       factory_context));
-  }
-
-  auto host_selection_attempts = retry_policy.host_selection_retry_max_attempts();
-  if (host_selection_attempts) {
-    host_selection_attempts_ = host_selection_attempts;
-  }
-
-  for (auto code : retry_policy.retriable_status_codes()) {
-    retriable_status_codes_.emplace_back(code);
-  }
-
-  if (retry_policy.has_retry_back_off()) {
-    base_interval_ = std::chrono::milliseconds(
-        PROTOBUF_GET_MS_REQUIRED(retry_policy.retry_back_off(), base_interval));
-    if ((*base_interval_).count() < 1) {
-      base_interval_ = std::chrono::milliseconds(1);
-    }
-
-    max_interval_ = PROTOBUF_GET_OPTIONAL_MS(retry_policy.retry_back_off(), max_interval);
-    if (max_interval_) {
-      // Apply the same rounding to max interval in case both are set to sub-millisecond values.
-      if ((*max_interval_).count() < 1) {
-        max_interval_ = std::chrono::milliseconds(1);
-      }
-
-      if ((*max_interval_).count() < (*base_interval_).count()) {
-        creation_status = absl::InvalidArgumentError(
-            "retry_policy.max_interval must greater than or equal to the base_interval");
-        return;
-      }
-    }
-  }
-
-  if (retry_policy.has_rate_limited_retry_back_off()) {
-    reset_headers_ = ResetHeaderParserImpl::buildResetHeaderParserVector(
-        retry_policy.rate_limited_retry_back_off().reset_headers());
-
-    absl::optional<std::chrono::milliseconds> reset_max_interval =
-        PROTOBUF_GET_OPTIONAL_MS(retry_policy.rate_limited_retry_back_off(), max_interval);
-    if (reset_max_interval.has_value()) {
-      std::chrono::milliseconds max_interval = reset_max_interval.value();
-      if (max_interval.count() < 1) {
-        max_interval = std::chrono::milliseconds(1);
-      }
-      reset_max_interval_ = max_interval;
-    }
-  }
-}
-
-std::vector<Upstream::RetryHostPredicateSharedPtr> RetryPolicyImpl::retryHostPredicates() const {
-  std::vector<Upstream::RetryHostPredicateSharedPtr> predicates;
-  predicates.reserve(retry_host_predicate_configs_.size());
-  for (const auto& config : retry_host_predicate_configs_) {
-    predicates.emplace_back(config.first.createHostPredicate(*config.second, num_retries_));
-  }
-
-  return predicates;
-}
-
-Upstream::RetryPrioritySharedPtr RetryPolicyImpl::retryPriority() const {
-  if (retry_priority_config_.first == nullptr) {
-    return nullptr;
-  }
-
-  return retry_priority_config_.first->createRetryPriority(*retry_priority_config_.second,
-                                                           *validation_visitor_, num_retries_);
-}
 
 absl::StatusOr<std::unique_ptr<InternalRedirectPolicyImpl>> InternalRedirectPolicyImpl::create(
     const envoy::config::route::v3::InternalRedirectPolicy& policy_config,
@@ -1142,19 +1017,16 @@ absl::StatusOr<std::unique_ptr<RetryPolicyImpl>> RouteEntryImplBase::buildRetryP
     RetryPolicyConstOptRef vhost_retry_policy,
     const envoy::config::route::v3::RouteAction& route_config,
     ProtobufMessage::ValidationVisitor& validation_visitor,
-    Server::Configuration::ServerFactoryContext& factory_context) const {
-  Upstream::RetryExtensionFactoryContextImpl retry_factory_context(
-      factory_context.singletonManager());
+    Server::Configuration::CommonFactoryContext& factory_context) const {
   // Route specific policy wins, if available.
   if (route_config.has_retry_policy()) {
     return RetryPolicyImpl::create(route_config.retry_policy(), validation_visitor,
-                                   retry_factory_context, factory_context);
+                                   factory_context);
   }
 
   // If not, we fallback to the virtual host policy if there is one.
   if (vhost_retry_policy.has_value()) {
-    return RetryPolicyImpl::create(*vhost_retry_policy, validation_visitor, retry_factory_context,
-                                   factory_context);
+    return RetryPolicyImpl::create(*vhost_retry_policy, validation_visitor, factory_context);
   }
 
   // Otherwise, an empty policy will do.

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -32,6 +32,7 @@
 #include "source/common/router/header_parser.h"
 #include "source/common/router/metadatamatchcriteria_impl.h"
 #include "source/common/router/per_filter_config.h"
+#include "source/common/router/retry_policy_impl.h"
 #include "source/common/router/router_ratelimit.h"
 #include "source/common/router/tls_context_match_criteria_impl.h"
 #include "source/common/stats/symbol_table.h"
@@ -400,80 +401,6 @@ private:
 };
 
 using VirtualHostImplSharedPtr = std::shared_ptr<VirtualHostImpl>;
-
-/**
- * Implementation of RetryPolicy that reads from the proto route or virtual host config.
- */
-class RetryPolicyImpl : public RetryPolicy {
-
-public:
-  static absl::StatusOr<std::unique_ptr<RetryPolicyImpl>>
-  create(const envoy::config::route::v3::RetryPolicy& retry_policy,
-         ProtobufMessage::ValidationVisitor& validation_visitor,
-         Upstream::RetryExtensionFactoryContext& factory_context,
-         Server::Configuration::CommonFactoryContext& common_context);
-  RetryPolicyImpl() = default;
-
-  // Router::RetryPolicy
-  std::chrono::milliseconds perTryTimeout() const override { return per_try_timeout_; }
-  std::chrono::milliseconds perTryIdleTimeout() const override { return per_try_idle_timeout_; }
-  uint32_t numRetries() const override { return num_retries_; }
-  uint32_t retryOn() const override { return retry_on_; }
-  std::vector<Upstream::RetryHostPredicateSharedPtr> retryHostPredicates() const override;
-  Upstream::RetryPrioritySharedPtr retryPriority() const override;
-  absl::Span<const Upstream::RetryOptionsPredicateConstSharedPtr>
-  retryOptionsPredicates() const override {
-    return retry_options_predicates_;
-  }
-  uint32_t hostSelectionMaxAttempts() const override { return host_selection_attempts_; }
-  const std::vector<uint32_t>& retriableStatusCodes() const override {
-    return retriable_status_codes_;
-  }
-  const std::vector<Http::HeaderMatcherSharedPtr>& retriableHeaders() const override {
-    return retriable_headers_;
-  }
-  const std::vector<Http::HeaderMatcherSharedPtr>& retriableRequestHeaders() const override {
-    return retriable_request_headers_;
-  }
-  absl::optional<std::chrono::milliseconds> baseInterval() const override { return base_interval_; }
-  absl::optional<std::chrono::milliseconds> maxInterval() const override { return max_interval_; }
-  const std::vector<ResetHeaderParserSharedPtr>& resetHeaders() const override {
-    return reset_headers_;
-  }
-  std::chrono::milliseconds resetMaxInterval() const override { return reset_max_interval_; }
-
-private:
-  RetryPolicyImpl(const envoy::config::route::v3::RetryPolicy& retry_policy,
-                  ProtobufMessage::ValidationVisitor& validation_visitor,
-                  Upstream::RetryExtensionFactoryContext& factory_context,
-                  Server::Configuration::CommonFactoryContext& common_context,
-                  absl::Status& creation_status);
-  std::chrono::milliseconds per_try_timeout_{0};
-  std::chrono::milliseconds per_try_idle_timeout_{0};
-  // We set the number of retries to 1 by default (i.e. when no route or vhost level retry policy is
-  // set) so that when retries get enabled through the x-envoy-retry-on header we default to 1
-  // retry.
-  uint32_t num_retries_{1};
-  uint32_t retry_on_{};
-  // Each pair contains the name and config proto to be used to create the RetryHostPredicates
-  // that should be used when with this policy.
-  std::vector<std::pair<Upstream::RetryHostPredicateFactory&, ProtobufTypes::MessagePtr>>
-      retry_host_predicate_configs_;
-  // Name and config proto to use to create the RetryPriority to use with this policy. Default
-  // initialized when no RetryPriority should be used.
-  std::pair<Upstream::RetryPriorityFactory*, ProtobufTypes::MessagePtr> retry_priority_config_;
-  uint32_t host_selection_attempts_{1};
-  std::vector<uint32_t> retriable_status_codes_;
-  std::vector<Http::HeaderMatcherSharedPtr> retriable_headers_;
-  std::vector<Http::HeaderMatcherSharedPtr> retriable_request_headers_;
-  absl::optional<std::chrono::milliseconds> base_interval_;
-  absl::optional<std::chrono::milliseconds> max_interval_;
-  std::vector<ResetHeaderParserSharedPtr> reset_headers_;
-  std::chrono::milliseconds reset_max_interval_{300000};
-  ProtobufMessage::ValidationVisitor* validation_visitor_{};
-  std::vector<Upstream::RetryOptionsPredicateConstSharedPtr> retry_options_predicates_;
-};
-using DefaultRetryPolicy = ConstSingleton<RetryPolicyImpl>;
 
 /**
  * Implementation of ShadowPolicy that reads from the proto route config.
@@ -913,7 +840,7 @@ private:
   buildRetryPolicy(RetryPolicyConstOptRef vhost_retry_policy,
                    const envoy::config::route::v3::RouteAction& route_config,
                    ProtobufMessage::ValidationVisitor& validation_visitor,
-                   Server::Configuration::ServerFactoryContext& factory_context) const;
+                   Server::Configuration::CommonFactoryContext& factory_context) const;
 
   absl::StatusOr<std::unique_ptr<InternalRedirectPolicyImpl>>
   buildInternalRedirectPolicy(const envoy::config::route::v3::RouteAction& route_config,

--- a/source/common/router/retry_policy_impl.cc
+++ b/source/common/router/retry_policy_impl.cc
@@ -1,0 +1,134 @@
+#include "source/common/router/retry_policy_impl.h"
+
+#include "source/common/config/utility.h"
+#include "source/common/router/reset_header_parser.h"
+#include "source/common/router/retry_state_impl.h"
+#include "source/common/upstream/retry_factory.h"
+
+namespace Envoy {
+namespace Router {
+
+absl::StatusOr<std::unique_ptr<RetryPolicyImpl>>
+RetryPolicyImpl::create(const envoy::config::route::v3::RetryPolicy& retry_policy,
+                        ProtobufMessage::ValidationVisitor& validation_visitor,
+                        Server::Configuration::CommonFactoryContext& common_context) {
+  absl::Status creation_status = absl::OkStatus();
+  auto ret = std::unique_ptr<RetryPolicyImpl>(
+      new RetryPolicyImpl(retry_policy, validation_visitor, common_context, creation_status));
+  RETURN_IF_NOT_OK(creation_status);
+  return ret;
+}
+
+RetryPolicyImpl::RetryPolicyImpl(const envoy::config::route::v3::RetryPolicy& retry_policy,
+                                 ProtobufMessage::ValidationVisitor& validation_visitor,
+                                 Server::Configuration::CommonFactoryContext& common_context,
+                                 absl::Status& creation_status)
+    : retriable_headers_(Http::HeaderUtility::buildHeaderMatcherVector(
+          retry_policy.retriable_headers(), common_context)),
+      retriable_request_headers_(Http::HeaderUtility::buildHeaderMatcherVector(
+          retry_policy.retriable_request_headers(), common_context)),
+      validation_visitor_(&validation_visitor) {
+  per_try_timeout_ =
+      std::chrono::milliseconds(PROTOBUF_GET_MS_OR_DEFAULT(retry_policy, per_try_timeout, 0));
+  per_try_idle_timeout_ =
+      std::chrono::milliseconds(PROTOBUF_GET_MS_OR_DEFAULT(retry_policy, per_try_idle_timeout, 0));
+  num_retries_ = PROTOBUF_GET_WRAPPED_OR_DEFAULT(retry_policy, num_retries, 1);
+  retry_on_ = RetryStateImpl::parseRetryOn(retry_policy.retry_on()).first;
+  retry_on_ |= RetryStateImpl::parseRetryGrpcOn(retry_policy.retry_on()).first;
+
+  for (const auto& host_predicate : retry_policy.retry_host_predicate()) {
+    auto& factory = Envoy::Config::Utility::getAndCheckFactory<Upstream::RetryHostPredicateFactory>(
+        host_predicate);
+    auto config = Envoy::Config::Utility::translateToFactoryConfig(host_predicate,
+                                                                   validation_visitor, factory);
+    retry_host_predicate_configs_.emplace_back(factory, std::move(config));
+  }
+
+  const auto& retry_priority = retry_policy.retry_priority();
+  if (!retry_priority.name().empty()) {
+    auto& factory =
+        Envoy::Config::Utility::getAndCheckFactory<Upstream::RetryPriorityFactory>(retry_priority);
+    retry_priority_config_ =
+        std::make_pair(&factory, Envoy::Config::Utility::translateToFactoryConfig(
+                                     retry_priority, validation_visitor, factory));
+  }
+
+  Upstream::RetryExtensionFactoryContextImpl factory_context(common_context.singletonManager());
+  for (const auto& options_predicate : retry_policy.retry_options_predicates()) {
+    auto& factory =
+        Envoy::Config::Utility::getAndCheckFactory<Upstream::RetryOptionsPredicateFactory>(
+            options_predicate);
+    retry_options_predicates_.emplace_back(
+        factory.createOptionsPredicate(*Envoy::Config::Utility::translateToFactoryConfig(
+                                           options_predicate, validation_visitor, factory),
+                                       factory_context));
+  }
+
+  auto host_selection_attempts = retry_policy.host_selection_retry_max_attempts();
+  if (host_selection_attempts) {
+    host_selection_attempts_ = host_selection_attempts;
+  }
+
+  for (auto code : retry_policy.retriable_status_codes()) {
+    retriable_status_codes_.emplace_back(code);
+  }
+
+  if (retry_policy.has_retry_back_off()) {
+    base_interval_ = std::chrono::milliseconds(
+        PROTOBUF_GET_MS_REQUIRED(retry_policy.retry_back_off(), base_interval));
+    if ((*base_interval_).count() < 1) {
+      base_interval_ = std::chrono::milliseconds(1);
+    }
+
+    max_interval_ = PROTOBUF_GET_OPTIONAL_MS(retry_policy.retry_back_off(), max_interval);
+    if (max_interval_) {
+      // Apply the same rounding to max interval in case both are set to sub-millisecond values.
+      if ((*max_interval_).count() < 1) {
+        max_interval_ = std::chrono::milliseconds(1);
+      }
+
+      if ((*max_interval_).count() < (*base_interval_).count()) {
+        creation_status = absl::InvalidArgumentError(
+            "retry_policy.max_interval must greater than or equal to the base_interval");
+        return;
+      }
+    }
+  }
+
+  if (retry_policy.has_rate_limited_retry_back_off()) {
+    reset_headers_ = ResetHeaderParserImpl::buildResetHeaderParserVector(
+        retry_policy.rate_limited_retry_back_off().reset_headers());
+
+    absl::optional<std::chrono::milliseconds> reset_max_interval =
+        PROTOBUF_GET_OPTIONAL_MS(retry_policy.rate_limited_retry_back_off(), max_interval);
+    if (reset_max_interval.has_value()) {
+      std::chrono::milliseconds max_interval = reset_max_interval.value();
+      if (max_interval.count() < 1) {
+        max_interval = std::chrono::milliseconds(1);
+      }
+      reset_max_interval_ = max_interval;
+    }
+  }
+}
+
+std::vector<Upstream::RetryHostPredicateSharedPtr> RetryPolicyImpl::retryHostPredicates() const {
+  std::vector<Upstream::RetryHostPredicateSharedPtr> predicates;
+  predicates.reserve(retry_host_predicate_configs_.size());
+  for (const auto& config : retry_host_predicate_configs_) {
+    predicates.emplace_back(config.first.createHostPredicate(*config.second, num_retries_));
+  }
+
+  return predicates;
+}
+
+Upstream::RetryPrioritySharedPtr RetryPolicyImpl::retryPriority() const {
+  if (retry_priority_config_.first == nullptr) {
+    return nullptr;
+  }
+
+  return retry_priority_config_.first->createRetryPriority(*retry_priority_config_.second,
+                                                           *validation_visitor_, num_retries_);
+}
+
+} // namespace Router
+} // namespace Envoy

--- a/source/common/router/retry_policy_impl.h
+++ b/source/common/router/retry_policy_impl.h
@@ -1,0 +1,91 @@
+#pragma once
+
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "envoy/config/route/v3/route_components.pb.h"
+#include "envoy/config/route/v3/route_components.pb.validate.h"
+#include "envoy/router/router.h"
+#include "envoy/server/factory_context.h"
+
+#include "absl/types/optional.h"
+
+namespace Envoy {
+namespace Router {
+
+/**
+ * Implementation of RetryPolicy that reads from the proto route or virtual host config.
+ */
+class RetryPolicyImpl : public RetryPolicy {
+
+public:
+  static absl::StatusOr<std::unique_ptr<RetryPolicyImpl>>
+  create(const envoy::config::route::v3::RetryPolicy& retry_policy,
+         ProtobufMessage::ValidationVisitor& validation_visitor,
+         Server::Configuration::CommonFactoryContext& common_context);
+  RetryPolicyImpl() = default;
+
+  // Router::RetryPolicy
+  std::chrono::milliseconds perTryTimeout() const override { return per_try_timeout_; }
+  std::chrono::milliseconds perTryIdleTimeout() const override { return per_try_idle_timeout_; }
+  uint32_t numRetries() const override { return num_retries_; }
+  uint32_t retryOn() const override { return retry_on_; }
+  std::vector<Upstream::RetryHostPredicateSharedPtr> retryHostPredicates() const override;
+  Upstream::RetryPrioritySharedPtr retryPriority() const override;
+  absl::Span<const Upstream::RetryOptionsPredicateConstSharedPtr>
+  retryOptionsPredicates() const override {
+    return retry_options_predicates_;
+  }
+  uint32_t hostSelectionMaxAttempts() const override { return host_selection_attempts_; }
+  const std::vector<uint32_t>& retriableStatusCodes() const override {
+    return retriable_status_codes_;
+  }
+  const std::vector<Http::HeaderMatcherSharedPtr>& retriableHeaders() const override {
+    return retriable_headers_;
+  }
+  const std::vector<Http::HeaderMatcherSharedPtr>& retriableRequestHeaders() const override {
+    return retriable_request_headers_;
+  }
+  absl::optional<std::chrono::milliseconds> baseInterval() const override { return base_interval_; }
+  absl::optional<std::chrono::milliseconds> maxInterval() const override { return max_interval_; }
+  const std::vector<ResetHeaderParserSharedPtr>& resetHeaders() const override {
+    return reset_headers_;
+  }
+  std::chrono::milliseconds resetMaxInterval() const override { return reset_max_interval_; }
+
+private:
+  RetryPolicyImpl(const envoy::config::route::v3::RetryPolicy& retry_policy,
+                  ProtobufMessage::ValidationVisitor& validation_visitor,
+                  Server::Configuration::CommonFactoryContext& common_context,
+                  absl::Status& creation_status);
+  std::chrono::milliseconds per_try_timeout_{0};
+  std::chrono::milliseconds per_try_idle_timeout_{0};
+  // We set the number of retries to 1 by default (i.e. when no route or vhost level retry policy is
+  // set) so that when retries get enabled through the x-envoy-retry-on header we default to 1
+  // retry.
+  uint32_t num_retries_{1};
+  uint32_t retry_on_{};
+  // Each pair contains the name and config proto to be used to create the RetryHostPredicates
+  // that should be used when with this policy.
+  std::vector<std::pair<Upstream::RetryHostPredicateFactory&, ProtobufTypes::MessagePtr>>
+      retry_host_predicate_configs_;
+  // Name and config proto to use to create the RetryPriority to use with this policy. Default
+  // initialized when no RetryPriority should be used.
+  std::pair<Upstream::RetryPriorityFactory*, ProtobufTypes::MessagePtr> retry_priority_config_;
+  uint32_t host_selection_attempts_{1};
+  std::vector<uint32_t> retriable_status_codes_;
+  std::vector<Http::HeaderMatcherSharedPtr> retriable_headers_;
+  std::vector<Http::HeaderMatcherSharedPtr> retriable_request_headers_;
+  absl::optional<std::chrono::milliseconds> base_interval_;
+  absl::optional<std::chrono::milliseconds> max_interval_;
+  std::vector<ResetHeaderParserSharedPtr> reset_headers_;
+  std::chrono::milliseconds reset_max_interval_{300000};
+  ProtobufMessage::ValidationVisitor* validation_visitor_{};
+  std::vector<Upstream::RetryOptionsPredicateConstSharedPtr> retry_options_predicates_;
+};
+using DefaultRetryPolicy = ConstSingleton<RetryPolicyImpl>;
+
+} // namespace Router
+} // namespace Envoy


### PR DESCRIPTION
Commit Message: async stream options: use shared pointer for pased retry policy
Additional Description:

This PR updated the StreamOptions. The shared pointer of RetryPolicy is used rather than a reference to avoid potential lifetime problem.

This also fixed a potential bug at the `Http::AsyncStreamImpl`. At there, if the parsing of proto retry policy is field, will result in core dump.

Risk Level: low.
Testing: n/a.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.