### PR TITLE
access_log: add a new COALESCE substitution formatter

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -261,6 +261,11 @@ new_features:
   change: |
     Added process-level rate limiting on access log emission via
     :ref:`ProcessRateLimitFilter <envoy_v3_api_msg_extensions.access_loggers.filters.process_ratelimit.v3.ProcessRateLimitFilter>`.
+- area: access_log
+  change: |
+    Added :ref:`COALESCE <config_access_log_format_coalesce>` substitution formatter operator that evaluates multiple
+    formatter operators in sequence and returns the first non-null result. This enables fallback behavior such as
+    using SNI when available but falling back to the ``:authority`` header when SNI is not set.
 - area: listener_filters
   change: |
     Added :ref:`Postgres Inspector <config_listener_filters_postgres_inspector>` listener filter for detecting

--- a/docs/root/configuration/observability/access_log/usage.rst
+++ b/docs/root/configuration/observability/access_log/usage.rst
@@ -1470,3 +1470,61 @@ UDP
 %CUSTOM_FLAGS%
   Custom flags set into the stream info. This could be used to log any custom event from the filters.
   Multiple flags are separated by comma.
+
+.. _config_access_log_format_coalesce:
+
+%COALESCE(JSON_CONFIG):Z%
+  HTTP
+    A higher-order formatter operator that evaluates multiple formatter operators in sequence and
+    returns the first non-null, non-empty result. This is useful for implementing fallback behavior,
+    such as using SNI when available but falling back to the ``:authority`` header when SNI is not set.
+
+    The ``JSON_CONFIG`` parameter is a JSON object with an ``operators`` array. Each operator can be
+    specified as either:
+
+    * A string representing a simple command name that does not require a parameter.
+    * An object with the following fields:
+
+      * ``command`` (required): The command name (e.g., ``REQ``, ``REQUESTED_SERVER_NAME``).
+      * ``param`` (optional): The command parameter (e.g., ``:authority`` for the ``REQ`` command).
+      * ``max_length`` (optional): Maximum length for this operator's output.
+
+    ``Z`` is an optional parameter denoting string truncation up to ``Z`` characters for the final output.
+
+    .. note::
+
+      The JSON parameter cannot contain literal ``)`` characters as they would interfere with the
+      command parser. If you need a ``)`` character in a string value, use the Unicode escape
+      sequence ``\u0029``.
+
+    **Example: SNI with fallback to authority header**
+
+    .. code-block:: none
+
+      %COALESCE({"operators": ["REQUESTED_SERVER_NAME", {"command": "REQ", "param": ":authority"}]})%
+
+    This returns the Server Name Indication (SNI) if available, otherwise falls back to the
+    ``:authority`` header.
+
+    **Example: Cascade fallback with multiple headers**
+
+    .. code-block:: none
+
+      %COALESCE({"operators": ["REQUESTED_SERVER_NAME", {"command": "REQ", "param": ":authority"}, {"command": "REQ", "param": "x-envoy-original-host"}]})%
+
+    This tries SNI first, then ``:authority``, then ``x-envoy-original-host``.
+
+    **Example: With length truncation**
+
+    .. code-block:: none
+
+      %COALESCE({"operators": [{"command": "REQ", "param": ":authority"}]}):50%
+
+    This returns the ``:authority`` header value truncated to 50 characters.
+
+    **Supported Commands**
+
+    The ``COALESCE`` operator supports any built-in formatter command.
+
+  TCP/UDP
+    Not implemented ("-").

