### PR TITLE
check request header map count after applying mutations

### DIFF
--- a/test/extensions/filters/http/ext_authz/ext_authz_integration_test.cc
+++ b/test/extensions/filters/http/ext_authz/ext_authz_integration_test.cc
@@ -1917,6 +1917,32 @@ TEST_P(ExtAuthzGrpcIntegrationTest, GoogleAsyncClientCreation) {
   cleanup();
 }
 
+// Verifies that the downstream request fails when the ext_authz response
+// would cause the request headers to exceed their limit.
+TEST_P(ExtAuthzGrpcIntegrationTest, DownstreamRequestFailsOnHeaderLimit) {
+  // Set a low header limit on the HttpConnectionManager. The default request sent by
+  // initiateClientConnection() has 15 headers. The ext_authz response can add one header before
+  // violating this limit.
+  config_helper_.addConfigModifier(
+      [](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
+             hcm) { hcm.mutable_common_http_protocol_options()->mutable_max_headers_count()->set_value(16); });
+
+  initializeConfig();
+  setDownstreamProtocol(Http::CodecType::HTTP2);
+  HttpIntegrationTest::initialize();
+
+  initiateClientConnection(0);
+
+  waitForExtAuthzRequest(expectedCheckRequest(Http::CodecClient::Type::HTTP2));
+  sendExtAuthzResponse({{"header16", "value"}, {"header17", "value"}}, {}, {}, {}, {}, {}, {}, {});
+
+  // The request should now fail with a 431 status code.
+  ASSERT_TRUE(response_->waitForEndStream());
+  EXPECT_TRUE(response_->complete());
+  EXPECT_EQ("500", response_->headers().getStatusValue());
+  cleanup();
+}
+
 // Regression test for https://github.com/envoyproxy/envoy/issues/17344
 TEST(ExtConfigValidateTest, Validate) {
   Server::TestComponentFactory component_factory;

--- a/test/extensions/filters/http/ext_authz/ext_authz_test.cc
+++ b/test/extensions/filters/http/ext_authz/ext_authz_test.cc
@@ -1987,6 +1987,52 @@ TEST_F(HttpFilterTest, ClearCacheRouteHeadersToRemoveOnly) {
   EXPECT_EQ(1U, config_->stats().ok_.value());
 }
 
+// Verifies that the downstream request fails when the ext_authz response
+// would cause the request headers to exceed their limit.
+TEST_F(HttpFilterTest, DownstreamRequestFailsOnHeaderLimit) {
+  InSequence s;
+
+  initialize(R"EOF(
+      grpc_service:
+        envoy_grpc:
+          cluster_name: "ext_authz_server"
+      )EOF");
+
+  // The total number of headers in the request header map is not allowed to
+  // exceed the limit.
+  Http::TestRequestHeaderMapImpl request_headers({}, /*max_headers_kb=*/99999,
+                                                 /*max_headers_count=*/4);
+  request_headers.addCopy(Http::Headers::get().Host, "host");
+  request_headers.addCopy(Http::Headers::get().Path, "/");
+  request_headers.addCopy(Http::Headers::get().Method, "GET");
+
+  prepareCheck();
+
+  EXPECT_CALL(*client_, check(_, _, _, _))
+      .WillOnce(Invoke([&](Filters::Common::ExtAuthz::RequestCallbacks& callbacks,
+                           const envoy::service::auth::v3::CheckRequest&, Tracing::Span&,
+                           const StreamInfo::StreamInfo&) -> void {
+        request_callbacks_ = &callbacks;
+      }));
+
+  EXPECT_EQ(Http::FilterHeadersStatus::StopAllIterationAndWatermark,
+            filter_->decodeHeaders(request_headers, false));
+
+  Filters::Common::ExtAuthz::Response response{};
+  response.status = Filters::Common::ExtAuthz::CheckStatus::OK;
+  response.headers_to_set = {{"foo", "bar"}, {"foo2", "bar2"}};
+
+  // Now the test should fail, since we expect the downstream request to fail.
+  EXPECT_CALL(decoder_filter_callbacks_, encodeHeaders_(_, _))
+      .WillOnce(Invoke([&](const Http::ResponseHeaderMap& headers, bool) -> void {
+        EXPECT_EQ(headers.getStatusValue(),
+                  std::to_string(enumToInt(Http::Code::InternalServerError)));
+      }));
+  EXPECT_CALL(decoder_filter_callbacks_, continueDecoding()).Times(0);
+
+  request_callbacks_->onComplete(std::make_unique<Filters::Common::ExtAuthz::Response>(response));
+}
+
 // Verifies that the filter DOES NOT clear the route cache when an authorization response:
 // 1. is an OK response.
 // 2. has NO headers to append.


### PR DESCRIPTION
Commit Message: check request header map count after applying mutations
Additional Description:

This PR adds a new check to the ext_authz http filter. After request header mutations are applied, this PR checks the number of headers in the request header map and fails the downstream request if the total number of headers is greater than the header limit for the request header map.

There's more that can be done, but no need to do it in a single huge PR. We can check the number of mutations before applying them. We can also do the same things on the response path. This PR just adds the simplest check for the request path.

Risk Level: low
Testing: unit / integration tested