### PR TITLE
github/bazel: Only rebuild client cache on change to repo_locations

### DIFF
--- a/.github/workflows/_request.yml
+++ b/.github/workflows/_request.yml
@@ -23,13 +23,14 @@ on:
         type: string
         required: true
 
+      # TODO: move this to .github/config.yml
       cache-bazel-hash-paths:
         type: string
         default: |
           WORKSPACE
-          **/*.bzl
+          bazel/repository_locations.bzl
+          api/bazel/repository_locations.bzl
           .github/workflows/_request_cache_bazel.yml
-          !mobile/**/*
       config-file:
         type: string
         default: ./.github/config.yml


### PR DESCRIPTION
building the client cache is expensive/slow, and is about to become much more so

this prevents rebuilds on changes to bzl files that dont generally change deps

once bzlmod lands this can be improved - eg using lock file expiry

