### PR TITLE
fix build target upstream_to_downstream_impl_base

### DIFF
--- a/source/common/router/BUILD
+++ b/source/common/router/BUILD
@@ -350,7 +350,7 @@ envoy_cc_library(
 
 envoy_cc_library(
     name = "upstream_to_downstream_impl_base",
-    srcs = [
+    hdrs = [
         "upstream_to_downstream_impl_base.h",
     ],
     deps = [


### PR DESCRIPTION
Commit Message: the target should expose the .h file as headers rather than resources. Otherwise its dependent targets will fail C++ layering check.


Risk Level: low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
