### PR TITLE
hcm: minor update to fix clang tidy

### DIFF
--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -346,36 +346,30 @@ private:
 
     // All state for the stream. Put here for readability.
     struct State {
-      State()
-          : codec_saw_local_complete_(false), codec_encode_complete_(false),
-            on_reset_stream_called_(false), is_zombie_stream_(false), successful_upgrade_(false),
-            is_internally_destroyed_(false), is_internally_created_(false), is_tunneling_(false),
-            decorated_propagate_(true), deferred_to_next_io_iteration_(false),
-            deferred_end_stream_(false) {}
-
       // It's possibly for the codec to see the completed response but not fully
       // encode it.
-      bool codec_saw_local_complete_ : 1; // This indicates that local is complete as the completed
-                                          // response has made its way to the codec.
-      bool codec_encode_complete_ : 1;    // This indicates that the codec has
-                                          // completed encoding the response.
-      bool on_reset_stream_called_ : 1;   // Whether the stream has been reset.
-      bool is_zombie_stream_ : 1;         // Whether stream is waiting for signal
-                                          // the underlying codec to be destroyed.
-      bool successful_upgrade_ : 1;
+      bool codec_saw_local_complete_ : 1 = false; // This indicates that local is complete
+                                                  // as the completed
+                                                  // response has made its way to the codec.
+      bool codec_encode_complete_ : 1 = false;    // This indicates that the codec has
+                                                  // completed encoding the response.
+      bool on_reset_stream_called_ : 1 = false;   // Whether the stream has been reset.
+      bool is_zombie_stream_ : 1 = false;         // Whether stream is waiting for signal
+                                                  // the underlying codec to be destroyed.
+      bool successful_upgrade_ : 1 = false;
 
       // True if this stream was the original externally created stream, but was
       // destroyed as part of internal redirect.
-      bool is_internally_destroyed_ : 1;
+      bool is_internally_destroyed_ : 1 = false;
       // True if this stream is internally created. Currently only used for
       // internal redirects or other streams created via recreateStream().
-      bool is_internally_created_ : 1;
+      bool is_internally_created_ : 1 = false;
 
       // True if the response headers indicate a successful upgrade or connect
       // response.
-      bool is_tunneling_ : 1;
+      bool is_tunneling_ : 1 = false;
 
-      bool decorated_propagate_ : 1;
+      bool decorated_propagate_ : 1 = true;
 
       // True if the decorator operation is overridden by the request header.
       bool decorator_overriden_ : 1 = false;
@@ -385,8 +379,8 @@ private:
       // they are deferred too.
       // TODO(yanavlasov): encapsulate the entire state of deferred streams into a separate
       // structure, so it can be atomically created and cleared.
-      bool deferred_to_next_io_iteration_ : 1;
-      bool deferred_end_stream_ : 1;
+      bool deferred_to_next_io_iteration_ : 1 = false;
+      bool deferred_end_stream_ : 1 = false;
     };
 
     bool canDestroyStream() const {


### PR DESCRIPTION
Commit Message: hcm: minor update to fix clang tidy
Additional Description:
Risk Level: low.
Testing: n/a.
Docs Changes: n/a.
Release Notes: n/a.