### PR TITLE
bazel/liburing: Patch Makefile to avoid hard coding absolute path

### DIFF
--- a/bazel/foreign_cc/BUILD
+++ b/bazel/foreign_cc/BUILD
@@ -28,11 +28,10 @@ config_setting(
 configure_make(
     name = "liburing",
     configure_in_place = True,
-    env = select({
+    env = {"ENABLE_SHARED": "0"} | select({
         "//bazel:clang_build": {
-            "AR": "$$EXT_BUILD_ROOT/$(AR)",
-            "LD": "$$EXT_BUILD_ROOT/$(LD)",
-            "RANLIB": "$$EXT_BUILD_ROOT/$(AR) -s",
+            "AR": "$(AR)",
+            "RANLIB": "$(AR) -s",
         },
         "//conditions:default": {},
     }),
@@ -41,10 +40,7 @@ configure_make(
         "nocompdb",
         "skip_on_windows",
     ],
-    targets = [
-        "library",
-        "install",
-    ],
+    targets = ["install"],
 )
 
 envoy_cc_library(

--- a/bazel/foreign_cc/liburing.patch
+++ b/bazel/foreign_cc/liburing.patch
@@ -1,0 +1,36 @@
+diff --git a/src/Makefile b/src/Makefile
+index 8f89701a..65439c2f 100644
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -44,6 +44,22 @@ else
+ endif
+ LINK_FLAGS+=$(LDFLAGS)
+ 
++AR ?= ar
++RANLIB ?= ranlib
++
++ifdef EXT_BUILD_ROOT
++    ifneq ($(findstring /,$(AR)),)
++        ifeq ($(filter /%,$(AR)),)
++            AR := $(EXT_BUILD_ROOT)/$(AR)
++        endif
++    endif
++    ifneq ($(findstring /,$(RANLIB)),)
++        ifeq ($(filter /%,$(RANLIB)),)
++            RANLIB := $(EXT_BUILD_ROOT)/$(RANLIB)
++        endif
++    endif
++endif
++
+ all: $(all_targets)
+ 
+ liburing_srcs := setup.c queue.c register.c syscall.c version.c
+@@ -78,8 +94,6 @@ liburing_ffi_sobjs := ffi.os
+ -include $(liburing_objs:%=%.d)
+ -include $(liburing_sobjs:%=%.d)
+ 
+-AR ?= ar
+-RANLIB ?= ranlib
+ liburing.a: $(liburing_objs)
+ 	@rm -f liburing.a
+ 	$(QUIET_AR)$(AR) r liburing.a $^

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -301,6 +301,8 @@ def _com_github_axboe_liburing():
     external_http_archive(
         name = "com_github_axboe_liburing",
         build_file_content = BUILD_ALL_CONTENT,
+        patch_args = ["-p1"],
+        patches = ["@envoy//bazel/foreign_cc:liburing.patch"],
     )
 
 def _com_github_bazel_buildtools():


### PR DESCRIPTION
this fixes (for liburing) an issue where `toolchain_root` is set and the toolpaths are already absolute

patch can probably be removed once #42396 is resolved