### PR TITLE
composite: support matching on response headers and trailers in composite filter

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -67,6 +67,11 @@ bug_fixes:
     Fixed ``shouldDrainConnectionUponCompletion()`` to properly send ``GOAWAY`` frames for HTTP/2 and HTTP/3
     instead of aggressively closing connections. This prevents response body transmission interruption and
     ``ERR_DRAINING`` errors on the client side. HTTP/1.1 behavior remains unchanged.
+- area: composite
+  change: |
+    Fixed per-route configuration for composite filter to support matching on response headers and trailers.
+    Previously, per-route matchers would silently fail when attempting to match on ``HttpResponseHeaderMatchInput``
+    or ``HttpResponseTrailerMatchInput``, causing the delegated filter to be skipped without error.
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/source/extensions/filters/http/match_delegate/config.cc
+++ b/source/extensions/filters/http/match_delegate/config.cc
@@ -363,6 +363,10 @@ FilterConfigPerRoute::createFilterMatchTree(
   requirements->mutable_data_input_allow_list()->add_type_url(TypeUtil::descriptorFullNameToTypeUrl(
       envoy::type::matcher::v3::HttpRequestHeaderMatchInput::default_instance().GetTypeName()));
   requirements->mutable_data_input_allow_list()->add_type_url(TypeUtil::descriptorFullNameToTypeUrl(
+      envoy::type::matcher::v3::HttpResponseHeaderMatchInput::default_instance().GetTypeName()));
+  requirements->mutable_data_input_allow_list()->add_type_url(TypeUtil::descriptorFullNameToTypeUrl(
+      envoy::type::matcher::v3::HttpResponseTrailerMatchInput::default_instance().GetTypeName()));
+  requirements->mutable_data_input_allow_list()->add_type_url(TypeUtil::descriptorFullNameToTypeUrl(
       xds::type::matcher::v3::HttpAttributesCelMatchInput::default_instance().GetTypeName()));
   Envoy::Http::Matching::HttpFilterActionContext action_context{
       .is_downstream_ = true,

--- a/test/extensions/filters/http/match_delegate/config_test.cc
+++ b/test/extensions/filters/http/match_delegate/config_test.cc
@@ -135,6 +135,74 @@ xds_matcher:
   EXPECT_TRUE(route_config.get());
 }
 
+TEST(MatchWrapper, PerRouteConfigResponseHeaders) {
+  TestFactory test_factory;
+  Envoy::Registry::InjectFactory<Envoy::Server::Configuration::NamedHttpFilterConfigFactory>
+      inject_factory(test_factory);
+
+  const auto yaml = (R"EOF(
+xds_matcher:
+  matcher_tree:
+    input:
+      name: response-headers
+      typed_config:
+        "@type": type.googleapis.com/envoy.type.matcher.v3.HttpResponseHeaderMatchInput
+        header_name: match-response-header
+    exact_match_map:
+        map:
+            match:
+                action:
+                    name: skip
+                    typed_config:
+                        "@type": type.googleapis.com/envoy.extensions.filters.common.matcher.action.v3.SkipFilter
+)EOF");
+
+  MatchDelegateConfig factory;
+  NiceMock<Server::Configuration::MockServerFactoryContext> server_factory_context;
+  envoy::extensions::common::matching::v3::ExtensionWithMatcherPerRoute config;
+  TestUtility::loadFromYamlAndValidate(yaml, config);
+  Router::RouteSpecificFilterConfigConstSharedPtr route_config =
+      factory
+          .createRouteSpecificFilterConfig(config, server_factory_context,
+                                           ProtobufMessage::getNullValidationVisitor())
+          .value();
+  EXPECT_TRUE(route_config.get());
+}
+
+TEST(MatchWrapper, PerRouteConfigResponseTrailers) {
+  TestFactory test_factory;
+  Envoy::Registry::InjectFactory<Envoy::Server::Configuration::NamedHttpFilterConfigFactory>
+      inject_factory(test_factory);
+
+  const auto yaml = (R"EOF(
+xds_matcher:
+  matcher_tree:
+    input:
+      name: response-trailers
+      typed_config:
+        "@type": type.googleapis.com/envoy.type.matcher.v3.HttpResponseTrailerMatchInput
+        header_name: match-response-trailer
+    exact_match_map:
+        map:
+            match:
+                action:
+                    name: skip
+                    typed_config:
+                        "@type": type.googleapis.com/envoy.extensions.filters.common.matcher.action.v3.SkipFilter
+)EOF");
+
+  MatchDelegateConfig factory;
+  NiceMock<Server::Configuration::MockServerFactoryContext> server_factory_context;
+  envoy::extensions::common::matching::v3::ExtensionWithMatcherPerRoute config;
+  TestUtility::loadFromYamlAndValidate(yaml, config);
+  Router::RouteSpecificFilterConfigConstSharedPtr route_config =
+      factory
+          .createRouteSpecificFilterConfig(config, server_factory_context,
+                                           ProtobufMessage::getNullValidationVisitor())
+          .value();
+  EXPECT_TRUE(route_config.get());
+}
+
 TEST(MatchWrapper, DEPRECATED_FEATURE_TEST(WithDeprecatedMatcher)) {
   TestFactory test_factory;
   Envoy::Registry::InjectFactory<Envoy::Server::Configuration::NamedHttpFilterConfigFactory>

--- a/test/extensions/filters/http/match_delegate/match_delegate_integration_test.cc
+++ b/test/extensions/filters/http/match_delegate/match_delegate_integration_test.cc
@@ -97,6 +97,94 @@ TEST_P(MatchDelegateIntegrationTest, PerRouteConfig) {
   EXPECT_EQ("403", response->headers().getStatusValue());
 }
 
+// Verify that per-route config with HttpResponseHeaderMatchInput is accepted and loads correctly.
+TEST_P(MatchDelegateIntegrationTest, PerRouteConfigResponseHeaders) {
+  const std::string per_route_response_header_config = R"EOF(
+      xds_matcher:
+        matcher_tree:
+          input:
+            name: response-headers
+            typed_config:
+              "@type": type.googleapis.com/envoy.type.matcher.v3.HttpResponseHeaderMatchInput
+              header_name: match-response-header
+          exact_match_map:
+            map:
+              match:
+                action:
+                  name: skip
+                  typed_config:
+                    "@type": type.googleapis.com/envoy.extensions.filters.common.matcher.action.v3.SkipFilter
+    )EOF";
+
+  config_helper_.addConfigModifier([&](ConfigHelper::HttpConnectionManager& cm) {
+    auto* vh = cm.mutable_route_config()->mutable_virtual_hosts()->Mutable(0);
+    auto* route = vh->mutable_routes()->Mutable(0);
+    route->mutable_route()->set_cluster("cluster_0");
+    route->mutable_match()->set_prefix("/test");
+    const auto matcher =
+        TestUtility::parseYaml<ExtensionWithMatcherPerRoute>(per_route_response_header_config);
+    Any cfg_any;
+    ASSERT_TRUE(cfg_any.PackFrom(matcher));
+    route->mutable_typed_per_filter_config()->insert(
+        MapPair<std::string, Any>("match_delegate_filter", cfg_any));
+  });
+
+  // initialize() should succeed without throwing an exception.
+  // Before the changes, the response header matcher would be rejected by the allowlist,
+  // causing the match tree to be empty and the filter to be silently skipped.
+  EXPECT_NO_THROW(initialize());
+
+  // Send a basic request to verify the configuration is functional.
+  auto response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
+  ASSERT_TRUE(response->waitForEndStream());
+  // The filter should apply since we're not sending matching response headers from upstream.
+  EXPECT_EQ("403", response->headers().getStatusValue());
+}
+
+// Verify that per-route config with HttpResponseTrailerMatchInput is accepted and loads correctly.
+TEST_P(MatchDelegateIntegrationTest, PerRouteConfigResponseTrailers) {
+  const std::string per_route_response_trailer_config = R"EOF(
+      xds_matcher:
+        matcher_tree:
+          input:
+            name: response-trailers
+            typed_config:
+              "@type": type.googleapis.com/envoy.type.matcher.v3.HttpResponseTrailerMatchInput
+              header_name: match-response-trailer
+          exact_match_map:
+            map:
+              match:
+                action:
+                  name: skip
+                  typed_config:
+                    "@type": type.googleapis.com/envoy.extensions.filters.common.matcher.action.v3.SkipFilter
+    )EOF";
+
+  config_helper_.addConfigModifier([&](ConfigHelper::HttpConnectionManager& cm) {
+    auto* vh = cm.mutable_route_config()->mutable_virtual_hosts()->Mutable(0);
+    auto* route = vh->mutable_routes()->Mutable(0);
+    route->mutable_route()->set_cluster("cluster_0");
+    route->mutable_match()->set_prefix("/test");
+    const auto matcher =
+        TestUtility::parseYaml<ExtensionWithMatcherPerRoute>(per_route_response_trailer_config);
+    Any cfg_any;
+    ASSERT_TRUE(cfg_any.PackFrom(matcher));
+    route->mutable_typed_per_filter_config()->insert(
+        MapPair<std::string, Any>("match_delegate_filter", cfg_any));
+  });
+
+  // initialize() should succeed without throwing an exception.
+  // Before the changes, the response trailer matcher would be rejected by the allowlist,
+  // causing the match tree to be empty and the filter to be silently skipped.
+  EXPECT_NO_THROW(initialize());
+
+  // Send a basic request to verify the configuration is functional.
+  auto response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
+  ASSERT_TRUE(response->waitForEndStream());
+  // The filter should apply since we're not sending matching response trailers from upstream.
+  EXPECT_EQ("403", response->headers().getStatusValue());
+}
+
 } // namespace
 } // namespace MatchDelegate
 } // namespace Http


### PR DESCRIPTION
## Description

This PR fixes per-route configuration for composite filter to support matching on response headers and trailers. 

Previously, per-route matchers would silently fail when attempting to match on ``HttpResponseHeaderMatchInput`` or ``HttpResponseTrailerMatchInput``, causing the delegated filter to be skipped without error.

Fix https://github.com/envoyproxy/envoy/issues/41726

---

**Commit Message:** composite: support matching on response headers and trailers in composite filter
**Additional Description:** Fixes per-route configuration for composite filter to support matching on response headers and trailers. 
**Risk Level:** Low
**Testing:** Added Unit & Integration Tests
**Docs Changes:** Added
**Release Notes:** Added