### PR TITLE
http: add server context only factory support to thrift_to_metadata filter

### DIFF
--- a/source/extensions/filters/http/thrift_to_metadata/config.cc
+++ b/source/extensions/filters/http/thrift_to_metadata/config.cc
@@ -25,6 +25,17 @@ Http::FilterFactoryCb ThriftToMetadataConfig::createFilterFactoryFromProtoTyped(
   };
 }
 
+Http::FilterFactoryCb ThriftToMetadataConfig::createFilterFactoryFromProtoWithServerContextTyped(
+    const envoy::extensions::filters::http::thrift_to_metadata::v3::ThriftToMetadata& proto_config,
+    const std::string&, Server::Configuration::ServerFactoryContext& context) {
+  std::shared_ptr<FilterConfig> config =
+      std::make_shared<FilterConfig>(proto_config, context.scope());
+
+  return [config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
+    callbacks.addStreamFilter(std::make_shared<Filter>(config));
+  };
+}
+
 /**
  * Static registration for this filter. @see RegisterFactory.
  */

--- a/source/extensions/filters/http/thrift_to_metadata/config.h
+++ b/source/extensions/filters/http/thrift_to_metadata/config.h
@@ -22,6 +22,10 @@ private:
   Http::FilterFactoryCb createFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::thrift_to_metadata::v3::ThriftToMetadata&,
       const std::string&, Server::Configuration::FactoryContext&) override;
+
+  Http::FilterFactoryCb createFilterFactoryFromProtoWithServerContextTyped(
+      const envoy::extensions::filters::http::thrift_to_metadata::v3::ThriftToMetadata&,
+      const std::string&, Server::Configuration::ServerFactoryContext&) override;
 };
 
 } // namespace ThriftToMetadata


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message: http: add server context only factory support to thrift_to_metadata filter
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
