### PR TITLE
dynamic_modules: add scheduler to listener filters ABI

### DIFF
--- a/source/extensions/filters/listener/dynamic_modules/abi_impl.cc
+++ b/source/extensions/filters/listener/dynamic_modules/abi_impl.cc
@@ -665,6 +665,53 @@ envoy_dynamic_module_callback_listener_filter_record_histogram_value(
   return envoy_dynamic_module_type_metrics_result_Success;
 }
 
+// -----------------------------------------------------------------------------
+// Scheduler Callbacks
+// -----------------------------------------------------------------------------
+
+envoy_dynamic_module_type_listener_filter_scheduler_module_ptr
+envoy_dynamic_module_callback_listener_filter_scheduler_new(
+    envoy_dynamic_module_type_listener_filter_envoy_ptr filter_envoy_ptr) {
+  auto* filter = static_cast<DynamicModuleListenerFilter*>(filter_envoy_ptr);
+  Event::Dispatcher* dispatcher = filter->dispatcher();
+  if (dispatcher == nullptr) {
+    return nullptr;
+  }
+  return new DynamicModuleListenerFilterScheduler(filter->weak_from_this(), *dispatcher);
+}
+
+void envoy_dynamic_module_callback_listener_filter_scheduler_delete(
+    envoy_dynamic_module_type_listener_filter_scheduler_module_ptr scheduler_module_ptr) {
+  delete static_cast<DynamicModuleListenerFilterScheduler*>(scheduler_module_ptr);
+}
+
+void envoy_dynamic_module_callback_listener_filter_scheduler_commit(
+    envoy_dynamic_module_type_listener_filter_scheduler_module_ptr scheduler_module_ptr,
+    uint64_t event_id) {
+  auto* scheduler = static_cast<DynamicModuleListenerFilterScheduler*>(scheduler_module_ptr);
+  scheduler->commit(event_id);
+}
+
+envoy_dynamic_module_type_listener_filter_config_scheduler_module_ptr
+envoy_dynamic_module_callback_listener_filter_config_scheduler_new(
+    envoy_dynamic_module_type_listener_filter_config_envoy_ptr filter_config_envoy_ptr) {
+  auto* filter_config = static_cast<DynamicModuleListenerFilterConfig*>(filter_config_envoy_ptr);
+  return new DynamicModuleListenerFilterConfigScheduler(filter_config->weak_from_this(),
+                                                        filter_config->main_thread_dispatcher_);
+}
+
+void envoy_dynamic_module_callback_listener_filter_config_scheduler_delete(
+    envoy_dynamic_module_type_listener_filter_config_scheduler_module_ptr scheduler_module_ptr) {
+  delete static_cast<DynamicModuleListenerFilterConfigScheduler*>(scheduler_module_ptr);
+}
+
+void envoy_dynamic_module_callback_listener_filter_config_scheduler_commit(
+    envoy_dynamic_module_type_listener_filter_config_scheduler_module_ptr scheduler_module_ptr,
+    uint64_t event_id) {
+  auto* scheduler = static_cast<DynamicModuleListenerFilterConfigScheduler*>(scheduler_module_ptr);
+  scheduler->commit(event_id);
+}
+
 } // extern "C"
 
 } // namespace ListenerFilters

--- a/source/extensions/filters/listener/dynamic_modules/factory.cc
+++ b/source/extensions/filters/listener/dynamic_modules/factory.cc
@@ -40,7 +40,7 @@ DynamicModuleListenerFilterConfigFactory::createListenerFilterFactoryFromProto(
   auto filter_config =
       Extensions::DynamicModules::ListenerFilters::newDynamicModuleListenerFilterConfig(
           proto_config.filter_name(), filter_config_str, std::move(dynamic_module.value()),
-          context.listenerScope());
+          context.listenerScope(), context.serverFactoryContext().mainThreadDispatcher());
 
   if (!filter_config.ok()) {
     throw EnvoyException("Failed to create filter config: " +

--- a/source/extensions/filters/listener/dynamic_modules/filter.cc
+++ b/source/extensions/filters/listener/dynamic_modules/filter.cc
@@ -81,6 +81,13 @@ size_t DynamicModuleListenerFilter::maxReadBytes() const {
       const_cast<DynamicModuleListenerFilter*>(this)->thisAsVoidPtr(), in_module_filter_);
 }
 
+void DynamicModuleListenerFilter::onScheduled(uint64_t event_id) {
+  // By the time this event is invoked, the filter might be destroyed.
+  if (in_module_filter_ && config_->on_listener_filter_scheduled_) {
+    config_->on_listener_filter_scheduled_(thisAsVoidPtr(), in_module_filter_, event_id);
+  }
+}
+
 } // namespace ListenerFilters
 } // namespace DynamicModules
 } // namespace Extensions

