### PR TITLE
Use mutex reference in lock constructors p4

### DIFF
--- a/source/common/signal/fatal_error_handler.cc
+++ b/source/common/signal/fatal_error_handler.cc
@@ -103,7 +103,7 @@ FatalAction::Status runFatalActions(FatalActionType action_type) {
 
 void registerFatalErrorHandler(const FatalErrorHandlerInterface& handler) {
 #ifdef ENVOY_OBJECT_TRACE_ON_DUMP
-  absl::MutexLock l(&failure_mutex);
+  absl::MutexLock l(failure_mutex);
   FailureFunctionList* list = fatal_error_handlers.exchange(nullptr);
   if (list == nullptr) {
     list = new FailureFunctionList;
@@ -118,7 +118,7 @@ void registerFatalErrorHandler(const FatalErrorHandlerInterface& handler) {
 
 void removeFatalErrorHandler(const FatalErrorHandlerInterface& handler) {
 #ifdef ENVOY_OBJECT_TRACE_ON_DUMP
-  absl::MutexLock l(&failure_mutex);
+  absl::MutexLock l(failure_mutex);
   FailureFunctionList* list = fatal_error_handlers.exchange(nullptr);
   if (list == nullptr) {
     // removeFatalErrorHandler() may see an empty list of fatal error handlers

--- a/source/extensions/common/dynamic_forward_proxy/cluster_store.cc
+++ b/source/extensions/common/dynamic_forward_proxy/cluster_store.cc
@@ -9,7 +9,7 @@ SINGLETON_MANAGER_REGISTRATION(dynamic_forward_proxy_cluster_store);
 
 DfpClusterSharedPtr DFPClusterStore::load(const std::string cluster_name) {
   ClusterStoreType& clusterStore = getClusterStore();
-  absl::ReaderMutexLock lock(&clusterStore.mutex_);
+  absl::ReaderMutexLock lock(clusterStore.mutex_);
   auto it = clusterStore.map_.find(cluster_name);
   if (it != clusterStore.map_.end()) {
     return it->second.lock();
@@ -19,13 +19,13 @@ DfpClusterSharedPtr DFPClusterStore::load(const std::string cluster_name) {
 
 void DFPClusterStore::save(const std::string cluster_name, DfpClusterSharedPtr cluster) {
   ClusterStoreType& clusterStore = getClusterStore();
-  absl::WriterMutexLock lock(&clusterStore.mutex_);
+  absl::WriterMutexLock lock(clusterStore.mutex_);
   clusterStore.map_[cluster_name] = std::move(cluster);
 }
 
 void DFPClusterStore::remove(const std::string cluster_name) {
   ClusterStoreType& clusterStore = getClusterStore();
-  absl::WriterMutexLock lock(&clusterStore.mutex_);
+  absl::WriterMutexLock lock(clusterStore.mutex_);
   clusterStore.map_.erase(cluster_name);
 }
 


### PR DESCRIPTION
Replace deprecated absl::MutexLock::MutexLock(Mutex*) constructor with absl::MutexLock::MutexLock(Mutex&)

Additional Description: needed due to upcoming absl change.
Similar to #41208.

Risk Level: low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A