### PR TITLE
http: add server context only factory support to csrf filter

### DIFF
--- a/source/extensions/filters/http/csrf/config.cc
+++ b/source/extensions/filters/http/csrf/config.cc
@@ -21,6 +21,16 @@ Http::FilterFactoryCb CsrfFilterFactory::createFilterFactoryFromProtoTyped(
   };
 }
 
+Http::FilterFactoryCb CsrfFilterFactory::createFilterFactoryFromProtoWithServerContextTyped(
+    const envoy::extensions::filters::http::csrf::v3::CsrfPolicy& policy,
+    const std::string& stats_prefix, Server::Configuration::ServerFactoryContext& context) {
+  CsrfFilterConfigSharedPtr config =
+      std::make_shared<CsrfFilterConfig>(policy, stats_prefix, context.scope(), context);
+  return [config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
+    callbacks.addStreamDecoderFilter(std::make_shared<CsrfFilter>(config));
+  };
+}
+
 absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
 CsrfFilterFactory::createRouteSpecificFilterConfigTyped(
     const envoy::extensions::filters::http::csrf::v3::CsrfPolicy& policy,

--- a/source/extensions/filters/http/csrf/config.h
+++ b/source/extensions/filters/http/csrf/config.h
@@ -22,6 +22,12 @@ private:
   Http::FilterFactoryCb createFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::csrf::v3::CsrfPolicy& policy,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
+
+  Http::FilterFactoryCb createFilterFactoryFromProtoWithServerContextTyped(
+      const envoy::extensions::filters::http::csrf::v3::CsrfPolicy& policy,
+      const std::string& stats_prefix,
+      Server::Configuration::ServerFactoryContext& context) override;
+
   absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
   createRouteSpecificFilterConfigTyped(
       const envoy::extensions::filters::http::csrf::v3::CsrfPolicy& policy,

--- a/test/extensions/filters/http/csrf/BUILD
+++ b/test/extensions/filters/http/csrf/BUILD
@@ -30,6 +30,18 @@ envoy_extension_cc_test(
 )
 
 envoy_extension_cc_test(
+    name = "csrf_config_test",
+    srcs = ["csrf_config_test.cc"],
+    extension_names = ["envoy.filters.http.csrf"],
+    rbe_pool = "6gig",
+    deps = [
+        "//source/extensions/filters/http/csrf:config",
+        "//test/mocks/server:factory_context_mocks",
+        "@envoy_api//envoy/extensions/filters/http/csrf/v3:pkg_cc_proto",
+    ],
+)
+
+envoy_extension_cc_test(
     name = "csrf_filter_integration_test",
     size = "large",
     srcs = ["csrf_filter_integration_test.cc"],

--- a/test/extensions/filters/http/csrf/csrf_config_test.cc
+++ b/test/extensions/filters/http/csrf/csrf_config_test.cc
@@ -1,0 +1,44 @@
+#include "envoy/extensions/filters/http/csrf/v3/csrf.pb.h"
+
+#include "source/extensions/filters/http/csrf/config.h"
+
+#include "test/mocks/server/server_factory_context.h"
+#include "test/test_common/utility.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+using testing::NiceMock;
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace Csrf {
+namespace {
+
+TEST(CsrfFilterConfigTest, ServerContextOnlyFactory) {
+  const std::string yaml_string = R"EOF(
+  filter_enabled:
+    default_value:
+      numerator: 100
+      denominator: HUNDRED
+  shadow_enabled:
+    default_value:
+      numerator: 100
+      denominator: HUNDRED
+  )EOF";
+
+  envoy::extensions::filters::http::csrf::v3::CsrfPolicy proto_config;
+  TestUtility::loadFromYaml(yaml_string, proto_config);
+  CsrfFilterFactory factory;
+  NiceMock<Server::Configuration::MockServerFactoryContext> context;
+
+  auto cb = factory.createFilterFactoryFromProtoWithServerContext(proto_config, "stats", context);
+  EXPECT_NE(cb, nullptr);
+}
+
+} // namespace
+} // namespace Csrf
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
