### PR TITLE
bazel: Remove `remote-clang/gcc` configs and cleanups

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -8,7 +8,7 @@ tasks:
     - "//test/integration/..."
     - "//test/exe/..."
     test_flags:
-    - "--config=remote-clang"
+    - "--config=clang"
     - "--config=remote-ci"
     - "--define=wasm=disabled"
     - "--jobs=75"

--- a/.bazelrc
+++ b/.bazelrc
@@ -98,7 +98,6 @@ build:linux --cxxopt=-fsized-deallocation --host_cxxopt=-fsized-deallocation
 build:linux --conlyopt=-fexceptions
 build:linux --fission=dbg,opt
 build:linux --features=per_object_debug_info
-build:linux --action_env=BAZEL_LINKLIBS=-l%:libstdc++.a
 build:linux --action_env=BAZEL_LINKOPTS=-lm:-fuse-ld=gold
 
 # macOS
@@ -113,15 +112,16 @@ build:macos --cxxopt=-Wno-nullability-completeness
 #############################################################################
 
 # Common flags for Clang (shared between all clang variants)
-common:clang-common --action_env=BAZEL_COMPILER=clang
 common:clang-common --linkopt=-fuse-ld=lld
+common:clang-common --action_env=BAZEL_COMPILER=clang
+common:clang-common --action_env=LDFLAGS="-fuse-ld=lld"
 common:clang-common --action_env=CC=clang --host_action_env=CC=clang
 common:clang-common --action_env=CXX=clang++ --host_action_env=CXX=clang++
 
 # Clang with libc++ (default)
 common:clang --config=clang-common
 common:clang --config=libc++
-common:clang --action_env=LDFLAGS="-fuse-ld=lld"
+common:clang --host_platform=@clang_platform
 
 # Use gold linker for gcc compiler.
 build:gcc --config=libstdc++
@@ -141,8 +141,9 @@ build:gcc --cxxopt=-Wno-missing-requires
 build:gcc --cxxopt=-Wno-dangling-reference
 build:gcc --cxxopt=-Wno-nonnull-compare
 build:gcc --linkopt=-fuse-ld=gold --host_linkopt=-fuse-ld=gold
+build:gcc --host_platform=@envoy//bazel/rbe/toolchains:rbe_linux_gcc_platform
 
-# libc++ default for clang
+# libc++ - default for clang
 common:libc++ --action_env=CXXFLAGS=-stdlib=libc++
 common:libc++ --action_env=LDFLAGS="-stdlib=libc++ -fuse-ld=lld"
 common:libc++ --action_env=BAZEL_CXXOPTS=-stdlib=libc++
@@ -152,6 +153,7 @@ common:libc++ --define force_libcpp=enabled
 common:libc++ --@envoy//bazel:libc++=true
 
 # libstdc++ - currently only used for gcc
+build:libstdc++ --action_env=BAZEL_LINKLIBS=-l%:libstdc++.a
 build:libstdc++ --@envoy//bazel:libc++=false
 build:libstdc++ --@envoy//bazel:libstdc++=true
 
@@ -383,31 +385,11 @@ build:sizeopt -c opt --copt -Os
 # remote: Setup for cache, BES, RBE, and Docker workers
 #############################################################################
 
-# Remote execution: https://docs.bazel.build/versions/master/remote-execution.html
-build:rbe-toolchain --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
-
-build:rbe-toolchain-clang --config=rbe-toolchain
-build:rbe-toolchain-clang --config=clang
-build:rbe-toolchain-clang --platforms=@clang_platform
-build:rbe-toolchain-clang --host_platform=@clang_platform
-build:rbe-toolchain-clang --crosstool_top=@envoy//bazel/rbe/toolchains/configs/linux/clang/cc:toolchain
-
-build:rbe-toolchain-gcc --config=rbe-toolchain
-build:rbe-toolchain-gcc --config=gcc
-build:rbe-toolchain-gcc --platforms=@envoy//bazel/rbe/toolchains:rbe_linux_gcc_platform
-build:rbe-toolchain-gcc --host_platform=@envoy//bazel/rbe/toolchains:rbe_linux_gcc_platform
-build:rbe-toolchain-gcc --crosstool_top=@envoy//bazel/rbe/toolchains/configs/linux/gcc/cc:toolchain
-
-build:remote-clang --config=remote
-build:remote-clang --config=rbe-toolchain-clang
-
-build:remote-gcc --config=remote
-build:remote-gcc --config=rbe-toolchain-gcc
-
 build:remote --spawn_strategy=remote,sandboxed,local
 build:remote --strategy=Javac=remote,sandboxed,local
 build:remote --strategy=Closure=remote,sandboxed,local
 build:remote --strategy=Genrule=remote,sandboxed,local
