### PR TITLE
not all awk support \s and this will make developers' life easier

### DIFF
--- a/ci/envoy_build_sha.sh
+++ b/ci/envoy_build_sha.sh
@@ -3,16 +3,16 @@
 CONFIG_FILE="$(realpath "$(dirname "${BASH_SOURCE[0]}")")/../.github/config.yml"
 
 # Parse values from .github/config.yml
-BUILD_REPO=$(awk '/^\s*repo: /{print $2}' "$CONFIG_FILE")
-BUILD_SHA=$(awk '/^\s*sha: /{print $2}' "$CONFIG_FILE")
-BUILD_SHA_CI=$(awk '/^\s*sha-ci: /{print $2}' "$CONFIG_FILE")
-BUILD_SHA_DEVTOOLS=$(awk '/^\s*sha-devtools: /{print $2}' "$CONFIG_FILE")
-BUILD_SHA_DOCKER=$(awk '/^\s*sha-docker: /{print $2}' "$CONFIG_FILE")
-BUILD_SHA_GCC=$(awk '/^\s*sha-gcc: /{print $2}' "$CONFIG_FILE")
-BUILD_SHA_MOBILE=$(awk '/^\s*sha-mobile: /{print $2}' "$CONFIG_FILE")
-BUILD_SHA_WORKER=$(awk '/^\s*sha-worker: /{print $2}' "$CONFIG_FILE")
+BUILD_REPO=$(awk '/^[ ]*repo: /{print $2}' "$CONFIG_FILE")
+BUILD_SHA=$(awk '/^[ ]*sha: /{print $2}' "$CONFIG_FILE")
+BUILD_SHA_CI=$(awk '/^[ ]*sha-ci: /{print $2}' "$CONFIG_FILE")
+BUILD_SHA_DEVTOOLS=$(awk '/^[ ]*sha-devtools: /{print $2}' "$CONFIG_FILE")
+BUILD_SHA_DOCKER=$(awk '/^[ ]*sha-docker: /{print $2}' "$CONFIG_FILE")
+BUILD_SHA_GCC=$(awk '/^[ ]*sha-gcc: /{print $2}' "$CONFIG_FILE")
+BUILD_SHA_MOBILE=$(awk '/^[ ]*sha-mobile: /{print $2}' "$CONFIG_FILE")
+BUILD_SHA_WORKER=$(awk '/^[ ]*sha-worker: /{print $2}' "$CONFIG_FILE")
 
-BUILD_TAG=$(awk '/^\s*tag: /{print $2}' "$CONFIG_FILE")
+BUILD_TAG=$(awk '/^[ ]*tag: /{print $2}' "$CONFIG_FILE")
 
 
 case $ENVOY_BUILD_VARIANT in


### PR DESCRIPTION
Commit Message: not all awk support \s and this will make developers' life easier
Additional Description:

Like the users of "Ubuntu 24.04.2 LTS"

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
