### PR TITLE
tracing: add trace_id_pattern config to OpenTelemetry tracer

### DIFF
--- a/api/envoy/config/trace/v3/opentelemetry.proto
+++ b/api/envoy/config/trace/v3/opentelemetry.proto
@@ -21,8 +21,17 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // Configuration for the OpenTelemetry tracer.
 //  [#extension: envoy.tracers.opentelemetry]
-// [#next-free-field: 7]
+// [#next-free-field: 8]
 message OpenTelemetryConfig {
+  // Trace ID generation pattern.
+  enum TraceIdPattern {
+    // Use random 128-bit trace ID (UUID-v4-style, default for backward compatibility).
+    UUID_V4 = 0;
+
+    // Use UUID-v7 format trace ID (RFC 9562) with timestamp prefix for better sortability.
+    UUID_V7 = 1;
+  }
+
   // The upstream gRPC cluster that will receive OTLP traces.
   // Note that the tracer drops traces if the server does not read data fast enough.
   // This field can be left empty to disable reporting traces to the gRPC service.
@@ -64,4 +73,7 @@ message OpenTelemetryConfig {
   // This field specifies the maximum number of spans that can be cached. If not specified, the
   // default is 1024.
   google.protobuf.UInt32Value max_cache_size = 6;
+
+  // Trace ID generation pattern. Defaults to UUID_V4 for backward compatibility.
+  TraceIdPattern trace_id_pattern = 7;
 }

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -23,5 +23,11 @@ removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`
 
 new_features:
+- area: tracing
+  change: |
+    Added :ref:`trace_id_pattern <envoy_v3_api_field_config.trace.v3.OpenTelemetryConfig.trace_id_pattern>`
+    configuration option to OpenTelemetry tracer. Allows selection between ``UUID_V4`` (random 128-bit, default)
+    and ``UUID_V7`` (RFC 9562 timestamp-based) for trace ID generation. ``UUID_V7`` provides better sortability
+    and time-based ordering of traces. Defaults to ``UUID_V4`` for backward compatibility.
 
 deprecated:

--- a/source/extensions/tracers/opentelemetry/opentelemetry_tracer_impl.cc
+++ b/source/extensions/tracers/opentelemetry/opentelemetry_tracer_impl.cc
@@ -110,10 +110,10 @@ Driver::Driver(const envoy::config::trace::v3::OpenTelemetryConfig& opentelemetr
     // Get the max cache size from config
     uint64_t max_cache_size = PROTOBUF_GET_WRAPPED_OR_DEFAULT(opentelemetry_config, max_cache_size,
                                                               DEFAULT_MAX_CACHE_SIZE);
-    TracerPtr tracer =
-        std::make_unique<Tracer>(std::move(exporter), factory_context.timeSource(),
-                                 factory_context.api().randomGenerator(), factory_context.runtime(),
-                                 dispatcher, tracing_stats_, resource_ptr, sampler, max_cache_size);
+    TracerPtr tracer = std::make_unique<Tracer>(
+        std::move(exporter), factory_context.timeSource(), factory_context.api().randomGenerator(),
+        factory_context.runtime(), dispatcher, tracing_stats_, resource_ptr, sampler,
+        max_cache_size, opentelemetry_config.trace_id_pattern());
     return std::make_shared<TlsTracer>(std::move(tracer));
   });
 }

--- a/tools/spelling/spelling_dictionary.txt
+++ b/tools/spelling/spelling_dictionary.txt
@@ -525,6 +525,8 @@ UTC
 UTF
 UUID
 UUIDs
+UUIDv4
+UUIDv7
 VC
 VCHAR
 VCL
@@ -1373,6 +1375,7 @@ socklen
 sockopt
 sockopts
 somestring
+sortability
 spanid
 spdlog
 splitter


### PR DESCRIPTION
Adds a new configuration option `trace_id_pattern` to the OpenTelemetry tracer that allows users to select between UUID_V4 (random 128-bit) and UUID_V7 (RFC 9562 timestamp-based) trace ID generation patterns.

UUID_V7 provides several benefits:
- Time-based ordering: Trace IDs are naturally sortable by creation time
- Better database indexing: Monotonically increasing IDs improve B-tree index performance
- Distributed system correlation: Timestamp prefix helps correlate traces across services

The default remains UUID_V4 for backward compatibility.

Configuration example:
```yaml
tracing:
  http:
    name: envoy.tracers.opentelemetry
    typed_config:
      "@type": type.googleapis.com/envoy.config.trace.v3.OpenTelemetryConfig
      grpc_service:
        envoy_grpc:
          cluster_name: otel-collector
      trace_id_pattern: UUID_V7
```

Risk Level: Low
Testing: Unit tests added for UUID_V7 trace ID generation



Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
