### PR TITLE
deflake: deflaking the ClientSideWeightedRoundRobinEdsIntegrationTest tests

### DIFF
--- a/test/extensions/load_balancing_policies/client_side_weighted_round_robin/integration_test.cc
+++ b/test/extensions/load_balancing_policies/client_side_weighted_round_robin/integration_test.cc
@@ -469,7 +469,7 @@ public:
     }
 
     // Create 4 autonomous upstream servers that will be used as endpoints.
-    // While typipcally this is invoked prior to initialize(), it is ok to
+    // While typically this is invoked prior to initialize(), it is ok to
     // invoke it here as it will create the autonomous upstreams next.
     fake_upstreams_count_ = 4;
     createUpstreams();


### PR DESCRIPTION
Commit Message: deflake: delfaking the ClientSideWeightedRoundRobinEdsIntegrationTest tests
Additional Description:
Deflaking the "Eds" tests by doing the following:
- Using autonomous upstreams to automatically reply 200.
- Enable retry when connections to upstreams times out
- When initializing the test, add a wait before trying to accept a new xDS-connection.

Risk Level: low - tests only
Testing: Updated
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
Partially addresses: #38507