### PR TITLE
dym: make the metric id from 1 rather than 0

### DIFF
--- a/source/extensions/access_loggers/dynamic_modules/access_log_config.h
+++ b/source/extensions/access_loggers/dynamic_modules/access_log_config.h
@@ -95,26 +95,24 @@ public:
     Stats::Histogram& histogram_;
   };
 
-#define INDEX_TO_ID(index) ((index) + 1)
+// We use 1-based IDs for the metrics in the ABI, so we need to convert them to 0-based indices
+// for our internal storage. These helper functions do that conversion.
 #define ID_TO_INDEX(id) ((id) - 1)
 
   // Methods for adding metrics during configuration.
   size_t addCounter(ModuleCounterHandle&& counter) {
-    size_t id = INDEX_TO_ID(counters_.size());
     counters_.push_back(std::move(counter));
-    return id;
+    return counters_.size();
   }
 
   size_t addGauge(ModuleGaugeHandle&& gauge) {
-    size_t id = INDEX_TO_ID(gauges_.size());
     gauges_.push_back(std::move(gauge));
-    return id;
+    return gauges_.size();
   }
 
   size_t addHistogram(ModuleHistogramHandle&& histogram) {
-    size_t id = INDEX_TO_ID(histograms_.size());
     histograms_.push_back(std::move(histogram));
-    return id;
+    return histograms_.size();
   }
 
   // Methods for getting metrics by ID.

--- a/source/extensions/bootstrap/dynamic_modules/extension_config.h
+++ b/source/extensions/bootstrap/dynamic_modules/extension_config.h
@@ -239,43 +239,38 @@ public:
     Stats::Histogram::Unit unit_;
   };
 
-#define INDEX_TO_ID(index) ((index) + 1)
+// We use 1-based IDs for the metrics in the ABI, so we need to convert them to 0-based indices
+// for our internal storage. These helper functions do that conversion.
 #define ID_TO_INDEX(id) ((id) - 1)
 
   size_t addCounter(ModuleCounterHandle&& counter) {
-    size_t id = INDEX_TO_ID(counters_.size());
     counters_.push_back(std::move(counter));
-    return id;
+    return counters_.size();
   }
 
   size_t addCounterVec(ModuleCounterVecHandle&& counter_vec) {
-    size_t id = INDEX_TO_ID(counter_vecs_.size());
     counter_vecs_.push_back(std::move(counter_vec));
-    return id;
+    return counter_vecs_.size();
   }
 
   size_t addGauge(ModuleGaugeHandle&& gauge) {
-    size_t id = INDEX_TO_ID(gauges_.size());
     gauges_.push_back(std::move(gauge));
-    return id;
+    return gauges_.size();
   }
 
   size_t addGaugeVec(ModuleGaugeVecHandle&& gauge_vec) {
-    size_t id = INDEX_TO_ID(gauge_vecs_.size());
     gauge_vecs_.push_back(std::move(gauge_vec));
-    return id;
+    return gauge_vecs_.size();
   }
 
   size_t addHistogram(ModuleHistogramHandle&& histogram) {
-    size_t id = INDEX_TO_ID(histograms_.size());
     histograms_.push_back(std::move(histogram));
-    return id;
+    return histograms_.size();
   }
 
   size_t addHistogramVec(ModuleHistogramVecHandle&& histogram_vec) {
-    size_t id = INDEX_TO_ID(histogram_vecs_.size());
     histogram_vecs_.push_back(std::move(histogram_vec));
-    return id;
+    return histogram_vecs_.size();
   }
 
   OptRef<const ModuleCounterHandle> getCounterById(size_t id) const {
@@ -320,7 +315,6 @@ public:
     return histogram_vecs_[ID_TO_INDEX(id)];
   }
 
-#undef INDEX_TO_ID
 #undef ID_TO_INDEX
 
   // Stats scope for metric creation.

--- a/source/extensions/filters/http/dynamic_modules/filter_config.h
+++ b/source/extensions/filters/http/dynamic_modules/filter_config.h
@@ -217,21 +217,18 @@ public:
     Stats::Histogram::Unit unit_;
   };
 
