### PR TITLE
dynamic_modules: add retry awareness to lb module

### DIFF
--- a/source/extensions/dynamic_modules/abi/abi.h
+++ b/source/extensions/dynamic_modules/abi/abi.h
@@ -8488,6 +8488,35 @@ bool envoy_dynamic_module_callback_lb_context_get_downstream_header(
     envoy_dynamic_module_type_module_buffer key,
     envoy_dynamic_module_type_envoy_buffer* result_buffer, size_t index, size_t* optional_size);
 
+/**
+ * envoy_dynamic_module_callback_lb_context_get_host_selection_retry_count returns the number
+ * of times host selection should be retried if the chosen host is rejected by
+ * shouldSelectAnotherHost. Built-in load balancers use this value as the upper bound of a
+ * retry loop during host selection.
+ *
+ * @param context_envoy_ptr is the pointer to the LoadBalancerContext.
+ * @return the maximum number of host selection retries, or 0 if the context is null.
+ */
+uint32_t envoy_dynamic_module_callback_lb_context_get_host_selection_retry_count(
+    envoy_dynamic_module_type_lb_context_envoy_ptr context_envoy_ptr);
+
+/**
+ * envoy_dynamic_module_callback_lb_context_should_select_another_host checks whether the
+ * load balancer should reject the given host and retry selection. This is used during retries
+ * to avoid selecting hosts that were already attempted. The host is identified by priority
+ * and index within all hosts at that priority.
+ *
+ * @param lb_envoy_ptr is the pointer to the Envoy load balancer object.
+ * @param context_envoy_ptr is the pointer to the LoadBalancerContext.
+ * @param priority is the priority level.
+ * @param index is the index of the host within all hosts.
+ * @return true if the host should be rejected and selection retried, false otherwise.
+ */
+bool envoy_dynamic_module_callback_lb_context_should_select_another_host(
+    envoy_dynamic_module_type_lb_envoy_ptr lb_envoy_ptr,
+    envoy_dynamic_module_type_lb_context_envoy_ptr context_envoy_ptr, uint32_t priority,
+    size_t index);
+
 // =============================================================================
 // Matcher Types
 // =============================================================================

--- a/source/extensions/dynamic_modules/abi_impl.cc
+++ b/source/extensions/dynamic_modules/abi_impl.cc
@@ -544,6 +544,22 @@ __attribute__((weak)) bool envoy_dynamic_module_callback_lb_context_get_downstre
   return false;
 }
 
+__attribute__((weak)) uint32_t
+envoy_dynamic_module_callback_lb_context_get_host_selection_retry_count(
+    envoy_dynamic_module_type_lb_context_envoy_ptr) {
+  IS_ENVOY_BUG("envoy_dynamic_module_callback_lb_context_get_host_selection_retry_count: "
+               "not implemented in this context");
+  return 0;
+}
+
+__attribute__((weak)) bool envoy_dynamic_module_callback_lb_context_should_select_another_host(
+    envoy_dynamic_module_type_lb_envoy_ptr, envoy_dynamic_module_type_lb_context_envoy_ptr,
+    uint32_t, size_t) {
+  IS_ENVOY_BUG("envoy_dynamic_module_callback_lb_context_should_select_another_host: "
+               "not implemented in this context");
+  return false;
+}
+
 __attribute__((weak)) bool
 envoy_dynamic_module_callback_lb_set_host_data(envoy_dynamic_module_type_lb_envoy_ptr, uint32_t,
                                                size_t, uintptr_t) {

--- a/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
@@ -10439,6 +10439,18 @@ pub trait EnvoyLoadBalancer {
   /// Returns the value and optionally the total number of values for the key.
   /// Only valid during choose_host callback.
   fn context_get_downstream_header(&self, key: &str, index: usize) -> Option<(String, usize)>;
+
+  /// Returns the maximum number of times host selection should be retried if the chosen host
+  /// is rejected by [`context_should_select_another_host`]. Built-in load balancers use this
+  /// value as the upper bound of a retry loop during host selection.
+  /// Only valid during choose_host callback.
+  fn context_get_host_selection_retry_count(&self) -> u32;
+
+  /// Checks whether the load balancer should reject the given host and retry selection.
+  /// This is used during retries to avoid selecting hosts that were already attempted.
+  /// The host is identified by priority and index within all hosts at that priority.
+  /// Only valid during choose_host callback.
+  fn context_should_select_another_host(&self, priority: u32, index: usize) -> bool;
 }
 
 /// Implementation of EnvoyLoadBalancer that calls into the Envoy ABI.
@@ -10964,6 +10976,29 @@ impl EnvoyLoadBalancer for EnvoyLoadBalancerImpl {
       }
     } else {
       None
+    }
+  }
+
+  fn context_get_host_selection_retry_count(&self) -> u32 {
+    if self.context_ptr.is_null() {
+      return 0;
+    }
+    unsafe {
+      abi::envoy_dynamic_module_callback_lb_context_get_host_selection_retry_count(self.context_ptr)
+    }
+  }
+
+  fn context_should_select_another_host(&self, priority: u32, index: usize) -> bool {
+    if self.context_ptr.is_null() || self.lb_ptr.is_null() {
+      return false;
+    }
+    unsafe {
+      abi::envoy_dynamic_module_callback_lb_context_should_select_another_host(
+        self.lb_ptr,
+        self.context_ptr,
+        priority,
+        index,
+      )
     }
   }
 }

