### PR TITLE
docs: fix link to dynamic module abi.h

### DIFF
--- a/api/envoy/extensions/dynamic_modules/v3/dynamic_modules.proto
+++ b/api/envoy/extensions/dynamic_modules/v3/dynamic_modules.proto
@@ -25,7 +25,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // reused.
 //
 // A module must be compatible with the ABI specified in :repo:`abi.h
-// <source/extensions/dynamic_modules/abi.h>`. Currently, compatibility is only guaranteed by an
+// <source/extensions/dynamic_modules/abi/abi.h>`. Currently, compatibility is only guaranteed by an
 // exact version match between the Envoy codebase and the dynamic module SDKs. In the future, after
 // the ABI is stabilized, this restriction will be revisited. Until then, Envoy checks the hash of
 // the ABI header files to ensure that the dynamic modules are built against the same version of the

--- a/docs/root/intro/arch_overview/advanced/dynamic_modules.rst
+++ b/docs/root/intro/arch_overview/advanced/dynamic_modules.rst
@@ -10,7 +10,7 @@ Dynamic modules
    We are looking for feedback from the community to improve the feature.
 
 Envoy has support for loading shared libraries at runtime to extend its functionality. In Envoy, these are known as "dynamic modules." More specifically, dynamic modules are shared libraries that implement the
-:repo:`ABI <source/extensions/dynamic_modules/abi.h>` written in a pure C header file. The ABI defines a set of functions
+:repo:`ABI <source/extensions/dynamic_modules/abi/abi.h>` written in a pure C header file. The ABI defines a set of functions
 that the dynamic module must implement to be loaded by Envoy. Also, it specifies the functions implemented by Envoy
 that the dynamic module can call to interact with Envoy.
 


### PR DESCRIPTION
Commit Message: docs: fix link to dynamic module `abi.h`
Additional Description: [Currently](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/dynamic_modules/v3/dynamic_modules.proto#envoy-v3-api-msg-extensions-dynamic-modules-v3-dynamicmoduleconfig), following the link returns a 404
Risk Level: Low
