### PR TITLE
coverage: adjust the LCOV numbers for ExtProc

### DIFF
--- a/test/coverage.yaml
+++ b/test/coverage.yaml
@@ -41,6 +41,7 @@ directories:
   source/extensions/filters/http/dynamic_forward_proxy: 94.8
   source/extensions/filters/http/dynamic_modules: 95.2
   source/extensions/filters/http/decompressor: 95.9
+  source/extensions/filters/http/ext_proc: 96.4
   source/extensions/filters/http/grpc_json_reverse_transcoder: 94.8
   source/extensions/filters/http/grpc_json_transcoder: 94.0  # TODO(#28232)
   source/extensions/filters/http/ip_tagging: 95.9


### PR DESCRIPTION
## Description

This PR adjusts the ExtProc coverage numbers as main is failing and is outdated with the current coverage for this filter.

---

**Commit Message:** coverage: adjust the LCOV numbers for ExtProc
**Additional Description:** Adjust LCOV for ExtProc.
**Risk Level:** N/A
**Testing:** CI
**Docs Changes:** N/A
**Release Notes:** N/A