### PR TITLE
Use mutex reference in lock constructors p2

### DIFF
--- a/mobile/library/common/logger/logger_delegate.cc
+++ b/mobile/library/common/logger/logger_delegate.cc
@@ -44,12 +44,12 @@ DefaultDelegate::~DefaultDelegate() { restoreDelegate(); }
 
 // SinkDelegate
 void DefaultDelegate::log(absl::string_view msg, const spdlog::details::log_msg&) {
-  absl::MutexLock l(&mutex_);
+  absl::MutexLock l(mutex_);
   std::cerr << msg;
 }
 
 void DefaultDelegate::flush() {
-  absl::MutexLock l(&mutex_);
+  absl::MutexLock l(mutex_);
   std::cerr << std::flush;
 }
 

--- a/test/integration/alpn_integration_test.cc
+++ b/test/integration/alpn_integration_test.cc
@@ -146,7 +146,7 @@ TEST_P(AlpnIntegrationTest, Http2RememberSettings) {
   test_server_->waitForCounterGe("cluster.cluster_0.upstream_cx_total", 1);
 
   {
-    absl::MutexLock l(&fake_upstreams_[0]->lock());
+    absl::MutexLock l(fake_upstreams_[0]->lock());
     IntegrationCodecClientPtr codec_client1 = makeHttpConnection(lookupPort("http"));
     auto response1 = codec_client1->makeHeaderOnlyRequest(default_request_headers_);
     IntegrationCodecClientPtr codec_client2 = makeHttpConnection(lookupPort("http"));

--- a/test/integration/api_listener_integration_test.cc
+++ b/test/integration/api_listener_integration_test.cc
@@ -162,7 +162,7 @@ TEST_P(ApiListenerIntegrationTest, FromWorkerThread) {
       ThreadLocal::TypedSlot<>::makeUnique(test_server_->server().threadLocal());
   slot->set([&dispatchers_mutex, &dispatchers, &has_dispatcher](
                 Event::Dispatcher& dispatcher) -> std::shared_ptr<ThreadLocal::ThreadLocalObject> {
-    absl::MutexLock ml(&dispatchers_mutex);
+    absl::MutexLock ml(dispatchers_mutex);
     // A string comparison on thread name seems to be the only way to
     // distinguish worker threads from the main thread with the slots interface.
     if (dispatcher.name() != "main_thread") {

--- a/test/integration/autonomous_upstream.cc
+++ b/test/integration/autonomous_upstream.cc
@@ -44,7 +44,7 @@ void AutonomousStream::decodeHeaders(Http::RequestHeaderMapSharedPtr&& headers, 
   FakeStream::decodeHeaders(std::move(headers), end_stream);
 
   if (send_response) {
-    absl::MutexLock lock(&lock_);
+    absl::MutexLock lock(lock_);
     sendResponse();
   }
 }

--- a/test/integration/base_integration_test.cc
+++ b/test/integration/base_integration_test.cc
@@ -377,12 +377,12 @@ bool BaseIntegrationTest::getSocketOption(const std::string& listener_name, int 
   std::vector<std::reference_wrapper<Network::ListenerConfig>> listeners;
   test_server_->server().dispatcher().post([&]() {
     listeners = test_server_->server().listenerManager().listeners();
-    l.Lock();
+    l.lock();
     listeners_ready = true;
-    l.Unlock();
+    l.unlock();
   });
   l.LockWhen(absl::Condition(&listeners_ready));
-  l.Unlock();
+  l.unlock();
 
   for (auto& listener : listeners) {
     if (listener.get().name() == listener_name) {
@@ -404,12 +404,12 @@ void BaseIntegrationTest::registerTestServerPorts(const std::vector<std::string>
   std::vector<std::reference_wrapper<Network::ListenerConfig>> listeners;
   test_server->server().dispatcher().post([&listeners, &listeners_ready, &l, &test_server]() {
     listeners = test_server->server().listenerManager().listeners();
-    l.Lock();
+    l.lock();
     listeners_ready = true;
-    l.Unlock();
+    l.unlock();
   });
   l.LockWhen(absl::Condition(&listeners_ready));
-  l.Unlock();
+  l.unlock();
 
   auto listener_it = listeners.cbegin();
   auto port_it = port_names.cbegin();


### PR DESCRIPTION
Replace deprecated absl::MutexLock::MutexLock(Mutex*) constructor with absl::MutexLock::MutexLock(Mutex&)

Risk Level: none
Testing: unit tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a