### PR TITLE
reverse_tunnel: add per connection timer

### DIFF
--- a/source/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/upstream_socket_manager.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/upstream_socket_manager.cc
@@ -133,6 +133,7 @@ void UpstreamSocketManager::addConnectionSocket(const std::string& node_id,
   fd_to_timer_map_[fd] = dispatcher_.createTimer([this, fd]() { onPingTimeout(fd); });
 
   accepted_reverse_connections_[node_id].push_back(std::move(socket));
+  fd_to_socket_it_map_[fd] = std::prev(accepted_reverse_connections_[node_id].end());
   Network::ConnectionSocketPtr& socket_ref = accepted_reverse_connections_[node_id].back();
 
   // Update stats registry.
@@ -210,6 +211,7 @@ UpstreamSocketManager::getConnectionSocket(const std::string& node_id) {
   fd_to_event_map_.erase(fd);
   fd_to_timer_map_.erase(fd);
   fd_to_ping_send_timer_map_.erase(fd);
+  fd_to_socket_it_map_.erase(fd);
 
   return socket;
 }
@@ -279,35 +281,26 @@ void UpstreamSocketManager::markSocketDead(const int fd) {
   // Decrement the active FD counter for the node.
   auto count_it = node_to_active_fd_count_.find(node_id);
   if (count_it != node_to_active_fd_count_.end()) {
-    if (count_it->second > 0) {
-      count_it->second--;
-    }
-    if (count_it->second == 0) {
+    ASSERT(count_it->second > 0);
+    if (--count_it->second == 0) {
       node_to_active_fd_count_.erase(count_it);
     }
   }
 
-  // Determine if this is an idle or used socket by searching for the FD in the idle pool.
-  auto& sockets = accepted_reverse_connections_[node_id];
-  bool is_idle_socket = false;
+  // Determine if this is an idle or used socket via O(1) iterator lookup.
+  auto socket_it = fd_to_socket_it_map_.find(fd);
+  if (socket_it != fd_to_socket_it_map_.end()) {
+    // Found in idle pool — erase from list and clean up timers/events.
+    ENVOY_LOG(debug, "reverse_tunnel: marking idle socket dead. node: {} cluster: {} fd: {}.",
+              node_id, cluster_id, fd);
+    ::shutdown(fd, SHUT_RDWR);
+    accepted_reverse_connections_[node_id].erase(socket_it->second);
+    fd_to_socket_it_map_.erase(socket_it);
 
-  for (auto itr = sockets.begin(); itr != sockets.end(); itr++) {
-    if (fd == itr->get()->ioHandle().fdDoNotUse()) {
-      // Found the FD in idle pool, this is an idle socket.
-      ENVOY_LOG(debug, "reverse_tunnel: marking idle socket dead. node: {} cluster: {} fd: {}.",
-                node_id, cluster_id, fd);
-      ::shutdown(fd, SHUT_RDWR);
-      itr = sockets.erase(itr);
-      is_idle_socket = true;
-
-      fd_to_event_map_.erase(fd);
-      fd_to_timer_map_.erase(fd);
-      fd_to_ping_send_timer_map_.erase(fd);
-      break;
-    }
-  }
-
-  if (!is_idle_socket) {
+    fd_to_event_map_.erase(fd);
+    fd_to_timer_map_.erase(fd);
+    fd_to_ping_send_timer_map_.erase(fd);
+  } else {
     // FD not found in idle pool, this is a used socket.
     // The socket will be closed by the owning UpstreamReverseConnectionIOHandle.
     ENVOY_LOG(debug, "reverse_tunnel: marking used socket dead. node: {} cluster: {} fd: {}.",
@@ -430,19 +423,12 @@ void UpstreamSocketManager::sendPingForConnection(int fd) {
   }
   const std::string& node_id = node_it->second;
 
-  auto& sockets = accepted_reverse_connections_[node_id];
-  Network::ConnectionSocket* socket_ptr = nullptr;
-  for (auto& s : sockets) {
-    if (s->ioHandle().fdDoNotUse() == fd) {
-      socket_ptr = s.get();
-      break;
-    }
-  }
-
-  if (socket_ptr == nullptr) {
+  auto socket_it = fd_to_socket_it_map_.find(fd);
+  if (socket_it == fd_to_socket_it_map_.end()) {
     ENVOY_LOG(debug, "reverse_tunnel: sendPingForConnection: fd {} not found in idle pool.", fd);
     return;
   }
+  Network::ConnectionSocket* socket_ptr = socket_it->second->get();
 
   auto buffer = ::Envoy::Extensions::Bootstrap::ReverseConnection::ReverseConnectionUtility::
       createPingResponse();
@@ -535,6 +521,7 @@ UpstreamSocketManager::~UpstreamSocketManager() {
   // Clear any remaining fd mappings.
   fd_to_node_map_.clear();
   fd_to_cluster_map_.clear();
+  fd_to_socket_it_map_.clear();
 
   // Remove this instance from the global socket managers list.
   absl::WriterMutexLock lock(UpstreamSocketManager::socket_manager_lock);

--- a/source/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/upstream_socket_manager.h
+++ b/source/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/upstream_socket_manager.h
@@ -168,6 +168,9 @@ private:
   // node and is removed when the socket dies.
   absl::flat_hash_map<int, std::string> fd_to_node_map_;
 
+  // Map from FD to its iterator in accepted_reverse_connections_, used to avoid linear scans.
+  absl::flat_hash_map<int, std::list<Network::ConnectionSocketPtr>::iterator> fd_to_socket_it_map_;
+
   // Map from file descriptor to cluster ID. An entry is added when a reverse tunnel is accepted
   // from a node and is removed when the socket dies.
   absl::flat_hash_map<int, std::string> fd_to_cluster_map_;

--- a/test/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/upstream_socket_manager_test.cc
+++ b/test/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/upstream_socket_manager_test.cc
@@ -65,6 +65,7 @@ protected:
   void verifyInitialState() {
     EXPECT_EQ(socket_manager_->accepted_reverse_connections_.size(), 0);
     EXPECT_EQ(socket_manager_->fd_to_node_map_.size(), 0);
+    EXPECT_EQ(socket_manager_->fd_to_socket_it_map_.size(), 0);
     EXPECT_EQ(socket_manager_->node_to_cluster_map_.size(), 0);
     EXPECT_EQ(socket_manager_->cluster_to_node_info_map_.size(), 0);
   }
@@ -96,6 +97,12 @@ protected:
     return socket_manager_->fd_to_ping_send_timer_map_.find(fd) !=
            socket_manager_->fd_to_ping_send_timer_map_.end();
   }
+
+  bool verifyFDToSocketItMap(int fd) {
+    return socket_manager_->fd_to_socket_it_map_.find(fd) !=
+           socket_manager_->fd_to_socket_it_map_.end();
+  }
+  size_t getFDToSocketItMapSize() { return socket_manager_->fd_to_socket_it_map_.size(); }
 
   uint32_t getNodeToActiveFdCount(const std::string& node_id) {
     auto it = socket_manager_->node_to_active_fd_count_.find(node_id);


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message: use per connection rping timer with jitter similar to HTTP2 keepalives
Additional Description: we have observed higher p90 latencies for requests from upstream to downstream when there are high number(>10k) of active reverse connections due to the for loop for rpings which initiates rpings for all connections without yielding for the requests. Per connection rping timers help with request events not starving
Risk Level: Low
Testing: Unit tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
