### PR TITLE
rust: take headers & trailers as slice, not vector

### DIFF
--- a/source/extensions/dynamic_modules/sdk/rust/src/http.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/http.rs
@@ -401,7 +401,7 @@ pub trait EnvoyHttpFilterConfig {
   fn send_http_callout<'a>(
     &mut self,
     cluster_name: &'a str,
-    headers: Vec<(&'a str, &'a [u8])>,
+    headers: &'a [(&'a str, &'a [u8])],
     body: Option<&'a [u8]>,
     timeout_milliseconds: u64,
   ) -> (abi::envoy_dynamic_module_type_http_callout_init_result, u64);
@@ -411,7 +411,7 @@ pub trait EnvoyHttpFilterConfig {
   fn start_http_stream<'a>(
     &mut self,
     cluster_name: &'a str,
-    headers: Vec<(&'a str, &'a [u8])>,
+    headers: &'a [(&'a str, &'a [u8])],
     body: Option<&'a [u8]>,
     end_stream: bool,
     timeout_milliseconds: u64,
@@ -439,7 +439,7 @@ pub trait EnvoyHttpFilterConfig {
   unsafe fn send_http_stream_trailers<'a>(
     &mut self,
     stream_handle: u64,
-    trailers: Vec<(&'a str, &'a [u8])>,
+    trailers: &'a [(&'a str, &'a [u8])],
   ) -> bool;
 
   /// Reset an HTTP stream started via [`EnvoyHttpFilterConfig::start_http_stream`].
@@ -580,13 +580,13 @@ impl EnvoyHttpFilterConfig for EnvoyHttpFilterConfigImpl {
   fn send_http_callout<'a>(
     &mut self,
     cluster_name: &'a str,
-    headers: Vec<(&'a str, &'a [u8])>,
+    headers: &'a [(&'a str, &'a [u8])],
     body: Option<&'a [u8]>,
     timeout_milliseconds: u64,
   ) -> (abi::envoy_dynamic_module_type_http_callout_init_result, u64) {
     let body_ptr = body.map(|s| s.as_ptr()).unwrap_or(std::ptr::null());
     let body_length = body.map(|s| s.len()).unwrap_or(0);
-    let HeaderPairSlice(headers_ptr, headers_len) = headers.as_slice().into();
+    let HeaderPairSlice(headers_ptr, headers_len) = headers.into();
     let mut callout_id: u64 = 0;
 
     let result = unsafe {
@@ -610,14 +610,14 @@ impl EnvoyHttpFilterConfig for EnvoyHttpFilterConfigImpl {
   fn start_http_stream<'a>(
     &mut self,
     cluster_name: &'a str,
-    headers: Vec<(&'a str, &'a [u8])>,
+    headers: &'a [(&'a str, &'a [u8])],
     body: Option<&'a [u8]>,
     end_stream: bool,
     timeout_milliseconds: u64,
   ) -> (abi::envoy_dynamic_module_type_http_callout_init_result, u64) {
     let body_ptr = body.map(|s| s.as_ptr()).unwrap_or(std::ptr::null());
     let body_length = body.map(|s| s.len()).unwrap_or(0);
-    let HeaderPairSlice(headers_ptr, headers_len) = headers.as_slice().into();
+    let HeaderPairSlice(headers_ptr, headers_len) = headers.into();
     let mut stream_id: u64 = 0;
 
     let result = unsafe {
@@ -658,9 +658,9 @@ impl EnvoyHttpFilterConfig for EnvoyHttpFilterConfigImpl {
   unsafe fn send_http_stream_trailers<'a>(
     &mut self,
     stream_handle: u64,
-    trailers: Vec<(&'a str, &'a [u8])>,
+    trailers: &'a [(&'a str, &'a [u8])],
   ) -> bool {
-    let HeaderPairSlice(trailers_ptr, trailers_len) = trailers.as_slice().into();
+    let HeaderPairSlice(trailers_ptr, trailers_len) = trailers.into();
     unsafe {
       abi::envoy_dynamic_module_callback_http_filter_config_stream_send_trailers(
         self.raw_ptr,
@@ -849,7 +849,7 @@ pub trait EnvoyHttpFilter {
   fn send_response<'a>(
     &mut self,
     status_code: u32,
-    headers: Vec<(&'a str, &'a [u8])>,
+    headers: &'a [(&'a str, &'a [u8])],
     body: Option<&'a [u8]>,
     details: Option<&'a str>,
   );
@@ -858,7 +858,7 @@ pub trait EnvoyHttpFilter {
   /// Necessary pseudo headers such as :status should be present.
   ///
   /// The headers are passed as a list of key-value pairs.
-  fn send_response_headers<'a>(&mut self, headers: Vec<(&'a str, &'a [u8])>, end_stream: bool);
+  fn send_response_headers<'a>(&mut self, headers: &'a [(&'a str, &'a [u8])], end_stream: bool);
 
   /// Send response body data to the downstream, optionally indicating end of stream.
   fn send_response_data<'a>(&mut self, body: &'a [u8], end_stream: bool);
@@ -866,7 +866,7 @@ pub trait EnvoyHttpFilter {
   /// Send response trailers to the downstream. This implicitly ends the stream.
   ///
   /// The trailers are passed as a list of key-value pairs.
-  fn send_response_trailers<'a>(&mut self, trailers: Vec<(&'a str, &'a [u8])>);
+  fn send_response_trailers<'a>(&mut self, trailers: &'a [(&'a str, &'a [u8])]);
 
   /// add a custom flag to indicate a noteworthy event of this stream. Mutliple flags could be added
   /// and will be concatenated with comma. It should not contain any empty or space characters (' ',
@@ -1238,7 +1238,7 @@ pub trait EnvoyHttpFilter {
   fn send_http_callout<'a>(
     &mut self,
     _cluster_name: &'a str,
-    _headers: Vec<(&'a str, &'a [u8])>,
+    _headers: &'a [(&'a str, &'a [u8])],
     _body: Option<&'a [u8]>,
     _timeout_milliseconds: u64,
   ) -> (
@@ -1265,7 +1265,7 @@ pub trait EnvoyHttpFilter {
   fn start_http_stream<'a>(
     &mut self,
     _cluster_name: &'a str,
-    _headers: Vec<(&'a str, &'a [u8])>,
+    _headers: &'a [(&'a str, &'a [u8])],
     _body: Option<&'a [u8]>,
     _end_stream: bool,
     _timeout_milliseconds: u64,
@@ -1301,7 +1301,7 @@ pub trait EnvoyHttpFilter {
   unsafe fn send_http_stream_trailers<'a>(
     &mut self,
     _stream_handle: u64,
-    _trailers: Vec<(&'a str, &'a [u8])>,
+    _trailers: &'a [(&'a str, &'a [u8])],
   ) -> bool;
 
   /// Reset (cancel) an active HTTP stream.
@@ -1625,7 +1625,7 @@ pub trait EnvoyHttpFilter {
   ///
   /// Returns `true` if the stream recreation was initiated successfully, `false` otherwise (e.g.,
   /// if the request body has not been fully received yet or if the stream cannot be recreated).
-  fn recreate_stream<'a>(&mut self, headers: Option<Vec<(&'a str, &'a [u8])>>) -> bool;
+  fn recreate_stream<'a>(&mut self, headers: Option<&'a [(&'a str, &'a [u8])]>) -> bool;
 
   /// Clear only the cluster selection for the current route without clearing the entire route
   /// cache.
@@ -2125,7 +2125,7 @@ impl EnvoyHttpFilter for EnvoyHttpFilterImpl {
   fn send_response(
     &mut self,
     status_code: u32,
-    headers: Vec<(&str, &[u8])>,
+    headers: &[(&str, &[u8])],
     body: Option<&[u8]>,
     details: Option<&str>,
   ) {
@@ -2134,7 +2134,7 @@ impl EnvoyHttpFilter for EnvoyHttpFilterImpl {
     let details_ptr = details.map(|s| s.as_ptr()).unwrap_or(std::ptr::null());
     let details_length = details.map(|s| s.len()).unwrap_or(0);
 
-    let HeaderPairSlice(headers_ptr, headers_len) = headers.as_slice().into();
+    let HeaderPairSlice(headers_ptr, headers_len) = headers.into();
 
     unsafe {
       abi::envoy_dynamic_module_callback_http_send_response(
@@ -2154,8 +2154,8 @@ impl EnvoyHttpFilter for EnvoyHttpFilterImpl {
     }
   }
 
-  fn send_response_headers(&mut self, headers: Vec<(&str, &[u8])>, end_stream: bool) {
-    let HeaderPairSlice(headers_ptr, headers_len) = headers.as_slice().into();
+  fn send_response_headers(&mut self, headers: &[(&str, &[u8])], end_stream: bool) {
+    let HeaderPairSlice(headers_ptr, headers_len) = headers.into();
 
     unsafe {
       abi::envoy_dynamic_module_callback_http_send_response_headers(
@@ -2177,8 +2177,8 @@ impl EnvoyHttpFilter for EnvoyHttpFilterImpl {
     }
   }
 
-  fn send_response_trailers(&mut self, trailers: Vec<(&str, &[u8])>) {
-    let HeaderPairSlice(trailers_ptr, trailers_len) = trailers.as_slice().into();
+  fn send_response_trailers(&mut self, trailers: &[(&str, &[u8])]) {
+    let HeaderPairSlice(trailers_ptr, trailers_len) = trailers.into();
 
     unsafe {
       abi::envoy_dynamic_module_callback_http_send_response_trailers(
@@ -2790,13 +2790,13 @@ impl EnvoyHttpFilter for EnvoyHttpFilterImpl {
   fn send_http_callout<'a>(
     &mut self,
     cluster_name: &'a str,
-    headers: Vec<(&'a str, &'a [u8])>,
+    headers: &'a [(&'a str, &'a [u8])],
     body: Option<&'a [u8]>,
     timeout_milliseconds: u64,
   ) -> (abi::envoy_dynamic_module_type_http_callout_init_result, u64) {
     let body_ptr = body.map(|s| s.as_ptr()).unwrap_or(std::ptr::null());
     let body_length = body.map(|s| s.len()).unwrap_or(0);
-    let HeaderPairSlice(headers_ptr, headers_len) = headers.as_slice().into();
+    let HeaderPairSlice(headers_ptr, headers_len) = headers.into();
     let mut callout_id: u64 = 0;
 
     let result = unsafe {
@@ -2820,14 +2820,14 @@ impl EnvoyHttpFilter for EnvoyHttpFilterImpl {
   fn start_http_stream<'a>(
     &mut self,
     cluster_name: &'a str,
-    headers: Vec<(&'a str, &'a [u8])>,
+    headers: &'a [(&'a str, &'a [u8])],
     body: Option<&'a [u8]>,
     end_stream: bool,
     timeout_milliseconds: u64,
   ) -> (abi::envoy_dynamic_module_type_http_callout_init_result, u64) {
     let body_ptr = body.map(|s| s.as_ptr()).unwrap_or(std::ptr::null());
     let body_length = body.map(|s| s.len()).unwrap_or(0);
-    let HeaderPairSlice(headers_ptr, headers_len) = headers.as_slice().into();
+    let HeaderPairSlice(headers_ptr, headers_len) = headers.into();
     let mut stream_id: u64 = 0;
 
     let result = unsafe {
@@ -2868,9 +2868,9 @@ impl EnvoyHttpFilter for EnvoyHttpFilterImpl {
   unsafe fn send_http_stream_trailers<'a>(
     &mut self,
     stream_handle: u64,
-    trailers: Vec<(&'a str, &'a [u8])>,
+    trailers: &'a [(&'a str, &'a [u8])],
   ) -> bool {
-    let HeaderPairSlice(trailers_ptr, trailers_len) = trailers.as_slice().into();
+    let HeaderPairSlice(trailers_ptr, trailers_len) = trailers.into();
     unsafe {
       abi::envoy_dynamic_module_callback_http_stream_send_trailers(
         self.raw_ptr,
@@ -3351,10 +3351,10 @@ impl EnvoyHttpFilter for EnvoyHttpFilterImpl {
     }
   }
 
-  fn recreate_stream<'a>(&mut self, headers: Option<Vec<(&'a str, &'a [u8])>>) -> bool {
+  fn recreate_stream<'a>(&mut self, headers: Option<&'a [(&'a str, &'a [u8])]>) -> bool {
     match headers {
-      Some(header_vec) => {
-        let HeaderPairSlice(headers_ptr, headers_len) = header_vec.as_slice().into();
+      Some(headers) => {
+        let HeaderPairSlice(headers_ptr, headers_len) = headers.into();
         unsafe {
           abi::envoy_dynamic_module_callback_http_filter_recreate_stream(
             self.raw_ptr,

--- a/test/extensions/dynamic_modules/test_data/rust/bootstrap_http_combined_test.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/bootstrap_http_combined_test.rs
@@ -206,7 +206,7 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for CombinedHttpFilter {
         envoy_log_error!("get_route_endpoint not found in function registry");
         envoy_filter.send_response(
           503,
-          vec![("x-error-reason", b"function_not_registered")],
+          &[("x-error-reason", b"function_not_registered")],
           Some(b"routing function not registered"),
           Some("function_not_registered"),
         );
@@ -241,7 +241,7 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for CombinedHttpFilter {
         } else {
           envoy_filter.send_response(
             503,
-            vec![("x-error-reason", b"service_not_onboarded")],
+            &[("x-error-reason", b"service_not_onboarded")],
             Some(format!("service '{}' is not onboarded", svc).as_bytes()),
             Some("service_not_onboarded"),
           );

--- a/test/extensions/dynamic_modules/test_data/rust/http.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/http.rs
@@ -441,7 +441,7 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for SendResponseFilter {
   ) -> abi::envoy_dynamic_module_type_on_http_filter_request_headers_status {
     envoy_filter.send_response(
       200,
-      vec![
+      &[
         ("header1", "value1".as_bytes()),
         ("header2", "value2".as_bytes()),
       ],

--- a/test/extensions/dynamic_modules/test_data/rust/http_integration_test.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/http_integration_test.rs
@@ -103,7 +103,7 @@ fn new_http_filter_config_fn<EC: EnvoyHttpFilterConfig, EHF: EnvoyHttpFilter>(
       let callout_done = Arc::new(AtomicBool::new(false));
       let (result, _callout_id) = envoy_filter_config.send_http_callout(
         &cluster_name,
-        vec![
+        &[
           (":path", b"/config-init"),
           (":method", b"GET"),
           ("host", b"example.com"),
@@ -121,7 +121,7 @@ fn new_http_filter_config_fn<EC: EnvoyHttpFilterConfig, EHF: EnvoyHttpFilter>(
       let stream_done = Arc::new(AtomicBool::new(false));
       let (result, _stream_id) = envoy_filter_config.start_http_stream(
         &cluster_name,
-        vec![
+        &[
           (":path", b"/config-stream"),
           (":method", b"GET"),
           ("host", b"example.com"),
@@ -226,9 +226,9 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for ConfigCalloutFilter {
     _end_of_stream: bool,
   ) -> abi::envoy_dynamic_module_type_on_http_filter_request_headers_status {
     if self.callout_done.load(Ordering::SeqCst) {
-      envoy_filter.send_response(200, vec![("x-config-callout", b"success")], None, None);
+      envoy_filter.send_response(200, &[("x-config-callout", b"success")], None, None);
     } else {
-      envoy_filter.send_response(503, vec![("x-config-callout", b"pending")], None, None);
+      envoy_filter.send_response(503, &[("x-config-callout", b"pending")], None, None);
     }
     abi::envoy_dynamic_module_type_on_http_filter_request_headers_status::StopIteration
   }
@@ -279,9 +279,9 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for ConfigStreamFilter {
     _end_of_stream: bool,
   ) -> abi::envoy_dynamic_module_type_on_http_filter_request_headers_status {
     if self.stream_done.load(Ordering::SeqCst) {
-      envoy_filter.send_response(200, vec![("x-config-stream", b"success")], None, None);
+      envoy_filter.send_response(200, &[("x-config-stream", b"success")], None, None);
     } else {
-      envoy_filter.send_response(503, vec![("x-config-stream", b"pending")], None, None);
+      envoy_filter.send_response(503, &[("x-config-stream", b"pending")], None, None);
     }
     abi::envoy_dynamic_module_type_on_http_filter_request_headers_status::StopIteration
   }
@@ -814,7 +814,7 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for SendResponseHttpFilter {
     if self == &SendResponseHttpFilter::RequestHeader {
       envoy_filter.send_response(
         200,
-        vec![("some_header", b"some_value")],
+        &[("some_header", b"some_value")],
         Some(b"local_response_body_from_on_request_headers"),
         Some("test_details"),
       );
@@ -832,7 +832,7 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for SendResponseHttpFilter {
     if self == &SendResponseHttpFilter::RequestBody {
       envoy_filter.send_response(
         200,
-        vec![("some_header", b"some_value")],
+        &[("some_header", b"some_value")],
         Some(b"local_response_body_from_on_request_body"),
         None,
       );
@@ -850,7 +850,7 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for SendResponseHttpFilter {
     if self == &SendResponseHttpFilter::ResponseHeader {
       envoy_filter.send_response(
         500,
-        vec![("some_header", b"some_value")],
+        &[("some_header", b"some_value")],
         Some(b"local_response_body_from_on_response_headers"),
         None,
       );
@@ -886,7 +886,7 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for HttpCalloutsFilter {
   ) -> envoy_dynamic_module_type_on_http_filter_request_headers_status {
     let (result, handle) = envoy_filter.send_http_callout(
       &self.cluster_name,
-      vec![
+      &[
         (":path", b"/"),
         (":method", b"GET"),
         ("host", b"example.com"),
@@ -895,7 +895,7 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for HttpCalloutsFilter {
       1000,
     );
     if result != envoy_dynamic_module_type_http_callout_init_result::Success {
-      envoy_filter.send_response(500, vec![("foo", b"bar")], None, None);
+      envoy_filter.send_response(500, &[("foo", b"bar")], None, None);
     }
     self.callout_handle = handle;
     envoy_dynamic_module_type_on_http_filter_request_headers_status::StopIteration
@@ -939,7 +939,7 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for HttpCalloutsFilter {
 
     envoy_filter.send_response(
       200,
-      vec![("some_header", b"some_value")],
+      &[("some_header", b"some_value")],
       Some(b"local_response_body"),
       Some("callout_success"),
     );
@@ -1078,7 +1078,7 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for FakeExternalCachingFilter {
       // Event from the on_scheduled when the cache key was found.
       1 => {
         let result = self.rx.take().unwrap().recv().unwrap();
-        envoy_filter.send_response(200, vec![("cached", b"yes")], Some(result.as_bytes()), None);
+        envoy_filter.send_response(200, &[("cached", b"yes")], Some(result.as_bytes()), None);
       },
       // Event from the on_response_headers.
       2 => {
@@ -1353,7 +1353,7 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for StreamingTerminalHttpFilter {
     match event_id {
       EVENT_ID_START_RESPONSE => {
         envoy_filter.send_response_headers(
-          vec![
+          &[
             (":status", b"200"),
             ("x-filter", b"terminal"),
             ("trailers", b"x-status"),
@@ -1376,7 +1376,7 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for StreamingTerminalHttpFilter {
           self.send_large_response_chunk(envoy_filter);
         } else {
           envoy_filter.send_response_data(b"Thanks!", false);
-          envoy_filter.send_response_trailers(vec![
+          envoy_filter.send_response_trailers(&[
             ("x-status", b"finished"),
             (
               "x-above-watermark-count",
@@ -1537,7 +1537,7 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for HttpStreamBasicFilter {
   ) -> envoy_dynamic_module_type_on_http_filter_request_headers_status {
     let (result, handle) = envoy_filter.start_http_stream(
       &self.cluster_name,
-      vec![
+      &[
         (":path", b"/"),
         (":method", b"GET"),
         ("host", b"example.com"),
@@ -1548,7 +1548,7 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for HttpStreamBasicFilter {
     );
 
     if result != envoy_dynamic_module_type_http_callout_init_result::Success {
-      envoy_filter.send_response(500, vec![("x-error", b"stream_init_failed")], None, None);
+      envoy_filter.send_response(500, &[("x-error", b"stream_init_failed")], None, None);
       return envoy_dynamic_module_type_on_http_filter_request_headers_status::StopIteration;
     }
 
@@ -1600,7 +1600,7 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for HttpStreamBasicFilter {
 
     envoy_filter.send_response(
       200,
-      vec![("x-stream-test", b"basic")],
+      &[("x-stream-test", b"basic")],
       Some(b"stream_callout_success"),
       None,
     );
@@ -1654,7 +1654,7 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for HttpStreamBidirectionalFilter {
   ) -> envoy_dynamic_module_type_on_http_filter_request_headers_status {
     let (result, handle) = envoy_filter.start_http_stream(
       &self.cluster_name,
-      vec![
+      &[
         (":path", b"/stream"),
         (":method", b"POST"),
         ("host", b"example.com"),
@@ -1665,7 +1665,7 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for HttpStreamBidirectionalFilter {
     );
 
     if result != envoy_dynamic_module_type_http_callout_init_result::Success {
-      envoy_filter.send_response(500, vec![("x-error", b"stream_init_failed")], None, None);
+      envoy_filter.send_response(500, &[("x-error", b"stream_init_failed")], None, None);
       return envoy_dynamic_module_type_on_http_filter_request_headers_status::StopIteration;
     }
 
@@ -1681,9 +1681,8 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for HttpStreamBidirectionalFilter {
     self.data_chunks_sent += 1;
 
     // Send trailers.
-    let success = unsafe {
-      envoy_filter.send_http_stream_trailers(handle, vec![("x-request-trailer", b"value")])
-    };
+    let success =
+      unsafe { envoy_filter.send_http_stream_trailers(handle, &[("x-request-trailer", b"value")]) };
     assert!(success);
     self.trailers_sent = true;
 
@@ -1728,7 +1727,7 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for HttpStreamBidirectionalFilter {
 
     envoy_filter.send_response(
       200,
-      vec![
+      &[
         ("x-stream-test", b"bidirectional"),
         (
           "x-chunks-sent",
@@ -1783,7 +1782,7 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for UpstreamResetFilter {
     // Start a stream that we expect to be reset by the upstream.
     let (result, handle) = envoy_filter.start_http_stream(
       &self.cluster_name,
-      vec![
+      &[
         (":path", b"/reset"),
         (":method", b"GET"),
         ("host", b"example.com"),
@@ -1794,7 +1793,7 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for UpstreamResetFilter {
     );
 
     if result != envoy_dynamic_module_type_http_callout_init_result::Success {
-      envoy_filter.send_response(500, vec![("x-error", b"stream_init_failed")], None, None);
+      envoy_filter.send_response(500, &[("x-error", b"stream_init_failed")], None, None);
       return envoy_dynamic_module_type_on_http_filter_request_headers_status::StopIteration;
     }
 
@@ -1842,11 +1841,6 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for UpstreamResetFilter {
     _reason: envoy_dynamic_module_type_http_stream_reset_reason,
   ) {
     assert_eq!(stream_handle, self.stream_handle);
-    envoy_filter.send_response(
-      200,
-      vec![("x-reset", b"true")],
-      Some(b"upstream_reset"),
-      None,
-    );
+    envoy_filter.send_response(200, &[("x-reset", b"true")], Some(b"upstream_reset"), None);
   }
 }

--- a/test/extensions/dynamic_modules/test_data/rust/http_stream_callouts_test.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/http_stream_callouts_test.rs
@@ -75,7 +75,7 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for BasicStreamLifecycleFilter {
     // Start an HTTP stream.
     let (result, handle) = envoy_filter.start_http_stream(
       &self.cluster_name,
-      vec![
+      &[
         (":path", b"/test"),
         (":method", b"GET"),
         ("host", b"example.com"),
@@ -86,7 +86,7 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for BasicStreamLifecycleFilter {
     );
 
     if result != envoy_dynamic_module_type_http_callout_init_result::Success {
-      envoy_filter.send_response(500, vec![("x-error", b"stream_init_failed")], None, None);
+      envoy_filter.send_response(500, &[("x-error", b"stream_init_failed")], None, None);
       return envoy_dynamic_module_type_on_http_filter_request_headers_status::StopIteration;
     }
 
@@ -120,7 +120,7 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for BasicStreamLifecycleFilter {
     self.received_response = true;
     envoy_filter.send_response(
       200,
-      vec![("x-stream", b"success")],
+      &[("x-stream", b"success")],
       Some(b"stream_callout_success"),
       None,
     );
@@ -171,7 +171,7 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for BidirectionalStreamingFilter {
     // Start an HTTP stream with POST method.
     let (result, handle) = envoy_filter.start_http_stream(
       &self.cluster_name,
-      vec![
+      &[
         (":path", b"/stream"),
         (":method", b"POST"),
         ("host", b"example.com"),
@@ -183,7 +183,7 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for BidirectionalStreamingFilter {
     );
 
     if result != envoy_dynamic_module_type_http_callout_init_result::Success {
-      envoy_filter.send_response(500, vec![("x-error", b"stream_init_failed")], None, None);
+      envoy_filter.send_response(500, &[("x-error", b"stream_init_failed")], None, None);
       return envoy_dynamic_module_type_on_http_filter_request_headers_status::StopIteration;
     }
 
@@ -200,7 +200,7 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for BidirectionalStreamingFilter {
     assert!(success);
 
     // Send trailers to end the stream.
-    let trailers = vec![("x-trailer", b"value" as &[u8])];
+    let trailers = &[("x-trailer", b"value" as &[u8])];
     let success = unsafe { envoy_filter.send_http_stream_trailers(handle, trailers) };
     assert!(success);
 
@@ -223,7 +223,7 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for BidirectionalStreamingFilter {
     let chunks_str = self.chunks_received.to_string();
     envoy_filter.send_response(
       200,
-      vec![("x-chunks-received", chunks_str.as_bytes())],
+      &[("x-chunks-received", chunks_str.as_bytes())],
       Some(b"bidirectional_success"),
       None,
     );
@@ -266,7 +266,7 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for MultipleStreamsFilter {
       let path = format!("/stream{}", i);
       let (result, handle) = envoy_filter.start_http_stream(
         &self.cluster_name,
-        vec![
+        &[
           (":path", path.as_bytes()),
           (":method", b"GET"),
           ("host", b"example.com"),
@@ -282,7 +282,7 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for MultipleStreamsFilter {
     }
 
     if self.stream_handles.len() != 3 {
-      envoy_filter.send_response(500, vec![("x-error", b"stream_init_failed")], None, None);
+      envoy_filter.send_response(500, &[("x-error", b"stream_init_failed")], None, None);
     }
 
     envoy_dynamic_module_type_on_http_filter_request_headers_status::StopIteration
@@ -293,7 +293,7 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for MultipleStreamsFilter {
     self.completed_streams += 1;
 
     if self.completed_streams == 3 {
-      envoy_filter.send_response(200, vec![("x-stream", b"all_success")], None, None);
+      envoy_filter.send_response(200, &[("x-stream", b"all_success")], None, None);
     }
   }
 }
@@ -334,7 +334,7 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for StreamResetFilter {
     // Start a stream to a cluster that will be reset.
     let (result, handle) = envoy_filter.start_http_stream(
       &self.cluster_name,
-      vec![
+      &[
         (":path", b"/slow"),
         (":method", b"GET"),
         ("host", b"example.com"),
@@ -345,7 +345,7 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for StreamResetFilter {
     );
 
     if result != envoy_dynamic_module_type_http_callout_init_result::Success {
-      envoy_filter.send_response(500, vec![("x-error", b"stream_init_failed")], None, None);
+      envoy_filter.send_response(500, &[("x-error", b"stream_init_failed")], None, None);
       return envoy_dynamic_module_type_on_http_filter_request_headers_status::StopIteration;
     }
 
@@ -381,7 +381,7 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for StreamResetFilter {
     // Send response indicating reset occurred.
     envoy_filter.send_response(
       200,
-      vec![("x-stream", b"reset_ok")],
+      &[("x-stream", b"reset_ok")],
       Some(b"stream_was_reset"),
       None,
     );
@@ -427,7 +427,7 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for UpstreamResetFilter {
     // Start a stream that we expect to be reset by the upstream.
     let (result, handle) = envoy_filter.start_http_stream(
       &self.cluster_name,
-      vec![
+      &[
         (":path", b"/reset"),
         (":method", b"GET"),
         ("host", b"example.com"),
@@ -438,7 +438,7 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for UpstreamResetFilter {
     );
 
     if result != envoy_dynamic_module_type_http_callout_init_result::Success {
-      envoy_filter.send_response(500, vec![("x-error", b"stream_init_failed")], None, None);
+      envoy_filter.send_response(500, &[("x-error", b"stream_init_failed")], None, None);
       return envoy_dynamic_module_type_on_http_filter_request_headers_status::StopIteration;
     }
 
@@ -453,11 +453,6 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for UpstreamResetFilter {
     _reason: envoy_dynamic_module_type_http_stream_reset_reason,
   ) {
     assert_eq!(stream_handle, self.stream_handle);
-    envoy_filter.send_response(
-      200,
-      vec![("x-reset", b"true")],
-      Some(b"upstream_reset"),
-      None,
-    );
+    envoy_filter.send_response(200, &[("x-reset", b"true")], Some(b"upstream_reset"), None);
   }
 }


### PR DESCRIPTION
Commit Message:
This allows callers to provide a slice, which could be on the stack, instead of a Vec, which requires allocating on the heap. This is safe since the called functions weren't using the fact that they were taking ownership of the input, and were just producing a slice from the Vec internally and acting on that.

Additional Description:
Since the changed methods are using `unsafe` code, the usual "if it compiles, it's safe" Rust guarantees around lifetimes don't apply. That being said, all the callers were already taking containers of references, so if there is any usage beyond the lifetimes of those values happening with this change, it was present in the previous version of the code.

Risk Level: low
Testing: build and ran unit tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a