### PR TITLE
build: fix zlib-ng compilation issue and add testing

### DIFF
--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -532,6 +532,17 @@ config_setting(
     values = {"define": "zlib=ng"},
 )
 
+# Alias pointing to the selected version of zlib:
+# - zlib-ng from //bazel/foreign_cc:zlib_ng when --define zlib=ng is specified (Linux only).
+# - Regular zlib from @zlib otherwise.
+alias(
+    name = "zlib",
+    actual = select({
+        "//bazel:zlib_ng": "//bazel/foreign_cc:zlib_ng",
+        "//conditions:default": "@zlib",
+    }),
+)
+
 config_setting(
     name = "wasm_v8",
     values = {"define": "wasm=v8"},

--- a/bazel/external/quiche.BUILD
+++ b/bazel/external/quiche.BUILD
@@ -2461,7 +2461,7 @@ envoy_quic_cc_library(
         ":quic_core_versions_lib",
         ":quic_platform",
         ":quiche_common_wire_serialization",
-        "@zlib",
+        "@envoy//bazel:zlib",
     ],
 )
 
@@ -2483,7 +2483,7 @@ envoy_quic_cc_library(
         ":quic_core_crypto_client_proof_source_lib",
         ":quic_core_crypto_crypto_handshake_lib",
         ":quiche_common_platform_client_stats",
-        "@zlib",
+        "@envoy//bazel:zlib",
     ],
 )
 
@@ -2504,7 +2504,7 @@ envoy_quic_cc_library(
         ":quic_core_proto_crypto_server_config_proto_header",
         ":quic_core_server_id_lib",
         ":quic_server_crypto_tls_handshake_lib",
-        "@zlib",
+        "@envoy//bazel:zlib",
     ],
 )
 

--- a/bazel/foreign_cc/BUILD
+++ b/bazel/foreign_cc/BUILD
@@ -465,3 +465,53 @@ cc_library(
     }),
     alwayslink = 1,
 )
+
+# zlib-ng is a performance-optimized fork of zlib.
+# This is built using cmake and provides a drop-in replacement for zlib when
+# --define zlib=ng is specified.
+envoy_cmake(
+    name = "zlib_ng",
+    build_args = select({
+        "//bazel/foreign_cc:parallel_builds_enabled": ["-j"],
+        "//conditions:default": ["-j1"],
+    }),
+    cache_entries = {
+        "CMAKE_CXX_COMPILER_FORCED": "on",
+        "CMAKE_C_COMPILER_FORCED": "on",
+        "SKIP_BUILD_EXAMPLES": "on",
+        "BUILD_SHARED_LIBS": "off",
+        # zlib-ng specific options.
+        # Reference: https://github.com/zlib-ng/zlib-ng#build-options.
+        "ZLIB_COMPAT": "on",
+        "ZLIB_ENABLE_TESTS": "off",
+        # Warning: Turning WITH_OPTIM to "on" doesn't pass ZlibCompressorImplTest.CallingChecksum.
+        "WITH_OPTIM": "on",
+        # However turning off SSE4 fixes it.
+        "WITH_SSE4": "off",
+        # Warning: Turning WITH_NEW_STRATEGIES to "on" doesn't pass gzip compressor fuzz test.
+        # Turning this off means falling into NO_QUICK_STRATEGY route.
+        "WITH_NEW_STRATEGIES": "off",
+        # Only allow aligned address.
+        # Reference: https://github.com/zlib-ng/zlib-ng#advanced-build-options.
+        "UNALIGNED_OK": "off",
+    },
+    exec_properties = select({
+        "//bazel:engflow_rbe_x86_64": {
+            "Pool": "linux_x64_large",
+        },
+        "//bazel:engflow_rbe_aarch64": {
+            "Pool": "linux_arm64_small",
+        },
+        "//conditions:default": {},
+    }),
+    generate_args = [
+        "-G",
+        "Ninja",
+    ],
+    lib_source = "@com_github_zlib_ng_zlib_ng//:all",
+    out_static_libs = select({
+        "//bazel:windows_x86_64": ["zlib.lib"],
+        "//conditions:default": ["libz.a"],
+    }),
+    tags = ["skip_on_windows"],
+)

--- a/bazel/protobuf.patch
+++ b/bazel/protobuf.patch
@@ -99,3 +99,15 @@ diff --git a/build_defs/cpp_opts.bzl b/build_defs/cpp_opts.bzl
      ],
  })
 
+diff --git a/src/google/protobuf/io/BUILD.bazel b/src/google/protobuf/io/BUILD.bazel
+--- a/src/google/protobuf/io/BUILD.bazel
++++ b/src/google/protobuf/io/BUILD.bazel
+@@ -160,7 +160,7 @@ cc_library(
+         "@abseil-cpp//absl/log:absl_log",
+     ] + select({
+         "//build_defs:config_msvc": [],
+-        "//conditions:default": ["@zlib"],
++        "//conditions:default": ["@envoy//bazel:zlib"],
+     }),
+ )
+

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -423,6 +423,14 @@ case $CI_TARGET in
             @envoy//source/exe:envoy-static \
             --build_tag_filters=-nofips
         collect_build_profile build
