### PR TITLE
dynamic_modules: add metrics ABI to network filter

### DIFF
--- a/source/extensions/dynamic_modules/abi.h
+++ b/source/extensions/dynamic_modules/abi.h
@@ -2994,6 +2994,121 @@ envoy_dynamic_module_callback_network_filter_http_callout(
     envoy_dynamic_module_type_module_http_header* headers, size_t headers_size,
     envoy_dynamic_module_type_module_buffer body, uint64_t timeout_milliseconds);
 
+// -----------------------------------------------------------------------------
+// Network Filter Callbacks - Metrics
+// -----------------------------------------------------------------------------
+
+/**
+ * envoy_dynamic_module_callback_network_filter_config_define_counter is called by the module
+ * during initialization to create a new Stats::Counter with the given name.
+ *
+ * @param config_envoy_ptr is the pointer to the DynamicModuleNetworkFilterConfig in which the
+ * counter will be defined.
+ * @param name is the name of the counter to be defined.
+ * @param counter_id_ptr where the opaque ID that represents a unique metric will be stored. This
+ * can be passed to envoy_dynamic_module_callback_network_filter_increment_counter together with
+ * filter_envoy_ptr.
+ * @return the result of the operation.
+ */
+envoy_dynamic_module_type_metrics_result
+envoy_dynamic_module_callback_network_filter_config_define_counter(
+    envoy_dynamic_module_type_network_filter_config_envoy_ptr config_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer name, size_t* counter_id_ptr);
+
+/**
+ * envoy_dynamic_module_callback_network_filter_increment_counter is called by the module to
+ * increment a previously defined counter.
+ *
+ * @param filter_envoy_ptr is the pointer to the DynamicModuleNetworkFilter object.
+ * @param id is the ID of the counter previously defined using the config.
+ * @param value is the value to increment the counter by.
+ * @return the result of the operation.
+ */
+envoy_dynamic_module_type_metrics_result
+envoy_dynamic_module_callback_network_filter_increment_counter(
+    envoy_dynamic_module_type_network_filter_envoy_ptr filter_envoy_ptr, size_t id, uint64_t value);
+
+/**
+ * envoy_dynamic_module_callback_network_filter_config_define_gauge is called by the module during
+ * initialization to create a new Stats::Gauge with the given name.
+ *
+ * @param config_envoy_ptr is the pointer to the DynamicModuleNetworkFilterConfig in which the
+ * gauge will be defined.
+ * @param name is the name of the gauge to be defined.
+ * @param gauge_id_ptr where the opaque ID that represents a unique metric will be stored.
+ * @return the result of the operation.
+ */
+envoy_dynamic_module_type_metrics_result
+envoy_dynamic_module_callback_network_filter_config_define_gauge(
+    envoy_dynamic_module_type_network_filter_config_envoy_ptr config_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer name, size_t* gauge_id_ptr);
+
+/**
+ * envoy_dynamic_module_callback_network_filter_set_gauge is called by the module to set the value
+ * of a previously defined gauge.
+ *
+ * @param filter_envoy_ptr is the pointer to the DynamicModuleNetworkFilter object.
+ * @param id is the ID of the gauge previously defined using the config.
+ * @param value is the value to set the gauge to.
+ * @return the result of the operation.
+ */
+envoy_dynamic_module_type_metrics_result envoy_dynamic_module_callback_network_filter_set_gauge(
+    envoy_dynamic_module_type_network_filter_envoy_ptr filter_envoy_ptr, size_t id, uint64_t value);
+
+/**
+ * envoy_dynamic_module_callback_network_filter_increment_gauge is called by the module to increase
+ * the value of a previously defined gauge.
+ *
+ * @param filter_envoy_ptr is the pointer to the DynamicModuleNetworkFilter object.
+ * @param id is the ID of the gauge previously defined using the config.
+ * @param value is the value to increase the gauge by.
+ * @return the result of the operation.
+ */
+envoy_dynamic_module_type_metrics_result
+envoy_dynamic_module_callback_network_filter_increment_gauge(
+    envoy_dynamic_module_type_network_filter_envoy_ptr filter_envoy_ptr, size_t id, uint64_t value);
+
+/**
+ * envoy_dynamic_module_callback_network_filter_decrement_gauge is called by the module to decrease
+ * the value of a previously defined gauge.
+ *
+ * @param filter_envoy_ptr is the pointer to the DynamicModuleNetworkFilter object.
+ * @param id is the ID of the gauge previously defined using the config.
+ * @param value is the value to decrease the gauge by.
+ * @return the result of the operation.
+ */
+envoy_dynamic_module_type_metrics_result
+envoy_dynamic_module_callback_network_filter_decrement_gauge(
+    envoy_dynamic_module_type_network_filter_envoy_ptr filter_envoy_ptr, size_t id, uint64_t value);
+
+/**
+ * envoy_dynamic_module_callback_network_filter_config_define_histogram is called by the module
+ * during initialization to create a new Stats::Histogram with the given name.
+ *
+ * @param config_envoy_ptr is the pointer to the DynamicModuleNetworkFilterConfig in which the
+ * histogram will be defined.
+ * @param name is the name of the histogram to be defined.
+ * @param histogram_id_ptr where the opaque ID that represents a unique metric will be stored.
+ * @return the result of the operation.
+ */
+envoy_dynamic_module_type_metrics_result
+envoy_dynamic_module_callback_network_filter_config_define_histogram(
+    envoy_dynamic_module_type_network_filter_config_envoy_ptr config_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer name, size_t* histogram_id_ptr);
+
+/**
+ * envoy_dynamic_module_callback_network_filter_record_histogram_value is called by the module to
+ * record a value in a previously defined histogram.
+ *
+ * @param filter_envoy_ptr is the pointer to the DynamicModuleNetworkFilter object.
+ * @param id is the ID of the histogram previously defined using the config.
+ * @param value is the value to record in the histogram.
+ * @return the result of the operation.
+ */
+envoy_dynamic_module_type_metrics_result
+envoy_dynamic_module_callback_network_filter_record_histogram_value(
+    envoy_dynamic_module_type_network_filter_envoy_ptr filter_envoy_ptr, size_t id, uint64_t value);
+
 // =============================================================================
 // ----------------------------- Listener Filter Callbacks ---------------------
 // =============================================================================

