### PR TITLE
access log: use generic factory context

### DIFF
--- a/envoy/access_log/access_log_config.h
+++ b/envoy/access_log/access_log_config.h
@@ -26,7 +26,7 @@ public:
    * @return an instance of extension filter implementation from a config proto.
    */
   virtual FilterPtr createFilter(const envoy::config::accesslog::v3::ExtensionFilter& config,
-                                 Server::Configuration::FactoryContext& context) PURE;
+                                 Server::Configuration::GenericFactoryContext& context) PURE;
 
   std::string category() const override { return "envoy.access_loggers.extension_filters"; }
 };
@@ -50,7 +50,7 @@ public:
    */
   virtual AccessLog::InstanceSharedPtr
   createAccessLogInstance(const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
-                          Server::Configuration::FactoryContext& context,
+                          Server::Configuration::GenericFactoryContext& context,
                           std::vector<Formatter::CommandParserPtr>&& command_parsers = {}) PURE;
 
   std::string category() const override { return "envoy.access_loggers"; }

--- a/source/common/access_log/access_log_impl.cc
+++ b/source/common/access_log/access_log_impl.cc
@@ -54,7 +54,7 @@ bool ComparisonFilter::compareAgainstValue(uint64_t lhs) const {
 }
 
 FilterPtr FilterFactory::fromProto(const envoy::config::accesslog::v3::AccessLogFilter& config,
-                                   Server::Configuration::FactoryContext& context) {
+                                   Server::Configuration::GenericFactoryContext& context) {
   Runtime::Loader& runtime = context.serverFactoryContext().runtime();
   Random::RandomGenerator& random = context.serverFactoryContext().api().randomGenerator();
   ProtobufMessage::ValidationVisitor& validation_visitor = context.messageValidationVisitor();
@@ -157,7 +157,7 @@ bool RuntimeFilter::evaluate(const Formatter::HttpFormatterContext&,
 
 OperatorFilter::OperatorFilter(
     const Protobuf::RepeatedPtrField<envoy::config::accesslog::v3::AccessLogFilter>& configs,
-    Server::Configuration::FactoryContext& context) {
+    Server::Configuration::GenericFactoryContext& context) {
   for (const auto& config : configs) {
     auto filter = FilterFactory::fromProto(config, context);
     if (filter != nullptr) {
@@ -167,11 +167,11 @@ OperatorFilter::OperatorFilter(
 }
 
 OrFilter::OrFilter(const envoy::config::accesslog::v3::OrFilter& config,
-                   Server::Configuration::FactoryContext& context)
+                   Server::Configuration::GenericFactoryContext& context)
     : OperatorFilter(config.filters(), context) {}
 
 AndFilter::AndFilter(const envoy::config::accesslog::v3::AndFilter& config,
-                     Server::Configuration::FactoryContext& context)
+                     Server::Configuration::GenericFactoryContext& context)
     : OperatorFilter(config.filters(), context) {}
 
 bool OrFilter::evaluate(const Formatter::HttpFormatterContext& context,
@@ -330,7 +330,7 @@ bool MetadataFilter::evaluate(const Formatter::HttpFormatterContext&,
 
 InstanceSharedPtr
 AccessLogFactory::fromProto(const envoy::config::accesslog::v3::AccessLog& config,
-                            Server::Configuration::FactoryContext& context,
+                            Server::Configuration::GenericFactoryContext& context,
                             std::vector<Formatter::CommandParserPtr>&& command_parsers) {
   FilterPtr filter;
   if (config.has_filter()) {

--- a/source/common/access_log/access_log_impl.h
+++ b/source/common/access_log/access_log_impl.h
@@ -34,7 +34,7 @@ public:
    * Read a filter definition from proto and instantiate a concrete filter class.
    */
   static FilterPtr fromProto(const envoy::config::accesslog::v3::AccessLogFilter& config,
-                             Server::Configuration::FactoryContext& context);
+                             Server::Configuration::GenericFactoryContext& context);
 };
 
 /**
@@ -86,7 +86,7 @@ class OperatorFilter : public Filter {
 public:
   OperatorFilter(
       const Protobuf::RepeatedPtrField<envoy::config::accesslog::v3::AccessLogFilter>& configs,
-      Server::Configuration::FactoryContext& context);
+      Server::Configuration::GenericFactoryContext& context);
 
 protected:
   std::vector<FilterPtr> filters_;
@@ -98,7 +98,7 @@ protected:
 class AndFilter : public OperatorFilter {
 public:
   AndFilter(const envoy::config::accesslog::v3::AndFilter& config,
-            Server::Configuration::FactoryContext& context);
+            Server::Configuration::GenericFactoryContext& context);
 
   // AccessLog::Filter
   bool evaluate(const Formatter::HttpFormatterContext& context,
@@ -111,7 +111,7 @@ public:
 class OrFilter : public OperatorFilter {
 public:
   OrFilter(const envoy::config::accesslog::v3::OrFilter& config,
-           Server::Configuration::FactoryContext& context);
+           Server::Configuration::GenericFactoryContext& context);
 
   // AccessLog::Filter
   bool evaluate(const Formatter::HttpFormatterContext& context,
@@ -269,7 +269,7 @@ public:
    */
   static InstanceSharedPtr
   fromProto(const envoy::config::accesslog::v3::AccessLog& config,
-            Server::Configuration::FactoryContext& context,
+            Server::Configuration::GenericFactoryContext& context,
             std::vector<Formatter::CommandParserPtr>&& command_parsers = {});
 };
 

--- a/source/common/quic/envoy_quic_dispatcher.cc
+++ b/source/common/quic/envoy_quic_dispatcher.cc
@@ -94,6 +94,7 @@ std::unique_ptr<quic::QuicSession> EnvoyQuicDispatcher::CreateQuicSession(
   // ALPN.
   Network::ConnectionSocketPtr connection_socket = createServerConnectionSocket(
       listen_socket_.ioHandle(), self_address, peer_address, std::string(parsed_chlo.sni), "h3");
+  connection_socket->connectionInfoProvider().setListenerInfo(listener_config_->listenerInfo());
   auto stream_info = std::make_unique<StreamInfo::StreamInfoImpl>(
       dispatcher_.timeSource(), connection_socket->connectionInfoProviderSharedPtr(),
       StreamInfo::FilterState::LifeSpan::Connection);

--- a/source/extensions/access_loggers/common/stream_access_log_common_impl.h
+++ b/source/extensions/access_loggers/common/stream_access_log_common_impl.h
@@ -13,7 +13,7 @@ namespace AccessLoggers {
 template <class T, Filesystem::DestinationType destination_type>
 AccessLog::InstanceSharedPtr
 createStreamAccessLogInstance(const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
-                              Server::Configuration::FactoryContext& context,
+                              Server::Configuration::GenericFactoryContext& context,
                               std::vector<Formatter::CommandParserPtr>&& command_parsers = {}) {
   const auto& fal_config =
       MessageUtil::downcastAndValidate<const T&>(config, context.messageValidationVisitor());

--- a/source/extensions/access_loggers/file/config.cc
+++ b/source/extensions/access_loggers/file/config.cc
@@ -21,7 +21,7 @@ namespace File {
 
 AccessLog::InstanceSharedPtr FileAccessLogFactory::createAccessLogInstance(
     const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
-    Server::Configuration::FactoryContext& context,
+    Server::Configuration::GenericFactoryContext& context,
     std::vector<Formatter::CommandParserPtr>&& command_parsers) {
   const auto& fal_config = MessageUtil::downcastAndValidate<
       const envoy::extensions::access_loggers::file::v3::FileAccessLog&>(

--- a/source/extensions/access_loggers/file/config.h
+++ b/source/extensions/access_loggers/file/config.h
@@ -14,7 +14,7 @@ class FileAccessLogFactory : public AccessLog::AccessLogInstanceFactory {
 public:
   AccessLog::InstanceSharedPtr
   createAccessLogInstance(const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
-                          Server::Configuration::FactoryContext& context,
+                          Server::Configuration::GenericFactoryContext& context,
                           std::vector<Formatter::CommandParserPtr>&& command_parsers = {}) override;
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override;

--- a/source/extensions/access_loggers/filters/cel/config.cc
+++ b/source/extensions/access_loggers/filters/cel/config.cc
@@ -16,7 +16,7 @@ namespace CEL {
 
 Envoy::AccessLog::FilterPtr CELAccessLogExtensionFilterFactory::createFilter(
     const envoy::config::accesslog::v3::ExtensionFilter& config,
-    Server::Configuration::FactoryContext& context) {
+    Server::Configuration::GenericFactoryContext& context) {
 
   auto factory_config =
       Config::Utility::translateToFactoryConfig(config, context.messageValidationVisitor(), *this);

--- a/source/extensions/access_loggers/filters/cel/config.h
+++ b/source/extensions/access_loggers/filters/cel/config.h
@@ -22,7 +22,7 @@ class CELAccessLogExtensionFilterFactory : public Envoy::AccessLog::ExtensionFil
 public:
   Envoy::AccessLog::FilterPtr
   createFilter(const envoy::config::accesslog::v3::ExtensionFilter& config,
-               Server::Configuration::FactoryContext& context) override;
+               Server::Configuration::GenericFactoryContext& context) override;
   ProtobufTypes::MessagePtr createEmptyConfigProto() override;
   std::string name() const override { return "envoy.access_loggers.extension_filters.cel"; }
 };

--- a/source/extensions/access_loggers/fluentd/config.cc
+++ b/source/extensions/access_loggers/fluentd/config.cc
@@ -33,7 +33,7 @@ getAccessLoggerCacheSingleton(Server::Configuration::ServerFactoryContext& conte
 
 AccessLog::InstanceSharedPtr FluentdAccessLogFactory::createAccessLogInstance(
     const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
-    Server::Configuration::FactoryContext& context,
+    Server::Configuration::GenericFactoryContext& context,
     std::vector<Formatter::CommandParserPtr>&& command_parsers) {
   const auto& proto_config = MessageUtil::downcastAndValidate<
       const envoy::extensions::access_loggers::fluentd::v3::FluentdAccessLogConfig&>(

--- a/source/extensions/access_loggers/fluentd/config.h
+++ b/source/extensions/access_loggers/fluentd/config.h
@@ -14,7 +14,7 @@ class FluentdAccessLogFactory : public AccessLog::AccessLogInstanceFactory {
 public:
   AccessLog::InstanceSharedPtr
   createAccessLogInstance(const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
-                          Server::Configuration::FactoryContext& context,
+                          Server::Configuration::GenericFactoryContext& context,
                           std::vector<Formatter::CommandParserPtr>&& command_parsers = {}) override;
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override;

--- a/source/extensions/access_loggers/grpc/http_config.cc
+++ b/source/extensions/access_loggers/grpc/http_config.cc
@@ -20,7 +20,8 @@ namespace HttpGrpc {
 
 AccessLog::InstanceSharedPtr HttpGrpcAccessLogFactory::createAccessLogInstance(
     const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
-    Server::Configuration::FactoryContext& context, std::vector<Formatter::CommandParserPtr>&&) {
+    Server::Configuration::GenericFactoryContext& context,
+    std::vector<Formatter::CommandParserPtr>&&) {
   GrpcCommon::validateProtoDescriptors();
 
   const auto& proto_config = MessageUtil::downcastAndValidate<

--- a/source/extensions/access_loggers/grpc/http_config.h
+++ b/source/extensions/access_loggers/grpc/http_config.h
@@ -16,7 +16,7 @@ class HttpGrpcAccessLogFactory : public AccessLog::AccessLogInstanceFactory {
 public:
   AccessLog::InstanceSharedPtr
   createAccessLogInstance(const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
-                          Server::Configuration::FactoryContext& context,
+                          Server::Configuration::GenericFactoryContext& context,
                           std::vector<Formatter::CommandParserPtr>&& = {}) override;
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override;

--- a/source/extensions/access_loggers/grpc/tcp_config.cc
+++ b/source/extensions/access_loggers/grpc/tcp_config.cc
@@ -20,7 +20,8 @@ namespace TcpGrpc {
 
 AccessLog::InstanceSharedPtr TcpGrpcAccessLogFactory::createAccessLogInstance(
     const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
-    Server::Configuration::FactoryContext& context, std::vector<Formatter::CommandParserPtr>&&) {
+    Server::Configuration::GenericFactoryContext& context,
+    std::vector<Formatter::CommandParserPtr>&&) {
   GrpcCommon::validateProtoDescriptors();
 
   const auto& proto_config = MessageUtil::downcastAndValidate<

--- a/source/extensions/access_loggers/grpc/tcp_config.h
+++ b/source/extensions/access_loggers/grpc/tcp_config.h
@@ -16,7 +16,7 @@ class TcpGrpcAccessLogFactory : public AccessLog::AccessLogInstanceFactory {
 public:
   AccessLog::InstanceSharedPtr
   createAccessLogInstance(const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
-                          Server::Configuration::FactoryContext& context,
+                          Server::Configuration::GenericFactoryContext& context,
                           std::vector<Formatter::CommandParserPtr>&& = {}) override;
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override;

--- a/source/extensions/access_loggers/open_telemetry/config.cc
+++ b/source/extensions/access_loggers/open_telemetry/config.cc
@@ -33,7 +33,7 @@ getAccessLoggerCacheSingleton(Server::Configuration::CommonFactoryContext& conte
 
 ::Envoy::AccessLog::InstanceSharedPtr AccessLogFactory::createAccessLogInstance(
     const Protobuf::Message& config, ::Envoy::AccessLog::FilterPtr&& filter,
-    Server::Configuration::FactoryContext& context,
+    Server::Configuration::GenericFactoryContext& context,
     std::vector<Formatter::CommandParserPtr>&& command_parsers) {
   validateProtoDescriptors();
 

--- a/source/extensions/access_loggers/open_telemetry/config.h
+++ b/source/extensions/access_loggers/open_telemetry/config.h
@@ -16,7 +16,7 @@ class AccessLogFactory : public Envoy::AccessLog::AccessLogInstanceFactory {
 public:
   ::Envoy::AccessLog::InstanceSharedPtr
   createAccessLogInstance(const Protobuf::Message& config, ::Envoy::AccessLog::FilterPtr&& filter,
-                          Server::Configuration::FactoryContext& context,
+                          Server::Configuration::GenericFactoryContext& context,
                           std::vector<Formatter::CommandParserPtr>&& command_parsers = {}) override;
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override;

--- a/source/extensions/access_loggers/stream/config.cc
+++ b/source/extensions/access_loggers/stream/config.cc
@@ -22,7 +22,7 @@ namespace File {
 
 AccessLog::InstanceSharedPtr StdoutAccessLogFactory::createAccessLogInstance(
     const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
-    Server::Configuration::FactoryContext& context,
+    Server::Configuration::GenericFactoryContext& context,
     std::vector<Formatter::CommandParserPtr>&& command_parsers) {
   return AccessLoggers::createStreamAccessLogInstance<
       envoy::extensions::access_loggers::stream::v3::StdoutAccessLog,
@@ -45,7 +45,7 @@ LEGACY_REGISTER_FACTORY(StdoutAccessLogFactory, AccessLog::AccessLogInstanceFact
 
 AccessLog::InstanceSharedPtr StderrAccessLogFactory::createAccessLogInstance(
     const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
-    Server::Configuration::FactoryContext& context,
+    Server::Configuration::GenericFactoryContext& context,
     std::vector<Formatter::CommandParserPtr>&& command_parsers) {
   return createStreamAccessLogInstance<
       envoy::extensions::access_loggers::stream::v3::StderrAccessLog,

--- a/source/extensions/access_loggers/stream/config.h
+++ b/source/extensions/access_loggers/stream/config.h
@@ -14,7 +14,7 @@ class StdoutAccessLogFactory : public AccessLog::AccessLogInstanceFactory {
 public:
   AccessLog::InstanceSharedPtr
   createAccessLogInstance(const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
-                          Server::Configuration::FactoryContext& context,
+                          Server::Configuration::GenericFactoryContext& context,
                           std::vector<Formatter::CommandParserPtr>&& command_parsers = {}) override;
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override;
@@ -29,7 +29,7 @@ class StderrAccessLogFactory : public AccessLog::AccessLogInstanceFactory {
 public:
   AccessLog::InstanceSharedPtr
   createAccessLogInstance(const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
-                          Server::Configuration::FactoryContext& context,
+                          Server::Configuration::GenericFactoryContext& context,
                           std::vector<Formatter::CommandParserPtr>&& command_parsers = {}) override;
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override;

--- a/source/extensions/access_loggers/wasm/config.cc
+++ b/source/extensions/access_loggers/wasm/config.cc
@@ -14,9 +14,11 @@ namespace Extensions {
 namespace AccessLoggers {
 namespace Wasm {
 
-AccessLog::InstanceSharedPtr WasmAccessLogFactory::createAccessLogInstance(
-    const Protobuf::Message& proto_config, AccessLog::FilterPtr&& filter,
-    Server::Configuration::FactoryContext& context, std::vector<Formatter::CommandParserPtr>&&) {
+AccessLog::InstanceSharedPtr
+WasmAccessLogFactory::createAccessLogInstance(const Protobuf::Message& proto_config,
+                                              AccessLog::FilterPtr&& filter,
+                                              Server::Configuration::GenericFactoryContext& context,
+                                              std::vector<Formatter::CommandParserPtr>&&) {
   const auto& config = MessageUtil::downcastAndValidate<
       const envoy::extensions::access_loggers::wasm::v3::WasmAccessLog&>(
       proto_config, context.messageValidationVisitor());

--- a/source/extensions/access_loggers/wasm/config.h
+++ b/source/extensions/access_loggers/wasm/config.h
@@ -17,7 +17,7 @@ class WasmAccessLogFactory : public AccessLog::AccessLogInstanceFactory,
 public:
   AccessLog::InstanceSharedPtr
   createAccessLogInstance(const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
-                          Server::Configuration::FactoryContext& context,
+                          Server::Configuration::GenericFactoryContext& context,
                           std::vector<Formatter::CommandParserPtr>&& = {}) override;
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override;

--- a/test/common/access_log/access_log_impl_test.cc
+++ b/test/common/access_log/access_log_impl_test.cc
@@ -1603,7 +1603,7 @@ public:
   ~TestHeaderFilterFactory() override = default;
 
   FilterPtr createFilter(const envoy::config::accesslog::v3::ExtensionFilter& config,
-                         Server::Configuration::FactoryContext& context) override {
+                         Server::Configuration::GenericFactoryContext& context) override {
     auto factory_config = Config::Utility::translateToFactoryConfig(
         config, context.messageValidationVisitor(), *this);
     const auto& header_config =
@@ -1699,7 +1699,7 @@ public:
   ~SampleExtensionFilterFactory() override = default;
 
   FilterPtr createFilter(const envoy::config::accesslog::v3::ExtensionFilter& config,
-                         Server::Configuration::FactoryContext& context) override {
+                         Server::Configuration::GenericFactoryContext& context) override {
     auto factory_config = Config::Utility::translateToFactoryConfig(
         config, context.messageValidationVisitor(), *this);
 

--- a/test/extensions/filters/network/generic_proxy/fake_codec.h
+++ b/test/extensions/filters/network/generic_proxy/fake_codec.h
@@ -440,7 +440,7 @@ class FakeAccessLogExtensionFilterFactory : public AccessLog::ExtensionFilterFac
 public:
   // AccessLogFilterFactory
   AccessLog::FilterPtr createFilter(const envoy::config::accesslog::v3::ExtensionFilter&,
-                                    Server::Configuration::FactoryContext&) override {
+                                    Server::Configuration::GenericFactoryContext&) override {
     return std::make_unique<FakeAccessLogExtensionFilter>();
   }
 

--- a/test/integration/fake_access_log.h
+++ b/test/integration/fake_access_log.h
@@ -30,7 +30,7 @@ class FakeAccessLogFactory : public AccessLog::AccessLogInstanceFactory {
 public:
   AccessLog::InstanceSharedPtr
   createAccessLogInstance(const Protobuf::Message&, AccessLog::FilterPtr&&,
-                          Server::Configuration::FactoryContext&,
+                          Server::Configuration::GenericFactoryContext&,
                           std::vector<Formatter::CommandParserPtr>&& = {}) override {
     std::lock_guard<std::mutex> guard(log_callback_lock_);
     auto access_log_instance = std::make_shared<FakeAccessLog>(log_cb_);


### PR DESCRIPTION
Change-Id: Ie17a21068efdfba87dbe9375672b864c4cc52a51

Commit Message: Move access log factory to use generic context. This will allow using it in non-listener contexts (upstream logs, side request logs, application logs, ECDS logs). While at it, find and fix a bug in Quic listener not setting the listener info.
Additional Description: Also move access log filter to use generic context. In almost all cases, server context is enough for both apart from validation - the one exception is Wasm which has other issues.
Risk Level: low, no functional change.
Testing: passed
Docs Changes: none, internal change
Release Notes: none