### PR TITLE
http: implement setUpstreamOverrideHost for AsyncClient

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -523,5 +523,9 @@ new_features:
   change: |
     Added ``max_downstream_connection_duration_jitter_percentage`` to allow adding a jitter to the max downstream connection duration.
     This can be used to avoid thundering herd problems with many clients being disconnected and possibly reconnecting at the same time.
+- area: http
+  change: |
+    Added ``setUpstreamOverrideHost`` method to AsyncClient StreamOptions to enable direct host routing
+    that bypasses load balancer selection.
 
 deprecated:

--- a/envoy/http/async_client.h
+++ b/envoy/http/async_client.h
@@ -13,6 +13,7 @@
 #include "envoy/stream_info/filter_state.h"
 #include "envoy/stream_info/stream_info.h"
 #include "envoy/tracing/tracer.h"
+#include "envoy/upstream/load_balancer.h"
 
 #include "source/common/protobuf/protobuf.h"
 
@@ -392,6 +393,11 @@ public:
       remote_close_timeout = timeout;
       return *this;
     }
+    StreamOptions&
+    setUpstreamOverrideHost(const Upstream::LoadBalancerContext::OverrideHost& host) {
+      upstream_override_host_ = host;
+      return *this;
+    }
 
     // For gmock test
     bool operator==(const StreamOptions& src) const {
@@ -461,6 +467,9 @@ public:
     // This callback is invoked when AsyncStream object is deleted.
     // Test only use to validate deferred deletion.
     std::function<void()> on_delete_callback_for_test_only;
+
+    // Optional upstream override host for bypassing load balancer selection
+    absl::optional<Upstream::LoadBalancerContext::OverrideHost> upstream_override_host_;
   };
 
   /**

--- a/source/common/http/async_client_impl.cc
+++ b/source/common/http/async_client_impl.cc
@@ -119,7 +119,8 @@ AsyncStreamImpl::AsyncStreamImpl(AsyncClientImpl& parent, AsyncClient::StreamCal
                              StreamInfo::FilterState::LifeSpan::FilterChain)),
       tracing_config_(Tracing::EgressConfig::get()), local_reply_(*parent.local_reply_),
       account_(options.account_), buffer_limit_(options.buffer_limit_), send_xff_(options.send_xff),
-      send_internal_(options.send_internal) {
+      send_internal_(options.send_internal),
+      upstream_override_host_(options.upstream_override_host_) {
   auto retry_policy = createRetryPolicy(options, parent.factory_context_, creation_status);
 
   // A field initialization may set the creation-status as unsuccessful.

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -252,7 +252,7 @@ private:
   void setUpstreamOverrideHost(Upstream::LoadBalancerContext::OverrideHost) override {}
   absl::optional<Upstream::LoadBalancerContext::OverrideHost>
   upstreamOverrideHost() const override {
-    return absl::nullopt;
+    return upstream_override_host_;
   }
   bool shouldLoadShed() const override { return false; }
   absl::string_view filterConfigName() const override { return ""; }
@@ -294,6 +294,9 @@ private:
   bool send_xff_{true};
   bool send_internal_{true};
   bool router_destroyed_{false};
+
+  // Upstream override host for bypassing load balancer selection
+  absl::optional<Upstream::LoadBalancerContext::OverrideHost> upstream_override_host_;
 
   friend class AsyncClientImpl;
   friend class AsyncClientImplUnitTest;

--- a/test/common/http/async_client_impl_test.cc
+++ b/test/common/http/async_client_impl_test.cc
@@ -2467,5 +2467,167 @@ TEST_F(AsyncClientImplUnitTest, NullVirtualHost) {
   EXPECT_EQ(std::numeric_limits<uint64_t>::max(), vhost_.requestBodyBufferLimit());
 }
 
+TEST_F(AsyncClientImplTest, UpstreamOverrideHost) {
+  Buffer::InstancePtr body{new Buffer::OwnedImpl("test body")};
+  Upstream::LoadBalancerContext::OverrideHost override_host{"192.168.1.100:8080", true};
+
+  EXPECT_CALL(cm_.thread_local_cluster_, httpConnPool(_, _, _, _))
+      .WillOnce(Invoke([&](Upstream::HostConstSharedPtr, Upstream::ResourcePriority,
+                           absl::optional<Http::Protocol>, Upstream::LoadBalancerContext* context) {
+        // Verify that the upstream override host is passed through the load balancer context
+        auto retrieved_override = context->overrideHostToSelect();
+        EXPECT_TRUE(retrieved_override.has_value());
+        EXPECT_EQ(retrieved_override->first, "192.168.1.100:8080");
+        EXPECT_EQ(retrieved_override->second, true);
+        return Upstream::HttpPoolData([]() {}, &cm_.thread_local_cluster_.conn_pool_);
+      }));
+
+  // Verify that the load balancer queries for the upstream override host
+  EXPECT_CALL(cm_.thread_local_cluster_, chooseHost(_))
+      .WillOnce(Invoke([&](Upstream::LoadBalancerContext* context) {
+        // The load balancer should call overrideHostToSelect() to get the override
+        auto retrieved_override = context->overrideHostToSelect();
+        EXPECT_TRUE(retrieved_override.has_value());
+        EXPECT_EQ(retrieved_override->first, "192.168.1.100:8080");
+        EXPECT_EQ(retrieved_override->second, true);
+        return Upstream::HostSelectionResponse{cm_.thread_local_cluster_.lb_.host_};
+      }));
+
+  EXPECT_CALL(cm_.thread_local_cluster_.conn_pool_, newStream(_, _, _))
+      .WillOnce(Invoke([&](ResponseDecoder& decoder, ConnectionPool::Callbacks& callbacks,
+                           const ConnectionPool::Instance::StreamOptions&) {
+        callbacks.onPoolReady(stream_encoder_, cm_.thread_local_cluster_.conn_pool_.host_,
+                              stream_info_, {});
+        response_decoder_ = &decoder;
+        return nullptr;
+      }));
+
+  TestRequestHeaderMapImpl headers;
+  HttpTestUtility::addDefaultHeaders(headers);
+  EXPECT_CALL(stream_encoder_, encodeHeaders(HeaderMapEqualRef(&headers), false));
+  EXPECT_CALL(stream_encoder_, encodeData(BufferEqual(body.get()), true));
+
+  expectResponseHeaders(stream_callbacks_, 200, false);
+  EXPECT_CALL(stream_callbacks_, onData(BufferEqual(body.get()), true));
+  EXPECT_CALL(stream_callbacks_, onComplete());
+
+  AsyncClient::StreamOptions options;
+  options.setUpstreamOverrideHost(override_host);
+  AsyncClient::Stream* stream = client_.start(stream_callbacks_, options);
+
+  stream->sendHeaders(headers, false);
+  stream->sendData(*body, true);
+
+  response_decoder_->decodeHeaders(
+      ResponseHeaderMapPtr(new TestResponseHeaderMapImpl{{":status", "200"}}), false);
+  response_decoder_->decodeData(*body, true);
+}
+
+TEST_F(AsyncClientImplTest, UpstreamOverrideHostNotStrict) {
+  Buffer::InstancePtr body{new Buffer::OwnedImpl("test body")};
+  Upstream::LoadBalancerContext::OverrideHost override_host{"example.com:8080", false};
+
+  EXPECT_CALL(cm_.thread_local_cluster_, httpConnPool(_, _, _, _))
+      .WillOnce(Invoke([&](Upstream::HostConstSharedPtr, Upstream::ResourcePriority,
+                           absl::optional<Http::Protocol>, Upstream::LoadBalancerContext* context) {
+        // Verify that the non-strict upstream override host is passed correctly
+        auto retrieved_override = context->overrideHostToSelect();
+        EXPECT_TRUE(retrieved_override.has_value());
+        EXPECT_EQ(retrieved_override->first, "example.com:8080");
+        EXPECT_EQ(retrieved_override->second, false);
+        return Upstream::HttpPoolData([]() {}, &cm_.thread_local_cluster_.conn_pool_);
+      }));
+
+  // Verify that the load balancer queries for the non-strict upstream override host
+  EXPECT_CALL(cm_.thread_local_cluster_, chooseHost(_))
+      .WillOnce(Invoke([&](Upstream::LoadBalancerContext* context) {
+        // The load balancer should call overrideHostToSelect() to get the override
+        auto retrieved_override = context->overrideHostToSelect();
+        EXPECT_TRUE(retrieved_override.has_value());
+        EXPECT_EQ(retrieved_override->first, "example.com:8080");
+        EXPECT_EQ(retrieved_override->second, false);
+        return Upstream::HostSelectionResponse{cm_.thread_local_cluster_.lb_.host_};
+      }));
+
+  EXPECT_CALL(cm_.thread_local_cluster_.conn_pool_, newStream(_, _, _))
+      .WillOnce(Invoke([&](ResponseDecoder& decoder, ConnectionPool::Callbacks& callbacks,
+                           const ConnectionPool::Instance::StreamOptions&) {
+        callbacks.onPoolReady(stream_encoder_, cm_.thread_local_cluster_.conn_pool_.host_,
+                              stream_info_, {});
+        response_decoder_ = &decoder;
+        return nullptr;
+      }));
+
+  TestRequestHeaderMapImpl headers;
+  HttpTestUtility::addDefaultHeaders(headers);
+  EXPECT_CALL(stream_encoder_, encodeHeaders(HeaderMapEqualRef(&headers), false));
+  EXPECT_CALL(stream_encoder_, encodeData(BufferEqual(body.get()), true));
+
+  expectResponseHeaders(stream_callbacks_, 200, false);
+  EXPECT_CALL(stream_callbacks_, onData(BufferEqual(body.get()), true));
+  EXPECT_CALL(stream_callbacks_, onComplete());
+
+  AsyncClient::StreamOptions options;
+  options.setUpstreamOverrideHost(override_host);
+  AsyncClient::Stream* stream = client_.start(stream_callbacks_, options);
+
+  stream->sendHeaders(headers, false);
+  stream->sendData(*body, true);
+
+  response_decoder_->decodeHeaders(
+      ResponseHeaderMapPtr(new TestResponseHeaderMapImpl{{":status", "200"}}), false);
+  response_decoder_->decodeData(*body, true);
+}
+
+TEST_F(AsyncClientImplTest, NoUpstreamOverrideHost) {
+  Buffer::InstancePtr body{new Buffer::OwnedImpl("test body")};
+
+  EXPECT_CALL(cm_.thread_local_cluster_, httpConnPool(_, _, _, _))
+      .WillOnce(Invoke([&](Upstream::HostConstSharedPtr, Upstream::ResourcePriority,
+                           absl::optional<Http::Protocol>, Upstream::LoadBalancerContext* context) {
+        // Verify that no upstream override host is set when not specified
+        auto retrieved_override = context->overrideHostToSelect();
+        EXPECT_FALSE(retrieved_override.has_value());
+        return Upstream::HttpPoolData([]() {}, &cm_.thread_local_cluster_.conn_pool_);
+      }));
+
+  // Verify that the load balancer queries for override host and gets nullopt
+  EXPECT_CALL(cm_.thread_local_cluster_, chooseHost(_))
+      .WillOnce(Invoke([&](Upstream::LoadBalancerContext* context) {
+        // The load balancer should call overrideHostToSelect() but get nullopt
+        auto retrieved_override = context->overrideHostToSelect();
+        EXPECT_FALSE(retrieved_override.has_value());
+        return Upstream::HostSelectionResponse{cm_.thread_local_cluster_.lb_.host_};
+      }));
+
+  EXPECT_CALL(cm_.thread_local_cluster_.conn_pool_, newStream(_, _, _))
+      .WillOnce(Invoke([&](ResponseDecoder& decoder, ConnectionPool::Callbacks& callbacks,
+                           const ConnectionPool::Instance::StreamOptions&) {
+        callbacks.onPoolReady(stream_encoder_, cm_.thread_local_cluster_.conn_pool_.host_,
+                              stream_info_, {});
+        response_decoder_ = &decoder;
+        return nullptr;
+      }));
+
+  TestRequestHeaderMapImpl headers;
+  HttpTestUtility::addDefaultHeaders(headers);
+  EXPECT_CALL(stream_encoder_, encodeHeaders(HeaderMapEqualRef(&headers), false));
+  EXPECT_CALL(stream_encoder_, encodeData(BufferEqual(body.get()), true));
+
+  expectResponseHeaders(stream_callbacks_, 200, false);
+  EXPECT_CALL(stream_callbacks_, onData(BufferEqual(body.get()), true));
+  EXPECT_CALL(stream_callbacks_, onComplete());
+
+  AsyncClient::StreamOptions options;
+  AsyncClient::Stream* stream = client_.start(stream_callbacks_, options);
+
+  stream->sendHeaders(headers, false);
+  stream->sendData(*body, true);
+
+  response_decoder_->decodeHeaders(
+      ResponseHeaderMapPtr(new TestResponseHeaderMapImpl{{":status", "200"}}), false);
+  response_decoder_->decodeData(*body, true);
+}
+
 } // namespace Http
 } // namespace Envoy


### PR DESCRIPTION
Add `setUpstreamOverrideHost` method to `AsyncClient::StreamOptions` to enable applications to bypass load balancer selection and route requests directly to specific upstream hosts. This supports use cases like consistent hashing, sticky sessions, and stateful service routing.

Risk Level: Low ?
Testing: unit tests
Docs Changes: No
Release Notes: Yes