--- a/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
@@ -3169,7 +3169,25 @@ pub static NEW_NETWORK_FILTER_CONFIG_FUNCTION: OnceLock<
 /// This is used in [`NewNetworkFilterConfigFunction`] to pass the Envoy filter configuration
 /// to the dynamic module.
 #[automock]
-pub trait EnvoyNetworkFilterConfig {}
+pub trait EnvoyNetworkFilterConfig {
+  /// Define a new counter scoped to this filter config with the given name.
+  fn define_counter(
+    &mut self,
+    name: &str,
+  ) -> Result<EnvoyCounterId, envoy_dynamic_module_type_metrics_result>;
+
+  /// Define a new gauge scoped to this filter config with the given name.
+  fn define_gauge(
+    &mut self,
+    name: &str,
+  ) -> Result<EnvoyGaugeId, envoy_dynamic_module_type_metrics_result>;
+
+  /// Define a new histogram scoped to this filter config with the given name.
+  fn define_histogram(
+    &mut self,
+    name: &str,
+  ) -> Result<EnvoyHistogramId, envoy_dynamic_module_type_metrics_result>;
+}
 
 /// The trait that represents the configuration for an Envoy network filter configuration.
 /// This has one to one mapping with the [`EnvoyNetworkFilterConfig`] object.
@@ -3436,6 +3454,41 @@ pub trait EnvoyNetworkFilter {
     abi::envoy_dynamic_module_type_http_callout_init_result,
     u64, // callout handle
   );
+
+  /// Increment the counter with the given id.
+  fn increment_counter(
+    &self,
+    id: EnvoyCounterId,
+    value: u64,
+  ) -> Result<(), envoy_dynamic_module_type_metrics_result>;
+
+  /// Set the value of the gauge with the given id.
+  fn set_gauge(
+    &self,
+    id: EnvoyGaugeId,
+    value: u64,
+  ) -> Result<(), envoy_dynamic_module_type_metrics_result>;
+
+  /// Increase the gauge with the given id.
+  fn increase_gauge(
+    &self,
+    id: EnvoyGaugeId,
+    value: u64,
+  ) -> Result<(), envoy_dynamic_module_type_metrics_result>;
+
+  /// Decrease the gauge with the given id.
+  fn decrease_gauge(
+    &self,
+    id: EnvoyGaugeId,
+    value: u64,
+  ) -> Result<(), envoy_dynamic_module_type_metrics_result>;
+
+  /// Record a value in the histogram with the given id.
+  fn record_histogram_value(
+    &self,
+    id: EnvoyHistogramId,
+    value: u64,
+  ) -> Result<(), envoy_dynamic_module_type_metrics_result>;
 }
 
 pub enum SocketOptionValue {
@@ -3461,7 +3514,52 @@ impl EnvoyNetworkFilterConfigImpl {
   }
 }
 
