### PR TITLE
[bp/v1.37] ext_authz: fix header propagation to client for denied authorization responses

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -8,6 +8,9 @@ minor_behavior_changes:
 
 bug_fixes:
 # *Changes expected to improve the state of the world and are unlikely to have negative effects*
+- area: ext_authz
+  change: |
+    Fixed a bug where headers from a denied authorization response (non-200s) were not properly propagated to the client.
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/test/extensions/filters/common/ext_authz/ext_authz_http_impl_test.cc
+++ b/test/extensions/filters/common/ext_authz/ext_authz_http_impl_test.cc
@@ -795,9 +795,12 @@ TEST_F(ExtAuthzHttpClientTest, SetCookieHeaderOnDenied) {
 
   Response expected_response =
       TestCommon::makeAuthzResponse(CheckStatus::Denied, Http::Code::Forbidden, expected_body);
-  // For denied responses, headers matching allowed_client_headers go to response_headers_to_add.
-  expected_response.response_headers_to_add = {{"set-cookie", "error=invalid"},
-                                               {"x-auth-error", "invalid_token"}};
+  // For denied responses, headers matching allowed_client_headers populate headers_to_set
+  // which is used by the ext_authz filter for the local reply.
+  // Note: :status is included because toClientMatchers adds default matchers for Status,
+  // Content-Length, WWW-Authenticate, and Location when allowed_client_headers is non-empty.
+  expected_response.headers_to_set = {
+      {":status", "403"}, {"set-cookie", "error=invalid"}, {"x-auth-error", "invalid_token"}};
 
   envoy::service::auth::v3::CheckRequest request;
   client_->check(request_callbacks_, request, parent_span_, stream_info_);

--- a/test/extensions/filters/common/ext_authz/test_common.h
+++ b/test/extensions/filters/common/ext_authz/test_common.h
@@ -122,6 +122,10 @@ MATCHER_P(AuthzDeniedResponse, response, "") {
   if (arg->body.compare(response.body)) {
     return false;
   }
+  // Compare headers_to_set (used by ext_authz filter for denied local reply).
+  if (!TestCommon::compareHeaderVector(response.headers_to_set, arg->headers_to_set)) {
+    return false;
+  }
   // Compare headers_to_add.
   return TestCommon::compareHeaderVector(response.headers_to_add, arg->headers_to_add);
 }


### PR DESCRIPTION
## Description

**Back-Port:** https://github.com/envoyproxy/envoy/pull/43043

There seems to be a regression in Envoy v1.37 where ExtAuthZ no longer adds the header allowlisted as part of `allowed_client_headers` for non-successful responses (non-200s). It seems to have been caused by a new behavior change that got added in v1.37 to configure two different lists for successful and non-successful responses i.e. using `allowed_client_headers` and `allowed_client_headers_on_success`.

This PR fixes this regression.

---

**Commit Message:** ext_authz: fix header propagation to client for denied authorization responses
**Additional Description:** Fixes a bug around the header propagation to downstream clients for denied authorization. responses **Risk Level:** Low
**Testing:** Added Unit + Integration Tests
**Docs Changes:** Added
**Release Notes:** Added