### PR TITLE
dynamic_modules: add scheduler to network filters ABI

### DIFF
--- a/source/extensions/filters/network/dynamic_modules/abi_impl.cc
+++ b/source/extensions/filters/network/dynamic_modules/abi_impl.cc
@@ -940,6 +940,53 @@ bool envoy_dynamic_module_callback_network_filter_start_upstream_secure_transpor
   return filter->readCallbacks()->startUpstreamSecureTransport();
 }
 
+// -----------------------------------------------------------------------------
+// Network filter scheduler callbacks.
+// -----------------------------------------------------------------------------
+
+envoy_dynamic_module_type_network_filter_scheduler_module_ptr
+envoy_dynamic_module_callback_network_filter_scheduler_new(
+    envoy_dynamic_module_type_network_filter_envoy_ptr filter_envoy_ptr) {
+  auto* filter = static_cast<DynamicModuleNetworkFilter*>(filter_envoy_ptr);
+  Event::Dispatcher* dispatcher = filter->dispatcher();
+  if (dispatcher == nullptr) {
+    return nullptr;
+  }
+  return new DynamicModuleNetworkFilterScheduler(filter->weak_from_this(), *dispatcher);
+}
+
+void envoy_dynamic_module_callback_network_filter_scheduler_delete(
+    envoy_dynamic_module_type_network_filter_scheduler_module_ptr scheduler_module_ptr) {
+  delete static_cast<DynamicModuleNetworkFilterScheduler*>(scheduler_module_ptr);
+}
+
+void envoy_dynamic_module_callback_network_filter_scheduler_commit(
+    envoy_dynamic_module_type_network_filter_scheduler_module_ptr scheduler_module_ptr,
+    uint64_t event_id) {
+  auto* scheduler = static_cast<DynamicModuleNetworkFilterScheduler*>(scheduler_module_ptr);
+  scheduler->commit(event_id);
+}
+
+envoy_dynamic_module_type_network_filter_config_scheduler_module_ptr
+envoy_dynamic_module_callback_network_filter_config_scheduler_new(
+    envoy_dynamic_module_type_network_filter_config_envoy_ptr filter_config_envoy_ptr) {
+  auto* filter_config = static_cast<DynamicModuleNetworkFilterConfig*>(filter_config_envoy_ptr);
+  return new DynamicModuleNetworkFilterConfigScheduler(filter_config->weak_from_this(),
+                                                       filter_config->main_thread_dispatcher_);
+}
+
+void envoy_dynamic_module_callback_network_filter_config_scheduler_delete(
+    envoy_dynamic_module_type_network_filter_config_scheduler_module_ptr scheduler_module_ptr) {
+  delete static_cast<DynamicModuleNetworkFilterConfigScheduler*>(scheduler_module_ptr);
+}
+
+void envoy_dynamic_module_callback_network_filter_config_scheduler_commit(
+    envoy_dynamic_module_type_network_filter_config_scheduler_module_ptr scheduler_module_ptr,
+    uint64_t event_id) {
+  auto* scheduler = static_cast<DynamicModuleNetworkFilterConfigScheduler*>(scheduler_module_ptr);
+  scheduler->commit(event_id);
+}
+
 } // extern "C"
 
 } // namespace NetworkFilters

--- a/source/extensions/filters/network/dynamic_modules/factory.cc
+++ b/source/extensions/filters/network/dynamic_modules/factory.cc
@@ -35,7 +35,8 @@ DynamicModuleNetworkFilterConfigFactory::createFilterFactoryFromProtoTyped(
           Envoy::Extensions::DynamicModules::NetworkFilters::newDynamicModuleNetworkFilterConfig(
               proto_config.filter_name(), config, std::move(dynamic_module.value()),
               context.serverFactoryContext().clusterManager(),
-              context.serverFactoryContext().scope());
+              context.serverFactoryContext().scope(),
+              context.serverFactoryContext().mainThreadDispatcher());
 
   if (!filter_config.ok()) {
     return absl::InvalidArgumentError("Failed to create filter config: " +

--- a/source/extensions/filters/network/dynamic_modules/filter.cc
+++ b/source/extensions/filters/network/dynamic_modules/filter.cc
@@ -116,6 +116,12 @@ void DynamicModuleNetworkFilter::onEvent(Network::ConnectionEvent event) {
                                     toAbiConnectionEvent(event));
 }
 
+void DynamicModuleNetworkFilter::onScheduled(uint64_t event_id) {
+  if (in_module_filter_ != nullptr && config_->on_network_filter_scheduled_ != nullptr) {
+    config_->on_network_filter_scheduled_(thisAsVoidPtr(), in_module_filter_, event_id);
+  }
+}
+
 void DynamicModuleNetworkFilter::onAboveWriteBufferHighWatermark() {
   // Not currently exposed to dynamic modules.
 }

--- a/test/extensions/dynamic_modules/network/filter_test.cc
+++ b/test/extensions/dynamic_modules/network/filter_test.cc
@@ -3,6 +3,7 @@
 #include "source/extensions/filters/network/dynamic_modules/filter.h"
 
 #include "test/extensions/dynamic_modules/util.h"
+#include "test/mocks/event/mocks.h"
 #include "test/mocks/network/mocks.h"
 #include "test/mocks/upstream/cluster_manager.h"
 #include "test/test_common/utility.h"
@@ -18,14 +19,15 @@ public:
     auto dynamic_module = newDynamicModule(testSharedObjectPath("network_no_op", "c"), false);
     EXPECT_TRUE(dynamic_module.ok()) << dynamic_module.status().message();
 
-    auto filter_config_or_status =
-        newDynamicModuleNetworkFilterConfig("test_filter", "", std::move(dynamic_module.value()),
-                                            cluster_manager_, *stats_.rootScope());
+    auto filter_config_or_status = newDynamicModuleNetworkFilterConfig(
+        "test_filter", "", std::move(dynamic_module.value()), cluster_manager_, *stats_.rootScope(),
+        main_thread_dispatcher_);
     EXPECT_TRUE(filter_config_or_status.ok()) << filter_config_or_status.status().message();
     filter_config_ = filter_config_or_status.value();
   }
 
   Stats::IsolatedStoreImpl stats_;
