### PR TITLE
ext_proc: add status_on_error option to control the status code returned

### DIFF
--- a/api/envoy/extensions/filters/http/ext_proc/v3/BUILD
+++ b/api/envoy/extensions/filters/http/ext_proc/v3/BUILD
@@ -10,6 +10,7 @@ api_proto_package(
         "//envoy/config/common/mutation_rules/v3:pkg",
         "//envoy/config/core/v3:pkg",
         "//envoy/type/matcher/v3:pkg",
+        "//envoy/type/v3:pkg",
         "@com_github_cncf_xds//udpa/annotations:pkg",
         "@com_github_cncf_xds//xds/annotations/v3:pkg",
     ],

--- a/api/envoy/extensions/filters/http/ext_proc/v3/ext_proc.proto
+++ b/api/envoy/extensions/filters/http/ext_proc/v3/ext_proc.proto
@@ -9,6 +9,7 @@ import "envoy/config/core/v3/grpc_service.proto";
 import "envoy/config/core/v3/http_service.proto";
 import "envoy/extensions/filters/http/ext_proc/v3/processing_mode.proto";
 import "envoy/type/matcher/v3/string.proto";
+import "envoy/type/v3/http_status.proto";
 
 import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
@@ -95,7 +96,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // <arch_overview_advanced_filter_state_sharing>` object in a namespace matching the filter
 // name.
 //
