### PR TITLE
dym go SDK: use the UnsafeEnvoyBuffer to indicate the lifetime explicitly

### DIFF
--- a/source/extensions/dynamic_modules/sdk/go/shared/mocks/mock_base.go
+++ b/source/extensions/dynamic_modules/sdk/go/shared/mocks/mock_base.go
@@ -65,10 +65,10 @@ func (mr *MockBodyBufferMockRecorder) Drain(numBytes any) *gomock.Call {
 }
 
 // GetChunks mocks base method.
-func (m *MockBodyBuffer) GetChunks() [][]byte {
+func (m *MockBodyBuffer) GetChunks() []shared.UnsafeEnvoyBuffer {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetChunks")
-	ret0, _ := ret[0].([][]byte)
+	ret0, _ := ret[0].([]shared.UnsafeEnvoyBuffer)
 	return ret0
 }
 
@@ -129,10 +129,10 @@ func (mr *MockHeaderMapMockRecorder) Add(key, value any) *gomock.Call {
 }
 
 // Get mocks base method.
-func (m *MockHeaderMap) Get(key string) []string {
+func (m *MockHeaderMap) Get(key string) []shared.UnsafeEnvoyBuffer {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get", key)
-	ret0, _ := ret[0].([]string)
+	ret0, _ := ret[0].([]shared.UnsafeEnvoyBuffer)
 	return ret0
 }
 
@@ -143,10 +143,10 @@ func (mr *MockHeaderMapMockRecorder) Get(key any) *gomock.Call {
 }
 
 // GetAll mocks base method.
-func (m *MockHeaderMap) GetAll() [][2]string {
+func (m *MockHeaderMap) GetAll() [][2]shared.UnsafeEnvoyBuffer {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAll")
-	ret0, _ := ret[0].([][2]string)
+	ret0, _ := ret[0].([][2]shared.UnsafeEnvoyBuffer)
 	return ret0
 }
 
@@ -157,10 +157,10 @@ func (mr *MockHeaderMapMockRecorder) GetAll() *gomock.Call {
 }
 
 // GetOne mocks base method.
-func (m *MockHeaderMap) GetOne(key string) string {
+func (m *MockHeaderMap) GetOne(key string) shared.UnsafeEnvoyBuffer {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetOne", key)
-	ret0, _ := ret[0].(string)
+	ret0, _ := ret[0].(shared.UnsafeEnvoyBuffer)
 	return ret0
 }
 
@@ -219,7 +219,7 @@ func (m *MockHttpCalloutCallback) EXPECT() *MockHttpCalloutCallbackMockRecorder 
 }
 
 // OnHttpCalloutDone mocks base method.
-func (m *MockHttpCalloutCallback) OnHttpCalloutDone(calloutID uint64, result shared.HttpCalloutResult, headers [][2]string, body [][]byte) {
+func (m *MockHttpCalloutCallback) OnHttpCalloutDone(calloutID uint64, result shared.HttpCalloutResult, headers [][2]shared.UnsafeEnvoyBuffer, body []shared.UnsafeEnvoyBuffer) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "OnHttpCalloutDone", calloutID, result, headers, body)
 }
@@ -267,7 +267,7 @@ func (mr *MockHttpStreamCallbackMockRecorder) OnHttpStreamComplete(streamID any)
 }
 
 // OnHttpStreamData mocks base method.
-func (m *MockHttpStreamCallback) OnHttpStreamData(streamID uint64, body [][]byte, endStream bool) {
+func (m *MockHttpStreamCallback) OnHttpStreamData(streamID uint64, body []shared.UnsafeEnvoyBuffer, endStream bool) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "OnHttpStreamData", streamID, body, endStream)
 }
@@ -279,7 +279,7 @@ func (mr *MockHttpStreamCallbackMockRecorder) OnHttpStreamData(streamID, body, e
 }
 
 // OnHttpStreamHeaders mocks base method.
-func (m *MockHttpStreamCallback) OnHttpStreamHeaders(streamID uint64, headers [][2]string, endStream bool) {
+func (m *MockHttpStreamCallback) OnHttpStreamHeaders(streamID uint64, headers [][2]shared.UnsafeEnvoyBuffer, endStream bool) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "OnHttpStreamHeaders", streamID, headers, endStream)
 }
