### PR TITLE
Credential Injector Filter: EOF when retrieving token in oauth_client does not retry - Fixes: 42009

### DIFF
--- a/source/extensions/http/injected_credentials/oauth2/oauth.h
+++ b/source/extensions/http/injected_credentials/oauth2/oauth.h
@@ -18,12 +18,7 @@ namespace OAuth2 {
 class FilterCallbacks {
 public:
   virtual ~FilterCallbacks() = default;
-  enum class FailureReason {
-    StreamReset,
-    BadToken,
-    BadResponseCode,
-    BadTokenTransientFailure
-  };
+  enum class FailureReason { StreamReset, BadToken, BadResponseCode, BadTokenTransientFailure };
 
   virtual void onGetAccessTokenSuccess(const std::string& access_token,
                                        std::chrono::seconds expires_in) PURE;

--- a/source/extensions/http/injected_credentials/oauth2/oauth_client.cc
+++ b/source/extensions/http/injected_credentials/oauth2/oauth_client.cc
@@ -87,7 +87,7 @@ void OAuth2ClientImpl::onSuccess(const Envoy::Http::AsyncClient::Request&,
   END_TRY catch (EnvoyException& e) {
     ENVOY_LOG(error, "Error parsing response body, received exception: {}", e.what());
     ENVOY_LOG(error, "Response body: {}", response_body);
-    //if the response body is empty we consider this a potentially transient failure
+    // if the response body is empty we consider this a potentially transient failure
     if (response_body.empty()) {
       parent_->onGetAccessTokenFailure(FilterCallbacks::FailureReason::BadTokenTransientFailure);
       ENVOY_LOG(error, "Response body is empty, permitting retry to cope with transient failure");

--- a/source/extensions/http/injected_credentials/oauth2/token_provider.cc
+++ b/source/extensions/http/injected_credentials/oauth2/token_provider.cc
@@ -119,7 +119,7 @@ void TokenProvider::onGetAccessTokenFailure(FailureReason failure_reason) {
     retry = false;
     break;
   case FailureReason::BadTokenTransientFailure:
-    //we still record this as a bad token failure but we permit retry
+    // we still record this as a bad token failure but we permit retry
     stats_.token_fetch_failed_on_bad_token_.inc();
     retry = true;
     break;


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Credential Injector Filter: Allow retries if 200 OK is received with an empty body and provide tests 
Additional Description:
Risk Level: Low
Testing: New integration test added to test/extensions/http/credential_injector/oauth2/credential_injector_oauth_integration_test.cc to cover change in behaviour
Docs Changes: None
Release Notes: None
Platform Specific Features: None
Fixes: #42009

