### PR TITLE
remove redundant cast

### DIFF
--- a/source/extensions/filters/http/rate_limit_quota/filter.cc
+++ b/source/extensions/filters/http/rate_limit_quota/filter.cc
@@ -98,9 +98,9 @@ addDenyResponseHeadersCb(const DenyResponseSettings& settings) {
 Http::FilterHeadersStatus sendDenyResponse(Http::StreamDecoderFilterCallbacks* cb,
                                            const DenyResponseSettings& settings,
                                            StreamInfo::CoreResponseFlag flag) {
-  cb->sendLocalReply(
-      getDenyResponseCode(settings), MessageUtil::bytesToString(getResponseBodyText(settings)),
-      addDenyResponseHeadersCb(settings), getGrpcStatus(settings), "rate_limited_by_quota");
+  cb->sendLocalReply(getDenyResponseCode(settings), getResponseBodyText(settings),
+                     addDenyResponseHeadersCb(settings), getGrpcStatus(settings),
+                     "rate_limited_by_quota");
   cb->streamInfo().setResponseFlag(flag);
   return Envoy::Http::FilterHeadersStatus::StopIteration;
 }


### PR DESCRIPTION
Commit Message: remove redundant cast
Additional Description:

getResponseBodyText already returns a string. there's no need to cast it to a Cord to then cast it back to a string.

Risk Level: none