### PR TITLE
add support for uint64 cel-expression upstream.num_endpoints

### DIFF
--- a/docs/root/intro/arch_overview/advanced/attributes.rst
+++ b/docs/root/intro/arch_overview/advanced/attributes.rst
@@ -141,6 +141,7 @@ The following attributes are available once the upstream connection is establish
    :widths: 1, 1, 4
 
    upstream.address, string, Upstream connection remote address
+   upstream.num_endpoints, uint64, the number of endpoints of the upstream cluster.
    upstream.port, int, Upstream connection remote port
    upstream.tls_version, string, TLS version of the upstream TLS connection
    upstream.subject_local_certificate, string, The subject field of the local certificate in the upstream TLS connection

--- a/source/extensions/filters/common/expr/context.cc
+++ b/source/extensions/filters/common/expr/context.cc
@@ -214,6 +214,18 @@ const RequestLookupValues& RequestLookupValues::get() {
              path = path.substr(query_offset + 1);
              auto fragment_offset = path.find('#');
              return CelValue::CreateStringView(path.substr(0, fragment_offset));
+          }},
+          {BackendServiceHasEndpoints,
+           [](const RequestWrapper& wrapper) -> absl::optional<CelValue> {
+             if (wrapper.info_.upstreamClusterInfo().value_or(nullptr) !=
+                 nullptr) {
+               return CelValue::CreateBool(wrapper.info_.upstreamClusterInfo()
+                                               .value()
+                                               .get()
+                                               ->endpointStats()
+                                               .membership_total_.value() > 0);
+             }
+             return CelValue::CreateBool(false);
            }}});
 }
 

--- a/source/extensions/filters/common/expr/context.cc
+++ b/source/extensions/filters/common/expr/context.cc
@@ -214,19 +214,7 @@ const RequestLookupValues& RequestLookupValues::get() {
              path = path.substr(query_offset + 1);
              auto fragment_offset = path.find('#');
              return CelValue::CreateStringView(path.substr(0, fragment_offset));
-          }},
-          {UpstreamClusterEndpoints,
-           [](const RequestWrapper& wrapper) -> absl::optional<CelValue> {
-             if (wrapper.info_.upstreamClusterInfo().value_or(nullptr) !=
-                 nullptr) {
-               return CelValue::CreateUint64(wrapper.info_.upstreamClusterInfo()
-                                               .value()
-                                               .get()
-                                               ->endpointStats()
-                                               .membership_total_.value());
-             }
-             return CelValue::CreateUint64(0);
-           }}});
+            }}});
 }
 
 // Response lookup implementation
@@ -412,6 +400,18 @@ const UpstreamLookupValues& UpstreamLookupValues::get() {
           {UpstreamRequestAttemptCount,
            [](const UpstreamWrapper& wrapper) -> absl::optional<CelValue> {
              return CelValue::CreateUint64(wrapper.info_.attemptCount().value_or(0));
+          }},
+          {UpstreamNumEndpoints,
+           [](const UpstreamWrapper& wrapper) -> absl::optional<CelValue> {
+             if (wrapper.info_.upstreamClusterInfo().value_or(nullptr) !=
+                 nullptr) {
+               return CelValue::CreateUint64(wrapper.info_.upstreamClusterInfo()
+                                               .value()
+                                               .get()
+                                               ->endpointStats()
+                                               .membership_total_.value());
+             }
+             return CelValue::CreateUint64(0);
            }}});
 }
 

--- a/source/extensions/filters/common/expr/context.cc
+++ b/source/extensions/filters/common/expr/context.cc
@@ -400,16 +400,14 @@ const UpstreamLookupValues& UpstreamLookupValues::get() {
           {UpstreamRequestAttemptCount,
            [](const UpstreamWrapper& wrapper) -> absl::optional<CelValue> {
              return CelValue::CreateUint64(wrapper.info_.attemptCount().value_or(0));
-          }},
-          {UpstreamNumEndpoints,
-           [](const UpstreamWrapper& wrapper) -> absl::optional<CelValue> {
-             if (wrapper.info_.upstreamClusterInfo().value_or(nullptr) !=
-                 nullptr) {
+           }},
+          {UpstreamNumEndpoints, [](const UpstreamWrapper& wrapper) -> absl::optional<CelValue> {
+             if (wrapper.info_.upstreamClusterInfo().value_or(nullptr) != nullptr) {
                return CelValue::CreateUint64(wrapper.info_.upstreamClusterInfo()
-                                               .value()
-                                               .get()
-                                               ->endpointStats()
-                                               .membership_total_.value());
+                                                 .value()
+                                                 .get()
+                                                 ->endpointStats()
+                                                 .membership_total_.value());
              }
              return {};
            }}});