@@ -303,7 +303,7 @@ func (mr *MockHttpStreamCallbackMockRecorder) OnHttpStreamReset(streamID, reason
 }
 
 // OnHttpStreamTrailers mocks base method.
-func (m *MockHttpStreamCallback) OnHttpStreamTrailers(streamID uint64, trailers [][2]string) {
+func (m *MockHttpStreamCallback) OnHttpStreamTrailers(streamID uint64, trailers [][2]shared.UnsafeEnvoyBuffer) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "OnHttpStreamTrailers", streamID, trailers)
 }
@@ -529,21 +529,6 @@ func (mr *MockHttpFilterHandleMockRecorder) DecrementGaugeValue(id, value any, t
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DecrementGaugeValue", reflect.TypeOf((*MockHttpFilterHandle)(nil).DecrementGaugeValue), varargs...)
 }
 
-// GetAttributeNumber mocks base method.
-func (m *MockHttpFilterHandle) GetAttributeNumber(attributeID shared.AttributeID) (float64, bool) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAttributeNumber", attributeID)
-	ret0, _ := ret[0].(float64)
-	ret1, _ := ret[1].(bool)
-	return ret0, ret1
-}
-
-// GetAttributeNumber indicates an expected call of GetAttributeNumber.
-func (mr *MockHttpFilterHandleMockRecorder) GetAttributeNumber(attributeID any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAttributeNumber", reflect.TypeOf((*MockHttpFilterHandle)(nil).GetAttributeNumber), attributeID)
-}
-
 // GetAttributeBool mocks base method.
 func (m *MockHttpFilterHandle) GetAttributeBool(attributeID shared.AttributeID) (bool, bool) {
 	m.ctrl.T.Helper()
@@ -559,11 +544,26 @@ func (mr *MockHttpFilterHandleMockRecorder) GetAttributeBool(attributeID any) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAttributeBool", reflect.TypeOf((*MockHttpFilterHandle)(nil).GetAttributeBool), attributeID)
 }
 
+// GetAttributeNumber mocks base method.
+func (m *MockHttpFilterHandle) GetAttributeNumber(attributeID shared.AttributeID) (float64, bool) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAttributeNumber", attributeID)
+	ret0, _ := ret[0].(float64)
+	ret1, _ := ret[1].(bool)
+	return ret0, ret1
+}
+
+// GetAttributeNumber indicates an expected call of GetAttributeNumber.
+func (mr *MockHttpFilterHandleMockRecorder) GetAttributeNumber(attributeID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAttributeNumber", reflect.TypeOf((*MockHttpFilterHandle)(nil).GetAttributeNumber), attributeID)
+}
+
 // GetAttributeString mocks base method.
-func (m *MockHttpFilterHandle) GetAttributeString(attributeID shared.AttributeID) (string, bool) {
+func (m *MockHttpFilterHandle) GetAttributeString(attributeID shared.AttributeID) (shared.UnsafeEnvoyBuffer, bool) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAttributeString", attributeID)
-	ret0, _ := ret[0].(string)
+	ret0, _ := ret[0].(shared.UnsafeEnvoyBuffer)
 	ret1, _ := ret[1].(bool)
 	return ret0, ret1
 }
@@ -589,10 +589,10 @@ func (mr *MockHttpFilterHandleMockRecorder) GetData(key any) *gomock.Call {
 }
 
 // GetFilterState mocks base method.
-func (m *MockHttpFilterHandle) GetFilterState(key string) ([]byte, bool) {
+func (m *MockHttpFilterHandle) GetFilterState(key string) (shared.UnsafeEnvoyBuffer, bool) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetFilterState", key)
-	ret0, _ := ret[0].([]byte)
+	ret0, _ := ret[0].(shared.UnsafeEnvoyBuffer)
 	ret1, _ := ret[1].(bool)
 	return ret0, ret1
 }
