### PR TITLE
dispatcher: add bounded batching for deferred delete processing

### DIFF
--- a/api/envoy/config/bootstrap/v3/bootstrap.proto
+++ b/api/envoy/config/bootstrap/v3/bootstrap.proto
@@ -42,7 +42,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // <config_overview_bootstrap>` for more detail.
 
 // Bootstrap :ref:`configuration overview <config_overview_bootstrap>`.
-// [#next-free-field: 43]
+// [#next-free-field: 44]
 message Bootstrap {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.bootstrap.v2.Bootstrap";
@@ -433,6 +433,16 @@ message Bootstrap {
   // Optional configuration for memory allocation manager.
   // Memory releasing is only supported for `tcmalloc allocator <https://github.com/google/tcmalloc>`_.
   MemoryAllocatorManager memory_allocator_manager = 41;
+
+  // The maximum number of deferred object deletions to process per event loop iteration.
+  // When a large number of connections are closed simultaneously (e.g., after an EDS endpoint
+  // membership update), their cleanup is queued for deferred deletion. Processing all
+  // of them in a single pass can stall the event loop for seconds, causing connection timeouts
+  // and a self-sustaining degradation loop. Setting this to a non-zero value splits the work
+  // across multiple event loop iterations, allowing timers and I/O events to fire between
+  // batches. If not specified, the default is ``0`` (disabled, all pending deletions are
+  // processed in one pass, preserving existing behavior).
+  google.protobuf.UInt32Value deferred_deletes_batch_size = 43;
 }
 
 // Administration interface :ref:`operations documentation
@@ -547,7 +557,7 @@ message Watchdogs {
 // Envoy process watchdog configuration. When configured, this monitors for
 // nonresponsive threads and kills the process after the configured thresholds.
 // See the :ref:`watchdog documentation <operations_performance_watchdog>` for more information.
-// [#next-free-field: 9]
+// [#next-free-field: 8]
 message Watchdog {
   option (udpa.annotations.versioning).previous_message_type = "envoy.config.bootstrap.v2.Watchdog";
 
@@ -605,17 +615,6 @@ message Watchdog {
   // nonresponsive threads required for the ``multikill_timeout``.
   // If not specified the default is ``0``.
   type.v3.Percent multikill_threshold = 5;
-
-  // The maximum number of deferred object deletions to process per event loop iteration.
-  // When a large number of connections are closed simultaneously (e.g., after an EDS endpoint
-  // membership update), their cleanup is queued for deferred deletion. Processing all
-  // of them in a single pass can stall the event loop for seconds, causing connection timeouts
-  // and a self-sustaining degradation loop. Setting this to a non-zero value splits the work
-  // across multiple event loop iterations, allowing timers and I/O events to fire between
-  // batches. The value should be low enough that a single batch completes well within the
-  // ``miss_timeout`` (default 200ms). If not specified, the default is ``0`` (disabled --
-  // all pending deletions are processed in one pass, preserving existing behavior).
-  google.protobuf.UInt32Value deferred_deletes_batch_size = 8;
 }
 
 // Fatal actions to run while crashing. Actions can be safe (meaning they are

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -497,7 +497,7 @@ new_features:
 - area: dispatcher
   change: |
     Added :ref:`deferred_deletes_batch_size
-    <envoy_v3_api_field_config.bootstrap.v3.Watchdog.deferred_deletes_batch_size>` to the watchdog
+    <envoy_v3_api_field_config.bootstrap.v3.Bootstrap.deferred_deletes_batch_size>` to the bootstrap
     configuration. When set to a non-zero value, large batches of deferred object deletions (e.g.,
     HTTP/2+TLS connections removed by an EDS update) are processed across multiple event loop
     iterations instead of a single pass, preventing event loop starvation that can cascade into

--- a/envoy/server/configuration.h
+++ b/envoy/server/configuration.h
@@ -63,12 +63,6 @@ public:
    */
   virtual Protobuf::RepeatedPtrField<envoy::config::bootstrap::v3::Watchdog::WatchdogAction>
   actions() const PURE;
-
-  /**
-   * @return uint32_t the maximum number of deferred deletions to process per event loop iteration.
-   *         0 means unbounded (all items processed in a single pass).
-   */
-  virtual uint32_t deferredDeletesBatchSize() const PURE;
 };
 
 class StatsConfig {

--- a/source/server/configuration_impl.cc
+++ b/source/server/configuration_impl.cc
@@ -245,8 +245,6 @@ WatchdogImpl::WatchdogImpl(const envoy::config::bootstrap::v3::Watchdog& watchdo
       std::chrono::milliseconds(PROTOBUF_GET_MS_OR_DEFAULT(watchdog, multikill_timeout, 0));
   multikill_threshold_ = PROTOBUF_PERCENT_TO_DOUBLE_OR_DEFAULT(watchdog, multikill_threshold, 0.0);
   actions_ = watchdog.actions();
-  deferred_deletes_batch_size_ =
-      PROTOBUF_GET_WRAPPED_OR_DEFAULT(watchdog, deferred_deletes_batch_size, 0);
 }
 
 InitialImpl::InitialImpl(const envoy::config::bootstrap::v3::Bootstrap& bootstrap,

--- a/source/server/configuration_impl.h
+++ b/source/server/configuration_impl.h
@@ -176,7 +176,6 @@ public:
   actions() const override {
     return actions_;
   }
-  uint32_t deferredDeletesBatchSize() const override { return deferred_deletes_batch_size_; }
 
 private:
   std::chrono::milliseconds miss_timeout_;
@@ -185,7 +184,6 @@ private:
   std::chrono::milliseconds multikill_timeout_;
   double multikill_threshold_;
   Protobuf::RepeatedPtrField<envoy::config::bootstrap::v3::Watchdog::WatchdogAction> actions_;
-  uint32_t deferred_deletes_batch_size_;
 };
 
 /**

--- a/source/server/guarddog_impl.cc
+++ b/source/server/guarddog_impl.cc
@@ -91,7 +91,7 @@ GuardDogImpl::GuardDogImpl(Stats::Scope& stats_scope, const Server::Configuratio
 
         return map;
       }(config)),
-      run_thread_(true), deferred_deletes_batch_size_(config.deferredDeletesBatchSize()) {
+      run_thread_(true) {
   start(api);
 }
 
@@ -202,7 +202,6 @@ WatchDogSharedPtr GuardDogImpl::createWatchDog(Thread::ThreadId thread_id,
     watched_dogs_.push_back(std::move(watched_dog));
   }
   dispatcher.registerWatchdog(new_watchdog, wd_interval);
-  dispatcher.setDeferredDeletesBatchSize(deferred_deletes_batch_size_);
   new_watchdog->touch();
   return new_watchdog;
 }

--- a/source/server/guarddog_impl.h
+++ b/source/server/guarddog_impl.h
@@ -147,7 +147,6 @@ private:
   EventToActionsMap events_to_actions_;
   Thread::MutexBasicLockable mutex_;
   bool run_thread_ ABSL_GUARDED_BY(mutex_);
-  const uint32_t deferred_deletes_batch_size_;
 };
 
 } // namespace Server

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -866,6 +866,11 @@ absl::Status InstanceBase::initializeOrThrow(Network::Address::InstanceConstShar
   // started and before our own run() loop runs.
   main_thread_guard_dog_ = maybeCreateGuardDog("main_thread");
   worker_guard_dog_ = maybeCreateGuardDog("workers");
+
+  const uint32_t batch_size =
+      PROTOBUF_GET_WRAPPED_OR_DEFAULT(bootstrap_, deferred_deletes_batch_size, 0);
+  dispatcher_->setDeferredDeletesBatchSize(batch_size);
+
   return absl::OkStatus();
 }
 

--- a/source/server/worker_impl.cc
+++ b/source/server/worker_impl.cc
@@ -3,6 +3,7 @@
 #include <functional>
 #include <memory>
 
+#include "envoy/config/bootstrap/v3/bootstrap.pb.h"
 #include "envoy/event/dispatcher.h"
 #include "envoy/event/timer.h"
 #include "envoy/network/exception.h"
@@ -10,6 +11,7 @@
 #include "envoy/thread_local/thread_local.h"
 
 #include "source/common/config/utility.h"
+#include "source/common/protobuf/utility.h"
 #include "source/server/listener_manager_factory.h"
 
 namespace Envoy {
@@ -37,6 +39,9 @@ WorkerPtr ProdWorkerFactory::createWorker(uint32_t index, OverloadManager& overl
                                           const std::string& worker_name) {
   Event::DispatcherPtr dispatcher(
       api_.allocateDispatcher(worker_name, overload_manager.scaledTimerFactory()));
+  const uint32_t batch_size =
+      PROTOBUF_GET_WRAPPED_OR_DEFAULT(api_.bootstrap(), deferred_deletes_batch_size, 0);
+  dispatcher->setDeferredDeletesBatchSize(batch_size);
   auto conn_handler = getHandler(*dispatcher, index, overload_manager, null_overload_manager);
   return std::make_unique<WorkerImpl>(tls_, hooks_, std::move(dispatcher), std::move(conn_handler),
                                       overload_manager, api_, stat_names_);

--- a/test/mocks/server/watchdog_config.cc
+++ b/test/mocks/server/watchdog_config.cc
@@ -31,7 +31,6 @@ MockWatchdog::MockWatchdog(int miss, int megamiss, int kill, int multikill,
   ON_CALL(*this, multiKillTimeout()).WillByDefault(Return(multikill_));
   ON_CALL(*this, multiKillThreshold()).WillByDefault(Return(multikill_threshold_));
   ON_CALL(*this, actions).WillByDefault(Return(actions_));
-  ON_CALL(*this, deferredDeletesBatchSize()).WillByDefault(Return(0));
 }
 
 } // namespace Configuration

--- a/test/mocks/server/watchdog_config.h
+++ b/test/mocks/server/watchdog_config.h
@@ -23,7 +23,6 @@ public:
   MOCK_METHOD(double, multiKillThreshold, (), (const));
   MOCK_METHOD(Protobuf::RepeatedPtrField<envoy::config::bootstrap::v3::Watchdog::WatchdogAction>,
               actions, (), (const));
-  MOCK_METHOD(uint32_t, deferredDeletesBatchSize, (), (const));
 
   std::chrono::milliseconds miss_;
   std::chrono::milliseconds megamiss_;


### PR DESCRIPTION
Commit Message:
Large EDS membership updates can cause thousands of HTTP/2+TLS connections to be closed simultaneously, queuing their destructions in the dispatcher's deferred delete list. Processing all of them in a single clearDeferredDeleteList() call starves the event loop for seconds, causing upstream connection timeouts (connect_timeout < stall duration) and a self-sustaining degradation loop where timeouts generate more work, perpetuating the stall.

Add a configurable deferred_deletes_batch_size setting under the watchdog config that bounds the number of deferred deletions processed per event loop iteration. Remaining items are re-scheduled via scheduleCallbackCurrentIteration(), allowing timers, I/O events, and health checks to fire between batches. The setting defaults to 0 (disabled), preserving existing behavior unless explicitly opted in.

Configurable via bootstrap:
```
  watchdogs:
    worker_watchdog:
      deferred_deletes_batch_size: 32
```
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
