### PR TITLE
tls: cert_mapper/sni add config flag for appending signature algorithm to the secret name

### DIFF
--- a/api/envoy/extensions/transport_sockets/tls/cert_mappers/sni/v3/config.proto
+++ b/api/envoy/extensions/transport_sockets/tls/cert_mappers/sni/v3/config.proto
@@ -18,4 +18,8 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 message SNI {
   // The value to use as the secret name when SNI is empty or absent.
   string default_value = 1 [(validate.rules).string = {min_len: 1}];
+
+  // Whether to include the signature algorithm in the SNI-based name. If true, the secret name will be in the format
+  // "<sni>/<signature_algorithm>". If false, the secret name will be just "<sni>".
+  bool include_signature_algorithm = 2;
 }

--- a/api/envoy/extensions/transport_sockets/tls/cert_mappers/sni/v3/config.proto
+++ b/api/envoy/extensions/transport_sockets/tls/cert_mappers/sni/v3/config.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package envoy.extensions.transport_sockets.tls.cert_mappers.sni.v3;
 
+import "google/protobuf/wrappers.proto";
+
 import "udpa/annotations/status.proto";
 import "validate/validate.proto";
 
@@ -21,5 +23,5 @@ message SNI {
 
   // Whether to include the signature algorithm in the SNI-based name. If true, the secret name will be in the format
   // "<sni>/<signature_algorithm>". If false, the secret name will be just "<sni>".
-  bool include_signature_algorithm = 2;
+  google.protobuf.BoolValue include_signature_algorithm = 2;
 }

--- a/source/extensions/transport_sockets/tls/cert_mappers/sni/config.cc
+++ b/source/extensions/transport_sockets/tls/cert_mappers/sni/config.cc
@@ -55,7 +55,8 @@ SNIMapperFactory::createTlsCertificateMapperFactory(
   const SNIConfigProto& config = MessageUtil::downcastAndValidate<const SNIConfigProto&>(
       proto_config, factory_context.messageValidationVisitor());
   return [default_value = config.default_value(),
-          include_signature_algorithm = config.include_signature_algorithm()]() {
+          include_signature_algorithm =
+              PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, include_signature_algorithm, false)]() {
     return std::make_unique<SNIMapper>(default_value, include_signature_algorithm);
   };
 }

