### PR TITLE
[ProtoApiScrubber] Add Integration Tests

### DIFF
--- a/test/extensions/filters/http/proto_api_scrubber/BUILD
+++ b/test/extensions/filters/http/proto_api_scrubber/BUILD
@@ -75,6 +75,7 @@ envoy_cc_test(
         "//test/integration:http_protocol_integration_lib",
         "//test/proto:apikeys_proto_cc_proto",
         "@com_google_absl//absl/strings:str_format",
+        "@com_google_cel_cpp//parser",
         "@envoy_api//envoy/extensions/filters/http/proto_api_scrubber/v3:pkg_cc_proto",
     ],
 )


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Add Integration tests.
Additional Description: Currently, the tests are added using envoy_cc_extension as envoy_extension_cc_test fails to recognize the extension as it's not registered. Once the filter's core functionality is complete, we'll do the registration and update the build rule. Currently, only request integration tests are added as response flow is not ready. Response ITs will be added once response flow code is checked-in.
Risk Level: None.
Testing: ITs added.
Docs Changes: None.
Release Notes: None.
Platform Specific Features: None.
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
