### PR TITLE
Improve error message for filter_state ENVOY_BUGs

### DIFF
--- a/source/common/stream_info/filter_state_impl.cc
+++ b/source/common/stream_info/filter_state_impl.cc
@@ -36,8 +36,10 @@ void FilterStateImpl::setData(absl::string_view data_name, std::shared_ptr<Objec
                               StreamSharingMayImpactPooling stream_sharing) {
   if (life_span > life_span_) {
     if (hasDataWithNameInternally(data_name)) {
-      IS_ENVOY_BUG("FilterStateAccessViolation: FilterState::setData<T> called twice with "
-                   "conflicting life_span on the same data_name.");
+      IS_ENVOY_BUG(fmt::format("FilterStateAccessViolation: FilterState::setData<T> "
+                               "called twice with "
+                               "conflicting life_span on the same data_name: {}.",
+                               data_name));
       return;
     }
     // Note if ancestor argument of ctor is not nullptr, parent will be created at the time of
@@ -48,8 +50,10 @@ void FilterStateImpl::setData(absl::string_view data_name, std::shared_ptr<Objec
     return;
   }
   if (parent_ && parent_->hasDataWithName(data_name)) {
-    IS_ENVOY_BUG("FilterStateAccessViolation: FilterState::setData<T> called twice with "
-                 "conflicting life_span on the same data_name.");
+    IS_ENVOY_BUG(
+        fmt::format("FilterStateAccessViolation: FilterState::setData<T> called twice with "
+                    "conflicting life_span on the same data_name: {}.",
+                    data_name));
     return;
   }
   const auto& it = data_storage_.find(data_name);
@@ -59,14 +63,16 @@ void FilterStateImpl::setData(absl::string_view data_name, std::shared_ptr<Objec
     // cannot be overwritten by readonly data.
     const FilterStateImpl::FilterObject* current = it->second.get();
     if (current->state_type_ == FilterState::StateType::ReadOnly) {
-      IS_ENVOY_BUG("FilterStateAccessViolation: FilterState::setData<T> called twice on same "
-                   "ReadOnly state.");
+      IS_ENVOY_BUG(fmt::format("FilterStateAccessViolation: FilterState::setData<T> "
+                               "called twice on same ReadOnly state: {}.",
+                               data_name));
       return;
     }
 
     if (current->state_type_ != state_type) {
-      IS_ENVOY_BUG("FilterStateAccessViolation: FilterState::setData<T> called twice with "
-                   "different state types.");
+      IS_ENVOY_BUG(fmt::format("FilterStateAccessViolation: FilterState::setData<T> "
+                               "called twice with different state types: {}.",
+                               data_name));
       return;
     }
   }
@@ -114,7 +120,9 @@ FilterStateImpl::getDataSharedMutableGeneric(absl::string_view data_name) {
 
   FilterStateImpl::FilterObject* current = it->second.get();
   if (current->state_type_ == FilterState::StateType::ReadOnly) {
-    IS_ENVOY_BUG("FilterStateAccessViolation: FilterState accessed immutable data as mutable.");
+    IS_ENVOY_BUG(fmt::format("FilterStateAccessViolation: FilterState accessed "
+                             "immutable data as mutable: {}.",
+                             data_name));
     // To reduce the chances of a crash, allow the mutation in this case instead of returning a
     // nullptr.
   }

--- a/test/common/stream_info/filter_state_impl_test.cc
+++ b/test/common/stream_info/filter_state_impl_test.cc
@@ -161,14 +161,16 @@ TEST_F(FilterStateImplTest, NameConflictReadOnly) {
   // read only data cannot be overwritten (by any state type)
   filterState().setData("test_1", std::make_unique<SimpleType>(1), FilterState::StateType::ReadOnly,
                         FilterState::LifeSpan::FilterChain);
-  EXPECT_ENVOY_BUG(
-      filterState().setData("test_1", std::make_unique<SimpleType>(2),
-                            FilterState::StateType::ReadOnly, FilterState::LifeSpan::FilterChain),
-      "FilterStateAccessViolation: FilterState::setData<T> called twice on same ReadOnly state.");
-  EXPECT_ENVOY_BUG(
-      filterState().setData("test_1", std::make_unique<SimpleType>(2),
-                            FilterState::StateType::Mutable, FilterState::LifeSpan::FilterChain),
-      "FilterStateAccessViolation: FilterState::setData<T> called twice on same ReadOnly state.");
+  EXPECT_ENVOY_BUG(filterState().setData("test_1", std::make_unique<SimpleType>(2),
+                                         FilterState::StateType::ReadOnly,
+                                         FilterState::LifeSpan::FilterChain),
+                   "FilterStateAccessViolation: FilterState::setData<T> called twice on "
+                   "same ReadOnly state: test_1.");
+  EXPECT_ENVOY_BUG(filterState().setData("test_1", std::make_unique<SimpleType>(2),
+                                         FilterState::StateType::Mutable,
+                                         FilterState::LifeSpan::FilterChain),
+                   "FilterStateAccessViolation: FilterState::setData<T> called twice on "
+                   "same ReadOnly state: test_1.");
   EXPECT_EQ(1, filterState().getDataReadOnly<SimpleType>("test_1")->access());
 }
 
@@ -178,7 +180,8 @@ TEST_F(FilterStateImplTest, NameConflictDifferentTypesReadOnly) {
   EXPECT_ENVOY_BUG(
       filterState().setData("test_1", std::make_unique<TestStoredTypeTracking>(2, nullptr, nullptr),
                             FilterState::StateType::ReadOnly, FilterState::LifeSpan::FilterChain),
-      "FilterStateAccessViolation: FilterState::setData<T> called twice on same ReadOnly state.");
+      "FilterStateAccessViolation: FilterState::setData<T> called twice on "
+      "same ReadOnly state: test_1.");
 }
 
 TEST_F(FilterStateImplTest, NameConflictMutableAndReadOnly) {
@@ -189,7 +192,7 @@ TEST_F(FilterStateImplTest, NameConflictMutableAndReadOnly) {
                                          FilterState::StateType::ReadOnly,
                                          FilterState::LifeSpan::FilterChain),
                    "FilterStateAccessViolation: FilterState::setData<T> called twice with "
-                   "different state types.");
+                   "different state types: test_1.");
 }
 
 TEST_F(FilterStateImplTest, NoNameConflictMutableAndMutable) {
@@ -228,9 +231,11 @@ TEST_F(FilterStateImplTest, ErrorAccessingReadOnlyAsMutable) {
   filterState().setData("test_name", std::make_unique<TestStoredTypeTracking>(5, nullptr, nullptr),
                         FilterState::StateType::ReadOnly, FilterState::LifeSpan::FilterChain);
   EXPECT_ENVOY_BUG(filterState().getDataMutable<TestStoredTypeTracking>("test_name"),
-                   "FilterStateAccessViolation: FilterState accessed immutable data as mutable.");
+                   "FilterStateAccessViolation: FilterState accessed immutable "
+                   "data as mutable: test_name.");
   EXPECT_ENVOY_BUG(filterState().getDataSharedMutableGeneric("test_name"),
-                   "FilterStateAccessViolation: FilterState accessed immutable data as mutable.");
+                   "FilterStateAccessViolation: FilterState accessed "
+                   "immutable data as mutable: test_name.");
 }
 
 namespace {
@@ -290,12 +295,14 @@ TEST_F(FilterStateImplTest, LifeSpanInitFromParent) {
   EXPECT_TRUE(new_filter_state.hasDataWithName("test_5"));
   EXPECT_TRUE(new_filter_state.hasDataWithName("test_6"));
   EXPECT_ENVOY_BUG(new_filter_state.getDataMutable<SimpleType>("test_3"),
-                   "FilterStateAccessViolation: FilterState accessed immutable data as mutable.");
+                   "FilterStateAccessViolation: FilterState accessed "
+                   "immutable data as mutable: test_3.");
 
   EXPECT_EQ(4, new_filter_state.getDataMutable<SimpleType>("test_4")->access());
 
   EXPECT_ENVOY_BUG(new_filter_state.getDataMutable<SimpleType>("test_5"),
-                   "FilterStateAccessViolation: FilterState accessed immutable data as mutable.");
+                   "FilterStateAccessViolation: FilterState accessed "
+                   "immutable data as mutable: test_5.");
 
   EXPECT_EQ(6, new_filter_state.getDataMutable<SimpleType>("test_6")->access());
 }
