### PR TITLE
ext_authz: enahnce the ext_authz integration for gRPC request retries

### DIFF
--- a/test/extensions/filters/http/ext_authz/ext_authz_integration_test.cc
+++ b/test/extensions/filters/http/ext_authz/ext_authz_integration_test.cc
@@ -1321,6 +1321,10 @@ TEST_P(ExtAuthzGrpcIntegrationTest, Retry) {
                        Headers{});
   waitForSuccessfulUpstreamResponse("200");
 
+  // Verify retry stats are incremented correctly.
+  test_server_->waitForCounterGe("cluster.ext_authz_cluster.upstream_rq_retry", 1);
+  test_server_->waitForCounterGe("cluster.ext_authz_cluster.upstream_rq_total", 2);
+
   cleanup();
 }
 


### PR DESCRIPTION
## Description

A very small change in the ExtAuthZ integration test to also verify that the cluster-level stats are incremented when retry happens from the ExtAuthZ filter. It took me a while to figure out whether cluster emit stats in this scenario or not.

---

**Commit Message:** ext_authz: enahnce the ext_authz integration for gRPC request retries
**Additional Description:** -
**Risk Level:** N/A
**Testing:** CI
**Docs Changes:** N/A
**Release Notes:** N/A