### PR TITLE
bazel/luajit: Use bash to configure build

### DIFF
--- a/bazel/foreign_cc/BUILD
+++ b/bazel/foreign_cc/BUILD
@@ -130,7 +130,7 @@ cc_library(
 
 configure_make(
     name = "luajit",
-    configure_command = "build.py",
+    configure_command = "luajit_build.sh",
     env = select({
         # This shouldn't be needed! See
         # https://github.com/envoyproxy/envoy/issues/6084

--- a/bazel/foreign_cc/luajit.patch
+++ b/bazel/foreign_cc/luajit.patch
@@ -1,8 +1,8 @@
 diff --git a/src/Makefile b/src/Makefile
-index 30d64be2..ae7ec875 100644
+index c83abfa0..0276f9e3 100644
 --- a/src/Makefile
 +++ b/src/Makefile
-@@ -27,7 +27,7 @@ NODOTABIVER= 51
+@@ -26,7 +26,7 @@ NODOTABIVER= 51
  DEFAULT_CC = gcc
  #
  # LuaJIT builds as a native 32 or 64 bit binary by default.
@@ -11,7 +11,7 @@ index 30d64be2..ae7ec875 100644
  #
  # Use this if you want to force a 32 bit build on a 64 bit multilib OS.
  #CC= $(DEFAULT_CC) -m32
-@@ -71,10 +71,10 @@ CCWARN= -Wall
+@@ -70,10 +70,10 @@ CCWARN= -Wall
  # as dynamic mode.
  #
  # Mixed mode creates a static + dynamic library and a statically linked luajit.
@@ -24,7 +24,7 @@ index 30d64be2..ae7ec875 100644
  #
  # Dynamic mode creates a dynamic library and a dynamically linked luajit.
  # Note: this executable will only run when the library is installed!
-@@ -99,7 +99,7 @@ XCFLAGS=
+@@ -98,7 +98,7 @@ XCFLAGS=
  # enabled by default. Some other features that *might* break some existing
  # code (e.g. __pairs or os.execute() return values) can be enabled here.
  # Note: this does not provide full compatibility with Lua 5.2 at this time.
@@ -33,79 +33,75 @@ index 30d64be2..ae7ec875 100644
  #
  # Disable the JIT compiler, i.e. turn LuaJIT into a pure interpreter.
  #XCFLAGS+= -DLUAJIT_DISABLE_JIT
-@@ -212,7 +212,7 @@ TARGET_STCC= $(STATIC_CC)
+@@ -211,7 +211,7 @@ TARGET_STCC= $(STATIC_CC)
  TARGET_DYNCC= $(DYNAMIC_CC)
  TARGET_LD= $(CROSS)$(CC)
  TARGET_AR= $(CROSS)ar rcus
 -TARGET_STRIP= $(CROSS)strip
 +TARGET_STRIP?= $(CROSS)strip
-
+ 
  TARGET_LIBPATH= $(or $(PREFIX),/usr/local)/$(or $(MULTILIB),lib)
  TARGET_SONAME= libluajit-$(ABIVER).so.$(MAJVER)
-@@ -598,7 +598,7 @@ endif
-
+@@ -616,7 +616,7 @@ endif
+ 
  Q= @
  E= @echo
 -#Q=
 +Q=
  #E= @:
-
+ 
  ##############################################################################
-diff --git a/build.py b/build.py
+diff --git a/luajit_build.sh b/luajit_build.sh
 new file mode 100755
-index 00000000..1201542c
+index 00000000..3b4f8eca
 --- /dev/null
-+++ b/build.py
-@@ -0,0 +1,52 @@
-+#!/usr/bin/env python3
++++ b/luajit_build.sh
+@@ -0,0 +1,48 @@
++#!/bin/bash
 +
-+import argparse
-+import os
-+import shutil
++set -e
 +
-+def main():
-+    parser = argparse.ArgumentParser()
-+    parser.add_argument("--prefix")
-+    args = parser.parse_args()
-+    src_dir = os.path.dirname(os.path.realpath(__file__))
-+    shutil.copytree(src_dir, os.path.basename(src_dir))
-+    os.chdir(os.path.basename(src_dir))
++PREFIX=""
++while [[ $# -gt 0 ]]; do
++    case $1 in
++        --prefix=*)
++            PREFIX="${1#*=}"
++            shift
++            ;;
++        --prefix)
++            PREFIX="$2"
++            shift 2
++            ;;
++        *)
++            shift
++            ;;
++    esac
++done
 +
-+    os.environ["MACOSX_DEPLOYMENT_TARGET"] = "10.8"
-+    os.environ["DEFAULT_CC"] = os.environ.get("CC", "")
-+    os.environ["TARGET_CFLAGS"] = os.environ.get("CFLAGS", "") + " -fno-function-sections -fno-data-sections"
-+    os.environ["TARGET_LDFLAGS"] = os.environ.get("CFLAGS", "") + " -fno-function-sections -fno-data-sections"
-+    os.environ["CFLAGS"] = ""
-+    os.environ["LDFLAGS"] = ""
++# Copy source tree to a build directory
++SRC_DIR="$(dirname "$(realpath "$0")")"
++BUILD_DIR="$(basename "$SRC_DIR")"
++cp -r "$SRC_DIR" "$BUILD_DIR"
++cd "$BUILD_DIR"
 +
-+    # Don't strip the binary - it doesn't work when cross-compiling, and we don't use it anyway.
-+    os.environ["TARGET_STRIP"] = "@echo"
++# Set environment variables
++export MACOSX_DEPLOYMENT_TARGET="10.8"
++export DEFAULT_CC="${CC:-}"
++export TARGET_CFLAGS="${CFLAGS:-} -fno-function-sections -fno-data-sections"
++export TARGET_LDFLAGS="${CFLAGS:-} -fno-function-sections -fno-data-sections"
++export CFLAGS=""
++export LDFLAGS=""
 +
-+    # Remove LuaJIT from ASAN for now.
-+    # TODO(htuch): Remove this when https://github.com/envoyproxy/envoy/issues/6084 is resolved.
-+    if "ENVOY_CONFIG_ASAN" in os.environ or "ENVOY_CONFIG_MSAN" in os.environ:
-+      os.environ["TARGET_CFLAGS"] += " -fsanitize-blacklist=%s/com_github_luajit_luajit/clang-asan-blocklist.txt" % os.environ["PWD"]
-+      with open("clang-asan-blocklist.txt", "w") as f:
-+        f.write("fun:*\n")
++# Don't strip the binary - it doesn't work when cross-compiling
++export TARGET_STRIP="@echo"
 +
-+    os.system('"{}" -j{} V=1 PREFIX="{}" install'.format(os.environ["MAKE"], os.cpu_count(), args.prefix))
++# Remove LuaJIT from ASAN/MSAN for now
++# TODO(htuch): Remove this when https://github.com/envoyproxy/envoy/issues/6084 is resolved
++if [[ -n "${ENVOY_CONFIG_ASAN}" ]] || [[ -n "${ENVOY_CONFIG_MSAN}" ]]; then
++    BLOCK_PATH=$(realpath clang-asan-blocklist.txt)
++    export TARGET_CFLAGS="${TARGET_CFLAGS} -fsanitize-blacklist=${BLOCK_PATH}"
++    echo "fun:*" > clang-asan-blocklist.txt
++fi
 +
-+def win_main():
-+    src_dir = os.path.dirname(os.path.realpath(__file__))
-+    dst_dir = os.getcwd() + "/luajit"
-+    shutil.copytree(src_dir, os.path.basename(src_dir))
-+    os.chdir(os.path.basename(src_dir) + "/src")
-+    os.system('msvcbuild.bat ' + os.getenv('WINDOWS_DBG_BUILD', '') + ' static')
-+    os.makedirs(dst_dir + "/lib", exist_ok=True)
-+    shutil.copy("lua51.lib", dst_dir + "/lib")
-+    os.makedirs(dst_dir + "/include/luajit-2.1", exist_ok=True)
-+    for header in ["lauxlib.h", "luaconf.h", "lua.h", "lua.hpp", "luajit.h", "lualib.h"]:
-+      shutil.copy(header, dst_dir + "/include/luajit-2.1")
-+    os.makedirs(dst_dir + "/bin", exist_ok=True)
-+    shutil.copy("luajit.exe", dst_dir + "/bin")
-+
-+if os.name == 'nt':
-+  win_main()
-+else:
-+  main()
-+
++# Run make with all available cores
++"${MAKE:-make}" -j$(nproc) V=1 PREFIX="$PREFIX" install

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -920,7 +920,6 @@ def _com_github_luajit_luajit():
         build_file_content = BUILD_ALL_CONTENT,
         patches = ["@envoy//bazel/foreign_cc:luajit.patch"],
         patch_args = ["-p1"],
-        patch_cmds = ["chmod u+x build.py"],
     )
 
 def _com_github_google_tcmalloc():


### PR DESCRIPTION
this currently uses python unnecessarily which relies on a host python being present