### PR TITLE
dynamic_modules: add a way to access overridden host address from the LB context

### DIFF
--- a/source/extensions/dynamic_modules/abi/abi.h
+++ b/source/extensions/dynamic_modules/abi/abi.h
@@ -8517,6 +8517,25 @@ bool envoy_dynamic_module_callback_lb_context_should_select_another_host(
     envoy_dynamic_module_type_lb_context_envoy_ptr context_envoy_ptr, uint32_t priority,
     size_t index);
 
+/**
+ * envoy_dynamic_module_callback_lb_context_get_override_host returns the override host address
+ * and strict mode flag from the load balancer context. Override host allows upstream filters to
+ * direct the load balancer to prefer a specific host by address. Note that override host
+ * resolution is normally handled by the ClusterManager before the load balancer is invoked, so
+ * this callback provides read-only access to the override host preference.
+ *
+ * @param context_envoy_ptr is the pointer to the LoadBalancerContext.
+ * @param address is the output buffer for the override host address string. The buffer points to
+ * Envoy-owned memory valid for the duration of the context.
+ * @param strict is the output for the strict mode flag. When true, the load balancer should
+ * return nullptr if the override host is not valid. When false, the load balancer should fall
+ * back to normal selection.
+ * @return true if an override host is set, false otherwise.
+ */
+bool envoy_dynamic_module_callback_lb_context_get_override_host(
+    envoy_dynamic_module_type_lb_context_envoy_ptr context_envoy_ptr,
+    envoy_dynamic_module_type_envoy_buffer* address, bool* strict);
+
 // =============================================================================
 // Matcher Types
 // =============================================================================

--- a/source/extensions/dynamic_modules/abi_impl.cc
+++ b/source/extensions/dynamic_modules/abi_impl.cc
@@ -560,6 +560,14 @@ __attribute__((weak)) bool envoy_dynamic_module_callback_lb_context_should_selec
   return false;
 }
 
+__attribute__((weak)) bool envoy_dynamic_module_callback_lb_context_get_override_host(
+    envoy_dynamic_module_type_lb_context_envoy_ptr, envoy_dynamic_module_type_envoy_buffer*,
+    bool*) {
+  IS_ENVOY_BUG("envoy_dynamic_module_callback_lb_context_get_override_host: "
+               "not implemented in this context");
+  return false;
+}
+
 __attribute__((weak)) bool
 envoy_dynamic_module_callback_lb_set_host_data(envoy_dynamic_module_type_lb_envoy_ptr, uint32_t,
                                                size_t, uintptr_t) {

--- a/source/extensions/dynamic_modules/sdk/rust/src/load_balancer.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/load_balancer.rs
@@ -165,6 +165,13 @@ pub trait EnvoyLoadBalancer {
   /// The host is identified by priority and index within all hosts at that priority.
   /// Only valid during choose_host callback.
   fn context_should_select_another_host(&self, priority: u32, index: usize) -> bool;
+
+  /// Returns the override host address and strict mode flag from the context. Override host
+  /// allows upstream filters to direct the load balancer to prefer a specific host by address.
+  /// Returns `Some((address, strict))` if an override host is set, `None` otherwise. When
+  /// `strict` is true, the load balancer should return no host if the override is not valid.
+  /// Only valid during choose_host callback.
+  fn context_get_override_host(&self) -> Option<(String, bool)>;
 }
 
 /// Implementation of EnvoyLoadBalancer that calls into the Envoy ABI.
@@ -713,6 +720,38 @@ impl EnvoyLoadBalancer for EnvoyLoadBalancerImpl {
         priority,
         index,
       )
+    }
+  }
+
+  fn context_get_override_host(&self) -> Option<(String, bool)> {
+    if self.context_ptr.is_null() {
+      return None;
+    }
+    let mut address = abi::envoy_dynamic_module_type_envoy_buffer {
+      ptr: std::ptr::null(),
+      length: 0,
+    };
+    let mut strict = false;
+    let found = unsafe {
+      abi::envoy_dynamic_module_callback_lb_context_get_override_host(
+        self.context_ptr,
+        &mut address,
+        &mut strict,
+      )
+    };
+    if found {
+      unsafe {
+        Some((
+          std::str::from_utf8_unchecked(std::slice::from_raw_parts(
+            address.ptr as *const _,
+            address.length,
+          ))
+          .to_string(),
+          strict,
+        ))
+      }
+    } else {
+      None
     }
   }
 }

