### PR TITLE
docs: enhance the docs around the retry_policy for gRPC

### DIFF
--- a/api/envoy/config/core/v3/grpc_service.proto
+++ b/api/envoy/config/core/v3/grpc_service.proto
@@ -45,10 +45,20 @@ message GrpcService {
         [(validate.rules).string =
              {min_len: 0 max_bytes: 16384 well_known_regex: HTTP_HEADER_VALUE strict: false}];
 
-    // Indicates the retry policy for re-establishing the gRPC stream
-    // This field is optional. If max interval is not provided, it will be set to ten times the provided base interval.
-    // Currently only supported for xDS gRPC streams.
-    // If not set, xDS gRPC streams default base interval:500ms, maximum interval:30s will be applied.
+    // Specifies the retry backoff policy for re-establishing long‑lived xDS gRPC streams.
+    //
+    // This field is optional. If ``retry_back_off.max_interval`` is not provided, it will be set to
+    // ten times the configured ``retry_back_off.base_interval``.
+    //
+    // .. note::
+    //
+    //   This field is only honored for management‑plane xDS gRPC streams created from
+    //   :ref:`ApiConfigSource <envoy_v3_api_msg_config.core.v3.ApiConfigSource>` that use
+    //   ``envoy_grpc``. Data‑plane gRPC clients (for example external authorization or external
+    //   processing filters) must use :ref:`GrpcService.retry_policy
+    //   <envoy_v3_api_field_config.core.v3.GrpcService.retry_policy>` instead.
+    //
+    // If not set, xDS gRPC streams default to a base interval of 500ms and a maximum interval of 30s.
     RetryPolicy retry_policy = 3;
 
     // Maximum gRPC message size that is allowed to be received.
@@ -329,7 +339,17 @@ message GrpcService {
   // <config_http_conn_man_headers_custom_request_headers>`.
   repeated HeaderValue initial_metadata = 5;
 
-  // Optional default retry policy for streams toward the service.
-  // If an async stream doesn't have retry policy configured in its stream options, this retry policy is used.
+  // Optional default retry policy for RPCs or streams initiated toward this gRPC service.
+  //
+  // If an async stream does not have a retry policy configured in its per‑stream options, this
+  // policy is used as the default.
+  //
+  // .. note::
+  //
+  //   This field is only applied by Envoy gRPC (``envoy_grpc``) clients. Google gRPC
+  //   (``google_grpc``) clients currently ignore this field.
+  //
+  // If not specified, no default retry policy is applied at the client level and retries only occur
+  // when explicitly configured in per‑stream options.
   RetryPolicy retry_policy = 6;
 }


### PR DESCRIPTION
## Description

Currently, the doc for [retry_policy](https://arc.net/l/quote/rjzyalhz) for gRPC is a bit confusing. We have multiple level of retries from `envoy_grpc`, `google_grpc` and an outer `retry_policy`. This is an attempt to add some more clarification on the Retry Policy and which one is applicable for ExtAuthZ.

---

**Commit Message:** docs: enhance the docs around the retry_policy for gRPC
**Additional Description:**
**Risk Level:** N/A
**Testing:** CI
**Docs Changes:** N/A
**Release Notes:** N/A