### PR TITLE
github/ci: Delete all in diskspace hack where possible

### DIFF
--- a/.github/workflows/_check_build.yml
+++ b/.github/workflows/_check_build.yml
@@ -38,7 +38,6 @@ jobs:
       bazel-extra: '--config=rbe'
       cache-build-image: ${{ fromJSON(inputs.request).request.build-image.default }}
       concurrency-suffix: -${{ matrix.target }}
-      diskspace-hack-paths: ${{ matrix.diskspace-hack-paths }}
       docker-ci: ${{ matrix.docker-ci || false }}
       error-match: |
         ERROR

--- a/.github/workflows/_check_coverage.yml
+++ b/.github/workflows/_check_coverage.yml
@@ -41,7 +41,6 @@ jobs:
       bazel-extra: '--config=rbe'
       cache-build-image: ${{ fromJSON(inputs.request).request.build-image.default }}
       concurrency-suffix: -${{ matrix.target }}
-      diskspace-hack-paths: ${{ matrix.diskspace-hack-paths }}
       error-match: |
         ERROR
         error:
@@ -72,8 +71,5 @@ jobs:
         include:
         - target: coverage
           name: Coverage
-          diskspace-hack-paths:
         - target: fuzz_coverage
           name: Fuzz coverage
-          diskspace-hack-paths: |
-            /opt/hostedtoolcache

--- a/.github/workflows/_check_san.yml
+++ b/.github/workflows/_check_san.yml
@@ -38,7 +38,6 @@ jobs:
       bazel-extra: '--config=rbe'
       cache-build-image: ${{ fromJSON(inputs.request).request.build-image.default }}
       concurrency-suffix: -${{ matrix.target }}
-      diskspace-hack-paths: ${{ matrix.diskspace-hack-paths || '/opt/hostedtoolcache' }}
       request: ${{ inputs.request }}
       error-match: |
         ERROR
@@ -58,7 +57,4 @@ jobs:
         - target: msan
           rbe: true
         - target: tsan
-          diskspace-hack-paths: |
-            /opt/hostedtoolcache
-            /usr/local/.ghcup
           rbe: true

--- a/.github/workflows/_mobile_container_ci.yml
+++ b/.github/workflows/_mobile_container_ci.yml
@@ -53,8 +53,7 @@ on:
         default: false
       diskspace-hack-paths:
         type: string
-        default: |
-          /opt/hostedtoolcache
+        default:
       downloads:
         type: string
         default:

--- a/.github/workflows/_precheck_deps.yml
+++ b/.github/workflows/_precheck_deps.yml
@@ -40,7 +40,6 @@ jobs:
       bazel-extra: '--config=rbe'
       cache-build-image: ${{ fromJSON(inputs.request).request.build-image.default }}
       concurrency-suffix: -${{ matrix.target }}
-      diskspace-hack-paths: ${{ matrix.diskspace-hack-paths }}
       gcs-cache-bucket: ${{ inputs.gcs-cache-bucket }}
       request: ${{ inputs.request }}
       error-match: |
@@ -54,7 +53,6 @@ jobs:
       matrix:
         include:
         - target: deps
-          diskspace-hack-paths:
 
   dependency-review:
     runs-on: ubuntu-24.04

--- a/.github/workflows/_precheck_format.yml
+++ b/.github/workflows/_precheck_format.yml
@@ -38,7 +38,6 @@ jobs:
       bazel-extra: '--config=rbe'
       cache-build-image: ${{ fromJSON(inputs.request).request.build-image.default }}
       concurrency-suffix: -${{ matrix.target }}
-      diskspace-hack-paths: ${{ matrix.diskspace-hack-paths }}
       gcs-cache-bucket: ${{ inputs.gcs-cache-bucket }}
       request: ${{ inputs.request }}
       # format needs aspell, and format-api requires git

--- a/.github/workflows/_precheck_publish.yml
+++ b/.github/workflows/_precheck_publish.yml
@@ -42,7 +42,6 @@ jobs:
       cache-build-image: ${{ fromJSON(inputs.request).request.build-image.default }}
       cache-build-image-key-suffix: ${{ matrix.arch == 'arm64' && '-arm64' || '' }}
       concurrency-suffix: -${{ matrix.target }}${{ matrix.arch && format('-{0}', matrix.arch) || '' }}
-      diskspace-hack-paths: ${{ matrix.diskspace-hack-paths || '/opt/hostedtoolcache' }}
       gcs-cache-bucket: ${{ inputs.gcs-cache-bucket }}
       rbe: ${{ matrix.rbe }}
       request: ${{ inputs.request }}
@@ -64,9 +63,6 @@ jobs:
           name: Release (x64)
           target-suffix: x64
           arch: x64
-          diskspace-hack-paths: |
-            /opt/hostedtoolcache
-            /usr/local/.ghcup
           rbe: true
         - target: release.test_only
           name: Release (arm64)

