### PR TITLE
stats: add OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE support

### DIFF
--- a/api/envoy/extensions/stat_sinks/open_telemetry/v3/open_telemetry.proto
+++ b/api/envoy/extensions/stat_sinks/open_telemetry/v3/open_telemetry.proto
@@ -23,7 +23,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // Stats configuration proto schema for ``envoy.stat_sinks.open_telemetry`` sink.
 // [#extension: envoy.stat_sinks.open_telemetry]
 
-// [#next-free-field: 9]
+// [#next-free-field: 10]
 message SinkConfig {
   // ConversionAction is used to convert a stat to a metric. If a stat matches,
   // the metric_name and static_metric_labels will be
@@ -82,4 +82,13 @@ message SinkConfig {
   // - ``envoy.extensions.stat_sinks.open_telemetry.v3.SinkConfig.ConversionAction``.
   // If stats are not matched, they will be directly converted to OTLP metrics as usual.
   xds.type.matcher.v3.Matcher custom_metric_conversions = 8;
+
+  // When true, reads the ``OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE`` environment variable
+  // to set temporality preference. Supported values are ``cumulative`` (default), ``delta``, and
+  // ``lowmemory``. When set to ``delta`` or ``lowmemory``, counters and histograms are reported as
+  // deltas. This is only used when ``report_counters_as_deltas`` and ``report_histograms_as_deltas``
+  // are not explicitly configured. If those fields are set, they take precedence over the
+  // environment variable. Follows `OTel SDK conventions
+  // <https://opentelemetry.io/docs/specs/otel/metrics/sdk_exporters/otlp/#additional-configuration>`_.
+  bool use_otel_temporality_env_var = 9;
 }

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -269,6 +269,12 @@ new_features:
     Added support for dropping stats via
     :ref:`DropAction <envoy_v3_api_msg_extensions.stat_sinks.open_telemetry.v3.SinkConfig.DropAction>` during
     custom metric conversion.
+- area: otlp_stat_sink
+  change: |
+    Added :ref:`use_otel_temporality_env_var
+    <envoy_v3_api_field_extensions.stat_sinks.open_telemetry.v3.SinkConfig.use_otel_temporality_env_var>` to read
+    the ``OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE`` environment variable for configuring metrics
+    temporality. Supports values ``cumulative`` (default), ``delta``, and ``lowmemory``.
 - area: tcp_proxy
   change: |
     Added :ref:`upstream_connect_mode

--- a/source/extensions/stat_sinks/open_telemetry/open_telemetry_impl.h
+++ b/source/extensions/stat_sinks/open_telemetry/open_telemetry_impl.h
@@ -25,6 +25,14 @@ namespace Extensions {
 namespace StatSinks {
 namespace OpenTelemetry {
 
+// Environment variable name for OTel SDK temporality preference.
+constexpr absl::string_view kOtelTemporalityEnvVar =
+    "OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE";
+// Supported temporality preference values from OTel SDK specification.
+constexpr absl::string_view kTemporalityDelta = "delta";
+constexpr absl::string_view kTemporalityCumulative = "cumulative";
+constexpr absl::string_view kTemporalityLowMemory = "lowmemory";
+
 using AggregationTemporality = opentelemetry::proto::metrics::v1::AggregationTemporality;
 using MetricsExportRequest =
     opentelemetry::proto::collector::metrics::v1::ExportMetricsServiceRequest;


### PR DESCRIPTION
## Description

Adds support for the OTel SDK standard environment variable `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE` to the OTLP stat sink. This helps backends like Elastic and Datadog that require delta temporality.

---

**Commit Message:** stats: add OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE support
**Additional Description:** Adds `use_otel_temporality_env_var` field to read the env var. Supports `cumulative` (default), `delta`, and `lowmemory` values. Explicit config fields take precedence.
**Risk Level:** Low
**Testing:** Unit tests added
**Docs Changes:** N/A
**Release Notes:** Added to changelogs/current.yaml