### PR TITLE
http_filter: added a new sampling_decision http filter

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -90,6 +90,8 @@ extensions/filters/common/original_src @klarose @mattklein123
 /*/extensions/clusters/redis @msukalski @henryyyang @mattklein123
 # reverse conn cluster extension
 /*/extensions/clusters/reverse_connection @agrawroh @basundhara-c @botengyao @yanavlasov
+# sampling decision http filter extension
+/*/extensions/filters/http/sampling_decision @agrawroh @wbpcode
 /*/extensions/common/redis @msukalski @henryyyang @mattklein123
 /*/extensions/health_checkers/redis @mattklein123 @UNOWNED
 /*/extensions/filters/network/redis_proxy @mattklein123 @UNOWNED

--- a/api/envoy/extensions/filters/http/sampling_decision/v3/BUILD
+++ b/api/envoy/extensions/filters/http/sampling_decision/v3/BUILD
@@ -1,0 +1,10 @@
+load("@envoy_api//bazel:api_build_system.bzl", "api_proto_package")
+
+licenses(["notice"])  # Apache 2
+
+api_proto_package(
+    deps = [
+        "//envoy/type/v3:pkg",
+        "@com_github_cncf_xds//udpa/annotations:pkg",
+    ],
+)

--- a/api/envoy/extensions/filters/http/sampling_decision/v3/sampling_decision.proto
+++ b/api/envoy/extensions/filters/http/sampling_decision/v3/sampling_decision.proto
@@ -1,0 +1,50 @@
+syntax = "proto3";
+
+package envoy.extensions.filters.http.sampling_decision.v3;
+
+import "envoy/type/v3/percent.proto";
+
+import "udpa/annotations/status.proto";
+import "validate/validate.proto";
+
+option java_package = "io.envoyproxy.envoy.extensions.filters.http.sampling_decision.v3";
+option java_outer_classname = "SamplingDecisionProto";
+option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/sampling_decision/v3;sampling_decisionv3";
+option (udpa.annotations.file_status).package_version_status = ACTIVE;
+
+// [#protodoc-title: Sampling Decision]
+// Sampling Decision :ref:`configuration overview <config_http_filters_sampling_decision>`.
+// [#extension: envoy.filters.http.sampling_decision]
+
+// The sampling decision filter evaluates whether a request should be sampled based on runtime
+// configuration and stores the decision in dynamic metadata. This allows other components, such as
+// access log filters, to reference the sampling decision without re-evaluating the sampling logic.
+// [#next-free-field: 5]
+message SamplingDecision {
+  // The runtime key to use for sampling. The runtime value will override the configured
+  // ``percent_sampled`` if present.
+  string runtime_key = 1 [(validate.rules).string = {min_len: 1}];
+
+  // The default sampling percentage to use if the runtime key is not set.
+  // Defaults to 0% (no sampling) if not specified.
+  type.v3.FractionalPercent percent_sampled = 2;
+
+  // By default, sampling will be based on the request ID to ensure consistent sampling
+  // across different filters for the same request. If this field is set to true, each
+  // evaluation will use an independent random value, which may be useful in some
+  // scenarios, such as when independent sampling decisions that should not be correlated
+  // with other filters are required. Note that this will cause the filter to behave like
+  // an independent random variable when used multiple times in the filter chain.
+  bool use_independent_randomness = 3;
+
+  // The metadata namespace to use for storing the sampling decision.
+  // Defaults to ``envoy.filters.http.sampling_decision`` if not specified.
+  //
+  // The following fields will be set in dynamic metadata under the configured namespace:
+  // ``sampled`` (boolean) indicating whether the request was sampled, ``numerator`` and
+  // ``denominator`` (numbers) indicating the sampling rate, and ``runtime_key`` (string)
+  // indicating the runtime key used for sampling. This metadata can be accessed later by
+  // other filters, access log filters, or formatters using dynamic metadata accessors.
+  string metadata_namespace = 4;
+}

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -138,6 +138,12 @@ removed_config_or_runtime:
     Removed runtime guard ``envoy.reloadable_features.report_load_with_rq_issued`` and legacy code paths.
 
 new_features:
+- area: http_filter
+  change: |
+    Added :ref:`sampling_decision http filter <config_http_filters_sampling_decision>` which evaluates runtime-based
+    sampling decisions and stores them in dynamic metadata. This allows other filters, such as access log filters,
+    to reference the sampling decision without re-evaluating the sampling logic. The filter supports configurable
+    runtime keys, sampling percentages, deterministic or independent randomness, and custom metadata namespaces.
 - area: http filter
   change: |
     Added :ref:`transform http filter <config_http_filters_transform>` which adds the ability to modify request

--- a/docs/root/configuration/http/http_filters/http_filters.rst
+++ b/docs/root/configuration/http/http_filters/http_filters.rst
@@ -61,6 +61,7 @@ HTTP filters
   rate_limit_quota_filter
   rbac_filter
   router_filter
+  sampling_decision_filter
   set_filter_state
   set_metadata_filter
   stateful_session_filter

