### PR TITLE
build: exclude QUIC libraries when HTTP3 is disabled

### DIFF
--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -326,6 +326,14 @@ config_setting(
 )
 
 selects.config_setting_group(
+    name = "http3_enabled_and_linux",
+    match_all = [
+        "//bazel:linux",
+        "//bazel:enable_http3",
+    ],
+)
+
+selects.config_setting_group(
     name = "enable_http3_on_linux_ppc",
     match_all = [
         ":enable_http3",

--- a/bazel/external/quiche.BUILD
+++ b/bazel/external/quiche.BUILD
@@ -9,6 +9,7 @@ load(
 load(
     "@envoy//bazel/external:quiche.bzl",
     "envoy_quic_cc_library",
+    "envoy_quic_cc_test",
     "envoy_quic_cc_test_library",
     "envoy_quiche_platform_impl_cc_library",
     "envoy_quiche_platform_impl_cc_test_library",
@@ -1810,13 +1811,10 @@ envoy_quic_cc_library(
     ],
 )
 
-envoy_cc_library(
+envoy_quic_cc_library(
     name = "quic_core_bandwidth_lib",
     srcs = ["quiche/quic/core/quic_bandwidth.cc"],
     hdrs = ["quiche/quic/core/quic_bandwidth.h"],
-    copts = quiche_copts,
-    repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         ":quic_core_constants_lib",
         ":quic_core_time_lib",
@@ -2381,13 +2379,10 @@ envoy_quic_cc_library(
     ],
 )
 
-envoy_cc_library(
+envoy_quic_cc_library(
     name = "quic_core_constants_lib",
     srcs = ["quiche/quic/core/quic_constants.cc"],
     hdrs = ["quiche/quic/core/quic_constants.h"],
-    copts = quiche_copts,
-    repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         ":quic_core_types_lib",
         ":quic_platform_export",
@@ -2876,7 +2871,7 @@ envoy_quic_cc_library(
     ],
 )
 
-envoy_cc_library(
+envoy_quic_cc_library(
     name = "quic_core_frames_frames_lib",
     srcs = [
         "quiche/quic/core/frames/quic_ack_frame.cc",
@@ -2934,15 +2929,12 @@ envoy_cc_library(
         "quiche/quic/core/frames/quic_streams_blocked_frame.h",
         "quiche/quic/core/frames/quic_window_update_frame.h",
     ],
-    copts = quiche_copts,
     # TODO: Work around initializer in anonymous union in fastbuild build.
     # Remove this after upstream fix.
     defines = select({
         "@envoy//bazel:windows_x86_64": ["QUIC_FRAME_DEBUG=0"],
         "//conditions:default": [],
     }),
-    repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         ":quic_core_constants_lib",
         ":quic_core_error_codes_lib",
@@ -3517,7 +3509,7 @@ envoy_cc_library(
     ],
 )
 
-envoy_cc_library(
+envoy_quic_cc_library(
     name = "quic_core_packets_lib",
     srcs = [
         "quiche/quic/core/quic_packets.cc",
@@ -3527,9 +3519,6 @@ envoy_cc_library(
         "quiche/quic/core/quic_packets.h",
         "quiche/quic/core/quic_write_blocked_list.h",
     ],
-    copts = quiche_copts,
-    repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         ":http2_core_priority_write_scheduler_lib",
         ":quic_core_ack_listener_interface_lib",
@@ -3930,7 +3919,7 @@ envoy_quic_cc_library(
     ],
 )
 
-envoy_cc_library(
+envoy_quic_cc_library(
     name = "quic_stream_priority_lib",
     srcs = [
         "quiche/quic/core/quic_stream_priority.cc",
@@ -3938,10 +3927,7 @@ envoy_cc_library(
     hdrs = [
         "quiche/quic/core/quic_stream_priority.h",
     ],
-    copts = quiche_copts,
     external_deps = ["ssl"],
-    repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         ":quic_core_types_lib",
         ":quic_platform_export",
@@ -4233,7 +4219,7 @@ envoy_quic_cc_library(
     ],
 )
 
-envoy_cc_library(
+envoy_quic_cc_library(
     name = "quic_core_types_lib",
     srcs = [
         "quiche/quic/core/quic_connection_id.cc",
@@ -4245,10 +4231,7 @@ envoy_cc_library(
         "quiche/quic/core/quic_packet_number.h",
         "quiche/quic/core/quic_types.h",
     ],
-    copts = quiche_copts,
     external_deps = ["ssl"],
-    repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         ":quic_core_crypto_random_lib",
         ":quic_core_error_codes_lib",
@@ -4321,13 +4304,10 @@ envoy_quic_cc_library(
     ],
 )
 
-envoy_cc_library(
+envoy_quic_cc_library(
     name = "quic_core_utils_lib",
     srcs = ["quiche/quic/core/quic_utils.cc"],
     hdrs = ["quiche/quic/core/quic_utils.h"],
-    copts = quiche_copts,
-    repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         ":quic_core_constants_lib",
         ":quic_core_crypto_random_lib",
@@ -4352,13 +4332,10 @@ envoy_quic_cc_library(
     ],
 )
 
-envoy_cc_library(
+envoy_quic_cc_library(
     name = "quic_core_versions_lib",
     srcs = ["quiche/quic/core/quic_versions.cc"],
     hdrs = ["quiche/quic/core/quic_versions.h"],
-    copts = quiche_copts,
-    repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         ":quic_core_crypto_random_lib",
         ":quic_core_tag_lib",
@@ -5195,14 +5172,12 @@ envoy_cc_library(
     ],
 )
 
-envoy_cc_test(
+envoy_quic_cc_test(
     name = "quiche_common_test",
     srcs = [
         "quiche/common/quiche_linked_hash_map_test.cc",
         "quiche/common/quiche_mem_slice_storage_test.cc",
     ],
-    copts = quiche_copts,
-    repository = "@envoy",
     deps = [
         ":quiche_common_lib",
         ":quiche_common_mem_slice_storage",
@@ -5223,12 +5198,10 @@ envoy_cc_test(
     ],
 )
 
-envoy_cc_library(
+envoy_quic_cc_library(
     name = "quiche_common_mem_slice_storage",
     srcs = ["quiche/common/quiche_mem_slice_storage.cc"],
     hdrs = ["quiche/common/quiche_mem_slice_storage.h"],
-    repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         ":quic_core_types_lib",
         ":quic_core_utils_lib",

--- a/bazel/external/quiche.bzl
+++ b/bazel/external/quiche.bzl
@@ -1,6 +1,7 @@
 load(
     "@envoy//bazel:envoy_build_system.bzl",
     "envoy_cc_library",
+    "envoy_cc_test",
     "envoy_cc_test_library",
 )
 load("@envoy//bazel:envoy_select.bzl", "envoy_select_enable_http3")
@@ -85,6 +86,22 @@ def envoy_quic_cc_test_library(
         name = name,
         srcs = envoy_select_enable_http3(srcs, "@envoy"),
         hdrs = envoy_select_enable_http3(hdrs, "@envoy"),
+        copts = quiche_copts,
+        repository = "@envoy",
+        tags = tags,
+        external_deps = external_deps,
+        deps = envoy_select_enable_http3(deps, "@envoy"),
+    )
+
+def envoy_quic_cc_test(
+        name,
+        srcs = [],
+        tags = [],
+        external_deps = [],
+        deps = []):
+    envoy_cc_test(
+        name = name,
+        srcs = envoy_select_enable_http3(srcs, "@envoy"),
         copts = quiche_copts,
         repository = "@envoy",
         tags = tags,

--- a/source/common/quic/BUILD
+++ b/source/common/quic/BUILD
@@ -1,4 +1,3 @@
-load("@bazel_skylib//lib:selects.bzl", "selects")
 load(
     "@envoy_build_config//:extensions_build_config.bzl",
     "LEGACY_ALWAYSLINK",
@@ -12,15 +11,6 @@ load(
 )
 
 licenses(["notice"])  # Apache 2
-
-# Create a condition for HTTP3 enabled AND Linux
-selects.config_setting_group(
-    name = "http3_enabled_and_linux",
-    match_all = [
-        "//bazel:linux",
-        "//bazel:enable_http3",
-    ],
-)
 
 # TODO(mattklein123): Default visibility for this package should not be public. We should have
 # default by private to within this package and package tests, and then only expose the libraries
@@ -599,7 +589,7 @@ envoy_cc_library(
 envoy_cc_library(
     name = "udp_gso_batch_writer_lib",
     srcs = select({
-        ":http3_enabled_and_linux": ["udp_gso_batch_writer.cc"],
+        "//bazel:http3_enabled_and_linux": ["udp_gso_batch_writer.cc"],
         "//conditions:default": [],
     }),
     hdrs = envoy_select_enable_http3(["udp_gso_batch_writer.h"]),
@@ -611,7 +601,7 @@ envoy_cc_library(
         "//source/common/runtime:runtime_lib",
         "@com_github_google_quiche//:quic_platform",
     ]) + select({
-        ":http3_enabled_and_linux": ["@com_github_google_quiche//:quic_core_batch_writer_gso_batch_writer_lib"],
+        "//bazel:http3_enabled_and_linux": ["@com_github_google_quiche//:quic_core_batch_writer_gso_batch_writer_lib"],
         "//conditions:default": [],
     }),
 )

--- a/test/common/quic/platform/BUILD
+++ b/test/common/quic/platform/BUILD
@@ -15,7 +15,7 @@ envoy_package()
 envoy_cc_test(
     name = "quic_platform_test",
     srcs = select({
-        "//bazel:linux": ["quic_platform_test.cc"],
+        "//bazel:http3_enabled_and_linux": ["quic_platform_test.cc"],
         "//conditions:default": [],
     }),
     copts = select({

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -1835,7 +1835,7 @@ envoy_cc_test(
 envoy_cc_test(
     name = "extension_discovery_integration_test",
     size = "large",
-    srcs = ["extension_discovery_integration_test.cc"],
+    srcs = envoy_select_enable_http3(["extension_discovery_integration_test.cc"]),
     rbe_pool = "6gig",
     deps = [
         ":http_integration_lib",
@@ -1858,7 +1858,7 @@ envoy_cc_test(
 envoy_cc_test(
     name = "listener_extension_discovery_integration_test",
     size = "large",
-    srcs = ["listener_extension_discovery_integration_test.cc"],
+    srcs = envoy_select_enable_http3(["listener_extension_discovery_integration_test.cc"]),
     rbe_pool = "2core",
     deps = [
         ":http_integration_lib",
@@ -2264,9 +2264,11 @@ envoy_cc_test(
 envoy_cc_test(
     name = "xds_integration_test",
     size = "large",
-    srcs = envoy_select_admin_functionality([
-        "xds_integration_test.cc",
-    ]),
+    srcs = select({
+        "//bazel:disable_http3": [],
+        "//bazel:disable_admin_functionality": [],
+        "//conditions:default": ["xds_integration_test.cc"],
+    }),
     data = [
         "//test/config/integration:server_xds_files",
         "//test/config/integration/certs",

--- a/test/integration/filters/test_listener_filter.h
+++ b/test/integration/filters/test_listener_filter.h
@@ -7,7 +7,9 @@
 #include "source/common/router/string_accessor_impl.h"
 #include "source/common/stream_info/uint32_accessor_impl.h"
 
+#ifdef ENVOY_ENABLE_QUIC
 #include "quiche/quic/core/quic_packets.h"
+#endif
 
 namespace Envoy {
 /**

--- a/test/server/admin/BUILD
+++ b/test/server/admin/BUILD
@@ -258,7 +258,11 @@ envoy_cc_test(
 
 envoy_cc_test(
     name = "config_dump_handler_test",
-    srcs = envoy_select_admin_functionality(["config_dump_handler_test.cc"]),
+    srcs = select({
+        "//bazel:disable_admin_functionality": [],
+        "//bazel:disable_http3": [],
+        "//conditions:default": ["config_dump_handler_test.cc"],
+    }),
     rbe_pool = "6gig",
     deps = [
         ":admin_instance_lib",


### PR DESCRIPTION
Convert several QUIC libraries in quiche.BUILD to use envoy_quic_cc_library and wrap test dependencies with envoy_select_enable_http3 to ensure they're properly excluded when HTTP3 support is disabled.
