### PR TITLE
feat: add formatters for masked IP addresses

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -40,5 +40,10 @@ removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`
 
 new_features:
+- area: formatter
+  change: |
+    Extended ``*_WITHOUT_PORT`` address formatters to accept an optional ``MASK_PREFIX_LEN`` parameter that masks IP addresses
+    and returns them in CIDR notation (e.g., ``%DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT(16)%`` returns ``10.1.0.0/16`` for
+    client IP ``10.1.10.23``).
 
 deprecated:

--- a/docs/root/configuration/advanced/substitution_formatter.rst
+++ b/docs/root/configuration/advanced/substitution_formatter.rst
@@ -561,9 +561,20 @@ Current supported substitution commands include:
   Local address of the upstream connection. If the address is an IP address, it includes both
   address and port.
 
-``%UPSTREAM_LOCAL_ADDRESS_WITHOUT_PORT%``
+``%UPSTREAM_LOCAL_ADDRESS_WITHOUT_PORT(MASK_PREFIX_LEN)%``
   Local address of the upstream connection, without any port component.
   IP addresses are the only address type with a port component.
+
+  - If ``MASK_PREFIX_LEN`` is specified, the IP address is masked to that many bits and returned in CIDR notation.
+  - If ``MASK_PREFIX_LEN`` is omitted, the unmasked address is returned (without port).
+  - For IPv4, ``MASK_PREFIX_LEN`` must be between 0-32.
+  - For IPv6, ``MASK_PREFIX_LEN`` must be between 0-128.
+
+  Examples:
+
+  - ``%UPSTREAM_LOCAL_ADDRESS_WITHOUT_PORT(16)%`` returns ``10.1.0.0/16`` for source IP ``10.1.10.23``
+  - ``%UPSTREAM_LOCAL_ADDRESS_WITHOUT_PORT(64)%`` returns ``2001:db8:1234:5678::/64`` for source IP ``2001:db8:1234:5678:9abc:def0:1234:5678``
+  - ``%UPSTREAM_LOCAL_ADDRESS_WITHOUT_PORT%`` returns ``10.1.10.23`` for source IP ``10.1.10.23``
 
 ``%UPSTREAM_LOCAL_PORT%``
   Local port of the upstream connection.
@@ -576,9 +587,20 @@ Current supported substitution commands include:
   address and port. Identical to the :ref:`UPSTREAM_HOST <config_access_log_format_upstream_host>` value if the upstream
   host only has one address and connection is established successfully.
 
-``%UPSTREAM_REMOTE_ADDRESS_WITHOUT_PORT%``
+``%UPSTREAM_REMOTE_ADDRESS_WITHOUT_PORT(MASK_PREFIX_LEN)%``
   Remote address of the upstream connection, without any port component.
   IP addresses are the only address type with a port component.
+
+  - If ``MASK_PREFIX_LEN`` is specified, the IP address is masked to that many bits and returned in CIDR notation.
+  - If ``MASK_PREFIX_LEN`` is omitted, the unmasked address is returned (without port).
+  - For IPv4, ``MASK_PREFIX_LEN`` must be between 0-32.
+  - For IPv6, ``MASK_PREFIX_LEN`` must be between 0-128.
+
+  Examples:
+
+  - ``%UPSTREAM_REMOTE_ADDRESS_WITHOUT_PORT(16)%`` returns ``10.1.0.0/16`` for upstream IP ``10.1.10.23``
+  - ``%UPSTREAM_REMOTE_ADDRESS_WITHOUT_PORT(64)%`` returns ``2001:db8:1234:5678::/64`` for upstream IP ``2001:db8:1234:5678:9abc:def0:1234:5678``
+  - ``%UPSTREAM_REMOTE_ADDRESS_WITHOUT_PORT%`` returns ``10.1.10.23`` for upstream IP ``10.1.10.23``
 
 ``%UPSTREAM_REMOTE_PORT%``
   Remote port of the upstream connection.
@@ -624,9 +646,20 @@ Current supported substitution commands include:
     :ref:`Proxy Protocol filter <config_listener_filters_proxy_protocol>` or :ref:`x-forwarded-for
     <config_http_conn_man_headers_x-forwarded-for>`.
 
-``%DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT%``
+``%DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT(MASK_PREFIX_LEN)%``
   Remote address of the downstream connection, without any port component.
   IP addresses are the only address type with a port component.
+
+  - If ``MASK_PREFIX_LEN`` is specified, the IP address is masked to that many bits and returned in CIDR notation.
+  - If ``MASK_PREFIX_LEN`` is omitted, the unmasked address is returned (without port).
+  - For IPv4, ``MASK_PREFIX_LEN`` must be between 0-32.
+  - For IPv6, ``MASK_PREFIX_LEN`` must be between 0-128.
+
+  Examples:
+
+  - ``%DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT(16)%`` returns ``10.1.0.0/16`` for client IP ``10.1.10.23``
+  - ``%DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT(64)%`` returns ``2001:db8:1234:5678::/64`` for client IP ``2001:db8:1234:5678:9abc:def0:1234:5678``
+  - ``%DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT%`` returns ``10.1.10.23`` for client IP ``10.1.10.23``
 
   .. note::
 
@@ -654,9 +687,20 @@ Current supported substitution commands include:
     been inferred from :ref:`Proxy Protocol filter <config_listener_filters_proxy_protocol>`
     or :ref:`x-forwarded-for <config_http_conn_man_headers_x-forwarded-for>`.
 
-``%DOWNSTREAM_DIRECT_REMOTE_ADDRESS_WITHOUT_PORT%``
+``%DOWNSTREAM_DIRECT_REMOTE_ADDRESS_WITHOUT_PORT(MASK_PREFIX_LEN)%``
   Direct remote address of the downstream connection, without any port component.
   IP addresses are the only address type with a port component.
+
+  - If ``MASK_PREFIX_LEN`` is specified, the IP address is masked to that many bits and returned in CIDR notation.
+  - If ``MASK_PREFIX_LEN`` is omitted, the unmasked address is returned (without port).
+  - For IPv4, ``MASK_PREFIX_LEN`` must be between 0-32.
+  - For IPv6, ``MASK_PREFIX_LEN`` must be between 0-128.
+
+  Examples:
+
+  - ``%DOWNSTREAM_DIRECT_REMOTE_ADDRESS_WITHOUT_PORT(16)%`` returns ``10.1.0.0/16`` for client IP ``10.1.10.23``
+  - ``%DOWNSTREAM_DIRECT_REMOTE_ADDRESS_WITHOUT_PORT(64)%`` returns ``2001:db8:1234:5678::/64`` for client IP ``2001:db8:1234:5678:9abc:def0:1234:5678``
+  - ``%DOWNSTREAM_DIRECT_REMOTE_ADDRESS_WITHOUT_PORT%`` returns ``10.1.10.23`` for client IP ``10.1.10.23``
 
   .. note::
 
@@ -697,17 +741,39 @@ Current supported substitution commands include:
     This is always the physical local address even if the downstream remote address has been inferred from
     :ref:`Proxy Protocol filter <config_listener_filters_proxy_protocol>`.
 
-``%DOWNSTREAM_LOCAL_ADDRESS_WITHOUT_PORT%``
+``%DOWNSTREAM_LOCAL_ADDRESS_WITHOUT_PORT(MASK_PREFIX_LEN)%``
   Local address of the downstream connection, without any port component.
   IP addresses are the only address type with a port component.
+
+  - If ``MASK_PREFIX_LEN`` is specified, the IP address is masked to that many bits and returned in CIDR notation.
+  - If ``MASK_PREFIX_LEN`` is omitted, the unmasked address is returned (without port).
+  - For IPv4, ``MASK_PREFIX_LEN`` must be between 0-32.
+  - For IPv6, ``MASK_PREFIX_LEN`` must be between 0-128.
+
+  Examples:
+
+  - ``%DOWNSTREAM_LOCAL_ADDRESS_WITHOUT_PORT(16)%`` returns ``10.1.0.0/16`` for local IP ``10.1.10.23``
+  - ``%DOWNSTREAM_LOCAL_ADDRESS_WITHOUT_PORT(64)%`` returns ``2001:db8:1234:5678::/64`` for local IP ``2001:db8:1234:5678:9abc:def0:1234:5678``
+  - ``%DOWNSTREAM_LOCAL_ADDRESS_WITHOUT_PORT%`` returns ``10.1.10.23`` for local IP ``10.1.10.23``
 
   .. note::
 
     This may not be the physical local address if the downstream local address has been inferred from
     :ref:`Proxy Protocol filter <config_listener_filters_proxy_protocol>`.
 
-``%DOWNSTREAM_DIRECT_LOCAL_ADDRESS_WITHOUT_PORT%``
+``%DOWNSTREAM_DIRECT_LOCAL_ADDRESS_WITHOUT_PORT(MASK_PREFIX_LEN)%``
   Direct local address of the downstream connection, without any port component.
+
+  - If ``MASK_PREFIX_LEN`` is specified, the IP address is masked to that many bits and returned in CIDR notation.
+  - If ``MASK_PREFIX_LEN`` is omitted, the unmasked address is returned (without port).
+  - For IPv4, ``MASK_PREFIX_LEN`` must be between 0-32.
+  - For IPv6, ``MASK_PREFIX_LEN`` must be between 0-128.
+
+  Examples:
+
+  - ``%DOWNSTREAM_DIRECT_LOCAL_ADDRESS_WITHOUT_PORT(16)%`` returns ``10.1.0.0/16`` for local IP ``10.1.10.23``
+  - ``%DOWNSTREAM_DIRECT_LOCAL_ADDRESS_WITHOUT_PORT(64)%`` returns ``2001:db8:1234:5678::/64`` for local IP ``2001:db8:1234:5678:9abc:def0:1234:5678``
+  - ``%DOWNSTREAM_DIRECT_LOCAL_ADDRESS_WITHOUT_PORT%`` returns ``10.1.10.23`` for local IP ``10.1.10.23``
 
   .. note::
 

--- a/source/common/stream_info/BUILD
+++ b/source/common/stream_info/BUILD
@@ -43,6 +43,7 @@ envoy_cc_library(
         "//envoy/http:codes_interface",
         "//envoy/stream_info:stream_info_interface",
         "//source/common/http:default_server_string_lib",
+        "//source/common/network:cidr_range_lib",
         "//source/common/runtime:runtime_features_lib",
         "@com_google_absl//absl/container:node_hash_map",
         "@com_google_absl//absl/types:optional",

--- a/source/common/stream_info/utility.h
+++ b/source/common/stream_info/utility.h
@@ -240,10 +240,14 @@ class Utility {
 public:
   /**
    * @param address supplies the downstream address.
-   * @return a properly formatted address for logs, header expansion, etc.
+   * @param mask_prefix_len optional CIDR prefix length to mask the address. If not provided,
+   * returns the unmasked IP address (without port).
+   * @return the IP address without port, or masked IP address in CIDR notation if mask_prefix_len
+   * is specified (e.g., "10.1.0.0/16"), or empty string if masking fails.
    */
-  static const std::string&
-  formatDownstreamAddressNoPort(const Network::Address::Instance& address);
+  static const std::string
+  formatDownstreamAddressNoPort(const Network::Address::Instance& address,
+                                absl::optional<int> mask_prefix_len = absl::nullopt);
 
   /**
    * @param address supplies the downstream address.


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message: Add formatters for masked IP addresses
Additional Description: Added masked alternatives for supported substitution formatters that return IP addresses today
Risk Level: Low
Testing: Unit testing
Docs Changes: Added the new substitution formatters to docs
Release Notes: Yes
Platform Specific Features: N/A
Related: https://github.com/envoyproxy/envoy/pull/42845#discussion_r2684950080
