### PR TITLE
feat: support path override in ext authz

### DIFF
--- a/api/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
+++ b/api/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
@@ -426,7 +426,7 @@ message BufferSettings {
 // metadata as well as body may be added to the client's response. See :ref:`allowed_client_headers
 // <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.AuthorizationResponse.allowed_client_headers>`
 // for details.
-// [#next-free-field: 10]
+// [#next-free-field: 11]
 message HttpService {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.http.ext_authz.v2.HttpService";
@@ -437,7 +437,12 @@ message HttpService {
   config.core.v3.HttpUri server_uri = 1;
 
   // Sets a prefix to the value of authorization request header ``Path``.
+  // Only one of ``path_prefix`` or ``path_override`` may be set.
   string path_prefix = 2;
+
+  // Replaces the value of authorization request header ``Path`` with this value.
+  // Only one of ``path_prefix`` or ``path_override`` may be set.
+  string path_override = 10;
 
   // Settings used for controlling authorization request metadata.
   AuthorizationRequest authorization_request = 7;

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -192,6 +192,12 @@ new_features:
     Added HTTP callout support for dynamic module listener filters, enabling listener filters to initiate
     asynchronous HTTP requests to upstream clusters and receive responses via the ``send_http_callout`` ABI
     callback and ``on_listener_filter_http_callout_done`` event hook.
+- area: ext_authz
+  change: |
+    Added :ref:`path_override <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.HttpService.path_override>`
+    to the HTTP ext_authz filter. When set, the request path sent to the authorization service is replaced
+    entirely by this value. Only one of ``path_prefix`` or ``path_override`` may be set; validation fails
+    at config load if both are specified.
 - area: stats
   change: |
     Added support to limit the number of stats stored in each stats scope in the stats library.

--- a/source/extensions/filters/common/ext_authz/ext_authz_http_impl.h
+++ b/source/extensions/filters/common/ext_authz/ext_authz_http_impl.h
@@ -45,6 +45,11 @@ public:
   const std::string& pathPrefix() { return path_prefix_; }
 
   /**
+   * Returns the authorization request path override (replaces path entirely when set).
+   */
+  const std::string& pathOverride() { return path_override_; }
+
+  /**
    * Returns authorization request timeout.
    */
   const std::chrono::milliseconds& timeout() const { return timeout_; }
@@ -125,6 +130,7 @@ private:
   const std::string cluster_name_;
   const std::chrono::milliseconds timeout_;
   const std::string path_prefix_;
+  const std::string path_override_;
   const std::string tracing_name_;
   Router::HeaderParserPtr request_headers_parser_;
   const bool encode_raw_headers_;


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message: feat: support path override in ext authz
Additional Description: Today ext authz supports adding path prefix only. This will allow users to override complete path.
Risk Level: Low
Testing: Unit testing
Docs Changes: N/A
Release Notes: Yes
Platform Specific Features: N/A
Fixes #43398 