### PR TITLE
[bp/1.36] Use allocated memory for fixed heap pressure (#41442)

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -18,5 +18,12 @@ removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`
 
 new_features:
+- area: overload management
+  change: |
+    The fixed heap resource monitor can now calculate memory pressure as currently allocated memory divided by maximum heap size,
+    giving more accurate and lower memory pressure values.
+    This can avoid unnecessary load shedding or overload actions.
+    To enable, set ``envoy.reloadable_features.fixed_heap_use_allocated`` to true.
+    The default algorithm (heap_size - pageheap_unmapped - pageheap_free) does not discount for free memory in TCMalloc caches.
 
 deprecated:

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -190,6 +190,8 @@ FALSE_RUNTIME_GUARD(envoy_restart_features_use_cached_grpc_client_for_xds);
 // Runtime guard to revert back to old non-RFC-compliant CONNECT behavior without Host header.
 // TODO(vinaykul): Drop this false-runtime-guard when deemed safe with RFC 9110 compliant CONNECT.
 FALSE_RUNTIME_GUARD(envoy_reloadable_features_http_11_proxy_connect_legacy_format);
+// TODO(tsaarni): Flip to true after prod testing or remove.
+FALSE_RUNTIME_GUARD(envoy_reloadable_features_fixed_heap_use_allocated);
 
 // Block of non-boolean flags. Use of int flags is deprecated. Do not add more.
 ABSL_FLAG(uint64_t, re2_max_program_size_error_level, 100, ""); // NOLINT

--- a/source/extensions/resource_monitors/fixed_heap/fixed_heap_monitor.h
+++ b/source/extensions/resource_monitors/fixed_heap/fixed_heap_monitor.h
@@ -22,6 +22,8 @@ public:
   virtual uint64_t unmappedHeapBytes();
   // Memory in free, mapped pages in the page heap.
   virtual uint64_t freeMappedHeapBytes();
+  // Memory currently allocated by the process.
+  virtual uint64_t allocatedHeapBytes();
 };
 
 /**

--- a/test/extensions/resource_monitors/fixed_heap/BUILD
+++ b/test/extensions/resource_monitors/fixed_heap/BUILD
@@ -18,6 +18,7 @@ envoy_extension_cc_test(
     rbe_pool = "6gig",
     deps = [
         "//source/extensions/resource_monitors/fixed_heap:fixed_heap_monitor",
+        "//test/test_common:test_runtime_lib",
         "@com_google_absl//absl/types:optional",
         "@envoy_api//envoy/extensions/resource_monitors/fixed_heap/v3:pkg_cc_proto",
     ],


### PR DESCRIPTION
**Commit Message:**
After applying this PR the fixed heap resource monitor will use allocated memory for memory pressure calculation, so reported pressure is lower and more accurate. This can prevent unnecessary load shedding when there is enough free memory.
New formula is simply: `currently_allocated / max_heap_size` and it does not include any overhead that allocations might have. See
https://github.com/envoyproxy/envoy/issues/21923#issuecomment-3378633585 for background.
**Risk Level:** Low
**Testing:** test case added
**Docs Changes:**
**Release Notes:**
**Runtime guard:** `envoy.reloadable_features.fixed_heap_use_allocated`. Default value is `false`.

Fixes #21923