--- a/source/extensions/load_balancing_policies/dynamic_modules/abi_impl.cc
+++ b/source/extensions/load_balancing_policies/dynamic_modules/abi_impl.cc
@@ -410,6 +410,32 @@ bool envoy_dynamic_module_callback_lb_context_get_downstream_header(
   return true;
 }
 
+uint32_t envoy_dynamic_module_callback_lb_context_get_host_selection_retry_count(
+    envoy_dynamic_module_type_lb_context_envoy_ptr context_envoy_ptr) {
+  if (context_envoy_ptr == nullptr) {
+    return 0;
+  }
+  return getContext(context_envoy_ptr)->hostSelectionRetryCount();
+}
+
+bool envoy_dynamic_module_callback_lb_context_should_select_another_host(
+    envoy_dynamic_module_type_lb_envoy_ptr lb_envoy_ptr,
+    envoy_dynamic_module_type_lb_context_envoy_ptr context_envoy_ptr, uint32_t priority,
+    size_t index) {
+  if (lb_envoy_ptr == nullptr || context_envoy_ptr == nullptr) {
+    return false;
+  }
+  const auto& host_sets = getLb(lb_envoy_ptr)->prioritySet().hostSetsPerPriority();
+  if (priority >= host_sets.size()) {
+    return false;
+  }
+  const auto& hosts = host_sets[priority]->hosts();
+  if (index >= hosts.size()) {
+    return false;
+  }
+  return getContext(context_envoy_ptr)->shouldSelectAnotherHost(*hosts[index]);
+}
+
 bool envoy_dynamic_module_callback_lb_set_host_data(
     envoy_dynamic_module_type_lb_envoy_ptr lb_envoy_ptr, uint32_t priority, size_t index,
     uintptr_t data) {

--- a/test/extensions/dynamic_modules/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/abi_impl_test.cc
@@ -670,6 +670,30 @@ TEST(CommonAbiImplTest, LbContextGetDownstreamHeaderEnvoyBug) {
       "not implemented in this context");
 }
 
