### PR TITLE
fix: add module declaration to go.mod in api/

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -1,1 +1,0 @@
-module github.com/envoyproxy/envoy/api


### PR DESCRIPTION
As far as I can tell, a completely empty go.mod is invalid. Certain `go` tools like `go list` throw an error when reading this (it also makes my IDE (GoLand) complain about this go.mod every time the envoy repo is opened):

```
~/go/src/github.com/envoyproxy/envoy/api (main)$ go list -mod mod all
go: error reading go.mod: missing module declaration. To specify the module path:
		go mod edit -module=example.com/mod
```

It seems to have been like this for a
[_long_](https://github.com/envoyproxy/envoy/pull/26606/files#diff-ba0784a950902285760f839a4ad720a381b2981e8a67147f5f43f7508e6343ed) time, however I could not find any other PRs / issues about this.

Fixing it by simply adding the `module` directive in the file.

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
