### PR TITLE
Make grpc_json_transcoder_filter correctly handle empty decodeData

### DIFF
--- a/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
+++ b/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
@@ -604,7 +604,7 @@ Http::FilterDataStatus JsonTranscoderFilter::decodeData(Buffer::Instance& data, 
       // split the input buffer into 1MB pieces until the buffer is smaller than 1MB.
       Buffer::OwnedImpl remaining_request_data;
       remaining_request_data.move(request_data_);
-      while (remaining_request_data.length() > 0) {
+      while (!first_request_sent_ || remaining_request_data.length() > 0) {
         uint64_t piece_size = std::min<uint64_t>(remaining_request_data.length(),
                                                  JsonTranscoderConfig::MaxStreamedPieceSize);
         request_data_.move(remaining_request_data, piece_size);


### PR DESCRIPTION
Commit Message: Make grpc_json_transcoder_filter correctly handle empty decodeData
Additional Description: The symptom without this fix is upstreams start flakily declaring that the client cancelled the stream, for us this was about one request in twenty, of `HttpBody` styled streaming grpcs. I think the amount it flakes depends to some extent on the behavior of the downstream, as whether a request of this form comes in as headers-with-end-stream or headers-without-end-stream-then-empty-body-with-end-stream is determined by the outcome of a race. This bug was introduced by me in #41115.
Risk Level: Negative.
Testing:
New test before fix:
```
[ RUN      ] IpVersions/GrpcJsonTranscoderIntegrationTest.EmptyMessagePost/IPv4
test/extensions/filters/http/grpc_json_transcoder/grpc_json_transcoder_integration_test.cc:302: Failure
Expected equality of these values:
  1
  frames.size()
    Which is: 0
```

Docs Changes: n/a
Release Notes: n/a (because it's a fix to a bug that hasn't been in a release yet)
Platform Specific Features: n/a
