### PR TITLE
rate_limit_quota: Fix minor tsan and msan errors in rate_limit_quota test cases.

### DIFF
--- a/test/extensions/filters/http/rate_limit_quota/client_test_utils.h
+++ b/test/extensions/filters/http/rate_limit_quota/client_test_utils.h
@@ -220,7 +220,7 @@ public:
   MockAsyncClientWithReset* async_client_ = nullptr;
   Grpc::MockAsyncStream stream_;
   NiceMock<StreamInfo::MockStreamInfo> stream_info_;
-  Grpc::RawAsyncStreamCallbacks* stream_callbacks_;
+  Grpc::RawAsyncStreamCallbacks* stream_callbacks_ = nullptr;
   Grpc::Status::GrpcStatus grpc_status_ = Grpc::Status::WellKnownGrpcStatus::Ok;
   int fail_starts_ = 0;
   std::string domain_ = "cloud_12345_67890_rlqs";

--- a/test/extensions/filters/http/rate_limit_quota/config_test.cc
+++ b/test/extensions/filters/http/rate_limit_quota/config_test.cc
@@ -52,12 +52,13 @@ TEST(RateLimitQuotaFilterConfigTest, RateLimitQuotaFilterWithCorrectProto) {
   envoy::extensions::filters::http::rate_limit_quota::v3::RateLimitQuotaFilterConfig filter_config;
   TestUtility::loadFromYaml(filter_config_yaml, filter_config);
 
-  Http::MockFilterChainFactoryCallbacks filter_callback;
-  EXPECT_CALL(filter_callback, addStreamFilter(_));
   // Handle the global client's creation by expecting the underlying async grpc
   // client creation. getOrThrow fails otherwise.
   auto mock_stream_client = std::make_unique<RateLimitTestClient>();
   mock_stream_client->expectClientCreationWithFactory();
+
+  Http::MockFilterChainFactoryCallbacks filter_callback;
+  EXPECT_CALL(filter_callback, addStreamFilter(_));
 
   RateLimitQuotaFilterFactory factory;
   std::string stats_prefix = "test";


### PR DESCRIPTION
Commit Message: Fix minor tsan and msan errors in rate_limit_quota test cases.

Additional Description: Specifically fix the following sanitizer complaints:
- filter_persistence_test needed to coordinate the emptying of GlobalTlsStores better after pushing a removal of all active rate_limit_quota filters per tsan.
- fix the potential for stream_callbacks_ in test utils to not have been initialized before first-usage per msan.

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
