### PR TITLE
Use mutex reference in lock constructors

### DIFF
--- a/source/common/network/connection_balancer_impl.cc
+++ b/source/common/network/connection_balancer_impl.cc
@@ -4,12 +4,12 @@ namespace Envoy {
 namespace Network {
 
 void ExactConnectionBalancerImpl::registerHandler(BalancedConnectionHandler& handler) {
-  absl::MutexLock lock(&lock_);
+  absl::MutexLock lock(lock_);
   handlers_.push_back(&handler);
 }
 
 void ExactConnectionBalancerImpl::unregisterHandler(BalancedConnectionHandler& handler) {
-  absl::MutexLock lock(&lock_);
+  absl::MutexLock lock(lock_);
   // This could be made more efficient in various ways, but the number of listeners is generally
   // small and this is a rare operation so we can start with this and optimize later if this
   // becomes a perf bottleneck.
@@ -20,7 +20,7 @@ BalancedConnectionHandler&
 ExactConnectionBalancerImpl::pickTargetHandler(BalancedConnectionHandler&) {
   BalancedConnectionHandler* min_connection_handler = nullptr;
   {
-    absl::MutexLock lock(&lock_);
+    absl::MutexLock lock(lock_);
     for (BalancedConnectionHandler* handler : handlers_) {
       if (min_connection_handler == nullptr ||
           handler->numConnections() < min_connection_handler->numConnections()) {

--- a/source/common/network/udp_listener_impl.cc
+++ b/source/common/network/udp_listener_impl.cc
@@ -174,7 +174,7 @@ UdpListenerWorkerRouterImpl::UdpListenerWorkerRouterImpl(uint32_t concurrency)
     : workers_(concurrency) {}
 
 void UdpListenerWorkerRouterImpl::registerWorkerForListener(UdpListenerCallbacks& listener) {
-  absl::WriterMutexLock lock(&mutex_);
+  absl::WriterMutexLock lock(mutex_);
 
   ASSERT(listener.workerIndex() < workers_.size());
   ASSERT(workers_.at(listener.workerIndex()) == nullptr);
@@ -182,14 +182,14 @@ void UdpListenerWorkerRouterImpl::registerWorkerForListener(UdpListenerCallbacks
 }
 
 void UdpListenerWorkerRouterImpl::unregisterWorkerForListener(UdpListenerCallbacks& listener) {
-  absl::WriterMutexLock lock(&mutex_);
+  absl::WriterMutexLock lock(mutex_);
 
   ASSERT(workers_.at(listener.workerIndex()) == &listener);
   workers_.at(listener.workerIndex()) = nullptr;
 }
 
 void UdpListenerWorkerRouterImpl::deliver(uint32_t dest_worker_index, UdpRecvData&& data) {
-  absl::ReaderMutexLock lock(&mutex_);
+  absl::ReaderMutexLock lock(mutex_);
 
   ASSERT(dest_worker_index < workers_.size(),
          "UdpListenerCallbacks::destination returned out-of-range value");

--- a/source/common/stats/allocator_impl.cc
+++ b/source/common/stats/allocator_impl.cc
@@ -283,12 +283,12 @@ public:
   // Stats::TextReadout
   void set(absl::string_view value) override {
     std::string value_copy(value);
-    absl::MutexLock lock(&mutex_);
+    absl::MutexLock lock(mutex_);
     value_ = std::move(value_copy);
     flags_ |= Flags::Used;
   }
   std::string value() const override {
-    absl::MutexLock lock(&mutex_);
+    absl::MutexLock lock(mutex_);
     return value_;
   }
 

--- a/source/common/stats/symbol_table.cc
+++ b/source/common/stats/symbol_table.cc
@@ -757,7 +757,7 @@ StatNameSet::StatNameSet(SymbolTable& symbol_table, absl::string_view name)
 void StatNameSet::rememberBuiltin(absl::string_view str) {
   StatName stat_name;
   {
-    absl::MutexLock lock(&mutex_);
+    absl::MutexLock lock(mutex_);
     stat_name = pool_.add(str);
   }
   builtin_stat_names_[str] = stat_name;

--- a/source/extensions/clusters/common/logical_host.cc
+++ b/source/extensions/clusters/common/logical_host.cc
@@ -41,7 +41,7 @@ LogicalHost::LogicalHost(
 }
 
 Network::Address::InstanceConstSharedPtr LogicalHost::healthCheckAddress() const {
-  absl::MutexLock lock(&address_lock_);
+  absl::MutexLock lock(address_lock_);
   return health_check_address_;
 }
 
@@ -57,7 +57,7 @@ void LogicalHost::setNewAddresses(const Network::Address::InstanceConstSharedPtr
     ASSERT(*address_list.front() == *address);
   }
   {
-    absl::MutexLock lock(&address_lock_);
+    absl::MutexLock lock(address_lock_);
     address_ = address;
     address_list_or_null_ = std::move(shared_address_list);
     health_check_address_ = std::move(health_check_address);
@@ -65,12 +65,12 @@ void LogicalHost::setNewAddresses(const Network::Address::InstanceConstSharedPtr
 }
 
 HostDescription::SharedConstAddressVector LogicalHost::addressListOrNull() const {
-  absl::MutexLock lock(&address_lock_);
+  absl::MutexLock lock(address_lock_);
   return address_list_or_null_;
 }
 
 Network::Address::InstanceConstSharedPtr LogicalHost::address() const {
-  absl::MutexLock lock(&address_lock_);
+  absl::MutexLock lock(address_lock_);
   return address_;
 }
 
@@ -80,7 +80,7 @@ Upstream::Host::CreateConnectionData LogicalHost::createConnection(
   Network::Address::InstanceConstSharedPtr address;
   SharedConstAddressVector address_list_or_null;
   {
-    absl::MutexLock lock(&address_lock_);
+    absl::MutexLock lock(address_lock_);
     address = address_;
     address_list_or_null = address_list_or_null_;
   }

--- a/source/extensions/transport_sockets/alts/alts_channel_pool.cc
+++ b/source/extensions/transport_sockets/alts/alts_channel_pool.cc
@@ -54,7 +54,7 @@ AltsChannelPool::AltsChannelPool(const std::vector<std::shared_ptr<grpc::Channel
 std::shared_ptr<grpc::Channel> AltsChannelPool::getChannel() {
   std::shared_ptr<grpc::Channel> channel;
   {
-    absl::MutexLock lock(&mu_);
+    absl::MutexLock lock(mu_);
     channel = channel_pool_[index_];
     index_ = (index_ + 1) % channel_pool_.size();
   }

--- a/test/extensions/filters/network/match_delegate/match_delegate_integration_test.cc
+++ b/test/extensions/filters/network/match_delegate/match_delegate_integration_test.cc
@@ -26,13 +26,13 @@ class CountingFilter : public Network::Filter {
 public:
   // Read filter methods
   Network::FilterStatus onData(Buffer::Instance& data, bool) override {
-    absl::MutexLock lock(&mutex_);
+    absl::MutexLock lock(mutex_);
     data_bytes_ += data.length();
     return Network::FilterStatus::Continue;
   }
 
   Network::FilterStatus onNewConnection() override {
-    absl::MutexLock lock(&mutex_);
+    absl::MutexLock lock(mutex_);
     connection_count_++;
     return Network::FilterStatus::Continue;
   }
@@ -43,7 +43,7 @@ public:
 
   // Write filter methods
   Network::FilterStatus onWrite(Buffer::Instance& data, bool) override {
-    absl::MutexLock lock(&mutex_);
+    absl::MutexLock lock(mutex_);
     write_bytes_ += data.length();
     return Network::FilterStatus::Continue;
   }
@@ -54,23 +54,23 @@ public:
 
   // Thread-safe getters for counter values
   static uint32_t getConnectionCount() {
-    absl::MutexLock lock(&mutex_);
+    absl::MutexLock lock(mutex_);
     return connection_count_;
   }
 
   static uint64_t getDataBytes() {
-    absl::MutexLock lock(&mutex_);
+    absl::MutexLock lock(mutex_);
     return data_bytes_;
   }
 
   static uint64_t getWriteBytes() {
-    absl::MutexLock lock(&mutex_);
+    absl::MutexLock lock(mutex_);
     return write_bytes_;
   }
 
   // Reset all counters
   static void resetCounters() {
-    absl::MutexLock lock(&mutex_);
+    absl::MutexLock lock(mutex_);
     connection_count_ = 0;
     data_bytes_ = 0;
     write_bytes_ = 0;

--- a/test/mocks/filesystem/mocks.cc
+++ b/test/mocks/filesystem/mocks.cc
@@ -10,7 +10,7 @@ MockFile::MockFile() = default;
 MockFile::~MockFile() = default;
 
 Api::IoCallBoolResult MockFile::open(FlagSet flag) {
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
 
   Api::IoCallBoolResult result = open_(flag);
   is_open_ = result.return_value_;
@@ -20,7 +20,7 @@ Api::IoCallBoolResult MockFile::open(FlagSet flag) {
 }
 
 Api::IoCallSizeResult MockFile::write(absl::string_view buffer) {
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
   if (!is_open_) {
     return {-1, Api::IoErrorPtr(nullptr, [](Api::IoError*) { PANIC("reached unexpected code"); })};
   }
@@ -32,7 +32,7 @@ Api::IoCallSizeResult MockFile::write(absl::string_view buffer) {
 }
 
 Api::IoCallSizeResult MockFile::pread(void* buf, uint64_t count, uint64_t offset) {
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
   if (!is_open_) {
     return {-1, Api::IoErrorPtr(nullptr, [](Api::IoError*) { PANIC("reached unexpected code"); })};
   }
@@ -44,7 +44,7 @@ Api::IoCallSizeResult MockFile::pread(void* buf, uint64_t count, uint64_t offset
 }
 
 Api::IoCallSizeResult MockFile::pwrite(const void* buf, uint64_t count, uint64_t offset) {
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
   if (!is_open_) {
     return {-1, Api::IoErrorPtr(nullptr, [](Api::IoError*) { PANIC("reached unexpected code"); })};
   }

--- a/test/server/admin/stats_handler_test.cc
+++ b/test/server/admin/stats_handler_test.cc
@@ -1256,7 +1256,7 @@ protected:
     for (uint32_t s = 0; s < NumScopes; ++s) {
       Stats::ScopeSharedPtr scope = store_->rootScope()->scopeFromStatName(scope_names_[s]);
       {
-        absl::MutexLock lock(&scope_mutexes_[s]);
+        absl::MutexLock lock(scope_mutexes_[s]);
         scopes_[s] = scope;
       }
       for (Stats::StatName counter_name : counter_names_) {


### PR DESCRIPTION
Commit Message:
Replace deprecated absl::MutexLock::MutexLock(Mutex*) constructor with absl::MutexLock::MutexLock(Mutex&)

Risk Level: none
Testing: unit tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
