### PR TITLE
jwt_authn: deprecate flag jwt_fetcher_use_scheme_from_uri and legacy code branches

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -21,6 +21,9 @@ bug_fixes:
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`
+- area: jwt_authn
+  change: |
+    Removed runtime guard ``envoy.reloadable_features.jwt_fetcher_use_scheme_from_uri`` and legacy code paths.
 - area: http
   change: |
     Removed runtime guard ``envoy.reloadable_features.http1_balsa_allow_cr_or_lf_at_request_start`` and legacy code paths.

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -52,7 +52,6 @@ RUNTIME_GUARD(envoy_reloadable_features_http2_use_oghttp2);
 RUNTIME_GUARD(envoy_reloadable_features_http3_remove_empty_cookie);
 // Delay deprecation and decommission until UHV is enabled.
 RUNTIME_GUARD(envoy_reloadable_features_http_reject_path_with_fragment);
-RUNTIME_GUARD(envoy_reloadable_features_jwt_fetcher_use_scheme_from_uri);
 RUNTIME_GUARD(envoy_reloadable_features_no_extension_lookup_by_name);
 RUNTIME_GUARD(envoy_reloadable_features_oauth2_cleanup_cookies);
 RUNTIME_GUARD(envoy_reloadable_features_oauth2_encrypt_tokens);

--- a/source/extensions/filters/http/common/jwks_fetcher.cc
+++ b/source/extensions/filters/http/common/jwks_fetcher.cc
@@ -7,7 +7,6 @@
 #include "source/common/http/headers.h"
 #include "source/common/http/utility.h"
 #include "source/common/protobuf/utility.h"
-#include "source/common/runtime/runtime_features.h"
 
 #include "jwt_verify_lib/status.h"
 
@@ -56,9 +55,7 @@ public:
       return;
     }
 
-    Http::RequestMessagePtr message = Http::Utility::prepareHeaders(
-        remote_jwks_.http_uri(), Runtime::runtimeFeatureEnabled(
-                                     "envoy.reloadable_features.jwt_fetcher_use_scheme_from_uri"));
+    Http::RequestMessagePtr message = Http::Utility::prepareHeaders(remote_jwks_.http_uri(), true);
     message->headers().setReferenceMethod(Http::Headers::get().MethodValues.Get);
     message->headers().setReferenceUserAgent(Http::Headers::get().UserAgentValues.GoBrowser);
     ENVOY_LOG(debug, "fetch pubkey from [uri = {}]: start", remote_jwks_.http_uri().uri());

--- a/test/extensions/filters/http/common/jwks_fetcher_test.cc
+++ b/test/extensions/filters/http/common/jwks_fetcher_test.cc
@@ -10,7 +10,6 @@
 #include "test/extensions/filters/http/common/mock.h"
 #include "test/mocks/http/mocks.h"
 #include "test/mocks/server/factory_context.h"
-#include "test/test_common/test_runtime.h"
 #include "test/test_common/utility.h"
 
 using envoy::extensions::filters::http::jwt_authn::v3::RemoteJwks;
@@ -356,34 +355,6 @@ TEST_F(JwksFetcherTest, TestSchemeHeaderHttp) {
           [](Http::RequestMessagePtr& message, Http::AsyncClient::Callbacks&,
              const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
             EXPECT_THAT(message->headers(), ContainsHeader(Http::Headers::get().Scheme, "http"));
-            return nullptr;
-          }));
-
-  MockJwksReceiver receiver;
-
-  // Act
-  fetcher_->fetch(parent_span_, receiver);
-}
-
-TEST_F(JwksFetcherTest, TestSchemeHeaderLegacy) {
-  // Setup
-  TestScopedRuntime scoped_runtime;
-  scoped_runtime.mergeValues(
-      {{"envoy.reloadable_features.jwt_fetcher_use_scheme_from_uri", "false"}});
-  setupFetcher(R"(
-    http_uri:
-      uri: https://pubkey_server/pubkey_path
-      cluster: pubkey_cluster
-    )");
-  auto& cm = mock_factory_ctx_.server_factory_context_.cluster_manager_;
-  Http::MockAsyncClientRequest request(&cm.thread_local_cluster_.async_client_);
-
-  // Expect no :scheme header due to the disabled runtime guard.
-  EXPECT_CALL(cm.thread_local_cluster_.async_client_, send_(_, _, _))
-      .WillOnce(testing::Invoke(
-          [](Http::RequestMessagePtr& message, Http::AsyncClient::Callbacks&,
-             const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
-            EXPECT_TRUE(message->headers().get(Http::Headers::get().Scheme).empty());
             return nullptr;
           }));
 


### PR DESCRIPTION
## Description

This PR removes the deprecated reloadable flag `jwt_fetcher_use_scheme_from_uri` and cleans up the legacy paths.

Fix https://github.com/envoyproxy/envoy/issues/41507

---

**Commit Message:** jwt_authn: deprecate flag jwt_fetcher_use_scheme_from_uri and remove legacy code paths
**Additional Description:** Remove the deprecated reloadable flag `jwt_fetcher_use_scheme_from_uri` and cleans up the legacy paths.
**Risk Level:** Low
**Testing:** CI
**Docs Changes:** N/A
**Release Notes:** Added