### PR TITLE
ext_proc Changing the API to allow ext_proc server sends an empty response type in case no mutation

### DIFF
--- a/api/envoy/service/ext_proc/v3/external_processor.proto
+++ b/api/envoy/service/ext_proc/v3/external_processor.proto
@@ -167,30 +167,31 @@ message ProcessingRequest {
 // [#next-free-field: 11]
 message ProcessingResponse {
   // The response type that is sent by the server.
+  // If the server does not set any of the response type, the data plane will interpret
+  // it as the server has no mutation for the request message.
   oneof response {
-    option (validate.required) = true;
 
-    // The server must send back this message in response to a message with the
+    // The server might send back this message in response to a message with the
     // ``request_headers`` field set.
     HeadersResponse request_headers = 1;
 
-    // The server must send back this message in response to a message with the
+    // The server might send back this message in response to a message with the
     // ``response_headers`` field set.
     HeadersResponse response_headers = 2;
 
-    // The server must send back this message in response to a message with
+    // The server might send back this message in response to a message with
     // the ``request_body`` field set.
     BodyResponse request_body = 3;
 
-    // The server must send back this message in response to a message with
+    // The server might send back this message in response to a message with
     // the ``response_body`` field set.
     BodyResponse response_body = 4;
 
-    // The server must send back this message in response to a message with
+    // The server might send back this message in response to a message with
     // the ``request_trailers`` field set.
     TrailersResponse request_trailers = 5;
 
-    // The server must send back this message in response to a message with
+    // The server might send back this message in response to a message with
     // the ``response_trailers`` field set.
     TrailersResponse response_trailers = 6;
 


### PR DESCRIPTION
Change the ext_proc API to allow  ext_proc server not set the response type in case they do not want to mutate the original request contents.

The can still encode other data, like dynamic_metatdata, or mode_override in the ProcessingResponse.  

This is to address: https://github.com/envoyproxy/envoy/issues/42163