### PR TITLE
docs: remove link to the completed issue in TLS stats

### DIFF
--- a/docs/root/_include/ssl_stats.rst
+++ b/docs/root/_include/ssl_stats.rst
@@ -18,4 +18,4 @@
    curves.<curve>, Counter, Total successful TLS connections that used ECDHE curve <curve>
    sigalgs.<sigalg>, Counter, Total successful TLS connections that used signature algorithm <sigalg>
    versions.<version>, Counter, Total successful TLS connections that used protocol version <version>
-   was_key_usage_invalid, Counter, Total successful TLS connections that used an `invalid keyUsage extension <https://github.com/google/boringssl/blob/6f13380d27835e70ec7caf807da7a1f239b10da6/ssl/internal.h#L3117>`_. (This is not available in BoringSSL FIPS yet due to `issue #28246 <https://github.com/envoyproxy/envoy/issues/28246>`_)
+   was_key_usage_invalid, Counter, Total successful TLS connections that used an `invalid keyUsage extension <https://github.com/google/boringssl/blob/6f13380d27835e70ec7caf807da7a1f239b10da6/ssl/internal.h#L3117>`_.


### PR DESCRIPTION
## Description

The linked issue is now complete and the TLS stat `was_key_usage_invalid` should now be available for FIPS as well. THis PR removes the note.

---

**Commit Message:** docs: remove link to the completed issue in TLS stats
**Additional Description:** Removes the note as the TLS stat should now be available for FIPS as well.
**Risk Level:** N/A
**Testing:** CI
**Docs Changes**: N/A
**Release Notes:** N/A