### PR TITLE
github/ci: Fix branches

### DIFF
--- a/.github/workflows/_request.yml
+++ b/.github/workflows/_request.yml
@@ -67,7 +67,7 @@ jobs:
       name: Checkout Envoy repository (requested)
       with:
         pr: ${{ github.event.number }}
-        branch: ${{ github.ref_name }}
+        branch: ${{ github.base_ref || github.ref_name }}
         config: |
           fetch-depth: ${{ startsWith(github.event_name, 'pull_request') && 1 || 2 }}
           path: requested


### PR DESCRIPTION
prior to https://github.blog/changelog/2025-11-07-actions-pull_request_target-and-environment-branch-protections-changes/ `pull_request_target` events received the target branch as `github.ref_name`

since that change the ref_name will always resolve to the default branch (ie `main`)

this restores the old behaviour to ensure branch CI uses the release branches

