### PR TITLE
listener: Consider network namespace in address comparison

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -93,6 +93,9 @@ bug_fixes:
     Fixed a bug where the premature resets of streams may result in the recursive draining and potential
     stack overflow. Setting proper ``max_concurrent_streams`` value for HTTP/2 or HTTP/3 could eliminate
     the risk of the stack overflow before this fix.
+- area: listener
+  change: |
+    Fixed a bug where comparing listeners did not consider the network namespace they were listening in.
 - area: http
   change: |
     Fixed a bug where the ``response_headers_to_add`` may be processed multiple times for the local responses from

--- a/source/common/listener_manager/listener_impl.cc
+++ b/source/common/listener_manager/listener_impl.cc
@@ -1135,7 +1135,7 @@ bool ListenerImpl::hasCompatibleAddress(const ListenerImpl& other) const {
     return false;
   }
 
-  // Second, check if the listener has the same addresses.
+  // Second, check if the listener has the same addresses (including network namespaces if Linux).
   // The listener support listening on the zero port address for test. Multiple zero
   // port addresses are also supported. For comparing two listeners with multiple
   // zero port addresses, only need to ensure there are the same number of zero

--- a/source/common/network/address_impl.cc
+++ b/source/common/network/address_impl.cc
@@ -164,7 +164,8 @@ Ipv4Instance::Ipv4Instance(absl::Status& status, const sockaddr_in* address,
 bool Ipv4Instance::operator==(const Instance& rhs) const {
   const Ipv4Instance* rhs_casted = dynamic_cast<const Ipv4Instance*>(&rhs);
   return (rhs_casted && (ip_.ipv4_.address() == rhs_casted->ip_.ipv4_.address()) &&
-          (ip_.port() == rhs_casted->ip_.port()));
+          (ip_.port() == rhs_casted->ip_.port()) &&
+          (InstanceBase::networkNamespace() == rhs.networkNamespace()));
 }
 
 std::string Ipv4Instance::sockaddrToString(const sockaddr_in& addr) {
@@ -313,7 +314,8 @@ bool Ipv6Instance::operator==(const Instance& rhs) const {
   const auto* rhs_casted = dynamic_cast<const Ipv6Instance*>(&rhs);
   return (rhs_casted && (ip_.ipv6_.address() == rhs_casted->ip_.ipv6_.address()) &&
           (ip_.port() == rhs_casted->ip_.port()) &&
-          (ip_.ipv6_.scopeId() == rhs_casted->ip_.ipv6_.scopeId()));
+          (ip_.ipv6_.scopeId() == rhs_casted->ip_.ipv6_.scopeId()) &&
+          (InstanceBase::networkNamespace() == rhs.networkNamespace()));
 }
 
 Ipv6Instance::Ipv6Instance(absl::Status& status, const sockaddr_in6& address, bool v6only,

--- a/test/common/listener_manager/listener_manager_impl_test.cc
+++ b/test/common/listener_manager/listener_manager_impl_test.cc
@@ -6691,6 +6691,59 @@ TEST_P(ListenerManagerImplWithRealFiltersTest, MptcpNotSupported) {
       "listener mptcp-udp: enable_mptcp is set but MPTCP is not supported by the operating system");
 }
 
