### PR TITLE
[WIP/bp/1.32] tls_inspector: do not close plain text connections for >16Kb reads (#…A

### DIFF
--- a/api/envoy/extensions/filters/listener/tls_inspector/v3/tls_inspector.proto
+++ b/api/envoy/extensions/filters/listener/tls_inspector/v3/tls_inspector.proto
@@ -32,4 +32,15 @@ message TlsInspector {
   // tls inspector will consume.
   google.protobuf.UInt32Value initial_read_buffer_size = 2
       [(validate.rules).uint32 = {lt: 65537 gt: 255}];
+
+  // Close connection when TLS ClientHello message could not be parsed.
+  // This flag should be enabled only if it is known that incoming connections are expected to use
+  // TLS protocol, as Envoy does not distinguish between a plain text message or a malformed TLS
+  // ClientHello message.
+  // By default this flag is false and TLS ClientHello parsing errors are interpreted as a
+  // plain text connection.
+  // Setting this to true will cause connections to be terminated and the ``client_hello_too_large``
+  // counter to be incremented if the ClientHello message is over implementation defined limit
+  // (currently 16Kb).
+  bool close_connection_on_client_hello_parsing_errors = 4;
 }

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -19,6 +19,11 @@ bug_fixes:
     - CVE-2025-27818: kafka
     - CVE-2024-51745: wasmtime
     - CVE-2025-53901: wasmtime.
+- area: tls_inspector
+  change: |
+    Fixed regression in tls_inspector that caused plain text connections to be closed if more than 16Kb is read at once.
+    This behavior can be reverted by setting the runtime guard ``envoy.reloadable_features.tls_inspector_no_length_check_on_error``
+    to false.
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/source/extensions/filters/listener/tls_inspector/tls_inspector.cc
+++ b/source/extensions/filters/listener/tls_inspector/tls_inspector.cc
@@ -54,6 +54,10 @@ Config::Config(
       ssl_ctx_(SSL_CTX_new(TLS_with_buffers_method())),
       enable_ja3_fingerprinting_(
           PROTOBUF_GET_WRAPPED_OR_DEFAULT(proto_config, enable_ja3_fingerprinting, false)),
+      enable_ja4_fingerprinting_(
+          PROTOBUF_GET_WRAPPED_OR_DEFAULT(proto_config, enable_ja4_fingerprinting, false)),
+      close_connection_on_client_hello_parsing_errors_(
+          proto_config.close_connection_on_client_hello_parsing_errors()),
       max_client_hello_size_(max_client_hello_size),
       initial_read_buffer_size_(
           std::min(PROTOBUF_GET_WRAPPED_OR_DEFAULT(proto_config, initial_read_buffer_size,
@@ -169,6 +173,71 @@ Network::FilterStatus Filter::onData(Network::ListenerFilterBuffer& buffer) {
   return Network::FilterStatus::StopIteration;
 }
 
+void Filter::setDynamicMetadata(absl::string_view failure_reason) {
+  Protobuf::Struct metadata;
+  auto& fields = *metadata.mutable_fields();
+  fields[failureReasonKey()].set_string_value(failure_reason);
+  cb_->setDynamicMetadata(dynamicMetadataKey(), metadata);
+}
+
+ParseState Filter::getParserState(int handshake_status) {
+  switch (SSL_get_error(ssl_.get(), handshake_status)) {
+  case SSL_ERROR_WANT_READ:
+    if (read_ >= maxConfigReadBytes()) {
+      // We've hit the specified size limit. This is an unreasonably large ClientHello;
+      // indicate failure.
+      config_->stats().client_hello_too_large_.inc();
+      setDynamicMetadata(failureReasonClientHelloTooLarge());
+      return ParseState::Error;
+    }
+    if (read_ >= requested_read_bytes_) {
+      // Double requested bytes up to the maximum configured.
+      requested_read_bytes_ = std::min<uint32_t>(2 * read_, maxConfigReadBytes());
+    }
+    return ParseState::Continue;
+  case SSL_ERROR_SSL:
+    // There are 3 possibilities when get here:
+    // 1. A valid TLS Client Hello message was parsed (`clienthello_success_` is true)
+    // 2. A plain text message that generated a parsing error
+    // 3. A TLS Client Hello that generated a parsing error (i.e. invalid cipher list)
+    // It is not practical to distinguish between 2 and 3 based on error codes, so Envoy assumes
+    // this is either a plain text connection or invalid TLS connection based on config option.
+    // In the future it may be possible to add some error checking to make this detection more
+    // optimal.
+    if (clienthello_success_) {
+      config_->stats().tls_found_.inc();
+      if (alpn_found_) {
+        config_->stats().alpn_found_.inc();
+      } else {
+        config_->stats().alpn_not_found_.inc();
+      }
+      cb_->socket().setDetectedTransportProtocol("tls");
+    } else {
+      // Checking max message length should not be done here as it will close all plain text
+      // connections that happened to read more than maxConfigReadBytes() in one I/O operation. With
+      // the default limit of 16Kb it is fairly likely.
+      if (config_->closeConnectionOnTlsHelloParsingErrors()) {
+        // We've hit the specified size limit. This is an unreasonably large ClientHello;
+        // indicate failure.
+        if (read_ >= maxConfigReadBytes()) {
+          setDynamicMetadata(failureReasonClientHelloTooLarge());
+          config_->stats().client_hello_too_large_.inc();
+        }
+        return ParseState::Error;
+      }
+      config_->stats().tls_not_found_.inc();
+      setDynamicMetadata(failureReasonClientHelloNotDetected());
+      ENVOY_LOG(
+          debug, "tls inspector: parseClientHello failed: {}, {}: {}", ERR_peek_error(),
+          ERR_peek_last_error(),
+          Extensions::TransportSockets::Tls::Utility::getLastCryptoError().value_or("unknown"));
+    }
+    return ParseState::Done;
+  default:
+    return ParseState::Error;
+  }
+}
+
 ParseState Filter::parseClientHello(const void* data, size_t len,
                                     uint64_t bytes_already_processed) {
   // Ownership remains here though we pass a reference to it in `SSL_set0_rbio()`.
@@ -185,37 +254,7 @@ ParseState Filter::parseClientHello(const void* data, size_t len,
 
   // This should never succeed because an error is always returned from the SNI callback.
   ASSERT(ret <= 0);
-  ParseState state = [this, ret]() {
-    switch (SSL_get_error(ssl_.get(), ret)) {
-    case SSL_ERROR_WANT_READ:
-      if (read_ >= maxConfigReadBytes()) {
-        // We've hit the specified size limit. This is an unreasonably large ClientHello;
-        // indicate failure.
-        config_->stats().client_hello_too_large_.inc();
-        return ParseState::Error;
-      }
-      if (read_ >= requested_read_bytes_) {
-        // Double requested bytes up to the maximum configured.
-        requested_read_bytes_ = std::min<uint32_t>(2 * read_, maxConfigReadBytes());
-      }
-      return ParseState::Continue;
-    case SSL_ERROR_SSL:
-      if (clienthello_success_) {
-        config_->stats().tls_found_.inc();
-        if (alpn_found_) {
-          config_->stats().alpn_found_.inc();
-        } else {
-          config_->stats().alpn_not_found_.inc();
-        }
-        cb_->socket().setDetectedTransportProtocol("tls");
-      } else {
-        config_->stats().tls_not_found_.inc();
-      }
-      return ParseState::Done;
-    default:
-      return ParseState::Error;
-    }
-  }();
+  ParseState state = getParserState(ret);
 
   if (state != ParseState::Continue) {
     // Record bytes analyzed as we're done processing.

--- a/source/extensions/filters/listener/tls_inspector/tls_inspector.h
+++ b/source/extensions/filters/listener/tls_inspector/tls_inspector.h
@@ -59,8 +59,14 @@ public:
   bool enableJA3Fingerprinting() const { return enable_ja3_fingerprinting_; }
   uint32_t maxClientHelloSize() const { return max_client_hello_size_; }
   uint32_t initialReadBufferSize() const { return initial_read_buffer_size_; }
+  bool closeConnectionOnTlsHelloParsingErrors() const {
+    return close_connection_on_client_hello_parsing_errors_;
+  }
 
-  static constexpr size_t TLS_MAX_CLIENT_HELLO = 64 * 1024;
+  // This is the maximum size of a ClientHello that boring ssl will accept.
+  // Here is the check in boring ssl:
+  // https://boringssl.googlesource.com/boringssl/+/refs/tags/0.20250818.0/ssl/handshake.cc#137
+  static constexpr size_t TLS_MAX_CLIENT_HELLO = SSL3_RT_MAX_PLAIN_LENGTH;
   static const unsigned TLS_MIN_SUPPORTED_VERSION;
   static const unsigned TLS_MAX_SUPPORTED_VERSION;
 
@@ -68,6 +74,8 @@ private:
   TlsInspectorStats stats_;
   bssl::UniquePtr<SSL_CTX> ssl_ctx_;
   const bool enable_ja3_fingerprinting_;
+  const bool enable_ja4_fingerprinting_;
+  const bool close_connection_on_client_hello_parsing_errors_;
   const uint32_t max_client_hello_size_;
   const uint32_t initial_read_buffer_size_;
 };
@@ -93,6 +101,8 @@ private:
   void onServername(absl::string_view name);
   void createJA3Hash(const SSL_CLIENT_HELLO* ssl_client_hello);
   uint32_t maxConfigReadBytes() const { return config_->maxClientHelloSize(); }
+  ParseState getParserState(int handshake_status);
+  void setDynamicMetadata(absl::string_view failure_reason);
 
   ConfigSharedPtr config_;
   Network::ListenerFilterCallbacks* cb_{};

--- a/test/extensions/filters/listener/tls_inspector/tls_inspector_test.cc
+++ b/test/extensions/filters/listener/tls_inspector/tls_inspector_test.cc
@@ -257,12 +257,11 @@ TEST_P(TlsInspectorTest, NoExtensions) {
 // maximum allowed size.
 TEST_P(TlsInspectorTest, ClientHelloTooBig) {
   envoy::extensions::filters::listener::tls_inspector::v3::TlsInspector proto_config;
-  const size_t max_size = 50;
-  cfg_ =
-      std::make_shared<Config>(*store_.rootScope(), proto_config, static_cast<uint32_t>(max_size));
-  std::vector<uint8_t> client_hello = Tls::Test::generateClientHello(
-      std::get<0>(GetParam()), std::get<1>(GetParam()), "example.com", "");
-  ASSERT(client_hello.size() > max_size);
+  proto_config.set_close_connection_on_client_hello_parsing_errors(true);
+  cfg_ = std::make_shared<Config>(*store_.rootScope(), proto_config);
+  std::vector<uint8_t> client_hello = Tls::Test::generateClientHelloFromJA3Fingerprint(
+      "769,47-53-5-10-49161-49162-49171-49172-50-56-19-4,0-10-11,23-24-25,0", 17000);
+  ASSERT(client_hello.size() > Config::TLS_MAX_CLIENT_HELLO);
 
   filter_ = std::make_unique<Filter>(cfg_);
 
@@ -288,6 +287,39 @@ TEST_P(TlsInspectorTest, ClientHelloTooBig) {
       store_.histogramValues("tls_inspector.bytes_processed", false);
   ASSERT_EQ(1, bytes_processed.size());
   EXPECT_EQ(max_size, bytes_processed[0]);
+}
+
+TEST_P(TlsInspectorTest, ClientHelloTooBigTreatParsingErrorAsPlainText) {
+  envoy::extensions::filters::listener::tls_inspector::v3::TlsInspector proto_config;
+  cfg_ = std::make_shared<Config>(*store_.rootScope(), proto_config);
+  std::vector<uint8_t> client_hello = Tls::Test::generateClientHelloFromJA3Fingerprint(
+      "769,47-53-5-10-49161-49162-49171-49172-50-56-19-4,0-10-11,23-24-25,0", 17000);
+  ASSERT(client_hello.size() > Config::TLS_MAX_CLIENT_HELLO);
+
+  filter_ = std::make_unique<Filter>(cfg_);
+  EXPECT_CALL(socket_, detectedTransportProtocol()).Times(0);
+  EXPECT_CALL(cb_, socket()).WillRepeatedly(ReturnRef(socket_));
+  EXPECT_CALL(socket_, ioHandle()).WillRepeatedly(ReturnRef(*io_handle_));
+  EXPECT_CALL(dispatcher_,
+              createFileEvent_(_, _, Event::PlatformDefaultTriggerType,
+                               Event::FileReadyType::Read | Event::FileReadyType::Closed))
+      .WillOnce(
+          DoAll(SaveArg<1>(&file_event_callback_), ReturnNew<NiceMock<Event::MockFileEvent>>()));
+  buffer_ = std::make_unique<Network::ListenerFilterBufferImpl>(
+      *io_handle_, dispatcher_, [](bool) {}, [](Network::ListenerFilterBuffer&) {},
+      cfg_->maxClientHelloSize() == 0, cfg_->maxClientHelloSize());
+
+  filter_->onAccept(cb_);
+  mockSysCallForPeek(client_hello, true);
+  EXPECT_CALL(socket_, detectedTransportProtocol()).Times(::testing::AnyNumber());
+  EXPECT_TRUE(file_event_callback_(Event::FileReadyType::Read).ok());
+  auto state = filter_->onData(*buffer_);
+  EXPECT_EQ(Network::FilterStatus::Continue, state);
+  EXPECT_EQ(1, cfg_->stats().tls_not_found_.value());
+  const std::vector<uint64_t> bytes_processed =
+      store_.histogramValues("tls_inspector.bytes_processed", false);
+  ASSERT_EQ(1, bytes_processed.size());
+  EXPECT_EQ(5, bytes_processed[0]);
 }
 
 // Test that the filter sets the `JA3` hash
@@ -407,6 +439,26 @@ TEST_P(TlsInspectorTest, NotSsl) {
 
   // Use 100 bytes of zeroes. This is not valid as a ClientHello.
   data.resize(100);
+  mockSysCallForPeek(data);
+  // trigger the event to copy the client hello message into buffer:q
+  EXPECT_TRUE(file_event_callback_(Event::FileReadyType::Read).ok());
+  auto state = filter_->onData(*buffer_);
+  EXPECT_EQ(Network::FilterStatus::Continue, state);
+  EXPECT_EQ(1, cfg_->stats().tls_not_found_.value());
+  const std::vector<uint64_t> bytes_processed =
+      store_.histogramValues("tls_inspector.bytes_processed", false);
+  ASSERT_EQ(1, bytes_processed.size());
+  EXPECT_EQ(5, bytes_processed[0]);
+}
+
+// Verify that a plain text connection with a single I/O read of more than
+// maximum TLS inspector buffer (currently 16Kb) is correctly detected.
+TEST_P(TlsInspectorTest, NotSslOverMaxReadBytesSingleRead) {
+  init();
+  std::vector<uint8_t> data;
+
+  // Use more than max number of bytes for a ClientHello.
+  data.resize(Config::TLS_MAX_CLIENT_HELLO + 1);
   mockSysCallForPeek(data);
   // trigger the event to copy the client hello message into buffer:q
   EXPECT_TRUE(file_event_callback_(Event::FileReadyType::Read).ok());


### PR DESCRIPTION
…40911)

if Envoy read more than 16Kb in a single read operation. The bug was always there, but before #39903 a single read of more than 64Kb was needed which was much less likely (and recommended network buffer size is 32Kb). See issue #40730

After #39903 Envoy gained ability to disconnect connections with TLS client hello above 16Kb but made pre-existing bug
that caused valid plain text connections to be disconnected much more likely.

This PR bring Envoy largely to the old behavior. Connections with TLS client hello above 16Kb will be interpreted as plain text (as it was before #39903). The only difference is that Envoy will not disconnect connections with a single read of more than 64Kb, but this is too rare to be a meaningful difference in behavior and is arguably more correct.

Risk Level: low (brings back old behavior)
Testing: unit tests
Docs Changes: n/a
Release Notes: yes
Platform Specific Features: n/a
Runtime guard:
envoy.reloadable_features.tls_inspector_no_length_check_on_error Fixes #40730

---------

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
