### PR TITLE
Attempt admission control extension point for circuit breaker

### DIFF
--- a/api/envoy/config/cluster/v3/circuit_breaker.proto
+++ b/api/envoy/config/cluster/v3/circuit_breaker.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package envoy.config.cluster.v3;
 
 import "envoy/config/core/v3/base.proto";
+import "envoy/config/core/v3/extension.proto";
 import "envoy/type/v3/percent.proto";
 
 import "google/protobuf/wrappers.proto";
@@ -27,7 +28,7 @@ message CircuitBreakers {
 
   // A Thresholds defines CircuitBreaker settings for a
   // :ref:`RoutingPriority<envoy_v3_api_enum_config.core.v3.RoutingPriority>`.
-  // [#next-free-field: 9]
+  // [#next-free-field: 10]
   message Thresholds {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.api.v2.cluster.CircuitBreakers.Thresholds";
@@ -80,6 +81,22 @@ message CircuitBreakers {
     //    If this field is set, the retry budget will override any configured retry circuit
     //    breaker.
     RetryBudget retry_budget = 8;
+
+    // The attempt admission control extension admits or rejects candidate requests based on
+    // overall traffic patterns and load across the cluster at the given priority level.
+    // This field is optional.
+    //
+    // .. note::
+    //
+    //    If this field is set, the attempt admission control will override any configured
+    //    :ref:`max_retries <envoy_v3_api_field_config.cluster.v3.CircuitBreakers.Thresholds.max_retries>` or
+    //    :ref:`retry_budget <envoy_v3_api_field_config.cluster.v3.CircuitBreakers.Thresholds.retry_budget>`
+    //    circuit breakers.
+    //
+    //    In addition, extensions in this field may deny the initial attempt of a request.
+    //
+    // [#extension-category: envoy.attempt_admission_control]
+    core.v3.TypedExtensionConfig attempt_admission_control = 9;
 
     // If track_remaining is true, then stats will be published that expose
     // the number of resources remaining until the circuit breakers open. If

--- a/api/envoy/config/cluster/v3/circuit_breaker.proto
+++ b/api/envoy/config/cluster/v3/circuit_breaker.proto
@@ -94,8 +94,6 @@ message CircuitBreakers {
     //    circuit breakers.
     //
     //    In addition, extensions in this field may deny the initial attempt of a request.
-    //
-    // [#extension-category: envoy.attempt_admission_control]
     core.v3.TypedExtensionConfig attempt_admission_control = 9;
 
     // If track_remaining is true, then stats will be published that expose

--- a/envoy/upstream/BUILD
+++ b/envoy/upstream/BUILD
@@ -134,6 +134,17 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
+    name = "admission_control_interface",
+    hdrs = ["admission_control.h"],
+    deps = [
+        "//envoy/config:typed_config_interface",
+        "//envoy/protobuf:message_validator_interface",
+        "//envoy/stream_info:stream_info_interface",
+        "//envoy/upstream:types_interface",
+    ],
+)
+
+envoy_cc_library(
     name = "thread_local_cluster_interface",
     hdrs = ["thread_local_cluster.h"],
     deps = [
@@ -156,6 +167,7 @@ envoy_cc_library(
     name = "upstream_interface",
     hdrs = ["upstream.h"],
     deps = [
+        ":admission_control_interface",
         ":health_check_host_monitor_interface",
         ":locality_lib",
         ":resource_manager_interface",

--- a/envoy/upstream/admission_control.h
+++ b/envoy/upstream/admission_control.h
@@ -1,0 +1,180 @@
+#pragma once
+
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+
+#include "envoy/common/pure.h"
+#include "envoy/config/typed_config.h"
+#include "envoy/protobuf/message_validator.h"
+#include "envoy/stream_info/stream_info.h"
+
+#include "absl/types/optional.h"
+
+namespace Envoy {
+namespace Upstream {
+
+/**
+ * An admission controller that determines if an attempt should be allowed for a single stream.
+ * The controller is instantiated once for each stream, and is shared by all tries.
+ * The controller should be destroyed once a winning upstream try has been chosen to be proxied
+ downstream.
+ *
+ * A try is defined as a single attempt to send a request to the upstream.
+ * The lifecycle of a try is as follows:
+ * 1. The try is scheduled (possibly immediately)
+ * 2. The try is started, i.e. dispatched to an upstream connection pool.
+ * 3. (optional) The try is considered successful,
+      i.e. it is selected as the winning try to be proxied downstream.
+ * 3. The try is completed, either successfully or not:
+ *    a. Finished successfully (selected as winning try and upstream component complete)
+ *    b. Aborted due to started retry
+ *    c. Aborted due to non-retry reasons
+ *
+ * When the stream admission controller is destroyed, all outstanding tries are considered aborted.
+ *
+ * The controller needs to track the lifecycle of each try, retry or otherwise, so that it can
+ * make informed admission decisions, both within this stream and for other streams routed to the
+ same cluster.
+ */
+class AttemptStreamAdmissionController {
+public:
+  virtual ~AttemptStreamAdmissionController() = default;
+
+  /**
+   * Called when a try is started, i.e. issued to the upstream.
+   * The initial try is started immediately after the stream is routed to the cluster.
+   * Retries are only said to have started after any backoff elapses and the upstream
+   * request is sent to the connection pool.
+   *
+   * @param attempt_number the number of the try that started.
+   */
+  virtual void onTryStarted(uint32_t attempt_number) PURE;
+
+  /**
+   * Called when a try has succeeded.
+   * A try is said to have succeeded if it is picked as the winning try to
+   * be streamed to the downstream.
+   * This should be called immediately once the try is chosen
+   * as the final winning try for downstream consumption.
+   *
+   * This method must be called at most once, as only at most one try can win.
+   *
+   * @param attempt_number the number of the try that succeeded.
+   */
+  virtual void onTrySucceeded(uint32_t attempt_number) PURE;
+
+  /**
+   * Called when an upstream try previously marked as successful has
+   * completed the entire upstream component, and is no longer using any upstream resources.
+   *
+   * Note that the downstream may not yet be finished.
+   */
+  virtual void onSuccessfulTryFinished() PURE;
+
+  /**
+   * Called when a try has been aborted and the abort isn't due to an admitted retry for the try.
+   *
+   * There are many reasons why a try may be aborted, including:
+   * - The stream is reset by the downstream.
+   * - Multiple tries are in-flight and one has succeeded.
+   * - The retry buffer for replaying request data becomes full while a retry is scheduled but not
+   * yet started.
+   * - The upstream cluster is removed between tries when this try is scheduled, but not yet
+   * started.
+   * - The try had a stream timeout or reset.
+   *
+   * An aborted try is considered done, and will never be considered successful.
+   * However, an aborted try may be retried, for instance in the case of an upstream reset retry.
+   *
+   * @param attempt_number the number of the try that was aborted.
+   */
+  virtual void onTryAborted(uint32_t attempt_number) PURE;
+
+  /**
+   * Whether the initial attempt for this stream should be admitted.
+   *
+   * @return true if the intial attempt is admitted. False if the initial attempt is not admitted
+   * and the call should be cancelled before being materialized to the upstream.
+   */
+  virtual bool isInitialAttemptAdmitted() PURE;
+
+  /**
+   * Retrieves the details behind whether the initial attempt was admitted. Call only after calling
+   * `isInitialAttemptAdmitted` which may determine whether the initial attempt is admitted.
+   *
+   * @return the details behind whether the initial attempt was admitted.
+   */
+  virtual absl::string_view initialAttemptDetails() const PURE;
+
+  /**
+   * Called when the router wants to retry a previously-started try.
+   * If a retry is admitted, then it must be attempted.
+   * A try may only be retried once.
+   *
+   * @param previous_attempt_number the number of the try that the router wants to re-attempt.
+   * @param retry_attempt_number the number of the new retry attempt, valid only if the retry is
+   admitted.
+   *                             If admitted, the new try will begin in the "scheduled" phase.
+   * @param abort_previous_on_retry true if and only if the previous try isn't already aborted,
+                                    and accepting the proposed retry implies that the previous
+                                    try becomes aborted.
+   * @return true if and only if the retry is admitted.
+   */
+  virtual bool isAttemptAdmitted(uint32_t previous_attempt_number, uint32_t retry_attempt_number,
+                                 bool abort_previous_on_retry) PURE;
+};
+
+using AttemptStreamAdmissionControllerPtr = std::unique_ptr<AttemptStreamAdmissionController>;
+
+/**
+ * An admission controller that determines if an attempt should be allowed for a stream.
+ * The controller is instantiated once for the whole cluster, and is shared by all streams
+ * (across multiple threads).
+ *
+ * The role of the controller is to hand out attempt permits to streams which tracks attempts
+ * for that stream. No calls should materialize without a corresponding permit.
+ */
+class AttemptAdmissionController {
+public:
+  virtual ~AttemptAdmissionController() = default;
+
+  /**
+   * Create a new admission controller for a stream.
+   * This must be called when a stream is first routed to a cluster,
+   * before the first try is attempted.
+   *
+   * @param request_stream_info the stream info for the downstream.
+   */
+  virtual AttemptStreamAdmissionControllerPtr
+  createStreamAdmissionController(const StreamInfo::StreamInfo& request_stream_info) PURE;
+};
+
+using AttemptAdmissionControllerSharedPtr = std::shared_ptr<AttemptAdmissionController>;
+
+struct ClusterCircuitBreakersStats;
+
+/**
+ * Factory for AttemtpAdmissionController.
+ */
+class AttemptAdmissionControllerFactory : public Config::TypedFactory {
+public:
+  virtual AttemptAdmissionControllerSharedPtr
+  createAdmissionController(const Protobuf::Message& config,
+                            ProtobufMessage::ValidationVisitor& validation_visitor,
+                            Runtime::Loader& runtime, std::string runtime_key_prefix,
+                            const ClusterCircuitBreakersStats& cb_stats, Stats::Scope& scope) PURE;
+
+  std::string category() const override { return "envoy.retry_admission_control"; }
+};
+
+class AdmissionControl {
+public:
+  virtual ~AdmissionControl() = default;
+
+  virtual AttemptAdmissionControllerSharedPtr attempt() PURE;
+};
+
+} // namespace Upstream
+} // namespace Envoy

--- a/envoy/upstream/upstream.h
+++ b/envoy/upstream/upstream.h
@@ -22,6 +22,7 @@
 #include "envoy/ssl/context.h"
 #include "envoy/stats/scope.h"
 #include "envoy/stats/stats.h"
+#include "envoy/upstream/admission_control.h"
 #include "envoy/upstream/health_check_host_monitor.h"
 #include "envoy/upstream/locality.h"
 #include "envoy/upstream/outlier_detection.h"
@@ -1146,6 +1147,12 @@ public:
    *         a particular priority).
    */
   virtual ResourceManager& resourceManager(ResourcePriority priority) const PURE;
+
+  /**
+   * @return AdmissionControl& the attempt limiter to use for streams associated with this cluster
+   *         (at a particular priority) if it exists.
+   */
+  virtual OptRef<AdmissionControl> admissionControl(ResourcePriority priority) const PURE;
 
   /**
    * @return TransportSocketMatcher& the transport socket matcher associated

--- a/source/common/router/retry_state_impl.cc
+++ b/source/common/router/retry_state_impl.cc
@@ -25,12 +25,13 @@ bool clusterSupportsHttp3AndTcpFallback(const Upstream::ClusterInfo& cluster) {
          (cluster.features() & Upstream::ClusterInfo::Features::USE_ALPN);
 }
 
-std::unique_ptr<RetryStateImpl>
-RetryStateImpl::create(const RetryPolicy& route_policy, Http::RequestHeaderMap& request_headers,
-                       const Upstream::ClusterInfo& cluster, const VirtualCluster* vcluster,
-                       RouteStatsContextOptRef route_stats_context,
-                       Server::Configuration::CommonFactoryContext& context,
-                       Event::Dispatcher& dispatcher, Upstream::ResourcePriority priority) {
+std::unique_ptr<RetryStateImpl> RetryStateImpl::create(
+    const RetryPolicy& route_policy, Http::RequestHeaderMap& request_headers,
+    const Upstream::ClusterInfo& cluster, const VirtualCluster* vcluster,
+    RouteStatsContextOptRef route_stats_context,
+    Server::Configuration::CommonFactoryContext& context, Event::Dispatcher& dispatcher,
+    Upstream::ResourcePriority priority,
+    OptRef<Upstream::AttemptStreamAdmissionController> attempt_admission_controller) {
   std::unique_ptr<RetryStateImpl> ret;
 
   // We short circuit here and do not bother with an allocation if there is no chance we will retry.
@@ -40,11 +41,13 @@ RetryStateImpl::create(const RetryPolicy& route_policy, Http::RequestHeaderMap& 
   if (request_headers.EnvoyRetryOn() || request_headers.EnvoyRetryGrpcOn() ||
       route_policy.retryOn()) {
     ret.reset(new RetryStateImpl(route_policy, request_headers, cluster, vcluster,
-                                 route_stats_context, context, dispatcher, priority, false));
+                                 route_stats_context, context, dispatcher, priority, false,
+                                 attempt_admission_controller));
   } else if ((cluster.features() & Upstream::ClusterInfo::Features::HTTP3) &&
              Http::Utility::isSafeRequest(request_headers)) {
     ret.reset(new RetryStateImpl(route_policy, request_headers, cluster, vcluster,
-                                 route_stats_context, context, dispatcher, priority, true));
+                                 route_stats_context, context, dispatcher, priority, true,
+                                 attempt_admission_controller));
   }
 
   // Consume all retry related headers to avoid them being propagated to the upstream
@@ -59,13 +62,13 @@ RetryStateImpl::create(const RetryPolicy& route_policy, Http::RequestHeaderMap& 
   return ret;
 }
 
-RetryStateImpl::RetryStateImpl(const RetryPolicy& route_policy,
-                               Http::RequestHeaderMap& request_headers,
-                               const Upstream::ClusterInfo& cluster, const VirtualCluster* vcluster,
-                               RouteStatsContextOptRef route_stats_context,
-                               Server::Configuration::CommonFactoryContext& context,
-                               Event::Dispatcher& dispatcher, Upstream::ResourcePriority priority,
-                               bool auto_configured_for_http3)
+RetryStateImpl::RetryStateImpl(
+    const RetryPolicy& route_policy, Http::RequestHeaderMap& request_headers,
+    const Upstream::ClusterInfo& cluster, const VirtualCluster* vcluster,
+    RouteStatsContextOptRef route_stats_context,
+    Server::Configuration::CommonFactoryContext& context, Event::Dispatcher& dispatcher,
+    Upstream::ResourcePriority priority, bool auto_configured_for_http3,
+    OptRef<Upstream::AttemptStreamAdmissionController> attempt_admission_controller)
     : cluster_(cluster), vcluster_(vcluster), route_stats_context_(route_stats_context),
       runtime_(context.runtime()), random_(context.api().randomGenerator()),
       dispatcher_(dispatcher), time_source_(context.timeSource()),
@@ -74,9 +77,10 @@ RetryStateImpl::RetryStateImpl(const RetryPolicy& route_policy,
       retriable_status_codes_(route_policy.retriableStatusCodes()),
       retriable_headers_(route_policy.retriableHeaders()),
       reset_headers_(route_policy.resetHeaders()),
-      reset_max_interval_(route_policy.resetMaxInterval()), retry_on_(route_policy.retryOn()),
-      retries_remaining_(route_policy.numRetries()), priority_(priority),
-      auto_configured_for_http3_(auto_configured_for_http3) {
+      reset_max_interval_(route_policy.resetMaxInterval()),
+      attempt_admission_controller_(attempt_admission_controller),
+      retry_on_(route_policy.retryOn()), retries_remaining_(route_policy.numRetries()),
+      priority_(priority), auto_configured_for_http3_(auto_configured_for_http3) {
   if ((cluster.features() & Upstream::ClusterInfo::Features::HTTP3) &&
       Http::Utility::isSafeRequest(request_headers)) {
     // Because 0-RTT requests could be rejected because they are sent too early, and such requests
@@ -266,7 +270,8 @@ void RetryStateImpl::resetRetry() {
   }
 }
 
-RetryStatus RetryStateImpl::shouldRetry(RetryDecision would_retry, DoRetryCallback callback) {
+RetryStatus RetryStateImpl::shouldRetry(RetryDecision would_retry, DoRetryCallback callback,
+                                        bool abort_previous_on_retry) {
   // If a callback is armed from a previous shouldRetry and we don't need to
   // retry this particular request, we can infer that we did a retry earlier
   // and it was successful.
@@ -301,7 +306,8 @@ RetryStatus RetryStateImpl::shouldRetry(RetryDecision would_retry, DoRetryCallba
 
   retries_remaining_--;
 
-  if (!cluster_.resourceManager(priority_).retries().canCreate()) {
+  if (!attempt_admission_controller_.has_value() &&
+      !cluster_.resourceManager(priority_).retries().canCreate()) {
     cluster_.trafficStats()->upstream_rq_retry_overflow_.inc();
     if (vcluster_) {
       vcluster_->stats().upstream_rq_retry_overflow_.inc();
@@ -315,6 +321,20 @@ RetryStatus RetryStateImpl::shouldRetry(RetryDecision would_retry, DoRetryCallba
   if (!runtime_.snapshot().featureEnabled("upstream.use_retry", 100)) {
     return RetryStatus::No;
   }
+
+  if (attempt_admission_controller_.has_value() &&
+      !attempt_admission_controller_->isAttemptAdmitted(attempt_number_, attempt_number_ + 1,
+                                                        abort_previous_on_retry)) {
+    cluster_.trafficStats()->upstream_rq_retry_overflow_.inc();
+    if (vcluster_) {
+      vcluster_->stats().upstream_rq_retry_overflow_.inc();
+    }
+    if (route_stats_context_.has_value()) {
+      route_stats_context_->stats().upstream_rq_retry_overflow_.inc();
+    }
+    return RetryStatus::NoOverflow;
+  }
+  ++attempt_number_;
 
   ASSERT(!backoff_callback_ && !next_loop_callback_);
   cluster_.resourceManager(priority_).retries().inc();
@@ -353,8 +373,8 @@ RetryStatus RetryStateImpl::shouldRetryHeaders(const Http::ResponseHeaderMap& re
     }
   }
 
-  return shouldRetry(retry_decision,
-                     [disable_early_data, callback]() { callback(disable_early_data); });
+  return shouldRetry(
+      retry_decision, [disable_early_data, callback]() { callback(disable_early_data); }, true);
 }
 
 RetryStatus RetryStateImpl::shouldRetryReset(Http::StreamResetReason reset_reason,
@@ -365,7 +385,8 @@ RetryStatus RetryStateImpl::shouldRetryReset(Http::StreamResetReason reset_reaso
   bool disable_http3 = false;
   const RetryDecision retry_decision =
       wouldRetryFromReset(reset_reason, http3_used, disable_http3, upstream_request_started);
-  return shouldRetry(retry_decision, [disable_http3, callback]() { callback(disable_http3); });
+  return shouldRetry(
+      retry_decision, [disable_http3, callback]() { callback(disable_http3); }, false);
 }
 
 RetryStatus RetryStateImpl::shouldHedgeRetryPerTryTimeout(DoRetryCallback callback) {
@@ -376,7 +397,7 @@ RetryStatus RetryStateImpl::shouldHedgeRetryPerTryTimeout(DoRetryCallback callba
   // retries are associated with a stream reset which is analogous to a gateway
   // error. When hedging on per try timeout is enabled, however, there is no
   // stream reset.
-  return shouldRetry(RetryState::RetryDecision::RetryWithBackoff, callback);
+  return shouldRetry(RetryState::RetryDecision::RetryWithBackoff, callback, false);
 }
 
 RetryState::RetryDecision

--- a/source/common/router/retry_state_impl.h
+++ b/source/common/router/retry_state_impl.h
@@ -140,7 +140,7 @@ private:
   std::vector<ResetHeaderParserSharedPtr> reset_headers_{};
   std::chrono::milliseconds reset_max_interval_{};
   // This may be unset if no attempt admission controller extensions are configured.
-  // If this is set, then we defer to the attempt admission controller in leiu of the circuit
+  // If this is set, then we defer to the attempt admission controller in lieu of the circuit
   // breakers.
   OptRef<Upstream::AttemptStreamAdmissionController> attempt_admission_controller_;
   uint32_t attempt_number_{1};

--- a/source/common/router/retry_state_impl.h
+++ b/source/common/router/retry_state_impl.h
@@ -32,7 +32,8 @@ public:
          const Upstream::ClusterInfo& cluster, const VirtualCluster* vcluster,
          RouteStatsContextOptRef route_stats_context,
          Server::Configuration::CommonFactoryContext& context, Event::Dispatcher& dispatcher,
-         Upstream::ResourcePriority priority);
+         Upstream::ResourcePriority priority,
+         OptRef<Upstream::AttemptStreamAdmissionController> attempt_admission_controller);
   ~RetryStateImpl() override;
 
   /**
@@ -105,7 +106,8 @@ private:
                  RouteStatsContextOptRef route_stats_context,
                  Server::Configuration::CommonFactoryContext& context,
                  Event::Dispatcher& dispatcher, Upstream::ResourcePriority priority,
-                 bool auto_configured_for_http3);
+                 bool auto_configured_for_http3,
+                 OptRef<Upstream::AttemptStreamAdmissionController> attempt_admission_controller);
 
   void enableBackoffTimer();
   void resetRetry();
@@ -116,7 +118,8 @@ private:
   RetryDecision wouldRetryFromReset(const Http::StreamResetReason reset_reason,
                                     Http3Used http3_used, bool& disable_http3,
                                     bool upstream_request_started);
-  RetryStatus shouldRetry(RetryDecision would_retry, DoRetryCallback callback);
+  RetryStatus shouldRetry(RetryDecision would_retry, DoRetryCallback callback,
+                          bool abort_previous_on_retry);
 
   const Upstream::ClusterInfo& cluster_;
   const VirtualCluster* vcluster_;
@@ -136,6 +139,11 @@ private:
   std::vector<Http::HeaderMatcherSharedPtr> retriable_headers_;
   std::vector<ResetHeaderParserSharedPtr> reset_headers_{};
   std::chrono::milliseconds reset_max_interval_{};
+  // This may be unset if no attempt admission controller extensions are configured.
+  // If this is set, then we defer to the attempt admission controller in leiu of the circuit
+  // breakers.
+  OptRef<Upstream::AttemptStreamAdmissionController> attempt_admission_controller_;
+  uint32_t attempt_number_{1};
 
   // Keep small members (bools, enums and int32s) at the end of class, to reduce alignment overhead.
   uint32_t retry_on_{};

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -809,9 +809,24 @@ bool Filter::continueDecodeHeaders(Upstream::ThreadLocalCluster* cluster,
   // Ensure an http transport scheme is selected before continuing with decoding.
   ASSERT(headers.Scheme());
 
+  OptRef<Upstream::AttemptStreamAdmissionController> controller;
+  if (auto cluster_controller = cluster_->admissionControl(route_entry_->priority());
+      cluster_controller.has_value()) {
+    attempt_controller_ =
+        cluster_controller->attempt()->createStreamAdmissionController(*requestStreamInfo());
+    controller = *attempt_controller_;
+  }
+
+  if (attempt_controller_ != nullptr && !attempt_controller_->isInitialAttemptAdmitted()) {
+    callbacks_->sendLocalReply(Http::Code::ServiceUnavailable,
+                               "Initial Attempt Rejected by Attempt Controller", nullptr,
+                               absl::nullopt, attempt_controller_->initialAttemptDetails());
+    return false;
+  }
+
   retry_state_ = createRetryState(*getEffectiveRetryPolicy(), headers, *cluster_, request_vcluster_,
                                   route_stats_context_, config_->factory_context_,
-                                  callbacks_->dispatcher(), route_entry_->priority());
+                                  callbacks_->dispatcher(), route_entry_->priority(), controller);
 
   // Determine which shadow policies to use. It's possible that we don't do any shadowing due to
   // runtime keys. Also the method CONNECT doesn't support shadowing.
@@ -846,7 +861,10 @@ bool Filter::continueDecodeHeaders(Upstream::ThreadLocalCluster* cluster,
       !transport_socket_options_ || !transport_socket_options_->http11ProxyInfo().has_value();
   UpstreamRequestPtr upstream_request = std::make_unique<UpstreamRequest>(
       *this, std::move(generic_conn_pool), can_send_early_data, can_use_http3,
-      allow_multiplexed_upstream_half_close_ /*enable_half_close*/);
+      allow_multiplexed_upstream_half_close_ /*enable_half_close*/, attempt_count_);
+  if (attempt_controller_) {
+    attempt_controller_->onTryStarted(attempt_count_);
+  }
   LinkedList::moveIntoList(std::move(upstream_request), upstream_requests_);
   upstream_requests_.front()->acceptHeadersFromRouter(end_stream);
   // Start the shadow streams.
@@ -1289,6 +1307,9 @@ void Filter::onResponseTimeout() {
       chargeUpstreamAbort(timeout_response_code_, false, *upstream_request);
     }
     upstream_request->resetStream();
+    if (attempt_controller_) {
+      attempt_controller_->onTryAborted(upstream_request->attemptNumber());
+    }
   }
 
   onUpstreamTimeoutAbort(StreamInfo::CoreResponseFlag::UpstreamRequestTimeout,
@@ -1357,6 +1378,9 @@ void Filter::onPerTryTimeoutCommon(UpstreamRequest& upstream_request, Stats::Cou
   }
 
   upstream_request.resetStream();
+  if (attempt_controller_) {
+    attempt_controller_->onTryAborted(upstream_request.attemptNumber());
+  }
 
   updateOutlierDetection(Upstream::Outlier::Result::LocalOriginTimeout, upstream_request,
                          absl::optional<uint64_t>(enumToInt(timeout_response_code_)));
@@ -1375,6 +1399,9 @@ void Filter::onPerTryTimeoutCommon(UpstreamRequest& upstream_request, Stats::Cou
 
 void Filter::onStreamMaxDurationReached(UpstreamRequest& upstream_request) {
   upstream_request.resetStream();
+  if (attempt_controller_) {
+    attempt_controller_->onTryAborted(upstream_request.attemptNumber());
+  }
 
   if (maybeRetryReset(Http::StreamResetReason::LocalReset, upstream_request, TimeoutRetry::No)) {
     return;
@@ -1550,6 +1577,10 @@ void Filter::onUpstreamReset(Http::StreamResetReason reset_reason,
                            absl::nullopt);
   }
 
+  if (attempt_controller_) {
+    attempt_controller_->onTryAborted(upstream_request.attemptNumber());
+  }
+
   if (maybeRetryReset(reset_reason, upstream_request, TimeoutRetry::No)) {
     return;
   }
@@ -1671,6 +1702,10 @@ void Filter::onUpstream1xxHeaders(Http::ResponseHeaderMapPtr&& headers,
   final_upstream_request_ = &upstream_request;
   resetOtherUpstreams(upstream_request);
 
+  if (attempt_controller_) {
+    attempt_controller_->onTrySucceeded(upstream_request.attemptNumber());
+  }
+
   // Don't send retries after 100-Continue has been sent on. Arguably we could attempt to do a
   // retry, assume the next upstream would also send an 100-Continue and swallow the second one
   // but it's sketchy (as the subsequent upstream might not send a 100-Continue) and not worth
@@ -1684,6 +1719,9 @@ void Filter::resetAll() {
   while (!upstream_requests_.empty()) {
     auto request_ptr = upstream_requests_.back()->removeFromList(upstream_requests_);
     request_ptr->resetStream();
+    if (attempt_controller_) {
+      attempt_controller_->onTryAborted(request_ptr->attemptNumber());
+    }
     callbacks_->dispatcher().deferredDelete(std::move(request_ptr));
   }
 }
@@ -1697,6 +1735,9 @@ void Filter::resetOtherUpstreams(UpstreamRequest& upstream_request) {
         upstream_requests_.back()->removeFromList(upstream_requests_);
     if (upstream_request_tmp.get() != &upstream_request) {
       upstream_request_tmp->resetStream();
+      if (attempt_controller_) {
+        attempt_controller_->onTryAborted(upstream_request_tmp->attemptNumber());
+      }
       // TODO: per-host stat for hedge abandoned.
       // TODO: cluster stat for hedge abandoned.
     } else {
@@ -1880,6 +1921,9 @@ void Filter::onUpstreamHeaders(uint64_t response_code, Http::ResponseHeaderMapPt
   callbacks_->streamInfo().setResponseCode(response_code);
   downstream_response_started_ = true;
   final_upstream_request_ = &upstream_request;
+  if (attempt_controller_) {
+    attempt_controller_->onTrySucceeded(upstream_request.attemptNumber());
+  }
   // Make sure that for request hedging, we end up with the correct final upstream info.
   callbacks_->streamInfo().setUpstreamInfo(final_upstream_request_->streamInfo().upstreamInfo());
   resetOtherUpstreams(upstream_request);
@@ -1965,6 +2009,9 @@ void Filter::onUpstreamComplete(UpstreamRequest& upstream_request) {
       return;
     }
     upstream_request.resetStream();
+  }
+  if (attempt_controller_) {
+    attempt_controller_->onSuccessfulTryFinished();
   }
   Event::Dispatcher& dispatcher = callbacks_->dispatcher();
   std::chrono::milliseconds response_time = std::chrono::duration_cast<std::chrono::milliseconds>(
@@ -2281,7 +2328,10 @@ void Filter::continueDoRetry(bool can_send_early_data, bool can_use_http3,
   }
   UpstreamRequestPtr upstream_request = std::make_unique<UpstreamRequest>(
       *this, std::move(generic_conn_pool), can_send_early_data, can_use_http3,
-      allow_multiplexed_upstream_half_close_ /*enable_half_close*/);
+      allow_multiplexed_upstream_half_close_ /*enable_half_close*/, attempt_count_);
+  if (attempt_controller_) {
+    attempt_controller_->onTryStarted(upstream_request->attemptNumber());
+  }
 
   if (include_attempt_count_in_request_) {
     downstream_headers_->setEnvoyAttemptCount(attempt_count_);
@@ -2447,15 +2497,16 @@ const Router::RetryPolicy* Filter::getEffectiveRetryPolicy() const {
   return retry_policy;
 }
 
-RetryStatePtr
-ProdFilter::createRetryState(const RetryPolicy& policy, Http::RequestHeaderMap& request_headers,
-                             const Upstream::ClusterInfo& cluster, const VirtualCluster* vcluster,
-                             RouteStatsContextOptRef route_stats_context,
-                             Server::Configuration::CommonFactoryContext& context,
-                             Event::Dispatcher& dispatcher, Upstream::ResourcePriority priority) {
+RetryStatePtr ProdFilter::createRetryState(
+    const RetryPolicy& policy, Http::RequestHeaderMap& request_headers,
+    const Upstream::ClusterInfo& cluster, const VirtualCluster* vcluster,
+    RouteStatsContextOptRef route_stats_context,
+    Server::Configuration::CommonFactoryContext& context, Event::Dispatcher& dispatcher,
+    Upstream::ResourcePriority priority,
+    OptRef<Upstream::AttemptStreamAdmissionController> attempt_admission_controller) {
   std::unique_ptr<RetryStateImpl> retry_state =
       RetryStateImpl::create(policy, request_headers, cluster, vcluster, route_stats_context,
-                             context, dispatcher, priority);
+                             context, dispatcher, priority, attempt_admission_controller);
   if (retry_state != nullptr && retry_state->isAutomaticallyConfiguredForHttp3()) {
     // Since doing retry will make Envoy to buffer the request body, if upstream using HTTP/3 is the
     // only reason for doing retry, set the buffer limit to 0 so that we don't retry or

--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -565,12 +565,13 @@ private:
                           bool dropped);
   void chargeUpstreamAbort(Http::Code code, bool dropped, UpstreamRequest& upstream_request);
   void cleanup();
-  virtual RetryStatePtr
-  createRetryState(const RetryPolicy& policy, Http::RequestHeaderMap& request_headers,
-                   const Upstream::ClusterInfo& cluster, const VirtualCluster* vcluster,
-                   RouteStatsContextOptRef route_stats_context,
-                   Server::Configuration::CommonFactoryContext& context,
-                   Event::Dispatcher& dispatcher, Upstream::ResourcePriority priority) PURE;
+  virtual RetryStatePtr createRetryState(
+      const RetryPolicy& policy, Http::RequestHeaderMap& request_headers,
+      const Upstream::ClusterInfo& cluster, const VirtualCluster* vcluster,
+      RouteStatsContextOptRef route_stats_context,
+      Server::Configuration::CommonFactoryContext& context, Event::Dispatcher& dispatcher,
+      Upstream::ResourcePriority priority,
+      OptRef<Upstream::AttemptStreamAdmissionController> attempt_admission_controller) PURE;
 
   std::unique_ptr<GenericConnPool>
   createConnPool(Upstream::ThreadLocalCluster& thread_local_cluster,
@@ -633,6 +634,7 @@ private:
   bool isEarlyConnectData();
 
   RetryStatePtr retry_state_;
+  Upstream::AttemptStreamAdmissionControllerPtr attempt_controller_{nullptr};
   const FilterConfigSharedPtr config_;
   Http::StreamDecoderFilterCallbacks* callbacks_{};
   RouteConstSharedPtr route_;
@@ -701,13 +703,13 @@ public:
 
 private:
   // Filter
-  RetryStatePtr createRetryState(const RetryPolicy& policy, Http::RequestHeaderMap& request_headers,
-                                 const Upstream::ClusterInfo& cluster,
-                                 const VirtualCluster* vcluster,
-                                 RouteStatsContextOptRef route_stats_context,
-                                 Server::Configuration::CommonFactoryContext& context,
-                                 Event::Dispatcher& dispatcher,
-                                 Upstream::ResourcePriority priority) override;
+  RetryStatePtr createRetryState(
+      const RetryPolicy& policy, Http::RequestHeaderMap& request_headers,
+      const Upstream::ClusterInfo& cluster, const VirtualCluster* vcluster,
+      RouteStatsContextOptRef route_stats_context,
+      Server::Configuration::CommonFactoryContext& context, Event::Dispatcher& dispatcher,
+      Upstream::ResourcePriority priority,
+      OptRef<Upstream::AttemptStreamAdmissionController> attempt_admission_controller) override;
 };
 
 } // namespace Router

--- a/source/common/router/upstream_request.cc
+++ b/source/common/router/upstream_request.cc
@@ -80,8 +80,8 @@ public:
 UpstreamRequest::UpstreamRequest(RouterFilterInterface& parent,
                                  std::unique_ptr<GenericConnPool>&& conn_pool,
                                  bool can_send_early_data, bool can_use_http3,
-                                 bool enable_half_close)
-    : parent_(parent), conn_pool_(std::move(conn_pool)),
+                                 bool enable_half_close, uint32_t attempt_number)
+    : parent_(parent), conn_pool_(std::move(conn_pool)), attempt_number_(attempt_number),
       stream_info_(parent_.callbacks()->dispatcher().timeSource(),
                    parent_.callbacks()->connection().has_value()
                        ? parent_.callbacks()->connection()->connectionInfoProviderSharedPtr()

--- a/source/common/router/upstream_request.h
+++ b/source/common/router/upstream_request.h
@@ -71,7 +71,8 @@ class UpstreamRequest : public Logger::Loggable<Logger::Id::router>,
                         public Event::DeferredDeletable {
 public:
   UpstreamRequest(RouterFilterInterface& parent, std::unique_ptr<GenericConnPool>&& conn_pool,
-                  bool can_send_early_data, bool can_use_http3, bool enable_half_close);
+                  bool can_send_early_data, bool can_use_http3, bool enable_half_close,
+                  uint32_t attempt_number);
   ~UpstreamRequest() override;
   void deleteIsPending() override { cleanUp(); }
 
@@ -155,6 +156,7 @@ public:
   bool outlierDetectionTimeoutRecorded() { return outlier_detection_timeout_recorded_; }
   void retried(bool value) { retried_ = value; }
   bool retried() { return retried_; }
+  uint32_t attemptNumber() const { return attempt_number_; }
   bool grpcRqSuccessDeferred() { return grpc_rq_success_deferred_; }
   void grpcRqSuccessDeferred(bool deferred) { grpc_rq_success_deferred_ = deferred; }
   void upstreamCanary(bool value) { upstream_canary_ = value; }
@@ -197,6 +199,7 @@ private:
   std::unique_ptr<GenericConnPool> conn_pool_;
   Event::TimerPtr per_try_timeout_;
   Event::TimerPtr per_try_idle_timeout_;
+  uint32_t attempt_number_;
   std::unique_ptr<GenericUpstream> upstream_;
   absl::optional<Http::StreamResetReason> deferred_reset_reason_;
   Upstream::HostDescriptionConstSharedPtr upstream_host_;

--- a/source/common/tcp_proxy/upstream.cc
+++ b/source/common/tcp_proxy/upstream.cc
@@ -411,7 +411,7 @@ void HttpConnPool::newStream(GenericConnectionPoolCallbacks& callbacks) {
         *this, upstream_callbacks_, *decoder_filter_callbacks_, config_, downstream_info_);
     RouterUpstreamRequestPtr upstream_request = std::make_unique<RouterUpstreamRequest>(
         *combined_upstream_, std::move(generic_conn_pool_), /*can_send_early_data_=*/false,
-        /*can_use_http3_=*/true, true /*enable_tcp_tunneling*/);
+        /*can_use_http3_=*/true, true /*enable_tcp_tunneling*/, 1);
     combined_upstream_->setRouterUpstreamRequest(std::move(upstream_request));
     combined_upstream_->newStream(callbacks);
     return;

--- a/source/common/upstream/BUILD
+++ b/source/common/upstream/BUILD
@@ -384,6 +384,15 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
+    name = "admission_control_lib",
+    hdrs = ["admission_control_impl.h"],
+    deps = [
+        "//envoy/upstream:admission_control_interface",
+        "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
+    ],
+)
+
+envoy_cc_library(
     name = "upstream_lib",
     srcs = ["upstream_impl.cc"],
     rbe_pool = "6gig",
@@ -459,6 +468,7 @@ envoy_cc_library(
         "upstream_impl.h",
     ],
     deps = [
+        ":admission_control_lib",
         ":load_balancer_context_base_lib",
         ":locality_pool_lib",
         ":resource_manager_lib",

--- a/source/common/upstream/admission_control_impl.h
+++ b/source/common/upstream/admission_control_impl.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <memory>
+#include <string>
+
+#include "envoy/config/core/v3/extension.pb.h"
+#include "envoy/upstream/admission_control.h"
+
+#include "source/common/common/assert.h"
+#include "source/common/config/utility.h"
+#include "source/common/protobuf/message_validator_impl.h"
+
+namespace Envoy {
+namespace Upstream {
+class AdmissionControlImpl : public AdmissionControl {
+public:
+  AdmissionControlImpl(const envoy::config::core::v3::TypedExtensionConfig& config,
+                       ProtobufMessage::ValidationVisitor& validation_visitor,
+                       Runtime::Loader& runtime, std::string runtime_key_prefix,
+                       ClusterCircuitBreakersStats cb_stats, Stats::Scope& scope) {
+    auto& attempt_factory =
+        Config::Utility::getAndCheckFactory<AttemptAdmissionControllerFactory>(config);
+    auto retry_factory_config = Envoy::Config::Utility::translateToFactoryConfig(
+        config, validation_visitor, attempt_factory);
+    attempt_ = attempt_factory.createAdmissionController(
+        *retry_factory_config, validation_visitor, runtime, runtime_key_prefix, cb_stats, scope);
+  }
+
+  AttemptAdmissionControllerSharedPtr attempt() override { return attempt_; }
+
+private:
+  AttemptAdmissionControllerSharedPtr attempt_;
+};
+using AdmissionControlImplSharedPtr = std::shared_ptr<AdmissionControlImpl>;
+
+} // namespace Upstream
+} // namespace Envoy

--- a/source/common/upstream/resource_manager_impl.h
+++ b/source/common/upstream/resource_manager_impl.h
@@ -78,7 +78,8 @@ public:
                       uint64_t max_requests, uint64_t max_retries, uint64_t max_connection_pools,
                       uint64_t max_connections_per_host, ClusterCircuitBreakersStats cb_stats,
                       absl::optional<double> budget_percent,
-                      absl::optional<uint32_t> min_retry_concurrency)
+                      absl::optional<uint32_t> min_retry_concurrency,
+                      bool attempt_extension_configured)
       : connections_(max_connections, runtime, runtime_key + "max_connections", cb_stats.cx_open_,
                      cb_stats.remaining_cx_),
         pending_requests_(max_pending_requests, runtime, runtime_key + "max_pending_requests",
@@ -90,8 +91,8 @@ public:
         max_connections_per_host_(max_connections_per_host),
         retries_(budget_percent, min_retry_concurrency, max_retries, runtime,
                  runtime_key + "retry_budget.", runtime_key + "max_retries",
-                 cb_stats.rq_retry_open_, cb_stats.remaining_retries_, requests_,
-                 pending_requests_) {}
+                 cb_stats.rq_retry_open_, cb_stats.remaining_retries_, requests_, pending_requests_,
+                 attempt_extension_configured) {}
 
   // Upstream::ResourceManager
   ResourceLimit& connections() override { return connections_; }
@@ -109,9 +110,10 @@ private:
                     Runtime::Loader& runtime, const std::string& retry_budget_runtime_key,
                     const std::string& max_retries_runtime_key, Stats::Gauge& open_gauge,
                     Stats::Gauge& remaining, const ResourceLimit& requests,
-                    const ResourceLimit& pending_requests)
+                    const ResourceLimit& pending_requests, bool attempt_extension_configured)
         : runtime_(runtime),
           max_retry_resource_(max_retries, runtime, max_retries_runtime_key, open_gauge, remaining),
+          delegate_to_attempt_controller_(attempt_extension_configured),
           budget_percent_(budget_percent), min_retry_concurrency_(min_retry_concurrency),
           budget_percent_key_(retry_budget_runtime_key + "budget_percent"),
           min_retry_concurrency_key_(retry_budget_runtime_key + "min_retry_concurrency"),
@@ -119,6 +121,8 @@ private:
 
     // Envoy::ResourceLimit
     bool canCreate() override {
+      ENVOY_BUG(!delegate_to_attempt_controller_,
+                "Should only use the configured attempt controller for retries");
       if (!useRetryBudget()) {
         return max_retry_resource_.canCreate();
       }
@@ -126,14 +130,23 @@ private:
       return count() < max();
     }
     void inc() override {
+      if (delegate_to_attempt_controller_) {
+        return;
+      }
       max_retry_resource_.inc();
       clearRemainingGauge();
     }
     void dec() override {
+      if (delegate_to_attempt_controller_) {
+        return;
+      }
       max_retry_resource_.dec();
       clearRemainingGauge();
     }
     void decBy(uint64_t amount) override {
+      if (delegate_to_attempt_controller_) {
+        return;
+      }
       max_retry_resource_.decBy(amount);
       clearRemainingGauge();
     }
@@ -177,6 +190,7 @@ private:
     // The max_retry resource is nested within the budget to maintain state if the retry budget is
     // toggled.
     ManagedResourceImpl max_retry_resource_;
+    const bool delegate_to_attempt_controller_;
     const absl::optional<double> budget_percent_;
     const absl::optional<uint32_t> min_retry_concurrency_;
     const std::string budget_percent_key_;

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -408,6 +408,28 @@ createUpstreamLocalAddressSelector(
   return selector_or_error.value();
 }
 
+OptRef<const envoy::config::core::v3::TypedExtensionConfig>
+getAttemptAdmissionControlConfigForPriority(
+    const envoy::config::cluster::v3::Cluster& config,
+    const envoy::config::core::v3::RoutingPriority& priority) {
+  const auto& thresholds = config.circuit_breakers().thresholds();
+  const auto it = std::find_if(
+      thresholds.cbegin(), thresholds.cend(),
+      [priority](const envoy::config::cluster::v3::CircuitBreakers::Thresholds& threshold) {
+        return threshold.priority() == priority;
+      });
+
+  if (it == thresholds.cend()) {
+    return {};
+  }
+
+  if (it->has_attempt_admission_control()) {
+    return {it->attempt_admission_control()};
+  } else {
+    return {};
+  }
+}
+
 } // namespace
 
 // Allow disabling ALPN checks for transport sockets. See
@@ -1133,10 +1155,10 @@ ClusterInfoImpl::ClusterInfoImpl(
               : nullptr),
       features_(ClusterInfoImpl::HttpProtocolOptionsConfigImpl::parseFeatures(
           config, *http_protocol_options_)),
-      resource_managers_(config, runtime, name_, *stats_scope_,
-                         factory_context.serverFactoryContext()
-                             .clusterManager()
-                             .clusterCircuitBreakersStatNames()),
+      resource_managers_(
+          config, runtime, name_, *stats_scope_,
+          factory_context.serverFactoryContext().clusterManager().clusterCircuitBreakersStatNames(),
+          server_context.messageValidationVisitor()),
       maintenance_mode_runtime_key_(absl::StrCat("upstream.maintenance_mode.", name_)),
       upstream_local_address_selector_(
           THROW_OR_RETURN_VALUE(createUpstreamLocalAddressSelector(config, bind_config),
@@ -1701,6 +1723,18 @@ ResourceManager& ClusterInfoImpl::resourceManager(ResourcePriority priority) con
   return *resource_managers_.managers_[enumToInt(priority)];
 }
 
+OptRef<AdmissionControl> ClusterInfoImpl::admissionControl(ResourcePriority priority) const {
+  ASSERT(enumToInt(priority) < resource_managers_.controls_.size());
+  // If we move the default circuit breaker behaviors transparently over to the admission control
+  // extensions, we can get rid of this as we'd always have default attempt admission control
+  // policies.
+  auto val = resource_managers_.controls_[enumToInt(priority)];
+  if (val == nullptr) {
+    return {};
+  }
+  return *val;
+}
+
 void ClusterImplBase::initialize(std::function<absl::Status()> callback) {
   ASSERT(!initialization_started_);
   ASSERT(initialization_complete_callback_ == nullptr);
@@ -1937,14 +1971,22 @@ ClusterInfoImpl::OptionalClusterStats::OptionalClusterStats(
 ClusterInfoImpl::ResourceManagers::ResourceManagers(
     const envoy::config::cluster::v3::Cluster& config, Runtime::Loader& runtime,
     const std::string& cluster_name, Stats::Scope& stats_scope,
-    const ClusterCircuitBreakersStatNames& circuit_breakers_stat_names)
+    const ClusterCircuitBreakersStatNames& circuit_breakers_stat_names,
+    ProtobufMessage::ValidationVisitor& validation_visitor)
     : circuit_breakers_stat_names_(circuit_breakers_stat_names) {
-  managers_[enumToInt(ResourcePriority::Default)] = THROW_OR_RETURN_VALUE(
-      load(config, runtime, cluster_name, stats_scope, envoy::config::core::v3::DEFAULT),
-      ResourceManagerImplPtr);
-  managers_[enumToInt(ResourcePriority::High)] = THROW_OR_RETURN_VALUE(
-      load(config, runtime, cluster_name, stats_scope, envoy::config::core::v3::HIGH),
-      ResourceManagerImplPtr);
+  using ResourceManagerAndAdmissionControlPtrs =
+      std::pair<ResourceManagerImplPtr, AdmissionControlImplSharedPtr>;
+
+  std::tie(managers_[enumToInt(ResourcePriority::Default)],
+           controls_[enumToInt(ResourcePriority::Default)]) =
+      THROW_OR_RETURN_VALUE(load(config, runtime, cluster_name, stats_scope,
+                                 envoy::config::core::v3::DEFAULT, validation_visitor),
+                            ResourceManagerAndAdmissionControlPtrs);
+  std::tie(managers_[enumToInt(ResourcePriority::High)],
+           controls_[enumToInt(ResourcePriority::High)]) =
+      THROW_OR_RETURN_VALUE(load(config, runtime, cluster_name, stats_scope,
+                                 envoy::config::core::v3::HIGH, validation_visitor),
+                            ResourceManagerAndAdmissionControlPtrs);
 }
 
 ClusterCircuitBreakersStats
@@ -2044,11 +2086,12 @@ ClusterInfoImpl::createSingletonUpstreamNetworkFilterConfigProviderManager(
       [] { return std::make_shared<Filter::UpstreamNetworkFilterConfigProviderManagerImpl>(); });
 }
 
-absl::StatusOr<ResourceManagerImplPtr>
+absl::StatusOr<std::pair<ResourceManagerImplPtr, AdmissionControlImplSharedPtr>>
 ClusterInfoImpl::ResourceManagers::load(const envoy::config::cluster::v3::Cluster& config,
                                         Runtime::Loader& runtime, const std::string& cluster_name,
                                         Stats::Scope& stats_scope,
-                                        const envoy::config::core::v3::RoutingPriority& priority) {
+                                        const envoy::config::core::v3::RoutingPriority& priority,
+                                        ProtobufMessage::ValidationVisitor& validation_visitor) {
   uint64_t max_connections = 1024;
   uint64_t max_pending_requests = 1024;
   uint64_t max_requests = 1024;
@@ -2087,7 +2130,6 @@ ClusterInfoImpl::ResourceManagers::load(const envoy::config::cluster::v3::Cluste
       [priority](const envoy::config::cluster::v3::CircuitBreakers::Thresholds& threshold) {
         return threshold.priority() == priority;
       });
-
   absl::optional<double> budget_percent;
   absl::optional<uint32_t> min_retry_concurrency;
   if (it != thresholds.cend()) {
@@ -2111,12 +2153,27 @@ ClusterInfoImpl::ResourceManagers::load(const envoy::config::cluster::v3::Cluste
       max_connections_per_host = per_host_it->max_connections().value();
     }
   }
-  return std::make_unique<ResourceManagerImpl>(
-      runtime, runtime_prefix, max_connections, max_pending_requests, max_requests, max_retries,
-      max_connection_pools, max_connections_per_host,
-      ClusterInfoImpl::generateCircuitBreakersStats(stats_scope, priority_stat_name,
-                                                    track_remaining, circuit_breakers_stat_names_),
-      budget_percent, min_retry_concurrency);
+
+  auto cb_stats = ClusterInfoImpl::generateCircuitBreakersStats(
+      stats_scope, priority_stat_name, track_remaining, circuit_breakers_stat_names_);
+
+  auto admission_control_config = getAttemptAdmissionControlConfigForPriority(config, priority);
+  AdmissionControlImplSharedPtr admission_control;
+  if (admission_control_config.has_value()) {
+    admission_control =
+        std::make_shared<AdmissionControlImpl>(admission_control_config.value(), validation_visitor,
+                                               runtime, runtime_prefix, cb_stats, stats_scope);
+  }
+
+  // If an attempt extension is configured, we use it to control the circuit breaker retry stats.
+  const bool attempt_extension_configured =
+      getAttemptAdmissionControlConfigForPriority(config, priority).has_value();
+  return std::make_pair(std::make_unique<ResourceManagerImpl>(
+                            runtime, runtime_prefix, max_connections, max_pending_requests,
+                            max_requests, max_retries, max_connection_pools,
+                            max_connections_per_host, cb_stats, budget_percent,
+                            min_retry_concurrency, attempt_extension_configured),
+                        admission_control);
 }
 
 PriorityStateManager::PriorityStateManager(ClusterImplBase& cluster,

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -15,9 +15,11 @@
 #include "envoy/common/callback.h"
 #include "envoy/common/optref.h"
 #include "envoy/common/time.h"
+#include "envoy/config/cluster/v3/circuit_breaker.pb.h"
 #include "envoy/config/cluster/v3/cluster.pb.h"
 #include "envoy/config/core/v3/address.pb.h"
 #include "envoy/config/core/v3/base.pb.h"
+#include "envoy/config/core/v3/extension.pb.h"
 #include "envoy/config/core/v3/health_check.pb.h"
 #include "envoy/config/core/v3/protocol.pb.h"
 #include "envoy/config/endpoint/v3/endpoint_components.pb.h"
@@ -58,6 +60,7 @@
 #include "source/common/orca/orca_load_metrics.h"
 #include "source/common/shared_pool/shared_pool.h"
 #include "source/common/stats/isolated_store_impl.h"
+#include "source/common/upstream/admission_control_impl.h"
 #include "source/common/upstream/load_balancer_context_base.h"
 #include "source/common/upstream/locality_pool.h"
 #include "source/common/upstream/resource_manager_impl.h"
@@ -662,7 +665,7 @@ using HostSetImplPtr = std::unique_ptr<HostSetImpl>;
  */
 class PrioritySetImpl : public PrioritySet {
 public:
-  PrioritySetImpl() : batch_update_(false) {}
+  PrioritySetImpl() = default;
   // From PrioritySet
   ABSL_MUST_USE_RESULT Common::CallbackHandlePtr
   addMemberUpdateCb(MemberUpdateCb callback) const override {
@@ -727,7 +730,7 @@ private:
       member_update_cb_helper_;
   mutable Common::CallbackManager<void, uint32_t, const HostVector&, const HostVector&>
       priority_update_cb_helper_;
-  bool batch_update_ : 1;
+  bool batch_update_ : 1 {};
 
   // Helper class to maintain state as we perform multiple host updates. Keeps track of all hosts
   // that have been added/removed throughout the batch update, and ensures that we properly manage
@@ -892,6 +895,7 @@ public:
     return name_;
   }
   ResourceManager& resourceManager(ResourcePriority priority) const override;
+  OptRef<AdmissionControl> admissionControl(ResourcePriority priority) const override;
   TransportSocketMatcher& transportSocketMatcher() const override { return *socket_matcher_; }
   DeferredCreationCompatibleClusterTrafficStats& trafficStats() const override {
     return traffic_stats_;
@@ -1016,16 +1020,20 @@ private:
   struct ResourceManagers {
     ResourceManagers(const envoy::config::cluster::v3::Cluster& config, Runtime::Loader& runtime,
                      const std::string& cluster_name, Stats::Scope& stats_scope,
-                     const ClusterCircuitBreakersStatNames& circuit_breakers_stat_names);
-    absl::StatusOr<ResourceManagerImplPtr>
+                     const ClusterCircuitBreakersStatNames& circuit_breakers_stat_names,
+                     ProtobufMessage::ValidationVisitor& validation_visitor);
+    absl::StatusOr<std::pair<ResourceManagerImplPtr, AdmissionControlImplSharedPtr>>
     load(const envoy::config::cluster::v3::Cluster& config, Runtime::Loader& runtime,
          const std::string& cluster_name, Stats::Scope& stats_scope,
-         const envoy::config::core::v3::RoutingPriority& priority);
+         const envoy::config::core::v3::RoutingPriority& priority,
+         ProtobufMessage::ValidationVisitor& validation_visitor);
 
+    using AdmissionControls = std::array<AdmissionControlImplSharedPtr, NumResourcePriorities>;
     using Managers = std::array<ResourceManagerImplPtr, NumResourcePriorities>;
 
-    Managers managers_;
     const ClusterCircuitBreakersStatNames& circuit_breakers_stat_names_;
+    AdmissionControls controls_;
+    Managers managers_;
   };
 
   struct OptionalClusterStats {

--- a/test/common/http/hcm_router_fuzz_test.cc
+++ b/test/common/http/hcm_router_fuzz_test.cc
@@ -45,12 +45,12 @@ public:
     return StreamDecoderFilterSharedPtr{fuzz_filter};
   }
   // Filter
-  Router::RetryStatePtr createRetryState(const Router::RetryPolicy&, RequestHeaderMap&,
-                                         const Upstream::ClusterInfo&,
-                                         const Router::VirtualCluster*,
-                                         Router::RouteStatsContextOptRef,
-                                         Server::Configuration::CommonFactoryContext&,
-                                         Event::Dispatcher&, Upstream::ResourcePriority) override {
+  Router::RetryStatePtr
+  createRetryState(const Router::RetryPolicy&, RequestHeaderMap&, const Upstream::ClusterInfo&,
+                   const Router::VirtualCluster*, Router::RouteStatsContextOptRef,
+                   Server::Configuration::CommonFactoryContext&, Event::Dispatcher&,
+                   Upstream::ResourcePriority,
+                   OptRef<Upstream::AttemptStreamAdmissionController>) override {
     EXPECT_EQ(nullptr, retry_state_);
     retry_state_ = new NiceMock<Router::MockRetryState>();
 

--- a/test/common/router/retry_state_impl_test.cc
+++ b/test/common/router/retry_state_impl_test.cc
@@ -58,7 +58,7 @@ public:
   void setup(Http::RequestHeaderMap& request_headers) {
     state_ = RetryStateImpl::create(*policy_, request_headers, cluster_, &virtual_cluster_,
                                     route_stats_context_, factory_context_, dispatcher_,
-                                    Upstream::ResourcePriority::Default);
+                                    Upstream::ResourcePriority::Default, attempt_controller_opt_);
   }
 
   void expectTimerCreateAndEnable() {
@@ -177,6 +177,8 @@ public:
   NiceMock<Server::Configuration::MockServerFactoryContext> factory_context_;
   NiceMock<Runtime::MockLoader>& runtime_{factory_context_.runtime_loader_};
   NiceMock<Random::MockRandomGenerator>& random_{factory_context_.api_.random_};
+  NiceMock<Upstream::MockAttemptStreamAdmissionController> attempt_controller_;
+  OptRef<Upstream::AttemptStreamAdmissionController> attempt_controller_opt_;
   Event::MockDispatcher& dispatcher_{factory_context_.dispatcher_};
   Event::MockTimer* retry_timer_{};
   Event::MockSchedulableCallback* retry_schedulable_callback_{nullptr};
@@ -1592,6 +1594,97 @@ TEST_F(RouterRetryStateImplTest, RemoveAllRetryHeaders) {
     EXPECT_FALSE(request_headers.has("x-envoy-hedge-on-per-try-timeout"));
     EXPECT_FALSE(request_headers.has("x-envoy-upstream-rq-per-try-timeout-ms"));
   }
+}
+
+TEST_F(RouterRetryStateImplTest, AttemptAdmissionControlAllowed) {
+  Http::TestRequestHeaderMapImpl request_headers{{"x-envoy-retry-on", "5xx"},
+                                                 {"x-envoy-max-retries", "42"}};
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "500"}};
+  attempt_controller_opt_ = attempt_controller_;
+
+  setup(request_headers);
+  EXPECT_TRUE(state_->enabled());
+
+  expectTimerCreateAndEnable();
+  EXPECT_CALL(attempt_controller_, isAttemptAdmitted(1, 2, true)).WillOnce(Return(true));
+  EXPECT_EQ(RetryStatus::Yes,
+            state_->shouldRetryHeaders(response_headers, request_headers, header_callback_));
+}
+
+TEST_F(RouterRetryStateImplTest, AttemptAdmissionControlDenied) {
+  Http::TestRequestHeaderMapImpl request_headers{{"x-envoy-retry-on", "5xx"},
+                                                 {"x-envoy-max-retries", "42"}};
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "500"}};
+  attempt_controller_opt_ = attempt_controller_;
+
+  setup(request_headers);
+  EXPECT_TRUE(state_->enabled());
+
+  EXPECT_CALL(attempt_controller_, isAttemptAdmitted(1, 2, true)).WillOnce(Return(false));
+  EXPECT_EQ(RetryStatus::NoOverflow,
+            state_->shouldRetryHeaders(response_headers, request_headers, header_callback_));
+
+  EXPECT_EQ(0UL, cluster_.trafficStats()->upstream_rq_retry_.value());
+  EXPECT_EQ(0UL, cluster_.trafficStats()->upstream_rq_retry_success_.value());
+  EXPECT_EQ(1UL, cluster_.trafficStats()->upstream_rq_retry_overflow_.value());
+  EXPECT_EQ(0UL, virtual_cluster_.stats().upstream_rq_retry_.value());
+  EXPECT_EQ(0UL, virtual_cluster_.stats().upstream_rq_retry_success_.value());
+  EXPECT_EQ(1UL, virtual_cluster_.stats().upstream_rq_retry_overflow_.value());
+  EXPECT_EQ(0UL, route_stats_context_.stats().upstream_rq_retry_.value());
+  EXPECT_EQ(0UL, route_stats_context_.stats().upstream_rq_retry_success_.value());
+  EXPECT_EQ(1UL, route_stats_context_.stats().upstream_rq_retry_overflow_.value());
+}
+
+TEST_F(RouterRetryStateImplTest, AttemptAdmissionControlHedgedTimeout) {
+  Http::TestRequestHeaderMapImpl request_headers{
+      {"x-envoy-retry-on", "5xx"},
+      {"x-envoy-max-retries", "42"},
+      {"x-envoy-hedge-on-per-try-timeout", "true"},
+      {"x-envoy-upstream-rq-per-try-timeout-ms", "2"},
+  };
+  attempt_controller_opt_ = attempt_controller_;
+
+  setup(request_headers);
+  EXPECT_TRUE(state_->enabled());
+
+  EXPECT_CALL(attempt_controller_, isAttemptAdmitted(1, 2, false)).WillOnce(Return(false));
+  EXPECT_EQ(RetryStatus::NoOverflow, state_->shouldHedgeRetryPerTryTimeout(callback_));
+}
+
+TEST_F(RouterRetryStateImplTest, AttemptAdmissionControlNoAbortPreviousOnReset) {
+  Http::TestRequestHeaderMapImpl request_headers{{"x-envoy-retry-on", "refused-stream"}};
+  attempt_controller_opt_ = attempt_controller_;
+  setup(request_headers);
+  EXPECT_TRUE(state_->enabled());
+
+  EXPECT_CALL(attempt_controller_, isAttemptAdmitted(1, 2, false)).WillOnce(Return(false));
+  EXPECT_EQ(RetryStatus::NoOverflow,
+            state_->shouldRetryReset(remote_refused_stream_reset_, RetryState::Http3Used::No,
+                                     reset_callback_, false));
+}
+
+TEST_F(RouterRetryStateImplTest, AttemptAdmissionControlAttemptNumbers) {
+  Http::TestRequestHeaderMapImpl request_headers{{"x-envoy-retry-on", "5xx"},
+                                                 {"x-envoy-max-retries", "42"}};
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "500"}};
+  attempt_controller_opt_ = attempt_controller_;
+
+  setup(request_headers);
+  EXPECT_TRUE(state_->enabled());
+
+  retry_timer_ = new Event::MockTimer(&dispatcher_);
+  for (int64_t i = 1; i <= 10; i++) {
+    EXPECT_CALL(attempt_controller_, isAttemptAdmitted(i, i + 1, true)).WillOnce(Return(true));
+    EXPECT_CALL(*retry_timer_, enableTimer(_, _));
+    EXPECT_EQ(RetryStatus::Yes,
+              state_->shouldRetryHeaders(response_headers, request_headers, header_callback_));
+    EXPECT_CALL(callback_ready_, ready());
+    retry_timer_->invokeCallback();
+  }
+
+  EXPECT_CALL(attempt_controller_, isAttemptAdmitted(11, 12, true)).WillOnce(Return(false));
+  EXPECT_EQ(RetryStatus::NoOverflow,
+            state_->shouldRetryHeaders(response_headers, request_headers, header_callback_));
 }
 
 } // namespace

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -8045,5 +8045,223 @@ TEST_F(RouterTest, OrcaLoadReportInvalidHeaderValue) {
   response_decoder->decodeHeaders(std::move(response_headers), true);
 }
 
+class RouterAttemptAdmissionControlTest : public RouterTest {
+public:
+  RouterAttemptAdmissionControlTest() {
+    cm_.thread_local_cluster_.cluster_.info_->setAdmissionControl(admission_control_);
+    attempt_admission_control_ptr_ =
+        std::make_unique<NiceMock<Upstream::MockAttemptStreamAdmissionController>>();
+    attempt_admission_controller_ = attempt_admission_control_ptr_.get();
+    EXPECT_CALL(*admission_control_.attempt_admission_controller_,
+                createStreamAdmissionController(_))
+        .WillOnce(Invoke([this](const StreamInfo::StreamInfo&) mutable
+                         -> Upstream::AttemptStreamAdmissionControllerPtr {
+          auto tmp = std::move(attempt_admission_control_ptr_);
+          return tmp;
+        }));
+    // Recreate router filter so it latches the correct value of streaming shadow.
+    router_ = std::make_unique<RouterTestFilter>(config_, config_->default_stats_);
+    router_->setDecoderFilterCallbacks(callbacks_);
+    router_->downstream_connection_.stream_info_.downstream_connection_info_provider_
+        ->setLocalAddress(host_address_);
+    router_->downstream_connection_.stream_info_.downstream_connection_info_provider_
+        ->setRemoteAddress(Network::Utility::parseInternetAddressAndPortNoThrow("1.2.3.4:80"));
+  }
+
+protected:
+  NiceMock<Upstream::MockAdmissionControl> admission_control_;
+  std::unique_ptr<NiceMock<Upstream::MockAttemptStreamAdmissionController>>
+      attempt_admission_control_ptr_;
+  // This is owned by the router filter itself which this test fixture owns.
+  // We keep a pointer to it to allow us to set mocked expectations.
+  NiceMock<Upstream::MockAttemptStreamAdmissionController>* attempt_admission_controller_;
+};
+
+TEST_F(RouterAttemptAdmissionControlTest, RetryAdmissionControlOneSuccessfulTry) {
+  EXPECT_CALL(*attempt_admission_controller_, onTryStarted(1));
+  EXPECT_CALL(*attempt_admission_controller_, onTrySucceeded(1));
+  EXPECT_CALL(*attempt_admission_controller_, onSuccessfulTryFinished());
+  testRequestResponse(false);
+}
+
+TEST_F(RouterAttemptAdmissionControlTest, RetryAdmissionControlOneAbortedTry) {
+  Http::TestRequestHeaderMapImpl headers;
+  HttpTestUtility::addDefaultHeaders(headers);
+  expectResponseTimerCreate();
+  EXPECT_CALL(*attempt_admission_controller_, onTryStarted(1));
+  router_->decodeHeaders(headers, true);
+
+  EXPECT_CALL(*attempt_admission_controller_, onTryAborted(1));
+  router_->onDestroy();
+}
+
+TEST_F(RouterAttemptAdmissionControlTest, RetryAdmissionControlRetryHeaders) {
+  EXPECT_CALL(*attempt_admission_controller_, onTryAborted(_)).Times(0);
+
+  NiceMock<Http::MockRequestEncoder> encoder1;
+  Http::ResponseDecoder* response_decoder = nullptr;
+  EXPECT_CALL(
+      cm_.thread_local_cluster_.conn_pool_.host_->outlier_detector_,
+      putResult(Upstream::Outlier::Result::LocalOriginConnectSuccess, absl::optional<uint64_t>{}));
+  expectNewStreamWithImmediateEncoder(encoder1, &response_decoder, Http::Protocol::Http10);
+
+  Http::TestRequestHeaderMapImpl headers{{"x-envoy-retry-on", "5xx"}};
+  HttpTestUtility::addDefaultHeaders(headers);
+  expectResponseTimerCreate();
+  EXPECT_CALL(*attempt_admission_controller_, onTryStarted(1));
+  router_->decodeHeaders(headers, true);
+
+  // without a mock in the way, expectHeadersRetry will call isRetryAdmitted
+  // which will abort attempt 1
+  router_->retry_state_->expectHeadersRetry();
+  Http::ResponseHeaderMapPtr response_headers1(
+      new Http::TestResponseHeaderMapImpl{{":status", "503"}});
+  EXPECT_CALL(cm_.thread_local_cluster_.conn_pool_.host_->outlier_detector_,
+              putResult(_, absl::optional<uint64_t>(503)));
+  response_decoder->decodeHeaders(std::move(response_headers1), true);
+
+  NiceMock<Http::MockRequestEncoder> encoder2;
+  EXPECT_CALL(
+      cm_.thread_local_cluster_.conn_pool_.host_->outlier_detector_,
+      putResult(Upstream::Outlier::Result::LocalOriginConnectSuccess, absl::optional<uint64_t>{}));
+  expectNewStreamWithImmediateEncoder(encoder2, &response_decoder, Http::Protocol::Http10);
+  EXPECT_CALL(*attempt_admission_controller_, onTryStarted(2));
+  router_->retry_state_->callback_();
+
+  EXPECT_CALL(*router_->retry_state_, shouldRetryHeaders(_, _, _))
+      .WillOnce(Return(RetryStatus::No));
+  Http::ResponseHeaderMapPtr response_headers2(
+      new Http::TestResponseHeaderMapImpl{{":status", "200"}});
+  EXPECT_CALL(cm_.thread_local_cluster_.conn_pool_.host_->outlier_detector_,
+              putResult(_, absl::optional<uint64_t>(200)));
+  EXPECT_CALL(*attempt_admission_controller_, onTrySucceeded(2));
+  EXPECT_CALL(*attempt_admission_controller_, onSuccessfulTryFinished());
+  response_decoder->decodeHeaders(std::move(response_headers2), true);
+
+  router_->onDestroy();
+}
+
+TEST_F(RouterAttemptAdmissionControlTest, RetryAdmissionControlRetryReset) {
+  EXPECT_CALL(*attempt_admission_controller_, onTryAborted(_)).Times(0);
+
+  NiceMock<Http::MockRequestEncoder> encoder1;
+  Http::ResponseDecoder* response_decoder = nullptr;
+  expectNewStreamWithImmediateEncoder(encoder1, &response_decoder, Http::Protocol::Http10);
+
+  Http::TestRequestHeaderMapImpl headers;
+  HttpTestUtility::addDefaultHeaders(headers);
+  expectResponseTimerCreate();
+  EXPECT_CALL(*attempt_admission_controller_, onTryStarted(1));
+  router_->decodeHeaders(headers, true);
+
+  router_->retry_state_->expectResetRetry();
+  EXPECT_CALL(*attempt_admission_controller_, onTryAborted(1));
+  encoder1.stream_.resetStream(Http::StreamResetReason::RemoteReset);
+
+  NiceMock<Http::MockRequestEncoder> encoder2;
+  expectNewStreamWithImmediateEncoder(encoder2, &response_decoder, Http::Protocol::Http10);
+  EXPECT_CALL(*attempt_admission_controller_, onTryStarted(2));
+  router_->retry_state_->callback_();
+
+  EXPECT_CALL(*router_->retry_state_, shouldRetryHeaders(_, _, _))
+      .WillOnce(Return(RetryStatus::No));
+  Http::ResponseHeaderMapPtr response_headers(
+      new Http::TestResponseHeaderMapImpl{{":status", "200"}});
+  EXPECT_CALL(cm_.thread_local_cluster_.conn_pool_.host_->outlier_detector_,
+              putResult(_, absl::optional<uint64_t>(200)));
+  EXPECT_CALL(*attempt_admission_controller_, onTrySucceeded(2));
+  EXPECT_CALL(*attempt_admission_controller_, onSuccessfulTryFinished());
+  response_decoder->decodeHeaders(std::move(response_headers), true);
+
+  router_->onDestroy();
+}
+
+TEST_F(RouterAttemptAdmissionControlTest, RetryAdmissionControlTrySuccessWithData) {
+  EXPECT_CALL(*attempt_admission_controller_, onTryAborted(_)).Times(0);
+
+  NiceMock<Http::MockRequestEncoder> encoder1;
+  Http::ResponseDecoder* response_decoder = nullptr;
+  expectNewStreamWithImmediateEncoder(encoder1, &response_decoder, Http::Protocol::Http10);
+
+  Http::TestRequestHeaderMapImpl headers;
+  HttpTestUtility::addDefaultHeaders(headers);
+  expectResponseTimerCreate();
+  EXPECT_CALL(*attempt_admission_controller_, onTryStarted(1));
+  router_->decodeHeaders(headers, true);
+
+  Http::ResponseHeaderMapPtr response_headers(
+      new Http::TestResponseHeaderMapImpl{{":status", "200"}});
+  EXPECT_CALL(cm_.thread_local_cluster_.conn_pool_.host_->outlier_detector_,
+              putResult(_, absl::optional<uint64_t>(200)));
+  EXPECT_CALL(*attempt_admission_controller_, onTrySucceeded(1));
+  response_decoder->decodeHeaders(std::move(response_headers), false);
+
+  EXPECT_CALL(*attempt_admission_controller_, onSuccessfulTryFinished());
+  auto data = Buffer::OwnedImpl("data");
+  response_decoder->decodeData(data, true);
+
+  router_->onDestroy();
+}
+
+TEST_F(RouterAttemptAdmissionControlTest, RetryAdmissionControlHedgeOnPerTryTimeout) {
+  enableHedgeOnPerTryTimeout();
+
+  // Start try 1 going
+  NiceMock<Http::MockRequestEncoder> encoder1;
+  Http::ResponseDecoder* response_decoder1 = nullptr;
+  expectNewStreamWithImmediateEncoder(encoder1, &response_decoder1, Http::Protocol::Http10);
+
+  expectPerTryTimerCreate();
+  expectResponseTimerCreate();
+  Http::TestRequestHeaderMapImpl headers{{"x-envoy-upstream-rq-per-try-timeout-ms", "5"}};
+  HttpTestUtility::addDefaultHeaders(headers);
+  EXPECT_CALL(*attempt_admission_controller_, onTryStarted(1));
+  router_->decodeHeaders(headers, true);
+
+  // Try 1 hits per try timeout and schedules a hedged retry
+  EXPECT_CALL(encoder1.stream_, resetStream(_)).Times(0);
+  EXPECT_CALL(*attempt_admission_controller_, onTryAborted(1)).Times(0);
+  router_->retry_state_->expectHedgedPerTryTimeoutRetry();
+  per_try_timeout_->invokeCallback();
+
+  // Once the retry callback is called, try 2 starts
+  NiceMock<Http::MockRequestEncoder> encoder2;
+  Http::ResponseDecoder* response_decoder2 = nullptr;
+  expectNewStreamWithImmediateEncoder(encoder2, &response_decoder2, Http::Protocol::Http10);
+  expectPerTryTimerCreate();
+  EXPECT_CALL(*attempt_admission_controller_, onTryStarted(2));
+  router_->retry_state_->callback_();
+
+  // While try 2 is waiting for a response from upstream, try 1 gets a successful response
+  Http::ResponseHeaderMapPtr response_headers(
+      new Http::TestResponseHeaderMapImpl{{":status", "200"}});
+  EXPECT_CALL(callbacks_, encodeHeaders_(_, _))
+      .WillOnce(Invoke([&](Http::ResponseHeaderMap& headers, bool end_stream) -> void {
+        EXPECT_EQ(headers.Status()->value(), "200");
+        EXPECT_TRUE(end_stream);
+      }));
+  EXPECT_CALL(*router_->retry_state_, shouldRetryHeaders(_, _, _)).Times(0);
+  EXPECT_CALL(*router_->retry_state_, wouldRetryFromHeaders(_, _, _))
+      .WillOnce(Return(RetryState::RetryDecision::NoRetry));
+  // Try 2 is aborted once try 1 succeeds since it isn't needed anymore
+  EXPECT_CALL(*attempt_admission_controller_, onTryAborted(2));
+  EXPECT_CALL(*attempt_admission_controller_, onTrySucceeded(1));
+  EXPECT_CALL(*attempt_admission_controller_, onSuccessfulTryFinished());
+  response_decoder1->decodeHeaders(std::move(response_headers), true);
+
+  router_->onDestroy();
+}
+
+TEST_F(RouterAttemptAdmissionControlTest, CanRejectInitialAttempt) {
+  Http::TestRequestHeaderMapImpl headers;
+  HttpTestUtility::addDefaultHeaders(headers);
+  EXPECT_CALL(*attempt_admission_controller_, isInitialAttemptAdmitted()).WillOnce(Return(false));
+  EXPECT_CALL(*attempt_admission_controller_, initialAttemptDetails())
+      .WillOnce(Return("attempt controller rejected"));
+  router_->decodeHeaders(headers, true);
+  EXPECT_TRUE(verifyHostUpstreamStats(0, 0));
+  EXPECT_EQ(callbacks_.details(), "attempt controller rejected");
+}
+
 } // namespace Router
 } // namespace Envoy

