### PR TITLE
docs: clarify predictive_preconnect_ratio upper limit

### DIFF
--- a/api/envoy/config/cluster/v3/cluster.proto
+++ b/api/envoy/config/cluster/v3/cluster.proto
@@ -748,6 +748,9 @@ message Cluster {
     // If both this and preconnect_ratio are set, Envoy will make sure both predicted needs are met,
     // basically preconnecting max(predictive-preconnect, per-upstream-preconnect), for each
     // upstream.
+    //
+    // This is limited somewhat arbitrarily to 3 because preconnecting too aggressively can
+    // harm latency more than the preconnecting helps.
     google.protobuf.DoubleValue predictive_preconnect_ratio = 2
         [(validate.rules).double = {lte: 3.0 gte: 1.0}];
   }


### PR DESCRIPTION
Add documentation explaining that predictive_preconnect_ratio is limited to 3. Per_upstream_preconnect_ratio and predictive_preconnect_ratio are both limited to 3, but previously only the former had this upper bound documented.

---

Commit Message: docs: clarify predictive_preconnect_ratio upper limit

Add documentation explaining that predictive_preconnect_ratio is limited to 3. Per_upstream_preconnect_ratio and predictive_preconnect_ratio are both limited to 3, but previously only the former had this upper bound documented.

Additional Description: 

Users unaware of the upper bound that set too high of a value will see CDS updates rejected (ask me how I know :) )
```
xds update failed for node=foo, message=Proto constraint validation failed (ClusterValidationError.PreconnectPolicy: embedded message failed validation | caused by PreconnectPolicyValidationError.PredictivePreconnectRatio: value must be inside range [1, 3])
```

Fixing the documentation gap here https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto#config-cluster-v3-cluster-preconnectpolicy lessens the chance of that happening. I copied the comment word for word from the proto comment for per_upstream_preconnect_ratio.

Risk Level: low
Testing: n/a
Docs Changes: API protos doc update