-impl EnvoyNetworkFilterConfig for EnvoyNetworkFilterConfigImpl {}
+impl EnvoyNetworkFilterConfig for EnvoyNetworkFilterConfigImpl {
+  fn define_counter(
+    &mut self,
+    name: &str,
+  ) -> Result<EnvoyCounterId, envoy_dynamic_module_type_metrics_result> {
+    let mut id: usize = 0;
+    Result::from(unsafe {
+      abi::envoy_dynamic_module_callback_network_filter_config_define_counter(
+        self.raw,
+        str_to_module_buffer(name),
+        &mut id,
+      )
+    })?;
+    Ok(EnvoyCounterId(id))
+  }
+
+  fn define_gauge(
+    &mut self,
+    name: &str,
+  ) -> Result<EnvoyGaugeId, envoy_dynamic_module_type_metrics_result> {
+    let mut id: usize = 0;
+    Result::from(unsafe {
+      abi::envoy_dynamic_module_callback_network_filter_config_define_gauge(
+        self.raw,
+        str_to_module_buffer(name),
+        &mut id,
+      )
+    })?;
+    Ok(EnvoyGaugeId(id))
+  }
+
+  fn define_histogram(
+    &mut self,
+    name: &str,
+  ) -> Result<EnvoyHistogramId, envoy_dynamic_module_type_metrics_result> {
+    let mut id: usize = 0;
+    Result::from(unsafe {
+      abi::envoy_dynamic_module_callback_network_filter_config_define_histogram(
+        self.raw,
+        str_to_module_buffer(name),
+        &mut id,
+      )
+    })?;
+    Ok(EnvoyHistogramId(id))
+  }
+}
 
 /// The implementation of [`EnvoyNetworkFilter`] for the Envoy network filter.
 pub struct EnvoyNetworkFilterImpl {
@@ -4124,6 +4222,85 @@ impl EnvoyNetworkFilter for EnvoyNetworkFilterImpl {
     };
 
     (result, callout_id)
+  }
+
+  fn increment_counter(
+    &self,
+    id: EnvoyCounterId,
+    value: u64,
+  ) -> Result<(), envoy_dynamic_module_type_metrics_result> {
+    let EnvoyCounterId(id) = id;
+    let res = unsafe {
+      abi::envoy_dynamic_module_callback_network_filter_increment_counter(self.raw, id, value)
+    };
+    if res == envoy_dynamic_module_type_metrics_result::Success {
+      Ok(())
+    } else {
+      Err(res)
+    }
+  }
+
+  fn set_gauge(
+    &self,
+    id: EnvoyGaugeId,
+    value: u64,
+  ) -> Result<(), envoy_dynamic_module_type_metrics_result> {
+    let EnvoyGaugeId(id) = id;
+    let res =
+      unsafe { abi::envoy_dynamic_module_callback_network_filter_set_gauge(self.raw, id, value) };
+    if res == envoy_dynamic_module_type_metrics_result::Success {
+      Ok(())
+    } else {
+      Err(res)
+    }
+  }
+
+  fn increase_gauge(
+    &self,
+    id: EnvoyGaugeId,
+    value: u64,
+  ) -> Result<(), envoy_dynamic_module_type_metrics_result> {
+    let EnvoyGaugeId(id) = id;
+    let res = unsafe {
+      abi::envoy_dynamic_module_callback_network_filter_increment_gauge(self.raw, id, value)
+    };
+    if res == envoy_dynamic_module_type_metrics_result::Success {
+      Ok(())
+    } else {
+      Err(res)
+    }
+  }
+
+  fn decrease_gauge(
+    &self,
+    id: EnvoyGaugeId,
+    value: u64,
+  ) -> Result<(), envoy_dynamic_module_type_metrics_result> {
+    let EnvoyGaugeId(id) = id;
+    let res = unsafe {
+      abi::envoy_dynamic_module_callback_network_filter_decrement_gauge(self.raw, id, value)
+    };
+    if res == envoy_dynamic_module_type_metrics_result::Success {
+      Ok(())
+    } else {
+      Err(res)
+    }
+  }
+
+  fn record_histogram_value(
+    &self,
+    id: EnvoyHistogramId,
+    value: u64,
+  ) -> Result<(), envoy_dynamic_module_type_metrics_result> {
+    let EnvoyHistogramId(id) = id;
+    let res = unsafe {
+      abi::envoy_dynamic_module_callback_network_filter_record_histogram_value(self.raw, id, value)
+    };
+    if res == envoy_dynamic_module_type_metrics_result::Success {
+      Ok(())
+    } else {
+      Err(res)
+    }
   }
 }
 

--- a/source/extensions/filters/network/dynamic_modules/BUILD
+++ b/source/extensions/filters/network/dynamic_modules/BUILD
@@ -14,8 +14,10 @@ envoy_cc_library(
     srcs = ["filter_config.cc"],
     hdrs = ["filter_config.h"],
     deps = [
+        "//envoy/stats:stats_interface",
         "//envoy/upstream:cluster_manager_interface",
         "//source/common/config:utility_lib",
+        "//source/common/stats:utility_lib",
         "//source/extensions/dynamic_modules:dynamic_modules_lib",
     ],
 )

--- a/source/extensions/filters/network/dynamic_modules/abi_impl.cc
+++ b/source/extensions/filters/network/dynamic_modules/abi_impl.cc
@@ -9,8 +9,10 @@
 #include "source/common/network/upstream_socket_options_filter_state.h"
 #include "source/common/protobuf/protobuf.h"
 #include "source/common/router/string_accessor_impl.h"
+#include "source/common/stats/utility.h"
 #include "source/extensions/dynamic_modules/abi.h"
 #include "source/extensions/filters/network/dynamic_modules/filter.h"
+#include "source/extensions/filters/network/dynamic_modules/filter_config.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -706,6 +708,112 @@ void envoy_dynamic_module_callback_network_get_socket_options(
   auto* filter = static_cast<DynamicModuleNetworkFilter*>(filter_envoy_ptr);
   size_t options_written = 0;
   filter->copySocketOptions(options_out, filter->socketOptionCount(), options_written);
