### PR TITLE
fix: fixes MacOS build by resolving type mismatch in std::min

### DIFF
--- a/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
+++ b/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
@@ -605,8 +605,8 @@ Http::FilterDataStatus JsonTranscoderFilter::decodeData(Buffer::Instance& data, 
       Buffer::OwnedImpl remaining_request_data;
       remaining_request_data.move(request_data_);
       while (remaining_request_data.length() > 0) {
-        uint64_t piece_size =
-            std::min(remaining_request_data.length(), JsonTranscoderConfig::MaxStreamedPieceSize);
+        uint64_t piece_size = std::min<uint64_t>(remaining_request_data.length(),
+                                                 JsonTranscoderConfig::MaxStreamedPieceSize);
         request_data_.move(remaining_request_data, piece_size);
         maybeSendHttpBodyRequestMessage(&data);
       }


### PR DESCRIPTION
## Description

This PR fixes the compilation error on macOS caused by type mismatch between `uint64_t` and `size_t in std::min` template deduction by explicitly adding a template parameter to `std::min` to resolve this ambiguity.

Without this fix the build on macOS fails with this error:
```bash
$ bazel build //source/exe:envoy-static --define=wasm=disabled --copt=-Wno-nullability-completeness
...
ERROR: /Users/rohit.agrawal/envoy-fork/source/extensions/filters/http/grpc_json_transcoder/BUILD:15:17: Compiling source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc failed: (Exit 1): cc_wrapper.sh failed: error executing CppCompile command (from target //source/extensions/filters/http/grpc_json_transcoder:json_transcoder_filter_lib) external/local_config_cc/cc_wrapper.sh -U_FORTIFY_SOURCE -fstack-protector -Wall -Wthread-safety -Wself-assign -Wunused-but-set-parameter -Wno-free-nonheap-object -fcolor-diagnostics ... (remaining 239 arguments skipped)

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc:609:13: error: no matching function for call to 'min'
  609 |             std::min(remaining_request_data.length(), JsonTranscoderConfig::MaxStreamedPieceSize);
      |             ^~~~~~~~
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__algorithm/min.h:35:1: note: candidate template ignored: deduced conflicting types for parameter '_Tp' ('uint64_t' (aka 'unsigned long long') vs. 'size_t' (aka 'unsigned long'))
   35 | min(_LIBCPP_LIFETIMEBOUND const _Tp& __a, _LIBCPP_LIFETIMEBOUND const _Tp& __b) {
      | ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__algorithm/min.h:43:1: note: candidate template ignored: could not match 'initializer_list<_Tp>' against 'uint64_t' (aka 'unsigned long long')
   43 | min(initializer_list<_Tp> __t, _Compare __comp) {
      | ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__algorithm/min.h:48:82: note: candidate function template not viable: requires single argument '__t', but 2 arguments were provided
   48 | [[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 _Tp min(initializer_list<_Tp> __t) {
      |                                                                                  ^   ~~~~~~~~~~~~~~~~~~~~~~~~~
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__algorithm/min.h:29:1: note: candidate function template not viable: requires 3 arguments, but 2 were provided
   29 | min(_LIBCPP_LIFETIMEBOUND const _Tp& __a, _LIBCPP_LIFETIMEBOUND const _Tp& __b, _Compare __comp) {
      | ^                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
Target //source/exe:envoy-static failed to build
Use --verbose_failures to see the command lines of failed build steps.
INFO: Elapsed time: 242.332s, Critical Path: 204.52s
INFO: 179 processes: 27 internal, 152 darwin-sandbox.
ERROR: Build did NOT complete successfully
```

---

**Commit Message:** fix: fixes MacOS build by resolving type mismatch in std::min
**Additional Description:** Fixes compilation on macOS with Xcode toolchain.
**Risk Level:** Low
**Testing:** CI
**Docs Changes:** N/A
**Release Notes:** N/A