--- a/docs/root/configuration/http/http_filters/sampling_decision_filter.rst
+++ b/docs/root/configuration/http/http_filters/sampling_decision_filter.rst
@@ -1,0 +1,199 @@
+.. _config_http_filters_sampling_decision:
+
+Sampling decision
+=================
+
+The sampling decision filter evaluates whether a request should be sampled based on different
+criteria like runtime configuration, request ID, and independent randomness. It then stores the
+decision in dynamic metadata. This allows access log filters and formatters to reference a
+centralized sampling decision without re-evaluating the sampling logic.
+
+* This filter should be configured with the type URL ``type.googleapis.com/envoy.extensions.filters.http.sampling_decision.v3.SamplingDecision``.
+* :ref:`v3 API reference <envoy_v3_api_msg_extensions.filters.http.sampling_decision.v3.SamplingDecision>`
+
+The filter evaluates sampling during request processing and stores the decision along with
+sampling parameters in :ref:`dynamic metadata <envoy_v3_api_field_config.core.v3.Metadata>`.
+This metadata can be consumed by access log filters to control logging, by formatters to include
+sampling information in log output, or by other filters to make sampling-aware decisions.
+
+By default, the filter uses deterministic sampling based on the request ID, ensuring that the
+same request receives the same sampling decision across multiple evaluations. This is useful
+when multiple access logs or filters need to make consistent sampling decisions. The filter
+also supports independent randomness mode for scenarios where uncorrelated sampling decisions
+are required.
+
+Configuration
+-------------
+
+Basic Configuration
+^^^^^^^^^^^^^^^^^^^
+
+A simple configuration with 5% sampling:
+
+.. code-block:: yaml
+
+  http_filters:
+    - name: envoy.filters.http.sampling_decision
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.filters.http.sampling_decision.v3.SamplingDecision
+        runtime_key: "sampling.requests"
+        percent_sampled:
+          numerator: 5
+          denominator: HUNDRED
+
+Access Log Integration
+^^^^^^^^^^^^^^^^^^^^^^
+
+Using the sampling decision to control access logging:
+
+.. code-block:: yaml
+
+  http_filters:
+    - name: envoy.filters.http.sampling_decision
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.filters.http.sampling_decision.v3.SamplingDecision
+        runtime_key: "sampling.access_logs"
+        percent_sampled:
+          numerator: 10
+          denominator: HUNDRED
+
+  access_log:
+    - filter:
+        metadata_filter:
+          matcher:
+            filter: envoy.filters.http.sampling_decision
+            path:
+              - key: sampled
+            value:
+              bool_match: true
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+        path: /var/log/envoy/sampled_access.log
+        log_format:
+          text_format: |
+            [%START_TIME%] sampled=%DYNAMIC_METADATA(envoy.filters.http.sampling_decision:sampled)% rate=%DYNAMIC_METADATA(envoy.filters.http.sampling_decision:numerator)%/%DYNAMIC_METADATA(envoy.filters.http.sampling_decision:denominator)% "%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% "%REQ(X-FORWARDED-FOR)%" "%REQ(USER-AGENT)%" "%REQ(X-REQUEST-ID)%"
+
+Custom Metadata Namespace
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Using a custom metadata namespace for multiple sampling decisions:
+
+.. code-block:: yaml
+
+  http_filters:
+    - name: envoy.filters.http.sampling_decision
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.filters.http.sampling_decision.v3.SamplingDecision
+        runtime_key: "sampling.debug"
+        percent_sampled:
+          numerator: 1
+          denominator: HUNDRED
+        metadata_namespace: "sampling.debug"
+
+    - name: envoy.filters.http.sampling_decision
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.filters.http.sampling_decision.v3.SamplingDecision
+        runtime_key: "sampling.metrics"
+        percent_sampled:
+          numerator: 50
+          denominator: HUNDRED
+        metadata_namespace: "sampling.metrics"
+
+  access_log:
+    - filter:
+        metadata_filter:
+          matcher:
+            filter: sampling.debug
+            path:
+              - key: sampled
+            value:
+              bool_match: true
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+        path: /var/log/envoy/debug.log
+
+    - filter:
+        metadata_filter:
+          matcher:
+            filter: sampling.metrics
+            path:
+              - key: sampled
+            value:
+              bool_match: true
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+        path: /var/log/envoy/metrics.log
+
+Runtime Override
+^^^^^^^^^^^^^^^^
+
+The sampling percentage can be overridden at runtime. Configuration:
+
+.. code-block:: yaml
+
+  http_filters:
+    - name: envoy.filters.http.sampling_decision
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.filters.http.sampling_decision.v3.SamplingDecision
+        runtime_key: "sampling.requests"
+        percent_sampled:
+          numerator: 5
+          denominator: HUNDRED
+
+To override the sampling rate at runtime:
+
+.. code-block:: console
+
+  $ curl -X POST http://localhost:9901/runtime_modify?sampling.requests=10
+
+This changes the sampling rate to 10% without requiring a configuration reload.
+
+Independent Randomness
+^^^^^^^^^^^^^^^^^^^^^^
+
+Using independent randomness for uncorrelated sampling:
+
+.. code-block:: yaml
+
+  http_filters:
+    - name: envoy.filters.http.sampling_decision
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.filters.http.sampling_decision.v3.SamplingDecision
+        runtime_key: "sampling.independent"
+        percent_sampled:
+          numerator: 5
+          denominator: HUNDRED
+        use_independent_randomness: true
+
+.. note::
+
+   When :ref:`use_independent_randomness <envoy_v3_api_field_extensions.filters.http.sampling_decision.v3.SamplingDecision.use_independent_randomness>`
+   is set to true, the same request may receive different sampling decisions if the filter is
+   evaluated multiple times. Use this setting carefully if consistent sampling behavior is required.
+
+.. _config_http_filters_sampling_decision_dynamic_metadata:
+
+Dynamic Metadata
+----------------
+
+The sampling decision filter emits dynamic metadata in the namespace specified by
+:ref:`metadata_namespace <envoy_v3_api_field_extensions.filters.http.sampling_decision.v3.SamplingDecision.metadata_namespace>`
+(defaults to ``envoy.filters.http.sampling_decision``). The following fields are set:
+
+.. csv-table::
+  :header: Name, Type, Description
+  :widths: 1, 1, 2
+
+  sampled, boolean, Whether the request was sampled based on the configured sampling rate
+  numerator, number, The numerator of the sampling rate used (may be overridden by runtime)
+  denominator, number, "The denominator of the sampling rate (100, 10000, or 1000000)"
+  runtime_key, string, The runtime key used for sampling
+
+The metadata can be accessed by access log filters using the
+:ref:`metadata_filter <envoy_v3_api_msg_config.accesslog.v3.MetadataFilter>` or by formatters
+using the ``%DYNAMIC_METADATA(...)%`` :ref:`command operator <config_access_log_format_dynamic_metadata>`.
+
+Statistics
+----------
+
+The sampling decision filter does not emit any statistics.

