### PR TITLE
eds: fix triple hash-map lookup in LEDS batchUpdate

### DIFF
--- a/source/extensions/clusters/eds/eds.cc
+++ b/source/extensions/clusters/eds/eds.cc
@@ -85,10 +85,9 @@ void EdsClusterImpl::BatchUpdateHelper::batchUpdate(PrioritySet::HostUpdateCb& h
 
       // The batchUpdate call must be performed after all the endpoints of all localities
       // were received.
-      ASSERT(parent_.leds_localities_.find(leds_config) != parent_.leds_localities_.end() &&
-             parent_.leds_localities_[leds_config]->isUpdated());
-      for (const auto& [_, lb_endpoint] :
-           parent_.leds_localities_[leds_config]->getEndpointsMap()) {
+      const auto it = parent_.leds_localities_.find(leds_config);
+      ASSERT(it != parent_.leds_localities_.end() && it->second->isUpdated());
+      for (const auto& [_, lb_endpoint] : it->second->getEndpointsMap()) {
         updateLocalityEndpoints(lb_endpoint, locality_lb_endpoint, priority_state_manager,
                                 all_new_hosts);
       }


### PR DESCRIPTION
Commit Message:
batchUpdate() performed three separate lookups on leds_localities_ (find, operator[], operator[]) for the same key. Since the key is a protobuf message hashed via TextFormat::PrintToString, each lookup involves an expensive serialization. Reuse the iterator from a single find() call instead.
Additional Description:
Risk Level: low
Testing: existing tests cover the changed code path
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]