### PR TITLE
encode whether require_client_certificate was explicitly configured or not

### DIFF
--- a/envoy/ssl/context_config.h
+++ b/envoy/ssl/context_config.h
@@ -184,7 +184,7 @@ public:
   /**
    * @return True if client certificate is required, false otherwise.
    */
-  virtual bool requireClientCertificate() const PURE;
+  virtual absl::optional<bool> requireClientCertificate() const PURE;
 
   /**
    * @return OcspStaplePolicy The rule for determining whether to staple OCSP

--- a/source/common/quic/quic_server_transport_socket_factory.cc
+++ b/source/common/quic/quic_server_transport_socket_factory.cc
@@ -25,7 +25,8 @@ QuicServerTransportSocketConfigFactory::createTransportSocketFactory(
   RETURN_IF_NOT_OK(server_config_or_error.status());
   auto server_config = std::move(server_config_or_error.value());
   // TODO(RyanTheOptimist): support TLS client authentication.
-  if (server_config->requireClientCertificate()) {
+  if (server_config->requireClientCertificate().has_value() &&
+      *server_config->requireClientCertificate()) {
     return absl::InvalidArgumentError("TLS Client Authentication is not supported over QUIC");
   }
 

--- a/source/common/tls/server_context_config_impl.cc
+++ b/source/common/tls/server_context_config_impl.cc
@@ -124,8 +124,9 @@ ServerContextConfigImpl::ServerContextConfigImpl(
           config.common_tls_context(), false /* auto_sni_san_match */, DEFAULT_MIN_VERSION,
           DEFAULT_MAX_VERSION, FIPS_mode() ? DEFAULT_CIPHER_SUITES_FIPS : DEFAULT_CIPHER_SUITES,
           FIPS_mode() ? DEFAULT_CURVES_FIPS : DEFAULT_CURVES, factory_context, creation_status),
-      require_client_certificate_(
-          PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, require_client_certificate, absl::nullopt)),
+      require_client_certificate_(config.has_require_client_certificate()
+                                      ? config.require_client_certificate().value()
+                                      : absl::nullopt),
       ocsp_staple_policy_(ocspStaplePolicyFromProto(config.ocsp_staple_policy())),
       session_ticket_keys_provider_(
           getTlsSessionTicketKeysConfigProvider(factory_context, config, creation_status)),

--- a/source/common/tls/server_context_config_impl.cc
+++ b/source/common/tls/server_context_config_impl.cc
@@ -125,7 +125,7 @@ ServerContextConfigImpl::ServerContextConfigImpl(
           DEFAULT_MAX_VERSION, FIPS_mode() ? DEFAULT_CIPHER_SUITES_FIPS : DEFAULT_CIPHER_SUITES,
           FIPS_mode() ? DEFAULT_CURVES_FIPS : DEFAULT_CURVES, factory_context, creation_status),
       require_client_certificate_(
-          PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, require_client_certificate, false)),
+          PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, require_client_certificate, absl::nullopt)),
       ocsp_staple_policy_(ocspStaplePolicyFromProto(config.ocsp_staple_policy())),
       session_ticket_keys_provider_(
           getTlsSessionTicketKeysConfigProvider(factory_context, config, creation_status)),

--- a/source/common/tls/server_context_config_impl.cc
+++ b/source/common/tls/server_context_config_impl.cc
@@ -124,9 +124,10 @@ ServerContextConfigImpl::ServerContextConfigImpl(
           config.common_tls_context(), false /* auto_sni_san_match */, DEFAULT_MIN_VERSION,
           DEFAULT_MAX_VERSION, FIPS_mode() ? DEFAULT_CIPHER_SUITES_FIPS : DEFAULT_CIPHER_SUITES,
           FIPS_mode() ? DEFAULT_CURVES_FIPS : DEFAULT_CURVES, factory_context, creation_status),