+// Test that the weak symbol stub for lb_context_get_host_selection_retry_count triggers an
+// ENVOY_BUG when called.
+TEST(CommonAbiImplTest, LbContextGetHostSelectionRetryCountEnvoyBug) {
+  EXPECT_ENVOY_BUG(
+      {
+        auto count =
+            envoy_dynamic_module_callback_lb_context_get_host_selection_retry_count(nullptr);
+        EXPECT_EQ(count, 0);
+      },
+      "not implemented in this context");
+}
+
+// Test that the weak symbol stub for lb_context_should_select_another_host triggers an ENVOY_BUG
+// when called.
+TEST(CommonAbiImplTest, LbContextShouldSelectAnotherHostEnvoyBug) {
+  EXPECT_ENVOY_BUG(
+      {
+        auto should_retry = envoy_dynamic_module_callback_lb_context_should_select_another_host(
+            nullptr, nullptr, 0, 0);
+        EXPECT_FALSE(should_retry);
+      },
+      "not implemented in this context");
+}
+
 // Test that the weak symbol stub for lb_set_host_data triggers an ENVOY_BUG when called.
 TEST(CommonAbiImplTest, LbSetHostDataEnvoyBug) {
   EXPECT_ENVOY_BUG(

--- a/test/extensions/dynamic_modules/test_data/c/lb_callbacks_test.c
+++ b/test/extensions/dynamic_modules/test_data/c/lb_callbacks_test.c
@@ -216,6 +216,16 @@ bool envoy_dynamic_module_on_lb_choose_host(
     bool header_found = envoy_dynamic_module_callback_lb_context_get_downstream_header(
         context_envoy_ptr, method_key, &method_result, 0, &method_count);
     (void)header_found;
+
+    // Test host selection retry count.
+    uint32_t retry_count =
+        envoy_dynamic_module_callback_lb_context_get_host_selection_retry_count(context_envoy_ptr);
+    (void)retry_count;
+
+    // Test should_select_another_host for the first host.
+    bool should_retry = envoy_dynamic_module_callback_lb_context_should_select_another_host(
+        lb_envoy_ptr, context_envoy_ptr, 0, 0);
+    (void)should_retry;
   }
 
   if (healthy_count == 0) {

--- a/test/extensions/load_balancing_policies/dynamic_modules/config_test.cc
+++ b/test/extensions/load_balancing_policies/dynamic_modules/config_test.cc
@@ -542,6 +542,11 @@ TEST_F(DynamicModulesLoadBalancerTest, AbiCallbacksWithNullPointers) {
   envoy_dynamic_module_type_envoy_buffer header_result = {nullptr, 0};
   EXPECT_FALSE(envoy_dynamic_module_callback_lb_context_get_downstream_header(
       nullptr, header_key, &header_result, 0, nullptr));
+
+  // Test retry-awareness context callbacks with null.
+  EXPECT_EQ(envoy_dynamic_module_callback_lb_context_get_host_selection_retry_count(nullptr), 0);
+  EXPECT_FALSE(
+      envoy_dynamic_module_callback_lb_context_should_select_another_host(nullptr, nullptr, 0, 0));
 }
 
 TEST_F(DynamicModulesLoadBalancerTest, AbiCallbacksWithInvalidPriority) {
@@ -971,6 +976,126 @@ TEST_F(DynamicModulesLoadBalancerTest, ContextCallbacksHeaderOutOfBounds) {
   envoy_dynamic_module_type_envoy_buffer result = {nullptr, 0};
   EXPECT_FALSE(envoy_dynamic_module_callback_lb_context_get_downstream_header(
       context_ptr, key, &result, 999, nullptr));
+}
+
+// =============================================================================
+// Retry Awareness Tests
+// =============================================================================
+
+TEST_F(DynamicModulesLoadBalancerTest, HostSelectionRetryCount) {
+  NiceMock<Upstream::MockLoadBalancerContext> context;
+  ON_CALL(context, hostSelectionRetryCount()).WillByDefault(Return(3));
+
+  auto* context_ptr = static_cast<Upstream::LoadBalancerContext*>(&context);
+
+  EXPECT_EQ(envoy_dynamic_module_callback_lb_context_get_host_selection_retry_count(context_ptr),
+            3);
+}
+
+TEST_F(DynamicModulesLoadBalancerTest, HostSelectionRetryCountZero) {
+  NiceMock<Upstream::MockLoadBalancerContext> context;
+  ON_CALL(context, hostSelectionRetryCount()).WillByDefault(Return(0));
+
+  auto* context_ptr = static_cast<Upstream::LoadBalancerContext*>(&context);
+
+  EXPECT_EQ(envoy_dynamic_module_callback_lb_context_get_host_selection_retry_count(context_ptr),
+            0);
+}
+
+TEST_F(DynamicModulesLoadBalancerTest, ShouldSelectAnotherHostAccepted) {
+  envoy::extensions::load_balancing_policies::dynamic_modules::v3::DynamicModulesLoadBalancerConfig
+      config;
+  config.mutable_dynamic_module_config()->set_name("lb_round_robin");
+  config.set_lb_policy_name("test_lb");
+
+  Factory factory;
+  auto lb_config_or_error = factory.loadConfig(factory_context_, config);
+  ASSERT_TRUE(lb_config_or_error.ok());
+
+  auto thread_aware_lb =
+      factory.create(OptRef<const Upstream::LoadBalancerConfig>(*lb_config_or_error.value()),
+                     cluster_info_, priority_set_, runtime_, random_, time_source_);
+  ASSERT_NE(thread_aware_lb, nullptr);
+  ASSERT_TRUE(thread_aware_lb->initialize().ok());
+
+  Upstream::LoadBalancerParams params{priority_set_, nullptr};
+  auto lb = thread_aware_lb->factory()->create(params);
+  ASSERT_NE(lb, nullptr);
+
+  auto* lb_ptr = static_cast<DynamicModuleLoadBalancer*>(lb.get());
+
+  NiceMock<Upstream::MockLoadBalancerContext> context;
+  ON_CALL(context, shouldSelectAnotherHost(_)).WillByDefault(Return(false));
+  auto* context_ptr = static_cast<Upstream::LoadBalancerContext*>(&context);
+
+  // Host should be accepted (shouldSelectAnotherHost returns false).
+  EXPECT_FALSE(envoy_dynamic_module_callback_lb_context_should_select_another_host(
+      lb_ptr, context_ptr, 0, 0));
+}
+
+TEST_F(DynamicModulesLoadBalancerTest, ShouldSelectAnotherHostRejected) {
+  envoy::extensions::load_balancing_policies::dynamic_modules::v3::DynamicModulesLoadBalancerConfig
+      config;
+  config.mutable_dynamic_module_config()->set_name("lb_round_robin");
+  config.set_lb_policy_name("test_lb");
+
+  Factory factory;
+  auto lb_config_or_error = factory.loadConfig(factory_context_, config);
+  ASSERT_TRUE(lb_config_or_error.ok());
+
+  auto thread_aware_lb =
+      factory.create(OptRef<const Upstream::LoadBalancerConfig>(*lb_config_or_error.value()),
+                     cluster_info_, priority_set_, runtime_, random_, time_source_);
+  ASSERT_NE(thread_aware_lb, nullptr);
+  ASSERT_TRUE(thread_aware_lb->initialize().ok());
+
+  Upstream::LoadBalancerParams params{priority_set_, nullptr};
+  auto lb = thread_aware_lb->factory()->create(params);
+  ASSERT_NE(lb, nullptr);
+
+  auto* lb_ptr = static_cast<DynamicModuleLoadBalancer*>(lb.get());
+
+  NiceMock<Upstream::MockLoadBalancerContext> context;
+  ON_CALL(context, shouldSelectAnotherHost(_)).WillByDefault(Return(true));
+  auto* context_ptr = static_cast<Upstream::LoadBalancerContext*>(&context);
+
+  // Host should be rejected (shouldSelectAnotherHost returns true).
+  EXPECT_TRUE(envoy_dynamic_module_callback_lb_context_should_select_another_host(
+      lb_ptr, context_ptr, 0, 0));
+}
+
+TEST_F(DynamicModulesLoadBalancerTest, ShouldSelectAnotherHostInvalidPriority) {
+  envoy::extensions::load_balancing_policies::dynamic_modules::v3::DynamicModulesLoadBalancerConfig
+      config;
+  config.mutable_dynamic_module_config()->set_name("lb_round_robin");
+  config.set_lb_policy_name("test_lb");
+
+  Factory factory;
+  auto lb_config_or_error = factory.loadConfig(factory_context_, config);
+  ASSERT_TRUE(lb_config_or_error.ok());
+
+  auto thread_aware_lb =
+      factory.create(OptRef<const Upstream::LoadBalancerConfig>(*lb_config_or_error.value()),
+                     cluster_info_, priority_set_, runtime_, random_, time_source_);
+  ASSERT_NE(thread_aware_lb, nullptr);
+  ASSERT_TRUE(thread_aware_lb->initialize().ok());
+
+  Upstream::LoadBalancerParams params{priority_set_, nullptr};
+  auto lb = thread_aware_lb->factory()->create(params);
+  ASSERT_NE(lb, nullptr);
+
+  auto* lb_ptr = static_cast<DynamicModuleLoadBalancer*>(lb.get());
+
+  NiceMock<Upstream::MockLoadBalancerContext> context;
+  auto* context_ptr = static_cast<Upstream::LoadBalancerContext*>(&context);
+
+  // Invalid priority returns false.
+  EXPECT_FALSE(envoy_dynamic_module_callback_lb_context_should_select_another_host(
+      lb_ptr, context_ptr, 999, 0));
+
+  // Invalid host index returns false.
+  EXPECT_FALSE(envoy_dynamic_module_callback_lb_context_should_select_another_host(
+      lb_ptr, context_ptr, 0, 999));
 }
 
 // =============================================================================


### PR DESCRIPTION
## Description

This PR adds retry awareness to the LB Dynamic Modules.

---

**Commit Message:** dynamic_modules: add retry awareness to lb module
**Additional Description:** Added retry awareness to the LB Dynamic Modules.
**Risk Level:** Low
**Testing:** Added Tests
**Docs Changes:** Added
**Release Notes:** N/A