### PR TITLE
reverse_tunnels: fixes the unwanted bind causing sudo issues for the downstream rc io handle

### DIFF
--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.h
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.h
@@ -205,6 +205,14 @@ public:
   void onBelowWriteBufferLowWatermark() override {}
 
   /**
+   * No-op for reverse connections
+   */
+  Api::SysCallIntResult bind(Network::Address::InstanceConstSharedPtr address) override {
+    ENVOY_LOG(info, "Bind called on rc socket handle: {}", address->logicalName());
+    return Api::SysCallIntResult{0, 0};
+  }
+
+  /**
    * Get the file descriptor for the pipe monitor used to wake up accept().
    * @return the file descriptor for the pipe monitor
    */

--- a/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/BUILD
+++ b/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/BUILD
@@ -58,11 +58,13 @@ envoy_cc_test(
         "//source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface:reverse_connection_io_handle_lib",
         "//source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface:reverse_tunnel_extension_lib",
         "//source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface:reverse_tunnel_initiator_lib",
+        "//test/mocks/api:api_mocks",
         "//test/mocks/event:event_mocks",
         "//test/mocks/server:factory_context_mocks",
         "//test/mocks/stats:stats_mocks",
         "//test/mocks/thread_local:thread_local_mocks",
         "//test/mocks/upstream:upstream_mocks",
+        "//test/test_common:threadsafe_singleton_injector_lib",
         "@envoy_api//envoy/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/v3:pkg_cc_proto",
     ],
 )


### PR DESCRIPTION
## Commit Message
Fixes the unwanted bind causing sudo issues for the downstream rc io handle.

## Additional Description
The following error is hit when envoy is started without sudo for the `docs/root/_configs/reverse_connection/initiator-envoy.yaml`.

`[2026-02-11 15:12:17.602][1466597][error][io] [source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.cc:338] Closing original socket FD: 27.
[2026-02-11 15:12:17.602][1466597][error][config] [source/common/listener_manager/listener_manager_impl.cc:1304] listener 'reverse_conn_listener' failed to bind or apply socket options: cannot bind '127.0.0.1:1': Permission denied
[2026-02-11 15:12:17.602][1466597][critical][main] [source/server/server.cc:453] error cannot bind '127.0.0.1:1': Permission denied initializing config 'goo.gle/debugonly  
  docs/root/_configs/reverse_connection/initiator-envoy.yaml'
[2026-02-11 15:12:17.605][1466597][info][main] [source/server/server.cc:1120] exiting
cannot bind '127.0.0.1:1': Permission denied`

Occurs because the io_handle_->bind() called from SocketImpl::bind is not overriden for the rc socket which leads to the call of IoSocketHandleImpl::bind() -> syscall which uses the `kReverseConnectionListenerPortPlaceholder` leading to a call to bind 127.0.0.1:1 which is a privileged port.