### PR TITLE
access log: add new END_TIME formatter

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -384,5 +384,9 @@ new_features:
     Added a new metric ``db_build_epoch`` to track the build timestamp of the MaxMind geolocation database files.
     This can be used to monitor the freshness of the databases currently in use by the filter.
     See `MaxMind DB build_epoch <https://maxmind.github.io/MaxMind-DB/#build_epoch>`_ for more details.
+- area: access_log
+  change: |
+    Added :ref:`%END_TIME% <config_access_log_format_end_time>` to access log format to log the end time of the request.
+    The end time point precision can be configured in this new command.
 
 deprecated:

--- a/docs/root/configuration/observability/access_log/usage.rst
+++ b/docs/root/configuration/observability/access_log/usage.rst
@@ -175,6 +175,21 @@ The following command operators are supported:
 %START_TIME_LOCAL%
   Same as :ref:`START_TIME <config_access_log_format_start_time>`, but use local time zone.
 
+.. _config_access_log_format_end_time:
+
+%END_TIME%
+  HTTP/THRIFT
+    Time of the request last byte out, including milliseconds.
+
+  TCP
+    Downstream connection end time including milliseconds.
+
+  UDP
+    Not implemented (0).
+
+  END_TIME can be customized using a `format string <https://en.cppreference.com/w/cpp/io/manip/put_time>`_.
+  See :ref:`START_TIME <config_access_log_format_start_time>` for additional format specifiers and examples.
+
 .. _config_access_log_format_emit_time:
 
 %EMIT_TIME%

--- a/source/common/formatter/stream_info_formatter.cc
+++ b/source/common/formatter/stream_info_formatter.cc
@@ -1820,6 +1820,21 @@ const StreamInfoFormatterProviderLookupTable& getKnownStreamInfoFormatterProvide
                       }),
                   true);
             }}},
+          {"END_TIME",
+           {CommandSyntaxChecker::PARAMS_OPTIONAL,
+            [](absl::string_view format, absl::optional<size_t>) {
+              return std::make_unique<SystemTimeFormatter>(
+                  format,
+                  std::make_unique<SystemTimeFormatter::TimeFieldExtractor>(
+                      [](const StreamInfo::StreamInfo& stream_info) -> absl::optional<SystemTime> {
+                        if (stream_info.currentDuration().has_value()) {
+                          return stream_info.startTime() +
+                                 std::chrono::duration_cast<std::chrono::system_clock::duration>(
+                                     stream_info.currentDuration().value());
+                        }
+                        return absl::nullopt;
+                      }));
+            }}},
           {"EMIT_TIME",
            {CommandSyntaxChecker::PARAMS_OPTIONAL,
             [](absl::string_view format, absl::optional<size_t>) {

--- a/test/common/formatter/substitution_formatter_test.cc
+++ b/test/common/formatter/substitution_formatter_test.cc
@@ -1146,6 +1146,22 @@ TEST(SubstitutionFormatterTest, streamInfoFormatter) {
   }
 
   {
+    NiceMock<StreamInfo::MockStreamInfo> stream_info;
+    const std::string format = "%END_TIME(%Y/%m/%d)%|%END_TIME(%s)%|%END_TIME(bad_format)%|"
+                               "%END_TIME%|%END_TIME(%f.%1f.%2f.%3f)%";
+
+    time_system.setMonotonicTime(MonotonicTime(std::chrono::milliseconds(100)));
+    time_t expected_time_in_epoch = 1522280158 - 100000;
+    SystemTime time = std::chrono::system_clock::from_time_t(expected_time_in_epoch);
+    EXPECT_CALL(stream_info, startTime()).WillRepeatedly(Return(time));
+    FormatterPtr formatter = *FormatterImpl::create(format, false);
+
+    EXPECT_EQ(fmt::format("2018/03/28|{}|bad_format|2018-03-28T23:35:58.000Z|000000000.0.00.000",
+                          expected_time_in_epoch + 100000),
+              formatter->formatWithContext(formatter_context, stream_info));
+  }
+
+  {
     StreamInfoFormatter upstream_connection_pool_callback_duration_format(
         "UPSTREAM_CONNECTION_POOL_READY_DURATION");
     EXPECT_CALL(time_system, monotonicTime)


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: access log: add new END_TIME formatter
Additional Description: Adding END_TIME formatter for HTTP Streams TCP Connections, similarly too START_TIME.
Risk Level: low.
Testing: added UnitTest
Docs Changes: Updated access-log usage doc. (docs/root/configuration/observability/access_log/usage.rst)
Release Notes: added
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
