### PR TITLE
dynamic_modules: add cluster info support to HTTP filter ABI 

### DIFF
--- a/source/extensions/dynamic_modules/abi.h
+++ b/source/extensions/dynamic_modules/abi.h
@@ -2170,6 +2170,57 @@ envoy_dynamic_module_type_child_span_module_ptr envoy_dynamic_module_callback_ht
 void envoy_dynamic_module_callback_http_child_span_finish(
     envoy_dynamic_module_type_child_span_module_ptr span);
 
+// ------------------- Cluster/Upstream Information Callbacks -------------------------
+
+/**
+ * envoy_dynamic_module_callback_http_get_cluster_name retrieves the name of the cluster that the
+ * current request is routed to. This is useful for making routing decisions or for logging.
+ *
+ * @param filter_envoy_ptr is the pointer to the DynamicModuleHttpFilter object.
+ * @param result is the pointer to store the cluster name. The buffer is owned by Envoy and is
+ * valid until the end of the current event hook or until the route changes.
+ * @return true if the cluster name was retrieved successfully, false otherwise (e.g., no route
+ * selected yet).
+ */
+bool envoy_dynamic_module_callback_http_get_cluster_name(
+    envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr,
+    envoy_dynamic_module_type_envoy_buffer* result);
+
+/**
+ * envoy_dynamic_module_callback_http_get_cluster_host_count retrieves the host counts for the
+ * cluster that the current request is routed to. This provides visibility into the cluster's
+ * health state and can be used to implement scale-to-zero logic or custom load balancing decisions.
+ *
+ * @param filter_envoy_ptr is the pointer to the DynamicModuleHttpFilter object.
+ * @param priority is the priority level to query (0 for default priority).
+ * @param total_count is the pointer to store the total number of hosts. Can be null if not needed.
+ * @param healthy_count is the pointer to store the number of healthy hosts. Can be null if not
+ * needed.
+ * @param degraded_count is the pointer to store the number of degraded hosts. Can be null if not
+ * needed.
+ * @return true if the counts were retrieved successfully, false otherwise (e.g., no cluster
+ * available).
+ */
+bool envoy_dynamic_module_callback_http_get_cluster_host_count(
+    envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr, uint32_t priority,
+    size_t* total_count, size_t* healthy_count, size_t* degraded_count);
+
+/**
+ * envoy_dynamic_module_callback_http_set_upstream_override_host sets the override host to be used
+ * by the upstream load balancer. If the target host exists in the host list of the routed cluster,
+ * this host should be selected first. This is useful for implementing sticky sessions, host
+ * affinity, or custom load balancing logic.
+ *
+ * @param filter_envoy_ptr is the pointer to the DynamicModuleHttpFilter object.
+ * @param host is the host address to override (e.g., "10.0.0.1:8080"). Must be a valid IP address.
+ * @param strict if true, the request will fail if the override host is not available. If false,
+ * normal load balancing will be used as a fallback.
+ * @return true if the override host was set successfully, false if the host address is invalid.
+ */
+bool envoy_dynamic_module_callback_http_set_upstream_override_host(
+    envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer host, bool strict);
+
 // =============================================================================
 // ============================= Network Filter ================================
 // =============================================================================

--- a/source/extensions/filters/http/dynamic_modules/filter.h
+++ b/source/extensions/filters/http/dynamic_modules/filter.h
@@ -216,6 +216,7 @@ public:
    */
   bool sendStreamTrailers(uint64_t stream_id, Http::RequestTrailerMapPtr trailers);
 
+  bool hasConfig() const { return config_ != nullptr; }
   const DynamicModuleHttpFilterConfig& getFilterConfig() const { return *config_; }
   Stats::StatNameDynamicPool& getStatNamePool() { return stat_name_pool_; }
 

--- a/test/extensions/dynamic_modules/http/BUILD
+++ b/test/extensions/dynamic_modules/http/BUILD
@@ -64,16 +64,25 @@ envoy_cc_test(
 envoy_cc_test(
     name = "abi_impl_test",
     srcs = ["abi_impl_test.cc"],
+    data = [
+        "//test/extensions/dynamic_modules/test_data/c:no_op",
+    ],
     # http_mocks needs this.
     rbe_pool = "6gig",
     deps = [
         "//source/extensions/filters/http/dynamic_modules:abi_impl",
+        "//source/extensions/filters/http/dynamic_modules:filter_lib",
         "//test/common/stats:stat_test_utility_lib",
+        "//test/extensions/dynamic_modules:util",
         "//test/mocks/http:http_mocks",
         "//test/mocks/network:network_mocks",
         "//test/mocks/server:server_factory_context_mocks",
         "//test/mocks/ssl:ssl_mocks",
         "//test/mocks/tracing:tracing_mocks",
+        "//test/mocks/upstream:cluster_manager_mocks",
+        "//test/mocks/upstream:host_set_mocks",
+        "//test/mocks/upstream:priority_set_mocks",
+        "//test/mocks/upstream:thread_local_cluster_mocks",
     ],
 )
 


### PR DESCRIPTION
## Description

This PR adds support for cluster info in HTTP Dynamic Modules.

---

**Commit Message:** dynamic_modules: add cluster info support to HTTP filter ABI
**Additional Description:** Added support for cluster info in HTTP Dynamic Modules.
**Risk Level:** Low
**Testing:** Added Unit + Integration Tests
**Docs Changes:** Added
**Release Notes:** N/A