### PR TITLE
config: use resource_name if name is empty in DecodedResourceImpl

### DIFF
--- a/envoy/config/subscription.h
+++ b/envoy/config/subscription.h
@@ -65,6 +65,12 @@ public:
    * @return optional ref<envoy::config::core::v3::Metadata> of a resource.
    */
   virtual const OptRef<const envoy::config::core::v3::Metadata> metadata() const PURE;
+
+  /**
+   * @return optional ref<envoy::service::discovery::v3::DynamicParameterConstraints> of a resource.
+   */
+  virtual const OptRef<const envoy::service::discovery::v3::DynamicParameterConstraints>
+  dynamicParameterConstraints() const PURE;
 };
 
 using DecodedResourcePtr = std::unique_ptr<DecodedResource>;

--- a/source/common/config/decoded_resource_impl.h
+++ b/source/common/config/decoded_resource_impl.h
@@ -41,7 +41,7 @@ public:
 
     return std::unique_ptr<DecodedResourceImpl>(new DecodedResourceImpl(
         resource_decoder, absl::nullopt, Protobuf::RepeatedPtrField<std::string>(), resource, true,
-        version, absl::nullopt, absl::nullopt));
+        version, absl::nullopt, absl::nullopt, absl::nullopt));
   }
 
   static DecodedResourceImplPtr
@@ -53,21 +53,30 @@ public:
   DecodedResourceImpl(OpaqueResourceDecoder& resource_decoder,
                       const envoy::service::discovery::v3::Resource& resource)
       : DecodedResourceImpl(
-            resource_decoder, getResourceName(resource), resource.aliases(), resource.resource(),
-            resource.has_resource(), resource.version(),
+            resource_decoder,
+            (resource.has_resource_name() && !resource.resource_name().name().empty())
+                ? resource.resource_name().name()
+                : resource.name(),
+            resource.aliases(), resource.resource(), resource.has_resource(), resource.version(),
             resource.has_ttl() ? absl::make_optional(std::chrono::milliseconds(
                                      DurationUtil::durationToMilliseconds(resource.ttl())))
                                : absl::nullopt,
-            resource.has_metadata() ? absl::make_optional(resource.metadata()) : absl::nullopt) {}
+            resource.has_metadata() ? absl::make_optional(resource.metadata()) : absl::nullopt,
+            (resource.has_resource_name() &&
+             resource.resource_name().has_dynamic_parameter_constraints())
+                ? absl::make_optional(resource.resource_name().dynamic_parameter_constraints())
+                : absl::nullopt) {}
   DecodedResourceImpl(OpaqueResourceDecoder& resource_decoder,
                       const xds::core::v3::CollectionEntry::InlineEntry& inline_entry)
       : DecodedResourceImpl(resource_decoder, inline_entry.name(),
                             Protobuf::RepeatedPtrField<std::string>(), inline_entry.resource(),
-                            true, inline_entry.version(), absl::nullopt, absl::nullopt) {}
+                            true, inline_entry.version(), absl::nullopt, absl::nullopt,
+                            absl::nullopt) {}
   DecodedResourceImpl(ProtobufTypes::MessagePtr resource, const std::string& name,
                       const std::vector<std::string>& aliases, const std::string& version)
       : resource_(std::move(resource)), has_resource_(true), name_(name), aliases_(aliases),
-        version_(version), ttl_(absl::nullopt), metadata_(absl::nullopt) {}
+        version_(version), ttl_(absl::nullopt), metadata_(absl::nullopt),
+        dynamic_parameter_constraints_(absl::nullopt) {}
 
   // Config::DecodedResource
   const std::string& name() const override { return name_; }
@@ -79,25 +88,25 @@ public:
   const OptRef<const envoy::config::core::v3::Metadata> metadata() const override {
     return metadata_.has_value() ? makeOptRef(metadata_.value()) : absl::nullopt;
   }
