### PR TITLE
mcp_router: support session less when backends don't return mcp-session-id

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -124,6 +124,10 @@ bug_fixes:
 - area: release
   change: |
     Published contrib binaries now include the ``-contrib`` suffix in their version string.
+- area: mcp_router
+  change: |
+    Fixed MCP router to support session-less backends that do not return ``mcp-session-id``
+    headers. Previously this caused a spurious 500 error.
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/source/extensions/filters/http/mcp_router/session_codec.cc
+++ b/source/extensions/filters/http/mcp_router/session_codec.cc
@@ -46,7 +46,8 @@ SessionCodec::parseCompositeSessionId(const std::string& composite) {
   result.subject = Base64::decode(parts[1]);
 
   if (parts[2].empty()) {
-    return absl::InvalidArgumentError("Empty backend sessions");
+    // No backend sessions (all backends are session-less).
+    return result;
   }
 
   std::vector<std::string> backend_parts = absl::StrSplit(parts[2], ',');

--- a/test/extensions/filters/http/mcp_router/session_codec_test.cc
+++ b/test/extensions/filters/http/mcp_router/session_codec_test.cc
@@ -57,9 +57,7 @@ TEST(SessionCodecTest, SubjectWithAtSymbol) {
 
 TEST(SessionCodecTest, ParseInvalidCustomFormat) {
   const std::vector<std::string> invalid_inputs = {
-      "invalid",
-      "no_backends@user",
-      "route@user@",         // Empty backends
+      "invalid", "no_backends@user",
       "route@user@backend",  // Missing colon
       "route@user@:session", // Empty backend name
   };
@@ -67,6 +65,18 @@ TEST(SessionCodecTest, ParseInvalidCustomFormat) {
   for (const auto& input : invalid_inputs) {
     EXPECT_FALSE(SessionCodec::parseCompositeSessionId(input).ok()) << "Input: " << input;
   }
+}
+
+// Backends that don't return mcp-session-id are session-less.
+TEST(SessionCodecTest, ParseEmptyBackendSessions) {
+  std::string composite = absl::StrCat("route1@", SessionCodec::encode("user1"), "@");
+
+  auto result = SessionCodec::parseCompositeSessionId(composite);
+
+  ASSERT_TRUE(result.ok());
+  EXPECT_EQ(result->route, "route1");
+  EXPECT_EQ(result->subject, "user1");
+  EXPECT_TRUE(result->backend_sessions.empty());
 }
 
 } // namespace


### PR DESCRIPTION
allow empty value for session-id from backends, and if all are empty, don't return the aggregated session-id by the mcp_router.

Commit Message:
Additional Description:
Risk Level: low
Testing: integration test
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
