### PR TITLE
Quiet -Woverloaded-virtual for stream_info_formatter.h (gcc)

### DIFF
--- a/source/common/formatter/stream_info_formatter.h
+++ b/source/common/formatter/stream_info_formatter.h
@@ -68,6 +68,8 @@ public:
 
   // StreamInfoFormatterProvider
   absl::optional<std::string> format(const StreamInfo::StreamInfo& stream_info) const override;
+  // Don't hide the other structure of formatValue.
+  using StreamInfoFormatterProvider::formatValue;
   Protobuf::Value formatValue(const StreamInfo::StreamInfo& stream_info) const override;
 
 protected:
@@ -127,6 +129,9 @@ public:
                        absl::string_view field_name = {});
 
   // StreamInfoFormatterProvider
+  // Don't hide the other structure of format and formatValue.
+  using StreamInfoFormatterProvider::format;
+  using StreamInfoFormatterProvider::formatValue;
   absl::optional<std::string> format(const StreamInfo::StreamInfo&) const override;
   Protobuf::Value formatValue(const StreamInfo::StreamInfo&) const override;
 
@@ -155,6 +160,9 @@ public:
         duration_precision_(duration_precision) {}
 
   // StreamInfoFormatterProvider
+  // Don't hide the other structure of format and formatValue.
+  using StreamInfoFormatterProvider::format;
+  using StreamInfoFormatterProvider::formatValue;
   absl::optional<std::string> format(const StreamInfo::StreamInfo&) const override;
   Protobuf::Value formatValue(const StreamInfo::StreamInfo&) const override;
 
@@ -209,6 +217,9 @@ public:
   SystemTimeFormatter(absl::string_view format, TimeFieldExtractorPtr f, bool local_time = false);
 
   // StreamInfoFormatterProvider
+  // Don't hide the other structure of format and formatValue.
+  using StreamInfoFormatterProvider::format;
+  using StreamInfoFormatterProvider::formatValue;
   absl::optional<std::string> format(const StreamInfo::StreamInfo&) const override;
   Protobuf::Value formatValue(const StreamInfo::StreamInfo&) const override;
 
@@ -271,6 +282,9 @@ public:
   EnvironmentFormatter(absl::string_view key, absl::optional<size_t> max_length);
 
   // StreamInfoFormatterProvider
+  // Don't hide the other structure of format and formatValue.
+  using StreamInfoFormatterProvider::format;
+  using StreamInfoFormatterProvider::formatValue;
   absl::optional<std::string> format(const StreamInfo::StreamInfo&) const override;
   Protobuf::Value formatValue(const StreamInfo::StreamInfo&) const override;
 


### PR DESCRIPTION
Commit Message: Quiet -Woverloaded-virtual for stream_info_formatter.h (gcc)
Additional Description: [Some example build log noise](https://github.com/envoyproxy/envoy/actions/runs/19056203905/job/54426871948)
<code>
In file included from ./source/extensions/formatter/xfcc_value/xfcc_value.h:8,
                 from source/extensions/formatter/xfcc_value/xfcc_value.cc:1:
./source/common/formatter/stream_info_formatter.h:25:31: warning: ‘virtual std::optional<std::__cxx11::basic_string<char> > Envoy::Formatter::StreamInfoFormatterProvider::format(const Envoy::Formatter::Context&, const Envoy::StreamInfo::StreamInfo&) const’ was hidden [-Woverloaded-virtual=]
   25 |   absl::optional<std::string> format(const Context&,
      |                               ^~~~~~
./source/common/formatter/stream_info_formatter.h:70:31: note:   by ‘virtual std::optional<std::__cxx11::basic_string<char> > Envoy::Formatter::MetadataFormatter::format(const Envoy::StreamInfo::StreamInfo&) const’
   70 |   absl::optional<std::string> format(const StreamInfo::StreamInfo& stream_info) const override;
      |                               ^~~~~~
./source/common/formatter/stream_info_formatter.h:29:19: warning: ‘virtual google::protobuf::Value Envoy::Formatter::StreamInfoFormatterProvider::formatValue(const Envoy::Formatter::Context&, const Envoy::StreamInfo::StreamInfo&) const’ was hidden [-Woverloaded-virtual=]
   29 |   Protobuf::Value formatValue(const Context&,
      |                   ^~~~~~~~~~~
./source/common/formatter/stream_info_formatter.h:71:19: note:   by ‘virtual google::protobuf::Value Envoy::Formatter::MetadataFormatter::formatValue(const Envoy::StreamInfo::StreamInfo&) const’
   71 |   Protobuf::Value formatValue(const StreamInfo::StreamInfo& stream_info) const override;
      |                   ^~~~~~~~~~~
</code>
(goes on, 2 or 3 times this long, for every cc file that [eventually] includes that header.)
Risk Level: No behavior change.
Testing: No behavior change.
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
