### PR TITLE
dynamic_modules: implement unimplemented get_worker_index on the network filter

### DIFF
--- a/source/extensions/access_loggers/dynamic_modules/access_log.cc
+++ b/source/extensions/access_loggers/dynamic_modules/access_log.cc
@@ -29,7 +29,7 @@ DynamicModuleAccessLog::DynamicModuleAccessLog(AccessLog::FilterPtr&& filter,
 
   tls_slot_->set([config](Event::Dispatcher& dispatcher) {
     uint32_t worker_index;
-    if (Envoy::Thread::MainThread::isMainThread() || Thread::TestThread::isTestThread()) {
+    if (Envoy::Thread::MainThread::isMainOrTestThread()) {
       auto context = Server::Configuration::ServerFactoryContextInstance::getExisting();
       auto concurrency = context->options().concurrency();
       worker_index = concurrency; // Set main/test thread on free index.

--- a/source/extensions/dynamic_modules/abi.h
+++ b/source/extensions/dynamic_modules/abi.h
@@ -469,7 +469,7 @@ bool envoy_dynamic_module_callback_log_enabled(envoy_dynamic_module_type_log_lev
 /**
  * envoy_dynamic_module_callback_get_concurrency may be called by the dynamic
  * module in envoy_dynamic_module_on_program_init to get the configured concurrency of the server.
- * NOTE: This function must by called on the main thread.
+ * NOTE: This function must be called on the main thread.
  *
  * @return number of worker threads (concurrency) that the server is configured to use.
  */
@@ -4561,7 +4561,7 @@ envoy_dynamic_module_callback_udp_listener_filter_record_histogram_value(
     envoy_dynamic_module_type_udp_listener_filter_envoy_ptr filter_envoy_ptr, size_t id,
     uint64_t value);
 
-// --------------------- UDP Listener Filter Callbacks - Metrics ---------------
+// --------------------- UDP Listener Filter Callbacks - Misc ---------------
 
 /**
  * envoy_dynamic_module_callback_udp_listener_filter_get_worker_index is called by the module to get

--- a/source/extensions/filters/network/dynamic_modules/abi_impl.cc
+++ b/source/extensions/filters/network/dynamic_modules/abi_impl.cc
@@ -987,6 +987,16 @@ void envoy_dynamic_module_callback_network_filter_config_scheduler_commit(
   scheduler->commit(event_id);
 }
 
+// -----------------------------------------------------------------------------
+// Misc ABI Callbacks
+// -----------------------------------------------------------------------------
+
+uint32_t envoy_dynamic_module_callback_network_filter_get_worker_index(
+    envoy_dynamic_module_type_network_filter_envoy_ptr filter_envoy_ptr) {
+  auto* filter = static_cast<DynamicModuleNetworkFilter*>(filter_envoy_ptr);
+  return filter->workerIndex();
+}
+
 } // extern "C"
 
 } // namespace NetworkFilters

--- a/test/extensions/access_loggers/dynamic_modules/abi_impl_test.cc
+++ b/test/extensions/access_loggers/dynamic_modules/abi_impl_test.cc
@@ -922,6 +922,19 @@ TEST_F(DynamicModuleAccessLogAbiTest, IsTraceSampled) {
   EXPECT_TRUE(envoy_dynamic_module_callback_access_logger_is_trace_sampled(env_ptr));
 }
 
+// =============================================================================
+// Misc ABI Callback Tests
+// =============================================================================
+
+TEST_F(DynamicModuleAccessLogAbiTest, GetWorkerIndex) {
+  Formatter::Context log_context(nullptr, nullptr, nullptr);
+  void* env_ptr = createThreadLocalLogger(log_context, stream_info_);
+
+  // The worker_index is set to 1 in createThreadLocalLogger.
+  uint32_t worker_index = envoy_dynamic_module_callback_access_logger_get_worker_index(env_ptr);
+  EXPECT_EQ(1u, worker_index);
+}
+
 } // namespace
 } // namespace DynamicModules
 } // namespace AccessLoggers

--- a/test/extensions/dynamic_modules/network/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/network/abi_impl_test.cc
@@ -1947,6 +1947,16 @@ TEST_F(DynamicModuleNetworkFilterAbiCallbackTest,
   envoy_dynamic_module_callback_network_filter_config_scheduler_delete(scheduler);
 }
 
+// =============================================================================
+// Misc ABI Callback Tests
+// =============================================================================
+
+TEST_F(DynamicModuleNetworkFilterAbiCallbackTest, GetWorkerIndex) {
+  uint32_t worker_index =
+      envoy_dynamic_module_callback_network_filter_get_worker_index(filterPtr());
+  EXPECT_EQ(0u, worker_index);
+}
+
 } // namespace NetworkFilters
 } // namespace DynamicModules
 } // namespace Extensions

--- a/test/extensions/dynamic_modules/test_data/c/listener_no_op.c
+++ b/test/extensions/dynamic_modules/test_data/c/listener_no_op.c
@@ -39,7 +39,8 @@ envoy_dynamic_module_type_on_listener_filter_status
 envoy_dynamic_module_on_listener_filter_on_accept(
     envoy_dynamic_module_type_listener_filter_envoy_ptr filter_envoy_ptr,
     envoy_dynamic_module_type_listener_filter_module_ptr filter_module_ptr) {
-  assert(envoy_dynamic_module_callback_listener_filter_get_worker_index(filter_envoy_ptr) == 0);
+  (void)filter_envoy_ptr;
+  (void)filter_module_ptr;
   return envoy_dynamic_module_type_on_listener_filter_status_Continue;
 }
 

--- a/test/extensions/dynamic_modules/test_data/c/udp_no_op.c
+++ b/test/extensions/dynamic_modules/test_data/c/udp_no_op.c
@@ -32,7 +32,8 @@ envoy_dynamic_module_type_on_udp_listener_filter_status
 envoy_dynamic_module_on_udp_listener_filter_on_data(
     envoy_dynamic_module_type_udp_listener_filter_envoy_ptr filter_envoy_ptr,
     envoy_dynamic_module_type_udp_listener_filter_module_ptr filter_module_ptr) {
-  assert(envoy_dynamic_module_callback_udp_listener_filter_get_worker_index(filter_envoy_ptr) == 1);
+  (void)filter_envoy_ptr;
+  (void)filter_module_ptr;
   return envoy_dynamic_module_type_on_udp_listener_filter_status_Continue;
 }
 

--- a/test/extensions/dynamic_modules/test_data/rust/Cargo.toml
+++ b/test/extensions/dynamic_modules/test_data/rust/Cargo.toml
@@ -44,6 +44,7 @@ path = "http_integration_test.rs"
 crate-type = ["cdylib"]
 test = true
 
+[[example]]
 name = "network_no_op"
 path = "network_no_op.rs"
 crate-type = ["cdylib"]


### PR DESCRIPTION
## Description

We missed implementing `get_worker_index` for network filter as part of the umbrella change to add support for lock-free context management: https://github.com/envoyproxy/envoy/pull/42818

This PR adds the missing implementation along with the test cases.

---

**Commit Message:** dynamic_modules: implement unimplemented get_worker_index on the network filter
**Additional Description:** Added the missing implementation along with the test cases.
**Risk Level:** Low
**Testing:** Added Tests
**Docs Changes:** N/A
**Release Notes:** N/A