### PR TITLE
tls: added a new API on the connection interface to allow limiting TLS record sizes

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -517,5 +517,9 @@ new_features:
     requests to more backend servers. The filter supports fanout to multiple backends for initialize and tools-list requests,
     single-backend routing for tools-call based on tool name prefix, session management with composite session IDs,
     and response aggregation.
+- area: tls
+  change: |
+    Added ``setTransportSocketDataChunkSendLimit()`` API to ``Network::Connection`` to allow limiting TLS record
+    sizes. This is useful for working around bugs in clients like libpq that cannot handle TLS records >= 8KB.
 
 deprecated:

--- a/envoy/network/connection.h
+++ b/envoy/network/connection.h
@@ -426,6 +426,16 @@ public:
    * return value is cwnd(in packets) times the connection's MSS.
    */
   virtual absl::optional<uint64_t> congestionWindowInBytes() const PURE;
+
+  /**
+   * Set the maximum size of data chunks that the transport socket will write in a single
+   * operation. This is primarily useful for limiting TLS record sizes to work around bugs
+   * in certain clients (e.g., libpq which cannot handle TLS records >= 8KB).
+   * @param data_chunk_size the maximum size of each data chunk in bytes. If not set or
+   *        set to 0, the transport socket will use its default chunk size.
+   * @note This is a no-op for transport sockets that don't support this feature.
+   */
+  virtual void setTransportSocketDataChunkSendLimit(uint64_t data_chunk_size) PURE;
 };
 
 using ConnectionPtr = std::unique_ptr<Connection>;

--- a/envoy/network/transport_socket.h
+++ b/envoy/network/transport_socket.h
@@ -208,6 +208,16 @@ public:
    */
   virtual void configureInitialCongestionWindow(uint64_t bandwidth_bits_per_sec,
                                                 std::chrono::microseconds rtt) PURE;
+
+  /**
+   * Set the maximum size of data chunks that will be written in a single operation.
+   * This is primarily useful for limiting TLS record sizes to work around bugs in certain
+   * clients (e.g., libpq which cannot handle TLS records >= 8KB).
+   * @param data_chunk_size the maximum size of each data chunk in bytes. If set to 0, the
+   *        transport socket will use its default chunk size.
+   * @note This is a no-op for transport sockets that don't support this feature.
+   */
+  virtual void setTransportSocketDataChunkSendLimit(uint64_t data_chunk_size) PURE;
 };
 
 using TransportSocketPtr = std::unique_ptr<TransportSocket>;

--- a/source/common/network/connection_impl.h
+++ b/source/common/network/connection_impl.h
@@ -114,6 +114,9 @@ public:
   const StreamInfo::StreamInfo& streamInfo() const override { return stream_info_; }
   absl::string_view transportFailureReason() const override;
   bool startSecureTransport() override { return transport_socket_->startSecureTransport(); }
+  void setTransportSocketDataChunkSendLimit(uint64_t data_chunk_size) override {
+    transport_socket_->setTransportSocketDataChunkSendLimit(data_chunk_size);
+  }
   absl::optional<std::chrono::milliseconds> lastRoundTripTime() const override;
   void configureInitialCongestionWindow(uint64_t bandwidth_bits_per_sec,
                                         std::chrono::microseconds rtt) override;

--- a/source/common/network/multi_connection_base_impl.cc
+++ b/source/common/network/multi_connection_base_impl.cc
@@ -304,6 +304,12 @@ bool MultiConnectionBaseImpl::startSecureTransport() {
   return ret;
 }
 
