### PR TITLE
test: add integration tests for on_demand VHDS with request bodies

### DIFF
--- a/test/extensions/filters/http/on_demand/BUILD
+++ b/test/extensions/filters/http/on_demand/BUILD
@@ -42,6 +42,7 @@ envoy_extension_cc_test(
         "//source/extensions/filters/http/on_demand:on_demand_update_lib",
         "//test/config:v2_link_hacks",
         "//test/integration:http_integration_lib",
+        "//test/integration:http_protocol_integration_lib",
         "//test/integration:scoped_rds_lib",
         "//test/integration:vhds_lib",
         "@envoy_api//envoy/config/bootstrap/v3:pkg_cc_proto",


### PR DESCRIPTION
Commit Message:
Add integration tests verifying VHDS on-demand updates work correctly with request bodies for both HTTP/1.1 and HTTP/2. The tests use HttpProtocolIntegrationTest parameterization to automatically run for both downstream protocols (HTTP/1.1 and HTTP/2), ensuring the fix for #17891 works correctly across different HTTP protocol versions.

Additional Description:

Tests verify that:
- Request bodies are preserved when triggering on-demand VHDS updates
- Stream recreation works correctly after VHDS updates complete
- Both HTTP/1.1 and HTTP/2 protocols handle bodies correctly

The test instantiation uses getProtocolTestParamsWithoutHTTP3() which returns parameter combinations for both HTTP/1.1 and HTTP/2 downstream protocols, so each test runs multiple times (once per protocol combination).

Complements the unit tests in d39afea2c2a32e184ecfb0edadaa3303d9e1f5f7 and provides end-to-end verification for #17891.

followup of https://github.com/envoyproxy/envoy/pull/42158
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
