### PR TITLE
tracing/datadog: fix sampling priority escalation on route cache refresh

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -106,6 +106,13 @@ bug_fixes:
     Fixed hot restart for listeners with a network namespace in the address. Previously, socket
     hand-off didn't work cleanly because the namespace was not included in the ``PassListenSocket``
     request, causing the parent to always fall back to binding a new socket.
+- area: tracing/datadog
+  change: |
+    Fixed the Datadog tracer's ``setSampled(true)`` to not override the sampling priority, matching
+    the ``startSpan()`` behavior of leaving the priority unset so the Datadog agent can apply its
+    own sampling rate. Previously, ``setSampled(true)`` would set ``USER_KEEP`` priority which
+    prevented the agent from downsampling, causing a significant increase in trace volume when
+    combined with route cache refreshes in Envoy 1.36.
 - area: dynamic_modules
   change: |
     Fixed the dynamic modules network filter to always set a local close reason when closing connections. This

--- a/source/extensions/tracers/datadog/span.cc
+++ b/source/extensions/tracers/datadog/span.cc
@@ -84,12 +84,27 @@ void Span::log(SystemTime, const std::string&) {
   // Datadog spans don't have in-bound "events" or "logs".
 }
 
-void Span::finishSpan() { span_.reset(); }
+void Span::finishSpan() {
+  if (span_ && sampled_.has_value() && !sampled_.value()) {
+    span_->trace_segment().override_sampling_priority(
+        static_cast<int>(datadog::tracing::SamplingPriority::USER_DROP));
+  }
+  span_.reset();
+}
 
 void Span::injectContext(Tracing::TraceContext& trace_context, const Tracing::UpstreamContext&) {
   if (!span_) {
     return;
   }
+
+  // Apply the deferred sampling decision before injection so the correct
+  // priority is propagated in the trace context headers.
+  if (sampled_.has_value() && !sampled_.value()) {
+    span_->trace_segment().override_sampling_priority(
+        static_cast<int>(datadog::tracing::SamplingPriority::USER_DROP));
+  }
+  // When sampled is true or not set, don't override — let inject() handle it
+  // via make_sampling_decision_if_null() so the Datadog sampler decides.
 
   TraceContextWriter writer{trace_context};
   span_->inject(writer);
@@ -122,14 +137,10 @@ void Span::setSampled(bool sampled) {
     return;
   }
 
-  if (!sampled) {
-    // Match startSpan() semantics: false is a definite drop.
-    span_->trace_segment().override_sampling_priority(
-        static_cast<int>(datadog::tracing::SamplingPriority::USER_DROP));
-  }
-  // When sampled is true, do nothing — leave the priority as-is so the
-  // Datadog agent can apply its own sampling rate. This matches how
-  // startSpan() handles traced=true by leaving the priority unset.
+  // Save the sampled state. The actual sampling priority override is deferred
+  // to injectContext()/finishSpan() so that a later setSampled(true) (e.g.
+  // from a route cache refresh) can undo an earlier setSampled(false).
+  sampled_ = sampled;
 }
 
 std::string Span::getBaggage(absl::string_view) {

--- a/source/extensions/tracers/datadog/span.h
+++ b/source/extensions/tracers/datadog/span.h
@@ -5,6 +5,7 @@
 #include "envoy/common/time.h"
 #include "envoy/tracing/trace_driver.h"
 
+#include "absl/types/optional.h"
 #include "datadog/span.h"
 
 namespace Envoy {
@@ -54,6 +55,11 @@ public:
 private:
   datadog::tracing::Optional<datadog::tracing::Span> span_;
   const bool use_local_decision_{false};
+  // Tracks the most recent sampled state from setSampled(). The decision is
+  // deferred and applied in injectContext()/finishSpan() so that a later
+  // setSampled(true) (e.g. from a route cache refresh) can undo an earlier
+  // setSampled(false) set during startSpan().
+  absl::optional<bool> sampled_;
 };
 
 } // namespace Datadog

