### PR TITLE
http: add server context only factory support to connect_grpc_bridge

### DIFF
--- a/source/extensions/filters/http/connect_grpc_bridge/config.cc
+++ b/source/extensions/filters/http/connect_grpc_bridge/config.cc
@@ -19,6 +19,15 @@ Http::FilterFactoryCb ConnectGrpcFilterConfigFactory::createFilterFactoryFromPro
   };
 }
 
+Http::FilterFactoryCb
+ConnectGrpcFilterConfigFactory::createFilterFactoryFromProtoWithServerContextTyped(
+    const envoy::extensions::filters::http::connect_grpc_bridge::v3::FilterConfig&,
+    const std::string&, Server::Configuration::ServerFactoryContext&) {
+  return [](Http::FilterChainFactoryCallbacks& callbacks) {
+    callbacks.addStreamFilter(std::make_shared<ConnectGrpcBridgeFilter>());
+  };
+}
+
 /**
  * Static registration for the Connect RPC stats filter. @see RegisterFactory.
  */

--- a/source/extensions/filters/http/connect_grpc_bridge/config.h
+++ b/source/extensions/filters/http/connect_grpc_bridge/config.h
@@ -21,6 +21,10 @@ private:
   Http::FilterFactoryCb createFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::connect_grpc_bridge::v3::FilterConfig& proto_config,
       const std::string&, Server::Configuration::FactoryContext&) override;
+
+  Http::FilterFactoryCb createFilterFactoryFromProtoWithServerContextTyped(
+      const envoy::extensions::filters::http::connect_grpc_bridge::v3::FilterConfig& proto_config,
+      const std::string&, Server::Configuration::ServerFactoryContext&) override;
 };
 
 } // namespace ConnectGrpcBridge

--- a/test/extensions/filters/http/connect_grpc_bridge/config_test.cc
+++ b/test/extensions/filters/http/connect_grpc_bridge/config_test.cc
@@ -27,6 +27,17 @@ TEST(ConnectGrpcBridgeFilterConfigTest, ConnectGrpcBridgeFilter) {
   cb(filter_callback);
 }
 
+TEST(ConnectGrpcBridgeFilterConfigTest, ConnectGrpcBridgeFilterWithServerContext) {
+  NiceMock<Server::Configuration::MockServerFactoryContext> context;
+  ConnectGrpcFilterConfigFactory factory;
+  envoy::extensions::filters::http::connect_grpc_bridge::v3::FilterConfig config;
+  Http::FilterFactoryCb cb =
+      factory.createFilterFactoryFromProtoWithServerContext(config, "stats", context);
+  Http::MockFilterChainFactoryCallbacks filter_callback;
+  EXPECT_CALL(filter_callback, addStreamFilter(_)).Times(AtLeast(1));
+  cb(filter_callback);
+}
+
 } // namespace
 } // namespace ConnectGrpcBridge
 } // namespace HttpFilters


### PR DESCRIPTION

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
