### PR TITLE
mcp_router: Use MuxDemux for single-backend operations

### DIFF
--- a/source/extensions/filters/http/mcp_router/mcp_router.h
+++ b/source/extensions/filters/http/mcp_router/mcp_router.h
@@ -153,14 +153,10 @@ private:
   std::string encoded_session_id_;
   absl::flat_hash_map<std::string, std::string> backend_sessions_;
 
-  // MuxDemux for fanout operations (per-filter instance)
+  // MuxDemux for all backend operations (fanout and single-backend)
   std::shared_ptr<Http::MuxDemux> muxdemux_;
   std::unique_ptr<Http::MultiStream> multistream_;
   std::vector<std::shared_ptr<BackendStreamCallbacks>> stream_callbacks_;
-
-  // Single backend stream (for tools/call)
-  // TODO(botengyao): better to use MuxDemux, but this is simpler now.
-  Http::AsyncClient::Stream* single_stream_{};
 
   // Store headers to keep them alive for the duration of the stream
   // AsyncStreamImpl stores only a pointer to headers, so we must keep them alive


### PR DESCRIPTION
Commit Message:
Refactor to use MuxDemux::multicast() for single-backend requests instead of directly using AsyncClient::Stream. This unifies the code path for both fanout and single-backend operations, addressing the TODO comment.

#39174 

Removes single_stream_ member variable and consolidates all backend operations to use the multistream_ path.
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
