### PR TITLE
oauth2: minor perf-refactor when fetching a cluster

### DIFF
--- a/source/extensions/filters/http/oauth2/filter.cc
+++ b/source/extensions/filters/http/oauth2/filter.cc
@@ -469,7 +469,7 @@ FilterConfig::FilterConfig(
            proto_config.cookie_configs().has_code_verifier_cookie_config())
               ? CookieSettings(proto_config.cookie_configs().code_verifier_cookie_config())
               : CookieSettings()) {
-  if (!context.clusterManager().clusters().hasCluster(oauth_token_endpoint_.cluster())) {
+  if (!context.clusterManager().hasCluster(oauth_token_endpoint_.cluster())) {
     // This is not necessarily a configuration error — sometimes cluster is sent later than the
     // listener in the xDS stream.
     ENVOY_LOG(warn, "OAuth2 filter: unknown cluster '{}' in config. ",


### PR DESCRIPTION
Commit Message: oauth2: minor perf-refactor when fetching a cluster
Additional Description:
Minor perf-refactor for oauth2 to use an O(1) time and space complexity when fetching a cluster, instead of O(n).

Risk Level: low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
