### PR TITLE
admission control filter: support configuring request threshold

### DIFF
--- a/api/envoy/extensions/filters/http/admission_control/v3/admission_control.proto
+++ b/api/envoy/extensions/filters/http/admission_control/v3/admission_control.proto
@@ -19,7 +19,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // [#protodoc-title: Admission Control]
 // [#extension: envoy.filters.http.admission_control]
 
-// [#next-free-field: 8]
+// [#next-free-field: 9]
 message AdmissionControl {
   // Default method of specifying what constitutes a successful request. All status codes that
   // indicate a successful request must be explicitly specified if not relying on the default
@@ -96,6 +96,11 @@ message AdmissionControl {
   // will not be rejected, even if the success rate is lower than sr_threshold.
   // Defaults to 0.
   config.core.v3.RuntimeUInt32 rps_threshold = 6;
+
+  // If the number of requests within the sampling window is below this threshold, the request
+  // will not be rejected, even if the success rate is lower than sr_threshold.
+  // Defaults to 0.
+  config.core.v3.RuntimeUInt32 requests_threshold = 8;
 
   // The probability of rejection will never exceed this value, even if the failure rate is rising.
   // Defaults to 80%.

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -503,5 +503,12 @@ new_features:
   change: |
     Added ``max_downstream_connection_duration_jitter_percentage`` to allow adding a jitter to the max downstream connection duration.
     This can be used to avoid thundering herd problems with many clients being disconnected and possibly reconnecting at the same time.
+- area: admission control
+  change: |
+    Added :ref:`requests_threshold
+    <envoy_v3_api_field_extensions.filters.http.admission_control.v3.AdmissionControl.requests_threshold>`
+    configuration field to the admission control filter. This allows configuring a threshold for the number of requests
+    within the sampling window to bypass rejection. This can be useful for low qps scenarios (< 1 qps) where the sampling
+    window occurs over a long period of time.
 
 deprecated:

--- a/docs/root/configuration/http/http_filters/admission_control_filter.rst
+++ b/docs/root/configuration/http/http_filters/admission_control_filter.rst
@@ -40,6 +40,7 @@ where,
 Note that there are additional parameters that affect the rejection probability:
 
 - *rps_threshold* is a configurable value that when RPS is lower than it, requests will pass through the filter.
+- *requests_threshold* is a configurable value that when the number of requests within the sampling window is lower than it, requests will pass through the filter.
 - *max_reject_probability* represents the upper limit of the rejection probability.
 
 .. note::

--- a/source/extensions/filters/http/admission_control/admission_control.h
+++ b/source/extensions/filters/http/admission_control/admission_control.h
@@ -66,6 +66,7 @@ public:
   double aggression() const;
   double successRateThreshold() const;
   uint32_t rpsThreshold() const;
+  uint32_t requestsThreshold() const;
   double maxRejectionProbability() const;
   ResponseEvaluator& responseEvaluator() const { return *response_evaluator_; }
 
@@ -77,6 +78,7 @@ private:
   std::unique_ptr<Runtime::Double> aggression_;
   std::unique_ptr<Runtime::Percentage> sr_threshold_;
   std::unique_ptr<Runtime::UInt32> rps_threshold_;
+  std::unique_ptr<Runtime::UInt32> requests_threshold_;
   std::unique_ptr<Runtime::Percentage> max_rejection_probability_;
   std::shared_ptr<ResponseEvaluator> response_evaluator_;
 };

--- a/source/extensions/filters/http/admission_control/thread_local_controller.cc
+++ b/source/extensions/filters/http/admission_control/thread_local_controller.cc
@@ -27,6 +27,8 @@ uint32_t ThreadLocalControllerImpl::averageRps() const {
   return global_data_.requests / secs.count();
 }
 
+uint32_t ThreadLocalControllerImpl::numRequestsInWindow() const { return global_data_.requests; }
+
 void ThreadLocalControllerImpl::maybeUpdateHistoricalData() {
   // Purge stale samples.
   while (!historical_data_.empty() && ageOfOldestSample() >= sampling_window_) {

--- a/source/extensions/filters/http/admission_control/thread_local_controller.h
+++ b/source/extensions/filters/http/admission_control/thread_local_controller.h
@@ -41,6 +41,9 @@ public:
   // Returns the average RPS across the sampling window.
   virtual uint32_t averageRps() const PURE;
 
+  // Returns the current number of requests.
+  virtual uint32_t numRequestsInWindow() const PURE;
+
   // Returns the sample window for this controller.
   virtual std::chrono::seconds samplingWindow() const PURE;
 };
@@ -70,6 +73,8 @@ public:
   }
 
   uint32_t averageRps() const override;
+
+  uint32_t numRequestsInWindow() const override;
 
   std::chrono::seconds samplingWindow() const override { return sampling_window_; }
 

--- a/test/extensions/filters/http/admission_control/config_test.cc
+++ b/test/extensions/filters/http/admission_control/config_test.cc
@@ -127,6 +127,9 @@ aggression:
 rps_threshold:
   default_value: 5
   runtime_key: "foo.rps_threshold"
+requests_threshold:
+  default_value: 10
+  runtime_key: "foo.requests_threshold"
 max_rejection_probability:
   default_value:
     value: 70.0
@@ -142,6 +145,7 @@ success_criteria:
   EXPECT_EQ(4.2, config->aggression());
   EXPECT_EQ(0.92, config->successRateThreshold());
   EXPECT_EQ(5, config->rpsThreshold());
+  EXPECT_EQ(10, config->requestsThreshold());
   EXPECT_EQ(0.7, config->maxRejectionProbability());
 }
 
