### PR TITLE
docs: clarify gateway-error behavior

### DIFF
--- a/docs/root/configuration/http/http_filters/router_filter.rst
+++ b/docs/root/configuration/http/http_filters/router_filter.rst
@@ -83,8 +83,8 @@ can be specified using a ',' delimited list. The supported policies are:
     request, including any retries that take place.
 
 gateway-error
-  This policy is similar to the *5xx* policy but will only retry requests that result in a 502, 503,
-  or 504.
+  This policy is similar to the *5xx* policy but will attempt a retry if the upstream server responds
+  with 502, 503, or 504 response code, or does not respond at all (disconnect/reset/read timeout).
 
 reset
   Envoy will attempt a retry if the upstream server does not respond at all (disconnect/reset/read timeout.)


### PR DESCRIPTION
Commit Message: clarify gateway-error behaviour for HTTP router filter
Additional Description: `gateway-error` retries on timeouts, not only 502/503/504 errors as stated.
Risk Level: Low
Testing: N/A
Docs Changes: clarify gateway-error behaviour for HTTP router filter
Release Notes: N/A
Platform Specific Features: N/A
