### PR TITLE
dynamic_modules: added response header modification for LB

### DIFF
--- a/source/extensions/dynamic_modules/abi/abi.h
+++ b/source/extensions/dynamic_modules/abi/abi.h
@@ -8578,6 +8578,25 @@ bool envoy_dynamic_module_callback_lb_context_get_override_host(
     envoy_dynamic_module_type_envoy_buffer* address, bool* strict);
 
 /**
+ * envoy_dynamic_module_callback_lb_context_add_response_header adds a response header to be sent
+ * downstream after the upstream response is received. This callback is only valid during the
+ * ``envoy_dynamic_module_on_lb_choose_host`` event hook. Multiple calls will add multiple headers.
+ * The header values are copied so the module can free the buffers after this call returns.
+ *
+ * This uses the ``LoadBalancerContext::setHeadersModifier`` mechanism internally, which is applied
+ * once per request regardless of retries.
+ *
+ * @param lb_envoy_ptr is the pointer to the Envoy load balancer object.
+ * @param context_envoy_ptr is the pointer to the LoadBalancerContext.
+ * @param key is the header name to add.
+ * @param value is the header value to add.
+ */
+void envoy_dynamic_module_callback_lb_context_add_response_header(
+    envoy_dynamic_module_type_lb_envoy_ptr lb_envoy_ptr,
+    envoy_dynamic_module_type_lb_context_envoy_ptr context_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer key, envoy_dynamic_module_type_module_buffer value);
+
+/**
  * envoy_dynamic_module_callback_lb_get_member_update_host_address returns the address of an added
  * or removed host during the on_host_membership_update event hook. This callback is only valid
  * during envoy_dynamic_module_on_lb_on_host_membership_update.

--- a/source/extensions/dynamic_modules/abi_impl.cc
+++ b/source/extensions/dynamic_modules/abi_impl.cc
@@ -666,6 +666,13 @@ __attribute__((weak)) uint64_t envoy_dynamic_module_callback_lb_get_host_counter
   return 0;
 }
 
+__attribute__((weak)) void envoy_dynamic_module_callback_lb_context_add_response_header(
+    envoy_dynamic_module_type_lb_envoy_ptr, envoy_dynamic_module_type_lb_context_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer, envoy_dynamic_module_type_module_buffer) {
+  IS_ENVOY_BUG("envoy_dynamic_module_callback_lb_context_add_response_header: "
+               "not implemented in this context");
+}
+
 // ---------------------- Matcher callbacks ------------------------
 // These are weak symbols that provide default stub implementations. The actual implementations
 // are provided in the matcher extension abi_impl.cc when the matcher extension is used.

--- a/source/extensions/dynamic_modules/sdk/rust/src/load_balancer.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/load_balancer.rs
@@ -191,6 +191,11 @@ pub trait EnvoyLoadBalancer {
   /// `strict` is true, the load balancer should return no host if the override is not valid.
   /// Only valid during choose_host callback.
   fn context_get_override_host(&self) -> Option<(String, bool)>;
+
+  /// Adds a response header to be sent downstream after the upstream response is received.
+  /// Multiple calls will add multiple headers. The header values are copied.
+  /// Only valid during choose_host callback.
+  fn context_add_response_header(&self, key: &str, value: &str);
 }
 
 /// Implementation of EnvoyLoadBalancer that calls into the Envoy ABI.
@@ -813,6 +818,28 @@ impl EnvoyLoadBalancer for EnvoyLoadBalancerImpl {
       }
     } else {
       None
+    }
+  }
+
+  fn context_add_response_header(&self, key: &str, value: &str) {
+    if self.context_ptr.is_null() {
+      return;
+    }
+    let key_buf = abi::envoy_dynamic_module_type_module_buffer {
+      ptr: key.as_ptr() as *const _,
+      length: key.len(),
+    };
+    let value_buf = abi::envoy_dynamic_module_type_module_buffer {
+      ptr: value.as_ptr() as *const _,
+      length: value.len(),
+    };
+    unsafe {
+      abi::envoy_dynamic_module_callback_lb_context_add_response_header(
+        self.lb_ptr,
+        self.context_ptr,
+        key_buf,
+        value_buf,
+      );
     }
   }
 }

--- a/source/extensions/load_balancing_policies/dynamic_modules/abi_impl.cc
+++ b/source/extensions/load_balancing_policies/dynamic_modules/abi_impl.cc
@@ -453,6 +453,19 @@ bool envoy_dynamic_module_callback_lb_context_get_override_host(
   return true;
 }
 
+void envoy_dynamic_module_callback_lb_context_add_response_header(
+    envoy_dynamic_module_type_lb_envoy_ptr lb_envoy_ptr,
+    envoy_dynamic_module_type_lb_context_envoy_ptr context_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer key, envoy_dynamic_module_type_module_buffer value) {
+  if (lb_envoy_ptr == nullptr || context_envoy_ptr == nullptr || key.ptr == nullptr) {
+    return;
+  }
+  getLb(lb_envoy_ptr)
+      ->addPendingResponseHeader(std::string(key.ptr, key.length),
+                                 value.ptr != nullptr ? std::string(value.ptr, value.length)
+                                                      : std::string());
+}
+
 bool envoy_dynamic_module_callback_lb_set_host_data(
     envoy_dynamic_module_type_lb_envoy_ptr lb_envoy_ptr, uint32_t priority, size_t index,
     uintptr_t data) {

--- a/source/extensions/load_balancing_policies/dynamic_modules/load_balancer.cc
+++ b/source/extensions/load_balancing_policies/dynamic_modules/load_balancer.cc
@@ -1,5 +1,7 @@
 #include "source/extensions/load_balancing_policies/dynamic_modules/load_balancer.h"
 
+#include "envoy/http/header_map.h"
+
 namespace Envoy {
 namespace Extensions {
 namespace LoadBalancingPolicies {
@@ -47,6 +49,19 @@ DynamicModuleLoadBalancer::chooseHost(Upstream::LoadBalancerContext* context) {
   uint32_t host_index = 0;
   bool selected = config_->on_choose_host_(this, in_module_lb_, context, &priority, &host_index);
 
+  // Apply any response headers accumulated during on_choose_host.
+  if (!pending_response_headers_.empty()) {
+    if (context != nullptr) {
+      context->setHeadersModifier([headers = std::move(pending_response_headers_)](
+                                      Http::ResponseHeaderMap& response_headers) {
+        for (const auto& [key, value] : headers) {
+          response_headers.addCopy(Http::LowerCaseString(key), value);
+        }
+      });
+    }
+    pending_response_headers_.clear();
+  }
+
   if (!selected) {
     return {nullptr};
   }
@@ -67,6 +82,10 @@ DynamicModuleLoadBalancer::chooseHost(Upstream::LoadBalancerContext* context) {
   }
 
   return {healthy_hosts[host_index]};
+}
+
+void DynamicModuleLoadBalancer::addPendingResponseHeader(std::string key, std::string value) {
+  pending_response_headers_.emplace_back(std::move(key), std::move(value));
 }
 
 Upstream::HostConstSharedPtr

--- a/source/extensions/load_balancing_policies/dynamic_modules/load_balancer.h
+++ b/source/extensions/load_balancing_policies/dynamic_modules/load_balancer.h
@@ -42,6 +42,9 @@ public:
   const Upstream::HostVector* hostsAdded() const { return hosts_added_; }
   const Upstream::HostVector* hostsRemoved() const { return hosts_removed_; }
 
+  // Adds a response header to be set via the context's setHeadersModifier after host selection.
+  void addPendingResponseHeader(std::string key, std::string value);
+
 private:
   DynamicModuleLbConfigSharedPtr config_;
   const Upstream::PrioritySet& priority_set_;
@@ -57,6 +60,9 @@ private:
 
   // Per-host data storage keyed by (priority, index). This is per-LB-instance (per-worker).
   absl::flat_hash_map<std::pair<uint32_t, size_t>, uintptr_t> per_host_data_;
+
+  // Pending response headers accumulated during choose_host, applied via setHeadersModifier.
+  std::vector<std::pair<std::string, std::string>> pending_response_headers_;
 };
 
 } // namespace DynamicModules

--- a/test/extensions/dynamic_modules/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/abi_impl_test.cc
@@ -836,6 +836,18 @@ TEST(CommonAbiImplTest, LbGetHostCounterStatEnvoyBug) {
       "not implemented in this context");
 }
 
+// Test that the weak symbol stub for lb_context_add_response_header triggers an ENVOY_BUG
+// when called.
+TEST(CommonAbiImplTest, LbContextAddResponseHeaderEnvoyBug) {
+  envoy_dynamic_module_type_module_buffer key = {"x-test", 6};
+  envoy_dynamic_module_type_module_buffer value = {"val", 3};
+  EXPECT_ENVOY_BUG(
+      {
+        envoy_dynamic_module_callback_lb_context_add_response_header(nullptr, nullptr, key, value);
+      },
+      "not implemented in this context");
+}
+
 // =====================================================================
 // Matcher weak symbol stub tests
 // =====================================================================

--- a/test/extensions/dynamic_modules/test_data/c/lb_callbacks_test.c
+++ b/test/extensions/dynamic_modules/test_data/c/lb_callbacks_test.c
@@ -193,6 +193,14 @@ bool envoy_dynamic_module_on_lb_choose_host(
     (void)bool_found;
   }
 
+  // Test response header modification via context.
+  if (context_envoy_ptr != NULL) {
+    envoy_dynamic_module_type_module_buffer hdr_key = {"x-lb-test", 9};
+    envoy_dynamic_module_type_module_buffer hdr_value = {"test-value", 10};
+    envoy_dynamic_module_callback_lb_context_add_response_header(
+        lb_envoy_ptr, context_envoy_ptr, hdr_key, hdr_value);
+  }
+
   // Test locality-related callbacks.
   size_t locality_count = envoy_dynamic_module_callback_lb_get_locality_count(lb_envoy_ptr, 0);
   if (locality_count > 0) {

--- a/test/extensions/load_balancing_policies/dynamic_modules/config_test.cc
+++ b/test/extensions/load_balancing_policies/dynamic_modules/config_test.cc
@@ -560,6 +560,15 @@ TEST_F(DynamicModulesLoadBalancerTest, AbiCallbacksWithNullPointers) {
   EXPECT_EQ(envoy_dynamic_module_callback_lb_get_host_counter_stat(
                 nullptr, 0, 0, envoy_dynamic_module_type_host_counter_stat_RqTotal),
             0);
+
+  // Test add response header callback with null pointers (should not crash).
+  envoy_dynamic_module_type_module_buffer key = {"x-test", 6};
+  envoy_dynamic_module_type_module_buffer value = {"value", 5};
+  envoy_dynamic_module_callback_lb_context_add_response_header(nullptr, nullptr, key, value);
+
+  // Test add response header with null value pointer (empty value, should not crash).
+  envoy_dynamic_module_type_module_buffer null_value = {nullptr, 0};
+  envoy_dynamic_module_callback_lb_context_add_response_header(nullptr, nullptr, key, null_value);
 }
 
 TEST_F(DynamicModulesLoadBalancerTest, AbiCallbacksWithInvalidPriority) {
@@ -1574,6 +1583,90 @@ TEST_F(DynamicModulesLoadBalancerTest, CallbacksTestModuleExercisesNewCallbacks)
   ON_CALL(context, computeHashKey()).WillByDefault(Return(absl::optional<uint64_t>(12345)));
 
   auto response = lb->chooseHost(&context);
+  EXPECT_NE(response.host, nullptr);
+}
+
+TEST_F(DynamicModulesLoadBalancerTest, ResponseHeaderModification) {
+  auto metadata = std::make_shared<envoy::config::core::v3::Metadata>();
+  auto& filter_metadata = (*metadata->mutable_filter_metadata())["envoy.lb"];
+  (*filter_metadata.mutable_fields())["version"].set_string_value("v1.0");
+  ON_CALL(*host1_, metadata()).WillByDefault(Return(metadata));
+
+  auto* mock_host_set = priority_set_.getMockHostSet(0);
+  Upstream::HostVector locality0_hosts = {host1_, host2_};
+  std::vector<Upstream::HostVector> hosts_per_locality = {locality0_hosts};
+  auto hosts_per_locality_ptr =
+      std::make_shared<Upstream::HostsPerLocalityImpl>(std::move(hosts_per_locality), false);
+  ON_CALL(*mock_host_set, healthyHostsPerLocality())
+      .WillByDefault(ReturnRef(*hosts_per_locality_ptr));
+
+  auto locality_weights =
+      std::make_shared<Upstream::LocalityWeights>(Upstream::LocalityWeights{100});
+  ON_CALL(*mock_host_set, localityWeights()).WillByDefault(Return(locality_weights));
+
+  envoy::extensions::load_balancing_policies::dynamic_modules::v3::DynamicModulesLoadBalancerConfig
+      config;
+  config.mutable_dynamic_module_config()->set_name("lb_callbacks_test");
+  config.set_lb_policy_name("test_lb");
+
+  Factory factory;
+  auto lb_config_or_error = factory.loadConfig(factory_context_, config);
+  ASSERT_TRUE(lb_config_or_error.ok());
+
+  auto thread_aware_lb =
+      factory.create(OptRef<const Upstream::LoadBalancerConfig>(*lb_config_or_error.value()),
+                     cluster_info_, priority_set_, runtime_, random_, time_source_);
+  ASSERT_NE(thread_aware_lb, nullptr);
+  ASSERT_TRUE(thread_aware_lb->initialize().ok());
+
+  Upstream::LoadBalancerParams params{priority_set_, nullptr};
+  auto lb = thread_aware_lb->factory()->create(params);
+  ASSERT_NE(lb, nullptr);
+
+  NiceMock<Upstream::MockLoadBalancerContext> context;
+  Http::TestRequestHeaderMapImpl headers{{":method", "GET"}};
+  ON_CALL(context, downstreamHeaders()).WillByDefault(Return(&headers));
+
+  // Capture the headers modifier set by the LB.
+  std::function<void(Http::ResponseHeaderMap&)> captured_modifier;
+  EXPECT_CALL(context, setHeadersModifier(testing::_))
+      .WillOnce([&captured_modifier](std::function<void(Http::ResponseHeaderMap&)> modifier) {
+        captured_modifier = std::move(modifier);
+      });
+
+  auto response = lb->chooseHost(&context);
+  EXPECT_NE(response.host, nullptr);
+
+  // Verify the modifier was captured and apply it.
+  ASSERT_NE(captured_modifier, nullptr);
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}};
+  captured_modifier(response_headers);
+  EXPECT_EQ(response_headers.get(Http::LowerCaseString("x-lb-test"))[0]->value().getStringView(),
+            "test-value");
+}
+
+TEST_F(DynamicModulesLoadBalancerTest, ResponseHeaderModificationNoContext) {
+  envoy::extensions::load_balancing_policies::dynamic_modules::v3::DynamicModulesLoadBalancerConfig
+      config;
+  config.mutable_dynamic_module_config()->set_name("lb_round_robin");
+  config.set_lb_policy_name("test_lb");
+
+  Factory factory;
+  auto lb_config_or_error = factory.loadConfig(factory_context_, config);
+  ASSERT_TRUE(lb_config_or_error.ok());
+
+  auto thread_aware_lb =
+      factory.create(OptRef<const Upstream::LoadBalancerConfig>(*lb_config_or_error.value()),
+                     cluster_info_, priority_set_, runtime_, random_, time_source_);
+  ASSERT_NE(thread_aware_lb, nullptr);
+  ASSERT_TRUE(thread_aware_lb->initialize().ok());
+
+  Upstream::LoadBalancerParams params{priority_set_, nullptr};
+  auto lb = thread_aware_lb->factory()->create(params);
+  ASSERT_NE(lb, nullptr);
+
+  // With null context, chooseHost should still work without crash.
+  auto response = lb->chooseHost(nullptr);
   EXPECT_NE(response.host, nullptr);
 }
 


### PR DESCRIPTION
## Description

This PR adds a way to do response header modification for LB Dynamic Modules.

---

**Commit Message**: dynamic_modules: added response header modification for LB
**Additional Description**: Added a way to do response header modification for LB Dynamic Modules.
**Risk Level:** Low
**Testing:** Added Tests
**Docs Changes**: Added
**Release Notes:** N/A