### PR TITLE
quic: Wrap `quic_core_types_lib` with `envoy_quic_cc_library`

### DIFF
--- a/bazel/external/quiche.BUILD
+++ b/bazel/external/quiche.BUILD
@@ -4233,7 +4233,7 @@ envoy_quic_cc_library(
     ],
 )
 
-envoy_cc_library(
+envoy_quic_cc_library(
     name = "quic_core_types_lib",
     srcs = [
         "quiche/quic/core/quic_connection_id.cc",
@@ -4245,10 +4245,7 @@ envoy_cc_library(
         "quiche/quic/core/quic_packet_number.h",
         "quiche/quic/core/quic_types.h",
     ],
-    copts = quiche_copts,
     external_deps = ["ssl"],
-    repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         ":quic_core_crypto_random_lib",
         ":quic_core_error_codes_lib",


### PR DESCRIPTION
So it is skipped when http3 is disabled.
