### PR TITLE
deps: Rename c-ares -> `com_github_cares_cares`

### DIFF
--- a/bazel/grpc.patch
+++ b/bazel/grpc.patch
@@ -256,7 +256,7 @@ index 13a4714d4b..8664e99ffc 100644
  alias(
      name = "cares",
 -    actual = "@com_github_cares_cares//:ares",
-+    actual = "@com_github_c_ares_c_ares//:ares",
++    actual = "@com_github_cares_cares//:ares",
      tags = ["manual"],
  )
  

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -144,7 +144,7 @@ def envoy_dependencies(skip_targets = []):
     _com_github_awslabs_aws_c_auth()
     _com_github_axboe_liburing()
     _com_github_bazel_buildtools()
-    _com_github_c_ares_c_ares()
+    _com_github_cares_cares()
     _com_github_openhistogram_libcircllhist()
     _com_github_cyan4973_xxhash()
     _com_github_datadog_dd_trace_cpp()
@@ -321,9 +321,9 @@ def _com_github_bazel_buildtools():
         name = "com_github_bazelbuild_buildtools",
     )
 
-def _com_github_c_ares_c_ares():
+def _com_github_cares_cares():
     external_http_archive(
-        name = "com_github_c_ares_c_ares",
+        name = "com_github_cares_cares",
         build_file = "@envoy//bazel/external:c-ares.BUILD",
         patch_args = ["-p1"],
         patches = ["@envoy//bazel:c-ares.patch"],

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -261,7 +261,7 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         license = "Apache-2.0",
         license_url = "https://github.com/google/perfetto/blob/v{version}/LICENSE",
     ),
-    com_github_c_ares_c_ares = dict(
+    com_github_cares_cares = dict(
         project_name = "c-ares",
         project_desc = "C library for asynchronous DNS requests",
         project_url = "https://c-ares.haxx.se/",

--- a/source/extensions/filters/udp/dns_filter/BUILD
+++ b/source/extensions/filters/udp/dns_filter/BUILD
@@ -48,7 +48,7 @@ envoy_cc_library(
         "//source/common/protobuf:utility_lib",
         "//source/common/runtime:runtime_lib",
         "//source/common/upstream:cluster_manager_lib",
-        "@com_github_c_ares_c_ares//:ares",
+        "@com_github_cares_cares//:ares",
         "@envoy_api//envoy/extensions/filters/udp/dns_filter/v3:pkg_cc_proto",
         "@envoy_api//envoy/type/matcher/v3:pkg_cc_proto",
     ],

--- a/source/extensions/network/dns_resolver/cares/BUILD
+++ b/source/extensions/network/dns_resolver/cares/BUILD
@@ -25,6 +25,6 @@ envoy_cc_extension(
         "//source/common/network:utility_lib",
         "//source/common/network/dns_resolver:dns_factory_util_lib",
         "//source/common/runtime:runtime_features_lib",
-        "@com_github_c_ares_c_ares//:ares",
+        "@com_github_cares_cares//:ares",
     ],
 )

--- a/test/extensions/filters/udp/dns_filter/BUILD
+++ b/test/extensions/filters/udp/dns_filter/BUILD
@@ -24,7 +24,7 @@ envoy_extension_cc_test_library(
         "//source/common/network:utility_lib",
         "//source/extensions/filters/udp/dns_filter:dns_filter_lib",
         "//test/test_common:environment_lib",
-        "@com_github_c_ares_c_ares//:ares",
+        "@com_github_cares_cares//:ares",
     ],
 )
 


### PR DESCRIPTION
i think we are the only ones that call it `com_github_c_ares_c_ares`, and with bzlmod doing so breaks our patches (for grpc)

