### PR TITLE
bazel/rc: Add a (temp) clang-local target

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -124,6 +124,10 @@ common:clang --config=clang-common
 common:clang --config=libc++
 common:clang --host_platform=@clang_platform
 
+# Clang installed to non-standard location (ie not /opt/llvm/)
+common:clang --config=clang-common
+common:clang --config=libc++
+
 # Use gold linker for gcc compiler.
 build:gcc --config=libstdc++
 build:gcc --test_env=HEAPCHECK=


### PR DESCRIPTION
currently if you build using llvm installed in a non-standard place it breaks expecting /opt/llvm/bin/clang

this provides a new config `--config=clang-local` that worksaround the issue

this is a temporary workaround until the switchover to hermetic toolchains

