### PR TITLE
router: Uses an InlinedVector to hold routes within VirtualHostImpl

### DIFF
--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -1755,6 +1755,7 @@ VirtualHostImpl::VirtualHostImpl(const envoy::config::route::v3::VirtualHost& vi
       return;
     }
   } else {
+    routes_.reserve(virtual_host.routes().size());
     for (const auto& route : virtual_host.routes()) {
       auto route_or_error = RouteCreator::createAndValidateRoute(
           route, shared_virtual_host_, factory_context, validator, validate_clusters);

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -38,6 +38,7 @@
 #include "source/common/router/tls_context_match_criteria_impl.h"
 #include "source/common/stats/symbol_table.h"
 
+#include "absl/container/inlined_vector.h"
 #include "absl/container/node_hash_map.h"
 #include "absl/types/optional.h"
 
@@ -389,7 +390,7 @@ private:
   std::shared_ptr<const SslRedirectRoute> ssl_redirect_route_;
   SslRequirements ssl_requirements_;
 
-  std::vector<RouteEntryImplBaseConstSharedPtr> routes_;
+  absl::InlinedVector<RouteEntryImplBaseConstSharedPtr, 2> routes_;
   Matcher::MatchTreeSharedPtr<Http::HttpMatchingData> matcher_;
 };
 


### PR DESCRIPTION
This avoids needing to make a separate vector memory allocation for virtual hosts with only one or two routes.

Commit Message:
Additional Description:
Risk Level: minimal
Testing: ran unit and integration tests locally
Docs Changes:
Release Notes:
Platform Specific Features:
