### PR TITLE
codeowners: add @agrawroh as an extension owner for MCP Router

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -242,7 +242,7 @@ extensions/upstreams/tcp @ggreenway @mattklein123
 # HTTP MCP filter
 /*/extensions/filters/http/mcp @botengyao @yanavlasov
 # MCP router filter
-/*/extensions/filters/http/mcp_router @botengyao @yanavlasov @wdauchy
+/*/extensions/filters/http/mcp_router @botengyao @yanavlasov @wdauchy @agrawroh
 # Original IP detection
 /*/extensions/http/original_ip_detection/custom_header @ryantheoptimist @mattklein123
 /*/extensions/http/original_ip_detection/xff @yanavlasov @mattklein123


### PR DESCRIPTION
## Description

This PR adds @agrawroh as an extension owner for MCP Router filter to facilitate code reviews. Rohit has been contribution frequently on MCP and could also help review PRs.

---

**Commit Message**: codeowners: add @agrawroh as an extension owner for MCP Router
**Additional Description**: Added @agrawroh as an extension owner for MCP Router filter to facilitate code reviews
**Risk Level:** N/A
**Testing:** CI
**Docs Changes:** N/A
**Release Notes:** N/A