### PR TITLE
quic: Change the scale factor of TCP Delay when using the SRTT

### DIFF
--- a/source/common/http/conn_pool_grid.cc
+++ b/source/common/http/conn_pool_grid.cc
@@ -332,7 +332,7 @@ ConnectivityGrid::ConnectivityGrid(
   std::chrono::milliseconds rtt =
       std::chrono::duration_cast<std::chrono::milliseconds>(alternate_protocols_->getSrtt(origin_));
   if (rtt.count() != 0) {
-    next_attempt_duration_ = std::chrono::milliseconds(rtt.count() * 2);
+    next_attempt_duration_ = std::chrono::milliseconds(rtt.count() * 1.5);
   }
 }
 


### PR DESCRIPTION
Currently, the SRTT is multiplied by 2 when setting the duration for attempting TCP after initializing a QUIC connection. However, Chromium/Cronet use a scale factor of 1.5:
https://source.chromium.org/chromium/chromium/src/+/main:net/quic/quic_session_pool.cc;l=1487;drc=25581cebdad93ddff406d27d49b577266bb4865d.

This change aligns Envoy with Chromium client-side QUIC settings by making the scale factor 1.5 also.