--- a/source/extensions/extensions_build_config.bzl
+++ b/source/extensions/extensions_build_config.bzl
@@ -190,6 +190,7 @@ EXTENSIONS = {
     "envoy.filters.http.jwt_authn":                     "//source/extensions/filters/http/jwt_authn:config",
     "envoy.filters.http.mcp":                           "//source/extensions/filters/http/mcp:config",
     "envoy.filters.http.rate_limit_quota":              "//source/extensions/filters/http/rate_limit_quota:config",
+    "envoy.filters.http.sampling_decision":             "//source/extensions/filters/http/sampling_decision:config",
     # Disabled by default. kill_request is not built into most prebuilt images.
     # For instructions for building with disabled-by-default filters enabled, see
     # https://github.com/envoyproxy/envoy/blob/main/bazel/README.md#enabling-and-disabling-extensions

--- a/source/extensions/extensions_metadata.yaml
+++ b/source/extensions/extensions_metadata.yaml
@@ -540,6 +540,13 @@ envoy.filters.http.jwt_authn:
   type_urls:
   - envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication
   - envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
+envoy.filters.http.sampling_decision:
+  categories:
+  - envoy.filters.http
+  security_posture: robust_to_untrusted_downstream
+  status: alpha
+  type_urls:
+  - envoy.extensions.filters.http.sampling_decision.v3.SamplingDecision
 envoy.filters.http.kill_request:
   categories:
   - envoy.filters.http

--- a/source/extensions/filters/http/sampling_decision/BUILD
+++ b/source/extensions/filters/http/sampling_decision/BUILD
@@ -1,0 +1,34 @@
+load(
+    "//bazel:envoy_build_system.bzl",
+    "envoy_cc_extension",
+    "envoy_cc_library",
+    "envoy_extension_package",
+)
+
+licenses(["notice"])  # Apache 2
+
+envoy_extension_package()
+
+envoy_cc_library(
+    name = "sampling_decision_filter_lib",
+    srcs = ["sampling_decision_filter.cc"],
+    hdrs = ["sampling_decision_filter.h"],
+    deps = [
+        "//envoy/runtime:runtime_interface",
+        "//source/common/common:assert_lib",
+        "//source/common/protobuf:utility_lib",
+        "//source/extensions/filters/http/common:pass_through_filter_lib",
+        "@envoy_api//envoy/extensions/filters/http/sampling_decision/v3:pkg_cc_proto",
+    ],
+)
+
+envoy_cc_extension(
+    name = "config",
+    srcs = ["config.cc"],
+    hdrs = ["config.h"],
+    deps = [
+        ":sampling_decision_filter_lib",
+        "//source/extensions/filters/http/common:factory_base_lib",
+        "@envoy_api//envoy/extensions/filters/http/sampling_decision/v3:pkg_cc_proto",
+    ],
+)

--- a/source/extensions/filters/http/sampling_decision/config.cc
+++ b/source/extensions/filters/http/sampling_decision/config.cc
@@ -1,0 +1,34 @@
+#include "source/extensions/filters/http/sampling_decision/config.h"
+
+#include "envoy/extensions/filters/http/sampling_decision/v3/sampling_decision.pb.h"
+#include "envoy/extensions/filters/http/sampling_decision/v3/sampling_decision.pb.validate.h"
+#include "envoy/registry/registry.h"
+
+#include "source/extensions/filters/http/sampling_decision/sampling_decision_filter.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace SamplingDecision {
+
+Http::FilterFactoryCb SamplingDecisionFilterFactory::createFilterFactoryFromProtoTyped(
+    const envoy::extensions::filters::http::sampling_decision::v3::SamplingDecision& proto_config,
+    const std::string&, Server::Configuration::FactoryContext& context) {
+  auto config = std::make_shared<SamplingDecisionConfig>(proto_config);
+  return [config, &context](Http::FilterChainFactoryCallbacks& callbacks) -> void {
+    callbacks.addStreamDecoderFilter(std::make_shared<SamplingDecisionFilter>(
+        config, context.serverFactoryContext().runtime(),
+        context.serverFactoryContext().api().randomGenerator()));
+  };
+}
+
+/**
+ * Static registration for the sampling decision filter.
+ */
+REGISTER_FACTORY(SamplingDecisionFilterFactory,
+                 Server::Configuration::NamedHttpFilterConfigFactory);
+
+} // namespace SamplingDecision
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/http/sampling_decision/config.h
+++ b/source/extensions/filters/http/sampling_decision/config.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "envoy/extensions/filters/http/sampling_decision/v3/sampling_decision.pb.h"
+#include "envoy/extensions/filters/http/sampling_decision/v3/sampling_decision.pb.validate.h"
+
+#include "source/extensions/filters/http/common/factory_base.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace SamplingDecision {
+
+/**
+ * Config registration for the sampling decision filter.
+ */
+class SamplingDecisionFilterFactory
+    : public Common::FactoryBase<
+          envoy::extensions::filters::http::sampling_decision::v3::SamplingDecision> {
+public:
+  SamplingDecisionFilterFactory() : FactoryBase("envoy.filters.http.sampling_decision") {}
+
+private:
+  Http::FilterFactoryCb createFilterFactoryFromProtoTyped(
+      const envoy::extensions::filters::http::sampling_decision::v3::SamplingDecision& proto_config,
+      const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
+};
+
+} // namespace SamplingDecision
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/http/sampling_decision/sampling_decision_filter.cc
+++ b/source/extensions/filters/http/sampling_decision/sampling_decision_filter.cc
@@ -1,0 +1,92 @@
+#include "source/extensions/filters/http/sampling_decision/sampling_decision_filter.h"
+
+#include "envoy/extensions/filters/http/sampling_decision/v3/sampling_decision.pb.h"
+
+#include "source/common/protobuf/utility.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace SamplingDecision {
+
+namespace {
+constexpr const char* DefaultMetadataNamespace = "envoy.filters.http.sampling_decision";
+constexpr const char* SampledKey = "sampled";
+constexpr const char* NumeratorKey = "numerator";
+constexpr const char* DenominatorKey = "denominator";
+constexpr const char* RuntimeKeyFieldName = "runtime_key";
+} // namespace
+
+SamplingDecisionConfig::SamplingDecisionConfig(
+    const envoy::extensions::filters::http::sampling_decision::v3::SamplingDecision& config)
+    : runtime_key_(config.runtime_key()),
+      percent_sampled_(config.has_percent_sampled() ? config.percent_sampled()
+                                                    : envoy::type::v3::FractionalPercent()),
+      use_independent_randomness_(config.use_independent_randomness()),
+      metadata_namespace_(config.metadata_namespace().empty() ? DefaultMetadataNamespace
+                                                              : config.metadata_namespace()) {}
+
+SamplingDecisionFilter::SamplingDecisionFilter(SamplingDecisionConfigSharedPtr config,
+                                               Runtime::Loader& runtime,
+                                               Random::RandomGenerator& random)
+    : config_(std::move(config)), runtime_(runtime), random_(random) {}
+
+bool SamplingDecisionFilter::evaluateSamplingDecision() {
+  // This code is verbose to avoid pre-allocating a random number that is not needed.
+  uint64_t random_value;
+  if (config_->useIndependentRandomness()) {
+    random_value = random_.random();
+  } else if (!decoder_callbacks_->streamInfo().getStreamIdProvider().has_value()) {
+    random_value = random_.random();
+  } else {
+    const auto rid_to_integer = decoder_callbacks_->streamInfo().getStreamIdProvider()->toInteger();
+    if (!rid_to_integer.has_value()) {
+      random_value = random_.random();
+    } else {
+      random_value =
+          rid_to_integer.value() % ProtobufPercentHelper::fractionalPercentDenominatorToInt(
+                                       config_->percentSampled().denominator());
+    }
+  }
+
+  const uint64_t denominator = ProtobufPercentHelper::fractionalPercentDenominatorToInt(
+      config_->percentSampled().denominator());
+
+  return runtime_.snapshot().featureEnabled(
+      config_->runtimeKey(), config_->percentSampled().numerator(), random_value, denominator);
+}
+
+Http::FilterHeadersStatus SamplingDecisionFilter::decodeHeaders(Http::RequestHeaderMap&, bool) {
+  // Evaluate the sampling decision.
+  const bool sampled = evaluateSamplingDecision();
+
+  // Get the actual numerator from runtime (may differ from config default).
+  const uint64_t numerator =
+      runtime_.snapshot().getInteger(config_->runtimeKey(), config_->percentSampled().numerator());
+  const uint64_t denominator = ProtobufPercentHelper::fractionalPercentDenominatorToInt(
+      config_->percentSampled().denominator());
+
+  // Store the sampling decision and parameters in dynamic metadata.
+  Protobuf::Struct sampling_metadata;
+  auto* sampling_fields = sampling_metadata.mutable_fields();
+
+  (*sampling_fields)[SampledKey].set_bool_value(sampled);
+  (*sampling_fields)[RuntimeKeyFieldName].set_string_value(config_->runtimeKey());
+  (*sampling_fields)[NumeratorKey].set_number_value(numerator);
+  (*sampling_fields)[DenominatorKey].set_number_value(denominator);
+
+  decoder_callbacks_->streamInfo().setDynamicMetadata(config_->metadataNamespace(),
+                                                      sampling_metadata);
+
+  ENVOY_LOG(trace,
+            "Sampling decision for request: sampled={}, runtime_key={}, numerator={}, "
+            "denominator={}",
+            sampled, config_->runtimeKey(), numerator, denominator);
+
+  return Http::FilterHeadersStatus::Continue;
+}
+
+} // namespace SamplingDecision
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/http/sampling_decision/sampling_decision_filter.h
+++ b/source/extensions/filters/http/sampling_decision/sampling_decision_filter.h
@@ -1,0 +1,70 @@
+#pragma once
+
+#include <string>
+
+#include "envoy/common/random_generator.h"
+#include "envoy/extensions/filters/http/sampling_decision/v3/sampling_decision.pb.h"
+#include "envoy/runtime/runtime.h"
+
+#include "source/extensions/filters/http/common/pass_through_filter.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace SamplingDecision {
+
+/**
+ * Configuration for the sampling decision filter.
+ */
+class SamplingDecisionConfig {
+public:
+  SamplingDecisionConfig(
+      const envoy::extensions::filters::http::sampling_decision::v3::SamplingDecision& config);
+
+  const std::string& runtimeKey() const { return runtime_key_; }
+  const envoy::type::v3::FractionalPercent& percentSampled() const { return percent_sampled_; }
+  bool useIndependentRandomness() const { return use_independent_randomness_; }
+  const std::string& metadataNamespace() const { return metadata_namespace_; }
+
+private:
+  const std::string runtime_key_;
+  const envoy::type::v3::FractionalPercent percent_sampled_;
+  const bool use_independent_randomness_;
+  const std::string metadata_namespace_;
+};
+
+using SamplingDecisionConfigSharedPtr = std::shared_ptr<SamplingDecisionConfig>;
+
+/**
+ * HTTP filter that evaluates sampling decisions and stores them in dynamic metadata.
+ *
+ * This filter evaluates whether a request should be sampled based on runtime configuration
+ * and stores the decision in dynamic metadata. The metadata can then be consumed by other
+ * filters such as access log filters to determine whether to log the request.
+ */
+class SamplingDecisionFilter : public Http::PassThroughDecoderFilter,
+                               public Logger::Loggable<Logger::Id::filter> {
+public:
+  SamplingDecisionFilter(SamplingDecisionConfigSharedPtr config, Runtime::Loader& runtime,
+                         Random::RandomGenerator& random);
+
+  // Http::StreamFilterBase.
+  void onDestroy() override {}
+
+  // Http::StreamDecoderFilter.
+  Http::FilterHeadersStatus decodeHeaders(Http::RequestHeaderMap& headers,
+                                          bool end_stream) override;
+
+private:
+  // Evaluate the sampling decision and return whether the request should be sampled.
+  bool evaluateSamplingDecision();
+
+  const SamplingDecisionConfigSharedPtr config_;
+  Runtime::Loader& runtime_;
+  Random::RandomGenerator& random_;
+};
+
+} // namespace SamplingDecision
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/test/extensions/filters/http/sampling_decision/BUILD
+++ b/test/extensions/filters/http/sampling_decision/BUILD
@@ -1,0 +1,38 @@
+load(
+    "//bazel:envoy_build_system.bzl",
+    "envoy_package",
+)
+load(
+    "//test/extensions:extensions_build_system.bzl",
+    "envoy_extension_cc_test",
+)
+
+licenses(["notice"])  # Apache 2
+
+envoy_package()
+
+envoy_extension_cc_test(
+    name = "sampling_decision_filter_test",
+    srcs = ["sampling_decision_filter_test.cc"],
+    extension_names = ["envoy.filters.http.sampling_decision"],
+    deps = [
+        "//source/extensions/filters/http/sampling_decision:sampling_decision_filter_lib",
+        "//test/mocks/http:http_mocks",
+        "//test/mocks/runtime:runtime_mocks",
+        "//test/mocks/server:factory_context_mocks",
+        "//test/test_common:utility_lib",
+        "@envoy_api//envoy/extensions/filters/http/sampling_decision/v3:pkg_cc_proto",
+    ],
+)
+
+envoy_extension_cc_test(
+    name = "sampling_decision_integration_test",
+    srcs = ["sampling_decision_integration_test.cc"],
+    extension_names = ["envoy.filters.http.sampling_decision"],
+    deps = [
+        "//source/extensions/filters/http/sampling_decision:config",
+        "//test/integration:http_integration_lib",
+        "//test/test_common:utility_lib",
+        "@envoy_api//envoy/extensions/filters/http/sampling_decision/v3:pkg_cc_proto",
+    ],
+)

