### PR TITLE
http: add tests for source/common/http and improve coverage

### DIFF
--- a/test/common/http/filter_manager_test.cc
+++ b/test/common/http/filter_manager_test.cc
@@ -707,6 +707,16 @@ TEST_F(FilterManagerTest, EncodeMetadataSendsLocalReply) {
   filter_manager_->destroyFilters();
 }
 
+TEST_F(FilterManagerTest, RequestedApplicationProtocols) {
+  initialize();
+
+  const auto& protocols =
+      filter_manager_->streamInfo().downstreamAddressProvider().requestedApplicationProtocols();
+  EXPECT_TRUE(protocols.empty());
+
+  filter_manager_->destroyFilters();
+}
+
 TEST_F(FilterManagerTest, IdleTimerResets) {
   initialize();
 

--- a/test/coverage.yaml
+++ b/test/coverage.yaml
@@ -8,7 +8,7 @@ directories:
   source/common/api/posix: 94.9  # setns requires Linux CAP_NET_ADMIN privileges
   source/common/crypto: 91.0  # Static singleton initialization and OpenSSL internal error paths not testable
   source/common/filesystem/posix: 96.4  # FileReadToEndNotReadable fails in some env; createPath can't test all failure branches.
-  source/common/http: 96.4
+  source/common/http: 96.5
   source/common/http/http1: 93.4  # To be removed when http_inspector_use_balsa_parser is retired.
   source/common/http/http2: 96.6
   source/common/json: 95.2


### PR DESCRIPTION
Related to
https://github.com/envoyproxy/envoy/pull/42523
https://github.com/envoyproxy/envoy/pull/42339

Commit Message:
Additional Description:
Risk Level: low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
