### PR TITLE
docs: Improve threading model docs

### DIFF
--- a/docs/root/intro/arch_overview/intro/threading_model.rst
+++ b/docs/root/intro/arch_overview/intro/threading_model.rst
@@ -11,7 +11,7 @@ High-Level Overview
 -------------------
 
 .. note::
-  Matt Klein wrote a `detailed blog post <https://blog.envoyproxy.io/envoy-threading-model-a8d44b922310>`_ 
+  Matt Klein wrote a `detailed blog post <https://blog.envoyproxy.io/envoy-threading-model-a8d44b922310>`_
   on the Envoy threading model. Though it is a bit old, it is still accurate anda great companion to this
   document.
 


### PR DESCRIPTION
This patch elaborates on the existing threading model documentation.

The document starts with a higher-level overview and then goes into details that developers will care about. This also adds examples of using the dispatcher in tests, troubleshooting, etc.

_AI was used to assist in writing, but I more-or-less rewrote the slop. I stand behind every line and have verified every link._

Risk Level: n/a
Testing: n/a
Docs Changes: Oh yes!
Release Notes: n/a