### PR TITLE
On-demand VHDS over delta ADS

### DIFF
--- a/test/common/router/vhds_test.cc
+++ b/test/common/router/vhds_test.cc
@@ -128,6 +128,29 @@ vhds:
                    .ok());
 }
 
+// Verify that VHDS over GRPC fails when ADS is using DELTA_GRPC.
+TEST_F(VhdsTest, VhdsInstantiationShouldFailWithGrpcAndAdsDeltaGrpc) {
+  factory_context_.bootstrap().mutable_dynamic_resources()->mutable_ads_config()->set_api_type(
+      envoy::config::core::v3::ApiConfigSource::DELTA_GRPC);
+  const auto route_config =
+      TestUtility::parseYaml<envoy::config::route::v3::RouteConfiguration>(R"EOF(
+name: my_route
+vhds:
+  config_source:
+    api_config_source:
+      api_type: GRPC
+      grpc_services:
+        envoy_grpc:
+          cluster_name: xds_cluster
+  )EOF");
+  RouteConfigUpdatePtr config_update_info = makeRouteConfigUpdate(route_config);
+
+  EXPECT_FALSE(VhdsSubscription::createVhdsSubscription(config_update_info, factory_context_,
+                                                        context_, provider_)
+                   .status()
+                   .ok());
+}
+
 // verify that ADS with DELTA_GRPC in bootstrap passes validation
 TEST_F(VhdsTest, VhdsInstantiationShouldSucceedWithAdsAndDeltaGrpc) {
   // Configure bootstrap with ADS using DELTA_GRPC

--- a/test/config/utility.cc
+++ b/test/config/utility.cc
@@ -695,6 +695,50 @@ ConfigHelper::buildRouteConfig(const std::string& name, const std::string& clust
 #endif
 }
 
+envoy::config::route::v3::RouteConfiguration
+ConfigHelper::buildRouteConfigWithVhdsOverAds(const std::string& name) {
+  API_NO_BOOST(envoy::config::route::v3::RouteConfiguration) route;
+#ifdef ENVOY_ENABLE_YAML
+  TestUtility::loadFromYaml(fmt::format(R"EOF(
+      name: "{}"
+      vhds:
+        config_source:
+          ads: {{}}
+    )EOF",
+                                        name),
+                            route);
+  return route;
+#else
+  UNREFERENCED_PARAMETER(name);
+  PANIC("YAML support compiled out");
+#endif
+}
+
+envoy::config::route::v3::VirtualHost ConfigHelper::buildVirtualHost(const std::string& name,
+                                                                     const std::string& domain,
+                                                                     const std::string& prefix,
+                                                                     const std::string& cluster) {
+  API_NO_BOOST(envoy::config::route::v3::VirtualHost) vhost;
+#ifdef ENVOY_ENABLE_YAML
+  TestUtility::loadFromYaml(fmt::format(R"EOF(
+        name: {}
+        domains: [{}]
+        routes:
+        - match: {{ prefix: {} }}
+          route: {{ cluster: {} }}
+      )EOF",
+                                        name, domain, prefix, cluster),
+                            vhost);
+  return vhost;
+#else
+  UNREFERENCED_PARAMETER(name);
+  UNREFERENCED_PARAMETER(domain);
+  UNREFERENCED_PARAMETER(prefix);
+  UNREFERENCED_PARAMETER(cluster);
+  PANIC("YAML support compiled out");
+#endif
+}
+
 envoy::config::endpoint::v3::Endpoint ConfigHelper::buildEndpoint(const std::string& address) {
   envoy::config::endpoint::v3::Endpoint endpoint;
   endpoint.mutable_address()->mutable_socket_address()->set_address(address);

--- a/test/config/utility.h
+++ b/test/config/utility.h
@@ -283,6 +283,14 @@ public:
   buildRouteConfig(const std::string& name, const std::string& cluster,
                    bool header_mutations = false);
 
+  static envoy::config::route::v3::RouteConfiguration
+  buildRouteConfigWithVhdsOverAds(const std::string& name);
+
+  static envoy::config::route::v3::VirtualHost buildVirtualHost(const std::string& name,
+                                                                const std::string& domain,
+                                                                const std::string& prefix,
+                                                                const std::string& cluster);
+
   // Builds a standard Endpoint suitable for population by finalize().
   static envoy::config::endpoint::v3::Endpoint buildEndpoint(const std::string& address);
 

--- a/test/integration/ads_integration.cc
+++ b/test/integration/ads_integration.cc
@@ -133,6 +133,17 @@ AdsIntegrationTestBase::buildRouteConfig(const std::string& name, const std::str
   return ConfigHelper::buildRouteConfig(name, cluster);
 }
 
+envoy::config::route::v3::RouteConfiguration
+AdsIntegrationTestBase::buildRouteConfigWithVhds(const std::string& name) {
+  return ConfigHelper::buildRouteConfigWithVhdsOverAds(name);
+}
+
+envoy::config::route::v3::VirtualHost
+AdsIntegrationTestBase::buildVirtualHost(const std::string& name, const std::string& domain,
+                                         const std::string& prefix, const std::string& cluster) {
+  return ConfigHelper::buildVirtualHost(name, domain, prefix, cluster);
+}
+
 void AdsIntegrationTestBase::makeSingleRequest() {
   registerTestServerPorts({"http"});
   testRouterHeaderOnlyRequestAndResponse();

--- a/test/integration/ads_integration.h
+++ b/test/integration/ads_integration.h
@@ -74,6 +74,13 @@ public:
   envoy::config::route::v3::RouteConfiguration buildRouteConfig(const std::string& name,
                                                                 const std::string& cluster);
 
+  envoy::config::route::v3::RouteConfiguration buildRouteConfigWithVhds(const std::string& name);
+
+  envoy::config::route::v3::VirtualHost buildVirtualHost(const std::string& name,
+                                                         const std::string& domain,
+                                                         const std::string& prefix,
+                                                         const std::string& cluster);
+
   void makeSingleRequest();
   void makeSingleRequestWithDropOverload();
 

--- a/test/integration/ads_integration_test.cc
+++ b/test/integration/ads_integration_test.cc
@@ -4,6 +4,7 @@
 #include "envoy/config/endpoint/v3/endpoint.pb.h"
 #include "envoy/config/listener/v3/listener.pb.h"
 #include "envoy/config/route/v3/route.pb.h"
+#include "envoy/config/route/v3/route_components.pb.h"
 #include "envoy/grpc/status.h"
 
 #include "source/common/config/protobuf_link_hacks.h"
@@ -3040,6 +3041,296 @@ TEST_P(AdsReplacementIntegrationTest, ReplaceAdsConfig) {
       Grpc::Status::WellKnownGrpcStatus::Ok, "", second_xds_stream_.get()));
 
   makeSingleRequest();
+}
+
+// Tests the following scenarios:
+// - Multiple VHDS resources for the same route can be sent over ADS.
+// - Removal of one listener doesn't impact another that references the same vhost over the same
+// route config.
+// - Removal of one vhost doesn't impact another vhost in the same route config.
+// - Removal of a vhost from one route config doesn't impact the same vhost in another route config.
+TEST_P(AdsIntegrationTest, MultipleVhdsOverAds) {
+  if (sotw_or_delta_ != Grpc::SotwOrDelta::Delta &&
+      sotw_or_delta_ != Grpc::SotwOrDelta::UnifiedDelta) {
+    GTEST_SKIP_("This test is for delta only");
+  }
+  initialize();
+
+  // Send initial configuration that sets up 3 listeners with the following vhosts:
+  // listener_0 -> route_config_0/foo
+  // listener_0 -> route_config_0/bar
+  // listener_1 -> route_config_0/foo
+  // listener_1 -> route_config_0/bar
+  // listener_2 -> route_config_1/foo
+  EXPECT_TRUE(compareDiscoveryRequest(Config::TestTypeUrl::get().Cluster, "", {}, {}, {}, true));
+  sendDiscoveryResponse<envoy::config::cluster::v3::Cluster>(Config::TestTypeUrl::get().Cluster, {},
+                                                             {
+                                                                 buildCluster("cluster_0"),
+                                                                 buildCluster("cluster_1"),
+                                                             },
+                                                             {}, "1");
+  EXPECT_TRUE(compareDiscoveryRequest(Config::TestTypeUrl::get().ClusterLoadAssignment, "", {},
+                                      {"cluster_0", "cluster_1"}, {}));
+  sendDiscoveryResponse<envoy::config::endpoint::v3::ClusterLoadAssignment>(
+      Config::TestTypeUrl::get().ClusterLoadAssignment, {},
+      {buildClusterLoadAssignment("cluster_0"), buildClusterLoadAssignment("cluster_1")}, {}, "1");
+  EXPECT_TRUE(compareDiscoveryRequest(Config::TestTypeUrl::get().Cluster, "", {}, {}, {}));
+
+  EXPECT_TRUE(compareDiscoveryRequest(Config::TestTypeUrl::get().Listener, "", {}, {}, {}));
+  sendDiscoveryResponse<envoy::config::listener::v3::Listener>(
+      Config::TestTypeUrl::get().Listener, {},
+      {buildListener("listener_0", "route_config_0"),
+       buildListener("listener_1", "route_config_0")},
+      {}, "1");
+
+  EXPECT_TRUE(
+      compareDiscoveryRequest(Config::TestTypeUrl::get().ClusterLoadAssignment, "", {}, {}, {}));
+  EXPECT_TRUE(compareDiscoveryRequest(Config::TestTypeUrl::get().RouteConfiguration, "", {},
+                                      {"route_config_0"}, {}));
+  sendDiscoveryResponse<envoy::config::route::v3::RouteConfiguration>(
+      Config::TestTypeUrl::get().RouteConfiguration, {},
+      {buildRouteConfigWithVhds("route_config_0")}, {}, "1");
+  EXPECT_TRUE(compareDiscoveryRequest(Config::TestTypeUrl::get().Listener, "", {}, {}, {}));
+  EXPECT_TRUE(compareDiscoveryRequest(Config::TestTypeUrl::get().VirtualHost, "", {}, {}, {}));
+  EXPECT_TRUE(
+      compareDiscoveryRequest(Config::TestTypeUrl::get().RouteConfiguration, "", {}, {}, {}));
+
+  sendDiscoveryResponse<envoy::config::listener::v3::Listener>(
+      Config::TestTypeUrl::get().Listener, {}, {buildListener("listener_2", "route_config_1")}, {},
+      "1");
+  EXPECT_TRUE(compareDiscoveryRequest(Config::TestTypeUrl::get().RouteConfiguration, "", {},
+                                      {"route_config_1"}, {}));
+  sendDiscoveryResponse<envoy::config::route::v3::RouteConfiguration>(
+      Config::TestTypeUrl::get().RouteConfiguration, {},
+      {buildRouteConfigWithVhds("route_config_1")}, {}, "1");
+  EXPECT_TRUE(compareDiscoveryRequest(Config::TestTypeUrl::get().Listener, "", {}, {}, {}));
+  EXPECT_TRUE(
+      compareDiscoveryRequest(Config::TestTypeUrl::get().RouteConfiguration, "", {}, {}, {}));
+
+  sendDiscoveryResponse<envoy::config::route::v3::VirtualHost>(
+      Config::TestTypeUrl::get().VirtualHost, {},
+      {buildVirtualHost("route_config_0/foo", "foo.com", "/foo", "cluster_0"),
+       buildVirtualHost("route_config_0/bar", "bar.com", "/bar", "cluster_0"),
+       buildVirtualHost("route_config_1/foo", "foo.com", "/foo", "cluster_1")},
+      {}, "1");
+  EXPECT_TRUE(compareDiscoveryRequest(Config::TestTypeUrl::get().VirtualHost, "", {}, {}, {}));
+
+  test_server_->waitForCounterGe("listener_manager.listener_create_success", 3);
+
+  auto foo_request_headers = Http::TestRequestHeaderMapImpl{
+      {":method", "GET"}, {":path", "/foo"}, {":scheme", "http"}, {":authority", "foo.com"}};
+  auto bar_request_headers = Http::TestRequestHeaderMapImpl{
+      {":method", "GET"}, {":path", "/bar"}, {":scheme", "http"}, {":authority", "bar.com"}};
+  registerTestServerPorts({"http0", "http1", "http2"});
+
+  auto send_request_and_verify = [this](const std::string& port_name,
+                                        const Http::TestRequestHeaderMapImpl& headers,
+                                        bool verify_404 = false) {
+    codec_client_ = makeHttpConnection(makeClientConnection((lookupPort(port_name))));
+    if (verify_404) {
+      auto response = codec_client_->makeHeaderOnlyRequest(headers);
+      ASSERT_TRUE(response->waitForEndStream());
+      EXPECT_EQ("404", response->headers().getStatusValue());
+    } else {
+      auto response = sendRequestAndWaitForResponse(headers, 0, default_response_headers_, 0, 0);
+      checkSimpleRequestSuccess(0U, 0U, response.get());
+    }
+    cleanupUpstreamAndDownstream();
+  };
+
+  // Verify all vhosts across all listeners are correctly configured.
+  send_request_and_verify("http0", foo_request_headers);
+  send_request_and_verify("http0", bar_request_headers);
+  send_request_and_verify("http1", foo_request_headers);
+  send_request_and_verify("http1", bar_request_headers);
+  send_request_and_verify("http2", foo_request_headers);
+
+  // Verify that removing listener_0 doesn't impact listener_1 that also references
+  // route_config_0/foo and route_config_0/bar.
+  sendDiscoveryResponse<envoy::config::listener::v3::Listener>(Config::TestTypeUrl::get().Listener,
+                                                               {}, {}, {"listener_0"}, "1");
+  send_request_and_verify("http1", foo_request_headers);
+  send_request_and_verify("http1", bar_request_headers);
+
+  // Verify that removing route_config_0/foo makes foo.com unreachable but bar.com is still
+  // reachable from listener_1.
+  sendDiscoveryResponse<envoy::config::route::v3::VirtualHost>(
+      Config::TestTypeUrl::get().VirtualHost, {}, {}, {"route_config_0/foo"}, "1");
+  send_request_and_verify("http1", foo_request_headers, true);
+  send_request_and_verify("http1", bar_request_headers);
+
+  // Verify that listener_2 is unaffected and continues to work.
+  send_request_and_verify("http2", foo_request_headers);
+}
+
+// Verifies that when two listeners are using the same route with VHDS resource and after one of the
+// listeners is removed, the other listener continues to receive updates on that VHDS resource.
+TEST_P(AdsIntegrationTest, VHDSUpdatesAfterListenerRemoval) {
+  if (sotw_or_delta_ != Grpc::SotwOrDelta::Delta &&
+      sotw_or_delta_ != Grpc::SotwOrDelta::UnifiedDelta) {
+    GTEST_SKIP_("This test is for delta only");
+  }
+  initialize();
+
+  // Send initial configuration that sets up two listeners with the following vhosts:
+  // listener_0 -> route_config_0/foo
+  // listener_1 -> route_config_0/foo
+  EXPECT_TRUE(compareDiscoveryRequest(Config::TestTypeUrl::get().Cluster, "", {}, {}, {}, true));
+  sendDiscoveryResponse<envoy::config::cluster::v3::Cluster>(Config::TestTypeUrl::get().Cluster, {},
+                                                             {buildCluster("cluster_0")}, {}, "1");
+  EXPECT_TRUE(compareDiscoveryRequest(Config::TestTypeUrl::get().ClusterLoadAssignment, "", {},
+                                      {"cluster_0"}, {}));
+  sendDiscoveryResponse<envoy::config::endpoint::v3::ClusterLoadAssignment>(
+      Config::TestTypeUrl::get().ClusterLoadAssignment, {},
+      {buildClusterLoadAssignment("cluster_0")}, {}, "1");
+  EXPECT_TRUE(compareDiscoveryRequest(Config::TestTypeUrl::get().Cluster, "", {}, {}, {}));
+
+  EXPECT_TRUE(compareDiscoveryRequest(Config::TestTypeUrl::get().Listener, "", {}, {}, {}));
+  sendDiscoveryResponse<envoy::config::listener::v3::Listener>(
+      Config::TestTypeUrl::get().Listener, {},
+      {buildListener("listener_0", "route_config_0"),
+       buildListener("listener_1", "route_config_0")},
+      {}, "1");
+
+  EXPECT_TRUE(
+      compareDiscoveryRequest(Config::TestTypeUrl::get().ClusterLoadAssignment, "", {}, {}, {}));
+  EXPECT_TRUE(compareDiscoveryRequest(Config::TestTypeUrl::get().RouteConfiguration, "", {},
+                                      {"route_config_0"}, {}));
+  sendDiscoveryResponse<envoy::config::route::v3::RouteConfiguration>(
+      Config::TestTypeUrl::get().RouteConfiguration, {},
+      {buildRouteConfigWithVhds("route_config_0")}, {}, "1");
+  EXPECT_TRUE(compareDiscoveryRequest(Config::TestTypeUrl::get().Listener, "", {}, {}, {}));
+  EXPECT_TRUE(compareDiscoveryRequest(Config::TestTypeUrl::get().VirtualHost, "", {}, {}, {}));
+  EXPECT_TRUE(
+      compareDiscoveryRequest(Config::TestTypeUrl::get().RouteConfiguration, "", {}, {}, {}));
+
+  sendDiscoveryResponse<envoy::config::route::v3::VirtualHost>(
+      Config::TestTypeUrl::get().VirtualHost, {},
+      {buildVirtualHost("route_config_0/foo", "foo.com", "/foo", "cluster_0")}, {}, "1");
+  EXPECT_TRUE(compareDiscoveryRequest(Config::TestTypeUrl::get().VirtualHost, "", {}, {}, {}));
+  test_server_->waitForCounterGe("listener_manager.listener_create_success", 2);
+  registerTestServerPorts({"http0", "http1"});
+
+  auto send_request_and_verify = [this](const std::string& port_name,
+                                        const Http::TestRequestHeaderMapImpl& headers,
+                                        bool verify_404 = false) {
+    codec_client_ = makeHttpConnection(makeClientConnection((lookupPort(port_name))));
+    if (verify_404) {
+      auto response = codec_client_->makeHeaderOnlyRequest(headers);
+      ASSERT_TRUE(response->waitForEndStream());
+      EXPECT_EQ("404", response->headers().getStatusValue());
+    } else {
+      auto response = sendRequestAndWaitForResponse(headers, 0, default_response_headers_, 0, 0);
+      checkSimpleRequestSuccess(0U, 0U, response.get());
+    }
+    cleanupUpstreamAndDownstream();
+  };
+
+  send_request_and_verify("http0", Http::TestRequestHeaderMapImpl{{":method", "GET"},
+                                                                  {":path", "/foo"},
+                                                                  {":scheme", "http"},
+                                                                  {":authority", "foo.com"}});
+  send_request_and_verify("http1", Http::TestRequestHeaderMapImpl{{":method", "GET"},
+                                                                  {":path", "/foo"},
+                                                                  {":scheme", "http"},
+                                                                  {":authority", "foo.com"}});
+  codec_client_->close();
+
+  // Remove listener_1 and verify that listener_0 continues to receive VHDS updates.
+  sendDiscoveryResponse<envoy::config::listener::v3::Listener>(Config::TestTypeUrl::get().Listener,
+                                                               {}, {}, {"listener_1"}, "1");
+  EXPECT_TRUE(compareDiscoveryRequest(Config::TestTypeUrl::get().Listener, "", {}, {}, {}));
+  test_server_->waitForGaugeEq("listener_manager.total_listeners_draining", 0);
+
+  // Verify that listener_0 still works.
+  send_request_and_verify("http0", Http::TestRequestHeaderMapImpl{{":method", "GET"},
+                                                                  {":path", "/foo"},
+                                                                  {":scheme", "http"},
+                                                                  {":authority", "foo.com"}});
+
+  // Send VHDS update to change the domain and path to bar.com and verify that requests to foo.com
+  // now fail while requests to bar.com pass.
+  sendDiscoveryResponse<envoy::config::route::v3::VirtualHost>(
+      Config::TestTypeUrl::get().VirtualHost, {},
+      {buildVirtualHost("route_config_0/foo", "bar.com", "/bar", "cluster_0")}, {}, "2");
+  EXPECT_TRUE(compareDiscoveryRequest(Config::TestTypeUrl::get().VirtualHost, "", {}, {}, {}));
+  send_request_and_verify(
+      "http0",
+      Http::TestRequestHeaderMapImpl{
+          {":method", "GET"}, {":path", "/foo"}, {":scheme", "http"}, {":authority", "foo.com"}},
+      true);
+  send_request_and_verify("http0", Http::TestRequestHeaderMapImpl{{":method", "GET"},
+                                                                  {":path", "/bar"},
+                                                                  {":scheme", "http"},
+                                                                  {":authority", "bar.com"}});
+}
+
+// Tests that when a new listener arrives referencing an existing route config, it doesn't request
+// for new route config resources and instead uses the local copy.
+TEST_P(AdsIntegrationTest, NewListenerUsesLocalRouteConfig) {
+  if (sotw_or_delta_ != Grpc::SotwOrDelta::Delta &&
+      sotw_or_delta_ != Grpc::SotwOrDelta::UnifiedDelta) {
+    GTEST_SKIP_("This test is for delta only");
+  }
+  initialize();
+
+  // Send initial configuration that sets up 1 listeners with the following vhosts:
+  // listener_0 -> route_config_0/foo
+  EXPECT_TRUE(compareDiscoveryRequest(Config::TestTypeUrl::get().Cluster, "", {}, {}, {}, true));
+  sendDiscoveryResponse<envoy::config::cluster::v3::Cluster>(Config::TestTypeUrl::get().Cluster, {},
+                                                             {buildCluster("cluster_0")}, {}, "1");
+  EXPECT_TRUE(compareDiscoveryRequest(Config::TestTypeUrl::get().ClusterLoadAssignment, "", {},
+                                      {"cluster_0"}, {}));
+  sendDiscoveryResponse<envoy::config::endpoint::v3::ClusterLoadAssignment>(
+      Config::TestTypeUrl::get().ClusterLoadAssignment, {},
+      {buildClusterLoadAssignment("cluster_0")}, {}, "1");
+  EXPECT_TRUE(compareDiscoveryRequest(Config::TestTypeUrl::get().Cluster, "", {}, {}, {}));
+
+  EXPECT_TRUE(compareDiscoveryRequest(Config::TestTypeUrl::get().Listener, "", {}, {}, {}));
+  sendDiscoveryResponse<envoy::config::listener::v3::Listener>(
+      Config::TestTypeUrl::get().Listener, {}, {buildListener("listener_0", "route_config_0")}, {},
+      "1");
+
+  EXPECT_TRUE(
+      compareDiscoveryRequest(Config::TestTypeUrl::get().ClusterLoadAssignment, "", {}, {}, {}));
+  EXPECT_TRUE(compareDiscoveryRequest(Config::TestTypeUrl::get().RouteConfiguration, "", {},
+                                      {"route_config_0"}, {}));
+  sendDiscoveryResponse<envoy::config::route::v3::RouteConfiguration>(
+      Config::TestTypeUrl::get().RouteConfiguration, {},
+      {buildRouteConfigWithVhds("route_config_0")}, {}, "1");
+  EXPECT_TRUE(compareDiscoveryRequest(Config::TestTypeUrl::get().Listener, "", {}, {}, {}));
+  EXPECT_TRUE(compareDiscoveryRequest(Config::TestTypeUrl::get().VirtualHost, "", {}, {}, {}));
+  EXPECT_TRUE(
+      compareDiscoveryRequest(Config::TestTypeUrl::get().RouteConfiguration, "", {}, {}, {}));
+  sendDiscoveryResponse<envoy::config::route::v3::VirtualHost>(
+      Config::TestTypeUrl::get().VirtualHost, {},
+      {buildVirtualHost("route_config_0/foo", "foo.com", "/foo", "cluster_0")}, {}, "1");
+  EXPECT_TRUE(compareDiscoveryRequest(Config::TestTypeUrl::get().VirtualHost, "", {}, {}, {}));
+  test_server_->waitForCounterGe("listener_manager.listener_create_success", 1);
+  registerTestServerPorts({"http0"});
+  codec_client_ = makeHttpConnection(makeClientConnection((lookupPort("http0"))));
+  auto response = sendRequestAndWaitForResponse(
+      Http::TestRequestHeaderMapImpl{
+          {":method", "GET"}, {":path", "/foo"}, {":scheme", "http"}, {":authority", "foo.com"}},
+      0, default_response_headers_, 0, 0);
+  checkSimpleRequestSuccess(0U, 0U, response.get());
+  cleanupUpstreamAndDownstream();
+
+  // Create new listener (listener_1) using the same route config (route_config_0) that shouldn't
+  // request for VHDS again and use the local copy.
+  sendDiscoveryResponse<envoy::config::listener::v3::Listener>(
+      Config::TestTypeUrl::get().Listener, {}, {buildListener("listener_1", "route_config_0")}, {},
+      "1");
+  EXPECT_TRUE(compareDiscoveryRequest(Config::TestTypeUrl::get().Listener, "", {}, {}, {}));
+  test_server_->waitForCounterGe("listener_manager.listener_create_success", 2);
+  registerTestServerPorts({"http0", "http1"});
+  codec_client_ = makeHttpConnection(makeClientConnection((lookupPort("http1"))));
+  response = sendRequestAndWaitForResponse(
+      Http::TestRequestHeaderMapImpl{
+          {":method", "GET"}, {":path", "/foo"}, {":scheme", "http"}, {":authority", "foo.com"}},
+      0, default_response_headers_, 0, 0);
+  checkSimpleRequestSuccess(0U, 0U, response.get());
+  cleanupUpstreamAndDownstream();
 }
 
 } // namespace Envoy


### PR DESCRIPTION
Commit Message: Enable VHDS subscriptions over Delta ADS with an opt-in singleton subscription

Additional Description: 
This PR attempts to make on-demand VHDS work over delta ADS. The current challenge is that the initial VHDS subscription is a wildcard request. This makes it difficult for the server to associate a subscription with a route config. Hence, there might be scenarios where a server sends some resources to Envoy where some get discarded but later re-requested through the on-demand filter - in this case, the server may not respond back since there may not have been a change in the resource and hence, the on-demand request is left hanging. To address this, this PR introduces a new field to start a singleton VHDS subscription over the route name. 

Risk Level: Low (opt-in feature)
Testing: Unit test and integration tests
Docs Changes: Covered by comments in proto file
Release Notes: Added to `changelogs/current.yaml`
Platform Specific Features: N/A

