### PR TITLE
Make git pre-push hook not refetch toolchains

### DIFF
--- a/support/hooks/pre-push
+++ b/support/hooks/pre-push
@@ -78,7 +78,7 @@ do
     # "$SCRIPT_DIR"/spelling/check_spelling_pedantic.py check "${CHANGES[@]}" || exit 1
 
     # TODO(mattklein123): Optimally we would be able to do this on a per-file basis.
-    "$CI_DIR"/do_ci.sh check_proto_format || exit 1
+    "${SCRIPT_DIR}/proto_format/proto_format.sh" check || exit 1
 
     bazel run //tools/code:check -- \
           -s main \


### PR DESCRIPTION
Commit Message: Make git pre-push hook not refetch toolchains
Additional Description: Now that clang is being constructed from toolchains, running `do_ci.sh` (which operates with a new `--output_base` vs straight bazel commands) has to download all the relevant toolchains into the new base, which is generally very wasteful. The githook before this PR is in the worst possible configuration, mixing do_ci with direct commands, thereby guaranteeing that toolchains have to be downloaded twice.
This PR changes the proto_format check to be done the same way as the others, which reduces the chances of an extraneous re-fetch.
I took the replacement command directly from what the do_ci script does, modifying only how the path is constructed.
Risk Level: No change to actual product.
Testing: `git push origin githook` did not do surprise re-fetching of things. Previous `git push origin branch_name` refetched more than once.
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