--- a/source/extensions/load_balancing_policies/dynamic_modules/abi_impl.cc
+++ b/source/extensions/load_balancing_policies/dynamic_modules/abi_impl.cc
@@ -436,6 +436,23 @@ bool envoy_dynamic_module_callback_lb_context_should_select_another_host(
   return getContext(context_envoy_ptr)->shouldSelectAnotherHost(*hosts[index]);
 }
 
+bool envoy_dynamic_module_callback_lb_context_get_override_host(
+    envoy_dynamic_module_type_lb_context_envoy_ptr context_envoy_ptr,
+    envoy_dynamic_module_type_envoy_buffer* address, bool* strict) {
+  if (context_envoy_ptr == nullptr || address == nullptr || strict == nullptr) {
+    return false;
+  }
+  auto override_host = getContext(context_envoy_ptr)->overrideHostToSelect();
+  if (!override_host.has_value()) {
+    return false;
+  }
+  auto host_address = override_host.value().first;
+  address->ptr = const_cast<char*>(host_address.data());
+  address->length = host_address.size();
+  *strict = override_host.value().second;
+  return true;
+}
+
 bool envoy_dynamic_module_callback_lb_set_host_data(
     envoy_dynamic_module_type_lb_envoy_ptr lb_envoy_ptr, uint32_t priority, size_t index,
     uintptr_t data) {

--- a/test/extensions/dynamic_modules/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/abi_impl_test.cc
@@ -694,6 +694,18 @@ TEST(CommonAbiImplTest, LbContextShouldSelectAnotherHostEnvoyBug) {
       "not implemented in this context");
 }
 