+}
+
+// -----------------------------------------------------------------------------
+// Metrics Callbacks
+// -----------------------------------------------------------------------------
+
+envoy_dynamic_module_type_metrics_result
+envoy_dynamic_module_callback_network_filter_config_define_counter(
+    envoy_dynamic_module_type_network_filter_config_envoy_ptr config_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer name, size_t* counter_id_ptr) {
+  auto* config = static_cast<DynamicModuleNetworkFilterConfig*>(config_envoy_ptr);
+  Stats::StatName main_stat_name =
+      config->stat_name_pool_.add(absl::string_view(name.ptr, name.length));
+  Stats::Counter& c = Stats::Utility::counterFromStatNames(*config->stats_scope_, {main_stat_name});
+  *counter_id_ptr = config->addCounter({c});
+  return envoy_dynamic_module_type_metrics_result_Success;
+}
+
+envoy_dynamic_module_type_metrics_result
+envoy_dynamic_module_callback_network_filter_increment_counter(
+    envoy_dynamic_module_type_network_filter_envoy_ptr filter_envoy_ptr, size_t id,
+    uint64_t value) {
+  auto* filter = static_cast<DynamicModuleNetworkFilter*>(filter_envoy_ptr);
+  auto counter = filter->getFilterConfig().getCounterById(id);
+  if (!counter.has_value()) {
+    return envoy_dynamic_module_type_metrics_result_MetricNotFound;
+  }
+  counter->add(value);
+  return envoy_dynamic_module_type_metrics_result_Success;
+}
+
+envoy_dynamic_module_type_metrics_result
+envoy_dynamic_module_callback_network_filter_config_define_gauge(
+    envoy_dynamic_module_type_network_filter_config_envoy_ptr config_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer name, size_t* gauge_id_ptr) {
+  auto* config = static_cast<DynamicModuleNetworkFilterConfig*>(config_envoy_ptr);
+  Stats::StatName main_stat_name =
+      config->stat_name_pool_.add(absl::string_view(name.ptr, name.length));
+  Stats::Gauge& g = Stats::Utility::gaugeFromStatNames(*config->stats_scope_, {main_stat_name},
+                                                       Stats::Gauge::ImportMode::Accumulate);
+  *gauge_id_ptr = config->addGauge({g});
+  return envoy_dynamic_module_type_metrics_result_Success;
+}
+
+envoy_dynamic_module_type_metrics_result envoy_dynamic_module_callback_network_filter_set_gauge(
+    envoy_dynamic_module_type_network_filter_envoy_ptr filter_envoy_ptr, size_t id,
+    uint64_t value) {
+  auto* filter = static_cast<DynamicModuleNetworkFilter*>(filter_envoy_ptr);
+  auto gauge = filter->getFilterConfig().getGaugeById(id);
+  if (!gauge.has_value()) {
+    return envoy_dynamic_module_type_metrics_result_MetricNotFound;
+  }
+  gauge->set(value);
+  return envoy_dynamic_module_type_metrics_result_Success;
+}
+
+envoy_dynamic_module_type_metrics_result
+envoy_dynamic_module_callback_network_filter_increment_gauge(
+    envoy_dynamic_module_type_network_filter_envoy_ptr filter_envoy_ptr, size_t id,
+    uint64_t value) {
+  auto* filter = static_cast<DynamicModuleNetworkFilter*>(filter_envoy_ptr);
+  auto gauge = filter->getFilterConfig().getGaugeById(id);
+  if (!gauge.has_value()) {
+    return envoy_dynamic_module_type_metrics_result_MetricNotFound;
+  }
+  gauge->add(value);
+  return envoy_dynamic_module_type_metrics_result_Success;
+}
+
+envoy_dynamic_module_type_metrics_result
+envoy_dynamic_module_callback_network_filter_decrement_gauge(
+    envoy_dynamic_module_type_network_filter_envoy_ptr filter_envoy_ptr, size_t id,
+    uint64_t value) {
+  auto* filter = static_cast<DynamicModuleNetworkFilter*>(filter_envoy_ptr);
+  auto gauge = filter->getFilterConfig().getGaugeById(id);
+  if (!gauge.has_value()) {
+    return envoy_dynamic_module_type_metrics_result_MetricNotFound;
+  }
+  gauge->sub(value);
+  return envoy_dynamic_module_type_metrics_result_Success;
+}
+
+envoy_dynamic_module_type_metrics_result
+envoy_dynamic_module_callback_network_filter_config_define_histogram(
+    envoy_dynamic_module_type_network_filter_config_envoy_ptr config_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer name, size_t* histogram_id_ptr) {
+  auto* config = static_cast<DynamicModuleNetworkFilterConfig*>(config_envoy_ptr);
+  Stats::StatName main_stat_name =
+      config->stat_name_pool_.add(absl::string_view(name.ptr, name.length));
+  Stats::Histogram& h = Stats::Utility::histogramFromStatNames(
+      *config->stats_scope_, {main_stat_name}, Stats::Histogram::Unit::Unspecified);
+  *histogram_id_ptr = config->addHistogram({h});
+  return envoy_dynamic_module_type_metrics_result_Success;
+}
+
+envoy_dynamic_module_type_metrics_result
+envoy_dynamic_module_callback_network_filter_record_histogram_value(
+    envoy_dynamic_module_type_network_filter_envoy_ptr filter_envoy_ptr, size_t id,
+    uint64_t value) {
+  auto* filter = static_cast<DynamicModuleNetworkFilter*>(filter_envoy_ptr);
+  auto histogram = filter->getFilterConfig().getHistogramById(id);
+  if (!histogram.has_value()) {
+    return envoy_dynamic_module_type_metrics_result_MetricNotFound;
+  }
+  histogram->recordValue(value);
+  return envoy_dynamic_module_type_metrics_result_Success;
 }
 
 } // extern "C"

