### PR TITLE
[datasource] remove tmp obj creation

### DIFF
--- a/source/common/config/datasource.h
+++ b/source/common/config/datasource.h
@@ -173,7 +173,7 @@ public:
                                      std::move(*transformed_new_data_or_error.value()))](
                                     OptRef<typename DynamicData<DataType>::ThreadLocalData> obj) {
         if (obj.has_value()) {
-          obj->data_ = std::make_shared<DataType>(*new_data);
+          obj->data_ = new_data;
         }
       });
       return absl::OkStatus();


### PR DESCRIPTION
Cleaning up unnecessary temp object creation for updating tls data, instead just copying the lambda arg `new_data` into tls value.

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
