### PR TITLE
Set envoy_reloadable_features_http2_use_oghttp2=false by default

### DIFF
--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -196,7 +196,7 @@ FALSE_RUNTIME_GUARD(envoy_reloadable_features_fixed_heap_use_allocated);
 // TODO(yavlasov): Enabling by default will be hugely disruptive to existing traffic.
 // Replace with a config option (default off) post CVE release.
 FALSE_RUNTIME_GUARD(envoy_reloadable_features_reject_early_connect_data);
-// TODO: Flip back to true once performance aligns with nghttp2 and
+// Flip back to true once performance aligns with nghttp2 and
 // https://github.com/envoyproxy/envoy/issues/40070 is resolved.
 FALSE_RUNTIME_GUARD(envoy_reloadable_features_http2_use_oghttp2);
 


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Disables oghttp2 by default due to regressions vs nghttp2
Additional Description:
Risk Level:
Testing: Yes
Docs Changes: No
Release Notes: Changes the default value of envoy.reloadable_features.http2_use_oghttp2 to false. This changes the codec used for HTTP/2 requests and responses. Once issue 40070 is resolved this will be re-enabled in a future version.
Platform Specific Features:

xRef: https://github.com/envoyproxy/envoy/issues/40070