### PR TITLE
dynamic_modules: add metrics ABI to UDP listener filter

### DIFF
--- a/source/extensions/dynamic_modules/abi.h
+++ b/source/extensions/dynamic_modules/abi.h
@@ -3748,6 +3748,127 @@ bool envoy_dynamic_module_callback_udp_listener_filter_send_datagram(
     envoy_dynamic_module_type_module_buffer peer_address, uint32_t peer_port);
 
 // -----------------------------------------------------------------------------
+// UDP Listener Filter Callbacks - Metrics
+// -----------------------------------------------------------------------------
+
+/**
+ * envoy_dynamic_module_callback_udp_listener_filter_config_define_counter is called by the module
+ * during initialization to create a new Stats::Counter with the given name.
+ *
+ * @param config_envoy_ptr is the pointer to the DynamicModuleUdpListenerFilterConfig in which the
+ * counter will be defined.
+ * @param name is the name of the counter to be defined.
+ * @param counter_id_ptr where the opaque ID that represents a unique metric will be stored. This
+ * can be passed to envoy_dynamic_module_callback_udp_listener_filter_increment_counter together
+ * with filter_envoy_ptr.
+ * @return the result of the operation.
+ */
+envoy_dynamic_module_type_metrics_result
+envoy_dynamic_module_callback_udp_listener_filter_config_define_counter(
+    envoy_dynamic_module_type_udp_listener_filter_config_envoy_ptr config_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer name, size_t* counter_id_ptr);
+
+/**
+ * envoy_dynamic_module_callback_udp_listener_filter_increment_counter is called by the module to
+ * increment a previously defined counter.
+ *
+ * @param filter_envoy_ptr is the pointer to the DynamicModuleUdpListenerFilter object.
+ * @param id is the ID of the counter previously defined using the config.
+ * @param value is the value to increment the counter by.
+ * @return the result of the operation.
+ */
+envoy_dynamic_module_type_metrics_result
+envoy_dynamic_module_callback_udp_listener_filter_increment_counter(
+    envoy_dynamic_module_type_udp_listener_filter_envoy_ptr filter_envoy_ptr, size_t id,
+    uint64_t value);
+
+/**
+ * envoy_dynamic_module_callback_udp_listener_filter_config_define_gauge is called by the module
+ * during initialization to create a new Stats::Gauge with the given name.
+ *
+ * @param config_envoy_ptr is the pointer to the DynamicModuleUdpListenerFilterConfig in which the
+ * gauge will be defined.
+ * @param name is the name of the gauge to be defined.
+ * @param gauge_id_ptr where the opaque ID that represents a unique metric will be stored.
+ * @return the result of the operation.
+ */
+envoy_dynamic_module_type_metrics_result
+envoy_dynamic_module_callback_udp_listener_filter_config_define_gauge(
+    envoy_dynamic_module_type_udp_listener_filter_config_envoy_ptr config_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer name, size_t* gauge_id_ptr);
+
+/**
+ * envoy_dynamic_module_callback_udp_listener_filter_set_gauge is called by the module to set the
+ * value of a previously defined gauge.
+ *
+ * @param filter_envoy_ptr is the pointer to the DynamicModuleUdpListenerFilter object.
+ * @param id is the ID of the gauge previously defined using the config.
+ * @param value is the value to set the gauge to.
+ * @return the result of the operation.
+ */
+envoy_dynamic_module_type_metrics_result
+envoy_dynamic_module_callback_udp_listener_filter_set_gauge(
+    envoy_dynamic_module_type_udp_listener_filter_envoy_ptr filter_envoy_ptr, size_t id,
+    uint64_t value);
+
+/**
+ * envoy_dynamic_module_callback_udp_listener_filter_increment_gauge is called by the module to
+ * increase the value of a previously defined gauge.
+ *
+ * @param filter_envoy_ptr is the pointer to the DynamicModuleUdpListenerFilter object.
+ * @param id is the ID of the gauge previously defined using the config.
+ * @param value is the value to increase the gauge by.
+ * @return the result of the operation.
+ */
+envoy_dynamic_module_type_metrics_result
+envoy_dynamic_module_callback_udp_listener_filter_increment_gauge(
+    envoy_dynamic_module_type_udp_listener_filter_envoy_ptr filter_envoy_ptr, size_t id,
+    uint64_t value);
+
+/**
+ * envoy_dynamic_module_callback_udp_listener_filter_decrement_gauge is called by the module to
+ * decrease the value of a previously defined gauge.
+ *
+ * @param filter_envoy_ptr is the pointer to the DynamicModuleUdpListenerFilter object.
+ * @param id is the ID of the gauge previously defined using the config.
+ * @param value is the value to decrease the gauge by.
+ * @return the result of the operation.
+ */
+envoy_dynamic_module_type_metrics_result
+envoy_dynamic_module_callback_udp_listener_filter_decrement_gauge(
+    envoy_dynamic_module_type_udp_listener_filter_envoy_ptr filter_envoy_ptr, size_t id,
+    uint64_t value);
+
+/**
+ * envoy_dynamic_module_callback_udp_listener_filter_config_define_histogram is called by the
+ * module during initialization to create a new Stats::Histogram with the given name.
+ *
+ * @param config_envoy_ptr is the pointer to the DynamicModuleUdpListenerFilterConfig in which the
+ * histogram will be defined.
+ * @param name is the name of the histogram to be defined.
+ * @param histogram_id_ptr where the opaque ID that represents a unique metric will be stored.
+ * @return the result of the operation.
+ */
+envoy_dynamic_module_type_metrics_result
+envoy_dynamic_module_callback_udp_listener_filter_config_define_histogram(
+    envoy_dynamic_module_type_udp_listener_filter_config_envoy_ptr config_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer name, size_t* histogram_id_ptr);
+
+/**
+ * envoy_dynamic_module_callback_udp_listener_filter_record_histogram_value is called by the module
+ * to record a value in a previously defined histogram.
+ *
+ * @param filter_envoy_ptr is the pointer to the DynamicModuleUdpListenerFilter object.
+ * @param id is the ID of the histogram previously defined using the config.
+ * @param value is the value to record in the histogram.
+ * @return the result of the operation.
+ */
+envoy_dynamic_module_type_metrics_result
+envoy_dynamic_module_callback_udp_listener_filter_record_histogram_value(
+    envoy_dynamic_module_type_udp_listener_filter_envoy_ptr filter_envoy_ptr, size_t id,
+    uint64_t value);
+
+// -----------------------------------------------------------------------------
 // Access Logger Types
 // -----------------------------------------------------------------------------
 

