### PR TITLE
reverse_tunnels: intercept RPING on upstream reverse connections

### DIFF
--- a/source/extensions/bootstrap/reverse_tunnel/common/BUILD
+++ b/source/extensions/bootstrap/reverse_tunnel/common/BUILD
@@ -1,6 +1,7 @@
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_extension",
+    "envoy_cc_library",
     "envoy_extension_package",
 )
 
@@ -20,5 +21,15 @@ envoy_cc_extension(
         "//source/common/common:logger_lib",
         "//source/common/http:header_map_lib",
         "//source/common/http:headers_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "rping_interceptor_lib",
+    srcs = ["rping_interceptor.cc"],
+    hdrs = ["rping_interceptor.h"],
+    deps = [
+        ":reverse_connection_utility_lib",
+        "//source/common/network:default_socket_interface_lib",
     ],
 )

--- a/source/extensions/bootstrap/reverse_tunnel/common/rping_interceptor.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/common/rping_interceptor.cc
@@ -1,0 +1,76 @@
+#include "source/extensions/bootstrap/reverse_tunnel/common/rping_interceptor.h"
+
+#include "source/extensions/bootstrap/reverse_tunnel/common/reverse_connection_utility.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace Bootstrap {
+namespace ReverseConnection {
+
+Api::IoCallUint64Result RpingInterceptor::read(Buffer::Instance& buffer,
+                                               absl::optional<uint64_t> max_length) {
+  // Perform the actual read first.
+  Api::IoCallUint64Result result = IoSocketHandleImpl::read(buffer, max_length);
+  ENVOY_LOG(trace, "RpingInterceptor: read result: {}", result.return_value_);
+
+  // If RPING keepalives are still active, check whether the incoming data is a RPING message.
+  if (ping_echo_active_ && result.err_ == nullptr && result.return_value_ > 0) {
+    const uint64_t expected = ReverseConnectionUtility::PING_MESSAGE.size();
+
+    // Compare up to the expected size using a zero-copy view.
+    const uint64_t len = std::min<uint64_t>(buffer.length(), expected);
+    const char* data = static_cast<const char*>(buffer.linearize(len));
+    absl::string_view peek_sv{data, static_cast<size_t>(len)};
+
+    // Check if we have a complete RPING message.
+    if (len == expected && ReverseConnectionUtility::isPingMessage(peek_sv)) {
+      // Found a complete RPING. Echo and drain it from the buffer.
+      buffer.drain(expected);
+      onPingMessage();
+
+      // If buffer only contained RPING, return showing we processed it.
+      if (buffer.length() == 0) {
+        return Api::IoCallUint64Result{expected, Api::IoError::none()};
+      }
+
+      // RPING followed by application data. Disable echo and return the remaining data.
+      ENVOY_LOG(trace,
+                "RpingInterceptor: received application data after RPING, "
+                "disabling RPING echo for FD: {}",
+                fd_);
+      ping_echo_active_ = false;
+      // The adjusted return value is the number of bytes excluding the drained RPING. It should be
+      // transparent to upper layers that the RPING was processed.
+      const uint64_t adjusted =
+          (result.return_value_ >= expected) ? (result.return_value_ - expected) : 0;
+      return Api::IoCallUint64Result{adjusted, Api::IoError::none()};
+    }
+
+    // If partial data could be the start of RPING (only when fewer than expected bytes).
+    if (len < expected) {
+      const absl::string_view rping_prefix =
+          ReverseConnectionUtility::PING_MESSAGE.substr(0, static_cast<size_t>(len));
+      if (peek_sv == rping_prefix) {
+        ENVOY_LOG(trace,
+                  "RpingInterceptor: partial RPING received ({} bytes), waiting "
+                  "for more.",
+                  len);
+        return result; // Wait for more data.
+      }
+    }
+
+    // Data is not RPING (complete or partial). Disable echo permanently.
+    ENVOY_LOG(trace,
+              "RpingInterceptor: received application data ({} bytes), "
+              "disabling RPING echo for FD: {}",
+              len, fd_);
+    ping_echo_active_ = false;
+  }
+
+  return result;
+}
+
+} // namespace ReverseConnection
+} // namespace Bootstrap
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/bootstrap/reverse_tunnel/common/rping_interceptor.h
+++ b/source/extensions/bootstrap/reverse_tunnel/common/rping_interceptor.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "source/common/network/io_socket_handle_impl.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace Bootstrap {
+namespace ReverseConnection {
+
+class RpingInterceptor : public virtual Network::IoSocketHandleImpl {
+public:
+  // Intercept reads to handle reverse connection keep-alive pings.
+  Api::IoCallUint64Result read(Buffer::Instance& buffer,
+                               absl::optional<uint64_t> max_length) override;
+
+  virtual void onPingMessage() PURE;
+
+protected:
+  // Whether to actively echo RPING messages while the connection is idle.
+  // Disabled permanently after the first non-RPING application byte is observed.
+  bool ping_echo_active_{true};
+};
+
+} // namespace ReverseConnection
+} // namespace Bootstrap
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/BUILD
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/BUILD
@@ -89,6 +89,7 @@ envoy_cc_library(
         "//source/common/tls:ssl_handshaker_lib",
         "//source/common/upstream:load_balancer_context_base_lib",
         "//source/extensions/bootstrap/reverse_tunnel/common:reverse_connection_utility_lib",
+        "//source/extensions/bootstrap/reverse_tunnel/common:rping_interceptor_lib",
     ],
 )
 

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/downstream_reverse_connection_io_handle.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/downstream_reverse_connection_io_handle.cc
@@ -1,7 +1,6 @@
 #include "source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/downstream_reverse_connection_io_handle.h"
 
 #include "source/common/common/logger.h"
