### PR TITLE
http: add server context only factory support to mcp filter

### DIFF
--- a/source/extensions/filters/http/mcp/config.cc
+++ b/source/extensions/filters/http/mcp/config.cc
@@ -21,6 +21,17 @@ Http::FilterFactoryCb McpFilterConfigFactory::createFilterFactoryFromProtoTyped(
   };
 }
 
+Http::FilterFactoryCb McpFilterConfigFactory::createFilterFactoryFromProtoWithServerContextTyped(
+    const envoy::extensions::filters::http::mcp::v3::Mcp& proto_config,
+    const std::string& stats_prefix, Server::Configuration::ServerFactoryContext& context) {
+
+  auto config = std::make_shared<McpFilterConfig>(proto_config, stats_prefix, context.scope());
+
+  return [config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
+    callbacks.addStreamFilter(std::make_shared<McpFilter>(config));
+  };
+}
+
 absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
 McpFilterConfigFactory::createRouteSpecificFilterConfigTyped(
     const envoy::extensions::filters::http::mcp::v3::McpOverride& proto_config,

--- a/source/extensions/filters/http/mcp/config.h
+++ b/source/extensions/filters/http/mcp/config.h
@@ -25,6 +25,11 @@ private:
       const envoy::extensions::filters::http::mcp::v3::Mcp& proto_config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
 
+  Http::FilterFactoryCb createFilterFactoryFromProtoWithServerContextTyped(
+      const envoy::extensions::filters::http::mcp::v3::Mcp& proto_config,
+      const std::string& stats_prefix,
+      Server::Configuration::ServerFactoryContext& context) override;
+
   absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
   createRouteSpecificFilterConfigTyped(
       const envoy::extensions::filters::http::mcp::v3::McpOverride& proto_config,

--- a/test/extensions/filters/http/mcp/config_test.cc
+++ b/test/extensions/filters/http/mcp/config_test.cc
@@ -52,6 +52,19 @@ TEST_F(McpFilterConfigTest, CreateRouteSpecificConfig) {
   EXPECT_NE(nullptr, config_or.value());
 }
 
+// Test creating filter with server context
+TEST_F(McpFilterConfigTest, CreateFilterWithServerContext) {
+  envoy::extensions::filters::http::mcp::v3::Mcp proto_config;
+  NiceMock<Server::Configuration::MockServerFactoryContext> server_context;
+
+  Http::FilterFactoryCb cb = factory_->createFilterFactoryFromProtoWithServerContext(
+      proto_config, "stats", server_context);
+
+  NiceMock<Http::MockFilterChainFactoryCallbacks> filter_callbacks;
+  EXPECT_CALL(filter_callbacks, addStreamFilter(_));
+  cb(filter_callbacks);
+}
+
 } // namespace
 } // namespace Mcp
 } // namespace HttpFilters


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
