### PR TITLE
memory: replaced the custom timer-based tcmalloc memory release with tcmalloc's native APIs

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -31,6 +31,12 @@ behavior_changes:
 
 minor_behavior_changes:
 # *Changes that may cause incompatibilities for some users, but should not for most*
+- area: memory
+  change: |
+    Replaced the custom timer-based tcmalloc memory release with tcmalloc's native
+    ``ProcessBackgroundActions`` and ``SetBackgroundReleaseRate`` APIs. This provides more comprehensive
+    background memory management including per-CPU cache reclamation, cache shuffling, and size class
+    resizing, in addition to memory release. The ``tcmalloc.released_by_timer`` stat has been removed.
 - area: mcp
   change: |
     Changed the default metadata namespace for the MCP filter from ``mcp_proxy`` to ``envoy.filters.http.mcp``.

--- a/source/common/memory/BUILD
+++ b/source/common/memory/BUILD
@@ -21,7 +21,6 @@ envoy_cc_library(
     hdrs = ["stats.h"],
     tcmalloc_dep = 1,
     deps = [
-        "//envoy/stats:stats_macros",
         "//source/common/common:assert_lib",
         "//source/common/common:logger_lib",
         "//source/common/common:thread_lib",

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -567,8 +567,8 @@ absl::Status InstanceBase::initializeOrThrow(Network::Address::InstanceConstShar
                                   server_stats_->dynamic_unknown_fields_,
                                   server_stats_->wip_protos_);
 
-  memory_allocator_manager_ = std::make_unique<Memory::AllocatorManager>(
-      *api_, *stats_store_.rootScope(), bootstrap_.memory_allocator_manager());
+  memory_allocator_manager_ =
+      std::make_unique<Memory::AllocatorManager>(*api_, bootstrap_.memory_allocator_manager());
 
   initialization_timer_ = std::make_unique<Stats::HistogramCompletableTimespanImpl>(
       server_stats_->initialization_time_ms_, timeSource());

--- a/test/common/memory/BUILD
+++ b/test/common/memory/BUILD
@@ -28,10 +28,7 @@ envoy_cc_test(
     srcs = ["memory_release_test.cc"],
     rbe_pool = "6gig",
     deps = [
-        "//source/common/event:dispatcher_lib",
         "//source/common/memory:stats_lib",
-        "//test/common/stats:stat_test_utility_lib",
-        "//test/test_common:simulated_time_system_lib",
         "//test/test_common:utility_lib",
     ],
 )


### PR DESCRIPTION
## Description

This PR replaces the custom timer-based `tcmalloc` memory release with `tcmalloc`'s native `ProcessBackgroundActions` and `SetBackgroundReleaseRate` APIs.

This provides more comprehensive background memory management including per-CPU cache reclamation, cache shuffling, and size class resizing, in addition to memory release. 

The `tcmalloc.released_by_timer` stat has been removed as it's no longer required.

---

**Commit Message:** memory: replaced the custom timer-based tcmalloc memory release with tcmalloc's native APIs
**Additional Description:** Replaces the custom timer-based `tcmalloc` memory release with `tcmalloc`'s native `ProcessBackgroundActions` and `SetBackgroundReleaseRate` APIs.
**Risk Level:** Low
**Testing:** Added Tests
**Docs Changes:** Added
**Release Notes:** Added