### PR TITLE
[json_transcoder_filter] Cap grpc stream frame size

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -90,6 +90,11 @@ minor_behavior_changes:
     Honor the default DNS resolver configuration in the bootstrap config
     :ref:`typed_dns_resolver_config <envoy_v3_api_field_config.bootstrap.v3.Bootstrap.typed_dns_resolver_config>` if the
     :ref:`client_config <envoy_v3_api_field_extensions.filters.udp.dns_filter.v3.DnsFilterConfig.client_config>` is empty.
+- area: grpc_json_transcoder
+  change: |
+    Cap the frame size for streamed grpc at 1MB. Without this change there was a small chance
+    that if a request streamed in sufficiently faster than it was processed, a frame larger than
+    4MB could be encoded, which most upstream grpc services would, by default, treat as an error.
 
 bug_fixes:
 # *Changes expected to improve the state of the world and are unlikely to have negative effects*

--- a/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
+++ b/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
@@ -594,12 +594,23 @@ Http::FilterDataStatus JsonTranscoderFilter::decodeData(Buffer::Instance& data, 
   if (method_->request_type_is_http_body_) {
     stats_->transcoder_request_buffer_bytes_.add(data.length());
     request_data_.move(data);
-    if (decoderBufferLimitReached(request_data_.length())) {
+    if (!method_->descriptor_->client_streaming() &&
+        decoderBufferLimitReached(request_data_.length())) {
       return Http::FilterDataStatus::StopIterationNoBuffer;
     }
 
-    // TODO(euroelessar): Upper bound message size for streaming case.
-    if (end_stream || method_->descriptor_->client_streaming()) {
+    if (method_->descriptor_->client_streaming()) {
+      // To avoid sending a grpc frame larger than 4MB (which grpc will by default reject),
+      // split the input buffer into 1MB pieces until the buffer is smaller than 1MB.
+      Buffer::OwnedImpl remaining_request_data;
+      remaining_request_data.move(request_data_);
+      while (remaining_request_data.length() > 0) {
+        uint64_t piece_size =
+            std::min(remaining_request_data.length(), JsonTranscoderConfig::MaxStreamedPieceSize);
+        request_data_.move(remaining_request_data, piece_size);
+        maybeSendHttpBodyRequestMessage(&data);
+      }
+    } else if (end_stream) {
       maybeSendHttpBodyRequestMessage(&data);
     } else {
       // TODO(euroelessar): Avoid buffering if content length is already known.

--- a/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.h
+++ b/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.h
@@ -50,6 +50,11 @@ public:
           proto_config,
       Api::Api& api);
 
+  // grpc by default doesn't like a frame larger than 4MB. Splitting streamed data
+  // into 1MB pieces should keep that threshold from being exceeded when data comes
+  // in as a large buffer.
+  static constexpr size_t MaxStreamedPieceSize = 1024 * 1024;
+
   /**
    * Create an instance of Transcoder interface based on incoming request.
    * @param headers headers received from decoder.

--- a/test/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter_test.cc
+++ b/test/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter_test.cc
@@ -495,12 +495,6 @@ protected:
     ON_CALL(encoder_callbacks_, encoderBufferLimit()).WillByDefault(Return(2 << 20));
   }
 
-  virtual envoy::extensions::filters::http::grpc_json_transcoder::v3::GrpcJsonTranscoder
-  modifyProtoConfig(envoy::extensions::filters::http::grpc_json_transcoder::v3::GrpcJsonTranscoder&&
-                        proto_config) {
-    return proto_config;
-  }
-
   static envoy::extensions::filters::http::grpc_json_transcoder::v3::GrpcJsonTranscoder
   bookstoreProtoConfig() {
     const std::string json_string = "{\"proto_descriptor\": \"" + bookstoreDescriptorPath() +

--- a/test/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter_test.cc
+++ b/test/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter_test.cc
@@ -495,6 +495,12 @@ protected:
     ON_CALL(encoder_callbacks_, encoderBufferLimit()).WillByDefault(Return(2 << 20));
   }
 
+  virtual envoy::extensions::filters::http::grpc_json_transcoder::v3::GrpcJsonTranscoder
+  modifyProtoConfig(envoy::extensions::filters::http::grpc_json_transcoder::v3::GrpcJsonTranscoder&&
+                        proto_config) {
+    return proto_config;
+  }
+
   static envoy::extensions::filters::http::grpc_json_transcoder::v3::GrpcJsonTranscoder
   bookstoreProtoConfig() {
     const std::string json_string = "{\"proto_descriptor\": \"" + bookstoreDescriptorPath() +
@@ -1297,6 +1303,68 @@ TEST_F(GrpcJsonTranscoderFilterTest, TranscodingStreamPostWithHttpBody) {
   }
 }
 
+class GrpcJsonTranscoderFilterTestWithLargerBuffer : public GrpcJsonTranscoderFilterTest {
+public:
+  GrpcJsonTranscoderFilterTestWithLargerBuffer()
+      : GrpcJsonTranscoderFilterTest(modifiedBookstoreProtoConfig()) {}
+  envoy::extensions::filters::http::grpc_json_transcoder::v3::GrpcJsonTranscoder
+  modifiedBookstoreProtoConfig() {
+    auto proto_config = bookstoreProtoConfig();
+    proto_config.mutable_max_request_body_size()->set_value(1024 * 1024 * 2);
+    return proto_config;
+  }
+};
+
+TEST_F(GrpcJsonTranscoderFilterTestWithLargerBuffer, TranscodingStreamPostWithLargeBufferHttpBody) {
+  Http::TestRequestHeaderMapImpl request_headers{
+      {":method", "POST"}, {":path", "/streamBody?arg=hi"}, {"content-type", "text/plain"}};
+
+  EXPECT_CALL(decoder_callbacks_.downstream_callbacks_, clearRouteCache());
+
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.decodeHeaders(request_headers, false));
+  EXPECT_EQ("application/grpc", request_headers.get_("content-type"));
+  EXPECT_EQ("/streamBody?arg=hi", request_headers.get_("x-envoy-original-path"));
+  EXPECT_EQ("POST", request_headers.get_("x-envoy-original-method"));
+  EXPECT_EQ("/bookstore.Bookstore/StreamBody", request_headers.get_(":path"));
+  EXPECT_EQ("trailers", request_headers.get_("te"));
+
+  // For client_streaming, a large buffer should be packaged into multiple grpc frames.
+  // Test this with a buffer of 2MB plus 512 bytes.
+  std::string text(JsonTranscoderConfig::MaxStreamedPieceSize * 2 + 512, 'X');
+  Buffer::OwnedImpl buffer;
+  buffer.add(text);
+  EXPECT_CALL(decoder_callbacks_, sendLocalReply).Times(0);
+  EXPECT_EQ(Http::FilterDataStatus::Continue, filter_.decodeData(buffer, true));
+
+  Grpc::Decoder decoder;
+  std::vector<Grpc::Frame> frames;
+  std::ignore = decoder.decode(buffer, frames);
+  ASSERT_EQ(frames.size(), 3);
+
+  // First frame should include non-streamed content, plus 1MB of streamed content.
+  bookstore::EchoBodyRequest expected_first_request;
+  expected_first_request.set_arg("hi");
+  expected_first_request.mutable_nested()->mutable_content()->set_content_type("text/plain");
+  expected_first_request.mutable_nested()->mutable_content()->set_data(
+      std::string(JsonTranscoderConfig::MaxStreamedPieceSize, 'X'));
+  bookstore::EchoBodyRequest request;
+  request.ParseFromString(frames[0].data_->toString());
+  EXPECT_THAT(request, ProtoEq(expected_first_request));
+
+  // Second frame should have only 1MB of streamed content.
+  bookstore::EchoBodyRequest expected_second_request;
+  expected_second_request.mutable_nested()->mutable_content()->set_data(
+      std::string(JsonTranscoderConfig::MaxStreamedPieceSize, 'X'));
+  request.ParseFromString(frames[1].data_->toString());
+  EXPECT_THAT(request, ProtoEq(expected_second_request));
+
+  // Third frame should have the remaining 512 bytes of streamed content.
+  bookstore::EchoBodyRequest expected_third_request;
+  expected_third_request.mutable_nested()->mutable_content()->set_data(std::string(512, 'X'));
+  request.ParseFromString(frames[2].data_->toString());
+  EXPECT_THAT(request, ProtoEq(expected_third_request));
+}
+
 TEST_F(GrpcJsonTranscoderFilterTest, TranscodingStreamSSE) {
   envoy::extensions::filters::http::grpc_json_transcoder::v3::GrpcJsonTranscoder proto_config =
       bookstoreProtoConfig();
@@ -1337,7 +1405,7 @@ TEST_F(GrpcJsonTranscoderFilterTest, TranscodingStreamSSE) {
 // The configured buffer limits will not apply.
 TEST_F(GrpcJsonTranscoderFilterTest, TranscodingStreamPostWithHttpBodyNoBuffer) {
   EXPECT_CALL(decoder_callbacks_, decoderBufferLimit())
-      .Times(testing::AtLeast(3))
+      .Times(testing::AtLeast(1))
       .WillRepeatedly(Return(8));
 
   Http::TestRequestHeaderMapImpl request_headers{


### PR DESCRIPTION
Commit Message: [json_transcoder_filter] Cap grpc stream frame size
Additional Description: If the downstream sends data quickly enough, a `decodeData` buffer can contain over 4MB. The upstream grpc service by default will respond with an error if it receives such a frame, that error is surprisingly mapped to a 429 by envoy, and the upstream service won't see it because the grpc library never delivered it, which makes it very difficult to figure out what happened.
This change makes it so if the `decodeData` buffer is larger than 1MB while streaming, the buffer is broken into 1MB pieces, thereby avoiding that error (and completing an ancient TODO).
This is a behavior change, but should be largely indistinguishable from previous behavior as there are no guarantees about how many buffers the `decodeData` stream is delivered in - it could already have been doing 1MB frames for 5MB of data, or 32KB frames, or really any size. As such I don't think the change merits a runtime guard.
Risk Level: Very small, only a [beneficial] behavior change when receiving large buffers.
Testing: Added test.
Docs Changes: n/a
Release Notes: Yes
Platform Specific Features: n/a
