### PR TITLE
mcp: added support for logging/* MCP methods

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -115,6 +115,9 @@ new_features:
   change: |
     Added support for MCP completion method ``completion/complete`` with routing based on
     ``ref/prompt`` or ``ref/resource``.
+- area: mcp_router
+  change: |
+    Added support for MCP logging method ``logging/setLevel``.
 - area: formatter
   change: |
     Extended ``*_WITHOUT_PORT`` address formatters to accept an optional ``MASK_PREFIX_LEN`` parameter

--- a/source/extensions/filters/http/mcp_router/mcp_router.h
+++ b/source/extensions/filters/http/mcp_router/mcp_router.h
@@ -35,6 +35,7 @@ enum class McpMethod {
   PromptsList,
   PromptsGet,
   CompletionComplete,
+  LoggingSetLevel,
   Ping,
   // Notifications (client -> server, fire-and-forget).
   NotificationInitialized,
@@ -138,6 +139,7 @@ private:
   void handlePromptsList();
   void handlePromptsGet();
   void handleCompletionComplete();
+  void handleLoggingSetLevel();
   void handlePing();
   // Generic handler for client→server notifications (fanout to all backends).
   void handleNotification(absl::string_view notification_name);

--- a/test/extensions/filters/http/mcp_router/mcp_router_integration_test.cc
+++ b/test/extensions/filters/http/mcp_router/mcp_router_integration_test.cc
@@ -482,6 +482,219 @@ TEST_P(McpRouterIntegrationTest, ToolCallToSecondBackend) {
   EXPECT_THAT(response->body(), testing::HasSubstr("\"text\": \"3\""));
 }
 
+// Test tools/call content-length is adjusted when tool name is rewritten.
+TEST_P(McpRouterIntegrationTest, ToolCallContentLengthAdjustment) {
+  initializeFilter();
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+
+  const std::string request_body =
+      R"({"jsonrpc":"2.0","method":"tools/call","id":1,"params":{"name":"time__get_time","arguments":{}}})";
+
+  auto response = codec_client_->makeRequestWithBody(
+      Http::TestRequestHeaderMapImpl{{":method", "POST"},
+                                     {":path", "/mcp"},
+                                     {":scheme", "http"},
+                                     {":authority", "host"},
+                                     {"accept", "application/json"},
+                                     {"accept", "text/event-stream"},
+                                     {"content-type", "application/json"},
+                                     {"content-length", std::to_string(request_body.size())}},
+      request_body);
+
+  ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, time_backend_connection_));
+  ASSERT_TRUE(time_backend_connection_->waitForNewStream(*dispatcher_, time_backend_request_));
+  ASSERT_TRUE(time_backend_request_->waitForEndStream(*dispatcher_));
+
+  // Verify content-length was adjusted: original "time__get_time" -> "get_time" (7 chars removed).
+  auto content_length_header = time_backend_request_->headers().ContentLength();
+  ASSERT_NE(content_length_header, nullptr);
+  int64_t upstream_length = 0;
+  ASSERT_TRUE(absl::SimpleAtoi(content_length_header->value().getStringView(), &upstream_length));
+  // Original body size minus "time__" prefix (6 chars).
+  EXPECT_EQ(upstream_length, static_cast<int64_t>(request_body.size()) - 6);
+
+  const std::string backend_response = R"({"jsonrpc":"2.0","id":1,"result":{}})";
+  time_backend_request_->encodeHeaders(
+      Http::TestResponseHeaderMapImpl{{":status", "200"}, {"content-type", "application/json"}},
+      false);
+  Buffer::OwnedImpl resp_body(backend_response);
+  time_backend_request_->encodeData(resp_body, true);
+
+  ASSERT_TRUE(response->waitForEndStream());
+  EXPECT_EQ("200", response->headers().getStatusValue());
+}
+
+// Test resources/read content-length is adjusted when URI is rewritten.
+TEST_P(McpRouterIntegrationTest, ResourcesReadContentLengthAdjustment) {
+  initializeFilter();
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+
+  const std::string request_body =
+      R"({"jsonrpc":"2.0","method":"resources/read","id":2,"params":{"uri":"time+file://data"}})";
+
+  auto response = codec_client_->makeRequestWithBody(
+      Http::TestRequestHeaderMapImpl{{":method", "POST"},
+                                     {":path", "/mcp"},
+                                     {":scheme", "http"},
+                                     {":authority", "host"},
+                                     {"accept", "application/json"},
+                                     {"accept", "text/event-stream"},
+                                     {"content-type", "application/json"},
+                                     {"content-length", std::to_string(request_body.size())}},
+      request_body);
+
+  ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, time_backend_connection_));
+  ASSERT_TRUE(time_backend_connection_->waitForNewStream(*dispatcher_, time_backend_request_));
+  ASSERT_TRUE(time_backend_request_->waitForEndStream(*dispatcher_));
+
+  // Verify content-length was adjusted: "time+file://data" -> "file://data" (5 chars removed).
+  auto content_length_header = time_backend_request_->headers().ContentLength();
+  ASSERT_NE(content_length_header, nullptr);
+  int64_t upstream_length = 0;
+  ASSERT_TRUE(absl::SimpleAtoi(content_length_header->value().getStringView(), &upstream_length));
+  EXPECT_EQ(upstream_length, static_cast<int64_t>(request_body.size()) - 5);
+
+  const std::string backend_response = R"({"jsonrpc":"2.0","id":2,"result":{"contents":[]}})";
+  time_backend_request_->encodeHeaders(
+      Http::TestResponseHeaderMapImpl{{":status", "200"}, {"content-type", "application/json"}},
+      false);
+  Buffer::OwnedImpl resp_body(backend_response);
+  time_backend_request_->encodeData(resp_body, true);
+
+  ASSERT_TRUE(response->waitForEndStream());
+  EXPECT_EQ("200", response->headers().getStatusValue());
+}
+
+// Test prompts/get content-length is adjusted when prompt name is rewritten.
+TEST_P(McpRouterIntegrationTest, PromptsGetContentLengthAdjustment) {
+  initializeFilter();
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+
+  const std::string request_body =
+      R"({"jsonrpc":"2.0","method":"prompts/get","id":3,"params":{"name":"time__greeting"}})";
+
+  auto response = codec_client_->makeRequestWithBody(
+      Http::TestRequestHeaderMapImpl{{":method", "POST"},
+                                     {":path", "/mcp"},
+                                     {":scheme", "http"},
+                                     {":authority", "host"},
+                                     {"accept", "application/json"},
+                                     {"accept", "text/event-stream"},
+                                     {"content-type", "application/json"},
+                                     {"content-length", std::to_string(request_body.size())}},
+      request_body);
+
+  ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, time_backend_connection_));
+  ASSERT_TRUE(time_backend_connection_->waitForNewStream(*dispatcher_, time_backend_request_));
+  ASSERT_TRUE(time_backend_request_->waitForEndStream(*dispatcher_));
+
+  // Verify content-length was adjusted: "time__greeting" -> "greeting" (6 chars removed).
+  auto content_length_header = time_backend_request_->headers().ContentLength();
+  ASSERT_NE(content_length_header, nullptr);
+  int64_t upstream_length = 0;
+  ASSERT_TRUE(absl::SimpleAtoi(content_length_header->value().getStringView(), &upstream_length));
+  EXPECT_EQ(upstream_length, static_cast<int64_t>(request_body.size()) - 6);
+
+  const std::string backend_response = R"({"jsonrpc":"2.0","id":3,"result":{"messages":[]}})";
+  time_backend_request_->encodeHeaders(
+      Http::TestResponseHeaderMapImpl{{":status", "200"}, {"content-type", "application/json"}},
+      false);
+  Buffer::OwnedImpl resp_body(backend_response);
+  time_backend_request_->encodeData(resp_body, true);
+
+  ASSERT_TRUE(response->waitForEndStream());
+  EXPECT_EQ("200", response->headers().getStatusValue());
+}
+
+// Test completion/complete with ref/prompt content-length is adjusted.
+TEST_P(McpRouterIntegrationTest, CompletionCompletePromptRefContentLengthAdjustment) {
+  initializeFilter();
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+
+  const std::string request_body =
+      R"({"jsonrpc":"2.0","method":"completion/complete","id":4,"params":{"ref":{"type":"ref/prompt","name":"time__greet"},"argument":{"name":"x","value":"y"}}})";
+
+  auto response = codec_client_->makeRequestWithBody(
+      Http::TestRequestHeaderMapImpl{{":method", "POST"},
+                                     {":path", "/mcp"},
+                                     {":scheme", "http"},
+                                     {":authority", "host"},
+                                     {"accept", "application/json"},
+                                     {"accept", "text/event-stream"},
+                                     {"content-type", "application/json"},
+                                     {"content-length", std::to_string(request_body.size())}},
+      request_body);
+
+  ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, time_backend_connection_));
+  ASSERT_TRUE(time_backend_connection_->waitForNewStream(*dispatcher_, time_backend_request_));
+  ASSERT_TRUE(time_backend_request_->waitForEndStream(*dispatcher_));
+
+  // Verify content-length was adjusted: "time__greet" -> "greet" (6 chars removed).
+  auto content_length_header = time_backend_request_->headers().ContentLength();
+  ASSERT_NE(content_length_header, nullptr);
+  int64_t upstream_length = 0;
+  ASSERT_TRUE(absl::SimpleAtoi(content_length_header->value().getStringView(), &upstream_length));
+  EXPECT_EQ(upstream_length, static_cast<int64_t>(request_body.size()) - 6);
+
+  const std::string backend_response =
+      R"({"jsonrpc":"2.0","id":4,"result":{"completion":{"values":[]}}})";
+  time_backend_request_->encodeHeaders(
+      Http::TestResponseHeaderMapImpl{{":status", "200"}, {"content-type", "application/json"}},
+      false);
+  Buffer::OwnedImpl resp_body(backend_response);
+  time_backend_request_->encodeData(resp_body, true);
+
+  ASSERT_TRUE(response->waitForEndStream());
+  EXPECT_EQ("200", response->headers().getStatusValue());
+}
+
+// Test completion/complete with ref/resource content-length is adjusted.
+TEST_P(McpRouterIntegrationTest, CompletionCompleteResourceRefContentLengthAdjustment) {
+  initializeFilter();
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+
+  const std::string request_body =
+      R"({"jsonrpc":"2.0","method":"completion/complete","id":5,"params":{"ref":{"type":"ref/resource","uri":"time+file://x"},"argument":{"name":"a","value":"b"}}})";
+
+  auto response = codec_client_->makeRequestWithBody(
+      Http::TestRequestHeaderMapImpl{{":method", "POST"},
+                                     {":path", "/mcp"},
+                                     {":scheme", "http"},
+                                     {":authority", "host"},
+                                     {"accept", "application/json"},
+                                     {"accept", "text/event-stream"},
+                                     {"content-type", "application/json"},
+                                     {"content-length", std::to_string(request_body.size())}},
+      request_body);
+
+  ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, time_backend_connection_));
+  ASSERT_TRUE(time_backend_connection_->waitForNewStream(*dispatcher_, time_backend_request_));
+  ASSERT_TRUE(time_backend_request_->waitForEndStream(*dispatcher_));
+
+  // Verify content-length was adjusted: "time+file://x" -> "file://x" (5 chars removed).
+  auto content_length_header = time_backend_request_->headers().ContentLength();
+  ASSERT_NE(content_length_header, nullptr);
+  int64_t upstream_length = 0;
+  ASSERT_TRUE(absl::SimpleAtoi(content_length_header->value().getStringView(), &upstream_length));
+  EXPECT_EQ(upstream_length, static_cast<int64_t>(request_body.size()) - 5);
+
+  const std::string backend_response =
+      R"({"jsonrpc":"2.0","id":5,"result":{"completion":{"values":[]}}})";
+  time_backend_request_->encodeHeaders(
+      Http::TestResponseHeaderMapImpl{{":status", "200"}, {"content-type", "application/json"}},
+      false);
+  Buffer::OwnedImpl resp_body(backend_response);
+  time_backend_request_->encodeData(resp_body, true);
+
+  ASSERT_TRUE(response->waitForEndStream());
+  EXPECT_EQ("200", response->headers().getStatusValue());
+}
+
 // Test session ID from initialize is propagated in subsequent requests
 TEST_P(McpRouterIntegrationTest, SessionIdPropagation) {
   initializeFilter();
@@ -1213,6 +1426,66 @@ TEST_P(McpRouterIntegrationTest, CompletionCompleteWithInvalidRefType) {
   // Invalid ref type should return 400 Bad Request.
   ASSERT_TRUE(response->waitForEndStream());
   EXPECT_EQ("400", response->headers().getStatusValue());
+}
+
+// Test logging/setLevel is forwarded to all backends.
+TEST_P(McpRouterIntegrationTest, LoggingSetLevelFanout) {
+  initializeFilter();
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+
+  const std::string request_body = R"({
+    "jsonrpc": "2.0",
+    "method": "logging/setLevel",
+    "id": 50,
+    "params": {
+      "level": "debug"
+    }
+  })";
+
+  auto response = codec_client_->makeRequestWithBody(
+      Http::TestRequestHeaderMapImpl{{":method", "POST"},
+                                     {":path", "/mcp"},
+                                     {":scheme", "http"},
+                                     {":authority", "host"},
+                                     {"accept", "application/json"},
+                                     {"accept", "text/event-stream"},
+                                     {"content-type", "application/json"}},
+      request_body);
+
+  // Both backends should receive the request.
+  ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, time_backend_connection_));
+  ASSERT_TRUE(time_backend_connection_->waitForNewStream(*dispatcher_, time_backend_request_));
+
+  ASSERT_TRUE(fake_upstreams_[1]->waitForHttpConnection(*dispatcher_, tools_backend_connection_));
+  ASSERT_TRUE(tools_backend_connection_->waitForNewStream(*dispatcher_, tools_backend_request_));
+
+  // Wait for both to receive the full request.
+  ASSERT_TRUE(time_backend_request_->waitForEndStream(*dispatcher_));
+  ASSERT_TRUE(tools_backend_request_->waitForEndStream(*dispatcher_));
+
+  // Verify both backends received the logging level parameter.
+  EXPECT_THAT(time_backend_request_->body().toString(), testing::HasSubstr("\"level\""));
+  EXPECT_THAT(tools_backend_request_->body().toString(), testing::HasSubstr("\"level\""));
+
+  // Backends respond with empty result.
+  const std::string backend_response = R"({"jsonrpc":"2.0","id":50,"result":{}})";
+  time_backend_request_->encodeHeaders(
+      Http::TestResponseHeaderMapImpl{{":status", "200"}, {"content-type", "application/json"}},
+      false);
+  Buffer::OwnedImpl time_resp(backend_response);
+  time_backend_request_->encodeData(time_resp, true);
+
+  tools_backend_request_->encodeHeaders(
+      Http::TestResponseHeaderMapImpl{{":status", "200"}, {"content-type", "application/json"}},
+      false);
+  Buffer::OwnedImpl tools_resp(backend_response);
+  tools_backend_request_->encodeData(tools_resp, true);
+
+  ASSERT_TRUE(response->waitForEndStream());
+  EXPECT_EQ("200", response->headers().getStatusValue());
+  // Response should be a JSON-RPC result with empty object.
+  EXPECT_THAT(response->body(), testing::HasSubstr("\"result\""));
 }
 
 // Test notifications/cancelled is forwarded to all backends.

--- a/test/extensions/filters/http/mcp_router/mcp_router_test.cc
+++ b/test/extensions/filters/http/mcp_router/mcp_router_test.cc
@@ -31,6 +31,7 @@ TEST(ParseMethodStringTest, AllMethods) {
   EXPECT_EQ(parseMethodString("prompts/list"), McpMethod::PromptsList);
   EXPECT_EQ(parseMethodString("prompts/get"), McpMethod::PromptsGet);
   EXPECT_EQ(parseMethodString("completion/complete"), McpMethod::CompletionComplete);
+  EXPECT_EQ(parseMethodString("logging/setLevel"), McpMethod::LoggingSetLevel);
   EXPECT_EQ(parseMethodString("ping"), McpMethod::Ping);
   // Notifications (client -> server only).
   EXPECT_EQ(parseMethodString("notifications/initialized"), McpMethod::NotificationInitialized);


### PR DESCRIPTION
## Description

This PR adds support for MCP logging method `logging/setLevel`.

---

**Commit Message:** mcp: added support for logging/* MCP methods
**Additional Description:** Added support for MCP logging method `logging/setLevel`.
**Risk Level:** Low
**Testing:** Added Unit + Integration Tests
**Docs Changes:** Added
**Release Notes:** Added