--- a/source/extensions/filters/common/expr/context.cc
+++ b/source/extensions/filters/common/expr/context.cc
@@ -214,7 +214,7 @@ const RequestLookupValues& RequestLookupValues::get() {
              path = path.substr(query_offset + 1);
              auto fragment_offset = path.find('#');
              return CelValue::CreateStringView(path.substr(0, fragment_offset));
-            }}});
+           }}});
 }
 
 // Response lookup implementation

--- a/source/extensions/filters/common/expr/context.cc
+++ b/source/extensions/filters/common/expr/context.cc
@@ -215,17 +215,17 @@ const RequestLookupValues& RequestLookupValues::get() {
              auto fragment_offset = path.find('#');
              return CelValue::CreateStringView(path.substr(0, fragment_offset));
           }},
-          {BackendServiceHasEndpoints,
+          {UpstreamClusterEndpoints,
            [](const RequestWrapper& wrapper) -> absl::optional<CelValue> {
              if (wrapper.info_.upstreamClusterInfo().value_or(nullptr) !=
                  nullptr) {
-               return CelValue::CreateBool(wrapper.info_.upstreamClusterInfo()
+               return CelValue::CreateUint64(wrapper.info_.upstreamClusterInfo()
                                                .value()
                                                .get()
                                                ->endpointStats()
-                                               .membership_total_.value() > 0);
+                                               .membership_total_.value());
              }
-             return CelValue::CreateBool(false);
+             return CelValue::CreateUint64(0);
            }}});
 }
 

--- a/source/extensions/filters/common/expr/context.cc
+++ b/source/extensions/filters/common/expr/context.cc
@@ -411,7 +411,7 @@ const UpstreamLookupValues& UpstreamLookupValues::get() {
                                                ->endpointStats()
                                                .membership_total_.value());
              }
-             return CelValue::CreateUint64(0);
+             return {};
            }}});
 }
 

--- a/source/extensions/filters/common/expr/context.h
+++ b/source/extensions/filters/common/expr/context.h
@@ -40,6 +40,8 @@ constexpr absl::string_view TotalSize = "total_size";
 constexpr absl::string_view Duration = "duration";
 constexpr absl::string_view Protocol = "protocol";
 constexpr absl::string_view Query = "query";
+constexpr absl::string_view BackendServiceHasEndpoints =
+    "backend_service_has_endpoints";
 
 // Symbols for traversing the response properties
 constexpr absl::string_view Response = "response";

--- a/source/extensions/filters/common/expr/context.h
+++ b/source/extensions/filters/common/expr/context.h
@@ -40,8 +40,8 @@ constexpr absl::string_view TotalSize = "total_size";
 constexpr absl::string_view Duration = "duration";
 constexpr absl::string_view Protocol = "protocol";
 constexpr absl::string_view Query = "query";
-constexpr absl::string_view BackendServiceHasEndpoints =
-    "backend_service_has_endpoints";
+constexpr absl::string_view UpstreamClusterEndpoints =
+    "upstream_cluster_endpoints";
 
 // Symbols for traversing the response properties
 constexpr absl::string_view Response = "response";

--- a/source/extensions/filters/common/expr/context.h
+++ b/source/extensions/filters/common/expr/context.h
@@ -40,8 +40,6 @@ constexpr absl::string_view TotalSize = "total_size";
 constexpr absl::string_view Duration = "duration";
 constexpr absl::string_view Protocol = "protocol";
 constexpr absl::string_view Query = "query";
-constexpr absl::string_view UpstreamClusterEndpoints =
-    "upstream_cluster_endpoints";
 
 // Symbols for traversing the response properties
 constexpr absl::string_view Response = "response";
