### PR TITLE
Transport socket tap/streamed trace minor changes for the last sequence number.

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -47,6 +47,9 @@ minor_behavior_changes:
 - area: tap
   change: |
     Add sequence number per event in transport socket streamed trace.
+- area: tap
+  change: |
+    Change the last sequence number from sentinel value to the previous sequence number plus one.
 - area: ext_proc
   change: |
     Use a hard-coded set of error messages when a :ref:`HeaderMutation

--- a/source/extensions/transport_sockets/tap/tap_config_impl.cc
+++ b/source/extensions/transport_sockets/tap/tap_config_impl.cc
@@ -49,18 +49,19 @@ void PerSocketTapperImpl::closeSocket(Network::ConnectionEvent) {
   }
 
   if (config_->streaming()) {
+    seq_num++;
     if (shouldSendStreamedMsgByConfiguredSize()) {
       makeStreamedTraceIfNeeded();
       auto& event =
           *streamed_trace_->mutable_socket_streamed_trace_segment()->mutable_events()->add_events();
-      initStreamingEvent(event, MaxSeqNum);
+      initStreamingEvent(event, seq_num);
       event.mutable_closed();
       // submit directly and don't check current_streamed_rx_tx_bytes_ any more
       submitStreamedDataPerConfiguredSize();
     } else {
       TapCommon::TraceWrapperPtr trace = makeTraceSegment();
       auto& event = *trace->mutable_socket_streamed_trace_segment()->mutable_event();
-      initStreamingEvent(event, MaxSeqNum);
+      initStreamingEvent(event, seq_num);
       event.mutable_closed();
       sink_handle_->submitTrace(std::move(trace));
     }

--- a/source/extensions/transport_sockets/tap/tap_config_impl.h
+++ b/source/extensions/transport_sockets/tap/tap_config_impl.h
@@ -66,7 +66,6 @@ private:
   // Add sequence number to allow the receiver to reconstruct byte order and
   // determine completeness, similar to TCP sequence numbers.
   uint64_t seq_num{};
-  static constexpr uint64_t MaxSeqNum = std::numeric_limits<uint64_t>::max();
   SocketTapConfigSharedPtr config_;
   Extensions::Common::Tap::PerTapSinkHandleManagerPtr sink_handle_;
   const Network::Connection& connection_;

--- a/test/extensions/transport_sockets/tap/tap_config_impl_test.cc
+++ b/test/extensions/transport_sockets/tap/tap_config_impl_test.cc
@@ -169,7 +169,7 @@ socket_streamed_trace_segment:
   event:
     timestamp: 1970-01-01T00:00:02Z
     closed: {}
-    seq_num: 18446744073709551615
+    seq_num: 12
 )EOF")));
   time_system_.setSystemTime(std::chrono::seconds(2));
   tapper_->closeSocket(Network::ConnectionEvent::RemoteClose);
@@ -269,7 +269,7 @@ socket_streamed_trace_segment:
         socket_address:
           address: 10.0.0.3
           port_value: 50000
-    seq_num: 18446744073709551615
+    seq_num: 12
 )EOF")));
   time_system_.setSystemTime(std::chrono::seconds(2));
   tapper_->closeSocket(Network::ConnectionEvent::RemoteClose);
@@ -370,7 +370,7 @@ socket_streamed_trace_segment:
         socket_address:
           address: 10.0.0.3
           port_value: 50000
-    seq_num: 18446744073709551615
+    seq_num: 12
 )EOF")));
   time_system_.setSystemTime(std::chrono::seconds(2));
   tapper_->closeSocket(Network::ConnectionEvent::RemoteClose);
@@ -484,7 +484,7 @@ socket_streamed_trace_segment:
           socket_address:
             address: 10.0.0.3
             port_value: 50000
-      seq_num: 18446744073709551615
+      seq_num: 109
 )EOF")));
   time_system_.setSystemTime(std::chrono::seconds(2));
   tapper_->closeSocket(Network::ConnectionEvent::RemoteClose);
@@ -587,7 +587,7 @@ socket_streamed_trace_segment:
           socket_address:
             address: 10.0.0.3
             port_value: 50000
-      seq_num: 18446744073709551615
+      seq_num: 108
 )EOF")));
   time_system_.setSystemTime(std::chrono::seconds(2));
   tapper_->closeSocket(Network::ConnectionEvent::RemoteClose);
@@ -693,7 +693,7 @@ socket_streamed_trace_segment:
           socket_address:
             address: 10.0.0.3
             port_value: 50000
-      seq_num: 18446744073709551615
+      seq_num: 110
 )EOF")));
   time_system_.setSystemTime(std::chrono::seconds(2));
   tapper_->closeSocket(Network::ConnectionEvent::RemoteClose);
@@ -785,7 +785,7 @@ socket_streamed_trace_segment:
           socket_address:
             address: 10.0.0.3
             port_value: 50000
-      seq_num: 18446744073709551615
+      seq_num: 109
 )EOF")));
   tapper_->onRead(Buffer::OwnedImpl("Test transport socket tap buffered data onRead submit"), 53);
   time_system_.setSystemTime(std::chrono::seconds(2));


### PR DESCRIPTION
Per RFC 793, a TCP FIN consumes one sequence number. 
When a connection is closed, the final sequence number is the last data sequence number plus one, not a sentinel value.

This PR updates the close-event behavior so that:
The final seq_num is advanced by +1 from the previous data sequence number
The previous uint64_t max-value sentinel is removed
This change ensures streamed transport socket traces accurately reflect tapped sequence number behavior.

Commit Message:
Additional Description:
Risk Level: low
Testing:UT/DT
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
