### PR TITLE
dynamic module: support server factory based context

### DIFF
--- a/source/extensions/filters/http/dynamic_modules/factory.cc
+++ b/source/extensions/filters/http/dynamic_modules/factory.cc
@@ -7,9 +7,9 @@ namespace Envoy {
 namespace Server {
 namespace Configuration {
 
-absl::StatusOr<Http::FilterFactoryCb> DynamicModuleConfigFactory::createFilterFactoryFromProtoTyped(
-    const FilterConfig& proto_config, const std::string&, DualInfo dual_info,
-    Server::Configuration::ServerFactoryContext& context) {
+absl::StatusOr<Http::FilterFactoryCb> DynamicModuleConfigFactory::createFilterFactory(
+    const FilterConfig& proto_config, const std::string&,
+    Server::Configuration::ServerFactoryContext& context, Stats::Scope& scope) {
 
   const auto& module_config = proto_config.dynamic_module_config();
   auto dynamic_module = Extensions::DynamicModules::newDynamicModuleByName(
@@ -30,7 +30,7 @@ absl::StatusOr<Http::FilterFactoryCb> DynamicModuleConfigFactory::createFilterFa
       filter_config =
           Envoy::Extensions::DynamicModules::HttpFilters::newDynamicModuleHttpFilterConfig(
               proto_config.filter_name(), config, proto_config.terminal_filter(),
-              std::move(dynamic_module.value()), dual_info.scope, context);
+              std::move(dynamic_module.value()), scope, context);
 
   if (!filter_config.ok()) {
     return absl::InvalidArgumentError("Failed to create filter config: " +
@@ -54,6 +54,15 @@ absl::StatusOr<Http::FilterFactoryCb> DynamicModuleConfigFactory::createFilterFa
     filter->initializeInModuleFilter();
     callbacks.addStreamFilter(filter);
   };
+}
+
+Envoy::Http::FilterFactoryCb
+DynamicModuleConfigFactory::createFilterFactoryFromProtoWithServerContextTyped(
+    const FilterConfig& proto_config, const std::string& stat_prefix,
+    Server::Configuration::ServerFactoryContext& context) {
+  auto cb_or_error = createFilterFactory(proto_config, stat_prefix, context, context.scope());
+  THROW_IF_NOT_OK_REF(cb_or_error.status());
+  return cb_or_error.value();
 }
 
 absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>

--- a/source/extensions/filters/http/dynamic_modules/factory.h
+++ b/source/extensions/filters/http/dynamic_modules/factory.h
@@ -20,8 +20,18 @@ class DynamicModuleConfigFactory
 public:
   DynamicModuleConfigFactory() : DualFactoryBase("envoy.extensions.filters.http.dynamic_modules") {}
   absl::StatusOr<Http::FilterFactoryCb>
-  createFilterFactoryFromProtoTyped(const FilterConfig& raw_config, const std::string&, DualInfo,
-                                    Server::Configuration::ServerFactoryContext& context) override;
+  createFilterFactoryFromProtoTyped(const FilterConfig& proto_config,
+                                    const std::string& stat_prefix, DualInfo dual_info,
+                                    Server::Configuration::ServerFactoryContext& context) override {
+    return createFilterFactory(proto_config, stat_prefix, context, dual_info.scope);
+  }
+  Envoy::Http::FilterFactoryCb createFilterFactoryFromProtoWithServerContextTyped(
+      const FilterConfig& proto_config, const std::string& stat_prefix,
+      Server::Configuration::ServerFactoryContext& context) override;
+
+  absl::StatusOr<Http::FilterFactoryCb>
+  createFilterFactory(const FilterConfig& proto_config, const std::string& stat_prefix,
+                      Server::Configuration::ServerFactoryContext& context, Stats::Scope& scope);
 
   absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
   createRouteSpecificFilterConfigTyped(const RouteConfigProto&,

--- a/tools/code_format/config.yaml
+++ b/tools/code_format/config.yaml
@@ -170,6 +170,7 @@ paths:
     - source/extensions/filters/http/cache
     - source/extensions/filters/http/common
     - source/extensions/filters/http/composite
+    - source/extensions/filters/http/dynamic_modules/factory.cc
     - source/extensions/filters/http/ext_authz
     - source/extensions/filters/http/ext_proc
     - source/extensions/filters/http/file_system_buffer


### PR DESCRIPTION


Commit Message: dynamic module: support server factory based context
Additional Description:

To support loading dynamic module based on server factory context. Once https://github.com/envoyproxy/envoy/pull/42912 is done, we could easily to support actual per route dynamic module filter.

Risk Level: low.
Testing: unit.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