@@ -181,6 +185,9 @@ aggression:
 rps_threshold:
   default_value: 5
   runtime_key: "foo.rps_threshold"
+requests_threshold:
+  default_value: 10
+  runtime_key: "foo.requests_threshold"
 max_rejection_probability:
   default_value:
     value: 70.0
@@ -200,6 +207,8 @@ success_criteria:
   EXPECT_EQ(0.24, config->successRateThreshold());
   EXPECT_CALL(runtime_.snapshot_, getInteger("foo.rps_threshold", 5)).WillOnce(Return(12));
   EXPECT_EQ(12, config->rpsThreshold());
+  EXPECT_CALL(runtime_.snapshot_, getInteger("foo.requests_threshold", 10)).WillOnce(Return(12));
+  EXPECT_EQ(12, config->requestsThreshold());
   EXPECT_CALL(runtime_.snapshot_, getDouble("foo.max_rejection_probability", 70.0))
       .WillOnce(Return(32.0));
   EXPECT_EQ(0.32, config->maxRejectionProbability());
@@ -211,6 +220,9 @@ success_criteria:
   EXPECT_EQ(0.92, config->successRateThreshold());
   EXPECT_CALL(runtime_.snapshot_, getInteger("foo.rps_threshold", 5)).WillOnce(Return(99ull << 40));
   EXPECT_EQ(5, config->rpsThreshold());
+  EXPECT_CALL(runtime_.snapshot_, getInteger("foo.requests_threshold", 10))
+      .WillOnce(Return(99ull << 40));
+  EXPECT_EQ(10, config->requestsThreshold());
   EXPECT_CALL(runtime_.snapshot_, getDouble("foo.max_rejection_probability", 70.0))
       .WillOnce(Return(-2.0));
   EXPECT_EQ(0.7, config->maxRejectionProbability());


### PR DESCRIPTION
Commit Message: admission control filter: support configuring request threshold
Additional Description: This allows configuring a threshold for the number of requests within the sampling window to bypass rejection. This can be useful for low qps scenarios (< 1 qps) where the sampling window occurs over a long period of time.
Risk Level: Low
Testing: Unit testing
Docs Changes: Yes
Release Notes: Yes
Platform Specific Features: N/A
