### PR TITLE
lua: clarify TODO for buffer copies

### DIFF
--- a/source/extensions/filters/common/lua/wrappers.cc
+++ b/source/extensions/filters/common/lua/wrappers.cc
@@ -57,7 +57,8 @@ int BufferWrapper::luaGetBytes(lua_State* state) {
     luaL_error(state, "index/length must be >= 0 and (index + length) must be <= buffer size");
   }
 
-  // TODO(mattklein123): Reduce copies here by using Lua direct buffer builds.
+  // Note: Lua buffer API (`luaL_prepbuffsize`) could reduce copies here, but Envoy
+  // uses luajit which does not expose this function.
   std::unique_ptr<char[]> data(new char[length]);
   data_.copyOut(index, length, data.get());
   lua_pushlstring(state, data.get(), length);

--- a/tools/spelling/spelling_dictionary.txt
+++ b/tools/spelling/spelling_dictionary.txt
@@ -1013,6 +1013,7 @@ lowp
 lstat
 ltrim
 lua
+luajit
 lyft
 maglev
 malloc


### PR DESCRIPTION
Commit Message:
clarify an old TODO to explain why the current implemented way is correct and cannot be changed.

I initially wanted to resolve this TODO but quickly realise this is actually not possible with luaJIT.

Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
