### PR TITLE
rate_limit_quota: fix ASAN flake in GlobalRateLimitClientImpl's RLQS Stream

### DIFF
--- a/source/extensions/filters/http/rate_limit_quota/config.cc
+++ b/source/extensions/filters/http/rate_limit_quota/config.cc
@@ -56,15 +56,15 @@ Http::FilterFactoryCb RateLimitQuotaFilterFactory::createFilterFactoryFromProtoT
 
   // Get the TLS store from the global map, or create one if it doesn't exist.
   std::shared_ptr<TlsStore> tls_store = GlobalTlsStores::getTlsStore(
-      config->rlqs_server(), context, rlqs_server_target, filter_config.domain());
+      config_with_hash_key, context, rlqs_server_target, filter_config.domain());
 
-  return [&, config = std::move(config), tls_store = std::move(tls_store),
+  return [&, config = std::move(config), config_with_hash_key, tls_store = std::move(tls_store),
           matcher = std::move(matcher)](Http::FilterChainFactoryCallbacks& callbacks) -> void {
     std::unique_ptr<RateLimitClient> local_client =
         createLocalRateLimitClient(tls_store->global_client.get(), tls_store->buckets_tls);
 
-    callbacks.addStreamFilter(
-        std::make_shared<RateLimitQuotaFilter>(config, context, std::move(local_client), matcher));
+    callbacks.addStreamFilter(std::make_shared<RateLimitQuotaFilter>(
+        config, context, std::move(local_client), config_with_hash_key, matcher));
   };
 }
 

--- a/source/extensions/filters/http/rate_limit_quota/filter.h
+++ b/source/extensions/filters/http/rate_limit_quota/filter.h
@@ -51,9 +51,10 @@ public:
   RateLimitQuotaFilter(FilterConfigConstSharedPtr config,
                        Server::Configuration::FactoryContext& factory_context,
                        std::unique_ptr<RateLimitClient> local_client,
+                       Grpc::GrpcServiceConfigWithHashKey config_with_hash_key,
                        Matcher::MatchTreeSharedPtr<Http::HttpMatchingData> matcher)
-      : config_(std::move(config)), factory_context_(factory_context), matcher_(matcher),
-        client_(std::move(local_client)),
+      : config_(std::move(config)), config_with_hash_key_(config_with_hash_key),
+        factory_context_(factory_context), matcher_(matcher), client_(std::move(local_client)),
         time_source_(factory_context.serverFactoryContext().mainThreadDispatcher().timeSource()) {}
 
   Http::FilterHeadersStatus decodeHeaders(Http::RequestHeaderMap&, bool end_stream) override;
@@ -78,6 +79,7 @@ private:
   bool shouldAllowRequest(const CachedBucket& cached_bucket);
 
   FilterConfigConstSharedPtr config_;
+  Grpc::GrpcServiceConfigWithHashKey config_with_hash_key_;
   Server::Configuration::FactoryContext& factory_context_;
   Http::StreamDecoderFilterCallbacks* callbacks_ = nullptr;
   RateLimitQuotaValidationVisitor visitor_ = {};

--- a/source/extensions/filters/http/rate_limit_quota/filter_persistence.h
+++ b/source/extensions/filters/http/rate_limit_quota/filter_persistence.h
@@ -67,7 +67,7 @@ public:
 
   // Get an existing TLS store by index, or create one if not found.
   static std::shared_ptr<TlsStore>
-  getTlsStore(const envoy::config::core::v3::GrpcService& rlqs_service,
+  getTlsStore(const Grpc::GrpcServiceConfigWithHashKey& config_with_hash_key,
               Server::Configuration::FactoryContext& context, absl::string_view target_address,
               absl::string_view domain);
 
@@ -95,12 +95,6 @@ private:
     static absl::NoDestructor<TlsStoreMap> tls_stores{};
     return *tls_stores;
   }
-
-  // Find or initialize a TLS store for the given config.
-  static std::shared_ptr<TlsStore>
-  getTlsStoreImpl(Grpc::GrpcServiceConfigWithHashKey& config_with_hash_key,
-                  Server::Configuration::FactoryContext& context, TlsStoreIndex& index,
-                  bool* new_store_out);
 
   // Clear a specified index when it is no longer captured by any filter factories.
   static void clearTlsStore(const TlsStoreIndex& index) { stores().erase(index); }

--- a/source/extensions/filters/http/rate_limit_quota/global_client_impl.h
+++ b/source/extensions/filters/http/rate_limit_quota/global_client_impl.h
@@ -62,7 +62,7 @@ class GlobalRateLimitClientImpl : public Grpc::AsyncStreamCallbacks<
 public:
   // Note: rlqs_client is owned directly to ensure that it does not outlive the
   // GlobalRateLimitClientImpl (as the impl provides stream callbacks).