--- a/source/extensions/filters/network/dynamic_modules/factory.cc
+++ b/source/extensions/filters/network/dynamic_modules/factory.cc
@@ -34,7 +34,8 @@ DynamicModuleNetworkFilterConfigFactory::createFilterFactoryFromProtoTyped(
       filter_config =
           Envoy::Extensions::DynamicModules::NetworkFilters::newDynamicModuleNetworkFilterConfig(
               proto_config.filter_name(), config, std::move(dynamic_module.value()),
-              context.serverFactoryContext().clusterManager());
+              context.serverFactoryContext().clusterManager(),
+              context.serverFactoryContext().scope());
 
   if (!filter_config.ok()) {
     return absl::InvalidArgumentError("Failed to create filter config: " +

--- a/source/extensions/filters/network/dynamic_modules/filter_config.h
+++ b/source/extensions/filters/network/dynamic_modules/filter_config.h
@@ -1,8 +1,12 @@
 #pragma once
 
+#include "envoy/common/optref.h"
+#include "envoy/stats/scope.h"
+#include "envoy/stats/stats.h"
 #include "envoy/upstream/cluster_manager.h"
 
 #include "source/common/common/statusor.h"
+#include "source/common/stats/utility.h"
 #include "source/extensions/dynamic_modules/abi.h"
 #include "source/extensions/dynamic_modules/dynamic_modules.h"
 
@@ -22,6 +26,9 @@ using OnNetworkFilterDestroyType = decltype(&envoy_dynamic_module_on_network_fil
 using OnNetworkFilterHttpCalloutDoneType =
     decltype(&envoy_dynamic_module_on_network_filter_http_callout_done);
 
+// Custom namespace prefix for network filter stats.
+constexpr char NetworkFilterStatsNamespace[] = "dynamic_module_network_filter";
+
 /**
  * A config to create network filters based on a dynamic module. This will be owned by multiple
  * filter instances. This resolves and holds the symbols used for the network filters.
@@ -39,11 +46,13 @@ public:
    * @param filter_config the configuration for the module.
    * @param dynamic_module the dynamic module to use.
    * @param cluster_manager the cluster manager for async HTTP callouts.
+   * @param stats_scope the stats scope for metrics.
    */
   DynamicModuleNetworkFilterConfig(const absl::string_view filter_name,
                                    const absl::string_view filter_config,
                                    DynamicModulePtr dynamic_module,
-                                   Envoy::Upstream::ClusterManager& cluster_manager);
+                                   Envoy::Upstream::ClusterManager& cluster_manager,
+                                   Stats::Scope& stats_scope);
 
   ~DynamicModuleNetworkFilterConfig();
 
@@ -64,13 +73,91 @@ public:
 
   Envoy::Upstream::ClusterManager& cluster_manager_;
 
+  // ----------------------------- Metrics Support -----------------------------
+  // Handle classes for storing defined metrics.
+
+  class ModuleCounterHandle {
+  public:
+    ModuleCounterHandle(Stats::Counter& counter) : counter_(counter) {}
+    void add(uint64_t value) const { counter_.add(value); }
+
+  private:
+    Stats::Counter& counter_;
+  };
+
+  class ModuleGaugeHandle {
+  public:
+    ModuleGaugeHandle(Stats::Gauge& gauge) : gauge_(gauge) {}
+    void add(uint64_t value) const { gauge_.add(value); }
+    void sub(uint64_t value) const { gauge_.sub(value); }
+    void set(uint64_t value) const { gauge_.set(value); }
+
+  private:
+    Stats::Gauge& gauge_;
+  };
+
+  class ModuleHistogramHandle {
+  public:
+    ModuleHistogramHandle(Stats::Histogram& histogram) : histogram_(histogram) {}
+    void recordValue(uint64_t value) const { histogram_.recordValue(value); }
+
+  private:
+    Stats::Histogram& histogram_;
+  };
+
+  // Methods for adding metrics during configuration.
+  size_t addCounter(ModuleCounterHandle&& counter) {
+    size_t id = counters_.size();
+    counters_.push_back(std::move(counter));
+    return id;
+  }
+
+  size_t addGauge(ModuleGaugeHandle&& gauge) {
+    size_t id = gauges_.size();
+    gauges_.push_back(std::move(gauge));
+    return id;
+  }
+
+  size_t addHistogram(ModuleHistogramHandle&& histogram) {
+    size_t id = histograms_.size();
+    histograms_.push_back(std::move(histogram));
+    return id;
+  }
+
+  // Methods for getting metrics by ID.
+  OptRef<const ModuleCounterHandle> getCounterById(size_t id) const {
+    if (id >= counters_.size()) {
+      return {};
+    }
+    return counters_[id];
+  }
+
+  OptRef<const ModuleGaugeHandle> getGaugeById(size_t id) const {
+    if (id >= gauges_.size()) {
+      return {};
+    }
+    return gauges_[id];
+  }
+
+  OptRef<const ModuleHistogramHandle> getHistogramById(size_t id) const {
+    if (id >= histograms_.size()) {
+      return {};
+    }
+    return histograms_[id];
+  }
+
+  // Stats scope for metric creation.
+  const Stats::ScopeSharedPtr stats_scope_;
+  Stats::StatNamePool stat_name_pool_;
+
 private:
   // Allow the factory function to access private members for initialization.
   friend absl::StatusOr<std::shared_ptr<DynamicModuleNetworkFilterConfig>>
   newDynamicModuleNetworkFilterConfig(const absl::string_view filter_name,
                                       const absl::string_view filter_config,
                                       DynamicModulePtr dynamic_module,
-                                      Envoy::Upstream::ClusterManager& cluster_manager);
+                                      Envoy::Upstream::ClusterManager& cluster_manager,
+                                      Stats::Scope& stats_scope);
 
   // The name of the filter passed in the constructor.
   const std::string filter_name_;
@@ -80,6 +167,11 @@ private:
 
   // The handle for the module.
   Extensions::DynamicModules::DynamicModulePtr dynamic_module_;
+
+  // Metric storage.
+  std::vector<ModuleCounterHandle> counters_;
+  std::vector<ModuleGaugeHandle> gauges_;
+  std::vector<ModuleHistogramHandle> histograms_;
 };
 
 using DynamicModuleNetworkFilterConfigSharedPtr = std::shared_ptr<DynamicModuleNetworkFilterConfig>;
