### PR TITLE
compressor: fix the compressor docs to highlight other extensions

### DIFF
--- a/api/envoy/extensions/filters/http/compressor/v3/compressor.proto
+++ b/api/envoy/extensions/filters/http/compressor/v3/compressor.proto
@@ -28,21 +28,31 @@ message Compressor {
       "envoy.config.filter.http.compressor.v2.Compressor";
 
   message CommonDirectionConfig {
-    // Runtime flag that controls whether compression is enabled or not for the direction this
-    // common config is put in. If set to false, the filter will operate as a pass-through filter
-    // in the chosen direction, unless overridden by CompressorPerRoute.
-    // If the field is omitted, the filter will be enabled.
+    // Runtime flag that controls whether compression is enabled for the direction this
+    // common config is applied to. When this field is ``false``, the filter will operate as a
+    // pass-through filter in the chosen direction, unless overridden by ``CompressorPerRoute``.
+    // If this field is not specified, the filter will be enabled.
     config.core.v3.RuntimeFeatureFlag enabled = 1;
 
-    // Minimum value of Content-Length header of request or response messages (depending on the direction
-    // this common config is put in), in bytes, which will trigger compression. The default value is 30.
+    // Minimum value of the ``Content-Length`` header in request or response messages (depending on the
+    // direction this common config is applied to), in bytes, that will trigger compression. Defaults to 30.
     google.protobuf.UInt32Value min_content_length = 2;
 
     // Set of strings that allows specifying which mime-types yield compression; e.g.,
-    // application/json, text/html, etc. When this field is not defined, compression will be applied
-    // to the following mime-types: "application/javascript", "application/json",
-    // "application/xhtml+xml", "image/svg+xml", "text/css", "text/html", "text/plain", "text/xml"
-    // and their synonyms.
+    // ``application/json``, ``text/html``, etc.
+    //
+    // When this field is not specified, compression will be applied to these following mime-types
+    // and their synonyms:
+    //
+    // * ``application/javascript``
+    // * ``application/json``
+    // * ``application/xhtml+xml``
+    // * ``image/svg+xml``
+    // * ``text/css``
+    // * ``text/html``
+    // * ``text/plain``
+    // * ``text/xml``
+    // 
     repeated string content_type = 3;
   }
 
@@ -55,20 +65,21 @@ message Compressor {
   message ResponseDirectionConfig {
     CommonDirectionConfig common_config = 1;
 
-    // If true, disables compression when the response contains an etag header. When it is false, the
-    // filter will preserve weak etags and remove the ones that require strong validation.
+    // When this field is ``true``, disables compression when the response contains an ``ETag`` header.
+    // When this field is ``false``, the filter will preserve weak ``ETag`` values and remove those that
+    // require strong validation.
     bool disable_on_etag_header = 2;
 
-    // If true, removes accept-encoding from the request headers before dispatching it to the upstream
-    // so that responses do not get compressed before reaching the filter.
+    // When this field is ``true``, removes ``Accept-Encoding`` from the request headers before dispatching
+    // the request to the upstream so that responses do not get compressed before reaching the filter.
     //
     // .. attention::
     //
-    //    To avoid interfering with other compression filters in the same chain use this option in
+    //    To avoid interfering with other compression filters in the same chain, use this option in
     //    the filter closest to the upstream.
     bool remove_accept_encoding_header = 3;
 
-    // Set of response codes for which compression is disabled, e.g. 206 Partial Content should not
+    // Set of response codes for which compression is disabled; e.g., 206 Partial Content should not
     // be compressed.
     repeated uint32 uncompressible_response_codes = 4 [(validate.rules).repeated = {
       unique: true
@@ -81,60 +92,69 @@ message Compressor {
       [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
 
   // Set of strings that allows specifying which mime-types yield compression; e.g.,
-  // application/json, text/html, etc. When this field is not defined, compression will be applied
-  // to the following mime-types: "application/javascript", "application/json",
-  // "application/xhtml+xml", "image/svg+xml", "text/css", "text/html", "text/plain", "text/xml"
-  // and their synonyms.
+  // ``application/json``, ``text/html``, etc.
+  //
+  // When this field is not specified, compression will be applied to these following mime-types
+  // and their synonyms:
+  //
+  // * ``application/javascript``
+  // * ``application/json``
+  // * ``application/xhtml+xml``
+  // * ``image/svg+xml``
+  // * ``text/css``
+  // * ``text/html``
+  // * ``text/plain``
+  // * ``text/xml``
+  //
   repeated string content_type = 2
       [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
 
-  // If true, disables compression when the response contains an etag header. When it is false, the
-  // filter will preserve weak etags and remove the ones that require strong validation.
+  // When this field is ``true``, disables compression when the response contains an ``ETag`` header.
+  // When this field is ``false``, the filter will preserve weak ``ETag`` values and remove those that
+  // require strong validation.
   bool disable_on_etag_header = 3
       [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
 
-  // If true, removes accept-encoding from the request headers before dispatching it to the upstream
-  // so that responses do not get compressed before reaching the filter.
+  // When this field is ``true``, removes ``Accept-Encoding`` from the request headers before dispatching
+  // the request to the upstream so that responses do not get compressed before reaching the filter.
   //
   // .. attention::
   //
-  //    To avoid interfering with other compression filters in the same chain use this option in
+  //    To avoid interfering with other compression filters in the same chain, use this option in
   //    the filter closest to the upstream.
   bool remove_accept_encoding_header = 4
       [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
 
-  // Runtime flag that controls whether the filter is enabled or not. If set to false, the
-  // filter will operate as a pass-through filter, unless overridden by
-  // CompressorPerRoute. If not specified, defaults to enabled.
+  // Runtime flag that controls whether the filter is enabled. When this field is ``false``, the
+  // filter will operate as a pass-through filter, unless overridden by ``CompressorPerRoute``.
+  // If this field is not specified, the filter is enabled by default.
   config.core.v3.RuntimeFeatureFlag runtime_enabled = 5
       [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
 
-  // A compressor library to use for compression. Currently only
-  // :ref:`envoy.compression.gzip.compressor<envoy_v3_api_msg_extensions.compression.gzip.compressor.v3.Gzip>`
-  // is included in Envoy.
+  // A compressor library to use for compression.
   // [#extension-category: envoy.compression.compressor]
   config.core.v3.TypedExtensionConfig compressor_library = 6
       [(validate.rules).message = {required: true}];
 
-  // Configuration for request compression. Compression is disabled by default if left empty.
+  // Configuration for request compression. If this field is not specified, request compression is disabled.
   RequestDirectionConfig request_direction_config = 7;
 
-  // Configuration for response compression. Compression is enabled by default if left empty.
+  // Configuration for response compression. If this field is not specified, response compression is enabled.
   //
   // .. attention::
   //
-  //    If the field is not empty then the duplicate deprecated fields of the ``Compressor`` message,
+  //    When this field is set, duplicate deprecated fields of the ``Compressor`` message,
   //    such as ``content_length``, ``content_type``, ``disable_on_etag_header``,
-  //    ``remove_accept_encoding_header`` and ``runtime_enabled``, are ignored.
+  //    ``remove_accept_encoding_header``, and ``runtime_enabled``, are ignored.
   //
-  //    Also all the statistics related to response compression will be rooted in
+  //    Additionally, all statistics related to response compression will be rooted in
   //    ``<stat_prefix>.compressor.<compressor_library.name>.<compressor_library_stat_prefix>.response.*``
   //    instead of
   //    ``<stat_prefix>.compressor.<compressor_library.name>.<compressor_library_stat_prefix>.*``.
   ResponseDirectionConfig response_direction_config = 8;
 
-  // If true, chooses this compressor first to do compression when the q-values in ``Accept-Encoding`` are same.
-  // The last compressor which enables choose_first will be chosen if multiple compressor filters in the chain have choose_first as true.
+  // When this field is ``true``, this compressor is preferred when q-values in ``Accept-Encoding`` are equal.
+  // If multiple compressor filters set ``choose_first`` to ``true``, the last one in the filter chain is chosen.
   bool choose_first = 9;
 }
 
@@ -159,7 +179,7 @@ message CompressorPerRoute {
     option (validate.required) = true;
 
     // If set, the filter will operate as a pass-through filter.
-    // Overrides Compressor.runtime_enabled and CommonDirectionConfig.enabled.
+    // Overrides ``Compressor.runtime_enabled`` and ``CommonDirectionConfig.enabled``.
     bool disabled = 1 [(validate.rules).bool = {const: true}];
 
     // Per-route overrides. Fields set here will override corresponding fields in ``Compressor``.


### PR DESCRIPTION
## Description

This PR fixes the compressor docs which currently says that the only built-in compressor to Envoy is the GZip which is no longer true as we also bundle in ZTSD and Brotli. We also address typos and some other styling nits.

<img width="950" height="391" alt="Screenshot 2025-09-22 at 16 12 48" src="https://github.com/user-attachments/assets/2916e036-951d-44ba-9eee-1162045ff58b" />

---

**Commit Message:** compressor: fix the compressor docs to highlight other extensions
**Additional Description:** Fix the compressor docs to call out the other compressors which are bundled in with Envoy.
**Risk Level:** N/A
**Testing:** CI
**Docs Changes:** N/A
**Release Notes:** N/A