### PR TITLE
dynamic_modules: expose access logger methods to RUST SDK

### DIFF
--- a/source/extensions/access_loggers/dynamic_modules/abi_impl.cc
+++ b/source/extensions/access_loggers/dynamic_modules/abi_impl.cc
@@ -250,6 +250,18 @@ bool envoy_dynamic_module_callback_access_logger_get_route_name(
   return true;
 }
 
+bool envoy_dynamic_module_callback_access_logger_get_virtual_cluster_name(
+    envoy_dynamic_module_type_access_logger_envoy_ptr logger_envoy_ptr,
+    envoy_dynamic_module_type_envoy_buffer* result) {
+  auto* logger = static_cast<ThreadLocalLogger*>(logger_envoy_ptr);
+  const auto& name = logger->stream_info_->virtualClusterName();
+  if (!name.has_value() || name->empty()) {
+    return false;
+  }
+  *result = {const_cast<char*>(name->data()), name->size()};
+  return true;
+}
+
 bool envoy_dynamic_module_callback_access_logger_is_health_check(
     envoy_dynamic_module_type_access_logger_envoy_ptr logger_envoy_ptr) {
   auto* logger = static_cast<ThreadLocalLogger*>(logger_envoy_ptr);

--- a/source/extensions/dynamic_modules/abi/abi.h
+++ b/source/extensions/dynamic_modules/abi/abi.h
@@ -5602,6 +5602,17 @@ bool envoy_dynamic_module_callback_access_logger_get_route_name(
     envoy_dynamic_module_type_envoy_buffer* result);
 
 /**
+ * Get the virtual cluster name.
+ *
+ * @param logger_envoy_ptr is the pointer to the log context.
+ * @param result is the output buffer.
+ * @return true if virtual cluster name is available, false otherwise.
+ */
+bool envoy_dynamic_module_callback_access_logger_get_virtual_cluster_name(
+    envoy_dynamic_module_type_access_logger_envoy_ptr logger_envoy_ptr,
+    envoy_dynamic_module_type_envoy_buffer* result);
+
+/**
  * Check if this is a health check request.
  *
  * @param logger_envoy_ptr is the pointer to the log context.

--- a/test/extensions/access_loggers/dynamic_modules/abi_impl_test.cc
+++ b/test/extensions/access_loggers/dynamic_modules/abi_impl_test.cc
@@ -268,6 +268,37 @@ TEST_F(DynamicModuleAccessLogAbiTest, GetRouteNameEmpty) {
   EXPECT_FALSE(envoy_dynamic_module_callback_access_logger_get_route_name(env_ptr, &result));
 }
 
+TEST_F(DynamicModuleAccessLogAbiTest, GetVirtualClusterName) {
+  stream_info_.virtual_cluster_name_ = "test_vcluster";
+  Formatter::Context log_context(nullptr, nullptr, nullptr);
+  void* env_ptr = createThreadLocalLogger(log_context, stream_info_);
+
+  envoy_dynamic_module_type_envoy_buffer result;
+  EXPECT_TRUE(
+      envoy_dynamic_module_callback_access_logger_get_virtual_cluster_name(env_ptr, &result));
+  EXPECT_EQ("test_vcluster", std::string(result.ptr, result.length));
+}
+
+TEST_F(DynamicModuleAccessLogAbiTest, GetVirtualClusterNameEmpty) {
+  stream_info_.virtual_cluster_name_ = "";
+  Formatter::Context log_context(nullptr, nullptr, nullptr);
+  void* env_ptr = createThreadLocalLogger(log_context, stream_info_);
+
+  envoy_dynamic_module_type_envoy_buffer result;
+  EXPECT_FALSE(
+      envoy_dynamic_module_callback_access_logger_get_virtual_cluster_name(env_ptr, &result));
+}
+
+TEST_F(DynamicModuleAccessLogAbiTest, GetVirtualClusterNameNotSet) {
+  stream_info_.virtual_cluster_name_ = absl::nullopt;
+  Formatter::Context log_context(nullptr, nullptr, nullptr);
+  void* env_ptr = createThreadLocalLogger(log_context, stream_info_);
+
+  envoy_dynamic_module_type_envoy_buffer result;
+  EXPECT_FALSE(
+      envoy_dynamic_module_callback_access_logger_get_virtual_cluster_name(env_ptr, &result));
+}
+
 TEST_F(DynamicModuleAccessLogAbiTest, IsHealthCheck) {
   ON_CALL(stream_info_, healthCheck()).WillByDefault(testing::Return(true));
   Formatter::Context log_context(nullptr, nullptr, nullptr);

--- a/test/extensions/dynamic_modules/test_data/rust/access_log_integration_test.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/access_log_integration_test.rs
@@ -91,6 +91,48 @@ impl AccessLogger for TestAccessLogger {
     // Test worker id.
     let worker_id = ctx.get_worker_index();
     assert_eq!(worker_id, 0);
+
+    // Test response flags.
+    let _response_flags = ctx.response_flags();
+    let _has_flag =
+      ctx.has_response_flag(abi::envoy_dynamic_module_type_response_flag::NoRouteFound);
+
+    // Test attempt count.
+    let _attempt_count = ctx.attempt_count();
+
+    // Test address accessors.
+    let _downstream_remote = ctx.downstream_remote_address();
+    let _downstream_local = ctx.downstream_local_address();
+    let _upstream_remote = ctx.upstream_remote_address();
+    let _upstream_local = ctx.upstream_local_address();
+
+    // Test upstream info.
+    let _upstream_failure = ctx.upstream_transport_failure_reason();
+
+    // Test TLS/connection info.
+    let _tls_version = ctx.downstream_tls_version();
+    let _peer_subject = ctx.downstream_peer_subject();
+    let _peer_digest = ctx.downstream_peer_cert_digest();
+
+    // Test request ID and metadata.
+    let _request_id = ctx.request_id();
+    let _filter_state = ctx.get_filter_state("test_key");
+
+    // Test tracing (stubs that always return None).
+    let _trace_id = ctx.get_trace_id();
+    let _span_id = ctx.get_span_id();
+
+    // Test response trailer access.
+    let _response_trailer = ctx.get_response_trailer("x-trailer");
+
+    // Test bulk header access.
+    let request_headers =
+      ctx.get_all_headers(abi::envoy_dynamic_module_type_http_header_type::RequestHeader);
+    assert!(!request_headers.is_empty());
+    let _response_headers =
+      ctx.get_all_headers(abi::envoy_dynamic_module_type_http_header_type::ResponseHeader);
+    let _response_trailers =
+      ctx.get_all_headers(abi::envoy_dynamic_module_type_http_header_type::ResponseTrailer);
   }
 
   fn flush(&mut self) {


### PR DESCRIPTION
## Description

This PR exposes the unexposed methods to RUST SDK for Access Logger Dynamic Modules. We have also added a new method to expose Virtual Cluster Name.

---

**Commit Message:** dynamic_modules: expose access logger methods to RUST SDK
**Additional Description:** Exposes the unexposed methods to RUST SDK for Access Logger Dynamic Modules.
**Risk Level:** Low
**Testing:** Added Tests
**Docs Changes:** Added
**Release Notes:** Added