### PR TITLE
perf: avoid string copy while accessing filesystem path

### DIFF
--- a/envoy/filesystem/filesystem.h
+++ b/envoy/filesystem/filesystem.h
@@ -119,7 +119,7 @@ public:
   /**
    * @return string the file path
    */
-  virtual std::string path() const PURE;
+  virtual absl::string_view path() const PURE;
 
   /**
    * @return the type of the destination

--- a/source/common/filesystem/file_shared_impl.cc
+++ b/source/common/filesystem/file_shared_impl.cc
@@ -23,7 +23,7 @@ std::string IoFileError::getErrorDetails() const { return errorDetails(errno_); 
 
 bool FileSharedImpl::isOpen() const { return fd_ != INVALID_HANDLE; };
 
-std::string FileSharedImpl::path() const { return filepath_and_type_.path_; };
+absl::string_view FileSharedImpl::path() const { return filepath_and_type_.path_; };
 
 DestinationType FileSharedImpl::destinationType() const { return filepath_and_type_.file_type_; };
 

--- a/source/common/filesystem/file_shared_impl.h
+++ b/source/common/filesystem/file_shared_impl.h
@@ -44,7 +44,7 @@ public:
   ~FileSharedImpl() override = default;
 
   bool isOpen() const override;
-  std::string path() const override;
+  absl::string_view path() const override;
   DestinationType destinationType() const override;
 
 protected:

--- a/source/common/filesystem/posix/filesystem_impl.cc
+++ b/source/common/filesystem/posix/filesystem_impl.cc
@@ -55,7 +55,7 @@ Api::IoCallBoolResult FileImplPosix::open(FlagSet in) {
     return fd_ != -1 ? resultSuccess(true) : resultFailure(false, errno);
   }
   const auto flags_and_mode = translateFlag(in);
-  fd_ = ::open(path().c_str(), flags_and_mode.flags_, flags_and_mode.mode_);
+  fd_ = ::open(filepath_and_type_.path_.c_str(), flags_and_mode.flags_, flags_and_mode.mode_);
   return fd_ != -1 ? resultSuccess(true) : resultFailure(false, errno);
 }
 
@@ -67,8 +67,8 @@ Api::IoCallBoolResult TmpFileImplPosix::open(FlagSet in) {
   const auto flags_and_mode = translateFlag(in);
 #ifdef O_TMPFILE
   // Try to create a temp file with no name. Only some file systems support this.
-  fd_ =
-      ::open(path().c_str(), (flags_and_mode.flags_ & ~O_CREAT) | O_TMPFILE, flags_and_mode.mode_);
+  fd_ = ::open(filepath_and_type_.path_.c_str(), (flags_and_mode.flags_ & ~O_CREAT) | O_TMPFILE,
+               flags_and_mode.mode_);
   if (fd_ != -1) {
     return resultSuccess(true);
   }

--- a/source/common/filesystem/win32/filesystem_impl.cc
+++ b/source/common/filesystem/win32/filesystem_impl.cc
@@ -35,7 +35,7 @@ Api::IoCallBoolResult FileImplWin32::open(FlagSet in) {
   }
 
   auto flags = translateFlag(in);
-  fd_ = CreateFileA(path().c_str(), flags.access_,
+  fd_ = CreateFileA(filepath_and_type_.path_.c_str(), flags.access_,
                     FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, 0, flags.creation_, 0,
                     NULL);
   if (fd_ == INVALID_HANDLE) {
@@ -175,7 +175,7 @@ fileInfoFromAttributeData(absl::string_view path, const WIN32_FILE_ATTRIBUTE_DAT
 Api::IoCallResult<FileInfo> FileImplWin32::info() {
   ASSERT(isOpen());
   WIN32_FILE_ATTRIBUTE_DATA data;
-  BOOL result = GetFileAttributesEx(path().c_str(), GetFileExInfoStandard, &data);
+  BOOL result = GetFileAttributesEx(filepath_and_type_.path_.c_str(), GetFileExInfoStandard, &data);
   if (!result) {
     return resultFailure<FileInfo>({}, ::GetLastError());
   }

--- a/test/mocks/filesystem/mocks.h
+++ b/test/mocks/filesystem/mocks.h
@@ -25,7 +25,7 @@ public:
   Api::IoCallSizeResult pread(void* buf, uint64_t count, uint64_t offset) override;
   Api::IoCallSizeResult pwrite(const void* buf, uint64_t count, uint64_t offset) override;
   bool isOpen() const override { return is_open_; };
-  MOCK_METHOD(std::string, path, (), (const));
+  MOCK_METHOD(absl::string_view, path, (), (const));
   MOCK_METHOD(DestinationType, destinationType, (), (const));
   MOCK_METHOD(Api::IoCallResult<FileInfo>, info, ());
 


### PR DESCRIPTION
Commit Message: perf: avoid string copy while accessing filesystem path
Additional Description:
Minor perf refactor - returning an `absl::string_view` instead of `std::string` when accessing `path()`.

Risk Level: low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A