### PR TITLE
tools/proto_format: Build locally

### DIFF
--- a/tools/proto_format/BUILD
+++ b/tools/proto_format/BUILD
@@ -108,6 +108,9 @@ genrule(
     && git -C $$TEMPDIR ls-files -s api/ > $@ \
     && rm -rf $$TEMPDIR
     """,
+    # Requires git - this avoids adding git to rbe workers
+    # this could be resolved by the addition of rules_git
+    tags = ["no-remote-exec"],
     tools = [":formatted_api"],
 )
 


### PR DESCRIPTION
this tool requires git - so rather than adding git to RBE workers, switching to local build for this job.

once bzlmod lands we can install rules_git and revert this.

