### PR TITLE
router: cache runtime flag to avoid per-chunk evaluation

### DIFF
--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -976,8 +976,7 @@ uint64_t Filter::calculateEffectiveBufferLimit() const {
 
 bool Filter::isEarlyConnectData() {
   return downstream_headers_ != nullptr && Http::HeaderUtility::isConnect(*downstream_headers_) &&
-         !downstream_response_started_ &&
-         Runtime::runtimeFeatureEnabled("envoy.reloadable_features.reject_early_connect_data");
+         !downstream_response_started_ && reject_early_connect_data_enabled_;
 }
 
 Http::FilterDataStatus Filter::decodeData(Buffer::Instance& data, bool end_stream) {

--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -303,7 +303,10 @@ public:
   Filter(const FilterConfigSharedPtr& config, FilterStats& stats)
       : config_(config), stats_(stats),
         allow_multiplexed_upstream_half_close_(Runtime::runtimeFeatureEnabled(
-            "envoy.reloadable_features.allow_multiplexed_upstream_half_close")) {}
+            "envoy.reloadable_features.allow_multiplexed_upstream_half_close")),
+        reject_early_connect_data_enabled_(
+            Runtime::runtimeFeatureEnabled("envoy.reloadable_features.reject_early_connect_data")) {
+  }
 
   ~Filter() override;
 
@@ -689,6 +692,9 @@ private:
   // Indicate that ORCA report is received to process it only once in either response headers or
   // trailers.
   bool orca_load_report_received_ : 1 = false;
+  // Cached runtime flag value for reject_early_connect_data to avoid evaluating it on every data
+  // chunk.
+  bool reject_early_connect_data_enabled_ : 1 = false;
 };
 
 class ProdFilter : public Filter {


### PR DESCRIPTION
Commit Message:
Cache the `reject_early_connect_data` runtime flag value in the Filter constructor instead of evaluating it on every data chunk in `decodeData()`. This optimization follows the same pattern as `allow_multiplexed_upstream_half_close_` and reduces overhead for requests with large bodies split into many chunks.

The runtime flag is now evaluated once per request (in the constructor) and reused for all data chunks, eliminating repeated hash map lookups in the hot path while still allowing runtime flag changes to take effect for new requests.

Risk Level: Low
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
