### PR TITLE
Quiche roll 20251114195216

### DIFF
--- a/bazel/external/quiche.BUILD
+++ b/bazel/external/quiche.BUILD
@@ -58,9 +58,7 @@ test_suite(
         "http2_adapter_recording_http2_visitor_test",
         "http2_adapter_window_manager_test",
         "http2_platform_api_test",
-        # TODO(abeyad) currently failed due to test issue.
-        # Re-enable it with next QUICHE update.
-        # "quiche_balsa_balsa_frame_test",
+        "quiche_balsa_balsa_frame_test",
         "quiche_balsa_balsa_headers_test",
         "quiche_balsa_header_properties_test",
         "quiche_balsa_simple_buffer_test",


### PR DESCRIPTION
Update QUICHE from c5087ecf2 to b9bf668dd
 
https://github.com/google/quiche/compare/c5087ecf2..b9bf668dd
    
    ```
    $ git log c5087ecf2..b9bf668dd --date=short --no-merges --format="%ad %al %s"
    
    2025-11-19 martinduke Remove redundant VersionSupportsGoogleAltSvcFormat.
    2025-11-19 martinduke Clean up includes in quic_versions.h. Several classes were reliant on these includes so those have been updated as well.
    2025-11-18 martinduke Delete ParsedQuicVersion::SupportsGoogleAltSvcFormat(). This method is unused.
    2025-11-18 martinduke Replace HasLongHeaderLengths, UsesCryptoFrames, HasIetfQuicFrames, VersionHasLongHeaderLengths, QuicVersionUsesCryptoFrames() and VersionHasIetfQuicFrames() with IsIetfQuic().
    2025-11-18 vasilvv Add a class to track when objects are acknowledged out-of-order.
    2025-11-18 martinduke Deprecate ParsedQuicVersion::UsesTls(), ParsedQuicVersion::UsesHttp3(), and VersionUsesHttp3(). Remove function calls everywhere that does not need extensive approvals.
    2025-11-18 martinduke Replace SupportsClientConnectiondIds, HasLengthPrefixedConnectionIds, SupportsAntiAmplificationLimit, and CanSendCoalescedPackets with IsIetfQuic().
    2025-11-18 martinduke Replace ParsedQuicVersion::HasHeaderProtection, SupportsRetry, SendsVariableLengthPacketNumberLongHeader, and AllowsVariableLengthConnectionIds with IsIetfQuic.
    2025-11-18 dmcardle Weaken DCHECK in `operator*(QuicBandwidth, QuicTime::Delta)`
    2025-11-18 martinduke Replace redundant calls to ParsedQuicVersion::UsesInitialObfuscators() and AllowsLowFlowControlLimits with IsIetfQuic()
    2025-11-17 martinduke Rename ParsedQuicVersion::KnowsWhichDecrypterToUse to IsIetfQuic.
    2025-11-17 dschinazi Deprecate the legacy version information QUIC transport parameter
    2025-11-17 quiche-dev Add `control_plane_override` to AuthAndSignResponse.
    2025-11-17 ripere Refactoring Indeterminate-Length BHTTP message section and tests.
    2025-11-17 quiche-dev Deprecate --gfe2_reloadable_flag_quic_client_default_enable_new_alps_codepoint.
    2025-11-14 quiche-dev Fix Quiche test failing during Envoy Quiche roll
    2025-11-14 martinduke Add QUIC_CODE_COUNT for quic_disconnect_early_exit.
    2025-11-14 quiche-dev Add code count when new validation policy is on and invalid methods are detected.
    2025-11-13 quiche-dev Add an HttpValidationPolicy field for handling invalid methods
    2025-11-13 dmcardle Add kDSNI connection option to permit sending debugging_sni despite ECH GREASE
    2025-11-13 vasilvv Manually enable BBRv1 for MOQ.
    2025-11-12 dmcardle No public description
    2025-11-12 martinduke Deprecate gfe2_reloadable_flag_quic_fail_on_empty_ack
    2025-11-11 vasilvv No public description
    2025-11-11 dmcardle Add regression test for iteration bug in MoqtOutgoingQueue::RemoveAllSubscriptions()
    2025-11-11 quiche-dev Prefactor response vs request ahead of METHOD validation
    2025-11-11 vasilvv Disable a flaky MOQT test assertion.
    2025-11-10 rch Use SSL_set_shed_handshake_config in QUIC to drop BoringSSL handshake state after the handshake finishes in order to save memory.
    2025-11-10 ianswett Remove some references to gQUIC Padded Ping. Padded Ping is still sent by gQUIC clients as a connectivity check, but we're not shipping any new gQUIC clients, so SerializeGQuicConnectivityProbingPacket could be removed completely removed if you prefer.
    2025-11-10 dmcardle Deflake MoqtIntegrationTest.CleanPublishDone
    2025-11-10 martinduke Replace remaining references SUBSCRIBE_DONE with PUBLISH_DONE.
    2025-11-10 quiche-dev Fix public bazel build of quiche
    2025-11-10 quiche-dev No public description
    2025-11-10 ianswett Refactor ACK sending so it always goes through SendAllPendingAcks.  This is mostly for code readability, but it also makes it clearer what code paths are gQUIC only.
    2025-11-07 dmcardle Add `--force_debugging_sni` flag to toy client
    2025-11-06 dmcardle Clamp bandwidth and rtt to avoid UB signed overflow in `QuicBandwidth::ToBytesPerPeriod()`
    2025-11-06 dmcardle Cascading IWYU fixes starting with quic_bandwidth.h
    2025-11-05 abhisinghx Update Masque Connection pool and Masque OHTTP client to allow a custom DNS resolver
    2025-11-03 quiche-dev Add proxy logging and code counts for methods that are invalid tokens
    2025-11-03 martinduke Call `OnSubscribeAccepted` when adding a listener to `MoqtRelayTrackPublisher`.
    ```


Additional Description: quiche_balsa_balsa_frame_test was excluded from Coverage CI.

Risk Level: low, no behavior change introduced
Testing: existing tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
