### PR TITLE
bazel: remove duplicated envoyproxy_sqlparser in dependencies

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -188,7 +188,6 @@ def envoy_dependencies(skip_targets = []):
     _com_google_absl()
     _com_google_googletest()
     _com_google_protobuf()
-    _com_github_envoyproxy_sqlparser()
     _v8()
     _fast_float()
     _highway()


### PR DESCRIPTION
Commit Message:
Additional Description: Already called L162
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
