### PR TITLE
dynamic_modules: add timer API to network filters ABI

### DIFF
--- a/source/extensions/filters/network/dynamic_modules/abi_impl.cc
+++ b/source/extensions/filters/network/dynamic_modules/abi_impl.cc
@@ -987,6 +987,45 @@ void envoy_dynamic_module_callback_network_filter_config_scheduler_commit(
   scheduler->commit(event_id);
 }
 
+// -----------------------------------------------------------------------------
+// Network filter timer callbacks.
+// -----------------------------------------------------------------------------
+
+envoy_dynamic_module_type_network_filter_timer_module_ptr
+envoy_dynamic_module_callback_network_filter_timer_new(
+    envoy_dynamic_module_type_network_filter_envoy_ptr filter_envoy_ptr, uint64_t timer_id) {
+  auto* filter = static_cast<DynamicModuleNetworkFilter*>(filter_envoy_ptr);
+  Event::Dispatcher* dispatcher = filter->dispatcher();
+  if (dispatcher == nullptr) {
+    return nullptr;
+  }
+  return new DynamicModuleNetworkFilterTimer(filter->weak_from_this(), *dispatcher, timer_id);
+}
+
+void envoy_dynamic_module_callback_network_filter_timer_enable(
+    envoy_dynamic_module_type_network_filter_timer_module_ptr timer_module_ptr,
+    uint64_t duration_milliseconds) {
+  auto* timer = static_cast<DynamicModuleNetworkFilterTimer*>(timer_module_ptr);
+  timer->enable(std::chrono::milliseconds(duration_milliseconds));
+}
+
+void envoy_dynamic_module_callback_network_filter_timer_disable(
+    envoy_dynamic_module_type_network_filter_timer_module_ptr timer_module_ptr) {
+  auto* timer = static_cast<DynamicModuleNetworkFilterTimer*>(timer_module_ptr);
+  timer->disable();
+}
+
+bool envoy_dynamic_module_callback_network_filter_timer_enabled(
+    envoy_dynamic_module_type_network_filter_timer_module_ptr timer_module_ptr) {
+  auto* timer = static_cast<DynamicModuleNetworkFilterTimer*>(timer_module_ptr);
+  return timer->enabled();
+}
+
+void envoy_dynamic_module_callback_network_filter_timer_delete(
+    envoy_dynamic_module_type_network_filter_timer_module_ptr timer_module_ptr) {
+  delete static_cast<DynamicModuleNetworkFilterTimer*>(timer_module_ptr);
+}
+
 } // extern "C"
 
 } // namespace NetworkFilters

--- a/source/extensions/filters/network/dynamic_modules/filter.cc
+++ b/source/extensions/filters/network/dynamic_modules/filter.cc
@@ -122,6 +122,22 @@ void DynamicModuleNetworkFilter::onScheduled(uint64_t event_id) {
   }
 }
 
+void DynamicModuleNetworkFilter::onTimerExpired(uint64_t timer_id) {
+  if (in_module_filter_ != nullptr && config_->on_network_filter_timer_expired_ != nullptr) {
+    config_->on_network_filter_timer_expired_(thisAsVoidPtr(), in_module_filter_, timer_id);
+  }
+}
+
+DynamicModuleNetworkFilterTimer::DynamicModuleNetworkFilterTimer(
+    DynamicModuleNetworkFilterWeakPtr filter, Event::Dispatcher& dispatcher, uint64_t timer_id)
+    : filter_(std::move(filter)), timer_id_(timer_id) {
+  timer_ = dispatcher.createTimer([this]() {
+    if (DynamicModuleNetworkFilterSharedPtr filter_shared = filter_.lock()) {
+      filter_shared->onTimerExpired(timer_id_);
+    }
+  });
+}
+
 void DynamicModuleNetworkFilter::onAboveWriteBufferHighWatermark() {
   // Not currently exposed to dynamic modules.
 }

--- a/source/extensions/filters/network/dynamic_modules/filter_config.cc
+++ b/source/extensions/filters/network/dynamic_modules/filter_config.cc
@@ -81,6 +81,10 @@ absl::StatusOr<DynamicModuleNetworkFilterConfigSharedPtr> newDynamicModuleNetwor
   auto on_config_scheduled = dynamic_module->getFunctionPointer<OnNetworkFilterConfigScheduledType>(
       "envoy_dynamic_module_on_network_filter_config_scheduled");
 
+  // Optional: modules that don't need timers don't need to implement this.
+  auto on_timer_expired = dynamic_module->getFunctionPointer<OnNetworkFilterTimerExpiredType>(
+      "envoy_dynamic_module_on_network_filter_timer_expired");
+
   auto config = std::make_shared<DynamicModuleNetworkFilterConfig>(
       filter_name, filter_config, std::move(dynamic_module), cluster_manager, stats_scope,
       main_thread_dispatcher);
@@ -99,6 +103,8 @@ absl::StatusOr<DynamicModuleNetworkFilterConfigSharedPtr> newDynamicModuleNetwor
       on_filter_scheduled.ok() ? on_filter_scheduled.value() : nullptr;
   config->on_network_filter_config_scheduled_ =
       on_config_scheduled.ok() ? on_config_scheduled.value() : nullptr;
+  config->on_network_filter_timer_expired_ =
+      on_timer_expired.ok() ? on_timer_expired.value() : nullptr;
 
   // Create the in-module configuration.
   envoy_dynamic_module_type_envoy_buffer name_buffer = {const_cast<char*>(filter_name.data()),

--- a/source/extensions/filters/network/dynamic_modules/filter_config.h
+++ b/source/extensions/filters/network/dynamic_modules/filter_config.h
@@ -29,6 +29,8 @@ using OnNetworkFilterHttpCalloutDoneType =
 using OnNetworkFilterScheduledType = decltype(&envoy_dynamic_module_on_network_filter_scheduled);
 using OnNetworkFilterConfigScheduledType =
     decltype(&envoy_dynamic_module_on_network_filter_config_scheduled);
+using OnNetworkFilterTimerExpiredType =
+    decltype(&envoy_dynamic_module_on_network_filter_timer_expired);
 
 // Custom namespace prefix for network filter stats.
 constexpr char NetworkFilterStatsNamespace[] = "dynamic_module_network_filter";
@@ -88,6 +90,8 @@ public:
   // Optional: modules that don't need scheduling don't need to implement this.
   OnNetworkFilterScheduledType on_network_filter_scheduled_ = nullptr;
   OnNetworkFilterConfigScheduledType on_network_filter_config_scheduled_ = nullptr;
+  // Optional: modules that don't need timers don't need to implement this.
+  OnNetworkFilterTimerExpiredType on_network_filter_timer_expired_ = nullptr;
 
   Envoy::Upstream::ClusterManager& cluster_manager_;
 


### PR DESCRIPTION
## Description

This PR adds timer API to the Dynamic Modules network filter ABI.

---

**Commit Message:** dynamic_modules: add timer to network filters ABI
**Additional Description:** Added timer API to the Dynamic Modules network filter ABI.
**Risk Level:** Low
**Testing:** Added Tests
**Docs Changes:** Added
**Release Notes:** N/A