### PR TITLE
Fix occasional Envoy build failures due to missing yq tool

### DIFF
--- a/bazel/repo.bzl
+++ b/bazel/repo.bzl
@@ -279,7 +279,7 @@ _envoy_repo = repository_rule(
         "envoy_api_version": attr.label(default = "@envoy//:API_VERSION.txt"),
         "envoy_ci_config": attr.label(default = "@envoy//:.github/config.yml"),
         "yq": attr.label(default = "@yq"),
-        "deps": attr.label_list(default = ["@yq_linux_amd64//:yq", "@yq_linux_arm64//:yq", "@yq_darwin_amd64//:yq", "@ya_darwin_arm64//:yq"]),
+        "deps": attr.label_list(default = ["@yq_linux_amd64//:yq", "@yq_linux_arm64//:yq", "@yq_darwin_amd64//:yq", "@yq_darwin_arm64//:yq"]),
     },
     environ = ["BAZEL_LLVM_PATH"],
 )


### PR DESCRIPTION
Commit Message:

envoy_repo rule uses yq tool internally. The tool provided to the rule explicitly in form of a label. The default value of that label is `@yq` currently.

The problem with the current setup is that `@yq` repository rule just creates a symlink to the right yq tool, but it does not actually download the yq tool as part of that rule and there is no dependency between the rules that would tell Bazel that it should download the right version of yq before running `@yq` repository rule that creates a symlink.

NOTE: Without going into much details, aspect_bazel_lib defines a separate repository rule for each platfrom-specific version of yq, i.e. `@yq_linux_amd64` or `@yq_linux_arm64`, and it also defines a plain `@yq` repository rule that creates a symlink to the right yq version for the host platfom, but the `@yq` rule does not have any explicit dependencies on platform specific rules, so bazel does not know that it has to run `@yq_linux_amd64` before running `@yq`.

This change forces bazel to make sure that all platfrom dependent yq repository rules get executed before we try to call yq over a symlink. To force Bazel to execute those platfrom rules I ask Bazel to read the yq binary from each of those explicitly into a string (and then ignore it).

It's a rather ugly hack, but I'm pretty sure that upstream bazel lib will not address this issue - they removed support for yq tool (and a few other tools as well).

Fixing it with a patch for bazel lib is also non-trivial due to `@yq` repository rule currently relying on string manipulations only without ever considering its dependencies.

So this is the most sensible and supportable way to fix it that I found at the moment. The only other alternative that may be worth considering is relying on non-hermetic version of yq installed in the host system.

And we can't do nothing at all. Currently, the build might fail (and keep consistently failing - it's not just one off) if you just specify a "wrong" output directory (there is nothing actually wrong with the name, it's just it impacts the order in which artifacts are listed in some internal Bazel hash table or something like that) and that triggers bazel to execute repository rules in different order.

It's not reproducable in Envoy CI, otherwise it would be noticed by now. So this issue basically affects a small number of users, but it makes it impossible to build Envoy for them, and it's not because they do something wrong, but due to random reasons.

The downside here is that we will be downloading yq tools that we don't need, e.g., when we build on x86 we would download and not use yq for arm64 as well. Hopefully that's not a big deal, since yq is a rather small tool.

Additional Description:

I'd like to also backport it to the 1.37 release branch as well.

Risk Level: Low
Testing: Manually verified that it builds on Linux, other than that rely on CI.
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
