### PR TITLE
xDS: improve documentation for ext_proc

### DIFF
--- a/api/envoy/extensions/filters/http/ext_proc/v3/BUILD
+++ b/api/envoy/extensions/filters/http/ext_proc/v3/BUILD
@@ -6,6 +6,7 @@ licenses(["notice"])  # Apache 2
 
 api_proto_package(
     deps = [
+        "//envoy/annotations:pkg",
         "//envoy/config/common/mutation_rules/v3:pkg",
         "//envoy/config/core/v3:pkg",
         "//envoy/type/matcher/v3:pkg",

--- a/api/envoy/extensions/filters/http/ext_proc/v3/ext_proc.proto
+++ b/api/envoy/extensions/filters/http/ext_proc/v3/ext_proc.proto
@@ -16,6 +16,7 @@ import "google/protobuf/wrappers.proto";
 
 import "xds/annotations/v3/status.proto";
 
+import "envoy/annotations/deprecation.proto";
 import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
 import "validate/validate.proto";
@@ -48,8 +49,6 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 //
 // * Whether it receives the response message at all.
 // * Whether it receives the message body at all, in separate chunks, or as a single buffer.
-// * Whether subsequent HTTP requests are transmitted synchronously or whether they are
-//   sent asynchronously.
 // * To modify request or response trailers if they already exist.
 //
 // The filter supports up to six different processing steps. Each is represented by
@@ -57,9 +56,11 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // processor must send a matching response.
 //
 // * Request headers: Contains the headers from the original HTTP request.
-// * Request body: Delivered if they are present and sent in a single message if
-//   the ``BUFFERED`` or ``BUFFERED_PARTIAL`` mode is chosen, in multiple messages if the
-//   ``STREAMED`` mode is chosen, and not at all otherwise.
+// * Request body: If the body is present, the behavior depends on the
+//   body send mode. In ``BUFFERED`` or ``BUFFERED_PARTIAL`` mode, the body is sent to the external
+//   processor in a single message. In ``STREAMED`` or ``FULL_DUPLEX_STREAMED`` mode, the body will
+//   be split across multiple messages sent to the external processor. In ``NONE`` mode, the body
+//   will not be sent to the external processor.
 // * Request trailers: Delivered if they are present and if the trailer mode is set
 //   to ``SEND``.
 // * Response headers: Contains the headers from the HTTP response. Keep in mind
@@ -75,7 +76,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // from the external processor. The latter is only enabled if ``allow_mode_override`` is
 // set to true. This way, a processor may, for example, use information
 // in the request header to determine whether the message body must be examined, or whether
-// the proxy should simply stream it straight through.
+// the data plane should simply stream it straight through.
 //
 // All of this together allows a server to process the filter traffic in fairly
 // sophisticated ways. For example:
@@ -84,12 +85,8 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 //   on the content of the headers.
 // * A server may choose to immediately reject some messages based on their HTTP
 //   headers (or other dynamic metadata) and more carefully examine others.
-// * A server may asynchronously monitor traffic coming through the filter by inspecting
-//   headers, bodies, or both, and then decide to switch to a synchronous processing
-//   mode, either permanently or temporarily.
 //
-// The protocol itself is based on a bidirectional gRPC stream. Envoy will send the
-// server
+// The protocol itself is based on a bidirectional gRPC stream. The data plane will send the server
 // :ref:`ProcessingRequest <envoy_v3_api_msg_service.ext_proc.v3.ProcessingRequest>`
 // messages, and the server must reply with
 // :ref:`ProcessingResponse <envoy_v3_api_msg_service.ext_proc.v3.ProcessingResponse>`.
@@ -124,7 +121,6 @@ message ExternalProcessor {
   reserved "async_mode";
 
   // Configuration for the gRPC service that the filter will communicate with.
-  // The filter supports both the "Envoy" and "Google" gRPC clients.
   // Only one of ``grpc_service`` or ``http_service`` can be set.
   // It is required that one of them must be set.
   config.core.v3.GrpcService grpc_service = 1
@@ -140,14 +136,14 @@ message ExternalProcessor {
   // cannot be configured to send any body or trailers. i.e., ``http_service`` only supports
   // sending request or response headers to the side stream server.
   //
-  // With this configuration, Envoy behavior:
+  // With this configuration, the data plane behavior is:
   //
   // 1. The headers are first put in a proto message
   // :ref:`ProcessingRequest <envoy_v3_api_msg_service.ext_proc.v3.ProcessingRequest>`.
   //
   // 2. This proto message is then transcoded into a JSON text.
   //
-  // 3. Envoy then sends an HTTP POST message with content-type as "application/json",
+  // 3. The data plane then sends an HTTP POST message with content-type as "application/json",
   // and this JSON text as body to the side stream server.
   //
   // After the side-stream receives this HTTP request message, it is expected to do as follows:
@@ -160,7 +156,7 @@ message ExternalProcessor {
   //
   // 3. It converts the ``ProcessingResponse`` proto message into a JSON text.
   //
-  // 4. It then sends an HTTP response back to Envoy with status code as ``"200"``,
+  // 4. It then sends an HTTP response back to the data plane with status code as ``"200"``,
   // ``content-type`` as ``"application/json"`` and sets the JSON text as the body.
   //
   ExtProcHttpService http_service = 20 [
@@ -190,28 +186,31 @@ message ExternalProcessor {
   // sent. See ``ProcessingMode`` for details.
   ProcessingMode processing_mode = 3;
 
-  // Envoy provides a number of :ref:`attributes <arch_overview_attributes>`
+  // The data plane provides a number of :ref:`attributes <arch_overview_attributes>`
   // for expressive policies. Each attribute name provided in this field will be
-  // matched against that list and populated in the ``request_headers`` message.
+  // matched against that list and populated in the
+  // :ref:`ProcessingRequest.attributes <envoy_v3_api_field_service.ext_proc.v3.ProcessingRequest.attributes>` field.
   // See the :ref:`attribute documentation <arch_overview_request_attributes>`
   // for the list of supported attributes and their types.
   repeated string request_attributes = 5;
 
-  // Envoy provides a number of :ref:`attributes <arch_overview_attributes>`
+  // The data plane provides a number of :ref:`attributes <arch_overview_attributes>`
   // for expressive policies. Each attribute name provided in this field will be
-  // matched against that list and populated in the ``response_headers`` message.
+  // matched against that list and populated in the
+  // :ref:`ProcessingRequest.attributes <envoy_v3_api_field_service.ext_proc.v3.ProcessingRequest.attributes>` field.
   // See the :ref:`attribute documentation <arch_overview_attributes>`
   // for the list of supported attributes and their types.
   repeated string response_attributes = 6;
 
-  // Specifies the timeout for each individual message sent on the stream and
-  // when the filter is running in synchronous mode. Whenever the proxy sends
-  // a message on the stream that requires a response, it will reset this timer,
-  // and will stop processing and return an error (subject to the processing mode)
-  // if the timer expires before a matching response is received. There is no
-  // timeout when the filter is running in asynchronous mode. Zero is a valid
-  // config which means the timer will be triggered immediately. If not
-  // configured, default is 200 milliseconds.
+  // Specifies the timeout for each individual message sent on the stream.
+  // Whenever the data plane sends a message on the stream that requires a
+  // response, it will reset this timer, and will stop processing and return
+  // an error (subject to the processing mode) if the timer expires before a
+  // matching response is received. There is no timeout when the filter is
+  // running in observability mode or when the body send mode is
+  // ``FULL_DUPLEX_STREAMED``. Zero is a valid config which means the timer
+  // will be triggered immediately. If not configured, default is 200
+  // milliseconds.
   google.protobuf.Duration message_timeout = 7 [(validate.rules).duration = {
     lte {seconds: 3600}
     gte {}
@@ -228,7 +227,7 @@ message ExternalProcessor {
   // :ref:`header_prefix <envoy_v3_api_field_config.bootstrap.v3.Bootstrap.header_prefix>`
   // (which is usually "x-envoy").
   // Note that changing headers such as "host" or ":authority" may not in itself
-  // change Envoy's routing decision, as routes can be cached. To also force the
+  // change the data plane's routing decision, as routes can be cached. To also force the
   // route to be recomputed, set the
   // :ref:`clear_route_cache <envoy_v3_api_field_service.ext_proc.v3.CommonResponse.clear_route_cache>`
   // field to true in the same response.
@@ -256,6 +255,7 @@ message ExternalProcessor {
   // can be overridden by the response message from the external processing server
   // :ref:`mode_override <envoy_v3_api_field_service.ext_proc.v3.ProcessingResponse.mode_override>`.
   // If not set, ``mode_override`` API in the response message will be ignored.
+  // Mode override is not supported if the body send mode is ``FULL_DUPLEX_STREAMED``.
   bool allow_mode_override = 14;
 
   // If set to true, ignore the
@@ -270,10 +270,10 @@ message ExternalProcessor {
 
   // If true, send each part of the HTTP request or response specified by ``ProcessingMode``
   // without pausing on filter chain iteration. It is "Send and Go" mode that can be used
-  // by external processor to observe Envoy data and status. In this mode:
+  // by external processor to observe the request's data and status. In this mode:
   //
-  // 1. Only ``STREAMED`` body processing mode is supported and any other body processing modes will be
-  // ignored. ``NONE`` mode (i.e., skip body processing) will still work as expected.
+  // 1. Only ``STREAMED`` and ``NONE`` body processing modes are supported; for any other body
+  // processing mode, the body will not be sent.
   //
   // 2. External processor should not send back processing response, as any responses will be ignored.
   // This also means that
@@ -310,12 +310,13 @@ message ExternalProcessor {
   // Specifies the deferred closure timeout for gRPC stream that connects to external processor. Currently, the deferred stream closure
   // is only used in :ref:`observability_mode <envoy_v3_api_field_extensions.filters.http.ext_proc.v3.ExternalProcessor.observability_mode>`.
   // In observability mode, gRPC streams may be held open to the external processor longer than the lifetime of the regular client to
-  // backend stream lifetime. In this case, Envoy will eventually timeout the external processor stream according to this time limit.
+  // backend stream lifetime. In this case, the data plane will eventually timeout the external processor stream according to this time limit.
   // The default value is 5000 milliseconds (5 seconds) if not specified.
   google.protobuf.Duration deferred_close_timeout = 19;
 
   // Send body to the side stream server once it arrives without waiting for the header response from that server.
-  // It only works for ``STREAMED`` body processing mode. For any other body processing modes, it is ignored.
+  // It only works for ``STREAMED`` body processing mode. For any other body
+  // processing modes, it is ignored.
   // The server has two options upon receiving a header request:
   //
   // 1. Instant Response: send the header response as soon as the header request is received.
@@ -324,9 +325,9 @@ message ExternalProcessor {
   //
   // In all scenarios, the header-body ordering must always be maintained.
   //
-  // If enabled Envoy will ignore the
+  // If enabled the data plane will ignore the
   // :ref:`mode_override <envoy_v3_api_field_service.ext_proc.v3.ProcessingResponse.mode_override>`
-  // value that the server sends in the header response. This is because Envoy may have already
+  // value that the server sends in the header response. This is because the data plane may have already
   // sent the body to the server, prior to processing the header response.
   bool send_body_without_waiting_for_header_response = 21;
 
@@ -430,7 +431,8 @@ message ExtProcOverrides {
 
   // [#not-implemented-hide:]
   // Set a different asynchronous processing option than the default.
-  bool async_mode = 2;
+  // Deprecated and not implemented.
+  bool async_mode = 2 [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
 
   // [#not-implemented-hide:]
   // Set different optional attributes than the default setting of the

--- a/api/envoy/extensions/filters/http/ext_proc/v3/processing_mode.proto
+++ b/api/envoy/extensions/filters/http/ext_proc/v3/processing_mode.proto
@@ -65,8 +65,7 @@ message ProcessingMode {
     // Do not send the body at all. This is the default.
     NONE = 0;
 
-    // Stream the body to the server in pieces as they arrive at the
-    // proxy.
+    // Stream the body to the server in pieces as they are seen.
     STREAMED = 1;
 
     // Buffer the message body in memory and send the entire body at once.
@@ -79,11 +78,11 @@ message ProcessingMode {
     // up to the buffer limit will be sent.
     BUFFERED_PARTIAL = 3;
 
-    // Envoy streams the body to the server in pieces as they arrive.
+    // The ext_proc client streams the body to the server in pieces as they arrive.
     //
     // 1) The server may choose to buffer any number chunks of data before processing them.
     // After it finishes buffering, the server processes the buffered data. Then it splits the processed
-    // data into any number of chunks, and streams them back to Envoy one by one.
+    // data into any number of chunks, and streams them back to the client one by one.
     // The server may continuously do so until the complete body is processed.
     // The individual response chunk size is recommended to be no greater than 64K bytes, or
     // :ref:`max_receive_message_length <envoy_v3_api_field_config.core.v3.GrpcService.EnvoyGrpc.max_receive_message_length>`
@@ -98,15 +97,15 @@ message ProcessingMode {
     //
     // In this body mode:
     // * The corresponding trailer mode has to be set to ``SEND``.
-    // * Envoy will send body and trailers (if present) to the server as they arrive.
+    // * The client will send body and trailers (if present) to the server as they arrive.
     //   Sending the trailers (if present) is to inform the server the complete body arrives.
-    //   In case there are no trailers, then Envoy will set
+    //   In case there are no trailers, then the client will set
     //   :ref:`end_of_stream <envoy_v3_api_field_service.ext_proc.v3.HttpBody.end_of_stream>`
     //   to true as part of the last body chunk request to notify the server that no other data is to be sent.
     // * The server needs to send
     //   :ref:`StreamedBodyResponse <envoy_v3_api_msg_service.ext_proc.v3.StreamedBodyResponse>`
-    //   to Envoy in the body response.
-    // * Envoy will stream the body chunks in the responses from the server to the upstream/downstream as they arrive.
+    //   to the client in the body response.
+    // * The client will stream the body chunks in the responses from the server to the upstream/downstream as they arrive.
 
     FULL_DUPLEX_STREAMED = 4;
   }

--- a/api/envoy/extensions/filters/http/ext_proc/v3/processing_mode.proto
+++ b/api/envoy/extensions/filters/http/ext_proc/v3/processing_mode.proto
@@ -82,7 +82,7 @@ message ProcessingMode {
     //
     // 1) The server may choose to buffer any number chunks of data before processing them.
     // After it finishes buffering, the server processes the buffered data. Then it splits the processed
-    // data into any number of chunks, and streams them back to the client one by one.
+    // data into any number of chunks, and streams them back to the ext_proc client one by one.
     // The server may continuously do so until the complete body is processed.
     // The individual response chunk size is recommended to be no greater than 64K bytes, or
     // :ref:`max_receive_message_length <envoy_v3_api_field_config.core.v3.GrpcService.EnvoyGrpc.max_receive_message_length>`

--- a/api/envoy/extensions/filters/http/ext_proc/v3/processing_mode.proto
+++ b/api/envoy/extensions/filters/http/ext_proc/v3/processing_mode.proto
@@ -78,7 +78,7 @@ message ProcessingMode {
     // up to the buffer limit will be sent.
     BUFFERED_PARTIAL = 3;
 
-    // The ext_proc client streams the body to the server in pieces as they arrive.
+    // The ext_proc client (the data plane) streams the body to the server in pieces as they arrive.
     //
     // 1) The server may choose to buffer any number chunks of data before processing them.
     // After it finishes buffering, the server processes the buffered data. Then it splits the processed

--- a/api/envoy/service/ext_proc/v3/external_processor.proto
+++ b/api/envoy/service/ext_proc/v3/external_processor.proto
@@ -27,29 +27,31 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // as part of a filter chain.
 // The overall external processing protocol works like this:
 //
-// 1. Envoy sends to the service information about the HTTP request.
-// 2. The service sends back a ProcessingResponse message that directs Envoy
-//    to either stop processing, continue without it, or send it the
-//    next chunk of the message body.
-// 3. If so requested, Envoy sends the server the message body in chunks,
-//    or the entire body at once. In either case, the server may send back
-//    a ProcessingResponse for each message it receives, or wait for certain amount
-//    of body chunks received before streams back the ProcessingResponse messages.
-// 4. If so requested, Envoy sends the server the HTTP trailers,
+// 1. The data plane sends to the service information about the HTTP request.
+// 2. The service sends back a ProcessingResponse message that directs
+//    the data plane to either stop processing, continue without it, or send
+//    it the next chunk of the message body.
+// 3. If so requested, the data plane sends the server the message body in
+//    chunks, or the entire body at once. In either case, the server may send
+//    back a ProcessingResponse for each message it receives, or wait for
+//    a certain amount of body chunks received before streaming back the
+//    ProcessingResponse messages.
+// 4. If so requested, the data plane sends the server the HTTP trailers,
 //    and the server sends back a ProcessingResponse.
 // 5. At this point, request processing is done, and we pick up again
-//    at step 1 when Envoy receives a response from the upstream server.
+//    at step 1 when the data plane receives a response from the upstream
+//    server.
 // 6. At any point above, if the server closes the gRPC stream cleanly,
-//    then Envoy proceeds without consulting the server.
+//    then the data plane proceeds without consulting the server.
 // 7. At any point above, if the server closes the gRPC stream with an error,
-//    then Envoy returns a 500 error to the client, unless the filter
+//    then the data plane returns a 500 error to the client, unless the filter
 //    was configured to ignore errors.
 //
 // In other words, the process is a request/response conversation, but
 // using a gRPC stream to make it easier for the server to
 // maintain state.
 service ExternalProcessor {
-  // This begins the bidirectional stream that Envoy will use to
+  // This begins the bidirectional stream that the data plane will use to
   // give the server control over what the filter does. The actual
   // protocol is described by the ProcessingRequest and ProcessingResponse
   // messages below.
@@ -79,7 +81,7 @@ message ProtocolConfiguration {
   bool send_body_without_waiting_for_header_response = 3;
 }
 
-// This represents the different types of messages that Envoy can send
+// This represents the different types of messages that the data plane can send
 // to an external processing server.
 // [#next-free-field: 12]
 message ProcessingRequest {
@@ -132,7 +134,7 @@ message ProcessingRequest {
   // The values of properties selected by the ``request_attributes``
   // or ``response_attributes`` list in the configuration. Each entry
   // in the list is populated from the standard
-  // :ref:`attributes <arch_overview_attributes>` supported across Envoy.
+  // :ref:`attributes <arch_overview_attributes>` supported in the data plane.
   map<string, google.protobuf.Struct> attributes = 9;
 
   // Specify whether the filter that sent this request is running in :ref:`observability_mode
@@ -153,7 +155,7 @@ message ProcessingRequest {
   ProtocolConfiguration protocol_config = 11;
 }
 
-// This represents the different types of messages the server may send back to Envoy
+// This represents the different types of messages the server may send back to the data plane
 // when the ``observability_mode`` field in the received ProcessingRequest is set to false.
 //
 // * If the corresponding ``BodySendMode`` in the
@@ -212,8 +214,8 @@ message ProcessingResponse {
   // may use this to intelligently control how requests are processed
   // based on the headers and other metadata that they see.
   // This field is only applicable when servers responding to the header requests.
-  // If it is set in the response to the body or trailer requests, it will be ignored by Envoy.
-  // It is also ignored by Envoy when the ext_proc filter config
+  // If it is set in the response to the body or trailer requests, it will be ignored by the data plane.
+  // It is also ignored by the data plane when the ext_proc filter config
   // :ref:`allow_mode_override
   // <envoy_v3_api_field_extensions.filters.http.ext_proc.v3.ExternalProcessor.allow_mode_override>`
   // is set to false, or
@@ -224,16 +226,16 @@ message ProcessingResponse {
 
   // When ext_proc server receives a request message, in case it needs more
   // time to process the message, it sends back a ProcessingResponse message
-  // with a new timeout value. When Envoy receives this response message,
-  // it ignores other fields in the response, just stop the original timer,
-  // which has the timeout value specified in
+  // with a new timeout value. When the data plane receives this response
+  // message, it ignores other fields in the response, just stop the original
+  // timer, which has the timeout value specified in
   // :ref:`message_timeout
   // <envoy_v3_api_field_extensions.filters.http.ext_proc.v3.ExternalProcessor.message_timeout>`
   // and start a new timer with this ``override_message_timeout`` value and keep the
-  // Envoy ext_proc filter state machine intact.
+  // data plane ext_proc filter state machine intact.
   // Has to be >= 1ms and <=
   // :ref:`max_message_timeout <envoy_v3_api_field_extensions.filters.http.ext_proc.v3.ExternalProcessor.max_message_timeout>`
-  // Such message can be sent at most once in a particular Envoy ext_proc filter processing state.
+  // Such message can be sent at most once in a particular data plane ext_proc filter processing state.
   // To enable this API, one has to set ``max_message_timeout`` to a number >= 1ms.
   google.protobuf.Duration override_message_timeout = 10;
 }
@@ -283,26 +285,26 @@ message HttpTrailers {
 
 // The following are messages that may be sent back by the server.
 
-// This message is sent by the external server to Envoy after ``HttpHeaders`` was
+// This message is sent by the external server to the data plane after ``HttpHeaders`` was
 // sent to it.
 message HeadersResponse {
-  // Details the modifications (if any) to be made by Envoy to the current
+  // Details the modifications (if any) to be made by the data plane to the current
   // request/response.
   CommonResponse response = 1;
 }
 
-// This message is sent by the external server to Envoy after ``HttpBody`` was
+// This message is sent by the external server to the data plane after ``HttpBody`` was
 // sent to it.
 message BodyResponse {
-  // Details the modifications (if any) to be made by Envoy to the current
+  // Details the modifications (if any) to be made by the data plane to the current
   // request/response.
   CommonResponse response = 1;
 }
 
-// This message is sent by the external server to Envoy after ``HttpTrailers`` was
+// This message is sent by the external server to the data plane after ``HttpTrailers`` was
 // sent to it.
 message TrailersResponse {
-  // Details the modifications (if any) to be made by Envoy to the current
+  // Details the modifications (if any) to be made by the data plane to the current
   // request/response trailers.
   HeaderMutation header_mutation = 1;
 }
@@ -332,7 +334,7 @@ message CommonResponse {
     CONTINUE_AND_REPLACE = 1;
   }
 
-  // If set, provide additional direction on how the Envoy proxy should
+  // If set, provide additional direction on how the data plane should
   // handle the rest of the HTTP filter chain.
   ResponseStatus status = 1 [(validate.rules).enum = {defined_only: true}];
 
@@ -361,7 +363,7 @@ message CommonResponse {
   // Clear the route cache for the current client request. This is necessary
   // if the remote server modified headers that are used to calculate the route.
   // This field is ignored in the response direction. This field is also ignored
-  // if the Envoy ext_proc filter is in the upstream filter chain.
+  // if the data plane ext_proc filter is in the upstream filter chain.
   bool clear_route_cache = 5;
 }
 
@@ -415,7 +417,7 @@ message HeaderMutation {
 
 // The body response message corresponding to FULL_DUPLEX_STREAMED body mode.
 message StreamedBodyResponse {
-  // The body response chunk that will be passed to the upstream/downstream by Envoy.
+  // The body response chunk that will be passed to the upstream/downstream by the data plane.
   bytes body = 1;
 
   // The server sets this flag to true if it has received a body request with
@@ -424,7 +426,7 @@ message StreamedBodyResponse {
   bool end_of_stream = 2;
 }
 
-// This message specifies the body mutation the server sends to Envoy.
+// This message specifies the body mutation the server sends to the data plane.
 message BodyMutation {
   // The type of mutation for the body.
   oneof mutation {


### PR DESCRIPTION
Commit Message: xDS: improve documentation for ext_proc
Additional Description: Made a number of documentation changes:
- Removed lingering references to async mode, which was replaced with observability mode.
- Document that message timeouts are not supported in `FULL_DUPLEX_STREAMED` body send mode.
- Document that mode override is not supported in `FULL_DUPLEX_STREAMED` body send mode.
- Clarify that in observability mode, the body is not sent if body send mode is something other than `STREAMED`.
- Changed wording to clarify that the client may not be Envoy, since gRPC will soon be adding ext_proc support.

Risk Level: None
Testing: N/A
Docs Changes: Included in PR
Release Notes: N/A
Platform Specific Features: N/A