-// To ensure our IDs are never 0 (as 0 is used to indicate invalid ID), we store the stats in
-// vectors and use the index + 1 as the ID.
-#define INDEX_TO_ID(index) ((index) + 1)
+// We use 1-based IDs for the metrics in the ABI, so we need to convert them to 0-based indices
+// for our internal storage. These helper functions do that conversion.
 #define ID_TO_INDEX(id) ((id) - 1)
 
   size_t addCounter(ModuleCounterHandle&& counter) {
-    size_t id = INDEX_TO_ID(counters_.size());
     counters_.push_back(std::move(counter));
-    return id;
+    return counters_.size();
   }
 
   size_t addCounterVec(ModuleCounterVecHandle&& counter_vec) {
-    size_t id = INDEX_TO_ID(counter_vecs_.size());
     counter_vecs_.push_back(std::move(counter_vec));
-    return id;
+    return counter_vecs_.size();
   }
 
   OptRef<const ModuleCounterHandle> getCounterById(size_t id) const {
@@ -249,15 +246,13 @@ public:
   }
 
   size_t addGauge(ModuleGaugeHandle&& gauge) {
-    size_t id = INDEX_TO_ID(gauges_.size());
     gauges_.push_back(std::move(gauge));
-    return id;
+    return gauges_.size();
   }
 
   size_t addGaugeVec(ModuleGaugeVecHandle&& gauge_vec) {
-    size_t id = INDEX_TO_ID(gauge_vecs_.size());
     gauge_vecs_.push_back(std::move(gauge_vec));
-    return id;
+    return gauge_vecs_.size();
   }
 
   OptRef<const ModuleGaugeHandle> getGaugeById(size_t id) const {
@@ -275,15 +270,13 @@ public:
   }
 
   size_t addHistogram(ModuleHistogramHandle&& hist) {
-    size_t id = INDEX_TO_ID(hists_.size());
     hists_.push_back(std::move(hist));
-    return id;
+    return hists_.size();
   }
 
   size_t addHistogramVec(ModuleHistogramVecHandle&& hist_vec) {
-    size_t id = INDEX_TO_ID(hist_vecs_.size());
     hist_vecs_.push_back(std::move(hist_vec));
-    return id;
+    return hist_vecs_.size();
   }
 
   OptRef<const ModuleHistogramHandle> getHistogramById(size_t id) const {
@@ -300,7 +293,6 @@ public:
     return hist_vecs_[ID_TO_INDEX(id)];
   }
 
-#undef INDEX_TO_ID
 #undef ID_TO_INDEX
 
 private:

--- a/source/extensions/filters/listener/dynamic_modules/filter_config.h
+++ b/source/extensions/filters/listener/dynamic_modules/filter_config.h
@@ -134,26 +134,24 @@ public:
     Stats::Histogram& histogram_;
   };
 
-#define INDEX_TO_ID(index) ((index) + 1)
+// We use 1-based IDs for the metrics in the ABI, so we need to convert them to 0-based indices
+// for our internal storage. These helper functions do that conversion.
 #define ID_TO_INDEX(id) ((id) - 1)
 
   // Methods for adding metrics during configuration.
   size_t addCounter(ModuleCounterHandle&& counter) {
-    size_t id = INDEX_TO_ID(counters_.size());
     counters_.push_back(std::move(counter));
-    return id;
+    return counters_.size();
   }
 
   size_t addGauge(ModuleGaugeHandle&& gauge) {
-    size_t id = INDEX_TO_ID(gauges_.size());
     gauges_.push_back(std::move(gauge));
-    return id;
+    return gauges_.size();
   }
 
   size_t addHistogram(ModuleHistogramHandle&& histogram) {
-    size_t id = INDEX_TO_ID(histograms_.size());
     histograms_.push_back(std::move(histogram));
-    return id;
+    return histograms_.size();
   }
 
   // Methods for getting metrics by ID.
