### PR TITLE
bazel/platforms: Setups and cleanups

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -8,10 +8,6 @@ load("//bazel:api_repositories.bzl", "envoy_api_dependencies")
 
 envoy_api_dependencies()
 
-load("//bazel:repo.bzl", "envoy_repo")
-
-envoy_repo()
-
 load("//bazel:repositories.bzl", "envoy_dependencies")
 
 envoy_dependencies()
@@ -31,6 +27,14 @@ envoy_python_dependencies()
 load("//bazel:dependency_imports.bzl", "envoy_dependency_imports")
 
 envoy_dependency_imports()
+
+load("//bazel:repo.bzl", "envoy_repo")
+
+envoy_repo()
+
+load("//bazel:toolchains.bzl", "envoy_toolchains")
+
+envoy_toolchains()
 
 load("//bazel:dependency_imports_extra.bzl", "envoy_dependency_imports_extra")
 

--- a/bazel/dependency_imports.bzl
+++ b/bazel/dependency_imports.bzl
@@ -10,7 +10,6 @@ load("@emsdk//:emscripten_deps.bzl", "emscripten_deps")
 load("@emsdk//:toolchains.bzl", "register_emscripten_toolchains")
 load("@envoy_toolshed//compile:sanitizer_libs.bzl", "setup_sanitizer_libs")
 load("@envoy_toolshed//coverage/grcov:grcov_repository.bzl", "grcov_repository")
-load("@envoy_toolshed//repository:utils.bzl", "arch_alias")
 load("@fuzzing_pip3//:requirements.bzl", pip_fuzzing_dependencies = "install_deps")
 load("@io_bazel_rules_go//go:deps.bzl", "go_download_sdk", "go_register_toolchains", "go_rules_dependencies")
 load("@proxy_wasm_rust_sdk//bazel:dependencies.bzl", "proxy_wasm_rust_sdk_dependencies")
@@ -40,16 +39,6 @@ def envoy_dependency_imports(
         yq_version = YQ_VERSION,
         buf_sha = BUF_SHA,
         buf_version = BUF_VERSION):
-    native.register_toolchains("@envoy//bazel/rbe/toolchains/configs/linux/clang/config:cc-toolchain")
-    native.register_toolchains("@envoy//bazel/rbe/toolchains/configs/linux/clang/config:cc-toolchain-arm64")
-    native.register_toolchains("@envoy//bazel/rbe/toolchains/configs/linux/gcc/config:cc-toolchain")
-    arch_alias(
-        name = "clang_platform",
-        aliases = {
-            "amd64": "@envoy//bazel/rbe/toolchains:rbe_linux_clang_platform",
-            "aarch64": "@envoy//bazel/rbe/toolchains:rbe_linux_arm64_clang_platform",
-        },
-    )
     compatibility_proxy_repo()
     rules_foreign_cc_dependencies()
     go_rules_dependencies()

