### PR TITLE
dym go sdk: add ondestroy to filter factory

### DIFF
--- a/source/extensions/dynamic_modules/sdk/go/abi/internal.go
+++ b/source/extensions/dynamic_modules/sdk/go/abi/internal.go
@@ -1130,6 +1130,11 @@ func envoy_dynamic_module_on_http_filter_config_new(
 func envoy_dynamic_module_on_http_filter_config_destroy(
 	configPtr C.envoy_dynamic_module_type_http_filter_config_module_ptr,
 ) {
+	factoryWrapper := configManager.unwrap(unsafe.Pointer(configPtr))
+	if factoryWrapper == nil {
+		return
+	}
+	factoryWrapper.pluginFactory.OnDestroy()
 	configManager.remove(unsafe.Pointer(configPtr))
 }
 

--- a/source/extensions/dynamic_modules/sdk/go/shared/api.go
+++ b/source/extensions/dynamic_modules/sdk/go/shared/api.go
@@ -145,10 +145,20 @@ type HttpFilterFactory interface {
 	// Create creates a HttpFilter instance.
 	Create(handle HttpFilterHandle) HttpFilter
 
-	// OnDestory is called when the factory is being destroyed. This is a good place to clean up any
+	// OnDestroy is called when the factory is being destroyed. This is a good place to clean up any
 	// resources. This usually happens when the configuration is updated and all existing streams
 	// using this factory are closed.
-	OnDestory()
+	OnDestroy()
+}
+
+type EmptyHttpFilterFactory struct {
+}
+
+func (f *EmptyHttpFilterFactory) Create(handle HttpFilterHandle) HttpFilter {
+	return &EmptyHttpFilter{}
+}
+
+func (f *EmptyHttpFilterFactory) OnDestroy() {
 }
 
 // HttpFilterConfigFactory is the factory interface for creating stream plugin configurations.
@@ -169,7 +179,7 @@ type EmptyHttpFilterConfigFactory struct {
 
 func (f *EmptyHttpFilterConfigFactory) Create(handle HttpFilterConfigHandle,
 	unparsedConfig []byte) (HttpFilterFactory, error) {
-	return nil, nil
+	return &EmptyHttpFilterFactory{}, nil
 }
 
 func (f *EmptyHttpFilterConfigFactory) CreatePerRoute(unparsedConfig []byte) (any, error) {

--- a/source/extensions/dynamic_modules/sdk/go/shared/mocks/mock_api.go
+++ b/source/extensions/dynamic_modules/sdk/go/shared/mocks/mock_api.go
@@ -174,6 +174,18 @@ func (mr *MockHttpFilterFactoryMockRecorder) Create(handle any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockHttpFilterFactory)(nil).Create), handle)
 }
 
