### PR TITLE
mobile: introduce ClientEngineBuilder class

### DIFF
--- a/mobile/library/cc/BUILD
+++ b/mobile/library/cc/BUILD
@@ -59,6 +59,55 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
+    name = "client_engine_builder_lib",
+    srcs = [
+        "client_engine_builder.cc",
+    ],
+    hdrs = [
+        "client_engine_builder.h",
+    ],
+    repository = "@envoy",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":engine_builder_lib",
+        ":envoy_engine_cc_lib_no_stamp",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/debugging:leak_check",
+        "@com_google_absl//absl/functional:any_invocable",
+        "@com_google_absl//absl/types:optional",
+        "@envoy_api//envoy/config/bootstrap/v3:pkg_cc_proto",
+        "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
+        "@envoy_api//envoy/config/metrics/v3:pkg_cc_proto",
+        "@envoy_api//envoy/config/route/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/compression/brotli/decompressor/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/compression/gzip/decompressor/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/filters/http/alternate_protocols_cache/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/filters/http/decompressor/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/filters/http/dynamic_forward_proxy/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/filters/http/router/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/filters/network/http_connection_manager/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/http/header_formatters/preserve_case/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/network/dns_resolver/apple/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/network/dns_resolver/getaddrinfo/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/transport_sockets/http_11_proxy/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/transport_sockets/quic/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/transport_sockets/raw_buffer/v3:pkg_cc_proto",
+        "//library/common:engine_types_lib",
+        "//library/common/config:certificates_lib",
+        "//library/common/extensions/cert_validator/platform_bridge:platform_bridge_cc_proto",
+        "//library/common/extensions/filters/http/local_error:filter_cc_proto",
+        "//library/common/extensions/filters/http/network_configuration:filter_cc_proto",
+        "//library/common/extensions/filters/http/socket_tag:filter_cc_proto",
+        "//library/common/extensions/key_value/platform:platform_cc_proto",
+        "//library/common/types:matcher_data_lib",
+        "@envoy//source/common/common:assert_lib",
+        "@envoy//source/common/protobuf",
+        "@envoy//source/server:options_lib",
+        "@com_github_gabime_spdlog//:spdlog",
+    ],
+)
+
+envoy_cc_library(
     name = "envoy_engine_cc_lib_no_stamp",
     srcs = [
         "engine.cc",
@@ -97,6 +146,7 @@ envoy_cc_library(
     repository = "@envoy",
     visibility = ["//visibility:public"],
     deps = [
+        ":client_engine_builder_lib",
         ":engine_builder_lib",
         ":envoy_engine_cc_lib_no_stamp",
         "//library/common:engine_common_lib_stamped",

--- a/mobile/library/cc/client_engine_builder.cc
+++ b/mobile/library/cc/client_engine_builder.cc
@@ -1,0 +1,339 @@
+#include "client_engine_builder.h"
+
+#include <stdint.h>
+#include <sys/socket.h>
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "absl/functional/any_invocable.h"
+#include "envoy/config/bootstrap/v3/bootstrap.pb.h"
+#include "source/common/protobuf/protobuf.h"
+#include "library/cc/engine.h"
+#include "library/cc/key_value_store.h"
+#include "library/cc/string_accessor.h"
+#include "library/common/engine_types.h"
+#include "envoy/config/route/v3/route.pb.h"
+#include "envoy/extensions/filters/http/router/v3/router.pb.h"
+#include "library/cc/engine_builder.h"
+#include "library/cc/stream_client.h"
+#include "source/common/common/base_logger.h"
+#include "envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.pb.h"
+#include "envoy/config/metrics/v3/metrics_service.pb.h"
+#include "envoy/extensions/compression/brotli/decompressor/v3/brotli.pb.h"
+#include "envoy/extensions/compression/gzip/decompressor/v3/gzip.pb.h"
+#include "envoy/extensions/filters/http/decompressor/v3/decompressor.pb.h"
+#include "envoy/extensions/filters/http/dynamic_forward_proxy/v3/dynamic_forward_proxy.pb.h"
+#include "envoy/extensions/network/dns_resolver/getaddrinfo/v3/getaddrinfo_dns_resolver.pb.h"
+#include "envoy/extensions/transport_sockets/quic/v3/quic_transport.pb.h"
+#include "envoy/config/core/v3/base.pb.h"
+#include "absl/debugging/leak_check.h"
+#include "library/common/api/c_types.h"
+#include "library/common/api/external.h"
+#include "library/common/internal_engine.h"
+#include "source/common/common/assert.h"
+#include "source/server/options_impl_base.h"
+#include "spdlog/spdlog.h"
+
+#if defined(ENVOY_ENABLE_FULL_PROTOS)
+
+namespace Envoy {
+namespace Platform {
+
+ClientEngineBuilder::ClientEngineBuilder() : callbacks_(std::make_unique<EngineCallbacks>()) {}
+
+ClientEngineBuilder& ClientEngineBuilder::setNetworkThreadPriority(int thread_priority) {
+  network_thread_priority_ = thread_priority;
+  return *this;
+}
+
+ClientEngineBuilder& ClientEngineBuilder::setBufferHighWatermark(size_t high_watermark) {
+  high_watermark_ = high_watermark;
+  return *this;
+}
+
+ClientEngineBuilder& ClientEngineBuilder::setLogLevel(Logger::Logger::Levels log_level) {
+  log_level_ = log_level;
+  return *this;
+}
+
+ClientEngineBuilder& ClientEngineBuilder::setLogger(std::unique_ptr<EnvoyLogger> logger) {
+  logger_ = std::move(logger);
+  return *this;
+}
+
+ClientEngineBuilder& ClientEngineBuilder::enableLogger(bool logger_on) {
+  enable_logger_ = logger_on;
+  return *this;
+}
+
+ClientEngineBuilder& ClientEngineBuilder::setEngineCallbacks(std::unique_ptr<EngineCallbacks> callbacks) {
+  callbacks_ = std::move(callbacks);
+  return *this;
+}
+
+ClientEngineBuilder& ClientEngineBuilder::setOnEngineRunning(absl::AnyInvocable<void()> closure) {
+  callbacks_->on_engine_running_ = std::move(closure);
+  return *this;
+}
+
+ClientEngineBuilder& ClientEngineBuilder::setOnEngineExit(absl::AnyInvocable<void()> closure) {
+  callbacks_->on_exit_ = std::move(closure);
+  return *this;
+}
+
+ClientEngineBuilder& ClientEngineBuilder::setEventTracker(std::unique_ptr<EnvoyEventTracker> event_tracker) {
+  event_tracker_ = std::move(event_tracker);
+  return *this;
+}
+
+ClientEngineBuilder& ClientEngineBuilder::addKeyValueStore(std::string name,
+                                               KeyValueStoreSharedPtr key_value_store) {
+  key_value_stores_[std::move(name)] = std::move(key_value_store);
+  return *this;
+}
+
+ClientEngineBuilder& ClientEngineBuilder::setHcmStreamIdleTimeoutSeconds(int stream_idle_timeout_seconds) {
+  stream_idle_timeout_seconds_ = stream_idle_timeout_seconds;
+  return *this;
+}
+
+
+ClientEngineBuilder& ClientEngineBuilder::addStringAccessor(std::string name,
+                                                StringAccessorSharedPtr accessor) {
+  string_accessors_[std::move(name)] = std::move(accessor);
+  return *this;
+}
+
+ClientEngineBuilder& ClientEngineBuilder::addCluster(envoy::config::cluster::v3::Cluster&& cluster) {
+  clusters_.push_back(std::move(cluster));
+  return *this;
+}
+
+ClientEngineBuilder& ClientEngineBuilder::addHcmHttpFilter(envoy::extensions::filters::network::http_connection_manager::v3::HttpFilter&& filter) {
+  hcm_http_filters_.push_back(std::move(filter));
+  return *this;
+}
+
+ClientEngineBuilder& ClientEngineBuilder::setHcmRouteConfiguration(envoy::config::route::v3::RouteConfiguration&& route_configuration) {
+  route_configuration_ =
+      std::make_unique<envoy::config::route::v3::RouteConfiguration>(
+          std::move(route_configuration));
+  return *this;
+}
+
+ClientEngineBuilder& ClientEngineBuilder::setWatchdog(envoy::config::bootstrap::v3::Watchdogs&& watchdog) {
+  watchdog_ = std::move(watchdog);
+  return *this;
+}
+ClientEngineBuilder& ClientEngineBuilder::setRouterConfig(envoy::extensions::filters::http::router::v3::Router&& router_config) {
+  router_config_ = std::move(router_config);
+  return *this;
+}
+ClientEngineBuilder& ClientEngineBuilder::setPerConnectionBufferLimit(uint32_t limit) {
+  per_connection_buffer_limit_bytes_ = limit;
+  return *this;
+}
+ClientEngineBuilder& ClientEngineBuilder::addStatsPrefix(std::string&& prefix) {
+  stats_prefixes_.push_back(std::move(prefix));
+  return *this;
+}
+
+ClientEngineBuilder& ClientEngineBuilder::addRuntimeGuard(std::string guard, bool value) {
+  runtime_guards_.emplace_back(std::move(guard), value);
+  return *this;
+}
+
+ClientEngineBuilder& ClientEngineBuilder::addRestartRuntimeGuard(std::string guard, bool value) {
+  restart_runtime_guards_.emplace_back(std::move(guard), value);
+  return *this;
+}
+
+ClientEngineBuilder& ClientEngineBuilder::enableStatsCollection(bool stats_collection_on) {
+  enable_stats_collection_ = stats_collection_on;
+  return *this;
+}
+
+ClientEngineBuilder& ClientEngineBuilder::setNodeId(std::string node_id) {
+  node_id_ = std::move(node_id);
+  return *this;
+}
+
+ClientEngineBuilder& ClientEngineBuilder::setNodeLocality(std::string region, std::string zone,
+                                              std::string sub_zone) {
+  node_locality_ = {std::move(region), std::move(zone), std::move(sub_zone)};
+  return *this;
+}
+
+ClientEngineBuilder& ClientEngineBuilder::setNodeMetadata(Protobuf::Struct node_metadata) {
+  node_metadata_ = std::move(node_metadata);
+  return *this;
+}
+
+std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> ClientEngineBuilder::generateBootstrap() {
+  std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> bootstrap =
+      std::make_unique<envoy::config::bootstrap::v3::Bootstrap>();
+
+  // Set up the HCM, make sure a route config is provided.
+  envoy::extensions::filters::network::http_connection_manager::v3::EnvoyMobileHttpConnectionManager
+      api_listener_config;
+  auto* hcm = api_listener_config.mutable_config();
+  hcm->set_stat_prefix("hcm");
+  hcm->set_server_header_transformation(
+      envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager::
+          PASS_THROUGH);
+  hcm->mutable_stream_idle_timeout()->set_seconds(stream_idle_timeout_seconds_);
+  if (route_configuration_ == nullptr) {
+    RELEASE_ASSERT(false, "ClientEngineBuilder::GenerateBootstrap called with no route configuration provided.");
+  }
+  *(hcm->mutable_route_config()) = *std::move(route_configuration_).get();
+  route_configuration_.reset();
+
+  // Add any provided HTTP filters to the HCM.
+  for (auto filter : hcm_http_filters_) {
+    *hcm->add_http_filters() = std::move(filter);
+  }
+  hcm_http_filters_.clear();
+
+  // Add the router filter to the HCM last.
+  auto* router_filter = hcm->add_http_filters();
+  router_filter->set_name("envoy.router");
+  if (router_config_.has_value()) {
+    router_filter->mutable_typed_config()->PackFrom(*router_config_);
+  } else {
+    envoy::extensions::filters::http::router::v3::Router router_config;
+    router_filter->mutable_typed_config()->PackFrom(router_config);
+  }
+
+  auto* static_resources = bootstrap->mutable_static_resources();
+
+  // Finally create the base API listener, and point it at the HCM.
+  auto* base_listener = static_resources->add_listeners();
+  base_listener->set_name("base_api_listener");
+  auto* base_address = base_listener->mutable_address();
+  base_address->mutable_socket_address()->set_protocol(envoy::config::core::v3::SocketAddress::TCP);
+  base_address->mutable_socket_address()->set_address("0.0.0.0");
+  base_address->mutable_socket_address()->set_port_value(10000);
+  base_listener->mutable_per_connection_buffer_limit_bytes()->set_value(per_connection_buffer_limit_bytes_);
+  base_listener->mutable_api_listener()->mutable_api_listener()->PackFrom(api_listener_config);
+
+  // Add all clusters to the bootstrap, there should be at least one.
+  if (clusters_.empty()) {
+    RELEASE_ASSERT(false, "ClientEngineBuilder::GenerateBootstrap called with no clusters provided.");
+  }
+  for (auto cluster : clusters_) {
+    *static_resources->add_clusters() = std::move(cluster);
+  }
+  clusters_.clear();
+
+  // Set up stats if provided.
+  if (!stats_prefixes_.empty()) {
+    auto* list =
+        bootstrap->mutable_stats_config()->mutable_stats_matcher()->mutable_inclusion_list();
+    for (const auto& prefix : stats_prefixes_) {
+      list->add_patterns()->set_prefix(prefix);
+    }
+  } else {
+    bootstrap->mutable_stats_config()->mutable_stats_matcher()->set_reject_all(true);
+  }
+  bootstrap->mutable_stats_config()->mutable_use_all_default_tags()->set_value(false);
+
+  // Set up watchdog if provided.
+  if (watchdog_.has_value()) {
+    *bootstrap->mutable_watchdogs() = std::move(watchdog_).value();
+  }
+
+  // Set up node.
+  auto* node = bootstrap->mutable_node();
+  node->set_id(node_id_.empty() ? "envoy-client" : node_id_);
+  node->set_cluster("envoy-client");
+  if (node_locality_ && !node_locality_->region.empty()) {
+    node->mutable_locality()->set_region(node_locality_->region);
+    node->mutable_locality()->set_zone(node_locality_->zone);
+    node->mutable_locality()->set_sub_zone(node_locality_->sub_zone);
+  }
+  if (node_metadata_.has_value()) {
+    *node->mutable_metadata() = *node_metadata_;
+  }
+
+  // Set up runtime.
+  auto* runtime = bootstrap->mutable_layered_runtime()->add_layers();
+  runtime->set_name("static_layer_0");
+  Protobuf::Struct envoy_layer;
+  Protobuf::Struct& runtime_values =
+      *(*envoy_layer.mutable_fields())["envoy"].mutable_struct_value();
+  Protobuf::Struct& reloadable_features =
+      *(*runtime_values.mutable_fields())["reloadable_features"].mutable_struct_value();
+  for (auto& guard_and_value : runtime_guards_) {
+    (*reloadable_features.mutable_fields())[guard_and_value.first].set_bool_value(
+        guard_and_value.second);
+  }
+  Protobuf::Struct& restart_features =
+      *(*runtime_values.mutable_fields())["restart_features"].mutable_struct_value();
+  (*runtime_values.mutable_fields())["disallow_global_stats"].set_bool_value(true);
+  for (auto& guard_and_value : restart_runtime_guards_) {
+    (*restart_features.mutable_fields())[guard_and_value.first].set_bool_value(
+        guard_and_value.second);
+  }
+  Protobuf::Struct& overload_values =
+      *(*envoy_layer.mutable_fields())["overload"].mutable_struct_value();
+  (*overload_values.mutable_fields())["global_downstream_max_connections"].set_string_value(
+      "4294967295");
+  runtime->mutable_static_layer()->MergeFrom(envoy_layer);
+
+  bootstrap->mutable_dynamic_resources();
+
+  envoy::config::listener::v3::ApiListenerManager api;
+  auto* listener_manager = bootstrap->mutable_listener_manager();
+  listener_manager->mutable_typed_config()->PackFrom(api);
+  listener_manager->set_name("envoy.listener_manager_impl.api");
+
+  return bootstrap;
+}
+
+EngineSharedPtr ClientEngineBuilder::build() {
+  InternalEngine* envoy_engine = absl::IgnoreLeak(
+      new InternalEngine(std::move(callbacks_), std::move(logger_), std::move(event_tracker_),
+                         network_thread_priority_, high_watermark_,
+                         false, enable_logger_));
+
+  for (const auto& [name, store] : key_value_stores_) {
+    // TODO(goaway): This leaks, but it's tied to the life of the engine.
+    if (!Api::External::retrieveApi(name, true)) {
+      auto* api = new envoy_kv_store();
+      *api = store->asEnvoyKeyValueStore();
+      Envoy::Api::External::registerApi(name.c_str(), api);
+    }
+  }
+
+  for (const auto& [name, accessor] : string_accessors_) {
+    // TODO(RyanTheOptimist): This leaks, but it's tied to the life of the engine.
+    if (!Api::External::retrieveApi(name, true)) {
+      auto* api = new envoy_string_accessor();
+      *api = StringAccessor::asEnvoyStringAccessor(accessor);
+      Envoy::Api::External::registerApi(name.c_str(), api);
+    }
+  }
+
+  Engine* engine = new Engine(envoy_engine);
+
+  auto options = std::make_shared<Envoy::OptionsImplBase>();
+  std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> bootstrap = generateBootstrap();
+  if (bootstrap) {
+    options->setConfigProto(std::move(bootstrap));
+  }
+  options->setLogLevel(static_cast<spdlog::level::level_enum>(log_level_));
+  options->setConcurrency(1);
+  envoy_engine->run(options);
+
+  // we can't construct via std::make_shared
+  // because Engine is only constructible as a friend
+  auto engine_ptr = EngineSharedPtr(engine);
+  return engine_ptr;
+}
+
+} // namespace Platform
+} // namespace Envoy
+
+#endif // ENVOY_ENABLE_FULL_PROTOS

--- a/mobile/library/cc/client_engine_builder.h
+++ b/mobile/library/cc/client_engine_builder.h
@@ -1,0 +1,131 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "absl/functional/any_invocable.h"
+
+#include "envoy/config/bootstrap/v3/bootstrap.pb.h"
+#include "source/common/protobuf/protobuf.h"
+
+#include "absl/container/flat_hash_map.h"
+#include "absl/types/optional.h"
+#include "library/cc/engine.h"
+#include "library/cc/key_value_store.h"
+#include "library/cc/string_accessor.h"
+#include "library/common/engine_types.h"
+
+#include "envoy/config/route/v3/route.pb.h"
+#include "envoy/extensions/filters/http/router/v3/router.pb.h"
+#include "library/cc/engine_builder.h"
+#include "library/cc/stream_client.h"
+#include "source/common/common/base_logger.h"
+#include "envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.pb.h"
+
+
+#if defined(ENVOY_ENABLE_FULL_PROTOS)
+
+namespace Envoy {
+namespace Platform {
+
+// The C++ client engine builder creates a semi-structured bootstrap proto and modifies it through parameters
+// set through the ClientEngineBuilder API calls to produce the Bootstrap config that the Engine is
+// created from. This differs from the EngineBuilder which is intended to be used for mobile environments and uses a more rigid bootstrap.
+class ClientEngineBuilder {
+public:
+  ClientEngineBuilder();
+  ClientEngineBuilder(ClientEngineBuilder&&) = default;
+  virtual ~ClientEngineBuilder() = default;
+
+  ClientEngineBuilder& addCluster(envoy::config::cluster::v3::Cluster&& cluster);
+  ClientEngineBuilder& addHcmHttpFilter(envoy::extensions::filters::network::http_connection_manager::v3::HttpFilter&& filter);
+  ClientEngineBuilder& setHcmRouteConfiguration(envoy::config::route::v3::RouteConfiguration&& route_configuration);
+  ClientEngineBuilder& setPerConnectionBufferLimit(uint32_t limit);
+  ClientEngineBuilder& addStatsPrefix(std::string&& prefix);
+  ClientEngineBuilder& setWatchdog(envoy::config::bootstrap::v3::Watchdogs&& watchdog);
+  ClientEngineBuilder& setRouterConfig(envoy::extensions::filters::http::router::v3::Router&& router_config);
+
+  ClientEngineBuilder& setLogLevel(Logger::Logger::Levels log_level);
+  ClientEngineBuilder& setLogger(std::unique_ptr<EnvoyLogger> logger);
+  ClientEngineBuilder& enableLogger(bool logger_on);
+  ClientEngineBuilder& setEngineCallbacks(std::unique_ptr<EngineCallbacks> callbacks);
+  ClientEngineBuilder& setOnEngineRunning(absl::AnyInvocable<void()> closure);
+  ClientEngineBuilder& setOnEngineExit(absl::AnyInvocable<void()> closure);
+  ClientEngineBuilder& setEventTracker(std::unique_ptr<EnvoyEventTracker> event_tracker);
+  ClientEngineBuilder& setHcmStreamIdleTimeoutSeconds(int stream_idle_timeout_seconds);
+
+  ClientEngineBuilder& addRuntimeGuard(std::string guard, bool value);
+  // Adds a runtime guard for the `envoy.restart_features.<guard>`. Restart features cannot be
+  // changed after the Envoy applicable has started and initialized.
+  // For example if the runtime guard is `envoy.restart_features.use_foo`, the guard name is
+  // `use_foo`.
+  ClientEngineBuilder& addRestartRuntimeGuard(std::string guard, bool value);
+
+  // These functions don't affect the Bootstrap configuration but instead perform registrations.
+  ClientEngineBuilder& addKeyValueStore(std::string name, KeyValueStoreSharedPtr key_value_store);
+  ClientEngineBuilder& addStringAccessor(std::string name, StringAccessorSharedPtr accessor);
+
+  // Sets the thread priority of the Envoy main (network) thread.
+  // The value must be an integer between -20 (highest priority) and 19 (lowest priority). Values
+  // outside of this range will be ignored.
+  ClientEngineBuilder& setNetworkThreadPriority(int thread_priority);
+  // Sets the high watermark for the response buffer. The low watermark is set to half of this
+  // value. Defaults to 2MB if not set.
+  ClientEngineBuilder& setBufferHighWatermark(size_t high_watermark);
+
+  // Sets the node.id field in the Bootstrap configuration.
+  ClientEngineBuilder& setNodeId(std::string node_id);
+  // Sets the node.locality field in the Bootstrap configuration.
+  ClientEngineBuilder& setNodeLocality(std::string region, std::string zone, std::string sub_zone);
+  // Sets the node.metadata field in the Bootstrap configuration.
+  ClientEngineBuilder& setNodeMetadata(Protobuf::Struct node_metadata);
+  // Sets whether to collect Envoy's internal stats (counters & guages). Off by default.
+  ClientEngineBuilder& enableStatsCollection(bool stats_collection_on);
+
+  // This is separated from build() for the sake of testability
+  virtual std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> generateBootstrap();
+
+  EngineSharedPtr build();
+
+private:
+  Logger::Logger::Levels log_level_ = Logger::Logger::Levels::info;
+  std::unique_ptr<EnvoyLogger> logger_ = nullptr;
+  bool enable_logger_ = false;
+  std::unique_ptr<EngineCallbacks> callbacks_ = nullptr;
+  std::unique_ptr<EnvoyEventTracker> event_tracker_ = nullptr;
+
+  int stream_idle_timeout_seconds_ = 15;
+  absl::optional<int> network_thread_priority_ = absl::nullopt;
+  absl::optional<size_t> high_watermark_ = absl::nullopt;
+
+  absl::flat_hash_map<std::string, KeyValueStoreSharedPtr> key_value_stores_ = {};
+
+  std::vector<envoy::extensions::filters::network::http_connection_manager::v3::HttpFilter > hcm_http_filters_ = {};
+  std::vector<envoy::config::cluster::v3::Cluster> clusters_ = {};
+  std::unique_ptr<envoy::config::route::v3::RouteConfiguration> route_configuration_ = nullptr;
+  uint32_t per_connection_buffer_limit_bytes_ = 10 * 1024 * 1024;
+  std::vector<std::string> stats_prefixes_ = {};
+  std::optional<envoy::config::bootstrap::v3::Watchdogs> watchdog_ = std::nullopt;
+  std::optional<envoy::extensions::filters::http::router::v3::Router> router_config_ = std::nullopt;
+
+  std::vector<std::pair<std::string, bool>> runtime_guards_ = {};
+  std::vector<std::pair<std::string, bool>> restart_runtime_guards_ = {};
+  absl::flat_hash_map<std::string, StringAccessorSharedPtr> string_accessors_ = {};
+
+  std::string node_id_ = "";
+  absl::optional<NodeLocality> node_locality_ = absl::nullopt;
+  absl::optional<Protobuf::Struct> node_metadata_ = absl::nullopt;
+  bool enable_stats_collection_ = false;
+};
+
+using ClientEngineBuilderSharedPtr = std::shared_ptr<ClientEngineBuilder>;
+
+} // namespace Platform
+} // namespace Envoy
+
+#endif // ENVOY_ENABLE_FULL_PROTOS

--- a/mobile/library/cc/engine.h
+++ b/mobile/library/cc/engine.h
@@ -36,6 +36,7 @@ private:
 
   // required to access private constructor
   friend class EngineBuilder;
+  friend class ClientEngineBuilder;
   // required to use envoy_engine_t without exposing it publicly
   friend class StreamPrototype;
   // for testing only

--- a/mobile/test/cc/integration/BUILD
+++ b/mobile/test/cc/integration/BUILD
@@ -20,6 +20,23 @@ envoy_cc_test(
 )
 
 envoy_cc_test(
+    name = "client_send_headers_test",
+    srcs = ["client_send_headers_test.cc"],
+    repository = "@envoy",
+    tags = ["requires-net:ipv4"],
+    deps = [
+        "//library/cc:client_engine_builder_lib",
+        "//library/common:engine_types_lib",
+        "//library/common/http:header_utility_lib",
+        "//test/common/http/filters/assertion:filter_cc_proto",
+        "//test/common/integration:client_engine_with_test_server",
+        "//test/common/integration:test_server_lib",
+        "@com_google_absl//absl/synchronization",
+        "@envoy_build_config//:test_extensions",
+    ],
+)
+
+envoy_cc_test(
     name = "send_trailers_test",
     srcs = ["send_trailers_test.cc"],
     repository = "@envoy",
@@ -30,6 +47,22 @@ envoy_cc_test(
         "//test/common/http/filters/assertion:filter_cc_proto",
         "//test/common/integration:engine_with_test_server",
         "//test/common/integration:test_server_lib",
+        "@envoy_build_config//:test_extensions",
+    ],
+)
+
+envoy_cc_test(
+    name = "client_send_trailers_test",
+    srcs = ["client_send_trailers_test.cc"],
+    repository = "@envoy",
+    deps = [
+        "//library/cc:client_engine_builder_lib",
+        "//library/common:engine_types_lib",
+        "//library/common/http:header_utility_lib",
+        "//test/common/http/filters/assertion:filter_cc_proto",
+        "//test/common/integration:client_engine_with_test_server",
+        "//test/common/integration:test_server_lib",
+        "@com_google_absl//absl/synchronization",
         "@envoy_build_config//:test_extensions",
     ],
 )
@@ -50,6 +83,22 @@ envoy_cc_test(
 )
 
 envoy_cc_test(
+    name = "client_send_data_test",
+    srcs = ["client_send_data_test.cc"],
+    repository = "@envoy",
+    deps = [
+        "//library/cc:client_engine_builder_lib",
+        "//library/common:engine_types_lib",
+        "//library/common/http:header_utility_lib",
+        "//test/common/http/filters/assertion:filter_cc_proto",
+        "//test/common/integration:client_engine_with_test_server",
+        "//test/common/integration:test_server_lib",
+        "@com_google_absl//absl/synchronization",
+        "@envoy_build_config//:test_extensions",
+    ],
+)
+
+envoy_cc_test(
     name = "receive_headers_test",
     srcs = ["receive_headers_test.cc"],
     repository = "@envoy",
@@ -59,6 +108,21 @@ envoy_cc_test(
         "//library/common/http:header_utility_lib",
         "//test/common/integration:engine_with_test_server",
         "//test/common/integration:test_server_lib",
+        "@envoy_build_config//:test_extensions",
+    ],
+)
+
+envoy_cc_test(
+    name = "client_receive_headers_test",
+    srcs = ["client_receive_headers_test.cc"],
+    repository = "@envoy",
+    deps = [
+       "//library/cc:client_engine_builder_lib",
+        "//library/common:engine_types_lib",
+        "//library/common/http:header_utility_lib",
+        "//test/common/integration:client_engine_with_test_server",
+        "//test/common/integration:test_server_lib",
+        "@com_google_absl//absl/synchronization",
         "@envoy_build_config//:test_extensions",
     ],
 )
@@ -78,6 +142,21 @@ envoy_cc_test(
 )
 
 envoy_cc_test(
+    name = "client_receive_data_test",
+    srcs = ["client_receive_data_test.cc"],
+    repository = "@envoy",
+    deps = [
+        "//library/cc:client_engine_builder_lib",
+        "//library/common:engine_types_lib",
+        "//library/common/http:header_utility_lib",
+        "//test/common/integration:client_engine_with_test_server",
+        "//test/common/integration:test_server_lib",
+        "@com_google_absl//absl/synchronization",
+        "@envoy_build_config//:test_extensions",
+    ],
+)
+
+envoy_cc_test(
     name = "receive_trailers_test",
     srcs = ["receive_trailers_test.cc"],
     repository = "@envoy",
@@ -92,6 +171,21 @@ envoy_cc_test(
 )
 
 envoy_cc_test(
+    name = "client_receive_trailers_test",
+    srcs = ["client_receive_trailers_test.cc"],
+    repository = "@envoy",
+    deps = [
+        "//library/cc:client_engine_builder_lib",
+        "//library/common:engine_types_lib",
+        "//library/common/http:header_utility_lib",
+        "//test/common/integration:client_engine_with_test_server",
+        "//test/common/integration:test_server_lib",
+        "@com_google_absl//absl/synchronization",
+        "@envoy_build_config//:test_extensions",
+    ],
+)
+
+envoy_cc_test(
     name = "lifetimes_test",
     srcs = ["lifetimes_test.cc"],
     repository = "@envoy",
@@ -101,6 +195,22 @@ envoy_cc_test(
         "//library/common/http:header_utility_lib",
         "//test/common/integration:engine_with_test_server",
         "//test/common/integration:test_server_lib",
+        "@envoy_build_config//:test_extensions",
+    ],
+)
+
+envoy_cc_test(
+    name = "client_lifetimes_test",
+    srcs = ["client_lifetimes_test.cc"],
+    repository = "@envoy",
+    tags = ["requires-net:ipv4"],
+    deps = [
+        "//library/cc:client_engine_builder_lib",
+        "//library/common:engine_types_lib",
+        "//library/common/http:header_utility_lib",
+        "//test/common/integration:client_engine_with_test_server",
+        "//test/common/integration:test_server_lib",
+        "@com_google_absl//absl/synchronization",
         "@envoy_build_config//:test_extensions",
     ],
 )

--- a/mobile/test/cc/integration/client_lifetimes_test.cc
+++ b/mobile/test/cc/integration/client_lifetimes_test.cc
@@ -1,0 +1,80 @@
+#include "test/common/http/filters/assertion/filter.pb.h"
+#include "test/common/integration/client_engine_with_test_server.h"
+#include "test/common/integration/test_server.h"
+
+#include "absl/synchronization/notification.h"
+#include "gtest/gtest.h"
+#include "library/cc/client_engine_builder.h"
+#include "library/common/engine_types.h"
+#include "library/common/http/header_utility.h"
+
+#if defined(ENVOY_ENABLE_FULL_PROTOS)
+
+namespace Envoy {
+namespace {
+
+class ClientLifetimesTest : public testing::TestWithParam<TestServerType> {};
+
+INSTANTIATE_TEST_SUITE_P(ClientLifetimesTest, ClientLifetimesTest,
+                         testing::Values(TestServerType::HTTP1_WITHOUT_TLS,
+                                         TestServerType::HTTP1_WITH_TLS,
+                                         TestServerType::HTTP2_WITH_TLS, TestServerType::HTTP3));
+
+void sendRequest(TestServerType server_type) {
+  absl::Notification engine_running;
+  Platform::ClientEngineBuilder engine_builder;
+  engine_builder.enableLogger(false)
+      .setLogLevel(Logger::Logger::debug)
+      .setOnEngineRunning([&]() { engine_running.Notify(); });
+  ClientEngineWithTestServer client_engine_with_test_server(engine_builder, server_type);
+  engine_running.WaitForNotification();
+
+  std::string actual_status_code;
+  bool actual_end_stream;
+  absl::Notification stream_complete;
+  EnvoyStreamCallbacks stream_callbacks;
+  stream_callbacks.on_headers_ = [&](const Http::ResponseHeaderMap& headers, bool end_stream,
+                                     envoy_stream_intel) {
+    actual_status_code = headers.getStatusValue();
+    actual_end_stream = end_stream;
+  };
+  stream_callbacks.on_data_ = [&](const Buffer::Instance&, uint64_t /* length */, bool end_stream,
+                                  envoy_stream_intel) { actual_end_stream = end_stream; };
+  stream_callbacks.on_complete_ = [&](envoy_stream_intel, envoy_final_stream_intel) {
+    stream_complete.Notify();
+  };
+  stream_callbacks.on_error_ = [&](const EnvoyError&, envoy_stream_intel,
+                                   envoy_final_stream_intel) { stream_complete.Notify(); };
+  stream_callbacks.on_cancel_ = [&](envoy_stream_intel, envoy_final_stream_intel) {
+    stream_complete.Notify();
+  };
+  auto stream_prototype =
+      client_engine_with_test_server.engine()->streamClient()->newStreamPrototype();
+  Platform::StreamSharedPtr stream = stream_prototype->start(std::move(stream_callbacks));
+
+  auto headers = Http::Utility::createRequestHeaderMapPtr();
+  headers->addCopy(Http::LowerCaseString(":method"), "GET");
+  headers->addCopy(Http::LowerCaseString(":scheme"),
+                   server_type == TestServerType::HTTP1_WITHOUT_TLS ? "http" : "https");
+  headers->addCopy(Http::LowerCaseString(":authority"),
+                   client_engine_with_test_server.testServer().getAddress());
+  headers->addCopy(Http::LowerCaseString(":path"), "/");
+  stream->sendHeaders(std::move(headers), true);
+  stream_complete.WaitForNotification();
+
+  EXPECT_EQ(actual_status_code, "200");
+  EXPECT_TRUE(actual_end_stream);
+}
+
+// this test attempts to elicit race conditions deriving from
+// the semantics of ownership on StreamCallbacks
+TEST_P(ClientLifetimesTest, CallbacksStayAlive) {
+  for (size_t i = 0; i < 10; i++) {
+    sendRequest(GetParam());
+  }
+}
+
+} // namespace
+} // namespace Envoy
+
+#endif // defined(ENVOY_ENABLE_FULL_PROTOS)

--- a/mobile/test/cc/integration/client_receive_data_test.cc
+++ b/mobile/test/cc/integration/client_receive_data_test.cc
@@ -1,0 +1,81 @@
+#include "test/common/http/filters/assertion/filter.pb.h"
+#include "test/common/integration/client_engine_with_test_server.h"
+#include "test/common/integration/test_server.h"
+
+#include "absl/synchronization/notification.h"
+#include "gtest/gtest.h"
+#include "library/cc/client_engine_builder.h"
+#include "library/common/engine_types.h"
+#include "library/common/http/header_utility.h"
+
+#if defined(ENVOY_ENABLE_FULL_PROTOS)
+
+namespace Envoy {
+
+class ClientReceiveDataTest : public testing::TestWithParam<TestServerType> {};
+
+INSTANTIATE_TEST_SUITE_P(ClientReceiveDataTest, ClientReceiveDataTest,
+                         testing::Values(TestServerType::HTTP1_WITHOUT_TLS,
+                                         TestServerType::HTTP1_WITH_TLS,
+                                         TestServerType::HTTP2_WITH_TLS, TestServerType::HTTP3));
+
+TEST_P(ClientReceiveDataTest, Success) {
+  absl::Notification engine_running;
+  Platform::ClientEngineBuilder engine_builder;
+  engine_builder.enableLogger(false)
+      .setLogLevel(Logger::Logger::debug)
+      .setOnEngineRunning([&]() { engine_running.Notify(); });
+  ClientEngineWithTestServer client_engine_with_test_server(
+      engine_builder, GetParam(),
+      /* headers= */ {}, /* body= */ "hello world",
+      /* trailers= */ {});
+  engine_running.WaitForNotification();
+
+  bool on_data_was_called = false;
+  std::string actual_status_code;
+  bool actual_end_stream;
+  std::string actual_response_body;
+  absl::Notification stream_complete;
+  EnvoyStreamCallbacks stream_callbacks;
+  stream_callbacks.on_headers_ = [&](const Http::ResponseHeaderMap& headers, bool end_stream,
+                                     envoy_stream_intel) {
+    actual_status_code = headers.getStatusValue();
+    actual_end_stream = end_stream;
+  };
+  stream_callbacks.on_data_ = [&](const Buffer::Instance& buffer, uint64_t length, bool end_stream,
+                                  envoy_stream_intel) {
+    on_data_was_called = true;
+    actual_end_stream = end_stream;
+    actual_response_body += absl::string_view(buffer.toString().data(), length);
+  };
+  stream_callbacks.on_complete_ = [&](envoy_stream_intel, envoy_final_stream_intel) {
+    stream_complete.Notify();
+  };
+  stream_callbacks.on_error_ = [&](const EnvoyError&, envoy_stream_intel,
+                                   envoy_final_stream_intel) { stream_complete.Notify(); };
+  stream_callbacks.on_cancel_ = [&](envoy_stream_intel, envoy_final_stream_intel) {
+    stream_complete.Notify();
+  };
+  auto stream_prototype =
+      client_engine_with_test_server.engine()->streamClient()->newStreamPrototype();
+  Platform::StreamSharedPtr stream = stream_prototype->start(std::move(stream_callbacks));
+
+  auto headers = Http::Utility::createRequestHeaderMapPtr();
+  headers->addCopy(Http::LowerCaseString(":method"), "GET");
+  headers->addCopy(Http::LowerCaseString(":scheme"),
+                   GetParam() == TestServerType::HTTP1_WITHOUT_TLS ? "http" : "https");
+  headers->addCopy(Http::LowerCaseString(":authority"),
+                   client_engine_with_test_server.testServer().getAddress());
+  headers->addCopy(Http::LowerCaseString(":path"), "/");
+  stream->sendHeaders(std::move(headers), true);
+  stream_complete.WaitForNotification();
+
+  EXPECT_TRUE(on_data_was_called);
+  EXPECT_EQ(actual_status_code, "200");
+  EXPECT_TRUE(actual_end_stream);
+  EXPECT_EQ(actual_response_body, "hello world");
+}
+
+} // namespace Envoy
+
+#endif // defined(ENVOY_ENABLE_FULL_PROTOS)

--- a/mobile/test/cc/integration/client_receive_headers_test.cc
+++ b/mobile/test/cc/integration/client_receive_headers_test.cc
@@ -1,0 +1,77 @@
+#include "test/common/http/filters/assertion/filter.pb.h"
+#include "test/common/integration/client_engine_with_test_server.h"
+#include "test/common/integration/test_server.h"
+
+#include "absl/synchronization/notification.h"
+#include "gtest/gtest.h"
+#include "library/cc/client_engine_builder.h"
+#include "library/common/engine_types.h"
+#include "library/common/http/header_utility.h"
+
+#if defined(ENVOY_ENABLE_FULL_PROTOS)
+
+namespace Envoy {
+
+class ClientReceiveHeadersTest : public testing::TestWithParam<TestServerType> {};
+
+INSTANTIATE_TEST_SUITE_P(ClientReceiveHeadersTest, ClientReceiveHeadersTest,
+                         testing::Values(TestServerType::HTTP1_WITHOUT_TLS,
+                                         TestServerType::HTTP1_WITH_TLS,
+                                         TestServerType::HTTP2_WITH_TLS, TestServerType::HTTP3));
+
+TEST_P(ClientReceiveHeadersTest, Success) {
+  absl::Notification engine_running;
+  Platform::ClientEngineBuilder engine_builder;
+  engine_builder.enableLogger(false)
+      .setLogLevel(Logger::Logger::debug)
+      .setOnEngineRunning([&]() { engine_running.Notify(); });
+  ClientEngineWithTestServer client_engine_with_test_server(engine_builder, GetParam(),
+                                                            {{"foo", "bar"}});
+  engine_running.WaitForNotification();
+
+  bool on_headers_was_called = false;
+  std::string actual_status_code;
+  bool actual_end_stream;
+  absl::Notification stream_complete;
+  EnvoyStreamCallbacks stream_callbacks;
+  stream_callbacks.on_headers_ = [&](const Http::ResponseHeaderMap& headers, bool end_stream,
+                                     envoy_stream_intel) {
+    on_headers_was_called = true;
+    actual_status_code = headers.getStatusValue();
+    EXPECT_EQ("bar", headers.get(Http::LowerCaseString("foo"))[0]->value().getStringView());
+    actual_end_stream = end_stream;
+  };
+  stream_callbacks.on_data_ = [&](const Buffer::Instance&, uint64_t /* length */, bool end_stream,
+                                  envoy_stream_intel) { actual_end_stream = end_stream; };
+  stream_callbacks.on_complete_ = [&](envoy_stream_intel, envoy_final_stream_intel) {
+    stream_complete.Notify();
+  };
+  stream_callbacks.on_error_ = [&](const EnvoyError&, envoy_stream_intel,
+                                   envoy_final_stream_intel) { stream_complete.Notify(); };
+  stream_callbacks.on_cancel_ = [&](envoy_stream_intel, envoy_final_stream_intel) {
+    stream_complete.Notify();
+  };
+  auto stream_prototype =
+      client_engine_with_test_server.engine()->streamClient()->newStreamPrototype();
+  Platform::StreamSharedPtr stream = stream_prototype->start(std::move(stream_callbacks));
+
+  auto headers = Http::Utility::createRequestHeaderMapPtr();
+  headers->addCopy(Http::LowerCaseString(":method"), "GET");
+  headers->addCopy(Http::LowerCaseString(":scheme"),
+                   GetParam() == TestServerType::HTTP1_WITHOUT_TLS ? "http" : "https");
+  headers->addCopy(Http::LowerCaseString(":authority"),
+                   client_engine_with_test_server.testServer().getAddress());
+  headers->addCopy(Http::LowerCaseString(":path"), "/");
+  stream->sendHeaders(std::move(headers), true);
+  stream->sendData(std::make_unique<Buffer::OwnedImpl>("request body"));
+  stream->close(std::make_unique<Buffer::OwnedImpl>("request body"));
+  stream_complete.WaitForNotification();
+
+  EXPECT_TRUE(on_headers_was_called);
+  EXPECT_EQ(actual_status_code, "200");
+  EXPECT_TRUE(actual_end_stream);
+}
+
+} // namespace Envoy
+
+#endif // defined(ENVOY_ENABLE_FULL_PROTOS)

--- a/mobile/test/cc/integration/client_receive_trailers_test.cc
+++ b/mobile/test/cc/integration/client_receive_trailers_test.cc
@@ -1,0 +1,76 @@
+#include "test/common/http/filters/assertion/filter.pb.h"
+#include "test/common/integration/client_engine_with_test_server.h"
+#include "test/common/integration/test_server.h"
+
+#include "absl/synchronization/notification.h"
+#include "gtest/gtest.h"
+#include "library/cc/client_engine_builder.h"
+#include "library/common/engine_types.h"
+#include "library/common/http/header_utility.h"
+
+#if defined(ENVOY_ENABLE_FULL_PROTOS)
+
+namespace Envoy {
+
+class ClientReceiveTrailersTest : public testing::TestWithParam<TestServerType> {};
+
+INSTANTIATE_TEST_SUITE_P(ClientReceiveTrailersTest, ClientReceiveTrailersTest,
+                         testing::Values(TestServerType::HTTP1_WITHOUT_TLS,
+                                         TestServerType::HTTP1_WITH_TLS,
+                                         TestServerType::HTTP2_WITH_TLS,
+                                         TestServerType::HTTP3));
+
+TEST_P(ClientReceiveTrailersTest, Success) {
+  absl::Notification engine_running;
+  Platform::ClientEngineBuilder engine_builder;
+  engine_builder.enableLogger(false)
+      .setLogLevel(Logger::Logger::debug)
+      .setOnEngineRunning([&]() { engine_running.Notify(); });
+  ClientEngineWithTestServer client_engine_with_test_server(
+      engine_builder, GetParam(),
+      /* headers= */ {},
+      /* body= */ "", /* trailers= */ {{"foo", "bar"}});
+  engine_running.WaitForNotification();
+
+  bool on_trailers_was_called = false;
+  std::string actual_status_code;
+  absl::Notification stream_complete;
+  EnvoyStreamCallbacks stream_callbacks;
+  stream_callbacks.on_headers_ = [&](const Http::ResponseHeaderMap& headers, bool /* end_stream */,
+                                     envoy_stream_intel) {
+    actual_status_code = headers.getStatusValue();
+  };
+  stream_callbacks.on_trailers_ = [&](const Http::ResponseTrailerMap& trailers,
+                                      envoy_stream_intel) {
+    on_trailers_was_called = true;
+    EXPECT_EQ("bar", trailers.get(Http::LowerCaseString("foo"))[0]->value().getStringView());
+  };
+  stream_callbacks.on_complete_ = [&](envoy_stream_intel, envoy_final_stream_intel) {
+    stream_complete.Notify();
+  };
+  stream_callbacks.on_error_ = [&](const EnvoyError&, envoy_stream_intel,
+                                   envoy_final_stream_intel) { stream_complete.Notify(); };
+  stream_callbacks.on_cancel_ = [&](envoy_stream_intel, envoy_final_stream_intel) {
+    stream_complete.Notify();
+  };
+  auto stream_prototype =
+      client_engine_with_test_server.engine()->streamClient()->newStreamPrototype();
+  Platform::StreamSharedPtr stream = stream_prototype->start(std::move(stream_callbacks));
+
+  auto headers = Http::Utility::createRequestHeaderMapPtr();
+  headers->addCopy(Http::LowerCaseString(":method"), "GET");
+  headers->addCopy(Http::LowerCaseString(":scheme"), GetParam() == TestServerType::HTTP1_WITHOUT_TLS ? "http" : "https");
+  headers->addCopy(Http::LowerCaseString(":authority"),
+                   client_engine_with_test_server.testServer().getAddress());
+  headers->addCopy(Http::LowerCaseString(":path"), "/");
+  stream->sendHeaders(std::move(headers), true);
+
+  stream_complete.WaitForNotification();
+
+  EXPECT_TRUE(on_trailers_was_called);
+  EXPECT_EQ(actual_status_code, "200");
+}
+
+} // namespace Envoy
+
+#endif // defined(ENVOY_ENABLE_FULL_PROTOS)

--- a/mobile/test/cc/integration/client_send_data_test.cc
+++ b/mobile/test/cc/integration/client_send_data_test.cc
@@ -1,0 +1,82 @@
+#include "test/common/http/filters/assertion/filter.pb.h"
+#include "test/common/integration/client_engine_with_test_server.h"
+#include "test/common/integration/test_server.h"
+
+#include "absl/synchronization/notification.h"
+#include "gtest/gtest.h"
+#include "library/cc/client_engine_builder.h"
+#include "library/common/engine_types.h"
+#include "library/common/http/header_utility.h"
+
+#if defined(ENVOY_ENABLE_FULL_PROTOS)
+
+namespace Envoy {
+
+class ClientSendDataTest : public testing::TestWithParam<TestServerType> {};
+
+INSTANTIATE_TEST_SUITE_P(ClientSendDataTest, ClientSendDataTest,
+                         testing::Values(TestServerType::HTTP1_WITHOUT_TLS,
+                                         TestServerType::HTTP1_WITH_TLS,
+                                         TestServerType::HTTP2_WITH_TLS, TestServerType::HTTP3));
+
+TEST_P(ClientSendDataTest, Success) {
+  envoymobile::extensions::filters::http::assertion::Assertion assertion;
+  auto* request_generic_body_match =
+      assertion.mutable_match_config()->mutable_http_request_generic_body_match();
+  request_generic_body_match->add_patterns()->set_string_match("request body");
+
+  absl::Notification engine_running;
+  Platform::ClientEngineBuilder engine_builder;
+  envoy::extensions::filters::network::http_connection_manager::v3::HttpFilter assertion_filter;
+  assertion_filter.set_name("envoy.filters.http.assertion");
+  assertion_filter.mutable_typed_config()->PackFrom(assertion);
+  engine_builder.addHcmHttpFilter(std::move(assertion_filter));
+
+  engine_builder.enableLogger(false)
+      .setLogLevel(Logger::Logger::debug)
+      .setOnEngineRunning([&]() { engine_running.Notify(); });
+  ClientEngineWithTestServer client_engine_with_test_server(engine_builder, GetParam());
+  engine_running.WaitForNotification();
+
+  std::string actual_status_code;
+  bool actual_end_stream;
+  absl::Notification stream_complete;
+  EnvoyStreamCallbacks stream_callbacks;
+  stream_callbacks.on_headers_ = [&](const Http::ResponseHeaderMap& headers, bool end_stream,
+                                     envoy_stream_intel) {
+    actual_status_code = headers.getStatusValue();
+    actual_end_stream = end_stream;
+  };
+  stream_callbacks.on_data_ = [&](const Buffer::Instance&, uint64_t /* length */, bool end_stream,
+                                  envoy_stream_intel) { actual_end_stream = end_stream; };
+  stream_callbacks.on_complete_ = [&](envoy_stream_intel, envoy_final_stream_intel) {
+    stream_complete.Notify();
+  };
+  stream_callbacks.on_error_ = [&](const EnvoyError&, envoy_stream_intel,
+                                   envoy_final_stream_intel) { stream_complete.Notify(); };
+  stream_callbacks.on_cancel_ = [&](envoy_stream_intel, envoy_final_stream_intel) {
+    stream_complete.Notify();
+  };
+  auto stream_prototype =
+      client_engine_with_test_server.engine()->streamClient()->newStreamPrototype();
+  Platform::StreamSharedPtr stream = stream_prototype->start(std::move(stream_callbacks));
+
+  auto headers = Http::Utility::createRequestHeaderMapPtr();
+  headers->addCopy(Http::LowerCaseString(":method"), "GET");
+  headers->addCopy(Http::LowerCaseString(":scheme"),
+                   GetParam() == TestServerType::HTTP1_WITHOUT_TLS ? "http" : "https");
+  headers->addCopy(Http::LowerCaseString(":authority"),
+                   client_engine_with_test_server.testServer().getAddress());
+  headers->addCopy(Http::LowerCaseString(":path"), "/");
+  stream->sendHeaders(std::move(headers), false);
+  stream->sendData(std::make_unique<Buffer::OwnedImpl>("request body"));
+  stream->close(std::make_unique<Buffer::OwnedImpl>("request body"));
+  stream_complete.WaitForNotification();
+
+  EXPECT_EQ(actual_status_code, "200");
+  EXPECT_TRUE(actual_end_stream);
+}
+
+} // namespace Envoy
+
+#endif // defined(ENVOY_ENABLE_FULL_PROTOS)

--- a/mobile/test/cc/integration/client_send_headers_test.cc
+++ b/mobile/test/cc/integration/client_send_headers_test.cc
@@ -1,0 +1,88 @@
+#include "test/common/http/filters/assertion/filter.pb.h"
+#include "test/common/integration/client_engine_with_test_server.h"
+#include "test/common/integration/test_server.h"
+
+#include "absl/synchronization/notification.h"
+#include "gtest/gtest.h"
+#include "library/cc/client_engine_builder.h"
+#include "library/common/engine_types.h"
+#include "library/common/http/header_utility.h"
+
+#if defined(ENVOY_ENABLE_FULL_PROTOS)
+
+namespace Envoy {
+
+class ClientSendHeadersTest : public testing::TestWithParam<TestServerType> {};
+
+INSTANTIATE_TEST_SUITE_P(ClientSendHeadersTest, ClientSendHeadersTest,
+                         testing::Values(TestServerType::HTTP1_WITHOUT_TLS,
+                                         TestServerType::HTTP1_WITH_TLS,
+                                         TestServerType::HTTP2_WITH_TLS, TestServerType::HTTP3));
+
+TEST_P(ClientSendHeadersTest, Success) {
+  envoymobile::extensions::filters::http::assertion::Assertion assertion;
+  auto* http_request_headers_match =
+      assertion.mutable_match_config()->mutable_http_request_headers_match();
+  auto* headers1 = http_request_headers_match->add_headers();
+  headers1->set_name(":method");
+  headers1->set_exact_match("GET");
+  auto* headers2 = http_request_headers_match->add_headers();
+  headers2->set_name(":scheme");
+  headers2->set_exact_match(GetParam() == TestServerType::HTTP1_WITHOUT_TLS ? "http" : "https");
+  auto* headers3 = http_request_headers_match->add_headers();
+  headers3->set_name(":path");
+  headers3->set_exact_match("/");
+
+  absl::Notification engine_running;
+  Platform::ClientEngineBuilder engine_builder;
+  envoy::extensions::filters::network::http_connection_manager::v3::HttpFilter assertion_filter;
+  assertion_filter.set_name("envoy.filters.http.assertion");
+  assertion_filter.mutable_typed_config()->PackFrom(assertion);
+  engine_builder.addHcmHttpFilter(std::move(assertion_filter));
+
+  engine_builder.enableLogger(false)
+      .setLogLevel(Logger::Logger::debug)
+      .setOnEngineRunning([&]() { engine_running.Notify(); });
+  ClientEngineWithTestServer client_engine_with_test_server(engine_builder, GetParam());
+  engine_running.WaitForNotification();
+
+  std::string actual_status_code;
+  bool actual_end_stream;
+  absl::Notification stream_complete;
+  EnvoyStreamCallbacks stream_callbacks;
+  stream_callbacks.on_headers_ = [&](const Http::ResponseHeaderMap& headers, bool end_stream,
+                                     envoy_stream_intel) {
+    actual_status_code = headers.getStatusValue();
+    actual_end_stream = end_stream;
+  };
+  stream_callbacks.on_data_ = [&](const Buffer::Instance&, uint64_t /* length */, bool end_stream,
+                                  envoy_stream_intel) { actual_end_stream = end_stream; };
+  stream_callbacks.on_complete_ = [&](envoy_stream_intel, envoy_final_stream_intel) {
+    stream_complete.Notify();
+  };
+  stream_callbacks.on_error_ = [&](const EnvoyError&, envoy_stream_intel,
+                                   envoy_final_stream_intel) { stream_complete.Notify(); };
+  stream_callbacks.on_cancel_ = [&](envoy_stream_intel, envoy_final_stream_intel) {
+    stream_complete.Notify();
+  };
+  auto stream_prototype =
+      client_engine_with_test_server.engine()->streamClient()->newStreamPrototype();
+  Platform::StreamSharedPtr stream = stream_prototype->start(std::move(stream_callbacks));
+
+  auto headers = Http::Utility::createRequestHeaderMapPtr();
+  headers->addCopy(Http::LowerCaseString(":method"), "GET");
+  headers->addCopy(Http::LowerCaseString(":scheme"),
+                   GetParam() == TestServerType::HTTP1_WITHOUT_TLS ? "http" : "https");
+  headers->addCopy(Http::LowerCaseString(":authority"),
+                   client_engine_with_test_server.testServer().getAddress());
+  headers->addCopy(Http::LowerCaseString(":path"), "/");
+  stream->sendHeaders(std::move(headers), true);
+  stream_complete.WaitForNotification();
+
+  EXPECT_EQ(actual_status_code, "200");
+  EXPECT_TRUE(actual_end_stream);
+}
+
+} // namespace Envoy
+
+#endif // defined(ENVOY_ENABLE_FULL_PROTOS)

--- a/mobile/test/cc/integration/client_send_trailers_test.cc
+++ b/mobile/test/cc/integration/client_send_trailers_test.cc
@@ -1,0 +1,92 @@
+#include "test/common/http/filters/assertion/filter.pb.h"
+#include "test/common/integration/client_engine_with_test_server.h"
+#include "test/common/integration/test_server.h"
+
+#include "absl/synchronization/notification.h"
+#include "gtest/gtest.h"
+#include "library/cc/client_engine_builder.h"
+#include "library/common/engine_types.h"
+#include "library/common/http/header_utility.h"
+
+#if defined(ENVOY_ENABLE_FULL_PROTOS)
+
+namespace Envoy {
+
+class ClientSendTrailersTest : public testing::TestWithParam<TestServerType> {};
+
+INSTANTIATE_TEST_SUITE_P(ClientSendTrailersTest, ClientSendTrailersTest,
+                         testing::Values(TestServerType::HTTP1_WITHOUT_TLS,
+                                         TestServerType::HTTP1_WITH_TLS,
+                                         TestServerType::HTTP2_WITH_TLS, TestServerType::HTTP3));
+
+TEST_P(ClientSendTrailersTest, Success) {
+  envoymobile::extensions::filters::http::assertion::Assertion assertion;
+  auto* http_request_trailers_match =
+      assertion.mutable_match_config()->mutable_http_request_trailers_match();
+  auto trailer = http_request_trailers_match->add_headers();
+  trailer->set_name("trailer-key");
+  trailer->set_exact_match("trailer-value");
+
+  absl::Notification engine_running;
+  Platform::ClientEngineBuilder engine_builder;
+  envoy::extensions::filters::network::http_connection_manager::v3::HttpFilter assertion_filter;
+  assertion_filter.set_name("envoy.filters.http.assertion");
+  assertion_filter.mutable_typed_config()->PackFrom(assertion);
+  engine_builder.addHcmHttpFilter(std::move(assertion_filter));
+
+  engine_builder.enableLogger(false)
+      .setLogLevel(Logger::Logger::debug)
+      .setOnEngineRunning([&]() { engine_running.Notify(); });
+  ClientEngineWithTestServer client_engine_with_test_server(
+      engine_builder, GetParam(),
+      /* headers= */ {}, /* body= */ "body",
+      /* trailers= */ {{"trailer-key", "trailer-value"}});
+  engine_running.WaitForNotification();
+
+  std::string actual_status_code;
+  std::string actual_trailer_value;
+  absl::Notification stream_complete;
+  EnvoyStreamCallbacks stream_callbacks;
+  stream_callbacks.on_headers_ = [&](const Http::ResponseHeaderMap& headers, bool /* end_stream */,
+                                     envoy_stream_intel) {
+    actual_status_code = headers.getStatusValue();
+  };
+  stream_callbacks.on_trailers_ = [&](const Http::ResponseTrailerMap& trailers,
+                                      envoy_stream_intel) {
+    actual_trailer_value =
+        trailers.get(Http::LowerCaseString("trailer-key"))[0]->value().getStringView();
+  };
+  stream_callbacks.on_complete_ = [&](envoy_stream_intel, envoy_final_stream_intel) {
+    stream_complete.Notify();
+  };
+  stream_callbacks.on_error_ = [&](const EnvoyError&, envoy_stream_intel,
+                                   envoy_final_stream_intel) { stream_complete.Notify(); };
+  stream_callbacks.on_cancel_ = [&](envoy_stream_intel, envoy_final_stream_intel) {
+    stream_complete.Notify();
+  };
+  auto stream_prototype =
+      client_engine_with_test_server.engine()->streamClient()->newStreamPrototype();
+  Platform::StreamSharedPtr stream = stream_prototype->start(std::move(stream_callbacks));
+
+  auto headers = Http::Utility::createRequestHeaderMapPtr();
+  headers->addCopy(Http::LowerCaseString(":method"), "GET");
+  headers->addCopy(Http::LowerCaseString(":scheme"),
+                   GetParam() == TestServerType::HTTP1_WITHOUT_TLS ? "http" : "https");
+  headers->addCopy(Http::LowerCaseString(":authority"),
+                   client_engine_with_test_server.testServer().getAddress());
+  headers->addCopy(Http::LowerCaseString(":path"), "/");
+  stream->sendHeaders(std::move(headers), false);
+
+  auto trailers = Http::Utility::createRequestTrailerMapPtr();
+  trailers->addCopy(Http::LowerCaseString("trailer-key"), "trailer-value");
+  stream->close(std::move(trailers));
+
+  stream_complete.WaitForNotification();
+
+  EXPECT_EQ(actual_status_code, "200");
+  EXPECT_EQ(actual_trailer_value, "trailer-value");
+}
+
+} // namespace Envoy
+
+#endif // defined(ENVOY_ENABLE_FULL_PROTOS)

--- a/mobile/test/cc/unit/BUILD
+++ b/mobile/test/cc/unit/BUILD
@@ -5,6 +5,22 @@ licenses(["notice"])  # Apache 2
 envoy_mobile_package()
 
 envoy_cc_test(
+    name = "client_envoy_config_test",
+    srcs = ["client_envoy_config_test.cc"],
+    repository = "@envoy",
+    deps = [
+        "@com_google_absl//absl/strings",
+        "@envoy_api//envoy/config/cluster/v3:pkg_cc_proto_library",
+        "@envoy_api//envoy/config/core/v3:pkg_cc_proto_library",
+        "@envoy_api//envoy/config/route/v3:pkg_cc_proto_library",
+        "@envoy_api//envoy/extensions/filters/http/buffer/v3:pkg_cc_proto_library",
+        "@envoy_api//envoy/extensions/filters/http/router/v3:pkg_cc_proto_library",
+        "@envoy_api//envoy/extensions/filters/network/http_connection_manager/v3:pkg_cc_proto_library",
+        "//library/cc:client_engine_builder_lib",
+    ],
+)
+
+envoy_cc_test(
     name = "envoy_config_test",
     srcs = ["envoy_config_test.cc"],
     linkopts = select({

--- a/mobile/test/cc/unit/client_envoy_config_test.cc
+++ b/mobile/test/cc/unit/client_envoy_config_test.cc
@@ -1,0 +1,192 @@
+#include "third_party/envoy/src/mobile/library/cc/client_engine_builder.h"
+
+#include <sys/socket.h>
+
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "envoy/config/cluster/v3/cluster.pb.h"
+#include "envoy/config/route/v3/route.proto.h"
+#include "envoy/extensions/filters/http/buffer/v3/buffer.pb.h"
+#include "envoy/extensions/filters/http/router/v3/router.pb.h"
+#include "envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto.h"
+
+#if defined(ENVOY_ENABLE_FULL_PROTOS)
+
+namespace Envoy {
+namespace {
+
+using namespace Platform;
+
+using envoy::config::bootstrap::v3::Bootstrap;
+using envoy::config::cluster::v3::Cluster;
+using envoy::extensions::filters::network::http_connection_manager::v3::
+    EnvoyMobileHttpConnectionManager;
+using testing::EqualsProto;
+using testing::HasSubstr;
+
+envoy::config::route::v3::RouteConfiguration defaultRouteConfig() {
+  envoy::config::route::v3::RouteConfiguration route_configuration;
+  route_configuration.set_name("route_config");
+  auto* virtual_host = route_configuration.add_virtual_hosts();
+  virtual_host->set_name("virtual_host");
+  virtual_host->add_domains("*");
+  auto* route = virtual_host->add_routes();
+  route->mutable_match()->set_prefix("/");
+  route->mutable_route()->set_cluster("some_cluster");
+  return route_configuration;
+}
+
+envoy::config::cluster::v3::Cluster defaultCluster() {
+  envoy::config::cluster::v3::Cluster cluster;
+  cluster.set_name("some_cluster");
+  return cluster;
+}
+
+ClientEngineBuilder defaultClientEngineBuilder() {
+  ClientEngineBuilder engine_builder;
+  engine_builder.setHcmRouteConfiguration(defaultRouteConfig());
+  engine_builder.addCluster(defaultCluster());
+  return engine_builder;
+}
+
+TEST(TestClientConfig, StreamIdleTimeout) {
+  ClientEngineBuilder engine_builder = defaultClientEngineBuilder();
+  std::unique_ptr<Bootstrap> bootstrap = engine_builder.generateBootstrap();
+  EXPECT_THAT(bootstrap->ShortDebugString(), HasSubstr("stream_idle_timeout { seconds: 15 }"));
+  engine_builder.setHcmRouteConfiguration(defaultRouteConfig());
+  engine_builder.addCluster(defaultCluster());
+  engine_builder.setHcmStreamIdleTimeoutSeconds(42);
+  bootstrap = engine_builder.generateBootstrap();
+  EXPECT_THAT(bootstrap->ShortDebugString(), HasSubstr("stream_idle_timeout { seconds: 42 }"));
+}
+
+TEST(TestClientConfig, SetPerConnectionBufferLimit) {
+  ClientEngineBuilder engine_builder = defaultClientEngineBuilder();
+  std::unique_ptr<Bootstrap> bootstrap = engine_builder.generateBootstrap();
+  EXPECT_THAT(bootstrap->ShortDebugString(),
+              HasSubstr("per_connection_buffer_limit_bytes { value: 10485760 }"));
+  engine_builder.setHcmRouteConfiguration(defaultRouteConfig());
+  engine_builder.addCluster(defaultCluster());
+  engine_builder.setPerConnectionBufferLimit(12345);
+  bootstrap = engine_builder.generateBootstrap();
+  EXPECT_THAT(bootstrap->ShortDebugString(),
+              HasSubstr("per_connection_buffer_limit_bytes { value: 12345 }"));
+}
+
+TEST(TestClientConfig, MultiFlag) {
+  ClientEngineBuilder engine_builder = defaultClientEngineBuilder();
+  engine_builder.addRuntimeGuard("test_feature_false", true)
+      .addRuntimeGuard("test_feature_true", false);
+  std::unique_ptr<Bootstrap> bootstrap = engine_builder.generateBootstrap();
+  const std::string bootstrap_str = bootstrap->ShortDebugString();
+  EXPECT_THAT(bootstrap_str, HasSubstr("\"test_feature_false\" value { bool_value: true }"));
+  EXPECT_THAT(bootstrap_str, HasSubstr("\"test_feature_true\" value { bool_value: false }"));
+}
+
+TEST(TestClientConfig, SetNodeId) {
+  ClientEngineBuilder engine_builder = defaultClientEngineBuilder();
+  const std::string default_node_id = "envoy-client";
+  EXPECT_EQ(engine_builder.generateBootstrap()->node().id(), default_node_id);
+  engine_builder.setHcmRouteConfiguration(defaultRouteConfig());
+  engine_builder.addCluster(defaultCluster());
+  const std::string test_node_id = "my_test_node";
+  engine_builder.setNodeId(test_node_id);
+  EXPECT_EQ(engine_builder.generateBootstrap()->node().id(), test_node_id);
+}
+
+TEST(TestClientConfig, SetNodeLocality) {
+  ClientEngineBuilder engine_builder = defaultClientEngineBuilder();
+  const std::string region = "us-west-1";
+  const std::string zone = "some_zone";
+  const std::string sub_zone = "some_sub_zone";
+  engine_builder.setNodeLocality(region, zone, sub_zone);
+  std::unique_ptr<Bootstrap> bootstrap = engine_builder.generateBootstrap();
+  EXPECT_EQ(bootstrap->node().locality().region(), region);
+  EXPECT_EQ(bootstrap->node().locality().zone(), zone);
+  EXPECT_EQ(bootstrap->node().locality().sub_zone(), sub_zone);
+}
+
+TEST(TestClientConfig, SetNodeMetadata) {
+  ClientEngineBuilder engine_builder = defaultClientEngineBuilder();
+  Protobuf::Struct node_metadata;
+  (*node_metadata.mutable_fields())["string_field"].set_string_value("some_string");
+  (*node_metadata.mutable_fields())["bool_field"].set_bool_value(true);
+  (*node_metadata.mutable_fields())["number_field"].set_number_value(28.3);
+  engine_builder.setNodeMetadata(node_metadata);
+  std::unique_ptr<Bootstrap> bootstrap = engine_builder.generateBootstrap();
+  EXPECT_EQ(bootstrap->node().metadata().fields().at("string_field").string_value(), "some_string");
+  EXPECT_EQ(bootstrap->node().metadata().fields().at("bool_field").bool_value(), true);
+  EXPECT_DOUBLE_EQ(bootstrap->node().metadata().fields().at("number_field").number_value(), 28.3);
+}
+
+TEST(TestClientConfig, AddCluster) {
+  ClientEngineBuilder engine_builder;
+  engine_builder.setHcmRouteConfiguration(defaultRouteConfig());
+  envoy::config::cluster::v3::Cluster cluster;
+  cluster.set_name("test_cluster");
+  cluster.mutable_connect_timeout()->set_seconds(5);
+  cluster.set_lb_policy(envoy::config::cluster::v3::Cluster::ROUND_ROBIN);
+  // Keep a copy for comparison.
+  envoy::config::cluster::v3::Cluster expected_cluster = cluster;
+  engine_builder.addCluster(std::move(cluster));
+  std::unique_ptr<Bootstrap> bootstrap = engine_builder.generateBootstrap();
+  EXPECT_EQ(bootstrap->static_resources().clusters_size(), 1);
+  EXPECT_THAT(bootstrap->static_resources().clusters(0), EqualsProto(expected_cluster));
+}
+
+TEST(TestClientConfig, AddHcmHttpFilter) {
+  ClientEngineBuilder engine_builder = defaultClientEngineBuilder();
+  envoy::extensions::filters::network::http_connection_manager::v3::HttpFilter filter;
+  filter.set_name("envoy.filters.http.buffer");
+  envoy::extensions::filters::http::buffer::v3::Buffer buffer_config;
+  buffer_config.mutable_max_request_bytes()->set_value(12345);
+  filter.mutable_typed_config()->PackFrom(buffer_config);
+  envoy::extensions::filters::network::http_connection_manager::v3::HttpFilter expected_filter =
+      filter;
+  engine_builder.addHcmHttpFilter(std::move(filter));
+  std::unique_ptr<Bootstrap> bootstrap = engine_builder.generateBootstrap();
+  EnvoyMobileHttpConnectionManager api_listener_config;
+  bootstrap->static_resources().listeners(0).api_listener().api_listener().UnpackTo(
+      &api_listener_config);
+  ASSERT_EQ(api_listener_config.config().http_filters_size(), 2);
+  EXPECT_THAT(api_listener_config.config().http_filters(0), EqualsProto(expected_filter));
+}
+
+TEST(TestClientConfig, SetRouterConfig) {
+  ClientEngineBuilder engine_builder = defaultClientEngineBuilder();
+  envoy::extensions::filters::http::router::v3::Router router_config;
+  router_config.set_suppress_envoy_headers(true);
+  router_config.add_strict_check_headers("x-foo");
+  envoy::extensions::filters::http::router::v3::Router expected_router_config = router_config;
+  engine_builder.setRouterConfig(std::move(router_config));
+  std::unique_ptr<Bootstrap> bootstrap = engine_builder.generateBootstrap();
+  EnvoyMobileHttpConnectionManager api_listener_config;
+  bootstrap->static_resources().listeners(0).api_listener().api_listener().UnpackTo(
+      &api_listener_config);
+  ASSERT_EQ(api_listener_config.config().http_filters_size(), 1);
+  EXPECT_EQ(api_listener_config.config().http_filters(0).name(), "envoy.router");
+  envoy::extensions::filters::http::router::v3::Router actual_router_config;
+  api_listener_config.config().http_filters(0).typed_config().UnpackTo(&actual_router_config);
+  EXPECT_THAT(actual_router_config, EqualsProto(expected_router_config));
+}
+
+TEST(TestClientConfig, SetWatchdog) {
+  ClientEngineBuilder engine_builder;
+  engine_builder.setHcmRouteConfiguration(defaultRouteConfig());
+  engine_builder.addCluster(defaultCluster());
+  envoy::config::bootstrap::v3::Watchdogs watchdogs;
+  watchdogs.mutable_main_thread_watchdog()->mutable_miss_timeout()->set_seconds(123);
+  watchdogs.mutable_main_thread_watchdog()->mutable_megamiss_timeout()->set_seconds(456);
+  watchdogs.mutable_worker_watchdog()->mutable_miss_timeout()->set_seconds(789);
+  envoy::config::bootstrap::v3::Watchdogs expected_watchdogs = watchdogs;
+  engine_builder.setWatchdog(std::move(watchdogs));
+  std::unique_ptr<Bootstrap> bootstrap = engine_builder.generateBootstrap();
+  EXPECT_THAT(bootstrap->watchdogs(), EqualsProto(expected_watchdogs));
+}
+
+} // namespace
+} // namespace Envoy
+
+#endif // ENVOY_ENABLE_FULL_PROTOS

--- a/mobile/test/common/integration/BUILD
+++ b/mobile/test/common/integration/BUILD
@@ -121,6 +121,31 @@ envoy_cc_test_library(
     ],
 )
 
+envoy_cc_test_library(
+    name = "client_engine_with_test_server",
+    srcs = [
+        "client_engine_with_test_server.cc",
+    ],
+    hdrs = [
+        "client_engine_with_test_server.h",
+    ],
+    repository = "@envoy",
+    deps = [
+        ":test_server_lib",
+        "//library/cc:client_engine_builder_lib",
+        "//library/cc:envoy_engine_cc_lib_no_stamp",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/strings",
+        "@envoy_api//envoy/config/cluster/v3:pkg_cc_proto",
+        "@envoy_api//envoy/config/endpoint/v3:pkg_cc_proto",
+        "@envoy_api//envoy/config/route/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/transport_sockets/http_11_proxy/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/transport_sockets/quic/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/transport_sockets/tls/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/upstreams/http/v3:pkg_cc_proto",
+    ],
+)
+
 envoy_cc_test(
     name = "rtds_integration_test",
     srcs = envoy_select_envoy_mobile_xds(

--- a/mobile/test/common/integration/client_engine_with_test_server.cc
+++ b/mobile/test/common/integration/client_engine_with_test_server.cc
@@ -1,0 +1,131 @@
+#include "test/common/integration/client_engine_with_test_server.h"
+
+#include <string>
+#include <utility>
+
+#include "absl/container/flat_hash_map.h"
+#include "absl/strings/string_view.h"
+
+#include "envoy/config/cluster/v3/cluster.pb.h"
+#include "envoy/config/endpoint/v3/endpoint_components.pb.h"
+#include "envoy/config/route/v3/route_components.pb.h"
+#include "envoy/extensions/transport_sockets/tls/v3/tls.pb.h"
+#include "envoy/extensions/upstreams/http/v3/http_protocol_options.pb.h"
+#include "envoy/extensions/transport_sockets/http_11_proxy/v3/upstream_http_11_connect.pb.h"
+#include "envoy/extensions/transport_sockets/quic/v3/quic_transport.pb.h"
+#include "library/cc/client_engine_builder.h"
+#include "library/cc/stream_client.h"
+#include "test/common/integration/test_server.h"
+
+#if defined(ENVOY_ENABLE_FULL_PROTOS)
+
+namespace Envoy {
+
+ClientEngineWithTestServer::ClientEngineWithTestServer(
+    Platform::ClientEngineBuilder& engine_builder, TestServerType type,
+    const absl::flat_hash_map<std::string, std::string>& headers, absl::string_view body,
+    const absl::flat_hash_map<std::string, std::string>& trailers) {
+  test_server_.start(type);
+  test_server_.setResponse(headers, body, trailers);
+
+  // Set up route configuration and cluster for ClientEngineBuilder to route requests to test_server_.
+  envoy::config::route::v3::RouteConfiguration route_configuration;
+  route_configuration.set_name("route_config");
+  auto* virtual_host = route_configuration.add_virtual_hosts();
+  virtual_host->set_name("test_virtual_host");
+  virtual_host->add_domains("*");
+  auto* route = virtual_host->add_routes();
+  route->mutable_match()->set_prefix("/");
+  route->mutable_route()->set_cluster("test_cluster");
+  engine_builder.setHcmRouteConfiguration(std::move(route_configuration));
+
+  envoy::config::cluster::v3::Cluster cluster;
+  cluster.set_name("test_cluster");
+  cluster.mutable_connect_timeout()->set_seconds(5);
+  auto* endpoint = cluster.mutable_load_assignment()
+                       ->add_endpoints()
+                       ->add_lb_endpoints()
+                       ->mutable_endpoint();
+  endpoint->mutable_address()->mutable_socket_address()->set_address(test_server_.getIpAddress());
+  endpoint->mutable_address()->mutable_socket_address()->set_port_value(test_server_.getPort());
+  cluster.mutable_load_assignment()->set_cluster_name("test_cluster");
+
+  bool use_tls = type == TestServerType::HTTP1_WITH_TLS || type == TestServerType::HTTP2_WITH_TLS ||
+                 type == TestServerType::HTTP3;
+
+  if (use_tls) {
+    envoy::extensions::transport_sockets::tls::v3::UpstreamTlsContext tls_context;
+    tls_context.mutable_common_tls_context()
+        ->mutable_validation_context()
+        ->set_trust_chain_verification(envoy::extensions::transport_sockets::tls::v3::
+                                           CertificateValidationContext::ACCEPT_UNTRUSTED);
+    tls_context.set_sni("www.lyft.com");
+
+    if (type == TestServerType::HTTP2_WITH_TLS) {
+      tls_context.mutable_common_tls_context()->add_alpn_protocols("h2");
+      envoy::extensions::upstreams::http::v3::HttpProtocolOptions protocol_options;
+      protocol_options.mutable_explicit_http_config()->mutable_http2_protocol_options();
+      (*cluster.mutable_typed_extension_protocol_options())
+          ["envoy.extensions.upstreams.http.v3.HttpProtocolOptions"]
+              .PackFrom(protocol_options);
+    } else if (type == TestServerType::HTTP1_WITH_TLS) {
+      tls_context.mutable_common_tls_context()->add_alpn_protocols("http/1.1");
+      envoy::extensions::upstreams::http::v3::HttpProtocolOptions protocol_options;
+      protocol_options.mutable_explicit_http_config()
+          ->mutable_http_protocol_options()
+          ->set_enable_trailers(true);
+      (*cluster.mutable_typed_extension_protocol_options())
+          ["envoy.extensions.upstreams.http.v3.HttpProtocolOptions"]
+              .PackFrom(protocol_options);
+    }
+    cluster.mutable_transport_socket()->set_name("envoy.transport_sockets.tls");
+    cluster.mutable_transport_socket()->mutable_typed_config()->PackFrom(tls_context);
+
+    if (type == TestServerType::HTTP3) {
+      envoy::extensions::upstreams::http::v3::HttpProtocolOptions protocol_options;
+      protocol_options.mutable_explicit_http_config()->mutable_http3_protocol_options();
+      (*cluster.mutable_typed_extension_protocol_options())
+          ["envoy.extensions.upstreams.http.v3.HttpProtocolOptions"]
+              .PackFrom(protocol_options);
+      envoy::extensions::transport_sockets::quic::v3::QuicUpstreamTransport h3_inner_socket;
+      h3_inner_socket.mutable_upstream_tls_context()->CopyFrom(tls_context);
+      envoy::extensions::transport_sockets::http_11_proxy::v3::Http11ProxyUpstreamTransport
+          h3_proxy_socket;
+      h3_proxy_socket.mutable_transport_socket()->mutable_typed_config()->PackFrom(h3_inner_socket);
+      h3_proxy_socket.mutable_transport_socket()->set_name("envoy.transport_sockets.quic");
+      cluster.mutable_transport_socket()->set_name("envoy.transport_sockets.http_11_proxy");
+      cluster.mutable_transport_socket()->mutable_typed_config()->PackFrom(h3_proxy_socket);
+    }
+  } else {
+    cluster.mutable_transport_socket()->set_name("envoy.transport_sockets.raw_buffer");
+    envoy::extensions::upstreams::http::v3::HttpProtocolOptions protocol_options;
+    protocol_options.mutable_explicit_http_config()
+          ->mutable_http_protocol_options()
+          ->set_enable_trailers(true);
+      (*cluster.mutable_typed_extension_protocol_options())
+          ["envoy.extensions.upstreams.http.v3.HttpProtocolOptions"]
+              .PackFrom(protocol_options);
+  }
+
+  engine_builder.addCluster(std::move(cluster));
+
+  engine_ = engine_builder.build();
+}
+
+ClientEngineWithTestServer::~ClientEngineWithTestServer() {
+  // It is important that the we shutdown the TestServer first before terminating the Engine. This
+  // is because when the Engine is terminated, the Logger::Context will be destroyed and
+  // Logger::Context is a global variable that is used by both Engine and TestServer. By shutting
+  // down the TestServer first, the TestServer will no longer access a Logger::Context that has been
+  // destroyed.
+  test_server_.shutdown();
+  engine_->terminate();
+}
+
+Platform::EngineSharedPtr& ClientEngineWithTestServer::engine() { return engine_; }
+
+TestServer& ClientEngineWithTestServer::testServer() { return test_server_; }
+
+} // namespace Envoy
+
+#endif // defined(ENVOY_ENABLE_FULL_PROTOS)

--- a/mobile/test/common/integration/client_engine_with_test_server.h
+++ b/mobile/test/common/integration/client_engine_with_test_server.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "test/common/integration/test_server.h"
+
+#include "library/cc/engine_builder.h"
+
+#if defined(ENVOY_ENABLE_FULL_PROTOS)
+
+namespace Envoy {
+
+/**
+ * This class starts `TestServer` and builds the `Engine` and ensures that the `TestServer` is
+ * shutdown first before terminating the `Engine` in order to avoid accessing the destroyed
+ * `Logger::Context` given that the `Logger::Context` is a global variable used by both the
+ * `TestServer` and `Engine`. This class uses the `ClientEngineBuilder` to build the `Engine`,
+ * with the cluster and route configuration being provided by the class constructor.
+ */
+class ClientEngineWithTestServer {
+public:
+  ClientEngineWithTestServer(Platform::ClientEngineBuilder& engine_builder, TestServerType type,
+                             const absl::flat_hash_map<std::string, std::string>& headers = {},
+                             absl::string_view body = "",
+                             const absl::flat_hash_map<std::string, std::string>& trailers = {});
+  ~ClientEngineWithTestServer();
+
+  /** Returns the reference of `Engine` created. */
+  Platform::EngineSharedPtr& engine();
+
+  /** Returns the reference of `TestServer` started. */
+  TestServer& testServer();
+
+private:
+  Platform::EngineSharedPtr engine_;
+  TestServer test_server_;
+};
+
+} // namespace Envoy
+
+#endif // defined(ENVOY_ENABLE_FULL_PROTOS)


### PR DESCRIPTION
Commit Message: This PR introduces a new ClientEngineBuilder class. This class is a variant of the existing EngineBuilder class that provides a more configurable bootstrap via its exposed API but is similarly used to create an engine. The ClientEngineBuilder requires the user to provide their own cluster and route configuration, giving the user more control over the client's behavior. This client is not intended to be used in mobile environments and does not provide support for XDS as of now.

Additional Description: N/A
Risk Level: Low - this is a new, separate client and should not affect Envoy or Envoy Mobile.
Testing: Unit and integration are included in this PR. I also conducted manual testing using the client in a staging environment to send requests to an Envoy Server.
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
