### PR TITLE
[bp/1.36] tcp_proxy: fixes a cx leak in the TCP Proxy when receive_before_conne…

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -18,6 +18,10 @@ bug_fixes:
     Fixed an issue where the custom
     :ref:`header_prefix <envoy_v3_api_field_config.bootstrap.v3.Bootstrap.header_prefix>`
     will result in crash at startup.
+- area: tcp_proxy
+  change: |
+    Fixed a connection leak in the TCP proxy when the ``receive_before_connect`` feature is enabled and the
+    downstream connection closes before the upstream connection is established.
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/source/common/tcp_proxy/tcp_proxy.cc
+++ b/source/common/tcp_proxy/tcp_proxy.cc
@@ -1131,9 +1131,9 @@ void Filter::onConnectMaxAttempts() {
 void Filter::onUpstreamConnection() {
   connecting_ = false;
 
-  // If we have received any data before upstream connection is established, send it to
-  // the upstream connection.
-  if (early_data_buffer_.length() > 0) {
+  // If we have received any data before upstream connection is established, or if the downstream
+  // has indicated end of stream, send the data and/or end_stream to the upstream connection.
+  if (early_data_buffer_.length() > 0 || early_data_end_stream_) {
     // Early data should only happen when receive_before_connect is enabled.
     ASSERT(receive_before_connect_);
 
@@ -1146,7 +1146,7 @@ void Filter::onUpstreamConnection() {
     // Re-enable downstream reads now that the early data buffer is flushed.
     read_callbacks_->connection().readDisable(false);
   } else if (!receive_before_connect_) {
-    // Re-enable downstream reads now that the upstream connection is established
+    // Re-enable downstream reads now that the upstream connection is established.
     read_callbacks_->connection().readDisable(false);
   }
 


### PR DESCRIPTION
Backport (#42024)