@@ -90,13 +182,13 @@ using DynamicModuleNetworkFilterConfigSharedPtr = std::shared_ptr<DynamicModuleN
  * @param filter_config the configuration for the module.
  * @param dynamic_module the dynamic module to use.
  * @param cluster_manager the cluster manager for async HTTP callouts.
+ * @param stats_scope the stats scope for metrics.
  * @return a shared pointer to the new config object or an error if the module could not be loaded.
  */
-absl::StatusOr<DynamicModuleNetworkFilterConfigSharedPtr>
-newDynamicModuleNetworkFilterConfig(const absl::string_view filter_name,
-                                    const absl::string_view filter_config,
-                                    Extensions::DynamicModules::DynamicModulePtr dynamic_module,
-                                    Envoy::Upstream::ClusterManager& cluster_manager);
+absl::StatusOr<DynamicModuleNetworkFilterConfigSharedPtr> newDynamicModuleNetworkFilterConfig(
+    const absl::string_view filter_name, const absl::string_view filter_config,
+    Extensions::DynamicModules::DynamicModulePtr dynamic_module,
+    Envoy::Upstream::ClusterManager& cluster_manager, Stats::Scope& stats_scope);
 
 } // namespace NetworkFilters
 } // namespace DynamicModules

--- a/test/extensions/dynamic_modules/network/BUILD
+++ b/test/extensions/dynamic_modules/network/BUILD
@@ -19,6 +19,7 @@ envoy_cc_test(
     ],
     rbe_pool = "6gig",
     deps = [
+        "//source/common/stats:isolated_store_lib",
         "//source/extensions/filters/network/dynamic_modules:config",
         "//source/extensions/filters/network/dynamic_modules:filter_lib",
         "//test/extensions/dynamic_modules:util",
@@ -54,6 +55,7 @@ envoy_cc_test(
     rbe_pool = "6gig",
     deps = [
         "//source/common/router:string_accessor_lib",
+        "//source/common/stats:isolated_store_lib",
         "//source/extensions/filters/network/dynamic_modules:config",
         "//source/extensions/filters/network/dynamic_modules:filter_lib",
         "//test/extensions/dynamic_modules:util",

--- a/test/extensions/dynamic_modules/network/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/network/abi_impl_test.cc
@@ -3,6 +3,7 @@
 #include "source/common/http/message_impl.h"
 #include "source/common/network/address_impl.h"
 #include "source/common/router/string_accessor_impl.h"
+#include "source/common/stats/isolated_store_impl.h"
 #include "source/extensions/dynamic_modules/abi.h"
 #include "source/extensions/filters/network/dynamic_modules/filter.h"
 
@@ -24,8 +25,9 @@ public:
     auto dynamic_module = newDynamicModule(testSharedObjectPath("network_no_op", "c"), false);
     EXPECT_TRUE(dynamic_module.ok()) << dynamic_module.status().message();
 
-    auto filter_config_or_status = newDynamicModuleNetworkFilterConfig(
-        "test_filter", "", std::move(dynamic_module.value()), cluster_manager_);
+    auto filter_config_or_status =
+        newDynamicModuleNetworkFilterConfig("test_filter", "", std::move(dynamic_module.value()),
+                                            cluster_manager_, *stats_.rootScope());
     EXPECT_TRUE(filter_config_or_status.ok()) << filter_config_or_status.status().message();
     filter_config_ = filter_config_or_status.value();
 
@@ -47,6 +49,7 @@ public:
 
   void* filterPtr() { return static_cast<void*>(filter_.get()); }
 
+  Stats::IsolatedStoreImpl stats_;
   NiceMock<Upstream::MockClusterManager> cluster_manager_;
   DynamicModuleNetworkFilterConfigSharedPtr filter_config_;
   std::shared_ptr<DynamicModuleNetworkFilter> filter_;
@@ -1258,8 +1261,9 @@ public:
     auto dynamic_module = newDynamicModule(testSharedObjectPath("network_no_op", "c"), false);
     EXPECT_TRUE(dynamic_module.ok()) << dynamic_module.status().message();
 
-    auto filter_config_or_status = newDynamicModuleNetworkFilterConfig(
-        "test_filter", "", std::move(dynamic_module.value()), cluster_manager_);
+    auto filter_config_or_status =
+        newDynamicModuleNetworkFilterConfig("test_filter", "", std::move(dynamic_module.value()),
+                                            cluster_manager_, *stats_.rootScope());
     EXPECT_TRUE(filter_config_or_status.ok()) << filter_config_or_status.status().message();
     filter_config_ = filter_config_or_status.value();
 
@@ -1280,6 +1284,7 @@ public:
 
   void* filterPtr() { return static_cast<void*>(filter_.get()); }
 
+  Stats::IsolatedStoreImpl stats_;
   NiceMock<Upstream::MockClusterManager> cluster_manager_;
   DynamicModuleNetworkFilterConfigSharedPtr filter_config_;
   std::shared_ptr<DynamicModuleNetworkFilter> filter_;

--- a/test/extensions/dynamic_modules/network/filter_test.cc
+++ b/test/extensions/dynamic_modules/network/filter_test.cc
@@ -1,3 +1,4 @@
+#include "source/common/stats/isolated_store_impl.h"
 #include "source/extensions/dynamic_modules/abi.h"
 #include "source/extensions/filters/network/dynamic_modules/filter.h"
 
@@ -17,12 +18,14 @@ public:
     auto dynamic_module = newDynamicModule(testSharedObjectPath("network_no_op", "c"), false);
     EXPECT_TRUE(dynamic_module.ok()) << dynamic_module.status().message();
 
-    auto filter_config_or_status = newDynamicModuleNetworkFilterConfig(
-        "test_filter", "", std::move(dynamic_module.value()), cluster_manager_);
+    auto filter_config_or_status =
+        newDynamicModuleNetworkFilterConfig("test_filter", "", std::move(dynamic_module.value()),
+                                            cluster_manager_, *stats_.rootScope());
     EXPECT_TRUE(filter_config_or_status.ok()) << filter_config_or_status.status().message();
     filter_config_ = filter_config_or_status.value();
   }
 
+  Stats::IsolatedStoreImpl stats_;
   DynamicModuleNetworkFilterConfigSharedPtr filter_config_;
   NiceMock<Upstream::MockClusterManager> cluster_manager_;
 };
@@ -240,9 +243,11 @@ TEST(DynamicModuleNetworkFilterConfigTest, ConfigInitialization) {
   auto dynamic_module = newDynamicModule(testSharedObjectPath("network_no_op", "c"), false);
   EXPECT_TRUE(dynamic_module.ok()) << dynamic_module.status().message();
 
+  Stats::IsolatedStoreImpl stats;
   NiceMock<Upstream::MockClusterManager> cluster_manager;
   auto filter_config_or_status = newDynamicModuleNetworkFilterConfig(
-      "test_filter", "some_config", std::move(dynamic_module.value()), cluster_manager);
+      "test_filter", "some_config", std::move(dynamic_module.value()), cluster_manager,
+      *stats.rootScope());
   EXPECT_TRUE(filter_config_or_status.ok());
 
   auto config = filter_config_or_status.value();
@@ -261,9 +266,10 @@ TEST(DynamicModuleNetworkFilterConfigTest, MissingSymbols) {
   auto dynamic_module = newDynamicModule(testSharedObjectPath("no_op", "c"), false);
   EXPECT_TRUE(dynamic_module.ok()) << dynamic_module.status().message();
 
+  Stats::IsolatedStoreImpl stats;
   NiceMock<Upstream::MockClusterManager> cluster_manager;
   auto filter_config_or_status = newDynamicModuleNetworkFilterConfig(
-      "test_filter", "", std::move(dynamic_module.value()), cluster_manager);
+      "test_filter", "", std::move(dynamic_module.value()), cluster_manager, *stats.rootScope());
   EXPECT_FALSE(filter_config_or_status.ok());
 }
 
