### PR TITLE
dynamic_modules: add more methods to network filters ABI

### DIFF
--- a/source/extensions/dynamic_modules/abi.h
+++ b/source/extensions/dynamic_modules/abi.h
@@ -2953,6 +2953,74 @@ envoy_dynamic_module_type_metrics_result
 envoy_dynamic_module_callback_network_filter_record_histogram_value(
     envoy_dynamic_module_type_network_filter_envoy_ptr filter_envoy_ptr, size_t id, uint64_t value);
 
+// ---------------------- Upstream Host Access Callbacks -----------------------
+
+/**
+ * envoy_dynamic_module_callback_network_filter_get_upstream_host_address is called by the module
+ * to get the address and port of the currently selected upstream host.
+ *
+ * @param filter_envoy_ptr is the pointer to the DynamicModuleNetworkFilter object.
+ * @param address_out is the output buffer where the address string owned by Envoy will be stored.
+ * @param port_out is the output pointer to the port number.
+ * @return true if the upstream host is set and has an IP address, false otherwise.
+ */
+bool envoy_dynamic_module_callback_network_filter_get_upstream_host_address(
+    envoy_dynamic_module_type_network_filter_envoy_ptr filter_envoy_ptr,
+    envoy_dynamic_module_type_envoy_buffer* address_out, uint32_t* port_out);
+
+/**
+ * envoy_dynamic_module_callback_network_filter_get_upstream_host_hostname is called by the module
+ * to get the hostname of the currently selected upstream host.
+ *
+ * @param filter_envoy_ptr is the pointer to the DynamicModuleNetworkFilter object.
+ * @param hostname_out is the output buffer where the hostname string owned by Envoy will be stored.
+ * @return true if the upstream host is set and has a hostname, false otherwise.
+ */
+bool envoy_dynamic_module_callback_network_filter_get_upstream_host_hostname(
+    envoy_dynamic_module_type_network_filter_envoy_ptr filter_envoy_ptr,
+    envoy_dynamic_module_type_envoy_buffer* hostname_out);
+
+/**
+ * envoy_dynamic_module_callback_network_filter_get_upstream_host_cluster is called by the module
+ * to get the cluster name of the currently selected upstream host.
+ *
+ * @param filter_envoy_ptr is the pointer to the DynamicModuleNetworkFilter object.
+ * @param cluster_name_out is the output buffer where the cluster name string owned by Envoy will
+ * be stored.
+ * @return true if the upstream host is set, false otherwise.
+ */
+bool envoy_dynamic_module_callback_network_filter_get_upstream_host_cluster(
+    envoy_dynamic_module_type_network_filter_envoy_ptr filter_envoy_ptr,
+    envoy_dynamic_module_type_envoy_buffer* cluster_name_out);
+
+/**
+ * envoy_dynamic_module_callback_network_filter_has_upstream_host is called by the module to check
+ * if an upstream host has been selected for this connection.
+ *
+ * @param filter_envoy_ptr is the pointer to the DynamicModuleNetworkFilter object.
+ * @return true if an upstream host is set, false otherwise.
+ */
+bool envoy_dynamic_module_callback_network_filter_has_upstream_host(
+    envoy_dynamic_module_type_network_filter_envoy_ptr filter_envoy_ptr);
+
+// ---------------------- StartTLS Support Callbacks ---------------------------
+
+/**
+ * envoy_dynamic_module_callback_network_filter_start_upstream_secure_transport is called by the
+ * module to convert the upstream connection from non-secure to secure mode (StartTLS).
+ *
+ * This signals the filter manager to enable secure transport mode in the upstream connection.
+ * This is done when the upstream connection's transport socket is of startTLS type. At the moment
+ * it is the only transport socket type which can be programmatically converted from non-secure
+ * mode to secure mode.
+ *
+ * @param filter_envoy_ptr is the pointer to the DynamicModuleNetworkFilter object.
+ * @return true if the upstream transport was successfully converted to secure mode, false
+ * otherwise.
+ */
+bool envoy_dynamic_module_callback_network_filter_start_upstream_secure_transport(
+    envoy_dynamic_module_type_network_filter_envoy_ptr filter_envoy_ptr);
+
 // =============================================================================
 // ============================= Listener Filter ===============================
 // =============================================================================

--- a/source/extensions/filters/network/dynamic_modules/abi_impl.cc
+++ b/source/extensions/filters/network/dynamic_modules/abi_impl.cc
@@ -826,6 +826,120 @@ envoy_dynamic_module_callback_network_filter_record_histogram_value(
   return envoy_dynamic_module_type_metrics_result_Success;
 }
 
