### PR TITLE
dynamic_modules: link dynamic library lifetime with per route config

### DIFF
--- a/source/extensions/filters/http/dynamic_modules/filter_config.cc
+++ b/source/extensions/filters/http/dynamic_modules/filter_config.cc
@@ -47,8 +47,8 @@ newDynamicModuleHttpPerRouteConfig(const absl::string_view per_route_config_name
     return absl::InvalidArgumentError("Failed to initialize per-route dynamic module");
   }
 
-  return std::make_shared<const DynamicModuleHttpPerRouteFilterConfig>(filter_config_envoy_ptr,
-                                                                       destroy.value());
+  return std::make_shared<const DynamicModuleHttpPerRouteFilterConfig>(
+      filter_config_envoy_ptr, destroy.value(), std::move(dynamic_module));
 }
 
 absl::StatusOr<DynamicModuleHttpFilterConfigSharedPtr> newDynamicModuleHttpFilterConfig(

--- a/source/extensions/filters/http/dynamic_modules/filter_config.h
+++ b/source/extensions/filters/http/dynamic_modules/filter_config.h
@@ -283,14 +283,16 @@ class DynamicModuleHttpPerRouteFilterConfig : public Router::RouteSpecificFilter
 public:
   DynamicModuleHttpPerRouteFilterConfig(
       envoy_dynamic_module_type_http_filter_config_module_ptr config,
-      OnHttpPerRouteConfigDestroyType destroy)
-      : config_(config), destroy_(destroy) {}
+      OnHttpPerRouteConfigDestroyType destroy,
+      Extensions::DynamicModules::DynamicModulePtr dynamic_module)
+      : config_(config), destroy_(destroy), dynamic_module_(std::move(dynamic_module)) {}
   ~DynamicModuleHttpPerRouteFilterConfig() override;
 
   envoy_dynamic_module_type_http_filter_config_module_ptr config_;
 
 private:
   OnHttpPerRouteConfigDestroyType destroy_;
+  Extensions::DynamicModules::DynamicModulePtr dynamic_module_;
 };
 
 using DynamicModuleHttpFilterConfigSharedPtr = std::shared_ptr<DynamicModuleHttpFilterConfig>;


### PR DESCRIPTION
Commit Message: dynamic_modules: link dynamic library lifetime with per route config
Additional Description: Pass the RAII handle to the dynamic library to the per route config to ensure that at least one ref count for the dynamic library exists while the per route config is active. This can avoid the library from being closed and unmapped from the process should no filter config be active while per route configs are.
Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
Potentially fixes https://github.com/envoyproxy/envoy/issues/41094
