### PR TITLE
list-matcher: replace push_back with emplace_back

### DIFF
--- a/source/common/matcher/list_matcher.h
+++ b/source/common/matcher/list_matcher.h
@@ -43,7 +43,7 @@ public:
   }
 
   void addMatcher(FieldMatcherPtr<DataType>&& matcher, OnMatch<DataType> action) {
-    matchers_.push_back({std::move(matcher), std::move(action)});
+    matchers_.emplace_back(std::move(matcher), std::move(action));
   }
 
 private:


### PR DESCRIPTION
Commit Message: list-matcher: replace push_back with emplace_back
Additional Description:
Minor refactor that uses vector `emplace_back()` instead of `push_back()`.

Risk Level: low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
