### PR TITLE
dynamic_modules: fixes network filter to always set a local close reason when closing connections

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -58,6 +58,10 @@ minor_behavior_changes:
 
 bug_fixes:
 # *Changes expected to improve the state of the world and are unlikely to have negative effects*
+- area: dynamic_modules
+  change: |
+    Fixed the dynamic modules network filter to always set a local close reason when closing connections. This
+    resolves an error when a dynamic modules network filter closes a connection that has an HTTP filter present.
 - area: tls
   change: |
     Fix on-demand TLS selector to enforce session resumption settings.

--- a/source/extensions/filters/network/dynamic_modules/abi_impl.cc
+++ b/source/extensions/filters/network/dynamic_modules/abi_impl.cc
@@ -247,7 +247,7 @@ void envoy_dynamic_module_callback_network_filter_close(
     envoy_dynamic_module_type_network_filter_envoy_ptr filter_envoy_ptr,
     envoy_dynamic_module_type_network_connection_close_type close_type) {
   auto* filter = static_cast<DynamicModuleNetworkFilter*>(filter_envoy_ptr);
-  filter->connection().close(toEnvoyCloseType(close_type));
+  filter->connection().close(toEnvoyCloseType(close_type), "dynamic_module_close");
 }
 
 uint64_t envoy_dynamic_module_callback_network_filter_get_connection_id(
@@ -312,11 +312,11 @@ void envoy_dynamic_module_callback_network_filter_close_with_details(
     envoy_dynamic_module_type_network_connection_close_type close_type,
     envoy_dynamic_module_type_module_buffer details) {
   auto* filter = static_cast<DynamicModuleNetworkFilter*>(filter_envoy_ptr);
-  if (details.ptr != nullptr && details.length > 0) {
-    filter->connection().streamInfo().setConnectionTerminationDetails(
-        absl::string_view(details.ptr, details.length));
-  }
-  filter->connection().close(toEnvoyCloseType(close_type));
+  absl::string_view details_view = (details.ptr != nullptr && details.length > 0)
+                                       ? absl::string_view(details.ptr, details.length)
+                                       : "dynamic_module_close";
+  filter->connection().streamInfo().setConnectionTerminationDetails(details_view);
+  filter->connection().close(toEnvoyCloseType(close_type), details_view);
 }
 
 bool envoy_dynamic_module_callback_network_filter_get_requested_server_name(

--- a/test/extensions/dynamic_modules/network/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/network/abi_impl_test.cc
@@ -478,31 +478,36 @@ TEST_F(DynamicModuleNetworkFilterAbiCallbackTest, ContinueReading) {
 // =============================================================================
 
 TEST_F(DynamicModuleNetworkFilterAbiCallbackTest, CloseFlushWrite) {
-  EXPECT_CALL(connection_, close(Network::ConnectionCloseType::FlushWrite));
+  EXPECT_CALL(connection_, close(Network::ConnectionCloseType::FlushWrite,
+                                 absl::string_view("dynamic_module_close")));
   envoy_dynamic_module_callback_network_filter_close(
       filterPtr(), envoy_dynamic_module_type_network_connection_close_type_FlushWrite);
 }
 
 TEST_F(DynamicModuleNetworkFilterAbiCallbackTest, CloseNoFlush) {
-  EXPECT_CALL(connection_, close(Network::ConnectionCloseType::NoFlush));
+  EXPECT_CALL(connection_, close(Network::ConnectionCloseType::NoFlush,
+                                 absl::string_view("dynamic_module_close")));
   envoy_dynamic_module_callback_network_filter_close(
       filterPtr(), envoy_dynamic_module_type_network_connection_close_type_NoFlush);
 }
 
 TEST_F(DynamicModuleNetworkFilterAbiCallbackTest, CloseFlushWriteAndDelay) {
-  EXPECT_CALL(connection_, close(Network::ConnectionCloseType::FlushWriteAndDelay));
+  EXPECT_CALL(connection_, close(Network::ConnectionCloseType::FlushWriteAndDelay,
+                                 absl::string_view("dynamic_module_close")));
   envoy_dynamic_module_callback_network_filter_close(
       filterPtr(), envoy_dynamic_module_type_network_connection_close_type_FlushWriteAndDelay);
 }
 
 TEST_F(DynamicModuleNetworkFilterAbiCallbackTest, CloseAbort) {
-  EXPECT_CALL(connection_, close(Network::ConnectionCloseType::Abort));
+  EXPECT_CALL(connection_, close(Network::ConnectionCloseType::Abort,
+                                 absl::string_view("dynamic_module_close")));
   envoy_dynamic_module_callback_network_filter_close(
       filterPtr(), envoy_dynamic_module_type_network_connection_close_type_Abort);
 }
 
 TEST_F(DynamicModuleNetworkFilterAbiCallbackTest, CloseAbortReset) {
-  EXPECT_CALL(connection_, close(Network::ConnectionCloseType::AbortReset));
+  EXPECT_CALL(connection_, close(Network::ConnectionCloseType::AbortReset,
+                                 absl::string_view("dynamic_module_close")));
   envoy_dynamic_module_callback_network_filter_close(
       filterPtr(), envoy_dynamic_module_type_network_connection_close_type_AbortReset);
 }
@@ -648,7 +653,8 @@ TEST_F(DynamicModuleNetworkFilterAbiCallbackTest, CloseWithDetails) {
   const std::string details = "auth_failed";
   EXPECT_CALL(connection_.stream_info_,
               setConnectionTerminationDetails(absl::string_view(details)));
-  EXPECT_CALL(connection_, close(Network::ConnectionCloseType::NoFlush));
+  EXPECT_CALL(connection_,
+              close(Network::ConnectionCloseType::NoFlush, absl::string_view(details)));
 
   envoy_dynamic_module_callback_network_filter_close_with_details(
       filterPtr(), envoy_dynamic_module_type_network_connection_close_type_NoFlush,
@@ -656,8 +662,10 @@ TEST_F(DynamicModuleNetworkFilterAbiCallbackTest, CloseWithDetails) {
 }
 
 TEST_F(DynamicModuleNetworkFilterAbiCallbackTest, CloseWithNullDetails) {
-  EXPECT_CALL(connection_.stream_info_, setConnectionTerminationDetails(testing::_)).Times(0);
-  EXPECT_CALL(connection_, close(Network::ConnectionCloseType::NoFlush));
+  EXPECT_CALL(connection_.stream_info_,
+              setConnectionTerminationDetails(absl::string_view("dynamic_module_close")));
+  EXPECT_CALL(connection_, close(Network::ConnectionCloseType::NoFlush,
+                                 absl::string_view("dynamic_module_close")));
 
   envoy_dynamic_module_callback_network_filter_close_with_details(
       filterPtr(), envoy_dynamic_module_type_network_connection_close_type_NoFlush, {nullptr, 0});


### PR DESCRIPTION
## Description

This PR fixes the dynamic modules network filter to always set a local close reason when closing connections. This resolves an error when a dynamic modules network filter closes a connection that has an HTTP filter present.

Fix https://github.com/envoyproxy/envoy/issues/43507

---

**Commit Message:** dynamic_modules: fixes network filter to always set a local close reason when closing connections
**Additional Description:** Fixes the dynamic modules network filter to always set a local close reason when closing connections.
**Risk Level:** Low
**Testing:** Added Tests
**Docs Changes:** Added
**Release Notes:** Added