### PR TITLE
test: fix TcpProxyOdcdsIntegrationTest RepeatedRequest test

### DIFF
--- a/test/integration/tcp_proxy_odcds_integration_test.cc
+++ b/test/integration/tcp_proxy_odcds_integration_test.cc
@@ -186,13 +186,14 @@ TEST_P(TcpProxyOdcdsIntegrationTest, RepeatedRequest) {
   // Verify the on-demand CDS request and respond without providing the cluster.
   EXPECT_TRUE(compareDeltaDiscoveryRequest(Config::TestTypeUrl::get().Cluster, {"new_cluster"}, {},
                                            odcds_stream_.get()));
+
+  test_server_->waitForCounterEq("tcp.tcpproxy_stats.on_demand_cluster_attempt",
+                                 expected_upstream_connections);
+
   sendDeltaDiscoveryResponse<envoy::config::cluster::v3::Cluster>(
       Config::TestTypeUrl::get().Cluster, {new_cluster_}, {}, "1", odcds_stream_.get());
   EXPECT_TRUE(compareDeltaDiscoveryRequest(Config::TestTypeUrl::get().Cluster, {}, {},
                                            odcds_stream_.get()));
-
-  test_server_->waitForCounterEq("tcp.tcpproxy_stats.on_demand_cluster_attempt",
-                                 expected_upstream_connections);
 
   // This upstream is listening on the endpoint of `new_cluster`.
   for (auto n = expected_upstream_connections; n != 0; n--) {


### PR DESCRIPTION
## Description

Fix https://github.com/envoyproxy/envoy/issues/42677

**Thousand Iterations:**

```
$ bazel test //test/integration:tcp_proxy_odcds_integration_test --test_filter="IpVersionsClientType/TcpProxyOdcdsIntegrationTest.RepeatedRequest/*" --runs_per_test=1000 --test_output=errors
INFO: Analyzed target //test/integration:tcp_proxy_odcds_integration_test (0 packages loaded, 13 targets configured).
INFO: Found 1 test target...
Target //test/integration:tcp_proxy_odcds_integration_test up-to-date:
  bazel-bin/test/integration/tcp_proxy_odcds_integration_test
INFO: Elapsed time: 139.266s, Critical Path: 2.22s
INFO: 1001 processes: 1 internal, 1000 darwin-sandbox.
INFO: Build completed successfully, 1001 total actions

Executed 1 out of 1 test: 1 test passes.
```

---

**Commit Message:** test: fix TcpProxyOdcdsIntegrationTest RepeatedRequest test
**Additional Description:** Unflake TcpProxyOdcdsIntegrationTest test.
**Risk Level:** N/A
**Testing:** CI
**Docs Changes:** N/A
**Release Notes:** N/A