### PR TITLE
Update QUICHE from 474fbc6d0 to 4b9143d5a

### DIFF
--- a/bazel/deps.yaml
+++ b/bazel/deps.yaml
@@ -284,7 +284,7 @@ quiche:
   project_name: "QUICHE"
   project_desc: "QUICHE (QUIC, HTTP/2, Etc) is Google‘s implementation of QUIC and related protocols"
   project_url: "https://github.com/google/quiche"
-  release_date: "2026-02-06"
+  release_date: "2026-02-12"
   use_category:
   - controlplane
   - dataplane_core

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -542,8 +542,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         urls = ["https://github.com/simdutf/simdutf/releases/download/v{version}/singleheader.zip"],
     ),
     quiche = dict(
-        version = "474fbc6d05fab1373644829594cc0fe342d3a049",
-        sha256 = "ed4651a2e0ebbda204f24a34083dd317b0f9ff4b10f7bb66613697e600a09f5e",
+        version = "4b9143d5a85d6bd89b281ddc69606edf7934734f",
+        sha256 = "5abc4d44c53f7b51e4c5e060e292c1ea1413feb3a876f2fe5b18b3c80a1fb7c4",
         urls = ["https://github.com/google/quiche/archive/{version}.tar.gz"],
         strip_prefix = "quiche-{version}",
     ),


### PR DESCRIPTION
https://github.com/google/quiche/compare/474fbc6d0..4b9143d5a

```
$ git log 474fbc6d0..4b9143d5a --date=short --no-merges --format="%ad %al %s"

2026-02-11 asedeno moqt_framer.cc: fix portability issue.
2026-02-11 martinduke Increment num_objects_read_ when End Of Group flag is set.
2026-02-11 martinduke Handles expires param = 0 as infinite.
2026-02-11 asedeno Fix OSS QUICHE build.
2026-02-11 vasilvv Use receive timestamps to limit BBR bandwidth estimates.
2026-02-11 vasilvv Use QuicheStringTuple for MOQT names.
2026-02-11 birenroy No public description
2026-02-11 martinduke Update PUBLISH_NAMESPACE to MOQT draft-16.
2026-02-10 quiche-dev QBONE Bonnet: Prepare for ability to split Read/Write fds in `TunDevice`.
2026-02-09 haoyuewang Do not delete QuicConfig in YperfSession.
2026-02-09 vasilvv Provide the certificate and the SPKI hash in WebTransportFingerprintProofVerifier.
2026-02-09 dschinazi Add tests to indeterminate length binary HTTP encoding
2026-02-08 vasilvv Clean up bandwidth_sampler.h
2026-02-08 martinduke Fix memory errors that QUICHE uncovered with MoqtSession.
2026-02-07 dschinazi Prevent timeout in OHTTP test client when the stream gets reset
2026-02-06 martinduke Support REQUEST_UPDATE for SUBSCRIBE_NAMESPACE
2026-02-06 martinduke Change MOQT SUBSCRIBE_UPDATE to REQUEST_UPDATE.
2026-02-06 dschinazi Avoid sending an invalid content terminator when ChunkedOhttpGatewayFilter::encodeData is called with empty data and !end_stream
2026-02-06 martinduke Update MoqtSession and applications to use MoqtNamespaceStream.
2026-02-06 quiche-dev Fix broken Quiche OSS tests
2026-02-06 dschinazi Allow passing in headers to OHTTP client, similar to curl
2026-02-06 quiche-dev No public description
2026-02-06 quiche-dev No public description
2026-02-06 quiche-dev No public description
2026-02-06 dschinazi Log response body to std::cout instead of QUICHE_LOG(INFO) in OHTTP test client
```

Risk Level: Low
Testing: CI