--- a/source/common/formatter/BUILD
+++ b/source/common/formatter/BUILD
@@ -64,10 +64,26 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
+    name = "coalesce_formatter_lib",
+    srcs = ["coalesce_formatter.cc"],
+    hdrs = ["coalesce_formatter.h"],
+    deps = [
+        ":substitution_format_utility_lib",
+        "//envoy/formatter:substitution_formatter_interface",
+        "//envoy/json:json_object_interface",
+        "//envoy/stream_info:stream_info_interface",
+        "//source/common/common:fmt_lib",
+        "//source/common/common:statusor_lib",
+        "//source/common/json:json_loader_lib",
+    ],
+)
+
+envoy_cc_library(
     name = "http_speicific_formatter_extension_lib",
     srcs = ["http_specific_formatter.cc"],
     hdrs = ["http_specific_formatter.h"],
     deps = [
+        ":coalesce_formatter_lib",
         "//envoy/api:api_interface",
         "//envoy/formatter:substitution_formatter_interface",
         "//envoy/runtime:runtime_interface",

--- a/source/common/formatter/coalesce_formatter.cc
+++ b/source/common/formatter/coalesce_formatter.cc
@@ -1,0 +1,154 @@
+#include "source/common/formatter/coalesce_formatter.h"
+
+#include "source/common/common/fmt.h"
+#include "source/common/json/json_loader.h"
+
+namespace Envoy {
+namespace Formatter {
+
+absl::StatusOr<FormatterProviderPtr> CoalesceFormatter::create(absl::string_view json_config,
+                                                               absl::optional<size_t> max_length) {
+  if (json_config.empty()) {
+    return absl::InvalidArgumentError("COALESCE requires a JSON configuration parameter");
+  }
+
+  auto json_or_error = Json::Factory::loadFromString(std::string(json_config));
+  if (!json_or_error.ok()) {
+    return absl::InvalidArgumentError(fmt::format(
+        "COALESCE: failed to parse JSON configuration: {}", json_or_error.status().message()));
+  }
+
+  const auto& json = *json_or_error.value();
+
+  if (!json.hasObject("operators")) {
+    return absl::InvalidArgumentError(
+        "COALESCE: JSON configuration must contain 'operators' array");
+  }
+
+  auto operators_or_error = json.getObjectArray("operators");
+  if (!operators_or_error.ok()) {
+    return absl::InvalidArgumentError(fmt::format("COALESCE: 'operators' must be an array: {}",
+                                                  operators_or_error.status().message()));
+  }
+
+  const auto& operators = operators_or_error.value();
+  if (operators.empty()) {
+    return absl::InvalidArgumentError("COALESCE: 'operators' array must not be empty");
+  }
+
+  std::vector<FormatterProviderPtr> formatters;
+  formatters.reserve(operators.size());
+
+  for (size_t i = 0; i < operators.size(); ++i) {
+    const auto& entry = operators[i];
+    auto formatter_or_error = parseOperatorEntry(*entry);
+    if (!formatter_or_error.ok()) {
+      return absl::InvalidArgumentError(
+          fmt::format("COALESCE: failed to parse operator at index {}: {}", i,
+                      formatter_or_error.status().message()));
+    }
+    formatters.push_back(std::move(formatter_or_error.value()));
+  }
+
+  return std::make_unique<CoalesceFormatter>(std::move(formatters), max_length);
+}
+
+absl::StatusOr<FormatterProviderPtr>
+CoalesceFormatter::parseOperatorEntry(const Json::Object& entry) {
+  // Check if this is a simple string command with command-only and no parameters.
+  auto string_value = entry.asString();
+  if (string_value.ok()) {
+    return createFormatterForCommand(string_value.value(), "", absl::nullopt);
+  }
+
+  // Otherwise, it should be an object with "command" field.
+  if (!entry.isObject()) {
+    return absl::InvalidArgumentError(
+        "operator entry must be either a string (command name) or an object with 'command' field");
+  }
+
+  auto command_or_error = entry.getString("command");
+  if (!command_or_error.ok()) {
+    return absl::InvalidArgumentError(fmt::format("operator object must have 'command' field: {}",
+                                                  command_or_error.status().message()));
+  }
+
+  std::string param;
+  if (entry.hasObject("param")) {
+    auto param_or_error = entry.getString("param");
+    if (!param_or_error.ok()) {
+      return absl::InvalidArgumentError(
+          fmt::format("'param' field must be a string: {}", param_or_error.status().message()));
+    }
+    param = param_or_error.value();
+  }
+
+  absl::optional<size_t> entry_max_length;
+  if (entry.hasObject("max_length")) {
+    auto max_length_or_error = entry.getInteger("max_length");
+    if (!max_length_or_error.ok()) {
+      return absl::InvalidArgumentError(fmt::format("'max_length' field must be an integer: {}",
+                                                    max_length_or_error.status().message()));
+    }
+    if (max_length_or_error.value() <= 0) {
+      return absl::InvalidArgumentError("'max_length' must be a positive integer");
+    }
+    entry_max_length = static_cast<size_t>(max_length_or_error.value());
+  }
+
+  return createFormatterForCommand(command_or_error.value(), param, entry_max_length);
+}
+
+absl::StatusOr<FormatterProviderPtr>
+CoalesceFormatter::createFormatterForCommand(absl::string_view command, absl::string_view param,
+                                             absl::optional<size_t> max_length) {
+  // Try built-in command parsers to create the formatter.
+  for (const auto& parser : BuiltInCommandParserFactoryHelper::commandParsers()) {
+    auto formatter = parser->parse(command, param, max_length);
+    if (formatter != nullptr) {
+      return formatter;
+    }
+  }
+
+  return absl::InvalidArgumentError(fmt::format("unknown command: '{}'", command));
+}
+
+absl::optional<std::string>
+CoalesceFormatter::format(const Context& context, const StreamInfo::StreamInfo& stream_info) const {
+  for (const auto& formatter : formatters_) {
+    auto result = formatter->format(context, stream_info);
+    if (result.has_value() && !result.value().empty()) {
+      if (max_length_.has_value()) {
+        SubstitutionFormatUtils::truncate(result.value(), max_length_.value());
+      }
+      return result;
+    }
+  }
+  return absl::nullopt;
+}
+
+Protobuf::Value CoalesceFormatter::formatValue(const Context& context,
+                                               const StreamInfo::StreamInfo& stream_info) const {
+  for (const auto& formatter : formatters_) {
+    auto result = formatter->formatValue(context, stream_info);
+    // Check if this is a valid non-null value.
+    if (result.kind_case() != Protobuf::Value::KIND_NOT_SET &&
+        result.kind_case() != Protobuf::Value::kNullValue) {
+      // For string values, also check if empty.
+      if (result.kind_case() == Protobuf::Value::kStringValue) {
+        if (!result.string_value().empty()) {
+          if (max_length_.has_value() && result.string_value().size() > max_length_.value()) {
+            result.set_string_value(result.string_value().substr(0, max_length_.value()));
+          }
+          return result;
+        }
+      } else {
+        return result;
+      }
+    }
+  }
+  return SubstitutionFormatUtils::unspecifiedValue();
+}
+
+} // namespace Formatter
+} // namespace Envoy

--- a/source/common/formatter/coalesce_formatter.h
+++ b/source/common/formatter/coalesce_formatter.h
@@ -1,0 +1,84 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "envoy/formatter/substitution_formatter.h"
+#include "envoy/json/json_object.h"
+#include "envoy/stream_info/stream_info.h"
+
+#include "source/common/common/statusor.h"
+#include "source/common/formatter/substitution_format_utility.h"
+
+#include "absl/types/optional.h"
+
+namespace Envoy {
+namespace Formatter {
+
+/**
+ * CoalesceFormatter provides a higher-order formatter that evaluates multiple
+ * formatter operators in sequence and returns the first non-null result.
+ *
+ * This formatter accepts a JSON configuration specifying an array of operators
+ * to evaluate. Each operator can be either:
+ * - A string representing a simple command (e.g., "REQUESTED_SERVER_NAME")
+ * - An object with "command" and optional "param" and "max_length" fields
+ *
+ * Example JSON configuration:
+ * {
+ *   "operators": [
+ *     "REQUESTED_SERVER_NAME",
+ *     {"command": "REQ", "param": ":authority"},
+ *     {"command": "REQ", "param": "host"}
+ *   ]
+ * }
+ *
+ * Note that the JSON parameter cannot contain literal ')' characters as they would
+ * interfere with the command parser regex.
+ */
+class CoalesceFormatter : public FormatterProvider {
+public:
+  /**
+   * Creates a CoalesceFormatter from a JSON configuration string.
+   * @param json_config the JSON configuration string.
+   * @param max_length optional maximum length for the output.
+   * @return StatusOr containing the formatter or an error.
+   */
+  static absl::StatusOr<FormatterProviderPtr> create(absl::string_view json_config,
+                                                     absl::optional<size_t> max_length);
+
+  CoalesceFormatter(std::vector<FormatterProviderPtr>&& formatters,
+                    absl::optional<size_t> max_length)
+      : formatters_(std::move(formatters)), max_length_(max_length) {}
+
+  // FormatterProvider interface.
+  absl::optional<std::string> format(const Context& context,
+                                     const StreamInfo::StreamInfo& stream_info) const override;
+  Protobuf::Value formatValue(const Context& context,
+                              const StreamInfo::StreamInfo& stream_info) const override;
+
+private:
+  /**
+   * Parses a single operator entry from the JSON configuration.
+   * @param entry the JSON object representing an operator entry.
+   * @return StatusOr containing the formatter or an error.
+   */
+  static absl::StatusOr<FormatterProviderPtr> parseOperatorEntry(const Json::Object& entry);
+
+  /**
+   * Creates a formatter for the given command using built-in command parsers.
+   * @param command the command name.
+   * @param param the command parameter (may be empty).
+   * @param max_length optional maximum length.
+   * @return StatusOr containing the formatter or an error.
+   */
+  static absl::StatusOr<FormatterProviderPtr>
+  createFormatterForCommand(absl::string_view command, absl::string_view param,
+                            absl::optional<size_t> max_length);
+
+  std::vector<FormatterProviderPtr> formatters_;
+  absl::optional<size_t> max_length_;
+};
+
+} // namespace Formatter
+} // namespace Envoy

--- a/source/common/formatter/http_specific_formatter.cc
+++ b/source/common/formatter/http_specific_formatter.cc
@@ -6,6 +6,7 @@
 #include "source/common/common/thread.h"
 #include "source/common/common/utility.h"
 #include "source/common/config/metadata.h"
+#include "source/common/formatter/coalesce_formatter.h"
 #include "source/common/grpc/common.h"
 #include "source/common/grpc/status.h"
 #include "source/common/http/header_map_impl.h"
@@ -501,6 +502,12 @@ BuiltInHttpCommandParser::getKnownFormatters() {
            absl::string_view option;
            SubstitutionFormatUtils::parseSubcommand(format, ':', query, option);
            return THROW_OR_RETURN_VALUE(PathFormatter::create(query, option, max_length),
+                                        FormatterProviderPtr);
+         }}},
+       {"COALESCE",
+        {CommandSyntaxChecker::PARAMS_REQUIRED | CommandSyntaxChecker::LENGTH_ALLOWED,
+         [](absl::string_view format, absl::optional<size_t> max_length) {
+           return THROW_OR_RETURN_VALUE(CoalesceFormatter::create(format, max_length),
                                         FormatterProviderPtr);
          }}}});
 }

