### PR TITLE
build: use GNU ld instead of gold for GCC build

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -76,7 +76,7 @@ build:linux --conlyopt=-fexceptions
 build:linux --fission=dbg,opt
 build:linux --features=per_object_debug_info
 build:linux --action_env=BAZEL_LINKLIBS=-l%:libstdc++.a
-build:linux --action_env=BAZEL_LINKOPTS=-lm:-fuse-ld=gold
+build:linux --action_env=BAZEL_LINKOPTS=-lm:-fuse-ld=bfd
 
 # We already have absl in the build, define absl=1 to tell googletest to use absl for backtrace.
 build --define absl=1
@@ -109,7 +109,7 @@ build:clang-pch --define=ENVOY_CLANG_PCH=1
 build:libstdc++ --@envoy//bazel:libc++=false
 build:libstdc++ --@envoy//bazel:libstdc++=true
 
-# Use gold linker for gcc compiler.
+# Gcc with libstdc++
 build:gcc --config=libstdc++
 build:gcc --test_env=HEAPCHECK=
 build:gcc --action_env=BAZEL_COMPILER=gcc
@@ -127,7 +127,11 @@ build:gcc --cxxopt=-Wno-missing-requires
 build:gcc --cxxopt=-Wno-dangling-reference
 build:gcc --cxxopt=-Wno-nonnull-compare
 build:gcc --incompatible_enable_cc_toolchain_resolution=false
-build:gcc --linkopt=-fuse-ld=gold --host_linkopt=-fuse-ld=gold
+build:gcc --linkopt=-fuse-ld=bfd --host_linkopt=-fuse-ld=bfd
+build:gcc --features=-supports_start_end_lib --host_features=-supports_start_end_lib
+# Optimize for memory usage during linking to avoid OOM kills.
+build:gcc --linkopt=-Wl,--no-keep-memory
+build:gcc --linkopt=-Wl,--reduce-memory-overheads
 
 # Clang-tidy
 # TODO(phlax): enable this, its throwing some errors as well as finding more issues

--- a/bazel/rbe/toolchains/configs/linux/gcc/cc/BUILD
+++ b/bazel/rbe/toolchains/configs/linux/gcc/cc/BUILD
@@ -101,13 +101,12 @@ cc_toolchain_config(
     dbg_compile_flags = ["-g"],
     host_system_name = "local",
     link_flags = [
-        "-fuse-ld=lld",
+        "-fuse-ld=bfd",
         "-Wl,-no-as-needed",
         "-Wl,-z,relro,-z,now",
         "-B/usr/bin",
         "-pass-exit-codes",
         "-lm",
-        "-fuse-ld=gold",
     ],
     link_libs = ["-l:libstdc++.a"],
     opt_compile_flags = [
@@ -119,7 +118,7 @@ cc_toolchain_config(
         "-fdata-sections",
     ],
     opt_link_flags = ["-Wl,--gc-sections"],
-    supports_start_end_lib = True,
+    supports_start_end_lib = False,
     target_libc = "local",
     target_system_name = "local",
     tool_paths = {

--- a/bazel/rbe/toolchains/gcc.env.json
+++ b/bazel/rbe/toolchains/gcc.env.json
@@ -1,7 +1,7 @@
 {
   "BAZEL_COMPILER": "gcc",
   "BAZEL_LINKLIBS": "-l%:libstdc++.a",
-  "BAZEL_LINKOPTS": "-lm:-fuse-ld=gold",
+  "BAZEL_LINKOPTS": "-lm:-fuse-ld=bfd",
   "CC": "gcc",
   "CXX": "g++",
   "PATH": "/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/llvm/bin"

--- a/bazel/rbe/toolchains/rbe_toolchains_config.bzl
+++ b/bazel/rbe/toolchains/rbe_toolchains_config.bzl
@@ -31,7 +31,7 @@ _CLANG_LIBCXX_ENV = dicts.add(_CLANG_ENV, {
 _GCC_ENV = {
     "BAZEL_COMPILER": "gcc",
     "BAZEL_LINKLIBS": "-l%:libstdc++.a",
-    "BAZEL_LINKOPTS": "-lm:-fuse-ld=gold",
+    "BAZEL_LINKOPTS": "-lm:-fuse-ld=bfd",
     "CC": "gcc",
     "CXX": "g++",
     "PATH": "/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/llvm/bin",

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -94,6 +94,9 @@ minor_behavior_changes:
     Cap the frame size for streamed grpc at 1MB. Without this change there was a small chance
     that if a request streamed in sufficiently faster than it was processed, a frame larger than
     4MB could be encoded, which most upstream grpc services would, by default, treat as an error.
+- area: build
+  change: |
+    GCC build now use GNU ld. The gold linker was deprecated in binutils 2.44.
 
 bug_fixes:
 # *Changes expected to improve the state of the world and are unlikely to have negative effects*

--- a/test/server/config_validation/BUILD
+++ b/test/server/config_validation/BUILD
@@ -93,6 +93,7 @@ envoy_cc_fuzz_test(
     size = "large",
     srcs = ["config_fuzz_test.cc"],
     corpus = "//test/server:server_fuzz_test_corpus",
+    rbe_pool = "6gig",
     deps = [
         "//source/common/common:thread_lib",
         "//source/server/config_validation:server_lib",


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

**Commit Message:** build: use GNU ld instead of gold for GCC build
**Additional Description:** 
When building with GCC using `--config=gcc` the build system now uses GNU ld. Gold is deprecated beginning from GNU binutils 2.44. It is no longer included in standard binutils release and it is scheduled for complete removal. See https://lwn.net/Articles/1007541/.
**Risk Level:** Low
**Testing:**
**Docs Changes:** 
**Release Notes:** GCC builds now use GNU ld. The gold linker was deprecated in binutils 2.44.
**Platform Specific Features:**

Fixes #41171
