### PR TITLE
[ProtoApiScrubber] Add UTs for array type in FieldChecker

### DIFF
--- a/test/extensions/filters/http/proto_api_scrubber/scrubbing_util_lib/field_checker_test.cc
+++ b/test/extensions/filters/http/proto_api_scrubber/scrubbing_util_lib/field_checker_test.cc
@@ -387,13 +387,13 @@ TEST_F(RequestFieldCheckerTest, ArrayType) {
   ProtoApiScrubberConfig config;
   std::string method = "/library.BookService/UpdateBook";
 
-  // 1. Top-level repeated primitive: "tags" -> Remove
+  // Top-level repeated primitive: "tags" -> Remove
   addRestriction(config, method, "tags", FieldType::Request, true);
 
-  // 2. Nested repeated primitive: "metadata.history.edits" -> Remove
+  // Nested repeated primitive: "metadata.history.edits" -> Remove
   addRestriction(config, method, "metadata.history.edits", FieldType::Request, true);
 
-  // 3. Repeated Message: "chapters" -> No Rule (Should result in Partial to scrub children)
+  // Repeated Message: "chapters" -> No Rule (Should result in Partial to scrub children)
 
   initializeFilterConfig(config);
 
@@ -558,11 +558,13 @@ TEST_F(ResponseFieldCheckerTest, ArrayType) {
   ProtoApiScrubberConfig config;
   std::string method = "/library.BookService/GetBook";
 
-  // 1. Top-level repeated primitive: "comments" -> Remove
+  // Top-level repeated primitive: "comments" -> Remove
   addRestriction(config, method, "comments", FieldType::Response, true);
 
-  // 2. Nested repeated primitive: "author.awards" -> Remove
+  // Nested repeated primitive: "author.awards" -> Remove
   addRestriction(config, method, "author.awards", FieldType::Response, true);
+
+  // Repeated Message: "tags" -> No Rule (Should result in Partial to scrub children)
 
   initializeFilterConfig(config);
 
@@ -600,6 +602,17 @@ TEST_F(ResponseFieldCheckerTest, ArrayType) {
     field.set_cardinality(Protobuf::Field_Cardinality_CARDINALITY_REPEATED);
 
     EXPECT_EQ(field_checker.CheckField({"related_books"}, &field), FieldCheckResults::kPartial);
+  }
+
+  {
+    // Case 4: Repeated Primitive with NO matcher
+    // Should return kInclude (keep the whole list).
+    Protobuf::Field field;
+    field.set_name("tags");
+    field.set_kind(Protobuf::Field_Kind_TYPE_STRING);
+    field.set_cardinality(Protobuf::Field_Cardinality_CARDINALITY_REPEATED);
+
+    EXPECT_EQ(field_checker.CheckField({"tags"}, &field), FieldCheckResults::kInclude);
   }
 }
 


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Add UTs for array type in FieldChecker.
Additional Description: This is the first part of support for non-primitive types. Enums, maps and `Any` type will follow. For arrays, there's no additional change needed in the `CheckField()` method. The field paths for array's child fields would be configured just like simple message's child fields and the `proto_scrubber` library also passes the `path` argument to `CheckField` just like simple message. ProtoApiScrubber would not support index level scrubbing i.e., the scrubbing rules in the filter config can't be defined array index wise. e.g., for a field `request.api_keys_list[*].current_key` would be configured as `request.api_keys_list.current_key`.
Risk Level: None
Testing: UTs are added.
Docs Changes: None for now. The documentation (once published) will contain guidelines for configuring array types.
Release Notes: None.
Platform Specific Features: None.
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
