### PR TITLE
ci: fix go api build by adding gazelle resolve directives for x/net

### DIFF
--- a/bazel/dependency_imports.bzl
+++ b/bazel/dependency_imports.bzl
@@ -104,6 +104,9 @@ def envoy_dependency_imports(
         build_external = "external",
         build_directives = [
             "gazelle:resolve go google.golang.org/genproto/googleapis/rpc/status @org_golang_google_genproto_googleapis_rpc//status",
+            "gazelle:resolve go golang.org/x/net/http2 @org_golang_x_net//http2",
+            "gazelle:resolve go golang.org/x/net/http2/hpack @org_golang_x_net//http2/hpack",
+            "gazelle:resolve go golang.org/x/net/trace @org_golang_x_net//trace",
         ],
     )
     go_repository(


### PR DESCRIPTION
Add gazelle:resolve directives for golang.org/x/net imports in the org_golang_google_grpc go_repository, fixing the api CI check failure. This is the same class of issue fixed in #43536 (genproto) and #43556 (xds) — the rules_go 0.53→0.59 bump changed gazelle's cross-repo import resolution behavior, and remote cache expiry has been gradually exposing unresolved imports.

```
  compilepkg: missing strict dependencies:
      .../org_golang_google_grpc/internal/transport/controlbuf.go: import of "golang.org/x/net/http2"
      .../org_golang_google_grpc/internal/transport/controlbuf.go: import of "golang.org/x/net/http2/hpack"
```

Testing: Reproduced locally with bazel build --noremote_accept_cached @org_golang_google_grpc//internal/transport:transport — fails without the fix, passes with it.