### PR TITLE
Update findEventEnd return type to be a struct for better readability and maintainability  

### DIFF
--- a/source/common/http/sse/sse_parser.cc
+++ b/source/common/http/sse/sse_parser.cc
@@ -72,8 +72,7 @@ SseParser::ParsedEvent SseParser::parseEvent(absl::string_view event) {
   return parsed_event;
 }
 
-std::tuple<size_t, size_t, size_t> SseParser::findEventEnd(absl::string_view buffer,
-                                                           bool end_stream) {
+SseParser::FindEventEndResult SseParser::findEventEnd(absl::string_view buffer, bool end_stream) {
   size_t consumed = 0;
   size_t event_start = 0;
   absl::string_view remaining = buffer;

--- a/test/common/http/sse/sse_parser_test.cc
+++ b/test/common/http/sse/sse_parser_test.cc
@@ -85,128 +85,127 @@ TEST_F(SseParserTest, ParseEventCR) {
 // Test findEventEnd with complete event (double newline)
 TEST_F(SseParserTest, FindEventEndComplete) {
   const std::string buffer = "data: test\n\nmore data";
-  auto [event_start, event_end, next_event] = SseParser::findEventEnd(buffer, false);
-  EXPECT_EQ(event_start, 0);
-  EXPECT_EQ(event_end, 11);  // Position before the second newline
-  EXPECT_EQ(next_event, 12); // Position after the second newline
+  auto result = SseParser::findEventEnd(buffer, false);
+  EXPECT_EQ(result.event_start, 0);
+  EXPECT_EQ(result.event_end, 11);  // Position before the second newline
+  EXPECT_EQ(result.next_start, 12); // Position after the second newline
 }
 
 // Test findEventEnd with incomplete event
 TEST_F(SseParserTest, FindEventEndIncomplete) {
   const std::string buffer = "data: test\n";
-  auto [event_start, event_end, next_event] = SseParser::findEventEnd(buffer, false);
-  EXPECT_EQ(event_start, absl::string_view::npos);
-  EXPECT_EQ(event_end, absl::string_view::npos);
-  EXPECT_EQ(next_event, absl::string_view::npos);
+  auto result = SseParser::findEventEnd(buffer, false);
+  EXPECT_EQ(result.event_start, absl::string_view::npos);
+  EXPECT_EQ(result.event_end, absl::string_view::npos);
+  EXPECT_EQ(result.next_start, absl::string_view::npos);
 }
 
 // Test findEventEnd with end_stream and incomplete event
 TEST_F(SseParserTest, FindEventEndEndStream) {
   const std::string buffer = "data: test\n";
-  auto [event_start, event_end, next_event] = SseParser::findEventEnd(buffer, true);
+  auto result = SseParser::findEventEnd(buffer, true);
   // With end_stream, incomplete event should not be found (still needs blank line)
-  EXPECT_EQ(event_start, absl::string_view::npos);
-  EXPECT_EQ(event_end, absl::string_view::npos);
-  EXPECT_EQ(next_event, absl::string_view::npos);
+  EXPECT_EQ(result.event_start, absl::string_view::npos);
+  EXPECT_EQ(result.event_end, absl::string_view::npos);
+  EXPECT_EQ(result.next_start, absl::string_view::npos);
 }
 
 // Test findEventEnd with end_stream and blank line
 TEST_F(SseParserTest, FindEventEndEndStreamWithBlankLine) {
   const std::string buffer = "data: test\n\n";
-  auto [event_start, event_end, next_event] = SseParser::findEventEnd(buffer, true);
-  EXPECT_EQ(event_start, 0);
-  EXPECT_EQ(event_end, 11);
-  EXPECT_EQ(next_event, 12);
+  auto result = SseParser::findEventEnd(buffer, true);
+  EXPECT_EQ(result.event_start, 0);
+  EXPECT_EQ(result.event_end, 11);
+  EXPECT_EQ(result.next_start, 12);
 }
 
 // Test findEventEnd with CRLF blank line
 TEST_F(SseParserTest, FindEventEndCRLF) {
   const std::string buffer = "data: test\r\n\r\n";
-  auto [event_start, event_end, next_event] = SseParser::findEventEnd(buffer, false);
-  EXPECT_EQ(event_start, 0);
-  EXPECT_EQ(event_end, 12);
-  EXPECT_EQ(next_event, 14);
+  auto result = SseParser::findEventEnd(buffer, false);
+  EXPECT_EQ(result.event_start, 0);
+  EXPECT_EQ(result.event_end, 12);
+  EXPECT_EQ(result.next_start, 14);
 }
 
 // Test findEventEnd with mixed line endings
 TEST_F(SseParserTest, FindEventEndMixed) {
   const std::string buffer = "data: test\r\n\n";
-  auto [event_start, event_end, next_event] = SseParser::findEventEnd(buffer, false);
-  EXPECT_EQ(event_start, 0);
-  EXPECT_EQ(event_end, 12);
-  EXPECT_EQ(next_event, 13);
+  auto result = SseParser::findEventEnd(buffer, false);
+  EXPECT_EQ(result.event_start, 0);
+  EXPECT_EQ(result.event_end, 12);
+  EXPECT_EQ(result.next_start, 13);
 }
 
 // Test findEventEnd with CR line endings
 TEST_F(SseParserTest, FindEventEndCR) {
   const std::string buffer = "data: test\r\rmore";
-  auto [event_start, event_end, next_event] = SseParser::findEventEnd(buffer, false);
-  EXPECT_EQ(event_start, 0);
-  EXPECT_EQ(event_end, 11);
-  EXPECT_EQ(next_event, 12);
+  auto result = SseParser::findEventEnd(buffer, false);
+  EXPECT_EQ(result.event_start, 0);
+  EXPECT_EQ(result.event_end, 11);
+  EXPECT_EQ(result.next_start, 12);
 }
 
 // Test findEventEnd with multiple events
 TEST_F(SseParserTest, FindEventEndMultiple) {
   const std::string buffer = "data: first\n\ndata: second\n\n";
-  auto [event_start, event_end, next_event] = SseParser::findEventEnd(buffer, false);
-  EXPECT_EQ(event_start, 0);
-  EXPECT_EQ(event_end, 12);
-  EXPECT_EQ(next_event, 13);
+  auto result = SseParser::findEventEnd(buffer, false);
+  EXPECT_EQ(result.event_start, 0);
+  EXPECT_EQ(result.event_end, 12);
+  EXPECT_EQ(result.next_start, 13);
 
   // Find second event
-  auto [event_start2, event_end2, next_event2] =
-      SseParser::findEventEnd(buffer.substr(next_event), false);
-  EXPECT_EQ(event_start2, 0);
-  EXPECT_EQ(event_end2, 13);
-  EXPECT_EQ(next_event2, 14);
+  auto result2 = SseParser::findEventEnd(buffer.substr(result.next_start), false);
+  EXPECT_EQ(result2.event_start, 0);
+  EXPECT_EQ(result2.event_end, 13);
+  EXPECT_EQ(result2.next_start, 14);
 }
 
 // Test findEventEnd with empty buffer
 TEST_F(SseParserTest, FindEventEndEmpty) {
   const std::string buffer = "";
-  auto [event_start, event_end, next_event] = SseParser::findEventEnd(buffer, false);
-  EXPECT_EQ(event_start, absl::string_view::npos);
-  EXPECT_EQ(event_end, absl::string_view::npos);
-  EXPECT_EQ(next_event, absl::string_view::npos);
+  auto result = SseParser::findEventEnd(buffer, false);
+  EXPECT_EQ(result.event_start, absl::string_view::npos);
+  EXPECT_EQ(result.event_end, absl::string_view::npos);
+  EXPECT_EQ(result.next_start, absl::string_view::npos);
 }
 
 // Test findEventEnd with only blank lines
 TEST_F(SseParserTest, FindEventEndOnlyBlankLines) {
   const std::string buffer = "\n\n";
-  auto [event_start, event_end, next_event] = SseParser::findEventEnd(buffer, false);
-  EXPECT_EQ(event_start, 0);
-  EXPECT_EQ(event_end, 0);
-  EXPECT_EQ(next_event, 1);
+  auto result = SseParser::findEventEnd(buffer, false);
+  EXPECT_EQ(result.event_start, 0);
+  EXPECT_EQ(result.event_end, 0);
+  EXPECT_EQ(result.next_start, 1);
 }
 
 // Test findEventEnd with comment before blank line
 TEST_F(SseParserTest, FindEventEndWithComment) {
   const std::string buffer = ": comment\ndata: test\n\n";
-  auto [event_start, event_end, next_event] = SseParser::findEventEnd(buffer, false);
-  EXPECT_EQ(event_start, 0);
-  EXPECT_EQ(event_end, 21);
-  EXPECT_EQ(next_event, 22);
+  auto result = SseParser::findEventEnd(buffer, false);
+  EXPECT_EQ(result.event_start, 0);
+  EXPECT_EQ(result.event_end, 21);
+  EXPECT_EQ(result.next_start, 22);
 }
 
 // Test findEventEnd with trailing CR needing CRLF check
 TEST_F(SseParserTest, FindEventEndTrailingCR) {
   const std::string buffer = "data: test\r";
-  auto [event_start, event_end, next_event] = SseParser::findEventEnd(buffer, false);
+  auto result = SseParser::findEventEnd(buffer, false);
   // Should wait for potential LF
-  EXPECT_EQ(event_start, absl::string_view::npos);
-  EXPECT_EQ(event_end, absl::string_view::npos);
-  EXPECT_EQ(next_event, absl::string_view::npos);
+  EXPECT_EQ(result.event_start, absl::string_view::npos);
+  EXPECT_EQ(result.event_end, absl::string_view::npos);
+  EXPECT_EQ(result.next_start, absl::string_view::npos);
 }
 
 // Test findEventEnd with trailing CR and end_stream
 TEST_F(SseParserTest, FindEventEndTrailingCREndStream) {
   const std::string buffer = "data: test\r";
-  auto [event_start, event_end, next_event] = SseParser::findEventEnd(buffer, true);
+  auto result = SseParser::findEventEnd(buffer, true);
   // With end_stream, should treat CR as line ending but still need blank line
-  EXPECT_EQ(event_start, absl::string_view::npos);
-  EXPECT_EQ(event_end, absl::string_view::npos);
-  EXPECT_EQ(next_event, absl::string_view::npos);
+  EXPECT_EQ(result.event_start, absl::string_view::npos);
+  EXPECT_EQ(result.event_end, absl::string_view::npos);
+  EXPECT_EQ(result.next_start, absl::string_view::npos);
 }
 
 // Test parseEvent with JSON content
@@ -296,46 +295,46 @@ TEST_F(SseParserTest, ParseEventTab) {
 // Test findEventEnd with three consecutive blank lines
 TEST_F(SseParserTest, FindEventEndTripleBlankLines) {
   const std::string buffer = "data: test\n\n\n";
-  auto [event_start, event_end, next_event] = SseParser::findEventEnd(buffer, false);
-  EXPECT_EQ(event_start, 0);
-  EXPECT_EQ(event_end, 11);
-  EXPECT_EQ(next_event, 12);
+  auto result = SseParser::findEventEnd(buffer, false);
+  EXPECT_EQ(result.event_start, 0);
+  EXPECT_EQ(result.event_end, 11);
+  EXPECT_EQ(result.next_start, 12);
 }
 
 // Test findEventEnd with buffer starting with blank line
 TEST_F(SseParserTest, FindEventEndStartsWithBlankLine) {
   const std::string buffer = "\ndata: test\n\n";
-  auto [event_start, event_end, next_event] = SseParser::findEventEnd(buffer, false);
-  EXPECT_EQ(event_start, 0);
-  EXPECT_EQ(event_end, 0);
-  EXPECT_EQ(next_event, 1);
+  auto result = SseParser::findEventEnd(buffer, false);
+  EXPECT_EQ(result.event_start, 0);
+  EXPECT_EQ(result.event_end, 0);
+  EXPECT_EQ(result.next_start, 1);
 }
 
 // Test findEventEnd with CRLF then LF
 TEST_F(SseParserTest, FindEventEndCRLFThenLF) {
   const std::string buffer = "data: test\r\n\n";
-  auto [event_start, event_end, next_event] = SseParser::findEventEnd(buffer, false);
-  EXPECT_EQ(event_start, 0);
-  EXPECT_EQ(event_end, 12);
-  EXPECT_EQ(next_event, 13);
+  auto result = SseParser::findEventEnd(buffer, false);
+  EXPECT_EQ(result.event_start, 0);
+  EXPECT_EQ(result.event_end, 12);
+  EXPECT_EQ(result.next_start, 13);
 }
 
 // Test findEventEnd with LF then CRLF
 TEST_F(SseParserTest, FindEventEndLFThenCRLF) {
   const std::string buffer = "data: test\n\r\n";
-  auto [event_start, event_end, next_event] = SseParser::findEventEnd(buffer, false);
-  EXPECT_EQ(event_start, 0);
-  EXPECT_EQ(event_end, 11);
-  EXPECT_EQ(next_event, 13);
+  auto result = SseParser::findEventEnd(buffer, false);
+  EXPECT_EQ(result.event_start, 0);
+  EXPECT_EQ(result.event_end, 11);
+  EXPECT_EQ(result.next_start, 13);
 }
 
 // Test findEventEnd with CR, CR (double CR)
 TEST_F(SseParserTest, FindEventEndDoubleCR) {
   const std::string buffer = "data: test\r\rmore";
-  auto [event_start, event_end, next_event] = SseParser::findEventEnd(buffer, false);
-  EXPECT_EQ(event_start, 0);
-  EXPECT_EQ(event_end, 11);
-  EXPECT_EQ(next_event, 12);
+  auto result = SseParser::findEventEnd(buffer, false);
+  EXPECT_EQ(result.event_start, 0);
+  EXPECT_EQ(result.event_end, 11);
+  EXPECT_EQ(result.next_start, 12);
 }
 
 // Test parseEvent with field name containing whitespace
@@ -364,10 +363,10 @@ TEST_F(SseParserTest, ParseEventWithEventField) {
 // Test findEventEnd with very long line
 TEST_F(SseParserTest, FindEventEndLongLine) {
   std::string buffer = "data: " + std::string(10000, 'x') + "\n\n";
-  auto [event_start, event_end, next_event] = SseParser::findEventEnd(buffer, false);
-  EXPECT_EQ(event_start, 0);
-  EXPECT_EQ(event_end, 10007);
-  EXPECT_EQ(next_event, 10008);
+  auto result = SseParser::findEventEnd(buffer, false);
+  EXPECT_EQ(result.event_start, 0);
+  EXPECT_EQ(result.event_end, 10007);
+  EXPECT_EQ(result.next_start, 10008);
 }
 
 // Test parseEvent with multiple data fields separated by other fields
@@ -381,10 +380,10 @@ TEST_F(SseParserTest, ParseEventInterspersed) {
 // Test findEventEnd with only comments
 TEST_F(SseParserTest, FindEventEndOnlyComments) {
   const std::string buffer = ": comment 1\n: comment 2\n\n";
-  auto [event_start, event_end, next_event] = SseParser::findEventEnd(buffer, false);
-  EXPECT_EQ(event_start, 0);
-  EXPECT_EQ(event_end, 24);
-  EXPECT_EQ(next_event, 25);
+  auto result = SseParser::findEventEnd(buffer, false);
+  EXPECT_EQ(result.event_start, 0);
+  EXPECT_EQ(result.event_end, 24);
+  EXPECT_EQ(result.next_start, 25);
 }
 
 // Test parseEvent with empty string
@@ -397,20 +396,20 @@ TEST_F(SseParserTest, ParseEventEmptyString) {
 // Test findEventEnd with single newline at end
 TEST_F(SseParserTest, FindEventEndSingleNewlineAtEnd) {
   const std::string buffer = "data: test\n";
-  auto [event_start, event_end, next_event] = SseParser::findEventEnd(buffer, false);
-  EXPECT_EQ(event_start, absl::string_view::npos);
-  EXPECT_EQ(event_end, absl::string_view::npos);
-  EXPECT_EQ(next_event, absl::string_view::npos);
+  auto result = SseParser::findEventEnd(buffer, false);
+  EXPECT_EQ(result.event_start, absl::string_view::npos);
+  EXPECT_EQ(result.event_end, absl::string_view::npos);
+  EXPECT_EQ(result.next_start, absl::string_view::npos);
 }
 
 // Test findEventEnd with trailing CR followed by more data
 TEST_F(SseParserTest, FindEventEndTrailingCRWithData) {
   const std::string buffer = "data: test\rmore data";
-  auto [event_start, event_end, next_event] = SseParser::findEventEnd(buffer, false);
+  auto result = SseParser::findEventEnd(buffer, false);
   // Should find CR as line ending
-  EXPECT_EQ(event_start, absl::string_view::npos);
-  EXPECT_EQ(event_end, absl::string_view::npos);
-  EXPECT_EQ(next_event, absl::string_view::npos);
+  EXPECT_EQ(result.event_start, absl::string_view::npos);
+  EXPECT_EQ(result.event_end, absl::string_view::npos);
+  EXPECT_EQ(result.next_start, absl::string_view::npos);
 }
 
 // Test parseEvent with empty lines to exercise parseFieldLine empty line case
@@ -432,22 +431,23 @@ TEST_F(SseParserTest, ParseEventNoLineEnding) {
 // Test findEventEnd with data without newline and end_stream=true
 TEST_F(SseParserTest, FindEventEndNoLineEndingEndStream) {
   const std::string buffer = "data: test";
-  auto [event_start, event_end, next_event] = SseParser::findEventEnd(buffer, true);
-  EXPECT_EQ(event_start, absl::string_view::npos);
-  EXPECT_EQ(event_end, absl::string_view::npos);
-  EXPECT_EQ(next_event, absl::string_view::npos);
+  auto result = SseParser::findEventEnd(buffer, true);
+  EXPECT_EQ(result.event_start, absl::string_view::npos);
+  EXPECT_EQ(result.event_end, absl::string_view::npos);
+  EXPECT_EQ(result.next_start, absl::string_view::npos);
 }
 
 TEST_F(SseParserTest, FindEventEndWithBOM) {
   // UTF-8 BOM (0xEF 0xBB 0xBF) should be stripped at stream start
   const std::string buffer = std::string("\xEF\xBB\xBF") + "data: hello\n\n";
-  auto [event_start, event_end, next_event] = SseParser::findEventEnd(buffer, false);
-  EXPECT_EQ(event_start, 3); // Event starts after BOM
-  EXPECT_EQ(event_end, 15);  // BOM (3) + "data: hello\n" (12) = 15
-  EXPECT_EQ(next_event, 16); // BOM (3) + "data: hello\n\n" (13) = 16
+  auto result = SseParser::findEventEnd(buffer, false);
+  EXPECT_EQ(result.event_start, 3); // Event starts after BOM
+  EXPECT_EQ(result.event_end, 15);  // BOM (3) + "data: hello\n" (12) = 15
+  EXPECT_EQ(result.next_start, 16); // BOM (3) + "data: hello\n\n" (13) = 16
 
   // Verify the event content using the API-provided positions
-  auto event_str = absl::string_view(buffer).substr(event_start, event_end - event_start);
+  auto event_str =
+      absl::string_view(buffer).substr(result.event_start, result.event_end - result.event_start);
   auto event = SseParser::parseEvent(event_str);
   ASSERT_TRUE(event.data.has_value());
   EXPECT_EQ(event.data.value(), "hello");


### PR DESCRIPTION
Commit Message: Update findEventEnd return type to be a struct for better readability and maintainability  
Additional Description: Addressed 3rd point in https://github.com/envoyproxy/envoy/issues/43136
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
