### PR TITLE
Replace c-ares library with getaddrinfo DNS library in redis_proxy network filter integration test

### DIFF
--- a/test/extensions/filters/network/redis_proxy/BUILD
+++ b/test/extensions/filters/network/redis_proxy/BUILD
@@ -209,6 +209,7 @@ envoy_extension_cc_test(
     deps = [
         "//source/extensions/filters/network/common/redis:fault_lib",
         "//source/extensions/filters/network/redis_proxy:config",
+        "//source/extensions/network/dns_resolver/getaddrinfo:config",
         "//test/integration:integration_lib",
         "@envoy_api//envoy/service/redis_auth/v3:pkg_cc_proto",
     ],

--- a/test/extensions/filters/network/redis_proxy/redis_proxy_integration_test.cc
+++ b/test/extensions/filters/network/redis_proxy/redis_proxy_integration_test.cc
@@ -6,6 +6,7 @@
 #include "source/common/common/fmt.h"
 #include "source/extensions/filters/network/common/redis/fault_impl.h"
 #include "source/extensions/filters/network/redis_proxy/command_splitter_impl.h"
+#include "source/extensions/network/dns_resolver/getaddrinfo/getaddrinfo.h"
 
 #include "test/common/grpc/grpc_client_integration.h"
 #include "test/integration/integration.h"
@@ -88,6 +89,10 @@ constexpr absl::string_view CONFIG_WITH_REDIRECTION_DNS = R"EOF({}
               name: foo
               dns_lookup_family: {}
               max_hosts: 100
+              typed_dns_resolver_config:
+                name: envoy.network.dns_resolver.getaddrinfo
+                typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.network.dns_resolver.getaddrinfo.v3.GetAddrInfoDnsResolverConfig
 )EOF";
 
 // This is a configuration with batching enabled.


### PR DESCRIPTION
This is a follow up of https://github.com/envoyproxy/envoy/pull/41097
It's the 12th step to address: https://github.com/envoyproxy/envoy/issues/39900