### PR TITLE
golang: add nil check in stream complete/destroy callbacks

### DIFF
--- a/contrib/golang/filters/http/source/go/pkg/http/shim.go
+++ b/contrib/golang/filters/http/source/go/pkg/http/shim.go
@@ -351,6 +351,10 @@ func envoyGoFilterOnHttpLog(r *C.httpRequest, logType uint64,
 //export envoyGoFilterOnHttpStreamComplete
 func envoyGoFilterOnHttpStreamComplete(r *C.httpRequest) {
 	req := getRequest(r)
+	if req == nil {
+		return
+	}
+
 	defer req.recoverPanic()
 
 	f := req.httpFilter
@@ -360,6 +364,10 @@ func envoyGoFilterOnHttpStreamComplete(r *C.httpRequest) {
 //export envoyGoFilterOnHttpDestroy
 func envoyGoFilterOnHttpDestroy(r *C.httpRequest, reason uint64) {
 	req := getRequest(r)
+	if req == nil {
+		return
+	}
+
 	// do nothing even when req.panic is true, since filter is already destroying.
 	defer req.recoverPanic()
 


### PR DESCRIPTION
**Commit Message:** 

golang: add nil guard in stream complete and destroy callbacks

Add nil check in envoyGoFilterOnHttpStreamComplete and
envoyGoFilterOnHttpDestroy to prevent panic when a Go filter
terminates the stream early (e.g., via SendLocalReply).

Without this, subsequent Go filters in the same chain may receive
callbacks on a cleared request context, causing nil pointer dereference.

**Additional Description:**

If a Go HTTP filter terminates the stream early (e.g., by calling SendLocalReply), Envoy may still call OnStreamComplete and OnDestroy on later Go filters in the chain.  

At that point, the request context has already been cleared, so getRequest() returns nil. Without a nil check, the callback panics when trying to use the request.  

This change adds a nil guard to both callbacks, so they safely return early if the request is gone.


Risk Level: Low

Testing: N/A
Docs Changes: N/A
Release Notes: Fixed a potential crash in Go HTTP filters when an early-terminating filter causes subsequent Go filters to be invoked on a cleared request context.
Platform Specific Features: N/A
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
