### PR TITLE
Use mutex reference in lock constructors p7

### DIFF
--- a/source/extensions/common/async_files/async_file_manager_factory.cc
+++ b/source/extensions/common/async_files/async_file_manager_factory.cc
@@ -50,7 +50,7 @@ std::shared_ptr<AsyncFileManager> AsyncFileManagerFactoryImpl::getAsyncFileManag
   Api::OsSysCalls& posix = substitute_posix_file_operations == nullptr
                                ? Api::OsSysCallsSingleton::get()
                                : *substitute_posix_file_operations;
-  absl::MutexLock lock(&mu_);
+  absl::MutexLock lock(mu_);
   auto it = managers_.find(config.id());
   if (it == managers_.end()) {
     switch (config.manager_type_case()) {

--- a/source/extensions/common/wasm/stats_handler.cc
+++ b/source/extensions/common/wasm/stats_handler.cc
@@ -10,7 +10,7 @@ namespace Common {
 namespace Wasm {
 
 Stats::ScopeSharedPtr CreateStatsHandler::lockAndCreateStats(const Stats::ScopeSharedPtr& scope) {
-  absl::MutexLock l(&mutex_);
+  absl::MutexLock l(mutex_);
   Stats::ScopeSharedPtr lock;
   if (!(lock = scope_.lock())) {
     resetStats();
@@ -23,7 +23,7 @@ Stats::ScopeSharedPtr CreateStatsHandler::lockAndCreateStats(const Stats::ScopeS
 }
 
 void CreateStatsHandler::resetStatsForTesting() {
-  absl::MutexLock l(&mutex_);
+  absl::MutexLock l(mutex_);
   resetStats();
 }
 

--- a/source/extensions/network/dns_resolver/cares/dns_impl.cc
+++ b/source/extensions/network/dns_resolver/cares/dns_impl.cc
@@ -680,7 +680,7 @@ public:
 
   void initialize() override {
     // Initialize c-ares library in case first time.
-    absl::MutexLock lock(&mutex_);
+    absl::MutexLock lock(mutex_);
     if (!ares_library_initialized_) {
       ares_library_initialized_ = true;
       ENVOY_LOG(trace, "c-ares library initialized.");
@@ -689,7 +689,7 @@ public:
   }
   void terminate() override {
     // Cleanup c-ares library if initialized.
-    absl::MutexLock lock(&mutex_);
+    absl::MutexLock lock(mutex_);
     if (ares_library_initialized_) {
       ares_library_initialized_ = false;
       ENVOY_LOG(trace, "c-ares library cleaned up.");


### PR DESCRIPTION
Replace deprecated absl::MutexLock::MutexLock(Mutex*) constructor with absl::MutexLock::MutexLock(Mutex&)

Additional Description: needed due to upcoming absl change.
Similar to #41208.

Risk Level: low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A