### PR TITLE
leds: replace dynamic_cast with static_cast for LbEndpoint resource

### DIFF
--- a/source/extensions/clusters/eds/leds.cc
+++ b/source/extensions/clusters/eds/leds.cc
@@ -67,7 +67,7 @@ LedsSubscription::onConfigUpdate(const std::vector<Config::DecodedResourceRef>& 
     const auto& added_resource_name = added_resource.get().name();
     ENVOY_LOG(trace, "Adding/Updating endpoint {} using LEDS update.", added_resource_name);
     envoy::config::endpoint::v3::LbEndpoint lb_endpoint =
-        dynamic_cast<const envoy::config::endpoint::v3::LbEndpoint&>(
+        static_cast<const envoy::config::endpoint::v3::LbEndpoint&>(
             added_resource.get().resource());
     endpoints_map_[added_resource_name] = std::move(lb_endpoint);
   }


### PR DESCRIPTION
Commit Message:
LedsSubscription extends SubscriptionBase<LbEndpoint>, so the resource type is guaranteed by the typed subscription framework. The dynamic_cast RTTI check is redundant and adds overhead on every endpoint received from the LEDS stream.
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