+        # Test zlib-ng explicitly to prevent regressions (Linux only).
+        echo "Testing zlib-ng compression..."
+        bazel_with_collection \
+            test "${BAZEL_BUILD_OPTIONS[@]}" \
+            --define zlib=ng \
+            -c fastbuild \
+            @envoy//test/extensions/compression/gzip/compressor:compressor_test \
+            @envoy//test/extensions/compression/gzip/decompressor:zlib_decompressor_impl_test
         ;;
 
     coverage|fuzz_coverage)

--- a/contrib/qat/compression/qatzip/compressor/source/BUILD
+++ b/contrib/qat/compression/qatzip/compressor/source/BUILD
@@ -47,7 +47,7 @@ configure_make(
     visibility = ["//visibility:public"],
     deps = [
         "//bazel/foreign_cc:lz4",
-        "@zlib",
+        "//bazel:zlib",
         "//contrib/qat:qatlib",
         # Use boringssl alias to select fips vs non-fips version.
         "//bazel:boringcrypto",

--- a/source/common/quic/BUILD
+++ b/source/common/quic/BUILD
@@ -735,7 +735,7 @@ envoy_cc_library(
     hdrs = envoy_select_enable_http3(["cert_compression.h"]),
     external_deps = ["ssl"],
     deps = envoy_select_enable_http3([
-        "@zlib//:zlib",
+        "//bazel:zlib",
         "//source/common/common:assert_lib",
         "//source/common/common:logger_lib",
         "//source/common/runtime:runtime_lib",

--- a/source/extensions/common/wasm/BUILD
+++ b/source/extensions/common/wasm/BUILD
@@ -97,6 +97,7 @@ envoy_cc_extension(
     deps = [
         ":wasm_hdr",
         ":wasm_runtime_factory_interface",
+        "//bazel:zlib",
         "//envoy/server:lifecycle_notifier_interface",
         "//source/common/buffer:buffer_lib",
         "//source/common/common:enum_to_int",
@@ -126,7 +127,6 @@ envoy_cc_extension(
         "@envoy_api//envoy/extensions/wasm/v3:pkg_cc_proto",
         "@proxy_wasm_cpp_host//:base_lib",
         "@proxy_wasm_cpp_host//:null_lib",
-        "@zlib",
     ] + select(
         {
             "//bazel:windows_x86_64": [],

--- a/source/extensions/compression/gzip/common/BUILD
+++ b/source/extensions/compression/gzip/common/BUILD
@@ -13,7 +13,7 @@ envoy_cc_library(
     srcs = ["base.cc"],
     hdrs = ["base.h"],
     deps = [
+        "//bazel:zlib",
         "//source/common/buffer:buffer_lib",
-        "@zlib",
     ],
 )

--- a/source/extensions/compression/gzip/compressor/BUILD
+++ b/source/extensions/compression/gzip/compressor/BUILD
@@ -14,11 +14,11 @@ envoy_cc_library(
     srcs = ["zlib_compressor_impl.cc"],
     hdrs = ["zlib_compressor_impl.h"],
     deps = [
+        "//bazel:zlib",
         "//envoy/compression/compressor:compressor_interface",
         "//source/common/buffer:buffer_lib",
         "//source/common/common:assert_lib",
         "//source/extensions/compression/gzip/common:zlib_base_lib",
-        "@zlib",
     ],
 )
 

--- a/source/extensions/compression/gzip/decompressor/BUILD
+++ b/source/extensions/compression/gzip/decompressor/BUILD
@@ -14,6 +14,7 @@ envoy_cc_library(
     srcs = ["zlib_decompressor_impl.cc"],
     hdrs = ["zlib_decompressor_impl.h"],
     deps = [
+        "//bazel:zlib",
         "//envoy/compression/decompressor:decompressor_interface",
         "//envoy/stats:stats_interface",
         "//envoy/stats:stats_macros",
@@ -22,7 +23,6 @@ envoy_cc_library(
         "//source/common/common:minimal_logger_lib",
         "//source/common/runtime:runtime_features_lib",
         "//source/extensions/compression/gzip/common:zlib_base_lib",
-        "@zlib",
     ],
 )
 


### PR DESCRIPTION
## Description

This PR fixes the build issue where the build with `zlib-ng` got broke when we moved `zlib` to BCR.

Fix https://github.com/envoyproxy/envoy/issues/43039

---

**Commit Message:** build: fix zlib-ng compilation issue and add testing
**Additional Description:** Fixes the build issue where the build with `zlib-ng` got broke when we moved `zlib` to BCR.
**Risk Level:** Low
**Testing:** CI
**Docs Changes:** N/A
**Release Notes:** N/A