### PR TITLE
fix mcp filter fuzz case

### DIFF
--- a/test/extensions/filters/http/common/fuzz/filter_corpus/testcase-6574538059218944
+++ b/test/extensions/filters/http/common/fuzz/filter_corpus/testcase-6574538059218944
@@ -1,0 +1,21 @@
+config {
+  name: "envoy.filters.http.mcp"
+  typed_config {
+    type_url: "type.googleapis.com/envoy.extensions.filters.http.mcp.v3.Mcp"
+  }
+}
+data {
+  headers {
+    headers {
+      key: "content-type"
+      value: "application/json"
+    }
+    headers {
+      key: ":method"
+      value: "POST"
+    }
+  }
+  http_body {
+    data: "{\"theme\": \"Children\"}"
+  }
+}

--- a/test/extensions/filters/http/common/fuzz/uber_filter.cc
+++ b/test/extensions/filters/http/common/fuzz/uber_filter.cc
@@ -142,7 +142,7 @@ void UberFilterFuzzer::reset() {
 
   access_logger_.reset();
   custom_stat_namespaces_ = Stats::CustomStatNamespacesImpl();
-  decoding_buffer_ = nullptr;
+  decoding_buffer_.reset();
   HttpFilterFuzzer::reset();
 }
 

--- a/test/extensions/filters/http/common/fuzz/uber_filter.h
+++ b/test/extensions/filters/http/common/fuzz/uber_filter.h
@@ -66,7 +66,7 @@ private:
   Event::DispatcherPtr worker_thread_dispatcher_;
   std::function<void()> destroy_filters_ = []() {};
 
-  const Buffer::Instance* decoding_buffer_{};
+  Buffer::InstancePtr decoding_buffer_{};
 };
 
 } // namespace HttpFilters


### PR DESCRIPTION
Commit Message: fix mcp filter fuzz case
Additional Description:

This PR fixes a fuzz case that causes the mcp filter to call addDecodedData followed by decodingBuffer. In the real decoder callbacks a new buffer is created even if the data is empty. This is not simulated in the expectations. This pr fixes the expectations to be more faithful to the actual implementation.

Risk Level: none
Testing: fuzz fix