### PR TITLE
composite: make next set of filters to resume correctly when a filter stops

### DIFF
--- a/source/extensions/filters/http/composite/filter.h
+++ b/source/extensions/filters/http/composite/filter.h
@@ -85,6 +85,19 @@ public:
 
 private:
   std::vector<Http::StreamFilterSharedPtr> filters_;
+  // Track the index of the last filter processed for each operation type.
+  // When a filter returns StopIteration, we save the index. On the next call,
+  // we resume from the next filter.
+  size_t decode_headers_index_{0};
+  size_t decode_data_index_{0};
+  size_t decode_trailers_index_{0};
+  size_t decode_metadata_index_{0};
+  // For encode operations, we track from the end in reverse order.
+  size_t encode_1xx_headers_index_{0};
+  size_t encode_headers_index_{0};
+  size_t encode_data_index_{0};
+  size_t encode_trailers_index_{0};
+  size_t encode_metadata_index_{0};
 };
 
 class Filter : public Http::StreamFilter,


### PR DESCRIPTION
## Description

This PR fixes the behavior of the Composite Filter to not stop the filter chain in scenarios where the first filter returns stop at the `decodeHeaders()`. We track the indices at each operation and would correctly resume the chain with this change.

---

**Commit Message:** composite: make next set of filters to resume correctly when a filter stops
**Additional Description:** Fixes the behavior of the Composite Filter to not stop the filter chain in scenarios where the first filter returns stop at the `decodeHeaders()`.
**Risk Level:** Low
**Testing:** Added Tests
**Docs Changes:** N/A
**Release Notes:** N/A