### PR TITLE
http: support per-backend StreamOptions in MuxDemux::multicast

### DIFF
--- a/source/common/http/muxdemux.cc
+++ b/source/common/http/muxdemux.cc
@@ -168,8 +168,11 @@ MuxDemux::multicast(const AsyncClient::StreamOptions& options,
 
   auto multistream = std::unique_ptr<MultiStream>(new MultiStream(shared_from_this()));
   for (const Callbacks& callback : callbacks) {
-    absl::Status status = multistream->addStream(options, callback.cluster_name, callback.callbacks,
-                                                 factory_context_);
+    // Use per-backend options if provided, otherwise fall back to the default options.
+    const AsyncClient::StreamOptions& effective_options =
+        callback.options.has_value() ? callback.options.value() : options;
+    absl::Status status = multistream->addStream(effective_options, callback.cluster_name,
+                                                 callback.callbacks, factory_context_);
     if (!status.ok()) {
       return status;
     }

--- a/source/common/http/muxdemux.h
+++ b/source/common/http/muxdemux.h
@@ -112,6 +112,7 @@ public:
   struct Callbacks {
     std::string cluster_name;
     std::weak_ptr<AsyncClient::StreamCallbacks> callbacks;
+    absl::optional<AsyncClient::StreamOptions> options;
   };
 
   static std::shared_ptr<MuxDemux> create(Server::Configuration::FactoryContext& context) {


### PR DESCRIPTION
Commit Message:
Previously, MuxDemux::multicast accepted a single StreamOptions for all backends, which meant per-backend timeouts couldn't be configured. The mcp_router worked around this by using the maximum timeout across all backends.

This change adds an optional `options` field to MuxDemux::Callbacks, allowing callers to specify per-backend StreamOptions. When set, these options override the default options passed to multicast().

The mcp_router now uses this feature to set proper per-backend timeouts instead of the max-timeout workaround.
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
