### PR TITLE
router: Support request header addition/removal and host header rewrite for mirroring

### DIFF
--- a/api/envoy/config/route/v3/route_components.proto
+++ b/api/envoy/config/route/v3/route_components.proto
@@ -833,7 +833,7 @@ message RouteAction {
   // .. note::
   //
   //   Shadowing doesn't support Http CONNECT and upgrades.
-  // [#next-free-field: 7]
+  // [#next-free-field: 9]
   message RequestMirrorPolicy {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.api.v2.route.RouteAction.RequestMirrorPolicy";
@@ -885,6 +885,21 @@ message RouteAction {
 
     // Disables appending the ``-shadow`` suffix to the shadowed ``Host`` header. Defaults to ``false``.
     bool disable_shadow_host_suffix_append = 6;
+
+    // Specifies a list of HTTP headers that should be added to each mirrored request.
+    // Headers specified here take precedence over any headers with the same name
+    // from the original request. For more information, including details on header value syntax, see
+    // the documentation on :ref:`custom request headers
+    // <config_http_conn_man_headers_custom_request_headers>`.
+    repeated core.v3.HeaderValueOption request_headers_to_add = 7
+        [(validate.rules).repeated = {max_items: 1000}];
+
+    // Specifies a list of HTTP headers that should be removed from each request that is sent to the
+    // health checked cluster.
+    repeated string request_headers_to_remove = 8 [(validate.rules).repeated = {
+      items {string {well_known_regex: HTTP_HEADER_NAME strict: false}}
+    }];
+
   }
 
   // Specifies the route's hashing policy if the upstream cluster uses a hashing :ref:`load balancer

--- a/api/envoy/config/route/v3/route_components.proto
+++ b/api/envoy/config/route/v3/route_components.proto
@@ -833,7 +833,7 @@ message RouteAction {
   // .. note::
   //
   //   Shadowing doesn't support Http CONNECT and upgrades.
-  // [#next-free-field: 9]
+  // [#next-free-field: 10]
   message RequestMirrorPolicy {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.api.v2.route.RouteAction.RequestMirrorPolicy";
@@ -895,11 +895,15 @@ message RouteAction {
         [(validate.rules).repeated = {max_items: 1000}];
 
     // Specifies a list of HTTP headers that should be removed from each request that is sent to the
-    // health checked cluster.
+    // mirror cluster.
     repeated string request_headers_to_remove = 8 [(validate.rules).repeated = {
       items {string {well_known_regex: HTTP_HEADER_NAME strict: false}}
     }];
 
+    // Indicates that during mirroring, the host header will be swapped with this value.
+    // `disable_shadow_host_suffix_append` is always enabled if this field is set.
+    string host_rewrite_literal = 9
+        [(validate.rules).string = {well_known_regex: HTTP_HEADER_VALUE strict: false}];
   }
 
   // Specifies the route's hashing policy if the upstream cluster uses a hashing :ref:`load balancer

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -419,4 +419,16 @@ new_features:
 - area: dynamic_modules
   change: |
     Added support for counters, gauges, histograms, and their vector variants to the dynamic modules API.
+- area: router
+  change: |
+    Added support for :ref:`request_headers_to_add
+    <envoy_v3_api_field_config.route.v3.RouteAction.RequestMirrorPolicy.request_headers_to_add>` and
+    :ref:`request_headers_to_remove
+    <envoy_v3_api_field_config.route.v3.RouteAction.RequestMirrorPolicy.request_headers_to_remove>` in
+    :ref:`request_mirror_policies <envoy_v3_api_field_config.route.v3.RouteAction.request_mirror_policies>` to enable header
+    manipulation for mirror requests.
+    Added support for :ref:`host_rewrite_literal
+    <envoy_v3_api_field_config.route.v3.RouteAction.RequestMirrorPolicy.host_rewrite_literal>` in
+    :ref:`request_mirror_policies <envoy_v3_api_field_config.route.v3.RouteAction.request_mirror_policies>` to enable
+    host header rewrite for mirror requests.
 deprecated:

--- a/envoy/http/BUILD
+++ b/envoy/http/BUILD
@@ -224,7 +224,7 @@ envoy_cc_library(
     name = "header_evaluator",
     hdrs = ["header_evaluator.h"],
     deps = [
-        "//envoy/formatter:substitution_formatter_interface",
+        "//envoy/formatter:http_formatter_context_interface",
         "//envoy/http:header_map_interface",
         "//envoy/stream_info:stream_info_interface",
     ],

--- a/envoy/http/header_evaluator.h
+++ b/envoy/http/header_evaluator.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "envoy/formatter/substitution_formatter.h"
+#include "envoy/formatter/http_formatter_context.h"
 #include "envoy/http/header_map.h"
 #include "envoy/stream_info/stream_info.h"
 

--- a/envoy/router/BUILD
+++ b/envoy/router/BUILD
@@ -89,6 +89,7 @@ envoy_cc_library(
         "//envoy/http:codes_interface",
         "//envoy/http:conn_pool_interface",
         "//envoy/http:hash_policy_interface",
+        "//envoy/http:header_evaluator",
         "//envoy/http:header_map_interface",
         "//envoy/rds:rds_config_interface",
         "//envoy/tcp:conn_pool_interface",

--- a/envoy/router/router.h
+++ b/envoy/router/router.h
@@ -552,6 +552,11 @@ public:
    * @return the header evaluator for manipulating headers in mirrored requests.
    */
   virtual const Http::HeaderEvaluator& headerEvaluator() const PURE;
+
+  /**
+   * @return the literal value to rewrite the host header with, or empty if no rewrite.
+   */
+  virtual absl::string_view hostRewriteLiteral() const PURE;
 };
 
 using ShadowPolicyPtr = std::shared_ptr<ShadowPolicy>;

--- a/envoy/router/router.h
+++ b/envoy/router/router.h
@@ -17,6 +17,7 @@
 #include "envoy/http/codes.h"
 #include "envoy/http/conn_pool.h"
 #include "envoy/http/hash_policy.h"
+#include "envoy/http/header_evaluator.h"
 #include "envoy/rds/config.h"
 #include "envoy/router/internal_redirect.h"
 #include "envoy/router/path_matcher.h"
@@ -546,6 +547,11 @@ public:
    * @return true if host name should be suffixed with "-shadow".
    */
   virtual bool disableShadowHostSuffixAppend() const PURE;
+
+  /**
+   * @return the header evaluator for manipulating headers in mirrored requests.
+   */
+  virtual const Http::HeaderEvaluator& headerEvaluator() const PURE;
 };
 
 using ShadowPolicyPtr = std::shared_ptr<ShadowPolicy>;

--- a/source/common/router/BUILD
+++ b/source/common/router/BUILD
@@ -489,6 +489,7 @@ envoy_cc_library(
     ],
     hdrs = ["header_parser.h"],
     deps = [
+        "//envoy/formatter:substitution_formatter_interface",
         "//envoy/http:header_evaluator",
         "//envoy/http:header_map_interface",
         "//source/common/formatter:substitution_formatter_lib",

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -434,7 +434,8 @@ ShadowPolicyImpl::create(const RequestMirrorPolicy& config) {
 
 ShadowPolicyImpl::ShadowPolicyImpl(const RequestMirrorPolicy& config, absl::Status& creation_status)
     : cluster_(config.cluster()), cluster_header_(config.cluster_header()),
-      disable_shadow_host_suffix_append_(config.disable_shadow_host_suffix_append()) {
+      disable_shadow_host_suffix_append_(config.disable_shadow_host_suffix_append()),
+      host_rewrite_literal_(config.host_rewrite_literal()) {
   SET_AND_RETURN_IF_NOT_OK(validateMirrorClusterSpecifier(config), creation_status);
 
   if (config.has_runtime_fraction()) {

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -491,6 +491,7 @@ public:
   const envoy::type::v3::FractionalPercent& defaultValue() const override { return default_value_; }
   absl::optional<bool> traceSampled() const override { return trace_sampled_; }
   bool disableShadowHostSuffixAppend() const override { return disable_shadow_host_suffix_append_; }
+  const Http::HeaderEvaluator& headerEvaluator() const override;
 
 private:
   explicit ShadowPolicyImpl(const RequestMirrorPolicy& config, absl::Status& creation_status);
@@ -501,6 +502,7 @@ private:
   envoy::type::v3::FractionalPercent default_value_;
   absl::optional<bool> trace_sampled_;
   const bool disable_shadow_host_suffix_append_;
+  Router::HeaderParserPtr request_headers_parser_;
 };
 
 /**

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -490,8 +490,11 @@ public:
   const std::string& runtimeKey() const override { return runtime_key_; }
   const envoy::type::v3::FractionalPercent& defaultValue() const override { return default_value_; }
   absl::optional<bool> traceSampled() const override { return trace_sampled_; }
-  bool disableShadowHostSuffixAppend() const override { return disable_shadow_host_suffix_append_; }
+  bool disableShadowHostSuffixAppend() const override {
+    return disable_shadow_host_suffix_append_ || !host_rewrite_literal_.empty();
+  }
   const Http::HeaderEvaluator& headerEvaluator() const override;
+  absl::string_view hostRewriteLiteral() const override { return host_rewrite_literal_; }
 
 private:
   explicit ShadowPolicyImpl(const RequestMirrorPolicy& config, absl::Status& creation_status);
@@ -502,6 +505,7 @@ private:
   envoy::type::v3::FractionalPercent default_value_;
   absl::optional<bool> trace_sampled_;
   const bool disable_shadow_host_suffix_append_;
+  const std::string host_rewrite_literal_;
   Router::HeaderParserPtr request_headers_parser_;
 };
 

--- a/source/common/router/header_parser.h
+++ b/source/common/router/header_parser.h
@@ -5,6 +5,7 @@
 
 #include "envoy/access_log/access_log.h"
 #include "envoy/config/core/v3/base.pb.h"
+#include "envoy/formatter/substitution_formatter_base.h"
 #include "envoy/http/header_evaluator.h"
 #include "envoy/http/header_map.h"
 

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -1159,6 +1159,10 @@ void Filter::applyShadowPolicyHeaders(const ShadowPolicy& shadow_policy,
   const Envoy::Formatter::HttpFormatterContext formatter_context{&headers};
   shadow_policy.headerEvaluator().evaluateHeaders(headers, formatter_context,
                                                   callbacks_->streamInfo());
+
+  if (!shadow_policy.hostRewriteLiteral().empty()) {
+    headers.setHost(shadow_policy.hostRewriteLiteral());
+  }
 }
 
 void Filter::onRequestComplete() {

--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -537,6 +537,8 @@ private:
   UpstreamRequestPtr createUpstreamRequest();
   absl::optional<absl::string_view> getShadowCluster(const ShadowPolicy& shadow_policy,
                                                      const Http::HeaderMap& headers) const;
+  void applyShadowPolicyHeaders(const ShadowPolicy& shadow_policy,
+                                Http::RequestHeaderMap& headers) const;
   bool maybeRetryReset(Http::StreamResetReason reset_reason, UpstreamRequest& upstream_request,
                        TimeoutRetry is_timeout_retry);
   uint32_t numRequestsAwaitingHeaders();

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -5031,13 +5031,12 @@ TEST_F(RouterTest, ResponseHeadersTCopyCopiesHeadersOrClears) {
 
 namespace {
 
-std::shared_ptr<ShadowPolicyImpl>
-makeShadowPolicy(std::string cluster = "", std::string cluster_header = "",
-                 absl::optional<std::string> runtime_key = absl::nullopt,
-                 absl::optional<envoy::type::v3::FractionalPercent> default_value = absl::nullopt,
-                 bool trace_sampled = true,
-                 std::vector<std::pair<std::string, std::string>> headers_to_add = {},
-                 std::vector<std::string> headers_to_remove = {}) {
+std::shared_ptr<ShadowPolicyImpl> makeShadowPolicy(
+    std::string cluster = "", std::string cluster_header = "",
+    absl::optional<std::string> runtime_key = absl::nullopt,
+    absl::optional<envoy::type::v3::FractionalPercent> default_value = absl::nullopt,
+    bool trace_sampled = true, std::vector<std::pair<std::string, std::string>> headers_to_add = {},
+    std::vector<std::string> headers_to_remove = {}, std::string host_rewrite_literal = "") {
   envoy::config::route::v3::RouteAction::RequestMirrorPolicy policy;
   policy.set_cluster(cluster);
   policy.set_cluster_header(cluster_header);
@@ -5057,6 +5056,10 @@ makeShadowPolicy(std::string cluster = "", std::string cluster_header = "",
 
   for (const auto& header_name : headers_to_remove) {
     policy.add_request_headers_to_remove(header_name);
+  }
+
+  if (!host_rewrite_literal.empty()) {
+    policy.set_host_rewrite_literal(host_rewrite_literal);
   }
 
   return THROW_OR_RETURN_VALUE(ShadowPolicyImpl::create(policy), std::shared_ptr<ShadowPolicyImpl>);

--- a/test/integration/shadow_policy_integration_test.cc
+++ b/test/integration/shadow_policy_integration_test.cc
@@ -1033,5 +1033,85 @@ TEST_P(ShadowPolicyIntegrationTest, ShadowedRequestMetadataLoadbalancing) {
   sendRequestAndValidateResponse();
 }
 
+TEST_P(ShadowPolicyIntegrationTest, ShadowWithHeaderManipulation) {
+  initialConfigSetup("cluster_1", "");
+
+  // Configure the mirror policy with header manipulation
+  config_helper_.addConfigModifier(
+      [=](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
+              hcm) -> void {
+        auto* mirror_policy = hcm.mutable_route_config()
+                                  ->mutable_virtual_hosts(0)
+                                  ->mutable_routes(0)
+                                  ->mutable_route()
+                                  ->mutable_request_mirror_policies(0);
+
+        auto* header_to_add1 = mirror_policy->add_request_headers_to_add();
+        header_to_add1->mutable_header()->set_key("x-mirror-test");
+        header_to_add1->mutable_header()->set_value("mirror-value");
+        header_to_add1->set_append_action(
+            envoy::config::core::v3::HeaderValueOption::OVERWRITE_IF_EXISTS_OR_ADD);
+
+        auto* header_to_add2 = mirror_policy->add_request_headers_to_add();
+        header_to_add2->mutable_header()->set_key("x-mirror-static");
+        header_to_add2->mutable_header()->set_value("static-value");
+
+        mirror_policy->add_request_headers_to_remove("x-sensitive-header");
+        mirror_policy->add_request_headers_to_remove("authorization");
+
+        mirror_policy->set_host_rewrite_literal("shadow-target.example.com");
+      });
+
+  initialize();
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+
+  // Create request headers including some that should be removed in the shadow
+  Http::TestRequestHeaderMapImpl request_headers = default_request_headers_;
+  request_headers.addCopy("x-sensitive-header", "secret-data");
+  request_headers.addCopy("authorization", "Bearer token123");
+  request_headers.addCopy("x-custom-header", "should-remain");
+  request_headers.addCopy("x-mirror-test", "should-be-overwritten");
+
+  IntegrationStreamDecoderPtr response = codec_client_->makeHeaderOnlyRequest(request_headers);
+  ASSERT_TRUE(response->waitForEndStream());
+  EXPECT_TRUE(response->complete());
+  EXPECT_EQ("200", response->headers().getStatusValue());
+
+  upstream_headers_ =
+      reinterpret_cast<AutonomousUpstream*>(fake_upstreams_[0].get())->lastRequestHeaders();
+  EXPECT_TRUE(upstream_headers_ != nullptr);
+  mirror_headers_ =
+      reinterpret_cast<AutonomousUpstream*>(fake_upstreams_[1].get())->lastRequestHeaders();
+  EXPECT_TRUE(mirror_headers_ != nullptr);
+
+  // Validate that main request headers are unchanged
+  EXPECT_EQ(upstream_headers_->get(Http::LowerCaseString("x-sensitive-header"))[0]->value(),
+            "secret-data");
+  EXPECT_EQ(upstream_headers_->get(Http::LowerCaseString("authorization"))[0]->value(),
+            "Bearer token123");
+  EXPECT_EQ(upstream_headers_->get(Http::LowerCaseString("x-custom-header"))[0]->value(),
+            "should-remain");
+
+  // Validate that mirror request has added headers
+  EXPECT_EQ(mirror_headers_->get(Http::LowerCaseString("x-mirror-test"))[0]->value(),
+            "mirror-value");
+  EXPECT_EQ(mirror_headers_->get(Http::LowerCaseString("x-mirror-static"))[0]->value(),
+            "static-value");
+
+  // Validate that mirror request has removed sensitive headers
+  EXPECT_TRUE(mirror_headers_->get(Http::LowerCaseString("x-sensitive-header")).empty());
+  EXPECT_TRUE(mirror_headers_->get(Http::LowerCaseString("authorization")).empty());
+
+  // Validate that non-sensitive headers are preserved in mirror
+  EXPECT_EQ(mirror_headers_->get(Http::LowerCaseString("x-custom-header"))[0]->value(),
+            "should-remain");
+
+  EXPECT_EQ(mirror_headers_->getHostValue(), "shadow-target.example.com");
+  EXPECT_EQ(upstream_headers_->getHostValue(), "sni.lyft.com");
+
+  cleanupUpstreamAndDownstream();
+}
+
 } // namespace
 } // namespace Envoy


### PR DESCRIPTION
Commit Message: router: Allow request header addition/removal and host header rewrite for mirroring
Additional Description:
Risk Level: Low
Testing: unit/integ tests
Docs Changes:
Release Notes: Added support for `request_headers_to_add` and `request_headers_to_remove` in `request_mirror_policies` to enable header manipulation for mirror requests. Added support for `host_rewrite_literal` in `request_mirror_policies` to enable host header rewrite for mirror requests.
Platform Specific Features:
