### PR TITLE
dynamic_modules: add a method to get host health by address

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -428,6 +428,10 @@ new_features:
     Added :ref:`load balancing policies
     <envoy_v3_api_msg_extensions.load_balancing_policies.dynamic_modules.v3.DynamicModulesLoadBalancerConfig>`
     support for dynamic modules, enabling custom load balancing algorithms to be implemented in dynamic modules.
+- area: dynamic_modules
+  change: |
+    Added ``get_host_health_by_address`` ABI callback for dynamic module load balancers, providing O(1)
+    host health lookup by address string using the cross-priority host map.
 - area: sse_parser
   change: |
     Extended the SSE parser utility to support all standard SSE fields: ``id``, ``event`` (as ``event_type``),

--- a/source/extensions/dynamic_modules/abi/abi.h
+++ b/source/extensions/dynamic_modules/abi/abi.h
@@ -8197,6 +8197,24 @@ envoy_dynamic_module_type_host_health envoy_dynamic_module_callback_lb_get_host_
     envoy_dynamic_module_type_lb_envoy_ptr lb_envoy_ptr, uint32_t priority, size_t index);
 
 /**
+ * envoy_dynamic_module_callback_lb_get_host_health_by_address looks up a host by its address
+ * string across all priorities and returns the health status. This uses the cross-priority host
+ * map internally, providing O(1) lookup by address instead of requiring the caller to iterate
+ * through all hosts by index.
+ *
+ * The address string must match the format returned by host->address()->asStringView(), which is
+ * typically "ip:port" (e.g., "10.0.0.1:8080").
+ *
+ * @param lb_envoy_ptr is the pointer to the Envoy load balancer object.
+ * @param address is the address string to look up.
+ * @param result is the output for the health status of the host.
+ * @return true if the host was found, false if the address is not in the host map.
+ */
+bool envoy_dynamic_module_callback_lb_get_host_health_by_address(
+    envoy_dynamic_module_type_lb_envoy_ptr lb_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer address, envoy_dynamic_module_type_host_health* result);
+
+/**
  * envoy_dynamic_module_callback_lb_get_host_address returns the address of a host
  * by index within all hosts at a given priority.
  *

--- a/source/extensions/dynamic_modules/abi_impl.cc
+++ b/source/extensions/dynamic_modules/abi_impl.cc
@@ -462,6 +462,17 @@ envoy_dynamic_module_callback_lb_get_host_health(envoy_dynamic_module_type_lb_en
   return envoy_dynamic_module_type_host_health_Unhealthy;
 }
 
+__attribute__((weak)) bool envoy_dynamic_module_callback_lb_get_host_health_by_address(
+    envoy_dynamic_module_type_lb_envoy_ptr, envoy_dynamic_module_type_module_buffer,
+    envoy_dynamic_module_type_host_health* result) {
+  IS_ENVOY_BUG("envoy_dynamic_module_callback_lb_get_host_health_by_address: "
+               "not implemented in this context");
+  if (result != nullptr) {
+    *result = envoy_dynamic_module_type_host_health_Unhealthy;
+  }
+  return false;
+}
+
 __attribute__((weak)) bool
 envoy_dynamic_module_callback_lb_get_host_address(envoy_dynamic_module_type_lb_envoy_ptr, uint32_t,
                                                   size_t,

--- a/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
@@ -10327,6 +10327,16 @@ pub trait EnvoyLoadBalancer {
     index: usize,
   ) -> abi::envoy_dynamic_module_type_host_health;
 
+  /// Looks up a host by its address string across all priorities and returns its health status.
+  /// This provides O(1) lookup by address using the cross-priority host map, instead of requiring
+  /// iteration through all hosts by index.
+  ///
+  /// The address must match the format "ip:port" (e.g., "10.0.0.1:8080").
+  fn get_host_health_by_address(
+    &self,
+    address: &str,
+  ) -> Option<abi::envoy_dynamic_module_type_host_health>;
+
   /// Returns the address of a host by index within all hosts at a given priority.
   fn get_host_address(&self, priority: u32, index: usize) -> Option<String>;
 
@@ -10526,6 +10536,30 @@ impl EnvoyLoadBalancer for EnvoyLoadBalancerImpl {
     index: usize,
   ) -> abi::envoy_dynamic_module_type_host_health {
     unsafe { abi::envoy_dynamic_module_callback_lb_get_host_health(self.lb_ptr, priority, index) }
+  }
+
+  fn get_host_health_by_address(
+    &self,
+    address: &str,
+  ) -> Option<abi::envoy_dynamic_module_type_host_health> {
+    let address_buf = abi::envoy_dynamic_module_type_module_buffer {
+      ptr: address.as_ptr() as *const _,
+      length: address.len(),
+    };
+    let mut health: abi::envoy_dynamic_module_type_host_health =
+      abi::envoy_dynamic_module_type_host_health::Unhealthy;
+    let found = unsafe {
+      abi::envoy_dynamic_module_callback_lb_get_host_health_by_address(
+        self.lb_ptr,
+        address_buf,
+        &mut health,
+      )
+    };
+    if found {
+      Some(health)
+    } else {
+      None
+    }
   }
 
   fn get_host_address(&self, priority: u32, index: usize) -> Option<String> {

--- a/source/extensions/load_balancing_policies/dynamic_modules/abi_impl.cc
+++ b/source/extensions/load_balancing_policies/dynamic_modules/abi_impl.cc
@@ -183,6 +183,41 @@ envoy_dynamic_module_type_host_health envoy_dynamic_module_callback_lb_get_host_
   return envoy_dynamic_module_type_host_health_Unhealthy;
 }
 
+bool envoy_dynamic_module_callback_lb_get_host_health_by_address(
+    envoy_dynamic_module_type_lb_envoy_ptr lb_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer address,
+    envoy_dynamic_module_type_host_health* result) {
+  if (result == nullptr) {
+    return false;
+  }
+  *result = envoy_dynamic_module_type_host_health_Unhealthy;
+
+  if (lb_envoy_ptr == nullptr || address.ptr == nullptr) {
+    return false;
+  }
+  const auto host_map = getLb(lb_envoy_ptr)->prioritySet().crossPriorityHostMap();
+  if (host_map == nullptr) {
+    return false;
+  }
+  std::string address_str(address.ptr, address.length);
+  const auto it = host_map->find(address_str);
+  if (it == host_map->end()) {
+    return false;
+  }
+  switch (it->second->coarseHealth()) {
+  case Envoy::Upstream::Host::Health::Unhealthy:
+    *result = envoy_dynamic_module_type_host_health_Unhealthy;
+    break;
+  case Envoy::Upstream::Host::Health::Degraded:
+    *result = envoy_dynamic_module_type_host_health_Degraded;
+    break;
+  case Envoy::Upstream::Host::Health::Healthy:
+    *result = envoy_dynamic_module_type_host_health_Healthy;
+    break;
+  }
+  return true;
+}
+
 bool envoy_dynamic_module_callback_lb_get_host_address(
     envoy_dynamic_module_type_lb_envoy_ptr lb_envoy_ptr, uint32_t priority, size_t index,
     envoy_dynamic_module_type_envoy_buffer* result) {

--- a/test/extensions/dynamic_modules/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/abi_impl_test.cc
@@ -551,6 +551,21 @@ TEST(CommonAbiImplTest, LbGetHostHealthEnvoyBug) {
       "not implemented in this context");
 }
 
+// Test that the weak symbol stub for lb_get_host_health_by_address triggers an ENVOY_BUG when
+// called.
+TEST(CommonAbiImplTest, LbGetHostHealthByAddressEnvoyBug) {
+  envoy_dynamic_module_type_host_health health = envoy_dynamic_module_type_host_health_Unhealthy;
+  envoy_dynamic_module_type_module_buffer addr = {"10.0.0.1:8080", 13};
+  EXPECT_ENVOY_BUG(
+      {
+        auto found =
+            envoy_dynamic_module_callback_lb_get_host_health_by_address(nullptr, addr, &health);
+        EXPECT_FALSE(found);
+      },
+      "not implemented in this context");
+  EXPECT_EQ(health, envoy_dynamic_module_type_host_health_Unhealthy);
+}
+
 // Test that the weak symbol stub for lb_get_host_address triggers an ENVOY_BUG when called.
 TEST(CommonAbiImplTest, LbGetHostAddressEnvoyBug) {
   envoy_dynamic_module_type_envoy_buffer result = {nullptr, 0};

--- a/test/extensions/dynamic_modules/test_data/c/lb_callbacks_test.c
+++ b/test/extensions/dynamic_modules/test_data/c/lb_callbacks_test.c
@@ -92,6 +92,30 @@ bool envoy_dynamic_module_on_lb_choose_host(
     (void)health;
   }
 
+  // Test O(1) host health lookup by address.
+  if (host_count > 0) {
+    // Get the address of the first host to use for the by-address lookup.
+    envoy_dynamic_module_type_envoy_buffer first_host_addr = {NULL, 0};
+    envoy_dynamic_module_callback_lb_get_host_address(lb_envoy_ptr, 0, 0, &first_host_addr);
+    if (first_host_addr.ptr != NULL && first_host_addr.length > 0) {
+      envoy_dynamic_module_type_host_health health_by_addr =
+          envoy_dynamic_module_type_host_health_Unhealthy;
+      envoy_dynamic_module_type_module_buffer addr_buf = {first_host_addr.ptr,
+                                                          first_host_addr.length};
+      bool found_by_addr = envoy_dynamic_module_callback_lb_get_host_health_by_address(
+          lb_envoy_ptr, addr_buf, &health_by_addr);
+      (void)found_by_addr;
+    }
+
+    // Test with a non-existent address.
+    envoy_dynamic_module_type_host_health not_found_health =
+        envoy_dynamic_module_type_host_health_Unhealthy;
+    envoy_dynamic_module_type_module_buffer bad_addr = {"1.2.3.4:9999", 12};
+    bool not_found = envoy_dynamic_module_callback_lb_get_host_health_by_address(
+        lb_envoy_ptr, bad_addr, &not_found_health);
+    (void)not_found;
+  }
+
   // Test all-hosts callbacks (address, weight, active requests, connections, locality).
   if (host_count > 0) {
     envoy_dynamic_module_type_envoy_buffer host_address_result = {NULL, 0};

--- a/test/extensions/load_balancing_policies/dynamic_modules/config_test.cc
+++ b/test/extensions/load_balancing_policies/dynamic_modules/config_test.cc
@@ -759,6 +759,99 @@ TEST_F(DynamicModulesLoadBalancerTest, AbiCallbacksHostStatsAndLocality) {
   EXPECT_EQ(absl::string_view(region.ptr, region.length), "us-east");
 }
 
+TEST_F(DynamicModulesLoadBalancerTest, HostHealthByAddressSuccess) {
+  // Set up a cross-priority host map containing the test hosts.
+  auto host_map = std::make_shared<Upstream::HostMap>();
+  host_map->insert({"10.0.0.1:8080", host1_});
+  host_map->insert({"10.0.0.2:8080", host2_});
+  host_map->insert({"10.0.0.3:8080", host3_});
+  ON_CALL(priority_set_, crossPriorityHostMap()).WillByDefault(Return(host_map));
+
+  envoy::extensions::load_balancing_policies::dynamic_modules::v3::DynamicModulesLoadBalancerConfig
+      config;
+  config.mutable_dynamic_module_config()->set_name("lb_round_robin");
+  config.set_lb_policy_name("test_lb");
+
+  Factory factory;
+  auto lb_config_or_error = factory.loadConfig(factory_context_, config);
+  ASSERT_TRUE(lb_config_or_error.ok());
+
+  auto thread_aware_lb =
+      factory.create(OptRef<const Upstream::LoadBalancerConfig>(*lb_config_or_error.value()),
+                     cluster_info_, priority_set_, runtime_, random_, time_source_);
+  ASSERT_NE(thread_aware_lb, nullptr);
+  ASSERT_TRUE(thread_aware_lb->initialize().ok());
+
+  Upstream::LoadBalancerParams params{priority_set_, nullptr};
+  auto lb = thread_aware_lb->factory()->create(params);
+  ASSERT_NE(lb, nullptr);
+
+  auto* lb_ptr = static_cast<DynamicModuleLoadBalancer*>(lb.get());
+
+  // Lookup healthy host by address.
+  envoy_dynamic_module_type_host_health health = envoy_dynamic_module_type_host_health_Unhealthy;
+  envoy_dynamic_module_type_module_buffer addr1 = {"10.0.0.1:8080", 13};
+  EXPECT_TRUE(envoy_dynamic_module_callback_lb_get_host_health_by_address(lb_ptr, addr1, &health));
+  EXPECT_EQ(health, envoy_dynamic_module_type_host_health_Healthy);
+
+  // Lookup another healthy host.
+  envoy_dynamic_module_type_module_buffer addr2 = {"10.0.0.2:8080", 13};
+  EXPECT_TRUE(envoy_dynamic_module_callback_lb_get_host_health_by_address(lb_ptr, addr2, &health));
+  EXPECT_EQ(health, envoy_dynamic_module_type_host_health_Healthy);
+
+  // Lookup degraded host.
+  envoy_dynamic_module_type_module_buffer addr3 = {"10.0.0.3:8080", 13};
+  EXPECT_TRUE(envoy_dynamic_module_callback_lb_get_host_health_by_address(lb_ptr, addr3, &health));
+  EXPECT_EQ(health, envoy_dynamic_module_type_host_health_Degraded);
+
+  // Lookup non-existent address.
+  envoy_dynamic_module_type_module_buffer bad_addr = {"1.2.3.4:9999", 12};
+  EXPECT_FALSE(
+      envoy_dynamic_module_callback_lb_get_host_health_by_address(lb_ptr, bad_addr, &health));
+}
+
+TEST_F(DynamicModulesLoadBalancerTest, HostHealthByAddressNullInputs) {
+  envoy::extensions::load_balancing_policies::dynamic_modules::v3::DynamicModulesLoadBalancerConfig
+      config;
+  config.mutable_dynamic_module_config()->set_name("lb_round_robin");
+  config.set_lb_policy_name("test_lb");
+
+  Factory factory;
+  auto lb_config_or_error = factory.loadConfig(factory_context_, config);
+  ASSERT_TRUE(lb_config_or_error.ok());
+
+  auto thread_aware_lb =
+      factory.create(OptRef<const Upstream::LoadBalancerConfig>(*lb_config_or_error.value()),
+                     cluster_info_, priority_set_, runtime_, random_, time_source_);
+  ASSERT_NE(thread_aware_lb, nullptr);
+  ASSERT_TRUE(thread_aware_lb->initialize().ok());
+
+  Upstream::LoadBalancerParams params{priority_set_, nullptr};
+  auto lb = thread_aware_lb->factory()->create(params);
+  ASSERT_NE(lb, nullptr);
+
+  auto* lb_ptr = static_cast<DynamicModuleLoadBalancer*>(lb.get());
+
+  // Null lb_envoy_ptr.
+  envoy_dynamic_module_type_host_health health = envoy_dynamic_module_type_host_health_Healthy;
+  envoy_dynamic_module_type_module_buffer addr = {"10.0.0.1:8080", 13};
+  EXPECT_FALSE(envoy_dynamic_module_callback_lb_get_host_health_by_address(nullptr, addr, &health));
+  EXPECT_EQ(health, envoy_dynamic_module_type_host_health_Unhealthy);
+
+  // Null result pointer.
+  EXPECT_FALSE(envoy_dynamic_module_callback_lb_get_host_health_by_address(lb_ptr, addr, nullptr));
+
+  // Null address pointer.
+  envoy_dynamic_module_type_module_buffer null_addr = {nullptr, 0};
+  EXPECT_FALSE(
+      envoy_dynamic_module_callback_lb_get_host_health_by_address(lb_ptr, null_addr, &health));
+
+  // Null host map (default mock returns nullptr).
+  envoy_dynamic_module_type_module_buffer valid_addr = {"10.0.0.1:8080", 13};
+  EXPECT_FALSE(
+      envoy_dynamic_module_callback_lb_get_host_health_by_address(lb_ptr, valid_addr, &health));
+}
+
 TEST_F(DynamicModulesLoadBalancerTest, ContextCallbacksSuccessfulCases) {
   envoy::extensions::load_balancing_policies::dynamic_modules::v3::DynamicModulesLoadBalancerConfig
       config;


### PR DESCRIPTION
## Description

This PR adds a method to get the host health by address in the LB Dynamic Module.

---

**Commit Message:** dynamic_modules: add a method to get host health by address
**Additional Description:** Adds a method to get the host health by address in the LB Dynamic Module.
**Risk Level:** Low
**Testing:** Added Tests
**Docs Changes:** Added
**Release Notes:** N/A