### PR TITLE
filter chain refactoring: add more context for FilterChainFactoryCallbacks

### DIFF
--- a/envoy/http/filter.h
+++ b/envoy/http/filter.h
@@ -1276,6 +1276,47 @@ public:
    * @param return the worker thread's dispatcher.
    */
   virtual Event::Dispatcher& dispatcher() PURE;
+
+  /**
+   * @return absl::string_view the latest configured name of the filter in the filter chain.
+   */
+  virtual absl::string_view filterConfigName() const PURE;
+
+  /**
+   * Set the configured name of the filter in the filter chain. This name is used to identify
+   * the filter self and look up filter-specific configuration in various places (e.g., route
+   * configuration).
+   *
+   * NOTE: This method should be called for each filter before adding the filter to the filter
+   * chain via addStreamDecoderFilter(), addStreamEncoderFilter(), or addStreamFilter().
+   *
+   * @param name the name to be used for looking up filter-specific configuration.
+   */
+  virtual void setFilterConfigName(absl::string_view name) PURE;
+
+  /**
+   * @return OptRef<const Router::Route> the route selected for this stream, if any.
+   */
+  virtual OptRef<const Router::Route> route() const PURE;
+
+  /**
+   * Check whether the filter chain is disabled for this stream.
+   * @param name the name of the filter chain to check.
+   *
+   * @return absl::optional<bool> whether the filter chain is disabled for this stream.
+   */
+  virtual absl::optional<bool> filterDisabled(absl::string_view name) const PURE;
+
+  /**
+   * @return const StreamInfo::StreamInfo& the stream info for this stream.
+   */
+  virtual const StreamInfo::StreamInfo& streamInfo() const PURE;
+
+  /**
+   * @return RequestHeaderMapOptRef the request headers for this stream.
+   */
+  virtual RequestHeaderMapOptRef requestHeaders() const PURE;
 };
+
 } // namespace Http
 } // namespace Envoy

