### PR TITLE
upstream: fix mid-batch thread-aware LB initialization out-of-bounds

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -184,6 +184,10 @@ bug_fixes:
   change: |
     Fixed MCP router to support session-less backends that do not return ``mcp-session-id``
     headers. Previously this caused a spurious 500 error.
+- area: upstream
+  change: |
+    Fixed an out-of-bounds issue in ThreadAwareLoadBalancerBase that could occur during mid-batch EDS host updates
+    due to eagerly calling refresh() before the deferred priority state resize.
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`


### PR DESCRIPTION
Fixes a crash introduced by #43346. 
When a thread-aware load balancer is initialized mid-batch, the per-priority panic tracking vectors have not been resized yet because the batch member update callback hasn't fired. This causes an out-of-bounds read during the LB refresh loop.

1. Process any dirty priorities to properly size vectors if the load balancer is initialized mid-batch.
2. Add a bounds check `ASSERT` to prevent silent out-of-bounds bit vector reads.
3. Add an initialization regression test to prevent this pattern from breaking in the future.

Commit Message:
Additional Description:
Risk Level: low (already guarded by `envoy.reloadable_features.coalesce_lb_rebuilds_on_batch_update`).
Testing:
Docs Changes:
Release Notes:
