### PR TITLE
coverage: adjust the LCOV numbers to reflect current state

### DIFF
--- a/test/coverage.yaml
+++ b/test/coverage.yaml
@@ -22,12 +22,10 @@ directories:
   source/common/tls: 94.5  # FIPS code paths impossible to trigger on non-FIPS builds and vice versa
   source/common/tls/cert_validator: 95.0
   source/common/tls/private_key: 88.9
-  source/common/tracing: 95.9
   source/common/watchdog: 60.0  # Death tests don't report LCOV
   source/exe: 94.4  # increased by #32346, need coverage for terminate_handler and hot restart failures
   source/extensions/api_listeners: 55.0  # Many IS_ENVOY_BUG are not covered.
   source/extensions/api_listeners/default_api_listener: 67.8  # Many IS_ENVOY_BUG are not covered.
-  source/extensions/access_loggers/open_telemetry: 96.4  # Serialization failure path is untestable
   source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface: 96.3
   source/extensions/common/aws: 98.5
   source/extensions/common/aws/credential_providers: 100.0


### PR DESCRIPTION
## Description

This PR adjusts the LCOV numbers to reflect the current state as both these extensions now have good coverage and could be removed from the exception list:
```
source/common/tracing: 97.9% (current threshold: 95.9%)
source/extensions/access_loggers/open_telemetry: 98.9% (current threshold: 96.4%)
```

---

**Commit Message:** coverage: adjust the LCOV numbers to reflect current state
**Additional Description:** Adjusts the LCOV numbers to reflect the current state
**Risk Level:** N/A
**Testing:** CI
**Docs Changes:** N/A
**Release Notes:** N/A