### PR TITLE
chore: remove unnecessary if condition in path formatter

### DIFF
--- a/source/common/formatter/http_specific_formatter.cc
+++ b/source/common/formatter/http_specific_formatter.cc
@@ -339,11 +339,7 @@ absl::optional<std::string> PathFormatter::format(const Context& context,
     }
   }
 
-  // Truncate the path if needed.
-  if (max_length_.has_value()) {
-    path_view = SubstitutionFormatUtils::truncateStringView(path_view, max_length_);
-  }
-
+  path_view = SubstitutionFormatUtils::truncateStringView(path_view, max_length_);
   return std::string(path_view);
 }
 


### PR DESCRIPTION
Commit Message: chore: remove unnecessary if condition in path formatter `SubstitutionFormatUtils::truncateStringView` already handles the case of no max_length set.
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
