### PR TITLE
add response fuzzing to ext_authz grpc fuzz test

### DIFF
--- a/test/extensions/filters/http/ext_authz/ext_authz_fuzz.proto
+++ b/test/extensions/filters/http/ext_authz/ext_authz_fuzz.proto
@@ -13,6 +13,8 @@ message ExtAuthzTestCaseBase {
       [(validate.rules).message = {required: true}];
   // HTTP request data.
   test.fuzz.HttpData request_data = 2 [(validate.rules).message = {required: true}];
+  // HTTP response data.
+  test.fuzz.HttpData response_data = 5 [(validate.rules).message = {required: true}];
   // Filter metadata.
   envoy.config.core.v3.Metadata filter_metadata = 4;
 }

--- a/test/extensions/filters/http/ext_authz/ext_authz_grpc_corpus/response_headers
+++ b/test/extensions/filters/http/ext_authz/ext_authz_grpc_corpus/response_headers
@@ -1,0 +1,50 @@
+base {
+  config {
+  }
+  request_data {
+    headers {
+      headers {
+        key: "overwrite-if-exists"
+        value: "original-value"
+      }
+    }
+  }
+  response_data {
+  }
+}
+response {
+  status {
+    code: 0
+    message: "LGTM!"
+  }
+  ok_response {
+    response_headers_to_add {
+      header {
+        key: "append-if-exists-or-add"
+        value: "foo"
+      }
+      append_action: APPEND_IF_EXISTS_OR_ADD
+    }
+    response_headers_to_add {
+      header {
+        key: "add-if-absent"
+        value: "foo"
+      }
+      append_action: ADD_IF_ABSENT
+    }
+    response_headers_to_add {
+      header {
+        key: "overwrite-if-exists-or-add"
+        value: "foo"
+      }
+      append_action: OVERWRITE_IF_EXISTS_OR_ADD
+    }
+    response_headers_to_add {
+      header {
+        key: "overwrite-if-exists"
+        value: "foo"
+      }
+      append_action: OVERWRITE_IF_EXISTS
+    }
+  }
+}

--- a/test/extensions/filters/http/ext_authz/ext_authz_grpc_fuzz_test.cc
+++ b/test/extensions/filters/http/ext_authz/ext_authz_grpc_fuzz_test.cc
@@ -104,6 +104,9 @@ DEFINE_PROTO_FUZZER(ExtAuthzTestCaseGrpc& input) {
   static Envoy::Extensions::HttpFilters::HttpFilterFuzzer fuzzer;
   fuzzer.runData(static_cast<Envoy::Http::StreamDecoderFilter*>(filter->get()),
                  input.base().request_data());
+  fuzzer.runData(static_cast<Envoy::Http::StreamEncoderFilter*>(filter->get()),
+                 input.base().response_data());
+  fuzzer.reset();
 }
 
 } // namespace


### PR DESCRIPTION
Commit Message: add response fuzzing to ext_authz grpc fuzz test
Additional Description:

Add response fuzzing in the simplest way possible to the ext authz grpc fuzzer.

This fuzzer now, regardless of what happened on the request path, will also invoke the response path. This is not the "highest fidelity" way to do it but it is the simplest and I ran the test overnight with zero crashes, so I think it's fine for improving fuzz coverage for the ext authz filter.

Risk Level: none
Testing: fuzz improvement