### PR TITLE
dynamic_modules: added helper functions to the Rust for type-safe sharing

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -509,6 +509,11 @@ new_features:
     cross-module interactions analogous to ``dlsym``.
 - area: dynamic_modules
   change: |
+    Added ``register_shared_state`` and ``get_shared_state`` convenience functions to the Rust SDK
+    for type-safe sharing of ``Arc<T>`` state between extension points (e.g., bootstrap and HTTP
+    filters) within the same module. This is a pure Rust SDK addition with no ABI changes.
+- area: dynamic_modules
+  change: |
     Added support for loading dynamic module binaries from local file paths via the new
     :ref:`module <envoy_v3_api_field_extensions.dynamic_modules.v3.DynamicModuleConfig.module>`
     field in ``DynamicModuleConfig``. This allows specifying an absolute path to a ``.so`` file

--- a/source/extensions/dynamic_modules/abi_impl.cc
+++ b/source/extensions/dynamic_modules/abi_impl.cc
@@ -12,6 +12,7 @@
 #include "source/common/common/logger.h"
 #include "source/extensions/dynamic_modules/abi/abi.h"
 
+#include "absl/base/no_destructor.h"
 #include "absl/container/flat_hash_map.h"
 #include "absl/synchronization/mutex.h"
 
@@ -19,8 +20,14 @@ namespace {
 
 // Process-wide function registry. Modules register function pointers by name during bootstrap,
 // and other modules resolve them by name during configuration creation.
-absl::Mutex function_registry_mutex;
-absl::flat_hash_map<std::string, void*> function_registry ABSL_GUARDED_BY(function_registry_mutex);
+//
+// Wrapped in NoDestructor so that the registry contents including any heap pointers stored as
+// void* values, remain reachable at process exit. Without this, the map destructor would run
+// during static cleanup, freeing the bucket storage before LeakSanitizer scans for reachable
+// allocations, causing false-positive leak reports for data intentionally stored here for the
+// lifetime of the process. For example, Arc<T> pointers from Rust shared state.
+absl::NoDestructor<absl::Mutex> function_registry_mutex;
+absl::NoDestructor<absl::flat_hash_map<std::string, void*>> function_registry;
 
 } // namespace
 
@@ -75,17 +82,17 @@ bool envoy_dynamic_module_callback_register_function(envoy_dynamic_module_type_m
     return false;
   }
   std::string key_str(key.ptr, key.length);
