### PR TITLE
docs: fix incorrect nibble index in uuid request id extension comment

### DIFF
--- a/api/envoy/extensions/request_id/uuid/v3/uuid.proto
+++ b/api/envoy/extensions/request_id/uuid/v3/uuid.proto
@@ -23,9 +23,9 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // 2. Request ID is a universally unique identifier `(UUID4)
 //    <https://en.wikipedia.org/wiki/Universally_unique_identifier#Version_4_(random)>`_.
 //
-// 3. Tracing decision (sampled, forced, etc) is set in 14th nibble of the UUID. By default this will
+// 3. Tracing decision (sampled, forced, etc) is set in 13th nibble of the UUID. By default this will
 //    overwrite existing UUIDs received in the ``x-request-id`` header if the trace sampling decision
-//    is changed. The 14th nibble of the UUID4 has been chosen because it is fixed to '4' by the
+//    is changed. The 13th nibble of the UUID4 has been chosen because it is fixed to '4' by the
 //    standard. Thus, '4' indicates a default UUID and no trace status. This nibble is swapped to:
 //
 //      a. '9': Sampled.


### PR DESCRIPTION
The UUID4 version digit '4' is the [13th nibble](https://cryptosys.net/pki/uuid-rfc4122.html#:~:text=A%20Universally%20Unique%20IDentifier%20(UUID)%20is%20a,one%20of%20%228%22%2C%20%229%22%2C%20%22A%22%20or%20%22B%22) (1-indexed, counting only hex digits), not the 14th. The previous comment incorrectly referenced the 14th nibble, probably mistaken with the [0-indexed character position](https://github.com/envoyproxy/envoy/blob/6cf5ca25071b665b1e159faa9afa51617f4defc3/source/extensions/request_id/uuid/config.h#L50) in the string representation (which includes hyphens).  
  
Risk Level: Low
Docs Changes: 