### PR TITLE
ext_authz: track active client explicitly for correct cancellation

### DIFF
--- a/source/extensions/filters/http/ext_authz/ext_authz.cc
+++ b/source/extensions/filters/http/ext_authz/ext_authz.cc
@@ -313,7 +313,6 @@ void Filter::initiateCall(const Http::RequestHeaderMap& headers) {
   }
 
   // Check if we need to use a per-route service override (gRPC or HTTP).
-  Filters::Common::ExtAuthz::Client* client_to_use = client_.get();
   if (maybe_merged_per_route_config) {
     if (maybe_merged_per_route_config->grpcService().has_value()) {
       const auto& grpc_service = maybe_merged_per_route_config->grpcService().value();
@@ -321,9 +320,9 @@ void Filter::initiateCall(const Http::RequestHeaderMap& headers) {
                        *decoder_callbacks_);
 
       // Create a new gRPC client for this route.
-      per_route_client_ = createPerRouteGrpcClient(grpc_service);
-      if (per_route_client_ != nullptr) {
-        client_to_use = per_route_client_.get();
+      auto per_route_client = createPerRouteGrpcClient(grpc_service);
+      if (per_route_client != nullptr) {
+        client_ = std::move(per_route_client);
         ENVOY_STREAM_LOG(debug, "ext_authz filter: successfully created per-route gRPC client.",
                          *decoder_callbacks_);
       } else {
@@ -338,9 +337,9 @@ void Filter::initiateCall(const Http::RequestHeaderMap& headers) {
                        *decoder_callbacks_);
 
       // Create a new HTTP client for this route.
-      per_route_client_ = createPerRouteHttpClient(http_service);
-      if (per_route_client_ != nullptr) {
-        client_to_use = per_route_client_.get();
+      auto per_route_client = createPerRouteHttpClient(http_service);
+      if (per_route_client != nullptr) {
+        client_ = std::move(per_route_client);
         ENVOY_STREAM_LOG(debug, "ext_authz filter: successfully created per-route HTTP client.",
                          *decoder_callbacks_);
       } else {
@@ -385,10 +384,9 @@ void Filter::initiateCall(const Http::RequestHeaderMap& headers) {
   filter_return_ = FilterReturn::StopDecoding; // Don't let the filter chain continue as we are
                                                // going to invoke check call.
   cluster_ = decoder_callbacks_->clusterInfo();
-  active_client_ = client_to_use;
   initiating_call_ = true;
-  client_to_use->check(*this, check_request_, decoder_callbacks_->activeSpan(),
-                       decoder_callbacks_->streamInfo());
+  client_->check(*this, check_request_, decoder_callbacks_->activeSpan(),
+                 decoder_callbacks_->streamInfo());
   initiating_call_ = false;
 }
 
@@ -610,9 +608,7 @@ void Filter::setEncoderFilterCallbacks(Http::StreamEncoderFilterCallbacks& callb
 void Filter::onDestroy() {
   if (state_ == State::Calling) {
     state_ = State::Complete;
-    if (active_client_ != nullptr) {
-      active_client_->cancel();
-    }
+    client_->cancel();
   }
 }
 
@@ -629,7 +625,6 @@ CheckResult Filter::validateAndCheckDecoderHeaderMutation(
 
 void Filter::onComplete(Filters::Common::ExtAuthz::ResponsePtr&& response) {
   state_ = State::Complete;
-  active_client_ = nullptr;
   using Filters::Common::ExtAuthz::CheckStatus;
   Stats::StatName empty_stat_name;
 

--- a/source/extensions/filters/http/ext_authz/ext_authz.h
+++ b/source/extensions/filters/http/ext_authz/ext_authz.h
@@ -484,10 +484,6 @@ private:
   Http::HeaderMapPtr getHeaderMap(const Filters::Common::ExtAuthz::ResponsePtr& response);
   FilterConfigSharedPtr config_;
   Filters::Common::ExtAuthz::ClientPtr client_;
-  // Per-route gRPC client that overrides the default client when specified.
-  Filters::Common::ExtAuthz::ClientPtr per_route_client_;
-  // Client currently being used for the authorization check.
-  Filters::Common::ExtAuthz::Client* active_client_{nullptr};
   // Server context for creating per-route clients.
   Server::Configuration::ServerFactoryContext* server_context_{nullptr};
   Http::StreamDecoderFilterCallbacks* decoder_callbacks_{};


### PR DESCRIPTION
Commit Message:

The onDestroy() function was always canceling the default client_, regardless of whether a per-route client was actually being used. While we're uncertain if this causes a real issue in practice (since per-route clients are created per-request and the filter lifecycle should align with the request), it seems like we may have missed something in the onDestroy implementation.

This change adds an active_client_ member variable that tracks which client (default or per-route) is currently being used for the authorization check. The active_client_ pointer is set in initiateCall() when the check is initiated, and used in onDestroy() to cancel the correct client.

Added tests to verify:
- onDestroy cancels per-route client when it's being used
- onDestroy cancels default client when no per-route client exists

Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
