### PR TITLE
dynamic_modules: added Cluster/host stats access for lb

### DIFF
--- a/source/extensions/dynamic_modules/abi/abi.h
+++ b/source/extensions/dynamic_modules/abi/abi.h
@@ -8032,6 +8032,25 @@ typedef enum {
   envoy_dynamic_module_type_host_health_Healthy = 2,
 } envoy_dynamic_module_type_host_health;
 
+/**
+ * envoy_dynamic_module_type_host_counter_stat identifies a per-host counter stat.
+ * These correspond to the counters in Envoy's HostStats struct.
+ */
+typedef enum {
+  // Total connection connect failures.
+  envoy_dynamic_module_type_host_counter_stat_CxConnectFail = 0,
+  // Total connections opened.
+  envoy_dynamic_module_type_host_counter_stat_CxTotal = 1,
+  // Total request errors (used for EDS load reporting).
+  envoy_dynamic_module_type_host_counter_stat_RqError = 2,
+  // Total successful requests (used for EDS load reporting).
+  envoy_dynamic_module_type_host_counter_stat_RqSuccess = 3,
+  // Total request timeouts.
+  envoy_dynamic_module_type_host_counter_stat_RqTimeout = 4,
+  // Total requests sent.
+  envoy_dynamic_module_type_host_counter_stat_RqTotal = 5,
+} envoy_dynamic_module_type_host_counter_stat;
+
 // =============================================================================
 // Load Balancer Event Hooks
 // =============================================================================
@@ -8573,6 +8592,21 @@ bool envoy_dynamic_module_callback_lb_context_get_override_host(
 bool envoy_dynamic_module_callback_lb_get_member_update_host_address(
     envoy_dynamic_module_type_lb_envoy_ptr lb_envoy_ptr, size_t index, bool is_added,
     envoy_dynamic_module_type_envoy_buffer* result);
+
+/**
+ * envoy_dynamic_module_callback_lb_get_host_counter_stat returns the value of a per-host counter
+ * stat identified by the stat enum. This provides access to host-level counters such as total
+ * connections, request errors, and request totals.
+ *
+ * @param lb_envoy_ptr is the pointer to the Envoy load balancer object.
+ * @param priority is the priority level.
+ * @param index is the index of the host within all hosts.
+ * @param stat is the counter stat to query.
+ * @return the counter value, or 0 if the host was not found or the stat is invalid.
+ */
+uint64_t envoy_dynamic_module_callback_lb_get_host_counter_stat(
+    envoy_dynamic_module_type_lb_envoy_ptr lb_envoy_ptr, uint32_t priority, size_t index,
+    envoy_dynamic_module_type_host_counter_stat stat);
 
 // =============================================================================
 // Matcher Types

--- a/source/extensions/dynamic_modules/abi_impl.cc
+++ b/source/extensions/dynamic_modules/abi_impl.cc
@@ -658,6 +658,14 @@ __attribute__((weak)) bool envoy_dynamic_module_callback_lb_get_member_update_ho
   return false;
 }
 
+__attribute__((weak)) uint64_t envoy_dynamic_module_callback_lb_get_host_counter_stat(
+    envoy_dynamic_module_type_lb_envoy_ptr, uint32_t, size_t,
+    envoy_dynamic_module_type_host_counter_stat) {
+  IS_ENVOY_BUG("envoy_dynamic_module_callback_lb_get_host_counter_stat: "
+               "not implemented in this context");
+  return 0;
+}
+
 // ---------------------- Matcher callbacks ------------------------
 // These are weak symbols that provide default stub implementations. The actual implementations
 // are provided in the matcher extension abi_impl.cc when the matcher extension is used.

