### PR TITLE
bazel: Allow filegroup directories as sources

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -10,6 +10,7 @@
 # Startup options cannot be selected via config.
 # TODO: Adding just to test android
 startup --host_jvm_args=-Xmx3g
+startup --host_jvm_args="-DBAZEL_TRACK_SOURCE_DIRECTORIES=1"
 
 common --noenable_bzlmod
 


### PR DESCRIPTION
this is more efficient apparently than globbing the files in a dir

