### PR TITLE
jwt: use ECDSA_SIG_set0() for OpenSSL compatibility

### DIFF
--- a/test/common/jwt/verify_pem_ec_test.cc
+++ b/test/common/jwt/verify_pem_ec_test.cc
@@ -181,6 +181,70 @@ TEST(VerifyPKCSTestRs256, jwksIncorrectAlgSpecifiedFail) {
   });
 }
 
+// Test EC signature verification with empty signature.
+// This exercises the `BN_bin2bn` and `ECDSA_SIG_set0` code paths with zero-length data.
+TEST(VerifyPemECTest, EmptySignatureFail) {
+  Jwt jwt;
+  EXPECT_EQ(jwt.parseFromString(JwtPemEs256), Status::Ok);
+  auto jwks = Jwks::createFrom(es256pubkey, Jwks::Type::PEM);
+  EXPECT_EQ(jwks->getStatus(), Status::Ok);
+  jwks->keys()[0]->alg_ = "ES256";
+  jwks->keys()[0]->crv_ = "P-256";
+  // Clear the signature to make it empty.
+  jwt.signature_.clear();
+  EXPECT_EQ(verifyJwt(jwt, *jwks, 1), Status::JwtVerificationFail);
+}
+
+// Test EC signature verification with a very short signature (1 byte).
+TEST(VerifyPemECTest, VeryShortSignatureFail) {
+  Jwt jwt;
+  EXPECT_EQ(jwt.parseFromString(JwtPemEs256), Status::Ok);
+  auto jwks = Jwks::createFrom(es256pubkey, Jwks::Type::PEM);
+  EXPECT_EQ(jwks->getStatus(), Status::Ok);
+  jwks->keys()[0]->alg_ = "ES256";
+  jwks->keys()[0]->crv_ = "P-256";
+  // Set signature to a single byte.
+  jwt.signature_ = "x";
+  EXPECT_EQ(verifyJwt(jwt, *jwks, 1), Status::JwtVerificationFail);
+}
+
+// Test EC signature verification with a 2-byte signature.
+TEST(VerifyPemECTest, TwoByteSignatureFail) {
+  Jwt jwt;
+  EXPECT_EQ(jwt.parseFromString(JwtPemEs256), Status::Ok);
+  auto jwks = Jwks::createFrom(es256pubkey, Jwks::Type::PEM);
+  EXPECT_EQ(jwks->getStatus(), Status::Ok);
+  jwks->keys()[0]->alg_ = "ES256";
+  jwks->keys()[0]->crv_ = "P-256";
+  // Set signature to two bytes.
+  jwt.signature_ = "xy";
+  EXPECT_EQ(verifyJwt(jwt, *jwks, 1), Status::JwtVerificationFail);
+}
+
+// Test ES384 signature verification with empty signature using PEM key.
+TEST(VerifyPemECTest, ES384EmptySignatureFail) {
+  Jwt jwt;
+  EXPECT_EQ(jwt.parseFromString(JwtPemEs384), Status::Ok);
+  auto jwks = Jwks::createFrom(es384pubkey, Jwks::Type::PEM);
+  EXPECT_EQ(jwks->getStatus(), Status::Ok);
+  jwks->keys()[0]->alg_ = "ES384";
+  jwks->keys()[0]->crv_ = "P-384";
+  jwt.signature_.clear();
+  EXPECT_EQ(verifyJwt(jwt, *jwks, 1), Status::JwtVerificationFail);
+}
+
+// Test ES512 signature verification with empty signature using PEM key.
+TEST(VerifyPemECTest, ES512EmptySignatureFail) {
+  Jwt jwt;
+  EXPECT_EQ(jwt.parseFromString(JwtPemEs512), Status::Ok);
+  auto jwks = Jwks::createFrom(es512pubkey, Jwks::Type::PEM);
+  EXPECT_EQ(jwks->getStatus(), Status::Ok);
+  jwks->keys()[0]->alg_ = "ES512";
+  jwks->keys()[0]->crv_ = "P-512";
+  jwt.signature_.clear();
+  EXPECT_EQ(verifyJwt(jwt, *jwks, 1), Status::JwtVerificationFail);
+}
+
 } // namespace
 } // namespace JwtVerify
 } // namespace Envoy


### PR DESCRIPTION
The previous code directly accessed the r and s members of the ECDSA_SIG struct when converting the JWT signature to an ECDSA signature object. This worked with BoringSSL which exposes struct internals, but fails with OpenSSL where ECDSA_SIG is an opaque type.

This change uses ECDSA_SIG_set0() to set the r and s BIGNUM values, which is supported by both BoringSSL and OpenSSL. The BIGNUMs are created separately and then transferred to the ECDSA_SIG object via ECDSA_SIG_set0(), which takes ownership of them. The unique_ptrs are released after the transfer to prevent double-free.
