### PR TITLE
dynamic_modules: add support for hot reloading

### DIFF
--- a/api/envoy/extensions/dynamic_modules/v3/dynamic_modules.proto
+++ b/api/envoy/extensions/dynamic_modules/v3/dynamic_modules.proto
@@ -30,6 +30,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // the ABI is stabilized, this restriction will be revisited. Until then, Envoy checks the hash of
 // the ABI header files to ensure that the dynamic modules are built against the same version of the
 // ABI.
+// [#next-free-field: 6]
 message DynamicModuleConfig {
   // The name of the dynamic module.
   //
@@ -45,7 +46,7 @@ message DynamicModuleConfig {
   //   There is some remaining work to make the search path configurable via command line options.
   string name = 1 [(validate.rules).string = {min_len: 1}];
 
-  // If true, prevents the module from being unloaded with ``dlclose``.
+  // If ``true``, prevents the module from being unloaded with ``dlclose``.
   //
   // This is useful for modules that have global state that should not be unloaded. A module is
   // closed when no more references to it exist in the process. For example, no HTTP filters are
@@ -54,7 +55,7 @@ message DynamicModuleConfig {
   // Defaults to ``false``.
   bool do_not_close = 3;
 
-  // If true, the dynamic module is loaded with the ``RTLD_GLOBAL`` flag.
+  // If ``true``, the dynamic module is loaded with the ``RTLD_GLOBAL`` flag.
   //
   // The dynamic module is loaded with the ``RTLD_LOCAL`` flag by default to avoid symbol conflicts
   // when multiple modules are loaded. Set this to ``true`` to load the module with the
@@ -69,4 +70,19 @@ message DynamicModuleConfig {
   //
   // Defaults to ``false``.
   bool load_globally = 4;
+
+  // If ``true``, forces the module to be loaded fresh even if a module with the same path is already
+  // loaded. This is useful for hot reloading scenarios where the module binary has been updated on
+  // disk and a new version needs to be loaded.
+  //
+  // When enabled, Envoy will bypass the check that normally prevents loading duplicate modules,
+  // allowing multiple versions of the same module to coexist temporarily. The old version will
+  // remain loaded until all references to it (e.g., in-flight requests) are released.
+  //
+  // .. warning::
+  //   This option cannot be used together with ``do_not_close``. The module must be unloadable
+  //   for hot reloading to work correctly.
+  //
+  // Defaults to ``false``.
+  bool force_reload = 5;
 }

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -72,5 +72,11 @@ new_features:
   change: |
     Added ``%DOWNSTREAM_DETECTED_CLOSE_TYPE%`` to expose the detected close type
     of downstream and connections. The possible values are ``Normal``, ``LocalReset``, and ``RemoteReset``.
+- area: dynamic_modules
+  change: |
+    Added support for hot-reloading dynamic modules via the ``force_reload`` option in the
+    :ref:`DynamicModuleConfig <envoy_v3_api_msg_extensions.dynamic_modules.v3.DynamicModuleConfig>`.
+    When enabled, Envoy will load a fresh copy of the module even if one with the same path is
+    already loaded, allowing module binaries to be updated on disk without restarting Envoy.
 
 deprecated:

--- a/source/extensions/access_loggers/dynamic_modules/config.cc
+++ b/source/extensions/access_loggers/dynamic_modules/config.cc
@@ -21,7 +21,8 @@ AccessLog::InstanceSharedPtr DynamicModuleAccessLogFactory::createAccessLogInsta
 
   const auto& module_config = proto_config.dynamic_module_config();
   auto dynamic_module_or_error = Extensions::DynamicModules::newDynamicModuleByName(
-      module_config.name(), module_config.do_not_close(), module_config.load_globally());
+      module_config.name(), module_config.do_not_close(), module_config.load_globally(),
+      module_config.force_reload());
 
   if (!dynamic_module_or_error.ok()) {
     throw EnvoyException("Failed to load dynamic module: " +

--- a/source/extensions/bootstrap/dynamic_modules/factory.cc
+++ b/source/extensions/bootstrap/dynamic_modules/factory.cc
@@ -22,7 +22,8 @@ Server::BootstrapExtensionPtr DynamicModuleBootstrapExtensionFactory::createBoot
 
   const auto& module_config = proto_config.dynamic_module_config();
   auto dynamic_module = Extensions::DynamicModules::newDynamicModuleByName(
-      module_config.name(), module_config.do_not_close(), module_config.load_globally());
+      module_config.name(), module_config.do_not_close(), module_config.load_globally(),
+      module_config.force_reload());
   if (!dynamic_module.ok()) {
     throwEnvoyExceptionOrPanic("Failed to load dynamic module: " +
                                std::string(dynamic_module.status().message()));

--- a/source/extensions/dynamic_modules/dynamic_modules.h
+++ b/source/extensions/dynamic_modules/dynamic_modules.h
@@ -66,10 +66,12 @@ using DynamicModulePtr = std::unique_ptr<DynamicModule>;
  * @param load_globally if true, the dlopen will be called with RTLD_GLOBAL, so the loaded object
  * can share symbols with other dynamically loaded modules. This is useful for modules that need to
  * share symbols with other modules.
+ * @param force_reload if true, forces the module to be loaded fresh even if a module with the same
+ * path is already loaded. This bypasses the RTLD_NOLOAD check. Cannot be used with do_not_close.
  */
 absl::StatusOr<DynamicModulePtr>
 newDynamicModule(const std::filesystem::path& object_file_absolute_path, const bool do_not_close,
-                 const bool load_globally = false);
+                 const bool load_globally = false, const bool force_reload = false);
 
 /**
  * Creates a new DynamicModule by name under the search path specified by the environment variable
@@ -82,10 +84,13 @@ newDynamicModule(const std::filesystem::path& object_file_absolute_path, const b
  * @param load_globally if true, the dlopen will be called with RTLD_GLOBAL, so the loaded object
  * can share symbols with other dynamically loaded modules. This is useful for modules that need to
  * share symbols with other modules.
+ * @param force_reload if true, forces the module to be loaded fresh even if a module with the same
+ * path is already loaded. This bypasses the RTLD_NOLOAD check. Cannot be used with do_not_close.
  */
 absl::StatusOr<DynamicModulePtr> newDynamicModuleByName(const absl::string_view module_name,
                                                         const bool do_not_close,
-                                                        const bool load_globally = false);
+                                                        const bool load_globally = false,
+                                                        const bool force_reload = false);
 } // namespace DynamicModules
 } // namespace Extensions
 } // namespace Envoy

