### PR TITLE
Refactor method for reuse in streaming local responses

### DIFF
--- a/source/extensions/filters/http/ext_proc/processor_state.h
+++ b/source/extensions/filters/http/ext_proc/processor_state.h
@@ -313,43 +313,36 @@ private:
    * Routes to appropriate handler based on body state and processing mode
    * (none, buffered, streamed, partial, or full-duplex).
    *
-   * @param response HeadersResponse with continue action
    * @return Status of the operation
    */
-  absl::Status handleHeaderContinue(const envoy::service::ext_proc::v3::HeadersResponse& response);
+  absl::Status handleHeaderContinue();
 
   /**
    * Handle the body when the complete body is already available.
    * Sends buffered body to processor based on callback state,
    * manages streamed data, and continues filter chain when appropriate.
    *
-   * @param response HeadersResponse from processor
    * @return Status of the operation
    */
-  absl::Status
-  handleCompleteBodyAvailable(const envoy::service::ext_proc::v3::HeadersResponse& response);
+  absl::Status handleCompleteBodyAvailable();
 
   /**
    * Handle partial body buffering with watermark control when geting a header response.
    * Enqueues buffered data, sends chunks when high watermark is reached,
    * and holds headers during buffering phase.
    *
-   * @param response HeadersResponse from processor
    * @return Status of the operation
    */
-  absl::Status
-  handleBufferedPartialMode(const envoy::service::ext_proc::v3::HeadersResponse& response);
+  absl::Status handleBufferedPartialMode();
 
   /**
    * Finalizes processing by handling trailers and cleanup.
    * Either sends available trailers to processor or cleans up resources
    * by clearing headers, notifying filter, and continuing the chain.
    *
-   * @param response HeadersResponse from processor
    * @return Status of the operation
    */
-  absl::Status
-  handleTrailersAndCleanup(const envoy::service::ext_proc::v3::HeadersResponse& response);
+  absl::Status handleTrailersAndCleanup();
 
   /**
    * Validates if the current callback state is valid for processing body responses.


### PR DESCRIPTION
Refactor method for processing header response to allow it to be reused for local streaming responses.

Risk Level: none
Testing: unit tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
