### PR TITLE
bazel/grpc: Fix go imports

### DIFF
--- a/bazel/dependency_imports.bzl
+++ b/bazel/dependency_imports.bzl
@@ -107,6 +107,7 @@ def envoy_dependency_imports(
             "gazelle:resolve go golang.org/x/net/http2 @org_golang_x_net//http2",
             "gazelle:resolve go golang.org/x/net/http2/hpack @org_golang_x_net//http2/hpack",
             "gazelle:resolve go golang.org/x/net/trace @org_golang_x_net//trace",
+            "gazelle:resolve go golang.org/x/sys/unix @org_golang_x_sys//unix",
         ],
     )
     go_repository(


### PR DESCRIPTION
Commit Message: Add golang.org/x/sys/unix as dependency
Additional Description: Cache is expired/invalidated and hitting dependency failures
Examples:
- https://github.com/envoyproxy/envoy/actions/runs/22830405720/job/66217617905
- https://github.com/envoyproxy/envoy/actions/runs/22827969434/job/66211339364

Looks to stem from https://github.com/envoyproxy/envoy/pull/41746/changes