### PR TITLE
Docs: update instructions when invoking the spell checker.

### DIFF
--- a/bazel/README.md
+++ b/bazel/README.md
@@ -934,14 +934,17 @@ tools/gen_compilation_database.py --exclude_contrib
 # Running format linting without docker
 
 Note that if you run the `check_spelling.py` script you will need to have `aspell` installed.
+Prefer to run it via bazel as the environment will contain the dictionary used.
 
 You can run clang-format directly, without docker:
 
 ```shell
 bazel run //tools/code_format:check_format -- check
-./tools/spelling/check_spelling_pedantic.py check
+# Target root needs to be an absolute path to your envoy repository to run on
+# the entire codebase by default.
+bazel run //tools/spelling:check_spelling_pedantic -- check --target_root=$(pwd)
 bazel run //tools/code_format:check_format -- fix
-./tools/spelling/check_spelling_pedantic.py fix
+bazel run //tools/spelling:check_spelling_pedantic -- fix --target_root=$(pwd)
 ```
 
 # Advanced caching setup


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Docs: update instructions when invoking the spell checker.
Additional Description: If you invoke the script directly you need to specific the dictionary directly (unless you hardcode it)
e.g. 

```
  ASPELL_DICT=tools/spelling/spelling_dictionary.txt ./tools/spelling/check_spelling_pedantic.py check
```

but then if you invoke it via bazel which sets this up correctly it'll run inside the bazel-bin folder and have no files checked:

```
[03:31:40] kbaichoo:conn-card:0 $  bazel run //tools/spelling:check_spelling_pedantic fix
WARNING: The following configs were expanded more than once: [libc++]. For repeatable flags, repeats are counted twice and may lead to unexpected behavior.
WARNING: The following configs were expanded more than once: [libc++]. For repeatable flags, repeats are counted twice and may lead to unexpected behavior.
INFO: Analyzed target //tools/spelling:check_spelling_pedantic (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //tools/spelling:check_spelling_pedantic up-to-date:
  bazel-bin/tools/spelling/check_spelling_pedantic
INFO: Elapsed time: 0.187s, Critical Path: 0.04s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Running command line: bazel-bin/tools/spelling/check_spelling_pedantic fix
Checked 0 file(s) and 0 comment(s), found 0 error(s).

```

but if you include the target root as the base of the envoy repo as the command would require it works:
```
[03:34:28] kbaichoo:conn-card:0 $bazel run //tools/spelling:check_spelling_pedantic -- check --target_root=$(pwd)
WARNING: The following configs were expanded more than once: [libc++]. For repeatable flags, repeats are counted twice and may lead to unexpected behavior.
WARNING: The following configs were expanded more than once: [libc++]. For repeatable flags, repeats are counted twice and may lead to unexpected behavior.
INFO: Analyzed target //tools/spelling:check_spelling_pedantic (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //tools/spelling:check_spelling_pedantic up-to-date:
  bazel-bin/tools/spelling/check_spelling_pedantic
INFO: Elapsed time: 0.183s, Critical Path: 0.03s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Running command line: bazel-bin/tools/spelling/check_spelling_pedantic check '--target_root=/home/kbaichoo/git/conn-card'
Checked 5783 file(s) and 176335 comment(s), found 0 error(s).

```

Risk Level:  n/a
Testing: ran locally
Docs Changes: yes
Release Notes: n/a
Platform Specific Features: n/a
