### PR TITLE
tools: update the notifier tool calendar link

### DIFF
--- a/tools/repo/notify.py
+++ b/tools/repo/notify.py
@@ -30,7 +30,20 @@ from aio.run import runner
 ENVOY_REPO = "envoyproxy/envoy"
 
 # Oncall calendar
-CALENDAR = "https://calendar.google.com/calendar/ical/d6glc0l5rc3v235q9l2j29dgovh3dn48%40import.calendar.google.com/public/basic.ics"
+# This calendar is currently in the Google calndar account of @adisuissa. Once
+# his account is closed, the calendar will not be available. In order to create
+# a new calendar link, please do the following:
+# 1. Find the link on the opsgenie page -> "Who is on-call" -> "Envoy maintainer
+#    rotation" -> calendar icon on the top-right of the screen. This will point to
+#    a webcall link, similar to:
+#    webcal://kubernetes.app.opsgenie.com/webapi/webcal/getRecentSchedule?webcalToken=<someToken>&scheduleId=a3505963-c064-4c97-8865-947dfcb06060
+# 2. Go to your personal Google calendar, and add a new one (press '+' next to
+#    "Other calendars") -> then press "From URL".
+# 3. Paste the webcal link to the "URL of calendar", check the "Make the
+#    calendar publicly accessible", and press "Add calendar".
+# 4. In the calendar settings you can now change the calendar's name, and copy
+#    paste the "public address in iCal format" link here.
+CALENDAR = "https://calendar.google.com/calendar/ical/jlcv20uad0arnm7g69ip9iu956vvnrf6%40import.calendar.google.com/public/basic.ics"
 
 ISSUE_LINK = "https://github.com/envoyproxy/envoy/issues?q=is%3Aissue+is%3Aopen+label%3Atriage"
 SLACK_EXPORT_URL = "https://api.slack.com/apps/A023NPQQ33K/oauth?"


### PR DESCRIPTION
Commit Message: tools: update the notifier tool calendar link
Additional Description:
Fixing the notifier tool calendar link to point to a new Envoy maintainers rotation on-call calendar.
Also added instructions on how to repro this, if needed in the future.

Validated by executing `bazel run //tools/repo:notify -- --dry_run`, and getting the following relevant info:
```
RepoNotifier NOTICE Slack message (#envoy-maintainer-oncall):
Oncall now <@U5CALEVSL>
```
which maps to this week's oncaller

Risk Level: low - tools only
Testing: Manual
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A