### PR TITLE
http: add server context only factory support to aws_lambda filter

### DIFF
--- a/source/extensions/filters/http/aws_lambda/config.h
+++ b/source/extensions/filters/http/aws_lambda/config.h
@@ -29,10 +29,20 @@ protected:
       const envoy::extensions::filters::http::aws_lambda::v3::Config& proto_config,
       Server::Configuration::ServerFactoryContext& server_context, const std::string& region) const;
 
+  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoHelper(
+      const envoy::extensions::filters::http::aws_lambda::v3::Config& proto_config,
+      const std::string& stats_prefix, Server::Configuration::ServerFactoryContext& server_context,
+      Stats::Scope& scope, bool is_upstream) const;
+
 private:
   absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::aws_lambda::v3::Config& proto_config,
       const std::string& stats_prefix, DualInfo dual_info,
+      Server::Configuration::ServerFactoryContext& context) override;
+
+  Http::FilterFactoryCb createFilterFactoryFromProtoWithServerContextTyped(
+      const envoy::extensions::filters::http::aws_lambda::v3::Config& proto_config,
+      const std::string& stats_prefix,
       Server::Configuration::ServerFactoryContext& context) override;
 
   absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>

--- a/test/extensions/filters/http/aws_lambda/config_test.cc
+++ b/test/extensions/filters/http/aws_lambda/config_test.cc
@@ -384,6 +384,33 @@ aws_session_token = profile4_token
   EXPECT_EQ("default_token", credentials.sessionToken().value());
 }
 
+TEST(AwsLambdaFilterConfigTest, ValidConfigCreatesFilterWithServerContext) {
+  const std::string yaml = R"EOF(
+arn: "arn:aws:lambda:region:424242:function:fun"
+payload_passthrough: true
+invocation_mode: asynchronous
+  )EOF";
+
+  LambdaConfig proto_config;
+  TestUtility::loadFromYamlAndValidate(yaml, proto_config);
+
+  testing::NiceMock<Server::Configuration::MockServerFactoryContext> context;
+  AwsLambdaFilterFactory factory;
+
+  Http::FilterFactoryCb cb =
+      factory.createFilterFactoryFromProtoWithServerContext(proto_config, "stats", context);
+  Http::MockFilterChainFactoryCallbacks filter_callbacks;
+  auto has_expected_settings = [](std::shared_ptr<Envoy::Http::StreamFilter> stream_filter) {
+    auto filter = std::static_pointer_cast<Filter>(stream_filter);
+    const auto& settings = filter->settingsForTest();
+    return settings.payloadPassthrough() &&
+           settings.invocationMode() == InvocationMode::Asynchronous;
+  };
+
+  EXPECT_CALL(filter_callbacks, addStreamFilter(Truly(has_expected_settings)));
+  cb(filter_callbacks);
+}
+
 } // namespace
 } // namespace AwsLambdaFilter
 } // namespace HttpFilters


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
