### PR TITLE
docs: fix the broken build because of glibc arg

### DIFF
--- a/bazel/repositories_extra.bzl
+++ b/bazel/repositories_extra.bzl
@@ -25,7 +25,7 @@ def envoy_dependencies_extra(
         ignore_root_user_error = False):
     compatibility_proxy_repo()
     bazel_toolchain_dependencies()
-    setup_sysroots(glibc_version = glibc_version)
+    setup_sysroots()
     emsdk_deps()
     raze_fetch_remote_crates()
     crate_repositories()


### PR DESCRIPTION
## Description

`setup_sysroots()` no longer accepts the `glibc_version` as an arg and it's breaking the docs build.

```
1:51:10 AM: ERROR: Traceback (most recent call last):
1:51:10 AM: 	File "/opt/build/repo/WORKSPACE", line 28, column 25, in <toplevel>
1:51:10 AM: 		envoy_dependencies_extra()
1:51:10 AM: 	File "/opt/buildhome/.cache/bazel/_bazel_buildbot/9a72ce7fe51e5e46a147640bcd3de03b/external/envoy/bazel/repositories_extra.bzl", line 28, column 19, in envoy_dependencies_extra
1:51:10 AM: 		setup_sysroots(glibc_version = glibc_version)
1:51:10 AM: 	File "/opt/buildhome/.cache/bazel/_bazel_buildbot/9a72ce7fe51e5e46a147640bcd3de03b/external/envoy_toolshed/sysroot/sysroot.bzl", line 87, column 5, in setup_sysroots
1:51:10 AM: 		def setup_sysroots(
1:51:10 AM: Error: setup_sysroots() got unexpected keyword argument: glibc_version
1:51:10 AM: ERROR: Error computing the main repository mapping: at /opt/buildhome/.cache/bazel/_bazel_buildbot/9a72ce7fe51e5e46a147640bcd3de03b/external/envoy/bazel/python_dependencies.bzl:3:6: at /opt/buildhome/.cache/bazel/_bazel_buildbot/9a72ce7fe51e5e46a147640bcd3de03b/external/rules_python/python/pip.bzl:29:6: at /opt/buildhome/.cache/bazel/_bazel_buildbot/9a72ce7fe51e5e46a147640bcd3de03b/external/rules_python/python/private/pypi/pip_compile.bzl:22:6: at /opt/buildhome/.cache/bazel/_bazel_buildbot/9a72ce7fe51e5e46a147640bcd3de03b/external/rules_python/python/py_binary.bzl:17:6: at /opt/buildhome/.cache/bazel/_bazel_buildbot/9a72ce7fe51e5e46a147640bcd3de03b/external/rules_python/python/private/py_binary_macro.bzl:16:6: at /opt/buildhome/.cache/bazel/_bazel_buildbot/9a72ce7fe51e5e46a147640bcd3de03b/external/rules_python/python/private/py_binary_rule.bzl:16:6: at /opt/buildhome/.cache/bazel/_bazel_buildbot/9a72ce7fe51e5e46a147640bcd3de03b/external/rules_python/python/private/attributes.bzl:18:6: at /opt/buildhome/.cache/bazel/_bazel_buildbot/9a72ce7fe51e5e46a147640bcd3de03b/external/rules_cc/cc/common/cc_info.bzl:16:6: Encountered error while reading extension file 'symbols.bzl': no such package
```

https://app.netlify.com/projects/envoy-website/deploys/693b2777f7cc050007465ae2

---

**Commit Message**: docs: fix the broken build because of glibc arg
**Additional Description:** Fixes the broken build because of glibc arg.
**Risk Level:** N/A
**Testing:** CI
**Docs Changes:** N/A
**Release Notes:** N/A