--- a/source/extensions/transport_sockets/tls/cert_mappers/sni/config.cc
+++ b/source/extensions/transport_sockets/tls/cert_mappers/sni/config.cc
@@ -12,15 +12,39 @@ namespace SNI {
 namespace {
 class SNIMapper : public Ssl::TlsCertificateMapper {
 public:
-  explicit SNIMapper(const std::string& default_value) : default_value_(default_value) {}
+  explicit SNIMapper(const std::string& default_value, const bool include_signature_algorithm)
+      : default_value_(default_value), include_signature_algorithm_(include_signature_algorithm) {}
   std::string deriveFromClientHello(const SSL_CLIENT_HELLO& ssl_client_hello) {
     absl::string_view sni = absl::NullSafeStringView(
         SSL_get_servername(ssl_client_hello.ssl, TLSEXT_NAMETYPE_host_name));
+    if (include_signature_algorithm_) {
+      return deriveWithSignatureAlgorithm(ssl_client_hello, sni);
+    }
     return sni.empty() ? default_value_ : std::string(sni);
+  }
+
+  std::string deriveWithSignatureAlgorithm(const SSL_CLIENT_HELLO& ssl_client_hello,
+                                           const absl::string_view sni) const {
+    for (size_t i = 0; i < ssl_client_hello.cipher_suites_len; i += 2) {
+      uint16_t cipher_suite =
+          (ssl_client_hello.cipher_suites[i] << 8) | ssl_client_hello.cipher_suites[i + 1];
+      const SSL_CIPHER* cipher = SSL_get_cipher_by_value(cipher_suite);
+      if (cipher == nullptr) {
+        continue;
+      }
+      const int sig_alg = SSL_CIPHER_get_auth_nid(cipher);
+      // TLS 1.3 signature algorithms will return NID_auth_any.
+      if (sig_alg == NID_auth_ecdsa || sig_alg == NID_auth_any) {
+        // return SNI with ECDSA suffix early if ECDSA support is detected
+        return (sni.empty() ? default_value_ : std::string(sni)) + "/ecdsa";
+      }
+    }
+    return (sni.empty() ? default_value_ : std::string(sni)) + "/rsa";
   }
 
 private:
   const std::string default_value_;
+  const bool include_signature_algorithm_;
 };
 } // namespace
 
@@ -30,8 +54,9 @@ SNIMapperFactory::createTlsCertificateMapperFactory(
     Server::Configuration::GenericFactoryContext& factory_context) {
   const SNIConfigProto& config = MessageUtil::downcastAndValidate<const SNIConfigProto&>(
       proto_config, factory_context.messageValidationVisitor());
-  return [default_value = config.default_value()]() {
-    return std::make_unique<SNIMapper>(default_value);
+  return [default_value = config.default_value(),
+          include_signature_algorithm = config.include_signature_algorithm()]() {
+    return std::make_unique<SNIMapper>(default_value, include_signature_algorithm);
   };
 }
 

--- a/test/extensions/transport_sockets/tls/cert_mappers/sni/BUILD
+++ b/test/extensions/transport_sockets/tls/cert_mappers/sni/BUILD
@@ -1,0 +1,24 @@
+load(
+    "//bazel:envoy_build_system.bzl",
+    "envoy_package",
+)
+load(
+    "//test/extensions:extensions_build_system.bzl",
+    "envoy_extension_cc_test",
+)
+
+licenses(["notice"])  # Apache 2
+
+envoy_package()
+
+envoy_extension_cc_test(
+    name = "config_test",
+    srcs = ["config_test.cc"],
+    extension_names = [],
+    deps = [
+        "//source/extensions/transport_sockets/tls/cert_mappers/sni:config",
+        "//test/mocks/server:server_factory_context_mocks",
+        "//test/test_common:status_utility_lib",
+        "@envoy_api//envoy/extensions/transport_sockets/tls/cert_mappers/sni/v3:pkg_cc_proto",
+    ],
+)

--- a/test/extensions/transport_sockets/tls/cert_mappers/sni/config_test.cc
+++ b/test/extensions/transport_sockets/tls/cert_mappers/sni/config_test.cc
@@ -1,0 +1,99 @@
+#include "envoy/extensions/transport_sockets/tls/cert_mappers/sni/v3/config.pb.h"
+
+#include "test/mocks/server/server_factory_context.h"
+#include "test/test_common/status_utility.h"
+
+#include "openssl/ssl.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace TransportSockets {
+namespace Tls {
+namespace CertificateMappers {
+namespace SNI {
+namespace {
+
+using ::testing::NiceMock;
+
+TEST(SNIMapper, DerivationSNI) {
+  NiceMock<Server::Configuration::MockGenericFactoryContext> factory_context;
+  Ssl::TlsCertificateMapperConfigFactory& mapper_factory =
+      Config::Utility::getAndCheckFactoryByName<Ssl::TlsCertificateMapperConfigFactory>(
+          "envoy.tls.certificate_mappers.sni");
+  envoy::extensions::transport_sockets::tls::cert_mappers::sni::v3::SNI config;
+  TestUtility::loadFromYaml(R"EOF(
+    default_value: "*"
+  )EOF",
+                            config);
+  auto mapper_status = mapper_factory.createTlsCertificateMapperFactory(config, factory_context);
+  ASSERT_OK(mapper_status);
+  auto mapper = mapper_status.value()();
+  bssl::UniquePtr<SSL_CTX> ctx(SSL_CTX_new(TLS_method()));
+  bssl::UniquePtr<SSL> ssl(SSL_new(ctx.get()));
+  SSL_set_tlsext_host_name(ssl.get(), "example.com");
+  SSL_CLIENT_HELLO ssl_client_hello;
+  ssl_client_hello.ssl = ssl.get();
+  EXPECT_EQ("example.com", mapper->deriveFromClientHello(ssl_client_hello));
+}
+
+TEST(SNIMapper, DerivationECDSA) {
+  NiceMock<Server::Configuration::MockGenericFactoryContext> factory_context;
+  Ssl::TlsCertificateMapperConfigFactory& mapper_factory =
+      Config::Utility::getAndCheckFactoryByName<Ssl::TlsCertificateMapperConfigFactory>(
+          "envoy.tls.certificate_mappers.sni");
+  envoy::extensions::transport_sockets::tls::cert_mappers::sni::v3::SNI config;
+  TestUtility::loadFromYaml(R"EOF(
+    default_value: "*"
+    include_signature_algorithm: true
+  )EOF",
+                            config);
+  auto mapper_status = mapper_factory.createTlsCertificateMapperFactory(config, factory_context);
+  ASSERT_OK(mapper_status);
+  auto mapper = mapper_status.value()();
+  bssl::UniquePtr<SSL_CTX> ctx(SSL_CTX_new(TLS_method()));
+  bssl::UniquePtr<SSL> ssl(SSL_new(ctx.get()));
+  SSL_set_tlsext_host_name(ssl.get(), "example.com");
+  SSL_CLIENT_HELLO ssl_client_hello;
+  ssl_client_hello.ssl = ssl.get();
+  // Simulate ECDSA support in client hello.
+  constexpr uint8_t ecdsa_cipher_suite[] = {(TLS1_3_CK_AES_256_GCM_SHA384 >> 8) & 0xFF,
+                                            TLS1_3_CK_AES_256_GCM_SHA384 & 0xFF};
+  ssl_client_hello.cipher_suites = ecdsa_cipher_suite;
+  ssl_client_hello.cipher_suites_len = sizeof(ecdsa_cipher_suite);
+  EXPECT_EQ("example.com/ecdsa", mapper->deriveFromClientHello(ssl_client_hello));
+}
+
+TEST(SNIMapper, DerivationRSA) {
+  NiceMock<Server::Configuration::MockGenericFactoryContext> factory_context;
+  Ssl::TlsCertificateMapperConfigFactory& mapper_factory =
+      Config::Utility::getAndCheckFactoryByName<Ssl::TlsCertificateMapperConfigFactory>(
+          "envoy.tls.certificate_mappers.sni");
+  envoy::extensions::transport_sockets::tls::cert_mappers::sni::v3::SNI config;
+  TestUtility::loadFromYaml(R"EOF(
+    default_value: "*"
+    include_signature_algorithm: true
+  )EOF",
+                            config);
+  auto mapper_status = mapper_factory.createTlsCertificateMapperFactory(config, factory_context);
+  ASSERT_OK(mapper_status);
+  auto mapper = mapper_status.value()();
+  bssl::UniquePtr<SSL_CTX> ctx(SSL_CTX_new(TLS_method()));
+  bssl::UniquePtr<SSL> ssl(SSL_new(ctx.get()));
+  SSL_set_tlsext_host_name(ssl.get(), "example.com");
+  SSL_CLIENT_HELLO ssl_client_hello;
+  ssl_client_hello.ssl = ssl.get();
+  // Simulate RSA support in client hello.
+  constexpr uint8_t ecdsa_cipher_suite[] = {(TLS1_CK_DH_RSA_WITH_AES_256_SHA256 >> 8) & 0xFF,
+                                            TLS1_CK_DH_RSA_WITH_AES_256_SHA256 & 0xFF};
+  ssl_client_hello.cipher_suites = ecdsa_cipher_suite;
+  ssl_client_hello.cipher_suites_len = sizeof(ecdsa_cipher_suite);
+  EXPECT_EQ("example.com/rsa", mapper->deriveFromClientHello(ssl_client_hello));
+}
+
+} // namespace
+} // namespace SNI
+} // namespace CertificateMappers
+} // namespace Tls
+} // namespace TransportSockets
+} // namespace Extensions
+} // namespace Envoy


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message: Adding opt-in support for RSA/ECDSA certificates to the cert_mapper for on_demand_secrets
Additional Description: When the configuration is set to true, all requests for secrets from the SNI mapper will have either `/rsa` or `/ecdsa` appended to the SNI name to indicate which type of certificate should be returned from SDS.
Risk Level: Low
Testing: Manual testing using a custom client to submit requests with specific cipher lists targeting only RSA, only ECDSA, and both.  Also added tests against the SNI cert_mapper to verify suffixed secret names are returned.
Docs Changes: An additional field was added to the existing config for the SNI cert mapper.
Release Notes: 
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
