### PR TITLE
ext_authz: add more integration tests for ExtAuthZ

### DIFF
--- a/test/extensions/filters/http/ext_authz/ext_authz_integration_test.cc
+++ b/test/extensions/filters/http/ext_authz/ext_authz_integration_test.cc
@@ -1890,6 +1890,468 @@ TEST_P(ExtAuthzHttpIntegrationTest, DeniedResponseMultipleSetCookieHeaders) {
   cleanup();
 }
 
+// Verifies that headers from a successful authorization response are properly
+// forwarded to the client when allowed_client_headers_on_success is configured.
+TEST_P(ExtAuthzHttpIntegrationTest, SuccessResponseHeadersForwarding) {
+  config_helper_.addConfigModifier([this](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
+    auto* ext_authz_cluster = bootstrap.mutable_static_resources()->add_clusters();
+    ext_authz_cluster->MergeFrom(bootstrap.static_resources().clusters()[0]);
+    ext_authz_cluster->set_name("ext_authz");
+
+    const std::string ext_authz_config = R"EOF(
+    http_service:
+      server_uri:
+        uri: "ext_authz:9000"
+        cluster: "ext_authz"
+        timeout: 300s
+      authorization_response:
+        allowed_client_headers_on_success:
+          patterns:
+          - exact: "set-cookie"
+            ignore_case: true
+          - exact: "x-custom-success-header"
+            ignore_case: true
+          - exact: "cache-control"
+            ignore_case: true
+    failure_mode_allow: false
+    )EOF";
+    TestUtility::loadFromYaml(ext_authz_config, proto_config_);
+    proto_config_.set_encode_raw_headers(encodeRawHeaders());
+
+    envoy::extensions::filters::network::http_connection_manager::v3::HttpFilter ext_authz_filter;
+    ext_authz_filter.set_name("envoy.filters.http.ext_authz");
+    ext_authz_filter.mutable_typed_config()->PackFrom(proto_config_);
+
+    config_helper_.prependFilter(MessageUtil::getJsonStringFromMessageOrError(ext_authz_filter));
+  });
+
+  HttpIntegrationTest::initialize();
+
+  auto conn = makeClientConnection(lookupPort("http"));
+  codec_client_ = makeHttpConnection(std::move(conn));
+  response_ = codec_client_->makeHeaderOnlyRequest(Http::TestRequestHeaderMapImpl{
+      {":method", "GET"},
+      {":path", "/"},
+      {":scheme", "http"},
+      {":authority", "host"},
+  });
+
+  AssertionResult result =
+      fake_upstreams_.back()->waitForHttpConnection(*dispatcher_, fake_ext_authz_connection_);
+  RELEASE_ASSERT(result, result.message());
+  result = fake_ext_authz_connection_->waitForNewStream(*dispatcher_, ext_authz_request_);
+  RELEASE_ASSERT(result, result.message());
+  result = ext_authz_request_->waitForEndStream(*dispatcher_);
+  RELEASE_ASSERT(result, result.message());
+
+  // Send a 200 OK response with headers that should be forwarded to the client.
+  Http::TestResponseHeaderMapImpl ext_authz_response_headers{
+      {":status", "200"},
+      {"set-cookie", "session=abc123; Path=/; HttpOnly; Secure"},
+      {"x-custom-success-header", "custom-value"},
+      {"cache-control", "private, max-age=3600"},
+      {"x-should-not-forward", "this-header-should-not-appear"},
+  };
+  ext_authz_request_->encodeHeaders(ext_authz_response_headers, true);
+
+  // Wait for the request to be forwarded to upstream.
+  result = fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, fake_upstream_connection_);
+  RELEASE_ASSERT(result, result.message());
+  result = fake_upstream_connection_->waitForNewStream(*dispatcher_, upstream_request_);
+  RELEASE_ASSERT(result, result.message());
+  result = upstream_request_->waitForEndStream(*dispatcher_);
+  RELEASE_ASSERT(result, result.message());
+
+  // Send upstream response.
+  upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, true);
+
+  ASSERT_TRUE(response_->waitForEndStream());
+  EXPECT_TRUE(response_->complete());
+
+  // Verify the response status is 200.
+  EXPECT_EQ("200", response_->headers().getStatusValue());
+
+  // Verify that allowed_client_headers_on_success are forwarded to the client.
+  EXPECT_EQ(
+      "session=abc123; Path=/; HttpOnly; Secure",
+      response_->headers().get(Http::LowerCaseString("set-cookie"))[0]->value().getStringView());
+  EXPECT_EQ("custom-value", response_->headers()
+                                .get(Http::LowerCaseString("x-custom-success-header"))[0]
+                                ->value()
+                                .getStringView());
+  EXPECT_EQ(
+      "private, max-age=3600",
+      response_->headers().get(Http::LowerCaseString("cache-control"))[0]->value().getStringView());
+
+  // Verify that headers not in allowed_client_headers_on_success are not forwarded.
+  EXPECT_TRUE(response_->headers().get(Http::LowerCaseString("x-should-not-forward")).empty());
+
+  cleanup();
+}
+
+// Verifies that multiple set-cookie headers from a successful authorization response are properly
+// forwarded to the client.
+TEST_P(ExtAuthzHttpIntegrationTest, SuccessResponseMultipleSetCookieHeaders) {
+  config_helper_.addConfigModifier([this](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
+    auto* ext_authz_cluster = bootstrap.mutable_static_resources()->add_clusters();
+    ext_authz_cluster->MergeFrom(bootstrap.static_resources().clusters()[0]);
+    ext_authz_cluster->set_name("ext_authz");
+
+    const std::string ext_authz_config = R"EOF(
+    http_service:
+      server_uri:
+        uri: "ext_authz:9000"
+        cluster: "ext_authz"
+        timeout: 300s
+      authorization_response:
+        allowed_client_headers_on_success:
+          patterns:
+          - exact: "set-cookie"
+            ignore_case: true
+    failure_mode_allow: false
+    )EOF";
+    TestUtility::loadFromYaml(ext_authz_config, proto_config_);
+    proto_config_.set_encode_raw_headers(encodeRawHeaders());
+
+    envoy::extensions::filters::network::http_connection_manager::v3::HttpFilter ext_authz_filter;
+    ext_authz_filter.set_name("envoy.filters.http.ext_authz");
+    ext_authz_filter.mutable_typed_config()->PackFrom(proto_config_);
+
+    config_helper_.prependFilter(MessageUtil::getJsonStringFromMessageOrError(ext_authz_filter));
+  });
+
+  HttpIntegrationTest::initialize();
+
+  auto conn = makeClientConnection(lookupPort("http"));
+  codec_client_ = makeHttpConnection(std::move(conn));
+  response_ = codec_client_->makeHeaderOnlyRequest(Http::TestRequestHeaderMapImpl{
+      {":method", "GET"},
+      {":path", "/"},
+      {":scheme", "http"},
+      {":authority", "host"},
+  });
+
+  AssertionResult result =
+      fake_upstreams_.back()->waitForHttpConnection(*dispatcher_, fake_ext_authz_connection_);
+  RELEASE_ASSERT(result, result.message());
+  result = fake_ext_authz_connection_->waitForNewStream(*dispatcher_, ext_authz_request_);
+  RELEASE_ASSERT(result, result.message());
+  result = ext_authz_request_->waitForEndStream(*dispatcher_);
+  RELEASE_ASSERT(result, result.message());
+
+  // Send a 200 OK response with multiple set-cookie headers.
+  Http::TestResponseHeaderMapImpl ext_authz_response_headers{{":status", "200"}};
+  ext_authz_response_headers.addCopy(Http::LowerCaseString("set-cookie"),
+                                     "session=abc123; Path=/; HttpOnly; Secure");
+  ext_authz_response_headers.addCopy(Http::LowerCaseString("set-cookie"),
+                                     "user=john; Path=/; Max-Age=3600");
+  ext_authz_request_->encodeHeaders(ext_authz_response_headers, true);
+
+  // Wait for the request to be forwarded to upstream.
+  result = fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, fake_upstream_connection_);
+  RELEASE_ASSERT(result, result.message());
+  result = fake_upstream_connection_->waitForNewStream(*dispatcher_, upstream_request_);
+  RELEASE_ASSERT(result, result.message());
+  result = upstream_request_->waitForEndStream(*dispatcher_);
+  RELEASE_ASSERT(result, result.message());
+
+  // Send upstream response.
+  upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, true);
+
+  ASSERT_TRUE(response_->waitForEndStream());
+  EXPECT_TRUE(response_->complete());
+
+  // Verify the response status is 200.
+  EXPECT_EQ("200", response_->headers().getStatusValue());
+
+  // Verify that multiple set-cookie headers are forwarded.
+  const auto set_cookie_headers = response_->headers().get(Http::LowerCaseString("set-cookie"));
+  EXPECT_EQ(2, set_cookie_headers.size());
+
+  cleanup();
+}
+
+// Verifies that allowed_client_headers_on_success works independently of allowed_upstream_headers.
+// Headers can be forwarded to the client without being forwarded to the upstream.
+TEST_P(ExtAuthzHttpIntegrationTest, SuccessClientHeadersIndependentOfUpstreamHeaders) {
+  config_helper_.addConfigModifier([this](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
+    auto* ext_authz_cluster = bootstrap.mutable_static_resources()->add_clusters();
+    ext_authz_cluster->MergeFrom(bootstrap.static_resources().clusters()[0]);
+    ext_authz_cluster->set_name("ext_authz");
+
+    // Configure allowed_client_headers_on_success with set-cookie, but do NOT include it
+    // in allowed_upstream_headers. The header should still reach the client.
+    const std::string ext_authz_config = R"EOF(
+    http_service:
+      server_uri:
+        uri: "ext_authz:9000"
+        cluster: "ext_authz"
+        timeout: 300s
+      authorization_response:
+        allowed_upstream_headers:
+          patterns:
+          - exact: "x-upstream-only"
+            ignore_case: true
+        allowed_client_headers_on_success:
+          patterns:
+          - exact: "set-cookie"
+            ignore_case: true
+          - exact: "x-client-only"
+            ignore_case: true
+    failure_mode_allow: false
+    )EOF";
+    TestUtility::loadFromYaml(ext_authz_config, proto_config_);
+    proto_config_.set_encode_raw_headers(encodeRawHeaders());
+
+    envoy::extensions::filters::network::http_connection_manager::v3::HttpFilter ext_authz_filter;
+    ext_authz_filter.set_name("envoy.filters.http.ext_authz");
+    ext_authz_filter.mutable_typed_config()->PackFrom(proto_config_);
+
+    config_helper_.prependFilter(MessageUtil::getJsonStringFromMessageOrError(ext_authz_filter));
+  });
+
+  HttpIntegrationTest::initialize();
+
+  auto conn = makeClientConnection(lookupPort("http"));
+  codec_client_ = makeHttpConnection(std::move(conn));
+  response_ = codec_client_->makeHeaderOnlyRequest(Http::TestRequestHeaderMapImpl{
+      {":method", "GET"},
+      {":path", "/"},
+      {":scheme", "http"},
+      {":authority", "host"},
+  });
+
+  AssertionResult result =
+      fake_upstreams_.back()->waitForHttpConnection(*dispatcher_, fake_ext_authz_connection_);
+  RELEASE_ASSERT(result, result.message());
+  result = fake_ext_authz_connection_->waitForNewStream(*dispatcher_, ext_authz_request_);
+  RELEASE_ASSERT(result, result.message());
+  result = ext_authz_request_->waitForEndStream(*dispatcher_);
+  RELEASE_ASSERT(result, result.message());
+
+  // Send a 200 OK response with headers for both upstream and client.
+  Http::TestResponseHeaderMapImpl ext_authz_response_headers{
+      {":status", "200"},
+      {"set-cookie", "session=abc123"},
+      {"x-client-only", "client-value"},
+      {"x-upstream-only", "upstream-value"},
+  };
+  ext_authz_request_->encodeHeaders(ext_authz_response_headers, true);
+
+  // Wait for the request to be forwarded to upstream.
+  result = fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, fake_upstream_connection_);
+  RELEASE_ASSERT(result, result.message());
+  result = fake_upstream_connection_->waitForNewStream(*dispatcher_, upstream_request_);
+  RELEASE_ASSERT(result, result.message());
+  result = upstream_request_->waitForEndStream(*dispatcher_);
+  RELEASE_ASSERT(result, result.message());
+
+  // Verify upstream receives x-upstream-only but NOT set-cookie or x-client-only.
+  EXPECT_THAT(upstream_request_->headers(), ContainsHeader("x-upstream-only", "upstream-value"));
+  EXPECT_TRUE(upstream_request_->headers().get(Http::LowerCaseString("set-cookie")).empty());
+  EXPECT_TRUE(upstream_request_->headers().get(Http::LowerCaseString("x-client-only")).empty());
+
+  // Send upstream response.
+  upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, true);
+
+  ASSERT_TRUE(response_->waitForEndStream());
+  EXPECT_TRUE(response_->complete());
+
+  // Verify the response status is 200.
+  EXPECT_EQ("200", response_->headers().getStatusValue());
+
+  // Verify that allowed_client_headers_on_success are forwarded to the client,
+  // independent of allowed_upstream_headers.
+  EXPECT_EQ(
+      "session=abc123",
+      response_->headers().get(Http::LowerCaseString("set-cookie"))[0]->value().getStringView());
+  EXPECT_EQ(
+      "client-value",
+      response_->headers().get(Http::LowerCaseString("x-client-only"))[0]->value().getStringView());
+
+  // Verify x-upstream-only is NOT forwarded to client since it's not in
+  // allowed_client_headers_on_success.
+  EXPECT_TRUE(response_->headers().get(Http::LowerCaseString("x-upstream-only")).empty());
+
+  cleanup();
+}
+
+// Verifies that when allowed_client_headers_on_success is not set, no headers from the
+// authorization response are forwarded to the client on success.
+TEST_P(ExtAuthzHttpIntegrationTest, SuccessNoClientHeadersWhenNotConfigured) {
+  config_helper_.addConfigModifier([this](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
+    auto* ext_authz_cluster = bootstrap.mutable_static_resources()->add_clusters();
+    ext_authz_cluster->MergeFrom(bootstrap.static_resources().clusters()[0]);
+    ext_authz_cluster->set_name("ext_authz");
+
+    // Do NOT configure allowed_client_headers_on_success.
+    const std::string ext_authz_config = R"EOF(
+    http_service:
+      server_uri:
+        uri: "ext_authz:9000"
+        cluster: "ext_authz"
+        timeout: 300s
+      authorization_response:
+        allowed_upstream_headers:
+          patterns:
+          - exact: "x-upstream-header"
+            ignore_case: true
+    failure_mode_allow: false
+    )EOF";
+    TestUtility::loadFromYaml(ext_authz_config, proto_config_);
+    proto_config_.set_encode_raw_headers(encodeRawHeaders());
+
+    envoy::extensions::filters::network::http_connection_manager::v3::HttpFilter ext_authz_filter;
+    ext_authz_filter.set_name("envoy.filters.http.ext_authz");
+    ext_authz_filter.mutable_typed_config()->PackFrom(proto_config_);
+
+    config_helper_.prependFilter(MessageUtil::getJsonStringFromMessageOrError(ext_authz_filter));
+  });
+
+  HttpIntegrationTest::initialize();
+
+  auto conn = makeClientConnection(lookupPort("http"));
+  codec_client_ = makeHttpConnection(std::move(conn));
+  response_ = codec_client_->makeHeaderOnlyRequest(Http::TestRequestHeaderMapImpl{
+      {":method", "GET"},
+      {":path", "/"},
+      {":scheme", "http"},
+      {":authority", "host"},
+  });
+
+  AssertionResult result =
+      fake_upstreams_.back()->waitForHttpConnection(*dispatcher_, fake_ext_authz_connection_);
+  RELEASE_ASSERT(result, result.message());
+  result = fake_ext_authz_connection_->waitForNewStream(*dispatcher_, ext_authz_request_);
+  RELEASE_ASSERT(result, result.message());
+  result = ext_authz_request_->waitForEndStream(*dispatcher_);
+  RELEASE_ASSERT(result, result.message());
+
+  // Send a 200 OK response with headers.
+  Http::TestResponseHeaderMapImpl ext_authz_response_headers{
+      {":status", "200"},
+      {"set-cookie", "session=abc123"},
+      {"x-upstream-header", "upstream-value"},
+  };
+  ext_authz_request_->encodeHeaders(ext_authz_response_headers, true);
+
+  // Wait for the request to be forwarded to upstream.
+  result = fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, fake_upstream_connection_);
+  RELEASE_ASSERT(result, result.message());
+  result = fake_upstream_connection_->waitForNewStream(*dispatcher_, upstream_request_);
+  RELEASE_ASSERT(result, result.message());
+  result = upstream_request_->waitForEndStream(*dispatcher_);
+  RELEASE_ASSERT(result, result.message());
+
+  // Verify upstream receives x-upstream-header.
+  EXPECT_THAT(upstream_request_->headers(), ContainsHeader("x-upstream-header", "upstream-value"));
+
+  // Send upstream response.
+  upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, true);
+
+  ASSERT_TRUE(response_->waitForEndStream());
+  EXPECT_TRUE(response_->complete());
+
+  // Verify the response status is 200.
+  EXPECT_EQ("200", response_->headers().getStatusValue());
+
+  // Verify that NO headers from authorization response are forwarded to the client
+  // since allowed_client_headers_on_success is not configured.
+  EXPECT_TRUE(response_->headers().get(Http::LowerCaseString("set-cookie")).empty());
+  EXPECT_TRUE(response_->headers().get(Http::LowerCaseString("x-upstream-header")).empty());
+
+  cleanup();
+}
+
+// Verifies that when allowed_client_headers is configured with any header, the default headers
+// are automatically forwarded to the client on denied responses, as documented in the proto.
+TEST_P(ExtAuthzHttpIntegrationTest, DeniedResponseDefaultHeadersAutoIncluded) {
+  config_helper_.addConfigModifier([this](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
+    auto* ext_authz_cluster = bootstrap.mutable_static_resources()->add_clusters();
+    ext_authz_cluster->MergeFrom(bootstrap.static_resources().clusters()[0]);
+    ext_authz_cluster->set_name("ext_authz");
+
+    // Only configure set-cookie in allowed_client_headers. Per documentation, Location,
+    // Status, Content-Length, and WWW-Authenticate should be automatically included.
+    const std::string ext_authz_config = R"EOF(
+    http_service:
+      server_uri:
+        uri: "ext_authz:9000"
+        cluster: "ext_authz"
+        timeout: 300s
+      authorization_response:
+        allowed_client_headers:
+          patterns:
+          - exact: "set-cookie"
+            ignore_case: true
+    failure_mode_allow: false
+    )EOF";
+    TestUtility::loadFromYaml(ext_authz_config, proto_config_);
+    proto_config_.set_encode_raw_headers(encodeRawHeaders());
+
+    envoy::extensions::filters::network::http_connection_manager::v3::HttpFilter ext_authz_filter;
+    ext_authz_filter.set_name("envoy.filters.http.ext_authz");
+    ext_authz_filter.mutable_typed_config()->PackFrom(proto_config_);
+
+    config_helper_.prependFilter(MessageUtil::getJsonStringFromMessageOrError(ext_authz_filter));
+  });
+
+  HttpIntegrationTest::initialize();
+
+  auto conn = makeClientConnection(lookupPort("http"));
+  codec_client_ = makeHttpConnection(std::move(conn));
+  response_ = codec_client_->makeHeaderOnlyRequest(Http::TestRequestHeaderMapImpl{
+      {":method", "GET"},
+      {":path", "/"},
+      {":scheme", "http"},
+      {":authority", "host"},
+  });
+
+  AssertionResult result =
+      fake_upstreams_.back()->waitForHttpConnection(*dispatcher_, fake_ext_authz_connection_);
+  RELEASE_ASSERT(result, result.message());
+  result = fake_ext_authz_connection_->waitForNewStream(*dispatcher_, ext_authz_request_);
+  RELEASE_ASSERT(result, result.message());
+  result = ext_authz_request_->waitForEndStream(*dispatcher_);
+  RELEASE_ASSERT(result, result.message());
+
+  // Send a 302 redirect response. Location is NOT explicitly in allowed_client_headers,
+  // but should be automatically included per documentation.
+  Http::TestResponseHeaderMapImpl ext_authz_response_headers{
+      {":status", "302"},
+      {"location", "https://auth.example.com/login"},
+      {"set-cookie", "session=abc123"},
+      {"www-authenticate", "Bearer realm=\"example\""},
+      {"x-should-not-forward", "this-header-should-not-appear"},
+  };
+  ext_authz_request_->encodeHeaders(ext_authz_response_headers, true);
+
+  ASSERT_TRUE(response_->waitForEndStream());
+  EXPECT_TRUE(response_->complete());
+
+  // Verify the response status is 302.
+  EXPECT_EQ("302", response_->headers().getStatusValue());
+
+  // Verify that set-cookie (explicitly configured) is forwarded.
+  EXPECT_EQ(
+      "session=abc123",
+      response_->headers().get(Http::LowerCaseString("set-cookie"))[0]->value().getStringView());
+
+  // Verify that Location is automatically forwarded even though it's not explicitly configured.
+  EXPECT_EQ("https://auth.example.com/login", response_->headers().getLocationValue());
+
+  // Verify that WWW-Authenticate is automatically forwarded.
+  EXPECT_EQ("Bearer realm=\"example\"", response_->headers()
+                                            .get(Http::LowerCaseString("www-authenticate"))[0]
+                                            ->value()
+                                            .getStringView());
+
+  // Verify that headers not in allowed_client_headers (and not auto-included) are NOT forwarded.
+  EXPECT_TRUE(response_->headers().get(Http::LowerCaseString("x-should-not-forward")).empty());
+
+  cleanup();
+}
+
 TEST_P(ExtAuthzHttpIntegrationTest, HttpRetryPolicy) {
   config_helper_.addConfigModifier([this](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
     auto* ext_authz_cluster = bootstrap.mutable_static_resources()->add_clusters();


### PR DESCRIPTION
## Description

This PR add some integration tests to ExtAuthZ around `allowed_client_headers` and `allowed_client_headers_on_success`.

---

**Commit Message:** ext_authz: add more integration tests for ExtAuthZ
**Additional Description:** Added some integration tests to ExtAuthZ around `allowed_client_headers` and `allowed_client_headers_on_success`.
**Risk Level:** Low
**Testing:** Added Integration Tests
**Docs Changes:** N/A
**Release Notes:** N/A