### PR TITLE
Disable excessively flaky test

### DIFF
--- a/test/integration/tcp_tunneling_integration_test.cc
+++ b/test/integration/tcp_tunneling_integration_test.cc
@@ -450,6 +450,9 @@ TEST_P(ConnectTerminationIntegrationTest, IgnoreH11HostField) {
 }
 
 TEST_P(ConnectTerminationIntegrationTest, EarlyConnectDataRejectedWithOverride) {
+  // TODO(yanavlasov): fix the test
+  GTEST_SKIP() << "Test is too flaky for CI. "
+                  "https://github.com/envoyproxy/envoy/issues/39856#issuecomment-3637976574";
   config_helper_.addRuntimeOverride("envoy.reloadable_features.reject_early_connect_data", "true");
   initialize();
 


### PR DESCRIPTION
Commit Message: Disable excessively flaky test
Additional Description: With a TODO to fix. We can't roll back the PR that introduced the flakiness (#42370) because it was a security patch. Relevant flakiness described in https://github.com/envoyproxy/envoy/issues/39856#issuecomment-3637997415
Risk Level: test-only
Testing: it is
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
