### PR TITLE
covergae: adjust the LCOV for quic to fix main

### DIFF
--- a/test/coverage.yaml
+++ b/test/coverage.yaml
@@ -16,7 +16,7 @@ directories:
   source/common/memory: 98.1  # tcmalloc code path is not enabled in coverage build, only gperf tcmalloc, see PR#32589
   source/common/network: 94.3  # Flaky, `activateFileEvents`, `startSecureTransport` and `ioctl`, listener_socket do not always report LCOV
   source/common/network/dns_resolver: 91.4   # A few lines of MacOS code not tested in linux scripts. Tested in MacOS scripts
-  source/common/quic: 93.4
+  source/common/quic: 93.3
   source/common/signal: 87.4  # Death tests don't report LCOV
   source/common/thread: 0.0  # Death tests don't report LCOV
   source/common/tls: 94.5  # FIPS code paths impossible to trigger on non-FIPS builds and vice versa


### PR DESCRIPTION
## Description

This PR fixes the LCOV for main to fix main.

https://github.com/envoyproxy/envoy/actions/runs/19146001009/job/54723697132

---

**Commit Message:** covergae: adjust the LCOV for quic to fix main
**Additional Description:** Adjust LCOV for QUIC.
**Risk Level:** Low
**Testing:** CI
**Docs Changes:** N/A
**Release Notes:** N/A