### PR TITLE
memory: added methods to MemoryAllocatorManager for fine-grained control of tcmalloc

### DIFF
--- a/api/envoy/config/bootstrap/v3/bootstrap.proto
+++ b/api/envoy/config/bootstrap/v3/bootstrap.proto
@@ -774,6 +774,7 @@ message CustomInlineHeader {
   InlineHeaderType inline_header_type = 2 [(validate.rules).enum = {defined_only: true}];
 }
 
+// [#next-free-field: 6]
 message MemoryAllocatorManager {
   // Configures tcmalloc to perform background release of free memory in amount of bytes per ``memory_release_interval`` interval.
   // If equals to ``0``, no memory release will occur. Defaults to ``0``.
@@ -783,4 +784,29 @@ message MemoryAllocatorManager {
   // interval Envoy will try to release ``bytes_to_release`` of free memory back to operating system for reuse.
   // Defaults to ``1000`` milliseconds.
   google.protobuf.Duration memory_release_interval = 2;
+
+  // Sets the soft memory limit for tcmalloc. When the total memory used by tcmalloc exceeds this
+  // limit, background release will be performed more aggressively to bring memory usage below the
+  // limit. If not set, no soft memory limit is applied.
+  //
+  // .. note::
+  //     This is currently only supported with tcmalloc and not with ``gperftools``.
+  //
+  google.protobuf.UInt64Value soft_memory_limit_bytes = 3;
+
+  // Sets the maximum per-CPU cache size in bytes for tcmalloc. Smaller values reduce per-CPU
+  // memory overhead at the cost of increased contention on the central free list. If not set,
+  // tcmalloc's default is used.
+  //
+  // .. note::
+  //     This is currently only supported with tcmalloc and not with ``gperftools``.
+  //
+  google.protobuf.UInt32Value max_per_cpu_cache_size_bytes = 4;
+
+  // The threshold of unfreed memory in bytes that triggers the heap shrinker to release memory
+  // back to the OS. When the difference between physical memory used and application-allocated
+  // memory exceeds this threshold, free memory is released.
+  //
+  // Defaults to ``104857600`` (100 MB).
+  uint64 max_unfreed_memory_bytes = 5;
 }

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -259,6 +259,11 @@ new_features:
   change: |
     Added dynamic module input matcher extension which would allow implementing custom matching logic
     in external languages (Rust, Go, C) via dynamic modules.
+- area: memory
+  change: |
+    Added ``soft_memory_limit_bytes``, ``max_per_cpu_cache_size_bytes``, and ``max_unfreed_memory_bytes``
+    fields to :ref:`MemoryAllocatorManager <envoy_v3_api_msg_config.bootstrap.v3.MemoryAllocatorManager>`
+    for fine-grained control of tcmalloc memory management.
 - area: dynamic_modules
   change: |
     Added :ref:`TLS certificate validator

--- a/source/common/memory/stats.cc
+++ b/source/common/memory/stats.cc
@@ -1,5 +1,6 @@
 #include "source/common/memory/stats.h"
 
+#include <atomic>
 #include <cstdint>
 
 #include "source/common/common/assert.h"
@@ -13,6 +14,18 @@
 
 namespace Envoy {
 namespace Memory {
+
+namespace {
+std::atomic<uint64_t> max_unfreed_memory_bytes{DEFAULT_MAX_UNFREED_MEMORY_BYTES};
+} // namespace
+
+uint64_t maxUnfreedMemoryBytes() {
+  return max_unfreed_memory_bytes.load(std::memory_order_relaxed);
+}
+
+void setMaxUnfreedMemoryBytes(uint64_t value) {
+  max_unfreed_memory_bytes.store(value, std::memory_order_relaxed);
+}
 
 uint64_t Stats::totalCurrentlyAllocated() {
 #if defined(TCMALLOC)
@@ -145,6 +158,7 @@ AllocatorManager::AllocatorManager(
       background_release_rate_bytes_per_second_(
           computeBackgroundReleaseRate(bytes_to_release_, memory_release_interval_msec_)),
       api_(api) {
+  configureTcmallocOptions(config);
   configureBackgroundMemoryRelease();
 };
 
@@ -160,6 +174,36 @@ AllocatorManager::~AllocatorManager() {
     tcmalloc::MallocExtension::SetBackgroundReleaseRate(
         tcmalloc::MallocExtension::BytesPerSecond{0});
     tcmalloc::MallocExtension::SetBackgroundProcessActionsEnabled(true);
+  }
+#endif
+}
+
+void AllocatorManager::configureTcmallocOptions(
+    const envoy::config::bootstrap::v3::MemoryAllocatorManager& config) {
+  if (config.max_unfreed_memory_bytes() > 0) {
+    setMaxUnfreedMemoryBytes(config.max_unfreed_memory_bytes());
+    ENVOY_LOG_MISC(info, "Set max unfreed memory threshold to {} bytes.",
+                   config.max_unfreed_memory_bytes());
+  }
+#if defined(TCMALLOC)
+  if (config.has_soft_memory_limit_bytes()) {
+    tcmalloc::MallocExtension::SetMemoryLimit(config.soft_memory_limit_bytes().value(),
+                                              tcmalloc::MallocExtension::LimitKind::kSoft);
+    ENVOY_LOG_MISC(info, "Set tcmalloc soft memory limit to {} bytes.",
+                   config.soft_memory_limit_bytes().value());
+  }
+  if (config.has_max_per_cpu_cache_size_bytes()) {
+    tcmalloc::MallocExtension::SetMaxPerCpuCacheSize(config.max_per_cpu_cache_size_bytes().value());
+    ENVOY_LOG_MISC(info, "Set tcmalloc max per-CPU cache size to {} bytes.",
+                   config.max_per_cpu_cache_size_bytes().value());
+  }
+#else
+  if (config.has_soft_memory_limit_bytes()) {
+    ENVOY_LOG_MISC(warn, "Soft memory limit is only supported with Google's tcmalloc, ignoring.");
+  }
+  if (config.has_max_per_cpu_cache_size_bytes()) {
+    ENVOY_LOG_MISC(warn,
+                   "Max per-CPU cache size is only supported with Google's tcmalloc, ignoring.");
   }
 #endif
 }

--- a/source/common/memory/stats.h
+++ b/source/common/memory/stats.h
@@ -11,6 +11,14 @@ namespace Envoy {
 namespace Memory {
 
 constexpr absl::string_view TCMALLOC_ROUTINE_THREAD_ID = "TcmallocProcessBackgroundActions";
+constexpr uint64_t DEFAULT_MAX_UNFREED_MEMORY_BYTES = 100 * 1024 * 1024;
+
+/**
+ * Accessors for the configurable max unfreed memory threshold. This value controls when
+ * tryShrinkHeap releases memory back to the OS. Defaults to 100 MB.
+ */
+uint64_t maxUnfreedMemoryBytes();
+void setMaxUnfreedMemoryBytes(uint64_t value);
 
 /**
  * Runtime stats for process memory usage.
@@ -68,7 +76,8 @@ public:
  * When configured with a non-zero release rate, a dedicated thread is started that runs
  * tcmalloc's ProcessBackgroundActions, which handles per-CPU cache reclamation, cache shuffling,
  * size class resizing, transfer cache plundering, and memory release to the OS at the configured
- * rate.
+ * rate. Also supports configuring a soft memory limit, per-CPU cache size, and the threshold
+ * for tryShrinkHeap.
  */
 class AllocatorManager {
 public:
@@ -84,6 +93,7 @@ private:
   Api::Api& api_;
   Thread::ThreadPtr tcmalloc_thread_;
   void configureBackgroundMemoryRelease();
+  void configureTcmallocOptions(const envoy::config::bootstrap::v3::MemoryAllocatorManager& config);
   // Used for testing.
   friend class AllocatorManagerPeer;
 };

--- a/source/common/memory/utils.cc
+++ b/source/common/memory/utils.cc
@@ -12,16 +12,9 @@
 namespace Envoy {
 namespace Memory {
 
-namespace {
-#if defined(TCMALLOC) || defined(GPERFTOOLS_TCMALLOC)
-// TODO(zyfjeff): Make max unfreed memory byte configurable
-constexpr uint64_t MAX_UNFREED_MEMORY_BYTE = 100 * 1024 * 1024;
-#endif
-} // namespace
-
 void Utils::releaseFreeMemory() {
 #if defined(TCMALLOC)
-  tcmalloc::MallocExtension::ReleaseMemoryToSystem(MAX_UNFREED_MEMORY_BYTE);
+  tcmalloc::MallocExtension::ReleaseMemoryToSystem(maxUnfreedMemoryBytes());
 #elif defined(GPERFTOOLS_TCMALLOC)
   MallocExtension::instance()->ReleaseFreeMemory();
 #endif
@@ -37,9 +30,10 @@ void Utils::tryShrinkHeap() {
 #if defined(TCMALLOC) || defined(GPERFTOOLS_TCMALLOC)
   auto total_physical_bytes = Stats::totalPhysicalBytes();
   auto allocated_size_by_app = Stats::totalCurrentlyAllocated();
+  const uint64_t threshold = maxUnfreedMemoryBytes();
 
   if (total_physical_bytes >= allocated_size_by_app &&
-      (total_physical_bytes - allocated_size_by_app) >= MAX_UNFREED_MEMORY_BYTE) {
+      (total_physical_bytes - allocated_size_by_app) >= threshold) {
     Utils::releaseFreeMemory();
   }
 #endif

--- a/test/common/memory/memory_release_test.cc
+++ b/test/common/memory/memory_release_test.cc
@@ -141,6 +141,68 @@ TEST_F(MemoryReleaseTest, BackgroundReleaseRateComputedCorrectly) {
 #endif
 }
 
+TEST_F(MemoryReleaseTest, MaxUnfreedMemoryBytesConfigured) {
+  EXPECT_EQ(DEFAULT_MAX_UNFREED_MEMORY_BYTES, maxUnfreedMemoryBytes());
+  const std::string yaml_config = R"EOF(
+  max_unfreed_memory_bytes: 52428800
+)EOF";
+  const auto proto_config =
+      TestUtility::parseYaml<envoy::config::bootstrap::v3::MemoryAllocatorManager>(yaml_config);
+  EXPECT_LOG_CONTAINS("info", "Set max unfreed memory threshold to 52428800 bytes.",
+                      allocator_manager_ =
+                          std::make_unique<Memory::AllocatorManager>(*api_, proto_config));
+  EXPECT_EQ(52428800, maxUnfreedMemoryBytes());
+  // Reset to default for other tests.
+  setMaxUnfreedMemoryBytes(DEFAULT_MAX_UNFREED_MEMORY_BYTES);
+}
+
+TEST_F(MemoryReleaseTest, MaxUnfreedMemoryBytesDefaultWhenZero) {
+  setMaxUnfreedMemoryBytes(DEFAULT_MAX_UNFREED_MEMORY_BYTES);
+  const std::string yaml_config = R"EOF(
+  max_unfreed_memory_bytes: 0
+)EOF";
+  const auto proto_config =
+      TestUtility::parseYaml<envoy::config::bootstrap::v3::MemoryAllocatorManager>(yaml_config);
+  EXPECT_LOG_NOT_CONTAINS("info", "Set max unfreed memory threshold",
+                          allocator_manager_ =
+                              std::make_unique<Memory::AllocatorManager>(*api_, proto_config));
+  EXPECT_EQ(DEFAULT_MAX_UNFREED_MEMORY_BYTES, maxUnfreedMemoryBytes());
+}
+
+TEST_F(MemoryReleaseTest, SoftMemoryLimitConfigured) {
+  const std::string yaml_config = R"EOF(
+  soft_memory_limit_bytes: 1073741824
+)EOF";
+  const auto proto_config =
+      TestUtility::parseYaml<envoy::config::bootstrap::v3::MemoryAllocatorManager>(yaml_config);
+#if defined(TCMALLOC)
+  EXPECT_LOG_CONTAINS("info", "Set tcmalloc soft memory limit to 1073741824 bytes.",
+                      allocator_manager_ =
+                          std::make_unique<Memory::AllocatorManager>(*api_, proto_config));
+#else
+  EXPECT_LOG_CONTAINS(
+      "warn", "Soft memory limit is only supported with Google's tcmalloc, ignoring.",
+      allocator_manager_ = std::make_unique<Memory::AllocatorManager>(*api_, proto_config));
+#endif
+}
+
+TEST_F(MemoryReleaseTest, MaxPerCpuCacheSizeConfigured) {
+  const std::string yaml_config = R"EOF(
+  max_per_cpu_cache_size_bytes: 2097152
+)EOF";
+  const auto proto_config =
+      TestUtility::parseYaml<envoy::config::bootstrap::v3::MemoryAllocatorManager>(yaml_config);
+#if defined(TCMALLOC)
+  EXPECT_LOG_CONTAINS("info", "Set tcmalloc max per-CPU cache size to 2097152 bytes.",
+                      allocator_manager_ =
+                          std::make_unique<Memory::AllocatorManager>(*api_, proto_config));
+#else
+  EXPECT_LOG_CONTAINS(
+      "warn", "Max per-CPU cache size is only supported with Google's tcmalloc, ignoring.",
+      allocator_manager_ = std::make_unique<Memory::AllocatorManager>(*api_, proto_config));
+#endif
+}
+
 } // namespace
 } // namespace Memory
 } // namespace Envoy

--- a/tools/spelling/spelling_dictionary.txt
+++ b/tools/spelling/spelling_dictionary.txt
@@ -1663,6 +1663,7 @@ cpuacct.usage
 cpufreq
 effective_cpus
 cpus
+shrinker
 ja3
 ja4
 jsonl


### PR DESCRIPTION
## Description

This PR adds `soft_memory_limit_bytes`, `max_per_cpu_cache_size_bytes`, and `max_unfreed_memory_bytes` fields to `MemoryAllocatorManager` for fine-grained control of tcmalloc memory management.

---

**Commit Message:** memory: added methods to MemoryAllocatorManager for fine-grained control of tcmalloc
**Additional Description:** Added new fields to `MemoryAllocatorManager` for fine-grained control of tcmalloc memory management.
**Risk Level**: Low
**Testing:** Added Tests
**Docs Changes:** Added
**Release Notes:** Added