### PR TITLE
clean-up: use mutex reference p3

### DIFF
--- a/source/extensions/clusters/redis/redis_cluster_lb.cc
+++ b/source/extensions/clusters/redis/redis_cluster_lb.cc
@@ -68,7 +68,7 @@ bool RedisClusterLoadBalancerFactory::onClusterSlotUpdate(ClusterSlotsSharedPtr&
   }
 
   {
-    absl::WriterMutexLock lock(&mutex_);
+    absl::WriterMutexLock lock(mutex_);
     current_cluster_slot_ = std::move(slots);
     slot_array_ = std::move(updated_slots);
     shard_vector_ = std::move(shard_vector);
@@ -96,7 +96,7 @@ void RedisClusterLoadBalancerFactory::onHostHealthUpdate() {
   }
 
   {
-    absl::WriterMutexLock lock(&mutex_);
+    absl::WriterMutexLock lock(mutex_);
     shard_vector_ = std::move(shard_vector);
   }
 }

--- a/source/extensions/http/cache/simple_http_cache/simple_http_cache.cc
+++ b/source/extensions/http/cache/simple_http_cache/simple_http_cache.cc
@@ -178,7 +178,7 @@ void SimpleHttpCache::updateHeaders(const LookupContext& lookup_context,
                                     UpdateHeadersCallback on_complete) {
   const auto& simple_lookup_context = static_cast<const SimpleLookupContext&>(lookup_context);
   const Key& key = simple_lookup_context.request().key();
-  absl::WriterMutexLock lock(&mutex_);
+  absl::WriterMutexLock lock(mutex_);
   auto iter = map_.find(key);
   auto post_complete = [on_complete = std::move(on_complete),
                         &dispatcher = simple_lookup_context.dispatcher()](bool result) mutable {
@@ -234,7 +234,7 @@ SimpleHttpCache::Entry SimpleHttpCache::lookup(const LookupRequest& request) {
 bool SimpleHttpCache::insert(const Key& key, Http::ResponseHeaderMapPtr&& response_headers,
                              ResponseMetadata&& metadata, std::string&& body,
                              Http::ResponseTrailerMapPtr&& trailers) {
-  absl::WriterMutexLock lock(&mutex_);
+  absl::WriterMutexLock lock(mutex_);
   map_[key] = SimpleHttpCache::Entry{std::move(response_headers), std::move(metadata),
                                      std::move(body), std::move(trailers)};
   return true;
@@ -273,7 +273,7 @@ bool SimpleHttpCache::varyInsert(const Key& request_key,
                                  const Http::RequestHeaderMap& request_headers,
                                  const VaryAllowList& vary_allow_list,
                                  Http::ResponseTrailerMapPtr&& trailers) {
-  absl::WriterMutexLock lock(&mutex_);
+  absl::WriterMutexLock lock(mutex_);
 
   absl::btree_set<absl::string_view> vary_header_values =
       VaryHeaderUtils::getVaryValues(*response_headers);

--- a/test/common/access_log/access_log_manager_impl_test.cc
+++ b/test/common/access_log/access_log_manager_impl_test.cc
@@ -188,7 +188,7 @@ TEST_F(AccessLogManagerImplTest, FlushToLogFileOnDemand) {
   log_file->write("test");
 
   {
-    absl::MutexLock lock(&file_->mutex_);
+    absl::MutexLock lock(file_->mutex_);
     EXPECT_EQ(expected_writes, file_->num_writes_);
   }
 

--- a/test/extensions/geoip_providers/maxmind/geoip_provider_test.cc
+++ b/test/extensions/geoip_providers/maxmind/geoip_provider_test.cc
@@ -112,7 +112,7 @@ public:
   }
 
   ~GeoipProviderTestBase() {
-    absl::WriterMutexLock lock(&mutex_);
+    absl::WriterMutexLock lock(mutex_);
     on_changed_cbs_.clear();
   };
 
@@ -129,7 +129,7 @@ public:
               .WillRepeatedly(Invoke([this, &conditional](absl::string_view, uint32_t,
                                                           Filesystem::Watcher::OnChangedCb cb) {
                 {
-                  absl::WriterMutexLock lock(&mutex_);
+                  absl::WriterMutexLock lock(mutex_);
                   on_changed_cbs_.reserve(1);
                   on_changed_cbs_.emplace_back(std::move(cb));
                 }


### PR DESCRIPTION
Replace deprecated absl::MutexLock::MutexLock(Mutex*) constructor with absl::MutexLock::MutexLock(Mutex&)

Similar to https://github.com/envoyproxy/envoy/pull/41208.

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
