### PR TITLE
Memory: configure and enforce unfreed memory threshold

### DIFF
--- a/api/envoy/config/bootstrap/v3/bootstrap.proto
+++ b/api/envoy/config/bootstrap/v3/bootstrap.proto
@@ -783,4 +783,10 @@ message MemoryAllocatorManager {
   // interval Envoy will try to release ``bytes_to_release`` of free memory back to operating system for reuse.
   // Defaults to ``1000`` milliseconds.
   google.protobuf.Duration memory_release_interval = 2;
+
+  // Minimum unfreed memory bytes threshold that triggers memory release during admin handler.
+  // If the unfreed memory bytes is less than this value, no memory release will occur.
+  // If set to ``0``, the threshold is disabled and memory release will be attempted whenever unfreed
+  // memory is available (subject to allocator support). Defaults to 100 MB.
+  google.protobuf.UInt64Value minimum_unfreed_memory_bytes_threshold = 3;
 }

--- a/envoy/server/BUILD
+++ b/envoy/server/BUILD
@@ -117,6 +117,7 @@ envoy_cc_library(
         ":hot_restart_interface",
         ":lifecycle_notifier_interface",
         ":listener_manager_interface",
+        ":memory_interface",
         ":options_interface",
         "//envoy/access_log:access_log_interface",
         "//envoy/api:api_interface",
@@ -146,6 +147,14 @@ envoy_cc_library(
         "//envoy/stats:stats_interface",
         "@envoy_api//envoy/admin/v3:pkg_cc_proto",
         "@envoy_api//envoy/config/bootstrap/v3:pkg_cc_proto",
+    ],
+)
+
+envoy_cc_library(
+    name = "memory_interface",
+    hdrs = ["memory.h"],
+    deps = [
+        "//envoy/common:pure_lib",
     ],
 )
 

--- a/envoy/server/instance.h
+++ b/envoy/server/instance.h
@@ -26,6 +26,7 @@
 #include "envoy/server/hot_restart.h"
 #include "envoy/server/lifecycle_notifier.h"
 #include "envoy/server/listener_manager.h"
+#include "envoy/server/memory.h"
 #include "envoy/server/options.h"
 #include "envoy/server/overload/overload_manager.h"
 #include "envoy/ssl/context_manager.h"
@@ -150,6 +151,11 @@ public:
    * @return the server's overload manager.
    */
   virtual OverloadManager& overloadManager() PURE;
+
+  /**
+   * @return the server's memory allocator manager.
+   */
+  virtual MemoryAllocatorManager& memoryAllocatorManager() PURE;
 
   /**
    * @return the server's null overload manager in case we want to skip overloading the server.

--- a/envoy/server/memory.h
+++ b/envoy/server/memory.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "envoy/common/pure.h"
+
+namespace Envoy {
+namespace Server {
+
+/**
+ * Interface for managing the memory allocator.
+ */
+class MemoryAllocatorManager {
+public:
+  virtual ~MemoryAllocatorManager() = default;
+
+  // Release free allocator memory to the OS when unused bytes exceed a configured threshold.
+  virtual void maybeReleaseFreeMemory() PURE;
+
+  // Release free allocator memory immediately (skip threshold check).
+  virtual void releaseFreeMemory() PURE;
+};
+
+} // namespace Server
+} // namespace Envoy

