### PR TITLE
dym: improve the stream callout to handle the reset on initialization

### DIFF
--- a/test/extensions/dynamic_modules/http/filter_test.cc
+++ b/test/extensions/dynamic_modules/http/filter_test.cc
@@ -1224,7 +1224,7 @@ TEST(DynamicModuleHttpStreamTest, StartHttpStreamHandlesInlineResetDuringHeaders
 
   auto result = filter->startHttpStream(&stream_id, "cluster", std::move(message),
                                         true /* end_stream */, 1000);
-  EXPECT_EQ(result, envoy_dynamic_module_type_http_callout_init_result_Success);
+  EXPECT_EQ(result, envoy_dynamic_module_type_http_callout_init_result_CannotCreateRequest);
   EXPECT_NE(captured_callbacks, nullptr);
 }
 
@@ -1509,7 +1509,7 @@ TEST(DynamicModulesTest, HttpFilterStartHttpStreamInlineResetOnHeaders) {
   auto message = std::make_unique<Http::RequestMessageImpl>(std::move(headers));
   auto result = filter->startHttpStream(&stream_id, "cluster", std::move(message), true, 1000);
   // Should still return success even with inline reset.
-  EXPECT_EQ(result, envoy_dynamic_module_type_http_callout_init_result_Success);
+  EXPECT_EQ(result, envoy_dynamic_module_type_http_callout_init_result_CannotCreateRequest);
 
   // Clean up properly.
   filter->onDestroy();
@@ -1573,7 +1573,7 @@ TEST(DynamicModulesTest, HttpFilterStartHttpStreamInlineResetOnData) {
   message->body().add("request body");
   auto result = filter->startHttpStream(&stream_id, "cluster", std::move(message), true, 1000);
   // Should still return success even with inline reset on data.
-  EXPECT_EQ(result, envoy_dynamic_module_type_http_callout_init_result_Success);
+  EXPECT_EQ(result, envoy_dynamic_module_type_http_callout_init_result_CannotCreateRequest);
 
   // Clean up properly.
   filter->onDestroy();


### PR DESCRIPTION
Commit Message: dym: improve the stream callout to handle the reset on initialization
Additional Description:

In the previous implementation, the reset on initialization will be propagate to module by event hook and the status of `startHttpStream` will be `Success`.

In the new implementation, all failures on initialization will not trigger the event hook but will result in error status of `startHttpStream`.

The failure on initialization is very tricky and hard to process in practice of Envoy extension. It's hard to change current implementation of Envoy because it's used everywhere, but we still have chance to make the better usability for dynamic module. 

Risk Level: low.
Testing: unit.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.
