### PR TITLE
proto_api_scrubber: Implement message-level restrictions.

### DIFF
--- a/test/extensions/filters/http/proto_api_scrubber/BUILD
+++ b/test/extensions/filters/http/proto_api_scrubber/BUILD
@@ -71,7 +71,10 @@ envoy_cc_test(
     srcs = [
         "integration_test.cc",
     ],
-    data = ["//test/proto:apikeys_proto_descriptor"],
+    data = [
+        "//test/proto:apikeys_proto_descriptor",
+        "//test/proto:bookstore_proto_descriptor",
+    ],
     # Following attribute will be enabled once the filter is registered.
     # extension_names = ["envoy.filters.http.proto_api_scrubber"],
     rbe_pool = "6gig",
@@ -83,6 +86,7 @@ envoy_cc_test(
         "//test/extensions/filters/http/grpc_field_extraction/message_converter:message_converter_test_lib",
         "//test/integration:http_protocol_integration_lib",
         "//test/proto:apikeys_proto_cc_proto",
+        "//test/proto:bookstore_proto_cc_proto",
         "@com_google_absl//absl/strings:str_format",
         "@com_google_cel_cpp//parser",
         "@envoy_api//envoy/extensions/filters/http/proto_api_scrubber/v3:pkg_cc_proto",

--- a/test/extensions/filters/http/proto_api_scrubber/filter_test.cc
+++ b/test/extensions/filters/http/proto_api_scrubber/filter_test.cc
@@ -64,6 +64,8 @@ class MockProtoApiScrubberFilterConfig : public ProtoApiScrubberFilterConfig {
 public:
   MOCK_METHOD(MatchTreeHttpMatchingDataSharedPtr, getMethodMatcher,
               (const std::string& method_name), (const, override));
+  MOCK_METHOD(MatchTreeHttpMatchingDataSharedPtr, getMessageMatcher,
+              (const std::string& message_name), (const, override));
   MOCK_METHOD(MatchTreeHttpMatchingDataSharedPtr, getRequestFieldMatcher,
               (const std::string& method_name, const std::string& field_mask), (const, override));
   MOCK_METHOD(MatchTreeHttpMatchingDataSharedPtr, getResponseFieldMatcher,
@@ -95,6 +97,9 @@ public:
         });
     ON_CALL(*this, getMethodMatcher(_)).WillByDefault([this](const std::string& method_name) {
       return real_config_->getMethodMatcher(method_name);
+    });
+    ON_CALL(*this, getMessageMatcher(_)).WillByDefault([this](const std::string& message_name) {
+      return real_config_->getMessageMatcher(message_name);
     });
   }
 

--- a/test/extensions/filters/http/proto_api_scrubber/integration_test.cc
+++ b/test/extensions/filters/http/proto_api_scrubber/integration_test.cc
@@ -6,6 +6,7 @@
 #include "test/extensions/filters/http/grpc_field_extraction/message_converter/message_converter_test_lib.h"
 #include "test/integration/http_protocol_integration.h"
 #include "test/proto/apikeys.pb.h"
+#include "test/proto/bookstore.pb.h"
 
 #include "cel/expr/syntax.pb.h"
 #include "fmt/format.h"
@@ -27,8 +28,12 @@ using ::Envoy::Extensions::HttpFilters::GrpcFieldExtraction::checkSerializedData
 std::string apikeysDescriptorPath() {
   return TestEnvironment::runfilesPath("test/proto/apikeys.descriptor");
 }
+std::string bookstoreDescriptorPath() {
+  return TestEnvironment::runfilesPath("test/proto/bookstore.descriptor");
+}
 
 const std::string kCreateApiKeyMethod = "/apikeys.ApiKeys/CreateApiKey";
+const std::string kCreateShelfMethod = "/bookstore.Bookstore/CreateShelf";
 
 class ProtoApiScrubberIntegrationTest : public HttpProtocolIntegrationTest {
 public:
@@ -64,63 +69,73 @@ public:
     return predicate;
   }
 
-  // Helper to build the configuration with a generic predicate.
+  xds::type::matcher::v3::Matcher
+  buildMatcher(const xds::type::matcher::v3::Matcher::MatcherList::Predicate& match_predicate) {
+    xds::type::matcher::v3::Matcher matcher_proto;
+    auto* matcher_entry = matcher_proto.mutable_matcher_list()->add_matchers();
+    *matcher_entry->mutable_predicate() = match_predicate;
+    envoy::extensions::filters::http::proto_api_scrubber::v3::RemoveFieldAction remove_action;
+    matcher_entry->mutable_on_match()->mutable_action()->mutable_typed_config()->PackFrom(
+        remove_action);
+    matcher_entry->mutable_on_match()->mutable_action()->set_name("remove_field");
+    return matcher_proto;
+  }
+
+  // Helper to build the configuration for field-level restrictions.
   std::string
   getFilterConfig(const std::string& descriptor_path, const std::string& method_name = "",
                   const std::string& field_to_scrub = "",
                   RestrictionType type = RestrictionType::Request,
                   const xds::type::matcher::v3::Matcher::MatcherList::Predicate& match_predicate =
                       buildCelPredicate("true")) {
-    std::string full_config_text;
-    if (method_name.empty() || field_to_scrub.empty()) {
-      full_config_text = fmt::format(R"pb(
-      filtering_mode: OVERRIDE
-      descriptor_set {{ data_source {{ filename: "{0}" }} }}
-    )pb",
-                                     descriptor_path);
-    } else {
+    ProtoApiScrubberConfig filter_config_proto;
+    filter_config_proto.set_filtering_mode(ProtoApiScrubberConfig::OVERRIDE);
+    filter_config_proto.mutable_descriptor_set()->mutable_data_source()->set_filename(
+        descriptor_path);
+
+    if (!method_name.empty() && !field_to_scrub.empty()) {
       std::string restriction_key = (type == RestrictionType::Request)
                                         ? "request_field_restrictions"
                                         : "response_field_restrictions";
 
-      // Build the Matcher
-      xds::type::matcher::v3::Matcher matcher_proto;
-      auto* matcher_entry = matcher_proto.mutable_matcher_list()->add_matchers();
-      *matcher_entry->mutable_predicate() = match_predicate;
-      envoy::extensions::filters::http::proto_api_scrubber::v3::RemoveFieldAction remove_action;
-      matcher_entry->mutable_on_match()->mutable_action()->mutable_typed_config()->PackFrom(
-          remove_action);
-      matcher_entry->mutable_on_match()->mutable_action()->set_name("remove_field");
+      xds::type::matcher::v3::Matcher matcher_proto = buildMatcher(match_predicate);
 
-      full_config_text = fmt::format(R"pb(
-      filtering_mode: OVERRIDE
-      descriptor_set {{
-        data_source {{ filename: "{0}" }}
-      }}
-      restrictions {{
-        method_restrictions {{
-          key: "{1}"
-          value {{
-            {2} {{
-              key: "{3}"
-              value {{
-                matcher {{ {4} }}
-              }}
-            }}
-          }}
-        }}
-      }}
-    )pb",
-                                     descriptor_path,            // {0}
-                                     method_name,                // {1}
-                                     restriction_key,            // {2}
-                                     field_to_scrub,             // {3}
-                                     matcher_proto.DebugString() // {4} Inject the Generic Matcher
-      );
+      auto& method_restrictions =
+          (*filter_config_proto.mutable_restrictions()->mutable_method_restrictions())[method_name];
+      auto* field_map = (type == RestrictionType::Request)
+                            ? method_restrictions.mutable_request_field_restrictions()
+                            : method_restrictions.mutable_response_field_restrictions();
+      (*field_map)[field_to_scrub] =
+          envoy::extensions::filters::http::proto_api_scrubber::v3::RestrictionConfig();
+      *(*field_map)[field_to_scrub].mutable_matcher() = matcher_proto;
     }
 
+    Protobuf::Any any_config;
+    any_config.PackFrom(filter_config_proto);
+    return fmt::format(R"EOF(
+    name: envoy.filters.http.proto_api_scrubber
+    typed_config: {})EOF",
+                       MessageUtil::getJsonStringFromMessageOrError(any_config));
+  }
+
+  // Helper to build the configuration for message-level restrictions.
+  std::string getConfigWithMessageRestriction(
+      const std::string& descriptor_path, const std::string& message_name,
+      const xds::type::matcher::v3::Matcher::MatcherList::Predicate& match_predicate =
+          buildCelPredicate("true")) {
     ProtoApiScrubberConfig filter_config_proto;
-    Protobuf::TextFormat::ParseFromString(full_config_text, &filter_config_proto);
+    filter_config_proto.set_filtering_mode(ProtoApiScrubberConfig::OVERRIDE);
+    filter_config_proto.mutable_descriptor_set()->mutable_data_source()->set_filename(
+        descriptor_path);
+
+    if (!message_name.empty()) {
+      xds::type::matcher::v3::Matcher matcher_proto = buildMatcher(match_predicate);
+      auto& message_restrictions =
+          (*filter_config_proto.mutable_restrictions()->mutable_message_restrictions());
+      message_restrictions[message_name] =
+          envoy::extensions::filters::http::proto_api_scrubber::v3::MessageRestrictions();
+      *message_restrictions[message_name].mutable_config()->mutable_matcher() = matcher_proto;
+    }
 
     Protobuf::Any any_config;
     any_config.PackFrom(filter_config_proto);
@@ -158,6 +173,18 @@ apikeys::CreateApiKeyRequest makeCreateApiKeyRequest(absl::string_view pb = R"pb
   }
 )pb") {
   apikeys::CreateApiKeyRequest request;
