### PR TITLE
docker/release: Fix manifests by bumping buildah (via ubuntu)

### DIFF
--- a/.github/workflows/_publish_release_container.yml
+++ b/.github/workflows/_publish_release_container.yml
@@ -48,7 +48,7 @@ concurrency:
 jobs:
   push-manifests:
     name: Create manifests (${{ inputs.trustred && 'dry run' || 'push' }})
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       packages: read


### PR DESCRIPTION
Our docker manifest publishing was not quite to spec, causing rules_oci to bork.

More recent ubuntu has more recent buildah which fixes

Fix: #41864
