### PR TITLE
ci/spelling: Use bazel to run the tool

### DIFF
--- a/ci/format_pre.sh
+++ b/ci/format_pre.sh
@@ -56,7 +56,7 @@ CURRENT=configs
 bazel "${BAZEL_STARTUP_OPTIONS[@]}" run "${BAZEL_BUILD_OPTIONS[@]}" //configs:example_configs_validation
 
 CURRENT=spelling
-"${ENVOY_SRCDIR}/tools/spelling/check_spelling_pedantic.py" --mark check
+bazel "${BAZEL_STARTUP_OPTIONS[@]}" run "${BAZEL_BUILD_OPTIONS[@]}" //tools/spelling:check_spelling_pedantic -- --mark check --target_root="$PWD"
 
 CURRENT=check_format
 bazel "${BAZEL_STARTUP_OPTIONS[@]}" run "${BAZEL_BUILD_OPTIONS[@]}" //tools/code_format:check_format -- fix --fail_on_diff

--- a/tools/local_fix_format.sh
+++ b/tools/local_fix_format.sh
@@ -73,7 +73,7 @@ format_some () {
 
     if [[ "$use_bazel" == "1" ]]; then
         bazel run //tools/code_format:check_format fix "$@"
-        ./tools/spelling/check_spelling_pedantic.py fix "$@"
+        bazel run //tools/spelling:check_spelling_pedantic fix "$@"
     else
       for arg in "$@"; do
           ./tools/code_format/check_format.py \
@@ -91,7 +91,7 @@ function format_all() {
       set -x
     fi
     bazel run //tools/code_format:check_format -- fix
-    ./tools/spelling/check_spelling_pedantic.py fix
+    bazel run //tools/spelling:check_spelling_pedantic -- fix --target_root="$PWD"
   )
 }
 

--- a/tools/spelling/BUILD
+++ b/tools/spelling/BUILD
@@ -1,0 +1,12 @@
+load("@rules_python//python:defs.bzl", "py_binary")
+
+licenses(["notice"])  # Apache 2
+
+py_binary(
+    name = "check_spelling_pedantic",
+    srcs = ["check_spelling_pedantic.py"],
+    data = [":spelling_dictionary.txt"],
+    env = {
+        "ASPELL_DICT": "$(location :spelling_dictionary.txt)",
+    },
+)


### PR DESCRIPTION
this could do with a lot more cleaning up and is non-hermetic - but at least shifting it to bazel means it uses the hermetic python interpreter