### PR TITLE
mobile: add JUnit4TestNotRun:OFF to JNI test helper

### DIFF
--- a/mobile/test/java/io/envoyproxy/envoymobile/jni/BUILD
+++ b/mobile/test/java/io/envoyproxy/envoymobile/jni/BUILD
@@ -10,6 +10,7 @@ envoy_mobile_android_test(
     srcs = [
         "JniHelperTest.java",
     ],
+    javacopts = ["-Xep:JUnit4TestNotRun:OFF"],
     native_deps = [
         "//test/jni:libenvoy_jni_helper_test.so",
     ],


### PR DESCRIPTION
Suppresses forthcoming violations in internal Google checks.  Eventually we should update the helper with the correct JUnit4 annotations.