### PR TITLE
bazel/fips: Remove incorrect version validation

### DIFF
--- a/bazel/external/boringssl_fips.BUILD
+++ b/bazel/external/boringssl_fips.BUILD
@@ -6,12 +6,6 @@ licenses(["notice"])  # Apache 2
 # BoringSSL build as described in the Security Policy for BoringCrypto module "update stream":
 # https://boringssl.googlesource.com/boringssl/+/refs/heads/main/crypto/fipsmodule/FIPS.md#update-stream
 
-FIPS_GO_VERSION = "go1.24.4"
-
-FIPS_NINJA_VERSION = "1.13.1"
-
-FIPS_CMAKE_VERSION = "cmake version 4.1.2"
-
 SUPPORTED_ARCHES = {
     "x86_64": "amd64",
     "aarch64": "arm64",
@@ -77,9 +71,6 @@ genrule(
     cmd = select(boringssl_fips_build_command(
         SUPPORTED_ARCHES,
         STDLIBS,
-        FIPS_GO_VERSION,
-        FIPS_NINJA_VERSION,
-        FIPS_CMAKE_VERSION,
     )),
     exec_properties = select({
         "@envoy//bazel:engflow_rbe_x86_64": {

--- a/bazel/external/boringssl_fips.genrule_cmd
+++ b/bazel/external/boringssl_fips.genrule_cmd
@@ -24,36 +24,6 @@ if [[ -z "$SSL_OUT" ]]; then
     exit
 fi
 
-validate_go() {
-    GO_VERSION=$(go version | awk '{print $3}')
-    if [[ "$GO_VERSION" != "$EXPECTED_GO_VERSION" ]]; then
-        echo "ERROR: Go version doesn't match." >&2
-        echo "  expected: $EXPECTED_GO_VERSION" >&2
-        echo "  found: $GO_VERSION" >&2
-        return 1
-    fi
-}
-
-validate_ninja() {
-    NINJA_VERSION=$(ninja --version)
-    if [[ "$NINJA_VERSION" != "$EXPECTED_NINJA_VERSION" ]]; then
-        echo "ERROR: Ninja version doesn't match." >&2
-        echo "  expected: $EXPECTED_NINJA_VERSION" >&2
-        echo "  found: $NINJA_VERSION" >&2
-        return 1
-    fi
-}
-
-validate_cmake() {
-    CMAKE_VERSION=$(cmake --version | head -n1)
-    if [[ "$CMAKE_VERSION" != "$EXPECTED_CMAKE_VERSION" ]]; then
-        echo "ERROR: CMake version doesn't match." >&2
-        echo "  expected: $EXPECTED_CMAKE_VERSION" >&2
-        echo "  found: $CMAKE_VERSION" >&2
-        return 1
-    fi
-}
-
 build_boringssl_fips() {
     cd "$BSSL_SRC" || exit 1
     export HOME="${BSSL_SRC}"
@@ -108,9 +78,6 @@ output_libs() {
     mv "${BSSL_SRC}/build/libssl.a" "$SSL_OUT"
 }
 
-validate_go
-validate_ninja
-validate_cmake
 build_boringssl_fips
 validate_fips
 output_libs

--- a/bazel/external/fips_build.bzl
+++ b/bazel/external/fips_build.bzl
@@ -34,11 +34,6 @@ export PATH="$${GOPATH}/bin:$${GO_BINDIR}:$${PATH}"
 BSSL_SRC=$$(realpath $$(dirname $$(dirname $(location crypto_marker))))
 export BSSL_SRC
 
-# fips expectations
-export EXPECTED_GO_VERSION="%s"
-export EXPECTED_NINJA_VERSION="%s"
-export EXPECTED_CMAKE_VERSION="%s"
-
 # We might need to make this configurable if it causes issues outside of CI
 export NINJA_CORES=$$(nproc)
 
@@ -91,28 +86,22 @@ def _create_boringssl_fips_build_config(lib, arch, arch_alias):
         match_all = conditions,
     )
 
-def _create_boringssl_fips_build_command(lib, arch, arch_alias, go_version, ninja_version, cmake_version):
+def _create_boringssl_fips_build_command(lib, arch, arch_alias):
     """Create the command."""
     _create_boringssl_fips_build_config(lib, arch, arch_alias)
     return BUILD_COMMAND % (
         lib,
         "@fips_cmake_linux_%s" % arch,
         "@fips_go_linux_%s" % arch_alias,
-        go_version,
-        ninja_version,
-        cmake_version,
     )
 
-def boringssl_fips_build_command(arches, libs, go_version, ninja_version, cmake_version):
+def boringssl_fips_build_command(arches, libs):
     """Create conditional commands from the cartesian product of possible arches/stdlib."""
     return {
         ":%s_%s" % (arch, lib): _create_boringssl_fips_build_command(
             lib,
             arch,
             arch_alias,
-            go_version,
-            ninja_version,
-            cmake_version,
         )
         for arch, arch_alias in arches.items()
         for lib in libs


### PR DESCRIPTION
as the policy for these deps is "latest stable" - these validations are incorrect - removing them makes it easier to keep the deps up-to-date with latest stable