### PR TITLE
[notifier] Add section for pending deployments

### DIFF
--- a/tools/repo/notify.py
+++ b/tools/repo/notify.py
@@ -314,7 +314,7 @@ class RepoNotifier(runner.Runner):
                 ))
             await self.send_message(
                 channel='#envoy-maintainer-oncall',
-                text=(f"*Pending Deployments* (workflow runs that need manual approval from maintainer)\n<{"https://github.com/envoyproxy/envoy-ci-staging/actions/workflows/request.yml?query=is%3Aaction_required"}>"))
+                text=(f"*Pending Deployments* (workflow runs that need manual approval from maintainer)\n<{"https://github.com/envoyproxy/envoy/actions/workflows/request.yml?query=is%3Aaction_required"}>"))
             await self.send_message(
                 channel='#envoy-ci',
                 text=(


### PR DESCRIPTION
Sample output:
```
nezdolik@lima-default1:/Users/nezdolik/Documents/code2/envoy/tools/repo$ bazel run --config=ci //tools/repo:notify -- --dry_run
INFO: Analyzed target //tools/repo:notify (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //tools/repo:notify up-to-date:
  bazel-bin/tools/repo/notify
INFO: Elapsed time: 0.321s, Critical Path: 0.21s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Running command line: bazel-bin/tools/repo/notify ./reviewers.yaml --dry_run
RepoNotifier NOTICE Slack message (#envoy-maintainer-oncall):
*Pending Deployments* (workflow runs that need manual approval from maintainer)
<https://github.com/envoyproxy/envoy-ci-staging/actions/workflows/request.yml?query=is%3Aaction_required>
```