--- a/source/extensions/filters/listener/dynamic_modules/filter_config.cc
+++ b/source/extensions/filters/listener/dynamic_modules/filter_config.cc
@@ -11,8 +11,10 @@ namespace ListenerFilters {
 
 DynamicModuleListenerFilterConfig::DynamicModuleListenerFilterConfig(
     const absl::string_view filter_name, const absl::string_view filter_config,
-    DynamicModulePtr dynamic_module, Stats::Scope& stats_scope)
-    : stats_scope_(stats_scope.createScope(std::string(ListenerFilterStatsNamespace) + ".")),
+    DynamicModulePtr dynamic_module, Stats::Scope& stats_scope,
+    Event::Dispatcher& main_thread_dispatcher)
+    : main_thread_dispatcher_(main_thread_dispatcher),
+      stats_scope_(stats_scope.createScope(std::string(ListenerFilterStatsNamespace) + ".")),
       stat_name_pool_(stats_scope_->symbolTable()), filter_name_(filter_name),
       filter_config_(filter_config), dynamic_module_(std::move(dynamic_module)) {}
 
@@ -22,10 +24,17 @@ DynamicModuleListenerFilterConfig::~DynamicModuleListenerFilterConfig() {
   }
 }
 
+void DynamicModuleListenerFilterConfig::onScheduled(uint64_t event_id) {
+  if (on_listener_filter_config_scheduled_) {
+    (*on_listener_filter_config_scheduled_)(this, in_module_config_, event_id);
+  }
+}
+
 absl::StatusOr<DynamicModuleListenerFilterConfigSharedPtr>
 newDynamicModuleListenerFilterConfig(const absl::string_view filter_name,
                                      const absl::string_view filter_config,
-                                     DynamicModulePtr dynamic_module, Stats::Scope& stats_scope) {
+                                     DynamicModulePtr dynamic_module, Stats::Scope& stats_scope,
+                                     Event::Dispatcher& main_thread_dispatcher) {
 
   // Resolve the symbols for the listener filter using graceful error handling.
   auto on_config_new =
@@ -63,8 +72,17 @@ newDynamicModuleListenerFilterConfig(const absl::string_view filter_name,
       "envoy_dynamic_module_on_listener_filter_destroy");
   RETURN_IF_NOT_OK_REF(on_destroy.status());
 
+  auto on_scheduled = dynamic_module->getFunctionPointer<OnListenerFilterScheduledType>(
+      "envoy_dynamic_module_on_listener_filter_scheduled");
+  RETURN_IF_NOT_OK_REF(on_scheduled.status());
+
+  // This is optional. Modules that don't need config-level scheduling don't need to implement it.
+  auto on_config_scheduled =
+      dynamic_module->getFunctionPointer<OnListenerFilterConfigScheduledType>(
+          "envoy_dynamic_module_on_listener_filter_config_scheduled");
+
   auto config = std::make_shared<DynamicModuleListenerFilterConfig>(
-      filter_name, filter_config, std::move(dynamic_module), stats_scope);
+      filter_name, filter_config, std::move(dynamic_module), stats_scope, main_thread_dispatcher);
 
   // Store the resolved function pointers.
   config->on_listener_filter_config_destroy_ = on_config_destroy.value();