--- a/source/extensions/dynamic_modules/sdk/rust/src/load_balancer.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/load_balancer.rs
@@ -65,6 +65,15 @@ pub trait EnvoyLoadBalancer {
   /// priority. This is useful for connection-aware load balancing decisions.
   fn get_host_active_connections(&self, priority: u32, index: usize) -> u64;
 
+  /// Returns the value of a per-host counter stat. This provides access to host-level counters
+  /// such as total connections, request errors, and request totals.
+  fn get_host_counter_stat(
+    &self,
+    priority: u32,
+    index: usize,
+    stat: abi::envoy_dynamic_module_type_host_counter_stat,
+  ) -> u64;
+
   /// Returns the locality information (region, zone, sub_zone) for a host by index within all
   /// hosts at a given priority. This enables zone-aware and locality-aware load balancing.
   fn get_host_locality(&self, priority: u32, index: usize) -> Option<(String, String, String)>;
@@ -349,6 +358,22 @@ impl EnvoyLoadBalancer for EnvoyLoadBalancerImpl {
         self.lb_ptr,
         priority,
         index,
+      )
+    }
+  }
+
+  fn get_host_counter_stat(
+    &self,
+    priority: u32,
+    index: usize,
+    stat: abi::envoy_dynamic_module_type_host_counter_stat,
+  ) -> u64 {
+    unsafe {
+      abi::envoy_dynamic_module_callback_lb_get_host_counter_stat(
+        self.lb_ptr,
+        priority,
+        index,
+        stat,
       )
     }
   }

--- a/source/extensions/load_balancing_policies/dynamic_modules/abi_impl.cc
+++ b/source/extensions/load_balancing_policies/dynamic_modules/abi_impl.cc
@@ -628,4 +628,36 @@ bool envoy_dynamic_module_callback_lb_get_member_update_host_address(
   return true;
 }
 
+uint64_t envoy_dynamic_module_callback_lb_get_host_counter_stat(
+    envoy_dynamic_module_type_lb_envoy_ptr lb_envoy_ptr, uint32_t priority, size_t index,
+    envoy_dynamic_module_type_host_counter_stat stat) {
+  if (lb_envoy_ptr == nullptr) {
+    return 0;
+  }
+  const auto& host_sets = getLb(lb_envoy_ptr)->prioritySet().hostSetsPerPriority();
+  if (priority >= host_sets.size()) {
+    return 0;
+  }
+  const auto& hosts = host_sets[priority]->hosts();
+  if (index >= hosts.size()) {
+    return 0;
+  }
+  const auto& host_stats = hosts[index]->stats();
+  switch (stat) {
+  case envoy_dynamic_module_type_host_counter_stat_CxConnectFail:
+    return host_stats.cx_connect_fail_.value();
+  case envoy_dynamic_module_type_host_counter_stat_CxTotal:
+    return host_stats.cx_total_.value();
+  case envoy_dynamic_module_type_host_counter_stat_RqError:
+    return host_stats.rq_error_.value();
+  case envoy_dynamic_module_type_host_counter_stat_RqSuccess:
+    return host_stats.rq_success_.value();
+  case envoy_dynamic_module_type_host_counter_stat_RqTimeout:
+    return host_stats.rq_timeout_.value();
+  case envoy_dynamic_module_type_host_counter_stat_RqTotal:
+    return host_stats.rq_total_.value();
+  }
+  return 0;
+}
+
 } // extern "C"

--- a/test/extensions/dynamic_modules/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/abi_impl_test.cc
@@ -825,6 +825,17 @@ TEST(CommonAbiImplTest, LbGetMemberUpdateHostAddressEnvoyBug) {
       "not implemented in this context");
 }
 
+// Test that the weak symbol stub for lb_get_host_counter_stat triggers an ENVOY_BUG when called.
+TEST(CommonAbiImplTest, LbGetHostCounterStatEnvoyBug) {
+  EXPECT_ENVOY_BUG(
+      {
+        auto value = envoy_dynamic_module_callback_lb_get_host_counter_stat(
+            nullptr, 0, 0, envoy_dynamic_module_type_host_counter_stat_RqTotal);
+        EXPECT_EQ(value, 0);
+      },
+      "not implemented in this context");
+}
+
 // =====================================================================
 // Matcher weak symbol stub tests
 // =====================================================================

