### PR TITLE
rbac: add an option to prevent upstream cx from getting established before enforcement completes

### DIFF
--- a/api/envoy/extensions/filters/network/rbac/v3/rbac.proto
+++ b/api/envoy/extensions/filters/network/rbac/v3/rbac.proto
@@ -27,7 +27,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 //
 // Header should not be used in rules/shadow_rules in RBAC network filter as
 // this information is only available in :ref:`RBAC http filter <config_http_filters_rbac>`.
-// [#next-free-field: 9]
+// [#next-free-field: 10]
 message RBAC {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.network.rbac.v2.RBAC";
@@ -90,4 +90,64 @@ message RBAC {
   // This is useful to provide a better protection for Envoy against clients that retries
   // aggressively when the connection is rejected by the RBAC filter.
   google.protobuf.Duration delay_deny = 8;
+
+  // If set to ``true``, the RBAC filter will do the enforcement when the downstream transport
+  // socket is ready (e.g., after the TLS handshake completes for TLS connections). This ensures
+  // that connection information such as X509 certificates and negotiated TLS parameters are
+  // available for authorization decisions.
+  //
+  // When enabled, the filter pauses the filter chain initialization. After the transport socket
+  // raises a ``Connected`` event and authorization completes successfully, the filter resumes the
+  // filter chain. This prevents downstream filters (such as
+  // :ref:`tcp_proxy <config_network_filters_tcp_proxy>`) from establishing upstream connections
+  // before authorization completes.
+  //
+  // For raw TCP connections that do not raise a ``Connected`` event, the filter automatically
+  // falls back to enforcing authorization when the first data byte arrives.
+  //
+  // When using this option with the :ref:`tcp_proxy <config_network_filters_tcp_proxy>` filter,
+  // configure one of the following to ensure upstream connections are not established before
+  // authorization completes:
+  //
+  // * Set :ref:`upstream_connect_mode
+  //   <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.upstream_connect_mode>`
+  //   to ``ON_DOWNSTREAM_DATA`` or ``ON_DOWNSTREAM_TLS_HANDSHAKE``.
+  // * Set :ref:`max_early_data_bytes
+  //   <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.max_early_data_bytes>`.
+  //
+  // Example configuration:
+  //
+  // .. code-block:: yaml
+  //
+  //    filter_chains:
+  //    - filters:
+  //      - name: envoy.filters.network.rbac
+  //        typed_config:
+  //          "@type": type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC
+  //          stat_prefix: tcp.
+  //          enforce_on_transport_ready: true
+  //          rules:
+  //            policies:
+  //              "require-mtls-client":
+  //                permissions:
+  //                  - any: true
+  //                principals:
+  //                  - authenticated:
+  //                      principal_name:
+  //                        exact: "spiffe://cluster.local/ns/default/sa/frontend"
+  //      - name: envoy.filters.network.tcp_proxy
+  //        typed_config:
+  //          "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+  //          stat_prefix: tcp
+  //          cluster: backend
+  //          upstream_connect_mode: ON_DOWNSTREAM_TLS_HANDSHAKE
+  //
+  // .. attention::
+  //
+  //    Server-first protocols (e.g., SMTP, MySQL, POP3) require immediate upstream connection
+  //    establishment. Do not use this option with server-first protocols as the upstream server
+  //    needs to send data before receiving any data from the client.
+  //
+  // Defaults to ``false``.
+  bool enforce_on_transport_ready = 9;
 }

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -217,6 +217,12 @@ removed_config_or_runtime:
     Removed runtime guard ``envoy.reloadable_features.report_load_with_rq_issued`` and legacy code paths.
 
 new_features:
+- area: rbac
+  change: |
+    Added :ref:`enforce_on_transport_ready
+    <envoy_v3_api_field_extensions.filters.network.rbac.v3.RBAC.enforce_on_transport_ready>`
+    option to the RBAC network filter. When enabled, authorization is performed when the transport
+    socket is ready. This prevents upstream connection establishment before authorization completes.
 - area: dynamic modules
   change: |
     Added support for loading dynamic modules globally by setting :ref:`load_globally

--- a/source/extensions/filters/network/rbac/BUILD
+++ b/source/extensions/filters/network/rbac/BUILD
@@ -33,6 +33,8 @@ envoy_cc_library(
         "//envoy/network:connection_interface",
         "//envoy/network:filter_interface",
         "//source/common/common:minimal_logger_lib",
+        "//source/common/stream_info:bool_accessor_lib",
+        "//source/common/tcp_proxy",
         "//source/extensions/filters/common/rbac:engine_lib",
         "//source/extensions/filters/common/rbac:utility_lib",
         "//source/extensions/filters/network:well_known_names",

--- a/source/extensions/filters/network/rbac/rbac_filter.h
+++ b/source/extensions/filters/network/rbac/rbac_filter.h
@@ -61,6 +61,8 @@ public:
 
   std::chrono::milliseconds delayDenyMs() const { return delay_deny_ms_; }
 
+  bool enforceOnTransportReady() const { return enforce_on_transport_ready_; }
+
 private:
   Filters::Common::RBAC::RoleBasedAccessControlFilterStats stats_;
   const std::string shadow_rules_stat_prefix_;
@@ -70,6 +72,7 @@ private:
   std::unique_ptr<const Filters::Common::RBAC::RoleBasedAccessControlEngine> shadow_engine_;
   const envoy::extensions::filters::network::rbac::v3::RBAC::EnforcementType enforcement_type_;
   std::chrono::milliseconds delay_deny_ms_;
+  const bool enforce_on_transport_ready_;
 };
 
 using RoleBasedAccessControlFilterConfigSharedPtr =
@@ -89,11 +92,8 @@ public:
 
   // Network::ReadFilter
   Network::FilterStatus onData(Buffer::Instance& data, bool end_stream) override;
-  Network::FilterStatus onNewConnection() override { return Network::FilterStatus::Continue; };
-  void initializeReadFilterCallbacks(Network::ReadFilterCallbacks& callbacks) override {
-    callbacks_ = &callbacks;
-    callbacks_->connection().addConnectionCallbacks(*this);
-  }
+  Network::FilterStatus onNewConnection() override;
+  void initializeReadFilterCallbacks(Network::ReadFilterCallbacks& callbacks) override;
 
   // Network::ConnectionCallbacks
   void onEvent(Network::ConnectionEvent event) override;
@@ -110,10 +110,19 @@ private:
   EngineResult shadow_engine_result_{Unknown};
 
   Result checkEngine(Filters::Common::RBAC::EnforcementMode mode) const;
+
+  // Runs authorization check and returns true if allowed, false if denied.
+  // On denial, connection is closed immediately or after delay.
+  bool runAuthorization();
+
   void closeConnection() const;
   void resetTimerState();
   Event::TimerPtr delay_timer_{nullptr};
   bool is_delay_denied_{false};
+
+  // When true, authorization would be pending and waiting for either the
+  // Connected event or onData fallback.
+  bool authorization_pending_{false};
 };
 
 } // namespace RBACFilter

--- a/test/extensions/filters/network/rbac/BUILD
+++ b/test/extensions/filters/network/rbac/BUILD
@@ -32,6 +32,8 @@ envoy_extension_cc_test(
     rbe_pool = "6gig",
     tags = ["skip_on_windows"],
     deps = [
+        "//source/common/stream_info:bool_accessor_lib",
+        "//source/common/tcp_proxy",
         "//source/extensions/filters/common/rbac:utility_lib",
         "//source/extensions/filters/network:well_known_names",
         "//source/extensions/filters/network/rbac:rbac_filter",


### PR DESCRIPTION
## Description

This PR adds a new option to Network RBAC filter called `enforce_on_transport_ready` to prevent upstream connections from getting established before RBAC enforcement completes.

There were several past attempts on this but we wanted a common solution for both RBAC and ExtAuthZ and the feature to put TCP Proxy in a different mode did not exist. Now since the PR to introduce `upstream_connect_mode` is already merged, this is part of the changes for blocking connectivity in network RBAC filter.

Fix https://github.com/envoyproxy/envoy/issues/9023

---

**Commit Message:** rbac: add an option to prevent upstream cx from getting established before enforcement completes
**Additional Description:** Adds a new option to Network RBAC filter called `enforce_on_transport_ready` to prevent upstream connections from getting established before RBAC enforcement completes.
**Risk Level:** Low
**Testing:** Added Unit + Integration Tests
**Docs Changes:** Added
**Release Notes:** Added