### PR TITLE
feat: support rate limit action based on cidr match

### DIFF
--- a/api/envoy/config/route/v3/route_components.proto
+++ b/api/envoy/config/route/v3/route_components.proto
@@ -2492,7 +2492,6 @@ message RateLimit {
     // .. code-block:: cpp
     //
     //   ("remote_address_match", "<descriptor_value>")
-    // [#not-implemented-hide:]
     message RemoteAddressMatch {
       // Descriptor value of entry.
       //
@@ -2502,13 +2501,13 @@ message RateLimit {
       //
       // .. note::
       //
-      //   The format string can contain multiple valid substitution fields. If multiple substitution
-      //   fields are present, their results will be concatenated to form the final descriptor value.
-      //   If it contains no substitution fields, the value will be used as is.
-      //   All substitution fields will be evaluated and their results concatenated.
-      //   If the final concatenated result is empty and ``default_value`` is set, the ``default_value`` will be used.
-      //   If ``default_value`` is not set and the result is empty, this descriptor will be skipped
-      //   and not included in the rate limit call.
+      //   The format string can contain multiple valid substitution fields. If multiple
+      //   substitution fields are present, their results will be concatenated to form the
+      //   final descriptor value. If it contains no substitution fields, the value will be
+      //   used as is. All substitution fields will be evaluated and their results concatenated.
+      //   If the final concatenated result is empty and ``default_value`` is set, the
+      //   ``default_value`` will be used. If ``default_value`` is not set and the result is
+      //   empty, this descriptor will be skipped and not included in the rate limit call.
       //
       // For example, ``static_value`` will be used as is since there are no substitution fields.
       // ``%REQ(:method)%`` will be replaced with the HTTP method, and
@@ -2588,7 +2587,6 @@ message RateLimit {
       // Rate limit on the existence of query parameters.
       QueryParameterValueMatch query_parameter_value_match = 11;
 
-      // [#not-implemented-hide:]
       // Rate limit on remote address match.
       RemoteAddressMatch remote_address_match = 13;
     }

--- a/api/envoy/type/matcher/v3/address.proto
+++ b/api/envoy/type/matcher/v3/address.proto
@@ -20,7 +20,9 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 message AddressMatcher {
   repeated xds.core.v3.CidrRange ranges = 1;
 
-  // [#not-implemented-hide:]
   // If true, the match result will be inverted. Defaults to false.
+  //
+  // * If set to false (default), the matcher will return true if the IP matches any of the CIDR ranges.
+  // * If set to true, the matcher will return true if the IP does NOT match any of the CIDR ranges.
   bool invert_match = 2;
 }

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -154,6 +154,10 @@ new_features:
     Added per-descriptor ``x-ratelimit-*`` headers support. See the
     :ref:`x_ratelimit_option <envoy_v3_api_field_config.route.v3.RateLimit.x_ratelimit_option>`
     field documentation for more details.
+- area: ratelimit
+  change: |
+    Added ``RemoteAddressMatch`` action to the rate limit filter. This action will generate a descriptor based on the remote address of the
+    downstream connection by matching it against specified CIDR ranges with support for inversion and formatter substitution.
 - area: mcp_router
   change: |
     Added support for MCP client-to-server notification methods ``notifications/cancelled``

--- a/source/common/common/filter_state_object_matchers.cc
+++ b/source/common/common/filter_state_object_matchers.cc
@@ -13,8 +13,8 @@ namespace Envoy {
 namespace Matchers {
 
 FilterStateIpRangeMatcher::FilterStateIpRangeMatcher(
-    std::unique_ptr<Network::Address::IpList>&& ip_list)
-    : ip_list_(std::move(ip_list)) {}
+    std::unique_ptr<Network::Address::IpList>&& ip_list, bool invert_match)
+    : ip_list_(std::move(ip_list)), invert_match_(invert_match) {}
 
 bool FilterStateIpRangeMatcher::match(const StreamInfo::FilterState::Object& object) const {
   const Network::Address::InstanceAccessor* ip =
@@ -22,7 +22,8 @@ bool FilterStateIpRangeMatcher::match(const StreamInfo::FilterState::Object& obj
   if (ip == nullptr) {
     return false;
   }
-  return ip_list_->contains(*ip->getIp());
+  const bool matches = ip_list_->contains(*ip->getIp());
+  return invert_match_ ? !matches : matches;
 }
 
 FilterStateStringMatcher::FilterStateStringMatcher(StringMatcherPtr&& string_matcher)

--- a/source/common/common/filter_state_object_matchers.h
+++ b/source/common/common/filter_state_object_matchers.h
@@ -21,11 +21,13 @@ using FilterStateObjectMatcherPtr = std::unique_ptr<FilterStateObjectMatcher>;
 
 class FilterStateIpRangeMatcher : public FilterStateObjectMatcher {
 public:
-  FilterStateIpRangeMatcher(std::unique_ptr<Network::Address::IpList>&& ip_list);
+  FilterStateIpRangeMatcher(std::unique_ptr<Network::Address::IpList>&& ip_list,
+                            bool invert_match = false);
   bool match(const StreamInfo::FilterState::Object& object) const override;
 
 private:
   std::unique_ptr<Envoy::Network::Address::IpList> ip_list_;
+  const bool invert_match_;
 };
 
 class FilterStateStringMatcher : public FilterStateObjectMatcher {

--- a/source/common/common/matchers.cc
+++ b/source/common/common/matchers.cc
@@ -182,7 +182,8 @@ filterStateObjectMatcherFromProto(const envoy::type::matcher::v3::FilterStateMat
   case envoy::type::matcher::v3::FilterStateMatcher::MatcherCase::kAddressMatch: {
     auto ip_list = Network::Address::IpList::create(matcher.address_match().ranges());
     RETURN_IF_NOT_OK_REF(ip_list.status());
-    return std::make_unique<FilterStateIpRangeMatcher>(std::move(*ip_list));
+    return std::make_unique<FilterStateIpRangeMatcher>(std::move(*ip_list),
+                                                       matcher.address_match().invert_match());
     break;
   }
   default:

--- a/source/common/router/router_ratelimit.h
+++ b/source/common/router/router_ratelimit.h
@@ -238,6 +238,29 @@ private:
   const std::unique_ptr<Formatter::FormatterImpl> descriptor_formatter_;
 };
 
+/**
+ * Action for remote address match rate limiting.
+ */
+class RemoteAddressMatchAction : public RateLimit::DescriptorProducer {
+public:
+  RemoteAddressMatchAction(
+      const envoy::config::route::v3::RateLimit::Action::RemoteAddressMatch& action,
+      Server::Configuration::CommonFactoryContext& context);
+
+  // Ratelimit::DescriptorProducer
+  bool populateDescriptor(RateLimit::DescriptorEntry& descriptor_entry,
+                          const std::string& local_service_cluster,
+                          const Http::RequestHeaderMap& headers,
+                          const StreamInfo::StreamInfo& info) const override;
+
+private:
+  const std::string descriptor_key_;
+  const std::string default_value_;
+  const std::unique_ptr<Network::Address::IpList> ip_list_;
+  const bool invert_match_;
+  const std::unique_ptr<Formatter::FormatterImpl> descriptor_formatter_;
+};
+
 class RateLimitDescriptorValidationVisitor
     : public Matcher::MatchTreeValidationVisitor<Http::HttpMatchingData> {
 public:

--- a/source/extensions/filters/common/ratelimit_config/ratelimit_config.cc
+++ b/source/extensions/filters/common/ratelimit_config/ratelimit_config.cc
@@ -161,6 +161,10 @@ RateLimitPolicy::RateLimitPolicy(const ProtoRateLimit& config,
           action.query_parameter_value_match(), context, std::move(formatter_or_error.value())));
       break;
     }
+    case ProtoRateLimit::Action::ActionSpecifierCase::kRemoteAddressMatch:
+      actions_.emplace_back(
+          new Router::RemoteAddressMatchAction(action.remote_address_match(), context));
+      break;
     default:
       creation_status = absl::InvalidArgumentError(fmt::format(
           "Unsupported rate limit action: {}", static_cast<int>(action.action_specifier_case())));

--- a/test/common/router/BUILD
+++ b/test/common/router/BUILD
@@ -317,7 +317,7 @@ envoy_cc_test(
     rbe_pool = "6gig",
     tags = ["skip_on_windows"],
     deps = [
-        "//source/common/formatter:http_speicific_formatter_extension_lib",
+        "//source/common/formatter:formatter_extension_lib",
         "//source/common/http:header_map_lib",
         "//source/common/protobuf:utility_lib",
         "//source/common/router:config_lib",

--- a/test/extensions/filters/common/ratelimit_config/BUILD
+++ b/test/extensions/filters/common/ratelimit_config/BUILD
@@ -23,7 +23,7 @@ envoy_cc_test(
     rbe_pool = "6gig",
     deps = [
         ":ratelimit_config_test_proto_cc_proto",
-        "//source/common/formatter:http_speicific_formatter_extension_lib",
+        "//source/common/formatter:formatter_extension_lib",
         "//source/common/http:header_map_lib",
         "//source/common/protobuf:utility_lib",
         "//source/common/router:config_lib",


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message:
Additional Description: Support rate limit actions on remote address match. Includes implementation `invert_match` for address matcher.
Risk Level: Low
Testing: Unit testing
Docs Changes: n/a
Release Notes: Yes
Platform Specific Features:
[Optional Runtime guard:]
Fixes #36442 
Implements API introduced in #42845 
