### PR TITLE
ext_proc: allow immediate response from upstream filter

### DIFF
--- a/docs/root/configuration/http/http_filters/ext_proc_filter.rst
+++ b/docs/root/configuration/http/http_filters/ext_proc_filter.rst
@@ -54,7 +54,6 @@ The following statistics are supported:
   clear_route_cache_ignored, Counter, The number of clear cache request that were ignored
   clear_route_cache_disabled, Counter, The number of clear cache requests that were rejected from being disabled
   clear_route_cache_upstream_ignored, Counter, The number of clear cache request that were ignored if the filter is in upstream
-  send_immediate_resp_upstream_ignored, Counter, The number of send immediate response messages that were ignored if the filter is in upstream
 
 Access Log Fields
 ------------------

--- a/source/extensions/filters/http/ext_proc/ext_proc.cc
+++ b/source/extensions/filters/http/ext_proc/ext_proc.cc
@@ -1731,12 +1731,6 @@ void Filter::onFinishProcessorCalls(Grpc::Status::GrpcStatus call_status) {
 }
 
 void Filter::sendImmediateResponse(const ImmediateResponse& response) {
-  if (config_->isUpstream()) {
-    stats_.send_immediate_resp_upstream_ignored_.inc();
-    ENVOY_STREAM_LOG(debug, "Ignoring send immediate response when ext_proc filter is in upstream",
-                     *decoder_callbacks_);
-    return;
-  }
   auto status_code = response.has_status() ? response.status().code() : DefaultImmediateStatus;
   if (!MutationUtils::isValidHttpStatus(status_code)) {
     ENVOY_STREAM_LOG(debug, "Ignoring attempt to set invalid HTTP status {}", *decoder_callbacks_,

--- a/source/extensions/filters/http/ext_proc/ext_proc.h
+++ b/source/extensions/filters/http/ext_proc/ext_proc.h
@@ -50,7 +50,6 @@ namespace ExternalProcessing {
   COUNTER(clear_route_cache_ignored)                                                               \
   COUNTER(clear_route_cache_disabled)                                                              \
   COUNTER(clear_route_cache_upstream_ignored)                                                      \
-  COUNTER(send_immediate_resp_upstream_ignored)                                                    \
   COUNTER(http_not_ok_resp_received)
 
 struct ExtProcFilterStats {

--- a/test/extensions/filters/http/ext_proc/filter_test.cc
+++ b/test/extensions/filters/http/ext_proc/filter_test.cc
@@ -5071,8 +5071,6 @@ TEST_F(HttpFilterTest, ClearRouteCacheHeaderMutationUpstreamIgnored) {
   EXPECT_EQ(config_->stats().streams_closed_.value(), 1);
 }
 
-// When ext_proc filter is in upstream filter chain, do not sending local
-// reply to downstream in case immediate response is received.
 TEST_F(HttpFilterTest, PostAndRespondImmediatelyUpstream) {
   initialize(R"EOF(
   grpc_service:
@@ -5084,12 +5082,12 @@ TEST_F(HttpFilterTest, PostAndRespondImmediatelyUpstream) {
   EXPECT_EQ(filter_->decodeHeaders(request_headers_, false), FilterHeadersStatus::StopIteration);
   test_time_->advanceTimeWait(std::chrono::microseconds(10));
   TestResponseHeaderMapImpl immediate_response_headers;
-  ON_CALL(encoder_callbacks_, sendLocalReply(::Envoy::Http::Code::BadRequest, "Bad request", _,
-                                             Eq(absl::nullopt), "Got_a_bad_request"))
-      .WillByDefault(Invoke([&immediate_response_headers](
-                                Unused, Unused,
-                                std::function<void(ResponseHeaderMap & headers)> modify_headers,
-                                Unused, Unused) { modify_headers(immediate_response_headers); }));
+  EXPECT_CALL(encoder_callbacks_, sendLocalReply(::Envoy::Http::Code::BadRequest, "Bad request", _,
+                                                 Eq(absl::nullopt), "Got_a_bad_request"))
+      .WillOnce(Invoke([&immediate_response_headers](
+                           Unused, Unused,
+                           std::function<void(ResponseHeaderMap & headers)> modify_headers, Unused,
+                           Unused) { modify_headers(immediate_response_headers); }));
   std::unique_ptr<ProcessingResponse> resp1 = std::make_unique<ProcessingResponse>();
   auto* immediate_response = resp1->mutable_immediate_response();
   immediate_response->mutable_status()->set_code(envoy::type::v3::StatusCode::BadRequest);
@@ -5100,12 +5098,15 @@ TEST_F(HttpFilterTest, PostAndRespondImmediatelyUpstream) {
   hdr1->mutable_append()->set_value(false);
   hdr1->mutable_header()->set_key("content-type");
   hdr1->mutable_header()->set_raw_value("text/plain");
+  auto* hdr2 = immediate_headers->add_set_headers();
+  hdr2->mutable_append()->set_value(true);
+  hdr2->mutable_header()->set_key("foo");
+  hdr2->mutable_header()->set_raw_value("bar");
   stream_callbacks_->onReceiveMessage(std::move(resp1));
-  TestResponseHeaderMapImpl expected_response_headers{};
-  // Send local reply never happened.
+
+  TestResponseHeaderMapImpl expected_response_headers{{"content-type", "text/plain"},
+                                                      {"foo", "bar"}};
   EXPECT_THAT(&immediate_response_headers, HeaderMapEqualIgnoreOrder(&expected_response_headers));
-  // The send immediate response counter is increased.
-  EXPECT_EQ(config_->stats().send_immediate_resp_upstream_ignored_.value(), 1);
   EXPECT_EQ(config_->stats().streams_started_.value(), 1);
   EXPECT_EQ(config_->stats().stream_msgs_sent_.value(), 1);
   EXPECT_EQ(config_->stats().stream_msgs_received_.value(), 1);


### PR DESCRIPTION
Commit Message: ext_proc: allow immediate response from upstream filter

Additional Description:
This is from the discussion here: https://github.com/envoyproxy/envoy/pull/33273#discussion_r2277354590
Previously, sending local replies from an upstream ext_proc filter was prohibited just because of the implementation choice. This prevented users from returning errors from there, which results in clients indefinitely waiting for the response until timeout without any feedback. In short, ext_proc was previously unable to fail.

Closes https://github.com/envoyproxy/ai-gateway/issues/840

Risk Level: low (previously considered invalid code paths)
Testing: done
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a