### PR TITLE
foreign_cc/ragel: Remove stdlib workaround

### DIFF
--- a/bazel/foreign_cc/BUILD
+++ b/bazel/foreign_cc/BUILD
@@ -176,11 +176,6 @@ configure_make(
         "--enable-static",
         "--with-colm=$$EXT_BUILD_DEPS/colm",
     ],
-    # Workaround for the issue with statically linked libstdc++
-    # using -l:libstdc++.a.
-    env = {
-        "CXXFLAGS": "--static -lstdc++ -Wno-unused-command-line-argument",
-    },
     lib_source = "@net_colm_open_source_ragel//:all",
     out_binaries = ["ragel"],
     tags = ["skip_on_windows"],


### PR DESCRIPTION
similar to #41920 this also breaks compiler args for hermetic toolchains