@@ -601,21 +601,6 @@ func (m *MockHttpFilterHandle) GetFilterState(key string) ([]byte, bool) {
 func (mr *MockHttpFilterHandleMockRecorder) GetFilterState(key any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFilterState", reflect.TypeOf((*MockHttpFilterHandle)(nil).GetFilterState), key)
-}
-
-// GetMetadataNumber mocks base method.
-func (m *MockHttpFilterHandle) GetMetadataNumber(source shared.MetadataSourceType, metadataNamespace, key string) (float64, bool) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetMetadataNumber", source, metadataNamespace, key)
-	ret0, _ := ret[0].(float64)
-	ret1, _ := ret[1].(bool)
-	return ret0, ret1
-}
-
-// GetMetadataNumber indicates an expected call of GetMetadataNumber.
-func (mr *MockHttpFilterHandleMockRecorder) GetMetadataNumber(source, metadataNamespace, key any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMetadataNumber", reflect.TypeOf((*MockHttpFilterHandle)(nil).GetMetadataNumber), source, metadataNamespace, key)
 }
 
 // GetMetadataBool mocks base method.
@@ -634,10 +619,10 @@ func (mr *MockHttpFilterHandleMockRecorder) GetMetadataBool(source, metadataName
 }
 
 // GetMetadataKeys mocks base method.
-func (m *MockHttpFilterHandle) GetMetadataKeys(source shared.MetadataSourceType, metadataNamespace string) []string {
+func (m *MockHttpFilterHandle) GetMetadataKeys(source shared.MetadataSourceType, metadataNamespace string) []shared.UnsafeEnvoyBuffer {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMetadataKeys", source, metadataNamespace)
-	ret0, _ := ret[0].([]string)
+	ret0, _ := ret[0].([]shared.UnsafeEnvoyBuffer)
 	return ret0
 }
 
@@ -648,10 +633,10 @@ func (mr *MockHttpFilterHandleMockRecorder) GetMetadataKeys(source, metadataName
 }
 
 // GetMetadataNamespaces mocks base method.
-func (m *MockHttpFilterHandle) GetMetadataNamespaces(source shared.MetadataSourceType) []string {
+func (m *MockHttpFilterHandle) GetMetadataNamespaces(source shared.MetadataSourceType) []shared.UnsafeEnvoyBuffer {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMetadataNamespaces", source)
-	ret0, _ := ret[0].([]string)
+	ret0, _ := ret[0].([]shared.UnsafeEnvoyBuffer)
 	return ret0
 }
 
@@ -661,11 +646,26 @@ func (mr *MockHttpFilterHandleMockRecorder) GetMetadataNamespaces(source any) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMetadataNamespaces", reflect.TypeOf((*MockHttpFilterHandle)(nil).GetMetadataNamespaces), source)
 }
 
+// GetMetadataNumber mocks base method.
+func (m *MockHttpFilterHandle) GetMetadataNumber(source shared.MetadataSourceType, metadataNamespace, key string) (float64, bool) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMetadataNumber", source, metadataNamespace, key)
+	ret0, _ := ret[0].(float64)
+	ret1, _ := ret[1].(bool)
+	return ret0, ret1
+}
+
+// GetMetadataNumber indicates an expected call of GetMetadataNumber.
+func (mr *MockHttpFilterHandleMockRecorder) GetMetadataNumber(source, metadataNamespace, key any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMetadataNumber", reflect.TypeOf((*MockHttpFilterHandle)(nil).GetMetadataNumber), source, metadataNamespace, key)
+}
+
 // GetMetadataString mocks base method.
-func (m *MockHttpFilterHandle) GetMetadataString(source shared.MetadataSourceType, metadataNamespace, key string) (string, bool) {
+func (m *MockHttpFilterHandle) GetMetadataString(source shared.MetadataSourceType, metadataNamespace, key string) (shared.UnsafeEnvoyBuffer, bool) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMetadataString", source, metadataNamespace, key)
-	ret0, _ := ret[0].(string)
+	ret0, _ := ret[0].(shared.UnsafeEnvoyBuffer)
 	ret1, _ := ret[1].(bool)
 	return ret0, ret1
 }