--- a/bazel/platforms/BUILD
+++ b/bazel/platforms/BUILD
@@ -81,6 +81,22 @@ platform(
 )
 
 platform(
+    name = "linux_arm64",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:aarch64",
+    ],
+)
+
+platform(
+    name = "linux_x64",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
+)
+
+platform(
     name = "macos_x86_64",
     constraint_values = [
         "@platforms//cpu:x86_64",

--- a/bazel/platforms/rbe/BUILD
+++ b/bazel/platforms/rbe/BUILD
@@ -1,4 +1,9 @@
+load("@bazel_toolchains//rules/exec_properties:exec_properties.bzl", "create_rbe_exec_properties_dict")
+load("@envoy_repo//:containers.bzl", "image_worker")
+
 licenses(["notice"])  # Apache 2
+
+package(default_visibility = ["//visibility:public"])
 
 platform(
     name = "macos",
@@ -6,4 +11,28 @@ platform(
         "Pool": "macos15",
     },
     parents = ["//bazel/platforms:macos_arm64"],
+)
+
+platform(
+    name = "linux_x64",
+    exec_properties = create_rbe_exec_properties_dict(
+        container_image = "docker://%s" % image_worker(),
+        docker_add_capabilities = "SYS_PTRACE,NET_RAW,NET_ADMIN",
+        docker_network = "standard",
+        docker_privileged = True,
+    ),
+    parents = ["//bazel/rbe/toolchains/configs/linux/clang/config:platform"],
+)
+
+platform(
+    name = "linux_arm64",
+    exec_properties = create_rbe_exec_properties_dict(
+        container_image = "docker://%s" % image_worker(),
+        docker_add_capabilities = "SYS_PTRACE,NET_RAW,NET_ADMIN",
+        docker_network = "standard",
+        docker_privileged = True,
+    ) | {
+        "Pool": "arm",
+    },
+    parents = ["//bazel/rbe/toolchains/configs/linux/clang/config:platform-arm64"],
 )

--- a/bazel/rbe/toolchains/BUILD
+++ b/bazel/rbe/toolchains/BUILD
@@ -3,28 +3,6 @@ load("@bazel_toolchains//rules/exec_properties:exec_properties.bzl", "create_rbe
 licenses(["notice"])  # Apache 2
 
 platform(
-    name = "rbe_linux_clang_platform",
-    exec_properties = create_rbe_exec_properties_dict(
-        docker_add_capabilities = "SYS_PTRACE,NET_RAW,NET_ADMIN",
-        docker_network = "standard",
-        docker_privileged = True,
-    ),
-    parents = ["//bazel/rbe/toolchains/configs/linux/clang/config:platform"],
-    visibility = ["//visibility:public"],
-)
-
-platform(
-    name = "rbe_linux_arm64_clang_platform",
-    exec_properties = create_rbe_exec_properties_dict(
-        docker_add_capabilities = "SYS_PTRACE,NET_RAW,NET_ADMIN",
-        docker_network = "standard",
-        docker_privileged = True,
-    ),
-    parents = ["//bazel/rbe/toolchains/configs/linux/clang/config:platform-arm64"],
-    visibility = ["//visibility:public"],
-)
-
-platform(
     name = "rbe_linux_gcc_platform",
     exec_properties = create_rbe_exec_properties_dict(
         docker_add_capabilities = "SYS_PTRACE,NET_RAW,NET_ADMIN",

--- a/bazel/repo.bzl
+++ b/bazel/repo.bzl
@@ -81,6 +81,11 @@ def _envoy_repo_impl(repository_ctx):
     api_version_path = repository_ctx.path(repository_ctx.attr.envoy_api_version)
     version = repository_ctx.read(repo_version_path).strip()
     api_version = repository_ctx.read(api_version_path).strip()
+
+    # Read BAZEL_LLVM_PATH environment variable for local LLVM installations
+    llvm_path = repository_ctx.os.environ.get("BAZEL_LLVM_PATH", "")
+
+    repository_ctx.file("compiler.bzl", "LLVM_PATH = '%s'" % (llvm_path))
     repository_ctx.file("version.bzl", "VERSION = '%s'\nAPI_VERSION = '%s'" % (version, api_version))
     repository_ctx.file("path.bzl", "PATH = '%s'" % repo_version_path.dirname)
     repository_ctx.file("envoy_repo.py", "PATH = '%s'\nVERSION = '%s'\nAPI_VERSION = '%s'" % (repo_version_path.dirname, version, api_version))
@@ -232,6 +237,7 @@ _envoy_repo = repository_rule(
         "envoy_ci_config": attr.label(default = "@envoy//:.github/config.yml"),
         "yq": attr.label(default = "@yq"),
     },
+    environ = ["BAZEL_LLVM_PATH"],
 )
 
 def envoy_repo():

--- a/bazel/toolchains.bzl
+++ b/bazel/toolchains.bzl
@@ -1,0 +1,14 @@
+load("@envoy_repo//:compiler.bzl", "LLVM_PATH")
+load("@envoy_toolshed//repository:utils.bzl", "arch_alias")
+
+def envoy_toolchains():
+    native.register_toolchains("@envoy//bazel/rbe/toolchains/configs/linux/clang/config:cc-toolchain")
+    native.register_toolchains("@envoy//bazel/rbe/toolchains/configs/linux/clang/config:cc-toolchain-arm64")
+    native.register_toolchains("@envoy//bazel/rbe/toolchains/configs/linux/gcc/config:cc-toolchain")
+    arch_alias(
+        name = "clang_platform",
+        aliases = {
+            "amd64": "@envoy//bazel/platforms/rbe:linux_x64",
+            "aarch64": "@envoy//bazel/platforms/rbe:linux_arm64",
+        },
+    )

--- a/mobile/WORKSPACE
+++ b/mobile/WORKSPACE
@@ -7,7 +7,6 @@ http_archive(
     name = "bazel_gazelle",
     sha256 = "e467b801046b6598c657309b45d2426dc03513777bd1092af2c62eebf990aca5",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.45.0/bazel-gazelle-v0.45.0.tar.gz",
         "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.45.0/bazel-gazelle-v0.45.0.tar.gz",
     ],
 )
@@ -34,10 +33,6 @@ load("@envoy//bazel:api_repositories.bzl", "envoy_api_dependencies")
 
 envoy_api_dependencies()
 
-load("@envoy//bazel:repo.bzl", "envoy_repo")
-
-envoy_repo()
-
 load("@envoy//bazel:repositories.bzl", "envoy_dependencies")
 
 envoy_dependencies()
@@ -58,6 +53,14 @@ load("@envoy//bazel:dependency_imports.bzl", "envoy_dependency_imports")
 
 envoy_dependency_imports()
 
+load("@envoy//bazel:repo.bzl", "envoy_repo")
+
+envoy_repo()
+
+load("@envoy//bazel:toolchains.bzl", "envoy_toolchains")
+
+envoy_toolchains()
+
 load("@envoy_mobile//bazel:envoy_mobile_dependencies.bzl", "envoy_mobile_dependencies")
 
 envoy_mobile_dependencies()
@@ -65,6 +68,10 @@ envoy_mobile_dependencies()
 load("@envoy_mobile//bazel:envoy_mobile_toolchains.bzl", "envoy_mobile_toolchains")
 
 envoy_mobile_toolchains()
+
+load("@envoy_mobile//bazel:platforms.bzl", "envoy_mobile_platforms")
+
+envoy_mobile_platforms()
 
 load("//bazel:android_configure.bzl", "android_configure")
 

--- a/mobile/bazel/platforms.bzl
+++ b/mobile/bazel/platforms.bzl
@@ -1,0 +1,10 @@
+load("@envoy_toolshed//repository:utils.bzl", "arch_alias")
+
+def envoy_mobile_platforms():
+    arch_alias(
+        name = "mobile_clang_platform",
+        aliases = {
+            "amd64": "@envoy_mobile//bazel/platforms/rbe:linux_x64",
+            "aarch64": "@envoy_mobile//bazel/platforms/rbe:linux_arm64",
+        },
+    )

--- a/mobile/bazel/platforms/rbe/BUILD
+++ b/mobile/bazel/platforms/rbe/BUILD
@@ -1,0 +1,26 @@
+load("@bazel_toolchains//rules/exec_properties:exec_properties.bzl", "create_rbe_exec_properties_dict")
+load("@envoy_repo//:containers.bzl", "image_mobile")
+
+licenses(["notice"])  # Apache 2
+
+package(default_visibility = ["//visibility:public"])
+
+platform(
+    name = "linux_x64",
+    exec_properties = create_rbe_exec_properties_dict(
+        container_image = "docker://%s" % image_mobile(),
+    ) | {
+        "Pool": "linux",
+    },
+    parents = ["@envoy//bazel/platforms:linux_x64"],
+)
+
+platform(
+    name = "linux_arm64",
+    exec_properties = create_rbe_exec_properties_dict(
+        container_image = "docker://%s" % image_mobile(),
+    ) | {
+        "Pool": "linux",
+    },
+    parents = ["@envoy//bazel/platforms:linux_arm64"],
+)


### PR DESCRIPTION
this does some groundwork for switching to hermetic llvm toolchains

- move platform registration to `bazel/platforms`
- add `BAZEL_LLVM_PATH` var that can be set via `repo_env` for setting local llvm install
- add `@mobile_clang_platform`
