### PR TITLE
http: wire ConnectionLifetimeCallbacks into pool connection events

### DIFF
--- a/envoy/http/conn_pool.h
+++ b/envoy/http/conn_pool.h
@@ -122,26 +122,7 @@ public:
   virtual absl::string_view protocolDescription() const PURE;
 
   virtual void setLifetimeCallbacks(OptRef<ConnectionLifetimeCallbacks> callbacks,
-                                    std::vector<uint8_t> hash_key) {
-    callbacks_ = callbacks;
-    hash_key_ = std::move(hash_key);
-  }
-
-  virtual void onConnectionOpen(const Network::Connection& connection) {
-    if (callbacks_.has_value()) {
-      callbacks_->onConnectionOpen(*this, hash_key_, connection);
-    }
-  }
-
-  virtual void onConnectionDraining(const Network::Connection& connection) {
-    if (callbacks_.has_value()) {
-      callbacks_->onConnectionDraining(*this, hash_key_, connection);
-    }
-  }
-
-protected:
-  OptRef<ConnectionLifetimeCallbacks> callbacks_;
-  std::vector<uint8_t> hash_key_;
+                                    std::vector<uint8_t> hash_key) PURE;
 };
 
 using InstancePtr = std::unique_ptr<Instance>;

--- a/envoy/http/conn_pool.h
+++ b/envoy/http/conn_pool.h
@@ -2,6 +2,7 @@
 
 #include <functional>
 #include <memory>
+#include <vector>
 
 #include "envoy/common/conn_pool.h"
 #include "envoy/common/pure.h"
@@ -119,6 +120,28 @@ public:
    * @return absl::string_view a protocol description for logging.
    */
   virtual absl::string_view protocolDescription() const PURE;
+
+  virtual void setLifetimeCallbacks(OptRef<ConnectionLifetimeCallbacks> callbacks,
+                                    std::vector<uint8_t> hash_key) {
+    callbacks_ = callbacks;
+    hash_key_ = std::move(hash_key);
+  }
+
+  virtual void onConnectionOpen(const Network::Connection& connection) {
+    if (callbacks_.has_value()) {
+      callbacks_->onConnectionOpen(*this, hash_key_, connection);
+    }
+  }
+
+  virtual void onConnectionDraining(const Network::Connection& connection) {
+    if (callbacks_.has_value()) {
+      callbacks_->onConnectionDraining(*this, hash_key_, connection);
+    }
+  }
+
+protected:
+  OptRef<ConnectionLifetimeCallbacks> callbacks_;
+  std::vector<uint8_t> hash_key_;
 };
 
 using InstancePtr = std::unique_ptr<Instance>;

--- a/source/common/http/codec_client.h
+++ b/source/common/http/codec_client.h
@@ -155,6 +155,9 @@ public:
 
   bool connectCalled() const { return connect_called_; }
 
