### PR TITLE
bazel/build: fix local bazel rbe build docker pull failure

### DIFF
--- a/bazel/repo.bzl
+++ b/bazel/repo.bzl
@@ -14,8 +14,8 @@ def image_mobile():
         REPO, PREFIX_MOBILE, TAG, SHA_MOBILE)
 
 def image_worker():
-    return "%s:%s@sha256:%s" % (
-        REPO_GCR, TAG, SHA)
+    return "%s@sha256:%s" % (
+        REPO_GCR, SHA)
 
 """
 


### PR DESCRIPTION
Fix the local build

```
failed to pull docker image "gcr.io/envoy-ci/envoy-build:4ce0cb04f941fb89d475597a640176ae64070bb1@sha256:de54e91a8d27623ffbd3fb9bd1aba8241567e41c0fb82b167128e3629c2ede18" using the service account "service-612482638943@remotebuildexecution.iam.gserviceaccount.com": rpc error: code = Internal desc = docker pull succeeds but the image is not found locally: See https://developers.google.com/remote-build-execution/docs/docker-image-pull-errors for information on how to resolve this issue
```

Commit Message:
Additional Description:
Risk Level: low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
