### PR TITLE
upstream: fixed transport socket matcher to correctly use downstream connection filter state

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -197,6 +197,10 @@ bug_fixes:
     Fixed SDS to enable auto-recovery when initial certificate file loading fails. Previously, if certificate
     files did not exist during initial SDS configuration, no file watch callbacks were set up, preventing
     automatic recovery when files appeared later.
+- area: upstream
+  change: |
+    Fixed transport socket matcher to correctly use downstream connection filter state for matching and optimized the
+    selection path to avoid per-connection resolution overhead when filter state input is not used.
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/envoy/upstream/host_description.h
+++ b/envoy/upstream/host_description.h
@@ -273,9 +273,18 @@ public:
    */
   virtual void setLastHcPassTime(MonotonicTime last_hc_pass_time) PURE;
 
-  virtual Network::UpstreamTransportSocketFactory&
-  resolveTransportSocketFactory(const Network::Address::InstanceConstSharedPtr& dest_address,
-                                const envoy::config::core::v3::Metadata* metadata) const PURE;
+  /**
+   * Resolve the transport socket factory to use for connections to this host.
+   * @param dest_address the destination address for the connection.
+   * @param metadata optional endpoint metadata for matching.
+   * @param transport_socket_options optional transport socket options containing
+   *        filter state shared from downstream for per-connection matching.
+   * @return the resolved transport socket factory.
+   */
+  virtual Network::UpstreamTransportSocketFactory& resolveTransportSocketFactory(
+      const Network::Address::InstanceConstSharedPtr& dest_address,
+      const envoy::config::core::v3::Metadata* metadata,
+      Network::TransportSocketOptionsConstSharedPtr transport_socket_options = nullptr) const PURE;
 
   /**
    * Set load balancing policy related data to the host.
@@ -343,10 +352,16 @@ public:
       const envoy::config::core::v3::Metadata* locality_metadata,
       Network::TransportSocketOptionsConstSharedPtr transport_socket_options = nullptr) const PURE;
 
-  /*
-   * return true if all matches support ALPN, false otherwise.
+  /**
+   * @return true if all matches support ALPN, false otherwise.
    */
   virtual bool allMatchesSupportAlpn() const PURE;
+
+  /**
+   * @return true if the matcher uses filter state for transport socket selection. When true,
+   *         transport socket resolution must be done per-connection with transport_socket_options.
+   */
+  virtual bool usesFilterState() const PURE;
 };
 
 using TransportSocketMatcherPtr = std::unique_ptr<TransportSocketMatcher>;

--- a/source/common/upstream/transport_socket_match_impl.h
+++ b/source/common/upstream/transport_socket_match_impl.h
@@ -83,6 +83,8 @@ public:
     return true;
   }
 
+  bool usesFilterState() const override { return uses_filter_state_; }
+
 protected:
   TransportSocketMatcherImpl(
       const Protobuf::RepeatedPtrField<envoy::config::cluster::v3::Cluster::TransportSocketMatch>&
@@ -153,6 +155,7 @@ private:
   // Mutable because stats counters need to be incremented in the const resolve() method.
   mutable absl::flat_hash_map<std::string, TransportSocketMatchStats> matcher_stats_by_name_;
   std::unique_ptr<Matcher::MatchTree<Upstream::TransportSocketMatchingData>> matcher_;
+  bool uses_filter_state_{false};
 };
 
 // Import action classes from the extension.

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -220,9 +220,11 @@ public:
   }
   uint32_t priority() const override { return priority_; }
   void priority(uint32_t priority) override { priority_ = priority; }
-  Network::UpstreamTransportSocketFactory&
-  resolveTransportSocketFactory(const Network::Address::InstanceConstSharedPtr& dest_address,
-                                const envoy::config::core::v3::Metadata* metadata) const override;
+  Network::UpstreamTransportSocketFactory& resolveTransportSocketFactory(
+      const Network::Address::InstanceConstSharedPtr& dest_address,
+      const envoy::config::core::v3::Metadata* metadata,
+      Network::TransportSocketOptionsConstSharedPtr transport_socket_options =
+          nullptr) const override;
   absl::optional<MonotonicTime> lastHcPassTime() const override { return last_hc_pass_time_; }
 
   void setHealthChecker(HealthCheckHostMonitorPtr&& health_checker) override {

--- a/source/extensions/clusters/common/logical_host.h
+++ b/source/extensions/clusters/common/logical_host.h
@@ -124,10 +124,13 @@ public:
     return logical_host_->lastHcPassTime();
   }
   uint32_t priority() const override { return logical_host_->priority(); }
