### PR TITLE
tls: Const-correct some more uses of X509 API

### DIFF
--- a/source/common/tls/cert_validator/default_validator.cc
+++ b/source/common/tls/cert_validator/default_validator.cc
@@ -552,7 +552,7 @@ absl::Status DefaultCertValidator::addClientValidationContext(SSL_CTX* ctx,
     if (cert == nullptr) {
       break;
     }
-    X509_NAME* name = X509_get_subject_name(cert.get());
+    const X509_NAME* name = X509_get_subject_name(cert.get());
     if (name == nullptr) {
       return absl::InvalidArgumentError(absl::StrCat(
           "Failed to load trusted client CA certificates from ", config_->caCertPath()));

--- a/source/common/tls/default_tls_certificate_selector.cc
+++ b/source/common/tls/default_tls_certificate_selector.cc
@@ -68,14 +68,14 @@ void DefaultTlsCertificateSelector::populateServerNamesMap(const Ssl::TlsContext
     // of CN-ID if the presented identifiers include a DNS-ID, SRV-ID,
     // URI-ID, or any application-specific identifier types supported by the
     // client.
-    X509_NAME* cert_subject = X509_get_subject_name(ctx.cert_chain_.get());
+    const X509_NAME* cert_subject = X509_get_subject_name(ctx.cert_chain_.get());
     const int cn_index = X509_NAME_get_index_by_NID(cert_subject, NID_commonName, -1);
     if (cn_index >= 0) {
-      X509_NAME_ENTRY* cn_entry = X509_NAME_get_entry(cert_subject, cn_index);
+      const X509_NAME_ENTRY* cn_entry = X509_NAME_get_entry(cert_subject, cn_index);
       if (cn_entry) {
-        ASN1_STRING* cn_asn1 = X509_NAME_ENTRY_get_data(cn_entry);
+        const ASN1_STRING* cn_asn1 = X509_NAME_ENTRY_get_data(cn_entry);
         if (ASN1_STRING_length(cn_asn1) > 0) {
-          std::string subject_cn(reinterpret_cast<const char*>(ASN1_STRING_data(cn_asn1)),
+          std::string subject_cn(reinterpret_cast<const char*>(ASN1_STRING_get0_data(cn_asn1)),
                                  ASN1_STRING_length(cn_asn1));
           populate(subject_cn);
         }

--- a/source/extensions/transport_sockets/tls/cert_validator/spiffe/spiffe_validator.cc
+++ b/source/extensions/transport_sockets/tls/cert_validator/spiffe/spiffe_validator.cc
@@ -248,7 +248,7 @@ absl::Status SPIFFEValidator::addClientValidationContext(SSL_CTX* ctx, bool) {
 
   auto spiffe_data = getSpiffeData();
   for (auto& ca : spiffe_data->ca_certs_) {
-    X509_NAME* name = X509_get_subject_name(ca.get());
+    const X509_NAME* name = X509_get_subject_name(ca.get());
 
     // Check for duplicates.
     if (sk_X509_NAME_find(list.get(), nullptr, name)) {


### PR DESCRIPTION
Commit Message:
This future-proofs Envoy and is needed to keep it building with later versions of BoringSSL. BoringSSL plans to const-correct these APIs and making ASN1_STRING opaque, in order to unblock some memory usage improvements in X509.

See also http://github.com/envoyproxy/envoy/pull/41022 for more details.

This PR has no behavior change. It is purely to fix some const issues in Envoy.
Additional Description:
Risk Level: none
Testing: CI checks it compiles
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
