### PR TITLE
[bp/1.35] tcp_proxy: fixes a cx leak in the TCP Proxy when receive_before_conne…

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -13,6 +13,10 @@ minor_behavior_changes:
 
 bug_fixes:
 # *Changes expected to improve the state of the world and are unlikely to have negative effects*
+- area: tcp_proxy
+  change: |
+    Fixed a connection leak in the TCP proxy when the ``receive_before_connect`` feature is enabled and the
+    downstream connection closes before the upstream connection is established.
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/source/common/tcp_proxy/tcp_proxy.cc
+++ b/source/common/tcp_proxy/tcp_proxy.cc
@@ -1006,9 +1006,9 @@ void Filter::onConnectMaxAttempts() {
 void Filter::onUpstreamConnection() {
   connecting_ = false;
 
-  // If we have received any data before upstream connection is established, send it to
-  // the upstream connection.
-  if (early_data_buffer_.length() > 0) {
+  // If we have received any data before upstream connection is established, or if the downstream
+  // has indicated end of stream, send the data and/or end_stream to the upstream connection.
+  if (early_data_buffer_.length() > 0 || early_data_end_stream_) {
     // Early data should only happen when receive_before_connect is enabled.
     ASSERT(receive_before_connect_);
 
@@ -1021,7 +1021,7 @@ void Filter::onUpstreamConnection() {
     // Re-enable downstream reads now that the early data buffer is flushed.
     read_callbacks_->connection().readDisable(false);
   } else if (!receive_before_connect_) {
-    // Re-enable downstream reads now that the upstream connection is established
+    // Re-enable downstream reads now that the upstream connection is established.
     read_callbacks_->connection().readDisable(false);
   }
 

--- a/test/common/tcp_proxy/tcp_proxy_test.cc
+++ b/test/common/tcp_proxy/tcp_proxy_test.cc
@@ -797,6 +797,43 @@ TEST_P(TcpProxyTest, ReceiveBeforeConnectEarlyDataWithEndStream) {
   upstream_callbacks_->onUpstreamData(response, false);
 }
 
+// Test that when downstream closes without sending any data before upstream connection is
+// established, the end_stream signal is properly propagated to upstream.
+// This prevents upstream connection leaks.
+TEST_P(TcpProxyTest, ReceiveBeforeConnectDownstreamClosesWithoutData) {
+  setup(/*connections=*/1, /*set_redirect_records=*/false, /*receive_before_connect=*/true);
+
+  // Downstream closes without sending any data.
+  Buffer::OwnedImpl empty_buffer;
+  EXPECT_CALL(*upstream_connections_.at(0), write(_, _)).Times(0);
+  filter_->onData(empty_buffer, /*end_stream=*/true);
+
+  // When upstream connection is established, the end_stream signal should be sent even though
+  // the buffer is empty. This ensures the upstream connection is properly closed.
+  EXPECT_CALL(*upstream_connections_.at(0), write(BufferStringEqual(""), /*end_stream*/ true));
+  raiseEventUpstreamConnected(/*conn_index=*/0);
+}
+
+// Test that when downstream sends empty buffer with end_stream before upstream is connected,
+// the end_stream is properly handled.
+TEST_P(TcpProxyTest, ReceiveBeforeConnectEmptyBufferWithEndStream) {
+  setup(/*connections=*/1, /*set_redirect_records=*/false, /*receive_before_connect=*/true);
+
+  // Downstream sends empty data with end_stream set.
+  Buffer::OwnedImpl empty_buffer;
+  EXPECT_CALL(*upstream_connections_.at(0), write(_, _)).Times(0);
+  filter_->onData(empty_buffer, /*end_stream=*/true);
+
+  // When upstream connection is established, end_stream should be propagated.
+  EXPECT_CALL(*upstream_connections_.at(0), write(BufferStringEqual(""), /*end_stream*/ true));
+  raiseEventUpstreamConnected(/*conn_index=*/0);
+
+  // Upstream can still send data back.
+  Buffer::OwnedImpl response("response data");
+  EXPECT_CALL(filter_callbacks_.connection_, write(BufferEqual(&response), _));
+  upstream_callbacks_->onUpstreamData(response, false);
+}
+
 TEST_P(TcpProxyTest, ReceiveBeforeConnectNoEarlyData) {
   setup(1, /*set_redirect_records=*/false, /*receive_before_connect=*/true);
   raiseEventUpstreamConnected(/*conn_index=*/0, /*expect_read_enable=*/false);


### PR DESCRIPTION
backport (#42024)

