### PR TITLE
docs: refactor tcp proxy docs and add more details

### DIFF
--- a/api/envoy/extensions/filters/network/tcp_proxy/v3/tcp_proxy.proto
+++ b/api/envoy/extensions/filters/network/tcp_proxy/v3/tcp_proxy.proto
@@ -34,9 +34,8 @@ message TcpProxy {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.network.tcp_proxy.v2.TcpProxy";
 
-  // Allows for specification of multiple upstream clusters along with weights
-  // that indicate the percentage of traffic to be forwarded to each cluster.
-  // The router selects an upstream cluster based on these weights.
+  // Allows specification of multiple upstream clusters along with weights indicating the percentage of
+  // traffic forwarded to each cluster. The cluster selection is based on these weights.
   message WeightedCluster {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.config.filter.network.tcp_proxy.v2.TcpProxy.WeightedCluster";
@@ -62,12 +61,12 @@ message TcpProxy {
       config.core.v3.Metadata metadata_match = 3;
     }
 
-    // Specifies one or more upstream clusters associated with the route.
+    // Specifies the upstream clusters associated with this configuration.
     repeated ClusterWeight clusters = 1 [(validate.rules).repeated = {min_items: 1}];
   }
 
   // Configuration for tunneling TCP over other transports or application layers.
-  // Tunneling is supported over both HTTP/1.1 and HTTP/2. Upstream protocol is
+  // Tunneling is supported over HTTP/1.1 and HTTP/2. The upstream protocol is
   // determined by the cluster configuration.
   // [#next-free-field: 8]
   message TunnelingConfig {
@@ -75,16 +74,16 @@ message TcpProxy {
         "envoy.config.filter.network.tcp_proxy.v2.TcpProxy.TunnelingConfig";
 
     // The hostname to send in the synthesized CONNECT headers to the upstream proxy.
-    // This field evaluates command operators if set, otherwise returns hostname as is.
+    // This field evaluates command operators if present; otherwise, the value is used as-is.
     //
-    // Example: dynamically set hostname using downstream SNI
+    // For example:
     //
     // .. code-block:: yaml
     //
     //    tunneling_config:
     //      hostname: "%REQUESTED_SERVER_NAME%:443"
     //
-    // Example: dynamically set hostname using dynamic metadata
+    // For example, dynamically set the hostname using dynamic metadata:
     //
     // .. code-block:: yaml
     //
@@ -93,30 +92,30 @@ message TcpProxy {
     //
     string hostname = 1 [(validate.rules).string = {min_len: 1}];
 
-    // Use POST method instead of CONNECT method to tunnel the TCP stream.
-    // The 'protocol: bytestream' header is also NOT set for HTTP/2 to comply with the spec.
+    // Use the POST method instead of the CONNECT method to tunnel the TCP stream.
+    // The ``protocol: bytestream`` header is not set for HTTP/2 to comply with the specification.
     //
-    // The upstream proxy is expected to convert POST payload as raw TCP.
+    // The upstream proxy is expected to interpret the POST payload as raw TCP.
     bool use_post = 2;
 
-    // Additional request headers to upstream proxy. This is mainly used to
-    // trigger upstream to convert POST requests back to CONNECT requests.
+    // Additional request headers to send to the upstream proxy. This is mainly used to
+    // trigger the upstream to convert POST requests back to CONNECT requests.
     //
-    // Neither ``:-prefixed`` pseudo-headers nor the Host: header can be overridden.
+    // Neither ``:``-prefixed pseudo-headers like ``:path`` nor the ``host`` header can be overridden.
     repeated config.core.v3.HeaderValueOption headers_to_add = 3
         [(validate.rules).repeated = {max_items: 1000}];
 
-    // Save the response headers to the downstream info filter state for consumption
-    // by the network filters. The filter state key is ``envoy.tcp_proxy.propagate_response_headers``.
+    // Save response headers to the downstream connection's filter state for consumption
+    // by network filters. The filter state key is ``envoy.tcp_proxy.propagate_response_headers``.
     bool propagate_response_headers = 4;
 
-    // The path used with POST method. Default path is ``/``. If post path is specified and
+    // The path used with the POST method. The default path is ``/``. If this field is specified and
     // :ref:`use_post field <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.TunnelingConfig.use_post>`
-    // isn't true, it will be rejected.
+    // is not set to true, the configuration will be rejected.
     string post_path = 5;
 
-    // Save the response trailers to the downstream info filter state for consumption
-    // by the network filters. The filter state key is ``envoy.tcp_proxy.propagate_response_trailers``.
+    // Save response trailers to the downstream connection's filter state for consumption
+    // by network filters. The filter state key is ``envoy.tcp_proxy.propagate_response_trailers``.
     bool propagate_response_trailers = 6;
 
     // The configuration of the request ID extension used for generation, validation, and
@@ -134,34 +133,32 @@ message TcpProxy {
   }
 
   message OnDemand {
-    // An optional configuration for on-demand cluster discovery
-    // service. If not specified, the on-demand cluster discovery will
-    // be disabled. When it's specified, the filter will pause a request
-    // to an unknown cluster and will begin a cluster discovery
-    // process. When the discovery is finished (successfully or not),
-    // the request will be resumed.
+    // Optional configuration for the on-demand cluster discovery service.
+    // If not specified, on-demand cluster discovery is disabled. When specified, the filter pauses a request
+    // to an unknown cluster and begins a cluster discovery process. When discovery completes (successfully
+    // or not), the request is resumed.
     config.core.v3.ConfigSource odcds_config = 1;
 
     // xdstp:// resource locator for on-demand cluster collection.
     // [#not-implemented-hide:]
     string resources_locator = 2;
 
-    // The timeout for on demand cluster lookup. If the CDS cannot return the required cluster,
+    // The timeout for on-demand cluster lookup. If the CDS cannot return the required cluster,
     // the downstream request will be closed with the error code detail NO_CLUSTER_FOUND.
     // [#not-implemented-hide:]
     google.protobuf.Duration timeout = 3;
   }
 
   message TcpAccessLogOptions {
-    // The interval to flush access log. The TCP proxy will flush only one access log when the connection
-    // is closed by default. If this field is set, the TCP proxy will flush access log periodically with
-    // the specified interval.
+    // The interval for flushing access logs. By default, the TCP proxy flushes a single access log when the
+    // connection is closed. If this field is set, the TCP proxy flushes access logs periodically at the
+    // specified interval.
     // The interval must be at least 1ms.
     google.protobuf.Duration access_log_flush_interval = 1
         [(validate.rules).duration = {gte {nanos: 1000000}}];
 
-    // If set to true, access log will be flushed when the TCP proxy has successfully established a
-    // connection with the upstream. If the connection failed, the access log will not be flushed.
+    // If set to true, the access log is flushed when the TCP proxy successfully establishes a
+    // connection with the upstream. If the connection fails, the access log is not flushed.
     bool flush_access_log_on_connected = 2;
   }
 
@@ -179,9 +176,8 @@ message TcpProxy {
     // The upstream cluster to connect to.
     string cluster = 2;
 
-    // Multiple upstream clusters can be specified for a given route. The
-    // request is routed to one of the upstream clusters based on weights
-    // assigned to each cluster.
+    // Multiple upstream clusters can be specified. The request is routed to one of the upstream clusters
+    // based on the weights assigned to each cluster.
     WeightedCluster weighted_clusters = 10;
   }
 
@@ -197,16 +193,14 @@ message TcpProxy {
   // for load balancing. The filter name should be specified as ``envoy.lb``.
   config.core.v3.Metadata metadata_match = 9;
 
-  // The idle timeout for connections managed by the TCP proxy filter. The idle timeout
-  // is defined as the period in which there are no bytes sent or received on either
-  // the upstream or downstream connection. If not set, the default idle timeout is 1 hour. If set
-  // to 0s, the timeout will be disabled.
-  // It is possible to dynamically override this configuration by setting a per-connection filter
-  // state object for the key ``envoy.tcp_proxy.per_connection_idle_timeout_ms``.
+  // The idle timeout for connections managed by the TCP proxy filter. The idle timeout is defined as the
+  // period in which there are no bytes sent or received on either the upstream or downstream connection.
+  // If not set, the default idle timeout is 1 hour. If set to 0s, the timeout is disabled.
+  // It is possible to dynamically override this configuration by setting a per-connection filter state
+  // object for the key ``envoy.tcp_proxy.per_connection_idle_timeout_ms``.
   //
   // .. warning::
-  //   Disabling this timeout has a highly likelihood of yielding connection leaks due to lost TCP
-  //   FIN packets, etc.
+  //   Disabling this timeout is likely to yield connection leaks due to lost TCP FIN packets, etc.
   google.protobuf.Duration idle_timeout = 8;
 
   // [#not-implemented-hide:] The idle timeout for connections managed by the TCP proxy
@@ -220,8 +214,7 @@ message TcpProxy {
   // [#not-implemented-hide:]
   google.protobuf.Duration upstream_idle_timeout = 4;
 
-  // Configuration for :ref:`access logs <arch_overview_access_logs>`
-  // emitted by the this tcp_proxy.
+  // Configuration for :ref:`access logs <arch_overview_access_logs>` emitted by this TCP proxy.
   repeated config.accesslog.v3.AccessLog access_log = 5;
 
   // The maximum number of unsuccessful connection attempts that will be made before
@@ -236,25 +229,25 @@ message TcpProxy {
   // limited to 1.
   repeated type.v3.HashPolicy hash_policy = 11 [(validate.rules).repeated = {max_items: 1}];
 
-  // If set, this configures tunneling, e.g. configuration options to tunnel TCP payload over
-  // HTTP CONNECT. If this message is absent, the payload will be proxied upstream as per usual.
-  // It is possible to dynamically override this configuration and disable tunneling per connection,
-  // by setting a per-connection filter state object for the key ``envoy.tcp_proxy.disable_tunneling``.
+  // If set, this configures tunneling, for example configuration options to tunnel TCP payload over
+  // HTTP CONNECT. If this message is absent, the payload is proxied upstream as usual.
+  // It is possible to dynamically override this configuration and disable tunneling per connection by
+  // setting a per-connection filter state object for the key ``envoy.tcp_proxy.disable_tunneling``.
   TunnelingConfig tunneling_config = 12;
 
-  // The maximum duration of a connection. The duration is defined as the period since a connection
-  // was established. If not set, there is no max duration. When max_downstream_connection_duration
-  // is reached the connection will be closed. Duration must be at least 1ms.
+  // The maximum duration of a connection. The duration is defined as the period since a connection was
+  // established. If not set, there is no maximum duration. When ``max_downstream_connection_duration`` is
+  // reached, the connection is closed. The duration must be at least 1ms.
   google.protobuf.Duration max_downstream_connection_duration = 13
       [(validate.rules).duration = {gte {nanos: 1000000}}];
 
-  // Percentage-based jitter for max_downstream_connection_duration. The jitter will increase
-  // the max_downstream_connection_duration by some random duration up to the provided percentage.
-  // This field is ignored if max_downstream_connection_duration is not set.
-  // If not set, no jitter will be added.
+  // Percentage-based jitter for ``max_downstream_connection_duration``. The jitter increases the
+  // ``max_downstream_connection_duration`` by a random duration up to the provided percentage.
+  // This field is ignored if ``max_downstream_connection_duration`` is not set. If not set, no jitter
+  // is added.
   type.v3.Percent max_downstream_connection_duration_jitter_percentage = 20;
 
-  // Note that if both this field and :ref:`access_log_flush_interval
+  // If both this field and :ref:`access_log_flush_interval
   // <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.TcpAccessLogOptions.access_log_flush_interval>`
   // are specified, the former (deprecated field) is ignored.
   //
@@ -268,7 +261,7 @@ message TcpProxy {
     (envoy.annotations.deprecated_at_minor_version) = "3.0"
   ];
 
-  // Note that if both this field and :ref:`flush_access_log_on_connected
+  // If both this field and :ref:`flush_access_log_on_connected
   // <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.TcpAccessLogOptions.flush_access_log_on_connected>`
   // are specified, the former (deprecated field) is ignored.
   //
@@ -279,21 +272,20 @@ message TcpProxy {
   bool flush_access_log_on_connected = 16
       [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
 
-  // Additional access log options for TCP Proxy.
+  // Additional access log options for the TCP proxy.
   TcpAccessLogOptions access_log_options = 17;
 
-  // If set, the specified PROXY protocol TLVs (Type-Length-Value) will be added to the PROXY protocol
-  // state created by the TCP proxy filter. These TLVs will be sent in the PROXY protocol v2 header
-  // to upstream.
+  // If set, the specified PROXY protocol TLVs (Type-Length-Value) are added to the PROXY protocol state
+  // created by the TCP proxy filter. These TLVs are sent in the PROXY protocol v2 header to the upstream.
   //
-  // This field only takes effect when the TCP proxy filter is creating new PROXY protocol
-  // state and there is an upstream proxy protocol transport socket configured in the cluster.
-  // If the connection already contains PROXY protocol state (including any TLVs) parsed by a
-  // downstream proxy protocol listener filter, the TLVs specified here are ignored.
+  // This field only takes effect when the TCP proxy filter is creating new PROXY protocol state and an
+  // upstream proxy protocol transport socket is configured in the cluster. If the connection already
+  // contains PROXY protocol state (including any TLVs) parsed by a downstream proxy protocol listener
+  // filter, the TLVs specified here are ignored.
   //
   // .. note::
-  //   To ensure specified TLVs are allowed in the upstream PROXY protocol header, you must also
-  //   configure the passthrough TLVs on the upstream proxy protocol transport. See
+  //   To ensure the specified TLVs are allowed in the upstream PROXY protocol header, you must also
+  //   configure passthrough TLVs on the upstream proxy protocol transport. See
   //   :ref:`core.v3.ProxyProtocolConfig.pass_through_tlvs <envoy_v3_api_field_config.core.v3.ProxyProtocolConfig.pass_through_tlvs>`
   //   for details.
   repeated config.core.v3.TlvEntry proxy_protocol_tlvs = 19;


### PR DESCRIPTION
## Description

This PR refactored the TCP Proxy docs to align the style with rest of the docs in the codebase. It's currently using inconsistent style around the header names, etc.

---

**Commit Message:** docs: refactor tcp proxy docs and add more details
**Additional Description:** Refactor tcp proxy docs and add more details
**Risk Level:** N/A
**Testing:** CI
**Docs Changes:** N/A
**Release Notes:** N/A