### PR TITLE
config: parametrize DataSourceProvider with type and transformation callback

### DIFF
--- a/source/common/config/datasource.h
+++ b/source/common/config/datasource.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <functional>
+#include <memory>
+
 #include "envoy/api/api.h"
 #include "envoy/common/random_generator.h"
 #include "envoy/config/core/v3/base.pb.h"
@@ -14,17 +17,17 @@
 #include "source/common/config/remote_data_fetcher.h"
 #include "source/common/init/target_impl.h"
 
+#include "absl/status/statusor.h"
 #include "absl/types/optional.h"
 
 namespace Envoy {
 namespace Config {
 namespace DataSource {
 
-class DataSourceProvider;
+template <typename T> class DataSourceProvider;
 
 using ProtoDataSource = envoy::config::core::v3::DataSource;
 using ProtoWatchedDirectory = envoy::config::core::v3::WatchedDirectory;
-using DataSourceProviderPtr = std::unique_ptr<DataSourceProvider>;
 
 /**
  * Read contents of the file.
@@ -58,11 +61,15 @@ absl::StatusOr<std::string> read(const envoy::config::core::v3::DataSource& sour
  */
 absl::optional<std::string> getPath(const envoy::config::core::v3::DataSource& source);
 
-class DynamicData {
+/**
+ * DynamicData manages thread-local storage for dynamically reloadable data of type T.
+ * The data is watched and automatically updated when the underlying file changes.
+ */
+template <typename T> class DynamicData {
 public:
   struct ThreadLocalData : public ThreadLocal::ThreadLocalObject {
-    ThreadLocalData(std::shared_ptr<std::string> data) : data_(std::move(data)) {}
-    std::shared_ptr<std::string> data_;
+    ThreadLocalData(std::shared_ptr<const T> data) : data_(std::move(data)) {}
+    std::shared_ptr<const T> data_;
   };
 
   DynamicData(DynamicData&&) = default;
@@ -70,7 +77,7 @@ public:
               Filesystem::WatcherPtr watcher);
   ~DynamicData();
 
-  const std::string& data() const;
+  const T& data() const;
 
 private:
   Event::Dispatcher& dispatcher_;
@@ -83,36 +90,175 @@ private:
  * content changes. The watch only works for filename-based DataSource and watched directory
  * is provided explicitly.
  *
+ * The provider is templated on the data type T and accepts a transformation callback that
+ * converts raw string data into the target type. This callback is invoked both on initial
+ * load and on file reload events.
+ *
  * NOTE: This should only be used when the envoy.config.core.v3.DataSource is necessary and
  * file watch is required.
  */
-class DataSourceProvider {
+template <typename T> class DataSourceProvider {
 public:
   /**
-   * Create a DataSourceProvider from a DataSource.
+   * Transformation callback type that converts raw string data to type T.
+   * Returns unique_ptr<const T> for immutable data or error status on failure.
+   */
+  using TransformFn = std::function<absl::StatusOr<std::unique_ptr<const T>>(const std::string&)>;
+
+  /**
+   * Create a DataSourceProvider from a DataSource with data transformation.
    * @param source data source.
    * @param main_dispatcher reference to the main dispatcher.
    * @param tls reference to the thread local slot allocator.
    * @param api reference to the Api.
    * @param allow_empty return an empty string if no DataSource case is specified.
    * @param max_size max size limit of file to read, default 0 means no limit.
+   * @param transform_fn callback to transform raw string data to type T.
    * @return absl::StatusOr<DataSourceProvider> with DataSource contents. or an error
-   * status if any error occurs.
+   * status if any error occurs (including transformation failures).
    * NOTE: If file watch is enabled and the new file content does not meet the
-   * requirements (allow_empty, max_size), the provider will keep the old content.
+   * requirements (allow_empty, max_size) or transformation fails, the provider will
+   * keep the old content.
    */
-  static absl::StatusOr<DataSourceProviderPtr>
+  static absl::StatusOr<std::unique_ptr<DataSourceProvider<T>>>
   create(const ProtoDataSource& source, Event::Dispatcher& main_dispatcher,
-         ThreadLocal::SlotAllocator& tls, Api::Api& api, bool allow_empty, uint64_t max_size = 0);
+         ThreadLocal::SlotAllocator& tls, Api::Api& api, bool allow_empty, uint64_t max_size,
+         TransformFn transform_fn);
 
-  const std::string& data() const;
+  const T& data() const;
 
 private:
-  DataSourceProvider(std::string&& data) : data_(std::move(data)) {}
-  DataSourceProvider(DynamicData&& data) : data_(std::move(data)) {}
+  DataSourceProvider(std::unique_ptr<const T> data) : data_(std::move(data)) {}
+  DataSourceProvider(DynamicData<T>&& data) : data_(std::move(data)) {}
 
-  absl::variant<std::string, DynamicData> data_;
+  absl::variant<std::unique_ptr<const T>, DynamicData<T>> data_;
 };
+
+/**
+ * Type alias for string-based DataSourceProvider.
+ */
+using DataSourceProviderPtr = std::unique_ptr<DataSourceProvider<std::string>>;
+
+/**
+ * Helper function to create a string-based DataSourceProvider.
+ * This uses an identity transformation that wraps the string in a unique_ptr.
+ * @param source data source.
+ * @param main_dispatcher reference to the main dispatcher.
+ * @param tls reference to the thread local slot allocator.
+ * @param api reference to the Api.
+ * @param allow_empty return an empty string if no DataSource case is specified.
+ * @param max_size max size limit of file to read, default 0 means no limit.
+ * @return absl::StatusOr<DataSourceProvider<std::string>> with DataSource contents.
+ */
+absl::StatusOr<DataSourceProviderPtr>
+createStringDataSourceProvider(const ProtoDataSource& source, Event::Dispatcher& main_dispatcher,
+                               ThreadLocal::SlotAllocator& tls, Api::Api& api, bool allow_empty,
+                               uint64_t max_size = 0);
+
+// Template implementations.
+
+template <typename T>
+DynamicData<T>::DynamicData(Event::Dispatcher& main_dispatcher,
+                            ThreadLocal::TypedSlotPtr<ThreadLocalData> slot,
+                            Filesystem::WatcherPtr watcher)
+    : dispatcher_(main_dispatcher), slot_(std::move(slot)), watcher_(std::move(watcher)) {}
+
+template <typename T> DynamicData<T>::~DynamicData() {
+  if (!dispatcher_.isThreadSafe()) {
+    dispatcher_.post([to_delete = std::move(slot_)] {});
+  }
+}
+
+template <typename T> const T& DynamicData<T>::data() const {
+  const auto thread_local_data = slot_->get();
+  ASSERT(thread_local_data.has_value() && thread_local_data->data_,
+         "DynamicData accessed before initialization");
+  return *thread_local_data->data_;
+}
+
+template <typename T> const T& DataSourceProvider<T>::data() const {
+  if (absl::holds_alternative<std::unique_ptr<const T>>(data_)) {
+    return *absl::get<std::unique_ptr<const T>>(data_);
+  }
+  return absl::get<DynamicData<T>>(data_).data();
+}
+
+template <typename T>
+absl::StatusOr<std::unique_ptr<DataSourceProvider<T>>>
+DataSourceProvider<T>::create(const ProtoDataSource& source, Event::Dispatcher& main_dispatcher,
+                              ThreadLocal::SlotAllocator& tls, Api::Api& api, bool allow_empty,
+                              uint64_t max_size, TransformFn transform_fn) {
+  auto initial_data_or_error = read(source, allow_empty, api, max_size);
+  RETURN_IF_NOT_OK_REF(initial_data_or_error.status());
+
+  // read() only validates the size of the file and does not check the size of inline data.
+  // We check the size of inline data here.
+  // TODO(wbpcode): consider moving this check to read() to avoid duplicate checks.
+  if (max_size > 0 && initial_data_or_error.value().length() > max_size) {
+    return absl::InvalidArgumentError(fmt::format("response body size is {} bytes; maximum is {}",
+                                                  initial_data_or_error.value().length(),
+                                                  max_size));
+  }
+
+  // Apply the transformation to the initial data.
+  auto transformed_data_or_error = transform_fn(initial_data_or_error.value());
+  RETURN_IF_NOT_OK(transformed_data_or_error.status());
+
+  if (!source.has_watched_directory() ||
+      source.specifier_case() != envoy::config::core::v3::DataSource::kFilename) {
+    return std::unique_ptr<DataSourceProvider<T>>(
+        new DataSourceProvider<T>(std::move(transformed_data_or_error).value()));
+  }
+
+  auto slot = ThreadLocal::TypedSlot<typename DynamicData<T>::ThreadLocalData>::makeUnique(tls);
+  auto initial_data_shared = std::shared_ptr<const T>(std::move(transformed_data_or_error).value());
+  slot->set([initial_data_shared](Event::Dispatcher&) {
+    return std::make_shared<typename DynamicData<T>::ThreadLocalData>(initial_data_shared);
+  });
+
+  const auto& filename = source.filename();
+  auto watcher = main_dispatcher.createFilesystemWatcher();
+  // DynamicData will ensure that the watcher is destroyed before the slot is destroyed.
+  // TODO(wbpcode): use Config::WatchedDirectory instead of directly creating a watcher
+  // if the Config::WatchedDirectory is exception-free in the future.
+  // Capture transform_fn by value to ensure it remains valid for the lifetime of the watcher.
+  auto watcher_status = watcher->addWatch(
+      absl::StrCat(source.watched_directory().path(), "/"), Filesystem::Watcher::Events::MovedTo,
+      [slot_ptr = slot.get(), &api, filename, allow_empty, max_size,
+       transform_fn](uint32_t) -> absl::Status {
+        auto new_data_or_error = readFile(filename, api, allow_empty, max_size);
+        if (!new_data_or_error.ok()) {
+          // Log an error but don't fail the watch to avoid throwing EnvoyException at runtime.
+          ENVOY_LOG_TO_LOGGER(Logger::Registry::getLog(Logger::Id::config), error,
+                              "Failed to read file: {}", new_data_or_error.status().message());
+          return absl::OkStatus();
+        }
+
+        // Apply transformation to the new data.
+        auto transformed_new_data_or_error = transform_fn(new_data_or_error.value());
+        if (!transformed_new_data_or_error.ok()) {
+          // Log an error but don't fail the watch; keep the old data.
+          ENVOY_LOG_TO_LOGGER(Logger::Registry::getLog(Logger::Id::config), error,
+                              "Failed to transform reloaded data: {}",
+                              transformed_new_data_or_error.status().message());
+          return absl::OkStatus();
+        }
+
+        auto new_data_shared =
+            std::shared_ptr<const T>(std::move(transformed_new_data_or_error).value());
+        slot_ptr->runOnAllThreads(
+            [new_data_shared](OptRef<typename DynamicData<T>::ThreadLocalData> obj) {
+              if (obj.has_value()) {
+                obj->data_ = new_data_shared;
+              }
+            });
+        return absl::OkStatus();
+      });
+  RETURN_IF_NOT_OK(watcher_status);
+
+  return std::unique_ptr<DataSourceProvider<T>>(new DataSourceProvider<T>(
+      DynamicData<T>(main_dispatcher, std::move(slot), std::move(watcher))));
+}
 
 } // namespace DataSource
 } // namespace Config

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -517,7 +517,7 @@ RouteEntryImplBase::RouteEntryImplBase(const CommonVirtualHostSharedPtr& vhost,
                                                      : RetryPolicyImpl::DefaultRetryPolicy;
 
   if (route.has_direct_response() && route.direct_response().has_body()) {
-    auto provider_or_error = Envoy::Config::DataSource::DataSourceProvider::create(
+    auto provider_or_error = Envoy::Config::DataSource::createStringDataSourceProvider(
         route.direct_response().body(), factory_context.mainThreadDispatcher(),
         factory_context.threadLocal(), factory_context.api(), true,
         vhost_->globalRouteConfig().maxDirectResponseBodySizeBytes());

--- a/source/extensions/common/aws/credential_providers/credentials_file_credentials_provider.cc
+++ b/source/extensions/common/aws/credential_providers/credentials_file_credentials_provider.cc
@@ -16,7 +16,7 @@ CredentialsFileCredentialsProvider::CredentialsFileCredentialsProvider(
     : context_(context), profile_("") {
 
   if (credential_file_config.has_credentials_data_source()) {
-    auto provider_or_error_ = Config::DataSource::DataSourceProvider::create(
+    auto provider_or_error_ = Config::DataSource::createStringDataSourceProvider(
         credential_file_config.credentials_data_source(), context.mainThreadDispatcher(),
         context.threadLocal(), context.api(), false, 4096);
     if (provider_or_error_.ok()) {

--- a/source/extensions/common/aws/credential_providers/iam_roles_anywhere_x509_credentials_provider.cc
+++ b/source/extensions/common/aws/credential_providers/iam_roles_anywhere_x509_credentials_provider.cc
@@ -40,7 +40,7 @@ absl::Status IAMRolesAnywhereX509CredentialsProvider::initialize() {
 
   absl::Status status = absl::InvalidArgumentError("IAM Roles Anywhere will not be enabled");
 
-  auto provider_or_error = Config::DataSource::DataSourceProvider::create(
+  auto provider_or_error = Config::DataSource::createStringDataSourceProvider(
       certificate_data_source_, context_.mainThreadDispatcher(), context_.threadLocal(),
       context_.api(), false, X509_CERTIFICATE_MAX_BYTES);
   if (provider_or_error.ok()) {
@@ -53,7 +53,7 @@ absl::Status IAMRolesAnywhereX509CredentialsProvider::initialize() {
   }
 
   if (certificate_chain_data_source_.has_value()) {
-    auto chain_provider_or_error_ = Config::DataSource::DataSourceProvider::create(
+    auto chain_provider_or_error_ = Config::DataSource::createStringDataSourceProvider(
         certificate_chain_data_source_.value(), context_.mainThreadDispatcher(),
         context_.threadLocal(), context_.api(), false, X509_CERTIFICATE_MAX_BYTES * 5);
     if (chain_provider_or_error_.ok()) {
@@ -67,7 +67,7 @@ absl::Status IAMRolesAnywhereX509CredentialsProvider::initialize() {
     certificate_chain_data_source_provider_ = absl::nullopt;
   }
 
-  auto pkey_provider_or_error_ = Config::DataSource::DataSourceProvider::create(
+  auto pkey_provider_or_error_ = Config::DataSource::createStringDataSourceProvider(
       private_key_data_source_, context_.mainThreadDispatcher(), context_.threadLocal(),
       context_.api(), false, X509_PRIVATE_KEY_MAX_BYTES);
   if (pkey_provider_or_error_.ok()) {

--- a/source/extensions/common/aws/credential_providers/webidentity_credentials_provider.cc
+++ b/source/extensions/common/aws/credential_providers/webidentity_credentials_provider.cc
@@ -23,7 +23,7 @@ WebIdentityCredentialsProvider::WebIdentityCredentialsProvider(
       role_arn_(web_identity_config.role_arn()),
       role_session_name_(web_identity_config.role_session_name()) {
 
-  auto provider_or_error_ = Config::DataSource::DataSourceProvider::create(
+  auto provider_or_error_ = Config::DataSource::createStringDataSourceProvider(
       web_identity_config.web_identity_token_data_source(), context.mainThreadDispatcher(),
       context.threadLocal(), context.api(), false, 4096);
   if (provider_or_error_.ok()) {


### PR DESCRIPTION
## Description

This change parametrizes `DataSourceProvider` to support custom data types and transformation callbacks. This would help enable automatic data parsing and transformation during file reloads.

Fix https://github.com/envoyproxy/envoy/issues/41623

---

**Commit Message:** config: parametrize DataSourceProvider with type and transformation callback
**Additional Description:** Parametrizes `DataSourceProvider` to support custom data types and transformation callbacks.
**Risk Level:** Low
**Testing:** Added Tests
**Docs Changes:** N/A
**Release Notes:** N/A