### PR TITLE
Quiet -Woverloaded-virtual for FieldChecker (in gcc)

### DIFF
--- a/source/extensions/filters/http/proto_api_scrubber/scrubbing_util_lib/field_checker.h
+++ b/source/extensions/filters/http/proto_api_scrubber/scrubbing_util_lib/field_checker.h
@@ -33,6 +33,10 @@ public:
   FieldChecker& operator=(const FieldChecker&) = delete;
   ~FieldChecker() override {}
 
+  // Make all the overloads from the base class visible here so the one explicit
+  // override doesn't hide the other signatures.
+  using FieldCheckerInterface::CheckField;
+
   /**
    * Returns whether the `field` should be included (kInclude), excluded (kExclude)
    * or traversed further (kPartial).


### PR DESCRIPTION
Commit Message: Quiet -Woverloaded-virtual for FieldChecker (in gcc)
Additional Description: [Example of the noise](https://github.com/envoyproxy/envoy/actions/runs/19056203905/job/54426871948).
```
In file included from ./source/extensions/filters/http/proto_api_scrubber/scrubbing_util_lib/field_checker.h:8,
                 from source/extensions/filters/http/proto_api_scrubber/scrubbing_util_lib/field_checker.cc:1:
external/com_google_protoprocessinglib/proto_processing_lib/proto_scrubber/field_checker_interface.h:77:29: warning: ‘virtual proto_processing_lib::proto_scrubber::FieldCheckResults proto_processing_lib::proto_scrubber::FieldCheckerInterface::CheckField(const std::vector<std::__cxx11::basic_string<char> >&, const google::protobuf::Field*, int, const google::protobuf::Type*) const’ was hidden [-Woverloaded-virtual=]
   77 |   virtual FieldCheckResults CheckField(
      |                             ^~~~~~~~~~
./source/extensions/filters/http/proto_api_scrubber/scrubbing_util_lib/field_checker.h:40:21: note:   by ‘virtual proto_processing_lib::proto_scrubber::FieldCheckResults Envoy::Extensions::HttpFilters::ProtoApiScrubber::FieldChecker::CheckField(const std::vector<std::__cxx11::basic_string<char> >&, const google::protobuf::Field*) const’
   40 |   FieldCheckResults CheckField(const std::vector<std::string>& path,
      |                     ^~~~~~~~~~
```
Risk Level: No behavior change.
Testing: No behavior change.
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
