### PR TITLE
http: optimize MultiStream container from std::list to std::vector

### DIFF
--- a/source/common/http/muxdemux.cc
+++ b/source/common/http/muxdemux.cc
@@ -167,6 +167,7 @@ MuxDemux::multicast(const AsyncClient::StreamOptions& options,
   }
 
   auto multistream = std::unique_ptr<MultiStream>(new MultiStream(shared_from_this()));
+  multistream->callbacks_facades_.reserve(callbacks.size());
   for (const Callbacks& callback : callbacks) {
     // Use per-backend options if provided, otherwise fall back to the default options.
     const AsyncClient::StreamOptions& effective_options =

--- a/source/common/http/muxdemux.h
+++ b/source/common/http/muxdemux.h
@@ -3,9 +3,9 @@
 #include <cstddef>
 #include <cstdint>
 #include <iterator>
-#include <list>
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "envoy/buffer/buffer.h"
 #include "envoy/http/async_client.h"
@@ -54,7 +54,7 @@ public:
     using element_type = AsyncClient::Stream*;
     using pointer = element_type*;
     using reference = element_type&;
-    explicit StreamIterator(std::list<CallbacksFacade>::iterator it) : it(it) {}
+    explicit StreamIterator(std::vector<CallbacksFacade>::iterator it) : it(it) {}
     StreamIterator() = default;
 
     reference operator*() { return it->stream_; }
@@ -72,7 +72,7 @@ public:
     }
     bool operator==(const StreamIterator& other) const { return it == other.it; }
 
-    std::list<CallbacksFacade>::iterator it;
+    std::vector<CallbacksFacade>::iterator it;
   };
 
   // Iterator over underlying Http::AsyncClient::Stream objects
@@ -102,7 +102,7 @@ private:
 
   uint32_t active_streams_{0};
   std::weak_ptr<MuxDemux> muxdemux_;
-  std::list<CallbacksFacade> callbacks_facades_;
+  std::vector<CallbacksFacade> callbacks_facades_;
 };
 
 // MuxDemux allows sending the same or different requests to multiple destinations.


### PR DESCRIPTION
Commit Message:
Replace std::list<CallbacksFacade> with std::vector<CallbacksFacade> in
MultiStream.

The current API never removes elements from the middle of the container.
Streams are added via emplace_back(), and completed/reset streams are
marked idle (is_idle_ = true) rather than removed. Elements are only
removed from the back in error paths.

std::list incurs ~16 bytes overhead per element for prev/next pointers
plus per-node heap allocation overhead.

std::vector provides contiguous memory allocation, improving cache
locality during iteration in multicastHeaders/Data/Trailers methods,
and reduces heap allocations from O(n) to O(1).

Additionally, reserve() is called with the known callback count before
adding streams, ensuring a single allocation with no reallocation
copies during stream setup.

Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
