### PR TITLE
changelog: fix an entry that is incorrectly in bug fixes instead of new features

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -105,10 +105,6 @@ bug_fixes:
     Fixed per-route configuration for composite filter to support matching on response headers and trailers.
     Previously, per-route matchers would silently fail when attempting to match on ``HttpResponseHeaderMatchInput``
     or ``HttpResponseTrailerMatchInput``, causing the delegated filter to be skipped without error.
-- area: dns
-  change: |
-    c-ares resolver: add optional ``reinit_channel_on_timeout`` to reinitialize
-    the resolver after DNS timeouts.
 - area: router
   change: |
     Fixed a regression where router-set headers (e.g., ``x-envoy-expected-rq-timeout-ms``, ``x-envoy-attempt-count``)
@@ -166,6 +162,10 @@ new_features:
   change: |
     Added support for the not-equal operator in access log filter rules, in
     :ref:`ComparisonFilter <envoy_v3_api_msg_config.accesslog.v3.ComparisonFilter>`.
+- area: c-ares
+  change: |
+    Add an optional ``reinit_channel_on_timeout`` to the c-ares resolver to reinitialize the channel
+    after DNS timeouts.
 - area: cel
   change: |
     Added per-expression configuration options for CEL evaluator to control string conversion, concatenation,
@@ -178,9 +178,11 @@ new_features:
 - area: formatter
   change: |
     Added support for the following new access log formatters:
-    - ``%REQUEST_HEADER(X?Y):Z%`` as full name version of ``%REQ(X?Y):Z%``
-    - ``%RESPONSE_HEADER(X?Y):Z%`` as full name version of ``%RESP(X?Y):Z%``
-    - ``%RESPONSE_TRAILER(X?Y):Z%`` as full name version of ``%TRAILER(X?Y):Z%``
+
+    #. ``%REQUEST_HEADER(X?Y):Z%`` as full name version of ``%REQ(X?Y):Z%``.
+    #. ``%RESPONSE_HEADER(X?Y):Z%`` as full name version of ``%RESP(X?Y):Z%``.
+    #. ``%RESPONSE_TRAILER(X?Y):Z%`` as full name version of ``%TRAILER(X?Y):Z%``.
+
     This provides a more consistent naming scheme for users to understand and use.
 - area: tracing
   change: |


### PR DESCRIPTION
## Description

There is an entry which is incorrectly in the "bug fixes" section instead of "new features". This PR moves it to the correct section.

---

**Commit Message:** changelog: fix an entry that is incorrectly in bug fixes instead of new features
**Additional Description:** Fixes the entry which is incorrectly in the "bug fixes" list.
**Risk Level:** N/A
**Testing:** CI
**Docs Changes:** N/A
**Release Notes:** N/A