### PR TITLE
github/ci: Cleanups/improvements/diskspace

### DIFF
--- a/.github/workflows/_check_build.yml
+++ b/.github/workflows/_check_build.yml
@@ -38,6 +38,8 @@ jobs:
       bazel-extra: '--config=remote-envoy-engflow'
       cache-build-image: ${{ fromJSON(inputs.request).request.build-image.default }}
       concurrency-suffix: -${{ matrix.target }}
+      diskspace-hack-paths: ${{ matrix.diskspace-hack-paths || '/opt/hostedtoolcache' }}
+      docker-ci: ${{ matrix.docker-ci || false }}
       error-match: |
         ERROR
         error:
@@ -56,5 +58,9 @@ jobs:
           name: API
         - target: compile_time_options
           name: Compile time options
+          docker-ci: true
         - target: gcc
           name: GCC
+          diskspace-hack-paths: |
+            /opt/hostedtoolcache
+            /usr/local/.ghcup

--- a/.github/workflows/_check_coverage.yml
+++ b/.github/workflows/_check_coverage.yml
@@ -41,7 +41,7 @@ jobs:
       bazel-extra: '--config=remote-envoy-engflow'
       cache-build-image: ${{ fromJSON(inputs.request).request.build-image.default }}
       concurrency-suffix: -${{ matrix.target }}
-      diskspace-hack-paths: ${{ matrix.diskspace-hack-paths || '/opt/hostedtoolcache' }}
+      diskspace-hack-paths: ${{ matrix.diskspace-hack-paths }}
       error-match: |
         ERROR
         error:
@@ -72,8 +72,8 @@ jobs:
         include:
         - target: coverage
           name: Coverage
-          diskspace-hack-paths: |
-            /opt/hostedtoolcache
-            /usr/local/.ghcup
+          diskspace-hack-paths:
         - target: fuzz_coverage
           name: Fuzz coverage
+          diskspace-hack-paths: |
+            /opt/hostedtoolcache

--- a/.github/workflows/_precheck_deps.yml
+++ b/.github/workflows/_precheck_deps.yml
@@ -40,7 +40,7 @@ jobs:
       bazel-extra: '--config=remote-envoy-engflow'
       cache-build-image: ${{ fromJSON(inputs.request).request.build-image.default }}
       concurrency-suffix: -${{ matrix.target }}
-      diskspace-hack-paths: ${{ matrix.diskspace-hack-paths || '/opt/hostedtoolcache' }}
+      diskspace-hack-paths: ${{ matrix.diskspace-hack-paths }}
       gcs-cache-bucket: ${{ inputs.gcs-cache-bucket }}
       request: ${{ inputs.request }}
       error-match: |
@@ -55,9 +55,7 @@ jobs:
         include:
         - target: deps
           rbe: false
-          diskspace-hack-paths: |
-            /opt/hostedtoolcache
-            /usr/local/.ghcup
+          diskspace-hack-paths:
 
   dependency-review:
     runs-on: ubuntu-24.04

--- a/.github/workflows/_precheck_format.yml
+++ b/.github/workflows/_precheck_format.yml
@@ -40,6 +40,8 @@ jobs:
       concurrency-suffix: -${{ matrix.target }}
       gcs-cache-bucket: ${{ inputs.gcs-cache-bucket }}
       request: ${{ inputs.request }}
+      # format needs aspell, and format-api requires git
+      docker-ci: false
       error-match: |
         ERROR
         error:

--- a/.github/workflows/_publish_build.yml
+++ b/.github/workflows/_publish_build.yml
@@ -86,10 +86,6 @@ jobs:
         export ENVOY_DOCKER_IN_DOCKER=1
         export ENVOY_DOCKER_SAVE_IMAGE=true
         export ENVOY_OCI_DIR=build_images
-
-        # export DOCKER_BUILD_PLATFORM=${{ inputs.arch == 'x64' && 'linux/amd64' || 'linux/arm64' }}
-        # export DOCKER_LOAD_IMAGES=true
-        # export DOCKER_FORCE_OCI_OUTPUT=true
       trusted: ${{ inputs.trusted }}
       upload-name: oci.${{ inputs.arch }}
       upload-path: container/envoy/${{ inputs.arch }}/build_images
