### PR TITLE
ExtProc: Cleanup unused class ImmediateMutationChecker and destructor ProcessingRequestModifierFactory

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -206,6 +206,9 @@ bug_fixes:
 - area: release
   change: |
     Fixed the distroless image to ensure nonroot.
+- area: ext_proc
+  change: |
+    Removed unused class ImmediateMutationChecker and unused destructor ProcessingRequestModifierFactory().
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -206,9 +206,6 @@ bug_fixes:
 - area: release
   change: |
     Fixed the distroless image to ensure nonroot.
-- area: ext_proc
-  change: |
-    Removed unused class ImmediateMutationChecker and unused destructor ProcessingRequestModifierFactory().
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/source/extensions/filters/http/ext_proc/ext_proc.cc
+++ b/source/extensions/filters/http/ext_proc/ext_proc.cc
@@ -214,27 +214,6 @@ std::function<std::unique_ptr<ProcessingRequestModifier>()> createProcessingRequ
   };
 }
 
-// Changes to headers are normally tested against the MutationRules supplied
-// with configuration. When writing an immediate response message, however,
-// we want to support a more liberal set of rules so that filters can create
-// custom error messages, and we want to prevent the MutationRules in the
-// configuration from making that impossible. This is a fixed, permissive
-// set of rules for that purpose.
-class ImmediateMutationChecker {
-public:
-  ImmediateMutationChecker(Regex::Engine& regex_engine) {
-    HeaderMutationRules rules;
-    rules.mutable_allow_all_routing()->set_value(true);
-    rules.mutable_allow_envoy()->set_value(true);
-    rule_checker_ = std::make_unique<Checker>(rules, regex_engine);
-  }
-
-  const Checker& checker() const { return *rule_checker_; }
-
-private:
-  std::unique_ptr<Checker> rule_checker_;
-};
-
 ProcessingMode allDisabledMode() {
   ProcessingMode pm;
   pm.set_request_header_mode(ProcessingMode::SKIP);
@@ -282,7 +261,6 @@ FilterConfig::FilterConfig(const ExternalProcessor& config,
                               config.allowed_override_modes().end()),
       expression_manager_(builder, context.localInfo(), config.request_attributes(),
                           config.response_attributes()),
-      immediate_mutation_checker_(context.regexEngine()),
       processing_request_modifier_factory_cb_(
           createProcessingRequestModifierCb(config, builder, context)),
       on_processing_response_factory_cb_(

--- a/source/extensions/filters/http/ext_proc/ext_proc.h
+++ b/source/extensions/filters/http/ext_proc/ext_proc.h
@@ -147,27 +147,6 @@ private:
   std::string http_response_code_details_;
 };
 
-// Changes to headers are normally tested against the MutationRules supplied
-// with configuration. When writing an immediate response message, however,
-// we want to support a more liberal set of rules so that filters can create
-// custom error messages, and we want to prevent the MutationRules in the
-// configuration from making that impossible. This is a fixed, permissive
-// set of rules for that purpose.
-class ImmediateMutationChecker {
-public:
-  ImmediateMutationChecker(Regex::Engine& regex_engine) {
-    envoy::config::common::mutation_rules::v3::HeaderMutationRules rules;
-    rules.mutable_allow_all_routing()->set_value(true);
-    rules.mutable_allow_envoy()->set_value(true);
-    rule_checker_ = std::make_unique<Filters::Common::MutationRules::Checker>(rules, regex_engine);
-  }
-
-  const Filters::Common::MutationRules::Checker& checker() const { return *rule_checker_; }
-
-private:
-  std::unique_ptr<Filters::Common::MutationRules::Checker> rule_checker_;
-};
-
 class ThreadLocalStreamManager;
 // Default value is 5000 milliseconds (5 seconds)
 inline constexpr uint32_t DEFAULT_DEFERRED_CLOSE_TIMEOUT_MS = 5000;
@@ -284,10 +263,6 @@ public:
     return untyped_receiving_namespaces_;
   }
 
-  const ImmediateMutationChecker& immediateMutationChecker() const {
-    return immediate_mutation_checker_;
-  }
-
   const std::vector<envoy::extensions::filters::http::ext_proc::v3::ProcessingMode>&
   allowedOverrideModes() const {
     return allowed_override_modes_;
@@ -365,7 +340,6 @@ private:
   const std::vector<envoy::extensions::filters::http::ext_proc::v3::ProcessingMode>
       allowed_override_modes_;
   const ExpressionManager expression_manager_;
-  const ImmediateMutationChecker immediate_mutation_checker_;
 
   const std::function<std::unique_ptr<ProcessingRequestModifier>()>
       processing_request_modifier_factory_cb_;

--- a/source/extensions/filters/http/ext_proc/processing_request_modifier.h
+++ b/source/extensions/filters/http/ext_proc/processing_request_modifier.h
@@ -40,8 +40,6 @@ public:
 
 class ProcessingRequestModifierFactory : public Config::TypedFactory {
 public:
-  ~ProcessingRequestModifierFactory() override = default;
-
   /**
    * Creates a new attribute builder based on the type supplied by the config.
    *


### PR DESCRIPTION
Commit Message: Cleanup unused class ImmediateMutationChecker and destructor ProcessingRequestModifierFactory
Additional Description: This code is not invoked and is causing ext_proc coverage tests to fail. Clean-up suggested by Adi and Yanjun in https://github.com/envoyproxy/envoy/pull/41295. ImmediateMutationChecker is not needed any more after the runtime guard added in https://github.com/envoyproxy/envoy/pull/27925 is removed.

Risk Level: Low
Docs Changes: N/A
Platform Specific Features: N/A

Release Notes: Ext Proc: Removed unused class ImmediateMutationChecker and unused destructor ProcessingRequestModifierFactory()

/assign @yanjunxiang-google
/assign @adisuissa