### PR TITLE
docs: clean up the ExtProc docs and make it consistent

### DIFF
--- a/api/envoy/extensions/filters/http/ext_proc/v3/processing_mode.proto
+++ b/api/envoy/extensions/filters/http/ext_proc/v3/processing_mode.proto
@@ -20,20 +20,20 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#next-free-field: 7]
 message ProcessingMode {
-  // Control how headers and trailers are handled
+  // Control how headers and trailers are handled.
   enum HeaderSendMode {
-    // When used to configure the ext_proc filter :ref:`processing_mode
-    // <envoy_v3_api_field_extensions.filters.http.ext_proc.v3.ExternalProcessor.processing_mode>`,
-    // the default HeaderSendMode depends on which part of the message is being processed. By
+    // When used to configure the ext_proc filter
+    // :ref:`processing_mode <envoy_v3_api_field_extensions.filters.http.ext_proc.v3.ExternalProcessor.processing_mode>`,
+    // the default ``HeaderSendMode`` depends on which part of the message is being processed. By
     // default, request and response headers are sent, while trailers are skipped.
     //
-    // When used in :ref:`mode_override
-    // <envoy_v3_api_field_service.ext_proc.v3.ProcessingResponse.mode_override>` or
-    // :ref:`allowed_override_modes
-    // <envoy_v3_api_field_extensions.filters.http.ext_proc.v3.ExternalProcessor.allowed_override_modes>`,
-    // a value of DEFAULT indicates that there is no change from the behavior that is configured for
-    // the filter in :ref:`processing_mode
-    // <envoy_v3_api_field_extensions.filters.http.ext_proc.v3.ExternalProcessor.processing_mode>`.
+    // When used in
+    // :ref:`mode_override <envoy_v3_api_field_service.ext_proc.v3.ProcessingResponse.mode_override>`
+    // or
+    // :ref:`allowed_override_modes <envoy_v3_api_field_extensions.filters.http.ext_proc.v3.ExternalProcessor.allowed_override_modes>`,
+    // a value of ``DEFAULT`` indicates that there is no change from the behavior that is configured
+    // for the filter in
+    // :ref:`processing_mode <envoy_v3_api_field_extensions.filters.http.ext_proc.v3.ExternalProcessor.processing_mode>`.
     DEFAULT = 0;
 
     // Send the header or trailer.
@@ -43,24 +43,26 @@ message ProcessingMode {
     SKIP = 2;
   }
 
-  // Control how the request and response bodies are handled
-  // When body mutation by external processor is enabled, ext_proc filter will always remove
-  // the content length header in four cases below because content length can not be guaranteed
-  // to be set correctly:
-  // 1) STREAMED BodySendMode: header processing completes before body mutation comes back.
-  // 2) BUFFERED_PARTIAL BodySendMode: body is buffered and could be injected in different phases.
-  // 3) BUFFERED BodySendMode + SKIP HeaderSendMode: header processing (e.g., update content-length) is skipped.
-  // 4) FULL_DUPLEX_STREAMED BodySendMode: header processing completes before body mutation comes back.
+  // Control how the request and response bodies are handled.
   //
-  // In Envoy's http1 codec implementation, removing content length will enable chunked transfer
-  // encoding whenever feasible. The recipient (either client or server) must be able
-  // to parse and decode the chunked transfer coding.
+  // When body mutation by external processor is enabled, ext_proc filter will always remove the
+  // content length header in the following four cases because content length cannot be guaranteed
+  // to be set correctly:
+  //
+  // 1) ``STREAMED`` BodySendMode: header processing completes before body mutation comes back.
+  // 2) ``BUFFERED_PARTIAL`` BodySendMode: body is buffered and could be injected in different phases.
+  // 3) ``BUFFERED`` BodySendMode + ``SKIP`` HeaderSendMode: header processing (e.g., update content-length) is skipped.
+  // 4) ``FULL_DUPLEX_STREAMED`` BodySendMode: header processing completes before body mutation comes back.
+  //
+  // In Envoy's HTTP/1 codec implementation, removing content length will enable chunked transfer
+  // encoding whenever feasible. The recipient (either client or server) must be able to parse and
+  // decode the chunked transfer coding
   // (see `details in RFC9112 <https://tools.ietf.org/html/rfc9112#section-7.1>`_).
   //
-  // In BUFFERED BodySendMode + SEND HeaderSendMode, content length header is allowed but it is
-  // external processor's responsibility to set the content length correctly matched to the length
-  // of mutated body. If they don't match, the corresponding body mutation will be rejected and
-  // local reply will be sent with an error message.
+  // In ``BUFFERED`` BodySendMode + ``SEND`` HeaderSendMode, content length header is allowed but it
+  // is the external processor's responsibility to set the content length correctly matched to the
+  // length of the mutated body. If they don't match, the corresponding body mutation will be
+  // rejected and a local reply will be sent with an error message.
   enum BodySendMode {
     // Do not send the body at all. This is the default.
     NONE = 0;
@@ -80,73 +82,88 @@ message ProcessingMode {
 
     // The ext_proc client (the data plane) streams the body to the server in pieces as they arrive.
     //
-    // 1) The server may choose to buffer any number chunks of data before processing them.
-    // After it finishes buffering, the server processes the buffered data. Then it splits the processed
-    // data into any number of chunks, and streams them back to the ext_proc client one by one.
-    // The server may continuously do so until the complete body is processed.
-    // The individual response chunk size is recommended to be no greater than 64K bytes, or
-    // :ref:`max_receive_message_length <envoy_v3_api_field_config.core.v3.GrpcService.EnvoyGrpc.max_receive_message_length>`
-    // if EnvoyGrpc is used.
+    // 1) The server may choose to buffer any number of chunks of data before processing them.
+    //    After it finishes buffering, the server processes the buffered data. Then it splits the
+    //    processed data into any number of chunks, and streams them back to the ext_proc client one
+    //    by one. The server may continuously do so until the complete body is processed. The
+    //    individual response chunk size is recommended to be no greater than 64K bytes, or
+    //    :ref:`max_receive_message_length <envoy_v3_api_field_config.core.v3.GrpcService.EnvoyGrpc.max_receive_message_length>`
+    //    if EnvoyGrpc is used.
     //
-    // 2) The server may also choose to buffer the entire message, including the headers (if header mode is
-    // ``SEND``), the entire body, and the trailers (if present), before sending back any response.
-    // The server response has to maintain the headers-body-trailers ordering.
+    // 2) The server may also choose to buffer the entire message, including the headers (if header
+    //    mode is ``SEND``), the entire body, and the trailers (if present), before sending back any
+    //    response. The server response has to maintain the headers-body-trailers ordering.
     //
-    // 3) Note that the server might also choose not to buffer data. That is, upon receiving a
-    // body request, it could process the data and send back a body response immediately.
+    // 3) Note that the server might also choose not to buffer data. That is, upon receiving a body
+    //    request, it could process the data and send back a body response immediately.
     //
     // In this body mode:
+    //
     // * The corresponding trailer mode has to be set to ``SEND``.
-    // * The client will send body and trailers (if present) to the server as they arrive.
-    //   Sending the trailers (if present) is to inform the server the complete body arrives.
-    //   In case there are no trailers, then the client will set
+    // * The client will send body and trailers (if present) to the server as they arrive. Sending
+    //   the trailers (if present) is to inform the server that the complete body has arrived. In
+    //   case there are no trailers, then the client will set
     //   :ref:`end_of_stream <envoy_v3_api_field_service.ext_proc.v3.HttpBody.end_of_stream>`
-    //   to true as part of the last body chunk request to notify the server that no other data is to be sent.
+    //   to ``true`` as part of the last body chunk request to notify the server that no other data
+    //   is to be sent.
     // * The server needs to send
     //   :ref:`StreamedBodyResponse <envoy_v3_api_msg_service.ext_proc.v3.StreamedBodyResponse>`
     //   to the client in the body response.
-    // * The client will stream the body chunks in the responses from the server to the upstream/downstream as they arrive.
-
+    // * The client will stream the body chunks in the responses from the server to the
+    //   upstream/downstream as they arrive.
     FULL_DUPLEX_STREAMED = 4;
 
     // [#not-implemented-hide:]
-    // A mode for gRPC traffic. This is similar to ``FULL_DUPLEX_STREAMED``,
-    // except that instead of sending raw chunks of the HTTP/2 DATA frames,
-    // the ext_proc client will de-frame the individual gRPC messages inside
-    // the HTTP/2 DATA frames, and as each message is de-framed, it will be
-    // sent to the ext_proc server as a :ref:`request_body
-    // <envoy_v3_api_field_service.ext_proc.v3.ProcessingRequest.request_body>`
-    // or :ref:`response_body
-    // <envoy_v3_api_field_service.ext_proc.v3.ProcessingRequest.response_body>`.
+    // A mode for gRPC traffic. This is similar to ``FULL_DUPLEX_STREAMED``, except that instead of
+    // sending raw chunks of the HTTP/2 DATA frames, the ext_proc client will de-frame the
+    // individual gRPC messages inside the HTTP/2 DATA frames, and as each message is de-framed, it
+    // will be sent to the ext_proc server as a
+    // :ref:`request_body <envoy_v3_api_field_service.ext_proc.v3.ProcessingRequest.request_body>`
+    // or
+    // :ref:`response_body <envoy_v3_api_field_service.ext_proc.v3.ProcessingRequest.response_body>`.
     // The ext_proc server will stream back individual gRPC messages in the
     // :ref:`StreamedBodyResponse <envoy_v3_api_msg_service.ext_proc.v3.StreamedBodyResponse>`
-    // field, but the number of messages sent by the ext_proc server
-    // does not need to equal the number of messages sent by the data
-    // plane. This allows the ext_proc server to change the number of
-    // messages sent on the stream.
-    // In this mode, the client will send body and trailers to the server as
-    // they arrive.
+    // field, but the number of messages sent by the ext_proc server does not need to equal the
+    // number of messages sent by the data plane. This allows the ext_proc server to change the
+    // number of messages sent on the stream. In this mode, the client will send body and trailers
+    // to the server as they arrive.
     GRPC = 5;
   }
 
-  // How to handle the request header. Default is "SEND".
-  // Note this field is ignored in :ref:`mode_override
-  // <envoy_v3_api_field_service.ext_proc.v3.ProcessingResponse.mode_override>`, since mode
-  // overrides can only affect messages exchanged after the request header is processed.
+  // How to handle the request header.
+  //
+  // .. note::
+  //
+  //    This field is ignored in
+  //    :ref:`mode_override <envoy_v3_api_field_service.ext_proc.v3.ProcessingResponse.mode_override>`,
+  //    since mode overrides can only affect messages exchanged after the request header is
+  //    processed.
+  //
+  // Defaults to ``SEND``.
   HeaderSendMode request_header_mode = 1 [(validate.rules).enum = {defined_only: true}];
 
-  // How to handle the response header. Default is "SEND".
+  // How to handle the response header.
+  //
+  // Defaults to ``SEND``.
   HeaderSendMode response_header_mode = 2 [(validate.rules).enum = {defined_only: true}];
 
-  // How to handle the request body. Default is "NONE".
+  // How to handle the request body.
+  //
+  // Defaults to ``NONE``.
   BodySendMode request_body_mode = 3 [(validate.rules).enum = {defined_only: true}];
 
-  // How do handle the response body. Default is "NONE".
+  // How to handle the response body.
+  //
+  // Defaults to ``NONE``.
   BodySendMode response_body_mode = 4 [(validate.rules).enum = {defined_only: true}];
 
-  // How to handle the request trailers. Default is "SKIP".
+  // How to handle the request trailers.
+  //
+  // Defaults to ``SKIP``.
   HeaderSendMode request_trailer_mode = 5 [(validate.rules).enum = {defined_only: true}];
 
-  // How to handle the response trailers. Default is "SKIP".
+  // How to handle the response trailers.
+  //
+  // Defaults to ``SKIP``.
   HeaderSendMode response_trailer_mode = 6 [(validate.rules).enum = {defined_only: true}];
 }

--- a/api/envoy/service/ext_proc/v3/external_processor.proto
+++ b/api/envoy/service/ext_proc/v3/external_processor.proto
@@ -23,37 +23,31 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: External processing service]
 
-// A service that can access and modify HTTP requests and responses
-// as part of a filter chain.
+// A service that can access and modify HTTP requests and responses as part of a filter chain.
 // The overall external processing protocol works like this:
 //
 // 1. The data plane sends to the service information about the HTTP request.
-// 2. The service sends back a ProcessingResponse message that directs
-//    the data plane to either stop processing, continue without it, or send
-//    it the next chunk of the message body.
-// 3. If so requested, the data plane sends the server the message body in
-//    chunks, or the entire body at once. In either case, the server may send
-//    back a ProcessingResponse for each message it receives, or wait for
-//    a certain amount of body chunks received before streaming back the
-//    ProcessingResponse messages.
-// 4. If so requested, the data plane sends the server the HTTP trailers,
-//    and the server sends back a ProcessingResponse.
-// 5. At this point, request processing is done, and we pick up again
-//    at step 1 when the data plane receives a response from the upstream
-//    server.
-// 6. At any point above, if the server closes the gRPC stream cleanly,
-//    then the data plane proceeds without consulting the server.
-// 7. At any point above, if the server closes the gRPC stream with an error,
-//    then the data plane returns a 500 error to the client, unless the filter
-//    was configured to ignore errors.
+// 2. The service sends back a ``ProcessingResponse`` message that directs the data plane to either
+//    stop processing, continue without it, or send it the next chunk of the message body.
+// 3. If so requested, the data plane sends the server the message body in chunks, or the entire
+//    body at once. In either case, the server may send back a ``ProcessingResponse`` for each
+//    message it receives, or wait for a certain amount of body chunks to be received before
+//    streaming back the ``ProcessingResponse`` messages.
+// 4. If so requested, the data plane sends the server the HTTP trailers, and the server sends back
+//    a ``ProcessingResponse``.
+// 5. At this point, request processing is done, and we pick up again at step 1 when the data plane
+//    receives a response from the upstream server.
+// 6. At any point above, if the server closes the gRPC stream cleanly, then the data plane
+//    proceeds without consulting the server.
+// 7. At any point above, if the server closes the gRPC stream with an error, then the data plane
+//    returns a ``500`` error to the client, unless the filter was configured to ignore errors.
 //
-// In other words, the process is a request/response conversation, but
-// using a gRPC stream to make it easier for the server to
-// maintain state.
+// In other words, the process is a request/response conversation, but using a gRPC stream to make
+// it easier for the server to maintain state.
 service ExternalProcessor {
   // This begins the bidirectional stream that the data plane will use to
   // give the server control over what the filter does. The actual
-  // protocol is described by the ProcessingRequest and ProcessingResponse
+  // protocol is described by the ``ProcessingRequest`` and ``ProcessingResponse``
   // messages below.
   rpc Process(stream ProcessingRequest) returns (stream ProcessingResponse) {
   }
@@ -61,23 +55,25 @@ service ExternalProcessor {
 
 // This message specifies the filter protocol configurations which will be sent to the ext_proc
 // server in a :ref:`ProcessingRequest <envoy_v3_api_msg_service.ext_proc.v3.ProcessingRequest>`.
-// If the server does not support these protocol configurations, it may choose to close the gRPC stream.
-// If the server supports these protocol configurations, it should respond based on the API specifications.
+// If the server does not support these protocol configurations, it may choose to close the gRPC
+// stream. If the server supports these protocol configurations, it should respond based on the
+// API specifications.
 message ProtocolConfiguration {
-  // Specify the filter configuration :ref:`request_body_mode
-  // <envoy_v3_api_field_extensions.filters.http.ext_proc.v3.ProcessingMode.request_body_mode>`
+  // Specifies the filter configuration
+  // :ref:`request_body_mode <envoy_v3_api_field_extensions.filters.http.ext_proc.v3.ProcessingMode.request_body_mode>`.
   envoy.extensions.filters.http.ext_proc.v3.ProcessingMode.BodySendMode request_body_mode = 1
       [(validate.rules).enum = {defined_only: true}];
 
-  // Specify the filter configuration :ref:`response_body_mode
-  // <envoy_v3_api_field_extensions.filters.http.ext_proc.v3.ProcessingMode.response_body_mode>`
+  // Specifies the filter configuration
+  // :ref:`response_body_mode <envoy_v3_api_field_extensions.filters.http.ext_proc.v3.ProcessingMode.response_body_mode>`.
   envoy.extensions.filters.http.ext_proc.v3.ProcessingMode.BodySendMode response_body_mode = 2
       [(validate.rules).enum = {defined_only: true}];
 
-  // Specify the filter configuration :ref:`send_body_without_waiting_for_header_response
-  // <envoy_v3_api_field_extensions.filters.http.ext_proc.v3.ExternalProcessor.send_body_without_waiting_for_header_response>`
-  // If the client is waiting for a header response from the server, setting ``true`` means the client will send body to the server
-  // as they arrive. Setting ``false`` means the client will buffer the arrived data and not send it to the server immediately.
+  // Specifies the filter configuration
+  // :ref:`send_body_without_waiting_for_header_response <envoy_v3_api_field_extensions.filters.http.ext_proc.v3.ExternalProcessor.send_body_without_waiting_for_header_response>`.
+  // If the client is waiting for a header response from the server, setting to ``true`` means the
+  // client will send the body to the server as it arrives. Setting to ``false`` means the client
+  // will buffer the arrived data and not send it to the server immediately.
   bool send_body_without_waiting_for_header_response = 3;
 }
 
@@ -97,31 +93,31 @@ message ProcessingRequest {
 
     // Information about the HTTP request headers, as well as peer info and additional
     // properties. Unless ``observability_mode`` is ``true``, the server must send back a
-    // HeaderResponse message, an ImmediateResponse message, or close the stream.
+    // ``HeaderResponse`` message, an ``ImmediateResponse`` message, or close the stream.
     HttpHeaders request_headers = 2;
 
     // Information about the HTTP response headers, as well as peer info and additional
     // properties. Unless ``observability_mode`` is ``true``, the server must send back a
-    // HeaderResponse message or close the stream.
+    // ``HeaderResponse`` message or close the stream.
     HttpHeaders response_headers = 3;
 
-    // A chunk of the HTTP request body. Unless ``observability_mode`` is true, the server must send back
-    // a BodyResponse message, an ImmediateResponse message, or close the stream.
+    // A chunk of the HTTP request body. Unless ``observability_mode`` is ``true``, the server must
+    // send back a ``BodyResponse`` message, an ``ImmediateResponse`` message, or close the stream.
     HttpBody request_body = 4;
 
-    // A chunk of the HTTP response body. Unless ``observability_mode`` is ``true``, the server must send back
-    // a BodyResponse message or close the stream.
+    // A chunk of the HTTP response body. Unless ``observability_mode`` is ``true``, the server must
+    // send back a ``BodyResponse`` message or close the stream.
     HttpBody response_body = 5;
 
     // The HTTP trailers for the request path. Unless ``observability_mode`` is ``true``, the server
-    // must send back a TrailerResponse message or close the stream.
+    // must send back a ``TrailerResponse`` message or close the stream.
     //
     // This message is only sent if the trailers processing mode is set to ``SEND`` and
     // the original downstream request has trailers.
     HttpTrailers request_trailers = 6;
 
     // The HTTP trailers for the response path. Unless ``observability_mode`` is ``true``, the server
-    // must send back a TrailerResponse message or close the stream.
+    // must send back a ``TrailerResponse`` message or close the stream.
     //
     // This message is only sent if the trailers processing mode is set to ``SEND`` and
     // the original upstream response has trailers.
@@ -137,17 +133,16 @@ message ProcessingRequest {
   // :ref:`attributes <arch_overview_attributes>` supported in the data plane.
   map<string, google.protobuf.Struct> attributes = 9;
 
-  // Specify whether the filter that sent this request is running in :ref:`observability_mode
-  // <envoy_v3_api_field_extensions.filters.http.ext_proc.v3.ExternalProcessor.observability_mode>`
-  // and defaults to false.
+  // Specifies whether the filter that sent this request is running in
+  // :ref:`observability_mode <envoy_v3_api_field_extensions.filters.http.ext_proc.v3.ExternalProcessor.observability_mode>`.
   //
-  // * A value of ``false`` indicates that the server must respond
-  //   to this message by either sending back a matching ProcessingResponse message,
-  //   or by closing the stream.
+  // * A value of ``false`` indicates that the server must respond to this message by either
+  //   sending back a matching ``ProcessingResponse`` message, or by closing the stream.
   // * A value of ``true`` indicates that the server should not respond to this message, as any
-  //   responses will be ignored. However, it may still close the stream to indicate that no more messages
-  //   are needed.
+  //   responses will be ignored. However, it may still close the stream to indicate that no more
+  //   messages are needed.
   //
+  // Defaults to ``false``.
   bool observability_mode = 10;
 
   // Specify the filter protocol configurations to be sent to the server.
@@ -156,14 +151,14 @@ message ProcessingRequest {
 }
 
 // This represents the different types of messages the server may send back to the data plane
-// when the ``observability_mode`` field in the received ProcessingRequest is set to false.
+// when the ``observability_mode`` field in the received ``ProcessingRequest`` is set to ``false``.
 //
 // * If the corresponding ``BodySendMode`` in the
 //   :ref:`processing_mode <envoy_v3_api_field_extensions.filters.http.ext_proc.v3.ExternalProcessor.processing_mode>`
-//   is not set to ``FULL_DUPLEX_STREAMED``, then for every received ProcessingRequest,
-//   the server must send back exactly one ProcessingResponse message.
+//   is not set to ``FULL_DUPLEX_STREAMED``, then for every received ``ProcessingRequest``,
+//   the server must send back exactly one ``ProcessingResponse`` message.
 // * If it is set to ``FULL_DUPLEX_STREAMED``, the server must follow the API defined
-//   for this mode to send the ProcessingResponse messages.
+//   for this mode to send the ``ProcessingResponse`` messages.
 // [#next-free-field: 13]
 message ProcessingResponse {
   // The response type that is sent by the server.
@@ -204,17 +199,19 @@ message ProcessingResponse {
     ImmediateResponse immediate_response = 7;
 
     // The server sends back this message to initiate or continue local response streaming.
-    // The server must initiate local response streaming with the ``headers_response`` in response to a ProcessingRequest
-    // with the ``request_headers`` only.
-    // The server may follow up with multiple messages containing ``body_response``. The server must indicate
-    // end of stream by setting ``end_of_stream`` to ``true`` in the ``headers_response``
+    // The server must initiate local response streaming with the ``headers_response`` in response
+    // to a ``ProcessingRequest`` with the ``request_headers`` only.
+    // The server may follow up with multiple messages containing ``body_response``. The server must
+    // indicate end of stream by setting ``end_of_stream`` to ``true`` in the ``headers_response``
     // or ``body_response`` message or by sending a ``trailers_response`` message.
-    // The client may send a ``request_body`` or ``request_trailers`` to the server depending on configuration.
+    // The client may send a ``request_body`` or ``request_trailers`` to the server depending on
+    // configuration.
     // The streaming local response can only be sent when the ``request_header_mode`` in the filter
     // :ref:`processing_mode <envoy_v3_api_field_extensions.filters.http.ext_proc.v3.ExternalProcessor.processing_mode>`
-    // is set to ``SEND``. The ext_proc server should not send StreamedImmediateResponse if it did not observe request headers,
-    // as it will result in the race with the upstream server response and reset of the client request.
-    // Presently only the FULL_DUPLEX_STREAMED or NONE body modes are supported.
+    // is set to ``SEND``. The ext_proc server should not send ``StreamedImmediateResponse`` if it
+    // did not observe request headers, as it will result in a race with the upstream server
+    // response and reset of the client request.
+    // Presently only the ``FULL_DUPLEX_STREAMED`` or ``NONE`` body modes are supported.
     StreamedImmediateResponse streamed_immediate_response = 11;
   }
 
@@ -223,19 +220,17 @@ message ProcessingResponse {
   // field name(s) of the struct.
   google.protobuf.Struct dynamic_metadata = 8;
 
-  // Override how parts of the HTTP request and response are processed
-  // for the duration of this particular request/response only. Servers
-  // may use this to intelligently control how requests are processed
-  // based on the headers and other metadata that they see.
-  // This field is only applicable when servers responding to the header requests.
-  // If it is set in the response to the body or trailer requests, it will be ignored by the data plane.
+  // Override how parts of the HTTP request and response are processed for the duration of this
+  // particular request/response only. Servers may use this to intelligently control how requests
+  // are processed based on the headers and other metadata that they see.
+  //
+  // This field is only applicable when servers are responding to the header requests. If it is set
+  // in the response to the body or trailer requests, it will be ignored by the data plane.
   // It is also ignored by the data plane when the ext_proc filter config
-  // :ref:`allow_mode_override
-  // <envoy_v3_api_field_extensions.filters.http.ext_proc.v3.ExternalProcessor.allow_mode_override>`
-  // is set to false, or
-  // :ref:`send_body_without_waiting_for_header_response
-  // <envoy_v3_api_field_extensions.filters.http.ext_proc.v3.ExternalProcessor.send_body_without_waiting_for_header_response>`
-  // is set to true.
+  // :ref:`allow_mode_override <envoy_v3_api_field_extensions.filters.http.ext_proc.v3.ExternalProcessor.allow_mode_override>`
+  // is set to ``false``, or
+  // :ref:`send_body_without_waiting_for_header_response <envoy_v3_api_field_extensions.filters.http.ext_proc.v3.ExternalProcessor.send_body_without_waiting_for_header_response>`
+  // is set to ``true``.
   envoy.extensions.filters.http.ext_proc.v3.ProcessingMode mode_override = 9;
 
   // [#not-implemented-hide:]
@@ -251,70 +246,64 @@ message ProcessingResponse {
   // client had already sent before it saw the ext_proc stream termination.
   bool request_drain = 12;
 
-  // When ext_proc server receives a request message, in case it needs more
-  // time to process the message, it sends back a ProcessingResponse message
-  // with a new timeout value. When the data plane receives this response
-  // message, it ignores other fields in the response, just stop the original
-  // timer, which has the timeout value specified in
-  // :ref:`message_timeout
-  // <envoy_v3_api_field_extensions.filters.http.ext_proc.v3.ExternalProcessor.message_timeout>`
-  // and start a new timer with this ``override_message_timeout`` value and keep the
-  // data plane ext_proc filter state machine intact.
-  // Has to be >= 1ms and <=
-  // :ref:`max_message_timeout <envoy_v3_api_field_extensions.filters.http.ext_proc.v3.ExternalProcessor.max_message_timeout>`
-  // Such message can be sent at most once in a particular data plane ext_proc filter processing state.
-  // To enable this API, one has to set ``max_message_timeout`` to a number >= 1ms.
+  // When the ext_proc server receives a request message and needs more time to process it, it
+  // sends back a ``ProcessingResponse`` message with a new timeout value. When the data plane
+  // receives this response message, it ignores other fields in the response, stops the original
+  // timer (which has the timeout value specified in
+  // :ref:`message_timeout <envoy_v3_api_field_extensions.filters.http.ext_proc.v3.ExternalProcessor.message_timeout>`),
+  // and starts a new timer with this ``override_message_timeout`` value while keeping the data
+  // plane ext_proc filter state machine intact.
+  //
+  // The value must be >= 1ms and <=
+  // :ref:`max_message_timeout <envoy_v3_api_field_extensions.filters.http.ext_proc.v3.ExternalProcessor.max_message_timeout>`.
+  // Such a message can be sent at most once in a particular data plane ext_proc filter processing
+  // state. To enable this API, ``max_message_timeout`` must be set to a value >= 1ms.
   google.protobuf.Duration override_message_timeout = 10;
 }
 
 // The following are messages that are sent to the server.
 
-// This message is sent to the external server when the HTTP request and responses
+// This message is sent to the external server when the HTTP request and response headers
 // are first received.
 message HttpHeaders {
-  // The HTTP request headers. All header keys will be
-  // lower-cased, because HTTP header keys are case-insensitive.
-  // The header value is encoded in the
+  // The HTTP request headers. All header keys will be lower-cased, because HTTP header keys are
+  // case-insensitive. The header value is encoded in the
   // :ref:`raw_value <envoy_v3_api_field_config.core.v3.HeaderValue.raw_value>` field.
   config.core.v3.HeaderMap headers = 1;
 
   // [#not-implemented-hide:]
-  // This field is deprecated and not implemented. Attributes will be sent in
-  // the  top-level :ref:`attributes <envoy_v3_api_field_service.ext_proc.v3.ProcessingRequest.attributes`
-  // field.
+  // This field is deprecated and not implemented. Attributes will be sent in the top-level
+  // :ref:`attributes <envoy_v3_api_field_service.ext_proc.v3.ProcessingRequest.attributes>` field.
   map<string, google.protobuf.Struct> attributes = 2
       [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
 
-  // If ``true``, then there is no message body associated with this
-  // request or response.
+  // If ``true``, then there is no message body associated with this request or response.
   bool end_of_stream = 3;
 }
 
-// This message is sent to the external server when the HTTP request and
-// response bodies are received.
+// This message is sent to the external server when the HTTP request and response bodies are
+// received.
 message HttpBody {
-  // The contents of the body in the HTTP request/response. Note that in
-  // streaming mode multiple ``HttpBody`` messages may be sent.
+  // The contents of the body in the HTTP request/response. Note that in streaming mode multiple
+  // ``HttpBody`` messages may be sent.
   //
-  // In ``GRPC`` body send mode, a separate ``HttpBody`` message will be
-  // sent for each message in the gRPC stream.
+  // In ``GRPC`` body send mode, a separate ``HttpBody`` message will be sent for each message in
+  // the gRPC stream.
   bytes body = 1;
 
-  // If ``true``, this will be the last ``HttpBody`` message that will be sent and no
-  // trailers will be sent for the current request/response.
+  // If ``true``, this will be the last ``HttpBody`` message that will be sent and no trailers
+  // will be sent for the current request/response.
   bool end_of_stream = 2;
 
-  // This field is used in ``GRPC`` body send mode when ``end_of_stream`` is
-  // true and ``body`` is empty. Those values would normally indicate an
-  // empty message on the stream with the end-of-stream bit set.
-  // However, if the half-close happens after the last message on the
-  // stream was already sent, then this field will be true to indicate an
-  // end-of-stream with *no* message (as opposed to an empty message).
+  // This field is used in ``GRPC`` body send mode when ``end_of_stream`` is ``true`` and ``body``
+  // is empty. Those values would normally indicate an empty message on the stream with the
+  // end-of-stream bit set. However, if the half-close happens after the last message on the stream
+  // was already sent, then this field will be ``true`` to indicate an end-of-stream with *no*
+  // message (as opposed to an empty message).
   bool end_of_stream_without_message = 3;
 
-  // This field is used in ``GRPC`` body send mode to indicate whether
-  // the message is compressed. This will never be set to true by gRPC
-  // but may be set to true by a proxy like Envoy.
+  // This field is used in ``GRPC`` body send mode to indicate whether the message is compressed.
+  // This will never be set to ``true`` by gRPC but may be set to ``true`` by a proxy like Envoy.
   bool grpc_message_compressed = 4;
 }
 
@@ -352,13 +341,14 @@ message TrailersResponse {
   HeaderMutation header_mutation = 1;
 }
 
-// This message is sent by the external server to the data plane after ``HttpHeaders``
-// to initiate local response streaming. The server may follow up with multiple messages containing ``body_response``.
-// The server must indicate end of stream by setting ``end_of_stream`` to ``true`` in the ``headers_response``
-// or ``body_response`` message or by sending a ``trailers_response`` message.
+// This message is sent by the external server to the data plane after ``HttpHeaders`` to initiate
+// local response streaming. The server may follow up with multiple messages containing
+// ``body_response``. The server must indicate end of stream by setting ``end_of_stream`` to
+// ``true`` in the ``headers_response`` or ``body_response`` message or by sending a
+// ``trailers_response`` message.
 message StreamedImmediateResponse {
   oneof response {
-    // Response headers to be sent downstream. The ":status" header must be set.
+    // Response headers to be sent downstream. The ``:status`` header must be set.
     HttpHeaders headers_response = 1;
 
     // Response body to be sent downstream.
@@ -384,7 +374,7 @@ message CommonResponse {
     // further messages for this request or response even if the processing
     // mode is configured to do so.
     //
-    // When used in response to a request_headers or response_headers message,
+    // When used in response to a ``request_headers`` or ``response_headers`` message,
     // this status makes it possible to either completely replace the body
     // while discarding the original body, or to add a body to a message that
     // formerly did not have one.
@@ -401,23 +391,22 @@ message CommonResponse {
   ResponseStatus status = 1 [(validate.rules).enum = {defined_only: true}];
 
   // Instructions on how to manipulate the headers. When responding to an
-  // HttpBody request, header mutations will only take effect if
-  // the current processing mode for the body is BUFFERED.
+  // ``HttpBody`` request, header mutations will only take effect if the current processing mode
+  // for the body is ``BUFFERED``.
   HeaderMutation header_mutation = 2;
 
-  // Replace the body of the last message sent to the remote server on this
-  // stream. If responding to an HttpBody request, simply replace or clear
-  // the body chunk that was sent with that request. Body mutations may take
-  // effect in response either to ``header`` or ``body`` messages. When it is
-  // in response to ``header`` messages, it only take effect if the
+  // Replace the body of the last message sent to the remote server on this stream. If responding
+  // to an ``HttpBody`` request, simply replace or clear the body chunk that was sent with that
+  // request. Body mutations may take effect in response either to ``header`` or ``body`` messages.
+  // When it is in response to ``header`` messages, it only takes effect if the
   // :ref:`status <envoy_v3_api_field_service.ext_proc.v3.CommonResponse.status>`
-  // is set to CONTINUE_AND_REPLACE.
+  // is set to ``CONTINUE_AND_REPLACE``.
   BodyMutation body_mutation = 3;
 
   // [#not-implemented-hide:]
-  // Add new trailers to the message. This may be used when responding to either a
-  // HttpHeaders or HttpBody message, but only if this message is returned
-  // along with the CONTINUE_AND_REPLACE status.
+  // Add new trailers to the message. This may be used when responding to either an
+  // ``HttpHeaders`` or ``HttpBody`` message, but only if this message is returned
+  // along with the ``CONTINUE_AND_REPLACE`` status.
   // The header value is encoded in the
   // :ref:`raw_value <envoy_v3_api_field_config.core.v3.HeaderValue.raw_value>` field.
   config.core.v3.HeaderMap trailers = 4;
@@ -429,34 +418,32 @@ message CommonResponse {
   bool clear_route_cache = 5;
 }
 
-// This message causes the filter to attempt to create a locally
-// generated response, send it  downstream, stop processing
-// additional filters, and ignore any additional messages received
-// from the remote server for this request or response. If a response
-// has already started, then  this will either ship the reply directly
-// to the downstream codec, or reset the stream.
+// This message causes the filter to attempt to create a locally generated response, send it
+// downstream, stop processing additional filters, and ignore any additional messages received
+// from the remote server for this request or response. If a response has already started, then
+// this will either ship the reply directly to the downstream codec, or reset the stream.
 // [#next-free-field: 6]
 message ImmediateResponse {
   // The response code to return.
   type.v3.HttpStatus status = 1 [(validate.rules).message = {required: true}];
 
-  // Apply changes to the default headers, which will include content-type.
+  // Apply changes to the default headers, which will include ``content-type``.
   HeaderMutation headers = 2;
 
   // The message body to return with the response which is sent using the
-  // text/plain content type, or encoded in the grpc-message header.
+  // ``text/plain`` content type, or encoded in the ``grpc-message`` header.
   bytes body = 3;
 
   // If set, then include a gRPC status trailer.
   GrpcStatus grpc_status = 4;
 
   // A string detailing why this local reply was sent, which may be included
-  // in log and debug output (e.g. this populates the %RESPONSE_CODE_DETAILS%
+  // in log and debug output (e.g., this populates the ``%RESPONSE_CODE_DETAILS%``
   // command operator field for use in access logging).
   string details = 5;
 }
 
-// This message specifies a gRPC status for an ImmediateResponse message.
+// This message specifies a gRPC status for an ``ImmediateResponse`` message.
 message GrpcStatus {
   // The actual gRPC status.
   uint32 status = 1;
@@ -484,26 +471,24 @@ message StreamedBodyResponse {
   // a serialized gRPC message to be passed to the upstream/downstream by the data plane.
   bytes body = 1;
 
-  // The server sets this flag to true if it has received a body request with
-  // :ref:`end_of_stream <envoy_v3_api_field_service.ext_proc.v3.HttpBody.end_of_stream>` set to true,
-  // and this is the last chunk of body responses.
-  // Note that in ``GRPC`` body send mode, this allows the ext_proc
-  // server to tell the data plane to send a half close after a client
-  // message, which will result in discarding any other messages sent by
-  // the client application.
+  // The server sets this flag to ``true`` if it has received a body request with
+  // :ref:`end_of_stream <envoy_v3_api_field_service.ext_proc.v3.HttpBody.end_of_stream>` set to
+  // ``true``, and this is the last chunk of body responses.
+  //
+  // Note that in ``GRPC`` body send mode, this allows the ext_proc server to tell the data plane
+  // to send a half close after a client message, which will result in discarding any other
+  // messages sent by the client application.
   bool end_of_stream = 2;
 
-  // This field is used in ``GRPC`` body send mode when ``end_of_stream`` is
-  // true and ``body`` is empty. Those values would normally indicate an
-  // empty message on the stream with the end-of-stream bit set.
-  // However, if the half-close happens after the last message on the
-  // stream was already sent, then this field will be true to indicate an
-  // end-of-stream with *no* message (as opposed to an empty message).
+  // This field is used in ``GRPC`` body send mode when ``end_of_stream`` is ``true`` and ``body``
+  // is empty. Those values would normally indicate an empty message on the stream with the
+  // end-of-stream bit set. However, if the half-close happens after the last message on the stream
+  // was already sent, then this field will be ``true`` to indicate an end-of-stream with *no*
+  // message (as opposed to an empty message).
   bool end_of_stream_without_message = 3;
 
-  // This field is used in ``GRPC`` body send mode to indicate whether
-  // the message is compressed. This will never be set to true by gRPC
-  // but may be set to true by a proxy like Envoy.
+  // This field is used in ``GRPC`` body send mode to indicate whether the message is compressed.
+  // This will never be set to ``true`` by gRPC but may be set to ``true`` by a proxy like Envoy.
   bool grpc_message_compressed = 4;
 }
 
@@ -517,11 +502,10 @@ message BodyMutation {
     // is not set to ``FULL_DUPLEX_STREAMED`` or ``GRPC``.
     bytes body = 1;
 
-    // Clear the corresponding body chunk.
-    // Should only be used when the corresponding ``BodySendMode`` in the
+    // Clear the corresponding body chunk. Should only be used when the corresponding
+    // ``BodySendMode`` in the
     // :ref:`processing_mode <envoy_v3_api_field_extensions.filters.http.ext_proc.v3.ExternalProcessor.processing_mode>`
     // is not set to ``FULL_DUPLEX_STREAMED`` or ``GRPC``.
-    // Clear the corresponding body chunk.
     bool clear_body = 2;
 
     // Must be used when the corresponding ``BodySendMode`` in the


### PR DESCRIPTION
## Description

This PR cleans up the ExtProc docs and make it consistent with rest of the docs.

---

**Commit Message:** docs: clean up the ExtProc docs and make it consistent
**Additional Description:** Cleans up the ExtProc docs and make it consistent with rest of the docs.
**Risk Level:** N/A
**Testing:** CI
**Docs Changes:** N/A
**Release Notes:** N/A