### PR TITLE
github/ci: Improve CI triggers

### DIFF
--- a/.github/workflows/request.yml
+++ b/.github/workflows/request.yml
@@ -7,10 +7,15 @@ permissions:
 
 on:
   pull_request_target:
+    branches:
+    - main
+    - release/v*
+    - ci/testing
   push:
     branches:
     - main
     - release/v*
+    - ci/testing
   schedule:
   - cron: '30 6 * * *'
 


### PR DESCRIPTION
this should allow CI testing in a more controlled way