-#include "source/extensions/bootstrap/reverse_tunnel/common/reverse_connection_utility.h"
 #include "source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.h"
 
 #include "absl/strings/string_view.h"
@@ -31,79 +30,15 @@ DownstreamReverseConnectionIOHandle::~DownstreamReverseConnectionIOHandle() {
       fd_, connection_key_);
 }
 
-Api::IoCallUint64Result
-DownstreamReverseConnectionIOHandle::read(Buffer::Instance& buffer,
-                                          absl::optional<uint64_t> max_length) {
-  // Perform the actual read first.
-  Api::IoCallUint64Result result = IoSocketHandleImpl::read(buffer, max_length);
-  ENVOY_LOG(trace, "DownstreamReverseConnectionIOHandle: read result: {}", result.return_value_);
+void DownstreamReverseConnectionIOHandle::onPingMessage() {
+  auto echo_rc = ReverseConnectionUtility::sendPingResponse(*this);
 
-  // If RPING keepalives are still active, check whether the incoming data is a RPING message.
-  if (ping_echo_active_ && result.err_ == nullptr && result.return_value_ > 0) {
-    const uint64_t expected =
-        ::Envoy::Extensions::Bootstrap::ReverseConnection::ReverseConnectionUtility::PING_MESSAGE
-            .size();
-
-    // Compare up to the expected size using a zero-copy view.
-    const uint64_t len = std::min<uint64_t>(buffer.length(), expected);
-    const char* data = static_cast<const char*>(buffer.linearize(len));
-    absl::string_view peek_sv{data, static_cast<size_t>(len)};
-
-    // Check if we have a complete RPING message.
-    if (len == expected &&
-        ::Envoy::Extensions::Bootstrap::ReverseConnection::ReverseConnectionUtility::isPingMessage(
-            peek_sv)) {
-      // Found a complete RPING. Echo and drain it from the buffer.
-      buffer.drain(expected);
-      auto echo_rc = ::Envoy::Extensions::Bootstrap::ReverseConnection::ReverseConnectionUtility::
-          sendPingResponse(*this);
-      if (!echo_rc.ok()) {
-        ENVOY_LOG(trace, "DownstreamReverseConnectionIOHandle: failed to send RPING echo on FD: {}",
-                  fd_);
-      } else {
-        ENVOY_LOG(trace, "DownstreamReverseConnectionIOHandle: echoed RPING on FD: {}", fd_);
-      }
-
-      // If buffer only contained RPING, return showing we processed it.
-      if (buffer.length() == 0) {
-        return Api::IoCallUint64Result{expected, Api::IoError::none()};
-      }
-
-      // RPING followed by application data. Disable echo and return the remaining data.
-      ENVOY_LOG(trace,
-                "DownstreamReverseConnectionIOHandle: received application data after RPING, "
-                "disabling RPING echo for FD: {}",
-                fd_);
-      ping_echo_active_ = false;
-      // The adjusted return value is the number of bytes excluding the drained RPING. It should be
-      // transparent to upper layers that the RPING was processed.
-      const uint64_t adjusted =
-          (result.return_value_ >= expected) ? (result.return_value_ - expected) : 0;
-      return Api::IoCallUint64Result{adjusted, Api::IoError::none()};
-    }
-
-    // If partial data could be the start of RPING (only when fewer than expected bytes).
-    if (len < expected) {
-      const absl::string_view rping_prefix =
-          ReverseConnectionUtility::PING_MESSAGE.substr(0, static_cast<size_t>(len));
-      if (peek_sv == rping_prefix) {
-        ENVOY_LOG(trace,
-                  "DownstreamReverseConnectionIOHandle: partial RPING received ({} bytes), waiting "
-                  "for more.",
-                  len);
-        return result; // Wait for more data.
-      }
-    }
-
-    // Data is not RPING (complete or partial). Disable echo permanently.
-    ENVOY_LOG(trace,
-              "DownstreamReverseConnectionIOHandle: received application data ({} bytes), "
-              "disabling RPING echo for FD: {}",
-              len, fd_);
-    ping_echo_active_ = false;
+  if (!echo_rc.ok()) {
+    ENVOY_LOG(trace, "DownstreamReverseConnectionIOHandle: failed to send RPING echo on FD: {}",
+              fd_);
+  } else {
+    ENVOY_LOG(trace, "DownstreamReverseConnectionIOHandle: echoed RPING on FD: {}", fd_);
   }
-
-  return result;
 }
 
 // DownstreamReverseConnectionIOHandle close() implementation.

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/downstream_reverse_connection_io_handle.h
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/downstream_reverse_connection_io_handle.h
@@ -7,6 +7,8 @@
 
 #include "source/common/common/logger.h"
 #include "source/common/network/io_socket_handle_impl.h"
+#include "source/extensions/bootstrap/reverse_tunnel/common/reverse_connection_utility.h"
+#include "source/extensions/bootstrap/reverse_tunnel/common/rping_interceptor.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -21,7 +23,7 @@ class ReverseConnectionIOHandle;
  * This class is used internally by ReverseConnectionIOHandle to manage the lifecycle
  * of accepted downstream connections.
  */
-class DownstreamReverseConnectionIOHandle : public Network::IoSocketHandleImpl {
+class DownstreamReverseConnectionIOHandle : public RpingInterceptor {
 public:
   /**
    * Constructor that takes ownership of the socket and stores parent pointer and connection key.
@@ -33,11 +35,12 @@ public:
   ~DownstreamReverseConnectionIOHandle() override;
 
   // Network::IoHandle overrides.
-  // Intercept reads to handle reverse connection keep-alive pings.
-  Api::IoCallUint64Result read(Buffer::Instance& buffer,
-                               absl::optional<uint64_t> max_length) override;
   Api::IoCallUint64Result close() override;
   Api::SysCallIntResult shutdown(int how) override;
+
+  // RPING Interceptor overrides.
+  // Send the RPING response from here.
+  void onPingMessage() override;
 
   /**
    * Tell this IO handle to ignore close() and shutdown() calls.
@@ -60,10 +63,6 @@ private:
   std::string connection_key_;
   // Flag to ignore close and shutdown calls during socket hand-off.
   bool ignore_close_and_shutdown_{false};
-
-  // Whether to actively echo RPING messages while the connection is idle.
-  // Disabled permanently after the first non-RPING application byte is observed.
-  bool ping_echo_active_{true};
 };
 
 } // namespace ReverseConnection

--- a/source/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/BUILD
+++ b/source/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/BUILD
@@ -29,6 +29,7 @@ envoy_cc_extension(
         "//source/common/config:utility_lib",
         "//source/common/network:default_socket_interface_lib",
         "//source/extensions/bootstrap/reverse_tunnel/common:reverse_connection_utility_lib",
+        "//source/extensions/bootstrap/reverse_tunnel/common:rping_interceptor_lib",
         "@envoy_api//envoy/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/v3:pkg_cc_proto",
     ],
 )

--- a/source/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/reverse_connection_io_handle.h
+++ b/source/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/reverse_connection_io_handle.h
@@ -6,6 +6,7 @@
 #include "envoy/network/socket.h"
 
 #include "source/common/network/io_socket_handle_impl.h"
+#include "source/extensions/bootstrap/reverse_tunnel/common/rping_interceptor.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -17,7 +18,7 @@ namespace ReverseConnection {
  * This class implements RAII principles to ensure proper socket cleanup and provides
  * reverse connection semantics where the connection is already established.
  */
-class UpstreamReverseConnectionIOHandle : public Network::IoSocketHandleImpl {
+class UpstreamReverseConnectionIOHandle : public RpingInterceptor {
 public:
   /**
    * Constructs an UpstreamReverseConnectionIOHandle that takes ownership of a socket.
@@ -70,6 +71,10 @@ public:
    * This allows testing of defensive code paths where owned_socket_ is nullptr.
    */
   void releaseSocketForTest() { owned_socket_.reset(); }
+
+  // Ignore all ping messages.
+  // The connection is passed on to the http2 codec.
+  void onPingMessage() override {}
 
 private:
   // The name of the cluster this reverse connection belongs to.

--- a/test/extensions/bootstrap/reverse_tunnel/common/BUILD
+++ b/test/extensions/bootstrap/reverse_tunnel/common/BUILD
@@ -20,3 +20,14 @@ envoy_cc_test(
         "//test/test_common:test_runtime_lib",
     ],
 )
+
+envoy_cc_test(
+    name = "rping_interceptor_test",
+    size = "medium",
+    srcs = ["rping_interceptor_test.cc"],
+    deps = [
+        "//source/common/buffer:buffer_lib",
+        "//source/extensions/bootstrap/reverse_tunnel/common:reverse_connection_utility_lib",
+        "//source/extensions/bootstrap/reverse_tunnel/common:rping_interceptor_lib",
+    ],
+)

--- a/test/extensions/bootstrap/reverse_tunnel/common/rping_interceptor_test.cc
+++ b/test/extensions/bootstrap/reverse_tunnel/common/rping_interceptor_test.cc
@@ -1,0 +1,163 @@
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <string>
+
+#include "source/common/buffer/buffer_impl.h"
+#include "source/extensions/bootstrap/reverse_tunnel/common/reverse_connection_utility.h"
+#include "source/extensions/bootstrap/reverse_tunnel/common/rping_interceptor.h"
+
+#include "gtest/gtest.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace Bootstrap {
+namespace ReverseConnection {
+
+class TestRpingInterceptor : public RpingInterceptor {
+public:
+  explicit TestRpingInterceptor(int fd) : IoSocketHandleImpl(fd) {}
+
+  void onPingMessage() override { ++ping_messages_; }
+
+  uint64_t pingMessages() const { return ping_messages_; }
+
+private:
+  uint64_t ping_messages_{0};
+};
+
+class RpingInterceptorTest : public testing::Test {
+protected:
+  std::unique_ptr<TestRpingInterceptor> makeInterceptor(int fd) {
+    return std::make_unique<TestRpingInterceptor>(fd);
+  }
+};
+
+TEST_F(RpingInterceptorTest, FullRpingConsumedAndCallbackInvoked) {
+  int fds[2];
+  ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, fds), 0);
+
+  auto interceptor = makeInterceptor(fds[0]);
+  const std::string rping = std::string(ReverseConnectionUtility::PING_MESSAGE);
+  ASSERT_EQ(write(fds[1], rping.data(), rping.size()), static_cast<ssize_t>(rping.size()));
+
+  Buffer::OwnedImpl buffer;
+  const auto result = interceptor->read(buffer, absl::nullopt);
+
+  EXPECT_EQ(result.err_, nullptr);
+  EXPECT_EQ(result.return_value_, rping.size());
+  EXPECT_EQ(buffer.length(), 0);
+  EXPECT_EQ(interceptor->pingMessages(), 1);
+
+  close(fds[1]);
+}
+
+TEST_F(RpingInterceptorTest, ChoppedRpingCompletesAndDrainsInSingleBuffer) {
+  int fds[2];
+  ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, fds), 0);
+
+  auto interceptor = makeInterceptor(fds[0]);
+  const std::string rping = std::string(ReverseConnectionUtility::PING_MESSAGE);
+
+  const std::string prefix = rping.substr(0, 3);
+  const std::string suffix = rping.substr(3);
+
+  Buffer::OwnedImpl buffer;
+
+  ASSERT_EQ(write(fds[1], prefix.data(), prefix.size()), static_cast<ssize_t>(prefix.size()));
+  const auto first = interceptor->read(buffer, absl::nullopt);
+  EXPECT_EQ(first.err_, nullptr);
+  EXPECT_EQ(first.return_value_, prefix.size());
+  EXPECT_EQ(buffer.toString(), prefix);
+  EXPECT_EQ(interceptor->pingMessages(), 0);
+
+  ASSERT_EQ(write(fds[1], suffix.data(), suffix.size()), static_cast<ssize_t>(suffix.size()));
+  const auto second = interceptor->read(buffer, absl::nullopt);
+  EXPECT_EQ(second.err_, nullptr);
+  EXPECT_EQ(second.return_value_, rping.size());
+  EXPECT_EQ(buffer.length(), 0);
+  EXPECT_EQ(interceptor->pingMessages(), 1);
+
+  close(fds[1]);
+}
+
+TEST_F(RpingInterceptorTest, PingPlusDataConsumesPingAndReturnsPayload) {
+  int fds[2];
+  ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, fds), 0);
+
+  auto interceptor = makeInterceptor(fds[0]);
+  const std::string rping = std::string(ReverseConnectionUtility::PING_MESSAGE);
+  const std::string payload = " value";
+  const std::string combined = rping + payload;
+  ASSERT_EQ(write(fds[1], combined.data(), combined.size()), static_cast<ssize_t>(combined.size()));
+
+  Buffer::OwnedImpl buffer;
+  const auto result = interceptor->read(buffer, absl::nullopt);
+
+  EXPECT_EQ(result.err_, nullptr);
+  EXPECT_EQ(result.return_value_, payload.size());
+  EXPECT_EQ(buffer.toString(), payload);
+  EXPECT_EQ(interceptor->pingMessages(), 1);
+
+  close(fds[1]);
+}
+
+TEST_F(RpingInterceptorTest, DataAfterPingIsPassedThrough) {
+  int fds[2];
+  ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, fds), 0);
+
+  auto interceptor = makeInterceptor(fds[0]);
+  const std::string rping = std::string(ReverseConnectionUtility::PING_MESSAGE);
+  const std::string data = "GET /";
+
+  ASSERT_EQ(write(fds[1], rping.data(), rping.size()), static_cast<ssize_t>(rping.size()));
+  Buffer::OwnedImpl first_read_buffer;
+  const auto first = interceptor->read(first_read_buffer, absl::nullopt);
+  EXPECT_EQ(first.err_, nullptr);
+  EXPECT_EQ(first.return_value_, rping.size());
+  EXPECT_EQ(first_read_buffer.length(), 0);
+  EXPECT_EQ(interceptor->pingMessages(), 1);
+
+  ASSERT_EQ(write(fds[1], data.data(), data.size()), static_cast<ssize_t>(data.size()));
+  Buffer::OwnedImpl second_read_buffer;
+  const auto second = interceptor->read(second_read_buffer, absl::nullopt);
+  EXPECT_EQ(second.err_, nullptr);
+  EXPECT_EQ(second.return_value_, data.size());
+  EXPECT_EQ(second_read_buffer.toString(), data);
+  EXPECT_EQ(interceptor->pingMessages(), 1);
+
+  close(fds[1]);
+}
+
+TEST_F(RpingInterceptorTest, NonRpingFirstDisablesPingModeThenRpingPassesThrough) {
+  int fds[2];
+  ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, fds), 0);
+
+  auto interceptor = makeInterceptor(fds[0]);
+  const std::string first_data = "HELLO";
+  const std::string rping = std::string(ReverseConnectionUtility::PING_MESSAGE);
+
+  ASSERT_EQ(write(fds[1], first_data.data(), first_data.size()),
+            static_cast<ssize_t>(first_data.size()));
+  Buffer::OwnedImpl first_read_buffer;
+  const auto first = interceptor->read(first_read_buffer, absl::nullopt);
+  EXPECT_EQ(first.err_, nullptr);
+  EXPECT_EQ(first.return_value_, first_data.size());
+  EXPECT_EQ(first_read_buffer.toString(), first_data);
+  EXPECT_EQ(interceptor->pingMessages(), 0);
+
+  ASSERT_EQ(write(fds[1], rping.data(), rping.size()), static_cast<ssize_t>(rping.size()));
+  Buffer::OwnedImpl second_read_buffer;
+  const auto second = interceptor->read(second_read_buffer, absl::nullopt);
+  EXPECT_EQ(second.err_, nullptr);
+  EXPECT_EQ(second.return_value_, rping.size());
+  EXPECT_EQ(second_read_buffer.toString(), rping);
+  EXPECT_EQ(interceptor->pingMessages(), 0);
+
+  close(fds[1]);
+}
+
+} // namespace ReverseConnection
+} // namespace Bootstrap
+} // namespace Extensions
+} // namespace Envoy

