### PR TITLE
mcp: added support for prompts/* MCP methods

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -48,6 +48,9 @@ new_features:
   change: |
     Added support for MCP resource methods ``resources/list``, ``resources/read``,
     ``resources/subscribe``, and ``resources/unsubscribe``.
+- area: mcp_router
+  change: |
+    Added support for MCP prompt methods ``prompts/list`` and ``prompts/get``.
 - area: formatter
   change: |
     Extended ``*_WITHOUT_PORT`` address formatters to accept an optional ``MASK_PREFIX_LEN`` parameter that masks IP addresses

--- a/source/extensions/filters/http/mcp/mcp_json_parser.cc
+++ b/source/extensions/filters/http/mcp/mcp_json_parser.cc
@@ -32,7 +32,8 @@ void McpParserConfig::initializeDefaults() {
   addMethodConfig(Methods::RESOURCES_SUBSCRIBE, {AttributeExtractionRule("params.uri")});
   addMethodConfig(Methods::RESOURCES_UNSUBSCRIBE, {AttributeExtractionRule("params.uri")});
 
-  // Prompts
+  // Prompts.
+  addMethodConfig(Methods::PROMPTS_LIST, {});
   addMethodConfig(Methods::PROMPTS_GET, {AttributeExtractionRule("params.name")});
 
   // Completion

--- a/source/extensions/filters/http/mcp_router/mcp_router.h
+++ b/source/extensions/filters/http/mcp_router/mcp_router.h
@@ -36,6 +36,8 @@ enum class McpMethod {
   ResourcesRead,
   ResourcesSubscribe,
   ResourcesUnsubscribe,
+  PromptsList,
+  PromptsGet,
   Ping,
   NotificationInitialized,
 };
@@ -110,10 +112,13 @@ private:
 
   std::pair<std::string, std::string> parseToolName(const std::string& prefixed_name);
   std::pair<std::string, std::string> parseResourceUri(const std::string& uri);
+  std::pair<std::string, std::string> parsePromptName(const std::string& prefixed_name);
   // Rewrites the tool name in the buffer. Returns the size delta (new_size - old_size).
   ssize_t rewriteToolCallBody(Buffer::Instance& buffer);
   // Rewrites the resource URI in the buffer. Returns the size delta (new_size - old_size).
   ssize_t rewriteResourceUriBody(Buffer::Instance& buffer);
+  // Rewrites the prompt name in the buffer. Returns the size delta (new_size - old_size).
+  ssize_t rewritePromptsGetBody(Buffer::Instance& buffer);
   // Helper to replace content at a position in the buffer, and return the delta.
   ssize_t rewriteAtPosition(Buffer::Instance& buffer, ssize_t pos, const std::string& search_str,
                             const std::string& replacement);
@@ -128,6 +133,8 @@ private:
   void handleResourcesRead();
   void handleResourcesSubscribe();
   void handleResourcesUnsubscribe();
+  void handlePromptsList();
+  void handlePromptsGet();
   void handlePing();
   void handleNotificationInitialized();
 
@@ -135,6 +142,7 @@ private:
   std::string aggregateInitialize(const std::vector<BackendResponse>& responses);
   std::string aggregateToolsList(const std::vector<BackendResponse>& responses);
   std::string aggregateResourcesList(const std::vector<BackendResponse>& responses);
+  std::string aggregatePromptsList(const std::vector<BackendResponse>& responses);
 
   // Initialize fanout connections.
   void initializeFanout(AggregationCallback callback);
@@ -165,7 +173,9 @@ private:
   std::string unprefixed_tool_name_; // Unprefixed tool name for backend (e.g., "get_current_time")
   std::string resource_uri_;         // Original resource URI (e.g., "time://path/to/resource")
   std::string rewritten_uri_;        // Rewritten URI for backend (e.g., "file://path/to/resource")
-  bool needs_body_rewrite_{false};   // Whether tool name or URI rewriting is needed
+  std::string prompt_name_;          // Original prefixed prompt name (e.g., "time__greeting")
+  std::string unprefixed_prompt_name_; // Unprefixed prompt name for backend (e.g., "greeting")
+  bool needs_body_rewrite_{false};     // Whether tool/prompt name or URI rewriting is needed
 
   std::string route_name_{"default"};
   std::string session_subject_;

--- a/test/extensions/filters/http/mcp/mcp_json_parser_test.cc
+++ b/test/extensions/filters/http/mcp/mcp_json_parser_test.cc
@@ -165,6 +165,19 @@ TEST_F(McpJsonParserTest, ResourcesUnsubscribeExtraction) {
   EXPECT_EQ(value->string_value(), "file:///config/settings.json");
 }
 
+TEST_F(McpJsonParserTest, PromptsListExtraction) {
+  std::string json = R"({
+    "jsonrpc": "2.0",
+    "method": "prompts/list",
+    "id": 200
+  })";
+
+  EXPECT_OK(parser_->parse(json));
+
+  EXPECT_TRUE(parser_->isValidMcpRequest());
+  EXPECT_EQ(parser_->getMethod(), McpConstants::Methods::PROMPTS_LIST);
+}
+
 TEST_F(McpJsonParserTest, PromptsGetExtraction) {
   std::string json = R"({
     "jsonrpc": "2.0",

--- a/test/extensions/filters/http/mcp_router/mcp_router_integration_test.cc
+++ b/test/extensions/filters/http/mcp_router/mcp_router_integration_test.cc
@@ -896,6 +896,161 @@ TEST_P(McpRouterIntegrationTest, ResourcesReadWithUnknownBackendReturns400) {
   EXPECT_EQ("400", response->headers().getStatusValue());
 }
 
+// Test prompts/list request fans out to both backends and aggregates prompts.
+TEST_P(McpRouterIntegrationTest, PromptsListFanoutAggregation) {
+  initializeFilter();
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+
+  const std::string request_body = R"({
+    "jsonrpc": "2.0",
+    "method": "prompts/list",
+    "id": 30
+  })";
+
+  auto response = codec_client_->makeRequestWithBody(
+      Http::TestRequestHeaderMapImpl{{":method", "POST"},
+                                     {":path", "/mcp"},
+                                     {":scheme", "http"},
+                                     {":authority", "host"},
+                                     {"accept", "application/json"},
+                                     {"accept", "text/event-stream"},
+                                     {"content-type", "application/json"}},
+      request_body);
+
+  ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, time_backend_connection_));
+  ASSERT_TRUE(time_backend_connection_->waitForNewStream(*dispatcher_, time_backend_request_));
+  ASSERT_TRUE(time_backend_request_->waitForEndStream(*dispatcher_));
+
+  ASSERT_TRUE(fake_upstreams_[1]->waitForHttpConnection(*dispatcher_, tools_backend_connection_));
+  ASSERT_TRUE(tools_backend_connection_->waitForNewStream(*dispatcher_, tools_backend_request_));
+  ASSERT_TRUE(tools_backend_request_->waitForEndStream(*dispatcher_));
+
+  // Time backend returns a prompt.
+  const std::string time_response = R"({
+    "jsonrpc": "2.0",
+    "id": 30,
+    "result": {
+      "prompts": [
+        {"name": "greeting", "description": "A friendly greeting prompt"}
+      ]
+    }
+  })";
+  time_backend_request_->encodeHeaders(
+      Http::TestResponseHeaderMapImpl{{":status", "200"}, {"content-type", "application/json"}},
+      false);
+  Buffer::OwnedImpl time_body(time_response);
+  time_backend_request_->encodeData(time_body, true);
+
+  // Tools backend returns prompts.
+  const std::string tools_response = R"({
+    "jsonrpc": "2.0",
+    "id": 30,
+    "result": {
+      "prompts": [
+        {"name": "code_review", "description": "Review code for issues"},
+        {"name": "summarize", "description": "Summarize text", "arguments": [{"name": "text", "required": true}]}
+      ]
+    }
+  })";
+  tools_backend_request_->encodeHeaders(
+      Http::TestResponseHeaderMapImpl{{":status", "200"}, {"content-type", "application/json"}},
+      false);
+  Buffer::OwnedImpl tools_body(tools_response);
+  tools_backend_request_->encodeData(tools_body, true);
+
+  ASSERT_TRUE(response->waitForEndStream());
+  EXPECT_EQ("200", response->headers().getStatusValue());
+
+  // Verify the aggregated response contains prompts from both backends with name prefixes.
+  EXPECT_THAT(response->body(), testing::HasSubstr("time__greeting"));
+  EXPECT_THAT(response->body(), testing::HasSubstr("tools__code_review"));
+  EXPECT_THAT(response->body(), testing::HasSubstr("tools__summarize"));
+}
+
+// Test prompts/get routes to correct backend based on name prefix.
+TEST_P(McpRouterIntegrationTest, PromptsGetRoutesToCorrectBackend) {
+  initializeFilter();
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+
+  const std::string request_body = R"({
+    "jsonrpc": "2.0",
+    "method": "prompts/get",
+    "id": 31,
+    "params": {
+      "name": "time__greeting"
+    }
+  })";
+
+  auto response = codec_client_->makeRequestWithBody(
+      Http::TestRequestHeaderMapImpl{{":method", "POST"},
+                                     {":path", "/mcp"},
+                                     {":scheme", "http"},
+                                     {":authority", "host"},
+                                     {"accept", "application/json"},
+                                     {"accept", "text/event-stream"},
+                                     {"content-type", "application/json"}},
+      request_body);
+
+  // Request should be routed to time backend based on "time__" prefix.
+  ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, time_backend_connection_));
+  ASSERT_TRUE(time_backend_connection_->waitForNewStream(*dispatcher_, time_backend_request_));
+  ASSERT_TRUE(time_backend_request_->waitForEndStream(*dispatcher_));
+
+  // Verify upstream request body has prompt name rewritten (prefix stripped).
+  EXPECT_THAT(time_backend_request_->body().toString(), testing::HasSubstr("\"greeting\""));
+  EXPECT_THAT(time_backend_request_->body().toString(), testing::Not(testing::HasSubstr("time__")));
+
+  const std::string backend_response = R"({
+    "jsonrpc": "2.0",
+    "id": 31,
+    "result": {
+      "description": "A friendly greeting prompt",
+      "messages": [{"role": "user", "content": {"type": "text", "text": "Hello!"}}]
+    }
+  })";
+  time_backend_request_->encodeHeaders(
+      Http::TestResponseHeaderMapImpl{{":status", "200"}, {"content-type", "application/json"}},
+      false);
+  Buffer::OwnedImpl response_body(backend_response);
+  time_backend_request_->encodeData(response_body, true);
+
+  ASSERT_TRUE(response->waitForEndStream());
+  EXPECT_EQ("200", response->headers().getStatusValue());
+  EXPECT_THAT(response->body(), testing::HasSubstr("A friendly greeting prompt"));
+}
+
+// Test prompts/get with unknown backend prefix returns 400.
+TEST_P(McpRouterIntegrationTest, PromptsGetWithUnknownBackendReturns400) {
+  initializeFilter();
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+
+  const std::string request_body = R"({
+    "jsonrpc": "2.0",
+    "method": "prompts/get",
+    "id": 32,
+    "params": {
+      "name": "unknown__some_prompt"
+    }
+  })";
+
+  auto response = codec_client_->makeRequestWithBody(
+      Http::TestRequestHeaderMapImpl{{":method", "POST"},
+                                     {":path", "/mcp"},
+                                     {":scheme", "http"},
+                                     {":authority", "host"},
+                                     {"accept", "application/json"},
+                                     {"accept", "text/event-stream"},
+                                     {"content-type", "application/json"}},
+      request_body);
+
+  // Unknown backend prefix should return 400 Bad Request.
+  ASSERT_TRUE(response->waitForEndStream());
+  EXPECT_EQ("400", response->headers().getStatusValue());
+}
+
 class McpRouterSubjectValidationIntegrationTest : public McpRouterIntegrationTest {
 public:
   void initializeFilterWithSubjectValidation() {

--- a/test/extensions/filters/http/mcp_router/mcp_router_test.cc
+++ b/test/extensions/filters/http/mcp_router/mcp_router_test.cc
@@ -28,6 +28,8 @@ TEST(ParseMethodStringTest, AllMethods) {
   EXPECT_EQ(parseMethodString("resources/read"), McpMethod::ResourcesRead);
   EXPECT_EQ(parseMethodString("resources/subscribe"), McpMethod::ResourcesSubscribe);
   EXPECT_EQ(parseMethodString("resources/unsubscribe"), McpMethod::ResourcesUnsubscribe);
+  EXPECT_EQ(parseMethodString("prompts/list"), McpMethod::PromptsList);
+  EXPECT_EQ(parseMethodString("prompts/get"), McpMethod::PromptsGet);
   EXPECT_EQ(parseMethodString("ping"), McpMethod::Ping);
   EXPECT_EQ(parseMethodString("notifications/initialized"), McpMethod::NotificationInitialized);
   EXPECT_EQ(parseMethodString("unknown_method"), McpMethod::Unknown);


### PR DESCRIPTION
## Description

This PR adds support for MCP resource methods including `prompts/list` and `prompts/get`.

---

**Commit Message:** mcp: added support for prompts/* MCP methods
**Additional Description:** Added support for MCP resource methods including `prompts/list` and `prompts/get`.
**Risk Level:** Low
**Testing:** Added Unit + Integration Tests
**Docs Changes:** Added
**Release Notes:** Added

#39174 