--- a/test/extensions/filters/http/sampling_decision/sampling_decision_filter_test.cc
+++ b/test/extensions/filters/http/sampling_decision/sampling_decision_filter_test.cc
@@ -1,0 +1,351 @@
+#include "envoy/extensions/filters/http/sampling_decision/v3/sampling_decision.pb.h"
+
+#include "source/extensions/filters/http/sampling_decision/sampling_decision_filter.h"
+
+#include "test/mocks/http/mocks.h"
+#include "test/mocks/runtime/mocks.h"
+#include "test/mocks/server/server_factory_context.h"
+#include "test/test_common/utility.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+using testing::_;
+using testing::NiceMock;
+using testing::Return;
+using testing::ReturnRef;
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace SamplingDecision {
+namespace {
+
+class SamplingDecisionFilterTest : public testing::Test {
+public:
+  SamplingDecisionFilterTest() {
+    ON_CALL(runtime_.snapshot_, featureEnabled(_, _, _, _)).WillByDefault(Return(true));
+    ON_CALL(runtime_.snapshot_, getInteger(_, _)).WillByDefault(Return(5));
+
+    // Set up dynamic metadata to actually store values when setDynamicMetadata is called.
+    ON_CALL(decoder_callbacks_.stream_info_, setDynamicMetadata(_, _))
+        .WillByDefault(
+            testing::Invoke([this](const std::string& ns, const Protobuf::Struct& value) {
+              (*metadata_.mutable_filter_metadata())[ns] = value;
+            }));
+    ON_CALL(decoder_callbacks_.stream_info_, dynamicMetadata()).WillByDefault(ReturnRef(metadata_));
+    ON_CALL(testing::Const(decoder_callbacks_.stream_info_), dynamicMetadata())
+        .WillByDefault(ReturnRef(metadata_));
+  }
+
+  void setupFilter(const std::string& yaml) {
+    envoy::extensions::filters::http::sampling_decision::v3::SamplingDecision proto_config;
+    TestUtility::loadFromYaml(yaml, proto_config);
+    config_ = std::make_shared<SamplingDecisionConfig>(proto_config);
+    filter_ = std::make_shared<SamplingDecisionFilter>(config_, runtime_, random_);
+    filter_->setDecoderFilterCallbacks(decoder_callbacks_);
+  }
+
+  NiceMock<Runtime::MockLoader> runtime_;
+  NiceMock<Random::MockRandomGenerator> random_;
+  NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks_;
+  envoy::config::core::v3::Metadata metadata_;
+  std::shared_ptr<SamplingDecisionConfig> config_;
+  std::shared_ptr<SamplingDecisionFilter> filter_;
+  Http::TestRequestHeaderMapImpl request_headers_;
+};
+
+TEST_F(SamplingDecisionFilterTest, BasicSamplingEnabled) {
+  const std::string yaml = R"EOF(
+runtime_key: "sampling.test"
+percent_sampled:
+  numerator: 50
+  denominator: HUNDRED
+)EOF";
+
+  setupFilter(yaml);
+
+  EXPECT_CALL(random_, random()).WillOnce(Return(25));
+  EXPECT_CALL(runtime_.snapshot_, featureEnabled("sampling.test", 50, 25, 100))
+      .WillOnce(Return(true));
+  EXPECT_CALL(runtime_.snapshot_, getInteger("sampling.test", 50)).WillOnce(Return(50));
+
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers_, false));
+
+  // Verify metadata was set.
+  const auto& metadata = decoder_callbacks_.stream_info_.dynamicMetadata().filter_metadata();
+  EXPECT_EQ(metadata.count("envoy.filters.http.sampling_decision"), 1);
+  const auto& sampling_metadata = metadata.at("envoy.filters.http.sampling_decision").fields();
+  EXPECT_EQ(sampling_metadata.at("sampled").bool_value(), true);
+  EXPECT_EQ(sampling_metadata.at("runtime_key").string_value(), "sampling.test");
+  EXPECT_EQ(sampling_metadata.at("numerator").number_value(), 50);
+  EXPECT_EQ(sampling_metadata.at("denominator").number_value(), 100);
+}
+
+TEST_F(SamplingDecisionFilterTest, BasicSamplingDisabled) {
+  const std::string yaml = R"EOF(
+runtime_key: "sampling.test"
+percent_sampled:
+  numerator: 50
+  denominator: HUNDRED
+)EOF";
+
+  setupFilter(yaml);
+
+  EXPECT_CALL(random_, random()).WillOnce(Return(75));
+  EXPECT_CALL(runtime_.snapshot_, featureEnabled("sampling.test", 50, 75, 100))
+      .WillOnce(Return(false));
+  EXPECT_CALL(runtime_.snapshot_, getInteger("sampling.test", 50)).WillOnce(Return(50));
+
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers_, false));
+
+  // Verify metadata was set with sampled=false.
+  const auto& metadata = decoder_callbacks_.stream_info_.dynamicMetadata().filter_metadata();
+  EXPECT_EQ(metadata.count("envoy.filters.http.sampling_decision"), 1);
+  const auto& sampling_metadata = metadata.at("envoy.filters.http.sampling_decision").fields();
+  EXPECT_EQ(sampling_metadata.at("sampled").bool_value(), false);
+  EXPECT_EQ(sampling_metadata.at("runtime_key").string_value(), "sampling.test");
+  EXPECT_EQ(sampling_metadata.at("numerator").number_value(), 50);
+  EXPECT_EQ(sampling_metadata.at("denominator").number_value(), 100);
+}
+
+TEST_F(SamplingDecisionFilterTest, CustomMetadataNamespace) {
+  const std::string yaml = R"EOF(
+runtime_key: "sampling.test"
+percent_sampled:
+  numerator: 100
+  denominator: HUNDRED
+metadata_namespace: "custom.namespace"
+)EOF";
+
+  setupFilter(yaml);
+
+  EXPECT_CALL(random_, random()).WillOnce(Return(0));
+  EXPECT_CALL(runtime_.snapshot_, featureEnabled("sampling.test", 100, 0, 100))
+      .WillOnce(Return(true));
+  EXPECT_CALL(runtime_.snapshot_, getInteger("sampling.test", 100)).WillOnce(Return(100));
+
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers_, false));
+
+  // Verify metadata was set under custom namespace.
+  const auto& metadata = decoder_callbacks_.stream_info_.dynamicMetadata().filter_metadata();
+  EXPECT_EQ(metadata.count("custom.namespace"), 1);
+  const auto& sampling_metadata = metadata.at("custom.namespace").fields();
+  EXPECT_EQ(sampling_metadata.at("sampled").bool_value(), true);
+  EXPECT_EQ(sampling_metadata.at("runtime_key").string_value(), "sampling.test");
+  EXPECT_EQ(sampling_metadata.at("numerator").number_value(), 100);
+  EXPECT_EQ(sampling_metadata.at("denominator").number_value(), 100);
+}
+
+TEST_F(SamplingDecisionFilterTest, RuntimeOverride) {
+  const std::string yaml = R"EOF(
+runtime_key: "sampling.test"
+percent_sampled:
+  numerator: 50
+  denominator: HUNDRED
+)EOF";
+
+  setupFilter(yaml);
+
+  // Runtime overrides the configured value to 75.
+  EXPECT_CALL(random_, random()).WillOnce(Return(60));
+  EXPECT_CALL(runtime_.snapshot_, featureEnabled("sampling.test", 50, 60, 100))
+      .WillOnce(Return(true));
+  EXPECT_CALL(runtime_.snapshot_, getInteger("sampling.test", 50)).WillOnce(Return(75));
+
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers_, false));
+
+  // Verify metadata contains the runtime-overridden value.
+  const auto& metadata = decoder_callbacks_.stream_info_.dynamicMetadata().filter_metadata();
+  const auto& sampling_metadata = metadata.at("envoy.filters.http.sampling_decision").fields();
+  EXPECT_EQ(sampling_metadata.at("numerator").number_value(), 75);
+}
+
+TEST_F(SamplingDecisionFilterTest, UseIndependentRandomness) {
+  const std::string yaml = R"EOF(
+runtime_key: "sampling.test"
+percent_sampled:
+  numerator: 50
+  denominator: HUNDRED
+use_independent_randomness: true
+)EOF";
+
+  setupFilter(yaml);
+
+  // When use_independent_randomness is true, we should always use random_.random().
+  EXPECT_CALL(random_, random()).WillOnce(Return(25));
+  EXPECT_CALL(runtime_.snapshot_, featureEnabled("sampling.test", 50, 25, 100))
+      .WillOnce(Return(true));
+  EXPECT_CALL(runtime_.snapshot_, getInteger("sampling.test", 50)).WillOnce(Return(50));
+
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers_, false));
+
+  const auto& metadata = decoder_callbacks_.stream_info_.dynamicMetadata().filter_metadata();
+  const auto& sampling_metadata = metadata.at("envoy.filters.http.sampling_decision").fields();
+  EXPECT_EQ(sampling_metadata.at("sampled").bool_value(), true);
+}
+
+TEST_F(SamplingDecisionFilterTest, DeterministicSamplingWithRequestId) {
+  const std::string yaml = R"EOF(
+runtime_key: "sampling.test"
+percent_sampled:
+  numerator: 50
+  denominator: HUNDRED
+use_independent_randomness: false
+)EOF";
+
+  setupFilter(yaml);
+
+  // Set up a request ID provider.
+  auto stream_id_provider = std::make_shared<StreamInfo::StreamIdProviderImpl>("test-request-id");
+  EXPECT_CALL(decoder_callbacks_.stream_info_, getStreamIdProvider())
+      .WillRepeatedly(Return(makeOptRef<const StreamInfo::StreamIdProvider>(*stream_id_provider)));
+
+  // The random value should be derived from the request ID.
+  // If toInteger() doesn't return a value, the filter will fall back to random_.random().
+  auto to_integer_result = stream_id_provider->toInteger();
+  if (to_integer_result.has_value()) {
+    EXPECT_CALL(random_, random()).Times(0);
+    const uint64_t expected_random_value = to_integer_result.value() % 100;
+    EXPECT_CALL(runtime_.snapshot_, featureEnabled("sampling.test", 50, expected_random_value, 100))
+        .WillOnce(Return(true));
+  } else {
+    // Fall back to random generator if request ID can't be converted to integer.
+    EXPECT_CALL(random_, random()).WillOnce(Return(25));
+    EXPECT_CALL(runtime_.snapshot_, featureEnabled("sampling.test", 50, 25, 100))
+        .WillOnce(Return(true));
+  }
+  EXPECT_CALL(runtime_.snapshot_, getInteger("sampling.test", 50)).WillOnce(Return(50));
+
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers_, false));
+
+  const auto& metadata = metadata_.filter_metadata();
+  EXPECT_EQ(metadata.count("envoy.filters.http.sampling_decision"), 1);
+}
+
+TEST_F(SamplingDecisionFilterTest, TenThousandDenominator) {
+  const std::string yaml = R"EOF(
+runtime_key: "sampling.test"
+percent_sampled:
+  numerator: 5000
+  denominator: TEN_THOUSAND
+)EOF";
+
+  setupFilter(yaml);
+
+  EXPECT_CALL(random_, random()).WillOnce(Return(2500));
+  EXPECT_CALL(runtime_.snapshot_, featureEnabled("sampling.test", 5000, 2500, 10000))
+      .WillOnce(Return(true));
+  EXPECT_CALL(runtime_.snapshot_, getInteger("sampling.test", 5000)).WillOnce(Return(5000));
+
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers_, false));
+
+  const auto& metadata = decoder_callbacks_.stream_info_.dynamicMetadata().filter_metadata();
+  const auto& sampling_metadata = metadata.at("envoy.filters.http.sampling_decision").fields();
+  EXPECT_EQ(sampling_metadata.at("denominator").number_value(), 10000);
+}
+
+TEST_F(SamplingDecisionFilterTest, MillionDenominator) {
+  const std::string yaml = R"EOF(
+runtime_key: "sampling.test"
+percent_sampled:
+  numerator: 500000
+  denominator: MILLION
+)EOF";
+
+  setupFilter(yaml);
+
+  EXPECT_CALL(random_, random()).WillOnce(Return(250000));
+  EXPECT_CALL(runtime_.snapshot_, featureEnabled("sampling.test", 500000, 250000, 1000000))
+      .WillOnce(Return(true));
+  EXPECT_CALL(runtime_.snapshot_, getInteger("sampling.test", 500000)).WillOnce(Return(500000));
+
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers_, false));
+
+  const auto& metadata = decoder_callbacks_.stream_info_.dynamicMetadata().filter_metadata();
+  const auto& sampling_metadata = metadata.at("envoy.filters.http.sampling_decision").fields();
+  EXPECT_EQ(sampling_metadata.at("denominator").number_value(), 1000000);
+}
+
+TEST_F(SamplingDecisionFilterTest, DefaultPercentSampled) {
+  const std::string yaml = R"EOF(
+runtime_key: "sampling.test"
+)EOF";
+
+  setupFilter(yaml);
+
+  // With no percent_sampled configured, it defaults to 0/100.
+  EXPECT_CALL(random_, random()).WillOnce(Return(0));
+  EXPECT_CALL(runtime_.snapshot_, featureEnabled("sampling.test", 0, 0, 100))
+      .WillOnce(Return(false));
+  EXPECT_CALL(runtime_.snapshot_, getInteger("sampling.test", 0)).WillOnce(Return(0));
+
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers_, false));
+
+  const auto& metadata = decoder_callbacks_.stream_info_.dynamicMetadata().filter_metadata();
+  const auto& sampling_metadata = metadata.at("envoy.filters.http.sampling_decision").fields();
+  EXPECT_EQ(sampling_metadata.at("sampled").bool_value(), false);
+  EXPECT_EQ(sampling_metadata.at("numerator").number_value(), 0);
+  EXPECT_EQ(sampling_metadata.at("denominator").number_value(), 100);
+}
+
+TEST_F(SamplingDecisionFilterTest, AlwaysContinue) {
+  const std::string yaml = R"EOF(
+runtime_key: "sampling.test"
+percent_sampled:
+  numerator: 100
+  denominator: HUNDRED
+)EOF";
+
+  setupFilter(yaml);
+
+  EXPECT_CALL(random_, random()).WillOnce(Return(0));
+  EXPECT_CALL(runtime_.snapshot_, featureEnabled(_, _, _, _)).WillOnce(Return(true));
+  EXPECT_CALL(runtime_.snapshot_, getInteger(_, _)).WillOnce(Return(100));
+
+  // Filter should always return Continue regardless of sampling decision.
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers_, false));
+}
+
+TEST_F(SamplingDecisionFilterTest, ConfigValidation) {
+  // Test that config properly parses all fields.
+  const std::string yaml = R"EOF(
+runtime_key: "test.key"
+percent_sampled:
+  numerator: 25
+  denominator: HUNDRED
+use_independent_randomness: true
+metadata_namespace: "my.namespace"
+)EOF";
+
+  envoy::extensions::filters::http::sampling_decision::v3::SamplingDecision proto_config;
+  TestUtility::loadFromYaml(yaml, proto_config);
+  auto config = std::make_shared<SamplingDecisionConfig>(proto_config);
+
+  EXPECT_EQ(config->runtimeKey(), "test.key");
+  EXPECT_EQ(config->percentSampled().numerator(), 25);
+  EXPECT_EQ(config->percentSampled().denominator(), envoy::type::v3::FractionalPercent::HUNDRED);
+  EXPECT_EQ(config->useIndependentRandomness(), true);
+  EXPECT_EQ(config->metadataNamespace(), "my.namespace");
+}
+
+TEST_F(SamplingDecisionFilterTest, DefaultMetadataNamespace) {
+  const std::string yaml = R"EOF(
+runtime_key: "sampling.test"
+percent_sampled:
+  numerator: 50
+  denominator: HUNDRED
+)EOF";
+
+  envoy::extensions::filters::http::sampling_decision::v3::SamplingDecision proto_config;
+  TestUtility::loadFromYaml(yaml, proto_config);
+  auto config = std::make_shared<SamplingDecisionConfig>(proto_config);
+
+  EXPECT_EQ(config->metadataNamespace(), "envoy.filters.http.sampling_decision");
+}
+
+} // namespace
+} // namespace SamplingDecision
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/test/extensions/filters/http/sampling_decision/sampling_decision_integration_test.cc
+++ b/test/extensions/filters/http/sampling_decision/sampling_decision_integration_test.cc
@@ -1,0 +1,203 @@
+#include "envoy/extensions/filters/http/sampling_decision/v3/sampling_decision.pb.h"
+
+#include "test/integration/http_integration.h"
+
+#include "gtest/gtest.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace SamplingDecision {
+namespace {
+
+class SamplingDecisionIntegrationTest : public testing::TestWithParam<Network::Address::IpVersion>,
+                                        public HttpIntegrationTest {
+public:
+  SamplingDecisionIntegrationTest() : HttpIntegrationTest(Http::CodecType::HTTP1, GetParam()) {}
+
+  void initializeFilter(const std::string& filter_config) {
+    config_helper_.prependFilter(filter_config);
+    initialize();
+  }
+};
+
+INSTANTIATE_TEST_SUITE_P(IpVersions, SamplingDecisionIntegrationTest,
+                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
+
+// Test that the filter stores sampling metadata correctly.
+TEST_P(SamplingDecisionIntegrationTest, BasicSamplingMetadata) {
+  const std::string filter_config = R"EOF(
+name: envoy.filters.http.sampling_decision
+typed_config:
+  "@type": type.googleapis.com/envoy.extensions.filters.http.sampling_decision.v3.SamplingDecision
+  runtime_key: test.sampling.key
+  percent_sampled:
+    numerator: 100
+    denominator: HUNDRED
+)EOF";
+
+  initializeFilter(filter_config);
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+
+  auto response = codec_client_->makeRequestWithBody(
+      Http::TestRequestHeaderMapImpl{
+          {":method", "GET"}, {":path", "/test"}, {":scheme", "http"}, {":authority", "host"}},
+      1024);
+
+  waitForNextUpstreamRequest();
+
+  upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, false);
+  upstream_request_->encodeData(512, true);
+
+  ASSERT_TRUE(response->waitForEndStream());
+  EXPECT_TRUE(response->complete());
+  EXPECT_EQ("200", response->headers().getStatusValue());
+}
+
+// Test with custom metadata namespace.
+TEST_P(SamplingDecisionIntegrationTest, CustomMetadataNamespace) {
+  const std::string filter_config = R"EOF(
+name: envoy.filters.http.sampling_decision
+typed_config:
+  "@type": type.googleapis.com/envoy.extensions.filters.http.sampling_decision.v3.SamplingDecision
+  runtime_key: test.sampling.key
+  percent_sampled:
+    numerator: 50
+    denominator: HUNDRED
+  metadata_namespace: custom.sampling.namespace
+)EOF";
+
+  initializeFilter(filter_config);
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+
+  auto response = codec_client_->makeRequestWithBody(
+      Http::TestRequestHeaderMapImpl{
+          {":method", "GET"}, {":path", "/test"}, {":scheme", "http"}, {":authority", "host"}},
+      1024);
+
+  waitForNextUpstreamRequest();
+
+  upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, false);
+  upstream_request_->encodeData(512, true);
+
+  ASSERT_TRUE(response->waitForEndStream());
+  EXPECT_TRUE(response->complete());
+  EXPECT_EQ("200", response->headers().getStatusValue());
+}
+
+// Test that the filter works with independent randomness.
+TEST_P(SamplingDecisionIntegrationTest, IndependentRandomness) {
+  const std::string filter_config = R"EOF(
+name: envoy.filters.http.sampling_decision
+typed_config:
+  "@type": type.googleapis.com/envoy.extensions.filters.http.sampling_decision.v3.SamplingDecision
+  runtime_key: test.sampling.key
+  percent_sampled:
+    numerator: 100
+    denominator: HUNDRED
+  use_independent_randomness: true
+)EOF";
+
+  initializeFilter(filter_config);
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+
+  auto response = codec_client_->makeRequestWithBody(
+      Http::TestRequestHeaderMapImpl{
+          {":method", "POST"}, {":path", "/test"}, {":scheme", "http"}, {":authority", "host"}},
+      1024);
+
+  waitForNextUpstreamRequest();
+
+  upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, false);
+  upstream_request_->encodeData(512, true);
+
+  ASSERT_TRUE(response->waitForEndStream());
+  EXPECT_TRUE(response->complete());
+  EXPECT_EQ("200", response->headers().getStatusValue());
+}
+
+// Test that multiple sampling decision filters can coexist with different namespaces.
+TEST_P(SamplingDecisionIntegrationTest, MultipleFiltersWithDifferentNamespaces) {
+  const std::string filter_config1 = R"EOF(
+name: envoy.filters.http.sampling_decision
+typed_config:
+  "@type": type.googleapis.com/envoy.extensions.filters.http.sampling_decision.v3.SamplingDecision
+  runtime_key: test.sampling.key1
+  percent_sampled:
+    numerator: 100
+    denominator: HUNDRED
+  metadata_namespace: sampling.decision1
+)EOF";
+
+  const std::string filter_config2 = R"EOF(
+name: envoy.filters.http.sampling_decision
+typed_config:
+  "@type": type.googleapis.com/envoy.extensions.filters.http.sampling_decision.v3.SamplingDecision
+  runtime_key: test.sampling.key2
+  percent_sampled:
+    numerator: 50
+    denominator: HUNDRED
+  metadata_namespace: sampling.decision2
+)EOF";
+
+  config_helper_.prependFilter(filter_config1);
+  config_helper_.prependFilter(filter_config2);
+  initialize();
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+
+  auto response = codec_client_->makeRequestWithBody(
+      Http::TestRequestHeaderMapImpl{
+          {":method", "GET"}, {":path", "/test"}, {":scheme", "http"}, {":authority", "host"}},
+      1024);
+
+  waitForNextUpstreamRequest();
+
+  upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, false);
+  upstream_request_->encodeData(512, true);
+
+  ASSERT_TRUE(response->waitForEndStream());
+  EXPECT_TRUE(response->complete());
+  EXPECT_EQ("200", response->headers().getStatusValue());
+}
+
+// Test that the filter continues processing regardless of sampling decision.
+TEST_P(SamplingDecisionIntegrationTest, FilterAlwaysContinues) {
+  const std::string filter_config = R"EOF(
+name: envoy.filters.http.sampling_decision
+typed_config:
+  "@type": type.googleapis.com/envoy.extensions.filters.http.sampling_decision.v3.SamplingDecision
+  runtime_key: test.sampling.key
+  percent_sampled:
+    numerator: 0
+    denominator: HUNDRED
+)EOF";
+
+  initializeFilter(filter_config);
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+
+  // Even with 0% sampling, the request should still be processed.
+  auto response = codec_client_->makeRequestWithBody(
+      Http::TestRequestHeaderMapImpl{
+          {":method", "GET"}, {":path", "/test"}, {":scheme", "http"}, {":authority", "host"}},
+      1024);
+
+  waitForNextUpstreamRequest();
+
+  upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, false);
+  upstream_request_->encodeData(512, true);
+
+  ASSERT_TRUE(response->waitForEndStream());
+  EXPECT_TRUE(response->complete());
+  EXPECT_EQ("200", response->headers().getStatusValue());
+}
+
+} // namespace
+} // namespace SamplingDecision
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy


### PR DESCRIPTION
## Description

This PR adds a new `sampling_decision` http filter which evaluates runtime-based sampling decisions and stores them in dynamic metadata. This allows other filters, such as access log filters, to reference the sampling decision without re-evaluating the sampling logic.

---

**Commit Message:** http_filter: added a new sampling_decision http filter
**Additional Description:**
**Risk Level:** Low
**Testing:** Added Tests
**Docs Changes:** Added
**Release Notes:** Added