### PR TITLE
lua test: fix the large body test with initial_stream_window_size

### DIFF
--- a/test/extensions/filters/http/lua/lua_integration_test.cc
+++ b/test/extensions/filters/http/lua/lua_integration_test.cc
@@ -27,7 +27,7 @@ public:
     addFakeUpstream(Http::CodecType::HTTP2);
   }
 
- void initializeFilter(const std::string& filter_config, const std::string& domain = "*",
+  void initializeFilter(const std::string& filter_config, const std::string& domain = "*",
                         bool test_large_body = false) {
     config_helper_.prependFilter(filter_config);
 


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description: set the initial_stream_window_size to test body that is large than it in lua
Risk Level:
Testing:
Docs Changes:

