### PR TITLE
ext_proc: spurious response handling needs to consider per-route-override config

### DIFF
--- a/source/extensions/filters/http/ext_proc/ext_proc.cc
+++ b/source/extensions/filters/http/ext_proc/ext_proc.cc
@@ -1626,9 +1626,8 @@ void Filter::onReceiveMessage(std::unique_ptr<ProcessingResponse>&& r) {
     stats_.spurious_msgs_received_.inc();
     ENVOY_STREAM_LOG(warn, "Spurious response message {} received on gRPC stream",
                      *decoder_callbacks_, static_cast<int>(response->response_case()));
-    if (config_->failureModeAllow() ||
-        !Runtime::runtimeFeatureEnabled(
-            "envoy.reloadable_features.ext_proc_fail_close_spurious_resp")) {
+    if (failure_mode_allow_ || !Runtime::runtimeFeatureEnabled(
+                                   "envoy.reloadable_features.ext_proc_fail_close_spurious_resp")) {
       // When a message is received out of order,and fail open is configured,
       // ignore it and also ignore the stream for the rest of this filter
       // instance's lifetime to protect us from a malformed server.


### PR DESCRIPTION
Fixes a bug that when spurious response is received, Envoy should honor the per_route_override configuration of failure_mode_allow. The existing way to only consider the top level filter configuration is wrong.