--- a/test/extensions/dynamic_modules/test_data/go/http_integration_test/http_integration_test.go
+++ b/test/extensions/dynamic_modules/test_data/go/http_integration_test/http_integration_test.go
@@ -193,9 +193,9 @@ func assertEq(a, b interface{}, msg string) {
 func (p *HeaderCallbacksFilter) OnRequestHeaders(headers shared.HeaderMap,
 	endOfStream bool) shared.HeadersStatus {
 	p.reqHeadersCalled = true
-	assertEq(headers.GetOne(":path"), "/test/long/url", ":path header")
-	assertEq(headers.GetOne(":method"), "POST", ":method header")
-	assertEq(headers.GetOne("foo"), "bar", "foo header")
+	assertEq(headers.GetOne(":path").ToUnsafeString(), "/test/long/url", ":path header")
+	assertEq(headers.GetOne(":method").ToUnsafeString(), "POST", ":method header")
+	assertEq(headers.GetOne("foo").ToUnsafeString(), "bar", "foo header")
 
 	for k, v := range p.headersToAdd {
 		headers.Set(k, v)
@@ -203,33 +203,33 @@ func (p *HeaderCallbacksFilter) OnRequestHeaders(headers shared.HeaderMap,
 
 	// Test setter/getter
 	headers.Set("new", "value1")
-	assertEq(headers.GetOne("new"), "value1", "new header set")
+	assertEq(headers.GetOne("new").ToUnsafeString(), "value1", "new header set")
 
 	vals := headers.Get("new")
 	assertEq(len(vals), 1, "new header count")
-	assertEq(vals[0], "value1", "new header val")
+	assertEq(vals[0].ToUnsafeString(), "value1", "new header val")
 
 	// Test add
 	headers.Add("new", "value2")
 	vals = headers.Get("new")
 	assertEq(len(vals), 2, "new header count after add")
-	assertEq(vals[1], "value2", "new header val 2")
+	assertEq(vals[1].ToUnsafeString(), "value2", "new header val 2")
 
 	// Test remove
 	headers.Remove("new")
-	assertEq(headers.GetOne("new"), "", "new header removed")
+	assertEq(headers.GetOne("new").ToUnsafeString(), "", "new header removed")
 	return shared.HeadersStatusContinue
 }
 
 func (p *HeaderCallbacksFilter) OnRequestTrailers(trailers shared.HeaderMap) shared.TrailersStatus {
 	p.reqTrailersCalled = true
-	assertEq(trailers.GetOne("foo"), "bar", "foo trailer")
+	assertEq(trailers.GetOne("foo").ToUnsafeString(), "bar", "foo trailer")
 	for k, v := range p.headersToAdd {
 		trailers.Set(k, v)
 	}
 	// Test setter/getter
 	trailers.Set("new", "value1")
-	assertEq(trailers.GetOne("new"), "value1", "new trailer set")
+	assertEq(trailers.GetOne("new").ToUnsafeString(), "value1", "new trailer set")
 
 	// Test add
 	trailers.Add("new", "value2")
@@ -238,39 +238,39 @@ func (p *HeaderCallbacksFilter) OnRequestTrailers(trailers shared.HeaderMap) sha
 
 	// Test remove
 	trailers.Remove("new")
-	assertEq(trailers.GetOne("new"), "", "new trailer removed")
+	assertEq(trailers.GetOne("new").ToUnsafeString(), "", "new trailer removed")
 	return shared.TrailersStatusContinue
 }
 
 func (p *HeaderCallbacksFilter) OnResponseHeaders(headers shared.HeaderMap, endOfStream bool) shared.HeadersStatus {
 	p.resHeadersCalled = true
-	assertEq(headers.GetOne("foo"), "bar", "foo response header")
+	assertEq(headers.GetOne("foo").ToUnsafeString(), "bar", "foo response header")
 	for k, v := range p.headersToAdd {
 		headers.Set(k, v)
 	}
 
 	headers.Set("new", "value1")
-	assertEq(headers.GetOne("new"), "value1", "new resp header")
+	assertEq(headers.GetOne("new").ToUnsafeString(), "value1", "new resp header")
 	headers.Add("new", "value2")
 	assertEq(len(headers.Get("new")), 2, "new resp header count")
 	headers.Remove("new")
-	assertEq(headers.GetOne("new"), "", "new resp header removed")
+	assertEq(headers.GetOne("new").ToUnsafeString(), "", "new resp header removed")
 	return shared.HeadersStatusContinue
 }
 
 func (p *HeaderCallbacksFilter) OnResponseTrailers(trailers shared.HeaderMap) shared.TrailersStatus {
 	p.resTrailersCalled = true
-	assertEq(trailers.GetOne("foo"), "bar", "foo response trailer")
+	assertEq(trailers.GetOne("foo").ToUnsafeString(), "bar", "foo response trailer")
 	for k, v := range p.headersToAdd {
 		trailers.Set(k, v)
 	}
 
 	trailers.Set("new", "value1")
-	assertEq(trailers.GetOne("new"), "value1", "new resp trailer")
+	assertEq(trailers.GetOne("new").ToUnsafeString(), "value1", "new resp trailer")
 	trailers.Add("new", "value2")
 	assertEq(len(trailers.Get("new")), 2, "new resp trailer count")
 	trailers.Remove("new")
-	assertEq(trailers.GetOne("new"), "", "new resp trailer removed")
+	assertEq(trailers.GetOne("new").ToUnsafeString(), "", "new resp trailer removed")
 	return shared.TrailersStatusContinue
 }
 
@@ -383,10 +383,10 @@ func (p *BodyCallbacksFilter) OnRequestBody(body shared.BodyBuffer,
 	var body_content string
 
 	for _, c := range p.handle.BufferedRequestBody().GetChunks() {
-		body_content += string(c)
+		body_content += c.ToUnsafeString()
 	}
 	for _, c := range body.GetChunks() {
-		body_content += string(c)
+		body_content += c.ToUnsafeString()
 	}
 
 	assertEq(body_content, "request_body", "request body content")
@@ -417,10 +417,10 @@ func (p *BodyCallbacksFilter) OnResponseBody(body shared.BodyBuffer,
 	var body_content string
 
 	for _, c := range p.handle.BufferedResponseBody().GetChunks() {
-		body_content += string(c)
+		body_content += c.ToUnsafeString()
 	}
 	for _, c := range body.GetChunks() {
-		body_content += string(c)
+		body_content += c.ToUnsafeString()
 	}
 
 	assertEq(body_content, "response_body", "response body content")
@@ -546,7 +546,7 @@ func (p *HttpCalloutsFilter) OnRequestHeaders(headers shared.HeaderMap,
 }
 
 func (p *HttpCalloutsFilter) OnHttpCalloutDone(calloutID uint64, result shared.HttpCalloutResult,
-	headers [][2]string, body [][]byte) {
+	headers [][2]shared.UnsafeEnvoyBuffer, body []shared.UnsafeEnvoyBuffer) {
 	if p.clusterName == "resetting_cluster" {
 		assert(result == shared.HttpCalloutReset, "expected reset")
 		return
@@ -556,7 +556,7 @@ func (p *HttpCalloutsFilter) OnHttpCalloutDone(calloutID uint64, result shared.H
 
 	found := false
 	for _, h := range headers {
-		if h[0] == "some_header" && h[1] == "some_value" {
+		if h[0].ToUnsafeString() == "some_header" && h[1].ToUnsafeString() == "some_value" {
 			found = true
 			break
 		}
@@ -565,7 +565,7 @@ func (p *HttpCalloutsFilter) OnHttpCalloutDone(calloutID uint64, result shared.H
 
 	fullBody := ""
 	for _, b := range body {
-		fullBody += string(b)
+		fullBody += b.ToUnsafeString()
 	}
 	assertEq(fullBody, "response_body_from_callout", "resp body")
 
@@ -683,7 +683,7 @@ func (p *FakeExternalCacheFilter) OnRequestHeaders(headers shared.HeaderMap, end
 	sched := p.handle.GetScheduler()
 
 	go func() {
-		if key == "existing" {
+		if key.ToUnsafeString() == "existing" {
 			// Simulate hit
 			sched.Schedule(func() {
 				p.handle.SendLocalResponse(200, [][2]string{{"cached", "yes"}}, []byte("cached_response_body"), "")
@@ -785,18 +785,18 @@ type StatsCallbacksFilter struct {
 func (p *StatsCallbacksFilter) OnRequestHeaders(headers shared.HeaderMap, endOfStream bool) shared.HeadersStatus {
 	p.handle.IncrementCounterValue(p.ids.reqTotal, 1)
 	p.handle.IncrementGaugeValue(p.ids.reqPending, 1)
-	p.method = headers.GetOne(":method")
+	p.method = headers.GetOne(":method").ToUnsafeString()
 
 	p.handle.IncrementCounterValue(p.ids.epTotal, 1, "on_request_headers", p.method)
 	p.handle.IncrementGaugeValue(p.ids.epPending, 1, "on_request_headers", p.method)
 
-	if valStr := headers.GetOne(p.ids.headerToCount); valStr != "" {
+	if valStr := headers.GetOne(p.ids.headerToCount).ToUnsafeString(); valStr != "" {
 		if val, err := strconv.ParseUint(valStr, 10, 64); err == nil {
 			p.handle.RecordHistogramValue(p.ids.reqVals, val)
 			p.handle.RecordHistogramValue(p.ids.epVals, val, "on_request_headers", p.method)
 		}
 	}
-	if valStr := headers.GetOne(p.ids.headerToSet); valStr != "" {
+	if valStr := headers.GetOne(p.ids.headerToSet).ToUnsafeString(); valStr != "" {
 		if val, err := strconv.ParseUint(valStr, 10, 64); err == nil {
 			p.handle.SetGaugeValue(p.ids.reqSet, val)
 			p.handle.SetGaugeValue(p.ids.epSet, val, "on_request_headers", p.method)
@@ -811,12 +811,12 @@ func (p *StatsCallbacksFilter) OnResponseHeaders(headers shared.HeaderMap, endOf
 	p.handle.DecrementGaugeValue(p.ids.epPending, 1, "on_request_headers", p.method)
 	p.handle.IncrementGaugeValue(p.ids.epPending, 1, "on_response_headers", p.method)
 
-	if valStr := headers.GetOne(p.ids.headerToCount); valStr != "" {
+	if valStr := headers.GetOne(p.ids.headerToCount).ToUnsafeString(); valStr != "" {
 		if val, err := strconv.ParseUint(valStr, 10, 64); err == nil {
 			p.handle.RecordHistogramValue(p.ids.epVals, val, "on_response_headers", p.method)
 		}
 	}
-	if valStr := headers.GetOne(p.ids.headerToSet); valStr != "" {
+	if valStr := headers.GetOne(p.ids.headerToSet).ToUnsafeString(); valStr != "" {
 		if val, err := strconv.ParseUint(valStr, 10, 64); err == nil {
 			p.handle.SetGaugeValue(p.ids.epSet, val, "on_response_headers", p.method)
 		}
@@ -970,22 +970,23 @@ func (p *HttpStreamBasicFilter) OnRequestHeaders(h shared.HeaderMap, end bool) s
 	return shared.HeadersStatusStop
 }
 
-func (p *HttpStreamBasicFilter) OnHttpStreamHeaders(id uint64, headers [][2]string, end bool) {
+func (p *HttpStreamBasicFilter) OnHttpStreamHeaders(id uint64, headers [][2]shared.UnsafeEnvoyBuffer, end bool) {
 	assertEq(id, p.streamID, "stream id")
 	p.headers = true
 	found := false
 	for _, h := range headers {
-		if h[0] == ":status" && h[1] == "200" {
+		if h[0].ToUnsafeString() == ":status" && h[1].ToUnsafeString() == "200" {
 			found = true
 		}
 	}
 	assert(found, "status 200")
 }
-func (p *HttpStreamBasicFilter) OnHttpStreamData(id uint64, body [][]byte, end bool) {
+func (p *HttpStreamBasicFilter) OnHttpStreamData(id uint64, body []shared.UnsafeEnvoyBuffer, end bool) {
 	assertEq(id, p.streamID, "stream id")
 	p.data = true
 }
-func (p *HttpStreamBasicFilter) OnHttpStreamTrailers(id uint64, trailers [][2]string) {}
+func (p *HttpStreamBasicFilter) OnHttpStreamTrailers(id uint64, trailers [][2]shared.UnsafeEnvoyBuffer) {
+}
 func (p *HttpStreamBasicFilter) OnHttpStreamComplete(id uint64) {
 	assertEq(id, p.streamID, "stream id")
 	p.complete = true
@@ -1050,15 +1051,15 @@ func (p *HttpStreamBidiFilter) OnRequestHeaders(h shared.HeaderMap, end bool) sh
 	p.sentTrailers = true
 	return shared.HeadersStatusStop
 }
-func (p *HttpStreamBidiFilter) OnHttpStreamHeaders(id uint64, headers [][2]string, end bool) {
+func (p *HttpStreamBidiFilter) OnHttpStreamHeaders(id uint64, headers [][2]shared.UnsafeEnvoyBuffer, end bool) {
 	assertEq(id, p.streamID, "id")
 	p.recvHeaders = true
 }
-func (p *HttpStreamBidiFilter) OnHttpStreamData(id uint64, body [][]byte, end bool) {
+func (p *HttpStreamBidiFilter) OnHttpStreamData(id uint64, body []shared.UnsafeEnvoyBuffer, end bool) {
 	assertEq(id, p.streamID, "id")
 	p.recvChunks++
 }
-func (p *HttpStreamBidiFilter) OnHttpStreamTrailers(id uint64, trailers [][2]string) {
+func (p *HttpStreamBidiFilter) OnHttpStreamTrailers(id uint64, trailers [][2]shared.UnsafeEnvoyBuffer) {
 	assertEq(id, p.streamID, "id")
 	p.recvTrailers = true
 }
@@ -1118,10 +1119,13 @@ func (p *UpstreamResetFilter) OnRequestHeaders(h shared.HeaderMap, end bool) sha
 	p.streamID = id
 	return shared.HeadersStatusStop
 }
-func (p *UpstreamResetFilter) OnHttpStreamHeaders(id uint64, headers [][2]string, end bool) {}
-func (p *UpstreamResetFilter) OnHttpStreamData(id uint64, body [][]byte, end bool)          {}
-func (p *UpstreamResetFilter) OnHttpStreamTrailers(id uint64, trailers [][2]string)         {}
-func (p *UpstreamResetFilter) OnHttpStreamComplete(id uint64)                               {}
+func (p *UpstreamResetFilter) OnHttpStreamHeaders(id uint64, headers [][2]shared.UnsafeEnvoyBuffer, end bool) {
+}
+func (p *UpstreamResetFilter) OnHttpStreamData(id uint64, body []shared.UnsafeEnvoyBuffer, end bool) {
+}
+func (p *UpstreamResetFilter) OnHttpStreamTrailers(id uint64, trailers [][2]shared.UnsafeEnvoyBuffer) {
+}
+func (p *UpstreamResetFilter) OnHttpStreamComplete(id uint64) {}
 func (p *UpstreamResetFilter) OnHttpStreamReset(id uint64, reason shared.HttpStreamResetReason) {
 	assertEq(id, p.streamID, "id")
 	p.handle.SendLocalResponse(200, [][2]string{{"x-reset", "true"}}, []byte("upstream_reset"), "")


### PR DESCRIPTION
Commit Message: dym go SDK: use the UnsafeEnvoyBuffer to indicate the lifetime explicitly
Additional Description:

This refactored the golang SDK, and use the `UnsafeEnvoyBuffer` to represent any memory managed by Envoy (vs using unsafe `string` or unsafe `[]byte`). (cpp SDK use `absl::string_view` and rust SDK also use an `EnvoyBuffer` struct).

By this way, the developers could aware the the string or bytes are managed by Envoy clearly and won't mis-understand the lifetime of the string.

This will bring a little complexity (the test filters show the additional complexity is minor) for developers but also make the lifetime management more clear for developers.

Risk Level: low.
Testing: n/a.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.
