### PR TITLE
dns: reinitialize c-ares channel on ARES_ETIMEOUT

### DIFF
--- a/api/envoy/extensions/network/dns_resolver/cares/v3/cares_dns_resolver.proto
+++ b/api/envoy/extensions/network/dns_resolver/cares/v3/cares_dns_resolver.proto
@@ -21,7 +21,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // [#extension: envoy.network.dns_resolver.cares]
 
 // Configuration for c-ares DNS resolver.
-// [#next-free-field: 11]
+// [#next-free-field: 12]
 message CaresDnsResolverConfig {
   // A list of DNS resolver addresses.
   // :ref:`use_resolvers_as_fallback <envoy_v3_api_field_extensions.network.dns_resolver.cares.v3.CaresDnsResolverConfig.use_resolvers_as_fallback>`
@@ -99,4 +99,18 @@ message CaresDnsResolverConfig {
   //
   // If not specified, no periodic refresh will be performed.
   google.protobuf.Duration max_udp_channel_duration = 10 [(validate.rules).duration = {gte {}}];
+
+  // If true, reinitialize the c-ares channel when a DNS query fails with ``ARES_ETIMEOUT``.
+  //
+  // This can help recover from rare cases where the UDP sockets held by the c-ares
+  // channel become unusable after timeouts, causing subsequent queries to fail or
+  // Envoy to keep serving stale DNS results. When enabled, a timeout-triggered
+  // reinitialization attempts to restore healthy state quickly. In environments
+  // where timeouts are caused by intermittent network issues, enabling this may
+  // increase channel churn; consider using
+  // :ref:`max_udp_channel_duration <envoy_v3_api_field_extensions.network.dns_resolver.cares.v3.CaresDnsResolverConfig.max_udp_channel_duration>`
+  // for periodic refresh instead.
+  //
+  // Default is false.
+  bool reinit_channel_on_timeout = 11;
 }

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -74,8 +74,8 @@ bug_fixes:
     or ``HttpResponseTrailerMatchInput``, causing the delegated filter to be skipped without error.
 - area: dns
   change: |
-    Fixed c-ares DNS resolver to reinitialize when queries timeout. Previously,
-    timeout errors could leave the resolver unable to perform new lookups.
+    c-ares resolver: add optional ``reinit_channel_on_timeout`` to reinitialize
+    the resolver after DNS timeouts.
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/source/extensions/network/dns_resolver/cares/dns_impl.cc
+++ b/source/extensions/network/dns_resolver/cares/dns_impl.cc
@@ -61,7 +61,7 @@ DnsResolverImpl::DnsResolverImpl(
               ? std::chrono::milliseconds(Protobuf::util::TimeUtil::DurationToMilliseconds(
                     config.max_udp_channel_duration()))
               : std::chrono::milliseconds::zero()),
-      resolvers_csv_(resolvers_csv),
+      reinit_channel_on_timeout_(config.reinit_channel_on_timeout()), resolvers_csv_(resolvers_csv),
       filter_unroutable_families_(config.filter_unroutable_families()),
       scope_(root_scope.createScope("dns.cares.")), stats_(generateCaresDnsResolverStats(*scope_)) {
   AresOptions options = defaultAresOptions();
@@ -252,7 +252,7 @@ void DnsResolverImpl::AddrInfoPendingResolution::onAresGetAddrInfoCallback(
     // If c-ares returns ARES_ECONNREFUSED and there is no fallback we assume that the channel_ is
     // broken and hence we reinitialize it here.
     if (status == ARES_ECONNREFUSED || status == ARES_EREFUSED || status == ARES_ESERVFAIL ||
-        status == ARES_ENOTIMP || status == ARES_ETIMEOUT) {
+        status == ARES_ENOTIMP || (status == ARES_ETIMEOUT && parent_.reinit_channel_on_timeout_)) {
       parent_.reinitializeChannel();
     }
   }

--- a/source/extensions/network/dns_resolver/cares/dns_impl.h
+++ b/source/extensions/network/dns_resolver/cares/dns_impl.h
@@ -206,6 +206,7 @@ private:
   const bool rotate_nameservers_;
   const uint32_t edns0_max_payload_size_;
   const std::chrono::milliseconds max_udp_channel_duration_;
+  const bool reinit_channel_on_timeout_;
   const absl::optional<std::string> resolvers_csv_;
   const bool filter_unroutable_families_;
   Stats::ScopeSharedPtr scope_;

--- a/test/extensions/network/dns_resolver/cares/dns_impl_test.cc
+++ b/test/extensions/network/dns_resolver/cares/dns_impl_test.cc
@@ -733,6 +733,9 @@ public:
       cares.mutable_edns0_max_payload_size()->set_value(getEdns0MaxPayloadSize());
     }
 
+    // Enable `reinit_channel_on_timeout` if requested by the test case.
+    cares.set_reinit_channel_on_timeout(reinitOnTimeout());
+
     // Copy over the dns_resolver_options_.
     cares.mutable_dns_resolver_options()->MergeFrom(dns_resolver_options);
     // setup the typed config
@@ -741,6 +744,8 @@ public:
 
     return typed_dns_resolver_config;
   }
+  // Whether to enable `reinit_channel_on_timeout` in the resolver config for this test.
+  virtual bool reinitOnTimeout() const { return false; }
 
   void SetUp() override {
     // Instantiate TestDnsServer and listen on a random port on the loopback address.
@@ -1958,6 +1963,7 @@ TEST_P(DnsImplFilterUnroutableFamiliesDontFilterTest, DontFilterAllV6) {
 class DnsImplZeroTimeoutTest : public DnsImplTest {
 protected:
   bool queryTimeout() const override { return true; }
+  bool reinitOnTimeout() const override { return true; }
 };
 
 // Parameterize the DNS test server socket address.


### PR DESCRIPTION
Commit Message: dns: reinitialize c-ares channel on ARES_ETIMEOUT

Additional Description::
Add ARES_ETIMEOUT to the list of error conditions that trigger c-ares channel reinitialization. When DNS queries timeout, the c-ares channel can enter a broken state where UDP sockets become unusable and subsequent queries continue to fail. This is similar to ARES_ECONNREFUSED and other connection errors that already trigger reinitialization.

Risk Level: Low

Testing: Updated existing `DnsImplZeroTimeoutTest::Timeout` test to verify channel reinitialization after timeout.

Docs Changes: N/A

Release Notes: Added to changelogs/current.yaml

Platform Specific Features: N/A