### PR TITLE
Update google.golang.org/protobuf in envoy_api MODULE

### DIFF
--- a/api/MODULE.bazel
+++ b/api/MODULE.bazel
@@ -74,8 +74,8 @@ go_deps.module(
 )
 go_deps.module(
     path = "google.golang.org/protobuf",
-    sum = "h1:82DV7MYdb8anAVi3qge1wSnMDrnKK7ebr+I0hHRN1BU=",
-    version = "v1.36.3",
+    sum = "h1:AYd7cD/uASjIL6Q9LiTjz8JLcrh/88q5UObnmY3aOOE=",
+    version = "v1.36.10",
 )
 go_deps.module(
     path = "google.golang.org/genproto/googleapis/rpc",


### PR DESCRIPTION
Commit Message: Update google.golang.org/protobuf in envoy_api MODULE
Additional Description: google.golang.org/protobuf is in v1.36.10 in the rest of the project and shall be here too
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