--- a/source/common/memory/BUILD
+++ b/source/common/memory/BUILD
@@ -21,6 +21,7 @@ envoy_cc_library(
     hdrs = ["stats.h"],
     tcmalloc_dep = 1,
     deps = [
+        "//envoy/server:memory_interface",
         "//envoy/stats:stats_macros",
         "//source/common/common:assert_lib",
         "//source/common/common:logger_lib",
@@ -45,8 +46,8 @@ envoy_cc_library(
     srcs = ["heap_shrinker.cc"],
     hdrs = ["heap_shrinker.h"],
     deps = [
-        ":utils_lib",
         "//envoy/event:dispatcher_interface",
+        "//envoy/server:memory_interface",
         "//envoy/server/overload:overload_manager_interface",
         "//envoy/stats:stats_interface",
         "//source/common/stats:symbol_table_lib",

--- a/source/common/memory/heap_shrinker.cc
+++ b/source/common/memory/heap_shrinker.cc
@@ -1,6 +1,5 @@
 #include "source/common/memory/heap_shrinker.h"
 
-#include "source/common/memory/utils.h"
 #include "source/common/stats/symbol_table.h"
 
 #include "absl/strings/str_cat.h"
@@ -12,7 +11,8 @@ namespace Memory {
 constexpr std::chrono::milliseconds kTimerInterval = std::chrono::milliseconds(10000);
 
 HeapShrinker::HeapShrinker(Event::Dispatcher& dispatcher, Server::OverloadManager& overload_manager,
-                           Stats::Scope& stats) {
+                           Stats::Scope& stats, Server::MemoryAllocatorManager& allocator_manager)
+    : allocator_manager_(allocator_manager) {
   const auto action_name = Server::OverloadActionNames::get().ShrinkHeap;
   if (overload_manager.registerForAction(
           action_name, dispatcher,
@@ -30,7 +30,7 @@ HeapShrinker::HeapShrinker(Event::Dispatcher& dispatcher, Server::OverloadManage
 
 void HeapShrinker::shrinkHeap() {
   if (active_) {
-    Utils::releaseFreeMemory();
+    allocator_manager_.releaseFreeMemory();
     shrink_counter_->inc();
   }
 }

--- a/source/common/memory/heap_shrinker.h
+++ b/source/common/memory/heap_shrinker.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "envoy/event/dispatcher.h"
+#include "envoy/server/memory.h"
 #include "envoy/server/overload/overload_manager.h"
 #include "envoy/stats/scope.h"
 #include "envoy/stats/stats.h"
@@ -15,7 +16,7 @@ namespace Memory {
 class HeapShrinker {
 public:
   HeapShrinker(Event::Dispatcher& dispatcher, Server::OverloadManager& overload_manager,
-               Envoy::Stats::Scope& stats);
+               Envoy::Stats::Scope& stats, Server::MemoryAllocatorManager& allocator_manager);
 
 private:
   void shrinkHeap();
@@ -23,6 +24,7 @@ private:
   bool active_{false};
   Envoy::Stats::Counter* shrink_counter_;
   Envoy::Event::TimerPtr timer_;
+  Server::MemoryAllocatorManager& allocator_manager_;
 };
 
 } // namespace Memory

--- a/source/common/memory/stats.cc
+++ b/source/common/memory/stats.cc
@@ -127,6 +127,8 @@ AllocatorManager::AllocatorManager(
     : bytes_to_release_(config.bytes_to_release()),
       memory_release_interval_msec_(std::chrono::milliseconds(
           PROTOBUF_GET_MS_OR_DEFAULT(config, memory_release_interval, 1000))),
+      minimum_unfreed_memory_bytes_threshold_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(
+          config, minimum_unfreed_memory_bytes_threshold, 100 * 1024 * 1024)),
       allocator_manager_stats_(MemoryAllocatorManagerStats{
           MEMORY_ALLOCATOR_MANAGER_STATS(POOL_COUNTER_PREFIX(scope, "tcmalloc."))}),
       api_(api) {
@@ -148,6 +150,25 @@ AllocatorManager::~AllocatorManager() {
 void AllocatorManager::tcmallocRelease() {
 #if defined(TCMALLOC)
   tcmalloc::MallocExtension::ReleaseMemoryToSystem(bytes_to_release_);
+#endif
+}
+
+void AllocatorManager::releaseFreeMemory() {
+#if defined(TCMALLOC)
+  tcmallocRelease();
+#elif defined(GPERFTOOLS_TCMALLOC)
+  MallocExtension::instance()->ReleaseFreeMemory();
+#endif
+}
+
+void AllocatorManager::maybeReleaseFreeMemory() {
+#if defined(TCMALLOC) || defined(GPERFTOOLS_TCMALLOC)
+  auto total_physical_bytes = Stats::totalPhysicalBytes();
+  auto allocated_size_by_app = Stats::totalCurrentlyAllocated();
+  if (total_physical_bytes >= allocated_size_by_app &&
+      (total_physical_bytes - allocated_size_by_app) >= minimum_unfreed_memory_bytes_threshold_) {
+    releaseFreeMemory();
+  }
 #endif
 }
 

--- a/source/common/memory/stats.h
+++ b/source/common/memory/stats.h
@@ -3,6 +3,7 @@
 #include <cstdint>
 
 #include "envoy/config/bootstrap/v3/bootstrap.pb.h"
+#include "envoy/server/memory.h"
 #include "envoy/stats/store.h"
 
 #include "source/common/common/thread.h"
@@ -71,16 +72,23 @@ public:
   static absl::optional<std::string> dumpStats();
 };
 
-class AllocatorManager {
+class AllocatorManager : public Envoy::Server::MemoryAllocatorManager {
 public:
   AllocatorManager(Api::Api& api, Envoy::Stats::Scope& scope,
                    const envoy::config::bootstrap::v3::MemoryAllocatorManager& config);
 
   ~AllocatorManager();
 
+  // Release free allocator memory to the OS when unused bytes exceed a configured threshold.
+  void maybeReleaseFreeMemory() override;
+
+  // Release free allocator memory immediately (skip threshold check).
+  void releaseFreeMemory() override;
+
 private:
   const uint64_t bytes_to_release_;
   const std::chrono::milliseconds memory_release_interval_msec_;
+  const uint64_t minimum_unfreed_memory_bytes_threshold_;
   MemoryAllocatorManagerStats allocator_manager_stats_;
   Api::Api& api_;
   Thread::ThreadPtr tcmalloc_thread_;

--- a/source/server/admin/admin.cc
+++ b/source/server/admin/admin.cc
@@ -30,7 +30,6 @@
 #include "source/common/http/header_map_impl.h"
 #include "source/common/http/headers.h"
 #include "source/common/listener_manager/listener_impl.h"
-#include "source/common/memory/utils.h"
 #include "source/common/network/listen_socket_impl.h"
 #include "source/common/protobuf/protobuf.h"
 #include "source/common/protobuf/utility.h"
@@ -393,7 +392,7 @@ Http::Code AdminImpl::runCallback(Http::ResponseHeaderMap& response_headers,
   do {
     more_data = request->nextChunk(response);
   } while (more_data);
-  Memory::Utils::tryShrinkHeap();
+  server_.memoryAllocatorManager().maybeReleaseFreeMemory();
   return code;
 }
 

--- a/source/server/config_validation/server.h
+++ b/source/server/config_validation/server.h
@@ -106,6 +106,7 @@ public:
   Singleton::Manager& singletonManager() override { return singleton_manager_; }
   OverloadManager& overloadManager() override { return *overload_manager_; }
   OverloadManager& nullOverloadManager() override { return *null_overload_manager_; }
+  MemoryAllocatorManager& memoryAllocatorManager() override { return memory_allocator_manager_; }
   bool healthCheckFailed() override { return false; }
   const Options& options() override { return options_; }
   time_t startTimeCurrentEpoch() override { PANIC("not implemented"); }
@@ -157,6 +158,12 @@ public:
   }
 
 private:
+  class NoopMemoryAllocatorManager : public MemoryAllocatorManager {
+  public:
+    void maybeReleaseFreeMemory() override {}
+    void releaseFreeMemory() override {}
+  };
+
   void initialize(const Options& options,
                   const Network::Address::InstanceConstSharedPtr& local_address,
                   ComponentFactory& component_factory);
@@ -195,6 +202,7 @@ private:
   std::unique_ptr<ListenerManager> listener_manager_;
   std::unique_ptr<OverloadManager> overload_manager_;
   std::unique_ptr<OverloadManager> null_overload_manager_;
+  NoopMemoryAllocatorManager memory_allocator_manager_;
   MutexTracer* mutex_tracer_{nullptr};
   Grpc::ContextImpl grpc_context_;
   Http::ContextImpl http_context_;

--- a/source/server/instance_impl.cc
+++ b/source/server/instance_impl.cc
@@ -8,8 +8,8 @@
 namespace Envoy {
 namespace Server {
 void InstanceImpl::maybeCreateHeapShrinker() {
-  heap_shrinker_ =
-      std::make_unique<Memory::HeapShrinker>(dispatcher(), overloadManager(), *stats().rootScope());
+  heap_shrinker_ = std::make_unique<Memory::HeapShrinker>(
+      dispatcher(), overloadManager(), *stats().rootScope(), memoryAllocatorManager());
 }
 
 absl::StatusOr<std::unique_ptr<OverloadManager>> InstanceImpl::createOverloadManager() {

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -16,6 +16,7 @@
 #include "envoy/server/drain_manager.h"
 #include "envoy/server/guarddog.h"
 #include "envoy/server/instance.h"
+#include "envoy/server/memory.h"
 #include "envoy/server/process_context.h"
 #include "envoy/server/tracer_config.h"
 #include "envoy/server/transport_socket_config.h"
@@ -290,6 +291,7 @@ public:
   Envoy::MutexTracer* mutexTracer() override { return mutex_tracer_; }
   OverloadManager& overloadManager() override { return *overload_manager_; }
   OverloadManager& nullOverloadManager() override { return *null_overload_manager_; }
+  Memory::AllocatorManager& memoryAllocatorManager() override { return *memory_allocator_manager_; }
   Runtime::Loader& runtime() override;
   void shutdown() override;
   bool isShutdown() final { return shutdown_; }
@@ -359,7 +361,8 @@ private:
   void loadServerFlags(const absl::optional<std::string>& flags_path);
   void startWorkers();
   void terminate();
-  void notifyCallbacksForStage(Stage stage, std::function<void()> completion_cb = [] {});
+  void notifyCallbacksForStage(
+      Stage stage, std::function<void()> completion_cb = [] {});
   void onRuntimeReady();
   void onClusterManagerPrimaryInitializationComplete();
   using LifecycleNotifierCallbacks = std::list<StageCallback>;

--- a/test/common/memory/BUILD
+++ b/test/common/memory/BUILD
@@ -46,6 +46,7 @@ envoy_cc_test(
         "//source/common/memory:stats_lib",
         "//test/common/stats:stat_test_utility_lib",
         "//test/mocks/event:event_mocks",
+        "//test/mocks/server:memory_mocks",
         "//test/mocks/server:overload_manager_mocks",
         "//test/test_common:simulated_time_system_lib",
         "//test/test_common:utility_lib",

--- a/test/common/memory/heap_shrinker_test.cc
+++ b/test/common/memory/heap_shrinker_test.cc
@@ -4,6 +4,7 @@
 
 #include "test/common/stats/stat_test_utility.h"
 #include "test/mocks/event/mocks.h"
+#include "test/mocks/server/memory.h"
 #include "test/mocks/server/overload_manager.h"
 #include "test/test_common/simulated_time_system.h"
 
@@ -34,6 +35,7 @@ protected:
   Api::ApiPtr api_;
   Event::DispatcherImpl dispatcher_;
   NiceMock<Server::MockOverloadManager> overload_manager_;
+  NiceMock<Server::MockMemoryAllocatorManager> allocator_manager_;
   Event::TimerCb timer_cb_;
 };
 
@@ -41,7 +43,8 @@ TEST_F(HeapShrinkerTest, DoNotShrinkWhenNotConfigured) {
   NiceMock<Event::MockDispatcher> dispatcher;
   EXPECT_CALL(overload_manager_, registerForAction(_, _, _)).WillOnce(Return(false));
   EXPECT_CALL(dispatcher, createTimer_(_)).Times(0);
-  HeapShrinker h(dispatcher, overload_manager_, *stats_.rootScope());
+  EXPECT_CALL(allocator_manager_, releaseFreeMemory()).Times(0);
+  HeapShrinker h(dispatcher, overload_manager_, *stats_.rootScope(), allocator_manager_);
 }
 
 TEST_F(HeapShrinkerTest, ShrinkWhenTriggered) {
@@ -52,7 +55,8 @@ TEST_F(HeapShrinkerTest, ShrinkWhenTriggered) {
         return true;
       }));
 
-  HeapShrinker h(dispatcher_, overload_manager_, *stats_.rootScope());
+  EXPECT_CALL(allocator_manager_, releaseFreeMemory()).Times(2);
+  HeapShrinker h(dispatcher_, overload_manager_, *stats_.rootScope(), allocator_manager_);
 
   auto data = std::make_unique<char[]>(5000000);
   const uint64_t physical_mem_before_shrink =

--- a/test/common/memory/memory_release_test.cc
+++ b/test/common/memory/memory_release_test.cc
@@ -1,3 +1,5 @@
+#include "envoy/common/exception.h"
+
 #include "source/common/event/dispatcher_impl.h"
 #include "source/common/memory/stats.h"
 
@@ -20,6 +22,9 @@ public:
   static uint64_t bytesToRelease(const AllocatorManager& allocator_manager) {
     return allocator_manager.bytes_to_release_;
   }
+  static uint64_t minimumUnfreedMemoryBytesThreshold(const AllocatorManager& allocator_manager) {
+    return allocator_manager.minimum_unfreed_memory_bytes_threshold_;
+  }
 };
 
 namespace {
@@ -32,19 +37,20 @@ protected:
       : api_(Api::createApiForTest(stats_, time_system_)),
         dispatcher_("test_thread", *api_, time_system_), scope_("memory_release_test.", stats_) {}
 
-  void initialiseAllocatorManager(uint64_t bytes_to_release, float release_interval_s) {
-    const std::string yaml_config = (release_interval_s > 0)
-                                        ? fmt::format(R"EOF(
-  bytes_to_release: {}
-  memory_release_interval: {}s
-)EOF",
-                                                      bytes_to_release, release_interval_s)
-                                        : fmt::format(R"EOF(
-  bytes_to_release: {}
-)EOF",
-                                                      bytes_to_release);
-    const auto proto_config =
-        TestUtility::parseYaml<envoy::config::bootstrap::v3::MemoryAllocatorManager>(yaml_config);
+  void initialiseAllocatorManager(uint64_t bytes_to_release, float release_interval_s = 0,
+                                  uint64_t unfreed_memory_bytes_threshold = 0) {
+    envoy::config::bootstrap::v3::MemoryAllocatorManager proto_config;
+    proto_config.set_bytes_to_release(bytes_to_release);
+    if (release_interval_s > 0) {
+      proto_config.mutable_memory_release_interval()->set_seconds(
+          static_cast<int64_t>(release_interval_s));
+    }
+
+    if (unfreed_memory_bytes_threshold > 0) {
+      proto_config.mutable_minimum_unfreed_memory_bytes_threshold()->set_value(
+          unfreed_memory_bytes_threshold);
+    }
+
     allocator_manager_ = std::make_unique<Memory::AllocatorManager>(*api_, scope_, proto_config);
   }
 
@@ -136,6 +142,77 @@ TEST_F(MemoryReleaseTest, ReleaseRateAboveZeroCustomIntervalMemoryReleased) {
   auto final_released_bytes = Stats::totalPageHeapUnmapped();
   EXPECT_LT(initial_unmapped_bytes, final_released_bytes);
 #endif
+}
+
+TEST_F(MemoryReleaseTest, CustomThresholdConfiguration) {
+  initialiseAllocatorManager(MB, 0);
+  EXPECT_EQ(100 * MB,
+            AllocatorManagerPeer::minimumUnfreedMemoryBytesThreshold(*allocator_manager_));
+
+  initialiseAllocatorManager(MB, 0, 200 * MB);
+  EXPECT_EQ(200 * MB,
+            AllocatorManagerPeer::minimumUnfreedMemoryBytesThreshold(*allocator_manager_));
+
+  initialiseAllocatorManager(MB, 0, 10 * MB);
+  EXPECT_EQ(10 * MB, AllocatorManagerPeer::minimumUnfreedMemoryBytesThreshold(*allocator_manager_));
+}
+
+TEST_F(MemoryReleaseTest, ReleaseFreeMemory) {
+#if !defined(TCMALLOC) && !defined(GPERFTOOLS_TCMALLOC)
+  GTEST_SKIP() << "Test requires tcmalloc or gperftools.";
+#endif
+  initialiseAllocatorManager(100 * MB, 0);
+  auto data = std::make_unique<unsigned char[]>(50 * MB);
+  data.reset();
+  auto unmapped_bytes_before_release = Stats::totalPageHeapUnmapped();
+  allocator_manager_->releaseFreeMemory();
+  auto unmapped_bytes_after_release = Stats::totalPageHeapUnmapped();
+  EXPECT_LT(unmapped_bytes_before_release, unmapped_bytes_after_release);
+}
+
+TEST_F(MemoryReleaseTest, MaybeReleaseFreeMemory) {
+#if !defined(TCMALLOC) && !defined(GPERFTOOLS_TCMALLOC)
+  GTEST_SKIP() << "Test requires tcmalloc or gperftools.";
+#endif
+  size_t initial_allocated_bytes = Stats::totalCurrentlyAllocated();
+  auto a = std::make_unique<uint32_t[]>(40 * MB);
+  auto b = std::make_unique<uint32_t[]>(40 * MB);
+  if (Stats::totalCurrentlyAllocated() <= initial_allocated_bytes) {
+    GTEST_SKIP() << "Skipping test, cannot measure memory usage precisely on this platform.";
+  }
+  const uint64_t threshold = 100 * MB;
+  initialiseAllocatorManager(200 * MB, 0, threshold);
+  EXPECT_EQ(threshold,
+            AllocatorManagerPeer::minimumUnfreedMemoryBytesThreshold(*allocator_manager_));
+
+  // Release any remaining free memory to start fresh.
+  allocator_manager_->releaseFreeMemory();
+
+  // Allocate 150MB using 100KB chunks as allocating large chunk directly as it is returned back to
+  // the system immediately on release.
+  std::vector<std::unique_ptr<unsigned char[]>> chunks;
+  const uint64_t chunk_size = 100 * 1024; // 100KB
+  const int num_chunks = (150 * MB) / chunk_size;
+  for (int i = 0; i < num_chunks; ++i) {
+    chunks.push_back(std::make_unique<unsigned char[]>(chunk_size));
+  }
+  chunks.clear();
+  auto unmapped_bytes_before_release = Stats::totalPageHeapUnmapped();
+  allocator_manager_->maybeReleaseFreeMemory();
+  auto unmapped_bytes_after_release = Stats::totalPageHeapUnmapped();
+  EXPECT_LT(unmapped_bytes_before_release, unmapped_bytes_after_release);
+
+  // Don't release memory if the threshold is not met.
+  // Allocate 10MB using 100KB chunks
+  const int num_chunks_small = (10 * MB) / chunk_size; // 102 chunks
+  for (int i = 0; i < num_chunks_small; ++i) {
+    chunks.push_back(std::make_unique<unsigned char[]>(chunk_size));
+  }
+  chunks.clear();
+  unmapped_bytes_before_release = Stats::totalPageHeapUnmapped();
+  allocator_manager_->maybeReleaseFreeMemory();
+  unmapped_bytes_after_release = Stats::totalPageHeapUnmapped();
+  EXPECT_EQ(unmapped_bytes_before_release, unmapped_bytes_after_release);
 }
 
 } // namespace

--- a/test/mocks/server/BUILD
+++ b/test/mocks/server/BUILD
@@ -38,6 +38,16 @@ envoy_cc_mock(
 )
 
 envoy_cc_mock(
+    name = "memory_mocks",
+    srcs = ["memory.cc"],
+    hdrs = ["memory.h"],
+    deps = [
+        "//envoy/common:base_includes",
+        "//envoy/server:memory_interface",
+    ],
+)
+
+envoy_cc_mock(
     name = "fatal_action_factory_mocks",
     hdrs = ["fatal_action_factory.h"],
     deps = [
@@ -184,6 +194,7 @@ envoy_cc_mock(
     hdrs = ["instance.h"],
     rbe_pool = "6gig",
     deps = [
+        ":memory_mocks",
         ":server_factory_context_mocks",
         "//envoy/server:instance_interface",
         "//source/common/secret:secret_manager_impl_lib",

--- a/test/mocks/server/instance.h
+++ b/test/mocks/server/instance.h
@@ -4,6 +4,7 @@
 
 #include "test/mocks/config/xds_manager.h"
 #include "test/mocks/http/http_server_properties_cache.h"
+#include "test/mocks/server/memory.h"
 #include "test/mocks/server/server_factory_context.h"
 
 #include "gmock/gmock.h"
@@ -42,6 +43,7 @@ public:
   MOCK_METHOD(OverloadManager&, overloadManager, ());
   MOCK_METHOD(OverloadManager&, nullOverloadManager, ());
   MOCK_METHOD(bool, shouldBypassOverloadManager, (), (const));
+  MemoryAllocatorManager& memoryAllocatorManager() override { return memory_allocator_manager_; }
   MOCK_METHOD(Runtime::Loader&, runtime, ());
   MOCK_METHOD(void, shutdown, ());
   MOCK_METHOD(bool, isShutdown, ());
@@ -64,7 +66,7 @@ public:
   MOCK_METHOD(Configuration::ServerFactoryContext&, serverFactoryContext, ());
   MOCK_METHOD(Configuration::TransportSocketFactoryContext&, transportSocketFactoryContext, ());
   MOCK_METHOD(bool, enableReusePortDefault, ());
-  MOCK_METHOD(void, setSinkPredicates, (std::unique_ptr<Envoy::Stats::SinkPredicates>&&));
+  MOCK_METHOD(void, setSinkPredicates, (std::unique_ptr<Envoy::Stats::SinkPredicates> &&));
 
   void setDefaultTracingConfig(const envoy::config::trace::v3::Tracing& tracing_config) override {
     http_context_.setDefaultTracingConfig(tracing_config);
@@ -99,6 +101,7 @@ public:
   testing::NiceMock<MockListenerManager> listener_manager_;
   testing::NiceMock<MockOverloadManager> overload_manager_;
   testing::NiceMock<MockOverloadManager> null_overload_manager_;
+  testing::NiceMock<MockMemoryAllocatorManager> memory_allocator_manager_;
   Singleton::ManagerPtr singleton_manager_;
   Grpc::ContextImpl grpc_context_;
   Http::ContextImpl http_context_;

--- a/test/mocks/server/memory.cc
+++ b/test/mocks/server/memory.cc
@@ -1,0 +1,14 @@
+#include "test/mocks/server/memory.h"
+
+namespace Envoy {
+namespace Server {
+
+MockMemoryAllocatorManager::MockMemoryAllocatorManager() {
+  ON_CALL(*this, maybeReleaseFreeMemory).WillByDefault(testing::Return());
+  ON_CALL(*this, releaseFreeMemory).WillByDefault(testing::Return());
+}
+
+MockMemoryAllocatorManager::~MockMemoryAllocatorManager() = default;
+
+} // namespace Server
+} // namespace Envoy

--- a/test/mocks/server/memory.h
+++ b/test/mocks/server/memory.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "envoy/server/memory.h"
+
+#include "gmock/gmock.h"
+
+namespace Envoy {
+namespace Server {
+
+class MockMemoryAllocatorManager : public MemoryAllocatorManager {
+public:
+  MockMemoryAllocatorManager();
+  ~MockMemoryAllocatorManager() override;
+
+  MOCK_METHOD(void, maybeReleaseFreeMemory, ());
+  MOCK_METHOD(void, releaseFreeMemory, ());
+};
+
+} // namespace Server
+} // namespace Envoy


### PR DESCRIPTION
Commit Message:  Currently xds and admin can trigger memory release from either of the allocators by invoking the utils static APIs. These APIs have static thresholds today, making it difficult to configure the limits using bootstrap configuration.

In production, our xds configs have large footprints causing memory churns over 800MB. Repeated churns cause tcmalloc central collector stalls due to large cleanup operations (especially gperftools), impacting worker threads waiting for memory from central free list due to thread cache exhaustion.

This PR introduces a configurable minimum_unfreed_memory_bytes_threshold to the MemoryAllocatorManager bootstrap configuration. Memory release is only triggered when unfreed memory exceeds this threshold, defaulting to 100MB. Setting it to 0 disables the threshold check.

This is the first PR in a stack, scoped to core threshold configuration and enforcement. Follow-up PRs will pass `MemoryAllocatorManager` through the subscription factory, gRPC mux, and xDS manager, and remove the remaining static Memory::Utils calls.

Split from #41892 for easier review.

Additional Description: NA
Risk Level: Low
Testing: Unit test
Docs Changes: NA
Release Notes: NA
Platform Specific Features: NA