@@ -178,7 +176,6 @@ public:
     return histograms_[ID_TO_INDEX(id)];
   }
 
-#undef INDEX_TO_ID
 #undef ID_TO_INDEX
 
   // Stats scope for metric creation.

--- a/source/extensions/filters/network/dynamic_modules/filter_config.h
+++ b/source/extensions/filters/network/dynamic_modules/filter_config.h
@@ -139,26 +139,24 @@ public:
     Stats::Histogram& histogram_;
   };
 
-#define INDEX_TO_ID(index) ((index) + 1)
+// We use 1-based IDs for the metrics in the ABI, so we need to convert them to 0-based indices
+// for our internal storage. These helper functions do that conversion.
 #define ID_TO_INDEX(id) ((id) - 1)
 
   // Methods for adding metrics during configuration.
   size_t addCounter(ModuleCounterHandle&& counter) {
-    size_t id = INDEX_TO_ID(counters_.size());
     counters_.push_back(std::move(counter));
-    return id;
+    return counters_.size();
   }
 
   size_t addGauge(ModuleGaugeHandle&& gauge) {
-    size_t id = INDEX_TO_ID(gauges_.size());
     gauges_.push_back(std::move(gauge));
-    return id;
+    return gauges_.size();
   }
 
   size_t addHistogram(ModuleHistogramHandle&& histogram) {
-    size_t id = INDEX_TO_ID(histograms_.size());
     histograms_.push_back(std::move(histogram));
-    return id;
+    return histograms_.size();
   }
 
   // Methods for getting metrics by ID.
@@ -183,7 +181,6 @@ public:
     return histograms_[ID_TO_INDEX(id)];
   }
 
-#undef INDEX_TO_ID
 #undef ID_TO_INDEX
 
   // Stats scope for metric creation.

--- a/source/extensions/filters/udp/dynamic_modules/filter_config.h
+++ b/source/extensions/filters/udp/dynamic_modules/filter_config.h
@@ -73,26 +73,24 @@ public:
     Stats::Histogram& histogram_;
   };
 
-#define INDEX_TO_ID(index) ((index) + 1)
+// We use 1-based IDs for the metrics in the ABI, so we need to convert them to 0-based indices
+// for our internal storage. These helper functions do that conversion.
 #define ID_TO_INDEX(id) ((id) - 1)
 
   // Methods for adding metrics during configuration.
   size_t addCounter(ModuleCounterHandle&& counter) {
-    size_t id = INDEX_TO_ID(counters_.size());
     counters_.push_back(std::move(counter));
-    return id;
+    return counters_.size();
   }
 
   size_t addGauge(ModuleGaugeHandle&& gauge) {
-    size_t id = INDEX_TO_ID(gauges_.size());
     gauges_.push_back(std::move(gauge));
-    return id;
+    return gauges_.size();
   }
 
   size_t addHistogram(ModuleHistogramHandle&& histogram) {
-    size_t id = INDEX_TO_ID(histograms_.size());
     histograms_.push_back(std::move(histogram));
-    return id;
+    return histograms_.size();
   }
 
   // Methods for getting metrics by ID.
@@ -117,7 +115,6 @@ public:
     return histograms_[ID_TO_INDEX(id)];
   }
 
-#undef INDEX_TO_ID
 #undef ID_TO_INDEX
 
   // Stats scope for metric creation.

