### PR TITLE
changelog: fix typos in the current changelogs

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -46,12 +46,6 @@ bug_fixes:
 - area: tls
   change: |
     Fix on-demand TLS selector to enforce session resumption settings.
-- area: ext_authz
-  change: |
-    Added support for the ``append_action`` enum in gRPC ext_authz ``OkHttpResponse.headers`` for upstream
-    request header mutations. Previously, only the deprecated ``append`` boolean was checked. Now
-    ``APPEND_IF_EXISTS_OR_ADD``, ``ADD_IF_ABSENT``, ``OVERWRITE_IF_EXISTS``, and ``OVERWRITE_IF_EXISTS_OR_ADD``
-    actions are fully supported, providing parity with ``response_headers_to_add`` handling.
 - area: load_report
   change: |
     Fixed an issue upon load-report shutdown race with ADS stream. Introduced proper cleanup of the gRPC stream.
@@ -96,6 +90,12 @@ removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`
 
 new_features:
+- area: ext_authz
+  change: |
+    Added support for the ``append_action`` enum in gRPC ext_authz ``OkHttpResponse.headers`` for upstream
+    request header mutations. Previously, only the deprecated ``append`` boolean was checked. Now
+    ``APPEND_IF_EXISTS_OR_ADD``, ``ADD_IF_ABSENT``, ``OVERWRITE_IF_EXISTS``, and ``OVERWRITE_IF_EXISTS_OR_ADD``
+    actions are fully supported, providing parity with ``response_headers_to_add`` handling.
 - area: stats
   change: |
     Added support to limit the number of stats stored in each stats scope in the stats library.


### PR DESCRIPTION
## Description

This PR moves a misaligned entry from `bug_fixes` section to `new_features` in the Change Logs.

---

**Commit Message:** changelog: fix typos in the current changelogs
**Additional Description:** Moved a misaligned entry from `bug_fixes` section to `new_features` in the Change Logs.
**Risk Level:** Low
**Testing:** CI
**Docs Changes:** N/A
**Release Notes:** N/A