### PR TITLE
Fix MSAN use-after-free in Lua HeaderMapIterator destruction

### DIFF
--- a/source/extensions/filters/common/lua/lua.h
+++ b/source/extensions/filters/common/lua/lua.h
@@ -421,6 +421,13 @@ public:
     markDead();
     LuaRef<T>::reset();
   }
+
+  /**
+   * Resets the reference without calling markDead().
+   * Use this only when the referenced object is already being destroyed (e.g. inside its
+   * destructor) to avoid undefined behavior.
+   */
+  void resetWithoutMarkDead() { LuaRef<T>::reset(); }
 };
 
 /**

--- a/source/extensions/filters/http/lua/wrappers.cc
+++ b/source/extensions/filters/http/lua/wrappers.cc
@@ -17,18 +17,26 @@ namespace Extensions {
 namespace HttpFilters {
 namespace Lua {
 
-HeaderMapIterator::HeaderMapIterator(HeaderMapWrapper& parent) : parent_(parent) {
-  entries_.reserve(parent_.headers_.size());
-  parent_.headers_.iterate(
+HeaderMapIterator::HeaderMapIterator(HeaderMapWrapper& parent) : parent_(&parent) {
+  entries_.reserve(parent_->headers_.size());
+  parent_->headers_.iterate(
       [this](const Envoy::Http::HeaderEntry& header) -> Envoy::Http::HeaderMap::Iterate {
         entries_.push_back(&header);
         return Envoy::Http::HeaderMap::Iterate::Continue;
       });
 }
 
+HeaderMapIterator::~HeaderMapIterator() {
+  if (parent_ != nullptr) {
+    parent_->onIteratorDestroyed(this);
+  }
+}
+
 int HeaderMapIterator::luaPairsIterator(lua_State* state) {
   if (current_ == entries_.size()) {
-    parent_.iterator_.reset();
+    if (parent_ != nullptr) {
+      parent_->iterator_.reset();
+    }
     return 0;
   } else {
     const absl::string_view key_view(entries_[current_]->key().getStringView());
@@ -127,6 +135,12 @@ void HeaderMapWrapper::checkModifiable(lua_State* state) {
 
   if (!cb_()) {
     luaL_error(state, "header map can no longer be modified");
+  }
+}
+
+void HeaderMapWrapper::onIteratorDestroyed(HeaderMapIterator* it) {
+  if (iterator_.get() == it) {
+    iterator_.resetWithoutMarkDead();
   }
 }
 

--- a/source/extensions/filters/http/lua/wrappers.h
+++ b/source/extensions/filters/http/lua/wrappers.h
@@ -23,13 +23,16 @@ class HeaderMapWrapper;
 class HeaderMapIterator : public Filters::Common::Lua::BaseLuaObject<HeaderMapIterator> {
 public:
   HeaderMapIterator(HeaderMapWrapper& parent);
+  ~HeaderMapIterator() override;
 
   static ExportedFunctions exportedFunctions() { return {}; }
 
   DECLARE_LUA_CLOSURE(HeaderMapIterator, luaPairsIterator);
 
+  void onMarkDead() override { parent_ = nullptr; }
+
 private:
-  HeaderMapWrapper& parent_;
+  HeaderMapWrapper* parent_;
   std::vector<const Http::HeaderEntry*> entries_;
   uint64_t current_{};
 };
@@ -115,6 +118,7 @@ private:
   DECLARE_LUA_FUNCTION(HeaderMapWrapper, luaSetHttp1ReasonPhrase);
 
   void checkModifiable(lua_State* state);
+  void onIteratorDestroyed(HeaderMapIterator* it);
 
   // Envoy::Lua::BaseLuaObject
   void onMarkDead() override {

--- a/test/extensions/filters/http/lua/wrappers_test.cc
+++ b/test/extensions/filters/http/lua/wrappers_test.cc
@@ -282,6 +282,26 @@ TEST_F(LuaHeaderMapWrapperTest, IteratorAcrossYield) {
                             "[string \"...\"]:5: object used outside of proper scope");
 }
 
+// Verify that iterator garbage collection without completing iteration doesn't cause
+// use-after-free.
+TEST_F(LuaHeaderMapWrapperTest, IteratorGarbageCollection) {
+  const std::string SCRIPT{R"EOF(
+    function callMe(object)
+      for key, value in pairs(object) do
+        break
+      end
+      collectgarbage("collect")
+    end
+  )EOF"};
+
+  InSequence s;
+  setup(SCRIPT);
+
+  Http::TestRequestHeaderMapImpl headers{{"foo", "bar"}, {"hello", "world"}};
+  HeaderMapWrapper::create(coroutine_->luaState(), headers, []() { return true; });
+  start("callMe");
+}
+
 // Verify setting the HTTP1 reason phrase
 TEST_F(LuaHeaderMapWrapperTest, SetHttp1ReasonPhrase) {
   const std::string SCRIPT{R"EOF(


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

**Commit Message**: Fix MSAN use-after-free in Lua HeaderMapIterator destruction
**Additional Description**: This change fixes a memory safety issue detected by MSAN where HeaderMapWrapper could hold a dangling reference to a HeaderMapIterator that was being garbage collected by Lua, or attempt to call markDead() on a partially destroyed iterator.
When HeaderMapIterator is destroyed by the Lua GC, it now explicitly notifies its parent HeaderMapWrapper. The wrapper then releases its reference to the iterator using a new resetWithoutMarkDead() method. This method avoids calling markDead() on the iterator, which is critical because invoking methods on an object currently executing its destructor is unsafe and triggers MSAN errors.
This ensures the HeaderMapWrapper's reference is cleanly nullified without accessing the dying object.
**Risk Level**: Low
**Testing**: Check with existing tests, none of the existing test failing
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
