### PR TITLE
ext_authz: add an option to prevent upstream cx from getting established before authz completes

### DIFF
--- a/api/envoy/extensions/filters/network/ext_authz/v3/ext_authz.proto
+++ b/api/envoy/extensions/filters/network/ext_authz/v3/ext_authz.proto
@@ -25,7 +25,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // gRPC Authorization API defined by
 // :ref:`CheckRequest <envoy_v3_api_msg_service.auth.v3.CheckRequest>`.
 // A failed check will cause this filter to close the TCP connection.
-// [#next-free-field: 12]
+// [#next-free-field: 13]
 message ExtAuthz {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.network.ext_authz.v2.ExtAuthz";
@@ -100,4 +100,58 @@ message ExtAuthz {
   // the protobuf message definition in order to perform safe parsing.
   //
   repeated string typed_metadata_context_namespaces = 11;
+
+  // If set to ``true``, the filter will invoke the authorization check when the downstream transport
+  // socket is ready (e.g., after the TLS handshake completes for TLS connections). This ensures
+  // that connection information such as X.509 certificates and negotiated TLS parameters are
+  // available for the authorization service.
+  //
+  // When enabled, the filter pauses the filter chain initialization. After the transport socket
+  // raises a ``Connected`` event and authorization completes successfully, the filter would resume
+  // the filter chain. This prevents downstream filters (such as
+  // :ref:`tcp_proxy <config_network_filters_tcp_proxy>`) from establishing upstream connections
+  // before authorization completes.
+  //
+  // For raw TCP connections that do not raise a ``Connected`` event, the filter automatically
+  // falls back to invoking the authorization check when the first data byte arrives.
+  //
+  // When using this option with the :ref:`tcp_proxy <config_network_filters_tcp_proxy>` filter,
+  // configure one of the following to ensure upstream connections are not established before
+  // authorization completes:
+  //
+  // * Set :ref:`upstream_connect_mode
+  //   <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.upstream_connect_mode>`
+  //   to ``ON_DOWNSTREAM_DATA`` or ``ON_DOWNSTREAM_TLS_HANDSHAKE``.
+  // * Set :ref:`max_early_data_bytes
+  //   <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.max_early_data_bytes>`.
+  //
+  // Example configuration:
+  //
+  // .. code-block:: yaml
+  //
+  //    filter_chains:
+  //    - filters:
+  //      - name: envoy.filters.network.ext_authz
+  //        typed_config:
+  //          "@type": type.googleapis.com/envoy.extensions.filters.network.ext_authz.v3.ExtAuthz
+  //          stat_prefix: ext_authz
+  //          check_on_transport_ready: true
+  //          grpc_service:
+  //            envoy_grpc:
+  //              cluster_name: ext_authz_server
+  //      - name: envoy.filters.network.tcp_proxy
+  //        typed_config:
+  //          "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+  //          stat_prefix: tcp
+  //          cluster: backend
+  //          upstream_connect_mode: ON_DOWNSTREAM_TLS_HANDSHAKE
+  //
+  // .. attention::
+  //
+  //    Server-first protocols (e.g., SMTP, MySQL, POP3) require immediate upstream connection
+  //    establishment. Do not use this option with server-first protocols as the upstream server
+  //    needs to send data before receiving any data from the client.
+  //
+  // Defaults to ``false``.
+  bool check_on_transport_ready = 12;
 }

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -217,6 +217,13 @@ removed_config_or_runtime:
     Removed runtime guard ``envoy.reloadable_features.report_load_with_rq_issued`` and legacy code paths.
 
 new_features:
+- area: ext_authz
+  change: |
+    Added :ref:`check_on_transport_ready
+    <envoy_v3_api_field_extensions.filters.network.ext_authz.v3.ExtAuthz.check_on_transport_ready>`
+    option to the network ext_authz filter. When enabled, the authorization check is invoked when
+    the transport socket is ready. It would prevent upstream connection from getting established
+    before authorization completes.
 - area: dynamic modules
   change: |
     Added support for loading dynamic modules globally by setting :ref:`load_globally

--- a/source/extensions/filters/network/ext_authz/BUILD
+++ b/source/extensions/filters/network/ext_authz/BUILD
@@ -24,6 +24,8 @@ envoy_cc_library(
         "//envoy/upstream:cluster_manager_interface",
         "//source/common/common:assert_lib",
         "//source/common/common:matchers_lib",
+        "//source/common/stream_info:bool_accessor_lib",
+        "//source/common/tcp_proxy",
         "//source/common/tls:connection_info_impl_base_lib",
         "//source/common/tracing:http_tracer_lib",
         "//source/extensions/filters/common/ext_authz:ext_authz_grpc_lib",

--- a/test/extensions/filters/network/ext_authz/BUILD
+++ b/test/extensions/filters/network/ext_authz/BUILD
@@ -25,6 +25,8 @@ envoy_extension_cc_test(
         "//source/common/network:address_lib",
         "//source/common/protobuf:utility_lib",
         "//source/common/stats:stats_lib",
+        "//source/common/stream_info:bool_accessor_lib",
+        "//source/common/tcp_proxy",
         "//source/extensions/filters/network:well_known_names",
         "//source/extensions/filters/network/ext_authz",
         "//test/extensions/filters/common/ext_authz:ext_authz_mocks",


### PR DESCRIPTION
## Description

This PR adds a new option to Network ExtAuthZ filter called `check_on_transport_ready` to prevent upstream connections from getting established before authorization completes.

There were several past attempts on this but we wanted a common solution for both RBAC and ExtAuthZ and the feature to put TCP Proxy in a different mode did not exist. Now since the PR to introduce `upstream_connect_mode` is already merged, this is part of the changes for blocking connectivity in network ExtAuthZ filter.

**Previous Attempt:** https://github.com/envoyproxy/envoy/pull/40827

---

**Commit Message:** ext_authz: add an option to prevent upstream cx from getting established before authz completes
**Additional Description:** Adds a new option to Network ExtAuthZ filter called `check_on_transport_ready` to prevent upstream connections from getting established before authorization completes.
**Risk Level:** Low
**Testing:** Added Unit + Integration Tests
**Docs Changes:** Added
**Release Notes:** Added