### PR TITLE
http: add server context only factory support to basic_auth filter

### DIFF
--- a/source/extensions/filters/http/basic_auth/config.h
+++ b/source/extensions/filters/http/basic_auth/config.h
@@ -21,6 +21,12 @@ private:
   Http::FilterFactoryCb createFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::basic_auth::v3::BasicAuth& config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
+
+  Http::FilterFactoryCb createFilterFactoryFromProtoWithServerContextTyped(
+      const envoy::extensions::filters::http::basic_auth::v3::BasicAuth& config,
+      const std::string& stats_prefix,
+      Server::Configuration::ServerFactoryContext& context) override;
+
   absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
   createRouteSpecificFilterConfigTyped(
       const envoy::extensions::filters::http::basic_auth::v3::BasicAuthPerRoute& proto_config,

--- a/test/extensions/filters/http/basic_auth/config_test.cc
+++ b/test/extensions/filters/http/basic_auth/config_test.cc
@@ -150,6 +150,27 @@ TEST(Factory, InvalidConfigNotSHA) {
       EnvoyException, "basic auth: unsupported htpasswd format: please use {SHA}");
 }
 
+TEST(Factory, ValidConfigWithServerContext) {
+  const std::string yaml = R"(
+  users:
+    inline_string: |-
+        user1:{SHA}tESsBmE/yNY3lb6a0L6vVQEZNqw=
+        user2:{SHA}EJ9LPFDXsN9ynSmbxvjp75Bmlx8=
+  )";
+
+  BasicAuthFilterFactory factory;
+  BasicAuth proto_config;
+  TestUtility::loadFromYaml(yaml, proto_config);
+
+  NiceMock<Server::Configuration::MockServerFactoryContext> context;
+
+  auto callback =
+      factory.createFilterFactoryFromProtoWithServerContext(proto_config, "stats", context);
+  Http::MockFilterChainFactoryCallbacks filter_callback;
+  EXPECT_CALL(filter_callback, addStreamDecoderFilter(_));
+  callback(filter_callback);
+}
+
 } // namespace BasicAuth
 } // namespace HttpFilters
 } // namespace Extensions


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
