### PR TITLE
mobile/bazel: Remove very old foreign_cc pin

### DIFF
--- a/mobile/WORKSPACE
+++ b/mobile/WORKSPACE
@@ -12,18 +12,6 @@ http_archive(
     ],
 )
 
-# TODO(yannic): Remove once https://github.com/bazelbuild/rules_foreign_cc/pull/938
-# is merged and released.
-http_archive(
-    name = "rules_foreign_cc",
-    sha256 = "bbc605fd36048923939845d6843464197df6e6ffd188db704423952825e4760a",
-    strip_prefix = "rules_foreign_cc-a473d42bada74afac4e32b767964c1785232e07b",
-    urls = [
-        "https://storage.googleapis.com/engflow-tools-public/rules_foreign_cc-a473d42bada74afac4e32b767964c1785232e07b.tar.gz",
-        "https://github.com/EngFlow/rules_foreign_cc/archive/a473d42bada74afac4e32b767964c1785232e07b.tar.gz",
-    ],
-)
-
 load("@envoy_mobile//bazel:envoy_mobile_repositories.bzl", "envoy_mobile_repositories")
 
 envoy_mobile_repositories()


### PR DESCRIPTION
Not clear if this is needed - the related PR (https://github.com/bazelbuild/rules_foreign_cc/pull/938) never landed, but it seems the pinned version is not compatible with hermetic toolchains