+  // Get the underlying connection of the codec client for lifetimeCallbacks.
+  const Network::Connection& connection() const { return *connection_; }
+
 protected:
   /**
    * Create a codec client and connect to a remote host/port.

--- a/source/common/http/conn_pool_base.cc
+++ b/source/common/http/conn_pool_base.cc
@@ -115,6 +115,7 @@ void MultiplexedActiveClientBase::onGoAway(Http::GoAwayErrorCode) {
     if (codec_client_->numActiveRequests() == 0) {
       codec_client_->close();
     } else {
+      parent().onConnectionDraining(codec_client_->connection());
       parent_.transitionActiveClientState(*this, ActiveClient::State::Draining);
     }
   }

--- a/source/common/http/conn_pool_base.cc
+++ b/source/common/http/conn_pool_base.cc
@@ -104,6 +104,24 @@ void HttpConnPoolImplBase::onPoolReady(Envoy::ConnectionPool::ActiveClient& clie
                         http_client->codec_client_->protocol());
 }
 
+void HttpConnPoolImplBase::setLifetimeCallbacks(
+    OptRef<ConnectionPool::ConnectionLifetimeCallbacks> callbacks, std::vector<uint8_t> hash_key) {
+  callbacks_ = callbacks;
+  hash_key_ = std::move(hash_key);
+}
+
+void HttpConnPoolImplBase::onConnectionOpen(const Network::Connection& connection) {
+  if (callbacks_.has_value()) {
+    callbacks_->onConnectionOpen(*this, hash_key_, connection);
+  }
+}
+
+void HttpConnPoolImplBase::onConnectionDraining(const Network::Connection& connection) {
+  if (callbacks_.has_value()) {
+    callbacks_->onConnectionDraining(*this, hash_key_, connection);
+  }
+}
+
 // All streams are 2^31. Client streams are half that, minus stream 0. Just to be on the safe
 // side we do 2^29.
 constexpr uint32_t DEFAULT_MAX_STREAMS = 1U << 29;
@@ -221,6 +239,18 @@ RequestEncoder& MultiplexedActiveClientBase::newStreamEncoder(ResponseDecoder& r
 RequestEncoder&
 MultiplexedActiveClientBase::newStreamEncoder(ResponseDecoderHandlePtr response_decoder_handle) {
   return codec_client_->newStream(std::move(response_decoder_handle));
+}
+
+void MultiplexedActiveClientBase::onEvent(Network::ConnectionEvent event) {
+  if (event == Network::ConnectionEvent::Connected ||
+      event == Network::ConnectionEvent::ConnectedZeroRtt) {
+    parent().onConnectionOpen(codec_client_->connection());
+  } else if (event == Network::ConnectionEvent::LocalClose ||
+             event == Network::ConnectionEvent::RemoteClose) {
+    parent().onConnectionDraining(codec_client_->connection());
+  }
+
+  ActiveClient::onEvent(event);
 }
 
 } // namespace Http

--- a/source/common/http/conn_pool_base.h
+++ b/source/common/http/conn_pool_base.h
@@ -242,6 +242,21 @@ public:
   void onGoAway(Http::GoAwayErrorCode error_code) override;
   void onSettings(ReceivedSettings& settings) override;
 
+  // Override to provide the lifetimeCallbacks.
+  void onEvent(Network::ConnectionEvent event) override {
+    if (event == Network::ConnectionEvent::Connected ||
+        event == Network::ConnectionEvent::ConnectedZeroRtt) {
+      parent().onConnectionOpen(codec_client_->connection());
+    } else if (event == Network::ConnectionEvent::LocalClose ||
+               event == Network::ConnectionEvent::RemoteClose) {
+      // Makes sense semantically for the load balancers to process closes as drains.
+      // They just have to know that they cannot route to that connection anymore.
+      parent().onConnectionDraining(codec_client_->connection());
+    }
+
+    ActiveClient::onEvent(event);
+  }
+
 private:
   bool closed_with_active_rq_{};
 };

--- a/source/common/http/conn_pool_base.h
+++ b/source/common/http/conn_pool_base.h
@@ -98,6 +98,13 @@ public:
   virtual absl::optional<HttpServerPropertiesCache::Origin>& origin() { return origin_; }
   virtual Http::HttpServerPropertiesCacheSharedPtr cache() { return nullptr; }
 
+  void setLifetimeCallbacks(OptRef<ConnectionPool::ConnectionLifetimeCallbacks> callbacks,
+                            std::vector<uint8_t> hash_key) override;
+
+  void onConnectionOpen(const Network::Connection& connection);
+
+  void onConnectionDraining(const Network::Connection& connection);
+
 protected:
   friend class ActiveClient;
 
@@ -107,6 +114,8 @@ protected:
 
 private:
   absl::optional<HttpServerPropertiesCache::Origin> origin_;
+  OptRef<ConnectionPool::ConnectionLifetimeCallbacks> callbacks_;
+  std::vector<uint8_t> hash_key_;
 };
 
 // An implementation of Envoy::ConnectionPool::ActiveClient for HTTP/1.1 and HTTP/2
@@ -243,19 +252,7 @@ public:
   void onSettings(ReceivedSettings& settings) override;
 
   // Override to provide the lifetimeCallbacks.
-  void onEvent(Network::ConnectionEvent event) override {
-    if (event == Network::ConnectionEvent::Connected ||
-        event == Network::ConnectionEvent::ConnectedZeroRtt) {
-      parent().onConnectionOpen(codec_client_->connection());
-    } else if (event == Network::ConnectionEvent::LocalClose ||
-               event == Network::ConnectionEvent::RemoteClose) {
-      // Makes sense semantically for the load balancers to process closes as drains.
-      // They just have to know that they cannot route to that connection anymore.
-      parent().onConnectionDraining(codec_client_->connection());
-    }
-
-    ActiveClient::onEvent(event);
-  }
+  void onEvent(Network::ConnectionEvent event) override;
 
 private:
   bool closed_with_active_rq_{};

--- a/source/common/http/conn_pool_grid.cc
+++ b/source/common/http/conn_pool_grid.cc
@@ -417,6 +417,7 @@ ConnectionPool::InstancePtr ConnectivityGrid::createHttp3Pool(bool attempt_alter
 
 void ConnectivityGrid::setupPool(ConnectionPool::Instance& pool) {
   pool.addIdleCallback([this]() { onIdleReceived(); });
+  pool.setLifetimeCallbacks(makeOptRefFromPtr(this), hash_key_);
 }
 
 bool ConnectivityGrid::hasActiveConnections() const {
@@ -608,6 +609,26 @@ void ConnectivityGrid::onHandshakeComplete() {
 void ConnectivityGrid::onZeroRttHandshakeFailed() {
   ENVOY_LOG(trace, "Marking HTTP/3 failed for host '{}'.", host_->hostname());
   getHttp3StatusTracker().markHttp3FailedRecently();
+}
+
+void ConnectivityGrid::onConnectionOpen(ConnectionPool::Instance&, std::vector<uint8_t>&,
+                                        const Network::Connection& connection) {
+  if (callbacks_.has_value()) {
+    callbacks_->onConnectionOpen(*this, hash_key_, connection);
+  }
+}
+
+void ConnectivityGrid::onConnectionDraining(ConnectionPool::Instance&, std::vector<uint8_t>&,
+                                            const Network::Connection& connection) {
+  if (callbacks_.has_value()) {
+    callbacks_->onConnectionDraining(*this, hash_key_, connection);
+  }
+}
+
+void ConnectivityGrid::setLifetimeCallbacks(
+    OptRef<ConnectionPool::ConnectionLifetimeCallbacks> callbacks, std::vector<uint8_t> hash_key) {
+  callbacks_ = callbacks;
+  hash_key_ = std::move(hash_key);
 }
 
 } // namespace Http

--- a/source/common/http/conn_pool_grid.h
+++ b/source/common/http/conn_pool_grid.h
@@ -30,6 +30,7 @@ namespace Http {
 // the host's address list.
 class ConnectivityGrid : public ConnectionPool::Instance,
                          public Http3::PoolConnectResultCallback,
+                         public ConnectionPool::ConnectionLifetimeCallbacks,
                          protected Logger::Loggable<Logger::Id::pool> {
 public:
   struct ConnectivityOptions {
@@ -228,6 +229,15 @@ public:
   void onHandshakeComplete() override;
   void onZeroRttHandshakeFailed() override;
 
+  // ConnectionPool::ConnectionLifetimeCallbacks
+  void onConnectionOpen(ConnectionPool::Instance& pool, std::vector<uint8_t>& hash_key,
+                        const Network::Connection& connection) override;
+  void onConnectionDraining(ConnectionPool::Instance& pool, std::vector<uint8_t>& hash_key,
+                            const Network::Connection& connection) override;
+
+  void setLifetimeCallbacks(OptRef<ConnectionPool::ConnectionLifetimeCallbacks> callbacks,
+                            std::vector<uint8_t> hash_key) override;
+
 protected:
   // Set the required idle callback on the pool.
   void setupPool(ConnectionPool::Instance& pool);
@@ -308,6 +318,9 @@ private:
   bool deferred_deleting_{};
 
   OptRef<Quic::EnvoyQuicNetworkObserverRegistry> network_observer_registry_;
+
+  OptRef<ConnectionPool::ConnectionLifetimeCallbacks> callbacks_;
+  std::vector<uint8_t> hash_key_;
 };
 
 } // namespace Http

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -2023,6 +2023,8 @@ ClusterManagerImpl::ThreadLocalClusterManagerImpl::ClusterEntry::httpConnPoolImp
           parent.httpConnPoolIsIdle(host, priority, hash_key);
         });
 
+        pool->setLifetimeCallbacks(lb_->lifetimeCallbacks(), hash_key);
+
         return pool;
       });
 

--- a/test/common/http/conn_pool_grid_test.cc
+++ b/test/common/http/conn_pool_grid_test.cc
@@ -85,6 +85,13 @@ public:
 
   void createHttp3AlternatePool() {
     ConnectionPool::MockInstance* instance = new NiceMock<ConnectionPool::MockInstance>();
+    EXPECT_CALL(*instance, setLifetimeCallbacks(_, _))
+        .Times(testing::AtLeast(1))
+        .WillRepeatedly(
+            Invoke([this, instance](OptRef<ConnectionPool::ConnectionLifetimeCallbacks> cb,
+                                    std::vector<uint8_t> key) {
+              captured_lifetime_callbacks_[instance] = {cb, std::move(key)};
+            }));
     setupPool(*instance);
     http3_alternate_pool_.reset(instance);
     pools_.push_back(instance);
@@ -120,6 +127,13 @@ public:
               return cancel_;
             }));
     EXPECT_CALL(*instance, protocolDescription()).Times(AnyNumber()).WillRepeatedly(Return(type));
+    EXPECT_CALL(*instance, setLifetimeCallbacks(_, _))
+        .Times(testing::AtLeast(1))
+        .WillRepeatedly(
+            Invoke([this, instance](OptRef<ConnectionPool::ConnectionLifetimeCallbacks> cb,
+                                    std::vector<uint8_t> key) {
+              captured_lifetime_callbacks_[instance] = {cb, std::move(key)};
+            }));
     return absl::WrapUnique(instance);
   }
 
@@ -148,6 +162,21 @@ public:
     return http3_status_tracker.isHttp3Confirmed();
   }
 
+  // Simulate an inner pool firing onConnectionOpen to the grid,
+  // using the callbacks that setupPool wired via setLifetimeCallbacks.
+  void simulateConnectionOpen(ConnectionPool::Instance& pool,
+                              const Network::Connection& connection) {
+    auto it = captured_lifetime_callbacks_.find(&pool);
+    ASSERT(it != captured_lifetime_callbacks_.end());
+    it->second.callbacks->onConnectionOpen(pool, it->second.hash_key, connection);
+  }
+  void simulateConnectionDraining(ConnectionPool::Instance& pool,
+                                  const Network::Connection& connection) {
+    auto it = captured_lifetime_callbacks_.find(&pool);
+    ASSERT(it != captured_lifetime_callbacks_.end());
+    it->second.callbacks->onConnectionDraining(pool, it->second.hash_key, connection);
+  }
+
   StreamInfo::MockStreamInfo* info_;
   NiceMock<MockRequestEncoder>* encoder_;
   void setDestroying() { destroying_ = true; }
@@ -160,6 +189,12 @@ public:
 
   bool alternate_immediate_{true};
   bool alternate_failure_{true};
+
+  struct CapturedCallbacks {
+    OptRef<ConnectionPool::ConnectionLifetimeCallbacks> callbacks;
+    std::vector<uint8_t> hash_key;
+  };
+  absl::flat_hash_map<ConnectionPool::Instance*, CapturedCallbacks> captured_lifetime_callbacks_;
 };
 
 namespace {
@@ -1821,6 +1856,186 @@ TEST_F(ConnectivityGridTest, ConnectionCloseDuringAsyncConnect) {
 }
 
 #endif
+
+// Test 1: Without lifetime callbacks, all pool types (H3, H3 alt, H2) work normally.
+// setupPool unconditionally wires the grid as the inner pool's callback target,
+// so this verifies no crashes or unexpected behavior when no outer callbacks are set.
+TEST_F(ConnectivityGridTest, PoolsWorkWithoutLifetimeCallbacks) {
+  initialize();
+  addHttp3AlternateProtocol();
+
+  // Create the HTTP/3 pool via newStream, no lifetime callbacks set on the grid.
+  grid_->immediate_success_ = true;
+  auto* cancel = grid_->newStream(decoder_, callbacks_,
+                                  {/*can_send_early_data_=*/false,
+                                   /*can_use_http3_=*/true});
+  EXPECT_EQ(cancel, nullptr);
+  EXPECT_NE(grid_->http3Pool(), nullptr);
+
+  // Inner pool fires events to the grid via captured callbacks; no outer callbacks, no crash.
+  NiceMock<Network::MockConnection> connection;
+  grid_->simulateConnectionOpen(*grid_->http3Pool(), connection);
+  grid_->simulateConnectionDraining(*grid_->http3Pool(), connection);
+}
+
+TEST_F(ConnectivityGridTest, H2PoolWorksWithoutLifetimeCallbacks) {
+  initialize();
+  addHttp3AlternateProtocol();
+
+  // Create H3 pool, then fail it to trigger H2 pool creation.
+  EXPECT_NE(grid_->newStream(decoder_, callbacks_,
+                             {/*can_send_early_data_=*/false,
+                              /*can_use_http3_=*/true}),
+            nullptr);
+  EXPECT_NE(grid_->http3Pool(), nullptr);
+
+  grid_->immediate_success_ = true;
+  grid_->callbacks()->onPoolFailure(ConnectionPool::PoolFailureReason::LocalConnectionFailure,
+                                    "reason", host_);
+  EXPECT_NE(grid_->http2Pool(), nullptr);
+
+  NiceMock<Network::MockConnection> connection;
+  grid_->simulateConnectionOpen(*grid_->http2Pool(), connection);
+  grid_->simulateConnectionDraining(*grid_->http2Pool(), connection);
+}
+
+TEST_F(ConnectivityGridTest, H3AltPoolWorksWithoutLifetimeCallbacks) {
+  initialize();
+  addHttp3AlternateProtocol();
+  grid_->createHttp3AlternatePool();
+
+  EXPECT_NE(grid_->alternate(), nullptr);
+
+  NiceMock<Network::MockConnection> connection;
+  grid_->simulateConnectionOpen(*grid_->alternate(), connection);
+  grid_->simulateConnectionDraining(*grid_->alternate(), connection);
+}
+
+// Test 2: With lifetime callbacks set, verify events from inner pools flow through
+// to the mock load balancer with the grid's identity (not the inner pool's).
+TEST_F(ConnectivityGridTest, LifetimeCallbacksH3Only) {
+  initialize();
+  addHttp3AlternateProtocol();
+
+  ConnectionPool::MockConnectionLifetimeCallbacks lifetime_callbacks;
+  std::vector<uint8_t> hash_key = {1, 2, 3};
+  grid_->setLifetimeCallbacks(
+      makeOptRef<ConnectionPool::ConnectionLifetimeCallbacks>(lifetime_callbacks), hash_key);
+
+  EXPECT_NE(grid_->newStream(decoder_, callbacks_,
+                             {/*can_send_early_data_=*/false,
+                              /*can_use_http3_=*/true}),
+            nullptr);
+  EXPECT_NE(grid_->http3Pool(), nullptr);
+
+  NiceMock<Network::MockConnection> connection;
+
+  EXPECT_CALL(lifetime_callbacks,
+              onConnectionOpen(testing::Ref(*grid_), testing::ContainerEq(hash_key),
+                               testing::Ref(connection)));
+  grid_->simulateConnectionOpen(*grid_->http3Pool(), connection);
+
+  EXPECT_CALL(lifetime_callbacks,
+              onConnectionDraining(testing::Ref(*grid_), testing::ContainerEq(hash_key),
+                                   testing::Ref(connection)));
+  grid_->simulateConnectionDraining(*grid_->http3Pool(), connection);
+}
+
+TEST_F(ConnectivityGridTest, LifetimeCallbacksH3AndH2) {
+  initialize();
+  addHttp3AlternateProtocol();
+
+  ConnectionPool::MockConnectionLifetimeCallbacks lifetime_callbacks;
+  std::vector<uint8_t> hash_key = {4, 5, 6};
+  grid_->setLifetimeCallbacks(
+      makeOptRef<ConnectionPool::ConnectionLifetimeCallbacks>(lifetime_callbacks), hash_key);
+
+  // Create H3 pool.
+  EXPECT_NE(grid_->newStream(decoder_, callbacks_,
+                             {/*can_send_early_data_=*/false,
+                              /*can_use_http3_=*/true}),
+            nullptr);
+  EXPECT_NE(grid_->http3Pool(), nullptr);
+
+  // Fail H3 to create H2 pool.
+  grid_->callbacks()->onPoolFailure(ConnectionPool::PoolFailureReason::LocalConnectionFailure,
+                                    "reason", host_);
+  EXPECT_NE(grid_->http2Pool(), nullptr);
+
+  NiceMock<Network::MockConnection> h3_conn;
+  NiceMock<Network::MockConnection> h2_conn;
+
+  // Events from H3 pool forwarded with grid identity.
+  EXPECT_CALL(lifetime_callbacks,
+              onConnectionOpen(testing::Ref(*grid_), testing::ContainerEq(hash_key),
+                               testing::Ref(h3_conn)));
+  grid_->simulateConnectionOpen(*grid_->http3Pool(), h3_conn);
+
+  // Events from H2 pool also forwarded with grid identity.
+  EXPECT_CALL(lifetime_callbacks,
+              onConnectionOpen(testing::Ref(*grid_), testing::ContainerEq(hash_key),
+                               testing::Ref(h2_conn)));
+  grid_->simulateConnectionOpen(*grid_->http2Pool(), h2_conn);
+
+  // Draining from H2 pool forwarded with grid identity.
+  EXPECT_CALL(lifetime_callbacks,
+              onConnectionDraining(testing::Ref(*grid_), testing::ContainerEq(hash_key),
+                                   testing::Ref(h2_conn)));
+  grid_->simulateConnectionDraining(*grid_->http2Pool(), h2_conn);
+}
+
+TEST_F(ConnectivityGridTest, LifetimeCallbacksH3Alt) {
+  initialize();
+  addHttp3AlternateProtocol();
+
+  ConnectionPool::MockConnectionLifetimeCallbacks lifetime_callbacks;
+  std::vector<uint8_t> hash_key = {9, 10};
+  grid_->setLifetimeCallbacks(
+      makeOptRef<ConnectionPool::ConnectionLifetimeCallbacks>(lifetime_callbacks), hash_key);
+
+  grid_->createHttp3AlternatePool();
+  EXPECT_NE(grid_->alternate(), nullptr);
+
+  NiceMock<Network::MockConnection> connection;
+
+  // Events from the alternate H3 pool forwarded with grid identity.
+  EXPECT_CALL(lifetime_callbacks,
+              onConnectionOpen(testing::Ref(*grid_), testing::ContainerEq(hash_key),
+                               testing::Ref(connection)));
+  grid_->simulateConnectionOpen(*grid_->alternate(), connection);
+}
+
+// Verify that setting lifetime callbacks after pools already exist still works:
+// events from inner pools are visible at the load balancer.
+TEST_F(ConnectivityGridTest, LifetimeCallbacksSetAfterPoolCreation) {
+  initialize();
+  addHttp3AlternateProtocol();
+
+  // Create the HTTP/3 pool before setting any callbacks.
+  EXPECT_NE(grid_->newStream(decoder_, callbacks_,
+                             {/*can_send_early_data_=*/false,
+                              /*can_use_http3_=*/true}),
+            nullptr);
+  EXPECT_NE(grid_->http3Pool(), nullptr);
+
+  // Set callbacks after pool already exists.
+  ConnectionPool::MockConnectionLifetimeCallbacks lifetime_callbacks;
+  std::vector<uint8_t> hash_key = {11, 12};
+  grid_->setLifetimeCallbacks(
+      makeOptRef<ConnectionPool::ConnectionLifetimeCallbacks>(lifetime_callbacks), hash_key);
+
+  // Events from the pre-existing H3 pool are visible at the load balancer.
+  NiceMock<Network::MockConnection> connection;
+  EXPECT_CALL(lifetime_callbacks,
+              onConnectionOpen(testing::Ref(*grid_), testing::ContainerEq(hash_key),
+                               testing::Ref(connection)));
+  grid_->simulateConnectionOpen(*grid_->http3Pool(), connection);
+
+  EXPECT_CALL(lifetime_callbacks,
+              onConnectionDraining(testing::Ref(*grid_), testing::ContainerEq(hash_key),
+                                   testing::Ref(connection)));
+  grid_->simulateConnectionDraining(*grid_->http3Pool(), connection);
+}
 
 } // namespace
 } // namespace Http

