### PR TITLE
composite: add implementation for filter_chain

### DIFF
--- a/api/envoy/extensions/filters/http/composite/v3/composite.proto
+++ b/api/envoy/extensions/filters/http/composite/v3/composite.proto
@@ -74,7 +74,7 @@ message ExecuteFilterAction {
       [(udpa.annotations.field_migrate).oneof_promotion = "config_type"];
 
   // An inlined list of filter configurations. The specified filters will be executed in order.
-  // [#not-implemented-hide:]
+  // If this field is set, ``typed_config`` and ``dynamic_config`` are ignored.
   FilterChainConfiguration filter_chain = 4;
 
   // Probability of the action execution. If not specified, this is 100%.

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -236,6 +236,10 @@ removed_config_or_runtime:
     Removed runtime guard ``envoy.reloadable_features.router_filter_resetall_on_local_reply`` and legacy code paths.
 
 new_features:
+- area: composite filter
+  change: |
+    Added support for configuring a chain of filters in the composite filter's :ref:`ExecuteFilterAction
+    <envoy_v3_api_msg_extensions.filters.http.composite.v3.ExecuteFilterAction>` via the ``filter_chain`` field.
 - area: server
   change: |
     Add new command-line option ``--file-flush-min-size-kb <integer>`` to configure the minimum size in kilobytes for log file flushing.

--- a/source/extensions/filters/http/composite/factory_wrapper.cc
+++ b/source/extensions/filters/http/composite/factory_wrapper.cc
@@ -7,6 +7,12 @@ namespace Extensions {
 namespace HttpFilters {
 namespace Composite {
 void FactoryCallbacksWrapper::addStreamDecoderFilter(Http::StreamDecoderFilterSharedPtr filter) {
+  if (is_filter_chain_mode_) {
+    // In filter chain mode, wrap the decoder filter as a stream filter.
+    filters_to_inject_.push_back(std::make_shared<Filter::StreamFilterWrapper>(std::move(filter)));
+    return;
+  }
+
   if (filter_to_inject_) {
     errors_.push_back(absl::InvalidArgumentError(
         "cannot delegate to decoder filter that instantiates multiple filters"));
@@ -17,6 +23,12 @@ void FactoryCallbacksWrapper::addStreamDecoderFilter(Http::StreamDecoderFilterSh
 }
 
 void FactoryCallbacksWrapper::addStreamEncoderFilter(Http::StreamEncoderFilterSharedPtr filter) {
+  if (is_filter_chain_mode_) {
+    // In filter chain mode, wrap the encoder filter as a stream filter.
+    filters_to_inject_.push_back(std::make_shared<Filter::StreamFilterWrapper>(std::move(filter)));
+    return;
+  }
+
   if (filter_to_inject_) {
     errors_.push_back(absl::InvalidArgumentError(
         "cannot delegate to encoder filter that instantiates multiple filters"));
@@ -27,6 +39,12 @@ void FactoryCallbacksWrapper::addStreamEncoderFilter(Http::StreamEncoderFilterSh
 }
 
 void FactoryCallbacksWrapper::addStreamFilter(Http::StreamFilterSharedPtr filter) {
+  if (is_filter_chain_mode_) {
+    // In filter chain mode, store the filter directly.
+    filters_to_inject_.push_back(std::move(filter));
+    return;
+  }
+
   if (filter_to_inject_) {
     errors_.push_back(absl::InvalidArgumentError(
         "cannot delegate to stream filter that instantiates multiple filters"));

--- a/source/extensions/filters/http/composite/factory_wrapper.h
+++ b/source/extensions/filters/http/composite/factory_wrapper.h
@@ -13,9 +13,20 @@ class Filter;
 // Since we are unable to handle all the different callbacks, we track errors seen throughout
 // the lifetime of this wrapper by appending them to the errors_ field. This should be checked
 // afterwards to determine whether invalid callbacks were called.
+//
+// This wrapper supports following two modes:
+// 1. Single filter mode (default): Only one filter can be added. Adding more than one filter
+//    will result in an error.
+// 2. Filter chain mode: Multiple filters can be added. Filters are stored in order and will
+//    be executed in a chain sequence.
 struct FactoryCallbacksWrapper : public Http::FilterChainFactoryCallbacks {
+  // Creates a wrapper in single filter mode.
   FactoryCallbacksWrapper(Filter& filter, Event::Dispatcher& dispatcher)
-      : filter_(filter), dispatcher_(dispatcher) {}
+      : filter_(filter), dispatcher_(dispatcher), is_filter_chain_mode_(false) {}
+
+  // Creates a wrapper in filter chain mode.
+  FactoryCallbacksWrapper(Filter& filter, Event::Dispatcher& dispatcher, bool filter_chain_mode)
+      : filter_(filter), dispatcher_(dispatcher), is_filter_chain_mode_(filter_chain_mode) {}
 
   void addStreamDecoderFilter(Http::StreamDecoderFilterSharedPtr filter) override;
   void addStreamEncoderFilter(Http::StreamEncoderFilterSharedPtr filter) override;
@@ -29,9 +40,13 @@ struct FactoryCallbacksWrapper : public Http::FilterChainFactoryCallbacks {
   using FilterAlternative =
       absl::variant<Http::StreamDecoderFilterSharedPtr, Http::StreamEncoderFilterSharedPtr,
                     Http::StreamFilterSharedPtr>;
+  // For single filter mode we store the filter to inject.
   absl::optional<FilterAlternative> filter_to_inject_;
+  // For filter chain mode we store all filters in order.
+  std::vector<Http::StreamFilterSharedPtr> filters_to_inject_;
   AccessLog::InstanceSharedPtrVector access_loggers_;
   std::vector<absl::Status> errors_;
+  const bool is_filter_chain_mode_;
 };
 } // namespace Composite
 } // namespace HttpFilters

--- a/source/extensions/filters/http/composite/filter.cc
+++ b/source/extensions/filters/http/composite/filter.cc
@@ -94,7 +94,10 @@ void Filter::encodeComplete() {
 
 void Filter::onMatchCallback(const Matcher::Action& action) {
   const auto& composite_action = action.getTyped<ExecuteFilterAction>();
-  FactoryCallbacksWrapper wrapper(*this, dispatcher_);
+
+  // Use filter chain mode if the action is a filter chain.
+  const bool is_filter_chain = composite_action.isFilterChain();
+  FactoryCallbacksWrapper wrapper(*this, dispatcher_, is_filter_chain);
   composite_action.createFilters(wrapper);
 
   if (!wrapper.errors_.empty()) {
@@ -105,10 +108,27 @@ void Filter::onMatchCallback(const Matcher::Action& action) {
     return;
   }
 
+  const std::string& action_name = composite_action.actionName();
+
+  // Handle filter chain mode.
+  if (is_filter_chain) {
+    if (!wrapper.filters_to_inject_.empty()) {
+      stats_.filter_delegation_success_.inc();
+      delegated_filter_ =
+          std::make_shared<DelegatedFilterChain>(std::move(wrapper.filters_to_inject_));
+      updateFilterState(decoder_callbacks_, std::string(decoder_callbacks_->filterConfigName()),
+                        action_name);
+      delegated_filter_->setDecoderFilterCallbacks(*decoder_callbacks_);
+      delegated_filter_->setEncoderFilterCallbacks(*encoder_callbacks_);
+      access_loggers_.insert(access_loggers_.end(), wrapper.access_loggers_.begin(),
+                             wrapper.access_loggers_.end());
+    }
+    return;
+  }
+
+  // Handle single filter mode.
   if (wrapper.filter_to_inject_.has_value()) {
     stats_.filter_delegation_success_.inc();
-
-    const std::string& action_name = composite_action.actionName();
 
     auto createDelegatedFilterFn = Overloaded{
         [this, action_name](Http::StreamDecoderFilterSharedPtr filter) {
@@ -242,6 +262,147 @@ void Filter::StreamFilterWrapper::onStreamComplete() {
 
   if (encoder_filter_) {
     encoder_filter_->onStreamComplete();
+  }
+}
+
+// DelegatedFilterChain implementation.
+// For decode operations, iterate filters in order from first to last.
+// For encode operations, iterate filters in reverse order from last to first.
+Http::FilterHeadersStatus DelegatedFilterChain::decodeHeaders(Http::RequestHeaderMap& headers,
+                                                              bool end_stream) {
+  for (auto& filter : filters_) {
+    auto status = filter->decodeHeaders(headers, end_stream);
+    if (status != Http::FilterHeadersStatus::Continue) {
+      return status;
+    }
+  }
+  return Http::FilterHeadersStatus::Continue;
+}
+
+Http::FilterDataStatus DelegatedFilterChain::decodeData(Buffer::Instance& data, bool end_stream) {
+  for (auto& filter : filters_) {
+    auto status = filter->decodeData(data, end_stream);
+    if (status != Http::FilterDataStatus::Continue) {
+      return status;
+    }
+  }
+  return Http::FilterDataStatus::Continue;
+}
+
+Http::FilterTrailersStatus DelegatedFilterChain::decodeTrailers(Http::RequestTrailerMap& trailers) {
+  for (auto& filter : filters_) {
+    auto status = filter->decodeTrailers(trailers);
+    if (status != Http::FilterTrailersStatus::Continue) {
+      return status;
+    }
+  }
+  return Http::FilterTrailersStatus::Continue;
+}
+
+Http::FilterMetadataStatus DelegatedFilterChain::decodeMetadata(Http::MetadataMap& metadata_map) {
+  for (auto& filter : filters_) {
+    auto status = filter->decodeMetadata(metadata_map);
+    if (status != Http::FilterMetadataStatus::Continue) {
+      return status;
+    }
+  }
+  return Http::FilterMetadataStatus::Continue;
+}
+
+void DelegatedFilterChain::setDecoderFilterCallbacks(
+    Http::StreamDecoderFilterCallbacks& callbacks) {
+  for (auto& filter : filters_) {
+    filter->setDecoderFilterCallbacks(callbacks);
+  }
+}
+
+void DelegatedFilterChain::decodeComplete() {
+  for (auto& filter : filters_) {
+    filter->decodeComplete();
+  }
+}
+
+Http::Filter1xxHeadersStatus
+DelegatedFilterChain::encode1xxHeaders(Http::ResponseHeaderMap& headers) {
+  // Encode operations iterate in reverse order.
+  for (auto it = filters_.rbegin(); it != filters_.rend(); ++it) {
+    auto status = (*it)->encode1xxHeaders(headers);
+    if (status != Http::Filter1xxHeadersStatus::Continue) {
+      return status;
+    }
+  }
+  return Http::Filter1xxHeadersStatus::Continue;
+}
+
+Http::FilterHeadersStatus DelegatedFilterChain::encodeHeaders(Http::ResponseHeaderMap& headers,
+                                                              bool end_stream) {
+  // Encode operations iterate in reverse order.
+  for (auto it = filters_.rbegin(); it != filters_.rend(); ++it) {
+    auto status = (*it)->encodeHeaders(headers, end_stream);
+    if (status != Http::FilterHeadersStatus::Continue) {
+      return status;
+    }
+  }
+  return Http::FilterHeadersStatus::Continue;
+}
+
+Http::FilterDataStatus DelegatedFilterChain::encodeData(Buffer::Instance& data, bool end_stream) {
+  // Encode operations iterate in reverse order.
+  for (auto it = filters_.rbegin(); it != filters_.rend(); ++it) {
+    auto status = (*it)->encodeData(data, end_stream);
+    if (status != Http::FilterDataStatus::Continue) {
+      return status;
+    }
+  }
+  return Http::FilterDataStatus::Continue;
+}
+
+Http::FilterTrailersStatus
+DelegatedFilterChain::encodeTrailers(Http::ResponseTrailerMap& trailers) {
+  // Encode operations iterate in reverse order.
+  for (auto it = filters_.rbegin(); it != filters_.rend(); ++it) {
+    auto status = (*it)->encodeTrailers(trailers);
+    if (status != Http::FilterTrailersStatus::Continue) {
+      return status;
+    }
+  }
+  return Http::FilterTrailersStatus::Continue;
+}
+
+Http::FilterMetadataStatus DelegatedFilterChain::encodeMetadata(Http::MetadataMap& metadata_map) {
+  // Encode operations iterate in reverse order.
+  for (auto it = filters_.rbegin(); it != filters_.rend(); ++it) {
+    auto status = (*it)->encodeMetadata(metadata_map);
+    if (status != Http::FilterMetadataStatus::Continue) {
+      return status;
+    }
+  }
+  return Http::FilterMetadataStatus::Continue;
+}
+
+void DelegatedFilterChain::setEncoderFilterCallbacks(
+    Http::StreamEncoderFilterCallbacks& callbacks) {
+  for (auto& filter : filters_) {
+    filter->setEncoderFilterCallbacks(callbacks);
+  }
+}
+
+void DelegatedFilterChain::encodeComplete() {
+  // Encode operations iterate in reverse order.
+  for (auto it = filters_.rbegin(); it != filters_.rend(); ++it) {
+    (*it)->encodeComplete();
+  }
+}
+
+void DelegatedFilterChain::onDestroy() {
+  for (auto& filter : filters_) {
+    static_cast<Http::StreamDecoderFilter&>(*filter).onDestroy();
+  }
+}
+
+void DelegatedFilterChain::onStreamComplete() {
+  for (auto& filter : filters_) {
+    static_cast<Http::StreamDecoderFilter&>(*filter).onStreamComplete();
   }
 }
 

--- a/source/extensions/filters/http/composite/filter.h
+++ b/source/extensions/filters/http/composite/filter.h
@@ -52,6 +52,41 @@ private:
   absl::flat_hash_map<std::string, std::string> actions_;
 };
 
+// A wrapper that chains multiple filters together and delegates calls to each in sequence.
+// For decoding, filters are called in order from first to last.
+// For encoding, filters are called in reverse order from last to first.
+class DelegatedFilterChain : public Http::StreamFilter {
+public:
+  explicit DelegatedFilterChain(std::vector<Http::StreamFilterSharedPtr> filters)
+      : filters_(std::move(filters)) {}
+
+  // Http::StreamDecoderFilter
+  Http::FilterHeadersStatus decodeHeaders(Http::RequestHeaderMap& headers,
+                                          bool end_stream) override;
+  Http::FilterDataStatus decodeData(Buffer::Instance& data, bool end_stream) override;
+  Http::FilterTrailersStatus decodeTrailers(Http::RequestTrailerMap& trailers) override;
+  Http::FilterMetadataStatus decodeMetadata(Http::MetadataMap& metadata_map) override;
+  void setDecoderFilterCallbacks(Http::StreamDecoderFilterCallbacks& callbacks) override;
+  void decodeComplete() override;
+
+  // Http::StreamEncoderFilter
+  Http::Filter1xxHeadersStatus encode1xxHeaders(Http::ResponseHeaderMap& headers) override;
+  Http::FilterHeadersStatus encodeHeaders(Http::ResponseHeaderMap& headers,
+                                          bool end_stream) override;
+  Http::FilterDataStatus encodeData(Buffer::Instance& data, bool end_stream) override;
+  Http::FilterTrailersStatus encodeTrailers(Http::ResponseTrailerMap& trailers) override;
+  Http::FilterMetadataStatus encodeMetadata(Http::MetadataMap& metadata_map) override;
+  void setEncoderFilterCallbacks(Http::StreamEncoderFilterCallbacks& callbacks) override;
+  void encodeComplete() override;
+
+  // Http::StreamFilterBase
+  void onDestroy() override;
+  void onStreamComplete() override;
+
+private:
+  std::vector<Http::StreamFilterSharedPtr> filters_;
+};
+
 class Filter : public Http::StreamFilter,
                public AccessLog::Instance,
                Logger::Loggable<Logger::Id::filter> {

--- a/test/extensions/filters/http/composite/BUILD
+++ b/test/extensions/filters/http/composite/BUILD
@@ -45,6 +45,7 @@ envoy_extension_cc_test(
         "//test/common/grpc:grpc_client_integration_lib",
         "//test/common/http:common_lib",
         "//test/integration:http_integration_lib",
+        "//test/integration/filters:add_header_filter_config_lib",
         "//test/integration/filters:local_reply_during_encoding_filter_lib",
         "//test/integration/filters:server_factory_context_filter_config_proto_cc_proto",
         "//test/integration/filters:server_factory_context_filter_lib",

--- a/test/extensions/filters/http/composite/filter_test.cc
+++ b/test/extensions/filters/http/composite/filter_test.cc
@@ -788,6 +788,835 @@ TEST_F(UpstreamFilterTest, StreamEncoderFilterDelegationUpstream) {
   filter_.onDestroy();
 }
 
+// Test that a filter chain with multiple filters executes decode operations in order.
+TEST_F(FilterTest, FilterChainDecodeInOrder) {
+  auto filter1 = std::make_shared<Http::MockStreamFilter>();
+  auto filter2 = std::make_shared<Http::MockStreamFilter>();
+
+  StreamInfo::FilterStateSharedPtr filter_state =
+      std::make_shared<StreamInfo::FilterStateImpl>(StreamInfo::FilterState::LifeSpan::Connection);
+  ON_CALL(decoder_callbacks_, filterConfigName()).WillByDefault(testing::Return("rootFilterName"));
+  ON_CALL(decoder_callbacks_.stream_info_, filterState())
+      .WillByDefault(testing::ReturnRef(filter_state));
+
+  FilterFactoryCbList filter_factories;
+  filter_factories.push_back(
+      [&](Http::FilterChainFactoryCallbacks& cb) { cb.addStreamFilter(filter1); });
+  filter_factories.push_back(
+      [&](Http::FilterChainFactoryCallbacks& cb) { cb.addStreamFilter(filter2); });
+
+  EXPECT_CALL(*filter1, setDecoderFilterCallbacks(_));
+  EXPECT_CALL(*filter1, setEncoderFilterCallbacks(_));
+  EXPECT_CALL(*filter2, setDecoderFilterCallbacks(_));
+  EXPECT_CALL(*filter2, setEncoderFilterCallbacks(_));
+  EXPECT_CALL(success_counter_, inc());
+
+  ExecuteFilterAction action(std::move(filter_factories), "filter_chain", absl::nullopt,
+                             context_.runtime_loader_);
+  filter_.onMatchCallback(action);
+
+  // Verify filter state is set.
+  auto* info = filter_state->getDataMutable<MatchedActionInfo>(MatchedActionsFilterStateKey);
+  EXPECT_NE(nullptr, info);
+
+  // Verify decode order where filter1 should be called before filter2.
+  testing::InSequence seq;
+  EXPECT_CALL(*filter1, decodeHeaders(_, false))
+      .WillOnce(testing::Return(Http::FilterHeadersStatus::Continue));
+  EXPECT_CALL(*filter2, decodeHeaders(_, false))
+      .WillOnce(testing::Return(Http::FilterHeadersStatus::Continue));
+
+  filter_.decodeHeaders(default_request_headers_, false);
+
+  EXPECT_CALL(*filter1, onDestroy());
+  EXPECT_CALL(*filter2, onDestroy());
+  filter_.onDestroy();
+}
+
+// Test that a filter chain with multiple filters executes encode operations in reverse order.
+TEST_F(FilterTest, FilterChainEncodeInReverseOrder) {
+  auto filter1 = std::make_shared<Http::MockStreamFilter>();
+  auto filter2 = std::make_shared<Http::MockStreamFilter>();
+
+  StreamInfo::FilterStateSharedPtr filter_state =
+      std::make_shared<StreamInfo::FilterStateImpl>(StreamInfo::FilterState::LifeSpan::Connection);
+  ON_CALL(decoder_callbacks_, filterConfigName()).WillByDefault(testing::Return("rootFilterName"));
+  ON_CALL(decoder_callbacks_.stream_info_, filterState())
+      .WillByDefault(testing::ReturnRef(filter_state));
+
+  FilterFactoryCbList filter_factories;
+  filter_factories.push_back(
+      [&](Http::FilterChainFactoryCallbacks& cb) { cb.addStreamFilter(filter1); });
+  filter_factories.push_back(
+      [&](Http::FilterChainFactoryCallbacks& cb) { cb.addStreamFilter(filter2); });
+
+  EXPECT_CALL(*filter1, setDecoderFilterCallbacks(_));
+  EXPECT_CALL(*filter1, setEncoderFilterCallbacks(_));
+  EXPECT_CALL(*filter2, setDecoderFilterCallbacks(_));
+  EXPECT_CALL(*filter2, setEncoderFilterCallbacks(_));
+  EXPECT_CALL(success_counter_, inc());
+
+  ExecuteFilterAction action(std::move(filter_factories), "filter_chain", absl::nullopt,
+                             context_.runtime_loader_);
+  filter_.onMatchCallback(action);
+
+  // Verify encode order where filter2 should be called before filter1 i.e. in reverse order.
+  testing::InSequence seq;
+  EXPECT_CALL(*filter2, encodeHeaders(_, false))
+      .WillOnce(testing::Return(Http::FilterHeadersStatus::Continue));
+  EXPECT_CALL(*filter1, encodeHeaders(_, false))
+      .WillOnce(testing::Return(Http::FilterHeadersStatus::Continue));
+
+  filter_.encodeHeaders(default_response_headers_, false);
+
+  EXPECT_CALL(*filter1, onDestroy());
+  EXPECT_CALL(*filter2, onDestroy());
+  filter_.onDestroy();
+}
+
+// Test that filter chain stops iteration when a filter returns StopIteration during decode.
+TEST_F(FilterTest, FilterChainStopsIterationOnDecode) {
+  auto filter1 = std::make_shared<Http::MockStreamFilter>();
+  auto filter2 = std::make_shared<Http::MockStreamFilter>();
+
+  StreamInfo::FilterStateSharedPtr filter_state =
+      std::make_shared<StreamInfo::FilterStateImpl>(StreamInfo::FilterState::LifeSpan::Connection);
+  ON_CALL(decoder_callbacks_, filterConfigName()).WillByDefault(testing::Return("rootFilterName"));
+  ON_CALL(decoder_callbacks_.stream_info_, filterState())
+      .WillByDefault(testing::ReturnRef(filter_state));
+
+  FilterFactoryCbList filter_factories;
+  filter_factories.push_back(
+      [&](Http::FilterChainFactoryCallbacks& cb) { cb.addStreamFilter(filter1); });
+  filter_factories.push_back(
+      [&](Http::FilterChainFactoryCallbacks& cb) { cb.addStreamFilter(filter2); });
+
+  EXPECT_CALL(*filter1, setDecoderFilterCallbacks(_));
+  EXPECT_CALL(*filter1, setEncoderFilterCallbacks(_));
+  EXPECT_CALL(*filter2, setDecoderFilterCallbacks(_));
+  EXPECT_CALL(*filter2, setEncoderFilterCallbacks(_));
+  EXPECT_CALL(success_counter_, inc());
+
+  ExecuteFilterAction action(std::move(filter_factories), "filter_chain", absl::nullopt,
+                             context_.runtime_loader_);
+  filter_.onMatchCallback(action);
+
+  // filter1 returns StopIteration, so filter2 won't be called.
+  EXPECT_CALL(*filter1, decodeHeaders(_, false))
+      .WillOnce(testing::Return(Http::FilterHeadersStatus::StopIteration));
+  EXPECT_CALL(*filter2, decodeHeaders(_, _)).Times(0);
+
+  auto status = filter_.decodeHeaders(default_request_headers_, false);
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration, status);
+
+  EXPECT_CALL(*filter1, onDestroy());
+  EXPECT_CALL(*filter2, onDestroy());
+  filter_.onDestroy();
+}
+
+// Test that filter chain properly handles mixed filter types i.e. decoder and encoder filters.
+TEST_F(FilterTest, FilterChainWithMixedFilterTypes) {
+  auto decoder_filter = std::make_shared<Http::MockStreamDecoderFilter>();
+  auto encoder_filter = std::make_shared<Http::MockStreamEncoderFilter>();
+
+  StreamInfo::FilterStateSharedPtr filter_state =
+      std::make_shared<StreamInfo::FilterStateImpl>(StreamInfo::FilterState::LifeSpan::Connection);
+  ON_CALL(decoder_callbacks_, filterConfigName()).WillByDefault(testing::Return("rootFilterName"));
+  ON_CALL(decoder_callbacks_.stream_info_, filterState())
+      .WillByDefault(testing::ReturnRef(filter_state));
+
+  FilterFactoryCbList filter_factories;
+  filter_factories.push_back(
+      [&](Http::FilterChainFactoryCallbacks& cb) { cb.addStreamDecoderFilter(decoder_filter); });
+  filter_factories.push_back(
+      [&](Http::FilterChainFactoryCallbacks& cb) { cb.addStreamEncoderFilter(encoder_filter); });
+
+  EXPECT_CALL(*decoder_filter, setDecoderFilterCallbacks(_));
+  EXPECT_CALL(*encoder_filter, setEncoderFilterCallbacks(_));
+  EXPECT_CALL(success_counter_, inc());
+
+  ExecuteFilterAction action(std::move(filter_factories), "filter_chain", absl::nullopt,
+                             context_.runtime_loader_);
+  filter_.onMatchCallback(action);
+
+  // Decoder filter should receive decode calls and encoder filter should receive encode calls.
+  EXPECT_CALL(*decoder_filter, decodeHeaders(_, false))
+      .WillOnce(testing::Return(Http::FilterHeadersStatus::Continue));
+
+  filter_.decodeHeaders(default_request_headers_, false);
+
+  // Encoder filter should receive encode calls.
+  EXPECT_CALL(*encoder_filter, encodeHeaders(_, false))
+      .WillOnce(testing::Return(Http::FilterHeadersStatus::Continue));
+
+  filter_.encodeHeaders(default_response_headers_, false);
+
+  EXPECT_CALL(*decoder_filter, onDestroy());
+  EXPECT_CALL(*encoder_filter, onDestroy());
+  filter_.onDestroy();
+}
+
+// Test that an empty filter chain succeeds but does nothing.
+TEST_F(FilterTest, EmptyFilterChainSucceeds) {
+  StreamInfo::FilterStateSharedPtr filter_state =
+      std::make_shared<StreamInfo::FilterStateImpl>(StreamInfo::FilterState::LifeSpan::Connection);
+  ON_CALL(decoder_callbacks_, filterConfigName()).WillByDefault(testing::Return("rootFilterName"));
+  ON_CALL(decoder_callbacks_.stream_info_, filterState())
+      .WillByDefault(testing::ReturnRef(filter_state));
+
+  FilterFactoryCbList filter_factories; // Empty.
+
+  // Empty filter chain should not call success counter since no filters were injected.
+  EXPECT_CALL(success_counter_, inc()).Times(0);
+
+  ExecuteFilterAction action(std::move(filter_factories), "filter_chain", absl::nullopt,
+                             context_.runtime_loader_);
+  filter_.onMatchCallback(action);
+
+  // No delegated filter, so all calls should return Continue.
+  auto status = filter_.decodeHeaders(default_request_headers_, false);
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, status);
+
+  filter_.onDestroy();
+}
+
+// Test that filter chain with three filters executes in correct order.
+TEST_F(FilterTest, FilterChainWithThreeFilters) {
+  auto filter1 = std::make_shared<Http::MockStreamFilter>();
+  auto filter2 = std::make_shared<Http::MockStreamFilter>();
+  auto filter3 = std::make_shared<Http::MockStreamFilter>();
+
+  StreamInfo::FilterStateSharedPtr filter_state =
+      std::make_shared<StreamInfo::FilterStateImpl>(StreamInfo::FilterState::LifeSpan::Connection);
+  ON_CALL(decoder_callbacks_, filterConfigName()).WillByDefault(testing::Return("rootFilterName"));
+  ON_CALL(decoder_callbacks_.stream_info_, filterState())
+      .WillByDefault(testing::ReturnRef(filter_state));
+
+  FilterFactoryCbList filter_factories;
+  filter_factories.push_back(
+      [&](Http::FilterChainFactoryCallbacks& cb) { cb.addStreamFilter(filter1); });
+  filter_factories.push_back(
+      [&](Http::FilterChainFactoryCallbacks& cb) { cb.addStreamFilter(filter2); });
+  filter_factories.push_back(
+      [&](Http::FilterChainFactoryCallbacks& cb) { cb.addStreamFilter(filter3); });
+
+  EXPECT_CALL(*filter1, setDecoderFilterCallbacks(_));
+  EXPECT_CALL(*filter1, setEncoderFilterCallbacks(_));
+  EXPECT_CALL(*filter2, setDecoderFilterCallbacks(_));
+  EXPECT_CALL(*filter2, setEncoderFilterCallbacks(_));
+  EXPECT_CALL(*filter3, setDecoderFilterCallbacks(_));
+  EXPECT_CALL(*filter3, setEncoderFilterCallbacks(_));
+  EXPECT_CALL(success_counter_, inc());
+
+  ExecuteFilterAction action(std::move(filter_factories), "filter_chain", absl::nullopt,
+                             context_.runtime_loader_);
+  filter_.onMatchCallback(action);
+
+  // Verify decode order where filter1 should be called before filter2 and filter3.
+  {
+    testing::InSequence seq;
+    EXPECT_CALL(*filter1, decodeHeaders(_, false))
+        .WillOnce(testing::Return(Http::FilterHeadersStatus::Continue));
+    EXPECT_CALL(*filter2, decodeHeaders(_, false))
+        .WillOnce(testing::Return(Http::FilterHeadersStatus::Continue));
+    EXPECT_CALL(*filter3, decodeHeaders(_, false))
+        .WillOnce(testing::Return(Http::FilterHeadersStatus::Continue));
+  }
+  filter_.decodeHeaders(default_request_headers_, false);
+
+  // Verify encode order where filter3 should be called before filter2 and filter1 i.e. in reverse
+  // order.
+  {
+    testing::InSequence seq;
+    EXPECT_CALL(*filter3, encodeHeaders(_, false))
+        .WillOnce(testing::Return(Http::FilterHeadersStatus::Continue));
+    EXPECT_CALL(*filter2, encodeHeaders(_, false))
+        .WillOnce(testing::Return(Http::FilterHeadersStatus::Continue));
+    EXPECT_CALL(*filter1, encodeHeaders(_, false))
+        .WillOnce(testing::Return(Http::FilterHeadersStatus::Continue));
+  }
+  filter_.encodeHeaders(default_response_headers_, false);
+
+  EXPECT_CALL(*filter1, onDestroy());
+  EXPECT_CALL(*filter2, onDestroy());
+  EXPECT_CALL(*filter3, onDestroy());
+  filter_.onDestroy();
+}
+
+// Test that filter chain with sampling respects the sample_percent configuration.
+TEST_F(FilterTest, FilterChainWithSamplingSkipped) {
+  StreamInfo::FilterStateSharedPtr filter_state =
+      std::make_shared<StreamInfo::FilterStateImpl>(StreamInfo::FilterState::LifeSpan::Connection);
+  ON_CALL(decoder_callbacks_, filterConfigName()).WillByDefault(testing::Return("rootFilterName"));
+  ON_CALL(decoder_callbacks_.stream_info_, filterState())
+      .WillByDefault(testing::ReturnRef(filter_state));
+
+  FilterFactoryCbList filter_factories;
+  filter_factories.push_back([](Http::FilterChainFactoryCallbacks& cb) {
+    cb.addStreamFilter(std::make_shared<Http::MockStreamFilter>());
+  });
+
+  envoy::config::core::v3::RuntimeFractionalPercent sample_percent;
+  sample_percent.mutable_default_value()->set_numerator(0);
+  sample_percent.mutable_default_value()->set_denominator(
+      envoy::type::v3::FractionalPercent::HUNDRED);
+
+  // Sampling is disabled (0%), so filter chain should be skipped.
+  EXPECT_CALL(context_.runtime_loader_.snapshot_,
+              featureEnabled(_, testing::A<const envoy::type::v3::FractionalPercent&>()))
+      .WillOnce(testing::Return(false));
+  EXPECT_CALL(success_counter_, inc()).Times(0);
+
+  ExecuteFilterAction action(std::move(filter_factories), "filter_chain", sample_percent,
+                             context_.runtime_loader_);
+  filter_.onMatchCallback(action);
+
+  // No filter injected, so decode should return Continue i.e. filter chain should not be triggered.
+  auto status = filter_.decodeHeaders(default_request_headers_, false);
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, status);
+
+  filter_.onDestroy();
+}
+
+// Test that isFilterChain() returns true for filter chain actions.
+TEST(FilterChainActionTest, IsFilterChainReturnsTrue) {
+  FilterFactoryCbList filter_factories;
+  filter_factories.push_back([](Http::FilterChainFactoryCallbacks& cb) {
+    cb.addStreamFilter(std::make_shared<Http::MockStreamFilter>());
+  });
+
+  testing::NiceMock<Server::Configuration::MockServerFactoryContext> context;
+  ExecuteFilterAction action(std::move(filter_factories), "filter_chain", absl::nullopt,
+                             context.runtime_loader_);
+
+  EXPECT_TRUE(action.isFilterChain());
+}
+
+// Test that isFilterChain() returns false for single filter actions.
+TEST(FilterChainActionTest, IsFilterChainReturnsFalse) {
+  testing::NiceMock<Server::Configuration::MockServerFactoryContext> context;
+  Http::FilterFactoryCb callback = [](Http::FilterChainFactoryCallbacks&) {};
+
+  ExecuteFilterAction action(
+      [cb = std::move(callback)]() mutable -> OptRef<Http::FilterFactoryCb> { return cb; },
+      "single_filter", absl::nullopt, context.runtime_loader_);
+
+  EXPECT_FALSE(action.isFilterChain());
+}
+
+// Test filter chain with all decode and encode operations.
+TEST_F(FilterTest, FilterChainComprehensiveDecodeEncodeCoverage) {
+  auto filter1 = std::make_shared<Http::MockStreamFilter>();
+  auto filter2 = std::make_shared<Http::MockStreamFilter>();
+
+  StreamInfo::FilterStateSharedPtr filter_state =
+      std::make_shared<StreamInfo::FilterStateImpl>(StreamInfo::FilterState::LifeSpan::Connection);
+  ON_CALL(decoder_callbacks_, filterConfigName()).WillByDefault(testing::Return("rootFilterName"));
+  ON_CALL(decoder_callbacks_.stream_info_, filterState())
+      .WillByDefault(testing::ReturnRef(filter_state));
+
+  FilterFactoryCbList filter_factories;
+  filter_factories.push_back(
+      [&](Http::FilterChainFactoryCallbacks& cb) { cb.addStreamFilter(filter1); });
+  filter_factories.push_back(
+      [&](Http::FilterChainFactoryCallbacks& cb) { cb.addStreamFilter(filter2); });
+
+  EXPECT_CALL(*filter1, setDecoderFilterCallbacks(_));
+  EXPECT_CALL(*filter1, setEncoderFilterCallbacks(_));
+  EXPECT_CALL(*filter2, setDecoderFilterCallbacks(_));
+  EXPECT_CALL(*filter2, setEncoderFilterCallbacks(_));
+  EXPECT_CALL(success_counter_, inc());
+
+  ExecuteFilterAction action(std::move(filter_factories), "filter_chain", absl::nullopt,
+                             context_.runtime_loader_);
+  filter_.onMatchCallback(action);
+
+  // Test decodeHeaders.
+  {
+    testing::InSequence seq;
+    EXPECT_CALL(*filter1, decodeHeaders(_, false))
+        .WillOnce(testing::Return(Http::FilterHeadersStatus::Continue));
+    EXPECT_CALL(*filter2, decodeHeaders(_, false))
+        .WillOnce(testing::Return(Http::FilterHeadersStatus::Continue));
+  }
+  filter_.decodeHeaders(default_request_headers_, false);
+
+  // Test decodeData.
+  {
+    testing::InSequence seq;
+    EXPECT_CALL(*filter1, decodeData(_, false))
+        .WillOnce(testing::Return(Http::FilterDataStatus::Continue));
+    EXPECT_CALL(*filter2, decodeData(_, false))
+        .WillOnce(testing::Return(Http::FilterDataStatus::Continue));
+  }
+  Buffer::OwnedImpl decode_data("decode_data");
+  filter_.decodeData(decode_data, false);
+
+  // Test decodeTrailers. It covers DelegatedFilterChain::decodeTrailers.
+  {
+    testing::InSequence seq;
+    EXPECT_CALL(*filter1, decodeTrailers(_))
+        .WillOnce(testing::Return(Http::FilterTrailersStatus::Continue));
+    EXPECT_CALL(*filter2, decodeTrailers(_))
+        .WillOnce(testing::Return(Http::FilterTrailersStatus::Continue));
+  }
+  filter_.decodeTrailers(default_request_trailers_);
+
+  // Test decodeMetadata. It covers DelegatedFilterChain::decodeMetadata.
+  {
+    testing::InSequence seq;
+    EXPECT_CALL(*filter1, decodeMetadata(_))
+        .WillOnce(testing::Return(Http::FilterMetadataStatus::Continue));
+    EXPECT_CALL(*filter2, decodeMetadata(_))
+        .WillOnce(testing::Return(Http::FilterMetadataStatus::Continue));
+  }
+  Http::MetadataMap metadata;
+  filter_.decodeMetadata(metadata);
+
+  // Test decodeComplete. It covers DelegatedFilterChain::decodeComplete.
+  EXPECT_CALL(*filter1, decodeComplete());
+  EXPECT_CALL(*filter2, decodeComplete());
+  filter_.decodeComplete();
+
+  // Test encode1xxHeaders. It covers DelegatedFilterChain::encode1xxHeaders (reverse order).
+  {
+    testing::InSequence seq;
+    EXPECT_CALL(*filter2, encode1xxHeaders(_))
+        .WillOnce(testing::Return(Http::Filter1xxHeadersStatus::Continue));
+    EXPECT_CALL(*filter1, encode1xxHeaders(_))
+        .WillOnce(testing::Return(Http::Filter1xxHeadersStatus::Continue));
+  }
+  filter_.encode1xxHeaders(default_response_headers_);
+
+  // Test encodeHeaders in the reverse order.
+  {
+    testing::InSequence seq;
+    EXPECT_CALL(*filter2, encodeHeaders(_, false))
+        .WillOnce(testing::Return(Http::FilterHeadersStatus::Continue));
+    EXPECT_CALL(*filter1, encodeHeaders(_, false))
+        .WillOnce(testing::Return(Http::FilterHeadersStatus::Continue));
+  }
+  filter_.encodeHeaders(default_response_headers_, false);
+
+  // Test encodeData. It covers DelegatedFilterChain::encodeData in the reverse order.
+  {
+    testing::InSequence seq;
+    EXPECT_CALL(*filter2, encodeData(_, false))
+        .WillOnce(testing::Return(Http::FilterDataStatus::Continue));
+    EXPECT_CALL(*filter1, encodeData(_, false))
+        .WillOnce(testing::Return(Http::FilterDataStatus::Continue));
+  }
+  Buffer::OwnedImpl encode_data("encode_data");
+  filter_.encodeData(encode_data, false);
+
+  // Test encodeTrailers. It covers DelegatedFilterChain::encodeTrailers in the reverse order.
+  {
+    testing::InSequence seq;
+    EXPECT_CALL(*filter2, encodeTrailers(_))
+        .WillOnce(testing::Return(Http::FilterTrailersStatus::Continue));
+    EXPECT_CALL(*filter1, encodeTrailers(_))
+        .WillOnce(testing::Return(Http::FilterTrailersStatus::Continue));
+  }
+  filter_.encodeTrailers(default_response_trailers_);
+
+  // Test encodeMetadata. It covers DelegatedFilterChain::encodeMetadata in the reverse order.
+  {
+    testing::InSequence seq;
+    EXPECT_CALL(*filter2, encodeMetadata(_))
+        .WillOnce(testing::Return(Http::FilterMetadataStatus::Continue));
+    EXPECT_CALL(*filter1, encodeMetadata(_))
+        .WillOnce(testing::Return(Http::FilterMetadataStatus::Continue));
+  }
+  Http::MetadataMap encode_metadata;
+  filter_.encodeMetadata(encode_metadata);
+
+  // Test encodeComplete. It covers DelegatedFilterChain::encodeComplete in the reverse order.
+  {
+    testing::InSequence seq;
+    EXPECT_CALL(*filter2, encodeComplete());
+    EXPECT_CALL(*filter1, encodeComplete());
+  }
+  filter_.encodeComplete();
+
+  // Test onStreamComplete. It covers DelegatedFilterChain::onStreamComplete.
+  EXPECT_CALL(*filter1, onStreamComplete());
+  EXPECT_CALL(*filter2, onStreamComplete());
+  filter_.onStreamComplete();
+
+  EXPECT_CALL(*filter1, onDestroy());
+  EXPECT_CALL(*filter2, onDestroy());
+  filter_.onDestroy();
+}
+
+// Test that DelegatedFilterChain stops iteration on non-Continue status for trailers.
+TEST_F(FilterTest, FilterChainStopsIterationOnDecodeTrailers) {
+  auto filter1 = std::make_shared<Http::MockStreamFilter>();
+  auto filter2 = std::make_shared<Http::MockStreamFilter>();
+
+  StreamInfo::FilterStateSharedPtr filter_state =
+      std::make_shared<StreamInfo::FilterStateImpl>(StreamInfo::FilterState::LifeSpan::Connection);
+  ON_CALL(decoder_callbacks_, filterConfigName()).WillByDefault(testing::Return("rootFilterName"));
+  ON_CALL(decoder_callbacks_.stream_info_, filterState())
+      .WillByDefault(testing::ReturnRef(filter_state));
+
+  FilterFactoryCbList filter_factories;
+  filter_factories.push_back(
+      [&](Http::FilterChainFactoryCallbacks& cb) { cb.addStreamFilter(filter1); });
+  filter_factories.push_back(
+      [&](Http::FilterChainFactoryCallbacks& cb) { cb.addStreamFilter(filter2); });
+
+  EXPECT_CALL(*filter1, setDecoderFilterCallbacks(_));
+  EXPECT_CALL(*filter1, setEncoderFilterCallbacks(_));
+  EXPECT_CALL(*filter2, setDecoderFilterCallbacks(_));
+  EXPECT_CALL(*filter2, setEncoderFilterCallbacks(_));
+  EXPECT_CALL(success_counter_, inc());
+
+  ExecuteFilterAction action(std::move(filter_factories), "filter_chain", absl::nullopt,
+                             context_.runtime_loader_);
+  filter_.onMatchCallback(action);
+
+  // filter1 returns StopIteration on decodeTrailers, so filter2 should not be called.
+  EXPECT_CALL(*filter1, decodeTrailers(_))
+      .WillOnce(testing::Return(Http::FilterTrailersStatus::StopIteration));
+  EXPECT_CALL(*filter2, decodeTrailers(_)).Times(0);
+
+  auto status = filter_.decodeTrailers(default_request_trailers_);
+  EXPECT_EQ(Http::FilterTrailersStatus::StopIteration, status);
+
+  EXPECT_CALL(*filter1, onDestroy());
+  EXPECT_CALL(*filter2, onDestroy());
+  filter_.onDestroy();
+}
+
+// Test that DelegatedFilterChain stops iteration on non-Continue status for decodeMetadata.
+TEST_F(FilterTest, FilterChainStopsIterationOnDecodeMetadata) {
+  auto filter1 = std::make_shared<Http::MockStreamFilter>();
+  auto filter2 = std::make_shared<Http::MockStreamFilter>();
+
+  StreamInfo::FilterStateSharedPtr filter_state =
+      std::make_shared<StreamInfo::FilterStateImpl>(StreamInfo::FilterState::LifeSpan::Connection);
+  ON_CALL(decoder_callbacks_, filterConfigName()).WillByDefault(testing::Return("rootFilterName"));
+  ON_CALL(decoder_callbacks_.stream_info_, filterState())
+      .WillByDefault(testing::ReturnRef(filter_state));
+
+  FilterFactoryCbList filter_factories;
+  filter_factories.push_back(
+      [&](Http::FilterChainFactoryCallbacks& cb) { cb.addStreamFilter(filter1); });
+  filter_factories.push_back(
+      [&](Http::FilterChainFactoryCallbacks& cb) { cb.addStreamFilter(filter2); });
+
+  EXPECT_CALL(*filter1, setDecoderFilterCallbacks(_));
+  EXPECT_CALL(*filter1, setEncoderFilterCallbacks(_));
+  EXPECT_CALL(*filter2, setDecoderFilterCallbacks(_));
+  EXPECT_CALL(*filter2, setEncoderFilterCallbacks(_));
+  EXPECT_CALL(success_counter_, inc());
+
+  ExecuteFilterAction action(std::move(filter_factories), "filter_chain", absl::nullopt,
+                             context_.runtime_loader_);
+  filter_.onMatchCallback(action);
+
+  // filter1 returns StopIterationNoBuffer on decodeMetadata, so filter2 should not be called.
+  EXPECT_CALL(*filter1, decodeMetadata(_))
+      .WillOnce(testing::Return(Http::FilterMetadataStatus::StopIterationForLocalReply));
+  EXPECT_CALL(*filter2, decodeMetadata(_)).Times(0);
+
+  Http::MetadataMap metadata;
+  auto status = filter_.decodeMetadata(metadata);
+  EXPECT_EQ(Http::FilterMetadataStatus::StopIterationForLocalReply, status);
+
+  EXPECT_CALL(*filter1, onDestroy());
+  EXPECT_CALL(*filter2, onDestroy());
+  filter_.onDestroy();
+}
+
+// Test that DelegatedFilterChain stops iteration on non-Continue status for decodeData.
+TEST_F(FilterTest, FilterChainStopsIterationOnDecodeData) {
+  auto filter1 = std::make_shared<Http::MockStreamFilter>();
+  auto filter2 = std::make_shared<Http::MockStreamFilter>();
+
+  StreamInfo::FilterStateSharedPtr filter_state =
+      std::make_shared<StreamInfo::FilterStateImpl>(StreamInfo::FilterState::LifeSpan::Connection);
+  ON_CALL(decoder_callbacks_, filterConfigName()).WillByDefault(testing::Return("rootFilterName"));
+  ON_CALL(decoder_callbacks_.stream_info_, filterState())
+      .WillByDefault(testing::ReturnRef(filter_state));
+
+  FilterFactoryCbList filter_factories;
+  filter_factories.push_back(
+      [&](Http::FilterChainFactoryCallbacks& cb) { cb.addStreamFilter(filter1); });
+  filter_factories.push_back(
+      [&](Http::FilterChainFactoryCallbacks& cb) { cb.addStreamFilter(filter2); });
+
+  EXPECT_CALL(*filter1, setDecoderFilterCallbacks(_));
+  EXPECT_CALL(*filter1, setEncoderFilterCallbacks(_));
+  EXPECT_CALL(*filter2, setDecoderFilterCallbacks(_));
+  EXPECT_CALL(*filter2, setEncoderFilterCallbacks(_));
+  EXPECT_CALL(success_counter_, inc());
+
+  ExecuteFilterAction action(std::move(filter_factories), "filter_chain", absl::nullopt,
+                             context_.runtime_loader_);
+  filter_.onMatchCallback(action);
+
+  // filter1 returns StopIterationAndBuffer on decodeData, so filter2 should not be called.
+  EXPECT_CALL(*filter1, decodeData(_, false))
+      .WillOnce(testing::Return(Http::FilterDataStatus::StopIterationAndBuffer));
+  EXPECT_CALL(*filter2, decodeData(_, _)).Times(0);
+
+  Buffer::OwnedImpl data("test_data");
+  auto status = filter_.decodeData(data, false);
+  EXPECT_EQ(Http::FilterDataStatus::StopIterationAndBuffer, status);
+
+  EXPECT_CALL(*filter1, onDestroy());
+  EXPECT_CALL(*filter2, onDestroy());
+  filter_.onDestroy();
+}
+
+// Test that DelegatedFilterChain stops iteration on non-Continue status for encode1xxHeaders.
+TEST_F(FilterTest, FilterChainStopsIterationOnEncode1xxHeaders) {
+  auto filter1 = std::make_shared<Http::MockStreamFilter>();
+  auto filter2 = std::make_shared<Http::MockStreamFilter>();
+
+  StreamInfo::FilterStateSharedPtr filter_state =
+      std::make_shared<StreamInfo::FilterStateImpl>(StreamInfo::FilterState::LifeSpan::Connection);
+  ON_CALL(decoder_callbacks_, filterConfigName()).WillByDefault(testing::Return("rootFilterName"));
+  ON_CALL(decoder_callbacks_.stream_info_, filterState())
+      .WillByDefault(testing::ReturnRef(filter_state));
+
+  FilterFactoryCbList filter_factories;
+  filter_factories.push_back(
+      [&](Http::FilterChainFactoryCallbacks& cb) { cb.addStreamFilter(filter1); });
+  filter_factories.push_back(
+      [&](Http::FilterChainFactoryCallbacks& cb) { cb.addStreamFilter(filter2); });
+
+  EXPECT_CALL(*filter1, setDecoderFilterCallbacks(_));
+  EXPECT_CALL(*filter1, setEncoderFilterCallbacks(_));
+  EXPECT_CALL(*filter2, setDecoderFilterCallbacks(_));
+  EXPECT_CALL(*filter2, setEncoderFilterCallbacks(_));
+  EXPECT_CALL(success_counter_, inc());
+
+  ExecuteFilterAction action(std::move(filter_factories), "filter_chain", absl::nullopt,
+                             context_.runtime_loader_);
+  filter_.onMatchCallback(action);
+
+  // Encode operations are in reverse order. filter2 returns StopIteration, so filter1 should not
+  // be called.
+  EXPECT_CALL(*filter2, encode1xxHeaders(_))
+      .WillOnce(testing::Return(Http::Filter1xxHeadersStatus::StopIteration));
+  EXPECT_CALL(*filter1, encode1xxHeaders(_)).Times(0);
+
+  auto status = filter_.encode1xxHeaders(default_response_headers_);
+  EXPECT_EQ(Http::Filter1xxHeadersStatus::StopIteration, status);
+
+  EXPECT_CALL(*filter1, onDestroy());
+  EXPECT_CALL(*filter2, onDestroy());
+  filter_.onDestroy();
+}
+
+// Test that DelegatedFilterChain stops iteration on non-Continue status for encodeData.
+TEST_F(FilterTest, FilterChainStopsIterationOnEncodeData) {
+  auto filter1 = std::make_shared<Http::MockStreamFilter>();
+  auto filter2 = std::make_shared<Http::MockStreamFilter>();
+
+  StreamInfo::FilterStateSharedPtr filter_state =
+      std::make_shared<StreamInfo::FilterStateImpl>(StreamInfo::FilterState::LifeSpan::Connection);
+  ON_CALL(decoder_callbacks_, filterConfigName()).WillByDefault(testing::Return("rootFilterName"));
+  ON_CALL(decoder_callbacks_.stream_info_, filterState())
+      .WillByDefault(testing::ReturnRef(filter_state));
+
+  FilterFactoryCbList filter_factories;
+  filter_factories.push_back(
+      [&](Http::FilterChainFactoryCallbacks& cb) { cb.addStreamFilter(filter1); });
+  filter_factories.push_back(
+      [&](Http::FilterChainFactoryCallbacks& cb) { cb.addStreamFilter(filter2); });
+
+  EXPECT_CALL(*filter1, setDecoderFilterCallbacks(_));
+  EXPECT_CALL(*filter1, setEncoderFilterCallbacks(_));
+  EXPECT_CALL(*filter2, setDecoderFilterCallbacks(_));
+  EXPECT_CALL(*filter2, setEncoderFilterCallbacks(_));
+  EXPECT_CALL(success_counter_, inc());
+
+  ExecuteFilterAction action(std::move(filter_factories), "filter_chain", absl::nullopt,
+                             context_.runtime_loader_);
+  filter_.onMatchCallback(action);
+
+  // Encode operations are in reverse order. filter2 returns StopIterationAndBuffer, so filter1
+  // should not be called.
+  EXPECT_CALL(*filter2, encodeData(_, false))
+      .WillOnce(testing::Return(Http::FilterDataStatus::StopIterationAndBuffer));
+  EXPECT_CALL(*filter1, encodeData(_, _)).Times(0);
+
+  Buffer::OwnedImpl data("test_data");
+  auto status = filter_.encodeData(data, false);
+  EXPECT_EQ(Http::FilterDataStatus::StopIterationAndBuffer, status);
+
+  EXPECT_CALL(*filter1, onDestroy());
+  EXPECT_CALL(*filter2, onDestroy());
+  filter_.onDestroy();
+}
+
+// Test that DelegatedFilterChain stops iteration on non-Continue status for encodeTrailers.
+TEST_F(FilterTest, FilterChainStopsIterationOnEncodeTrailers) {
+  auto filter1 = std::make_shared<Http::MockStreamFilter>();
+  auto filter2 = std::make_shared<Http::MockStreamFilter>();
+
+  StreamInfo::FilterStateSharedPtr filter_state =
+      std::make_shared<StreamInfo::FilterStateImpl>(StreamInfo::FilterState::LifeSpan::Connection);
+  ON_CALL(decoder_callbacks_, filterConfigName()).WillByDefault(testing::Return("rootFilterName"));
+  ON_CALL(decoder_callbacks_.stream_info_, filterState())
+      .WillByDefault(testing::ReturnRef(filter_state));
+
+  FilterFactoryCbList filter_factories;
+  filter_factories.push_back(
+      [&](Http::FilterChainFactoryCallbacks& cb) { cb.addStreamFilter(filter1); });
+  filter_factories.push_back(
+      [&](Http::FilterChainFactoryCallbacks& cb) { cb.addStreamFilter(filter2); });
+
+  EXPECT_CALL(*filter1, setDecoderFilterCallbacks(_));
+  EXPECT_CALL(*filter1, setEncoderFilterCallbacks(_));
+  EXPECT_CALL(*filter2, setDecoderFilterCallbacks(_));
+  EXPECT_CALL(*filter2, setEncoderFilterCallbacks(_));
+  EXPECT_CALL(success_counter_, inc());
+
+  ExecuteFilterAction action(std::move(filter_factories), "filter_chain", absl::nullopt,
+                             context_.runtime_loader_);
+  filter_.onMatchCallback(action);
+
+  // Encode operations are in reverse order. filter2 returns StopIteration, so filter1 should not
+  // be called.
+  EXPECT_CALL(*filter2, encodeTrailers(_))
+      .WillOnce(testing::Return(Http::FilterTrailersStatus::StopIteration));
+  EXPECT_CALL(*filter1, encodeTrailers(_)).Times(0);
+
+  auto status = filter_.encodeTrailers(default_response_trailers_);
+  EXPECT_EQ(Http::FilterTrailersStatus::StopIteration, status);
+
+  EXPECT_CALL(*filter1, onDestroy());
+  EXPECT_CALL(*filter2, onDestroy());
+  filter_.onDestroy();
+}
+
+// Test that DelegatedFilterChain stops iteration on non-Continue status for encodeMetadata.
+TEST_F(FilterTest, FilterChainStopsIterationOnEncodeMetadata) {
+  auto filter1 = std::make_shared<Http::MockStreamFilter>();
+  auto filter2 = std::make_shared<Http::MockStreamFilter>();
+
+  StreamInfo::FilterStateSharedPtr filter_state =
+      std::make_shared<StreamInfo::FilterStateImpl>(StreamInfo::FilterState::LifeSpan::Connection);
+  ON_CALL(decoder_callbacks_, filterConfigName()).WillByDefault(testing::Return("rootFilterName"));
+  ON_CALL(decoder_callbacks_.stream_info_, filterState())
+      .WillByDefault(testing::ReturnRef(filter_state));
+
+  FilterFactoryCbList filter_factories;
+  filter_factories.push_back(
+      [&](Http::FilterChainFactoryCallbacks& cb) { cb.addStreamFilter(filter1); });
+  filter_factories.push_back(
+      [&](Http::FilterChainFactoryCallbacks& cb) { cb.addStreamFilter(filter2); });
+
+  EXPECT_CALL(*filter1, setDecoderFilterCallbacks(_));
+  EXPECT_CALL(*filter1, setEncoderFilterCallbacks(_));
+  EXPECT_CALL(*filter2, setDecoderFilterCallbacks(_));
+  EXPECT_CALL(*filter2, setEncoderFilterCallbacks(_));
+  EXPECT_CALL(success_counter_, inc());
+
+  ExecuteFilterAction action(std::move(filter_factories), "filter_chain", absl::nullopt,
+                             context_.runtime_loader_);
+  filter_.onMatchCallback(action);
+
+  // Encode operations are in reverse order. filter2 returns StopIterationForLocalReply, so filter1
+  // should not be called.
+  EXPECT_CALL(*filter2, encodeMetadata(_))
+      .WillOnce(testing::Return(Http::FilterMetadataStatus::StopIterationForLocalReply));
+  EXPECT_CALL(*filter1, encodeMetadata(_)).Times(0);
+
+  Http::MetadataMap metadata;
+  auto status = filter_.encodeMetadata(metadata);
+  EXPECT_EQ(Http::FilterMetadataStatus::StopIterationForLocalReply, status);
+
+  EXPECT_CALL(*filter1, onDestroy());
+  EXPECT_CALL(*filter2, onDestroy());
+  filter_.onDestroy();
+}
+
+// Test empty filter chain configuration throws exception.
+TEST(ConfigTest, TestEmptyFilterChainThrowsException) {
+  const std::string yaml_string = R"EOF(
+      filter_chain:
+        typed_config: []
+  )EOF";
+
+  envoy::extensions::filters::http::composite::v3::ExecuteFilterAction config;
+  TestUtility::loadFromYaml(yaml_string, config);
+
+  testing::NiceMock<Server::Configuration::MockServerFactoryContext> server_factory_context;
+  testing::NiceMock<Server::Configuration::MockFactoryContext> factory_context;
+  Envoy::Http::Matching::HttpFilterActionContext action_context{
+      .is_downstream_ = true,
+      .stat_prefix_ = "test",
+      .factory_context_ = factory_context,
+      .upstream_factory_context_ = absl::nullopt,
+      .server_factory_context_ = server_factory_context};
+  ExecuteFilterActionFactory factory;
+  EXPECT_THROW_WITH_MESSAGE(
+      factory.createAction(config, action_context, ProtobufMessage::getStrictValidationVisitor()),
+      EnvoyException, "Error: filter_chain must contain at least one filter.");
+}
+
+// Test filter chain configuration for upstream filters.
+TEST(ConfigTest, TestUpstreamFilterChainConfiguration) {
+  const std::string yaml_string = R"EOF(
+      filter_chain:
+        typed_config:
+          - name: set-response-code
+            typed_config:
+              "@type": type.googleapis.com/test.integration.filters.SetResponseCodeFilterConfigDual
+              code: 403
+  )EOF";
+
+  envoy::extensions::filters::http::composite::v3::ExecuteFilterAction config;
+  TestUtility::loadFromYaml(yaml_string, config);
+
+  testing::NiceMock<Server::Configuration::MockServerFactoryContext> server_factory_context;
+  testing::NiceMock<Server::Configuration::MockUpstreamFactoryContext> upstream_factory_context;
+  Envoy::Http::Matching::HttpFilterActionContext action_context{
+      .is_downstream_ = false,
+      .stat_prefix_ = "test",
+      .factory_context_ = absl::nullopt,
+      .upstream_factory_context_ = upstream_factory_context,
+      .server_factory_context_ = server_factory_context};
+  ExecuteFilterActionFactory factory;
+  auto action =
+      factory.createAction(config, action_context, ProtobufMessage::getStrictValidationVisitor());
+
+  EXPECT_TRUE(action->getTyped<ExecuteFilterAction>().isFilterChain());
+  EXPECT_EQ("filter_chain", action->getTyped<ExecuteFilterAction>().actionName());
+}
+
+// Test filter chain configuration for upstream filters when upstream factory context is missing.
+TEST(ConfigTest, TestUpstreamFilterChainNoUpstreamFactoryContext) {
+  const std::string yaml_string = R"EOF(
+      filter_chain:
+        typed_config:
+          - name: set-response-code
+            typed_config:
+              "@type": type.googleapis.com/test.integration.filters.SetResponseCodeFilterConfigDual
+              code: 403
+  )EOF";
+
+  envoy::extensions::filters::http::composite::v3::ExecuteFilterAction config;
+  TestUtility::loadFromYaml(yaml_string, config);
+
+  testing::NiceMock<Server::Configuration::MockServerFactoryContext> server_factory_context;
+  Envoy::Http::Matching::HttpFilterActionContext action_context{
+      .is_downstream_ = false,
+      .stat_prefix_ = "test",
+      .factory_context_ = absl::nullopt,
+      .upstream_factory_context_ = absl::nullopt,
+      .server_factory_context_ = server_factory_context};
+  ExecuteFilterActionFactory factory;
+  EXPECT_THROW_WITH_MESSAGE(
+      factory.createAction(config, action_context, ProtobufMessage::getStrictValidationVisitor()),
+      EnvoyException, "Failed to create upstream filter factory for filter 'set-response-code'");
+}
+
 } // namespace
 } // namespace Composite
 } // namespace HttpFilters


### PR DESCRIPTION
## Description

This PR adds the implementation for `filter_chain` in the Composite Filter. The API was added as part of [this](https://github.com/envoyproxy/envoy/pull/40885/) PR.

This would allow multiple HTTP filters to be delegated to as a single action, with filters executing in order for decoding and reverse order for encoding.

---

**Commit Message:** composite: add implementation for filter_chain
**Additional Description:** Adds the implementation for `filter_chain` in the Composite Filter. 
**Risk Level:** Low
**Testing:** Added Unit + Integration Tests
**Docs Changes:** Added
**Release Notes:** Added