### PR TITLE
tcp_proxy: remove missed code from tcp_proxy_retry_on_different_event_loop flag deprecation

### DIFF
--- a/source/common/tcp_proxy/tcp_proxy.cc
+++ b/source/common/tcp_proxy/tcp_proxy.cc
@@ -618,16 +618,6 @@ Network::FilterStatus Filter::establishUpstreamConnection() {
     return Network::FilterStatus::StopIteration;
   }
 
-  if (!config_->backoffStrategy()) {
-    const uint32_t max_connect_attempts = config_->maxConnectAttempts();
-    if (connect_attempts_ >= max_connect_attempts) {
-      getStreamInfo().setResponseFlag(StreamInfo::CoreResponseFlag::UpstreamRetryLimitExceeded);
-      cluster->trafficStats()->upstream_cx_connect_attempts_exceeded_.inc();
-      onInitFailure(UpstreamFailureReason::ConnectFailed);
-      return Network::FilterStatus::StopIteration;
-    }
-  }
-
   auto& downstream_connection = read_callbacks_->connection();
   auto& filter_state = downstream_connection.streamInfo().filterState();
   if (!filter_state->hasData<Network::ProxyProtocolFilterState>(


### PR DESCRIPTION
Commit Message: tcp_proxy: remove missed code from tcp_proxy_retry_on_different_event_loop flag deprecation
Additional Description: This logic was supposed to be removed in [tcp: deprecate flag tcp_proxy_retry_on_different_event_loop and legacy code branches #41539](https://github.com/envoyproxy/envoy/pull/41539)
Risk Level: low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
