### PR TITLE
http: add server context only factory support to cache_v2 filter

### DIFF
--- a/source/extensions/filters/http/cache_v2/config.h
+++ b/source/extensions/filters/http/cache_v2/config.h
@@ -19,6 +19,11 @@ private:
   Http::FilterFactoryCb createFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::cache_v2::v3::CacheV2Config& config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
+
+  Http::FilterFactoryCb createFilterFactoryFromProtoWithServerContextTyped(
+      const envoy::extensions::filters::http::cache_v2::v3::CacheV2Config& config,
+      const std::string& stats_prefix,
+      Server::Configuration::ServerFactoryContext& context) override;
 };
 
 } // namespace CacheV2

--- a/test/extensions/filters/http/cache_v2/config_test.cc
+++ b/test/extensions/filters/http/cache_v2/config_test.cc
@@ -83,6 +83,19 @@ TEST_F(CacheFilterFactoryTest, FactoryFailsToCreateCache) {
       EnvoyException);
 }
 
+TEST_F(CacheFilterFactoryTest, BasicWithServerContext) {
+  NiceMock<Server::Configuration::MockServerFactoryContext> server_context;
+  config_.mutable_typed_config()->PackFrom(
+      envoy::extensions::http::cache_v2::simple_http_cache::v3::SimpleHttpCacheV2Config());
+  Http::FilterFactoryCb cb =
+      factory_.createFilterFactoryFromProtoWithServerContext(config_, "stats", server_context);
+  Http::StreamFilterSharedPtr filter;
+  EXPECT_CALL(filter_callback_, addStreamFilter(_)).WillOnce(::testing::SaveArg<0>(&filter));
+  cb(filter_callback_);
+  ASSERT(filter);
+  ASSERT(dynamic_cast<CacheFilter*>(filter.get()));
+}
+
 } // namespace
 } // namespace CacheV2
 } // namespace HttpFilters


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