-  absl::WriterMutexLock lock(function_registry_mutex);
-  auto [it, inserted] = function_registry.try_emplace(key_str, function_ptr);
+  absl::WriterMutexLock lock(*function_registry_mutex);
+  auto [it, inserted] = function_registry->try_emplace(key_str, function_ptr);
   return inserted;
 }
 
 bool envoy_dynamic_module_callback_get_function(envoy_dynamic_module_type_module_buffer key,
                                                 void** function_ptr_out) {
   std::string key_str(key.ptr, key.length);
-  absl::ReaderMutexLock lock(function_registry_mutex);
-  auto it = function_registry.find(key_str);
-  if (it != function_registry.end()) {
+  absl::ReaderMutexLock lock(*function_registry_mutex);
+  auto it = function_registry->find(key_str);
+  if (it != function_registry->end()) {
     *function_ptr_out = it->second;
     return true;
   }

--- a/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
@@ -32,8 +32,8 @@ pub use utility::*;
 mod mod_test;
 
 use crate::abi::envoy_dynamic_module_type_metrics_result;
-use std::any::Any;
-use std::sync::OnceLock;
+use std::any::{Any, TypeId};
+use std::sync::{Arc, OnceLock};
 
 /// This module contains the generated bindings for the envoy dynamic modules ABI.
 ///
@@ -158,6 +158,49 @@ pub fn get_function(key: &str) -> Option<*const std::ffi::c_void> {
   } else {
     None
   }
+}
+
+/// Register a typed shared state object accessible by all extensions in this process.
+///
+/// This is a type-safe convenience wrapper over [`register_function`] for sharing `Arc<T>` state
+/// between extension points (e.g., bootstrap and HTTP filters) within the same module. The key is
+/// combined with the concrete `TypeId` of `T`, so two registrations under the same key but
+/// different types will not collide.
+///
+/// The `Arc<T>` is stored as a raw pointer in the process-wide C++ function registry and lives for
+/// the lifetime of the process. Because the registry uses `NoDestructor`, these pointers remain
+/// reachable to LeakSanitizer at process exit, avoiding false-positive leak reports.
+///
+/// Registration is typically done once during bootstrap (e.g., in `on_server_initialized`).
+/// Returns `false` if the key is already registered for the given type.
+///
+/// This is thread-safe and can be called from any thread.
+pub fn register_shared_state<T: Send + Sync + 'static>(key: &str, state: Arc<T>) -> bool {
+  let combined_key = format!("{}:{:?}", key, TypeId::of::<T>());
+  let raw = Arc::into_raw(state);
+  let success = unsafe { register_function(&combined_key, raw as *const std::ffi::c_void) };
+  if !success {
+    unsafe { Arc::from_raw(raw) };
+  }
+  success
+}
+
+/// Retrieve a previously registered typed shared state object by key.
+///
+/// Returns an `Arc<T>` sharing ownership with the originally registered instance. The key is
+/// combined with the concrete `TypeId` of `T`, so lookups are type-safe — requesting the wrong
+/// type for a given key returns `None`.
+///
+/// Resolution is typically done once during configuration creation (e.g., in
+/// `on_http_filter_config_new`) and the result cached for per-request use.
+///
+/// This is thread-safe and can be called from any thread.
+pub fn get_shared_state<T: Send + Sync + 'static>(key: &str) -> Option<Arc<T>> {
+  let combined_key = format!("{}:{:?}", key, TypeId::of::<T>());
+  let ptr = get_function(&combined_key)?;
+  let raw = ptr as *const T;
+  unsafe { Arc::increment_strong_count(raw) };
+  Some(unsafe { Arc::from_raw(raw) })
 }
 
 /// Log a trace message to Envoy's logging system with [dynamic_modules] Id. Messages won't be

--- a/source/extensions/dynamic_modules/sdk/rust/src/lib_test.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/lib_test.rs
@@ -1,6 +1,8 @@
 #![allow(clippy::unnecessary_cast)]
 use crate::*;
 #[cfg(test)]
+use std::collections::HashMap;
+#[cfg(test)]
 use std::sync::atomic::{AtomicBool, AtomicUsize}; // These are used for testing, not for actual concurrency.
 
 #[test]
@@ -2473,6 +2475,58 @@ pub extern "C" fn envoy_dynamic_module_callback_bootstrap_extension_remove_admin
 }
 
 // =============================================================================
+// Function Registry FFI stubs for testing.
+// =============================================================================
+
+struct SendablePtr(*mut std::ffi::c_void);
+// Safety: the pointers stored in the test registry are static function pointers that are safe to
+// access from any thread.
+unsafe impl Send for SendablePtr {}
+
+static FUNCTION_REGISTRY: std::sync::Mutex<Option<HashMap<String, SendablePtr>>> =
+  std::sync::Mutex::new(None);
+
+#[no_mangle]
+pub extern "C" fn envoy_dynamic_module_callback_register_function(
+  key: abi::envoy_dynamic_module_type_module_buffer,
+  function_ptr: *mut std::ffi::c_void,
+) -> bool {
+  if function_ptr.is_null() {
+    return false;
+  }
+  let key_str = unsafe {
+    std::str::from_utf8_unchecked(std::slice::from_raw_parts(key.ptr as *const u8, key.length))
+  };
+  let mut registry = FUNCTION_REGISTRY.lock().unwrap();
+  let map = registry.get_or_insert_with(HashMap::new);
+  if map.contains_key(key_str) {
+    return false;
+  }
+  map.insert(key_str.to_string(), SendablePtr(function_ptr));
+  true
+}
+
+#[no_mangle]
+pub extern "C" fn envoy_dynamic_module_callback_get_function(
+  key: abi::envoy_dynamic_module_type_module_buffer,
+  function_ptr_out: *mut *mut std::ffi::c_void,
+) -> bool {
+  let key_str = unsafe {
+    std::str::from_utf8_unchecked(std::slice::from_raw_parts(key.ptr as *const u8, key.length))
+  };
+  let registry = FUNCTION_REGISTRY.lock().unwrap();
+  if let Some(map) = registry.as_ref() {
+    if let Some(sendable) = map.get(key_str) {
+      unsafe {
+        *function_ptr_out = sendable.0;
+      }
+      return true;
+    }
+  }
+  false
+}
+
+// =============================================================================
 // Bootstrap Extension Tests
 // =============================================================================
 
