### PR TITLE
Switch to absl::MutexLock's reference constructor

### DIFF
--- a/contrib/kafka/filters/network/source/mesh/command_handlers/fetch.cc
+++ b/contrib/kafka/filters/network/source/mesh/command_handlers/fetch.cc
@@ -41,7 +41,7 @@ void FetchRequestHolder::startProcessing() {
   const TopicToPartitionsMap requested_topics = interest();
 
   {
-    absl::MutexLock lock(&state_mutex_);
+    absl::MutexLock lock(state_mutex_);
     for (const auto& topic_and_partitions : requested_topics) {
       const std::string& topic_name = topic_and_partitions.first;
       for (const int32_t partition : topic_and_partitions.second) {
@@ -81,7 +81,7 @@ void FetchRequestHolder::markFinishedByTimer() {
   ENVOY_LOG(trace, "Request {} timed out", toString());
   bool doCleanup = false;
   {
-    absl::MutexLock lock(&state_mutex_);
+    absl::MutexLock lock(state_mutex_);
     timer_ = nullptr;
     if (!finished_) {
       finished_ = true;
@@ -103,7 +103,7 @@ constexpr int32_t MINIMAL_MSG_CNT = 3;
 // - Kafka-consumer thread - when have the records delivered,
 // - dispatcher thread  - when we start processing and check whether anything was cached.
 CallbackReply FetchRequestHolder::receive(InboundRecordSharedPtr message) {
-  absl::MutexLock lock(&state_mutex_);
+  absl::MutexLock lock(state_mutex_);
   if (!finished_) {
     // Store a new record.
     const KafkaPartition kp = {message->topic_, message->partition_};
@@ -155,7 +155,7 @@ void FetchRequestHolder::cleanup(bool unregister) {
 }
 
 bool FetchRequestHolder::finished() const {
-  absl::MutexLock lock(&state_mutex_);
+  absl::MutexLock lock(state_mutex_);
   return finished_;
 }
 
@@ -174,7 +174,7 @@ AbstractResponseSharedPtr FetchRequestHolder::computeAnswer() const {
 
   std::vector<FetchableTopicResponse> responses;
   {
-    absl::MutexLock lock(&state_mutex_);
+    absl::MutexLock lock(state_mutex_);
     responses = converter_.convert(messages_);
   }
   const FetchResponse data = {responses};

--- a/contrib/kafka/filters/network/test/mesh/upstream_kafka_consumer_impl_unit_test.cc
+++ b/contrib/kafka/filters/network/test/mesh/upstream_kafka_consumer_impl_unit_test.cc
@@ -94,7 +94,7 @@ private:
 public:
   // Stores the first value put inside.
   void registerInvocation(const T& arg) {
-    absl::MutexLock lock{&mutex_};
+    absl::MutexLock lock(mutex_);
     if (0 == invocation_count_) {
       data_ = arg;
     }
@@ -104,14 +104,14 @@ public:
   // Blocks until some value appears, and returns it.
   T awaitFirstInvocation() const {
     const auto cond = std::bind(&Tracker::hasInvocations, this, 1);
-    absl::MutexLock lock{&mutex_, absl::Condition(&cond)};
+    absl::MutexLock lock(mutex_, absl::Condition(&cond));
     return data_;
   }
 
   // Blocks until N invocations have happened.
   void awaitInvocations(const int n) const {
     const auto cond = std::bind(&Tracker::hasInvocations, this, n);
-    absl::MutexLock lock{&mutex_, absl::Condition(&cond)};
+    absl::MutexLock lock(mutex_, absl::Condition(&cond));
   }
 
 private:

--- a/contrib/vcl/source/vcl_interface.cc
+++ b/contrib/vcl/source/vcl_interface.cc
@@ -94,7 +94,7 @@ uint32_t vclEpollHandle(uint32_t wrk_index) {
 
 void vclInterfaceWorkerRegister() {
   {
-    absl::MutexLock lk(&wrk_lock);
+    absl::MutexLock lk(wrk_lock);
     RELEASE_ASSERT(vppcom_worker_register() == VPPCOM_OK, "failed to register VCL worker");
   }
   const int wrk_index = vppcom_worker_index();

--- a/mobile/library/common/network/apple_proxy_resolver.cc
+++ b/mobile/library/common/network/apple_proxy_resolver.cc
@@ -24,7 +24,7 @@ AppleProxyResolver::~AppleProxyResolver() {
 SystemProxySettingsReadCallback AppleProxyResolver::proxySettingsUpdater() {
   return SystemProxySettingsReadCallback(
       [this](absl::optional<SystemProxySettings> proxy_settings) {
-        absl::MutexLock l(&mutex_);
+        absl::MutexLock l(mutex_);
         proxy_settings_ = std::move(proxy_settings);
       });
 }
@@ -45,7 +45,7 @@ AppleProxyResolver::resolveProxy(const std::string& target_url_string,
 
   std::string pac_file_url;
   {
-    absl::MutexLock l(&mutex_);
+    absl::MutexLock l(mutex_);
     if (!proxy_settings_.has_value()) {
       return ProxyResolutionResult::NoProxyConfigured;
     }

--- a/source/extensions/geoip_providers/maxmind/config.cc
+++ b/source/extensions/geoip_providers/maxmind/config.cc
@@ -28,7 +28,7 @@ public:
                                      Server::Configuration::FactoryContext& context) {
     std::shared_ptr<GeoipProvider> driver;
     const uint64_t key = MessageUtil::hash(proto_config);
-    absl::MutexLock lock(&mu_);
+    absl::MutexLock lock(mu_);
     auto it = drivers_.find(key);
     if (it != drivers_.end()) {
       driver = it->second.lock();

--- a/source/extensions/geoip_providers/maxmind/geoip_provider.cc
+++ b/source/extensions/geoip_providers/maxmind/geoip_provider.cc
@@ -515,53 +515,53 @@ absl::Status GeoipProvider::mmdbReload(const MaxmindDbSharedPtr reloaded_db,
 }
 
 MaxmindDbSharedPtr GeoipProvider::getCityDb() const ABSL_LOCKS_EXCLUDED(mmdb_mutex_) {
-  absl::ReaderMutexLock lock(&mmdb_mutex_);
+  absl::ReaderMutexLock lock(mmdb_mutex_);
   return city_db_;
 }
 
 void GeoipProvider::updateCityDb(MaxmindDbSharedPtr city_db) ABSL_LOCKS_EXCLUDED(mmdb_mutex_) {
-  absl::MutexLock lock(&mmdb_mutex_);
+  absl::MutexLock lock(mmdb_mutex_);
   city_db_ = city_db;
 }
 
 MaxmindDbSharedPtr GeoipProvider::getIspDb() const ABSL_LOCKS_EXCLUDED(mmdb_mutex_) {
-  absl::ReaderMutexLock lock(&mmdb_mutex_);
+  absl::ReaderMutexLock lock(mmdb_mutex_);
   return isp_db_;
 }
 
 void GeoipProvider::updateIspDb(MaxmindDbSharedPtr isp_db) ABSL_LOCKS_EXCLUDED(mmdb_mutex_) {
-  absl::MutexLock lock(&mmdb_mutex_);
+  absl::MutexLock lock(mmdb_mutex_);
   isp_db_ = isp_db;
 }
 
 MaxmindDbSharedPtr GeoipProvider::getAsnDb() const ABSL_LOCKS_EXCLUDED(mmdb_mutex_) {
-  absl::ReaderMutexLock lock(&mmdb_mutex_);
+  absl::ReaderMutexLock lock(mmdb_mutex_);
   return asn_db_;
 }
 
 void GeoipProvider::updateAsnDb(MaxmindDbSharedPtr asn_db) ABSL_LOCKS_EXCLUDED(mmdb_mutex_) {
-  absl::MutexLock lock(&mmdb_mutex_);
+  absl::MutexLock lock(mmdb_mutex_);
   asn_db_ = asn_db;
 }
 
 MaxmindDbSharedPtr GeoipProvider::getAnonDb() const ABSL_LOCKS_EXCLUDED(mmdb_mutex_) {
-  absl::ReaderMutexLock lock(&mmdb_mutex_);
+  absl::ReaderMutexLock lock(mmdb_mutex_);
   return anon_db_;
 }
 
 void GeoipProvider::updateAnonDb(MaxmindDbSharedPtr anon_db) ABSL_LOCKS_EXCLUDED(mmdb_mutex_) {
-  absl::MutexLock lock(&mmdb_mutex_);
+  absl::MutexLock lock(mmdb_mutex_);
   anon_db_ = anon_db;
 }
 
 MaxmindDbSharedPtr GeoipProvider::getCountryDb() const ABSL_LOCKS_EXCLUDED(mmdb_mutex_) {
-  absl::ReaderMutexLock lock(&mmdb_mutex_);
+  absl::ReaderMutexLock lock(mmdb_mutex_);
   return country_db_;
 }
 
 void GeoipProvider::updateCountryDb(MaxmindDbSharedPtr country_db)
     ABSL_LOCKS_EXCLUDED(mmdb_mutex_) {
-  absl::MutexLock lock(&mmdb_mutex_);
+  absl::MutexLock lock(mmdb_mutex_);
   country_db_ = country_db;
 }
 

--- a/test/common/stats/thread_local_store_test.cc
+++ b/test/common/stats/thread_local_store_test.cc
@@ -94,11 +94,11 @@ public:
     bool done = false;
     ThreadLocalStoreTestingPeer::numTlsHistograms(
         *store_, [&mutex, &done, &num_tls_histograms](uint32_t num) {
-          absl::MutexLock lock(&mutex);
+          absl::MutexLock lock(mutex);
           num_tls_histograms = num;
           done = true;
         });
-    absl::MutexLock lock(&mutex);
+    absl::MutexLock lock(mutex);
     mutex.Await(absl::Condition(&done));
     return num_tls_histograms;
   }

--- a/test/extensions/geoip_providers/maxmind/geoip_provider_test.cc
+++ b/test/extensions/geoip_providers/maxmind/geoip_provider_test.cc
@@ -38,7 +38,7 @@ public:
   }
   static void setCountryDbToNull(const DriverSharedPtr& driver) {
     auto provider = std::static_pointer_cast<GeoipProvider>(driver);
-    absl::MutexLock lock(&provider->mmdb_mutex_);
+    absl::MutexLock lock(provider->mmdb_mutex_);
     provider->country_db_.reset();
   }
 };
@@ -711,7 +711,7 @@ TEST_F(GeoipProviderTest, DbReloadedOnMmdbFileUpdate) {
   TestEnvironment::renameFile(reloaded_city_db_path, city_db_path);
   cb_added_opt.value().waitReady();
   {
-    absl::ReaderMutexLock guard(&mutex_);
+    absl::ReaderMutexLock guard(mutex_);
     EXPECT_TRUE(on_changed_cbs_[0](Filesystem::Watcher::Events::MovedTo).ok());
   }
   expectReloadStats("city_db", 1, 0);
@@ -753,7 +753,7 @@ TEST_F(GeoipProviderTest, DbEpochGaugeUpdatesWhenReloadedOnMmdbFileUpdate) {
   TestEnvironment::renameFile(reloaded_city_db_path, city_db_path);
   cb_added_opt.value().waitReady();
   {
-    absl::ReaderMutexLock guard(&mutex_);
+    absl::ReaderMutexLock guard(mutex_);
     EXPECT_TRUE(on_changed_cbs_[0](Filesystem::Watcher::Events::MovedTo).ok());
   }
   expectReloadStats("city_db", 1, 0);
@@ -1056,7 +1056,7 @@ TEST_P(MmdbReloadImplTest, MmdbReloaded) {
   TestEnvironment::renameFile(reloaded_db_file_path, source_db_file_path);
   cb_added_opt.value().waitReady();
   {
-    absl::ReaderMutexLock guard(&mutex_);
+    absl::ReaderMutexLock guard(mutex_);
     EXPECT_TRUE(on_changed_cbs_[0](Filesystem::Watcher::Events::MovedTo).ok());
   }
   expectReloadStats(test_case.db_type_, 1, 0);
@@ -1112,7 +1112,7 @@ TEST_P(MmdbReloadImplTest, MmdbReloadedInFlightReadsNotAffected) {
   TestEnvironment::renameFile(reloaded_db_file_path, source_db_file_path);
   cb_added_opt.value().waitReady();
   {
-    absl::ReaderMutexLock guard(&mutex_);
+    absl::ReaderMutexLock guard(mutex_);
     EXPECT_TRUE(on_changed_cbs_[0](Filesystem::Watcher::Events::MovedTo).ok());
   }
   GeoipProviderPeer::synchronizer(provider_).signal(lookup_sync_point_name);
@@ -1188,7 +1188,7 @@ TEST_P(MmdbReloadErrorImplTest, MmdbReloadErrorUsesPreviousDb) {
   TestEnvironment::renameFile(invalid_db_file_path, source_db_file_path);
   cb_added_opt.value().waitReady();
   {
-    absl::ReaderMutexLock guard(&mutex_);
+    absl::ReaderMutexLock guard(mutex_);
     EXPECT_TRUE(on_changed_cbs_[0](Filesystem::Watcher::Events::MovedTo).ok());
   }
   // On reload error the old db instance should be used for subsequent lookup requests.

--- a/test/test_common/file_system_for_test.h
+++ b/test/test_common/file_system_for_test.h
@@ -19,7 +19,7 @@ public:
   FilePtr createFile(const FilePathAndType& file_info) override;
 
   bool fileExists(const std::string& path) override {
-    absl::MutexLock m(&lock_);
+    absl::MutexLock m(lock_);
     auto it = files_.find(path);
     return (it != files_.end() || file_system_->fileExists(path));
   }
@@ -48,12 +48,12 @@ private:
   friend class ScopedUseMemfiles;
 
   void setUseMemfiles(bool value) {
-    absl::MutexLock m(&lock_);
+    absl::MutexLock m(lock_);
     use_memfiles_ = value;
   }
 
   bool useMemfiles() {
-    absl::MutexLock m(&lock_);
+    absl::MutexLock m(lock_);
     return use_memfiles_;
   }
 


### PR DESCRIPTION
`absl::MutexLock` has deprecated its constructor that takes a pointer to `absl::Mutex`, replacing it with one that takes a reference.

Risk Level: Low
Testing: CI