### PR TITLE
http: add server context only factory support to cors filter

### DIFF
--- a/source/extensions/filters/http/cors/config.cc
+++ b/source/extensions/filters/http/cors/config.cc
@@ -27,6 +27,16 @@ Http::FilterFactoryCb CorsFilterFactory::createFilterFactoryFromProtoTyped(
   };
 }
 
+Http::FilterFactoryCb CorsFilterFactory::createFilterFactoryFromProtoWithServerContextTyped(
+    const envoy::extensions::filters::http::cors::v3::Cors&, const std::string& stats_prefix,
+    Server::Configuration::ServerFactoryContext& context) {
+  CorsFilterConfigSharedPtr config =
+      std::make_shared<CorsFilterConfig>(stats_prefix, context.scope());
+  return [config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
+    callbacks.addStreamFilter(std::make_shared<CorsFilter>(config));
+  };
+}
+
 absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
 CorsFilterFactory::createRouteSpecificFilterConfigTyped(
     const envoy::extensions::filters::http::cors::v3::CorsPolicy& policy,

--- a/source/extensions/filters/http/cors/config.h
+++ b/source/extensions/filters/http/cors/config.h
@@ -23,6 +23,11 @@ public:
       const envoy::extensions::filters::http::cors::v3::Cors& proto_config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
 
+  Http::FilterFactoryCb createFilterFactoryFromProtoWithServerContextTyped(
+      const envoy::extensions::filters::http::cors::v3::Cors& proto_config,
+      const std::string& stats_prefix,
+      Server::Configuration::ServerFactoryContext& context) override;
+
   absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
   createRouteSpecificFilterConfigTyped(
       const envoy::extensions::filters::http::cors::v3::CorsPolicy& policy,

--- a/test/extensions/filters/http/cors/BUILD
+++ b/test/extensions/filters/http/cors/BUILD
@@ -12,6 +12,16 @@ licenses(["notice"])  # Apache 2
 envoy_package()
 
 envoy_extension_cc_test(
+    name = "config_test",
+    srcs = ["config_test.cc"],
+    extension_names = ["envoy.filters.http.cors"],
+    deps = [
+        "//source/extensions/filters/http/cors:config",
+        "//test/mocks/server:factory_context_mocks",
+    ],
+)
+
+envoy_extension_cc_test(
     name = "cors_filter_test",
     srcs = ["cors_filter_test.cc"],
     extension_names = ["envoy.filters.http.cors"],

--- a/test/extensions/filters/http/cors/config_test.cc
+++ b/test/extensions/filters/http/cors/config_test.cc
@@ -1,0 +1,42 @@
+#include "source/extensions/filters/http/cors/config.h"
+
+#include "test/mocks/server/factory_context.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+using testing::_;
+using testing::NiceMock;
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace Cors {
+namespace {
+
+TEST(CorsFilterConfigTest, CorsFilter) {
+  NiceMock<Server::Configuration::MockFactoryContext> context;
+  CorsFilterFactory factory;
+  envoy::extensions::filters::http::cors::v3::Cors config;
+  Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(config, "stats", context).value();
+  NiceMock<Http::MockFilterChainFactoryCallbacks> filter_callback;
+  EXPECT_CALL(filter_callback, addStreamFilter(_));
+  cb(filter_callback);
+}
+
+TEST(CorsFilterConfigTest, CorsFilterWithServerContext) {
+  NiceMock<Server::Configuration::MockServerFactoryContext> context;
+  CorsFilterFactory factory;
+  envoy::extensions::filters::http::cors::v3::Cors config;
+  Http::FilterFactoryCb cb =
+      factory.createFilterFactoryFromProtoWithServerContext(config, "stats", context);
+  NiceMock<Http::MockFilterChainFactoryCallbacks> filter_callback;
+  EXPECT_CALL(filter_callback, addStreamFilter(_));
+  cb(filter_callback);
+}
+
+} // namespace
+} // namespace Cors
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
