### PR TITLE
buffer: optimize addFragments() in buffer_impl

### DIFF
--- a/source/common/buffer/buffer_impl.cc
+++ b/source/common/buffer/buffer_impl.cc
@@ -684,12 +684,48 @@ size_t OwnedImpl::addFragments(absl::Span<const absl::string_view> fragments) {
     back.commit<false>(reservation);
     length_ += total_size_to_copy;
   } else {
-    // Downgrade to using `addImpl` if not enough memory in the back slice.
-    // TODO(wbpcode): Fill the remaining memory space in the back slice then
-    // allocate enough contiguous memory for the remaining unwritten fragments
-    // and copy them directly. This may result in better performance.
-    for (const auto& fragment : fragments) {
-      addImpl(fragment.data(), fragment.size());
+    // Fill the remaining space in the back slice first, then allocate one contiguous
+    // slice for all remaining fragments. This reduces the number of slices created and
+    // improves memory locality.
+    size_t fragment_index = 0;
+    uint64_t bytes_written_to_reservation = 0;
+
+    // Fill as many complete fragments as possible into the existing reservation.
+    while (fragment_index < fragments.size() &&
+           bytes_written_to_reservation + fragments[fragment_index].size() <= reservation.len_) {
+      const auto& fragment = fragments[fragment_index];
+      memcpy(mem, fragment.data(), fragment.size()); // NOLINT(safe-memcpy)
+      mem += fragment.size();
+      bytes_written_to_reservation += fragment.size();
+      fragment_index++;
+    }
+
+    // Commit what we've written to the existing reservation.
+    if (bytes_written_to_reservation > 0) {
+      back.commit<false>({reservation.mem_, bytes_written_to_reservation});
+      length_ += bytes_written_to_reservation;
+    }
+
+    // If there are remaining fragments, allocate one contiguous slice for all of them.
+    if (fragment_index < fragments.size()) {
+      size_t remaining_size = 0;
+      for (size_t i = fragment_index; i < fragments.size(); i++) {
+        remaining_size += fragments[i].size();
+      }
+
+      slices_.emplace_back(Slice(remaining_size, account_));
+      Slice& new_slice = slices_.back();
+      Slice::Reservation new_reservation = new_slice.reserve(remaining_size);
+      ASSERT(new_reservation.len_ == remaining_size);
+      uint8_t* new_mem = static_cast<uint8_t*>(new_reservation.mem_);
+
+      for (size_t i = fragment_index; i < fragments.size(); i++) {
+        memcpy(new_mem, fragments[i].data(), fragments[i].size()); // NOLINT(safe-memcpy)
+        new_mem += fragments[i].size();
+      }
+
+      new_slice.commit<false>(new_reservation);
+      length_ += remaining_size;
     }
   }
 


### PR DESCRIPTION
## Description

This PR adds a small optimization in `addFragments()` inside buffer_impl to reduce the number of slices created.

### Benchmark Results

<img width="2379" height="1180" alt="image" src="https://github.com/user-attachments/assets/c4c87d28-e962-4a33-aa9e-8a6b973f1bbf" />

**After:**
```
Running ./bazel-bin/test/common/buffer/buffer_speed_test
Run on (16 X 24 MHz CPU s)
CPU Caches:
  L1 Data 64 KiB
  L1 Instruction 128 KiB
  L2 Unified 4096 KiB (x16)
Load Average: 23.38, 15.83, 9.70
------------------------------------------------------------------------------------
Benchmark                                          Time             CPU   Iterations
------------------------------------------------------------------------------------
bufferAddVsAddFragments/0/0/16/2_mean       11019296 ns     11002177 ns            5
bufferAddVsAddFragments/0/0/16/2_median     11009101 ns     10994367 ns            5
bufferAddVsAddFragments/0/0/16/2_stddev        47872 ns        37902 ns            5
bufferAddVsAddFragments/0/0/16/2_cv             0.43 %          0.34 %             5
bufferAddVsAddFragments/0/0/64/2_mean        3261241 ns      3246636 ns            5
bufferAddVsAddFragments/0/0/64/2_median      3288486 ns      3262355 ns            5
bufferAddVsAddFragments/0/0/64/2_stddev        55066 ns        46845 ns            5
bufferAddVsAddFragments/0/0/64/2_cv             1.69 %          1.44 %             5
bufferAddVsAddFragments/0/0/4096/2_mean      1600086 ns      1595752 ns            5
bufferAddVsAddFragments/0/0/4096/2_median    1605105 ns      1601577 ns            5
bufferAddVsAddFragments/0/0/4096/2_stddev      18556 ns        16668 ns            5
bufferAddVsAddFragments/0/0/4096/2_cv           1.16 %          1.04 %             5
bufferAddVsAddFragments/0/0/16/5_mean       10917187 ns     10908050 ns            5
bufferAddVsAddFragments/0/0/16/5_median     10903531 ns     10901203 ns            5
bufferAddVsAddFragments/0/0/16/5_stddev        65348 ns        56504 ns            5
bufferAddVsAddFragments/0/0/16/5_cv             0.60 %          0.52 %             5
bufferAddVsAddFragments/0/0/64/5_mean        3313627 ns      3310722 ns            5
bufferAddVsAddFragments/0/0/64/5_median      3307106 ns      3305311 ns            5
bufferAddVsAddFragments/0/0/64/5_stddev        11328 ns        10535 ns            5
bufferAddVsAddFragments/0/0/64/5_cv             0.34 %          0.32 %             5
bufferAddVsAddFragments/0/0/4096/5_mean      1803057 ns      1795099 ns            5
bufferAddVsAddFragments/0/0/4096/5_median    1771150 ns      1765577 ns            5
bufferAddVsAddFragments/0/0/4096/5_stddev      63795 ns        54193 ns            5
bufferAddVsAddFragments/0/0/4096/5_cv           3.54 %          3.02 %             5
bufferAddVsAddFragments/0/1/16/2_mean        8427515 ns      8420832 ns            5
bufferAddVsAddFragments/0/1/16/2_median      8413508 ns      8407568 ns            5
bufferAddVsAddFragments/0/1/16/2_stddev        38710 ns        38143 ns            5
bufferAddVsAddFragments/0/1/16/2_cv             0.46 %          0.45 %             5
bufferAddVsAddFragments/0/1/64/2_mean        2972117 ns      2963541 ns            5
bufferAddVsAddFragments/0/1/64/2_median      2936023 ns      2930315 ns            5
bufferAddVsAddFragments/0/1/64/2_stddev        58493 ns        53212 ns            5
bufferAddVsAddFragments/0/1/64/2_cv             1.97 %          1.80 %             5
bufferAddVsAddFragments/0/1/4096/2_mean       910437 ns       908409 ns            5
bufferAddVsAddFragments/0/1/4096/2_median     913222 ns       911833 ns            5
bufferAddVsAddFragments/0/1/4096/2_stddev      17623 ns        15974 ns            5
bufferAddVsAddFragments/0/1/4096/2_cv           1.94 %          1.76 %             5
bufferAddVsAddFragments/0/1/16/5_mean        7482451 ns      7459730 ns            5
bufferAddVsAddFragments/0/1/16/5_median      7487164 ns      7469021 ns            5
bufferAddVsAddFragments/0/1/16/5_stddev        27523 ns        23702 ns            5
bufferAddVsAddFragments/0/1/16/5_cv             0.37 %          0.32 %             5
bufferAddVsAddFragments/0/1/64/5_mean        2705108 ns      2695718 ns            5
bufferAddVsAddFragments/0/1/64/5_median      2687419 ns      2677152 ns            5
bufferAddVsAddFragments/0/1/64/5_stddev        40875 ns        38954 ns            5
bufferAddVsAddFragments/0/1/64/5_cv             1.51 %          1.45 %             5
bufferAddVsAddFragments/0/1/4096/5_mean       627826 ns       623591 ns            5
bufferAddVsAddFragments/0/1/4096/5_median     632127 ns       624746 ns            5
bufferAddVsAddFragments/0/1/4096/5_stddev      11683 ns         9658 ns            5
bufferAddVsAddFragments/0/1/4096/5_cv           1.86 %          1.55 %             5
bufferAddVsAddFragments/1/0/16/2_mean       15506266 ns     15480874 ns            5
bufferAddVsAddFragments/1/0/16/2_median     15535613 ns     15510587 ns            5
bufferAddVsAddFragments/1/0/16/2_stddev       142515 ns       125039 ns            5
bufferAddVsAddFragments/1/0/16/2_cv             0.92 %          0.81 %             5
bufferAddVsAddFragments/1/0/64/2_mean        4374003 ns      4370320 ns            5
bufferAddVsAddFragments/1/0/64/2_median      4359386 ns      4357318 ns            5
bufferAddVsAddFragments/1/0/64/2_stddev        41960 ns        39689 ns            5
bufferAddVsAddFragments/1/0/64/2_cv             0.96 %          0.91 %             5
bufferAddVsAddFragments/1/0/4096/2_mean      1652470 ns      1647654 ns            5
bufferAddVsAddFragments/1/0/4096/2_median    1643791 ns      1637595 ns            5
bufferAddVsAddFragments/1/0/4096/2_stddev      36225 ns        32932 ns            5
bufferAddVsAddFragments/1/0/4096/2_cv           2.19 %          2.00 %             5
bufferAddVsAddFragments/1/0/16/5_mean       15594164 ns     15575882 ns            5
bufferAddVsAddFragments/1/0/16/5_median     15612272 ns     15590250 ns            5
bufferAddVsAddFragments/1/0/16/5_stddev        81760 ns        75386 ns            5
bufferAddVsAddFragments/1/0/16/5_cv             0.52 %          0.48 %             5
bufferAddVsAddFragments/1/0/64/5_mean        4526654 ns      4522763 ns            5
bufferAddVsAddFragments/1/0/64/5_median      4511559 ns      4510465 ns            5
bufferAddVsAddFragments/1/0/64/5_stddev        43949 ns        39867 ns            5
bufferAddVsAddFragments/1/0/64/5_cv             0.97 %          0.88 %             5
bufferAddVsAddFragments/1/0/4096/5_mean      1766329 ns      1763737 ns            5
bufferAddVsAddFragments/1/0/4096/5_median    1753214 ns      1752685 ns            5
bufferAddVsAddFragments/1/0/4096/5_stddev      30366 ns        25846 ns            5
bufferAddVsAddFragments/1/0/4096/5_cv           1.72 %          1.47 %             5
bufferAddVsAddFragments/1/1/16/2_mean        9808612 ns      9801279 ns            5
bufferAddVsAddFragments/1/1/16/2_median      9804311 ns      9798507 ns            5
bufferAddVsAddFragments/1/1/16/2_stddev        69941 ns        65436 ns            5
bufferAddVsAddFragments/1/1/16/2_cv             0.71 %          0.67 %             5
bufferAddVsAddFragments/1/1/64/2_mean        3337663 ns      3331344 ns            5
bufferAddVsAddFragments/1/1/64/2_median      3338714 ns      3331354 ns            5
bufferAddVsAddFragments/1/1/64/2_stddev        26043 ns        23815 ns            5
bufferAddVsAddFragments/1/1/64/2_cv             0.78 %          0.71 %             5
bufferAddVsAddFragments/1/1/4096/2_mean       921155 ns       919093 ns            5
bufferAddVsAddFragments/1/1/4096/2_median     922277 ns       918940 ns            5
bufferAddVsAddFragments/1/1/4096/2_stddev       9738 ns         9475 ns            5
bufferAddVsAddFragments/1/1/4096/2_cv           1.06 %          1.03 %             5
bufferAddVsAddFragments/1/1/16/5_mean        8043275 ns      8026979 ns            5
bufferAddVsAddFragments/1/1/16/5_median      8043364 ns      8027267 ns            5
bufferAddVsAddFragments/1/1/16/5_stddev        83183 ns        74265 ns            5
bufferAddVsAddFragments/1/1/16/5_cv             1.03 %          0.93 %             5
bufferAddVsAddFragments/1/1/64/5_mean        2738706 ns      2731889 ns            5
bufferAddVsAddFragments/1/1/64/5_median      2732174 ns      2727260 ns            5
bufferAddVsAddFragments/1/1/64/5_stddev        23638 ns        18034 ns            5
bufferAddVsAddFragments/1/1/64/5_cv             0.86 %          0.66 %             5
bufferAddVsAddFragments/1/1/4096/5_mean       595594 ns       595273 ns            5
bufferAddVsAddFragments/1/1/4096/5_median     596185 ns       595633 ns            5
bufferAddVsAddFragments/1/1/4096/5_stddev       5550 ns         5420 ns            5
bufferAddVsAddFragments/1/1/4096/5_cv           0.93 %          0.91 %             5
```

**Before:**
```
Running ./bazel-bin/test/common/buffer/buffer_speed_test
Run on (16 X 24 MHz CPU s)
CPU Caches:
  L1 Data 64 KiB
  L1 Instruction 128 KiB
  L2 Unified 4096 KiB (x16)
Load Average: 11.38, 12.91, 9.46
------------------------------------------------------------------------------------
Benchmark                                          Time             CPU   Iterations
------------------------------------------------------------------------------------
bufferAddVsAddFragments/0/0/16/2_mean       11127130 ns     11101315 ns            5
bufferAddVsAddFragments/0/0/16/2_median     11131283 ns     11109770 ns            5
bufferAddVsAddFragments/0/0/16/2_stddev        65462 ns        54682 ns            5
bufferAddVsAddFragments/0/0/16/2_cv             0.59 %          0.49 %             5
bufferAddVsAddFragments/0/0/64/2_mean        3287293 ns      3272505 ns            5
bufferAddVsAddFragments/0/0/64/2_median      3256553 ns      3247684 ns            5
bufferAddVsAddFragments/0/0/64/2_stddev        70429 ns        57405 ns            5
bufferAddVsAddFragments/0/0/64/2_cv             2.14 %          1.75 %             5
bufferAddVsAddFragments/0/0/4096/2_mean      1627965 ns      1623648 ns            5
bufferAddVsAddFragments/0/0/4096/2_median    1638051 ns      1630937 ns            5
bufferAddVsAddFragments/0/0/4096/2_stddev      38770 ns        36231 ns            5
bufferAddVsAddFragments/0/0/4096/2_cv           2.38 %          2.23 %             5
bufferAddVsAddFragments/0/0/16/5_mean       11097126 ns     11072863 ns            5
bufferAddVsAddFragments/0/0/16/5_median     11095258 ns     11074333 ns            5
bufferAddVsAddFragments/0/0/16/5_stddev        57645 ns        50081 ns            5
bufferAddVsAddFragments/0/0/16/5_cv             0.52 %          0.45 %             5
bufferAddVsAddFragments/0/0/64/5_mean        3343970 ns      3341766 ns            5
bufferAddVsAddFragments/0/0/64/5_median      3335905 ns      3334548 ns            5
bufferAddVsAddFragments/0/0/64/5_stddev        27226 ns        25284 ns            5
bufferAddVsAddFragments/0/0/64/5_cv             0.81 %          0.76 %             5
bufferAddVsAddFragments/0/0/4096/5_mean      1790948 ns      1787283 ns            5
bufferAddVsAddFragments/0/0/4096/5_median    1786723 ns      1779762 ns            5
bufferAddVsAddFragments/0/0/4096/5_stddev      36375 ns        34736 ns            5
bufferAddVsAddFragments/0/0/4096/5_cv           2.03 %          1.94 %             5
bufferAddVsAddFragments/0/1/16/2_mean        8612305 ns      8594482 ns            5
bufferAddVsAddFragments/0/1/16/2_median      8598115 ns      8590349 ns            5
bufferAddVsAddFragments/0/1/16/2_stddev        36270 ns        38063 ns            5
bufferAddVsAddFragments/0/1/16/2_cv             0.42 %          0.44 %             5
bufferAddVsAddFragments/0/1/64/2_mean        2868239 ns      2863680 ns            5
bufferAddVsAddFragments/0/1/64/2_median      2868820 ns      2865203 ns            5
bufferAddVsAddFragments/0/1/64/2_stddev        32820 ns        30893 ns            5
bufferAddVsAddFragments/0/1/64/2_cv             1.14 %          1.08 %             5
bufferAddVsAddFragments/0/1/4096/2_mean      1656552 ns      1651722 ns            5
bufferAddVsAddFragments/0/1/4096/2_median    1654560 ns      1650837 ns            5
bufferAddVsAddFragments/0/1/4096/2_stddev      25840 ns        24291 ns            5
bufferAddVsAddFragments/0/1/4096/2_cv           1.56 %          1.47 %             5
bufferAddVsAddFragments/0/1/16/5_mean        7484572 ns      7477426 ns            5
bufferAddVsAddFragments/0/1/16/5_median      7527128 ns      7518894 ns            5
bufferAddVsAddFragments/0/1/16/5_stddev        72543 ns        67100 ns            5
bufferAddVsAddFragments/0/1/16/5_cv             0.97 %          0.90 %             5
bufferAddVsAddFragments/0/1/64/5_mean        2694810 ns      2690754 ns            5
bufferAddVsAddFragments/0/1/64/5_median      2688739 ns      2685996 ns            5
bufferAddVsAddFragments/0/1/64/5_stddev        14337 ns        11229 ns            5
bufferAddVsAddFragments/0/1/64/5_cv             0.53 %          0.42 %             5
bufferAddVsAddFragments/0/1/4096/5_mean      1608756 ns      1606494 ns            5
bufferAddVsAddFragments/0/1/4096/5_median    1614205 ns      1612394 ns            5
bufferAddVsAddFragments/0/1/4096/5_stddev      22333 ns        20580 ns            5
bufferAddVsAddFragments/0/1/4096/5_cv           1.39 %          1.28 %             5
bufferAddVsAddFragments/1/0/16/2_mean       15347064 ns     15331498 ns            5
bufferAddVsAddFragments/1/0/16/2_median     15323991 ns     15316289 ns            5
bufferAddVsAddFragments/1/0/16/2_stddev       101618 ns        85982 ns            5
bufferAddVsAddFragments/1/0/16/2_cv             0.66 %          0.56 %             5
bufferAddVsAddFragments/1/0/64/2_mean        4573246 ns      4556994 ns            5
bufferAddVsAddFragments/1/0/64/2_median      4557908 ns      4514580 ns            5
bufferAddVsAddFragments/1/0/64/2_stddev        85180 ns        84817 ns            5
bufferAddVsAddFragments/1/0/64/2_cv             1.86 %          1.86 %             5
bufferAddVsAddFragments/1/0/4096/2_mean      1626490 ns      1622953 ns            5
bufferAddVsAddFragments/1/0/4096/2_median    1627059 ns      1623258 ns            5
bufferAddVsAddFragments/1/0/4096/2_stddev       8213 ns         8013 ns            5
bufferAddVsAddFragments/1/0/4096/2_cv           0.50 %          0.49 %             5
bufferAddVsAddFragments/1/0/16/5_mean       15690328 ns     15661268 ns            5
bufferAddVsAddFragments/1/0/16/5_median     15671217 ns     15649114 ns            5
bufferAddVsAddFragments/1/0/16/5_stddev        59255 ns        55385 ns            5
bufferAddVsAddFragments/1/0/16/5_cv             0.38 %          0.35 %             5
bufferAddVsAddFragments/1/0/64/5_mean        4676293 ns      4657449 ns            5
bufferAddVsAddFragments/1/0/64/5_median      4698956 ns      4675139 ns            5
bufferAddVsAddFragments/1/0/64/5_stddev        42347 ns        38288 ns            5
bufferAddVsAddFragments/1/0/64/5_cv             0.91 %          0.82 %             5
bufferAddVsAddFragments/1/0/4096/5_mean      1849562 ns      1841060 ns            5
bufferAddVsAddFragments/1/0/4096/5_median    1851501 ns      1842041 ns            5
bufferAddVsAddFragments/1/0/4096/5_stddev      19989 ns        16801 ns            5
bufferAddVsAddFragments/1/0/4096/5_cv           1.08 %          0.91 %             5
bufferAddVsAddFragments/1/1/16/2_mean        9977729 ns      9961186 ns            5
bufferAddVsAddFragments/1/1/16/2_median      9936161 ns      9923058 ns            5
bufferAddVsAddFragments/1/1/16/2_stddev        88805 ns        86313 ns            5
bufferAddVsAddFragments/1/1/16/2_cv             0.89 %          0.87 %             5
bufferAddVsAddFragments/1/1/64/2_mean        3257898 ns      3251180 ns            5
bufferAddVsAddFragments/1/1/64/2_median      3276008 ns      3265743 ns            5
bufferAddVsAddFragments/1/1/64/2_stddev        32780 ns        29492 ns            5
bufferAddVsAddFragments/1/1/64/2_cv             1.01 %          0.91 %             5
bufferAddVsAddFragments/1/1/4096/2_mean      1632215 ns      1629586 ns            5
bufferAddVsAddFragments/1/1/4096/2_median    1631453 ns      1627499 ns            5
bufferAddVsAddFragments/1/1/4096/2_stddev      27035 ns        25490 ns            5
bufferAddVsAddFragments/1/1/4096/2_cv           1.66 %          1.56 %             5
bufferAddVsAddFragments/1/1/16/5_mean        8164164 ns      8131179 ns            5
bufferAddVsAddFragments/1/1/16/5_median      8168557 ns      8138460 ns            5
bufferAddVsAddFragments/1/1/16/5_stddev        49384 ns        49524 ns            5
bufferAddVsAddFragments/1/1/16/5_cv             0.60 %          0.61 %             5
bufferAddVsAddFragments/1/1/64/5_mean        2811092 ns      2806651 ns            5
bufferAddVsAddFragments/1/1/64/5_median      2816052 ns      2807663 ns            5
bufferAddVsAddFragments/1/1/64/5_stddev        11737 ns        10828 ns            5
bufferAddVsAddFragments/1/1/64/5_cv             0.42 %          0.39 %             5
bufferAddVsAddFragments/1/1/4096/5_mean      1618015 ns      1614461 ns            5
bufferAddVsAddFragments/1/1/4096/5_median    1612703 ns      1607796 ns            5
bufferAddVsAddFragments/1/1/4096/5_stddev      31698 ns        29610 ns            5
bufferAddVsAddFragments/1/1/4096/5_cv           1.96 %          1.83 %             5
```

---

**Commit Message:** buffer: optimize addFragments() in buffer_impl
**Additional Description:** Adds a small optimization in `addFragments()` inside buffer_impl to reduce the number of slices created.
**Risk Level:** Low
**Testing:** Added Tests
**Docs Changes:** N/A
**Release Notes:** N/A