### PR TITLE
tools(base): add macOS wheel hash for cryptography to fix local docs build

### DIFF
--- a/tools/base/requirements.txt
+++ b/tools/base/requirements.txt
@@ -468,7 +468,8 @@ cryptography==46.0.1 \
     --hash=sha256:0dfb7c88d4462a0cfdd0d87a3c245a7bc3feb59de101f6ff88194f740f72eda6 \
     --hash=sha256:757af4f6341ce7a1e47c326ca2a81f41d236070217e5fbbad61bbfe299d55d28 \
     --hash=sha256:e22801b61613ebdebf7deb18b507919e107547a1d39a3b57f5f855032dd7cfb8 \
-    --hash=sha256:f7a24ea78de345cfa7f6a8d3bde8b242c7fac27f2bd78fa23474ca38dfaeeab9
+    --hash=sha256:f7a24ea78de345cfa7f6a8d3bde8b242c7fac27f2bd78fa23474ca38dfaeeab9 \
+    --hash=sha256:1cd6d50c1a8b79af1a6f703709d8973845f677c8e97b1268f5ff323d38ce8475
     # via
     #   -r requirements.in
     #   aioquic


### PR DESCRIPTION
- Append the observed cryptography==46.0.1 macOS universal2 wheel sha256 to requirements.txt
- Unblocks bazel docs build on macOS without Docker (rules_python --require-hashes)

Required this to be able to build docs locally on my mac for PR https://github.com/envoyproxy/envoy/pull/41251

Risk Level: Low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a