### PR TITLE
ext_proc: Remove extra spaces from proto comments causing git-push failure.

### DIFF
--- a/api/envoy/extensions/filters/http/ext_proc/v3/processing_mode.proto
+++ b/api/envoy/extensions/filters/http/ext_proc/v3/processing_mode.proto
@@ -122,7 +122,7 @@ message ProcessingMode {
     // :ref:`StreamedBodyResponse <envoy_v3_api_msg_service.ext_proc.v3.StreamedBodyResponse>`
     // field, but the number of messages sent by the ext_proc server
     // does not need to equal the number of messages sent by the data
-    // plane.  This allows the ext_proc server to change the number of
+    // plane. This allows the ext_proc server to change the number of
     // messages sent on the stream.
     // In this mode, the client will send body and trailers to the server as
     // they arrive.

--- a/api/envoy/service/ext_proc/v3/external_processor.proto
+++ b/api/envoy/service/ext_proc/v3/external_processor.proto
@@ -227,10 +227,10 @@ message ProcessingResponse {
   // [#not-implemented-hide:]
   // Used only in ``FULL_DUPLEX_STREAMED`` and ``GRPC`` body send modes.
   // Instructs the data plane to stop sending body data and to send a
-  // half-close on the ext_proc stream.  The ext_proc server should then echo
+  // half-close on the ext_proc stream. The ext_proc server should then echo
   // back all subsequent body contents as-is until it sees the client's
   // half-close, at which point the ext_proc server can terminate the stream
-  // with an OK status.  This provides a safe way for the ext_proc server
+  // with an OK status. This provides a safe way for the ext_proc server
   // to indicate that it does not need to see the rest of the stream;
   // without this, the ext_proc server could not terminate the stream
   // early, because it would wind up dropping any body contents that the


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message: Remove extra spaces from proto comments causing git-push failure.
Additional Description: After pulling latest main, git-push started failing with this error
```
ERROR: From ./api/envoy/extensions/filters/http/ext_proc/v3/processing_mode.proto
ERROR: ./api/envoy/extensions/filters/http/ext_proc/v3/processing_mode.proto:125: over-enthusiastic spaces
ERROR: From ./api/envoy/service/ext_proc/v3/external_processor.proto
ERROR: ./api/envoy/service/ext_proc/v3/external_processor.proto:230: over-enthusiastic spaces
ERROR: ./api/envoy/service/ext_proc/v3/external_processor.proto:233: over-enthusiastic spaces
```
I've removed the culprit extra-spaces from the proto. This was possibly caused by merging #38753

Risk Level: None. Only proto comment changes.
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