+  Protobuf::TextFormat::ParseFromString(pb, &request);
+  return request;
+}
+
+bookstore::CreateShelfRequest makeCreateShelfRequest(absl::string_view pb = R"pb(
+  shelf {
+    id: 123
+    theme: "Duckie's Favorites"
+    internal_notes: "Ssshhh secret"
+  }
+)pb") {
+  bookstore::CreateShelfRequest request;
   Protobuf::TextFormat::ParseFromString(pb, &request);
   return request;
 }
@@ -222,7 +249,7 @@ TEST_P(ProtoApiScrubberIntegrationTest, StreamingPassesThrough) {
 }
 
 // ============================================================================
-// TEST GROUP 2: SCRUBBING LOGIC
+// TEST GROUP 2: FIELD-LEVEL SCRUBBING LOGIC
 // ============================================================================
 
 // Tests scrubbing of top level fields in the request when the corresponding matcher evaluates to
@@ -303,7 +330,146 @@ TEST_P(ProtoApiScrubberIntegrationTest, ScrubNestedField_MatcherFalse) {
 }
 
 // ============================================================================
-// TEST GROUP 3: VALIDATION & REJECTION
+// TEST GROUP 3: MESSAGE-LEVEL SCRUBBING LOGIC (CURRENT BEHAVIOR)
+// ============================================================================
+
+// Tests that message fields are NOT cleared when message-level restriction matches.
+// kExclude from CheckType currently only prevents field traversal.
+TEST_P(ProtoApiScrubberIntegrationTest, ScrubMessageLevel_MatcherTrue) {
+  config_helper_.prependFilter(getConfigWithMessageRestriction(
+      bookstoreDescriptorPath(), "bookstore.Shelf", buildCelPredicate("true")));
+  initialize();
+
+  auto original_proto = makeCreateShelfRequest(); // Contains id, theme, internal_notes
+
+  auto response = sendGrpcRequest(original_proto, kCreateShelfMethod);
+  waitForNextUpstreamRequest();
+
+  // EXPECTED BEHAVIOR (CURRENT LIMITATION): Message fields are NOT cleared.
+  bookstore::CreateShelfRequest expected = original_proto;
+
+  Buffer::OwnedImpl data;
+  data.add(upstream_request_->body());
+  checkSerializedData<bookstore::CreateShelfRequest>(data, {expected});
+
+  upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, true);
+  ASSERT_TRUE(response->waitForEndStream());
+}
+
+// Tests that a message is NOT scrubbed if the message-level restriction matcher is false.
+TEST_P(ProtoApiScrubberIntegrationTest, ScrubMessageLevel_MatcherFalse) {
+  config_helper_.prependFilter(getConfigWithMessageRestriction(
+      bookstoreDescriptorPath(), "bookstore.Shelf", buildCelPredicate("false")));
+  initialize();
+
+  auto original_proto = makeCreateShelfRequest();
+
+  auto response = sendGrpcRequest(original_proto, kCreateShelfMethod);
+  waitForNextUpstreamRequest();
+
+  Buffer::OwnedImpl data;
+  data.add(upstream_request_->body());
+  // No changes expected
+  checkSerializedData<bookstore::CreateShelfRequest>(data, {original_proto});
+
+  upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, true);
+  ASSERT_TRUE(response->waitForEndStream());
+}
+
+// Tests message-level restriction based on a request header.
+// kExclude from CheckType currently only prevents field traversal.
+TEST_P(ProtoApiScrubberIntegrationTest, ScrubMessageLevel_HeaderMatch) {
+  config_helper_.prependFilter(getConfigWithMessageRestriction(
+      bookstoreDescriptorPath(), "bookstore.Shelf",
+      buildCelPredicate("request.headers['x-scrub-shelf'] == 'true'")));
+  initialize();
+
+  auto original_proto = makeCreateShelfRequest();
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+  auto request_buf = Grpc::Common::serializeToGrpcFrame(original_proto);
+  auto request_headers = Http::TestRequestHeaderMapImpl{
+      {":method", "POST"},    {":path", kCreateShelfMethod}, {"content-type", "application/grpc"},
+      {":authority", "host"}, {":scheme", "http"},           {"x-scrub-shelf", "true"}};
+  auto response = codec_client_->makeRequestWithBody(request_headers, request_buf->toString());
+  waitForNextUpstreamRequest();
+
+  // EXPECTED BEHAVIOR (CURRENT LIMITATION): Message fields are NOT cleared.
+  bookstore::CreateShelfRequest expected = original_proto;
+
+  Buffer::OwnedImpl data;
+  data.add(upstream_request_->body());
+  checkSerializedData<bookstore::CreateShelfRequest>(data, {expected});
+
+  upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, true);
+  ASSERT_TRUE(response->waitForEndStream());
+}
+
+// Tests precedence: Message-level kExclude prevents field-level rules from being applied
+// because traversal into the message is stopped.
+TEST_P(ProtoApiScrubberIntegrationTest, MessageScrubPrecedence) {
+  // Config with both message and field level restrictions.
+  ProtoApiScrubberConfig filter_config_proto;
+  filter_config_proto.set_filtering_mode(ProtoApiScrubberConfig::OVERRIDE);
+  filter_config_proto.mutable_descriptor_set()->mutable_data_source()->set_filename(
+      bookstoreDescriptorPath());
+
+  // Message-level: Match bookstore.Shelf if header x-scrub-shelf is true.
+  xds::type::matcher::v3::Matcher msg_matcher =
+      buildMatcher(buildCelPredicate("request.headers['x-scrub-shelf'] == 'true'"));
+  auto& message_restrictions =
+      (*filter_config_proto.mutable_restrictions()->mutable_message_restrictions());
+  message_restrictions["bookstore.Shelf"] =
+      envoy::extensions::filters::http::proto_api_scrubber::v3::MessageRestrictions();
+  *message_restrictions["bookstore.Shelf"].mutable_config()->mutable_matcher() = msg_matcher;
+
+  // Field-level: Scrub shelf.internal_notes if header x-scrub-notes is true.
+  xds::type::matcher::v3::Matcher field_matcher =
+      buildMatcher(buildCelPredicate("request.headers['x-scrub-notes'] == 'true'"));
+  auto& method_restrictions = (*filter_config_proto.mutable_restrictions()
+                                    ->mutable_method_restrictions())[kCreateShelfMethod];
+  auto* field_map = method_restrictions.mutable_request_field_restrictions();
+  (*field_map)["shelf.internal_notes"] =
+      envoy::extensions::filters::http::proto_api_scrubber::v3::RestrictionConfig();
+  *(*field_map)["shelf.internal_notes"].mutable_matcher() = field_matcher;
+
+  Protobuf::Any any_config;
+  any_config.PackFrom(filter_config_proto);
+  config_helper_.prependFilter(
+      fmt::format(R"EOF(
+    name: envoy.filters.http.proto_api_scrubber
+    typed_config: {})EOF",
+                  MessageUtil::getJsonStringFromMessageOrError(any_config)));
+  initialize();
+
+  auto original_proto = makeCreateShelfRequest(); // Has id, theme, internal_notes
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+  auto request_buf = Grpc::Common::serializeToGrpcFrame(original_proto);
+  // Set headers to trigger BOTH matchers
+  auto request_headers = Http::TestRequestHeaderMapImpl{
+      {":method", "POST"},      {":path", kCreateShelfMethod}, {"content-type", "application/grpc"},
+      {":authority", "host"},   {":scheme", "http"},           {"x-scrub-shelf", "true"},
+      {"x-scrub-notes", "true"}};
+  auto response = codec_client_->makeRequestWithBody(request_headers, request_buf->toString());
+  waitForNextUpstreamRequest();
+
+  // EXPECTED BEHAVIOR (CURRENT LIMITATION):
+  // Message-level kExclude prevents field-level rules from running on shelf.* fields.
+  // So, shelf.internal_notes is NOT scrubbed, because CheckField is never called for it.
+  // The message itself is NOT cleared.
+  bookstore::CreateShelfRequest expected = original_proto;
+
+  Buffer::OwnedImpl data;
+  data.add(upstream_request_->body());
+  checkSerializedData<bookstore::CreateShelfRequest>(data, {expected});
+
+  upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, true);
+  ASSERT_TRUE(response->waitForEndStream());
+}
+
+// ============================================================================
+// TEST GROUP 4: VALIDATION & REJECTION
 // ============================================================================
 
 // Tests that the request is rejected if the called gRPC method doesn't exist in the descriptor


