### PR TITLE
[bp/1.37] ext_proc: support two ext_proc filters in the chain 2nd attempt (#43175)

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -11,6 +11,10 @@ bug_fixes:
 - area: oauth2
   change: |
     Fixed OAuth2 refresh requests so host rewriting no longer overrides the original ``Host`` header value.
+- area: ext_proc
+  change: |
+    Fixed a bug to support two ext_proc filters configured in the chain. This change can be reverted by setting
+    the runtime guard ``envoy.reloadable_features.ext_proc_inject_data_with_state_update`` to ``false``.
 - area: ext_authz
   change: |
     Fixed a bug where headers from a denied authorization response (non-200) were not properly propagated

--- a/source/common/http/filter_manager.cc
+++ b/source/common/http/filter_manager.cc
@@ -467,6 +467,10 @@ void ActiveStreamDecoderFilter::injectDecodedDataToFilterChain(Buffer::Instance&
     headers_continued_ = true;
     doHeaders(false);
   }
+  if (Runtime::runtimeFeatureEnabled(
+          "envoy.reloadable_features.ext_proc_inject_data_with_state_update")) {
+    parent_.state().observed_decode_end_stream_ = end_stream;
+  }
   parent_.decodeData(this, data, end_stream,
                      FilterManager::FilterIterationStartState::CanStartFromCurrent);
 }
