### PR TITLE
rbac: enable use of NetworkNamespaceInput in HTTP RBAC filter

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -440,6 +440,12 @@ new_features:
     when used in formatting contexts that accept non-string values, such as
     :ref:`json_format <envoy_v3_api_field_config.core.v3.SubstitutionFormatString.json_format>`. The new command is introduced
     so as to not break compatibility with the existing command's behavior.
+- area: rbac
+  change: |
+    Enabled use of :ref:`NetworkNamespaceInput
+    <envoy_v3_api_msg_extensions.matching.common_inputs.network.v3.NetworkNamespaceInput>` in the
+    network and HTTP RBAC filters' matchers. This allows RBAC policies to evaluate the Linux network
+    namespace of the listening socket via the generic matcher API.
 - area: dynamic_modules
   change: |
     Added a new Logging ABI that allows modules to emit logs in the standard Envoy logging stream under ``dynamic_modules`` ID.

--- a/source/extensions/filters/http/rbac/rbac_filter.cc
+++ b/source/extensions/filters/http/rbac/rbac_filter.cc
@@ -36,6 +36,9 @@ const absl::flat_hash_set<std::string> ActionValidationVisitor::allowed_inputs_s
         envoy::extensions::matching::common_inputs::network::v3::ServerNameInput::descriptor()
             ->full_name())},
     {TypeUtil::descriptorFullNameToTypeUrl(
+        envoy::extensions::matching::common_inputs::network::v3::NetworkNamespaceInput::descriptor()
+            ->full_name())},
+    {TypeUtil::descriptorFullNameToTypeUrl(
         envoy::type::matcher::v3::HttpRequestHeaderMatchInput::descriptor()->full_name())},
     {TypeUtil::descriptorFullNameToTypeUrl(
         envoy::extensions::matching::common_inputs::ssl::v3::UriSanInput::descriptor()


### PR DESCRIPTION
## Description

This PR enables the use of `NetworkNamespaceInput` in the RBAC HTTP filter to be able to match on the incoming network namespace and do RBAC enforcement based on that.

---

**Commit Message:** rbac: enable use of NetworkNamespaceInput in HTTP RBAC filter
**Additional Description:** Enable `NetworkNamespaceInput` to be used in the HTTP RBAC filter.
**Risk Level:** Low
**Testing:** Added Unit Tests
**Docs Changes:** Added
**Release Notes:** Added