### PR TITLE
[bp/1.34] ci: gcc: Build before testing

### DIFF
--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -687,14 +687,14 @@ case $CI_TARGET in
         CONFIG="${CONFIG_PREFIX}gcc"
         BAZEL_BUILD_OPTIONS+=("--config=${CONFIG}")
         echo "gcc toolchain configured: ${CONFIG}"
+        echo "bazel fastbuild build with gcc..."
+        bazel_envoy_binary_build fastbuild
         echo "Testing ${TEST_TARGETS[*]}"
         bazel_with_collection \
             test "${BAZEL_BUILD_OPTIONS[@]}" \
             -c fastbuild  \
             --remote_download_minimal \
             -- "${TEST_TARGETS[@]}"
-        echo "bazel release build with gcc..."
-        bazel_envoy_binary_build fastbuild
         ;;
 
     info)


### PR DESCRIPTION
Mimic the behavior of clang; Building first might catch build and dependencies failures earlier.
