### PR TITLE
ppc64le: Refer to the correct path for including ppc_vsx-inl.h in highway.

### DIFF
--- a/bazel/highway-ppc64le.patch
+++ b/bazel/highway-ppc64le.patch
@@ -1,0 +1,12 @@
+diff --git a/BUILD b/BUILD
+index c825050b..7dd168db 100644
+--- a/BUILD
++++ b/BUILD
+@@ -198,6 +198,7 @@ cc_library(
+         "hwy/ops/x86_128-inl.h",
+         "hwy/ops/x86_256-inl.h",
+         "hwy/ops/x86_512-inl.h",
++        "hwy/ops/ppc_vsx-inl.h",
+         # Select avoids recompiling native arch if only non-native changed
+     ] + select({
+         ":compiler_emscripten": [

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -744,6 +744,10 @@ def _fast_float():
 def _highway():
     external_http_archive(
         name = "highway",
+        patches = [
+            "@envoy//bazel:highway-ppc64le.patch",
+        ],
+        patch_args = ["-p1"],
     )
 
 def _dragonbox():


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Patch to refer to the correct path for including ppc_vsx-inl.h while building highway for ppc64le.

Additional Description: This fixes the following error which happens when compiler looks for the file in /usr/include while building highway as an external dependency.

```
ERROR: /home/user/.cache/bazel/_bazel_user/43a771d06a0b358af5ad67b4e5bcbc9d/external/highway/BUILD:156:11: Compiling hwy/targets.cc [for tool] failed: (Exit 1): gcc failed: error executing CppCompile command (from target @@highway//:hwy) /usr/bin/gcc -U_FORTIFY_SOURCE -fstack-protector -Wall -Wunused-but-set-parameter -Wno-free-nonheap-object -fno-omit-frame-pointer -g0 -O2 '-D_FORTIFY_SOURCE=1' -DNDEBUG -ffunction-sections ... (remaining 28 arguments skipped)

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
In file included from external/highway/hwy/targets.cc:23:
external/highway/hwy/highway.h:586:10: fatal error: hwy/ops/ppc_vsx-inl.h: No such file or directory
  586 | #include "hwy/ops/ppc_vsx-inl.h"
      |          ^~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
Target //source/exe:envoy-static failed to build
```
Risk Level: Low
Testing: Yes, done locally.
Docs Changes: No.
