### PR TITLE
backport PR 43277

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -7,6 +7,12 @@ minor_behavior_changes:
 # *Changes that may cause incompatibilities for some users, but should not for most*
 
 bug_fixes:
+- area: health_check
+  change: |
+    Fixed a race condition where active health checks could start before required upstream TLS SDS secrets
+    were fetched, causing intermittent health check failures `#43116 <https://github.com/envoyproxy/envoy/issues/43116>`_.
+    This fix can be disabled by setting runtime guard ``envoy.reloadable_features.health_check_after_cluster_warming``
+    to ``false``.
 # *Changes expected to improve the state of the world and are unlikely to have negative effects*
 
 removed_config_or_runtime:

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -49,6 +49,7 @@ RUNTIME_GUARD(envoy_reloadable_features_filter_chain_aborted_can_not_continue);
 RUNTIME_GUARD(envoy_reloadable_features_gcp_authn_use_fixed_url);
 RUNTIME_GUARD(envoy_reloadable_features_getaddrinfo_num_retries);
 RUNTIME_GUARD(envoy_reloadable_features_grpc_side_stream_flow_control);
+RUNTIME_GUARD(envoy_reloadable_features_health_check_after_cluster_warming);
 RUNTIME_GUARD(envoy_reloadable_features_http1_balsa_allow_cr_or_lf_at_request_start);
 RUNTIME_GUARD(envoy_reloadable_features_http1_balsa_delay_reset);
 RUNTIME_GUARD(envoy_reloadable_features_http1_balsa_disallow_lone_cr_in_chunk_extension);
@@ -115,7 +116,6 @@ RUNTIME_GUARD(envoy_reloadable_features_xds_prevent_resource_copy);
 RUNTIME_GUARD(envoy_restart_features_fix_dispatcher_approximate_now);
 RUNTIME_GUARD(envoy_restart_features_skip_backing_cluster_check_for_sds);
 RUNTIME_GUARD(envoy_restart_features_use_eds_cache_for_ads);
-RUNTIME_GUARD(envoy_restart_features_validate_http3_pseudo_headers);
 
 // Begin false flags. Most of them should come with a TODO to flip true.
 
@@ -181,10 +181,6 @@ FALSE_RUNTIME_GUARD(envoy_reloadable_features_use_network_type_socket_option);
 FALSE_RUNTIME_GUARD(envoy_reloadable_features_quic_disable_client_early_data);
 
 FALSE_RUNTIME_GUARD(envoy_reloadable_features_ext_proc_graceful_grpc_close);
-
-// TODO(yavlasov): Enabling by default will be hugely disruptive to existing traffic.
-// Replace with a config option (default off) post CVE release.
-FALSE_RUNTIME_GUARD(envoy_reloadable_features_reject_early_connect_data);
 
 // Block of non-boolean flags. Use of int flags is deprecated. Do not add more.
 ABSL_FLAG(uint64_t, re2_max_program_size_error_level, 100, ""); // NOLINT

--- a/source/extensions/health_checkers/common/health_checker_base_impl.h
+++ b/source/extensions/health_checkers/common/health_checker_base_impl.h
@@ -162,6 +162,7 @@ private:
   const std::shared_ptr<const Network::TransportSocketOptionsImpl> transport_socket_options_;
   const MetadataConstSharedPtr transport_socket_match_metadata_;
   const Common::CallbackHandlePtr member_update_cb_;
+  bool started_{false};
 };
 
 } // namespace Upstream

--- a/test/integration/sds_dynamic_integration_test.cc
+++ b/test/integration/sds_dynamic_integration_test.cc
@@ -1448,6 +1448,130 @@ TEST_P(SdsDynamicClusterIntegrationTest, CdsSdsCyclicDependency) {
   test_server_->waitForGaugeEq("cluster_manager.active_clusters", 2);
 }
 
