### PR TITLE
quic: Remove an extra "#comment: " in the quic transport socket proto

### DIFF
--- a/api/envoy/extensions/transport_sockets/quic/v3/quic_transport.proto
+++ b/api/envoy/extensions/transport_sockets/quic/v3/quic_transport.proto
@@ -16,7 +16,7 @@ option go_package = "github.com/envoyproxy/go-control-plane/envoy/extensions/tra
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: quic transport]
-// [#comment:#extension: envoy.transport_sockets.quic]
+// [#extension: envoy.transport_sockets.quic]
 
 // Configuration for Downstream QUIC transport socket. This provides Google's implementation of Google QUIC and IETF QUIC to Envoy.
 message QuicDownstreamTransport {


### PR DESCRIPTION
quic: Remove an extra "#comment: " in the quic transport socket proto

This appears to have been added 5 years ago to hide the extension but we can make it visible now.