### PR TITLE
matcher: suppress excessive log

### DIFF
--- a/source/common/matcher/field_matcher.h
+++ b/source/common/matcher/field_matcher.h
@@ -170,7 +170,6 @@ public:
   FieldMatchResult match(const DataType& data) override {
     const auto input = data_input_->get(data);
 
-    ENVOY_LOG(trace, "Attempting to match {}", input);
     if (input.data_availability_ == DataInputGetResult::DataAvailability::NotAvailable) {
       return FieldMatchResult::insufficientData();
     }
@@ -178,11 +177,9 @@ public:
     bool current_match = input_matcher_->match(input.data_);
     if (!current_match && input.data_availability_ ==
                               DataInputGetResult::DataAvailability::MoreDataMightBeAvailable) {
-      ENVOY_LOG(trace, "No match yet; delaying result as more data might be available.");
       return FieldMatchResult::insufficientData();
     }
 
-    ENVOY_LOG(trace, "Match result: {}", current_match);
     return current_match ? FieldMatchResult::matched() : FieldMatchResult::noMatch();
   }
 


### PR DESCRIPTION
Change-Id: I5e22304fc1c67b69be91a074a40fa9ef58c0c83c

Commit Message: It's excessive to log every field match. When there are M items to match against N matchers, it ends up printing data M*N times.
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