-  GlobalRateLimitClientImpl(const envoy::config::core::v3::GrpcService& rlqs_service,
+  GlobalRateLimitClientImpl(const Grpc::GrpcServiceConfigWithHashKey& config_with_hash_key,
                             Server::Configuration::FactoryContext& context,
                             absl::string_view domain_name,
                             std::chrono::milliseconds send_reports_interval,
@@ -163,7 +163,6 @@ private:
   std::string domain_name_;
   // Client is stored as the bare object since GrpcAsyncClient already takes ownership of the given
   // raw AsyncClientPtr.
-  Grpc::AsyncClientFactoryPtr async_client_factory_ = nullptr;
   GrpcAsyncClient async_client_;
   Grpc::AsyncStream<RateLimitQuotaUsageReports> stream_{};
 
@@ -194,10 +193,11 @@ createGlobalRateLimitClientImpl(Server::Configuration::FactoryContext& context,
                                 absl::string_view domain_name,
                                 std::chrono::milliseconds send_reports_interval,
                                 ThreadLocal::TypedSlot<ThreadLocalBucketsCache>& buckets_tls,
-                                const envoy::config::core::v3::GrpcService& rlqs_service) {
+                                const Grpc::GrpcServiceConfigWithHashKey& config_with_hash_key) {
   Envoy::Event::Dispatcher& main_dispatcher = context.serverFactoryContext().mainThreadDispatcher();
-  return std::make_unique<GlobalRateLimitClientImpl>(
-      rlqs_service, context, domain_name, send_reports_interval, buckets_tls, main_dispatcher);
+  return std::make_unique<GlobalRateLimitClientImpl>(config_with_hash_key, context, domain_name,
+                                                     send_reports_interval, buckets_tls,
+                                                     main_dispatcher);
 }
 
 } // namespace RateLimitQuota

--- a/test/extensions/filters/http/rate_limit_quota/client_test.cc
+++ b/test/extensions/filters/http/rate_limit_quota/client_test.cc
@@ -110,7 +110,7 @@ protected:
 
     mock_stream_client->expectClientCreationWithFactory();
     global_client_ = std::make_unique<GlobalRateLimitClientImpl>(
-        mock_stream_client->grpc_service_, mock_stream_client->context_, mock_domain_,
+        mock_stream_client->config_with_hash_key_, mock_stream_client->context_, mock_domain_,
         reporting_interval_, *buckets_tls_, *mock_stream_client->dispatcher_);
     // Set callbacks to handle asynchronous timing.
     auto callbacks = std::make_unique<GlobalClientCallbacks>();

--- a/test/extensions/filters/http/rate_limit_quota/client_test_utils.h
+++ b/test/extensions/filters/http/rate_limit_quota/client_test_utils.h
@@ -70,6 +70,7 @@ class RateLimitTestClient {
 public:
   RateLimitTestClient() {
     grpc_service_.mutable_envoy_grpc()->set_cluster_name("rate_limit_quota");
+    config_with_hash_key_ = Grpc::GrpcServiceConfigWithHashKey(grpc_service_);
   }
 
   void expectClientReset() {
@@ -213,6 +214,7 @@ public:
 
   NiceMock<MockFactoryContext> context_;
 
+  Grpc::GrpcServiceConfigWithHashKey config_with_hash_key_;
   envoy::config::core::v3::GrpcService grpc_service_;
   std::shared_ptr<MockAsyncClientWithReset> owned_async_client_ = nullptr;
   MockAsyncClientWithReset* async_client_ = nullptr;

--- a/test/extensions/filters/http/rate_limit_quota/filter_test.cc
+++ b/test/extensions/filters/http/rate_limit_quota/filter_test.cc
@@ -108,10 +108,13 @@ public:
 
   void createFilter(bool set_callback = true) {
     filter_config_ = std::make_shared<FilterConfig>(config_);
+    Grpc::GrpcServiceConfigWithHashKey config_with_hash_key =
+        Grpc::GrpcServiceConfigWithHashKey(filter_config_->rlqs_server());
 
     mock_local_client_ = new MockRateLimitClient();
-    filter_ = std::make_unique<RateLimitQuotaFilter>(
-        filter_config_, context_, absl::WrapUnique(mock_local_client_), match_tree_);
+    filter_ = std::make_unique<RateLimitQuotaFilter>(filter_config_, context_,
+                                                     absl::WrapUnique(mock_local_client_),
+                                                     config_with_hash_key, match_tree_);
     if (set_callback) {
       filter_->setDecoderFilterCallbacks(decoder_callbacks_);
     }


### PR DESCRIPTION
Commit Message: The RLQS async stream in `GlobalRateLimitClientImpl` (`stream_`) doesn't actually own the underlying raw stream ptr. This was causing a race condition during shutdown, with the cluster-manager's deferred stream reset+deletion racing against the global client's deferred deletion. If the deferred global client deletion triggered first, without resetting the stream, then the cluster-manager would fail in its own stream reset attempt (the stream's callbacks having been deleted with the global client). If the global client guarantees stream reset + deletion, and the cluster manager wins the race, then the global client's reset + deletion fails with heap-use-after-free.

To get around this race condition, the `GlobalRateLimitClientImpl` can instead own its `RawAsyncClient` & delete it to guarantee that any of its active streams are cleaned up.

-------- 
Additional Description: With the owned RawAsyncClient, integration testing saw a new flake where sometimes the first connection to a fake upstream failed immediately with an empty-message internal error. This was addressed by adding `waitForRlqsStream()` to check all fake upstream connections for new streams, not just the first.

--------
Risk Level:
Testing: Unit & integration. integration_test & filter_persistence_test run 500 times to check for flakes.
Docs Changes:
Release Notes:
Platform Specific Features:
Fixes ASAN flake from PR https://github.com/envoyproxy/envoy/pull/40497
