### PR TITLE
proto: add kae-private-key-provider proto max_instances config

### DIFF
--- a/api/contrib/envoy/extensions/private_key_providers/kae/v3alpha/kae.proto
+++ b/api/contrib/envoy/extensions/private_key_providers/kae/v3alpha/kae.proto
@@ -5,6 +5,7 @@ package envoy.extensions.private_key_providers.kae.v3alpha;
 import "envoy/config/core/v3/base.proto";
 
 import "google/protobuf/duration.proto";
+import "google/protobuf/wrappers.proto";
 
 import "udpa/annotations/sensitive.proto";
 import "udpa/annotations/status.proto";
@@ -37,4 +38,9 @@ message KaePrivateKeyMethodConfig {
     required: true
     gte {nanos: 1000000}
   }];
+
+  // The number of instances to start during initialization.
+  // Too many instances may create a large number of threads, increasing resource usage and potential overhead.
+  // max_instances must be at least 1.
+  google.protobuf.UInt32Value max_instances = 3 [(validate.rules).uint32 = {gte: 1}];
 }

--- a/contrib/kae/private_key_providers/source/kae.cc
+++ b/contrib/kae/private_key_providers/source/kae.cc
@@ -211,12 +211,16 @@ bool KaeHandle::isDone() { return done_; }
 // KAE Section
 KaeSection::KaeSection(LibUadkCryptoSharedPtr libuadk) : libuadk_(libuadk) {};
 
-bool KaeSection::startSection(Api::Api& api, std::chrono::milliseconds poll_delay) {
+bool KaeSection::startSection(Api::Api& api, std::chrono::milliseconds poll_delay,
+                              uint32_t max_instances) {
   int ret = libuadk_->kaeGetNumInstances(&num_instances_);
   ENVOY_LOG(info, "found {} KAE instances", num_instances_);
   if (ret != WD_SUCCESS) {
     return false;
   }
+
+  num_instances_ = std::min(num_instances_, max_instances);
+  ENVOY_LOG(info, "use {} KAE instances", num_instances_);
 
   kae_handles_ = std::vector<KaeHandle>(num_instances_);
 

--- a/contrib/kae/private_key_providers/source/kae.h
+++ b/contrib/kae/private_key_providers/source/kae.h
@@ -74,7 +74,7 @@ private:
 class KaeSection : public Logger::Loggable<Logger::Id::connection> {
 public:
   KaeSection(LibUadkCryptoSharedPtr libuadk);
-  bool startSection(Api::Api& api, std::chrono::milliseconds poll_delay);
+  bool startSection(Api::Api& api, std::chrono::milliseconds poll_delay, uint32_t max_instances);
   KaeHandle& getNextHandle();
   bool isInitialized();
 

--- a/contrib/kae/private_key_providers/source/kae_private_key_provider.cc
+++ b/contrib/kae/private_key_providers/source/kae_private_key_provider.cc
@@ -359,6 +359,8 @@ KaePrivateKeyMethodProvider::KaePrivateKeyMethodProvider(
   std::string private_key =
       THROW_OR_RETURN_VALUE(Config::DataSource::read(conf.private_key(), false, api_), std::string);
 
+  const uint32_t max_instances = PROTOBUF_GET_WRAPPED_OR_DEFAULT(conf, max_instances, 16);
+
   bssl::UniquePtr<BIO> bio(
       BIO_new_mem_buf(const_cast<char*>(private_key.data()), private_key.size()));
 
@@ -374,7 +376,7 @@ KaePrivateKeyMethodProvider::KaePrivateKeyMethodProvider(
   pkey_ = std::move(pkey);
 
   section_ = std::make_shared<KaeSection>(libuadk);
-  if (!section_->startSection(api_, poll_delay)) {
+  if (!section_->startSection(api_, poll_delay, max_instances)) {
     ENVOY_LOG(warn, "Failed to start KAE.");
     return;
   }


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message:
add kae-private-key-provider proto max_instances config

Too many instances may create a large number of threads, increasing resource usage and potential overhead.Therefore, there should be a configuration option to specify the number of KAE instances to be created.

Additional Description:
Risk Level:low
Testing:N/A
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
