### PR TITLE
fix: make CVE scanner not fail on zero CVEs

### DIFF
--- a/tools/dependency/cve_test.sh
+++ b/tools/dependency/cve_test.sh
@@ -6,7 +6,9 @@ ANSI_LIBDIR="$(dirname "$JQ_ANSI_UTILS")"
 CVE_LIBDIR="$(dirname "$JQ_CVE_UTILS")"
 VERSION_LIBDIR="$(dirname "$JQ_VERSION_UTILS")"
 
-if [[ -s "$1" ]]; then
+# Check if the JSON array contains any CVEs and not just if file is non-empty.
+CVE_COUNT=$("$JQ_BIN" 'length' "$1")
+if [[ "$CVE_COUNT" -gt 0 ]]; then
     "$JQ_BIN" -r -f \
          -L "$ANSI_LIBDIR" \
          -L "$CVE_LIBDIR" \


### PR DESCRIPTION
## Description

This PR makes CVE scanner not fail when there are no CVEs detected.

---

**Commit Message:** fix: make CVE scanner not fail on zero CVEs
**Additional Description:** Make CVE scanner not fail when there are no CVEs detected.
**Risk Level:** N/A
**Testing:** CI
**Docs Changes:** N/A
**Release Notes:** N/A