### PR TITLE
router: added hash_policy to HttpProtocolOptions to support sticky routing

### DIFF
--- a/api/envoy/extensions/upstreams/http/v3/http_protocol_options.proto
+++ b/api/envoy/extensions/upstreams/http/v3/http_protocol_options.proto
@@ -61,7 +61,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 //             http2_protocol_options:
 //               max_concurrent_streams: 100
 //        .... [further cluster config]
-// [#next-free-field: 10]
+// [#next-free-field: 11]
 message HttpProtocolOptions {
   // If this is used, the cluster will only operate on one of the possible upstream protocols.
   // Note that HTTP/2 or above should generally be used for upstream gRPC clusters.
@@ -195,4 +195,19 @@ message HttpProtocolOptions {
   //   Mirroring will not be triggered if the :ref:`primary cluster
   //   <envoy_v3_api_field_config.route.v3.RouteAction.cluster>` does not exist.
   repeated config.route.v3.RouteAction.RequestMirrorPolicy request_mirror_policies = 9;
+
+  // Specifies a list of hash policies for consistent hashing load balancing (e.g., Ring Hash or
+  // Maglev) for requests routed to this cluster. When configured, cluster-level policies override
+  // route-level policies. When not configured, route-level policies (if any) will be used.
+  //
+  // This enables consistent routing to the same upstream host for all requests to a cluster,
+  // which is particularly useful for stateful services like caching, session management, or
+  // sticky routing requirements.
+  //
+  // .. note::
+  //
+  //   Hash policies are only effective when the cluster is configured with a hash-based load
+  //   balancing policy (e.g., :ref:`RING_HASH <envoy_v3_api_enum_value_config.cluster.v3.Cluster.LbPolicy.RING_HASH>`
+  //   or :ref:`MAGLEV <envoy_v3_api_enum_value_config.cluster.v3.Cluster.LbPolicy.MAGLEV>`).
+  repeated config.route.v3.RouteAction.HashPolicy hash_policy = 10;
 }

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -266,6 +266,11 @@ new_features:
     Added :ref:`request_mirror_policies <envoy_v3_api_field_extensions.upstreams.http.v3.HttpProtocolOptions.request_mirror_policies>`
     to :ref:`HttpProtocolOptions <envoy_v3_api_msg_extensions.upstreams.http.v3.HttpProtocolOptions>` to support
     cluster-level request mirroring. Cluster-level policies override route-level policies when both are configured.
+- area: router
+  change: |
+    Added :ref:`hash_policy <envoy_v3_api_field_extensions.upstreams.http.v3.HttpProtocolOptions.hash_policy>`
+    to :ref:`HttpProtocolOptions <envoy_v3_api_msg_extensions.upstreams.http.v3.HttpProtocolOptions>` to support
+    cluster-level hash policies.
 - area: network
   change: |
     Add logging info for network ext_proc to filter state.

--- a/envoy/upstream/upstream.h
+++ b/envoy/upstream/upstream.h
@@ -35,7 +35,8 @@
 namespace Envoy {
 namespace Http {
 class FilterChainManager;
-}
+class HashPolicy;
+} // namespace Http
 
 namespace Router {
 class ShadowPolicy;
@@ -1242,6 +1243,12 @@ public:
    * cluster.
    */
   virtual const std::vector<Router::ShadowPolicyPtr>& shadowPolicies() const PURE;
+
+  /**
+   * @return const Http::HashPolicy* the hash policy configured for this cluster. Returns nullptr
+   * if no cluster-level hash policy is configured.
+   */
+  virtual const Http::HashPolicy* hashPolicy() const PURE;
 
 protected:
   /**

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -1010,6 +1010,10 @@ public:
     return shadow_policies_;
   }
 
+  const Http::HashPolicy* hashPolicy() const override {
+    return http_protocol_options_ != nullptr ? http_protocol_options_->hash_policy_.get() : nullptr;
+  }
+
 protected:
   ClusterInfoImpl(Init::Manager& info, Server::Configuration::ServerFactoryContext& server_context,
                   const envoy::config::cluster::v3::Cluster& config,

--- a/source/extensions/upstreams/http/config.h
+++ b/source/extensions/upstreams/http/config.h
@@ -66,11 +66,16 @@ public:
 
   std::vector<Extensions::Common::Matcher::MatcherPtr> outlier_detection_http_error_matcher_;
   const std::vector<Envoy::Router::ShadowPolicyPtr> shadow_policies_;
+  const std::unique_ptr<Envoy::Http::HashPolicy> hash_policy_;
 
 private:
   static absl::StatusOr<std::vector<Envoy::Router::ShadowPolicyPtr>>
   buildShadowPolicies(const envoy::extensions::upstreams::http::v3::HttpProtocolOptions& options,
                       Server::Configuration::ServerFactoryContext& server_context);
+
+  static absl::StatusOr<std::unique_ptr<Envoy::Http::HashPolicy>>
+  buildHashPolicy(const envoy::extensions::upstreams::http::v3::HttpProtocolOptions& options,
+                  Server::Configuration::ServerFactoryContext& server_context);
 
   ProtocolOptionsConfigImpl(
       const envoy::extensions::upstreams::http::v3::HttpProtocolOptions& options,
@@ -78,6 +83,7 @@ private:
       Envoy::Http::HeaderValidatorFactoryPtr&& header_validator_factory,
       absl::optional<const envoy::config::core::v3::AlternateProtocolsCacheOptions> cache_options,
       std::vector<Envoy::Router::ShadowPolicyPtr>&& shadow_policies,
+      std::unique_ptr<Envoy::Http::HashPolicy>&& hash_policy,
       Server::Configuration::ServerFactoryContext& server_context);
   // Constructor for legacy (deprecated) config.
   ProtocolOptionsConfigImpl(

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -703,9 +703,9 @@ envoy_cc_test(
 )
 
 envoy_cc_test(
-    name = "cluster_shadow_policy_integration_test",
+    name = "cluster_http_protocol_options_integration_test",
     size = "large",
-    srcs = ["cluster_shadow_policy_integration_test.cc"],
+    srcs = ["cluster_http_protocol_options_integration_test.cc"],
     rbe_pool = "6gig",
     tags = [
         "cpu:3",
@@ -713,7 +713,10 @@ envoy_cc_test(
     deps = [
         ":http_integration_lib",
         ":integration_lib",
+        "//source/extensions/load_balancing_policies/maglev:config",
+        "//source/extensions/load_balancing_policies/ring_hash:config",
         "//test/test_common:test_runtime_lib",
+        "@envoy_api//envoy/config/route/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/filters/http/router/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/filters/http/upstream_codec/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/filters/network/http_connection_manager/v3:pkg_cc_proto",

--- a/test/integration/cluster_http_protocol_options_integration_test.cc
+++ b/test/integration/cluster_http_protocol_options_integration_test.cc
@@ -1,6 +1,7 @@
 #include <chrono>
 #include <string>
 
+#include "envoy/config/route/v3/route_components.pb.h"
 #include "envoy/extensions/filters/http/router/v3/router.pb.h"
 #include "envoy/extensions/filters/http/upstream_codec/v3/upstream_codec.pb.h"
 #include "envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.pb.h"
@@ -12,20 +13,66 @@
 namespace Envoy {
 namespace {
 
-// Test cluster-level shadow/mirror policies.
-class ClusterShadowPolicyIntegrationTest
+// Test cluster-level HTTP protocol options including shadow/mirror policies and hash policies.
+// Both features are configured via HttpProtocolOptions and support cluster vs route precedence.
+class ClusterHttpProtocolOptionsIntegrationTest
     : public testing::TestWithParam<Network::Address::IpVersion>,
       public HttpIntegrationTest {
 public:
-  ClusterShadowPolicyIntegrationTest() : HttpIntegrationTest(Http::CodecType::HTTP2, GetParam()) {
+  ClusterHttpProtocolOptionsIntegrationTest()
+      : HttpIntegrationTest(Http::CodecType::HTTP2, GetParam()) {
     setUpstreamProtocol(Http::CodecType::HTTP2);
     autonomous_upstream_ = true;
-    // Default upstream count for most tests. Some tests will create additional clusters
-    // dynamically.
+    // Default upstream count. Individual tests may override this.
     setUpstreamCount(2);
   }
 
   void setUpstreamCountForTest(int count) { setUpstreamCount(count); }
+
+  // Configure cluster with RING_HASH load balancer and proper load assignment.
+  void configureClusterWithRingHash(int num_upstreams) {
+    auto ip_version = GetParam();
+    config_helper_.addConfigModifier(
+        [num_upstreams, ip_version](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
+          auto* main_cluster = bootstrap.mutable_static_resources()->mutable_clusters(0);
+          main_cluster->set_lb_policy(envoy::config::cluster::v3::Cluster::RING_HASH);
+
+          // Clear and properly configure load assignment with the correct number of endpoints.
+          main_cluster->clear_load_assignment();
+          auto* load_assignment = main_cluster->mutable_load_assignment();
+          load_assignment->set_cluster_name(main_cluster->name());
+          auto* endpoints = load_assignment->add_endpoints();
+
+          for (int i = 0; i < num_upstreams; i++) {
+            auto* socket = endpoints->add_lb_endpoints()
+                               ->mutable_endpoint()
+                               ->mutable_address()
+                               ->mutable_socket_address();
+            socket->set_address(Network::Test::getLoopbackAddressString(ip_version));
+            socket->set_port_value(0); // Port will be filled by ConfigHelper.
+          }
+        });
+  }
+
+  // Setup cluster-level hash policy on cluster_0 with header-based hashing.
+  void setupClusterHashPolicy() {
+    configureClusterWithRingHash(3);
+
+    config_helper_.addConfigModifier([](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
+      auto* main_cluster = bootstrap.mutable_static_resources()->mutable_clusters(0);
+
+      // Add HTTP protocol options with cluster-level hash policy.
+      auto& options_any = (*main_cluster->mutable_typed_extension_protocol_options())
+          ["envoy.extensions.upstreams.http.v3.HttpProtocolOptions"];
+      envoy::extensions::upstreams::http::v3::HttpProtocolOptions options;
+      options.mutable_explicit_http_config()->mutable_http2_protocol_options();
+
+      // Add header-based hash policy.
+      auto* hash_policy = options.add_hash_policy();
+      hash_policy->mutable_header()->set_header_name("x-user-id");
+      options_any.PackFrom(options);
+    });
+  }
 
   // Setup cluster-level mirror policy on cluster_0 to mirror to cluster_1.
   void setupClusterMirrorPolicy() {
@@ -81,14 +128,18 @@ public:
   TestScopedRuntime scoped_runtime_;
 };
 
-INSTANTIATE_TEST_SUITE_P(IpVersions, ClusterShadowPolicyIntegrationTest,
+INSTANTIATE_TEST_SUITE_P(IpVersions, ClusterHttpProtocolOptionsIntegrationTest,
                          testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                          [](const ::testing::TestParamInfo<Network::Address::IpVersion>& params) {
                            return params.param == Network::Address::IpVersion::v4 ? "IPv4" : "IPv6";
                          });
 
+// ============================================================================
+// Shadow/Mirror Policy Tests
+// ============================================================================
+
 // Test basic cluster-level mirroring.
-TEST_P(ClusterShadowPolicyIntegrationTest, BasicClusterLevelMirroring) {
+TEST_P(ClusterHttpProtocolOptionsIntegrationTest, BasicClusterLevelMirroring) {
   setupClusterMirrorPolicy();
   initialize();
 
@@ -100,7 +151,7 @@ TEST_P(ClusterShadowPolicyIntegrationTest, BasicClusterLevelMirroring) {
 }
 
 // Test cluster-level mirroring with runtime fraction.
-TEST_P(ClusterShadowPolicyIntegrationTest, ClusterMirroringWithRuntimeFraction) {
+TEST_P(ClusterHttpProtocolOptionsIntegrationTest, ClusterMirroringWithRuntimeFraction) {
   config_helper_.addConfigModifier([](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
     // Create cluster_1 by copying from cluster_0.
     auto* cluster_1 = bootstrap.mutable_static_resources()->add_clusters();
@@ -140,7 +191,7 @@ TEST_P(ClusterShadowPolicyIntegrationTest, ClusterMirroringWithRuntimeFraction) 
 }
 
 // Test cluster-level mirroring with header mutations.
-TEST_P(ClusterShadowPolicyIntegrationTest, ClusterMirroringWithHeaderMutations) {
+TEST_P(ClusterHttpProtocolOptionsIntegrationTest, ClusterMirroringWithHeaderMutations) {
   config_helper_.addConfigModifier([](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
     // Create cluster_1 by copying from cluster_0.
     auto* cluster_1 = bootstrap.mutable_static_resources()->add_clusters();
@@ -205,7 +256,7 @@ TEST_P(ClusterShadowPolicyIntegrationTest, ClusterMirroringWithHeaderMutations) 
 }
 
 // Test that cluster without mirror policies doesn't create shadows.
-TEST_P(ClusterShadowPolicyIntegrationTest, NoClusterMirrorPolicies) {
+TEST_P(ClusterHttpProtocolOptionsIntegrationTest, NoClusterMirrorPolicies) {
   config_helper_.addConfigModifier([](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
     // Create cluster_1 but don't configure any mirror policies.
     auto* cluster_1 = bootstrap.mutable_static_resources()->add_clusters();
@@ -231,7 +282,7 @@ TEST_P(ClusterShadowPolicyIntegrationTest, NoClusterMirrorPolicies) {
 }
 
 // Test cluster-level mirroring with disabled shadow host suffix.
-TEST_P(ClusterShadowPolicyIntegrationTest, ClusterMirroringDisabledShadowHostSuffix) {
+TEST_P(ClusterHttpProtocolOptionsIntegrationTest, ClusterMirroringDisabledShadowHostSuffix) {
   config_helper_.addConfigModifier([](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
     // Create cluster_1 by copying from cluster_0.
     auto* cluster_1 = bootstrap.mutable_static_resources()->add_clusters();
@@ -275,7 +326,7 @@ TEST_P(ClusterShadowPolicyIntegrationTest, ClusterMirroringDisabledShadowHostSuf
 }
 
 // Test precedence: Route has policies, cluster has NO policies → route policies used.
-TEST_P(ClusterShadowPolicyIntegrationTest, PrecedenceRouteOnlyMirroring) {
+TEST_P(ClusterHttpProtocolOptionsIntegrationTest, PrecedenceRouteOnlyMirroring) {
   config_helper_.addConfigModifier([](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
     // Create cluster_1 by copying from cluster_0.
     auto* cluster_1 = bootstrap.mutable_static_resources()->add_clusters();
@@ -317,7 +368,7 @@ TEST_P(ClusterShadowPolicyIntegrationTest, PrecedenceRouteOnlyMirroring) {
 }
 
 // Test precedence: Route has NO policies, cluster has policies → cluster policies used.
-TEST_P(ClusterShadowPolicyIntegrationTest, PrecedenceClusterOnlyMirroring) {
+TEST_P(ClusterHttpProtocolOptionsIntegrationTest, PrecedenceClusterOnlyMirroring) {
   config_helper_.addConfigModifier([](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
     // Create cluster_1 by copying from cluster_0.
     auto* cluster_1 = bootstrap.mutable_static_resources()->add_clusters();
@@ -358,7 +409,7 @@ TEST_P(ClusterShadowPolicyIntegrationTest, PrecedenceClusterOnlyMirroring) {
 
 // Test precedence: Route has policies, cluster has policies → ONLY cluster policies used
 // (override).
-TEST_P(ClusterShadowPolicyIntegrationTest, PrecedenceClusterOverridesRoute) {
+TEST_P(ClusterHttpProtocolOptionsIntegrationTest, PrecedenceClusterOverridesRouteMirroring) {
   // Need 3 upstreams: cluster_0 (main), cluster_1 (route target), cluster_2 (cluster target).
   setUpstreamCountForTest(3);
 
@@ -420,8 +471,10 @@ TEST_P(ClusterShadowPolicyIntegrationTest, PrecedenceClusterOverridesRoute) {
 
 // Test precedence: Route has multiple policies, cluster has multiple policies → ONLY cluster
 // policies used.
-TEST_P(ClusterShadowPolicyIntegrationTest, PrecedenceClusterOverridesRouteMultiplePolicies) {
-  // Need 5 upstreams: cluster_0 (main), cluster_1-2 (route targets), cluster_3-4 (cluster targets).
+TEST_P(ClusterHttpProtocolOptionsIntegrationTest,
+       PrecedenceClusterOverridesRouteMultipleMirrorPolicies) {
+  // Need 5 upstreams: cluster_0 (main), cluster_1-2 (route targets), cluster_3-4 (cluster
+  // targets).
   setUpstreamCountForTest(5);
 
   config_helper_.addConfigModifier([](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
@@ -483,6 +536,335 @@ TEST_P(ClusterShadowPolicyIntegrationTest, PrecedenceClusterOverridesRouteMultip
   EXPECT_EQ(0, test_server_->counter("cluster.cluster_2.upstream_rq_total")->value());
   EXPECT_EQ(1, test_server_->counter("cluster.cluster_3.upstream_rq_total")->value());
   EXPECT_EQ(1, test_server_->counter("cluster.cluster_4.upstream_rq_total")->value());
+}
+
+// ============================================================================
+// Hash Policy Tests
+// ============================================================================
+
+// Test basic cluster-level hash policy with header-based hashing.
+TEST_P(ClusterHttpProtocolOptionsIntegrationTest, BasicClusterLevelHashPolicy) {
+  setUpstreamCountForTest(3);
+  setupClusterHashPolicy();
+  initialize();
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+
+  // Send two requests with the same user ID - they should go to the same upstream.
+  Http::TestRequestHeaderMapImpl request_headers{{":method", "GET"},
+                                                 {":path", "/test"},
+                                                 {":scheme", "http"},
+                                                 {":authority", "sni.lyft.com"},
+                                                 {"x-user-id", "user123"}};
+
+  IntegrationStreamDecoderPtr response1 = codec_client_->makeHeaderOnlyRequest(request_headers);
+  ASSERT_TRUE(response1->waitForEndStream());
+  EXPECT_TRUE(response1->complete());
+  EXPECT_EQ("200", response1->headers().getStatusValue());
+
+  IntegrationStreamDecoderPtr response2 = codec_client_->makeHeaderOnlyRequest(request_headers);
+  ASSERT_TRUE(response2->waitForEndStream());
+  EXPECT_TRUE(response2->complete());
+  EXPECT_EQ("200", response2->headers().getStatusValue());
+
+  // Both requests should have been routed to the same upstream based on consistent hashing.
+  cleanupUpstreamAndDownstream();
+}
+
+// Test that when route has policies and cluster has no policies then the route policies are used.
+TEST_P(ClusterHttpProtocolOptionsIntegrationTest, PrecedenceRouteOnlyHashPolicy) {
+  setUpstreamCountForTest(3);
+  configureClusterWithRingHash(3);
+
+  // Configure route-level hash policy.
+  config_helper_.addConfigModifier(
+      [](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
+             hcm) {
+        auto* hash_policy = hcm.mutable_route_config()
+                                ->mutable_virtual_hosts(0)
+                                ->mutable_routes(0)
+                                ->mutable_route()
+                                ->add_hash_policy();
+        hash_policy->mutable_header()->set_header_name("x-session-id");
+      });
+
+  initialize();
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+
+  // Send request with session-id header (route-level policy).
+  Http::TestRequestHeaderMapImpl request_headers{{":method", "GET"},
+                                                 {":path", "/test"},
+                                                 {":scheme", "http"},
+                                                 {":authority", "sni.lyft.com"},
+                                                 {"x-session-id", "session456"}};
+
+  IntegrationStreamDecoderPtr response = codec_client_->makeHeaderOnlyRequest(request_headers);
+  ASSERT_TRUE(response->waitForEndStream());
+  EXPECT_TRUE(response->complete());
+  EXPECT_EQ("200", response->headers().getStatusValue());
+
+  cleanupUpstreamAndDownstream();
+}
+
+// Test that when route has no policies and cluster has policies then cluster policies are used.
+TEST_P(ClusterHttpProtocolOptionsIntegrationTest, PrecedenceClusterOnlyHashPolicy) {
+  setUpstreamCountForTest(3);
+  configureClusterWithRingHash(3);
+
+  config_helper_.addConfigModifier([](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
+    auto* main_cluster = bootstrap.mutable_static_resources()->mutable_clusters(0);
+
+    // Add HTTP protocol options with cluster-level hash policy.
+    auto& options_any = (*main_cluster->mutable_typed_extension_protocol_options())
+        ["envoy.extensions.upstreams.http.v3.HttpProtocolOptions"];
+    envoy::extensions::upstreams::http::v3::HttpProtocolOptions options;
+    options.mutable_explicit_http_config()->mutable_http2_protocol_options();
+
+    // Add header-based hash policy.
+    auto* hash_policy = options.add_hash_policy();
+    hash_policy->mutable_header()->set_header_name("x-user-id");
+    options_any.PackFrom(options);
+  });
+
+  // Do NOT configure route-level hash policy.
+  initialize();
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+
+  // Send request with user-id header (cluster-level policy).
+  Http::TestRequestHeaderMapImpl request_headers{{":method", "GET"},
+                                                 {":path", "/test"},
+                                                 {":scheme", "http"},
+                                                 {":authority", "sni.lyft.com"},
+                                                 {"x-user-id", "user789"}};
+
+  IntegrationStreamDecoderPtr response = codec_client_->makeHeaderOnlyRequest(request_headers);
+  ASSERT_TRUE(response->waitForEndStream());
+  EXPECT_TRUE(response->complete());
+  EXPECT_EQ("200", response->headers().getStatusValue());
+
+  cleanupUpstreamAndDownstream();
+}
+
+// Test that when route has policies, cluster has policies then only cluster policies are used.
+TEST_P(ClusterHttpProtocolOptionsIntegrationTest, PrecedenceClusterOverridesRouteHashPolicy) {
+  setUpstreamCountForTest(3);
+  configureClusterWithRingHash(3);
+
+  config_helper_.addConfigModifier([](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
+    auto* main_cluster = bootstrap.mutable_static_resources()->mutable_clusters(0);
+
+    // Add HTTP protocol options with cluster-level hash policy on x-cluster-user.
+    auto& options_any = (*main_cluster->mutable_typed_extension_protocol_options())
+        ["envoy.extensions.upstreams.http.v3.HttpProtocolOptions"];
+    envoy::extensions::upstreams::http::v3::HttpProtocolOptions options;
+    options.mutable_explicit_http_config()->mutable_http2_protocol_options();
+
+    auto* hash_policy = options.add_hash_policy();
+    hash_policy->mutable_header()->set_header_name("x-cluster-user");
+    options_any.PackFrom(options);
+  });
+
+  // Configure route-level hash policy on x-route-user.
+  config_helper_.addConfigModifier(
+      [](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
+             hcm) {
+        auto* hash_policy = hcm.mutable_route_config()
+                                ->mutable_virtual_hosts(0)
+                                ->mutable_routes(0)
+                                ->mutable_route()
+                                ->add_hash_policy();
+        hash_policy->mutable_header()->set_header_name("x-route-user");
+      });
+
+  initialize();
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+
+  // Send two requests: same cluster header but different route header.
+  // If cluster policy is used, they should go to the same upstream.
+  // If route policy is used, they would go to different upstreams.
+  Http::TestRequestHeaderMapImpl request_headers1{{":method", "GET"},
+                                                  {":path", "/test"},
+                                                  {":scheme", "http"},
+                                                  {":authority", "sni.lyft.com"},
+                                                  {"x-cluster-user", "same-user"},
+                                                  {"x-route-user", "user-a"}};
+
+  Http::TestRequestHeaderMapImpl request_headers2{{":method", "GET"},
+                                                  {":path", "/test"},
+                                                  {":scheme", "http"},
+                                                  {":authority", "sni.lyft.com"},
+                                                  {"x-cluster-user", "same-user"},
+                                                  {"x-route-user", "user-b"}};
+
+  IntegrationStreamDecoderPtr response1 = codec_client_->makeHeaderOnlyRequest(request_headers1);
+  ASSERT_TRUE(response1->waitForEndStream());
+  EXPECT_TRUE(response1->complete());
+  EXPECT_EQ("200", response1->headers().getStatusValue());
+
+  IntegrationStreamDecoderPtr response2 = codec_client_->makeHeaderOnlyRequest(request_headers2);
+  ASSERT_TRUE(response2->waitForEndStream());
+  EXPECT_TRUE(response2->complete());
+  EXPECT_EQ("200", response2->headers().getStatusValue());
+
+  cleanupUpstreamAndDownstream();
+}
+
+// Test cluster-level hash policy with Maglev load balancer.
+TEST_P(ClusterHttpProtocolOptionsIntegrationTest, ClusterHashPolicyWithMaglev) {
+  setUpstreamCountForTest(3);
+
+  auto ip_version = GetParam();
+  config_helper_.addConfigModifier(
+      [ip_version](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
+        auto* main_cluster = bootstrap.mutable_static_resources()->mutable_clusters(0);
+        main_cluster->set_lb_policy(envoy::config::cluster::v3::Cluster::MAGLEV);
+
+        // Clear and properly configure load assignment with the correct number of endpoints.
+        main_cluster->clear_load_assignment();
+        auto* load_assignment = main_cluster->mutable_load_assignment();
+        load_assignment->set_cluster_name(main_cluster->name());
+        auto* endpoints = load_assignment->add_endpoints();
+
+        for (int i = 0; i < 3; i++) {
+          auto* socket = endpoints->add_lb_endpoints()
+                             ->mutable_endpoint()
+                             ->mutable_address()
+                             ->mutable_socket_address();
+          socket->set_address(Network::Test::getLoopbackAddressString(ip_version));
+          socket->set_port_value(0); // Port will be filled by ConfigHelper.
+        }
+
+        // Add HTTP protocol options with cluster-level hash policy.
+        auto& options_any = (*main_cluster->mutable_typed_extension_protocol_options())
+            ["envoy.extensions.upstreams.http.v3.HttpProtocolOptions"];
+        envoy::extensions::upstreams::http::v3::HttpProtocolOptions options;
+        options.mutable_explicit_http_config()->mutable_http2_protocol_options();
+
+        // Add header-based hash policy.
+        auto* hash_policy = options.add_hash_policy();
+        hash_policy->mutable_header()->set_header_name("x-account-id");
+        options_any.PackFrom(options);
+      });
+
+  initialize();
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+
+  // Send requests with the same account ID. They should go to the same upstream.
+  Http::TestRequestHeaderMapImpl request_headers{{":method", "GET"},
+                                                 {":path", "/test"},
+                                                 {":scheme", "http"},
+                                                 {":authority", "sni.lyft.com"},
+                                                 {"x-account-id", "account999"}};
+
+  IntegrationStreamDecoderPtr response1 = codec_client_->makeHeaderOnlyRequest(request_headers);
+  ASSERT_TRUE(response1->waitForEndStream());
+  EXPECT_TRUE(response1->complete());
+  EXPECT_EQ("200", response1->headers().getStatusValue());
+
+  IntegrationStreamDecoderPtr response2 = codec_client_->makeHeaderOnlyRequest(request_headers);
+  ASSERT_TRUE(response2->waitForEndStream());
+  EXPECT_TRUE(response2->complete());
+  EXPECT_EQ("200", response2->headers().getStatusValue());
+
+  cleanupUpstreamAndDownstream();
+}
+
+// Test cluster-level hash policy with connection properties (source IP).
+TEST_P(ClusterHttpProtocolOptionsIntegrationTest, ClusterHashPolicySourceIp) {
+  setUpstreamCountForTest(3);
+  configureClusterWithRingHash(3);
+
+  config_helper_.addConfigModifier([](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
+    auto* main_cluster = bootstrap.mutable_static_resources()->mutable_clusters(0);
+
+    // Add HTTP protocol options with source IP hash policy.
+    auto& options_any = (*main_cluster->mutable_typed_extension_protocol_options())
+        ["envoy.extensions.upstreams.http.v3.HttpProtocolOptions"];
+    envoy::extensions::upstreams::http::v3::HttpProtocolOptions options;
+    options.mutable_explicit_http_config()->mutable_http2_protocol_options();
+
+    auto* hash_policy = options.add_hash_policy();
+    hash_policy->mutable_connection_properties()->set_source_ip(true);
+    options_any.PackFrom(options);
+  });
+
+  initialize();
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+
+  // Send multiple requests. They should all go to the same upstream since they're from
+  // the same client IP.
+  Http::TestRequestHeaderMapImpl request_headers{
+      {":method", "GET"}, {":path", "/test"}, {":scheme", "http"}, {":authority", "sni.lyft.com"}};
+
+  for (int i = 0; i < 5; i++) {
+    IntegrationStreamDecoderPtr response = codec_client_->makeHeaderOnlyRequest(request_headers);
+    ASSERT_TRUE(response->waitForEndStream());
+    EXPECT_TRUE(response->complete());
+    EXPECT_EQ("200", response->headers().getStatusValue());
+  }
+
+  cleanupUpstreamAndDownstream();
+}
+
+// Test cluster-level hash policy with multiple hash policies.
+TEST_P(ClusterHttpProtocolOptionsIntegrationTest, ClusterMultipleHashPolicies) {
+  setUpstreamCountForTest(3);
+  configureClusterWithRingHash(3);
+
+  config_helper_.addConfigModifier([](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
+    auto* main_cluster = bootstrap.mutable_static_resources()->mutable_clusters(0);
+
+    auto& options_any = (*main_cluster->mutable_typed_extension_protocol_options())
+        ["envoy.extensions.upstreams.http.v3.HttpProtocolOptions"];
+    envoy::extensions::upstreams::http::v3::HttpProtocolOptions options;
+    options.mutable_explicit_http_config()->mutable_http2_protocol_options();
+
+    // First policy: x-primary header (non-terminal).
+    auto* hash_policy1 = options.add_hash_policy();
+    hash_policy1->mutable_header()->set_header_name("x-primary");
+    hash_policy1->set_terminal(false);
+
+    // Second policy: x-fallback header.
+    auto* hash_policy2 = options.add_hash_policy();
+    hash_policy2->mutable_header()->set_header_name("x-fallback");
+
+    options_any.PackFrom(options);
+  });
+
+  initialize();
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+
+  // Test with primary header present.
+  Http::TestRequestHeaderMapImpl request_headers1{{":method", "GET"},
+                                                  {":path", "/test"},
+                                                  {":scheme", "http"},
+                                                  {":authority", "sni.lyft.com"},
+                                                  {"x-primary", "value1"}};
+
+  IntegrationStreamDecoderPtr response1 = codec_client_->makeHeaderOnlyRequest(request_headers1);
+  ASSERT_TRUE(response1->waitForEndStream());
+  EXPECT_TRUE(response1->complete());
+  EXPECT_EQ("200", response1->headers().getStatusValue());
+
+  // Test with only fallback header present.
+  Http::TestRequestHeaderMapImpl request_headers2{{":method", "GET"},
+                                                  {":path", "/test"},
+                                                  {":scheme", "http"},
+                                                  {":authority", "sni.lyft.com"},
+                                                  {"x-fallback", "value2"}};
+
+  IntegrationStreamDecoderPtr response2 = codec_client_->makeHeaderOnlyRequest(request_headers2);
+  ASSERT_TRUE(response2->waitForEndStream());
+  EXPECT_TRUE(response2->complete());
+  EXPECT_EQ("200", response2->headers().getStatusValue());
+
+  cleanupUpstreamAndDownstream();
 }
 
 } // namespace

--- a/test/mocks/upstream/cluster_info.cc
+++ b/test/mocks/upstream/cluster_info.cc
@@ -177,6 +177,7 @@ MockClusterInfo::MockClusterInfo()
             lrs_report_metric_names_.get());
       }));
   ON_CALL(*this, shadowPolicies()).WillByDefault(ReturnRef(shadow_policies_));
+  ON_CALL(*this, hashPolicy()).WillByDefault(Return(nullptr));
 }
 
 MockClusterInfo::~MockClusterInfo() = default;

--- a/test/mocks/upstream/cluster_info.h
+++ b/test/mocks/upstream/cluster_info.h
@@ -179,6 +179,7 @@ public:
       happyEyeballsConfig, (), (const));
   MOCK_METHOD(OptRef<const std::vector<std::string>>, lrsReportMetricNames, (), (const));
   MOCK_METHOD(const std::vector<Router::ShadowPolicyPtr>&, shadowPolicies, (), (const));
+  MOCK_METHOD(const Http::HashPolicy*, hashPolicy, (), (const));
   ::Envoy::Http::HeaderValidatorStats& codecStats(Http::Protocol protocol) const;
   Http::Http1::CodecStats& http1CodecStats() const override;
   Http::Http2::CodecStats& http2CodecStats() const override;


### PR DESCRIPTION
## Description

Currently, the hashing policy is defined on the per-route basis [[Link]](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto.html?highlight=hash_policy#envoy-v3-api-msg-config-route-v3-routeaction-hashpolicy) using `hash_policy`. 

We have a use-case where we want to do sticky routing for all the incoming traffic for the external [ExtAuthZ](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/http/ext_authz/v3/ext_authz.proto#extensions-filters-http-ext-authz-v3-extauthz) and [RateLimit](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/http/ratelimit/v3/rate_limit.proto#envoy-v3-api-msg-extensions-filters-http-ratelimit-v3-ratelimit) services and we can benefit a lot from a consistent hash Load Balancing like [Ring Hash](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/load_balancing/load_balancers#ring-hash) and [Maglev](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/load_balancing/load_balancers#maglev).

This PR adds this support.

Fix https://github.com/envoyproxy/envoy/issues/23060

---

**Commit Message:** router: added hash_policy to HttpProtocolOptions to support sticky routing
**Additional Description:** Added support for hash_policy on the cluster-level.
**Risk Level:** Low
**Testing:** Added Unit & Integration Tests
**Docs Changes:** Added
**Release Notes:** Added