+// Test that the weak symbol stub for lb_context_get_override_host triggers an ENVOY_BUG when
+// called.
+TEST(CommonAbiImplTest, LbContextGetOverrideHostEnvoyBug) {
+  EXPECT_ENVOY_BUG(
+      {
+        auto found =
+            envoy_dynamic_module_callback_lb_context_get_override_host(nullptr, nullptr, nullptr);
+        EXPECT_FALSE(found);
+      },
+      "not implemented in this context");
+}
+
 // Test that the weak symbol stub for lb_set_host_data triggers an ENVOY_BUG when called.
 TEST(CommonAbiImplTest, LbSetHostDataEnvoyBug) {
   EXPECT_ENVOY_BUG(

--- a/test/extensions/dynamic_modules/test_data/c/lb_callbacks_test.c
+++ b/test/extensions/dynamic_modules/test_data/c/lb_callbacks_test.c
@@ -226,6 +226,13 @@ bool envoy_dynamic_module_on_lb_choose_host(
     bool should_retry = envoy_dynamic_module_callback_lb_context_should_select_another_host(
         lb_envoy_ptr, context_envoy_ptr, 0, 0);
     (void)should_retry;
+
+    // Test override host.
+    envoy_dynamic_module_type_envoy_buffer override_addr = {NULL, 0};
+    bool strict = false;
+    bool has_override = envoy_dynamic_module_callback_lb_context_get_override_host(
+        context_envoy_ptr, &override_addr, &strict);
+    (void)has_override;
   }
 
   if (healthy_count == 0) {

--- a/test/extensions/load_balancing_policies/dynamic_modules/config_test.cc
+++ b/test/extensions/load_balancing_policies/dynamic_modules/config_test.cc
@@ -547,6 +547,10 @@ TEST_F(DynamicModulesLoadBalancerTest, AbiCallbacksWithNullPointers) {
   EXPECT_EQ(envoy_dynamic_module_callback_lb_context_get_host_selection_retry_count(nullptr), 0);
   EXPECT_FALSE(
       envoy_dynamic_module_callback_lb_context_should_select_another_host(nullptr, nullptr, 0, 0));
+
+  // Test override host context callback with null.
+  EXPECT_FALSE(
+      envoy_dynamic_module_callback_lb_context_get_override_host(nullptr, nullptr, nullptr));
 }
 
 TEST_F(DynamicModulesLoadBalancerTest, AbiCallbacksWithInvalidPriority) {
@@ -1096,6 +1100,73 @@ TEST_F(DynamicModulesLoadBalancerTest, ShouldSelectAnotherHostInvalidPriority) {
   // Invalid host index returns false.
   EXPECT_FALSE(envoy_dynamic_module_callback_lb_context_should_select_another_host(
       lb_ptr, context_ptr, 0, 999));
+}
+
+// =============================================================================
+// Override Host Selection Tests
+// =============================================================================
+
+TEST_F(DynamicModulesLoadBalancerTest, OverrideHostPresent) {
+  NiceMock<Upstream::MockLoadBalancerContext> context;
+  ON_CALL(context, overrideHostToSelect())
+      .WillByDefault(Return(
+          absl::optional<Upstream::LoadBalancerContext::OverrideHost>({"10.0.0.1:8080", true})));
+
+  auto* context_ptr = static_cast<Upstream::LoadBalancerContext*>(&context);
+
+  envoy_dynamic_module_type_envoy_buffer address = {nullptr, 0};
+  bool strict = false;
+  EXPECT_TRUE(
+      envoy_dynamic_module_callback_lb_context_get_override_host(context_ptr, &address, &strict));
+  EXPECT_EQ(absl::string_view(address.ptr, address.length), "10.0.0.1:8080");
+  EXPECT_TRUE(strict);
+}
+
+TEST_F(DynamicModulesLoadBalancerTest, OverrideHostPresentNonStrict) {
+  NiceMock<Upstream::MockLoadBalancerContext> context;
+  ON_CALL(context, overrideHostToSelect())
+      .WillByDefault(Return(
+          absl::optional<Upstream::LoadBalancerContext::OverrideHost>({"10.0.0.2:9090", false})));
+
+  auto* context_ptr = static_cast<Upstream::LoadBalancerContext*>(&context);
+
+  envoy_dynamic_module_type_envoy_buffer address = {nullptr, 0};
+  bool strict = true;
+  EXPECT_TRUE(
+      envoy_dynamic_module_callback_lb_context_get_override_host(context_ptr, &address, &strict));
+  EXPECT_EQ(absl::string_view(address.ptr, address.length), "10.0.0.2:9090");
+  EXPECT_FALSE(strict);
+}
+
+TEST_F(DynamicModulesLoadBalancerTest, OverrideHostNotSet) {
+  NiceMock<Upstream::MockLoadBalancerContext> context;
+  ON_CALL(context, overrideHostToSelect()).WillByDefault(Return(absl::nullopt));
+
+  auto* context_ptr = static_cast<Upstream::LoadBalancerContext*>(&context);
+
+  envoy_dynamic_module_type_envoy_buffer address = {nullptr, 0};
+  bool strict = false;
+  EXPECT_FALSE(
+      envoy_dynamic_module_callback_lb_context_get_override_host(context_ptr, &address, &strict));
+}
+
+TEST_F(DynamicModulesLoadBalancerTest, OverrideHostNullOutputs) {
+  NiceMock<Upstream::MockLoadBalancerContext> context;
+  ON_CALL(context, overrideHostToSelect())
+      .WillByDefault(Return(
+          absl::optional<Upstream::LoadBalancerContext::OverrideHost>({"10.0.0.1:8080", true})));
+
+  auto* context_ptr = static_cast<Upstream::LoadBalancerContext*>(&context);
+
+  // Null address output.
+  bool strict = false;
+  EXPECT_FALSE(
+      envoy_dynamic_module_callback_lb_context_get_override_host(context_ptr, nullptr, &strict));
+
+  // Null strict output.
+  envoy_dynamic_module_type_envoy_buffer address = {nullptr, 0};
+  EXPECT_FALSE(
+      envoy_dynamic_module_callback_lb_context_get_override_host(context_ptr, &address, nullptr));
 }
 
 // =============================================================================


### PR DESCRIPTION
## Description

This PR adds a way to access overridden host address and the strict flag from the LB context.

---

**Commit Message:** dynamic_modules: add a way to access overridden host address from the LB context
**Additional Description:** Added a way to access overridden host address and the strict flag from the LB context.
**Risk Level:** Low
**Testing:** Added Tests
**Docs Changes:** Added
**Release Notes:** N/A