### PR TITLE
dynamic_modules: add metrics ABI to access loggers

### DIFF
--- a/source/extensions/access_loggers/dynamic_modules/access_log_config.h
+++ b/source/extensions/access_loggers/dynamic_modules/access_log_config.h
@@ -1,8 +1,12 @@
 #pragma once
 
+#include "envoy/common/optref.h"
 #include "envoy/extensions/access_loggers/dynamic_modules/v3/dynamic_modules.pb.h"
+#include "envoy/stats/scope.h"
+#include "envoy/stats/stats.h"
 
 #include "source/common/common/statusor.h"
+#include "source/common/stats/utility.h"
 #include "source/extensions/dynamic_modules/abi.h"
 #include "source/extensions/dynamic_modules/dynamic_modules.h"
 
@@ -20,6 +24,9 @@ using OnAccessLoggerLogType = decltype(&envoy_dynamic_module_on_access_logger_lo
 using OnAccessLoggerDestroyType = decltype(&envoy_dynamic_module_on_access_logger_destroy);
 using OnAccessLoggerFlushType = decltype(&envoy_dynamic_module_on_access_logger_flush);
 
+// Custom namespace prefix for access logger stats.
+constexpr char AccessLogStatsNamespace[] = "dynamic_module_access_logger";
+
 /**
  * Configuration for dynamic module access loggers. This resolves and holds the symbols used for
  * access logging. Multiple access log instances may share this config.
@@ -35,10 +42,12 @@ public:
    * @param logger_name the name of the logger.
    * @param logger_config the configuration bytes for the logger.
    * @param dynamic_module the dynamic module to use.
+   * @param stats_scope the stats scope for metrics.
    */
   DynamicModuleAccessLogConfig(const absl::string_view logger_name,
                                const absl::string_view logger_config,
-                               Extensions::DynamicModules::DynamicModulePtr dynamic_module);
+                               Extensions::DynamicModules::DynamicModulePtr dynamic_module,
+                               Stats::Scope& stats_scope);
 
   ~DynamicModuleAccessLogConfig();
 
@@ -54,12 +63,90 @@ public:
   // Optional flush callback. Called before logger destruction during shutdown.
   OnAccessLoggerFlushType on_logger_flush_{nullptr};
 
+  // ----------------------------- Metrics Support -----------------------------
+  // Handle classes for storing defined metrics.
+
+  class ModuleCounterHandle {
+  public:
+    ModuleCounterHandle(Stats::Counter& counter) : counter_(counter) {}
+    void add(uint64_t value) const { counter_.add(value); }
+
+  private:
+    Stats::Counter& counter_;
+  };
+
+  class ModuleGaugeHandle {
+  public:
+    ModuleGaugeHandle(Stats::Gauge& gauge) : gauge_(gauge) {}
+    void add(uint64_t value) const { gauge_.add(value); }
+    void sub(uint64_t value) const { gauge_.sub(value); }
+    void set(uint64_t value) const { gauge_.set(value); }
+
+  private:
+    Stats::Gauge& gauge_;
+  };
+
+  class ModuleHistogramHandle {
+  public:
+    ModuleHistogramHandle(Stats::Histogram& histogram) : histogram_(histogram) {}
+    void recordValue(uint64_t value) const { histogram_.recordValue(value); }
+
+  private:
+    Stats::Histogram& histogram_;
+  };
+
+  // Methods for adding metrics during configuration.
+  size_t addCounter(ModuleCounterHandle&& counter) {
+    size_t id = counters_.size();
+    counters_.push_back(std::move(counter));
+    return id;
+  }
+
+  size_t addGauge(ModuleGaugeHandle&& gauge) {
+    size_t id = gauges_.size();
+    gauges_.push_back(std::move(gauge));
+    return id;
+  }
+
+  size_t addHistogram(ModuleHistogramHandle&& histogram) {
+    size_t id = histograms_.size();
+    histograms_.push_back(std::move(histogram));
+    return id;
+  }
+
+  // Methods for getting metrics by ID.
+  OptRef<const ModuleCounterHandle> getCounterById(size_t id) const {
+    if (id >= counters_.size()) {
+      return {};
+    }
+    return counters_[id];
+  }
+
+  OptRef<const ModuleGaugeHandle> getGaugeById(size_t id) const {
+    if (id >= gauges_.size()) {
+      return {};
+    }
+    return gauges_[id];
+  }
+
+  OptRef<const ModuleHistogramHandle> getHistogramById(size_t id) const {
+    if (id >= histograms_.size()) {
+      return {};
+    }
+    return histograms_[id];
+  }
+
+  // Stats scope for metric creation.
+  const Stats::ScopeSharedPtr stats_scope_;
+  Stats::StatNamePool stat_name_pool_;
+
 private:
   // Allow the factory function to access private members for initialization.
   friend absl::StatusOr<std::shared_ptr<DynamicModuleAccessLogConfig>>
   newDynamicModuleAccessLogConfig(const absl::string_view logger_name,
                                   const absl::string_view logger_config,
-                                  Extensions::DynamicModules::DynamicModulePtr dynamic_module);
+                                  Extensions::DynamicModules::DynamicModulePtr dynamic_module,
+                                  Stats::Scope& stats_scope);
 
   // The name of the logger passed in the constructor.
   const std::string logger_name_;
