### PR TITLE
docs: remove deprecated flags #patch

### DIFF
--- a/docs/root/intro/arch_overview/security/ssl.rst
+++ b/docs/root/intro/arch_overview/security/ssl.rst
@@ -191,15 +191,6 @@ Envoy will not use a must-staple certificate for new connections after its OCSP 
 OCSP responses are never stapled to TLS requests that do not indicate support for OCSP stapling
 via the ``status_request`` extension.
 
-The following runtime flags are provided to adjust the requirements of OCSP responses and override
-the OCSP policy. These flags default to ``true``.
-
-* ``envoy.reloadable_features.require_ocsp_response_for_must_staple_certs``: Disabling this allows
-  the operator to omit an OCSP response for must-staple certs in the config.
-* ``envoy.reloadable_features.check_ocsp_policy``: Disabling this will disable OCSP policy
-  checking. OCSP responses are stapled when available if the client supports it, even if the
-  response is expired. Stapling is skipped if no response is present.
-
 OCSP responses are ignored for :ref:`UpstreamTlsContexts
 <envoy_v3_api_msg_extensions.transport_sockets.tls.v3.UpstreamTlsContext>`.
 


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: The runtime flags `envoy.reloadable_features.check_ocsp_policy` and `envoy.reloadable_features.require_ocsp_response_for_must_staple_certs` were deprecated in [v1.20.0 release ](https://github.com/envoyproxy/envoy/blob/91bc16d9b5077685b363a133019a40aef882fb39/changelogs/1.20.0.yaml#L234)but were never removed from the docs.
Additional Description: https://github.com/envoyproxy/envoy/issues/16006
Risk Level: low
Testing:
Docs Changes: Remove deprecated flags
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
