### PR TITLE
Use mutex reference in lock constructors p3

### DIFF
--- a/source/common/common/assert.cc
+++ b/source/common/common/assert.cc
@@ -45,12 +45,12 @@ public:
   static EnvoyBugState& get() { MUTABLE_CONSTRUCT_ON_FIRST_USE(EnvoyBugState); }
 
   void clear() {
-    absl::MutexLock lock(&mutex_);
+    absl::MutexLock lock(mutex_);
     counters_.clear();
   }
 
   uint64_t inc(absl::string_view bug_name) {
-    absl::MutexLock lock(&mutex_);
+    absl::MutexLock lock(mutex_);
     return ++counters_[bug_name];
   }
 

--- a/source/common/common/logger.cc
+++ b/source/common/common/logger.cc
@@ -64,12 +64,12 @@ void StderrSinkDelegate::flush() {
 }
 
 void DelegatingLogSink::set_formatter(std::unique_ptr<spdlog::formatter> formatter) {
-  absl::MutexLock lock(&format_mutex_);
+  absl::MutexLock lock(format_mutex_);
   formatter_ = std::move(formatter);
 }
 
 void DelegatingLogSink::log(const spdlog::details::log_msg& msg) {
-  absl::ReleasableMutexLock lock(&format_mutex_);
+  absl::ReleasableMutexLock lock(format_mutex_);
   absl::string_view msg_view = absl::string_view(msg.payload.data(), msg.payload.size());
 
   // This memory buffer must exist in the scope of the entire function,
@@ -95,7 +95,7 @@ void DelegatingLogSink::log(const spdlog::details::log_msg& msg) {
   // protection is really only needed in tests. It would be nice to figure out a test-only
   // mechanism for this that does not require extra locking that we don't explicitly need in the
   // prod code.
-  absl::ReaderMutexLock sink_lock(&sink_mutex_);
+  absl::ReaderMutexLock sink_lock(sink_mutex_);
   log_to_sink(*sink_);
 }
 
@@ -120,13 +120,13 @@ DelegatingLogSinkSharedPtr DelegatingLogSink::init() {
 }
 
 void DelegatingLogSink::flush() {
-  absl::ReaderMutexLock lock(&sink_mutex_);
+  absl::ReaderMutexLock lock(sink_mutex_);
   sink_->flush();
 }
 
 void DelegatingLogSink::logWithStableName(absl::string_view stable_name, absl::string_view level,
                                           absl::string_view component, absl::string_view message) {
-  absl::ReaderMutexLock sink_lock(&sink_mutex_);
+  absl::ReaderMutexLock sink_lock(sink_mutex_);
   sink_->logWithStableName(stable_name, level, component, message);
 }
 

--- a/source/common/common/thread.cc
+++ b/source/common/common/thread.cc
@@ -21,13 +21,13 @@ namespace {
 // tests more hermetic.
 struct ThreadIds {
   bool inMainThread() const {
-    absl::MutexLock lock(&mutex_);
+    absl::MutexLock lock(mutex_);
     return main_threads_to_usage_count_.find(std::this_thread::get_id()) !=
            main_threads_to_usage_count_.end();
   }
 
   bool isMainThreadActive() const {
-    absl::MutexLock lock(&mutex_);
+    absl::MutexLock lock(mutex_);
     return !main_threads_to_usage_count_.empty();
   }
 
@@ -36,7 +36,7 @@ struct ThreadIds {
 
   // Call this from the context of MainThread when it exits.
   void releaseMainThread() {
-    absl::MutexLock lock(&mutex_);
+    absl::MutexLock lock(mutex_);
     auto it = main_threads_to_usage_count_.find(std::this_thread::get_id());
     if (!skipAsserts()) {
       ASSERT(it != main_threads_to_usage_count_.end());
@@ -52,7 +52,7 @@ struct ThreadIds {
   // Declares current thread as the main one, or verifies that the current
   // thread matches any previous declarations.
   void registerMainThread() {
-    absl::MutexLock lock(&mutex_);
+    absl::MutexLock lock(mutex_);
     auto it = main_threads_to_usage_count_.find(std::this_thread::get_id());
     if (it == main_threads_to_usage_count_.end()) {
       it = main_threads_to_usage_count_.insert({std::this_thread::get_id(), 0}).first;

--- a/source/common/common/thread_synchronizer.cc
+++ b/source/common/common/thread_synchronizer.cc
@@ -10,7 +10,7 @@ void ThreadSynchronizer::enable() {
 
 ThreadSynchronizer::SynchronizerEntry&
 ThreadSynchronizer::getOrCreateEntry(absl::string_view event_name) {
-  absl::MutexLock lock(&data_->mutex_);
+  absl::MutexLock lock(data_->mutex_);
   auto& existing_entry = data_->entries_[event_name];
   if (existing_entry == nullptr) {
     ENVOY_LOG(debug, "thread synchronizer: creating entry: {}", event_name);
@@ -21,7 +21,7 @@ ThreadSynchronizer::getOrCreateEntry(absl::string_view event_name) {
 
 void ThreadSynchronizer::waitOnWorker(absl::string_view event_name) {
   SynchronizerEntry& entry = getOrCreateEntry(event_name);
-  absl::MutexLock lock(&entry.mutex_);
+  absl::MutexLock lock(entry.mutex_);
   ENVOY_LOG(debug, "thread synchronizer: waiting on next {}", event_name);
   ASSERT(!entry.wait_on_);
   entry.wait_on_ = true;
@@ -29,7 +29,7 @@ void ThreadSynchronizer::waitOnWorker(absl::string_view event_name) {
 
 void ThreadSynchronizer::syncPointWorker(absl::string_view event_name) {
   SynchronizerEntry& entry = getOrCreateEntry(event_name);
-  absl::MutexLock lock(&entry.mutex_);
+  absl::MutexLock lock(entry.mutex_);
 
   // See if we are ignoring waits. If so, just return.
   if (!entry.wait_on_) {
@@ -62,7 +62,7 @@ void ThreadSynchronizer::syncPointWorker(absl::string_view event_name) {
 
 void ThreadSynchronizer::barrierOnWorker(absl::string_view event_name) {
   SynchronizerEntry& entry = getOrCreateEntry(event_name);
-  absl::MutexLock lock(&entry.mutex_);
+  absl::MutexLock lock(entry.mutex_);
   ENVOY_LOG(debug, "thread synchronizer: barrier on {}", event_name);
   while (!entry.mutex_.AwaitWithTimeout(absl::Condition(&entry.at_barrier_), absl::Seconds(10))) {
     ENVOY_LOG(warn, "thread synchronizer: barrier on {} stuck for 10 seconds", event_name);
@@ -72,7 +72,7 @@ void ThreadSynchronizer::barrierOnWorker(absl::string_view event_name) {
 
 void ThreadSynchronizer::signalWorker(absl::string_view event_name) {
   SynchronizerEntry& entry = getOrCreateEntry(event_name);
-  absl::MutexLock lock(&entry.mutex_);
+  absl::MutexLock lock(entry.mutex_);
   ASSERT(!entry.signaled_);
   ENVOY_LOG(debug, "thread synchronizer: signaling {}", event_name);
   entry.signaled_ = true;


### PR DESCRIPTION
Replace deprecated absl::MutexLock::MutexLock(Mutex*) constructor with absl::MutexLock::MutexLock(Mutex&)

Risk Level: none
Testing: unit tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
