### PR TITLE
Set the dangling pointer to nullptr in the mocked getaddrinfo resolver

### DIFF
--- a/test/extensions/filters/http/dynamic_forward_proxy/proxy_filter_integration_test.cc
+++ b/test/extensions/filters/http/dynamic_forward_proxy/proxy_filter_integration_test.cc
@@ -37,6 +37,7 @@ public:
     ai->ai_addr = reinterpret_cast<sockaddr*>(storage);
     memcpy(ai->ai_addr, addr->sockAddr(), addr->sockAddrLen());
     ai->ai_addrlen = addr->sockAddrLen();
+    ai->ai_next = nullptr;
     return ai;
   }
 

--- a/test/extensions/filters/udp/dns_filter/dns_filter_integration_test.cc
+++ b/test/extensions/filters/udp/dns_filter/dns_filter_integration_test.cc
@@ -35,6 +35,7 @@ public:
     ai->ai_addr = reinterpret_cast<sockaddr*>(storage);
     memcpy(ai->ai_addr, addr->sockAddr(), addr->sockAddrLen());
     ai->ai_addrlen = addr->sockAddrLen();
+    ai->ai_next = nullptr;
     return ai;
   }
 


### PR DESCRIPTION
Test flakiness in proxy_filter_integration_test.cc. Please check https://github.com/envoyproxy/envoy/issues/42217.

The flakiness can not be reproduced, but is showing up in CI occasionally.  Suspecting the ai->ai_next pointer is garbage which caused the memory leaking and test failure. Explicitly set it to nullptr.  