### PR TITLE
upstream: pre-allocate vectors during EDS updates to reduce allocations

### DIFF
--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -1664,6 +1664,7 @@ ClusterImplBase::partitionHostList(const HostVector& hosts) {
   auto healthy_list = std::make_shared<HealthyHostVector>();
   auto degraded_list = std::make_shared<DegradedHostVector>();
   auto excluded_list = std::make_shared<ExcludedHostVector>();
+  healthy_list->get().reserve(hosts.size());
 
   for (const auto& host : hosts) {
     const Host::Health health_status = host->coarseHealth();
@@ -2285,6 +2286,7 @@ bool BaseDynamicClusterImpl::updateDynamicHostList(
   absl::flat_hash_set<std::string> hosts_with_active_health_check_flag_changed(
       current_priority_hosts.size());
   HostVector final_hosts;
+  final_hosts.reserve(new_hosts.size() + current_priority_hosts.size());
   for (const HostSharedPtr& host : new_hosts) {
     // To match a new host with an existing host means comparing their addresses.
     auto existing_host = all_hosts.find(addressToString(host->address()));

--- a/source/extensions/clusters/eds/eds.cc
+++ b/source/extensions/clusters/eds/eds.cc
@@ -413,6 +413,8 @@ bool EdsClusterImpl::updateHostsPerLocality(
 
   HostVector hosts_added;
   HostVector hosts_removed;
+  hosts_added.reserve(new_hosts.size());
+  hosts_removed.reserve(host_set.hosts().size());
   // We need to trigger updateHosts with the new host vectors if they have changed. We also do this
   // when the locality weight map or the overprovisioning factor. Note calling updateDynamicHostList
   // is responsible for both determining whether there was a change and to perform the actual update


### PR DESCRIPTION
Commit Message:
In deployments with large clusters (several clusters with 5k+ endpoints), we observe CPU spikes during EDS delta updates. Vector reallocations in the update hot path are a likely contributor.

This change adds reserve() calls to avoid repeated reallocations:
- final_hosts in updateDynamicHostList
- hosts_added/hosts_removed in updateHostsPerLocality
- healthy_list in partitionHostList

Without pre-allocation, a vector grows by doubling its capacity on each reallocation, requiring memory allocation and copying of all existing shared_ptr elements. For a 10k endpoint cluster, this results in ~14 reallocations per vector that grows from empty.

This is a low-risk optimization that reduces allocation pressure during EDS updates.
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
