### PR TITLE
cleanup: remove redundant line in scoped_rds

### DIFF
--- a/source/common/router/scoped_rds.cc
+++ b/source/common/router/scoped_rds.cc
@@ -288,7 +288,6 @@ absl::StatusOr<bool> ScopedRdsConfigSubscription::addOrUpdateScopes(
         scope_name_by_hash_.erase(scope_info_iter->second->scopeKey().hash());
       }
     }
-    rds.set_route_config_name(scoped_route_config.route_configuration_name());
     std::unique_ptr<RdsRouteConfigProviderHelper> rds_config_provider_helper;
     std::shared_ptr<ScopedRouteInfo> scoped_route_info = nullptr;
     if (scoped_route_config.has_route_configuration()) {


### PR DESCRIPTION
Commit Message: cleanup: remove redundant line in scoped_rds
Additional Description:
Removing a [line](https://github.com/envoyproxy/envoy/blob/24b2bdf189920d9bc97d02d8d26e7ffcc7b19d6c/source/common/router/scoped_rds.cc#L291) as it is done in [another line](https://github.com/envoyproxy/envoy/blob/24b2bdf189920d9bc97d02d8d26e7ffcc7b19d6c/source/common/router/scoped_rds.cc#L315) and only when the `rds` object is needed.

Risk Level: low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
