### PR TITLE
add JuniorHsu as senior maintainer of thrift

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -78,7 +78,7 @@ without further review.
   * Golang
 * Lizan Zhou ([lizan](https://github.com/lizan)) (lizan.j@gmail.com)
   * Wasm, JWT, gRPC-JSON transcoder
-* JuniorHsu ([juniorhsu](https://github.com/juniorhsu)) (CuveeHsu@gmail.com)
+* Kuo-Chung Hsu ([juniorhsu](https://github.com/juniorhsu)) (CuveeHsu@gmail.com)
   * Thrift
 
 # Envoy security team


### PR DESCRIPTION
Commit Message: add JuniorHsu as senior maintainer of thrift
Additional Description:

@JuniorHsu **is the only active contributor and also been code owner of thrift for a while.** Here is the contribution list from @JuniorHsu https://github.com/envoyproxy/envoy/pulls?q=is%3Apr+author%3AJuniorHsu+is%3Aclosed @JuniorHsu has submitted the highest number of Pull Requests in the Thrift domain to date. 

So, I suggest to add the @JuniorHsu as senior extension maintainer. :) 

NOTE: extension maintainer has no write permission but for extension in scope, the maintainers could treat the approval from extension maintainer as final decision. Of course, the maintainer may still need to take a look to ensure the PR changes is limited in the scope of specific extension and also ensure it's meet the basic code standards.  

 

Risk Level: low.
Testing: n/a.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.