### PR TITLE
dynamic_modules: add stats access APIs to Bootstrap Extension

### DIFF
--- a/source/extensions/bootstrap/dynamic_modules/BUILD
+++ b/source/extensions/bootstrap/dynamic_modules/BUILD
@@ -17,6 +17,7 @@ envoy_cc_library(
         "//envoy/event:dispatcher_interface",
         "//envoy/http:async_client_interface",
         "//envoy/server:factory_context_interface",
+        "//envoy/stats:stats_interface",
         "//source/common/buffer:buffer_lib",
         "//source/common/common:assert_lib",
         "//source/common/common:logger_lib",
@@ -32,6 +33,7 @@ envoy_cc_library(
     deps = [
         ":extension_config_lib",
         "//envoy/server:bootstrap_extension_config_interface",
+        "//envoy/stats:stats_interface",
         "//source/common/common:assert_lib",
         "//source/common/common:logger_lib",
         "//source/extensions/dynamic_modules:dynamic_modules_lib",
@@ -43,6 +45,8 @@ envoy_cc_library(
     srcs = ["abi_impl.cc"],
     deps = [
         ":extension_config_lib",
+        ":extension_lib",
+        "//source/common/stats:symbol_table_lib",
         "//source/extensions/dynamic_modules:dynamic_modules_lib",
     ],
 )

--- a/source/extensions/bootstrap/dynamic_modules/abi_impl.cc
+++ b/source/extensions/bootstrap/dynamic_modules/abi_impl.cc
@@ -2,9 +2,12 @@
 
 // This file provides host-side implementations for ABI callbacks specific to bootstrap extensions.
 
+#include "source/common/stats/symbol_table.h"
+#include "source/extensions/bootstrap/dynamic_modules/extension.h"
 #include "source/extensions/bootstrap/dynamic_modules/extension_config.h"
 #include "source/extensions/dynamic_modules/abi.h"
 
+using Envoy::Extensions::Bootstrap::DynamicModules::DynamicModuleBootstrapExtension;
 using Envoy::Extensions::Bootstrap::DynamicModules::DynamicModuleBootstrapExtensionConfig;
 using Envoy::Extensions::Bootstrap::DynamicModules::DynamicModuleBootstrapExtensionConfigScheduler;
 
@@ -31,6 +34,8 @@ void envoy_dynamic_module_callback_bootstrap_extension_config_scheduler_commit(
       static_cast<DynamicModuleBootstrapExtensionConfigScheduler*>(scheduler_module_ptr);
   scheduler->commit(event_id);
 }
+
+// -------------------- HTTP Callout Callbacks --------------------
 
 envoy_dynamic_module_type_http_callout_init_result
 envoy_dynamic_module_callback_bootstrap_extension_http_callout(
@@ -64,6 +69,112 @@ envoy_dynamic_module_callback_bootstrap_extension_http_callout(
   return config->sendHttpCallout(callout_id_out,
                                  absl::string_view(cluster_name.ptr, cluster_name.length),
                                  std::move(message), timeout_milliseconds);
+}
+
+// -------------------- Stats Access Callbacks --------------------
+
+bool envoy_dynamic_module_callback_bootstrap_extension_get_counter_value(
+    envoy_dynamic_module_type_bootstrap_extension_envoy_ptr extension_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer name, uint64_t* value_ptr) {
+  auto* extension = static_cast<DynamicModuleBootstrapExtension*>(extension_envoy_ptr);
+  Envoy::Stats::Store& stats_store = extension->statsStore();
+  const absl::string_view name_view(name.ptr, name.length);
+
+  // Use iterate() instead of forEachCounter() to enable early exit once the stat is found.
+  bool found = false;
+  Envoy::Stats::IterateFn<Envoy::Stats::Counter> counter_callback =
+      [&name_view, &found, value_ptr](const Envoy::Stats::CounterSharedPtr& counter) -> bool {
+    if (counter->name() == name_view) {
+      *value_ptr = counter->value();
+      found = true;
+      return false; // Stop iteration.
+    }
+    return true; // Continue iteration.
+  };
+  stats_store.iterate(counter_callback);
+  return found;
+}
+
+bool envoy_dynamic_module_callback_bootstrap_extension_get_gauge_value(
+    envoy_dynamic_module_type_bootstrap_extension_envoy_ptr extension_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer name, uint64_t* value_ptr) {
+  auto* extension = static_cast<DynamicModuleBootstrapExtension*>(extension_envoy_ptr);
+  Envoy::Stats::Store& stats_store = extension->statsStore();
+  const absl::string_view name_view(name.ptr, name.length);
+
+  // Use iterate() instead of forEachGauge() to enable early exit once the stat is found.
+  bool found = false;
+  Envoy::Stats::IterateFn<Envoy::Stats::Gauge> gauge_callback =
+      [&name_view, &found, value_ptr](const Envoy::Stats::GaugeSharedPtr& gauge) -> bool {
+    if (gauge->name() == name_view) {
+      *value_ptr = gauge->value();
+      found = true;
+      return false; // Stop iteration.
+    }
+    return true; // Continue iteration.
+  };
+  stats_store.iterate(gauge_callback);
+  return found;
+}
+
+bool envoy_dynamic_module_callback_bootstrap_extension_get_histogram_summary(
+    envoy_dynamic_module_type_bootstrap_extension_envoy_ptr extension_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer name, uint64_t* sample_count_ptr,
+    double* sample_sum_ptr) {
+  auto* extension = static_cast<DynamicModuleBootstrapExtension*>(extension_envoy_ptr);
+  Envoy::Stats::Store& stats_store = extension->statsStore();
+  const absl::string_view name_view(name.ptr, name.length);
+
+  bool found = false;
+  stats_store.forEachHistogram(
+      [](size_t) {},
+      [&name_view, &found, sample_count_ptr, sample_sum_ptr](Envoy::Stats::ParentHistogram& hist) {
+        if (!found && hist.name() == name_view) {
+          const auto& stats = hist.cumulativeStatistics();
+          *sample_count_ptr = stats.sampleCount();
+          *sample_sum_ptr = stats.sampleSum();
+          found = true;
+        }
+      });
+  return found;
+}
+
+void envoy_dynamic_module_callback_bootstrap_extension_iterate_counters(
+    envoy_dynamic_module_type_bootstrap_extension_envoy_ptr extension_envoy_ptr,
+    envoy_dynamic_module_type_counter_iterator_fn iterator_fn, void* user_data) {
+  auto* extension = static_cast<DynamicModuleBootstrapExtension*>(extension_envoy_ptr);
+  Envoy::Stats::Store& stats_store = extension->statsStore();
+
+  stats_store.forEachCounter([](size_t) {},
+                             [iterator_fn, user_data](Envoy::Stats::Counter& counter) {
+                               std::string name = counter.name();
+                               envoy_dynamic_module_type_envoy_buffer name_buffer{name.data(),
+                                                                                  name.size()};
+                               auto action = iterator_fn(name_buffer, counter.value(), user_data);
+                               // Note: forEachCounter doesn't support early exit, so we ignore Stop
+                               // action. The module should handle this by setting a flag in
+                               // user_data.
+                               (void)action;
+                             });
+}
+
+void envoy_dynamic_module_callback_bootstrap_extension_iterate_gauges(
+    envoy_dynamic_module_type_bootstrap_extension_envoy_ptr extension_envoy_ptr,
+    envoy_dynamic_module_type_gauge_iterator_fn iterator_fn, void* user_data) {
+  auto* extension = static_cast<DynamicModuleBootstrapExtension*>(extension_envoy_ptr);
+  Envoy::Stats::Store& stats_store = extension->statsStore();
+
+  stats_store.forEachGauge([](size_t) {},
+                           [iterator_fn, user_data](Envoy::Stats::Gauge& gauge) {
+                             std::string name = gauge.name();
+                             envoy_dynamic_module_type_envoy_buffer name_buffer{name.data(),
+                                                                                name.size()};
+                             auto action = iterator_fn(name_buffer, gauge.value(), user_data);
+                             // Note: forEachGauge doesn't support early exit, so we ignore Stop
+                             // action. The module should handle this by setting a flag in
+                             // user_data.
+                             (void)action;
+                           });
 }
 
 } // extern "C"

--- a/source/extensions/bootstrap/dynamic_modules/extension.h
+++ b/source/extensions/bootstrap/dynamic_modules/extension.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "envoy/server/bootstrap_extension_config.h"
+#include "envoy/stats/store.h"
 
 #include "source/common/common/logger.h"
 #include "source/extensions/bootstrap/dynamic_modules/extension_config.h"
@@ -37,6 +38,11 @@ public:
    * Get the extension configuration.
    */
   const DynamicModuleBootstrapExtensionConfig& getExtensionConfig() const { return *config_; }
+
+  /**
+   * Get the stats store.
+   */
+  Stats::Store& statsStore() { return config_->stats_store_; }
 
 private:
   /**

--- a/source/extensions/bootstrap/dynamic_modules/extension_config.cc
+++ b/source/extensions/bootstrap/dynamic_modules/extension_config.cc
@@ -10,9 +10,10 @@ namespace DynamicModules {
 DynamicModuleBootstrapExtensionConfig::DynamicModuleBootstrapExtensionConfig(
     const absl::string_view extension_name, const absl::string_view extension_config,
     Extensions::DynamicModules::DynamicModulePtr dynamic_module,
-    Event::Dispatcher& main_thread_dispatcher, Server::Configuration::ServerFactoryContext& context)
+    Event::Dispatcher& main_thread_dispatcher, Server::Configuration::ServerFactoryContext& context,
+    Stats::Store& stats_store)
     : dynamic_module_(std::move(dynamic_module)), main_thread_dispatcher_(main_thread_dispatcher),
-      context_(context) {
+      context_(context), stats_store_(stats_store) {
   ASSERT(dynamic_module_ != nullptr);
   ASSERT(extension_name.data() != nullptr);
   ASSERT(extension_config.data() != nullptr);
@@ -147,8 +148,8 @@ absl::StatusOr<DynamicModuleBootstrapExtensionConfigSharedPtr>
 newDynamicModuleBootstrapExtensionConfig(
     const absl::string_view extension_name, const absl::string_view extension_config,
     Extensions::DynamicModules::DynamicModulePtr dynamic_module,
-    Event::Dispatcher& main_thread_dispatcher,
-    Server::Configuration::ServerFactoryContext& context) {
+    Event::Dispatcher& main_thread_dispatcher, Server::Configuration::ServerFactoryContext& context,
+    Stats::Store& stats_store) {
 
   // Resolve the required symbols from the dynamic module.
   auto constructor =
@@ -207,7 +208,8 @@ newDynamicModuleBootstrapExtensionConfig(
   }
 
   auto config = std::make_shared<DynamicModuleBootstrapExtensionConfig>(
-      extension_name, extension_config, std::move(dynamic_module), main_thread_dispatcher, context);
+      extension_name, extension_config, std::move(dynamic_module), main_thread_dispatcher, context,
+      stats_store);
 
   const void* extension_config_module_ptr = (*constructor.value())(
       static_cast<void*>(config.get()), {extension_name.data(), extension_name.size()},

--- a/source/extensions/bootstrap/dynamic_modules/extension_config.h
+++ b/source/extensions/bootstrap/dynamic_modules/extension_config.h
@@ -5,6 +5,7 @@
 #include "envoy/event/dispatcher.h"
 #include "envoy/http/async_client.h"
 #include "envoy/server/factory_context.h"
+#include "envoy/stats/store.h"
 
 #include "source/common/common/logger.h"
 #include "source/common/http/message_impl.h"
@@ -49,12 +50,14 @@ public:
    * @param dynamic_module the dynamic module to use.
    * @param main_thread_dispatcher the main thread dispatcher.
    * @param context the server factory context for accessing cluster manager lazily.
+   * @param stats_store the stats store for accessing metrics.
    */
   DynamicModuleBootstrapExtensionConfig(const absl::string_view extension_name,
                                         const absl::string_view extension_config,
                                         Extensions::DynamicModules::DynamicModulePtr dynamic_module,
                                         Event::Dispatcher& main_thread_dispatcher,
-                                        Server::Configuration::ServerFactoryContext& context);
+                                        Server::Configuration::ServerFactoryContext& context,
+                                        Stats::Store& stats_store);
 
   ~DynamicModuleBootstrapExtensionConfig();
 
@@ -108,6 +111,9 @@ public:
   // available during bootstrap extension creation, so we store the context and access it when
   // needed.
   Server::Configuration::ServerFactoryContext& context_;
+
+  // The stats store for accessing metrics.
+  Stats::Store& stats_store_;
 
 private:
   /**
@@ -183,6 +189,7 @@ private:
  * @param dynamic_module the dynamic module to use.
  * @param main_thread_dispatcher the main thread dispatcher.
  * @param context the server factory context for accessing cluster manager lazily.
+ * @param stats_store the stats store for accessing metrics.
  * @return an error status if the module could not be loaded or the configuration could not be
  * created, or a shared pointer to the config.
  */
@@ -190,8 +197,8 @@ absl::StatusOr<DynamicModuleBootstrapExtensionConfigSharedPtr>
 newDynamicModuleBootstrapExtensionConfig(
     const absl::string_view extension_name, const absl::string_view extension_config,
     Extensions::DynamicModules::DynamicModulePtr dynamic_module,
-    Event::Dispatcher& main_thread_dispatcher,
-    Server::Configuration::ServerFactoryContext& context);
+    Event::Dispatcher& main_thread_dispatcher, Server::Configuration::ServerFactoryContext& context,
+    Stats::Store& stats_store);
 
 } // namespace DynamicModules
 } // namespace Bootstrap

