### PR TITLE
dynamic_modules: added scheduler support for dynamic module custom clusters

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -421,6 +421,10 @@ new_features:
     <envoy_v3_api_msg_extensions.clusters.dynamic_modules.v3.ClusterConfig>`
     support for dynamic modules, enabling custom service discovery and host management to be implemented
     in dynamic modules.
+- area: dynamic_modules
+  change: |
+    Added scheduler support for dynamic module custom clusters, allowing modules to safely dispatch
+    work to Envoy's main thread from background threads for thread-safe host updates.
 - area: stat_sinks
   change: |
     Added support for exporting OpenTelemetry metrics via HTTP. The new ``http_service`` field

--- a/source/extensions/clusters/dynamic_modules/abi_impl.cc
+++ b/source/extensions/clusters/dynamic_modules/abi_impl.cc
@@ -87,4 +87,26 @@ envoy_dynamic_module_callback_cluster_lb_get_healthy_host(
   return const_cast<Envoy::Upstream::Host*>(healthy_hosts[index].get());
 }
 
+envoy_dynamic_module_type_cluster_scheduler_module_ptr
+envoy_dynamic_module_callback_cluster_scheduler_new(
+    envoy_dynamic_module_type_cluster_envoy_ptr cluster_envoy_ptr) {
+  return Envoy::Extensions::Clusters::DynamicModules::DynamicModuleClusterScheduler::create(
+      getCluster(cluster_envoy_ptr));
+}
+
+void envoy_dynamic_module_callback_cluster_scheduler_delete(
+    envoy_dynamic_module_type_cluster_scheduler_module_ptr scheduler_module_ptr) {
+  delete static_cast<Envoy::Extensions::Clusters::DynamicModules::DynamicModuleClusterScheduler*>(
+      scheduler_module_ptr);
+}
+
+void envoy_dynamic_module_callback_cluster_scheduler_commit(
+    envoy_dynamic_module_type_cluster_scheduler_module_ptr scheduler_module_ptr,
+    uint64_t event_id) {
+  auto* scheduler =
+      static_cast<Envoy::Extensions::Clusters::DynamicModules::DynamicModuleClusterScheduler*>(
+          scheduler_module_ptr);
+  scheduler->commit(event_id);
+}
+
 } // extern "C"

--- a/source/extensions/clusters/dynamic_modules/cluster.cc
+++ b/source/extensions/clusters/dynamic_modules/cluster.cc
@@ -79,6 +79,8 @@ DynamicModuleClusterConfig::create(const std::string& cluster_name,
                  on_cluster_lb_destroy_);
   RESOLVE_SYMBOL("envoy_dynamic_module_on_cluster_lb_choose_host", OnClusterLbChooseHostType,
                  on_cluster_lb_choose_host_);
+  RESOLVE_SYMBOL("envoy_dynamic_module_on_cluster_scheduled", OnClusterScheduledType,
+                 on_cluster_scheduled_);
 
 #undef RESOLVE_SYMBOL
 
@@ -157,6 +159,12 @@ void DynamicModuleCluster::startPreInit() {
 }
 
 void DynamicModuleCluster::preInitComplete() { onPreInitComplete(); }
+
+void DynamicModuleCluster::onScheduled(uint64_t event_id) {
+  if (in_module_cluster_ != nullptr && config_->on_cluster_scheduled_ != nullptr) {
+    config_->on_cluster_scheduled_(this, in_module_cluster_, event_id);
+  }
+}
 
 bool DynamicModuleCluster::addHosts(const std::vector<std::string>& addresses,
                                     const std::vector<uint32_t>& weights,

--- a/source/extensions/clusters/dynamic_modules/cluster.h
+++ b/source/extensions/clusters/dynamic_modules/cluster.h
@@ -24,6 +24,7 @@ namespace Clusters {
 namespace DynamicModules {
 
 class DynamicModuleCluster;
+class DynamicModuleClusterScheduler;
 class DynamicModuleClusterTestPeer;
 
 // Function pointer types for the cluster ABI event hooks.
@@ -35,6 +36,7 @@ using OnClusterDestroyType = decltype(&envoy_dynamic_module_on_cluster_destroy);
 using OnClusterLbNewType = decltype(&envoy_dynamic_module_on_cluster_lb_new);
 using OnClusterLbDestroyType = decltype(&envoy_dynamic_module_on_cluster_lb_destroy);
 using OnClusterLbChooseHostType = decltype(&envoy_dynamic_module_on_cluster_lb_choose_host);
+using OnClusterScheduledType = decltype(&envoy_dynamic_module_on_cluster_scheduled);
 
 /**
  * Configuration for a dynamic module cluster. This holds the loaded dynamic module, resolved
@@ -65,6 +67,7 @@ public:
   OnClusterLbNewType on_cluster_lb_new_ = nullptr;
   OnClusterLbDestroyType on_cluster_lb_destroy_ = nullptr;
   OnClusterLbChooseHostType on_cluster_lb_choose_host_ = nullptr;
+  OnClusterScheduledType on_cluster_scheduled_ = nullptr;
 
   // The in-module configuration pointer.
   envoy_dynamic_module_type_cluster_config_module_ptr in_module_config_ = nullptr;
@@ -102,7 +105,8 @@ using DynamicModuleClusterHandleSharedPtr = std::shared_ptr<DynamicModuleCluster
  * The DynamicModuleCluster delegates host discovery and load balancing to a dynamic module.
  * The module manages hosts via add/remove callbacks and provides its own load balancer.
  */
-class DynamicModuleCluster : public Upstream::ClusterImplBase {
+class DynamicModuleCluster : public Upstream::ClusterImplBase,
+                             public std::enable_shared_from_this<DynamicModuleCluster> {
 public:
   ~DynamicModuleCluster() override;
 
@@ -117,6 +121,11 @@ public:
   size_t removeHosts(const std::vector<Upstream::HostSharedPtr>& hosts);
   Upstream::HostSharedPtr findHost(void* raw_host_ptr);
   void preInitComplete();
+
+  /**
+   * Called when an event is scheduled via DynamicModuleClusterScheduler::commit.
+   */
+  void onScheduled(uint64_t event_id);
 
   // Accessors.
   const DynamicModuleClusterConfigSharedPtr& config() const { return config_; }
@@ -134,6 +143,7 @@ protected:
 
 private:
   friend class DynamicModuleClusterFactory;
+  friend class DynamicModuleClusterScheduler;
   friend class DynamicModuleClusterTestPeer;
   friend class DynamicModuleClusterHandle;
   friend class DynamicModuleLoadBalancer;
@@ -145,6 +155,38 @@ private:
   // Map from raw host pointer to shared pointer for lookup in chooseHost.
   absl::Mutex host_map_lock_;
   absl::flat_hash_map<void*, Upstream::HostSharedPtr> host_map_ ABSL_GUARDED_BY(host_map_lock_);
+};
+
+/**
+ * This class is used to schedule a cluster event hook from a different thread than the main thread.
+ * This is created via envoy_dynamic_module_callback_cluster_scheduler_new and deleted via
+ * envoy_dynamic_module_callback_cluster_scheduler_delete.
+ */
+class DynamicModuleClusterScheduler {
+public:
+  /**
+   * Creates a new scheduler for the given cluster.
+   */
+  static DynamicModuleClusterScheduler* create(DynamicModuleCluster* cluster) {
+    return new DynamicModuleClusterScheduler(cluster->weak_from_this(), cluster->dispatcher_);
+  }
+
+  void commit(uint64_t event_id) {
+    dispatcher_.post([cluster = cluster_, event_id]() {
+      if (std::shared_ptr<DynamicModuleCluster> cluster_shared = cluster.lock()) {
+        cluster_shared->onScheduled(event_id);
+      }
+    });
+  }
+
+private:
+  DynamicModuleClusterScheduler(std::weak_ptr<DynamicModuleCluster> cluster,
+                                Event::Dispatcher& dispatcher)
+      : cluster_(std::move(cluster)), dispatcher_(dispatcher) {}
+
+  // Using a weak pointer to avoid unnecessarily extending the lifetime of the cluster.
+  std::weak_ptr<DynamicModuleCluster> cluster_;
+  Event::Dispatcher& dispatcher_;
 };
 
 /**

--- a/source/extensions/dynamic_modules/abi/abi.h
+++ b/source/extensions/dynamic_modules/abi/abi.h
@@ -7848,6 +7848,21 @@ typedef void* envoy_dynamic_module_type_cluster_host_envoy_ptr;
  */
 typedef void* envoy_dynamic_module_type_cluster_lb_context_envoy_ptr;
 
+/**
+ * envoy_dynamic_module_type_cluster_scheduler_envoy_ptr is a raw pointer to the
+ * DynamicModuleClusterScheduler class in Envoy. This is used to schedule events to the main thread
+ * from background threads.
+ *
+ * OWNERSHIP: The allocation is done by Envoy but the module is responsible for managing the
+ * lifetime of the pointer. Notably, it must be explicitly destroyed by the module
+ * when scheduling cluster events is done. The creation of this pointer is done by
+ * envoy_dynamic_module_callback_cluster_scheduler_new and the scheduling and destruction is done by
+ * envoy_dynamic_module_callback_cluster_scheduler_commit and
+ * envoy_dynamic_module_callback_cluster_scheduler_delete. Since its lifecycle is owned/managed by
+ * the module, this has _module_ptr suffix.
+ */
+typedef void* envoy_dynamic_module_type_cluster_scheduler_module_ptr;
+
 // =============================================================================
 // Cluster Event Hooks
 // =============================================================================
@@ -7946,6 +7961,21 @@ envoy_dynamic_module_type_cluster_host_envoy_ptr envoy_dynamic_module_on_cluster
     envoy_dynamic_module_type_cluster_lb_module_ptr lb_module_ptr,
     envoy_dynamic_module_type_cluster_lb_context_envoy_ptr context_envoy_ptr);
 
+/**
+ * envoy_dynamic_module_on_cluster_scheduled is called on the main thread when an event previously
+ * scheduled via envoy_dynamic_module_callback_cluster_scheduler_commit is dispatched. The module
+ * can use the event_id to distinguish between different scheduled events.
+ *
+ * @param cluster_envoy_ptr is the pointer to the Envoy cluster object. This can be used with
+ * cluster callbacks such as envoy_dynamic_module_callback_cluster_add_hosts.
+ * @param cluster_module_ptr is the pointer to the in-module cluster.
+ * @param event_id is the ID of the event that was scheduled with
+ * envoy_dynamic_module_callback_cluster_scheduler_commit.
+ */
+void envoy_dynamic_module_on_cluster_scheduled(
+    envoy_dynamic_module_type_cluster_envoy_ptr cluster_envoy_ptr,
+    envoy_dynamic_module_type_cluster_module_ptr cluster_module_ptr, uint64_t event_id);
+
 // =============================================================================
 // Cluster Dynamic Module Callbacks
 // =============================================================================
@@ -8021,6 +8051,42 @@ size_t envoy_dynamic_module_callback_cluster_lb_get_healthy_host_count(
 envoy_dynamic_module_type_cluster_host_envoy_ptr
 envoy_dynamic_module_callback_cluster_lb_get_healthy_host(
     envoy_dynamic_module_type_cluster_lb_envoy_ptr lb_envoy_ptr, uint32_t priority, size_t index);
+
+/**
+ * envoy_dynamic_module_callback_cluster_scheduler_new creates a new scheduler for the given
+ * cluster. The scheduler allows the module to dispatch events to the main thread from any thread.
+ *
+ * @param cluster_envoy_ptr is the pointer to the Envoy cluster.
+ * @return envoy_dynamic_module_type_cluster_scheduler_module_ptr is the pointer to the scheduler.
+ * The module is responsible for deleting the scheduler via
+ * envoy_dynamic_module_callback_cluster_scheduler_delete when it is no longer needed.
+ */
+envoy_dynamic_module_type_cluster_scheduler_module_ptr
+envoy_dynamic_module_callback_cluster_scheduler_new(
+    envoy_dynamic_module_type_cluster_envoy_ptr cluster_envoy_ptr);
+
+/**
+ * envoy_dynamic_module_callback_cluster_scheduler_delete deletes a scheduler previously created by
+ * envoy_dynamic_module_callback_cluster_scheduler_new. After this call, the scheduler pointer is
+ * no longer valid.
+ *
+ * @param scheduler_module_ptr is the pointer to the scheduler to delete.
+ */
+void envoy_dynamic_module_callback_cluster_scheduler_delete(
+    envoy_dynamic_module_type_cluster_scheduler_module_ptr scheduler_module_ptr);
+
+/**
+ * envoy_dynamic_module_callback_cluster_scheduler_commit schedules an event to be dispatched on
+ * the main thread. When the event is dispatched, envoy_dynamic_module_on_cluster_scheduled will be
+ * called with the same event_id.
+ *
+ * This function is thread-safe and can be called from any thread.
+ *
+ * @param scheduler_module_ptr is the pointer to the scheduler.
+ * @param event_id is a module-defined identifier to distinguish different scheduled events.
+ */
+void envoy_dynamic_module_callback_cluster_scheduler_commit(
+    envoy_dynamic_module_type_cluster_scheduler_module_ptr scheduler_module_ptr, uint64_t event_id);
 
 // =============================================================================
 // =============================== Load Balancer ===============================

--- a/source/extensions/dynamic_modules/abi_impl.cc
+++ b/source/extensions/dynamic_modules/abi_impl.cc
@@ -396,6 +396,25 @@ envoy_dynamic_module_callback_cluster_lb_get_healthy_host(
   return nullptr;
 }
 
+__attribute__((weak)) envoy_dynamic_module_type_cluster_scheduler_module_ptr
+envoy_dynamic_module_callback_cluster_scheduler_new(envoy_dynamic_module_type_cluster_envoy_ptr) {
+  IS_ENVOY_BUG("envoy_dynamic_module_callback_cluster_scheduler_new: "
+               "not implemented in this context");
+  return nullptr;
+}
+
+__attribute__((weak)) void envoy_dynamic_module_callback_cluster_scheduler_delete(
+    envoy_dynamic_module_type_cluster_scheduler_module_ptr) {
+  IS_ENVOY_BUG("envoy_dynamic_module_callback_cluster_scheduler_delete: "
+               "not implemented in this context");
+}
+
+__attribute__((weak)) void envoy_dynamic_module_callback_cluster_scheduler_commit(
+    envoy_dynamic_module_type_cluster_scheduler_module_ptr, uint64_t) {
+  IS_ENVOY_BUG("envoy_dynamic_module_callback_cluster_scheduler_commit: "
+               "not implemented in this context");
+}
+
 // ---------------------- Load Balancer callbacks ------------------------
 // These are weak symbols that provide default stub implementations. The actual implementations
 // are provided in the load balancing policy extension abi_impl.cc when the extension is used.

--- a/source/extensions/dynamic_modules/sdk/rust/src/cluster.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/cluster.rs
@@ -42,6 +42,14 @@ pub trait Cluster: Send + Sync {
   /// Each worker thread gets its own load balancer instance. The `envoy_lb`
   /// provides thread-local access to the cluster's host set.
   fn new_load_balancer(&self, envoy_lb: &dyn EnvoyClusterLoadBalancer) -> Box<dyn ClusterLb>;
+
+  /// Called on the main thread when a new event is scheduled via
+  /// [`EnvoyClusterScheduler::commit`] for this [`Cluster`].
+  ///
+  /// * `envoy_cluster` can be used to interact with the underlying Envoy cluster object.
+  /// * `event_id` is the ID of the event that was scheduled with [`EnvoyClusterScheduler::commit`]
+  ///   to distinguish multiple scheduled events.
+  fn on_scheduled(&self, _envoy_cluster: &dyn EnvoyCluster, _event_id: u64) {}
 }
 
 /// The module-side load balancer instance.
@@ -94,6 +102,11 @@ pub trait EnvoyCluster: Send + Sync {
   /// This must be called during or after [`Cluster::on_init`] to allow Envoy to start
   /// routing traffic to this cluster.
   fn pre_init_complete(&self);
+
+  /// Create a new implementation of the [`EnvoyClusterScheduler`] trait.
+  ///
+  /// This can be used to schedule an event to the main thread where the cluster is running.
+  fn new_scheduler(&self) -> Box<dyn EnvoyClusterScheduler>;
 }
 
 /// Envoy-side load balancer operations available to the module.
@@ -110,6 +123,46 @@ pub trait EnvoyClusterLoadBalancer: Send {
     priority: u32,
     index: usize,
   ) -> Option<abi::envoy_dynamic_module_type_cluster_host_envoy_ptr>;
+}
+
+/// Envoy-side scheduler that dispatches events to the main thread.
+///
+/// The scheduler can be used from any thread. When [`EnvoyClusterScheduler::commit`] is called,
+/// the event is posted to the main thread dispatcher and [`Cluster::on_scheduled`] will be
+/// invoked on the main thread with the corresponding `event_id`.
+#[automock]
+pub trait EnvoyClusterScheduler: Send + Sync {
+  /// Commit the scheduled event to the main thread.
+  fn commit(&self, event_id: u64);
+}
+
+struct EnvoyClusterSchedulerImpl {
+  raw_ptr: abi::envoy_dynamic_module_type_cluster_scheduler_module_ptr,
+}
+
+unsafe impl Send for EnvoyClusterSchedulerImpl {}
+unsafe impl Sync for EnvoyClusterSchedulerImpl {}
+
+impl Drop for EnvoyClusterSchedulerImpl {
+  fn drop(&mut self) {
+    unsafe {
+      abi::envoy_dynamic_module_callback_cluster_scheduler_delete(self.raw_ptr);
+    }
+  }
+}
+
+impl EnvoyClusterScheduler for EnvoyClusterSchedulerImpl {
+  fn commit(&self, event_id: u64) {
+    unsafe {
+      abi::envoy_dynamic_module_callback_cluster_scheduler_commit(self.raw_ptr, event_id);
+    }
+  }
+}
+
+impl EnvoyClusterScheduler for Box<dyn EnvoyClusterScheduler> {
+  fn commit(&self, event_id: u64) {
+    (**self).commit(event_id);
+  }
 }
 
 // Implementations
@@ -163,6 +216,15 @@ impl EnvoyCluster for EnvoyClusterImpl {
   fn pre_init_complete(&self) {
     unsafe {
       abi::envoy_dynamic_module_callback_cluster_pre_init_complete(self.raw);
+    }
+  }
+
+  fn new_scheduler(&self) -> Box<dyn EnvoyClusterScheduler> {
+    unsafe {
+      let scheduler_ptr = abi::envoy_dynamic_module_callback_cluster_scheduler_new(self.raw);
+      Box::new(EnvoyClusterSchedulerImpl {
+        raw_ptr: scheduler_ptr,
+      })
     }
   }
 }
@@ -313,4 +375,15 @@ pub extern "C" fn envoy_dynamic_module_on_cluster_lb_choose_host(
     Some(host) => host,
     None => std::ptr::null_mut(),
   }
+}
+
+#[no_mangle]
+pub extern "C" fn envoy_dynamic_module_on_cluster_scheduled(
+  cluster_envoy_ptr: abi::envoy_dynamic_module_type_cluster_envoy_ptr,
+  cluster_module_ptr: abi::envoy_dynamic_module_type_cluster_module_ptr,
+  event_id: u64,
+) {
+  let cluster = cluster_module_ptr as *const *const dyn Cluster;
+  let cluster = unsafe { &**cluster };
+  cluster.on_scheduled(&EnvoyClusterImpl::new(cluster_envoy_ptr), event_id);
 }

--- a/source/extensions/dynamic_modules/sdk/rust/src/lib_test.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/lib_test.rs
@@ -3496,3 +3496,97 @@ fn test_lb_config_vec_metric_invalid_id() {
     .record_histogram_value_vec(EnvoyHistogramVecId(999), &["v1"], 1)
     .is_err());
 }
+
+// =============================================================================
+// Cluster Extension FFI stubs for testing.
+// =============================================================================
+
+#[no_mangle]
+pub extern "C" fn envoy_dynamic_module_callback_cluster_add_hosts(
+  _cluster_envoy_ptr: abi::envoy_dynamic_module_type_cluster_envoy_ptr,
+  _addresses: *const abi::envoy_dynamic_module_type_module_buffer,
+  _weights: *const u32,
+  _count: usize,
+  _result_host_ptrs: *mut abi::envoy_dynamic_module_type_cluster_host_envoy_ptr,
+) -> bool {
+  false
+}
+
+#[no_mangle]
+pub extern "C" fn envoy_dynamic_module_callback_cluster_remove_hosts(
+  _cluster_envoy_ptr: abi::envoy_dynamic_module_type_cluster_envoy_ptr,
+  _host_envoy_ptrs: *const abi::envoy_dynamic_module_type_cluster_host_envoy_ptr,
+  _count: usize,
+) -> usize {
+  0
+}
+
+#[no_mangle]
+pub extern "C" fn envoy_dynamic_module_callback_cluster_pre_init_complete(
+  _cluster_envoy_ptr: abi::envoy_dynamic_module_type_cluster_envoy_ptr,
+) {
+}
+
+#[no_mangle]
+pub extern "C" fn envoy_dynamic_module_callback_cluster_lb_get_healthy_host_count(
+  _lb_envoy_ptr: abi::envoy_dynamic_module_type_cluster_lb_envoy_ptr,
+  _priority: u32,
+) -> usize {
+  0
+}
+
+#[no_mangle]
+pub extern "C" fn envoy_dynamic_module_callback_cluster_lb_get_healthy_host(
+  _lb_envoy_ptr: abi::envoy_dynamic_module_type_cluster_lb_envoy_ptr,
+  _priority: u32,
+  _index: usize,
+) -> abi::envoy_dynamic_module_type_cluster_host_envoy_ptr {
+  std::ptr::null_mut()
+}
+
+#[no_mangle]
+pub extern "C" fn envoy_dynamic_module_callback_cluster_scheduler_new(
+  _cluster_envoy_ptr: abi::envoy_dynamic_module_type_cluster_envoy_ptr,
+) -> abi::envoy_dynamic_module_type_cluster_scheduler_module_ptr {
+  std::ptr::null_mut()
+}
+
+#[no_mangle]
+pub extern "C" fn envoy_dynamic_module_callback_cluster_scheduler_delete(
+  _scheduler_module_ptr: abi::envoy_dynamic_module_type_cluster_scheduler_module_ptr,
+) {
+}
+
+#[no_mangle]
+pub extern "C" fn envoy_dynamic_module_callback_cluster_scheduler_commit(
+  _scheduler_module_ptr: abi::envoy_dynamic_module_type_cluster_scheduler_module_ptr,
+  _event_id: u64,
+) {
+}
+
+// =============================================================================
+// Cluster Extension Rust SDK tests.
+// =============================================================================
+
+#[test]
+fn test_cluster_scheduler_mock() {
+  let mut mock_scheduler = cluster::MockEnvoyClusterScheduler::new();
+  mock_scheduler
+    .expect_commit()
+    .with(mockall::predicate::eq(42u64))
+    .times(1)
+    .return_const(());
+  mock_scheduler.commit(42);
+}
+
+#[test]
+fn test_cluster_mock_envoy_cluster_new_scheduler() {
+  let mut mock_cluster = cluster::MockEnvoyCluster::new();
+  mock_cluster.expect_new_scheduler().times(1).returning(|| {
+    let mut mock_scheduler = cluster::MockEnvoyClusterScheduler::new();
+    mock_scheduler.expect_commit().return_const(());
+    Box::new(mock_scheduler)
+  });
+  let scheduler = mock_cluster.new_scheduler();
+  scheduler.commit(100);
+}

--- a/test/extensions/clusters/dynamic_modules/cluster_test.cc
+++ b/test/extensions/clusters/dynamic_modules/cluster_test.cc
@@ -552,6 +552,152 @@ TEST_F(DynamicModuleClusterTest, PreInitFlow) {
   EXPECT_TRUE(initialized);
 }
 
+// Test that the scheduler can be created and deleted via ABI callbacks.
+TEST_F(DynamicModuleClusterTest, SchedulerLifecycle) {
+  auto result = createCluster(makeYamlConfig("cluster_no_op"));
+  ASSERT_TRUE(result.ok()) << result.status().message();
+
+  auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
+  ASSERT_NE(nullptr, cluster);
+
+  // Create a scheduler via the ABI callback.
+  auto* scheduler_ptr = envoy_dynamic_module_callback_cluster_scheduler_new(cluster.get());
+  EXPECT_NE(scheduler_ptr, nullptr);
+
+  // Delete the scheduler via the ABI callback.
+  envoy_dynamic_module_callback_cluster_scheduler_delete(scheduler_ptr);
+}
+
+// Test that the scheduler commit posts to the dispatcher.
+TEST_F(DynamicModuleClusterTest, SchedulerCommit) {
+  auto result = createCluster(makeYamlConfig("cluster_no_op"));
+  ASSERT_TRUE(result.ok()) << result.status().message();
+
+  auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
+  ASSERT_NE(nullptr, cluster);
+
+  // Create a scheduler via the ABI callback.
+  auto* scheduler_ptr = envoy_dynamic_module_callback_cluster_scheduler_new(cluster.get());
+  EXPECT_NE(scheduler_ptr, nullptr);
+
+  // Capture the posted callback from commit.
+  Event::PostCb captured_cb;
+  bool first_captured = false;
+  ON_CALL(server_context_.dispatcher_, post(_))
+      .WillByDefault(testing::Invoke([&](Event::PostCb cb) {
+        if (!first_captured) {
+          captured_cb = std::move(cb);
+          first_captured = true;
+        }
+      }));
+
+  // Commit an event via the ABI callback.
+  envoy_dynamic_module_callback_cluster_scheduler_commit(scheduler_ptr, 42);
+  ASSERT_TRUE(first_captured);
+
+  // Execute the callback to complete the flow.
+  captured_cb();
+
+  // Clean up the scheduler and destroy the result before ON_CALL locals go out of scope.
+  // The result destruction triggers DynamicModuleClusterHandle::~DynamicModuleClusterHandle which
+  // posts to the dispatcher, so the ON_CALL lambda's captured references must still be alive.
+  envoy_dynamic_module_callback_cluster_scheduler_delete(scheduler_ptr);
+  cluster.reset();
+  result = absl::InternalError("cleanup");
+}
+
+// Test that onScheduled is called when the posted callback executes.
+TEST_F(DynamicModuleClusterTest, OnScheduledCallback) {
+  auto result = createCluster(makeYamlConfig("cluster_no_op"));
+  ASSERT_TRUE(result.ok()) << result.status().message();
+
+  auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
+  ASSERT_NE(nullptr, cluster);
+
+  // Create a scheduler via the ABI callback.
+  auto* scheduler_ptr = envoy_dynamic_module_callback_cluster_scheduler_new(cluster.get());
+  EXPECT_NE(scheduler_ptr, nullptr);
+
+  // Capture the posted callback from commit.
+  Event::PostCb captured_cb;
+  bool first_captured = false;
+  ON_CALL(server_context_.dispatcher_, post(_))
+      .WillByDefault(testing::Invoke([&](Event::PostCb cb) {
+        if (!first_captured) {
+          captured_cb = std::move(cb);
+          first_captured = true;
+        }
+      }));
+
+  // Commit an event via the ABI callback.
+  envoy_dynamic_module_callback_cluster_scheduler_commit(scheduler_ptr, 123);
+  ASSERT_TRUE(first_captured);
+
+  // Execute the captured callback to trigger onScheduled.
+  captured_cb();
+
+  // Clean up the scheduler and destroy the result before ON_CALL locals go out of scope.
+  envoy_dynamic_module_callback_cluster_scheduler_delete(scheduler_ptr);
+  cluster.reset();
+  result = absl::InternalError("cleanup");
+}
+
+// Test that onScheduled handles the case when cluster is already destroyed.
+TEST_F(DynamicModuleClusterTest, OnScheduledAfterClusterDestroyed) {
+  Event::PostCb captured_cb;
+  bool first_captured = false;
+
+  {
+    auto result = createCluster(makeYamlConfig("cluster_no_op"));
+    ASSERT_TRUE(result.ok()) << result.status().message();
+
+    auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
+    ASSERT_NE(nullptr, cluster);
+
+    // Create a scheduler via the ABI callback.
+    auto* scheduler_ptr = envoy_dynamic_module_callback_cluster_scheduler_new(cluster.get());
+    EXPECT_NE(scheduler_ptr, nullptr);
+
+    // Capture the posted callback from commit.
+    ON_CALL(server_context_.dispatcher_, post(_))
+        .WillByDefault(testing::Invoke([&](Event::PostCb cb) {
+          if (!first_captured) {
+            captured_cb = std::move(cb);
+            first_captured = true;
+          }
+        }));
+
+    // Commit an event via the ABI callback.
+    envoy_dynamic_module_callback_cluster_scheduler_commit(scheduler_ptr, 456);
+    ASSERT_TRUE(first_captured);
+
+    // Delete the scheduler before the callback is executed.
+    envoy_dynamic_module_callback_cluster_scheduler_delete(scheduler_ptr);
+
+    // Explicitly destroy the result while ON_CALL locals are still alive.
+    // The destruction triggers DynamicModuleClusterHandle::~DynamicModuleClusterHandle which
+    // posts to the dispatcher.
+    cluster.reset();
+    result = absl::InternalError("cleanup");
+  }
+
+  // Execute the captured callback after cluster is destroyed.
+  // This should not crash - the weak_ptr should be expired.
+  captured_cb();
+}
+
+// Test calling onScheduled directly.
+TEST_F(DynamicModuleClusterTest, OnScheduledDirect) {
+  auto result = createCluster(makeYamlConfig("cluster_no_op"));
+  ASSERT_TRUE(result.ok()) << result.status().message();
+
+  auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
+  ASSERT_NE(nullptr, cluster);
+
+  // Call onScheduled directly - this should call the in-module hook.
+  cluster->onScheduled(789);
+}
+
 // Test the DynamicModuleClusterHandle destructor dispatches to main thread.
 TEST_F(DynamicModuleClusterTest, HandleDestructorDispatchesToMainThread) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));

--- a/test/extensions/dynamic_modules/test_data/c/cluster_config_new_fail.c
+++ b/test/extensions/dynamic_modules/test_data/c/cluster_config_new_fail.c
@@ -65,3 +65,11 @@ envoy_dynamic_module_type_cluster_host_envoy_ptr envoy_dynamic_module_on_cluster
   (void)context_envoy_ptr;
   return NULL;
 }
+
+void envoy_dynamic_module_on_cluster_scheduled(
+    envoy_dynamic_module_type_cluster_envoy_ptr cluster_envoy_ptr,
+    envoy_dynamic_module_type_cluster_module_ptr cluster_module_ptr, uint64_t event_id) {
+  (void)cluster_envoy_ptr;
+  (void)cluster_module_ptr;
+  (void)event_id;
+}

--- a/test/extensions/dynamic_modules/test_data/c/cluster_new_fail.c
+++ b/test/extensions/dynamic_modules/test_data/c/cluster_new_fail.c
@@ -65,3 +65,11 @@ envoy_dynamic_module_type_cluster_host_envoy_ptr envoy_dynamic_module_on_cluster
   (void)context_envoy_ptr;
   return NULL;
 }
+
+void envoy_dynamic_module_on_cluster_scheduled(
+    envoy_dynamic_module_type_cluster_envoy_ptr cluster_envoy_ptr,
+    envoy_dynamic_module_type_cluster_module_ptr cluster_module_ptr, uint64_t event_id) {
+  (void)cluster_envoy_ptr;
+  (void)cluster_module_ptr;
+  (void)event_id;
+}

--- a/test/extensions/dynamic_modules/test_data/c/cluster_no_op.c
+++ b/test/extensions/dynamic_modules/test_data/c/cluster_no_op.c
@@ -70,3 +70,11 @@ envoy_dynamic_module_type_cluster_host_envoy_ptr envoy_dynamic_module_on_cluster
   // Return NULL. The C++ test will drive host selection.
   return NULL;
 }
+
+void envoy_dynamic_module_on_cluster_scheduled(
+    envoy_dynamic_module_type_cluster_envoy_ptr cluster_envoy_ptr,
+    envoy_dynamic_module_type_cluster_module_ptr cluster_module_ptr, uint64_t event_id) {
+  (void)cluster_envoy_ptr;
+  (void)cluster_module_ptr;
+  (void)event_id;
+}


### PR DESCRIPTION
## Description

This PR adds scheduler support for dynamic module custom clusters, allowing modules to safely dispatch work to Envoy's main thread from background threads for thread-safe host updates.

---

**Commit Message:** dynamic_modules: added scheduler support for dynamic module custom clusters
**Additional Description:** Added scheduler support for dynamic module custom clusters
**Risk Level:** Low
**Testing:** Added Tests
**Docs Changes:** Added
**Release Notes:** N/A