### PR TITLE
ProcessRateLimiter: fix use after free

### DIFF
--- a/source/extensions/access_loggers/filters/process_ratelimit/filter.h
+++ b/source/extensions/access_loggers/filters/process_ratelimit/filter.h
@@ -37,7 +37,7 @@ public:
 private:
   const intptr_t setter_key_;
   std::shared_ptr<std::atomic<bool>> cancel_cb_;
-  Server::Configuration::GenericFactoryContext& context_;
+  Event::Dispatcher& main_thread_dispatcher_;
   ProcessRateLimitFilterStats stats_;
   mutable Envoy::Extensions::Filters::Common::LocalRateLimit::RateLimiterProviderSingleton::
       RateLimiterWrapperPtr rate_limiter_;


### PR DESCRIPTION
Commit Message: [listener_factory_context and access_logs](https://github.com/envoyproxy/envoy/blob/29a553cd459786eb6bece9b5dd2e0602e9b4b921/source/common/listener_manager/listener_impl.h#L468-L483) are both owned by ListenerImpl while listener_factory_context get destructed first so this PR just replace listener_factory_context with main_thread_dispatcher which is used in destructor
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
