### PR TITLE
lua: hoist LowerCaseString out of inner loop in buildHeadersFromTable

### DIFF
--- a/source/extensions/filters/http/lua/lua_filter.cc
+++ b/source/extensions/filters/http/lua/lua_filter.cc
@@ -140,18 +140,19 @@ void buildHeadersFromTable(Http::HeaderMap& headers, lua_State* state, int table
   while (lua_next(state, table_index) != 0) {
     // Uses 'key' (at index -2) and 'value' (at index -1).
     const char* key = luaL_checkstring(state, -2);
+    const Http::LowerCaseString lower_key(key);
     // Check if the current value is a table, we iterate through the table and add each element of
     // it as a header entry value for the current key.
     if (lua_istable(state, -1)) {
       lua_pushnil(state);
       while (lua_next(state, -2) != 0) {
         const char* value = luaL_checkstring(state, -1);
-        headers.addCopy(Http::LowerCaseString(key), value);
+        headers.addCopy(lower_key, value);
         lua_pop(state, 1);
       }
     } else {
       const char* value = luaL_checkstring(state, -1);
-      headers.addCopy(Http::LowerCaseString(key), value);
+      headers.addCopy(lower_key, value);
     }
     // Removes 'value'; keeps 'key' for next iteration. This is the input for lua_next() so that
     // it can push the next key/value pair onto the stack.


### PR DESCRIPTION
Commit Message:
Avoid redundant LowerCaseString construction when processing multi-valued headers in Lua httpCall().
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
