### PR TITLE
mcp: make DELETE valid by the mcp filter 

### DIFF
--- a/api/envoy/extensions/filters/http/mcp/v3/mcp.proto
+++ b/api/envoy/extensions/filters/http/mcp/v3/mcp.proto
@@ -33,6 +33,7 @@ message Mcp {
     // Valid MCP requests are:
     // - POST requests with JSON-RPC 2.0 messages
     // - GET requests for SSE streams (with Accept: text/event-stream)
+    // - DELETE requests for session termination (with MCP-Session-Id header)
     REJECT_NO_MCP = 1;
   }
 

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -335,6 +335,10 @@ new_features:
   change: |
     Added :ref:`statistics <config_http_filters_mcp_router_statistics>` to the MCP router filter for
     observability into request routing, fanout operations, and error conditions.
+- area: mcp
+  change: |
+    Added HTTP DELETE session termination support to the MCP filter. DELETE requests with an
+    ``MCP-Session-Id`` header are now recognized as valid MCP traffic in ``REJECT_NO_MCP`` mode.
 - area: a2a
   change: |
     Added the parsing support for A2A(Agent2Agent) protocol. It is used to parse the A2A JSON-RPC messages.

--- a/source/extensions/filters/common/mcp/constants.h
+++ b/source/extensions/filters/common/mcp/constants.h
@@ -22,6 +22,9 @@ constexpr absl::string_view JSONRPC_FIELD = "jsonrpc";
 constexpr absl::string_view METHOD_FIELD = "method";
 constexpr absl::string_view ID_FIELD = "id";
 
+// HTTP header names
+constexpr absl::string_view MCP_SESSION_ID_HEADER = "mcp-session-id";
+
 // Method names
 namespace Methods {
 // Tools

--- a/source/extensions/filters/http/mcp/mcp_filter.cc
+++ b/source/extensions/filters/http/mcp/mcp_filter.cc
@@ -4,6 +4,7 @@
 #include "source/common/http/utility.h"
 #include "source/common/protobuf/protobuf.h"
 #include "source/common/protobuf/utility.h"
+#include "source/extensions/filters/common/mcp/constants.h"
 #include "source/extensions/filters/common/mcp/filter_state.h"
 
 #include "absl/strings/str_cat.h"
@@ -16,6 +17,10 @@ namespace Mcp {
 using FilterStateObject = Filters::Common::Mcp::FilterStateObject;
 
 namespace {
+
+const Http::LowerCaseString kMcpSessionId{
+    std::string(Filters::Common::Mcp::McpConstants::MCP_SESSION_ID_HEADER)};
+
 McpFilterStats generateStats(const std::string& prefix, Stats::Scope& scope) {
   const std::string final_prefix = absl::StrCat(prefix, "mcp.");
   return McpFilterStats{MCP_FILTER_STATS(POOL_COUNTER_PREFIX(scope, final_prefix))};
@@ -35,6 +40,14 @@ McpFilterConfig::McpFilterConfig(const envoy::extensions::filters::http::mcp::v3
                          ? McpParserConfig::fromProto(proto_config.parser_config())
                          : McpParserConfig::createDefault()),
       stats_(generateStats(stats_prefix, scope)) {}
+
+bool McpFilter::isValidMcpDeleteRequest(const Http::RequestHeaderMap& headers) const {
+  // DELETE is only meaningful for MCP session termination when MCP-Session-Id is present.
+  if (headers.getMethodValue() != Http::Headers::get().MethodValues.Delete) {
+    return false;
+  }
+  return !headers.get(kMcpSessionId).empty();
+}
 
 bool McpFilter::isValidMcpSseRequest(const Http::RequestHeaderMap& headers) const {
   // Check if this is a GET request for SSE stream
@@ -119,6 +132,12 @@ uint32_t McpFilter::getMaxRequestBodySize() const {
 
 Http::FilterHeadersStatus McpFilter::decodeHeaders(Http::RequestHeaderMap& headers,
                                                    bool end_stream) {
+  if (isValidMcpDeleteRequest(headers)) {
+    is_mcp_request_ = true;
+    ENVOY_LOG(debug, "valid MCP DELETE session-termination request, passing through");
+    return Http::FilterHeadersStatus::Continue;
+  }
+
   if (isValidMcpSseRequest(headers)) {
     is_mcp_request_ = true;
     ENVOY_LOG(debug, "valid MCP SSE request, passing through");

--- a/source/extensions/filters/http/mcp/mcp_filter.h
+++ b/source/extensions/filters/http/mcp/mcp_filter.h
@@ -126,6 +126,7 @@ public:
 private:
   bool isValidMcpSseRequest(const Http::RequestHeaderMap& headers) const;
   bool isValidMcpPostRequest(const Http::RequestHeaderMap& headers) const;
+  bool isValidMcpDeleteRequest(const Http::RequestHeaderMap& headers) const;
   bool shouldRejectRequest() const;
   uint32_t getMaxRequestBodySize() const;
 


### PR DESCRIPTION
Added HTTP DELETE session termination support to the MCP filter. DELETE requests with an ``MCP-Session-Id`` header are now recognized as valid MCP traffic in ``REJECT_NO_MCP`` mode.

```
Clients that no longer need a particular session (e.g., because the user is leaving the client application) SHOULD send an HTTP DELETE to the MCP endpoint with the MCP-Session-Id header, to explicitly terminate the session.
```
 
 MCP filter is just passing through.
 
Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