--- a/source/common/http/filter_chain_helper.cc
+++ b/source/common/http/filter_chain_helper.cc
@@ -16,19 +16,21 @@ namespace Envoy {
 namespace Http {
 
 void FilterChainUtility::createFilterChainForFactories(
-    Http::FilterChainManager& manager, const FilterChainOptions& options,
-    const FilterFactoriesList& filter_factories) {
+    Http::FilterChainFactoryCallbacks& callbacks, const FilterFactoriesList& filter_factories) {
   bool added_missing_config_filter = false;
+
   for (const auto& filter_config_provider : filter_factories) {
+    absl::string_view filter_config_name = filter_config_provider.provider->name();
     // If this filter is disabled explicitly, skip trying to create it.
-    if (options.filterDisabled(filter_config_provider.provider->name())
-            .value_or(filter_config_provider.disabled)) {
+    if (callbacks.filterDisabled(filter_config_name).value_or(filter_config_provider.disabled)) {
       continue;
     }
 
     auto config = filter_config_provider.provider->config();
+
     if (config.has_value()) {
-      manager.applyFilterFactoryCb({filter_config_provider.provider->name()}, config.ref());
+      callbacks.setFilterConfigName(filter_config_name);
+      config.value()(callbacks);
       continue;
     }
 
@@ -36,7 +38,8 @@ void FilterChainUtility::createFilterChainForFactories(
     if (!added_missing_config_filter) {
       ENVOY_LOG(trace, "Missing filter config for a provider {}",
                 filter_config_provider.provider->name());
-      manager.applyFilterFactoryCb({}, MissingConfigFilterFactory);
+      callbacks.setFilterConfigName("");
+      MissingConfigFilterFactory(callbacks);
       added_missing_config_filter = true;
     } else {
       ENVOY_LOG(trace, "Provider {} missing a filter config",

--- a/source/common/http/filter_chain_helper.h
+++ b/source/common/http/filter_chain_helper.h
@@ -55,8 +55,7 @@ public:
   using FiltersList = Protobuf::RepeatedPtrField<
       envoy::extensions::filters::network::http_connection_manager::v3::HttpFilter>;
 
-  static void createFilterChainForFactories(Http::FilterChainManager& manager,
-                                            const FilterChainOptions& options,
+  static void createFilterChainForFactories(Http::FilterChainFactoryCallbacks& callbacks,
                                             const FilterFactoriesList& filter_factories);
 
   static absl::Status checkUpstreamHttpFiltersList(const FiltersList& filters);

--- a/source/common/http/filter_manager.cc
+++ b/source/common/http/filter_manager.cc
@@ -551,11 +551,6 @@ void ActiveStreamDecoderFilter::requestDataTooLarge() {
   }
 }
 
-void FilterManager::applyFilterFactoryCb(FilterContext context, FilterFactoryCb& factory) {
-  FilterChainFactoryCallbacksImpl callbacks(*this, context);
-  factory(callbacks);
-}
-
 void FilterManager::maybeContinueDecoding(StreamDecoderFilters::Iterator continue_data_entry) {
   if (continue_data_entry != decoder_filters_.end()) {
     // We use the continueDecoding() code since it will correctly handle not calling
@@ -1666,7 +1661,7 @@ void FilterManager::contextOnContinue(ScopeTrackedObjectStack& tracked_object_st
 
 FilterManager::UpgradeResult
 FilterManager::createUpgradeFilterChain(const FilterChainFactory& filter_chain_factory,
-                                        const FilterChainOptionsImpl& options) {
+                                        FilterChainFactoryCallbacksImpl& callbacks) {
   const HeaderEntry* upgrade = nullptr;
   if (filter_manager_callbacks_.requestHeaders()) {
     upgrade = filter_manager_callbacks_.requestHeaders()->Upgrade();
@@ -1684,7 +1679,7 @@ FilterManager::createUpgradeFilterChain(const FilterChainFactory& filter_chain_f
 
   const Router::RouteEntry::UpgradeMap* upgrade_map = filter_manager_callbacks_.upgradeMap();
   return filter_chain_factory.createUpgradeFilterChain(upgrade->value().getStringView(),
-                                                       upgrade_map, *this, options)
+                                                       upgrade_map, callbacks)
              ? UpgradeResult::UpgradeAccepted
              : UpgradeResult::UpgradeRejected;
 }
@@ -1711,13 +1706,13 @@ FilterManager::createFilterChain(const FilterChainFactory& filter_chain_factory)
   OptRef<DownstreamStreamFilterCallbacks> downstream_callbacks =
       filter_manager_callbacks_.downstreamCallbacks();
 
-  FilterChainOptionsImpl options(streamInfo().route());
+  FilterChainFactoryCallbacksImpl callbacks(*this);
 
   UpgradeResult upgrade = UpgradeResult::UpgradeUnneeded;
 
   // Only try the upgrade filter chain for downstream filter chains.
   if (downstream_callbacks.has_value()) {
-    upgrade = createUpgradeFilterChain(filter_chain_factory, options);
+    upgrade = createUpgradeFilterChain(filter_chain_factory, callbacks);
     if (upgrade == UpgradeResult::UpgradeAccepted) {
       // Upgrade filter chain is created. Return the result directly.
       state_.create_chain_result_ = CreateChainResult(true, upgrade);
@@ -1728,7 +1723,7 @@ FilterManager::createFilterChain(const FilterChainFactory& filter_chain_factory)
   }
 
   state_.create_chain_result_ =
-      CreateChainResult(filter_chain_factory.createFilterChain(*this, options), upgrade);
+      CreateChainResult(filter_chain_factory.createFilterChain(callbacks), upgrade);
   return state_.create_chain_result_;
 }
 

--- a/source/common/http/filter_manager.h
+++ b/source/common/http/filter_manager.h
@@ -108,9 +108,9 @@ struct StreamEncoderFilters {
  */
 struct ActiveStreamFilterBase : public virtual StreamFilterCallbacks,
                                 Logger::Loggable<Logger::Id::http> {
-  ActiveStreamFilterBase(FilterManager& parent, FilterContext filter_context)
+  ActiveStreamFilterBase(FilterManager& parent, absl::string_view filter_config_name)
       : parent_(parent), iteration_state_(IterationState::Continue),
-        filter_context_(std::move(filter_context)) {}
+        filter_context_(filter_config_name) {}
 
   // Functions in the following block are called after the filter finishes processing
   // corresponding data. Those functions handle state updates and data storage (if needed)
@@ -238,8 +238,8 @@ struct ActiveStreamFilterBase : public virtual StreamFilterCallbacks,
 struct ActiveStreamDecoderFilter : public ActiveStreamFilterBase,
                                    public StreamDecoderFilterCallbacks {
   ActiveStreamDecoderFilter(FilterManager& parent, StreamDecoderFilterSharedPtr filter,
-                            FilterContext filter_context)
-      : ActiveStreamFilterBase(parent, std::move(filter_context)), handle_(std::move(filter)) {
+                            absl::string_view filter_config_name)
+      : ActiveStreamFilterBase(parent, filter_config_name), handle_(std::move(filter)) {
     handle_->setDecoderFilterCallbacks(*this);
   }
 
@@ -330,8 +330,8 @@ struct ActiveStreamDecoderFilter : public ActiveStreamFilterBase,
 struct ActiveStreamEncoderFilter : public ActiveStreamFilterBase,
                                    public StreamEncoderFilterCallbacks {
   ActiveStreamEncoderFilter(FilterManager& parent, StreamEncoderFilterSharedPtr filter,
-                            FilterContext filter_context)
-      : ActiveStreamFilterBase(parent, std::move(filter_context)), handle_(std::move(filter)) {
+                            absl::string_view filter_config_name)
+      : ActiveStreamFilterBase(parent, filter_config_name), handle_(std::move(filter)) {
     handle_->setEncoderFilterCallbacks(*this);
   }
 
@@ -678,9 +678,7 @@ private:
  * FilterManager manages decoding a request through a series of decoding filter and the encoding
  * of the resulting response.
  */
-class FilterManager : public ScopeTrackedObject,
-                      public FilterChainManager,
-                      Logger::Loggable<Logger::Id::http> {
+class FilterManager : public ScopeTrackedObject, Logger::Loggable<Logger::Id::http> {
 public:
   FilterManager(FilterManagerCallbacks& filter_manager_callbacks, Event::Dispatcher& dispatcher,
                 OptRef<const Network::Connection> connection, uint64_t stream_id,
@@ -711,9 +709,6 @@ public:
     DUMP_DETAILS(filter_manager_callbacks_.responseTrailers());
     DUMP_DETAILS(&streamInfo());
   }
-
-  // FilterChainManager
-  void applyFilterFactoryCb(FilterContext context, FilterFactoryCb& factory) override;
 
   void log(const Formatter::Context log_context) {
     for (const auto& log_handler : access_log_handlers_) {
@@ -987,30 +982,30 @@ private:
   friend class DownstreamFilterManager;
   class FilterChainFactoryCallbacksImpl : public Http::FilterChainFactoryCallbacks {
   public:
-    FilterChainFactoryCallbacksImpl(FilterManager& manager, const Http::FilterContext& context)
-        : manager_(manager), context_(context) {}
+    FilterChainFactoryCallbacksImpl(FilterManager& manager)
+        : manager_(manager), route_(manager_.streamInfo().route()) {}
 
     void addStreamDecoderFilter(Http::StreamDecoderFilterSharedPtr filter) override {
       manager_.filters_.push_back(filter.get());
 
-      manager_.decoder_filters_.entries_.emplace_back(
-          std::make_unique<ActiveStreamDecoderFilter>(manager_, std::move(filter), context_));
+      manager_.decoder_filters_.entries_.emplace_back(std::make_unique<ActiveStreamDecoderFilter>(
+          manager_, std::move(filter), filter_config_name_));
     }
 
     void addStreamEncoderFilter(Http::StreamEncoderFilterSharedPtr filter) override {
       manager_.filters_.push_back(filter.get());
 
-      manager_.encoder_filters_.entries_.emplace_back(
-          std::make_unique<ActiveStreamEncoderFilter>(manager_, std::move(filter), context_));
+      manager_.encoder_filters_.entries_.emplace_back(std::make_unique<ActiveStreamEncoderFilter>(
+          manager_, std::move(filter), filter_config_name_));
     }
 
     void addStreamFilter(Http::StreamFilterSharedPtr filter) override {
       manager_.filters_.push_back(filter.get());
 
       manager_.decoder_filters_.entries_.emplace_back(
-          std::make_unique<ActiveStreamDecoderFilter>(manager_, filter, context_));
-      manager_.encoder_filters_.entries_.emplace_back(
-          std::make_unique<ActiveStreamEncoderFilter>(manager_, std::move(filter), context_));
+          std::make_unique<ActiveStreamDecoderFilter>(manager_, filter, filter_config_name_));
+      manager_.encoder_filters_.entries_.emplace_back(std::make_unique<ActiveStreamEncoderFilter>(
+          manager_, std::move(filter), filter_config_name_));
     }
 
     void addAccessLogHandler(AccessLog::InstanceSharedPtr handler) override {
@@ -1019,28 +1014,33 @@ private:
 
     Event::Dispatcher& dispatcher() override { return manager_.dispatcher_; }
 
-  private:
-    FilterManager& manager_;
-    const Http::FilterContext& context_;
-  };
+    absl::string_view filterConfigName() const override { return filter_config_name_; }
 
-  class FilterChainOptionsImpl : public FilterChainOptions {
-  public:
-    FilterChainOptionsImpl(Router::RouteConstSharedPtr route) : route_(std::move(route)) {}
+    void setFilterConfigName(absl::string_view name) override { filter_config_name_ = name; }
+
+    OptRef<const Router::Route> route() const override { return makeOptRefFromPtr(route_.get()); }
 
     absl::optional<bool> filterDisabled(absl::string_view config_name) const override {
       return route_ != nullptr ? route_->filterDisabled(config_name) : absl::nullopt;
     }
 
+    const StreamInfo::StreamInfo& streamInfo() const override { return manager_.streamInfo(); }
+
+    RequestHeaderMapOptRef requestHeaders() const override {
+      return manager_.filter_manager_callbacks_.requestHeaders();
+    }
+
   private:
-    const Router::RouteConstSharedPtr route_;
+    FilterManager& manager_;
+    absl::string_view filter_config_name_;
+    Router::RouteConstSharedPtr route_;
   };
 
   // Indicates which filter to start the iteration with.
   enum class FilterIterationStartState { AlwaysStartFromNext, CanStartFromCurrent };
 
   UpgradeResult createUpgradeFilterChain(const FilterChainFactory& filter_chain_factory,
-                                         const FilterChainOptionsImpl& options);
+                                         FilterChainFactoryCallbacksImpl& callbacks);
 
   // Returns the encoder filter to start iteration with.
   StreamEncoderFilters::Iterator

--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -234,21 +234,19 @@ protected:
                absl::Status& creation_status);
 
 public:
-  bool createFilterChain(
-      Http::FilterChainManager& manager,
-      const Http::FilterChainOptions& options = Http::EmptyFilterChainOptions{}) const override {
+  bool createFilterChain(Http::FilterChainFactoryCallbacks& callbacks) const override {
     // Currently there is no default filter chain, so only_create_if_configured true doesn't make
     // sense.
     if (upstream_http_filter_factories_.empty()) {
       return false;
     }
-    Http::FilterChainUtility::createFilterChainForFactories(manager, options,
+    Http::FilterChainUtility::createFilterChainForFactories(callbacks,
                                                             upstream_http_filter_factories_);
     return true;
   }
 
-  bool createUpgradeFilterChain(absl::string_view, const UpgradeMap*, Http::FilterChainManager&,
-                                const Http::FilterChainOptions&) const override {
+  bool createUpgradeFilterChain(absl::string_view, const UpgradeMap*,
+                                Http::FilterChainFactoryCallbacks&) const override {
     // Upgrade filter chains not yet supported for upstream HTTP filters.
     return false;
   }

--- a/source/common/router/upstream_codec_filter.cc
+++ b/source/common/router/upstream_codec_filter.cc
@@ -266,14 +266,13 @@ public:
           callbacks.addStreamDecoderFilter(std::make_shared<UpstreamCodecFilter>());
         }) {}
 
-  bool createFilterChain(
-      Http::FilterChainManager& manager,
-      const Http::FilterChainOptions& = Http::EmptyFilterChainOptions{}) const override {
-    manager.applyFilterFactoryCb({"envoy.filters.http.upstream_codec"}, factory_);
+  bool createFilterChain(Http::FilterChainFactoryCallbacks& callbacks) const override {
+    callbacks.setFilterConfigName("envoy.filters.http.upstream_codec");
+    factory_(callbacks);
     return true;
   }
-  bool createUpgradeFilterChain(absl::string_view, const UpgradeMap*, Http::FilterChainManager&,
-                                const Http::FilterChainOptions&) const override {
+  bool createUpgradeFilterChain(absl::string_view, const UpgradeMap*,
+                                Http::FilterChainFactoryCallbacks&) const override {
     // Upgrade filter chains not yet supported for upstream HTTP filters.
     return false;
   }

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -951,18 +951,16 @@ public:
   upstreamHttpProtocol(absl::optional<Http::Protocol> downstream_protocol) const override;
 
   // Http::FilterChainFactory
-  bool createFilterChain(Http::FilterChainManager& manager,
-                         const Http::FilterChainOptions& options) const override {
+  bool createFilterChain(Http::FilterChainFactoryCallbacks& callbacks) const override {
     if (http_filter_factories_.empty()) {
       return false;
     }
 
-    Http::FilterChainUtility::createFilterChainForFactories(manager, options,
-                                                            http_filter_factories_);
+    Http::FilterChainUtility::createFilterChainForFactories(callbacks, http_filter_factories_);
     return true;
   }
-  bool createUpgradeFilterChain(absl::string_view, const UpgradeMap*, Http::FilterChainManager&,
-                                const Http::FilterChainOptions&) const override {
+  bool createUpgradeFilterChain(absl::string_view, const UpgradeMap*,
+                                Http::FilterChainFactoryCallbacks&) const override {
     // Upgrade filter chains not yet supported for upstream HTTP filters.
     return false;
   }

--- a/source/extensions/filters/http/composite/factory_wrapper.cc
+++ b/source/extensions/filters/http/composite/factory_wrapper.cc
@@ -57,6 +57,11 @@ void FactoryCallbacksWrapper::addStreamFilter(Http::StreamFilterSharedPtr filter
 void FactoryCallbacksWrapper::addAccessLogHandler(AccessLog::InstanceSharedPtr access_log) {
   access_loggers_.push_back(std::move(access_log));
 }
+
+const StreamInfo::StreamInfo& FactoryCallbacksWrapper::streamInfo() const {
+  return filter_.decoder_callbacks_->streamInfo();
+}
+
 } // namespace Composite
 } // namespace HttpFilters
 } // namespace Extensions

--- a/source/extensions/filters/http/composite/factory_wrapper.h
+++ b/source/extensions/filters/http/composite/factory_wrapper.h
@@ -33,6 +33,12 @@ struct FactoryCallbacksWrapper : public Http::FilterChainFactoryCallbacks {
   void addStreamFilter(Http::StreamFilterSharedPtr filter) override;
   void addAccessLogHandler(AccessLog::InstanceSharedPtr) override;
   Event::Dispatcher& dispatcher() override { return dispatcher_; }
+  absl::string_view filterConfigName() const override { return {}; }
+  void setFilterConfigName(absl::string_view) override {}
+  OptRef<const Router::Route> route() const override { return absl::nullopt; }
+  absl::optional<bool> filterDisabled(absl::string_view) const override { return absl::nullopt; }
+  Http::RequestHeaderMapOptRef requestHeaders() const override { return absl::nullopt; }
+  const StreamInfo::StreamInfo& streamInfo() const override;
 
   Filter& filter_;
   Event::Dispatcher& dispatcher_;

--- a/source/extensions/filters/http/match_delegate/config.cc
+++ b/source/extensions/filters/http/match_delegate/config.cc
@@ -92,6 +92,23 @@ struct DelegatingFactoryCallbacks : public Envoy::Http::FilterChainFactoryCallba
     delegated_callbacks_.addAccessLogHandler(std::move(handler));
   }
 
+  absl::string_view filterConfigName() const override {
+    return delegated_callbacks_.filterConfigName();
+  }
+  void setFilterConfigName(absl::string_view name) override {
+    return delegated_callbacks_.setFilterConfigName(name);
+  }
+  OptRef<const Router::Route> route() const override { return delegated_callbacks_.route(); }
+  absl::optional<bool> filterDisabled(absl::string_view config_name) const override {
+    return delegated_callbacks_.filterDisabled(config_name);
+  }
+  const StreamInfo::StreamInfo& streamInfo() const override {
+    return delegated_callbacks_.streamInfo();
+  }
+  Envoy::Http::RequestHeaderMapOptRef requestHeaders() const override {
+    return delegated_callbacks_.requestHeaders();
+  }
+
   Envoy::Http::FilterChainFactoryCallbacks& delegated_callbacks_;
   Matcher::MatchTreeSharedPtr<Envoy::Http::HttpMatchingData> match_tree_;
 };

--- a/source/extensions/filters/http/match_delegate/config.cc
+++ b/source/extensions/filters/http/match_delegate/config.cc
@@ -67,52 +67,6 @@ private:
   absl::optional<Protobuf::RepeatedPtrField<std::string>> data_input_allowlist_;
 };
 
-struct DelegatingFactoryCallbacks : public Envoy::Http::FilterChainFactoryCallbacks {
-  DelegatingFactoryCallbacks(Envoy::Http::FilterChainFactoryCallbacks& delegated_callbacks,
-                             Matcher::MatchTreeSharedPtr<Envoy::Http::HttpMatchingData> match_tree)
-      : delegated_callbacks_(delegated_callbacks), match_tree_(match_tree) {}
-
-  Event::Dispatcher& dispatcher() override { return delegated_callbacks_.dispatcher(); }
-  void addStreamDecoderFilter(Envoy::Http::StreamDecoderFilterSharedPtr filter) override {
-    auto delegating_filter =
-        std::make_shared<DelegatingStreamFilter>(match_tree_, std::move(filter), nullptr);
-    delegated_callbacks_.addStreamDecoderFilter(std::move(delegating_filter));
-  }
-  void addStreamEncoderFilter(Envoy::Http::StreamEncoderFilterSharedPtr filter) override {
-    auto delegating_filter =
-        std::make_shared<DelegatingStreamFilter>(match_tree_, nullptr, std::move(filter));
-    delegated_callbacks_.addStreamEncoderFilter(std::move(delegating_filter));
-  }
-  void addStreamFilter(Envoy::Http::StreamFilterSharedPtr filter) override {
-    auto delegating_filter = std::make_shared<DelegatingStreamFilter>(match_tree_, filter, filter);
-    delegated_callbacks_.addStreamFilter(std::move(delegating_filter));
-  }
-
-  void addAccessLogHandler(AccessLog::InstanceSharedPtr handler) override {
-    delegated_callbacks_.addAccessLogHandler(std::move(handler));
-  }
-
-  absl::string_view filterConfigName() const override {
-    return delegated_callbacks_.filterConfigName();
-  }
-  void setFilterConfigName(absl::string_view name) override {
-    return delegated_callbacks_.setFilterConfigName(name);
-  }
-  OptRef<const Router::Route> route() const override { return delegated_callbacks_.route(); }
-  absl::optional<bool> filterDisabled(absl::string_view config_name) const override {
-    return delegated_callbacks_.filterDisabled(config_name);
-  }
-  const StreamInfo::StreamInfo& streamInfo() const override {
-    return delegated_callbacks_.streamInfo();
-  }
-  Envoy::Http::RequestHeaderMapOptRef requestHeaders() const override {
-    return delegated_callbacks_.requestHeaders();
-  }
-
-  Envoy::Http::FilterChainFactoryCallbacks& delegated_callbacks_;
-  Matcher::MatchTreeSharedPtr<Envoy::Http::HttpMatchingData> match_tree_;
-};
-
 } // namespace Factory
 
 void DelegatingStreamFilter::FilterMatchState::evaluateMatchTree(
@@ -360,7 +314,7 @@ absl::StatusOr<Envoy::Http::FilterFactoryCb> MatchDelegateConfig::createFilterFa
   }
 
   return [filter_factory, match_tree](Envoy::Http::FilterChainFactoryCallbacks& callbacks) -> void {
-    Factory::DelegatingFactoryCallbacks delegating_callbacks(callbacks, match_tree);
+    DelegatingFactoryCallbacks delegating_callbacks(callbacks, match_tree);
     return filter_factory(delegating_callbacks);
   };
 }

--- a/source/extensions/filters/network/http_connection_manager/config.cc
+++ b/source/extensions/filters/network/http_connection_manager/config.cc
@@ -755,8 +755,8 @@ HttpConnectionManagerConfig::HttpConnectionManagerConfig(
           helper.processFilters(upgrade_config.filters(), name, "http upgrade", *factories),
           creation_status);
       // TODO(auni53): Validate encode dependencies too.
-      auto status = upgrade_dependency_manager.validDecodeDependencies();
-      SET_AND_RETURN_IF_NOT_OK(status, creation_status);
+      SET_AND_RETURN_IF_NOT_OK(upgrade_dependency_manager.validDecodeDependencies(),
+                               creation_status);
 
       upgrade_filter_factories_.emplace(
           std::make_pair(name, FilterConfig{std::move(factories), enabled}));
@@ -808,16 +808,16 @@ Http::ServerConnectionPtr HttpConnectionManagerConfig::createCodec(
   PANIC_DUE_TO_CORRUPT_ENUM;
 }
 
-bool HttpConnectionManagerConfig::createFilterChain(Http::FilterChainManager& manager,
-                                                    const Http::FilterChainOptions& options) const {
-  Http::FilterChainUtility::createFilterChainForFactories(manager, options, filter_factories_);
+bool HttpConnectionManagerConfig::createFilterChain(
+    Http::FilterChainFactoryCallbacks& callbacks) const {
+  Http::FilterChainUtility::createFilterChainForFactories(callbacks, filter_factories_);
   return true;
 }
 
 bool HttpConnectionManagerConfig::createUpgradeFilterChain(
     absl::string_view upgrade_type,
     const Http::FilterChainFactory::UpgradeMap* per_route_upgrade_map,
-    Http::FilterChainManager& callbacks, const Http::FilterChainOptions& options) const {
+    Http::FilterChainFactoryCallbacks& callbacks) const {
   bool route_enabled = false;
   if (per_route_upgrade_map) {
     auto route_it = findUpgradeBoolCaseInsensitive(*per_route_upgrade_map, upgrade_type);
@@ -842,7 +842,7 @@ bool HttpConnectionManagerConfig::createUpgradeFilterChain(
     filters_to_use = it->second.filter_factories.get();
   }
 
-  Http::FilterChainUtility::createFilterChainForFactories(callbacks, options, *filters_to_use);
+  Http::FilterChainUtility::createFilterChainForFactories(callbacks, *filters_to_use);
   return true;
 }
 

--- a/source/extensions/filters/network/http_connection_manager/config.h
+++ b/source/extensions/filters/network/http_connection_manager/config.h
@@ -138,9 +138,7 @@ public:
       FilterConfigProviderManager& filter_config_provider_manager, absl::Status& creation_status);
 
   // Http::FilterChainFactory
-  bool createFilterChain(
-      Http::FilterChainManager& manager,
-      const Http::FilterChainOptions& = Http::EmptyFilterChainOptions{}) const override;
+  bool createFilterChain(Http::FilterChainFactoryCallbacks& callbacks) const override;
   using FilterFactoriesList = Envoy::Http::FilterChainUtility::FilterFactoriesList;
   struct FilterConfig {
     std::unique_ptr<FilterFactoriesList> filter_factories;
@@ -148,8 +146,7 @@ public:
   };
   bool createUpgradeFilterChain(absl::string_view upgrade_type,
                                 const Http::FilterChainFactory::UpgradeMap* per_route_upgrade_map,
-                                Http::FilterChainManager& manager,
-                                const Http::FilterChainOptions& options) const override;
+                                Http::FilterChainFactoryCallbacks& callbacks) const override;
 
   // Http::ConnectionManagerConfig
   const Http::RequestIDExtensionSharedPtr& requestIDExtension() override {
@@ -356,8 +353,8 @@ private:
   const envoy::config::core::v3::HttpProtocolOptions::HeadersWithUnderscoresAction
       headers_with_underscores_action_;
   LocalReply::LocalReplyPtr local_reply_;
-  std::vector<Http::OriginalIPDetectionSharedPtr> original_ip_detection_extensions_{};
-  std::vector<Http::EarlyHeaderMutationPtr> early_header_mutation_extensions_{};
+  std::vector<Http::OriginalIPDetectionSharedPtr> original_ip_detection_extensions_;
+  std::vector<Http::EarlyHeaderMutationPtr> early_header_mutation_extensions_;
 
   // Default idle timeout is 5 minutes if nothing is specified in the HCM config.
   static const uint64_t StreamIdleTimeoutMs = 5 * 60 * 1000;

--- a/source/server/admin/admin.cc
+++ b/source/server/admin/admin.cc
@@ -309,12 +309,9 @@ bool AdminImpl::createNetworkFilterChain(Network::Connection& connection,
   return true;
 }
 
-bool AdminImpl::createFilterChain(Http::FilterChainManager& manager,
-                                  const Http::FilterChainOptions&) const {
-  Http::FilterFactoryCb factory = [this](Http::FilterChainFactoryCallbacks& callbacks) {
-    callbacks.addStreamFilter(std::make_shared<AdminFilter>(*this));
-  };
-  manager.applyFilterFactoryCb({}, factory);
+bool AdminImpl::createFilterChain(Http::FilterChainFactoryCallbacks& callbacks) const {
+  callbacks.setFilterConfigName("");
+  callbacks.addStreamFilter(std::make_shared<AdminFilter>(*this));
   return true;
 }
 

--- a/source/server/admin/admin.h
+++ b/source/server/admin/admin.h
@@ -115,11 +115,9 @@ public:
   bool createQuicListenerFilterChain(Network::QuicListenerFilterManager&) override { return true; }
 
   // Http::FilterChainFactory
-  bool createFilterChain(Http::FilterChainManager& manager,
-                         const Http::FilterChainOptions&) const override;
+  bool createFilterChain(Http::FilterChainFactoryCallbacks& callbacks) const override;
   bool createUpgradeFilterChain(absl::string_view, const Http::FilterChainFactory::UpgradeMap*,
-                                Http::FilterChainManager&,
-                                const Http::FilterChainOptions&) const override {
+                                Http::FilterChainFactoryCallbacks&) const override {
     return false;
   }
 
@@ -511,9 +509,9 @@ private:
   AdminListenerPtr listener_;
   const AdminInternalAddressConfig internal_address_config_;
   const LocalReply::LocalReplyPtr local_reply_;
-  const std::vector<Http::OriginalIPDetectionSharedPtr> detection_extensions_{};
-  const std::vector<Http::EarlyHeaderMutationPtr> early_header_mutations_{};
-  const absl::optional<std::string> scheme_{};
+  const std::vector<Http::OriginalIPDetectionSharedPtr> detection_extensions_;
+  const std::vector<Http::EarlyHeaderMutationPtr> early_header_mutations_;
+  const absl::optional<std::string> scheme_;
   const bool scheme_match_upstream_ = false;
   const bool ignore_global_conn_limit_;
   std::unique_ptr<HttpConnectionManagerProto::ProxyStatusConfig> proxy_status_config_;

--- a/test/common/common/execution_context_test.cc
+++ b/test/common/common/execution_context_test.cc
@@ -82,7 +82,7 @@ public:
 
   testing::NiceMock<StreamInfo::MockStreamInfo> stream_info_;
   testing::NiceMock<MockScopeTrackedObject> tracked_object_;
-  std::shared_ptr<TestExecutionContext> context_{};
+  std::shared_ptr<TestExecutionContext> context_;
 };
 
 TEST_F(ExecutionContextTest, NullContext) {

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -47,9 +47,10 @@ TEST_F(HttpConnectionManagerImplTest, HeaderOnlyRequestAndResponse) {
 
   EXPECT_CALL(filter_factory_, createFilterChain(_))
       .Times(2)
-      .WillRepeatedly(Invoke([&](FilterChainManager& manager) -> bool {
+      .WillRepeatedly(Invoke([&](FilterChainFactoryCallbacks& callbacks) -> bool {
         auto factory = createDecoderFilterFactoryCb(filter);
-        manager.applyFilterFactoryCb({}, factory);
+        callbacks.setFilterConfigName("");
+        factory(callbacks);
         return true;
       }));
 
@@ -118,9 +119,10 @@ TEST_F(HttpConnectionManagerImplTest, HandleLifetime) {
 
   EXPECT_CALL(filter_factory_, createFilterChain(_))
       .Times(2)
-      .WillRepeatedly(Invoke([&](FilterChainManager& manager) -> bool {
+      .WillRepeatedly(Invoke([&](FilterChainFactoryCallbacks& callbacks) -> bool {
         auto factory = createDecoderFilterFactoryCb(filter);
-        manager.applyFilterFactoryCb({}, factory);
+        callbacks.setFilterConfigName("");
+        factory(callbacks);
         return true;
       }));
 
@@ -216,9 +218,10 @@ TEST_F(HttpConnectionManagerImplTest, HeaderOnlyRequestAndResponseWithEarlyHeade
 
   EXPECT_CALL(filter_factory_, createFilterChain(_))
       .Times(2)
-      .WillRepeatedly(Invoke([&](FilterChainManager& manager) -> bool {
+      .WillRepeatedly(Invoke([&](FilterChainFactoryCallbacks& callbacks) -> bool {
         auto factory = createDecoderFilterFactoryCb(filter);
-        manager.applyFilterFactoryCb({}, factory);
+        callbacks.setFilterConfigName("");
+        factory(callbacks);
         return true;
       }));
 
@@ -279,9 +282,10 @@ TEST_F(HttpConnectionManagerImplTest, 1xxResponse) {
   EXPECT_CALL(*filter, setDecoderFilterCallbacks(_));
 
   EXPECT_CALL(filter_factory_, createFilterChain(_))
-      .WillRepeatedly(Invoke([&](FilterChainManager& manager) -> bool {
+      .WillRepeatedly(Invoke([&](FilterChainFactoryCallbacks& callbacks) -> bool {
         auto factory = createDecoderFilterFactoryCb(filter);
-        manager.applyFilterFactoryCb({}, factory);
+        callbacks.setFilterConfigName("");
+        factory(callbacks);
         return true;
       }));
 
@@ -428,9 +432,10 @@ TEST_F(HttpConnectionManagerImplTest, 1xxResponseWithDecoderPause) {
   EXPECT_CALL(*filter, setDecoderFilterCallbacks(_));
 
   EXPECT_CALL(filter_factory_, createFilterChain(_))
-      .WillRepeatedly(Invoke([&](FilterChainManager& manager) -> bool {
+      .WillRepeatedly(Invoke([&](FilterChainFactoryCallbacks& callbacks) -> bool {
         auto factory = createDecoderFilterFactoryCb(filter);
-        manager.applyFilterFactoryCb({}, factory);
+        callbacks.setFilterConfigName("");
+        factory(callbacks);
         return true;
       }));
 
@@ -589,9 +594,10 @@ TEST_F(HttpConnectionManagerImplTest, InvalidPathWithDualFilter) {
   // This test also verifies that decoder/encoder filters have onDestroy() called only once.
   auto* filter = new MockStreamFilter();
   EXPECT_CALL(filter_factory_, createFilterChain(_))
-      .WillOnce(Invoke([&](FilterChainManager& manager) -> bool {
+      .WillOnce(Invoke([&](FilterChainFactoryCallbacks& callbacks) -> bool {
         auto factory = createStreamFilterFactoryCb(StreamFilterSharedPtr{filter});
-        manager.applyFilterFactoryCb({}, factory);
+        callbacks.setFilterConfigName("");
+        factory(callbacks);
         return true;
       }));
   EXPECT_CALL(*filter, setDecoderFilterCallbacks(_));
@@ -636,9 +642,10 @@ TEST_F(HttpConnectionManagerImplTest, PathFailedtoSanitize) {
   // This test also verifies that decoder/encoder filters have onDestroy() called only once.
   auto* filter = new MockStreamFilter();
   EXPECT_CALL(filter_factory_, createFilterChain(_))
-      .WillOnce(Invoke([&](FilterChainManager& manager) -> bool {
+      .WillOnce(Invoke([&](FilterChainFactoryCallbacks& callbacks) -> bool {
         auto factory = createStreamFilterFactoryCb(StreamFilterSharedPtr{filter});
-        manager.applyFilterFactoryCb({}, factory);
+        callbacks.setFilterConfigName("");
+        factory(callbacks);
         return true;
       }));
   EXPECT_CALL(*filter, setDecoderFilterCallbacks(_));
@@ -674,9 +681,10 @@ TEST_F(HttpConnectionManagerImplTest, FilterShouldUseSantizedPath) {
   auto* filter = new MockStreamFilter();
 
   EXPECT_CALL(filter_factory_, createFilterChain(_))
-      .WillOnce(Invoke([&](FilterChainManager& manager) -> bool {
+      .WillOnce(Invoke([&](FilterChainFactoryCallbacks& callbacks) -> bool {
         auto factory = createDecoderFilterFactoryCb(StreamDecoderFilterSharedPtr{filter});
-        manager.applyFilterFactoryCb({}, factory);
+        callbacks.setFilterConfigName("");
+        factory(callbacks);
         return true;
       }));
 
@@ -740,7 +748,7 @@ TEST_F(HttpConnectionManagerImplTest, RouteShouldUseSantizedPath) {
         return Router::VirtualHostRoute{route->virtual_host_, route};
       }));
   EXPECT_CALL(filter_factory_, createFilterChain(_))
-      .WillOnce(Invoke([&](FilterChainManager&) -> bool { return false; }));
+      .WillOnce(Invoke([&](FilterChainFactoryCallbacks&) -> bool { return false; }));
 
   // Kick off the incoming data.
   Buffer::OwnedImpl fake_input("1234");
@@ -821,9 +829,10 @@ TEST_F(HttpConnectionManagerImplTest, AllNormalizationsWithEscapedSlashesForward
   auto* filter = new MockStreamFilter();
 
   EXPECT_CALL(filter_factory_, createFilterChain(_))
-      .WillOnce(Invoke([&](FilterChainManager& manager) -> bool {
+      .WillOnce(Invoke([&](FilterChainFactoryCallbacks& callbacks) -> bool {
         auto factory = createDecoderFilterFactoryCb(StreamDecoderFilterSharedPtr{filter});
-        manager.applyFilterFactoryCb({}, factory);
+        callbacks.setFilterConfigName("");
+        factory(callbacks);
         return true;
       }));
 
@@ -1367,9 +1376,10 @@ TEST_F(HttpConnectionManagerImplTest, FilterShouldUseNormalizedHost) {
   auto* filter = new MockStreamFilter();
 
   EXPECT_CALL(filter_factory_, createFilterChain(_))
-      .WillOnce(Invoke([&](FilterChainManager& manager) -> bool {
+      .WillOnce(Invoke([&](FilterChainFactoryCallbacks& callbacks) -> bool {
         auto factory = createDecoderFilterFactoryCb(StreamDecoderFilterSharedPtr{filter});
-        manager.applyFilterFactoryCb({}, factory);
+        callbacks.setFilterConfigName("");
+        factory(callbacks);
         return true;
       }));
 
@@ -1431,7 +1441,7 @@ TEST_F(HttpConnectionManagerImplTest, RouteShouldUseNormalizedHost) {
         return Router::VirtualHostRoute{route->virtual_host_, route};
       }));
   EXPECT_CALL(filter_factory_, createFilterChain(_))
-      .WillOnce(Invoke([&](FilterChainManager&) -> bool { return false; }));
+      .WillOnce(Invoke([&](FilterChainFactoryCallbacks&) -> bool { return false; }));
 
   // Kick off the incoming data.
   Buffer::OwnedImpl fake_input("1234");
@@ -1627,9 +1637,10 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlow) {
   std::shared_ptr<MockStreamDecoderFilter> filter(new NiceMock<MockStreamDecoderFilter>());
 
   EXPECT_CALL(filter_factory_, createFilterChain(_))
-      .WillRepeatedly(Invoke([&](FilterChainManager& manager) -> bool {
+      .WillRepeatedly(Invoke([&](FilterChainFactoryCallbacks& callbacks) -> bool {
         auto factory = createDecoderFilterFactoryCb(filter);
-        manager.applyFilterFactoryCb({}, factory);
+        callbacks.setFilterConfigName("");
+        factory(callbacks);
         return true;
       }));
 
@@ -1675,9 +1686,10 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanAndTraceDecisionRefreshA
   std::shared_ptr<MockStreamDecoderFilter> filter(new NiceMock<MockStreamDecoderFilter>());
 
   EXPECT_CALL(filter_factory_, createFilterChain(_))
-      .WillRepeatedly(Invoke([&](FilterChainManager& manager) -> bool {
+      .WillRepeatedly(Invoke([&](FilterChainFactoryCallbacks& callbacks) -> bool {
         auto factory = createDecoderFilterFactoryCb(filter);
-        manager.applyFilterFactoryCb({}, factory);
+        callbacks.setFilterConfigName("");
+        factory(callbacks);
         return true;
       }));
 
@@ -1750,9 +1762,10 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanAndTraceDecisionRefreshA
   std::shared_ptr<MockStreamDecoderFilter> filter(new NiceMock<MockStreamDecoderFilter>());
 
   EXPECT_CALL(filter_factory_, createFilterChain(_))
-      .WillRepeatedly(Invoke([&](FilterChainManager& manager) -> bool {
+      .WillRepeatedly(Invoke([&](FilterChainFactoryCallbacks& callbacks) -> bool {
         auto factory = createDecoderFilterFactoryCb(filter);
-        manager.applyFilterFactoryCb({}, factory);
+        callbacks.setFilterConfigName("");
+        factory(callbacks);
         return true;
       }));
 
@@ -1829,9 +1842,10 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanButDisableTraceDecisionR
   std::shared_ptr<MockStreamDecoderFilter> filter(new NiceMock<MockStreamDecoderFilter>());
 
   EXPECT_CALL(filter_factory_, createFilterChain(_))
-      .WillRepeatedly(Invoke([&](FilterChainManager& manager) -> bool {
+      .WillRepeatedly(Invoke([&](FilterChainFactoryCallbacks& callbacks) -> bool {
         auto factory = createDecoderFilterFactoryCb(filter);
-        manager.applyFilterFactoryCb({}, factory);
+        callbacks.setFilterConfigName("");
+        factory(callbacks);
         return true;
       }));
 
@@ -1924,9 +1938,10 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowWithHcmOperati
   std::shared_ptr<MockStreamDecoderFilter> filter(new NiceMock<MockStreamDecoderFilter>());
 
   EXPECT_CALL(filter_factory_, createFilterChain(_))
-      .WillRepeatedly(Invoke([&](FilterChainManager& manager) -> bool {
+      .WillRepeatedly(Invoke([&](FilterChainFactoryCallbacks& callbacks) -> bool {
         auto factory = createDecoderFilterFactoryCb(filter);
-        manager.applyFilterFactoryCb({}, factory);
+        callbacks.setFilterConfigName("");
+        factory(callbacks);
         return true;
       }));
 
@@ -1988,9 +2003,10 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowWithRouteOpera
   std::shared_ptr<MockStreamDecoderFilter> filter(new NiceMock<MockStreamDecoderFilter>());
 
   EXPECT_CALL(filter_factory_, createFilterChain(_))
-      .WillRepeatedly(Invoke([&](FilterChainManager& manager) -> bool {
+      .WillRepeatedly(Invoke([&](FilterChainFactoryCallbacks& callbacks) -> bool {
         auto factory = createDecoderFilterFactoryCb(filter);
-        manager.applyFilterFactoryCb({}, factory);
+        callbacks.setFilterConfigName("");
+        factory(callbacks);
         return true;
       }));
 
@@ -2056,9 +2072,10 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowWithOperationF
   std::shared_ptr<MockStreamDecoderFilter> filter(new NiceMock<MockStreamDecoderFilter>());
 
   EXPECT_CALL(filter_factory_, createFilterChain(_))
-      .WillRepeatedly(Invoke([&](FilterChainManager& manager) -> bool {
+      .WillRepeatedly(Invoke([&](FilterChainFactoryCallbacks& callbacks) -> bool {
         auto factory = createDecoderFilterFactoryCb(filter);
-        manager.applyFilterFactoryCb({}, factory);
+        callbacks.setFilterConfigName("");
+        factory(callbacks);
         return true;
       }));
 
@@ -2123,9 +2140,10 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowIngressDecorat
   std::shared_ptr<MockStreamDecoderFilter> filter(new NiceMock<MockStreamDecoderFilter>());
 
   EXPECT_CALL(filter_factory_, createFilterChain(_))
-      .WillRepeatedly(Invoke([&](FilterChainManager& manager) -> bool {
+      .WillRepeatedly(Invoke([&](FilterChainFactoryCallbacks& callbacks) -> bool {
         auto factory = createDecoderFilterFactoryCb(filter);
-        manager.applyFilterFactoryCb({}, factory);
+        callbacks.setFilterConfigName("");
+        factory(callbacks);
         return true;
       }));
 
@@ -2192,9 +2210,10 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowIngressDecorat
   std::shared_ptr<MockStreamDecoderFilter> filter(new NiceMock<MockStreamDecoderFilter>());
 
   EXPECT_CALL(filter_factory_, createFilterChain(_))
-      .WillRepeatedly(Invoke([&](FilterChainManager& manager) -> bool {
+      .WillRepeatedly(Invoke([&](FilterChainFactoryCallbacks& callbacks) -> bool {
         auto factory = createDecoderFilterFactoryCb(filter);
-        manager.applyFilterFactoryCb({}, factory);
+        callbacks.setFilterConfigName("");
+        factory(callbacks);
         return true;
       }));
 
@@ -2259,9 +2278,10 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowIngressDecorat
   std::shared_ptr<MockStreamDecoderFilter> filter(new NiceMock<MockStreamDecoderFilter>());
 
   EXPECT_CALL(filter_factory_, createFilterChain(_))
-      .WillRepeatedly(Invoke([&](FilterChainManager& manager) -> bool {
+      .WillRepeatedly(Invoke([&](FilterChainFactoryCallbacks& callbacks) -> bool {
         auto factory = createDecoderFilterFactoryCb(filter);
-        manager.applyFilterFactoryCb({}, factory);
+        callbacks.setFilterConfigName("");
+        factory(callbacks);
         return true;
       }));
 
@@ -2345,9 +2365,10 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowEgressDecorato
   std::shared_ptr<MockStreamDecoderFilter> filter(new NiceMock<MockStreamDecoderFilter>());
 
   EXPECT_CALL(filter_factory_, createFilterChain(_))
-      .WillRepeatedly(Invoke([&](FilterChainManager& manager) -> bool {
+      .WillRepeatedly(Invoke([&](FilterChainFactoryCallbacks& callbacks) -> bool {
         auto factory = createDecoderFilterFactoryCb(filter);
-        manager.applyFilterFactoryCb({}, factory);
+        callbacks.setFilterConfigName("");
+        factory(callbacks);
         return true;
       }));
 
@@ -2432,9 +2453,10 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowEgressDecorato
   std::shared_ptr<MockStreamDecoderFilter> filter(new NiceMock<MockStreamDecoderFilter>());
 
   EXPECT_CALL(filter_factory_, createFilterChain(_))
-      .WillRepeatedly(Invoke([&](FilterChainManager& manager) -> bool {
+      .WillRepeatedly(Invoke([&](FilterChainFactoryCallbacks& callbacks) -> bool {
         auto factory = createDecoderFilterFactoryCb(filter);
-        manager.applyFilterFactoryCb({}, factory);
+        callbacks.setFilterConfigName("");
+        factory(callbacks);
         return true;
       }));
 
@@ -2519,9 +2541,10 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowEgressDecorato
   std::shared_ptr<MockStreamDecoderFilter> filter(new NiceMock<MockStreamDecoderFilter>());
 
   EXPECT_CALL(filter_factory_, createFilterChain(_))
-      .WillRepeatedly(Invoke([&](FilterChainManager& manager) -> bool {
+      .WillRepeatedly(Invoke([&](FilterChainFactoryCallbacks& callbacks) -> bool {
         auto factory = createDecoderFilterFactoryCb(filter);
-        manager.applyFilterFactoryCb({}, factory);
+        callbacks.setFilterConfigName("");
+        factory(callbacks);
         return true;
       }));
 
@@ -2580,9 +2603,10 @@ TEST_F(HttpConnectionManagerImplTest,
   std::shared_ptr<MockStreamDecoderFilter> filter(new NiceMock<MockStreamDecoderFilter>());
 
   EXPECT_CALL(filter_factory_, createFilterChain(_))
-      .WillRepeatedly(Invoke([&](FilterChainManager& manager) -> bool {
+      .WillRepeatedly(Invoke([&](FilterChainFactoryCallbacks& callbacks) -> bool {
         auto factory = createDecoderFilterFactoryCb(filter);
-        manager.applyFilterFactoryCb({}, factory);
+        callbacks.setFilterConfigName("");
+        factory(callbacks);
         return true;
       }));
 
@@ -2622,9 +2646,10 @@ TEST_F(HttpConnectionManagerImplTest, NoHCMTracingConfigAndActiveSpanWouldBeNull
   std::shared_ptr<MockStreamDecoderFilter> filter(new NiceMock<MockStreamDecoderFilter>());
 
   EXPECT_CALL(filter_factory_, createFilterChain(_))
-      .WillRepeatedly(Invoke([&](FilterChainManager& manager) -> bool {
+      .WillRepeatedly(Invoke([&](FilterChainFactoryCallbacks& callbacks) -> bool {
         auto factory = createDecoderFilterFactoryCb(filter);
-        manager.applyFilterFactoryCb({}, factory);
+        callbacks.setFilterConfigName("");
+        factory(callbacks);
         return true;
       }));
 
@@ -2679,12 +2704,14 @@ TEST_F(HttpConnectionManagerImplTest, TestAccessLog) {
   std::shared_ptr<AccessLog::MockInstance> handler(new NiceMock<AccessLog::MockInstance>());
 
   EXPECT_CALL(filter_factory_, createFilterChain(_))
-      .WillOnce(Invoke([&](FilterChainManager& manager) -> bool {
+      .WillOnce(Invoke([&](FilterChainFactoryCallbacks& callbacks) -> bool {
         FilterFactoryCb filter_factory = createDecoderFilterFactoryCb(filter);
         FilterFactoryCb handler_factory = createLogHandlerFactoryCb(handler);
 
-        manager.applyFilterFactoryCb({}, filter_factory);
-        manager.applyFilterFactoryCb({}, handler_factory);
+        callbacks.setFilterConfigName("");
+        filter_factory(callbacks);
+        callbacks.setFilterConfigName("");
+        handler_factory(callbacks);
         return true;
       }));
 
@@ -2736,12 +2763,14 @@ TEST_F(HttpConnectionManagerImplTest, TestFilterCanEnrichAccessLogs) {
   std::shared_ptr<AccessLog::MockInstance> handler(new NiceMock<AccessLog::MockInstance>());
 
   EXPECT_CALL(filter_factory_, createFilterChain(_))
-      .WillOnce(Invoke([&](FilterChainManager& manager) -> bool {
+      .WillOnce(Invoke([&](FilterChainFactoryCallbacks& callbacks) -> bool {
         FilterFactoryCb filter_factory = createDecoderFilterFactoryCb(filter);
         FilterFactoryCb handler_factory = createLogHandlerFactoryCb(handler);
 
-        manager.applyFilterFactoryCb({}, filter_factory);
-        manager.applyFilterFactoryCb({}, handler_factory);
+        callbacks.setFilterConfigName("");
+        filter_factory(callbacks);
+        callbacks.setFilterConfigName("");
+        handler_factory(callbacks);
         return true;
       }));
 
@@ -2787,12 +2816,14 @@ TEST_F(HttpConnectionManagerImplTest, TestRemoteDownstreamDisconnectAccessLog) {
   std::shared_ptr<AccessLog::MockInstance> handler(new NiceMock<AccessLog::MockInstance>());
 
   EXPECT_CALL(filter_factory_, createFilterChain(_))
-      .WillOnce(Invoke([&](FilterChainManager& manager) -> bool {
+      .WillOnce(Invoke([&](FilterChainFactoryCallbacks& callbacks) -> bool {
         FilterFactoryCb filter_factory = createDecoderFilterFactoryCb(filter);
         FilterFactoryCb handler_factory = createLogHandlerFactoryCb(handler);
 
-        manager.applyFilterFactoryCb({}, filter_factory);
-        manager.applyFilterFactoryCb({}, handler_factory);
+        callbacks.setFilterConfigName("");
+        filter_factory(callbacks);
+        callbacks.setFilterConfigName("");
+        handler_factory(callbacks);
         return true;
       }));
 
@@ -2830,12 +2861,14 @@ TEST_F(HttpConnectionManagerImplTest, TestLocalDownstreamDisconnectAccessLog) {
   std::shared_ptr<AccessLog::MockInstance> handler(new NiceMock<AccessLog::MockInstance>());
 
   EXPECT_CALL(filter_factory_, createFilterChain(_))
-      .WillOnce(Invoke([&](FilterChainManager& manager) -> bool {
+      .WillOnce(Invoke([&](FilterChainFactoryCallbacks& callbacks) -> bool {
         FilterFactoryCb filter_factory = createDecoderFilterFactoryCb(filter);
         FilterFactoryCb handler_factory = createLogHandlerFactoryCb(handler);
 
-        manager.applyFilterFactoryCb({}, filter_factory);
-        manager.applyFilterFactoryCb({}, handler_factory);
+        callbacks.setFilterConfigName("");
+        filter_factory(callbacks);
+        callbacks.setFilterConfigName("");
+        handler_factory(callbacks);
         return true;
       }));
 
@@ -2871,12 +2904,14 @@ TEST_F(HttpConnectionManagerImplTest, TestAccessLogWithTrailers) {
   std::shared_ptr<AccessLog::MockInstance> handler(new NiceMock<AccessLog::MockInstance>());
 
   EXPECT_CALL(filter_factory_, createFilterChain(_))
-      .WillOnce(Invoke([&](FilterChainManager& manager) -> bool {
+      .WillOnce(Invoke([&](FilterChainFactoryCallbacks& callbacks) -> bool {
         FilterFactoryCb filter_factory = createDecoderFilterFactoryCb(filter);
         FilterFactoryCb handler_factory = createLogHandlerFactoryCb(handler);
 
-        manager.applyFilterFactoryCb({}, filter_factory);
-        manager.applyFilterFactoryCb({}, handler_factory);
+        callbacks.setFilterConfigName("");
+        filter_factory(callbacks);
+        callbacks.setFilterConfigName("");
+        handler_factory(callbacks);
         return true;
       }));
 
@@ -2923,12 +2958,14 @@ TEST_F(HttpConnectionManagerImplTest, TestAccessLogWithInvalidRequest) {
   std::shared_ptr<AccessLog::MockInstance> handler(new NiceMock<AccessLog::MockInstance>());
 
   EXPECT_CALL(filter_factory_, createFilterChain(_))
-      .WillOnce(Invoke([&](FilterChainManager& manager) -> bool {
+      .WillOnce(Invoke([&](FilterChainFactoryCallbacks& callbacks) -> bool {
         FilterFactoryCb filter_factory = createDecoderFilterFactoryCb(filter);
         FilterFactoryCb handler_factory = createLogHandlerFactoryCb(handler);
 
-        manager.applyFilterFactoryCb({}, filter_factory);
-        manager.applyFilterFactoryCb({}, handler_factory);
+        callbacks.setFilterConfigName("");
+        filter_factory(callbacks);
+        callbacks.setFilterConfigName("");
+        handler_factory(callbacks);
         return true;
       }));
 
@@ -2969,12 +3006,14 @@ TEST_F(HttpConnectionManagerImplTest, TestAccessLogOnNewRequest) {
   std::shared_ptr<AccessLog::MockInstance> handler(new NiceMock<AccessLog::MockInstance>());
 
   EXPECT_CALL(filter_factory_, createFilterChain(_))
-      .WillOnce(Invoke([&](FilterChainManager& manager) -> bool {
+      .WillOnce(Invoke([&](FilterChainFactoryCallbacks& callbacks) -> bool {
         FilterFactoryCb filter_factory = createDecoderFilterFactoryCb(filter);
         FilterFactoryCb handler_factory = createLogHandlerFactoryCb(handler);
 
-        manager.applyFilterFactoryCb({}, filter_factory);
-        manager.applyFilterFactoryCb({}, handler_factory);
+        callbacks.setFilterConfigName("");
+        filter_factory(callbacks);
+        callbacks.setFilterConfigName("");
+        handler_factory(callbacks);
         return true;
       }));
 
@@ -3030,13 +3069,14 @@ TEST_F(HttpConnectionManagerImplTest, TestAccessLogOnTunnelEstablished) {
   std::shared_ptr<MockStreamDecoderFilter> filter(new NiceMock<MockStreamDecoderFilter>());
   std::shared_ptr<AccessLog::MockInstance> handler(new NiceMock<AccessLog::MockInstance>());
 
-  EXPECT_CALL(filter_factory_, createUpgradeFilterChain("CONNECT", _, _, _))
+  EXPECT_CALL(filter_factory_, createUpgradeFilterChain("CONNECT", _, _))
       .WillOnce(Invoke([&](absl::string_view, const FilterChainFactory::UpgradeMap*,
-                           FilterChainManager& manager, const Http::FilterChainOptions&) -> bool {
+                           FilterChainFactoryCallbacks& callbacks) -> bool {
         FilterFactoryCb filter_factory = createDecoderFilterFactoryCb(filter);
         FilterFactoryCb handler_factory = createLogHandlerFactoryCb(handler);
-        manager.applyFilterFactoryCb({}, filter_factory);
-        manager.applyFilterFactoryCb({}, handler_factory);
+        callbacks.setFilterConfigName("");
+        filter_factory(callbacks);
+        handler_factory(callbacks);
         return true;
       }));
 
@@ -3096,12 +3136,14 @@ TEST_F(HttpConnectionManagerImplTest, TestPeriodicAccessLogging) {
   std::shared_ptr<AccessLog::MockInstance> handler(new NiceMock<AccessLog::MockInstance>());
 
   EXPECT_CALL(filter_factory_, createFilterChain(_))
-      .WillOnce(Invoke([&](FilterChainManager& manager) -> bool {
+      .WillOnce(Invoke([&](FilterChainFactoryCallbacks& callbacks) -> bool {
         FilterFactoryCb filter_factory = createDecoderFilterFactoryCb(filter);
         FilterFactoryCb handler_factory = createLogHandlerFactoryCb(handler);
 
-        manager.applyFilterFactoryCb({}, filter_factory);
-        manager.applyFilterFactoryCb({}, handler_factory);
+        callbacks.setFilterConfigName("");
+        filter_factory(callbacks);
+        callbacks.setFilterConfigName("");
+        handler_factory(callbacks);
         return true;
       }));
   Event::MockTimer* periodic_log_timer;
@@ -3174,12 +3216,14 @@ TEST_F(HttpConnectionManagerImplTest, TestAccessLogSsl) {
   std::shared_ptr<AccessLog::MockInstance> handler(new NiceMock<AccessLog::MockInstance>());
 
   EXPECT_CALL(filter_factory_, createFilterChain(_))
-      .WillOnce(Invoke([&](FilterChainManager& manager) -> bool {
+      .WillOnce(Invoke([&](FilterChainFactoryCallbacks& callbacks) -> bool {
         FilterFactoryCb filter_factory = createDecoderFilterFactoryCb(filter);
         FilterFactoryCb handler_factory = createLogHandlerFactoryCb(handler);
 
-        manager.applyFilterFactoryCb({}, filter_factory);
-        manager.applyFilterFactoryCb({}, handler_factory);
+        callbacks.setFilterConfigName("");
+        filter_factory(callbacks);
+        callbacks.setFilterConfigName("");
+        handler_factory(callbacks);
         return true;
       }));
 
@@ -3234,9 +3278,10 @@ TEST_F(HttpConnectionManagerImplTest, DoNotStartSpanIfTracingIsNotEnabled) {
   std::shared_ptr<MockStreamDecoderFilter> filter(new NiceMock<MockStreamDecoderFilter>());
 
   EXPECT_CALL(filter_factory_, createFilterChain(_))
-      .WillRepeatedly(Invoke([&](FilterChainManager& manager) -> bool {
+      .WillRepeatedly(Invoke([&](FilterChainFactoryCallbacks& callbacks) -> bool {
         auto factory = createDecoderFilterFactoryCb(filter);
-        manager.applyFilterFactoryCb({}, factory);
+        callbacks.setFilterConfigName("");
+        factory(callbacks);
         return true;
       }));
 
@@ -3351,9 +3396,10 @@ TEST_F(HttpConnectionManagerImplTest, AccessEncoderRouteBeforeHeadersArriveOnIdl
   std::shared_ptr<MockStreamEncoderFilter> filter(new NiceMock<MockStreamEncoderFilter>());
 
   EXPECT_CALL(filter_factory_, createFilterChain(_))
-      .WillOnce(Invoke([&](FilterChainManager& manager) -> bool {
+      .WillOnce(Invoke([&](FilterChainFactoryCallbacks& callbacks) -> bool {
         FilterFactoryCb factory = createEncoderFilterFactoryCb(filter);
-        manager.applyFilterFactoryCb({}, factory);
+        callbacks.setFilterConfigName("");
+        factory(callbacks);
         return true;
       }));
 
@@ -3433,12 +3479,14 @@ TEST_F(HttpConnectionManagerImplTest, TestStreamIdleAccessLog) {
       }));
 
   EXPECT_CALL(filter_factory_, createFilterChain(_))
-      .WillOnce(Invoke([&](FilterChainManager& manager) -> bool {
+      .WillOnce(Invoke([&](FilterChainFactoryCallbacks& callbacks) -> bool {
         FilterFactoryCb filter_factory = createDecoderFilterFactoryCb(filter);
         FilterFactoryCb handler_factory = createLogHandlerFactoryCb(handler);
 
-        manager.applyFilterFactoryCb({}, filter_factory);
-        manager.applyFilterFactoryCb({}, handler_factory);
+        callbacks.setFilterConfigName("");
+        filter_factory(callbacks);
+        callbacks.setFilterConfigName("");
+        handler_factory(callbacks);
         return true;
       }));
 
@@ -3998,9 +4046,10 @@ TEST_F(HttpConnectionManagerImplTest, PerStreamIdleTimeoutAfterUpstreamHeaders) 
   std::shared_ptr<MockStreamDecoderFilter> filter(new NiceMock<MockStreamDecoderFilter>());
 
   EXPECT_CALL(filter_factory_, createFilterChain(_))
-      .WillRepeatedly(Invoke([&](FilterChainManager& manager) -> bool {
+      .WillRepeatedly(Invoke([&](FilterChainFactoryCallbacks& callbacks) -> bool {
         auto factory = createDecoderFilterFactoryCb(filter);
-        manager.applyFilterFactoryCb({}, factory);
+        callbacks.setFilterConfigName("");
+        factory(callbacks);
         return true;
       }));
   EXPECT_CALL(filter_callbacks_.connection_.dispatcher_, deferredDelete_(_));
@@ -4050,9 +4099,10 @@ TEST_F(HttpConnectionManagerImplTest, PerStreamIdleTimeoutAfterBidiData) {
   std::shared_ptr<MockStreamDecoderFilter> filter(new NiceMock<MockStreamDecoderFilter>());
 
   EXPECT_CALL(filter_factory_, createFilterChain(_))
-      .WillRepeatedly(Invoke([&](FilterChainManager& manager) -> bool {
+      .WillRepeatedly(Invoke([&](FilterChainFactoryCallbacks& callbacks) -> bool {
         auto factory = createDecoderFilterFactoryCb(filter);
-        manager.applyFilterFactoryCb({}, factory);
+        callbacks.setFilterConfigName("");
+        factory(callbacks);
         return true;
       }));
   EXPECT_CALL(filter_callbacks_.connection_.dispatcher_, deferredDelete_(_));
@@ -4309,9 +4359,10 @@ TEST_F(HttpConnectionManagerImplTest, RequestTimeoutIsDisarmedOnEncodeHeaders) {
   setup();
   std::shared_ptr<MockStreamDecoderFilter> filter(new NiceMock<MockStreamDecoderFilter>());
   EXPECT_CALL(filter_factory_, createFilterChain(_))
-      .WillRepeatedly(Invoke([&](FilterChainManager& manager) -> bool {
+      .WillRepeatedly(Invoke([&](FilterChainFactoryCallbacks& callbacks) -> bool {
         auto factory = createDecoderFilterFactoryCb(filter);
-        manager.applyFilterFactoryCb({}, factory);
+        callbacks.setFilterConfigName("");
+        factory(callbacks);
         return true;
       }));
   EXPECT_CALL(response_encoder_, encodeHeaders(_, _));
@@ -4622,14 +4673,12 @@ TEST_F(HttpConnectionManagerImplTest, FooUpgradeDrainClose) {
   EXPECT_CALL(*filter, setDecoderFilterCallbacks(_));
   EXPECT_CALL(*filter, setEncoderFilterCallbacks(_));
 
-  EXPECT_CALL(filter_factory_, createUpgradeFilterChain(_, _, _, _))
-      .WillRepeatedly(
-          Invoke([&](absl::string_view, const Http::FilterChainFactory::UpgradeMap*,
-                     FilterChainManager& manager, const Http::FilterChainOptions&) -> bool {
-            auto factory = createStreamFilterFactoryCb(StreamFilterSharedPtr{filter});
-            manager.applyFilterFactoryCb({}, factory);
-            return true;
-          }));
+  EXPECT_CALL(filter_factory_, createUpgradeFilterChain(_, _, _))
+      .WillRepeatedly(Invoke([&](absl::string_view, const Http::FilterChainFactory::UpgradeMap*,
+                                 FilterChainFactoryCallbacks& callbacks) -> bool {
+        callbacks.addStreamFilter(StreamFilterSharedPtr{filter});
+        return true;
+      }));
 
   // When dispatch is called on the codec, we pretend to get a new stream and then fire a headers
   // only request into it. Then we respond into the filter.
@@ -4666,7 +4715,7 @@ TEST_F(HttpConnectionManagerImplTest, FooUpgradeDrainClose) {
 TEST_F(HttpConnectionManagerImplTest, ConnectAsUpgrade) {
   setup(SetupOpts().setTracing(false));
 
-  EXPECT_CALL(filter_factory_, createUpgradeFilterChain("CONNECT", _, _, _))
+  EXPECT_CALL(filter_factory_, createUpgradeFilterChain("CONNECT", _, _))
       .WillRepeatedly(Return(true));
 
   EXPECT_CALL(*codec_, dispatch(_))
@@ -4690,7 +4739,7 @@ TEST_F(HttpConnectionManagerImplTest, ConnectAsUpgrade) {
 TEST_F(HttpConnectionManagerImplTest, ConnectWithEmptyPath) {
   setup(SetupOpts().setTracing(false));
 
-  EXPECT_CALL(filter_factory_, createUpgradeFilterChain("CONNECT", _, _, _))
+  EXPECT_CALL(filter_factory_, createUpgradeFilterChain("CONNECT", _, _))
       .WillRepeatedly(Return(true));
 
   EXPECT_CALL(*codec_, dispatch(_))
@@ -4811,9 +4860,10 @@ TEST_F(HttpConnectionManagerImplTest, DrainClose) {
 
   MockStreamDecoderFilter* filter = new NiceMock<MockStreamDecoderFilter>();
   EXPECT_CALL(filter_factory_, createFilterChain(_))
-      .WillOnce(Invoke([&](FilterChainManager& manager) -> bool {
+      .WillOnce(Invoke([&](FilterChainFactoryCallbacks& callbacks) -> bool {
         auto factory = createDecoderFilterFactoryCb(StreamDecoderFilterSharedPtr{filter});
-        manager.applyFilterFactoryCb({}, factory);
+        callbacks.setFilterConfigName("");
+        factory(callbacks);
         return true;
       }));
 
@@ -5060,9 +5110,10 @@ TEST_F(HttpConnectionManagerImplTest, ShouldDrainConnectionUponCompletionHttp2) 
 
   MockStreamDecoderFilter* filter = new NiceMock<MockStreamDecoderFilter>();
   EXPECT_CALL(filter_factory_, createFilterChain(_))
-      .WillOnce(Invoke([&](FilterChainManager& manager) -> bool {
+      .WillOnce(Invoke([&](FilterChainFactoryCallbacks& callbacks) -> bool {
+        callbacks.setFilterConfigName("");
         auto factory = createDecoderFilterFactoryCb(StreamDecoderFilterSharedPtr{filter});
-        manager.applyFilterFactoryCb({}, factory);
+        factory(callbacks);
         return true;
       }));
 
@@ -5112,9 +5163,10 @@ TEST_F(HttpConnectionManagerImplTest, ShouldDrainConnectionUponCompletionHttp3) 
 
   MockStreamDecoderFilter* filter = new NiceMock<MockStreamDecoderFilter>();
   EXPECT_CALL(filter_factory_, createFilterChain(_))
-      .WillOnce(Invoke([&](FilterChainManager& manager) -> bool {
+      .WillOnce(Invoke([&](FilterChainFactoryCallbacks& callbacks) -> bool {
+        callbacks.setFilterConfigName("");
         auto factory = createDecoderFilterFactoryCb(StreamDecoderFilterSharedPtr{filter});
-        manager.applyFilterFactoryCb({}, factory);
+        factory(callbacks);
         return true;
       }));
 
@@ -5164,9 +5216,10 @@ TEST_F(HttpConnectionManagerImplTest, ShouldDrainConnectionUponCompletionHttp11)
 
   MockStreamDecoderFilter* filter = new NiceMock<MockStreamDecoderFilter>();
   EXPECT_CALL(filter_factory_, createFilterChain(_))
-      .WillOnce(Invoke([&](FilterChainManager& manager) -> bool {
+      .WillOnce(Invoke([&](FilterChainFactoryCallbacks& callbacks) -> bool {
         auto factory = createDecoderFilterFactoryCb(StreamDecoderFilterSharedPtr{filter});
-        manager.applyFilterFactoryCb({}, factory);
+        callbacks.setFilterConfigName("");
+        factory(callbacks);
         return true;
       }));
 
@@ -5211,9 +5264,10 @@ TEST_F(HttpConnectionManagerImplTest, SendGoAwayAndCloseGraceful) {
   EXPECT_CALL(*codec_, protocol()).WillRepeatedly(Return(Protocol::Http2));
   MockStreamDecoderFilter* filter = new NiceMock<MockStreamDecoderFilter>();
   EXPECT_CALL(filter_factory_, createFilterChain(_))
-      .WillOnce(Invoke([&](FilterChainManager& manager) -> bool {
+      .WillOnce(Invoke([&](FilterChainFactoryCallbacks& callbacks) -> bool {
         auto factory = createDecoderFilterFactoryCb(StreamDecoderFilterSharedPtr{filter});
-        manager.applyFilterFactoryCb({}, factory);
+        callbacks.setFilterConfigName("");
+        factory(callbacks);
         return true;
       }));
   EXPECT_CALL(*filter, decodeHeaders(_, true))
@@ -5248,9 +5302,10 @@ TEST_F(HttpConnectionManagerImplTest, TransportFailureReasonPropagation) {
 
   MockStreamDecoderFilter* filter = new NiceMock<MockStreamDecoderFilter>();
   EXPECT_CALL(filter_factory_, createFilterChain(_))
-      .WillOnce(Invoke([&](FilterChainManager& manager) -> bool {
+      .WillOnce(Invoke([&](FilterChainFactoryCallbacks& callbacks) -> bool {
         auto factory = createDecoderFilterFactoryCb(StreamDecoderFilterSharedPtr{filter});
-        manager.applyFilterFactoryCb({}, factory);
+        callbacks.setFilterConfigName("");
+        factory(callbacks);
         return true;
       }));
 
@@ -5302,9 +5357,10 @@ TEST_F(HttpConnectionManagerImplTest, TransportFailureReasonPropagationLocalClos
 
   MockStreamDecoderFilter* filter = new NiceMock<MockStreamDecoderFilter>();
   EXPECT_CALL(filter_factory_, createFilterChain(_))
-      .WillOnce(Invoke([&](FilterChainManager& manager) -> bool {
+      .WillOnce(Invoke([&](FilterChainFactoryCallbacks& callbacks) -> bool {
         auto factory = createDecoderFilterFactoryCb(StreamDecoderFilterSharedPtr{filter});
-        manager.applyFilterFactoryCb({}, factory);
+        callbacks.setFilterConfigName("");
+        factory(callbacks);
         return true;
       }));
 

--- a/test/common/http/conn_manager_impl_test_2.cc
+++ b/test/common/http/conn_manager_impl_test_2.cc
@@ -175,10 +175,10 @@ TEST_F(HttpConnectionManagerImplTest, ResponseStartBeforeRequestComplete) {
   // before the request completes, but don't finish the reply until after the request completes.
   MockStreamDecoderFilter* filter = new NiceMock<MockStreamDecoderFilter>();
   EXPECT_CALL(filter_factory_, createFilterChain(_))
-      .WillOnce(Invoke([&](FilterChainManager& manager) -> bool {
-        FilterFactoryCb factory =
-            createDecoderFilterFactoryCb(StreamDecoderFilterSharedPtr{filter});
-        manager.applyFilterFactoryCb({}, factory);
+      .WillOnce(Invoke([&](FilterChainFactoryCallbacks& callbacks) -> bool {
+        auto factory = createDecoderFilterFactoryCb(StreamDecoderFilterSharedPtr{filter});
+        callbacks.setFilterConfigName("");
+        factory(callbacks);
         return true;
       }));
 
@@ -300,12 +300,13 @@ TEST_F(HttpConnectionManagerImplTest, TestDownstreamProtocolErrorAfterHeadersAcc
   std::shared_ptr<AccessLog::MockInstance> handler(new NiceMock<AccessLog::MockInstance>());
 
   EXPECT_CALL(filter_factory_, createFilterChain(_))
-      .WillOnce(Invoke([&](FilterChainManager& manager) -> bool {
-        FilterFactoryCb filter_factory = createDecoderFilterFactoryCb(filter);
-        FilterFactoryCb handler_factory = createLogHandlerFactoryCb(handler);
+      .WillOnce(Invoke([&](FilterChainFactoryCallbacks& callbacks) -> bool {
+        auto filter_factory = createDecoderFilterFactoryCb(filter);
+        auto handler_factory = createLogHandlerFactoryCb(handler);
 
-        manager.applyFilterFactoryCb({}, filter_factory);
-        manager.applyFilterFactoryCb({}, handler_factory);
+        callbacks.setFilterConfigName("");
+        filter_factory(callbacks);
+        handler_factory(callbacks);
         return true;
       }));
 
@@ -422,9 +423,10 @@ TEST_F(HttpConnectionManagerImplTest, IdleTimeout) {
 
   MockStreamDecoderFilter* filter = new NiceMock<MockStreamDecoderFilter>();
   EXPECT_CALL(filter_factory_, createFilterChain(_))
-      .WillOnce(Invoke([&](FilterChainManager& manager) -> bool {
+      .WillOnce(Invoke([&](FilterChainFactoryCallbacks& callbacks) -> bool {
         auto factory = createDecoderFilterFactoryCb(StreamDecoderFilterSharedPtr{filter});
-        manager.applyFilterFactoryCb({}, factory);
+        callbacks.setFilterConfigName("");
+        factory(callbacks);
         return true;
       }));
 
@@ -540,9 +542,10 @@ TEST_F(HttpConnectionManagerImplTest, DrainConnectionUponCompletionVsOnDrainTime
   // Create a filter so we can encode responses.
   MockStreamDecoderFilter* filter = new NiceMock<MockStreamDecoderFilter>();
   EXPECT_CALL(filter_factory_, createFilterChain(_))
-      .WillRepeatedly(Invoke([&](FilterChainManager& manager) -> bool {
+      .WillRepeatedly(Invoke([&](FilterChainFactoryCallbacks& callbacks) -> bool {
         auto factory = createDecoderFilterFactoryCb(StreamDecoderFilterSharedPtr{filter});
-        manager.applyFilterFactoryCb({}, factory);
+        callbacks.setFilterConfigName("");
+        factory(callbacks);
         return true;
       }));
 
@@ -584,9 +587,10 @@ TEST_F(HttpConnectionManagerImplTest, ConnectionDuration) {
 
   MockStreamDecoderFilter* filter = new NiceMock<MockStreamDecoderFilter>();
   EXPECT_CALL(filter_factory_, createFilterChain(_))
-      .WillOnce(Invoke([&](FilterChainManager& manager) -> bool {
+      .WillOnce(Invoke([&](FilterChainFactoryCallbacks& callbacks) -> bool {
         auto factory = createDecoderFilterFactoryCb(StreamDecoderFilterSharedPtr{filter});
-        manager.applyFilterFactoryCb({}, factory);
+        callbacks.setFilterConfigName("");
+        factory(callbacks);
         return true;
       }));
 
@@ -626,9 +630,10 @@ TEST_F(HttpConnectionManagerImplTest, ConnectionDurationSafeHttp1) {
 
   MockStreamDecoderFilter* filter = new NiceMock<MockStreamDecoderFilter>();
   EXPECT_CALL(filter_factory_, createFilterChain(_))
-      .WillOnce(Invoke([&](FilterChainManager& manager) -> bool {
+      .WillOnce(Invoke([&](FilterChainFactoryCallbacks& callbacks) -> bool {
         auto factory = createDecoderFilterFactoryCb(StreamDecoderFilterSharedPtr{filter});
-        manager.applyFilterFactoryCb({}, factory);
+        callbacks.setFilterConfigName("");
+        factory(callbacks);
         return true;
       }));
 
@@ -1257,9 +1262,10 @@ TEST_F(HttpConnectionManagerImplTest, BlockRouteCacheTest) {
 
   MockStreamDecoderFilter* filter = new NiceMock<MockStreamDecoderFilter>();
   EXPECT_CALL(filter_factory_, createFilterChain(_))
-      .WillOnce(Invoke([&](FilterChainManager& manager) -> bool {
+      .WillOnce(Invoke([&](FilterChainFactoryCallbacks& callbacks) -> bool {
         auto factory = createDecoderFilterFactoryCb(StreamDecoderFilterSharedPtr{filter});
-        manager.applyFilterFactoryCb({}, factory);
+        callbacks.setFilterConfigName("");
+        factory(callbacks);
         return true;
       }));
 

--- a/test/common/http/conn_manager_misc_test.cc
+++ b/test/common/http/conn_manager_misc_test.cc
@@ -27,9 +27,10 @@ public:
 
     auto* filter = new MockStreamFilter();
     EXPECT_CALL(filter_factory_, createFilterChain(_))
-        .WillOnce(Invoke([&](FilterChainManager& manager) -> bool {
+        .WillOnce(Invoke([&](FilterChainFactoryCallbacks& callbacks) -> bool {
           auto factory = createStreamFilterFactoryCb(StreamFilterSharedPtr{filter});
-          manager.applyFilterFactoryCb({}, factory);
+          callbacks.setFilterConfigName("");
+          factory(callbacks);
           return true;
         }));
     EXPECT_CALL(*filter, setDecoderFilterCallbacks(_));

--- a/test/common/http/filter_chain_helper_test.cc
+++ b/test/common/http/filter_chain_helper_test.cc
@@ -1,7 +1,6 @@
 #include "source/common/http/filter_chain_helper.h"
 
 #include "test/mocks/http/mocks.h"
-#include "test/mocks/router/mocks.h"
 #include "test/test_common/utility.h"
 
 #include "gmock/gmock.h"
@@ -14,73 +13,79 @@ namespace Envoy {
 namespace Http {
 namespace {
 
-class MockFilterChainOptions : public FilterChainOptions {
-public:
-  MockFilterChainOptions() = default;
-
-  MOCK_METHOD(absl::optional<bool>, filterDisabled, (absl::string_view), (const));
-};
-
 TEST(FilterChainUtilityTest, CreateFilterChainForFactoriesWithRouteDisabled) {
-  NiceMock<MockFilterChainManager> manager;
-  NiceMock<MockFilterChainOptions> options;
+  NiceMock<MockFilterChainFactoryCallbacks> callbacks;
   FilterChainUtility::FilterFactoriesList filter_factories;
+  absl::flat_hash_set<std::string> added_filters;
 
   for (const auto& name : {"filter_0", "filter_1", "filter_2"}) {
     auto provider =
         std::make_unique<Filter::StaticFilterConfigProviderImpl<Filter::HttpFilterFactoryCb>>(
-            [](FilterChainFactoryCallbacks&) {}, name);
+            [name, &added_filters](FilterChainFactoryCallbacks&) { added_filters.insert(name); },
+            name);
     filter_factories.push_back({std::move(provider), false});
   }
 
   {
-    // If empty filter chain options is provided, all filters should be added.
-    EXPECT_CALL(manager, applyFilterFactoryCb(_, _)).Times(3);
-    FilterChainUtility::createFilterChainForFactories(manager, Http::EmptyFilterChainOptions{},
-                                                      filter_factories);
+    // If no filter is disabled explicitly by route, all filters should be added.
+    EXPECT_CALL(callbacks, filterDisabled(_)).Times(3).WillRepeatedly(Return(absl::nullopt));
+    EXPECT_CALL(callbacks, setFilterConfigName(_)).Times(3);
+    FilterChainUtility::createFilterChainForFactories(callbacks, filter_factories);
+    EXPECT_EQ(added_filters.size(), 3);
   }
+
+  added_filters.clear();
 
   {
 
-    EXPECT_CALL(options, filterDisabled("filter_0")).WillOnce(Return(absl::make_optional(true)));
-    EXPECT_CALL(options, filterDisabled("filter_1")).WillOnce(Return(absl::make_optional(false)));
-    EXPECT_CALL(options, filterDisabled("filter_2")).WillOnce(Return(absl::nullopt));
+    EXPECT_CALL(callbacks, filterDisabled("filter_0")).WillOnce(Return(absl::make_optional(true)));
+    EXPECT_CALL(callbacks, setFilterConfigName("filter_0")).Times(0);
+    EXPECT_CALL(callbacks, filterDisabled("filter_1")).WillOnce(Return(absl::make_optional(false)));
+    EXPECT_CALL(callbacks, setFilterConfigName("filter_1"));
+    EXPECT_CALL(callbacks, filterDisabled("filter_2")).WillOnce(Return(absl::nullopt));
+    EXPECT_CALL(callbacks, setFilterConfigName("filter_2"));
 
     // 'filter_1' and 'filter_2' should be added.
-    EXPECT_CALL(manager, applyFilterFactoryCb(_, _)).Times(2);
-    FilterChainUtility::createFilterChainForFactories(manager, options, filter_factories);
+    FilterChainUtility::createFilterChainForFactories(callbacks, filter_factories);
+    EXPECT_TRUE(added_filters.find("filter_1") != added_filters.end());
+    EXPECT_TRUE(added_filters.find("filter_2") != added_filters.end());
+    EXPECT_EQ(added_filters.size(), 2);
   }
 }
 
 TEST(FilterChainUtilityTest, CreateFilterChainForFactoriesWithRouteDisabledAndDefaultDisabled) {
-  NiceMock<MockFilterChainManager> manager;
-  NiceMock<MockFilterChainOptions> options;
+  NiceMock<MockFilterChainFactoryCallbacks> callbacks;
   FilterChainUtility::FilterFactoriesList filter_factories;
+  absl::flat_hash_set<std::string> added_filters;
 
   for (const auto& name : {"filter_0", "filter_1", "filter_2"}) {
     auto provider =
         std::make_unique<Filter::StaticFilterConfigProviderImpl<Filter::HttpFilterFactoryCb>>(
-            [](FilterChainFactoryCallbacks&) {}, name);
+            [name, &added_filters](FilterChainFactoryCallbacks&) { added_filters.insert(name); },
+            name);
     filter_factories.push_back({std::move(provider), true});
   }
 
   {
-    // If empty filter chain options is provided, all filters should not be added because they are
-    // all disabled by default.
-    EXPECT_CALL(manager, applyFilterFactoryCb(_, _)).Times(0);
-    FilterChainUtility::createFilterChainForFactories(manager, Http::EmptyFilterChainOptions{},
-                                                      filter_factories);
+    // If no filter is enabled explicitly by route, no filter should be added.
+    EXPECT_CALL(callbacks, filterDisabled(_)).Times(3).WillRepeatedly(Return(absl::nullopt));
+    FilterChainUtility::createFilterChainForFactories(callbacks, filter_factories);
+    EXPECT_EQ(added_filters.size(), 0);
   }
 
   {
 
-    EXPECT_CALL(options, filterDisabled("filter_0")).WillOnce(Return(absl::make_optional(true)));
-    EXPECT_CALL(options, filterDisabled("filter_1")).WillOnce(Return(absl::make_optional(false)));
-    EXPECT_CALL(options, filterDisabled("filter_2")).WillOnce(Return(absl::nullopt));
+    EXPECT_CALL(callbacks, filterDisabled("filter_0")).WillOnce(Return(absl::make_optional(true)));
+    EXPECT_CALL(callbacks, setFilterConfigName("filter_0")).Times(0);
+    EXPECT_CALL(callbacks, filterDisabled("filter_1")).WillOnce(Return(absl::make_optional(false)));
+    EXPECT_CALL(callbacks, setFilterConfigName("filter_1"));
+    EXPECT_CALL(callbacks, filterDisabled("filter_2")).WillOnce(Return(absl::nullopt));
+    EXPECT_CALL(callbacks, setFilterConfigName("filter_2")).Times(0);
 
     // Only filter_1 should be added.
-    EXPECT_CALL(manager, applyFilterFactoryCb(_, _));
-    FilterChainUtility::createFilterChainForFactories(manager, options, filter_factories);
+    FilterChainUtility::createFilterChainForFactories(callbacks, filter_factories);
+    EXPECT_TRUE(added_filters.find("filter_1") != added_filters.end());
+    EXPECT_EQ(added_filters.size(), 1);
   }
 }
 

--- a/test/common/http/filter_manager_test.cc
+++ b/test/common/http/filter_manager_test.cc
@@ -91,11 +91,13 @@ TEST_F(FilterManagerTest, RequestHeadersOrResponseHeadersAccess) {
   auto encoder_filter = std::make_shared<NiceMock<MockStreamEncoderFilter>>();
 
   EXPECT_CALL(filter_factory_, createFilterChain(_))
-      .WillOnce(Invoke([&](FilterChainManager& manager) -> bool {
+      .WillOnce(Invoke([&](FilterChainFactoryCallbacks& callbacks) -> bool {
         auto decoder_factory = createDecoderFilterFactoryCb(decoder_filter);
-        manager.applyFilterFactoryCb({}, decoder_factory);
+        callbacks.setFilterConfigName("");
+        decoder_factory(callbacks);
         auto encoder_factory = createEncoderFilterFactoryCb(encoder_filter);
-        manager.applyFilterFactoryCb({}, encoder_factory);
+        callbacks.setFilterConfigName("");
+        encoder_factory(callbacks);
         return true;
       }));
   filter_manager_->createDownstreamFilterChain();
@@ -166,9 +168,10 @@ TEST_F(FilterManagerTest, SendLocalReplyDuringDecodingGrpcClassiciation) {
       .WillByDefault(Return(makeOptRef(*grpc_headers)));
 
   EXPECT_CALL(filter_factory_, createFilterChain(_))
-      .WillRepeatedly(Invoke([&](FilterChainManager& manager) -> bool {
+      .WillRepeatedly(Invoke([&](FilterChainFactoryCallbacks& callbacks) -> bool {
         auto factory = createDecoderFilterFactoryCb(filter);
-        manager.applyFilterFactoryCb({"configName1"}, factory);
+        callbacks.setFilterConfigName("configName1");
+        factory(callbacks);
         return true;
       }));
 
@@ -220,12 +223,14 @@ TEST_F(FilterManagerTest, SendLocalReplyDuringEncodingGrpcClassiciation) {
       }));
 
   EXPECT_CALL(filter_factory_, createFilterChain(_))
-      .WillRepeatedly(Invoke([&](FilterChainManager& manager) -> bool {
+      .WillRepeatedly(Invoke([&](FilterChainFactoryCallbacks& callbacks) -> bool {
         auto decoder_factory = createDecoderFilterFactoryCb(decoder_filter);
-        manager.applyFilterFactoryCb({"configName1"}, decoder_factory);
+        callbacks.setFilterConfigName("configName1");
+        decoder_factory(callbacks);
 
         auto stream_factory = createStreamFilterFactoryCb(encoder_filter);
-        manager.applyFilterFactoryCb({"configName2"}, stream_factory);
+        callbacks.setFilterConfigName("configName2");
+        stream_factory(callbacks);
         return true;
       }));
 
@@ -270,13 +275,16 @@ TEST_F(FilterManagerTest, OnLocalReply) {
   ON_CALL(filter_manager_callbacks_, requestHeaders()).WillByDefault(Return(makeOptRef(*headers)));
 
   EXPECT_CALL(filter_factory_, createFilterChain(_))
-      .WillRepeatedly(Invoke([&](FilterChainManager& manager) -> bool {
+      .WillRepeatedly(Invoke([&](FilterChainFactoryCallbacks& callbacks) -> bool {
         auto decoder_factory = createDecoderFilterFactoryCb(decoder_filter);
-        manager.applyFilterFactoryCb({"configName1"}, decoder_factory);
+        callbacks.setFilterConfigName("configName1");
+        decoder_factory(callbacks);
         auto stream_factory = createStreamFilterFactoryCb(stream_filter);
-        manager.applyFilterFactoryCb({"configName2"}, stream_factory);
+        callbacks.setFilterConfigName("configName2");
+        stream_factory(callbacks);
         auto encoder_factory = createEncoderFilterFactoryCb(encoder_filter);
-        manager.applyFilterFactoryCb({"configName3"}, encoder_factory);
+        callbacks.setFilterConfigName("configName3");
+        encoder_factory(callbacks);
         return true;
       }));
 
@@ -333,13 +341,16 @@ TEST_F(FilterManagerTest, MultipleOnLocalReply) {
   ON_CALL(filter_manager_callbacks_, requestHeaders()).WillByDefault(Return(makeOptRef(*headers)));
 
   EXPECT_CALL(filter_factory_, createFilterChain(_))
-      .WillRepeatedly(Invoke([&](FilterChainManager& manager) -> bool {
+      .WillRepeatedly(Invoke([&](FilterChainFactoryCallbacks& callbacks) -> bool {
         auto decoder_factory = createDecoderFilterFactoryCb(decoder_filter);
-        manager.applyFilterFactoryCb({"configName1"}, decoder_factory);
+        callbacks.setFilterConfigName("configName1");
+        decoder_factory(callbacks);
         auto stream_factory = createStreamFilterFactoryCb(stream_filter);
-        manager.applyFilterFactoryCb({"configName2"}, stream_factory);
+        callbacks.setFilterConfigName("configName2");
+        stream_factory(callbacks);
         auto encoder_factory = createEncoderFilterFactoryCb(encoder_filter);
-        manager.applyFilterFactoryCb({"configName3"}, encoder_factory);
+        callbacks.setFilterConfigName("configName3");
+        encoder_factory(callbacks);
         return true;
       }));
 
@@ -394,9 +405,10 @@ TEST_F(FilterManagerTest, ResetIdleTimer) {
   std::shared_ptr<MockStreamDecoderFilter> decoder_filter(new NiceMock<MockStreamDecoderFilter>());
 
   EXPECT_CALL(filter_factory_, createFilterChain(_))
-      .WillRepeatedly(Invoke([&](FilterChainManager& manager) -> bool {
+      .WillRepeatedly(Invoke([&](FilterChainFactoryCallbacks& callbacks) -> bool {
         auto decoder_factory = createDecoderFilterFactoryCb(decoder_filter);
-        manager.applyFilterFactoryCb({}, decoder_factory);
+        callbacks.setFilterConfigName("");
+        decoder_factory(callbacks);
         return true;
       }));
   filter_manager_->createDownstreamFilterChain();
@@ -413,9 +425,10 @@ TEST_F(FilterManagerTest, SetAndGetUpstreamOverrideHost) {
   std::shared_ptr<MockStreamDecoderFilter> decoder_filter(new NiceMock<MockStreamDecoderFilter>());
 
   EXPECT_CALL(filter_factory_, createFilterChain(_))
-      .WillRepeatedly(Invoke([&](FilterChainManager& manager) -> bool {
+      .WillRepeatedly(Invoke([&](FilterChainFactoryCallbacks& callbacks) -> bool {
         auto decoder_factory = createDecoderFilterFactoryCb(decoder_filter);
-        manager.applyFilterFactoryCb({}, decoder_factory);
+        callbacks.setFilterConfigName("");
+        decoder_factory(callbacks);
         return true;
       }));
   filter_manager_->createDownstreamFilterChain();
@@ -435,9 +448,10 @@ TEST_F(FilterManagerTest, GetRouteLevelFilterConfig) {
   std::shared_ptr<MockStreamDecoderFilter> decoder_filter(new NiceMock<MockStreamDecoderFilter>());
 
   EXPECT_CALL(filter_factory_, createFilterChain(_))
-      .WillRepeatedly(Invoke([&](FilterChainManager& manager) -> bool {
+      .WillRepeatedly(Invoke([&](FilterChainFactoryCallbacks& callbacks) -> bool {
         auto decoder_factory = createDecoderFilterFactoryCb(decoder_filter);
-        manager.applyFilterFactoryCb({"custom-name"}, decoder_factory);
+        callbacks.setFilterConfigName("custom-name");
+        decoder_factory(callbacks);
         return true;
       }));
   filter_manager_->createDownstreamFilterChain();
@@ -483,9 +497,10 @@ TEST_F(FilterManagerTest, GetRouteLevelFilterConfigForNullRoute) {
   std::shared_ptr<MockStreamDecoderFilter> decoder_filter(new NiceMock<MockStreamDecoderFilter>());
 
   EXPECT_CALL(filter_factory_, createFilterChain(_))
-      .WillRepeatedly(Invoke([&](FilterChainManager& manager) -> bool {
+      .WillRepeatedly(Invoke([&](FilterChainFactoryCallbacks& callbacks) -> bool {
         auto decoder_factory = createDecoderFilterFactoryCb(decoder_filter);
-        manager.applyFilterFactoryCb({"custom-name"}, decoder_factory);
+        callbacks.setFilterConfigName("custom-name");
+        decoder_factory(callbacks);
         return true;
       }));
   filter_manager_->createDownstreamFilterChain();
@@ -514,11 +529,13 @@ TEST_F(FilterManagerTest, MetadataContinueAll) {
   std::shared_ptr<MockStreamFilter> filter_2(new NiceMock<MockStreamFilter>());
 
   EXPECT_CALL(filter_factory_, createFilterChain(_))
-      .WillRepeatedly(Invoke([&](FilterChainManager& manager) -> bool {
+      .WillRepeatedly(Invoke([&](FilterChainFactoryCallbacks& callbacks) -> bool {
         auto decoder_factory = createStreamFilterFactoryCb(filter_1);
-        manager.applyFilterFactoryCb({"configName1"}, decoder_factory);
+        callbacks.setFilterConfigName("configName1");
+        decoder_factory(callbacks);
         decoder_factory = createStreamFilterFactoryCb(filter_2);
-        manager.applyFilterFactoryCb({"configName2"}, decoder_factory);
+        callbacks.setFilterConfigName("configName2");
+        decoder_factory(callbacks);
         return true;
       }));
   filter_manager_->createDownstreamFilterChain();
@@ -586,11 +603,13 @@ TEST_F(FilterManagerTest, DecodeMetadataSendsLocalReply) {
 
   std::shared_ptr<MockStreamFilter> filter_2(new NiceMock<MockStreamFilter>());
   EXPECT_CALL(filter_factory_, createFilterChain(_))
-      .WillRepeatedly(Invoke([&](FilterChainManager& manager) -> bool {
+      .WillRepeatedly(Invoke([&](FilterChainFactoryCallbacks& callbacks) -> bool {
         auto factory = createStreamFilterFactoryCb(filter_1);
-        manager.applyFilterFactoryCb({"configName1"}, factory);
+        callbacks.setFilterConfigName("configName1");
+        factory(callbacks);
         factory = createStreamFilterFactoryCb(filter_2);
-        manager.applyFilterFactoryCb({"configName2"}, factory);
+        callbacks.setFilterConfigName("configName2");
+        factory(callbacks);
         return true;
       }));
   filter_manager_->createDownstreamFilterChain();
@@ -633,11 +652,13 @@ TEST_F(FilterManagerTest, MetadataContinueAllFollowedByHeadersLocalReply) {
   std::shared_ptr<MockStreamFilter> filter_2(new NiceMock<MockStreamFilter>());
 
   EXPECT_CALL(filter_factory_, createFilterChain(_))
-      .WillRepeatedly(Invoke([&](FilterChainManager& manager) -> bool {
+      .WillRepeatedly(Invoke([&](FilterChainFactoryCallbacks& callbacks) -> bool {
         auto decoder_factory = createStreamFilterFactoryCb(filter_1);
-        manager.applyFilterFactoryCb({"configName1"}, decoder_factory);
+        callbacks.setFilterConfigName("configName1");
+        decoder_factory(callbacks);
         decoder_factory = createStreamFilterFactoryCb(filter_2);
-        manager.applyFilterFactoryCb({"configName2"}, decoder_factory);
+        callbacks.setFilterConfigName("configName2");
+        decoder_factory(callbacks);
         return true;
       }));
   filter_manager_->createDownstreamFilterChain();
@@ -673,11 +694,13 @@ TEST_F(FilterManagerTest, EncodeMetadataSendsLocalReply) {
 
   std::shared_ptr<MockStreamFilter> filter_2(new NiceMock<MockStreamFilter>());
   EXPECT_CALL(filter_factory_, createFilterChain(_))
-      .WillRepeatedly(Invoke([&](FilterChainManager& manager) -> bool {
+      .WillRepeatedly(Invoke([&](FilterChainFactoryCallbacks& callbacks) -> bool {
         auto factory = createStreamFilterFactoryCb(filter_1);
-        manager.applyFilterFactoryCb({"configName1"}, factory);
+        callbacks.setFilterConfigName("configName1");
+        factory(callbacks);
         factory = createStreamFilterFactoryCb(filter_2);
-        manager.applyFilterFactoryCb({"configName2"}, factory);
+        callbacks.setFilterConfigName("configName2");
+        factory(callbacks);
         return true;
       }));
   filter_manager_->createDownstreamFilterChain();
@@ -722,9 +745,10 @@ TEST_F(FilterManagerTest, IdleTimerResets) {
 
   std::shared_ptr<MockStreamFilter> filter_1(new NiceMock<MockStreamFilter>());
   EXPECT_CALL(filter_factory_, createFilterChain(_))
-      .WillRepeatedly(Invoke([&](FilterChainManager& manager) -> bool {
+      .WillRepeatedly(Invoke([&](FilterChainFactoryCallbacks& callbacks) -> bool {
         auto factory = createStreamFilterFactoryCb(filter_1);
-        manager.applyFilterFactoryCb({"configName1"}, factory);
+        callbacks.setFilterConfigName("configName1");
+        factory(callbacks);
         return true;
       }));
   filter_manager_->createDownstreamFilterChain();

--- a/test/common/http/hcm_router_fuzz_test.cc
+++ b/test/common/http/hcm_router_fuzz_test.cc
@@ -459,11 +459,9 @@ public:
     cluster_manager_.createDefaultClusters(*this);
     // Install the `RouterFuzzFilter` here
     ON_CALL(filter_factory_, createFilterChain(_))
-        .WillByDefault(Invoke([this](FilterChainManager& manager) -> bool {
-          FilterFactoryCb decoder_filter_factory = [this](FilterChainFactoryCallbacks& callbacks) {
-            callbacks.addStreamDecoderFilter(RouterFuzzFilter::create(filter_config_));
-          };
-          manager.applyFilterFactoryCb({}, decoder_filter_factory);
+        .WillByDefault(Invoke([this](FilterChainFactoryCallbacks& callbacks) -> bool {
+          callbacks.setFilterConfigName("");
+          callbacks.addStreamDecoderFilter(RouterFuzzFilter::create(filter_config_));
           return true;
         }));
     ON_CALL(*route_config_provider_.route_config_, route(_, _, _, _))

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -223,8 +223,8 @@ public:
 
 TEST_F(RouterTest, SenselessTestForCoverage) {
   config_->timeSource();
-  Http::MockFilterChainManager mock_manager;
-  config_->createUpgradeFilterChain("", nullptr, mock_manager, Http::EmptyFilterChainOptions{});
+  Http::MockFilterChainFactoryCallbacks callbacks;
+  config_->createUpgradeFilterChain("", nullptr, callbacks);
 
   router_->route();
   router_->timeSource();

--- a/test/common/router/upstream_request_test.cc
+++ b/test/common/router/upstream_request_test.cc
@@ -144,18 +144,14 @@ TEST_F(UpstreamRequestTest, AcceptRouterHeaders) {
   std::shared_ptr<Http::MockStreamDecoderFilter> filter(
       new NiceMock<Http::MockStreamDecoderFilter>());
 
-  EXPECT_CALL(*router_filter_interface_.cluster_info_, createFilterChain(_, _))
-      .WillOnce(
-          Invoke([&](Http::FilterChainManager& manager, const Http::FilterChainOptions&) -> bool {
-            auto factory = createDecoderFilterFactoryCb(filter);
-            manager.applyFilterFactoryCb({}, factory);
-            Http::FilterFactoryCb factory_cb =
-                [](Http::FilterChainFactoryCallbacks& callbacks) -> void {
-              callbacks.addStreamDecoderFilter(std::make_shared<UpstreamCodecFilter>());
-            };
-            manager.applyFilterFactoryCb({}, factory_cb);
-            return true;
-          }));
+  EXPECT_CALL(*router_filter_interface_.cluster_info_, createFilterChain(_))
+      .WillOnce(Invoke([&](Http::FilterChainFactoryCallbacks& callbacks) -> bool {
+        auto factory = createDecoderFilterFactoryCb(filter);
+        callbacks.setFilterConfigName("");
+        callbacks.addStreamDecoderFilter(filter);
+        callbacks.addStreamDecoderFilter(std::make_shared<UpstreamCodecFilter>());
+        return true;
+      }));
 
   initialize();
   ASSERT_TRUE(filter->callbacks_ != nullptr);

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -6151,12 +6151,11 @@ TEST_F(ClusterInfoImplTest, FilterChain) {
                                                          Network::Address::IpVersion::v4);
 
     auto cluster = makeCluster(yaml);
-    Http::MockFilterChainManager manager;
-    const Http::EmptyFilterChainOptions options;
-    EXPECT_FALSE(cluster->info()->createUpgradeFilterChain("foo", nullptr, manager, options));
+    NiceMock<Http::MockFilterChainFactoryCallbacks> callbacks;
+    EXPECT_FALSE(cluster->info()->createUpgradeFilterChain("foo", nullptr, callbacks));
 
-    EXPECT_CALL(manager, applyFilterFactoryCb(_, _)).Times(0);
-    EXPECT_FALSE(cluster->info()->createFilterChain(manager));
+    EXPECT_CALL(callbacks, setFilterConfigName(_)).Times(0);
+    EXPECT_FALSE(cluster->info()->createFilterChain(callbacks));
   }
 
   {
@@ -6177,12 +6176,11 @@ TEST_F(ClusterInfoImplTest, FilterChain) {
                                                          Network::Address::IpVersion::v4);
 
     auto cluster = makeCluster(yaml);
-    Http::MockFilterChainManager manager;
-    const Http::EmptyFilterChainOptions options;
-    EXPECT_FALSE(cluster->info()->createUpgradeFilterChain("foo", nullptr, manager, options));
+    NiceMock<Http::MockFilterChainFactoryCallbacks> callbacks;
+    EXPECT_FALSE(cluster->info()->createUpgradeFilterChain("foo", nullptr, callbacks));
 
-    EXPECT_CALL(manager, applyFilterFactoryCb(_, _));
-    EXPECT_TRUE(cluster->info()->createFilterChain(manager));
+    EXPECT_CALL(callbacks, setFilterConfigName(_));
+    EXPECT_TRUE(cluster->info()->createFilterChain(callbacks));
   }
 }
 

--- a/test/extensions/common/wasm/wasm_test.cc
+++ b/test/extensions/common/wasm/wasm_test.cc
@@ -1360,9 +1360,10 @@ public:
   void setupContext() {
     WasmCommonContextTest::setupContext();
     ON_CALL(filter_factory_, createFilterChain(_))
-        .WillByDefault(Invoke([this](Http::FilterChainManager& manager) -> bool {
+        .WillByDefault(Invoke([this](Http::FilterChainFactoryCallbacks& callbacks) -> bool {
           auto factory = createWasmFilter();
-          manager.applyFilterFactoryCb({}, factory);
+          callbacks.setFilterConfigName("");
+          factory(callbacks);
           return true;
         }));
     ON_CALL(filter_manager_callbacks_, requestHeaders())

--- a/test/extensions/filters/http/match_delegate/config_test.cc
+++ b/test/extensions/filters/http/match_delegate/config_test.cc
@@ -785,6 +785,32 @@ TEST(DelegatingFilterTest, MatchTreeFilterActionEncodingTrailers) {
   delegating_filter->decodeComplete();
 }
 
+TEST(DelegatingFactoryCallbacks, DelegatingFactoryCallbacksTest) {
+  NiceMock<Envoy::Http::MockFilterChainFactoryCallbacks> factory_callbacks;
+  NiceMock<StreamInfo::MockStreamInfo> stream_info;
+  NiceMock<Event::MockDispatcher> dispatcher;
+  ON_CALL(factory_callbacks, streamInfo()).WillByDefault(ReturnRef(stream_info));
+  ON_CALL(factory_callbacks, dispatcher()).WillByDefault(ReturnRef(dispatcher));
+
+  auto decoder_filter = std::make_shared<Envoy::Http::MockStreamDecoderFilter>();
+  auto encoder_filter = std::make_shared<Envoy::Http::MockStreamEncoderFilter>();
+  auto filter = std::make_shared<Envoy::Http::MockStreamFilter>();
+
+  DelegatingFactoryCallbacks delegating_factory_callbacks(factory_callbacks, nullptr);
+
+  delegating_factory_callbacks.dispatcher();
+  delegating_factory_callbacks.addStreamDecoderFilter(decoder_filter);
+  delegating_factory_callbacks.addStreamEncoderFilter(encoder_filter);
+  delegating_factory_callbacks.addStreamFilter(filter);
+  delegating_factory_callbacks.addAccessLogHandler(nullptr);
+
+  delegating_factory_callbacks.filterConfigName();
+  delegating_factory_callbacks.setFilterConfigName("test");
+  delegating_factory_callbacks.streamInfo();
+  delegating_factory_callbacks.requestHeaders();
+  delegating_factory_callbacks.route();
+}
+
 } // namespace
 } // namespace MatchDelegate
 } // namespace Http

--- a/test/extensions/upstreams/http/tcp/upstream_request_test.cc
+++ b/test/extensions/upstreams/http/tcp/upstream_request_test.cc
@@ -94,10 +94,9 @@ TEST_F(TcpConnPoolTest, Cancel) {
 class TcpUpstreamTest : public ::testing::Test {
 public:
   TcpUpstreamTest() {
-    ON_CALL(*mock_router_filter_.cluster_info_, createFilterChain(_, _))
+    ON_CALL(*mock_router_filter_.cluster_info_, createFilterChain(_))
         .WillByDefault(
-            Invoke([&](Envoy::Http::FilterChainManager&,
-                       const Envoy::Http::FilterChainOptions&) -> bool { return false; }));
+            Invoke([&](Envoy::Http::FilterChainFactoryCallbacks&) -> bool { return false; }));
     EXPECT_CALL(mock_router_filter_, downstreamHeaders())
         .Times(AnyNumber())
         .WillRepeatedly(Return(&request_));

--- a/test/mocks/http/mocks.cc
+++ b/test/mocks/http/mocks.cc
@@ -50,14 +50,6 @@ MockServerConnection::~MockServerConnection() = default;
 MockClientConnection::MockClientConnection() = default;
 MockClientConnection::~MockClientConnection() = default;
 
-MockFilterChainManager::MockFilterChainManager() {
-  ON_CALL(*this, applyFilterFactoryCb(_, _))
-      .WillByDefault(
-          Invoke([this](FilterContext, FilterFactoryCb& factory) { factory(callbacks_); }));
-}
-
-MockFilterChainManager::~MockFilterChainManager() = default;
-
 MockFilterChainFactory::MockFilterChainFactory() = default;
 MockFilterChainFactory::~MockFilterChainFactory() = default;
 

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -192,17 +192,12 @@ public:
   MOCK_METHOD(void, addStreamFilter, (Http::StreamFilterSharedPtr filter));
   MOCK_METHOD(void, addAccessLogHandler, (AccessLog::InstanceSharedPtr handler));
   MOCK_METHOD(Event::Dispatcher&, dispatcher, ());
-};
-
-class MockFilterChainManager : public FilterChainManager {
-public:
-  MockFilterChainManager();
-  ~MockFilterChainManager() override;
-
-  // Http::FilterChainManager
-  MOCK_METHOD(void, applyFilterFactoryCb, (FilterContext context, FilterFactoryCb& factory));
-
-  NiceMock<MockFilterChainFactoryCallbacks> callbacks_;
+  MOCK_METHOD(absl::string_view, filterConfigName, (), (const));
+  MOCK_METHOD(void, setFilterConfigName, (absl::string_view name));
+  MOCK_METHOD(OptRef<const Router::Route>, route, (), (const));
+  MOCK_METHOD(absl::optional<bool>, filterDisabled, (absl::string_view filter_name), (const));
+  MOCK_METHOD(const StreamInfo::StreamInfo&, streamInfo, (), (const));
+  MOCK_METHOD(RequestHeaderMapOptRef, requestHeaders, (), (const));
 };
 
 class MockFilterChainFactory : public FilterChainFactory {
@@ -211,13 +206,10 @@ public:
   ~MockFilterChainFactory() override;
 
   // Http::FilterChainFactory
-  bool createFilterChain(FilterChainManager& manager, const FilterChainOptions&) const override {
-    return createFilterChain(manager);
-  }
-  MOCK_METHOD(bool, createFilterChain, (FilterChainManager & manager), (const));
+  MOCK_METHOD(bool, createFilterChain, (FilterChainFactoryCallbacks & callbacks), (const));
   MOCK_METHOD(bool, createUpgradeFilterChain,
               (absl::string_view upgrade_type, const FilterChainFactory::UpgradeMap* upgrade_map,
-               FilterChainManager& manager, const FilterChainOptions&),
+               FilterChainFactoryCallbacks& callbacks),
               (const));
 };
 

--- a/test/mocks/upstream/cluster_info.cc
+++ b/test/mocks/upstream/cluster_info.cc
@@ -154,9 +154,8 @@ MockClusterInfo::MockClusterInfo()
           }));
   ON_CALL(*this, upstreamHttpProtocol(_))
       .WillByDefault(Return(std::vector<Http::Protocol>{Http::Protocol::Http11}));
-  ON_CALL(*this, createFilterChain(_, _))
-      .WillByDefault(Invoke([&](Http::FilterChainManager&,
-                                const Http::FilterChainOptions&) -> bool { return false; }));
+  ON_CALL(*this, createFilterChain(_))
+      .WillByDefault(Invoke([&](Http::FilterChainFactoryCallbacks&) -> bool { return false; }));
   ON_CALL(*this, makeHeaderValidator(_)).WillByDefault(Invoke([&](Http::Protocol protocol) {
     return header_validator_factory_ ? header_validator_factory_->createClientHeaderValidator(
                                            protocol, codecStats(protocol))

--- a/test/mocks/upstream/cluster_info.h
+++ b/test/mocks/upstream/cluster_info.h
@@ -159,13 +159,12 @@ public:
   MOCK_METHOD(std::vector<Http::Protocol>, upstreamHttpProtocol, (absl::optional<Http::Protocol>),
               (const));
 
-  MOCK_METHOD(bool, createFilterChain,
-              (Http::FilterChainManager & manager, const Http::FilterChainOptions& options),
+  MOCK_METHOD(bool, createFilterChain, (Http::FilterChainFactoryCallbacks & callbacks),
               (const, override));
   MOCK_METHOD(bool, createUpgradeFilterChain,
               (absl::string_view upgrade_type,
                const Http::FilterChainFactory::UpgradeMap* upgrade_map,
-               Http::FilterChainManager& manager, const Http::FilterChainOptions&),
+               Http::FilterChainFactoryCallbacks& callbacks),
               (const));
   MOCK_METHOD(Http::ClientHeaderValidatorPtr, makeHeaderValidator, (Http::Protocol), (const));
   MOCK_METHOD(


### PR DESCRIPTION
Commit Message: filter chain refactoring: add more context for FilterChainFactoryCallbacks
Additional Description:

This PRs contains:
1. expose request headers, stream info and so on at the `FilterChainFactoryCallbacks`, the the filter factory could get more context about current stream to create a filter.
2. allow the filter factory to set the filterConfigName() which is helpful for the case where a single filter factory want to inject multiple different filters to chain.

Risk Level: mid. core code change.
Testing: n/a.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.