+  const OptRef<const envoy::service::discovery::v3::DynamicParameterConstraints>
+  dynamicParameterConstraints() const override {
+    return dynamic_parameter_constraints_.has_value()
+               ? makeOptRef(dynamic_parameter_constraints_.value())
+               : absl::nullopt;
+  }
 
 private:
-  DecodedResourceImpl(OpaqueResourceDecoder& resource_decoder, absl::optional<std::string> name,
-                      const Protobuf::RepeatedPtrField<std::string>& aliases,
-                      const Protobuf::Any& resource, bool has_resource, const std::string& version,
-                      absl::optional<std::chrono::milliseconds> ttl,
-                      const absl::optional<envoy::config::core::v3::Metadata>& metadata)
+  DecodedResourceImpl(
+      OpaqueResourceDecoder& resource_decoder, absl::optional<std::string> name,
+      const Protobuf::RepeatedPtrField<std::string>& aliases, const Protobuf::Any& resource,
+      bool has_resource, const std::string& version, absl::optional<std::chrono::milliseconds> ttl,
+      const absl::optional<envoy::config::core::v3::Metadata>& metadata,
+      const absl::optional<envoy::service::discovery::v3::DynamicParameterConstraints>&
+          dynamic_parameter_constraints)
       : resource_(resource_decoder.decodeResource(resource)), has_resource_(has_resource),
         name_(name ? *name : resource_decoder.resourceName(*resource_)),
         aliases_(repeatedPtrFieldToVector(aliases)), version_(version), ttl_(ttl),
-        metadata_(metadata) {}
-
-  static const std::string&
-  getResourceName(const envoy::service::discovery::v3::Resource& resource) {
-    if (resource.name().empty() && resource.has_resource_name()) {
-      return resource.resource_name().name();
-    }
-    return resource.name();
-  }
+        metadata_(metadata), dynamic_parameter_constraints_(dynamic_parameter_constraints) {}
 
   const ProtobufTypes::MessagePtr resource_;
   const bool has_resource_;
@@ -110,6 +119,9 @@ private:
   // This is the metadata info under the Resource wrapper.
   // It is intended to be consumed in the xds_config_tracker extension.
   const absl::optional<envoy::config::core::v3::Metadata> metadata_;
