### PR TITLE
[ProtoApiScrubber] Allow preserving unknown fields.

### DIFF
--- a/source/extensions/filters/http/proto_api_scrubber/scrubbing_util_lib/field_checker.cc
+++ b/source/extensions/filters/http/proto_api_scrubber/scrubbing_util_lib/field_checker.cc
@@ -65,6 +65,11 @@ std::string FieldChecker::constructFieldMask(const std::vector<std::string>& pat
 
 FieldCheckResults FieldChecker::CheckField(const std::vector<std::string>& path,
                                            const Protobuf::Field* field) const {
+  // If the field is unknown (i.e., not present in the descriptor), it should be preserved.
+  if (field == nullptr) {
+    return FieldCheckResults::kInclude;
+  }
+
   const std::string field_mask = constructFieldMask(path, field);
 
   MatchTreeHttpMatchingDataSharedPtr match_tree;

--- a/test/extensions/filters/http/proto_api_scrubber/scrubbing_util_lib/field_checker_test.cc
+++ b/test/extensions/filters/http/proto_api_scrubber/scrubbing_util_lib/field_checker_test.cc
@@ -651,7 +651,7 @@ TEST_F(ResponseFieldCheckerTest, PrimitiveAndMessageType) {
     // The field `name` has a match tree configured which always evaluates to true and has a match
     // action configured of type
     // `envoy.extensions.filters.http.proto_api_scrubber.v3.RemoveFieldAction`
-    // and hence, CheckField returns kInclude.
+    // and hence, CheckField returns kExclude.
     Protobuf::Field field;
     field.set_name("name");
     field.set_kind(Protobuf::Field_Kind_TYPE_STRING);
@@ -869,6 +869,20 @@ TEST_F(FieldCheckerTest, FilterName) {
                              "/library.BookService/GetBook", filter_config_.get());
 
   EXPECT_EQ(field_checker.FilterName(), FieldFilters::FieldMaskFilter);
+}
+
+// Tests that when `field` is nullptr (indicating an unknown field), CheckField returns kInclude.
+TEST_F(FieldCheckerTest, UnknownFieldIsNull) {
+  ProtoApiScrubberConfig config;
+  initializeFilterConfig(config);
+
+  NiceMock<StreamInfo::MockStreamInfo> mock_stream_info;
+  FieldChecker field_checker(ScrubberContext::kRequestScrubbing, &mock_stream_info,
+                             "/library.BookService/GetBook", filter_config_.get());
+
+  // Pass nullptr to simulate an unknown field.
+  EXPECT_EQ(field_checker.CheckField({"some", "unknown", "field"}, nullptr),
+            FieldCheckResults::kInclude);
 }
 
 } // namespace


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message: Allow preserving unknown fields.
Additional Description: The fields which are not present in the descriptor provided in the config are unknown fields and such fields would be preserved by this filter. `field == nullptr` denotes that the fields wasn't found in the descriptor.
Risk Level: None.
Testing: UTs added.
Docs Changes: None.
Release Notes: None.
Platform Specific Features: None.
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
