### PR TITLE
feat: implement lua filterState set

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -613,5 +613,10 @@ new_features:
     check against provided CRLs failed: unable to get certificate CRL, certificate CRL distribution points:
     [http://crl.example.com/ca.crl, http://backup-crl.example.com/ca.crl]``). This provides better visibility into CRL
     validation failures and helps operators identify connectivity or CRL server issues without requiring debug-level logging.
+- area: lua
+  change: |
+    Added :ref:`set() <config_http_filters_lua_stream_info_filter_state_wrapper>` to the Lua filter
+    state API, allowing Lua scripts to create and store filter state objects dynamically using
+    registered object factories.
 
 deprecated:

--- a/docs/root/configuration/http/http_filters/lua_filter.rst
+++ b/docs/root/configuration/http/http_filters/lua_filter.rst
@@ -1345,6 +1345,50 @@ Objects that support field access can have specific fields retrieved using the o
     end
   end
 
+``set()``
+^^^^^^^^^
+
+.. code-block:: lua
+
+  filterState:set(objectKey, factoryKey, payload)
+
+Sets a filter state object by name using a registered :ref:`object factory <well_known_filter_state>`.
+
+* ``objectKey`` is a string that specifies the name under which the object is stored in filter state.
+* ``factoryKey`` is a string that specifies the registered ``ObjectFactory`` name used to create the object. See :ref:`well-known filter state objects <well_known_filter_state>` for the list of available factory keys.
+* ``payload`` is a string passed to the factory's ``createFromBytes`` method.
+
+The object is stored as read-only with filter chain lifespan and no upstream sharing.
+
+Raises a Lua error if the factory key is not registered or if the factory fails to create an object from the given payload.
+
+.. code-block:: lua
+
+  function envoy_on_request(request_handle)
+    local filter_state = request_handle:streamInfo():filterState()
+
+    -- Set a simple string value using the generic string factory.
+    filter_state:set("my.custom.key", "envoy.string", "my-value")
+
+    -- Override upstream SNI.
+    filter_state:set("envoy.network.upstream_server_name", "envoy.network.upstream_server_name", "upstream.example.com")
+
+    -- Override upstream SAN validation with a comma-separated list.
+    filter_state:set("envoy.network.upstream_subject_alt_names", "envoy.network.upstream_subject_alt_names", "san1.example.com,san2.example.com")
+
+    -- Read back the SANs that were just set.
+    local sans = filter_state:get("envoy.network.upstream_subject_alt_names")
+    if sans then
+      request_handle:logInfo("Upstream SANs: " .. sans)
+    end
+
+    -- Read back a value that was just set.
+    local value = filter_state:get("my.custom.key")
+    if value then
+      request_handle:headers():add("x-custom-value", value)
+    end
+  end
+
 .. _config_http_filters_lua_connection_wrapper:
 
 Connection object API

--- a/source/common/network/BUILD
+++ b/source/common/network/BUILD
@@ -609,6 +609,7 @@ envoy_cc_library(
         "//envoy/registry",
         "//envoy/stream_info:filter_state_interface",
         "//source/common/common:macros",
+        "@abseil-cpp//absl/strings",
     ],
 )
 

--- a/source/common/network/upstream_subject_alt_names.h
+++ b/source/common/network/upstream_subject_alt_names.h
@@ -2,6 +2,8 @@
 
 #include "envoy/stream_info/filter_state.h"
 
