### PR TITLE
quic: Add a default-false runtime guard to disable socket options

### DIFF
--- a/source/common/quic/envoy_quic_utils.cc
+++ b/source/common/quic/envoy_quic_utils.cc
@@ -244,8 +244,14 @@ createConnectionSocket(const Network::Address::InstanceConstSharedPtr& peer_addr
     ENVOY_LOG_MISC(error, "Failed to create quic socket");
     return connection_socket;
   }
-  connection_socket->addOptions(Network::SocketOptionFactory::buildIpPacketInfoOptions());
-  connection_socket->addOptions(Network::SocketOptionFactory::buildRxQueueOverFlowOptions());
+  if (!Runtime::runtimeFeatureEnabled(
+          "envoy.reloadable_features.disable_quic_ip_packet_info_socket_options")) {
+    connection_socket->addOptions(Network::SocketOptionFactory::buildIpPacketInfoOptions());
+  }
+  if (!Runtime::runtimeFeatureEnabled(
+          "envoy.reloadable_features.disable_quic_rx_queue_overflow_socket_options")) {
+    connection_socket->addOptions(Network::SocketOptionFactory::buildRxQueueOverFlowOptions());
+  }
   connection_socket->addOptions(Network::SocketOptionFactory::buildIpRecvTosOptions());
   if (Api::OsSysCallsSingleton::get().supportsUdpGro()) {
     connection_socket->addOptions(Network::SocketOptionFactory::buildUdpGroOptions());

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -160,6 +160,10 @@ FALSE_RUNTIME_GUARD(envoy_reloadable_features_connection_close_through_filter_ma
 // TODO(adisuissa): flip to true after all xDS types use the new subscription
 // method, and this is tested extensively.
 FALSE_RUNTIME_GUARD(envoy_reloadable_features_xdstp_based_config_singleton_subscriptions);
+// TODO(abeyad): Flip to true after prod testing.
+FALSE_RUNTIME_GUARD(envoy_reloadable_features_disable_quic_rx_queue_overflow_socket_options);
+// TODO(abeyad): Flip to true after prod testing.
+FALSE_RUNTIME_GUARD(envoy_reloadable_features_disable_quic_ip_packet_info_socket_options);
 
 // A flag to set the maximum TLS version for google_grpc client to TLS1.2, when needed for
 // compliance restrictions.


### PR DESCRIPTION
Envoy Mobile will experiment with these socket options to see if client connections should enable or disable them by default for improved QUIC usage.