### PR TITLE
ext_authz: fix status_on_error ignored on HTTP client failure

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -78,6 +78,11 @@ bug_fixes:
   change: |
     Fixed a bug where headers from a denied authorization response (non-200) were not properly propagated
     to the client.
+- area: ext_authz
+  change: |
+    Fixed the HTTP ext_authz client to respect ``status_on_error`` configuration when the HTTP call fails.
+    Previously, HTTP client failures (timeout, 5xx responses, connection errors) always returned 403 Forbidden
+    regardless of the configured ``status_on_error`` setting.
 - area: formatter
   change: |
     Fixed the log formatter in HTTP router upstream logs by correctly setting the downstream connection's

--- a/source/extensions/filters/common/ext_authz/ext_authz_http_impl.cc
+++ b/source/extensions/filters/common/ext_authz/ext_authz_http_impl.cc
@@ -34,6 +34,9 @@ const Http::HeaderMap& lengthZeroHeader() {
 }
 
 // Static response used for creating authorization ERROR responses.
+// Note: status_code is intentionally left as default (0) so that the filter
+// uses the configured status_on_error value. See PR #42764 for the equivalent
+// gRPC fix.
 const Response& errorResponse() {
   CONSTRUCT_ON_FIRST_USE(Response, Response{CheckStatus::Error,
                                             HeaderMutationVector{},
@@ -44,7 +47,7 @@ const Response& errorResponse() {
                                             Http::Utility::QueryParamsVector{},
                                             {},
                                             EMPTY_STRING,
-                                            Http::Code::Forbidden,
+                                            Http::Code{},
                                             Protobuf::Struct{}});
 }
 

--- a/test/extensions/filters/common/ext_authz/ext_authz_http_impl_test.cc
+++ b/test/extensions/filters/common/ext_authz/ext_authz_http_impl_test.cc
@@ -708,8 +708,9 @@ TEST_F(ExtAuthzHttpClientTest, ErrorResponseStatusCodeUnsetForStatusOnError) {
   // Capture the actual response to verify status_code is Http::Code(0).
   ResponsePtr captured_response;
   EXPECT_CALL(request_callbacks_, onComplete_(_))
-      .WillOnce(Invoke(
-          [&captured_response](ResponsePtr& response) { captured_response = std::move(response); }));
+      .WillOnce(Invoke([&captured_response](ResponsePtr& response) {
+        captured_response = std::move(response);
+      }));
   client_->onFailure(async_request_, Http::AsyncClient::FailureReason::Reset);
 
   ASSERT_NE(captured_response, nullptr);
@@ -731,8 +732,9 @@ TEST_F(ExtAuthzHttpClientTest, Error5xxResponseStatusCodeUnsetForStatusOnError) 
   // Capture the actual response to verify status_code is Http::Code(0).
   ResponsePtr captured_response;
   EXPECT_CALL(request_callbacks_, onComplete_(_))
-      .WillOnce(Invoke(
-          [&captured_response](ResponsePtr& response) { captured_response = std::move(response); }));
+      .WillOnce(Invoke([&captured_response](ResponsePtr& response) {
+        captured_response = std::move(response);
+      }));
   client_->onSuccess(async_request_, std::move(check_response));
 
   ASSERT_NE(captured_response, nullptr);
@@ -751,8 +753,9 @@ TEST_F(ExtAuthzHttpClientTest, NoClusterErrorResponseStatusCodeUnsetForStatusOnE
   // Capture the actual response to verify status_code is Http::Code(0).
   ResponsePtr captured_response;
   EXPECT_CALL(request_callbacks_, onComplete_(_))
-      .WillOnce(Invoke(
-          [&captured_response](ResponsePtr& response) { captured_response = std::move(response); }));
+      .WillOnce(Invoke([&captured_response](ResponsePtr& response) {
+        captured_response = std::move(response);
+      }));
   client_->check(request_callbacks_, envoy::service::auth::v3::CheckRequest{}, parent_span_,
                  stream_info_);
 


### PR DESCRIPTION
## Summary
- Fix HTTP ext_authz client to not hardcode `Http::Code::Forbidden` in error responses
- Allow the filter to use the configured `status_on_error` when HTTP auth service fails

## Description

The HTTP ext_authz client's `errorResponse()` hardcoded `Http::Code::Forbidden` (403), which prevented the filter from using the configured `status_on_error` value
when:
- The HTTP auth service times out
- The HTTP auth service returns a 5xx error
- The ext_authz cluster is unavailable

This is the HTTP equivalent of the gRPC fix in #42764. The regression was introduced in #42099 which added custom `error_response` support. That PR changed the
filter logic to prefer `response->status_code` over `config_->statusOnError()` when `status_code` is non-zero:

```cpp
const Http::Code status_code = response->status_code != static_cast<Http::Code>(0)
                                   ? response->status_code
                                   : config_->statusOnError();
```

Since `errorResponse()` set `status_code = Http::Code::Forbidden`, the configured `status_on_error` was always ignored for HTTP client failures.

## Fix

Changed `errorResponse()` to leave `status_code` as default (0), matching the gRPC fix in #42764:

```cpp
// Before
Http::Code::Forbidden,

// After
Http::Code{},
```

## Test plan
- [x] Added unit tests that verify error responses have `status_code = Http::Code(0)`
- [x] Tests cover all three error scenarios: timeout/reset, 5xx response, missing cluster
- [x] All existing tests pass

---

**AI Tool Disclosure**: This PR was developed with assistance from Claude AI.