### PR TITLE
Flake

### DIFF
--- a/test/extensions/load_balancing_policies/client_side_weighted_round_robin/integration_test.cc
+++ b/test/extensions/load_balancing_policies/client_side_weighted_round_robin/integration_test.cc
@@ -119,10 +119,10 @@ public:
                                          std::vector<uint64_t>& upstream_usage) {
     // Expected number of upstreams.
     upstream_usage.resize(3);
-    ENVOY_LOG(error, "Start sending {} requests.", number_of_requests);
+    ENVOY_LOG(trace, "Start sending {} requests.", number_of_requests);
 
     for (uint64_t i = 0; i < number_of_requests; i++) {
-      ENVOY_LOG(error, "Before request {}.", i);
+      ENVOY_LOG(trace, "Before request {}.", i);
       absl::SleepFor(absl::Milliseconds(10));
       codec_client_ = makeHttpConnection(lookupPort("http"));
 
@@ -130,8 +130,6 @@ public:
           {":method", "GET"}, {":path", "/"}, {":scheme", "http"}, {":authority", "example.com"}};
 
       auto response = codec_client_->makeRequestWithBody(request_headers, 0);
-
-      absl::SleepFor(absl::Milliseconds(10));
 
       auto upstream_index = waitForNextUpstreamRequest({0, 1, 2}, std::chrono::seconds(15));
       ASSERT(upstream_index.has_value());
@@ -150,7 +148,7 @@ public:
       EXPECT_TRUE(response->complete());
       cleanupUpstreamAndDownstream();
       ASSERT_TRUE(codec_client_->waitForDisconnect());
-      ENVOY_LOG(error, "After request {}.", i);
+      ENVOY_LOG(trace, "After request {}.", i);
     }
   }
 
@@ -539,10 +537,10 @@ public:
     }
     // Expected number of upstreams.
     upstream_usage.resize(number_of_upstreams);
-    ENVOY_LOG(error, "Start sending {} requests.", number_of_requests);
+    ENVOY_LOG(trace, "Start sending {} requests.", number_of_requests);
 
     for (uint64_t i = 0; i < number_of_requests; i++) {
-      ENVOY_LOG(error, "Before request {}.", i);
+      ENVOY_LOG(trace, "Before request {}.", i);
       absl::SleepFor(absl::Milliseconds(10));
 
       codec_client_ = makeHttpConnection(lookupPort("http"));
@@ -574,7 +572,7 @@ public:
       cleanupUpstreamAndDownstream();
       ASSERT_TRUE(codec_client_->waitForDisconnect());
 
-      ENVOY_LOG(error, "After request {}.", i);
+      ENVOY_LOG(trace, "After request {}.", i);
     }
   }
 
@@ -734,16 +732,16 @@ TEST_P(ClientSideWeightedRoundRobinEdsIntegrationTest, AddRemoveLocality) {
 
     // Upstream QPS for ORCA load reports. All hosts report the same QPS.
     const std::vector<uint64_t> upstream_qps = {100, 100, 100, 100};
-    // Send 100 requests to cluster1 so host weights are updated.
+    // Send 10 requests to cluster1 so host weights are updated.
     std::vector<uint64_t> initial_usage;
     sendRequestsAndTrackUpstreamUsage(FirstUpstreamIndex, upstream_qps, 10, initial_usage);
     ENVOY_LOG(error, "initial_usage {}", initial_usage);
 
     EXPECT_EQ(i + 1, test_server_->counter("cluster.cluster_1.membership_change")->value());
 
-    // Send another 100 requests to cluster1, expecting weights to be used.
+    // Send another 20 requests to cluster1, expecting weights to be used.
     std::vector<uint64_t> upstream_usage;
-    sendRequestsAndTrackUpstreamUsage(FirstUpstreamIndex, upstream_qps, 100, upstream_usage);
+    sendRequestsAndTrackUpstreamUsage(FirstUpstreamIndex, upstream_qps, 20, upstream_usage);
     ENVOY_LOG(error, "upstream_usage {}", upstream_usage);
     // Expect the usage of first locality to be non-zero.
     EXPECT_GT(upstream_usage[0], 0);


### PR DESCRIPTION
Commit Message: Fix flaky `client_side_weighted_round_robin:integration_test`.

- Increase connection timeout.
- Add sleeps between requests
- Add `codec_client_->waitForDisconnect()` after `cleanupUpstreamAndDownstream();`
- Reduce number of requests.

Risk Level: Low
Testing: `bazel test //test/extensions/load_balancing_policies/client_side_weighted_round_robin:integration_test --config=compile-time-options --define admin_functionality=disabled --runs_per_test=100 --cache_test_results=no`

Fixes  #issue