--- a/test/common/formatter/substitution_formatter_test.cc
+++ b/test/common/formatter/substitution_formatter_test.cc
@@ -4833,6 +4833,290 @@ TEST(SubstitutionFormatterTest, UniqueIdFormatterTest) {
   EXPECT_NE(id1, id3);
   EXPECT_NE(id2, id3);
 }
+
+// COALESCE formatter tests.
+TEST(SubstitutionFormatterTest, CoalesceFormatterBasic) {
+  StreamInfo::MockStreamInfo stream_info;
+  absl::optional<Http::Protocol> protocol = Http::Protocol::Http11;
+  EXPECT_CALL(stream_info, protocol()).WillRepeatedly(Return(protocol));
+
+  // Test basic coalescing when the first value is available.
+  {
+    auto providers = *SubstitutionFormatParser::parse(R"(%COALESCE({"operators": ["PROTOCOL"]})%)");
+    ASSERT_EQ(providers.size(), 1);
+    EXPECT_EQ("HTTP/1.1", providers[0]->format({}, stream_info).value_or("-"));
+  }
+
+  // Test with request headers using the REQ command.
+  {
+    Http::TestRequestHeaderMapImpl request_headers{{":authority", "example.com"}};
+    auto providers = *SubstitutionFormatParser::parse(
+        R"(%COALESCE({"operators": [{"command": "REQ", "param": ":authority"}]})%)");
+    ASSERT_EQ(providers.size(), 1);
+    EXPECT_EQ("example.com", providers[0]->format({&request_headers}, stream_info).value_or("-"));
+  }
+}
+
+TEST(SubstitutionFormatterTest, CoalesceFormatterFallback) {
+  StreamInfo::MockStreamInfo stream_info;
+  EXPECT_CALL(stream_info, protocol()).WillRepeatedly(Return(absl::nullopt));
+
+  // Create mock address provider with empty SNI.
+  auto address = Network::Address::InstanceConstSharedPtr{
+      new Network::Address::Ipv4Instance("127.0.0.1", 8080)};
+  auto downstream_address_provider =
+      std::make_shared<Network::ConnectionInfoSetterImpl>(address, address);
+  downstream_address_provider->setRequestedServerName("");
+  EXPECT_CALL(stream_info, downstreamAddressProvider())
+      .WillRepeatedly(ReturnPointee(downstream_address_provider.get()));
+
+  // Test fallback when first operator returns null.
+  {
+    Http::TestRequestHeaderMapImpl request_headers{{":authority", "example.com"}};
+
+    auto providers = *SubstitutionFormatParser::parse(
+        R"(%COALESCE({"operators": ["REQUESTED_SERVER_NAME", {"command": "REQ", "param": ":authority"}]})%)");
+    ASSERT_EQ(providers.size(), 1);
+    // REQUESTED_SERVER_NAME is empty, so should fallback to :authority.
+    EXPECT_EQ("example.com", providers[0]->format({&request_headers}, stream_info).value_or("-"));
+  }
+
+  // Test when all operators return null.
+  {
+    Http::TestRequestHeaderMapImpl request_headers{};
+
+    auto providers = *SubstitutionFormatParser::parse(
+        R"(%COALESCE({"operators": ["REQUESTED_SERVER_NAME", {"command": "REQ", "param": ":authority"}]})%)");
+    ASSERT_EQ(providers.size(), 1);
+    // Both operators return null, should return nullopt.
+    EXPECT_FALSE(providers[0]->format({&request_headers}, stream_info).has_value());
+  }
+}
+
+TEST(SubstitutionFormatterTest, CoalesceFormatterMaxLength) {
+  StreamInfo::MockStreamInfo stream_info;
+  Http::TestRequestHeaderMapImpl request_headers{{":authority", "very-long-hostname.example.com"}};
+
+  // Test max_length at command level.
+  {
+    auto providers = *SubstitutionFormatParser::parse(
+        R"(%COALESCE({"operators": [{"command": "REQ", "param": ":authority"}]}):10%)");
+    ASSERT_EQ(providers.size(), 1);
+    EXPECT_EQ("very-long-", providers[0]->format({&request_headers}, stream_info).value_or("-"));
+  }
+
+  // Test max_length in operator entry.
+  {
+    auto providers = *SubstitutionFormatParser::parse(
+        R"(%COALESCE({"operators": [{"command": "REQ", "param": ":authority", "max_length": 5}]})%)");
+    ASSERT_EQ(providers.size(), 1);
+    EXPECT_EQ("very-", providers[0]->format({&request_headers}, stream_info).value_or("-"));
+  }
+}
+
+TEST(SubstitutionFormatterTest, CoalesceFormatterMixedOperators) {
+  StreamInfo::MockStreamInfo stream_info;
+  absl::optional<Http::Protocol> protocol = Http::Protocol::Http11;
+  EXPECT_CALL(stream_info, protocol()).WillRepeatedly(Return(protocol));
+
+  // Create mock address provider with SNI set.
+  auto address = Network::Address::InstanceConstSharedPtr{
+      new Network::Address::Ipv4Instance("127.0.0.1", 8080)};
+  auto downstream_address_provider =
+      std::make_shared<Network::ConnectionInfoSetterImpl>(address, address);
+  downstream_address_provider->setRequestedServerName("sni.example.com");
+  EXPECT_CALL(stream_info, downstreamAddressProvider())
+      .WillRepeatedly(ReturnPointee(downstream_address_provider.get()));
+
+  // Test with mixed operator types with string and object.
+  {
+    Http::TestRequestHeaderMapImpl request_headers{{":authority", "host.example.com"}};
+
+    auto providers = *SubstitutionFormatParser::parse(
+        R"(%COALESCE({"operators": ["REQUESTED_SERVER_NAME", {"command": "REQ", "param": ":authority"}, "PROTOCOL"]})%)");
+    ASSERT_EQ(providers.size(), 1);
+    // REQUESTED_SERVER_NAME should be returned as it's the first available value.
+    EXPECT_EQ("sni.example.com",
+              providers[0]->format({&request_headers}, stream_info).value_or("-"));
+  }
+}
+
+TEST(SubstitutionFormatterTest, CoalesceFormatterGridTest) {
+  // Multiple combinations of operators and headers.
+  struct TestCase {
+    std::string sni;
+    std::string authority;
+    std::string original_host;
+    std::string expected;
+  };
+
+  // Test SNI -> :authority -> x-envoy-original-host cascade.
+  std::vector<TestCase> test_cases = {
+      // SNI set, others set - return SNI.
+      {"sni.example.com", "authority.example.com", "original.example.com", "sni.example.com"},
+      // SNI empty, authority set - return authority.
+      {"", "authority.example.com", "original.example.com", "authority.example.com"},
+      // SNI empty, authority empty, original set - return original.
+      {"", "", "original.example.com", "original.example.com"},
+      // All empty - return nullopt.
+      {"", "", "", ""},
+  };
+
+  for (const auto& tc : test_cases) {
+    SCOPED_TRACE(fmt::format("sni='{}', authority='{}', original_host='{}'", tc.sni, tc.authority,
+                             tc.original_host));
+
+    StreamInfo::MockStreamInfo stream_info;
+
+    auto address = Network::Address::InstanceConstSharedPtr{
+        new Network::Address::Ipv4Instance("127.0.0.1", 8080)};
+    auto downstream_address_provider =
+        std::make_shared<Network::ConnectionInfoSetterImpl>(address, address);
+    downstream_address_provider->setRequestedServerName(tc.sni);
+    EXPECT_CALL(stream_info, downstreamAddressProvider())
+        .WillRepeatedly(ReturnPointee(downstream_address_provider.get()));
+
+    Http::TestRequestHeaderMapImpl request_headers;
+    if (!tc.authority.empty()) {
+      request_headers.addCopy(":authority", tc.authority);
+    }
+    if (!tc.original_host.empty()) {
+      request_headers.addCopy("x-envoy-original-host", tc.original_host);
+    }
+
+    auto providers = *SubstitutionFormatParser::parse(
+        R"(%COALESCE({"operators": ["REQUESTED_SERVER_NAME", {"command": "REQ", "param": ":authority"}, {"command": "REQ", "param": "x-envoy-original-host"}]})%)");
+    ASSERT_EQ(providers.size(), 1);
+
+    auto result = providers[0]->format({&request_headers}, stream_info);
+    if (tc.expected.empty()) {
+      EXPECT_FALSE(result.has_value());
+    } else {
+      EXPECT_EQ(tc.expected, result.value_or("-"));
+    }
+  }
+}
+
+TEST(SubstitutionFormatterTest, CoalesceFormatterErrorCases) {
+  // Empty JSON config.
+  {
+    EXPECT_THROW_WITH_MESSAGE(SubstitutionFormatParser::parse("%COALESCE()%").IgnoreError(),
+                              EnvoyException, "COALESCE requires parameters");
+  }
+
+  // Invalid JSON.
+  {
+    EXPECT_THROW_WITH_REGEX(SubstitutionFormatParser::parse("%COALESCE(not json)%").IgnoreError(),
+                            EnvoyException, "COALESCE: failed to parse JSON configuration.*");
+  }
+
+  // Missing operators field.
+  {
+    EXPECT_THROW_WITH_MESSAGE(
+        SubstitutionFormatParser::parse(R"(%COALESCE({"foo": "bar"})%)").IgnoreError(),
+        EnvoyException, "COALESCE: JSON configuration must contain 'operators' array");
+  }
+
+  // Empty operators array.
+  {
+    EXPECT_THROW_WITH_MESSAGE(
+        SubstitutionFormatParser::parse(R"(%COALESCE({"operators": []})%)").IgnoreError(),
+        EnvoyException, "COALESCE: 'operators' array must not be empty");
+  }
+
+  // Invalid operator which is not a string or object.
+  {
+    EXPECT_THROW_WITH_REGEX(
+        SubstitutionFormatParser::parse(R"(%COALESCE({"operators": [123]})%)").IgnoreError(),
+        EnvoyException, "COALESCE: failed to parse operator at index 0.*");
+  }
+
+  // Missing command field in operator object.
+  {
+    EXPECT_THROW_WITH_REGEX(
+        SubstitutionFormatParser::parse(R"(%COALESCE({"operators": [{"param": "foo"}]})%)")
+            .IgnoreError(),
+        EnvoyException, "COALESCE: failed to parse operator at index 0.*");
+  }
+
+  // Unknown command.
+  {
+    EXPECT_THROW_WITH_REGEX(
+        SubstitutionFormatParser::parse(R"(%COALESCE({"operators": ["UNKNOWN_COMMAND"]})%)")
+            .IgnoreError(),
+        EnvoyException, "COALESCE: failed to parse operator at index 0.*unknown command.*");
+  }
+
+  // Invalid not positive max_length.
+  {
+    EXPECT_THROW_WITH_REGEX(
+        SubstitutionFormatParser::parse(
+            R"(%COALESCE({"operators": [{"command": "PROTOCOL", "max_length": 0}]})%)")
+            .IgnoreError(),
+        EnvoyException, "COALESCE: failed to parse operator at index 0.*max_length.*positive.*");
+  }
+}
+
+TEST(SubstitutionFormatterTest, CoalesceFormatterFormatValue) {
+  StreamInfo::MockStreamInfo stream_info;
+  absl::optional<Http::Protocol> protocol = Http::Protocol::Http11;
+  EXPECT_CALL(stream_info, protocol()).WillRepeatedly(Return(protocol));
+
+  // Test formatValue returns proper protobuf value.
+  {
+    auto providers = *SubstitutionFormatParser::parse(R"(%COALESCE({"operators": ["PROTOCOL"]})%)");
+    ASSERT_EQ(providers.size(), 1);
+    auto value = providers[0]->formatValue({}, stream_info);
+    EXPECT_EQ(Protobuf::Value::kStringValue, value.kind_case());
+    EXPECT_EQ("HTTP/1.1", value.string_value());
+  }
+
+  // Test formatValue when all operators return null.
+  {
+    StreamInfo::MockStreamInfo null_stream_info;
+    EXPECT_CALL(null_stream_info, protocol()).WillRepeatedly(Return(absl::nullopt));
+    auto address = Network::Address::InstanceConstSharedPtr{
+        new Network::Address::Ipv4Instance("127.0.0.1", 8080)};
+    auto downstream_address_provider =
+        std::make_shared<Network::ConnectionInfoSetterImpl>(address, address);
+    downstream_address_provider->setRequestedServerName("");
+    EXPECT_CALL(null_stream_info, downstreamAddressProvider())
+        .WillRepeatedly(ReturnPointee(downstream_address_provider.get()));
+
+    Http::TestRequestHeaderMapImpl request_headers{};
+
+    auto providers = *SubstitutionFormatParser::parse(
+        R"(%COALESCE({"operators": ["REQUESTED_SERVER_NAME", {"command": "REQ", "param": ":authority"}]})%)");
+    ASSERT_EQ(providers.size(), 1);
+    auto value = providers[0]->formatValue({&request_headers}, null_stream_info);
+    EXPECT_EQ(Protobuf::Value::kNullValue, value.kind_case());
+  }
+}
+
+TEST(SubstitutionFormatterTest, CoalesceFormatterWithOtherCommands) {
+  // Test COALESCE in combination with other formatters in the same format string.
+  StreamInfo::MockStreamInfo stream_info;
+  absl::optional<Http::Protocol> protocol = Http::Protocol::Http11;
+  EXPECT_CALL(stream_info, protocol()).WillRepeatedly(Return(protocol));
+
+  auto address = Network::Address::InstanceConstSharedPtr{
+      new Network::Address::Ipv4Instance("127.0.0.1", 8080)};
+  auto downstream_address_provider =
+      std::make_shared<Network::ConnectionInfoSetterImpl>(address, address);
+  downstream_address_provider->setRequestedServerName("sni.example.com");
+  EXPECT_CALL(stream_info, downstreamAddressProvider())
+      .WillRepeatedly(ReturnPointee(downstream_address_provider.get()));
+
+  Http::TestRequestHeaderMapImpl request_headers{{":authority", "host.example.com"}};
+
+  auto formatter_or_error = FormatterImpl::create(
+      R"(protocol=%PROTOCOL% host=%COALESCE({"operators": ["REQUESTED_SERVER_NAME", {"command": "REQ", "param": ":authority"}]})%)");
+  ASSERT_TRUE(formatter_or_error.ok());
+  auto& formatter = *formatter_or_error.value();
+
+  std::string result = formatter.format({&request_headers}, stream_info);
+  EXPECT_EQ("protocol=HTTP/1.1 host=sni.example.com", result);
+}
 } // namespace
 } // namespace Formatter
 } // namespace Envoy


### PR DESCRIPTION
## Description

This PR adds a new `COALESCE` substitution formatter that evaluates multiple formatter operators in sequence and returns the first non-null result. This could be used to have a fallback behavior such as using SNI when available but falling back to the `:authority` header when SNI is not available.

**Example:**

```
%COALESCE(
  {
    "operators": [
      "REQUESTED_SERVER_NAME",
      {"command": "REQ", "param": ":authority"},
      {"command": "REQ", "param": "x-envoy-original-host"}
    ]
  }
)%
```

---

**Commit Message:** access_log: add a new **COALESCE** substitution formatter
**Additional Description:** Adds a new `COALESCE` substitution formatter that evaluates multiple formatter operators in sequence and returns the first non-null result. 
**Risk Level:** Low
**Testing:** Added Unit + Integration Tests
**Docs Changes:** Added
**Release Notes:** Added