### PR TITLE
dynamic_modules: added host membership update notifications for LB

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -525,6 +525,11 @@ new_features:
     Added init manager integration to the dynamic modules bootstrap extension ABI. An init target
     is automatically registered for every bootstrap extension, blocking traffic until the module
     signals readiness via ``signal_init_complete``.
+- area: dynamic_modules
+  change: |
+    Added ``on_host_membership_update`` event hook and ``get_member_update_host_address`` callback
+    for dynamic module load balancers, enabling modules to receive notifications when hosts are
+    added or removed from the cluster and inspect the affected host addresses.
 - area: geoip
   change: |
     Added ``asn_org`` field to :ref:`geo_field_keys

--- a/source/extensions/dynamic_modules/abi/abi.h
+++ b/source/extensions/dynamic_modules/abi/abi.h
@@ -8094,6 +8094,28 @@ bool envoy_dynamic_module_on_lb_choose_host(
     uint32_t* result_index);
 
 /**
+ * envoy_dynamic_module_on_lb_on_host_membership_update is called when the set of hosts in the
+ * cluster changes. This is triggered by EDS updates, health check transitions, or any other
+ * mechanism that adds or removes hosts from the priority set.
+ *
+ * During this callback, the module can call
+ * envoy_dynamic_module_callback_lb_get_member_update_host_address to get the addresses of the
+ * added or removed hosts by index.
+ *
+ * After this callback returns, the module can use the standard host query callbacks
+ * (get_hosts_count, get_healthy_hosts_count, etc.) to inspect the new host state.
+ *
+ * @param lb_envoy_ptr is the pointer to the Envoy load balancer object.
+ * @param lb_module_ptr is the pointer to the in-module load balancer instance.
+ * @param num_hosts_added is the number of hosts added.
+ * @param num_hosts_removed is the number of hosts removed.
+ */
+void envoy_dynamic_module_on_lb_on_host_membership_update(
+    envoy_dynamic_module_type_lb_envoy_ptr lb_envoy_ptr,
+    envoy_dynamic_module_type_lb_module_ptr lb_module_ptr, size_t num_hosts_added,
+    size_t num_hosts_removed);
+
+/**
  * envoy_dynamic_module_on_lb_destroy is called when the load balancer instance is
  * destroyed. The module should release any resources associated with it.
  *
@@ -8535,6 +8557,22 @@ bool envoy_dynamic_module_callback_lb_context_should_select_another_host(
 bool envoy_dynamic_module_callback_lb_context_get_override_host(
     envoy_dynamic_module_type_lb_context_envoy_ptr context_envoy_ptr,
     envoy_dynamic_module_type_envoy_buffer* address, bool* strict);
+
+/**
+ * envoy_dynamic_module_callback_lb_get_member_update_host_address returns the address of an added
+ * or removed host during the on_host_membership_update event hook. This callback is only valid
+ * during envoy_dynamic_module_on_lb_on_host_membership_update.
+ *
+ * @param lb_envoy_ptr is the pointer to the Envoy load balancer object.
+ * @param index is the index of the host in the added or removed list.
+ * @param is_added is true to get an added host address, false to get a removed host address.
+ * @param result is the output buffer for the host address string. The buffer points to Envoy-owned
+ * memory that is valid only for the duration of the on_host_membership_update callback.
+ * @return true if the host was found, false otherwise.
+ */
+bool envoy_dynamic_module_callback_lb_get_member_update_host_address(
+    envoy_dynamic_module_type_lb_envoy_ptr lb_envoy_ptr, size_t index, bool is_added,
+    envoy_dynamic_module_type_envoy_buffer* result);
 
 // =============================================================================
 // Matcher Types

--- a/source/extensions/dynamic_modules/abi_impl.cc
+++ b/source/extensions/dynamic_modules/abi_impl.cc
@@ -646,6 +646,18 @@ __attribute__((weak)) uint32_t envoy_dynamic_module_callback_lb_get_locality_wei
   return 0;
 }
 
+__attribute__((weak)) bool envoy_dynamic_module_callback_lb_get_member_update_host_address(
+    envoy_dynamic_module_type_lb_envoy_ptr, size_t, bool,
+    envoy_dynamic_module_type_envoy_buffer* result) {
+  IS_ENVOY_BUG("envoy_dynamic_module_callback_lb_get_member_update_host_address: "
+               "not implemented in this context");
+  if (result != nullptr) {
+    result->ptr = nullptr;
+    result->length = 0;
+  }
+  return false;
+}
+
 // ---------------------- Matcher callbacks ------------------------
 // These are weak symbols that provide default stub implementations. The actual implementations
 // are provided in the matcher extension abi_impl.cc when the matcher extension is used.

--- a/source/extensions/dynamic_modules/sdk/rust/src/load_balancer.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/load_balancer.rs
@@ -129,6 +129,16 @@ pub trait EnvoyLoadBalancer {
   fn get_locality_weight(&self, priority: u32, locality_index: usize) -> u32;
 
   // -------------------------------------------------------------------------
+  // Member update methods are only valid during on_host_membership_update callback.
+  // -------------------------------------------------------------------------
+
+  /// Returns the address of an added or removed host during on_host_membership_update.
+  /// If `is_added` is true, returns the address of the added host at the given index.
+  /// If `is_added` is false, returns the address of the removed host at the given index.
+  /// Only valid during on_host_membership_update callback.
+  fn get_member_update_host_address(&self, index: usize, is_added: bool) -> Option<String>;
+
+  // -------------------------------------------------------------------------
   // Context methods are only valid during choose_host callback.
   // -------------------------------------------------------------------------
 
@@ -587,6 +597,32 @@ impl EnvoyLoadBalancer for EnvoyLoadBalancerImpl {
     }
   }
 
+  fn get_member_update_host_address(&self, index: usize, is_added: bool) -> Option<String> {
+    let mut result = abi::envoy_dynamic_module_type_envoy_buffer {
+      ptr: std::ptr::null(),
+      length: 0,
+    };
+    let found = unsafe {
+      abi::envoy_dynamic_module_callback_lb_get_member_update_host_address(
+        self.lb_ptr,
+        index,
+        is_added,
+        &mut result,
+      )
+    };
+    if found && !result.ptr.is_null() && result.length > 0 {
+      Some(unsafe {
+        std::str::from_utf8_unchecked(std::slice::from_raw_parts(
+          result.ptr as *const _,
+          result.length,
+        ))
+        .to_string()
+      })
+    } else {
+      None
+    }
+  }
+
   fn has_context(&self) -> bool {
     !self.context_ptr.is_null()
   }
@@ -806,6 +842,21 @@ pub trait LoadBalancer {
   /// in the healthy hosts list at that priority, or `None` if no host should be selected
   /// (which will result in no upstream connection).
   fn choose_host(&mut self, envoy_lb: &dyn EnvoyLoadBalancer) -> Option<HostSelection>;
+
+  /// Called when the set of hosts in the cluster changes (hosts added or removed).
+  ///
+  /// The `envoy_lb` provides access to cluster/host information. During this callback,
+  /// [`EnvoyLoadBalancer::get_member_update_host_address`] can be used to get the addresses
+  /// of the added or removed hosts.
+  ///
+  /// The default implementation is a no-op.
+  fn on_host_membership_update(
+    &mut self,
+    _envoy_lb: &dyn EnvoyLoadBalancer,
+    _num_hosts_added: usize,
+    _num_hosts_removed: usize,
+  ) {
+  }
 }
 
 /// # Safety
@@ -887,6 +938,25 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_lb_choose_host(
     },
     None => false,
   }
+}
+
+/// # Safety
+///
+/// This is an FFI function called by Envoy. All pointer arguments must be valid as guaranteed
+/// by the Envoy dynamic module ABI.
+#[no_mangle]
+pub unsafe extern "C" fn envoy_dynamic_module_on_lb_on_host_membership_update(
+  lb_envoy_ptr: abi::envoy_dynamic_module_type_lb_envoy_ptr,
+  lb_module_ptr: abi::envoy_dynamic_module_type_lb_module_ptr,
+  num_hosts_added: usize,
+  num_hosts_removed: usize,
+) {
+  let envoy_lb = EnvoyLoadBalancerImpl::new(lb_envoy_ptr, std::ptr::null_mut());
+  let lb = {
+    let raw = lb_module_ptr as *mut *mut dyn LoadBalancer;
+    &mut **raw
+  };
+  lb.on_host_membership_update(&envoy_lb, num_hosts_added, num_hosts_removed);
 }
 
 /// # Safety

--- a/source/extensions/load_balancing_policies/dynamic_modules/abi_impl.cc
+++ b/source/extensions/load_balancing_policies/dynamic_modules/abi_impl.cc
@@ -605,4 +605,27 @@ uint32_t envoy_dynamic_module_callback_lb_get_locality_weight(
   return (*weights)[locality_index];
 }
 
+bool envoy_dynamic_module_callback_lb_get_member_update_host_address(
+    envoy_dynamic_module_type_lb_envoy_ptr lb_envoy_ptr, size_t index, bool is_added,
+    envoy_dynamic_module_type_envoy_buffer* result) {
+  if (lb_envoy_ptr == nullptr || result == nullptr) {
+    if (result != nullptr) {
+      result->ptr = nullptr;
+      result->length = 0;
+    }
+    return false;
+  }
+  const auto* hosts =
+      is_added ? getLb(lb_envoy_ptr)->hostsAdded() : getLb(lb_envoy_ptr)->hostsRemoved();
+  if (hosts == nullptr || index >= hosts->size()) {
+    result->ptr = nullptr;
+    result->length = 0;
+    return false;
+  }
+  const auto& address_str = (*hosts)[index]->address()->asStringView();
+  result->ptr = address_str.data();
+  result->length = address_str.size();
+  return true;
+}
+
 } // extern "C"

--- a/source/extensions/load_balancing_policies/dynamic_modules/lb_config.cc
+++ b/source/extensions/load_balancing_policies/dynamic_modules/lb_config.cc
@@ -26,6 +26,8 @@ DynamicModuleLbConfig::create(const std::string& lb_policy_name, const std::stri
                  on_config_destroy_);
   RESOLVE_SYMBOL("envoy_dynamic_module_on_lb_new", OnLbNewType, on_lb_new_);
   RESOLVE_SYMBOL("envoy_dynamic_module_on_lb_choose_host", OnLbChooseHostType, on_choose_host_);
+  RESOLVE_SYMBOL("envoy_dynamic_module_on_lb_on_host_membership_update",
+                 OnLbOnHostMembershipUpdateType, on_host_membership_update_);
   RESOLVE_SYMBOL("envoy_dynamic_module_on_lb_destroy", OnLbDestroyType, on_lb_destroy_);
 
 #undef RESOLVE_SYMBOL

--- a/source/extensions/load_balancing_policies/dynamic_modules/lb_config.h
+++ b/source/extensions/load_balancing_policies/dynamic_modules/lb_config.h
@@ -22,6 +22,8 @@ using OnLbConfigNewType = decltype(&envoy_dynamic_module_on_lb_config_new);
 using OnLbConfigDestroyType = decltype(&envoy_dynamic_module_on_lb_config_destroy);
 using OnLbNewType = decltype(&envoy_dynamic_module_on_lb_new);
 using OnLbChooseHostType = decltype(&envoy_dynamic_module_on_lb_choose_host);
+using OnLbOnHostMembershipUpdateType =
+    decltype(&envoy_dynamic_module_on_lb_on_host_membership_update);
 using OnLbDestroyType = decltype(&envoy_dynamic_module_on_lb_destroy);
 
 /**
@@ -49,6 +51,7 @@ public:
   OnLbConfigDestroyType on_config_destroy_;
   OnLbNewType on_lb_new_;
   OnLbChooseHostType on_choose_host_;
+  OnLbOnHostMembershipUpdateType on_host_membership_update_;
   OnLbDestroyType on_lb_destroy_;
 
   // The in-module configuration pointer.

--- a/source/extensions/load_balancing_policies/dynamic_modules/load_balancer.cc
+++ b/source/extensions/load_balancing_policies/dynamic_modules/load_balancer.cc
@@ -14,7 +14,19 @@ DynamicModuleLoadBalancer::DynamicModuleLoadBalancer(DynamicModuleLbConfigShared
   in_module_lb_ = config_->on_lb_new_(config_->in_module_config_, this);
   if (in_module_lb_ == nullptr) {
     ENVOY_LOG(error, "failed to create in-module load balancer instance");
+    return;
   }
+
+  // Register for host membership updates.
+  member_update_cb_ = priority_set_.addMemberUpdateCb(
+      [this](const Upstream::HostVector& hosts_added, const Upstream::HostVector& hosts_removed) {
+        hosts_added_ = &hosts_added;
+        hosts_removed_ = &hosts_removed;
+        config_->on_host_membership_update_(this, in_module_lb_, hosts_added.size(),
+                                            hosts_removed.size());
+        hosts_added_ = nullptr;
+        hosts_removed_ = nullptr;
+      });
 }
 
 DynamicModuleLoadBalancer::~DynamicModuleLoadBalancer() {

--- a/source/extensions/load_balancing_policies/dynamic_modules/load_balancer.h
+++ b/source/extensions/load_balancing_policies/dynamic_modules/load_balancer.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "envoy/common/callback.h"
 #include "envoy/upstream/load_balancer.h"
 
 #include "source/common/common/logger.h"
@@ -37,11 +38,22 @@ public:
   bool setHostData(uint32_t priority, size_t index, uintptr_t data);
   bool getHostData(uint32_t priority, size_t index, uintptr_t* data) const;
 
+  // Accessors for hosts added/removed during the on_host_membership_update callback.
+  const Upstream::HostVector* hostsAdded() const { return hosts_added_; }
+  const Upstream::HostVector* hostsRemoved() const { return hosts_removed_; }
+
 private:
   DynamicModuleLbConfigSharedPtr config_;
   const Upstream::PrioritySet& priority_set_;
   std::string cluster_name_;
   envoy_dynamic_module_type_lb_module_ptr in_module_lb_;
+
+  // Handle for the member update callback registration. Automatically unregisters on destruction.
+  Envoy::Common::CallbackHandlePtr member_update_cb_;
+
+  // Temporary pointers to host vectors, valid only during on_host_membership_update callback.
+  const Upstream::HostVector* hosts_added_{};
+  const Upstream::HostVector* hosts_removed_{};
 
   // Per-host data storage keyed by (priority, index). This is per-LB-instance (per-worker).
   absl::flat_hash_map<std::pair<uint32_t, size_t>, uintptr_t> per_host_data_;

--- a/test/extensions/dynamic_modules/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/abi_impl_test.cc
@@ -812,6 +812,19 @@ TEST(CommonAbiImplTest, LbGetLocalityWeightEnvoyBug) {
       "not implemented in this context");
 }
 
+// Test that the weak symbol stub for lb_get_member_update_host_address triggers an ENVOY_BUG
+// when called.
+TEST(CommonAbiImplTest, LbGetMemberUpdateHostAddressEnvoyBug) {
+  envoy_dynamic_module_type_envoy_buffer result = {nullptr, 0};
+  EXPECT_ENVOY_BUG(
+      {
+        auto found = envoy_dynamic_module_callback_lb_get_member_update_host_address(nullptr, 0,
+                                                                                     true, &result);
+        EXPECT_FALSE(found);
+      },
+      "not implemented in this context");
+}
+
 // =====================================================================
 // Matcher weak symbol stub tests
 // =====================================================================

--- a/test/extensions/dynamic_modules/test_data/c/lb_callbacks_test.c
+++ b/test/extensions/dynamic_modules/test_data/c/lb_callbacks_test.c
@@ -246,6 +246,35 @@ bool envoy_dynamic_module_on_lb_choose_host(
   return true;
 }
 
+void envoy_dynamic_module_on_lb_on_host_membership_update(
+    envoy_dynamic_module_type_lb_envoy_ptr lb_envoy_ptr,
+    envoy_dynamic_module_type_lb_module_ptr lb_module_ptr, size_t num_hosts_added,
+    size_t num_hosts_removed) {
+  (void)lb_module_ptr;
+
+  // Test accessing added host addresses.
+  for (size_t i = 0; i < num_hosts_added; i++) {
+    envoy_dynamic_module_type_envoy_buffer addr = {NULL, 0};
+    bool found = envoy_dynamic_module_callback_lb_get_member_update_host_address(
+        lb_envoy_ptr, i, true, &addr);
+    (void)found;
+  }
+
+  // Test accessing removed host addresses.
+  for (size_t i = 0; i < num_hosts_removed; i++) {
+    envoy_dynamic_module_type_envoy_buffer addr = {NULL, 0};
+    bool found = envoy_dynamic_module_callback_lb_get_member_update_host_address(
+        lb_envoy_ptr, i, false, &addr);
+    (void)found;
+  }
+
+  // Test out-of-bounds index.
+  envoy_dynamic_module_type_envoy_buffer oob_result = {NULL, 0};
+  bool oob = envoy_dynamic_module_callback_lb_get_member_update_host_address(
+      lb_envoy_ptr, num_hosts_added, true, &oob_result);
+  (void)oob;
+}
+
 void envoy_dynamic_module_on_lb_destroy(envoy_dynamic_module_type_lb_module_ptr lb_module_ptr) {
   free((void*)lb_module_ptr);
 }

--- a/test/extensions/dynamic_modules/test_data/c/lb_config_new_fail.c
+++ b/test/extensions/dynamic_modules/test_data/c/lb_config_new_fail.c
@@ -45,6 +45,16 @@ bool envoy_dynamic_module_on_lb_choose_host(
   return false;
 }
 
+void envoy_dynamic_module_on_lb_on_host_membership_update(
+    envoy_dynamic_module_type_lb_envoy_ptr lb_envoy_ptr,
+    envoy_dynamic_module_type_lb_module_ptr lb_module_ptr, size_t num_hosts_added,
+    size_t num_hosts_removed) {
+  (void)lb_envoy_ptr;
+  (void)lb_module_ptr;
+  (void)num_hosts_added;
+  (void)num_hosts_removed;
+}
+
 void envoy_dynamic_module_on_lb_destroy(envoy_dynamic_module_type_lb_module_ptr lb_module_ptr) {
   (void)lb_module_ptr;
 }

--- a/test/extensions/dynamic_modules/test_data/c/lb_invalid_host_index.c
+++ b/test/extensions/dynamic_modules/test_data/c/lb_invalid_host_index.c
@@ -49,6 +49,16 @@ bool envoy_dynamic_module_on_lb_choose_host(
   return true;
 }
 
+void envoy_dynamic_module_on_lb_on_host_membership_update(
+    envoy_dynamic_module_type_lb_envoy_ptr lb_envoy_ptr,
+    envoy_dynamic_module_type_lb_module_ptr lb_module_ptr, size_t num_hosts_added,
+    size_t num_hosts_removed) {
+  (void)lb_envoy_ptr;
+  (void)lb_module_ptr;
+  (void)num_hosts_added;
+  (void)num_hosts_removed;
+}
+
 void envoy_dynamic_module_on_lb_destroy(envoy_dynamic_module_type_lb_module_ptr lb_module_ptr) {
   (void)lb_module_ptr;
 }

--- a/test/extensions/dynamic_modules/test_data/c/lb_invalid_priority.c
+++ b/test/extensions/dynamic_modules/test_data/c/lb_invalid_priority.c
@@ -49,6 +49,16 @@ bool envoy_dynamic_module_on_lb_choose_host(
   return true;
 }
 
+void envoy_dynamic_module_on_lb_on_host_membership_update(
+    envoy_dynamic_module_type_lb_envoy_ptr lb_envoy_ptr,
+    envoy_dynamic_module_type_lb_module_ptr lb_module_ptr, size_t num_hosts_added,
+    size_t num_hosts_removed) {
+  (void)lb_envoy_ptr;
+  (void)lb_module_ptr;
+  (void)num_hosts_added;
+  (void)num_hosts_removed;
+}
+
 void envoy_dynamic_module_on_lb_destroy(envoy_dynamic_module_type_lb_module_ptr lb_module_ptr) {
   (void)lb_module_ptr;
 }

--- a/test/extensions/dynamic_modules/test_data/c/lb_new_fail.c
+++ b/test/extensions/dynamic_modules/test_data/c/lb_new_fail.c
@@ -47,6 +47,16 @@ bool envoy_dynamic_module_on_lb_choose_host(
   return false;
 }
 
+void envoy_dynamic_module_on_lb_on_host_membership_update(
+    envoy_dynamic_module_type_lb_envoy_ptr lb_envoy_ptr,
+    envoy_dynamic_module_type_lb_module_ptr lb_module_ptr, size_t num_hosts_added,
+    size_t num_hosts_removed) {
+  (void)lb_envoy_ptr;
+  (void)lb_module_ptr;
+  (void)num_hosts_added;
+  (void)num_hosts_removed;
+}
+
 void envoy_dynamic_module_on_lb_destroy(envoy_dynamic_module_type_lb_module_ptr lb_module_ptr) {
   (void)lb_module_ptr;
 }

--- a/test/extensions/dynamic_modules/test_data/c/lb_round_robin.c
+++ b/test/extensions/dynamic_modules/test_data/c/lb_round_robin.c
@@ -65,6 +65,16 @@ bool envoy_dynamic_module_on_lb_choose_host(
   return true;
 }
 
+void envoy_dynamic_module_on_lb_on_host_membership_update(
+    envoy_dynamic_module_type_lb_envoy_ptr lb_envoy_ptr,
+    envoy_dynamic_module_type_lb_module_ptr lb_module_ptr, size_t num_hosts_added,
+    size_t num_hosts_removed) {
+  (void)lb_envoy_ptr;
+  (void)lb_module_ptr;
+  (void)num_hosts_added;
+  (void)num_hosts_removed;
+}
+
 void envoy_dynamic_module_on_lb_destroy(envoy_dynamic_module_type_lb_module_ptr lb_module_ptr) {
   free((void*)lb_module_ptr);
 }

--- a/test/extensions/load_balancing_policies/dynamic_modules/config_test.cc
+++ b/test/extensions/load_balancing_policies/dynamic_modules/config_test.cc
@@ -551,6 +551,10 @@ TEST_F(DynamicModulesLoadBalancerTest, AbiCallbacksWithNullPointers) {
   // Test override host context callback with null.
   EXPECT_FALSE(
       envoy_dynamic_module_callback_lb_context_get_override_host(nullptr, nullptr, nullptr));
+
+  // Test member update host address callback with null.
+  EXPECT_FALSE(
+      envoy_dynamic_module_callback_lb_get_member_update_host_address(nullptr, 0, true, &result));
 }
 
 TEST_F(DynamicModulesLoadBalancerTest, AbiCallbacksWithInvalidPriority) {
@@ -1522,6 +1526,144 @@ TEST_F(DynamicModulesLoadBalancerTest, CallbacksTestModuleExercisesNewCallbacks)
 
   auto response = lb->chooseHost(&context);
   EXPECT_NE(response.host, nullptr);
+}
+
+// =============================================================================
+// Host Membership Update Tests
+// =============================================================================
+
+TEST_F(DynamicModulesLoadBalancerTest, HostMembershipUpdateNotifiesModule) {
+  envoy::extensions::load_balancing_policies::dynamic_modules::v3::DynamicModulesLoadBalancerConfig
+      config;
+  config.mutable_dynamic_module_config()->set_name("lb_callbacks_test");
+  config.set_lb_policy_name("test_lb");
+
+  Factory factory;
+  auto lb_config_or_error = factory.loadConfig(factory_context_, config);
+  ASSERT_TRUE(lb_config_or_error.ok());
+
+  auto thread_aware_lb =
+      factory.create(OptRef<const Upstream::LoadBalancerConfig>(*lb_config_or_error.value()),
+                     cluster_info_, priority_set_, runtime_, random_, time_source_);
+  ASSERT_NE(thread_aware_lb, nullptr);
+  ASSERT_TRUE(thread_aware_lb->initialize().ok());
+
+  Upstream::LoadBalancerParams params{priority_set_, nullptr};
+  auto lb = thread_aware_lb->factory()->create(params);
+  ASSERT_NE(lb, nullptr);
+
+  // Trigger a host membership update with hosts added and removed.
+  auto new_host = std::make_shared<NiceMock<Upstream::MockHost>>();
+  auto new_addr = Network::Utility::parseInternetAddressNoThrow("10.0.0.4", 8080, false);
+  ON_CALL(*new_host, address()).WillByDefault(Return(new_addr));
+
+  Upstream::HostVector hosts_added = {new_host};
+  Upstream::HostVector hosts_removed = {host3_};
+
+  priority_set_.runUpdateCallbacks(0, hosts_added, hosts_removed);
+
+  // Verify the LB still works after the update.
+  auto response = lb->chooseHost(nullptr);
+  EXPECT_NE(response.host, nullptr);
+}
+
+TEST_F(DynamicModulesLoadBalancerTest, HostMembershipUpdateEmptyVectors) {
+  envoy::extensions::load_balancing_policies::dynamic_modules::v3::DynamicModulesLoadBalancerConfig
+      config;
+  config.mutable_dynamic_module_config()->set_name("lb_round_robin");
+  config.set_lb_policy_name("test_lb");
+
+  Factory factory;
+  auto lb_config_or_error = factory.loadConfig(factory_context_, config);
+  ASSERT_TRUE(lb_config_or_error.ok());
+
+  auto thread_aware_lb =
+      factory.create(OptRef<const Upstream::LoadBalancerConfig>(*lb_config_or_error.value()),
+                     cluster_info_, priority_set_, runtime_, random_, time_source_);
+  ASSERT_NE(thread_aware_lb, nullptr);
+  ASSERT_TRUE(thread_aware_lb->initialize().ok());
+
+  Upstream::LoadBalancerParams params{priority_set_, nullptr};
+  auto lb = thread_aware_lb->factory()->create(params);
+  ASSERT_NE(lb, nullptr);
+
+  // Trigger an update with empty vectors (no hosts added or removed).
+  Upstream::HostVector empty_added;
+  Upstream::HostVector empty_removed;
+  priority_set_.runUpdateCallbacks(0, empty_added, empty_removed);
+
+  // Verify the LB still works after the no-op update.
+  auto response = lb->chooseHost(nullptr);
+  EXPECT_NE(response.host, nullptr);
+}
+
+TEST_F(DynamicModulesLoadBalancerTest, HostMembershipUpdateCallbackAddress) {
+  envoy::extensions::load_balancing_policies::dynamic_modules::v3::DynamicModulesLoadBalancerConfig
+      config;
+  config.mutable_dynamic_module_config()->set_name("lb_round_robin");
+  config.set_lb_policy_name("test_lb");
+
+  Factory factory;
+  auto lb_config_or_error = factory.loadConfig(factory_context_, config);
+  ASSERT_TRUE(lb_config_or_error.ok());
+
+  auto thread_aware_lb =
+      factory.create(OptRef<const Upstream::LoadBalancerConfig>(*lb_config_or_error.value()),
+                     cluster_info_, priority_set_, runtime_, random_, time_source_);
+  ASSERT_NE(thread_aware_lb, nullptr);
+  ASSERT_TRUE(thread_aware_lb->initialize().ok());
+
+  Upstream::LoadBalancerParams params{priority_set_, nullptr};
+  auto lb = thread_aware_lb->factory()->create(params);
+  ASSERT_NE(lb, nullptr);
+  auto* lb_ptr = static_cast<DynamicModuleLoadBalancer*>(lb.get());
+
+  // Verify host pointers are null when not in callback.
+  EXPECT_EQ(lb_ptr->hostsAdded(), nullptr);
+  EXPECT_EQ(lb_ptr->hostsRemoved(), nullptr);
+
+  // Verify the callback to get addresses returns false when not in an update callback.
+  envoy_dynamic_module_type_envoy_buffer result = {nullptr, 0};
+  EXPECT_FALSE(
+      envoy_dynamic_module_callback_lb_get_member_update_host_address(lb_ptr, 0, true, &result));
+  EXPECT_FALSE(
+      envoy_dynamic_module_callback_lb_get_member_update_host_address(lb_ptr, 0, false, &result));
+
+  // Verify null pointer handling.
+  EXPECT_FALSE(
+      envoy_dynamic_module_callback_lb_get_member_update_host_address(nullptr, 0, true, &result));
+  EXPECT_FALSE(
+      envoy_dynamic_module_callback_lb_get_member_update_host_address(lb_ptr, 0, true, nullptr));
+}
+
+TEST_F(DynamicModulesLoadBalancerTest, LbNewFailDoesNotRegisterCallback) {
+  envoy::extensions::load_balancing_policies::dynamic_modules::v3::DynamicModulesLoadBalancerConfig
+      config;
+  config.mutable_dynamic_module_config()->set_name("lb_new_fail");
+  config.set_lb_policy_name("test_lb");
+
+  Factory factory;
+  auto lb_config_or_error = factory.loadConfig(factory_context_, config);
+  ASSERT_TRUE(lb_config_or_error.ok());
+
+  auto thread_aware_lb =
+      factory.create(OptRef<const Upstream::LoadBalancerConfig>(*lb_config_or_error.value()),
+                     cluster_info_, priority_set_, runtime_, random_, time_source_);
+  ASSERT_NE(thread_aware_lb, nullptr);
+  ASSERT_TRUE(thread_aware_lb->initialize().ok());
+
+  Upstream::LoadBalancerParams params{priority_set_, nullptr};
+  auto lb = thread_aware_lb->factory()->create(params);
+  ASSERT_NE(lb, nullptr);
+
+  // Triggering an update should be safe even when on_lb_new returned null.
+  Upstream::HostVector empty_added;
+  Upstream::HostVector empty_removed;
+  priority_set_.runUpdateCallbacks(0, empty_added, empty_removed);
+
+  // chooseHost should return null since the module failed to initialize.
+  auto response = lb->chooseHost(nullptr);
+  EXPECT_EQ(response.host, nullptr);
 }
 
 } // namespace


### PR DESCRIPTION
## Description

This PR adds host membership update notifications for the Load Balancing Dynamic Module.

---

**Commit Message:** dynamic_modules: added host membership update notifications for LB
**Additional Description:** Added host membership update notifications for the Load Balancing Dynamic Module.
**Risk Level:** Low
**Testing:** Added Tests
**Docs Changes:** Added
**Release Notes:** N/A