@@ -323,7 +330,8 @@ TEST_F(FilterStateImplTest, LifeSpanInitFromGrandparent) {
   EXPECT_TRUE(new_filter_state.hasDataWithName("test_5"));
   EXPECT_TRUE(new_filter_state.hasDataWithName("test_6"));
   EXPECT_ENVOY_BUG(new_filter_state.getDataMutable<SimpleType>("test_5"),
-                   "FilterStateAccessViolation: FilterState accessed immutable data as mutable.");
+                   "FilterStateAccessViolation: FilterState accessed "
+                   "immutable data as mutable: test_5.");
   EXPECT_EQ(6, new_filter_state.getDataMutable<SimpleType>("test_6")->access());
 }
 
@@ -420,13 +428,13 @@ TEST_F(FilterStateImplTest, SetSameDataWithDifferentLifeSpan) {
                                          FilterState::StateType::Mutable,
                                          FilterState::LifeSpan::FilterChain),
                    "FilterStateAccessViolation: FilterState::setData<T> called twice with "
-                   "conflicting life_span on the same data_name.");
+                   "conflicting life_span on the same data_name: test_1.");
   Assert::resetEnvoyBugCountersForTest();
   EXPECT_ENVOY_BUG(filterState().setData("test_1", std::make_unique<SimpleType>(2),
                                          FilterState::StateType::Mutable,
                                          FilterState::LifeSpan::Request),
                    "FilterStateAccessViolation: FilterState::setData<T> called twice with "
-                   "conflicting life_span on the same data_name.");
+                   "conflicting life_span on the same data_name: test_1.");
 
   // Still mutable on the correct LifeSpan.
   filterState().setData("test_1", std::make_unique<SimpleType>(2), FilterState::StateType::Mutable,
@@ -440,13 +448,13 @@ TEST_F(FilterStateImplTest, SetSameDataWithDifferentLifeSpan) {
                                          FilterState::StateType::Mutable,
                                          FilterState::LifeSpan::FilterChain),
                    "FilterStateAccessViolation: FilterState::setData<T> called twice with "
-                   "conflicting life_span on the same data_name.");
+                   "conflicting life_span on the same data_name: test_2.");
   Assert::resetEnvoyBugCountersForTest();
   EXPECT_ENVOY_BUG(filterState().setData("test_2", std::make_unique<SimpleType>(2),
                                          FilterState::StateType::Mutable,
                                          FilterState::LifeSpan::Connection),
                    "FilterStateAccessViolation: FilterState::setData<T> called twice with "
-                   "conflicting life_span on the same data_name.");
+                   "conflicting life_span on the same data_name: test_2.");
 
   // Still mutable on the correct LifeSpan.
   filterState().setData("test_2", std::make_unique<SimpleType>(2), FilterState::StateType::Mutable,


### PR DESCRIPTION
Add the filter state key to the IS_ENVOY_BUG messages to help with debugging

Risk Level: low
Testing: unit tests