--- a/source/extensions/filters/udp/dynamic_modules/BUILD
+++ b/source/extensions/filters/udp/dynamic_modules/BUILD
@@ -14,7 +14,9 @@ envoy_cc_library(
     srcs = ["filter_config.cc"],
     hdrs = ["filter_config.h"],
     deps = [
+        "//envoy/stats:stats_interface",
         "//source/common/config:utility_lib",
+        "//source/common/stats:utility_lib",
         "//source/extensions/dynamic_modules:dynamic_modules_lib",
         "@envoy_api//envoy/extensions/filters/udp/dynamic_modules/v3:pkg_cc_proto",
     ],
@@ -38,6 +40,7 @@ envoy_cc_library(
         "//source/common/common:logger_lib",
         "//source/common/network:utility_lib",
         "//source/common/protobuf",
+        "//source/common/stats:utility_lib",
         "//source/extensions/dynamic_modules:dynamic_modules_lib",
     ],
 )

--- a/source/extensions/filters/udp/dynamic_modules/abi_impl.cc
+++ b/source/extensions/filters/udp/dynamic_modules/abi_impl.cc
@@ -4,9 +4,11 @@
 #include "envoy/network/address.h"
 
 #include "source/common/network/utility.h"
+#include "source/common/stats/utility.h"
 #include "source/extensions/filters/udp/dynamic_modules/filter.h"
 
 using Envoy::Extensions::UdpFilters::DynamicModules::DynamicModuleUdpListenerFilter;
