### PR TITLE
fips: restore the exe test

### DIFF
--- a/test/exe/BUILD
+++ b/test/exe/BUILD
@@ -4,6 +4,7 @@ load(
     "envoy_cc_test_library",
     "envoy_package",
     "envoy_select_admin_functionality",
+    "envoy_select_boringssl",
     "envoy_sh_test",
 )
 
@@ -154,6 +155,7 @@ envoy_cc_test(
     name = "all_extensions_build_test",
     size = "large",
     srcs = ["all_extensions_build_test.cc"],
+    copts = envoy_select_boringssl(["-DENVOY_SSL_FIPS"]),
     data = [
         "fips_check.sh",
         "//source/extensions:extensions_metadata.yaml",

--- a/test/exe/all_extensions_build_test.cc
+++ b/test/exe/all_extensions_build_test.cc
@@ -83,12 +83,12 @@ TEST(CheckExtensionsAgainstRegistry, CorrectMetadata) {
 // Note: this must be done on the "complete" build since transitive dependencies may override the
 // choice of the boringssl library.
 TEST(FIPS, ValidateFIPSModeConsistency) {
-  if (FIPS_mode() == 1) {
-    EXPECT_TRUE(VersionInfo::sslFipsCompliant());
-    TestEnvironment::exec({TestEnvironment::runfilesPath("test/exe/fips_check.sh")});
-  } else {
-    EXPECT_FALSE(VersionInfo::sslFipsCompliant());
-  }
+#ifdef ENVOY_SSL_FIPS
+  EXPECT_TRUE(VersionInfo::sslFipsCompliant());
+  TestEnvironment::exec({TestEnvironment::runfilesPath("test/exe/fips_check.sh")});
+#else
+  EXPECT_FALSE(VersionInfo::sslFipsCompliant());
+#endif
 }
 
 } // namespace


### PR DESCRIPTION
So that we make sure the bazel flag that activates fips builds actually is used and produces a fips binary.

Reverts parts of https://github.com/envoyproxy/envoy/pull/43216
