### PR TITLE
LSC: Add load statements for C++ rules

### DIFF
--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -4,6 +4,7 @@ load("@envoy_api//bazel:repository_locations.bzl", API_REPOSITORY_LOCATIONS_SPEC
 load("@envoy_api//bazel:repository_locations_utils.bzl", "load_repository_locations_spec", "merge_dicts")
 load("@envoy_toolshed//:macros.bzl", "json_data")
 load("@envoy_toolshed//dependency:macros.bzl", "updater")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:envoy_build_system.bzl", "envoy_package")
 load("//bazel:envoy_internal.bzl", "envoy_select_force_libcpp")
 load(":repository_locations.bzl", "REPOSITORY_LOCATIONS_SPEC")

--- a/bazel/external/http_parser/BUILD
+++ b/bazel/external/http_parser/BUILD
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
 licenses(["notice"])  # Apache 2
 
 cc_library(

--- a/source/extensions/common/wasm/ext/BUILD
+++ b/source/extensions/common/wasm/ext/BUILD
@@ -1,4 +1,5 @@
 load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_library",


### PR DESCRIPTION
Adds required load statements for C++ rules to BUILD and bzl files.

This is a no-op.

Commit Message: Add load statements for C++ rules
Additional Description: Adds required load statements for C++ rules to BUILD and bzl files. This is a no-op.
Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A