### PR TITLE
docs: clean up the ExtProc extension docs and make it consistent

### DIFF
--- a/api/envoy/extensions/http/ext_proc/processing_request_modifiers/mapped_attribute_builder/v3/mapped_attribute_builder.proto
+++ b/api/envoy/extensions/http/ext_proc/processing_request_modifiers/mapped_attribute_builder/v3/mapped_attribute_builder.proto
@@ -16,17 +16,19 @@ option (xds.annotations.v3.file_status).work_in_progress = true;
 // [#protodoc-title: Mapped Attribute Builder for the external processor]
 // [#extension: envoy.http.ext_proc.processing_request_modifiers.mapped_attribute_builder]
 
-// Extension to build custom attributes in the :ref:`request
-// <envoy_v3_api_msg_service.ext_proc.v3.ProcessingRequest>` based on a configurable mapping. The
-// native implementation uses the CEL expression as the key, which is not always desirable. Using this
-// extension, one can re-map a CEL expression that references internal filter state into a more
-// user-friendly key that decouples the value from the underlying filter implementation.
+// Extension to build custom attributes in the
+// :ref:`ProcessingRequest <envoy_v3_api_msg_service.ext_proc.v3.ProcessingRequest>` based on a
+// configurable mapping. The native implementation uses the CEL expression as the key, which is
+// not always desirable. Using this extension, one can re-map a CEL expression that references
+// internal filter state into a more user-friendly key that decouples the value from the underlying
+// filter implementation.
 //
-// If a given CEL expression fails to eval, it will not be present in the attributes struct.
+// If a given CEL expression fails to evaluate, it will not be present in the attributes struct.
 //
-// If this extension is configured, then the original :ref:`ProcessingRequest
-// <envoy_v3_api_msg_service.ext_proc.v3.ProcessingRequest>`'s ``request_attributes`` are ignored,
-// and all attributes should be explicitly set via this extension.
+// If this extension is configured, then the original
+// :ref:`ProcessingRequest <envoy_v3_api_msg_service.ext_proc.v3.ProcessingRequest>`'s
+// ``request_attributes`` are ignored, and all attributes should be explicitly set via this
+// extension.
 //
 // An example configuration may look like so:
 //
@@ -36,8 +38,10 @@ option (xds.annotations.v3.file_status).work_in_progress = true;
 //      "request.path": "request.path"
 //      "source.country": "metadata.filter_metadata['com.example.location_filter']['country_code']"
 //
-// In the above example, the complex filter_metadata expression is evaluated via CEL, and the value
-// is stored under the friendlier ``source.country`` key. ``The ProcessingRequest`` would look like:
+// In the above example, the complex ``filter_metadata`` expression is evaluated via CEL, and the
+// value is stored under the friendlier ``source.country`` key. The
+// :ref:`ProcessingRequest <envoy_v3_api_msg_service.ext_proc.v3.ProcessingRequest>` would look
+// like:
 //
 // .. code-block:: text
 //
@@ -60,21 +64,24 @@ option (xds.annotations.v3.file_status).work_in_progress = true;
 //    }
 //
 // .. note::
-//   Processing request modifiers are currently in alpha.
+//
+//    Processing request modifiers are currently in alpha.
 //
 message MappedAttributeBuilder {
-  // A map of request attributes to set in the attributes struct.
-  // The key is the attribute name, the value is the attribute value,
-  // interpretable by CEL. This allows for the re-mapping of attributes, which is not supported
-  // by the native attribute building logic.
+  // A map of request attributes to set in the
+  // :ref:`attributes <envoy_v3_api_field_service.ext_proc.v3.ProcessingRequest.attributes>` struct.
+  // The key is the attribute name, and the value is the CEL expression to evaluate. This allows
+  // for the re-mapping of attributes, which is not supported by the native attribute building
+  // logic.
   map<string, string> mapped_request_attributes = 1;
 
-  // Similar to ``mapped_request_attributes``, but for response attributes. The
-  // response nomenclature here just indicates that the attributes, whatever they may be, are sent
-  // with a response headers, body, or trailers ext_proc call.
-  // If a value contains a request key, e.g., ``request.host``, then the attribute would
-  // just be sent along in the response. This is useful if a given ext_proc extension is only
-  // enabled for response handling, e.g., ``RESPONSE_HEADERS`` but the backend wants to access request
+  // Similar to ``mapped_request_attributes``, but for response attributes. The "response"
+  // nomenclature here indicates that the attributes, whatever they may be, are sent with a
+  // response headers, body, or trailers ext_proc call.
+  //
+  // If a value contains a request key (e.g., ``request.host``), then the attribute would just be
+  // sent along in the response. This is useful if a given ext_proc extension is only enabled for
+  // response handling (e.g., ``RESPONSE_HEADERS``) but the backend wants to access request
   // metadata.
   map<string, string> mapped_response_attributes = 2;
 }

--- a/api/envoy/extensions/http/ext_proc/response_processors/save_processing_response/v3/save_processing_response.proto
+++ b/api/envoy/extensions/http/ext_proc/response_processors/save_processing_response/v3/save_processing_response.proto
@@ -13,55 +13,69 @@ option go_package = "github.com/envoyproxy/go-control-plane/envoy/extensions/htt
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 option (xds.annotations.v3.file_status).work_in_progress = true;
 
