### PR TITLE
cleanup: use mutex reference in lock constructs p11

### DIFF
--- a/source/extensions/filters/http/adaptive_concurrency/controller/gradient_controller.cc
+++ b/source/extensions/filters/http/adaptive_concurrency/controller/gradient_controller.cc
@@ -72,7 +72,7 @@ GradientController::GradientController(GradientControllerConfig config,
     }
 
     {
-      absl::MutexLock ml(&sample_mutation_mtx_);
+      absl::MutexLock ml(sample_mutation_mtx_);
       resetSampleWindow();
     }
 
@@ -108,7 +108,7 @@ void GradientController::enterMinRTTSamplingWindow() {
     return;
   }
 
-  absl::MutexLock ml(&sample_mutation_mtx_);
+  absl::MutexLock ml(sample_mutation_mtx_);
 
   stats_.min_rtt_calculation_active_.set(1);
 
@@ -246,7 +246,7 @@ void GradientController::recordLatencySample(MonotonicTime rq_send_time) {
                                                             rq_send_time);
   synchronizer_.syncPoint("pre_hist_insert");
   {
-    absl::MutexLock ml(&sample_mutation_mtx_);
+    absl::MutexLock ml(sample_mutation_mtx_);
     hist_insert(latency_sample_hist_.get(), rq_latency.count(), 1);
     updateMinRTT();
   }

--- a/source/extensions/filters/http/cache_v2/cache_sessions_impl.h
+++ b/source/extensions/filters/http/cache_v2/cache_sessions_impl.h
@@ -256,7 +256,7 @@ private:
   // The following fields and functions are only used by CacheSessions.
   friend class CacheSessionsImpl;
   bool inserting() const {
-    absl::MutexLock lock(&mu_);
+    absl::MutexLock lock(mu_);
     return state_ == State::Inserting;
   }
   void setExpiry(SystemTime expiry) { expires_at_ = expiry; }

--- a/source/server/hot_restarting_child.cc
+++ b/source/server/hot_restarting_child.cc
@@ -84,7 +84,7 @@ bool HotRestartingChild::abortDueToFailedParentConnection() {
 void HotRestartingChild::initialize(Event::Dispatcher& dispatcher) {
   if (abortDueToFailedParentConnection()) {
     ENVOY_LOG(warn, "hot restart sendmsg() connection refused, falling back to regular restart");
-    absl::MutexLock lock(&registry_mu_);
+    absl::MutexLock lock(registry_mu_);
     parent_terminated_ = parent_drained_ = true;
     return;
   }
@@ -180,7 +180,7 @@ void HotRestartingChild::registerUdpForwardingListener(
 
 void HotRestartingChild::registerParentDrainedCallback(
     const Network::Address::InstanceConstSharedPtr& address, absl::AnyInvocable<void()> callback) {
-  absl::MutexLock lock(&registry_mu_);
+  absl::MutexLock lock(registry_mu_);
   if (parent_drained_) {
     callback();
   } else {
@@ -189,7 +189,7 @@ void HotRestartingChild::registerParentDrainedCallback(
 }
 
 void HotRestartingChild::allDrainsImplicitlyComplete() {
-  absl::MutexLock lock(&registry_mu_);
+  absl::MutexLock lock(registry_mu_);
   for (auto& drain_action : on_drained_actions_) {
     // Call the callback.
     std::move(drain_action.second)();

--- a/test/extensions/filters/http/dynamic_forward_proxy/test_resolver.h
+++ b/test/extensions/filters/http/dynamic_forward_proxy/test_resolver.h
@@ -15,7 +15,7 @@ namespace Network {
 class TestResolver : public GetAddrInfoDnsResolver {
 public:
   ~TestResolver() {
-    absl::MutexLock guard(&mutex_);
+    absl::MutexLock guard(mutex_);
     blocked_resolutions_.clear();
   }
 
@@ -23,7 +23,7 @@ public:
 
   static void unblockResolve(absl::optional<std::string> dns_override = {}) {
     while (1) {
-      absl::MutexLock guard(&resolution_mutex_);
+      absl::MutexLock guard(resolution_mutex_);
       if (blocked_resolutions_.empty()) {
         continue;
       }
@@ -39,10 +39,10 @@ public:
     std::unique_ptr<PendingQuery> new_query =
         std::make_unique<PendingQuery>(dns_name, dns_lookup_family, callback);
     PendingQuery* raw_new_query = new_query.get();
-    absl::MutexLock guard(&resolution_mutex_);
+    absl::MutexLock guard(resolution_mutex_);
     blocked_resolutions_.push_back(
         [&, query = std::move(new_query)](absl::optional<std::string> dns_override) mutable {
-          absl::MutexLock guard(&mutex_);
+          absl::MutexLock guard(mutex_);
           if (dns_override.has_value()) {
             *const_cast<std::string*>(&query->dns_name_) = dns_override.value();
           }


### PR DESCRIPTION
Replace deprecated absl::MutexLock::MutexLock(Mutex*) constructor with absl::MutexLock::MutexLock(Mutex&)

Additional Description: needed due to upcoming absl change.
Similar to #41208.

Risk Level: low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
