### PR TITLE
dynamic_modules: refactor ABI of dynamic modules for  network filters

### DIFF
--- a/source/extensions/dynamic_modules/abi.h
+++ b/source/extensions/dynamic_modules/abi.h
@@ -2476,70 +2476,70 @@ envoy_dynamic_module_callback_get_most_specific_route_config(
 // =============================================================================
 
 /**
- * envoy_dynamic_module_callback_network_filter_get_read_buffer_slices_size is called by the module
- * to get the number of slices in the current read data buffer. Combined with
- * envoy_dynamic_module_callback_network_filter_get_read_buffer_slices, this can be used to iterate
- * over all slices in the read buffer. This is only valid during the
+ * envoy_dynamic_module_callback_network_filter_get_read_buffer_chunks_size is called by the module
+ * to get the number of chunks in the current read data buffer. Combined with
+ * envoy_dynamic_module_callback_network_filter_get_read_buffer_chunks, this can be used to iterate
+ * over all chunks in the read buffer. This is only valid during the
  * envoy_dynamic_module_on_network_filter_read callback.
  *
  * @param filter_envoy_ptr is the pointer to the DynamicModuleNetworkFilter object.
- * @param size is the pointer to the variable where the number of slices will be stored.
+ * @param size is the pointer to the variable where the number of chunks will be stored.
  * @return true if the buffer is available, false otherwise.
  */
-bool envoy_dynamic_module_callback_network_filter_get_read_buffer_slices_size(
+bool envoy_dynamic_module_callback_network_filter_get_read_buffer_chunks_size(
     envoy_dynamic_module_type_network_filter_envoy_ptr filter_envoy_ptr, size_t* size);
 
 /**
- * envoy_dynamic_module_callback_network_filter_get_read_buffer_slices is called by the module to
- * get the current read data buffer as slices. This is only valid during the
+ * envoy_dynamic_module_callback_network_filter_get_read_buffer_chunks is called by the module to
+ * get the current read data buffer as chunks. This is only valid during the
  * envoy_dynamic_module_on_network_filter_read callback.
  *
  * PRECONDITION: The module must ensure that the result_buffer_vector is valid and has enough length
- * to store all the slices. The module can use
- * envoy_dynamic_module_callback_network_filter_get_read_buffer_slices_size to get the number of
- * slices before calling this function.
+ * to store all the chunks. The module can use
+ * envoy_dynamic_module_callback_network_filter_get_read_buffer_chunks_size to get the number of
+ * chunks before calling this function.
  *
  * @param filter_envoy_ptr is the pointer to the DynamicModuleNetworkFilter object.
  * @param result_buffer_vector is the pointer to the array of envoy_dynamic_module_type_envoy_buffer
- * where the slices will be stored. The lifetime of the buffer is guaranteed until the end of the
+ * where the chunks will be stored. The lifetime of the buffer is guaranteed until the end of the
  * current callback.
- * @return the total length of all slices, or 0 if the buffer is not available.
+ * @return the total length of all chunks, or 0 if the buffer is not available.
  */
-size_t envoy_dynamic_module_callback_network_filter_get_read_buffer_slices(
+size_t envoy_dynamic_module_callback_network_filter_get_read_buffer_chunks(
     envoy_dynamic_module_type_network_filter_envoy_ptr filter_envoy_ptr,
     envoy_dynamic_module_type_envoy_buffer* result_buffer_vector);
 
 /**
- * envoy_dynamic_module_callback_network_filter_get_write_buffer_slices_size is called by the module
- * to get the number of slices in the current write data buffer. Combined with
- * envoy_dynamic_module_callback_network_filter_get_write_buffer_slices, this can be used to iterate
- * over all slices in the write buffer. This is only valid during the
+ * envoy_dynamic_module_callback_network_filter_get_write_buffer_chunks_size is called by the module
+ * to get the number of chunks in the current write data buffer. Combined with
+ * envoy_dynamic_module_callback_network_filter_get_write_buffer_chunks, this can be used to iterate
+ * over all chunks in the write buffer. This is only valid during the
  * envoy_dynamic_module_on_network_filter_write callback.
  *
  * @param filter_envoy_ptr is the pointer to the DynamicModuleNetworkFilter object.
- * @param size is the pointer to the variable where the number of slices will be stored.
+ * @param size is the pointer to the variable where the number of chunks will be stored.
  * @return true if the buffer is available, false otherwise.
  */
-bool envoy_dynamic_module_callback_network_filter_get_write_buffer_slices_size(
+bool envoy_dynamic_module_callback_network_filter_get_write_buffer_chunks_size(
     envoy_dynamic_module_type_network_filter_envoy_ptr filter_envoy_ptr, size_t* size);
 
 /**
- * envoy_dynamic_module_callback_network_filter_get_write_buffer_slices is called by the module to
- * get the current write data buffer as slices. This is only valid during the
+ * envoy_dynamic_module_callback_network_filter_get_write_buffer_chunks is called by the module to
+ * get the current write data buffer as chunks. This is only valid during the
  * envoy_dynamic_module_on_network_filter_write callback.
  *
  * PRECONDITION: The module must ensure that the result_buffer_vector is valid and has enough length
- * to store all the slices. The module can use
- * envoy_dynamic_module_callback_network_filter_get_write_buffer_slices_size to get the number of
- * slices before calling this function.
+ * to store all the chunks. The module can use
+ * envoy_dynamic_module_callback_network_filter_get_write_buffer_chunks_size to get the number of
+ * chunks before calling this function.
  *
  * @param filter_envoy_ptr is the pointer to the DynamicModuleNetworkFilter object.
  * @param result_buffer_vector is the pointer to the array of envoy_dynamic_module_type_envoy_buffer
- * where the slices will be stored. The lifetime of the buffer is guaranteed until the end of the
+ * where the chunks will be stored. The lifetime of the buffer is guaranteed until the end of the
  * current callback.
- * @return the total length of all slices, or 0 if the buffer is not available.
+ * @return the total length of all chunks, or 0 if the buffer is not available.
  */
-size_t envoy_dynamic_module_callback_network_filter_get_write_buffer_slices(
+size_t envoy_dynamic_module_callback_network_filter_get_write_buffer_chunks(
     envoy_dynamic_module_type_network_filter_envoy_ptr filter_envoy_ptr,
     envoy_dynamic_module_type_envoy_buffer* result_buffer_vector);
 

--- a/source/extensions/dynamic_modules/abi_version.h
+++ b/source/extensions/dynamic_modules/abi_version.h
@@ -6,7 +6,7 @@ namespace DynamicModules {
 #endif
 // This is the ABI version calculated as a sha256 hash of the ABI header files. When the ABI
 // changes, this value must change, and the correctness of this value is checked by the test.
-const char* kAbiVersion = "9c3db59ceccb7856588f1cacfbca586fac79dd4f4e776782b1af414a4da765f7";
+const char* kAbiVersion = "621206254680c586434c72a0183ab01b60a3ee506e4a55614a2cc0184c1fad16";
 
 #ifdef __cplusplus
 } // namespace DynamicModules

--- a/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
@@ -3272,11 +3272,11 @@ pub trait NetworkFilter<ENF: EnvoyNetworkFilter> {
 /// The trait that represents the Envoy network filter.
 /// This is used in [`NetworkFilter`] to interact with the underlying Envoy network filter object.
 pub trait EnvoyNetworkFilter {
-  /// Get the read buffer slices. This is only valid during the on_read callback.
-  fn get_read_buffer_slices(&mut self) -> (Vec<EnvoyBuffer>, usize);
+  /// Get the read buffer chunks. This is only valid during the on_read callback.
+  fn get_read_buffer_chunks(&mut self) -> (Vec<EnvoyBuffer>, usize);
 
-  /// Get the write buffer slices. This is only valid during the on_write callback.
-  fn get_write_buffer_slices(&mut self) -> (Vec<EnvoyBuffer>, usize);
+  /// Get the write buffer chunks. This is only valid during the on_write callback.
+  fn get_write_buffer_chunks(&mut self) -> (Vec<EnvoyBuffer>, usize);
 
   /// Drain bytes from the beginning of the read buffer.
   fn drain_read_buffer(&mut self, length: usize);
@@ -3352,10 +3352,10 @@ impl EnvoyNetworkFilterImpl {
 }
 
 impl EnvoyNetworkFilter for EnvoyNetworkFilterImpl {
-  fn get_read_buffer_slices(&mut self) -> (Vec<EnvoyBuffer>, usize) {
+  fn get_read_buffer_chunks(&mut self) -> (Vec<EnvoyBuffer>, usize) {
     let mut size: usize = 0;
     let ok = unsafe {
-      abi::envoy_dynamic_module_callback_network_filter_get_read_buffer_slices_size(
+      abi::envoy_dynamic_module_callback_network_filter_get_read_buffer_chunks_size(
         self.raw, &mut size,
       )
     };
@@ -3371,7 +3371,7 @@ impl EnvoyNetworkFilter for EnvoyNetworkFilterImpl {
       size
     ];
     let total_length = unsafe {
-      abi::envoy_dynamic_module_callback_network_filter_get_read_buffer_slices(
+      abi::envoy_dynamic_module_callback_network_filter_get_read_buffer_chunks(
         self.raw,
         buffers.as_mut_ptr(),
       )
@@ -3383,10 +3383,10 @@ impl EnvoyNetworkFilter for EnvoyNetworkFilterImpl {
     (envoy_buffers, total_length)
   }
 
-  fn get_write_buffer_slices(&mut self) -> (Vec<EnvoyBuffer>, usize) {
+  fn get_write_buffer_chunks(&mut self) -> (Vec<EnvoyBuffer>, usize) {
     let mut size: usize = 0;
     let ok = unsafe {
-      abi::envoy_dynamic_module_callback_network_filter_get_write_buffer_slices_size(
+      abi::envoy_dynamic_module_callback_network_filter_get_write_buffer_chunks_size(
         self.raw, &mut size,
       )
     };
@@ -3402,7 +3402,7 @@ impl EnvoyNetworkFilter for EnvoyNetworkFilterImpl {
       size
     ];
     let total_length = unsafe {
-      abi::envoy_dynamic_module_callback_network_filter_get_write_buffer_slices(
+      abi::envoy_dynamic_module_callback_network_filter_get_write_buffer_chunks(
         self.raw,
         buffers.as_mut_ptr(),
       )

--- a/source/extensions/filters/network/dynamic_modules/abi_impl.cc
+++ b/source/extensions/filters/network/dynamic_modules/abi_impl.cc
@@ -27,8 +27,8 @@ toEnvoyCloseType(envoy_dynamic_module_type_network_connection_close_type close_t
   return Network::ConnectionCloseType::NoFlush;
 }
 
-// Helper to fill buffer slices from a Buffer::Instance into a pre-allocated array.
-void fillBufferSlices(const Buffer::Instance& buffer,
+// Helper to fill buffer chunks from a Buffer::Instance into a pre-allocated array.
+void fillBufferChunks(const Buffer::Instance& buffer,
                       envoy_dynamic_module_type_envoy_buffer* result_buffer_vector) {
   Buffer::RawSliceVector raw_slices = buffer.getRawSlices();
   auto counter = 0;
@@ -43,7 +43,7 @@ void fillBufferSlices(const Buffer::Instance& buffer,
 
 extern "C" {
 
-bool envoy_dynamic_module_callback_network_filter_get_read_buffer_slices_size(
+bool envoy_dynamic_module_callback_network_filter_get_read_buffer_chunks_size(
     envoy_dynamic_module_type_network_filter_envoy_ptr filter_envoy_ptr, size_t* size) {
   auto* filter = static_cast<DynamicModuleNetworkFilter*>(filter_envoy_ptr);
   Buffer::Instance* buffer = filter->currentReadBuffer();
@@ -55,7 +55,7 @@ bool envoy_dynamic_module_callback_network_filter_get_read_buffer_slices_size(
   return true;
 }
 
-size_t envoy_dynamic_module_callback_network_filter_get_read_buffer_slices(
+size_t envoy_dynamic_module_callback_network_filter_get_read_buffer_chunks(
     envoy_dynamic_module_type_network_filter_envoy_ptr filter_envoy_ptr,
     envoy_dynamic_module_type_envoy_buffer* result_buffer_vector) {
   auto* filter = static_cast<DynamicModuleNetworkFilter*>(filter_envoy_ptr);
@@ -65,11 +65,11 @@ size_t envoy_dynamic_module_callback_network_filter_get_read_buffer_slices(
     return 0;
   }
 
-  fillBufferSlices(*buffer, result_buffer_vector);
+  fillBufferChunks(*buffer, result_buffer_vector);
   return buffer->length();
 }
 
-bool envoy_dynamic_module_callback_network_filter_get_write_buffer_slices_size(
+bool envoy_dynamic_module_callback_network_filter_get_write_buffer_chunks_size(
     envoy_dynamic_module_type_network_filter_envoy_ptr filter_envoy_ptr, size_t* size) {
   auto* filter = static_cast<DynamicModuleNetworkFilter*>(filter_envoy_ptr);
   Buffer::Instance* buffer = filter->currentWriteBuffer();
@@ -81,7 +81,7 @@ bool envoy_dynamic_module_callback_network_filter_get_write_buffer_slices_size(
   return true;
 }
 
-size_t envoy_dynamic_module_callback_network_filter_get_write_buffer_slices(
+size_t envoy_dynamic_module_callback_network_filter_get_write_buffer_chunks(
     envoy_dynamic_module_type_network_filter_envoy_ptr filter_envoy_ptr,
     envoy_dynamic_module_type_envoy_buffer* result_buffer_vector) {
   auto* filter = static_cast<DynamicModuleNetworkFilter*>(filter_envoy_ptr);
@@ -91,7 +91,7 @@ size_t envoy_dynamic_module_callback_network_filter_get_write_buffer_slices(
     return 0;
   }
 
-  fillBufferSlices(*buffer, result_buffer_vector);
+  fillBufferChunks(*buffer, result_buffer_vector);
   return buffer->length();
 }
 

--- a/test/extensions/dynamic_modules/network/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/network/abi_impl_test.cc
@@ -44,21 +44,21 @@ public:
 };
 
 // =============================================================================
-// Tests for get_read_buffer_slices with actual buffer.
+// Tests for get_read_buffer_chunks with actual buffer.
 // =============================================================================
 
-TEST_F(DynamicModuleNetworkFilterAbiCallbackTest, GetReadBufferSlicesWithData) {
+TEST_F(DynamicModuleNetworkFilterAbiCallbackTest, GetReadBufferChunksWithData) {
   Buffer::OwnedImpl buffer("hello world");
   filter_->setCurrentReadBufferForTest(&buffer);
 
   size_t size = 0;
   bool ok =
-      envoy_dynamic_module_callback_network_filter_get_read_buffer_slices_size(filterPtr(), &size);
+      envoy_dynamic_module_callback_network_filter_get_read_buffer_chunks_size(filterPtr(), &size);
   EXPECT_TRUE(ok);
   EXPECT_GT(size, 0);
 
   std::vector<envoy_dynamic_module_type_envoy_buffer> result_buffer(size);
-  size_t total_length = envoy_dynamic_module_callback_network_filter_get_read_buffer_slices(
+  size_t total_length = envoy_dynamic_module_callback_network_filter_get_read_buffer_chunks(
       filterPtr(), result_buffer.data());
 
   EXPECT_EQ(11, total_length);
@@ -67,32 +67,32 @@ TEST_F(DynamicModuleNetworkFilterAbiCallbackTest, GetReadBufferSlicesWithData) {
   filter_->setCurrentReadBufferForTest(nullptr);
 }
 
-TEST_F(DynamicModuleNetworkFilterAbiCallbackTest, GetReadBufferSlicesNullBuffer) {
+TEST_F(DynamicModuleNetworkFilterAbiCallbackTest, GetReadBufferChunksNullBuffer) {
   size_t size = 0;
   bool ok =
-      envoy_dynamic_module_callback_network_filter_get_read_buffer_slices_size(filterPtr(), &size);
+      envoy_dynamic_module_callback_network_filter_get_read_buffer_chunks_size(filterPtr(), &size);
   EXPECT_FALSE(ok);
   EXPECT_EQ(0, size);
 
   std::vector<envoy_dynamic_module_type_envoy_buffer> result_buffer(1);
-  size_t total_length = envoy_dynamic_module_callback_network_filter_get_read_buffer_slices(
+  size_t total_length = envoy_dynamic_module_callback_network_filter_get_read_buffer_chunks(
       filterPtr(), result_buffer.data());
 
   EXPECT_EQ(0, total_length);
 }
 
-TEST_F(DynamicModuleNetworkFilterAbiCallbackTest, GetReadBufferSlicesEmptyBuffer) {
+TEST_F(DynamicModuleNetworkFilterAbiCallbackTest, GetReadBufferChunksEmptyBuffer) {
   Buffer::OwnedImpl empty_buffer;
   filter_->setCurrentReadBufferForTest(&empty_buffer);
 
   size_t size = 0;
   bool ok =
-      envoy_dynamic_module_callback_network_filter_get_read_buffer_slices_size(filterPtr(), &size);
+      envoy_dynamic_module_callback_network_filter_get_read_buffer_chunks_size(filterPtr(), &size);
   EXPECT_TRUE(ok);
   EXPECT_EQ(0, size);
 
   std::vector<envoy_dynamic_module_type_envoy_buffer> result_buffer(1);
-  size_t total_length = envoy_dynamic_module_callback_network_filter_get_read_buffer_slices(
+  size_t total_length = envoy_dynamic_module_callback_network_filter_get_read_buffer_chunks(
       filterPtr(), result_buffer.data());
 
   EXPECT_EQ(0, total_length);
@@ -101,21 +101,21 @@ TEST_F(DynamicModuleNetworkFilterAbiCallbackTest, GetReadBufferSlicesEmptyBuffer
 }
 
 // =============================================================================
-// Tests for get_write_buffer_slices with actual buffer.
+// Tests for get_write_buffer_chunks with actual buffer.
 // =============================================================================
 
-TEST_F(DynamicModuleNetworkFilterAbiCallbackTest, GetWriteBufferSlicesWithData) {
+TEST_F(DynamicModuleNetworkFilterAbiCallbackTest, GetWriteBufferChunksWithData) {
   Buffer::OwnedImpl buffer("test data");
   filter_->setCurrentWriteBufferForTest(&buffer);
 
   size_t size = 0;
   bool ok =
-      envoy_dynamic_module_callback_network_filter_get_write_buffer_slices_size(filterPtr(), &size);
+      envoy_dynamic_module_callback_network_filter_get_write_buffer_chunks_size(filterPtr(), &size);
   EXPECT_TRUE(ok);
   EXPECT_GT(size, 0);
 
   std::vector<envoy_dynamic_module_type_envoy_buffer> result_buffer(size);
-  size_t total_length = envoy_dynamic_module_callback_network_filter_get_write_buffer_slices(
+  size_t total_length = envoy_dynamic_module_callback_network_filter_get_write_buffer_chunks(
       filterPtr(), result_buffer.data());
 
   EXPECT_EQ(9, total_length);
@@ -124,32 +124,32 @@ TEST_F(DynamicModuleNetworkFilterAbiCallbackTest, GetWriteBufferSlicesWithData) 
   filter_->setCurrentWriteBufferForTest(nullptr);
 }
 
-TEST_F(DynamicModuleNetworkFilterAbiCallbackTest, GetWriteBufferSlicesNullBuffer) {
+TEST_F(DynamicModuleNetworkFilterAbiCallbackTest, GetWriteBufferChunksNullBuffer) {
   size_t size = 0;
   bool ok =
-      envoy_dynamic_module_callback_network_filter_get_write_buffer_slices_size(filterPtr(), &size);
+      envoy_dynamic_module_callback_network_filter_get_write_buffer_chunks_size(filterPtr(), &size);
   EXPECT_FALSE(ok);
   EXPECT_EQ(0, size);
 
   std::vector<envoy_dynamic_module_type_envoy_buffer> result_buffer(1);
-  size_t total_length = envoy_dynamic_module_callback_network_filter_get_write_buffer_slices(
+  size_t total_length = envoy_dynamic_module_callback_network_filter_get_write_buffer_chunks(
       filterPtr(), result_buffer.data());
 
   EXPECT_EQ(0, total_length);
 }
 
-TEST_F(DynamicModuleNetworkFilterAbiCallbackTest, GetWriteBufferSlicesEmptyBuffer) {
+TEST_F(DynamicModuleNetworkFilterAbiCallbackTest, GetWriteBufferChunksEmptyBuffer) {
   Buffer::OwnedImpl empty_buffer;
   filter_->setCurrentWriteBufferForTest(&empty_buffer);
 
   size_t size = 0;
   bool ok =
-      envoy_dynamic_module_callback_network_filter_get_write_buffer_slices_size(filterPtr(), &size);
+      envoy_dynamic_module_callback_network_filter_get_write_buffer_chunks_size(filterPtr(), &size);
   EXPECT_TRUE(ok);
   EXPECT_EQ(0, size);
 
   std::vector<envoy_dynamic_module_type_envoy_buffer> result_buffer(1);
-  size_t total_length = envoy_dynamic_module_callback_network_filter_get_write_buffer_slices(
+  size_t total_length = envoy_dynamic_module_callback_network_filter_get_write_buffer_chunks(
       filterPtr(), result_buffer.data());
 
   EXPECT_EQ(0, total_length);


### PR DESCRIPTION
## Description

This PR refactors the ABI of the Dynamic Modules for Network Filter to make it aligned with the codebase. 

Slices are now called Chunks:
- `envoy_dynamic_module_callback_network_filter_get_read_buffer_slices_size` => `envoy_dynamic_module_callback_network_filter_get_read_buffer_chunks_size`

---

**Commit Message:** dynamic_modules: change ABI of dynamic modules for  network filters
**Additional Description:** Refactors the ABI of the Dynamic Modules for Network Filter to make it aligned with the codebase. 
**Risk Level:** Low
**Testing:** Added
**Docs Changes:** Added
**Release Notes:** N/A