### PR TITLE
Depend on protobuf directly instead of source for content parser

### DIFF
--- a/envoy/content_parser/BUILD
+++ b/envoy/content_parser/BUILD
@@ -15,6 +15,7 @@ envoy_cc_library(
         "//envoy/common:pure_lib",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/types:optional",
+        "@com_google_protobuf//:protobuf",
     ],
 )
 

--- a/envoy/content_parser/parser.h
+++ b/envoy/content_parser/parser.h
@@ -6,7 +6,7 @@
 
 #include "envoy/common/pure.h"
 
-#include "source/common/protobuf/protobuf.h"
+#include "google/protobuf/struct.pb.h"
 
 #include "absl/strings/string_view.h"
 #include "absl/types/optional.h"
@@ -23,7 +23,7 @@ namespace ContentParser {
 struct MetadataAction {
   std::string namespace_; // Must be non-empty (parser applies defaults)
   std::string key;
-  absl::optional<Protobuf::Value> value; // If empty, value extraction failed
+  absl::optional<google::protobuf::Value> value; // If empty, value extraction failed
   bool preserve_existing = false;
 };
 


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message:
Additional Description:
seems to be the reason for CI failure on main after https://github.com/envoyproxy/envoy/pull/43207 was landed
```
In file included from source/extensions/content_parsers/json/json_content_parser_impl.cc:1:
In file included from ./source/extensions/content_parsers/json/json_content_parser_impl.h:5:
In file included from ./envoy/content_parser/factory.h:3:
In file included from ./envoy/content_parser/parser.h:9:
In file included from ./source/common/protobuf/protobuf.h:9:
In file included from bazel-out/k8-opt/bin/external/com_google_protobuf/src/google/protobuf/_virtual_includes/any_proto/google/protobuf/any.pb.h:20:
In file included from bazel-out/k8-opt/bin/external/com_google_protobuf/src/google/protobuf/io/_virtual_includes/io/google/protobuf/io/coded_stream.h:109:
In file included from external/abseil-cpp/absl/log/absl_log.h:36:
In file included from external/abseil-cpp/absl/log/internal/log_impl.h:20:
In file included from external/abseil-cpp/absl/log/absl_vlog_is_on.h:63:
external/abseil-cpp/absl/log/internal/vlog_config.h:49:50: error: expected ')'
   49 | int RegisterAndInitialize(VLogSite* absl_nonnull v);
```
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
