### PR TITLE
[bp/1.35] dynamic module: make the loading flag configurable (#42058)

### DIFF
--- a/api/envoy/extensions/dynamic_modules/v3/dynamic_modules.proto
+++ b/api/envoy/extensions/dynamic_modules/v3/dynamic_modules.proto
@@ -41,4 +41,16 @@ message DynamicModuleConfig {
   // A module is closed when no more references to it exist in the process. For example,
   // no HTTP filters are using the module (e.g. after configuration update).
   bool do_not_close = 3;
+
+  // The dynamic module is loaded with ``RTLD_LOCAL`` flag to avoid symbol conflicts when multiple
+  // modules are loaded by default. Set this to true to load the module with ``RTLD_GLOBAL`` flag.
+  // This is useful for modules that need to share symbols with other dynamic libraries. For
+  // example, a module X may load another shared library Y that depends on some symbols defined
+  // in module X. In this case, module X must be loaded with ``RTLD_GLOBAL`` flag so that the
+  // symbols defined in module X are visible to library Y.
+  //
+  // .. warning::
+  //   Use this option with caution as it may lead to symbol conflicts and undefined behavior
+  //   if multiple modules define the same symbols and are loaded globally.
+  bool load_globally = 4;
 }

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -18,5 +18,9 @@ removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`
 
 new_features:
+- area: dynamic modules
+  change: |
+    Added support for loading dynamic modules globally by setting :ref:`load_globally
+    <envoy_v3_api_field_extensions.dynamic_modules.v3.DynamicModuleConfig.load_globally>` to true.
 
 deprecated:

--- a/source/extensions/dynamic_modules/dynamic_modules.h
+++ b/source/extensions/dynamic_modules/dynamic_modules.h
@@ -63,9 +63,13 @@ using DynamicModulePtr = std::unique_ptr<DynamicModule>;
  * will not be destroyed. This is useful when an object has some global state that should not be
  * terminated. For example, c-shared objects compiled by Go doesn't support dlclose
  * https://github.com/golang/go/issues/11100.
+ * @param load_globally if true, the dlopen will be called with RTLD_GLOBAL, so the loaded object
+ * can share symbols with other dynamically loaded modules. This is useful for modules that need to
+ * share symbols with other modules.
  */
 absl::StatusOr<DynamicModulePtr>
-newDynamicModule(const std::filesystem::path& object_file_absolute_path, const bool do_not_close);
+newDynamicModule(const std::filesystem::path& object_file_absolute_path, const bool do_not_close,
+                 const bool load_globally = false);
 
 /**
  * Creates a new DynamicModule by name under the search path specified by the environment variable
@@ -75,9 +79,13 @@ newDynamicModule(const std::filesystem::path& object_file_absolute_path, const b
  * @param do_not_close if true, the dlopen will be called with RTLD_NODELETE, so the loaded object
  * will not be destroyed. This is useful when an object has some global state that should not be
  * terminated.
+ * @param load_globally if true, the dlopen will be called with RTLD_GLOBAL, so the loaded object
+ * can share symbols with other dynamically loaded modules. This is useful for modules that need to
+ * share symbols with other modules.
  */
 absl::StatusOr<DynamicModulePtr> newDynamicModuleByName(const absl::string_view module_name,
-                                                        const bool do_not_close);
+                                                        const bool do_not_close,
+                                                        const bool load_globally = false);
 
 } // namespace DynamicModules
 } // namespace Extensions

--- a/source/extensions/filters/http/dynamic_modules/factory.cc
+++ b/source/extensions/filters/http/dynamic_modules/factory.cc
@@ -13,7 +13,7 @@ absl::StatusOr<Http::FilterFactoryCb> DynamicModuleConfigFactory::createFilterFa
 
   const auto& module_config = proto_config.dynamic_module_config();
   auto dynamic_module = Extensions::DynamicModules::newDynamicModuleByName(
-      module_config.name(), module_config.do_not_close());
+      module_config.name(), module_config.do_not_close(), module_config.load_globally());
   if (!dynamic_module.ok()) {
     return absl::InvalidArgumentError("Failed to load dynamic module: " +
                                       std::string(dynamic_module.status().message()));
@@ -51,7 +51,7 @@ DynamicModuleConfigFactory::createRouteSpecificFilterConfigTyped(
 
   const auto& module_config = proto_config.dynamic_module_config();
   auto dynamic_module = Extensions::DynamicModules::newDynamicModuleByName(
-      module_config.name(), module_config.do_not_close());
+      module_config.name(), module_config.do_not_close(), module_config.load_globally());
   if (!dynamic_module.ok()) {
     return absl::InvalidArgumentError("Failed to load dynamic module: " +
                                       std::string(dynamic_module.status().message()));

--- a/test/extensions/dynamic_modules/BUILD
+++ b/test/extensions/dynamic_modules/BUILD
@@ -23,6 +23,8 @@ envoy_cc_test(
         "//test/extensions/dynamic_modules/test_data/c:abi_version_mismatch",
         "//test/extensions/dynamic_modules/test_data/c:no_op",
         "//test/extensions/dynamic_modules/test_data/c:no_program_init",
+        "//test/extensions/dynamic_modules/test_data/c:program_child",
+        "//test/extensions/dynamic_modules/test_data/c:program_global",
         "//test/extensions/dynamic_modules/test_data/c:program_init_assert",
         "//test/extensions/dynamic_modules/test_data/c:program_init_fail",
         "//test/extensions/dynamic_modules/test_data/rust:abi_version_mismatch",

--- a/test/extensions/dynamic_modules/http/factory_test.cc
+++ b/test/extensions/dynamic_modules/http/factory_test.cc
@@ -27,6 +27,7 @@ TEST(DynamicModuleConfigFactory, LoadOK) {
 dynamic_module_config:
     name: no_op
     do_not_close: true
+    load_globally: false
 filter_name: foo
 filter_config:
     "@type": "type.googleapis.com/google.protobuf.StringValue"
@@ -59,6 +60,7 @@ TEST(DynamicModuleConfigFactory, LoadEmpty) {
 dynamic_module_config:
     name: no_op
     do_not_close: true
+    load_globally: true
 filter_name: foo
 )EOF";
 
@@ -88,6 +90,7 @@ TEST(DynamicModuleConfigFactory, LoadBytes) {
 dynamic_module_config:
     name: no_op
     do_not_close: true
+    load_globally: true
 filter_name: foo
 filter_config:
     "@type": "type.googleapis.com/google.protobuf.BytesValue"

--- a/test/extensions/dynamic_modules/test_data/c/BUILD
+++ b/test/extensions/dynamic_modules/test_data/c/BUILD
@@ -44,3 +44,7 @@ test_program(name = "no_http_filter_response_headers")
 test_program(name = "no_http_filter_response_body")
 
 test_program(name = "no_http_filter_response_trailers")
+
+test_program(name = "program_global")
+
+test_program(name = "program_child")

--- a/test/extensions/dynamic_modules/test_data/c/program_child.c
+++ b/test/extensions/dynamic_modules/test_data/c/program_child.c
@@ -1,0 +1,13 @@
+#include <assert.h>
+
+#include "source/extensions/dynamic_modules/abi.h"
+#include "source/extensions/dynamic_modules/abi_version.h"
+
+// Other functions that will be accessed by other tests.
+int dynamicModulesTestLoadGlobally();
+
+envoy_dynamic_module_type_abi_version_envoy_ptr envoy_dynamic_module_on_program_init(void) {
+  return kAbiVersion;
+}
+
+int getSomeVariable(void) { return dynamicModulesTestLoadGlobally(); }

--- a/test/extensions/dynamic_modules/test_data/c/program_global.c
+++ b/test/extensions/dynamic_modules/test_data/c/program_global.c
@@ -1,0 +1,13 @@
+#include <assert.h>
+
+#include "source/extensions/dynamic_modules/abi.h"
+#include "source/extensions/dynamic_modules/abi_version.h"
+
+envoy_dynamic_module_type_abi_version_envoy_ptr envoy_dynamic_module_on_program_init(void) {
+  return kAbiVersion;
+}
+
+// Other functions that will be accessed by other tests.
+int dynamicModulesTestLoadGlobally() {
+  return 42;
+}


### PR DESCRIPTION
Commit Message: [bp/1.35] dynamic module: make the loading flag configurable (#42058)
Additional Description:

To make the module loading flag configurable.

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