--- a/test/common/router/router_test_base.h
+++ b/test/common/router/router_test_base.h
@@ -38,7 +38,8 @@ public:
                                  const Upstream::ClusterInfo&, const VirtualCluster*,
                                  RouteStatsContextOptRef,
                                  Server::Configuration::CommonFactoryContext&, Event::Dispatcher&,
-                                 Upstream::ResourcePriority) override {
+                                 Upstream::ResourcePriority,
+                                 OptRef<Upstream::AttemptStreamAdmissionController>) override {
     EXPECT_EQ(nullptr, retry_state_);
     retry_state_ = new NiceMock<MockRetryState>();
     if (reject_all_hosts_) {

--- a/test/common/router/router_upstream_filter_test.cc
+++ b/test/common/router/router_upstream_filter_test.cc
@@ -39,7 +39,8 @@ public:
                                  const Upstream::ClusterInfo&, const VirtualCluster*,
                                  RouteStatsContextOptRef,
                                  Server::Configuration::CommonFactoryContext&, Event::Dispatcher&,
-                                 Upstream::ResourcePriority) override {
+                                 Upstream::ResourcePriority,
+                                 OptRef<Upstream::AttemptStreamAdmissionController>) override {
     EXPECT_EQ(nullptr, retry_state_);
     retry_state_ = new NiceMock<MockRetryState>();
     return RetryStatePtr{retry_state_};

--- a/test/common/router/router_upstream_log_test.cc
+++ b/test/common/router/router_upstream_log_test.cc
@@ -67,7 +67,8 @@ public:
                                  const Upstream::ClusterInfo&, const VirtualCluster*,
                                  RouteStatsContextOptRef,
                                  Server::Configuration::CommonFactoryContext&, Event::Dispatcher&,
-                                 Upstream::ResourcePriority) override {
+                                 Upstream::ResourcePriority,
+                                 OptRef<Upstream::AttemptStreamAdmissionController>) override {
     EXPECT_EQ(nullptr, retry_state_);
     retry_state_ = new NiceMock<MockRetryState>();
     return RetryStatePtr{retry_state_};

--- a/test/common/router/upstream_request_test.cc
+++ b/test/common/router/upstream_request_test.cc
@@ -37,7 +37,7 @@ public:
     ON_CALL(*conn_pool_, host()).WillByDefault(Return(host_));
     upstream_request_ =
         std::make_unique<UpstreamRequest>(router_filter_interface_, std::move(conn_pool), false,
-                                          true, false /*enable_tcp_tunneling*/);
+                                          true, false /*enable_tcp_tunneling*/, 1);
   }
   Http::FilterFactoryCb createDecoderFilterFactoryCb(Http::StreamDecoderFilterSharedPtr filter) {
     return [filter](Http::FilterChainFactoryCallbacks& callbacks) {

--- a/test/common/upstream/resource_manager_impl_test.cc
+++ b/test/common/upstream/resource_manager_impl_test.cc
@@ -31,7 +31,7 @@ TEST(ResourceManagerImplTest, RuntimeResourceManager) {
 
   ResourceManagerImpl resource_manager(
       runtime, "circuit_breakers.runtime_resource_manager_test.default.", 0, 0, 0, 1, 0, 100,
-      clusterCircuitBreakersStats(store), absl::nullopt, absl::nullopt);
+      clusterCircuitBreakersStats(store), absl::nullopt, absl::nullopt, false);
 
   EXPECT_CALL(
       runtime.snapshot_,
@@ -89,7 +89,7 @@ TEST(ResourceManagerImplTest, RemainingResourceGauges) {
   auto stats = clusterCircuitBreakersStats(store);
   ResourceManagerImpl resource_manager(runtime,
                                        "circuit_breakers.runtime_resource_manager_test.default.", 1,
-                                       2, 1, 0, 3, 100, stats, absl::nullopt, absl::nullopt);
+                                       2, 1, 0, 3, 100, stats, absl::nullopt, absl::nullopt, false);
 
   // Test remaining_cx_ gauge
   EXPECT_EQ(1U, resource_manager.connections().max());
@@ -155,7 +155,7 @@ TEST(ResourceManagerImplTest, RetryBudgetOverrideGauge) {
 
   // Test retry budgets disable remaining_retries gauge (it should always be 0).
   ResourceManagerImpl rm(runtime, "circuit_breakers.runtime_resource_manager_test.default.", 1, 2,
-                         1, 0, 3, 100, stats, 20.0, 5);
+                         1, 0, 3, 100, stats, 20.0, 5, false);
 
   EXPECT_EQ(5U, rm.retries().max());
   EXPECT_EQ(0U, stats.remaining_retries_.value());
@@ -165,6 +165,33 @@ TEST(ResourceManagerImplTest, RetryBudgetOverrideGauge) {
   EXPECT_EQ(0U, stats.remaining_retries_.value());
   EXPECT_EQ(100u, rm.maxConnectionsPerHost());
   rm.retries().dec();
+}
+
+TEST(ResourceManagerImplTest, AttemptBudgetOverridesRetryBudget) {
+  NiceMock<Runtime::MockLoader> runtime;
+  Stats::IsolatedStoreImpl store;
+
+  auto stats = clusterCircuitBreakersStats(store);
+
+  // Test retry budgets disable remaining_retries gauge (it should always be 0).
+  ResourceManagerImpl rm(runtime, "circuit_breakers.runtime_resource_manager_test.default.", 1, 2,
+                         1, 0, 3, 100, stats, 20.0, 5, true);
+  EXPECT_EQ(0U, stats.remaining_retries_.value());
+  EXPECT_EQ(0U, rm.retries().count());
+
+  rm.retries().inc();
+
+  EXPECT_EQ(0U, rm.retries().count());
+  EXPECT_EQ(0U, stats.remaining_retries_.value());
+
+  rm.retries().dec();
+
+  EXPECT_EQ(0U, rm.retries().count());
+  EXPECT_EQ(0U, stats.remaining_retries_.value());
+
+  rm.retries().decBy(10);
+  EXPECT_EQ(0U, rm.retries().count());
+  EXPECT_EQ(0U, stats.remaining_retries_.value());
 }
 } // namespace
 } // namespace Upstream

--- a/test/extensions/upstreams/http/tcp/upstream_request_test.cc
+++ b/test/extensions/upstreams/http/tcp/upstream_request_test.cc
@@ -104,7 +104,7 @@ public:
     EXPECT_CALL(mock_router_filter_, callbacks()).Times(AnyNumber());
     upstream_request_ = std::make_unique<UpstreamRequest>(
         mock_router_filter_, std::make_unique<NiceMock<Router::MockGenericConnPool>>(), false,
-        false, false /*enable_tcp_tunneling*/);
+        false, false /*enable_tcp_tunneling*/, 1);
     auto data = std::make_unique<NiceMock<Envoy::Tcp::ConnectionPool::MockConnectionData>>();
     EXPECT_CALL(*data, connection()).Times(AnyNumber()).WillRepeatedly(ReturnRef(connection()));
     tcp_upstream_ = std::make_unique<TcpUpstream>(upstream_request_.get(), std::move(data));

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -607,6 +607,23 @@ envoy_cc_test(
 )
 
 envoy_cc_test(
+    name = "attempt_admission_control_integration_test",
+    size = "large",
+    srcs = ["attempt_admission_control_integration_test.cc"],
+    rbe_pool = "6gig",
+    tags = [
+        "cpu:3",
+    ],
+    deps = [
+        ":http_protocol_integration_lib",
+        "//test/integration/attempt_admission_control:test_attempt_admission_controller",
+        "//test/test_common:test_runtime_lib",
+        "//test/test_common:test_time_lib",
+        "@envoy_api//envoy/config/bootstrap/v3:pkg_cc_proto",
+    ],
+)
+
+envoy_cc_test(
     name = "http2_flood_integration_test",
     size = "large",
     srcs = [

--- a/test/integration/attempt_admission_control/BUILD
+++ b/test/integration/attempt_admission_control/BUILD
@@ -1,0 +1,30 @@
+load(
+    "//bazel:envoy_build_system.bzl",
+    "envoy_cc_test_library",
+    "envoy_package",
+    "envoy_proto_library",
+)
+
+licenses(["notice"])  # Apache 2
+
+envoy_package()
+
+envoy_cc_test_library(
+    name = "test_attempt_admission_controller",
+    srcs = [
+        "test_attempt_admission_controller.cc",
+    ],
+    hdrs = [
+        "test_attempt_admission_controller.h",
+    ],
+    deps = [
+        ":config_cc_proto",
+        "//envoy/upstream:admission_control_interface",
+        "//test/test_common:registry_lib",
+    ],
+)
+
+envoy_proto_library(
+    name = "config",
+    srcs = ["config.proto"],
+)

--- a/test/integration/attempt_admission_control/config.proto
+++ b/test/integration/attempt_admission_control/config.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+package test.integration.attempt_admission_control;
+
+message TestAttemptAdmissionControlConfig {
+  // Number of retries to allow, not including the initial request.
+  uint32 retries_to_allow = 1;
+  // Whether the initial request should be allowed.
+  bool allow_initial_request = 2;
+}

--- a/test/integration/attempt_admission_control/test_attempt_admission_controller.cc
+++ b/test/integration/attempt_admission_control/test_attempt_admission_controller.cc
@@ -1,0 +1,10 @@
+#include "test/integration/attempt_admission_control/test_attempt_admission_controller.h"
+
+#include "envoy/registry/registry.h"
+
+namespace Envoy {
+
+REGISTER_FACTORY(TestAttemptAdmissionControllerFactory,
+                 Upstream::AttemptAdmissionControllerFactory);
+
+} // namespace Envoy

--- a/test/integration/attempt_admission_control/test_attempt_admission_controller.h
+++ b/test/integration/attempt_admission_control/test_attempt_admission_controller.h
@@ -1,0 +1,71 @@
+#pragma once
+
+#include <cstdint>
+
+#include "envoy/upstream/admission_control.h"
+
+#include "test/integration/attempt_admission_control/config.pb.h"
+#include "test/integration/attempt_admission_control/config.pb.validate.h"
+#include "test/test_common/registry.h"
+
+namespace Envoy {
+
+class TestAttemptStreamAdmissionController : public Upstream::AttemptStreamAdmissionController {
+public:
+  TestAttemptStreamAdmissionController(
+      const test::integration::attempt_admission_control::TestAttemptAdmissionControlConfig& config)
+      : allow_initial_attempt_(config.allow_initial_request()),
+        retries_to_allow_(config.retries_to_allow()) {}
+
+  void onTryStarted(uint32_t) override {}
+  void onTryAborted(uint32_t) override {}
+  void onTrySucceeded(uint32_t) override {}
+  void onSuccessfulTryFinished() override {}
+  bool isAttemptAdmitted(uint32_t, uint32_t retry_attempt_number, bool) override {
+    return retry_attempt_number <= retries_to_allow_;
+  }
+  bool isInitialAttemptAdmitted() override { return allow_initial_attempt_; }
+  absl::string_view initialAttemptDetails() const override { return ""; }
+
+private:
+  const bool allow_initial_attempt_;
+  const uint32_t retries_to_allow_;
+};
+
+class TestAttemptAdmissionController : public Upstream::AttemptAdmissionController {
+public:
+  TestAttemptAdmissionController(
+      const test::integration::attempt_admission_control::TestAttemptAdmissionControlConfig& config)
+      : config_(config) {}
+
+  Upstream::AttemptStreamAdmissionControllerPtr
+  createStreamAdmissionController(const StreamInfo::StreamInfo&) override {
+    return std::make_unique<TestAttemptStreamAdmissionController>(config_);
+  }
+
+private:
+  const test::integration::attempt_admission_control::TestAttemptAdmissionControlConfig config_;
+};
+
+class TestAttemptAdmissionControllerFactory : public Upstream::AttemptAdmissionControllerFactory {
+public:
+  Upstream::AttemptAdmissionControllerSharedPtr
+  createAdmissionController(const Protobuf::Message& generic_config,
+                            ProtobufMessage::ValidationVisitor& validation_visitor,
+                            Runtime::Loader&, std::string,
+                            const Upstream::ClusterCircuitBreakersStats&, Stats::Scope&) override {
+    const auto& config = MessageUtil::downcastAndValidate<
+        const test::integration::attempt_admission_control::TestAttemptAdmissionControlConfig&>(
+        generic_config, validation_visitor);
+    return std::make_shared<TestAttemptAdmissionController>(config);
+  };
+
+  std::string name() const override { return "envoy.attempt_admission_control.test"; }
+
+  ProtobufTypes::MessagePtr createEmptyConfigProto() override {
+    return std::make_unique<
+        test::integration::attempt_admission_control::TestAttemptAdmissionControlConfig>();
+  }
+};
+
+} // namespace Envoy

--- a/test/integration/attempt_admission_control_integration_test.cc
+++ b/test/integration/attempt_admission_control_integration_test.cc
@@ -1,0 +1,138 @@
+#include "envoy/config/bootstrap/v3/bootstrap.pb.h"
+
+#include "test/integration/attempt_admission_control/config.pb.h"
+#include "test/integration/http_protocol_integration.h"
+#include "test/test_common/test_runtime.h"
+
+namespace Envoy {
+namespace {
+
+class AttemptAdmissionControlIntegrationTest : public HttpProtocolIntegrationTest {
+public:
+  void initialize() override {
+    config_helper_.addConfigModifier([this](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
+      auto* static_resources = bootstrap.mutable_static_resources();
+      auto* cluster = static_resources->mutable_clusters(0);
+
+      auto* circuit_breakers = cluster->mutable_circuit_breakers();
+      auto* thresholds = circuit_breakers->add_thresholds();
+
+      thresholds->mutable_attempt_admission_control()->set_name(
+          "envoy.attempt_admission_control.test");
+      thresholds->mutable_attempt_admission_control()->mutable_typed_config()->PackFrom(
+          attempt_config_);
+    });
+
+    HttpProtocolIntegrationTest::initialize();
+  }
+
+protected:
+  test::integration::attempt_admission_control::TestAttemptAdmissionControlConfig attempt_config_;
+};
+
+INSTANTIATE_TEST_SUITE_P(Protocols, AttemptAdmissionControlIntegrationTest,
+                         testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParams()),
+                         HttpProtocolIntegrationTest::protocolTestParamsToString);
+
+TEST_P(AttemptAdmissionControlIntegrationTest, BlockAllRetries) {
+  attempt_config_.set_retries_to_allow(0);
+  attempt_config_.set_allow_initial_request(true);
+  config_helper_.addConfigModifier(
+      [&](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
+              hcm) -> void {
+        auto* retry_policy =
+            hcm.mutable_route_config()->mutable_virtual_hosts(0)->mutable_retry_policy();
+        retry_policy->set_retry_on("5xx");
+        retry_policy->mutable_retry_back_off()->mutable_base_interval()->set_nanos(
+            1000000); // min backoff
+      });
+
+  initialize();
+
+  // non-retried request works
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+  auto response1 = codec_client_->makeRequestWithBody(default_request_headers_, 1024);
+  waitForNextUpstreamRequest();
+  upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, true);
+  ASSERT_TRUE(upstream_request_->complete());
+  ASSERT_TRUE(response1->waitForEndStream());
+  EXPECT_EQ("200", response1->headers().getStatusValue());
+  EXPECT_EQ(0, test_server_->counter("cluster.cluster_0.upstream_rq_retry_overflow")->value());
+
+  // retried request fails
+  auto response2 = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
+  waitForNextUpstreamRequest();
+  upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "503"}}, true);
+  ASSERT_TRUE(upstream_request_->complete());
+  ASSERT_TRUE(response2->waitForEndStream());
+  EXPECT_EQ("503", response2->headers().getStatusValue());
+  EXPECT_EQ(1, test_server_->counter("cluster.cluster_0.upstream_rq_retry_overflow")->value());
+}
+
+TEST_P(AttemptAdmissionControlIntegrationTest, AllowAllRetries) {
+  attempt_config_.set_retries_to_allow(5);
+  attempt_config_.set_allow_initial_request(true);
+  config_helper_.addConfigModifier(
+      [&](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
+              hcm) -> void {
+        auto* retry_policy =
+            hcm.mutable_route_config()->mutable_virtual_hosts(0)->mutable_retry_policy();
+        retry_policy->set_retry_on("5xx");
+        retry_policy->mutable_num_retries()->set_value(5);
+        retry_policy->mutable_retry_back_off()->mutable_base_interval()->set_nanos(
+            1000000); // min backoff
+      });
+
+  initialize();
+
+  // non-retried request works
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+  auto response1 = codec_client_->makeRequestWithBody(default_request_headers_, 1024);
+  waitForNextUpstreamRequest();
+  upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, true);
+  ASSERT_TRUE(upstream_request_->complete());
+  ASSERT_TRUE(response1->waitForEndStream());
+  EXPECT_EQ("200", response1->headers().getStatusValue());
+  EXPECT_EQ(0, test_server_->counter("cluster.cluster_0.upstream_rq_retry_overflow")->value());
+
+  // failed requests are retried.
+  auto response2 = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
+  for (uint32_t i = 0; i < 4; ++i) {
+    waitForNextUpstreamRequest();
+    upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "503"}}, true);
+    ASSERT_TRUE(upstream_request_->complete());
+  }
+  waitForNextUpstreamRequest();
+  upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, true);
+  ASSERT_TRUE(upstream_request_->complete());
+  ASSERT_TRUE(response2->waitForEndStream());
+  EXPECT_EQ("200", response2->headers().getStatusValue());
+  EXPECT_EQ(0, test_server_->counter("cluster.cluster_0.upstream_rq_retry_overflow")->value());
+}
+
+TEST_P(AttemptAdmissionControlIntegrationTest, InitialAttemptBlocked) {
+  attempt_config_.set_allow_initial_request(false);
+  config_helper_.addConfigModifier(
+      [&](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
+              hcm) -> void {
+        auto* retry_policy =
+            hcm.mutable_route_config()->mutable_virtual_hosts(0)->mutable_retry_policy();
+        retry_policy->set_retry_on("5xx");
+        retry_policy->mutable_num_retries()->set_value(5);
+        retry_policy->mutable_retry_back_off()->mutable_base_interval()->set_nanos(
+            1000000); // min backoff
+      });
+
+  initialize();
+
+  // The initial attempt isn't admitted and no retries occur.
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+  auto response1 = codec_client_->makeRequestWithBody(default_request_headers_, 1024);
+  ASSERT_TRUE(response1->waitForEndStream());
+  EXPECT_EQ("503", response1->headers().getStatusValue());
+  EXPECT_EQ(0, test_server_->counter("cluster.cluster_0.upstream_rq_total")->value());
+  EXPECT_EQ(0, test_server_->counter("cluster.cluster_0.upstream_rq_retry_overflow")->value());
+}
+
+} // namespace
+} // namespace Envoy

