### PR TITLE
dynamic_modules: create RUST bindings for remaining network filter methods

### DIFF
--- a/source/extensions/dynamic_modules/sdk/rust/src/lib_test.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/lib_test.rs
@@ -236,3 +236,207 @@ fn test_envoy_dynamic_module_on_http_filter_callbacks() {
   assert!(ON_RESPONSE_TRAILERS_CALLED.load(std::sync::atomic::Ordering::SeqCst));
   assert!(ON_STREAM_COMPLETE_CALLED.load(std::sync::atomic::Ordering::SeqCst));
 }
+
+// =============================================================================
+// Network Filter Tests
+// =============================================================================
+
+#[test]
+fn test_envoy_dynamic_module_on_network_filter_config_new_impl() {
+  struct TestNetworkFilterConfig;
+  impl<ENF: EnvoyNetworkFilter> NetworkFilterConfig<ENF> for TestNetworkFilterConfig {
+    fn new_network_filter(&self, _envoy: &mut ENF) -> Box<dyn NetworkFilter<ENF>> {
+      Box::new(TestNetworkFilter)
+    }
+  }
+
+  struct TestNetworkFilter;
+  impl<ENF: EnvoyNetworkFilter> NetworkFilter<ENF> for TestNetworkFilter {}
+
+  let mut envoy_filter_config = EnvoyNetworkFilterConfigImpl {
+    raw: std::ptr::null_mut(),
+  };
+  let mut new_fn: NewNetworkFilterConfigFunction<
+    EnvoyNetworkFilterConfigImpl,
+    EnvoyNetworkFilterImpl,
+  > = |_, _, _| Some(Box::new(TestNetworkFilterConfig));
+  let result = init_network_filter_config(
+    &mut envoy_filter_config,
+    "test_name",
+    b"test_config",
+    &new_fn,
+  );
+  assert!(!result.is_null());
+
+  unsafe {
+    envoy_dynamic_module_on_network_filter_config_destroy(result);
+  }
+
+  // None should result in null pointer.
+  new_fn = |_, _, _| None;
+  let result = init_network_filter_config(
+    &mut envoy_filter_config,
+    "test_name",
+    b"test_config",
+    &new_fn,
+  );
+  assert!(result.is_null());
+}
+
+#[test]
+fn test_envoy_dynamic_module_on_network_filter_config_destroy() {
+  static DROPPED: AtomicBool = AtomicBool::new(false);
+  struct TestNetworkFilterConfig;
+  impl<ENF: EnvoyNetworkFilter> NetworkFilterConfig<ENF> for TestNetworkFilterConfig {
+    fn new_network_filter(&self, _envoy: &mut ENF) -> Box<dyn NetworkFilter<ENF>> {
+      Box::new(TestNetworkFilter)
+    }
+  }
+  impl Drop for TestNetworkFilterConfig {
+    fn drop(&mut self) {
+      DROPPED.store(true, std::sync::atomic::Ordering::SeqCst);
+    }
+  }
+
+  struct TestNetworkFilter;
+  impl<ENF: EnvoyNetworkFilter> NetworkFilter<ENF> for TestNetworkFilter {}
+
+  let new_fn: NewNetworkFilterConfigFunction<EnvoyNetworkFilterConfigImpl, EnvoyNetworkFilterImpl> =
+    |_, _, _| Some(Box::new(TestNetworkFilterConfig));
+  let config_ptr = init_network_filter_config(
+    &mut EnvoyNetworkFilterConfigImpl {
+      raw: std::ptr::null_mut(),
+    },
+    "test_name",
+    b"test_config",
+    &new_fn,
+  );
+
+  unsafe {
+    envoy_dynamic_module_on_network_filter_config_destroy(config_ptr);
+  }
+  // Now that the drop is called, DROPPED must be set to true.
+  assert!(DROPPED.load(std::sync::atomic::Ordering::SeqCst));
+}
+
+#[test]
+fn test_envoy_dynamic_module_on_network_filter_new_destroy() {
+  static DROPPED: AtomicBool = AtomicBool::new(false);
+  struct TestNetworkFilterConfig;
+  impl<ENF: EnvoyNetworkFilter> NetworkFilterConfig<ENF> for TestNetworkFilterConfig {
+    fn new_network_filter(&self, _envoy: &mut ENF) -> Box<dyn NetworkFilter<ENF>> {
+      Box::new(TestNetworkFilter)
+    }
+  }
+
+  struct TestNetworkFilter;
+  impl<ENF: EnvoyNetworkFilter> NetworkFilter<ENF> for TestNetworkFilter {}
+  impl Drop for TestNetworkFilter {
+    fn drop(&mut self) {
+      DROPPED.store(true, std::sync::atomic::Ordering::SeqCst);
+    }
+  }
+
+  let mut filter_config = TestNetworkFilterConfig;
+  let result = envoy_dynamic_module_on_network_filter_new_impl(
+    &mut EnvoyNetworkFilterImpl {
+      raw: std::ptr::null_mut(),
+    },
+    &mut filter_config,
+  );
+  assert!(!result.is_null());
+
+  unsafe {
+    envoy_dynamic_module_on_network_filter_destroy(result);
+  }
+
+  assert!(DROPPED.load(std::sync::atomic::Ordering::SeqCst));
+}
+
+#[test]
+fn test_envoy_dynamic_module_on_network_filter_callbacks() {
+  struct TestNetworkFilterConfig;
+  impl<ENF: EnvoyNetworkFilter> NetworkFilterConfig<ENF> for TestNetworkFilterConfig {
+    fn new_network_filter(&self, _envoy: &mut ENF) -> Box<dyn NetworkFilter<ENF>> {
+      Box::new(TestNetworkFilter)
+    }
+  }
+
+  static ON_NEW_CONNECTION_CALLED: AtomicBool = AtomicBool::new(false);
+  static ON_READ_CALLED: AtomicBool = AtomicBool::new(false);
+  static ON_WRITE_CALLED: AtomicBool = AtomicBool::new(false);
+  static ON_EVENT_CALLED: AtomicBool = AtomicBool::new(false);
+
+  struct TestNetworkFilter;
+  impl<ENF: EnvoyNetworkFilter> NetworkFilter<ENF> for TestNetworkFilter {
+    fn on_new_connection(
+      &mut self,
+      _envoy_filter: &mut ENF,
+    ) -> abi::envoy_dynamic_module_type_on_network_filter_data_status {
+      ON_NEW_CONNECTION_CALLED.store(true, std::sync::atomic::Ordering::SeqCst);
+      abi::envoy_dynamic_module_type_on_network_filter_data_status::Continue
+    }
+
+    fn on_read(
+      &mut self,
+      _envoy_filter: &mut ENF,
+      _data_length: usize,
+      _end_stream: bool,
+    ) -> abi::envoy_dynamic_module_type_on_network_filter_data_status {
+      ON_READ_CALLED.store(true, std::sync::atomic::Ordering::SeqCst);
+      abi::envoy_dynamic_module_type_on_network_filter_data_status::Continue
+    }
+
+    fn on_write(
+      &mut self,
+      _envoy_filter: &mut ENF,
+      _data_length: usize,
+      _end_stream: bool,
+    ) -> abi::envoy_dynamic_module_type_on_network_filter_data_status {
+      ON_WRITE_CALLED.store(true, std::sync::atomic::Ordering::SeqCst);
+      abi::envoy_dynamic_module_type_on_network_filter_data_status::Continue
+    }
+
+    fn on_event(
+      &mut self,
+      _envoy_filter: &mut ENF,
+      _event: abi::envoy_dynamic_module_type_network_connection_event,
+    ) {
+      ON_EVENT_CALLED.store(true, std::sync::atomic::Ordering::SeqCst);
+    }
+  }
+
+  let mut filter_config = TestNetworkFilterConfig;
+  let filter = envoy_dynamic_module_on_network_filter_new_impl(
+    &mut EnvoyNetworkFilterImpl {
+      raw: std::ptr::null_mut(),
+    },
+    &mut filter_config,
+  );
+
+  unsafe {
+    assert_eq!(
+      envoy_dynamic_module_on_network_filter_new_connection(std::ptr::null_mut(), filter),
+      abi::envoy_dynamic_module_type_on_network_filter_data_status::Continue
+    );
+    assert_eq!(
+      envoy_dynamic_module_on_network_filter_read(std::ptr::null_mut(), filter, 100, false),
+      abi::envoy_dynamic_module_type_on_network_filter_data_status::Continue
+    );
+    assert_eq!(
+      envoy_dynamic_module_on_network_filter_write(std::ptr::null_mut(), filter, 100, false),
+      abi::envoy_dynamic_module_type_on_network_filter_data_status::Continue
+    );
+    envoy_dynamic_module_on_network_filter_event(
+      std::ptr::null_mut(),
+      filter,
+      abi::envoy_dynamic_module_type_network_connection_event::RemoteClose,
+    );
+    envoy_dynamic_module_on_network_filter_destroy(filter);
+  }
+
+  assert!(ON_NEW_CONNECTION_CALLED.load(std::sync::atomic::Ordering::SeqCst));
+  assert!(ON_READ_CALLED.load(std::sync::atomic::Ordering::SeqCst));
+  assert!(ON_WRITE_CALLED.load(std::sync::atomic::Ordering::SeqCst));
+  assert!(ON_EVENT_CALLED.load(std::sync::atomic::Ordering::SeqCst));
+}


### PR DESCRIPTION
## Description

This PR exposes RUST bindings for Dynamic Modules Network Filter as there were some new methods which we added to the ABI but missed exposing RUST bindings for.

---

**Commit Message:** dynamic_modules: create RUST bindings for remaining network filter methods
**Additional Description:** Exposes RUST bindings for Dynamic Modules Network Filter.
**Risk Level:** Low
**Testing:** Added Tests
**Docs Changes:** N/A
**Release Notes:** N/A