### PR TITLE
Improve internal redirect logging

### DIFF
--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -1995,11 +1995,11 @@ bool Filter::setupRedirect(const Http::ResponseHeaderMap& headers) {
   // convertRequestHeadersForInternalRedirect logs failure reasons but log
   // details for other failure modes here.
   if (!downstream_end_stream_) {
-    ENVOY_STREAM_LOG(trace, "Internal redirect failed: request incomplete", *callbacks_);
+    ENVOY_STREAM_LOG(debug, "Internal redirect failed: request incomplete", *callbacks_);
   } else if (request_buffer_overflowed_) {
-    ENVOY_STREAM_LOG(trace, "Internal redirect failed: request body overflow", *callbacks_);
+    ENVOY_STREAM_LOG(debug, "Internal redirect failed: request body overflow", *callbacks_);
   } else if (location == nullptr) {
-    ENVOY_STREAM_LOG(trace, "Internal redirect failed: missing location header", *callbacks_);
+    ENVOY_STREAM_LOG(debug, "Internal redirect failed: missing location header", *callbacks_);
   }
 
   cluster_->trafficStats()->upstream_internal_redirect_failed_total_.inc();


### PR DESCRIPTION
Before this, internal redirect *successes* were logged at debug, while the *failures* were logged at trace. Since the failures are the ones that people are more likely to want to find, they should at least be at debug, not trace.

Commit Message: Improve internal redirect logging
Additional Description:
Before this, internal redirect *successes* were logged at debug, while the *failures* were logged at trace. Since the failures are the ones that people are more likely to want to find, they should at least be at debug, not trace.

Risk Level: low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
