### PR TITLE
sds: reduce copy of a structure by returning a const-ref

### DIFF
--- a/source/common/secret/sds_api.cc
+++ b/source/common/secret/sds_api.cc
@@ -208,7 +208,7 @@ void SdsApi::initialize(bool warm) {
   }
 }
 
-SdsApi::SecretData SdsApi::secretData() { return secret_data_; }
+const SdsApi::SecretData& SdsApi::secretData() const { return secret_data_; }
 
 SdsApi::FileContentMap SdsApi::loadFiles() {
   FileContentMap files;

--- a/source/common/secret/sds_api.h
+++ b/source/common/secret/sds_api.h
@@ -61,7 +61,7 @@ public:
          std::function<void()> destructor_cb, Event::Dispatcher& dispatcher, Api::Api& api,
          bool warm);
 
-  SecretData secretData();
+  const SecretData& secretData() const;
 
 protected:
   // Ordered for hash stability.


### PR DESCRIPTION
Commit Message: sds: reduce copy of a structure by returning a const-ref
Additional Description:
Internal refactor to return a const-ref instead of a copy in the `secretData()` method.

Risk Level: low - internal change
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
