### PR TITLE
Use mutex reference in lock constructors p8

### DIFF
--- a/test/integration/fake_upstream.cc
+++ b/test/integration/fake_upstream.cc
@@ -839,7 +839,7 @@ FakeUpstream::waitForHttpConnection(Event::Dispatcher& client_dispatcher,
     for (size_t i = 0; i < upstreams.size(); ++i) {
       FakeUpstream& upstream = *upstreams[i];
       {
-        absl::MutexLock lock(&upstream.lock_);
+        absl::MutexLock lock(upstream.lock_);
         if (!upstream.isInitialized()) {
           return absl::InternalError(
               "Must initialize the FakeUpstream first by calling initializeServer().");
@@ -855,7 +855,7 @@ FakeUpstream::waitForHttpConnection(Event::Dispatcher& client_dispatcher,
       }
 
       EXPECT_TRUE(upstream.runOnDispatcherThreadAndWait([&]() {
-        absl::MutexLock lock(&upstream.lock_);
+        absl::MutexLock lock(upstream.lock_);
         connection = std::make_unique<FakeHttpConnection>(
             upstream, upstream.consumeConnection(), upstream.http_type_, upstream.timeSystem(),
             Http::DEFAULT_MAX_REQUEST_HEADERS_KB, Http::DEFAULT_MAX_HEADERS_COUNT,

--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -72,20 +72,20 @@ public:
              Event::TestTimeSystem& time_system);
 
   uint64_t bodyLength() {
-    absl::MutexLock lock(&lock_);
+    absl::MutexLock lock(lock_);
     return body_.length();
   }
   // Returns a buffer containing the data that was received since the last
   // invocation of `body()` or since the stream first received data.
   Buffer::OwnedImpl body() {
-    absl::MutexLock lock(&lock_);
+    absl::MutexLock lock(lock_);
     Buffer::OwnedImpl body_ret;
     body_ret.move(body_);
     ASSERT(body_.length() == 0);
     return body_ret;
   }
   bool complete() {
-    absl::MutexLock lock(&lock_);
+    absl::MutexLock lock(lock_);
     return end_stream_;
   }
 
@@ -103,7 +103,7 @@ public:
   void encodeMetadata(const Http::MetadataMapVector& metadata_map_vector);
   void readDisable(bool disable);
   const Http::RequestHeaderMap& headers() {
-    absl::MutexLock lock(&lock_);
+    absl::MutexLock lock(lock_);
     if (client_headers_ != headers_) {
       client_headers_ = headers_;
     }
@@ -111,7 +111,7 @@ public:
   }
   void setAddServedByHeader(bool add_header) { add_served_by_header_ = add_header; }
   Http::RequestTrailerMapConstSharedPtr trailers() {
-    absl::MutexLock lock(&lock_);
+    absl::MutexLock lock(lock_);
     Http::RequestTrailerMapConstSharedPtr trailers{trailers_};
     return trailers;
   }
@@ -126,7 +126,7 @@ public:
                  absl::string_view /*details*/) override {
     bool is_head_request;
     {
-      absl::MutexLock lock(&lock_);
+      absl::MutexLock lock(lock_);
       is_head_request = headers_ != nullptr &&
                         headers_->getMethodValue() == Http::Headers::get().MethodValues.Head;
     }
@@ -214,7 +214,7 @@ public:
     }
     int last_body_size = 0;
     {
-      absl::MutexLock lock(&lock_);
+      absl::MutexLock lock(lock_);
       last_body_size = body_.length();
       if (!grpc_decoder_.decode(body_, decoded_grpc_frames_).ok()) {
         return testing::AssertionFailure()
@@ -227,7 +227,7 @@ public:
         return testing::AssertionFailure() << "Timed out waiting for end of gRPC message.";
       }
       {
-        absl::MutexLock lock(&lock_);
+        absl::MutexLock lock(lock_);
         if (!grpc_decoder_.decode(body_, decoded_grpc_frames_).ok()) {
           return testing::AssertionFailure()
                  << "Couldn't decode gRPC data frame: " << body_.toString();
@@ -356,7 +356,7 @@ public:
     // callback is invoked prior to connection_ deferred delete. We also know by locking below,
     // that elsewhere where we also hold lock_, that the connection cannot disappear inside the
     // locked scope.
-    absl::MutexLock lock(&lock_);
+    absl::MutexLock lock(lock_);
     if (event == Network::ConnectionEvent::RemoteClose ||
         event == Network::ConnectionEvent::LocalClose) {
       if (connection_.detectedCloseType() == Network::DetectedCloseType::RemoteReset ||
@@ -373,7 +373,7 @@ public:
   Event::Dispatcher& dispatcher() { return dispatcher_; }
 
   bool connected() {
-    absl::MutexLock lock(&lock_);
+    absl::MutexLock lock(lock_);
     return connectedLockHeld();
   }
 
@@ -403,7 +403,7 @@ public:
   executeOnDispatcher(std::function<void(Network::Connection&)> f,
                       std::chrono::milliseconds timeout = TestUtility::DefaultTimeout,
                       bool allow_disconnects = true) {
-    absl::MutexLock lock(&lock_);
+    absl::MutexLock lock(lock_);
     if (disconnected_) {
       return testing::AssertionSuccess();
     }
@@ -423,7 +423,7 @@ public:
           } else {
             unexpected_disconnect = true;
           }
-          absl::MutexLock lock_guard(&lock);
+          absl::MutexLock lock_guard(lock);
           callback_ready_event = true;
         });
     Event::TestTimeSystem& time_system =
@@ -440,7 +440,7 @@ public:
   absl::Mutex& lock() { return lock_; }
 
   void setParented() {
-    absl::MutexLock lock(&lock_);
+    absl::MutexLock lock(lock_);
     ASSERT(!parented_);
     parented_ = true;
   }
@@ -462,7 +462,7 @@ using SharedConnectionWrapperPtr = std::unique_ptr<SharedConnectionWrapper>;
 class FakeConnectionBase : public Logger::Loggable<Logger::Id::testing> {
 public:
   virtual ~FakeConnectionBase() {
-    absl::MutexLock lock(&lock_);
+    absl::MutexLock lock(lock_);
     ASSERT(initialized_);
     ASSERT(pending_cbs_ == 0);
   }
@@ -491,7 +491,7 @@ public:
   waitForHalfClose(std::chrono::milliseconds timeout = TestUtility::DefaultTimeout);
 
   virtual void initialize() {
-    absl::MutexLock lock(&lock_);
+    absl::MutexLock lock(lock_);
     initialized_ = true;
   }
 
@@ -671,7 +671,7 @@ public:
   }
 
   void clearData() {
-    absl::MutexLock lock(&lock_);
+    absl::MutexLock lock(lock_);
     data_.clear();
   }
 

--- a/test/integration/filters/pause_filter.cc
+++ b/test/integration/filters/pause_filter.cc
@@ -24,7 +24,7 @@ public:
 
   Http::FilterDataStatus decodeData(Buffer::Instance& buf, bool end_stream) override {
     if (end_stream) {
-      absl::WriterMutexLock m(&encode_lock_);
+      absl::WriterMutexLock m(encode_lock_);
       number_of_decode_calls_ref_++;
       // If this is the second stream to decode headers and we're at high watermark. force low
       // watermark state
@@ -37,7 +37,7 @@ public:
 
   Http::FilterDataStatus encodeData(Buffer::Instance& buf, bool end_stream) override {
     if (end_stream) {
-      absl::WriterMutexLock m(&encode_lock_);
+      absl::WriterMutexLock m(encode_lock_);
       number_of_encode_calls_ref_++;
       // If this is the first stream to encode headers and we're not at high watermark, force high
       // watermark state.
@@ -71,7 +71,7 @@ public:
     return [&](Http::FilterChainFactoryCallbacks& callbacks) -> void {
       // ABSL_GUARDED_BY insists the lock be held when the guarded variables are passed by
       // reference.
-      absl::WriterMutexLock m(&encode_lock_);
+      absl::WriterMutexLock m(encode_lock_);
       callbacks.addStreamFilter(std::make_shared<::Envoy::TestPauseFilter>(
           encode_lock_, number_of_encode_calls_, number_of_decode_calls_));
     };

--- a/test/integration/filters/pause_filter_for_quic.cc
+++ b/test/integration/filters/pause_filter_for_quic.cc
@@ -24,7 +24,7 @@ public:
 
   Http::FilterDataStatus decodeData(Buffer::Instance& buf, bool end_stream) override {
     if (end_stream) {
-      absl::WriterMutexLock m(&encode_lock_);
+      absl::WriterMutexLock m(encode_lock_);
       number_of_decode_calls_ref_++;
       // If this is the second stream to decode headers and we're at high watermark. force low
       // watermark state
@@ -42,7 +42,7 @@ public:
 
   Http::FilterDataStatus encodeData(Buffer::Instance& buf, bool end_stream) override {
     if (end_stream) {
-      absl::WriterMutexLock m(&encode_lock_);
+      absl::WriterMutexLock m(encode_lock_);
       number_of_encode_calls_ref_++;
       // If this is the first stream to encode headers and we're not at high watermark, force high
       // watermark state.
@@ -72,7 +72,7 @@ public:
     return [&](Http::FilterChainFactoryCallbacks& callbacks) -> void {
       // ABSL_GUARDED_BY insists the lock be held when the guarded variables are passed by
       // reference.
-      absl::WriterMutexLock m(&encode_lock_);
+      absl::WriterMutexLock m(encode_lock_);
       callbacks.addStreamFilter(std::make_shared<::Envoy::TestPauseFilterForQuic>(
           encode_lock_, number_of_encode_calls_, number_of_decode_calls_));
     };

--- a/test/integration/filters/random_pause_filter.cc
+++ b/test/integration/filters/random_pause_filter.cc
@@ -19,7 +19,7 @@ public:
       : rand_lock_(rand_lock), rng_(rng) {}
 
   Http::FilterDataStatus encodeData(Buffer::Instance& buf, bool end_stream) override {
-    absl::WriterMutexLock m(&rand_lock_);
+    absl::WriterMutexLock m(rand_lock_);
     uint64_t random = rng_.random();
     // Roughly every 5th encode (5 being arbitrary) swap the watermark state.
     if (random % 5 == 0) {
@@ -72,7 +72,7 @@ public:
   absl::StatusOr<Http::FilterFactoryCb>
   createFilter(const std::string&, Server::Configuration::FactoryContext&) override {
     return [&](Http::FilterChainFactoryCallbacks& callbacks) -> void {
-      absl::WriterMutexLock m(&rand_lock_);
+      absl::WriterMutexLock m(rand_lock_);
       if (rng_ == nullptr) {
         // Lazily create to ensure the test seed is set.
         rng_ = std::make_unique<TestRandomGenerator>();

--- a/test/integration/filters/tee_filter.cc
+++ b/test/integration/filters/tee_filter.cc
@@ -13,7 +13,7 @@ public:
   // Http::PassThroughFilter
   Http::FilterDataStatus decodeData(Buffer::Instance& buffer, bool end_stream) override {
     ENVOY_LOG_MISC(trace, "StreamTee decodeData {}", buffer.length());
-    absl::MutexLock l{&mutex_};
+    absl::MutexLock l{mutex_};
     request_body_.add(buffer);
     decode_end_stream_ = end_stream;
     if (on_decode_data_) {
@@ -23,7 +23,7 @@ public:
   }
 
   Http::FilterTrailersStatus decodeTrailers(Http::RequestTrailerMap& request_trailers) override {
-    absl::MutexLock l{&mutex_};
+    absl::MutexLock l{mutex_};
     request_trailers_ = Http::createHeaderMap<Http::RequestTrailerMapImpl>(request_trailers);
     decode_end_stream_ = true;
     return Http::FilterTrailersStatus::Continue;
@@ -31,7 +31,7 @@ public:
 
   Http::FilterDataStatus encodeData(Buffer::Instance& buffer, bool end_stream) override {
     ENVOY_LOG_MISC(trace, "StreamTee encodeData {}", buffer.length());
-    absl::MutexLock l{&mutex_};
+    absl::MutexLock l{mutex_};
     response_body_.add(buffer);
     encode_end_stream_ = end_stream;
     if (on_encode_data_) {
@@ -41,7 +41,7 @@ public:
   }
 
   Http::FilterTrailersStatus encodeTrailers(Http::ResponseTrailerMap& response_trailers) override {
-    absl::MutexLock l{&mutex_};
+    absl::MutexLock l{mutex_};
     response_trailers_ = Http::createHeaderMap<Http::ResponseTrailerMapImpl>(response_trailers);
     encode_end_stream_ = true;
     return Http::FilterTrailersStatus::Continue;
@@ -83,7 +83,7 @@ bool StreamTeeFilterConfig::setEncodeDataCallback(
   }
 
   StreamTeeSharedPtr& stream_tee = stream_id_to_stream_tee_.find(stream_id)->second;
-  absl::MutexLock l{&stream_tee->mutex_};
+  absl::MutexLock l{stream_tee->mutex_};
   stream_tee->on_encode_data_ = cb;
 
   return true;
@@ -100,7 +100,7 @@ bool StreamTeeFilterConfig::setDecodeDataCallback(
   }
 
   StreamTeeSharedPtr& stream_tee = stream_id_to_stream_tee_.find(stream_id)->second;
-  absl::MutexLock l{&stream_tee->mutex_};
+  absl::MutexLock l{stream_tee->mutex_};
   stream_tee->on_decode_data_ = cb;
   return true;
 }

--- a/test/integration/filters/test_listener_filter.h
+++ b/test/integration/filters/test_listener_filter.h
@@ -21,7 +21,7 @@ public:
 
   // Network::ListenerFilter
   Network::FilterStatus onAccept(Network::ListenerFilterCallbacks& cb) override {
-    absl::MutexLock m(&alpn_lock_);
+    absl::MutexLock m(alpn_lock_);
     ASSERT(!alpn_.empty());
     cb.socket().setRequestedApplicationProtocols({alpn_});
     alpn_.clear();
@@ -33,7 +33,7 @@ public:
   size_t maxReadBytes() const override { return 0; }
 
   static void setAlpn(std::string alpn) {
-    absl::MutexLock m(&alpn_lock_);
+    absl::MutexLock m(alpn_lock_);
     alpn_ = alpn;
   }
 

--- a/test/integration/filters/test_socket_interface.h
+++ b/test/integration/filters/test_socket_interface.h
@@ -45,7 +45,7 @@ public:
 
   void initializeFileEvent(Event::Dispatcher& dispatcher, Event::FileReadyCb cb,
                            Event::FileTriggerType trigger, uint32_t events) override {
-    absl::MutexLock lock(&mutex_);
+    absl::MutexLock lock(mutex_);
     dispatcher_ = &dispatcher;
     Test::IoSocketHandlePlatformImpl::initializeFileEvent(dispatcher, cb, trigger, events);
   }
@@ -54,7 +54,7 @@ public:
   // that this operation is inherently racy, nothing guarantees that the TestIoSocketHandle is not
   // deleted before the posted callback executes.
   void activateInDispatcherThread(uint32_t events) {
-    absl::MutexLock lock(&mutex_);
+    absl::MutexLock lock(mutex_);
     RELEASE_ASSERT(dispatcher_ != nullptr, "null dispatcher");
     dispatcher_->post([this, events]() { activateFileEvents(events); });
   }

--- a/test/integration/idle_timeout_integration_test.cc
+++ b/test/integration/idle_timeout_integration_test.cc
@@ -391,7 +391,7 @@ TEST_P(IdleTimeoutIntegrationTest, ResponseTimeout) {
   initialize();
 
   // Lock up fake upstream so that it won't accept connections.
-  absl::MutexLock l(&fake_upstreams_[0]->lock());
+  absl::MutexLock l(fake_upstreams_[0]->lock());
 
   codec_client_ = makeHttpConnection(makeClientConnection((lookupPort("http"))));
   auto response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);

--- a/test/integration/multiplexed_upstream_integration_test.cc
+++ b/test/integration/multiplexed_upstream_integration_test.cc
@@ -1008,7 +1008,7 @@ TEST_P(MultiplexedUpstreamIntegrationTest, DownstreamDisconnectDuringEarlyData) 
 
   {
     // Lock up fake upstream so that it won't process handshake.
-    absl::MutexLock l(&fake_upstreams_[0]->lock());
+    absl::MutexLock l(fake_upstreams_[0]->lock());
     auto response2 = codec_client_->makeHeaderOnlyRequest(
         Http::TestRequestHeaderMapImpl{{":method", "GET"},
                                        {":path", "/test/long/url"},
@@ -1061,7 +1061,7 @@ TEST_P(MultiplexedUpstreamIntegrationTest, ConnPoolQueuingNonSafeRequest) {
   IntegrationStreamDecoderPtr response4;
   {
     // Lock up fake upstream so that it won't process handshake.
-    absl::MutexLock l(&fake_upstreams_[0]->lock());
+    absl::MutexLock l(fake_upstreams_[0]->lock());
     response2 = codec_client_->makeHeaderOnlyRequest(
         Http::TestRequestHeaderMapImpl{{":method", "POST"},
                                        {":path", "/test/long/url"},

--- a/test/integration/protocol_integration_test.cc
+++ b/test/integration/protocol_integration_test.cc
@@ -5069,11 +5069,11 @@ TEST_P(ProtocolIntegrationTest, HandleUpstreamSocketFail) {
 class AllowForceFail : public Api::OsSysCallsImpl {
 public:
   void startFailing() {
-    absl::MutexLock m(&mutex_);
+    absl::MutexLock m(mutex_);
     fail_ = true;
   }
   Api::SysCallSocketResult socket(int domain, int type, int protocol) override {
-    absl::MutexLock m(&mutex_);
+    absl::MutexLock m(mutex_);
     if (fail_) {
       return {-1, 1};
     }

--- a/test/integration/server.h
+++ b/test/integration/server.h
@@ -184,7 +184,7 @@ public:
   }
   void add(uint64_t amount) override {
     counter_->add(amount);
-    absl::MutexLock l(&mutex_);
+    absl::MutexLock l(mutex_);
     condvar_.Signal();
   }
   void inc() override { add(1); }
@@ -213,7 +213,7 @@ public:
   using Stats::AllocatorImpl::AllocatorImpl;
 
   void waitForCounterFromStringEq(const std::string& name, uint64_t value) {
-    absl::MutexLock l(&mutex_);
+    absl::MutexLock l(mutex_);
     ENVOY_LOG_MISC(trace, "waiting for {} to be {}", name, value);
     while (getCounterLockHeld(name) == nullptr || getCounterLockHeld(name)->value() != value) {
       condvar_.Wait(&mutex_);
@@ -222,7 +222,7 @@ public:
   }
 
   void waitForCounterFromStringGe(const std::string& name, uint64_t value) {
-    absl::MutexLock l(&mutex_);
+    absl::MutexLock l(mutex_);
     ENVOY_LOG_MISC(trace, "waiting for {} to be {}", name, value);
     while (getCounterLockHeld(name) == nullptr || getCounterLockHeld(name)->value() < value) {
       condvar_.Wait(&mutex_);
@@ -231,7 +231,7 @@ public:
   }
 
   void waitForCounterExists(const std::string& name) {
-    absl::MutexLock l(&mutex_);
+    absl::MutexLock l(mutex_);
     ENVOY_LOG_MISC(trace, "waiting for {} to exist", name);
     while (getCounterLockHeld(name) == nullptr) {
       condvar_.Wait(&mutex_);
@@ -246,7 +246,7 @@ protected:
         Stats::AllocatorImpl::makeCounterInternal(name, tag_extracted_name, stat_name_tags), mutex_,
         condvar_);
     {
-      absl::MutexLock l(&mutex_);
+      absl::MutexLock l(mutex_);
       // Allow getting the counter directly from the allocator, since it's harder to
       // signal when the counter has been added to a given stats store.
       counters_.emplace(counter->name(), counter);

--- a/test/integration/socket_interface_swap.cc
+++ b/test/integration/socket_interface_swap.cc
@@ -32,7 +32,7 @@ SocketInterfaceSwap::SocketInterfaceSwap(Network::Socket::Type socket_type)
           })) {}
 
 void SocketInterfaceSwap::IoHandleMatcher::setResumeWrites() {
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
   mutex_.Await(absl::Condition(
       +[](Network::TestIoSocketHandle** matched_iohandle) { return *matched_iohandle != nullptr; },
       &matched_iohandle_));

--- a/test/integration/socket_interface_swap.h
+++ b/test/integration/socket_interface_swap.h
@@ -19,7 +19,7 @@ public:
     Api::IoErrorPtr
     returnOverride(Envoy::Network::TestIoSocketHandle* io_handle,
                    Network::Address::InstanceConstSharedPtr& peer_address_override_out) {
-      absl::MutexLock lock(&mutex_);
+      absl::MutexLock lock(mutex_);
       if (absl::StatusOr<Network::Address::InstanceConstSharedPtr> addr = io_handle->localAddress();
           socket_type_ == io_handle->getSocketType() && error_ &&
           ((addr.ok() && (*addr)->ip()->port() == src_port_) ||
@@ -43,7 +43,7 @@ public:
     Api::IoErrorPtr
     returnConnectOverride(Envoy::Network::TestIoSocketHandle* io_handle,
                           Network::Address::InstanceConstSharedPtr& peer_address_override_out) {
-      absl::MutexLock lock(&mutex_);
+      absl::MutexLock lock(mutex_);
       if (absl::StatusOr<Network::Address::InstanceConstSharedPtr> addr = io_handle->localAddress();
           block_connect_ && socket_type_ == io_handle->getSocketType() &&
           ((addr.ok() && (*addr)->ip()->port() == src_port_) ||
@@ -61,7 +61,7 @@ public:
     }
 
     void readOverride(Network::IoHandle::RecvMsgOutput& output) {
-      absl::MutexLock lock(&mutex_);
+      absl::MutexLock lock(mutex_);
       if (translated_dnat_address_ != nullptr) {
         for (auto& pkt : output.msg_) {
           // Reverse DNAT when receiving packets.
@@ -75,14 +75,14 @@ public:
 
     // Source port to match. The port specified should be associated with a listener.
     void setSourcePort(uint32_t port) {
-      absl::WriterMutexLock lock(&mutex_);
+      absl::WriterMutexLock lock(mutex_);
       dst_port_ = 0;
       src_port_ = port;
     }
 
     // Destination port to match. The port specified should be associated with a listener.
     void setDestinationPort(uint32_t port) {
-      absl::WriterMutexLock lock(&mutex_);
+      absl::WriterMutexLock lock(mutex_);
       src_port_ = 0;
       dst_port_ = port;
     }
@@ -93,20 +93,20 @@ public:
 
     // The caller is responsible for memory management.
     void setWriteOverride(Api::IoErrorPtr error) {
-      absl::WriterMutexLock lock(&mutex_);
+      absl::WriterMutexLock lock(mutex_);
       ASSERT(src_port_ != 0 || dst_port_ != 0);
       error_ = std::move(error);
     }
 
     void setConnectBlock(bool block) {
-      absl::WriterMutexLock lock(&mutex_);
+      absl::WriterMutexLock lock(mutex_);
       ASSERT(src_port_ != 0 || dst_port_ != 0);
       block_connect_ = block;
     }
 
     void setDnat(Network::Address::InstanceConstSharedPtr orig_address,
                  Network::Address::InstanceConstSharedPtr translated_address) {
-      absl::WriterMutexLock lock(&mutex_);
+      absl::WriterMutexLock lock(mutex_);
       orig_dnat_address_ = orig_address;
       translated_dnat_address_ = translated_address;
     }

--- a/test/integration/tracked_watermark_buffer.h
+++ b/test/integration/tracked_watermark_buffer.h
@@ -100,7 +100,7 @@ public:
 
   // Total bytes currently buffered across all known buffers.
   uint64_t totalBytesBuffered() const {
-    absl::MutexLock lock(&mutex_);
+    absl::MutexLock lock(mutex_);
     return total_buffer_size_;
   }
 

--- a/test/integration/xds_delegate_extension_integration_test.cc
+++ b/test/integration/xds_delegate_extension_integration_test.cc
@@ -184,7 +184,7 @@ public:
   }
 
   void waitforOnConfigUpdatedCount(const int expected_count) {
-    absl::MutexLock l(&lock_);
+    absl::MutexLock l(lock_);
     const auto reached_expected_count = [expected_count]() ABSL_EXCLUSIVE_LOCKS_REQUIRED(lock_) {
       return TestXdsResourcesDelegate::OnConfigUpdatedCount == expected_count;
     };


### PR DESCRIPTION
Replace deprecated absl::MutexLock::MutexLock(Mutex*) constructor with absl::MutexLock::MutexLock(Mutex&)

Additional Description: needed due to upcoming absl change.
Similar to #41208.

Risk Level: low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A