### PR TITLE
dynamic_modules: add E2E tests for function registry

### DIFF
--- a/test/extensions/dynamic_modules/bootstrap/BUILD
+++ b/test/extensions/dynamic_modules/bootstrap/BUILD
@@ -107,6 +107,7 @@ envoy_cc_test(
         "//test/extensions/dynamic_modules/test_data/c:bootstrap_no_op",
         "//test/extensions/dynamic_modules/test_data/rust:bootstrap_admin_handler_test",
         "//test/extensions/dynamic_modules/test_data/rust:bootstrap_function_registry_test",
+        "//test/extensions/dynamic_modules/test_data/rust:bootstrap_http_combined_test",
         "//test/extensions/dynamic_modules/test_data/rust:bootstrap_init_target_test",
         "//test/extensions/dynamic_modules/test_data/rust:bootstrap_integration_test",
         "//test/extensions/dynamic_modules/test_data/rust:bootstrap_stats_test",
@@ -114,6 +115,7 @@ envoy_cc_test(
     ],
     deps = [
         "//source/extensions/bootstrap/dynamic_modules:config",
+        "//source/extensions/filters/http/dynamic_modules:factory_registration",
         "//test/integration:http_integration_lib",
         "//test/test_common:environment_lib",
         "//test/test_common:utility_lib",

--- a/test/extensions/dynamic_modules/test_data/rust/BUILD
+++ b/test/extensions/dynamic_modules/test_data/rust/BUILD
@@ -40,4 +40,6 @@ test_program(name = "bootstrap_admin_handler_test")
 
 test_program(name = "network_integration_test")
 
+test_program(name = "bootstrap_http_combined_test")
+
 test_program(name = "access_log_integration_test")

--- a/test/extensions/dynamic_modules/test_data/rust/Cargo.toml
+++ b/test/extensions/dynamic_modules/test_data/rust/Cargo.toml
@@ -69,6 +69,12 @@ crate-type = ["cdylib"]
 test = true
 
 [[example]]
+name = "bootstrap_http_combined_test"
+path = "bootstrap_http_combined_test.rs"
+crate-type = ["cdylib"]
+test = true
+
+[[example]]
 name = "network_integration_test"
 path = "network_integration_test.rs"
 crate-type = ["cdylib"]

--- a/test/extensions/dynamic_modules/test_data/rust/bootstrap_http_combined_test.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/bootstrap_http_combined_test.rs
@@ -1,27 +1,25 @@
-//! Test module demonstrating a combined Bootstrap Extension + HTTP Filter pattern.
+//! Test module demonstrating cross-module data sharing via the function registry.
 //!
 //! This module uses `declare_all_init_functions!` to register both a bootstrap extension and an
-//! HTTP filter from a single dynamic module. This pattern is essential for integrations that
-//! require server-wide initialization (e.g., Dicer clerk manager setup) followed by per-request
-//! processing (e.g., routing based on slice keys).
+//! HTTP filter from a single dynamic module. The bootstrap extension performs asynchronous
+//! initialization, populates a routing table, and registers a lookup function in the process-wide
+//! function registry. The HTTP filter resolves this function via `get_function` during config
+//! creation and calls it on every request to perform routing decisions.
 //!
-//! The bootstrap extension performs asynchronous initialization in a background thread, signals
-//! readiness via `signal_init_complete`, and stores shared state in a global `OnceLock`. The HTTP
-//! filter accesses the shared state during request processing (after the init target has completed
-//! and traffic is allowed) for per-request routing decisions including header manipulation and
-//! local reply for error cases.
-//!
-//! Note: The HTTP filter config is created during Envoy config loading, which happens before the
-//! bootstrap init target is signaled. Therefore, shared state must NOT be accessed during HTTP
-//! filter config creation — only during request processing when the init target guarantees
-//! readiness.
+//! This pattern demonstrates the value of the function registry: when multiple dynamic modules
+//! are loaded in the same process, they can share data through registered functions without
+//! needing direct access to each other's globals. In this test, both the bootstrap extension and
+//! HTTP filter happen to be in the same shared object, but the HTTP filter deliberately avoids
+//! accessing the `ROUTING_TABLE` static directly — it resolves the lookup function by name,
+//! exactly as a separate module would.
 
 use envoy_proxy_dynamic_modules_rust_sdk::*;
 use std::collections::HashMap;
 use std::sync::{Arc, OnceLock};
 
-/// Shared routing table between the bootstrap extension and the HTTP filter.
-static SHARED_ROUTING_TABLE: OnceLock<Arc<RoutingTable>> = OnceLock::new();
+/// Routing table populated by the bootstrap extension. The HTTP filter does NOT access this
+/// directly — it uses the function registry instead.
+static ROUTING_TABLE: OnceLock<Arc<RoutingTable>> = OnceLock::new();
 
 declare_all_init_functions!(
   my_program_init,
@@ -58,20 +56,36 @@ impl RoutingTable {
 }
 
 // -------------------------------------------------------------------------------------
-// Function exposed via the process-wide function registry.
+// Functions exposed via the process-wide function registry.
 // -------------------------------------------------------------------------------------
 
-/// Checks whether a service is onboarded in the routing table.
+/// Looks up the endpoint for a service name in the routing table.
 ///
-/// This function is registered in the process-wide function registry by the bootstrap extension
-/// and can be resolved by any module in the same process.
-extern "C" fn is_service_onboarded(service_ptr: *const u8, service_len: usize) -> bool {
+/// On success, writes the endpoint pointer and length to the output parameters and returns true.
+/// On failure (service not found or routing table not initialized), returns false.
+///
+/// # Safety
+///
+/// The returned pointer is valid for the lifetime of the process because the routing table is
+/// stored in a `OnceLock<Arc<...>>` that is never dropped.
+extern "C" fn get_route_endpoint(
+  service_ptr: *const u8,
+  service_len: usize,
+  out_ptr: *mut *const u8,
+  out_len: *mut usize,
+) -> bool {
   let service =
     unsafe { std::str::from_utf8_unchecked(std::slice::from_raw_parts(service_ptr, service_len)) };
-  SHARED_ROUTING_TABLE
-    .get()
-    .map(|table| table.get_route(service).is_some())
-    .unwrap_or(false)
+  match ROUTING_TABLE.get().and_then(|t| t.get_route(service)) {
+    Some(endpoint) => {
+      unsafe {
+        *out_ptr = endpoint.as_ptr();
+        *out_len = endpoint.len();
+      }
+      true
+    },
+    None => false,
+  }
 }
 
 // -------------------------------------------------------------------------------------
@@ -83,30 +97,21 @@ fn my_new_bootstrap_extension_config_fn(
   _name: &str,
   _config: &[u8],
 ) -> Option<Box<dyn BootstrapExtensionConfig>> {
-  // Create a scheduler to signal async initialization completion back to the main thread.
   let scheduler = envoy_extension_config.new_scheduler();
 
-  // Define a counter to track initialization events.
-  let init_counter = envoy_extension_config
-    .define_counter("init_complete_total")
-    .expect("failed to define init_complete_total counter");
-
-  // Simulate asynchronous initialization in a background thread. In a real Dicer integration,
-  // this would create a tokio runtime and call DicerClerkManager::new().
+  // Simulate asynchronous initialization in a background thread.
   std::thread::spawn(move || {
     std::thread::sleep(std::time::Duration::from_millis(50));
     let table = Arc::new(RoutingTable::new());
-    SHARED_ROUTING_TABLE.set(table).ok();
+    ROUTING_TABLE.set(table).ok();
     envoy_log_info!("async initialization complete, scheduling readiness signal");
     scheduler.commit(1);
   });
 
-  Some(Box::new(CombinedBootstrapConfig { init_counter }))
+  Some(Box::new(CombinedBootstrapConfig {}))
 }
 
-struct CombinedBootstrapConfig {
-  init_counter: EnvoyCounterId,
-}
+struct CombinedBootstrapConfig {}
 
 impl BootstrapExtensionConfig for CombinedBootstrapConfig {
   fn new_bootstrap_extension(
@@ -125,18 +130,12 @@ impl BootstrapExtensionConfig for CombinedBootstrapConfig {
       // Register the lookup function in the process-wide function registry.
       let registered = unsafe {
         register_function(
-          "is_service_onboarded",
-          is_service_onboarded as *const std::ffi::c_void,
+          "get_route_endpoint",
+          get_route_endpoint as *const std::ffi::c_void,
         )
       };
       envoy_log_info!("function registry registration: {}", registered);
 
-      // Increment the init counter to track successful initialization.
-      envoy_extension_config
-        .increment_counter(self.init_counter, 1)
-        .ok();
-
-      // Signal init complete to unblock Envoy startup.
       envoy_extension_config.signal_init_complete();
       envoy_log_info!("bootstrap init signaled complete after async initialization");
     }
@@ -147,9 +146,6 @@ struct CombinedBootstrapExtension {}
 
 impl BootstrapExtension for CombinedBootstrapExtension {
   fn on_server_initialized(&mut self, _envoy_extension: &mut dyn EnvoyBootstrapExtension) {
-    // Note: on_server_initialized is called during the synchronous init sequence, which may
-    // happen BEFORE the async init thread completes and signal_init_complete is called. Therefore,
-    // shared state is NOT guaranteed to be available here. Use on_request_headers for verification.
     envoy_log_info!("combined module: server initialized");
   }
 
@@ -168,44 +164,33 @@ impl BootstrapExtension for CombinedBootstrapExtension {
 }
 
 // -------------------------------------------------------------------------------------
-// HTTP filter.
+// HTTP filter — uses the function registry to access bootstrap-loaded data.
 // -------------------------------------------------------------------------------------
 
+/// Function pointer type for the registered `get_route_endpoint` function.
+type GetRouteEndpointFn = extern "C" fn(*const u8, usize, *mut *const u8, *mut usize) -> bool;
+
 fn my_new_http_filter_config_fn<EC: EnvoyHttpFilterConfig, EHF: EnvoyHttpFilter>(
-  envoy_filter_config: &mut EC,
+  _envoy_filter_config: &mut EC,
   _name: &str,
   _config: &[u8],
 ) -> Option<Box<dyn HttpFilterConfig<EHF>>> {
-  // Note: Do NOT access the shared routing table here. The HTTP filter config is created during
-  // Envoy config loading, which happens before the bootstrap init target is signaled. The shared
-  // state is only guaranteed to be available during request processing.
-  envoy_log_info!("http filter config created");
-
-  // Define an HTTP filter counter for tracking routed requests.
-  let requests_routed_counter = envoy_filter_config
-    .define_counter("requests_routed_total")
-    .expect("failed to define requests_routed_total counter");
-
-  Some(Box::new(CombinedHttpFilterConfig {
-    requests_routed_counter,
-  }))
+  // Note: The function registry may not yet contain the bootstrap-registered function at this
+  // point because HTTP filter configs are created during Envoy config loading, which happens
+  // before the bootstrap init target is signaled. Resolution is deferred to request time.
+  envoy_log_info!("http filter config created (function resolution deferred to request time)");
+  Some(Box::new(CombinedHttpFilterConfig {}))
 }
 
-struct CombinedHttpFilterConfig {
-  requests_routed_counter: EnvoyCounterId,
-}
+struct CombinedHttpFilterConfig {}
 
 impl<EHF: EnvoyHttpFilter> HttpFilterConfig<EHF> for CombinedHttpFilterConfig {
   fn new_http_filter(&self, _envoy: &mut EHF) -> Box<dyn HttpFilter<EHF>> {
-    Box::new(CombinedHttpFilter {
-      requests_routed_counter: self.requests_routed_counter,
-    })
+    Box::new(CombinedHttpFilter {})
   }
 }
 
-struct CombinedHttpFilter {
-  requests_routed_counter: EnvoyCounterId,
-}
+struct CombinedHttpFilter {}
 
 impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for CombinedHttpFilter {
   fn on_request_headers(
@@ -213,22 +198,22 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for CombinedHttpFilter {
     envoy_filter: &mut EHF,
     _end_of_stream: bool,
   ) -> abi::envoy_dynamic_module_type_on_http_filter_request_headers_status {
-    // Access the shared routing table. This is safe because the bootstrap init target has been
-    // signaled before any traffic is allowed through.
-    let routing_table = match SHARED_ROUTING_TABLE.get() {
-      Some(table) => table,
+    // Resolve the lookup function from the process-wide function registry. This is safe because
+    // the bootstrap init target has been signaled before any traffic is allowed through.
+    let fn_ptr = match get_function("get_route_endpoint") {
+      Some(ptr) => ptr,
       None => {
-        // This should not happen if the init target mechanism works correctly.
-        envoy_log_error!("routing table not available, init target may not have completed");
+        envoy_log_error!("get_route_endpoint not found in function registry");
         envoy_filter.send_response(
           503,
-          vec![("x-error-reason", b"routing_table_unavailable")],
-          Some(b"routing table not initialized"),
-          Some("routing_table_unavailable"),
+          vec![("x-error-reason", b"function_not_registered")],
+          Some(b"routing function not registered"),
+          Some("function_not_registered"),
         );
         return abi::envoy_dynamic_module_type_on_http_filter_request_headers_status::StopIteration;
       },
     };
+    let get_route: GetRouteEndpointFn = unsafe { std::mem::transmute(fn_ptr) };
 
     // Read the target service name from the request header.
     let service = envoy_filter
@@ -237,20 +222,27 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for CombinedHttpFilter {
 
     match service {
       Some(svc) => {
-        if let Some(endpoint) = routing_table.get_route(&svc) {
-          // Service is onboarded: set routing header and continue.
+        let mut endpoint_ptr: *const u8 = std::ptr::null();
+        let mut endpoint_len: usize = 0;
+        let found = get_route(
+          svc.as_ptr(),
+          svc.len(),
+          &mut endpoint_ptr,
+          &mut endpoint_len,
+        );
+
+        if found {
+          let endpoint = unsafe {
+            std::str::from_utf8_unchecked(std::slice::from_raw_parts(endpoint_ptr, endpoint_len))
+          };
           envoy_filter.set_request_header("x-routed-to", endpoint.as_bytes());
-          envoy_filter
-            .increment_counter(self.requests_routed_counter, 1)
-            .ok();
           envoy_log_info!("routed service '{}' to endpoint '{}'", svc, endpoint);
           abi::envoy_dynamic_module_type_on_http_filter_request_headers_status::Continue
         } else {
-          // Service is not onboarded: send 503 local reply.
           envoy_filter.send_response(
             503,
             vec![("x-error-reason", b"service_not_onboarded")],
-            Some(format!("service '{}' is not onboarded for routing", svc).as_bytes()),
+            Some(format!("service '{}' is not onboarded", svc).as_bytes()),
             Some("service_not_onboarded"),
           );
           abi::envoy_dynamic_module_type_on_http_filter_request_headers_status::StopIteration


### PR DESCRIPTION
## Description

This PR adds an E2E test which validates that a bootstrap Dynamic Module could load the data, register a function in the function registry and then an HTTP Dynamic Module filter could call that function to access that data on a per-request basis.

---

**Commit Message:** dynamic_modules: add E2E tests for function registry
**Additional Description:** Adds an E2E test which validates bootstrap + http Dynamic Module functionality.
**Risk Level:** Low
**Testing:** CI
**Docs Changes:** N/A
**Release Notes:** N/A