### PR TITLE
Change getaddrinfo DNS resolver visibility to public

### DIFF
--- a/source/extensions/network/dns_resolver/getaddrinfo/BUILD
+++ b/source/extensions/network/dns_resolver/getaddrinfo/BUILD
@@ -12,7 +12,7 @@ envoy_cc_extension(
     name = "config",
     srcs = ["getaddrinfo.cc"],
     hdrs = ["getaddrinfo.h"],
-    extra_visibility = ["//test:__subpackages__"],
+    visibility = ["//visibility:public"],
     deps = [
         "//envoy/network:dns_resolver_interface",
         "//envoy/registry",


### PR DESCRIPTION
Changing getaddrinfo DNS resolver library visibility into: visibility:public as may have dependency from none //test:__subpackages__.   