### PR TITLE
Replace deprecated ParseFromArray

### DIFF
--- a/source/extensions/common/wasm/foreign.cc
+++ b/source/extensions/common/wasm/foreign.cc
@@ -135,7 +135,7 @@ RegisterForeignFunction registerSignForeignFunction(
     [](WasmBase&, std::string_view arguments,
        const std::function<void*(size_t size)>& alloc_result) -> WasmResult {
       envoy::source::extensions::common::wasm::SignArguments args;
-      if (args.ParseFromArray(arguments.data(), arguments.size())) {
+      if (args.ParseFromString(arguments)) {
         const auto& hash = args.hash_function();
         auto text_str = args.text();
 

--- a/test/extensions/filters/http/wasm/test_data/test_cpp.cc
+++ b/test/extensions/filters/http/wasm/test_data/test_cpp.cc
@@ -962,7 +962,7 @@ void TestRootContext::onTick() {
       if (WasmResult::Ok == proxy_call_foreign_function(function.data(), function.size(), in.data(),
                                                         in.size(), &out, &out_size)) {
         envoy::source::extensions::common::wasm::SignResult result;
-        if (result.ParseFromArray(out, static_cast<int>(out_size)) && result.result()) {
+        if (result.ParseFromString(absl::string_view(out, static_cast<int>(out_size))) && result.result()) {
           logInfo("signature created successfully");
         } else {
           logError(result.error());
@@ -985,7 +985,7 @@ void TestRootContext::onTick() {
       if (WasmResult::Ok == proxy_call_foreign_function(function.data(), function.size(), in.data(),
                                                         in.size(), &out, &out_size)) {
         envoy::source::extensions::common::wasm::SignResult result;
-        if (result.ParseFromArray(out, static_cast<int>(out_size)) && result.result()) {
+        if (result.ParseFromString(absl::string_view(out, static_cast<int>(out_size))) && result.result()) {
           logCritical("signature should not be ok");
         } else {
           logError(result.error());
@@ -1008,7 +1008,7 @@ void TestRootContext::onTick() {
       if (WasmResult::Ok == proxy_call_foreign_function(function.data(), function.size(), in.data(),
                                                         in.size(), &out, &out_size)) {
         envoy::source::extensions::common::wasm::SignResult result;
-        if (result.ParseFromArray(out, static_cast<int>(out_size)) && result.result()) {
+        if (result.ParseFromString(absl::string_view(out, static_cast<int>(out_size))) && result.result()) {
           logCritical("signature should not be ok");
         } else {
           logError(result.error());
@@ -1130,7 +1130,7 @@ void TestRootContext::onTick() {
                                                         sign_in.data(), sign_in.size(), &sign_out,
                                                         &sign_out_size)) {
         envoy::source::extensions::common::wasm::SignResult sign_result;
-        if (sign_result.ParseFromArray(sign_out, static_cast<int>(sign_out_size)) &&
+        if (sign_result.ParseFromString(absl::string_view(sign_out, static_cast<int>(sign_out_size))) &&
             sign_result.result()) {
           logInfo("signature created successfully, length: " +
                   std::to_string(sign_result.signature().size()));
@@ -1153,7 +1153,7 @@ void TestRootContext::onTick() {
                                                               verify_in.data(), verify_in.size(),
                                                               &verify_out, &verify_out_size)) {
               envoy::source::extensions::common::wasm::VerifySignatureResult verify_result;
-              if (verify_result.ParseFromArray(verify_out, static_cast<int>(verify_out_size)) &&
+              if (verify_result.ParseFromString(absl::string_view(verify_out, static_cast<int>(verify_out_size))) &&
                   verify_result.result()) {
                 logInfo("end-to-end test passed: signature created and verified successfully");
               } else {


### PR DESCRIPTION
The use of this symbol has been deprecated and marked for inlining. The function being deprecated is proto2::MessageLite::ParseFromArray.

Risk Level: low
Testing: unit tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
