### PR TITLE
coverage: adjust the LCOV numbers for MCP Filter

### DIFF
--- a/test/coverage.yaml
+++ b/test/coverage.yaml
@@ -45,7 +45,7 @@ directories:
   source/extensions/filters/http/grpc_json_transcoder: 94.0  # TODO(#28232)
   source/extensions/filters/http/ip_tagging: 95.9
   source/extensions/filters/http/kill_request: 91.7  # Death tests don't report LCOV
-  source/extensions/filters/http/mcp_router: 25  # TODO(yanavlasov): adjust up. Overriden to just scheck-in boilerplate.
+  source/extensions/filters/http/mcp_router: 80  # TODO(yanavlasov): adjust up. Overriden to just scheck-in boilerplate.
   source/extensions/filters/http/oauth2: 97.6
   source/extensions/filters/listener: 96.5
   source/extensions/filters/listener/original_src: 92.1


### PR DESCRIPTION
## Description

This PR is adjusting up the LCOV number for MCP Filter as now we have some tests. It should be further adjusted up as we keep adding more tests.

---

**Commit Message:** coverage: adjust the LCOV numbers for MCP Filter
**Additional Description:** Adjusting up the LCOV number for MCP Filter as now we have some tests.
**Risk Level:** N/A
**Testing:** CI
**Docs Changes:** N/A
**Release Notes:** N/A