### PR TITLE
ci/bazel: Improve cache priming

### DIFF
--- a/.github/workflows/_request.yml
+++ b/.github/workflows/_request.yml
@@ -28,6 +28,7 @@ on:
         default: |
           WORKSPACE
           **/*.bzl
+          .github/workflows/_request_cache_bazel.yml
       config-file:
         type: string
         default: ./.github/config.yml

--- a/.github/workflows/_request_cache_bazel.yml
+++ b/.github/workflows/_request_cache_bazel.yml
@@ -51,6 +51,19 @@ jobs:
     name: "[${{ inputs.arch }}] Prime Bazel cache"
     if: ${{ ! fromJSON(inputs.caches).bazel[inputs.arch] }}
     steps:
+    - uses: envoyproxy/toolshed/gh-actions/bind-mounts@actions-v0.3.28
+      with:
+        mounts: |
+          - src: /mnt/workspace
+            target: GITHUB_WORKSPACE
+            chown: "runner:runner"
+          - src: /mnt/workspace
+            target: /source
+            chown: "runner:docker"
+          # Simulate container build directory
+          - src: /mnt/build
+            target: /build
+            chown: "runner:docker"
     - uses: envoyproxy/toolshed/gh-actions/github/checkout@actions-v0.3.28
       id: checkout-target
       name: Checkout Envoy repository (target branch)
@@ -71,11 +84,6 @@ jobs:
       with:
         key: ${{ secrets.gcs-cache-key }}
         force-install: ${{ contains(fromJSON('["envoy-arm64-medium", "github-arm64-2c-8gb"]'), inputs.runs-on) }}
-    - run: |
-        # Simulate container build directory
-        sudo mkdir /build
-        sudo chown runner:docker /build
-        echo "GITHUB_TOKEN=${{ github.token }}" >> $GITHUB_ENV
     - uses: envoyproxy/toolshed/gh-actions/cache/prime@actions-v0.3.28
       id: bazel-cache
       name: Prime Bazel cache
@@ -84,11 +92,7 @@ jobs:
         # TODO(phlax): add loop for multiple targets
         command: |
           # Simulate container source directory
-          sudo mkdir /source
-          sudo chown runner:docker /source
           cd /source
-          git clone "$GITHUB_WORKSPACE" .
-
           export BAZEL_BUILD_EXTRA_OPTIONS="--config=ci ${{ inputs.bazel-extra }}"
           export ENVOY_CACHE_ROOT=/build/bazel_root
           export ENVOY_CACHE_TARGETS=$(echo "${{ inputs.targets }}" | sed 's/ / + /g')
@@ -102,3 +106,5 @@ jobs:
         mount-tmpfs: false
         path: /build/bazel_root
         run-as-sudo: false
+      env:
+        GITHUB_TOKEN: ${{ github.token }}

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -321,16 +321,17 @@ case $CI_TARGET in
             echo "ENVOY_CACHE_ROOT not set" >&2
             exit 1
         fi
-        BAZEL_BUILD_OPTIONS=()
         setup_clang_toolchain
         echo "Fetching cache: ${ENVOY_CACHE_TARGETS}"
         bazel --output_user_root="${ENVOY_CACHE_ROOT}" \
               --output_base="${ENVOY_CACHE_ROOT}/base" \
+              --nowrite_command_log \
               aquery "deps(${ENVOY_CACHE_TARGETS})" \
               --repository_cache="${ENVOY_REPOSITORY_CACHE}" \
-              "${BAZEL_BUILD_OPTIONS[@]}" \
               "${BAZEL_BUILD_EXTRA_OPTIONS[@]}" \
               > /dev/null
+          TOTAL_SIZE="$(du -ch "${ENVOY_CACHE_ROOT}" | grep total | tail -n1 | cut -f1)"
+          echo "Generated cache: ${TOTAL_SIZE}"
         ;;
 
     format-api|check_and_fix_proto_format)


### PR DESCRIPTION
This cleanups/improves/optimizes the code, and reduces the size of the client cache by not writing and caching a huge command.log