+build:remote --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
 
 ## RBE (Engflow Envoy)
 
@@ -447,22 +429,21 @@ build:docker-sandbox --experimental_docker_verbose
 build:docker-sandbox --experimental_enable_docker_sandbox
 
 build:docker-clang --config=docker-sandbox
-build:docker-clang --config=rbe-toolchain-clang
+build:docker-clang --config=clang
 
 build:docker-gcc --config=docker-sandbox
 build:docker-gcc --config=gcc
-build:docker-gcc --config=rbe-toolchain-gcc
 
 build:docker-asan --config=docker-sandbox
-build:docker-asan --config=rbe-toolchain-clang
+build:docker-asan --config=clang
 build:docker-asan --config=asan
 
 build:docker-msan --config=docker-sandbox
-build:docker-msan --config=rbe-toolchain-clang
+build:docker-msan --config=clang
 build:docker-msan --config=msan
 
 build:docker-tsan --config=docker-sandbox
-build:docker-tsan --config=rbe-toolchain-clang
+build:docker-tsan --config=clang
 build:docker-tsan --config=tsan
 
 

--- a/bazel/rbe/toolchains/BUILD
+++ b/bazel/rbe/toolchains/BUILD
@@ -1,10 +1,12 @@
 load("@bazel_toolchains//rules/exec_properties:exec_properties.bzl", "create_rbe_exec_properties_dict")
+load("@envoy_repo//:containers.bzl", "image_gcc")
 
 licenses(["notice"])  # Apache 2
 
 platform(
     name = "rbe_linux_gcc_platform",
     exec_properties = create_rbe_exec_properties_dict(
+        container_image = "docker://%s" % image_gcc(),
         docker_add_capabilities = "SYS_PTRACE,NET_RAW,NET_ADMIN",
         docker_network = "standard",
     ),

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -35,9 +35,6 @@ setup_clang_toolchain() {
     # We only support clang with libc++ now
     BAZEL_QUERY_OPTIONS=("${BAZEL_GLOBAL_OPTIONS[@]}" "--config=${config}")
     BAZEL_QUERY_OPTION_LIST="${BAZEL_QUERY_OPTIONS[*]}"
-    if [[ -n "${ENVOY_RBE}" ]]; then
-        config="remote-${config}"
-    fi
     BAZEL_BUILD_OPTIONS+=("--config=${config}")
     BAZEL_BUILD_OPTION_LIST="${BAZEL_BUILD_OPTIONS[*]}"
     export BAZEL_BUILD_OPTION_LIST
@@ -671,12 +668,8 @@ case $CI_TARGET in
         ;;
 
     gcc)
-        if [[ -n "${ENVOY_RBE}" ]]; then
-            CONFIG_PREFIX="remote-"
-        fi
-        CONFIG="${CONFIG_PREFIX}gcc"
-        BAZEL_BUILD_OPTIONS+=("--config=${CONFIG}")
-        echo "gcc toolchain configured: ${CONFIG}"
+        BAZEL_BUILD_OPTIONS+=("--config=gcc")
+        echo "gcc toolchain configured: gcc"
         echo "bazel fastbuild build with gcc..."
         bazel_envoy_binary_build fastbuild
         echo "Testing ${TEST_TARGETS[*]}"

--- a/mobile/.bazelrc
+++ b/mobile/.bazelrc
@@ -106,7 +106,6 @@ build:mobile-android-publish --fat_apk_cpu=x86,x86_64,armeabi-v7a,arm64-v8a
 build:mobile-clang --config=libc++
 build:mobile-clang --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
 build:mobile-clang --host_platform=@mobile_clang_platform
-build:mobile-clang --platforms=@mobile_clang_platform
 
 
 #############################################################################

--- a/mobile/tools/check_format.sh
+++ b/mobile/tools/check_format.sh
@@ -11,11 +11,7 @@ fi
 if [[ -n "$BAZEL_BUILD_EXTRA_OPTIONS" ]]; then
     read -ra BAZEL_BUILD_EXTRA_OPTIONS <<< "${BAZEL_BUILD_EXTRA_OPTIONS}"
 else
-    if [[ -n "$ENVOY_RBE" ]]; then
-        BAZEL_BUILD_EXTRA_OPTIONS=(--config=mobile-remote-clang)
-    else
-        BAZEL_BUILD_EXTRA_OPTIONS=(--config=mobile-clang)
-    fi
+    BAZEL_BUILD_EXTRA_OPTIONS=(--config=mobile-clang)
 fi
 
 echo "${BAZEL_BUILD_EXTRA_OPTIONS[*]}"


### PR DESCRIPTION
toolchain and platform are now separate and we use cc_toolchain_resolution - so `--config=clang` or `--config=gcc` should be sufficient (with any platform config separate)