### PR TITLE
ext_proc: fix proto which is causing build failures

### DIFF
--- a/api/envoy/service/ext_proc/v3/external_processor.proto
+++ b/api/envoy/service/ext_proc/v3/external_processor.proto
@@ -164,7 +164,7 @@ message ProcessingRequest {
 //   the server must send back exactly one ProcessingResponse message.
 // * If it is set to ``FULL_DUPLEX_STREAMED``, the server must follow the API defined
 //   for this mode to send the ProcessingResponse messages.
-// [#next-free-field: 12]
+// [#next-free-field: 13]
 message ProcessingResponse {
   // The response type that is sent by the server.
   oneof response {
@@ -249,7 +249,7 @@ message ProcessingResponse {
   // without this, the ext_proc server could not terminate the stream
   // early, because it would wind up dropping any body contents that the
   // client had already sent before it saw the ext_proc stream termination.
-  bool request_drain = 11;
+  bool request_drain = 12;
 
   // When ext_proc server receives a request message, in case it needs more
   // time to process the message, it sends back a ProcessingResponse message


### PR DESCRIPTION
## Description

This PR fixes a build failure in ExtProc which is probably caused due to a race condition while merging changes.

```
external/envoy_api/envoy/service/ext_proc/v3/external_processor.proto:252:24: Field number 11 has already been used in "envoy.service.ext_proc.v3.ProcessingResponse" by field "streamed_immediate_response". Next available field number is 12.
INFO: Elapsed time: 15.256s, Critical Path: 2.08s
INFO: 178 processes: 165 remote cache hit, 13 internal.
ERROR: Build did NOT complete successfully
ERROR: No test targets were found, yet testing was requested
```

---

**Commit Message:** ext_proc: fix proto which is causing build failures
**Additional Description:** Fix ExtProc failing build.
**Risk Level:** Low
**Testing:** CI
**Docs Changes:** N/A
**Release Notes:** N/A