### PR TITLE
mobile: Add paul-r-gall as a mobile maintainer

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -65,10 +65,10 @@ The following Envoy maintainers have final say over any changes only affecting /
 
 * Ali Beyad ([abeyad](https://github.com/abeyad)) (abeyad@google.com)
   * xDS, C++ integration tests.
-* Fredy Wijaya ([fredyw](https://github.com/fredyw)) (fredyw@google.com)
-  * Android, Java, Kotlin, JNI.
 * Dan Zhang ([danzh2010](https://github.com/danzh2010)) (danzh@google.com)
   * Envoy Mobile, QUIC, HTTP/3.
+* Paul Ogilby ([paul-r-gall](https://github.com/paul-r-gall)) (pgal@google.com)
+  * Language APIs, xDS.
 
 # Senior extension maintainers
 


### PR DESCRIPTION
And removes Fredy Wijaya as he's no longer an active maintainer.