+
+  const absl::optional<envoy::service::discovery::v3::DynamicParameterConstraints>
+      dynamic_parameter_constraints_;
 };
 
 struct DecodedResourcesWrapper {

--- a/test/common/config/decoded_resource_impl_test.cc
+++ b/test/common/config/decoded_resource_impl_test.cc
@@ -50,6 +50,7 @@ TEST(DecodedResourceImplTest, All) {
     EXPECT_THAT(decoded_resource.resource(), ProtoEq(Protobuf::Empty()));
     EXPECT_TRUE(decoded_resource.hasResource());
     EXPECT_FALSE(decoded_resource.metadata().has_value());
+    EXPECT_FALSE(decoded_resource.dynamicParameterConstraints().has_value());
   }
 
   // To verify the metadata is decoded as expected.
@@ -170,7 +171,7 @@ TEST(DecodedResourceImplTest, All) {
     EXPECT_FALSE(decoded_resource.metadata().has_value());
   }
 
-  // To verify the name field takes precedence over resource_name when both are set.
+  // To verify the resource_name field takes precedence over name when both are set.
   {
     envoy::service::discovery::v3::Resource resource_wrapper;
     resource_wrapper.set_name("real_name");
@@ -184,12 +185,49 @@ TEST(DecodedResourceImplTest, All) {
             []() -> ProtobufTypes::MessagePtr { return std::make_unique<Protobuf::Empty>(); }));
     EXPECT_CALL(resource_decoder, resourceName(ProtoEq(Protobuf::Empty()))).Times(0);
     DecodedResourceImpl decoded_resource(resource_decoder, resource_wrapper);
-    EXPECT_EQ("real_name", decoded_resource.name());
+    EXPECT_EQ("resource_name", decoded_resource.name());
     EXPECT_EQ((std::vector<std::string>{"bar", "baz"}), decoded_resource.aliases());
     EXPECT_EQ("foo", decoded_resource.version());
     EXPECT_THAT(decoded_resource.resource(), ProtoEq(Protobuf::Empty()));
     EXPECT_TRUE(decoded_resource.hasResource());
     EXPECT_FALSE(decoded_resource.metadata().has_value());
+  }
+
+  // To verify the dynamic parameter constraints are decoded as expected.
+  // Scenario: env=prod AND NOT version exists
+  {
+    envoy::service::discovery::v3::Resource resource_wrapper;
+    resource_wrapper.mutable_resource_name()->set_name("resource_name");
+    auto* constraints =
+        resource_wrapper.mutable_resource_name()->mutable_dynamic_parameter_constraints();
+    auto* and_constraints = constraints->mutable_and_constraints();
+    auto* c1 = and_constraints->add_constraints()->mutable_constraint();
+    c1->set_key("env");
+    c1->set_value("prod");
+    auto* c2 = and_constraints->add_constraints()->mutable_not_constraints();
+    c2->mutable_constraint()->set_key("version");
+    c2->mutable_constraint()->mutable_exists();
+    resource_wrapper.mutable_resource()->MergeFrom(some_opaque_resource);
+    resource_wrapper.set_version("foo");
+    EXPECT_CALL(resource_decoder, decodeResource(ProtoEq(some_opaque_resource)))
+        .WillOnce(InvokeWithoutArgs(
+            []() -> ProtobufTypes::MessagePtr { return std::make_unique<Protobuf::Empty>(); }));
+    EXPECT_CALL(resource_decoder, resourceName(ProtoEq(Protobuf::Empty()))).Times(0);
+    DecodedResourceImpl decoded_resource(resource_decoder, resource_wrapper);
+    EXPECT_EQ("resource_name", decoded_resource.name());
+    EXPECT_THAT(decoded_resource.resource(), ProtoEq(Protobuf::Empty()));
+    EXPECT_TRUE(decoded_resource.hasResource());
+    EXPECT_TRUE(decoded_resource.dynamicParameterConstraints().has_value());
+    const auto& preserved_constraints =
+        decoded_resource.dynamicParameterConstraints().value().get();
+    EXPECT_EQ(2, preserved_constraints.and_constraints().constraints_size());
+    const auto& c1_check = preserved_constraints.and_constraints().constraints(0).constraint();
+    EXPECT_EQ("env", c1_check.key());
+    EXPECT_EQ("prod", c1_check.value());
+    const auto& c2_not_check =
+        preserved_constraints.and_constraints().constraints(1).not_constraints().constraint();
+    EXPECT_EQ("version", c2_not_check.key());
+    EXPECT_TRUE(c2_not_check.has_exists());
   }
 }
 


### PR DESCRIPTION
Commit Message: `config: support resource_name and dynamic constraints in DecodedResource`
Additional Description:

This PR addresses issue #34285 by adding support for [envoy.service.discovery.v3.ResourceName](https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/discovery/v3/discovery.proto#envoy-v3-api-msg-service-discovery-v3-resourcename) in response resources.

~Previously, `DecodedResourceImpl` only used the `name` field from [envoy.service.discovery.v3.Resource](https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/discovery/v3/discovery.proto#service-discovery-v3-resource). As described in the issue, the xDS definition allows identifying resources by either `name` or `resource_name`.~

 *   `DecodedResource` now securely holds and exposes `dynamicParameterConstraints()`.
 *   Prioritization logic has been updated to prefer `resource_name` when available.
 *   Tests have been added to verify that complex nested constraints are preserved without data loss.

Risk Level: Low
Testing: Added unit tests in `decoded_resource_impl_test.cc` to verify priority logic and fallback behavior.
Docs Changes: N/A
Release Notes: `config: support resource_name and dynamic constraints in DecodedResource`
Platform Specific Features: N/A
