### PR TITLE
admin: drop experimental warn on config_dump

### DIFF
--- a/source/server/admin/admin.cc
+++ b/source/server/admin/admin.cc
@@ -133,7 +133,7 @@ AdminImpl::AdminImpl(const std::string& profile_path, Server::Instance& server,
                       {{Admin::ParamDescriptor::Type::String, "filter",
                         "Regular expression (Google re2) for filtering clusters by name"}}),
           makeHandler(
-              "/config_dump", "dump current Envoy configs (experimental)",
+              "/config_dump", "dump current Envoy configs",
               MAKE_ADMIN_HANDLER(config_dump_handler_.handlerConfigDump), false, false,
               {{Admin::ParamDescriptor::Type::String, "resource", "The resource to dump"},
                {Admin::ParamDescriptor::Type::String, "mask",

--- a/test/server/admin/admin_test.cc
+++ b/test/server/admin/admin_test.cc
@@ -147,7 +147,7 @@ TEST_P(AdminInstanceTest, Help) {
   /certs: print certs on machine
   /clusters: upstream cluster status
       filter: Regular expression (Google re2) for filtering clusters by name
-  /config_dump: dump current Envoy configs (experimental)
+  /config_dump: dump current Envoy configs
       resource: The resource to dump
       mask: The mask to apply. When both resource and mask are specified, the mask is applied to every element in the desired repeated field so that only a subset of fields are returned. The mask is parsed as a Protobuf::FieldMask
       name_regex: Dump only the currently loaded configurations whose names match the specified regex. Can be used with both resource and mask query parameters.


### PR DESCRIPTION
Commit Message: admin: drop experimental warn on config_dump
Additional Description:
The "experimental" warning was added in #3671 8 years ago saying #3665 must be closed before dropping it but it's also resolved 7 years ago. Given that it's been used heavily by envoy users for many years, it should be no problem to drop the warning.

Risk Level: low
Testing: existing ones
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
