### PR TITLE
[bp/v1.37] dym go SDK: use the UnsafeEnvoyBuffer to indicate the lifetime explicitly (#43634)

### DIFF
--- a/source/extensions/dynamic_modules/sdk/go/abi/internal.go
+++ b/source/extensions/dynamic_modules/sdk/go/abi/internal.go
@@ -145,25 +145,35 @@ func envoyBufferToBytesUnsafe(buf C.envoy_dynamic_module_type_envoy_buffer) []by
 	return unsafe.Slice((*byte)(unsafe.Pointer(buf.ptr)), buf.length)
 }
 
-func envoyHttpHeaderSliceToHeadersUnsafe(
+func envoyBufferToUnsafeEnvoyBuffer(buf C.envoy_dynamic_module_type_envoy_buffer) shared.UnsafeEnvoyBuffer {
+	return shared.UnsafeEnvoyBuffer{
+		Ptr: (*byte)(unsafe.Pointer(buf.ptr)),
+		Len: uint64(buf.length),
+	}
+}
+
+func envoyHttpHeaderSliceToUnsafeHeaderSlice(
 	buf []C.envoy_dynamic_module_type_envoy_http_header,
-) [][2]string {
-	headers := make([][2]string, len(buf))
+) [][2]shared.UnsafeEnvoyBuffer {
+	headers := make([][2]shared.UnsafeEnvoyBuffer, len(buf))
 	for i, header := range buf {
-		key := unsafe.String((*byte)(unsafe.Pointer(header.key_ptr)), header.key_length)
-		value := unsafe.String((*byte)(unsafe.Pointer(header.value_ptr)), header.value_length)
-		headers[i] = [2]string{key, value}
+		headers[i] = [2]shared.UnsafeEnvoyBuffer{
+			{Ptr: (*byte)(unsafe.Pointer(header.key_ptr)), Len: uint64(header.key_length)},
+			{Ptr: (*byte)(unsafe.Pointer(header.value_ptr)), Len: uint64(header.value_length)},
+		}
 	}
 	return headers
 }
 
-func envoyBufferSliceToBytesSliceUnsafe(
+func envoyBufferSliceToUnsafeEnvoyBufferSlice(
 	buf []C.envoy_dynamic_module_type_envoy_buffer,
-) [][]byte {
-	chunks := make([][]byte, 0, len(buf))
+) []shared.UnsafeEnvoyBuffer {
+	chunks := make([]shared.UnsafeEnvoyBuffer, 0, len(buf))
 	for _, chunk := range buf {
-		data := unsafe.Slice((*byte)(unsafe.Pointer(chunk.ptr)), chunk.length)
-		chunks = append(chunks, data)
+		chunks = append(chunks, shared.UnsafeEnvoyBuffer{
+			Ptr: (*byte)(unsafe.Pointer(chunk.ptr)),
+			Len: uint64(chunk.length),
+		})
 	}
 	return chunks
 }
@@ -189,7 +199,7 @@ type dymHeaderMap struct {
 	headerType    C.envoy_dynamic_module_type_http_header_type
 }
 
-func (h *dymHeaderMap) getSingleHeader(key string, index uint64, valueCount *uint64) string {
+func (h *dymHeaderMap) getSingleHeader(key string, index uint64, valueCount *uint64) shared.UnsafeEnvoyBuffer {
 	var valueView C.envoy_dynamic_module_type_envoy_buffer
 	ret := C.envoy_dynamic_module_callback_http_get_header(
 		h.hostPluginPtr,
@@ -201,22 +211,22 @@ func (h *dymHeaderMap) getSingleHeader(key string, index uint64, valueCount *uin
 	)
 
 	if !bool(ret) || valueView.ptr == nil || valueView.length == 0 {
-		return ""
+		return shared.UnsafeEnvoyBuffer{}
 	}
 
 	runtime.KeepAlive(key)
-	return envoyBufferToStringUnsafe(valueView)
+	return envoyBufferToUnsafeEnvoyBuffer(valueView)
 }
 
-func (h *dymHeaderMap) Get(key string) []string {
+func (h *dymHeaderMap) Get(key string) []shared.UnsafeEnvoyBuffer {
 	valueCount := uint64(0)
 
 	firstValue := h.getSingleHeader(key, 0, &valueCount)
 	if valueCount == 0 {
-		return []string{}
+		return []shared.UnsafeEnvoyBuffer{}
 	}
 
-	values := make([]string, 0, valueCount)
+	values := make([]shared.UnsafeEnvoyBuffer, 0, valueCount)
 	values = append(values, firstValue)
 
 	for i := uint64(1); i < valueCount; i++ {
@@ -227,11 +237,11 @@ func (h *dymHeaderMap) Get(key string) []string {
 	return values
 }
 
-func (h *dymHeaderMap) GetOne(key string) string {
+func (h *dymHeaderMap) GetOne(key string) shared.UnsafeEnvoyBuffer {
 	return h.getSingleHeader(key, 0, nil)
 }
 
-func (h *dymHeaderMap) GetAll() [][2]string {
+func (h *dymHeaderMap) GetAll() [][2]shared.UnsafeEnvoyBuffer {
 	headerCount := C.envoy_dynamic_module_callback_http_get_headers_size(
 		(C.envoy_dynamic_module_type_http_filter_envoy_ptr)(h.hostPluginPtr),
 		(C.envoy_dynamic_module_type_http_header_type)(h.headerType),
@@ -246,7 +256,7 @@ func (h *dymHeaderMap) GetAll() [][2]string {
 		(C.envoy_dynamic_module_type_http_header_type)(h.headerType),
 		unsafe.SliceData(resultHeaders),
 	)
-	finalResult := envoyHttpHeaderSliceToHeadersUnsafe(resultHeaders)
+	finalResult := envoyHttpHeaderSliceToUnsafeHeaderSlice(resultHeaders)
 	runtime.KeepAlive(resultHeaders)
 	return finalResult
 }
@@ -289,7 +299,7 @@ type dymBodyBuffer struct {
 	bufferType    C.envoy_dynamic_module_type_http_body_type
 }
 
-func (b *dymBodyBuffer) GetChunks() [][]byte {
+func (b *dymBodyBuffer) GetChunks() []shared.UnsafeEnvoyBuffer {
 	var chunksSize C.size_t = 0
 	size := C.envoy_dynamic_module_callback_http_get_body_chunks_size(
 		(C.envoy_dynamic_module_type_http_filter_envoy_ptr)(b.hostPluginPtr),
@@ -307,7 +317,7 @@ func (b *dymBodyBuffer) GetChunks() [][]byte {
 		unsafe.SliceData(resultChunks),
 	)
 	runtime.KeepAlive(resultChunks)
-	return envoyBufferSliceToBytesSliceUnsafe(resultChunks)
+	return envoyBufferSliceToUnsafeEnvoyBufferSlice(resultChunks)
 }
 
 func (b *dymBodyBuffer) GetSize() uint64 {
@@ -405,7 +415,7 @@ type dymHttpFilterHandle struct {
 	downstreamWatermarkCallbacks shared.DownstreamWatermarkCallbacks
 }
 
-func (h *dymHttpFilterHandle) GetMetadataString(source shared.MetadataSourceType, metadataNamespace, key string) (string, bool) {
+func (h *dymHttpFilterHandle) GetMetadataString(source shared.MetadataSourceType, metadataNamespace, key string) (shared.UnsafeEnvoyBuffer, bool) {
 	var valueView C.envoy_dynamic_module_type_envoy_buffer
 
 	ret := C.envoy_dynamic_module_callback_http_get_metadata_string(
@@ -416,12 +426,12 @@ func (h *dymHttpFilterHandle) GetMetadataString(source shared.MetadataSourceType
 		&valueView,
 	)
 	if !bool(ret) || valueView.ptr == nil || valueView.length == 0 {
-		return "", false
+		return shared.UnsafeEnvoyBuffer{}, false
 	}
 
 	runtime.KeepAlive(metadataNamespace)
 	runtime.KeepAlive(key)
-	return envoyBufferToStringUnsafe(valueView), true
+	return envoyBufferToUnsafeEnvoyBuffer(valueView), true
 }
 
 func (h *dymHttpFilterHandle) GetMetadataNumber(source shared.MetadataSourceType, metadataNamespace, key string) (float64, bool) {
@@ -530,7 +540,7 @@ func (h *dymHttpFilterHandle) GetAttributeNumber(
 
 func (h *dymHttpFilterHandle) GetAttributeString(
 	attributeID shared.AttributeID,
-) (string, bool) {
+) (shared.UnsafeEnvoyBuffer, bool) {
 	var valueView C.envoy_dynamic_module_type_envoy_buffer
 
 	ret := C.envoy_dynamic_module_callback_http_filter_get_attribute_string(
@@ -539,13 +549,13 @@ func (h *dymHttpFilterHandle) GetAttributeString(
 		&valueView,
 	)
 	if !bool(ret) || valueView.ptr == nil || valueView.length == 0 {
-		return "", false
+		return shared.UnsafeEnvoyBuffer{}, false
 	}
 
-	return envoyBufferToStringUnsafe(valueView), true
+	return envoyBufferToUnsafeEnvoyBuffer(valueView), true
 }
 
-func (h *dymHttpFilterHandle) GetFilterState(key string) ([]byte, bool) {
+func (h *dymHttpFilterHandle) GetFilterState(key string) (shared.UnsafeEnvoyBuffer, bool) {
 	var valueView C.envoy_dynamic_module_type_envoy_buffer
 
 	ret := C.envoy_dynamic_module_callback_http_get_filter_state_bytes(
@@ -554,11 +564,11 @@ func (h *dymHttpFilterHandle) GetFilterState(key string) ([]byte, bool) {
 		&valueView,
 	)
 	if !bool(ret) || valueView.ptr == nil || valueView.length == 0 {
-		return nil, false
+		return shared.UnsafeEnvoyBuffer{}, false
 	}
 
 	runtime.KeepAlive(key)
-	return envoyBufferToBytesUnsafe(valueView), true
+	return envoyBufferToUnsafeEnvoyBuffer(valueView), true
 }
 
 func (h *dymHttpFilterHandle) SetFilterState(key string, value []byte) {
@@ -572,13 +582,13 @@ func (h *dymHttpFilterHandle) SetFilterState(key string, value []byte) {
 }
 
 func (h *dymHttpFilterHandle) GetData(key string) any {
-	stringValue, found := h.GetMetadataString(shared.MetadataSourceTypeDynamic,
+	buf, found := h.GetMetadataString(shared.MetadataSourceTypeDynamic,
 		"composer.shared_data", key)
 	if !found {
 		return nil
 	}
 	// Convert string back to uintptr safely.
-	uintValue, err := strconv.ParseUint(stringValue, 10, 64)
+	uintValue, err := strconv.ParseUint(buf.ToUnsafeString(), 10, 64)
 	if err != nil {
 		return nil
 	}
@@ -1340,8 +1350,8 @@ func envoy_dynamic_module_on_http_filter_http_callout_done(
 	}
 
 	// Prepare headers and body chunks.
-	resultHeaders := envoyHttpHeaderSliceToHeadersUnsafe(unsafe.Slice(headers, int(headersSize)))
-	resultChunks := envoyBufferSliceToBytesSliceUnsafe(unsafe.Slice(chunks, int(chunksSize)))
+	resultHeaders := envoyHttpHeaderSliceToUnsafeHeaderSlice(unsafe.Slice(headers, int(headersSize)))
+	resultChunks := envoyBufferSliceToUnsafeEnvoyBufferSlice(unsafe.Slice(chunks, int(chunksSize)))
 
 	cb := pluginWrapper.calloutCallbacks[uint64(calloutID)]
 	if cb != nil {
@@ -1369,7 +1379,7 @@ func envoy_dynamic_module_on_http_filter_http_stream_headers(
 	}
 
 	// Prepare headers.
-	resultHeaders := envoyHttpHeaderSliceToHeadersUnsafe(unsafe.Slice(headers, int(headersSize)))
+	resultHeaders := envoyHttpHeaderSliceToUnsafeHeaderSlice(unsafe.Slice(headers, int(headersSize)))
 
 	cb := pluginWrapper.streamCallbacks[uint64(streamID)]
 	if cb != nil {
@@ -1392,7 +1402,7 @@ func envoy_dynamic_module_on_http_filter_http_stream_data(
 	}
 
 	// Prepare data.
-	resultData := envoyBufferSliceToBytesSliceUnsafe(unsafe.Slice(chunks, int(chunksSize)))
+	resultData := envoyBufferSliceToUnsafeEnvoyBufferSlice(unsafe.Slice(chunks, int(chunksSize)))
 
 	cb := pluginWrapper.streamCallbacks[uint64(streamID)]
 	if cb != nil {
@@ -1414,7 +1424,7 @@ func envoy_dynamic_module_on_http_filter_http_stream_trailers(
 	}
 
 	// Prepare trailers.
-	resultTrailers := envoyHttpHeaderSliceToHeadersUnsafe(unsafe.Slice(trailers, int(trailersSize)))
+	resultTrailers := envoyHttpHeaderSliceToUnsafeHeaderSlice(unsafe.Slice(trailers, int(trailersSize)))
 
 	cb := pluginWrapper.streamCallbacks[uint64(streamID)]
 	if cb != nil {

--- a/source/extensions/dynamic_modules/sdk/go/shared/base.go
+++ b/source/extensions/dynamic_modules/sdk/go/shared/base.go
@@ -1,13 +1,63 @@
 //go:generate mockgen -source=base.go -destination=mocks/mock_base.go -package=mocks
 package shared
 
+import (
+	"strings"
+	"unsafe"
+)
+
+// UnsafeEnvoyBuffer is a struct that represents a buffer of data from Envoy.
+// It contains a pointer to the data and its length. The memory of the data is managed by Envoy.
+type UnsafeEnvoyBuffer struct {
+	// Pointer to the start of the buffer data.
+	Ptr *byte
+	// Length of the buffer data in bytes.
+	Len uint64
+}
+
+func (b UnsafeEnvoyBuffer) ToUnsafeBytes() []byte {
+	if b.Ptr == nil || b.Len == 0 {
+		return nil
+	}
+	// Use unsafe to create a byte slice that points to the buffer data without copying.
+	return unsafe.Slice(b.Ptr, b.Len)
+}
+
+// ToBytes converts the UnsafeEnvoyBuffer to a byte slice. It creates a copy of the data in Go memory.
+func (b UnsafeEnvoyBuffer) ToBytes() []byte {
+	if b.Ptr == nil || b.Len == 0 {
+		return nil
+	}
+	// Create a byte slice that copys the data from the buffer.
+	owned := make([]byte, b.Len)
+	// Use unsafe to copy the data from the buffer to the byte slice.
+	src := unsafe.Slice(b.Ptr, b.Len)
+	copy(owned, src)
+	return owned
+}
+
+func (b UnsafeEnvoyBuffer) ToUnsafeString() string {
+	if b.Ptr == nil || b.Len == 0 {
+		return ""
+	}
+	// Use unsafe to create a string that points to the buffer data without copying.
+	return unsafe.String(b.Ptr, b.Len)
+}
+
+func (b UnsafeEnvoyBuffer) ToString() string {
+	if b.Ptr == nil || b.Len == 0 {
+		return ""
+	}
+	return strings.Clone(b.ToUnsafeString())
+}
+
 // BodyBuffer is an interface that provides access to the request and response body.
 // This should be implemented by the SDK or runtime.
 type BodyBuffer interface {
-	// GetChunks retrieves the body content as a list of byte slices.
+	// GetChunks retrieves the body content as a list of UnsafeEnvoyBuffer chunks.
 	// NOTE: The memory of underlying data may not be managed by Go GC. So you should
 	// copy the data if you need to keep it and use it later.
-	GetChunks() [][]byte
+	GetChunks() []UnsafeEnvoyBuffer
 
 	// GetSize retrieves the total size of the body buffer.
 	GetSize() uint64
@@ -28,20 +78,20 @@ type HeaderMap interface {
 	// nil will be returned.
 	// NOTE: The memory of underlying data may not be managed by Go GC. So you should
 	// copy the data if you need to keep it and use it later.
-	Get(key string) []string
+	Get(key string) []UnsafeEnvoyBuffer
 
 	// GetOne retrieves a single header value for a given key.
 	// If there are multiple values for the key, the first one will be returned.
-	// If the key does not exist, an empty string will be returned.
+	// If the key does not exist, an empty UnsafeEnvoyBuffer will be returned.
 	// NOTE: The memory of underlying data may not be managed by Go GC. So you should
 	// copy the data if you need to keep it and use it later.
-	GetOne(key string) string
+	GetOne(key string) UnsafeEnvoyBuffer
 
-	// GetAll retrieves all header values. You should not mutate the returned map
+	// GetAll retrieves all header values. You should not mutate the returned slice
 	// directly.
 	// NOTE: The memory of underlying data may not be managed by Go GC. So you should
 	// copy the data if you need to keep it and use it later.
-	GetAll() [][2]string
+	GetAll() [][2]UnsafeEnvoyBuffer
 
 	// Set sets the header value for a given key.
 	Set(key string, value string)
@@ -234,7 +284,7 @@ const (
 
 type HttpCalloutCallback interface {
 	OnHttpCalloutDone(calloutID uint64, result HttpCalloutResult,
-		headers [][2]string, body [][]byte)
+		headers [][2]UnsafeEnvoyBuffer, body []UnsafeEnvoyBuffer)
 }
 
 type HttpStreamResetReason uint32
@@ -251,9 +301,9 @@ const (
 )
 
 type HttpStreamCallback interface {
-	OnHttpStreamHeaders(streamID uint64, headers [][2]string, endStream bool)
-	OnHttpStreamData(streamID uint64, body [][]byte, endStream bool)
-	OnHttpStreamTrailers(streamID uint64, trailers [][2]string)
+	OnHttpStreamHeaders(streamID uint64, headers [][2]UnsafeEnvoyBuffer, endStream bool)
+	OnHttpStreamData(streamID uint64, body []UnsafeEnvoyBuffer, endStream bool)
+	OnHttpStreamTrailers(streamID uint64, trailers [][2]UnsafeEnvoyBuffer)
 	OnHttpStreamComplete(streamID uint64)
 	OnHttpStreamReset(streamID uint64, reason HttpStreamResetReason)
 }
@@ -281,8 +331,8 @@ type HttpFilterHandle interface {
 	// @Param source the metadata source type.
 	// @Param metadataNamespace the metadata namespace.
 	// @Param key the metadata key.
-	// @Return the metadata value if found, otherwise nil.
-	GetMetadataString(source MetadataSourceType, metadataNamespace, key string) (string, bool)
+	// @Return the metadata value if found, otherwise an empty UnsafeEnvoyBuffer.
+	GetMetadataString(source MetadataSourceType, metadataNamespace, key string) (UnsafeEnvoyBuffer, bool)
 
 	// GetMetadataNumber retrieves the dynamic metadata number value of the stream.
 	// @Param source the metadata source type.
@@ -299,8 +349,10 @@ type HttpFilterHandle interface {
 
 	// GetFilterState retrieves the serialized filter state value of the stream.
 	// @Param key the filter state key.
-	// @Return the filter state value if found, otherwise nil.
-	GetFilterState(key string) ([]byte, bool)
+	// @Return the filter state value if found, otherwise an empty UnsafeEnvoyBuffer.
+	// NOTE: The memory of underlying data may not be managed by Go GC. So you should
+	// copy the data if you need to keep it and use it later.
+	GetFilterState(key string) (UnsafeEnvoyBuffer, bool)
 
 	// SetFilterState sets the serialized filter state value of the stream.
 	// @Param key the filter state key.
@@ -308,9 +360,11 @@ type HttpFilterHandle interface {
 	SetFilterState(key string, value []byte)
 
 	// GetAttributeString retrieves the string attribute value of the stream.
-	// @Param key the attribute key.
-	// @Return the attribute value if found, otherwise nil.
-	GetAttributeString(attributeID AttributeID) (string, bool)
+	// @Param attributeID the attribute ID.
+	// @Return the attribute value if found, otherwise an empty UnsafeEnvoyBuffer.
+	// NOTE: The memory of underlying data may not be managed by Go GC. So you should
+	// copy the data if you need to keep it and use it later.
+	GetAttributeString(attributeID AttributeID) (UnsafeEnvoyBuffer, bool)
 
 	// GetAttributeNumber retrieves the float attribute value of the stream.
 	// @Param key the attribute key.

--- a/source/extensions/dynamic_modules/sdk/go/shared/mocks/mock_base.go
+++ b/source/extensions/dynamic_modules/sdk/go/shared/mocks/mock_base.go
@@ -65,10 +65,10 @@ func (mr *MockBodyBufferMockRecorder) Drain(numBytes any) *gomock.Call {
 }
 
 // GetChunks mocks base method.
-func (m *MockBodyBuffer) GetChunks() [][]byte {
+func (m *MockBodyBuffer) GetChunks() []shared.UnsafeEnvoyBuffer {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetChunks")
-	ret0, _ := ret[0].([][]byte)
+	ret0, _ := ret[0].([]shared.UnsafeEnvoyBuffer)
 	return ret0
 }
 
@@ -129,10 +129,10 @@ func (mr *MockHeaderMapMockRecorder) Add(key, value any) *gomock.Call {
 }
 
 // Get mocks base method.
-func (m *MockHeaderMap) Get(key string) []string {
+func (m *MockHeaderMap) Get(key string) []shared.UnsafeEnvoyBuffer {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get", key)
-	ret0, _ := ret[0].([]string)
+	ret0, _ := ret[0].([]shared.UnsafeEnvoyBuffer)
 	return ret0
 }
 
@@ -143,10 +143,10 @@ func (mr *MockHeaderMapMockRecorder) Get(key any) *gomock.Call {
 }
 
 // GetAll mocks base method.
-func (m *MockHeaderMap) GetAll() [][2]string {
+func (m *MockHeaderMap) GetAll() [][2]shared.UnsafeEnvoyBuffer {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAll")
-	ret0, _ := ret[0].([][2]string)
+	ret0, _ := ret[0].([][2]shared.UnsafeEnvoyBuffer)
 	return ret0
 }
 
@@ -157,10 +157,10 @@ func (mr *MockHeaderMapMockRecorder) GetAll() *gomock.Call {
 }
 
 // GetOne mocks base method.
-func (m *MockHeaderMap) GetOne(key string) string {
+func (m *MockHeaderMap) GetOne(key string) shared.UnsafeEnvoyBuffer {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetOne", key)
-	ret0, _ := ret[0].(string)
+	ret0, _ := ret[0].(shared.UnsafeEnvoyBuffer)
 	return ret0
 }
 
@@ -219,7 +219,7 @@ func (m *MockHttpCalloutCallback) EXPECT() *MockHttpCalloutCallbackMockRecorder 
 }
 
 // OnHttpCalloutDone mocks base method.
-func (m *MockHttpCalloutCallback) OnHttpCalloutDone(calloutID uint64, result shared.HttpCalloutResult, headers [][2]string, body [][]byte) {
+func (m *MockHttpCalloutCallback) OnHttpCalloutDone(calloutID uint64, result shared.HttpCalloutResult, headers [][2]shared.UnsafeEnvoyBuffer, body []shared.UnsafeEnvoyBuffer) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "OnHttpCalloutDone", calloutID, result, headers, body)
 }
@@ -267,7 +267,7 @@ func (mr *MockHttpStreamCallbackMockRecorder) OnHttpStreamComplete(streamID any)
 }
 
 // OnHttpStreamData mocks base method.
-func (m *MockHttpStreamCallback) OnHttpStreamData(streamID uint64, body [][]byte, endStream bool) {
+func (m *MockHttpStreamCallback) OnHttpStreamData(streamID uint64, body []shared.UnsafeEnvoyBuffer, endStream bool) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "OnHttpStreamData", streamID, body, endStream)
 }
@@ -279,7 +279,7 @@ func (mr *MockHttpStreamCallbackMockRecorder) OnHttpStreamData(streamID, body, e
 }
 
 // OnHttpStreamHeaders mocks base method.
-func (m *MockHttpStreamCallback) OnHttpStreamHeaders(streamID uint64, headers [][2]string, endStream bool) {
+func (m *MockHttpStreamCallback) OnHttpStreamHeaders(streamID uint64, headers [][2]shared.UnsafeEnvoyBuffer, endStream bool) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "OnHttpStreamHeaders", streamID, headers, endStream)
 }
@@ -303,7 +303,7 @@ func (mr *MockHttpStreamCallbackMockRecorder) OnHttpStreamReset(streamID, reason
 }
 
 // OnHttpStreamTrailers mocks base method.
-func (m *MockHttpStreamCallback) OnHttpStreamTrailers(streamID uint64, trailers [][2]string) {
+func (m *MockHttpStreamCallback) OnHttpStreamTrailers(streamID uint64, trailers [][2]shared.UnsafeEnvoyBuffer) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "OnHttpStreamTrailers", streamID, trailers)
 }
@@ -545,10 +545,10 @@ func (mr *MockHttpFilterHandleMockRecorder) GetAttributeNumber(attributeID any) 
 }
 
 // GetAttributeString mocks base method.
-func (m *MockHttpFilterHandle) GetAttributeString(attributeID shared.AttributeID) (string, bool) {
+func (m *MockHttpFilterHandle) GetAttributeString(attributeID shared.AttributeID) (shared.UnsafeEnvoyBuffer, bool) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAttributeString", attributeID)
-	ret0, _ := ret[0].(string)
+	ret0, _ := ret[0].(shared.UnsafeEnvoyBuffer)
 	ret1, _ := ret[1].(bool)
 	return ret0, ret1
 }
@@ -574,10 +574,10 @@ func (mr *MockHttpFilterHandleMockRecorder) GetData(key any) *gomock.Call {
 }
 
 // GetFilterState mocks base method.
-func (m *MockHttpFilterHandle) GetFilterState(key string) ([]byte, bool) {
+func (m *MockHttpFilterHandle) GetFilterState(key string) (shared.UnsafeEnvoyBuffer, bool) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetFilterState", key)
-	ret0, _ := ret[0].([]byte)
+	ret0, _ := ret[0].(shared.UnsafeEnvoyBuffer)
 	ret1, _ := ret[1].(bool)
 	return ret0, ret1
 }
@@ -604,10 +604,10 @@ func (mr *MockHttpFilterHandleMockRecorder) GetMetadataNumber(source, metadataNa
 }
 
 // GetMetadataString mocks base method.
-func (m *MockHttpFilterHandle) GetMetadataString(source shared.MetadataSourceType, metadataNamespace, key string) (string, bool) {
+func (m *MockHttpFilterHandle) GetMetadataString(source shared.MetadataSourceType, metadataNamespace, key string) (shared.UnsafeEnvoyBuffer, bool) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMetadataString", source, metadataNamespace, key)
-	ret0, _ := ret[0].(string)
+	ret0, _ := ret[0].(shared.UnsafeEnvoyBuffer)
 	ret1, _ := ret[1].(bool)
 	return ret0, ret1
 }

--- a/test/extensions/dynamic_modules/test_data/go/http/http.go
+++ b/test/extensions/dynamic_modules/test_data/go/http/http.go
@@ -82,7 +82,7 @@ func (f *statsCallbacksFactory) Create(handle shared.HttpFilterHandle) shared.Ht
 
 func (p *statsCallbacksFilter) OnRequestHeaders(headers shared.HeaderMap, endOfStream bool) shared.HeadersStatus {
 	p.handle.RecordHistogramValue(p.factory.ones, 1)
-	header := headers.GetOne("header")
+	header := headers.GetOne("header").ToUnsafeString()
 	p.handle.IncrementCounterValue(p.factory.testCounterVec, 1, header)
 	p.handle.IncrementGaugeValue(p.factory.testGaugeVec, 1, header)
 	p.handle.RecordHistogramValue(p.factory.testHistogramVec, 1, header)
@@ -154,16 +154,16 @@ func (p *headerCallbacksFilter) OnResponseTrailers(trailers shared.HeaderMap) sh
 
 func testHeaders(headers shared.HeaderMap) {
 	// Test single getter API
-	if val := headers.GetOne("single"); val != "value" {
+	if val := headers.GetOne("single").ToUnsafeString(); val != "value" {
 		panic(fmt.Sprintf("header single mismatch: %s", val))
 	}
-	if val := headers.GetOne("non-exist"); val != "" {
+	if val := headers.GetOne("non-exist").ToUnsafeString(); val != "" {
 		panic(fmt.Sprintf("header non-exist found: %s", val))
 	}
 
 	// Test multi getter API
 	vals := headers.Get("multi")
-	if len(vals) != 2 || vals[0] != "value1" || vals[1] != "value2" {
+	if len(vals) != 2 || vals[0].ToUnsafeString() != "value1" || vals[1].ToUnsafeString() != "value2" {
 		panic(fmt.Sprintf("header multi mismatch: %v", vals))
 	}
 	if len(headers.Get("non-exist")) != 0 {
@@ -172,7 +172,7 @@ func testHeaders(headers shared.HeaderMap) {
 
 	// Test setter API
 	headers.Set("new", "value")
-	if headers.GetOne("new") != "value" {
+	if headers.GetOne("new").ToUnsafeString() != "value" {
 		panic("header new mismatch")
 	}
 	headers.Remove("to-be-deleted")
@@ -180,7 +180,7 @@ func testHeaders(headers shared.HeaderMap) {
 	// Test adder API
 	headers.Add("multi", "value3")
 	newVals := headers.Get("multi")
-	if len(newVals) != 3 || newVals[0] != "value1" || newVals[1] != "value2" || newVals[2] != "value3" {
+	if len(newVals) != 3 || newVals[0].ToUnsafeString() != "value1" || newVals[1].ToUnsafeString() != "value2" || newVals[2].ToUnsafeString() != "value3" {
 		panic(fmt.Sprintf("header multi values mismatch: %v", newVals))
 	}
 
@@ -189,11 +189,11 @@ func testHeaders(headers shared.HeaderMap) {
 	if len(all) != 5 {
 		panic(fmt.Sprintf("header all length mismatch: %d", len(all)))
 	}
-	if all[0][0] != "single" || all[0][1] != "value" ||
-		all[1][0] != "multi" || all[1][1] != "value1" ||
-		all[2][0] != "multi" || all[2][1] != "value2" ||
-		all[3][0] != "new" || all[3][1] != "value" ||
-		all[4][0] != "multi" || all[4][1] != "value3" {
+	if all[0][0].ToUnsafeString() != "single" || all[0][1].ToUnsafeString() != "value" ||
+		all[1][0].ToUnsafeString() != "multi" || all[1][1].ToUnsafeString() != "value1" ||
+		all[2][0].ToUnsafeString() != "multi" || all[2][1].ToUnsafeString() != "value2" ||
+		all[3][0].ToUnsafeString() != "new" || all[3][1].ToUnsafeString() != "value" ||
+		all[4][0].ToUnsafeString() != "multi" || all[4][1].ToUnsafeString() != "value3" {
 		panic(fmt.Sprintf("header all mismatch: %v", all))
 	}
 }
@@ -271,15 +271,15 @@ func (p *dynamicMetadataCallbacksFilter) OnRequestHeaders(headers shared.HeaderM
 
 	// Try getting metadata from router, cluster, and host.
 	if val, ok := p.handle.GetMetadataString(shared.MetadataSourceTypeRoute,
-		"metadata", "route_key"); !ok || val != "route" {
+		"metadata", "route_key"); !ok || val.ToUnsafeString() != "route" {
 		panic(fmt.Sprintf("route metadata mismatch: %v", val))
 	}
 	if val, ok := p.handle.GetMetadataString(shared.MetadataSourceTypeCluster,
-		"metadata", "cluster_key"); !ok || val != "cluster" {
+		"metadata", "cluster_key"); !ok || val.ToUnsafeString() != "cluster" {
 		panic(fmt.Sprintf("cluster metadata mismatch: %v", val))
 	}
 	if val, ok := p.handle.GetMetadataString(shared.MetadataSourceTypeHost,
-		"metadata", "host_key"); !ok || val != "host" {
+		"metadata", "host_key"); !ok || val.ToUnsafeString() != "host" {
 		panic(fmt.Sprintf("host metadata mismatch: %v", val))
 	}
 
@@ -293,7 +293,7 @@ func (p *dynamicMetadataCallbacksFilter) OnRequestBody(body shared.BodyBuffer, e
 	}
 	// Set a string.
 	p.handle.SetMetadata("ns_req_body", "key", "value")
-	if val, ok := p.handle.GetMetadataString(shared.MetadataSourceTypeDynamic, "ns_req_body", "key"); !ok || val != "value" {
+	if val, ok := p.handle.GetMetadataString(shared.MetadataSourceTypeDynamic, "ns_req_body", "key"); !ok || val.ToUnsafeString() != "value" {
 		panic("metadata key mismatch")
 	}
 	// Try getting a string as number.
@@ -327,7 +327,7 @@ func (p *dynamicMetadataCallbacksFilter) OnResponseBody(body shared.BodyBuffer, 
 	}
 	// Set a string.
 	p.handle.SetMetadata("ns_res_body", "key", "value")
-	if val, ok := p.handle.GetMetadataString(shared.MetadataSourceTypeDynamic, "ns_res_body", "key"); !ok || val != "value" {
+	if val, ok := p.handle.GetMetadataString(shared.MetadataSourceTypeDynamic, "ns_res_body", "key"); !ok || val.ToUnsafeString() != "value" {
 		panic("metadata key mismatch")
 	}
 	// Try getting a string as number.
@@ -396,7 +396,7 @@ func (p *filterStateCallbacksFilter) OnStreamComplete() {
 
 func (p *filterStateCallbacksFilter) testFilterState(key, value string) {
 	p.handle.SetFilterState(key, []byte(value))
-	if val, ok := p.handle.GetFilterState(key); !ok || string(val) != value {
+	if val, ok := p.handle.GetFilterState(key); !ok || val.ToUnsafeString() != value {
 		panic(fmt.Sprintf("filter state %s mismatch", key))
 	}
 	if _, ok := p.handle.GetFilterState("key"); ok {

--- a/test/extensions/dynamic_modules/test_data/go/http_integration_test/http_integration_test.go
+++ b/test/extensions/dynamic_modules/test_data/go/http_integration_test/http_integration_test.go
@@ -193,9 +193,9 @@ func assertEq(a, b interface{}, msg string) {
 func (p *HeaderCallbacksFilter) OnRequestHeaders(headers shared.HeaderMap,
 	endOfStream bool) shared.HeadersStatus {
 	p.reqHeadersCalled = true
-	assertEq(headers.GetOne(":path"), "/test/long/url", ":path header")
-	assertEq(headers.GetOne(":method"), "POST", ":method header")
-	assertEq(headers.GetOne("foo"), "bar", "foo header")
+	assertEq(headers.GetOne(":path").ToUnsafeString(), "/test/long/url", ":path header")
+	assertEq(headers.GetOne(":method").ToUnsafeString(), "POST", ":method header")
+	assertEq(headers.GetOne("foo").ToUnsafeString(), "bar", "foo header")
 
 	for k, v := range p.headersToAdd {
 		headers.Set(k, v)
@@ -203,33 +203,33 @@ func (p *HeaderCallbacksFilter) OnRequestHeaders(headers shared.HeaderMap,
 
 	// Test setter/getter
 	headers.Set("new", "value1")
-	assertEq(headers.GetOne("new"), "value1", "new header set")
+	assertEq(headers.GetOne("new").ToUnsafeString(), "value1", "new header set")
 
 	vals := headers.Get("new")
 	assertEq(len(vals), 1, "new header count")
-	assertEq(vals[0], "value1", "new header val")
+	assertEq(vals[0].ToUnsafeString(), "value1", "new header val")
 
 	// Test add
 	headers.Add("new", "value2")
 	vals = headers.Get("new")
 	assertEq(len(vals), 2, "new header count after add")
-	assertEq(vals[1], "value2", "new header val 2")
+	assertEq(vals[1].ToUnsafeString(), "value2", "new header val 2")
 
 	// Test remove
 	headers.Remove("new")
-	assertEq(headers.GetOne("new"), "", "new header removed")
+	assertEq(headers.GetOne("new").ToUnsafeString(), "", "new header removed")
 	return shared.HeadersStatusContinue
 }
 
 func (p *HeaderCallbacksFilter) OnRequestTrailers(trailers shared.HeaderMap) shared.TrailersStatus {
 	p.reqTrailersCalled = true
-	assertEq(trailers.GetOne("foo"), "bar", "foo trailer")
+	assertEq(trailers.GetOne("foo").ToUnsafeString(), "bar", "foo trailer")
 	for k, v := range p.headersToAdd {
 		trailers.Set(k, v)
 	}
 	// Test setter/getter
 	trailers.Set("new", "value1")
-	assertEq(trailers.GetOne("new"), "value1", "new trailer set")
+	assertEq(trailers.GetOne("new").ToUnsafeString(), "value1", "new trailer set")
 
 	// Test add
 	trailers.Add("new", "value2")
@@ -238,39 +238,39 @@ func (p *HeaderCallbacksFilter) OnRequestTrailers(trailers shared.HeaderMap) sha
 
 	// Test remove
 	trailers.Remove("new")
-	assertEq(trailers.GetOne("new"), "", "new trailer removed")
+	assertEq(trailers.GetOne("new").ToUnsafeString(), "", "new trailer removed")
 	return shared.TrailersStatusContinue
 }
 
 func (p *HeaderCallbacksFilter) OnResponseHeaders(headers shared.HeaderMap, endOfStream bool) shared.HeadersStatus {
 	p.resHeadersCalled = true
-	assertEq(headers.GetOne("foo"), "bar", "foo response header")
+	assertEq(headers.GetOne("foo").ToUnsafeString(), "bar", "foo response header")
 	for k, v := range p.headersToAdd {
 		headers.Set(k, v)
 	}
 
 	headers.Set("new", "value1")
-	assertEq(headers.GetOne("new"), "value1", "new resp header")
+	assertEq(headers.GetOne("new").ToUnsafeString(), "value1", "new resp header")
 	headers.Add("new", "value2")
 	assertEq(len(headers.Get("new")), 2, "new resp header count")
 	headers.Remove("new")
-	assertEq(headers.GetOne("new"), "", "new resp header removed")
+	assertEq(headers.GetOne("new").ToUnsafeString(), "", "new resp header removed")
 	return shared.HeadersStatusContinue
 }
 
 func (p *HeaderCallbacksFilter) OnResponseTrailers(trailers shared.HeaderMap) shared.TrailersStatus {
 	p.resTrailersCalled = true
-	assertEq(trailers.GetOne("foo"), "bar", "foo response trailer")
+	assertEq(trailers.GetOne("foo").ToUnsafeString(), "bar", "foo response trailer")
 	for k, v := range p.headersToAdd {
 		trailers.Set(k, v)
 	}
 
 	trailers.Set("new", "value1")
-	assertEq(trailers.GetOne("new"), "value1", "new resp trailer")
+	assertEq(trailers.GetOne("new").ToUnsafeString(), "value1", "new resp trailer")
 	trailers.Add("new", "value2")
 	assertEq(len(trailers.Get("new")), 2, "new resp trailer count")
 	trailers.Remove("new")
-	assertEq(trailers.GetOne("new"), "", "new resp trailer removed")
+	assertEq(trailers.GetOne("new").ToUnsafeString(), "", "new resp trailer removed")
 	return shared.TrailersStatusContinue
 }
 
@@ -383,10 +383,10 @@ func (p *BodyCallbacksFilter) OnRequestBody(body shared.BodyBuffer,
 	var body_content string
 
 	for _, c := range p.handle.BufferedRequestBody().GetChunks() {
-		body_content += string(c)
+		body_content += c.ToUnsafeString()
 	}
 	for _, c := range body.GetChunks() {
-		body_content += string(c)
+		body_content += c.ToUnsafeString()
 	}
 
 	assertEq(body_content, "request_body", "request body content")
@@ -417,10 +417,10 @@ func (p *BodyCallbacksFilter) OnResponseBody(body shared.BodyBuffer,
 	var body_content string
 
 	for _, c := range p.handle.BufferedResponseBody().GetChunks() {
-		body_content += string(c)
+		body_content += c.ToUnsafeString()
 	}
 	for _, c := range body.GetChunks() {
-		body_content += string(c)
+		body_content += c.ToUnsafeString()
 	}
 
 	assertEq(body_content, "response_body", "response body content")
@@ -546,7 +546,7 @@ func (p *HttpCalloutsFilter) OnRequestHeaders(headers shared.HeaderMap,
 }
 
 func (p *HttpCalloutsFilter) OnHttpCalloutDone(calloutID uint64, result shared.HttpCalloutResult,
-	headers [][2]string, body [][]byte) {
+	headers [][2]shared.UnsafeEnvoyBuffer, body []shared.UnsafeEnvoyBuffer) {
 	if p.clusterName == "resetting_cluster" {
 		assert(result == shared.HttpCalloutReset, "expected reset")
 		return
@@ -556,7 +556,7 @@ func (p *HttpCalloutsFilter) OnHttpCalloutDone(calloutID uint64, result shared.H
 
 	found := false
 	for _, h := range headers {
-		if h[0] == "some_header" && h[1] == "some_value" {
+		if h[0].ToUnsafeString() == "some_header" && h[1].ToUnsafeString() == "some_value" {
 			found = true
 			break
 		}
@@ -565,7 +565,7 @@ func (p *HttpCalloutsFilter) OnHttpCalloutDone(calloutID uint64, result shared.H
 
 	fullBody := ""
 	for _, b := range body {
-		fullBody += string(b)
+		fullBody += b.ToUnsafeString()
 	}
 	assertEq(fullBody, "response_body_from_callout", "resp body")
 
@@ -683,7 +683,7 @@ func (p *FakeExternalCacheFilter) OnRequestHeaders(headers shared.HeaderMap, end
 	sched := p.handle.GetScheduler()
 
 	go func() {
-		if key == "existing" {
+		if key.ToUnsafeString() == "existing" {
 			// Simulate hit
 			sched.Schedule(func() {
 				p.handle.SendLocalResponse(200, [][2]string{{"cached", "yes"}}, []byte("cached_response_body"), "")
@@ -785,18 +785,18 @@ type StatsCallbacksFilter struct {
 func (p *StatsCallbacksFilter) OnRequestHeaders(headers shared.HeaderMap, endOfStream bool) shared.HeadersStatus {
 	p.handle.IncrementCounterValue(p.ids.reqTotal, 1)
 	p.handle.IncrementGaugeValue(p.ids.reqPending, 1)
-	p.method = headers.GetOne(":method")
+	p.method = headers.GetOne(":method").ToUnsafeString()
 
 	p.handle.IncrementCounterValue(p.ids.epTotal, 1, "on_request_headers", p.method)
 	p.handle.IncrementGaugeValue(p.ids.epPending, 1, "on_request_headers", p.method)
 
-	if valStr := headers.GetOne(p.ids.headerToCount); valStr != "" {
+	if valStr := headers.GetOne(p.ids.headerToCount).ToUnsafeString(); valStr != "" {
 		if val, err := strconv.ParseUint(valStr, 10, 64); err == nil {
 			p.handle.RecordHistogramValue(p.ids.reqVals, val)
 			p.handle.RecordHistogramValue(p.ids.epVals, val, "on_request_headers", p.method)
 		}
 	}
-	if valStr := headers.GetOne(p.ids.headerToSet); valStr != "" {
+	if valStr := headers.GetOne(p.ids.headerToSet).ToUnsafeString(); valStr != "" {
 		if val, err := strconv.ParseUint(valStr, 10, 64); err == nil {
 			p.handle.SetGaugeValue(p.ids.reqSet, val)
 			p.handle.SetGaugeValue(p.ids.epSet, val, "on_request_headers", p.method)
@@ -811,12 +811,12 @@ func (p *StatsCallbacksFilter) OnResponseHeaders(headers shared.HeaderMap, endOf
 	p.handle.DecrementGaugeValue(p.ids.epPending, 1, "on_request_headers", p.method)
 	p.handle.IncrementGaugeValue(p.ids.epPending, 1, "on_response_headers", p.method)
 
-	if valStr := headers.GetOne(p.ids.headerToCount); valStr != "" {
+	if valStr := headers.GetOne(p.ids.headerToCount).ToUnsafeString(); valStr != "" {
 		if val, err := strconv.ParseUint(valStr, 10, 64); err == nil {
 			p.handle.RecordHistogramValue(p.ids.epVals, val, "on_response_headers", p.method)
 		}
 	}
-	if valStr := headers.GetOne(p.ids.headerToSet); valStr != "" {
+	if valStr := headers.GetOne(p.ids.headerToSet).ToUnsafeString(); valStr != "" {
 		if val, err := strconv.ParseUint(valStr, 10, 64); err == nil {
 			p.handle.SetGaugeValue(p.ids.epSet, val, "on_response_headers", p.method)
 		}
@@ -970,22 +970,23 @@ func (p *HttpStreamBasicFilter) OnRequestHeaders(h shared.HeaderMap, end bool) s
 	return shared.HeadersStatusStop
 }
 
-func (p *HttpStreamBasicFilter) OnHttpStreamHeaders(id uint64, headers [][2]string, end bool) {
+func (p *HttpStreamBasicFilter) OnHttpStreamHeaders(id uint64, headers [][2]shared.UnsafeEnvoyBuffer, end bool) {
 	assertEq(id, p.streamID, "stream id")
 	p.headers = true
 	found := false
 	for _, h := range headers {
-		if h[0] == ":status" && h[1] == "200" {
+		if h[0].ToUnsafeString() == ":status" && h[1].ToUnsafeString() == "200" {
 			found = true
 		}
 	}
 	assert(found, "status 200")
 }
-func (p *HttpStreamBasicFilter) OnHttpStreamData(id uint64, body [][]byte, end bool) {
+func (p *HttpStreamBasicFilter) OnHttpStreamData(id uint64, body []shared.UnsafeEnvoyBuffer, end bool) {
 	assertEq(id, p.streamID, "stream id")
 	p.data = true
 }
-func (p *HttpStreamBasicFilter) OnHttpStreamTrailers(id uint64, trailers [][2]string) {}
+func (p *HttpStreamBasicFilter) OnHttpStreamTrailers(id uint64, trailers [][2]shared.UnsafeEnvoyBuffer) {
+}
 func (p *HttpStreamBasicFilter) OnHttpStreamComplete(id uint64) {
 	assertEq(id, p.streamID, "stream id")
 	p.complete = true
@@ -1050,15 +1051,15 @@ func (p *HttpStreamBidiFilter) OnRequestHeaders(h shared.HeaderMap, end bool) sh
 	p.sentTrailers = true
 	return shared.HeadersStatusStop
 }
-func (p *HttpStreamBidiFilter) OnHttpStreamHeaders(id uint64, headers [][2]string, end bool) {
+func (p *HttpStreamBidiFilter) OnHttpStreamHeaders(id uint64, headers [][2]shared.UnsafeEnvoyBuffer, end bool) {
 	assertEq(id, p.streamID, "id")
 	p.recvHeaders = true
 }
-func (p *HttpStreamBidiFilter) OnHttpStreamData(id uint64, body [][]byte, end bool) {
+func (p *HttpStreamBidiFilter) OnHttpStreamData(id uint64, body []shared.UnsafeEnvoyBuffer, end bool) {
 	assertEq(id, p.streamID, "id")
 	p.recvChunks++
 }
-func (p *HttpStreamBidiFilter) OnHttpStreamTrailers(id uint64, trailers [][2]string) {
+func (p *HttpStreamBidiFilter) OnHttpStreamTrailers(id uint64, trailers [][2]shared.UnsafeEnvoyBuffer) {
 	assertEq(id, p.streamID, "id")
 	p.recvTrailers = true
 }
@@ -1118,10 +1119,13 @@ func (p *UpstreamResetFilter) OnRequestHeaders(h shared.HeaderMap, end bool) sha
 	p.streamID = id
 	return shared.HeadersStatusStop
 }
-func (p *UpstreamResetFilter) OnHttpStreamHeaders(id uint64, headers [][2]string, end bool) {}
-func (p *UpstreamResetFilter) OnHttpStreamData(id uint64, body [][]byte, end bool)          {}
-func (p *UpstreamResetFilter) OnHttpStreamTrailers(id uint64, trailers [][2]string)         {}
-func (p *UpstreamResetFilter) OnHttpStreamComplete(id uint64)                               {}
+func (p *UpstreamResetFilter) OnHttpStreamHeaders(id uint64, headers [][2]shared.UnsafeEnvoyBuffer, end bool) {
+}
+func (p *UpstreamResetFilter) OnHttpStreamData(id uint64, body []shared.UnsafeEnvoyBuffer, end bool) {
+}
+func (p *UpstreamResetFilter) OnHttpStreamTrailers(id uint64, trailers [][2]shared.UnsafeEnvoyBuffer) {
+}
+func (p *UpstreamResetFilter) OnHttpStreamComplete(id uint64) {}
 func (p *UpstreamResetFilter) OnHttpStreamReset(id uint64, reason shared.HttpStreamResetReason) {
 	assertEq(id, p.streamID, "id")
 	p.handle.SendLocalResponse(200, [][2]string{{"x-reset", "true"}}, []byte("upstream_reset"), "")


### PR DESCRIPTION
Commit Message: dym go SDK: use the UnsafeEnvoyBuffer to indicate the lifetime explicitly
Additional Description:

This refactored the golang SDK, and use the `UnsafeEnvoyBuffer` to represent any memory managed by Envoy (vs using unsafe `string` or unsafe `[]byte`). (cpp SDK use `absl::string_view` and rust SDK also use an `EnvoyBuffer` struct).

By this way, the developers could aware the the string or bytes are managed by Envoy clearly and won't mis-understand the lifetime of the string.

This will bring a little complexity (the test filters show the additional complexity is minor) for developers but also make the lifetime management more clear for developers.

Risk Level: low.
Testing: n/a.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.
