### PR TITLE
api/tools: Run pcap test no-remote-exec

### DIFF
--- a/api/tools/BUILD
+++ b/api/tools/BUILD
@@ -19,7 +19,10 @@ py_test(
     ],
     # Don't run this by default, since we don't want to force local dependency on Wireshark/tshark,
     # will explicitly invoke in CI.
-    tags = ["manual"],
+    tags = [
+        "manual",
+        "no-remote-exec",
+    ],
     visibility = ["//visibility:public"],
     deps = [":tap2pcap"],
 )


### PR DESCRIPTION
this allows us to not include wireshark in the worker containers