### PR TITLE
Fix contrib builds when boost installed

### DIFF
--- a/contrib/hyperscan/matching/input_matchers/source/BUILD
+++ b/contrib/hyperscan/matching/input_matchers/source/BUILD
@@ -23,6 +23,7 @@ envoy_cmake(
     }),
     build_data = ["@boost//:header"],
     cache_entries = {
+        "Boost_NO_BOOST_CMAKE": "on",
         "BOOST_ROOT": "$$EXT_BUILD_ROOT/external/boost",
         "BUILD_AVX512": "on",
         "BUILD_AVX512VBMI": "on",
@@ -75,6 +76,7 @@ envoy_cmake(
     }),
     build_data = ["@boost//:header"],
     cache_entries = {
+        "Boost_NO_BOOST_CMAKE": "on",
         "BOOST_ROOT": "$$EXT_BUILD_ROOT/external/boost",
         #        "BUILD_SVE2_BITPERM": "on",
         #        "BUILD_SVE2": "on",


### PR DESCRIPTION
Commit Message:

Currently when a fresh enough boost version is installed in the host system, the contrib build may fail sometimes (depending on which version is actually installed in the system).

What's happening?

Starting with boost version 1.70, as part of distribution boost provides CMake configuration file (`BoostConfig.cmake` or `boost-config.cmake`). The `FindBoost` module used by hyperscan to find boost version considers various places for where the boost could be, including system paths, even if you provide hints like `BOOST_ROOT`.

See
https://cmake.org/cmake/help/v3.15/module/FindBoost.html#boost-cmake.

The problem is that when it finds a version of boost with CMake configuration file, it basically disregards all the hints, including `BOOST_ROOT` that we provide and uses the version where it found CMake configuration file.

This is a well known issue and it's been reported as far back as 2019: https://github.com/boostorg/boost_install/issues/12.

Putting it all together, if you have a boost version 1.70+ installed in your system and that version does not work with hyperscan, the build will fail, because CMake will use the version of the boost library that you have in the system, instead of the one that Bazel downloads. If the version you have installed, does work with hyperscan, the build will succeed, but it would use a version of boost that wasn't tested in Envoy CI.

As documented, we can disable that behavior by setting `Boost_NO_BOOST_CMAKE`, which is what this PR does.

Additional Description:

I'm working on making some changes to the non-hermetic builds and randomly stumbled on this issue. I don't think that it will ever affect CI builds, but it breaks both hermetic and non-hermetic builds when boost is installed locally, so it's probably worth fixing nontheless.

It would be nice to backport this change to 1.37 release branch as well.

Risk Level: low
Testing: Manually built with hermetic and non-hermetic toolchains (verified build commands to make sure that the right version of boost is used).
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