@@ -74,6 +92,10 @@ newDynamicModuleListenerFilterConfig(const absl::string_view filter_name,
   config->on_listener_filter_on_close_ = on_close.value();
   config->on_listener_filter_get_max_read_bytes_ = on_get_max_read_bytes.value();
   config->on_listener_filter_destroy_ = on_destroy.value();
+  config->on_listener_filter_scheduled_ = on_scheduled.value();
+  if (on_config_scheduled.ok()) {
+    config->on_listener_filter_config_scheduled_ = on_config_scheduled.value();
+  }
 
   // Create the in-module configuration.
   envoy_dynamic_module_type_envoy_buffer name_buffer = {const_cast<char*>(filter_name.data()),

--- a/source/extensions/filters/listener/dynamic_modules/filter_config.h
+++ b/source/extensions/filters/listener/dynamic_modules/filter_config.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "envoy/common/optref.h"
+#include "envoy/event/dispatcher.h"
 #include "envoy/stats/scope.h"
 #include "envoy/stats/stats.h"
 
@@ -23,9 +24,16 @@ using OnListenerFilterOnCloseType = decltype(&envoy_dynamic_module_on_listener_f
 using OnListenerFilterGetMaxReadBytesType =
     decltype(&envoy_dynamic_module_on_listener_filter_get_max_read_bytes);
 using OnListenerFilterDestroyType = decltype(&envoy_dynamic_module_on_listener_filter_destroy);
+using OnListenerFilterScheduledType = decltype(&envoy_dynamic_module_on_listener_filter_scheduled);
+using OnListenerFilterConfigScheduledType =
+    decltype(&envoy_dynamic_module_on_listener_filter_config_scheduled);
 
 // Custom namespace prefix for listener filter stats.
 constexpr char ListenerFilterStatsNamespace[] = "dynamic_module_listener_filter";
+
+class DynamicModuleListenerFilterConfig;
+using DynamicModuleListenerFilterConfigSharedPtr =
+    std::shared_ptr<DynamicModuleListenerFilterConfig>;
 
 /**
  * A config to create listener filters based on a dynamic module. This will be owned by multiple
@@ -36,7 +44,8 @@ constexpr char ListenerFilterStatsNamespace[] = "dynamic_module_listener_filter"
  * newDynamicModuleListenerFilterConfig() to provide graceful error handling. The constructor
  * only initializes basic members.
  */
-class DynamicModuleListenerFilterConfig {
+class DynamicModuleListenerFilterConfig
+    : public std::enable_shared_from_this<DynamicModuleListenerFilterConfig> {
 public:
   /**
    * Constructor for the config. Symbol resolution is done in
@@ -45,12 +54,19 @@ public:
    * @param filter_config the configuration for the module.
    * @param dynamic_module the dynamic module to use.
    * @param stats_scope the stats scope for metrics.
+   * @param main_thread_dispatcher the main thread dispatcher for scheduling events.
    */
   DynamicModuleListenerFilterConfig(const absl::string_view filter_name,
                                     const absl::string_view filter_config,
-                                    DynamicModulePtr dynamic_module, Stats::Scope& stats_scope);
+                                    DynamicModulePtr dynamic_module, Stats::Scope& stats_scope,
+                                    Event::Dispatcher& main_thread_dispatcher);
 
   ~DynamicModuleListenerFilterConfig();
+
+  /**
+   * This is called when an event is scheduled via DynamicModuleListenerFilterConfigScheduler.
+   */
+  void onScheduled(uint64_t event_id);
 
   // The corresponding in-module configuration.
   envoy_dynamic_module_type_listener_filter_config_module_ptr in_module_config_ = nullptr;
@@ -65,6 +81,12 @@ public:
   OnListenerFilterOnCloseType on_listener_filter_on_close_ = nullptr;
   OnListenerFilterGetMaxReadBytesType on_listener_filter_get_max_read_bytes_ = nullptr;
   OnListenerFilterDestroyType on_listener_filter_destroy_ = nullptr;
+  // Optional: modules that don't need config-level scheduling don't need to implement this.
+  OnListenerFilterScheduledType on_listener_filter_scheduled_ = nullptr;
+  OnListenerFilterConfigScheduledType on_listener_filter_config_scheduled_ = nullptr;
+
+  // The main thread dispatcher for scheduling config-level events.
+  Event::Dispatcher& main_thread_dispatcher_;
 
   // ----------------------------- Metrics Support -----------------------------
   // Handle classes for storing defined metrics.
@@ -148,7 +170,8 @@ private:
   friend absl::StatusOr<std::shared_ptr<DynamicModuleListenerFilterConfig>>
   newDynamicModuleListenerFilterConfig(const absl::string_view filter_name,
                                        const absl::string_view filter_config,
-                                       DynamicModulePtr dynamic_module, Stats::Scope& stats_scope);
+                                       DynamicModulePtr dynamic_module, Stats::Scope& stats_scope,
+                                       Event::Dispatcher& main_thread_dispatcher);
 
   // The name of the filter passed in the constructor.
   const std::string filter_name_;
@@ -165,8 +188,30 @@ private:
   std::vector<ModuleHistogramHandle> histograms_;
 };
 
-using DynamicModuleListenerFilterConfigSharedPtr =
-    std::shared_ptr<DynamicModuleListenerFilterConfig>;
+/**
+ * This class is used to schedule a listener filter config event hook from a different thread
+ * than the one it was assigned to. This is created via
+ * envoy_dynamic_module_callback_listener_filter_config_scheduler_new and deleted via
+ * envoy_dynamic_module_callback_listener_filter_config_scheduler_delete.
+ */
+class DynamicModuleListenerFilterConfigScheduler {
+public:
+  DynamicModuleListenerFilterConfigScheduler(
+      std::weak_ptr<DynamicModuleListenerFilterConfig> config, Event::Dispatcher& dispatcher)
+      : config_(std::move(config)), dispatcher_(dispatcher) {}
+
+  void commit(uint64_t event_id) {
+    dispatcher_.post([config = config_, event_id]() {
+      if (std::shared_ptr<DynamicModuleListenerFilterConfig> config_shared = config.lock()) {
+        config_shared->onScheduled(event_id);
+      }
+    });
+  }
+
+private:
+  std::weak_ptr<DynamicModuleListenerFilterConfig> config_;
+  Event::Dispatcher& dispatcher_;
+};
 
 /**
  * Creates a new DynamicModuleListenerFilterConfig for given configuration.
@@ -174,11 +219,13 @@ using DynamicModuleListenerFilterConfigSharedPtr =
  * @param filter_config the configuration for the module.
  * @param dynamic_module the dynamic module to use.
  * @param stats_scope the stats scope for metrics.
+ * @param main_thread_dispatcher the main thread dispatcher for scheduling events.
  * @return a shared pointer to the new config object or an error if the module could not be loaded.
  */
 absl::StatusOr<DynamicModuleListenerFilterConfigSharedPtr> newDynamicModuleListenerFilterConfig(
     const absl::string_view filter_name, const absl::string_view filter_config,
-    Extensions::DynamicModules::DynamicModulePtr dynamic_module, Stats::Scope& stats_scope);
+    Extensions::DynamicModules::DynamicModulePtr dynamic_module, Stats::Scope& stats_scope,
+    Event::Dispatcher& main_thread_dispatcher);
 
 } // namespace ListenerFilters
 } // namespace DynamicModules