@@ -89,6 +87,7 @@ constexpr absl::string_view UpstreamLocality = "locality";
 constexpr absl::string_view UpstreamTransportFailureReason = "transport_failure_reason";
 constexpr absl::string_view UpstreamRequestAttemptCount = "request_attempt_count";
 constexpr absl::string_view UpstreamConnectionPoolReadyDuration = "cx_pool_ready_duration";
+constexpr absl::string_view UpstreamNumEndpoints = "num_endpoints";
 
 // xDS configuration context properties
 constexpr absl::string_view XDS = "xds";

--- a/test/extensions/filters/common/expr/context_test.cc
+++ b/test/extensions/filters/common/expr/context_test.cc
@@ -861,9 +861,7 @@ TEST(Context, ConnectionAttributes) {
     EXPECT_CALL(info, upstreamClusterInfo())
         .WillRepeatedly(Return(absl::nullopt));
     auto value = upstream[CelValue::CreateStringView(UpstreamNumEndpoints)];
-    EXPECT_TRUE(value.has_value());
-    ASSERT_TRUE(value.value().IsUint64());
-    EXPECT_EQ(0, value.value().Uint64OrDie());
+    EXPECT_FALSE(value.has_value());
   }
 }
 

--- a/test/extensions/filters/common/expr/context_test.cc
+++ b/test/extensions/filters/common/expr/context_test.cc
@@ -858,8 +858,7 @@ TEST(Context, ConnectionAttributes) {
   }
 
   {
-    EXPECT_CALL(info, upstreamClusterInfo())
-        .WillRepeatedly(Return(absl::nullopt));
+    EXPECT_CALL(info, upstreamClusterInfo()).WillRepeatedly(Return(absl::nullopt));
     auto value = upstream[CelValue::CreateStringView(UpstreamNumEndpoints)];
     EXPECT_FALSE(value.has_value());
   }

--- a/test/extensions/filters/common/expr/context_test.cc
+++ b/test/extensions/filters/common/expr/context_test.cc
@@ -245,30 +245,27 @@ TEST(Context, RequestAttributes) {
 
   {
     cluster_info->endpoint_stats_.membership_total_.set(1);
-    auto value =
-        request[CelValue::CreateStringView(BackendServiceHasEndpoints)];
+    auto value = request[CelValue::CreateStringView(UpstreamClusterEndpoints)];
     EXPECT_TRUE(value.has_value());
-    ASSERT_TRUE(value.value().IsBool());
-    EXPECT_EQ(true, value.value().BoolOrDie());
+    ASSERT_TRUE(value.value().IsUint64());
+    EXPECT_EQ(1, value.value().Uint64OrDie());
   }
 
   {
     cluster_info->endpoint_stats_.membership_total_.set(0);
-    auto value =
-        request[CelValue::CreateStringView(BackendServiceHasEndpoints)];
+    auto value = request[CelValue::CreateStringView(UpstreamClusterEndpoints)];
     EXPECT_TRUE(value.has_value());
-    ASSERT_TRUE(value.value().IsBool());
-    EXPECT_EQ(false, value.value().BoolOrDie());
+    ASSERT_TRUE(value.value().IsUint64());
+    EXPECT_EQ(0, value.value().Uint64OrDie());
   }
 
   {
     EXPECT_CALL(info, upstreamClusterInfo())
         .WillRepeatedly(Return(absl::nullopt));
-    auto value =
-        request[CelValue::CreateStringView(BackendServiceHasEndpoints)];
+    auto value = request[CelValue::CreateStringView(UpstreamClusterEndpoints)];
     EXPECT_TRUE(value.has_value());
-    ASSERT_TRUE(value.value().IsBool());
-    EXPECT_EQ(false, value.value().BoolOrDie());
+    ASSERT_TRUE(value.value().IsUint64());
+    EXPECT_EQ(0, value.value().Uint64OrDie());
   }
 }
 


### PR DESCRIPTION
Commit Message: add support for uint64 cel-expression upstream.num_endpoints


Additional Description: This could be very useful when extension execution depends on endpoints status, esp when backend endpoints could be dynamically wake-up by requests. 

Risk Level: LOW (no prod usage)
Testing: unit test
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