--- a/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/downstream_reverse_connection_io_handle_test.cc
+++ b/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/downstream_reverse_connection_io_handle_test.cc
@@ -255,6 +255,32 @@ TEST_F(DownstreamReverseConnectionIOHandleTest, IgnoreCloseAndShutdown) {
   EXPECT_EQ(shutdown_wr.errno_, 0);
 }
 
+TEST_F(DownstreamReverseConnectionIOHandleTest, OnPingMessageWritesRpingToSocket) {
+  int fds[2];
+  ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, fds), 0);
+
+  auto mock_socket = std::make_unique<NiceMock<Network::MockConnectionSocket>>();
+  auto mock_io_handle = std::make_unique<Network::IoSocketHandleImpl>(fds[0]);
+  EXPECT_CALL(*mock_socket, ioHandle()).WillRepeatedly(ReturnRef(*mock_io_handle));
+
+  auto* io_handle_ptr = mock_io_handle.release();
+  mock_socket->io_handle_.reset(io_handle_ptr);
+
+  auto socket_ptr = Network::ConnectionSocketPtr(mock_socket.release());
+  auto handle = std::make_unique<DownstreamReverseConnectionIOHandle>(
+      std::move(socket_ptr), io_handle_.get(), "test_ping_key");
+
+  handle->onPingMessage();
+
+  const std::string expected = std::string(ReverseConnectionUtility::PING_MESSAGE);
+  char peer_buffer[16];
+  const ssize_t read_bytes = read(fds[1], peer_buffer, sizeof(peer_buffer));
+  ASSERT_EQ(read_bytes, static_cast<ssize_t>(expected.size()));
+  EXPECT_EQ(std::string(peer_buffer, read_bytes), expected);
+
+  close(fds[1]);
+}
+
 // Test read() method with real socket pairs to validate RPING handling.
 TEST_F(DownstreamReverseConnectionIOHandleTest, ReadRpingEchoScenarios) {
   const std::string rping_msg = std::string(ReverseConnectionUtility::PING_MESSAGE);

--- a/test/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/upstream_reverse_connection_io_handle_test.cc
+++ b/test/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/upstream_reverse_connection_io_handle_test.cc
@@ -1,6 +1,9 @@
+#include <fcntl.h>
+#include <sys/socket.h>
 #include <unistd.h>
 
 #include "source/common/network/utility.h"
+#include "source/extensions/bootstrap/reverse_tunnel/common/reverse_connection_utility.h"
 #include "source/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/reverse_connection_io_handle.h"
 #include "source/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/reverse_tunnel_acceptor.h"
 #include "source/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/reverse_tunnel_acceptor_extension.h"
@@ -49,6 +52,14 @@ protected:
     EXPECT_CALL(*mock_io_handle, fdDoNotUse()).WillRepeatedly(Return(123));
     EXPECT_CALL(*socket, ioHandle()).WillRepeatedly(ReturnRef(*mock_io_handle));
     socket->io_handle_ = std::move(mock_io_handle);
+    return socket;
+  }
+
+  Network::ConnectionSocketPtr createSocketWithFd(int fd) {
+    auto socket = std::make_unique<NiceMock<Network::MockConnectionSocket>>();
+    auto io_handle = std::make_unique<Network::IoSocketHandleImpl>(fd);
+    EXPECT_CALL(*socket, ioHandle()).WillRepeatedly(ReturnRef(*io_handle));
+    socket->io_handle_ = std::move(io_handle);
     return socket;
   }
 