--- a/test/extensions/dynamic_modules/listener/filter_test.cc
+++ b/test/extensions/dynamic_modules/listener/filter_test.cc
@@ -4,6 +4,7 @@
 #include "source/extensions/filters/listener/dynamic_modules/filter_config.h"
 
 #include "test/extensions/dynamic_modules/util.h"
+#include "test/mocks/event/mocks.h"
 #include "test/mocks/network/io_handle.h"
 #include "test/mocks/network/mocks.h"
 #include "test/test_common/utility.h"
@@ -44,14 +45,16 @@ public:
     auto dynamic_module = newDynamicModule(testSharedObjectPath("listener_no_op", "c"), false);
     EXPECT_TRUE(dynamic_module.ok()) << dynamic_module.status().message();
 
-    auto filter_config_or_status = newDynamicModuleListenerFilterConfig(
-        "test_filter", "", std::move(dynamic_module.value()), *stats_.rootScope());
+    auto filter_config_or_status =
+        newDynamicModuleListenerFilterConfig("test_filter", "", std::move(dynamic_module.value()),
+                                             *stats_.rootScope(), main_thread_dispatcher_);
     EXPECT_TRUE(filter_config_or_status.ok()) << filter_config_or_status.status().message();
     filter_config_ = filter_config_or_status.value();
   }
 
   Stats::IsolatedStoreImpl stats_;
   DynamicModuleListenerFilterConfigSharedPtr filter_config_;
