### PR TITLE
http: Fix flaky router integ test

### DIFF
--- a/test/common/router/config_impl_integration_test.cc
+++ b/test/common/router/config_impl_integration_test.cc
@@ -250,6 +250,7 @@ TEST_P(WeightedClusterHashPolicyIntegrationTest, SameUserIdGoesToSameUpstream) {
 
     ASSERT_TRUE(response->waitForEndStream());
     EXPECT_TRUE(response->complete());
+    ASSERT_TRUE(fake_upstream_connection->waitForDisconnect());
     EXPECT_EQ("200", response->headers().getStatusValue());
 
     // Verify consistency - same user should always go to same upstream
@@ -315,6 +316,7 @@ TEST_P(WeightedClusterHashPolicyIntegrationTest, DifferentUserIdsCanGoToDifferen
 
     ASSERT_TRUE(response->waitForEndStream());
     EXPECT_TRUE(response->complete());
+    ASSERT_TRUE(fake_upstream_connection->waitForDisconnect());
     EXPECT_EQ("200", response->headers().getStatusValue());
 
     user_to_upstream[user_id] = current_upstream;
@@ -380,6 +382,7 @@ TEST_P(WeightedClusterHashPolicyIntegrationTest, WeightedDistributionTest) {
 
     ASSERT_TRUE(response->waitForEndStream());
     EXPECT_TRUE(response->complete());
+    ASSERT_TRUE(fake_upstream_connection->waitForDisconnect());
     EXPECT_EQ("200", response->headers().getStatusValue());
 
     upstream_counts[current_upstream]++;


### PR DESCRIPTION
## Commit Message
Fix flaky router integ test usually surfaced as a segfault under asan

## Additional Description
https://github.com/aakugan/envoy/commit/4af388b81a737c08a37842b0d5daa28e03ecc8df

Caused because the integ test makes a seperate thread for the upstream connection and the sentinel frame callback has a ptr to the ServerConnectionImpl which is usually not the case for actual workflows -> only one thread.
After everything is shut down on the test thread the upstream thread can have a callback which crashes.

Ref: https://github.com/envoyproxy/envoy/actions/runs/22659006942/job/65674847129#step:19:751