### PR TITLE
Add cluster stats for ORCA load reports processing in `Router::Filter`.

### DIFF
--- a/envoy/upstream/upstream.h
+++ b/envoy/upstream/upstream.h
@@ -732,6 +732,9 @@ public:
   COUNTER(upstream_flow_control_resumed_reading_total)                                             \
   COUNTER(upstream_internal_redirect_failed_total)                                                 \
   COUNTER(upstream_internal_redirect_succeeded_total)                                              \
+  COUNTER(upstream_orca_lb_success)                                                                \
+  COUNTER(upstream_orca_lb_error)                                                                  \
+  COUNTER(upstream_orca_lrs)                                                                       \
   COUNTER(upstream_rq_cancelled)                                                                   \
   COUNTER(upstream_rq_completed)                                                                   \
   COUNTER(upstream_rq_maintenance_mode)                                                            \

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -2415,6 +2415,7 @@ void Filter::maybeProcessOrcaLoadReport(const Envoy::Http::HeaderMap& headers_or
   if (cluster_->lrsReportMetricNames().has_value()) {
     ENVOY_STREAM_LOG(trace, "Adding ORCA load report {} to load metrics", *callbacks_,
                      orca_load_report->DebugString());
+    cluster_->trafficStats()->upstream_orca_lrs_.inc();
     Envoy::Orca::addOrcaLoadReportToLoadMetricStats(
         *cluster_->lrsReportMetricNames(), *orca_load_report, upstream_host->loadMetricStats());
   }
@@ -2427,6 +2428,9 @@ void Filter::maybeProcessOrcaLoadReport(const Envoy::Http::HeaderMap& headers_or
       ENVOY_LOG_PERIODIC(error, std::chrono::seconds(10),
                          "LB policy onOrcaLoadReport failed: {} for load report {}",
                          status.message(), orca_load_report->DebugString());
+      cluster_->trafficStats()->upstream_orca_lb_error_.inc();
+    } else {
+      cluster_->trafficStats()->upstream_orca_lb_success_.inc();
     }
   }
 }

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -7614,6 +7614,8 @@ TEST_F(RouterTest, OrcaLoadReport) {
   EXPECT_EQ(load_metric_stats_map->at("cpu_utilization").num_requests_with_metric, 1);
   EXPECT_EQ(load_metric_stats_map->at("named_metrics.good").total_metric_value, 0.7);
   EXPECT_EQ(load_metric_stats_map->at("named_metrics.good").num_requests_with_metric, 1);
+  EXPECT_EQ(1U,
+            cm_.thread_local_cluster_.cluster_.info_->traffic_stats_->upstream_orca_lrs_.value());
 }
 
 TEST_F(RouterTest, OrcaLoadReport_NoConfiguredMetricNames) {
@@ -7702,6 +7704,12 @@ TEST_F(RouterTest, OrcaLoadReportCallbacks) {
   // Verify that received load report is set in headers.
   EXPECT_EQ(received_orca_load_report.cpu_utilization(),
             headers_orca_load_report.cpu_utilization());
+  EXPECT_EQ(
+      1U,
+      cm_.thread_local_cluster_.cluster_.info_->traffic_stats_->upstream_orca_lb_success_.value());
+  EXPECT_EQ(
+      0U,
+      cm_.thread_local_cluster_.cluster_.info_->traffic_stats_->upstream_orca_lb_error_.value());
 }
 
 TEST_F(RouterTest, OrcaLoadReportCallbackReturnsError) {
@@ -7742,6 +7750,12 @@ TEST_F(RouterTest, OrcaLoadReportCallbackReturnsError) {
       {":status", "200"}, {"endpoint-load-metrics-bin", orca_load_report_header_bin}});
   response_decoder->decodeTrailers(std::move(response_trailers));
   EXPECT_EQ(received_orca_load_report.named_metrics().at("good"), 0.7);
+  EXPECT_EQ(
+      0U,
+      cm_.thread_local_cluster_.cluster_.info_->traffic_stats_->upstream_orca_lb_success_.value());
+  EXPECT_EQ(
+      1U,
+      cm_.thread_local_cluster_.cluster_.info_->traffic_stats_->upstream_orca_lb_error_.value());
 }
 
 TEST_F(RouterTest, OrcaLoadReportInvalidHeaderValue) {


### PR DESCRIPTION
Adding cluster stat counters stats for ORCA load reports processing in `Router::Filter`:

- upstream_orca_lb_success - Host LB Policy callback success.
- upstream_orca_lb_error - Host LB Policy callback error.
- upstream_orca_lrs - ORCA load report added to LRS metrics.

Risk Level: LOW
Testing: `bazel test //test/common/router:router_test`
Docs Changes: None