+using Envoy::Extensions::UdpFilters::DynamicModules::DynamicModuleUdpListenerFilterConfig;
 
 namespace {
 
@@ -176,6 +178,114 @@ bool envoy_dynamic_module_callback_udp_listener_filter_send_datagram(
     return true;
   }
   return false;
+}
+
+// -----------------------------------------------------------------------------
+// Metrics ABI Callbacks
+// -----------------------------------------------------------------------------
+
+envoy_dynamic_module_type_metrics_result
+envoy_dynamic_module_callback_udp_listener_filter_config_define_counter(
+    envoy_dynamic_module_type_udp_listener_filter_config_envoy_ptr config_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer name, size_t* counter_id_ptr) {
+  auto* config = static_cast<DynamicModuleUdpListenerFilterConfig*>(config_envoy_ptr);
+  Envoy::Stats::StatName main_stat_name =
+      config->stat_name_pool_.add(absl::string_view(name.ptr, name.length));
+  Envoy::Stats::Counter& c =
+      Envoy::Stats::Utility::counterFromStatNames(*config->stats_scope_, {main_stat_name});
+  *counter_id_ptr = config->addCounter({c});
+  return envoy_dynamic_module_type_metrics_result_Success;
+}
+
+envoy_dynamic_module_type_metrics_result
+envoy_dynamic_module_callback_udp_listener_filter_increment_counter(
+    envoy_dynamic_module_type_udp_listener_filter_envoy_ptr filter_envoy_ptr, size_t id,
+    uint64_t value) {
+  auto* filter = static_cast<DynamicModuleUdpListenerFilter*>(filter_envoy_ptr);
+  auto counter = filter->getFilterConfig().getCounterById(id);
+  if (!counter.has_value()) {
+    return envoy_dynamic_module_type_metrics_result_MetricNotFound;
+  }
+  counter->add(value);
+  return envoy_dynamic_module_type_metrics_result_Success;
+}
+
+envoy_dynamic_module_type_metrics_result
+envoy_dynamic_module_callback_udp_listener_filter_config_define_gauge(
+    envoy_dynamic_module_type_udp_listener_filter_config_envoy_ptr config_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer name, size_t* gauge_id_ptr) {
+  auto* config = static_cast<DynamicModuleUdpListenerFilterConfig*>(config_envoy_ptr);
+  Envoy::Stats::StatName main_stat_name =
+      config->stat_name_pool_.add(absl::string_view(name.ptr, name.length));
+  Envoy::Stats::Gauge& g = Envoy::Stats::Utility::gaugeFromStatNames(
+      *config->stats_scope_, {main_stat_name}, Envoy::Stats::Gauge::ImportMode::Accumulate);
+  *gauge_id_ptr = config->addGauge({g});
+  return envoy_dynamic_module_type_metrics_result_Success;
+}
+
+envoy_dynamic_module_type_metrics_result
+envoy_dynamic_module_callback_udp_listener_filter_set_gauge(
+    envoy_dynamic_module_type_udp_listener_filter_envoy_ptr filter_envoy_ptr, size_t id,
+    uint64_t value) {
+  auto* filter = static_cast<DynamicModuleUdpListenerFilter*>(filter_envoy_ptr);
+  auto gauge = filter->getFilterConfig().getGaugeById(id);
+  if (!gauge.has_value()) {
+    return envoy_dynamic_module_type_metrics_result_MetricNotFound;
+  }
+  gauge->set(value);
+  return envoy_dynamic_module_type_metrics_result_Success;
+}
+
+envoy_dynamic_module_type_metrics_result
+envoy_dynamic_module_callback_udp_listener_filter_increment_gauge(
+    envoy_dynamic_module_type_udp_listener_filter_envoy_ptr filter_envoy_ptr, size_t id,
+    uint64_t value) {
+  auto* filter = static_cast<DynamicModuleUdpListenerFilter*>(filter_envoy_ptr);
+  auto gauge = filter->getFilterConfig().getGaugeById(id);
+  if (!gauge.has_value()) {
+    return envoy_dynamic_module_type_metrics_result_MetricNotFound;
+  }
+  gauge->add(value);
+  return envoy_dynamic_module_type_metrics_result_Success;
+}
+
+envoy_dynamic_module_type_metrics_result
+envoy_dynamic_module_callback_udp_listener_filter_decrement_gauge(
+    envoy_dynamic_module_type_udp_listener_filter_envoy_ptr filter_envoy_ptr, size_t id,
+    uint64_t value) {
+  auto* filter = static_cast<DynamicModuleUdpListenerFilter*>(filter_envoy_ptr);
+  auto gauge = filter->getFilterConfig().getGaugeById(id);
+  if (!gauge.has_value()) {
+    return envoy_dynamic_module_type_metrics_result_MetricNotFound;
+  }
+  gauge->sub(value);
+  return envoy_dynamic_module_type_metrics_result_Success;
+}
+
+envoy_dynamic_module_type_metrics_result
+envoy_dynamic_module_callback_udp_listener_filter_config_define_histogram(
+    envoy_dynamic_module_type_udp_listener_filter_config_envoy_ptr config_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer name, size_t* histogram_id_ptr) {
+  auto* config = static_cast<DynamicModuleUdpListenerFilterConfig*>(config_envoy_ptr);
+  Envoy::Stats::StatName main_stat_name =
+      config->stat_name_pool_.add(absl::string_view(name.ptr, name.length));
+  Envoy::Stats::Histogram& h = Envoy::Stats::Utility::histogramFromStatNames(
+      *config->stats_scope_, {main_stat_name}, Envoy::Stats::Histogram::Unit::Unspecified);
+  *histogram_id_ptr = config->addHistogram({h});
+  return envoy_dynamic_module_type_metrics_result_Success;
+}
+
+envoy_dynamic_module_type_metrics_result
+envoy_dynamic_module_callback_udp_listener_filter_record_histogram_value(
+    envoy_dynamic_module_type_udp_listener_filter_envoy_ptr filter_envoy_ptr, size_t id,
+    uint64_t value) {
+  auto* filter = static_cast<DynamicModuleUdpListenerFilter*>(filter_envoy_ptr);
+  auto histogram = filter->getFilterConfig().getHistogramById(id);
+  if (!histogram.has_value()) {
+    return envoy_dynamic_module_type_metrics_result_MetricNotFound;
+  }
+  histogram->recordValue(value);
+  return envoy_dynamic_module_type_metrics_result_Success;
 }
 
 } // extern "C"

