### PR TITLE
lua: deprecate connection():ssl() use streamInfo()

### DIFF
--- a/docs/root/configuration/http/http_filters/lua_filter.rst
+++ b/docs/root/configuration/http/http_filters/lua_filter.rst
@@ -1355,6 +1355,20 @@ Connection object API
 ``ssl()``
 ^^^^^^^^^
 
+.. warning::
+
+  **DEPRECATED**: This method is deprecated and will be removed in a future release.
+  Use ``streamInfo():downstreamSslConnection()`` instead:
+
+  .. code-block:: lua
+
+    -- Preferred approach:
+    if handle:streamInfo():downstreamSslConnection() == nil then
+      print("plain")
+    else
+      print("secure")
+    end
+
 .. code-block:: lua
 
   if connection:ssl() == nil then

--- a/source/extensions/filters/common/lua/wrappers.cc
+++ b/source/extensions/filters/common/lua/wrappers.cc
@@ -403,7 +403,10 @@ int SslConnectionWrapper::luaTlsVersion(lua_State* state) {
 }
 
 int ConnectionWrapper::luaSsl(lua_State* state) {
-  const auto& ssl = connection_->ssl();
+  ENVOY_LOG_MISC(warn, "connection():ssl() is deprecated and will be removed in a future release. "
+                       "Use streamInfo():downstreamSslConnection() instead.");
+
+  const auto& ssl = stream_info_.downstreamAddressProvider().sslConnection();
   if (ssl != nullptr) {
     if (ssl_connection_wrapper_.get() != nullptr) {
       ssl_connection_wrapper_.pushStack();

--- a/source/extensions/filters/http/lua/lua_filter.cc
+++ b/source/extensions/filters/http/lua/lua_filter.cc
@@ -687,7 +687,7 @@ int StreamHandleWrapper::luaConnection(lua_State* state) {
     connection_wrapper_.pushStack();
   } else {
     connection_wrapper_.reset(
-        Filters::Common::Lua::ConnectionWrapper::create(state, callbacks_.connection()), true);
+        Filters::Common::Lua::ConnectionWrapper::create(state, callbacks_.streamInfo()), true);
   }
   return 1;
 }

--- a/test/extensions/filters/http/lua/lua_filter_test.cc
+++ b/test/extensions/filters/http/lua/lua_filter_test.cc
@@ -106,9 +106,8 @@ public:
 
   void setupSecureConnection(const bool secure) {
     ssl_ = std::make_shared<NiceMock<Envoy::Ssl::MockConnectionInfo>>();
-    EXPECT_CALL(decoder_callbacks_, connection())
-        .WillOnce(Return(OptRef<const Network::Connection>{connection_}));
-    EXPECT_CALL(Const(connection_), ssl()).WillOnce(Return(secure ? ssl_ : nullptr));
+    EXPECT_CALL(decoder_callbacks_, streamInfo()).WillRepeatedly(ReturnRef(stream_info_));
+    stream_info_.downstream_connection_info_provider_->setSslConnection(secure ? ssl_ : nullptr);
   }
 
   void setupMetadata(const std::string& yaml) {
@@ -2773,6 +2772,7 @@ TEST_F(LuaHttpFilterTest, SetGetDynamicMetadata) {
 }
 
 // Check the connection.
+// Note: connection():ssl() is deprecated. Use streamInfo():downstreamSslConnection() instead.
 TEST_F(LuaHttpFilterTest, CheckConnection) {
   const std::string SCRIPT{R"EOF(
     function envoy_on_request(request_handle)


### PR DESCRIPTION
Commit Message:
Migrate connection():ssl() to use StreamInfo internally instead of the deprecated Network::Connection::ssl(). Add deprecation warning and update docs. The deprecated method will be removed in a future release.
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
