### PR TITLE
deps: Shift numa static build into envoy workspace

### DIFF
--- a/bazel/external/BUILD
+++ b/bazel/external/BUILD
@@ -42,3 +42,23 @@ cc_library(
         ],
     }),
 )
+
+# Create a proper static library archive from the cc_library.
+cc_static_library(
+    name = "numa_static",
+    target_compatible_with = ["@platforms//os:linux"],
+    deps = ["@numactl//:numa"],
+)
+
+# Create a properly named libnuma.a archive for foreign_cc dependencies.
+# The cc_library above produces Bazel-internal archives, but foreign_cc
+# configure_make rules (like qatlib) expect a traditional libnuma.a file
+# that can be found with -lnuma.
+genrule(
+    name = "numa_archive",
+    srcs = [":numa_static"],
+    outs = ["lib/libnuma.a"],
+    cmd = "mkdir -p $$(dirname $@) && cp $< $@",
+    target_compatible_with = ["@platforms//os:linux"],
+    visibility = ["//visibility:public"],
+)

--- a/bazel/external/numactl.BUILD
+++ b/bazel/external/numactl.BUILD
@@ -228,23 +228,3 @@ alias(
     actual = ":numa",
     visibility = ["//visibility:public"],
 )
-
-# Create a proper static library archive from the cc_library.
-cc_static_library(
-    name = "numa_static",
-    target_compatible_with = LINUX_ONLY,
-    deps = [":numa"],
-)
-
-# Create a properly named libnuma.a archive for foreign_cc dependencies.
-# The cc_library above produces Bazel-internal archives, but foreign_cc
-# configure_make rules (like qatlib) expect a traditional libnuma.a file
-# that can be found with -lnuma.
-genrule(
-    name = "numa_archive",
-    srcs = [":numa_static"],
-    outs = ["lib/libnuma.a"],
-    cmd = "mkdir -p $$(dirname $@) && cp $< $@",
-    target_compatible_with = LINUX_ONLY,
-    visibility = ["//visibility:public"],
-)

--- a/contrib/kae/BUILD
+++ b/contrib/kae/BUILD
@@ -23,9 +23,9 @@ configure_make(
         "--host aarch64-linux-gnu ",
         "--target aarch64-linux-gnu",
     ],
-    data = ["@numactl//:numa_archive"],
+    data = ["//bazel/external:numa_archive"],
     env = {
-        "LDFLAGS": "-L$$EXT_BUILD_ROOT/$(BINDIR)/external/numactl/lib",
+        "LDFLAGS": "-L$$EXT_BUILD_ROOT/$(BINDIR)/bazel/external/lib",
     } | select({
         "//bazel:clang_build": {
             "CFLAGS": "-Wno-unused-command-line-argument -Wno-incompatible-pointer-types",

--- a/contrib/qat/BUILD
+++ b/contrib/qat/BUILD
@@ -27,14 +27,12 @@ configure_make(
     ],
     # Include the numa_archive genrule output so that libnuma.a is available
     # for the linker to find with -lnuma.
-    data = [
-        "@numactl//:numa_archive",
-    ],
+    data = ["//bazel/external:numa_archive"],
     # Point to the directory containing the libnuma.a archive created by the
     # numa_archive genrule. The cc_library doesn't produce a file that can be
     # found with -lnuma, so we need to use the genrule output.
     env = {
-        "LDFLAGS": "-L$$EXT_BUILD_ROOT/$(BINDIR)/external/numactl/lib",
+        "LDFLAGS": "-L$$EXT_BUILD_ROOT/$(BINDIR)/bazel/external/lib",
     },
     lib_source = "@com_github_intel_qatlib//:all",
     out_static_libs = [

--- a/contrib/qat/compression/qatzip/compressor/source/BUILD
+++ b/contrib/qat/compression/qatzip/compressor/source/BUILD
@@ -15,7 +15,7 @@ licenses(["notice"])  # Apache 2
 envoy_contrib_package()
 
 COMMON_ENV = {
-    "LDFLAGS": "-L$$EXT_BUILD_ROOT/$(BINDIR)/external/numactl/lib",
+    "LDFLAGS": "-L$$EXT_BUILD_ROOT/$(BINDIR)/bazel/external/lib",
 }
 
 configure_make(
@@ -28,9 +28,7 @@ configure_make(
     ],
     # Include the numa_archive genrule output so that libnuma.a is available
     # for the linker to find with -lnuma.
-    data = [
-        "@numactl//:numa_archive",
-    ],
+    data = ["//bazel/external:numa_archive"],
     # Point to the directory containing the libnuma.a archive created by the
     # numa_archive genrule. The cc_library doesn't produce a file that can be
     # found with -lnuma, so we need to use the genrule output.

--- a/contrib/qat/compression/qatzstd/compressor/source/BUILD
+++ b/contrib/qat/compression/qatzstd/compressor/source/BUILD
@@ -17,7 +17,7 @@ envoy_contrib_package()
 COMMON_ENV = {
     "ZSTDLIB": "$$EXT_BUILD_ROOT/external/zstd/lib",
     "QAT_INCLUDE_PATH": "$$EXT_BUILD_DEPS/qatlib/include/qat",
-    "LDFLAGS": "-L$$EXT_BUILD_ROOT/$(BINDIR)/external/numactl/lib",
+    "LDFLAGS": "-L$$EXT_BUILD_ROOT/$(BINDIR)/bazel/external/lib",
 }
 
 COMMON_CFLAGS = "-I$$EXT_BUILD_ROOT/external/numactl"
@@ -27,9 +27,7 @@ make(
     build_data = ["@com_github_qat_zstd//:all"],
     # Include the numa_archive genrule output so that libnuma.a is available
     # for the linker to find with -lnuma.
-    data = [
-        "@numactl//:numa_archive",
-    ],
+    data = ["//bazel/external:numa_archive"],
     env = select({
         "//bazel:clang_build": COMMON_ENV | {
             "CFLAGS": COMMON_CFLAGS + " -Wno-error=unused-parameter -Wno-error=unused-command-line-argument",


### PR DESCRIPTION
Moving to bzlmod - this allows us to use the bcr module without any patches