### PR TITLE
cleanup: use mutex reference in lock constructs p10

### DIFF
--- a/source/common/common/fine_grain_logger.h
+++ b/source/common/common/fine_grain_logger.h
@@ -129,7 +129,7 @@ public:
    */
   void removeFineGrainLogEntryForTest(absl::string_view key)
       ABSL_LOCKS_EXCLUDED(fine_grain_log_lock_) {
-    absl::WriterMutexLock wl(&fine_grain_log_lock_);
+    absl::WriterMutexLock wl(fine_grain_log_lock_);
     fine_grain_log_map_->erase(key);
   }
 

--- a/source/common/common/logger.cc
+++ b/source/common/common/logger.cc
@@ -69,7 +69,7 @@ void DelegatingLogSink::set_formatter(std::unique_ptr<spdlog::formatter> formatt
 }
 
 void DelegatingLogSink::setShouldEscape(bool should_escape) {
-  absl::MutexLock lock(&format_mutex_);
+  absl::MutexLock lock(format_mutex_);
   should_escape_ = should_escape;
 }
 

--- a/source/common/quic/platform/quiche_logging_impl.cc
+++ b/source/common/quic/platform/quiche_logging_impl.cc
@@ -82,7 +82,7 @@ QuicheLogEmitter::~QuicheLogEmitter() {
 
   // Normally there is no log sink and we can avoid acquiring the lock.
   if (q_quiche_log_sink.load(std::memory_order_relaxed) != nullptr) {
-    absl::MutexLock lock(&q_quiche_log_sink_mutex);
+    absl::MutexLock lock(q_quiche_log_sink_mutex);
     QuicheLogSink* sink = q_quiche_log_sink.load(std::memory_order_relaxed);
     if (sink != nullptr) {
       sink->Log(level_, content);
@@ -110,7 +110,7 @@ void setDFatalExitDisabled(bool is_disabled) {
 }
 
 QuicheLogSink* SetLogSink(QuicheLogSink* new_sink) {
-  absl::MutexLock lock(&q_quiche_log_sink_mutex);
+  absl::MutexLock lock(q_quiche_log_sink_mutex);
   QuicheLogSink* old_sink = q_quiche_log_sink.load(std::memory_order_relaxed);
   q_quiche_log_sink.store(new_sink, std::memory_order_relaxed);
   return old_sink;

--- a/source/common/runtime/runtime_impl.cc
+++ b/source/common/runtime/runtime_impl.cc
@@ -656,7 +656,7 @@ absl::Status LoaderImpl::loadNewSnapshot() {
   refreshReloadableFlags(ptr->values());
 
   {
-    absl::MutexLock lock(&snapshot_mutex_);
+    absl::MutexLock lock(snapshot_mutex_);
     thread_safe_snapshot_ = ptr;
   }
   return absl::OkStatus();
@@ -674,7 +674,7 @@ SnapshotConstSharedPtr LoaderImpl::threadsafeSnapshot() {
   }
 
   {
-    absl::ReaderMutexLock lock(&snapshot_mutex_);
+    absl::ReaderMutexLock lock(snapshot_mutex_);
     return thread_safe_snapshot_;
   }
 }

--- a/source/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/upstream_socket_manager.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/upstream_socket_manager.cc
@@ -28,14 +28,14 @@ UpstreamSocketManager::UpstreamSocketManager(Event::Dispatcher& dispatcher,
   ping_timer_ = dispatcher_.createTimer([this]() { pingConnections(); });
 
   // Register this socket manager instance for rebalancing.
-  absl::WriterMutexLock lock(&UpstreamSocketManager::socket_manager_lock);
+  absl::WriterMutexLock lock(UpstreamSocketManager::socket_manager_lock);
   UpstreamSocketManager::socket_managers_.push_back(this);
 }
 
 UpstreamSocketManager&
 UpstreamSocketManager::pickLeastLoadedSocketManager(const std::string& node_id,
                                                     const std::string& cluster_id) {
-  absl::WriterMutexLock wlock(&UpstreamSocketManager::socket_manager_lock);
+  absl::WriterMutexLock wlock(UpstreamSocketManager::socket_manager_lock);
 
   // Assume that this worker is the best candidate for sending the reverse.
   // connection socket.
@@ -534,7 +534,7 @@ UpstreamSocketManager::~UpstreamSocketManager() {
   }
 
   // Remove this instance from the global socket managers list.
-  absl::WriterMutexLock lock(&UpstreamSocketManager::socket_manager_lock);
+  absl::WriterMutexLock lock(UpstreamSocketManager::socket_manager_lock);
   auto it = std::find(socket_managers_.begin(), socket_managers_.end(), this);
   if (it != socket_managers_.end()) {
     socket_managers_.erase(it);

--- a/test/common/quic/platform/quic_platform_test.cc
+++ b/test/common/quic/platform/quic_platform_test.cc
@@ -166,13 +166,13 @@ TEST_F(QuicPlatformTest, DISABLED_QuicThread) {
 
     void waitForRun() {
       // Wait for Run() to finish.
-      absl::MutexLock lk(&m_);
+      absl::MutexLock lk(m_);
       cv_.Wait(&m_);
     }
 
   protected:
     void Run() override {
-      absl::MutexLock lk(&m_);
+      absl::MutexLock lk(m_);
       *value_ += increment_;
       cv_.Signal();
     }


### PR DESCRIPTION
Replace deprecated absl::MutexLock::MutexLock(Mutex*) constructor with absl::MutexLock::MutexLock(Mutex&)

Additional Description: needed due to upcoming absl change.
Similar to #41208.

Risk Level: low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A