### PR TITLE
rbac: enable use of NetworkNamespaceInput in network RBAC filter

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -429,6 +429,12 @@ new_features:
     <envoy_v3_api_field_config.listener.v3.Listener.filter_chain_matcher>`, enabling filter chain
     selection based on the Linux network namespace of the bound socket. On non-Linux platforms,
     the input returns an empty value and connections use the default filter chain.
+- area: rbac
+  change: |
+    Enabled use of :ref:`NetworkNamespaceInput
+    <envoy_v3_api_msg_extensions.matching.common_inputs.network.v3.NetworkNamespaceInput>` in the
+    network RBAC filter's matcher. This allows RBAC policies to evaluate the Linux network namespace
+    of the listening socket via the generic matcher API.
 - area: lua
   change: |
     Added ``route()`` to the Stream handle API, allowing Lua scripts to retrieve route information. So far, the only method

--- a/source/extensions/filters/network/rbac/rbac_filter.cc
+++ b/source/extensions/filters/network/rbac/rbac_filter.cc
@@ -36,6 +36,9 @@ absl::Status ActionValidationVisitor::performDataInputValidation(
       {TypeUtil::descriptorFullNameToTypeUrl(
           envoy::extensions::matching::common_inputs::network::v3::ServerNameInput::descriptor()
               ->full_name())},
+      {TypeUtil::descriptorFullNameToTypeUrl(envoy::extensions::matching::common_inputs::network::
+                                                 v3::NetworkNamespaceInput::descriptor()
+                                                     ->full_name())},
       {TypeUtil::descriptorFullNameToTypeUrl(
           envoy::extensions::matching::common_inputs::ssl::v3::UriSanInput::descriptor()
               ->full_name())},

--- a/test/extensions/filters/network/rbac/filter_test.cc
+++ b/test/extensions/filters/network/rbac/filter_test.cc
@@ -207,6 +207,16 @@ on_no_match:
         .WillByDefault(ReturnPointee(stream_info_.downstream_connection_info_provider_));
   }
 
+  void setLocalAddressWithNetworkNamespace(const std::string& network_namespace_path,
+                                           uint16_t port = 123) {
+    address_ = std::make_shared<Network::Address::Ipv4Instance>(
+        "127.0.0.1", port, nullptr, absl::make_optional(std::string(network_namespace_path)));
+
+    stream_info_.downstream_connection_info_provider_->setLocalAddress(address_);
+    ON_CALL(callbacks_.connection_.stream_info_, downstreamAddressProvider())
+        .WillByDefault(ReturnPointee(stream_info_.downstream_connection_info_provider_));
+  }
+
   void checkAccessLogMetadata(bool expected) {
     auto filter_meta = stream_info_.dynamicMetadata().filter_metadata().at(
         Filters::Common::RBAC::DynamicMetadataKeysSingleton::get().CommonNamespace);
@@ -492,6 +502,106 @@ TEST_F(RoleBasedAccessControlNetworkFilterTest, MatcherDenied) {
       filter_meta.fields().at("shadow_rules_prefix_shadow_effective_policy_id").string_value());
   EXPECT_EQ("allowed",
             filter_meta.fields().at("shadow_rules_prefix_shadow_engine_result").string_value());
+}
+
+TEST_F(RoleBasedAccessControlNetworkFilterTest, MatcherNetworkNamespaceAllowed) {
+  envoy::extensions::filters::network::rbac::v3::RBAC config;
+  config.set_stat_prefix("tcp.");
+  config.set_shadow_rules_stat_prefix("shadow_rules_prefix_");
+
+  const std::string matcher_yaml = R"EOF(
+matcher_list:
+  matchers:
+  - predicate:
+      single_predicate:
+        input:
+          name: envoy.matching.inputs.network_namespace
+          typed_config:
+            "@type": type.googleapis.com/envoy.extensions.matching.common_inputs.network.v3.NetworkNamespaceInput
+        value_match:
+          exact: "/var/run/netns/ns1"
+    on_match:
+      action:
+        name: action
+        typed_config:
+          "@type": type.googleapis.com/envoy.config.rbac.v3.Action
+          name: allow_ns
+          action: ALLOW
+on_no_match:
+  action:
+    name: action
+    typed_config:
+      "@type": type.googleapis.com/envoy.config.rbac.v3.Action
+      name: deny_all
+      action: DENY
+)EOF";
+
+  xds::type::matcher::v3::Matcher matcher;
+  TestUtility::loadFromYaml(matcher_yaml, matcher);
+  *config.mutable_matcher() = matcher;
+
+  config_ = std::make_shared<RoleBasedAccessControlFilterConfig>(
+      config, *store_.rootScope(), context_, ProtobufMessage::getStrictValidationVisitor());
+  initFilter();
+
+  setLocalAddressWithNetworkNamespace("/var/run/netns/ns1", 123);
+
+  EXPECT_EQ(Network::FilterStatus::Continue, filter_->onNewConnection());
+
+  EXPECT_EQ(Network::FilterStatus::Continue, filter_->onData(data_, false));
+  EXPECT_EQ(Network::FilterStatus::Continue, filter_->onData(data_, false));
+  EXPECT_EQ(1U, config_->stats().allowed_.value());
+  EXPECT_EQ(0U, config_->stats().denied_.value());
+}
+
+TEST_F(RoleBasedAccessControlNetworkFilterTest, MatcherNetworkNamespaceDenied) {
+  envoy::extensions::filters::network::rbac::v3::RBAC config;
+  config.set_stat_prefix("tcp.");
+  config.set_shadow_rules_stat_prefix("shadow_rules_prefix_");
+
+  const std::string matcher_yaml = R"EOF(
+matcher_list:
+  matchers:
+  - predicate:
+      single_predicate:
+        input:
+          name: envoy.matching.inputs.network_namespace
+          typed_config:
+            "@type": type.googleapis.com/envoy.extensions.matching.common_inputs.network.v3.NetworkNamespaceInput
+        value_match:
+          exact: "/var/run/netns/ns1"
+    on_match:
+      action:
+        name: action
+        typed_config:
+          "@type": type.googleapis.com/envoy.config.rbac.v3.Action
+          name: allow_ns
+          action: ALLOW
+on_no_match:
+  action:
+    name: action
+    typed_config:
+      "@type": type.googleapis.com/envoy.config.rbac.v3.Action
+      name: deny_all
+      action: DENY
+)EOF";
+
+  xds::type::matcher::v3::Matcher matcher;
+  TestUtility::loadFromYaml(matcher_yaml, matcher);
+  *config.mutable_matcher() = matcher;
+
+  config_ = std::make_shared<RoleBasedAccessControlFilterConfig>(
+      config, *store_.rootScope(), context_, ProtobufMessage::getStrictValidationVisitor());
+  initFilter();
+
+  setLocalAddressWithNetworkNamespace("/var/run/netns/other", 123);
+
+  EXPECT_CALL(callbacks_.connection_, close(Network::ConnectionCloseType::NoFlush, _)).Times(2);
+
+  EXPECT_EQ(Network::FilterStatus::StopIteration, filter_->onData(data_, false));
+  EXPECT_EQ(Network::FilterStatus::StopIteration, filter_->onData(data_, false));
+  EXPECT_EQ(0U, config_->stats().allowed_.value());
+  EXPECT_EQ(1U, config_->stats().denied_.value());
 }
 
 // Log Tests


### PR DESCRIPTION
## Description

This PR enables the use of `NetworkNamespaceInput` in the RBAC filter to be able to match on the incoming network namespace and do RBAC enforcement based on that.

---

**Commit Message:** rbac: enable use of NetworkNamespaceInput in network RBAC filter
**Additional Description:** Enable `NetworkNamespaceInput` to be used in the Network RBAC filter.
**Risk Level:** Low
**Testing:** Added Unit Tests
**Docs Changes:** Added
**Release Notes:** Added