### PR TITLE
Fix for broken FIPS builds

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -282,7 +282,7 @@ def _boringssl_fips():
         name = "fips_cmake_linux_aarch64",
         build_file_content = CMAKE_BUILD_CONTENT,
     )
-    GO_BUILD_CONTENT = "%s\nexports_files([\"bin/go\"])" % _build_all_content([ "test/**" ])
+    GO_BUILD_CONTENT = "%s\nexports_files([\"bin/go\"])" % _build_all_content(["test/**"])
     external_http_archive(
         name = "fips_go_linux_amd64",
         build_file_content = GO_BUILD_CONTENT,

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -282,7 +282,7 @@ def _boringssl_fips():
         name = "fips_cmake_linux_aarch64",
         build_file_content = CMAKE_BUILD_CONTENT,
     )
-    GO_BUILD_CONTENT = "%s\nexports_files([\"bin/go\"])" % BUILD_ALL_CONTENT
+    GO_BUILD_CONTENT = "%s\nexports_files([\"bin/go\"])" % _build_all_content([ "test/**" ])
     external_http_archive(
         name = "fips_go_linux_amd64",
         build_file_content = GO_BUILD_CONTENT,


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

[This PR](https://github.com/envoyproxy/envoy/pull/39728) moved the Go dependency in FIPS builds to a Bazel `http_archive`. Once that was done, Bazel's `filegroup` doesn't seem to be dealing so well with non-UTF-8 characters present in a file name in Go's test suite, causing the build to fail. 

```
#23 170.8 ERROR: /build/top/BUILD/envoy/build/bazel_root/base/external/boringssl_fips/BUILD.bazel:70:8: Executing genrule @@boringssl_fips//:build failed: error reading file '@@fips_go_linux_amd64//:test/fixedbugs/issue27836.dir/Þmain.go': /build/top/BUILD/envoy/build/bazel_root/base/external/fips_go_linux_amd64/test/fixedbugs/issue27836.dir/Þmain.go (No such file or directory)
#23 170.8 ERROR: /build/top/BUILD/envoy/build/bazel_root/base/external/boringssl_fips/BUILD.bazel:70:8: Executing genrule @@boringssl_fips//:build failed: 1 input file(s) are in error
#23 171.2 Target //distribution/binary:release failed to build
```

It's not fully understood what circumstances cause Bazel to behave like that, but it seems reasonable to remove the `test` directory from the exports. Once a bug is filed to the Bazel project I'll update the PR with the issue number.

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
