### PR TITLE
balancer: cache min connection count in exact balance pick loop

### DIFF
--- a/source/common/network/connection_balancer_impl.cc
+++ b/source/common/network/connection_balancer_impl.cc
@@ -1,5 +1,7 @@
 #include "source/common/network/connection_balancer_impl.h"
 
+#include <limits>
+
 namespace Envoy {
 namespace Network {
 
@@ -21,9 +23,11 @@ ExactConnectionBalancerImpl::pickTargetHandler(BalancedConnectionHandler&) {
   BalancedConnectionHandler* min_connection_handler = nullptr;
   {
     absl::MutexLock lock(lock_);
+    uint64_t min_connections = std::numeric_limits<uint64_t>::max();
     for (BalancedConnectionHandler* handler : handlers_) {
-      if (min_connection_handler == nullptr ||
-          handler->numConnections() < min_connection_handler->numConnections()) {
+      const uint64_t connections = handler->numConnections();
+      if (connections < min_connections) {
+        min_connections = connections;
         min_connection_handler = handler;
       }
     }


### PR DESCRIPTION
Commit Message:
Avoid redundant atomic reads in ExactConnectionBalancerImpl::pickTargetHandler by caching the minimum connection count in a local variable. Previously the loop re-read min_connection_handler->numConnections() on every comparison, resulting in 2*(N-1) atomic loads instead of N (where N is the number of worker threads). This reduces lock hold time under contention.
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
