### PR TITLE
[bp/1.37] docs: add missing release note (#43743)

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -35,6 +35,10 @@ bug_fixes:
 - area: release
   change: |
     Published contrib binaries now include the ``-contrib`` suffix in their version string.
+- area: access_log
+  change: |
+    Fixed a crash on listener removal with a process-level access log rate limiter
+    :ref:`ProcessRateLimitFilter <envoy_v3_api_msg_extensions.access_loggers.filters.process_ratelimit.v3.ProcessRateLimitFilter>`.
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`


### PR DESCRIPTION
Change-Id: Ie721bece95ac9cda1b14beb8865324d5507aa49c

Commit Message: Add missing release note for
https://github.com/envoyproxy/envoy/pull/43325/
Risk Level: none
Testing: none
Docs Changes: yes
Release Notes: yes

