### PR TITLE
Update QUICHE from 823808232 to 73d3b6e2e

### DIFF
--- a/bazel/deps.yaml
+++ b/bazel/deps.yaml
@@ -284,7 +284,7 @@ quiche:
   project_name: "QUICHE"
   project_desc: "QUICHE (QUIC, HTTP/2, Etc) is Google‘s implementation of QUIC and related protocols"
   project_url: "https://github.com/google/quiche"
-  release_date: "2026-02-23"
+  release_date: "2026-03-03"
   use_category:
   - controlplane
   - dataplane_core

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -542,8 +542,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         urls = ["https://github.com/simdutf/simdutf/releases/download/v{version}/singleheader.zip"],
     ),
     quiche = dict(
-        version = "823808232a3d42a39b977cde9f9fe733963ba5de",
-        sha256 = "3cbc8656fc0bcec75fdd30ac657350422df46aa02d8a8f490265fe446da48ec9",
+        version = "73d3b6e2ed78b304e41fae23fe50b237b4c9b78a",
+        sha256 = "e395ce8b3bcf5a1af7cede3e8f0c9a5f9417f20c89a836a4a739e6fe4fbb3c26",
         urls = ["https://github.com/google/quiche/archive/{version}.tar.gz"],
         strip_prefix = "quiche-{version}",
     ),


### PR DESCRIPTION
https://github.com/google/quiche/compare/823808232..73d3b6e2e

```
$ git log 823808232..73d3b6e2e --date=short --no-merges --format="%ad %al %s"

2026-03-03 ripere Add support for PAT generation at prober request time.
2026-03-03 haoyuewang Add a memory reduction timeout to QuicIdleNetworkDetector.
2026-03-02 haoyuewang Add last_alarm_type_ to track the type of alarm set in QuicIdleNetworkDetector.
2026-03-02 quiche-dev No public description
2026-02-28 ianswett Deprecate gfe2_reloadable_flag_quic_limit_new_streams_per_loop_2.
2026-02-27 haoyuewang Remove duplicated handshake_timeout_ clean-up in QuicIdleNetworkDetector.
2026-02-27 reubent Use std::vector instead of absl::Span to prevent dangling pointers
2026-02-27 vasilvv Disable some of event loop WakeUp tests under TSAN, since those seem to crash due to OOM errors.
2026-02-26 haoyuewang Add a knob (QuicSentPacketManager::ReduceMemoryUsage) to reduce the memory used by unacked_packet_map and bandwidth_sampler owned by QuicSentPacketManager.
2026-02-26 reubent Pure refactor of `MULTIPLE_CONTENT_LENGTH_KEYS` logic
2026-02-26 reubent No public description
2026-02-26 reubent No public description
2026-02-24 vasilvv No public description
2026-02-24 reubent Add HttpValidationPolicy controlling semicolon delimitation of chunk-exts
2026-02-24 asedeno Fis OSS QUICHE build.
2026-02-24 quiche-dev No public description
2026-02-24 vasilvv Lower the number of iterations in QuicEventLoopFactoryTest.WakeUp test, and increase timeout a bit.
2026-02-24 martinduke Unblock and add flag counts for gfe2_reloadable_flag_quic_receive_ack_frequency.
2026-02-24 vasilvv Add WakeUp() to the QuicEventLoop API.
```