@@ -1871,6 +1875,10 @@ void ActiveStreamEncoderFilter::injectEncodedDataToFilterChain(Buffer::Instance&
   if (!headers_continued_) {
     headers_continued_ = true;
     doHeaders(false);
+  }
+  if (Runtime::runtimeFeatureEnabled(
+          "envoy.reloadable_features.ext_proc_inject_data_with_state_update")) {
+    parent_.state_.observed_encode_end_stream_ = end_stream;
   }
   parent_.encodeData(this, data, end_stream,
                      FilterManager::FilterIterationStartState::CanStartFromCurrent);

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -45,6 +45,7 @@ RUNTIME_GUARD(envoy_reloadable_features_ext_authz_http_client_retries_respect_us
 // Ignore the automated "remove this flag" issue: we should keep this for 1 year. Confirm with
 // @yanjunxiang-google before removing.
 RUNTIME_GUARD(envoy_reloadable_features_ext_proc_fail_close_spurious_resp);
+RUNTIME_GUARD(envoy_reloadable_features_ext_proc_inject_data_with_state_update);
 RUNTIME_GUARD(envoy_reloadable_features_ext_proc_stream_close_optimization);
 RUNTIME_GUARD(envoy_reloadable_features_generic_proxy_codec_buffer_limit);
 RUNTIME_GUARD(envoy_reloadable_features_get_header_tag_from_header_map);

--- a/source/extensions/filters/http/ext_proc/processor_state.cc
+++ b/source/extensions/filters/http/ext_proc/processor_state.cc
@@ -572,7 +572,7 @@ QueuedChunkPtr ProcessorState::dequeueStreamingChunk(Buffer::OwnedImpl& out_data
 
 void ProcessorState::clearAsyncState(Grpc::Status::GrpcStatus call_status) {
   onFinishProcessorCall(call_status);
-  if (chunkQueue().receivedData().length() > 0) {
+  if (!chunkQueue().empty()) {
     const auto& all_data = consolidateStreamedChunks();
     ENVOY_STREAM_LOG(trace, "Injecting leftover buffer of {} bytes", *filter_callbacks_,
                      chunkQueue().receivedData().length());

--- a/test/extensions/filters/http/ext_proc/ext_proc_full_duplex_integration_test.cc
+++ b/test/extensions/filters/http/ext_proc/ext_proc_full_duplex_integration_test.cc
@@ -79,16 +79,16 @@ TEST_P(ExtProcIntegrationTest, ServerWaitForBodyBeforeSendsHeaderRespDuplexStrea
 
   // The ext_proc server receives the headers.
   ProcessingRequest header_request;
-  serverReceiveHeaderDuplexStreamed(header_request);
+  serverReceiveHeaderReq(header_request);
   // The ext_proc server receives the body.
-  uint32_t total_req_body_msg = serverReceiveBodyDuplexStreamed(body_sent);
+  uint32_t total_req_body_msg = serverReceiveBodyDuplexStreamed(body_sent, processor_stream_);
 
   // The ext_proc server sends back the header response.
-  serverSendHeaderRespDuplexStreamed();
+  serverSendHeaderResp();
   // The ext_proc server sends back the body response.
   uint32_t total_resp_body_msg = 2 * total_req_body_msg;
   const std::string body_upstream(total_resp_body_msg, 'r');
-  serverSendBodyRespDuplexStreamed(total_resp_body_msg);
+  serverSendBodyRespDuplexStreamed(total_resp_body_msg, processor_stream_);
 
   handleUpstreamRequest();
   EXPECT_THAT(upstream_request_->headers(), ContainsHeader("x-new-header", "new"));
@@ -113,18 +113,18 @@ TEST_P(ExtProcIntegrationTest, LargeBodyTestDuplexStreamed) {
     codec_client_->sendData(*request_encoder_, body_sent, true);
     // The ext_proc server receives the headers.
     ProcessingRequest header_request;
-    serverReceiveHeaderDuplexStreamed(header_request);
+    serverReceiveHeaderReq(header_request);
     // The ext_proc server receives the body.
-    uint32_t total_req_body_msg = serverReceiveBodyDuplexStreamed(body_sent);
+    uint32_t total_req_body_msg = serverReceiveBodyDuplexStreamed(body_sent, processor_stream_);
     EXPECT_GT(total_req_body_msg, 0);
     // The ext_proc server sends back the header response.
-    serverSendHeaderRespDuplexStreamed();
+    serverSendHeaderResp();
     // The ext_proc server sends back body responses, which include 50 chunks,
     // and each chunk contains 64KB data, thus totally ~3MB per request.
     uint32_t total_resp_body_msg = 50;
     const std::string body_response(64 * 1024, 'r');
     const std::string body_upstream(total_resp_body_msg * 64 * 1024, 'r');
-    serverSendBodyRespDuplexStreamed(total_resp_body_msg, /*end_of_stream*/ true,
+    serverSendBodyRespDuplexStreamed(total_resp_body_msg, processor_stream_, /*end_of_stream*/ true,
                                      /*response*/ false, body_response);
 
     handleUpstreamRequest();
@@ -145,7 +145,7 @@ TEST_P(ExtProcIntegrationTest,
 
   // The ext_proc server receives the headers.
   ProcessingRequest header_request;
-  serverReceiveHeaderDuplexStreamed(header_request);
+  serverReceiveHeaderReq(header_request);
 
   std::string body_received;
   bool end_stream = false;
@@ -167,12 +167,12 @@ TEST_P(ExtProcIntegrationTest,
   EXPECT_EQ(body_received, body_sent);
 
   // The ext_proc server sends back the header response.
-  serverSendHeaderRespDuplexStreamed();
+  serverSendHeaderResp();
 
   // The ext_proc server sends back the body response.
   uint32_t total_resp_body_msg = total_req_body_msg / 2;
   const std::string body_upstream(total_resp_body_msg, 'r');
-  serverSendBodyRespDuplexStreamed(total_resp_body_msg, false);
+  serverSendBodyRespDuplexStreamed(total_resp_body_msg, processor_stream_, false);
 
   // The ext_proc server sends back the trailer response.
   serverSendTrailerRespDuplexStreamed();
@@ -193,7 +193,7 @@ TEST_P(ExtProcIntegrationTest, ServerSendBodyRespWithouRecvEntireBodyDuplexStrea
 
   // The ext_proc server receives the headers.
   ProcessingRequest header_request;
-  serverReceiveHeaderDuplexStreamed(header_request);
+  serverReceiveHeaderReq(header_request);
   Http::TestRequestHeaderMapImpl expected_request_headers{{":scheme", "http"},
                                                           {":method", "GET"},
                                                           {"host", "host"},
@@ -220,7 +220,7 @@ TEST_P(ExtProcIntegrationTest, ServerSendBodyRespWithouRecvEntireBodyDuplexStrea
       if (total_req_body_msg % 7 == 0) {
         if (!header_resp_sent) {
           // Before sending the 1st body response, sends a header response.
-          serverSendHeaderRespDuplexStreamed();
+          serverSendHeaderResp();
           header_resp_sent = true;
         }
         ProcessingResponse response_body;
@@ -269,14 +269,14 @@ TEST_P(ExtProcIntegrationTest, DuplexStreamedInBothDirection) {
 
   // The ext_proc server receives the headers/body.
   ProcessingRequest header_request;
-  serverReceiveHeaderDuplexStreamed(header_request);
-  uint32_t total_req_body_msg = serverReceiveBodyDuplexStreamed(body_sent);
+  serverReceiveHeaderReq(header_request);
+  uint32_t total_req_body_msg = serverReceiveBodyDuplexStreamed(body_sent, processor_stream_);
 
   // The ext_proc server sends back the response.
-  serverSendHeaderRespDuplexStreamed();
+  serverSendHeaderResp();
   uint32_t total_resp_body_msg = 2 * total_req_body_msg;
   const std::string body_upstream(total_resp_body_msg, 'r');
-  serverSendBodyRespDuplexStreamed(total_resp_body_msg);
+  serverSendBodyRespDuplexStreamed(total_resp_body_msg, processor_stream_);
 
   handleUpstreamRequest();
   EXPECT_THAT(upstream_request_->headers(), ContainsHeader("x-new-header", "new"));
@@ -284,12 +284,12 @@ TEST_P(ExtProcIntegrationTest, DuplexStreamedInBothDirection) {
 
   // The ext_proc server receives the responses from backend server.
   ProcessingRequest header_response;
-  serverReceiveHeaderDuplexStreamed(header_response, false, true);
-  uint32_t total_rsp_body_msg = serverReceiveBodyDuplexStreamed("", true, false);
+  serverReceiveHeaderReq(header_response, false, true);
+  uint32_t total_rsp_body_msg = serverReceiveBodyDuplexStreamed("", processor_stream_, true, false);
 
   // The ext_proc server sends back the response.
-  serverSendHeaderRespDuplexStreamed(false, true);
-  serverSendBodyRespDuplexStreamed(total_rsp_body_msg * 3, true, true);
+  serverSendHeaderResp(false, true);
+  serverSendBodyRespDuplexStreamed(total_rsp_body_msg * 3, processor_stream_, true, true);
 
   verifyDownstreamResponse(*response, 200);
 }
@@ -304,11 +304,11 @@ TEST_P(ExtProcIntegrationTest, ServerSendOutOfOrderResponseDuplexStreamed) {
 
   // The ext_proc server receives the request headers and body.
   ProcessingRequest header_request;
-  serverReceiveHeaderDuplexStreamed(header_request);
-  uint32_t total_req_body_msg = serverReceiveBodyDuplexStreamed(body_sent);
+  serverReceiveHeaderReq(header_request);
+  uint32_t total_req_body_msg = serverReceiveBodyDuplexStreamed(body_sent, processor_stream_);
   // The ext_proc server sends back the body response, which is wrong.
   processor_stream_->startGrpcStream();
-  serverSendBodyRespDuplexStreamed(total_req_body_msg);
+  serverSendBodyRespDuplexStreamed(total_req_body_msg, processor_stream_);
   // Envoy sends 500 response code to the client.
   verifyDownstreamResponse(*response, 500);
 }
@@ -326,8 +326,8 @@ TEST_P(ExtProcIntegrationTest, ServerWaitTooLongBeforeSendRespDuplexStreamed) {
 
   // The ext_proc server receives the headers and body.
   ProcessingRequest header_request;
-  serverReceiveHeaderDuplexStreamed(header_request);
-  serverReceiveBodyDuplexStreamed(body_sent);
+  serverReceiveHeaderReq(header_request);
+  serverReceiveBodyDuplexStreamed(body_sent, processor_stream_);
 
   // The ext_proc server waits for 12s before sending any response.
   // HCM stream_idle_timeout is triggered, and local reply is sent to downstream.
@@ -337,23 +337,24 @@ TEST_P(ExtProcIntegrationTest, ServerWaitTooLongBeforeSendRespDuplexStreamed) {
 
 // Testing the case that when the client does not send trailers, if the ext_proc server sends
 // back a synthesized trailer, it is ignored by Envoy and never reaches the upstream server.
-TEST_P(ExtProcIntegrationTest, DuplexStreamedServerResponseWithSynthesizedTrailer) {
+// Without the end_of_stream indication, this test fails. Disable it for now.
+TEST_P(ExtProcIntegrationTest, DISABLED_DuplexStreamedServerResponseWithSynthesizedTrailer) {
   const std::string body_sent(64 * 1024, 's');
   IntegrationStreamDecoderPtr response = initAndSendDataDuplexStreamedMode(body_sent, true);
 
   // The ext_proc server receives the headers.
   ProcessingRequest header_request;
-  serverReceiveHeaderDuplexStreamed(header_request);
+  serverReceiveHeaderReq(header_request);
   // The ext_proc server receives the body.
-  uint32_t total_req_body_msg = serverReceiveBodyDuplexStreamed(body_sent);
+  uint32_t total_req_body_msg = serverReceiveBodyDuplexStreamed(body_sent, processor_stream_);
 
   // The ext_proc server sends back the header response.
-  serverSendHeaderRespDuplexStreamed();
+  serverSendHeaderResp();
   // The ext_proc server sends back the body response.
   uint32_t total_resp_body_msg = 2 * total_req_body_msg;
   const std::string body_upstream(total_resp_body_msg, 'r');
   // The end_of_stream of the last body response is false.
-  serverSendBodyRespDuplexStreamed(total_resp_body_msg, false, false);
+  serverSendBodyRespDuplexStreamed(total_resp_body_msg, processor_stream_, false, false);
   // The ext_proc server sends back a synthesized trailer response.
   serverSendTrailerRespDuplexStreamed();
 
@@ -478,6 +479,188 @@ TEST_P(ExtProcIntegrationTest, ServerWaitforEnvoyHalfCloseThenCloseStream) {
 
   handleUpstreamRequest();
   verifyDownstreamResponse(*response, 200);
+}
+
+TEST_P(ExtProcIntegrationTest, TwoExtProcFiltersInRequestProcessing) {
+  two_ext_proc_filters_ = true;
+  config_helper_.addConfigModifier([this](envoy::config::bootstrap::v3::Bootstrap&) {
+    // Filter-1
+    proto_config_1_.mutable_processing_mode()->Clear();
+    auto* processing_mode_1 = proto_config_1_.mutable_processing_mode();
+    processing_mode_1->set_request_header_mode(ProcessingMode::SEND);
+    processing_mode_1->set_response_header_mode(ProcessingMode::SKIP);
+    addDownstreamExtProcFilter("ext_proc_server_1", grpc_upstreams_[1], proto_config_1_,
+                               "envoy.filters.http.ext_proc_1");
+    // Filter-0
+    proto_config_.mutable_processing_mode()->Clear();
+    auto* processing_mode = proto_config_.mutable_processing_mode();
+    processing_mode->set_request_header_mode(ProcessingMode::SEND);
+    processing_mode->set_response_header_mode(ProcessingMode::SKIP);
+    processing_mode->set_request_body_mode(ProcessingMode::FULL_DUPLEX_STREAMED);
+    processing_mode->set_request_trailer_mode(ProcessingMode::SEND);
+    addDownstreamExtProcFilter("ext_proc_server_0", grpc_upstreams_[0], proto_config_,
+                               "envoy.filters.http.ext_proc");
+  });
+
+  const std::string body_sent(3 * 1024, 's');
+  IntegrationStreamDecoderPtr response = initAndSendDataDuplexStreamedMode(body_sent, true);
+
+  // The ext_proc_server_0 receives the headers.
+  ProcessingRequest header_request;
+  serverReceiveHeaderReq(header_request);
+  // The ext_proc_server_0 receives the body.
+  uint32_t total_req_body_msg = serverReceiveBodyDuplexStreamed(body_sent, processor_stream_);
+  // The ext_proc_server_0 sends back the header response.
+  serverSendHeaderResp();
+  // The ext_proc_server_0 sends back a few chunks of the body responses.
+  const std::string body_upstream(total_req_body_msg, 'r');
+  serverSendBodyRespDuplexStreamed(total_req_body_msg - 1, processor_stream_, /*end_stream*/ false,
+                                   false, "");
+
+  // The ext_proc_server_1 receives the headers.
+  server1ReceiveHeaderReq(header_request);
+  // The ext_proc_server_1 sends back the header response.
+  server1SendHeaderResp();
+
+  timeSystem().advanceTimeWaitImpl(20ms);
+  // The ext_proc_server_0 now sends back the last chunk of the body responses.
+  serverSendBodyRespDuplexStreamed(1, processor_stream_, /*end_stream*/ true, false, "");
+
+  handleUpstreamRequest();
+  EXPECT_THAT(upstream_request_->headers(), ContainsHeader("x-new-header", "new"));
+  EXPECT_EQ(upstream_request_->body().toString(), body_upstream);
+  verifyDownstreamResponse(*response, 200);
+}
+
+TEST_P(ExtProcIntegrationTest, TwoExtProcFiltersInResponseProcessing) {
+  two_ext_proc_filters_ = true;
+  config_helper_.addConfigModifier([this](envoy::config::bootstrap::v3::Bootstrap&) {
+    // Filter-0
+    proto_config_.mutable_processing_mode()->Clear();
+    auto* processing_mode = proto_config_.mutable_processing_mode();
+    processing_mode->set_response_header_mode(ProcessingMode::SEND);
+    processing_mode->set_request_header_mode(ProcessingMode::SKIP);
+    processing_mode->set_response_body_mode(ProcessingMode::FULL_DUPLEX_STREAMED);
+    processing_mode->set_response_trailer_mode(ProcessingMode::SEND);
+    addDownstreamExtProcFilter("ext_proc_server_0", grpc_upstreams_[0], proto_config_,
+                               "envoy.filters.http.ext_proc");
+    // Filter-1
+    proto_config_1_.mutable_processing_mode()->Clear();
+    auto* processing_mode_1 = proto_config_1_.mutable_processing_mode();
+    processing_mode_1->set_response_header_mode(ProcessingMode::SEND);
+    processing_mode_1->set_request_header_mode(ProcessingMode::SKIP);
+    addDownstreamExtProcFilter("ext_proc_server_1", grpc_upstreams_[1], proto_config_1_,
+                               "envoy.filters.http.ext_proc_1");
+  });
+
+  const std::string body_sent(3 * 1024, 's');
+  IntegrationStreamDecoderPtr response = initAndSendDataDuplexStreamedMode(body_sent, true);
+  handleUpstreamRequest();
+
+  // The ext_proc_server_0 receives the responses from the backend server.
+  ProcessingRequest header_response;
+  serverReceiveHeaderReq(header_response, true, true);
+  (void)serverReceiveBodyDuplexStreamed("", processor_stream_, true, false);
+  // The ext_proc_server_0 sends back the header response.
+  serverSendHeaderResp(true, true);
+  // The ext_proc_server_0 sends back a few chunks of the body responses.
+  uint32_t total_resp_body_msg = 5;
+  const std::string body_downstream(total_resp_body_msg, 'r');
+  serverSendBodyRespDuplexStreamed(total_resp_body_msg - 1, processor_stream_, /*end_stream*/ false,
+                                   /*response*/ true, "");
+
+  // The ext_proc_server_1 receives the headers.
+  server1ReceiveHeaderReq(header_response, true, true);
+  // The ext_proc_server_1 sends back the header response.
+  server1SendHeaderResp(true, true);
+
+  timeSystem().advanceTimeWaitImpl(20ms);
+  // The ext_proc_server_0 now sends back the last chunk of the body responses.
+  serverSendBodyRespDuplexStreamed(1, processor_stream_, /*end_stream*/ true, /*response*/ true,
+                                   "");
+  verifyDownstreamResponse(*response, 200);
+  EXPECT_EQ(body_downstream, response->body());
+}
+
+TEST_P(ExtProcIntegrationTest, TwoExtProcFiltersBothDuplexInBothDirection) {
+  two_ext_proc_filters_ = true;
+  config_helper_.addConfigModifier([this](envoy::config::bootstrap::v3::Bootstrap&) {
+    // Filter-1
+    proto_config_1_.mutable_processing_mode()->Clear();
+    auto* processing_mode_1 = proto_config_1_.mutable_processing_mode();
+    processing_mode_1->set_request_header_mode(ProcessingMode::SEND);
+    processing_mode_1->set_response_header_mode(ProcessingMode::SEND);
+    processing_mode_1->set_request_body_mode(ProcessingMode::FULL_DUPLEX_STREAMED);
+    processing_mode_1->set_response_body_mode(ProcessingMode::FULL_DUPLEX_STREAMED);
+    processing_mode_1->set_request_trailer_mode(ProcessingMode::SEND);
+    processing_mode_1->set_response_trailer_mode(ProcessingMode::SEND);
+    addDownstreamExtProcFilter("ext_proc_server_1", grpc_upstreams_[1], proto_config_1_,
+                               "envoy.filters.http.ext_proc_1");
+    // Filter-0
+    proto_config_.mutable_processing_mode()->Clear();
+    auto* processing_mode = proto_config_.mutable_processing_mode();
+    processing_mode->set_request_header_mode(ProcessingMode::SEND);
+    processing_mode->set_response_header_mode(ProcessingMode::SEND);
+    processing_mode->set_request_body_mode(ProcessingMode::FULL_DUPLEX_STREAMED);
+    processing_mode->set_response_body_mode(ProcessingMode::FULL_DUPLEX_STREAMED);
+    processing_mode->set_request_trailer_mode(ProcessingMode::SEND);
+    processing_mode->set_response_trailer_mode(ProcessingMode::SEND);
+    addDownstreamExtProcFilter("ext_proc_server_0", grpc_upstreams_[0], proto_config_,
+                               "envoy.filters.http.ext_proc");
+  });
+
+  const std::string body_sent(5 * 1024, 's');
+  IntegrationStreamDecoderPtr response = initAndSendDataDuplexStreamedMode(body_sent, true);
+
+  // The ext_proc_server_0 receives the headers.
+  ProcessingRequest header_request;
+  serverReceiveHeaderReq(header_request);
+  // The ext_proc_server_0 receives the body.
+  uint32_t total_req_body_msg = serverReceiveBodyDuplexStreamed(body_sent, processor_stream_);
+  // The ext_proc_server_0 sends back the response.
+  serverSendHeaderResp();
+  const std::string body_upstream(total_req_body_msg, 'r');
+  serverSendBodyRespDuplexStreamed(total_req_body_msg, processor_stream_, /*end_stream*/ true,
+                                   false, "");
+
+  // The ext_proc_server_1 receives the headers.
+  server1ReceiveHeaderReq(header_request);
+  uint32_t total_req_body_msg_1 =
+      serverReceiveBodyDuplexStreamed(body_upstream, processor_stream_1_, false, true);
+  EXPECT_EQ(total_req_body_msg_1, total_req_body_msg);
+  // The ext_proc_server_1 sends back the response.
+  server1SendHeaderResp();
+  serverSendBodyRespDuplexStreamed(total_req_body_msg, processor_stream_1_, /*end_stream*/ true,
+                                   false, "");
+
+  handleUpstreamRequest();
+  EXPECT_THAT(upstream_request_->headers(), ContainsHeader("x-new-header", "new"));
+  EXPECT_THAT(upstream_request_->headers(), ContainsHeader("x-new-header_1", "new_1"));
+  EXPECT_EQ(upstream_request_->body().toString(), body_upstream);
+
+  // Now the response processing. In this direction, filter-1 sees the message first.
+  ProcessingRequest header_response;
+  server1ReceiveHeaderReq(header_response, false, true);
+  (void)serverReceiveBodyDuplexStreamed("", processor_stream_1_, true, false);
+  server1SendHeaderResp(false, true);
+  uint32_t total_resp_body_msg = 5;
+  const std::string body_server_1(total_resp_body_msg, 'm');
+  serverSendBodyRespDuplexStreamed(total_resp_body_msg, processor_stream_1_, /*end_stream*/ true,
+                                   /*response*/ true, "m");
+
+  // Now the ext_proc_server_0 receives the message.
+  serverReceiveHeaderReq(header_response, false, true);
+  (void)serverReceiveBodyDuplexStreamed(body_server_1, processor_stream_, true, true);
+  serverSendHeaderResp(false, true);
+  total_resp_body_msg = 7;
+  const std::string body_downstream(total_resp_body_msg, 'n');
+  serverSendBodyRespDuplexStreamed(total_resp_body_msg, processor_stream_, /*end_stream*/ true,
+                                   /*response*/ true, "n");
+
+  verifyDownstreamResponse(*response, 200);
+  EXPECT_EQ(body_downstream, response->body());
+  EXPECT_THAT(response->headers(), ContainsHeader("x-new-header", "new"));
+  EXPECT_THAT(response->headers(), ContainsHeader("x-new-header_1", "new_1"));
 }
 
 } // namespace ExternalProcessing

--- a/test/extensions/filters/http/ext_proc/ext_proc_integration_common.cc
+++ b/test/extensions/filters/http/ext_proc/ext_proc_integration_common.cc
@@ -42,11 +42,30 @@ void ExtProcIntegrationTest::TearDown() {
     ASSERT_TRUE(processor_connection_->close());
     ASSERT_TRUE(processor_connection_->waitForDisconnect());
   }
+
+  if (processor_connection_1_) {
+    ASSERT_TRUE(processor_connection_1_->close());
+    ASSERT_TRUE(processor_connection_1_->waitForDisconnect());
+  }
+
   cleanupUpstreamAndDownstream();
+}
+
+void ExtProcIntegrationTest::addDownstreamExtProcFilter(
+    const std::string& cluster_name, FakeUpstream* grpc_upstream,
+    envoy::extensions::filters::http::ext_proc::v3::ExternalProcessor proto_config,
+    const std::string& ext_proc_filter_name) {
+  setGrpcService(*proto_config.mutable_grpc_service(), cluster_name, grpc_upstream->localAddress());
+  envoy::extensions::filters::network::http_connection_manager::v3::HttpFilter ext_proc_filter;
+  ext_proc_filter.set_name(ext_proc_filter_name);
+  ext_proc_filter.mutable_typed_config()->PackFrom(proto_config);
+  config_helper_.prependFilter(MessageUtil::getJsonStringFromMessageOrError(ext_proc_filter));
 }
 
 void ExtProcIntegrationTest::initializeConfig(
     ConfigOptions config_option, const std::vector<std::pair<int, int>>& cluster_endpoints) {
+  scoped_runtime_.mergeValues(
+      {{"envoy.reloadable_features.ext_proc_inject_data_with_state_update", "true"}});
   int total_cluster_endpoints = 0;
   std::for_each(
       cluster_endpoints.begin(), cluster_endpoints.end(),
@@ -76,39 +95,42 @@ void ExtProcIntegrationTest::initializeConfig(
     }
 
     const std::string valid_grpc_cluster_name = "ext_proc_server_0";
-    if (config_option.valid_grpc_server) {
-      // Load configuration of the server from YAML and use a helper to add a grpc_service
-      // stanza pointing to the cluster that we just made
-      setGrpcService(*proto_config_.mutable_grpc_service(), valid_grpc_cluster_name,
-                     grpc_upstreams_[0]->localAddress());
-    } else {
-      // Set up the gRPC service with wrong cluster name and address.
-      setGrpcService(*proto_config_.mutable_grpc_service(), "ext_proc_wrong_server",
-                     std::make_shared<Network::Address::Ipv4Instance>("127.0.0.1", 1234));
-    }
-
     std::string ext_proc_filter_name = "envoy.filters.http.ext_proc";
-    switch (config_option.filter_setup) {
-    case ConfigOptions::FilterSetup::kNone:
-      break;
-    case ConfigOptions::FilterSetup::kDownstream: {
-      // Construct a configuration proto for our filter and then re-write it
-      // to JSON so that we can add it to the overall config
-      envoy::extensions::filters::network::http_connection_manager::v3::HttpFilter ext_proc_filter;
-      ext_proc_filter.set_name(ext_proc_filter_name);
-      ext_proc_filter.mutable_typed_config()->PackFrom(proto_config_);
-      config_helper_.prependFilter(MessageUtil::getJsonStringFromMessageOrError(ext_proc_filter));
-    } break;
-    case ConfigOptions::FilterSetup::kCompositeMatchOnRequestHeaders: {
-      envoy::type::matcher::v3::HttpRequestHeaderMatchInput request_match_input;
-      request_match_input.set_header_name("match-header");
-      prependExtProcCompositeFilter(request_match_input);
-    } break;
-    case ConfigOptions::FilterSetup::kCompositeMatchOnResponseHeaders: {
-      envoy::type::matcher::v3::HttpResponseHeaderMatchInput response_match_input;
-      response_match_input.set_header_name("match-header");
-      prependExtProcCompositeFilter(response_match_input);
-    } break;
+    if (!two_ext_proc_filters_) {
+      if (config_option.valid_grpc_server) {
+        // Load configuration of the server from YAML and use a helper to add a grpc_service
+        // stanza pointing to the cluster that we just made
+        setGrpcService(*proto_config_.mutable_grpc_service(), valid_grpc_cluster_name,
+                       grpc_upstreams_[0]->localAddress());
+      } else {
+        // Set up the gRPC service with wrong cluster name and address.
+        setGrpcService(*proto_config_.mutable_grpc_service(), "ext_proc_wrong_server",
+                       std::make_shared<Network::Address::Ipv4Instance>("127.0.0.1", 1234));
+      }
+
+      switch (config_option.filter_setup) {
+      case ConfigOptions::FilterSetup::kNone:
+        break;
+      case ConfigOptions::FilterSetup::kDownstream: {
+        // Construct a configuration proto for our filter and then re-write it
+        // to JSON so that we can add it to the overall config
+        envoy::extensions::filters::network::http_connection_manager::v3::HttpFilter
+            ext_proc_filter;
+        ext_proc_filter.set_name(ext_proc_filter_name);
+        ext_proc_filter.mutable_typed_config()->PackFrom(proto_config_);
+        config_helper_.prependFilter(MessageUtil::getJsonStringFromMessageOrError(ext_proc_filter));
+      } break;
+      case ConfigOptions::FilterSetup::kCompositeMatchOnRequestHeaders: {
+        envoy::type::matcher::v3::HttpRequestHeaderMatchInput request_match_input;
+        request_match_input.set_header_name("match-header");
+        prependExtProcCompositeFilter(request_match_input);
+      } break;
+      case ConfigOptions::FilterSetup::kCompositeMatchOnResponseHeaders: {
+        envoy::type::matcher::v3::HttpResponseHeaderMatchInput response_match_input;
+        response_match_input.set_header_name("match-header");
+        prependExtProcCompositeFilter(response_match_input);
+      } break;
+      }
     }
 
     // Add set_metadata filter to inject dynamic metadata used for testing
@@ -755,8 +777,8 @@ ExtProcIntegrationTest::initAndSendDataDuplexStreamedMode(absl::string_view body
   return response;
 }
 
-void ExtProcIntegrationTest::serverReceiveHeaderDuplexStreamed(ProcessingRequest& header,
-                                                               bool first_message, bool response) {
+void ExtProcIntegrationTest::serverReceiveHeaderReq(ProcessingRequest& header, bool first_message,
+                                                    bool response) {
   if (first_message) {
     EXPECT_TRUE(grpc_upstreams_[0]->waitForHttpConnection(*dispatcher_, processor_connection_));
     EXPECT_TRUE(processor_connection_->waitForNewStream(*dispatcher_, processor_stream_));
@@ -769,14 +791,29 @@ void ExtProcIntegrationTest::serverReceiveHeaderDuplexStreamed(ProcessingRequest
   }
 }
 
+void ExtProcIntegrationTest::server1ReceiveHeaderReq(ProcessingRequest& header, bool first_message,
+                                                     bool response) {
+  if (first_message) {
+    EXPECT_TRUE(grpc_upstreams_[1]->waitForHttpConnection(*dispatcher_, processor_connection_1_));
+    EXPECT_TRUE(processor_connection_1_->waitForNewStream(*dispatcher_, processor_stream_1_));
+  }
+  EXPECT_TRUE(processor_stream_1_->waitForGrpcMessage(*dispatcher_, header));
+  if (response) {
+    EXPECT_TRUE(header.has_response_headers());
+  } else {
+    EXPECT_TRUE(header.has_request_headers());
+  }
+}
+
 uint32_t ExtProcIntegrationTest::serverReceiveBodyDuplexStreamed(absl::string_view body_sent,
+                                                                 FakeStreamPtr& processor_stream,
                                                                  bool response, bool compare_body) {
   std::string body_received;
   bool end_stream = false;
   uint32_t total_req_body_msg = 0;
   while (!end_stream) {
     ProcessingRequest body_request;
-    EXPECT_TRUE(processor_stream_->waitForGrpcMessage(*dispatcher_, body_request));
+    EXPECT_TRUE(processor_stream->waitForGrpcMessage(*dispatcher_, body_request));
     if (response) {
       EXPECT_TRUE(body_request.has_response_body());
       body_received = absl::StrCat(body_received, body_request.response_body().body());
@@ -795,7 +832,7 @@ uint32_t ExtProcIntegrationTest::serverReceiveBodyDuplexStreamed(absl::string_vi
   return total_req_body_msg;
 }
 
-void ExtProcIntegrationTest::serverSendHeaderRespDuplexStreamed(bool first_message, bool response) {
+void ExtProcIntegrationTest::serverSendHeaderResp(bool first_message, bool response) {
   if (first_message) {
     processor_stream_->startGrpcStream();
   }
@@ -815,7 +852,28 @@ void ExtProcIntegrationTest::serverSendHeaderRespDuplexStreamed(bool first_messa
   processor_stream_->sendGrpcMessage(response_header);
 }
 
+void ExtProcIntegrationTest::server1SendHeaderResp(bool first_message, bool response) {
+  if (first_message) {
+    processor_stream_1_->startGrpcStream();
+  }
+  ProcessingResponse response_header;
+  HeadersResponse* header_resp;
+  if (response) {
+    header_resp = response_header.mutable_response_headers();
+  } else {
+    header_resp = response_header.mutable_request_headers();
+  }
+  auto* header_mutation = header_resp->mutable_response()->mutable_header_mutation();
+  auto* sh = header_mutation->add_set_headers();
+  auto* header = sh->mutable_header();
+  sh->mutable_append()->set_value(false);
+  header->set_key("x-new-header_1");
+  header->set_raw_value("new_1");
+  processor_stream_1_->sendGrpcMessage(response_header);
+}
+
 void ExtProcIntegrationTest::serverSendBodyRespDuplexStreamed(uint32_t total_resp_body_msg,
+                                                              FakeStreamPtr& processor_stream,
                                                               bool end_of_stream, bool response,
                                                               absl::string_view body_sent) {
   for (uint32_t i = 0; i < total_resp_body_msg; i++) {
@@ -838,7 +896,7 @@ void ExtProcIntegrationTest::serverSendBodyRespDuplexStreamed(uint32_t total_res
       const bool end_of_stream = (i == total_resp_body_msg - 1) ? true : false;
       streamed_response->set_end_of_stream(end_of_stream);
     }
-    processor_stream_->sendGrpcMessage(response_body);
+    processor_stream->sendGrpcMessage(response_body);
   }
 }
 

--- a/test/extensions/filters/http/ext_proc/filter_test.cc
+++ b/test/extensions/filters/http/ext_proc/filter_test.cc
@@ -105,6 +105,8 @@ protected:
   void initialize(std::string&& yaml, bool is_upstream_filter = false) {
     scoped_runtime_.mergeValues(
         {{"envoy.reloadable_features.ext_proc_stream_close_optimization", "true"}});
+    scoped_runtime_.mergeValues(
+        {{"envoy.reloadable_features.ext_proc_inject_data_with_state_update", "true"}});
     client_ = std::make_unique<MockClient>();
     route_ = std::make_shared<NiceMock<Router::MockRoute>>();
     EXPECT_CALL(*client_, start(_, _, _, _)).WillOnce(Invoke(this, &HttpFilterTest::doStart));

--- a/test/extensions/filters/http/ext_proc/filter_test_common.cc
+++ b/test/extensions/filters/http/ext_proc/filter_test_common.cc
@@ -67,6 +67,8 @@ static constexpr uint32_t BufferSize = 100000;
 void HttpFilterTest::initialize(std::string&& yaml, bool is_upstream_filter) {
   scoped_runtime_.mergeValues(
       {{"envoy.reloadable_features.ext_proc_stream_close_optimization", "true"}});
+  scoped_runtime_.mergeValues(
+      {{"envoy.reloadable_features.ext_proc_inject_data_with_state_update", "true"}});
   client_ = std::make_unique<MockClient>();
   route_ = std::make_shared<NiceMock<Router::MockRoute>>();
   EXPECT_CALL(*client_, start(_, _, _, _)).WillOnce(Invoke(this, &HttpFilterTest::doStart));

--- a/test/extensions/filters/http/ext_proc/unit_test_fuzz/BUILD
+++ b/test/extensions/filters/http/ext_proc/unit_test_fuzz/BUILD
@@ -33,5 +33,6 @@ envoy_cc_fuzz_test(
         "//test/mocks/http:http_mocks",
         "//test/mocks/network:network_mocks",
         "//test/mocks/server:server_factory_context_mocks",
+        "//test/test_common:test_runtime_lib",
     ],
 )

--- a/test/extensions/filters/http/ext_proc/unit_test_fuzz/ext_proc_unit_test_fuzz.cc
+++ b/test/extensions/filters/http/ext_proc/unit_test_fuzz/ext_proc_unit_test_fuzz.cc
@@ -7,6 +7,7 @@
 #include "test/mocks/http/mocks.h"
 #include "test/mocks/network/mocks.h"
 #include "test/mocks/server/server_factory_context.h"
+#include "test/test_common/test_runtime.h"
 
 using testing::Return;
 using testing::ReturnRef;
@@ -80,6 +81,10 @@ DEFINE_PROTO_FUZZER(
   if (input.response().ByteSizeLong() > max_body_size) {
     return;
   }
+
+  TestScopedRuntime scoped_runtime;
+  scoped_runtime.mergeValues(
+      {{"envoy.reloadable_features.ext_proc_inject_data_with_state_update", "true"}});
 
   static FuzzerMocks mocks;
   NiceMock<Stats::MockIsolatedStatsStore> stats_store;

--- a/test/integration/filters/continue_headers_only_inject_body_filter.cc
+++ b/test/integration/filters/continue_headers_only_inject_body_filter.cc
@@ -39,10 +39,10 @@ public:
   Http::FilterHeadersStatus encodeHeaders(Http::ResponseHeaderMap& headers,
                                           bool end_stream) override {
     headers.setContentLength(body_.length());
-    encoder_callbacks_->dispatcher().post([this, end_stream]() -> void {
+    encoder_callbacks_->dispatcher().post([this]() -> void {
       response_injected_ = true;
       Buffer::OwnedImpl buffer(body_);
-      encoder_callbacks_->injectEncodedDataToFilterChain(buffer, end_stream);
+      encoder_callbacks_->injectEncodedDataToFilterChain(buffer, true);
       if (response_encoded_) {
         encoder_callbacks_->continueEncoding();
       }

--- a/test/integration/filters/stop_iteration_headers_inject_body_filter.cc
+++ b/test/integration/filters/stop_iteration_headers_inject_body_filter.cc
@@ -33,12 +33,12 @@ public:
   }
 
   Http::FilterHeadersStatus encodeHeaders(Http::ResponseHeaderMap& headers,
-                                          bool end_stream) override {
+                                          bool /* end_stream */) override {
     headers.setContentLength(body_.length());
-    encoder_callbacks_->dispatcher().post([this, end_stream]() -> void {
+    encoder_callbacks_->dispatcher().post([this]() -> void {
       response_injected_ = true;
       Buffer::OwnedImpl buffer(body_);
-      encoder_callbacks_->injectEncodedDataToFilterChain(buffer, end_stream);
+      encoder_callbacks_->injectEncodedDataToFilterChain(buffer, true);
       if (response_encoded_) {
         encoder_callbacks_->continueEncoding();
       }


### PR DESCRIPTION
This is the 2nd attempt to fix
https://github.com/envoyproxy/envoy/issues/41654.

The 1st attempt is https://github.com/envoyproxy/envoy/pull/43042


The root cause of the issue is when the 2nd filter resume the processing:


[envoy/source/common/http/filter_manager.cc](https://github.com/envoyproxy/envoy/blob/e45201c87d8481ecd72299139102d9ebf049cf75/source/common/http/filter_manager.cc#L132)

Line 132 in
[e45201c](https://github.com/envoyproxy/envoy/commit/e45201c87d8481ecd72299139102d9ebf049cf75)

 doData(observedEndStream() && !had_trailers_before_data); 
, it is using an outdated observedEndStream() flag as end_of_stream. This flag is set to true once Envoy sees data with end_of_stream set to true either from downstream client or backend server. However, In the ext_proc case, after the data with end_of_stream=true is received by Envoy, it is sent out to the side-stream server and re-injected back to Envoy, the observedEndStream() flag has to be updated during re-injection. Otherwise, the 2nd filter commonContinue() deem the full body is in buffer, i.e, end_of_stream=true, even the 1st filter is still injecting more data.

The issue is reproduced in both ext_proc STREAMED and FULL_DUPLEX_STREAMED modes, also in both request and response directions. Please check the added integration tests.

---------

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
