### PR TITLE
http: add server context only factory support to grpc_http1_bridge

### DIFF
--- a/source/extensions/filters/http/grpc_http1_bridge/config.cc
+++ b/source/extensions/filters/http/grpc_http1_bridge/config.cc
@@ -18,6 +18,16 @@ Http::FilterFactoryCb GrpcHttp1BridgeFilterConfig::createFilterFactoryFromProtoT
   };
 }
 
+Http::FilterFactoryCb
+GrpcHttp1BridgeFilterConfig::createFilterFactoryFromProtoWithServerContextTyped(
+    const envoy::extensions::filters::http::grpc_http1_bridge::v3::Config& proto_config,
+    const std::string&, Server::Configuration::ServerFactoryContext& factory_context) {
+  return [&factory_context, proto_config](Http::FilterChainFactoryCallbacks& callbacks) {
+    callbacks.addStreamFilter(
+        std::make_shared<Http1BridgeFilter>(factory_context.grpcContext(), proto_config));
+  };
+}
+
 /**
  * Static registration for the grpc HTTP1 bridge filter. @see RegisterFactory.
  */

--- a/source/extensions/filters/http/grpc_http1_bridge/config.h
+++ b/source/extensions/filters/http/grpc_http1_bridge/config.h
@@ -22,6 +22,11 @@ public:
       const envoy::extensions::filters::http::grpc_http1_bridge::v3::Config& proto_config,
       const std::string& stats_prefix,
       Server::Configuration::FactoryContext& factory_context) override;
+
+  Http::FilterFactoryCb createFilterFactoryFromProtoWithServerContextTyped(
+      const envoy::extensions::filters::http::grpc_http1_bridge::v3::Config& proto_config,
+      const std::string& stats_prefix,
+      Server::Configuration::ServerFactoryContext& factory_context) override;
 };
 
 } // namespace GrpcHttp1Bridge

--- a/test/extensions/filters/http/grpc_http1_bridge/config_test.cc
+++ b/test/extensions/filters/http/grpc_http1_bridge/config_test.cc
@@ -23,6 +23,17 @@ TEST(GrpcHttp1BridgeFilterConfigTest, GrpcHttp1BridgeFilter) {
   cb(filter_callback);
 }
 
+TEST(GrpcHttp1BridgeFilterConfigTest, GrpcHttp1BridgeFilterWithServerContext) {
+  NiceMock<Server::Configuration::MockServerFactoryContext> context;
+  GrpcHttp1BridgeFilterConfig factory;
+  envoy::extensions::filters::http::grpc_http1_bridge::v3::Config config;
+  Http::FilterFactoryCb cb =
+      factory.createFilterFactoryFromProtoWithServerContext(config, "stats", context);
+  Http::MockFilterChainFactoryCallbacks filter_callback;
+  EXPECT_CALL(filter_callback, addStreamFilter(_));
+  cb(filter_callback);
+}
+
 } // namespace
 } // namespace GrpcHttp1Bridge
 } // namespace HttpFilters


### PR DESCRIPTION

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
