### PR TITLE
dynamic_modules: mark EnvoyHttpFilterScheduler as Sync since it's threadsafe

### DIFF
--- a/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
@@ -1999,8 +1999,10 @@ impl EnvoyHttpFilterImpl {
 /// Since this is primarily designed to be used from a different thread than the one
 /// where the [`HttpFilter`] instance was created, it is marked as `Send` so that
 /// the [`Box<dyn EnvoyHttpFilterScheduler>`] can be sent across threads.
+///
+/// It is also safe to be called concurrently, so it is marked as `Sync` as well.
 #[automock]
-pub trait EnvoyHttpFilterScheduler: Send {
+pub trait EnvoyHttpFilterScheduler: Send + Sync {
   /// Commit the scheduled event to the worker thread where [`HttpFilter`] is running.
   ///
   /// It accepts an `event_id` which can be used to distinguish different events
@@ -2019,6 +2021,7 @@ struct EnvoyHttpFilterSchedulerImpl {
 }
 
 unsafe impl Send for EnvoyHttpFilterSchedulerImpl {}
+unsafe impl Sync for EnvoyHttpFilterSchedulerImpl {}
 
 impl Drop for EnvoyHttpFilterSchedulerImpl {
   fn drop(&mut self) {


### PR DESCRIPTION
Commit Message: dynamic_modules: mark EnvoyHttpFilterScheduler as Sync since it's threadsafe
Additional Description:

I noticed the dispatcher seems to be thread-safe

https://github.com/envoyproxy/envoy/blob/d45e365e78ae391d4617d8b58236dbe67f8ebb28/source/common/event/dispatcher_impl.cc#L266

So it should be fine to mark the scheduler in dynamic modules as `Sync`. This would allow sharing it with `Arc` instead of having to use `new_scheduler` multiple times as I currently need to do.

Risk Level: Low
Testing: Unit tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: None