+// OnDestory mocks base method.
+func (m *MockHttpFilterFactory) OnDestory() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "OnDestory")
+}
+
+// OnDestory indicates an expected call of OnDestory.
+func (mr *MockHttpFilterFactoryMockRecorder) OnDestory() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OnDestory", reflect.TypeOf((*MockHttpFilterFactory)(nil).OnDestory))
+}
+
 // MockHttpFilterConfigFactory is a mock of HttpFilterConfigFactory interface.
 type MockHttpFilterConfigFactory struct {
 	ctrl     *gomock.Controller

--- a/test/extensions/dynamic_modules/test_data/go/http/http.go
+++ b/test/extensions/dynamic_modules/test_data/go/http/http.go
@@ -38,6 +38,7 @@ type statsCallbacksConfigFactory struct {
 }
 
 type statsCallbacksFactory struct {
+	shared.EmptyHttpFilterFactory
 	streamsTotal      shared.MetricID
 	concurrentStreams shared.MetricID
 	magicNumber       shared.MetricID
@@ -100,7 +101,9 @@ func (p *statsCallbacksFilter) OnStreamComplete() {
 type headerCallbacksConfigFactory struct {
 	shared.EmptyHttpFilterConfigFactory
 }
-type headerCallbacksFactory struct{}
+type headerCallbacksFactory struct {
+	shared.EmptyHttpFilterFactory
+}
 
 func (f *headerCallbacksConfigFactory) Create(handle shared.HttpFilterConfigHandle,
 	config []byte) (shared.HttpFilterFactory, error) {
@@ -199,7 +202,9 @@ func testHeaders(headers shared.HeaderMap) {
 type sendResponseConfigFactory struct {
 	shared.EmptyHttpFilterConfigFactory
 }
-type sendResponseFactory struct{}
+type sendResponseFactory struct {
+	shared.EmptyHttpFilterFactory
+}
 
 func (f *sendResponseConfigFactory) Create(handle shared.HttpFilterConfigHandle,
 	config []byte) (shared.HttpFilterFactory, error) {
@@ -226,7 +231,9 @@ func (p *sendResponseFilter) OnRequestHeaders(headers shared.HeaderMap,
 type dynamicMetadataCallbacksConfigFactory struct {
 	shared.EmptyHttpFilterConfigFactory
 }
-type dynamicMetadataCallbacksFactory struct{}
+type dynamicMetadataCallbacksFactory struct {
+	shared.EmptyHttpFilterFactory
+}
 
 func (f *dynamicMetadataCallbacksConfigFactory) Create(handle shared.HttpFilterConfigHandle,
 	config []byte) (shared.HttpFilterFactory, error) {
@@ -334,7 +341,9 @@ func (p *dynamicMetadataCallbacksFilter) OnResponseBody(body shared.BodyBuffer, 
 type filterStateCallbacksConfigFactory struct {
 	shared.EmptyHttpFilterConfigFactory
 }
-type filterStateCallbacksFactory struct{}
+type filterStateCallbacksFactory struct {
+	shared.EmptyHttpFilterFactory
+}
 
 func (f *filterStateCallbacksConfigFactory) Create(handle shared.HttpFilterConfigHandle,
 	config []byte) (shared.HttpFilterFactory, error) {
@@ -399,7 +408,9 @@ func (p *filterStateCallbacksFilter) testFilterState(key, value string) {
 type bodyCallbacksConfigFactory struct {
 	shared.EmptyHttpFilterConfigFactory
 }
-type bodyCallbacksFactory struct{}
+type bodyCallbacksFactory struct {
+	shared.EmptyHttpFilterFactory
+}
 
 func (f *bodyCallbacksConfigFactory) Create(handle shared.HttpFilterConfigHandle,
 	config []byte) (shared.HttpFilterFactory, error) {

--- a/test/extensions/dynamic_modules/test_data/go/http_integration_test/http_integration_test.go
+++ b/test/extensions/dynamic_modules/test_data/go/http_integration_test/http_integration_test.go
@@ -62,6 +62,7 @@ func (f *ConfigSchedulerConfigFactory) Create(handle shared.HttpFilterConfigHand
 }
 
 type ConfigSchedulerFilterFactory struct {
+	shared.EmptyHttpFilterFactory
 	sharedStatus *atomic.Bool
 }
 
@@ -97,7 +98,9 @@ func (f *PassthroughConfigFactory) Create(handle shared.HttpFilterConfigHandle,
 	return &PassthroughFilterFactory{}, nil
 }
 
-type PassthroughFilterFactory struct{}
+type PassthroughFilterFactory struct {
+	shared.EmptyHttpFilterFactory
+}
 
 func (f *PassthroughFilterFactory) Create(handle shared.HttpFilterHandle) shared.HttpFilter {
 	// Log test
@@ -151,6 +154,7 @@ func (f *HeaderCallbacksConfigFactory) Create(handle shared.HttpFilterConfigHand
 }
 
 type HeaderCallbacksFilterFactory struct {
+	shared.EmptyHttpFilterFactory
 	headersToAdd map[string]string
 }
 
@@ -295,6 +299,7 @@ func (f *PerRouteConfigFactory) CreatePerRoute(unparsedConfig []byte) (any, erro
 }
 
 type PerRouteFilterFactory struct {
+	shared.EmptyHttpFilterFactory
 	value string
 }
 
@@ -346,6 +351,7 @@ func (f *BodyCallbacksConfigFactory) Create(handle shared.HttpFilterConfigHandle
 }
 
 type BodyCallbacksFilterFactory struct {
+	shared.EmptyHttpFilterFactory
 	immediate bool
 }
 
@@ -447,6 +453,7 @@ func (f *SendResponseConfigFactory) Create(handle shared.HttpFilterConfigHandle,
 }
 
 type SendResponseFilterFactory struct {
+	shared.EmptyHttpFilterFactory
 	mode string
 }
 
@@ -507,6 +514,7 @@ func (f *HttpCalloutsConfigFactory) Create(handle shared.HttpFilterConfigHandle,
 }
 
 type HttpCalloutsFilterFactory struct {
+	shared.EmptyHttpFilterFactory
 	clusterName string
 }
 
@@ -578,7 +586,9 @@ func (f *HttpFilterSchedulerConfigFactory) Create(handle shared.HttpFilterConfig
 	return &HttpFilterSchedulerFilterFactory{}, nil
 }
 
-type HttpFilterSchedulerFilterFactory struct{}
+type HttpFilterSchedulerFilterFactory struct {
+	shared.EmptyHttpFilterFactory
+}
 
 func (f *HttpFilterSchedulerFilterFactory) Create(h shared.HttpFilterHandle) shared.HttpFilter {
 	return &HttpFilterSchedulerFilter{handle: h}
@@ -655,7 +665,9 @@ func (f *FakeExternalCacheConfigFactory) Create(h shared.HttpFilterConfigHandle,
 	return &FakeExternalCacheFilterFactory{}, nil
 }
 
-type FakeExternalCacheFilterFactory struct{}
+type FakeExternalCacheFilterFactory struct {
+	shared.EmptyHttpFilterFactory
+}
 
 func (f *FakeExternalCacheFilterFactory) Create(h shared.HttpFilterHandle) shared.HttpFilter {
 	return &FakeExternalCacheFilter{handle: h}
@@ -755,6 +767,7 @@ func (f *StatsCallbacksConfigFactory) Create(h shared.HttpFilterConfigHandle, c 
 }
 
 type StatsCallbacksFilterFactory struct {
+	shared.EmptyHttpFilterFactory
 	ids StatsCallbacksIDs
 }
 
@@ -827,7 +840,9 @@ func (f *StreamingTerminalConfigFactory) Create(h shared.HttpFilterConfigHandle,
 	return &StreamingTerminalFilterFactory{}, nil
 }
 
-type StreamingTerminalFilterFactory struct{}
+type StreamingTerminalFilterFactory struct {
+	shared.EmptyHttpFilterFactory
+}
 
 func (f *StreamingTerminalFilterFactory) Create(h shared.HttpFilterHandle) shared.HttpFilter {
 	p := &StreamingTerminalFilter{handle: h}
@@ -921,7 +936,10 @@ func (f *HttpStreamBasicConfigFactory) Create(h shared.HttpFilterConfigHandle,
 	return &HttpStreamBasicFilterFactory{cluster: string(c)}, nil
 }
 
-type HttpStreamBasicFilterFactory struct{ cluster string }
+type HttpStreamBasicFilterFactory struct {
+	shared.EmptyHttpFilterFactory
+	cluster string
+}
 
 func (f *HttpStreamBasicFilterFactory) Create(h shared.HttpFilterHandle) shared.HttpFilter {
 	return &HttpStreamBasicFilter{handle: h, cluster: f.cluster}
@@ -993,7 +1011,10 @@ func (f *HttpStreamBidirectionalConfigFactory) Create(h shared.HttpFilterConfigH
 	return &HttpStreamBidiFilterFactory{cluster: string(c)}, nil
 }
 
-type HttpStreamBidiFilterFactory struct{ cluster string }
+type HttpStreamBidiFilterFactory struct {
+	shared.EmptyHttpFilterFactory
+	cluster string
+}
 
 func (f *HttpStreamBidiFilterFactory) Create(h shared.HttpFilterHandle) shared.HttpFilter {
 	return &HttpStreamBidiFilter{handle: h, cluster: f.cluster}
@@ -1070,7 +1091,10 @@ func (f *UpstreamResetConfigFactory) Create(h shared.HttpFilterConfigHandle,
 	return &UpstreamResetFilterFactory{cluster: string(c)}, nil
 }
 
-type UpstreamResetFilterFactory struct{ cluster string }
+type UpstreamResetFilterFactory struct {
+	shared.EmptyHttpFilterFactory
+	cluster string
+}
 
 func (f *UpstreamResetFilterFactory) Create(h shared.HttpFilterHandle) shared.HttpFilter {
 	return &UpstreamResetFilter{handle: h, cluster: f.cluster}


### PR DESCRIPTION
Commit Message: add an explicit onDestory method to filter factory to allow golang to do some clean up.
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