--- a/source/extensions/tracers/datadog/tracer.cc
+++ b/source/extensions/tracers/datadog/tracer.cc
@@ -112,14 +112,15 @@ Tracing::SpanPtr Tracer::startSpan(const Tracing::Config&, Tracing::TraceContext
   // If Envoy is telling us to keep the trace, then we leave it up to the
   // tracer's internal sampler (which might decide to drop the trace anyway).
   const bool use_local_decision = !span.trace_segment().sampling_decision().has_value();
-  if (use_local_decision && !tracing_decision.traced) {
-    // TODO(wbpcode): use USER_KEEP to indicate that the trace should be kept if the
-    // Envoy is telling us to keep the trace.
-    span.trace_segment().override_sampling_priority(
-        int(datadog::tracing::SamplingPriority::USER_DROP));
-  }
 
-  return std::make_unique<Span>(std::move(span), use_local_decision);
+  auto result = std::make_unique<Span>(std::move(span), use_local_decision);
+  if (use_local_decision) {
+    // Defer the sampling decision to Span::injectContext()/finishSpan().
+    // This allows a subsequent setSampled(true) (e.g. from a route cache
+    // refresh) to undo this initial drop decision.
+    result->setSampled(tracing_decision.traced);
+  }
+  return result;
 }
 
 datadog::tracing::Span Tracer::extractOrCreateSpan(datadog::tracing::Tracer& tracer,

--- a/test/extensions/tracers/datadog/span_test.cc
+++ b/test/extensions/tracers/datadog/span_test.cc
@@ -316,50 +316,93 @@ TEST_F(DatadogTracerSpanTest, SpawnChild) {
 }
 
 TEST_F(DatadogTracerSpanTest, SetSampledTrue) {
-  // `Span::setSampled(bool)` on any span causes the entire group (chunk) of
-  // spans to take that sampling override. In terms of dd-trace-cpp, this means
-  // that the local root of the chunk will have its
-  // `datadog::tracing::tags::internal::sampling_priority` tag set to either -1
-  // (hard drop) or 2 (hard keep).
+  // setSampled(true) means "let the Datadog sampler decide." It should NOT
+  // set USER_KEEP priority — that was the old buggy behavior.
   auto dd_span = tracer_.create_span();
+  Span span(std::move(dd_span));
 
-  // First ensure that the trace will be dropped (until we override it by
-  // calling `setSampled`, below).
-  dd_span.trace_segment().override_sampling_priority(
-      static_cast<int>(datadog::tracing::SamplingPriority::USER_DROP));
+  span.setSampled(true);
 
-  Span parent(std::move(dd_span));
-  auto child = parent.spawnChild(Tracing::MockConfig{}, "child", time_.timeSystem().systemTime());
+  // Inject context and verify the sampling priority is NOT USER_KEEP.
+  // The Datadog sampler should decide. Our test sampler has sample_rate=0,
+  // so it drops (USER_DROP).
+  Tracing::TestTraceContextImpl context{};
+  span.injectContext(context, Tracing::UpstreamContext());
+  auto found = context.context_map_.find("x-datadog-sampling-priority");
+  ASSERT_NE(context.context_map_.end(), found);
+  EXPECT_NE(std::to_string(int(datadog::tracing::SamplingPriority::USER_KEEP)), found->second);
 
-  child->setSampled(true);
-  child->finishSpan();
-  parent.finishSpan();
+  span.finishSpan();
 
-  // Verify the spans successfully complete without errors.
+  // Verify the span successfully completes without errors.
   EXPECT_TRUE(test_logger_->errors().empty());
 }
 
 TEST_F(DatadogTracerSpanTest, SetSampledFalse) {
-  // `Span::setSampled(bool)` on any span causes the entire group (chunk) of
-  // spans to take that sampling override. In terms of dd-trace-cpp, this means
-  // that the local root of the chunk will have its
-  // `datadog::tracing::tags::internal::sampling_priority` tag set to either -1
-  // (hard drop) or 2 (hard keep).
+  // setSampled(false) should result in USER_DROP priority when injecting
+  // trace context.
   auto dd_span = tracer_.create_span();
+  Span span(std::move(dd_span));
 
-  // First ensure that the trace will be kept (until we override it by
-  // calling `setSampled`, below).
-  dd_span.trace_segment().override_sampling_priority(
-      static_cast<int>(datadog::tracing::SamplingPriority::USER_KEEP));
+  span.setSampled(false);
 
-  Span parent(std::move(dd_span));
-  auto child = parent.spawnChild(Tracing::MockConfig{}, "child", time_.timeSystem().systemTime());
+  // Inject context and verify USER_DROP priority.
+  Tracing::TestTraceContextImpl context{};
+  span.injectContext(context, Tracing::UpstreamContext());
+  auto found = context.context_map_.find("x-datadog-sampling-priority");
+  ASSERT_NE(context.context_map_.end(), found);
+  EXPECT_EQ(std::to_string(int(datadog::tracing::SamplingPriority::USER_DROP)), found->second);
 
-  child->setSampled(false);
-  child->finishSpan();
-  parent.finishSpan();
+  span.finishSpan();
 
-  // Verify the spans successfully complete without errors.
+  // Verify the span successfully completes without errors.
+  EXPECT_TRUE(test_logger_->errors().empty());
+}
+
+TEST_F(DatadogTracerSpanTest, SetSampledTrueAfterFalseUndoesDrop) {
+  // When setSampled(true) is called after setSampled(false) (e.g., after a
+  // route cache refresh), the Datadog sampler should decide the priority
+  // instead of keeping the USER_DROP override.
+  // Use a tracer with sample_rate=1.0 to verify the drop is actually undone.
+  datadog::tracing::TracerConfig config;
+  config.service = "test-service";
+  config.logger = test_logger_;
+  config.log_on_startup = false;
+  config.agent.http_client = std::make_shared<TestHTTPClient>();
+  config.agent.event_scheduler = std::make_shared<TestEventScheduler>();
+  config.collector = std::make_shared<datadog::tracing::NullCollector>();
+  config.telemetry.enabled = false;
+
+  datadog::tracing::TraceSamplerConfig::Rule rule;
+  rule.sample_rate = 1.0;
+  config.trace_sampler.rules.push_back(std::move(rule));
+
+  auto validated_config = datadog::tracing::finalize_config(config);
+  ASSERT_TRUE(validated_config);
+  datadog::tracing::Tracer keep_tracer(*validated_config, id_generator_);
+
+  auto dd_span = keep_tracer.create_span();
+  Span span(std::move(dd_span));
+
+  // Simulate: Envoy initially says "don't trace"
+  span.setSampled(false);
+  // Simulate: Route cache refresh, Envoy now says "trace"
+  span.setSampled(true);
+
+  // Inject context: since setSampled(true) was the last call, the Datadog
+  // sampler should decide. With sample_rate=1.0, it keeps the trace.
+  Tracing::TestTraceContextImpl context{};
+  span.injectContext(context, Tracing::UpstreamContext());
+  auto found = context.context_map_.find("x-datadog-sampling-priority");
+  ASSERT_NE(context.context_map_.end(), found);
+  int priority = std::stoi(found->second);
+  EXPECT_GT(priority, 0) << "Expected a keep decision (positive priority) "
+                         << "since setSampled(true) should let the Datadog "
+                         << "sampler decide, and the sampler keeps everything.";
+
+  span.finishSpan();
+
+  // Verify the span successfully completes without errors.
   EXPECT_TRUE(test_logger_->errors().empty());
 }
 

--- a/test/extensions/tracers/datadog/tracer_test.cc
+++ b/test/extensions/tracers/datadog/tracer_test.cc
@@ -159,6 +159,12 @@ TEST_F(DatadogTracerTest, SpanProperties) {
   EXPECT_EQ("envoy.proxy", dd_span.name());
   EXPECT_EQ("do.thing", dd_span.resource_name());
   EXPECT_EQ("envoy", dd_span.service_name());
+  // The sampling decision is deferred to injectContext()/finishSpan(), so
+  // the trace segment does not have it set immediately after startSpan().
+  // Verify it is applied after injecting context.
+  EXPECT_FALSE(dd_span.trace_segment().sampling_decision());
+  Tracing::TestTraceContextImpl inject_context{};
+  span->injectContext(inject_context, Tracing::UpstreamContext());
   ASSERT_TRUE(dd_span.trace_segment().sampling_decision());
   EXPECT_EQ(int(datadog::tracing::SamplingPriority::USER_DROP),
             dd_span.trace_segment().sampling_decision()->priority);
@@ -328,9 +334,10 @@ TEST_F(DatadogTracerTest, EnvoySamplingVersusExtractedSampling) {
       // of "traceparent" always containing a sampling decision in its flags. See
       // the main body of the test, below, for more information.
       {__LINE__, datadog::tracing::nullopt, true, datadog::tracing::PropagationStyle::W3C, 0},
-      // This is the only case, at least in this test, where Envoy's decision
-      // affects the resulting sampling priority.
-      {__LINE__, datadog::tracing::nullopt, false, datadog::tracing::PropagationStyle::DATADOG, -1},
+      // Envoy's drop decision is now deferred to injectContext()/finishSpan(),
+      // so the trace segment does not have a sampling decision immediately.
+      {__LINE__, datadog::tracing::nullopt, false, datadog::tracing::PropagationStyle::DATADOG,
+       datadog::tracing::nullopt},
       {__LINE__, datadog::tracing::nullopt, false, datadog::tracing::PropagationStyle::W3C, 0},
 
       {__LINE__, -1, true, datadog::tracing::PropagationStyle::DATADOG, -1},


### PR DESCRIPTION
Commit Message: Fix inconsistent behavior between DD tracer on startSpan and setSampled.
Additional Description:     Fixed the Datadog tracer's ``setSampled(true)`` to not override the sampling priority, matching the ``startSpan()`` behavior of leaving the priority unset so the Datadog agent can apply its own sampling rate. Previously, ``setSampled(true)`` would set ``USER_KEEP`` priority which prevented the agent from downsampling, causing a significant increase in trace volume when combined with route cache refreshes in Envoy 1.36.
Risk Level: Low
Testing: None
Docs Changes: N/A
Release Notes: Added


Fix https://github.com/envoyproxy/envoy/issues/43532