--- a/source/extensions/bootstrap/dynamic_modules/factory.cc
+++ b/source/extensions/bootstrap/dynamic_modules/factory.cc
@@ -40,7 +40,7 @@ Server::BootstrapExtensionPtr DynamicModuleBootstrapExtensionFactory::createBoot
 
   auto extension_config = newDynamicModuleBootstrapExtensionConfig(
       proto_config.extension_name(), extension_config_str, std::move(dynamic_module.value()),
-      context.mainThreadDispatcher(), context);
+      context.mainThreadDispatcher(), context, context.serverScope().store());
 
   if (!extension_config.ok()) {
     throwEnvoyExceptionOrPanic("Failed to create extension config: " +

--- a/source/extensions/dynamic_modules/abi.h
+++ b/source/extensions/dynamic_modules/abi.h
@@ -5287,6 +5287,109 @@ envoy_dynamic_module_callback_bootstrap_extension_http_callout(
     envoy_dynamic_module_type_module_http_header* headers, size_t headers_size,
     envoy_dynamic_module_type_module_buffer body, uint64_t timeout_milliseconds);
 
+// -------------------- Bootstrap Extension Callbacks - Stats Access --------------------
+
+/**
+ * envoy_dynamic_module_type_stats_iteration_action represents the action to take after each
+ * stat is visited during iteration.
+ */
+typedef enum {
+  // Continue iterating.
+  envoy_dynamic_module_type_stats_iteration_action_Continue = 0,
+  // Stop iterating.
+  envoy_dynamic_module_type_stats_iteration_action_Stop = 1,
+} envoy_dynamic_module_type_stats_iteration_action;
+
+/**
+ * envoy_dynamic_module_callback_bootstrap_extension_get_counter_value is called by the module to
+ * get the current value of a counter by name.
+ *
+ * @param extension_envoy_ptr is the pointer to the DynamicModuleBootstrapExtension object.
+ * @param name is the name of the counter to find.
+ * @param value_ptr is where the value will be stored if the counter is found.
+ * @return true if the counter was found and value_ptr was populated, false otherwise.
+ */
+bool envoy_dynamic_module_callback_bootstrap_extension_get_counter_value(
+    envoy_dynamic_module_type_bootstrap_extension_envoy_ptr extension_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer name, uint64_t* value_ptr);
+
+/**
+ * envoy_dynamic_module_callback_bootstrap_extension_get_gauge_value is called by the module to
+ * get the current value of a gauge by name.
+ *
+ * @param extension_envoy_ptr is the pointer to the DynamicModuleBootstrapExtension object.
+ * @param name is the name of the gauge to find.
+ * @param value_ptr is where the value will be stored if the gauge is found.
+ * @return true if the gauge was found and value_ptr was populated, false otherwise.
+ */
+bool envoy_dynamic_module_callback_bootstrap_extension_get_gauge_value(
+    envoy_dynamic_module_type_bootstrap_extension_envoy_ptr extension_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer name, uint64_t* value_ptr);
+
+/**
+ * envoy_dynamic_module_callback_bootstrap_extension_get_histogram_summary is called by the module
+ * to get the summary statistics of a histogram by name. This returns the cumulative statistics
+ * since the server started.
+ *
+ * @param extension_envoy_ptr is the pointer to the DynamicModuleBootstrapExtension object.
+ * @param name is the name of the histogram to find.
+ * @param sample_count_ptr is where the sample count will be stored if the histogram is found.
+ * @param sample_sum_ptr is where the sample sum will be stored if the histogram is found.
+ * @return true if the histogram was found and the output pointers were populated, false otherwise.
+ */
+bool envoy_dynamic_module_callback_bootstrap_extension_get_histogram_summary(
+    envoy_dynamic_module_type_bootstrap_extension_envoy_ptr extension_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer name, uint64_t* sample_count_ptr,
+    double* sample_sum_ptr);
+
+/**
+ * The callback type for iterating counters.
+ *
+ * @param name is the name of the counter.
+ * @param value is the current value of the counter.
+ * @param user_data is the user data passed to the iterate function.
+ * @return the action to take after visiting this counter.
+ */
+typedef envoy_dynamic_module_type_stats_iteration_action (
+    *envoy_dynamic_module_type_counter_iterator_fn)(envoy_dynamic_module_type_envoy_buffer name,
+                                                    uint64_t value, void* user_data);
+
+/**
+ * envoy_dynamic_module_callback_bootstrap_extension_iterate_counters is called by the module to
+ * iterate over all counters in the stats store.
+ *
+ * @param extension_envoy_ptr is the pointer to the DynamicModuleBootstrapExtension object.
+ * @param iterator_fn is the callback function to call for each counter.
+ * @param user_data is the user data to pass to the callback function.
+ */
+void envoy_dynamic_module_callback_bootstrap_extension_iterate_counters(
+    envoy_dynamic_module_type_bootstrap_extension_envoy_ptr extension_envoy_ptr,
+    envoy_dynamic_module_type_counter_iterator_fn iterator_fn, void* user_data);
+
+/**
+ * The callback type for iterating gauges.
+ *
+ * @param name is the name of the gauge.
+ * @param value is the current value of the gauge.
+ * @param user_data is the user data passed to the iterate function.
+ * @return the action to take after visiting this gauge.
+ */
+typedef envoy_dynamic_module_type_stats_iteration_action (
+    *envoy_dynamic_module_type_gauge_iterator_fn)(envoy_dynamic_module_type_envoy_buffer name,
+                                                  uint64_t value, void* user_data);
+
+/**
+ * envoy_dynamic_module_callback_bootstrap_extension_iterate_gauges is called by the module to
+ * iterate over all gauges in the stats store.
+ *
+ * @param extension_envoy_ptr is the pointer to the DynamicModuleBootstrapExtension object.
+ * @param iterator_fn is the callback function to call for each gauge.
+ * @param user_data is the user data to pass to the callback function.
+ */
+void envoy_dynamic_module_callback_bootstrap_extension_iterate_gauges(
+    envoy_dynamic_module_type_bootstrap_extension_envoy_ptr extension_envoy_ptr,
+    envoy_dynamic_module_type_gauge_iterator_fn iterator_fn, void* user_data);
+
 #ifdef __cplusplus
 }
 #endif

--- a/source/extensions/dynamic_modules/abi_impl.cc
+++ b/source/extensions/dynamic_modules/abi_impl.cc
@@ -87,4 +87,46 @@ envoy_dynamic_module_callback_bootstrap_extension_http_callout(
   return envoy_dynamic_module_type_http_callout_init_result_CannotCreateRequest;
 }
 
+// ---------------------- Bootstrap extension stats access callbacks ------------------------
+// These are weak symbols that provide default stub implementations. The actual implementations
+// are provided in the bootstrap extension abi_impl.cc when the bootstrap extension is used.
+
+__attribute__((weak)) bool envoy_dynamic_module_callback_bootstrap_extension_get_counter_value(
+    envoy_dynamic_module_type_bootstrap_extension_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer, uint64_t*) {
+  IS_ENVOY_BUG("envoy_dynamic_module_callback_bootstrap_extension_get_counter_value: "
+               "not implemented in this context");
+  return false;
+}
+
+__attribute__((weak)) bool envoy_dynamic_module_callback_bootstrap_extension_get_gauge_value(
+    envoy_dynamic_module_type_bootstrap_extension_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer, uint64_t*) {
+  IS_ENVOY_BUG("envoy_dynamic_module_callback_bootstrap_extension_get_gauge_value: "
+               "not implemented in this context");
+  return false;
+}
+
+__attribute__((weak)) bool envoy_dynamic_module_callback_bootstrap_extension_get_histogram_summary(
+    envoy_dynamic_module_type_bootstrap_extension_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer, uint64_t*, double*) {
+  IS_ENVOY_BUG("envoy_dynamic_module_callback_bootstrap_extension_get_histogram_summary: "
+               "not implemented in this context");
+  return false;
+}
+
+__attribute__((weak)) void envoy_dynamic_module_callback_bootstrap_extension_iterate_counters(
+    envoy_dynamic_module_type_bootstrap_extension_envoy_ptr,
+    envoy_dynamic_module_type_counter_iterator_fn, void*) {
+  IS_ENVOY_BUG("envoy_dynamic_module_callback_bootstrap_extension_iterate_counters: "
+               "not implemented in this context");
+}
+
+__attribute__((weak)) void envoy_dynamic_module_callback_bootstrap_extension_iterate_gauges(
+    envoy_dynamic_module_type_bootstrap_extension_envoy_ptr,
+    envoy_dynamic_module_type_gauge_iterator_fn, void*) {
+  IS_ENVOY_BUG("envoy_dynamic_module_callback_bootstrap_extension_iterate_gauges: "
+               "not implemented in this context");
+}
+
 } // extern "C"

