### PR TITLE
dynamic_modules: refactor RUST SDK to add repr(transparent)

### DIFF
--- a/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
@@ -337,26 +337,32 @@ pub struct ClusterHostCount {
 
 /// The identifier for an EnvoyCounter.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(transparent)]
 pub struct EnvoyCounterId(usize);
 
 /// The identifier for an EnvoyCounterVec.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(transparent)]
 pub struct EnvoyCounterVecId(usize);
 
 /// The identifier for an EnvoyGauge.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(transparent)]
 pub struct EnvoyGaugeId(usize);
 
 /// The identifier for an EnvoyGaugeVec.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(transparent)]
 pub struct EnvoyGaugeVecId(usize);
 
 /// The identifier for an EnvoyHistogram.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(transparent)]
 pub struct EnvoyHistogramId(usize);
 
 /// The identifier for an EnvoyHistogramVec.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(transparent)]
 pub struct EnvoyHistogramVecId(usize);
 
 impl From<envoy_dynamic_module_type_metrics_result>


### PR DESCRIPTION
## Description

We are missing `#[repr(transparent)]` on the metrics methods. This PR is to add it.

---

**Commit Message:** dynamic_modules: refactor RUST SDK to add repr(transparent)
**Additional Description:** Added missing `#[repr(transparent)]` on the metrics methods.
**Risk Level:** Low
**Testing:** CI
**Docs Changes:** N/A
**Release Notes:** N/A