### PR TITLE
Get rid of the `runtime-cpu` tag

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -64,8 +64,6 @@ build --incompatible_enforce_config_setting_visibility
 test --test_verbose_timeout_warnings
 test --experimental_ui_max_stdouterr_bytes=11712829 #default 1048576
 
-test --test_tag_filters=-runtime-cpu
-
 # Allow tags to influence execution requirements
 common --experimental_allow_tags_propagation
 
@@ -148,7 +146,7 @@ build:asan-common --config=sanitizer
 build:asan-common --define signal_trace=disabled
 build:asan-common --define ENVOY_CONFIG_ASAN=1
 build:asan-common --build_tag_filters=-no_san
-build:asan-common --test_tag_filters=-no_san,-runtime-cpu
+build:asan-common --test_tag_filters=-no_san
 build:asan-common --copt -fsanitize=address,undefined
 build:asan-common --linkopt -fsanitize=address,undefined
 # vptr and function sanitizer are enabled in asan if it is set up via bazel/setup_clang.sh.
@@ -199,7 +197,7 @@ build:tsan --copt -fsanitize=thread
 build:tsan --linkopt -fsanitize=thread
 build:tsan --copt -DTHREAD_SANITIZER=1
 build:tsan --build_tag_filters=-no_san,-no_tsan
-build:tsan --test_tag_filters=-no_san,-no_tsan,-runtime-cpu
+build:tsan --test_tag_filters=-no_san,-no_tsan
 # Needed due to https://github.com/libevent/libevent/issues/777
 build:tsan --copt -DEVENT__DISABLE_DEBUG_MODE
 # https://github.com/abseil/abseil-cpp/issues/760
@@ -211,7 +209,7 @@ build:tsan --test_timeout=120,600,1500,4800
 build:msan --action_env=ENVOY_MSAN=1
 build:msan --config=sanitizer
 build:msan --build_tag_filters=-no_san
-build:msan --test_tag_filters=-no_san,-runtime-cpu
+build:msan --test_tag_filters=-no_san
 build:msan --define ENVOY_CONFIG_MSAN=1
 build:msan --copt -fsanitize=memory
 build:msan --linkopt -fsanitize=memory
@@ -272,10 +270,10 @@ build:coverage --coverage_report_generator=@envoy//tools/coverage:report_generat
 
 build:test-coverage --test_arg="-l trace"
 build:test-coverage --test_arg="--log-path /dev/null"
-build:test-coverage --test_tag_filters=-nocoverage,-fuzz_target,-runtime-cpu
+build:test-coverage --test_tag_filters=-nocoverage,-fuzz_target
 build:fuzz-coverage --config=plain-fuzzer
 build:fuzz-coverage --run_under=@envoy//bazel/coverage:fuzz_coverage_wrapper.sh
-build:fuzz-coverage --test_tag_filters=-nocoverage,-runtime-cpu
+build:fuzz-coverage --test_tag_filters=-nocoverage
 # Existing fuzz tests don't need a full WASM runtime and in generally we don't really want to
 # fuzz dependencies anyways. On the other hand, disabling WASM reduces the build time and
 # resources required to build and run the tests.

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -391,7 +391,7 @@ case $CI_TARGET in
             --define wasm=wamr \
             -c fastbuild \
             "${TEST_TARGETS[@]}" \
-            --test_tag_filters=-nofips,-runtime-cpu \
+            --test_tag_filters=-nofips \
             --build_tests_only
         echo "Building and testing with wasm=wasmtime: and admin_functionality and admin_html disabled ${TEST_TARGETS[*]}"
         bazel_with_collection \
@@ -401,7 +401,7 @@ case $CI_TARGET in
             --define admin_functionality=disabled \
             -c fastbuild \
             "${TEST_TARGETS[@]}" \
-            --test_tag_filters=-nofips,-runtime-cpu \
+            --test_tag_filters=-nofips \
             --build_tests_only
         # "--define log_debug_assert_in_release=enabled" must be tested with a release build, so run only
         # these tests under "-c opt" to save time in CI.
@@ -453,7 +453,6 @@ case $CI_TARGET in
         fi
         setup_clang_toolchain
         bazel test \
-              --test_tag_filters=runtime-cpu \
               "${BAZEL_BUILD_OPTIONS[@]}" \
               //test/server:cgroup_cpu_simple_integration_test
         ;;

--- a/test/server/BUILD
+++ b/test/server/BUILD
@@ -303,7 +303,7 @@ envoy_cc_test(
     tags = [
         # This test requires Docker with CPU limits (--cpus=2) to properly test 'cgroup' detection.
         # Run locally with `ENVOY_DOCKER_CPUS=2 ./ci/run_envoy_docker.sh ./ci/do_ci.sh cpu-detection
-        "runtime-cpu",
+        "manual",
         "no-remote",
     ],
     deps = [

--- a/test/server/cgroup_cpu_simple_integration_test.cc
+++ b/test/server/cgroup_cpu_simple_integration_test.cc
@@ -14,7 +14,7 @@ namespace {
 #ifdef __linux__
 
 // This test runs in CI with Docker CPU limits (--cpus=2) to verify 'cgroups' detection.
-// Tagged 'runtime-cpu' to run only in controlled environments with CPU limits.
+// Tagged 'manual' to run only in controlled environments with CPU limits.
 // Tests basic cgroup detection without heavy server integration dependencies.
 class CgroupCpuSimpleIntegrationTest : public testing::Test {};
 


### PR DESCRIPTION
Instead, tag the test as `manual`, without any loss of functionality.