--- a/test/extensions/dynamic_modules/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/abi_impl_test.cc
@@ -44,6 +44,65 @@ TEST(CommonAbiImplTest, HttpCalloutEnvoyBug) {
       "not implemented in this context");
 }
 
+// Test that the weak symbol stub for get_counter_value triggers an ENVOY_BUG when called.
+TEST(CommonAbiImplTest, GetCounterValueEnvoyBug) {
+  uint64_t value = 0;
+  envoy_dynamic_module_type_module_buffer name = {"counter_name", 12};
+  EXPECT_ENVOY_BUG(
+      {
+        auto result = envoy_dynamic_module_callback_bootstrap_extension_get_counter_value(
+            nullptr, name, &value);
+        EXPECT_FALSE(result);
+      },
+      "not implemented in this context");
+}
+
+// Test that the weak symbol stub for get_gauge_value triggers an ENVOY_BUG when called.
+TEST(CommonAbiImplTest, GetGaugeValueEnvoyBug) {
+  uint64_t value = 0;
+  envoy_dynamic_module_type_module_buffer name = {"gauge_name", 10};
+  EXPECT_ENVOY_BUG(
+      {
+        auto result = envoy_dynamic_module_callback_bootstrap_extension_get_gauge_value(
+            nullptr, name, &value);
+        EXPECT_FALSE(result);
+      },
+      "not implemented in this context");
+}
+
+// Test that the weak symbol stub for get_histogram_summary triggers an ENVOY_BUG when called.
+TEST(CommonAbiImplTest, GetHistogramSummaryEnvoyBug) {
+  uint64_t sample_count = 0;
+  double sample_sum = 0.0;
+  envoy_dynamic_module_type_module_buffer name = {"histogram_name", 14};
+  EXPECT_ENVOY_BUG(
+      {
+        auto result = envoy_dynamic_module_callback_bootstrap_extension_get_histogram_summary(
+            nullptr, name, &sample_count, &sample_sum);
+        EXPECT_FALSE(result);
+      },
+      "not implemented in this context");
+}
+
+// Test that the weak symbol stub for iterate_counters triggers an ENVOY_BUG when called.
+TEST(CommonAbiImplTest, IterateCountersEnvoyBug) {
+  EXPECT_ENVOY_BUG(
+      {
+        envoy_dynamic_module_callback_bootstrap_extension_iterate_counters(nullptr, nullptr,
+                                                                           nullptr);
+      },
+      "not implemented in this context");
+}
+
+// Test that the weak symbol stub for iterate_gauges triggers an ENVOY_BUG when called.
+TEST(CommonAbiImplTest, IterateGaugesEnvoyBug) {
+  EXPECT_ENVOY_BUG(
+      {
+        envoy_dynamic_module_callback_bootstrap_extension_iterate_gauges(nullptr, nullptr, nullptr);
+      },
+      "not implemented in this context");
+}
+
 } // namespace
 } // namespace DynamicModules
 } // namespace Extensions

