### PR TITLE
docs: Add netns to well known filter state object

### DIFF
--- a/docs/root/configuration/advanced/well_known_filter_state.rst
+++ b/docs/root/configuration/advanced/well_known_filter_state.rst
@@ -81,6 +81,9 @@ The following lists the filter state object keys used by the Envoy extensions:
   <envoy_v3_api_field_service.ratelimit.v3.RateLimitRequest.hits_addend>` override on a per-route basis.
   Accepts a number string as a constructor.
 
+``envoy.network.network_namespace``
+  Contains the value of the downstream connection's Linux network namespace if it differs from the default.
+
 Filter state object fields
 --------------------------
 


### PR DESCRIPTION
#41799 made it so that the Linux network namespace of downstream connections would be populated into the filter state, but it did not add the key to the list of well-known objects.