### PR TITLE
github/codeql: Fixes and cleanups

### DIFF
--- a/.github/workflows/codeql-daily.yml
+++ b/.github/workflows/codeql-daily.yml
@@ -26,16 +26,33 @@ jobs:
     if: github.repository == 'envoyproxy/envoy'
 
     steps:
+
+    - uses: envoyproxy/toolshed/gh-actions/bind-mounts@actions-v0.3.31
+      if: |
+        ! github.event.repository.private
+      with:
+        mounts: |
+          - src: /mnt/workspace
+            target: GITHUB_WORKSPACE
+            chown: "runner:runner"
+          - src: /mnt/runner-home
+            target: /home/runner/.cache
+            chown: "runner:runner"
+    - name: Free disk space
+      if: |
+        env.BUILD_TARGETS != ''
+        && github.event.repository.private
+      uses: envoyproxy/toolshed/gh-actions/diskspace@actions-v0.3.31
+      with:
+        to_remove: |
+          /usr/local/.ghcup
+          /usr/local/lib/android
+
     - name: Checkout repository
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
-    - name: Free disk space
-      uses: envoyproxy/toolshed/gh-actions/diskspace@actions-v0.3.31
-
-    # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@e12f0178983d466f2f6028f5cc7a6d786fd97f4b  # codeql-bundle-v4.31.4
-      # Override language selection by uncommenting this and choosing your languages
       with:
         languages: cpp
         trap-caching: false
@@ -45,15 +62,14 @@ jobs:
       run: |
        sudo apt-get update --error-on=any
        sudo apt-get install --yes \
-           libtool libtinfo5 cmake automake autoconf make ninja-build curl unzip \
-           virtualenv openjdk-11-jdk build-essential libc++1
+           libtool libtinfo5 automake autoconf curl unzip
        # Note: the llvm/clang version should match the version specifed in:
        #  - bazel/repository_locations.bzl
        #  - .github/workflows/codeql-push.yml
        #  - https://github.com/envoyproxy/envoy-build-tools/blob/main/build_container/build_container_ubuntu.sh#L84
        mkdir -p bin/clang18.1.8
        cd bin/clang18.1.8
-       wget https://github.com/llvm/llvm-project/releases/download/llvmorg-18.1.8/clang+llvm-18.1.8-x86_64-linux-gnu-ubuntu-18.04.tar.xz
+       wget -q https://github.com/llvm/llvm-project/releases/download/llvmorg-18.1.8/clang+llvm-18.1.8-x86_64-linux-gnu-ubuntu-18.04.tar.xz
        tar -xf clang+llvm-18.1.8-x86_64-linux-gnu-ubuntu-18.04.tar.xz --strip-components 1
 
     - name: Build
@@ -66,7 +82,7 @@ jobs:
            --discard_analysis_cache \
            --nouse_action_cache \
            --features="-layering_check" \
-           --config=clang \
+           --config=clang-local \
            --config=ci \
            //source/common/http/...
 
@@ -76,5 +92,3 @@ jobs:
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@e12f0178983d466f2f6028f5cc7a6d786fd97f4b  # codeql-bundle-v4.31.4
-      with:
-        trap-caching: false

--- a/.github/workflows/codeql-push.yml
+++ b/.github/workflows/codeql-push.yml
@@ -33,6 +33,27 @@ jobs:
     runs-on: ubuntu-22.04
     if: github.repository == 'envoyproxy/envoy'
     steps:
+    - uses: envoyproxy/toolshed/gh-actions/bind-mounts@actions-v0.3.31
+      if: |
+        ! github.event.repository.private
+      with:
+        mounts: |
+          - src: /mnt/workspace
+            target: GITHUB_WORKSPACE
+            chown: "runner:runner"
+          - src: /mnt/runner-cache
+            target: /home/runner/.cache
+            chown: "runner:runner"
+    - name: Free disk space
+      if: |
+        env.BUILD_TARGETS != ''
+        && github.event.repository.private
+      uses: envoyproxy/toolshed/gh-actions/diskspace@actions-v0.3.31
+      with:
+        to_remove: |
+          /usr/local/.ghcup
+          /usr/local/lib/android
+
     - name: Checkout repository
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       with:
@@ -61,57 +82,52 @@ jobs:
       env:
         GIT_EVENT: ${{ github.event_name }}
 
-    - name: Free disk space
-      if: ${{ env.BUILD_TARGETS != '' }}
-      uses: envoyproxy/toolshed/gh-actions/diskspace@actions-v0.3.31
+    - name: Set default build target
+      if: ${{ env.BUILD_TARGETS == '' }}
+      run: |
+        echo "MINIMAL_BUILD_TARGET=//source/common/common:assert_lib" > $GITHUB_ENV
 
     - name: Initialize CodeQL
-      if: ${{ env.BUILD_TARGETS != '' }}
       uses: github/codeql-action/init@e12f0178983d466f2f6028f5cc7a6d786fd97f4b  # codeql-bundle-v4.31.4
       with:
         languages: cpp
         trap-caching: false
 
     - name: Install deps