+// Test that hasCompatibleAddress returns false if network namespace is different.
+TEST_P(ListenerManagerImplTest, HasCompatibleAddressWithNetNs) {
+  const std::string yaml_config1 = R"EOF(
+name: listener_0
+address:
+  socket_address:
+    address: 127.0.0.1
+    port_value: 10001
+    network_namespace_filepath: "/var/run/netns/ns1"
+filter_chains: {}
+)EOF";
+
+  const std::string yaml_config2 = R"EOF(
+name: listener_0
+address:
+  socket_address:
+    address: 127.0.0.1
+    port_value: 10001
+    network_namespace_filepath: "/var/run/netns/ns2"
+filter_chains: {}
+)EOF";
+
+  const std::string yaml_config3 = R"EOF(
+name: listener_0
+address:
+  socket_address:
+    address: 127.0.0.1
+    port_value: 10001
+    network_namespace_filepath: "/var/run/netns/ns1"
+filter_chains: {}
+)EOF";
+
+  envoy::config::listener::v3::Listener config1 =
+      TestUtility::parseYaml<envoy::config::listener::v3::Listener>(yaml_config1);
+  envoy::config::listener::v3::Listener config2 =
+      TestUtility::parseYaml<envoy::config::listener::v3::Listener>(yaml_config2);
+  envoy::config::listener::v3::Listener config3 =
+      TestUtility::parseYaml<envoy::config::listener::v3::Listener>(yaml_config3);
+
+  auto listener1 = ListenerImpl::create(config1, "", *manager_, config1.name(), false, false,
+                                        MessageUtil::hash(config1));
+  ASSERT_TRUE(listener1.ok());
+  auto listener2 = ListenerImpl::create(config2, "", *manager_, config2.name(), false, false,
+                                        MessageUtil::hash(config2));
+  ASSERT_TRUE(listener2.ok());
+  auto listener3 = ListenerImpl::create(config3, "", *manager_, config3.name(), false, false,
+                                        MessageUtil::hash(config3));
+  ASSERT_TRUE(listener3.ok());
+
+  EXPECT_FALSE(listener1.value()->hasCompatibleAddress(*(listener2.value())));
+  EXPECT_TRUE(listener1.value()->hasCompatibleAddress(*(listener3.value())));
+}
+
 // Set the resolver to the default IP resolver. The address resolver logic is unit tested in
 // resolver_impl_test.cc.
 TEST_P(ListenerManagerImplWithRealFiltersTest, AddressResolver) {

--- a/test/common/network/address_impl_test.cc
+++ b/test/common/network/address_impl_test.cc
@@ -206,6 +206,16 @@ TEST(Ipv4InstanceTest, PortOnly) {
   EXPECT_FALSE(address.ip()->isUnicastAddress());
 }
 
+TEST(Ipv4InstanceTest, NetnsComparison) {
+  Ipv4Instance address1("1.2.3.4", nullptr, "/var/run/netns/11111");
+  Ipv4Instance address2("1.2.3.4", nullptr, "/var/run/netns/22222");
+  // Same netns as address1.
+  Ipv4Instance address3("1.2.3.4", nullptr, "/var/run/netns/11111");
+
+  EXPECT_EQ(address1, address3);
+  EXPECT_NE(address1, address2);
+}
+
 TEST(Ipv4InstanceTest, Multicast) {
   Ipv4Instance address("230.0.0.1");
   EXPECT_EQ("230.0.0.1:0", address.asString());
@@ -332,6 +342,16 @@ TEST(Ipv6InstanceTest, ScopeIdStripping) {
   EXPECT_EQ("[fe80::f8f3:11ff:fef4:25a8]:80", no_scope_address->asString());
   EXPECT_EQ(IpVersion::v6, no_scope_address->ip()->version());
   EXPECT_EQ(0U, no_scope_address->ip()->ipv6()->scopeId());
+}
+
+TEST(Ipv6InstanceTest, NetnsCompare) {
+  Ipv6Instance address1("::0001", 80, nullptr, true, "/var/run/netns/11111");
+  Ipv6Instance address2("::0001", 80, nullptr, true, "/var/run/netns/22222");
+  // Same netns as address1.
+  Ipv6Instance address3("::0001", 80, nullptr, true, "/var/run/netns/11111");
+
+  EXPECT_NE(address1, address2);
+  EXPECT_EQ(address1, address3);
 }
 
 TEST(Ipv6InstanceTest, PortOnly) {


### PR DESCRIPTION
Fixed a bug where listeners were considered to have compatible addresses even if they were in different network namespaces. This happened because the address equality comparison for both IPv4 and IPv6 did not check the network namespace.

Risk Level: Low
Testing: new Listener and AddressImpl unit tests
Docs Changes: n/a
Release Notes: done
Platform Specific Features: Only relevant on Linux.