+// -----------------------------------------------------------------------------
+// Upstream Host Access Callbacks
+// -----------------------------------------------------------------------------
+
+bool envoy_dynamic_module_callback_network_filter_get_upstream_host_address(
+    envoy_dynamic_module_type_network_filter_envoy_ptr filter_envoy_ptr,
+    envoy_dynamic_module_type_envoy_buffer* address_out, uint32_t* port_out) {
+  auto* filter = static_cast<DynamicModuleNetworkFilter*>(filter_envoy_ptr);
+  if (filter->readCallbacks() == nullptr) {
+    address_out->ptr = nullptr;
+    address_out->length = 0;
+    *port_out = 0;
+    return false;
+  }
+
+  const auto host = filter->readCallbacks()->upstreamHost();
+  if (host == nullptr) {
+    address_out->ptr = nullptr;
+    address_out->length = 0;
+    *port_out = 0;
+    return false;
+  }
+
+  const auto& address = host->address();
+  if (address == nullptr || address->ip() == nullptr) {
+    address_out->ptr = nullptr;
+    address_out->length = 0;
+    *port_out = 0;
+    return false;
+  }
+
+  const std::string& addr_str = address->ip()->addressAsString();
+  address_out->ptr = const_cast<char*>(addr_str.data());
+  address_out->length = addr_str.size();
+  *port_out = address->ip()->port();
+  return true;
+}
+
+bool envoy_dynamic_module_callback_network_filter_get_upstream_host_hostname(
+    envoy_dynamic_module_type_network_filter_envoy_ptr filter_envoy_ptr,
+    envoy_dynamic_module_type_envoy_buffer* hostname_out) {
+  auto* filter = static_cast<DynamicModuleNetworkFilter*>(filter_envoy_ptr);
+  if (filter->readCallbacks() == nullptr) {
+    hostname_out->ptr = nullptr;
+    hostname_out->length = 0;
+    return false;
+  }
+
+  const auto host = filter->readCallbacks()->upstreamHost();
+  if (host == nullptr) {
+    hostname_out->ptr = nullptr;
+    hostname_out->length = 0;
+    return false;
+  }
+
+  const std::string& hostname = host->hostname();
+  if (hostname.empty()) {
+    hostname_out->ptr = nullptr;
+    hostname_out->length = 0;
+    return false;
+  }
+
+  hostname_out->ptr = const_cast<char*>(hostname.data());
+  hostname_out->length = hostname.size();
+  return true;
+}
+
+bool envoy_dynamic_module_callback_network_filter_get_upstream_host_cluster(
+    envoy_dynamic_module_type_network_filter_envoy_ptr filter_envoy_ptr,
+    envoy_dynamic_module_type_envoy_buffer* cluster_name_out) {
+  auto* filter = static_cast<DynamicModuleNetworkFilter*>(filter_envoy_ptr);
+  if (filter->readCallbacks() == nullptr) {
+    cluster_name_out->ptr = nullptr;
+    cluster_name_out->length = 0;
+    return false;
+  }
+
+  const auto host = filter->readCallbacks()->upstreamHost();
+  if (host == nullptr) {
+    cluster_name_out->ptr = nullptr;
+    cluster_name_out->length = 0;
+    return false;
+  }
+
+  const std::string& cluster_name = host->cluster().name();
+  cluster_name_out->ptr = const_cast<char*>(cluster_name.data());
+  cluster_name_out->length = cluster_name.size();
+  return true;
+}
+
+bool envoy_dynamic_module_callback_network_filter_has_upstream_host(
+    envoy_dynamic_module_type_network_filter_envoy_ptr filter_envoy_ptr) {
+  auto* filter = static_cast<DynamicModuleNetworkFilter*>(filter_envoy_ptr);
+  if (filter->readCallbacks() == nullptr) {
+    return false;
+  }
+
+  return filter->readCallbacks()->upstreamHost() != nullptr;
+}
+
+// -----------------------------------------------------------------------------
+// StartTLS Support Callbacks
+// -----------------------------------------------------------------------------
+
+bool envoy_dynamic_module_callback_network_filter_start_upstream_secure_transport(
+    envoy_dynamic_module_type_network_filter_envoy_ptr filter_envoy_ptr) {
+  auto* filter = static_cast<DynamicModuleNetworkFilter*>(filter_envoy_ptr);
+  if (filter->readCallbacks() == nullptr) {
+    return false;
+  }
+
+  return filter->readCallbacks()->startUpstreamSecureTransport();
+}
+
 } // extern "C"
 
 } // namespace NetworkFilters


### PR DESCRIPTION
## Description

This PR add some more methods to the network filters ABI for Dynamic Modules. These methods expose upstream host access and Start TLS callbacks. 

---

**Commit Message:** dynamic_modules: add more methods to network filters ABI
**Additional Description:** Added some more methods to the network filters ABI for Dynamic Modules. 
**Risk Level:** Low
**Testing**: Added Tests
**Docs Changes:** Added
**Release Notes:** N/A