### PR TITLE
router: optimize isEarlyConnectData() by checking flag first

### DIFF
--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -975,8 +975,8 @@ uint64_t Filter::calculateEffectiveBufferLimit() const {
 }
 
 bool Filter::isEarlyConnectData() {
-  return downstream_headers_ != nullptr && Http::HeaderUtility::isConnect(*downstream_headers_) &&
-         !downstream_response_started_ && reject_early_connect_data_enabled_;
+  return reject_early_connect_data_enabled_ && downstream_headers_ != nullptr &&
+         Http::HeaderUtility::isConnect(*downstream_headers_) && !downstream_response_started_;
 }
 
 Http::FilterDataStatus Filter::decodeData(Buffer::Instance& data, bool end_stream) {


### PR DESCRIPTION
Commit Message:
Reorder conditional to check reject_early_connect_data_enabled_ flag first, enabling early short-circuit when the feature is disabled and avoiding unnecessary operations.
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