+  NiceMock<Event::MockDispatcher> main_thread_dispatcher_;
 };
 
 TEST_F(DynamicModuleListenerFilterTest, BasicFilterFlow) {
@@ -195,11 +198,13 @@ TEST_F(DynamicModuleListenerFilterTest, GetFilterConfig) {
 
 TEST(DynamicModuleListenerFilterConfigTest, ConfigInitialization) {
   Stats::IsolatedStoreImpl stats;
+  NiceMock<Event::MockDispatcher> main_thread_dispatcher;
   auto dynamic_module = newDynamicModule(testSharedObjectPath("listener_no_op", "c"), false);
   EXPECT_TRUE(dynamic_module.ok()) << dynamic_module.status().message();
 
   auto filter_config_or_status = newDynamicModuleListenerFilterConfig(
-      "test_filter", "some_config", std::move(dynamic_module.value()), *stats.rootScope());
+      "test_filter", "some_config", std::move(dynamic_module.value()), *stats.rootScope(),
+      main_thread_dispatcher);
   EXPECT_TRUE(filter_config_or_status.ok());
 
   auto config = filter_config_or_status.value();
@@ -215,24 +220,28 @@ TEST(DynamicModuleListenerFilterConfigTest, ConfigInitialization) {
 
 TEST(DynamicModuleListenerFilterConfigTest, MissingSymbols) {
   Stats::IsolatedStoreImpl stats;
+  NiceMock<Event::MockDispatcher> main_thread_dispatcher;
   // Use the HTTP filter no_op module which lacks listener filter symbols.
   auto dynamic_module = newDynamicModule(testSharedObjectPath("no_op", "c"), false);
   EXPECT_TRUE(dynamic_module.ok()) << dynamic_module.status().message();
 
-  auto filter_config_or_status = newDynamicModuleListenerFilterConfig(
-      "test_filter", "", std::move(dynamic_module.value()), *stats.rootScope());
+  auto filter_config_or_status =
+      newDynamicModuleListenerFilterConfig("test_filter", "", std::move(dynamic_module.value()),
+                                           *stats.rootScope(), main_thread_dispatcher);
   EXPECT_FALSE(filter_config_or_status.ok());
 }
 
 TEST(DynamicModuleListenerFilterConfigTest, ConfigInitializationFailure) {
   Stats::IsolatedStoreImpl stats;
+  NiceMock<Event::MockDispatcher> main_thread_dispatcher;
   // Use a module that returns nullptr from config_new.
   auto dynamic_module =
       newDynamicModule(testSharedObjectPath("listener_config_new_fail", "c"), false);
   EXPECT_TRUE(dynamic_module.ok()) << dynamic_module.status().message();
 
-  auto filter_config_or_status = newDynamicModuleListenerFilterConfig(
-      "test_filter", "", std::move(dynamic_module.value()), *stats.rootScope());
+  auto filter_config_or_status =
+      newDynamicModuleListenerFilterConfig("test_filter", "", std::move(dynamic_module.value()),
+                                           *stats.rootScope(), main_thread_dispatcher);
   EXPECT_FALSE(filter_config_or_status.ok());
   EXPECT_THAT(filter_config_or_status.status().message(),
               testing::HasSubstr("Failed to initialize"));
@@ -240,12 +249,14 @@ TEST(DynamicModuleListenerFilterConfigTest, ConfigInitializationFailure) {
 
 TEST(DynamicModuleListenerFilterConfigTest, StopIterationStatus) {
   Stats::IsolatedStoreImpl stats;
+  NiceMock<Event::MockDispatcher> main_thread_dispatcher;
   auto dynamic_module =
       newDynamicModule(testSharedObjectPath("listener_stop_iteration", "c"), false);
   EXPECT_TRUE(dynamic_module.ok()) << dynamic_module.status().message();
 
-  auto filter_config_or_status = newDynamicModuleListenerFilterConfig(
-      "test_filter", "", std::move(dynamic_module.value()), *stats.rootScope());
+  auto filter_config_or_status =
+      newDynamicModuleListenerFilterConfig("test_filter", "", std::move(dynamic_module.value()),
+                                           *stats.rootScope(), main_thread_dispatcher);
   EXPECT_TRUE(filter_config_or_status.ok());
   auto config = filter_config_or_status.value();
 
@@ -263,12 +274,14 @@ TEST(DynamicModuleListenerFilterConfigTest, StopIterationStatus) {
 
 TEST(DynamicModuleListenerFilterConfigTest, OnDataStopIterationStatus) {
   Stats::IsolatedStoreImpl stats;
+  NiceMock<Event::MockDispatcher> main_thread_dispatcher;
   auto dynamic_module =
       newDynamicModule(testSharedObjectPath("listener_stop_iteration", "c"), false);
   EXPECT_TRUE(dynamic_module.ok()) << dynamic_module.status().message();
 
-  auto filter_config_or_status = newDynamicModuleListenerFilterConfig(
-      "test_filter", "", std::move(dynamic_module.value()), *stats.rootScope());
+  auto filter_config_or_status =
+      newDynamicModuleListenerFilterConfig("test_filter", "", std::move(dynamic_module.value()),
+                                           *stats.rootScope(), main_thread_dispatcher);
   EXPECT_TRUE(filter_config_or_status.ok());
   auto config = filter_config_or_status.value();
 

--- a/test/extensions/dynamic_modules/test_data/c/listener_config_new_fail.c
+++ b/test/extensions/dynamic_modules/test_data/c/listener_config_new_fail.c
@@ -51,3 +51,20 @@ size_t envoy_dynamic_module_on_listener_filter_get_max_read_bytes(
 
 void envoy_dynamic_module_on_listener_filter_destroy(
     envoy_dynamic_module_type_listener_filter_module_ptr filter_module_ptr) {}
+
+void envoy_dynamic_module_on_listener_filter_scheduled(
+    envoy_dynamic_module_type_listener_filter_envoy_ptr filter_envoy_ptr,
+    envoy_dynamic_module_type_listener_filter_module_ptr filter_module_ptr, uint64_t event_id) {
+  (void)filter_envoy_ptr;
+  (void)filter_module_ptr;
+  (void)event_id;
+}
+
+void envoy_dynamic_module_on_listener_filter_config_scheduled(
+    envoy_dynamic_module_type_listener_filter_config_envoy_ptr filter_config_envoy_ptr,
+    envoy_dynamic_module_type_listener_filter_config_module_ptr filter_config_module_ptr,
+    uint64_t event_id) {
+  (void)filter_config_envoy_ptr;
+  (void)filter_config_module_ptr;
+  (void)event_id;
+}

--- a/test/extensions/dynamic_modules/test_data/c/listener_no_op.c
+++ b/test/extensions/dynamic_modules/test_data/c/listener_no_op.c
@@ -64,3 +64,20 @@ void envoy_dynamic_module_on_listener_filter_destroy(
     envoy_dynamic_module_type_listener_filter_module_ptr filter_module_ptr) {
   assert(filter_module_ptr == &some_variable + 1);
 }
+
+void envoy_dynamic_module_on_listener_filter_scheduled(
+    envoy_dynamic_module_type_listener_filter_envoy_ptr filter_envoy_ptr,
+    envoy_dynamic_module_type_listener_filter_module_ptr filter_module_ptr, uint64_t event_id) {
+  (void)filter_envoy_ptr;
+  (void)filter_module_ptr;
+  (void)event_id;
+}
+
+void envoy_dynamic_module_on_listener_filter_config_scheduled(
+    envoy_dynamic_module_type_listener_filter_config_envoy_ptr filter_config_envoy_ptr,
+    envoy_dynamic_module_type_listener_filter_config_module_ptr filter_config_module_ptr,
+    uint64_t event_id) {
+  (void)filter_config_envoy_ptr;
+  (void)filter_config_module_ptr;
+  (void)event_id;
+}

--- a/test/extensions/dynamic_modules/test_data/c/listener_stop_iteration.c
+++ b/test/extensions/dynamic_modules/test_data/c/listener_stop_iteration.c
@@ -54,3 +54,20 @@ size_t envoy_dynamic_module_on_listener_filter_get_max_read_bytes(
 
 void envoy_dynamic_module_on_listener_filter_destroy(
     envoy_dynamic_module_type_listener_filter_module_ptr filter_module_ptr) {}
+
+void envoy_dynamic_module_on_listener_filter_scheduled(
+    envoy_dynamic_module_type_listener_filter_envoy_ptr filter_envoy_ptr,
+    envoy_dynamic_module_type_listener_filter_module_ptr filter_module_ptr, uint64_t event_id) {
+  (void)filter_envoy_ptr;
+  (void)filter_module_ptr;
+  (void)event_id;
+}
+
+void envoy_dynamic_module_on_listener_filter_config_scheduled(
+    envoy_dynamic_module_type_listener_filter_config_envoy_ptr filter_config_envoy_ptr,
+    envoy_dynamic_module_type_listener_filter_config_module_ptr filter_config_module_ptr,
+    uint64_t event_id) {
+  (void)filter_config_envoy_ptr;
+  (void)filter_config_module_ptr;
+  (void)event_id;
+}


### PR DESCRIPTION
## Description

This PR adds the scheduler API to Network Listener Dynamic Modules.

---

**Commit Message:** dynamic_modules: add scheduler to network filters ABI
**Additional Description:** Added the scheduler API to Network Listener Dynamic Modules.
**Risk Level:** Low
**Testing:** Added Tests
**Docs Changes:** Added
**Release Notes**: N/A