### PR TITLE
grpc_json_transcoder: when sse delimiter is on, make sure unary calls get content-type application/json

### DIFF
--- a/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
+++ b/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
@@ -711,7 +711,7 @@ Http::FilterHeadersStatus JsonTranscoderFilter::encodeHeaders(Http::ResponseHead
     return Http::FilterHeadersStatus::Continue;
   }
 
-  if (per_route_config_->isStreamSSEStyleDelimited()) {
+  if (method_->descriptor_->server_streaming() && per_route_config_->isStreamSSEStyleDelimited()) {
     headers.setContentType(Http::Headers::get().ContentTypeValues.TextEventStream);
   } else {
     headers.setReferenceContentType(Http::Headers::get().ContentTypeValues.Json);


### PR DESCRIPTION
Commit Message: grpc_json_transcoder: when sse delimiter is on, make sure unary calls get content-type application/json This aligns with grpc-httpjson-transcoding where body is sse encoded only for streaming requests. Fixes #41593
Additional Description:
Risk Level: Low
Testing: added TranscodingStreamSSEUnary test
Docs Changes: No
Release Notes: grpc_json_transcoder : when sse delimiter is on, make sure unary calls get content-type application/json
Platform Specific Features: No
