### PR TITLE
[bp/v1.37] ext_authz: fixed ext_authz to respect status_on_error config when server returns error

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -8,12 +8,18 @@ minor_behavior_changes:
 
 bug_fixes:
 # *Changes expected to improve the state of the world and are unlikely to have negative effects*
-- area: ext_authz
-  change: |
-    Fixed a bug where headers from a denied authorization response (non-200s) were not properly propagated to the client.
 - area: oauth2
   change: |
-    Fixed OAuth2 refresh requests so host rewriting no longer overrides the original Host value.
+    Fixed OAuth2 refresh requests so host rewriting no longer overrides the original ``Host`` header value.
+- area: ext_authz
+  change: |
+    Fixed a bug where headers from a denied authorization response (non-200) were not properly propagated
+    to the client.
+- area: ext_authz
+  change: |
+    Fixed the HTTP ext_authz client to respect ``status_on_error`` configuration when the authorization
+    server returns a 5xx error or when HTTP call failures occur. Previously, these error scenarios always
+    returned 403 Forbidden regardless of the configured error status.
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/source/extensions/filters/common/ext_authz/ext_authz_http_impl.cc
+++ b/source/extensions/filters/common/ext_authz/ext_authz_http_impl.cc
@@ -34,6 +34,8 @@ const Http::HeaderMap& lengthZeroHeader() {
 }
 
 // Static response used for creating authorization ERROR responses.