+void MultiConnectionBaseImpl::setTransportSocketDataChunkSendLimit(uint64_t data_chunk_size) {
+  for (auto& connection : connections_) {
+    connection->setTransportSocketDataChunkSendLimit(data_chunk_size);
+  }
+}
+
 absl::optional<std::chrono::milliseconds> MultiConnectionBaseImpl::lastRoundTripTime() const {
   // Note, this might change before connect finishes.
   return connections_[0]->lastRoundTripTime();

--- a/source/common/network/multi_connection_base_impl.h
+++ b/source/common/network/multi_connection_base_impl.h
@@ -95,6 +95,7 @@ public:
   void setDelayedCloseTimeout(std::chrono::milliseconds timeout) override;
   void setBufferLimits(uint32_t limit) override;
   bool startSecureTransport() override;
+  void setTransportSocketDataChunkSendLimit(uint64_t data_chunk_size) override;
   absl::optional<std::chrono::milliseconds> lastRoundTripTime() const override;
   void configureInitialCongestionWindow(uint64_t, std::chrono::microseconds) override {}
   absl::optional<uint64_t> congestionWindowInBytes() const override;

--- a/source/common/network/raw_buffer_socket.h
+++ b/source/common/network/raw_buffer_socket.h
@@ -24,6 +24,8 @@ public:
   Ssl::ConnectionInfoConstSharedPtr ssl() const override { return nullptr; }
   bool startSecureTransport() override { return false; }
   void configureInitialCongestionWindow(uint64_t, std::chrono::microseconds) override {}
+  // No-op for raw buffer socket as it does not do TLS.
+  void setTransportSocketDataChunkSendLimit(uint64_t) override {}
 
 protected:
   TransportSocketCallbacks* transportSocketCallbacks() const { return callbacks_; };

--- a/source/common/quic/quic_filter_manager_connection_impl.h
+++ b/source/common/quic/quic_filter_manager_connection_impl.h
@@ -142,6 +142,8 @@ public:
   const StreamInfo::StreamInfo& streamInfo() const override { return *stream_info_; }
   absl::string_view transportFailureReason() const override { return transport_failure_reason_; }
   bool startSecureTransport() override { return false; }
+  // QUIC has its own congestion control and does not support limiting data chunk sizes.
+  void setTransportSocketDataChunkSendLimit(uint64_t) override {}
   absl::optional<std::chrono::milliseconds> lastRoundTripTime() const override;
   void configureInitialCongestionWindow(uint64_t bandwidth_bits_per_sec,
                                         std::chrono::microseconds rtt) override;

--- a/source/common/tls/ssl_socket.cc
+++ b/source/common/tls/ssl_socket.cc
@@ -289,7 +289,7 @@ Network::IoResult SslSocket::doWrite(Buffer::Instance& write_buffer, bool end_st
     bytes_to_write = bytes_to_retry_;
     bytes_to_retry_ = 0;
   } else {
-    bytes_to_write = std::min(write_buffer.length(), static_cast<uint64_t>(16384));
+    bytes_to_write = std::min(write_buffer.length(), data_chunk_send_limit_);
   }
 
   uint64_t total_bytes_written = 0;
@@ -307,7 +307,7 @@ Network::IoResult SslSocket::doWrite(Buffer::Instance& write_buffer, bool end_st
       ASSERT(rc == static_cast<int>(bytes_to_write));
       total_bytes_written += rc;
       write_buffer.drain(rc);
-      bytes_to_write = std::min(write_buffer.length(), static_cast<uint64_t>(16384));
+      bytes_to_write = std::min(write_buffer.length(), data_chunk_send_limit_);
     } else {
       int err = SSL_get_error(rawSsl(), rc);
       ENVOY_CONN_LOG(trace, "ssl error occurred while write: {}", callbacks_->connection(),

--- a/source/common/tls/ssl_socket.h
+++ b/source/common/tls/ssl_socket.h
@@ -66,6 +66,9 @@ public:
   Ssl::ConnectionInfoConstSharedPtr ssl() const override;
   bool startSecureTransport() override { return false; }
   void configureInitialCongestionWindow(uint64_t, std::chrono::microseconds) override {}
+  void setTransportSocketDataChunkSendLimit(uint64_t data_chunk_size) override {
+    data_chunk_send_limit_ = data_chunk_size;
+  }
   // Ssl::PrivateKeyConnectionCallbacks
   void onPrivateKeyMethodComplete() override;
   // Ssl::HandshakeCallbacks
@@ -104,6 +107,8 @@ private:
   ContextImplSharedPtr ctx_;
   uint64_t bytes_to_retry_{};
   std::string failure_reason_;
+  // Default TLS record size limit (16KB is the standard TLS max record size).
+  uint64_t data_chunk_send_limit_{16384};
 
   SslHandshakerImplSharedPtr info_;
 };
@@ -125,6 +130,8 @@ public:
   Ssl::ConnectionInfoConstSharedPtr ssl() const override { return nullptr; }
   bool startSecureTransport() override { return false; }
   void configureInitialCongestionWindow(uint64_t, std::chrono::microseconds) override {}
+  // No-op for invalid SSL socket.
+  void setTransportSocketDataChunkSendLimit(uint64_t) override {}
 };
 
 // This SslSocket will be used when SSL secret is not fetched from SDS server.

--- a/source/extensions/api_listeners/default_api_listener/api_listener_impl.h
+++ b/source/extensions/api_listeners/default_api_listener/api_listener_impl.h
@@ -183,6 +183,7 @@ protected:
       absl::optional<std::chrono::milliseconds> lastRoundTripTime() const override { return {}; }
       void configureInitialCongestionWindow(uint64_t, std::chrono::microseconds) override {}
       absl::optional<uint64_t> congestionWindowInBytes() const override { return {}; }
+      void setTransportSocketDataChunkSendLimit(uint64_t) override {}
       // ScopeTrackedObject
       void dumpState(std::ostream& os, int) const override { os << "SyntheticConnection"; }
 

--- a/source/extensions/transport_sockets/alts/tsi_socket.h
+++ b/source/extensions/transport_sockets/alts/tsi_socket.h
@@ -74,6 +74,8 @@ public:
   void closeSocket(Network::ConnectionEvent event) override;
   Network::IoResult doRead(Buffer::Instance& buffer) override;
   void onConnected() override;
+  // No-op for ALTS socket as it uses its own framing protocol.
+  void setTransportSocketDataChunkSendLimit(uint64_t) override {}
 
   // TsiHandshakerCallbacks
   void onNextDone(NextResultPtr&& result) override;

--- a/source/extensions/transport_sockets/common/passthrough.h
+++ b/source/extensions/transport_sockets/common/passthrough.h
@@ -81,6 +81,9 @@ public:
   bool startSecureTransport() override { return false; }
   void configureInitialCongestionWindow(uint64_t bandwidth_bits_per_sec,
                                         std::chrono::microseconds rtt) override;
+  void setTransportSocketDataChunkSendLimit(uint64_t data_chunk_size) override {
+    transport_socket_->setTransportSocketDataChunkSendLimit(data_chunk_size);
+  }
 
 protected:
   Network::TransportSocketPtr transport_socket_;

--- a/source/extensions/transport_sockets/starttls/starttls_socket.h
+++ b/source/extensions/transport_sockets/starttls/starttls_socket.h
@@ -56,6 +56,10 @@ public:
     return active_socket_->configureInitialCongestionWindow(bandwidth_bits_per_sec, rtt);
   }
 
