### PR TITLE
Replace c-ares library with getaddrinfo DNS library in udp_proxy filter integration test

### DIFF
--- a/test/extensions/filters/udp/udp_proxy/session_filters/dynamic_forward_proxy/BUILD
+++ b/test/extensions/filters/udp/udp_proxy/session_filters/dynamic_forward_proxy/BUILD
@@ -61,6 +61,7 @@ envoy_extension_cc_test(
         "//source/extensions/filters/udp/udp_proxy:config",
         "//source/extensions/filters/udp/udp_proxy/session_filters/dynamic_forward_proxy:config",
         "//source/extensions/filters/udp/udp_proxy/session_filters/dynamic_forward_proxy:proxy_filter_lib",
+        "//source/extensions/network/dns_resolver/getaddrinfo:config",
         "//test/extensions/filters/udp/udp_proxy/session_filters:psc_setter_filter_config_lib",
         "//test/extensions/filters/udp/udp_proxy/session_filters:psc_setter_filter_proto_cc_proto",
         "//test/integration:integration_lib",

--- a/test/extensions/filters/udp/udp_proxy/session_filters/dynamic_forward_proxy/proxy_filter_integration_test.cc
+++ b/test/extensions/filters/udp/udp_proxy/session_filters/dynamic_forward_proxy/proxy_filter_integration_test.cc
@@ -6,6 +6,7 @@
 
 #include "source/extensions/filters/udp/udp_proxy/session_filters/dynamic_forward_proxy/config.h"
 #include "source/extensions/filters/udp/udp_proxy/session_filters/dynamic_forward_proxy/proxy_filter.h"
+#include "source/extensions/network/dns_resolver/getaddrinfo/getaddrinfo.h"
 
 #include "test/common/upstream/utility.h"
 #include "test/extensions/filters/udp/udp_proxy/session_filters/dynamic_forward_proxy/dfp_setter.h"
@@ -85,6 +86,10 @@ typed_config:
       stat_prefix: foo
       dns_cache_config:
         name: foo
+        typed_dns_resolver_config:
+          name: envoy.network.dns_resolver.getaddrinfo
+          typed_config:
+            "@type": type.googleapis.com/envoy.extensions.network.dns_resolver.getaddrinfo.v3.GetAddrInfoDnsResolverConfig
         dns_lookup_family: {}
         max_hosts: {}
         dns_cache_circuit_breaker:
@@ -142,6 +147,10 @@ typed_config:
   "@type": type.googleapis.com/envoy.extensions.clusters.dynamic_forward_proxy.v3.ClusterConfig
   dns_cache_config:
     name: foo
+    typed_dns_resolver_config:
+      name: envoy.network.dns_resolver.getaddrinfo
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.network.dns_resolver.getaddrinfo.v3.GetAddrInfoDnsResolverConfig
     dns_lookup_family: {}
     max_hosts: {}
     dns_cache_circuit_breaker:


### PR DESCRIPTION
This is a follow up of https://github.com/envoyproxy/envoy/pull/41096
It's the 11th step to address: https://github.com/envoyproxy/envoy/issues/39900
