### PR TITLE
deps: add brotli to dataplane_core use_category for TLS cert compression

### DIFF
--- a/bazel/deps.yaml
+++ b/bazel/deps.yaml
@@ -1109,6 +1109,7 @@ brotli:
   project_url: "https://brotli.org"
   release_date: "2025-10-27"
   use_category:
+  - dataplane_core
   - dataplane_ext
   extensions:
   - envoy.compression.brotli.compressor


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message: Add brotli to dataplane_core
Additional Description: #42690 introduced brotli as a core dependency but the deps validation was skipped in its CI run, so the breakage wasn't caught. Failing in https://github.com/envoyproxy/envoy/actions/runs/22792641018/job/66125517667