--- a/test/extensions/dynamic_modules/bootstrap/BUILD
+++ b/test/extensions/dynamic_modules/bootstrap/BUILD
@@ -25,6 +25,7 @@ envoy_cc_test(
         "//test/extensions/dynamic_modules/test_data/c:bootstrap_no_worker_initialized",
     ],
     deps = [
+        "//source/common/stats:isolated_store_lib",
         "//source/extensions/bootstrap/dynamic_modules:extension_config_lib",
         "//source/extensions/dynamic_modules:dynamic_modules_lib",
         "//test/mocks/event:event_mocks",
@@ -41,8 +42,10 @@ envoy_cc_test(
         "//test/extensions/dynamic_modules/test_data/c:bootstrap_no_op",
     ],
     deps = [
+        "//source/common/stats:isolated_store_lib",
         "//source/extensions/bootstrap/dynamic_modules:abi_impl",
         "//source/extensions/bootstrap/dynamic_modules:extension_config_lib",
+        "//source/extensions/bootstrap/dynamic_modules:extension_lib",
         "//source/extensions/dynamic_modules:dynamic_modules_lib",
         "//test/mocks/event:event_mocks",
         "//test/mocks/http:http_mocks",
@@ -62,6 +65,7 @@ envoy_cc_test(
         "//test/extensions/dynamic_modules/test_data/c:bootstrap_no_op",
     ],
     deps = [
+        "//source/common/stats:isolated_store_lib",
         "//source/extensions/bootstrap/dynamic_modules:extension_lib",
         "//test/mocks/event:event_mocks",
         "//test/mocks/server:factory_context_mocks",
@@ -93,6 +97,7 @@ envoy_cc_test(
         "//test/config/integration/certs",
         "//test/extensions/dynamic_modules/test_data/c:bootstrap_no_op",
         "//test/extensions/dynamic_modules/test_data/rust:bootstrap_integration_test",
+        "//test/extensions/dynamic_modules/test_data/rust:bootstrap_stats_test",
     ],
     deps = [
         "//source/extensions/bootstrap/dynamic_modules:config",

--- a/test/extensions/dynamic_modules/bootstrap/extension_config_test.cc
+++ b/test/extensions/dynamic_modules/bootstrap/extension_config_test.cc
@@ -28,7 +28,7 @@ TEST_F(ExtensionConfigTest, LoadOK) {
   ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
 
   auto config = newDynamicModuleBootstrapExtensionConfig(
-      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_);
+      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
   EXPECT_NE(config.value()->in_module_config_, nullptr);
   EXPECT_NE(config.value()->on_bootstrap_extension_config_destroy_, nullptr);
@@ -46,7 +46,7 @@ TEST_F(ExtensionConfigTest, ConfigNewFail) {
   ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
 
   auto config = newDynamicModuleBootstrapExtensionConfig(
-      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_);
+      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_, context_.store_);
   EXPECT_FALSE(config.ok());
   EXPECT_EQ(config.status().message(), "Failed to initialize dynamic module");
 }
@@ -57,7 +57,7 @@ TEST_F(ExtensionConfigTest, MissingConfigDestroy) {
   ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
 
   auto config = newDynamicModuleBootstrapExtensionConfig(
-      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_);
+      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_, context_.store_);
   EXPECT_FALSE(config.ok());
   EXPECT_THAT(config.status().message(),
               testing::HasSubstr("envoy_dynamic_module_on_bootstrap_extension_config_destroy"));
@@ -69,7 +69,7 @@ TEST_F(ExtensionConfigTest, MissingExtensionNew) {
   ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
 
   auto config = newDynamicModuleBootstrapExtensionConfig(
-      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_);
+      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_, context_.store_);
   EXPECT_FALSE(config.ok());
   EXPECT_THAT(config.status().message(),
               testing::HasSubstr("envoy_dynamic_module_on_bootstrap_extension_new"));
@@ -81,7 +81,7 @@ TEST_F(ExtensionConfigTest, MissingServerInitialized) {
   ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
 
   auto config = newDynamicModuleBootstrapExtensionConfig(
-      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_);
+      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_, context_.store_);
   EXPECT_FALSE(config.ok());
   EXPECT_THAT(config.status().message(),
               testing::HasSubstr("envoy_dynamic_module_on_bootstrap_extension_server_initialized"));
@@ -93,7 +93,7 @@ TEST_F(ExtensionConfigTest, MissingWorkerThreadInitialized) {
   ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
 
   auto config = newDynamicModuleBootstrapExtensionConfig(
-      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_);
+      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_, context_.store_);
   EXPECT_FALSE(config.ok());
   EXPECT_THAT(
       config.status().message(),
@@ -106,7 +106,7 @@ TEST_F(ExtensionConfigTest, MissingExtensionDestroy) {
   ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
 
   auto config = newDynamicModuleBootstrapExtensionConfig(
-      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_);
+      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_, context_.store_);
   EXPECT_FALSE(config.ok());
   EXPECT_THAT(config.status().message(),
               testing::HasSubstr("envoy_dynamic_module_on_bootstrap_extension_destroy"));
@@ -120,7 +120,7 @@ TEST_F(ExtensionConfigTest, MissingConstructor) {
   ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
 
   auto config = newDynamicModuleBootstrapExtensionConfig(
-      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_);
+      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_, context_.store_);
   EXPECT_FALSE(config.ok());
   EXPECT_THAT(config.status().message(),
               testing::HasSubstr("envoy_dynamic_module_on_bootstrap_extension_config_new"));
@@ -134,7 +134,7 @@ TEST_F(ExtensionConfigTest, MissingConfigScheduled) {
   ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
 
   auto config = newDynamicModuleBootstrapExtensionConfig(
-      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_);
+      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_, context_.store_);
   EXPECT_FALSE(config.ok());
   EXPECT_THAT(config.status().message(),
               testing::HasSubstr("envoy_dynamic_module_on_bootstrap_extension_config_scheduled"));
@@ -148,7 +148,7 @@ TEST_F(ExtensionConfigTest, MissingHttpCalloutDone) {
   ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
 
   auto config = newDynamicModuleBootstrapExtensionConfig(
-      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_);
+      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_, context_.store_);
   EXPECT_FALSE(config.ok());
   EXPECT_THAT(config.status().message(),
               testing::HasSubstr("envoy_dynamic_module_on_bootstrap_extension_http_callout_done"));

--- a/test/extensions/dynamic_modules/bootstrap/extension_test.cc
+++ b/test/extensions/dynamic_modules/bootstrap/extension_test.cc
@@ -31,7 +31,7 @@ TEST_F(ExtensionTest, NullInModuleExtension) {
   ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
 
   auto config = newDynamicModuleBootstrapExtensionConfig(
-      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_);
+      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
 
   auto extension = std::make_unique<DynamicModuleBootstrapExtension>(config.value());
@@ -57,7 +57,7 @@ TEST_F(ExtensionTest, IsDestroyedAndGetExtensionConfig) {
   ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
 
   auto config = newDynamicModuleBootstrapExtensionConfig(
-      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_);
+      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
 
   auto extension = std::make_unique<DynamicModuleBootstrapExtension>(config.value());
@@ -83,7 +83,7 @@ TEST_F(ExtensionTest, LifecycleWithValidExtension) {
   ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
 
   auto config = newDynamicModuleBootstrapExtensionConfig(
-      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_);
+      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
 
   auto extension = std::make_unique<DynamicModuleBootstrapExtension>(config.value());

--- a/test/extensions/dynamic_modules/bootstrap/integration_test.cc
+++ b/test/extensions/dynamic_modules/bootstrap/integration_test.cc
@@ -62,6 +62,16 @@ TEST_P(DynamicModulesBootstrapIntegrationTest, BasicRust) {
       initializeWithBootstrapExtension(testDataDir("rust"), "bootstrap_integration_test"));
 }
 
+// This test verifies that the Rust bootstrap extension can access stats from the stats store.
+TEST_P(DynamicModulesBootstrapIntegrationTest, StatsAccessRust) {
+  EXPECT_LOG_CONTAINS_ALL_OF(
+      Envoy::ExpectedLogMessages({{"info", "Correctly returned None for non-existent counter"},
+                                  {"info", "Correctly returned None for non-existent gauge"},
+                                  {"info", "Correctly returned None for non-existent histogram"},
+                                  {"info", "Bootstrap stats access test completed successfully!"}}),
+      initializeWithBootstrapExtension(testDataDir("rust"), "bootstrap_stats_test"));
+}
+
 } // namespace DynamicModules
 } // namespace Bootstrap
 } // namespace Extensions

--- a/test/extensions/dynamic_modules/test_data/rust/BUILD
+++ b/test/extensions/dynamic_modules/test_data/rust/BUILD
@@ -28,4 +28,6 @@ test_program(name = "http_stream_callouts_test")
 
 test_program(name = "bootstrap_integration_test")
 
+test_program(name = "bootstrap_stats_test")
+
 test_program(name = "access_log_integration_test")

--- a/test/extensions/dynamic_modules/test_data/rust/bootstrap_stats_test.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/bootstrap_stats_test.rs
@@ -1,0 +1,95 @@
+//! Test module for Bootstrap extension stats access functionality.
+//!
+//! This module tests the stats access callbacks that allow Bootstrap extensions to read
+//! counter values, gauge values, and histogram summaries from the Envoy stats store.
+
+use envoy_proxy_dynamic_modules_rust_sdk::*;
+
+declare_bootstrap_init_functions!(my_program_init, my_new_bootstrap_extension_config_fn);
+
+fn my_program_init() -> bool {
+  true
+}
+
+fn my_new_bootstrap_extension_config_fn(
+  _envoy_extension_config: &mut dyn EnvoyBootstrapExtensionConfig,
+  _name: &str,
+  _config: &[u8],
+) -> Option<Box<dyn BootstrapExtensionConfig>> {
+  Some(Box::new(StatsTestBootstrapExtensionConfig {}))
+}
+
+struct StatsTestBootstrapExtensionConfig {}
+
+impl BootstrapExtensionConfig for StatsTestBootstrapExtensionConfig {
+  fn new_bootstrap_extension(
+    &self,
+    _envoy_extension: &mut dyn EnvoyBootstrapExtension,
+  ) -> Box<dyn BootstrapExtension> {
+    Box::new(StatsTestBootstrapExtension {})
+  }
+}
+
+struct StatsTestBootstrapExtension {}
+
+impl BootstrapExtension for StatsTestBootstrapExtension {
+  fn on_server_initialized(&mut self, envoy_extension: &mut dyn EnvoyBootstrapExtension) {
+    // Test get_counter_value - looking for a counter that should exist after server init.
+    // The server.live gauge should exist.
+    let live_gauge = envoy_extension.get_gauge_value("server.live");
+    if let Some(value) = live_gauge {
+      envoy_log_info!("Found server.live gauge with value: {}", value);
+    } else {
+      envoy_log_info!("server.live gauge not found (this is expected in some test configs)");
+    }
+
+    // Test iterate_counters - count how many counters exist.
+    let mut counter_count = 0;
+    envoy_extension.iterate_counters(&mut |name, _value| {
+      counter_count += 1;
+      // Log the first few counters for debugging.
+      if counter_count <= 3 {
+        envoy_log_debug!("Counter: {}", name);
+      }
+      true // Continue iteration.
+    });
+    envoy_log_info!("Found {} counters in stats store", counter_count);
+
+    // Test iterate_gauges - count how many gauges exist.
+    let mut gauge_count = 0;
+    envoy_extension.iterate_gauges(&mut |name, _value| {
+      gauge_count += 1;
+      // Log the first few gauges for debugging.
+      if gauge_count <= 3 {
+        envoy_log_debug!("Gauge: {}", name);
+      }
+      true // Continue iteration.
+    });
+    envoy_log_info!("Found {} gauges in stats store", gauge_count);
+
+    // Test get_counter_value with a non-existent counter.
+    let missing = envoy_extension.get_counter_value("non.existent.counter");
+    if missing.is_none() {
+      envoy_log_info!("Correctly returned None for non-existent counter");
+    }
+
+    // Test get_gauge_value with a non-existent gauge.
+    let missing = envoy_extension.get_gauge_value("non.existent.gauge");
+    if missing.is_none() {
+      envoy_log_info!("Correctly returned None for non-existent gauge");
+    }
+
+    // Test get_histogram_summary with a non-existent histogram.
+    let missing = envoy_extension.get_histogram_summary("non.existent.histogram");
+    if missing.is_none() {
+      envoy_log_info!("Correctly returned None for non-existent histogram");
+    }
+
+    envoy_log_info!("Bootstrap stats access test completed successfully!");
+  }
+
+  fn on_worker_thread_initialized(&mut self, _envoy_extension: &mut dyn EnvoyBootstrapExtension) {
+    // Stats access is also available on worker threads.
+    envoy_log_info!("Bootstrap extension worker thread initialized with stats access!");
+  }
+}


### PR DESCRIPTION
## Description

This PR adds stats access APIs to the Bootstrap Extension.

---

**Commit Message:** dynamic_modules: add stats access APIs to Bootstrap Extension
**Additional Description:** Added stats access APIs to the Bootstrap Extension.
**Risk Level:** Low
**Testing:** Added Tests
**Docs Changes:** N/A
**Release Notes:** N/A