-      if: ${{ env.BUILD_TARGETS != '' }}
       shell: bash
       run: |
-       sudo apt-get update --error-on=any
-       sudo apt-get install --yes \
-           libtool libtinfo5 cmake automake autoconf make ninja-build curl \
-           unzip virtualenv openjdk-11-jdk build-essential libc++1
+       sudo apt-get -qq update --error-on=any
+       sudo apt-get -qq install --yes \
+           libtool libtinfo5 automake autoconf curl unzip
        # Note: the llvm/clang version should match the version specifed in:
        #  - bazel/repository_locations.bzl
        #  - .github/workflows/codeql-daily.yml
        #  - https://github.com/envoyproxy/envoy-build-tools/blob/main/build_container/build_container_ubuntu.sh#L84
        mkdir -p bin/clang18.1.8
        cd bin/clang18.1.8
-       wget https://github.com/llvm/llvm-project/releases/download/llvmorg-18.1.8/clang+llvm-18.1.8-x86_64-linux-gnu-ubuntu-18.04.tar.xz
+       wget -q https://github.com/llvm/llvm-project/releases/download/llvmorg-18.1.8/clang+llvm-18.1.8-x86_64-linux-gnu-ubuntu-18.04.tar.xz
        tar -xf clang+llvm-18.1.8-x86_64-linux-gnu-ubuntu-18.04.tar.xz --strip-components 1
 
     - name: Build
-      if: ${{ env.BUILD_TARGETS != '' }}
       run: |
-       bazel/setup_clang.sh "$(realpath bin/clang18.1.8)"
-       bazel shutdown
-       bazel build \
-           -c fastbuild \
-           --spawn_strategy=local \
-           --discard_analysis_cache \
-           --nouse_action_cache \
-           --features="-layering_check" \
-           --config=clang \
-           --config=ci \
-           $BUILD_TARGETS
-       echo -e "Built targets...\n$BUILD_TARGETS"
+        bazel/setup_clang.sh "$(realpath bin/clang18.1.8)"
+        PATH=$(bin/clang18.1.8/bin/llvm-config --bindir):$local_clang:$PATH
+        bazel shutdown
+        bazel build \
+            -c fastbuild \
+            --spawn_strategy=local \
+            --discard_analysis_cache \
+            --nouse_action_cache \
+            --features="-layering_check" \
+            --config=clang-local \
+            --config=ci \
+            ${BUILD_TARGETS:-${MINIMAL_BUILD_TARGET}}
+        echo -e "Built targets...\n${BUILD_TARGETS:-${MINIMAL_BUILD_TARGET}}"
 
     - name: Clean Artifacts
-      if: ${{ env.BUILD_TARGETS != '' }}
       run: |
         git clean -xdf
 
     - name: Perform CodeQL Analysis
-      if: ${{ env.BUILD_TARGETS != '' }}
+      # if: ${{ env.BUILD_TARGETS != '' }}
       uses: github/codeql-action/analyze@e12f0178983d466f2f6028f5cc7a6d786fd97f4b  # codeql-bundle-v4.31.4
-      with:
-        trap-caching: false

--- a/bazel/setup_clang.sh
+++ b/bazel/setup_clang.sh
@@ -15,13 +15,16 @@ fi
 LLVM_VERSION="$("${LLVM_CONFIG}" --version)"
 LLVM_LIBDIR="$("${LLVM_CONFIG}" --libdir)"
 LLVM_TARGET="$("${LLVM_CONFIG}" --host-target)"
-PATH="$("${LLVM_CONFIG}" --bindir):${PATH}"
+LLVM_BINDIR=$("${LLVM_CONFIG}" --bindir)
+PATH="$LLVM_BINDIR:${PATH}"
 
 RT_LIBRARY_PATH="${LLVM_LIBDIR}/clang/${LLVM_VERSION}/lib/${LLVM_TARGET}"
 
 cat <<EOF > "${BAZELRC_FILE}"
 # Generated file, do not edit. If you want to disable clang, just delete this file.
 build:clang --host_action_env=PATH=${PATH} --action_env=PATH=${PATH}
+build:clang --host_action_env=CC="${LLVM_BINDIR}/clang" --action_env=CC="${LLVM_BINDIR}/clang"
+build:clang --host_action_env=CXX="${LLVM_BINDIR}/clang++" --action_env=CC="${LLVM_BINDIR}/clang++"
 build:clang --define="LLVM_DIRECTORY=${LLVM_PREFIX}"
 build:clang --action_env="LLVM_DIRECTORY=${LLVM_PREFIX}"
 


### PR DESCRIPTION
- resolve diskspace issues
- fix for locally installed llvm
- ensure codeql always runs with a minimal test
- assorted codeql cleanups

switching on imcompatible_cc_toolchain_resolution has meant that setting PATH in bazel/setup_clang.sh (ie in bazelrc) no longer works - it will pick up any clang it can find in PATH - this hardcodes the configured path to ensure the correct compiler is used
