### PR TITLE
quic_lb: rename configuration option, reorder for clarity

### DIFF
--- a/api/envoy/extensions/quic/connection_id_generator/quic_lb/v3/quic_lb.proto
+++ b/api/envoy/extensions/quic/connection_id_generator/quic_lb/v3/quic_lb.proto
@@ -29,16 +29,10 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 //
 // .. warning::
 //
-//    This is still a work in progress. Performance is expected to be poor. Interoperability testing
-//    has not yet been performed.
+//    This is still a work in progress. Interoperability testing has not yet been performed.
 // [#next-free-field: 7]
 message Config {
   option (xds.annotations.v3.message_status).work_in_progress = true;
-
-  // Use the unencrypted mode. This is useful for testing, but allows for linking different CIDs
-  // for the same connection, and leaks information about the valid server IDs in use. This should
-  // only be used for testing.
-  bool unsafe_unencrypted_testing_mode = 1;
 
   // Must be at least 1 octet.
   // The length of server_id and nonce_length_bytes must be 18 or less.
@@ -72,4 +66,14 @@ message Config {
   // See https://datatracker.ietf.org/doc/html/draft-ietf-quic-load-balancers#name-config-rotation.
   transport_sockets.tls.v3.SdsSecretConfig encryption_parameters = 5
       [(validate.rules).message = {required: true}];
+
+  // Use the unencrypted mode. This is useful for testing or a simplified implementation of the
+  // downstream load balancer, but allows for linking different CIDs for the same connection, and
+  // leaks information about the valid server IDs in use. This mode does not comply with the RFC.
+  //
+  // Note that in this mode, :ref:`encryption_parameters
+  // <envoy_v3_api_field_extensions.quic.connection_id_generator.quic_lb.v3.Config.encryption_parameters>`
+  // is still required because it contains ``configuration_version``, which is still
+  // needed. ``encryption_key`` can be set to ``inline_string: '0000000000000000'``.
+  bool unencrypted_mode = 1;
 }

--- a/source/extensions/quic/connection_id_generator/quic_lb/quic_lb.cc
+++ b/source/extensions/quic/connection_id_generator/quic_lb/quic_lb.cc
@@ -87,7 +87,7 @@ QuicLbConnectionIdGenerator::ThreadLocalData::ThreadLocalData(
     absl::string_view server_id)
     : encoder_(*quic::QuicRandom::GetInstance(), nullptr /* visitor */,
                true /* len_self_encoded */),
-      unsafe_unencrypted_testing_mode_(config.unsafe_unencrypted_testing_mode()),
+      unencrypted_mode_(config.unencrypted_mode()),
       nonce_length_bytes_(config.nonce_length_bytes()), server_id_(server_id) {}
 
 absl::StatusOr<std::shared_ptr<QuicLbConnectionIdGenerator::ThreadLocalData>>
@@ -105,7 +105,7 @@ absl::Status
 QuicLbConnectionIdGenerator::ThreadLocalData::updateKeyAndVersion(absl::string_view key,
                                                                   uint8_t version) {
   absl::optional<quic::LoadBalancerConfig> lb_config;
-  if (unsafe_unencrypted_testing_mode_) {
+  if (unencrypted_mode_) {
     lb_config = quic::LoadBalancerConfig::CreateUnencrypted(version, server_id_.length(),
                                                             nonce_length_bytes_);
   } else {

--- a/source/extensions/quic/connection_id_generator/quic_lb/quic_lb.h
+++ b/source/extensions/quic/connection_id_generator/quic_lb/quic_lb.h
@@ -37,7 +37,7 @@ public:
         const envoy::extensions::quic::connection_id_generator::quic_lb::v3::Config& config,
         absl::string_view server_id);
 
-    const bool unsafe_unencrypted_testing_mode_;
+    const bool unencrypted_mode_;
     const uint32_t nonce_length_bytes_;
     const quic::LoadBalancerServerId server_id_;
   };

--- a/test/extensions/quic/connection_id_generator/quic_lb/quic_lb_test.cc
+++ b/test/extensions/quic/connection_id_generator/quic_lb/quic_lb_test.cc
@@ -267,12 +267,12 @@ TEST(QuicLbTest, InvalidConfig) {
       "'server_id' length (7) and 'nonce_length_bytes' (12) combined must be 18 bytes or less.");
 }
 
-// Validate that the server ID is present in plaintext when `unsafe_unencrypted_testing_mode`
+// Validate that the server ID is present in plaintext when `unencrypted_mode`
 // is enabled.
 TEST(QuicLbTest, Unencrypted) {
   uint8_t id_data[] = {0xab, 0xcd, 0xef, 0x12, 0x34, 0x56};
   envoy::extensions::quic::connection_id_generator::quic_lb::v3::Config cfg;
-  cfg.set_unsafe_unencrypted_testing_mode(true);
+  cfg.set_unencrypted_mode(true);
   cfg.mutable_server_id()->set_inline_bytes(id_data, sizeof(id_data));
   cfg.set_nonce_length_bytes(10);
   cfg.mutable_encryption_parameters()->set_name(kSecretName);
@@ -302,7 +302,7 @@ TEST(QuicLbTest, Base64ServerId) {
   constexpr absl::string_view id_data = "testtest";
 
   envoy::extensions::quic::connection_id_generator::quic_lb::v3::Config cfg;
-  cfg.set_unsafe_unencrypted_testing_mode(true);
+  cfg.set_unencrypted_mode(true);
   cfg.mutable_server_id()->set_inline_string(id_data_base64);
   cfg.set_server_id_base64_encoded(true);
   cfg.set_expected_server_id_length(id_data.length());


### PR DESCRIPTION
Rename from `unsafe_unencrypted_testing_mode` and elaborate the comment for that field, to better express what it means and implications of using it.

Re-order so that the most commonly configured fields are listed first.

Remove note about poor performance because that was addressed in a previous change.