### PR TITLE
http: add server context only factory support to grpc_http1_reverse_bridge filter

### DIFF
--- a/source/extensions/filters/http/grpc_http1_reverse_bridge/config.cc
+++ b/source/extensions/filters/http/grpc_http1_reverse_bridge/config.cc
@@ -20,6 +20,15 @@ Http::FilterFactoryCb Config::createFilterFactoryFromProtoTyped(
   };
 }
 
+Http::FilterFactoryCb Config::createFilterFactoryFromProtoWithServerContextTyped(
+    const envoy::extensions::filters::http::grpc_http1_reverse_bridge::v3::FilterConfig& config,
+    const std::string&, Server::Configuration::ServerFactoryContext&) {
+  return [config](Envoy::Http::FilterChainFactoryCallbacks& callbacks) -> void {
+    callbacks.addStreamFilter(std::make_shared<Filter>(
+        config.content_type(), config.withhold_grpc_frames(), config.response_size_header()));
+  };
+}
+
 absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
 Config::createRouteSpecificFilterConfigTyped(
     const envoy::extensions::filters::http::grpc_http1_reverse_bridge::v3::FilterConfigPerRoute&

--- a/source/extensions/filters/http/grpc_http1_reverse_bridge/config.h
+++ b/source/extensions/filters/http/grpc_http1_reverse_bridge/config.h
@@ -23,6 +23,11 @@ public:
       const std::string& stat_prefix,
       Envoy::Server::Configuration::FactoryContext& context) override;
 
+  Http::FilterFactoryCb createFilterFactoryFromProtoWithServerContextTyped(
+      const envoy::extensions::filters::http::grpc_http1_reverse_bridge::v3::FilterConfig& config,
+      const std::string& stat_prefix,
+      Envoy::Server::Configuration::ServerFactoryContext& context) override;
+
 private:
   absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
   createRouteSpecificFilterConfigTyped(

--- a/test/extensions/filters/http/grpc_http1_reverse_bridge/config_test.cc
+++ b/test/extensions/filters/http/grpc_http1_reverse_bridge/config_test.cc
@@ -58,6 +58,23 @@ TEST(ReverseBridgeFilterFactoryTest, ReverseBridgeFilterRouteSpecificConfig) {
   EXPECT_TRUE(inflated);
 }
 
+TEST(ReverseBridgeFilterFactoryTest, ReverseBridgeFilterWithServerContext) {
+  const std::string yaml_string = R"EOF(
+content_type: application/grpc+proto
+withhold_grpc_frames: true
+  )EOF";
+
+  envoy::extensions::filters::http::grpc_http1_reverse_bridge::v3::FilterConfig proto_config;
+  TestUtility::loadFromYaml(yaml_string, proto_config);
+  NiceMock<Server::Configuration::MockServerFactoryContext> context;
+  Config config_factory;
+  Http::FilterFactoryCb cb =
+      config_factory.createFilterFactoryFromProtoWithServerContext(proto_config, "stats", context);
+  Http::MockFilterChainFactoryCallbacks filter_callback;
+  EXPECT_CALL(filter_callback, addStreamFilter(_));
+  cb(filter_callback);
+}
+
 } // namespace
 } // namespace GrpcHttp1ReverseBridge
 } // namespace HttpFilters


### PR DESCRIPTION
…ridge filter

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
