### PR TITLE
http: add server context only factory support to grpc_json_reverse_transcoder filter

### DIFF
--- a/source/extensions/filters/http/grpc_json_reverse_transcoder/config.cc
+++ b/source/extensions/filters/http/grpc_json_reverse_transcoder/config.cc
@@ -24,6 +24,18 @@ Http::FilterFactoryCb GrpcJsonReverseTranscoderFactory::createFilterFactoryFromP
   };
 }
 
+Http::FilterFactoryCb
+GrpcJsonReverseTranscoderFactory::createFilterFactoryFromProtoWithServerContextTyped(
+    const envoy::extensions::filters::http::grpc_json_reverse_transcoder::v3::
+        GrpcJsonReverseTranscoder& proto_config,
+    const std::string&, Server::Configuration::ServerFactoryContext& context) {
+  std::shared_ptr<GrpcJsonReverseTranscoderConfig> filter_config =
+      std::make_shared<GrpcJsonReverseTranscoderConfig>(proto_config, context.api());
+  return [filter_config](Envoy::Http::FilterChainFactoryCallbacks& callbacks) -> void {
+    callbacks.addStreamFilter(std::make_shared<GrpcJsonReverseTranscoderFilter>(filter_config));
+  };
+}
+
 absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
 GrpcJsonReverseTranscoderFactory::createRouteSpecificFilterConfigTyped(
     const envoy::extensions::filters::http::grpc_json_reverse_transcoder::v3::

--- a/source/extensions/filters/http/grpc_json_reverse_transcoder/config.h
+++ b/source/extensions/filters/http/grpc_json_reverse_transcoder/config.h
@@ -23,6 +23,11 @@ private:
           GrpcJsonReverseTranscoder& proto_config,
       const std::string&, Server::Configuration::FactoryContext& context) override;
 
+  Http::FilterFactoryCb createFilterFactoryFromProtoWithServerContextTyped(
+      const envoy::extensions::filters::http::grpc_json_reverse_transcoder::v3::
+          GrpcJsonReverseTranscoder& proto_config,
+      const std::string&, Server::Configuration::ServerFactoryContext& context) override;
+
   absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
   createRouteSpecificFilterConfigTyped(
       const envoy::extensions::filters::http::grpc_json_reverse_transcoder::v3::

--- a/test/extensions/filters/http/grpc_json_reverse_transcoder/BUILD
+++ b/test/extensions/filters/http/grpc_json_reverse_transcoder/BUILD
@@ -45,11 +45,15 @@ envoy_extension_cc_test(
 envoy_extension_cc_test(
     name = "config_test",
     srcs = ["config_test.cc"],
+    data = [
+        "//test/proto:bookstore_proto_descriptor",
+    ],
     extension_names = ["envoy.filters.http.grpc_json_reverse_transcoder"],
     rbe_pool = "6gig",
     deps = [
         "//source/extensions/filters/http/grpc_json_reverse_transcoder:config",
         "//test/mocks/server:factory_context_mocks",
+        "//test/test_common:environment_lib",
         "@envoy_api//envoy/extensions/filters/http/grpc_json_reverse_transcoder/v3:pkg_cc_proto",
     ],
 )

--- a/test/extensions/filters/http/grpc_json_reverse_transcoder/config_test.cc
+++ b/test/extensions/filters/http/grpc_json_reverse_transcoder/config_test.cc
@@ -4,9 +4,13 @@
 #include "source/extensions/filters/http/grpc_json_reverse_transcoder/config.h"
 
 #include "test/mocks/server/factory_context.h"
+#include "test/test_common/environment.h"
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
+
+using testing::_;
+using testing::NiceMock;
 
 namespace Envoy {
 namespace Extensions {
@@ -23,6 +27,54 @@ TEST(GrpcJsonTranscoderFilterConfigTest, ValidateFail) {
                        "stats", context)
                    .value(),
                ProtoValidationException);
+}
+
+TEST(GrpcJsonTranscoderFilterConfigTest, ValidateFailWithServerContext) {
+  NiceMock<Server::Configuration::MockServerFactoryContext> context;
+  EXPECT_THROW(GrpcJsonReverseTranscoderFactory().createFilterFactoryFromProtoWithServerContext(
+                   envoy::extensions::filters::http::grpc_json_reverse_transcoder::v3::
+                       GrpcJsonReverseTranscoder(),
+                   "stats", context),
+               ProtoValidationException);
+}
+
+class GrpcJsonReverseTranscoderFilterFactoryTest : public testing::Test {
+protected:
+  void SetUp() override {
+    api_ = Api::createApiForTest();
+    // Load the descriptor file content into the config
+    auto descriptor_bytes =
+        api_->fileSystem()
+            .fileReadToEnd(TestEnvironment::runfilesPath("test/proto/bookstore.descriptor"))
+            .value();
+    config_.set_descriptor_binary(descriptor_bytes);
+  }
+
+  Api::ApiPtr api_;
+  envoy::extensions::filters::http::grpc_json_reverse_transcoder::v3::GrpcJsonReverseTranscoder
+      config_;
+};
+
+TEST_F(GrpcJsonReverseTranscoderFilterFactoryTest, CreateFilterFactoryFromProto) {
+  NiceMock<Server::Configuration::MockFactoryContext> context;
+  GrpcJsonReverseTranscoderFactory factory;
+
+  Http::FilterFactoryCb cb =
+      factory.createFilterFactoryFromProto(config_, "stats", context).value();
+  NiceMock<Http::MockFilterChainFactoryCallbacks> filter_callback;
+  EXPECT_CALL(filter_callback, addStreamFilter(_));
+  cb(filter_callback);
+}
+
+TEST_F(GrpcJsonReverseTranscoderFilterFactoryTest, CreateFilterFactoryFromProtoWithServerContext) {
+  NiceMock<Server::Configuration::MockServerFactoryContext> context;
+  GrpcJsonReverseTranscoderFactory factory;
+
+  Http::FilterFactoryCb cb =
+      factory.createFilterFactoryFromProtoWithServerContext(config_, "stats", context);
+  NiceMock<Http::MockFilterChainFactoryCallbacks> filter_callback;
+  EXPECT_CALL(filter_callback, addStreamFilter(_));
+  cb(filter_callback);
 }
 
 } // namespace


### PR DESCRIPTION
…anscoder filter

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
