### PR TITLE
oauth2: move cookie_domain field in the API alongside the path field

### DIFF
--- a/api/envoy/extensions/filters/http/oauth2/v3/BUILD
+++ b/api/envoy/extensions/filters/http/oauth2/v3/BUILD
@@ -6,6 +6,7 @@ licenses(["notice"])  # Apache 2
 
 api_proto_package(
     deps = [
+        "//envoy/annotations:pkg",
         "//envoy/config/core/v3:pkg",
         "//envoy/config/route/v3:pkg",
         "//envoy/extensions/transport_sockets/tls/v3:pkg",

--- a/api/envoy/extensions/filters/http/oauth2/v3/oauth.proto
+++ b/api/envoy/extensions/filters/http/oauth2/v3/oauth.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package envoy.extensions.filters.http.oauth2.v3;
 
+import "envoy/annotations/deprecation.proto";
 import "envoy/config/core/v3/base.proto";
 import "envoy/config/core/v3/http_uri.proto";
 import "envoy/config/route/v3/route_components.proto";
@@ -47,6 +48,11 @@ message CookieConfig {
   //
   // If not specified, defaults to ``/``.
   string path = 2 [(validate.rules).string = {pattern: "^$|^/[^\\x00-\\x1f\\x7f \",;<>\\\\]*$"}];
+
+  // The domain attribute for the cookie.
+  //
+  // If not specified, defaults to the request host without subdomains.
+  string domain = 3 [(validate.rules).string = {pattern: "^$|^[^\\x00-\\x1f\\x7f \",;<>\\\\]+$"}];
 }
 
 // [#next-free-field: 8]
@@ -131,7 +137,11 @@ message OAuth2Credentials {
 
   // The domain to set the cookie on. If not set, the cookie will default to the host of the request, not including the subdomains.
   // This is useful when token cookies need to be shared across multiple subdomains.
-  string cookie_domain = 5;
+  //
+  // This field is deprecated. Use :ref:`cookie_configs.*.domain
+  // <envoy_v3_api_field_extensions.filters.http.oauth2.v3.CookieConfig.domain>` instead.
+  string cookie_domain = 5
+      [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
 }
 
 // OAuth config

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -31,6 +31,12 @@ behavior_changes:
 
 minor_behavior_changes:
 # *Changes that may cause incompatibilities for some users, but should not for most*
+- area: oauth2
+  change: |
+    Added per-cookie ``domain`` support via ``cookie_configs.*.domain`` for the OAuth2 filter,
+    aligning domain and path scoping of emitted cookies. The legacy
+    ``credentials.cookie_domain`` field is now deprecated but continues to be honored as a
+    fallback.
 - area: router
   change: |
     Added :ref:`host_rewrite

--- a/source/extensions/filters/http/oauth2/filter.h
+++ b/source/extensions/filters/http/oauth2/filter.h
@@ -156,6 +156,7 @@ public:
   FilterStats& stats() { return stats_; }
   const std::string& encodedResourceQueryParams() const { return encoded_resource_query_params_; }
   const CookieNames& cookieNames() const { return cookie_names_; }
+  // Legacy cookie domain fallback for deprecated credentials.cookie_domain.
   const std::string& cookieDomain() const { return cookie_domain_; }
   const AuthType& authType() const { return auth_type_; }
   bool useRefreshToken() const { return use_refresh_token_; }
@@ -179,17 +180,20 @@ public:
   bool shouldUseRefreshToken(
       const envoy::extensions::filters::http::oauth2::v3::OAuth2Config& proto_config) const;
   struct CookieSettings {
-    CookieSettings(const envoy::extensions::filters::http::oauth2::v3::CookieConfig& config)
-        : same_site_(config.same_site()), path_(config.path().empty() ? "/" : config.path()) {}
+    CookieSettings(const envoy::extensions::filters::http::oauth2::v3::CookieConfig& config,
+                   const std::string& legacy_cookie_domain)
+        : same_site_(config.same_site()), path_(config.path().empty() ? "/" : config.path()),
+          domain_(config.domain().empty() ? legacy_cookie_domain : config.domain()) {}
 
     // Default constructor.
     CookieSettings()
         : same_site_(envoy::extensions::filters::http::oauth2::v3::CookieConfig_SameSite::
                          CookieConfig_SameSite_DISABLED),
-          path_("/") {}
+          path_("/"), domain_("") {}
 
     const envoy::extensions::filters::http::oauth2::v3::CookieConfig_SameSite same_site_;
     const std::string path_;
+    const std::string domain_;
   };
 
   const CookieSettings& bearerTokenCookieSettings() const { return bearer_token_cookie_settings_; }

--- a/test/extensions/filters/http/oauth2/config_test.cc
+++ b/test/extensions/filters/http/oauth2/config_test.cc
@@ -102,7 +102,9 @@ config:
       oauth_expires: OauthExpires
       id_token: IdToken
       refresh_token: RefreshToken
-    cookie_domain: example.com
+  cookie_configs:
+    bearer_token_cookie_config:
+      domain: example.com
   authorization_endpoint: https://oauth.com/oauth/authorize/
   redirect_uri: "%REQ(x-forwarded-proto)%://%REQ(:authority)%/callback"
   redirect_path_matcher:
@@ -241,7 +243,9 @@ config:
       oauth_expires: OauthExpires
       id_token: IdToken
       refresh_token: RefreshToken
-    cookie_domain: example.com
+  cookie_configs:
+    bearer_token_cookie_config:
+      domain: example.com
   authorization_endpoint: https://oauth.com/oauth/authorize/
   redirect_uri: "%REQ(x-forwarded-proto)%://%REQ(:authority)%/callback"
   redirect_path_matcher:


### PR DESCRIPTION
## Description

The current `cookie_domain` field in the API is no longer ideal. In this PR we are deprecating it and adding a new `domain` field alongside the `path` field. This aligns better with how cookies are typically scoped and makes the API more consistent and intuitive.

Fix https://github.com/envoyproxy/envoy/issues/42085

---

**Commit Message:** oauth2: move cookie_domain field in the API alongside the path field
**Additional Description:** Deprecated `cookie_domain` field in the API and added a new `domain` field alongside the `path` field.
**Risk Level:** Low
**Testing:** Added Unit Tests
**Docs Changes:** Added
**Release Notes:** Added