### PR TITLE
github/ci: Temp add back diskspace hack for failing format-api job

### DIFF
--- a/.github/workflows/_precheck_format.yml
+++ b/.github/workflows/_precheck_format.yml
@@ -38,6 +38,7 @@ jobs:
       bazel-extra: '--config=remote-envoy-engflow'
       cache-build-image: ${{ fromJSON(inputs.request).request.build-image.default }}
       concurrency-suffix: -${{ matrix.target }}
+      diskspace-hack: ${{ matrix.diskspace-hack || false }}
       gcs-cache-bucket: ${{ inputs.gcs-cache-bucket }}
       request: ${{ inputs.request }}
       error-match: |
@@ -59,3 +60,4 @@ jobs:
         - target: format-api
           upload-name: fix_proto_format.diff
           upload-path: /home/runner/work/_temp/container/fix_proto_format.diff
+          diskspace-hack: true


### PR DESCRIPTION
Its not clear why this has started failing - so as a temp measure we should just force the hack

