### PR TITLE
udp_proxy: reassign data.addresses_ after creating an active session

### DIFF
--- a/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.cc
+++ b/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.cc
@@ -90,6 +90,7 @@ Network::FilterStatus StickySessionUdpProxyFilter::onDataInternal(Network::UdpRe
     if (active_session == nullptr) {
       return Network::FilterStatus::StopIteration;
     }
+    data.addresses_ = active_session->addresses();
   } else {
     active_session = active_session_it->get();
     // We defer the socket creation when the session includes filters, so the filters can be
@@ -112,6 +113,7 @@ Network::FilterStatus StickySessionUdpProxyFilter::onDataInternal(Network::UdpRe
         ENVOY_LOG(debug, "upstream session unhealthy, recreating the session");
         removeSession(active_session);
         active_session = createSession(std::move(data.addresses_), host, false);
+        data.addresses_ = active_session->addresses();
       } else {
         // In this case we could not get a better host, so just keep using the current session.
         ENVOY_LOG(trace, "upstream session unhealthy, but unable to get a better host");


### PR DESCRIPTION
Additional Description: Fixes #41186. std::move causes data.addresses_'s contents to be empty
Risk Level: Low
Testing: Manual
Docs Changes:
Release Notes:
Platform Specific Features:
