### PR TITLE
mcp: add the simple json_rpc parse to dynamic metadata

### DIFF
--- a/source/common/common/logger.h
+++ b/source/common/common/logger.h
@@ -74,6 +74,7 @@ const static bool should_log = true;
   FUNCTION(local_rate_limit)                                                                       \
   FUNCTION(main)                                                                                   \
   FUNCTION(matcher)                                                                                \
+  FUNCTION(mcp)                                                                                    \
   FUNCTION(misc)                                                                                   \
   FUNCTION(mongo)                                                                                  \
   FUNCTION(multi_connection)                                                                       \

--- a/source/extensions/filters/http/mcp/mcp_filter.cc
+++ b/source/extensions/filters/http/mcp/mcp_filter.cc
@@ -1,30 +1,71 @@
 #include "source/extensions/filters/http/mcp/mcp_filter.h"
 
 #include "source/common/http/headers.h"
+#include "source/common/protobuf/utility.h"
 
 namespace Envoy {
 namespace Extensions {
 namespace HttpFilters {
 namespace Mcp {
 
-Http::FilterHeadersStatus McpFilter::decodeHeaders(Http::RequestHeaderMap&, bool) {
-  // TODO: Implement MCP request header processing
-  return Http::FilterHeadersStatus::Continue;
+using google::protobuf::Struct;
+using google::protobuf::Value;
+
+Http::FilterHeadersStatus McpFilter::decodeHeaders(Http::RequestHeaderMap& headers,
+                                                   bool end_stream) {
+  if (headers.getMethodValue() == Http::Headers::get().MethodValues.Post &&
+      headers.getContentTypeValue() == Http::Headers::get().ContentTypeValues.Json) {
+    is_json_post_request_ = true;
+  }
+
+  if (!is_json_post_request_ || end_stream) {
+    return Http::FilterHeadersStatus::Continue;
+  }
+
+  return Http::FilterHeadersStatus::StopIteration;
 }
 
-Http::FilterDataStatus McpFilter::decodeData(Buffer::Instance&, bool) {
-  // TODO: Implement MCP request data processing
-  return Http::FilterDataStatus::Continue;
+Http::FilterDataStatus McpFilter::decodeData(Buffer::Instance& data, bool end_stream) {
+  if (!is_json_post_request_) {
+    return Http::FilterDataStatus::Continue;
+  }
+
+  if (end_stream) {
+    decoder_callbacks_->addDecodedData(data, true);
+    std::string json = decoder_callbacks_->decodingBuffer()->toString();
+    if (metadata_ == nullptr) {
+      metadata_ = std::make_unique<Struct>();
+    }
+    bool has_unknown_fields = false;
+    auto status = MessageUtil::loadFromJsonNoThrow(json, *metadata_, has_unknown_fields);
+
+    if (!status.ok()) {
+      decoder_callbacks_->sendLocalReply(Envoy::Http::Code::BadRequest,
+                                         "Request body is not a valid JSON.", nullptr,
+                                         absl::nullopt, "");
+      return Http::FilterDataStatus::StopIterationNoBuffer;
+    }
+
+    if (!metadata_->fields().contains("jsonrpc") ||
+        metadata_->fields().at("jsonrpc").string_value() != "2.0") {
+      decoder_callbacks_->sendLocalReply(Envoy::Http::Code::BadRequest,
+                                         "Request body is not a valid JSON-RPC 2.0 request.",
+                                         nullptr, absl::nullopt, "");
+      return Http::FilterDataStatus::StopIterationNoBuffer;
+    }
+    finalizeDynamicMetadata();
+    return Http::FilterDataStatus::Continue;
+  }
+
+  return Http::FilterDataStatus::StopIterationAndBuffer;
 }
 
-Http::FilterHeadersStatus McpFilter::encodeHeaders(Http::ResponseHeaderMap&, bool) {
-  // TODO: Implement MCP response header processing
-  return Http::FilterHeadersStatus::Continue;
-}
-
-Http::FilterDataStatus McpFilter::encodeData(Buffer::Instance&, bool) {
-  // TODO: Implement MCP response data processing
-  return Http::FilterDataStatus::Continue;
+void McpFilter::finalizeDynamicMetadata() {
+  if (metadata_ != nullptr) {
+    decoder_callbacks_->streamInfo().setDynamicMetadata(std::string(MetadataKeys::FilterName),
+                                                        *metadata_);
+    ENVOY_LOG(debug, "MCP filter set dynamic metadata: {}", metadata_->DebugString());
+  }
 }
 
 } // namespace Mcp

--- a/source/extensions/filters/http/mcp/mcp_filter.h
+++ b/source/extensions/filters/http/mcp/mcp_filter.h
@@ -14,6 +14,11 @@ namespace Extensions {
 namespace HttpFilters {
 namespace Mcp {
 
+namespace MetadataKeys {
+// Core MCP fields
+constexpr absl::string_view FilterName = "mcp_proxy";
+} // namespace MetadataKeys
+
 /**
  * Configuration for the MCP filter.
  */
@@ -25,9 +30,9 @@ public:
 using McpFilterConfigSharedPtr = std::shared_ptr<McpFilterConfig>;
 
 /**
- * HTTP MCP filter implementation.
+ * MCP proxy implementation.
  */
-class McpFilter : public Http::PassThroughFilter, public Logger::Loggable<Logger::Id::filter> {
+class McpFilter : public Http::PassThroughFilter, public Logger::Loggable<Logger::Id::mcp> {
 public:
   explicit McpFilter(McpFilterConfigSharedPtr config) : config_(config) {}
 
@@ -37,12 +42,23 @@ public:
   Http::FilterDataStatus decodeData(Buffer::Instance& data, bool end_stream) override;
 
   // Http::StreamEncoderFilter
-  Http::FilterHeadersStatus encodeHeaders(Http::ResponseHeaderMap& headers,
-                                          bool end_stream) override;
-  Http::FilterDataStatus encodeData(Buffer::Instance& data, bool end_stream) override;
+  Http::FilterHeadersStatus encodeHeaders(Http::ResponseHeaderMap&, bool) override {
+    return Http::FilterHeadersStatus::Continue;
+  };
+  Http::FilterDataStatus encodeData(Buffer::Instance&, bool) override {
+    return Http::FilterDataStatus::Continue;
+  };
+
+  void setDecoderFilterCallbacks(Http::StreamDecoderFilterCallbacks& callbacks) override {
+    decoder_callbacks_ = &callbacks;
+  }
 
 private:
+  void finalizeDynamicMetadata();
   McpFilterConfigSharedPtr config_;
+  Http::StreamDecoderFilterCallbacks* decoder_callbacks_{};
+  bool is_json_post_request_{false};
+  std::unique_ptr<google::protobuf::Struct> metadata_;
 };
 
 } // namespace Mcp

--- a/test/extensions/filters/http/mcp/mcp_filter_integration_test.cc
+++ b/test/extensions/filters/http/mcp/mcp_filter_integration_test.cc
@@ -23,20 +23,104 @@ public:
 
 INSTANTIATE_TEST_SUITE_P(IpVersions, McpFilterIntegrationTest,
                          testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
-
-TEST_P(McpFilterIntegrationTest, BasicRequest) {
+// Test that a non-POST request is ignored and passes through.
+TEST_P(McpFilterIntegrationTest, NonPostRequestIgnored) {
   initializeFilter();
 
   codec_client_ = makeHttpConnection(lookupPort("http"));
   auto response = codec_client_->makeRequestWithBody(
       Http::TestRequestHeaderMapImpl{
           {":method", "GET"}, {":path", "/"}, {":scheme", "http"}, {":authority", "host"}},
-      1024);
+      0);
 
   waitForNextUpstreamRequest();
   upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, true);
 
   ASSERT_TRUE(response->waitForEndStream());
+  EXPECT_TRUE(upstream_request_->complete());
+  EXPECT_EQ("200", response->headers().getStatusValue());
+}
+
+// Test that a valid JSON-RPC POST request passes through successfully.
+TEST_P(McpFilterIntegrationTest, ValidJsonRpcPostRequest) {
+  initializeFilter();
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+  const std::string request_body = R"({"jsonrpc": "2.0", "method": "test"})";
+  auto response = codec_client_->makeRequestWithBody(
+      Http::TestRequestHeaderMapImpl{{":method", "POST"},
+                                     {":path", "/"},
+                                     {":scheme", "http"},
+                                     {":authority", "host"},
+                                     {"content-type", "application/json"}},
+      request_body);
+
+  waitForNextUpstreamRequest();
+  upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, true);
+
+  ASSERT_TRUE(response->waitForEndStream());
+  EXPECT_TRUE(upstream_request_->complete());
+  EXPECT_EQ(request_body, upstream_request_->body().toString());
+  EXPECT_EQ("200", response->headers().getStatusValue());
+}
+
+// Test that a request with malformed JSON is rejected with a 400.
+TEST_P(McpFilterIntegrationTest, InvalidJsonBodyRejected) {
+  initializeFilter();
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+  auto response = codec_client_->makeRequestWithBody(
+      Http::TestRequestHeaderMapImpl{{":method", "POST"},
+                                     {":path", "/"},
+                                     {":scheme", "http"},
+                                     {":authority", "host"},
+                                     {"content-type", "application/json"}},
+      R"({"jsonrpc": "2.0",)"); // Malformed JSON
+
+  ASSERT_TRUE(response->waitForEndStream());
+  // The upstream should NOT receive a request because the filter sends a local reply.
+  EXPECT_FALSE(upstream_request_ != nullptr);
+  EXPECT_EQ("400", response->headers().getStatusValue());
+}
+
+// Test that a request with valid JSON but missing the required fields is rejected with a 400.
+TEST_P(McpFilterIntegrationTest, MissingJsonRpcFieldRejected) {
+  initializeFilter();
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+  auto response = codec_client_->makeRequestWithBody(
+      Http::TestRequestHeaderMapImpl{{":method", "POST"},
+                                     {":path", "/"},
+                                     {":scheme", "http"},
+                                     {":authority", "host"},
+                                     {"content-type", "application/json"}},
+      R"({"method": "test"})"); // Missing 'jsonrpc: "2.0"'
+
+  ASSERT_TRUE(response->waitForEndStream());
+  // The upstream should NOT receive a request.
+  EXPECT_FALSE(upstream_request_ != nullptr);
+  EXPECT_EQ("400", response->headers().getStatusValue());
+}
+
+// Test that a POST request with the wrong content type is ignored and passes through.
+TEST_P(McpFilterIntegrationTest, WrongContentTypePostRequestIgnored) {
+  initializeFilter();
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+  const std::string request_body = R"({"jsonrpc": "2.0", "method": "test"})";
+  auto response = codec_client_->makeRequestWithBody(
+      Http::TestRequestHeaderMapImpl{{":method", "POST"},
+                                     {":path", "/"},
+                                     {":scheme", "http"},
+                                     {":authority", "host"},
+                                     {"content-type", "text/plain"}}, // Incorrect content type
+      request_body);
+
+  waitForNextUpstreamRequest();
+  upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, true);
+
+  ASSERT_TRUE(response->waitForEndStream());
+  EXPECT_TRUE(upstream_request_->complete());
   EXPECT_EQ("200", response->headers().getStatusValue());
 }
 


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Simple basic passthrough but store the JSON_RPC to metadata.
#39174

Commit Message:
Additional Description:
Risk Level: low
Testing:
Docs Changes:
Release Notes:
