### PR TITLE
dynamic_modules: added scheduler API for HTTP filter configuration

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -357,6 +357,11 @@ new_features:
     Added support for streamable HTTP callouts in dynamic modules. Modules can create streaming HTTP connections to
     upstream clusters using ``start_http_stream``, send request data and trailers incrementally, and receive streaming
     response headers, data, and trailers through dedicated callbacks.
+- area: dynamic modules
+  change: |
+    Added scheduler API for HTTP filter configuration in dynamic modules. The configuration scheduler allows modules
+    to dispatch asynchronous operations to the main thread, enabling singleton/bootstrap patterns similar to WASM
+    filters for initialization and background tasks.
 - area: udp_sink
   change: |
     Enhanced the UDP sink to support tapped messages larger than 64KB.

--- a/source/extensions/filters/http/dynamic_modules/abi_impl.cc
+++ b/source/extensions/filters/http/dynamic_modules/abi_impl.cc
@@ -1409,6 +1409,27 @@ void envoy_dynamic_module_callback_http_filter_scheduler_commit(
   scheduler->commit(event_id);
 }
 
+envoy_dynamic_module_type_http_filter_config_scheduler_module_ptr
+envoy_dynamic_module_callback_http_filter_config_scheduler_new(
+    envoy_dynamic_module_type_http_filter_config_envoy_ptr filter_config_envoy_ptr) {
+  auto filter_config = static_cast<DynamicModuleHttpFilterConfig*>(filter_config_envoy_ptr);
+  return new DynamicModuleHttpFilterConfigScheduler(filter_config->weak_from_this(),
+                                                    filter_config->main_thread_dispatcher_);
+}
+
+void envoy_dynamic_module_callback_http_filter_config_scheduler_delete(
+    envoy_dynamic_module_type_http_filter_config_scheduler_module_ptr scheduler_module_ptr) {
+  delete static_cast<DynamicModuleHttpFilterConfigScheduler*>(scheduler_module_ptr);
+}
+
+void envoy_dynamic_module_callback_http_filter_config_scheduler_commit(
+    envoy_dynamic_module_type_http_filter_config_scheduler_module_ptr scheduler_module_ptr,
+    uint64_t event_id) {
+  DynamicModuleHttpFilterConfigScheduler* scheduler =
+      static_cast<DynamicModuleHttpFilterConfigScheduler*>(scheduler_module_ptr);
+  scheduler->commit(event_id);
+}
+
 void envoy_dynamic_module_callback_http_filter_continue_decoding(
     envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr) {
   DynamicModuleHttpFilter* filter = static_cast<DynamicModuleHttpFilter*>(filter_envoy_ptr);


### PR DESCRIPTION
## Description

This PR adds scheduler API for HTTP filter configuration in the dynamic modules.

The configuration scheduler allows modules to dispatch asynchronous operations to the main thread, enabling singleton/bootstrap patterns similar to WASM filters for initialization and background tasks.

Fix https://github.com/envoyproxy/dynamic-modules-examples/issues/51

---

**Commit Message:** dynamic_modules: added scheduler API for HTTP filter configuration
**Additional Description:** Added scheduler API for HTTP filter configuration in the dynamic modules.
**Risk Level:** Low
**Testing:** Added Tests
**Docs Changes**: Added
**Release Notes**: Added