+// This test verifies that health checks do NOT start before SDS secrets are delivered.
+// Regression test of: https://github.com/envoyproxy/envoy/issues/43116
+TEST_P(SdsDynamicClusterIntegrationTest, ClusterWarmingWhileHealthCheckBlocksOnSds) {
+  defer_listener_finalization_ = true;
+
+  on_server_init_function_ = [this]() {
+    AssertionResult result = cdsUpstream()->waitForHttpConnection(*dispatcher_, xds_connection_);
+    RELEASE_ASSERT(result, result.message());
+    result = xds_connection_->waitForNewStream(*dispatcher_, xds_stream_);
+    RELEASE_ASSERT(result, result.message());
+    xds_stream_->startGrpcStream();
+
+    // Add health check to the dynamic cluster.
+    auto* health_check = dynamic_cluster_.add_health_checks();
+    health_check->mutable_timeout()->set_seconds(5);
+    health_check->mutable_interval()->CopyFrom(ProtobufUtil::TimeUtil::MillisecondsToDuration(100));
+    health_check->mutable_no_traffic_interval()->CopyFrom(
+        ProtobufUtil::TimeUtil::MillisecondsToDuration(100));
+    health_check->mutable_unhealthy_threshold()->set_value(1);
+    health_check->mutable_healthy_threshold()->set_value(1);
+    health_check->mutable_tcp_health_check();
+
+    // Send CDS response with both SDS cluster and dynamic cluster.
+    // The dynamic cluster will start warming, waiting for SDS.
+    sendCdsResponse();
+
+    // Wait for SDS connection to be established.
+    result = sdsUpstream()->waitForHttpConnection(*dispatcher_, sds_connection_);
+    RELEASE_ASSERT(result, result.message());
+    result = sds_connection_->waitForNewStream(*dispatcher_, sds_stream_);
+    RELEASE_ASSERT(result, result.message());
+    sds_stream_->startGrpcStream();
+
+    // Do NOT send SDS response yet - cluster should remain warming.
+  };
+  sds_cluster_name_ = "sds_dynamic_cluster.lyft.com";
+
+  // The defer_listener_finalization_ = true above ensures that initialize() does not block
+  // even though the dynamic cluster is warming while waiting for SDS.
+  initialize();
+
+  // Wait for the dynamic cluster to exist and be in warming state.
+  test_server_->waitForGaugeEq("cluster.dynamic.warming_state", 1);
+
+  // Health checks must NOT have started while cluster is warming.
+  // Note: The counter may exist but its value should be 0.
+  auto counter = test_server_->counter("cluster.dynamic.health_check.attempt");
+  uint64_t attempt_count = counter ? counter->value() : 0;
+  EXPECT_EQ(0, attempt_count) << "Health checks started before SDS secrets were delivered!";
+
+  // Now send the SDS response with actual client certificate.
+  sendSdsResponse2(getClientSecret(), *sds_stream_);
+
+  // After SDS secrets are delivered, health checks should start.
+  test_server_->waitForCounterGe("cluster.dynamic.health_check.attempt", 1);
+
+  // Clean up.
+  sendDiscoveryResponse<envoy::config::cluster::v3::Cluster>(Config::TestTypeUrl::get().Cluster, {},
+                                                             {}, {}, "42");
+  test_server_->waitForGaugeEq("cluster_manager.active_clusters", 2);
+}
+
+// This test verifies that with the runtime guard DISABLED, health checks starts and cluster becomes
+// unhealthy immediately.
+TEST_P(SdsDynamicClusterIntegrationTest, ClusterWarmingWhileHealthCheckBlocksOnSdsDisabled) {
+  config_helper_.addRuntimeOverride("envoy.reloadable_features.health_check_after_cluster_warming",
+                                    "false");
+  defer_listener_finalization_ = true;
+
+  on_server_init_function_ = [this]() {
+    AssertionResult result = cdsUpstream()->waitForHttpConnection(*dispatcher_, xds_connection_);
+    RELEASE_ASSERT(result, result.message());
+    result = xds_connection_->waitForNewStream(*dispatcher_, xds_stream_);
+    RELEASE_ASSERT(result, result.message());
+    xds_stream_->startGrpcStream();
+
+    // Add health check to the dynamic cluster.
+    auto* health_check = dynamic_cluster_.add_health_checks();
+    health_check->mutable_timeout()->set_seconds(5);
+    health_check->mutable_interval()->CopyFrom(ProtobufUtil::TimeUtil::MillisecondsToDuration(100));
+    health_check->mutable_no_traffic_interval()->CopyFrom(
+        ProtobufUtil::TimeUtil::MillisecondsToDuration(100));
+    health_check->mutable_unhealthy_threshold()->set_value(1);
+    health_check->mutable_healthy_threshold()->set_value(1);
+    health_check->mutable_tcp_health_check();
+
+    // Send CDS response with both SDS cluster and dynamic cluster.
+    // The dynamic cluster will start warming, waiting for SDS.
+    sendCdsResponse();
+
+    // Wait for SDS connection to be established.
+    result = sdsUpstream()->waitForHttpConnection(*dispatcher_, sds_connection_);
+    RELEASE_ASSERT(result, result.message());
+    result = sds_connection_->waitForNewStream(*dispatcher_, sds_stream_);
+    RELEASE_ASSERT(result, result.message());
+    sds_stream_->startGrpcStream();
+
+    // Do NOT send SDS response yet - cluster should remain warming.
+  };
+  sds_cluster_name_ = "sds_dynamic_cluster.lyft.com";
+
+  // The defer_listener_finalization_ = true above ensures that initialize() does not block
+  // even though the dynamic cluster is warming while waiting for SDS.
+  initialize();
+
+  // Wait for the dynamic cluster to exist and be in warming state.
+  test_server_->waitForGaugeEq("cluster.dynamic.warming_state", 1);
+
+  // With the runtime guard DISABLED, health checks start immediately (old behavior).
+  test_server_->waitForCounterGe("cluster.dynamic.health_check.attempt", 1);
+  test_server_->waitForGaugeEq("cluster.dynamic.membership_healthy", 0);
+
+  // Now send the SDS response with actual client certificate.
+  sendSdsResponse2(getClientSecret(), *sds_stream_);
+
+  // After SDS secrets are delivered, the cluster finishes warming.
+  test_server_->waitForGaugeEq("cluster.dynamic.warming_state", 0);
+
+  // Clean up.
+  sendDiscoveryResponse<envoy::config::cluster::v3::Cluster>(Config::TestTypeUrl::get().Cluster, {},
+                                                             {}, {}, "42");
+  test_server_->waitForGaugeEq("cluster_manager.active_clusters", 2);
+}
+
 class SdsDynamicDownstreamPrivateKeyIntegrationTest : public SdsDynamicDownstreamIntegrationTest {
 public:
   envoy::extensions::transport_sockets::tls::v3::Secret getCurrentServerPrivateKeyProviderSecret() {


### PR DESCRIPTION
Backport of the original #43277. Below text is copied from there:

Fixes https://github.com/envoyproxy/envoy/issues/43116

Commit Message: healthcheck: defer health check until cluster finishes warming

Additional Description:
Active health checks started before the cluster finished initializing, causing failures when the cluster required SDS secrets for upstream connections. Health checks failed because the transport socket configuration was not ready, leading to intermittent failures at startup and when recreating the cluster to update the SDS reference, such as during certificate rotation..

See https://github.com/envoyproxy/envoy/issues/43116 for full problem description.

This change defers the start of health checks until the cluster has finished warming, ensuring that all necessary configurations (including SDS secrets) are fetched before checks begin.

Risk Level: Low

Testing:
Added test to verify that health checks are deferred until the cluster warming state is cleared.

Docs Changes: N/A

Release Notes:
health_check: Fixed a race condition where active health checks could start before required upstream TLS SDS secrets were fetched, causing intermittent health check failures.

Platform Specific Features: N/A
