### PR TITLE
add route override support for json_to_metadata filter

### DIFF
--- a/source/extensions/filters/http/json_to_metadata/config.cc
+++ b/source/extensions/filters/http/json_to_metadata/config.cc
@@ -11,17 +11,27 @@ namespace Extensions {
 namespace HttpFilters {
 namespace JsonToMetadata {
 
-JsonToMetadataConfig::JsonToMetadataConfig() : FactoryBase("envoy.filters.http.json_to_metadata") {}
-
-Http::FilterFactoryCb JsonToMetadataConfig::createFilterFactoryFromProtoTyped(
+absl::StatusOr<Http::FilterFactoryCb> JsonToMetadataConfig::createFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::json_to_metadata::v3::JsonToMetadata& proto_config,
     const std::string&, Server::Configuration::FactoryContext& context) {
-  std::shared_ptr<FilterConfig> config = std::make_shared<FilterConfig>(
-      proto_config, context.scope(), context.serverFactoryContext().regexEngine());
+  absl::StatusOr<std::shared_ptr<FilterConfig>> filter_config_or = FilterConfig::create(
+      proto_config, context.scope(), context.serverFactoryContext().regexEngine(), false);
+  RETURN_IF_ERROR(filter_config_or.status());
 
-  return [config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
-    callbacks.addStreamFilter(std::make_shared<Filter>(config));
+  return [filter_config = std::move(filter_config_or.value())](
+             Http::FilterChainFactoryCallbacks& callbacks) -> void {
+    callbacks.addStreamFilter(std::make_shared<Filter>(filter_config));
   };
+}
+
+absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
+JsonToMetadataConfig::createRouteSpecificFilterConfigTyped(
+    const envoy::extensions::filters::http::json_to_metadata::v3::JsonToMetadata& config,
+    Server::Configuration::ServerFactoryContext& context, ProtobufMessage::ValidationVisitor&) {
+  absl::StatusOr<std::shared_ptr<FilterConfig>> config_or =
+      FilterConfig::create(config, context.scope(), context.regexEngine(), true);
+  RETURN_IF_ERROR(config_or.status());
+  return std::move(config_or.value());
 }
 
 /**

--- a/source/extensions/filters/http/json_to_metadata/config.h
+++ b/source/extensions/filters/http/json_to_metadata/config.h
@@ -13,15 +13,19 @@ namespace HttpFilters {
 namespace JsonToMetadata {
 
 class JsonToMetadataConfig
-    : public Extensions::HttpFilters::Common::FactoryBase<
+    : public Extensions::HttpFilters::Common::ExceptionFreeFactoryBase<
           envoy::extensions::filters::http::json_to_metadata::v3::JsonToMetadata> {
 public:
-  JsonToMetadataConfig();
+  JsonToMetadataConfig() : ExceptionFreeFactoryBase("envoy.filters.http.json_to_metadata") {}
 
 private:
-  Http::FilterFactoryCb createFilterFactoryFromProtoTyped(
+  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::json_to_metadata::v3::JsonToMetadata&,
       const std::string&, Server::Configuration::FactoryContext&) override;
+  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
+  createRouteSpecificFilterConfigTyped(
+      const envoy::extensions::filters::http::json_to_metadata::v3::JsonToMetadata& config,
+      Server::Configuration::ServerFactoryContext&, ProtobufMessage::ValidationVisitor&) override;
 };
 
 } // namespace JsonToMetadata

--- a/source/extensions/filters/http/json_to_metadata/filter.cc
+++ b/source/extensions/filters/http/json_to_metadata/filter.cc
@@ -108,9 +108,19 @@ Rule::Rule(const ProtoRule& rule) : rule_(rule) {
   }
 }
 
+absl::StatusOr<std::shared_ptr<FilterConfig>> FilterConfig::create(
+    const envoy::extensions::filters::http::json_to_metadata::v3::JsonToMetadata& proto_config,
+    Stats::Scope& scope, Regex::Engine& regex_engine, bool per_route) {
+  absl::Status creation_status = absl::OkStatus();
+  auto cfg = std::shared_ptr<FilterConfig>(
+      new FilterConfig(proto_config, scope, regex_engine, per_route, creation_status));
+  RETURN_IF_NOT_OK_REF(creation_status);
+  return cfg;
+}
+
 FilterConfig::FilterConfig(
     const envoy::extensions::filters::http::json_to_metadata::v3::JsonToMetadata& proto_config,
-    Stats::Scope& scope, Regex::Engine& regex_engine)
+    Stats::Scope& scope, Regex::Engine& regex_engine, bool per_route, absl::Status& creation_status)
     : rqstats_{ALL_JSON_TO_METADATA_FILTER_STATS(
           POOL_COUNTER_PREFIX(scope, "json_to_metadata.rq"))},
       respstats_{
@@ -134,8 +144,15 @@ FilterConfig::FilterConfig(
                     proto_config.response_rules().allow_content_types_regex(), regex_engine)
               : nullptr) {
   if (request_rules_.empty() && response_rules_.empty()) {
-    throw EnvoyException("json_to_metadata_filter: Per filter configs must at least specify "
-                         "either request or response rules");
+    if (per_route) {
+      creation_status =
+          absl::InvalidArgumentError("json_to_metadata_filter: Per route configs must specify "
+                                     "either request or response rules");
+    } else {
+      creation_status = absl::InvalidArgumentError(
+          "json_to_metadata_filter: Per filter configs must at least specify "
+          "either request or response rules");
+    }
   }
 }
 
@@ -393,57 +410,62 @@ void Filter::processBody(const Buffer::Instance* body, const Rules& rules,
 }
 
 void Filter::processRequestBody() {
-  processBody(decoder_callbacks_->decodingBuffer(), config_->requestRules(), true,
-              config_->rqstats(), *decoder_callbacks_, request_processing_finished_);
+  const auto* config = getConfig();
+  processBody(decoder_callbacks_->decodingBuffer(), config->requestRules(), true, config->rqstats(),
+              *decoder_callbacks_, request_processing_finished_);
 }
 
 void Filter::processResponseBody() {
-  processBody(encoder_callbacks_->encodingBuffer(), config_->responseRules(), false,
-              config_->respstats(), *encoder_callbacks_, response_processing_finished_);
+  const auto* config = getConfig();
+  processBody(encoder_callbacks_->encodingBuffer(), config->responseRules(), false,
+              config->respstats(), *encoder_callbacks_, response_processing_finished_);
 }
 
 Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers, bool end_stream) {
-  if (!config_->doRequest()) {
+  const auto* config = getConfig();
+  if (!config->doRequest()) {
     return Http::FilterHeadersStatus::Continue;
   }
-  if (!config_->requestContentTypeAllowed(headers.getContentTypeValue())) {
-    handleAllOnError(config_->requestRules(), true, *decoder_callbacks_,
+  if (!config->requestContentTypeAllowed(headers.getContentTypeValue())) {
+    handleAllOnError(config->requestRules(), true, *decoder_callbacks_,
                      request_processing_finished_);
-    config_->rqstats().mismatched_content_type_.inc();
+    config->rqstats().mismatched_content_type_.inc();
     return Http::FilterHeadersStatus::Continue;
   }
 
   if (end_stream) {
-    handleAllOnMissing(config_->requestRules(), true, *decoder_callbacks_,
+    handleAllOnMissing(config->requestRules(), true, *decoder_callbacks_,
                        request_processing_finished_);
-    config_->rqstats().no_body_.inc();
+    config->rqstats().no_body_.inc();
     return Http::FilterHeadersStatus::Continue;
   }
   return Http::FilterHeadersStatus::StopIteration;
 }
 
 Http::FilterHeadersStatus Filter::encodeHeaders(Http::ResponseHeaderMap& headers, bool end_stream) {
-  if (!config_->doResponse()) {
+  const auto* config = getConfig();
+  if (!config->doResponse()) {
     return Http::FilterHeadersStatus::Continue;
   }
-  if (!config_->responseContentTypeAllowed(headers.getContentTypeValue())) {
-    handleAllOnError(config_->responseRules(), false, *encoder_callbacks_,
+  if (!config->responseContentTypeAllowed(headers.getContentTypeValue())) {
+    handleAllOnError(config->responseRules(), false, *encoder_callbacks_,
                      response_processing_finished_);
-    config_->respstats().mismatched_content_type_.inc();
+    config->respstats().mismatched_content_type_.inc();
     return Http::FilterHeadersStatus::Continue;
   }
 
   if (end_stream) {
-    handleAllOnMissing(config_->responseRules(), false, *encoder_callbacks_,
+    handleAllOnMissing(config->responseRules(), false, *encoder_callbacks_,
                        response_processing_finished_);
-    config_->respstats().no_body_.inc();
+    config->respstats().no_body_.inc();
     return Http::FilterHeadersStatus::Continue;
   }
   return Http::FilterHeadersStatus::StopIteration;
 }
 
 Http::FilterDataStatus Filter::decodeData(Buffer::Instance& data, bool end_stream) {
-  if (!config_->doRequest()) {
+  const auto* config = getConfig();
+  if (!config->doRequest()) {
     return Http::FilterDataStatus::Continue;
   }
   if (request_processing_finished_) {
@@ -455,9 +477,9 @@ Http::FilterDataStatus Filter::decodeData(Buffer::Instance& data, bool end_strea
 
     if (!decoder_callbacks_->decodingBuffer() ||
         decoder_callbacks_->decodingBuffer()->length() == 0) {
-      handleAllOnMissing(config_->requestRules(), true, *decoder_callbacks_,
+      handleAllOnMissing(config->requestRules(), true, *decoder_callbacks_,
                          request_processing_finished_);
-      config_->rqstats().no_body_.inc();
+      config->rqstats().no_body_.inc();
       return Http::FilterDataStatus::Continue;
     }
     processRequestBody();
@@ -468,7 +490,8 @@ Http::FilterDataStatus Filter::decodeData(Buffer::Instance& data, bool end_strea
 }
 
 Http::FilterDataStatus Filter::encodeData(Buffer::Instance& data, bool end_stream) {
-  if (!config_->doResponse()) {
+  const auto* config = getConfig();
+  if (!config->doResponse()) {
     return Http::FilterDataStatus::Continue;
   }
   if (response_processing_finished_) {
@@ -480,9 +503,9 @@ Http::FilterDataStatus Filter::encodeData(Buffer::Instance& data, bool end_strea
 
     if (!encoder_callbacks_->encodingBuffer() ||
         encoder_callbacks_->encodingBuffer()->length() == 0) {
-      handleAllOnMissing(config_->responseRules(), false, *encoder_callbacks_,
+      handleAllOnMissing(config->responseRules(), false, *encoder_callbacks_,
                          response_processing_finished_);
-      config_->respstats().no_body_.inc();
+      config->respstats().no_body_.inc();
       return Http::FilterDataStatus::Continue;
     }
     processResponseBody();
@@ -493,7 +516,8 @@ Http::FilterDataStatus Filter::encodeData(Buffer::Instance& data, bool end_strea
 }
 
 Http::FilterTrailersStatus Filter::decodeTrailers(Http::RequestTrailerMap&) {
-  if (!config_->doRequest()) {
+  const auto* config = getConfig();
+  if (!config->doRequest()) {
     return Http::FilterTrailersStatus::Continue;
   }
   if (!request_processing_finished_) {
@@ -503,13 +527,30 @@ Http::FilterTrailersStatus Filter::decodeTrailers(Http::RequestTrailerMap&) {
 }
 
 Http::FilterTrailersStatus Filter::encodeTrailers(Http::ResponseTrailerMap&) {
-  if (!config_->doResponse()) {
+  const auto* config = getConfig();
+  if (!config->doResponse()) {
     return Http::FilterTrailersStatus::Continue;
   }
   if (!response_processing_finished_) {
     processResponseBody();
   }
   return Http::FilterTrailersStatus::Continue;
+}
+
+const FilterConfig* Filter::getConfig() const {
+  // Cached config pointer.
+  if (effective_config_) {
+    return effective_config_;
+  }
+
+  effective_config_ =
+      Http::Utility::resolveMostSpecificPerFilterConfig<FilterConfig>(decoder_callbacks_);
+  if (effective_config_) {
+    return effective_config_;
+  }
+
+  effective_config_ = config_.get();
+  return effective_config_;
 }
 
 } // namespace JsonToMetadata

--- a/test/extensions/filters/http/json_to_metadata/filter_test.cc
+++ b/test/extensions/filters/http/json_to_metadata/filter_test.cc
@@ -88,10 +88,16 @@ response_rules:
   void initializeFilter(const std::string& yaml) {
     envoy::extensions::filters::http::json_to_metadata::v3::JsonToMetadata config;
     TestUtility::loadFromYaml(yaml, config);
-    config_ = std::make_shared<FilterConfig>(config, *scope_.rootScope(), regex_engine_);
+    config_ = *FilterConfig::create(config, *scope_.rootScope(), regex_engine_, false);
     filter_ = std::make_shared<Filter>(config_);
     filter_->setDecoderFilterCallbacks(decoder_callbacks_);
     filter_->setEncoderFilterCallbacks(encoder_callbacks_);
+  }
+
+  std::shared_ptr<FilterConfig> createConfig(const std::string& yaml, bool per_route = false) {
+    envoy::extensions::filters::http::json_to_metadata::v3::JsonToMetadata config;
+    TestUtility::loadFromYaml(yaml, config);
+    return *FilterConfig::create(config, *scope_.rootScope(), regex_engine_, per_route);
   }
 
   void sendData(const std::vector<std::string>& data_vector) {
@@ -1812,6 +1818,197 @@ response_rules:
   EXPECT_EQ(getCounterValue("json_to_metadata.resp.mismatched_content_type"), 1);
   EXPECT_EQ(getCounterValue("json_to_metadata.resp.no_body"), 0);
   EXPECT_EQ(getCounterValue("json_to_metadata.resp.invalid_json_body"), 0);
+}
+
+// Test per-route override functionality
+TEST_F(FilterTest, PerRouteOverride) {
+  // Global config is empty (no rules)
+  const std::string empty_config = R"EOF(
+request_rules:
+  rules: []
+response_rules:
+  rules: []
+)EOF";
+
+  initializeFilter(empty_config);
+
+  const std::string request_body = R"delimiter({"version":"2.0.0"})delimiter";
+  const std::map<std::string, std::string> expected = {{"version", "2.0.0"}};
+
+  // Setup per route config
+  const std::string per_route_config_yaml = R"EOF(
+request_rules:
+  rules:
+  - selectors:
+    - key: version
+    on_present:
+      metadata_namespace: envoy.lb
+      key: version
+)EOF";
+
+  std::shared_ptr<FilterConfig> per_route_config = createConfig(per_route_config_yaml, true);
+  EXPECT_CALL(*decoder_callbacks_.route_, mostSpecificPerFilterConfig(_))
+      .WillOnce(Return(per_route_config.get()));
+
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
+            filter_->decodeHeaders(incoming_headers_, false));
+
+  EXPECT_CALL(decoder_callbacks_, streamInfo()).WillRepeatedly(ReturnRef(stream_info_));
+  EXPECT_CALL(decoder_callbacks_.downstream_callbacks_, clearRouteCache());
+  EXPECT_CALL(stream_info_, setDynamicMetadata("envoy.lb", MapEq(expected)));
+  testRequestWithBody(request_body);
+
+  EXPECT_EQ(getCounterValue("json_to_metadata.rq.success"), 1);
+}
+
+// Test that per-route config is cached
+TEST_F(FilterTest, PerRouteConfigIsCached) {
+  // Global config is empty
+  const std::string empty_config = R"EOF(
+request_rules:
+  rules: []
+response_rules:
+  rules: []
+)EOF";
+
+  initializeFilter(empty_config);
+
+  // Setup per route config
+  const std::string per_route_config_yaml = R"EOF(
+request_rules:
+  rules:
+  - selectors:
+    - key: version
+    on_present:
+      metadata_namespace: envoy.lb
+      key: version
+)EOF";
+
+  std::shared_ptr<FilterConfig> per_route_config = createConfig(per_route_config_yaml, true);
+
+  // mostSpecificPerFilterConfig should only be called once due to caching
+  EXPECT_CALL(*decoder_callbacks_.route_, mostSpecificPerFilterConfig(_))
+      .WillOnce(Return(per_route_config.get()));
+
+  // First call - fetches and caches the config
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
+            filter_->decodeHeaders(incoming_headers_, false));
+
+  // Subsequent operations should use cached config without additional lookups
+  const std::string request_body = R"delimiter({"version":"2.0.0"})delimiter";
+  const std::map<std::string, std::string> expected = {{"version", "2.0.0"}};
+
+  EXPECT_CALL(decoder_callbacks_, streamInfo()).WillRepeatedly(ReturnRef(stream_info_));
+  EXPECT_CALL(decoder_callbacks_.downstream_callbacks_, clearRouteCache());
+  EXPECT_CALL(stream_info_, setDynamicMetadata("envoy.lb", MapEq(expected)));
+  testRequestWithBody(request_body);
+}
+
+// Test per-route config with response rules
+TEST_F(FilterTest, PerRouteOverrideResponse) {
+  // Global config is empty
+  const std::string empty_config = R"EOF(
+request_rules:
+  rules: []
+response_rules:
+  rules: []
+)EOF";
+
+  initializeFilter(empty_config);
+
+  const std::string response_body = R"delimiter({"version":"3.0.0"})delimiter";
+  const std::map<std::string, std::string> expected = {{"version", "3.0.0"}};
+
+  // Setup per route config with response rules
+  const std::string per_route_config_yaml = R"EOF(
+response_rules:
+  rules:
+  - selectors:
+    - key: version
+    on_present:
+      metadata_namespace: envoy.lb
+      key: version
+)EOF";
+
+  std::shared_ptr<FilterConfig> per_route_config = createConfig(per_route_config_yaml, true);
+  EXPECT_CALL(*decoder_callbacks_.route_, mostSpecificPerFilterConfig(_))
+      .WillOnce(Return(per_route_config.get()));
+
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
+            filter_->encodeHeaders(response_headers_, false));
+
+  EXPECT_CALL(encoder_callbacks_, streamInfo()).WillRepeatedly(ReturnRef(stream_info_));
+  EXPECT_CALL(stream_info_, setDynamicMetadata("envoy.lb", MapEq(expected)));
+  testResponseWithBody(response_body);
+
+  EXPECT_EQ(getCounterValue("json_to_metadata.resp.success"), 1);
+}
+
+// Test that per-route config overrides global config
+TEST_F(FilterTest, PerRouteOverridesGlobalConfig) {
+  // Global config extracts "old_key"
+  const std::string global_config = R"EOF(
+request_rules:
+  rules:
+  - selectors:
+    - key: old_key
+    on_present:
+      metadata_namespace: envoy.lb
+      key: old_value
+)EOF";
+
+  initializeFilter(global_config);
+
+  // Per-route config extracts "new_key"
+  const std::string per_route_config_yaml = R"EOF(
+request_rules:
+  rules:
+  - selectors:
+    - key: new_key
+    on_present:
+      metadata_namespace: envoy.lb
+      key: new_value
+)EOF";
+
+  const std::string request_body =
+      R"delimiter({"old_key":"should_not_match","new_key":"should_match"})delimiter";
+  const std::map<std::string, std::string> expected = {{"new_value", "should_match"}};
+
+  std::shared_ptr<FilterConfig> per_route_config = createConfig(per_route_config_yaml, true);
+  EXPECT_CALL(*decoder_callbacks_.route_, mostSpecificPerFilterConfig(_))
+      .WillOnce(Return(per_route_config.get()));
+
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
+            filter_->decodeHeaders(incoming_headers_, false));
+
+  EXPECT_CALL(decoder_callbacks_, streamInfo()).WillRepeatedly(ReturnRef(stream_info_));
+  EXPECT_CALL(decoder_callbacks_.downstream_callbacks_, clearRouteCache());
+  EXPECT_CALL(stream_info_, setDynamicMetadata("envoy.lb", MapEq(expected)));
+  testRequestWithBody(request_body);
+
+  EXPECT_EQ(getCounterValue("json_to_metadata.rq.success"), 1);
+}
+
+// Test global config is used when no per-route config exists
+TEST_F(FilterTest, GlobalConfigUsedWhenNoPerRouteConfig) {
+  // Global config extracts "version"
+  initializeFilter(config_yaml_);
+
+  const std::string request_body = R"delimiter({"version":"1.5.0"})delimiter";
+  const std::map<std::string, std::string> expected = {{"version", "1.5.0"}};
+
+  // No per-route config
+  EXPECT_CALL(*decoder_callbacks_.route_, mostSpecificPerFilterConfig(_)).WillOnce(Return(nullptr));
+
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
+            filter_->decodeHeaders(incoming_headers_, false));
+
+  EXPECT_CALL(decoder_callbacks_, streamInfo()).WillRepeatedly(ReturnRef(stream_info_));
+  EXPECT_CALL(decoder_callbacks_.downstream_callbacks_, clearRouteCache());
+  EXPECT_CALL(stream_info_, setDynamicMetadata("envoy.lb", MapEq(expected)));
+  testRequestWithBody(request_body);
+
+  EXPECT_EQ(getCounterValue("json_to_metadata.rq.success"), 1);
 }
 
 } // namespace JsonToMetadata


### PR DESCRIPTION
Commit Message: json_to_metadata filter is an HTTP filter which can extract data from json body and put it into Envoy dynamic metadata. This PR supports route override for this filter.
Testing: unit test
