### PR TITLE
[bp/v1.37] fix: use TextFormat for message-valued CEL attributes

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -15,6 +15,14 @@ bug_fixes:
   change: |
     Fixed a bug to support two ext_proc filters configured in the chain. This change can be reverted by setting
     the runtime guard ``envoy.reloadable_features.ext_proc_inject_data_with_state_update`` to ``false``.
+- area: ext_proc
+  change: |
+    Fixed message-valued CEL attribute serialization (for example
+    ``xds.virtual_host_metadata``) to use protobuf text format instead of debug string output.
+    This restores ext_proc compatibility with protobuf 30+ where debug-string output is
+    intentionally not parseable (for example ``goo.gle/debugonly`` prefixes). This change can
+    be reverted by setting runtime guard
+    ``envoy.reloadable_features.cel_message_serialize_text_format`` to ``false``.
 - area: ext_authz
   change: |
     Fixed a bug where headers from a denied authorization response (non-200) were not properly propagated

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -35,6 +35,7 @@
 // ASAP by filing a bug on github. Overriding non-buggy code is strongly discouraged to avoid the
 // problem of the bugs being found after the old code path has been removed.
 RUNTIME_GUARD(envoy_reloadable_features_async_host_selection);
+RUNTIME_GUARD(envoy_reloadable_features_cel_message_serialize_text_format);
 RUNTIME_GUARD(envoy_reloadable_features_decouple_explicit_drain_pools_and_dns_refresh);
 RUNTIME_GUARD(envoy_reloadable_features_dfp_cluster_resolves_hosts);
 RUNTIME_GUARD(envoy_reloadable_features_disallow_quic_client_udp_mmsg);