--- a/source/extensions/filters/udp/dynamic_modules/factory.cc
+++ b/source/extensions/filters/udp/dynamic_modules/factory.cc
@@ -9,7 +9,7 @@ namespace DynamicModules {
 
 Network::UdpListenerFilterFactoryCb
 DynamicModuleUdpListenerFilterConfigFactory::createFilterFactoryFromProto(
-    const Protobuf::Message& config, Server::Configuration::ListenerFactoryContext&) {
+    const Protobuf::Message& config, Server::Configuration::ListenerFactoryContext& context) {
   const auto& proto_config = dynamic_cast<
       const envoy::extensions::filters::udp::dynamic_modules::v3::DynamicModuleUdpListenerFilter&>(
       config);
@@ -26,7 +26,7 @@ DynamicModuleUdpListenerFilterConfigFactory::createFilterFactoryFromProto(
   auto dynamic_module = std::move(dynamic_module_or_error.value());
 
   auto filter_config = std::make_shared<DynamicModuleUdpListenerFilterConfig>(
-      proto_config, std::move(dynamic_module));
+      proto_config, std::move(dynamic_module), context.scope());
 
   return [filter_config](Network::UdpListenerFilterManager& filter_manager,
                          Network::UdpReadFilterCallbacks& callbacks) -> void {

--- a/source/extensions/filters/udp/dynamic_modules/filter.h
+++ b/source/extensions/filters/udp/dynamic_modules/filter.h
@@ -28,6 +28,9 @@ public:
   Network::UdpRecvData* currentData() { return current_data_; }
   Network::UdpReadFilterCallbacks* callbacks() { return read_callbacks_; }
 
+  // Get the filter config for metrics access.
+  DynamicModuleUdpListenerFilterConfig& getFilterConfig() const { return *config_; }
+
 #ifdef ENVOY_ENABLE_FULL_PROTOS
   // Test-only method to set current_data_ for ABI callback testing.
   void setCurrentDataForTest(Network::UdpRecvData* data) { current_data_ = data; }

--- a/source/extensions/filters/udp/dynamic_modules/filter_config.cc
+++ b/source/extensions/filters/udp/dynamic_modules/filter_config.cc
@@ -11,10 +11,13 @@ namespace DynamicModules {
 DynamicModuleUdpListenerFilterConfig::DynamicModuleUdpListenerFilterConfig(
     const envoy::extensions::filters::udp::dynamic_modules::v3::DynamicModuleUdpListenerFilter&
         config,
-    Extensions::DynamicModules::DynamicModulePtr dynamic_module)
+    Extensions::DynamicModules::DynamicModulePtr dynamic_module, Stats::Scope& stats_scope)
     : filter_name_(config.filter_name()),
       filter_config_(MessageUtil::getJsonStringFromMessageOrError(config.filter_config())),
-      dynamic_module_(std::move(dynamic_module)) {
+      dynamic_module_(std::move(dynamic_module)),
+      stats_scope_(stats_scope.createScope(
+          absl::StrCat(UdpListenerFilterStatsNamespace, ".", config.filter_name(), "."))),
+      stat_name_pool_(stats_scope_->symbolTable()) {
 
   auto config_new_or_error = dynamic_module_->getFunctionPointer<decltype(on_filter_config_new_)>(
       "envoy_dynamic_module_on_udp_listener_filter_config_new");

--- a/source/extensions/filters/udp/dynamic_modules/filter_config.h
+++ b/source/extensions/filters/udp/dynamic_modules/filter_config.h
@@ -1,7 +1,11 @@
 #pragma once
 
+#include "envoy/common/optref.h"
 #include "envoy/extensions/filters/udp/dynamic_modules/v3/dynamic_modules.pb.h"
+#include "envoy/stats/scope.h"
+#include "envoy/stats/stats.h"
 
+#include "source/common/stats/utility.h"
 #include "source/extensions/dynamic_modules/abi.h"
 #include "source/extensions/dynamic_modules/dynamic_modules.h"
 
@@ -10,12 +14,15 @@ namespace Extensions {
 namespace UdpFilters {
 namespace DynamicModules {
 
+// Custom namespace prefix for UDP listener filter stats.
+constexpr char UdpListenerFilterStatsNamespace[] = "dynamic_module_udp_listener_filter";
+
 class DynamicModuleUdpListenerFilterConfig {
 public:
   DynamicModuleUdpListenerFilterConfig(
       const envoy::extensions::filters::udp::dynamic_modules::v3::DynamicModuleUdpListenerFilter&
           config,
-      Extensions::DynamicModules::DynamicModulePtr dynamic_module);
+      Extensions::DynamicModules::DynamicModulePtr dynamic_module, Stats::Scope& stats_scope);
 
   ~DynamicModuleUdpListenerFilterConfig();
 
@@ -31,6 +38,89 @@ public:
   decltype(envoy_dynamic_module_on_udp_listener_filter_new)* on_filter_new_{nullptr};
   decltype(envoy_dynamic_module_on_udp_listener_filter_on_data)* on_filter_on_data_{nullptr};
   decltype(envoy_dynamic_module_on_udp_listener_filter_destroy)* on_filter_destroy_{nullptr};
+
+  // ----------------------------- Metrics Support -----------------------------
+  // Handle classes for storing defined metrics.
+
+  class ModuleCounterHandle {
+  public:
+    ModuleCounterHandle(Stats::Counter& counter) : counter_(counter) {}
+    void add(uint64_t value) const { counter_.add(value); }
+
+  private:
+    Stats::Counter& counter_;
+  };
+
+  class ModuleGaugeHandle {
+  public:
+    ModuleGaugeHandle(Stats::Gauge& gauge) : gauge_(gauge) {}
+    void add(uint64_t value) const { gauge_.add(value); }
+    void sub(uint64_t value) const { gauge_.sub(value); }
+    void set(uint64_t value) const { gauge_.set(value); }
+
+  private:
+    Stats::Gauge& gauge_;
+  };
+
+  class ModuleHistogramHandle {
+  public:
+    ModuleHistogramHandle(Stats::Histogram& histogram) : histogram_(histogram) {}
+    void recordValue(uint64_t value) const { histogram_.recordValue(value); }
+
+  private:
+    Stats::Histogram& histogram_;
+  };
+
+  // Methods for adding metrics during configuration.
+  size_t addCounter(ModuleCounterHandle&& counter) {
+    size_t id = counters_.size();
+    counters_.push_back(std::move(counter));
+    return id;
+  }
+
+  size_t addGauge(ModuleGaugeHandle&& gauge) {
+    size_t id = gauges_.size();
+    gauges_.push_back(std::move(gauge));
+    return id;
+  }
+
+  size_t addHistogram(ModuleHistogramHandle&& histogram) {
+    size_t id = histograms_.size();
+    histograms_.push_back(std::move(histogram));
+    return id;
+  }
+
+  // Methods for getting metrics by ID.
+  OptRef<const ModuleCounterHandle> getCounterById(size_t id) const {
+    if (id >= counters_.size()) {
+      return {};
+    }
+    return counters_[id];
+  }
+
+  OptRef<const ModuleGaugeHandle> getGaugeById(size_t id) const {
+    if (id >= gauges_.size()) {
+      return {};
+    }
+    return gauges_[id];
+  }
+
+  OptRef<const ModuleHistogramHandle> getHistogramById(size_t id) const {
+    if (id >= histograms_.size()) {
+      return {};
+    }
+    return histograms_[id];
+  }
+
+  // Stats scope for metric creation.
+  const Stats::ScopeSharedPtr stats_scope_;
+  Stats::StatNamePool stat_name_pool_;
+
+private:
+  // Metric storage.
+  std::vector<ModuleCounterHandle> counters_;
+  std::vector<ModuleGaugeHandle> gauges_;
+  std::vector<ModuleHistogramHandle> histograms_;
 };
 
 using DynamicModuleUdpListenerFilterConfigSharedPtr =

--- a/test/extensions/dynamic_modules/udp/BUILD
+++ b/test/extensions/dynamic_modules/udp/BUILD
@@ -21,6 +21,7 @@ envoy_cc_test(
         "//test/extensions/dynamic_modules/test_data/c:udp_stop_iteration",
     ],
     deps = [
+        "//source/common/stats:isolated_store_lib",
         "//source/extensions/dynamic_modules:dynamic_modules_lib",
         "//source/extensions/filters/udp/dynamic_modules:filter_lib",
         "//test/extensions/dynamic_modules:util",
@@ -36,6 +37,7 @@ envoy_cc_test(
         "//test/extensions/dynamic_modules/test_data/c:udp_no_op",
     ],
     deps = [
+        "//source/common/stats:isolated_store_lib",
         "//source/extensions/filters/udp/dynamic_modules:filter_lib",
         "//test/extensions/dynamic_modules:util",
         "//test/mocks/network:network_mocks",

--- a/test/extensions/dynamic_modules/udp/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/udp/abi_impl_test.cc
@@ -2,6 +2,7 @@
 
 #include "source/common/network/address_impl.h"
 #include "source/common/network/utility.h"
+#include "source/common/stats/isolated_store_impl.h"
 #include "source/extensions/dynamic_modules/abi.h"
 #include "source/extensions/filters/udp/dynamic_modules/filter.h"
 
@@ -26,7 +27,7 @@ public:
     proto_config.mutable_filter_config()->set_value("some_config");
 
     filter_config_ = std::make_shared<DynamicModuleUdpListenerFilterConfig>(
-        proto_config, std::move(dynamic_module.value()));
+        proto_config, std::move(dynamic_module.value()), *stats_.rootScope());
 
     filter_ = std::make_shared<DynamicModuleUdpListenerFilter>(callbacks_, filter_config_);
   }
@@ -35,6 +36,7 @@ public:
 
   void* filterPtr() { return static_cast<void*>(filter_.get()); }
 
+  Stats::IsolatedStoreImpl stats_;
   DynamicModuleUdpListenerFilterConfigSharedPtr filter_config_;
   std::shared_ptr<DynamicModuleUdpListenerFilter> filter_;
   NiceMock<Network::MockUdpReadFilterCallbacks> callbacks_;


### PR DESCRIPTION
## Description

This PR adds metrics API to the UDP Listener Dynamic Modules. It's extremely useful to have the ability to export stats from the Dynamic Modules at different extension points. It's already supported for the HTTP Dynamic Modules today.

---

**Commit Message:** dynamic_modules: add metrics ABI to UDP listener filter
**Additional Description:** Added metrics API to the UDP Listener Dynamic Modules.
**Risk Level:** Low
**Testing:** Added Tests
**Docs Changes:** N/A
**Release Notes:** N/A