-// [#next-free-field: 24]
+// [#next-free-field: 25]
 message ExternalProcessor {
   // Describes the route cache action to be taken when an external processor response
   // is received in response to request headers.
@@ -350,6 +351,12 @@ message ExternalProcessor {
   // [#extension-category: envoy.http.ext_proc.response_processors]
   config.core.v3.TypedExtensionConfig on_processing_response = 23
       [(xds.annotations.v3.field_status).work_in_progress = true];
+
+  // Sets the HTTP status code that is returned to the client when the external processing server returns
+  // an error, fails to respond, or cannot be reached.
+  //
+  // The default status is ``HTTP 500 Internal Server Error``.
+  type.v3.HttpStatus status_on_error = 24;
 }
 
 // ExtProcHttpService is used for HTTP communication between the filter and the external processing service.

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -365,6 +365,12 @@ new_features:
     :ref:`grpc_service <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.CheckSettings.grpc_service>`
     in the per-route ``check_settings``. Routes without this configuration continue to use the default
     authorization service.
+- area: ext_proc
+  change: |
+    Added :ref:`status_on_error <envoy_v3_api_field_extensions.filters.http.ext_proc.v3.ExternalProcessor.status_on_error>`
+    to the ``ext_proc`` HTTP filter. This allows configuring the HTTP status code returned to the downstream
+    client when communication with the external processor fails (e.g., gRPC error). Previously, these cases returned a
+    fixed ``500``.
 - area: tracing
   change: |
     Added :ref:`trace_context_option <envoy_v3_api_field_config.trace.v3.ZipkinConfig.trace_context_option>` enum

--- a/envoy/http/codes.h
+++ b/envoy/http/codes.h
@@ -74,7 +74,9 @@ enum class Code : uint16_t {
   InsufficientStorage           = 507,
   LoopDetected                  = 508,
   NotExtended                   = 510,
-  NetworkAuthenticationRequired = 511
+  NetworkAuthenticationRequired = 511,
+  // 512-599 are unassigned server error codes.
+  LastUnassignedServerErrorCode = 599
   // clang-format on
 };
 

--- a/source/common/http/codes.cc
+++ b/source/common/http/codes.cc
@@ -292,6 +292,7 @@ const char* CodeUtility::toString(Code code) {
   case Code::LoopDetected:                  return "Loop Detected";
   case Code::NotExtended:                   return "Not Extended";
   case Code::NetworkAuthenticationRequired: return "Network Authentication Required";
+  case Code::LastUnassignedServerErrorCode: return "Last Unassigned Server Error Code";
   }
   // clang-format on
 

--- a/source/extensions/filters/http/ext_proc/ext_proc.h
+++ b/source/extensions/filters/http/ext_proc/ext_proc.h
@@ -10,6 +10,7 @@
 #include "envoy/event/timer.h"
 #include "envoy/extensions/filters/http/ext_proc/v3/ext_proc.pb.h"
 #include "envoy/grpc/async_client.h"
+#include "envoy/http/codes.h"
 #include "envoy/http/filter.h"
 #include "envoy/service/ext_proc/v3/external_processor.pb.h"
 #include "envoy/stats/scope.h"
@@ -305,7 +306,17 @@ public:
 
   std::unique_ptr<OnProcessingResponse> createOnProcessingResponse() const;
 
+  Http::Code statusOnError() const { return status_on_error_; }
+
 private:
+  static Http::Code toErrorCode(uint64_t status) {
+    const auto code = static_cast<Http::Code>(status);
+    if (code >= Http::Code::Continue && code <= Http::Code::NetworkAuthenticationRequired) {
+      return code;
+    }
+    return Http::Code::InternalServerError;
+  }
+
   ExtProcFilterStats generateStats(const std::string& prefix,
                                    const std::string& filter_stats_prefix, Stats::Scope& scope) {
     const std::string final_prefix = absl::StrCat(prefix, "ext_proc.", filter_stats_prefix);
@@ -353,6 +364,7 @@ private:
 
   ThreadLocal::SlotPtr thread_local_stream_manager_slot_;
   const std::chrono::milliseconds remote_close_timeout_;
+  const Http::Code status_on_error_;
 };
 
 using FilterConfigSharedPtr = std::shared_ptr<FilterConfig>;

--- a/source/extensions/filters/http/ext_proc/ext_proc.h
+++ b/source/extensions/filters/http/ext_proc/ext_proc.h
@@ -312,7 +312,7 @@ private:
   static Http::Code toErrorCode(uint64_t status) {
     const auto code = static_cast<Http::Code>(status);
     // Only allow 4xx and 5xx status codes.
-    if (code >= Http::Code::BadRequest && status <= Http::Code::LastUnassignedServerErrorCode) {
+    if (code >= Http::Code::BadRequest && code <= Http::Code::LastUnassignedServerErrorCode) {
       return code;
     }
     return Http::Code::InternalServerError;

--- a/source/extensions/filters/http/ext_proc/ext_proc.h
+++ b/source/extensions/filters/http/ext_proc/ext_proc.h
@@ -311,7 +311,8 @@ public:
 private:
   static Http::Code toErrorCode(uint64_t status) {
     const auto code = static_cast<Http::Code>(status);
-    if (code >= Http::Code::Continue && code <= Http::Code::NetworkAuthenticationRequired) {
+    // Only allow 4xx and 5xx status codes.
+    if (code >= Http::Code::BadRequest && status <= Http::Code::LastUnassignedServerErrorCode) {
       return code;
     }
     return Http::Code::InternalServerError;

--- a/test/extensions/filters/http/ext_proc/BUILD
+++ b/test/extensions/filters/http/ext_proc/BUILD
@@ -206,6 +206,7 @@ envoy_extension_cc_test(
         "@envoy_api//envoy/extensions/filters/http/set_metadata/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/filters/http/upstream_codec/v3:pkg_cc_proto",
         "@envoy_api//envoy/service/ext_proc/v3:pkg_cc_proto",
+        "@envoy_api//envoy/type/v3:pkg_cc_proto",
         "@ocp//ocpdiag/core/testing:status_matchers",
     ],
 )

--- a/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
+++ b/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
@@ -9,12 +9,14 @@
 #include "envoy/extensions/filters/http/upstream_codec/v3/upstream_codec.pb.h"
 #include "envoy/network/address.h"
 #include "envoy/service/ext_proc/v3/external_processor.pb.h"
+#include "envoy/type/v3/http_status.pb.h"
 
 #include "source/common/json/json_loader.h"
 #include "source/extensions/filters/http/ext_proc/config.h"
 #include "source/extensions/filters/http/ext_proc/ext_proc.h"
 #include "source/extensions/filters/http/ext_proc/on_processing_response.h"
 
+#include "test/common/grpc/grpc_client_integration.h"
 #include "test/common/http/common.h"
 #include "test/extensions/filters/http/ext_proc/logging_test_filter.pb.h"
 #include "test/extensions/filters/http/ext_proc/logging_test_filter.pb.validate.h"
@@ -6221,6 +6223,210 @@ TEST_P(ExtProcIntegrationTest, ExtProcLoggingInfoGRPCTimeout) {
   auto field_request_header_status = json_log->getString("field_request_header_call_status");
   // Should be 4:DEADLINE_EXCEEDED instead of 10:ABORTED
   EXPECT_EQ(*field_request_header_status, "4");
+}
+
+// Tests for status_on_error functionality.
+class ExtProcStatusOnErrorIntegrationTest : public HttpIntegrationTest,
+                                            public Grpc::GrpcClientIntegrationParamTest {
+protected:
+  ExtProcStatusOnErrorIntegrationTest()
+      : HttpIntegrationTest(Http::CodecType::HTTP2, ipVersion()) {}
+
+  void createUpstreams() override {
+    HttpIntegrationTest::createUpstreams();
+
+    // Create separate "upstreams" for ExtProc gRPC servers
+    for (int i = 0; i < grpc_upstream_count_; ++i) {
+      grpc_upstreams_.push_back(&addFakeUpstream(Http::CodecType::HTTP2));
+    }
+  }
+
+  void TearDown() override {
+    if (processor_connection_) {
+      ASSERT_TRUE(processor_connection_->close());
+      ASSERT_TRUE(processor_connection_->waitForDisconnect());
+    }
+    cleanupUpstreamAndDownstream();
+  }
+
+  void initializeConfig(uint32_t status_code) {
+    config_helper_.addConfigModifier([this, status_code](
+                                         envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
+      auto* server_cluster = bootstrap.mutable_static_resources()->add_clusters();
+      server_cluster->MergeFrom(bootstrap.static_resources().clusters()[0]);
+      server_cluster->set_name("ext_proc_server");
+      server_cluster->mutable_load_assignment()->set_cluster_name("ext_proc_server");
+
+      setGrpcService(*proto_config_.mutable_grpc_service(), "ext_proc_server",
+                     grpc_upstreams_[0]->localAddress());
+
+      proto_config_.mutable_status_on_error()->set_code(
+          static_cast<envoy::type::v3::StatusCode>(status_code));
+      proto_config_.set_failure_mode_allow(false);
+
+      envoy::extensions::filters::network::http_connection_manager::v3::HttpFilter ext_proc_filter;
+      ext_proc_filter.set_name("envoy.filters.http.ext_proc");
+      ext_proc_filter.mutable_typed_config()->PackFrom(proto_config_);
+      config_helper_.prependFilter(MessageUtil::getJsonStringFromMessageOrError(ext_proc_filter));
+    });
+
+    setUpstreamProtocol(Http::CodecType::HTTP1);
+    setDownstreamProtocol(Http::CodecType::HTTP1);
+  }
+
+  IntegrationStreamDecoderPtr sendDownstreamRequest(
+      absl::optional<std::function<void(Http::RequestHeaderMap& headers)>> modify_headers) {
+    auto conn = makeClientConnection(lookupPort("http"));
+    codec_client_ = makeHttpConnection(std::move(conn));
+    Http::TestRequestHeaderMapImpl headers;
+    HttpTestUtility::addDefaultHeaders(headers);
+    if (modify_headers) {
+      (*modify_headers)(headers);
+    }
+    return codec_client_->makeHeaderOnlyRequest(headers);
+  }
+
+  void waitForFirstMessage(FakeUpstream& grpc_upstream, ProcessingRequest& request) {
+    ASSERT_TRUE(grpc_upstream.waitForHttpConnection(*dispatcher_, processor_connection_));
+    ASSERT_TRUE(processor_connection_->waitForNewStream(*dispatcher_, processor_stream_));
+    ASSERT_TRUE(processor_stream_->waitForGrpcMessage(*dispatcher_, request));
+  }
+
+  bool IsEnvoyGrpc() { return std::get<1>(GetParam()) == Envoy::Grpc::ClientType::EnvoyGrpc; }
+
+  envoy::extensions::filters::http::ext_proc::v3::ExternalProcessor proto_config_{};
+  FakeStreamPtr processor_stream_;
+  FakeHttpConnectionPtr processor_connection_;
+  std::vector<FakeUpstream*> grpc_upstreams_;
+  int grpc_upstream_count_ = 1;
+};
+
+INSTANTIATE_TEST_SUITE_P(IpVersionsClientType, ExtProcStatusOnErrorIntegrationTest,
+                         GRPC_CLIENT_INTEGRATION_PARAMS,
+                         Grpc::GrpcClientIntegrationParamTest::protocolTestParamsToString);
+
+// Test that status_on_error is used when gRPC stream encounters an error.
+TEST_P(ExtProcStatusOnErrorIntegrationTest, GrpcStreamErrorCustomStatus) {
+  SKIP_IF_GRPC_CLIENT(Grpc::ClientType::EnvoyGrpc);
+
+  initializeConfig(503); // Use 503 Service Unavailable.
+  HttpIntegrationTest::initialize();
+  auto response = sendDownstreamRequest(absl::nullopt);
+
+  ProcessingRequest request_headers_msg;
+  waitForFirstMessage(*grpc_upstreams_[0], request_headers_msg);
+  processor_stream_->startGrpcStream();
+
+  // Send successful response first, then simulate gRPC stream error.
+  ProcessingResponse resp;
+  resp.mutable_request_headers();
+  processor_stream_->sendGrpcMessage(resp);
+
+  // Now trigger gRPC stream error which should use status_on_error.
+  processor_stream_->finishGrpcStream(Grpc::Status::Internal);
+
+  // Should get custom status code 503 instead of default 500.
+  ASSERT_TRUE(response->waitForEndStream());
+  EXPECT_EQ("503", response->headers().getStatusValue());
+}
+
+// Test that default status (500) is used when status_on_error is not configured.
+TEST_P(ExtProcStatusOnErrorIntegrationTest, GrpcStreamErrorDefaultStatus) {
+  SKIP_IF_GRPC_CLIENT(Grpc::ClientType::EnvoyGrpc);
+
+  // Initialize without setting status_on_error, should default to 500.
+  config_helper_.addConfigModifier([this](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
+    auto* server_cluster = bootstrap.mutable_static_resources()->add_clusters();
+    server_cluster->MergeFrom(bootstrap.static_resources().clusters()[0]);
+    server_cluster->set_name("ext_proc_server");
+    server_cluster->mutable_load_assignment()->set_cluster_name("ext_proc_server");
+
+    setGrpcService(*proto_config_.mutable_grpc_service(), "ext_proc_server",
+                   grpc_upstreams_[0]->localAddress());
+
+    proto_config_.set_failure_mode_allow(false);
+
+    envoy::extensions::filters::network::http_connection_manager::v3::HttpFilter ext_proc_filter;
+    ext_proc_filter.set_name("envoy.filters.http.ext_proc");
+    ext_proc_filter.mutable_typed_config()->PackFrom(proto_config_);
+    config_helper_.prependFilter(MessageUtil::getJsonStringFromMessageOrError(ext_proc_filter));
+  });
+
+  setUpstreamProtocol(Http::CodecType::HTTP1);
+  setDownstreamProtocol(Http::CodecType::HTTP1);
+
+  HttpIntegrationTest::initialize();
+  auto response = sendDownstreamRequest(absl::nullopt);
+
+  ProcessingRequest request_headers_msg;
+  waitForFirstMessage(*grpc_upstreams_[0], request_headers_msg);
+  processor_stream_->startGrpcStream();
+
+  // Send successful response first, then simulate gRPC stream error.
+  ProcessingResponse resp;
+  resp.mutable_request_headers();
+  processor_stream_->sendGrpcMessage(resp);
+
+  // Trigger gRPC stream error without status_on_error configured.
+  processor_stream_->finishGrpcStream(Grpc::Status::Internal);
+
+  // Should get default status code 500.
+  ASSERT_TRUE(response->waitForEndStream());
+  EXPECT_EQ("500", response->headers().getStatusValue());
+}
+
+// Test that message timeout returns 504 Gateway Timeout regardless of status_on_error.
+TEST_P(ExtProcStatusOnErrorIntegrationTest, MessageTimeoutReturnsGatewayTimeout) {
+  SKIP_IF_GRPC_CLIENT(Grpc::ClientType::EnvoyGrpc);
+
+  initializeConfig(502); // Configure 502, but timeout should return 504.
+  proto_config_.mutable_message_timeout()->set_nanos(100000000); // 100ms timeout.
+
+  HttpIntegrationTest::initialize();
+  auto response = sendDownstreamRequest(absl::nullopt);
+
+  ProcessingRequest request_headers_msg;
+  waitForFirstMessage(*grpc_upstreams_[0], request_headers_msg);
+  processor_stream_->startGrpcStream();
+
+  // Don't send a response to trigger timeout - just wait for the timeout to occur.
+
+  // Let timeout occur.
+  test_server_->waitForCounterGe("http.config_test.ext_proc.message_timeouts", 1);
+
+  // Should return 504 Gateway Timeout instead of configured status_on_error.
+  ASSERT_TRUE(response->waitForEndStream());
+  EXPECT_EQ("504", response->headers().getStatusValue());
+}
+
+// Test that status_on_error is used when processing/mutation errors occur.
+TEST_P(ExtProcStatusOnErrorIntegrationTest, ProcessingErrorCustomStatus) {
+  SKIP_IF_GRPC_CLIENT(Grpc::ClientType::EnvoyGrpc);
+
+  initializeConfig(422); // Use 422 Unprocessable Entity.
+  // Enable strict mutation rules to trigger processing errors.
+  proto_config_.mutable_mutation_rules()->mutable_disallow_is_error()->set_value(true);
+  proto_config_.mutable_mutation_rules()->mutable_disallow_system()->set_value(true);
+
+  HttpIntegrationTest::initialize();
+  auto response = sendDownstreamRequest(absl::nullopt);
+
+  // Process the request and send back invalid system header mutation.
+  ProcessingRequest request_headers_msg;
+  waitForFirstMessage(*grpc_upstreams_[0], request_headers_msg);
+  processor_stream_->startGrpcStream();
+
+  ProcessingResponse resp;
+  auto* header_mut = resp.mutable_request_headers()->mutable_response()->mutable_header_mutation();
+  auto* header = header_mut->add_set_headers();
+  header->mutable_append()->set_value(false);
+  header->mutable_header()->set_key(":system-header"); // This should trigger error.
+  header->mutable_header()->set_raw_value("invalid");
+  processor_stream_->sendGrpcMessage(resp);
+
+  // Should get custom status code 422 for processing error.
+  ASSERT_TRUE(response->waitForEndStream());
+  EXPECT_EQ("422", response->headers().getStatusValue());
 }
 
 } // namespace Envoy


### PR DESCRIPTION
## Description

This PR adds a new `status_on_error` in ExtProc similar to what we [have for ExtAuthZ](https://arc.net/l/quote/zoibcqsy) which could be used to control the status code returned back to the user in case of failures. users can have some flow in which they expect a different status code to be returned for failures instead of the hardcoded **500 Internal Server Error**.

---

**Commit Message:** ext_proc: add status_on_error option to control the status code returned
**Additional Description:** Added a new `status_on_error` in ExtProc to control the HTTP status code returned back to the user in case of failures.
**Risk Level:** Low
**Testing:** Added Integration Tests & Unit Tests
**Docs Changes:** Added
**Release Notes:** Added