+  void setTransportSocketDataChunkSendLimit(uint64_t data_chunk_size) override {
+    active_socket_->setTransportSocketDataChunkSendLimit(data_chunk_size);
+  }
+
 private:
   // This is a proxy for wrapping the transport callback object passed from the consumer.
   // Its primary purpose is to filter Connected events to ensure they only happen once per open.

--- a/test/coverage.yaml
+++ b/test/coverage.yaml
@@ -26,7 +26,7 @@ directories:
   source/common/watchdog: 60.0  # Death tests don't report LCOV
   source/exe: 94.4  # increased by #32346, need coverage for terminate_handler and hot restart failures
   source/extensions/api_listeners: 55.0  # Many IS_ENVOY_BUG are not covered.
-  source/extensions/api_listeners/default_api_listener: 67.8  # Many IS_ENVOY_BUG are not covered.
+  source/extensions/api_listeners/default_api_listener: 67.4  # Many IS_ENVOY_BUG are not covered.
   source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface: 96.3
   source/extensions/common/aws: 98.5
   source/extensions/common/aws/credential_providers: 100.0

--- a/test/extensions/transport_sockets/common/passthrough_test.cc
+++ b/test/extensions/transport_sockets/common/passthrough_test.cc
@@ -106,6 +106,12 @@ TEST_F(PassthroughTest, ConfigureInitialCongestionWindowDefersToInnerSocket) {
   passthrough_socket_->configureInitialCongestionWindow(100, std::chrono::microseconds(123));
 }
 