--- a/.github/workflows/_publish_build.yml
+++ b/.github/workflows/_publish_build.yml
@@ -54,9 +54,6 @@ jobs:
       cache-build-image: ${{ fromJSON(inputs.request).request.build-image.default }}
       cache-build-image-key-suffix: ${{ inputs.arch == 'arm64' && '-arm64' || '' }}
       concurrency-suffix: -${{ inputs.arch }}
-      diskspace-hack-paths: |
-        /opt/hostedtoolcache
-        /usr/local/.ghcup
       gcs-cache-bucket: ${{ inputs.gcs-cache-bucket }}
       rbe: true
       request: ${{ inputs.request }}
@@ -117,9 +114,6 @@ jobs:
       cache-build-image: ${{ fromJSON(inputs.request).request.build-image.default }}
       cache-build-image-key-suffix: ${{ inputs.arch == 'arm64' && '-arm64' || '' }}
       concurrency-suffix: -${{ inputs.arch }}
-      diskspace-hack-paths: |
-        /opt/hostedtoolcache
-        /usr/local/.ghcup
       docker-ci: false
       gcs-cache-bucket: ${{ inputs.gcs-cache-bucket }}
       import-gpg: true

--- a/.github/workflows/_publish_release.yml
+++ b/.github/workflows/_publish_release.yml
@@ -58,7 +58,6 @@ jobs:
         --//distribution:x64-release=//distribution:custom/x64/bin/release.tar.zst
         --//distribution:arm64-release=//distribution:custom/arm64/bin/release.tar.zst
       cache-build-image: ${{ fromJSON(inputs.request).request.build-image.default }}
-      diskspace-hack-paths:
       downloads: |
         packages.arm64: container/envoy/arm64/
         packages.x64: container/envoy/x64/

--- a/.github/workflows/_publish_verify.yml
+++ b/.github/workflows/_publish_verify.yml
@@ -42,9 +42,6 @@ jobs:
       cache-build-image-key-suffix: ${{ matrix.arch == 'arm64' && format('-{0}', matrix.arch) || '' }}
       container-command: ${{ matrix.container-command }}
       concurrency-suffix: -${{ matrix.arch || 'x64' }}
-      diskspace-hack-paths: |
-        /opt/hostedtoolcache
-        /usr/local/.ghcup
       downloads: ${{ matrix.downloads }}
       rbe: ${{ matrix.rbe }}
       request: ${{ inputs.request }}
@@ -162,9 +159,6 @@ jobs:
       cache-build-image-key-suffix: ${{ matrix.arch == 'arm64' && format('-{0}', matrix.arch) || '' }}
       container-command: ./ci/run_envoy_docker.sh
       concurrency-suffix: -${{ matrix.arch || 'x64' }}
-      diskspace-hack-paths: |
-        /opt/hostedtoolcache
-        /usr/local/.ghcup
       downloads: |
         release.signed: container/release.signed
       gcs-cache-bucket: ${{ inputs.gcs-cache-bucket }}

--- a/.github/workflows/_request_cache_bazel.yml
+++ b/.github/workflows/_request_cache_bazel.yml
@@ -63,9 +63,6 @@ jobs:
     - name: Free diskspace
       uses: envoyproxy/toolshed/gh-actions/diskspace@actions-v0.3.31
       if: inputs.arch == 'x64' && github.event.repository.private
-      with:
-        to_remove: |
-          /opt/hostedtoolcache
     - uses: envoyproxy/toolshed/gh-actions/github/checkout@actions-v0.3.31
       id: checkout-target
       name: Checkout Envoy repository (target branch)

--- a/.github/workflows/_run.yml
+++ b/.github/workflows/_run.yml
@@ -64,8 +64,7 @@ on:
         default: false
       diskspace-hack-paths:
         type: string
-        default: |
-          /opt/hostedtoolcache
+        default:
       docker-cpus:
         type: number
         default: 0
@@ -245,7 +244,7 @@ jobs:
     - uses: envoyproxy/toolshed/gh-actions/github/remnt@actions-v0.3.31
       if: steps.disk.outputs.should-remnt == 'true'
     - uses: envoyproxy/toolshed/gh-actions/bind-mounts@actions-v0.3.31
-      if: inputs.bind-mount
+      if: inputs.bind-mount && ! github.event.repository.private
       with:
         mounts: ${{ inputs.bind-mounts }}
     - name: Free diskspace

--- a/.github/workflows/mobile-android_tests.yml
+++ b/.github/workflows/mobile-android_tests.yml
@@ -49,7 +49,6 @@ jobs:
     with:
       args: ${{ matrix.args }}
       container: ${{ needs.load.outputs.build-image && fromJSON(needs.load.outputs.build-image).mobile || '' }}
-      diskspace-hack-paths:
       request: ${{ needs.load.outputs.request }}
       target: ${{ matrix.target }}
       timeout-minutes: 90


### PR DESCRIPTION
the toolshed action now backgrounds the `rm -rf` so its much faster, and in my testing appears to still be reliable

some Android CI actually uses pre-installed SDK so in those cases the paths still need to be specified

