### PR TITLE
check callbacks existence in onAboveWriteBufferHighWatermark and onBe…

### DIFF
--- a/source/common/tcp/conn_pool.h
+++ b/source/common/tcp/conn_pool.h
@@ -95,8 +95,16 @@ public:
   // Override the default's of Envoy::ConnectionPool::ActiveClient for class-specific functions.
   // Network::ConnectionCallbacks
   void onEvent(Network::ConnectionEvent event) override;
-  void onAboveWriteBufferHighWatermark() override { callbacks_->onAboveWriteBufferHighWatermark(); }
-  void onBelowWriteBufferLowWatermark() override { callbacks_->onBelowWriteBufferLowWatermark(); }
+  void onAboveWriteBufferHighWatermark() override {
+    if (callbacks_) {
+      callbacks_->onAboveWriteBufferHighWatermark();
+    }
+  }
+  void onBelowWriteBufferLowWatermark() override {
+    if (callbacks_) {
+      callbacks_->onBelowWriteBufferLowWatermark();
+    }
+  }
 
   // Undos the readDisable done in onEvent(Connected)
   void readEnableIfNew();


### PR DESCRIPTION
Commit Message:  check callbacks existence in onAboveWriteBufferHighWatermark and onBelowWriteBufferLowWatermark
Additional Description:  I got an envoy crash in my production environment and the crash stack points to ActiveTcpClient:: onBelowWriteBufferLowWatermark. The envoy is using generic proxy filter and using tcp connection pool to proxy customised protocol data. This crash can be frequently reproduced when I benchmark with large body request & response and  kill the client connections during the test. I check around other files, seems like check callbacks_ existence before calling it is quite common, and I try use this fix in my environment seems crash is solved.
Risk Level: High
