### PR TITLE
perf: minor modification to PR #41468 - moving the right object

### DIFF
--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -683,7 +683,7 @@ RouteEntryImplBase::RouteEntryImplBase(const CommonVirtualHostSharedPtr& vhost,
           absl::StrCat("Failed to create path rewrite formatter: ", formatter_or.status()));
       return;
     }
-    path_rewrite_formatter_ = std::move(formatter_or).value();
+    path_rewrite_formatter_ = std::move(formatter_or.value());
   }
 
   if (path_rewriter_ != nullptr) {
@@ -699,7 +699,7 @@ RouteEntryImplBase::RouteEntryImplBase(const CommonVirtualHostSharedPtr& vhost,
           absl::StrCat("Failed to create host rewrite formatter: ", formatter_or.status()));
       return;
     }
-    host_rewrite_formatter_ = std::move(formatter_or).value();
+    host_rewrite_formatter_ = std::move(formatter_or.value());
   }
 
   if (redirect_config_ != nullptr && redirect_config_->path_redirect_has_query_ &&


### PR DESCRIPTION
Commit Message: perf: minor modification to PR #41468 - moving the right object
Additional Description:
Minor change following up on #41468. Performing `std::move` on the value of the StatusOr, rather than on the StatusOr object.

Risk Level: low 
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A