@@ -69,6 +156,11 @@ private:
 
   // The handle for the module.
   Extensions::DynamicModules::DynamicModulePtr dynamic_module_;
+
+  // Metric storage.
+  std::vector<ModuleCounterHandle> counters_;
+  std::vector<ModuleGaugeHandle> gauges_;
+  std::vector<ModuleHistogramHandle> histograms_;
 };
 
 using DynamicModuleAccessLogConfigSharedPtr = std::shared_ptr<DynamicModuleAccessLogConfig>;
@@ -78,12 +170,12 @@ using DynamicModuleAccessLogConfigSharedPtr = std::shared_ptr<DynamicModuleAcces
  * @param logger_name the name of the logger.
  * @param logger_config the configuration bytes for the logger.
  * @param dynamic_module the dynamic module to use.
+ * @param stats_scope the stats scope for metrics.
  * @return a shared pointer to the new config object or an error if symbol resolution failed.
  */
-absl::StatusOr<DynamicModuleAccessLogConfigSharedPtr>
-newDynamicModuleAccessLogConfig(const absl::string_view logger_name,
-                                const absl::string_view logger_config,
-                                Extensions::DynamicModules::DynamicModulePtr dynamic_module);
+absl::StatusOr<DynamicModuleAccessLogConfigSharedPtr> newDynamicModuleAccessLogConfig(
+    const absl::string_view logger_name, const absl::string_view logger_config,
+    Extensions::DynamicModules::DynamicModulePtr dynamic_module, Stats::Scope& stats_scope);
 
 } // namespace DynamicModules
 } // namespace AccessLoggers

