### PR TITLE
dfp: deprecate flag dfp_cluster_resolves_hosts and remove legacy code paths

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -24,6 +24,9 @@ removed_config_or_runtime:
 - area: http
   change: |
     Removed runtime guard ``envoy.reloadable_features.http1_balsa_allow_cr_or_lf_at_request_start`` and legacy code paths.
+- area: dfp
+  change: |
+    Removed runtime guard ``envoy.reloadable_features.dfp_cluster_resolves_hosts`` and legacy code paths.
 
 new_features:
 

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -36,7 +36,6 @@
 // problem of the bugs being found after the old code path has been removed.
 RUNTIME_GUARD(envoy_reloadable_features_async_host_selection);
 RUNTIME_GUARD(envoy_reloadable_features_decouple_explicit_drain_pools_and_dns_refresh);
-RUNTIME_GUARD(envoy_reloadable_features_dfp_cluster_resolves_hosts);
 RUNTIME_GUARD(envoy_reloadable_features_disallow_quic_client_udp_mmsg);
 RUNTIME_GUARD(envoy_reloadable_features_enable_cel_regex_precompilation);
 RUNTIME_GUARD(envoy_reloadable_features_enable_compression_bomb_protection);

--- a/source/extensions/clusters/dynamic_forward_proxy/cluster.cc
+++ b/source/extensions/clusters/dynamic_forward_proxy/cluster.cc
@@ -432,10 +432,8 @@ Cluster::LoadBalancer::chooseHost(Upstream::LoadBalancerContext* context) {
   Upstream::HostConstSharedPtr host = findHostByName(hostname);
   bool force_refresh =
       Runtime::runtimeFeatureEnabled("envoy.reloadable_features.reresolve_if_no_connections") &&
-      Runtime::runtimeFeatureEnabled("envoy.reloadable_features.dfp_cluster_resolves_hosts") &&
       host && !host->used();
-  if ((host && !force_refresh) ||
-      !Runtime::runtimeFeatureEnabled("envoy.reloadable_features.dfp_cluster_resolves_hosts")) {
+  if (host && !force_refresh) {
     return {host};
   }
 

--- a/test/extensions/filters/http/dynamic_forward_proxy/BUILD
+++ b/test/extensions/filters/http/dynamic_forward_proxy/BUILD
@@ -112,39 +112,3 @@ envoy_extension_cc_test(
         "@envoy_api//envoy/extensions/transport_sockets/tls/v3:pkg_cc_proto",
     ],
 )
-
-envoy_extension_cc_test(
-    name = "legacy_proxy_filter_integration_test",
-    size = "large",
-    srcs = ["proxy_filter_integration_test.cc"],
-    args = [
-        "--runtime-feature-disable-for-tests=envoy.reloadable_features.dfp_cluster_resolves_hosts",
-    ],
-    data = [
-        "//test/config/integration/certs",
-    ],
-    extension_names = ["envoy.filters.http.dynamic_forward_proxy"],
-    rbe_pool = "2core",
-    # TODO(envoyproxy/windows-dev): Diagnose failure shown on clang-cl build, see:
-    #   https://gist.github.com/wrowe/a152cb1d12c2f751916122aed39d8517
-    tags = ["fails_on_clang_cl"],
-    deps = [
-        ":modify_host_filter_lib",
-        ":test_resolver_lib",
-        "//source/extensions/clusters/dns:dns_cluster_lib",
-        "//source/extensions/clusters/dynamic_forward_proxy:cluster",
-        "//source/extensions/filters/http/dynamic_forward_proxy:config",
-        "//source/extensions/filters/http/set_filter_state:config",
-        "//source/extensions/key_value/file_based:config_lib",
-        "//source/extensions/network/dns_resolver/getaddrinfo:config",
-        "//test/integration:http_integration_lib",
-        "//test/integration/filters:stream_info_to_headers_filter_lib",
-        "//test/test_common:test_runtime_lib",
-        "//test/test_common:threadsafe_singleton_injector_lib",
-        "@envoy_api//envoy/config/bootstrap/v3:pkg_cc_proto",
-        "@envoy_api//envoy/config/cluster/v3:pkg_cc_proto",
-        "@envoy_api//envoy/extensions/filters/network/http_connection_manager/v3:pkg_cc_proto",
-        "@envoy_api//envoy/extensions/transport_sockets/quic/v3:pkg_cc_proto",
-        "@envoy_api//envoy/extensions/transport_sockets/tls/v3:pkg_cc_proto",
-    ],
-)

--- a/test/integration/filters/stream_info_to_headers_filter.cc
+++ b/test/integration/filters/stream_info_to_headers_filter.cc
@@ -61,10 +61,8 @@ public:
   Http::FilterHeadersStatus encodeHeaders(Http::ResponseHeaderMap& headers, bool) override {
     std::string dns_start = "envoy.dynamic_forward_proxy.dns_start_ms";
     std::string dns_end = "envoy.dynamic_forward_proxy.dns_end_ms";
-    if (Runtime::runtimeFeatureEnabled("envoy.reloadable_features.dfp_cluster_resolves_hosts")) {
-      dns_start = "envoy.router.host_selection_start_ms";
-      dns_end = "envoy.router.host_selection_end_ms";
-    }
+    dns_start = "envoy.router.host_selection_start_ms";
+    dns_end = "envoy.router.host_selection_end_ms";
     StreamInfo::StreamInfo& stream_info = decoder_callbacks_->streamInfo();
     const StreamInfo::StreamInfo& conn_stream_info = decoder_callbacks_->connection()->streamInfo();
 


### PR DESCRIPTION
## Description

This PR removes the deprecated reloadable flag `dfp_cluster_resolves_hosts` and cleans up the legacy paths.

Fix https://github.com/envoyproxy/envoy/issues/41503

---

**Commit Message:** dfp: deprecate flag dfp_cluster_resolves_hosts and remove legacy code paths
**Additional Description:** Remove the deprecated reloadable flag `dfp_cluster_resolves_hosts` and cleans up the legacy paths.
**Risk Level:** Low
**Testing:** CI
**Docs Changes:** N/A
**Release Notes:** Added