### PR TITLE
deps/python: manually bump aiohttp to 3.13

### DIFF
--- a/tools/base/requirements.in
+++ b/tools/base/requirements.in
@@ -3,7 +3,7 @@ aio.api.bazel
 aio.api.github>=0.2.5
 aio.core>=0.10.2
 aiodocker>=0.22.2
-aiohttp>=3.11.6
+aiohttp>=3.13.3
 aioquic>=0.9.21
 cffi>=1.15.0
 colorama


### PR DESCRIPTION
Commit Message:
mainly to make sure we address the following CVE

https://osv.dev/vulnerability/GHSA-6mq8-rvhq-8wgg

no specific impact as the requirements is already up to date

Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
