### PR TITLE
dym: fix the bug where the struct cannot be used as configuration 2

### DIFF
--- a/source/extensions/matching/input_matchers/dynamic_modules/config.cc
+++ b/source/extensions/matching/input_matchers/dynamic_modules/config.cc
@@ -54,7 +54,7 @@ DynamicModuleInputMatcherFactory::createInputMatcherFactoryCb(
   // Parse the matcher config.
   std::string matcher_config_str;
   if (proto_config.has_matcher_config()) {
-    auto config_or_error = MessageUtil::anyToBytes(proto_config.matcher_config());
+    auto config_or_error = MessageUtil::knownAnyToBytes(proto_config.matcher_config());
     if (!config_or_error.ok()) {
       throw EnvoyException("Failed to parse matcher config: " +
                            std::string(config_or_error.status().message()));

--- a/source/extensions/transport_sockets/tls/cert_validator/dynamic_modules/config.cc
+++ b/source/extensions/transport_sockets/tls/cert_validator/dynamic_modules/config.cc
@@ -319,7 +319,7 @@ absl::StatusOr<CertValidatorPtr> DynamicModuleCertValidatorFactory::createCertVa
 
   std::string validator_config_str;
   if (proto_config.has_validator_config()) {
-    auto config_or_error = MessageUtil::anyToBytes(proto_config.validator_config());
+    auto config_or_error = MessageUtil::knownAnyToBytes(proto_config.validator_config());
     RETURN_IF_NOT_OK_REF(config_or_error.status());
     validator_config_str = std::move(config_or_error.value());
   }


### PR DESCRIPTION
Commit Message: dym: fix the bug where the struct cannot be used as configuration 2
Additional Description:

Continuous work of https://github.com/envoyproxy/envoy/pull/43791

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
