### PR TITLE
oauth2: Copy Host header when building OAuth2 refresh requests (#43014)

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -11,6 +11,9 @@ bug_fixes:
 - area: ext_authz
   change: |
     Fixed a bug where headers from a denied authorization response (non-200s) were not properly propagated to the client.
+- area: oauth2
+  change: |
+    Fixed OAuth2 refresh requests so host rewriting no longer overrides the original Host value.
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/source/extensions/filters/http/oauth2/filter.cc
+++ b/source/extensions/filters/http/oauth2/filter.cc
@@ -574,7 +574,7 @@ void OAuth2CookieValidator::setParams(const Http::RequestHeaderMap& headers,
   id_token_ = findValue(cookies, cookie_names_.id_token_);
   refresh_token_ = findValue(cookies, cookie_names_.refresh_token_);
   hmac_ = findValue(cookies, cookie_names_.oauth_hmac_);
-  host_ = headers.Host()->value().getStringView();
+  host_ = std::string(headers.Host()->value().getStringView());
 
   secret_.assign(secret.begin(), secret.end());
 }
@@ -657,7 +657,7 @@ Http::FilterHeadersStatus OAuth2Filter::decodeHeaders(Http::RequestHeaderMap& he
   // writing test code to not forget these important variables in mock requests
   const Http::HeaderEntry* host_header = headers.Host();
   ASSERT(host_header != nullptr);
-  host_ = host_header->value().getStringView();
+  host_ = std::string(host_header->value().getStringView());
 
   const Http::HeaderEntry* path_header = headers.Path();
   ASSERT(path_header != nullptr);

--- a/source/extensions/filters/http/oauth2/filter.h
+++ b/source/extensions/filters/http/oauth2/filter.h
@@ -291,7 +291,7 @@ private:
   std::string expires_;
   std::string hmac_;
   std::vector<uint8_t> secret_;
-  absl::string_view host_;
+  std::string host_;
   TimeSource& time_source_;
   const CookieNames cookie_names_;
   const std::string cookie_domain_;
@@ -356,7 +356,7 @@ private:
   std::string expires_refresh_token_in_;
   std::string expires_id_token_in_;
   std::string new_expires_;
-  absl::string_view host_;
+  std::string host_;
   std::string original_request_url_;
   std::string flow_id_;
   Http::RequestHeaderMap* request_headers_{nullptr};


### PR DESCRIPTION
Commit Message: OAuth2: Copy Host header when building OAuth2 refresh requests
Store the Host header as an owned string in the OAuth2 cookie validator and filter so it won't be changed by host_rewrite_literal(which should be used by upstream only).

Risk Level: Low (local type change to store Host as std::string within the OAuth2 filter)
Testing: Existing tests should already cover this change. Fixes: #42968
Docs Changes: N/A
Release Notes: Yes
Platform Specific Features: N/A

---------

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
