### PR TITLE
[bp/v1.36] Patch highway with ppc64le specific build flags (#42097)

### DIFF
--- a/bazel/highway-ppc64le.patch
+++ b/bazel/highway-ppc64le.patch
@@ -10,3 +10,17 @@ index c825050b..7dd168db 100644
          # Select avoids recompiling native arch if only non-native changed
      ] + select({
          ":compiler_emscripten": [
+diff --git a/BUILD b/BUILD
+index c825050b..23f5a03c 100644
+--- a/BUILD
++++ b/BUILD
+@@ -130,6 +130,9 @@ COPTS = select({
+         "-march=rv64gcv1p0",
+         "-menable-experimental-extensions",
+     ],
++    "@platforms//cpu:ppc64le": [
++        "-DTOOLCHAIN_MISS_ASM_HWCAP_H"
++    ],
+     "//conditions:default": [
+     ],
+ })


### PR DESCRIPTION
Backports (https://github.com/envoyproxy/envoy/pull/42097)

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->
---
Commit Message: Add ppc64le option to build highway without the asm/hwcap.h file, as it is not provided on ppc64le systems.
Additional Description: Patching the highway BUILD file to allow the google highway dependency to compile on the ppc64le architecture.
Risk Level: low
Testing: CI
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
