### PR TITLE
python: Remove requirements.txt entry from .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,6 +6,5 @@
 /test/common/tls/test_data/aes_128_key binary
 /test/common/tls/test_data/ticket_key_* binary
 /test/**/*_corpus/* linguist-generated=true
-requirements.txt binary
 package.lock binary
 yarn.lock binary


### PR DESCRIPTION
this causes more problems than it solves and seems to break dependabot

