### PR TITLE
mobile/deps: Bump `robolectric` -> 4.16

### DIFF
--- a/mobile/bazel/envoy_mobile_dependencies.bzl
+++ b/mobile/bazel/envoy_mobile_dependencies.bzl
@@ -87,7 +87,7 @@ def kotlin_dependencies(extra_maven_dependencies = []):
             "androidx.test:runner:1.5.0",
             "androidx.test:monitor:1.5.0",
             "androidx.test.ext:junit:1.1.5",
-            "org.robolectric:robolectric:4.8.2",
+            "org.robolectric:robolectric:4.16",
             "org.hamcrest:hamcrest:3.0",
         ] + extra_maven_dependencies,
         version_conflict_policy = "pinned",

--- a/mobile/bazel/envoy_mobile_repositories.bzl
+++ b/mobile/bazel/envoy_mobile_repositories.bzl
@@ -89,9 +89,9 @@ def kotlin_repos():
 
     http_archive(
         name = "robolectric",
-        sha256 = "5bcde5db598f6938c9887a140a0a1249f95d3c16274d40869503d0c322a20d5d",
-        urls = ["https://github.com/robolectric/robolectric-bazel/archive/4.8.2.tar.gz"],
-        strip_prefix = "robolectric-bazel-4.8.2",
+        sha256 = "cf04b4206b9d21b385e8dbee478fac619fc1344e8e46935dcec2d64939dd0525",
+        urls = ["https://github.com/robolectric/robolectric-bazel/releases/download/4.16/robolectric-bazel-4.16.tar.gz"],
+        strip_prefix = "robolectric-bazel-4.16",
     )
 
 def android_repos():


### PR DESCRIPTION
fixing rules_python hermetics broke ios and android - this update fixes android at least