### PR TITLE
mcp: Optimize the body data handling 

### DIFF
--- a/source/extensions/filters/http/mcp/mcp_filter.cc
+++ b/source/extensions/filters/http/mcp/mcp_filter.cc
@@ -275,7 +275,8 @@ Http::FilterDataStatus McpFilter::decodeData(Buffer::Instance& data, bool end_st
     return Http::FilterDataStatus::Continue;
   }
 
-  ENVOY_LOG(trace, "decodeData: buffer_size={}, already_parsed={}", data.length(), bytes_parsed_);
+  ENVOY_LOG(trace, "decodeData: buffer_size={}, already_parsed={}, end_stream={}", data.length(),
+            bytes_parsed_, end_stream);
 
   const uint32_t max_size = getMaxRequestBodySize();
 


### PR DESCRIPTION
linearize() is good to avoid the local string object, but itself almost always requires a memory copy. 

We can avoid this by operating on the buffer directly.

