### PR TITLE
test/dynamic: mark `BodyCallbacksFilter` test helpers as test-only

### DIFF
--- a/test/extensions/dynamic_modules/test_data/rust/http.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/http.rs
@@ -695,6 +695,7 @@ struct BodyCallbacksFilter {
   response_body: Vec<u8>,
 }
 
+#[cfg(test)]
 impl BodyCallbacksFilter {
   fn get_final_read_request_body<'a>(&'a self) -> &'a Vec<u8> {
     &self.request_body


### PR DESCRIPTION
and quieten unused methods warning

