### PR TITLE
warn on insecure default for require_client_certificate

### DIFF
--- a/source/common/tls/server_context_config_impl.cc
+++ b/source/common/tls/server_context_config_impl.cc
@@ -178,6 +178,18 @@ ServerContextConfigImpl::ServerContextConfigImpl(
     return;
   }
 
+  if (!config.has_require_client_certificate() &&
+      config.common_tls_context().validation_context_type_case() !=
+          envoy::extensions::transport_sockets::tls::v3::CommonTlsContext::
+              ValidationContextTypeCase::VALIDATION_CONTEXT_TYPE_NOT_SET) {
+    ENVOY_LOG_MISC(
+        warn,
+        "Using deprecated insecure default of not requiring client cert for TLS validation. "
+        "This default will be changed in a future version. Please explicitly configure a value for "
+        "require_client_certificate.");
+    factory_context.serverFactoryContext().runtime().countDeprecatedFeatureUse();
+  }
+
   auto factory =
       TlsCertificateSelectorConfigFactoryImpl::getDefaultTlsCertificateSelectorConfigFactory();
   const Protobuf::Any any;

--- a/test/common/tls/context_impl_test.cc
+++ b/test/common/tls/context_impl_test.cc
@@ -928,6 +928,31 @@ public:
   }
 };
 
+// If no require_client_certificate is configured but a validation context IS configured, warn
+// against using an insecure default.
+TEST_F(SslContextImplTest, NoRequireClientCertWithValidationContext_InsecureDefault) {
+  envoy::extensions::transport_sockets::tls::v3::DownstreamTlsContext tls_context;
+  const std::string tls_context_yaml = R"EOF(
+  common_tls_context:
+    tls_certificates:
+    - certificate_chain:
+        filename: "{{ test_rundir }}/test/common/tls/test_data/selfsigned_cert.pem"
+      private_key:
+        filename: "{{ test_rundir }}/test/common/tls/test_data/selfsigned_key.pem"
+    validation_context:
+      trusted_ca:
+        filename: "{{ test_rundir }}/test/common/tls/test_data/ca_cert.pem"
+  )EOF";
+  TestUtility::loadFromYaml(TestEnvironment::substitute(tls_context_yaml), tls_context);
+  EXPECT_CALL(factory_context_.server_context_.runtime_loader_.snapshot_,
+              deprecatedFeatureEnabled(_, _))
+      .WillRepeatedly(Return(true));
+  EXPECT_CALL(factory_context_.server_context_.runtime_loader_, countDeprecatedFeatureUse());
+  auto server_context_config =
+      *ServerContextConfigImpl::create(tls_context, factory_context_, false);
+  EXPECT_NO_THROW(loadConfig(*server_context_config));
+}
+
 TEST_F(SslServerContextImplTicketTest, TicketKeySuccess) {
   // Both keys are valid; no error should be thrown
   const std::string yaml = R"EOF(


### PR DESCRIPTION
Commit Message: warn on insecure default for require_client_certificate
Additional Description:

#41197 

If the downstream tls options is configured with no explicit value for require_client_certificate and a client certificate validation context is provided, the default behavior is that the envoy will validate any client certs that are sent but any requests without a client certificate will not be rejected.

This is an insecure default. This pr adds a check for this and warns & increments a deprecated feature use counter. Later we should also change the default value to be secure for this case.

Risk Level: none
Testing: unit tested
