### PR TITLE
Fix comment about TLS inspector buffering behavior

### DIFF
--- a/api/envoy/extensions/filters/listener/tls_inspector/v3/tls_inspector.proto
+++ b/api/envoy/extensions/filters/listener/tls_inspector/v3/tls_inspector.proto
@@ -32,8 +32,8 @@ message TlsInspector {
 
   // The size in bytes of the initial buffer requested by the tls_inspector.
   // If the filter needs to read additional bytes from the socket, the
-  // filter will double the buffer up to it's default maximum of 64KiB.
-  // If this size is not defined, defaults to maximum 64KiB that the
+  // filter will double the buffer up to it's default maximum of 16KiB.
+  // If this size is not defined, defaults to maximum 16KiB that the
   // tls inspector will consume.
   google.protobuf.UInt32Value initial_read_buffer_size = 2
       [(validate.rules).uint32 = {lt: 65537 gt: 255}];


### PR DESCRIPTION
Update proto field comment to reflect the implementation - https://github.com/envoyproxy/envoy/blob/c6fe45e40f602e5288b6d4a51e2904b0c937583a/source/extensions/filters/listener/tls_inspector/tls_inspector.h#L58

Risk Level: none
Testing: n/a