--- a/test/extensions/access_loggers/dynamic_modules/access_log_test.cc
+++ b/test/extensions/access_loggers/dynamic_modules/access_log_test.cc
@@ -256,7 +256,7 @@ TEST_F(DynamicModuleAccessLogTest, MetricsCounterDefineAndIncrement) {
   EXPECT_EQ(envoy_dynamic_module_type_metrics_result_Success,
             envoy_dynamic_module_callback_access_logger_config_define_counter(
                 static_cast<void*>(config_.get()), name, &counter_id));
-  EXPECT_EQ(0, counter_id);
+  EXPECT_EQ(1, counter_id);
 
   EXPECT_EQ(envoy_dynamic_module_type_metrics_result_Success,
             envoy_dynamic_module_callback_access_logger_increment_counter(
@@ -276,7 +276,7 @@ TEST_F(DynamicModuleAccessLogTest, MetricsGaugeDefineAndManipulate) {
   EXPECT_EQ(envoy_dynamic_module_type_metrics_result_Success,
             envoy_dynamic_module_callback_access_logger_config_define_gauge(
                 static_cast<void*>(config_.get()), name, &gauge_id));
-  EXPECT_EQ(0, gauge_id);
+  EXPECT_EQ(1, gauge_id);
 
   EXPECT_EQ(envoy_dynamic_module_type_metrics_result_Success,
             envoy_dynamic_module_callback_access_logger_set_gauge(static_cast<void*>(config_.get()),
@@ -304,7 +304,7 @@ TEST_F(DynamicModuleAccessLogTest, MetricsHistogramDefineAndRecord) {
   EXPECT_EQ(envoy_dynamic_module_type_metrics_result_Success,
             envoy_dynamic_module_callback_access_logger_config_define_histogram(
                 static_cast<void*>(config_.get()), name, &histogram_id));
-  EXPECT_EQ(0, histogram_id);
+  EXPECT_EQ(1, histogram_id);
 
   EXPECT_EQ(envoy_dynamic_module_type_metrics_result_Success,
             envoy_dynamic_module_callback_access_logger_record_histogram_value(

--- a/test/extensions/dynamic_modules/bootstrap/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/bootstrap/abi_impl_test.cc
@@ -797,7 +797,7 @@ TEST_F(BootstrapAbiImplTest, DefineAndIncrementCounter) {
   auto result = envoy_dynamic_module_callback_bootstrap_extension_config_define_counter(
       config.value()->thisAsVoidPtr(), name, nullptr, 0, &counter_id);
   EXPECT_EQ(result, envoy_dynamic_module_type_metrics_result_Success);
-  EXPECT_EQ(counter_id, 0u);
+  EXPECT_EQ(counter_id, 1u);
 
   // Increment the counter.
   result = envoy_dynamic_module_callback_bootstrap_extension_config_increment_counter(
@@ -846,7 +846,7 @@ TEST_F(BootstrapAbiImplTest, DefineAndManipulateGauge) {
   auto result = envoy_dynamic_module_callback_bootstrap_extension_config_define_gauge(
       config.value()->thisAsVoidPtr(), name, nullptr, 0, &gauge_id);
   EXPECT_EQ(result, envoy_dynamic_module_type_metrics_result_Success);
-  EXPECT_EQ(gauge_id, 0u);
+  EXPECT_EQ(gauge_id, 1u);
 
   // Set the gauge.
   result = envoy_dynamic_module_callback_bootstrap_extension_config_set_gauge(
@@ -906,7 +906,7 @@ TEST_F(BootstrapAbiImplTest, DefineAndRecordHistogram) {
   auto result = envoy_dynamic_module_callback_bootstrap_extension_config_define_histogram(
       config.value()->thisAsVoidPtr(), name, nullptr, 0, &histogram_id);
   EXPECT_EQ(result, envoy_dynamic_module_type_metrics_result_Success);
-  EXPECT_EQ(histogram_id, 0u);
+  EXPECT_EQ(histogram_id, 1u);
 
   // Record a value.
   result = envoy_dynamic_module_callback_bootstrap_extension_config_record_histogram_value(
@@ -956,8 +956,8 @@ TEST_F(BootstrapAbiImplTest, DefineMultipleMetrics) {
   EXPECT_EQ(envoy_dynamic_module_callback_bootstrap_extension_config_define_counter(
                 config.value()->thisAsVoidPtr(), name_1, nullptr, 0, &counter_id_1),
             envoy_dynamic_module_type_metrics_result_Success);
-  EXPECT_EQ(counter_id_0, 0u);
-  EXPECT_EQ(counter_id_1, 1u);
+  EXPECT_EQ(counter_id_0, 1u);
+  EXPECT_EQ(counter_id_1, 2u);
 
   // Define multiple gauges.
   size_t gauge_id_0 = 0;
@@ -970,8 +970,8 @@ TEST_F(BootstrapAbiImplTest, DefineMultipleMetrics) {
   EXPECT_EQ(envoy_dynamic_module_callback_bootstrap_extension_config_define_gauge(
                 config.value()->thisAsVoidPtr(), gauge_name_1, nullptr, 0, &gauge_id_1),
             envoy_dynamic_module_type_metrics_result_Success);
-  EXPECT_EQ(gauge_id_0, 0u);
-  EXPECT_EQ(gauge_id_1, 1u);
+  EXPECT_EQ(gauge_id_0, 1u);
+  EXPECT_EQ(gauge_id_1, 2u);
 
   // Increment each counter independently.
   EXPECT_EQ(envoy_dynamic_module_callback_bootstrap_extension_config_increment_counter(
@@ -1009,7 +1009,7 @@ TEST_F(BootstrapAbiImplTest, DefineAndIncrementCounterVec) {
   auto result = envoy_dynamic_module_callback_bootstrap_extension_config_define_counter(
       config.value()->thisAsVoidPtr(), name, label_names, 2, &counter_vec_id);
   EXPECT_EQ(result, envoy_dynamic_module_type_metrics_result_Success);
-  EXPECT_EQ(counter_vec_id, 0u);
+  EXPECT_EQ(counter_vec_id, 1u);
 
   // Increment the counter vec with matching labels.
   envoy_dynamic_module_type_module_buffer label_values[] = {{"GET", 3}, {"200", 3}};
@@ -1064,7 +1064,7 @@ TEST_F(BootstrapAbiImplTest, DefineAndManipulateGaugeVec) {
   auto result = envoy_dynamic_module_callback_bootstrap_extension_config_define_gauge(
       config.value()->thisAsVoidPtr(), name, label_names, 1, &gauge_vec_id);
   EXPECT_EQ(result, envoy_dynamic_module_type_metrics_result_Success);
-  EXPECT_EQ(gauge_vec_id, 0u);
+  EXPECT_EQ(gauge_vec_id, 1u);
 
   // Set, increment, and decrement the gauge vec with matching labels.
   envoy_dynamic_module_type_module_buffer label_values[] = {{"upstream_a", 10}};
@@ -1101,7 +1101,7 @@ TEST_F(BootstrapAbiImplTest, DefineAndRecordHistogramVec) {
   auto result = envoy_dynamic_module_callback_bootstrap_extension_config_define_histogram(
       config.value()->thisAsVoidPtr(), name, label_names, 1, &histogram_vec_id);
   EXPECT_EQ(result, envoy_dynamic_module_type_metrics_result_Success);
-  EXPECT_EQ(histogram_vec_id, 0u);
+  EXPECT_EQ(histogram_vec_id, 1u);
 
   // Record values with matching labels.
   envoy_dynamic_module_type_module_buffer label_values[] = {{"svc_a", 5}};

--- a/test/extensions/dynamic_modules/listener/filter_test.cc
+++ b/test/extensions/dynamic_modules/listener/filter_test.cc
@@ -317,7 +317,7 @@ TEST_F(DynamicModuleListenerFilterTest, MetricsCounterDefineAndIncrement) {
   EXPECT_EQ(envoy_dynamic_module_type_metrics_result_Success,
             envoy_dynamic_module_callback_listener_filter_config_define_counter(
                 static_cast<void*>(filter_config_.get()), name, &counter_id));
-  EXPECT_EQ(0, counter_id);
+  EXPECT_EQ(1, counter_id);
 
   auto filter = std::make_unique<DynamicModuleListenerFilter>(filter_config_);
   filter->onAccept(callbacks_);
@@ -340,7 +340,7 @@ TEST_F(DynamicModuleListenerFilterTest, MetricsGaugeDefineAndManipulate) {
   EXPECT_EQ(envoy_dynamic_module_type_metrics_result_Success,
             envoy_dynamic_module_callback_listener_filter_config_define_gauge(
                 static_cast<void*>(filter_config_.get()), name, &gauge_id));
-  EXPECT_EQ(0, gauge_id);
+  EXPECT_EQ(1, gauge_id);
 
   auto filter = std::make_unique<DynamicModuleListenerFilter>(filter_config_);
   filter->onAccept(callbacks_);
@@ -371,7 +371,7 @@ TEST_F(DynamicModuleListenerFilterTest, MetricsHistogramDefineAndRecord) {
   EXPECT_EQ(envoy_dynamic_module_type_metrics_result_Success,
             envoy_dynamic_module_callback_listener_filter_config_define_histogram(
                 static_cast<void*>(filter_config_.get()), name, &histogram_id));
-  EXPECT_EQ(0, histogram_id);
+  EXPECT_EQ(1, histogram_id);
 
   auto filter = std::make_unique<DynamicModuleListenerFilter>(filter_config_);
   filter->onAccept(callbacks_);

--- a/test/extensions/dynamic_modules/network/filter_test.cc
+++ b/test/extensions/dynamic_modules/network/filter_test.cc
@@ -316,7 +316,7 @@ TEST_F(DynamicModuleNetworkFilterTest, DefineAndIncrementCounter) {
   auto result = envoy_dynamic_module_callback_network_filter_config_define_counter(
       filter_config_.get(), name, &counter_id);
   EXPECT_EQ(result, envoy_dynamic_module_type_metrics_result_Success);
-  EXPECT_EQ(counter_id, 0);
+  EXPECT_EQ(counter_id, 1);
 
   // Create filter and increment counter.
   auto filter = std::make_shared<DynamicModuleNetworkFilter>(filter_config_);
@@ -339,7 +339,7 @@ TEST_F(DynamicModuleNetworkFilterTest, DefineAndManipulateGauge) {
   auto result = envoy_dynamic_module_callback_network_filter_config_define_gauge(
       filter_config_.get(), name, &gauge_id);
   EXPECT_EQ(result, envoy_dynamic_module_type_metrics_result_Success);
-  EXPECT_EQ(gauge_id, 0);
+  EXPECT_EQ(gauge_id, 1);
 
   // Create filter and manipulate gauge.
   auto filter = std::make_shared<DynamicModuleNetworkFilter>(filter_config_);
@@ -367,7 +367,7 @@ TEST_F(DynamicModuleNetworkFilterTest, DefineAndRecordHistogram) {
   auto result = envoy_dynamic_module_callback_network_filter_config_define_histogram(
       filter_config_.get(), name, &histogram_id);
   EXPECT_EQ(result, envoy_dynamic_module_type_metrics_result_Success);
-  EXPECT_EQ(histogram_id, 0);
+  EXPECT_EQ(histogram_id, 1);
 
   // Create filter and record histogram value.
   auto filter = std::make_shared<DynamicModuleNetworkFilter>(filter_config_);

--- a/test/extensions/dynamic_modules/udp/filter_test.cc
+++ b/test/extensions/dynamic_modules/udp/filter_test.cc
@@ -327,7 +327,7 @@ TEST_F(DynamicModuleUdpListenerFilterTest, MetricsCounterDefineAndIncrement) {
       static_cast<void*>(filter_config_.get()),
       {const_cast<char*>("test_counter"), strlen("test_counter")}, &counter_id);
   EXPECT_EQ(envoy_dynamic_module_type_metrics_result_Success, result);
-  EXPECT_EQ(0, counter_id);
+  EXPECT_EQ(1, counter_id);
 
   // Increment the counter via the filter.
   result = envoy_dynamic_module_callback_udp_listener_filter_increment_counter(


### PR DESCRIPTION
Commit Message: dym: make the metric id from 1 rather than 0
Additional Description:

0 is common default value for variable. When the `define_*` metrics ABI failed to create a new metric, will keep the id as unset (which basically will be 0). But in previous implementation, the 0 may also be an valid id for the first metric.

To avoid confusion, the PR will preserve the 0 as unknown metric.

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
