### PR TITLE
[WIP] bazel: Remove unused stdlib flag

### DIFF
--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -68,14 +68,6 @@ genrule(
     stamp = 1,
 )
 
-cc_library(
-    name = "static_stdlib",
-    linkopts = select({
-        "//bazel:linux": ["-static-libgcc"],
-        "//conditions:default": [],
-    }),
-)
-
 config_setting(
     name = "windows_opt_build",
     values = {

--- a/bazel/envoy_binary.bzl
+++ b/bazel/envoy_binary.bzl
@@ -7,7 +7,6 @@ load(
     "envoy_exported_symbols_input",
     "envoy_external_dep_path",
     "envoy_select_exported_symbols",
-    "envoy_stdlib_deps",
     "tcmalloc_external_dep",
 )
 
@@ -41,7 +40,7 @@ def envoy_cc_binary(
         linkopts = linkopts + _envoy_stamped_linkopts()
         deps = deps + _envoy_stamped_deps()
     linkopts += envoy_dbg_linkopts()
-    deps = deps + [envoy_external_dep_path(dep) for dep in external_deps] + envoy_stdlib_deps()
+    deps = deps + [envoy_external_dep_path(dep) for dep in external_deps]
     native.cc_binary(
         name = name,
         srcs = srcs,

--- a/bazel/envoy_internal.bzl
+++ b/bazel/envoy_internal.bzl
@@ -161,11 +161,6 @@ def envoy_select_force_libcpp(if_libcpp, default = None):
         "//conditions:default": default or [],
     })
 
-def envoy_stdlib_deps():
-    return select({
-        "//conditions:default": ["@envoy//bazel:static_stdlib"],
-    })
-
 def envoy_dbg_linkopts():
     return select({
         # TODO: Remove once we have https://github.com/bazelbuild/bazel/pull/15635

--- a/bazel/envoy_test.bzl
+++ b/bazel/envoy_test.bzl
@@ -13,7 +13,6 @@ load(
     "envoy_linkstatic",
     "envoy_select_exported_symbols",
     "envoy_select_force_libcpp",
-    "envoy_stdlib_deps",
     "tcmalloc_external_dep",
 )
 load(":envoy_library.bzl", "tcmalloc_external_deps")
@@ -104,7 +103,7 @@ def envoy_cc_fuzz_test(
     envoy_cc_test_library(
         name = test_lib_name,
         exec_properties = exec_properties,
-        deps = deps + envoy_stdlib_deps() + [
+        deps = deps + [
             repository + "//test/fuzz:fuzz_runner_lib",
             repository + "//test/test_common:test_version_linkstamp",
         ],
@@ -187,7 +186,7 @@ def envoy_cc_test(
         linkopts = _envoy_test_linkopts() + linkopts,
         linkstatic = envoy_linkstatic(),
         malloc = tcmalloc_external_dep(repository),
-        deps = envoy_stdlib_deps() + deps + [envoy_external_dep_path(dep) for dep in external_deps] + [
+        deps = deps + [envoy_external_dep_path(dep) for dep in external_deps] + [
             repository + "//test:main",
             repository + "//test/test_common:test_version_linkstamp",
             "@com_google_googletest//:gtest",


### PR DESCRIPTION
im not clear what this is doing - i think nothing - using the hermetic llvm toolchain it streams unused flag warnings.