--- a/test/mocks/router/upstream_request.cc
+++ b/test/mocks/router/upstream_request.cc
@@ -5,7 +5,7 @@ namespace Router {
 
 MockUpstreamRequest::MockUpstreamRequest(RouterFilterInterface& router_interface,
                                          std::unique_ptr<GenericConnPool>&& conn_pool)
-    : UpstreamRequest(router_interface, std::move(conn_pool), false, true, true) {}
+    : UpstreamRequest(router_interface, std::move(conn_pool), false, true, true, 1) {}
 
 MockUpstreamRequest::~MockUpstreamRequest() = default;
 

--- a/test/mocks/upstream/BUILD
+++ b/test/mocks/upstream/BUILD
@@ -13,6 +13,7 @@ envoy_cc_mock(
     srcs = ["cluster_info.cc"],
     hdrs = ["cluster_info.h"],
     deps = [
+        ":admission_control_mocks",
         ":transport_socket_match_mocks",
         "//envoy/upstream:cluster_manager_interface",
         "//envoy/upstream:upstream_interface",
@@ -84,6 +85,7 @@ envoy_cc_mock(
     name = "upstream_mocks",
     hdrs = ["mocks.h"],
     deps = [
+        ":admission_control_mocks",
         ":basic_resource_limit_mocks",
         ":cds_api_mocks",
         ":cluster_discovery_callback_handle_mocks",
@@ -397,5 +399,14 @@ envoy_cc_mock(
     hdrs = ["basic_resource_limit.h"],
     deps = [
         "//envoy/common:resource_interface",
+    ],
+)
+
+envoy_cc_mock(
+    name = "admission_control_mocks",
+    srcs = ["admission_control.cc"],
+    hdrs = ["admission_control.h"],
+    deps = [
+        "//envoy/upstream:admission_control_interface",
     ],
 )

--- a/test/mocks/upstream/admission_control.cc
+++ b/test/mocks/upstream/admission_control.cc
@@ -1,0 +1,40 @@
+#include "admission_control.h"
+
+#include <cstdint>
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace Envoy {
+namespace Upstream {
+
+using testing::_;
+using testing::Invoke;
+using testing::Return;
+
+MockAttemptStreamAdmissionController::MockAttemptStreamAdmissionController() {
+  ON_CALL(*this, isAttemptAdmitted(_, _, _)).WillByDefault(Return(true));
+  ON_CALL(*this, isInitialAttemptAdmitted()).WillByDefault(Return(true));
+};
+
+MockAttemptAdmissionController::MockAttemptAdmissionController()
+    : stream_admission_controller_(
+          std::make_unique<NiceMock<MockAttemptStreamAdmissionController>>()) {
+  ON_CALL(*this, createStreamAdmissionController(_))
+      .WillByDefault(Invoke(
+          [this](const StreamInfo::StreamInfo&) mutable -> AttemptStreamAdmissionControllerPtr {
+            // shuffle things around so we don't hold onto a ref to the old ptr
+            auto ptr = std::move(stream_admission_controller_);
+            stream_admission_controller_ =
+                std::make_unique<NiceMock<MockAttemptStreamAdmissionController>>();
+            return ptr;
+          }));
+};
+
+MockAdmissionControl::MockAdmissionControl()
+    : attempt_admission_controller_(std::make_shared<NiceMock<MockAttemptAdmissionController>>()) {
+  ON_CALL(*this, attempt()).WillByDefault(Return(attempt_admission_controller_));
+};
+
+} // namespace Upstream
+} // namespace Envoy

--- a/test/mocks/upstream/admission_control.h
+++ b/test/mocks/upstream/admission_control.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <cstdint>
+
+#include "envoy/upstream/admission_control.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace Envoy {
+namespace Upstream {
+
+using testing::NiceMock;
+
+class MockAttemptStreamAdmissionController : public AttemptStreamAdmissionController {
+public:
+  MockAttemptStreamAdmissionController();
+  ~MockAttemptStreamAdmissionController() override = default;
+
+  MOCK_METHOD(void, onTryStarted, (uint32_t));
+  MOCK_METHOD(void, onTrySucceeded, (uint32_t));
+  MOCK_METHOD(void, onSuccessfulTryFinished, ());
+  MOCK_METHOD(void, onTryAborted, (uint32_t));
+  MOCK_METHOD(bool, isAttemptAdmitted, (uint32_t, uint32_t, bool));
+  MOCK_METHOD(bool, isInitialAttemptAdmitted, ());
+  MOCK_METHOD(absl::string_view, initialAttemptDetails, (), (const));
+};
+
+using MockAttemptStreamAdmissionControllerPtr =
+    std::unique_ptr<NiceMock<MockAttemptStreamAdmissionController>>;
+
+class MockAttemptAdmissionController : public AttemptAdmissionController {
+public:
+  MockAttemptAdmissionController();
+  ~MockAttemptAdmissionController() override = default;
+
+  MOCK_METHOD(AttemptStreamAdmissionControllerPtr, createStreamAdmissionController,
+              (const StreamInfo::StreamInfo&));
+
+public:
+  // Note that by default this will get re-initialized on each call to
+  // createStreamAdmissionController to avoid sharing. To change the behavior, you can override the
+  // default behavior for createStreamAdmissionController.
+  MockAttemptStreamAdmissionControllerPtr stream_admission_controller_;
+};
+
+using MockAttemptAdmissionControllerSharedPtr =
+    std::shared_ptr<NiceMock<MockAttemptAdmissionController>>;
+
+class MockAdmissionControl : public AdmissionControl {
+public:
+  MockAdmissionControl();
+  ~MockAdmissionControl() override = default;
+
+  MOCK_METHOD(AttemptAdmissionControllerSharedPtr, attempt, ());
+
+  MockAttemptAdmissionControllerSharedPtr attempt_admission_controller_;
+};
+
+} // namespace Upstream
+} // namespace Envoy

--- a/test/mocks/upstream/cluster_info.cc
+++ b/test/mocks/upstream/cluster_info.cc
@@ -74,7 +74,7 @@ MockClusterInfo::MockClusterInfo()
       resource_manager_(new Upstream::ResourceManagerImpl(
           runtime_, "fake_key", 1, 1024, 1024, 1, std::numeric_limits<uint64_t>::max(),
           std::numeric_limits<uint64_t>::max(), circuit_breakers_stats_, absl::nullopt,
-          absl::nullopt)),
+          absl::nullopt, false)),
       upstream_local_address_selector_(
           std::make_shared<NiceMock<MockUpstreamLocalAddressSelector>>(source_address_)),
       stats_scope_(stats_store_.createScope("test_scope")) {
@@ -128,6 +128,9 @@ MockClusterInfo::MockClusterInfo()
   ON_CALL(*this, resourceManager(_))
       .WillByDefault(Invoke(
           [this](ResourcePriority) -> Upstream::ResourceManager& { return *resource_manager_; }));
+  ON_CALL(*this, admissionControl(_))
+      .WillByDefault(Invoke(
+          [this](ResourcePriority) -> OptRef<AdmissionControl> { return admission_control_; }));
   ON_CALL(*this, upstreamConfig())
       .WillByDefault(
           Invoke([this]() -> OptRef<const envoy::config::core::v3::TypedExtensionConfig> {

--- a/test/mocks/upstream/cluster_info.h
+++ b/test/mocks/upstream/cluster_info.h
@@ -22,6 +22,7 @@
 
 #include "test/mocks/runtime/mocks.h"
 #include "test/mocks/stats/mocks.h"
+#include "test/mocks/upstream/admission_control.h"
 #include "test/mocks/upstream/transport_socket_match.h"
 
 #include "gmock/gmock.h"
@@ -88,7 +89,7 @@ public:
                             uint64_t conn_pool, uint64_t conn_per_host = 100) {
     resource_manager_ = std::make_unique<ResourceManagerImpl>(
         runtime_, name_, cx, rq_pending, rq, rq_retry, conn_pool, conn_per_host,
-        circuit_breakers_stats_, absl::nullopt, absl::nullopt);
+        circuit_breakers_stats_, absl::nullopt, absl::nullopt, false);
   }
 
   void resetResourceManagerWithRetryBudget(uint64_t cx, uint64_t rq_pending, uint64_t rq,
@@ -97,7 +98,13 @@ public:
                                            uint64_t conn_per_host = 100) {
     resource_manager_ = std::make_unique<ResourceManagerImpl>(
         runtime_, name_, cx, rq_pending, rq, rq_retry, conn_pool, conn_per_host,
-        circuit_breakers_stats_, budget_percent, min_retry_concurrency);
+        circuit_breakers_stats_, budget_percent, min_retry_concurrency, false);
+  }
+
+  // By default this is unset so the admissions control extensions should not be used unless this
+  // is called.
+  void setAdmissionControl(NiceMock<MockAdmissionControl>& admission_control) {
+    admission_control_.emplace(admission_control);
   }
 
   // Upstream::ClusterInfo
@@ -136,6 +143,7 @@ public:
   MOCK_METHOD(const std::string&, name, (), (const));
   MOCK_METHOD(const std::string&, observabilityName, (), (const));
   MOCK_METHOD(ResourceManager&, resourceManager, (ResourcePriority priority), (const));
+  MOCK_METHOD(OptRef<AdmissionControl>, admissionControl, (ResourcePriority priority), (const));
   MOCK_METHOD(TransportSocketMatcher&, transportSocketMatcher, (), (const));
   MOCK_METHOD(DeferredCreationCompatibleClusterTrafficStats&, trafficStats, (), (const));
   MOCK_METHOD(ClusterLbStats&, lbStats, (), (const));
@@ -241,6 +249,7 @@ public:
   ClusterCircuitBreakersStats circuit_breakers_stats_;
   NiceMock<Runtime::MockLoader> runtime_;
   std::unique_ptr<Upstream::ResourceManager> resource_manager_;
+  OptRef<NiceMock<MockAdmissionControl>> admission_control_;
   Network::Address::InstanceConstSharedPtr source_address_;
   std::shared_ptr<MockUpstreamLocalAddressSelector> upstream_local_address_selector_;
   envoy::config::cluster::v3::Cluster::DiscoveryType type_{

--- a/test/mocks/upstream/mocks.h
+++ b/test/mocks/upstream/mocks.h
@@ -24,6 +24,7 @@
 #include "test/mocks/secret/mocks.h"
 #include "test/mocks/stats/mocks.h"
 #include "test/mocks/tcp/mocks.h"
+#include "test/mocks/upstream/admission_control.h"
 #include "test/mocks/upstream/basic_resource_limit.h"
 #include "test/mocks/upstream/cds_api.h"
 #include "test/mocks/upstream/cluster.h"


### PR DESCRIPTION
Commit Message: Attempt admission control extension point for circuit breaker
Additional Description:

This adds a new extension point for circuit breaker to allow new extensions to determine whether an attempt to a single stream should be allowed. For example, this enables some advanced request context aware retry strategy like user foo should be allowed at this point vs bar shouldn't be etc. 

Note: this commit itself doesn't add any concrete extension point implementation except inside the test. The plan is to add the dynamic module-based implementation as well as we already have an implementation internally too.

Risk Level: mid (some small change in the core)
Testing: done
Docs Changes: done (on API)
Release Notes: no concrete implementation yet 
Platform Specific Features: n/a
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
