### PR TITLE
Revert "github/ci: Bind mount docker directory for build CI (#42152)"

### DIFF
--- a/.github/workflows/_publish_build.yml
+++ b/.github/workflows/_publish_build.yml
@@ -78,18 +78,6 @@ jobs:
       arch: ${{ inputs.arch }}
       target: docker
       target-suffix: ${{ inputs.arch }}
-      bind-mounts: |
-        - src: /mnt/workspace
-          target: GITHUB_WORKSPACE
-          chown: "runner:runner"
-        - src: /mnt/runner
-          target: RUNNER_TEMP/container/bazel_root
-          chown: "runner:runner"
-        - src: /mnt/docker
-          target: /var/lib/docker
-          rm: true
-          command-pre: sudo systemctl stop docker
-          command-post: sudo systemctl start docker
       cache-build-image: ${{ fromJSON(inputs.request).request.build-image.default }}
       cache-build-image-key-suffix: ${{ inputs.arch == 'arm64' && '-arm64' || '' }}
       concurrency-suffix: -${{ inputs.arch }}


### PR DESCRIPTION
This reverts commit 941b37fe232eb8af38524f53ca2d75143d70437e.

x86 ci will still have the diskspace issue but this was never going to work
