### PR TITLE
foreign_cc/colm: Remove stdlib workaround

### DIFF
--- a/bazel/foreign_cc/BUILD
+++ b/bazel/foreign_cc/BUILD
@@ -159,11 +159,6 @@ configure_make(
         "--disable-shared",
         "--enable-static",
     ],
-    # Workaround for the issue with statically linked libstdc++
-    # using -l:libstdc++.a.
-    env = {
-        "CXXFLAGS": "--static -lstdc++ -Wno-unused-command-line-argument",
-    },
     lib_source = "@net_colm_open_source_colm//:all",
     out_binaries = ["colm"],
     tags = ["skip_on_windows"],


### PR DESCRIPTION
afaict this is not necessary and conflicts with args supplied by hermetic llvm toolchain