### PR TITLE
mcp: add configurable route cache clearing for metadata-based routing

### DIFF
--- a/api/envoy/extensions/filters/http/mcp/v3/mcp.proto
+++ b/api/envoy/extensions/filters/http/mcp/v3/mcp.proto
@@ -35,6 +35,11 @@ message Mcp {
 
   // Configures how the filter handles non-MCP traffic.
   TrafficMode traffic_mode = 1 [(validate.rules).enum = {defined_only: true}];
+
+  // When set to true, the filter will clear the route cache after setting dynamic metadata.
+  // This allows the route to be re-selected based on the MCP metadata (e.g., method, params).
+  // Defaults to false.
+  bool clear_route_cache = 2;
 }
 
 // McpOverride for MCP filter

--- a/source/extensions/filters/http/mcp/mcp_filter.cc
+++ b/source/extensions/filters/http/mcp/mcp_filter.cc
@@ -165,6 +165,14 @@ void McpFilter::finalizeDynamicMetadata() {
     decoder_callbacks_->streamInfo().setDynamicMetadata(std::string(MetadataKeys::FilterName),
                                                         *metadata_);
     ENVOY_LOG(debug, "MCP filter set dynamic metadata: {}", metadata_->DebugString());
+
+    // Clear route cache to allow route re-selection based on dynamic metadata
+    if (config_->clearRouteCache()) {
+      if (auto cb = decoder_callbacks_->downstreamCallbacks(); cb.has_value()) {
+        cb->clearRouteCache();
+        ENVOY_LOG(debug, "MCP filter cleared route cache for metadata-based routing");
+      }
+    }
   }
 }
 

--- a/source/extensions/filters/http/mcp/mcp_filter.h
+++ b/source/extensions/filters/http/mcp/mcp_filter.h
@@ -32,7 +32,8 @@ constexpr absl::string_view JsonRpcVersion = "2.0";
 class McpFilterConfig {
 public:
   explicit McpFilterConfig(const envoy::extensions::filters::http::mcp::v3::Mcp& proto_config)
-      : traffic_mode_(proto_config.traffic_mode()) {}
+      : traffic_mode_(proto_config.traffic_mode()),
+        clear_route_cache_(proto_config.clear_route_cache()) {}
 
   envoy::extensions::filters::http::mcp::v3::Mcp::TrafficMode trafficMode() const {
     return traffic_mode_;
@@ -42,8 +43,11 @@ public:
     return traffic_mode_ == envoy::extensions::filters::http::mcp::v3::Mcp::REJECT_NO_MCP;
   }
 
+  bool clearRouteCache() const { return clear_route_cache_; }
+
 private:
   const envoy::extensions::filters::http::mcp::v3::Mcp::TrafficMode traffic_mode_;
+  const bool clear_route_cache_;
 };
 
 /**


### PR DESCRIPTION
Commit Message:

This change adds a `clear_route_cache` configuration option to the MCP filter, allowing users to control whether the route cache is cleared after setting dynamic metadata.

Additional Description:

When enabled (default: true), the filter clears the route cache after extracting and storing MCP metadata (method, params, id, etc.). This allows routes to be re-evaluated based on the newly set dynamic metadata, enabling use cases like routing different MCP methods to different backend clusters.

Users can disable this behavior by setting `clear_route_cache: false` in the filter configuration to avoid the small performance cost of route re-evaluation when metadata-based routing is not needed.

Testing:

Configuration example:
```
http_filters:
- name: envoy.filters.http.mcp
  typed_config:
    "@type": type.googleapis.com/envoy.extensions.filters.http.mcp.v3.Mcp
    traffic_mode: PASS_THROUGH
    clear_route_cache: true  # defaultRoute matching example:
routes:
- match:
    prefix: "/"
    dynamic_metadata:
    - filter: mcp_proxy
      path:
      - key: method
      value:
        string_match:
          exact: "tools/call"
  route:
    cluster: tools_backend
```

Changes:
- api: add `clear_route_cache` bool field to Mcp proto (defaults to true)
- filter: call `clearRouteCache()` conditionally in `finalizeDynamicMetadata()`
- config: add `clearRouteCache()` getter with default true behavior
- tests: add 4 test cases covering default, disabled, enabled, and config getter

This follows the same pattern as the ext_authz filter's route cache clearing behavior.

Risk Level:

Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
Fixes #41997
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