### PR DESCRIPTION
Commit Message: feat(proto_api_scrubber): add message-level restrictions

Additional Description:
This commit introduces the configuration and evaluation logic for message-level restrictions to the Proto API Scrubber, as outlined in the design document. The filter can now evaluate matcher rules defined against specific Protobuf message types.

When a message-level matcher evaluates to true for a given message type, FieldChecker::CheckType returns FieldCheckResults::kExclude. In the current version of the proto-processing-lib, this prevents the scrubber from descending into the fields of that message instance for any further field-level checks.

Known Limitation:
This implementation does not clear the fields of the message when the message-level rule matches and CheckType returns kExclude. The message remains intact, but its fields are not scrubbed. True message content clearing upon a message-level match will require enhancements in the upstream proto-processing-lib repository, which will be handled separately.

Risk Level:
Low. This adds new functionality and does not alter the existing field-level or method-level restriction behavior.

Testing:
Unit tests have been added in test/extensions/filters/http/proto_api_scrubber/scrubbing_util_lib/field_checker_test.cc to validate the behavior of FieldChecker::CheckType with different matcher outcomes.
Integration tests have been added in test/extensions/filters/http/proto_api_scrubber/integration_test.cc (e.g., ScrubMessageLevel_MatcherTrue, ScrubMessageLevel_HeaderMatch, MessageScrubPrecedence) to demonstrate the current end-to-end behavior of message-level restrictions, confirming that field traversal is halted but content is not cleared.

Docs Changes:
N/A (No documentation files were modified in this change).

Release Notes:
feat(proto_api_scrubber): Added support for message-level restrictions. Matchers can be configured against fully qualified message names. When a message-level matcher evaluates to true, field-level scrubbing is skipped for the fields within that message instance.

Platform Specific Features:
None.

[Optional Runtime guard:]
N/A

[Optional Fixes #Issue]
N/A

[Optional Fixes commit #PR or SHA]
N/A

[Optional Deprecated:]
N/A

[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):] 
N/A
