### PR TITLE
Replace c-ares library with getaddrinfo DNS library in redis_cluster_integration_test

### DIFF
--- a/test/extensions/clusters/redis/BUILD
+++ b/test/extensions/clusters/redis/BUILD
@@ -106,6 +106,7 @@ envoy_extension_cc_test(
         "//source/extensions/filters/network/redis_proxy:config",
         "//source/extensions/load_balancing_policies/cluster_provided:config",
         "//source/extensions/load_balancing_policies/round_robin:config",
+        "//source/extensions/network/dns_resolver/getaddrinfo:config",
         "//test/integration:ads_integration_lib",
         "//test/integration:integration_lib",
         "@envoy_api//envoy/config/bootstrap/v3:pkg_cc_proto",

--- a/test/extensions/clusters/redis/redis_cluster_integration_test.cc
+++ b/test/extensions/clusters/redis/redis_cluster_integration_test.cc
@@ -6,6 +6,7 @@
 
 #include "source/common/common/macros.h"
 #include "source/extensions/filters/network/redis_proxy/command_splitter_impl.h"
+#include "source/extensions/network/dns_resolver/getaddrinfo/getaddrinfo.h"
 
 #include "test/integration/ads_integration.h"
 #include "test/integration/integration.h"
@@ -156,6 +157,13 @@ public:
 
     // Change the port for each of the discovery host in cluster_0.
     config_helper_.addConfigModifier([this](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
+      // Add default DNS resolver config.
+      auto* typed_dns_resolver_config = bootstrap.mutable_typed_dns_resolver_config();
+      typed_dns_resolver_config->set_name("envoy.network.dns_resolver.getaddrinfo");
+      envoy::extensions::network::dns_resolver::getaddrinfo::v3::GetAddrInfoDnsResolverConfig
+          config;
+      typed_dns_resolver_config->mutable_typed_config()->PackFrom(config);
+
       uint32_t upstream_idx = 0;
       auto* cluster_0 = bootstrap.mutable_static_resources()->mutable_clusters(0);
       if (version_ == Network::Address::IpVersion::v4) {


### PR DESCRIPTION
This is a follow up of https://github.com/envoyproxy/envoy/pull/41031
It's the 9th step to address: https://github.com/envoyproxy/envoy/issues/39900