### PR TITLE
dynamic_modules: allow user to set the stat prefix for dynamic module stats

### DIFF
--- a/api/envoy/extensions/filters/http/dynamic_modules/v3/dynamic_modules.proto
+++ b/api/envoy/extensions/filters/http/dynamic_modules/v3/dynamic_modules.proto
@@ -58,6 +58,10 @@ message DynamicModuleFilter {
   //    value: aGVsbG8= # echo -n "hello" | base64
   //
   google.protobuf.Any filter_config = 3;
+
+  // Allows configuring the stat prefix for all metrics emitted by the filter. By default, the stat prefix
+  // is equal to `dynamicmodulescustom`.
+  string stat_prefix = 4;
 }
 
 // Configuration of the HTTP per-route filter for dynamic modules. This filter allows loading shared object files

--- a/source/extensions/filters/http/dynamic_modules/factory.cc
+++ b/source/extensions/filters/http/dynamic_modules/factory.cc
@@ -30,7 +30,7 @@ absl::StatusOr<Http::FilterFactoryCb> DynamicModuleConfigFactory::createFilterFa
       filter_config =
           Envoy::Extensions::DynamicModules::HttpFilters::newDynamicModuleHttpFilterConfig(
               proto_config.filter_name(), config, std::move(dynamic_module.value()),
-              dual_info.scope, context);
+              dual_info.scope, proto_config.stat_prefix(), context);
 
   if (!filter_config.ok()) {
     return absl::InvalidArgumentError("Failed to create filter config: " +

--- a/source/extensions/filters/http/dynamic_modules/filter_config.h
+++ b/source/extensions/filters/http/dynamic_modules/filter_config.h
@@ -54,6 +54,7 @@ public:
   DynamicModuleHttpFilterConfig(const absl::string_view filter_name,
                                 const absl::string_view filter_config,
                                 DynamicModulePtr dynamic_module, Stats::Scope& stats_scope,
+                                const std::string stat_prefix,
                                 Server::Configuration::ServerFactoryContext& context);
 
   ~DynamicModuleHttpFilterConfig();
@@ -309,13 +310,14 @@ newDynamicModuleHttpPerRouteConfig(const absl::string_view per_route_config_name
  * @param filter_name the name of the filter.
  * @param filter_config the configuration for the module.
  * @param dynamic_module the dynamic module to use.
+ * @param stat_prefix the stat prefix for the filter.
  * @param context the server factory context.
  * @return a shared pointer to the new config object or an error if the module could not be loaded.
  */
 absl::StatusOr<DynamicModuleHttpFilterConfigSharedPtr> newDynamicModuleHttpFilterConfig(
     const absl::string_view filter_name, const absl::string_view filter_config,
     Extensions::DynamicModules::DynamicModulePtr dynamic_module, Stats::Scope& stats_scope,
-    Server::Configuration::ServerFactoryContext& context);
+    const std::string stat_prefix, Server::Configuration::ServerFactoryContext& context);
 
 } // namespace HttpFilters
 } // namespace DynamicModules

--- a/test/extensions/dynamic_modules/http/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/http/abi_impl_test.cc
@@ -1103,7 +1103,7 @@ TEST(ABIImpl, Stats) {
   Stats::TestUtil::TestScope stats_scope{"", stats_store};
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   auto filter_config = std::make_shared<DynamicModuleHttpFilterConfig>(
-      "some_name", "some_config", nullptr, stats_scope, context);
+      "some_name", "some_config", nullptr, stats_scope, "", context);
   DynamicModuleHttpFilter filter{filter_config, stats_scope.symbolTable()};
 
   const std::string counter_name{"some_counter"};


### PR DESCRIPTION
Commit Message: allow user to set the stat prefix for dynamic module stats
Additional Description: Provides the ability for the user to specify the string prefix prepended before all metrics created by their module
Risk Level: Low
Testing: Unit + Integration
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A