### PR TITLE
github/ci: Always use diskspace hack for private repos

### DIFF
--- a/.github/workflows/_run.yml
+++ b/.github/workflows/_run.yml
@@ -247,7 +247,7 @@ jobs:
 
     - name: Free diskspace
       uses: envoyproxy/toolshed/gh-actions/diskspace@actions-v0.3.26
-      if: inputs.diskspace-hack
+      if: inputs.diskspace-hack || github.event.repository.private
       with:
         to_remove: ${{ inputs.diskspace-hack-paths }}
 


### PR DESCRIPTION
Recently available diskspace seems to have been reduced for private repos. This is a bit of a sledge hammer but should get those repos working for now.