--- a/source/extensions/access_loggers/dynamic_modules/config.cc
+++ b/source/extensions/access_loggers/dynamic_modules/config.cc
@@ -40,7 +40,8 @@ AccessLog::InstanceSharedPtr DynamicModuleAccessLogFactory::createAccessLogInsta
   }
 
   auto access_log_config = newDynamicModuleAccessLogConfig(
-      proto_config.logger_name(), logger_config_str, std::move(dynamic_module_or_error.value()));
+      proto_config.logger_name(), logger_config_str, std::move(dynamic_module_or_error.value()),
+      context.serverFactoryContext().scope());
 
   if (!access_log_config.ok()) {
     throw EnvoyException("Failed to create access logger config: " +

--- a/source/extensions/dynamic_modules/abi.h
+++ b/source/extensions/dynamic_modules/abi.h
@@ -4118,6 +4118,126 @@ bool envoy_dynamic_module_callback_access_logger_get_span_id(
 bool envoy_dynamic_module_callback_access_logger_is_trace_sampled(
     envoy_dynamic_module_type_access_logger_envoy_ptr logger_envoy_ptr);
 
+// -----------------------------------------------------------------------------
+// Access Logger Callbacks - Metrics
+// -----------------------------------------------------------------------------
+
+/**
+ * envoy_dynamic_module_callback_access_logger_config_define_counter is called by the module during
+ * initialization to create a new Stats::Counter with the given name.
+ *
+ * @param config_envoy_ptr is the pointer to the DynamicModuleAccessLogConfig in which the
+ * counter will be defined.
+ * @param name is the name of the counter to be defined.
+ * @param counter_id_ptr where the opaque ID that represents a unique metric will be stored. This
+ * can be passed to envoy_dynamic_module_callback_access_logger_increment_counter together with
+ * config_envoy_ptr.
+ * @return the result of the operation.
+ */
+envoy_dynamic_module_type_metrics_result
+envoy_dynamic_module_callback_access_logger_config_define_counter(
+    envoy_dynamic_module_type_access_logger_config_envoy_ptr config_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer name, size_t* counter_id_ptr);
+
+/**
+ * envoy_dynamic_module_callback_access_logger_increment_counter is called by the module to
+ * increment a previously defined counter.
+ *
+ * @param config_envoy_ptr is the pointer to the DynamicModuleAccessLogConfig.
+ * @param id is the ID of the counter previously defined using this config.
+ * @param value is the value to increment the counter by.
+ * @return the result of the operation.
+ */
+envoy_dynamic_module_type_metrics_result
+envoy_dynamic_module_callback_access_logger_increment_counter(
+    envoy_dynamic_module_type_access_logger_config_envoy_ptr config_envoy_ptr, size_t id,
+    uint64_t value);
+
+/**
+ * envoy_dynamic_module_callback_access_logger_config_define_gauge is called by the module during
+ * initialization to create a new Stats::Gauge with the given name.
+ *
+ * @param config_envoy_ptr is the pointer to the DynamicModuleAccessLogConfig in which the
+ * gauge will be defined.
+ * @param name is the name of the gauge to be defined.
+ * @param gauge_id_ptr where the opaque ID that represents a unique metric will be stored.
+ * @return the result of the operation.
+ */
+envoy_dynamic_module_type_metrics_result
+envoy_dynamic_module_callback_access_logger_config_define_gauge(
+    envoy_dynamic_module_type_access_logger_config_envoy_ptr config_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer name, size_t* gauge_id_ptr);
+
+/**
+ * envoy_dynamic_module_callback_access_logger_set_gauge is called by the module to set the value
+ * of a previously defined gauge.
+ *
+ * @param config_envoy_ptr is the pointer to the DynamicModuleAccessLogConfig.
+ * @param id is the ID of the gauge previously defined using this config.
+ * @param value is the value to set the gauge to.
+ * @return the result of the operation.
+ */
+envoy_dynamic_module_type_metrics_result envoy_dynamic_module_callback_access_logger_set_gauge(
+    envoy_dynamic_module_type_access_logger_config_envoy_ptr config_envoy_ptr, size_t id,
+    uint64_t value);
+
+/**
+ * envoy_dynamic_module_callback_access_logger_increment_gauge is called by the module to increase
+ * the value of a previously defined gauge.
+ *
+ * @param config_envoy_ptr is the pointer to the DynamicModuleAccessLogConfig.
+ * @param id is the ID of the gauge previously defined using this config.
+ * @param value is the value to increase the gauge by.
+ * @return the result of the operation.
+ */
+envoy_dynamic_module_type_metrics_result
+envoy_dynamic_module_callback_access_logger_increment_gauge(
+    envoy_dynamic_module_type_access_logger_config_envoy_ptr config_envoy_ptr, size_t id,
+    uint64_t value);
+
+/**
+ * envoy_dynamic_module_callback_access_logger_decrement_gauge is called by the module to decrease
+ * the value of a previously defined gauge.
+ *
+ * @param config_envoy_ptr is the pointer to the DynamicModuleAccessLogConfig.
+ * @param id is the ID of the gauge previously defined using this config.
+ * @param value is the value to decrease the gauge by.
+ * @return the result of the operation.
+ */
+envoy_dynamic_module_type_metrics_result
+envoy_dynamic_module_callback_access_logger_decrement_gauge(
+    envoy_dynamic_module_type_access_logger_config_envoy_ptr config_envoy_ptr, size_t id,
+    uint64_t value);
+
+/**
+ * envoy_dynamic_module_callback_access_logger_config_define_histogram is called by the module
+ * during initialization to create a new Stats::Histogram with the given name.
+ *
+ * @param config_envoy_ptr is the pointer to the DynamicModuleAccessLogConfig in which the
+ * histogram will be defined.
+ * @param name is the name of the histogram to be defined.
+ * @param histogram_id_ptr where the opaque ID that represents a unique metric will be stored.
+ * @return the result of the operation.
+ */
+envoy_dynamic_module_type_metrics_result
+envoy_dynamic_module_callback_access_logger_config_define_histogram(
+    envoy_dynamic_module_type_access_logger_config_envoy_ptr config_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer name, size_t* histogram_id_ptr);
+
+/**
+ * envoy_dynamic_module_callback_access_logger_record_histogram_value is called by the module to
+ * record a value in a previously defined histogram.
+ *
+ * @param config_envoy_ptr is the pointer to the DynamicModuleAccessLogConfig.
+ * @param id is the ID of the histogram previously defined using this config.
+ * @param value is the value to record in the histogram.
+ * @return the result of the operation.
+ */
+envoy_dynamic_module_type_metrics_result
+envoy_dynamic_module_callback_access_logger_record_histogram_value(
+    envoy_dynamic_module_type_access_logger_config_envoy_ptr config_envoy_ptr, size_t id,
+    uint64_t value);
+
 #ifdef __cplusplus
 }
 #endif

--- a/test/extensions/access_loggers/dynamic_modules/BUILD
+++ b/test/extensions/access_loggers/dynamic_modules/BUILD
@@ -38,6 +38,7 @@ envoy_cc_test(
         "//test/extensions/dynamic_modules/test_data/c:access_log_no_op",
     ],
     deps = [
+        "//source/common/stats:isolated_store_lib",
         "//source/extensions/access_loggers/dynamic_modules:access_log_lib",
         "//test/extensions/dynamic_modules:util",
         "//test/mocks/access_log:access_log_mocks",


### PR DESCRIPTION
## Description

This PR adds metrics API to the Access Logger Dynamic Modules. It's extremely useful to have the ability to export stats from the Dynamic Modules at different extension points. It's already supported for the HTTP Dynamic Modules today.

---

**Commit Message:** dynamic_modules: add metrics ABI to access loggers
**Additional Description:** Added metrics API to the Access Logger Dynamic Modules.
**Risk Level:** Low
**Testing:** Added Tests
**Docs Changes:** N/A
**Release Notes:** N/A