@@ -118,6 +114,10 @@ jobs:
       cache-build-image: ${{ fromJSON(inputs.request).request.build-image.default }}
       cache-build-image-key-suffix: ${{ inputs.arch == 'arm64' && '-arm64' || '' }}
       concurrency-suffix: -${{ inputs.arch }}
+      diskspace-hack-paths: |
+        /opt/hostedtoolcache
+        /usr/local/.ghcup
+      docker-ci: false
       gcs-cache-bucket: ${{ inputs.gcs-cache-bucket }}
       import-gpg: true
       rbe: false

--- a/.github/workflows/_publish_release.yml
+++ b/.github/workflows/_publish_release.yml
@@ -58,9 +58,7 @@ jobs:
         --//distribution:x64-release=//distribution:custom/x64/bin/release.tar.zst
         --//distribution:arm64-release=//distribution:custom/arm64/bin/release.tar.zst
       cache-build-image: ${{ fromJSON(inputs.request).request.build-image.default }}
-      diskspace-hack-paths: |
-        /opt/hostedtoolcache
-        /usr/local/.ghcup
+      diskspace-hack-paths:
       downloads: |
         packages.arm64: container/envoy/arm64/
         packages.x64: container/envoy/x64/

--- a/.github/workflows/_publish_verify.yml
+++ b/.github/workflows/_publish_verify.yml
@@ -41,6 +41,9 @@ jobs:
       cache-build-image-key-suffix: ${{ matrix.arch == 'arm64' && format('-{0}', matrix.arch) || '' }}
       container-command: ${{ matrix.container-command }}
       concurrency-suffix: -${{ matrix.arch || 'x64' }}
+      diskspace-hack-paths: |
+        /opt/hostedtoolcache
+        /usr/local/.ghcup
       downloads: ${{ matrix.downloads }}
       rbe: ${{ matrix.rbe }}
       request: ${{ inputs.request }}
@@ -145,6 +148,9 @@ jobs:
       cache-build-image-key-suffix: ${{ matrix.arch == 'arm64' && format('-{0}', matrix.arch) || '' }}
       container-command: ./ci/run_envoy_docker.sh
       concurrency-suffix: -${{ matrix.arch || 'x64' }}
+      diskspace-hack-paths: |
+        /opt/hostedtoolcache
+        /usr/local/.ghcup
       downloads: |
         release.signed: container/release.signed
       gcs-cache-bucket: ${{ inputs.gcs-cache-bucket }}

--- a/.github/workflows/_request_cache_bazel.yml
+++ b/.github/workflows/_request_cache_bazel.yml
@@ -64,6 +64,12 @@ jobs:
           - src: /mnt/build
             target: /build
             chown: "runner:docker"
+    - name: Free diskspace
+      uses: envoyproxy/toolshed/gh-actions/diskspace@actions-v0.3.29
+      if: inputs.arch == 'x64' && github.event.repository.private
+      with:
+        to_remove: |
+          /opt/hostedtoolcache
     - uses: envoyproxy/toolshed/gh-actions/github/checkout@actions-v0.3.29
       id: checkout-target
       name: Checkout Envoy repository (target branch)

--- a/.github/workflows/_run.yml
+++ b/.github/workflows/_run.yml
@@ -69,6 +69,9 @@ on:
       docker-cpus:
         type: number
         default: 0
+      docker-ci:
+        type: boolean
+        default: true
       docker-ipv6:
         default: true
         type: boolean
@@ -411,3 +414,4 @@ jobs:
         CI_TARGET_BRANCH: ${{ fromJSON(inputs.request).request.target-branch }}
         MOUNT_GPG_HOME: ${{ inputs.import-gpg && 1 || '' }}
         ENVOY_DOCKER_CPUS: ${{ inputs.docker-cpus }}
+        ENVOY_DOCKER_CI: ${{ inputs.docker-ci && 'true' || '' }}


### PR DESCRIPTION
this prepares the CI env for the pending switch to hermetic llvm toolchains, by increasing diskspace available to private repos, and adding CI vars for container selection.

