### PR TITLE
distribution/docker: Install tzdata

### DIFF
--- a/distribution/docker/Dockerfile-envoy
+++ b/distribution/docker/Dockerfile-envoy
@@ -29,7 +29,7 @@ RUN --mount=type=tmpfs,target=/var/cache/apt \
     --mount=type=tmpfs,target=/var/lib/apt/lists \
     apt-get -qq update \
     && apt-get -qq upgrade -y \
-    && apt-get -qq install --no-install-recommends -y ca-certificates \
+    && apt-get -qq install --no-install-recommends -y ca-certificates tzdata \
     && apt-get -qq autoremove -y
 
 


### PR DESCRIPTION
So that `%START_TIME_LOCAL%` works in the logs.

Fixes: #42313
