### PR TITLE
Use the `docker.io/` prefix for docker images where applicable

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -380,7 +380,7 @@ build:compile-time-options --@envoy//source/extensions/filters/http/kill_request
 
 # Docker sandbox
 # NOTE: Update this from https://github.com/envoyproxy/envoy-build-tools/blob/main/toolchains/rbe_toolchains_config.bzl#L8
-build:docker-sandbox --experimental_docker_image=envoyproxy/envoy-build-ubuntu:f4a881a1205e8e6db1a57162faf3df7aed88eae8@sha256:b10346fe2eee41733dbab0e02322c47a538bf3938d093a5daebad9699860b814
+build:docker-sandbox --experimental_docker_image=docker.io/envoyproxy/envoy-build-ubuntu:f4a881a1205e8e6db1a57162faf3df7aed88eae8@sha256:b10346fe2eee41733dbab0e02322c47a538bf3938d093a5daebad9699860b814
 build:docker-sandbox --spawn_strategy=docker
 build:docker-sandbox --strategy=Javac=docker
 build:docker-sandbox --strategy=Closure=docker

--- a/.github/config.yml
+++ b/.github/config.yml
@@ -1,7 +1,7 @@
 agent-ubuntu: ubuntu-24.04
 build-image:
   # Authoritative configuration for build image/s
-  repo: envoyproxy/envoy-build-ubuntu
+  repo: docker.io/envoyproxy/envoy-build-ubuntu
   sha: b10346fe2eee41733dbab0e02322c47a538bf3938d093a5daebad9699860b814
   mobile-sha: 1a4da70e73be0de3ae2f3342aaf9a58b7b426ae9e6007f51fec36f57be7315db
   # this is authoritative, but is not currently used in github ci

--- a/.github/workflows/envoy-dependency.yml
+++ b/.github/workflows/envoy-dependency.yml
@@ -183,8 +183,8 @@ jobs:
       uses: envoyproxy/toolshed/gh-actions/docker/shas@actions-v0.3.25
       with:
         images: |
-           sha: envoyproxy/envoy-build-ubuntu:${{ steps.build-tools.outputs.tag }}
-           mobile-sha: envoyproxy/envoy-build-ubuntu:mobile-${{ steps.build-tools.outputs.tag }}
+           sha: docker.io/envoyproxy/envoy-build-ubuntu:${{ steps.build-tools.outputs.tag }}
+           mobile-sha: docker.io/envoyproxy/envoy-build-ubuntu:mobile-${{ steps.build-tools.outputs.tag }}
            gcr-sha: gcr.io/envoy-ci/envoy-build:${{ steps.build-tools.outputs.tag }}
 
     - run: |

--- a/ci/README.md
+++ b/ci/README.md
@@ -69,25 +69,19 @@ to build an Envoy static binary and run tests.
 
 The build image defaults to `envoyproxy/envoy-build-ubuntu` on Linux and
 `envoyproxy/envoy-build-windows2019` on Windows, but you can choose build image by setting
-`IMAGE_NAME` in the environment.
+`ENVOY_BUILD_IMAGE` in the environment.
 
 In case your setup is behind a proxy, set `http_proxy` and `https_proxy` to the proxy servers before
 invoking the build.
 
 ```bash
-IMAGE_NAME=envoyproxy/envoy-build-ubuntu http_proxy=http://proxy.foo.com:8080 https_proxy=http://proxy.bar.com:8080 ./ci/run_envoy_docker.sh <build_script_args>
+ENVOY_BUILD_IMAGE=docker.io/envoyproxy/envoy-build-ubuntu:<tag> http_proxy=http://proxy.foo.com:8080 https_proxy=http://proxy.bar.com:8080 ./ci/run_envoy_docker.sh <build_script_args>
 ```
 
 Besides `http_proxy` and `https_proxy`, maybe you need to set `go_proxy` to replace the default GOPROXY in China.
 
 ```bash
-IMAGE_NAME=envoyproxy/envoy-build-ubuntu go_proxy=https://goproxy.cn,direct http_proxy=http://proxy.foo.com:8080 https_proxy=http://proxy.bar.com:8080 ./ci/run_envoy_docker.sh <build_script_args>
-```
-
-To force the Envoy build image to be refreshed by Docker you can set `ENVOY_DOCKER_PULL=true`.
-
-```bash
-ENVOY_DOCKER_PULL=true ./ci/run_envoy_docker.sh <build_script_args>
+ENVOY_BUILD_IMAGE=docker.io/envoyproxy/envoy-build-ubuntu:<tag> go_proxy=https://goproxy.cn,direct http_proxy=http://proxy.foo.com:8080 https_proxy=http://proxy.bar.com:8080 ./ci/run_envoy_docker.sh <build_script_args>
 ```
 
 ## Resource Requirements and Troubleshooting

--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -1,6 +1,6 @@
 x-envoy-build-base: &envoy-build-base
   image: >-
-    ${ENVOY_BUILD_IMAGE:-envoyproxy/envoy-build-ubuntu:f4a881a1205e8e6db1a57162faf3df7aed88eae8@sha256:b10346fe2eee41733dbab0e02322c47a538bf3938d093a5daebad9699860b814}
+    ${ENVOY_BUILD_IMAGE:-docker.io/envoyproxy/envoy-build-ubuntu:f4a881a1205e8e6db1a57162faf3df7aed88eae8@sha256:b10346fe2eee41733dbab0e02322c47a538bf3938d093a5daebad9699860b814}
   user: root:root
   working_dir: ${ENVOY_DOCKER_SOURCE_DIR:-/source}
   stdin_open: true

--- a/mobile/third_party/rbe_configs/config/BUILD
+++ b/mobile/third_party/rbe_configs/config/BUILD
@@ -42,7 +42,7 @@ platform(
         "@bazel_tools//tools/cpp:clang",
     ],
     exec_properties = {
-        "container-image": "docker://envoyproxy/envoy-build-ubuntu:mobile-f4a881a1205e8e6db1a57162faf3df7aed88eae8@sha256:1a4da70e73be0de3ae2f3342aaf9a58b7b426ae9e6007f51fec36f57be7315db",
+        "container-image": "docker://docker.io/envoyproxy/envoy-build-ubuntu:mobile-f4a881a1205e8e6db1a57162faf3df7aed88eae8@sha256:1a4da70e73be0de3ae2f3342aaf9a58b7b426ae9e6007f51fec36f57be7315db",
         "OSFamily": "Linux",
         "Pool": "linux",
     },
@@ -57,7 +57,7 @@ platform(
         "@bazel_tools//tools/cpp:clang",
     ],
     exec_properties = {
-        "container-image": "docker://envoyproxy/envoy-build-ubuntu:mobile-f4a881a1205e8e6db1a57162faf3df7aed88eae8@sha256:1a4da70e73be0de3ae2f3342aaf9a58b7b426ae9e6007f51fec36f57be7315db",
+        "container-image": "docker://docker.io/envoyproxy/envoy-build-ubuntu:mobile-f4a881a1205e8e6db1a57162faf3df7aed88eae8@sha256:1a4da70e73be0de3ae2f3342aaf9a58b7b426ae9e6007f51fec36f57be7315db",
         "OSFamily": "Linux",
         "Pool": "linux",
         # Necessary to workaround https://github.com/google/sanitizers/issues/916, otherwise, dangling threads in the


### PR DESCRIPTION
Using the fully qualified name avoids ambiguity and works better with other container tools such as podman.