-  Network::UpstreamTransportSocketFactory&
-  resolveTransportSocketFactory(const Network::Address::InstanceConstSharedPtr& dest_address,
-                                const envoy::config::core::v3::Metadata* metadata) const override {
-    return logical_host_->resolveTransportSocketFactory(dest_address, metadata);
+  Network::UpstreamTransportSocketFactory& resolveTransportSocketFactory(
+      const Network::Address::InstanceConstSharedPtr& dest_address,
+      const envoy::config::core::v3::Metadata* metadata,
+      Network::TransportSocketOptionsConstSharedPtr transport_socket_options =
+          nullptr) const override {
+    return logical_host_->resolveTransportSocketFactory(dest_address, metadata,
+                                                        transport_socket_options);
   }
   OptRef<HostLbPolicyData> lbPolicyData() const override { return logical_host_->lbPolicyData(); }
 

--- a/test/extensions/clusters/common/logical_host_test.cc
+++ b/test/extensions/clusters/common/logical_host_test.cc
@@ -46,8 +46,9 @@ TEST_F(RealHostDescription, UnitTest) {
   const envoy::config::core::v3::Metadata metadata;
   const envoy::config::cluster::v3::Cluster cluster;
   Network::MockTransportSocketFactory socket_factory;
-  EXPECT_CALL(*mock_host_, resolveTransportSocketFactory(_, _)).WillOnce(ReturnRef(socket_factory));
-  description_.resolveTransportSocketFactory(address_, &metadata);
+  EXPECT_CALL(*mock_host_, resolveTransportSocketFactory(_, _, _))
+      .WillOnce(ReturnRef(socket_factory));
+  description_.resolveTransportSocketFactory(address_, &metadata, nullptr);
 
   description_.canary(false);
   description_.priority(0);

--- a/test/mocks/upstream/host.h
+++ b/test/mocks/upstream/host.h
@@ -112,7 +112,8 @@ public:
   }
   MOCK_METHOD(Network::UpstreamTransportSocketFactory&, resolveTransportSocketFactory,
               (const Network::Address::InstanceConstSharedPtr& dest_address,
-               const envoy::config::core::v3::Metadata* metadata),
+               const envoy::config::core::v3::Metadata* metadata,
+               Network::TransportSocketOptionsConstSharedPtr transport_socket_options),
               (const));
   MOCK_METHOD(void, setLbPolicyData, (HostLbPolicyDataPtr lb_policy_data));
   MOCK_METHOD(OptRef<HostLbPolicyData>, lbPolicyData, (), (const));
@@ -230,7 +231,8 @@ public:
 
   MOCK_METHOD(Network::UpstreamTransportSocketFactory&, resolveTransportSocketFactory,
               (const Network::Address::InstanceConstSharedPtr& dest_address,
-               const envoy::config::core::v3::Metadata* metadata),
+               const envoy::config::core::v3::Metadata* metadata,
+               Network::TransportSocketOptionsConstSharedPtr transport_socket_options),
               (const));
 
   testing::NiceMock<MockClusterInfo> cluster_;

--- a/test/mocks/upstream/transport_socket_match.h
+++ b/test/mocks/upstream/transport_socket_match.h
@@ -22,6 +22,7 @@ public:
                Network::TransportSocketOptionsConstSharedPtr),
               (const));
   MOCK_METHOD(bool, allMatchesSupportAlpn, (), (const));
+  MOCK_METHOD(bool, usesFilterState, (), (const));
 
   Network::UpstreamTransportSocketFactoryPtr socket_factory_;
   Stats::TestUtil::TestStore stats_store_;

--- a/test/server/admin/stats_handler_speed_test.cc
+++ b/test/server/admin/stats_handler_speed_test.cc
@@ -86,7 +86,8 @@ public:
 
   Network::UpstreamTransportSocketFactory&
   resolveTransportSocketFactory(const Network::Address::InstanceConstSharedPtr&,
-                                const envoy::config::core::v3::Metadata*) const override {
+                                const envoy::config::core::v3::Metadata*,
+                                Network::TransportSocketOptionsConstSharedPtr) const override {
     IS_ENVOY_BUG("unexpected call to resolveTransportSocketFactory");
     Network::UpstreamTransportSocketFactory* ptr = nullptr;
     return *ptr;


### PR DESCRIPTION
## Description

This PR fixes the transport socket matcher to correctly use downstream connection filter state for matching. It also optimizes the selection path to avoid per-connection resolution overhead when filter state input is not used.

---

**Commit Message:** upstream: fixed transport socket matcher to correctly use downstream connection filter state
**Additional Description:**
**Risk Level:** Low
**Testing:** Added Tests
**Docs Changes:** Added
**Release Notes:** Added