### PR TITLE
docs: Clarify :path pseudo-header includes query parameters

### DIFF
--- a/docs/root/configuration/http/http_conn_man/headers.rst
+++ b/docs/root/configuration/http/http_conn_man/headers.rst
@@ -36,8 +36,8 @@ The ``:scheme`` header will be used by Envoy over ``x-forwarded-proto`` where th
 -----
 
 The ``:path`` header is a pseudo-header populated by Envoy using the value of the path of the HTTP
-request. E.g. an HTTP request of the form ``GET /docs/thing HTTP/1.1`` would have a ``:path`` value
-of ``/docs/thing``.
+request, including query parameters. E.g. an HTTP request of the form ``GET /docs/thing HTTP/1.1``
+would have a ``:path`` value of ``/docs/thing``.
 
 :method
 -------


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: docs: Clarify :path pseudo-header includes query parameters

Additional Description:  Since, after https://github.com/envoyproxy/envoy/issues/7583#issuecomment-519305691, Envoy's `:path` corresponds with HTTP/2 pseud-headers, it may be sensible this document refers readers to the [Request Pseudo-Header Fields](https://datatracker.ietf.org/doc/html/rfc7540#section-8.1.2.3) for more complete explanation.

Risk Level: low
Testing: not necessary
Docs Changes: necessary
Release Notes: not necessary
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