-// [#protodoc-title: Save Processing Response from external processor.]
+// [#protodoc-title: Save Processing Response from external processor]
 // [#extension: envoy.http.ext_proc.response_processors.save_processing_response]
 
-// Extension to save the :ref:`response
-// <envoy_v3_api_msg_service.ext_proc.v3.ProcessingResponse>` from the external processor as
-// filter state with name
-// "envoy.http.ext_proc.response_processors.save_processing_response[.:ref:`filter_state_name_suffix
-// <envoy_v3_api_field_extensions.http.ext_proc.response_processors.save_processing_response.v3.SaveProcessingResponse.filter_state_name>`].
-// This extension supports saving of request and response headers and trailers,
+// Extension to save the
+// :ref:`ProcessingResponse <envoy_v3_api_msg_service.ext_proc.v3.ProcessingResponse>` from the
+// external processor as filter state with name
+// ``envoy.http.ext_proc.response_processors.save_processing_response``. If
+// :ref:`filter_state_name_suffix <envoy_v3_api_field_extensions.http.ext_proc.response_processors.save_processing_response.v3.SaveProcessingResponse.filter_state_name_suffix>`
+// is defined, it is appended to this name.
+//
+// This extension supports saving of request and response headers, request and response trailers,
 // and immediate response.
 //
 // .. note::
-//   Response processors are currently in alpha.
+//
+//    Response processors are currently in alpha.
 //
 // [#next-free-field: 7]
 message SaveProcessingResponse {
+  // Options for saving the processing response.
   message SaveOptions {
-    // Whether or not to save the response for the response type.
+    // When set to ``true``, saves the response for the corresponding response type.
+    //
+    // Defaults to ``false``.
     bool save_response = 1;
 
-    // When true, saves the response if there was an error when processing
-    // the response from the external processor.
+    // When set to ``true``, saves the response if there was an error when processing the response
+    // from the external processor.
+    //
+    // Defaults to ``false``.
     bool save_on_error = 2;
   }
 
   // The default filter state name is
-  // "envoy.http.ext_proc.response_processors.save_processing_response".
-  // If defined, ``filter_state_name_suffix`` is appended to this.
-  // For example, setting ``filter_state_name_suffix`` to "xyz" will set the
-  // filter state name to "envoy.http.ext_proc.response_processors.save_processing_response.xyz"
+  // ``envoy.http.ext_proc.response_processors.save_processing_response``.
+  // If defined, ``filter_state_name_suffix`` is appended to this name.
+  //
+  // For example, setting ``filter_state_name_suffix`` to ``xyz`` will set the filter state name
+  // to ``envoy.http.ext_proc.response_processors.save_processing_response.xyz``.
   string filter_state_name_suffix = 1;
 
-  // Save the response to filter state when :ref:`request_headers
-  // <envoy_v3_api_field_service.ext_proc.v3.ProcessingResponse.request_headers>` is set.
+  // Save the response to filter state when
+  // :ref:`request_headers <envoy_v3_api_field_service.ext_proc.v3.ProcessingResponse.request_headers>`
+  // is set.
   SaveOptions save_request_headers = 2;
 
-  // Save the response to filter state when :ref:`response_headers
-  // <envoy_v3_api_field_service.ext_proc.v3.ProcessingResponse.response_headers>` is set.
+  // Save the response to filter state when
+  // :ref:`response_headers <envoy_v3_api_field_service.ext_proc.v3.ProcessingResponse.response_headers>`
+  // is set.
   SaveOptions save_response_headers = 3;
 
-  // Save the response to filter state when :ref:`request_trailers
-  // <envoy_v3_api_field_service.ext_proc.v3.ProcessingResponse.request_trailers>` is set.
+  // Save the response to filter state when
+  // :ref:`request_trailers <envoy_v3_api_field_service.ext_proc.v3.ProcessingResponse.request_trailers>`
+  // is set.
   SaveOptions save_request_trailers = 4;
 
-  // Save the response to filter state when :ref:`response_trailers
-  // <envoy_v3_api_field_service.ext_proc.v3.ProcessingResponse.response_trailers>` is set.
+  // Save the response to filter state when
+  // :ref:`response_trailers <envoy_v3_api_field_service.ext_proc.v3.ProcessingResponse.response_trailers>`
+  // is set.
   SaveOptions save_response_trailers = 5;
 
-  // Save the response to filter state when :ref:`immediate_response
-  // <envoy_v3_api_field_service.ext_proc.v3.ProcessingResponse.immediate_response>` is set.
+  // Save the response to filter state when
+  // :ref:`immediate_response <envoy_v3_api_field_service.ext_proc.v3.ProcessingResponse.immediate_response>`
+  // is set.
   SaveOptions save_immediate_response = 6;
 }


### PR DESCRIPTION
## Description

This PR cleans up the ExtProc extension docs and make it consistent with rest of the docs.

---

**Commit Message:** docs: clean up the ExtProc extension docs and make it consistent
**Additional Description:** Cleans up the ExtProc extension docs and make it consistent with rest of the docs.
**Risk Level:** N/A
**Testing:** CI
**Docs Changes:** N/A
**Release Notes:** N/A