### PR TITLE
docs: fix stateful sessions doc to correctly call out stats generation

### DIFF
--- a/docs/root/configuration/http/http_filters/stateful_session_filter.rst
+++ b/docs/root/configuration/http/http_filters/stateful_session_filter.rst
@@ -3,13 +3,13 @@
 Stateful session
 ================
 
-Stateful session is an HTTP filter which overrides the upstream host based on extensible session state
-and updates the session state based on the final selected upstream host. The override host will
-eventually overwrites the load balancing result. This filter implements session stickiness without using
-a hash-based load balancer.
+The stateful session filter overrides the upstream host based on extensible session state
+and updates the session state based on the final selected upstream host. The override takes
+precedence over the result of load balancing. This filter implements session stickiness without
+relying on a hash-based load balancer.
 
-And by extending the session state, this filter also allows more flexible control over the results of
-the load balancing.
+By extending the session state, this filter also allows more flexible control over load balancing
+results.
 
 .. note::
 
@@ -24,12 +24,12 @@ Session stickiness allows requests belonging to the same session to be consisten
 upstream host.
 
 HTTP session stickiness in Envoy is generally achieved through hash-based load balancing.
-The stickiness of hash-based sessions can be regarded as 'weak' since the upstream host may change when the
+The stickiness of hash-based sessions is considered 'weak' because the upstream host may change when the
 host set changes. This filter implements 'strong' stickiness. It is intended to handle the following cases:
 
 * The case where more stable session stickiness is required. For example, when a host is marked as degraded
   but it is desirable to continue routing requests for existing sessions to that host.
-* The case where a non hash-based load balancer (Random, Round Robin, etc.) is used and session stickiness
+* The case where a non-hash-based load balancer (Random, Round Robin, etc.) is used and session stickiness
   is still required. If stateful sessions are enabled in this case, requests for new sessions will be routed
   to the corresponding upstream host based on the result of load balancing. Requests belonging to existing
   sessions will be routed to the session's upstream host.
@@ -54,13 +54,13 @@ If no existing session is found, the filter will create a session to store the s
 Please note that the session here is an abstract concept. The details of the storage are based on the
 session state implementation.
 
-One example
-___________
+Examples
+________
 
 Currently, :ref:`cookie-based session state
 <envoy_v3_api_msg_extensions.http.stateful_session.cookie.v3.CookieBasedSessionState>` and :ref:`header-based session state
 <envoy_v3_api_msg_extensions.http.stateful_session.header.v3.HeaderBasedSessionState>` are supported.
-So let's take this as an example for cookie based implementation.
+The following shows a cookie-based configuration.
 
 .. literalinclude:: _include/stateful-cookie-session.yaml
     :language: yaml
@@ -71,13 +71,13 @@ So let's take this as an example for cookie based implementation.
     :caption: :download:`stateful-cookie-session.yaml <_include/stateful-cookie-session.yaml>`
 
 In the above configuration, the cookie-based session state obtains the overridden host of the current session
-from the cookie named ``global-session-cookie`` and if the corresponding host exists in the upstream cluster, the
+from the cookie named ``global-session-cookie`` and, if the corresponding host exists in the upstream cluster, the
 request will be routed to that host.
 
 If there is no valid cookie, the load balancer will choose a new upstream host. When responding, the address
 of the selected upstream host will be stored in the cookie named ``global-session-cookie``.
 
-Similar example for header based configuration would be:
+A similar example for a header-based configuration is:
 
 .. literalinclude:: _include/stateful-header-session.yaml
     :language: yaml
@@ -88,7 +88,7 @@ Similar example for header based configuration would be:
     :caption: :download:`stateful-header-session.yaml <_include/stateful-header-session.yaml>`
 
 .. note::
-  The header based implementation assumes that a client will use the last supplied value for the session
+  The header-based implementation assumes that a client will use the last supplied value for the session
   header and will pass it with every subsequent request.
 
   ``StatefulSessionPerRoute`` should be used if path match is required.
@@ -101,10 +101,21 @@ This filter outputs statistics in the
 <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.stat_prefix>`
 comes from the owning HTTP connection manager.
 
+When :ref:`stat_prefix
+<envoy_v3_api_field_extensions.filters.http.stateful_session.v3.StatefulSession.stat_prefix>` is not
+configured on the filter, no statistics are emitted.
+
 If :ref:`stat_prefix
 <envoy_v3_api_field_extensions.filters.http.stateful_session.v3.StatefulSession.stat_prefix>` is
 configured on the filter, an additional segment is inserted after ``stateful_session`` to allow
 distinguishing statistics from multiple instances, e.g. ``http.<stat_prefix>.stateful_session.my_prefix.routed``.
+
+.. note::
+
+  Per-route configuration overrides do not support statistics and will not emit statistics even if
+  :ref:`stat_prefix
+  <envoy_v3_api_field_extensions.filters.http.stateful_session.v3.StatefulSession.stat_prefix>` is set in the
+  per-route configuration.
 
 The following statistics are supported:
 


### PR DESCRIPTION
## Description

This PR corrects the docs around stats generation for Stateful Sessions filter to mention that no stats would be generated if the `stat_perfix` is not supplied and the note on the Per-Route filter.

---

**Commit Message:** docs: fix stateful sessions doc to correctly call out stats generation
**Additional Description:** Fix section on the stats generation for Stateful Sessions filter. 
**Risk Level:** N/A
**Testing:** CI
**Docs Changes:** N/A
**Release Notes:** N/A