+// Test setTransportSocketDataChunkSendLimit method defers to inner socket.
+TEST_F(PassthroughTest, SetTransportSocketDataChunkSendLimitDefersToInnerSocket) {
+  EXPECT_CALL(*inner_socket_, setTransportSocketDataChunkSendLimit(8192));
+  passthrough_socket_->setTransportSocketDataChunkSendLimit(8192);
+}
+
 class UpstreamTestFactory : public PassthroughFactory {
 public:
   UpstreamTestFactory(Network::UpstreamTransportSocketFactoryPtr&& transport_socket_factory)

--- a/test/extensions/transport_sockets/starttls/starttls_socket_test.cc
+++ b/test/extensions/transport_sockets/starttls/starttls_socket_test.cc
@@ -54,6 +54,10 @@ TEST(StartTlsTest, BasicSwitch) {
   EXPECT_CALL(*ssl_socket, configureInitialCongestionWindow(_, _)).Times(0);
   socket->configureInitialCongestionWindow(100, std::chrono::microseconds(123));
 
+  EXPECT_CALL(*raw_socket, setTransportSocketDataChunkSendLimit(8192));
+  EXPECT_CALL(*ssl_socket, setTransportSocketDataChunkSendLimit(_)).Times(0);
+  socket->setTransportSocketDataChunkSendLimit(8192);
+
   EXPECT_CALL(*raw_socket, ssl());
   EXPECT_CALL(*ssl_socket, ssl()).Times(0);
   socket->ssl();
@@ -97,6 +101,9 @@ TEST(StartTlsTest, BasicSwitch) {
 
   EXPECT_CALL(*ssl_socket, configureInitialCongestionWindow(200, std::chrono::microseconds(223)));
   socket->configureInitialCongestionWindow(200, std::chrono::microseconds(223));
+
+  EXPECT_CALL(*ssl_socket, setTransportSocketDataChunkSendLimit(4096));
+  socket->setTransportSocketDataChunkSendLimit(4096);
 
   EXPECT_CALL(*ssl_socket, ssl());
   socket->ssl();

--- a/test/mocks/network/connection.h
+++ b/test/mocks/network/connection.h
@@ -93,6 +93,7 @@ public:
   MOCK_METHOD(absl::string_view, transportFailureReason, (), (const));                             \
   MOCK_METHOD(absl::string_view, localCloseReason, (), (const));                                   \
   MOCK_METHOD(bool, startSecureTransport, ());                                                     \
+  MOCK_METHOD(void, setTransportSocketDataChunkSendLimit, (uint64_t data_chunk_size));             \
   MOCK_METHOD(absl::optional<std::chrono::milliseconds>, lastRoundTripTime, (), (const));          \
   MOCK_METHOD(void, configureInitialCongestionWindow,                                              \
               (uint64_t bandwidth_bits_per_sec, std::chrono::microseconds rtt), ());               \

--- a/test/mocks/network/transport_socket.h
+++ b/test/mocks/network/transport_socket.h
@@ -36,6 +36,7 @@ public:
   MOCK_METHOD(bool, startSecureTransport, ());
   MOCK_METHOD(void, configureInitialCongestionWindow,
               (uint64_t bandwidth_bits_per_sec, std::chrono::microseconds rtt));
+  MOCK_METHOD(void, setTransportSocketDataChunkSendLimit, (uint64_t data_chunk_size));
 
   TransportSocketCallbacks* callbacks_{};
 };

--- a/tools/spelling/spelling_dictionary.txt
+++ b/tools/spelling/spelling_dictionary.txt
@@ -1607,6 +1607,7 @@ pinterest
 callouts
 streamable
 extern
+libpq
 NSS
 SSLKEYLOGFILE
 DLB


### PR DESCRIPTION
## Description

This PR adds a new API on the connection interface that allows limiting TLS record sizes. This is useful for working around bugs in some clients like `libpq` that cannot handle TLS records >= 8KB. We saw this issue in Postgres.

There will be a follow-up to use this new API behind a flag in Postgres Proxy filter.

---

**Commit Message:** tls: added a new API on the connection interface to allow limiting TLS record sizes
**Additional Description:** Adds a new API on the connection interface that allows limiting TLS record sizes. 
**Risk Level:** Low
**Testing:** Added Unit Tests
**Docs Changes:** Added
**Release Notes:** Added