### PR TITLE
docs: fix DNS docs for edns0_max_payload_size

### DIFF
--- a/api/envoy/extensions/network/dns_resolver/cares/v3/cares_dns_resolver.proto
+++ b/api/envoy/extensions/network/dns_resolver/cares/v3/cares_dns_resolver.proto
@@ -80,11 +80,11 @@ message CaresDnsResolverConfig {
 
   // Maximum EDNS0 UDP payload size in bytes.
   // If set, c-ares will include EDNS0 in DNS queries and use this value as the maximum UDP response size.
-
+  //
   // Recommended values:
   //
-  //   - 1232: Safe default (avoids fragmentation)
-  //   - 4096: Maximum allowed
+  // * **1232**: Safe default (avoids fragmentation).
+  // * **4096**: Maximum allowed.
   //
   // If unset, c-ares uses its internal default (usually 1232).
   google.protobuf.UInt32Value edns0_max_payload_size = 9


### PR DESCRIPTION
## Description

There is a small bug in `edns0_max_payload_size` docs where it skips the first two lines and only renders the docs after `Recommend Values:` due to missing `//` on the line above. This PR fixes the bug so that the docs renders correctly.

<img width="928" height="185" alt="Screenshot 2025-09-17 at 21 19 25" src="https://github.com/user-attachments/assets/982cff84-bec3-487d-b91a-2501d9406eaf" />

It's missing: _"Maximum EDNS0 UDP payload size in bytes. If set, c-ares will include EDNS0 in DNS queries and use this value as the maximum UDP response size."_

---

**Commit Message:** docs: fix DNS docs for edns0_max_payload_size
**Additional Description:** Fixes the bug in the `edns0_max_payload_size` docs.
**Risk Level:** N/A
**Testing:** CI
**Docs Changes:** N/A
**Release Notes:** N/A