@@ -272,6 +283,103 @@ TEST_F(UpstreamReverseConnectionIOHandleTest, ShutdownWhenNotOwned) {
   // Now shutdown should call IoSocketHandleImpl::shutdown().
   auto result = io_handle_->shutdown(SHUT_RDWR);
   EXPECT_GE(result.return_value_, -1);
+}
+
+TEST_F(UpstreamReverseConnectionIOHandleTest, ReadConsumesFullRping) {
+  int fds[2];
+  ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, fds), 0);
+
+  io_handle_ = std::make_unique<UpstreamReverseConnectionIOHandle>(createSocketWithFd(fds[0]),
+                                                                   "test-cluster");
+
+  const std::string rping = std::string(ReverseConnectionUtility::PING_MESSAGE);
+  ASSERT_EQ(write(fds[1], rping.data(), rping.size()), static_cast<ssize_t>(rping.size()));
+
+  Buffer::OwnedImpl buffer;
+  auto result = io_handle_->read(buffer, absl::nullopt);
+
+  EXPECT_EQ(result.err_, nullptr);
+  EXPECT_EQ(result.return_value_, rping.size());
+  EXPECT_EQ(buffer.length(), 0);
+
+  close(fds[1]);
+}
+
+TEST_F(UpstreamReverseConnectionIOHandleTest, ReadConsumesRpingAndReturnsTrailingPayload) {
+  int fds[2];
+  ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, fds), 0);
+
+  io_handle_ = std::make_unique<UpstreamReverseConnectionIOHandle>(createSocketWithFd(fds[0]),
+                                                                   "test-cluster");
+
+  const std::string rping = std::string(ReverseConnectionUtility::PING_MESSAGE);
+  const std::string payload = " value";
+  const std::string combined = rping + payload;
+  ASSERT_EQ(write(fds[1], combined.data(), combined.size()), static_cast<ssize_t>(combined.size()));
+
+  Buffer::OwnedImpl buffer;
+  auto result = io_handle_->read(buffer, absl::nullopt);
+
+  EXPECT_EQ(result.err_, nullptr);
+  EXPECT_EQ(result.return_value_, payload.size());
+  EXPECT_EQ(buffer.toString(), payload);
+
+  close(fds[1]);
+}
+
+TEST_F(UpstreamReverseConnectionIOHandleTest, OnPingMessageIsNoOpAndDoesNotWriteToSocket) {
+  int fds[2];
+  ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, fds), 0);
+
+  io_handle_ = std::make_unique<UpstreamReverseConnectionIOHandle>(createSocketWithFd(fds[0]),
+                                                                   "test-cluster");
+
+  const std::string rping = std::string(ReverseConnectionUtility::PING_MESSAGE);
+  ASSERT_EQ(write(fds[1], rping.data(), rping.size()), static_cast<ssize_t>(rping.size()));
+
+  Buffer::OwnedImpl buffer;
+  auto result = io_handle_->read(buffer, absl::nullopt);
+  EXPECT_EQ(result.err_, nullptr);
+  EXPECT_EQ(result.return_value_, rping.size());
+
+  char peer_buffer[16];
+  const int flags = fcntl(fds[1], F_GETFL, 0);
+  ASSERT_NE(flags, -1);
+  ASSERT_EQ(fcntl(fds[1], F_SETFL, flags | O_NONBLOCK), 0);
+  const ssize_t peer_read = read(fds[1], peer_buffer, sizeof(peer_buffer));
+  EXPECT_EQ(peer_read, -1);
+  EXPECT_EQ(errno, EAGAIN);
+
+  close(fds[1]);
+}
+
+TEST_F(UpstreamReverseConnectionIOHandleTest, NonRpingFirstDisablesPingModeThenRpingPassesThrough) {
+  int fds[2];
+  ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, fds), 0);
+
+  io_handle_ = std::make_unique<UpstreamReverseConnectionIOHandle>(createSocketWithFd(fds[0]),
+                                                                   "test-cluster");
+
+  const std::string non_rping = "HELLO";
+  ASSERT_EQ(write(fds[1], non_rping.data(), non_rping.size()),
+            static_cast<ssize_t>(non_rping.size()));
+
+  Buffer::OwnedImpl first_buffer;
+  auto first = io_handle_->read(first_buffer, absl::nullopt);
+  EXPECT_EQ(first.err_, nullptr);
+  EXPECT_EQ(first.return_value_, non_rping.size());
+  EXPECT_EQ(first_buffer.toString(), non_rping);
+
+  const std::string rping = std::string(ReverseConnectionUtility::PING_MESSAGE);
+  ASSERT_EQ(write(fds[1], rping.data(), rping.size()), static_cast<ssize_t>(rping.size()));
+
+  Buffer::OwnedImpl second_buffer;
+  auto second = io_handle_->read(second_buffer, absl::nullopt);
+  EXPECT_EQ(second.err_, nullptr);
+  EXPECT_EQ(second.return_value_, rping.size());
+  EXPECT_EQ(second_buffer.toString(), rping);
+
+  close(fds[1]);
 }
 
 } // namespace ReverseConnection


