### PR TITLE
access-log: refactor the MetadataMatcher to use simpler present matcher

### DIFF
--- a/source/common/access_log/access_log_impl.h
+++ b/source/common/access_log/access_log_impl.h
@@ -249,7 +249,7 @@ public:
                 const StreamInfo::StreamInfo& info) const override;
 
 private:
-  Matchers::ValueMatcherConstSharedPtr present_matcher_;
+  Matchers::PresentMatcher present_matcher_;
   Matchers::ValueMatcherConstSharedPtr value_matcher_;
 
   std::vector<std::string> path_;


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: access-log: refactor the MetadataMatcher to use simpler present matcher
Additional Description:
Changing the `present_matcher_` type from `ValueMatcherConstSharedPtr` to a specific `PresentMatcher`. This will reduce the shared_ptr overhead (deferred access and memory).

Risk Level: low - internal refactor
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
