### PR TITLE
router: minor refactor of filter-state matchers

### DIFF
--- a/source/common/common/matchers.h
+++ b/source/common/common/matchers.h
@@ -400,7 +400,7 @@ public:
 
 private:
   const std::string key_;
-  const FilterStateObjectMatcherPtr object_matcher_;
+  FilterStateObjectMatcherPtr object_matcher_;
 };
 
 using FilterStateMatcherPtr = std::unique_ptr<FilterStateMatcher>;

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -427,12 +427,13 @@ RouteEntryImplBase::RouteEntryImplBase(const CommonVirtualHostSharedPtr& vhost,
         return vec;
       }()),
       filter_state_([&]() {
-        std::vector<Envoy::Matchers::FilterStateMatcherPtr> vec;
+        std::vector<Envoy::Matchers::FilterStateMatcher> vec;
+        vec.reserve(route.match().filter_state().size());
         for (const auto& elt : route.match().filter_state()) {
           Envoy::Matchers::FilterStateMatcherPtr match = THROW_OR_RETURN_VALUE(
               Envoy::Matchers::FilterStateMatcher::create(elt, factory_context),
               Envoy::Matchers::FilterStateMatcherPtr);
-          vec.push_back(std::move(match));
+          vec.emplace_back(std::move(*match));
         }
         return vec;
       }()),
@@ -753,7 +754,7 @@ bool RouteEntryImplBase::matchRoute(const Http::RequestHeaderMap& headers,
       // No need to check anymore as all filter state matchers must match for a match to occur.
       break;
     }
-    matches &= m->match(stream_info.filterState());
+    matches &= m.match(stream_info.filterState());
   }
 
   return matches;

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -895,7 +895,7 @@ private:
   HeaderParserPtr response_headers_parser_;
   RouteMetadataPackPtr metadata_;
   const std::vector<Envoy::Matchers::MetadataMatcher> dynamic_metadata_;
-  const std::vector<Envoy::Matchers::FilterStateMatcherPtr> filter_state_;
+  const std::vector<Envoy::Matchers::FilterStateMatcher> filter_state_;
 
   // TODO(danielhochman): refactor multimap into unordered_map since JSON is unordered map.
   const std::multimap<std::string, std::string> opaque_config_;


### PR DESCRIPTION
Commit Message: router: minor refactor of filter-state matchers
Additional Description:
Change a vector of pointers to matchers to a vector of matchers, removing unneeded indirection overhead.

Risk Level: low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