--- a/test/extensions/dynamic_modules/test_data/c/lb_callbacks_test.c
+++ b/test/extensions/dynamic_modules/test_data/c/lb_callbacks_test.c
@@ -135,6 +135,26 @@ bool envoy_dynamic_module_on_lb_choose_host(
         lb_envoy_ptr, 0, 0);
     (void)active_cx;
 
+    // Test host counter stats.
+    uint64_t cx_total = envoy_dynamic_module_callback_lb_get_host_counter_stat(
+        lb_envoy_ptr, 0, 0, envoy_dynamic_module_type_host_counter_stat_CxTotal);
+    (void)cx_total;
+    uint64_t rq_total = envoy_dynamic_module_callback_lb_get_host_counter_stat(
+        lb_envoy_ptr, 0, 0, envoy_dynamic_module_type_host_counter_stat_RqTotal);
+    (void)rq_total;
+    uint64_t rq_error = envoy_dynamic_module_callback_lb_get_host_counter_stat(
+        lb_envoy_ptr, 0, 0, envoy_dynamic_module_type_host_counter_stat_RqError);
+    (void)rq_error;
+    uint64_t rq_success = envoy_dynamic_module_callback_lb_get_host_counter_stat(
+        lb_envoy_ptr, 0, 0, envoy_dynamic_module_type_host_counter_stat_RqSuccess);
+    (void)rq_success;
+    uint64_t rq_timeout = envoy_dynamic_module_callback_lb_get_host_counter_stat(
+        lb_envoy_ptr, 0, 0, envoy_dynamic_module_type_host_counter_stat_RqTimeout);
+    (void)rq_timeout;
+    uint64_t cx_fail = envoy_dynamic_module_callback_lb_get_host_counter_stat(
+        lb_envoy_ptr, 0, 0, envoy_dynamic_module_type_host_counter_stat_CxConnectFail);
+    (void)cx_fail;
+
     envoy_dynamic_module_type_envoy_buffer region = {NULL, 0};
     envoy_dynamic_module_type_envoy_buffer zone = {NULL, 0};
     envoy_dynamic_module_type_envoy_buffer sub_zone = {NULL, 0};

