### PR TITLE
[backport/1.36]tls_inspector: add early tls errors from tls inspector to downstream streaminfo

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -30,5 +30,9 @@ new_features:
     This can avoid unnecessary load shedding or overload actions.
     To enable, set ``envoy.reloadable_features.fixed_heap_use_allocated`` to true.
     The default algorithm (heap_size - pageheap_unmapped - pageheap_free) does not discount for free memory in TCMalloc caches.
+- area: tls_inspector
+  change: |
+    Propagate the transport error from the tls_inspector to the DownstreamTransportFailureReason in StreamInfo
+    for access logging prior to the TLS handshake.
 
 deprecated:

--- a/envoy/network/filter.h
+++ b/envoy/network/filter.h
@@ -399,6 +399,11 @@ public:
    * @param use_original_dst whether to use original destination address or not.
    */
   virtual void useOriginalDst(bool use_original_dst) PURE;
+
+  /**
+   * Return the connection level stream info interface.
+   */
+  virtual StreamInfo::StreamInfo& streamInfo() PURE;
 };
 
 /**

--- a/source/common/listener_manager/active_stream_listener_base.h
+++ b/source/common/listener_manager/active_stream_listener_base.h
@@ -101,12 +101,12 @@ public:
     } else {
       if (!active_socket->connected()) {
         // If active_socket is about to be destructed, emit logs if a connection is not created.
-        if (active_socket->streamInfo() != nullptr) {
-          emitLogs(*config_, *active_socket->streamInfo());
+        if (active_socket->streamInfoPtr() != nullptr) {
+          emitLogs(*config_, active_socket->streamInfo());
         } else {
           // If the active_socket is not connected, this socket is not promoted to active
           // connection. Thus the stream_info_ is owned by this active socket.
-          ENVOY_BUG(active_socket->streamInfo() != nullptr,
+          ENVOY_BUG(active_socket->streamInfoPtr() != nullptr,
                     "the unconnected active socket must have stream info.");
         }
       }

--- a/source/common/listener_manager/active_tcp_socket.h
+++ b/source/common/listener_manager/active_tcp_socket.h
@@ -84,7 +84,11 @@ public:
     return stream_info_->dynamicMetadata();
   };
   StreamInfo::FilterState& filterState() override { return *stream_info_->filterState().get(); }
-  StreamInfo::StreamInfo* streamInfo() const { return stream_info_.get(); }
+  StreamInfo::StreamInfo& streamInfo() override {
+    ASSERT(stream_info_ != nullptr);
+    return *stream_info_;
+  }
+  StreamInfo::StreamInfo* streamInfoPtr() const { return stream_info_.get(); }
   bool connected() const { return connected_; }
   bool isEndFilterIteration() const { return iter_ == accept_filters_.end(); }
 

--- a/source/common/quic/envoy_quic_server_connection.h
+++ b/source/common/quic/envoy_quic_server_connection.h
@@ -80,6 +80,7 @@ public:
     return stream_info_.dynamicMetadata();
   };
   StreamInfo::FilterState& filterState() override { return *stream_info_.filterState().get(); }
+  StreamInfo::StreamInfo& streamInfo() override { return stream_info_; }
 
   // Network::QuicListenerFilterManager
   void addFilter(const Network::ListenerFilterMatcherSharedPtr& listener_filter_matcher,

--- a/source/extensions/filters/listener/tls_inspector/tls_inspector.h
+++ b/source/extensions/filters/listener/tls_inspector/tls_inspector.h
@@ -113,6 +113,7 @@ private:
   uint32_t maxConfigReadBytes() const { return config_->maxClientHelloSize(); }
   ParseState getParserState(int handshake_status);
   void setDynamicMetadata(absl::string_view failure_reason);
+  void setDownstreamTransportFailureReason();
 
   ConfigSharedPtr config_;
   Network::ListenerFilterCallbacks* cb_{};

--- a/test/extensions/filters/listener/tls_inspector/tls_inspector_test.cc
+++ b/test/extensions/filters/listener/tls_inspector/tls_inspector_test.cc
@@ -463,6 +463,9 @@ TEST_P(TlsInspectorTest, NotSsl) {
       store_.histogramValues("tls_inspector.bytes_processed", false);
   ASSERT_EQ(1, bytes_processed.size());
   EXPECT_EQ(5, bytes_processed[0]);
+  EXPECT_EQ(
+      "TLS_error|error:100000f7:SSL routines:OPENSSL_internal:WRONG_VERSION_NUMBER:TLS_error_end",
+      cb_.streamInfo().downstreamTransportFailureReason());
 }
 
 // Verify that a plain text connection with a single I/O read of more than

--- a/test/mocks/network/mocks.cc
+++ b/test/mocks/network/mocks.cc
@@ -124,6 +124,7 @@ MockListenerFilterCallbacks::MockListenerFilterCallbacks()
     : filter_state_(StreamInfo::FilterStateImpl(StreamInfo::FilterState::LifeSpan::FilterChain)) {
   ON_CALL(*this, filterState()).WillByDefault(ReturnRef(filter_state_));
   ON_CALL(*this, socket()).WillByDefault(ReturnRef(socket_));
+  ON_CALL(*this, streamInfo()).WillByDefault(ReturnRef(stream_info_));
 }
 MockListenerFilterCallbacks::~MockListenerFilterCallbacks() = default;
 

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -448,10 +448,12 @@ public:
   MOCK_METHOD(envoy::config::core::v3::Metadata&, dynamicMetadata, ());
   MOCK_METHOD(const envoy::config::core::v3::Metadata&, dynamicMetadata, (), (const));
   MOCK_METHOD(StreamInfo::FilterState&, filterState, (), ());
+  MOCK_METHOD(StreamInfo::StreamInfo&, streamInfo, (), ());
   MOCK_METHOD(void, useOriginalDst, (bool));
 
   StreamInfo::FilterStateImpl filter_state_;
   NiceMock<MockConnectionSocket> socket_;
+  NiceMock<StreamInfo::MockStreamInfo> stream_info_;
 };
 
 class MockListenSocketFactory : public ListenSocketFactory {

--- a/test/server/active_tcp_listener_test.cc
+++ b/test/server/active_tcp_listener_test.cc
@@ -642,7 +642,7 @@ TEST_F(ActiveTcpListenerTest, PopulateSNIWhenActiveTcpSocketTimeout) {
   // trigger the onTimeout event manually, since the timer is fake.
   generic_active_listener_->sockets().front()->onTimeout();
   EXPECT_EQ(server_name,
-            tcp_socket->streamInfo()->downstreamAddressProvider().requestedServerName());
+            tcp_socket->streamInfoPtr()->downstreamAddressProvider().requestedServerName());
 }
 
 // Verify that the server connection with recovered address is rebalanced at redirected listener.


### PR DESCRIPTION
Propagate the transport error from the `tls_inspector` to the `downstreamTransportFailureReason` in StreamInfo for access logging prior to the real TLS handshake. Make sure the
`DOWNSTREAM_TRANSPORT_FAILURE_REASON` can capture the error from tls_inspector, during the early return when there is no matching network filter chain found and no real TLS handshake.

Previous approved PR: https://github.com/envoyproxy/envoy/pull/42034

https://github.com/istio/istio/issues/58281#issue-3617381770

cc @frittentheke

Commit Message:
Additional Description:
Risk Level: low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
