### PR TITLE
Wrap BIGNUM in a pointer

### DIFF
--- a/contrib/cryptomb/private_key_providers/source/cryptomb_private_key_provider.cc
+++ b/contrib/cryptomb/private_key_providers/source/cryptomb_private_key_provider.cc
@@ -740,20 +740,17 @@ CryptoMbPrivateKeyMethodProvider::CryptoMbPrivateKeyMethodProvider(
     // If longer keys are ever supported, remember to change the signature buffer to be larger.
     ASSERT(key_size / 8 <= CryptoMbContext::MAX_SIGNATURE_SIZE);
 
-    BIGNUM e_check;
+    bssl::UniquePtr<BIGNUM> e_check{BN_new()};
     // const BIGNUMs, memory managed by BoringSSL in RSA key structure.
     const BIGNUM* e = nullptr;
     const BIGNUM* n = nullptr;
     const BIGNUM* d = nullptr;
     RSA_get0_key(rsa, &n, &e, &d);
-    BN_init(&e_check);
-    BN_add_word(&e_check, 65537);
-    if (e == nullptr || BN_ucmp(e, &e_check) != 0) {
-      BN_free(&e_check);
+    BN_add_word(e_check.get(), 65537);
+    if (e == nullptr || BN_ucmp(e, e_check.get()) != 0) {
       throw EnvoyException("Only RSA keys with \"e\" parameter value 65537 are allowed, because "
                            "we can validate the signatures using multi-buffer instructions.");
     }
-    BN_free(&e_check);
   } else if (EVP_PKEY_id(pkey.get()) == EVP_PKEY_EC) {
     ENVOY_LOG(debug, "CryptoMb key type: ECDSA");
     key_type_ = KeyType::Ec;

--- a/source/common/tls/ocsp/asn1_utility.cc
+++ b/source/common/tls/ocsp/asn1_utility.cc
@@ -88,12 +88,10 @@ absl::StatusOr<std::string> Asn1Utility::parseInteger(CBS& cbs) {
   CSmartPtr<ASN1_INTEGER, freeAsn1Integer> asn1_integer(
       c2i_ASN1_INTEGER(nullptr, &head, CBS_len(&num)));
   if (asn1_integer != nullptr) {
-    BIGNUM num_bn;
-    BN_init(&num_bn);
-    ASN1_INTEGER_to_BN(asn1_integer.get(), &num_bn);
+    bssl::UniquePtr<BIGNUM> num_bn{BN_new()};
+    ASN1_INTEGER_to_BN(asn1_integer.get(), num_bn.get());
 
-    CSmartPtr<char, freeOpensslString> char_hex_number(BN_bn2hex(&num_bn));
-    BN_free(&num_bn);
+    CSmartPtr<char, freeOpensslString> char_hex_number(BN_bn2hex(num_bn.get()));
     if (char_hex_number != nullptr) {
       std::string hex_number(char_hex_number.get());
       return hex_number;

--- a/source/common/tls/utility.cc
+++ b/source/common/tls/utility.cc
@@ -206,11 +206,9 @@ inline bssl::UniquePtr<ASN1_TIME> currentASN1Time(TimeSource& time_source) {
 
 std::string Utility::getSerialNumberFromCertificate(X509& cert) {
   ASN1_INTEGER* serial_number = X509_get_serialNumber(&cert);
-  BIGNUM num_bn;
-  BN_init(&num_bn);
-  ASN1_INTEGER_to_BN(serial_number, &num_bn);
-  char* char_serial_number = BN_bn2hex(&num_bn);
-  BN_free(&num_bn);
+  bssl::UniquePtr<BIGNUM> num_bn{BN_new()};
+  ASN1_INTEGER_to_BN(serial_number, num_bn.get());
+  char* char_serial_number = BN_bn2hex(num_bn.get());
   if (char_serial_number != nullptr) {
     std::string serial_number(char_serial_number);
     OPENSSL_free(char_serial_number);
@@ -281,12 +279,11 @@ std::string Utility::generalNameAsString(const GENERAL_NAME* general_name) {
       break;
     case V_ASN1_ENUMERATED:
     case V_ASN1_INTEGER: {
-      BIGNUM san_bn;
-      BN_init(&san_bn);
-      value->type == V_ASN1_ENUMERATED ? ASN1_ENUMERATED_to_BN(value->value.enumerated, &san_bn)
-                                       : ASN1_INTEGER_to_BN(value->value.integer, &san_bn);
-      char* san_char = BN_bn2dec(&san_bn);
-      BN_free(&san_bn);
+      bssl::UniquePtr<BIGNUM> san_bn{BN_new()};
+      value->type == V_ASN1_ENUMERATED
+          ? ASN1_ENUMERATED_to_BN(value->value.enumerated, san_bn.get())
+          : ASN1_INTEGER_to_BN(value->value.integer, san_bn.get());
+      char* san_char = BN_bn2dec(san_bn.get());
       if (san_char != nullptr) {
         san.assign(san_char);
         OPENSSL_free(san_char);


### PR DESCRIPTION
So it works fine on both BoringSSL and OpenSSL, as in OpenSSL this is an opaque structure, therefore it only works with pointers.
