### PR TITLE
mcp: improve memory usage and avoid copying for json decoding

### DIFF
--- a/source/extensions/filters/http/mcp/mcp_filter.cc
+++ b/source/extensions/filters/http/mcp/mcp_filter.cc
@@ -180,14 +180,14 @@ Http::FilterDataStatus McpFilter::decodeData(Buffer::Instance& data, bool end_st
     to_parse = std::min(to_parse, remaining_limit);
   }
 
-  std::string parse_buffer;
-  parse_buffer.resize(to_parse);
-  data.copyOut(bytes_parsed_, to_parse, parse_buffer.data());
+  // Linearize the buffer and create a string_view to avoid copying.
+  const char* linearized = static_cast<const char*>(data.linearize(bytes_parsed_ + to_parse));
+  absl::string_view parse_view(linearized + bytes_parsed_, to_parse);
 
   // The partial parser will return an OK status if the requirements are not satisfied.
   // It will potentially be a bad status due to the partial parse if all the requirements
   // are extracted.
-  auto status = parser_->parse(parse_buffer);
+  auto status = parser_->parse(parse_view);
   bytes_parsed_ += to_parse;
 
   if (parser_->isAllFieldsCollected()) {


### PR DESCRIPTION
linearize the buffer and create a `string_view` to avoid copying, linearize() ensures the first `bytes_parsed_ + to_parse` bytes are contiguous, and the parser can operate on the view.

Commit Message:
Additional Description:
Risk Level: low
Testing:
Docs Changes:
Release Notes:
