### PR TITLE
local-rate-limit: improving cluster fetching validation

### DIFF
--- a/envoy/upstream/cluster_manager.h
+++ b/envoy/upstream/cluster_manager.h
@@ -350,6 +350,16 @@ public:
   virtual OptRef<const Cluster> getActiveCluster(const std::string& cluster_name) const PURE;
 
   /**
+   * Receives a cluster name and returns an active or warming cluster (if found).
+   * @param cluster_name the name of the cluster.
+   * @return OptRef<const Cluster> A reference to the cluster if found, and nullopt otherwise.
+   *
+   * NOTE: This method is only thread safe on the main thread. It should not be called elsewhere.
+   */
+  virtual OptRef<const Cluster>
+  getActiveOrWarmingCluster(const std::string& cluster_name) const PURE;
+
+  /**
    * Returns true iff the given cluster name is known in the cluster-manager
    * (either as active or as warming).
    * @param cluster_name the name of the cluster.

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -279,6 +279,17 @@ public:
     return absl::nullopt;
   }
 
+  OptRef<const Cluster> getActiveOrWarmingCluster(const std::string& cluster_name) const override {
+    ASSERT_IS_MAIN_OR_TEST_THREAD();
+    if (const auto& it = active_clusters_.find(cluster_name); it != active_clusters_.end()) {
+      return *it->second->cluster_;
+    }
+    if (const auto& it = warming_clusters_.find(cluster_name); it != warming_clusters_.end()) {
+      return *it->second->cluster_;
+    }
+    return absl::nullopt;
+  }
+
   bool hasCluster(const std::string& cluster_name) const override {
     ASSERT_IS_MAIN_OR_TEST_THREAD();
     return active_clusters_.contains(cluster_name) || warming_clusters_.contains(cluster_name);

--- a/source/extensions/filters/common/local_ratelimit/local_ratelimit_impl.cc
+++ b/source/extensions/filters/common/local_ratelimit/local_ratelimit_impl.cc
@@ -65,7 +65,7 @@ ShareProviderManagerSharedPtr ShareProviderManager::singleton(Event::Dispatcher&
         if (!local_cluster_name.has_value()) {
           return nullptr;
         }
-        auto cluster = cm.clusters().getCluster(local_cluster_name.value());
+        auto cluster = cm.getActiveOrWarmingCluster(local_cluster_name.value());
         if (!cluster.has_value()) {
           return nullptr;
         }

--- a/test/mocks/upstream/cluster_manager.h
+++ b/test/mocks/upstream/cluster_manager.h
@@ -44,6 +44,8 @@ public:
               (const envoy::config::bootstrap::v3::Bootstrap& bootstrap));
   MOCK_METHOD(ClusterInfoMaps, clusters, (), (const));
   MOCK_METHOD(OptRef<const Cluster>, getActiveCluster, (const std::string& cluster_name), (const));
+  MOCK_METHOD(OptRef<const Cluster>, getActiveOrWarmingCluster, (const std::string& cluster_name),
+              (const));
   MOCK_METHOD(bool, hasCluster, (const std::string& cluster_name), (const));
   MOCK_METHOD(bool, hasActiveClusters, (), (const));
 


### PR DESCRIPTION
Commit Message: local-rate-limit: improving cluster fetching validation
Additional Description:
Prior to this the local-rate-limit filter used an O(n) operation to fetch all clusters and then check for one.
This PR uses an O(1) lookup instead.

Risk Level: low - internal change
Testing: Added unit tests already existing tests cover the local-rate-limit functionality
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A