### PR TITLE
Add max_sessions_per_event_loop to quic protocol options.

### DIFF
--- a/api/envoy/config/listener/v3/quic_config.proto
+++ b/api/envoy/config/listener/v3/quic_config.proto
@@ -25,7 +25,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // [#protodoc-title: QUIC listener config]
 
 // Configuration specific to the UDP QUIC listener.
-// [#next-free-field: 14]
+// [#next-free-field: 15]
 message QuicProtocolOptions {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.api.v2.listener.QuicProtocolOptions";
@@ -99,4 +99,10 @@ message QuicProtocolOptions {
   // QUIC layer by replying with an empty version negotiation packet to the
   // client.
   bool reject_new_connections = 13;
+
+  // Maximum number of QUIC sessions to create per event loop.
+  // If not specified, the default value is 16.
+  // This is an equivalent of the TCP listener option
+  // max_connections_to_accept_per_socket_event.
+  google.protobuf.UInt32Value max_sessions_per_event_loop = 14 [(validate.rules).uint32 = {gt: 0}];
 }

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -584,5 +584,10 @@ new_features:
     Added :ref:`outlier_detection<envoy_v3_api_field_extensions.upstreams.http.v3.HttpProtocolOptions.outlier_detection>`
     to cluster's http protocol options to allow defining via an http matcher whether a response should be treated
     as error or as success by outlier detection.
+- area: quic
+  change: |
+    Add a new quic configuration field, 'max_sessions_per_event_loop', to QuicProtocolOptions in Envoy listener.
+    This allows tuning the maximum number of new QUIC sessions created within a single event loop.
+    The default value is 16, preserving the previous hardcoded limit.
 
 deprecated:

--- a/source/common/quic/active_quic_listener.cc
+++ b/source/common/quic/active_quic_listener.cc
@@ -129,6 +129,10 @@ ActiveQuicListener::ActiveQuicListener(
       udp_save_cmsg_config_.expected_size = save_cmsg_config.expected_size();
     }
   }
+
+  max_sessions_per_event_loop_ =
+      PROTOBUF_GET_WRAPPED_OR_DEFAULT(listener_config.udpListenerConfig()->config().quic_options(),
+                                      max_sessions_per_event_loop, kNumSessionsToCreatePerLoop);
 }
 
 ActiveQuicListener::~ActiveQuicListener() { onListenerShutdown(); }
@@ -198,7 +202,7 @@ void ActiveQuicListener::onReadReady() {
     event_loops_with_buffered_chlo_for_test_++;
   }
 
-  quic_dispatcher_->ProcessBufferedChlos(kNumSessionsToCreatePerLoop);
+  quic_dispatcher_->ProcessBufferedChlos(max_sessions_per_event_loop_);
 
   // If there were more buffered than the limit, schedule again for the next event loop.
   if (quic_dispatcher_->HasChlosBuffered()) {

--- a/source/common/quic/active_quic_listener.h
+++ b/source/common/quic/active_quic_listener.h
@@ -102,6 +102,7 @@ private:
   // During hot restart, an optional handler for packets that weren't for existing connections.
   OptRef<Network::NonDispatchedUdpPacketHandler> non_dispatched_udp_packet_handler_;
   Network::IoHandle::UdpSaveCmsgConfig udp_save_cmsg_config_;
+  uint32_t max_sessions_per_event_loop_;
 };
 
 using ActiveQuicListenerPtr = std::unique_ptr<ActiveQuicListener>;


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Add a new quic configuration field, 'max_sessions_per_event_loop', to QuicProtocolOptions in Envoy listener.
Additional Description: This change allows tuning the maximum number of new QUIC sessions created within a single event loop. The default value is 16, preserving the previous hardcoded limit.
Risk Level: low
Testing: unit tests
Docs Changes:
Release Notes: Add max_sessions_per_event_loop to quic protocol options.
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
