### PR TITLE
Replace c-ares library with getaddrinfo DNS library in aws_request_signing_integration_test

### DIFF
--- a/test/extensions/filters/http/aws_request_signing/BUILD
+++ b/test/extensions/filters/http/aws_request_signing/BUILD
@@ -44,6 +44,7 @@ envoy_extension_cc_test(
         "//source/extensions/clusters/dns:dns_cluster_lib",
         "//source/extensions/filters/http/aws_request_signing:aws_request_signing_filter_lib",
         "//source/extensions/filters/http/aws_request_signing:config",
+        "//source/extensions/network/dns_resolver/getaddrinfo:config",
         "//test/extensions/common/aws:aws_mocks",
         "//test/integration:http_integration_lib",
         "//test/test_common:utility_lib",


### PR DESCRIPTION
This is a follow up of https://github.com/envoyproxy/envoy/pull/41095
It's the 10th step to address: https://github.com/envoyproxy/envoy/issues/39900