### PR TITLE
Don't access variable used as move construction src

### DIFF
--- a/source/extensions/filters/http/jwt_authn/filter_config.cc
+++ b/source/extensions/filters/http/jwt_authn/filter_config.cc
@@ -17,7 +17,7 @@ FilterConfigImpl::FilterConfigImpl(
     envoy::extensions::filters::http::jwt_authn::v3::JwtAuthentication proto_config,
     const std::string& stats_prefix, Server::Configuration::FactoryContext& context)
     : proto_config_(std::move(proto_config)),
-      stats_(generateStats(stats_prefix, proto_config.stat_prefix(), context.scope())),
+      stats_(generateStats(stats_prefix, proto_config_.stat_prefix(), context.scope())),
       cm_(context.serverFactoryContext().clusterManager()),
       time_source_(context.serverFactoryContext().mainThreadDispatcher().timeSource()) {
 


### PR DESCRIPTION
Commit Message: Don't access variable used as move construction src
Additional Description:
Avoid a potential use-after-free or logic error caused by access of a variable that was already used as the argument to a move constructor.
Risk Level: low
Testing: ran existing unit tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a