### PR TITLE
Fix listener metadata in the accesslog formatter for router upstream_logs

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -39,6 +39,10 @@ bug_fixes:
 - area: ext_authz
   change: |
     Fixed a bug where headers from a denied authorization response (non-200s) were not properly propagated to the client.
+- area: formatter
+  change: |
+    Fixed the log formatter in http router upstream_logs by correctly setting the downstream connection's ConnectionInfoProvider
+    in the stream_info.
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/source/common/router/upstream_request.cc
+++ b/source/common/router/upstream_request.cc
@@ -82,7 +82,10 @@ UpstreamRequest::UpstreamRequest(RouterFilterInterface& parent,
                                  bool can_send_early_data, bool can_use_http3,
                                  bool enable_half_close)
     : parent_(parent), conn_pool_(std::move(conn_pool)),
-      stream_info_(parent_.callbacks()->dispatcher().timeSource(), nullptr,
+      stream_info_(parent_.callbacks()->dispatcher().timeSource(),
+                   parent_.callbacks()->connection().has_value()
+                       ? parent_.callbacks()->connection()->connectionInfoProviderSharedPtr()
+                       : nullptr,
                    StreamInfo::FilterState::LifeSpan::FilterChain),
       start_time_(parent_.callbacks()->dispatcher().timeSource().monotonicTime()),
       upstream_canary_(false), router_sent_end_stream_(false), encode_trailers_(false),


### PR DESCRIPTION
Commit Message: the downstream connectionInfo provider isn't corrected set in the upstream_request streamInfo so some formatter like listener metadata isn't available from router upstream_logs. This PR fixes this.
Additional Description:No need
Risk Level:low
Testing:added
Docs Changes:No need
Release Notes:updated
Platform Specific Features:NA