### PR TITLE
File_system_buffer: set end_stream flag correctly while injecting data to filter chain

### DIFF
--- a/source/extensions/filters/http/file_system_buffer/filter.cc
+++ b/source/extensions/filters/http/file_system_buffer/filter.cc
@@ -180,7 +180,7 @@ Http::FilterTrailersStatus FileSystemBufferFilter::receiveTrailers(const BufferB
     return Http::FilterTrailersStatus::Continue;
   }
   state.seen_end_stream_ = true;
-  state.seen_trailers = true;
+  state.seen_trailers_ = true;
   dispatchStateChanged();
   return Http::FilterTrailersStatus::StopIteration;
 }
@@ -247,7 +247,7 @@ void FileSystemBufferFilter::maybeOutputRequest() {
       auto out = request_state_.buffer_.front()->extract();
       request_state_.buffer_.pop_front();
       bool end_stream = (request_state_.buffer_.empty() && request_state_.seen_end_stream_ &&
-                         !request_state_.seen_trailers);
+                         !request_state_.seen_trailers_);
       request_callbacks_->injectDecodedDataToFilterChain(*out, end_stream);
     }
   }
@@ -274,7 +274,7 @@ bool FileSystemBufferFilter::maybeOutputResponse() {
       auto out = response_state_.buffer_.front()->extract();
       response_state_.buffer_.pop_front();
       bool end_stream = (response_state_.buffer_.empty() && response_state_.seen_end_stream_ &&
-                         !response_state_.seen_trailers);
+                         !response_state_.seen_trailers_);
       response_callbacks_->injectEncodedDataToFilterChain(*out, end_stream);
     }
   }

--- a/source/extensions/filters/http/file_system_buffer/filter.h
+++ b/source/extensions/filters/http/file_system_buffer/filter.h
@@ -17,7 +17,7 @@ struct BufferedStreamState {
   bool headers_sent_ = false;
   std::deque<std::unique_ptr<Fragment>> buffer_;
   bool seen_end_stream_ = false;
-  bool seen_trailers = false;
+  bool seen_trailers_ = false;
   bool sent_slow_down_ = false;
   bool finished_ = false;
   // This bool is used to signify that we should *not* intercept

--- a/test/extensions/filters/http/file_system_buffer/filter_test.cc
+++ b/test/extensions/filters/http/file_system_buffer/filter_test.cc
@@ -236,11 +236,9 @@ TEST_F(FileSystemBufferFilterTest, BuffersEntireRequestAndReplacesContentLength)
   EXPECT_EQ(request_sent_on_, "");
   testing::InSequence s;
   EXPECT_CALL(decoder_callbacks_, injectDecodedDataToFilterChain(_, false))
-      .WillOnce(
-          Invoke([this](Buffer::Instance& out, bool) { request_sent_on_ += out.toString(); }));
+      .WillOnce([this](Buffer::Instance& out, bool) { request_sent_on_ += out.toString(); });
   EXPECT_CALL(decoder_callbacks_, injectDecodedDataToFilterChain(_, true))
-      .WillOnce(
-          Invoke([this](Buffer::Instance& out, bool) { request_sent_on_ += out.toString(); }));
+      .WillOnce([this](Buffer::Instance& out, bool) { request_sent_on_ += out.toString(); });
   EXPECT_EQ(Http::FilterDataStatus::StopIterationNoBuffer, filter_->decodeData(data2, true));
   EXPECT_EQ(request_headers_.getContentLengthValue(), "12");
   EXPECT_EQ(request_sent_on_, "hello banana");
@@ -264,11 +262,9 @@ TEST_F(FileSystemBufferFilterTest, BuffersEntireResponseAndReplacesContentLength
   EXPECT_EQ(response_sent_on_, "");
   testing::InSequence s;
   EXPECT_CALL(encoder_callbacks_, injectEncodedDataToFilterChain(_, false))
-      .WillOnce(
-          Invoke([this](Buffer::Instance& out, bool) { response_sent_on_ += out.toString(); }));
+      .WillOnce([this](Buffer::Instance& out, bool) { response_sent_on_ += out.toString(); });
   EXPECT_CALL(encoder_callbacks_, injectEncodedDataToFilterChain(_, true))
-      .WillOnce(
-          Invoke([this](Buffer::Instance& out, bool) { response_sent_on_ += out.toString(); }));
+      .WillOnce([this](Buffer::Instance& out, bool) { response_sent_on_ += out.toString(); });
   EXPECT_EQ(Http::FilterDataStatus::StopIterationNoBuffer, filter_->encodeData(data2, true));
   EXPECT_EQ(response_headers_.getContentLengthValue(), "12");
   EXPECT_EQ(response_sent_on_, "hello banana");
@@ -588,8 +584,7 @@ TEST_F(FileSystemBufferFilterTest, RequestTrailersArePostponedUntilStreamComplet
   EXPECT_EQ("", request_sent_on_);
   EXPECT_FALSE(continued_decoding_);
   EXPECT_CALL(decoder_callbacks_, injectDecodedDataToFilterChain(_, false))
-      .WillOnce(
-          Invoke([this](Buffer::Instance& out, bool) { request_sent_on_ += out.toString(); }));
+      .WillOnce([this](Buffer::Instance& out, bool) { request_sent_on_ += out.toString(); });
   EXPECT_EQ(Http::FilterTrailersStatus::StopIteration, filter_->decodeTrailers(request_trailers_));
   EXPECT_EQ("hello", request_sent_on_);
   EXPECT_TRUE(continued_decoding_);
@@ -613,8 +608,7 @@ TEST_F(FileSystemBufferFilterTest, ResponseTrailersArePostponedUntilStreamComple
   EXPECT_EQ("", response_sent_on_);
   EXPECT_FALSE(continued_encoding_);
   EXPECT_CALL(encoder_callbacks_, injectEncodedDataToFilterChain(_, false))
-      .WillOnce(
-          Invoke([this](Buffer::Instance& out, bool) { response_sent_on_ += out.toString(); }));
+      .WillOnce([this](Buffer::Instance& out, bool) { response_sent_on_ += out.toString(); });
   EXPECT_EQ(Http::FilterTrailersStatus::StopIteration, filter_->encodeTrailers(response_trailers_));
   EXPECT_EQ("hello", response_sent_on_);
   EXPECT_TRUE(continued_encoding_);


### PR DESCRIPTION
Fix:  https://github.com/envoyproxy/envoy/issues/43170

For details, please check: https://github.com/envoyproxy/envoy/pull/43042#discussion_r2760344794