### PR TITLE
router: avoid debug log evaluation for each data chunk

### DIFF
--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -980,7 +980,6 @@ bool Filter::isEarlyConnectData() {
 }
 
 Http::FilterDataStatus Filter::decodeData(Buffer::Instance& data, bool end_stream) {
-  ENVOY_STREAM_LOG(debug, "router decoding data: {}", *callbacks_, data.length());
   if (data.length() > 0 && isEarlyConnectData()) {
     callbacks_->sendLocalReply(Http::Code::BadRequest, "", nullptr, absl::nullopt,
                                StreamInfo::ResponseCodeDetails::get().EarlyConnectData);


### PR DESCRIPTION
Commit Message:
it seems not very efficient to put a debug log evaluated for each data chunk in the router code even if the proxy is not running in debug mode. I believe we should avoid it.

Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
