### PR TITLE
bazel: Fix non-RBE tests

### DIFF
--- a/source/extensions/dynamic_modules/sdk/rust/BUILD
+++ b/source/extensions/dynamic_modules/sdk/rust/BUILD
@@ -42,8 +42,8 @@ cargo_build_script(
         "@envoy_repo//:use_local_llvm": [],
         "@platforms//os:linux": [
             "@llvm_toolchain_llvm//:include",
-            "@llvm_toolchain_llvm//:lib_legacy",
             "@llvm_toolchain_llvm//:lib/libclang.so",
+            "@llvm_toolchain_llvm//:lib_legacy",
         ],
         "//conditions:default": [],
     }),


### PR DESCRIPTION
there was a bug where using the lib targets we were for libclang caused a conflict in the rules_rust target

Fix #42451

