### PR TITLE
fix(Dynamic modules): ensure calls to set_response_trailer work befor…

### DIFF
--- a/source/extensions/filters/http/dynamic_modules/abi_impl.cc
+++ b/source/extensions/filters/http/dynamic_modules/abi_impl.cc
@@ -465,7 +465,8 @@ bool envoy_dynamic_module_callback_http_add_response_trailer(
     envoy_dynamic_module_type_buffer_module_ptr key, size_t key_length,
     envoy_dynamic_module_type_buffer_module_ptr value, size_t value_length) {
   DynamicModuleHttpFilter* filter = static_cast<DynamicModuleHttpFilter*>(filter_envoy_ptr);
-  return addHeaderValueImpl(filter->responseTrailers(), key, key_length, value, value_length);
+  return addHeaderValueImpl(filter->mutableResponseTrailers(), key, key_length, value,
+                            value_length);
 }
 
 bool setHeaderValueImpl(HeadersMapOptRef map, envoy_dynamic_module_type_buffer_module_ptr key,
@@ -514,7 +515,8 @@ bool envoy_dynamic_module_callback_http_set_response_trailer(
     envoy_dynamic_module_type_buffer_module_ptr key, size_t key_length,
     envoy_dynamic_module_type_buffer_module_ptr value, size_t value_length) {
   DynamicModuleHttpFilter* filter = static_cast<DynamicModuleHttpFilter*>(filter_envoy_ptr);
-  return setHeaderValueImpl(filter->responseTrailers(), key, key_length, value, value_length);
+  return setHeaderValueImpl(filter->mutableResponseTrailers(), key, key_length, value,
+                            value_length);
 }
 
 bool envoy_dynamic_module_callback_http_get_request_headers_size(

--- a/source/extensions/filters/http/dynamic_modules/filter.cc
+++ b/source/extensions/filters/http/dynamic_modules/filter.cc
@@ -385,6 +385,24 @@ bool DynamicModuleHttpFilter::sendStreamTrailers(
   return true;
 }
 
+ResponseTrailerMapOptRef DynamicModuleHttpFilter::mutableResponseTrailers() {
+  if (!encoder_callbacks_) {
+    return absl::nullopt;
+  }
+
+  // Return the existing map if it exists
+  ResponseTrailerMapOptRef trailers = encoder_callbacks_->responseTrailers();
+  if (trailers.has_value()) {
+    return trailers;
+  }
+
+  // Otherwise create a new map (this is possible if called before trailer parsing or if the
+  // response has no trailers)
+  Http::ResponseTrailerMap& created = encoder_callbacks_->addEncodedTrailers();
+
+  return ResponseTrailerMapOptRef(created);
+}
+
 void DynamicModuleHttpFilter::HttpStreamCalloutCallback::onHeaders(ResponseHeaderMapPtr&& headers,
                                                                    bool end_stream) {
   // Check if the filter is destroyed before the stream completes.

--- a/source/extensions/filters/http/dynamic_modules/filter.h
+++ b/source/extensions/filters/http/dynamic_modules/filter.h
@@ -123,6 +123,11 @@ public:
   }
 
   /**
+   * Helper to set/add trailers if none exist (yet)
+   */
+  ResponseTrailerMapOptRef mutableResponseTrailers();
+
+  /**
    * Helper to get the downstream information of the stream.
    */
   StreamInfo::StreamInfo* streamInfo() {


### PR DESCRIPTION
…e trailers have been parsed, or when no trailers are in response.


Commit Message: fix(Dynamic modules): ensure calls to set_response_trailer work before trailers have been parsed, or when no trailers are in response.
Risk Level: Low
Testing: TBD
Release Notes: calls to `set_response_trailer` from dynamic modules will now function if the response did not have trailers, and before trailers are parsed.

Fixes #42559