### PR TITLE
dynamic_modules: add configurable metrics_namespace for stats

### DIFF
--- a/api/envoy/extensions/dynamic_modules/v3/dynamic_modules.proto
+++ b/api/envoy/extensions/dynamic_modules/v3/dynamic_modules.proto
@@ -30,6 +30,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // the ABI is stabilized, this restriction will be revisited. Until then, Envoy checks the hash of
 // the ABI header files to ensure that the dynamic modules are built against the same version of the
 // ABI.
+// [#next-free-field: 6]
 message DynamicModuleConfig {
   // The name of the dynamic module.
   //
@@ -69,4 +70,12 @@ message DynamicModuleConfig {
   //
   // Defaults to ``false``.
   bool load_globally = 4;
+
+  // The namespace prefix for metrics emitted by this dynamic module.
+  //
+  // This allows users to customize the prefix used for all metrics created by the dynamic module.
+  // The prefix is prepended to all metric names.
+  //
+  // Defaults to ``dynamicmodulescustom``.
+  string metrics_namespace = 5;
 }

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -167,5 +167,11 @@ new_features:
     detects and selects between cgroup v1 and v2 at runtime by checking available cgroup files on
     the system. This enables the resource monitor to work correctly in both cgroup v1 and v2
     environments without configuration changes.
+- area: dynamic_modules
+  change: |
+    Added configurable :ref:`metrics_namespace
+    <envoy_v3_api_field_extensions.dynamic_modules.v3.DynamicModuleConfig.metrics_namespace>` field
+    to ``DynamicModuleConfig``. This allows users to customize the prefix used for all metrics
+    created by dynamic modules.
 
 deprecated:

--- a/source/extensions/filters/http/dynamic_modules/filter_config.h
+++ b/source/extensions/filters/http/dynamic_modules/filter_config.h
@@ -11,9 +11,10 @@ namespace Extensions {
 namespace DynamicModules {
 namespace HttpFilters {
 
-// The custom stat namespace which prepends all the user-defined metrics.
-// Note that the prefix is removed from the final output of /stats endpoints.
-constexpr absl::string_view CustomStatNamespace = "dynamicmodulescustom";
+// The default custom stat namespace which prepends all user-defined metrics.
+// Note that the prefix is removed from the final output of ``/stats`` endpoints.
+// This can be overridden via the ``metrics_namespace`` field in ``DynamicModuleConfig``.
+constexpr absl::string_view DefaultMetricsNamespace = "dynamicmodulescustom";
 
 using OnHttpConfigDestroyType = decltype(&envoy_dynamic_module_on_http_filter_config_destroy);
 using OnHttpFilterNewType = decltype(&envoy_dynamic_module_on_http_filter_new);
@@ -65,11 +66,14 @@ public:
    * Constructor for the config.
    * @param filter_name the name of the filter.
    * @param filter_config the configuration for the module.
+   * @param metrics_namespace the namespace prefix for metrics.
    * @param dynamic_module the dynamic module to use.
+   * @param stats_scope the stats scope for metric creation.
    * @param context the server factory context.
    */
   DynamicModuleHttpFilterConfig(const absl::string_view filter_name,
                                 const absl::string_view filter_config,
+                                const absl::string_view metrics_namespace,
                                 DynamicModulePtr dynamic_module, Stats::Scope& stats_scope,
                                 Server::Configuration::ServerFactoryContext& context);
 
@@ -298,6 +302,9 @@ private:
   // The configuration for the module.
   const std::string filter_config_;
 
+  // The namespace prefix for metrics.
+  const std::string metrics_namespace_;
+
   // The cached references to stats and their metadata.
   std::vector<ModuleCounterHandle> counters_;
   std::vector<ModuleCounterVecHandle> counter_vecs_;
@@ -364,14 +371,18 @@ newDynamicModuleHttpPerRouteConfig(const absl::string_view per_route_config_name
  * Creates a new DynamicModuleHttpFilterConfig for given configuration.
  * @param filter_name the name of the filter.
  * @param filter_config the configuration for the module.
+ * @param metrics_namespace the namespace prefix for metrics emitted by this module.
+ * @param terminal_filter whether the filter is terminal.
  * @param dynamic_module the dynamic module to use.
+ * @param stats_scope the stats scope for metric creation.
  * @param context the server factory context.
  * @return a shared pointer to the new config object or an error if the module could not be loaded.
  */
 absl::StatusOr<DynamicModuleHttpFilterConfigSharedPtr> newDynamicModuleHttpFilterConfig(
     const absl::string_view filter_name, const absl::string_view filter_config,
-    const bool terminal_filter, Extensions::DynamicModules::DynamicModulePtr dynamic_module,
-    Stats::Scope& stats_scope, Server::Configuration::ServerFactoryContext& context);
+    const absl::string_view metrics_namespace, const bool terminal_filter,
+    Extensions::DynamicModules::DynamicModulePtr dynamic_module, Stats::Scope& stats_scope,
+    Server::Configuration::ServerFactoryContext& context);
 
 } // namespace HttpFilters
 } // namespace DynamicModules

--- a/source/extensions/filters/listener/dynamic_modules/factory.cc
+++ b/source/extensions/filters/listener/dynamic_modules/factory.cc
@@ -37,10 +37,17 @@ DynamicModuleListenerFilterConfigFactory::createListenerFilterFactoryFromProto(
     filter_config_str = std::move(config_or_error.value());
   }
 
+  // Use configured metrics namespace or fall back to the default.
+  const std::string metrics_namespace =
+      module_config.metrics_namespace().empty()
+          ? std::string(Extensions::DynamicModules::ListenerFilters::DefaultMetricsNamespace)
+          : module_config.metrics_namespace();
+
   auto filter_config =
       Extensions::DynamicModules::ListenerFilters::newDynamicModuleListenerFilterConfig(
-          proto_config.filter_name(), filter_config_str, std::move(dynamic_module.value()),
-          context.listenerScope(), context.serverFactoryContext().mainThreadDispatcher());
+          proto_config.filter_name(), filter_config_str, metrics_namespace,
+          std::move(dynamic_module.value()), context.listenerScope(),
+          context.serverFactoryContext().mainThreadDispatcher());
 
   if (!filter_config.ok()) {
     throw EnvoyException("Failed to create filter config: " +

--- a/source/extensions/filters/listener/dynamic_modules/filter_config.cc
+++ b/source/extensions/filters/listener/dynamic_modules/filter_config.cc
@@ -4,6 +4,8 @@
 
 #include "source/extensions/dynamic_modules/abi/abi.h"
 
+#include "absl/strings/str_cat.h"
+
 namespace Envoy {
 namespace Extensions {
 namespace DynamicModules {
@@ -11,10 +13,10 @@ namespace ListenerFilters {
 
 DynamicModuleListenerFilterConfig::DynamicModuleListenerFilterConfig(
     const absl::string_view filter_name, const absl::string_view filter_config,
-    DynamicModulePtr dynamic_module, Stats::Scope& stats_scope,
-    Event::Dispatcher& main_thread_dispatcher)
+    const absl::string_view metrics_namespace, DynamicModulePtr dynamic_module,
+    Stats::Scope& stats_scope, Event::Dispatcher& main_thread_dispatcher)
     : main_thread_dispatcher_(main_thread_dispatcher),
-      stats_scope_(stats_scope.createScope(std::string(ListenerFilterStatsNamespace) + ".")),
+      stats_scope_(stats_scope.createScope(absl::StrCat(metrics_namespace, "."))),
       stat_name_pool_(stats_scope_->symbolTable()), filter_name_(filter_name),
       filter_config_(filter_config), dynamic_module_(std::move(dynamic_module)) {}
 
@@ -30,11 +32,10 @@ void DynamicModuleListenerFilterConfig::onScheduled(uint64_t event_id) {
   }
 }
 
-absl::StatusOr<DynamicModuleListenerFilterConfigSharedPtr>
-newDynamicModuleListenerFilterConfig(const absl::string_view filter_name,
-                                     const absl::string_view filter_config,
-                                     DynamicModulePtr dynamic_module, Stats::Scope& stats_scope,
-                                     Event::Dispatcher& main_thread_dispatcher) {
+absl::StatusOr<DynamicModuleListenerFilterConfigSharedPtr> newDynamicModuleListenerFilterConfig(
+    const absl::string_view filter_name, const absl::string_view filter_config,
+    const absl::string_view metrics_namespace, DynamicModulePtr dynamic_module,
+    Stats::Scope& stats_scope, Event::Dispatcher& main_thread_dispatcher) {
 
   // Resolve the symbols for the listener filter using graceful error handling.
   auto on_config_new =
@@ -82,7 +83,8 @@ newDynamicModuleListenerFilterConfig(const absl::string_view filter_name,
           "envoy_dynamic_module_on_listener_filter_config_scheduled");
 
   auto config = std::make_shared<DynamicModuleListenerFilterConfig>(
-      filter_name, filter_config, std::move(dynamic_module), stats_scope, main_thread_dispatcher);
+      filter_name, filter_config, metrics_namespace, std::move(dynamic_module), stats_scope,
+      main_thread_dispatcher);
 
   // Store the resolved function pointers.
   config->on_listener_filter_config_destroy_ = on_config_destroy.value();

--- a/source/extensions/filters/listener/dynamic_modules/filter_config.h
+++ b/source/extensions/filters/listener/dynamic_modules/filter_config.h
@@ -28,8 +28,10 @@ using OnListenerFilterScheduledType = decltype(&envoy_dynamic_module_on_listener
 using OnListenerFilterConfigScheduledType =
     decltype(&envoy_dynamic_module_on_listener_filter_config_scheduled);
 
-// Custom namespace prefix for listener filter stats.
-constexpr char ListenerFilterStatsNamespace[] = "dynamic_module_listener_filter";
+// The default custom stat namespace which prepends all user-defined metrics.
+// Note that the prefix is removed from the final output of ``/stats`` endpoints.
+// This can be overridden via the ``metrics_namespace`` field in ``DynamicModuleConfig``.
+constexpr absl::string_view DefaultMetricsNamespace = "dynamicmodulescustom";
 
 class DynamicModuleListenerFilterConfig;
 using DynamicModuleListenerFilterConfigSharedPtr =
@@ -52,12 +54,14 @@ public:
    * newDynamicModuleListenerFilterConfig().
    * @param filter_name the name of the filter.
    * @param filter_config the configuration for the module.
+   * @param metrics_namespace the namespace prefix for metrics.
    * @param dynamic_module the dynamic module to use.
    * @param stats_scope the stats scope for metrics.
    * @param main_thread_dispatcher the main thread dispatcher for scheduling events.
    */
   DynamicModuleListenerFilterConfig(const absl::string_view filter_name,
                                     const absl::string_view filter_config,
+                                    const absl::string_view metrics_namespace,
                                     DynamicModulePtr dynamic_module, Stats::Scope& stats_scope,
                                     Event::Dispatcher& main_thread_dispatcher);
 
@@ -170,6 +174,7 @@ private:
   friend absl::StatusOr<std::shared_ptr<DynamicModuleListenerFilterConfig>>
   newDynamicModuleListenerFilterConfig(const absl::string_view filter_name,
                                        const absl::string_view filter_config,
+                                       const absl::string_view metrics_namespace,
                                        DynamicModulePtr dynamic_module, Stats::Scope& stats_scope,
                                        Event::Dispatcher& main_thread_dispatcher);
 
@@ -217,6 +222,7 @@ private:
  * Creates a new DynamicModuleListenerFilterConfig for given configuration.
  * @param filter_name the name of the filter.
  * @param filter_config the configuration for the module.
+ * @param metrics_namespace the namespace prefix for metrics emitted by this module.
  * @param dynamic_module the dynamic module to use.
  * @param stats_scope the stats scope for metrics.
  * @param main_thread_dispatcher the main thread dispatcher for scheduling events.
@@ -224,6 +230,7 @@ private:
  */
 absl::StatusOr<DynamicModuleListenerFilterConfigSharedPtr> newDynamicModuleListenerFilterConfig(
     const absl::string_view filter_name, const absl::string_view filter_config,
+    const absl::string_view metrics_namespace,
     Extensions::DynamicModules::DynamicModulePtr dynamic_module, Stats::Scope& stats_scope,
     Event::Dispatcher& main_thread_dispatcher);
 

--- a/source/extensions/filters/network/dynamic_modules/factory.cc
+++ b/source/extensions/filters/network/dynamic_modules/factory.cc
@@ -29,12 +29,18 @@ DynamicModuleNetworkFilterConfigFactory::createFilterFactoryFromProtoTyped(
     config = std::move(config_or_error.value());
   }
 
+  // Use configured metrics namespace or fall back to the default.
+  const std::string metrics_namespace =
+      module_config.metrics_namespace().empty()
+          ? std::string(Extensions::DynamicModules::NetworkFilters::DefaultMetricsNamespace)
+          : module_config.metrics_namespace();
+
   absl::StatusOr<
       Envoy::Extensions::DynamicModules::NetworkFilters::DynamicModuleNetworkFilterConfigSharedPtr>
       filter_config =
           Envoy::Extensions::DynamicModules::NetworkFilters::newDynamicModuleNetworkFilterConfig(
-              proto_config.filter_name(), config, std::move(dynamic_module.value()),
-              context.serverFactoryContext().clusterManager(),
+              proto_config.filter_name(), config, metrics_namespace,
+              std::move(dynamic_module.value()), context.serverFactoryContext().clusterManager(),
               context.serverFactoryContext().scope(),
               context.serverFactoryContext().mainThreadDispatcher());
 

--- a/source/extensions/filters/network/dynamic_modules/filter_config.cc
+++ b/source/extensions/filters/network/dynamic_modules/filter_config.cc
@@ -4,6 +4,8 @@
 
 #include "source/extensions/dynamic_modules/abi/abi.h"
 
+#include "absl/strings/str_cat.h"
+
 namespace Envoy {
 namespace Extensions {
 namespace DynamicModules {
@@ -11,10 +13,11 @@ namespace NetworkFilters {
 
 DynamicModuleNetworkFilterConfig::DynamicModuleNetworkFilterConfig(
     const absl::string_view filter_name, const absl::string_view filter_config,
-    DynamicModulePtr dynamic_module, Envoy::Upstream::ClusterManager& cluster_manager,
-    Stats::Scope& stats_scope, Event::Dispatcher& main_thread_dispatcher)
+    const absl::string_view metrics_namespace, DynamicModulePtr dynamic_module,
+    Envoy::Upstream::ClusterManager& cluster_manager, Stats::Scope& stats_scope,
+    Event::Dispatcher& main_thread_dispatcher)
     : cluster_manager_(cluster_manager), main_thread_dispatcher_(main_thread_dispatcher),
-      stats_scope_(stats_scope.createScope(std::string(NetworkFilterStatsNamespace) + ".")),
+      stats_scope_(stats_scope.createScope(absl::StrCat(metrics_namespace, "."))),
       stat_name_pool_(stats_scope_->symbolTable()), filter_name_(filter_name),
       filter_config_(filter_config), dynamic_module_(std::move(dynamic_module)) {}
 
@@ -32,8 +35,9 @@ DynamicModuleNetworkFilterConfig::~DynamicModuleNetworkFilterConfig() {
 
 absl::StatusOr<DynamicModuleNetworkFilterConfigSharedPtr> newDynamicModuleNetworkFilterConfig(
     const absl::string_view filter_name, const absl::string_view filter_config,
-    DynamicModulePtr dynamic_module, Envoy::Upstream::ClusterManager& cluster_manager,
-    Stats::Scope& stats_scope, Event::Dispatcher& main_thread_dispatcher) {
+    const absl::string_view metrics_namespace, DynamicModulePtr dynamic_module,
+    Envoy::Upstream::ClusterManager& cluster_manager, Stats::Scope& stats_scope,
+    Event::Dispatcher& main_thread_dispatcher) {
 
   // Resolve the symbols for the network filter using graceful error handling.
   auto on_config_new =
@@ -90,8 +94,8 @@ absl::StatusOr<DynamicModuleNetworkFilterConfigSharedPtr> newDynamicModuleNetwor
           "envoy_dynamic_module_on_network_filter_below_write_buffer_low_watermark");
 
   auto config = std::make_shared<DynamicModuleNetworkFilterConfig>(
-      filter_name, filter_config, std::move(dynamic_module), cluster_manager, stats_scope,
-      main_thread_dispatcher);
+      filter_name, filter_config, metrics_namespace, std::move(dynamic_module), cluster_manager,
+      stats_scope, main_thread_dispatcher);
 
   // Store the resolved function pointers.
   config->on_network_filter_config_destroy_ = on_config_destroy.value();

--- a/source/extensions/filters/network/dynamic_modules/filter_config.h
+++ b/source/extensions/filters/network/dynamic_modules/filter_config.h
@@ -34,8 +34,10 @@ using OnNetworkFilterAboveWriteBufferHighWatermarkType =
 using OnNetworkFilterBelowWriteBufferLowWatermarkType =
     decltype(&envoy_dynamic_module_on_network_filter_below_write_buffer_low_watermark);
 
-// Custom namespace prefix for network filter stats.
-constexpr char NetworkFilterStatsNamespace[] = "dynamic_module_network_filter";
+// The default custom stat namespace which prepends all user-defined metrics.
+// Note that the prefix is removed from the final output of ``/stats`` endpoints.
+// This can be overridden via the ``metrics_namespace`` field in ``DynamicModuleConfig``.
+constexpr absl::string_view DefaultMetricsNamespace = "dynamicmodulescustom";
 
 class DynamicModuleNetworkFilterConfig;
 using DynamicModuleNetworkFilterConfigSharedPtr = std::shared_ptr<DynamicModuleNetworkFilterConfig>;
@@ -56,6 +58,7 @@ public:
    * Constructor for the config. Symbol resolution is done in newDynamicModuleNetworkFilterConfig().
    * @param filter_name the name of the filter.
    * @param filter_config the configuration for the module.
+   * @param metrics_namespace the namespace prefix for metrics.
    * @param dynamic_module the dynamic module to use.
    * @param cluster_manager the cluster manager for async HTTP callouts.
    * @param stats_scope the stats scope for metrics.
@@ -63,6 +66,7 @@ public:
    */
   DynamicModuleNetworkFilterConfig(const absl::string_view filter_name,
                                    const absl::string_view filter_config,
+                                   const absl::string_view metrics_namespace,
                                    DynamicModulePtr dynamic_module,
                                    Envoy::Upstream::ClusterManager& cluster_manager,
                                    Stats::Scope& stats_scope,
@@ -185,6 +189,7 @@ private:
   friend absl::StatusOr<std::shared_ptr<DynamicModuleNetworkFilterConfig>>
   newDynamicModuleNetworkFilterConfig(const absl::string_view filter_name,
                                       const absl::string_view filter_config,
+                                      const absl::string_view metrics_namespace,
                                       DynamicModulePtr dynamic_module,
                                       Envoy::Upstream::ClusterManager& cluster_manager,
                                       Stats::Scope& stats_scope,
@@ -234,6 +239,7 @@ private:
  * Creates a new DynamicModuleNetworkFilterConfig for given configuration.
  * @param filter_name the name of the filter.
  * @param filter_config the configuration for the module.
+ * @param metrics_namespace the namespace prefix for metrics emitted by this module.
  * @param dynamic_module the dynamic module to use.
  * @param cluster_manager the cluster manager for async HTTP callouts.
  * @param stats_scope the stats scope for metrics.
@@ -242,6 +248,7 @@ private:
  */
 absl::StatusOr<DynamicModuleNetworkFilterConfigSharedPtr> newDynamicModuleNetworkFilterConfig(
     const absl::string_view filter_name, const absl::string_view filter_config,
+    const absl::string_view metrics_namespace,
     Extensions::DynamicModules::DynamicModulePtr dynamic_module,
     Envoy::Upstream::ClusterManager& cluster_manager, Stats::Scope& stats_scope,
     Event::Dispatcher& main_thread_dispatcher);

--- a/source/extensions/filters/udp/dynamic_modules/filter_config.cc
+++ b/source/extensions/filters/udp/dynamic_modules/filter_config.cc
@@ -16,7 +16,10 @@ DynamicModuleUdpListenerFilterConfig::DynamicModuleUdpListenerFilterConfig(
       filter_config_(MessageUtil::getJsonStringFromMessageOrError(config.filter_config())),
       dynamic_module_(std::move(dynamic_module)),
       stats_scope_(stats_scope.createScope(
-          absl::StrCat(UdpListenerFilterStatsNamespace, ".", config.filter_name(), "."))),
+          absl::StrCat(config.dynamic_module_config().metrics_namespace().empty()
+                           ? std::string(DefaultMetricsNamespace)
+                           : config.dynamic_module_config().metrics_namespace(),
+                       ".", config.filter_name(), "."))),
       stat_name_pool_(stats_scope_->symbolTable()) {
 
   auto config_new_or_error = dynamic_module_->getFunctionPointer<decltype(on_filter_config_new_)>(

--- a/source/extensions/filters/udp/dynamic_modules/filter_config.h
+++ b/source/extensions/filters/udp/dynamic_modules/filter_config.h
@@ -14,8 +14,10 @@ namespace Extensions {
 namespace UdpFilters {
 namespace DynamicModules {
 
-// Custom namespace prefix for UDP listener filter stats.
-constexpr char UdpListenerFilterStatsNamespace[] = "dynamic_module_udp_listener_filter";
+// The default custom stat namespace which prepends all user-defined metrics.
+// Note that the prefix is removed from the final output of ``/stats`` endpoints.
+// This can be overridden via the ``metrics_namespace`` field in ``DynamicModuleConfig``.
+constexpr absl::string_view DefaultMetricsNamespace = "dynamicmodulescustom";
 
 class DynamicModuleUdpListenerFilterConfig {
 public:

--- a/test/extensions/dynamic_modules/http/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/http/abi_impl_test.cc
@@ -1644,7 +1644,7 @@ TEST(ABIImpl, Stats) {
   Stats::TestUtil::TestScope stats_scope{"", stats_store};
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   auto filter_config = std::make_shared<DynamicModuleHttpFilterConfig>(
-      "some_name", "some_config", nullptr, stats_scope, context);
+      "some_name", "some_config", DefaultMetricsNamespace, nullptr, stats_scope, context);
   DynamicModuleHttpFilter filter{filter_config, stats_scope.symbolTable(), 0};
 
   const std::string counter_vec_name{"some_counter_vec"};
@@ -2261,7 +2261,8 @@ public:
     ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status().message();
 
     auto filter_config_or_status = newDynamicModuleHttpFilterConfig(
-        "test_filter", "", false, std::move(dynamic_module.value()), *stats_scope_, context_);
+        "test_filter", "", DefaultMetricsNamespace, false, std::move(dynamic_module.value()),
+        *stats_scope_, context_);
     ASSERT_TRUE(filter_config_or_status.ok()) << filter_config_or_status.status().message();
     filter_config_ = filter_config_or_status.value();
 

--- a/test/extensions/dynamic_modules/http/filter_test.cc
+++ b/test/extensions/dynamic_modules/http/filter_test.cc
@@ -34,8 +34,9 @@ TEST_P(DynamicModuleTestLanguages, Nop) {
   Stats::IsolatedStoreImpl stats_store;
   auto filter_config_or_status =
       Envoy::Extensions::DynamicModules::HttpFilters::newDynamicModuleHttpFilterConfig(
-          filter_name, filter_config, false, std::move(dynamic_module.value()),
-          *stats_store.createScope(""), context);
+          filter_name, filter_config,
+          Envoy::Extensions::DynamicModules::HttpFilters::DefaultMetricsNamespace, false,
+          std::move(dynamic_module.value()), *stats_store.createScope(""), context);
   EXPECT_TRUE(filter_config_or_status.ok());
 
   auto filter = std::make_shared<DynamicModuleHttpFilter>(filter_config_or_status.value(),
@@ -88,7 +89,7 @@ TEST_P(DynamicModuleHttpLanguageTests, ConfigInitializationFailure) {
   Stats::IsolatedStoreImpl stats_store;
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   auto filter_config_or_status = newDynamicModuleHttpFilterConfig(
-      "config_init_failure", "", false, std::move(dynamic_module.value()),
+      "config_init_failure", "", DefaultMetricsNamespace, false, std::move(dynamic_module.value()),
       *stats_store.createScope(""), context);
   EXPECT_FALSE(filter_config_or_status.ok());
   EXPECT_THAT(filter_config_or_status.status().message(),
@@ -110,8 +111,8 @@ TEST_P(DynamicModuleHttpLanguageTests, StatsCallbacks) {
   Stats::TestUtil::TestScope stats_scope{"", stats_store};
   auto filter_config_or_status =
       Envoy::Extensions::DynamicModules::HttpFilters::newDynamicModuleHttpFilterConfig(
-          filter_name, filter_config, false, std::move(dynamic_module.value()), stats_scope,
-          context);
+          filter_name, filter_config, DefaultMetricsNamespace, false,
+          std::move(dynamic_module.value()), stats_scope, context);
   EXPECT_TRUE(filter_config_or_status.ok());
 
   auto filter = std::make_shared<DynamicModuleHttpFilter>(filter_config_or_status.value(),
@@ -230,8 +231,8 @@ TEST_P(DynamicModuleHttpLanguageTests, HeaderCallbacks) {
   Stats::IsolatedStoreImpl stats_store;
   auto filter_config_or_status =
       Envoy::Extensions::DynamicModules::HttpFilters::newDynamicModuleHttpFilterConfig(
-          filter_name, filter_config, false, std::move(dynamic_module.value()),
-          *stats_store.createScope(""), context);
+          filter_name, filter_config, DefaultMetricsNamespace, false,
+          std::move(dynamic_module.value()), *stats_store.createScope(""), context);
   EXPECT_TRUE(filter_config_or_status.ok());
 
   auto filter = std::make_shared<DynamicModuleHttpFilter>(filter_config_or_status.value(),
@@ -293,8 +294,8 @@ TEST_P(DynamicModuleHttpLanguageTests, DynamicMetadataCallbacks) {
   auto stats_scope = stats_store.createScope("");
   auto filter_config_or_status =
       Envoy::Extensions::DynamicModules::HttpFilters::newDynamicModuleHttpFilterConfig(
-          filter_name, filter_config, false, std::move(dynamic_module.value()), *stats_scope,
-          context);
+          filter_name, filter_config, DefaultMetricsNamespace, false,
+          std::move(dynamic_module.value()), *stats_scope, context);
   EXPECT_TRUE(filter_config_or_status.ok());
 
   auto filter = std::make_shared<DynamicModuleHttpFilter>(filter_config_or_status.value(),
@@ -377,8 +378,8 @@ TEST_P(DynamicModuleHttpLanguageTests, FilterStateCallbacks) {
   auto stats_scope = stats_store.createScope("");
   auto filter_config_or_status =
       Envoy::Extensions::DynamicModules::HttpFilters::newDynamicModuleHttpFilterConfig(
-          filter_name, filter_config, false, std::move(dynamic_module.value()), *stats_scope,
-          context);
+          filter_name, filter_config, DefaultMetricsNamespace, false,
+          std::move(dynamic_module.value()), *stats_scope, context);
   EXPECT_TRUE(filter_config_or_status.ok());
 
   auto filter = std::make_shared<DynamicModuleHttpFilter>(filter_config_or_status.value(),
@@ -455,8 +456,8 @@ TEST_P(DynamicModuleHttpLanguageTests, BodyCallbacks) {
   auto stats_scope = stats_store.createScope("");
   auto filter_config_or_status =
       Envoy::Extensions::DynamicModules::HttpFilters::newDynamicModuleHttpFilterConfig(
-          filter_name, filter_config, false, std::move(dynamic_module.value()), *stats_scope,
-          context);
+          filter_name, filter_config, DefaultMetricsNamespace, false,
+          std::move(dynamic_module.value()), *stats_scope, context);
   EXPECT_TRUE(filter_config_or_status.ok());
 
   auto filter = std::make_shared<DynamicModuleHttpFilter>(filter_config_or_status.value(),
@@ -537,8 +538,8 @@ TEST_P(DynamicModuleHttpLanguageTests, HttpFilterHttpCallout_non_existing_cluste
       .WillOnce(testing::Return(nullptr));
   auto filter_config_or_status =
       Envoy::Extensions::DynamicModules::HttpFilters::newDynamicModuleHttpFilterConfig(
-          filter_name, filter_config, false, std::move(dynamic_module.value()), *stats_scope,
-          context);
+          filter_name, filter_config, DefaultMetricsNamespace, false,
+          std::move(dynamic_module.value()), *stats_scope, context);
   EXPECT_TRUE(filter_config_or_status.ok());
 
   NiceMock<Http::MockStreamDecoderFilterCallbacks> callbacks;
@@ -580,8 +581,8 @@ TEST_P(DynamicModuleHttpLanguageTests, HttpFilterHttpCallout_immediate_failing_c
   const std::string filter_config = "immediate_failing_cluster";
   auto filter_config_or_status =
       Envoy::Extensions::DynamicModules::HttpFilters::newDynamicModuleHttpFilterConfig(
-          filter_name, filter_config, false, std::move(dynamic_module.value()), *stats_scope,
-          context);
+          filter_name, filter_config, DefaultMetricsNamespace, false,
+          std::move(dynamic_module.value()), *stats_scope, context);
   EXPECT_TRUE(filter_config_or_status.ok());
 
   std::shared_ptr<Upstream::MockThreadLocalCluster> cluster =
@@ -639,8 +640,8 @@ TEST_P(DynamicModuleHttpLanguageTests, HttpFilterHttpCallout_success) {
   const std::string filter_config = "success_cluster";
   auto filter_config_or_status =
       Envoy::Extensions::DynamicModules::HttpFilters::newDynamicModuleHttpFilterConfig(
-          filter_name, filter_config, false, std::move(dynamic_module.value()), *stats_scope,
-          context);
+          filter_name, filter_config, DefaultMetricsNamespace, false,
+          std::move(dynamic_module.value()), *stats_scope, context);
   EXPECT_TRUE(filter_config_or_status.ok());
 
   std::shared_ptr<Upstream::MockThreadLocalCluster> cluster =
@@ -714,8 +715,8 @@ TEST_P(DynamicModuleHttpLanguageTests, HttpFilterHttpCallout_resetting) {
   const std::string filter_config = "resetting_cluster";
   auto filter_config_or_status =
       Envoy::Extensions::DynamicModules::HttpFilters::newDynamicModuleHttpFilterConfig(
-          filter_name, filter_config, false, std::move(dynamic_module.value()), *stats_scope,
-          context);
+          filter_name, filter_config, DefaultMetricsNamespace, false,
+          std::move(dynamic_module.value()), *stats_scope, context);
   EXPECT_TRUE(filter_config_or_status.ok());
 
   std::shared_ptr<Upstream::MockThreadLocalCluster> cluster =
@@ -773,8 +774,8 @@ TEST_P(DynamicModuleHttpLanguageTests, HttpFilterPerRouteConfigLifetimes) {
   const std::string filter_config = "listener config";
   auto filter_config_or_status =
       Envoy::Extensions::DynamicModules::HttpFilters::newDynamicModuleHttpFilterConfig(
-          filter_name, filter_config, false, std::move(dynamic_module.value()), *stats_scope,
-          context);
+          filter_name, filter_config, DefaultMetricsNamespace, false,
+          std::move(dynamic_module.value()), *stats_scope, context);
   EXPECT_TRUE(filter_config_or_status.ok());
 
   auto dynamic_module_for_route =
@@ -928,7 +929,8 @@ TEST(DynamicModuleHttpStreamTest, HttpFilterHttpStreamCalloutOnComplete) {
 
   auto filter_config_or_status =
       Envoy::Extensions::DynamicModules::HttpFilters::newDynamicModuleHttpFilterConfig(
-          "filter", "", false, std::move(dynamic_module.value()), *stats_scope, context);
+          "filter", "", DefaultMetricsNamespace, false, std::move(dynamic_module.value()),
+          *stats_scope, context);
   EXPECT_TRUE(filter_config_or_status.ok());
 
   auto filter = std::make_shared<DynamicModuleHttpFilter>(filter_config_or_status.value(),
@@ -980,7 +982,8 @@ TEST(DynamicModuleHttpStreamTest, StartHttpStreamDoesNotSetContentLength) {
 
   auto filter_config_or_status =
       Envoy::Extensions::DynamicModules::HttpFilters::newDynamicModuleHttpFilterConfig(
-          "filter", "", false, std::move(dynamic_module.value()), *stats_scope, context);
+          "filter", "", DefaultMetricsNamespace, false, std::move(dynamic_module.value()),
+          *stats_scope, context);
   EXPECT_TRUE(filter_config_or_status.ok());
 
   auto filter = std::make_shared<DynamicModuleHttpFilter>(filter_config_or_status.value(),
@@ -1044,7 +1047,8 @@ TEST(DynamicModuleHttpStreamTest, StartHttpStreamAndNoCluster) {
 
   auto filter_config_or_status =
       Envoy::Extensions::DynamicModules::HttpFilters::newDynamicModuleHttpFilterConfig(
-          "filter", "", false, std::move(dynamic_module.value()), *stats_scope, context);
+          "filter", "", DefaultMetricsNamespace, false, std::move(dynamic_module.value()),
+          *stats_scope, context);
   EXPECT_TRUE(filter_config_or_status.ok());
 
   auto filter = std::make_shared<DynamicModuleHttpFilter>(filter_config_or_status.value(),
@@ -1082,7 +1086,8 @@ TEST(DynamicModuleHttpStreamTest, StartHttpStreamMissingRequiredHeaders) {
 
   auto filter_config_or_status =
       Envoy::Extensions::DynamicModules::HttpFilters::newDynamicModuleHttpFilterConfig(
-          "filter", "", false, std::move(dynamic_module.value()), *stats_scope, context);
+          "filter", "", DefaultMetricsNamespace, false, std::move(dynamic_module.value()),
+          *stats_scope, context);
   EXPECT_TRUE(filter_config_or_status.ok());
 
   auto filter = std::make_shared<DynamicModuleHttpFilter>(filter_config_or_status.value(),
@@ -1120,7 +1125,8 @@ TEST(DynamicModuleHttpStreamTest, StartHttpStreamHandlesInlineResetDuringHeaders
 
   auto filter_config_or_status =
       Envoy::Extensions::DynamicModules::HttpFilters::newDynamicModuleHttpFilterConfig(
-          "filter", "", false, std::move(dynamic_module.value()), *stats_scope, context);
+          "filter", "", DefaultMetricsNamespace, false, std::move(dynamic_module.value()),
+          *stats_scope, context);
   EXPECT_TRUE(filter_config_or_status.ok());
 
   auto filter = std::make_shared<DynamicModuleHttpFilter>(filter_config_or_status.value(),
@@ -1175,7 +1181,8 @@ TEST(DynamicModuleHttpStreamTest, HttpStreamCalloutDeferredDeleteOnDestroy) {
 
   auto filter_config_or_status =
       Envoy::Extensions::DynamicModules::HttpFilters::newDynamicModuleHttpFilterConfig(
-          "filter", "", false, std::move(dynamic_module.value()), *stats_scope, context);
+          "filter", "", DefaultMetricsNamespace, false, std::move(dynamic_module.value()),
+          *stats_scope, context);
   EXPECT_TRUE(filter_config_or_status.ok());
 
   auto filter = std::make_shared<DynamicModuleHttpFilter>(filter_config_or_status.value(),
@@ -1232,7 +1239,8 @@ TEST(DynamicModuleHttpStreamTest, HttpFilterHttpStreamCalloutOnReset) {
 
   auto filter_config_or_status =
       Envoy::Extensions::DynamicModules::HttpFilters::newDynamicModuleHttpFilterConfig(
-          "filter", "", false, std::move(dynamic_module.value()), *stats_scope, context);
+          "filter", "", DefaultMetricsNamespace, false, std::move(dynamic_module.value()),
+          *stats_scope, context);
   EXPECT_TRUE(filter_config_or_status.ok());
 
   auto filter = std::make_shared<DynamicModuleHttpFilter>(filter_config_or_status.value(),
@@ -1284,7 +1292,8 @@ TEST(DynamicModulesTest, HttpFilterResetHttpStream) {
 
   auto filter_config_or_status =
       Envoy::Extensions::DynamicModules::HttpFilters::newDynamicModuleHttpFilterConfig(
-          "filter", "", false, std::move(dynamic_module.value()), *stats_scope, context);
+          "filter", "", DefaultMetricsNamespace, false, std::move(dynamic_module.value()),
+          *stats_scope, context);
   EXPECT_TRUE(filter_config_or_status.ok());
 
   auto filter = std::make_shared<DynamicModuleHttpFilter>(filter_config_or_status.value(),
@@ -1343,7 +1352,8 @@ TEST(DynamicModulesTest, HttpFilterStartHttpStreamNoBodyEndStream) {
 
   auto filter_config_or_status =
       Envoy::Extensions::DynamicModules::HttpFilters::newDynamicModuleHttpFilterConfig(
-          "filter", "", false, std::move(dynamic_module.value()), *stats_scope, context);
+          "filter", "", DefaultMetricsNamespace, false, std::move(dynamic_module.value()),
+          *stats_scope, context);
   EXPECT_TRUE(filter_config_or_status.ok());
 
   auto filter = std::make_shared<DynamicModuleHttpFilter>(filter_config_or_status.value(),
@@ -1398,7 +1408,8 @@ TEST(DynamicModulesTest, HttpFilterStartHttpStreamInlineResetOnHeaders) {
 
   auto filter_config_or_status =
       Envoy::Extensions::DynamicModules::HttpFilters::newDynamicModuleHttpFilterConfig(
-          "filter", "", false, std::move(dynamic_module.value()), *stats_scope, context);
+          "filter", "", DefaultMetricsNamespace, false, std::move(dynamic_module.value()),
+          *stats_scope, context);
   EXPECT_TRUE(filter_config_or_status.ok());
 
   auto filter = std::make_shared<DynamicModuleHttpFilter>(filter_config_or_status.value(),
@@ -1458,7 +1469,8 @@ TEST(DynamicModulesTest, HttpFilterStartHttpStreamInlineResetOnData) {
 
   auto filter_config_or_status =
       Envoy::Extensions::DynamicModules::HttpFilters::newDynamicModuleHttpFilterConfig(
-          "filter", "", false, std::move(dynamic_module.value()), *stats_scope, context);
+          "filter", "", DefaultMetricsNamespace, false, std::move(dynamic_module.value()),
+          *stats_scope, context);
   EXPECT_TRUE(filter_config_or_status.ok());
 
   auto filter = std::make_shared<DynamicModuleHttpFilter>(filter_config_or_status.value(),
@@ -1522,7 +1534,8 @@ TEST(DynamicModulesTest, StartHttpStreamCannotCreateRequest) {
 
   auto filter_config_or_status =
       Envoy::Extensions::DynamicModules::HttpFilters::newDynamicModuleHttpFilterConfig(
-          "filter", "", false, std::move(dynamic_module.value()), *stats_scope, context);
+          "filter", "", DefaultMetricsNamespace, false, std::move(dynamic_module.value()),
+          *stats_scope, context);
   EXPECT_TRUE(filter_config_or_status.ok());
 
   NiceMock<Event::MockDispatcher> dispatcher;

--- a/test/extensions/dynamic_modules/listener/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/listener/abi_impl_test.cc
@@ -60,9 +60,9 @@ public:
     auto dynamic_module = newDynamicModule(testSharedObjectPath("listener_no_op", "c"), false);
     EXPECT_TRUE(dynamic_module.ok()) << dynamic_module.status().message();
 
-    auto filter_config_or_status =
-        newDynamicModuleListenerFilterConfig("test_filter", "", std::move(dynamic_module.value()),
-                                             *stats_.rootScope(), main_thread_dispatcher_);
+    auto filter_config_or_status = newDynamicModuleListenerFilterConfig(
+        "test_filter", "", DefaultMetricsNamespace, std::move(dynamic_module.value()),
+        *stats_.rootScope(), main_thread_dispatcher_);
     EXPECT_TRUE(filter_config_or_status.ok()) << filter_config_or_status.status().message();
     filter_config_ = filter_config_or_status.value();
 

--- a/test/extensions/dynamic_modules/listener/filter_test.cc
+++ b/test/extensions/dynamic_modules/listener/filter_test.cc
@@ -45,9 +45,9 @@ public:
     auto dynamic_module = newDynamicModule(testSharedObjectPath("listener_no_op", "c"), false);
     EXPECT_TRUE(dynamic_module.ok()) << dynamic_module.status().message();
 
-    auto filter_config_or_status =
-        newDynamicModuleListenerFilterConfig("test_filter", "", std::move(dynamic_module.value()),
-                                             *stats_.rootScope(), main_thread_dispatcher_);
+    auto filter_config_or_status = newDynamicModuleListenerFilterConfig(
+        "test_filter", "", DefaultMetricsNamespace, std::move(dynamic_module.value()),
+        *stats_.rootScope(), main_thread_dispatcher_);
     EXPECT_TRUE(filter_config_or_status.ok()) << filter_config_or_status.status().message();
     filter_config_ = filter_config_or_status.value();
 
@@ -117,9 +117,9 @@ TEST_F(DynamicModuleListenerFilterTest, OnAcceptWithNullInModuleFilterClosesSock
       newDynamicModule(testSharedObjectPath("listener_filter_new_fail", "c"), false);
   EXPECT_TRUE(dynamic_module.ok()) << dynamic_module.status().message();
 
-  auto filter_config_or_status =
-      newDynamicModuleListenerFilterConfig("test_filter", "", std::move(dynamic_module.value()),
-                                           *stats_.rootScope(), main_thread_dispatcher_);
+  auto filter_config_or_status = newDynamicModuleListenerFilterConfig(
+      "test_filter", "", DefaultMetricsNamespace, std::move(dynamic_module.value()),
+      *stats_.rootScope(), main_thread_dispatcher_);
   EXPECT_TRUE(filter_config_or_status.ok()) << filter_config_or_status.status().message();
   auto filter_config = filter_config_or_status.value();
 
@@ -205,8 +205,8 @@ TEST(DynamicModuleListenerFilterConfigTest, ConfigInitialization) {
   EXPECT_TRUE(dynamic_module.ok()) << dynamic_module.status().message();
 
   auto filter_config_or_status = newDynamicModuleListenerFilterConfig(
-      "test_filter", "some_config", std::move(dynamic_module.value()), *stats.rootScope(),
-      main_thread_dispatcher);
+      "test_filter", "some_config", DefaultMetricsNamespace, std::move(dynamic_module.value()),
+      *stats.rootScope(), main_thread_dispatcher);
   EXPECT_TRUE(filter_config_or_status.ok());
 
   auto config = filter_config_or_status.value();
@@ -227,9 +227,9 @@ TEST(DynamicModuleListenerFilterConfigTest, MissingSymbols) {
   auto dynamic_module = newDynamicModule(testSharedObjectPath("no_op", "c"), false);
   EXPECT_TRUE(dynamic_module.ok()) << dynamic_module.status().message();
 
-  auto filter_config_or_status =
-      newDynamicModuleListenerFilterConfig("test_filter", "", std::move(dynamic_module.value()),
-                                           *stats.rootScope(), main_thread_dispatcher);
+  auto filter_config_or_status = newDynamicModuleListenerFilterConfig(
+      "test_filter", "", DefaultMetricsNamespace, std::move(dynamic_module.value()),
+      *stats.rootScope(), main_thread_dispatcher);
   EXPECT_FALSE(filter_config_or_status.ok());
 }
 
@@ -241,9 +241,9 @@ TEST(DynamicModuleListenerFilterConfigTest, ConfigInitializationFailure) {
       newDynamicModule(testSharedObjectPath("listener_config_new_fail", "c"), false);
   EXPECT_TRUE(dynamic_module.ok()) << dynamic_module.status().message();
 
-  auto filter_config_or_status =
-      newDynamicModuleListenerFilterConfig("test_filter", "", std::move(dynamic_module.value()),
-                                           *stats.rootScope(), main_thread_dispatcher);
+  auto filter_config_or_status = newDynamicModuleListenerFilterConfig(
+      "test_filter", "", DefaultMetricsNamespace, std::move(dynamic_module.value()),
+      *stats.rootScope(), main_thread_dispatcher);
   EXPECT_FALSE(filter_config_or_status.ok());
   EXPECT_THAT(filter_config_or_status.status().message(),
               testing::HasSubstr("Failed to initialize"));
@@ -256,9 +256,9 @@ TEST(DynamicModuleListenerFilterConfigTest, StopIterationStatus) {
       newDynamicModule(testSharedObjectPath("listener_stop_iteration", "c"), false);
   EXPECT_TRUE(dynamic_module.ok()) << dynamic_module.status().message();
 
-  auto filter_config_or_status =
-      newDynamicModuleListenerFilterConfig("test_filter", "", std::move(dynamic_module.value()),
-                                           *stats.rootScope(), main_thread_dispatcher);
+  auto filter_config_or_status = newDynamicModuleListenerFilterConfig(
+      "test_filter", "", DefaultMetricsNamespace, std::move(dynamic_module.value()),
+      *stats.rootScope(), main_thread_dispatcher);
   EXPECT_TRUE(filter_config_or_status.ok());
   auto config = filter_config_or_status.value();
 
@@ -282,9 +282,9 @@ TEST(DynamicModuleListenerFilterConfigTest, OnDataStopIterationStatus) {
       newDynamicModule(testSharedObjectPath("listener_stop_iteration", "c"), false);
   EXPECT_TRUE(dynamic_module.ok()) << dynamic_module.status().message();
 
-  auto filter_config_or_status =
-      newDynamicModuleListenerFilterConfig("test_filter", "", std::move(dynamic_module.value()),
-                                           *stats.rootScope(), main_thread_dispatcher);
+  auto filter_config_or_status = newDynamicModuleListenerFilterConfig(
+      "test_filter", "", DefaultMetricsNamespace, std::move(dynamic_module.value()),
+      *stats.rootScope(), main_thread_dispatcher);
   EXPECT_TRUE(filter_config_or_status.ok());
   auto config = filter_config_or_status.value();
 
@@ -320,7 +320,7 @@ TEST_F(DynamicModuleListenerFilterTest, MetricsCounterDefineAndIncrement) {
                 static_cast<void*>(filter.get()), counter_id, 5));
 
   // Verify the counter value.
-  auto counter = TestUtility::findCounter(stats_, "dynamic_module_listener_filter.test_counter");
+  auto counter = TestUtility::findCounter(stats_, "dynamicmodulescustom.test_counter");
   ASSERT_NE(nullptr, counter);
   EXPECT_EQ(5, counter->value());
 }
@@ -351,7 +351,7 @@ TEST_F(DynamicModuleListenerFilterTest, MetricsGaugeDefineAndManipulate) {
                 static_cast<void*>(filter.get()), gauge_id, 5));
 
   // Verify the gauge value: 100 + 10 - 5 = 105.
-  auto gauge = TestUtility::findGauge(stats_, "dynamic_module_listener_filter.test_gauge");
+  auto gauge = TestUtility::findGauge(stats_, "dynamicmodulescustom.test_gauge");
   ASSERT_NE(nullptr, gauge);
   EXPECT_EQ(105, gauge->value());
 }

--- a/test/extensions/dynamic_modules/network/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/network/abi_impl_test.cc
@@ -31,8 +31,8 @@ public:
     EXPECT_TRUE(dynamic_module.ok()) << dynamic_module.status().message();
 
     auto filter_config_or_status = newDynamicModuleNetworkFilterConfig(
-        "test_filter", "", std::move(dynamic_module.value()), cluster_manager_, *stats_.rootScope(),
-        main_thread_dispatcher_);
+        "test_filter", "", DefaultMetricsNamespace, std::move(dynamic_module.value()),
+        cluster_manager_, *stats_.rootScope(), main_thread_dispatcher_);
     EXPECT_TRUE(filter_config_or_status.ok()) << filter_config_or_status.status().message();
     filter_config_ = filter_config_or_status.value();
 
@@ -1244,8 +1244,8 @@ public:
     EXPECT_TRUE(dynamic_module.ok()) << dynamic_module.status().message();
 
     auto filter_config_or_status = newDynamicModuleNetworkFilterConfig(
-        "test_filter", "", std::move(dynamic_module.value()), cluster_manager_, *stats_.rootScope(),
-        main_thread_dispatcher_);
+        "test_filter", "", DefaultMetricsNamespace, std::move(dynamic_module.value()),
+        cluster_manager_, *stats_.rootScope(), main_thread_dispatcher_);
     EXPECT_TRUE(filter_config_or_status.ok()) << filter_config_or_status.status().message();
     filter_config_ = filter_config_or_status.value();
 

--- a/test/extensions/dynamic_modules/network/filter_test.cc
+++ b/test/extensions/dynamic_modules/network/filter_test.cc
@@ -22,8 +22,8 @@ public:
     EXPECT_TRUE(dynamic_module.ok()) << dynamic_module.status().message();
 
     auto filter_config_or_status = newDynamicModuleNetworkFilterConfig(
-        "test_filter", "", std::move(dynamic_module.value()), cluster_manager_, *stats_.rootScope(),
-        main_thread_dispatcher_);
+        "test_filter", "", DefaultMetricsNamespace, std::move(dynamic_module.value()),
+        cluster_manager_, *stats_.rootScope(), main_thread_dispatcher_);
     EXPECT_TRUE(filter_config_or_status.ok()) << filter_config_or_status.status().message();
     filter_config_ = filter_config_or_status.value();
 
@@ -111,8 +111,8 @@ TEST_F(DynamicModuleNetworkFilterTest, FilterWithoutInModuleFilter) {
   EXPECT_TRUE(dynamic_module.ok()) << dynamic_module.status().message();
 
   auto filter_config_or_status = newDynamicModuleNetworkFilterConfig(
-      "test_filter", "", std::move(dynamic_module.value()), cluster_manager_, *stats_.rootScope(),
-      main_thread_dispatcher_);
+      "test_filter", "", DefaultMetricsNamespace, std::move(dynamic_module.value()),
+      cluster_manager_, *stats_.rootScope(), main_thread_dispatcher_);
   EXPECT_TRUE(filter_config_or_status.ok()) << filter_config_or_status.status().message();
   auto filter_config = filter_config_or_status.value();
   auto filter = std::make_shared<DynamicModuleNetworkFilter>(filter_config);
@@ -228,8 +228,8 @@ TEST(DynamicModuleNetworkFilterConfigTest, ConfigInitialization) {
   NiceMock<Upstream::MockClusterManager> cluster_manager;
   NiceMock<Event::MockDispatcher> main_thread_dispatcher;
   auto filter_config_or_status = newDynamicModuleNetworkFilterConfig(
-      "test_filter", "some_config", std::move(dynamic_module.value()), cluster_manager,
-      *stats.rootScope(), main_thread_dispatcher);
+      "test_filter", "some_config", DefaultMetricsNamespace, std::move(dynamic_module.value()),
+      cluster_manager, *stats.rootScope(), main_thread_dispatcher);
   EXPECT_TRUE(filter_config_or_status.ok());
 
   auto config = filter_config_or_status.value();
@@ -252,8 +252,8 @@ TEST(DynamicModuleNetworkFilterConfigTest, MissingSymbols) {
   NiceMock<Upstream::MockClusterManager> cluster_manager;
   NiceMock<Event::MockDispatcher> main_thread_dispatcher;
   auto filter_config_or_status = newDynamicModuleNetworkFilterConfig(
-      "test_filter", "", std::move(dynamic_module.value()), cluster_manager, *stats.rootScope(),
-      main_thread_dispatcher);
+      "test_filter", "", DefaultMetricsNamespace, std::move(dynamic_module.value()),
+      cluster_manager, *stats.rootScope(), main_thread_dispatcher);
   EXPECT_FALSE(filter_config_or_status.ok());
 }
 
@@ -267,8 +267,8 @@ TEST(DynamicModuleNetworkFilterConfigTest, ConfigInitializationFailure) {
   NiceMock<Upstream::MockClusterManager> cluster_manager;
   NiceMock<Event::MockDispatcher> main_thread_dispatcher;
   auto filter_config_or_status = newDynamicModuleNetworkFilterConfig(
-      "test_filter", "", std::move(dynamic_module.value()), cluster_manager, *stats.rootScope(),
-      main_thread_dispatcher);
+      "test_filter", "", DefaultMetricsNamespace, std::move(dynamic_module.value()),
+      cluster_manager, *stats.rootScope(), main_thread_dispatcher);
   EXPECT_FALSE(filter_config_or_status.ok());
   EXPECT_THAT(filter_config_or_status.status().message(),
               testing::HasSubstr("Failed to initialize"));
@@ -283,8 +283,8 @@ TEST(DynamicModuleNetworkFilterConfigTest, StopIterationStatus) {
   NiceMock<Upstream::MockClusterManager> cluster_manager;
   NiceMock<Event::MockDispatcher> main_thread_dispatcher;
   auto filter_config_or_status = newDynamicModuleNetworkFilterConfig(
-      "test_filter", "", std::move(dynamic_module.value()), cluster_manager, *stats.rootScope(),
-      main_thread_dispatcher);
+      "test_filter", "", DefaultMetricsNamespace, std::move(dynamic_module.value()),
+      cluster_manager, *stats.rootScope(), main_thread_dispatcher);
   EXPECT_TRUE(filter_config_or_status.ok());
   auto config = filter_config_or_status.value();
 

--- a/test/extensions/dynamic_modules/udp/filter_test.cc
+++ b/test/extensions/dynamic_modules/udp/filter_test.cc
@@ -335,8 +335,7 @@ TEST_F(DynamicModuleUdpListenerFilterTest, MetricsCounterDefineAndIncrement) {
   EXPECT_EQ(envoy_dynamic_module_type_metrics_result_Success, result);
 
   // Verify the counter value.
-  auto counter = TestUtility::findCounter(
-      stats_, "dynamic_module_udp_listener_filter.test_filter.test_counter");
+  auto counter = TestUtility::findCounter(stats_, "dynamicmodulescustom.test_filter.test_counter");
   ASSERT_NE(nullptr, counter);
   EXPECT_EQ(5, counter->value());
 }
@@ -368,8 +367,7 @@ TEST_F(DynamicModuleUdpListenerFilterTest, MetricsGaugeDefineAndOperations) {
   EXPECT_EQ(envoy_dynamic_module_type_metrics_result_Success, result);
 
   // Verify gauge value.
-  auto gauge =
-      TestUtility::findGauge(stats_, "dynamic_module_udp_listener_filter.test_filter.test_gauge");
+  auto gauge = TestUtility::findGauge(stats_, "dynamicmodulescustom.test_filter.test_gauge");
   ASSERT_NE(nullptr, gauge);
   EXPECT_EQ(105, gauge->value());
 }


### PR DESCRIPTION
## Description

This PR adds a configurable way via `metrics_namespace` for the Dynamic Modules stats emission.

---

**Commit Message:** dynamic_modules: add configurable metrics_namespace for stats
**Additional Description:** Adds a configurable way via `metrics_namespace` for the Dynamic Modules stats emission.
**Risk Level:** Low
**Testing:** Added Unit + Integration Tests
**Docs Changes:** Added
**Release Notes:** Added