+  NiceMock<Event::MockDispatcher> main_thread_dispatcher_;
   DynamicModuleNetworkFilterConfigSharedPtr filter_config_;
   NiceMock<Upstream::MockClusterManager> cluster_manager_;
 };
@@ -245,9 +247,10 @@ TEST(DynamicModuleNetworkFilterConfigTest, ConfigInitialization) {
 
   Stats::IsolatedStoreImpl stats;
   NiceMock<Upstream::MockClusterManager> cluster_manager;
+  NiceMock<Event::MockDispatcher> main_thread_dispatcher;
   auto filter_config_or_status = newDynamicModuleNetworkFilterConfig(
       "test_filter", "some_config", std::move(dynamic_module.value()), cluster_manager,
-      *stats.rootScope());
+      *stats.rootScope(), main_thread_dispatcher);
   EXPECT_TRUE(filter_config_or_status.ok());
 
   auto config = filter_config_or_status.value();
@@ -268,8 +271,10 @@ TEST(DynamicModuleNetworkFilterConfigTest, MissingSymbols) {
 
   Stats::IsolatedStoreImpl stats;
   NiceMock<Upstream::MockClusterManager> cluster_manager;
+  NiceMock<Event::MockDispatcher> main_thread_dispatcher;
   auto filter_config_or_status = newDynamicModuleNetworkFilterConfig(
-      "test_filter", "", std::move(dynamic_module.value()), cluster_manager, *stats.rootScope());
+      "test_filter", "", std::move(dynamic_module.value()), cluster_manager, *stats.rootScope(),
+      main_thread_dispatcher);
   EXPECT_FALSE(filter_config_or_status.ok());
 }
 
@@ -281,8 +286,10 @@ TEST(DynamicModuleNetworkFilterConfigTest, ConfigInitializationFailure) {
 
   Stats::IsolatedStoreImpl stats;
   NiceMock<Upstream::MockClusterManager> cluster_manager;
+  NiceMock<Event::MockDispatcher> main_thread_dispatcher;
   auto filter_config_or_status = newDynamicModuleNetworkFilterConfig(
-      "test_filter", "", std::move(dynamic_module.value()), cluster_manager, *stats.rootScope());
+      "test_filter", "", std::move(dynamic_module.value()), cluster_manager, *stats.rootScope(),
+      main_thread_dispatcher);
   EXPECT_FALSE(filter_config_or_status.ok());
   EXPECT_THAT(filter_config_or_status.status().message(),
               testing::HasSubstr("Failed to initialize"));
@@ -295,8 +302,10 @@ TEST(DynamicModuleNetworkFilterConfigTest, StopIterationStatus) {
 
   Stats::IsolatedStoreImpl stats;
   NiceMock<Upstream::MockClusterManager> cluster_manager;
+  NiceMock<Event::MockDispatcher> main_thread_dispatcher;
   auto filter_config_or_status = newDynamicModuleNetworkFilterConfig(
-      "test_filter", "", std::move(dynamic_module.value()), cluster_manager, *stats.rootScope());
+      "test_filter", "", std::move(dynamic_module.value()), cluster_manager, *stats.rootScope(),
+      main_thread_dispatcher);
   EXPECT_TRUE(filter_config_or_status.ok());
   auto config = filter_config_or_status.value();
 


### PR DESCRIPTION
## Description

This PR adds scheduler API to the Dynamic Modules network filter ABI.

---

**Commit Message:** dynamic_modules: add scheduler to network filters ABI
**Additional Description:** Added scheduler API to the Dynamic Modules network filter ABI.
**Risk Level:** Low
**Testing:** Added Tests
**Docs Changes:** Added
**Release Notes:** N/A