### PR TITLE
Fix typo in rbac_filter.rst

### DIFF
--- a/docs/root/configuration/http/http_filters/rbac_filter.rst
+++ b/docs/root/configuration/http/http_filters/rbac_filter.rst
@@ -8,7 +8,7 @@ explicitly manage callers to an application and protect it from unexpected or fo
 filter supports configuration with either a safe-list (ALLOW) or block-list (DENY) set of policies,
 or a matcher with different actions, based off properties of the connection (IPs, ports, SSL subject)
 as well as the incoming request's HTTP headers. This filter also supports policy in both enforcement
-and shadow mode, shadow mode won't effect real users, it is used to test that a new set of policies
+and shadow mode, shadow mode won't affect real users, it is used to test that a new set of policies
 work before rolling out to production.
 
 When a request is denied, the :ref:`RESPONSE_CODE_DETAILS<config_access_log_format_response_code_details>`


### PR DESCRIPTION
Corrected a typo in the rbac_filter documentation regarding shadow mode.

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
