### PR TITLE
http: add server context only factory support to credential_injector …

### DIFF
--- a/source/extensions/filters/http/credential_injector/config.h
+++ b/source/extensions/filters/http/credential_injector/config.h
@@ -16,10 +16,21 @@ class CredentialInjectorFilterFactory
 public:
   CredentialInjectorFilterFactory() : DualFactoryBase("envoy.filters.http.credential_injector") {}
 
+protected:
+  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoHelper(
+      const envoy::extensions::filters::http::credential_injector::v3::CredentialInjector& config,
+      const std::string& stats_prefix, Server::Configuration::ServerFactoryContext& context,
+      Stats::Scope& scope, Init::Manager& init_manager) const;
+
 private:
   absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::credential_injector::v3::CredentialInjector& config,
       const std::string& stats_prefix, DualInfo dual_info,
+      Server::Configuration::ServerFactoryContext& context) override;
+
+  Http::FilterFactoryCb createFilterFactoryFromProtoWithServerContextTyped(
+      const envoy::extensions::filters::http::credential_injector::v3::CredentialInjector& config,
+      const std::string& stats_prefix,
       Server::Configuration::ServerFactoryContext& context) override;
 };
 

--- a/test/extensions/filters/http/credential_injector/BUILD
+++ b/test/extensions/filters/http/credential_injector/BUILD
@@ -38,6 +38,9 @@ envoy_extension_cc_test(
     deps = [
         ":mock_credentail_cc_proto",
         "//source/extensions/filters/http/credential_injector:config",
+        "//source/extensions/filters/http/credential_injector:credential_injector_lib",
+        "//source/extensions/http/injected_credentials/generic:config",
+        "//source/extensions/http/injected_credentials/oauth2:client_credentials_lib",
         "//test/mocks/runtime:runtime_mocks",
         "//test/mocks/server:factory_context_mocks",
         "//test/mocks/server:server_mocks",


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
