### PR TITLE
ext_authz: fixed ext_authz to respect status_on_error config when server returns error

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -91,6 +91,11 @@ bug_fixes:
   change: |
     Fixed the log formatter in HTTP router upstream logs by correctly setting the downstream connection's
     ``ConnectionInfoProvider`` in the ``StreamInfo``.
+- area: ext_authz
+  change: |
+    Fixed the HTTP ext_authz client to respect ``status_on_error`` configuration when the authorization
+    server returns a 5xx error or when HTTP call failures occur. Previously, these error scenarios always
+    returned 403 Forbidden regardless of the configured error status.
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/source/extensions/filters/common/ext_authz/ext_authz_http_impl.cc
+++ b/source/extensions/filters/common/ext_authz/ext_authz_http_impl.cc
@@ -34,6 +34,8 @@ const Http::HeaderMap& lengthZeroHeader() {
 }
 
 // Static response used for creating authorization ERROR responses.
+// Note: status_code is left unset so the filter can use the configured status_on_error
+// configuration.
 const Response& errorResponse() {
   CONSTRUCT_ON_FIRST_USE(Response, Response{CheckStatus::Error,
                                             HeaderMutationVector{},
@@ -44,7 +46,7 @@ const Response& errorResponse() {
                                             Http::Utility::QueryParamsVector{},
                                             {},
                                             EMPTY_STRING,
-                                            Http::Code::Forbidden,
+                                            static_cast<Http::Code>(0),
                                             Protobuf::Struct{}});
 }
 


### PR DESCRIPTION
## Description

This PR fixes the HTTP `ext_authz` client to respect `status_on_error` configuration when the authorization server returns a 5xx error or when HTTP call failures occur. Previously, these error scenarios always returned `403 Forbidden` regardless of the configured error status.

---

**Commit Message:** ext_authz: fixed ext_authz to respect status_on_error config when server returns error
**Additional Description:** Fixes the HTTP `ext_authz` client to respect `status_on_error` configuration when the authorization server returns a 5xx error.
**Risk Level:** Low
**Testing:** Added Unit + Integration Tests
**Docs Changes:** Added
**Release Notes:** Added