### PR TITLE
LRS: introduce a load-stats-reporter interface

### DIFF
--- a/envoy/upstream/BUILD
+++ b/envoy/upstream/BUILD
@@ -90,6 +90,14 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
+    name = "load_stats_reporter_interface",
+    hdrs = ["load_stats_reporter.h"],
+    deps = [
+        "//envoy/stats:stats_macros",
+    ],
+)
+
+envoy_cc_library(
     name = "locality_lib",
     hdrs = ["locality.h"],
     deps = [

--- a/envoy/upstream/host_description.h
+++ b/envoy/upstream/host_description.h
@@ -33,7 +33,9 @@ using MetadataConstSharedPtr = std::shared_ptr<const envoy::config::core::v3::Me
  *
  * {rq_success, rq_error} have specific semantics driven by the needs of EDS load reporting. See
  * envoy.api.v2.endpoint.UpstreamLocalityStats for the definitions of success/error. These are
- * latched by LoadStatsReporter, independent of the normal stats sink flushing.
+ * latched by LoadStatsReporter interface implementations, independent of the normal stats sink
+ * flushing.
+
  */
 #define ALL_HOST_STATS(COUNTER, GAUGE)                                                             \
   COUNTER(cx_connect_fail)                                                                         \

--- a/envoy/upstream/load_stats_reporter.h
+++ b/envoy/upstream/load_stats_reporter.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <memory>
+
+#include "envoy/stats/stats_macros.h"
+
+namespace Envoy {
+namespace Upstream {
+
+/**
+ * All load reporter stats. @see stats_macros.h
+ */
+#define ALL_LOAD_REPORTER_STATS(COUNTER)                                                           \
+  COUNTER(requests)                                                                                \
+  COUNTER(responses)                                                                               \
+  COUNTER(errors)                                                                                  \
+  COUNTER(retries)
+
+/**
+ * Struct definition for all load reporter stats. @see stats_macros.h
+ */
+struct LoadReporterStats {
+  ALL_LOAD_REPORTER_STATS(GENERATE_COUNTER_STRUCT)
+};
+
+/**
+ * Interface for load stats reporting.
+ */
+class LoadStatsReporter {
+public:
+  virtual ~LoadStatsReporter() = default;
+
+  /**
+   * @return the load reporter stats.
+   */
+  virtual const LoadReporterStats& getStats() const PURE;
+};
+
+using LoadStatsReporterPtr = std::unique_ptr<LoadStatsReporter>;
+
+} // namespace Upstream
+} // namespace Envoy

--- a/envoy/upstream/upstream.h
+++ b/envoy/upstream/upstream.h
@@ -766,8 +766,9 @@ public:
  * All cluster load report stats. These are only use for EDS load reporting and not sent to the
  * stats sink. See envoy.config.endpoint.v3.ClusterStats for the definition of
  * total_dropped_requests and dropped_requests, which correspond to the upstream_rq_dropped and
- * upstream_rq_drop_overload counter here. These are latched by LoadStatsReporter, independent of
- * the normal stats sink flushing.
+ * upstream_rq_drop_overload counter here. These are latched by LoadStatsReporter interface
+ * implementations, independent of the normal stats sink flushing.
+
  */
 #define ALL_CLUSTER_LOAD_REPORT_STATS(COUNTER, GAUGE, HISTOGRAM, TEXT_READOUT, STATNAME)           \
   COUNTER(upstream_rq_dropped)                                                                     \

--- a/source/common/upstream/BUILD
+++ b/source/common/upstream/BUILD
@@ -273,12 +273,13 @@ envoy_cc_library(
 
 envoy_cc_library(
     name = "load_stats_reporter_lib",
-    srcs = ["load_stats_reporter.cc"],
-    hdrs = ["load_stats_reporter.h"],
+    srcs = ["load_stats_reporter_impl.cc"],
+    hdrs = ["load_stats_reporter_impl.h"],
     deps = [
         "//envoy/event:dispatcher_interface",
         "//envoy/stats:stats_macros",
         "//envoy/upstream:cluster_manager_interface",
+        "//envoy/upstream:load_stats_reporter_interface",
         "//source/common/common:minimal_logger_lib",
         "//source/common/grpc:async_client_lib",
         "@envoy_api//envoy/service/load_stats/v3:pkg_cc_proto",

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -41,6 +41,7 @@
 #include "source/common/upstream/cds_api_impl.h"
 #include "source/common/upstream/cluster_factory_impl.h"
 #include "source/common/upstream/load_balancer_context_base.h"
+#include "source/common/upstream/load_stats_reporter_impl.h"
 #include "source/common/upstream/priority_conn_pool_map_impl.h"
 
 #include "absl/hash/hash.h"
@@ -527,7 +528,7 @@ absl::Status ClusterManagerImpl::initializeSecondaryClusters(
       client_or_error = factory_or_error.value()->createUncachedRawAsyncClient();
     }
     RETURN_IF_NOT_OK_REF(client_or_error.status());
-    load_stats_reporter_ = std::make_unique<LoadStatsReporter>(
+    load_stats_reporter_ = std::make_unique<LoadStatsReporterImpl>(
         local_info_, *this, *stats_.rootScope(), std::move(client_or_error.value()), dispatcher_);
   }
   return absl::OkStatus();

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -28,6 +28,7 @@
 #include "envoy/tcp/async_tcp_client.h"
 #include "envoy/thread_local/thread_local.h"
 #include "envoy/upstream/cluster_manager.h"
+#include "envoy/upstream/load_stats_reporter.h"
 
 #include "source/common/common/cleanup.h"
 #include "source/common/common/thread.h"
@@ -39,7 +40,6 @@
 #include "source/common/tcp/async_tcp_client_impl.h"
 #include "source/common/upstream/cluster_discovery_manager.h"
 #include "source/common/upstream/host_utility.h"
-#include "source/common/upstream/load_stats_reporter.h"
 #include "source/common/upstream/priority_conn_pool_map.h"
 #include "source/common/upstream/upstream_impl.h"
 

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -1213,7 +1213,8 @@ ClusterInfoImpl::ClusterInfoImpl(
   }
 #endif
 
-  // Both LoadStatsReporter and per_endpoint_stats need to `latch()` the counters, so if both are
+  // Both LoadStatsReporter interface implementations and per_endpoint_stats need to `latch()` the
+  // counters, so if both are
   // configured they will interfere with each other and both get incorrect values.
   // TODO(ggreenway): Verify that bypassing virtual dispatch here was intentional
   if (ClusterInfoImpl::perEndpointStatsEnabled() &&

--- a/test/common/upstream/BUILD
+++ b/test/common/upstream/BUILD
@@ -407,7 +407,7 @@ envoy_cc_test(
 
 envoy_cc_test(
     name = "load_stats_reporter_test",
-    srcs = ["load_stats_reporter_test.cc"],
+    srcs = ["load_stats_reporter_impl_test.cc"],
     rbe_pool = "6gig",
     deps = [
         "//source/common/network:address_lib",

--- a/test/mocks/upstream/BUILD
+++ b/test/mocks/upstream/BUILD
@@ -71,6 +71,16 @@ envoy_cc_mock(
 )
 
 envoy_cc_mock(
+    name = "load_stats_reporter_mocks",
+    srcs = ["load_stats_reporter.cc"],
+    hdrs = ["load_stats_reporter.h"],
+    deps = [
+        "//envoy/upstream:load_stats_reporter_interface",
+        "//source/common/stats:isolated_store_lib",
+    ],
+)
+
+envoy_cc_mock(
     name = "upstream_mocks",
     hdrs = ["mocks.h"],
     deps = [
@@ -90,6 +100,7 @@ envoy_cc_mock(
         ":host_set_mocks",
         ":load_balancer_context_mock",
         ":load_balancer_mocks",
+        ":load_stats_reporter_mocks",
         ":missing_cluster_notifier_mocks",
         ":od_cds_api_handle_mocks",
         ":od_cds_api_mocks",

--- a/test/mocks/upstream/load_stats_reporter.cc
+++ b/test/mocks/upstream/load_stats_reporter.cc
@@ -1,0 +1,14 @@
+#include "test/mocks/upstream/load_stats_reporter.h"
+
+namespace Envoy {
+namespace Upstream {
+
+MockLoadStatsReporter::MockLoadStatsReporter()
+    : stats_{ALL_LOAD_REPORTER_STATS(POOL_COUNTER_PREFIX(*store_.rootScope(), "load_reporter."))} {
+  ON_CALL(*this, getStats()).WillByDefault(testing::ReturnRef(stats_));
+}
+
+MockLoadStatsReporter::~MockLoadStatsReporter() = default;
+
+} // namespace Upstream
+} // namespace Envoy

--- a/test/mocks/upstream/load_stats_reporter.h
+++ b/test/mocks/upstream/load_stats_reporter.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "envoy/stats/scope.h"
+#include "envoy/upstream/load_stats_reporter.h"
+
+#include "source/common/stats/isolated_store_impl.h"
+
+#include "gmock/gmock.h"
+
+namespace Envoy {
+namespace Upstream {
+
+class MockLoadStatsReporter : public LoadStatsReporter {
+public:
+  MockLoadStatsReporter();
+  ~MockLoadStatsReporter() override;
+
+  MOCK_METHOD(const LoadReporterStats&, getStats, (), (const, override));
+
+  Stats::IsolatedStoreImpl store_;
+  LoadReporterStats stats_;
+};
+
+} // namespace Upstream
+} // namespace Envoy

--- a/test/mocks/upstream/mocks.h
+++ b/test/mocks/upstream/mocks.h
@@ -41,6 +41,7 @@
 #include "test/mocks/upstream/host_set.h"
 #include "test/mocks/upstream/load_balancer.h"
 #include "test/mocks/upstream/load_balancer_context.h"
+#include "test/mocks/upstream/load_stats_reporter.h"
 #include "test/mocks/upstream/od_cds_api.h"
 #include "test/mocks/upstream/od_cds_api_handle.h"
 #include "test/mocks/upstream/priority_set.h"


### PR DESCRIPTION
Commit Message: LRS: introduce a load-stats-reporter interface
Additional Description:
The load-stats-reporter was only defined as a concrete class.
This PR introduces an abstract (interface) load-stats-reporter, which will make it easier to mock and test, and access by other components.

Risk Level: low - C++ changes
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A

Part of the work for #43326