@@ -3495,4 +3549,117 @@ fn test_lb_config_vec_metric_invalid_id() {
   assert!(mock_config
     .record_histogram_value_vec(EnvoyHistogramVecId(999), &["v1"], 1)
     .is_err());
+}
+
+// =============================================================================
+// Shared State Tests
+// =============================================================================
+
+// These tests use unique keys to avoid collisions with parallel test execution, since the
+// shared state registry is process-wide.
+
+#[test]
+fn test_register_and_get_shared_state() {
+  let state = std::sync::Arc::new(42u64);
+  assert!(register_shared_state("ss_basic", state.clone()));
+
+  let retrieved = get_shared_state::<u64>("ss_basic");
+  assert!(retrieved.is_some());
+  assert_eq!(*retrieved.unwrap(), 42);
+}
+
+#[test]
+fn test_shared_state_duplicate_registration_returns_false() {
+  let state1 = std::sync::Arc::new(1u32);
+  let state2 = std::sync::Arc::new(2u32);
+  assert!(register_shared_state("ss_dup", state1));
+  assert!(!register_shared_state("ss_dup", state2));
+}
+
+#[test]
+fn test_shared_state_get_nonexistent_returns_none() {
+  let result = get_shared_state::<u64>("ss_nonexistent");
+  assert!(result.is_none());
+}
+
+#[test]
+fn test_shared_state_type_safety() {
+  let state = std::sync::Arc::new(100u64);
+  assert!(register_shared_state("ss_typed", state));
+
+  // Same key but different type should return None.
+  let wrong_type = get_shared_state::<u32>("ss_typed");
+  assert!(wrong_type.is_none());
+
+  // Correct type should succeed.
+  let correct_type = get_shared_state::<u64>("ss_typed");
+  assert!(correct_type.is_some());
+  assert_eq!(*correct_type.unwrap(), 100);
+}
+
+#[test]
+fn test_shared_state_different_types_same_key() {
+  let u64_state = std::sync::Arc::new(64u64);
+  let u32_state = std::sync::Arc::new(32u32);
+
+  // Same key, different types should not collide.
+  assert!(register_shared_state("ss_multi_type", u64_state));
+  assert!(register_shared_state("ss_multi_type", u32_state));
+
+  let retrieved_u64 = get_shared_state::<u64>("ss_multi_type");
+  assert!(retrieved_u64.is_some());
+  assert_eq!(*retrieved_u64.unwrap(), 64);
+
+  let retrieved_u32 = get_shared_state::<u32>("ss_multi_type");
+  assert!(retrieved_u32.is_some());
+  assert_eq!(*retrieved_u32.unwrap(), 32);
+}
+
+#[test]
+fn test_shared_state_arc_refcount() {
+  let state = std::sync::Arc::new(String::from("shared"));
+  assert!(register_shared_state("ss_refcount", state));
+
+  // The registry holds one strong ref. Each retrieval clones the Arc, incrementing the refcount.
+  let retrieved = get_shared_state::<String>("ss_refcount").unwrap();
+  assert_eq!(*retrieved, "shared");
+  // 2 refs: one in the registry, one from this retrieval.
+  assert_eq!(std::sync::Arc::strong_count(&retrieved), 2);
+
+  let retrieved2 = get_shared_state::<String>("ss_refcount").unwrap();
+  // 3 refs: one in the registry, one from each retrieval.
+  assert_eq!(std::sync::Arc::strong_count(&retrieved2), 3);
+}
+
+#[test]
+fn test_shared_state_failed_registration_does_not_leak() {
+  let state1 = std::sync::Arc::new(vec![1, 2, 3]);
+  let state2 = std::sync::Arc::new(vec![4, 5, 6]);
+  let state2_clone = state2.clone();
+
+  assert!(register_shared_state("ss_leak", state1));
+  // Duplicate registration should fail and not leak the Arc.
+  assert!(!register_shared_state("ss_leak", state2));
+
+  // state2_clone should still be the only owner (the failed registration reclaimed the Arc).
+  assert_eq!(std::sync::Arc::strong_count(&state2_clone), 1);
+}
+
+#[test]
+fn test_shared_state_with_struct() {
+  #[derive(Debug, PartialEq)]
+  struct Config {
+    endpoint: String,
+    timeout_ms: u64,
+  }
+
+  let config = std::sync::Arc::new(Config {
+    endpoint: "http://localhost:8080".to_string(),
+    timeout_ms: 5000,
+  });
+  assert!(register_shared_state("ss_struct", config));
+
+  let retrieved = get_shared_state::<Config>("ss_struct").unwrap();
+  assert_eq!(retrieved.endpoint, "http://localhost:8080");
+  assert_eq!(retrieved.timeout_ms, 5000);
 }

