### PR TITLE
Include openssh-client in devcontainer

### DIFF
--- a/.devcontainer/Dockerfile.in
+++ b/.devcontainer/Dockerfile.in
@@ -8,7 +8,7 @@ ENV BUILD_DIR=/build
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get -y update \
-  && apt-get -y install --no-install-recommends libpython3.13 net-tools psmisc vim 2>&1 \
+  && apt-get -y install --no-install-recommends libpython3.13 net-tools psmisc vim openssh-client 2>&1 \
   # Create a non-root user to use if preferred - see https://aka.ms/vscode-remote/containers/non-root-user.
   && groupadd --gid $USER_GID $USERNAME \
   && groupadd -f pcap \


### PR DESCRIPTION
Commit Message: Include openssh-client in devcontainer
Additional Description: `git push origin $BRANCHNAME` doesn't work from inside a devcontainer without this change, due to the absence of `ssh`. An alternative way to achieve the same end would be to include the ssh client in the base image.
Risk Level: Negative, devcontainer behavior is currently malfunctioning and this improves it.
Testing: Rebuilt a devcontainer after this change and it went from not working to working.
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