@@ -273,9 +279,10 @@ TEST(DynamicModuleNetworkFilterConfigTest, ConfigInitializationFailure) {
       newDynamicModule(testSharedObjectPath("network_config_new_fail", "c"), false);
   EXPECT_TRUE(dynamic_module.ok()) << dynamic_module.status().message();
 
+  Stats::IsolatedStoreImpl stats;
   NiceMock<Upstream::MockClusterManager> cluster_manager;
   auto filter_config_or_status = newDynamicModuleNetworkFilterConfig(
-      "test_filter", "", std::move(dynamic_module.value()), cluster_manager);
+      "test_filter", "", std::move(dynamic_module.value()), cluster_manager, *stats.rootScope());
   EXPECT_FALSE(filter_config_or_status.ok());
   EXPECT_THAT(filter_config_or_status.status().message(),
               testing::HasSubstr("Failed to initialize"));
@@ -286,9 +293,10 @@ TEST(DynamicModuleNetworkFilterConfigTest, StopIterationStatus) {
       newDynamicModule(testSharedObjectPath("network_stop_iteration", "c"), false);
   EXPECT_TRUE(dynamic_module.ok()) << dynamic_module.status().message();
 
+  Stats::IsolatedStoreImpl stats;
   NiceMock<Upstream::MockClusterManager> cluster_manager;
   auto filter_config_or_status = newDynamicModuleNetworkFilterConfig(
-      "test_filter", "", std::move(dynamic_module.value()), cluster_manager);
+      "test_filter", "", std::move(dynamic_module.value()), cluster_manager, *stats.rootScope());
   EXPECT_TRUE(filter_config_or_status.ok());
   auto config = filter_config_or_status.value();
 
