### PR TITLE
ext_proc: add some integration tests for retry_policy behavior 

### DIFF
--- a/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
+++ b/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
@@ -4222,6 +4222,143 @@ TEST_P(ExtProcIntegrationTest, RetryOnDifferentHost) {
   verifyDownstreamResponse(*response, 200);
 }
 
+// Test that retry stats are correctly incremented when retries occur.
+TEST_P(ExtProcIntegrationTest, RetryStatsVerification) {
+  if (!IsEnvoyGrpc()) {
+    GTEST_SKIP() << "Retry is only supported for Envoy gRPC";
+  }
+  // Set envoy filter timeout to 5s to rule out noise.
+  proto_config_.mutable_message_timeout()->set_seconds(5);
+  proto_config_.mutable_max_message_timeout()->set_seconds(10);
+
+  envoy::config::core::v3::RetryPolicy* retry_policy =
+      proto_config_.mutable_grpc_service()->mutable_retry_policy();
+  retry_policy->mutable_num_retries()->set_value(2);
+  retry_policy->set_retry_on(
+      "resource-exhausted,unavailable"); // resource-exhausted: 8, unavailable: 14
+  retry_policy->mutable_retry_back_off()->mutable_base_interval()->set_seconds(0);
+  retry_policy->mutable_retry_back_off()->mutable_base_interval()->set_nanos(10000000); // 10ms
+  retry_policy->mutable_retry_back_off()->mutable_max_interval()->set_seconds(0);
+  retry_policy->mutable_retry_back_off()->mutable_max_interval()->set_nanos(100000000); // 100ms
+
+  initializeConfig();
+  HttpIntegrationTest::initialize();
+
+  auto response = sendDownstreamRequest(absl::nullopt);
+
+  ProcessingRequest request_headers_msg;
+  waitForFirstMessage(*grpc_upstreams_[0], request_headers_msg);
+
+  // First failure - resource-exhausted.
+  processor_stream_->encodeHeaders(
+      Http::TestResponseHeaderMapImpl{{":status", "500"}, {"grpc-status", "8"}}, true);
+  ASSERT_TRUE(processor_stream_->waitForReset());
+
+  // Retry happens in a new stream.
+  ProcessingRequest request_headers_msg2;
+  ASSERT_TRUE(processor_connection_->waitForNewStream(*dispatcher_, processor_stream_));
+  ASSERT_TRUE(processor_stream_->waitForGrpcMessage(*dispatcher_, request_headers_msg2));
+  EXPECT_TRUE(TestUtility::protoEqual(request_headers_msg2, request_headers_msg));
+
+  // Second failure - unavailable.
+  processor_stream_->encodeHeaders(
+      Http::TestResponseHeaderMapImpl{{":status", "500"}, {"grpc-status", "14"}}, true);
+  ASSERT_TRUE(processor_stream_->waitForReset());
+
+  // Second retry happens in a new stream.
+  ProcessingRequest request_headers_msg3;
+  ASSERT_TRUE(processor_connection_->waitForNewStream(*dispatcher_, processor_stream_));
+  ASSERT_TRUE(processor_stream_->waitForGrpcMessage(*dispatcher_, request_headers_msg3));
+  EXPECT_TRUE(TestUtility::protoEqual(request_headers_msg3, request_headers_msg));
+
+  // Third attempt succeeds.
+  processor_stream_->startGrpcStream(false);
+  processor_stream_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, false);
+  ProcessingResponse processing_response;
+  auto* headers_response = processing_response.mutable_request_headers()->mutable_response();
+  auto* add_header = headers_response->mutable_header_mutation()->add_set_headers();
+  add_header->mutable_header()->set_key("x-retry-test");
+  add_header->mutable_header()->set_raw_value("success");
+  processor_stream_->sendGrpcMessage(processing_response);
+  processor_stream_->finishGrpcStream(Grpc::Status::Ok);
+
+  handleUpstreamRequest();
+  EXPECT_EQ(upstream_request_->headers()
+                .get(Envoy::Http::LowerCaseString("x-retry-test"))[0]
+                ->value()
+                .getStringView(),
+            "success");
+
+  // Verify retry stats are incremented correctly.
+  test_server_->waitForCounterGe("cluster.ext_proc_server_0.upstream_rq_retry", 2);
+  test_server_->waitForCounterGe("cluster.ext_proc_server_0.upstream_rq_total", 3);
+
+  verifyDownstreamResponse(*response, 200);
+}
+
+// Test that gRPC retry works for deadline-exceeded status.
+TEST_P(ExtProcIntegrationTest, RetryOnDeadlineExceeded) {
+  if (!IsEnvoyGrpc()) {
+    GTEST_SKIP() << "Retry is only supported for Envoy gRPC";
+  }
+  // Set envoy filter timeout to 5s to rule out noise.
+  proto_config_.mutable_message_timeout()->set_seconds(5);
+  proto_config_.mutable_max_message_timeout()->set_seconds(10);
+
+  envoy::config::core::v3::RetryPolicy* retry_policy =
+      proto_config_.mutable_grpc_service()->mutable_retry_policy();
+  retry_policy->mutable_num_retries()->set_value(1);
+  // Configure to retry on deadline-exceeded (gRPC status 4).
+  retry_policy->set_retry_on("deadline-exceeded");
+  retry_policy->mutable_retry_back_off()->mutable_base_interval()->set_seconds(0);
+  retry_policy->mutable_retry_back_off()->mutable_base_interval()->set_nanos(10000000); // 10ms
+  retry_policy->mutable_retry_back_off()->mutable_max_interval()->set_seconds(0);
+  retry_policy->mutable_retry_back_off()->mutable_max_interval()->set_nanos(100000000); // 100ms
+
+  initializeConfig();
+  HttpIntegrationTest::initialize();
+
+  auto response = sendDownstreamRequest(absl::nullopt);
+
+  ProcessingRequest request_headers_msg;
+  waitForFirstMessage(*grpc_upstreams_[0], request_headers_msg);
+
+  // First attempt, deadline-exceeded.
+  processor_stream_->encodeHeaders(
+      Http::TestResponseHeaderMapImpl{{":status", "500"}, {"grpc-status", "4"}}, true);
+  ASSERT_TRUE(processor_stream_->waitForReset());
+
+  // Retry happens in a new stream.
+  ProcessingRequest request_headers_msg2;
+  ASSERT_TRUE(processor_connection_->waitForNewStream(*dispatcher_, processor_stream_));
+  ASSERT_TRUE(processor_stream_->waitForGrpcMessage(*dispatcher_, request_headers_msg2));
+  EXPECT_TRUE(TestUtility::protoEqual(request_headers_msg2, request_headers_msg));
+
+  // Second attempt succeeds.
+  processor_stream_->startGrpcStream(false);
+  processor_stream_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, false);
+  ProcessingResponse processing_response;
+  auto* headers_response = processing_response.mutable_request_headers()->mutable_response();
+  auto* add_header = headers_response->mutable_header_mutation()->add_set_headers();
+  add_header->mutable_header()->set_key("x-deadline-retry");
+  add_header->mutable_header()->set_raw_value("passed");
+  processor_stream_->sendGrpcMessage(processing_response);
+  processor_stream_->finishGrpcStream(Grpc::Status::Ok);
+
+  handleUpstreamRequest();
+  EXPECT_EQ(upstream_request_->headers()
+                .get(Envoy::Http::LowerCaseString("x-deadline-retry"))[0]
+                ->value()
+                .getStringView(),
+            "passed");
+
+  // Verify retry stats are incremented.
+  test_server_->waitForCounterGe("cluster.ext_proc_server_0.upstream_rq_retry", 1);
+  test_server_->waitForCounterGe("cluster.ext_proc_server_0.upstream_rq_total", 2);
+
+  verifyDownstreamResponse(*response, 200);
+}
+
 TEST_P(ExtProcIntegrationTest, SidestreamPushbackDownstream) {
   if (!IsEnvoyGrpc()) {
     return;


### PR DESCRIPTION
## Description

This PR adds some integration tests for ExtProc to verify that the retry policy configured on the `grpc_service` works as expected.

---

**Commit Message:** ext_proc: add some integration tests for retry_policy behavior
**Additional Description:** adds some integration tests for ExtProc to verify that the retry policy configured on the `grpc_service` works as expected.
**Risk Level:** Low
**Testing:** Added Integration Tests
**Docs Changes:** N/A
**Release Notes:** N/A