### PR TITLE
network: allow IP instance creation for unsupported IP families

### DIFF
--- a/contrib/vcl/source/config.cc
+++ b/contrib/vcl/source/config.cc
@@ -1,5 +1,6 @@
 #include "contrib/vcl/source/config.h"
 
+#include "absl/status/statusor.h"
 #include "contrib/envoy/extensions/vcl/v3alpha/vcl_socket_interface.pb.h"
 #include "contrib/vcl/source/vcl_interface.h"
 #include "contrib/vcl/source/vcl_io_handle.h"
@@ -21,7 +22,7 @@ ProtobufTypes::MessagePtr VclSocketInterface::createEmptyConfigProto() {
   return std::make_unique<envoy::extensions::vcl::v3alpha::VclSocketInterface>();
 }
 
-Envoy::Network::IoHandlePtr VclSocketInterface::socket(
+absl::StatusOr<Envoy::Network::IoHandlePtr> VclSocketInterface::socket(
     Envoy::Network::Socket::Type socket_type, Envoy::Network::Address::Type addr_type,
     Envoy::Network::Address::IpVersion, bool, const Envoy::Network::SocketCreationOptions&) const {
   if (vppcom_worker_index() == -1) {
@@ -39,7 +40,7 @@ Envoy::Network::IoHandlePtr VclSocketInterface::socket(
   return std::make_unique<VclIoHandle>(sh, VclInvalidFd);
 }
 
-Envoy::Network::IoHandlePtr
+absl::StatusOr<Envoy::Network::IoHandlePtr>
 VclSocketInterface::socket(Envoy::Network::Socket::Type socket_type,
                            const Envoy::Network::Address::InstanceConstSharedPtr addr,
                            const Envoy::Network::SocketCreationOptions& creation_options) const {

--- a/contrib/vcl/source/config.h
+++ b/contrib/vcl/source/config.h
@@ -2,6 +2,8 @@
 
 #include "source/common/network/socket_interface.h"
 
+#include "absl/status/statusor.h"
+
 namespace Envoy {
 namespace Extensions {
 namespace Network {
@@ -16,13 +18,14 @@ public:
 class VclSocketInterface : public Envoy::Network::SocketInterfaceBase {
 public:
   // Network::SocketInterface
-  Envoy::Network::IoHandlePtr socket(Envoy::Network::Socket::Type socket_type,
-                                     Envoy::Network::Address::Type addr_type,
-                                     Envoy::Network::Address::IpVersion version, bool socket_v6only,
-                                     const Envoy::Network::SocketCreationOptions&) const override;
-  Envoy::Network::IoHandlePtr socket(Envoy::Network::Socket::Type socket_type,
-                                     const Envoy::Network::Address::InstanceConstSharedPtr addr,
-                                     const Envoy::Network::SocketCreationOptions&) const override;
+  absl::StatusOr<Envoy::Network::IoHandlePtr>
+  socket(Envoy::Network::Socket::Type socket_type, Envoy::Network::Address::Type addr_type,
+         Envoy::Network::Address::IpVersion version, bool socket_v6only,
+         const Envoy::Network::SocketCreationOptions&) const override;
+  absl::StatusOr<Envoy::Network::IoHandlePtr>
+  socket(Envoy::Network::Socket::Type socket_type,
+         const Envoy::Network::Address::InstanceConstSharedPtr addr,
+         const Envoy::Network::SocketCreationOptions&) const override;
   bool ipFamilySupported(int domain) override;
 
   // Server::Configuration::BootstrapExtensionFactory

--- a/envoy/network/socket_interface.h
+++ b/envoy/network/socket_interface.h
@@ -6,6 +6,8 @@
 #include "envoy/common/pure.h"
 #include "envoy/network/socket.h"
 
+#include "absl/status/statusor.h"
+
 namespace Envoy {
 namespace Network {
 
@@ -41,10 +43,11 @@ public:
    * @param version IP version if address type is IP
    * @param socket_v6only if the socket is ipv6 version only
    * @param options additional options for how to create the socket
-   * @return @ref Network::IoHandlePtr that wraps the underlying socket file descriptor
+   * @return StatusOr<IoHandlePtr> with the socket file descriptor or an error status
    */
-  virtual IoHandlePtr socket(Socket::Type type, Address::Type addr_type, Address::IpVersion version,
-                             bool socket_v6only, const SocketCreationOptions& options) const PURE;
+  virtual absl::StatusOr<IoHandlePtr> socket(Socket::Type type, Address::Type addr_type,
+                                             Address::IpVersion version, bool socket_v6only,
+                                             const SocketCreationOptions& options) const PURE;
 
   /**
    * Low level api to create a socket in the underlying host stack. Does not create an
@@ -52,10 +55,11 @@ public:
    * @param socket_type type of socket requested
    * @param addr address that is gleaned for address type and version if needed
    * @param options additional options for how to create the socket
-   * @return @ref Network::IoHandlePtr that wraps the underlying socket file descriptor
+   * @return StatusOr<IoHandlePtr> with the socket file descriptor or an error status
    */
-  virtual IoHandlePtr socket(Socket::Type socket_type, const Address::InstanceConstSharedPtr addr,
-                             const SocketCreationOptions& options) const PURE;
+  virtual absl::StatusOr<IoHandlePtr> socket(Socket::Type socket_type,
+                                             const Address::InstanceConstSharedPtr addr,
+                                             const SocketCreationOptions& options) const PURE;
 
   /**
    * Returns true if the given family is supported on this machine.
@@ -70,11 +74,11 @@ using SocketInterfacePtr = std::unique_ptr<SocketInterface>;
  * Create IoHandle for given address.
  * @param type type of socket to be requested
  * @param addr address that is gleaned for address type, version and socket interface name
- * @return @ref Network::IoHandlePtr that wraps the underlying socket file descriptor
+ * @return StatusOr<IoHandlePtr> with the socket handle or an error status
  */
-static inline IoHandlePtr ioHandleForAddr(Socket::Type type,
-                                          const Address::InstanceConstSharedPtr addr,
-                                          const SocketCreationOptions& options) {
+static inline absl::StatusOr<IoHandlePtr>
+ioHandleForAddr(Socket::Type type, const Address::InstanceConstSharedPtr addr,
+                const SocketCreationOptions& options) {
   return addr->socketInterface().socket(type, addr, options);
 }
 

--- a/source/common/listener_manager/listener_manager_impl.cc
+++ b/source/common/listener_manager/listener_manager_impl.cc
@@ -26,6 +26,7 @@
 #include "source/common/network/utility.h"
 #include "source/common/protobuf/utility.h"
 
+#include "absl/status/statusor.h"
 #include "absl/synchronization/blocking_counter.h"
 
 #if defined(ENVOY_ENABLE_QUIC)
@@ -331,11 +332,13 @@ absl::StatusOr<Network::SocketSharedPtr> ProdListenerComponentFactory::createLis
   if (&socket_interface != &default_interface) {
     ENVOY_LOG(debug, "creating socket using custom interface for address: {}",
               address->logicalName());
-    auto io_handle = socket_interface.socket(socket_type, address, creation_options);
-    if (!io_handle) {
+    absl::StatusOr<Network::IoHandlePtr> io_handle_or =
+        socket_interface.socket(socket_type, address, creation_options);
+    RETURN_IF_NOT_OK(io_handle_or.status());
+    if (*io_handle_or == nullptr) {
       return absl::InvalidArgumentError("failed to create socket using custom interface");
     }
-    return std::make_shared<Network::TcpListenSocket>(std::move(io_handle), address, options,
+    return std::make_shared<Network::TcpListenSocket>(std::move(*io_handle_or), address, options,
                                                       absl::nullopt, bind_type != BindType::NoBind);
   }
 

--- a/source/common/network/BUILD
+++ b/source/common/network/BUILD
@@ -326,10 +326,12 @@ envoy_cc_library(
     name = "connection_socket_lib",
     hdrs = ["connection_socket_impl.h"],
     deps = [
+        ":socket_interface_lib",
         ":socket_lib",
         ":utility_lib",
         "//envoy/network:exception_interface",
         "//source/common/common:assert_lib",
+        "@com_google_absl//absl/status:statusor",
     ],
 )
 

--- a/source/common/network/address_impl.cc
+++ b/source/common/network/address_impl.cc
@@ -15,6 +15,9 @@
 #include "source/common/network/socket_interface.h"
 #include "source/common/runtime/runtime_features.h"
 
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+
 namespace Envoy {
 namespace Network {
 namespace Address {
@@ -114,7 +117,6 @@ Ipv4Instance::Ipv4Instance(const sockaddr_in* address, const SocketInterface* so
                            absl::optional<std::string> network_namespace)
     : InstanceBase(Type::Ip, sockInterfaceOrDefault(sock_interface)),
       network_namespace_(network_namespace) {
-  THROW_IF_NOT_OK(validateProtocolSupported());
   initHelper(address);
 }
 
@@ -127,7 +129,6 @@ Ipv4Instance::Ipv4Instance(const std::string& address, uint32_t port,
                            absl::optional<std::string> network_namespace)
     : InstanceBase(Type::Ip, sockInterfaceOrDefault(sock_interface)),
       network_namespace_(network_namespace) {
-  THROW_IF_NOT_OK(validateProtocolSupported());
   memset(&ip_.ipv4_.address_, 0, sizeof(ip_.ipv4_.address_));
   ip_.ipv4_.address_.sin_family = AF_INET;
   ip_.ipv4_.address_.sin_port = htons(port);
@@ -144,7 +145,6 @@ Ipv4Instance::Ipv4Instance(uint32_t port, const SocketInterface* sock_interface,
                            absl::optional<std::string> network_namespace)
     : InstanceBase(Type::Ip, sockInterfaceOrDefault(sock_interface)),
       network_namespace_(network_namespace) {
-  THROW_IF_NOT_OK(validateProtocolSupported());
   memset(&ip_.ipv4_.address_, 0, sizeof(ip_.ipv4_.address_));
   ip_.ipv4_.address_.sin_family = AF_INET;
   ip_.ipv4_.address_.sin_port = htons(port);
@@ -158,10 +158,7 @@ Ipv4Instance::Ipv4Instance(absl::Status& status, const sockaddr_in* address,
                            absl::optional<std::string> network_namespace)
     : InstanceBase(Type::Ip, sockInterfaceOrDefault(sock_interface)),
       network_namespace_(network_namespace) {
-  status = validateProtocolSupported();
-  if (!status.ok()) {
-    return;
-  }
+  status = absl::OkStatus();
   initHelper(address);
 }
 
@@ -288,7 +285,6 @@ Ipv6Instance::Ipv6Instance(const sockaddr_in6& address, bool v6only,
                            absl::optional<std::string> network_namespace)
     : InstanceBase(Type::Ip, sockInterfaceOrDefault(sock_interface)),
       network_namespace_(network_namespace) {
-  THROW_IF_NOT_OK(validateProtocolSupported());
   initHelper(address, v6only);
 }
 
@@ -302,7 +298,6 @@ Ipv6Instance::Ipv6Instance(const std::string& address, uint32_t port,
                            absl::optional<std::string> network_namespace)
     : InstanceBase(Type::Ip, sockInterfaceOrDefault(sock_interface)),
       network_namespace_(network_namespace) {
-  THROW_IF_NOT_OK(validateProtocolSupported());
   sockaddr_in6 addr_in;
   memset(&addr_in, 0, sizeof(addr_in));
   addr_in.sin6_family = AF_INET6;
@@ -335,10 +330,7 @@ Ipv6Instance::Ipv6Instance(absl::Status& status, const sockaddr_in6& address, bo
                            absl::optional<std::string> network_namespace)
     : InstanceBase(Type::Ip, sockInterfaceOrDefault(sock_interface)),
       network_namespace_(network_namespace) {
-  status = validateProtocolSupported();
-  if (!status.ok()) {
-    return;
-  }
+  status = absl::OkStatus();
   initHelper(address, v6only);
 }
 

--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -1033,16 +1033,6 @@ void ServerConnectionImpl::onTransportSocketConnectTimeout() {
 }
 
 ClientConnectionImpl::ClientConnectionImpl(
-    Event::Dispatcher& dispatcher, const Address::InstanceConstSharedPtr& remote_address,
-    const Network::Address::InstanceConstSharedPtr& source_address,
-    Network::TransportSocketPtr&& transport_socket,
-    const Network::ConnectionSocket::OptionsSharedPtr& options,
-    const Network::TransportSocketOptionsConstSharedPtr& transport_options)
-    : ClientConnectionImpl(dispatcher, std::make_unique<ClientSocketImpl>(remote_address, options),
-                           source_address, std::move(transport_socket), options,
-                           transport_options) {}
-
-ClientConnectionImpl::ClientConnectionImpl(
     Event::Dispatcher& dispatcher, std::unique_ptr<ConnectionSocket> socket,
     const Address::InstanceConstSharedPtr& source_address,
     Network::TransportSocketPtr&& transport_socket,

--- a/source/common/network/connection_impl.h
+++ b/source/common/network/connection_impl.h
@@ -292,13 +292,6 @@ private:
  */
 class ClientConnectionImpl : public ConnectionImpl, virtual public ClientConnection {
 public:
-  ClientConnectionImpl(Event::Dispatcher& dispatcher,
-                       const Address::InstanceConstSharedPtr& remote_address,
-                       const Address::InstanceConstSharedPtr& source_address,
-                       Network::TransportSocketPtr&& transport_socket,
-                       const Network::ConnectionSocket::OptionsSharedPtr& options,
-                       const Network::TransportSocketOptionsConstSharedPtr& transport_options);
-
   ClientConnectionImpl(Event::Dispatcher& dispatcher, std::unique_ptr<ConnectionSocket> socket,
                        const Address::InstanceConstSharedPtr& source_address,
                        Network::TransportSocketPtr&& transport_socket,

--- a/source/common/network/default_client_connection_factory.cc
+++ b/source/common/network/default_client_connection_factory.cc
@@ -1,9 +1,16 @@
 #include "source/common/network/default_client_connection_factory.h"
 
+#include <memory>
+#include <utility>
+
 #include "envoy/registry/registry.h"
 
+#include "source/common/common/assert.h"
 #include "source/common/network/address_impl.h"
 #include "source/common/network/connection_impl.h"
+#include "source/common/network/connection_socket_impl.h"
+
+#include "absl/status/statusor.h"
 
 namespace Envoy {
 
@@ -16,8 +23,15 @@ Network::ClientConnectionPtr DefaultClientConnectionFactory::createClientConnect
     const Network::ConnectionSocket::OptionsSharedPtr& options,
     const Network::TransportSocketOptionsConstSharedPtr& transport_options) {
   ASSERT(address->ip() || address->pipe());
+
+  absl::StatusOr<std::unique_ptr<Network::ClientSocketImpl>> client_socket_or =
+      ClientSocketImpl::create(address, options);
+  RELEASE_ASSERT(client_socket_or.ok(),
+                 absl::StrCat("failed to create socket: ", client_socket_or.status()));
+
   return std::make_unique<Network::ClientConnectionImpl>(
-      dispatcher, address, source_address, std::move(transport_socket), options, transport_options);
+      dispatcher, std::move(*client_socket_or), source_address, std::move(transport_socket),
+      options, transport_options);
 }
 REGISTER_FACTORY(DefaultClientConnectionFactory, Network::ClientConnectionFactory);
 

--- a/source/common/network/listen_socket_impl.cc
+++ b/source/common/network/listen_socket_impl.cc
@@ -53,7 +53,8 @@ void ListenSocketImpl::setupSocket(const Network::Socket::OptionsSharedPtr& opti
 }
 
 UdsListenSocket::UdsListenSocket(const Address::InstanceConstSharedPtr& address)
-    : ListenSocketImpl(ioHandleForAddr(Socket::Type::Stream, address, {}), address) {
+    : ListenSocketImpl(ioHandleForAddr(Socket::Type::Stream, address, {}).value_or(nullptr),
+                       address) {
   RELEASE_ASSERT(io_handle_ && io_handle_->isOpen(), "");
   bind(connection_info_provider_->localAddress());
 }

--- a/source/common/network/listen_socket_impl.h
+++ b/source/common/network/listen_socket_impl.h
@@ -48,9 +48,11 @@ public:
   NetworkListenSocket(const Address::InstanceConstSharedPtr& address,
                       const Network::Socket::OptionsSharedPtr& options, bool bind_to_port,
                       const SocketCreationOptions& creation_options = {})
-      : ListenSocketImpl(bind_to_port ? Network::ioHandleForAddr(T::type, address, creation_options)
-                                      : nullptr,
-                         address) {
+      : ListenSocketImpl(
+            bind_to_port
+                ? Network::ioHandleForAddr(T::type, address, creation_options).value_or(nullptr)
+                : nullptr,
+            address) {
     // Prebind is applied if the socket is bind to port.
     if (bind_to_port) {
       RELEASE_ASSERT(io_handle_ && io_handle_->isOpen(), "");

--- a/source/common/network/socket_impl.h
+++ b/source/common/network/socket_impl.h
@@ -7,6 +7,8 @@
 #include "source/common/common/assert.h"
 #include "source/common/common/dump_state_utils.h"
 
+#include "absl/status/statusor.h"
+
 namespace Envoy {
 namespace Network {
 
@@ -125,9 +127,10 @@ private:
 
 class SocketImpl : public virtual Socket {
 public:
-  SocketImpl(Socket::Type socket_type, const Address::InstanceConstSharedPtr& address_for_io_handle,
-             const Address::InstanceConstSharedPtr& remote_address,
-             const SocketCreationOptions& options);
+  static absl::StatusOr<std::unique_ptr<SocketImpl>>
+  create(Socket::Type socket_type, const Address::InstanceConstSharedPtr& address_for_io_handle,
+         const Address::InstanceConstSharedPtr& remote_address,
+         const SocketCreationOptions& options);
 
   // Network::Socket
   ConnectionInfoSetter& connectionInfoProvider() override { return *connection_info_provider_; }
@@ -184,6 +187,9 @@ public:
   absl::optional<Address::IpVersion> ipVersion() const override;
 
 protected:
+  SocketImpl(IoHandlePtr&& io_handle, Socket::Type sock_type, Address::Type addr_type,
+             const Address::InstanceConstSharedPtr& remote_address);
+
   SocketImpl(IoHandlePtr&& io_handle, const Address::InstanceConstSharedPtr& local_address,
              const Address::InstanceConstSharedPtr& remote_address);
 

--- a/source/common/network/socket_interface_impl.h
+++ b/source/common/network/socket_interface_impl.h
@@ -5,6 +5,8 @@
 
 #include "source/common/network/socket_interface.h"
 
+#include "absl/status/statusor.h"
+
 namespace Envoy {
 namespace Network {
 
@@ -25,11 +27,14 @@ protected:
 class SocketInterfaceImpl : public SocketInterfaceBase {
 public:
   // SocketInterface
-  IoHandlePtr socket(Socket::Type socket_type, Address::Type addr_type, Address::IpVersion version,
-                     bool socket_v6only, const SocketCreationOptions& options) const override;
-  IoHandlePtr socket(Socket::Type socket_type, const Address::InstanceConstSharedPtr addr,
-                     const SocketCreationOptions& options) const override;
+  absl::StatusOr<IoHandlePtr> socket(Socket::Type socket_type, Address::Type addr_type,
+                                     Address::IpVersion version, bool socket_v6only,
+                                     const SocketCreationOptions& options) const override;
+  absl::StatusOr<IoHandlePtr> socket(Socket::Type socket_type,
+                                     const Address::InstanceConstSharedPtr addr,
+                                     const SocketCreationOptions& options) const override;
   bool ipFamilySupported(int domain) override;
+  bool ipFamilySupported(int domain) const;
 
   // Server::Configuration::BootstrapExtensionFactory
   Server::BootstrapExtensionPtr

--- a/source/common/quic/envoy_quic_utils.h
+++ b/source/common/quic/envoy_quic_utils.h
@@ -11,6 +11,7 @@
 #include "source/common/network/connection_socket_impl.h"
 #include "source/common/quic/quic_io_handle_wrapper.h"
 
+#include "absl/status/statusor.h"
 #include "openssl/ssl.h"
 #include "quiche/common/http/http_header_block.h"
 #include "quiche/quic/core/http/quic_connection_migration_manager.h"
@@ -185,7 +186,7 @@ Http::StreamResetReason quicErrorCodeToEnvoyRemoteResetReason(quic::QuicErrorCod
 // custom_bind_func. This is used on Android platforms which have a unique id
 // for each network and has API to bind a socket to a specific handle.
 // Otherwise the platform will automatically pick a network interface.
-Network::ConnectionSocketPtr createConnectionSocket(
+absl::StatusOr<Network::ConnectionSocketPtr> createConnectionSocket(
     const Network::Address::InstanceConstSharedPtr& peer_addr,
     Network::Address::InstanceConstSharedPtr& local_addr,
     const Network::ConnectionSocket::OptionsSharedPtr& options,

--- a/source/common/quic/quic_client_packet_writer_factory_impl.cc
+++ b/source/common/quic/quic_client_packet_writer_factory_impl.cc
@@ -1,8 +1,11 @@
 #include "source/common/quic/quic_client_packet_writer_factory_impl.h"
 
+#include "source/common/network/io_socket_handle_impl.h"
 #include "source/common/network/udp_packet_writer_handler_impl.h"
 #include "source/common/quic/envoy_quic_packet_writer.h"
 #include "source/common/quic/envoy_quic_utils.h"
+
+#include "absl/status/statusor.h"
 
 namespace Envoy {
 namespace Quic {
@@ -12,8 +15,15 @@ QuicClientPacketWriterFactoryImpl::createSocketAndQuicPacketWriter(
     Network::Address::InstanceConstSharedPtr server_addr, quic::QuicNetworkHandle /*network*/,
     Network::Address::InstanceConstSharedPtr& local_addr,
     const Network::ConnectionSocket::OptionsSharedPtr& options) {
-  Network::ConnectionSocketPtr connection_socket =
+  absl::StatusOr<Network::ConnectionSocketPtr> connection_socket_or =
       createConnectionSocket(server_addr, local_addr, options);
+
+  Network::ConnectionSocketPtr connection_socket =
+      connection_socket_or.ok() ? std::move(*connection_socket_or)
+                                : std::make_unique<Network::ConnectionSocketImpl>(
+                                      std::make_unique<Network::IoSocketHandleImpl>(INVALID_SOCKET),
+                                      local_addr, server_addr);
+
   Network::IoHandle& io_handle = connection_socket->ioHandle();
   return {std::make_unique<EnvoyQuicPacketWriter>(
               std::make_unique<Network::UdpDefaultWriter>(io_handle)),

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator.h
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator.h
@@ -10,6 +10,8 @@
 #include "source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_address.h"
 #include "source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator_extension.h"
 
+#include "absl/status/statusor.h"
+
 namespace Envoy {
 namespace Extensions {
 namespace Bootstrap {
@@ -41,15 +43,15 @@ public:
    * @param version the IP version
    * @param socket_v6only whether to create IPv6-only socket
    * @param options socket creation options
-   * @return IoHandlePtr for the created socket, or nullptr for unsupported types
+   * @return StatusOr<IoHandlePtr> with the created socket, or error status for unsupported types
    */
-  Envoy::Network::IoHandlePtr
+  absl::StatusOr<Envoy::Network::IoHandlePtr>
   socket(Envoy::Network::Socket::Type socket_type, Envoy::Network::Address::Type addr_type,
          Envoy::Network::Address::IpVersion version, bool socket_v6only,
          const Envoy::Network::SocketCreationOptions& options) const override;
 
   // No-op for reverse connections.
-  Envoy::Network::IoHandlePtr
+  absl::StatusOr<Envoy::Network::IoHandlePtr>
   socket(Envoy::Network::Socket::Type socket_type,
          const Envoy::Network::Address::InstanceConstSharedPtr addr,
          const Envoy::Network::SocketCreationOptions& options) const override;
@@ -70,9 +72,9 @@ public:
    * @param addr_type the address type
    * @param version the IP version
    * @param config the reverse connection configuration
-   * @return IoHandlePtr for the reverse connection socket
+   * @return StatusOr<IoHandlePtr> for the reverse connection socket
    */
-  Envoy::Network::IoHandlePtr
+  absl::StatusOr<Envoy::Network::IoHandlePtr>
   createReverseConnectionSocket(Envoy::Network::Socket::Type socket_type,
                                 Envoy::Network::Address::Type addr_type,
                                 Envoy::Network::Address::IpVersion version,

--- a/source/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/reverse_tunnel_acceptor.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/reverse_tunnel_acceptor.cc
@@ -10,6 +10,8 @@
 #include "source/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/reverse_tunnel_acceptor_extension.h"
 #include "source/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/upstream_socket_manager.h"
 
+#include "absl/status/statusor.h"
+
 namespace Envoy {
 namespace Extensions {
 namespace Bootstrap {
@@ -21,18 +23,18 @@ ReverseTunnelAcceptor::ReverseTunnelAcceptor(Server::Configuration::ServerFactor
   ENVOY_LOG(debug, "reverse_tunnel: created acceptor");
 }
 
-Envoy::Network::IoHandlePtr
+absl::StatusOr<Envoy::Network::IoHandlePtr>
 ReverseTunnelAcceptor::socket(Envoy::Network::Socket::Type, Envoy::Network::Address::Type,
                               Envoy::Network::Address::IpVersion, bool,
                               const Envoy::Network::SocketCreationOptions&) const {
 
-  ENVOY_LOG(warn, "reverse_tunnel: socket() called without address; returning nullptr");
+  ENVOY_LOG(warn, "reverse_tunnel: socket() called without address; returning error");
 
   // Reverse connection sockets should always have an address.
-  return nullptr;
+  return absl::InvalidArgumentError("reverse_tunnel: socket() called without address");
 }
 
-Envoy::Network::IoHandlePtr
+absl::StatusOr<Envoy::Network::IoHandlePtr>
 ReverseTunnelAcceptor::socket(Envoy::Network::Socket::Type socket_type,
                               const Envoy::Network::Address::InstanceConstSharedPtr addr,
                               const Envoy::Network::SocketCreationOptions& options) const {

--- a/source/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/reverse_tunnel_acceptor.h
+++ b/source/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/reverse_tunnel_acceptor.h
@@ -20,6 +20,8 @@
 #include "source/common/network/socket_interface.h"
 #include "source/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/reverse_connection_io_handle.h"
 
+#include "absl/status/statusor.h"
+
 namespace Envoy {
 namespace Extensions {
 namespace Bootstrap {
@@ -55,7 +57,7 @@ public:
    * @param options socket creation options.
    * @return nullptr since reverse connections require specific addresses.
    */
-  Envoy::Network::IoHandlePtr
+  absl::StatusOr<Envoy::Network::IoHandlePtr>
   socket(Envoy::Network::Socket::Type socket_type, Envoy::Network::Address::Type addr_type,
          Envoy::Network::Address::IpVersion version, bool socket_v6only,
          const Envoy::Network::SocketCreationOptions& options) const override;
@@ -65,9 +67,9 @@ public:
    * @param socket_type the type of socket to create.
    * @param addr the address to bind to.
    * @param options socket creation options.
-   * @return IoHandlePtr for the reverse connection socket.
+   * @return StatusOr<IoHandlePtr> with the reverse connection socket, or error status
    */
-  Envoy::Network::IoHandlePtr
+  absl::StatusOr<Envoy::Network::IoHandlePtr>
   socket(Envoy::Network::Socket::Type socket_type,
          const Envoy::Network::Address::InstanceConstSharedPtr addr,
          const Envoy::Network::SocketCreationOptions& options) const override;

--- a/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.h
+++ b/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.h
@@ -35,6 +35,7 @@
 
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"
+#include "absl/status/statusor.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -908,10 +909,11 @@ private:
   ActiveSession* createSessionWithOptionalHost(Network::UdpRecvData::LocalPeerAddresses&& addresses,
                                                const Upstream::HostConstSharedPtr& host);
 
-  virtual Network::SocketPtr createUdpSocket(const Upstream::HostConstSharedPtr& host) {
+  virtual absl::StatusOr<Network::SocketPtr>
+  createUdpSocket(const Upstream::HostConstSharedPtr& host) {
     // Virtual so this can be overridden in unit tests.
-    return std::make_unique<Network::SocketImpl>(Network::Socket::Type::Datagram, host->address(),
-                                                 nullptr, Network::SocketCreationOptions{});
+    return Network::SocketImpl::create(Network::Socket::Type::Datagram, host->address(), nullptr,
+                                       Network::SocketCreationOptions{});
   }
 
   void fillProxyStreamInfo();

--- a/source/extensions/stat_sinks/common/statsd/statsd.cc
+++ b/source/extensions/stat_sinks/common/statsd/statsd.cc
@@ -30,7 +30,10 @@ namespace Statsd {
 
 UdpStatsdSink::WriterImpl::WriterImpl(UdpStatsdSink& parent)
     : parent_(parent), io_handle_(Network::ioHandleForAddr(Network::Socket::Type::Datagram,
-                                                           parent_.server_address_, {})) {}
+                                                           parent_.server_address_, {})
+                                      .value_or(nullptr)) {
+  RELEASE_ASSERT(io_handle_ && io_handle_->isOpen(), "failed to create socket");
+}
 
 void UdpStatsdSink::WriterImpl::write(const std::string& message) {
   // TODO(mattklein123): We can avoid this const_cast pattern by having a constant variant of

--- a/source/extensions/tracers/xray/daemon_broker.cc
+++ b/source/extensions/tracers/xray/daemon_broker.cc
@@ -30,9 +30,13 @@ std::string createHeader(const std::string& format, uint32_t version) {
 DaemonBrokerImpl::DaemonBrokerImpl(const std::string& daemon_endpoint)
     : address_(
           Network::Utility::parseInternetAddressAndPortNoThrow(daemon_endpoint, false /*v6only*/)),
-      io_handle_(Network::ioHandleForAddr(Network::Socket::Type::Datagram, address_, {})) {
+      io_handle_(Network::ioHandleForAddr(Network::Socket::Type::Datagram, address_, {})
+                     .value_or(nullptr)) {
   if (address_ == nullptr) {
     throw EnvoyException(absl::StrCat("malformed IP address: ", daemon_endpoint));
+  }
+  if (io_handle_ == nullptr || !io_handle_->isOpen()) {
+    throw EnvoyException(absl::StrCat("failed to create socket: ", daemon_endpoint));
   }
 }
 

--- a/source/server/config_validation/connection.h
+++ b/source/server/config_validation/connection.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <memory>
+#include <utility>
+
 #include "source/common/network/connection_impl.h"
 #include "source/server/config_validation/dispatcher.h"
 
@@ -14,12 +17,12 @@ namespace Network {
 class ConfigValidateConnection : public Network::ClientConnectionImpl {
 public:
   ConfigValidateConnection(Event::ValidationDispatcher& dispatcher,
-                           Network::Address::InstanceConstSharedPtr remote_address,
+                           std::unique_ptr<ConnectionSocket> socket,
                            Network::Address::InstanceConstSharedPtr source_address,
                            Network::TransportSocketPtr&& transport_socket,
                            const Network::ConnectionSocket::OptionsSharedPtr& options,
                            const Network::TransportSocketOptionsConstSharedPtr& transport_options)
-      : Network::ClientConnectionImpl(dispatcher, remote_address, source_address,
+      : Network::ClientConnectionImpl(dispatcher, std::move(socket), source_address,
                                       std::move(transport_socket), options, transport_options) {}
 
   // Unit tests may instantiate it without proper event machine and leave opened sockets.

--- a/source/server/config_validation/dispatcher.cc
+++ b/source/server/config_validation/dispatcher.cc
@@ -1,7 +1,13 @@
 #include "source/server/config_validation/dispatcher.h"
 
+#include <memory>
+#include <utility>
+
 #include "source/common/common/assert.h"
+#include "source/common/network/connection_socket_impl.h"
 #include "source/server/config_validation/connection.h"
+
+#include "absl/status/statusor.h"
 
 namespace Envoy {
 namespace Event {
@@ -12,9 +18,13 @@ Network::ClientConnectionPtr ValidationDispatcher::createClientConnection(
     Network::TransportSocketPtr&& transport_socket,
     const Network::ConnectionSocket::OptionsSharedPtr& options,
     const Network::TransportSocketOptionsConstSharedPtr& transport_options) {
-  return std::make_unique<Network::ConfigValidateConnection>(*this, remote_address, source_address,
-                                                             std::move(transport_socket), options,
-                                                             transport_options);
+  absl::StatusOr<std::unique_ptr<Network::ClientSocketImpl>> socket_or =
+      Network::ClientSocketImpl::create(remote_address, options);
+  RELEASE_ASSERT(socket_or.ok(), absl::StrCat("failed to create socket: ", socket_or.status()));
+
+  return std::make_unique<Network::ConfigValidateConnection>(
+      *this, std::move(*socket_or), source_address, std::move(transport_socket), options,
+      transport_options);
 }
 
 } // namespace Event

--- a/test/common/listener_manager/listener_manager_impl_test.cc
+++ b/test/common/listener_manager/listener_manager_impl_test.cc
@@ -38,6 +38,7 @@
 #include "test/test_common/registry.h"
 #include "test/test_common/utility.h"
 
+#include "absl/status/statusor.h"
 #include "absl/strings/escaping.h"
 #include "absl/strings/match.h"
 
@@ -8543,9 +8544,10 @@ public:
   TestCustomSocketInterface() = default;
 
   // Network::SocketInterface
-  Network::IoHandlePtr socket(Network::Socket::Type socket_type, Network::Address::Type addr_type,
-                              Network::Address::IpVersion version, bool socket_v6only,
-                              const Network::SocketCreationOptions& options) const override {
+  absl::StatusOr<Network::IoHandlePtr>
+  socket(Network::Socket::Type socket_type, Network::Address::Type addr_type,
+         Network::Address::IpVersion version, bool socket_v6only,
+         const Network::SocketCreationOptions& options) const override {
     if (mock_io_handle_) {
       return std::move(mock_io_handle_);
     }
@@ -8564,9 +8566,9 @@ public:
     return nullptr;
   }
 
-  Network::IoHandlePtr socket(Network::Socket::Type socket_type,
-                              const Network::Address::InstanceConstSharedPtr addr,
-                              const Network::SocketCreationOptions& options) const override {
+  absl::StatusOr<Network::IoHandlePtr>
+  socket(Network::Socket::Type socket_type, const Network::Address::InstanceConstSharedPtr addr,
+         const Network::SocketCreationOptions& options) const override {
     if (mock_io_handle_) {
       return std::move(mock_io_handle_);
     }
@@ -8748,9 +8750,9 @@ TEST_P(ListenerManagerImplTest, CustomSocketInterfaceFailureIsHandledGracefully)
   public:
     // Don't hide the other overload.
     using TestCustomSocketInterface::socket;
-    Network::IoHandlePtr socket(Network::Socket::Type socket_type,
-                                const Network::Address::InstanceConstSharedPtr addr,
-                                const Network::SocketCreationOptions& options) const override {
+    absl::StatusOr<Network::IoHandlePtr>
+    socket(Network::Socket::Type socket_type, const Network::Address::InstanceConstSharedPtr addr,
+           const Network::SocketCreationOptions& options) const override {
       UNREFERENCED_PARAMETER(socket_type);
       UNREFERENCED_PARAMETER(addr);
       UNREFERENCED_PARAMETER(options);

--- a/test/common/network/connection_impl_test.cc
+++ b/test/common/network/connection_impl_test.cc
@@ -1,6 +1,7 @@
 #include <cstdint>
 #include <memory>
 #include <string>
+#include <utility>
 
 #include "envoy/common/platform.h"
 #include "envoy/config/core/v3/base.pb.h"
@@ -40,6 +41,7 @@
 #include "test/test_common/threadsafe_singleton_injector.h"
 #include "test/test_common/utility.h"
 
+#include "absl/status/statusor.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
@@ -170,9 +172,15 @@ protected:
         listener_config.bindToPort(), listener_config.ignoreGlobalConnLimit(),
         listener_config.shouldBypassOverloadManager(),
         listener_config.maxConnectionsToAcceptPerSocketEvent(), overload_state);
+
+    absl::StatusOr<std::unique_ptr<Network::ClientSocketImpl>> socket_or =
+        Network::ClientSocketImpl::create(socket_->connectionInfoProvider().localAddress(),
+                                          socket_options_);
+    ASSERT_TRUE(socket_or.ok()) << socket_or.status();
+
     client_connection_ = std::make_unique<Network::TestClientConnectionImpl>(
-        *dispatcher_, socket_->connectionInfoProvider().localAddress(), source_address_,
-        createTransportSocket(), socket_options_, transport_socket_options_);
+        *dispatcher_, std::move(*socket_or), source_address_, createTransportSocket(),
+        socket_options_, transport_socket_options_);
     client_connection_->addConnectionCallbacks(client_callbacks_);
     EXPECT_EQ(nullptr, client_connection_->ssl());
     const Network::ClientConnection& const_connection = *client_connection_;

--- a/test/common/network/io_socket_handle_impl_integration_test.cc
+++ b/test/common/network/io_socket_handle_impl_integration_test.cc
@@ -28,11 +28,14 @@ TEST(IoSocketHandleImplIntegration, LastRoundTripIntegrationTest) {
   server.sin_port = htons(80);
 
   Address::InstanceConstSharedPtr addr(new Address::Ipv4Instance(&server));
-  auto socket_ = std::make_shared<Envoy::Network::ClientSocketImpl>(addr, nullptr);
-  socket_->setBlockingForTest(true);
-  EXPECT_TRUE(socket_->connect(addr).return_value_ == 0);
+  absl::StatusOr<std::unique_ptr<ClientSocketImpl>> socket_or =
+      ClientSocketImpl::create(addr, nullptr);
+  ASSERT_TRUE(socket_or.ok()) << socket_or.status();
+  std::unique_ptr<ClientSocketImpl> socket = std::move(*socket_or);
+  socket->setBlockingForTest(true);
+  EXPECT_TRUE(socket->connect(addr).return_value_ == 0);
 
-  EXPECT_TRUE(socket_->ioHandle().lastRoundTripTime() != absl::nullopt);
+  EXPECT_TRUE(socket->ioHandle().lastRoundTripTime() != absl::nullopt);
 }
 #endif
 

--- a/test/common/network/udp_listener_impl_test_base.h
+++ b/test/common/network/udp_listener_impl_test_base.h
@@ -24,6 +24,7 @@ protected:
   useHotRestartSocket(OptRef<ParentDrainedCallbackRegistrar> parent_drained_callback_registrar) {
     auto io_handle = std::make_unique<testing::NiceMock<MockIoHandle>>();
     MockIoHandle& ret = *io_handle;
+    ON_CALL(ret, isOpen()).WillByDefault(testing::Return(true));
     server_socket_ = createServerSocketFromExistingHandle(std::move(io_handle),
                                                           parent_drained_callback_registrar);
     return ret;

--- a/test/common/quic/envoy_quic_client_stream_test.cc
+++ b/test/common/quic/envoy_quic_client_stream_test.cc
@@ -47,7 +47,7 @@ public:
         quic_connection_(new MockEnvoyQuicClientConnection(
             quic::test::TestConnectionId(), connection_helper_, alarm_factory_, &writer_,
             /*owns_writer=*/false, {quic_version_}, *dispatcher_,
-            createConnectionSocket(peer_addr_, self_addr_, nullptr), connection_id_generator_)),
+            *createConnectionSocket(peer_addr_, self_addr_, nullptr), connection_id_generator_)),
         quic_session_(quic_config_, {quic_version_},
                       std::unique_ptr<EnvoyQuicClientConnection>(quic_connection_), *dispatcher_,
                       quic_config_.GetInitialStreamFlowControlWindowToSend() * 2,

--- a/test/common/quic/envoy_quic_utils_test.cc
+++ b/test/common/quic/envoy_quic_utils_test.cc
@@ -5,6 +5,7 @@
 #include "test/test_common/threadsafe_singleton_injector.h"
 #include "test/test_common/utility.h"
 
+#include "absl/status/statusor.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "quiche/quic/test_tools/quic_test_utils.h"
@@ -340,13 +341,18 @@ TEST(EnvoyQuicUtilsTest, CreateConnectionSocket) {
       std::make_shared<Network::Address::Ipv4Instance>("127.0.0.1");
   Network::Address::InstanceConstSharedPtr peer_addr =
       std::make_shared<Network::Address::Ipv4Instance>("127.0.0.1", 54321, nullptr);
-  auto connection_socket = createConnectionSocket(peer_addr, local_addr, nullptr);
+  absl::StatusOr<Network::ConnectionSocketPtr> connection_socket_or =
+      createConnectionSocket(peer_addr, local_addr, nullptr);
+  ASSERT_TRUE(connection_socket_or.ok()) << connection_socket_or.status();
+  Network::ConnectionSocketPtr connection_socket = std::move(*connection_socket_or);
   EXPECT_TRUE(connection_socket->isOpen());
   EXPECT_TRUE(connection_socket->ioHandle().wasConnected());
   connection_socket->close();
 
   Network::Address::InstanceConstSharedPtr no_local_addr = nullptr;
-  connection_socket = createConnectionSocket(peer_addr, no_local_addr, nullptr);
+  connection_socket_or = createConnectionSocket(peer_addr, no_local_addr, nullptr);
+  ASSERT_TRUE(connection_socket_or.ok()) << connection_socket_or.status();
+  connection_socket = std::move(*connection_socket_or);
   EXPECT_TRUE(connection_socket->isOpen());
   EXPECT_TRUE(connection_socket->ioHandle().wasConnected());
   EXPECT_EQ("127.0.0.1", no_local_addr->ip()->addressAsString());
@@ -369,12 +375,14 @@ TEST(EnvoyQuicUtilsTest, CreateConnectionSocket) {
   connection_socket->close();
 
   no_local_addr = nullptr;
-  connection_socket = createConnectionSocket(
+  connection_socket_or = createConnectionSocket(
       peer_addr, no_local_addr, nullptr, /*network*/ 1,
       [](Network::ConnectionSocket& socket, quic::QuicNetworkHandle network) {
         EXPECT_EQ(1, network);
         socket.close();
       });
+  ASSERT_TRUE(connection_socket_or.ok()) << connection_socket_or.status();
+  connection_socket = std::move(*connection_socket_or);
   EXPECT_FALSE(connection_socket->isOpen());
   EXPECT_FALSE(connection_socket->ioHandle().wasConnected());
 
@@ -382,7 +390,9 @@ TEST(EnvoyQuicUtilsTest, CreateConnectionSocket) {
       std::make_shared<Network::Address::Ipv6Instance>("::1", 0, nullptr, /*v6only*/ true);
   Network::Address::InstanceConstSharedPtr peer_addr_v6 =
       std::make_shared<Network::Address::Ipv6Instance>("::1", 54321, nullptr, /*v6only*/ false);
-  connection_socket = createConnectionSocket(peer_addr_v6, local_addr_v6, nullptr);
+  connection_socket_or = createConnectionSocket(peer_addr_v6, local_addr_v6, nullptr);
+  ASSERT_TRUE(connection_socket_or.ok()) << connection_socket_or.status();
+  connection_socket = std::move(*connection_socket_or);
   EXPECT_TRUE(connection_socket->isOpen());
   EXPECT_TRUE(connection_socket->ioHandle().wasConnected());
   EXPECT_TRUE(local_addr_v6->ip()->ipv6()->v6only());
@@ -415,7 +425,9 @@ TEST(EnvoyQuicUtilsTest, CreateConnectionSocket) {
   connection_socket->close();
 
   Network::Address::InstanceConstSharedPtr no_local_addr_v6 = nullptr;
-  connection_socket = createConnectionSocket(peer_addr_v6, no_local_addr_v6, nullptr);
+  connection_socket_or = createConnectionSocket(peer_addr_v6, no_local_addr_v6, nullptr);
+  ASSERT_TRUE(connection_socket_or.ok()) << connection_socket_or.status();
+  connection_socket = std::move(*connection_socket_or);
   EXPECT_TRUE(connection_socket->isOpen());
   EXPECT_TRUE(connection_socket->ioHandle().wasConnected());
   EXPECT_EQ("::1", no_local_addr_v6->ip()->addressAsString());

--- a/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_address_test.cc
+++ b/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_address_test.cc
@@ -6,6 +6,7 @@
 #include "test/mocks/network/mocks.h"
 #include "test/test_common/registry.h"
 
+#include "absl/status/statusor.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
@@ -164,9 +165,10 @@ TEST_F(ReverseConnectionAddressTest, SocketInterfaceWithReverseInterface) {
     TestReverseSocketInterface() = default;
 
     // Network::SocketInterface
-    Network::IoHandlePtr socket(Network::Socket::Type socket_type, Network::Address::Type addr_type,
-                                Network::Address::IpVersion version, bool socket_v6only,
-                                const Network::SocketCreationOptions& options) const override {
+    absl::StatusOr<Network::IoHandlePtr>
+    socket(Network::Socket::Type socket_type, Network::Address::Type addr_type,
+           Network::Address::IpVersion version, bool socket_v6only,
+           const Network::SocketCreationOptions& options) const override {
       UNREFERENCED_PARAMETER(socket_v6only);
       UNREFERENCED_PARAMETER(options);
       // Create a regular socket for testing
@@ -181,9 +183,9 @@ TEST_F(ReverseConnectionAddressTest, SocketInterfaceWithReverseInterface) {
       return nullptr;
     }
 
-    Network::IoHandlePtr socket(Network::Socket::Type socket_type,
-                                const Network::Address::InstanceConstSharedPtr addr,
-                                const Network::SocketCreationOptions& options) const override {
+    absl::StatusOr<Network::IoHandlePtr>
+    socket(Network::Socket::Type socket_type, const Network::Address::InstanceConstSharedPtr addr,
+           const Network::SocketCreationOptions& options) const override {
       // Delegate to the other socket method
       return socket(socket_type, addr->type(),
                     addr->ip() ? addr->ip()->version() : Network::Address::IpVersion::v4, false,

--- a/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator_test.cc
+++ b/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator_test.cc
@@ -17,6 +17,7 @@
 #include "test/mocks/upstream/mocks.h"
 #include "test/test_common/logging.h"
 
+#include "absl/status/statusor.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
@@ -163,60 +164,66 @@ TEST_F(ReverseTunnelInitiatorTest, FactoryName) {
 
 TEST_F(ReverseTunnelInitiatorTest, SocketMethodBasicIPv4) {
   // Test basic socket creation for IPv4.
-  auto socket = socket_interface_->socket(Network::Socket::Type::Stream, Network::Address::Type::Ip,
-                                          Network::Address::IpVersion::v4, false,
-                                          Network::SocketCreationOptions{});
-  EXPECT_NE(socket, nullptr);
-  EXPECT_TRUE(socket->isOpen());
+  absl::StatusOr<Network::IoHandlePtr> socket = socket_interface_->socket(
+      Network::Socket::Type::Stream, Network::Address::Type::Ip, Network::Address::IpVersion::v4,
+      false, Network::SocketCreationOptions{});
+  ASSERT_TRUE(socket.ok()) << socket.status();
+  ASSERT_NE(*socket, nullptr);
+  EXPECT_TRUE((*socket)->isOpen());
 
   // Verify it's NOT a ReverseConnectionIOHandle (should be a regular socket)
-  auto* reverse_handle = dynamic_cast<ReverseConnectionIOHandle*>(socket.get());
+  auto* reverse_handle = dynamic_cast<ReverseConnectionIOHandle*>(socket->get());
   EXPECT_EQ(reverse_handle, nullptr);
 }
 
 TEST_F(ReverseTunnelInitiatorTest, SocketMethodBasicIPv6) {
   // Test basic socket creation for IPv6.
-  auto socket = socket_interface_->socket(Network::Socket::Type::Stream, Network::Address::Type::Ip,
-                                          Network::Address::IpVersion::v6, false,
-                                          Network::SocketCreationOptions{});
-  EXPECT_NE(socket, nullptr);
-  EXPECT_TRUE(socket->isOpen());
+  absl::StatusOr<Network::IoHandlePtr> socket = socket_interface_->socket(
+      Network::Socket::Type::Stream, Network::Address::Type::Ip, Network::Address::IpVersion::v6,
+      false, Network::SocketCreationOptions{});
+  ASSERT_TRUE(socket.ok()) << socket.status();
+  ASSERT_NE(*socket, nullptr);
+  EXPECT_TRUE((*socket)->isOpen());
 }
 
 TEST_F(ReverseTunnelInitiatorTest, SocketMethodDatagram) {
   // Test datagram socket creation.
-  auto socket = socket_interface_->socket(
+  absl::StatusOr<Network::IoHandlePtr> socket = socket_interface_->socket(
       Network::Socket::Type::Datagram, Network::Address::Type::Ip, Network::Address::IpVersion::v4,
       false, Network::SocketCreationOptions{});
-  EXPECT_NE(socket, nullptr);
-  EXPECT_TRUE(socket->isOpen());
+  ASSERT_TRUE(socket.ok()) << socket.status();
+  ASSERT_NE(*socket, nullptr);
+  EXPECT_TRUE((*socket)->isOpen());
 }
 
 TEST_F(ReverseTunnelInitiatorTest, SocketMethodUnixDomain) {
   // Test Unix domain socket creation.
-  auto socket = socket_interface_->socket(
+  absl::StatusOr<Network::IoHandlePtr> socket = socket_interface_->socket(
       Network::Socket::Type::Stream, Network::Address::Type::Pipe, Network::Address::IpVersion::v4,
       false, Network::SocketCreationOptions{});
-  EXPECT_NE(socket, nullptr);
-  EXPECT_TRUE(socket->isOpen());
+  ASSERT_TRUE(socket.ok()) << socket.status();
+  ASSERT_NE(*socket, nullptr);
+  EXPECT_TRUE((*socket)->isOpen());
 }
 
 TEST_F(ReverseTunnelInitiatorTest, SocketMethodWithAddressIPv4) {
   // Test socket creation with IPv4 address.
   auto address = std::make_shared<Network::Address::Ipv4Instance>("127.0.0.1", 8080);
-  auto socket = socket_interface_->socket(Network::Socket::Type::Stream, address,
-                                          Network::SocketCreationOptions{});
-  EXPECT_NE(socket, nullptr);
-  EXPECT_TRUE(socket->isOpen());
+  absl::StatusOr<Network::IoHandlePtr> socket = socket_interface_->socket(
+      Network::Socket::Type::Stream, address, Network::SocketCreationOptions{});
+  ASSERT_TRUE(socket.ok()) << socket.status();
+  ASSERT_NE(*socket, nullptr);
+  EXPECT_TRUE((*socket)->isOpen());
 }
 
 TEST_F(ReverseTunnelInitiatorTest, SocketMethodWithAddressIPv6) {
   // Test socket creation with IPv6 address.
   auto address = std::make_shared<Network::Address::Ipv6Instance>("::1", 8080);
-  auto socket = socket_interface_->socket(Network::Socket::Type::Stream, address,
-                                          Network::SocketCreationOptions{});
-  EXPECT_NE(socket, nullptr);
-  EXPECT_TRUE(socket->isOpen());
+  absl::StatusOr<Network::IoHandlePtr> socket = socket_interface_->socket(
+      Network::Socket::Type::Stream, address, Network::SocketCreationOptions{});
+  ASSERT_TRUE(socket.ok()) << socket.status();
+  ASSERT_NE(*socket, nullptr);
+  EXPECT_TRUE((*socket)->isOpen());
 }
 
 TEST_F(ReverseTunnelInitiatorTest, SocketMethodWithReverseConnectionAddress) {
@@ -230,13 +237,14 @@ TEST_F(ReverseTunnelInitiatorTest, SocketMethodWithReverseConnectionAddress) {
 
   auto reverse_address = std::make_shared<ReverseConnectionAddress>(config);
 
-  auto socket = socket_interface_->socket(Network::Socket::Type::Stream, reverse_address,
-                                          Network::SocketCreationOptions{});
-  EXPECT_NE(socket, nullptr);
-  EXPECT_TRUE(socket->isOpen());
+  absl::StatusOr<Network::IoHandlePtr> socket = socket_interface_->socket(
+      Network::Socket::Type::Stream, reverse_address, Network::SocketCreationOptions{});
+  ASSERT_TRUE(socket.ok()) << socket.status();
+  ASSERT_NE(*socket, nullptr);
+  EXPECT_TRUE((*socket)->isOpen());
 
   // Verify it's a ReverseConnectionIOHandle (not a regular socket)
-  auto* reverse_handle = dynamic_cast<ReverseConnectionIOHandle*>(socket.get());
+  auto* reverse_handle = dynamic_cast<ReverseConnectionIOHandle*>(socket->get());
   EXPECT_NE(reverse_handle, nullptr);
 }
 
@@ -253,10 +261,11 @@ TEST_F(ReverseTunnelInitiatorTest, SocketUsesCustomHandshakeRequestPathFromExten
   config.connection_count = 1;
 
   auto reverse_address = std::make_shared<ReverseConnectionAddress>(config);
-  auto socket = socket_interface_->socket(Network::Socket::Type::Stream, reverse_address,
-                                          Network::SocketCreationOptions{});
-  ASSERT_NE(socket, nullptr);
-  auto* reverse_handle = dynamic_cast<ReverseConnectionIOHandle*>(socket.get());
+  absl::StatusOr<Network::IoHandlePtr> socket = socket_interface_->socket(
+      Network::Socket::Type::Stream, reverse_address, Network::SocketCreationOptions{});
+  ASSERT_TRUE(socket.ok()) << socket.status();
+  ASSERT_NE(*socket, nullptr);
+  auto* reverse_handle = dynamic_cast<ReverseConnectionIOHandle*>(socket->get());
   ASSERT_NE(reverse_handle, nullptr);
   EXPECT_EQ(reverse_handle->requestPath(), "/custom/handshake");
 }
@@ -271,15 +280,16 @@ TEST_F(ReverseTunnelInitiatorTest, CreateReverseConnectionSocketStreamIPv4) {
   config.src_tenant_id = "test-tenant";
   config.remote_clusters.push_back(RemoteClusterConnectionConfig("remote-cluster", 2));
 
-  auto socket = socket_interface_->createReverseConnectionSocket(
+  absl::StatusOr<Network::IoHandlePtr> socket = socket_interface_->createReverseConnectionSocket(
       Network::Socket::Type::Stream, Network::Address::Type::Ip, Network::Address::IpVersion::v4,
       config);
 
-  EXPECT_NE(socket, nullptr);
-  EXPECT_TRUE(socket->isOpen());
+  ASSERT_TRUE(socket.ok()) << socket.status();
+  ASSERT_NE(*socket, nullptr);
+  EXPECT_TRUE((*socket)->isOpen());
 
   // Verify it's a ReverseConnectionIOHandle.
-  auto* reverse_handle = dynamic_cast<ReverseConnectionIOHandle*>(socket.get());
+  auto* reverse_handle = dynamic_cast<ReverseConnectionIOHandle*>(socket->get());
   EXPECT_NE(reverse_handle, nullptr);
 
   // Verify that the TLS registry scope is being used.
@@ -295,15 +305,16 @@ TEST_F(ReverseTunnelInitiatorTest, CreateReverseConnectionSocketStreamIPv6) {
   config.src_tenant_id = "test-tenant";
   config.remote_clusters.push_back(RemoteClusterConnectionConfig("remote-cluster", 2));
 
-  auto socket = socket_interface_->createReverseConnectionSocket(
+  absl::StatusOr<Network::IoHandlePtr> socket = socket_interface_->createReverseConnectionSocket(
       Network::Socket::Type::Stream, Network::Address::Type::Ip, Network::Address::IpVersion::v6,
       config);
 
-  EXPECT_NE(socket, nullptr);
-  EXPECT_TRUE(socket->isOpen());
+  ASSERT_TRUE(socket.ok()) << socket.status();
+  ASSERT_NE(*socket, nullptr);
+  EXPECT_TRUE((*socket)->isOpen());
 
   // Verify it's a ReverseConnectionIOHandle.
-  auto* reverse_handle = dynamic_cast<ReverseConnectionIOHandle*>(socket.get());
+  auto* reverse_handle = dynamic_cast<ReverseConnectionIOHandle*>(socket->get());
   EXPECT_NE(reverse_handle, nullptr);
 }
 
@@ -315,15 +326,16 @@ TEST_F(ReverseTunnelInitiatorTest, CreateReverseConnectionSocketDatagram) {
   config.src_tenant_id = "test-tenant";
   config.remote_clusters.push_back(RemoteClusterConnectionConfig("remote-cluster", 2));
 
-  auto socket = socket_interface_->createReverseConnectionSocket(
+  absl::StatusOr<Network::IoHandlePtr> socket = socket_interface_->createReverseConnectionSocket(
       Network::Socket::Type::Datagram, Network::Address::Type::Ip, Network::Address::IpVersion::v4,
       config);
 
-  EXPECT_NE(socket, nullptr);
-  EXPECT_TRUE(socket->isOpen());
+  ASSERT_TRUE(socket.ok()) << socket.status();
+  ASSERT_NE(*socket, nullptr);
+  EXPECT_TRUE((*socket)->isOpen());
 
   // Verify it's NOT a ReverseConnectionIOHandle.
-  auto* reverse_handle = dynamic_cast<ReverseConnectionIOHandle*>(socket.get());
+  auto* reverse_handle = dynamic_cast<ReverseConnectionIOHandle*>(socket->get());
   EXPECT_EQ(reverse_handle, nullptr);
 }
 
@@ -335,15 +347,16 @@ TEST_F(ReverseTunnelInitiatorTest, CreateReverseConnectionSocketNonIP) {
   config.src_tenant_id = "test-tenant";
   config.remote_clusters.push_back(RemoteClusterConnectionConfig("remote-cluster", 2));
 
-  auto socket = socket_interface_->createReverseConnectionSocket(
+  absl::StatusOr<Network::IoHandlePtr> socket = socket_interface_->createReverseConnectionSocket(
       Network::Socket::Type::Stream, Network::Address::Type::Pipe, Network::Address::IpVersion::v4,
       config);
 
-  EXPECT_NE(socket, nullptr);
-  EXPECT_TRUE(socket->isOpen());
+  ASSERT_TRUE(socket.ok()) << socket.status();
+  ASSERT_NE(*socket, nullptr);
+  EXPECT_TRUE((*socket)->isOpen());
 
   // Verify it's NOT a ReverseConnectionIOHandle (should be a regular socket)
-  auto* reverse_handle = dynamic_cast<ReverseConnectionIOHandle*>(socket.get());
+  auto* reverse_handle = dynamic_cast<ReverseConnectionIOHandle*>(socket->get());
   EXPECT_EQ(reverse_handle, nullptr);
 }
 
@@ -355,12 +368,13 @@ TEST_F(ReverseTunnelInitiatorTest, CreateReverseConnectionSocketEmptyRemoteClust
   config.src_tenant_id = "test-tenant";
   // No remote_clusters added - should return early.
 
-  auto socket = socket_interface_->createReverseConnectionSocket(
+  absl::StatusOr<Network::IoHandlePtr> socket = socket_interface_->createReverseConnectionSocket(
       Network::Socket::Type::Stream, Network::Address::Type::Ip, Network::Address::IpVersion::v4,
       config);
 
   // Should return nullptr due to empty remote_clusters.
-  EXPECT_EQ(socket, nullptr);
+  ASSERT_TRUE(socket.ok()) << socket.status();
+  EXPECT_EQ(*socket, nullptr);
 }
 
 TEST_F(ReverseTunnelInitiatorTest, SocketMethodWithEmptyReverseConnectionAddress) {
@@ -374,10 +388,11 @@ TEST_F(ReverseTunnelInitiatorTest, SocketMethodWithEmptyReverseConnectionAddress
 
   auto reverse_address = std::make_shared<ReverseConnectionAddress>(config);
 
-  auto socket = socket_interface_->socket(Network::Socket::Type::Stream, reverse_address,
-                                          Network::SocketCreationOptions{});
-  EXPECT_NE(socket, nullptr);
-  EXPECT_TRUE(socket->isOpen());
+  absl::StatusOr<Network::IoHandlePtr> socket = socket_interface_->socket(
+      Network::Socket::Type::Stream, reverse_address, Network::SocketCreationOptions{});
+  ASSERT_TRUE(socket.ok()) << socket.status();
+  ASSERT_NE(*socket, nullptr);
+  EXPECT_TRUE((*socket)->isOpen());
 }
 
 TEST_F(ReverseTunnelInitiatorTest, SocketMethodWithSocketCreationOptions) {
@@ -387,9 +402,11 @@ TEST_F(ReverseTunnelInitiatorTest, SocketMethodWithSocketCreationOptions) {
   options.max_addresses_cache_size_ = 100;
 
   auto address = std::make_shared<Network::Address::Ipv4Instance>("127.0.0.1", 0);
-  auto socket = socket_interface_->socket(Network::Socket::Type::Stream, address, options);
-  EXPECT_NE(socket, nullptr);
-  EXPECT_TRUE(socket->isOpen());
+  absl::StatusOr<Network::IoHandlePtr> socket =
+      socket_interface_->socket(Network::Socket::Type::Stream, address, options);
+  ASSERT_TRUE(socket.ok()) << socket.status();
+  ASSERT_NE(*socket, nullptr);
+  EXPECT_TRUE((*socket)->isOpen());
 }
 
 } // namespace ReverseConnection

--- a/test/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/reverse_tunnel_acceptor_test.cc
+++ b/test/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/reverse_tunnel_acceptor_test.cc
@@ -10,6 +10,7 @@
 #include "test/mocks/stats/mocks.h"
 #include "test/mocks/thread_local/mocks.h"
 
+#include "absl/status/statusor.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
@@ -169,19 +170,24 @@ TEST_F(TestReverseTunnelAcceptor, CreateEmptyConfigProto) {
 
 TEST_F(TestReverseTunnelAcceptor, SocketWithoutAddress) {
   Network::SocketCreationOptions options;
-  auto io_handle =
+  absl::StatusOr<Network::IoHandlePtr> io_handle =
       socket_interface_->socket(Network::Socket::Type::Stream, Network::Address::Type::Ip,
                                 Network::Address::IpVersion::v4, false, options);
-  EXPECT_EQ(io_handle, nullptr);
+  EXPECT_FALSE(io_handle.ok());
+  EXPECT_EQ(io_handle.status().code(), absl::StatusCode::kInvalidArgument);
+  EXPECT_THAT(io_handle.status().message(), ::testing::HasSubstr("called without address"));
 }
 
 TEST_F(TestReverseTunnelAcceptor, SocketWithAddressNoThreadLocal) {
   const std::string node_id = "test-node";
   auto address = createAddressWithLogicalName(node_id);
   Network::SocketCreationOptions options;
-  auto io_handle = socket_interface_->socket(Network::Socket::Type::Stream, address, options);
-  EXPECT_NE(io_handle, nullptr);
-  EXPECT_EQ(dynamic_cast<UpstreamReverseConnectionIOHandle*>(io_handle.get()), nullptr);
+  absl::StatusOr<Network::IoHandlePtr> io_handle =
+      socket_interface_->socket(Network::Socket::Type::Stream, address, options);
+
+  ASSERT_TRUE(io_handle.ok()) << io_handle.status();
+  ASSERT_NE(*io_handle, nullptr);
+  EXPECT_EQ(dynamic_cast<UpstreamReverseConnectionIOHandle*>(io_handle->get()), nullptr);
 
   // Verify fallback counter increments for diagnostics.
   // Counter name is "<scope>.<stat_prefix>.fallback_no_reverse_socket".
@@ -199,9 +205,11 @@ TEST_F(TestReverseTunnelAcceptor, SocketWithAddressAndThreadLocalNoCachedSockets
   auto address = createAddressWithLogicalName(node_id);
 
   Network::SocketCreationOptions options;
-  auto io_handle = socket_interface_->socket(Network::Socket::Type::Stream, address, options);
-  EXPECT_NE(io_handle, nullptr);
-  EXPECT_EQ(dynamic_cast<UpstreamReverseConnectionIOHandle*>(io_handle.get()), nullptr);
+  absl::StatusOr<Network::IoHandlePtr> io_handle =
+      socket_interface_->socket(Network::Socket::Type::Stream, address, options);
+  ASSERT_TRUE(io_handle.ok()) << io_handle.status();
+  ASSERT_NE(*io_handle, nullptr);
+  EXPECT_EQ(dynamic_cast<UpstreamReverseConnectionIOHandle*>(io_handle->get()), nullptr);
 }
 
 TEST_F(TestReverseTunnelAcceptor, SocketWithAddressAndThreadLocalWithCachedSockets) {
@@ -221,16 +229,19 @@ TEST_F(TestReverseTunnelAcceptor, SocketWithAddressAndThreadLocalWithCachedSocke
   auto address = createAddressWithLogicalName(node_id);
 
   Network::SocketCreationOptions options;
-  auto io_handle = socket_interface_->socket(Network::Socket::Type::Stream, address, options);
-  EXPECT_NE(io_handle, nullptr);
+  absl::StatusOr<Network::IoHandlePtr> io_handle =
+      socket_interface_->socket(Network::Socket::Type::Stream, address, options);
+  ASSERT_TRUE(io_handle.ok()) << io_handle.status();
+  ASSERT_NE(*io_handle, nullptr);
 
-  auto* upstream_io_handle = dynamic_cast<UpstreamReverseConnectionIOHandle*>(io_handle.get());
+  auto* upstream_io_handle = dynamic_cast<UpstreamReverseConnectionIOHandle*>(io_handle->get());
   EXPECT_NE(upstream_io_handle, nullptr);
 
-  auto another_io_handle =
+  absl::StatusOr<Network::IoHandlePtr> another_io_handle =
       socket_interface_->socket(Network::Socket::Type::Stream, address, options);
-  EXPECT_NE(another_io_handle, nullptr);
-  EXPECT_EQ(dynamic_cast<UpstreamReverseConnectionIOHandle*>(another_io_handle.get()), nullptr);
+  ASSERT_TRUE(another_io_handle.ok()) << another_io_handle.status();
+  ASSERT_NE(*another_io_handle, nullptr);
+  EXPECT_EQ(dynamic_cast<UpstreamReverseConnectionIOHandle*>(another_io_handle->get()), nullptr);
 }
 
 TEST_F(TestReverseTunnelAcceptor, IpFamilySupported) {

--- a/test/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/upstream_reverse_connection_io_handle_test.cc
+++ b/test/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/upstream_reverse_connection_io_handle_test.cc
@@ -9,6 +9,7 @@
 #include "test/mocks/server/factory_context.h"
 #include "test/test_common/registry.h"
 
+#include "absl/status/statusor.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
@@ -169,15 +170,15 @@ TEST_F(UpstreamReverseConnectionIOHandleTest, CloseWhenSocketInterfaceWrongType)
     ProtobufTypes::MessagePtr createEmptyConfigProto() override { return nullptr; }
 
     // SocketInterface methods
-    Network::IoHandlePtr socket(Network::Socket::Type, Network::Address::Type,
-                                Network::Address::IpVersion, bool,
-                                const Network::SocketCreationOptions&) const override {
+    absl::StatusOr<Network::IoHandlePtr>
+    socket(Network::Socket::Type, Network::Address::Type, Network::Address::IpVersion, bool,
+           const Network::SocketCreationOptions&) const override {
       return nullptr;
     }
 
-    Network::IoHandlePtr socket(Network::Socket::Type,
-                                const Network::Address::InstanceConstSharedPtr,
-                                const Network::SocketCreationOptions&) const override {
+    absl::StatusOr<Network::IoHandlePtr>
+    socket(Network::Socket::Type, const Network::Address::InstanceConstSharedPtr,
+           const Network::SocketCreationOptions&) const override {
       return nullptr;
     }
 

--- a/test/extensions/filters/listener/proxy_protocol/proxy_protocol_test.cc
+++ b/test/extensions/filters/listener/proxy_protocol/proxy_protocol_test.cc
@@ -253,22 +253,6 @@ INSTANTIATE_TEST_SUITE_P(IpVersions, ProxyProtocolTest,
                          testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                          TestUtility::ipTestParamsToString);
 
-TEST_P(ProxyProtocolTest, V1UnsupportedIPv4) {
-  connect(false);
-  Cleanup cleaner = Network::Address::Ipv4Instance::forceProtocolUnsupportedForTest(true);
-  write("PROXY TCP4 1.2.3.4 253.253.253.253 65535 1234\r\nmore data");
-  expectProxyProtoError();
-  EXPECT_EQ(stats_store_.counter("proxy_proto.versions.v1.error").value(), 1);
-}
-
-TEST_P(ProxyProtocolTest, V1UnsupportedIPv6) {
-  connect(false);
-  Cleanup cleaner = Network::Address::Ipv6Instance::forceProtocolUnsupportedForTest(true);
-  write("PROXY TCP6 1:2:3::4 5:6::7:8 65535 1234\r\nmore data");
-  expectProxyProtoError();
-  EXPECT_EQ(stats_store_.counter("proxy_proto.versions.v1.error").value(), 1);
-}
-
 TEST_P(ProxyProtocolTest, V1Basic) {
   connect();
   write("PROXY TCP4 1.2.3.4 253.253.253.253 65535 1234\r\nmore data");
@@ -438,36 +422,6 @@ TEST_P(ProxyProtocolTest, V2BasicV6) {
 
   disconnect();
   EXPECT_EQ(stats_store_.counter("proxy_proto.versions.v2.found").value(), 1);
-}
-
-TEST_P(ProxyProtocolTest, V2UnsupportedIPv4) {
-  // A well-formed ipv4/tcp message, no extensions
-  constexpr uint8_t buffer[] = {0x0d, 0x0a, 0x0d, 0x0a, 0x00, 0x0d, 0x0a, 0x51, 0x55, 0x49,
-                                0x54, 0x0a, 0x21, 0x11, 0x00, 0x0c, 0x01, 0x02, 0x03, 0x04,
-                                0x00, 0x01, 0x01, 0x02, 0x03, 0x05, 0x00, 0x02, 'm',  'o',
-                                'r',  'e',  ' ',  'd',  'a',  't',  'a'};
-
-  connect(false);
-  Cleanup cleaner = Network::Address::Ipv4Instance::forceProtocolUnsupportedForTest(true);
-  write(buffer, sizeof(buffer));
-  expectProxyProtoError();
-  EXPECT_EQ(stats_store_.counter("proxy_proto.versions.v2.error").value(), 1);
-}
-
-TEST_P(ProxyProtocolTest, V2UnsupportedIPv6) {
-  // A well-formed ipv6/tcp message, no extensions
-  constexpr uint8_t buffer[] = {0x0d, 0x0a, 0x0d, 0x0a, 0x00, 0x0d, 0x0a, 0x51, 0x55, 0x49, 0x54,
-                                0x0a, 0x21, 0x22, 0x00, 0x24, 0x00, 0x01, 0x00, 0x02, 0x00, 0x03,
-                                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0x00,
-                                0x01, 0x01, 0x00, 0x02, 0x00, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00,
-                                0x00, 0x00, 0x00, 0x00, 0x00, 0x08, 0x00, 0x02, 'm',  'o',  'r',
-                                'e',  ' ',  'd',  'a',  't',  'a'};
-
-  connect(false);
-  Cleanup cleaner = Network::Address::Ipv6Instance::forceProtocolUnsupportedForTest(true);
-  write(buffer, sizeof(buffer));
-  expectProxyProtoError();
-  EXPECT_EQ(stats_store_.counter("proxy_proto.versions.v2.error").value(), 1);
 }
 
 TEST_P(ProxyProtocolTest, V2UnsupportedAF) {

--- a/test/extensions/filters/udp/udp_proxy/udp_proxy_filter_test.cc
+++ b/test/extensions/filters/udp/udp_proxy/udp_proxy_filter_test.cc
@@ -30,6 +30,7 @@
 #include "test/mocks/upstream/thread_local_cluster.h"
 #include "test/test_common/threadsafe_singleton_injector.h"
 
+#include "absl/status/statusor.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
@@ -72,7 +73,8 @@ public:
                      const UdpProxyFilterConfigSharedPtr& config)
       : UdpProxyFilter(callbacks, config) {}
 
-  MOCK_METHOD(Network::SocketPtr, createUdpSocket, (const Upstream::HostConstSharedPtr& host));
+  MOCK_METHOD(absl::StatusOr<Network::SocketPtr>, createUdpSocket,
+              (const Upstream::HostConstSharedPtr& host));
 };
 
 class TestStickySessionUdpProxyFilter : public TestUdpProxyFilter,
@@ -325,7 +327,8 @@ public:
     }
 
     EXPECT_CALL(*filter_, createUdpSocket(_))
-        .WillOnce(Return(ByMove(Network::SocketPtr{test_sessions_.back().socket_})));
+        .WillOnce(Return(ByMove(absl::StatusOr<Network::SocketPtr>{
+            Network::SocketPtr{test_sessions_.back().socket_}})));
     EXPECT_CALL(
         *new_session.socket_->io_handle_,
         createFileEvent_(_, _, Event::PlatformDefaultTriggerType, Event::FileReadyType::Read))

--- a/test/extensions/upstreams/http/udp/upstream_request_test.cc
+++ b/test/extensions/upstreams/http/udp/upstream_request_test.cc
@@ -240,6 +240,8 @@ TEST_F(UdpConnPoolTest, ApplySocketOptionsFailure) {
   NiceMock<Envoy::Api::MockOsSysCalls> mock_os_sys_calls;
   Envoy::TestThreadsafeSingletonInjector<Envoy::Api::OsSysCallsImpl> os_sys_calls(
       &mock_os_sys_calls);
+  // Allow close() to succeed for the socket created in ipFamilySupported() check.
+  ON_CALL(mock_os_sys_calls, close).WillByDefault(Return(Api::SysCallIntResult{0, 0}));
   // Use ON_CALL since the applyOptions call fail without calling the setsockopt_ in Windows.
   ON_CALL(mock_os_sys_calls, setsockopt_).WillByDefault(Return(-1));
   udp_conn_pool_->newStream(&mock_callback_);
@@ -251,6 +253,8 @@ TEST_F(UdpConnPoolTest, BindFailure) {
   NiceMock<Envoy::Api::MockOsSysCalls> mock_os_sys_calls;
   Envoy::TestThreadsafeSingletonInjector<Envoy::Api::OsSysCallsImpl> os_sys_calls(
       &mock_os_sys_calls);
+  // Allow close() to succeed for the socket created in ipFamilySupported() check.
+  ON_CALL(mock_os_sys_calls, close).WillByDefault(Return(Api::SysCallIntResult{0, 0}));
   EXPECT_CALL(mock_os_sys_calls, bind).WillOnce(Return(Api::SysCallIntResult{-1, 0}));
   udp_conn_pool_->newStream(&mock_callback_);
 }
@@ -277,6 +281,8 @@ TEST_F(UdpConnPoolTest, ConnectionInfoProviderHasRemoteAddress) {
   NiceMock<Envoy::Api::MockOsSysCalls> mock_os_sys_calls;
   Envoy::TestThreadsafeSingletonInjector<Envoy::Api::OsSysCallsImpl> os_sys_calls(
       &mock_os_sys_calls);
+  // Allow close() to succeed for the socket created in ipFamilySupported() check.
+  ON_CALL(mock_os_sys_calls, close).WillByDefault(Return(Api::SysCallIntResult{0, 0}));
   EXPECT_CALL(mock_os_sys_calls, bind).WillOnce(Return(Api::SysCallIntResult{0, 0}));
   udp_conn_pool_->newStream(&mock_callback_);
 

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -32,6 +32,7 @@
 #include "test/mocks/stream_info/mocks.h"
 #include "test/test_common/printers.h"
 
+#include "absl/status/statusor.h"
 #include "gmock/gmock.h"
 
 namespace Envoy {
@@ -759,10 +760,10 @@ class MockSocketInterface : public SocketInterfaceImpl {
 public:
   explicit MockSocketInterface(const std::vector<Address::IpVersion>& versions)
       : versions_(versions.begin(), versions.end()) {}
-  MOCK_METHOD(IoHandlePtr, socket,
+  MOCK_METHOD(absl::StatusOr<IoHandlePtr>, socket,
               (Socket::Type, Address::Type, Address::IpVersion, bool, const SocketCreationOptions&),
               (const));
-  MOCK_METHOD(IoHandlePtr, socket,
+  MOCK_METHOD(absl::StatusOr<IoHandlePtr>, socket,
               (Socket::Type, const Address::InstanceConstSharedPtr, const SocketCreationOptions&),
               (const));
   bool ipFamilySupported(int domain) override {


### PR DESCRIPTION
Commit Message:

1. Allow Ipv4Instance and Ipv6Instance objects to be created even if host does not support IPv4 or IPv6.
2. Add support for SocketInterfaceImpl::socket() to return error status to signal unsupported IP family at socket creation time.

Additional Description: This PR is inspired by https://github.com/envoyproxy/envoy/pull/41836#issuecomment-3517667805 and in its first iteration is a proof of concept as an alternative to #41836. In order to be considered for merging, it will require flag protection and extensive testing.
Risk Level: medium
Testing: TODO
Docs Changes: n/a
Release Notes: allow proxy_protocol to parse IPv4 or IPv6 addresses even when not supported by host
Platform Specific Features: n/a
Optional Runtime guard: TODO
Fixes #41826