### PR TITLE
Oncall: update Dan's opsgenie

### DIFF
--- a/reviewers.yaml
+++ b/reviewers.yaml
@@ -17,6 +17,7 @@ daixiang0:
   slack: U020CJG6UU8
 danzh2010:
   maintainer: true
+  opsgenie: Dan
   slack: UDR2MA31P
 ggreenway:
   maintainer: true


### PR DESCRIPTION
Commit Message: Oncall: update Dan's opsgenie
Additional Description:
Followup to #41847. Fixed another maintainer missing opsgenie.

Risk Level: low 
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A