### PR TITLE
[bp/v1.35] build: set -Wno-error in quiche and v8 dep builds

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -174,6 +174,7 @@ build:asan --linkopt='-L/opt/llvm/lib/clang/18/lib/x86_64-unknown-linux-gnu'
 build:macos --action_env=PATH=/opt/homebrew/bin:/opt/local/bin:/usr/local/bin:/usr/bin:/bin
 build:macos --host_action_env=PATH=/opt/homebrew/bin:/opt/local/bin:/usr/local/bin:/usr/bin:/bin
 build:macos --define tcmalloc=disabled
+build:macos --cxxopt=-Wno-nullability-completeness
 
 # macOS ASAN/UBSAN
 build:macos-asan --config=asan

--- a/bazel/external/quiche.bzl
+++ b/bazel/external/quiche.bzl
@@ -11,6 +11,9 @@ quiche_common_copts = [
     # hpack_huffman_decoder.cc overloads operator<<.
     "-Wno-unused-function",
     "-Wno-old-style-cast",
+
+    # Envoy build should not fail if a dependency has a warning.
+    "-Wno-error",
 ]
 
 quiche_copts = select({

--- a/bazel/v8.patch
+++ b/bazel/v8.patch
@@ -82,6 +82,15 @@ diff --git a/bazel/defs.bzl b/bazel/defs.bzl
 index 0539ea176ac..92c7aeb904f 100644
 --- a/bazel/defs.bzl
 +++ b/bazel/defs.bzl
+@@ -106,7 +106,7 @@ def _default_args():
+             "@v8//bazel/config:is_posix": [
+                 "-fPIC",
+                 "-fno-strict-aliasing",
+-                "-Werror",
++                "-Wno-error", # Envoy build should not fail for warnings in dependencies
+                 "-Wextra",
+                 "-Wno-unneeded-internal-declaration",
+                 "-Wno-unknown-warning-option", # b/330781959
 @@ -117,6 +117,9 @@ def _default_args():
                  "-Wno-implicit-int-float-conversion",
                  "-Wno-deprecated-copy",


### PR DESCRIPTION
Envoy is built by various platform and compiler combinations, and some of those produce warnings in quiche and v8 builds. This should not prevent those builds from succeeding.

Cherry-pick of https://github.com/envoyproxy/envoy/pull/41130
