### PR TITLE
cleanup: use mutex reference in lock constructs p9

### DIFF
--- a/source/extensions/clusters/original_dst/original_dst_cluster.h
+++ b/source/extensions/clusters/original_dst/original_dst_cluster.h
@@ -159,12 +159,12 @@ private:
   };
 
   HostMultiMapConstSharedPtr getCurrentHostMap() {
-    absl::ReaderMutexLock lock(&host_map_lock_);
+    absl::ReaderMutexLock lock(host_map_lock_);
     return host_map_;
   }
 
   void setHostMap(const HostMultiMapConstSharedPtr& new_host_map) {
-    absl::WriterMutexLock lock(&host_map_lock_);
+    absl::WriterMutexLock lock(host_map_lock_);
     host_map_ = new_host_map;
   }
 

--- a/source/extensions/clusters/reverse_connection/reverse_connection.cc
+++ b/source/extensions/clusters/reverse_connection/reverse_connection.cc
@@ -74,7 +74,7 @@ Upstream::HostSelectionResponse RevConCluster::checkAndCreateHost(absl::string_v
   ENVOY_LOG(debug, "reverse_connection: resolved key '{}' to node: '{}'", host_id, node_id);
 
   {
-    absl::ReaderMutexLock rlock(&host_map_lock_);
+    absl::ReaderMutexLock rlock(host_map_lock_);
     // Check if node_id is already present in host_map_ or not. This ensures,
     // that envoy reuses a conn_pool_container for an endpoint.
     auto host_itr = host_map_.find(node_id);
@@ -85,7 +85,7 @@ Upstream::HostSelectionResponse RevConCluster::checkAndCreateHost(absl::string_v
     }
   }
 
-  absl::WriterMutexLock wlock(&host_map_lock_);
+  absl::WriterMutexLock wlock(host_map_lock_);
 
   // Re-check under writer lock to avoid duplicate creation under contention.
   auto host_itr2 = host_map_.find(node_id);
@@ -115,7 +115,7 @@ Upstream::HostSelectionResponse RevConCluster::checkAndCreateHost(absl::string_v
 }
 
 void RevConCluster::cleanup() {
-  absl::WriterMutexLock wlock(&host_map_lock_);
+  absl::WriterMutexLock wlock(host_map_lock_);
 
   for (auto iter = host_map_.begin(); iter != host_map_.end();) {
     // Check if the host handle is acquired by any connection pool container or not. If not

--- a/source/extensions/http/cache/file_system_http_cache/config.cc
+++ b/source/extensions/http/cache/file_system_http_cache/config.cc
@@ -53,7 +53,7 @@ public:
     std::shared_ptr<FileSystemHttpCache> cache;
     ConfigProto config = normalizeConfig(non_normalized_config);
     auto key = config.cache_path();
-    absl::MutexLock lock(&mu_);
+    absl::MutexLock lock(mu_);
     auto it = caches_.find(key);
     if (it != caches_.end()) {
       cache = it->second.lock();

--- a/source/extensions/http/cache/file_system_http_cache/file_system_http_cache.cc
+++ b/source/extensions/http/cache/file_system_http_cache/file_system_http_cache.cc
@@ -322,17 +322,17 @@ void FileSystemHttpCache::updateHeaders(const LookupContext& base_lookup_context
 absl::string_view FileSystemHttpCache::cachePath() const { return shared_->cachePath(); }
 
 bool FileSystemHttpCache::workInProgress(const Key& key) {
-  absl::MutexLock lock(&cache_mu_);
+  absl::MutexLock lock(cache_mu_);
   return entries_being_written_.contains(key);
 }
 
 std::shared_ptr<Cleanup> FileSystemHttpCache::maybeStartWritingEntry(const Key& key) {
-  absl::MutexLock lock(&cache_mu_);
+  absl::MutexLock lock(cache_mu_);
   if (!entries_being_written_.emplace(key).second) {
     return nullptr;
   }
   return std::make_shared<Cleanup>([this, key]() {
-    absl::MutexLock lock(&cache_mu_);
+    absl::MutexLock lock(cache_mu_);
     entries_being_written_.erase(key);
   });
 }

--- a/source/extensions/http/cache_v2/file_system_http_cache/config.cc
+++ b/source/extensions/http/cache_v2/file_system_http_cache/config.cc
@@ -54,7 +54,7 @@ public:
     std::shared_ptr<CacheSessions> cache;
     ConfigProto config = normalizeConfig(non_normalized_config);
     auto key = config.cache_path();
-    absl::MutexLock lock(&mu_);
+    absl::MutexLock lock(mu_);
     auto it = caches_.find(key);
     if (it != caches_.end()) {
       cache = it->second.lock();

--- a/source/extensions/http/cache_v2/file_system_http_cache/file_system_http_cache.cc
+++ b/source/extensions/http/cache_v2/file_system_http_cache/file_system_http_cache.cc
@@ -41,7 +41,7 @@ CacheShared::CacheShared(ConfigProto config, Stats::Scope& stats_scope,
       stats_(generateStats(stat_names_, stats_scope, cachePath())) {}
 
 void CacheShared::disconnectEviction() {
-  absl::MutexLock lock(&signal_mu_);
+  absl::MutexLock lock(signal_mu_);
   signal_eviction_ = []() {};
 }
 
@@ -256,7 +256,7 @@ void CacheShared::trackFileAdded(uint64_t file_size) {
   stats_.size_bytes_.add(file_size);
   if (needsEviction()) {
     {
-      absl::MutexLock lock(&signal_mu_);
+      absl::MutexLock lock(signal_mu_);
       signal_eviction_();
     }
   }


### PR DESCRIPTION
Replace deprecated absl::MutexLock::MutexLock(Mutex*) constructor with absl::MutexLock::MutexLock(Mutex&)

Additional Description: needed due to upcoming absl change.
Similar to #41208.

Risk Level: low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
