### PR TITLE
backport: dym SDK: support utility methods to read body (#43598)

### DIFF
--- a/source/extensions/dynamic_modules/sdk/cpp/sdk.cc
+++ b/source/extensions/dynamic_modules/sdk/cpp/sdk.cc
@@ -27,6 +27,49 @@ HttpFilterHandle::~HttpFilterHandle() = default;
 
 HttpFilterConfigHandle::~HttpFilterConfigHandle() = default;
 
+namespace {
+bool isSameChunks(const std::vector<BufferView>& a, const std::vector<BufferView>& b) {
+  if (a.size() != b.size()) {
+    return false;
+  }
+  for (size_t i = 0; i < a.size(); i++) {
+    if (a[i].data() != b[i].data()) {
+      return false;
+    }
+  }
+  return true;
+}
+
+std::string getBodyContent(BodyBuffer& buffered_body, BodyBuffer& received_body) {
+  std::string result;
+  const auto buffered_chunks = buffered_body.getChunks();
+  for (const auto& chunk : buffered_chunks) {
+    result.append(chunk.data(), chunk.size());
+  }
+  const auto received_chunks = received_body.getChunks();
+  // Because of the complex buffering logic in Envoy, it's possible that the latest received body
+  // is the same as the buffered body. This happens when a previous filter returns StopAndBuffer,
+  // and then this filter is called again with the buffered body as the received body.
+  // TODO(wbpcode): optimize this by adding a new ABI to directly check it.
+  if (!isSameChunks(buffered_chunks, received_chunks)) {
+    for (const auto& chunk : received_chunks) {
+      result.append(chunk.data(), chunk.size());
+    }
+  }
+  return result;
+}
+} // namespace
+
+namespace Utility {
+std::string readWholeRequestBody(HttpFilterHandle& handle) {
+  return getBodyContent(handle.bufferedRequestBody(), handle.receivedRequestBody());
+}
+
+std::string readWholeResponseBody(HttpFilterHandle& handle) {
+  return getBodyContent(handle.bufferedResponseBody(), handle.receivedResponseBody());
+}
+} // namespace Utility
+
 HttpFilterConfigFactoryRegister::HttpFilterConfigFactoryRegister(absl::string_view name,
                                                                  HttpFilterConfigFactoryPtr factory)
     : name_(name) {

--- a/source/extensions/dynamic_modules/sdk/cpp/sdk.h
+++ b/source/extensions/dynamic_modules/sdk/cpp/sdk.h
@@ -486,6 +486,15 @@ public:
   virtual BodyBuffer& bufferedRequestBody() = 0;
 
   /**
+   * Returns reference to the latest received request body chunk.
+   * NOTE: This is only valid in the onRequestBody callback, and it retrieves the latest received
+   * body chunk that triggers the callback. For other callbacks or outside of the callbacks, you
+   * should use bufferedRequestBody() to get the currently buffered body in the chain.
+   * @return Reference to BodyBuffer containing the latest received request body chunk.
+   */
+  virtual BodyBuffer& receivedRequestBody() = 0;
+
+  /**
    * Returns reference to request trailers.
    * @return Reference to StreamHeaderMap containing request trailers.
    */
@@ -502,6 +511,15 @@ public:
    * @return Reference to BodyBuffer containing response body.
    */
   virtual BodyBuffer& bufferedResponseBody() = 0;
+
+  /**
+   * Returns reference to the latest received response body chunk.
+   * NOTE: This is only valid in the onResponseBody callback, and it retrieves the latest received
+   * body chunk that triggers the callback. For other callbacks or outside of the callbacks, you
+   * should use bufferedResponseBody() to get the currently buffered body in the chain.
+   * @return Reference to BodyBuffer containing the latest received response body chunk.
+   */
+  virtual BodyBuffer& receivedResponseBody() = 0;
 
   /**
    * Returns reference to response trailers.
@@ -814,6 +832,28 @@ public:
 };
 
 using HttpFilterConfigFactoryPtr = std::unique_ptr<HttpFilterConfigFactory>;
+
+namespace Utility {
+
+/**
+ * Reads the whole request body by combining the buffered body and the latest received body.
+ * This should only be called after we see the end of the request, which means the end_of_stream
+ * flag is true in the onRequestBody callback or we are in the onRequestTrailers callback.
+ * @param handle The HTTP filter handle.
+ * @return The combined request body as a string.
+ */
+std::string readWholeRequestBody(HttpFilterHandle& handle);
+
+/**
+ * Reads the whole response body by combining the buffered body and the latest received body.
+ * This should only be called after we see the end of the response, which means the end_of_stream
+ * flag is true in the onResponseBody callback or we are in the onResponseTrailers callback.
+ * @param handle The HTTP filter handle.
+ * @return The combined response body as a string.
+ */
+std::string readWholeResponseBody(HttpFilterHandle& handle);
+
+} // namespace Utility
 
 class HttpFilterConfigFactoryRegistry {
 public:

--- a/source/extensions/dynamic_modules/sdk/cpp/sdk_internal.cc
+++ b/source/extensions/dynamic_modules/sdk/cpp/sdk_internal.cc
@@ -335,11 +335,15 @@ public:
 
   BodyBuffer& bufferedRequestBody() override { return buffered_request_body_; }
 
+  BodyBuffer& receivedRequestBody() override { return received_request_body_; }
+
   HeaderMap& requestTrailers() override { return request_trailers_; }
 
   HeaderMap& responseHeaders() override { return response_headers_; }
 
   BodyBuffer& bufferedResponseBody() override { return buffered_response_body_; }
+
+  BodyBuffer& receivedResponseBody() override { return received_response_body_; }
 
   HeaderMap& responseTrailers() override { return response_trailers_; }
 

--- a/source/extensions/dynamic_modules/sdk/cpp/sdk_mocks.h
+++ b/source/extensions/dynamic_modules/sdk/cpp/sdk_mocks.h
@@ -99,9 +99,11 @@ public:
   MOCK_METHOD(void, clearRouteCache, (), (override));
   MOCK_METHOD(HeaderMap&, requestHeaders, (), (override));
   MOCK_METHOD(BodyBuffer&, bufferedRequestBody, (), (override));
+  MOCK_METHOD(BodyBuffer&, receivedRequestBody, (), (override));
   MOCK_METHOD(HeaderMap&, requestTrailers, (), (override));
   MOCK_METHOD(HeaderMap&, responseHeaders, (), (override));
   MOCK_METHOD(BodyBuffer&, bufferedResponseBody, (), (override));
+  MOCK_METHOD(BodyBuffer&, receivedResponseBody, (), (override));
   MOCK_METHOD(HeaderMap&, responseTrailers, (), (override));
   MOCK_METHOD(const RouteSpecificConfig*, getMostSpecificConfig, (), (override));
   MOCK_METHOD(std::shared_ptr<Scheduler>, getScheduler, (), (override));

--- a/source/extensions/dynamic_modules/sdk/go/abi/internal.go
+++ b/source/extensions/dynamic_modules/sdk/go/abi/internal.go
@@ -704,6 +704,10 @@ func (h *dymHttpFilterHandle) BufferedRequestBody() shared.BodyBuffer {
 	return &h.bufferedRequestBody
 }
 
+func (h *dymHttpFilterHandle) ReceivedRequestBody() shared.BodyBuffer {
+	return &h.receivedRequestBody
+}
+
 func (h *dymHttpFilterHandle) RequestTrailers() shared.HeaderMap {
 	return &h.requestTrailerMap
 }
@@ -714,6 +718,10 @@ func (h *dymHttpFilterHandle) ResponseHeaders() shared.HeaderMap {
 
 func (h *dymHttpFilterHandle) BufferedResponseBody() shared.BodyBuffer {
 	return &h.bufferedResponseBody
+}
+
+func (h *dymHttpFilterHandle) ReceivedResponseBody() shared.BodyBuffer {
+	return &h.receivedResponseBody
 }
 
 func (h *dymHttpFilterHandle) ResponseTrailers() shared.HeaderMap {

--- a/source/extensions/dynamic_modules/sdk/go/shared/base.go
+++ b/source/extensions/dynamic_modules/sdk/go/shared/base.go
@@ -387,6 +387,12 @@ type HttpFilterHandle interface {
 	// @Return the buffered request body.
 	BufferedRequestBody() BodyBuffer
 
+	// ReceivedRequestBody retrieves the latest received request body chunk in the OnRequestBody callback.
+	// NOTE: This is only valid in the OnRequestBody callback, and it retrieves the latest received
+	// body chunk that triggers the callback. For other callbacks or outside of the callbacks, you
+	// should use BufferedRequestBody to get the currently buffered body in the chain.
+	ReceivedRequestBody() BodyBuffer
+
 	// RequestTrailers retrieves the request trailers.
 	// @Return the request trailers.
 	RequestTrailers() HeaderMap
@@ -403,6 +409,12 @@ type HttpFilterHandle interface {
 	// called, the full request body is received.
 	// @Return the buffered response body.
 	BufferedResponseBody() BodyBuffer
+
+	// ReceivedResponseBody retrieves the latest received response body chunk in the OnResponseBody callback.
+	// NOTE: This is only valid in the OnResponseBody callback, and it retrieves the latest received
+	// body chunk that triggers the callback. For other callbacks or outside of the callbacks, you
+	// should use BufferedResponseBody to get the currently buffered body in the chain.
+	ReceivedResponseBody() BodyBuffer
 
 	// ResponseTrailers retrieves the response trailers.
 	// @Return the response trailers.

--- a/source/extensions/dynamic_modules/sdk/go/shared/mocks/mock_api.go
+++ b/source/extensions/dynamic_modules/sdk/go/shared/mocks/mock_api.go
@@ -174,16 +174,16 @@ func (mr *MockHttpFilterFactoryMockRecorder) Create(handle any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockHttpFilterFactory)(nil).Create), handle)
 }
 
-// OnDestory mocks base method.
-func (m *MockHttpFilterFactory) OnDestory() {
+// OnDestroy mocks base method.
+func (m *MockHttpFilterFactory) OnDestroy() {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "OnDestory")
+	m.ctrl.Call(m, "OnDestroy")
 }
 
-// OnDestory indicates an expected call of OnDestory.
-func (mr *MockHttpFilterFactoryMockRecorder) OnDestory() *gomock.Call {
+// OnDestroy indicates an expected call of OnDestroy.
+func (mr *MockHttpFilterFactoryMockRecorder) OnDestroy() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OnDestory", reflect.TypeOf((*MockHttpFilterFactory)(nil).OnDestory))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OnDestroy", reflect.TypeOf((*MockHttpFilterFactory)(nil).OnDestroy))
 }
 
 // MockHttpFilterConfigFactory is a mock of HttpFilterConfigFactory interface.

--- a/source/extensions/dynamic_modules/sdk/go/shared/mocks/mock_base.go
+++ b/source/extensions/dynamic_modules/sdk/go/shared/mocks/mock_base.go
@@ -716,6 +716,34 @@ func (mr *MockHttpFilterHandleMockRecorder) Log(level, format any, args ...any) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Log", reflect.TypeOf((*MockHttpFilterHandle)(nil).Log), varargs...)
 }
 
+// ReceivedRequestBody mocks base method.
+func (m *MockHttpFilterHandle) ReceivedRequestBody() shared.BodyBuffer {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReceivedRequestBody")
+	ret0, _ := ret[0].(shared.BodyBuffer)
+	return ret0
+}
+
+// ReceivedRequestBody indicates an expected call of ReceivedRequestBody.
+func (mr *MockHttpFilterHandleMockRecorder) ReceivedRequestBody() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReceivedRequestBody", reflect.TypeOf((*MockHttpFilterHandle)(nil).ReceivedRequestBody))
+}
+
+// ReceivedResponseBody mocks base method.
+func (m *MockHttpFilterHandle) ReceivedResponseBody() shared.BodyBuffer {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReceivedResponseBody")
+	ret0, _ := ret[0].(shared.BodyBuffer)
+	return ret0
+}
+
+// ReceivedResponseBody indicates an expected call of ReceivedResponseBody.
+func (mr *MockHttpFilterHandleMockRecorder) ReceivedResponseBody() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReceivedResponseBody", reflect.TypeOf((*MockHttpFilterHandle)(nil).ReceivedResponseBody))
+}
+
 // RecordHistogramValue mocks base method.
 func (m *MockHttpFilterHandle) RecordHistogramValue(id shared.MetricID, value uint64, tagsValues ...string) shared.MetricsResult {
 	m.ctrl.T.Helper()

--- a/source/extensions/dynamic_modules/sdk/go/shared/utility/utility.go
+++ b/source/extensions/dynamic_modules/sdk/go/shared/utility/utility.go
@@ -1,0 +1,71 @@
+package utility
+
+import (
+	"unsafe"
+
+	"github.com/envoyproxy/envoy/source/extensions/dynamic_modules/sdk/go/shared"
+)
+
+func isSameChunks(bufferedChunk [][]byte, receivedChunk [][]byte) bool {
+	if len(bufferedChunk) != len(receivedChunk) {
+		return false
+	}
+	for i := range bufferedChunk {
+		if unsafe.SliceData(bufferedChunk[i]) != unsafe.SliceData(receivedChunk[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func getBodyContent(bufferedBody, receivedBody shared.BodyBuffer) []byte {
+	var bodySize int
+	if bufferedBody != nil {
+		bodySize += int(bufferedBody.GetSize())
+	}
+	if receivedBody != nil {
+		bodySize += int(receivedBody.GetSize())
+	}
+	body := make([]byte, 0, bodySize)
+
+	var bufferedChunks [][]byte
+
+	if bufferedBody != nil {
+		bufferedChunks = bufferedBody.GetChunks()
+		for _, chunk := range bufferedChunks {
+			body = append(body, chunk...)
+		}
+	}
+	if receivedBody != nil {
+		receivedChunks := receivedBody.GetChunks()
+		// Because the the complex buffering logic in Envoy, it's possible that the
+		// latest received body are the same as the buffered body.
+		// This will happens when previous filter returns StopAndBuffer, and then this
+		// filter is called again with the buffered body as received body.
+		// TODO(wbpcode): optimize this by add a new ABI to directly check it.
+		if !isSameChunks(bufferedChunks, receivedChunks) {
+			// Avoid duplicate appending the same chunks
+			for _, chunk := range receivedChunks {
+				body = append(body, chunk...)
+			}
+		}
+	}
+
+	return body
+}
+
+// ReadWholeRequestBody reads the whole request body by combining the buffered body and the
+// latest received body.
+// This should only be called after we see the end of the request, which means the end_of_stream flag
+// is true in the OnRequestBody callback or we are in the OnRequestTrailers callback.
+func ReadWholeRequestBody(handle shared.HttpFilterHandle) []byte {
+	return getBodyContent(handle.BufferedRequestBody(), handle.ReceivedRequestBody())
+}
+
+// ReadWholeResponseBody reads the whole response body by combining the buffered body and the
+// latest received body.
+// This should only be called after we see the end of the response, which means the end_of_stream flag
+// is true in the OnResponseBody callback or we are in the OnResponseTrailers callback.
+func ReadWholeResponseBody(handle shared.HttpFilterHandle) []byte {
+	return getBodyContent(handle.BufferedResponseBody(), handle.ReceivedResponseBody())
+}

--- a/source/extensions/dynamic_modules/sdk/go/shared/utility/utility_test.go
+++ b/source/extensions/dynamic_modules/sdk/go/shared/utility/utility_test.go
@@ -1,0 +1,119 @@
+package utility
+
+import (
+	"testing"
+
+	"github.com/envoyproxy/envoy/source/extensions/dynamic_modules/sdk/go/shared/fake"
+	"github.com/envoyproxy/envoy/source/extensions/dynamic_modules/sdk/go/shared/mocks"
+	gomock "go.uber.org/mock/gomock"
+)
+
+func TestReadWholeRequestBody_SameChunks(t *testing.T) {
+	// When received body and buffered body point to the same underlying memory,
+	// the data should only appear once in the result.
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	body := []byte("hello world")
+	buf := fake.NewFakeBodyBuffer(body)
+
+	handle := mocks.NewMockHttpFilterHandle(ctrl)
+	handle.EXPECT().BufferedRequestBody().Return(buf)
+	handle.EXPECT().ReceivedRequestBody().Return(buf) // same pointer → same chunks
+
+	result := ReadWholeRequestBody(handle)
+	if string(result) != "hello world" {
+		t.Errorf("expected %q, got %q", "hello world", string(result))
+	}
+}
+
+func TestReadWholeRequestBody_DifferentChunks(t *testing.T) {
+	// When buffered and received body point to different memory, both are combined.
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	buffered := fake.NewFakeBodyBuffer([]byte("hello "))
+	received := fake.NewFakeBodyBuffer([]byte("world"))
+
+	handle := mocks.NewMockHttpFilterHandle(ctrl)
+	handle.EXPECT().BufferedRequestBody().Return(buffered)
+	handle.EXPECT().ReceivedRequestBody().Return(received)
+
+	result := ReadWholeRequestBody(handle)
+	if string(result) != "hello world" {
+		t.Errorf("expected %q, got %q", "hello world", string(result))
+	}
+}
+
+func TestReadWholeRequestBody_EmptyBuffered(t *testing.T) {
+	// When buffered body is empty, result equals the received body.
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	buffered := fake.NewFakeBodyBuffer([]byte{})
+	received := fake.NewFakeBodyBuffer([]byte("world"))
+
+	handle := mocks.NewMockHttpFilterHandle(ctrl)
+	handle.EXPECT().BufferedRequestBody().Return(buffered)
+	handle.EXPECT().ReceivedRequestBody().Return(received)
+
+	result := ReadWholeRequestBody(handle)
+	if string(result) != "world" {
+		t.Errorf("expected %q, got %q", "world", string(result))
+	}
+}
+
+func TestReadWholeResponseBody_SameChunks(t *testing.T) {
+	// When received body and buffered body point to the same underlying memory,
+	// the data should only appear once in the result.
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	body := []byte("hello world")
+	buf := fake.NewFakeBodyBuffer(body)
+
+	handle := mocks.NewMockHttpFilterHandle(ctrl)
+	handle.EXPECT().BufferedResponseBody().Return(buf)
+	handle.EXPECT().ReceivedResponseBody().Return(buf) // same pointer → same chunks
+
+	result := ReadWholeResponseBody(handle)
+	if string(result) != "hello world" {
+		t.Errorf("expected %q, got %q", "hello world", string(result))
+	}
+}
+
+func TestReadWholeResponseBody_DifferentChunks(t *testing.T) {
+	// When buffered and received body point to different memory, both are combined.
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	buffered := fake.NewFakeBodyBuffer([]byte("hello "))
+	received := fake.NewFakeBodyBuffer([]byte("world"))
+
+	handle := mocks.NewMockHttpFilterHandle(ctrl)
+	handle.EXPECT().BufferedResponseBody().Return(buffered)
+	handle.EXPECT().ReceivedResponseBody().Return(received)
+
+	result := ReadWholeResponseBody(handle)
+	if string(result) != "hello world" {
+		t.Errorf("expected %q, got %q", "hello world", string(result))
+	}
+}
+
+func TestReadWholeResponseBody_EmptyBuffered(t *testing.T) {
+	// When buffered body is empty, result equals the received body.
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	buffered := fake.NewFakeBodyBuffer([]byte{})
+	received := fake.NewFakeBodyBuffer([]byte("world"))
+
+	handle := mocks.NewMockHttpFilterHandle(ctrl)
+	handle.EXPECT().BufferedResponseBody().Return(buffered)
+	handle.EXPECT().ReceivedResponseBody().Return(received)
+
+	result := ReadWholeResponseBody(handle)
+	if string(result) != "world" {
+		t.Errorf("expected %q, got %q", "world", string(result))
+	}
+}

--- a/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
@@ -6,9 +6,11 @@
 
 pub mod access_log;
 pub mod buffer;
+pub mod utility;
 pub use buffer::{EnvoyBuffer, EnvoyMutBuffer};
 use mockall::predicate::*;
 use mockall::*;
+pub use utility::{read_whole_request_body, read_whole_response_body};
 
 #[cfg(test)]
 #[path = "./lib_test.rs"]

--- a/source/extensions/dynamic_modules/sdk/rust/src/utility.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/utility.rs
@@ -1,0 +1,195 @@
+use crate::EnvoyHttpFilter;
+
+/// Collects raw pointer addresses from body chunks without copying data.
+fn collect_chunk_ptrs<EHF: EnvoyHttpFilter>(
+  envoy_filter: &mut EHF,
+  request: bool,
+  buffered: bool,
+) -> Vec<usize> {
+  let chunks = match (request, buffered) {
+    (true, true) => envoy_filter.get_buffered_request_body(),
+    (true, false) => envoy_filter.get_received_request_body(),
+    (false, true) => envoy_filter.get_buffered_response_body(),
+    (false, false) => envoy_filter.get_received_response_body(),
+  };
+  chunks.map_or(Vec::new(), |chunks| {
+    chunks
+      .iter()
+      .map(|c| c.as_slice().as_ptr() as usize)
+      .collect()
+  })
+}
+
+/// Copies data from body chunks into a `Vec<u8>`.
+fn collect_chunk_data<EHF: EnvoyHttpFilter>(
+  envoy_filter: &mut EHF,
+  request: bool,
+  buffered: bool,
+) -> Vec<u8> {
+  let chunks = match (request, buffered) {
+    (true, true) => envoy_filter.get_buffered_request_body(),
+    (true, false) => envoy_filter.get_received_request_body(),
+    (false, true) => envoy_filter.get_buffered_response_body(),
+    (false, false) => envoy_filter.get_received_response_body(),
+  };
+  chunks.map_or(Vec::new(), |chunks| {
+    let mut data = Vec::new();
+    for chunk in &chunks {
+      data.extend_from_slice(chunk.as_slice());
+    }
+    data
+  })
+}
+
+fn get_body_content<EHF: EnvoyHttpFilter>(envoy_filter: &mut EHF, request: bool) -> Vec<u8> {
+  // First, collect only raw pointers from both bodies to check for sameness, without copying
+  // any data. Because of the complex buffering logic in Envoy, the received body may be the
+  // same as the buffered body. This happens when a previous filter returns StopAndBuffer, and
+  // then this filter is called again with the buffered body as the received body.
+  // TODO(wbpcode): optimize this by adding a new ABI to directly check it.
+  let received_ptrs = collect_chunk_ptrs(envoy_filter, request, false);
+  let buffered_ptrs = collect_chunk_ptrs(envoy_filter, request, true);
+
+  if received_ptrs == buffered_ptrs {
+    // Same underlying memory: copy buffered data once.
+    collect_chunk_data(envoy_filter, request, true)
+  } else {
+    // Different chunks: copy buffered first, then append received.
+    let mut result = collect_chunk_data(envoy_filter, request, true);
+    result.extend(collect_chunk_data(envoy_filter, request, false));
+    result
+  }
+}
+
+/// Reads the whole request body by combining the buffered body and the latest received body.
+///
+/// This should only be called after we see the end of the request, which means the
+/// `end_of_stream` flag is true in the `on_request_body` callback or we are in the
+/// `on_request_trailers` callback.
+pub fn read_whole_request_body<EHF: EnvoyHttpFilter>(envoy_filter: &mut EHF) -> Vec<u8> {
+  get_body_content(envoy_filter, true)
+}
+
+/// Reads the whole response body by combining the buffered body and the latest received body.
+///
+/// This should only be called after we see the end of the response, which means the
+/// `end_of_stream` flag is true in the `on_response_body` callback or we are in the
+/// `on_response_trailers` callback.
+pub fn read_whole_response_body<EHF: EnvoyHttpFilter>(envoy_filter: &mut EHF) -> Vec<u8> {
+  get_body_content(envoy_filter, false)
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::{EnvoyMutBuffer, MockEnvoyHttpFilter};
+
+  #[test]
+  fn test_read_whole_request_body_same_chunks() {
+    // When received and buffered body point to the same underlying memory (which happens
+    // when a previous filter returned StopAndBuffer), the data should appear only once.
+    static mut BUFFER: [u8; 11] = *b"hello world";
+    let mut mock = MockEnvoyHttpFilter::default();
+    // get_received_request_body: called once (pointer collection).
+    mock
+      .expect_get_received_request_body()
+      .times(1)
+      .returning(|| Some(vec![EnvoyMutBuffer::new(unsafe { &mut BUFFER })]));
+    // get_buffered_request_body: called twice (pointer collection + data copy).
+    mock
+      .expect_get_buffered_request_body()
+      .times(2)
+      .returning(|| Some(vec![EnvoyMutBuffer::new(unsafe { &mut BUFFER })]));
+
+    assert_eq!(read_whole_request_body(&mut mock), b"hello world");
+  }
+
+  #[test]
+  fn test_read_whole_request_body_different_chunks() {
+    // When received and buffered bodies are different, the result is buffered + received.
+    static mut BUFFERED: [u8; 6] = *b"hello ";
+    static mut RECEIVED: [u8; 5] = *b"world";
+    let mut mock = MockEnvoyHttpFilter::default();
+    // Each getter is called twice: once for pointer collection, once for data copy.
+    mock
+      .expect_get_received_request_body()
+      .times(2)
+      .returning(|| Some(vec![EnvoyMutBuffer::new(unsafe { &mut RECEIVED })]));
+    mock
+      .expect_get_buffered_request_body()
+      .times(2)
+      .returning(|| Some(vec![EnvoyMutBuffer::new(unsafe { &mut BUFFERED })]));
+
+    assert_eq!(read_whole_request_body(&mut mock), b"hello world");
+  }
+
+  #[test]
+  fn test_read_whole_request_body_empty_buffered() {
+    // When buffered body is empty (None), result equals the received body.
+    static mut RECEIVED: [u8; 5] = *b"world";
+    let mut mock = MockEnvoyHttpFilter::default();
+    mock
+      .expect_get_received_request_body()
+      .times(2)
+      .returning(|| Some(vec![EnvoyMutBuffer::new(unsafe { &mut RECEIVED })]));
+    mock
+      .expect_get_buffered_request_body()
+      .times(2)
+      .returning(|| None);
+
+    assert_eq!(read_whole_request_body(&mut mock), b"world");
+  }
+
+  #[test]
+  fn test_read_whole_response_body_same_chunks() {
+    // When received and buffered body point to the same underlying memory,
+    // the data should appear only once.
+    static mut BUFFER: [u8; 11] = *b"hello world";
+    let mut mock = MockEnvoyHttpFilter::default();
+    mock
+      .expect_get_received_response_body()
+      .times(1)
+      .returning(|| Some(vec![EnvoyMutBuffer::new(unsafe { &mut BUFFER })]));
+    mock
+      .expect_get_buffered_response_body()
+      .times(2)
+      .returning(|| Some(vec![EnvoyMutBuffer::new(unsafe { &mut BUFFER })]));
+
+    assert_eq!(read_whole_response_body(&mut mock), b"hello world");
+  }
+
+  #[test]
+  fn test_read_whole_response_body_different_chunks() {
+    // When received and buffered bodies are different, the result is buffered + received.
+    static mut BUFFERED: [u8; 6] = *b"hello ";
+    static mut RECEIVED: [u8; 5] = *b"world";
+    let mut mock = MockEnvoyHttpFilter::default();
+    mock
+      .expect_get_received_response_body()
+      .times(2)
+      .returning(|| Some(vec![EnvoyMutBuffer::new(unsafe { &mut RECEIVED })]));
+    mock
+      .expect_get_buffered_response_body()
+      .times(2)
+      .returning(|| Some(vec![EnvoyMutBuffer::new(unsafe { &mut BUFFERED })]));
+
+    assert_eq!(read_whole_response_body(&mut mock), b"hello world");
+  }
+
+  #[test]
+  fn test_read_whole_response_body_empty_buffered() {
+    // When buffered body is empty (None), result equals the received body.
+    static mut RECEIVED: [u8; 5] = *b"world";
+    let mut mock = MockEnvoyHttpFilter::default();
+    mock
+      .expect_get_received_response_body()
+      .times(2)
+      .returning(|| Some(vec![EnvoyMutBuffer::new(unsafe { &mut RECEIVED })]));
+    mock
+      .expect_get_buffered_response_body()
+      .times(2)
+      .returning(|| None);
+
+    assert_eq!(read_whole_response_body(&mut mock), b"world");
+  }
+}


### PR DESCRIPTION
Commit Message: dym SDK: support utility methods to read body Additional Description:

Added helper methods to read the whole request/response body correctly.

Risk Level: low.
Testing: n/a.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.

---------

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
