### PR TITLE
logs: remove unused tls delegate

### DIFF
--- a/source/common/common/logger.cc
+++ b/source/common/common/logger.cc
@@ -28,15 +28,8 @@ void SinkDelegate::logWithStableName(absl::string_view, absl::string_view, absl:
 
 SinkDelegate::~SinkDelegate() {
   // The previous delegate should have never been set or should have been reset by now via
-  // restoreDelegate()/restoreTlsDelegate();
+  // restoreDelegate().
   assert(previous_delegate_ == nullptr);
-  assert(previous_tls_delegate_ == nullptr);
-}
-
-void SinkDelegate::setTlsDelegate() {
-  assert(previous_tls_delegate_ == nullptr);
-  previous_tls_delegate_ = log_sink_->tlsDelegate();
-  log_sink_->setTlsDelegate(this);
 }
 
 void SinkDelegate::setDelegate() {
@@ -44,13 +37,6 @@ void SinkDelegate::setDelegate() {
   assert(previous_delegate_ == nullptr);
   previous_delegate_ = log_sink_->delegate();
   log_sink_->setDelegate(this);
-}
-
-void SinkDelegate::restoreTlsDelegate() {
-  // Ensures stacked allocation of delegates.
-  assert(log_sink_->tlsDelegate() == this);
-  log_sink_->setTlsDelegate(previous_tls_delegate_);
-  previous_tls_delegate_ = nullptr;
 }
 
 void SinkDelegate::restoreDelegate() {

--- a/source/common/common/logger.h
+++ b/source/common/common/logger.h
@@ -154,30 +154,21 @@ public:
   virtual void flush() PURE;
 
 protected:
-  // Swap the current thread local log sink delegate for this one. This should be called by the
+  // Swap the current *global* log sink delegate for this one. This should be called by the
   // derived class constructor immediately before returning. This is required to match
   // restoreTlsDelegate(), otherwise it's possible for the previous delegate to get set in the base
   // class constructor, the derived class constructor throws, and cleanup becomes broken.
-  void setTlsDelegate();
-
-  // Swap the current *global* log sink delegate for this one. This behaves as setTlsDelegate, but
-  // operates on the global log sink instead of the thread local one.
   void setDelegate();
 
-  // Swap the current thread local log sink (this) for the previous one. This should be called by
+  // Swap the current *global* log sink (this) for the previous one. This should be called by
   // the derived class destructor in the body. This is critical as otherwise it's possible for a log
   // message to get routed to a partially destructed sink.
-  void restoreTlsDelegate();
-
-  // Swap the current *global* log sink delegate for the previous one. This behaves as
-  // restoreTlsDelegate, but operates on the global sink instead of the thread local one.
   void restoreDelegate();
 
   SinkDelegate* previousDelegate() { return previous_delegate_; }
 
 private:
   SinkDelegate* previous_delegate_{nullptr};
-  SinkDelegate* previous_tls_delegate_{nullptr};
   DelegatingLogSinkSharedPtr log_sink_;
 };
 

--- a/source/common/common/logger.h
+++ b/source/common/common/logger.h
@@ -156,7 +156,7 @@ public:
 protected:
   // Swap the current *global* log sink delegate for this one. This should be called by the
   // derived class constructor immediately before returning. This is required to match
-  // restoreTlsDelegate(), otherwise it's possible for the previous delegate to get set in the base
+  // restoreDelegate(), otherwise it's possible for the previous delegate to get set in the base
   // class constructor, the derived class constructor throws, and cleanup becomes broken.
   void setDelegate();
 
@@ -252,9 +252,6 @@ private:
     absl::ReaderMutexLock lock(&sink_mutex_);
     return sink_;
   }
-  SinkDelegate** tlsSink();
-  void setTlsDelegate(SinkDelegate* sink);
-  SinkDelegate* tlsDelegate();
 
   SinkDelegate* sink_ ABSL_GUARDED_BY(sink_mutex_){nullptr};
   absl::Mutex sink_mutex_;

--- a/test/common/common/logger_test.cc
+++ b/test/common/common/logger_test.cc
@@ -230,52 +230,6 @@ TEST_F(NamedLogTest, NamedLogsAreSentToSink) {
   ENVOY_LOG_EVENT_TO_LOGGER(Registry::getLog(Id::misc), debug, "misc_event", "log");
 }
 
-struct TlsLogSink : SinkDelegate {
-  TlsLogSink(DelegatingLogSinkSharedPtr log_sink) : SinkDelegate(log_sink) { setTlsDelegate(); }
-  ~TlsLogSink() override { restoreTlsDelegate(); }
-
-  MOCK_METHOD(void, log, (absl::string_view, const spdlog::details::log_msg&));
-  MOCK_METHOD(void, logWithStableName,
-              (absl::string_view, absl::string_view, absl::string_view, absl::string_view));
-  MOCK_METHOD(void, flush, ());
-};
-
-// Verifies that we can register a thread local sink override.
-TEST(TlsLoggingOverrideTest, OverrideSink) {
-  MockLogSink global_sink(Envoy::Logger::Registry::getSink());
-  testing::InSequence s;
-
-  {
-    TlsLogSink tls_sink(Envoy::Logger::Registry::getSink());
-
-    // Calls on the current thread goes to the TLS sink.
-    EXPECT_CALL(tls_sink, log(_, _));
-    ENVOY_LOG_MISC(info, "hello tls");
-
-    // Calls on other threads should use the global sink.
-    std::thread([&]() {
-      EXPECT_CALL(global_sink, log(_, _));
-      ENVOY_LOG_MISC(info, "hello global");
-    }).join();
-
-    // Sanity checking that we're still using the TLS sink.
-    EXPECT_CALL(tls_sink, log(_, _));
-    ENVOY_LOG_MISC(info, "hello tls");
-
-    // All the logging functions should be delegated to the TLS override.
-    EXPECT_CALL(tls_sink, flush());
-    Registry::getSink()->flush();
-
-    EXPECT_CALL(tls_sink, logWithStableName(_, _, _, _));
-    Registry::getSink()->logWithStableName("foo", "level", "bar", "msg");
-  }
-
-  // Now that the TLS sink is out of scope, log calls on this thread should use the global sink
-  // again.
-  EXPECT_CALL(global_sink, log(_, _));
-  ENVOY_LOG_MISC(info, "hello global 2");
-}
-
 TEST(LoggerTest, LogWithLogDetails) {
   Envoy::Logger::Registry::setLogLevel(spdlog::level::info);
 


### PR DESCRIPTION
Change-Id: I9b006e2adf96aa3c109d084ed705c3854b567766

Commit Message: dead code. Maybe some distributors use it? Not clear what the value of a thread-local log sink is.
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
