### PR TITLE
Cleanup the envoy-sync GitHub workflow

### DIFF
--- a/.github/workflows/envoy-sync.yml
+++ b/.github/workflows/envoy-sync.yml
@@ -7,8 +7,6 @@ on:
   push:
     branches:
     - main
-    - release/v1.28
-    - release/v1.31
   workflow_dispatch:
 
 concurrency:
@@ -45,32 +43,3 @@ jobs:
         ref: main
         token: ${{ steps.appauth.outputs.token }}
         workflow: envoy-sync.yaml
-
-  sync-release:
-    runs-on: ubuntu-24.04
-    if: >-
-      ${{
-          github.repository == 'envoyproxy/envoy'
-          && contains(fromJSON('["main", "release/v1.28", "release/v1.31"]'), github.ref_name)
-          && (github.event.push
-              || !contains(github.actor, '[bot]'))
-      }}
-    strategy:
-      fail-fast: false
-      matrix:
-        downstream:
-        - envoy-openssl
-    steps:
-    - uses: envoyproxy/toolshed/gh-actions/appauth@actions-v0.3.25
-      id: appauth
-      with:
-        app_id: ${{ secrets.ENVOY_CI_SYNC_APP_ID }}
-        key: ${{ secrets.ENVOY_CI_SYNC_APP_KEY }}
-    - uses: envoyproxy/toolshed/gh-actions/dispatch@actions-v0.3.25
-      with:
-        repository: "envoyproxy/${{ matrix.downstream }}"
-        ref: release/v1.28
-        token: ${{ steps.appauth.outputs.token }}
-        workflow: envoy-sync-receive.yaml
-        inputs: |
-          branch: ${{ github.ref_name }}


### PR DESCRIPTION
By removing unused branches and downstream repos.
