### PR TITLE
reverse_tunnel: fix the downstream reverse conn cleanup

### DIFF
--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.cc
@@ -51,8 +51,11 @@ ReverseConnectionIOHandle::~ReverseConnectionIOHandle() {
 void ReverseConnectionIOHandle::cleanup() {
   ENVOY_LOG_MISC(debug, "Starting cleanup of reverse connection resources.");
 
-  // Reset file events before closing trigger pipe.
-  ENVOY_LOG_MISC(trace, "reverse_tunnel: resetting file events before closing trigger pipe.");
+  // Reset file events before closing trigger pipe to avoid busy loop from EOF on read FD.
+  ENVOY_LOG_MISC(trace,
+                 "reverse_tunnel: resetting file events before closing trigger pipe; "
+                 "trigger_pipe_write_fd_={}, trigger_pipe_read_fd_={}",
+                 trigger_pipe_write_fd_, trigger_pipe_read_fd_);
   resetFileEvents();
 
   // Clean up pipe trigger mechanism first to prevent use-after-free.

--- a/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle_test.cc
+++ b/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle_test.cc
@@ -2472,17 +2472,12 @@ TEST_F(ReverseConnectionIOHandleTest, CleanupClosesEstablishedConnections) {
   EXPECT_EQ(getEstablishedConnectionsSize(), 0);
 }
 
-// Test that cleanup() resets file events before closing trigger pipe FDs.
-// This is critical to prevent a busy loop bug where closing the write FD causes
-// EOF on the read FD, which triggers the file event callback, which calls accept(),
-// which reads EOF, creating an infinite loop.
+// Test that cleanup() resets file events before closing trigger pipe FDs to prevent busy loop.
 TEST_F(ReverseConnectionIOHandleTest, CleanupResetsFileEventsBeforeClosingPipe) {
   auto config = createDefaultTestConfig();
   io_handle_ = createTestIOHandle(config);
   EXPECT_NE(io_handle_, nullptr);
 
-  // Set up trigger pipe and initialize file events.
-  // This creates a file event that monitors the trigger pipe read FD.
   int callback_call_count = 0;
   Event::FileReadyCb mock_callback = [&callback_call_count](uint32_t) -> absl::Status {
     callback_call_count++;
@@ -2491,37 +2486,19 @@ TEST_F(ReverseConnectionIOHandleTest, CleanupResetsFileEventsBeforeClosingPipe) 
   io_handle_->initializeFileEvent(dispatcher_, mock_callback, Event::FileTriggerType::Level,
                                   Event::FileReadyType::Read);
 
-  // Verify trigger pipe is ready and file events are registered.
   EXPECT_TRUE(isTriggerPipeReady());
-  int pipe_read_fd = getTriggerPipeReadFd();
-  int pipe_write_fd = getTriggerPipeWriteFd();
-  EXPECT_GE(pipe_read_fd, 0);
-  EXPECT_GE(pipe_write_fd, 0);
+  EXPECT_GE(getTriggerPipeReadFd(), 0);
+  EXPECT_GE(getTriggerPipeWriteFd(), 0);
+  EXPECT_EQ(io_handle_->fdDoNotUse(), getTriggerPipeReadFd());
 
-  // Verify that the monitored FD is the pipe read FD.
-  EXPECT_EQ(io_handle_->fdDoNotUse(), pipe_read_fd);
-
-  // Call cleanup() - this should:
-  // 1. Call resetFileEvents() first (which resets the file event)
-  // 2. Close trigger_pipe_write_fd_
-  // 3. Close trigger_pipe_read_fd_
-  // If resetFileEvents() is NOT called first, closing the write FD would cause
-  // EOF on the read FD, triggering the file event callback and creating a busy loop.
   cleanup();
 
-  // Verify that trigger pipe FDs are closed (cleanup completed successfully).
   EXPECT_FALSE(isTriggerPipeReady());
   EXPECT_EQ(getTriggerPipeReadFd(), -1);
   EXPECT_EQ(getTriggerPipeWriteFd(), -1);
 
-  // Run the dispatcher briefly to verify that the file event callback is NOT called.
-  // If resetFileEvents() wasn't called before closing the pipe, the callback would
-  // be triggered repeatedly (busy loop). Since resetFileEvents() was called,
-  // the callback should not be invoked.
+  // Verify the file event callback is not triggered after cleanup (no busy loop).
   dispatcher_.run(Event::Dispatcher::RunType::NonBlock);
-
-  // Verify callback was not called after cleanup().
-  // This confirms that resetFileEvents() was called before closing the pipe FDs.
   EXPECT_EQ(callback_call_count, 0);
 }
 


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message: fix the downstream reverse connection cleanup
Additional Description: `cleanup()` resets file events before closing trigger pipe FDs. This is critical to prevent a busy loop bug where closing the write FD causes EOF on the read FD, which triggers the file event callback, which calls accept(), which reads EOF, creating an infinite CPU spin loop
Risk Level: Low
Testing: Unit tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
