### PR TITLE
dns test: improve tests by teardown the server and upstream

### DIFF
--- a/test/extensions/filters/udp/dns_filter/dns_filter_integration_test.cc
+++ b/test/extensions/filters/udp/dns_filter/dns_filter_integration_test.cc
@@ -89,6 +89,13 @@ public:
 
   void setupResponseParser() { histogram_.unit_ = Stats::Histogram::Unit::Milliseconds; }
 
+  void TearDown() override {
+    if (test_server_) {
+      test_server_.reset();
+    }
+    fake_upstreams_.clear();
+  }
+
   static std::string configToUse() {
     return fmt::format(R"EOF(
 admin:


### PR DESCRIPTION
TearDown before the `mock_os_sys_calls_`

Risk: low