+#include "absl/strings/str_join.h"
+
 namespace Envoy {
 namespace Network {
 
@@ -14,6 +16,9 @@ public:
   explicit UpstreamSubjectAltNames(const std::vector<std::string>& upstream_subject_alt_names)
       : upstream_subject_alt_names_(upstream_subject_alt_names) {}
   const std::vector<std::string>& value() const { return upstream_subject_alt_names_; }
+  absl::optional<std::string> serializeAsString() const override {
+    return absl::StrJoin(upstream_subject_alt_names_, ",");
+  }
   static const std::string& key();
 
 private:

--- a/source/extensions/filters/http/lua/BUILD
+++ b/source/extensions/filters/http/lua/BUILD
@@ -41,6 +41,7 @@ envoy_cc_library(
     hdrs = ["wrappers.h"],
     deps = [
         "//envoy/http:header_map_interface",
+        "//envoy/registry",
         "//envoy/stream_info:stream_info_interface",
         "//source/common/crypto:utility_lib",
         "//source/common/http:header_utility_lib",

--- a/source/extensions/filters/http/lua/wrappers.cc
+++ b/source/extensions/filters/http/lua/wrappers.cc
@@ -1,5 +1,7 @@
 #include "source/extensions/filters/http/lua/wrappers.h"
 
+#include "envoy/registry/registry.h"
+
 #include "source/common/common/logger.h"
 #include "source/common/http/header_map_impl.h"
 #include "source/common/http/header_utility.h"
@@ -448,6 +450,31 @@ int FilterStateWrapper::luaGet(lua_State* state) {
   }
 
   // If string serialization is not supported, return nil.
+  return 0;
+}
+
+int FilterStateWrapper::luaSet(lua_State* state) {
+  const char* object_key = luaL_checkstring(state, 2);
+  const char* factory_key = luaL_checkstring(state, 3);
+  const char* payload = luaL_checkstring(state, 4);
+
+  const auto* factory =
+      Registry::FactoryRegistry<StreamInfo::FilterState::ObjectFactory>::getFactory(factory_key);
+  if (factory == nullptr) {
+    luaL_error(state, "'%s' does not have an object factory", factory_key);
+    return 0;
+  }
+
+  auto object = factory->createFromBytes(payload);
+  if (object == nullptr) {
+    luaL_error(state, "failed to create an object '%s' from value '%s'", object_key, payload);
+    return 0;
+  }
+
+  streamInfo().filterState()->setData(object_key, std::move(object),
+                                      StreamInfo::FilterState::StateType::ReadOnly,
+                                      StreamInfo::FilterState::LifeSpan::FilterChain,
+                                      StreamInfo::StreamSharingMayImpactPooling::None);
   return 0;
 }
 

--- a/source/extensions/filters/http/lua/wrappers.h
+++ b/source/extensions/filters/http/lua/wrappers.h
@@ -266,7 +266,9 @@ private:
 class FilterStateWrapper : public Filters::Common::Lua::BaseLuaObject<FilterStateWrapper> {
 public:
   FilterStateWrapper(StreamInfoWrapper& parent) : parent_(parent) {}
-  static ExportedFunctions exportedFunctions() { return {{"get", static_luaGet}}; }
+  static ExportedFunctions exportedFunctions() {
+    return {{"get", static_luaGet}, {"set", static_luaSet}};
+  }
 
 private:
   /**
@@ -276,6 +278,15 @@ private:
    * @return filter state value as string, or nil if not found.
    */
   DECLARE_LUA_FUNCTION(FilterStateWrapper, luaGet);
+
+  /**
+   * Set a filter state object by name using a registered factory.
+   * @param 1 (string): object key (the name under which the object is stored).
+   * @param 2 (string): factory key (the registered ObjectFactory name).
+   * @param 3 (string): bytes payload to pass to the factory's createFromBytes.
+   * @return nothing.
+   */
+  DECLARE_LUA_FUNCTION(FilterStateWrapper, luaSet);
 
   StreamInfo::StreamInfo& streamInfo();
 

--- a/test/extensions/filters/http/lua/BUILD
+++ b/test/extensions/filters/http/lua/BUILD
@@ -41,6 +41,7 @@ envoy_extension_cc_test(
     rbe_pool = "6gig",
     deps = [
         "//source/common/network:address_lib",
+        "//source/common/network:upstream_subject_alt_names_lib",
         "//source/common/router:string_accessor_lib",
         "//source/common/stream_info:bool_accessor_lib",
         "//source/common/stream_info:stream_info_lib",
@@ -62,6 +63,7 @@ envoy_extension_cc_test(
     rbe_pool = "4core",
     deps = [
         "//source/common/protobuf:utility_lib",
+        "//source/common/router:string_accessor_lib",
         "//source/extensions/filters/http/lua:config",
         "//source/extensions/filters/http/set_metadata:config",
         "//source/extensions/filters/listener/proxy_protocol:config",

--- a/test/extensions/filters/http/lua/lua_integration_test.cc
+++ b/test/extensions/filters/http/lua/lua_integration_test.cc
@@ -3,6 +3,7 @@
 #include "envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.pb.h"
 
 #include "source/common/protobuf/utility.h"
+#include "source/common/router/string_accessor_impl.h"
 
 #include "test/integration/http_integration.h"
 #include "test/integration/http_protocol_integration.h"
@@ -13,6 +14,18 @@
 
 namespace Envoy {
 namespace {
+
+// Test factory for ``filterState():set()`` integration tests.
+class LuaTestStringObjectFactory : public StreamInfo::FilterState::ObjectFactory {
+public:
+  std::string name() const override { return "lua.test.string"; }
+  std::unique_ptr<StreamInfo::FilterState::Object>
+  createFromBytes(absl::string_view data) const override {
+    return std::make_unique<Router::StringAccessorImpl>(data);
+  }
+};
+
+REGISTER_FACTORY(LuaTestStringObjectFactory, StreamInfo::FilterState::ObjectFactory);
 
 class LuaIntegrationTest : public UpstreamDownstreamIntegrationTest {
 public:
@@ -2260,6 +2273,53 @@ typed_config:
                        .get(Http::LowerCaseString("another_missing"))[0]
                        ->value()
                        .getStringView());
+
+  upstream_request_->encodeHeaders(default_response_headers_, true);
+  ASSERT_TRUE(response->waitForEndStream());
+
+  EXPECT_TRUE(response->complete());
+  EXPECT_EQ("200", response->headers().getStatusValue());
+
+  cleanup();
+}
+
+// Test ``filterState():set()`` functionality to set filter state from Lua.
+TEST_P(LuaIntegrationTest, FilterStateSet) {
+  const std::string FILTER_AND_CODE = R"EOF(
+name: lua
+typed_config:
+  "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
+  default_source_code:
+    inline_string: |
+      function envoy_on_request(request_handle)
+        local stream_info = request_handle:streamInfo()
+
+        -- Set a filter state value using the factory.
+        stream_info:filterState():set("my_key", "lua.test.string", "my_value")
+
+        -- Read back the filter state value.
+        local result = stream_info:filterState():get("my_key")
+        if result then
+          request_handle:headers():add("filter_state_result", result)
+        else
+          request_handle:headers():add("filter_state_result", "not_found")
+        end
+      end
+)EOF";
+
+  initializeFilter(FILTER_AND_CODE);
+  codec_client_ = makeHttpConnection(makeClientConnection(lookupPort("http")));
+  Http::TestRequestHeaderMapImpl request_headers{
+      {":method", "GET"}, {":path", "/test/long/url"}, {":scheme", "http"}, {":authority", "host"}};
+
+  auto response = codec_client_->makeHeaderOnlyRequest(request_headers);
+  waitForNextUpstreamRequest();
+
+  // Verify the filter state was set and read back successfully.
+  EXPECT_EQ("my_value", upstream_request_->headers()
+                            .get(Http::LowerCaseString("filter_state_result"))[0]
+                            ->value()
+                            .getStringView());
 
   upstream_request_->encodeHeaders(default_response_headers_, true);
   ASSERT_TRUE(response->waitForEndStream());

--- a/test/extensions/filters/http/lua/wrappers_test.cc
+++ b/test/extensions/filters/http/lua/wrappers_test.cc
@@ -2,6 +2,7 @@
 
 #include "source/common/http/utility.h"
 #include "source/common/network/address_impl.h"
+#include "source/common/network/upstream_subject_alt_names.h"
 #include "source/common/router/string_accessor_impl.h"
 #include "source/common/stream_info/bool_accessor_impl.h"
 #include "source/common/stream_info/stream_info_impl.h"
@@ -1415,6 +1416,153 @@ TEST_F(LuaStreamInfoWrapperTest, GetFilterStateNullObject) {
   EXPECT_CALL(printer_, testPrint("null_filter_state_returned_nil"));
   EXPECT_CALL(printer_, testPrint("null_filter_state_field_returned_nil"));
   start("callMe");
+  wrapper.reset();
+}
+
+// Test factory for ``filterState():set()`` tests.
+class TestStringObjectFactory : public StreamInfo::FilterState::ObjectFactory {
+public:
+  std::string name() const override { return "test.string"; }
+  std::unique_ptr<StreamInfo::FilterState::Object>
+  createFromBytes(absl::string_view data) const override {
+    return std::make_unique<Router::StringAccessorImpl>(data);
+  }
+};
+
+REGISTER_FACTORY(TestStringObjectFactory, StreamInfo::FilterState::ObjectFactory);
+
+// Test factory that always returns nullptr from createFromBytes.
+class TestNullObjectFactory : public StreamInfo::FilterState::ObjectFactory {
+public:
+  std::string name() const override { return "test.null"; }
+  std::unique_ptr<StreamInfo::FilterState::Object>
+  createFromBytes(absl::string_view) const override {
+    return nullptr;
+  }
+};
+
+REGISTER_FACTORY(TestNullObjectFactory, StreamInfo::FilterState::ObjectFactory);
+
+// Test for ``filterState():set()`` basic functionality.
+TEST_F(LuaStreamInfoWrapperTest, SetFilterStateBasic) {
+  const std::string SCRIPT{R"EOF(
+    function callMe(object)
+      object:filterState():set("my_key", "test.string", "my_value")
+      local result = object:filterState():get("my_key")
+      if result then
+        testPrint("found")
+        testPrint(result)
+      else
+        testPrint("not_found")
+      end
+    end
+  )EOF"};
+
+  InSequence s;
+  setup(SCRIPT);
+
+  StreamInfo::StreamInfoImpl stream_info(Http::Protocol::Http2, test_time_.timeSystem(), nullptr,
+                                         StreamInfo::FilterState::LifeSpan::FilterChain);
+
+  Filters::Common::Lua::LuaDeathRef<StreamInfoWrapper> wrapper(
+      StreamInfoWrapper::create(coroutine_->luaState(), stream_info), true);
+  EXPECT_CALL(printer_, testPrint("found"));
+  EXPECT_CALL(printer_, testPrint("my_value"));
+  start("callMe");
+
+  // Verify the filter state was actually set on the stream info.
+  const auto* accessor =
+      stream_info.filterState()->getDataReadOnly<Router::StringAccessor>("my_key");
+  ASSERT_NE(nullptr, accessor);
+  EXPECT_EQ(accessor->serializeAsString(), "my_value");
+
+  wrapper.reset();
+}
+
+// Test for ``filterState():set()`` with unknown factory key.
+TEST_F(LuaStreamInfoWrapperTest, SetFilterStateUnknownFactory) {
+  const std::string SCRIPT{R"EOF(
+    function callMe(object)
+      object:filterState():set("my_key", "nonexistent.factory", "payload")
+    end
+  )EOF"};
+
+  setup(SCRIPT);
+
+  StreamInfo::StreamInfoImpl stream_info(Http::Protocol::Http2, test_time_.timeSystem(), nullptr,
+                                         StreamInfo::FilterState::LifeSpan::FilterChain);
+
+  Filters::Common::Lua::LuaDeathRef<StreamInfoWrapper> wrapper(
+      StreamInfoWrapper::create(coroutine_->luaState(), stream_info), true);
+  EXPECT_THROW_WITH_MESSAGE(start("callMe"), Filters::Common::Lua::LuaException,
+                            "[string \"...\"]:3: 'nonexistent.factory' does not have an object "
+                            "factory");
+  wrapper.reset();
+}
+
+// Test for ``filterState():set()`` when factory returns nullptr.
+TEST_F(LuaStreamInfoWrapperTest, SetFilterStateFactoryReturnsNull) {
+  const std::string SCRIPT{R"EOF(
+    function callMe(object)
+      object:filterState():set("my_key", "test.null", "payload")
+    end
+  )EOF"};
+
+  setup(SCRIPT);
+
+  StreamInfo::StreamInfoImpl stream_info(Http::Protocol::Http2, test_time_.timeSystem(), nullptr,
+                                         StreamInfo::FilterState::LifeSpan::FilterChain);
+
+  Filters::Common::Lua::LuaDeathRef<StreamInfoWrapper> wrapper(
+      StreamInfoWrapper::create(coroutine_->luaState(), stream_info), true);
+  EXPECT_THROW_WITH_MESSAGE(start("callMe"), Filters::Common::Lua::LuaException,
+                            "[string \"...\"]:3: failed to create an object 'my_key' from value "
+                            "'payload'");
+  wrapper.reset();
+}
+
+// Test for ``filterState():set()`` with envoy.network.upstream_subject_alt_names factory.
+TEST_F(LuaStreamInfoWrapperTest, SetFilterStateUpstreamSubjectAltNames) {
+  const std::string SCRIPT{R"EOF(
+    function callMe(object)
+      -- Set upstream SANs using comma-separated values.
+      object:filterState():set(
+        "envoy.network.upstream_subject_alt_names",
+        "envoy.network.upstream_subject_alt_names",
+        "san1.example.com,san2.example.com,san3.example.com")
+
+      -- Read it back via string serialization to verify it was stored.
+      local result = object:filterState():get("envoy.network.upstream_subject_alt_names")
+      if result then
+        testPrint("found_sans")
+        testPrint(result)
+      else
+        testPrint("sans_not_found")
+      end
+    end
+  )EOF"};
+
+  InSequence s;
+  setup(SCRIPT);
+
+  StreamInfo::StreamInfoImpl stream_info(Http::Protocol::Http2, test_time_.timeSystem(), nullptr,
+                                         StreamInfo::FilterState::LifeSpan::FilterChain);
+
+  Filters::Common::Lua::LuaDeathRef<StreamInfoWrapper> wrapper(
+      StreamInfoWrapper::create(coroutine_->luaState(), stream_info), true);
+  EXPECT_CALL(printer_, testPrint("found_sans"));
+  EXPECT_CALL(printer_, testPrint("san1.example.com,san2.example.com,san3.example.com"));
+  start("callMe");
+
+  // Verify the filter state was set on the C++ side with the correct SANs.
+  const auto* sans = stream_info.filterState()->getDataReadOnly<Network::UpstreamSubjectAltNames>(
+      "envoy.network.upstream_subject_alt_names");
+  ASSERT_NE(nullptr, sans);
+  EXPECT_EQ(3, sans->value().size());
+  EXPECT_EQ("san1.example.com", sans->value()[0]);
+  EXPECT_EQ("san2.example.com", sans->value()[1]);
+  EXPECT_EQ("san3.example.com", sans->value()[2]);
+
   wrapper.reset();
 }
 


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message: feat: implement lua filterState set
Additional Description: Implement `filterState().set(...)` to support setting filter state in Lua scripts. Also implemented `serializeAsString()` for `upstream_subject_alt_names` to support calling `filterState().get()` on this well known filter state.
Risk Level: Low (new feature)
Testing: Unit tests
Docs Changes: Yes
Release Notes: Yes
Platform Specific Features: N/A
Fixes #43698 
