### PR TITLE
build: make qatzip compile with zlib-ng

### DIFF
--- a/bazel/external/BUILD
+++ b/bazel/external/BUILD
@@ -62,3 +62,23 @@ genrule(
     target_compatible_with = ["@platforms//os:linux"],
     visibility = ["//visibility:public"],
 )
+
+# Create a proper static library archive from zlib-ng cc_library.
+cc_static_library(
+    name = "zlib_ng_static",
+    target_compatible_with = ["@platforms//os:linux"],
+    deps = ["@com_github_zlib_ng_zlib_ng//:zlib-ng"],
+)
+
+# Create a properly named libz.a archive for foreign_cc dependencies.
+# The zlib-ng cc_library produces Bazel-internal archives, but foreign_cc
+# configure_make rules (like qatzip) expect a traditional libz.a file
+# that can be found with -lz.
+genrule(
+    name = "zlib_ng_archive",
+    srcs = [":zlib_ng_static"],
+    outs = ["lib/libz.a"],
+    cmd = "mkdir -p $$(dirname $@) && cp $< $@",
+    target_compatible_with = ["@platforms//os:linux"],
+    visibility = ["//visibility:public"],
+)

--- a/contrib/qat/compression/qatzip/compressor/source/BUILD
+++ b/contrib/qat/compression/qatzip/compressor/source/BUILD
@@ -27,11 +27,15 @@ configure_make(
         "--disable-shared",
     ],
     # Include the numa_archive genrule output so that libnuma.a is available
-    # for the linker to find with -lnuma.
-    data = ["//bazel/external:numa_archive"],
-    # Point to the directory containing the libnuma.a archive created by the
-    # numa_archive genrule. The cc_library doesn't produce a file that can be
-    # found with -lnuma, so we need to use the genrule output.
+    # for the linker to find with -lnuma. Include zlib_ng_archive when building
+    # with zlib-ng so that libz.a is available for the configure script.
+    data = ["//bazel/external:numa_archive"] + select({
+        "//bazel:zlib_ng": ["//bazel/external:zlib_ng_archive"],
+        "//conditions:default": [],
+    }),
+    # Point to the directory containing the libnuma.a and libz.a archives.
+    # The cc_library targets don't produce files that can be found with -lnuma
+    # or -lz, so we need to use the genrule outputs.
     env = select({
         "//bazel:clang_build": COMMON_ENV | {
             "CFLAGS": "-Wno-error=newline-eof -Wno-error=strict-prototypes -Wno-error=unused-but-set-variable",


### PR DESCRIPTION
## Description

Today the QATzip extension uses `configure_make` from `rules_foreign_cc`, which runs an autotools-based configure script. This script checks for `zlib` via:
```
checking for deflate in -lz... noconfigure: error: deflate not found
```

With standard `zlib`, the build produces `libz.a` which can be found via `-lz`. But with `zlib-ng`, the library is built as a bazel `cc_library` target producing an internal archive that is not named `libz.a` and is not in a standard library path that is accessible to the `autotools` configure.

This PR modifies `bazel/external/zlib_ng.BUILD` to generate a proper `libz.a` archive using a `genrule`, similar to how `bazel/external/BUILD` creates `numa_archive` today.

---

**Commit Message:** build: make qatzip compile with zlib-ng
**Additional Description:** Modifies `bazel/external/zlib_ng.BUILD` to generate a proper `libz.a` archive using a `genrule`, similar to how `bazel/external/BUILD` creates `numa_archive` today.
**Risk Level:** Low
**Testing:** CI
**Docs Changes:** N/A
**Release Notes:** N/A