### PR TITLE
llvm/local: Fix foreign_cc failure/s

### DIFF
--- a/.github/workflows/codeql-daily.yml
+++ b/.github/workflows/codeql-daily.yml
@@ -58,7 +58,7 @@ jobs:
 
     - name: Build
       run: |
-       bazel/setup_clang.sh bin/clang18.1.8
+       bazel/setup_clang.sh "$(realpath bin/clang18.1.8)"
        bazelisk shutdown
        bazel build \
            -c fastbuild \

--- a/.github/workflows/codeql-push.yml
+++ b/.github/workflows/codeql-push.yml
@@ -92,7 +92,7 @@ jobs:
     - name: Build
       if: ${{ env.BUILD_TARGETS != '' }}
       run: |
-       bazel/setup_clang.sh bin/clang18.1.8
+       bazel/setup_clang.sh "$(realpath bin/clang18.1.8)"
        bazel shutdown
        bazel build \
            -c fastbuild \

--- a/bazel/setup_clang.sh
+++ b/bazel/setup_clang.sh
@@ -22,6 +22,7 @@ RT_LIBRARY_PATH="${LLVM_LIBDIR}/clang/${LLVM_VERSION}/lib/${LLVM_TARGET}"
 cat <<EOF > "${BAZELRC_FILE}"
 # Generated file, do not edit. If you want to disable clang, just delete this file.
 build:clang --host_action_env=PATH=${PATH} --action_env=PATH=${PATH}
+build:clang --define="LLVM_DIRECTORY=${LLVM_PREFIX}"
 
 build:clang --action_env=LLVM_CONFIG=${LLVM_CONFIG} --host_action_env=LLVM_CONFIG=${LLVM_CONFIG}
 build:clang --repo_env=LLVM_CONFIG=${LLVM_CONFIG}


### PR DESCRIPTION
Fix #42106 

this is manifesting in codeql but will hit anyone building from an llvm installed in a non-standard path (that didnt explicitly set `--define=LLVM_DIRECTORY=/path/to/llvm`)