-      require_client_certificate_(config.has_require_client_certificate()
-                                      ? config.require_client_certificate().value()
-                                      : absl::nullopt),
+      require_client_certificate_(
+          config.has_require_client_certificate()
+              ? absl::make_optional(config.require_client_certificate().value())
+              : absl::nullopt),
       ocsp_staple_policy_(ocspStaplePolicyFromProto(config.ocsp_staple_policy())),
       session_ticket_keys_provider_(
           getTlsSessionTicketKeysConfigProvider(factory_context, config, creation_status)),

--- a/source/common/tls/server_context_config_impl.h
+++ b/source/common/tls/server_context_config_impl.h
@@ -18,7 +18,9 @@ public:
          bool for_quic);
 
   // Ssl::ServerContextConfig
-  bool requireClientCertificate() const override { return require_client_certificate_; }
+  absl::optional<bool> requireClientCertificate() const override {
+    return require_client_certificate_;
+  }
   OcspStaplePolicy ocspStaplePolicy() const override { return ocsp_staple_policy_; }
   const std::vector<SessionTicketKey>& sessionTicketKeys() const override {
     return session_ticket_keys_;
@@ -58,7 +60,7 @@ private:
   static const std::string DEFAULT_CURVES;
   static const std::string DEFAULT_CURVES_FIPS;
 
-  const bool require_client_certificate_;
+  const absl::optional<bool> require_client_certificate_;
   const OcspStaplePolicy ocsp_staple_policy_;
   std::vector<SessionTicketKey> session_ticket_keys_;
   const Secret::TlsSessionTicketKeysConfigProviderSharedPtr session_ticket_keys_provider_;

--- a/source/common/tls/server_context_impl.cc
+++ b/source/common/tls/server_context_impl.cc
@@ -140,9 +140,10 @@ ServerContextImpl::ServerContextImpl(Stats::Scope& scope,
   for (uint32_t i = 0; i < tls_certificates.size(); ++i) {
     auto& ctx = tls_contexts_[i];
     if (!config.capabilities().verifies_peer_certificates) {
-      SET_AND_RETURN_IF_NOT_OK(cert_validator_->addClientValidationContext(
-                                   ctx.ssl_ctx_.get(), config.requireClientCertificate()),
-                               creation_status);
+      SET_AND_RETURN_IF_NOT_OK(
+          cert_validator_->addClientValidationContext(
+              ctx.ssl_ctx_.get(), config.requireClientCertificate().value_or(false)),
+          creation_status);
     }
 
     if (!parsed_alpn_protocols_.empty() && !config.capabilities().handles_alpn_selection) {

--- a/test/mocks/ssl/mocks.h
+++ b/test/mocks/ssl/mocks.h
@@ -160,7 +160,7 @@ public:
   MOCK_METHOD(Ssl::HandshakerCapabilities, capabilities, (), (const, override));
   MOCK_METHOD(Ssl::SslCtxCb, sslctxCb, (), (const, override));
 
-  MOCK_METHOD(bool, requireClientCertificate, (), (const));
+  MOCK_METHOD(absl::optional<bool>, requireClientCertificate, (), (const));
   MOCK_METHOD(OcspStaplePolicy, ocspStaplePolicy, (), (const));
   MOCK_METHOD(const std::vector<SessionTicketKey>&, sessionTicketKeys, (), (const));
   MOCK_METHOD(bool, disableStatelessSessionResumption, (), (const));


### PR DESCRIPTION
Commit Message: encode whether require_client_certificate was explicitly configured or not
Additional Description:

Currently require_client_certificate always defaults to false. Even when you configure downstream tls options with trusted_ca set to true. This means if you configure a trusted_ca, if the downstream provides a client cert, it will be validated via your cert validation config, but if they don't provide a cert, that's ok too. This may be surprising (and indeed has been for some). It's not secure by default.

We should prefer for envoy to be secure by default (and require a client certificate if you have configured a trusted_ca if you did not explicitly configure `require_client_certificate=false`) or at least loudly complain if you are doing something that might not work the way you are expecting.

To implement either of these, you need to preserve whether or not the configuration explicitly provided a value and not just default to false.

No behavior change for any configs with this PR, just encoding additional information in the saved config.

Risk Level: none
Testing: no behavior change, existing tests should all pass
Docs Changes: none 
Release Notes: none