### PR TITLE
Adds compression status header to compressor_filter

### DIFF
--- a/docs/root/configuration/http/http_filters/compressor_filter.rst
+++ b/docs/root/configuration/http/http_filters/compressor_filter.rst
@@ -107,6 +107,35 @@ When request compression is *applied*:
 - ``content-encoding`` with the compression scheme used (e.g., ``gzip``) is added to
   request headers.
 
+Compression Status Header
+-------------------------
+
+To aid upstream caches and clients in understanding why a response was or was not compressed, the Compressor filter can add a response header ``x-envoy-compression-status``. This header provides visibility into the filter's decision-making process, which is particularly useful for cache invalidation strategies when compression settings or request/response characteristics change.
+
+To enable this feature, the runtime flag ``envoy.reloadable_features.compressor_add_status_header`` must be set to ``true``.
+
+The header value follows the format: ``<encoder-type>;<status>[;<additional-params>]``. Where:
+
+- ``<encoder-type>``: The name of the compressor library configured (e.g., ``gzip``, ``br``).
+- ``<status>``: The result of the compression check.
+- ``<additional-params>``: Optional key-value pairs providing more context.
+
+If multiple Compressor filters are present in the chain, each filter will append its status to the header, separated by commas. For example: ``gzip;ContentTypeNotAllowed,br;Compressed;OriginalLength=1024``
+
+Possible status values:
+
+- ``Compressed``: The response was compressed by this filter.
+   - Additional Parameter: ``OriginalLength=<value>``, where ``<value>`` is the original value of the ``Content-Length`` header before compression.
+- ``ContentLengthTooSmall``: Compression was skipped because the content length is below the configured minimum threshold.
+- ``ContentTypeNotAllowed``: Compression was skipped because the response ``Content-Type`` is not in the allowed list.
+- ``EtagNotAllowed``: Compression was skipped because the response contains an ``ETag`` header and the ``disable_on_etag_header`` option is enabled.
+- ``StatusCodeNotAllowed``: Compression was skipped because the response status code is in the list of uncompressible status codes.
+
+Behavior Notes:
+
+- When the `envoy.reloadable_features.compressor_add_status_header` flag is enabled, the order of internal checks within the filter is adjusted to ensure the most accurate reason for skipping compression is reported.
+- The conditions are evaluated in a specific order. The first condition that causes compression to be skipped is the one reported in the `x-envoy-compression-status` header. Subsequent checks are not performed for that filter instance. For example, if a response has both a disallowed content type and a content length below the threshold, only the reason that is checked first will be reported.
+
 Per-Route Configuration
 -----------------------
 

--- a/source/common/http/headers.h
+++ b/source/common/http/headers.h
@@ -206,6 +206,7 @@ public:
   const LowerCaseString EnvoyUpstreamStreamDurationMs{
       absl::StrCat(prefix(), "-upstream-stream-duration-ms")};
   const LowerCaseString EnvoyDecoratorOperation{absl::StrCat(prefix(), "-decorator-operation")};
+  const LowerCaseString EnvoyCompressionStatus{absl::StrCat(prefix(), "-compression-status")};
   const LowerCaseString Expect{"expect"};
   const LowerCaseString ForwardedClientCert{"x-forwarded-client-cert"};
   const LowerCaseString ForwardedFor{"x-forwarded-for"};
@@ -373,6 +374,17 @@ public:
     const std::string Http2String{"HTTP/2"};
     const std::string Http3String{"HTTP/3"};
   } ProtocolStrings;
+
+  struct {
+    const std::string ContentLengthTooSmall{"ContentLengthTooSmall"};
+    const std::string ContentTypeNotAllowed{"ContentTypeNotAllowed"};
+    const std::string EtagNotAllowed{"EtagNotAllowed"};
+    const std::string StatusCodeNotAllowed{"StatusCodeNotAllowed"};
+    const std::string Compressed{"Compressed"};
+    const std::string OriginalLengthPrefix{"OriginalLength="};
+    const std::string Separator{";"};
+    const std::string ValueSeparator{","};
+  } EnvoyCompressionStatusValues;
 };
 
 using Headers = ConstSingleton<HeaderValues>;

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -170,6 +170,10 @@ FALSE_RUNTIME_GUARD(envoy_reloadable_features_getaddrinfo_no_ai_flags);
 FALSE_RUNTIME_GUARD(envoy_reloadable_features_enable_new_dns_implementation);
 // Force a local reply from upstream envoy for reverse connections.
 FALSE_RUNTIME_GUARD(envoy_reloadable_features_reverse_conn_force_local_reply);
+// Adds status header for compressor filter.
+// Change alters order of evaluating conditions within the filter.
+// Flip to true after prod testing
+FALSE_RUNTIME_GUARD(envoy_reloadable_features_compressor_add_status_header);
 
 // Block of non-boolean flags. Use of int flags is deprecated. Do not add more.
 ABSL_FLAG(uint64_t, re2_max_program_size_error_level, 100, ""); // NOLINT

