### PR TITLE
tests: proper cleanup of upstream connections in tcp_tunneling_integration_test

### DIFF
--- a/test/integration/http_integration.h
+++ b/test/integration/http_integration.h
@@ -228,7 +228,7 @@ protected:
                                 FakeHttpConnectionPtr& fake_upstream_connection);
 
   // Close |codec_client_| and |fake_upstream_connection_| cleanly.
-  void cleanupUpstreamAndDownstream();
+  virtual void cleanupUpstreamAndDownstream();
 
   // Verifies the response_headers contains the expected_headers, and response body matches given
   // body string.

--- a/test/integration/tcp_tunneling_integration_test.cc
+++ b/test/integration/tcp_tunneling_integration_test.cc
@@ -120,6 +120,19 @@ public:
     EXPECT_EQ(header_bytes_received, expected_header_bytes_received);
   }
 
+  void cleanupUpstreamAndDownstream() override {
+    // Cleanup the fake connection.
+    if (fake_raw_upstream_connection_) {
+      AssertionResult result = fake_raw_upstream_connection_->close();
+      RELEASE_ASSERT(result, result.message());
+      result = fake_raw_upstream_connection_->waitForDisconnect();
+      RELEASE_ASSERT(result, result.message());
+      fake_raw_upstream_connection_.reset();
+    }
+    // Cleanup the downstream and (possibly) the other upstreams.
+    HttpProtocolIntegrationTest::cleanupUpstreamAndDownstream();
+  }
+
   FakeRawConnectionPtr fake_raw_upstream_connection_;
   IntegrationStreamDecoderPtr response_;
   bool terminate_via_cluster_config_{};


### PR DESCRIPTION
Commit Message: tests: proper cleanup of upstream connections in tcp_tunneling_integration_test
Additional Description:
Cleaning up `fake_raw_upstream_connection_` instead of `fake_upstream_connection_`.

Risk Level: low - tests only
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
