### PR TITLE
http: minor refactoring to add reserve()

### DIFF
--- a/source/common/http/header_mutation.cc
+++ b/source/common/http/header_mutation.cc
@@ -103,6 +103,7 @@ HeaderMutations::HeaderMutations(const ProtoHeaderMutatons& header_mutations,
                                  Server::Configuration::CommonFactoryContext& context,
                                  const Formatter::CommandParserPtrVector& command_parsers,
                                  absl::Status& creation_status) {
+  header_mutations_.reserve(header_mutations.size());
   for (const auto& mutation : header_mutations) {
     switch (mutation.action_case()) {
     case envoy::config::common::mutation_rules::v3::HeaderMutation::ActionCase::kAppend:

--- a/source/common/router/scoped_config_impl.cc
+++ b/source/common/router/scoped_config_impl.cc
@@ -96,6 +96,7 @@ ScopedRouteInfo::ScopedRouteInfo(envoy::config::route::v3::ScopedRouteConfigurat
 
 ScopeKeyBuilderImpl::ScopeKeyBuilderImpl(ScopedRoutes::ScopeKeyBuilder&& config)
     : ScopeKeyBuilderBase(std::move(config)) {
+  fragment_builders_.reserve(config_.fragments().size());
   for (const auto& fragment_builder : config_.fragments()) {
     switch (fragment_builder.type_case()) {
     case ScopedRoutes::ScopeKeyBuilder::FragmentBuilder::kHeaderValueExtractor:


### PR DESCRIPTION
## Description

Minor refactoring to add `reserve()` in the HTTP Header Mutations and Router.

---

**Commit Message: ratelimit**: minor refactoring to add reserve()
**Additional Description:** Minor refactoring to add `reserve()` in HTTP Header Mutations and Router.
**Risk Level:** Low
**Testing:** CI
**Docs Changes:** N/A
**Release Notes:** N/A