### PR TITLE
http: cap number of actions in conn_manager_impl_fuzz_test

### DIFF
--- a/test/common/http/conn_manager_impl_fuzz_test.cc
+++ b/test/common/http/conn_manager_impl_fuzz_test.cc
@@ -649,10 +649,11 @@ DEFINE_PROTO_FUZZER(const test::common::http::ConnManagerImplTestCase& input) {
   std::vector<FuzzStreamPtr> streams;
 
   // Limiting the number of actions processed to avoid excessively long executions
-  constexpr int kMaxActions = 1024;
-  const int num_actions = std::min<int>(kMaxActions, input.actions_size());
-  for (int i = 0; i < num_actions; ++i) {
-    const auto& action = input.actions(i);
+  constexpr uint32_t kMaxActions = 4096;
+  const uint32_t num_actions =
+      std::min<uint32_t>(kMaxActions, static_cast<uint32_t>(input.actions_size()));
+  for (uint32_t i = 0; i < num_actions; ++i) {
+    const auto& action = input.actions(static_cast<int>(i));
     ENVOY_LOG_MISC(trace, "action {} with {} streams", action.DebugString(), streams.size());
     if (!connection_alive) {
       ENVOY_LOG_MISC(trace, "skipping due to dead connection");


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->
Fixes #40524

cap number of actions in **conn_manager_impl_fuzz_test** to avoid long runtimes on pathological inputs. Process at most 1024 actions per testcase.

### **Additional Description:**

- Adds a bounded loop over input.actions() with kMaxActions = 1024.

- Mirrors limits used in other Envoy fuzzers to keep OSS-Fuzz/local runs stable.

### **Risk Level:**

- Low (test-only; no production code paths affected).

### **Testing:**

- Corpus run:

  - `bazel test //test/common/http:conn_manager_impl_fuzz_test --test_output=errors`

- Repro input timing (ASAN dbg):

  - `bazel-bin/test/common/http/conn_manager_impl_fuzz_test test/common/http/conn_manager_impl_corpus/clusterfuzz-testcase-minimized-conn_manager_impl_fuzz_test-6184237135364096.txt`
  - Completed in **~1.53s locally (previously ~50s).**
