### PR TITLE
ci: docker-compose: Add MOUNT_ACCES_MODE variable

### DIFF
--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -92,9 +92,9 @@ services:
   envoy-build:
     <<: *envoy-build-base
     volumes:
-    - ${ENVOY_DOCKER_BUILD_DIR:-/tmp/envoy-docker-build}:/build
-    - ${SOURCE_DIR:-..}:/source
-    - ${SHARED_TMP_DIR:-/tmp/bazel-shared}:${SHARED_TMP_DIR:-/tmp/bazel-shared}
+    - ${ENVOY_DOCKER_BUILD_DIR:-/tmp/envoy-docker-build}:/build${MOUNT_ACCESS_MODE:-}
+    - ${SOURCE_DIR:-..}:/source${MOUNT_ACCESS_MODE:-}
+    - ${SHARED_TMP_DIR:-/tmp/bazel-shared}:${SHARED_TMP_DIR:-/tmp/bazel-shared}${MOUNT_ACCESS_MODE:-}
 
   envoy-build-gpg:
     <<: *envoy-build-base


### PR DESCRIPTION
Commit Message: Add a `MOUNT_ACCES_MODE` variable to set mount options on the volumes. Environments where SELinux is enabled will now be able to mount to the volumes with `MOUNT_ACCES_MODE=":Z"` to make the bind mount permissions work correctly.
Additional Description: N/A
Risk Level: Low
Testing: It now compiles on Fedora 43 with `MOUNT_ACCES_MODE=":Z"`. Should have no impact in envs where MOUNT_ACCES_MODE is not set (haven't tested myself).
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
Fixes: https://github.com/envoyproxy/envoy/issues/42197