--- a/source/extensions/filters/common/expr/evaluator.cc
+++ b/source/extensions/filters/common/expr/evaluator.cc
@@ -302,8 +302,22 @@ std::string print(CelValue value) {
     return std::string(value.StringOrDie().value());
   case CelValue::Type::kBytes:
     return std::string(value.BytesOrDie().value());
-  case CelValue::Type::kMessage:
-    return value.IsNull() ? "NULL" : value.MessageOrDie()->ShortDebugString();
+  case CelValue::Type::kMessage: {
+    if (value.IsNull()) {
+      return "NULL";
+    }
+    if (!Runtime::runtimeFeatureEnabled(
+            "envoy.reloadable_features.cel_message_serialize_text_format")) {
+      return value.MessageOrDie()->ShortDebugString();
+    }
+    std::string textproto;
+    Protobuf::TextFormat::Printer printer;
+    printer.SetSingleLineMode(true);
+    if (printer.PrintToString(*value.MessageOrDie(), &textproto)) {
+      return textproto;
+    }
+    return "";
+  }
   case CelValue::Type::kDuration:
     return absl::FormatDuration(value.DurationOrDie());
   case CelValue::Type::kTimestamp:

--- a/test/extensions/filters/common/expr/evaluator_test.cc
+++ b/test/extensions/filters/common/expr/evaluator_test.cc
@@ -32,8 +32,12 @@ TEST(Evaluator, Print) {
   std::string node_yaml = "id: test";
   TestUtility::loadFromYaml(node_yaml, node);
   EXPECT_EQ(print(CelValue::CreateNull()), "NULL");
-  EXPECT_THAT(print(google::api::expr::runtime::CelProtoWrapper::CreateMessage(&node, &arena)),
-              MatchesRegex(".*id:\\s+\"test\""));
+  const std::string node_textproto =
+      print(google::api::expr::runtime::CelProtoWrapper::CreateMessage(&node, &arena));
+  EXPECT_THAT(node_textproto, ::testing::HasSubstr("id: \"test\""));
+  envoy::config::core::v3::Node parsed;
+  EXPECT_TRUE(Protobuf::TextFormat::ParseFromString(node_textproto, &parsed));
+  EXPECT_EQ(parsed.id(), "test");
 
   EXPECT_EQ(print(CelValue::CreateDuration(absl::Minutes(1))), "1m");
   absl::Time time = TestUtility::parseTime("Dec 22 01:50:34 2020 GMT", "%b %e %H:%M:%S %Y GMT");

--- a/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
+++ b/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
@@ -3946,6 +3946,59 @@ TEST_P(ExtProcIntegrationTest, RequestAttributesInResponseOnlyProcessing) {
   verifyDownstreamResponse(*response, 200);
 }
 
+TEST_P(ExtProcIntegrationTest, RequestAttributeVirtualHostMetadataIsTextProto) {
+  proto_config_.mutable_processing_mode()->set_request_header_mode(ProcessingMode::SEND);
+  proto_config_.mutable_processing_mode()->set_response_header_mode(ProcessingMode::SKIP);
+  proto_config_.mutable_request_attributes()->Add("xds.virtual_host_metadata");
+
+  config_helper_.addConfigModifier([](HttpConnectionManager& cm) {
+    auto* vh = cm.mutable_route_config()->mutable_virtual_hosts()->Mutable(0);
+    auto* metadata = vh->mutable_metadata();
+
+    Protobuf::Struct struct_val;
+    (*struct_val.mutable_fields())["apiIdentifier"].set_string_value("test-api");
+    (*struct_val.mutable_fields())["extHost"].set_string_value("test-host");
+    (*metadata->mutable_filter_metadata())["someKey"] = struct_val;
+  });
+
+  initializeConfig();
+  HttpIntegrationTest::initialize();
+
+  auto response = sendDownstreamRequest(absl::nullopt);
+
+  processGenericMessage(
+      *grpc_upstreams_[0], true,
+      [](const ProcessingRequest& req, ProcessingResponse& resp) -> bool {
+        // Send a valid request-headers response for this request-headers processing step.
+        resp.mutable_request_headers();
+
+        EXPECT_TRUE(req.has_request_headers());
+        EXPECT_EQ(req.attributes().size(), 1);
+        const auto& proto_struct = req.attributes().at("envoy.filters.http.ext_proc");
+        EXPECT_TRUE(proto_struct.fields().contains("xds.virtual_host_metadata"));
+        const auto& metadata_textproto =
+            proto_struct.fields().at("xds.virtual_host_metadata").string_value();
+        envoy::config::core::v3::Metadata parsed_metadata;
+        const bool parsed =
+            Protobuf::TextFormat::ParseFromString(metadata_textproto, &parsed_metadata);
+        EXPECT_TRUE(parsed);
+        EXPECT_TRUE(parsed_metadata.filter_metadata().contains("someKey"));
+        EXPECT_EQ(parsed_metadata.filter_metadata()
+                      .at("someKey")
+                      .fields()
+                      .at("apiIdentifier")
+                      .string_value(),
+                  "test-api");
+        EXPECT_EQ(
+            parsed_metadata.filter_metadata().at("someKey").fields().at("extHost").string_value(),
+            "test-host");
+        return true;
+      });
+
+  handleUpstreamRequest();
+  verifyDownstreamResponse(*response, 200);
+}
+
 TEST_P(ExtProcIntegrationTest, MappedAttributeBuilder) {
   proto_config_.mutable_processing_mode()->set_request_body_mode(ProcessingMode::STREAMED);
   proto_config_.mutable_processing_mode()->set_response_header_mode(ProcessingMode::SEND);


### PR DESCRIPTION
Commit Message:

Envoy 1.37.0 updated protobuf from 29.3 to 33.2. That dependency change altered debug-string output semantics and broke behavior that worked in 1.36.x for ext_proc consumers parsing `xds.virtual_host_metadata`.

This behavior change was introduced in #42435 and #42827.

This PR switches message serialization from debug-string APIs to protobuf text-format APIs so message-valued CEL attributes are machine-parseable again, as recommended by protobuf programming guides. https://protobuf.dev/programming-guides/deserialize-debug

 **What broke in 1.37.0**

  - In both 1.36.x and 1.37.0, message-valued CEL results were stringified via ShortDebugString().
  - In 1.36.x (protobuf 29.3), that output was parseable.
  - In 1.37.0 (protobuf 33.2), debug strings are now prefixed with `goo.gle/debugonly` / `goo.gle/debugstr`, which is intentionally non-parseable as textproto.
  - Result: ext_proc implementations that parse `xds.virtual_host_metadata` as textproto started failing after upgrading to 1.37.0.
  
 **Note**:  xds metadata attributes in ext_proc requests are **not diagnostic log fields**; they are machine-to-machine payload data consumed by external processors. External processors parse these values to make policy and routing decisions, so serialization must be stable and machine-readable by standard protobuf tooling. `DebugString` is a diagnostic format with no compatibility contract, and in protobuf 30+ it may include `goo.gle/debug...` prefixes that intentionally break parsing. For this path, protobuf `TextFormat` is the correct format, not debug serialization.


**Example**

  Given virtual host metadata:

```yaml
  {
    "metadata": {
      "filterMetadata": {
        "envoy-gateway": {
          "resources": [
            {
              "kind": "Gateway",
              "name": "eg",
              "namespace": "default",
              "sectionName": "http"
            }
          ]
        }
      }
    }
  }
 ```

  Before (1.37.0 + protobuf 30+ path), ext_proc may receive:

`goo.gle/debugonly  filter_metadata { key: "envoy-gateway" value { ... } }`

  Parsing fails at token 1.

  After this PR:

`filter_metadata { key: "envoy-gateway" value { ... } }`

This is protobuf text format and parses via TextFormat::ParseFromString(...).

**Compatibility notes**

  - This restores 1.36.x-like effective behavior for ext_proc users (parseable metadata strings), while using the correct serialization API.
  - Minor formatting differences vs 1.36.x debug output are possible (whitespace/order), but output is now stable machine-readable textproto.
  - Scope includes other call sites using Expr::print(...) for message-valued CEL results (for example rate-limit descriptor CEL stringification).
  
Additional Description:
Risk Level: low
Testing: unit and integration test
Docs Changes:
Release Notes: yes
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #43466]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]



(cherry picked from commit 697e419cdae5b9717b32185fc195c840b53c00af)
