### PR TITLE
http/lua: add server context only filter factory support

### DIFF
--- a/source/extensions/filters/http/lua/config.h
+++ b/source/extensions/filters/http/lua/config.h
@@ -25,6 +25,11 @@ private:
       const std::string& stats_prefix, DualInfo info,
       Server::Configuration::ServerFactoryContext& context) override;
 
+  Http::FilterFactoryCb createFilterFactoryFromProtoWithServerContextTyped(
+      const envoy::extensions::filters::http::lua::v3::Lua& proto_config,
+      const std::string& stats_prefix,
+      Server::Configuration::ServerFactoryContext& context) override;
+
   absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
   createRouteSpecificFilterConfigTyped(
       const envoy::extensions::filters::http::lua::v3::LuaPerRoute& proto_config,

--- a/test/extensions/filters/http/lua/config_test.cc
+++ b/test/extensions/filters/http/lua/config_test.cc
@@ -48,6 +48,26 @@ TEST(LuaFilterConfigTest, LuaFilterWithDefaultSourceCode) {
   cb(filter_callback);
 }
 
+TEST(LuaFilterConfigTest, LuaFilterWithDefaultSourceCodeWithServerContext) {
+  const std::string yaml_string = R"EOF(
+  default_source_code:
+    inline_string: |
+      function envoy_on_request(request_handle)
+        request_handle:headers():add("code", "code_from_hello")
+      end
+  )EOF";
+
+  envoy::extensions::filters::http::lua::v3::Lua proto_config;
+  TestUtility::loadFromYaml(yaml_string, proto_config);
+  NiceMock<Server::Configuration::MockServerFactoryContext> context;
+  LuaFilterConfig factory;
+  Http::FilterFactoryCb cb =
+      factory.createFilterFactoryFromProtoWithServerContext(proto_config, "stats", context);
+  Http::MockFilterChainFactoryCallbacks filter_callback;
+  EXPECT_CALL(filter_callback, addStreamFilter(_));
+  cb(filter_callback);
+}
+
 #ifndef ENVOY_DISABLE_DEPRECATED_FEATURES
 TEST(LuaFilterConfigTest, LuaFilterInJson) {
   const std::string yaml_string = R"EOF(


### PR DESCRIPTION

Commit Message: http/lua: add server context only filter factory support
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