+// Note: status_code is left unset so the filter can use the configured status_on_error
+// configuration.
 const Response& errorResponse() {
   CONSTRUCT_ON_FIRST_USE(Response, Response{CheckStatus::Error,
                                             UnsafeHeaderVector{},
@@ -48,7 +50,7 @@ const Response& errorResponse() {
                                             Http::Utility::QueryParamsVector{},
                                             {},
                                             EMPTY_STRING,
-                                            Http::Code::Forbidden,
+                                            static_cast<Http::Code>(0),
                                             Protobuf::Struct{}});
 }
 

--- a/test/extensions/filters/common/ext_authz/ext_authz_http_impl_test.cc
+++ b/test/extensions/filters/common/ext_authz/ext_authz_http_impl_test.cc
@@ -626,6 +626,60 @@ TEST_F(ExtAuthzHttpClientTest, AuthorizationRequest5xxError) {
   client_->onSuccess(async_request_, std::move(check_response));
 }
 
+// Test that HTTP call failure leaves status_code unset. This allows the filter to use
+// status_on_error configuration instead of a hardcoded value.
+TEST_F(ExtAuthzHttpClientTest, HttpCallFailureDoesNotSetStatusCode) {
+  envoy::service::auth::v3::CheckRequest request;
+
+  // Expected: status_code should be unset (0), not Forbidden.
+  auto expected_response = Response{};
+  expected_response.status = CheckStatus::Error;
+  expected_response.status_code = static_cast<Http::Code>(0);
+
+  client_->check(request_callbacks_, request, parent_span_, stream_info_);
+
+  EXPECT_CALL(request_callbacks_, onComplete_(WhenDynamicCastTo<ResponsePtr&>(
+                                      AuthzErrorResponseWithAttributes(expected_response))));
+  client_->onFailure(async_request_, Http::AsyncClient::FailureReason::Reset);
+}
+
+// Test that HTTP 5xx response leaves status_code unset. This allows the filter to use
+// status_on_error configuration instead of a hardcoded value.
+TEST_F(ExtAuthzHttpClientTest, Http5xxResponseDoesNotSetStatusCode) {
+  Http::ResponseMessagePtr check_response(new Http::ResponseMessageImpl(
+      Http::ResponseHeaderMapPtr{new Http::TestResponseHeaderMapImpl{{":status", "503"}}}));
+  envoy::service::auth::v3::CheckRequest request;
+
+  // Expected: status_code should be unset (0), not Forbidden.
+  auto expected_response = Response{};
+  expected_response.status = CheckStatus::Error;
+  expected_response.status_code = static_cast<Http::Code>(0);
+
+  client_->check(request_callbacks_, request, parent_span_, stream_info_);
+
+  EXPECT_CALL(request_callbacks_, onComplete_(WhenDynamicCastTo<ResponsePtr&>(
+                                      AuthzErrorResponseWithAttributes(expected_response))));
+  client_->onSuccess(async_request_, std::move(check_response));
+}
+
+// Test that missing cluster leaves status_code unset. This allows the filter to use
+// status_on_error configuration instead of a hardcoded value.
+TEST_F(ExtAuthzHttpClientTest, MissingClusterDoesNotSetStatusCode) {
+  InSequence s;
+
+  // Expected: status_code should be unset (0), not Forbidden.
+  auto expected_response = Response{};
+  expected_response.status = CheckStatus::Error;
+  expected_response.status_code = static_cast<Http::Code>(0);
+
+  EXPECT_CALL(cm_, getThreadLocalCluster(Eq("ext_authz"))).WillOnce(Return(nullptr));
+  EXPECT_CALL(cm_.thread_local_cluster_, httpAsyncClient()).Times(0);
+  EXPECT_CALL(request_callbacks_, onComplete_(WhenDynamicCastTo<ResponsePtr&>(
+                                      AuthzErrorResponseWithAttributes(expected_response))));
+  client_->check(request_callbacks_, envoy::service::auth::v3::CheckRequest{}, parent_span_,
+                 stream_info_);
+}
+
 // Test the client when the request is canceled.
 TEST_F(ExtAuthzHttpClientTest, CancelledAuthorizationRequest) {
   envoy::service::auth::v3::CheckRequest request;

--- a/test/extensions/filters/http/ext_authz/ext_authz_integration_test.cc
+++ b/test/extensions/filters/http/ext_authz/ext_authz_integration_test.cc
@@ -849,8 +849,9 @@ public:
   }
 
   void initializeConfig(bool legacy_allowed_headers = true, bool failure_mode_allow = true,
-                        uint64_t timeout_ms = 300) {
-    config_helper_.addConfigModifier([this, legacy_allowed_headers, failure_mode_allow, timeout_ms](
+                        uint64_t timeout_ms = 300, uint32_t status_on_error_code = 0) {
+    config_helper_.addConfigModifier([this, legacy_allowed_headers, failure_mode_allow, timeout_ms,
+                                      status_on_error_code](
                                          envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
       auto* ext_authz_cluster = bootstrap.mutable_static_resources()->add_clusters();
       ext_authz_cluster->MergeFrom(bootstrap.static_resources().clusters()[0]);
@@ -866,6 +867,11 @@ public:
       proto_config_.mutable_http_service()->mutable_server_uri()->mutable_timeout()->CopyFrom(
           Protobuf::util::TimeUtil::MillisecondsToDuration(timeout_ms));
       proto_config_.set_encode_raw_headers(encodeRawHeaders());
+
+      if (status_on_error_code > 0) {
+        proto_config_.mutable_status_on_error()->set_code(
+            static_cast<envoy::type::v3::StatusCode>(status_on_error_code));
+      }
 
       envoy::extensions::filters::network::http_connection_manager::v3::HttpFilter ext_authz_filter;
       ext_authz_filter.set_name("envoy.filters.http.ext_authz");
@@ -1718,6 +1724,40 @@ TEST_P(ExtAuthzHttpIntegrationTest, TimeoutFailOpen) {
   ASSERT_TRUE(response_->waitForEndStream());
   EXPECT_TRUE(response_->complete());
   EXPECT_EQ("200", response_->headers().getStatusValue());
+
+  cleanup();
+}
+
+// Test that HTTP ext_authz call failure respects status_on_error configuration.
+TEST_P(ExtAuthzHttpIntegrationTest, HttpCallFailureUsesStatusOnError) {
+  initializeConfig(false, /*failure_mode_allow=*/false, /*timeout_ms=*/1,
+                   /*status_on_error_code=*/503);
+  HttpIntegrationTest::initialize();
+  initiateClientConnection();
+
+  // Do not sendExtAuthzResponse(). Envoy should reject with configured status_on_error.
+  ASSERT_TRUE(response_->waitForEndStream(Envoy::Seconds(10)));
+  EXPECT_TRUE(response_->complete());
+  EXPECT_EQ("503", response_->headers().getStatusValue());
+
+  cleanup();
+}
+
+// Test that HTTP ext_authz 5xx response respects status_on_error configuration.
+TEST_P(ExtAuthzHttpIntegrationTest, Http5xxResponseUsesStatusOnError) {
+  initializeConfig(false, /*failure_mode_allow=*/false, /*timeout_ms=*/300000,
+                   /*status_on_error_code=*/503);
+  HttpIntegrationTest::initialize();
+  initiateClientConnection();
+  waitForExtAuthzRequest();
+
+  // Send a 5xx response from ext_authz server.
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "500"}};
+  ext_authz_request_->encodeHeaders(response_headers, true);
+
+  ASSERT_TRUE(response_->waitForEndStream());
+  EXPECT_TRUE(response_->complete());
+  EXPECT_EQ("503", response_->headers().getStatusValue());
 
   cleanup();
 }


### PR DESCRIPTION
**Original PR:** https://github.com/envoyproxy/envoy/pull/43257

## Description

This PR fixes the HTTP `ext_authz` client to respect `status_on_error` configuration when the authorization server returns a 5xx error or when HTTP call failures occur. Previously, these error scenarios always returned `403 Forbidden` regardless of the configured error status.

---

**Commit Message:** ext_authz: fixed ext_authz to respect status_on_error config when server returns error
**Additional Description:** Fixes the HTTP `ext_authz` client to respect `status_on_error` configuration when the authorization server returns a 5xx error.
**Risk Level:** Low
**Testing:** Added Unit + Integration Tests
**Docs Changes:** Added
**Release Notes:** Added