### PR TITLE
fix: make broken docs-build job succeed

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -71,6 +71,7 @@ common --experimental_allow_tags_propagation
 
 # Python
 common --@rules_python//python/config_settings:bootstrap_impl=script
+common --incompatible_default_to_explicit_init_py
 
 build:linux --copt=-fdebug-types-section
 # Enable position independent code (this is the default on macOS and Windows)


### PR DESCRIPTION
## Description

This PR fixes the broken docs-build job.

https://app.netlify.com/projects/envoy-website/deploys/6901250a7919d300084a3183

---

**Commit Message:** fix: make broken docs-build job succeed
**Additional Description:** Fixes the broken docs-build job.
**Risk Level:** Low
**Testing:** CI
**Docs Changes:** N/A
**Release Notes:** N/A