### PR TITLE
dynamic_modules: add flow control and watermark callback methods to Network ABI

### DIFF
--- a/source/extensions/dynamic_modules/abi.h
+++ b/source/extensions/dynamic_modules/abi.h
@@ -2381,6 +2381,35 @@ typedef enum envoy_dynamic_module_type_network_connection_event {
   envoy_dynamic_module_type_network_connection_event_ConnectedZeroRtt,
 } envoy_dynamic_module_type_network_connection_event;
 
+/**
+ * envoy_dynamic_module_type_network_connection_state represents the current state of a connection.
+ * This corresponds to `Network::Connection::State` in envoy/network/connection.h.
+ */
+typedef enum envoy_dynamic_module_type_network_connection_state {
+  // Connection is open.
+  envoy_dynamic_module_type_network_connection_state_Open,
+  // Connection is closing.
+  envoy_dynamic_module_type_network_connection_state_Closing,
+  // Connection is closed.
+  envoy_dynamic_module_type_network_connection_state_Closed,
+} envoy_dynamic_module_type_network_connection_state;
+
+/**
+ * envoy_dynamic_module_type_network_read_disable_status represents the result of calling
+ * read_disable on a connection.
+ * This corresponds to `Network::Connection::ReadDisableStatus` in envoy/network/connection.h.
+ */
+typedef enum envoy_dynamic_module_type_network_read_disable_status {
+  // No transition occurred.
+  envoy_dynamic_module_type_network_read_disable_status_NoTransition,
+  // Reading is still disabled.
+  envoy_dynamic_module_type_network_read_disable_status_StillReadDisabled,
+  // Transitioned from disabled to enabled.
+  envoy_dynamic_module_type_network_read_disable_status_TransitionedToReadEnabled,
+  // Transitioned from enabled to disabled.
+  envoy_dynamic_module_type_network_read_disable_status_TransitionedToReadDisabled,
+} envoy_dynamic_module_type_network_read_disable_status;
+
 // =============================================================================
 // Network Filter Event Hooks
 // =============================================================================
