### PR TITLE
build: exclude QUIC libraries when HTTP3 is disabled

### DIFF
--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -385,7 +385,7 @@ case $CI_TARGET in
             -c fastbuild \
             "${TEST_TARGETS[@]}" \
             --test_tag_filters=-nofips \
-            --build_tests_only
+            --build_tag_filters=-nofips
         echo "Building and testing with wasm=wasmtime: and admin_functionality and admin_html disabled ${TEST_TARGETS[*]}"
         bazel_with_collection \
             test "${BAZEL_BUILD_OPTIONS[@]}" \
@@ -395,7 +395,7 @@ case $CI_TARGET in
             -c fastbuild \
             "${TEST_TARGETS[@]}" \
             --test_tag_filters=-nofips \
-            --build_tests_only
+            --build_tag_filters=-nofips
         # "--define log_debug_assert_in_release=enabled" must be tested with a release build, so run only
         # these tests under "-c opt" to save time in CI.
         bazel_with_collection \

--- a/test/common/quic/BUILD
+++ b/test/common/quic/BUILD
@@ -434,7 +434,7 @@ envoy_proto_library(
 
 envoy_cc_test_library(
     name = "envoy_quic_h3_fuzz_helper_lib",
-    srcs = ["envoy_quic_h3_fuzz_helper.cc"],
+    srcs = envoy_select_enable_http3(["envoy_quic_h3_fuzz_helper.cc"]),
     hdrs = ["envoy_quic_h3_fuzz_helper.h"],
     deps = [
         ":envoy_quic_h3_fuzz_proto_cc_proto",

--- a/test/exe/BUILD
+++ b/test/exe/BUILD
@@ -69,7 +69,7 @@ envoy_sh_test(
 
 envoy_cc_test_library(
     name = "main_common_test_base_lib",
-    srcs = ["main_common_test_base.cc"],
+    srcs = envoy_select_admin_functionality(["main_common_test_base.cc"]),
     hdrs = ["main_common_test_base.h"],
     data = [
         "//test/config/integration:google_com_proxy_port_0",

--- a/test/extensions/quic/proof_source/BUILD
+++ b/test/extensions/quic/proof_source/BUILD
@@ -2,6 +2,7 @@ load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_test_library",
     "envoy_package",
+    "envoy_select_enable_http3",
 )
 
 licenses(["notice"])  # Apache 2
@@ -10,7 +11,7 @@ envoy_package()
 
 envoy_cc_test_library(
     name = "pending_proof_source_factory_impl_lib",
-    srcs = ["pending_proof_source_factory_impl.cc"],
+    srcs = envoy_select_enable_http3(["pending_proof_source_factory_impl.cc"]),
     hdrs = ["pending_proof_source_factory_impl.h"],
     deps = [
         "//envoy/registry",


### PR DESCRIPTION
Follows up https://github.com/envoyproxy/envoy/pull/41886

Also remove `--build_tests_only` from the CI test so that everything is built and errors like this are caught.
