### PR TITLE
Bump abseil_cpp, boringssl, and protobuf

### DIFF
--- a/bazel/deps.yaml
+++ b/bazel/deps.yaml
@@ -53,7 +53,7 @@ boringssl:
   project_name: "BoringSSL"
   project_desc: "Minimal OpenSSL fork"
   project_url: "https://github.com/google/boringssl"
-  release_date: "2025-11-25"
+  release_date: "2026-02-11"
   use_category:
   - controlplane
   - dataplane_core
@@ -549,7 +549,7 @@ abseil_cpp:
   project_name: "Abseil"
   project_desc: "Open source collection of C++ libraries drawn from the most fundamental pieces of Google’s internal codebase"
   project_url: "https://abseil.io/"
-  release_date: "2026-01-07"
+  release_date: "2026-02-11"
   use_category:
   - dataplane_core
   - controlplane
@@ -627,7 +627,7 @@ com_google_protobuf:
   project_name: "Protocol Buffers"
   project_desc: "Language-neutral, platform-neutral extensible mechanism for serializing structured data"
   project_url: "https://developers.google.com/protocol-buffers"
-  release_date: "2025-12-05"
+  release_date: "2026-01-29"
   use_category:
   - dataplane_core
   - controlplane
@@ -646,7 +646,7 @@ com_google_protobuf_protoc_linux_aarch_64:
   project_name: "Protocol Buffers (protoc) linux_aarch_64"
   project_desc: "Protoc compiler for protobuf (linux_aarch_64)"
   project_url: "https://developers.google.com/protocol-buffers"
-  release_date: "2025-12-05"
+  release_date: "2026-01-29"
   use_category:
   - build
 
@@ -654,7 +654,7 @@ com_google_protobuf_protoc_linux_ppcle_64:
   project_name: "Protocol Buffers (protoc) linux_ppcle_64"
   project_desc: "Protoc compiler for protobuf (linux_ppcle_64)"
   project_url: "https://developers.google.com/protocol-buffers"
-  release_date: "2025-12-05"
+  release_date: "2026-01-29"
   use_category:
   - build
 
@@ -662,7 +662,7 @@ com_google_protobuf_protoc_linux_x86_64:
   project_name: "Protocol Buffers (protoc) linux_x86_64"
   project_desc: "Protoc compiler for protobuf (linux_x86_64)"
   project_url: "https://developers.google.com/protocol-buffers"
-  release_date: "2025-12-05"
+  release_date: "2026-01-29"
   use_category:
   - build
 
@@ -670,7 +670,7 @@ com_google_protobuf_protoc_osx_aarch_64:
   project_name: "Protocol Buffers (protoc) osx_aarch_64"
   project_desc: "Protoc compiler for protobuf (osx_aarch_64)"
   project_url: "https://developers.google.com/protocol-buffers"
-  release_date: "2025-12-05"
+  release_date: "2026-01-29"
   use_category:
   - build
 
@@ -678,7 +678,7 @@ com_google_protobuf_protoc_osx_x86_64:
   project_name: "Protocol Buffers (protoc) osx_x86_64"
   project_desc: "Protoc compiler for protobuf (osx_x86_64)"
   project_url: "https://developers.google.com/protocol-buffers"
-  release_date: "2025-12-05"
+  release_date: "2026-01-29"
   use_category:
   - build
 
@@ -686,7 +686,7 @@ com_google_protobuf_protoc_win64:
   project_name: "Protocol Buffers (protoc) win64"
   project_desc: "Protoc compiler for protobuf (win64)"
   project_url: "https://developers.google.com/protocol-buffers"
-  release_date: "2025-12-05"
+  release_date: "2026-01-29"
   use_category:
   - build
 

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -1,6 +1,6 @@
 # This should match the schema defined in external_deps.bzl.
 
-PROTOBUF_VERSION = "33.2"
+PROTOBUF_VERSION = "33.5"
 
 # These names of these deps *must* match the names used in `/bazel/protobuf.patch`,
 # and both must match the names from the protobuf releases (see
