### PR TITLE
Update QUICHE from 4b9143d5a to 9711fb297

### DIFF
--- a/bazel/deps.yaml
+++ b/bazel/deps.yaml
@@ -284,7 +284,7 @@ quiche:
   project_name: "QUICHE"
   project_desc: "QUICHE (QUIC, HTTP/2, Etc) is Google‘s implementation of QUIC and related protocols"
   project_url: "https://github.com/google/quiche"
-  release_date: "2026-02-12"
+  release_date: "2026-02-16"
   use_category:
   - controlplane
   - dataplane_core

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -542,8 +542,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         urls = ["https://github.com/simdutf/simdutf/releases/download/v{version}/singleheader.zip"],
     ),
     quiche = dict(
-        version = "4b9143d5a85d6bd89b281ddc69606edf7934734f",
-        sha256 = "5abc4d44c53f7b51e4c5e060e292c1ea1413feb3a876f2fe5b18b3c80a1fb7c4",
+        version = "9711fb297e4d60826f516ccc80d71b81c9c7de12",
+        sha256 = "de7b01e62b1dfb4f15ba41b6a3b9b41b2d1e8b827efda859dd774a198a32f0d0",
         urls = ["https://github.com/google/quiche/archive/{version}.tar.gz"],
         strip_prefix = "quiche-{version}",
     ),


### PR DESCRIPTION
https://github.com/google/quiche/compare/4b9143d5a..9711fb297

```
$ git log 4b9143d5a..9711fb297 --date=short --no-merges --format="%ad %al %s"

2026-02-15 asedeno OSS QUICHE: update MODULE.bazel to use a newer highwayhash.
2026-02-12 vasilvv Implement a parser for MOQT track name format.
2026-02-12 martinduke Parameterize remaining MOQT message types.
2026-02-12 reubent Add new balsa_frame microbenchmark
2026-02-12 vasilvv Support standard encoding for track names and namespaces.
2026-02-12 haoyuewang Release the capacity after clear on two std::vector in QuicCryptoStream::ResetCryptoSubstreams.
2026-02-12 martinduke Fix MSAN error in PublishNamespaceCancel()
```