@@ -2554,6 +2583,34 @@ void envoy_dynamic_module_on_network_filter_scheduled(
 void envoy_dynamic_module_on_network_filter_config_scheduled(
     envoy_dynamic_module_type_network_filter_config_module_ptr filter_config_ptr,
     uint64_t event_id);
+
+/**
+ * envoy_dynamic_module_on_network_filter_above_write_buffer_high_watermark is called when the
+ * write buffer for the connection goes over its high watermark. This can be used to implement
+ * flow control by disabling reads when the write buffer is full.
+ *
+ * @param filter_envoy_ptr is the pointer to the DynamicModuleNetworkFilter object of the
+ * corresponding network filter.
+ * @param filter_module_ptr is the pointer to the in-module network filter created by
+ * envoy_dynamic_module_on_network_filter_new.
+ */
+void envoy_dynamic_module_on_network_filter_above_write_buffer_high_watermark(
+    envoy_dynamic_module_type_network_filter_envoy_ptr filter_envoy_ptr,
+    envoy_dynamic_module_type_network_filter_module_ptr filter_module_ptr);
+
+/**
+ * envoy_dynamic_module_on_network_filter_below_write_buffer_low_watermark is called when the
+ * write buffer for the connection goes from over its high watermark to under its low watermark.
+ * This can be used to re-enable reads after flow control was applied.
+ *
+ * @param filter_envoy_ptr is the pointer to the DynamicModuleNetworkFilter object of the
+ * corresponding network filter.
+ * @param filter_module_ptr is the pointer to the in-module network filter created by
+ * envoy_dynamic_module_on_network_filter_new.
+ */
+void envoy_dynamic_module_on_network_filter_below_write_buffer_low_watermark(
+    envoy_dynamic_module_type_network_filter_envoy_ptr filter_envoy_ptr,
+    envoy_dynamic_module_type_network_filter_module_ptr filter_module_ptr);
 
 // =============================================================================
 // Network Filter Callbacks
@@ -3313,6 +3370,112 @@ bool envoy_dynamic_module_callback_network_filter_has_upstream_host(
  * otherwise.
  */
 bool envoy_dynamic_module_callback_network_filter_start_upstream_secure_transport(
+    envoy_dynamic_module_type_network_filter_envoy_ptr filter_envoy_ptr);
+
+// ---------------------- Connection State and Flow Control Callbacks ----------
+
+/**
+ * envoy_dynamic_module_callback_network_filter_get_connection_state is called by the module to get
+ * the current state of the connection.
+ *
+ * @param filter_envoy_ptr is the pointer to the DynamicModuleNetworkFilter object.
+ * @return the current connection state (Open, Closing, or Closed).
+ */
+envoy_dynamic_module_type_network_connection_state
+envoy_dynamic_module_callback_network_filter_get_connection_state(
+    envoy_dynamic_module_type_network_filter_envoy_ptr filter_envoy_ptr);
+
+/**
+ * envoy_dynamic_module_callback_network_filter_read_disable is called by the module to disable
+ * or enable reading from the connection. This is the primary mechanism for implementing
+ * back-pressure in TCP filters.
+ *
+ * When reads are disabled, no more data will be read from the socket. When re-enabled, if there
+ * is data in the input buffer, it will be re-dispatched through the filter chain.
+ *
+ * Note that this function reference counts calls. For example:
+ *   read_disable(true);  // Disables reading
+ *   read_disable(true);  // Notes the connection is blocked by two sources
+ *   read_disable(false); // Notes the connection is blocked by one source
+ *   read_disable(false); // Marks the connection as unblocked, so resumes reading
+ *
+ * @param filter_envoy_ptr is the pointer to the DynamicModuleNetworkFilter object.
+ * @param disable is true to disable reading, false to enable reading.
+ * @return the status indicating the outcome of the operation.
+ */
+envoy_dynamic_module_type_network_read_disable_status
+envoy_dynamic_module_callback_network_filter_read_disable(
+    envoy_dynamic_module_type_network_filter_envoy_ptr filter_envoy_ptr, bool disable);
+
+/**
+ * envoy_dynamic_module_callback_network_filter_read_enabled is called by the module to check if
+ * reading is currently enabled on the connection.
+ *
+ * @param filter_envoy_ptr is the pointer to the DynamicModuleNetworkFilter object.
+ * @return true if reading is enabled, false if reading is disabled.
+ */
+bool envoy_dynamic_module_callback_network_filter_read_enabled(
+    envoy_dynamic_module_type_network_filter_envoy_ptr filter_envoy_ptr);
+
+/**
+ * envoy_dynamic_module_callback_network_filter_is_half_close_enabled is called by the module to
+ * check if half-close semantics are enabled on this connection.
+ *
+ * When half-close is enabled, reading a remote half-close will not fully close the connection.
+ *
+ * @param filter_envoy_ptr is the pointer to the DynamicModuleNetworkFilter object.
+ * @return true if half-close semantics are enabled, false otherwise.
+ */
+bool envoy_dynamic_module_callback_network_filter_is_half_close_enabled(
+    envoy_dynamic_module_type_network_filter_envoy_ptr filter_envoy_ptr);
+
+/**
+ * envoy_dynamic_module_callback_network_filter_enable_half_close is called by the module to enable
+ * or disable half-close semantics on the connection.
+ *
+ * When half-close is enabled, reading a remote half-close will not fully close the connection,
+ * allowing the filter to continue writing data.
+ *
+ * @param filter_envoy_ptr is the pointer to the DynamicModuleNetworkFilter object.
+ * @param enabled is true to enable half-close semantics, false to disable.
+ */
+void envoy_dynamic_module_callback_network_filter_enable_half_close(
+    envoy_dynamic_module_type_network_filter_envoy_ptr filter_envoy_ptr, bool enabled);
+
+/**
+ * envoy_dynamic_module_callback_network_filter_get_buffer_limit is called by the module to get
+ * the current buffer limit set on the connection.
+ *
+ * @param filter_envoy_ptr is the pointer to the DynamicModuleNetworkFilter object.
+ * @return the current buffer limit in bytes.
+ */
+uint32_t envoy_dynamic_module_callback_network_filter_get_buffer_limit(
+    envoy_dynamic_module_type_network_filter_envoy_ptr filter_envoy_ptr);
+
+/**
+ * envoy_dynamic_module_callback_network_filter_set_buffer_limits is called by the module to set
+ * a soft limit on the size of buffers for the connection.
+ *
+ * For the read buffer, this limits the bytes read prior to flushing to further stages in the
+ * processing pipeline. For the write buffer, it sets watermarks. When enough data is buffered,
+ * it triggers envoy_dynamic_module_on_network_filter_above_write_buffer_high_watermark callback.
+ * When enough data is drained from the write buffer,
+ * envoy_dynamic_module_on_network_filter_below_write_buffer_low_watermark is called.
+ *
+ * @param filter_envoy_ptr is the pointer to the DynamicModuleNetworkFilter object.
+ * @param limit is the buffer limit in bytes.
+ */
+void envoy_dynamic_module_callback_network_filter_set_buffer_limits(
+    envoy_dynamic_module_type_network_filter_envoy_ptr filter_envoy_ptr, uint32_t limit);
+
+/**
+ * envoy_dynamic_module_callback_network_filter_above_high_watermark is called by the module to
+ * check if the connection is currently above the high watermark.
+ *
+ * @param filter_envoy_ptr is the pointer to the DynamicModuleNetworkFilter object.
+ * @return true if the connection is above the high watermark, false otherwise.
+ */
+bool envoy_dynamic_module_callback_network_filter_above_high_watermark(
     envoy_dynamic_module_type_network_filter_envoy_ptr filter_envoy_ptr);
 
 // ---------------------- Network filter scheduler callbacks -------------------

--- a/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
@@ -3939,6 +3939,21 @@ pub trait NetworkFilter<ENF: EnvoyNetworkFilter> {
   ///
   /// See [`EnvoyNetworkFilter::new_scheduler`] for more details on how to use this.
   fn on_scheduled(&mut self, _envoy_filter: &mut ENF, _event_id: u64) {}
+
+  /// This is called when the write buffer for the connection goes over its high watermark.
+  /// This can be used to implement flow control by disabling reads when the write buffer is full.
+  ///
+  /// A typical implementation would call `envoy_filter.read_disable(true)` to stop reading
+  /// from the downstream connection until the write buffer drains.
+  fn on_above_write_buffer_high_watermark(&mut self, _envoy_filter: &mut ENF) {}
+
+  /// This is called when the write buffer for the connection goes from over its high watermark
+  /// to under its low watermark. This can be used to re-enable reads after flow control was
+  /// applied.
+  ///
+  /// A typical implementation would call `envoy_filter.read_disable(false)` to resume reading
+  /// from the downstream connection.
+  fn on_below_write_buffer_low_watermark(&mut self, _envoy_filter: &mut ENF) {}
 }
 
 /// The trait that represents the Envoy network filter.
@@ -4169,6 +4184,53 @@ pub trait EnvoyNetworkFilter {
   /// This is done when upstream connection's transport socket is of startTLS type.
   /// Returns true if the upstream transport was successfully converted to secure mode.
   fn start_upstream_secure_transport(&mut self) -> bool;
+
+  /// Get the current state of the connection (Open, Closing, or Closed).
+  fn get_connection_state(&self) -> abi::envoy_dynamic_module_type_network_connection_state;
+
+  /// Disable or enable reading from the connection. This is the primary mechanism for
+  /// implementing back-pressure in TCP filters.
+  ///
+  /// When reads are disabled, no more data will be read from the socket. When re-enabled,
+  /// if there is data in the input buffer, it will be re-dispatched through the filter chain.
+  ///
+  /// Note that this function reference counts calls. For example:
+  /// ```text
+  /// read_disable(true);  // Disables reading
+  /// read_disable(true);  // Notes the connection is blocked by two sources
+  /// read_disable(false); // Notes the connection is blocked by one source
+  /// read_disable(false); // Marks the connection as unblocked, so resumes reading
+  /// ```
+  fn read_disable(
+    &mut self,
+    disable: bool,
+  ) -> abi::envoy_dynamic_module_type_network_read_disable_status;
+
+  /// Check if reading is currently enabled on the connection.
+  fn read_enabled(&self) -> bool;
+
+  /// Check if half-close semantics are enabled on this connection.
+  /// When half-close is enabled, reading a remote half-close will not fully close the connection.
+  fn is_half_close_enabled(&self) -> bool;
+
+  /// Enable or disable half-close semantics on the connection.
+  /// When half-close is enabled, reading a remote half-close will not fully close the connection,
+  /// allowing the filter to continue writing data.
+  fn enable_half_close(&mut self, enabled: bool);
+
+  /// Get the current buffer limit set on the connection.
+  fn get_buffer_limit(&self) -> u32;
+
+  /// Set a soft limit on the size of buffers for the connection.
+  ///
+  /// For the read buffer, this limits the bytes read prior to flushing to further stages in the
+  /// processing pipeline. For the write buffer, it sets watermarks. When enough data is buffered,
+  /// [`NetworkFilter::on_above_write_buffer_high_watermark`] is called. When enough data is
+  /// drained, [`NetworkFilter::on_below_write_buffer_low_watermark`] is called.
+  fn set_buffer_limits(&mut self, limit: u32);
+
+  /// Check if the connection is currently above the high watermark.
+  fn above_high_watermark(&self) -> bool;
 
   /// Create a new implementation of the [`EnvoyNetworkFilterScheduler`] trait.
   ///
@@ -5213,6 +5275,43 @@ impl EnvoyNetworkFilter for EnvoyNetworkFilterImpl {
     }
   }
 
+  fn get_connection_state(&self) -> abi::envoy_dynamic_module_type_network_connection_state {
+    unsafe { abi::envoy_dynamic_module_callback_network_filter_get_connection_state(self.raw) }
+  }
+
+  fn read_disable(
+    &mut self,
+    disable: bool,
+  ) -> abi::envoy_dynamic_module_type_network_read_disable_status {
+    unsafe { abi::envoy_dynamic_module_callback_network_filter_read_disable(self.raw, disable) }
+  }
+
+  fn read_enabled(&self) -> bool {
+    unsafe { abi::envoy_dynamic_module_callback_network_filter_read_enabled(self.raw) }
+  }
+
+  fn is_half_close_enabled(&self) -> bool {
+    unsafe { abi::envoy_dynamic_module_callback_network_filter_is_half_close_enabled(self.raw) }
+  }
+
+  fn enable_half_close(&mut self, enabled: bool) {
+    unsafe {
+      abi::envoy_dynamic_module_callback_network_filter_enable_half_close(self.raw, enabled)
+    }
+  }
+
+  fn get_buffer_limit(&self) -> u32 {
+    unsafe { abi::envoy_dynamic_module_callback_network_filter_get_buffer_limit(self.raw) }
+  }
+
+  fn set_buffer_limits(&mut self, limit: u32) {
+    unsafe { abi::envoy_dynamic_module_callback_network_filter_set_buffer_limits(self.raw, limit) }
+  }
+
+  fn above_high_watermark(&self) -> bool {
+    unsafe { abi::envoy_dynamic_module_callback_network_filter_above_high_watermark(self.raw) }
+  }
+
   fn new_scheduler(&self) -> impl EnvoyNetworkFilterScheduler + 'static {
     unsafe {
       let scheduler_ptr = abi::envoy_dynamic_module_callback_network_filter_scheduler_new(self.raw);
@@ -5432,6 +5531,26 @@ pub extern "C" fn envoy_dynamic_module_on_network_filter_config_scheduled(
     unsafe { &**raw }
   };
   filter_config.on_config_scheduled(event_id);
+}
+
+#[no_mangle]
+pub extern "C" fn envoy_dynamic_module_on_network_filter_above_write_buffer_high_watermark(
+  envoy_ptr: abi::envoy_dynamic_module_type_network_filter_envoy_ptr,
+  filter_ptr: abi::envoy_dynamic_module_type_network_filter_module_ptr,
+) {
+  let filter = filter_ptr as *mut Box<dyn NetworkFilter<EnvoyNetworkFilterImpl>>;
+  let filter = unsafe { &mut *filter };
+  filter.on_above_write_buffer_high_watermark(&mut EnvoyNetworkFilterImpl::new(envoy_ptr));
+}
+
+#[no_mangle]
+pub extern "C" fn envoy_dynamic_module_on_network_filter_below_write_buffer_low_watermark(
+  envoy_ptr: abi::envoy_dynamic_module_type_network_filter_envoy_ptr,
+  filter_ptr: abi::envoy_dynamic_module_type_network_filter_module_ptr,
+) {
+  let filter = filter_ptr as *mut Box<dyn NetworkFilter<EnvoyNetworkFilterImpl>>;
+  let filter = unsafe { &mut *filter };
+  filter.on_below_write_buffer_low_watermark(&mut EnvoyNetworkFilterImpl::new(envoy_ptr));
 }
 
 // =============================================================================

--- a/source/extensions/filters/network/dynamic_modules/abi_impl.cc
+++ b/source/extensions/filters/network/dynamic_modules/abi_impl.cc
@@ -941,6 +941,93 @@ bool envoy_dynamic_module_callback_network_filter_start_upstream_secure_transpor
 }
 
 // -----------------------------------------------------------------------------
+// Connection State and Flow Control Callbacks
+// -----------------------------------------------------------------------------
+
+namespace {
+
+envoy_dynamic_module_type_network_connection_state
+toAbiConnectionState(Network::Connection::State state) {
+  switch (state) {
+  case Network::Connection::State::Open:
+    return envoy_dynamic_module_type_network_connection_state_Open;
+  case Network::Connection::State::Closing:
+    return envoy_dynamic_module_type_network_connection_state_Closing;
+  case Network::Connection::State::Closed:
+    return envoy_dynamic_module_type_network_connection_state_Closed;
+  }
+  return envoy_dynamic_module_type_network_connection_state_Closed;
+}
+
+envoy_dynamic_module_type_network_read_disable_status
+toAbiReadDisableStatus(Network::Connection::ReadDisableStatus status) {
+  switch (status) {
+  case Network::Connection::ReadDisableStatus::NoTransition:
+    return envoy_dynamic_module_type_network_read_disable_status_NoTransition;
+  case Network::Connection::ReadDisableStatus::StillReadDisabled:
+    return envoy_dynamic_module_type_network_read_disable_status_StillReadDisabled;
+  case Network::Connection::ReadDisableStatus::TransitionedToReadEnabled:
+    return envoy_dynamic_module_type_network_read_disable_status_TransitionedToReadEnabled;
+  case Network::Connection::ReadDisableStatus::TransitionedToReadDisabled:
+    return envoy_dynamic_module_type_network_read_disable_status_TransitionedToReadDisabled;
+  }
+  return envoy_dynamic_module_type_network_read_disable_status_NoTransition;
+}
+
+} // namespace
+
+envoy_dynamic_module_type_network_connection_state
+envoy_dynamic_module_callback_network_filter_get_connection_state(
+    envoy_dynamic_module_type_network_filter_envoy_ptr filter_envoy_ptr) {
+  auto* filter = static_cast<DynamicModuleNetworkFilter*>(filter_envoy_ptr);
+  return toAbiConnectionState(filter->connection().state());
+}
+
+envoy_dynamic_module_type_network_read_disable_status
+envoy_dynamic_module_callback_network_filter_read_disable(
+    envoy_dynamic_module_type_network_filter_envoy_ptr filter_envoy_ptr, bool disable) {
+  auto* filter = static_cast<DynamicModuleNetworkFilter*>(filter_envoy_ptr);
+  auto status = filter->connection().readDisable(disable);
+  return toAbiReadDisableStatus(status);
+}
+
+bool envoy_dynamic_module_callback_network_filter_read_enabled(
+    envoy_dynamic_module_type_network_filter_envoy_ptr filter_envoy_ptr) {
+  auto* filter = static_cast<DynamicModuleNetworkFilter*>(filter_envoy_ptr);
+  return filter->connection().readEnabled();
+}
+
+bool envoy_dynamic_module_callback_network_filter_is_half_close_enabled(
+    envoy_dynamic_module_type_network_filter_envoy_ptr filter_envoy_ptr) {
+  auto* filter = static_cast<DynamicModuleNetworkFilter*>(filter_envoy_ptr);
+  return filter->connection().isHalfCloseEnabled();
+}
+
+void envoy_dynamic_module_callback_network_filter_enable_half_close(
+    envoy_dynamic_module_type_network_filter_envoy_ptr filter_envoy_ptr, bool enabled) {
+  auto* filter = static_cast<DynamicModuleNetworkFilter*>(filter_envoy_ptr);
+  filter->connection().enableHalfClose(enabled);
+}
+
+uint32_t envoy_dynamic_module_callback_network_filter_get_buffer_limit(
+    envoy_dynamic_module_type_network_filter_envoy_ptr filter_envoy_ptr) {
+  auto* filter = static_cast<DynamicModuleNetworkFilter*>(filter_envoy_ptr);
+  return filter->connection().bufferLimit();
+}
+
+void envoy_dynamic_module_callback_network_filter_set_buffer_limits(
+    envoy_dynamic_module_type_network_filter_envoy_ptr filter_envoy_ptr, uint32_t limit) {
+  auto* filter = static_cast<DynamicModuleNetworkFilter*>(filter_envoy_ptr);
+  filter->connection().setBufferLimits(limit);
+}
+
+bool envoy_dynamic_module_callback_network_filter_above_high_watermark(
+    envoy_dynamic_module_type_network_filter_envoy_ptr filter_envoy_ptr) {
+  auto* filter = static_cast<DynamicModuleNetworkFilter*>(filter_envoy_ptr);
+  return filter->connection().aboveHighWatermark();
+}
+
+// -----------------------------------------------------------------------------
 // Network filter scheduler callbacks.
 // -----------------------------------------------------------------------------
 

--- a/source/extensions/filters/network/dynamic_modules/filter.cc
+++ b/source/extensions/filters/network/dynamic_modules/filter.cc
@@ -135,11 +135,19 @@ void DynamicModuleNetworkFilter::onScheduled(uint64_t event_id) {
 }
 
 void DynamicModuleNetworkFilter::onAboveWriteBufferHighWatermark() {
-  // Not currently exposed to dynamic modules.
+  if (in_module_filter_ == nullptr ||
+      config_->on_network_filter_above_write_buffer_high_watermark_ == nullptr) {
+    return;
+  }
+  config_->on_network_filter_above_write_buffer_high_watermark_(thisAsVoidPtr(), in_module_filter_);
 }
 
 void DynamicModuleNetworkFilter::onBelowWriteBufferLowWatermark() {
-  // Not currently exposed to dynamic modules.
+  if (in_module_filter_ == nullptr ||
+      config_->on_network_filter_below_write_buffer_low_watermark_ == nullptr) {
+    return;
+  }
+  config_->on_network_filter_below_write_buffer_low_watermark_(thisAsVoidPtr(), in_module_filter_);
 }
 
 void DynamicModuleNetworkFilter::continueReading() {

--- a/source/extensions/filters/network/dynamic_modules/filter_config.cc
+++ b/source/extensions/filters/network/dynamic_modules/filter_config.cc
@@ -81,6 +81,14 @@ absl::StatusOr<DynamicModuleNetworkFilterConfigSharedPtr> newDynamicModuleNetwor
   auto on_config_scheduled = dynamic_module->getFunctionPointer<OnNetworkFilterConfigScheduledType>(
       "envoy_dynamic_module_on_network_filter_config_scheduled");
 
+  // Optional: modules that don't need watermark notifications don't need to implement these.
+  auto on_above_write_buffer_high_watermark =
+      dynamic_module->getFunctionPointer<OnNetworkFilterAboveWriteBufferHighWatermarkType>(
+          "envoy_dynamic_module_on_network_filter_above_write_buffer_high_watermark");
+  auto on_below_write_buffer_low_watermark =
+      dynamic_module->getFunctionPointer<OnNetworkFilterBelowWriteBufferLowWatermarkType>(
+          "envoy_dynamic_module_on_network_filter_below_write_buffer_low_watermark");
+
   auto config = std::make_shared<DynamicModuleNetworkFilterConfig>(
       filter_name, filter_config, std::move(dynamic_module), cluster_manager, stats_scope,
       main_thread_dispatcher);
@@ -99,6 +107,12 @@ absl::StatusOr<DynamicModuleNetworkFilterConfigSharedPtr> newDynamicModuleNetwor
       on_filter_scheduled.ok() ? on_filter_scheduled.value() : nullptr;
   config->on_network_filter_config_scheduled_ =
       on_config_scheduled.ok() ? on_config_scheduled.value() : nullptr;
+  config->on_network_filter_above_write_buffer_high_watermark_ =
+      on_above_write_buffer_high_watermark.ok() ? on_above_write_buffer_high_watermark.value()
+                                                : nullptr;
+  config->on_network_filter_below_write_buffer_low_watermark_ =
+      on_below_write_buffer_low_watermark.ok() ? on_below_write_buffer_low_watermark.value()
+                                               : nullptr;
 
   // Create the in-module configuration.
   envoy_dynamic_module_type_envoy_buffer name_buffer = {const_cast<char*>(filter_name.data()),

--- a/source/extensions/filters/network/dynamic_modules/filter_config.h
+++ b/source/extensions/filters/network/dynamic_modules/filter_config.h
@@ -29,6 +29,10 @@ using OnNetworkFilterHttpCalloutDoneType =
 using OnNetworkFilterScheduledType = decltype(&envoy_dynamic_module_on_network_filter_scheduled);
 using OnNetworkFilterConfigScheduledType =
     decltype(&envoy_dynamic_module_on_network_filter_config_scheduled);
+using OnNetworkFilterAboveWriteBufferHighWatermarkType =
+    decltype(&envoy_dynamic_module_on_network_filter_above_write_buffer_high_watermark);
+using OnNetworkFilterBelowWriteBufferLowWatermarkType =
+    decltype(&envoy_dynamic_module_on_network_filter_below_write_buffer_low_watermark);
 
 // Custom namespace prefix for network filter stats.
 constexpr char NetworkFilterStatsNamespace[] = "dynamic_module_network_filter";
@@ -88,6 +92,11 @@ public:
   // Optional: modules that don't need scheduling don't need to implement this.
   OnNetworkFilterScheduledType on_network_filter_scheduled_ = nullptr;
   OnNetworkFilterConfigScheduledType on_network_filter_config_scheduled_ = nullptr;
+  // Optional: modules that don't need watermark notifications don't need to implement these.
+  OnNetworkFilterAboveWriteBufferHighWatermarkType
+      on_network_filter_above_write_buffer_high_watermark_ = nullptr;
+  OnNetworkFilterBelowWriteBufferLowWatermarkType
+      on_network_filter_below_write_buffer_low_watermark_ = nullptr;
 
   Envoy::Upstream::ClusterManager& cluster_manager_;
 


### PR DESCRIPTION
## Description

This PR adds support for flow control and watermark callback methods to the Network filter ABI.

---

**Commit Message:** dynamic_modules: add flow control and watermark callback methods to Network ABI
**Additional Description:** Added support for flow control and watermark callback methods to the Network filter ABI.
**Risk Level:** Low
**Testing:** Added Unit + Integration Tests
**Docs Changes:** Added
**Release Notes:** N/A