@@ -8,12 +8,12 @@ PROTOBUF_VERSION = "33.2"
 # The names change in upcoming versions.
 # The shas are calculated from the downloads on the releases page.
 PROTOC_VERSIONS = dict(
-    linux_aarch_64 = "706662a332683aa2fffe1c4ea61588279d31679cd42d91c7d60a69651768edb8",
-    linux_x86_64 = "b24b53f87c151bfd48b112fe4c3a6e6574e5198874f38036aff41df3456b8caf",
-    linux_ppcle_64 = "16b4a36c07daab458bc040523b1f333ddd37e1440fa71634f297a458c7fef4c4",
-    osx_aarch_64 = "5be1427127788c9f7dd7d606c3e69843dd3587327dea993917ffcb77e7234b44",
-    osx_x86_64 = "dba51cfcc85076d56e7de01a647865c5a7f995c3dce427d5215b53e50b7be43f",
-    win64 = "376770cd4073beb63db56fdd339260edb9957b3c4472e05a75f5f9ec8f98d8f5",
+    linux_aarch_64 = "2b0fcf9b2c32cbadccc0eb7a88b841fffecd4a06fc80acdba2b5be45e815c38a",
+    linux_x86_64 = "24e58fb231d50306ee28491f33a170301e99540f7e29ca461e0e80fd1239f8d1",
+    linux_ppcle_64 = "eef750b2119fc03bda049c24322777ade4a0215bd3996a04f915d1eb6a283328",
+    osx_aarch_64 = "7084c6482e3bb416a33fe2162ba566711773b842e6953bf6cb181647b9ef57c0",
+    osx_x86_64 = "7f31625f8bec4929082ae9209e101c1c03692624457cc6332f83736db495ee92",
+    win64 = "7e3468cd1fbd1ae9361a5304d4ac28fbd593aa1a425b5464bd9d4da5fca224b4",
 )
 
 REPOSITORY_LOCATIONS_SPEC = dict(
@@ -61,8 +61,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
     boringssl = dict(
         # To update BoringSSL, which tracks BCR tags, open https://registry.bazel.build/modules/boringssl
         # and select an appropriate tag for the new version.
-        version = "0.20251124.0",
-        sha256 = "d47f89b894bf534c82071d7426c5abf1e5bd044fee242def53cd5d3d0f656c09",
+        version = "0.20260211.0",
+        sha256 = "52e2d96759d483e384e3964a2513781ea05cb6b2d677f1f8f5a4049aea30535d",
         strip_prefix = "boringssl-{version}",
         urls = ["https://github.com/google/boringssl/archive/{version}.tar.gz"],
     ),
@@ -79,8 +79,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         urls = ["https://github.com/aspect-build/bazel-lib/archive/v{version}.tar.gz"],
     ),
     abseil_cpp = dict(
-        version = "20260107.0",
-        sha256 = "4c124408da902be896a2f368042729655709db5e3004ec99f57e3e14439bc1b2",
+        version = "20260107.1",
+        sha256 = "4314e2a7cbac89cac25a2f2322870f343d81579756ceff7f431803c2c9090195",
         strip_prefix = "abseil-cpp-{version}",
         urls = ["https://github.com/abseil/abseil-cpp/archive/{version}.tar.gz"],
     ),
@@ -404,7 +404,7 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         # test/common/json:gen_excluded_unicodes to recompute the ranges
         # excluded from differential fuzzing that are populated in
         # test/common/json/json_sanitizer_test_util.cc.
-        sha256 = "6b6599b54c88d75904b7471f5ca34a725fa0af92e134dd1a32d5b395aa4b4ca8",
+        sha256 = "c6c7c27fadc19d40ab2eaa23ff35debfe01f6494a8345559b9bb285ce4144dd1",
         strip_prefix = "protobuf-{version}",
         urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v{version}/protobuf-{version}.tar.gz"],
     ),


### PR DESCRIPTION
abseil_cpp: 20260107.0 -> 20260107.1
boringssl: 0.20251124.0 -> 0.20260211.0
protobuf: 33.2 -> 33.5

Fixes: #43439, #43440

Risk Level: Low
Testing: CI
