### PR TITLE
tcp_proxy: add support for populating TLVs with dynamic metadata

### DIFF
--- a/api/envoy/config/core/v3/proxy_protocol.proto
+++ b/api/envoy/config/core/v3/proxy_protocol.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package envoy.config.core.v3;
 
+import "envoy/config/core/v3/substitution_format_string.proto";
+
 import "udpa/annotations/status.proto";
 import "validate/validate.proto";
 
@@ -33,12 +35,35 @@ message ProxyProtocolPassThroughTLVs {
 }
 
 // Represents a single Type-Length-Value (TLV) entry.
+// [#next-free-field: 4]
 message TlvEntry {
   // The type of the TLV. Must be a uint8 (0-255) as per the Proxy Protocol v2 specification.
   uint32 type = 1 [(validate.rules).uint32 = {lt: 256}];
 
-  // The value of the TLV. Must be at least one byte long.
-  bytes value = 2 [(validate.rules).bytes = {min_len: 1}];
+  oneof value_specifier {
+    option (validate.required) = true;
+
+    // The static value of the TLV. Must be at least one byte long.
+    bytes value = 2 [(validate.rules).bytes = {min_len: 1}];
+
+    // Uses the :ref:`format string <config_access_log_format_strings>` to dynamically
+    // populate the TLV value from stream information. The formatted output will be
+    // Base64-encoded before being set as the TLV value. This allows dynamic values
+    // such as metadata, filter state, or other stream properties to be included in
+    // the TLV.
+    //
+    // For example:
+    //
+    // .. code-block:: yaml
+    //
+    //   type: 0xF0
+    //   format_string:
+    //     text_format_source:
+    //       inline_string: "%DYNAMIC_METADATA(envoy.filters.network:key)%"
+    //
+    // The formatted string will be Base64-encoded and included as the TLV value.
+    SubstitutionFormatString format_string = 3;
+  }
 }
 
 message ProxyProtocolConfig {

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -500,6 +500,12 @@ new_features:
   change: |
     Added a new Logging ABI that allows modules to emit logs in the standard Envoy logging stream under ``dynamic_modules`` ID.
     In the Rust SDK, they are available as ``envoy_log_info``, etc.
+- area: tcp_proxy
+  change: |
+    Added support for dynamic TLV values in PROXY protocol using :ref:`format_string
+    <envoy_v3_api_field_config.core.v3.TlvEntry.format_string>` field. This allows TLV values to be
+    populated dynamically from stream information using format strings (e.g., ``%DYNAMIC_METADATA(...)%``,
+    ``%FILTER_STATE(...)%``, ``%DOWNSTREAM_REMOTE_ADDRESS%``).
 - area: http
   change: |
     Added ``upstream_rq_per_cx`` histogram to track requests per connection for monitoring connection reuse efficiency.

--- a/source/common/tcp_proxy/tcp_proxy.cc
+++ b/source/common/tcp_proxy/tcp_proxy.cc
@@ -19,6 +19,7 @@
 
 #include "source/common/access_log/access_log_impl.h"
 #include "source/common/common/assert.h"
+#include "source/common/common/base64.h"
 #include "source/common/common/empty_string.h"
 #include "source/common/common/enum_to_int.h"
 #include "source/common/common/fmt.h"
@@ -188,7 +189,8 @@ Config::SharedConfig::SharedConfig(
   }
 
   if (!config.proxy_protocol_tlvs().empty()) {
-    proxy_protocol_tlvs_ = parseTLVs(config.proxy_protocol_tlvs());
+    proxy_protocol_tlvs_ =
+        parseTLVs(config.proxy_protocol_tlvs(), context, dynamic_tlv_formatters_);
   }
 }
 
@@ -321,13 +323,56 @@ TcpProxyStats Config::SharedConfig::generateStats(Stats::Scope& scope) {
 }
 
 Network::ProxyProtocolTLVVector
-Config::SharedConfig::parseTLVs(absl::Span<const envoy::config::core::v3::TlvEntry* const> tlvs) {
+Config::SharedConfig::parseTLVs(absl::Span<const envoy::config::core::v3::TlvEntry* const> tlvs,
+                                Server::Configuration::GenericFactoryContext& context,
+                                std::vector<TlvFormatter>& dynamic_tlvs) {
   Network::ProxyProtocolTLVVector tlv_vector;
   for (const auto& tlv : tlvs) {
-    tlv_vector.push_back({static_cast<uint8_t>(tlv->type()),
-                          std::vector<unsigned char>(tlv->value().begin(), tlv->value().end())});
+    const uint8_t tlv_type = static_cast<uint8_t>(tlv->type());
+
+    switch (tlv->value_specifier_case()) {
+    case envoy::config::core::v3::TlvEntry::ValueSpecifierCase::kValue: {
+      // Static TLV value.
+      tlv_vector.push_back(
+          {tlv_type, std::vector<unsigned char>(tlv->value().begin(), tlv->value().end())});
+      break;
+    }
+    case envoy::config::core::v3::TlvEntry::ValueSpecifierCase::kFormatString: {
+      // Dynamic TLV value using formatter.
+      auto formatter_or_error =
+          Formatter::SubstitutionFormatStringUtils::fromProtoConfig(tlv->format_string(), context);
+      if (!formatter_or_error.ok()) {
+        throw EnvoyException(absl::StrCat("Failed to parse TLV format string: ",
+                                          formatter_or_error.status().ToString()));
+      }
+      dynamic_tlvs.push_back({tlv_type, std::move(*formatter_or_error)});
+      break;
+    }
+    case envoy::config::core::v3::TlvEntry::ValueSpecifierCase::VALUE_SPECIFIER_NOT_SET:
+      // This should not happen due to proto validation.
+      PANIC("TLV value_specifier not set");
+    }
   }
   return tlv_vector;
+}
+
+Network::ProxyProtocolTLVVector
+Config::SharedConfig::evaluateDynamicTLVs(const StreamInfo::StreamInfo& stream_info) const {
+  Network::ProxyProtocolTLVVector result = proxy_protocol_tlvs_;
+
+  // Evaluate dynamic TLV formatters.
+  for (const auto& tlv_formatter : dynamic_tlv_formatters_) {
+    const std::string formatted_value = tlv_formatter.formatter->formatWithContext({}, stream_info);
+
+    // Base64-encode the formatted value.
+    const std::string encoded_value = Base64::encode(formatted_value);
+
+    // Convert to bytes and add to result.
+    result.push_back({tlv_formatter.type,
+                      std::vector<unsigned char>(encoded_value.begin(), encoded_value.end())});
+  }
+
+  return result;
 }
 
 void Filter::initializeReadFilterCallbacks(Network::ReadFilterCallbacks& callbacks) {
@@ -584,12 +629,13 @@ Network::FilterStatus Filter::establishUpstreamConnection() {
   auto& filter_state = downstream_connection.streamInfo().filterState();
   if (!filter_state->hasData<Network::ProxyProtocolFilterState>(
           Network::ProxyProtocolFilterState::key())) {
+    // Evaluate dynamic TLVs with the connection's stream info.
+    const auto tlvs = config_->sharedConfig()->evaluateDynamicTLVs(getStreamInfo());
     filter_state->setData(
         Network::ProxyProtocolFilterState::key(),
         std::make_shared<Network::ProxyProtocolFilterState>(Network::ProxyProtocolData{
             downstream_connection.connectionInfoProvider().remoteAddress(),
-            downstream_connection.connectionInfoProvider().localAddress(),
-            config_->proxyProtocolTLVs()}),
+            downstream_connection.connectionInfoProvider().localAddress(), tlvs}),
         StreamInfo::FilterState::StateType::ReadOnly,
         StreamInfo::FilterState::LifeSpan::Connection);
   }

--- a/source/common/tcp_proxy/tcp_proxy.h
+++ b/source/common/tcp_proxy/tcp_proxy.h
@@ -259,11 +259,23 @@ public:
       return proxy_protocol_tlvs_;
     }
 
+    // Evaluate dynamic TLV formatters and combine with static TLVs.
+    Network::ProxyProtocolTLVVector
+    evaluateDynamicTLVs(const StreamInfo::StreamInfo& stream_info) const;
+
   private:
+    // Structure to hold TLV formatter information.
+    struct TlvFormatter {
+      uint8_t type;
+      Formatter::FormatterPtr formatter;
+    };
+
     static TcpProxyStats generateStats(Stats::Scope& scope);
 
     static Network::ProxyProtocolTLVVector
-    parseTLVs(absl::Span<const envoy::config::core::v3::TlvEntry* const> tlvs);
+    parseTLVs(absl::Span<const envoy::config::core::v3::TlvEntry* const> tlvs,
+              Server::Configuration::GenericFactoryContext& context,
+              std::vector<TlvFormatter>& dynamic_tlvs);
 
     // Hold a Scope for the lifetime of the configuration because connections in
     // the UpstreamDrainManager can live longer than the listener.
@@ -279,6 +291,7 @@ public:
     std::unique_ptr<OnDemandConfig> on_demand_config_;
     BackOffStrategyPtr backoff_strategy_;
     Network::ProxyProtocolTLVVector proxy_protocol_tlvs_;
+    std::vector<TlvFormatter> dynamic_tlv_formatters_;
   };
 
   using SharedConfigSharedPtr = std::shared_ptr<SharedConfig>;


### PR DESCRIPTION
## Description

We have a requirement where we want to populate the additional TLVs using dynamic metadata. We don't have that option today as TLV value takes a hardcoded stream of bytes.

In this PR we are adding an option to use the substitution formatters to be able to provide the TLV data. It'd be Base64-ed in the TCP Proxy.

---

**Commit Message:** tcp_proxy: add support for populating TLVs with dynamic metadata
**Additional Description:** Added support for populating TLVs data dynamically using substitution formatters.
**Risk Level:** Low
**Testing:** Added Unit Tests
**Docs Changes:** Added
**Release Notes:** Added