### PR TITLE
dynamic_modules: support network filters to be terminal

### DIFF
--- a/api/envoy/extensions/filters/network/dynamic_modules/v3/dynamic_modules.proto
+++ b/api/envoy/extensions/filters/network/dynamic_modules/v3/dynamic_modules.proto
@@ -68,4 +68,9 @@ message DynamicModuleNetworkFilter {
   //    value: aGVsbG8=  # echo -n "hello" | base64
   //
   google.protobuf.Any filter_config = 3;
+
+  // Set true if the dynamic module is a terminal filter to use without an upstream connection.
+  // The dynamic module is responsible for creating and sending the response to downstream.
+  // If not specified, defaults to false.
+  bool terminal_filter = 4;
 }

--- a/source/extensions/filters/network/dynamic_modules/factory.h
+++ b/source/extensions/filters/network/dynamic_modules/factory.h
@@ -24,10 +24,9 @@ private:
   createFilterFactoryFromProtoTyped(const FilterConfig& proto_config,
                                     FactoryContext& context) override;
 
-  bool isTerminalFilterByProtoTyped(const FilterConfig&, ServerFactoryContext&) override {
-    // Network filters can be terminal or not, but dynamic modules don't have explicit terminal
-    // support like HTTP filters.
-    return false;
+  bool isTerminalFilterByProtoTyped(const FilterConfig& proto_config,
+                                    ServerFactoryContext&) override {
+    return proto_config.terminal_filter();
   }
 };
 


### PR DESCRIPTION
## Description

This PR supports Dynamic Modules for network filters to make them `terminal`.

---

**Commit Message:** dynamic_modules: support network filters to be terminal
**Additional Description:** Added support for Dynamic Modules for the network filters to make them `terminal`.
**Risk Level:** Low
**Testing:** Added Tests
**Docs Changes:** Added
**Release Notes:** N/A