--- a/source/extensions/filters/http/dynamic_modules/factory.cc
+++ b/source/extensions/filters/http/dynamic_modules/factory.cc
@@ -13,7 +13,8 @@ absl::StatusOr<Http::FilterFactoryCb> DynamicModuleConfigFactory::createFilterFa
 
   const auto& module_config = proto_config.dynamic_module_config();
   auto dynamic_module = Extensions::DynamicModules::newDynamicModuleByName(
-      module_config.name(), module_config.do_not_close(), module_config.load_globally());
+      module_config.name(), module_config.do_not_close(), module_config.load_globally(),
+      module_config.force_reload());
   if (!dynamic_module.ok()) {
     return absl::InvalidArgumentError("Failed to load dynamic module: " +
                                       std::string(dynamic_module.status().message()));
@@ -63,7 +64,8 @@ DynamicModuleConfigFactory::createRouteSpecificFilterConfigTyped(
 
   const auto& module_config = proto_config.dynamic_module_config();
   auto dynamic_module = Extensions::DynamicModules::newDynamicModuleByName(
-      module_config.name(), module_config.do_not_close(), module_config.load_globally());
+      module_config.name(), module_config.do_not_close(), module_config.load_globally(),
+      module_config.force_reload());
   if (!dynamic_module.ok()) {
     return absl::InvalidArgumentError("Failed to load dynamic module: " +
                                       std::string(dynamic_module.status().message()));

--- a/source/extensions/filters/listener/dynamic_modules/factory.cc
+++ b/source/extensions/filters/listener/dynamic_modules/factory.cc
@@ -21,7 +21,8 @@ DynamicModuleListenerFilterConfigFactory::createListenerFilterFactoryFromProto(
 
   const auto& module_config = proto_config.dynamic_module_config();
   auto dynamic_module = Extensions::DynamicModules::newDynamicModuleByName(
-      module_config.name(), module_config.do_not_close(), module_config.load_globally());
+      module_config.name(), module_config.do_not_close(), module_config.load_globally(),
+      module_config.force_reload());
   if (!dynamic_module.ok()) {
     throw EnvoyException("Failed to load dynamic module: " +
                          std::string(dynamic_module.status().message()));

--- a/source/extensions/filters/network/dynamic_modules/factory.cc
+++ b/source/extensions/filters/network/dynamic_modules/factory.cc
@@ -16,7 +16,8 @@ DynamicModuleNetworkFilterConfigFactory::createFilterFactoryFromProtoTyped(
 
   const auto& module_config = proto_config.dynamic_module_config();
   auto dynamic_module = Extensions::DynamicModules::newDynamicModuleByName(
-      module_config.name(), module_config.do_not_close(), module_config.load_globally());
+      module_config.name(), module_config.do_not_close(), module_config.load_globally(),
+      module_config.force_reload());
   if (!dynamic_module.ok()) {
     return absl::InvalidArgumentError("Failed to load dynamic module: " +
                                       std::string(dynamic_module.status().message()));

--- a/source/extensions/filters/udp/dynamic_modules/factory.cc
+++ b/source/extensions/filters/udp/dynamic_modules/factory.cc
@@ -17,7 +17,8 @@ DynamicModuleUdpListenerFilterConfigFactory::createFilterFactoryFromProto(
   auto dynamic_module_or_error = Extensions::DynamicModules::newDynamicModuleByName(
       proto_config.dynamic_module_config().name(),
       proto_config.dynamic_module_config().do_not_close(),
-      proto_config.dynamic_module_config().load_globally());
+      proto_config.dynamic_module_config().load_globally(),
+      proto_config.dynamic_module_config().force_reload());
 
   if (!dynamic_module_or_error.ok()) {
     throw EnvoyException(std::string(dynamic_module_or_error.status().message()));


### PR DESCRIPTION
## Description

This PR adds support for hot reloading for Dynamic Modules via a new `force_reload` option. When enabled, Envoy will load a fresh copy of the module even if one with the same path is already loaded, allowing module binaries to be updated on disk without restarting Envoy.

---

**Commit Message:** dynamic_modules: add support for hot reloading
**Additional Description:** Added support for hot reloading for Dynamic Modules via a new `force_reload` option.
**Risk Level:** Low
**Testing:** Added Tests
**Docs Changes:** Added
**Release Notes:** Added