--- a/test/extensions/dynamic_modules/test_data/rust/bootstrap_function_registry_test.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/bootstrap_function_registry_test.rs
@@ -1,4 +1,5 @@
 use envoy_proxy_dynamic_modules_rust_sdk::*;
+use std::sync::Arc;
 
 declare_bootstrap_init_functions!(my_program_init, my_new_bootstrap_extension_config_fn);
 
@@ -37,6 +38,12 @@ extern "C" fn double_it(x: u64) -> u64 {
   x * 2
 }
 
+#[derive(Debug, PartialEq)]
+struct ServiceConfig {
+  endpoint: String,
+  timeout_ms: u64,
+}
+
 impl BootstrapExtension for MyBootstrapExtension {
   fn on_server_initialized(&mut self, _envoy_extension: &mut dyn EnvoyBootstrapExtension) {
     // Register functions. The registry is process-wide, so these may already exist from a prior
@@ -55,6 +62,46 @@ impl BootstrapExtension for MyBootstrapExtension {
 
     // Non-existent key returns None.
     assert!(get_function("no_such_fn").is_none());
+
+    // --- Typed shared state tests ---
+
+    // Register a typed shared state object.
+    let config = Arc::new(ServiceConfig {
+      endpoint: "http://backend:8080".to_string(),
+      timeout_ms: 3000,
+    });
+    // The shared state is stored in the process-wide C++ function registry. On the first
+    // parameterized test run it succeeds; on subsequent runs the key already exists.
+    let _ = register_shared_state("service_config", config);
+
+    // Retrieve and verify the shared state.
+    let retrieved = get_shared_state::<ServiceConfig>("service_config")
+      .expect("shared state should be retrievable");
+    assert_eq!(retrieved.endpoint, "http://backend:8080");
+    assert_eq!(retrieved.timeout_ms, 3000);
+
+    // Requesting the wrong type for the same key should return None.
+    assert!(get_shared_state::<u64>("service_config").is_none());
+
+    // Non-existent key should return None.
+    assert!(get_shared_state::<ServiceConfig>("nonexistent").is_none());
+
+    // Duplicate registration should return false.
+    let duplicate = Arc::new(ServiceConfig {
+      endpoint: "other".to_string(),
+      timeout_ms: 0,
+    });
+    assert!(!register_shared_state("service_config", duplicate));
+
+    // Multiple retrievals should share ownership via Arc.
+    let retrieved2 = get_shared_state::<ServiceConfig>("service_config").unwrap();
+    assert_eq!(*retrieved, *retrieved2);
+
+    // Different types under the same key should not collide.
+    let _ = register_shared_state("multi", Arc::new(42u64));
+    let _ = register_shared_state("multi", Arc::new(32u32));
+    assert_eq!(*get_shared_state::<u64>("multi").unwrap(), 42);
+    assert_eq!(*get_shared_state::<u32>("multi").unwrap(), 32);
 
     envoy_log_info!("Bootstrap function registry test completed successfully!");
   }


### PR DESCRIPTION
## Description

This PR  adds `register_shared_state` and `get_shared_state` convenience functions to the Rust SDK for type-safe sharing of `Arc<T>` state between extension points (e.g., bootstrap and HTTP filters) within the same module.

---

**Commit Message:** dynamic_modules: added helper functions to the Rust for type-safe sharing
**Additional Description:** Added convenience functions to the Rust SDK for type-safe sharing of `Arc<T>` state between extension points.
**Risk Level:** Low
**Testing:** Added Tests
**Docs Changes:** Added
**Release Notes:** N/A