### PR TITLE
Declare BAZEL_USE_HOST_SYSROOT environment variable in the envoy repo…

### DIFF
--- a/bazel/repo.bzl
+++ b/bazel/repo.bzl
@@ -303,7 +303,7 @@ _envoy_repo = repository_rule(
         "envoy_ci_config": attr.label(default = "@envoy//:.github/config.yml"),
         "yq": attr.label(default = "@yq"),
     },
-    environ = ["BAZEL_LLVM_PATH"],
+    environ = ["BAZEL_LLVM_PATH", "BAZEL_USE_HOST_SYSROOT"],
 )
 
 def envoy_repo():


### PR DESCRIPTION
Commit Message:

It's a followup for #43681 - after spllitting sysroot from the toolchain I didn't push the local change that declares `BAZEL_USE_HOST_SYSROOT` environment variable in the repository rule. As a result local tests passed (because I had that change locally) and remote tests passed (because they don't test setup without sysroot), but if you checkout state from the upstream repository building with host sysroot still uses Envoy provided sysroot and that results in error of finding the right libraries.

Additional Description:

It does not break any builds that worked before, but without this commit setting `BAZEL_USE_HOST_SYSROOT` also does not do anything, as it's ignored.

Risk Level: low
Testing: built locally
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
