### PR TITLE
quic: Wrap some libs with `envoy_quic_cc_library`

### DIFF
--- a/bazel/external/quiche.BUILD
+++ b/bazel/external/quiche.BUILD
@@ -1810,13 +1810,10 @@ envoy_quic_cc_library(
     ],
 )
 
-envoy_cc_library(
+envoy_quic_cc_library(
     name = "quic_core_bandwidth_lib",
     srcs = ["quiche/quic/core/quic_bandwidth.cc"],
     hdrs = ["quiche/quic/core/quic_bandwidth.h"],
-    copts = quiche_copts,
-    repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         ":quic_core_constants_lib",
         ":quic_core_time_lib",
@@ -2381,13 +2378,10 @@ envoy_quic_cc_library(
     ],
 )
 
-envoy_cc_library(
+envoy_quic_cc_library(
     name = "quic_core_constants_lib",
     srcs = ["quiche/quic/core/quic_constants.cc"],
     hdrs = ["quiche/quic/core/quic_constants.h"],
-    copts = quiche_copts,
-    repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         ":quic_core_types_lib",
         ":quic_platform_export",
@@ -2876,7 +2870,7 @@ envoy_quic_cc_library(
     ],
 )
 
-envoy_cc_library(
+envoy_quic_cc_library(
     name = "quic_core_frames_frames_lib",
     srcs = [
         "quiche/quic/core/frames/quic_ack_frame.cc",
@@ -2934,15 +2928,12 @@ envoy_cc_library(
         "quiche/quic/core/frames/quic_streams_blocked_frame.h",
         "quiche/quic/core/frames/quic_window_update_frame.h",
     ],
-    copts = quiche_copts,
     # TODO: Work around initializer in anonymous union in fastbuild build.
     # Remove this after upstream fix.
     defines = select({
         "@envoy//bazel:windows_x86_64": ["QUIC_FRAME_DEBUG=0"],
         "//conditions:default": [],
     }),
-    repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         ":quic_core_constants_lib",
         ":quic_core_error_codes_lib",
@@ -3517,7 +3508,7 @@ envoy_cc_library(
     ],
 )
 
-envoy_cc_library(
+envoy_quic_cc_library(
     name = "quic_core_packets_lib",
     srcs = [
         "quiche/quic/core/quic_packets.cc",
@@ -3527,9 +3518,6 @@ envoy_cc_library(
         "quiche/quic/core/quic_packets.h",
         "quiche/quic/core/quic_write_blocked_list.h",
     ],
-    copts = quiche_copts,
-    repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         ":http2_core_priority_write_scheduler_lib",
         ":quic_core_ack_listener_interface_lib",
@@ -3930,7 +3918,7 @@ envoy_quic_cc_library(
     ],
 )
 
-envoy_cc_library(
+envoy_quic_cc_library(
     name = "quic_stream_priority_lib",
     srcs = [
         "quiche/quic/core/quic_stream_priority.cc",
@@ -3938,10 +3926,7 @@ envoy_cc_library(
     hdrs = [
         "quiche/quic/core/quic_stream_priority.h",
     ],
-    copts = quiche_copts,
     external_deps = ["ssl"],
-    repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         ":quic_core_types_lib",
         ":quic_platform_export",
@@ -4233,7 +4218,7 @@ envoy_quic_cc_library(
     ],
 )
 
-envoy_cc_library(
+envoy_quic_cc_library(
     name = "quic_core_types_lib",
     srcs = [
         "quiche/quic/core/quic_connection_id.cc",
@@ -4245,10 +4230,7 @@ envoy_cc_library(
         "quiche/quic/core/quic_packet_number.h",
         "quiche/quic/core/quic_types.h",
     ],
-    copts = quiche_copts,
     external_deps = ["ssl"],
-    repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         ":quic_core_crypto_random_lib",
         ":quic_core_error_codes_lib",
@@ -4321,13 +4303,10 @@ envoy_quic_cc_library(
     ],
 )
 
-envoy_cc_library(
+envoy_quic_cc_library(
     name = "quic_core_utils_lib",
     srcs = ["quiche/quic/core/quic_utils.cc"],
     hdrs = ["quiche/quic/core/quic_utils.h"],
-    copts = quiche_copts,
-    repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         ":quic_core_constants_lib",
         ":quic_core_crypto_random_lib",
@@ -4352,13 +4331,10 @@ envoy_quic_cc_library(
     ],
 )
 
-envoy_cc_library(
+envoy_quic_cc_library(
     name = "quic_core_versions_lib",
     srcs = ["quiche/quic/core/quic_versions.cc"],
     hdrs = ["quiche/quic/core/quic_versions.h"],
-    copts = quiche_copts,
-    repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         ":quic_core_crypto_random_lib",
         ":quic_core_tag_lib",


### PR DESCRIPTION
So they're skipped when http3 is disabled.
