### PR TITLE
dynamic_modules: allow registration of any combination of filters

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -147,8 +147,8 @@ new_features:
     can now be loaded by an Envoy binary of v1.39.
 - area: dynamic modules
   change: |
-    Added support for dynamic modules authors to register any combination of http, network,
-    listener, UDP listener, and bootstrap filters in the rust SDK.
+    Added support for dynamic modules authors to register any combination of http, network, listener,
+    udp listener, and bootstrap filters in the rust SDK.
 - area: mcp_router
   change: |
     Added support for MCP resource methods ``resources/list``, ``resources/read``,

--- a/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
@@ -3932,17 +3932,17 @@ macro_rules! declare_network_filter_init_functions {
   };
 }
 
-/// Declare the init functions for the dynamic module with any combination of filter types.     
-///         
-/// This macro allows a single module to provide any combination of HTTP, Network, Listener,    
-/// UDP Listener, and Bootstrap filters.     
-///         
+/// Declare the init functions for the dynamic module with any combination of filter types.
+///
+/// This macro allows a single module to provide any combination of HTTP, Network, Listener,
+/// UDP Listener, and Bootstrap filters.
+///
 /// The first argument has [`ProgramInitFunction`] type, and it is called when the dynamic module is
 /// loaded.
-///         
+///
 /// The remaining arguments are keyword-labeled filter config functions. Omitted filters won't be
-/// registered.         
-/// Supported filters:          
+/// registered.
+/// Supported filters:
 /// - `http:` — [`NewHttpFilterConfigFunction`] for HTTP filters
 /// - `network:` — [`NewNetworkFilterConfigFunction`] for Network filters
 /// - `listener:` — [`NewListenerFilterConfigFunction`] for Listener filters
@@ -3951,10 +3951,10 @@ macro_rules! declare_network_filter_init_functions {
 ///
 /// # Examples
 ///
-/// HTTP only:                   
+/// HTTP only:
 /// ```ignore
-/// declare_all_init_functions!(my_program_init,      
-///     http: my_new_http_filter_config_fn,           
+/// declare_all_init_functions!(my_program_init,
+///     http: my_new_http_filter_config_fn,
 /// );
 /// ```
 ///
@@ -3963,8 +3963,8 @@ macro_rules! declare_network_filter_init_functions {
 /// declare_all_init_functions!(my_program_init,
 ///     network: my_new_network_filter_config_fn,
 ///     udp_listener: my_new_udp_listener_filter_config_fn,
-/// );      
-/// ```     
+/// );
+/// ```
 #[macro_export]
 macro_rules! declare_all_init_functions {
   ($f:ident, $($filter_type:ident : $filter_fn:expr),+ $(,)?) => {


### PR DESCRIPTION
## Description
This PR allows dynamic module authors to register any combination of http, network, listener, udp listener, and bootstrap filters in the rust SDK

I specifically ran into this issue when looking into contributing to the [dynamic-modules-examples](https://github.com/envoyproxy/dynamic-modules-examples/pull/56/changes#diff-f64796ccc388f201986ea7eaaf07bbefbd8ac1a56bb995fb505da80879872a39R69-R77) repo, as I was looking to register a UDP filter
 <!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message: dynamic_modules: allow registration of any combination of filters
Additional Description: updates the `declare_all_init_functions` rust macro to actually register any combination of filters, previously was only network and http filters.
Risk Level: Low
Testing: None
Docs Changes: None
Release Notes: Added
Platform Specific Features: None