### PR DESCRIPTION
## Commit Message
Intercept RPING on upstream reverse connections

## Additional Description
If a RPING is sent and then the connection is upgraded to http2 via the conn pool the downstream reverse connection io handle's rping response causes a 502 protocol error.

More specifically: Remote peer returned unexpected data while we expected SETTINGS frame

Additional logs: 
```
2026-02-26 17:01:22.937 trace connection[thread=41 func=onReadReady file=source/common/network/connection_impl.cc:721] [Tags: "ConnectionId":"10614"] read ready. dispatch_buffered_data=0
2026-02-26 17:01:22.937 info misc[thread=41 func=read file=./source/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/reverse_connection_io_handle.h:89] ALERT GOT SOME RPING Bytes: RPING
2026-02-26 17:01:22.937 trace connection[thread=41 func=doRead file=source/common/network/raw_buffer_socket.cc:25] [Tags: "ConnectionId":"10614"] read returns: 20745
2026-02-26 17:01:22.937 info misc[thread=41 func=read file=./source/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/reverse_connection_io_handle.h:89] ALERT GOT SOME RPING Bytes: RPING
2026-02-26 17:01:22.937 trace connection[thread=41 func=doRead file=source/common/network/raw_buffer_socket.cc:39] [Tags: "ConnectionId":"10614"] read error: Resource temporarily unavailable, code: 0
2026-02-26 17:01:22.937 trace http2[thread=41 func=dispatch file=source/common/http/http2/codec_impl.cc:1077] [Tags: "ConnectionId":"10614"] dispatching 20745 bytes
2026-02-26 17:01:22.937 debug http2[thread=41 func=onError file=source/common/http/http2/codec_impl.cc:1395] [Tags: "ConnectionId":"10614"] invalid http2: Remote peer returned unexpected data while we expected SETTINGS frame.  Perhaps, peer does not support HTTP/2 properly.
```

The Alert was a custom log line added by me for easier debugging.
Its better for both the downstream and upstream rc io handles to share a common read implementation.

## Testing
Unit tests.
Additionally, manually validated the example in the docs which also works after the change.