### PR TITLE
access-log: refactor the ResponseFlagFilter and remove an redundant boolean flag

### DIFF
--- a/source/common/access_log/access_log_impl.cc
+++ b/source/common/access_log/access_log_impl.cc
@@ -217,27 +217,27 @@ bool HeaderFilter::evaluate(const Formatter::HttpFormatterContext& context,
 }
 
 ResponseFlagFilter::ResponseFlagFilter(
-    const envoy::config::accesslog::v3::ResponseFlagFilter& config)
-    : has_configured_flags_(!config.flags().empty()) {
+    const envoy::config::accesslog::v3::ResponseFlagFilter& config) {
+  if (!config.flags().empty()) {
+    // Preallocate the vector to avoid frequent heap allocations.
+    configured_flags_.resize(StreamInfo::ResponseFlagUtils::responseFlagsVec().size(), false);
+    for (int i = 0; i < config.flags_size(); i++) {
+      auto response_flag = StreamInfo::ResponseFlagUtils::toResponseFlag(config.flags(i));
+      // The config has been validated. Therefore, every flag in the config will have a mapping.
+      ASSERT(response_flag.has_value());
 
-  // Preallocate the vector to avoid frequent heap allocations.
-  configured_flags_.resize(StreamInfo::ResponseFlagUtils::responseFlagsVec().size(), false);
-  for (int i = 0; i < config.flags_size(); i++) {
-    auto response_flag = StreamInfo::ResponseFlagUtils::toResponseFlag(config.flags(i));
-    // The config has been validated. Therefore, every flag in the config will have a mapping.
-    ASSERT(response_flag.has_value());
+      // The vector is allocated with the size of the response flags vec. Therefore, the index
+      // should always be valid.
+      ASSERT(response_flag.value().value() < configured_flags_.size());
 
-    // The vector is allocated with the size of the response flags vec. Therefore, the index
-    // should always be valid.
-    ASSERT(response_flag.value().value() < configured_flags_.size());
-
-    configured_flags_[response_flag.value().value()] = true;
+      configured_flags_[response_flag.value().value()] = true;
+    }
   }
 }
 
 bool ResponseFlagFilter::evaluate(const Formatter::HttpFormatterContext&,
                                   const StreamInfo::StreamInfo& info) const {
-  if (has_configured_flags_) {
+  if (!configured_flags_.empty()) {
     for (const auto flag : info.responseFlags()) {
       ASSERT(flag.value() < configured_flags_.size());
       if (configured_flags_[flag.value()]) {

--- a/source/common/access_log/access_log_impl.h
+++ b/source/common/access_log/access_log_impl.h
@@ -188,7 +188,6 @@ public:
                 const StreamInfo::StreamInfo& info) const override;
 
 private:
-  const bool has_configured_flags_{};
   std::vector<bool> configured_flags_{};
 };
 


### PR DESCRIPTION
Commit Message: access-log: refactor the ResponseFlagFilter and remove an redundant boolean flag
Additional Description:
Removing a redundant boolean flag, and ensuring ODR is preserved.

Risk Level: low - internal refactor
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A