### PR TITLE
StatsAccessLogger: change the scope back to evictable

### DIFF
--- a/source/extensions/access_loggers/stats/stats.cc
+++ b/source/extensions/access_loggers/stats/stats.cc
@@ -113,7 +113,7 @@ StatsAccessLog::StatsAccessLog(const envoy::extensions::access_loggers::stats::v
                                AccessLog::FilterPtr&& filter,
                                const std::vector<Formatter::CommandParserPtr>& commands)
     : Common::ImplBase(std::move(filter)),
-      scope_(context.statsScope().createScope(config.stat_prefix())),
+      scope_(context.statsScope().createScope(config.stat_prefix(), true /* evictable */)),
       stat_name_pool_(scope_->symbolTable()), histograms_([&]() {
         std::vector<Histogram> histograms;
         for (const auto& hist_cfg : config.histograms()) {


### PR DESCRIPTION
Commit Message: change the scope back to evictable which was mistakenly changed in [PR](https://github.com/envoyproxy/envoy/pull/42226/changes#diff-db6991f26f588514a611aa56a743a7375c137c40aebde44b2a48e94b2570880eR116)
Additional Description:
Risk Level:no
Testing:
Docs Changes:


