### PR TITLE
Avoid multimap::find unspecified behavior

### DIFF
--- a/test/extensions/filters/http/ext_proc/streaming_integration_test.cc
+++ b/test/extensions/filters/http/ext_proc/streaming_integration_test.cc
@@ -175,8 +175,7 @@ TEST_P(StreamingIntegrationTest, PostAndProcessHeadersOnly) {
       [](grpc::ServerContext* ctx) {
         // Verify that the metadata set in the grpc client configuration
         // above is actually sent to our RPC.
-        auto [request_id, request_id_end] =
-            ctx->client_metadata().equal_range("x-request-id");
+        auto [request_id, request_id_end] = ctx->client_metadata().equal_range("x-request-id");
         ASSERT_NE(request_id, request_id_end);
         EXPECT_EQ(request_id->second, "sent some metadata");
       });


### PR DESCRIPTION
Commit Message: When a multimap has multiple entries with the same key, calling multimap::find(key) returns an unspecified element. 

Historically, this returns the first matching element. However, this is not guaranteed, and recent libc++ changes make this return an arbitrary element.

Using equal_range() is a replacement that will preserve the current behavior. The behavior of this is guaranteed to return the first match instead of an arbitrary one.

Additional Description:
Risk Level: Low
Testing: Unit tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a