### PR TITLE
ext_authz: fix status_on_error ignored on gRPC failure

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -208,6 +208,10 @@ bug_fixes:
   change: |
     Fixed transport socket matcher to correctly use downstream connection filter state for matching and optimized the
     selection path to avoid per-connection resolution overhead when filter state input is not used.
+- area: ext_authz
+  change: |
+    Fixed the gRPC ext_authz client to respect ``status_on_error`` configuration when gRPC calls fail.
+    Previously, gRPC call failures always returned 403 Forbidden regardless of the configured error status.
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/source/extensions/filters/common/ext_authz/ext_authz_grpc_impl.cc
+++ b/source/extensions/filters/common/ext_authz/ext_authz_grpc_impl.cc
@@ -168,7 +168,6 @@ void GrpcClientImpl::onFailure(Grpc::Status::GrpcStatus status, const std::strin
   ASSERT(status != Grpc::Status::WellKnownGrpcStatus::Ok);
   Response response{};
   response.status = CheckStatus::Error;
-  response.status_code = Http::Code::Forbidden;
   response.grpc_status = status;
   callbacks_->onComplete(std::make_unique<Response>(response));
   callbacks_ = nullptr;


### PR DESCRIPTION
GrpcClientImpl::onFailure() hardcoded status 403, preventing `status_on_error` config from working when gRPC calls fail since it starts checking the 0 status.  Now leaves status unset so the filter uses the configured value.

fix a regression introduced from https://github.com/envoyproxy/envoy/pull/42099

Commit Message:
Additional Description:
Risk Level: low
Testing: both 
Docs Changes:
Release Notes: