### PR TITLE
docs: add missing LB entry in the Dynamic Modules docs

### DIFF
--- a/docs/root/intro/arch_overview/advanced/dynamic_modules.rst
+++ b/docs/root/intro/arch_overview/advanced/dynamic_modules.rst
@@ -28,6 +28,7 @@ Currently, dynamic modules are supported at the following extension points:
 * As a :ref:`network filter <envoy_v3_api_msg_extensions.filters.network.dynamic_modules.v3.DynamicModuleNetworkFilter>`.
 * As an :ref:`HTTP filter <envoy_v3_api_msg_extensions.filters.http.dynamic_modules.v3.DynamicModuleFilter>`.
 * As a :ref:`TLS certificate validator <envoy_v3_api_msg_extensions.transport_sockets.tls.cert_validator.dynamic_modules.v3.DynamicModuleCertValidatorConfig>`.
+* As a :ref:`load balancing policy <envoy_v3_api_msg_extensions.load_balancing_policies.dynamic_modules.v3.DynamicModulesLoadBalancerConfig>`.
 
 There are a few design goals for the dynamic modules:
 


### PR DESCRIPTION
## Description

This PR adds the missing LB Dynamic Module entry to the main documentation page.

---

**Commit Message:** docs: add missing LB entry in the Dynamic Modules docs
**Additional Description:** Added the missing LB Dynamic Module entry to the main documentation page.
**Risk Level:** Low
**Testing:** CI
**Docs Changes:** N/A
**Release Notes:** N/A