--- a/source/extensions/filters/http/compressor/BUILD
+++ b/source/extensions/filters/http/compressor/BUILD
@@ -19,6 +19,7 @@ envoy_cc_library(
     deps = [
         "//envoy/compression/compressor:compressor_factory_interface",
         "//envoy/stats:stats_macros",
+        "//source/common/runtime:runtime_features_lib",
         "//source/common/runtime:runtime_lib",
         "//source/extensions/filters/http/common:pass_through_filter_lib",
         "@envoy_api//envoy/extensions/filters/http/compressor/v3:pkg_cc_proto",

--- a/source/extensions/filters/http/compressor/compressor_filter.cc
+++ b/source/extensions/filters/http/compressor/compressor_filter.cc
@@ -6,6 +6,7 @@
 #include "source/common/http/header_map_impl.h"
 #include "source/common/http/utility.h"
 #include "source/common/protobuf/protobuf.h"
+#include "source/common/runtime/runtime_features.h"
 
 #include "absl/container/flat_hash_set.h"
 #include "absl/types/optional.h"
@@ -27,6 +28,8 @@ Http::RegisterCustomInlineHeader<Http::CustomInlineHeaderRegistry::Type::Respons
     etag_handle(Http::CustomHeaders::get().Etag);
 Http::RegisterCustomInlineHeader<Http::CustomInlineHeaderRegistry::Type::ResponseHeaders>
     vary_handle(Http::CustomHeaders::get().Vary);
+Http::RegisterCustomInlineHeader<Http::CustomInlineHeaderRegistry::Type::ResponseHeaders>
+    compression_status_handle(Http::Headers::get().EnvoyCompressionStatus);
 
 Http::RegisterCustomInlineHeader<Http::CustomInlineHeaderRegistry::Type::RequestHeaders>
     request_content_encoding_handle(Http::CustomHeaders::get().ContentEncoding);
@@ -303,6 +306,12 @@ Http::FilterHeadersStatus CompressorFilter::encodeHeaders(Http::ResponseHeaderMa
   const auto* per_route_config =
       Http::Utility::resolveMostSpecificPerFilterConfig<CompressorPerRouteFilterConfig>(
           decoder_callbacks_);
+  const bool is_status_header_enabled =
+      Runtime::runtimeFeatureEnabled("envoy.reloadable_features.compressor_add_status_header");
+
+  if (is_status_header_enabled) {
+    return encodeHeadersWithStatusHeader(headers, end_stream, config, per_route_config);
+  }
 
   // This is used to decide whether stats for accept-encoding header should be touched.
   const bool isEnabledAndContentLengthBigEnough =
@@ -311,7 +320,8 @@ Http::FilterHeadersStatus CompressorFilter::encodeHeaders(Http::ResponseHeaderMa
   const bool isCompressible =
       isEnabledAndContentLengthBigEnough && !Http::Utility::isUpgrade(headers) &&
       config.isContentTypeAllowed(headers) && !hasCacheControlNoTransform(headers) &&
-      isEtagAllowed(headers) && !headers.getInline(response_content_encoding_handle.handle()) &&
+      checkIsEtagAllowedLogResponseStats(headers) &&
+      !headers.getInline(response_content_encoding_handle.handle()) &&
       isResponseCodeCompressible(headers, config);
   if (!end_stream && isAcceptEncodingAllowed(isEnabledAndContentLengthBigEnough, headers) &&
       isCompressible && isTransferEncodingAllowed(headers)) {
@@ -332,6 +342,84 @@ Http::FilterHeadersStatus CompressorFilter::encodeHeaders(Http::ResponseHeaderMa
     insertVaryHeader(headers);
   }
 
+  return Http::FilterHeadersStatus::Continue;
+}
+
+Http::FilterHeadersStatus CompressorFilter::encodeHeadersWithStatusHeader(
+    Http::ResponseHeaderMap& headers, bool end_stream,
+    const CompressorFilterConfig::ResponseDirectionConfig& config,
+    const CompressorPerRouteFilterConfig* per_route_config) {
+  const bool meets_base_compression_preconditions =
+      compressionEnabled(config, per_route_config) && !Http::Utility::isUpgrade(headers) &&
+      !hasCacheControlNoTransform(headers) &&
+      !headers.getInline(response_content_encoding_handle.handle());
+
+  const bool is_compressible = meets_base_compression_preconditions &&
+                               config.isMinimumContentLength(headers) &&
+                               config.isContentTypeAllowed(headers) && isEtagAllowed(headers) &&
+                               isResponseCodeCompressible(headers, config);
+
+  // Even if we decide not to compress due to incompatible Accept-Encoding value,
+  // the Vary header should be inserted to let a caching proxy in front of Envoy
+  // know that the requested resource still can be served with compression applied.
+  if (is_compressible) {
+    insertVaryHeader(headers);
+  }
+
+  if (end_stream || !meets_base_compression_preconditions || !isTransferEncodingAllowed(headers) ||
+      !compressionEnabled(config, per_route_config)) {
+    config.stats().not_compressed_.inc();
+    return Http::FilterHeadersStatus::Continue;
+  }
+
+  if (!config.isMinimumContentLength(headers)) {
+    insertEnvoyCompressionStatusHeader(
+        headers, config_->contentEncoding(),
+        Http::Headers::get().EnvoyCompressionStatusValues.ContentLengthTooSmall);
+    config.stats().not_compressed_.inc();
+    return Http::FilterHeadersStatus::Continue;
+  }
+
+  if (!config.isContentTypeAllowed(headers)) {
+    insertEnvoyCompressionStatusHeader(
+        headers, config_->contentEncoding(),
+        Http::Headers::get().EnvoyCompressionStatusValues.ContentTypeNotAllowed);
+    config.stats().not_compressed_.inc();
+    return Http::FilterHeadersStatus::Continue;
+  }
+
+  if (!isEtagAllowed(headers)) {
+    insertEnvoyCompressionStatusHeader(
+        headers, config_->contentEncoding(),
+        Http::Headers::get().EnvoyCompressionStatusValues.EtagNotAllowed);
+    config.stats().not_compressed_.inc();
+    config_->responseDirectionConfig().responseStats().not_compressed_etag_.inc();
+    return Http::FilterHeadersStatus::Continue;
+  }
+
+  if (!isResponseCodeCompressible(headers, config)) {
+    insertEnvoyCompressionStatusHeader(
+        headers, config_->contentEncoding(),
+        Http::Headers::get().EnvoyCompressionStatusValues.StatusCodeNotAllowed);
+    config.stats().not_compressed_.inc();
+    return Http::FilterHeadersStatus::Continue;
+  }
+
+  if (!isAcceptEncodingAllowed(headers)) {
+    config.stats().not_compressed_.inc();
+    return Http::FilterHeadersStatus::Continue;
+  }
+
+  sanitizeEtagHeader(headers);
+  std::string content_length = std::string(headers.getContentLengthValue());
+  headers.removeContentLength();
+  headers.setInline(response_content_encoding_handle.handle(), config_->contentEncoding());
+  config.stats().compressed_.inc();
+  // Finally instantiate the compressor.
+  response_compressor_ = config_->makeCompressor();
+  insertEnvoyCompressionStatusHeader(headers, config_->contentEncoding(),
+                                     Http::Headers::get().EnvoyCompressionStatusValues.Compressed,
+                                     content_length);
   return Http::FilterHeadersStatus::Continue;
 }
 
@@ -546,7 +634,10 @@ bool CompressorFilter::isAcceptEncodingAllowed(bool maybe_compress,
   if (!maybe_compress) {
     return false;
   }
+  return isAcceptEncodingAllowed(headers);
+}
 
+bool CompressorFilter::isAcceptEncodingAllowed(const Http::ResponseHeaderMap& headers) const {
   if (accept_encoding_ == nullptr) {
     config_->responseDirectionConfig().responseStats().no_accept_header_.inc();
     return false;
@@ -583,13 +674,17 @@ bool CompressorFilterConfig::DirectionConfig::isContentTypeAllowed(
   return true;
 }
 
-bool CompressorFilter::isEtagAllowed(Http::ResponseHeaderMap& headers) const {
-  const bool is_etag_allowed = !(config_->responseDirectionConfig().disableOnEtagHeader() &&
-                                 headers.getInline(etag_handle.handle()));
+bool CompressorFilter::checkIsEtagAllowedLogResponseStats(Http::ResponseHeaderMap& headers) const {
+  const bool is_etag_allowed = isEtagAllowed(headers);
   if (!is_etag_allowed) {
     config_->responseDirectionConfig().responseStats().not_compressed_etag_.inc();
   }
   return is_etag_allowed;
+}
+
+bool CompressorFilter::isEtagAllowed(Http::ResponseHeaderMap& headers) const {
+  return !(config_->responseDirectionConfig().disableOnEtagHeader() &&
+           headers.getInline(etag_handle.handle()));
 }
 
 bool CompressorFilterConfig::ResponseDirectionConfig::areAllResponseCodesCompressible() const {
@@ -642,6 +737,37 @@ bool CompressorFilter::isTransferEncodingAllowed(Http::RequestOrResponseHeaderMa
   }
 
   return true;
+}
+
+std::string CompressorFilter::getEnvoyCompressionStatusHeaderValue(
+    absl::string_view encoding_type, absl::string_view status_to_set,
+    absl::optional<absl::string_view> original_length) {
+  std::string status_value = std::string(encoding_type);
+  absl::StrAppend(&status_value, ";", status_to_set);
+  if (status_to_set == Http::Headers::get().EnvoyCompressionStatusValues.Compressed &&
+      original_length.has_value()) {
+    absl::StrAppend(&status_value, Http::Headers::get().EnvoyCompressionStatusValues.Separator,
+                    Http::Headers::get().EnvoyCompressionStatusValues.OriginalLengthPrefix,
+                    *original_length);
+  }
+  return status_value;
+}
+
+void CompressorFilter::insertEnvoyCompressionStatusHeader(
+    Http::ResponseHeaderMap& headers, absl::string_view encoding_type,
+    absl::string_view status_to_set, absl::optional<absl::string_view> original_length) {
+  std::string status_value =
+      getEnvoyCompressionStatusHeaderValue(encoding_type, status_to_set, original_length);
+  const Http::HeaderEntry* compression_status =
+      headers.getInline(compression_status_handle.handle());
+  if (compression_status != nullptr) {
+    std::string new_header;
+    absl::StrAppend(&new_header, compression_status->value().getStringView(),
+                    Http::Headers::get().EnvoyCompressionStatusValues.ValueSeparator, status_value);
+    headers.setInline(compression_status_handle.handle(), new_header);
+  } else {
+    headers.setInline(compression_status_handle.handle(), status_value);
+  }
 }
 
 void CompressorFilter::insertVaryHeader(Http::ResponseHeaderMap& headers) {

--- a/source/extensions/filters/http/compressor/compressor_filter.h
+++ b/source/extensions/filters/http/compressor/compressor_filter.h
@@ -201,16 +201,29 @@ public:
   Http::FilterTrailersStatus encodeTrailers(Http::ResponseTrailerMap&) override;
 
 private:
+  Http::FilterHeadersStatus
+  encodeHeadersWithStatusHeader(Http::ResponseHeaderMap& headers, bool end_stream,
+                                const CompressorFilterConfig::ResponseDirectionConfig& config,
+                                const CompressorPerRouteFilterConfig* per_route_config);
   bool compressionEnabled(const CompressorFilterConfig::ResponseDirectionConfig& config,
                           const CompressorPerRouteFilterConfig* per_route_config) const;
   bool removeAcceptEncodingHeader(const CompressorFilterConfig::ResponseDirectionConfig& config,
                                   const CompressorPerRouteFilterConfig* per_route_config) const;
   bool hasCacheControlNoTransform(Http::ResponseHeaderMap& headers) const;
   bool isAcceptEncodingAllowed(bool maybe_compress, const Http::ResponseHeaderMap& headers) const;
+  bool isAcceptEncodingAllowed(const Http::ResponseHeaderMap& headers) const;
+  bool checkIsEtagAllowedLogResponseStats(Http::ResponseHeaderMap& headers) const;
   bool isEtagAllowed(Http::ResponseHeaderMap& headers) const;
   bool isTransferEncodingAllowed(Http::RequestOrResponseHeaderMap& headers) const;
 
   void sanitizeEtagHeader(Http::ResponseHeaderMap& headers);
+  std::string getEnvoyCompressionStatusHeaderValue(
+      absl::string_view encoding_type, absl::string_view status_to_set,
+      absl::optional<absl::string_view> original_length = std::nullopt);
+  void insertEnvoyCompressionStatusHeader(
+      Http::ResponseHeaderMap& headers, absl::string_view encoding_type,
+      absl::string_view status_to_set,
+      absl::optional<absl::string_view> original_length = std::nullopt);
   void insertVaryHeader(Http::ResponseHeaderMap& headers);
 
   class EncodingDecision : public StreamInfo::FilterState::Object {

--- a/test/extensions/filters/http/compressor/compressor_filter_integration_test.cc
+++ b/test/extensions/filters/http/compressor/compressor_filter_integration_test.cc
@@ -15,13 +15,19 @@ namespace Envoy {
 using Envoy::Protobuf::Any;
 using Envoy::Protobuf::MapPair;
 
-class CompressorIntegrationTest : public testing::TestWithParam<Network::Address::IpVersion>,
-                                  public Event::SimulatedTimeSystem,
-                                  public HttpIntegrationTest {
+class CompressorIntegrationTest
+    : public testing::TestWithParam<std::tuple<Network::Address::IpVersion, bool>>,
+      public Event::SimulatedTimeSystem,
+      public HttpIntegrationTest {
 public:
-  CompressorIntegrationTest() : HttpIntegrationTest(Http::CodecType::HTTP1, GetParam()) {}
+  CompressorIntegrationTest()
+      : HttpIntegrationTest(Http::CodecType::HTTP1, std::get<0>(GetParam())) {}
 
-  void SetUp() override { decompressor_.init(window_bits); }
+  void SetUp() override {
+    Runtime::maybeSetRuntimeGuard("envoy.reloadable_features.compressor_add_status_header",
+                                  std::get<1>(GetParam()));
+    decompressor_.init(window_bits);
+  }
   void TearDown() override { cleanupUpstreamAndDownstream(); }
 
   void initializeFilter(const std::string& config) {
@@ -156,9 +162,13 @@ public:
       *stats_store_.rootScope(), "test", 4096, 100};
 };
 
-INSTANTIATE_TEST_SUITE_P(IpVersions, CompressorIntegrationTest,
-                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
-                         TestUtility::ipTestParamsToString);
+INSTANTIATE_TEST_SUITE_P(
+    IpVersions, CompressorIntegrationTest,
+    testing::Combine(testing::ValuesIn(TestEnvironment::getIpVersionsForTest()), testing::Bool()),
+    [](const testing::TestParamInfo<std::tuple<Network::Address::IpVersion, bool>>& params) {
+      return fmt::format("{}_{}", TestUtility::ipVersionToString(std::get<0>(params.param)),
+                         std::get<1>(params.param) ? "WithStatusHeader" : "NoStatusHeader");
+    });
 
 /**
  * Exercises gzip compression with default configuration.
@@ -491,6 +501,163 @@ TEST_P(CompressorIntegrationTest, PerRouteEnable) {
                           Http::TestResponseHeaderMapImpl{{":status", "200"},
                                                           {"content-length", "40"},
                                                           {"content-type", "text/xml"}});
+}
+
+/**
+ * Test suite for cases where the envoy.reloadable_features.compressor_add_status_header flag is
+ * explicitly set to true.
+ */
+class CompressorIntegrationTestWithStatusHeader : public CompressorIntegrationTest {};
+
+INSTANTIATE_TEST_SUITE_P(
+    IpVersions, CompressorIntegrationTestWithStatusHeader,
+    testing::Combine(testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+                     testing::Values(true)),
+    [](const testing::TestParamInfo<std::tuple<Network::Address::IpVersion, bool>>& params) {
+      return fmt::format("{}_{}", TestUtility::ipVersionToString(std::get<0>(params.param)),
+                         "WithStatusHeader");
+    });
+
+/**
+ * Exercises filter when upstream responds with content length below the default threshold.
+ */
+TEST_P(CompressorIntegrationTestWithStatusHeader, EnvoyCompressionStatusContentLengthTooSmall) {
+  initializeFilter(default_config);
+  Http::TestRequestHeaderMapImpl request_headers{{":method", "GET"},
+                                                 {":path", "/test/long/url"},
+                                                 {":scheme", "http"},
+                                                 {":authority", "host"},
+                                                 {"accept-encoding", "deflate, gzip"}};
+
+  Http::TestResponseHeaderMapImpl response_headers{
+      {":status", "200"}, {"content-length", "10"}, {"content-type", "application/json"}};
+
+  auto response = sendRequestAndWaitForResponse(request_headers, 0, response_headers, 10);
+
+  EXPECT_TRUE(upstream_request_->complete());
+  EXPECT_EQ(0U, upstream_request_->bodyLength());
+  EXPECT_TRUE(response->complete());
+  EXPECT_EQ("200", response->headers().getStatusValue());
+  ASSERT_TRUE(response->headers().get(Http::CustomHeaders::get().ContentEncoding).empty());
+  EXPECT_EQ(10U, response->body().size());
+  EXPECT_EQ("gzip;ContentLengthTooSmall", response->headers()
+                                              .get(Http::Headers::get().EnvoyCompressionStatus)[0]
+                                              ->value()
+                                              .getStringView());
+}
+
+/**
+ * Exercises filter when upstream responds with restricted content-type value.
+ */
+TEST_P(CompressorIntegrationTestWithStatusHeader, EnvoyCompressionStatusContentTypeNotAllowed) {
+  initializeFilter(full_config);
+  Http::TestRequestHeaderMapImpl request_headers{{":method", "GET"},
+                                                 {":path", "/test/long/url"},
+                                                 {":scheme", "http"},
+                                                 {":authority", "host"},
+                                                 {"accept-encoding", "deflate, gzip"}};
+  Http::TestResponseHeaderMapImpl response_headers{
+      {":status", "200"}, {"content-length", "128"}, {"content-type", "application/xml"}};
+
+  auto response = sendRequestAndWaitForResponse(request_headers, 0, response_headers, 128);
+
+  EXPECT_TRUE(upstream_request_->complete());
+  EXPECT_EQ(0U, upstream_request_->bodyLength());
+  EXPECT_TRUE(response->complete());
+  EXPECT_EQ("200", response->headers().getStatusValue());
+  ASSERT_TRUE(response->headers().get(Http::CustomHeaders::get().ContentEncoding).empty());
+  EXPECT_EQ(128U, response->body().size());
+  EXPECT_EQ("gzip;ContentTypeNotAllowed", response->headers()
+                                              .get(Http::Headers::get().EnvoyCompressionStatus)[0]
+                                              ->value()
+                                              .getStringView());
+}
+
+/**
+ * Exercises filter when upstream responds with an ETag header and disable_on_etag_header is true.
+ */
+TEST_P(CompressorIntegrationTestWithStatusHeader, EnvoyCompressionStatusEtagNotAllowed) {
+  initializeFilter(full_config);
+  Http::TestRequestHeaderMapImpl request_headers{{":method", "GET"},
+                                                 {":path", "/test/long/url"},
+                                                 {":scheme", "http"},
+                                                 {":authority", "host"},
+                                                 {"accept-encoding", "deflate, gzip"}};
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "200"},
+                                                   {"content-length", "128"},
+                                                   {"etag", "12345"},
+                                                   {"content-type", "application/json"}};
+
+  auto response = sendRequestAndWaitForResponse(request_headers, 0, response_headers, 128);
+
+  EXPECT_TRUE(upstream_request_->complete());
+  EXPECT_EQ(0U, upstream_request_->bodyLength());
+  EXPECT_TRUE(response->complete());
+  EXPECT_EQ("200", response->headers().getStatusValue());
+  ASSERT_TRUE(response->headers().get(Http::CustomHeaders::get().ContentEncoding).empty());
+  EXPECT_EQ(128U, response->body().size());
+  EXPECT_EQ("gzip;EtagNotAllowed", response->headers()
+                                       .get(Http::Headers::get().EnvoyCompressionStatus)[0]
+                                       ->value()
+                                       .getStringView());
+}
+
+/**
+ * Exercises filter when upstream responds with restricted response code value.
+ */
+TEST_P(CompressorIntegrationTestWithStatusHeader, EnvoyCompressionStatusStatusCodeNotAllowed) {
+  initializeFilter(full_config);
+  Http::TestRequestHeaderMapImpl request_headers{
+      {":method", "GET"},     {":path", "/test/long/url"},          {":scheme", "http"},
+      {":authority", "host"}, {"accept-encoding", "deflate, gzip"}, {"range", "bytes=100-227"}};
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "206"},
+                                                   {"content-length", "128"},
+                                                   {"content-range", "bytes=100-227/567"},
+                                                   {"content-type", "application/json"}};
+
+  auto response = sendRequestAndWaitForResponse(request_headers, 0, response_headers, 128);
+
+  EXPECT_TRUE(upstream_request_->complete());
+  EXPECT_EQ(0U, upstream_request_->bodyLength());
+  EXPECT_TRUE(response->complete());
+  EXPECT_EQ("206", response->headers().getStatusValue());
+  ASSERT_TRUE(response->headers().get(Http::CustomHeaders::get().ContentEncoding).empty());
+  EXPECT_EQ(128U, response->body().size());
+  EXPECT_EQ("gzip;StatusCodeNotAllowed", response->headers()
+                                             .get(Http::Headers::get().EnvoyCompressionStatus)[0]
+                                             ->value()
+                                             .getStringView());
+}
+
+/**
+ * Exercises gzip compression with full configuration and checks for the EnvoyCompressionStatus
+ * header.
+ */
+TEST_P(CompressorIntegrationTestWithStatusHeader, EnvoyCompressionStatusCompressed) {
+  initializeFilter(full_config);
+  Http::TestRequestHeaderMapImpl request_headers{{":method", "GET"},
+                                                 {":path", "/test/long/url"},
+                                                 {":scheme", "http"},
+                                                 {":authority", "host"},
+                                                 {"accept-encoding", "deflate, gzip"}};
+  Http::TestResponseHeaderMapImpl response_headers{
+      {":status", "200"}, {"content-length", "4400"}, {"content-type", "application/json"}};
+
+  auto response = sendRequestAndWaitForResponse(request_headers, 0, response_headers, 4400);
+
+  EXPECT_TRUE(upstream_request_->complete());
+  EXPECT_EQ(0U, upstream_request_->bodyLength());
+  EXPECT_TRUE(response->complete());
+  EXPECT_EQ("200", response->headers().getStatusValue());
+  EXPECT_EQ("gzip", response->headers()
+                        .get(Http::CustomHeaders::get().ContentEncoding)[0]
+                        ->value()
+                        .getStringView());
+  EXPECT_EQ("gzip;Compressed;OriginalLength=4400",
+            response->headers()
+                .get(Http::Headers::get().EnvoyCompressionStatus)[0]
+                ->value()
+                .getStringView());
 }
 
 } // namespace Envoy

--- a/test/extensions/filters/http/compressor/compressor_filter_test.cc
+++ b/test/extensions/filters/http/compressor/compressor_filter_test.cc
@@ -191,29 +191,59 @@ public:
 enum class PerRouteConfig { None, Empty, Enabled, Disabled };
 
 struct EnablementParams {
+  bool compressor_add_status_header_enabled_;
   bool runtime_enabled_;
   PerRouteConfig per_route_enabled_;
   bool expect_compression_;
 };
 
 class CompresorFilterEnablementTest : public CompressorFilterTest,
-                                      public testing::WithParamInterface<EnablementParams> {};
+                                      public testing::WithParamInterface<EnablementParams> {
+  void SetUp() override {
+    CompressorFilterTest::SetUp();
+    Runtime::maybeSetRuntimeGuard("envoy.reloadable_features.compressor_add_status_header",
+                                  GetParam().compressor_add_status_header_enabled_);
+  };
+};
+
+class CompressorFilterWithStatusHeaderRuntimeFeatureTest
+    : public CompressorFilterTest,
+      public testing::WithParamInterface<bool> {
+  void SetUp() override {
+    CompressorFilterTest::SetUp();
+    Runtime::maybeSetRuntimeGuard("envoy.reloadable_features.compressor_add_status_header",
+                                  GetParam());
+  };
+};
 
 INSTANTIATE_TEST_SUITE_P(CompresorFilterEnablementTest, CompresorFilterEnablementTest,
                          testing::ValuesIn<EnablementParams>(
                              {// no per-route config, so runtime flag controls
-                              {true, PerRouteConfig::None, true},
-                              {false, PerRouteConfig::None, false},
+                              {false, true, PerRouteConfig::None, true},
+                              {false, false, PerRouteConfig::None, false},
                               // empty CompressorPerRoute.overrides, so runtime flag controls
-                              {true, PerRouteConfig::Empty, true},
-                              {false, PerRouteConfig::Empty, false},
+                              {false, true, PerRouteConfig::Empty, true},
+                              {false, false, PerRouteConfig::Empty, false},
                               // enabled by empty CompressorPerRoute.overrides.
                               // This must remain true no matter what fields ever get added.
-                              {true, PerRouteConfig::Enabled, true},
-                              {false, PerRouteConfig::Enabled, true},
+                              {false, true, PerRouteConfig::Enabled, true},
+                              {false, false, PerRouteConfig::Enabled, true},
                               // disabled by CompressorPerRoute.disabled
-                              {true, PerRouteConfig::Disabled, false},
-                              {false, PerRouteConfig::Disabled, false}}));
+                              {false, true, PerRouteConfig::Disabled, false},
+                              {false, false, PerRouteConfig::Disabled, false},
+                              // All configs below have compressor status header enabled
+                              {true, true, PerRouteConfig::None, true},
+                              {true, false, PerRouteConfig::None, false},
+                              // empty CompressorPerRoute.overrides, so runtime flag controls
+                              {true, true, PerRouteConfig::Empty, true},
+                              {true, false, PerRouteConfig::Empty, false},
+                              // enabled by empty CompressorPerRoute.overrides.
+                              // This must remain true no matter what fields ever get added.
+                              {true, true, PerRouteConfig::Enabled, true},
+                              {true, false, PerRouteConfig::Enabled, true},
+                              // disabled by CompressorPerRoute.disabled
+                              {true, true, PerRouteConfig::Disabled, false},
+                              {true, false, PerRouteConfig::Disabled, false}}));
 
 // common_config.enabled should enable/disable compression, unless a CompressorPerRoute config
 // overrides it.
@@ -276,117 +306,6 @@ TEST_F(CompressorFilterTest, DefaultConfigValues) {
   EXPECT_EQ(false, config_->responseDirectionConfig().removeAcceptEncodingHeader());
   EXPECT_EQ(20, config_->responseDirectionConfig().contentTypeValues().size());
   EXPECT_EQ(20, config_->requestDirectionConfig().contentTypeValues().size());
-}
-
-TEST_F(CompressorFilterTest, CompressRequest) {
-  setUpFilter(R"EOF(
-{
-  "request_direction_config": {},
-  "compressor_library": {
-     "name": "test",
-     "typed_config": {
-       "@type": "type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip"
-     }
-  }
-}
-)EOF");
-  doRequestCompression({{":method", "post"}, {"content-length", "256"}}, false);
-  Http::TestResponseHeaderMapImpl headers{{":method", "post"}, {"content-length", "256"}};
-  doResponseNoCompression(headers);
-}
-
-TEST_F(CompressorFilterTest, CompressRequestAndResponseNoContentLength) {
-  setUpFilter(R"EOF(
-{
-  "request_direction_config": {},
-  "response_direction_config": {},
-  "compressor_library": {
-     "name": "test",
-     "typed_config": {
-       "@type": "type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip"
-     }
-  }
-}
-)EOF");
-  response_stats_prefix_ = "response.";
-  doRequestCompression({{":method", "post"}, {"accept-encoding", "deflate, test"}}, false);
-  Http::TestResponseHeaderMapImpl headers{{":status", "200"}};
-  doResponseCompression(headers, false);
-}
-
-TEST_F(CompressorFilterTest, CompressRequestWithTrailers) {
-  setUpFilter(R"EOF(
-{
-  "request_direction_config": {},
-  "compressor_library": {
-     "name": "test",
-     "typed_config": {
-       "@type": "type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip"
-     }
-  }
-}
-)EOF");
-  compressor_factory_->setExpectedCompressCalls(2);
-  doRequestCompression({{":method", "post"}, {"content-length", "256"}}, true);
-  Http::TestResponseHeaderMapImpl headers{{":method", "post"}, {"content-length", "256"}};
-  doResponseNoCompression(headers);
-}
-
-// Acceptance Testing with default configuration.
-TEST_F(CompressorFilterTest, AcceptanceTestEncoding) {
-  doRequestNoCompression({{":method", "get"}, {"accept-encoding", "deflate, test"}});
-
-  Http::TestResponseHeaderMapImpl headers{{":method", "get"}, {"content-length", "256"}};
-  doResponseCompression(headers, false);
-}
-
-TEST_F(CompressorFilterTest, AcceptanceTestEncodingWithTrailers) {
-  doRequestNoCompression({{":method", "get"}, {"accept-encoding", "deflate, test"}});
-  Http::TestResponseHeaderMapImpl headers{{":method", "get"}, {"content-length", "256"}};
-  compressor_factory_->setExpectedCompressCalls(2);
-  doResponseCompression(headers, true);
-}
-
-TEST_F(CompressorFilterTest, NoAcceptEncodingHeader) {
-  doRequestNoCompression({{":method", "get"}, {}});
-  Http::TestResponseHeaderMapImpl headers{{":method", "get"}, {"content-length", "256"}};
-  doResponseNoCompression(headers);
-  EXPECT_EQ(1, stats_.counter("test.compressor.test.test.no_accept_header").value());
-  EXPECT_EQ("Accept-Encoding", headers.get_("vary"));
-}
-
-TEST_F(CompressorFilterTest, NoAcceptEncodingAndMinmunContentLength) {
-  doRequestNoCompression({{":method", "get"}, {}});
-  Http::TestResponseHeaderMapImpl headers{{":method", "get"}, {"content-length", "15"}};
-  doResponseNoCompression(headers);
-  EXPECT_EQ(0, stats_.counter("test.compressor.test.test.no_accept_header").value());
-  EXPECT_EQ("", headers.get_("vary"));
-}
-
-TEST_F(CompressorFilterTest, NoAcceptEncodingAndCompressionDisabled) {
-  setUpFilter(R"EOF(
-{
-  "response_direction_config": {
-    "common_config": {
-      "enabled": {
-        "default_value": false,
-      }
-    }
-  },
-  "compressor_library": {
-     "name": "test",
-     "typed_config": {
-       "@type": "type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip"
-     }
-  }
-}
-)EOF");
-  response_stats_prefix_ = "response.";
-  doRequestNoCompression({{":method", "get"}, {}});
-  Http::TestResponseHeaderMapImpl headers{{":method", "get"}, {"content-length", "256"}};
-  doResponseNoCompression(headers);
-  EXPECT_EQ(0, stats_.counter("test.compressor.test.test.no_accept_header").value());
-  EXPECT_EQ("", headers.get_("vary"));
 }
 
 TEST_F(CompressorFilterTest, CacheIdentityDecision) {
@@ -634,6 +553,121 @@ TEST_F(CompressorFilterTest, RemoveAcceptEncodingHeader) {
   }
 }
 
+INSTANTIATE_TEST_SUITE_P(CompressorFilterWithStatusHeaderRuntimeFeatureTestSuite,
+                         CompressorFilterWithStatusHeaderRuntimeFeatureTest, testing::Bool());
+
+TEST_P(CompressorFilterWithStatusHeaderRuntimeFeatureTest, CompressRequest) {
+  setUpFilter(R"EOF(
+{
+  "request_direction_config": {},
+  "compressor_library": {
+     "name": "test",
+     "typed_config": {
+       "@type": "type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip"
+     }
+  }
+}
+)EOF");
+  doRequestCompression({{":method", "post"}, {"content-length", "256"}}, false);
+  Http::TestResponseHeaderMapImpl headers{{":method", "post"}, {"content-length", "256"}};
+  doResponseNoCompression(headers);
+}
+
+TEST_P(CompressorFilterWithStatusHeaderRuntimeFeatureTest,
+       CompressRequestAndResponseNoContentLength) {
+  setUpFilter(R"EOF(
+{
+  "request_direction_config": {},
+  "response_direction_config": {},
+  "compressor_library": {
+     "name": "test",
+     "typed_config": {
+       "@type": "type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip"
+     }
+  }
+}
+)EOF");
+  response_stats_prefix_ = "response.";
+  doRequestCompression({{":method", "post"}, {"accept-encoding", "deflate, test"}}, false);
+  Http::TestResponseHeaderMapImpl headers{{":status", "200"}};
+  doResponseCompression(headers, false);
+}
+
+TEST_P(CompressorFilterWithStatusHeaderRuntimeFeatureTest, CompressRequestWithTrailers) {
+  setUpFilter(R"EOF(
+{
+  "request_direction_config": {},
+  "compressor_library": {
+     "name": "test",
+     "typed_config": {
+       "@type": "type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip"
+     }
+  }
+}
+)EOF");
+  compressor_factory_->setExpectedCompressCalls(2);
+  doRequestCompression({{":method", "post"}, {"content-length", "256"}}, true);
+  Http::TestResponseHeaderMapImpl headers{{":method", "post"}, {"content-length", "256"}};
+  doResponseNoCompression(headers);
+}
+
+// Acceptance Testing with default configuration.
+TEST_P(CompressorFilterWithStatusHeaderRuntimeFeatureTest, AcceptanceTestEncoding) {
+  doRequestNoCompression({{":method", "get"}, {"accept-encoding", "deflate, test"}});
+
+  Http::TestResponseHeaderMapImpl headers{{":method", "get"}, {"content-length", "256"}};
+  doResponseCompression(headers, false);
+}
+
+TEST_P(CompressorFilterWithStatusHeaderRuntimeFeatureTest, AcceptanceTestEncodingWithTrailers) {
+  doRequestNoCompression({{":method", "get"}, {"accept-encoding", "deflate, test"}});
+  Http::TestResponseHeaderMapImpl headers{{":method", "get"}, {"content-length", "256"}};
+  compressor_factory_->setExpectedCompressCalls(2);
+  doResponseCompression(headers, true);
+}
+
+TEST_P(CompressorFilterWithStatusHeaderRuntimeFeatureTest, NoAcceptEncodingHeader) {
+  doRequestNoCompression({{":method", "get"}, {}});
+  Http::TestResponseHeaderMapImpl headers{{":method", "get"}, {"content-length", "256"}};
+  doResponseNoCompression(headers);
+  EXPECT_EQ(1, stats_.counter("test.compressor.test.test.no_accept_header").value());
+  EXPECT_EQ("Accept-Encoding", headers.get_("vary"));
+}
+
+TEST_P(CompressorFilterWithStatusHeaderRuntimeFeatureTest, NoAcceptEncodingAndMinmunContentLength) {
+  doRequestNoCompression({{":method", "get"}, {}});
+  Http::TestResponseHeaderMapImpl headers{{":method", "get"}, {"content-length", "15"}};
+  doResponseNoCompression(headers);
+  EXPECT_EQ(0, stats_.counter("test.compressor.test.test.no_accept_header").value());
+  EXPECT_EQ("", headers.get_("vary"));
+}
+
+TEST_P(CompressorFilterWithStatusHeaderRuntimeFeatureTest, NoAcceptEncodingAndCompressionDisabled) {
+  setUpFilter(R"EOF(
+{
+  "response_direction_config": {
+    "common_config": {
+      "enabled": {
+        "default_value": false,
+      }
+    }
+  },
+  "compressor_library": {
+     "name": "test",
+     "typed_config": {
+       "@type": "type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip"
+     }
+  }
+}
+)EOF");
+  response_stats_prefix_ = "response.";
+  doRequestNoCompression({{":method", "get"}, {}});
+  Http::TestResponseHeaderMapImpl headers{{":method", "get"}, {"content-length", "256"}};
+  doResponseNoCompression(headers);
+  EXPECT_EQ(0, stats_.counter("test.compressor.test.test.no_accept_header").value());
+  EXPECT_EQ("", headers.get_("vary"));
+}
+
 class IsAcceptEncodingAllowedTest
     : public CompressorFilterTest,
       public testing::WithParamInterface<std::tuple<std::string, bool, int, int, int, int>> {};
@@ -665,6 +699,29 @@ INSTANTIATE_TEST_SUITE_P(
                     std::make_tuple("test;q=invalid", false, 0, 0, 1, 0)));
 
 TEST_P(IsAcceptEncodingAllowedTest, Validate) {
+  Runtime::maybeSetRuntimeGuard("envoy.reloadable_features.compressor_add_status_header", true);
+  const std::string& accept_encoding = std::get<0>(GetParam());
+  const bool is_compression_expected = std::get<1>(GetParam());
+  const int compressor_used = std::get<2>(GetParam());
+  const int wildcard = std::get<3>(GetParam());
+  const int not_valid = std::get<4>(GetParam());
+  const int identity = std::get<5>(GetParam());
+
+  doRequestNoCompression({{":method", "get"}, {"accept-encoding", accept_encoding}});
+  Http::TestResponseHeaderMapImpl headers{{":method", "get"}, {"content-length", "256"}};
+  doResponse(headers, is_compression_expected, false);
+  EXPECT_EQ(compressor_used,
+            stats_.counter("test.compressor.test.test.header_compressor_used").value());
+  EXPECT_EQ(wildcard, stats_.counter("test.compressor.test.test.header_wildcard").value());
+  EXPECT_EQ(not_valid, stats_.counter("test.compressor.test.test.header_not_valid").value());
+  EXPECT_EQ(identity, stats_.counter("test.compressor.test.test.header_identity").value());
+  // Even if compression is disallowed by a client we must let her know the resource is
+  // compressible.
+  EXPECT_EQ("Accept-Encoding", headers.get_("vary"));
+}
+
+TEST_P(IsAcceptEncodingAllowedTest, ValidateForCompressionHeaderFeatureEnabled) {
+  Runtime::maybeSetRuntimeGuard("envoy.reloadable_features.compressor_add_status_header", false);
   const std::string& accept_encoding = std::get<0>(GetParam());
   const bool is_compression_expected = std::get<1>(GetParam());
   const int compressor_used = std::get<2>(GetParam());
@@ -714,6 +771,7 @@ INSTANTIATE_TEST_SUITE_P(
         std::make_tuple("test/insensitive", true, true)));
 
 TEST_P(IsContentTypeAllowedTest, Validate) {
+  Runtime::maybeSetRuntimeGuard("envoy.reloadable_features.compressor_add_status_header", false);
   const std::string& content_type = std::get<0>(GetParam());
   const bool should_compress = std::get<1>(GetParam());
   const bool is_custom_config = std::get<2>(GetParam());
@@ -740,8 +798,37 @@ TEST_P(IsContentTypeAllowedTest, Validate) {
   Http::TestResponseHeaderMapImpl headers{
       {":method", "get"}, {"content-length", "256"}, {"content-type", content_type}};
   doResponse(headers, should_compress, false);
-  EXPECT_EQ(should_compress ? 0 : 1,
-            stats_.counter("test.compressor.test.test.header_not_valid").value());
+  EXPECT_EQ(should_compress, headers.has("vary"));
+}
+
+TEST_P(IsContentTypeAllowedTest, ValidateForCompressionHeaderFeatureEnabled) {
+  Runtime::maybeSetRuntimeGuard("envoy.reloadable_features.compressor_add_status_header", true);
+  const std::string& content_type = std::get<0>(GetParam());
+  const bool should_compress = std::get<1>(GetParam());
+  const bool is_custom_config = std::get<2>(GetParam());
+
+  if (is_custom_config) {
+    setUpFilter(R"EOF(
+      {
+        "content_type": [
+          "text/html",
+          "xyz/svg+xml",
+          "Test/INSENSITIVE"
+        ],
+    "compressor_library": {
+       "name": "test",
+       "typed_config": {
+         "@type": "type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip"
+       }
+    }
+      }
+    )EOF");
+  }
+
+  doRequestNoCompression({{":method", "get"}, {"accept-encoding", "test, deflate"}});
+  Http::TestResponseHeaderMapImpl headers{
+      {":method", "get"}, {"content-length", "256"}, {"content-type", content_type}};
+  doResponse(headers, should_compress, false);
   EXPECT_EQ(should_compress, headers.has("vary"));
 }
 
@@ -762,6 +849,46 @@ INSTANTIATE_TEST_SUITE_P(
                     std::make_tuple(200, true, true, std::vector<uint32_t>{404, 206})));
 
 TEST_P(IsResponseCodeAllowedTest, Validate) {
+  Runtime::maybeSetRuntimeGuard("envoy.reloadable_features.compressor_add_status_header", false);
+  const uint32_t response_code = std::get<0>(GetParam());
+  const bool should_compress = std::get<1>(GetParam());
+  const bool is_custom_config = std::get<2>(GetParam());
+  const std::vector<uint32_t>& uncompressible_response_codes = std::get<3>(GetParam());
+
+  if (is_custom_config) {
+    setUpFilter(fmt::format(R"EOF(
+    {{
+      "response_direction_config": {{
+        "common_config": {{
+          "enabled": {{
+            "default_value": true,
+          }},
+        }},
+        "uncompressible_response_codes": [
+          {}
+        ]
+      }},
+      "compressor_library": {{
+        "name": "test",
+        "typed_config": {{
+          "@type": "type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip"
+        }}
+      }}
+    }})EOF",
+                            absl::StrJoin(uncompressible_response_codes, ", ")));
+    response_stats_prefix_ = "response.";
+  }
+
+  doRequestNoCompression({{":method", "get"}, {"accept-encoding", "test, deflate"}});
+  Http::TestResponseHeaderMapImpl headers{
+      {":method", "get"}, {"content-length", "256"}, {":status", std::to_string(response_code)}};
+  doResponse(headers, should_compress);
+
+  EXPECT_EQ(should_compress, headers.has("vary"));
+}
+
+TEST_P(IsResponseCodeAllowedTest, ValidateForCompressionHeaderFeatureEnabled) {
+  Runtime::maybeSetRuntimeGuard("envoy.reloadable_features.compressor_add_status_header", true);
   const uint32_t response_code = std::get<0>(GetParam());
   const bool should_compress = std::get<1>(GetParam());
   const bool is_custom_config = std::get<2>(GetParam());
@@ -801,19 +928,26 @@ TEST_P(IsResponseCodeAllowedTest, Validate) {
 
 class CompressWithEtagTest
     : public CompressorFilterTest,
-      public testing::WithParamInterface<std::tuple<std::string, std::string, bool>> {};
+      public testing::WithParamInterface<std::tuple<std::string, std::string, bool, bool>> {};
 
 INSTANTIATE_TEST_SUITE_P(
     CompressWithEtagSuite, CompressWithEtagTest,
-    testing::Values(std::make_tuple("etag", R"EOF(W/"686897696a7c876b7e")EOF", true),
-                    std::make_tuple("etag", R"EOF(w/"686897696a7c876b7e")EOF", true),
-                    std::make_tuple("etag", "686897696a7c876b7e", false),
-                    std::make_tuple("x-garbage", "garbagevalue", false)));
+    testing::Values(std::make_tuple("etag", R"EOF(W/"686897696a7c876b7e")EOF", true, true),
+                    std::make_tuple("etag", R"EOF(w/"686897696a7c876b7e")EOF", true, true),
+                    std::make_tuple("etag", "686897696a7c876b7e", false, true),
+                    std::make_tuple("x-garbage", "garbagevalue", false, true),
+                    std::make_tuple("etag", R"EOF(W/"686897696a7c876b7e")EOF", true, false),
+                    std::make_tuple("etag", R"EOF(w/"686897696a7c876b7e")EOF", true, false),
+                    std::make_tuple("etag", "686897696a7c876b7e", false, false),
+                    std::make_tuple("x-garbage", "garbagevalue", false, false)));
 
 TEST_P(CompressWithEtagTest, CompressionIsEnabledOnEtag) {
   const std::string& header_name = std::get<0>(GetParam());
   const std::string& header_value = std::get<1>(GetParam());
   const bool is_weak_etag = std::get<2>(GetParam());
+  const bool is_compressor_add_status_header_enabled = std::get<3>(GetParam());
+  Runtime::maybeSetRuntimeGuard("envoy.reloadable_features.compressor_add_status_header",
+                                is_compressor_add_status_header_enabled);
 
   doRequestNoCompression({{":method", "get"}, {"accept-encoding", "test, deflate"}});
   Http::TestResponseHeaderMapImpl headers{
@@ -831,6 +965,9 @@ TEST_P(CompressWithEtagTest, CompressionIsEnabledOnEtag) {
 TEST_P(CompressWithEtagTest, CompressionIsDisabledOnEtag) {
   const std::string& header_name = std::get<0>(GetParam());
   const std::string& header_value = std::get<1>(GetParam());
+  const bool is_compressor_add_status_header_enabled = std::get<3>(GetParam());
+  Runtime::maybeSetRuntimeGuard("envoy.reloadable_features.compressor_add_status_header",
+                                is_compressor_add_status_header_enabled);
 
   setUpFilter(R"EOF(
 {
@@ -863,22 +1000,100 @@ TEST_P(CompressWithEtagTest, CompressionIsDisabledOnEtag) {
 
 class HasCacheControlNoTransformTest
     : public CompressorFilterTest,
-      public testing::WithParamInterface<std::tuple<std::string, bool>> {};
+      public testing::WithParamInterface<std::tuple<std::string, bool, bool>> {};
 
 INSTANTIATE_TEST_SUITE_P(HasCacheControlNoTransformTestSuite, HasCacheControlNoTransformTest,
-                         testing::Values(std::make_tuple("no-cache", true),
-                                         std::make_tuple("no-transform", false),
-                                         std::make_tuple("No-Transform", false)));
+                         testing::Values(std::make_tuple("no-cache", true, true),
+                                         std::make_tuple("no-transform", false, true),
+                                         std::make_tuple("No-Transform", false, true),
+                                         std::make_tuple("no-cache", true, false),
+                                         std::make_tuple("no-transform", false, false),
+                                         std::make_tuple("No-Transform", false, false)));
 
 TEST_P(HasCacheControlNoTransformTest, Validate) {
   const std::string& cache_control = std::get<0>(GetParam());
   const bool is_compression_expected = std::get<1>(GetParam());
+  const bool is_compressor_add_status_header_enabled = std::get<2>(GetParam());
+  Runtime::maybeSetRuntimeGuard("envoy.reloadable_features.compressor_add_status_header",
+                                is_compressor_add_status_header_enabled);
 
   doRequestNoCompression({{":method", "get"}, {"accept-encoding", "test, deflate"}});
   Http::TestResponseHeaderMapImpl headers{
       {":method", "get"}, {"content-length", "256"}, {"cache-control", cache_control}};
   doResponse(headers, is_compression_expected, false);
   EXPECT_EQ(is_compression_expected, headers.has("vary"));
+}
+
+TEST_F(CompressorFilterTest, EnvoyCompressionStatusHeaderContentLength) {
+  Runtime::maybeSetRuntimeGuard("envoy.reloadable_features.compressor_add_status_header", true);
+  doRequestNoCompression({{":method", "get"}, {"accept-encoding", "test, deflate"}});
+  Http::TestResponseHeaderMapImpl headers{{":method", "get"}, {"content-length", "10"}};
+  doResponse(headers, false, false);
+  EXPECT_EQ(headers.get_("x-envoy-compression-status"), "test;ContentLengthTooSmall");
+}
+
+TEST_F(CompressorFilterTest, EnvoyCompressionStatusHeaderContentType) {
+  Runtime::maybeSetRuntimeGuard("envoy.reloadable_features.compressor_add_status_header", true);
+  doRequestNoCompression({{":method", "get"}, {"accept-encoding", "test, deflate"}});
+  Http::TestResponseHeaderMapImpl headers{
+      {":method", "get"}, {"content-length", "256"}, {"content-type", "image/jpeg"}};
+  doResponse(headers, false, false);
+  EXPECT_EQ(headers.get_("x-envoy-compression-status"), "test;ContentTypeNotAllowed");
+}
+
+TEST_F(CompressorFilterTest, EnvoyCompressionStatusHeaderEtag) {
+  Runtime::maybeSetRuntimeGuard("envoy.reloadable_features.compressor_add_status_header", true);
+  setUpFilter(R"EOF(
+{
+  "disable_on_etag_header": true,
+  "compressor_library": {
+     "name": "test",
+     "typed_config": {
+       "@type": "type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip"
+     }
+  }
+}
+)EOF");
+
+  doRequestNoCompression({{":method", "get"}, {"accept-encoding", "test, deflate"}});
+  Http::TestResponseHeaderMapImpl headers{
+      {":method", "get"}, {"content-length", "256"}, {"etag", "12345"}};
+  doResponse(headers, false, false);
+  EXPECT_EQ(headers.get_("x-envoy-compression-status"), "test;EtagNotAllowed");
+}
+
+TEST_F(CompressorFilterTest, EnvoyCompressionStatusHeaderStatusCode) {
+  Runtime::maybeSetRuntimeGuard("envoy.reloadable_features.compressor_add_status_header", true);
+  setUpFilter(R"EOF(
+{
+  "response_direction_config": {
+    "uncompressible_response_codes": [
+      206
+    ]
+  },
+  "compressor_library": {
+     "name": "test",
+     "typed_config": {
+       "@type": "type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip"
+     }
+  }
+}
+)EOF");
+  response_stats_prefix_ = "response.";
+
+  doRequestNoCompression({{":method", "get"}, {"accept-encoding", "test, deflate"}});
+  Http::TestResponseHeaderMapImpl headers{
+      {":method", "get"}, {"content-length", "256"}, {":status", "206"}};
+  doResponse(headers, false, false);
+  EXPECT_EQ(headers.get_("x-envoy-compression-status"), "test;StatusCodeNotAllowed");
+}
+
+TEST_F(CompressorFilterTest, EnvoyCompressionStatusHeaderCompressed) {
+  Runtime::maybeSetRuntimeGuard("envoy.reloadable_features.compressor_add_status_header", true);
+  doRequestNoCompression({{":method", "get"}, {"accept-encoding", "test, deflate"}});
+  Http::TestResponseHeaderMapImpl headers{{":method", "get"}, {"content-length", "256"}};
+  doResponse(headers, true, false);
+  EXPECT_EQ(headers.get_("x-envoy-compression-status"), "test;Compressed;OriginalLength=256");
 }
 
 class IsMinimumContentLengthTest
@@ -895,6 +1110,33 @@ INSTANTIATE_TEST_SUITE_P(
                     std::make_tuple("content-length", "499", "\"content_length\": 500,", false)));
 
 TEST_P(IsMinimumContentLengthTest, Validate) {
+  Runtime::maybeSetRuntimeGuard("envoy.reloadable_features.compressor_add_status_header", false);
+  const std::string& header_name = std::get<0>(GetParam());
+  const std::string& header_value = std::get<1>(GetParam());
+  const std::string& content_length_config = std::get<2>(GetParam());
+  const bool is_compression_expected = std::get<3>(GetParam());
+
+  setUpFilter(fmt::format(R"EOF(
+{{
+  {}
+  "compressor_library": {{
+     "name": "test",
+     "typed_config": {{
+       "@type": "type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip"
+     }}
+  }}
+}}
+)EOF",
+                          content_length_config));
+
+  doRequestNoCompression({{":method", "get"}, {"accept-encoding", "test, deflate"}});
+  Http::TestResponseHeaderMapImpl headers{{":method", "get"}, {header_name, header_value}};
+  doResponse(headers, is_compression_expected, false);
+  EXPECT_EQ(is_compression_expected, headers.has("vary"));
+}
+
+TEST_P(IsMinimumContentLengthTest, ValidateForCompressionHeaderFeatureEnabled) {
+  Runtime::maybeSetRuntimeGuard("envoy.reloadable_features.compressor_add_status_header", true);
   const std::string& header_name = std::get<0>(GetParam());
   const std::string& header_value = std::get<1>(GetParam());
   const std::string& content_length_config = std::get<2>(GetParam());
@@ -934,6 +1176,20 @@ INSTANTIATE_TEST_SUITE_P(
                     std::make_tuple("x-garbage", "no_value", true)));
 
 TEST_P(IsTransferEncodingAllowedTest, Validate) {
+  Runtime::maybeSetRuntimeGuard("envoy.reloadable_features.compressor_add_status_header", false);
+  const std::string& header_name = std::get<0>(GetParam());
+  const std::string& header_value = std::get<1>(GetParam());
+  const bool is_compression_expected = std::get<2>(GetParam());
+
+  doRequestNoCompression({{":method", "get"}, {"accept-encoding", "test"}});
+  Http::TestResponseHeaderMapImpl headers{
+      {":method", "get"}, {"content-length", "256"}, {header_name, header_value}};
+  doResponse(headers, is_compression_expected, false);
+  EXPECT_EQ("Accept-Encoding", headers.get_("vary"));
+}
+
+TEST_P(IsTransferEncodingAllowedTest, ValidateForCompressionHeaderFeatureEnabled) {
+  Runtime::maybeSetRuntimeGuard("envoy.reloadable_features.compressor_add_status_header", true);
   const std::string& header_name = std::get<0>(GetParam());
   const std::string& header_value = std::get<1>(GetParam());
   const bool is_compression_expected = std::get<2>(GetParam());
@@ -960,6 +1216,20 @@ INSTANTIATE_TEST_SUITE_P(
                     std::make_tuple("vary", "Accept-Encoding", "Accept-Encoding")));
 
 TEST_P(InsertVaryHeaderTest, Validate) {
+  Runtime::maybeSetRuntimeGuard("envoy.reloadable_features.compressor_add_status_header", false);
+  const std::string& header_name = std::get<0>(GetParam());
+  const std::string& header_value = std::get<1>(GetParam());
+  const std::string& expected = std::get<2>(GetParam());
+
+  doRequestNoCompression({{":method", "get"}, {"accept-encoding", "test"}});
+  Http::TestResponseHeaderMapImpl headers{
+      {":method", "get"}, {"content-length", "256"}, {header_name, header_value}};
+  doResponseCompression(headers, false);
+  EXPECT_EQ(expected, headers.get_("vary"));
+}
+
+TEST_P(InsertVaryHeaderTest, ValidateForCompressionHeaderFeatureEnabled) {
+  Runtime::maybeSetRuntimeGuard("envoy.reloadable_features.compressor_add_status_header", true);
   const std::string& header_name = std::get<0>(GetParam());
   const std::string& header_value = std::get<1>(GetParam());
   const std::string& expected = std::get<2>(GetParam());
@@ -973,9 +1243,25 @@ TEST_P(InsertVaryHeaderTest, Validate) {
 
 class MultipleFiltersTest : public testing::Test {
 protected:
-  void SetUp() override {
+  void setUpFilters(const std::string& json1, const std::string& json2) {
     envoy::extensions::filters::http::compressor::v3::Compressor compressor;
-    TestUtility::loadFromJson(R"EOF(
+    TestUtility::loadFromJson(json1, compressor);
+    auto compressor_factory1 = std::make_unique<TestCompressorFactory>("test1");
+    compressor_factory1->setExpectedCompressCalls(0);
+    auto config1 = std::make_shared<CompressorFilterConfig>(
+        compressor, "test1.", *stats1_.rootScope(), runtime_, std::move(compressor_factory1));
+    filter1_ = std::make_unique<CompressorFilter>(config1);
+
+    TestUtility::loadFromJson(json2, compressor);
+    auto compressor_factory2 = std::make_unique<TestCompressorFactory>("test2");
+    compressor_factory2->setExpectedCompressCalls(0);
+    auto config2 = std::make_shared<CompressorFilterConfig>(
+        compressor, "test2.", *stats2_.rootScope(), runtime_, std::move(compressor_factory2));
+    filter2_ = std::make_unique<CompressorFilter>(config2);
+  }
+
+  void setUpDefaultFilters() {
+    setUpFilters(R"EOF(
 {
   "compressor_library": {
      "name": "test1",
@@ -985,14 +1271,7 @@ protected:
   }
 }
 )EOF",
-                              compressor);
-    auto compressor_factory1 = std::make_unique<TestCompressorFactory>("test1");
-    compressor_factory1->setExpectedCompressCalls(0);
-    auto config1 = std::make_shared<CompressorFilterConfig>(
-        compressor, "test1.", *stats1_.rootScope(), runtime_, std::move(compressor_factory1));
-    filter1_ = std::make_unique<CompressorFilter>(config1);
-
-    TestUtility::loadFromJson(R"EOF(
+                 R"EOF(
 {
   "compressor_library": {
      "name": "test2",
@@ -1001,13 +1280,7 @@ protected:
      }
   }
 }
-)EOF",
-                              compressor);
-    auto compressor_factory2 = std::make_unique<TestCompressorFactory>("test2");
-    compressor_factory2->setExpectedCompressCalls(0);
-    auto config2 = std::make_shared<CompressorFilterConfig>(
-        compressor, "test2.", *stats2_.rootScope(), runtime_, std::move(compressor_factory2));
-    filter2_ = std::make_unique<CompressorFilter>(config2);
+)EOF");
   }
 
   NiceMock<Runtime::MockLoader> runtime_;
@@ -1017,7 +1290,19 @@ protected:
   std::unique_ptr<CompressorFilter> filter2_;
 };
 
-TEST_F(MultipleFiltersTest, IndependentFilters) {
+class MultipleFiltersWithStatusHeaderRuntimeFeatureTest : public MultipleFiltersTest,
+                                                          public testing::WithParamInterface<bool> {
+  void SetUp() override {
+    Runtime::maybeSetRuntimeGuard("envoy.reloadable_features.compressor_add_status_header",
+                                  GetParam());
+    setUpDefaultFilters();
+  };
+};
+
+INSTANTIATE_TEST_SUITE_P(MultipleFiltersWithStatusHeaderRuntimeFeatureTest,
+                         MultipleFiltersWithStatusHeaderRuntimeFeatureTest, testing::Bool());
+
+TEST_P(MultipleFiltersWithStatusHeaderRuntimeFeatureTest, IndependentFilters) {
   // The compressor "test1" from an independent filter chain should not overshadow "test2".
   // The independence is simulated with different instances of DecoderFilterCallbacks set for
   // "test1" and "test2".
@@ -1044,7 +1329,7 @@ TEST_F(MultipleFiltersTest, IndependentFilters) {
   EXPECT_EQ(1, stats2_.counter("test2.compressor.test2.test.header_compressor_used").value());
 }
 
-TEST_F(MultipleFiltersTest, CacheEncodingDecision) {
+TEST_P(MultipleFiltersWithStatusHeaderRuntimeFeatureTest, CacheEncodingDecision) {
   // Test that encoding decision is cached when used by multiple filters.
   NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks;
   filter1_->setDecoderFilterCallbacks(decoder_callbacks);
@@ -1069,7 +1354,7 @@ TEST_F(MultipleFiltersTest, CacheEncodingDecision) {
   EXPECT_EQ(2, stats2_.counter("test2.compressor.test2.test.header_compressor_used").value());
 }
 
-TEST_F(MultipleFiltersTest, UseFirstRegisteredFilterWhenWildcard) {
+TEST_P(MultipleFiltersWithStatusHeaderRuntimeFeatureTest, UseFirstRegisteredFilterWhenWildcard) {
   // Test that first registered filter is used when handling wildcard.
   NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks;
   filter1_->setDecoderFilterCallbacks(decoder_callbacks);
@@ -1088,12 +1373,201 @@ TEST_F(MultipleFiltersTest, UseFirstRegisteredFilterWhenWildcard) {
   EXPECT_EQ(1, stats2_.counter("test2.compressor.test2.test.header_wildcard").value());
 }
 
+TEST_F(MultipleFiltersTest, BothFiltersFail) {
+  Runtime::maybeSetRuntimeGuard("envoy.reloadable_features.compressor_add_status_header", true);
+  setUpDefaultFilters();
+  // Test that when both filters fail to compress, the x-envoy-compression-status header
+  // contains entries for both.
+  NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks;
+  filter1_->setDecoderFilterCallbacks(decoder_callbacks);
+  filter2_->setDecoderFilterCallbacks(decoder_callbacks);
+
+  Http::TestRequestHeaderMapImpl req_headers{{":method", "get"},
+                                             {"accept-encoding", "test1, test2"}};
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter1_->decodeHeaders(req_headers, false));
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter2_->decodeHeaders(req_headers, false));
+  Http::TestResponseHeaderMapImpl headers{{":method", "get"}, {"content-length", "10"}};
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter1_->encodeHeaders(headers, false));
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter2_->encodeHeaders(headers, false));
+  EXPECT_EQ(headers.get_("x-envoy-compression-status"),
+            "test1;ContentLengthTooSmall,test2;ContentLengthTooSmall");
+}
+
+TEST_F(MultipleFiltersTest, OneFilterFailsOneSucceeds) {
+  Runtime::maybeSetRuntimeGuard("envoy.reloadable_features.compressor_add_status_header", true);
+  setUpFilters(R"EOF(
+{
+  "compressor_library": {
+     "name": "test1",
+     "typed_config": {
+       "@type": "type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip"
+     }
+  },
+  "response_direction_config": {
+    "common_config": {
+      "content_type": [
+        "application/javascript"
+      ]
+    }
+  }
+}
+)EOF",
+               R"EOF(
+{
+  "compressor_library": {
+     "name": "test2",
+     "typed_config": {
+       "@type": "type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip"
+     }
+  }
+}
+)EOF");
+  // Test that when one filter fails to compress and the other succeeds, the
+  // x-envoy-compression-status header contains entries for both.
+  NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks;
+  filter1_->setDecoderFilterCallbacks(decoder_callbacks);
+  filter2_->setDecoderFilterCallbacks(decoder_callbacks);
+
+  Http::TestRequestHeaderMapImpl req_headers{{":method", "get"},
+                                             {"accept-encoding", "test1, test2"}};
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter1_->decodeHeaders(req_headers, false));
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter2_->decodeHeaders(req_headers, false));
+  Http::TestResponseHeaderMapImpl headers{
+      {":method", "get"}, {"content-length", "256"}, {"content-type", "text/plain"}};
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter1_->encodeHeaders(headers, false));
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter2_->encodeHeaders(headers, false));
+  EXPECT_EQ(headers.get_("x-envoy-compression-status"),
+            "test1;ContentTypeNotAllowed,test2;Compressed;OriginalLength=256");
+}
+
+TEST_F(MultipleFiltersTest, FirstFilterSucceedsSecondSkips) {
+  Runtime::maybeSetRuntimeGuard("envoy.reloadable_features.compressor_add_status_header", true);
+  setUpDefaultFilters();
+  // Test that when the first filter compresses, the second filter skips.
+  NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks;
+  filter1_->setDecoderFilterCallbacks(decoder_callbacks);
+  filter2_->setDecoderFilterCallbacks(decoder_callbacks);
+
+  Http::TestRequestHeaderMapImpl req_headers{{":method", "get"},
+                                             {"accept-encoding", "test1, test2"}};
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter1_->decodeHeaders(req_headers, false));
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter2_->decodeHeaders(req_headers, false));
+  Http::TestResponseHeaderMapImpl headers{
+      {":method", "get"}, {"content-length", "256"}, {"content-type", "text/plain"}};
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter1_->encodeHeaders(headers, false));
+  // The second filter should not compress because the content-encoding header is already set.
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter2_->encodeHeaders(headers, false));
+  EXPECT_EQ(headers.get_("x-envoy-compression-status"), "test1;Compressed;OriginalLength=256");
+  EXPECT_EQ(headers.get_("content-encoding"), "test1");
+}
+
+TEST_F(MultipleFiltersTest, BothFiltersFailDifferentReasons) {
+  Runtime::maybeSetRuntimeGuard("envoy.reloadable_features.compressor_add_status_header", true);
+  setUpFilters(R"EOF(
+{
+  "compressor_library": {
+     "name": "test1",
+     "typed_config": {
+       "@type": "type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip"
+     }
+  },
+  "response_direction_config": {
+    "common_config": {
+      "min_content_length": 512
+    }
+  }
+}
+)EOF",
+               R"EOF(
+{
+  "compressor_library": {
+     "name": "test2",
+     "typed_config": {
+       "@type": "type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip"
+     }
+  },
+  "response_direction_config": {
+    "common_config": {
+      "content_type": [
+        "application/javascript"
+      ]
+    }
+  }
+}
+)EOF");
+  // Test that when both filters fail to compress for different reasons, the
+  // x-envoy-compression-status header contains entries for both.
+  NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks;
+  filter1_->setDecoderFilterCallbacks(decoder_callbacks);
+  filter2_->setDecoderFilterCallbacks(decoder_callbacks);
+
+  Http::TestRequestHeaderMapImpl req_headers{{":method", "get"},
+                                             {"accept-encoding", "test1, test2"}};
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter1_->decodeHeaders(req_headers, false));
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter2_->decodeHeaders(req_headers, false));
+  Http::TestResponseHeaderMapImpl headers{
+      {":method", "get"}, {"content-length", "256"}, {"content-type", "text/plain"}};
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter1_->encodeHeaders(headers, false));
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter2_->encodeHeaders(headers, false));
+  EXPECT_EQ(headers.get_("x-envoy-compression-status"),
+            "test1;ContentLengthTooSmall,test2;ContentTypeNotAllowed");
+}
+
+TEST_F(MultipleFiltersTest, BothFiltersFailEtagAndStatusCode) {
+  Runtime::maybeSetRuntimeGuard("envoy.reloadable_features.compressor_add_status_header", true);
+  setUpFilters(R"EOF(
+{
+  "compressor_library": {
+     "name": "test1",
+     "typed_config": {
+       "@type": "type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip"
+     }
+  },
+  "response_direction_config": {
+    "disable_on_etag_header": true
+  }
+}
+)EOF",
+               R"EOF(
+{
+  "compressor_library": {
+     "name": "test2",
+     "typed_config": {
+       "@type": "type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip"
+     }
+  },
+  "response_direction_config": {
+    "uncompressible_response_codes": [
+      206
+    ]
+  }
+}
+)EOF");
+  // Test that when both filters fail to compress for ETag and StatusCode reasons, the
+  // x-envoy-compression-status header contains entries for both.
+  NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks;
+  filter1_->setDecoderFilterCallbacks(decoder_callbacks);
+  filter2_->setDecoderFilterCallbacks(decoder_callbacks);
+
+  Http::TestRequestHeaderMapImpl req_headers{{":method", "get"},
+                                             {"accept-encoding", "test1, test2"}};
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter1_->decodeHeaders(req_headers, false));
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter2_->decodeHeaders(req_headers, false));
+  Http::TestResponseHeaderMapImpl headers{
+      {":method", "get"}, {"content-length", "256"}, {"etag", "12345"}, {":status", "206"}};
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter1_->encodeHeaders(headers, false));
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter2_->encodeHeaders(headers, false));
+  EXPECT_EQ(headers.get_("x-envoy-compression-status"),
+            "test1;EtagNotAllowed,test2;StatusCodeNotAllowed");
+}
+
 // TODO(giantcroc): Refactor the code of MultipleFiltersTest and CompressorFilterTest due to many
 // duplicate methods
 class ChooseFirstTest : public MultipleFiltersTest,
                         public testing::WithParamInterface<
                             std::tuple<std::string, std::string, std::string, bool, std::string>> {
 protected:
+  void SetUp() override { MultipleFiltersTest::setUpDefaultFilters(); }
   // ChooseFirstTest Helpers
   void setUpFilter(const std::string& choose_first1, const std::string& choose_first2) {
     envoy::extensions::filters::http::compressor::v3::Compressor compressor;
@@ -1212,6 +1686,26 @@ INSTANTIATE_TEST_SUITE_P(
                     std::make_tuple("true", "true", "test2;q=1, test1;q=0.5", false, "")));
 
 TEST_P(ChooseFirstTest, Validate) {
+  Runtime::maybeSetRuntimeGuard("envoy.reloadable_features.compressor_add_status_header", false);
+  const std::string& choose_first1 = std::get<0>(GetParam());
+  const std::string& choose_first2 = std::get<1>(GetParam());
+  const std::string& accept_encoding = std::get<2>(GetParam());
+  const bool is_compression_expected = std::get<3>(GetParam());
+  const std::string& content_encoding = std::get<4>(GetParam());
+
+  setUpFilter(choose_first1, choose_first2);
+  NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks;
+  filter1_->setDecoderFilterCallbacks(decoder_callbacks);
+  filter1_->setEncoderFilterCallbacks(encoder_callbacks_);
+  filter2_->setDecoderFilterCallbacks(decoder_callbacks);
+
+  doRequest({{":method", "get"}, {"accept-encoding", accept_encoding}});
+  Http::TestResponseHeaderMapImpl headers{{":method", "get"}, {"content-length", "256"}};
+  doResponse(headers, is_compression_expected, false, content_encoding);
+}
+
+TEST_P(ChooseFirstTest, ValidateForCompressionHeaderFeatureEnabled) {
+  Runtime::maybeSetRuntimeGuard("envoy.reloadable_features.compressor_add_status_header", true);
   const std::string& choose_first1 = std::get<0>(GetParam());
   const std::string& choose_first2 = std::get<1>(GetParam());
   const std::string& accept_encoding = std::get<2>(GetParam());


### PR DESCRIPTION
Commit Message: Adds compression status header to compressor_filter
Additional Description:

This change introduces a new response header x-envoy-compression-status to the compressor_filter. This header provides information on whether the response was compressed and, if not, the reason why compression was skipped.

The possible values for the status include:

Compressed: Indicates the response was compressed by this filter. Includes an additional OriginalLength parameter which stores the value from the ContentLength header that is removed on compression.
ContentLengthTooSmall: Skipped due to content length being below the minimum threshold.
ContentTypeNotAllowed: Skipped because the content type is not configured for compression.
EtagNotAllowed: Skipped due to the presence of an ETag header when disable_on_etag_header is true.
StatusCodeNotAllowed: Skipped because the response status code is not configured for compression.
The value format is <encoder-type>;<status>[;<additional-params>]. Multiple compressor filters in a chain will append their results separated by commas.

To enable this header, the runtime feature envoy.reloadable_features.compressor_add_status_header must be true. When enabled, the order of checks within the filter is slightly modified to emit the appropriate status reason. The behavior with the flag disabled remains unchanged.

Risk Level: Medium
Testing:

Added new unit tests in compressor_filter_test.cc and integration tests in compressor_filter_integration_test.cc to validate the presence and content of the x-envoy-compression-status header for various scenarios.
Adjusted existing tests to run with the runtime flag envoy.reloadable_features.compressor_add_status_header both enabled and disabled to ensure no behavioral changes for the existing logic.
Docs Changes: added section on the header to the: docs/root/configuration/http/http_filters/compressor_filter.rst
Release Notes: compressor: added the x-envoy-compression-status response header, which details if compression was applied or why it was skipped. This feature is gated by the envoy.reloadable_features.compressor_add_status_header runtime guard.
Platform Specific Features: N/A
Runtime guard: envoy.reloadable_features.compressor_add_status_header