### PR TITLE
Allow bind for sockets created from non default IOHandles

### DIFF
--- a/source/common/listener_manager/listener_manager_impl.cc
+++ b/source/common/listener_manager/listener_manager_impl.cc
@@ -335,7 +335,8 @@ absl::StatusOr<Network::SocketSharedPtr> ProdListenerComponentFactory::createLis
     if (!io_handle) {
       return absl::InvalidArgumentError("failed to create socket using custom interface");
     }
-    return std::make_shared<Network::TcpListenSocket>(std::move(io_handle), address, options);
+    return std::make_shared<Network::TcpListenSocket>(std::move(io_handle), address, options,
+                                                      absl::nullopt, bind_type != BindType::NoBind);
   }
 
   // Continue with standard socket creation for addresses using the default interface.

--- a/source/common/network/listen_socket_impl.h
+++ b/source/common/network/listen_socket_impl.h
@@ -71,10 +71,17 @@ public:
   NetworkListenSocket(
       IoHandlePtr&& io_handle, const Address::InstanceConstSharedPtr& address,
       const Network::Socket::OptionsSharedPtr& options,
-      OptRef<ParentDrainedCallbackRegistrar> parent_drained_callback_registrar = absl::nullopt)
+      OptRef<ParentDrainedCallbackRegistrar> parent_drained_callback_registrar = absl::nullopt,
+      bool bind_to_port = false)
       : ListenSocketImpl(std::move(io_handle), address),
         parent_drained_callback_registrar_(parent_drained_callback_registrar) {
-    setListenSocketOptions(options);
+    if (bind_to_port) {
+      RELEASE_ASSERT(io_handle_ && io_handle_->isOpen(), "");
+      setPrebindSocketOptions();
+      setupSocket(options);
+    } else {
+      setListenSocketOptions(options);
+    }
   }
 
   OptRef<ParentDrainedCallbackRegistrar> parentDrainedCallbackRegistrar() const override {


### PR DESCRIPTION
This change allows sockets that are creates from custom IOHandles to also use the bind config.

Risk Level: low
Testing: unit tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
