### PR TITLE
dynamic_modules: add an ID to identify timers in bootstrap

### DIFF
--- a/test/extensions/dynamic_modules/bootstrap/integration_test.cc
+++ b/test/extensions/dynamic_modules/bootstrap/integration_test.cc
@@ -102,7 +102,8 @@ TEST_P(DynamicModulesBootstrapIntegrationTest, InitTargetRust) {
 }
 
 // This test verifies that the Rust bootstrap extension timer API works correctly.
-// A timer is created during config_new, armed with a short delay, and on_timer_fired logs success.
+// Two timers are created during config_new, armed with short delays, and on_timer_fired uses the
+// timer identity API to distinguish which timer fired. Init completes after both timers fire.
 TEST_P(DynamicModulesBootstrapIntegrationTest, TimerRust) {
   EXPECT_LOG_CONTAINS(
       "info", "Bootstrap timer test completed successfully!",

--- a/test/extensions/dynamic_modules/test_data/rust/bootstrap_timer_test.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/bootstrap_timer_test.rs
@@ -1,10 +1,16 @@
 //! Test module for Bootstrap extension timer functionality.
 //!
 //! This module tests the timer API that allows bootstrap extensions to create timers on the main
-//! thread event loop. It creates a timer during config_new, arms it with a short delay, and
-//! verifies that on_timer_fired is called.
+//! thread event loop. It creates two timers during config_new, arms them with short delays, and
+//! verifies that on_timer_fired is called for each. The timer identity API (`id()`) is used to
+//! distinguish which timer fired in the callback.
+//!
+//! Initialization is deferred until both timers have fired by calling `signal_init_complete` from
+//! `on_timer_fired` only after both timers are accounted for. This guarantees the timers fire
+//! before `initialize()` returns.
 
 use envoy_proxy_dynamic_modules_rust_sdk::*;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Mutex;
 use std::time::Duration;
 
@@ -19,29 +25,56 @@ fn my_new_bootstrap_extension_config_fn(
   _name: &str,
   _config: &[u8],
 ) -> Option<Box<dyn BootstrapExtensionConfig>> {
-  // Create a timer on the main thread dispatcher.
-  let timer = envoy_extension_config.new_timer();
+  // Create two timers on the main thread dispatcher.
+  let timer_a = envoy_extension_config.new_timer();
+  let timer_b = envoy_extension_config.new_timer();
 
-  // Verify the timer is not enabled upon creation.
+  // Verify both timers are not enabled upon creation.
   assert!(
-    !timer.enabled(),
-    "Timer should not be enabled upon creation"
+    !timer_a.enabled(),
+    "Timer A should not be enabled upon creation"
+  );
+  assert!(
+    !timer_b.enabled(),
+    "Timer B should not be enabled upon creation"
   );
 
-  // Arm the timer with a short delay.
-  timer.enable(Duration::from_millis(10));
-  assert!(timer.enabled(), "Timer should be enabled after arming");
+  // Verify each timer has a unique identity.
+  assert_ne!(
+    timer_a.id(),
+    timer_b.id(),
+    "Different timers must have different ids"
+  );
 
-  envoy_log_info!("Timer created and armed during config_new");
+  let timer_a_id = timer_a.id();
+  let timer_b_id = timer_b.id();
 
-  envoy_extension_config.signal_init_complete();
+  // Arm both timers with short delays.
+  timer_a.enable(Duration::from_millis(10));
+  timer_b.enable(Duration::from_millis(20));
+
+  envoy_log_info!("Two timers created and armed during config_new");
+
+  // Do NOT call signal_init_complete here. Instead, defer it until both timers have fired in
+  // on_timer_fired. This ensures the event loop keeps running and both timers fire before
+  // initialize() returns.
   Some(Box::new(TimerTestBootstrapExtensionConfig {
-    timer: Mutex::new(Some(timer)),
+    timer_a: Mutex::new(Some(timer_a)),
+    timer_b: Mutex::new(Some(timer_b)),
+    timer_a_id,
+    timer_b_id,
+    timer_a_fired: AtomicBool::new(false),
+    timer_b_fired: AtomicBool::new(false),
   }))
 }
 
 struct TimerTestBootstrapExtensionConfig {
-  timer: Mutex<Option<Box<dyn EnvoyBootstrapExtensionTimer>>>,
+  timer_a: Mutex<Option<Box<dyn EnvoyBootstrapExtensionTimer>>>,
+  timer_b: Mutex<Option<Box<dyn EnvoyBootstrapExtensionTimer>>>,
+  timer_a_id: usize,
+  timer_b_id: usize,
+  timer_a_fired: AtomicBool,
+  timer_b_fired: AtomicBool,
 }
 
 impl BootstrapExtensionConfig for TimerTestBootstrapExtensionConfig {
@@ -54,13 +87,32 @@ impl BootstrapExtensionConfig for TimerTestBootstrapExtensionConfig {
 
   fn on_timer_fired(
     &self,
-    _envoy_extension_config: &mut dyn EnvoyBootstrapExtensionConfig,
-    _timer: &dyn EnvoyBootstrapExtensionTimer,
+    envoy_extension_config: &mut dyn EnvoyBootstrapExtensionConfig,
+    timer: &dyn EnvoyBootstrapExtensionTimer,
   ) {
-    envoy_log_info!("Bootstrap timer test completed successfully!");
-    // Disable and drop the timer to clean up.
-    let mut timer_guard = self.timer.lock().unwrap();
-    *timer_guard = None;
+    let fired_id = timer.id();
+
+    if fired_id == self.timer_a_id {
+      envoy_log_info!("Timer A fired, identified by id");
+      self.timer_a_fired.store(true, Ordering::SeqCst);
+      // Drop timer A to clean up.
+      let mut guard = self.timer_a.lock().unwrap();
+      *guard = None;
+    } else if fired_id == self.timer_b_id {
+      envoy_log_info!("Timer B fired, identified by id");
+      self.timer_b_fired.store(true, Ordering::SeqCst);
+      // Drop timer B to clean up.
+      let mut guard = self.timer_b.lock().unwrap();
+      *guard = None;
+    } else {
+      panic!("Unknown timer fired with id: {}", fired_id);
+    }
+
+    // Signal init complete and log success once both timers have fired.
+    if self.timer_a_fired.load(Ordering::SeqCst) && self.timer_b_fired.load(Ordering::SeqCst) {
+      envoy_extension_config.signal_init_complete();
+      envoy_log_info!("Bootstrap timer test completed successfully!");
+    }
   }
 }
 


### PR DESCRIPTION
## Description

This PR adds a way to allow modules with multiple timers to identify which timer gets fired in the callback by comparing the id of the fired timer reference against the ids of their stored timer handles.

---

**Commit Message:** dynamic_modules: add an ID to identify timers in bootstrap
**Additional Description:** Adds a way to allow modules with multiple timers to identify which timer gets fired in the callback.
**Risk Level:** Low
**Testing:** Added Tests
**Docs Changes:** N/A
**Release Notes:** N/A