--- a/test/extensions/load_balancing_policies/dynamic_modules/config_test.cc
+++ b/test/extensions/load_balancing_policies/dynamic_modules/config_test.cc
@@ -555,6 +555,11 @@ TEST_F(DynamicModulesLoadBalancerTest, AbiCallbacksWithNullPointers) {
   // Test member update host address callback with null.
   EXPECT_FALSE(
       envoy_dynamic_module_callback_lb_get_member_update_host_address(nullptr, 0, true, &result));
+
+  // Test host counter stat callback with null.
+  EXPECT_EQ(envoy_dynamic_module_callback_lb_get_host_counter_stat(
+                nullptr, 0, 0, envoy_dynamic_module_type_host_counter_stat_RqTotal),
+            0);
 }
 
 TEST_F(DynamicModulesLoadBalancerTest, AbiCallbacksWithInvalidPriority) {
@@ -598,6 +603,11 @@ TEST_F(DynamicModulesLoadBalancerTest, AbiCallbacksWithInvalidPriority) {
   EXPECT_EQ(envoy_dynamic_module_callback_lb_get_host_active_connections(lb_ptr, 999, 0), 0);
   EXPECT_FALSE(envoy_dynamic_module_callback_lb_get_host_locality(lb_ptr, 999, 0, nullptr, nullptr,
                                                                   nullptr));
+
+  // Test host counter stat with invalid priority.
+  EXPECT_EQ(envoy_dynamic_module_callback_lb_get_host_counter_stat(
+                lb_ptr, 999, 0, envoy_dynamic_module_type_host_counter_stat_RqTotal),
+            0);
 }
 
 TEST_F(DynamicModulesLoadBalancerTest, AbiCallbacksWithInvalidHostIndex) {
@@ -636,6 +646,11 @@ TEST_F(DynamicModulesLoadBalancerTest, AbiCallbacksWithInvalidHostIndex) {
   EXPECT_EQ(envoy_dynamic_module_callback_lb_get_host_active_connections(lb_ptr, 0, 999), 0);
   EXPECT_FALSE(envoy_dynamic_module_callback_lb_get_host_locality(lb_ptr, 0, 999, nullptr, nullptr,
                                                                   nullptr));
+
+  // Test host counter stat with invalid host index.
+  EXPECT_EQ(envoy_dynamic_module_callback_lb_get_host_counter_stat(
+                lb_ptr, 0, 999, envoy_dynamic_module_type_host_counter_stat_RqTotal),
+            0);
 }
 
 TEST_F(DynamicModulesLoadBalancerTest, AbiCallbacksSuccessfulCases) {
@@ -727,6 +742,15 @@ TEST_F(DynamicModulesLoadBalancerTest, AbiCallbacksHostStatsAndLocality) {
   host2_->stats().rq_active_.set(10);
   host2_->stats().cx_active_.set(7);
 
+  // Set counter stats on hosts.
+  host1_->stats().cx_connect_fail_.inc();
+  host1_->stats().cx_connect_fail_.inc();
+  host1_->stats().cx_total_.add(100);
+  host1_->stats().rq_error_.add(3);
+  host1_->stats().rq_success_.add(42);
+  host1_->stats().rq_timeout_.inc();
+  host1_->stats().rq_total_.add(46);
+
   envoy::extensions::load_balancing_policies::dynamic_modules::v3::DynamicModulesLoadBalancerConfig
       config;
   config.mutable_dynamic_module_config()->set_name("lb_round_robin");
@@ -770,6 +794,31 @@ TEST_F(DynamicModulesLoadBalancerTest, AbiCallbacksHostStatsAndLocality) {
   EXPECT_TRUE(
       envoy_dynamic_module_callback_lb_get_host_locality(lb_ptr, 0, 0, &region, nullptr, nullptr));
   EXPECT_EQ(absl::string_view(region.ptr, region.length), "us-east");
+
+  // Verify host counter stats.
+  EXPECT_EQ(envoy_dynamic_module_callback_lb_get_host_counter_stat(
+                lb_ptr, 0, 0, envoy_dynamic_module_type_host_counter_stat_CxConnectFail),
+            2);
+  EXPECT_EQ(envoy_dynamic_module_callback_lb_get_host_counter_stat(
+                lb_ptr, 0, 0, envoy_dynamic_module_type_host_counter_stat_CxTotal),
+            100);
+  EXPECT_EQ(envoy_dynamic_module_callback_lb_get_host_counter_stat(
+                lb_ptr, 0, 0, envoy_dynamic_module_type_host_counter_stat_RqError),
+            3);
+  EXPECT_EQ(envoy_dynamic_module_callback_lb_get_host_counter_stat(
+                lb_ptr, 0, 0, envoy_dynamic_module_type_host_counter_stat_RqSuccess),
+            42);
+  EXPECT_EQ(envoy_dynamic_module_callback_lb_get_host_counter_stat(
+                lb_ptr, 0, 0, envoy_dynamic_module_type_host_counter_stat_RqTimeout),
+            1);
+  EXPECT_EQ(envoy_dynamic_module_callback_lb_get_host_counter_stat(
+                lb_ptr, 0, 0, envoy_dynamic_module_type_host_counter_stat_RqTotal),
+            46);
+
+  // Verify host2 counter stats are 0 (not set).
+  EXPECT_EQ(envoy_dynamic_module_callback_lb_get_host_counter_stat(
+                lb_ptr, 0, 1, envoy_dynamic_module_type_host_counter_stat_RqTotal),
+            0);
 }
 
 TEST_F(DynamicModulesLoadBalancerTest, HostHealthByAddressSuccess) {


### PR DESCRIPTION
## Description

This PR adds Cluster/host stats access for the Load Balancing Dynamic Module.

---

**Commit Message:** dynamic_modules: added Cluster/host stats access for lb
**Additional Description:** Added Cluster/host stats access for the Load Balancing Dynamic Module.
**Risk Level:** Low
**Testing:** Added Tests
**Docs Changes:** Added
**Release Notes:** N/A