### PR TITLE
Fix the stale node cleanup causing segfault upstream socket manager

### DIFF
--- a/source/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/upstream_socket_manager.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/upstream_socket_manager.cc
@@ -471,8 +471,14 @@ void UpstreamSocketManager::pingConnections(const std::string& node_id) {
 
 void UpstreamSocketManager::pingConnections() {
   ENVOY_LOG(trace, "reverse_tunnel: pinging connections.");
-  for (auto& itr : accepted_reverse_connections_) {
-    pingConnections(itr.first);
+  // If the last socket for a node errors out the map entry is cleared. So we cant use normal for
+  // loops.
+  for (auto itr = accepted_reverse_connections_.begin();
+       itr != accepted_reverse_connections_.end();) {
+    auto next = std::next(itr);
+
+    pingConnections(itr->first);
+    itr = next;
   }
   ping_timer_->enableTimer(ping_interval_);
 }


### PR DESCRIPTION
## Commit Message
Fix the stale node cleanup causing segfault upstream socket manager

## Additional Description
If the last socket for a node has some error, we cleanup the stale node from the accepted_reverse_connections_ map which causes a segfault cuz the for loop holds an invalid iterator.

Pre increment of iterator solves this. The test passes now and causes a crash for the previous code.