### PR TITLE
ext_authz: fixed a bug to honor filter_enabled_metadata when the filter is marked with disabled=true

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -54,6 +54,11 @@ minor_behavior_changes:
     Fixed HTTP ext_authz service to properly propagate headers (such as ``set-cookie``) back to clients. The
     filter now correctly uses ``allowed_client_headers`` for denied responses and ``allowed_client_headers_on_success``
     for successful authorization responses.
+- area: ext_authz
+  change: |
+    Fixed a bug where ``filter_enabled_metadata`` was not honored when the filter was marked with ``disabled: true``.
+    The filter is now instantiated when ``filter_enabled_metadata`` is configured, allowing it to check dynamic metadata
+    at runtime and enable itself conditionally.
 - area: quic
   change: |
     Switch to use QUICHE provided migration logic to handle port migration upon path degrading and migration to Server

--- a/envoy/server/filter_config.h
+++ b/envoy/server/filter_config.h
@@ -305,6 +305,16 @@ public:
                                        Server::Configuration::ServerFactoryContext&) {
     return false;
   }
+
+  /**
+   * @return bool true if the filter should ignore the 'disabled' flag during filter chain creation.
+   * This allows filters to defer the enable/disable decision to runtime based on dynamic metadata
+   * or other runtime conditions. By default returns false.
+   */
+  virtual bool shouldIgnoreDisabledFlag(const Protobuf::Message&,
+                                        Server::Configuration::ServerFactoryContext&) {
+    return false;
+  }
 };
 
 class NamedHttpFilterConfigFactory : public virtual HttpFilterConfigFactoryBase {

--- a/source/extensions/filters/http/ext_authz/config.h
+++ b/source/extensions/filters/http/ext_authz/config.h
@@ -21,6 +21,15 @@ class ExtAuthzFilterConfig
 public:
   ExtAuthzFilterConfig() : FactoryBase("envoy.filters.http.ext_authz") {}
 
+  bool shouldIgnoreDisabledFlag(const Protobuf::Message& config,
+                                Server::Configuration::ServerFactoryContext&) override {
+    const auto& typed_config =
+        dynamic_cast<const envoy::extensions::filters::http::ext_authz::v3::ExtAuthz&>(config);
+    // If filter_enabled_metadata is configured, the filter needs to be instantiated
+    // to check metadata at runtime, so ignore the disabled flag.
+    return typed_config.has_filter_enabled_metadata();
+  }
+
 private:
   static constexpr uint64_t DefaultTimeout = 200;
   Http::FilterFactoryCb createFilterFactoryFromProtoTyped(

--- a/test/extensions/filters/http/ext_authz/config_test.cc
+++ b/test/extensions/filters/http/ext_authz/config_test.cc
@@ -711,6 +711,72 @@ TEST_F(ExtAuthzFilterGrpcTest, GoogleGrpc) {
   testFilterFactoryAndFilterWithGrpcClient(ext_authz_config_yaml);
 }
 
+// Test that shouldIgnoreDisabledFlag returns true when filter_enabled_metadata is configured.
+TEST(ExtAuthzFilterConfigTest, ShouldIgnoreDisabledFlagWithMetadata) {
+  const std::string yaml = R"EOF(
+  grpc_service:
+    envoy_grpc:
+      cluster_name: "ext_authz_server"
+  filter_enabled_metadata:
+    filter: "abc.xyz"
+    path:
+    - key: "k1"
+    value:
+      string_match:
+        exact: "check"
+  )EOF";
+
+  ExtAuthzFilterConfig factory;
+  envoy::extensions::filters::http::ext_authz::v3::ExtAuthz config;
+  TestUtility::loadFromYaml(yaml, config);
+
+  NiceMock<Server::Configuration::MockServerFactoryContext> context;
+
+  // The filter should ignore the disabled flag when filter_enabled_metadata is configured.
+  EXPECT_TRUE(factory.shouldIgnoreDisabledFlag(config, context));
+}
+
+// Test that shouldIgnoreDisabledFlag returns false when filter_enabled_metadata is NOT configured.
+TEST(ExtAuthzFilterConfigTest, ShouldNotIgnoreDisabledFlagWithoutMetadata) {
+  const std::string yaml = R"EOF(
+  grpc_service:
+    envoy_grpc:
+      cluster_name: "ext_authz_server"
+  )EOF";
+
+  ExtAuthzFilterConfig factory;
+  envoy::extensions::filters::http::ext_authz::v3::ExtAuthz config;
+  TestUtility::loadFromYaml(yaml, config);
+
+  NiceMock<Server::Configuration::MockServerFactoryContext> context;
+
+  // The filter should respect the disabled flag when filter_enabled_metadata is not configured.
+  EXPECT_FALSE(factory.shouldIgnoreDisabledFlag(config, context));
+}
+
+// Test that shouldIgnoreDisabledFlag returns false when only filter_enabled is configured.
+TEST(ExtAuthzFilterConfigTest, ShouldNotIgnoreDisabledFlagWithOnlyFilterEnabled) {
+  const std::string yaml = R"EOF(
+  grpc_service:
+    envoy_grpc:
+      cluster_name: "ext_authz_server"
+  filter_enabled:
+    runtime_key: "http.ext_authz.enabled"
+    default_value:
+      numerator: 100
+      denominator: HUNDRED
+  )EOF";
+
+  ExtAuthzFilterConfig factory;
+  envoy::extensions::filters::http::ext_authz::v3::ExtAuthz config;
+  TestUtility::loadFromYaml(yaml, config);
+
+  NiceMock<Server::Configuration::MockServerFactoryContext> context;
+
+  // The filter should respect the disabled flag when only filter_enabled is configured.
+  EXPECT_FALSE(factory.shouldIgnoreDisabledFlag(config, context));
+}
+
 } // namespace ExtAuthz
 } // namespace HttpFilters
 } // namespace Extensions

--- a/test/extensions/filters/http/ext_authz/ext_authz_integration_test.cc
+++ b/test/extensions/filters/http/ext_authz/ext_authz_integration_test.cc
@@ -2237,7 +2237,6 @@ TEST_P(ExtAuthzGrpcIntegrationTest, EncodeHeadersToAppendIfAbsentExceedsLimit) {
   EXPECT_TRUE(response_->headers().get(Http::LowerCaseString("new-header-99")).empty());
   cleanup();
 }
-
 // Regression test for https://github.com/envoyproxy/envoy/issues/17344
 TEST(ExtConfigValidateTest, Validate) {
   Server::TestComponentFactory component_factory;


### PR DESCRIPTION
## Description

This PR fixes a bug to honor ``filter_enabled_metadata`` when the filter is marked with ``disabled: true``. The filter is now instantiated when ``filter_enabled_metadata`` is configured, allowing it to check dynamic metadata at runtime and enable itself conditionally.

Fix https://github.com/envoyproxy/envoy/issues/41501

---

**Commit Message:** ext_authz: fixed a bug to honor filter_enabled_metadata when the filter is marked with disabled=true
**Additional Description:** Fixes a bug to honor ``filter_enabled_metadata`` when the filter is marked with ``disabled: true``.
**Risk Level:** Low
**Testing:** Added Tests
**Docs Changes:** N/A
**Release Notes:** Added