@@ -306,6 +314,105 @@ TEST(DynamicModuleNetworkFilterConfigTest, StopIterationStatus) {
   Buffer::OwnedImpl data("test");
   EXPECT_EQ(Network::FilterStatus::StopIteration, filter->onData(data, false));
   EXPECT_EQ(Network::FilterStatus::StopIteration, filter->onWrite(data, false));
+}
+
+// -----------------------------------------------------------------------------
+// Metrics Tests
+// -----------------------------------------------------------------------------
+
+TEST_F(DynamicModuleNetworkFilterTest, DefineAndIncrementCounter) {
+  // Define a counter on the config.
+  size_t counter_id = 0;
+  envoy_dynamic_module_type_module_buffer name = {"test_counter", 12};
+  auto result = envoy_dynamic_module_callback_network_filter_config_define_counter(
+      filter_config_.get(), name, &counter_id);
+  EXPECT_EQ(result, envoy_dynamic_module_type_metrics_result_Success);
+  EXPECT_EQ(counter_id, 0);
+
+  // Create filter and increment counter.
+  auto filter = std::make_shared<DynamicModuleNetworkFilter>(filter_config_);
+  filter->initializeInModuleFilter();
+
+  result =
+      envoy_dynamic_module_callback_network_filter_increment_counter(filter.get(), counter_id, 5);
+  EXPECT_EQ(result, envoy_dynamic_module_type_metrics_result_Success);
+
+  // Verify counter value.
+  auto counter = filter_config_->getCounterById(counter_id);
+  EXPECT_TRUE(counter.has_value());
+}
+
+TEST_F(DynamicModuleNetworkFilterTest, DefineAndManipulateGauge) {
+  // Define a gauge on the config.
+  size_t gauge_id = 0;
+  envoy_dynamic_module_type_module_buffer name = {"test_gauge", 10};
+  auto result = envoy_dynamic_module_callback_network_filter_config_define_gauge(
+      filter_config_.get(), name, &gauge_id);
+  EXPECT_EQ(result, envoy_dynamic_module_type_metrics_result_Success);
+  EXPECT_EQ(gauge_id, 0);
+
+  // Create filter and manipulate gauge.
+  auto filter = std::make_shared<DynamicModuleNetworkFilter>(filter_config_);
+  filter->initializeInModuleFilter();
+
+  result = envoy_dynamic_module_callback_network_filter_set_gauge(filter.get(), gauge_id, 100);
+  EXPECT_EQ(result, envoy_dynamic_module_type_metrics_result_Success);
+
+  result = envoy_dynamic_module_callback_network_filter_increment_gauge(filter.get(), gauge_id, 50);
+  EXPECT_EQ(result, envoy_dynamic_module_type_metrics_result_Success);
+
+  result = envoy_dynamic_module_callback_network_filter_decrement_gauge(filter.get(), gauge_id, 25);
+  EXPECT_EQ(result, envoy_dynamic_module_type_metrics_result_Success);
+
+  // Verify gauge exists.
+  auto gauge = filter_config_->getGaugeById(gauge_id);
+  EXPECT_TRUE(gauge.has_value());
+}
+
+TEST_F(DynamicModuleNetworkFilterTest, DefineAndRecordHistogram) {
+  // Define a histogram on the config.
+  size_t histogram_id = 0;
+  envoy_dynamic_module_type_module_buffer name = {"test_histogram", 14};
+  auto result = envoy_dynamic_module_callback_network_filter_config_define_histogram(
+      filter_config_.get(), name, &histogram_id);
+  EXPECT_EQ(result, envoy_dynamic_module_type_metrics_result_Success);
+  EXPECT_EQ(histogram_id, 0);
+
+  // Create filter and record histogram value.
+  auto filter = std::make_shared<DynamicModuleNetworkFilter>(filter_config_);
+  filter->initializeInModuleFilter();
+
+  result = envoy_dynamic_module_callback_network_filter_record_histogram_value(filter.get(),
+                                                                               histogram_id, 42);
+  EXPECT_EQ(result, envoy_dynamic_module_type_metrics_result_Success);
+
+  // Verify histogram exists.
+  auto histogram = filter_config_->getHistogramById(histogram_id);
+  EXPECT_TRUE(histogram.has_value());
+}
+
+TEST_F(DynamicModuleNetworkFilterTest, MetricNotFound) {
+  // Create filter without defining metrics.
+  auto filter = std::make_shared<DynamicModuleNetworkFilter>(filter_config_);
+  filter->initializeInModuleFilter();
+
+  // Try to use invalid metric IDs.
+  auto result =
+      envoy_dynamic_module_callback_network_filter_increment_counter(filter.get(), 999, 1);
+  EXPECT_EQ(result, envoy_dynamic_module_type_metrics_result_MetricNotFound);
+
+  result = envoy_dynamic_module_callback_network_filter_set_gauge(filter.get(), 999, 1);
+  EXPECT_EQ(result, envoy_dynamic_module_type_metrics_result_MetricNotFound);
+
+  result = envoy_dynamic_module_callback_network_filter_increment_gauge(filter.get(), 999, 1);
+  EXPECT_EQ(result, envoy_dynamic_module_type_metrics_result_MetricNotFound);
+
+  result = envoy_dynamic_module_callback_network_filter_decrement_gauge(filter.get(), 999, 1);
+  EXPECT_EQ(result, envoy_dynamic_module_type_metrics_result_MetricNotFound);
+
+  result =
+      envoy_dynamic_module_callback_network_filter_record_histogram_value(filter.get(), 999, 1);
+  EXPECT_EQ(result, envoy_dynamic_module_type_metrics_result_MetricNotFound);
 }
 
 } // namespace NetworkFilters


### PR DESCRIPTION
## Description

This PR adds metrics API to the Network Dynamic Modules. It's extremely useful to have the ability to export stats from the Dynamic Modules at different extension points. It's already supported for the HTTP Dynamic Modules today.

---

**Commit Message:** dynamic_modules: add metrics ABI to network filter
**Additional Description:** Added metrics API to the Network Dynamic Modules.
**Risk Level:** Low
**Testing:** Added Tests
**Docs Changes:** N/A
**Release Notes:** N/A