### PR TITLE
googleurl: change repo 

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -73,7 +73,7 @@ common --@rules_python//python/config_settings:bootstrap_impl=script
 build --define absl=1
 
 # Disable ICU linking for googleurl.
-build --@com_github_google_gurl//build_config:system_icu=0
+build --@googleurl//build_config:system_icu=0
 
 # Test options
 build --test_env=HEAPCHECK=normal --test_env=PPROF_PATH

--- a/bazel/external/quiche.BUILD
+++ b/bazel/external/quiche.BUILD
@@ -4708,7 +4708,7 @@ envoy_quiche_platform_impl_cc_library(
         "quiche/common/platform/default/quiche_platform_impl/quiche_googleurl_impl.h",
     ],
     deps = [
-        "@com_github_google_gurl//url",
+        "@googleurl//url",
     ],
 )
 

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -196,7 +196,7 @@ def envoy_dependencies(skip_targets = []):
     _simdutf()
     _intel_ittapi()
     _com_github_google_quiche()
-    _com_github_google_gurl()
+    _googleurl()
     _io_hyperscan()
     _io_vectorscan()
     _io_opentelemetry_api_cpp()
@@ -804,9 +804,9 @@ def _com_github_google_quiche():
         build_file = "@envoy//bazel/external:quiche.BUILD",
     )
 
-def _com_github_google_gurl():
+def _googleurl():
     external_http_archive(
-        name = "com_github_google_gurl",
+        name = "googleurl",
         patches = ["@envoy//bazel/external:googleurl.patch"],
         patch_args = ["-p1"],
     )

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -1287,7 +1287,7 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         license = "BSD-3-Clause",
         license_url = "https://github.com/google/quiche/blob/{version}/LICENSE",
     ),
-    com_github_google_gurl = dict(
+    googleurl = dict(
         project_name = "Chrome URL parsing library",
         project_desc = "Chrome URL parsing library",
         project_url = "https://github.com/google/gurl",

--- a/source/common/http/BUILD
+++ b/source/common/http/BUILD
@@ -598,8 +598,8 @@ envoy_cc_library(
         "//envoy/http:header_map_interface",
         "//source/common/common:logger_lib",
         "//source/common/runtime:runtime_features_lib",
-        "@com_github_google_gurl//url",
         "@com_google_absl//absl/types:optional",
+        "@googleurl//url",
     ],
 )
 


### PR DESCRIPTION
Commit Message: switch to https://github.com/google/gurl from https://quiche.googlesource.com/googleurl.

the old .tar host https://storage.googleapis.com/quiche-envoy-integration/ will be turned down very soon.

Risk Level: low, the new repo is mirrored 
Testing: existing tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A

