### PR TITLE
dynamic_modules: add set_dynamic_metadata_bool for network filters

### DIFF
--- a/source/extensions/dynamic_modules/abi/abi.h
+++ b/source/extensions/dynamic_modules/abi/abi.h
@@ -3819,6 +3819,37 @@ bool envoy_dynamic_module_callback_network_get_dynamic_metadata_number(
     envoy_dynamic_module_type_module_buffer filter_namespace,
     envoy_dynamic_module_type_module_buffer key, double* result);
 
+/**
+ * envoy_dynamic_module_callback_network_set_dynamic_metadata_bool is called by the module to
+ * set the bool value of the dynamic metadata with the given namespace and key. If the metadata
+ * is existing, it will be overwritten.
+ *
+ * @param filter_envoy_ptr is the pointer to the DynamicModuleNetworkFilter object.
+ * @param filter_namespace is the namespace owned by the module.
+ * @param key is the key owned by the module.
+ * @param value is the bool value of the dynamic metadata to be set.
+ */
+void envoy_dynamic_module_callback_network_set_dynamic_metadata_bool(
+    envoy_dynamic_module_type_network_filter_envoy_ptr filter_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer filter_namespace,
+    envoy_dynamic_module_type_module_buffer key, bool value);
+
+/**
+ * envoy_dynamic_module_callback_network_get_dynamic_metadata_bool is called by the module to
+ * get the bool value of the dynamic metadata with the given namespace and key. If the namespace
+ * does not exist, the key does not exist, or the value is not a bool, this returns false.
+ *
+ * @param filter_envoy_ptr is the pointer to the DynamicModuleNetworkFilter object.
+ * @param filter_namespace is the namespace owned by the module.
+ * @param key is the key owned by the module.
+ * @param result is the output pointer to the bool value of the dynamic metadata.
+ * @return true if the operation is successful, false otherwise.
+ */
+bool envoy_dynamic_module_callback_network_get_dynamic_metadata_bool(
+    envoy_dynamic_module_type_network_filter_envoy_ptr filter_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer filter_namespace,
+    envoy_dynamic_module_type_module_buffer key, bool* result);
+
 // ------------------------------ HTTP Callouts -------------------------------
 
 /**

--- a/source/extensions/dynamic_modules/abi_impl.cc
+++ b/source/extensions/dynamic_modules/abi_impl.cc
@@ -975,6 +975,21 @@ __attribute__((weak)) bool envoy_dynamic_module_callback_network_get_dynamic_met
   return false;
 }
 
+__attribute__((weak)) void envoy_dynamic_module_callback_network_set_dynamic_metadata_bool(
+    envoy_dynamic_module_type_network_filter_envoy_ptr, envoy_dynamic_module_type_module_buffer,
+    envoy_dynamic_module_type_module_buffer, bool) {
+  IS_ENVOY_BUG("envoy_dynamic_module_callback_network_set_dynamic_metadata_bool: "
+               "not implemented in this context");
+}
+
+__attribute__((weak)) bool envoy_dynamic_module_callback_network_get_dynamic_metadata_bool(
+    envoy_dynamic_module_type_network_filter_envoy_ptr, envoy_dynamic_module_type_module_buffer,
+    envoy_dynamic_module_type_module_buffer, bool*) {
+  IS_ENVOY_BUG("envoy_dynamic_module_callback_network_get_dynamic_metadata_bool: "
+               "not implemented in this context");
+  return false;
+}
+
 __attribute__((weak)) envoy_dynamic_module_type_http_callout_init_result
 envoy_dynamic_module_callback_network_filter_http_callout(
     envoy_dynamic_module_type_network_filter_envoy_ptr, uint64_t*,

--- a/source/extensions/dynamic_modules/sdk/rust/src/network.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/network.rs
@@ -293,6 +293,13 @@ pub trait EnvoyNetworkFilter {
   /// Returns None if the metadata is not found or is the wrong type.
   fn get_dynamic_metadata_number(&self, namespace: &str, key: &str) -> Option<f64>;
 
+  /// Set the bool-typed dynamic metadata value with the given namespace and key value.
+  fn set_dynamic_metadata_bool(&mut self, namespace: &str, key: &str, value: bool);
+
+  /// Get the bool-typed dynamic metadata value with the given namespace and key value.
+  /// Returns None if the metadata is not found or is the wrong type.
+  fn get_dynamic_metadata_bool(&self, namespace: &str, key: &str) -> Option<bool>;
+
   /// Set an integer socket option with the given level, name, and state.
   fn set_socket_option_int(
     &mut self,
@@ -1187,6 +1194,34 @@ impl EnvoyNetworkFilter for EnvoyNetworkFilterImpl {
     let mut result: f64 = 0.0;
     let success = unsafe {
       abi::envoy_dynamic_module_callback_network_get_dynamic_metadata_number(
+        self.raw,
+        str_to_module_buffer(namespace),
+        str_to_module_buffer(key),
+        &mut result,
+      )
+    };
+    if success {
+      Some(result)
+    } else {
+      None
+    }
+  }
+
+  fn set_dynamic_metadata_bool(&mut self, namespace: &str, key: &str, value: bool) {
+    unsafe {
+      abi::envoy_dynamic_module_callback_network_set_dynamic_metadata_bool(
+        self.raw,
+        str_to_module_buffer(namespace),
+        str_to_module_buffer(key),
+        value,
+      )
+    }
+  }
+
+  fn get_dynamic_metadata_bool(&self, namespace: &str, key: &str) -> Option<bool> {
+    let mut result: bool = false;
+    let success = unsafe {
+      abi::envoy_dynamic_module_callback_network_get_dynamic_metadata_bool(
         self.raw,
         str_to_module_buffer(namespace),
         str_to_module_buffer(key),

--- a/source/extensions/filters/network/dynamic_modules/abi_impl.cc
+++ b/source/extensions/filters/network/dynamic_modules/abi_impl.cc
@@ -626,6 +626,54 @@ bool envoy_dynamic_module_callback_network_get_dynamic_metadata_number(
   return true;
 }
 
+void envoy_dynamic_module_callback_network_set_dynamic_metadata_bool(
+    envoy_dynamic_module_type_network_filter_envoy_ptr filter_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer filter_namespace,
+    envoy_dynamic_module_type_module_buffer key, bool value) {
+  auto* filter = static_cast<DynamicModuleNetworkFilter*>(filter_envoy_ptr);
+  auto& stream_info = filter->connection().streamInfo();
+
+  std::string namespace_str(filter_namespace.ptr, filter_namespace.length);
+  absl::string_view key_view(key.ptr, key.length);
+
+  // Get or create the metadata for this namespace.
+  Protobuf::Struct metadata(
+      (*stream_info.dynamicMetadata().mutable_filter_metadata())[namespace_str]);
+  auto& fields = *metadata.mutable_fields();
+  fields[std::string(key_view)].set_bool_value(value);
+  stream_info.setDynamicMetadata(namespace_str, metadata);
+}
+
+bool envoy_dynamic_module_callback_network_get_dynamic_metadata_bool(
+    envoy_dynamic_module_type_network_filter_envoy_ptr filter_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer filter_namespace,
+    envoy_dynamic_module_type_module_buffer key, bool* result) {
+  auto* filter = static_cast<DynamicModuleNetworkFilter*>(filter_envoy_ptr);
+  auto& stream_info = filter->connection().streamInfo();
+
+  std::string namespace_str(filter_namespace.ptr, filter_namespace.length);
+  std::string key_str(key.ptr, key.length);
+
+  const auto& metadata_map = stream_info.dynamicMetadata().filter_metadata();
+  auto namespace_it = metadata_map.find(namespace_str);
+  if (namespace_it == metadata_map.end()) {
+    return false;
+  }
+
+  const auto& fields = namespace_it->second.fields();
+  auto field_it = fields.find(key_str);
+  if (field_it == fields.end()) {
+    return false;
+  }
+
+  if (!field_it->second.has_bool_value()) {
+    return false;
+  }
+
+  *result = field_it->second.bool_value();
+  return true;
+}
+
 envoy_dynamic_module_type_http_callout_init_result
 envoy_dynamic_module_callback_network_filter_http_callout(
     envoy_dynamic_module_type_network_filter_envoy_ptr filter_envoy_ptr, uint64_t* callout_id_out,

--- a/test/extensions/dynamic_modules/network/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/network/abi_impl_test.cc
@@ -1337,6 +1337,179 @@ TEST_F(DynamicModuleNetworkFilterAbiCallbackTest, SetDynamicMetadataNumberNegati
   EXPECT_DOUBLE_EQ(negative_value, result);
 }
 
+TEST_F(DynamicModuleNetworkFilterAbiCallbackTest, SetAndGetDynamicMetadataBool) {
+  const std::string ns = "test.ns";
+  const std::string key = "bool.key";
+
+  envoy::config::core::v3::Metadata metadata;
+  EXPECT_CALL(connection_.stream_info_, dynamicMetadata())
+      .WillRepeatedly(testing::ReturnRef(metadata));
+  EXPECT_CALL(connection_.stream_info_, setDynamicMetadata(ns, testing::_))
+      .WillRepeatedly(testing::SaveArg<1>(&(*metadata.mutable_filter_metadata())[ns]));
+
+  // Set the metadata to true.
+  envoy_dynamic_module_callback_network_set_dynamic_metadata_bool(
+      filterPtr(), {const_cast<char*>(ns.data()), ns.size()},
+      {const_cast<char*>(key.data()), key.size()}, true);
+
+  // Verify by reading it back.
+  bool result = false;
+  bool ok = envoy_dynamic_module_callback_network_get_dynamic_metadata_bool(
+      filterPtr(), {const_cast<char*>(ns.data()), ns.size()},
+      {const_cast<char*>(key.data()), key.size()}, &result);
+  EXPECT_TRUE(ok);
+  EXPECT_TRUE(result);
+}
+
+TEST_F(DynamicModuleNetworkFilterAbiCallbackTest, SetDynamicMetadataBoolOverwrite) {
+  // Test overwriting a bool metadata value from true to false.
+  const std::string ns = "test.ns";
+  const std::string key = "bool.key";
+
+  envoy::config::core::v3::Metadata metadata;
+  EXPECT_CALL(connection_.stream_info_, dynamicMetadata())
+      .WillRepeatedly(testing::ReturnRef(metadata));
+  EXPECT_CALL(connection_.stream_info_, setDynamicMetadata(ns, testing::_))
+      .WillRepeatedly(testing::SaveArg<1>(&(*metadata.mutable_filter_metadata())[ns]));
+
+  // Set the metadata to true.
+  envoy_dynamic_module_callback_network_set_dynamic_metadata_bool(
+      filterPtr(), {const_cast<char*>(ns.data()), ns.size()},
+      {const_cast<char*>(key.data()), key.size()}, true);
+
+  bool result = false;
+  bool ok = envoy_dynamic_module_callback_network_get_dynamic_metadata_bool(
+      filterPtr(), {const_cast<char*>(ns.data()), ns.size()},
+      {const_cast<char*>(key.data()), key.size()}, &result);
+  EXPECT_TRUE(ok);
+  EXPECT_TRUE(result);
+
+  // Overwrite with false.
+  envoy_dynamic_module_callback_network_set_dynamic_metadata_bool(
+      filterPtr(), {const_cast<char*>(ns.data()), ns.size()},
+      {const_cast<char*>(key.data()), key.size()}, false);
+
+  ok = envoy_dynamic_module_callback_network_get_dynamic_metadata_bool(
+      filterPtr(), {const_cast<char*>(ns.data()), ns.size()},
+      {const_cast<char*>(key.data()), key.size()}, &result);
+  EXPECT_TRUE(ok);
+  EXPECT_FALSE(result);
+}
+
+TEST_F(DynamicModuleNetworkFilterAbiCallbackTest, GetDynamicMetadataBoolNonExistingNamespace) {
+  const std::string ns = "nonexistent.ns";
+  const std::string key = "test.key";
+
+  envoy::config::core::v3::Metadata metadata;
+  EXPECT_CALL(connection_.stream_info_, dynamicMetadata())
+      .WillRepeatedly(testing::ReturnRef(metadata));
+
+  bool result = false;
+  bool ok = envoy_dynamic_module_callback_network_get_dynamic_metadata_bool(
+      filterPtr(), {const_cast<char*>(ns.data()), ns.size()},
+      {const_cast<char*>(key.data()), key.size()}, &result);
+
+  EXPECT_FALSE(ok);
+}
+
+TEST_F(DynamicModuleNetworkFilterAbiCallbackTest, GetDynamicMetadataBoolNonExistingKey) {
+  const std::string ns = "test.ns";
+  const std::string key = "nonexistent.key";
+
+  envoy::config::core::v3::Metadata metadata;
+  EXPECT_CALL(connection_.stream_info_, dynamicMetadata())
+      .WillRepeatedly(testing::ReturnRef(metadata));
+  EXPECT_CALL(connection_.stream_info_, setDynamicMetadata(ns, testing::_))
+      .WillRepeatedly(testing::SaveArg<1>(&(*metadata.mutable_filter_metadata())[ns]));
+
+  // Set a different key.
+  const std::string other_key = "other.key";
+  envoy_dynamic_module_callback_network_set_dynamic_metadata_bool(
+      filterPtr(), {const_cast<char*>(ns.data()), ns.size()},
+      {const_cast<char*>(other_key.data()), other_key.size()}, true);
+
+  // Try to get non-existent key.
+  bool result = false;
+  bool ok = envoy_dynamic_module_callback_network_get_dynamic_metadata_bool(
+      filterPtr(), {const_cast<char*>(ns.data()), ns.size()},
+      {const_cast<char*>(key.data()), key.size()}, &result);
+
+  EXPECT_FALSE(ok);
+}
+
+TEST_F(DynamicModuleNetworkFilterAbiCallbackTest, GetDynamicMetadataBoolWrongType) {
+  const std::string ns = "test.ns";
+  const std::string key = "string.key";
+
+  envoy::config::core::v3::Metadata metadata;
+  EXPECT_CALL(connection_.stream_info_, dynamicMetadata())
+      .WillRepeatedly(testing::ReturnRef(metadata));
+  EXPECT_CALL(connection_.stream_info_, setDynamicMetadata(ns, testing::_))
+      .WillRepeatedly(testing::SaveArg<1>(&(*metadata.mutable_filter_metadata())[ns]));
+
+  // Set as string first.
+  const std::string value = "test.value";
+  envoy_dynamic_module_callback_network_set_dynamic_metadata_string(
+      filterPtr(), {const_cast<char*>(ns.data()), ns.size()},
+      {const_cast<char*>(key.data()), key.size()}, {const_cast<char*>(value.data()), value.size()});
+
+  // Try to get as bool. It should fail because it's a string.
+  bool result = false;
+  bool ok = envoy_dynamic_module_callback_network_get_dynamic_metadata_bool(
+      filterPtr(), {const_cast<char*>(ns.data()), ns.size()},
+      {const_cast<char*>(key.data()), key.size()}, &result);
+
+  EXPECT_FALSE(ok);
+}
+
+TEST_F(DynamicModuleNetworkFilterAbiCallbackTest, GetDynamicMetadataStringWrongTypeBool) {
+  const std::string ns = "test.ns";
+  const std::string key = "bool.key";
+
+  envoy::config::core::v3::Metadata metadata;
+  EXPECT_CALL(connection_.stream_info_, dynamicMetadata())
+      .WillRepeatedly(testing::ReturnRef(metadata));
+  EXPECT_CALL(connection_.stream_info_, setDynamicMetadata(ns, testing::_))
+      .WillRepeatedly(testing::SaveArg<1>(&(*metadata.mutable_filter_metadata())[ns]));
+
+  // Set as bool first.
+  envoy_dynamic_module_callback_network_set_dynamic_metadata_bool(
+      filterPtr(), {const_cast<char*>(ns.data()), ns.size()},
+      {const_cast<char*>(key.data()), key.size()}, true);
+
+  // Try to get as string. It should fail because it's a bool.
+  envoy_dynamic_module_type_envoy_buffer result;
+  bool ok = envoy_dynamic_module_callback_network_get_dynamic_metadata_string(
+      filterPtr(), {const_cast<char*>(ns.data()), ns.size()},
+      {const_cast<char*>(key.data()), key.size()}, &result);
+
+  EXPECT_FALSE(ok);
+}
+
+TEST_F(DynamicModuleNetworkFilterAbiCallbackTest, GetDynamicMetadataNumberWrongTypeBool) {
+  const std::string ns = "test.ns";
+  const std::string key = "bool.key";
+
+  envoy::config::core::v3::Metadata metadata;
+  EXPECT_CALL(connection_.stream_info_, dynamicMetadata())
+      .WillRepeatedly(testing::ReturnRef(metadata));
+  EXPECT_CALL(connection_.stream_info_, setDynamicMetadata(ns, testing::_))
+      .WillRepeatedly(testing::SaveArg<1>(&(*metadata.mutable_filter_metadata())[ns]));
+
+  // Set as bool first.
+  envoy_dynamic_module_callback_network_set_dynamic_metadata_bool(
+      filterPtr(), {const_cast<char*>(ns.data()), ns.size()},
+      {const_cast<char*>(key.data()), key.size()}, true);
+
+  // Try to get as number. It should fail because it's a bool.
+  double result = 0.0;
+  bool ok = envoy_dynamic_module_callback_network_get_dynamic_metadata_number(
+      filterPtr(), {const_cast<char*>(ns.data()), ns.size()},
+      {const_cast<char*>(key.data()), key.size()}, &result);
+
+  EXPECT_FALSE(ok);
+}
+
 // =============================================================================
 // Tests for socket options.
 // =============================================================================


### PR DESCRIPTION
## Description

This PR adds the missing `set_dynamic_metadata_bool` to the Network Filter Dynamic Modules.

---

**Commit Message:** dynamic_modules: add set_dynamic_metadata_bool for network filters
**Additional Description:** Added the missing `set_dynamic_metadata_bool` to the Network Filter Dynamic Modules.
**Risk Level:** Low
**Testing:** Added Tests
**Docs Changes:** Added
**Release Notes:** N/A