### PR TITLE
fix: ordering of dependency imports to make bazel happy

### DIFF
--- a/bazel/bazel_deps.bzl
+++ b/bazel/bazel_deps.bzl
@@ -2,3 +2,4 @@ load("@bazel_features//:deps.bzl", "bazel_features_deps")
 
 def envoy_bazel_dependencies():
     bazel_features_deps()
+


### PR DESCRIPTION
## Description

This PR fixes the ordering of the dependency imports in `WORKSPACE` and `mobile/WORKSPACE` to make bazel happy. The docs job is failing currently as it couldn't import `bazel_features`.

**See:** https://github.com/envoyproxy/envoy-website/actions/runs/19188285700/job/54858890220

---

**Commit Message:** fix: ordering of dependency imports to make bazel happy
**Additional Description:** Fixes the ordering of the dependency imports in `WORKSPACE` and `mobile/WORKSPACE` to make bazel happy. 
**Risk Level:** N/A
**Testing:** CI
**Docs Changes:** N/A
**Release Notes:** N/A