### PR TITLE
github/ci: Bind mount docker directory for build CI

### DIFF
--- a/.github/workflows/_publish_build.yml
+++ b/.github/workflows/_publish_build.yml
@@ -78,6 +78,18 @@ jobs:
       arch: ${{ inputs.arch }}
       target: docker
       target-suffix: ${{ inputs.arch }}
+      bind-mounts: |
+        - src: /mnt/workspace
+          target: GITHUB_WORKSPACE
+          chown: "runner:runner"
+        - src: /mnt/runner
+          target: RUNNER_TEMP/container/bazel_root
+          chown: "runner:runner"
+        - src: /mnt/docker
+          target: /var/lib/docker
+          rm: true
+          command-pre: sudo systemctl stop docker
+          command-post: sudo systemctl start docker
       cache-build-image: ${{ fromJSON(inputs.request).request.build-image.default }}
       cache-build-image-key-suffix: ${{ inputs.arch == 'arm64' && '-arm64' || '' }}
       concurrency-suffix: -${{ inputs.arch }}


### PR DESCRIPTION
the combination of shrinking github diskspace and switching the ubuntu version seems to have pushed this ci over the edge

this fix will also speed this ci up

fixes failing ci here https://github.com/envoyproxy/envoy/actions/runs/19525782645