### PR TITLE
dynamic module: unify the abi name

### DIFF
--- a/source/extensions/dynamic_modules/abi.h
+++ b/source/extensions/dynamic_modules/abi.h
@@ -1072,7 +1072,7 @@ envoy_dynamic_module_callback_http_filter_config_define_gauge_vec(
     size_t* gauge_id_ptr);
 
 /**
- * envoy_dynamic_module_callback_http_filter_increase_gauge is called by the module to increase the
+ * envoy_dynamic_module_callback_http_filter_increment_gauge is called by the module to increase the
  * value of a previously defined gauge.
  *
  * @param filter_envoy_ptr is the pointer to the DynamicModuleHttpFilter object.
@@ -1081,11 +1081,11 @@ envoy_dynamic_module_callback_http_filter_config_define_gauge_vec(
  * @param value is the value to increase the gauge by.
  * @return the result of the operation.
  */
-envoy_dynamic_module_type_metrics_result envoy_dynamic_module_callback_http_filter_increase_gauge(
+envoy_dynamic_module_type_metrics_result envoy_dynamic_module_callback_http_filter_increment_gauge(
     envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr, size_t id, uint64_t value);
 
 /**
- * envoy_dynamic_module_callback_http_filter_increase_gauge_vec is called by the module to increase
+ * envoy_dynamic_module_callback_http_filter_increment_gauge_vec is called by the module to increase
  * the value of a previously defined gauge vec.
  *
  * @param filter_envoy_ptr is the pointer to the DynamicModuleHttpFilter object.
@@ -1097,13 +1097,13 @@ envoy_dynamic_module_type_metrics_result envoy_dynamic_module_callback_http_filt
  * @return the result of the operation.
  */
 envoy_dynamic_module_type_metrics_result
-envoy_dynamic_module_callback_http_filter_increase_gauge_vec(
+envoy_dynamic_module_callback_http_filter_increment_gauge_vec(
     envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr, size_t id,
     envoy_dynamic_module_type_module_buffer* label_values, size_t label_values_length,
     uint64_t value);
 
 /**
- * envoy_dynamic_module_callback_http_filter_decrease_gauge is called by the module to decrease the
+ * envoy_dynamic_module_callback_http_filter_decrement_gauge is called by the module to decrease the
  * value of a previously defined gauge.
  *
  * @param filter_envoy_ptr is the pointer to the DynamicModuleHttpFilter object.
@@ -1112,11 +1112,11 @@ envoy_dynamic_module_callback_http_filter_increase_gauge_vec(
  * @param value is the value to decrease the gauge by.
  * @return the result of the operation.
  */
-envoy_dynamic_module_type_metrics_result envoy_dynamic_module_callback_http_filter_decrease_gauge(
+envoy_dynamic_module_type_metrics_result envoy_dynamic_module_callback_http_filter_decrement_gauge(
     envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr, size_t id, uint64_t value);
 
 /**
- * envoy_dynamic_module_callback_http_filter_decrease_gauge_vec is called by the module to decrease
+ * envoy_dynamic_module_callback_http_filter_decrement_gauge_vec is called by the module to decrease
  * the value of a previously defined gauge vec.
  *
  * @param filter_envoy_ptr is the pointer to the DynamicModuleHttpFilter object.
@@ -1128,7 +1128,7 @@ envoy_dynamic_module_type_metrics_result envoy_dynamic_module_callback_http_filt
  * @return the result of the operation.
  */
 envoy_dynamic_module_type_metrics_result
-envoy_dynamic_module_callback_http_filter_decrease_gauge_vec(
+envoy_dynamic_module_callback_http_filter_decrement_gauge_vec(
     envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr, size_t id,
     envoy_dynamic_module_type_module_buffer* label_values, size_t label_values_length,
     uint64_t value);

--- a/source/extensions/dynamic_modules/abi_version.h
+++ b/source/extensions/dynamic_modules/abi_version.h
@@ -6,7 +6,7 @@ namespace DynamicModules {
 #endif
 // This is the ABI version calculated as a sha256 hash of the ABI header files. When the ABI
 // changes, this value must change, and the correctness of this value is checked by the test.
-const char* kAbiVersion = "1ba1ea660354920fa486a9b6fa80917bd6df046ae05c7ebd7a26d4a7155ed7b7";
+const char* kAbiVersion = "a99c48e67c54e9d7a0074657be47da70327c98410558ab1ce34405149b27d55e";
 
 #ifdef __cplusplus
 } // namespace DynamicModules

--- a/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
@@ -2310,7 +2310,7 @@ impl EnvoyHttpFilter for EnvoyHttpFilterImpl {
   ) -> Result<(), envoy_dynamic_module_type_metrics_result> {
     let EnvoyGaugeId(id) = id;
     let res = unsafe {
-      abi::envoy_dynamic_module_callback_http_filter_increase_gauge(self.raw_ptr, id, value)
+      abi::envoy_dynamic_module_callback_http_filter_increment_gauge(self.raw_ptr, id, value)
     };
     if res == envoy_dynamic_module_type_metrics_result::Success {
       Ok(())
@@ -2327,7 +2327,7 @@ impl EnvoyHttpFilter for EnvoyHttpFilterImpl {
   ) -> Result<(), envoy_dynamic_module_type_metrics_result> {
     let EnvoyGaugeVecId(id) = id;
     let res = unsafe {
-      abi::envoy_dynamic_module_callback_http_filter_increase_gauge_vec(
+      abi::envoy_dynamic_module_callback_http_filter_increment_gauge_vec(
         self.raw_ptr,
         id,
         labels.as_ptr() as *const _ as *mut _,
@@ -2349,7 +2349,7 @@ impl EnvoyHttpFilter for EnvoyHttpFilterImpl {
   ) -> Result<(), envoy_dynamic_module_type_metrics_result> {
     let EnvoyGaugeId(id) = id;
     let res = unsafe {
-      abi::envoy_dynamic_module_callback_http_filter_decrease_gauge(self.raw_ptr, id, value)
+      abi::envoy_dynamic_module_callback_http_filter_decrement_gauge(self.raw_ptr, id, value)
     };
     if res == envoy_dynamic_module_type_metrics_result::Success {
       Ok(())
@@ -2366,7 +2366,7 @@ impl EnvoyHttpFilter for EnvoyHttpFilterImpl {
   ) -> Result<(), envoy_dynamic_module_type_metrics_result> {
     let EnvoyGaugeVecId(id) = id;
     let res = unsafe {
-      abi::envoy_dynamic_module_callback_http_filter_decrease_gauge_vec(
+      abi::envoy_dynamic_module_callback_http_filter_decrement_gauge_vec(
         self.raw_ptr,
         id,
         labels.as_ptr() as *const _ as *mut _,

--- a/source/extensions/filters/http/dynamic_modules/abi_impl.cc
+++ b/source/extensions/filters/http/dynamic_modules/abi_impl.cc
@@ -219,7 +219,7 @@ envoy_dynamic_module_callback_http_filter_config_define_gauge_vec(
   return envoy_dynamic_module_type_metrics_result_Success;
 }
 
-envoy_dynamic_module_type_metrics_result envoy_dynamic_module_callback_http_filter_increase_gauge(
+envoy_dynamic_module_type_metrics_result envoy_dynamic_module_callback_http_filter_increment_gauge(
     envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr, size_t id, uint64_t value) {
   auto filter = static_cast<DynamicModuleHttpFilter*>(filter_envoy_ptr);
   auto gauge = filter->getFilterConfig().getGaugeById(id);
@@ -231,7 +231,7 @@ envoy_dynamic_module_type_metrics_result envoy_dynamic_module_callback_http_filt
 }
 
 envoy_dynamic_module_type_metrics_result
-envoy_dynamic_module_callback_http_filter_increase_gauge_vec(
+envoy_dynamic_module_callback_http_filter_increment_gauge_vec(
     envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr, size_t id,
     envoy_dynamic_module_type_module_buffer* label_values, size_t label_values_length,
     uint64_t value) {
@@ -249,7 +249,7 @@ envoy_dynamic_module_callback_http_filter_increase_gauge_vec(
   return envoy_dynamic_module_type_metrics_result_Success;
 }
 
-envoy_dynamic_module_type_metrics_result envoy_dynamic_module_callback_http_filter_decrease_gauge(
+envoy_dynamic_module_type_metrics_result envoy_dynamic_module_callback_http_filter_decrement_gauge(
     envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr, size_t id, uint64_t value) {
   auto filter = static_cast<DynamicModuleHttpFilter*>(filter_envoy_ptr);
   auto gauge = filter->getFilterConfig().getGaugeById(id);
@@ -261,7 +261,7 @@ envoy_dynamic_module_type_metrics_result envoy_dynamic_module_callback_http_filt
 }
 
 envoy_dynamic_module_type_metrics_result
-envoy_dynamic_module_callback_http_filter_decrease_gauge_vec(
+envoy_dynamic_module_callback_http_filter_decrement_gauge_vec(
     envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr, size_t id,
     envoy_dynamic_module_type_module_buffer* label_values, size_t label_values_length,
     uint64_t value) {

--- a/test/extensions/dynamic_modules/http/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/http/abi_impl_test.cc
@@ -1561,13 +1561,13 @@ TEST(ABIImpl, Stats) {
   Stats::GaugeOptConstRef gauge = stats_store.findGaugeByString("dynamicmodulescustom.some_gauge");
   EXPECT_TRUE(gauge.has_value());
   EXPECT_EQ(gauge->get().value(), 0);
-  result = envoy_dynamic_module_callback_http_filter_increase_gauge(&filter, gauge_id, 10);
+  result = envoy_dynamic_module_callback_http_filter_increment_gauge(&filter, gauge_id, 10);
   EXPECT_EQ(result, envoy_dynamic_module_type_metrics_result_Success);
   EXPECT_EQ(gauge->get().value(), 10);
-  result = envoy_dynamic_module_callback_http_filter_increase_gauge(&filter, gauge_id, 42);
+  result = envoy_dynamic_module_callback_http_filter_increment_gauge(&filter, gauge_id, 42);
   EXPECT_EQ(result, envoy_dynamic_module_type_metrics_result_Success);
   EXPECT_EQ(gauge->get().value(), 52);
-  result = envoy_dynamic_module_callback_http_filter_decrease_gauge(&filter, gauge_id, 50);
+  result = envoy_dynamic_module_callback_http_filter_decrement_gauge(&filter, gauge_id, 50);
   EXPECT_EQ(result, envoy_dynamic_module_type_metrics_result_Success);
   EXPECT_EQ(gauge->get().value(), 2);
   result = envoy_dynamic_module_callback_http_filter_set_gauge(&filter, gauge_id, 9001);
@@ -1589,18 +1589,18 @@ TEST(ABIImpl, Stats) {
   std::vector<envoy_dynamic_module_type_module_buffer> gauge_vec_labels_values = {
       {const_cast<char*>(gauge_vec_label_value.data()), gauge_vec_label_value.size()},
   };
-  result = envoy_dynamic_module_callback_http_filter_increase_gauge_vec(
+  result = envoy_dynamic_module_callback_http_filter_increment_gauge_vec(
       &filter, gauge_vec_id, gauge_vec_labels_values.data(), gauge_vec_labels_values.size(), 10);
   EXPECT_EQ(result, envoy_dynamic_module_type_metrics_result_Success);
   Stats::GaugeOptConstRef gauge_vec =
       stats_store.findGaugeByString("dynamicmodulescustom.some_gauge_vec.some_label.some_value");
   EXPECT_TRUE(gauge_vec.has_value());
   EXPECT_EQ(gauge_vec->get().value(), 10);
-  result = envoy_dynamic_module_callback_http_filter_increase_gauge_vec(
+  result = envoy_dynamic_module_callback_http_filter_increment_gauge_vec(
       &filter, gauge_vec_id, gauge_vec_labels_values.data(), gauge_vec_labels_values.size(), 10);
   EXPECT_EQ(result, envoy_dynamic_module_type_metrics_result_Success);
   EXPECT_EQ(gauge_vec->get().value(), 20);
-  result = envoy_dynamic_module_callback_http_filter_decrease_gauge_vec(
+  result = envoy_dynamic_module_callback_http_filter_decrement_gauge_vec(
       &filter, gauge_vec_id, gauge_vec_labels_values.data(), gauge_vec_labels_values.size(), 12);
   EXPECT_EQ(result, envoy_dynamic_module_type_metrics_result_Success);
   EXPECT_EQ(gauge_vec->get().value(), 8);
@@ -1672,16 +1672,16 @@ TEST(ABIImpl, Stats) {
       &filter, invalid_stat_id, counter_vec_labels_values.data(), counter_vec_labels_values.size(),
       10);
   EXPECT_EQ(result, envoy_dynamic_module_type_metrics_result_MetricNotFound);
-  result = envoy_dynamic_module_callback_http_filter_increase_gauge(&filter, invalid_stat_id, 10);
+  result = envoy_dynamic_module_callback_http_filter_increment_gauge(&filter, invalid_stat_id, 10);
   EXPECT_EQ(result, envoy_dynamic_module_type_metrics_result_MetricNotFound);
-  result = envoy_dynamic_module_callback_http_filter_decrease_gauge(&filter, invalid_stat_id, 10);
+  result = envoy_dynamic_module_callback_http_filter_decrement_gauge(&filter, invalid_stat_id, 10);
   EXPECT_EQ(result, envoy_dynamic_module_type_metrics_result_MetricNotFound);
   result = envoy_dynamic_module_callback_http_filter_set_gauge(&filter, invalid_stat_id, 10);
   EXPECT_EQ(result, envoy_dynamic_module_type_metrics_result_MetricNotFound);
-  result = envoy_dynamic_module_callback_http_filter_increase_gauge_vec(
+  result = envoy_dynamic_module_callback_http_filter_increment_gauge_vec(
       &filter, invalid_stat_id, gauge_vec_labels_values.data(), gauge_vec_labels_values.size(), 10);
   EXPECT_EQ(result, envoy_dynamic_module_type_metrics_result_MetricNotFound);
-  result = envoy_dynamic_module_callback_http_filter_decrease_gauge_vec(
+  result = envoy_dynamic_module_callback_http_filter_decrement_gauge_vec(
       &filter, invalid_stat_id, gauge_vec_labels_values.data(), gauge_vec_labels_values.size(), 10);
   EXPECT_EQ(result, envoy_dynamic_module_type_metrics_result_MetricNotFound);
   result = envoy_dynamic_module_callback_http_filter_set_gauge_vec(
@@ -1699,8 +1699,8 @@ TEST(ABIImpl, Stats) {
   result = envoy_dynamic_module_callback_http_filter_increment_counter_vec(&filter, counter_vec_id,
                                                                            {}, 0, 10);
   EXPECT_EQ(result, envoy_dynamic_module_type_metrics_result_InvalidLabels);
-  result = envoy_dynamic_module_callback_http_filter_increase_gauge_vec(&filter, gauge_vec_id, {},
-                                                                        0, 10);
+  result = envoy_dynamic_module_callback_http_filter_increment_gauge_vec(&filter, gauge_vec_id, {},
+                                                                         0, 10);
   EXPECT_EQ(result, envoy_dynamic_module_type_metrics_result_InvalidLabels);
   result = envoy_dynamic_module_callback_http_filter_record_histogram_value_vec(
       &filter, histogram_vec_id, {}, 0, 10);


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: dynamic module: unify the abi name of gauge metric.
Additional Description:
Risk Level: n/a.
Testing: n/a.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.