--- a/test/common/http/http2/BUILD
+++ b/test/common/http/http2/BUILD
@@ -73,6 +73,7 @@ envoy_cc_test(
         "//test/common/http:common_lib",
         "//test/common/upstream:utility_lib",
         "//test/mocks/event:event_mocks",
+        "//test/mocks/http:conn_pool_mocks",
         "//test/mocks/http:http_mocks",
         "//test/mocks/http:http_server_properties_cache_mocks",
         "//test/mocks/network:network_mocks",

--- a/test/common/http/http2/conn_pool_test.cc
+++ b/test/common/http/http2/conn_pool_test.cc
@@ -11,6 +11,7 @@
 #include "test/common/http/common.h"
 #include "test/common/upstream/utility.h"
 #include "test/mocks/event/mocks.h"
+#include "test/mocks/http/conn_pool.h"
 #include "test/mocks/http/http_server_properties_cache.h"
 #include "test/mocks/http/mocks.h"
 #include "test/mocks/network/mocks.h"
@@ -2085,6 +2086,186 @@ TEST_F(Http2ConnPoolImplTest, RequestTrackingConnectionFailureNoMetric) {
   // Verify the connection failure was recorded
   EXPECT_EQ(1U, cluster_->traffic_stats_->upstream_cx_destroy_.value());
   EXPECT_EQ(1U, cluster_->traffic_stats_->upstream_cx_destroy_remote_.value());
+}
+
+// Normal pool lifecycle works without any lifetime callbacks set.
+TEST_F(Http2ConnPoolImplTest, ConnectionLifecycleNoopsWithoutCallbacks) {
+  InSequence s;
+
+  expectClientCreate();
+  ActiveTestRequest r1(*this, 0, false);
+  expectClientConnect(0, r1);
+  completeRequestCloseUpstream(0, r1);
+}
+
+// Connected event fires onConnectionOpen with correct pool, hash_key, and connection args.
+TEST_F(Http2ConnPoolImplTest, ConnectedEventFiresOpenCallbackWithCorrectArgs) {
+  InSequence s;
+
+  ConnectionPool::MockConnectionLifetimeCallbacks lifetime_callbacks;
+  std::vector<uint8_t> hash_key = {1, 2, 3};
+  pool_->setLifetimeCallbacks(
+      makeOptRef<ConnectionPool::ConnectionLifetimeCallbacks>(lifetime_callbacks), hash_key);
+
+  expectClientCreate();
+  ActiveTestRequest r1(*this, 0, false);
+
+  EXPECT_CALL(lifetime_callbacks,
+              onConnectionOpen(testing::Ref(*pool_), testing::ContainerEq(hash_key),
+                               testing::Ref(*test_clients_[0].connection_)));
+  expectClientConnect(0, r1);
+
+  completeRequest(r1);
+
+  EXPECT_CALL(lifetime_callbacks,
+              onConnectionDraining(testing::Ref(*pool_), testing::ContainerEq(hash_key),
+                                   testing::Ref(*test_clients_[0].connection_)));
+  EXPECT_CALL(*this, onClientDestroy());
+  test_clients_[0].connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
+  dispatcher_.clearDeferredDeleteList();
+}
+
+// RemoteClose fires onConnectionDraining with correct args.
+TEST_F(Http2ConnPoolImplTest, RemoteCloseFiresDrainingCallbackWithCorrectArgs) {
+  InSequence s;
+
+  ConnectionPool::MockConnectionLifetimeCallbacks lifetime_callbacks;
+  std::vector<uint8_t> hash_key = {4, 5, 6};
+  pool_->setLifetimeCallbacks(
+      makeOptRef<ConnectionPool::ConnectionLifetimeCallbacks>(lifetime_callbacks), hash_key);
+
+  expectClientCreate();
+  ActiveTestRequest r1(*this, 0, false);
+
+  EXPECT_CALL(lifetime_callbacks, onConnectionOpen(_, _, _));
+  expectClientConnect(0, r1);
+
+  completeRequest(r1);
+
+  EXPECT_CALL(lifetime_callbacks,
+              onConnectionDraining(testing::Ref(*pool_), testing::ContainerEq(hash_key),
+                                   testing::Ref(*test_clients_[0].connection_)));
+  EXPECT_CALL(*this, onClientDestroy());
+  test_clients_[0].connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
+  dispatcher_.clearDeferredDeleteList();
+}
+
+// LocalClose fires onConnectionDraining with correct args.
+TEST_F(Http2ConnPoolImplTest, LocalCloseFiresDrainingCallbackWithCorrectArgs) {
+  InSequence s;
+
+  ConnectionPool::MockConnectionLifetimeCallbacks lifetime_callbacks;
+  std::vector<uint8_t> hash_key = {4, 5, 6};
+  pool_->setLifetimeCallbacks(
+      makeOptRef<ConnectionPool::ConnectionLifetimeCallbacks>(lifetime_callbacks), hash_key);
+
+  expectClientCreate();
+  ActiveTestRequest r1(*this, 0, false);
+
+  EXPECT_CALL(lifetime_callbacks, onConnectionOpen(_, _, _));
+  expectClientConnect(0, r1);
+
+  completeRequest(r1);
+
+  EXPECT_CALL(lifetime_callbacks,
+              onConnectionDraining(testing::Ref(*pool_), testing::ContainerEq(hash_key),
+                                   testing::Ref(*test_clients_[0].connection_)));
+  EXPECT_CALL(*this, onClientDestroy());
+  test_clients_[0].connection_->raiseEvent(Network::ConnectionEvent::LocalClose);
+  dispatcher_.clearDeferredDeleteList();
+}
+
+// GOAWAY with an active stream fires onConnectionDraining once from the GOAWAY handler
+// and again when the connection closes after the stream completes.
+TEST_F(Http2ConnPoolImplTest, GoAwayWithActiveStreamFiresDrainingCallback) {
+  InSequence s;
+
+  ConnectionPool::MockConnectionLifetimeCallbacks lifetime_callbacks;
+  std::vector<uint8_t> hash_key = {7, 8, 9};
+  pool_->setLifetimeCallbacks(
+      makeOptRef<ConnectionPool::ConnectionLifetimeCallbacks>(lifetime_callbacks), hash_key);
+
+  expectClientCreate();
+  ActiveTestRequest r1(*this, 0, false);
+
+  EXPECT_CALL(lifetime_callbacks, onConnectionOpen(_, _, _));
+  expectClientConnect(0, r1);
+
+  EXPECT_CALL(r1.inner_encoder_, encodeHeaders(_, true));
+  EXPECT_TRUE(
+      r1.callbacks_.outer_encoder_
+          ->encodeHeaders(TestRequestHeaderMapImpl{{":path", "/"}, {":method", "GET"}}, true)
+          .ok());
+
+  // GOAWAY with active request fires draining from the goaway handler.
+  EXPECT_CALL(lifetime_callbacks,
+              onConnectionDraining(testing::Ref(*pool_), testing::ContainerEq(hash_key),
+                                   testing::Ref(*test_clients_[0].connection_)));
+  test_clients_[0].codec_client_->raiseGoAway(Http::GoAwayErrorCode::NoError);
+
+  // Completing the request triggers close on the draining connection, firing draining again.
+  EXPECT_CALL(lifetime_callbacks, onConnectionDraining(_, _, _));
+  EXPECT_CALL(r1.decoder_, decodeHeaders_(_, true));
+  EXPECT_CALL(*this, onClientDestroy());
+  r1.inner_decoder_->decodeHeaders(
+      ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", "200"}}}, true);
+  dispatcher_.clearDeferredDeleteList();
+}
+
+// GOAWAY on an idle connection closes immediately; draining fires from the close event only.
+TEST_F(Http2ConnPoolImplTest, GoAwayIdleConnectionFiresDrainingDuetoClose) {
+  InSequence s;
+
+  ConnectionPool::MockConnectionLifetimeCallbacks lifetime_callbacks;
+  std::vector<uint8_t> hash_key = {10, 11, 12};
+  pool_->setLifetimeCallbacks(
+      makeOptRef<ConnectionPool::ConnectionLifetimeCallbacks>(lifetime_callbacks), hash_key);
+
+  expectClientCreate();
+  ActiveTestRequest r1(*this, 0, false);
+
+  EXPECT_CALL(lifetime_callbacks, onConnectionOpen(_, _, _));
+  expectClientConnect(0, r1);
+
+  completeRequest(r1);
+
+  EXPECT_CALL(lifetime_callbacks,
+              onConnectionDraining(testing::Ref(*pool_), testing::ContainerEq(hash_key),
+                                   testing::Ref(*test_clients_[0].connection_)));
+  EXPECT_CALL(*this, onClientDestroy());
+  test_clients_[0].codec_client_->raiseGoAway(Http::GoAwayErrorCode::NoError);
+  dispatcher_.clearDeferredDeleteList();
+}
+
+// Calling setLifetimeCallbacks a second time replaces the first; only the latest fires.
+TEST_F(Http2ConnPoolImplTest, SetLifetimeCallbacksReplacesExisting) {
+  InSequence s;
+
+  ConnectionPool::MockConnectionLifetimeCallbacks first_callbacks;
+  ConnectionPool::MockConnectionLifetimeCallbacks second_callbacks;
+  std::vector<uint8_t> hash_key = {1};
+
+  pool_->setLifetimeCallbacks(
+      makeOptRef<ConnectionPool::ConnectionLifetimeCallbacks>(first_callbacks), hash_key);
+  pool_->setLifetimeCallbacks(
+      makeOptRef<ConnectionPool::ConnectionLifetimeCallbacks>(second_callbacks), hash_key);
+
+  expectClientCreate();
+  ActiveTestRequest r1(*this, 0, false);
+
+  EXPECT_CALL(first_callbacks, onConnectionOpen(_, _, _)).Times(0);
+  EXPECT_CALL(second_callbacks,
+              onConnectionOpen(testing::Ref(*pool_), testing::ContainerEq(hash_key), _));
+  expectClientConnect(0, r1);
+
+  completeRequest(r1);
+
+  EXPECT_CALL(first_callbacks, onConnectionDraining(_, _, _)).Times(0);
+  EXPECT_CALL(second_callbacks,
+              onConnectionDraining(testing::Ref(*pool_), testing::ContainerEq(hash_key), _));
+  EXPECT_CALL(*this, onClientDestroy());
+  test_clients_[0].connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
+  dispatcher_.clearDeferredDeleteList();
 }
 
 } // namespace Http2

--- a/test/common/http/http3/BUILD
+++ b/test/common/http/http3/BUILD
@@ -23,6 +23,7 @@ envoy_cc_test(
         "//test/common/quic:test_utils_lib",
         "//test/common/upstream:utility_lib",
         "//test/mocks/event:event_mocks",
+        "//test/mocks/http:conn_pool_mocks",
         "//test/mocks/http:http_mocks",
         "//test/mocks/network:network_mocks",
         "//test/mocks/runtime:runtime_mocks",

--- a/test/common/http/http3/conn_pool_test.cc
+++ b/test/common/http/http3/conn_pool_test.cc
@@ -350,13 +350,10 @@ TEST_F(Http3ConnPoolImplTest, LifetimeCallbackOpenAndGoAwayDraining) {
   EXPECT_EQ(1u, clients.size());
   auto* client = static_cast<MultiplexedActiveClientBase*>(clients.front().get());
 
-  // Connected event fires onConnectionOpen.
+  // ConnectedZeroRtt event fires onConnectionOpen.
   EXPECT_CALL(lifetime_callbacks,
               onConnectionOpen(testing::Ref(*pool_), testing::ContainerEq(hash_key), testing::_));
-  EXPECT_CALL(connect_result_callback_, onHandshakeComplete()).WillOnce(Invoke([cancellable]() {
-    cancellable->cancel(Envoy::ConnectionPool::CancelPolicy::Default);
-  }));
-  client->onEvent(Network::ConnectionEvent::Connected);
+  client->onEvent(Network::ConnectionEvent::ConnectedZeroRtt);
 
   // GOAWAY on idle connection -> closes -> LocalClose -> onConnectionDraining.
   EXPECT_CALL(lifetime_callbacks, onConnectionDraining(testing::Ref(*pool_),

--- a/test/common/http/http3/conn_pool_test.cc
+++ b/test/common/http/http3/conn_pool_test.cc
@@ -1,6 +1,7 @@
 #include <chrono>
 #include <memory>
 
+#include "source/common/http/conn_pool_base.h"
 #include "source/common/http/http3/conn_pool.h"
 #include "source/common/quic/quic_client_transport_socket_factory.h"
 
@@ -9,6 +10,7 @@
 #include "test/common/upstream/utility.h"
 #include "test/mocks/common.h"
 #include "test/mocks/event/mocks.h"
+#include "test/mocks/http/conn_pool.h"
 #include "test/mocks/server/overload_manager.h"
 #include "test/mocks/server/server_factory_context.h"
 #include "test/mocks/ssl/mocks.h"
@@ -304,6 +306,64 @@ TEST_F(Http3ConnPoolImplTest, GetNetworkChangeEvents) {
   observers_.onNetworkConnected(-1);
   observers_.onNetworkMadeDefault(-1);
   observers_.onNetworkDisconnected(-1);
+}
+
+// Connected fires onConnectionOpen, then GOAWAY on an idle connection closes it
+// which fires onConnectionDraining. Exercises the full MultiplexedActiveClientBase
+// callback path through the HTTP/3 pool.
+TEST_F(Http3ConnPoolImplTest, LifetimeCallbackOpenAndGoAwayDraining) {
+  EXPECT_CALL(mockHost(), address()).WillRepeatedly(Return(test_address_));
+  initialize();
+
+  Http::ConnectionPool::MockConnectionLifetimeCallbacks lifetime_callbacks;
+  std::vector<uint8_t> hash_key = {1, 2, 3};
+  pool_->setLifetimeCallbacks(
+      makeOptRef<Http::ConnectionPool::ConnectionLifetimeCallbacks>(lifetime_callbacks), hash_key);
+
+  MockResponseDecoder decoder;
+  ConnPoolCallbacks callbacks;
+  mockHost().cluster_.cluster_socket_options_ = std::make_shared<Network::Socket::Options>();
+  std::shared_ptr<Network::MockSocketOption> cluster_socket_option{new Network::MockSocketOption()};
+  mockHost().cluster_.cluster_socket_options_->push_back(cluster_socket_option);
+  EXPECT_CALL(*mockHost().cluster_.upstream_local_address_selector_,
+              getUpstreamLocalAddressImpl(_, _))
+      .WillOnce(Invoke(
+          [&](const Network::Address::InstanceConstSharedPtr& address,
+              OptRef<const Network::TransportSocketOptions>) -> Upstream::UpstreamLocalAddress {
+            EXPECT_EQ(address, test_address_);
+            Network::ConnectionSocket::OptionsSharedPtr options =
+                std::make_shared<Network::ConnectionSocket::Options>();
+            Network::Socket::appendOptions(options, mockHost().cluster_.cluster_socket_options_);
+            return Upstream::UpstreamLocalAddress({nullptr, options});
+          }));
+  EXPECT_CALL(*cluster_socket_option, setOption(_, _)).Times(3u);
+  EXPECT_CALL(*socket_option_, setOption(_, _)).Times(3u);
+  // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
+  auto* async_connect_callback = new NiceMock<Event::MockSchedulableCallback>(&dispatcher_);
+  ConnectionPool::Cancellable* cancellable = pool_->newStream(
+      decoder, callbacks, {/*can_send_early_data_=*/false, /*can_use_http3_=*/true});
+  EXPECT_NE(nullptr, cancellable);
+  async_connect_callback->invokeCallback();
+
+  std::list<Envoy::ConnectionPool::ActiveClientPtr>& clients =
+      Http3ConnPoolImplPeer::connectingClients(*pool_);
+  EXPECT_EQ(1u, clients.size());
+  auto* client = static_cast<MultiplexedActiveClientBase*>(clients.front().get());
+
+  // Connected event fires onConnectionOpen.
+  EXPECT_CALL(lifetime_callbacks,
+              onConnectionOpen(testing::Ref(*pool_), testing::ContainerEq(hash_key), testing::_));
+  EXPECT_CALL(connect_result_callback_, onHandshakeComplete()).WillOnce(Invoke([cancellable]() {
+    cancellable->cancel(Envoy::ConnectionPool::CancelPolicy::Default);
+  }));
+  client->onEvent(Network::ConnectionEvent::Connected);
+
+  // GOAWAY on idle connection -> closes -> LocalClose -> onConnectionDraining.
+  EXPECT_CALL(lifetime_callbacks, onConnectionDraining(testing::Ref(*pool_),
+                                                       testing::ContainerEq(hash_key), testing::_));
+  EXPECT_CALL(dispatcher_, deferredDelete_(_));
+  client->onGoAway(Http::GoAwayErrorCode::NoError);
+  dispatcher_.to_delete_.clear();
 }
 
 } // namespace Http3

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -1719,6 +1719,25 @@ TEST_F(ClusterManagerImplTest, UpstreamSocketOptionsPassedToConnPool) {
   EXPECT_TRUE(opt_cp.has_value());
 }
 
+// Verify that httpConnPool calls setLifetimeCallbacks on the newly created pool.
+TEST_F(ClusterManagerImplTest, LifetimeCallbacksPassedToConnPool) {
+  createWithBasicStaticCluster();
+  NiceMock<MockLoadBalancerContext> context;
+
+  Http::ConnectionPool::MockInstance* to_create =
+      new NiceMock<Http::ConnectionPool::MockInstance>();
+
+  EXPECT_CALL(factory_, allocateConnPool_(_, _, _, _, _, _, _)).WillOnce(Return(to_create));
+  EXPECT_CALL(*to_create, setLifetimeCallbacks(_, _));
+
+  auto opt_cp =
+      cluster_manager_->getThreadLocalCluster("cluster_1")
+          ->httpConnPool(
+              cluster_manager_->getThreadLocalCluster("cluster_1")->chooseHost(nullptr).host,
+              ResourcePriority::Default, Http::Protocol::Http11, &context);
+  EXPECT_TRUE(opt_cp.has_value());
+}
+
 TEST_F(ClusterManagerImplTest, UpstreamSocketOptionsUsedInConnPoolHash) {
   NiceMock<MockLoadBalancerContext> context1;
   NiceMock<MockLoadBalancerContext> context2;
@@ -1808,6 +1827,7 @@ TEST_F(ClusterManagerImplTest, HttpPoolDataForwardsCallsToConnectionPool) {
 
   EXPECT_CALL(factory_, allocateConnPool_(_, _, _, _, _, _, _)).WillOnce(Return(pool_mock));
   EXPECT_CALL(*pool_mock, addIdleCallback(_));
+  EXPECT_CALL(*pool_mock, setLifetimeCallbacks(_, _));
 
   auto opt_cp =
       cluster_manager_->getThreadLocalCluster("cluster_1")
@@ -2271,6 +2291,7 @@ TEST_F(ClusterManagerImplTest, ConnectionPoolPerDownstreamConnection) {
   for (size_t i = 0; i < 3; ++i) {
     conn_pool_vector.push_back(new Http::ConnectionPool::MockInstance());
     EXPECT_CALL(*conn_pool_vector.back(), addIdleCallback(_));
+    EXPECT_CALL(*conn_pool_vector.back(), setLifetimeCallbacks(_, _));
     EXPECT_CALL(factory_, allocateConnPool_(_, _, _, _, _, _, _))
         .WillOnce(Return(conn_pool_vector.back()));
     EXPECT_CALL(downstream_connection, hashKey)
@@ -2351,6 +2372,7 @@ TEST_F(ClusterManagerImplTest, PassDownNetworkObserverRegistryToConnectionPool) 
   auto* pool = new Http::ConnectionPool::MockInstance();
   Quic::EnvoyQuicNetworkObserverRegistry* created_registry = nullptr;
   EXPECT_CALL(*pool, addIdleCallback(_));
+  EXPECT_CALL(*pool, setLifetimeCallbacks(_, _));
   EXPECT_CALL(factory_, allocateConnPool_(_, _, _, _, _, _, _))
       .WillOnce(testing::WithArg<5>(
           Invoke([pool, created_registry_ptr = &created_registry](
@@ -2369,6 +2391,7 @@ TEST_F(ClusterManagerImplTest, PassDownNetworkObserverRegistryToConnectionPool) 
 
   pool = new Http::ConnectionPool::MockInstance();
   EXPECT_CALL(*pool, addIdleCallback(_));
+  EXPECT_CALL(*pool, setLifetimeCallbacks(_, _));
   EXPECT_CALL(factory_, allocateConnPool_(_, _, _, _, _, _, _))
       .WillOnce(testing::WithArg<5>(
           Invoke([pool, created_registry](

--- a/test/common/upstream/cluster_manager_lifecycle_test.cc
+++ b/test/common/upstream/cluster_manager_lifecycle_test.cc
@@ -742,6 +742,7 @@ TEST_P(ClusterManagerLifecycleTest, DynamicAddRemove) {
   Http::ConnectionPool::Instance::IdleCb idle_cb;
   EXPECT_CALL(factory_, allocateConnPool_(_, _, _, _, _, _, _)).WillOnce(Return(cp));
   EXPECT_CALL(*cp, addIdleCallback(_)).WillOnce(SaveArg<0>(&idle_cb));
+  EXPECT_CALL(*cp, setLifetimeCallbacks(_, _));
   EXPECT_EQ(
       cp,
       HttpPoolDataPeer::getPool(
@@ -1941,6 +1942,7 @@ TEST_P(ClusterManagerLifecycleTest, ConnPoolDestroyWithDraining) {
   Http::ConnectionPool::Instance::IdleCb drained_cb;
   EXPECT_CALL(factory_, allocateConnPool_(_, _, _, _, _, _, _)).WillOnce(Return(mock_cp));
   EXPECT_CALL(*mock_cp, addIdleCallback(_)).WillOnce(SaveArg<0>(&drained_cb));
+  EXPECT_CALL(*mock_cp, setLifetimeCallbacks(_, _));
   EXPECT_CALL(*mock_cp, drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainAndDelete));
 
   MockTcpConnPoolWithDestroy* mock_tcp = new NiceMock<MockTcpConnPoolWithDestroy>();

--- a/test/mocks/http/conn_pool.h
+++ b/test/mocks/http/conn_pool.h
@@ -39,9 +39,21 @@ public:
   MOCK_METHOD(bool, maybePreconnect, (float));
   MOCK_METHOD(Upstream::HostDescriptionConstSharedPtr, host, (), (const));
   MOCK_METHOD(absl::string_view, protocolDescription, (), (const));
+  MOCK_METHOD(void, setLifetimeCallbacks,
+              (OptRef<ConnectionLifetimeCallbacks> callbacks, std::vector<uint8_t> hash_key));
 
   std::shared_ptr<testing::NiceMock<Upstream::MockHostDescription>> host_;
   IdleCb idle_cb_;
+};
+
+class MockConnectionLifetimeCallbacks : public ConnectionLifetimeCallbacks {
+public:
+  MOCK_METHOD(void, onConnectionOpen,
+              (Instance & pool, std::vector<uint8_t>& hash_key,
+               const Network::Connection& connection));
+  MOCK_METHOD(void, onConnectionDraining,
+              (Instance & pool, std::vector<uint8_t>& hash_key,
+               const Network::Connection& connection));
 };
 
 } // namespace ConnectionPool


### PR DESCRIPTION
## Commit Message
http: wire ConnectionLifetimeCallbacks into pool connection events

## Description
Wires up the `ConnectionLifetimeCallbacks` interface that is there but is not connected to actual connection events from what I see at least. The cluster manager now passes the LB's callbacks into each HTTP pool at creation time, and `MultiplexedActiveClientBase` fires them on Connected, Close, and GOAWAY events.

Primary motivation: allows the reverse tunnel cluster's LB to detect GOAWAY and report it to the tunnel reporter ([raw example](https://github.com/aakugan/envoy/commit/31094c951cf2f185f75f408e96fea0fb60c699af)). Also applicable to DFP clusters for connection coalescing awareness from what I [see](https://github.com/envoyproxy/envoy/pull/17874).

## Risk Level
Should be low. Additive-only changes to production code. Callbacks are no-ops unless explicitly set by the LB. No behavior change for existing clusters.

## Testing
- HTTP/2 conn pool unit tests (7 tests): no-op without callbacks, Connected/RemoteClose/LocalClose with arg verification, GOAWAY with active streams, idle GOAWAY, callback replacement.
- HTTP/3 conn pool unit test: Connected + idle GOAWAY through `MultiplexedActiveClientBase`.
- Cluster manager unit tests: verifies `setLifetimeCallbacks` is called on pool creation.

## Docs Changes
N/A

## Release Notes
N/A