### PR TITLE
reverse_tunnels: prevent port resolution to allow all workers to initiate reverse connections

### DIFF
--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_address.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_address.cc
@@ -14,7 +14,7 @@ namespace Extensions {
 namespace Bootstrap {
 namespace ReverseConnection {
 
-static const std::string reverse_connection_address = "127.0.0.1:0";
+const std::string ReverseConnectionAddress::ReverseConnectionIp::address_str_ = "127.0.0.1";
 
 ReverseConnectionAddress::ReverseConnectionAddress(const ReverseConnectionConfig& config)
     : config_(config) {
@@ -23,9 +23,10 @@ ReverseConnectionAddress::ReverseConnectionAddress(const ReverseConnectionConfig
   logical_name_ = fmt::format("rc://{}:{}:{}@{}:{}", config.src_node_id, config.src_cluster_id,
                               config.src_tenant_id, config.remote_cluster, config.connection_count);
 
-  // Use localhost with a static port for the actual address string to pass IP validation
+  // Use localhost with the placeholder port for the actual address string.
   // This will be used by the filter chain manager for matching.
-  address_string_ = reverse_connection_address;
+  address_string_ = fmt::format("{}:{}", ReverseConnectionIp::address_str_,
+                                kReverseConnectionListenerPortPlaceholder);
 
   ENVOY_LOG_MISC(debug, "reverse connection address: logical_name={}, address={}", logical_name_,
                  address_string_);
@@ -50,10 +51,10 @@ absl::string_view ReverseConnectionAddress::asStringView() const { return addres
 const std::string& ReverseConnectionAddress::logicalName() const { return logical_name_; }
 
 const sockaddr* ReverseConnectionAddress::sockAddr() const {
-  // Return a valid localhost sockaddr structure for IP validation.
+  // Return a valid localhost sockaddr structure with placeholder port.
   static struct sockaddr_in addr;
   addr.sin_family = AF_INET;
-  addr.sin_port = htons(0);                      // Port 0
+  addr.sin_port = htons(kReverseConnectionListenerPortPlaceholder);
   addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK); // 127.0.0.1
   return reinterpret_cast<const sockaddr*>(&addr);
 }


### PR DESCRIPTION
**Commit Message:** This PR fixes [Issue#43270](https://github.com/envoyproxy/envoy/issues/43270)

**Additional Description:**: The change allows custom socket interfaces to bind to port. This results in reverse tunnels being created only on worker_0. This is because reverse tunnel listeners are created with port 0, the OS assigns a random port, and [the local address is replaced with the resolved address](https://github.com/envoyproxy/envoy/blob/f0e51db62b58196f012f93f20899d86ec81c63e6/source/common/listener_manager/listener_impl.cc#L123). This address is passed on while [creating sockets on the other workers](https://github.com/envoyproxy/envoy/blob/f0e51db62b58196f012f93f20899d86ec81c63e6/source/common/listener_manager/listener_impl.cc#L133), as a result of which, other workers use the default socket interface instead of the reverse connection socket interface, and therefore do not initiate reverse tunnels.
The PR fixes this by setting a placeholder port (!=0) for the reverse conn listener. The port number itself is not significant because the reverse conn listener initiates reverse connections instead of binding to port.

Risk Level: Low 
Testing: Unit Tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A

Signed-off-by: Basundhara Chakrabarty <basundhara.c@nutanix.com>